### PR TITLE
fix: maw wake handles stale branches (#62)

### DIFF
--- a/src/commands/wake.ts
+++ b/src/commands/wake.ts
@@ -174,6 +174,8 @@ export async function cmdWake(oracle: string, opts: { task?: string; newWt?: str
       const wtPath = `${parentDir}/${repoName}.wt-${wtName}`;
       const branch = `agents/${wtName}`;
 
+      // Delete stale branch if it exists but has no worktree (#62)
+      try { await ssh(`git -C '${repoPath}' branch -D '${branch}' 2>/dev/null`); } catch { /* branch doesn't exist — fine */ }
       await ssh(`git -C '${repoPath}' worktree add '${wtPath}' -b '${branch}'`);
       console.log(`\x1b[32m+\x1b[0m worktree: ${wtPath} (${branch})`);
 


### PR DESCRIPTION
Deletes existing branch before `git worktree add -b`. Fixes #62.