### PR TITLE
fix(view): prevent maw a from closing SSH terminal on detach

### DIFF
--- a/src/commands/view.ts
+++ b/src/commands/view.ts
@@ -1,6 +1,7 @@
 import { listSessions } from "../ssh";
 import { Tmux, tmuxCmd, resolveSocket } from "../tmux";
 import { loadConfig } from "../config";
+import { execSync } from "child_process";
 
 export async function cmdView(agent: string, windowHint?: string, clean = false) {
   // Find the session
@@ -54,16 +55,44 @@ export async function cmdView(agent: string, windowHint?: string, clean = false)
   const host = process.env.MAW_HOST || loadConfig().host || "local";
   const isLocal = host === "local" || host === "localhost";
   const socket = resolveSocket();
-  const attachArgs = isLocal
-    ? (socket ? ["tmux", "-S", socket, "attach-session", "-t", viewName]
-              : ["tmux", "attach-session", "-t", viewName])
-    : ["ssh", "-tt", host, `${tmuxCmd()} attach-session -t '${viewName}'`];
   console.log(`\x1b[36mattach\x1b[0m  → ${viewName}${clean ? " (clean)" : ""}`);
-  const proc = Bun.spawn(attachArgs, { stdin: "inherit", stdout: "inherit", stderr: "inherit" });
-  const exitCode = await proc.exited;
 
-  // Cleanup: kill grouped session after detach
+  // Already inside tmux? switch-client is the only option — nested
+  // `attach-session` would fail with "sessions should be nested with care".
+  // Fire-and-forget: we can't block until the user detaches, so we skip the
+  // automatic kill-session cleanup and print a hint instead.
+  if (isLocal && process.env.TMUX) {
+    await t.switchClient(viewName);
+    console.log(
+      `\x1b[90mhint\x1b[0m    → detach with prefix+d, then \`tmux kill-session -t ${viewName}\` when done`,
+    );
+    return;
+  }
+
+  // Use execSync (not Bun.spawn) for the blocking attach — Bun.spawn with
+  // stdin:"inherit" has TTY handoff issues that can propagate SIGHUP up to
+  // the parent SSH session when tmux detaches, closing the whole terminal.
+  // execSync + stdio:"inherit" matches the proven pattern in wake.ts
+  // (attachToSession helper, e07b7e9).
+  const attachCmd = isLocal
+    ? socket
+      ? `tmux -S ${socket} attach-session -t ${viewName}`
+      : `tmux attach-session -t ${viewName}`
+    : `ssh -tt ${host} "${tmuxCmd()} attach-session -t '${viewName}'"`;
+
+  try {
+    execSync(attachCmd, { stdio: "inherit" });
+  } catch (err) {
+    // tmux exits non-zero when attach fails (session gone, socket missing,
+    // etc). Log but do NOT re-throw — a failed attach should not cascade
+    // into process.exit(1) that might take the SSH session with it.
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`\x1b[33mwarn\x1b[0m: attach exited non-zero — ${msg}`);
+  }
+
+  // Cleanup: kill grouped session after detach (or after failed attach)
   await t.killSession(viewName);
   console.log(`\x1b[90mcleaned\x1b[0m → ${viewName}`);
-  process.exit(exitCode);
+  // Normal return — no process.exit. Letting the event loop drain naturally
+  // is safer than forcing an exit code that can race with parent shell state.
 }


### PR DESCRIPTION
## Summary

Nat reported that `maw a <agent>` sometimes exits the whole SSH session, forcing a reconnect. Three issues in `src/commands/view.ts` conspired:

1. **`Bun.spawn` TTY handoff** — `Bun.spawn` with `stdio:"inherit"` + tmux attach-session has TTY handoff issues. When tmux hands back the controlling terminal on detach, Bun's process group handling can leak SIGHUP up to the parent SSH shell.

2. **Propagated exit code** — `process.exit(exitCode)` passed tmux's exit code straight through. A non-zero exit (session killed mid-attach, socket race, etc.) became maw's exit code, which in some shell configurations cascades into the SSH session tearing down.

3. **Nested tmux unhandled** — running `maw a` from inside tmux would spawn `tmux attach-session` which tmux rejects with `sessions should be nested with care, unset $TMUX to force`.

## Fix

Match the proven pattern from `wake.ts` `attachToSession` (e07b7e9):

- **`execSync` with `stdio:"inherit"`** instead of `Bun.spawn`. Same pattern wake.ts uses; known to hand the TTY back cleanly without signal leakage.
- **Nested tmux case**: use `tmux.switchClient` when `process.env.TMUX` is set (fire-and-forget, since we can't block until the user detaches from a switched client). Print a hint for manual cleanup.
- **try/catch around execSync** — log non-zero exits instead of propagating.
- **Remove `process.exit(exitCode)`** — let the event loop drain naturally. Normal return is safer than a forced exit that can race with parent shell state.

## Test plan

- [x] `bun test` → 236 pass / 0 fail
- [x] `bun build src/cli.ts` → clean, 0.50 MB bundle
- [ ] Manual: SSH into white, `maw a <agent>`, detach with prefix+d, verify SSH session stays alive
- [ ] Manual: from inside tmux, `maw a <agent>`, verify switch-client behavior + hint
- [ ] Manual: `maw a nonexistent` → graceful error, no cascade

No view/attach unit test exists (tmux I/O isn't unit-testable), but the new code paths all match wake.ts's proven pattern.

## Related

- e07b7e9 shipped the same pattern for wake cold-start attach
- Issue surfaced tonight during federation sync merge cycle