### PR TITLE
feat: maw ls dead oracle detection

### DIFF
--- a/src/commands/comm.ts
+++ b/src/commands/comm.ts
@@ -1,12 +1,33 @@
-import { listSessions, findWindow, capture, sendKeys, getPaneCommand } from "../ssh";
+import { listSessions, findWindow, capture, sendKeys, getPaneCommand, getPaneCommands } from "../ssh";
 
 export async function cmdList() {
   const sessions = await listSessions();
+
+  // Batch-check what process each pane is running
+  const targets: string[] = [];
+  for (const s of sessions) {
+    for (const w of s.windows) targets.push(`${s.name}:${w.index}`);
+  }
+  const cmds = await getPaneCommands(targets);
+
   for (const s of sessions) {
     console.log(`\x1b[36m${s.name}\x1b[0m`);
     for (const w of s.windows) {
-      const dot = w.active ? "\x1b[32m*\x1b[0m" : " ";
-      console.log(`  ${dot} ${w.index}: ${w.name}`);
+      const target = `${s.name}:${w.index}`;
+      const proc = cmds[target] || "";
+      const isAgent = /claude|codex|node/i.test(proc);
+
+      let dot: string;
+      let suffix = "";
+      if (w.active && isAgent) {
+        dot = "\x1b[32m●\x1b[0m"; // green — active + agent running
+      } else if (isAgent) {
+        dot = "\x1b[34m●\x1b[0m"; // blue — agent running
+      } else {
+        dot = "\x1b[31m●\x1b[0m"; // red — dead (shell only)
+        suffix = `  \x1b[90m(${proc || "?"})\x1b[0m`;
+      }
+      console.log(`  ${dot} ${w.index}: ${w.name}${suffix}`);
     }
   }
 }

--- a/src/ssh.ts
+++ b/src/ssh.ts
@@ -77,6 +77,13 @@ export async function getPaneCommand(target: string, host?: string): Promise<str
   return t.getPaneCommand(target);
 }
 
+/** Batch-check which panes are running what command. */
+export async function getPaneCommands(targets: string[], host?: string): Promise<Record<string, string>> {
+  const { Tmux } = await import("./tmux");
+  const t = new Tmux(host);
+  return t.getPaneCommands(targets);
+}
+
 export async function sendKeys(target: string, text: string, host?: string): Promise<void> {
   const { Tmux } = await import("./tmux");
   const t = new Tmux(host);


### PR DESCRIPTION
## Summary
- `maw ls` now shows process status for each window:
  - 🟢 Green: active window + agent running
  - 🔵 Blue: agent running (background)
  - 🔴 Red: dead — shell only, shows process name (e.g. `zsh`, `bash`)
- Batch `getPaneCommands` for performance (parallel tmux queries)
- Added `getPaneCommands` export to ssh.ts

## Test plan
- [ ] `maw ls` shows colored dots with dead detection
- [ ] Red dots appear for windows where Claude has exited
- [ ] Green/blue dots for running agents
- [ ] No performance regression (batch query)

🤖 Generated with [Claude Code](https://claude.com/claude-code)