### PR TITLE
fix: terminal view send blocked + global shortcuts fire in /#terminal

### DIFF
--- a/office/src/App.tsx
+++ b/office/src/App.tsx
@@ -127,10 +127,16 @@ export function App() {
   const [showJump, setShowJump] = useState(false);
   const [showInbox, setShowInbox] = useState(false);
 
+  // Track current route for keyboard handler (avoid stale closure)
+  const routeRef = useRef(route);
+  useEffect(() => { routeRef.current = route; }, [route]);
+
   // "?" key opens shortcut overlay, "j" or Ctrl+K opens jump overlay
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+      // Terminal view captures all keystrokes — don't fire global shortcuts
+      if (routeRef.current === "terminal") return;
       if (e.key === "?" ) {
         setShowShortcuts(true);
         return;

--- a/office/src/components/TerminalView.tsx
+++ b/office/src/components/TerminalView.tsx
@@ -80,7 +80,7 @@ export const TerminalView = memo(function TerminalView({ sessions, agents, conne
 
     sendingRef.current = true;
     const text = sendQueue[0];
-    ws.send(JSON.stringify({ type: "send", target: selectedTarget, text }));
+    ws.send(JSON.stringify({ type: "send", target: selectedTarget, text, force: true }));
     setTimeout(() => {
       setSendQueue(q => q.slice(1));
       sendingRef.current = false;


### PR DESCRIPTION
## Summary

- **TerminalView send silently blocked**: `handlers.ts` guards sends with `/claude|codex|node/i` regex, but Claude Code reports its process name as a version number (e.g. `2.1.81`) — not `claude`. Added `force: true` to `TerminalView`'s send message to bypass the guard, since `/#terminal` is a raw terminal view that should work with any pane.
- **Global shortcuts fire while typing in terminal**: `j` → jump overlay, `v` → vs view, `i` → inbox, `/` → jump all triggered while typing in the terminal input div. The global handler only excluded `HTMLInputElement`/`HTMLTextAreaElement`, but `TerminalView` uses a `div` with `tabIndex={0}`. Added a `routeRef` to skip all global shortcuts when `route === "terminal"`.

## Test plan

- [ ] Open `/#terminal`, select a window running Claude Code — verify messages arrive in tmux
- [ ] Type `j`, `v`, `i`, `/` in the terminal input — verify they appear as text, not trigger overlays
- [ ] Navigate away from `/#terminal` — verify `j`, `v`, `i` shortcuts work normally again

🤖 Generated with [Claude Code](https://claude.com/claude-code)