### PR TITLE
feat: hot-reload plugins on file change (#230)

### DIFF
--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -1,5 +1,5 @@
 /**
- * Plugin System v2 — 4-phase lifecycle hooks.
+ * Plugin System v2 — 4-phase lifecycle hooks + scoped unload + hot-reload.
  *
  * Inspired by cmmakerclub/MQTT-Connector (Nat's Arduino lib, 2016):
  *   - Hook signature IS the permission (pointer=modify, value=read, bool*=cancel)
@@ -12,6 +12,11 @@
  *     hooks.on("SessionStart", (event) => console.log(event)); // observe
  *     hooks.late("*", (event) => auditLog(event)); // guaranteed cleanup
  *   }
+ *
+ * Hot-reload: watchUserPlugins() + reloadUserPlugins() let user plugins be
+ * re-loaded on file change without touching builtin plugins or restarting
+ * the server. Every hook entry is tagged with its source scope so a reload
+ * only drops user-scoped registrations — builtin plugins stay live.
  */
 
 import type { FeedEvent, FeedEventType } from "./lib/feed";
@@ -21,6 +26,9 @@ type Filter = (event: FeedEvent) => FeedEvent;
 type Handler = (event: Readonly<FeedEvent>) => void | Promise<void>;
 type Late = (event: Readonly<FeedEvent>) => void;
 export type MawPlugin = (hooks: MawHooks) => void | (() => void);
+export type PluginScope = "builtin" | "user";
+
+interface Scoped<T> { fn: T; scope: PluginScope; }
 
 export interface MawHooks {
   /** Phase 0: GATE — return false to cancel the entire pipeline */
@@ -36,7 +44,7 @@ export interface MawHooks {
 export interface PluginInfo {
   name: string;
   type: "ts" | "js" | "wasm-shared" | "wasm-wasi" | "unknown";
-  source: "builtin" | "user";
+  source: PluginScope;
   loadedAt: string;
   events: number;
   errors: number;
@@ -45,21 +53,25 @@ export interface PluginInfo {
 }
 
 export class PluginSystem {
-  private gates = new Map<string, Gate[]>();
-  private filters = new Map<string, Filter[]>();
-  private handlers = new Map<string, Handler[]>();
-  private lates = new Map<string, Late[]>();
-  private teardowns: Array<() => void> = [];
+  private gates = new Map<string, Scoped<Gate>[]>();
+  private filters = new Map<string, Scoped<Filter>[]>();
+  private handlers = new Map<string, Scoped<Handler>[]>();
+  private lates = new Map<string, Scoped<Late>[]>();
+  private teardowns: Scoped<() => void>[] = [];
   private _plugins: PluginInfo[] = [];
   private _totalEvents = 0;
   private _totalErrors = 0;
   private _gated = 0;
   private _startedAt = new Date().toISOString();
+  private _currentScope: PluginScope = "user";
+  private _reloads = 0;
+  private _lastReloadAt?: string;
 
-  private _addTo<T>(map: Map<string, T[]>, event: string, fn: T) {
+  private _addTo<T>(map: Map<string, Scoped<T>[]>, event: string, fn: T) {
+    const entry: Scoped<T> = { fn, scope: this._currentScope };
     const list = map.get(event);
-    if (list) list.push(fn);
-    else map.set(event, [fn]);
+    if (list) list.push(entry);
+    else map.set(event, [entry]);
   }
 
   readonly hooks: MawHooks = {
@@ -78,13 +90,13 @@ export class PluginSystem {
 
     // Phase 0: GATE — any gate returning false cancels the pipeline
     const frozen = Object.freeze({ ...event });
-    for (const fn of this.gates.get(event.event) ?? []) {
+    for (const { fn } of this.gates.get(event.event) ?? []) {
       try { if (fn(frozen) === false) { this._gated++; return false; } } catch (err) {
         this._totalErrors++;
         console.error(`[plugin:gate] ${event.event}:`, (err as Error).message);
       }
     }
-    for (const fn of this.gates.get("*") ?? []) {
+    for (const { fn } of this.gates.get("*") ?? []) {
       try { if (fn(frozen) === false) { this._gated++; return false; } } catch (err) {
         this._totalErrors++;
         console.error(`[plugin:gate] *:`, (err as Error).message);
@@ -92,13 +104,13 @@ export class PluginSystem {
     }
 
     // Phase 1: FILTER — modify event (mutable)
-    for (const fn of this.filters.get(event.event) ?? []) {
+    for (const { fn } of this.filters.get(event.event) ?? []) {
       try { event = fn(event); } catch (err) {
         this._totalErrors++;
         console.error(`[plugin:filter] ${event.event}:`, (err as Error).message);
       }
     }
-    for (const fn of this.filters.get("*") ?? []) {
+    for (const { fn } of this.filters.get("*") ?? []) {
       try { event = fn(event); } catch (err) {
         this._totalErrors++;
         console.error(`[plugin:filter] *:`, (err as Error).message);
@@ -107,13 +119,13 @@ export class PluginSystem {
 
     // Phase 2: HANDLE — observe (read-only)
     const readOnly = Object.freeze({ ...event });
-    for (const fn of this.handlers.get(event.event) ?? []) {
+    for (const { fn } of this.handlers.get(event.event) ?? []) {
       try { await fn(readOnly); } catch (err) {
         this._totalErrors++;
         console.error(`[plugin] ${event.event}:`, (err as Error).message);
       }
     }
-    for (const fn of this.handlers.get("*") ?? []) {
+    for (const { fn } of this.handlers.get("*") ?? []) {
       try { await fn(readOnly); } catch (err) {
         this._totalErrors++;
         console.error(`[plugin] *:`, (err as Error).message);
@@ -121,13 +133,13 @@ export class PluginSystem {
     }
 
     // Phase 3: LATE — guaranteed cleanup (runs even if HANDLE threw)
-    for (const fn of this.lates.get(event.event) ?? []) {
+    for (const { fn } of this.lates.get(event.event) ?? []) {
       try { fn(readOnly); } catch (err) {
         this._totalErrors++;
         console.error(`[plugin:late] ${event.event}:`, (err as Error).message);
       }
     }
-    for (const fn of this.lates.get("*") ?? []) {
+    for (const { fn } of this.lates.get("*") ?? []) {
       try { fn(readOnly); } catch (err) {
         this._totalErrors++;
         console.error(`[plugin:late] *:`, (err as Error).message);
@@ -143,33 +155,93 @@ export class PluginSystem {
     return true;
   }
 
-  load(plugin: MawPlugin) {
-    const teardown = plugin(this.hooks);
-    if (typeof teardown === "function") this.teardowns.push(teardown);
+  /**
+   * Invoke a plugin factory and record all its hook registrations + teardown
+   * under the given scope. Defaults to "user" so the common (external plugin)
+   * path stays one argument; built-in plugins pass "builtin" explicitly.
+   */
+  load(plugin: MawPlugin, scope: PluginScope = "user") {
+    const prev = this._currentScope;
+    this._currentScope = scope;
+    try {
+      const teardown = plugin(this.hooks);
+      if (typeof teardown === "function") {
+        this.teardowns.push({ fn: teardown, scope });
+      }
+    } finally {
+      this._currentScope = prev;
+    }
   }
 
-  register(name: string, type: PluginInfo["type"], source: PluginInfo["source"] = "user") {
+  register(name: string, type: PluginInfo["type"], source: PluginScope = "user") {
     this._plugins.push({ name, type, source, loadedAt: new Date().toISOString(), events: 0, errors: 0 });
   }
 
+  /**
+   * Unload every plugin registered under `scope`: run its teardowns, drop its
+   * hook registrations, remove its PluginInfo. Other scopes are untouched.
+   *
+   * This is the scoped-reset primitive that makes hot-reload safe: user
+   * plugins can be dropped and re-imported while builtin plugins stay live.
+   */
+  unloadScope(scope: PluginScope) {
+    // Run teardowns for this scope, keep others
+    const keep: Scoped<() => void>[] = [];
+    for (const t of this.teardowns) {
+      if (t.scope === scope) {
+        try { t.fn(); } catch {}
+      } else {
+        keep.push(t);
+      }
+    }
+    this.teardowns = keep;
+
+    // Strip scoped entries from each hook map
+    const clean = <T>(map: Map<string, Scoped<T>[]>) => {
+      for (const [key, list] of map) {
+        const kept = list.filter((e) => e.scope !== scope);
+        if (kept.length === 0) map.delete(key);
+        else map.set(key, kept);
+      }
+    };
+    clean(this.gates);
+    clean(this.filters);
+    clean(this.handlers);
+    clean(this.lates);
+
+    // Drop PluginInfo entries for this scope
+    this._plugins = this._plugins.filter((p) => p.source !== scope);
+  }
+
+  /** Internal: bump the reload counter. Used by reloadUserPlugins(). */
+  _markReloaded() {
+    this._reloads++;
+    this._lastReloadAt = new Date().toISOString();
+  }
+
   stats() {
+    const countScoped = <T>(map: Map<string, Scoped<T>[]>) =>
+      Object.fromEntries([...map].map(([k, v]) => [k, v.length]));
     return {
       startedAt: this._startedAt,
       plugins: this._plugins,
       totalEvents: this._totalEvents,
       totalErrors: this._totalErrors,
       gated: this._gated,
-      gates: Object.fromEntries([...this.gates].map(([k, v]) => [k, v.length])),
-      filters: Object.fromEntries([...this.filters].map(([k, v]) => [k, v.length])),
-      handlers: Object.fromEntries([...this.handlers].map(([k, v]) => [k, v.length])),
-      lates: Object.fromEntries([...this.lates].map(([k, v]) => [k, v.length])),
+      reloads: this._reloads,
+      lastReloadAt: this._lastReloadAt,
+      gates: countScoped(this.gates),
+      filters: countScoped(this.filters),
+      handlers: countScoped(this.handlers),
+      lates: countScoped(this.lates),
     };
   }
 
   destroy() {
-    for (const fn of this.teardowns) {
-      try { fn(); } catch {}
+    for (const t of this.teardowns) {
+      try { t.fn(); } catch {}
     }
+    this.teardowns = [];
   }
 }
 
@@ -180,7 +252,7 @@ export class PluginSystem {
  *   - OR: module exports `on_event` string array for filtering
  *   - Fallback: if module exports `_start` (WASI), run as subprocess per event
  */
-async function loadWasmPlugin(system: PluginSystem, path: string, filename: string, source: PluginInfo["source"] = "user") {
+async function loadWasmPlugin(system: PluginSystem, path: string, filename: string, source: PluginScope = "user") {
   const { readFileSync } = require("fs");
   const wasmBytes = readFileSync(path);
   const mod = new WebAssembly.Module(wasmBytes);
@@ -201,7 +273,7 @@ async function loadWasmPlugin(system: PluginSystem, path: string, filename: stri
         buf.set(json, 0);
         handle(0, json.length);
       });
-    });
+    }, source);
     system.register(filename, "wasm-shared", source);
     console.log(`[plugin] loaded wasm: ${filename} (shared memory)`);
     return;
@@ -240,7 +312,7 @@ async function loadWasmPlugin(system: PluginSystem, path: string, filename: stri
           wasi.start(instance);
         } catch {}
       });
-    });
+    }, source);
     system.register(filename, "wasm-wasi", source);
     console.log(`[plugin] loaded wasm: ${filename} (WASI)`);
     return;
@@ -256,8 +328,17 @@ async function loadWasmPlugin(system: PluginSystem, path: string, filename: stri
  * Supported formats:
  *   .ts / .js  — TypeScript/JavaScript: export default function(hooks) { ... }
  *   .wasm      — WebAssembly: export handle(ptr, len) + memory, or WASI _start
+ *
+ * @param cacheBust  If true, append ?t=<timestamp> to the import specifier so
+ *                   Bun re-evaluates the module instead of returning a cached
+ *                   copy. Used by hot-reload; disabled for initial startup.
  */
-export async function loadPlugins(system: PluginSystem, dir: string, source: PluginInfo["source"] = "user") {
+export async function loadPlugins(
+  system: PluginSystem,
+  dir: string,
+  source: PluginScope = "user",
+  cacheBust = false,
+) {
   const { readdirSync } = require("fs");
   const { join } = require("path");
   let files: string[];
@@ -274,10 +355,11 @@ export async function loadPlugins(system: PluginSystem, dir: string, source: Plu
       if (file.endsWith(".wasm")) {
         await loadWasmPlugin(system, path, file, source);
       } else {
-        const mod = await import(path);
+        const spec = cacheBust ? `${path}?t=${Date.now()}` : path;
+        const mod = await import(spec);
         const plugin = mod.default ?? mod;
         if (typeof plugin === "function") {
-          system.load(plugin);
+          system.load(plugin, source);
           system.register(file, file.endsWith(".ts") ? "ts" : "js", source);
           console.log(`[plugin] loaded: ${file} (${source})`);
         }
@@ -286,4 +368,71 @@ export async function loadPlugins(system: PluginSystem, dir: string, source: Plu
       console.error(`[plugin] failed to load ${file}:`, (err as Error).message);
     }
   }
+}
+
+/**
+ * Reload every user plugin in `dir`: run user teardowns, drop user hook
+ * registrations, then re-import every file with cache-busting so edits on
+ * disk are picked up. Builtin plugins are left untouched.
+ *
+ * Safe to call repeatedly. Bumps the reload counter visible via stats().
+ */
+export async function reloadUserPlugins(system: PluginSystem, dir: string) {
+  system.unloadScope("user");
+  await loadPlugins(system, dir, "user", true);
+  system._markReloaded();
+  console.log(`[plugin] reloaded user plugins from ${dir}`);
+}
+
+/**
+ * Watch a plugins directory for file changes. On any change to a .ts/.js/.wasm
+ * file the debounced timer fires `onReload(filename)`. Disable entirely by
+ * setting `MAW_HOT_RELOAD=0`.
+ *
+ * Returns a close function that stops the watcher and cancels any pending
+ * debounced reload.
+ */
+export function watchUserPlugins(
+  dir: string,
+  onReload: (changedFile: string) => void | Promise<void>,
+  debounceMs = 200,
+): () => void {
+  if (process.env.MAW_HOT_RELOAD === "0") {
+    console.log(`[plugin] hot-reload disabled via MAW_HOT_RELOAD=0`);
+    return () => {};
+  }
+
+  const { watch, existsSync } = require("fs");
+  if (!existsSync(dir)) {
+    // Nothing to watch yet — user hasn't created ~/.oracle/plugins/.
+    return () => {};
+  }
+
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let lastChanged = "";
+
+  let watcher: { close: () => void };
+  try {
+    watcher = watch(dir, { persistent: false }, (_eventType: string, filename: string | null) => {
+      if (!filename) return;
+      if (!(filename.endsWith(".ts") || filename.endsWith(".js") || filename.endsWith(".wasm"))) return;
+      lastChanged = filename;
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        timer = null;
+        Promise.resolve(onReload(lastChanged)).catch((err) => {
+          console.error(`[plugin:reload] failed for ${lastChanged}:`, (err as Error).message);
+        });
+      }, debounceMs);
+    });
+  } catch (err) {
+    console.error(`[plugin:watch] cannot watch ${dir}:`, (err as Error).message);
+    return () => {};
+  }
+
+  console.log(`[plugin] hot-reload watching ${dir}`);
+  return () => {
+    if (timer) clearTimeout(timer);
+    try { watcher.close(); } catch {}
+  };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -78,7 +78,7 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
 
   // Plugin system — built-in + user plugins
   try {
-    const { PluginSystem, loadPlugins } = require("./plugins");
+    const { PluginSystem, loadPlugins, reloadUserPlugins, watchUserPlugins } = require("./plugins");
     const { homedir } = require("os");
     const { join, resolve, dirname } = require("path");
     const plugins = new PluginSystem();
@@ -88,13 +88,25 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
     await loadPlugins(plugins, builtinDir, "builtin");
 
     // User plugins (file-drop: ~/.oracle/plugins/)
-    await loadPlugins(plugins, join(homedir(), ".oracle", "plugins"), "user");
+    const userPluginsDir = join(homedir(), ".oracle", "plugins");
+    await loadPlugins(plugins, userPluginsDir, "user");
+
+    // Hot-reload: watch the user plugins dir and re-import on .ts/.js/.wasm
+    // change. Builtin plugins are not touched. Opt out with MAW_HOT_RELOAD=0.
+    watchUserPlugins(userPluginsDir, async (changedFile: string) => {
+      console.log(`[plugin] reloading user plugins (${changedFile} changed)`);
+      await reloadUserPlugins(plugins, userPluginsDir);
+    });
 
     // Single feedListener wires everything through the plugin pipeline
     feedListeners.add((event) => plugins.emit(event));
 
     // Plugin debug API + page
     app.get("/api/plugins", (c) => c.json(plugins.stats()));
+    app.post("/api/plugins/reload", async (c) => {
+      await reloadUserPlugins(plugins, userPluginsDir);
+      return c.json({ ok: true, ...plugins.stats() });
+    });
     const { pluginsView } = require("./views/plugins");
     app.route("/plugins", pluginsView(plugins));
   } catch (err) {

--- a/test/plugins.test.ts
+++ b/test/plugins.test.ts
@@ -1,6 +1,9 @@
 import { describe, test, expect } from "bun:test";
-import { PluginSystem, loadPlugins } from "../src/plugins";
+import { PluginSystem, loadPlugins, reloadUserPlugins } from "../src/plugins";
 import type { FeedEvent } from "../src/lib/feed";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 
 const mockEvent: FeedEvent = {
   timestamp: "2026-04-10 16:00",
@@ -294,5 +297,217 @@ describe("PluginSystem", () => {
     expect(s.filters).toEqual({ "*": 1 });
     expect(s.handlers).toEqual({ "*": 1 });
     expect(s.lates).toEqual({ "*": 1 });
+  });
+
+  // ─── Scoped unload + hot-reload (issue #230) ───
+
+  test("unloadScope('user') removes user hooks but keeps builtin hooks", async () => {
+    const sys = new PluginSystem();
+    const log: string[] = [];
+
+    sys.load((hooks) => {
+      hooks.on("SessionStart", () => log.push("builtin"));
+    }, "builtin");
+    sys.load((hooks) => {
+      hooks.on("SessionStart", () => log.push("user"));
+    }, "user");
+
+    await sys.emit(mockEvent);
+    expect(log).toEqual(["builtin", "user"]);
+
+    sys.unloadScope("user");
+    log.length = 0;
+    await sys.emit(mockEvent);
+    expect(log).toEqual(["builtin"]);
+  });
+
+  test("unloadScope('user') runs user teardowns but not builtin teardowns", () => {
+    const sys = new PluginSystem();
+    let userTorn = false;
+    let builtinTorn = false;
+
+    sys.load(() => () => { builtinTorn = true; }, "builtin");
+    sys.load(() => () => { userTorn = true; }, "user");
+
+    sys.unloadScope("user");
+    expect(userTorn).toBe(true);
+    expect(builtinTorn).toBe(false);
+  });
+
+  test("unloadScope drops PluginInfo entries for that scope only", () => {
+    const sys = new PluginSystem();
+    sys.register("core.ts", "ts", "builtin");
+    sys.register("mqtt.ts", "ts", "user");
+    sys.register("debug.ts", "ts", "user");
+
+    sys.unloadScope("user");
+    const infos = sys.stats().plugins;
+    expect(infos.map((p) => p.name)).toEqual(["core.ts"]);
+  });
+
+  test("unloadScope clears all 4 hook phases", async () => {
+    const sys = new PluginSystem();
+    sys.load((hooks) => {
+      hooks.gate("SessionStart", () => true);
+      hooks.filter("*", (e) => e);
+      hooks.on("*", () => {});
+      hooks.late("*", () => {});
+    }, "user");
+
+    sys.unloadScope("user");
+    const s = sys.stats();
+    expect(s.gates).toEqual({});
+    expect(s.filters).toEqual({});
+    expect(s.handlers).toEqual({});
+    expect(s.lates).toEqual({});
+  });
+
+  test("unloadScope is idempotent (safe to call twice)", () => {
+    const sys = new PluginSystem();
+    sys.load((hooks) => { hooks.on("*", () => {}); }, "user");
+
+    sys.unloadScope("user");
+    expect(() => sys.unloadScope("user")).not.toThrow();
+  });
+
+  test("reloadUserPlugins picks up edits to plugin files on disk", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "maw-plugins-"));
+    try {
+      const file = join(dir, "tap.ts");
+
+      // v1: pushes "v1"
+      writeFileSync(
+        file,
+        `export default function(hooks) { hooks.on("*", (e) => (globalThis as any).__tapLog.push("v1:" + e.event)); }`,
+      );
+      (globalThis as any).__tapLog = [];
+
+      const sys = new PluginSystem();
+      await loadPlugins(sys, dir, "user");
+      await sys.emit(mockEvent);
+      expect((globalThis as any).__tapLog).toEqual(["v1:SessionStart"]);
+
+      // Edit file to push "v2" instead
+      writeFileSync(
+        file,
+        `export default function(hooks) { hooks.on("*", (e) => (globalThis as any).__tapLog.push("v2:" + e.event)); }`,
+      );
+      (globalThis as any).__tapLog = [];
+
+      await reloadUserPlugins(sys, dir);
+      await sys.emit(mockEvent);
+      expect((globalThis as any).__tapLog).toEqual(["v2:SessionStart"]);
+
+      // Handler count stays at 1 — no double-registration
+      expect(sys.stats().handlers["*"]).toBe(1);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      delete (globalThis as any).__tapLog;
+    }
+  });
+
+  test("reloadUserPlugins does not double-register on successive reloads", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "maw-plugins-"));
+    try {
+      const file = join(dir, "double.ts");
+      writeFileSync(
+        file,
+        `export default function(hooks) { hooks.on("SessionStart", () => {}); }`,
+      );
+
+      const sys = new PluginSystem();
+      await loadPlugins(sys, dir, "user");
+      expect(sys.stats().handlers.SessionStart).toBe(1);
+
+      await reloadUserPlugins(sys, dir);
+      await reloadUserPlugins(sys, dir);
+      await reloadUserPlugins(sys, dir);
+
+      expect(sys.stats().handlers.SessionStart).toBe(1);
+      expect(sys.stats().plugins.length).toBe(1);
+      expect(sys.stats().reloads).toBe(3);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("reloadUserPlugins preserves builtin plugins across reloads", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "maw-plugins-"));
+    try {
+      const file = join(dir, "u.ts");
+      writeFileSync(
+        file,
+        `export default function(hooks) { hooks.on("*", () => (globalThis as any).__uCalls++); }`,
+      );
+      (globalThis as any).__uCalls = 0;
+      (globalThis as any).__bCalls = 0;
+
+      const sys = new PluginSystem();
+      sys.load((hooks) => {
+        hooks.on("*", () => (globalThis as any).__bCalls++);
+      }, "builtin");
+
+      await loadPlugins(sys, dir, "user");
+      await sys.emit(mockEvent);
+      expect((globalThis as any).__bCalls).toBe(1);
+      expect((globalThis as any).__uCalls).toBe(1);
+
+      await reloadUserPlugins(sys, dir);
+      await sys.emit(mockEvent);
+      expect((globalThis as any).__bCalls).toBe(2); // builtin survived
+      expect((globalThis as any).__uCalls).toBe(2); // user re-registered
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      delete (globalThis as any).__uCalls;
+      delete (globalThis as any).__bCalls;
+    }
+  });
+
+  test("reloadUserPlugins removes a deleted plugin file", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "maw-plugins-"));
+    try {
+      const a = join(dir, "a.ts");
+      const b = join(dir, "b.ts");
+      writeFileSync(a, `export default function(h) { h.on("*", () => {}); }`);
+      writeFileSync(b, `export default function(h) { h.on("*", () => {}); }`);
+
+      const sys = new PluginSystem();
+      await loadPlugins(sys, dir, "user");
+      expect(sys.stats().plugins.length).toBe(2);
+
+      rmSync(b);
+      await reloadUserPlugins(sys, dir);
+      expect(sys.stats().plugins.length).toBe(1);
+      expect(sys.stats().plugins[0].name).toBe("a.ts");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("stats.reloads increments on each reloadUserPlugins call", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "maw-plugins-"));
+    try {
+      writeFileSync(join(dir, "p.ts"), `export default function(h) { h.on("*", () => {}); }`);
+      const sys = new PluginSystem();
+      await loadPlugins(sys, dir, "user");
+      expect(sys.stats().reloads).toBe(0);
+
+      await reloadUserPlugins(sys, dir);
+      expect(sys.stats().reloads).toBe(1);
+      expect(sys.stats().lastReloadAt).toBeDefined();
+
+      await reloadUserPlugins(sys, dir);
+      expect(sys.stats().reloads).toBe(2);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("load() default scope is 'user' (backwards-compatible)", () => {
+    const sys = new PluginSystem();
+    sys.load((hooks) => { hooks.on("*", () => {}); });
+    // Without explicit scope it defaults to "user" — unloadScope('user') must drop it
+    sys.unloadScope("user");
+    expect(sys.stats().handlers).toEqual({});
   });
 });


### PR DESCRIPTION
## Summary

Implements #230 — user plugins are now re-imported from disk on file change without restarting the server. Builtin plugins stay live across reloads.

## Design

Each hook entry (gate / filter / handle / late) now carries a scope tag (`builtin` or `user`). A new `PluginSystem.unloadScope(scope)` method runs that scope's teardowns, strips its hook entries from all four phases, and drops its `PluginInfo` — leaving other scopes untouched. This is the primitive that makes hot-reload safe: user plugins can be dropped and re-imported while MQTT-publish / shell-hooks and other builtin plugins keep running.

Two new exports from `src/plugins.ts`:

| Function | What it does |
|---|---|
| `reloadUserPlugins(system, dir)` | `unloadScope("user")` then `loadPlugins(..., cacheBust=true)`; Bun ESM re-imports via `?t=<timestamp>` so disk edits are picked up |
| `watchUserPlugins(dir, onReload)` | `fs.watch` + 200 ms debounce, filters `.ts/.js/.wasm`, honors `MAW_HOT_RELOAD=0`, returns a close handle |

## Server wiring (`src/server.ts`)

- After initial `loadPlugins`, calls `watchUserPlugins(~/.oracle/plugins/, reloadFn)`.
- New `POST /api/plugins/reload` for manual reload from the debug page / API clients.

## Test coverage

31 tests total (20 existing + 11 new, all green). Highlights:

- `unloadScope('user')` keeps builtin hooks but removes user hooks
- `unloadScope('user')` runs only user teardowns
- Clears all 4 phases (gate/filter/handle/late) + `PluginInfo`
- Idempotent
- **Live file-edit round-trip**: write `v1` plugin → emit → see `v1` → overwrite file with `v2` → `reloadUserPlugins` → emit → see `v2`, handler count stays at 1
- 3× successive reloads = still 1 handler (no double-registration)
- Builtin plugin still fires after user-plugin reload
- Deleted plugin file is dropped on next reload
- `stats.reloads` + `lastReloadAt` increment correctly

## Test plan

- [x] Unit tests (`bun test test/plugins.test.ts`) — 31/31 pass
- [x] Full suite (`bun test`) — 247 pass, 0 fail
- [x] Build check (`bun build src/cli.ts --target=bun --minify`) — 161 modules bundled
- [ ] Manual: edit a plugin in `~/.oracle/plugins/`, see the reload line in server log, confirm the edit takes effect on next emit
- [ ] Manual: `curl -X POST http://localhost:3456/api/plugins/reload` — returns stats with bumped `reloads` counter

## Out of scope

- **Per-file reload**: this PR drops all user plugins and re-loads them. Per-file reload (unregister just the changed file) would be more surgical but needs per-file hook attribution that we don't track yet. Filed as a possible follow-up.
- **Plugin dependency DAG**: if user plugin A depends on user plugin B (via globalThis or module-level state), reload order is not guaranteed. Not a regression — existing behavior.

## How it was scoped

Cross-node scope/execute/verify loop with `white:mawjs-oracle` tonight:
1. Oracle-world read all 7 open issues, proposed #230 as "the feature"
2. White confirmed + added scoping notes: *don't touch builtin*, *cache-bust via query string*, *fs.watch + debounce*, *destroy() already handles teardowns*
3. Oracle-world implemented scoped unload (the refined shape), all tests green
4. Draft PR opened for white's morning review

🤖 ตอบโดย mawjs จาก Nat → maw-js
Co-Authored-By: mawjs <noreply@anthropic.com>