### PR TITLE
fix(pm2): launcher shim for maw-boot to bypass bun async-module crash

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -14,9 +14,19 @@ module.exports = {
     },
     {
       name: 'maw-boot',
-      script: 'src/cli.ts',
-      args: 'wake all --resume',
-      interpreter: '/home/nat/.bun/bin/bun',
+      // Launcher shim: PM2 wraps spawned processes with require-in-the-middle,
+      // which sync-require()s the entry file. src/cli.ts is an ESM async module
+      // (top-level await) → require() throws on Windows and some Linux setups:
+      //
+      //   TypeError: require() async module "...src/cli.ts" is unsupported.
+      //   use "await import()" instead.
+      //
+      // The .cjs shim is require-safe and spawns bun via child_process,
+      // bypassing the PM2 require hook entirely.
+      // See scripts/maw-boot.launcher.cjs.
+      script: 'scripts/maw-boot.launcher.cjs',
+      args: ['wake', 'all', '--resume'],
+      interpreter: 'node',
       // One-shot: spawn fleet after server starts, don't restart
       autorestart: false,
       // Give maw server time to come up

--- a/scripts/maw-boot.launcher.cjs
+++ b/scripts/maw-boot.launcher.cjs
@@ -1,0 +1,75 @@
+// Node.js launcher shim for maw-boot (src/cli.ts wake all --resume).
+//
+// Why this exists: PM2 wraps spawned processes with `require-in-the-middle`,
+// which synchronously require()s the entry file. src/cli.ts is an ESM async
+// module (uses top-level await), and require()ing it throws:
+//
+//   TypeError: require() async module "...\src\cli.ts" is unsupported.
+//   use "await import()" instead.
+//
+// Result: maw-boot crash-loops on every pm2 start. This is especially visible
+// on Windows but can affect any environment where PM2's APM hooks are active.
+//
+// Fix: PM2 spawns Node (safe, .cjs is require-compatible), Node spawns bun
+// via child_process (bypasses the require-in-the-middle hook), bun runs
+// cli.ts cleanly. Signals and exit codes forward so pm2's lifecycle works.
+
+const { spawn } = require("node:child_process");
+const path = require("node:path");
+const os = require("node:os");
+const fs = require("node:fs");
+
+const IS_WIN = process.platform === "win32";
+
+// Resolve bun binary:
+//   1. $BUN_BIN env override (for non-standard installs)
+//   2. Windows: %APPDATA%\npm\bun.cmd (npm-global install)
+//   3. Linux/macOS: ~/.bun/bin/bun (curl installer default)
+//   4. Fallback: "bun" on PATH
+function resolveBun() {
+  if (process.env.BUN_BIN && fs.existsSync(process.env.BUN_BIN)) {
+    return process.env.BUN_BIN;
+  }
+  if (IS_WIN) {
+    const npmBun = path.join(
+      process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming"),
+      "npm",
+      "bun.cmd",
+    );
+    if (fs.existsSync(npmBun)) return npmBun;
+  } else {
+    const homeBun = path.join(os.homedir(), ".bun", "bin", "bun");
+    if (fs.existsSync(homeBun)) return homeBun;
+  }
+  return "bun";
+}
+
+const BUN_BIN = resolveBun();
+const CLI = path.join(__dirname, "..", "src", "cli.ts");
+const forwardedArgs = process.argv.slice(2);
+
+const child = spawn(BUN_BIN, ["run", CLI, ...forwardedArgs], {
+  stdio: "inherit",
+  // shell:true on Windows is required to execute .cmd files.
+  shell: IS_WIN,
+  windowsHide: true,
+});
+
+child.on("error", (err) => {
+  console.error("[maw-boot launcher] failed to spawn bun:", err);
+  process.exit(1);
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    console.error(`[maw-boot launcher] bun exited via signal ${signal}`);
+    process.exit(1);
+  }
+  process.exit(code ?? 0);
+});
+
+const forward = (sig) => {
+  if (!child.killed) child.kill(sig);
+};
+process.on("SIGINT", () => forward("SIGINT"));
+process.on("SIGTERM", () => forward("SIGTERM"));


