### PR TITLE
fix: federation identity chain (#216, #192, #190, #175)

### DIFF
--- a/src/api/federation.ts
+++ b/src/api/federation.ts
@@ -21,6 +21,22 @@ federationApi.get("/snapshots/:id", (c) => {
   return c.json(snap);
 });
 
+/** Node identity — public endpoint for federation dedup (#192) */
+federationApi.get("/identity", async (c) => {
+  const config = loadConfig();
+  const node = config.node ?? "local";
+  const agents = Object.entries(config.agents || {})
+    .filter(([, n]) => n === node)
+    .map(([name]) => name);
+  const pkg = require("../../package.json");
+  return c.json({
+    node,
+    version: pkg.version,
+    agents,
+    uptime: Math.floor(process.uptime()),
+  });
+});
+
 /** Auth status — public diagnostic endpoint (never reveals the token) */
 federationApi.get("/auth/status", (c) => {
   const config = loadConfig();

--- a/src/api/sessions.ts
+++ b/src/api/sessions.ts
@@ -48,8 +48,10 @@ sessionsApi.post("/send", async (c) => {
     const result = resolveTarget(target, config, local);
 
     // Also try with -oracle stripped (backwards compat)
-    const altResult = !result ? resolveTarget(target.replace(/-oracle$/, ""), config, local) : null;
-    const resolved = result || altResult;
+    const isResolved = result && result.type !== "error";
+    const altResult = !isResolved ? resolveTarget(target.replace(/-oracle$/, ""), config, local) : null;
+    const altResolved = altResult && altResult.type !== "error";
+    const resolved = isResolved ? result : altResolved ? altResult : (result || altResult);
 
     // Local or self-node → send via tmux
     if (resolved?.type === "local" || resolved?.type === "self-node") {
@@ -81,7 +83,8 @@ sessionsApi.post("/send", async (c) => {
       return c.json({ error: "Failed to send to peer", target, source: peerUrl }, 502);
     }
 
-    return c.json({ error: `target not found: ${target}`, target }, 404);
+    const errDetail = resolved?.type === "error" ? { reason: resolved.reason, detail: resolved.detail, hint: resolved.hint } : {};
+    return c.json({ error: `target not found: ${target}`, target, ...errDetail }, 404);
   } catch (err) {
     return c.json({ error: String(err) }, 500);
   }

--- a/src/commands/comm.ts
+++ b/src/commands/comm.ts
@@ -183,10 +183,15 @@ export async function cmdSend(query: string, message: string, force = false) {
     }
   }
 
-  // Not found
-  console.error(`\x1b[31merror\x1b[0m: window not found: ${query}`);
-  if (config.agents && Object.keys(config.agents).length > 0) {
-    console.error(`\x1b[33mhint\x1b[0m:  known agents: ${Object.keys(config.agents).join(", ")}`);
+  // Not found — surface error details from resolveTarget (#216)
+  if (result?.type === "error") {
+    console.error(`\x1b[31merror\x1b[0m: ${result.detail}`);
+    if (result.hint) console.error(`\x1b[33mhint\x1b[0m:  ${result.hint}`);
+  } else {
+    console.error(`\x1b[31merror\x1b[0m: window not found: ${query}`);
+    if (config.agents && Object.keys(config.agents).length > 0) {
+      console.error(`\x1b[33mhint\x1b[0m:  known agents: ${Object.keys(config.agents).join(", ")}`);
+    }
   }
   process.exit(1);
 }

--- a/src/peers.ts
+++ b/src/peers.ts
@@ -10,17 +10,26 @@ export interface PeerStatus {
   url: string;
   reachable: boolean;
   latency?: number;
+  node?: string;
+  agents?: string[];
 }
 
 /**
  * Check if a peer is reachable by making a HEAD request
  */
-async function checkPeerReachable(url: string): Promise<{ reachable: boolean; latency: number }> {
+async function checkPeerReachable(url: string): Promise<{ reachable: boolean; latency: number; node?: string; agents?: string[] }> {
   const start = Date.now();
   try {
     const res = await curlFetch(`${url}/api/sessions`, { timeout: cfgTimeout("http") });
     const latency = Date.now() - start;
-    return { reachable: res.ok, latency };
+    // Fetch identity for node dedup (#192)
+    let node: string | undefined;
+    let agents: string[] | undefined;
+    try {
+      const id = await curlFetch(`${url}/api/identity`, { timeout: cfgTimeout("http") });
+      if (id.ok && id.data) { node = id.data.node; agents = id.data.agents; }
+    } catch {}
+    return { reachable: res.ok, latency, node, agents };
   } catch {
     return { reachable: false, latency: Date.now() - start };
   }
@@ -81,7 +90,14 @@ export async function getAggregatedSessions(localSessions: Session[]): Promise<(
     return sessions.map(s => ({ ...s, source: url }));
   }));
 
-  const peerSessions = peerResults.flat();
+  // Dedup sessions by source + name (#175)
+  const seen = new Set<string>();
+  const peerSessions = peerResults.flat().filter(s => {
+    const key = `${s.source}:${s.name}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
   aggregatedCache = { peers: peerSessions, ts: Date.now() };
 
   return [...local, ...peerSessions];
@@ -101,11 +117,21 @@ export async function getFederationStatus(): Promise<{
   const port = loadConfig().port;
   const localUrl = `http://localhost:${port}`;
 
-  const statuses = await Promise.all(peers.map(async (url) => {
-    const { reachable, latency } = await checkPeerReachable(url);
-    return { url, reachable, latency };
+  const rawStatuses = await Promise.all(peers.map(async (url) => {
+    const { reachable, latency, node, agents } = await checkPeerReachable(url);
+    return { url, reachable, latency, node, agents };
   }));
 
+  // Dedup by node identity (#190) — keep fastest URL per node
+  const byNode = new Map<string, PeerStatus>();
+  for (const s of rawStatuses) {
+    const key = s.node || s.url; // fall back to URL if no identity
+    const existing = byNode.get(key);
+    if (!existing || (s.reachable && (!existing.reachable || (s.latency ?? Infinity) < (existing.latency ?? Infinity)))) {
+      byNode.set(key, s);
+    }
+  }
+  const statuses = [...byNode.values()];
   const reachablePeers = statuses.filter(s => s.reachable).length;
 
   return {

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -17,6 +17,7 @@ export type ResolveResult =
   | { type: "local"; target: string }
   | { type: "peer"; peerUrl: string; target: string; node: string }
   | { type: "self-node"; target: string }
+  | { type: "error"; reason: string; detail: string; hint?: string }
   | null;
 
 /**
@@ -28,7 +29,7 @@ export function resolveTarget(
   config: MawConfig,
   sessions: Session[],
 ): ResolveResult {
-  if (!query) return null;
+  if (!query) return { type: "error", reason: "empty_query", detail: "no target specified", hint: "usage: maw hey <agent> <message>" };
 
   const selfNode = config.node ?? "local";
 
@@ -43,13 +44,13 @@ export function resolveTarget(
     const colonIdx = query.indexOf(":");
     const nodeName = query.slice(0, colonIdx);
     const agentName = query.slice(colonIdx + 1);
-    if (!nodeName || !agentName) return null;
+    if (!nodeName || !agentName) return { type: "error", reason: "empty_node_or_agent", detail: `invalid format: '${query}'`, hint: "use node:agent format (e.g. mba:homekeeper)" };
 
     // Self-node check: "white:mawjs" from white → resolve locally
     if (nodeName === selfNode) {
       // Try local findWindow with just the agent part
       const selfTarget = findWindow(sessions, agentName);
-      return selfTarget ? { type: "self-node", target: selfTarget } : null;
+      return selfTarget ? { type: "self-node", target: selfTarget } : { type: "error", reason: "self_not_running", detail: `'${agentName}' not found in local sessions on ${selfNode}`, hint: `maw wake ${agentName}` };
     }
 
     // Remote node: find peer URL
@@ -59,7 +60,7 @@ export function resolveTarget(
     }
 
     // Unknown node
-    return null;
+    return { type: "error", reason: "unknown_node", detail: `node '${nodeName}' not in namedPeers or peers`, hint: "add to maw.config.json namedPeers" };
   }
 
   // --- Step 3: Agents map (bare name, e.g. "homekeeper") ---
@@ -69,7 +70,7 @@ export function resolveTarget(
 
   if (agentNode) {
     // Self-node: agent is mapped to our own node → treat as local miss
-    if (agentNode === selfNode) return null;
+    if (agentNode === selfNode) return { type: "error", reason: "self_not_running", detail: `'${query}' mapped to ${selfNode} (local) but not found in sessions`, hint: `maw wake ${query}` };
 
     // Remote node: find peer URL
     const peerUrl = findPeerUrl(agentNode, config);
@@ -78,11 +79,11 @@ export function resolveTarget(
     }
 
     // Agent mapped to unknown node (no peer URL found)
-    return null;
+    return { type: "error", reason: "no_peer_url", detail: `'${query}' mapped to node '${agentNode}' but no URL found`, hint: `add ${agentNode} to maw.config.json namedPeers` };
   }
 
   // --- Step 4: Not resolved (caller handles peer discovery fallback) ---
-  return null;
+  return { type: "error", reason: "not_found", detail: `'${query}' not in local sessions or agents map`, hint: "check: maw ls" };
 }
 
 /** Find a peer URL by node name from namedPeers or legacy peers[] */

--- a/test/routing.test.ts
+++ b/test/routing.test.ts
@@ -66,15 +66,15 @@ describe("resolveTarget", () => {
   });
 
   // #5: NODE:AGENT → SELF-NODE (no local match)
-  test("self-node prefix with no local match returns null", () => {
+  test("self-node prefix with no local match returns error", () => {
     const r = resolveTarget("white:ghost", BASE_CONFIG, SESSIONS);
-    expect(r).toBeNull();
+    expect(r).toMatchObject({ type: "error", reason: "self_not_running" });
   });
 
   // #6: NODE:AGENT → UNKNOWN NODE
-  test("unknown node returns null", () => {
+  test("unknown node returns error", () => {
     const r = resolveTarget("mars:neo", BASE_CONFIG, SESSIONS);
-    expect(r).toBeNull();
+    expect(r).toMatchObject({ type: "error", reason: "unknown_node" });
   });
 
   // #7: BARE NAME → AGENTS MAP → REMOTE
@@ -84,15 +84,15 @@ describe("resolveTarget", () => {
   });
 
   // #8: BARE NAME → AGENTS MAP → SELF (skip, treat as local miss)
-  test("bare name mapped to self-node returns null (local search handles it)", () => {
+  test("bare name mapped to self-node returns error", () => {
     const r = resolveTarget("neo", BASE_CONFIG, SESSIONS);
-    expect(r).toBeNull();
+    expect(r).toMatchObject({ type: "error", reason: "self_not_running" });
   });
 
   // #10: BARE NAME → NOT FOUND
-  test("bare name not found anywhere returns null", () => {
+  test("bare name not found anywhere returns error", () => {
     const r = resolveTarget("ghost", BASE_CONFIG, SESSIONS);
-    expect(r).toBeNull();
+    expect(r).toMatchObject({ type: "error", reason: "not_found" });
   });
 
   // #11: BARE NAME WITH -oracle SUFFIX STRIP
@@ -104,7 +104,7 @@ describe("resolveTarget", () => {
   // #12: SLASH IN QUERY (not node:agent)
   test("query with slash is not treated as node:agent", () => {
     const r = resolveTarget("13-mother/worktree", BASE_CONFIG, SESSIONS);
-    expect(r).toBeNull();
+    expect(r).toMatchObject({ type: "error", reason: "not_found" });
   });
 
   // #13: PEER URL FALLBACK (peers[] array — URL must contain node name)
@@ -115,27 +115,28 @@ describe("resolveTarget", () => {
   });
 
   // #14: AGENTS MAP → NODE EXISTS BUT NO PEER URL
-  test("agent mapped to node with no peer URL returns null", () => {
+  test("agent mapped to node with no peer URL returns error", () => {
     const config = { ...BASE_CONFIG, namedPeers: [], peers: [] };
     const r = resolveTarget("homekeeper", config, SESSIONS);
-    expect(r).toBeNull();
+    expect(r).toMatchObject({ type: "error", reason: "no_peer_url" });
   });
 
   // #15: EMPTY QUERY
-  test("empty query returns null", () => {
-    expect(resolveTarget("", BASE_CONFIG, SESSIONS)).toBeNull();
+  test("empty query returns error", () => {
+    const r = resolveTarget("", BASE_CONFIG, SESSIONS);
+    expect(r).toMatchObject({ type: "error", reason: "empty_query" });
   });
 
   // #16: COLON WITH EMPTY NODE
-  test("empty node prefix treated as local miss", () => {
+  test("empty node prefix returns error", () => {
     const r = resolveTarget(":agent", BASE_CONFIG, SESSIONS);
-    expect(r).toBeNull();
+    expect(r).toMatchObject({ type: "error", reason: "empty_node_or_agent" });
   });
 
   // #17: COLON WITH EMPTY AGENT
-  test("empty agent after colon returns null", () => {
+  test("empty agent after colon returns error", () => {
     const r = resolveTarget("node:", BASE_CONFIG, SESSIONS);
-    expect(r).toBeNull();
+    expect(r).toMatchObject({ type: "error", reason: "empty_node_or_agent" });
   });
 
   // #18: MULTIPLE COLONS


### PR DESCRIPTION
## Summary
- **#216**: resolveTarget returns error objects with reason/detail/hint instead of null. Actionable error messages.
- **#192**: `GET /api/identity` endpoint — node name, agents, version, uptime.
- **#190**: getFederationStatus dedupes peers by node identity, keeps fastest URL per node.
- **#175**: getAggregatedSessions dedupes by source+name, prevents exponential session duplication.

## Test plan
- [x] 174 tests pass (pre-commit hook)
- [x] Build clean (1.11 MB)
- [x] Auto-deployed to PM2
- [ ] `maw hey ghost test` → shows actionable error
- [ ] `curl localhost:3456/api/identity` → returns node identity
- [ ] `maw federation status` → no duplicate nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)