### PR TITLE
fix(federation): merge namedPeers in getPeers() + show local node in status

### DIFF
--- a/src/commands/federation.ts
+++ b/src/commands/federation.ts
@@ -1,5 +1,7 @@
 import { getFederationStatus, getPeers } from "../peers";
 import { curlFetch } from "../curl-fetch";
+import { listSessions } from "../ssh";
+import { loadConfig } from "../config";
 
 async function fetchPeerAgentCount(url: string): Promise<number> {
   try {
@@ -12,26 +14,69 @@ async function fetchPeerAgentCount(url: string): Promise<number> {
   }
 }
 
-/** maw federation status — show peer connectivity + agent counts */
+/** Count local agents = sum of windows across local tmux sessions. */
+async function countLocalAgents(): Promise<number> {
+  try {
+    const sessions = await listSessions();
+    return sessions.reduce((n, s) => n + (s.windows?.length || 0), 0);
+  } catch {
+    return 0;
+  }
+}
+
+/** Build a human-readable label for a peer URL, preferring namedPeers.name. */
+function labelForPeer(url: string, named: { name: string; url: string }[]): string {
+  const match = named.find(p => p.url === url);
+  if (match) return match.name;
+  try {
+    const u = new URL(url);
+    return u.hostname === "localhost" || u.hostname === "127.0.0.1"
+      ? `localhost:${u.port}` : u.host;
+  } catch { return url; }
+}
+
+/** maw federation status — show all nodes (local + peers) with connectivity + agent counts */
 export async function cmdFederationStatus() {
   const peers = getPeers();
+  const config = loadConfig();
+  const named = config.namedPeers ?? [];
+  const totalNodes = peers.length + 1; // +1 for local
+  const localLabel = config.node ? `${config.node} (local)` : "local";
 
+  // Header always includes local, so "N nodes (1 local + M peers)"
+  console.log(
+    `\n\x1b[36;1mFederation Status\x1b[0m  ` +
+    `\x1b[90m${totalNodes} node${totalNodes !== 1 ? "s" : ""} ` +
+    `(1 local + ${peers.length} peer${peers.length !== 1 ? "s" : ""})\x1b[0m\n`
+  );
+
+  // Fetch local + peer state in parallel
+  const [localCount, { peers: statuses, localUrl }] = await Promise.all([
+    countLocalAgents(),
+    getFederationStatus(),
+  ]);
+
+  // Render local row FIRST — the triangle is only visible if local is in the table
+  console.log(
+    `  \x1b[32m●\x1b[0m  \x1b[37m${localLabel}\x1b[0m  ` +
+    `\x1b[32monline\x1b[0m  ` +
+    `\x1b[90m${localCount} agent${localCount !== 1 ? "s" : ""}\x1b[0m`
+  );
+  console.log(`     \x1b[90m${localUrl}\x1b[0m`);
+
+  // No peers? Still show helpful hint.
   if (peers.length === 0) {
-    console.log("\x1b[90mNo peers configured. Add peers[] to maw.config.json.\x1b[0m");
-    console.log('\x1b[90mExample: { "peers": ["http://other-host:3456"] }\x1b[0m');
+    console.log("\n\x1b[90mNo peers configured. Add namedPeers[] to maw.config.json.\x1b[0m");
+    console.log('\x1b[90mExample: { "namedPeers": [{ "name": "other", "url": "http://other-host:3456" }] }\x1b[0m\n');
     return;
   }
 
-  console.log(`\n\x1b[36;1mFederation Status\x1b[0m  \x1b[90m${peers.length} peer${peers.length !== 1 ? "s" : ""} configured\x1b[0m\n`);
-
-  const { peers: statuses, localUrl } = await getFederationStatus();
-
-  // Fetch agent counts in parallel for online peers
+  // Fetch peer agent counts in parallel for online peers
   const counts = await Promise.all(
     statuses.map(p => p.reachable ? fetchPeerAgentCount(p.url) : Promise.resolve(0))
   );
 
-  let online = 0;
+  let online = 1; // local is always online (we're executing in it)
   for (let i = 0; i < statuses.length; i++) {
     const { url, reachable, latency } = statuses[i];
     const agentCount = counts[i];
@@ -42,16 +87,10 @@ export async function cmdFederationStatus() {
       ? `\x1b[32monline\x1b[0m  \x1b[90m${latency}ms · ${agentCount} agent${agentCount !== 1 ? "s" : ""}\x1b[0m`
       : "\x1b[31moffline\x1b[0m";
 
-    let label: string;
-    try {
-      const u = new URL(url);
-      label = u.hostname === "localhost" || u.hostname === "127.0.0.1"
-        ? `localhost:${u.port}` : u.host;
-    } catch { label = url; }
-
+    const label = labelForPeer(url, named);
     console.log(`  ${dot}  \x1b[37m${label}\x1b[0m  ${status}`);
     console.log(`     \x1b[90m${url}\x1b[0m`);
   }
 
-  console.log(`\n\x1b[90m${online}/${peers.length} online · local: ${localUrl}\x1b[0m\n`);
+  console.log(`\n\x1b[90m${online}/${totalNodes} online\x1b[0m\n`);
 }

--- a/src/peers.ts
+++ b/src/peers.ts
@@ -27,11 +27,23 @@ async function checkPeerReachable(url: string): Promise<{ reachable: boolean; la
 }
 
 /**
- * Get all configured peers from maw.config.json
+ * Get all configured peers from maw.config.json — merges flat peers[]
+ * with namedPeers[].url, deduped by URL (first occurrence wins).
+ * Both sources feed the same federation peer list.
  */
 export function getPeers(): string[] {
   const config = loadConfig();
-  return config.peers || [];
+  const flat = config.peers ?? [];
+  const named = (config.namedPeers ?? []).map(p => p.url);
+  const seen = new Set<string>();
+  const merged: string[] = [];
+  for (const url of [...flat, ...named]) {
+    if (!seen.has(url)) {
+      seen.add(url);
+      merged.push(url);
+    }
+  }
+  return merged;
 }
 
 /**

--- a/test/peers.test.ts
+++ b/test/peers.test.ts
@@ -1,0 +1,105 @@
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+// Import the real D defaults BEFORE mocking the module, so our mock can
+// delegate cfgInterval/cfgTimeout/cfgLimit to the real defaults. This keeps
+// transitively-loaded modules (tmux.ts uses cfgLimit) working when this
+// test file runs before theirs and the mock persists in the module cache.
+import { D as RealD } from "../src/config";
+
+// Mock config so getPeers() reads fixtures, not the real ~/.config/maw/maw.config.json.
+// getPeers() only calls loadConfig() — no network side effects — so we don't need
+// to mock curl-fetch (and mocking it globally would leak into curl-fetch.test.ts).
+let mockConfig: any = {};
+mock.module("../src/config", () => ({
+  loadConfig: () => mockConfig,
+  resetConfig: () => {},
+  cfg: (key: string) => (mockConfig as any)[key],
+  cfgInterval: (key: keyof typeof RealD.intervals) => RealD.intervals[key],
+  cfgTimeout: (key: keyof typeof RealD.timeouts) => RealD.timeouts[key],
+  cfgLimit: (key: keyof typeof RealD.limits) => RealD.limits[key],
+  D: RealD,
+}));
+
+const { getPeers } = await import("../src/peers");
+
+describe("getPeers — merges peers[] and namedPeers[]", () => {
+  beforeEach(() => {
+    mockConfig = {};
+  });
+
+  test("empty config → empty array", () => {
+    mockConfig = {};
+    expect(getPeers()).toEqual([]);
+  });
+
+  test("only peers[] → returns flat list unchanged", () => {
+    mockConfig = { peers: ["http://a.wg:3456", "http://b.wg:3456"] };
+    expect(getPeers()).toEqual(["http://a.wg:3456", "http://b.wg:3456"]);
+  });
+
+  test("only namedPeers[] → returns URLs from named entries", () => {
+    mockConfig = {
+      namedPeers: [
+        { name: "mba", url: "http://mba.wg:3457" },
+        { name: "clinic", url: "http://clinic.wg:3457" },
+      ],
+    };
+    expect(getPeers()).toEqual(["http://mba.wg:3457", "http://clinic.wg:3457"]);
+  });
+
+  test("both peers[] and namedPeers[] → merged, peers[] first", () => {
+    mockConfig = {
+      peers: ["http://old.wg:3456"],
+      namedPeers: [
+        { name: "mba", url: "http://mba.wg:3457" },
+        { name: "clinic", url: "http://clinic.wg:3457" },
+      ],
+    };
+    expect(getPeers()).toEqual([
+      "http://old.wg:3456",
+      "http://mba.wg:3457",
+      "http://clinic.wg:3457",
+    ]);
+  });
+
+  test("duplicate URL in peers[] and namedPeers[] → deduped, peers[] wins", () => {
+    mockConfig = {
+      peers: ["http://mba.wg:3457"],
+      namedPeers: [
+        { name: "mba", url: "http://mba.wg:3457" },
+        { name: "clinic", url: "http://clinic.wg:3457" },
+      ],
+    };
+    const result = getPeers();
+    expect(result).toEqual(["http://mba.wg:3457", "http://clinic.wg:3457"]);
+    expect(result.length).toBe(2); // no duplicate
+  });
+
+  test("duplicate URL across multiple namedPeers → deduped", () => {
+    mockConfig = {
+      namedPeers: [
+        { name: "mba-alias-1", url: "http://mba.wg:3457" },
+        { name: "mba-alias-2", url: "http://mba.wg:3457" },
+      ],
+    };
+    expect(getPeers()).toEqual(["http://mba.wg:3457"]);
+  });
+
+  test("triangle federation config → 2 peers visible (fix for #bug)", () => {
+    // This is the exact shape that was broken before:
+    // white's maw.config.json with only namedPeers entries, no peers[].
+    // Before the fix, getPeers() returned [] and federation status showed
+    // "0 peers configured" even though white is wired to mba + clinic.
+    mockConfig = {
+      node: "white",
+      port: 3456,
+      namedPeers: [
+        { name: "mba", url: "http://mba.wg:3457" },
+        { name: "clinic", url: "http://clinic.wg:3457" },
+      ],
+    };
+    const result = getPeers();
+    expect(result.length).toBe(2);
+    expect(result).toContain("http://mba.wg:3457");
+    expect(result).toContain("http://clinic.wg:3457");
+  });
+});


### PR DESCRIPTION
## Summary

Two related federation display bugs, shipped as one PR.

- **Bug 1** — `src/peers.ts:32` `getPeers()` ignored `config.namedPeers`. A config that used the typed `namedPeers: [{name, url}]` shape exclusively looked empty to the federation machinery. Workaround until now was duplicating each named peer into the flat `peers[]` array. **Fix**: merge both sources, dedupe by URL (peers[] wins on conflict).
- **Bug 2** — `maw federation status` hid the local node. Header said "2 peers configured" on a 3-node triangle, making the triangle invisible. **Fix**: header is "3 nodes (1 local + 2 peers)", local renders as the first row with its `config.node` label, localhost URL, and agent count (sum of local tmux windows).

One fix unblocks the other: with `getPeers()` merging `namedPeers`, the workaround duplicate entries in `peers[]` can be removed.

## What changed

- `src/peers.ts:32` — `getPeers()` now merges `config.peers` + `config.namedPeers.map(p => p.url)`, deduped by URL, first-seen wins.
- `src/commands/federation.ts` — `cmdFederationStatus()`:
  - Header: `N nodes (1 local + M peers)` instead of `M peers configured`
  - Local row rendered first with `config.node` label (or `local`), localhost URL, agent count
  - Peer rows prefer `namedPeers.name` as their friendly label when a URL matches
  - Empty-peers path still prints the local row (proves the daemon is up)
- `test/peers.test.ts` (new) — 7 unit tests covering:
  - Empty config
  - Only `peers[]`
  - Only `namedPeers[]`
  - Both sources merged (peers[] first)
  - Duplicate URL across peers[] and namedPeers[] → deduped
  - Duplicate URL across multiple namedPeers → deduped
  - Triangle federation shape (2 namedPeers, 0 peers[]) — the exact scenario that was broken

## Smoke test

Real `maw federation status` on white with the triangle config:

```
Federation Status  5 nodes (1 local + 4 peers)

  ●  white (local)  online  9 agents
     http://localhost:3456
  ●  mba            online  296ms · 14 agents
     http://mba.wg:3457
  ●  clinic-nat     online  118ms · 3 agents
     http://10.20.0.1:3457
  ...

  3/5 online
```

Local is visible, friendly names from `namedPeers` come through, the count matches reality.

## Test plan

- [x] `bun test` — 91 pass, 0 fail, 6 todo (baseline on alpha is 84 pass; +7 new peers tests, zero regressions)
- [x] `bun test test/peers.test.ts` — 7/7 pass in isolation
- [x] Smoke: `maw federation status` on white.local shows local as first row with agent count + localhost URL
- [x] Smoke: friendly `namedPeers.name` labels render when URL matches (mba, clinic-nat, oracle-world)
- [ ] After merge: remove workaround `peers[]` duplicates from maw.config.json; federation status should still show all nodes

## Refs

- Bug reported in federation triangle wrap session 2026-04-07 20:48 +07
- Same root cause as the `maw federation status ignores namedPeers[]` item from the morning exam bug list
- Captured in `ψ/memory/learnings/2026-04-07_maw-hey-message-metadata.md` as the related envelope-gap discussion (separate follow-up issue)