### PR TITLE
fix: Recently Active shows busy + last 5 idle

### DIFF
--- a/office/src/components/FleetGrid.tsx
+++ b/office/src/components/FleetGrid.tsx
@@ -287,6 +287,7 @@ export const FleetGrid = memo(function FleetGrid({
     const recentGone = [...recentByName.values()]
       .filter(e => !seenNames.has(e.name))
       .sort((a, b) => b.lastBusy - a.lastBusy)
+      .slice(0, 5)
       .map(e => agentMap.get(e.target) || agents.find(a => a.name === e.name) || e);
 
     // Active first, then recently-gone


### PR DESCRIPTION
## Summary
Cap recently-gone (idle/ready) entries to 5 most recent. Currently-busy oracles still show unlimited. Keeps the section useful without becoming a wall of 28 agents.

## Test plan
- [ ] Busy oracles always appear
- [ ] Max 5 idle/recently-gone oracles shown
- [ ] Most recent idle oracles prioritized

🤖 Generated with [Claude Code](https://claude.com/claude-code)