### PR TITLE
fix: repo audit — session routing, fleet renumber, close stale issues

### DIFF
--- a/src/commands/comm.ts
+++ b/src/commands/comm.ts
@@ -1,8 +1,29 @@
-import { listSessions, findWindow, capture, sendKeys, getPaneCommand, getPaneCommands, getPaneInfos } from "../ssh";
+import { listSessions, findWindow, capture, sendKeys, getPaneCommand, getPaneCommands, getPaneInfos, Session } from "../ssh";
+import { loadConfig } from "../config";
+import { resolveFleetSession } from "./wake";
 import { runHook } from "../hooks";
 import { appendFile, mkdir } from "fs/promises";
 import { homedir } from "os";
 import { join } from "path";
+
+/** Resolve which sessions to search for an oracle query (#86). */
+function resolveSearchSessions(query: string, sessions: Session[]): Session[] {
+  const config = loadConfig();
+  // 1. Check config.sessions mapping
+  const mapped = (config.sessions as Record<string, string>)?.[query];
+  if (mapped) {
+    const filtered = sessions.filter(s => s.name === mapped);
+    if (filtered.length > 0) return filtered;
+  }
+  // 2. Check fleet configs for oracle → session mapping
+  const fleetSession = resolveFleetSession(query);
+  if (fleetSession) {
+    const filtered = sessions.filter(s => s.name === fleetSession);
+    if (filtered.length > 0) return filtered;
+  }
+  // 3. Fallback: search all
+  return sessions;
+}
 
 export async function cmdList() {
   const sessions = await listSessions();
@@ -59,10 +80,7 @@ export async function cmdPeek(query?: string) {
     }
     return;
   }
-  const { loadConfig } = await import("../config");
-  const config = await loadConfig();
-  const sessionName = (config.sessions as Record<string, string>)?.[query];
-  const searchIn = sessionName ? sessions.filter(s => s.name === sessionName) : sessions;
+  const searchIn = resolveSearchSessions(query, sessions);
   const target = findWindow(searchIn, query);
   if (!target) { console.error(`window not found: ${query}`); process.exit(1); }
   const content = await capture(target);
@@ -71,11 +89,8 @@ export async function cmdPeek(query?: string) {
 }
 
 export async function cmdSend(query: string, message: string, force = false) {
-  const { loadConfig } = await import("../config");
-  const config = await loadConfig();
-  const sessionName = (config.sessions as Record<string, string>)?.[query];
   const sessions = await listSessions();
-  const searchIn = sessionName ? sessions.filter(s => s.name === sessionName) : sessions;
+  const searchIn = resolveSearchSessions(query, sessions);
   const target = findWindow(searchIn, query);
   if (!target) { console.error(`window not found: ${query}`); process.exit(1); }
 

--- a/src/commands/fleet.ts
+++ b/src/commands/fleet.ts
@@ -1,5 +1,5 @@
 import { join } from "path";
-import { readdirSync, renameSync, existsSync } from "fs";
+import { readdirSync, renameSync, existsSync, unlinkSync } from "fs";
 import { ssh } from "../ssh";
 import { tmux } from "../tmux";
 import { loadConfig, buildCommand, getEnvVars } from "../config";
@@ -139,17 +139,18 @@ export async function cmdFleetRenumber() {
       // Remove old file (only if name changed)
       const oldPath = join(FLEET_DIR, e.file);
       if (existsSync(oldPath) && newFile !== e.file) {
-        const { unlinkSync } = require("fs");
         unlinkSync(oldPath);
       }
 
-      // Rename running tmux session if it matches old name
-      if (runningSessions.includes(oldName)) {
+      // Rename running tmux session (#84) — try exact name first, then pattern match
+      const runningMatch = runningSessions.find(s => s === oldName)
+        || runningSessions.find(s => s.replace(/^\d+-/, "") === e.groupName);
+      if (runningMatch && runningMatch !== newName) {
         try {
-          await tmux.run("rename-session", "-t", oldName, newName);
-          console.log(`  ${e.file.padEnd(28)} → ${newFile}  (tmux renamed)`);
+          await tmux.run("rename-session", "-t", runningMatch, newName);
+          console.log(`  ${e.file.padEnd(28)} → ${newFile}  (tmux: ${runningMatch} → ${newName})`);
         } catch {
-          console.log(`  ${e.file.padEnd(28)} → ${newFile}  (tmux rename failed)`);
+          console.log(`  ${e.file.padEnd(28)} → ${newFile}  (tmux rename failed: ${runningMatch})`);
         }
       } else {
         console.log(`  ${e.file.padEnd(28)} → ${newFile}`);


### PR DESCRIPTION
## Summary
Full repo audit per #96.

### Bugs fixed
- **#86** — `maw hey` routes to wrong session: `cmdSend`/`cmdPeek` now resolve oracle→session via fleet configs (not just `config.sessions`). New `resolveSearchSessions()` helper checks config.sessions → fleet configs → all sessions.
- **#84** — `fleet renumber` fails to rename tmux sessions: now pattern-matches by group name (strips number prefix), so diverged session names are found and renamed.
- Replaced `require("fs")` with static import in fleet.ts

### Issues closed (already fixed or stale)
- **#82** — fleet-init duplicate numbering: already fixed (`rmSync` before write)
- **#26** — branch exists on wake: already fixed (`git branch -D` before worktree add)
- **#81** — worktree report-back: addressed via inbox signal + `/talk-to`
- **#66** — study commits: stale
- **#65** — setup office server: done

## Test plan
- [ ] `maw hey neo "test"` → routes to correct session (03-neo), not first match
- [ ] `maw peek neo` → shows correct session's capture
- [ ] `maw fleet renumber` with diverged tmux session names → renames correctly
- [ ] TypeScript clean (`tsc --noEmit` passes)

Closes #96, #86, #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)