### PR TITLE
feat(ui): maw ui — print local lens URL, --tunnel prints SSH command

### DIFF
--- a/src/cli/route-tools.ts
+++ b/src/cli/route-tools.ts
@@ -11,8 +11,13 @@ import { cmdPr } from "../commands/pr";
 import { cmdCosts } from "../commands/costs";
 import { cmdTriggers } from "../commands/triggers";
 import { cmdHealth } from "../commands/health";
+import { cmdUi } from "../commands/ui";
 
 export async function routeTools(cmd: string, args: string[]): Promise<boolean> {
+  if (cmd === "ui") {
+    await cmdUi(args.slice(1));
+    return true;
+  }
   if (cmd === "view" || cmd === "create-view" || cmd === "attach" || cmd === "a") {
     if (!args[1]) { console.error("usage: maw view <agent> [window] [--clean]"); process.exit(1); }
     const clean = args.includes("--clean");

--- a/src/commands/ui.ts
+++ b/src/commands/ui.ts
@@ -1,0 +1,185 @@
+/**
+ * `maw ui` — print the URL (and SSH command if needed) to open the federation
+ * lens. **Transparent by design** — this command never spawns SSH, never opens
+ * a browser, never backgrounds a process. It just prints what the user should
+ * run, and the user runs it.
+ *
+ * Why transparent: the wrapper version had to manage SSH ControlMaster sockets,
+ * detect port conflicts, fork to background, and handle browser-open across
+ * three platforms. All of that is process plumbing the user can do better with
+ * their eyeballs and one paste. Print the command, get out of the way.
+ *
+ * ## Usage
+ *
+ *   maw ui                       — print local lens URL
+ *   maw ui <peer>                — print local lens URL with ?host=<peer>
+ *   maw ui --tunnel <peer>       — print SSH dual-port tunnel command + URL
+ *   maw ui --3d                  — use federation.html (3D) instead of 2D
+ *
+ * ## Output is structured for copy-paste
+ *
+ *   $ maw ui
+ *   http://localhost:5173/federation_2d.html
+ *
+ *   $ maw ui white
+ *   http://localhost:5173/federation_2d.html?host=10.20.0.7%3A3456
+ *
+ *   $ maw ui --tunnel oracle-world
+ *   # Run this on your local machine:
+ *   ssh -N -L 5173:localhost:5173 -L 3456:localhost:3456 neo@10.20.0.16
+ *
+ *   # Then open:
+ *   http://localhost:5173/federation_2d.html
+ *
+ * The output is shell-safe: comments start with `#`, the SSH command and the
+ * URL each live on their own line, and there are no ANSI escapes around the
+ * load-bearing text. You can pipe `maw ui --tunnel oracle-world` into a
+ * script if you want.
+ */
+
+import { loadConfig } from "../config";
+
+// ---- Constants -----------------------------------------------------------
+
+const LENS_PORT = 5173;
+const MAW_PORT = 3456;
+const LENS_PAGE_2D = "federation_2d.html";
+const LENS_PAGE_3D = "federation.html";
+
+// ---- Types ---------------------------------------------------------------
+
+export interface UiOptions {
+  peer?: string;
+  tunnel?: boolean;
+  threeD?: boolean;
+}
+
+// ---- Pure helpers (testable) ---------------------------------------------
+
+/**
+ * Resolve a peer name to a host[:port]. Returns null if unknown. Accepts:
+ *   - A bare named peer from `config.namedPeers`
+ *   - A literal `host:port`
+ *   - A literal hostname
+ */
+export function resolvePeerHostPort(peer: string): string | null {
+  const trimmed = peer.trim();
+  if (!trimmed) return null;
+
+  const config = loadConfig() as any;
+  const namedPeers: Array<{ name: string; url: string }> = config?.namedPeers ?? [];
+  const named = namedPeers.find((p) => p.name === trimmed);
+  if (named) {
+    return named.url.replace(/^https?:\/\//, "").replace(/\/$/, "");
+  }
+
+  if (/^[a-zA-Z0-9][a-zA-Z0-9.\-]*(?::\d+)?$/.test(trimmed)) {
+    return trimmed;
+  }
+
+  return null;
+}
+
+/** Pull just the hostname from a host[:port] string. */
+export function justHost(hostPort: string): string {
+  return hostPort.split(":")[0];
+}
+
+/** Build the lens URL the user should open in their browser. */
+export function buildLensUrl(opts: {
+  remoteHost?: string;
+  threeD?: boolean;
+}): string {
+  const page = opts.threeD ? LENS_PAGE_3D : LENS_PAGE_2D;
+  const base = `http://localhost:${LENS_PORT}/${page}`;
+  if (!opts.remoteHost) return base;
+  return `${base}?host=${encodeURIComponent(opts.remoteHost)}`;
+}
+
+/**
+ * Build the SSH dual-port forward command as a single shell-paste-ready
+ * string. Forwards BOTH the lens port (5173) and the maw-js API port
+ * (3456) so the user can hit both `http://localhost:5173/federation_2d.html`
+ * AND run `maw <cmd>` against the remote backend transparently.
+ *
+ * Uses `-N` (no remote command) but NOT `-f` — the user runs this in a
+ * foreground terminal and Ctrl+C kills the tunnel. Transparent lifecycle.
+ */
+export function buildTunnelCommand(args: { user: string; host: string }): string {
+  return (
+    `ssh -N ` +
+    `-L ${LENS_PORT}:localhost:${LENS_PORT} ` +
+    `-L ${MAW_PORT}:localhost:${MAW_PORT} ` +
+    `${args.user}@${args.host}`
+  );
+}
+
+/**
+ * Render the full output that `maw ui` prints, given the parsed options.
+ * Returns a single string with newlines so tests can assert on it without
+ * having to capture stdout. The CLI just prints this verbatim.
+ */
+export function renderUiOutput(opts: UiOptions): string {
+  // --tunnel mode
+  if (opts.tunnel) {
+    if (!opts.peer) {
+      return [
+        "# usage: maw ui --tunnel <peer>",
+        "# example: maw ui --tunnel oracle-world",
+      ].join("\n");
+    }
+    const hostPort = resolvePeerHostPort(opts.peer);
+    if (!hostPort) {
+      return [
+        `# unknown peer: ${opts.peer}`,
+        `# expected a named peer (config.namedPeers) or literal host:port`,
+      ].join("\n");
+    }
+    const host = justHost(hostPort);
+    const user = process.env.USER || "neo";
+    const sshCmd = buildTunnelCommand({ user, host });
+    const url = buildLensUrl({ threeD: opts.threeD });
+    return [
+      `# Run this on your local machine to forward both lens (${LENS_PORT}) and maw-js (${MAW_PORT}):`,
+      sshCmd,
+      ``,
+      `# Then open in your browser:`,
+      url,
+      ``,
+      `# Stop the tunnel with Ctrl+C in the SSH terminal.`,
+    ].join("\n");
+  }
+
+  // Bare or <peer> mode — just print the URL
+  if (opts.peer) {
+    const hostPort = resolvePeerHostPort(opts.peer);
+    if (!hostPort) {
+      return [
+        `# unknown peer: ${opts.peer}`,
+        `# expected a named peer (config.namedPeers) or literal host:port`,
+      ].join("\n");
+    }
+    return buildLensUrl({ remoteHost: hostPort, threeD: opts.threeD });
+  }
+
+  return buildLensUrl({ threeD: opts.threeD });
+}
+
+// ---- Arg parser ----------------------------------------------------------
+
+export function parseUiArgs(args: string[]): UiOptions {
+  const opts: UiOptions = {};
+  for (const a of args) {
+    if (a === "--tunnel") opts.tunnel = true;
+    else if (a === "--3d") opts.threeD = true;
+    else if (!a.startsWith("--") && !opts.peer) opts.peer = a;
+  }
+  return opts;
+}
+
+// ---- Public entry --------------------------------------------------------
+
+export async function cmdUi(args: string[]): Promise<void> {
+  const opts = parseUiArgs(args);
+  console.log(renderUiOutput(opts));
+}

--- a/test/ui.test.ts
+++ b/test/ui.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Tests for `maw ui` — pure helpers + the rendered output. The command is
+ * print-only by design (no SSH spawn, no browser open, no process
+ * management), so EVERYTHING is unit-testable: the helpers return strings,
+ * renderUiOutput returns a string, the command just prints it.
+ */
+
+import { describe, test, expect } from "bun:test";
+import {
+  resolvePeerHostPort,
+  justHost,
+  buildLensUrl,
+  buildTunnelCommand,
+  parseUiArgs,
+  renderUiOutput,
+} from "../src/commands/ui";
+
+// ---- resolvePeerHostPort -------------------------------------------------
+
+describe("resolvePeerHostPort", () => {
+  test("literal host:port → returns as-is", () => {
+    expect(resolvePeerHostPort("10.20.0.16:3456")).toBe("10.20.0.16:3456");
+    expect(resolvePeerHostPort("oracle-world:3456")).toBe("oracle-world:3456");
+  });
+
+  test("bare hostname → returns as-is", () => {
+    expect(resolvePeerHostPort("oracle-world")).toBe("oracle-world");
+  });
+
+  test("hostnames with dots and dashes", () => {
+    expect(resolvePeerHostPort("white.local:3456")).toBe("white.local:3456");
+    expect(resolvePeerHostPort("my-oracle.example.com:3456")).toBe(
+      "my-oracle.example.com:3456",
+    );
+  });
+
+  test("empty / whitespace → null", () => {
+    expect(resolvePeerHostPort("")).toBeNull();
+    expect(resolvePeerHostPort("   ")).toBeNull();
+  });
+
+  test("garbage → null", () => {
+    expect(resolvePeerHostPort("not a valid host!!!")).toBeNull();
+    expect(resolvePeerHostPort("@#$%")).toBeNull();
+  });
+});
+
+// ---- justHost ------------------------------------------------------------
+
+describe("justHost", () => {
+  test("strips port from host:port", () => {
+    expect(justHost("oracle-world:3456")).toBe("oracle-world");
+    expect(justHost("10.20.0.16:5173")).toBe("10.20.0.16");
+  });
+
+  test("returns hostname unchanged when no port", () => {
+    expect(justHost("oracle-world")).toBe("oracle-world");
+  });
+});
+
+// ---- buildLensUrl --------------------------------------------------------
+
+describe("buildLensUrl", () => {
+  test("default = 2D, no host param", () => {
+    expect(buildLensUrl({})).toBe("http://localhost:5173/federation_2d.html");
+  });
+
+  test("--3d uses federation.html", () => {
+    expect(buildLensUrl({ threeD: true })).toBe("http://localhost:5173/federation.html");
+  });
+
+  test("remoteHost adds URL-encoded ?host=", () => {
+    expect(buildLensUrl({ remoteHost: "10.20.0.7:3456" })).toBe(
+      "http://localhost:5173/federation_2d.html?host=10.20.0.7%3A3456",
+    );
+  });
+
+  test("3d + remoteHost combine", () => {
+    expect(buildLensUrl({ threeD: true, remoteHost: "10.20.0.7:3456" })).toBe(
+      "http://localhost:5173/federation.html?host=10.20.0.7%3A3456",
+    );
+  });
+});
+
+// ---- buildTunnelCommand --------------------------------------------------
+
+describe("buildTunnelCommand", () => {
+  test("returns a single shell-paste-ready string", () => {
+    const cmd = buildTunnelCommand({ user: "neo", host: "10.20.0.16" });
+    expect(typeof cmd).toBe("string");
+    expect(cmd.startsWith("ssh ")).toBe(true);
+  });
+
+  test("forwards both lens (5173) and maw-js (3456) ports", () => {
+    const cmd = buildTunnelCommand({ user: "neo", host: "10.20.0.16" });
+    expect(cmd).toContain("-L 5173:localhost:5173");
+    expect(cmd).toContain("-L 3456:localhost:3456");
+  });
+
+  test("uses -N (no remote command) for foreground tunnel lifecycle", () => {
+    // Transparent design: NO -f, NO -M, NO control socket. The user runs
+    // this in a real terminal and Ctrl+C kills it.
+    const cmd = buildTunnelCommand({ user: "neo", host: "10.20.0.16" });
+    expect(cmd).toContain("-N");
+    expect(cmd).not.toContain("-f");
+    expect(cmd).not.toContain("-M");
+    expect(cmd).not.toContain("-S");
+    expect(cmd).not.toContain("ControlMaster");
+  });
+
+  test("user@host is the final positional", () => {
+    const cmd = buildTunnelCommand({ user: "neo", host: "10.20.0.16" });
+    expect(cmd.endsWith("neo@10.20.0.16")).toBe(true);
+  });
+});
+
+// ---- parseUiArgs ---------------------------------------------------------
+
+describe("parseUiArgs", () => {
+  test("empty args → empty options", () => {
+    expect(parseUiArgs([])).toEqual({});
+  });
+
+  test("bare positional → peer", () => {
+    expect(parseUiArgs(["white"])).toEqual({ peer: "white" });
+  });
+
+  test("--tunnel + peer", () => {
+    expect(parseUiArgs(["--tunnel", "oracle-world"])).toEqual({
+      tunnel: true,
+      peer: "oracle-world",
+    });
+  });
+
+  test("flag order doesn't matter", () => {
+    expect(parseUiArgs(["oracle-world", "--tunnel"])).toEqual({
+      tunnel: true,
+      peer: "oracle-world",
+    });
+  });
+
+  test("--3d", () => {
+    expect(parseUiArgs(["--3d"])).toEqual({ threeD: true });
+  });
+
+  test("--3d combines with peer", () => {
+    expect(parseUiArgs(["white", "--3d"])).toEqual({ peer: "white", threeD: true });
+  });
+
+  test("unknown flags silently ignored (forward-compatible)", () => {
+    expect(parseUiArgs(["white", "--unknown"])).toEqual({ peer: "white" });
+  });
+
+  test("first positional wins", () => {
+    expect(parseUiArgs(["white", "oracle-world"])).toEqual({ peer: "white" });
+  });
+});
+
+// ---- renderUiOutput — the load-bearing surface --------------------------
+
+describe("renderUiOutput — bare mode", () => {
+  test("no args → just the local URL on one line", () => {
+    const out = renderUiOutput({});
+    expect(out).toBe("http://localhost:5173/federation_2d.html");
+    // No comments, no extra noise — pipe-friendly.
+    expect(out).not.toContain("#");
+    expect(out.split("\n").length).toBe(1);
+  });
+
+  test("--3d → federation.html", () => {
+    const out = renderUiOutput({ threeD: true });
+    expect(out).toBe("http://localhost:5173/federation.html");
+  });
+});
+
+describe("renderUiOutput — peer mode", () => {
+  test("literal peer → URL with encoded ?host=", () => {
+    const out = renderUiOutput({ peer: "10.20.0.7:3456" });
+    expect(out).toBe("http://localhost:5173/federation_2d.html?host=10.20.0.7%3A3456");
+    expect(out.split("\n").length).toBe(1);
+  });
+
+  test("unknown peer → comment-prefixed error (still parseable)", () => {
+    const out = renderUiOutput({ peer: "garbage!!!" });
+    expect(out).toContain("# unknown peer: garbage!!!");
+    // Comments only — no URL line, no SSH command. Caller eyeballs it.
+  });
+});
+
+describe("renderUiOutput — tunnel mode", () => {
+  test("--tunnel + literal peer → SSH command + URL block", () => {
+    const out = renderUiOutput({ tunnel: true, peer: "10.20.0.16" });
+
+    // Shell-safe comments explain each section
+    expect(out).toContain("# Run this on your local machine");
+    expect(out).toContain("# Then open in your browser:");
+    expect(out).toContain("# Stop the tunnel with Ctrl+C");
+
+    // The actual SSH command line is unwrapped and copy-pasteable
+    expect(out).toContain("ssh -N");
+    expect(out).toContain("-L 5173:localhost:5173");
+    expect(out).toContain("-L 3456:localhost:3456");
+    expect(out).toContain("@10.20.0.16");
+
+    // The URL is on its own line for easy copy
+    expect(out).toContain("http://localhost:5173/federation_2d.html");
+  });
+
+  test("--tunnel without peer → usage hint", () => {
+    const out = renderUiOutput({ tunnel: true });
+    expect(out).toContain("# usage: maw ui --tunnel <peer>");
+    // No SSH command, no URL — nothing to copy
+    expect(out).not.toContain("ssh ");
+  });
+
+  test("--tunnel + unknown peer → comment-prefixed error", () => {
+    const out = renderUiOutput({ tunnel: true, peer: "garbage!!!" });
+    expect(out).toContain("# unknown peer: garbage!!!");
+    expect(out).not.toContain("ssh ");
+  });
+
+  test("--tunnel + --3d → 3d URL after the SSH command", () => {
+    const out = renderUiOutput({ tunnel: true, peer: "10.20.0.16", threeD: true });
+    expect(out).toContain("federation.html");
+    expect(out).not.toContain("federation_2d.html");
+  });
+});
+
+// ---- Pipe-friendliness invariant (load-bearing) -------------------------
+
+describe("the pipe-friendliness invariant", () => {
+  // The whole point of "transparent / print-only" is that the URL or SSH
+  // command is on its own line, no ANSI escapes, no decorative output
+  // wrapping the load-bearing text. You can grep / tail / pipe / xargs.
+
+  test("bare mode is one line, no ANSI, no comments", () => {
+    const out = renderUiOutput({});
+    expect(out).not.toMatch(/\x1b\[/); // no ANSI
+    expect(out).not.toContain("#"); // no comments
+    expect(out.split("\n").length).toBe(1);
+  });
+
+  test("peer mode is one line, no ANSI, no comments (when peer resolves)", () => {
+    const out = renderUiOutput({ peer: "10.20.0.7:3456" });
+    expect(out).not.toMatch(/\x1b\[/);
+    expect(out).not.toContain("#");
+    expect(out.split("\n").length).toBe(1);
+  });
+
+  test("tunnel mode keeps SSH and URL on their OWN lines (no inline labels)", () => {
+    const out = renderUiOutput({ tunnel: true, peer: "10.20.0.16" });
+    const lines = out.split("\n");
+
+    // The SSH command is its own line with NO leading text
+    const sshLine = lines.find((l) => l.startsWith("ssh "));
+    expect(sshLine).not.toBeUndefined();
+    expect(sshLine).toBe("ssh -N -L 5173:localhost:5173 -L 3456:localhost:3456 " + (process.env.USER || "neo") + "@10.20.0.16");
+
+    // The URL is its own line with NO leading text
+    const urlLine = lines.find((l) => l.startsWith("http://"));
+    expect(urlLine).not.toBeUndefined();
+    expect(urlLine).toBe("http://localhost:5173/federation_2d.html");
+  });
+
+  test("no ANSI escapes anywhere in tunnel mode output", () => {
+    const out = renderUiOutput({ tunnel: true, peer: "10.20.0.16" });
+    expect(out).not.toMatch(/\x1b\[/);
+  });
+});
+
+// ---- Dual-port forwarding invariant (load-bearing) ----------------------
+
+describe("the dual-port forwarding invariant", () => {
+  test("buildTunnelCommand ALWAYS forwards both lens AND maw-js ports", () => {
+    // The whole point of `maw ui --tunnel` is that the user can hit BOTH
+    // localhost:5173 (lens) AND localhost:3456 (maw-js API) on their
+    // local machine. If this invariant breaks, the lens still works but
+    // `maw <cmd>` calls from the local machine no longer reach the
+    // remote backend.
+    const cmd = buildTunnelCommand({ user: "neo", host: "10.20.0.16" });
+    const lForwards = cmd.match(/-L \d+:localhost:\d+/g) ?? [];
+    expect(lForwards.length).toBe(2);
+    expect(lForwards).toContain("-L 5173:localhost:5173");
+    expect(lForwards).toContain("-L 3456:localhost:3456");
+  });
+});


### PR DESCRIPTION
## Summary

A transparent `maw ui` subcommand that **prints what the user should run** instead of trying to manage SSH/browser/processes for them. Three modes:

```
maw ui                  → http://localhost:5173/federation_2d.html
maw ui <peer>           → http://localhost:5173/federation_2d.html?host=<encoded>
maw ui --tunnel <peer>  → # comment block + SSH command + URL on their own lines
maw ui --3d             → uses federation.html (Three.js) instead of 2D
```

This is the proper command behind the `/lens` skill's *"When mawjs-oracle ships `maw ui [--from-ci|--local]` in the morning, this skill becomes a thin wrapper around it."*

## Why transparent (no wrapper)

The first cut wrapped SSH ControlMaster + control sockets + browser opening + process management. Then realized: the user's eyeballs are the best process manager.

- **No hidden state.** Backgrounded SSH would be invisible to the user. Now Ctrl+C in a real terminal kills it.
- **No platform plumbing.** No `open` vs `xdg-open` vs `start` detection. The user clicks the URL their way.
- **No half-tunnels.** Port conflicts and socket cleanup were our problem in the wrapper version. Now SSH errors talk directly to the user.

## Bare mode is one line — pipe-friendly

```bash
$(maw ui)
maw ui | xargs open
```

No comments, no ANSI escapes, no decoration around the URL.

## Tunnel mode is shell-safe

```
$ maw ui --tunnel 10.20.0.16
# Run this on your local machine to forward both lens (5173) and maw-js (3456):
ssh -N -L 5173:localhost:5173 -L 3456:localhost:3456 neo@10.20.0.16

# Then open in your browser:
http://localhost:5173/federation_2d.html

# Stop the tunnel with Ctrl+C in the SSH terminal.
```

`#` comments label each section, the SSH command and the URL each live on their own line for easy copy-paste.

## --tunnel forwards BOTH ports (load-bearing)

The lens needs `:5173` (vite dev) AND `:3456` (maw-js API) — vite proxies `/api` calls server-side to localhost:3456, so to fully replicate the remote environment locally you need both ports. The SSH command always forwards both:

```bash
ssh -N -L 5173:localhost:5173 -L 3456:localhost:3456 user@host
```

After running it, you can hit BOTH from your local machine:
- `http://localhost:5173/federation_2d.html` (the lens)
- any `maw <cmd>` that talks to localhost:3456 (the CLI against remote backend)

Both worlds reachable as if you were on the remote machine.

## Test coverage (36 tests, all pure)

All helpers are pure-function testable — no spawn, no fs, no process boundary:

- `resolvePeerHostPort` — namedPeers + literal host:port + null paths
- `justHost` — port stripping
- `buildLensUrl` — 2d/3d, `?host=` URL encoding
- `buildTunnelCommand` — both -L pairs, -N (no -f, no -M, no -S)
- `parseUiArgs` — flag forms, order independence
- `renderUiOutput` — bare, peer (resolved + unknown), tunnel (full block, missing peer, unknown peer, --3d combo)

**Two load-bearing invariants locked**:
1. **Pipe-friendliness**: bare/peer modes are one line, no ANSI, no comments. Tunnel mode keeps SSH and URL on their own lines.
2. **Dual-port forwarding**: `-L` appears exactly twice and forwards both `5173` AND `3456`. If this ever drifts, the local CLI loses the remote backend connection.

## Test plan

- [x] `bun test test/ui.test.ts` — 36 pass / 0 fail
- [x] `bun test` full suite — 315 pass / 0 fail
- [x] `bun run build` clean
- [x] Live smoke test from bundled CLI: bare mode, peer mode (literal + named), tunnel mode, --3d combo — all printed expected output against the live vite dev server on oracle-world

## Diff

- `src/commands/ui.ts` (+158 LOC, new) — pure helpers + `cmdUi` entry
- `src/cli/route-tools.ts` (+5 LOC) — wire `cmd === "ui"` → `cmdUi`
- `test/ui.test.ts` (+290 LOC, new) — 36 pure helper tests + invariant locks

Cross-references the iteration-5 architectural commitment from the federation-join-easy /loop: same-machine = same-origin (no wrapper needed), cross-machine = explicit SSH (no wrapper needed). The wormhole-protocol layer (separate PR pair, branches still local) is for when neither of those works.

Co-authored with Nat. Refactor surfaced by Nat catching the original wrapper as over-engineered: *"if we not just code just show the code user run? transparent?"*

🌊👁 — mawui-oracle