### PR TITLE
fix: MQTT inbox routing — lazy-load sessions + fallback forward

### DIFF
--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -48,12 +48,42 @@ export class MawEngine {
   setTransportRouter(router: TransportRouter) {
     this.transportRouter = router;
     router.onMessage(async (msg) => {
-      const { findWindow } = await import("../ssh");
-      const target = findWindow(this.sessionCache.sessions, msg.to);
+      const { findWindow, sendKeys } = await import("../ssh");
+
+      // Lazy-load sessions if cache is empty (no WS clients connected yet)
+      let sessions = this.sessionCache.sessions;
+      if (sessions.length === 0) {
+        sessions = await tmux.listAll().catch(() => [] as SessionInfo[]);
+        this.sessionCache.sessions = sessions;
+      }
+
+      const target = findWindow(sessions, msg.to);
       if (target) {
-        const { sendKeys } = await import("../ssh");
         await sendKeys(target, msg.body);
         console.log(`[transport] ${msg.transport}: ${msg.from} → ${msg.to} (${target})`);
+      } else {
+        // Fallback: forward to HTTP peer that might have the agent
+        const config = loadConfig();
+        const agentHost = config.agents?.[msg.to];
+        if (agentHost && agentHost !== (config.node || config.host || "local")) {
+          const peer = (config.namedPeers || []).find((p: { name: string; url: string }) => p.name === agentHost);
+          const peerUrl = peer?.url || config.peers?.find((u: string) => u.includes(agentHost));
+          if (peerUrl) {
+            try {
+              const resp = await fetch(`${peerUrl}/api/send`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ target: msg.to, text: msg.body }),
+                signal: AbortSignal.timeout(10_000),
+              });
+              if (resp.ok) {
+                console.log(`[transport] ${msg.transport}: ${msg.from} → ${msg.to} (forwarded via ${peerUrl})`);
+              }
+            } catch {
+              console.log(`[transport] ${msg.transport}: ${msg.from} → ${msg.to} (forward failed to ${peerUrl})`);
+            }
+          }
+        }
       }
     });
 


### PR DESCRIPTION
## Summary
- Fix MQTT inbox messages being silently dropped when no WebSocket client is connected (sessionCache empty)
- Add fallback HTTP forwarding for relay nodes that don't have the target agent locally

## Bug Details

### Bug 1: Empty sessionCache
`engine/index.ts:50` — `router.onMessage` uses `findWindow(this.sessionCache.sessions, msg.to)` but `sessionCache` is only populated when WebSocket clients trigger `startIntervals()`. No clients = empty cache = all MQTT inbox messages dropped.

**Fix**: Lazy-load sessions via `tmux.listAll()` when cache is empty.

### Bug 2: No fallback forwarding on relay
Relay subscribes to `oracle/+/inbox` but has no local agents. When it receives a message for `neo` (on white) or `homekeeper` (on mba), `findWindow` returns null and the message is dropped with no fallback.

**Fix**: Use `config.agents` map to find which peer hosts the target agent, then forward via HTTP `POST /api/send` to that peer.

## Test plan
- [ ] Send MQTT message to agent when no WebSocket client is open — should now deliver
- [ ] Send MQTT message via relay to agent on a peer — should forward via HTTP
- [ ] Existing direct MQTT delivery still works when WebSocket clients are connected

Generated by No.0 Paladin (Claude Opus 4.6) — Soul Brews Studio