### PR TITLE
fix: maw ls detects deleted working directories

### DIFF
--- a/src/commands/comm.ts
+++ b/src/commands/comm.ts
@@ -1,31 +1,35 @@
-import { listSessions, findWindow, capture, sendKeys, getPaneCommand, getPaneCommands } from "../ssh";
+import { listSessions, findWindow, capture, sendKeys, getPaneCommand, getPaneCommands, getPaneInfos } from "../ssh";
 
 export async function cmdList() {
   const sessions = await listSessions();
 
-  // Batch-check what process each pane is running
+  // Batch-check process + cwd for each pane
   const targets: string[] = [];
   for (const s of sessions) {
     for (const w of s.windows) targets.push(`${s.name}:${w.index}`);
   }
-  const cmds = await getPaneCommands(targets);
+  const infos = await getPaneInfos(targets);
 
   for (const s of sessions) {
     console.log(`\x1b[36m${s.name}\x1b[0m`);
     for (const w of s.windows) {
       const target = `${s.name}:${w.index}`;
-      const proc = cmds[target] || "";
-      const isAgent = /claude|codex|node/i.test(proc);
+      const info = infos[target] || { command: "", cwd: "" };
+      const isAgent = /claude|codex|node/i.test(info.command);
+      const cwdBroken = info.cwd.includes("(deleted)") || info.cwd.includes("(dead)");
 
       let dot: string;
       let suffix = "";
-      if (w.active && isAgent) {
+      if (cwdBroken) {
+        dot = "\x1b[31m●\x1b[0m"; // red — working dir deleted
+        suffix = "  \x1b[31m(path deleted)\x1b[0m";
+      } else if (w.active && isAgent) {
         dot = "\x1b[32m●\x1b[0m"; // green — active + agent running
       } else if (isAgent) {
         dot = "\x1b[34m●\x1b[0m"; // blue — agent running
       } else {
         dot = "\x1b[31m●\x1b[0m"; // red — dead (shell only)
-        suffix = `  \x1b[90m(${proc || "?"})\x1b[0m`;
+        suffix = `  \x1b[90m(${info.command || "?"})\x1b[0m`;
       }
       console.log(`  ${dot} ${w.index}: ${w.name}${suffix}`);
     }

--- a/src/ssh.ts
+++ b/src/ssh.ts
@@ -84,6 +84,13 @@ export async function getPaneCommands(targets: string[], host?: string): Promise
   return t.getPaneCommands(targets);
 }
 
+/** Batch-check command + cwd for all panes. */
+export async function getPaneInfos(targets: string[], host?: string): Promise<Record<string, { command: string; cwd: string }>> {
+  const { Tmux } = await import("./tmux");
+  const t = new Tmux(host);
+  return t.getPaneInfos(targets);
+}
+
 export async function sendKeys(target: string, text: string, host?: string): Promise<void> {
   const { Tmux } = await import("./tmux");
   const t = new Tmux(host);

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -143,6 +143,22 @@ export class Tmux {
     return result;
   }
 
+  /** Get command + cwd for a pane. */
+  async getPaneInfo(target: string): Promise<{ command: string; cwd: string }> {
+    const raw = await this.run("list-panes", "-t", target, "-F", "#{pane_current_command}\t#{pane_current_path}");
+    const [command = "", cwd = ""] = raw.split("\n")[0].split("\t");
+    return { command, cwd };
+  }
+
+  /** Batch-check command + cwd for all panes. */
+  async getPaneInfos(targets: string[]): Promise<Record<string, { command: string; cwd: string }>> {
+    const result: Record<string, { command: string; cwd: string }> = {};
+    await Promise.allSettled(targets.map(async (t) => {
+      try { result[t] = await this.getPaneInfo(t); } catch {}
+    }));
+    return result;
+  }
+
   async capture(target: string, lines = 80): Promise<string> {
     if (lines > 50) {
       return this.run("capture-pane", "-t", target, "-e", "-p", "-S", -lines);


### PR DESCRIPTION
## Summary
- Process check alone missed broken oracles — Claude can run in a deleted worktree
- Now checks `#{pane_current_path}` for `(deleted)` marker from tmux
- Shows red **"path deleted"** instead of false blue/green dot
- Added `getPaneInfo`/`getPaneInfos` to tmux.ts + ssh.ts (returns command + cwd)

Before: `neo-oracle-skills-cli` showed 🔵 (agent running)
After: `neo-oracle-skills-cli` shows 🔴 (path deleted)

## Test plan
- [ ] `maw ls` shows "path deleted" for orphaned worktree windows
- [ ] Normal windows still show green/blue correctly
- [ ] Dead shells still show red with process name

🤖 Generated with [Claude Code](https://claude.com/claude-code)