### PR TITLE
feat: worktree hygiene dashboard

### DIFF
--- a/office/src/App.tsx
+++ b/office/src/App.tsx
@@ -13,6 +13,7 @@ import { ConfigView } from "./components/ConfigView";
 import { TerminalView } from "./components/TerminalView";
 import { OrbitalView } from "./components/OrbitalView";
 import { InboxOverlay } from "./components/InboxView";
+import { WorktreeView } from "./components/WorktreeView";
 import { ShortcutOverlay } from "./components/ShortcutOverlay";
 import { JumpOverlay } from "./components/JumpOverlay";
 import { unlockAudio, isAudioUnlocked, setSoundMuted } from "./lib/sounds";
@@ -275,6 +276,14 @@ export function App() {
     return (
       <Layout activeView="overview" {...layoutProps}>
         <OverviewGrid sessions={sessions} agents={agents} connected={connected} send={send} onSelectAgent={onSelectAgent} />
+      </Layout>
+    );
+  }
+
+  if (route === "worktrees") {
+    return (
+      <Layout activeView="worktrees" {...layoutProps}>
+        <WorktreeView />
       </Layout>
     );
   }

--- a/office/src/components/WorktreeView.tsx
+++ b/office/src/components/WorktreeView.tsx
@@ -1,0 +1,195 @@
+import { useState, useEffect, useCallback } from "react";
+
+interface WorktreeInfo {
+  path: string;
+  branch: string;
+  repo: string;
+  mainRepo: string;
+  name: string;
+  status: "active" | "stale" | "orphan";
+  tmuxWindow?: string;
+  fleetFile?: string;
+}
+
+const STATUS_BADGE: Record<string, { bg: string; text: string; label: string }> = {
+  active: { bg: "bg-green-900/40", text: "text-green-400", label: "Active" },
+  stale: { bg: "bg-yellow-900/40", text: "text-yellow-400", label: "Stale" },
+  orphan: { bg: "bg-red-900/40", text: "text-red-400", label: "Orphan" },
+};
+
+export function WorktreeView() {
+  const [worktrees, setWorktrees] = useState<WorktreeInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [cleaning, setCleaning] = useState<Set<string>>(new Set());
+  const [logs, setLogs] = useState<Record<string, string[]>>({});
+
+  const fetchWorktrees = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const res = await fetch("/api/worktrees");
+      const data = await res.json();
+      if (Array.isArray(data)) {
+        setWorktrees(data);
+      } else if (data.error) {
+        setError(data.error);
+      }
+    } catch (e: any) {
+      setError(e.message);
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { fetchWorktrees(); }, [fetchWorktrees]);
+
+  const cleanup = useCallback(async (wt: WorktreeInfo) => {
+    setCleaning((prev) => new Set(prev).add(wt.path));
+    try {
+      const res = await fetch("/api/worktrees/cleanup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ path: wt.path }),
+      });
+      const data = await res.json();
+      if (data.ok) {
+        setLogs((prev) => ({ ...prev, [wt.path]: data.log }));
+        // Refresh after cleanup
+        setTimeout(fetchWorktrees, 500);
+      } else {
+        setLogs((prev) => ({ ...prev, [wt.path]: [`Error: ${data.error}`] }));
+      }
+    } catch (e: any) {
+      setLogs((prev) => ({ ...prev, [wt.path]: [`Error: ${e.message}`] }));
+    }
+    setCleaning((prev) => {
+      const next = new Set(prev);
+      next.delete(wt.path);
+      return next;
+    });
+  }, [fetchWorktrees]);
+
+  const cleanupAll = useCallback(async () => {
+    const targets = worktrees.filter((wt) => wt.status !== "active");
+    for (const wt of targets) {
+      await cleanup(wt);
+    }
+  }, [worktrees, cleanup]);
+
+  const staleCount = worktrees.filter((wt) => wt.status === "stale").length;
+  const orphanCount = worktrees.filter((wt) => wt.status === "orphan").length;
+  const activeCount = worktrees.filter((wt) => wt.status === "active").length;
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-xl font-semibold text-white">Worktree Hygiene</h1>
+          <p className="text-sm text-zinc-500 mt-1">
+            {worktrees.length} worktrees &mdash;{" "}
+            <span className="text-green-400">{activeCount} active</span>
+            {staleCount > 0 && <>, <span className="text-yellow-400">{staleCount} stale</span></>}
+            {orphanCount > 0 && <>, <span className="text-red-400">{orphanCount} orphan</span></>}
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={fetchWorktrees}
+            disabled={loading}
+            className="px-3 py-1.5 text-sm rounded bg-zinc-800 text-zinc-300 hover:bg-zinc-700 disabled:opacity-50 transition-colors"
+          >
+            {loading ? "Scanning..." : "Refresh"}
+          </button>
+          {(staleCount + orphanCount) > 0 && (
+            <button
+              onClick={cleanupAll}
+              className="px-3 py-1.5 text-sm rounded bg-red-900/60 text-red-300 hover:bg-red-800/60 transition-colors"
+            >
+              Clean All ({staleCount + orphanCount})
+            </button>
+          )}
+        </div>
+      </div>
+
+      {error && (
+        <div className="mb-4 p-3 rounded bg-red-900/30 text-red-400 text-sm">{error}</div>
+      )}
+
+      {loading && worktrees.length === 0 ? (
+        <div className="text-zinc-500 text-center py-12">Scanning worktrees...</div>
+      ) : worktrees.length === 0 ? (
+        <div className="text-center py-12">
+          <div className="text-zinc-400 text-lg mb-2">No worktrees found</div>
+          <div className="text-zinc-600 text-sm">All clean. Nothing to do.</div>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {worktrees.map((wt) => {
+            const badge = STATUS_BADGE[wt.status];
+            const isCleaning = cleaning.has(wt.path);
+            const wtLogs = logs[wt.path];
+
+            return (
+              <div
+                key={wt.path}
+                className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-4"
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div className="min-w-0 flex-1">
+                    {/* Name + Status */}
+                    <div className="flex items-center gap-2 mb-1">
+                      <span className="text-white font-medium truncate">{wt.name}</span>
+                      <span className={`px-2 py-0.5 rounded text-xs ${badge.bg} ${badge.text}`}>
+                        {badge.label}
+                      </span>
+                      {wt.tmuxWindow && (
+                        <span className="text-xs text-zinc-500">tmux: {wt.tmuxWindow}</span>
+                      )}
+                    </div>
+
+                    {/* Details */}
+                    <div className="text-xs text-zinc-500 space-y-0.5">
+                      <div className="truncate">
+                        <span className="text-zinc-600">repo:</span>{" "}
+                        <span className="text-zinc-400">{wt.mainRepo}</span>
+                      </div>
+                      <div className="truncate">
+                        <span className="text-zinc-600">branch:</span>{" "}
+                        <span className="text-blue-400">{wt.branch}</span>
+                      </div>
+                      <div className="truncate">
+                        <span className="text-zinc-600">path:</span>{" "}
+                        <span className="text-zinc-500">{wt.path}</span>
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Actions */}
+                  {wt.status !== "active" && (
+                    <button
+                      onClick={() => cleanup(wt)}
+                      disabled={isCleaning}
+                      className="px-3 py-1.5 text-sm rounded bg-zinc-800 text-zinc-300 hover:bg-red-900/60 hover:text-red-300 disabled:opacity-50 transition-colors shrink-0"
+                    >
+                      {isCleaning ? "Cleaning..." : "Remove"}
+                    </button>
+                  )}
+                </div>
+
+                {/* Cleanup log */}
+                {wtLogs && (
+                  <div className="mt-2 p-2 rounded bg-zinc-950 text-xs font-mono text-zinc-400 space-y-0.5">
+                    {wtLogs.map((line, i) => (
+                      <div key={i}>{line}</div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,6 +39,7 @@ function usage() {
   maw overview --kill       Tear down overview
   maw done <window>            Clean up finished worktree window
   maw pulse add "task" [opts] Create issue + wake oracle
+  maw pulse cleanup [--dry-run] Clean stale/orphan worktrees
   maw view <agent> [window]   Grouped tmux session (interactive attach)
   maw create-view <agent> [w] Alias for view
   maw view <agent> --clean    Hide status bar (full screen)
@@ -136,8 +137,25 @@ if (!cmd || cmd === "--help" || cmd === "-h") {
   } else if (subcmd === "ls" || subcmd === "list") {
     const sync = args.includes("--sync");
     await cmdPulseLs({ sync });
+  } else if (subcmd === "cleanup" || subcmd === "clean") {
+    const { scanWorktrees, cleanupWorktree } = await import("./worktrees");
+    const worktrees = await scanWorktrees();
+    const stale = worktrees.filter(wt => wt.status !== "active");
+    if (!stale.length) { console.log("\x1b[32m✓\x1b[0m All worktrees are active. Nothing to clean."); process.exit(0); }
+    console.log(`\n\x1b[36mWorktree Cleanup\x1b[0m\n`);
+    console.log(`  \x1b[32m${worktrees.filter(w => w.status === "active").length} active\x1b[0m | \x1b[33m${worktrees.filter(w => w.status === "stale").length} stale\x1b[0m | \x1b[31m${worktrees.filter(w => w.status === "orphan").length} orphan\x1b[0m\n`);
+    for (const wt of stale) {
+      const color = wt.status === "orphan" ? "\x1b[31m" : "\x1b[33m";
+      console.log(`${color}${wt.status}\x1b[0m  ${wt.name} (${wt.mainRepo}) [${wt.branch}]`);
+      if (!args.includes("--dry-run")) {
+        const log = await cleanupWorktree(wt.path);
+        for (const line of log) console.log(`  \x1b[32m✓\x1b[0m ${line}`);
+      }
+    }
+    if (args.includes("--dry-run")) console.log(`\n\x1b[90m(dry run — use without --dry-run to clean)\x1b[0m`);
+    console.log();
   } else {
-    console.error("usage: maw pulse <add|ls> [opts]");
+    console.error("usage: maw pulse <add|ls|cleanup> [opts]");
     process.exit(1);
   }
 } else if (cmd === "overview" || cmd === "warroom" || cmd === "ov") {

--- a/src/server.ts
+++ b/src/server.ts
@@ -314,6 +314,28 @@ app.post("/api/config", async (c) => {
   }
 });
 
+// --- Worktree Hygiene ---
+import { scanWorktrees, cleanupWorktree } from "./worktrees";
+
+app.get("/api/worktrees", async (c) => {
+  try {
+    return c.json(await scanWorktrees());
+  } catch (e: any) {
+    return c.json({ error: e.message }, 500);
+  }
+});
+
+app.post("/api/worktrees/cleanup", async (c) => {
+  const { path } = await c.req.json();
+  if (!path) return c.json({ error: "path required" }, 400);
+  try {
+    const log = await cleanupWorktree(path);
+    return c.json({ ok: true, log });
+  } catch (e: any) {
+    return c.json({ error: e.message }, 500);
+  }
+});
+
 // --- Oracle Feed ---
 const feedTailer = new FeedTailer();
 

--- a/src/worktrees.ts
+++ b/src/worktrees.ts
@@ -1,0 +1,221 @@
+import { ssh, listSessions } from "./ssh";
+import { loadConfig } from "./config";
+import { readdirSync, readFileSync, existsSync } from "fs";
+import { join } from "path";
+
+export interface WorktreeInfo {
+  path: string;
+  branch: string;
+  repo: string; // org/repo
+  mainRepo: string; // org/mainRepo
+  name: string; // e.g. "1-freelance"
+  status: "active" | "stale" | "orphan";
+  tmuxWindow?: string; // window name if running
+  fleetFile?: string; // fleet config if registered
+}
+
+/**
+ * Scan all worktrees across ghq repos.
+ * Classifies:
+ *   active  — has a running tmux window
+ *   stale   — exists on disk, no tmux window
+ *   orphan  — git reports prunable
+ */
+export async function scanWorktrees(): Promise<WorktreeInfo[]> {
+  const config = loadConfig();
+  const ghqRoot = config.ghqRoot;
+  const fleetDir = join(import.meta.dir, "../fleet");
+
+  // 1. Find all .wt- directories
+  let wtPaths: string[] = [];
+  try {
+    const raw = await ssh(`find ${ghqRoot} -maxdepth 4 -name '*.wt-*' -type d 2>/dev/null`);
+    wtPaths = raw.split("\n").filter(Boolean);
+  } catch { /* no worktrees */ }
+
+  // 2. Get running tmux windows for matching
+  const sessions = await listSessions();
+  const runningWindows = new Set<string>();
+  for (const s of sessions) {
+    for (const w of s.windows) {
+      runningWindows.add(w.name);
+    }
+  }
+
+  // 3. Load fleet configs for matching
+  const fleetWindows = new Map<string, string>(); // repo -> fleet file
+  try {
+    for (const file of readdirSync(fleetDir).filter(f => f.endsWith(".json"))) {
+      const cfg = JSON.parse(readFileSync(join(fleetDir, file), "utf-8"));
+      for (const w of cfg.windows || []) {
+        if (w.repo) fleetWindows.set(w.repo, file);
+      }
+    }
+  } catch { /* no fleet dir */ }
+
+  // 4. Classify each worktree
+  const results: WorktreeInfo[] = [];
+
+  for (const wtPath of wtPaths) {
+    const dirName = wtPath.split("/").pop()!;
+    const parts = dirName.split(".wt-");
+    if (parts.length < 2) continue;
+
+    const mainRepoName = parts[0];
+    const wtName = parts[1];
+
+    // Derive org/repo path
+    const relPath = wtPath.replace(ghqRoot + "/", "");
+    const parentParts = relPath.split("/");
+    parentParts.pop(); // remove wt dir
+    const org = parentParts.join("/");
+    const mainRepo = `${org}/${mainRepoName}`;
+    const repo = `${org}/${dirName}`;
+
+    // Get branch
+    let branch = "";
+    try {
+      branch = (await ssh(`git -C '${wtPath}' rev-parse --abbrev-ref HEAD 2>/dev/null`)).trim();
+    } catch { branch = "unknown"; }
+
+    // Match to tmux window — check fleet config or name pattern
+    let tmuxWindow: string | undefined;
+    const fleetFile = fleetWindows.get(repo);
+
+    // Try to find matching window by name pattern
+    for (const s of sessions) {
+      for (const w of s.windows) {
+        // Window names like "neo-freelance" match wt name "1-freelance"
+        const taskPart = wtName.replace(/^\d+-/, "");
+        if (w.name.endsWith(`-${taskPart}`) || w.name === taskPart) {
+          tmuxWindow = w.name;
+        }
+      }
+    }
+
+    const status: WorktreeInfo["status"] = tmuxWindow ? "active" : "stale";
+
+    results.push({
+      path: wtPath,
+      branch,
+      repo,
+      mainRepo,
+      name: wtName,
+      status,
+      tmuxWindow,
+      fleetFile,
+    });
+  }
+
+  // 5. Check for orphaned worktrees (git reports them as prunable)
+  // Collect unique main repos that have worktrees
+  const mainRepos = [...new Set(results.map(r => r.mainRepo))];
+  for (const mainRepo of mainRepos) {
+    const mainPath = join(ghqRoot, mainRepo);
+    try {
+      const prunable = await ssh(`git -C '${mainPath}' worktree list --porcelain 2>/dev/null | grep -A1 'prunable' | grep 'worktree' | sed 's/worktree //'`);
+      for (const orphanPath of prunable.split("\n").filter(Boolean)) {
+        // Check if we already have this path
+        const existing = results.find(r => r.path === orphanPath);
+        if (existing) {
+          existing.status = "orphan";
+        } else {
+          const dirName = orphanPath.split("/").pop() || "";
+          results.push({
+            path: orphanPath,
+            branch: "(prunable)",
+            repo: dirName,
+            mainRepo,
+            name: dirName,
+            status: "orphan",
+          });
+        }
+      }
+    } catch { /* no prunable worktrees */ }
+  }
+
+  return results;
+}
+
+/**
+ * Clean up a single worktree by path.
+ * Kills tmux window, removes worktree, prunes, deletes branch.
+ */
+export async function cleanupWorktree(wtPath: string): Promise<string[]> {
+  const config = loadConfig();
+  const ghqRoot = config.ghqRoot;
+  const fleetDir = join(import.meta.dir, "../fleet");
+  const log: string[] = [];
+
+  const dirName = wtPath.split("/").pop()!;
+  const parts = dirName.split(".wt-");
+  if (parts.length < 2) {
+    log.push(`not a worktree: ${dirName}`);
+    return log;
+  }
+
+  const mainRepoName = parts[0];
+  const relPath = wtPath.replace(ghqRoot + "/", "");
+  const parentParts = relPath.split("/");
+  parentParts.pop();
+  const org = parentParts.join("/");
+  const mainPath = join(ghqRoot, org, mainRepoName);
+  const repo = `${org}/${dirName}`;
+
+  // 1. Find and kill tmux window
+  const sessions = await listSessions();
+  const wtName = parts[1];
+  const taskPart = wtName.replace(/^\d+-/, "");
+
+  for (const s of sessions) {
+    for (const w of s.windows) {
+      if (w.name.endsWith(`-${taskPart}`) || w.name === taskPart) {
+        try {
+          await ssh(`tmux kill-window -t '${s.name}:${w.name}'`);
+          log.push(`killed window ${s.name}:${w.name}`);
+        } catch {
+          log.push(`window already closed: ${w.name}`);
+        }
+      }
+    }
+  }
+
+  // 2. Get branch, remove worktree
+  let branch = "";
+  try { branch = (await ssh(`git -C '${wtPath}' rev-parse --abbrev-ref HEAD`)).trim(); } catch {}
+
+  try {
+    await ssh(`git -C '${mainPath}' worktree remove '${wtPath}' --force`);
+    await ssh(`git -C '${mainPath}' worktree prune`);
+    log.push(`removed worktree ${dirName}`);
+  } catch (e: any) {
+    log.push(`worktree remove failed: ${e.message || e}`);
+  }
+
+  // 3. Delete branch
+  if (branch && branch !== "main" && branch !== "HEAD" && branch !== "unknown") {
+    try {
+      await ssh(`git -C '${mainPath}' branch -d '${branch}'`);
+      log.push(`deleted branch ${branch}`);
+    } catch {
+      log.push(`branch ${branch} not deleted (may have unmerged changes)`);
+    }
+  }
+
+  // 4. Remove from fleet config
+  try {
+    for (const file of readdirSync(fleetDir).filter(f => f.endsWith(".json"))) {
+      const filePath = join(fleetDir, file);
+      const cfg = JSON.parse(readFileSync(filePath, "utf-8"));
+      const before = cfg.windows?.length || 0;
+      cfg.windows = (cfg.windows || []).filter((w: any) => w.repo !== repo);
+      if (cfg.windows.length < before) {
+        const { writeFileSync } = await import("fs");
+        writeFileSync(filePath, JSON.stringify(cfg, null, 2) + "\n");
+        log.push(`removed from ${file}`);
+      }
+    }
+  } catch { /* fleet dir may not exist */ }
+
+  return log;
+}


### PR DESCRIPTION
## Summary

- Adds worktree scanning, classification (active/stale/orphan), and one-click cleanup
- Backend: `GET /api/worktrees` + `POST /api/worktrees/cleanup` + `maw pulse cleanup` CLI
- Frontend: `#worktrees` view with status badges and batch cleanup

## Files Changed

| File | Change |
|------|--------|
| `src/worktrees.ts` | New — scan + cleanup logic |
| `src/server.ts` | Add `/api/worktrees` routes |
| `src/cli.ts` | Add `maw pulse cleanup` subcommand |
| `office/src/components/WorktreeView.tsx` | New — React dashboard |
| `office/src/App.tsx` | Add `#worktrees` route |

## Test plan

- [ ] `maw pulse cleanup --dry-run` lists stale worktrees without removing
- [ ] `maw pulse cleanup` removes stale worktrees (kills window, prunes, deletes branch)
- [ ] Web UI at `#worktrees` shows all worktrees with correct status
- [ ] "Remove" button cleans individual worktree
- [ ] "Clean All" removes all stale + orphan worktrees
- [ ] Active worktrees are protected from cleanup

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)