### PR TITLE
fix: feed resolver handles oracle-oracle double suffix

### DIFF
--- a/office/src/hooks/useSessions.ts
+++ b/office/src/hooks/useSessions.ts
@@ -59,8 +59,11 @@ export function useSessions() {
       if (agent) return agent;
     }
     // Fallback: match by oracle name (main window)
-    const oracleMain = `${event.oracle}-oracle`.toLowerCase();
-    return agentsRef.current.find(a => a.name.toLowerCase() === oracleMain);
+    // Handle both formats: oracle="neo" → "neo-oracle", oracle="calliope-oracle" → "calliope-oracle"
+    const oracleLower = event.oracle.toLowerCase();
+    const oracleMain = oracleLower.endsWith("-oracle") ? oracleLower : `${oracleLower}-oracle`;
+    return agentsRef.current.find(a => a.name.toLowerCase() === oracleMain)
+      || agentsRef.current.find(a => a.name.toLowerCase() === oracleLower);
   }, []);
 
   const updateStatusFromFeed = useCallback((event: FeedEvent) => {


### PR DESCRIPTION
Calliope (and others with full name in feed) now resolve correctly to their tmux window.