### PR TITLE
fix(windows): pass windowsHide to Bun.spawn to suppress console flash

### DIFF
--- a/src/curl-fetch.ts
+++ b/src/curl-fetch.ts
@@ -74,7 +74,7 @@ async function curlSpawn(url: string, opts: typeof curlFetch extends (u: string,
   args.push(url);
 
   try {
-    const proc = Bun.spawn(args, { stdout: "pipe", stderr: "pipe" });
+    const proc = Bun.spawn(args, { stdout: "pipe", stderr: "pipe", windowsHide: true });
     const text = await new Response(proc.stdout).text();
     const code = await proc.exited;
     if (code !== 0) return { ok: false, status: code, data: null };

--- a/src/pty.ts
+++ b/src/pty.ts
@@ -109,6 +109,7 @@ async function attach(ws: ServerWebSocket<any>, target: string, cols: number, ro
     stdout: "pipe",
     stderr: "ignore",
     env: { ...process.env, TERM: "xterm-256color" },
+    windowsHide: true,
   });
 
   session = { proc, target: safe, ptySessionName, viewers: new Set([ws]), cleanupTimer: null };

--- a/src/ssh.ts
+++ b/src/ssh.ts
@@ -8,7 +8,7 @@ const IS_LOCAL = DEFAULT_HOST === "local" || DEFAULT_HOST === "localhost";
 export async function hostExec(cmd: string, host = DEFAULT_HOST): Promise<string> {
   const local = host === "local" || host === "localhost" || IS_LOCAL;
   const args = local ? ["bash", "-c", cmd] : ["ssh", host, cmd];
-  const proc = Bun.spawn(args, { stdout: "pipe", stderr: "pipe" });
+  const proc = Bun.spawn(args, { stdout: "pipe", stderr: "pipe", windowsHide: true });
   const text = await new Response(proc.stdout).text();
   const code = await proc.exited;
   if (code !== 0) {

--- a/src/triggers.ts
+++ b/src/triggers.ts
@@ -94,7 +94,7 @@ export async function fire(event: TriggerEvent, ctx: TriggerContext = {}): Promi
     const result: TriggerFireResult = { trigger: t, action, ok: false, ts: Date.now() };
 
     try {
-      const proc = Bun.spawn(["bash", "-c", action], { stdout: "pipe", stderr: "pipe", env: { ...process.env } });
+      const proc = Bun.spawn(["bash", "-c", action], { stdout: "pipe", stderr: "pipe", env: { ...process.env }, windowsHide: true });
       const output = (await new Response(proc.stdout).text()).trim();
       const code = await proc.exited;
       if (code !== 0) throw new Error(`exit ${code}`);


### PR DESCRIPTION
## Problem

On Windows with WindowsTerminal as the default terminal (Win11 default), every `Bun.spawn(["bash", "-c", ...])` without `windowsHide: true` allocates a new console. Windows routes this through AppX activation → svchost → `OpenConsole.exe` + `WindowsTerminal.exe`. Even when the child exits in <100ms, a terminal window briefly opens and closes — a visible flash.

When this happens inside a polling loop (e.g. `hostExec` firing `tmux list-panes` / `list-windows` every 3-5s while `MAW_HOST=local`), the screen flashes continuously. The polled tmux command itself fails (no `tmux.exe` on Windows), but the console allocation already happened — **the failure is irrelevant, the spawn is the problem**.

## Repro

1. Run maw-js on Windows with `MAW_HOST=local` (the default in `ecosystem.config.cjs`)
2. Start `maw` via pm2
3. Observe: a `WindowsTerminal.exe` window flashes open/closed every ~3s

## Root cause

Five `Bun.spawn` call sites in `src/` spawn non-interactive children (`stdio: "pipe"`) but don't pass `windowsHide: true`. On Linux this does nothing; on Windows it leaks a console for every spawn.

## Fix

Add `windowsHide: true` to the four `Bun.spawn` calls that spawn silent children:

- `src/ssh.ts` — `hostExec` wrapper (hottest path — called from every tmux operation)
- `src/triggers.ts` — action firing via `bash -c`
- `src/curl-fetch.ts` — curl subprocess for HTTP
- `src/pty.ts` — `script(1)` PTY bridge

Intentionally **not** patched:

- `src/commands/view.ts` — interactive attach, must remain user-visible

## Verification

Tested on Windows 11 with WindowsTerminal as default terminal:

| Metric | Before | After |
|---|---|---|
| `WindowsTerminal.exe` spawns / 15s | ~8 | **0** |
| `OpenConsole.exe` spawns / 15s | ~8 | **0** |
| `bash.exe` polls from maw / 15s | ~8 (visible) | ~8 (**windowless**) |

The polling continues unchanged — just without the console allocation.

## Test plan

- [x] Apply fix on Windows 11 with default WindowsTerminal
- [x] Start maw via pm2, confirm no WindowsTerminal/OpenConsole spawns via `Get-CimInstance Win32_Process` polling
- [x] Confirm bash polling still fires (functionality preserved)
- [ ] Linux smoke test — `windowsHide` is a no-op on non-Windows, but worth a `bun test` pass
- [ ] `MAW_HOST=remote` smoke test (the ssh path uses the same `Bun.spawn` call, already covered)