### PR TITLE
feat(contacts): add --inbox and --repo flags to match canonical schema

### DIFF
--- a/src/commands/contacts.ts
+++ b/src/commands/contacts.ts
@@ -6,6 +6,8 @@ import { loadConfig } from "../config";
 interface Contact {
   maw?: string;
   thread?: string;
+  inbox?: string | null;
+  repo?: string | null;
   notes?: string;
   retired?: boolean;
 }
@@ -44,8 +46,10 @@ export async function cmdContactsLs() {
   for (const [name, c] of active) {
     const maw = c.maw ? `maw: \x1b[33m${c.maw}\x1b[0m` : "";
     const thread = c.thread ? `thread: \x1b[90m${c.thread}\x1b[0m` : "";
+    const inbox = c.inbox ? `inbox: \x1b[90m${c.inbox}\x1b[0m` : "";
+    const repo = c.repo ? `repo: \x1b[90m${c.repo}\x1b[0m` : "";
     const notes = c.notes ? `\x1b[90m"${c.notes}"\x1b[0m` : "";
-    const parts = [maw, thread, notes].filter(Boolean).join("    ");
+    const parts = [maw, thread, inbox, repo, notes].filter(Boolean).join("    ");
     console.log(`  \x1b[32m${name.padEnd(12)}\x1b[0m  ${parts}`);
   }
   console.log();
@@ -57,6 +61,8 @@ export async function cmdContactsAdd(name: string, args: string[]) {
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--maw" && args[i + 1]) c.maw = args[++i];
     else if (args[i] === "--thread" && args[i + 1]) c.thread = args[++i];
+    else if (args[i] === "--inbox" && args[i + 1]) c.inbox = args[++i];
+    else if (args[i] === "--repo" && args[i + 1]) c.repo = args[++i];
     else if (args[i] === "--notes" && args[i + 1]) c.notes = args[++i];
   }
   if (c.retired) delete c.retired;

--- a/test/contacts.test.ts
+++ b/test/contacts.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for `maw contacts add` — flag parsing + canonical schema fields.
+ *
+ * Background: the /contacts skill canonical schema (SKILL.md) specifies five
+ * per-contact fields: `maw`, `thread`, `inbox`, `repo`, `notes`. The maw-js
+ * CLI originally supported only three (`--maw`, `--thread`, `--notes`), so
+ * contacts written by other oracles via /contacts came through canonical but
+ * `maw contacts add` couldn't populate `inbox` or `repo`. This test locks the
+ * fix: all five flags parse, persist, and round-trip through the JSON file.
+ *
+ * Following the bud-root.test.ts convention, we exercise cmdContactsAdd by
+ * pointing cwd at a temp dir so the fs writes are isolated and deterministic.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, readFileSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { cmdContactsAdd } from "../src/commands/contacts";
+
+let tmp: string;
+let prevCwd: string;
+
+beforeEach(() => {
+  prevCwd = process.cwd();
+  tmp = mkdtempSync(join(tmpdir(), "maw-contacts-test-"));
+  // Pre-create ψ/ so resolvePsiPath() picks the canonical unicode branch
+  // instead of falling through to the romanized "psi" fallback.
+  mkdirSync(join(tmp, "ψ"), { recursive: true });
+  process.chdir(tmp);
+});
+
+afterEach(() => {
+  process.chdir(prevCwd);
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function readContacts(): any {
+  const path = join(tmp, "ψ", "contacts.json");
+  expect(existsSync(path)).toBe(true);
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+describe("cmdContactsAdd — canonical schema flag parsing", () => {
+  test("--maw / --thread / --notes still work (regression)", async () => {
+    await cmdContactsAdd("alpha", ["--maw", "a:agent", "--thread", "ch:alpha", "--notes", "first"]);
+    const data = readContacts();
+    expect(data.contacts.alpha).toEqual({
+      maw: "a:agent",
+      thread: "ch:alpha",
+      notes: "first",
+    });
+  });
+
+  test("--inbox flag persists inbox field", async () => {
+    await cmdContactsAdd("beta", ["--inbox", "https://ex.com/inbox"]);
+    const data = readContacts();
+    expect(data.contacts.beta.inbox).toBe("https://ex.com/inbox");
+  });
+
+  test("--repo flag persists repo field", async () => {
+    await cmdContactsAdd("gamma", ["--repo", "laris-co/gamma-oracle"]);
+    const data = readContacts();
+    expect(data.contacts.gamma.repo).toBe("laris-co/gamma-oracle");
+  });
+
+  test("all five canonical flags together round-trip cleanly", async () => {
+    await cmdContactsAdd("delta", [
+      "--maw", "white:delta",
+      "--thread", "channel:delta",
+      "--inbox", "https://delta.example/inbox",
+      "--repo", "Soul-Brews-Studio/delta-oracle",
+      "--notes", "canonical five-field contact",
+    ]);
+    const data = readContacts();
+    expect(data.contacts.delta).toEqual({
+      maw: "white:delta",
+      thread: "channel:delta",
+      inbox: "https://delta.example/inbox",
+      repo: "Soul-Brews-Studio/delta-oracle",
+      notes: "canonical five-field contact",
+    });
+  });
+
+  test("second add call merges new fields into existing contact (update semantics)", async () => {
+    await cmdContactsAdd("epsilon", ["--maw", "e:agent", "--thread", "ch:e"]);
+    await cmdContactsAdd("epsilon", ["--inbox", "https://e.inbox", "--repo", "o/e"]);
+    const data = readContacts();
+    expect(data.contacts.epsilon).toEqual({
+      maw: "e:agent",
+      thread: "ch:e",
+      inbox: "https://e.inbox",
+      repo: "o/e",
+    });
+  });
+
+  test("contacts.json has canonical top-level shape (contacts + updated only)", async () => {
+    await cmdContactsAdd("zeta", ["--maw", "z:agent"]);
+    const data = readContacts();
+    expect(Object.keys(data).sort()).toEqual(["contacts", "updated"]);
+    expect(typeof data.updated).toBe("string");
+  });
+});


### PR DESCRIPTION
## Summary

- Extend `Contact` interface with `inbox?: string | null` and `repo?: string | null`
- Parse `--inbox` and `--repo` in `cmdContactsAdd` alongside existing flags
- Render inbox and repo in `cmdContactsLs` between thread and notes
- Add `test/contacts.test.ts` — six regression tests covering flag parsing, round-trip persistence, update semantics, and canonical top-level shape

## Why

The `/contacts` skill SKILL.md specifies **five** per-contact fields: `maw`, `thread`, `inbox`, `repo`, `notes`. The maw-js CLI only supported three (`--maw`, `--thread`, `--notes`), so contacts written via the skill came through canonical but couldn't be populated or updated through the CLI, and `maw contacts ls` silently dropped `inbox` and `repo` from display.

This was discovered during a schema-drift incident in mawui-oracle (2026-04-11) where the `/contacts` skill was re-affirmed as the canonical contract owner and all five oracles were re-aligned to the five-field shape. This PR closes the loop by bringing the maw-js CLI into agreement with the skill.

Dual routing (`cmd === 'contacts' || cmd === 'contact'`) was already present at `src/cli/route-tools.ts:51` — no routing changes needed.

## Example

```
$ maw contacts add mawjs-oracle \
    --maw mawjs-oracle \
    --thread channel:mawjs-oracle \
    --inbox https://oracle-world.example/inbox/mawjs \
    --repo Soul-Brews-Studio/mawjs-oracle \
    --notes "Hub oracle for cross-oracle coordination"

$ maw contacts ls
CONTACTS (1):
  mawjs-oracle  maw: mawjs-oracle    thread: channel:mawjs-oracle    inbox: https://...    repo: Soul-Brews-Studio/mawjs-oracle    "Hub oracle..."
```

## Test plan

- [x] `bun test test/contacts.test.ts` — 6 pass, 0 fail
- [x] `bun test` full suite — 279 pass, 0 fail
- [x] Live `bun src/cli.ts contacts ls` against real mawui-oracle `ψ/contacts.json` — renders `repo` field for 6 of 9 contacts (others have `repo: null` by design, correctly hidden)
- [x] Live `bun src/cli.ts contact add <name> --inbox X --repo Y` (singular dual-route) — writes + ls round-trip confirmed

---

Co-authored with Nat (human). Patch authored by **mawui-oracle** — the Living Lens 👁.