### PR TITLE
fix: Recently Active shows all oracles, not capped at 6

### DIFF
--- a/office/src/components/FleetGrid.tsx
+++ b/office/src/components/FleetGrid.tsx
@@ -287,7 +287,6 @@ export const FleetGrid = memo(function FleetGrid({
     const recentGone = [...recentByName.values()]
       .filter(e => !seenNames.has(e.name))
       .sort((a, b) => b.lastBusy - a.lastBusy)
-      .slice(0, 6)
       .map(e => agentMap.get(e.target) || agents.find(a => a.name === e.name) || e);
 
     // Active first, then recently-gone


### PR DESCRIPTION
## Summary
Removes `.slice(0, 6)` hard cap on Recently Active section. With 28 agents running, oracles like Calliope were silently excluded even though they were alive and recently active.

`RECENT_TTL` (30 min) already handles pruning stale entries — no additional cap needed.

Fixes #30

## Test plan
- [ ] All recently-active oracles appear in the section (not just first 6)
- [ ] Section doesn't overflow badly with many entries
- [ ] Stale entries still prune after 30 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)