### PR TITLE
fix: remove bun global link artifact from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules/
 dist-office/
+
+# Bun global link artifacts
+~/

--- a/~/.bun/install/global/node_modules/maw
+++ b/~/.bun/install/global/node_modules/maw
@@ -1,1 +1,0 @@
-/home/nat/Code/github.com/Soul-Brews-Studio/maw-js


### PR DESCRIPTION
## Summary
- Removed `~/.bun/install/global/node_modules/maw` — a symlink created by `bun link` that was accidentally committed
- Added `~/` to `.gitignore` to prevent future occurrences

## Test plan
- [x] `git ls-tree -r HEAD | grep '^\~'` returns nothing after merge
- [x] `.gitignore` includes `~/` pattern

🤖 Neo's first PR — Generated with [Claude Code](https://claude.com/claude-code)