### PR TITLE
feat: maw sleep — single agent shutdown

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,7 @@ import { cmdOracleList, cmdOracleAbout } from "./commands/oracle";
 import { cmdWakeAll, cmdSleep, cmdFleetLs, cmdFleetRenumber, cmdFleetValidate, cmdFleetSync } from "./commands/fleet";
 import { cmdFleetInit } from "./commands/fleet-init";
 import { cmdDone } from "./commands/done";
+import { cmdSleepOne } from "./commands/sleep";
 import { cmdLogLs, cmdLogExport, cmdLogChat } from "./commands/log";
 import { cmdTokens } from "./commands/tokens";
 
@@ -34,6 +35,7 @@ function usage() {
   maw wake all [--kill]       Wake fleet (01-15 + 99, skips dormant 20+)
   maw wake all --all          Wake ALL including dormant
   maw wake all --resume       Wake fleet + send /recap to active board items
+  maw sleep <oracle> [window] Gracefully stop one oracle window
   maw stop                    Stop all fleet sessions
   maw about <oracle>           Oracle profile — session, worktrees, fleet
   maw oracle ls               Fleet status (awake/sleeping/worktrees)
@@ -154,8 +156,17 @@ if (cmd === "--version" || cmd === "-v") {
 } else if (cmd === "done" || cmd === "finish") {
   if (!args[1]) { console.error("usage: maw done <window-name>\n       e.g. maw done neo-freelance"); process.exit(1); }
   await cmdDone(args[1]);
-} else if (cmd === "stop" || cmd === "sleep" || cmd === "rest") {
+} else if (cmd === "stop" || cmd === "rest") {
   await cmdSleep();
+} else if (cmd === "sleep") {
+  if (!args[1]) {
+    // No args: fleet-wide sleep (same as maw stop)
+    await cmdSleep();
+  } else if (args[1] === "--all-done") {
+    console.log("\x1b[90m(placeholder) maw sleep --all-done — sleep ALL agents. Not yet implemented.\x1b[0m");
+  } else {
+    await cmdSleepOne(args[1], args[2]);
+  }
 } else if (cmd === "wake") {
   if (!args[1]) { console.error("usage: maw wake <oracle> [task] [--new <name>]\n       maw wake all [--kill]"); process.exit(1); }
   if (args[1].toLowerCase() === "all") {

--- a/src/commands/sleep.ts
+++ b/src/commands/sleep.ts
@@ -1,0 +1,104 @@
+import { tmux } from "../tmux";
+import { detectSession } from "./wake";
+import { appendFile, mkdir } from "fs/promises";
+import { homedir } from "os";
+import { join } from "path";
+
+/**
+ * maw sleep <oracle> [window]
+ *
+ * Gracefully stop a single Oracle agent's tmux window:
+ * 1. Send /exit to the Claude session
+ * 2. Wait 3 seconds
+ * 3. If window still exists, kill it
+ * 4. Log the event
+ */
+export async function cmdSleepOne(oracle: string, window?: string) {
+  // Resolve session
+  const session = await detectSession(oracle);
+  if (!session) {
+    console.error(`\x1b[31merror\x1b[0m: no running session found for '${oracle}'`);
+    process.exit(1);
+  }
+
+  // Determine window name
+  const windowName = window ? `${oracle}-${window}` : `${oracle}-oracle`;
+
+  // Verify window exists
+  let windows;
+  try {
+    windows = await tmux.listWindows(session);
+  } catch {
+    console.error(`\x1b[31merror\x1b[0m: could not list windows for session '${session}'`);
+    process.exit(1);
+  }
+
+  const target = windows.find(w => w.name === windowName);
+  if (!target) {
+    // Try partial match (e.g. oracle-N-name pattern)
+    const nameSuffix = window || "oracle";
+    const fuzzy = windows.find(w =>
+      w.name === windowName ||
+      new RegExp(`^${oracle}-\\d+-${nameSuffix}$`).test(w.name)
+    );
+    if (!fuzzy) {
+      console.error(`\x1b[31merror\x1b[0m: window '${windowName}' not found in session '${session}'`);
+      console.error(`\x1b[90mavailable:\x1b[0m ${windows.map(w => w.name).join(", ")}`);
+      process.exit(1);
+    }
+    // Use the fuzzy-matched name
+    return await doSleep(session, fuzzy.name, oracle);
+  }
+
+  await doSleep(session, windowName, oracle);
+}
+
+async function doSleep(session: string, windowName: string, oracle: string) {
+  const target = `${session}:${windowName}`;
+
+  // 1. Send /exit for graceful shutdown
+  console.log(`\x1b[90m...\x1b[0m sending /exit to ${target}`);
+  try {
+    // Send /exit char by char (slash command pattern from sendKeys in ssh.ts)
+    for (const ch of "/exit") {
+      await tmux.sendKeysLiteral(target, ch);
+    }
+    await tmux.sendKeys(target, "Enter");
+  } catch {
+    // Window might already be gone
+  }
+
+  // 2. Wait 3 seconds for graceful shutdown
+  await new Promise(r => setTimeout(r, 3000));
+
+  // 3. If window still exists, force kill
+  try {
+    const windows = await tmux.listWindows(session);
+    const stillExists = windows.some(w => w.name === windowName);
+    if (stillExists) {
+      await tmux.killWindow(target);
+      console.log(`  \x1b[33m!\x1b[0m force-killed ${windowName} (did not exit gracefully)`);
+    } else {
+      console.log(`  \x1b[32m✓\x1b[0m ${windowName} exited gracefully`);
+    }
+  } catch {
+    // Session might be gone if it was the last window
+    console.log(`  \x1b[32m✓\x1b[0m ${windowName} stopped`);
+  }
+
+  // 4. Log the sleep event
+  const logDir = join(homedir(), ".oracle");
+  const logFile = join(logDir, "maw-log.jsonl");
+  const line = JSON.stringify({
+    ts: new Date().toISOString(),
+    type: "sleep",
+    oracle,
+    window: windowName,
+  }) + "\n";
+  try {
+    await mkdir(logDir, { recursive: true });
+    await appendFile(logFile, line);
+  } catch {}
+
+  console.log(`\x1b[32msleep\x1b[0m ${oracle} (${windowName})`);
+}


### PR DESCRIPTION
## Summary

- Add `maw sleep <oracle> [window]` command for gracefully stopping a single Oracle agent
- Sends `/exit` to Claude session, waits 3s, force-kills if needed
- Logs sleep events to `~/.oracle/maw-log.jsonl`
- Supports fuzzy window matching for fleet patterns

## Usage

```
maw sleep hermes          # Sleep hermes-oracle main window
maw sleep neo mawjs       # Sleep neo-mawjs worktree window
```

## Test plan

- [ ] `maw sleep` on a running Oracle — verify graceful /exit
- [ ] `maw sleep` on a stuck agent — verify force-kill after 3s
- [ ] `maw sleep` on non-existent oracle — verify error message
- [ ] Check `~/.oracle/maw-log.jsonl` for sleep event entry
- [ ] Verify worktree preserved on disk after sleep

Closes Pulse-Oracle/pulse-cli#7

🤖 Generated with [Claude Code](https://claude.com/claude-code)