### PR TITLE
feat(bud): --org shorthand for per-invocation target org (#235)

### DIFF
--- a/src/cli/route-agent.ts
+++ b/src/cli/route-agent.ts
@@ -70,10 +70,11 @@ export async function routeAgent(cmd: string, args: string[]): Promise<boolean> 
     return true;
   }
   if (cmd === "bud") {
-    if (!args[1] || args[1] === "--help" || args[1] === "-h") { console.error("usage: maw bud <name> [--from <oracle>] [--repo org/repo] [--issue N] [--fast] [--dry-run]"); process.exit(1); }
-    const budOpts: { from?: string; repo?: string; issue?: number; fast?: boolean; dryRun?: boolean; note?: string } = {};
+    if (!args[1] || args[1] === "--help" || args[1] === "-h") { console.error("usage: maw bud <name> [--from <oracle>] [--org <org>] [--repo org/repo] [--issue N] [--note <text>] [--fast] [--dry-run]"); process.exit(1); }
+    const budOpts: { from?: string; repo?: string; org?: string; issue?: number; fast?: boolean; dryRun?: boolean; note?: string } = {};
     for (let i = 2; i < args.length; i++) {
       if (args[i] === "--from" && args[i + 1]) budOpts.from = args[++i];
+      else if (args[i] === "--org" && args[i + 1]) budOpts.org = args[++i];
       else if (args[i] === "--repo" && args[i + 1]) budOpts.repo = args[++i];
       else if (args[i] === "--issue" && args[i + 1]) budOpts.issue = +args[++i];
       else if (args[i] === "--note" && args[i + 1]) budOpts.note = args[++i];

--- a/src/commands/bud.ts
+++ b/src/commands/bud.ts
@@ -10,6 +10,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
 export interface BudOpts {
   from?: string;
   repo?: string;
+  org?: string;
   issue?: number;
   fast?: boolean;
   dryRun?: boolean;
@@ -17,9 +18,18 @@ export interface BudOpts {
 }
 
 /**
- * maw bud <name> [--from <parent>] [--repo org/repo] [--issue N] [--fast] [--dry-run]
+ * maw bud <name> [--from <parent>] [--org <org>] [--repo org/repo] [--issue N] [--fast] [--dry-run]
  *
  * Yeast budding — any oracle can spawn a new oracle.
+ *
+ * Target org resolution (first wins):
+ *   1. --org <org>                    — per-invocation override (#235)
+ *   2. config.githubOrg               — per-machine default from config
+ *   3. "Soul-Brews-Studio"            — hard-coded fallback
+ *
+ * Note: --repo is an INCUBATION flag (seeds the bud from an existing local
+ * project's ψ/), NOT a target-org override. Use --org to target a different
+ * GitHub org for the bud's own repo.
  *
  * Steps:
  *   1. Create oracle repo (gh repo create)
@@ -33,7 +43,7 @@ export interface BudOpts {
 export async function cmdBud(name: string, opts: BudOpts = {}) {
   const config = loadConfig();
   const ghqRoot = config.ghqRoot;
-  const org = config.githubOrg || "Soul-Brews-Studio";
+  const org = opts.org || config.githubOrg || "Soul-Brews-Studio";
 
   // Resolve parent oracle
   let parentName = opts.from;


### PR DESCRIPTION
## Summary

Adds `--org <org>` flag to `maw bud` so a bud can target a non-default GitHub org without editing `maw.config.json`. Closes #235 (with a nuance flagged below for the issue author).

**Resolution order** (first wins):
1. `--org <org>` — per-invocation override
2. `config.githubOrg` — per-machine default
3. `"Soul-Brews-Studio"` — hard-coded fallback

## Example

```bash
# Bud into a different org for one-off experiments
maw bud scratch --from mawjs --org laris-co --fast

# Normal usage still honors per-machine default
maw bud newpal --from mawjs
```

## ⚠️ Semantic nuance re: issue #235

Issue #235 describes `--repo org/repo` as a target-org override. But reading the existing code, `opts.repo` is actually an **incubation flag**:

- `src/commands/bud.ts:220` → `wakeOpts.incubate = opts.repo`
- `src/commands/bud.ts:231` → `join(ghqRoot, \"github.com\", opts.repo, \"ψ\", \"memory\")` (seeds ψ/ from an existing local project)

So overloading `--repo` as the target-org knob would break incubation. This PR implements `--org` as a cleanly independent flag instead. The JSDoc on `cmdBud` now spells out the distinction so future-us doesn't re-derive it:

```
Target org resolution (first wins):
  1. --org <org>                    — per-invocation override (#235)
  2. config.githubOrg               — per-machine default from config
  3. \"Soul-Brews-Studio\"            — hard-coded fallback

Note: --repo is an INCUBATION flag (seeds the bud from an existing local
project's ψ/), NOT a target-org override. Use --org to target a different
GitHub org for the bud's own repo.
```

@laris-co — when you get a moment, mind updating #235's description to say \`--org\` instead of \`--repo\`? Keeps the history coherent.

## Changes

- \`src/commands/bud.ts\` — \`BudOpts.org?: string\`; resolution prefix \`opts.org ||\`; JSDoc updated
- \`src/cli/route-agent.ts\` — parse \`--org\` in bud dispatcher; usage string updated

## Test plan

- [x] \`bun build src/cli.ts --target=bun --minify\` — 161 modules, 0.29 MB
- [ ] \`maw bud test --org laris-co --dry-run\` (manual smoke, morning)
- [ ] Confirm existing behavior unchanged when \`--org\` omitted

## Finders

oracle-world:mawjs + oracle-world:boonkeeper — spotted the gap during overnight #235 triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)