### PR TITLE
feat: nav bar on Terminal + Orbital views

### DIFF
--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -34,6 +34,19 @@
   .hero .stats {
     margin-top: 16px; display: flex; justify-content: center; gap: 24px; font-size: 13px;
   }
+  .nav-bar {
+    position: fixed; top: 0; left: 0; right: 0; z-index: 100;
+    display: flex; align-items: center; gap: 16px;
+    padding: 10px 24px;
+    background: rgba(0,0,0,0.5); backdrop-filter: blur(12px);
+    border-bottom: 1px solid rgba(255,255,255,0.06);
+    font-family: 'SF Mono', 'Fira Code', monospace; font-size: 11px;
+  }
+  .nav-bar .brand { font-size: 14px; font-weight: bold; color: #26c6da; letter-spacing: 4px; text-transform: uppercase; }
+  .nav-bar .links { margin-left: auto; display: flex; gap: 14px; }
+  .nav-bar .links a { color: rgba(255,255,255,0.5); text-decoration: none; transition: color 0.2s; }
+  .nav-bar .links a:hover { color: rgba(255,255,255,0.8); }
+  .nav-bar .links a.active { color: #26c6da; font-weight: bold; }
   .hero .stat { color: #888; }
   .hero .stat strong { color: #e0e0e0; font-weight: 600; }
   .conn-dot {
@@ -242,8 +255,19 @@
 </head>
 <body>
 
+<!-- Nav Bar -->
+<div class="nav-bar">
+  <span class="brand">Oracle Orbital</span>
+  <div class="links">
+    <a href="/office/#office">Office</a>
+    <a href="/office/#mission">Mission</a>
+    <a href="/">Terminal</a>
+    <a href="/dashboard" class="active">Orbital</a>
+  </div>
+</div>
+
 <!-- Hero -->
-<div class="hero">
+<div class="hero" style="padding-top: 80px;">
   <h1>maw</h1>
   <div class="subtitle">multi-agent workflow orchestra</div>
   <div class="stats">

--- a/src/ui.html
+++ b/src/ui.html
@@ -18,6 +18,10 @@
   .header .status { font-size: 12px; margin-left: auto; }
   .header .status.online { color: #4caf50; }
   .header .status.offline { color: #f44336; }
+  .header .nav-links { display: flex; gap: 12px; margin-left: 16px; font-size: 11px; }
+  .header .nav-links a { color: rgba(255,255,255,0.5); text-decoration: none; transition: color 0.2s; }
+  .header .nav-links a:hover { color: rgba(255,255,255,0.8); }
+  .header .nav-links a.active { color: #26c6da; font-weight: bold; }
 
   .container { display: flex; height: calc(100vh - 45px); }
 
@@ -90,6 +94,12 @@
   <h1>maw <span style="color:#555;font-weight:400;font-size:12px">by cat lab</span></h1>
   <span class="target-name" id="targetName"></span>
   <span class="status offline" id="status">connecting...</span>
+  <div class="nav-links">
+    <a href="/office/#office">Office</a>
+    <a href="/office/#mission">Mission</a>
+    <a href="/" class="active">Terminal</a>
+    <a href="/dashboard">Orbital</a>
+  </div>
 </div>
 
 <div class="container">


### PR DESCRIPTION
## Summary
- Adds consistent nav links to Terminal (ui.html) and Orbital (dashboard.html) pages
- All 4 views now have navigation: Office, Mission, Terminal, Orbital
- Terminal uses inline `.nav-links` in the header
- Orbital uses a fixed `.nav-bar` with brand label

## Test plan
- [ ] Navigate between all 4 views using nav links
- [ ] Verify active state highlighting on each page


🤖 Generated with [Claude Code](https://claude.com/claude-code)