### PR TITLE
feat: oracle feed SDK + dedup fix + iPad jump

### DIFF
--- a/office/src/App.tsx
+++ b/office/src/App.tsx
@@ -74,7 +74,7 @@ export function App() {
     return () => window.removeEventListener("keydown", handler, true);
   }, []);
 
-  const { sessions, agents, saiyanTargets, eventLog, addEvent, handleMessage } = useSessions();
+  const { sessions, agents, saiyanTargets, eventLog, addEvent, handleMessage, feedActive } = useSessions();
   const { connected, send } = useWebSocket(handleMessage);
 
   const onSelectAgent = useCallback((agent: AgentState) => {
@@ -119,7 +119,7 @@ export function App() {
     return (
       <div className="relative min-h-screen" style={{ background: "#020208" }}>
         <div className="relative z-10">
-          <StatusBar connected={connected} agentCount={agents.length} sessionCount={sessions.length} activeView="overview" />
+          <StatusBar connected={connected} agentCount={agents.length} sessionCount={sessions.length} activeView="overview" onJump={() => setShowJump(true)} />
         </div>
         <OverviewGrid
           sessions={sessions}
@@ -141,7 +141,7 @@ export function App() {
     return (
       <div className="relative min-h-screen" style={{ background: "#020208" }}>
         <div className="relative z-10">
-          <StatusBar connected={connected} agentCount={agents.length} sessionCount={sessions.length} activeView="fleet" />
+          <StatusBar connected={connected} agentCount={agents.length} sessionCount={sessions.length} activeView="fleet" onJump={() => setShowJump(true)} />
         </div>
         <FleetGrid
           sessions={sessions}
@@ -152,6 +152,7 @@ export function App() {
           onSelectAgent={onSelectAgent}
           eventLog={eventLog}
           addEvent={addEvent}
+          feedActive={feedActive}
         />
         {terminalModal}
         {showShortcuts && <ShortcutOverlay onClose={() => setShowShortcuts(false)} />}
@@ -165,7 +166,7 @@ export function App() {
     return (
       <div className="relative min-h-screen" style={{ background: "#020208" }}>
         <div className="relative z-10">
-          <StatusBar connected={connected} agentCount={agents.length} sessionCount={sessions.length} activeView="mission" />
+          <StatusBar connected={connected} agentCount={agents.length} sessionCount={sessions.length} activeView="mission" onJump={() => setShowJump(true)} />
         </div>
         <MissionControl
           sessions={sessions}
@@ -189,11 +190,12 @@ export function App() {
     <div className="relative min-h-screen">
       <UniverseBg />
       <div className="relative z-10">
-        <StatusBar connected={connected} agentCount={agents.length} sessionCount={sessions.length} activeView="office" />
+        <StatusBar connected={connected} agentCount={agents.length} sessionCount={sessions.length} activeView="office" onJump={() => setShowJump(true)} />
         <RoomGrid sessions={sessions} agents={agents} saiyanTargets={saiyanTargets} onSelectAgent={onSelectAgent} />
       </div>
       {terminalModal}
       {showShortcuts && <ShortcutOverlay onClose={() => setShowShortcuts(false)} />}
+      {jumpOverlay}
     </div>
   );
 }

--- a/office/src/components/AgentRow.tsx
+++ b/office/src/components/AgentRow.tsx
@@ -12,6 +12,7 @@ interface AgentRowProps {
   saiyan: boolean;
   isLast: boolean;
   agoLabel?: string;
+  feedActivity?: string | null;
   observe: (el: HTMLElement | null, target: string) => void;
   showPreview: (agent: AgentState, accent: string, label: string, e: React.MouseEvent) => void;
   hidePreview: () => void;
@@ -27,6 +28,7 @@ export const AgentRow = memo(function AgentRow({
   saiyan,
   isLast,
   agoLabel,
+  feedActivity,
   observe,
   showPreview,
   hidePreview,
@@ -141,6 +143,11 @@ export const AgentRow = memo(function AgentRow({
           <span className="text-[13px] truncate" style={{ color: "#64748B" }}>
             {agent.preview?.slice(0, 80) || "\u00a0"}
           </span>
+          {feedActivity && (
+            <span className="text-[11px] truncate" style={{ color: "#fbbf24", opacity: 0.7 }}>
+              {feedActivity}
+            </span>
+          )}
         </div>
 
         {/* Mic button */}

--- a/office/src/components/FleetGrid.tsx
+++ b/office/src/components/FleetGrid.tsx
@@ -7,6 +7,7 @@ import { BottomStats } from "./BottomStats";
 import { useFps } from "./FpsCounter";
 import { useFleetStore, RECENT_TTL_MS, type RecentEntry } from "../lib/store";
 import type { AgentState, Session, AgentEvent } from "../lib/types";
+import { describeActivity, type FeedEvent } from "../lib/feed";
 
 interface FleetGridProps {
   sessions: Session[];
@@ -17,6 +18,7 @@ interface FleetGridProps {
   onSelectAgent: (agent: AgentState) => void;
   eventLog: AgentEvent[];
   addEvent: (target: string, type: AgentEvent["type"], detail: string) => void;
+  feedActive?: Map<string, FeedEvent>;
 }
 
 /** Track visible agent targets via IntersectionObserver */
@@ -76,7 +78,7 @@ function sortRooms(sessions: Session[], agentMap: Map<string, AgentState[]>, mod
 }
 
 export const FleetGrid = memo(function FleetGrid({
-  sessions, agents, saiyanTargets, connected, send, onSelectAgent, eventLog, addEvent,
+  sessions, agents, saiyanTargets, connected, send, onSelectAgent, eventLog, addEvent, feedActive,
 }: FleetGridProps) {
   const fps = useFps();
   const observe = useVisibleTargets(send);
@@ -184,25 +186,49 @@ export const FleetGrid = memo(function FleetGrid({
     return result;
   }, [sorted, sessionAgents, grouped]);
 
+  // Resolve feed activity for an agent by oracle name
+  const getFeedActivity = useCallback((agentName: string): string | null => {
+    if (!feedActive) return null;
+    const oracleName = agentName.replace(/-oracle$/, "");
+    const event = feedActive.get(oracleName);
+    if (!event) return null;
+    return describeActivity(event);
+  }, [feedActive]);
+
   const busyAgents = useMemo(() => agents.filter(a => a.status === "busy"), [agents]);
   const busyCount = busyAgents.length;
   const readyCount = agents.filter(a => a.status === "ready").length;
   const idleCount = agents.length - busyCount - readyCount;
 
   // Recently active: busy agents first, then recently-gone from store
+  // Deduplicated by agent name (same agent may have multiple tmux windows)
   const recentlyActive = useMemo((): (AgentState | RecentEntry)[] => {
     const agentMap = new Map(agents.map(a => [a.target, a]));
     const busyTargets = new Set(busyAgents.map(a => a.target));
 
-    // Recently-gone: in store but not currently busy
-    const recentGone = Object.values(recentMap)
-      .filter(e => !busyTargets.has(e.target))
+    // Dedup busy agents by name — keep first (arbitrary, same agent)
+    const seenNames = new Set<string>();
+    const dedupBusy = busyAgents.filter(a => {
+      if (seenNames.has(a.name)) return false;
+      seenNames.add(a.name);
+      return true;
+    });
+
+    // Recently-gone: in store but not currently busy, dedup by name (keep most recent)
+    const recentByName = new Map<string, RecentEntry>();
+    for (const e of Object.values(recentMap)) {
+      if (busyTargets.has(e.target)) continue;
+      const prev = recentByName.get(e.name);
+      if (!prev || e.lastBusy > prev.lastBusy) recentByName.set(e.name, e);
+    }
+    const recentGone = [...recentByName.values()]
+      .filter(e => !seenNames.has(e.name))
       .sort((a, b) => b.lastBusy - a.lastBusy)
       .slice(0, 10)
       .map(e => agentMap.get(e.target) || e);
 
     // Active first, then recently-gone
-    return [...busyAgents, ...recentGone];
+    return [...dedupBusy, ...recentGone];
   }, [agents, busyAgents, recentMap]);
 
   return (
@@ -290,7 +316,7 @@ export const FleetGrid = memo(function FleetGrid({
                 return (
                   <AgentRow key={`recent-${entry.target}`} agent={agent} accent={rs.accent} roomLabel={rs.label}
                     saiyan={saiyanTargets.has(entry.target)} isLast={i === recentlyActive.length - 1}
-                    agoLabel={agoLabel}
+                    agoLabel={agoLabel} feedActivity={getFeedActivity(agent.name)}
                     observe={observe} showPreview={showPreview} hidePreview={hidePreview} onAgentClick={onAgentClick}
                     send={send} onSendDone={onSendDone} />
                 );
@@ -324,6 +350,7 @@ export const FleetGrid = memo(function FleetGrid({
                   {vr.agents.map((agent, i) => (
                     <AgentRow key={agent.target} agent={agent} accent={style.accent} roomLabel={vr.label}
                       saiyan={saiyanTargets.has(agent.target)} isLast={i === vr.agents.length - 1}
+                      feedActivity={getFeedActivity(agent.name)}
                       observe={observe} showPreview={showPreview} hidePreview={hidePreview} onAgentClick={onAgentClick}
                       send={send} onSendDone={onSendDone} />
                   ))}

--- a/office/src/components/StageSection.tsx
+++ b/office/src/components/StageSection.tsx
@@ -21,11 +21,17 @@ export const StageSection = memo(function StageSection({
   hidePreview,
   onAgentClick,
 }: StageSectionProps) {
-  // Ghost agents: recent but not busy, shown greyed out on stage
+  // Ghost agents: recent but not busy, shown greyed out on stage (dedup by name)
   const ghostAgents = useMemo(() => {
-    const busyTargets = new Set(busyAgents.map(a => a.target));
+    const busyNames = new Set(busyAgents.map(a => a.name));
+    const seenNames = new Set<string>();
     return recentlyActive
-      .filter(e => !busyTargets.has(e.target))
+      .filter(e => !busyNames.has(e.name))
+      .filter(e => {
+        if (seenNames.has(e.name)) return false;
+        seenNames.add(e.name);
+        return true;
+      })
       .slice(0, 5)
       .map(e => {
         if ("status" in e) return e as AgentState;

--- a/office/src/components/StatusBar.tsx
+++ b/office/src/components/StatusBar.tsx
@@ -5,6 +5,7 @@ interface StatusBarProps {
   agentCount: number;
   sessionCount: number;
   activeView?: string;
+  onJump?: () => void;
 }
 
 const NAV_ITEMS = [
@@ -15,7 +16,9 @@ const NAV_ITEMS = [
   { href: "/dashboard", label: "Orbital", id: "orbital" },
 ];
 
-export const StatusBar = memo(function StatusBar({ connected, agentCount, sessionCount, activeView = "office" }: StatusBarProps) {
+const isTouch = typeof window !== "undefined" && ("ontouchstart" in window || navigator.maxTouchPoints > 0);
+
+export const StatusBar = memo(function StatusBar({ connected, agentCount, sessionCount, activeView = "office", onJump }: StatusBarProps) {
   return (
     <header className="sticky top-0 z-20 flex flex-wrap items-center gap-x-4 gap-y-2 mx-4 sm:mx-6 mt-3 px-4 sm:px-6 py-2.5 rounded-2xl bg-black/50 backdrop-blur-xl border border-white/[0.06] shadow-[0_4px_30px_rgba(0,0,0,0.4)]">
       <h1 className="text-base sm:text-lg font-bold tracking-[4px] sm:tracking-[6px] text-cyan-400 uppercase whitespace-nowrap">
@@ -34,7 +37,18 @@ export const StatusBar = memo(function StatusBar({ connected, agentCount, sessio
         <strong className="text-purple-400">{sessionCount}</strong> rooms
       </span>
 
-      <nav className="ml-auto flex items-center gap-3 sm:gap-4 text-sm">
+      {isTouch && onJump && (
+        <button
+          onClick={onJump}
+          className="ml-auto px-3 py-1.5 rounded-lg text-xs font-mono font-bold cursor-pointer active:scale-95 transition-all whitespace-nowrap"
+          style={{ background: "rgba(34,211,238,0.15)", color: "#22d3ee", border: "1px solid rgba(34,211,238,0.25)" }}
+          title="Jump to agent (⌘J)"
+        >
+          ⌘J Jump
+        </button>
+      )}
+
+      <nav className={`${isTouch && onJump ? "" : "ml-auto "}flex items-center gap-3 sm:gap-4 text-sm`}>
         {NAV_ITEMS.map((item) => (
           <a
             key={item.id}

--- a/office/src/hooks/useSessions.ts
+++ b/office/src/hooks/useSessions.ts
@@ -4,6 +4,7 @@ import { stripAnsi } from "../lib/ansi";
 import { playSaiyanSound } from "../lib/sounds";
 import { agentSortKey } from "../lib/constants";
 import { useFleetStore } from "../lib/store";
+import { activeOracles, describeActivity, type FeedEvent } from "../lib/feed";
 
 // Simple string hash
 function hash(s: string): number {
@@ -27,6 +28,10 @@ export function useSessions() {
   const [eventLog, setEventLog] = useState<AgentEvent[]>([]);
   const MAX_EVENTS = 200;
 
+  // Oracle feed state
+  const [feedEvents, setFeedEvents] = useState<FeedEvent[]>([]);
+  const MAX_FEED = 100;
+
   const addEvent = useCallback((target: string, type: AgentEvent["type"], detail: string) => {
     setEventLog(prev => {
       const next = [...prev, { time: Date.now(), target, type, detail }];
@@ -43,6 +48,15 @@ export function useSessions() {
       // Server-side recent agents → merge into zustand store
       const agents: { target: string; name: string; session: string }[] = data.agents || [];
       if (agents.length > 0) markBusy(agents);
+    } else if (data.type === "feed") {
+      // Single real-time feed event
+      setFeedEvents(prev => {
+        const next = [...prev, data.event as FeedEvent];
+        return next.length > MAX_FEED ? next.slice(-MAX_FEED) : next;
+      });
+    } else if (data.type === "feed-history") {
+      // Batch of recent events on connect
+      setFeedEvents((data.events as FeedEvent[]).slice(-MAX_FEED));
     } else if (data.type === "previews") {
       // Lightweight preview updates from viewport-aware subscription
       const previews: Record<string, string> = data.data;
@@ -189,5 +203,8 @@ export function useSessions() {
     return list;
   }, [sessions, captureData]);
 
-  return { sessions, agents, saiyanTargets, eventLog, addEvent, handleMessage };
+  // Compute active oracles from feed (memoized, 5min window)
+  const feedActive = useMemo(() => activeOracles(feedEvents, 5 * 60_000), [feedEvents]);
+
+  return { sessions, agents, saiyanTargets, eventLog, addEvent, handleMessage, feedEvents, feedActive };
 }

--- a/office/src/lib/feed.ts
+++ b/office/src/lib/feed.ts
@@ -1,0 +1,147 @@
+/**
+ * Oracle Feed Parser — Pure functions, zero dependencies.
+ * Works in both server (Bun) and browser (via Vite).
+ *
+ * Feed log format:
+ *   TIMESTAMP | ORACLE | HOST | EVENT | PROJECT | SESSION_ID » MESSAGE
+ */
+
+export type FeedEventType =
+  | "PreToolUse"
+  | "PostToolUse"
+  | "PostToolUseFailure"
+  | "UserPromptSubmit"
+  | "SubagentStart"
+  | "SubagentStop"
+  | "TaskCompleted"
+  | "SessionEnd"
+  | "SessionStart"
+  | "Stop"
+  | "Notification";
+
+export interface FeedEvent {
+  timestamp: string;
+  oracle: string;
+  host: string;
+  event: FeedEventType;
+  project: string;
+  sessionId: string;
+  message: string;
+  ts: number;
+}
+
+/**
+ * Parse a single feed.log line into a FeedEvent.
+ * Returns null if the line is malformed.
+ */
+export function parseLine(line: string): FeedEvent | null {
+  if (!line || !line.includes(" | ")) return null;
+
+  const parts = line.split(" | ").map((s) => s.trim());
+  if (parts.length < 5) return null;
+
+  const timestamp = parts[0];
+  const oracle = parts[1];
+  const host = parts[2];
+  const event = parts[3] as FeedEventType;
+  const project = parts[4];
+
+  // Session ID and message are separated by » in the remaining part
+  const rest = parts.slice(5).join(" | ");
+  let sessionId = "";
+  let message = "";
+
+  const guiIdx = rest.indexOf(" » ");
+  if (guiIdx !== -1) {
+    sessionId = rest.slice(0, guiIdx).trim();
+    message = rest.slice(guiIdx + 3).trim();
+  } else {
+    // Fallback: treat entire rest as sessionId (no message)
+    sessionId = rest.trim();
+  }
+
+  // Parse timestamp to epoch ms
+  const ts = new Date(timestamp.replace(" ", "T") + "+07:00").getTime();
+  if (isNaN(ts)) return null;
+
+  return { timestamp, oracle, host, event, project, sessionId, message, ts };
+}
+
+/**
+ * Get active oracles from a list of events within a time window.
+ * Returns Map of oracle name → most recent FeedEvent.
+ */
+export function activeOracles(
+  events: FeedEvent[],
+  windowMs = 5 * 60_000,
+): Map<string, FeedEvent> {
+  const cutoff = Date.now() - windowMs;
+  const map = new Map<string, FeedEvent>();
+
+  for (const e of events) {
+    if (e.ts < cutoff) continue;
+    const prev = map.get(e.oracle);
+    if (!prev || e.ts > prev.ts) map.set(e.oracle, e);
+  }
+
+  return map;
+}
+
+/** Tool name extraction from PreToolUse messages */
+const TOOL_ICONS: Record<string, string> = {
+  Bash: "⚡",
+  Read: "📖",
+  Edit: "✏️",
+  Write: "📝",
+  Grep: "🔍",
+  Glob: "📂",
+  Agent: "🤖",
+  WebFetch: "🌐",
+  WebSearch: "🔎",
+};
+
+/**
+ * Human-readable one-liner for what the oracle is doing.
+ */
+export function describeActivity(event: FeedEvent): string {
+  switch (event.event) {
+    case "PreToolUse": {
+      // Message format: "ToolName: details..." or "ToolName ✓"
+      const colonIdx = event.message.indexOf(":");
+      const tool =
+        colonIdx > 0 ? event.message.slice(0, colonIdx).trim() : event.message.split(" ")[0];
+      const icon = TOOL_ICONS[tool] || "🔧";
+      const detail = colonIdx > 0 ? event.message.slice(colonIdx + 1).trim() : "";
+      const short = detail.length > 60 ? detail.slice(0, 57) + "..." : detail;
+      return short ? `${icon} ${tool}: ${short}` : `${icon} ${tool}`;
+    }
+    case "PostToolUse":
+    case "PostToolUseFailure": {
+      const ok = event.event === "PostToolUse";
+      const tool = event.message.replace(/ [✓✗].*$/, "").trim() || "Tool";
+      return ok ? `✓ ${tool} done` : `✗ ${tool} failed`;
+    }
+    case "UserPromptSubmit": {
+      const short =
+        event.message.length > 60 ? event.message.slice(0, 57) + "..." : event.message;
+      return `💬 ${short || "New prompt"}`;
+    }
+    case "SubagentStart":
+      return `🤖 Subagent started`;
+    case "SubagentStop":
+      return `🤖 Subagent done`;
+    case "SessionStart":
+      return `🟢 Session started`;
+    case "SessionEnd":
+      return `⏹ Session ended`;
+    case "Stop": {
+      const short =
+        event.message.length > 60 ? event.message.slice(0, 57) + "..." : event.message;
+      return `⏹ ${short || "Stopped"}`;
+    }
+    case "Notification":
+      return `🔔 ${event.message || "Notification"}`;
+    default:
+      return event.message || event.event;
+  }
+}

--- a/src/feed-tail.ts
+++ b/src/feed-tail.ts
@@ -1,0 +1,137 @@
+/**
+ * FeedTailer — Tails ~/.oracle/feed.log using byte-offset polling.
+ * Bun-specific (uses Bun.file, node:fs).
+ */
+
+import { statSync, openSync, readSync, closeSync } from "node:fs";
+import { join } from "node:path";
+import { parseLine, activeOracles, type FeedEvent } from "./lib/feed";
+
+const DEFAULT_PATH = join(process.env.HOME || "/home/nat", ".oracle", "feed.log");
+const POLL_MS = 1000;
+const DEFAULT_MAX_BUFFER = 200;
+
+export class FeedTailer {
+  private path: string;
+  private maxBuffer: number;
+  private offset = 0;
+  private buffer: FeedEvent[] = [];
+  private listeners = new Set<(event: FeedEvent) => void>();
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(path?: string, maxBuffer?: number) {
+    this.path = path || DEFAULT_PATH;
+    this.maxBuffer = maxBuffer || DEFAULT_MAX_BUFFER;
+  }
+
+  /** Start polling. Reads last N lines for initial buffer. */
+  start(): void {
+    if (this.timer) return;
+
+    // Seed buffer from tail of file
+    try {
+      const file = Bun.file(this.path);
+      const size = file.size;
+      if (size > 0) {
+        // Read last chunk (up to 100KB) for initial buffer
+        const chunkSize = Math.min(size, 100_000);
+        const fd = openSync(this.path, "r");
+        const buf = Buffer.alloc(chunkSize);
+        readSync(fd, buf, 0, chunkSize, size - chunkSize);
+        closeSync(fd);
+
+        const text = buf.toString("utf-8");
+        const lines = text.split("\n").filter(Boolean);
+        // Take last maxBuffer lines
+        const tail = lines.slice(-this.maxBuffer);
+        for (const line of tail) {
+          const event = parseLine(line);
+          if (event) this.buffer.push(event);
+        }
+        // Trim buffer
+        if (this.buffer.length > this.maxBuffer) {
+          this.buffer = this.buffer.slice(-this.maxBuffer);
+        }
+        this.offset = size;
+      }
+    } catch {
+      // File doesn't exist yet — that's OK
+      this.offset = 0;
+    }
+
+    // Start polling
+    this.timer = setInterval(() => this.poll(), POLL_MS);
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /** Subscribe to new events. Returns unsubscribe function. */
+  onEvent(cb: (event: FeedEvent) => void): () => void {
+    this.listeners.add(cb);
+    return () => this.listeners.delete(cb);
+  }
+
+  /** Get recent events from buffer. */
+  getRecent(n?: number): FeedEvent[] {
+    const count = n || this.maxBuffer;
+    return this.buffer.slice(-count);
+  }
+
+  /** Get active oracles within time window. */
+  getActive(windowMs?: number): Map<string, FeedEvent> {
+    return activeOracles(this.buffer, windowMs);
+  }
+
+  private poll(): void {
+    try {
+      const stat = statSync(this.path);
+      const size = stat.size;
+
+      // File rotated or truncated
+      if (size < this.offset) {
+        this.offset = 0;
+      }
+
+      // No new data
+      if (size <= this.offset) return;
+
+      // Read new bytes
+      const newBytes = size - this.offset;
+      const fd = openSync(this.path, "r");
+      const buf = Buffer.alloc(newBytes);
+      readSync(fd, buf, 0, newBytes, this.offset);
+      closeSync(fd);
+
+      this.offset = size;
+
+      // Parse new lines
+      const text = buf.toString("utf-8");
+      const lines = text.split("\n").filter(Boolean);
+
+      for (const line of lines) {
+        const event = parseLine(line);
+        if (!event) continue;
+
+        this.buffer.push(event);
+        // Emit to listeners
+        for (const cb of this.listeners) {
+          try {
+            cb(event);
+          } catch {}
+        }
+      }
+
+      // Trim buffer
+      if (this.buffer.length > this.maxBuffer) {
+        this.buffer = this.buffer.slice(-this.maxBuffer);
+      }
+    } catch {
+      // File might not exist or be temporarily unavailable
+    }
+  }
+}

--- a/src/lib/feed.ts
+++ b/src/lib/feed.ts
@@ -1,0 +1,147 @@
+/**
+ * Oracle Feed Parser — Pure functions, zero dependencies.
+ * Works in both server (Bun) and browser (via Vite).
+ *
+ * Feed log format:
+ *   TIMESTAMP | ORACLE | HOST | EVENT | PROJECT | SESSION_ID » MESSAGE
+ */
+
+export type FeedEventType =
+  | "PreToolUse"
+  | "PostToolUse"
+  | "PostToolUseFailure"
+  | "UserPromptSubmit"
+  | "SubagentStart"
+  | "SubagentStop"
+  | "TaskCompleted"
+  | "SessionEnd"
+  | "SessionStart"
+  | "Stop"
+  | "Notification";
+
+export interface FeedEvent {
+  timestamp: string;
+  oracle: string;
+  host: string;
+  event: FeedEventType;
+  project: string;
+  sessionId: string;
+  message: string;
+  ts: number;
+}
+
+/**
+ * Parse a single feed.log line into a FeedEvent.
+ * Returns null if the line is malformed.
+ */
+export function parseLine(line: string): FeedEvent | null {
+  if (!line || !line.includes(" | ")) return null;
+
+  const parts = line.split(" | ").map((s) => s.trim());
+  if (parts.length < 5) return null;
+
+  const timestamp = parts[0];
+  const oracle = parts[1];
+  const host = parts[2];
+  const event = parts[3] as FeedEventType;
+  const project = parts[4];
+
+  // Session ID and message are separated by » in the remaining part
+  const rest = parts.slice(5).join(" | ");
+  let sessionId = "";
+  let message = "";
+
+  const guiIdx = rest.indexOf(" » ");
+  if (guiIdx !== -1) {
+    sessionId = rest.slice(0, guiIdx).trim();
+    message = rest.slice(guiIdx + 3).trim();
+  } else {
+    // Fallback: treat entire rest as sessionId (no message)
+    sessionId = rest.trim();
+  }
+
+  // Parse timestamp to epoch ms
+  const ts = new Date(timestamp.replace(" ", "T") + "+07:00").getTime();
+  if (isNaN(ts)) return null;
+
+  return { timestamp, oracle, host, event, project, sessionId, message, ts };
+}
+
+/**
+ * Get active oracles from a list of events within a time window.
+ * Returns Map of oracle name → most recent FeedEvent.
+ */
+export function activeOracles(
+  events: FeedEvent[],
+  windowMs = 5 * 60_000,
+): Map<string, FeedEvent> {
+  const cutoff = Date.now() - windowMs;
+  const map = new Map<string, FeedEvent>();
+
+  for (const e of events) {
+    if (e.ts < cutoff) continue;
+    const prev = map.get(e.oracle);
+    if (!prev || e.ts > prev.ts) map.set(e.oracle, e);
+  }
+
+  return map;
+}
+
+/** Tool name extraction from PreToolUse messages */
+const TOOL_ICONS: Record<string, string> = {
+  Bash: "⚡",
+  Read: "📖",
+  Edit: "✏️",
+  Write: "📝",
+  Grep: "🔍",
+  Glob: "📂",
+  Agent: "🤖",
+  WebFetch: "🌐",
+  WebSearch: "🔎",
+};
+
+/**
+ * Human-readable one-liner for what the oracle is doing.
+ */
+export function describeActivity(event: FeedEvent): string {
+  switch (event.event) {
+    case "PreToolUse": {
+      // Message format: "ToolName: details..." or "ToolName ✓"
+      const colonIdx = event.message.indexOf(":");
+      const tool =
+        colonIdx > 0 ? event.message.slice(0, colonIdx).trim() : event.message.split(" ")[0];
+      const icon = TOOL_ICONS[tool] || "🔧";
+      const detail = colonIdx > 0 ? event.message.slice(colonIdx + 1).trim() : "";
+      const short = detail.length > 60 ? detail.slice(0, 57) + "..." : detail;
+      return short ? `${icon} ${tool}: ${short}` : `${icon} ${tool}`;
+    }
+    case "PostToolUse":
+    case "PostToolUseFailure": {
+      const ok = event.event === "PostToolUse";
+      const tool = event.message.replace(/ [✓✗].*$/, "").trim() || "Tool";
+      return ok ? `✓ ${tool} done` : `✗ ${tool} failed`;
+    }
+    case "UserPromptSubmit": {
+      const short =
+        event.message.length > 60 ? event.message.slice(0, 57) + "..." : event.message;
+      return `💬 ${short || "New prompt"}`;
+    }
+    case "SubagentStart":
+      return `🤖 Subagent started`;
+    case "SubagentStop":
+      return `🤖 Subagent done`;
+    case "SessionStart":
+      return `🟢 Session started`;
+    case "SessionEnd":
+      return `⏹ Session ended`;
+    case "Stop": {
+      const short =
+        event.message.length > 60 ? event.message.slice(0, 57) + "..." : event.message;
+      return `⏹ ${short || "Stopped"}`;
+    }
+    case "Notification":
+      return `🔔 ${event.message || "Notification"}`;
+    default:
+      return event.message || event.event;
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import { cors } from "hono/cors";
 import { serveStatic } from "hono/bun";
 import { listSessions, capture, sendKeys, selectWindow } from "./ssh";
 import { processMirror } from "./overview";
+import { FeedTailer } from "./feed-tail";
 import type { ServerWebSocket } from "bun";
 
 const app = new Hono();
@@ -115,6 +116,18 @@ app.get("/api/oracle/stats", async (c) => {
   } catch (e: any) {
     return c.json({ error: `Oracle unreachable: ${e.message}` }, 502);
   }
+});
+
+// --- Oracle Feed ---
+const feedTailer = new FeedTailer();
+
+app.get("/api/feed", (c) => {
+  const limit = Math.min(200, +(c.req.query("limit") || "50"));
+  const oracle = c.req.query("oracle") || undefined;
+  let events = feedTailer.getRecent(limit);
+  if (oracle) events = events.filter(e => e.oracle === oracle);
+  const active = [...feedTailer.getActive().keys()];
+  return c.json({ events: events.reverse(), total: events.length, active_oracles: active });
 });
 
 app.onError((err, c) => c.json({ error: err.message }, 500));
@@ -246,6 +259,9 @@ let captureInterval: ReturnType<typeof setInterval> | null = null;
 let sessionInterval: ReturnType<typeof setInterval> | null = null;
 let previewInterval: ReturnType<typeof setInterval> | null = null;
 
+// Feed broadcast: emit events to all clients in real-time
+let feedUnsub: (() => void) | null = null;
+
 function startIntervals() {
   if (captureInterval) return;
   // Capture every 50ms for real-time feel (full terminal, single subscribed target)
@@ -258,6 +274,12 @@ function startIntervals() {
   previewInterval = setInterval(() => {
     for (const ws of clients) pushPreviews(ws);
   }, 2000);
+  // Feed tailer
+  feedTailer.start();
+  feedUnsub = feedTailer.onEvent((event) => {
+    const msg = JSON.stringify({ type: "feed", event });
+    for (const ws of clients) ws.send(msg);
+  });
 }
 
 function stopIntervals() {
@@ -265,6 +287,8 @@ function stopIntervals() {
   if (captureInterval) { clearInterval(captureInterval); captureInterval = null; }
   if (sessionInterval) { clearInterval(sessionInterval); sessionInterval = null; }
   if (previewInterval) { clearInterval(previewInterval); previewInterval = null; }
+  if (feedUnsub) { feedUnsub(); feedUnsub = null; }
+  feedTailer.stop();
 }
 
 export function startServer(port = +(process.env.MAW_PORT || 3456)) {
@@ -284,11 +308,12 @@ export function startServer(port = +(process.env.MAW_PORT || 3456)) {
       open(ws: ServerWebSocket<WSData>) {
         clients.add(ws);
         startIntervals();
-        // Send sessions + recent immediately
+        // Send sessions + recent + feed history immediately
         listSessions().then(s => {
           ws.send(JSON.stringify({ type: "sessions", sessions: s }));
           ws.send(JSON.stringify({ type: "recent", agents: getRecentList() }));
         }).catch(() => {});
+        ws.send(JSON.stringify({ type: "feed-history", events: feedTailer.getRecent(50) }));
       },
       message(ws: ServerWebSocket<WSData>, msg) {
         try {


### PR DESCRIPTION
## Summary

- **Oracle Feed integration**: Real-time feed from `~/.oracle/feed.log` → WebSocket → office UI. Each agent row shows what the oracle is doing (e.g., "⚡ Bash: curl ...", "📖 Read: /path/file")
- **Feed SDK**: Pure parser (`parseLine`, `activeOracles`, `describeActivity`) + server-side `FeedTailer` with byte-offset polling
- **Dedup fix**: Same agent with multiple tmux windows no longer appears twice in Recently Active / Stage
- **iPad Jump button**: Touch-friendly "⌘J Jump" button in StatusBar (no keyboard shortcut on iPad)

### New files
- `src/lib/feed.ts` — Pure parser (shared server/client)
- `src/feed-tail.ts` — Server-side FeedTailer class
- `office/src/lib/feed.ts` — Client-side parser copy

### Modified
- `src/server.ts` — FeedTailer wiring, `/api/feed` endpoint, WS broadcast
- `office/src/hooks/useSessions.ts` — Feed event handling, `feedActive` map
- `office/src/components/FleetGrid.tsx` — Feed activity prop + dedup fix
- `office/src/components/AgentRow.tsx` — Amber feed activity line
- `office/src/components/StageSection.tsx` — Ghost agent dedup fix
- `office/src/components/StatusBar.tsx` — iPad Jump button
- `office/src/App.tsx` — Thread feedActive, onJump, JumpOverlay on office route

## Test plan

- [ ] Open Fleet view (`/office/#fleet`) — verify feed activity shows under active agents
- [ ] Run a Claude Code session — verify amber text updates within ~1s
- [ ] `curl 'localhost:3456/api/feed?limit=5'` — verify JSON response with events + active_oracles
- [ ] Check Recently Active — no duplicate agents for multi-window tmux sessions
- [ ] Open on iPad — verify Jump button appears in StatusBar

🤖 Generated with [Claude Code](https://claude.com/claude-code)