### PR TITLE
fix: soul-sync --project repo-segment drop when ghqRoot is bare (#193)

### DIFF
--- a/src/commands/soul-sync.ts
+++ b/src/commands/soul-sync.ts
@@ -88,6 +88,41 @@ export function findProjectsForOracle(oracleName: string): string[] {
 }
 
 /**
+ * Resolve a git repo path to its canonical "org/repo" slug for `project_repos`
+ * lookup. Handles both shapes of `ghqRoot`:
+ *
+ *   A. github.com-rooted: `/home/neo/Code/github.com`
+ *      repoRoot = `/home/neo/Code/github.com/Soul-Brews-Studio/maw-js`
+ *      → rel = `Soul-Brews-Studio/maw-js` → slug = `Soul-Brews-Studio/maw-js`
+ *
+ *   B. bare ghq root:     `/home/neo/Code`
+ *      repoRoot = `/home/neo/Code/github.com/Soul-Brews-Studio/maw-js`
+ *      → rel = `github.com/Soul-Brews-Studio/maw-js` → (strip host) →
+ *        `Soul-Brews-Studio/maw-js` → slug = `Soul-Brews-Studio/maw-js`
+ *
+ * Before this normalization, shape B produced the org-only slug
+ * `github.com/Soul-Brews-Studio` because `.split("/").slice(0, 2)` grabbed
+ * the host + org instead of org + repo. See #193.
+ *
+ * Worktree suffix (`.wt-*`) is stripped from the repo segment so worktrees
+ * match their parent repo's `project_repos` entry.
+ *
+ * Returns null if `repoRoot` is not under `ghqRoot` or doesn't have the
+ * expected depth (e.g. sitting directly under ghqRoot with no org segment).
+ */
+export function resolveProjectSlug(repoRoot: string, ghqRoot: string): string | null {
+  if (!repoRoot.startsWith(ghqRoot)) return null;
+  let rel = repoRoot.slice(ghqRoot.length).replace(/^\/+/, "");
+  // If ghqRoot is the bare ghq root (not github.com-rooted), rel starts with
+  // a host segment — strip known forges so we always land at "<org>/<repo>".
+  rel = rel.replace(/^(github\.com|gitlab\.com|bitbucket\.org)\//, "");
+  const parts = rel.split("/").slice(0, 2);
+  if (parts.length !== 2 || !parts[0] || !parts[1]) return null;
+  parts[1] = parts[1].replace(/\.wt-.*$/, "");
+  return parts.join("/");
+}
+
+/**
  * Find the oracle that owns a given project repo (org/repo slug).
  */
 export function findOracleForProject(projectRepo: string): string | null {
@@ -306,15 +341,7 @@ export async function cmdSoulSyncProject(opts?: { cwd?: string }): Promise<Proje
   } catch { /* not a git repo */ }
 
   // Strip ghq root → "org/repo" slug. Drop worktree suffix for matching.
-  let repoSlug: string | null = null;
-  if (repoRoot.startsWith(ghqRoot)) {
-    const rel = repoRoot.slice(ghqRoot.length).replace(/^\/+/, "");
-    const parts = rel.split("/").slice(0, 2);
-    if (parts.length === 2) {
-      parts[1] = parts[1].replace(/\.wt-.*$/, "");
-      repoSlug = parts.join("/");
-    }
-  }
+  const repoSlug = resolveProjectSlug(repoRoot, ghqRoot);
 
   const repoBase = basename(repoRoot).replace(/\.wt-.*$/, "");
   const isOracle = repoBase.endsWith("-oracle");

--- a/test/soul-sync.test.ts
+++ b/test/soul-sync.test.ts
@@ -115,6 +115,47 @@ describe("soul-sync", () => {
       expect(findOracleForProjectForTest("nobody/orphan", fleet)).toBeNull();
     });
 
+    test("resolveProjectSlug handles github.com-rooted ghqRoot (#193)", () => {
+      const { resolveProjectSlug } = require("../src/commands/soul-sync");
+      const ghqRoot = "/home/neo/Code/github.com";
+      expect(
+        resolveProjectSlug("/home/neo/Code/github.com/Soul-Brews-Studio/maw-js", ghqRoot)
+      ).toBe("Soul-Brews-Studio/maw-js");
+    });
+
+    test("resolveProjectSlug handles bare ghq root (#193 — was dropping repo segment)", () => {
+      const { resolveProjectSlug } = require("../src/commands/soul-sync");
+      const ghqRoot = "/home/neo/Code";
+      // Before the fix this returned "github.com/Soul-Brews-Studio" (org-only) —
+      // slice(0, 2) was grabbing [host, org] instead of [org, repo].
+      expect(
+        resolveProjectSlug("/home/neo/Code/github.com/Soul-Brews-Studio/maw-js", ghqRoot)
+      ).toBe("Soul-Brews-Studio/maw-js");
+    });
+
+    test("resolveProjectSlug strips worktree suffix (#193)", () => {
+      const { resolveProjectSlug } = require("../src/commands/soul-sync");
+      const ghqRoot = "/home/neo/Code/github.com";
+      expect(
+        resolveProjectSlug("/home/neo/Code/github.com/Soul-Brews-Studio/maw-js.wt-issue-193", ghqRoot)
+      ).toBe("Soul-Brews-Studio/maw-js");
+    });
+
+    test("resolveProjectSlug returns null when repoRoot is outside ghqRoot (#193)", () => {
+      const { resolveProjectSlug } = require("../src/commands/soul-sync");
+      expect(
+        resolveProjectSlug("/tmp/somewhere-else", "/home/neo/Code/github.com")
+      ).toBeNull();
+    });
+
+    test("resolveProjectSlug returns null when path has no repo segment (#193)", () => {
+      const { resolveProjectSlug } = require("../src/commands/soul-sync");
+      // Sitting at the org directory, no repo to resolve.
+      expect(
+        resolveProjectSlug("/home/neo/Code/github.com/Soul-Brews-Studio", "/home/neo/Code/github.com")
+      ).toBeNull();
+    });
+
     test("project ψ/ syncs into oracle ψ/ across all SYNC_DIRS, new files only", () => {
       // Build a fake project + oracle pair
       const PROJECT_PSI = join(TEST_DIR, "project-repo", "ψ");


### PR DESCRIPTION
## Summary

`maw soul-sync --project` failed with `no oracle owns project 'github.com/Soul-Brews-Studio'` from inside `Soul-Brews-Studio/maw-js`. The resolver was dropping the repo segment — lookup always returned null on machines where `detectGhqRoot()` returned the bare ghq root (no `github.com` subdir).

This is the same class of bug as #231 — when `ghqRoot` can be either `<root>` or `<root>/github.com`, code that joins/splits paths has to normalize both shapes.

## Root cause

Old inline logic at `src/commands/soul-sync.ts` (near line 309):

```typescript
const rel = repoRoot.slice(ghqRoot.length).replace(/^\/+/, "");
const parts = rel.split("/").slice(0, 2);
```

| Shape | `ghqRoot` | `rel` | `slice(0, 2)` | Result |
|---|---|---|---|---|
| A — github.com-rooted | `/home/neo/Code/github.com` | `Soul-Brews-Studio/maw-js` | `[org, repo]` | ✅ `Soul-Brews-Studio/maw-js` |
| B — bare ghq root | `/home/neo/Code` | `github.com/Soul-Brews-Studio/maw-js` | `[host, org]` | ❌ `github.com/Soul-Brews-Studio` |

Shape B's `repoSlug` never matched any `project_repos` entry because those are stored as `org/repo`, not `host/org`.

## Fix

Extract a pure helper `resolveProjectSlug(repoRoot, ghqRoot)` and normalize both shapes by stripping a leading forge-host segment (`github.com/`, `gitlab.com/`, `bitbucket.org/`) before taking the first two remaining segments.

```typescript
export function resolveProjectSlug(repoRoot: string, ghqRoot: string): string | null {
  if (!repoRoot.startsWith(ghqRoot)) return null;
  let rel = repoRoot.slice(ghqRoot.length).replace(/^\/+/, "");
  rel = rel.replace(/^(github\.com|gitlab\.com|bitbucket\.org)\//, "");
  const parts = rel.split("/").slice(0, 2);
  if (parts.length !== 2 || !parts[0] || !parts[1]) return null;
  parts[1] = parts[1].replace(/\.wt-.*$/, "");
  return parts.join("/");
}
```

One line replaces the inline logic at the call site:

```diff
- let repoSlug: string | null = null;
- if (repoRoot.startsWith(ghqRoot)) {
-   const rel = repoRoot.slice(ghqRoot.length).replace(/^\/+/, "");
-   const parts = rel.split("/").slice(0, 2);
-   if (parts.length === 2) {
-     parts[1] = parts[1].replace(/\.wt-.*$/, "");
-     repoSlug = parts.join("/");
-   }
- }
+ const repoSlug = resolveProjectSlug(repoRoot, ghqRoot);
```

## Regression tests

Five new tests in `test/soul-sync.test.ts` exercising the pure helper directly:

- ✅ github.com-rooted `ghqRoot` → correct slug (shape A, was already working)
- ✅ **bare ghq root → correct slug** (shape B, the regression guard that would have caught this)
- ✅ worktree suffix (`.wt-issue-193`) stripped from repo segment
- ✅ `repoRoot` outside `ghqRoot` → `null`
- ✅ path with no repo segment (sitting at org level) → `null`

## Verification

- **252 pass / 6 skip / 6 todo / 0 fail** — 264 tests total (+5 from this PR)
- Build: 161 modules, 0.29 MB — no size change
- Same suite numbers as post-merge `main` + 5 new passing tests

## Test plan

- [x] `bun test` — full suite green
- [x] `bun run build` — clean
- [x] `bun test test/soul-sync.test.ts` — 15 tests pass (was 10), all 5 new tests exercise the helper directly
- [ ] Manual: run `maw soul-sync --project` from inside `Soul-Brews-Studio/maw-js` on a machine where `detectGhqRoot()` returns the bare root — should resolve the slug correctly and sync. (Deferred to Nat for morning smoke test.)

Closes #193
Related: #231 (same class — `github.com` path normalization, addressed in #250)

---
Bonus D from the overnight cron cycle. Batch so far: #245 / #246 / #247 (merged), #250 / #8 (drafts), #230 (stale-swept), #249 (ops), this PR. Quality > quantity still the rule — next targets are #248 doc flip + maybe #215 Option A if they land clean.

🤖 ตอบโดย mawjs จาก [Human] → mawjs-oracle