### PR TITLE
feat(fleet): maw fleet init --agents — reconcile agents map (#215)

### DIFF
--- a/src/cli/route-fleet.ts
+++ b/src/cli/route-fleet.ts
@@ -1,5 +1,5 @@
 import { cmdFleetLs, cmdFleetRenumber, cmdFleetValidate, cmdFleetSync, cmdFleetSyncConfigs } from "../commands/fleet";
-import { cmdFleetInit } from "../commands/fleet-init";
+import { cmdFleetInit, cmdFleetInitAgents } from "../commands/fleet-init";
 import { cmdPulseAdd, cmdPulseLs } from "../commands/pulse";
 import { cmdOverview } from "../commands/overview";
 import { cmdMegaStatus, cmdMegaStop } from "../commands/mega";
@@ -17,7 +17,11 @@ export async function routeFleet(cmd: string, args: string[]): Promise<boolean> 
   if (cmd === "fleet") {
     const sub = args[1];
     if (sub === "init") {
-      await cmdFleetInit();
+      if (args.includes("--agents")) {
+        await cmdFleetInitAgents({ dryRun: args.includes("--dry-run") });
+      } else {
+        await cmdFleetInit();
+      }
     } else if (sub === "ls") {
       await cmdFleetLs();
     } else if (sub === "renumber") {

--- a/src/cli/usage.ts
+++ b/src/cli/usage.ts
@@ -11,6 +11,8 @@ export function usage() {
   maw wake <oracle> --issue N Wake oracle with GitHub issue as prompt
   maw wake <oracle> --incubate org/repo  Clone repo + worktree
   maw fleet init              Scan ghq repos, generate fleet/*.json
+  maw fleet init --agents     Reconcile config.agents from fleet + peers
+                              (additive, add --dry-run to preview)
   maw fleet ls                List fleet configs with conflict detection
   maw fleet renumber          Fix numbering conflicts (sequential)
   maw fleet validate          Check for problems (dupes, orphans, missing repos)

--- a/src/commands/fleet-init.ts
+++ b/src/commands/fleet-init.ts
@@ -2,6 +2,8 @@ import { join } from "path";
 import { existsSync, mkdirSync, rmSync } from "fs";
 import { hostExec } from "../ssh";
 import { FLEET_DIR } from "../paths";
+import { loadConfig, saveConfig } from "../config";
+import { loadFleet } from "./fleet-load";
 
 interface FleetWindow {
   name: string;
@@ -160,4 +162,123 @@ export async function cmdFleetInit() {
 
   console.log(`\n  \x1b[32m${sorted.length + 1} fleet configs written to fleet/\x1b[0m`);
   console.log(`  Run \x1b[36mmaw wake all\x1b[0m to start the fleet.\n`);
+}
+
+export interface FleetInitAgentsResult {
+  added: Record<string, string>;
+  existingPreserved: number;
+  peersReached: number;
+  peersFailed: string[];
+  total: number;
+}
+
+/**
+ * Reconcile `config.agents` against local fleet windows + federation peers.
+ *
+ * Mechanical, additive-only:
+ *   - Local fleet windows → agents[name] = "local" (unless already set)
+ *   - For each namedPeer, fetch {url}/api/config and adopt any entry
+ *     the peer marks as "local" → agents[name] = peer.name (unless already set)
+ *   - Never overwrites user-set values, never deletes
+ *
+ * Fixes the drift reported in #215 (boonkeeper on oracle-world had a stale
+ * agents map that cost vpnkeeper 30+ minutes diagnosing a `maw hey volt`
+ * failure). Additive-only preserves any hand-tuned overrides.
+ */
+export async function cmdFleetInitAgents(
+  opts: { dryRun?: boolean } = {},
+): Promise<FleetInitAgentsResult> {
+  const current = loadConfig();
+  const existing: Record<string, string> = { ...(current.agents || {}) };
+  const proposed: Record<string, string> = { ...existing };
+  const peersFailed: string[] = [];
+  let peersReached = 0;
+
+  console.log(`\n  \x1b[36mReconciling config.agents...\x1b[0m\n`);
+
+  // 1. Local fleet windows → "local"
+  let localScanned = 0;
+  try {
+    const fleet = loadFleet();
+    for (const sess of fleet) {
+      for (const w of sess.windows || []) {
+        if (!w?.name) continue;
+        localScanned++;
+        if (!(w.name in proposed)) proposed[w.name] = "local";
+      }
+    }
+  } catch (e: any) {
+    console.log(`  \x1b[33m⚠\x1b[0m fleet scan failed: ${e.message}`);
+  }
+
+  // 2. namedPeers → fetch {url}/api/config and adopt their "local" agents
+  for (const peer of current.namedPeers || []) {
+    if (!peer?.url || !peer?.name) continue;
+    try {
+      const res = await fetch(`${peer.url}/api/config`, {
+        signal: AbortSignal.timeout(3000),
+      });
+      if (!res.ok) {
+        peersFailed.push(`${peer.name} (HTTP ${res.status})`);
+        continue;
+      }
+      const pcfg = (await res.json()) as { agents?: Record<string, string> };
+      const peerAgents = pcfg.agents || {};
+      peersReached++;
+      for (const [name, host] of Object.entries(peerAgents)) {
+        // Only adopt entries the peer owns (host === "local") — skip their
+        // view of other peers, which may be stale on their side too.
+        if (host === "local" && !(name in proposed)) {
+          proposed[name] = peer.name;
+        }
+      }
+    } catch (e: any) {
+      peersFailed.push(`${peer.name} (${e?.message || "unknown"})`);
+    }
+  }
+
+  // 3. Diff report
+  const added: Record<string, string> = {};
+  for (const [k, v] of Object.entries(proposed)) {
+    if (existing[k] !== v) added[k] = v;
+  }
+
+  const result: FleetInitAgentsResult = {
+    added,
+    existingPreserved: Object.keys(existing).length,
+    peersReached,
+    peersFailed,
+    total: Object.keys(proposed).length,
+  };
+
+  // Render
+  console.log(
+    `  scanned: \x1b[36m${localScanned}\x1b[0m local window(s), \x1b[36m${peersReached}\x1b[0m peer(s) reached`,
+  );
+  if (peersFailed.length > 0) {
+    console.log(`  \x1b[33m⚠\x1b[0m peers unreachable: ${peersFailed.join(", ")}`);
+  }
+  console.log(`  preserved: \x1b[36m${Object.keys(existing).length}\x1b[0m existing entries`);
+
+  const addedKeys = Object.keys(added);
+  if (addedKeys.length === 0) {
+    console.log(`\n  \x1b[32m○\x1b[0m agents map already in sync (${Object.keys(proposed).length} entries)\n`);
+    return result;
+  }
+
+  console.log(`\n  new entries (${addedKeys.length}):`);
+  const pad = Math.max(...addedKeys.map(k => k.length));
+  for (const k of addedKeys.sort()) {
+    const host = added[k] === "local" ? "\x1b[32mlocal\x1b[0m" : `\x1b[36m${added[k]}\x1b[0m`;
+    console.log(`    \x1b[32m+\x1b[0m ${k.padEnd(pad)}  →  ${host}`);
+  }
+
+  if (opts.dryRun) {
+    console.log(`\n  \x1b[33mdry-run:\x1b[0m no changes written (run without --dry-run to apply)\n`);
+    return result;
+  }
+
+  saveConfig({ agents: proposed });
+  console.log(`\n  \x1b[32m✓\x1b[0m wrote ${addedKeys.length} new entries to config.agents (${Object.keys(proposed).length} total)\n`);
+  return result;
 }

--- a/test/fleet-init-agents.test.ts
+++ b/test/fleet-init-agents.test.ts
@@ -1,0 +1,149 @@
+import { describe, test, expect } from "bun:test";
+
+// The cmdFleetInitAgents function lives in src/commands/fleet-init.ts and
+// depends on loadConfig/saveConfig/loadFleet/fetch — side-effecty stuff we
+// don't want to stand up in a unit test. Extract the pure merge logic
+// inline here and test it directly. Keep the algorithm identical to the
+// real command: additive-only, never overwrite, "local" wins over peer
+// attribution when collisions happen via fleet scan, peer attribution
+// only adopts entries that peer marked as "local".
+
+interface Peer { name: string; agents: Record<string, string>; }
+interface FleetWindow { name: string; }
+interface FleetSession { windows: FleetWindow[]; }
+
+function mergeAgents(
+  existing: Record<string, string>,
+  fleet: FleetSession[],
+  peers: Peer[],
+): Record<string, string> {
+  const proposed: Record<string, string> = { ...existing };
+
+  for (const sess of fleet) {
+    for (const w of sess.windows || []) {
+      if (!w?.name) continue;
+      if (!(w.name in proposed)) proposed[w.name] = "local";
+    }
+  }
+
+  for (const peer of peers) {
+    for (const [name, host] of Object.entries(peer.agents)) {
+      if (host === "local" && !(name in proposed)) proposed[name] = peer.name;
+    }
+  }
+
+  return proposed;
+}
+
+describe("fleet init --agents (#215)", () => {
+  test("adds missing local fleet windows to agents map", () => {
+    const existing = {};
+    const fleet: FleetSession[] = [
+      { windows: [{ name: "pulse-oracle" }, { name: "neo-oracle" }] },
+      { windows: [{ name: "mawjs-oracle" }] },
+    ];
+    const result = mergeAgents(existing, fleet, []);
+    expect(result).toEqual({
+      "pulse-oracle": "local",
+      "neo-oracle": "local",
+      "mawjs-oracle": "local",
+    });
+  });
+
+  test("preserves existing user-set entries — never overwrites", () => {
+    const existing = {
+      // user manually pinned volt to mba (maybe it's on a different host)
+      volt: "mba",
+      // local override that should not be replaced even though fleet says "local"
+      "pulse-oracle": "white",
+    };
+    const fleet: FleetSession[] = [
+      { windows: [{ name: "pulse-oracle" }, { name: "neo-oracle" }] },
+    ];
+    const result = mergeAgents(existing, fleet, []);
+    expect(result.volt).toBe("mba");               // untouched
+    expect(result["pulse-oracle"]).toBe("white");  // not replaced with "local"
+    expect(result["neo-oracle"]).toBe("local");    // new, added
+  });
+
+  test("adopts peer's local agents under peer.name", () => {
+    const existing = {};
+    const fleet: FleetSession[] = [];
+    const peers: Peer[] = [
+      {
+        name: "white",
+        agents: {
+          pulse: "local",
+          floodboy: "local",
+          fireman: "local",
+          // peer's view of ANOTHER peer — should NOT be adopted, shapes drift
+          homekeeper: "mba",
+        },
+      },
+    ];
+    const result = mergeAgents(existing, fleet, peers);
+    expect(result).toEqual({
+      pulse: "white",
+      floodboy: "white",
+      fireman: "white",
+      // homekeeper: "mba" NOT copied — we only trust each peer for what it owns
+    });
+  });
+
+  test("local wins over peer attribution when both present", () => {
+    const existing = {};
+    const fleet: FleetSession[] = [
+      { windows: [{ name: "mawjs-oracle" }] },
+    ];
+    const peers: Peer[] = [
+      {
+        name: "white",
+        // white ALSO claims mawjs-oracle (it exists on both nodes as a bud)
+        agents: { "mawjs-oracle": "local" },
+      },
+    ];
+    const result = mergeAgents(existing, fleet, peers);
+    // Local scan runs first, so mawjs-oracle gets "local" and the peer
+    // adoption loop skips it because it's already present.
+    expect(result["mawjs-oracle"]).toBe("local");
+  });
+
+  test("multi-peer merge without collisions", () => {
+    const existing = {};
+    const fleet: FleetSession[] = [
+      { windows: [{ name: "mawjs-oracle" }] },
+    ];
+    const peers: Peer[] = [
+      { name: "white", agents: { pulse: "local", floodboy: "local" } },
+      { name: "mba", agents: { homekeeper: "local", vpnkeeper: "local" } },
+      { name: "clinic-nat", agents: { neo: "local" } },
+    ];
+    const result = mergeAgents(existing, fleet, peers);
+    expect(result).toEqual({
+      "mawjs-oracle": "local",
+      pulse: "white",
+      floodboy: "white",
+      homekeeper: "mba",
+      vpnkeeper: "mba",
+      neo: "clinic-nat",
+    });
+  });
+
+  test("handles empty peers and empty fleet (no-op)", () => {
+    const existing = { already: "here" };
+    const result = mergeAgents(existing, [], []);
+    expect(result).toEqual({ already: "here" });
+  });
+
+  test("skips windows with missing name gracefully", () => {
+    const existing = {};
+    const fleet: FleetSession[] = [
+      { windows: [{ name: "" }, { name: "pulse-oracle" }] },
+      // @ts-expect-error — intentionally malformed window to exercise the guard
+      { windows: [{ name: null }] },
+    ];
+    const result = mergeAgents(existing, fleet, []);
+    // Only the valid window is added; empty/null are skipped.
+    expect(result).toEqual({ "pulse-oracle": "local" });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `maw fleet init --agents` — Option A from #215, mechanical reconciliation of `config.agents` from fleet/*.json + namedPeers
- Additive-only: never overwrites user-set entries, never deletes
- `--dry-run` flag to preview changes before writing
- 7 new focused tests for the pure merge logic + full suite stays green
- Smoke-tested live on oracle-world (found 2 real drift entries)

## Behavior

1. **Local scan** — walk `fleet/*.json`, map each `windows[*].name` → `"local"` if not already in `config.agents`
2. **Peer scan** — for each `namedPeers[*]`, GET `{url}/api/config` (v1 public endpoint documented in #248), adopt entries the peer marks as `"local"` and map to `peer.name`. Skip entries the peer attributes to other peers (we only trust each peer for what it owns, to avoid cascading stale views).
3. **Additive-only** — existing entries survive even when fleet/peer scan would suggest otherwise. Hand-tuned overrides persist.
4. **Diff report** — shows new entries with color coding, counts scanned windows / peers reached / peers unreachable / existing preserved.

## Live smoke test (oracle-world, --dry-run)

\`\`\`
  Reconciling config.agents...

  scanned: 6 local window(s), 3 peer(s) reached
  preserved: 21 existing entries

  new entries (2):
    + boonkeeper-oracle   →  local
    + whitekeeper-oracle  →  local

  dry-run: no changes written (run without --dry-run to apply)
\`\`\`

Two real drift entries — exactly the class of drift #215 reports. The agents map had 21 entries but the local fleet had 2 windows that were never registered. With \`--agents\`, \`maw hey boonkeeper-oracle\` on this host will resolve cleanly instead of failing with a generic "send failed".

## Why Option A (vs B/C)

- **Mechanical**: no daemon, no reconcile loop, no background process
- **Explicit**: user runs it when they want a rebuild, deterministic output
- **Safe**: additive-only means worst case is "more entries than needed", never "lost my override"
- **Builds on #248**: uses the v1 public API surface we just documented — each peer's \`/api/config.agents\` is the canonical self-description, consumed the same way the maw-ui lens consumes it. Soul of the fleet API grounds both the lens AND the CLI.

## What stays open

Option B (daemon auto-reconcile on startup) and Option C (both) remain viable if drift continues without manual reconciliation. File a follow-up issue if it does. This PR ships the smallest useful slice.

## Verification

- \`bun test test/fleet-init-agents.test.ts\` — 7/7 pass
- \`bun test\` — 259 pass / 6 skip / 6 todo / 0 fail (+7 from this PR, was 252)
- \`bun run build\` — 161 modules, 0.30 MB
- Live smoke on oracle-world (--dry-run, no writes)

## Closes

Closes #215

Related: #248 (v1 federation API docs — this PR consumes the same surface), #201 (shared resolver that will use this agents map once both land).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) by mawjs-oracle