### PR TITLE
fix: sendText literal mode — preserves pipe chars in markdown

### DIFF
--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -224,8 +224,9 @@ export class Tmux {
       await new Promise(r => setTimeout(r, 150));
       await this.sendKeys(target, "Enter");
     } else {
-      // Direct send-keys — let q() in run() handle all escaping
-      await this.run("send-keys", "-t", target, "--", text, "Enter");
+      // Literal send — -l prevents tmux from interpreting special chars like |
+      await this.sendKeysLiteral(target, text);
+      await this.sendKeys(target, "Enter");
     }
   }
 


### PR DESCRIPTION
## Summary
`tmux send-keys` without `-l` can interpret `|` as special characters, stripping leading pipes from markdown table rows. Now uses `send-keys -l` (literal) for short text, preventing tmux from interpreting content.

Fixes broken markdown table headers in blog posts sent via `maw hey`.

## Test plan
- [ ] `maw hey agent '| Header | Col |'` preserves all pipe characters
- [ ] Normal text sending still works
- [ ] Multiline (buffer path) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)