### PR TITLE
fix: prevent exponential session duplication in federation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
       "devDependencies": {
         "@resvg/resvg-js": "^2.6.2",
         "@tailwindcss/vite": "^4.2.1",
+        "@types/bun": "^1.3.11",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@types/three": "^0.183.1",
@@ -255,6 +256,8 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
+    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
@@ -304,6 +307,8 @@
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001777", "", {}, "sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ=="],
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@resvg/resvg-js": "^2.6.2",
     "@tailwindcss/vite": "^4.2.1",
+    "@types/bun": "^1.3.11",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@types/three": "^0.183.1",

--- a/src/api/sessions.ts
+++ b/src/api/sessions.ts
@@ -9,6 +9,9 @@ export const sessionsApi = new Hono();
 
 sessionsApi.get("/sessions", async (c) => {
   const local = await listSessions();
+  if (c.req.query("local") === "true") {
+    return c.json(local.map(s => ({ ...s, source: "local" })));
+  }
   const aggregated = await getAggregatedSessions(local);
   return c.json(aggregated);
 });

--- a/src/peers.ts
+++ b/src/peers.ts
@@ -39,7 +39,7 @@ export function getPeers(): string[] {
  */
 async function fetchPeerSessions(url: string): Promise<Session[]> {
   try {
-    const res = await curlFetch(`${url}/api/sessions`, { timeout: cfgTimeout("http") });
+    const res = await curlFetch(`${url}/api/sessions?local=true`, { timeout: cfgTimeout("http") });
     if (!res.ok) return [];
     return res.data || [];
   } catch {


### PR DESCRIPTION
## Summary

- When Node A fetches `/api/sessions` from Node B, Node B was returning its local sessions **and** all federated sessions it had fetched from other peers. In a 5-node mesh, this caused exponential duplication — 30 real agents appeared as 1,493.
- Added `?local=true` query parameter support to the `/api/sessions` endpoint so peers can request only local sessions.
- Updated `fetchPeerSessions` in `src/peers.ts` to use `?local=true` when fetching from peers, breaking the duplication cycle.

## Changes

**`src/api/sessions.ts`** — When `?local=true` is passed, return only local sessions (tagged with `source: "local"`) without aggregating federated peers. Default behavior (no query param) is unchanged.

**`src/peers.ts`** — `fetchPeerSessions` now requests `?local=true` so each node only gets the peer's own sessions, not sessions the peer fetched from *other* peers.

## Test plan

- [ ] Deploy to one node, verify `curl localhost:3456/api/sessions` still returns aggregated sessions (default behavior preserved)
- [ ] Verify `curl localhost:3456/api/sessions?local=true` returns only local sessions
- [ ] In a multi-node mesh, run `maw ls` and confirm agent count matches actual agents (no duplication)
- [ ] Verify `maw hey <remote-agent>` still routes correctly through federation

🤖 Generated with [Claude Code](https://claude.com/claude-code)