### PR TITLE
feat: maw tab + maw talk-to (#79, #78)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,8 @@ import { cmdDone } from "./commands/done";
 import { cmdSleepOne } from "./commands/sleep";
 import { cmdLogLs, cmdLogExport, cmdLogChat } from "./commands/log";
 import { cmdTokens } from "./commands/tokens";
+import { cmdTab } from "./commands/tab";
+import { cmdTalkTo } from "./commands/talk-to";
 
 const args = process.argv.slice(2);
 const cmd = args[0]?.toLowerCase();
@@ -52,6 +54,10 @@ function usage() {
   maw tokens --json           JSON output for API consumption
   maw log chat [oracle]       Chat view — grouped conversation bubbles
   maw chat [oracle]           Shorthand for log chat
+  maw tab                      List tabs in current session
+  maw tab N                    Peek tab N
+  maw tab N <msg...>           Send message to tab N
+  maw talk-to <agent> <msg>    Thread + hey (persistent + real-time)
   maw <agent> <msg...>        Shorthand for hey
   maw <agent>                 Shorthand for peek
   maw serve [port]            Start web UI (default: 3456)
@@ -97,6 +103,11 @@ if (cmd === "--version" || cmd === "-v") {
   const msgArgs = args.slice(2).filter(a => a !== "--force");
   if (!args[1] || !msgArgs.length) { console.error("usage: maw hey <agent> <message> [--force]"); process.exit(1); }
   await cmdSend(args[1], msgArgs.join(" "), force);
+} else if (cmd === "talk-to" || cmd === "talkto" || cmd === "talk") {
+  const force = args.includes("--force");
+  const msgArgs = args.slice(2).filter(a => a !== "--force");
+  if (!args[1] || !msgArgs.length) { console.error("usage: maw talk-to <agent> <message> [--force]"); process.exit(1); }
+  await cmdTalkTo(args[1], msgArgs.join(" "), force);
 } else if (cmd === "fleet" && args[1] === "init") {
   await cmdFleetInit();
 } else if (cmd === "fleet" && args[1] === "ls") {
@@ -240,6 +251,8 @@ if (cmd === "--version" || cmd === "-v") {
   }
 } else if (cmd === "completions") {
   await cmdCompletions(args[1]);
+} else if (cmd === "tab" || cmd === "tabs") {
+  await cmdTab(args.slice(1));
 } else if (cmd === "view" || cmd === "create-view" || cmd === "attach") {
   if (!args[1]) { console.error("usage: maw view <agent> [window] [--clean]"); process.exit(1); }
   const clean = args.includes("--clean");

--- a/src/commands/completions.ts
+++ b/src/commands/completions.ts
@@ -3,7 +3,7 @@ import { join } from "path";
 
 export async function cmdCompletions(sub: string) {
   if (sub === "commands") {
-    console.log("ls peek hey wake fleet stop done overview about oracle pulse view create-view serve");
+    console.log("ls peek hey wake fleet stop done overview about oracle pulse view create-view tab talk-to serve");
   } else if (sub === "oracles" || sub === "windows") {
     const fleetDir = join(import.meta.dir, "../../fleet");
     const names = new Set<string>();

--- a/src/commands/tab.ts
+++ b/src/commands/tab.ts
@@ -1,0 +1,81 @@
+import { ssh } from "../ssh";
+import { cmdPeek, cmdSend } from "./comm";
+import { cmdTalkTo } from "./talk-to";
+
+/**
+ * Get current tmux session name (whoami).
+ * Uses tmux display-message which returns the session of the calling terminal.
+ */
+async function currentSession(): Promise<string> {
+  try {
+    return (await ssh("tmux display-message -p '#S'")).trim();
+  } catch {
+    console.error("\x1b[31merror\x1b[0m: not inside a tmux session");
+    process.exit(1);
+  }
+}
+
+/**
+ * List windows in current session, mapping index → name.
+ */
+async function listTabs(session: string): Promise<{ index: number; name: string; active: boolean }[]> {
+  const raw = await ssh(
+    `tmux list-windows -t '${session}' -F '#{window_index}:#{window_name}:#{window_active}'`
+  );
+  return raw.split("\n").filter(Boolean).map(line => {
+    const [idx, name, active] = line.split(":");
+    return { index: +idx, name, active: active === "1" };
+  });
+}
+
+/**
+ * maw tab          — list tabs in current session
+ * maw tab N        — peek tab N
+ * maw tab N "msg"  — hey tab N
+ * maw tab N --talk "msg" — talk-to tab N (future: #78)
+ */
+export async function cmdTab(tabArgs: string[]) {
+  const session = await currentSession();
+  const tabNum = tabArgs[0] ? parseInt(tabArgs[0], 10) : NaN;
+
+  // maw tab — list all tabs
+  if (isNaN(tabNum)) {
+    const tabs = await listTabs(session);
+    console.log(`\x1b[36m${session}\x1b[0m tabs:`);
+    for (const t of tabs) {
+      const marker = t.active ? " \x1b[32m← you are here\x1b[0m" : "";
+      console.log(`  ${t.index}: ${t.name}${marker}`);
+    }
+    return;
+  }
+
+  // Resolve tab number → window name
+  const tabs = await listTabs(session);
+  const tab = tabs.find(t => t.index === tabNum);
+  if (!tab) {
+    console.error(`\x1b[31merror\x1b[0m: tab ${tabNum} not found in session \x1b[36m${session}\x1b[0m`);
+    console.error(`available: ${tabs.map(t => t.index).join(", ")}`);
+    process.exit(1);
+  }
+
+  const hasTalk = tabArgs.includes("--talk");
+  const remaining = tabArgs.slice(1).filter(a => a !== "--force" && a !== "--talk");
+  const force = tabArgs.includes("--force");
+
+  // maw tab N — peek
+  if (!remaining.length) {
+    await cmdPeek(tab.name);
+    return;
+  }
+
+  const message = remaining.join(" ");
+
+  // maw tab N --talk "msg" — talk-to (MCP + hey)
+  if (hasTalk) {
+    await cmdTalkTo(tab.name, message, force);
+    return;
+  }
+
+  // maw tab N "msg" — hey
+  await cmdSend(tab.name, message, force);
+}

--- a/src/commands/talk-to.ts
+++ b/src/commands/talk-to.ts
@@ -1,0 +1,189 @@
+import { loadConfig } from "../config";
+import { listSessions, findWindow, sendKeys, getPaneCommand } from "../ssh";
+import { runHook } from "../hooks";
+import { appendFile, mkdir } from "fs/promises";
+import { homedir, hostname } from "os";
+import { join } from "path";
+
+const ORACLE_URL = () => process.env.ORACLE_URL || loadConfig().oracleUrl;
+
+interface ThreadResponse {
+  thread_id: number;
+  message_id: number;
+  status: string;
+  oracle_response?: {
+    content: string;
+    principles_found: number;
+    patterns_found: number;
+  } | null;
+}
+
+interface ThreadInfo {
+  thread: {
+    id: number;
+    title: string;
+    status: string;
+    created_at: string;
+  };
+  messages: {
+    id: number;
+    role: string;
+    content: string;
+    created_at: string;
+  }[];
+}
+
+/**
+ * Find or create a channel thread for a target.
+ * Convention: thread title = "channel:<target>"
+ */
+async function findChannelThread(target: string): Promise<number | null> {
+  try {
+    const res = await fetch(`${ORACLE_URL()}/api/threads?limit=50`);
+    if (!res.ok) return null;
+    const data = await res.json() as { threads: { id: number; title: string; status: string }[] };
+    const channel = data.threads.find(t => t.title === `channel:${target}` && t.status !== "closed");
+    return channel?.id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Post message to oracle_thread (MCP persistence layer).
+ */
+async function postToThread(target: string, message: string): Promise<ThreadResponse | null> {
+  const threadId = await findChannelThread(target);
+  const body: Record<string, unknown> = {
+    message,
+    role: "claude",
+  };
+  if (threadId) {
+    body.thread_id = threadId;
+  } else {
+    body.title = `channel:${target}`;
+  }
+
+  try {
+    const res = await fetch(`${ORACLE_URL()}/api/thread`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      console.error(`\x1b[31merror\x1b[0m: Oracle API returned ${res.status}`);
+      return null;
+    }
+    return await res.json() as ThreadResponse;
+  } catch (e: any) {
+    console.error(`\x1b[31merror\x1b[0m: Oracle unreachable — ${e.message}`);
+    return null;
+  }
+}
+
+/**
+ * Get thread message count.
+ */
+async function getThreadInfo(threadId: number): Promise<{ messageCount: number } | null> {
+  try {
+    const res = await fetch(`${ORACLE_URL()}/api/thread/${threadId}`);
+    if (!res.ok) return null;
+    const data = await res.json() as ThreadInfo;
+    return { messageCount: data.messages.length };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * maw talk-to <target> "message"
+ *
+ * 1. Post to oracle_thread (MCP) → persistent
+ * 2. Send maw hey to target → notification with context
+ *
+ * MCP first, hey after. Order matters.
+ */
+export async function cmdTalkTo(target: string, message: string, force = false) {
+  // Step 1: Post to oracle_thread
+  console.log(`\x1b[36m💬\x1b[0m posting to thread channel:${target}...`);
+  const threadResult = await postToThread(target, message);
+
+  if (!threadResult) {
+    console.error(`\x1b[33mwarn\x1b[0m: thread post failed — falling back to maw hey only`);
+  }
+
+  // Step 2: Build notification with context
+  const from = process.env.CLAUDE_AGENT_NAME || "cli";
+  const preview = message.length > 80 ? message.slice(0, 77) + "..." : message;
+
+  let notification: string;
+  if (threadResult) {
+    const info = await getThreadInfo(threadResult.thread_id);
+    const msgCount = info?.messageCount ?? "?";
+    notification = [
+      `💬 channel:${target} (#${threadResult.thread_id}) — ${msgCount} msgs`,
+      `From: ${from}`,
+      `Preview: "${preview}"`,
+      `→ อ่านเต็มที่ thread #${threadResult.thread_id} หรือพิมพ์ /talk-to #${threadResult.thread_id}`,
+    ].join("\n");
+  } else {
+    notification = [
+      `💬 from ${from}`,
+      `"${preview}"`,
+    ].join("\n");
+  }
+
+  // Step 3: Send hey with context
+  const sessions = await listSessions();
+  const tmuxTarget = findWindow(sessions, target);
+  if (!tmuxTarget) {
+    // Thread was posted but target window not found — still useful
+    if (threadResult) {
+      console.log(`\x1b[32m✓\x1b[0m thread #${threadResult.thread_id} updated`);
+      console.log(`\x1b[33mwarn\x1b[0m: window "${target}" not found — message saved to thread only`);
+    } else {
+      console.error(`\x1b[31merror\x1b[0m: window "${target}" not found`);
+      process.exit(1);
+    }
+    return;
+  }
+
+  // Check if agent is running
+  if (!force) {
+    const cmd = await getPaneCommand(tmuxTarget);
+    const isAgent = /claude|codex|node/i.test(cmd);
+    if (!isAgent) {
+      if (threadResult) {
+        console.log(`\x1b[32m✓\x1b[0m thread #${threadResult.thread_id} updated`);
+        console.log(`\x1b[33mwarn\x1b[0m: no active Claude in ${tmuxTarget} — message saved to thread only`);
+      } else {
+        console.error(`\x1b[31merror\x1b[0m: no active Claude session in ${tmuxTarget} (use --force)`);
+        process.exit(1);
+      }
+      return;
+    }
+  }
+
+  await sendKeys(tmuxTarget, notification);
+  await runHook("after_send", { to: target, message: notification });
+
+  // Log to maw-log.jsonl
+  const logDir = join(homedir(), ".oracle");
+  const logFile = join(logDir, "maw-log.jsonl");
+  const host = hostname();
+  const sid = process.env.CLAUDE_SESSION_ID || null;
+  const ch = threadResult ? `thread:${threadResult.thread_id}` : undefined;
+  const line = JSON.stringify({
+    ts: new Date().toISOString(),
+    from,
+    to: target,
+    target: tmuxTarget,
+    msg: message,
+    host,
+    sid,
+    ch,
+  }) + "\n";
+  try { await mkdir(logDir, { recursive: true }); await appendFile(logFile, line); } catch {}
+
+  console.log(`\x1b[32m✓\x1b[0m thread #${threadResult?.thread_id ?? "?"} + sent → ${tmuxTarget}`);
+}


### PR DESCRIPTION
## Summary

- **`maw tab`** (#79) — alias windows by number within current tmux session
  - `maw tab` → list tabs with "← you are here" marker
  - `maw tab N` → peek tab N
  - `maw tab N msg` → hey tab N
  - `maw tab N --talk msg` → talk-to tab N (MCP + hey)

- **`maw talk-to`** (#78) — MCP thread + hey notification with context
  - Posts to `channel:<target>` oracle_thread first (persistent)
  - Then sends hey with thread ID, msg count, preview
  - Graceful fallback: Oracle unreachable → hey only; window not found → thread only

## Files Changed

- `src/commands/tab.ts` — new command
- `src/commands/talk-to.ts` — new command
- `src/cli.ts` — routing + usage text
- `src/commands/completions.ts` — shell autocomplete

## Test plan

- [ ] `maw tab` lists windows in current session
- [ ] `maw tab 3` peeks correct window
- [ ] `maw tab 3 "msg"` sends to correct window
- [ ] `maw talk-to neo "msg"` posts to thread + sends hey
- [ ] `maw talk-to` without args shows usage

Closes #79, closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)