### PR TITLE
fix(bud): reorder worktree regex strip — .wt- before -oracle

### DIFF
--- a/src/commands/bud.ts
+++ b/src/commands/bud.ts
@@ -52,7 +52,7 @@ export async function cmdBud(name: string, opts: BudOpts = {}) {
     try {
       const cwd = (await hostExec("tmux display-message -p '#{pane_current_path}'")).trim();
       const repoName = cwd.split("/").pop() || "";
-      parentName = repoName.replace(/-oracle$/, "").replace(/\.wt-.*$/, "");
+      parentName = repoName.replace(/\.wt-.*$/, "").replace(/-oracle$/, "");
     } catch {
       console.error("  \x1b[31m✗\x1b[0m could not detect parent oracle. Use --from <oracle> or --root");
       process.exit(1);

--- a/test/bud-root.test.ts
+++ b/test/bud-root.test.ts
@@ -25,7 +25,7 @@ function resolveParent(
   let parentName: string | null = opts.from || null;
   if (!parentName && !opts.root) {
     if (tmuxCwdName === null) return "ERROR"; // cmdBud would process.exit(1)
-    parentName = tmuxCwdName.replace(/-oracle$/, "").replace(/\.wt-.*$/, "");
+    parentName = tmuxCwdName.replace(/\.wt-.*$/, "").replace(/-oracle$/, "");
   }
   return parentName;
 }
@@ -88,13 +88,14 @@ describe("maw bud --root — parent resolution", () => {
     expect(resolveParent({}, "mawjs-oracle")).toBe("mawjs");
   });
 
-  test("no --root, no --from, worktree cwd → .wt- suffix stripped (pre-existing regex order leaves -oracle)", () => {
-    // NOTE: bud.ts currently runs `.replace(/-oracle$/)` BEFORE `.replace(/\.wt-.*$/)`,
-    // so for "mawjs-oracle.wt-feat-x" the -oracle$ match fails (because .wt- is
-    // at the end), only the .wt- suffix is stripped. Result is "mawjs-oracle",
-    // not "mawjs". This is pre-existing (not PR #254) and worth filing, but
-    // the test documents actual behavior so regressions here are visible.
-    expect(resolveParent({}, "mawjs-oracle.wt-feat-x")).toBe("mawjs-oracle");
+  test("no --root, no --from, worktree cwd → .wt- suffix AND -oracle stripped", () => {
+    // Fix for #255: bud.ts now runs `.replace(/\.wt-.*$/)` BEFORE `.replace(/-oracle$/)`,
+    // so "mawjs-oracle.wt-feat-x" → "mawjs-oracle" → "mawjs" (correct parent name).
+    // Before the fix, only .wt- was stripped (because -oracle$ didn't match the
+    // .wt-suffixed string) and the result was "mawjs-oracle", which silently
+    // corrupted lineage fields (budded_from, sync_peers lookup miss, soul-sync
+    // seed target miss) when budding from any worktree.
+    expect(resolveParent({}, "mawjs-oracle.wt-feat-x")).toBe("mawjs");
   });
 
   test("no --root, no --from, no tmux cwd → error sentinel (would process.exit)", () => {


### PR DESCRIPTION
## Summary

Fix #255 — pre-existing regex-order bug in `cmdBud`'s tmux-cwd parent auto-detect. When `maw bud` was invoked from a worktree cwd like `mawjs-oracle.wt-feat-x`, the parent name came out as `mawjs-oracle` (non-existent oracle) instead of `mawjs`, silently corrupting lineage fields.

## Root cause

`src/commands/bud.ts:55` ran:
```ts
repoName.replace(/-oracle$/, "").replace(/\.wt-.*$/, "")
```

For `mawjs-oracle.wt-feat-x`, the `-oracle$` anchor didn't match (because `.wt-feat-x` is at the end), so only `.wt-*` was stripped. Result: `mawjs-oracle`.

## Downstream effects (silent)

- `budded_from` field in fleet config got `mawjs-oracle`
- `sync_peers` lookup iterated fleet entries by stripped name (`mawjs`), never matching `mawjs-oracle` → parent sync_peers update silently skipped
- Soul-sync seed target missed for the same reason → warning, not error
- CLAUDE.md lineage header cited a non-existent parent

No crash, no error — just corrupted lineage for any `maw bud` run from a worktree.

## Fix

Swap the regex order:
```ts
repoName.replace(/\.wt-.*$/, "").replace(/-oracle$/, "")
```

Now `.wt-*` is stripped first → intermediate `mawjs-oracle` → then `-oracle$` matches → `mawjs`. Non-worktree cwds (`mawjs-oracle`) still resolve correctly because the first replace is a no-op.

## Test lockstep

`test/bud-root.test.ts` inlines the same regex order in its helper (per the file's own lockstep warning comment). Both were updated together. The test case that previously pinned the buggy behavior (`expect(resolveParent(...)).toBe("mawjs-oracle")`) now pins the correct behavior (`toBe("mawjs")`), and the NOTE comment documents the fix instead of the bug.

## Test plan
- [x] `bun test test/bud-root.test.ts` — 14/14 pass
- [x] `bun test` — 285 pass, 0 fail, no regressions
- [x] `bun run build` — clean bundle (161 modules, 18ms)
- [x] Closes #255

## Provenance

Filed by `[oracle-world:mawjs]` after writing the test in PR #254 that documented the buggy behavior as a pre-existing regression guard. This PR closes the loop.

Co-authored with `[white:mawjs]` via federation handshake (right-of-refusal granted on autonomous-shaped scope).

🤖 ตอบโดย mawjs จาก [Nat] → mawjs-oracle

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>