### PR TITLE
fix: delay before Enter after literal send-keys

### DIFF
--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -226,6 +226,8 @@ export class Tmux {
     } else {
       // Literal send — -l prevents tmux from interpreting special chars like |
       await this.sendKeysLiteral(target, text);
+      // Claude Code needs time to process literal text before Enter
+      await new Promise(r => setTimeout(r, 150));
       await this.sendKeys(target, "Enter");
     }
   }


### PR DESCRIPTION
150ms delay between text and Enter, matching the buffer path.