### PR TITLE
fix: remove redundant "github.com" from ghqRoot joins (#231)

### DIFF
--- a/src/commands/archive.ts
+++ b/src/commands/archive.ts
@@ -28,7 +28,7 @@ export async function cmdArchive(oracleName: string, opts: { dryRun?: boolean } 
 
   const mainWindow = entry.session.windows[0];
   const repoSlug = mainWindow?.repo || "";
-  const repoPath = repoSlug ? join(ghqRoot, "github.com", repoSlug) : "";
+  const repoPath = repoSlug ? join(ghqRoot, repoSlug) : "";
 
   console.log(`\n  \x1b[36m⚰️  Archiving\x1b[0m — ${oracleName}\n`);
 

--- a/src/commands/bud.ts
+++ b/src/commands/bud.ts
@@ -60,7 +60,7 @@ export async function cmdBud(name: string, opts: BudOpts = {}) {
 
   const budRepoName = `${name}-oracle`;
   const budRepoSlug = `${org}/${budRepoName}`;
-  const budRepoPath = join(ghqRoot, "github.com", org, budRepoName);
+  const budRepoPath = join(ghqRoot, org, budRepoName);
 
   console.log(`\n  \x1b[36m🧬 Budding\x1b[0m — ${parentName} → ${name}\n`);
 
@@ -268,7 +268,7 @@ Run \`/awaken\` for the full identity setup ceremony.
 
   // 8.5. Copy local project ψ/ if --repo was used and it exists
   if (opts.repo) {
-    const localPsi = join(ghqRoot, "github.com", opts.repo, "ψ", "memory");
+    const localPsi = join(ghqRoot, opts.repo, "ψ", "memory");
     if (existsSync(localPsi)) {
       const { syncDir } = await import("./soul-sync");
       for (const sub of ["learnings", "retrospectives", "traces"]) {

--- a/src/commands/find.ts
+++ b/src/commands/find.ts
@@ -29,7 +29,7 @@ export async function cmdFind(keyword: string, opts: { oracle?: string } = {}) {
     const mainWindow = sess.windows[0];
     if (!mainWindow?.repo) continue;
 
-    const repoPath = join(ghqRoot, "github.com", mainWindow.repo);
+    const repoPath = join(ghqRoot, mainWindow.repo);
     const psiPath = join(repoPath, "ψ", "memory");
     if (existsSync(psiPath)) {
       targets.push({ name: oracleName, psiPath });

--- a/src/commands/fleet-consolidate.ts
+++ b/src/commands/fleet-consolidate.ts
@@ -55,7 +55,7 @@ export async function cmdFleetConsolidate(opts: { dryRun?: boolean; remove?: boo
     }
 
     const repo = cfg.windows?.[0]?.repo || "";
-    const repoPath = repo ? join(ghqRoot, "github.com", repo) : "";
+    const repoPath = repo ? join(ghqRoot, repo) : "";
     const repoExists = repoPath ? require("fs").existsSync(repoPath) : false;
 
     const result: ConsolidateResult = { name: dName, num, repo, repoExists, branches: [], merged: [], pushOk: false, removed: false };

--- a/src/commands/fleet-health.ts
+++ b/src/commands/fleet-health.ts
@@ -28,7 +28,7 @@ export async function cmdFleetHealth() {
     let daysSinceActivity = -1;
     const mainWindow = entry.session.windows[0];
     if (mainWindow?.repo) {
-      const repoPath = join(ghqRoot, "github.com", mainWindow.repo);
+      const repoPath = join(ghqRoot, mainWindow.repo);
       try {
         const ts = await hostExec(`git -C '${repoPath}' log -1 --format='%ci' 2>/dev/null`);
         if (ts.trim()) {
@@ -95,7 +95,7 @@ export async function cmdFleetHealth() {
         const wins = cfg.windows?.length || 0;
         const repo = cfg.windows?.[0]?.repo || "?";
         const peers = cfg.sync_peers?.length || 0;
-        const repoExists = require("fs").existsSync(join(ghqRoot, "github.com", repo));
+        const repoExists = require("fs").existsSync(join(ghqRoot, repo));
         console.log(`  \x1b[90m  ${num.padStart(2)}  ${dName.padEnd(20)} ${String(wins).padStart(2)} win  repo:${repoExists ? "yes" : "no "}  peers:${peers}\x1b[0m`);
       } catch {
         const dName = f.replace(/^\d+-/, "").replace(".json.disabled", "");


### PR DESCRIPTION
## Summary

`detectGhqRoot()` in `src/config.ts` returns `<root>/github.com` when that directory exists, so callers should NOT add `github.com` again. A handful of call sites still did, producing invalid double paths like `/home/neo/Code/github.com/github.com/org/repo` on machines where ghq root is `/home/neo/Code`.

This PR sweeps the 7 remaining buggy locations flagged by FRIDAY Oracle in #231.

## Fix

Removed the literal `"github.com"` segment from 7 `join(ghqRoot, ...)` calls across 5 files:

| File | Line | Context |
|---|---|---|
| `src/commands/archive.ts` | 31 | `repoPath` for oracle archival |
| `src/commands/bud.ts` | 63 | `budRepoPath` for new bud clone target |
| `src/commands/bud.ts` | 271 | `localPsi` for `--repo` incubation seed |
| `src/commands/fleet-consolidate.ts` | 58 | `repoPath` for branch consolidation |
| `src/commands/fleet-health.ts` | 31 | `repoPath` for last-activity probe |
| `src/commands/fleet-health.ts` | 98 | disabled-oracle `repoExists` check |
| `src/commands/find.ts` | 32 | ψ/ scan target |

Earlier commits `e3cc944` + `4d7ba24` covered 2 other locations. This closes the gap.

## What I left alone

`src/commands/fleet-doctor.ts:226` intentionally probes BOTH shapes (`direct` = `join(ghqRoot, repo)`, `nested` = `join(ghqRoot, "github.com", repo)`) as a defensive fallback for the edge case where `detectGhqRoot()` returns a bare ghq root (no `github.com` subdir exists). That hedge is still correct — I did not touch it.

## Verification

- 247 pass / 6 skip / 6 todo / 0 fail (259 tests, 1.67s)
- Build: 161 modules, 0.29 MB
- Same numbers as post-merge main — zero regressions
- Grep confirmed no other `join(ghqRoot, "github.com", ...)` calls remain outside the intentional fleet-doctor hedge

## Test plan

- [x] `bun test` — 247/0
- [x] `bun run build` — clean
- [x] `grep 'ghqRoot,\s*[\"'\'']github\.com[\"'\'']'` returns only fleet-doctor.ts:226
- [ ] Reviewer check: any machine-specific behavior changes around `archive`/`consolidate`/`health`/`find`/`bud` (should be none — the paths now resolve to the correct github.com-rooted location)

Closes #231

---
Bonus C from the overnight cron cycle (first window was #245/#246/#247). Keeping this as draft pending review.

🤖 ตอบโดย mawjs จาก [Human] → mawjs-oracle