### PR TITLE
feat: multi-user shared tmux socket + external config

### DIFF
--- a/src/commands/completions.ts
+++ b/src/commands/completions.ts
@@ -1,11 +1,12 @@
 import { readdirSync, readFileSync } from "fs";
 import { join } from "path";
+import { FLEET_DIR } from "../paths";
 
 export async function cmdCompletions(sub: string) {
   if (sub === "commands") {
     console.log("ls peek hey wake fleet stop done overview about oracle pulse view create-view tab talk-to serve");
   } else if (sub === "oracles" || sub === "windows") {
-    const fleetDir = join(import.meta.dir, "../../fleet");
+    const fleetDir = FLEET_DIR;
     const names = new Set<string>();
     try {
       for (const f of readdirSync(fleetDir).filter(f => f.endsWith(".json") && !f.endsWith(".disabled"))) {

--- a/src/commands/done.ts
+++ b/src/commands/done.ts
@@ -4,8 +4,7 @@ import { loadConfig } from "../config";
 import { readdirSync, readFileSync, writeFileSync, appendFileSync, mkdirSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
-
-const FLEET_DIR = join(import.meta.dir, "../../fleet");
+import { FLEET_DIR } from "../paths";
 
 /**
  * maw done <window-name>

--- a/src/commands/fleet-init.ts
+++ b/src/commands/fleet-init.ts
@@ -1,6 +1,7 @@
 import { join } from "path";
 import { existsSync, mkdirSync, rmSync } from "fs";
 import { ssh } from "../ssh";
+import { FLEET_DIR } from "../paths";
 
 interface FleetWindow {
   name: string;
@@ -49,7 +50,7 @@ const GROUPS: Record<string, { session: string; order: number }> = {
 };
 
 export async function cmdFleetInit() {
-  const fleetDir = join(import.meta.dir, "../../fleet");
+  const fleetDir = FLEET_DIR;
   // Clean old configs to prevent duplicate numbering (#82)
   if (existsSync(fleetDir)) rmSync(fleetDir, { recursive: true });
   mkdirSync(fleetDir, { recursive: true });

--- a/src/commands/fleet.ts
+++ b/src/commands/fleet.ts
@@ -4,6 +4,7 @@ import { ssh } from "../ssh";
 import { tmux } from "../tmux";
 import { loadConfig, buildCommand, getEnvVars } from "../config";
 import { ensureSessionRunning } from "./wake";
+import { FLEET_DIR } from "../paths";
 
 interface FleetWindow {
   name: string;
@@ -15,8 +16,6 @@ interface FleetSession {
   windows: FleetWindow[];
   skip_command?: boolean;
 }
-
-const FLEET_DIR = join(import.meta.dir, "../../fleet");
 
 function loadFleet(): FleetSession[] {
   const files = readdirSync(FLEET_DIR)

--- a/src/commands/oracle.ts
+++ b/src/commands/oracle.ts
@@ -2,6 +2,7 @@ import { listSessions, ssh, capture } from "../ssh";
 import { findWorktrees, detectSession, resolveFleetSession } from "./wake";
 import { readdirSync, readFileSync } from "fs";
 import { join } from "path";
+import { FLEET_DIR } from "../paths";
 
 /** Like resolveOracle but returns null instead of process.exit */
 async function resolveOracleSafe(oracle: string): Promise<{ repoPath: string; repoName: string; parentDir: string } | { parentDir: ""; repoName: ""; repoPath: "" }> {
@@ -27,7 +28,7 @@ async function discoverOracles(): Promise<string[]> {
   const names = new Set<string>();
 
   // 1. Fleet configs (registered — includes sleeping)
-  const fleetDir = join(import.meta.dir, "../../fleet");
+  const fleetDir = FLEET_DIR;
   try {
     for (const file of readdirSync(fleetDir).filter(f => f.endsWith(".json") && !f.endsWith(".disabled"))) {
       const config = JSON.parse(readFileSync(join(fleetDir, file), "utf-8"));
@@ -96,7 +97,7 @@ export async function cmdOracleAbout(oracle: string) {
   }
 
   // Fleet config
-  const fleetDir = join(import.meta.dir, "../../fleet");
+  const fleetDir = FLEET_DIR;
   let fleetFile: string | null = null;
   let fleetWindowCount = 0;
   try {

--- a/src/commands/tab.ts
+++ b/src/commands/tab.ts
@@ -1,5 +1,5 @@
 import { ssh } from "../ssh";
-import { tmux } from "../tmux";
+import { tmux, tmuxCmd } from "../tmux";
 import { cmdPeek, cmdSend } from "./comm";
 import { cmdTalkTo } from "./talk-to";
 
@@ -21,7 +21,7 @@ async function currentSession(): Promise<string> {
  */
 async function listTabs(session: string): Promise<{ index: number; name: string; active: boolean }[]> {
   const raw = await ssh(
-    `tmux list-windows -t '${session}' -F '#{window_index}:#{window_name}:#{window_active}'`
+    `${tmuxCmd()} list-windows -t '${session}' -F '#{window_index}:#{window_name}:#{window_active}'`
   );
   return raw.split("\n").filter(Boolean).map(line => {
     const [idx, name, active] = line.split(":");

--- a/src/commands/view.ts
+++ b/src/commands/view.ts
@@ -1,5 +1,5 @@
 import { listSessions } from "../ssh";
-import { Tmux } from "../tmux";
+import { Tmux, tmuxCmd, resolveSocket } from "../tmux";
 import { loadConfig } from "../config";
 
 export async function cmdView(agent: string, windowHint?: string, clean = false) {
@@ -53,9 +53,11 @@ export async function cmdView(agent: string, windowHint?: string, clean = false)
   // Attach interactively
   const host = process.env.MAW_HOST || loadConfig().host || "white.local";
   const isLocal = host === "local" || host === "localhost";
+  const socket = resolveSocket();
   const attachArgs = isLocal
-    ? ["tmux", "attach-session", "-t", viewName]
-    : ["ssh", "-tt", host, `tmux attach-session -t '${viewName}'`];
+    ? (socket ? ["tmux", "-S", socket, "attach-session", "-t", viewName]
+              : ["tmux", "attach-session", "-t", viewName])
+    : ["ssh", "-tt", host, `${tmuxCmd()} attach-session -t '${viewName}'`];
   console.log(`\x1b[36mattach\x1b[0m  → ${viewName}${clean ? " (clean)" : ""}`);
   const proc = Bun.spawn(attachArgs, { stdin: "inherit", stdout: "inherit", stderr: "inherit" });
   const exitCode = await proc.exited;

--- a/src/commands/wake.ts
+++ b/src/commands/wake.ts
@@ -3,6 +3,7 @@ import { tmux } from "../tmux";
 import { loadConfig, buildCommand, getEnvVars } from "../config";
 import { readdirSync, readFileSync } from "fs";
 import { join } from "path";
+import { FLEET_DIR } from "../paths";
 
 /**
  * Verify all windows in a session are running Claude (not empty zsh).
@@ -70,7 +71,7 @@ export async function resolveOracle(oracle: string): Promise<{ repoPath: string;
   }
 
   // 2. Fallback: check fleet configs for repo mapping
-  const fleetDir = join(import.meta.dir, "../../fleet");
+  const fleetDir = FLEET_DIR;
   try {
     for (const file of readdirSync(fleetDir).filter(f => f.endsWith(".json"))) {
       const config = JSON.parse(readFileSync(join(fleetDir, file), "utf-8"));
@@ -107,7 +108,7 @@ export function getSessionMap(): Record<string, string> {
 
 /** Scan fleet/*.json for a config containing a window matching the oracle name */
 export function resolveFleetSession(oracle: string): string | null {
-  const fleetDir = join(import.meta.dir, "../../fleet");
+  const fleetDir = FLEET_DIR;
   try {
     for (const file of readdirSync(fleetDir).filter(f => f.endsWith(".json") && !f.endsWith(".disabled"))) {
       const config = JSON.parse(readFileSync(join(fleetDir, file), "utf-8"));

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 import { readFileSync, writeFileSync } from "fs";
 import { join } from "path";
+import { CONFIG_FILE } from "./paths";
 
 export interface MawConfig {
   host: string;
@@ -9,6 +10,7 @@ export interface MawConfig {
   env: Record<string, string>;
   commands: Record<string, string>;
   sessions: Record<string, string>;
+  tmuxSocket?: string;
 }
 
 const DEFAULTS: MawConfig = {
@@ -25,9 +27,8 @@ let cached: MawConfig | null = null;
 
 export function loadConfig(): MawConfig {
   if (cached) return cached;
-  const configPath = join(import.meta.dir, "../maw.config.json");
   try {
-    const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+    const raw = JSON.parse(readFileSync(CONFIG_FILE, "utf-8"));
     cached = { ...DEFAULTS, ...raw };
   } catch {
     cached = { ...DEFAULTS };
@@ -42,10 +43,9 @@ export function resetConfig() {
 
 /** Write config to maw.config.json and reset cache */
 export function saveConfig(update: Partial<MawConfig>) {
-  const configPath = join(import.meta.dir, "../maw.config.json");
   const current = loadConfig();
   const merged = { ...current, ...update };
-  writeFileSync(configPath, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  writeFileSync(CONFIG_FILE, JSON.stringify(merged, null, 2) + "\n", "utf-8");
   resetConfig(); // clear cache so next loadConfig() reads fresh
   return loadConfig();
 }

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,0 +1,10 @@
+import { join } from "path";
+import { mkdirSync } from "fs";
+import { homedir } from "os";
+
+export const CONFIG_DIR = process.env.MAW_CONFIG_DIR || join(homedir(), ".config", "maw");
+export const FLEET_DIR = join(CONFIG_DIR, "fleet");
+export const CONFIG_FILE = join(CONFIG_DIR, "maw.config.json");
+
+// Ensure dirs exist on first import
+mkdirSync(FLEET_DIR, { recursive: true });

--- a/src/pty.ts
+++ b/src/pty.ts
@@ -1,4 +1,4 @@
-import { tmux } from "./tmux";
+import { tmux, tmuxCmd } from "./tmux";
 import { loadConfig } from "./config";
 import type { ServerWebSocket } from "bun";
 
@@ -89,11 +89,11 @@ async function attach(ws: ServerWebSocket<any>, target: string, cols: number, ro
   // Spawn PTY via script(1) — attach to our grouped session (not the original)
   let args: string[];
   if (isLocalHost()) {
-    const cmd = `stty rows ${r} cols ${c} 2>/dev/null; TERM=xterm-256color tmux attach-session -t '${ptySessionName}'`;
+    const cmd = `stty rows ${r} cols ${c} 2>/dev/null; TERM=xterm-256color ${tmuxCmd()} attach-session -t '${ptySessionName}'`;
     args = ["script", "-qfc", cmd, "/dev/null"];
   } else {
     const host = process.env.MAW_HOST || loadConfig().host || "white.local";
-    args = ["ssh", "-tt", host, `TERM=xterm-256color tmux attach-session -t '${ptySessionName}'`];
+    args = ["ssh", "-tt", host, `TERM=xterm-256color ${tmuxCmd()} attach-session -t '${ptySessionName}'`];
   }
 
   const proc = Bun.spawn(args, {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,9 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { serveStatic } from "hono/bun";
+import { dirname, resolve } from "path";
+
+const MAW_ROOT = resolve(dirname(new URL(import.meta.url).pathname), "..");
 import { listSessions, capture, sendKeys, selectWindow } from "./ssh";
 import { processMirror } from "./commands/overview";
 import { FeedTailer } from "./feed-tail";
@@ -50,46 +53,46 @@ app.post("/api/select", async (c) => {
 });
 
 // Serve React app from root (single entry point for all views)
-app.get("/", serveStatic({ root: "./dist-office", path: "/index.html" }));
+app.get("/", serveStatic({ root: `${MAW_ROOT}/dist-office`, path: "/index.html" }));
 
 // Legacy redirects — old paths → hash routes in the React app
 app.get("/dashboard", (c) => c.redirect("/#orbital"));
 app.get("/office", (c) => c.redirect("/#office"));
 
 // Serve React app assets
-app.get("/assets/*", serveStatic({ root: "./dist-office" }));
+app.get("/assets/*", serveStatic({ root: `${MAW_ROOT}/dist-office` }));
 
 // Keep /office/* for backward compat (deep-links, bookmarks)
 app.get("/office/*", serveStatic({
-  root: "./",
+  root: MAW_ROOT,
   rewriteRequestPath: (p) => p.replace(/^\/office/, "/dist-office"),
 }));
 
 // Serve 8-bit office (Bevy WASM)
-app.get("/office-8bit", serveStatic({ root: "./dist-8bit-office", path: "/index.html" }));
+app.get("/office-8bit", serveStatic({ root: `${MAW_ROOT}/dist-8bit-office`, path: "/index.html" }));
 app.get("/office-8bit/*", serveStatic({
-  root: "./",
+  root: MAW_ROOT,
   rewriteRequestPath: (p) => p.replace(/^\/office-8bit/, "/dist-8bit-office"),
 }));
 
 // Serve War Room (Bevy WASM)
-app.get("/war-room", serveStatic({ root: "./dist-war-room", path: "/index.html" }));
+app.get("/war-room", serveStatic({ root: `${MAW_ROOT}/dist-war-room`, path: "/index.html" }));
 app.get("/war-room/*", serveStatic({
-  root: "./",
+  root: MAW_ROOT,
   rewriteRequestPath: (p) => p.replace(/^\/war-room/, "/dist-war-room"),
 }));
 
 // Serve Race Track (Bevy WASM)
-app.get("/race-track", serveStatic({ root: "./dist-race-track", path: "/index.html" }));
+app.get("/race-track", serveStatic({ root: `${MAW_ROOT}/dist-race-track`, path: "/index.html" }));
 app.get("/race-track/*", serveStatic({
-  root: "./",
+  root: MAW_ROOT,
   rewriteRequestPath: (p) => p.replace(/^\/race-track/, "/dist-race-track"),
 }));
 
 // Serve Superman Universe (Bevy WASM)
-app.get("/superman", serveStatic({ root: "./dist-superman", path: "/index.html" }));
+app.get("/superman", serveStatic({ root: `${MAW_ROOT}/dist-superman`, path: "/index.html" }));
 app.get("/superman/*", serveStatic({
-  root: "./",
+  root: MAW_ROOT,
   rewriteRequestPath: (p) => p.replace(/^\/superman/, "/dist-superman"),
 }));
 
@@ -179,7 +182,7 @@ app.post("/api/asks", async (c) => {
 
 // --- Fleet Config ---
 
-const fleetDir = join(import.meta.dir, "../fleet");
+import { FLEET_DIR as fleetDir } from "./paths";
 
 app.get("/api/fleet-config", (c) => {
   try {

--- a/src/ssh.ts
+++ b/src/ssh.ts
@@ -1,4 +1,5 @@
 import { loadConfig } from "./config";
+import { tmuxCmd } from "./tmux";
 
 const DEFAULT_HOST = process.env.MAW_HOST || loadConfig().host || "white.local";
 const IS_LOCAL = DEFAULT_HOST === "local" || DEFAULT_HOST === "localhost";
@@ -29,12 +30,12 @@ export interface Session {
 
 export async function listSessions(host?: string): Promise<Session[]> {
   let raw: string;
-  try { raw = await ssh("tmux list-sessions -F '#{session_name}' 2>/dev/null", host); }
+  try { raw = await ssh(`${tmuxCmd()} list-sessions -F '#{session_name}' 2>/dev/null`, host); }
   catch { return []; }
   const sessions: Session[] = [];
   for (const s of raw.split("\n").filter(Boolean)) {
     const winRaw = await ssh(
-      `tmux list-windows -t '${s}' -F '#{window_index}:#{window_name}:#{window_active}' 2>/dev/null`,
+      `${tmuxCmd()} list-windows -t '${s}' -F '#{window_index}:#{window_name}:#{window_active}' 2>/dev/null`,
       host,
     );
     const windows = winRaw.split("\n").filter(Boolean).map(w => {
@@ -61,13 +62,13 @@ export async function capture(target: string, lines = 80, host?: string): Promis
   // -e preserves ANSI escape sequences (colors), -S captures scroll-back
   if (lines > 50) {
     // Grab full visible pane + some scrollback
-    return ssh(`tmux capture-pane -t '${target}' -e -p -S -${lines} 2>/dev/null`, host);
+    return ssh(`${tmuxCmd()} capture-pane -t '${target}' -e -p -S -${lines} 2>/dev/null`, host);
   }
-  return ssh(`tmux capture-pane -t '${target}' -e -p 2>/dev/null | tail -${lines}`, host);
+  return ssh(`${tmuxCmd()} capture-pane -t '${target}' -e -p 2>/dev/null | tail -${lines}`, host);
 }
 
 export async function selectWindow(target: string, host?: string): Promise<void> {
-  await ssh(`tmux select-window -t '${target}' 2>/dev/null`, host);
+  await ssh(`${tmuxCmd()} select-window -t '${target}' 2>/dev/null`, host);
 }
 
 /** Get the command running in a tmux pane (e.g. "claude", "zsh") */

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -1,4 +1,16 @@
 import { ssh } from "./ssh";
+import { loadConfig } from "./config";
+
+/** Resolve tmux socket path from env or config. */
+export function resolveSocket(): string | undefined {
+  return process.env.MAW_TMUX_SOCKET || loadConfig().tmuxSocket || undefined;
+}
+
+/** Build the `tmux` (or `tmux -S <socket>`) prefix for raw commands. */
+export function tmuxCmd(): string {
+  const socket = resolveSocket();
+  return socket ? `tmux -S '${socket}'` : "tmux";
+}
 
 export interface TmuxWindow {
   index: number;
@@ -26,11 +38,15 @@ function q(s: string | number): string {
  * All methods build arg arrays and delegate to `run()`.
  */
 export class Tmux {
-  constructor(private host?: string) {}
+  private socket?: string;
+  constructor(private host?: string, socket?: string) {
+    this.socket = socket !== undefined ? socket : resolveSocket();
+  }
 
-  /** Base runner — executes `tmux <subcommand> [args...]` via ssh. */
+  /** Base runner — executes `tmux [-S socket] <subcommand> [args...]` via ssh. */
   async run(subcommand: string, ...args: (string | number)[]): Promise<string> {
-    const cmd = `tmux ${subcommand} ${args.map(q).join(" ")} 2>/dev/null`;
+    const socketFlag = this.socket ? `-S ${q(this.socket)} ` : "";
+    const cmd = `tmux ${socketFlag}${subcommand} ${args.map(q).join(" ")} 2>/dev/null`;
     return ssh(cmd, this.host);
   }
 
@@ -165,7 +181,8 @@ export class Tmux {
       return this.run("capture-pane", "-t", target, "-e", "-p", "-S", -lines);
     }
     // For shorter captures, pipe through tail (needs raw ssh)
-    const cmd = `tmux capture-pane -t ${q(target)} -e -p 2>/dev/null | tail -${lines}`;
+    const socketFlag = this.socket ? `-S ${q(this.socket)} ` : "";
+    const cmd = `tmux ${socketFlag}capture-pane -t ${q(target)} -e -p 2>/dev/null | tail -${lines}`;
     return ssh(cmd, this.host);
   }
 
@@ -203,7 +220,8 @@ export class Tmux {
 
   async loadBuffer(text: string): Promise<void> {
     const escaped = text.replace(/'/g, "'\\''");
-    const cmd = `printf '%s' '${escaped}' | tmux load-buffer -`;
+    const socketFlag = this.socket ? `-S ${q(this.socket)} ` : "";
+    const cmd = `printf '%s' '${escaped}' | tmux ${socketFlag}load-buffer -`;
     await ssh(cmd, this.host);
   }
 

--- a/src/worktrees.ts
+++ b/src/worktrees.ts
@@ -3,6 +3,7 @@ import { tmux } from "./tmux";
 import { loadConfig } from "./config";
 import { readdirSync, readFileSync, existsSync } from "fs";
 import { join } from "path";
+import { FLEET_DIR } from "./paths";
 
 export interface WorktreeInfo {
   path: string;
@@ -25,7 +26,7 @@ export interface WorktreeInfo {
 export async function scanWorktrees(): Promise<WorktreeInfo[]> {
   const config = loadConfig();
   const ghqRoot = config.ghqRoot;
-  const fleetDir = join(import.meta.dir, "../fleet");
+  const fleetDir = FLEET_DIR;
 
   // 1. Find all .wt- directories
   let wtPaths: string[] = [];
@@ -145,7 +146,7 @@ export async function scanWorktrees(): Promise<WorktreeInfo[]> {
 export async function cleanupWorktree(wtPath: string): Promise<string[]> {
   const config = loadConfig();
   const ghqRoot = config.ghqRoot;
-  const fleetDir = join(import.meta.dir, "../fleet");
+  const fleetDir = FLEET_DIR;
   const log: string[] = [];
 
   const dirName = wtPath.split("/").pop()!;

--- a/test/tmux.test.ts
+++ b/test/tmux.test.ts
@@ -5,6 +5,12 @@ import { Tmux } from "../src/tmux";
 let commands: string[] = [];
 let sshResult = "";
 
+// Mock config to return no socket (tests expect plain "tmux" commands)
+mock.module("../src/config", () => ({
+  loadConfig: () => ({ host: "white.local" }),
+  resetConfig: () => {},
+}));
+
 // Mock ssh module — intercept the command string
 mock.module("../src/ssh", () => ({
   ssh: async (cmd: string, _host?: string) => {
@@ -12,6 +18,9 @@ mock.module("../src/ssh", () => ({
     return sshResult;
   },
 }));
+
+// Ensure no socket env var leaks into tests
+delete process.env.MAW_TMUX_SOCKET;
 
 describe("Tmux", () => {
   let t: Tmux;


### PR DESCRIPTION
## Summary

- **Shared tmux socket** — all tmux commands support `-S` flag via `tmuxSocket` config field or `MAW_TMUX_SOCKET` env var. Enables multiple Linux users to share one maw server.
- **External config** — config and fleet files moved from repo to `~/.config/maw/`. Overridable via `MAW_CONFIG_DIR`.
- **Absolute static paths** — `server.ts` uses `import.meta.url` instead of relative `./dist-*`, fixing 404 when `maw serve` runs from non-maw-js directory.

## Files changed (15)

| File | Change |
|------|--------|
| `src/paths.ts` | **NEW** — `CONFIG_DIR`, `FLEET_DIR`, `CONFIG_FILE` |
| `src/tmux.ts` | `resolveSocket()`, `tmuxCmd()`, `-S` flag in `run()`, `capture()`, `loadBuffer()` |
| `src/config.ts` | `tmuxSocket?: string` field, read/write from external config |
| `src/ssh.ts` | `tmuxCmd()` for raw tmux strings |
| `src/server.ts` | `MAW_ROOT` absolute paths for static files |
| `src/pty.ts` | Socket in attach-session |
| `src/commands/view.ts` | Socket in attach args |
| `src/commands/tab.ts` | Socket in list-windows |
| `src/commands/{fleet,fleet-init,wake,done,oracle,completions,worktrees}.ts` | Import `FLEET_DIR` from paths |

## Config example

```json
{
  "host": "local",
  "port": 3458,
  "ghqRoot": "/home/user/ghq/github.com",
  "tmuxSocket": "/tmp/maw-shared/maw"
}
```

## Test plan

- [x] `maw ls` sees sessions in shared socket
- [x] `maw serve` works from any directory (no 404)
- [x] `maw fleet ls` reads from `~/.config/maw/fleet/`
- [x] Backward compatible — no `tmuxSocket` = default behavior
- [ ] `maw wake all` creates sessions in shared socket
- [ ] Multiple users see same sessions via shared socket

🤖 Generated with [Claude Code](https://claude.com/claude-code)