### PR DESCRIPTION
## Problem

Every \`pm2 start ecosystem.config.cjs\` crashes \`maw-boot\` with:

\`\`\`
TypeError: require() async module \"...\src\cli.ts\" is unsupported.
use \"await import()\" instead.
  at ...\pm2\node_modules\require-in-the-middle\index.js:101:39
  at ...\pm2\lib\ProcessContainerForkBun.js:27:1
\`\`\`

## Root cause

PM2 wraps spawned processes with [\`require-in-the-middle\`](https://github.com/elastic/require-in-the-middle) (an APM instrumentation hook). The hook **synchronously** \`require()\`s the entry file before the process starts. \`src/cli.ts\` is an ESM async module (uses top-level \`await\`), and \`require()\`ing an async module throws unconditionally in modern Node/Bun.

Result: \`maw-boot\` crash-loops on every \`pm2 start\`. Each crash prints \`Waking fleet... (N sessions)\` before dying, cascading stale fleet state (and, on Windows, a storm of WindowsTerminal.exe flashes).

## Fix

Route \`maw-boot\` through a Node.js launcher shim at \`scripts/maw-boot.launcher.cjs\`:

1. PM2 spawns Node on the \`.cjs\` shim → \`require-in-the-middle\` is happy because the shim is CommonJS.
2. Shim uses \`child_process.spawn\` to invoke \`bun run src/cli.ts wake all --resume\` as a child process.
3. \`require-in-the-middle\` doesn't instrument child processes spawned via \`child_process\`, so bun runs \`cli.ts\` cleanly as an ESM async module.

The shim also:
- Resolves bun via \`BUN_BIN\` env, \`%APPDATA%\npm\bun.cmd\` (Windows), \`~/.bun/bin/bun\` (Unix), or PATH fallback — so it works for anyone, not just the maintainer's \`/home/nat/.bun/bin/bun\` hardcoded path
- Forwards argv so \`wake all --resume\` reaches cli.ts
- Forwards SIGINT/SIGTERM and exit codes so pm2 lifecycle semantics work
- Sets \`windowsHide: true\` to avoid flashing a console on Windows
- Uses \`shell: true\` on Windows only (required for \`.cmd\` execution)

Patterned after [luna-oracle commit 3cd8796](https://github.com/laris-co/luna-oracle/commit/3cd8796) which solved the same PM2+bun interop problem for the discord async wrapper.

## Verification

Tested on Windows 11 + pm2 6.x + bun 1.1.x:

| | Before | After |
|---|---|---|
| \`pm2 start --only maw-boot\` | crash-loop every ~2s | ✅ starts cleanly |
| \`pm2 logs maw-boot\` | \`TypeError: require() async module\` | ✅ \`Waking fleet\` + fleet session list |
| \`autorestart: false\` semantics | undefined (crash masks it) | ✅ preserved — one-shot as designed |
| Visible terminal flash | continuous (tied to crash-restart) | ✅ none |

## Test plan

- [x] Windows 11, pm2 6.x, bun 1.1.x — \`pm2 start\` succeeds, fleet wakes
- [x] \`autorestart: false\` still one-shot (verified in \`pm2 list\` — process goes online, exits after wake completes)
- [ ] Linux smoke test — shim resolves \`~/.bun/bin/bun\`, same behavior
- [ ] \`BUN_BIN\` env override for non-standard bun installs

## Related

- Companion PR #236 fixes the \`WindowsTerminal.exe\` flash storm caused by \`Bun.spawn\` missing \`windowsHide: true\` in \`src/ssh.ts\`, \`src/triggers.ts\`, \`src/curl-fetch.ts\`, \`src/pty.ts\`. Together these two PRs make maw-js run cleanly on Windows via pm2.