### PR TITLE
fix: maw wake ensures Claude runs in all windows

### DIFF
--- a/src/commands/fleet.ts
+++ b/src/commands/fleet.ts
@@ -3,6 +3,7 @@ import { readdirSync, renameSync, existsSync } from "fs";
 import { ssh } from "../ssh";
 import { tmux } from "../tmux";
 import { loadConfig, buildCommand, getEnvVars } from "../config";
+import { ensureSessionRunning } from "./wake";
 
 interface FleetWindow {
   name: string;
@@ -462,6 +463,7 @@ export async function cmdWakeAll(opts: { kill?: boolean; all?: boolean; resume?:
     }
 
     if (!sess.skip_command) {
+      await new Promise(r => setTimeout(r, 300));
       try { await tmux.sendText(`${sess.name}:${first.name}`, buildCommand(first.name)); } catch { /* ok */ }
     }
     winCount++;
@@ -491,6 +493,22 @@ export async function cmdWakeAll(opts: { kill?: boolean; all?: boolean; resume?:
   // Scan disk for worktrees not covered by fleet configs and spawn them
   const wtExtra = await respawnMissingWorktrees(sessions);
   winCount += wtExtra;
+
+  // Verify all windows actually started Claude (not stuck on zsh)
+  if (sessCount > 0) {
+    console.log("  \x1b[36mVerifying sessions...\x1b[0m");
+    await new Promise(r => setTimeout(r, 3000)); // let shells init
+    let totalRetried = 0;
+    for (const sess of sessions) {
+      if (sess.skip_command) continue;
+      totalRetried += await ensureSessionRunning(sess.name);
+    }
+    if (totalRetried > 0) {
+      console.log(`  \x1b[33m${totalRetried} window(s) retried.\x1b[0m`);
+    } else {
+      console.log("  \x1b[32m✓ All windows running.\x1b[0m");
+    }
+  }
 
   console.log(`\n  \x1b[32m${sessCount} sessions, ${winCount} windows woke up.\x1b[0m\n`);
 

--- a/src/commands/wake.ts
+++ b/src/commands/wake.ts
@@ -4,6 +4,36 @@ import { loadConfig, buildCommand, getEnvVars } from "../config";
 import { readdirSync, readFileSync } from "fs";
 import { join } from "path";
 
+/**
+ * Verify all windows in a session are running Claude (not empty zsh).
+ * Retries buildCommand for any that are still on a shell prompt.
+ */
+export async function ensureSessionRunning(session: string): Promise<number> {
+  let retried = 0;
+  let windows: { index: number; name: string; active: boolean }[];
+  try {
+    windows = await tmux.listWindows(session);
+  } catch { return 0; }
+
+  const targets = windows.map(w => `${session}:${w.name}`);
+  const cmds = await tmux.getPaneCommands(targets);
+
+  for (const win of windows) {
+    const target = `${session}:${win.name}`;
+    const paneCmd = (cmds[target] || "").trim().toLowerCase();
+
+    if (paneCmd === "zsh" || paneCmd === "bash" || paneCmd === "sh" || paneCmd === "") {
+      try {
+        await new Promise(r => setTimeout(r, 500));
+        await tmux.sendText(target, buildCommand(win.name));
+        console.log(`\x1b[33m↻\x1b[0m retry: ${win.name} (was ${paneCmd || "empty"})`);
+        retried++;
+      } catch { /* window may have been killed */ }
+    }
+  }
+  return retried;
+}
+
 /** Fetch a GitHub issue and build a prompt for claude -p */
 export async function fetchIssuePrompt(issueNum: number, repo?: string): Promise<string> {
   // Detect repo from git remote if not specified
@@ -181,6 +211,11 @@ export async function cmdWake(oracle: string, opts: { task?: string; newWt?: str
         }
       }
     }
+
+    // Verify all windows started Claude (not stuck on zsh)
+    await new Promise(r => setTimeout(r, 3000));
+    const retried = await ensureSessionRunning(session);
+    if (retried > 0) console.log(`\x1b[33m${retried} window(s) retried.\x1b[0m`);
   }
 
   let targetPath = repoPath;


### PR DESCRIPTION
## Summary
- Adds `ensureSessionRunning()` — after spawning windows, verifies each pane is running `claude`/`codex` (not stuck on `zsh`). Retries `buildCommand()` for any that are still on a shell prompt.
- Adds missing 300ms delay before first window's `sendText` in `cmdWakeAll()` (subsequent windows already had this).
- Verification runs after a 3s settle period in both `maw wake <oracle>` and `maw wake all`.

## Test plan
- [ ] `maw wake all --kill` → verify no empty zsh shells after full fleet spawn
- [ ] `maw wake neo` with existing worktrees → verify all worktree windows have Claude running
- [ ] Kill a worktree window, run `maw wake neo` → verify it respawns with Claude

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)