### PR TITLE
fix: double Enter after literal send-keys

### DIFF
--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -229,6 +229,9 @@ export class Tmux {
       // Claude Code needs time to process literal text before Enter
       await new Promise(r => setTimeout(r, 150));
       await this.sendKeys(target, "Enter");
+      // Second Enter after delay — first may get swallowed by Claude Code input processing
+      await new Promise(r => setTimeout(r, 150));
+      await this.sendKeys(target, "Enter");
     }
   }
 


### PR DESCRIPTION
Two Enter keys 150ms apart. First may get swallowed, second ensures submit.