### PR TITLE
draft: POST /api/wormhole/request — signed command relay (federation-join-easy)

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -15,6 +15,7 @@ import { triggersApi } from "./triggers";
 import { avengersApi } from "./avengers";
 import { transportApi } from "./transport";
 import { workspaceApi } from "./workspace";
+import { wormholeApi } from "./wormhole";
 import { federationAuth } from "../lib/federation-auth";
 
 export const api = new Hono();
@@ -38,3 +39,4 @@ api.route("/", triggersApi);
 api.route("/", avengersApi);
 api.route("/", transportApi);
 api.route("/", workspaceApi);
+api.route("/", wormholeApi);

--- a/src/api/wormhole.ts
+++ b/src/api/wormhole.ts
@@ -1,0 +1,320 @@
+/**
+ * POST /api/wormhole/request — HTTP transport layer for the /wormhole protocol.
+ *
+ * PROTOTYPE — iteration 3 of the federation-join-easy proof. See
+ * `mawui-oracle/ψ/writing/federation-join-easy.md` for the full architectural
+ * context. This file is the server half of the "global maw-ui + ?host= via
+ * wormhole relay" pattern — a companion to `wormholeClient.ts` in maw-ui.
+ *
+ * ## Why this endpoint exists
+ *
+ * `src/lib/api.ts` in maw-ui implements the drizzle.studio `?host=` pattern:
+ * a hosted UI can point itself at any backend via a query param. That works
+ * cleanly for HTTPS peers on the public internet, but hits three walls for
+ * the "lazy-setup federation via global UI" case:
+ *
+ *   1. **Mixed-content rule**: an HTTPS origin (e.g. local.buildwithoracle.com)
+ *      cannot fetch from an HTTP LAN peer (e.g. http://10.20.0.7:3456). This
+ *      is a browser-level protocol rule, CORS-independent.
+ *   2. **WireGuard-only peers**: the browser doesn't have WG routes; only the
+ *      local backend does. A public origin cannot reach a WG-only peer
+ *      directly.
+ *   3. **Unified auth**: browsers don't know `federationToken`. Giving every
+ *      visitor an HMAC token is a non-starter.
+ *
+ * The wormhole relay fixes all three by making the local backend the trust
+ * gateway: browser → local backend is same-origin (no mixed-content, no CORS,
+ * no new auth); local backend → peer uses the existing `signHeaders()` HMAC
+ * mechanism.
+ *
+ * NOTE: this does NOT sidestep CORS — `src/server.ts:40` already runs
+ * `app.use("/api/*", cors())` (default permissive) and lines 36-39 set
+ * `Access-Control-Allow-Private-Network: true`. CORS and PNA are already
+ * handled for the direct-fetch path. The wormhole relay exists for the
+ * mixed-content + WG + unified-auth problems, not for CORS. See the proof
+ * doc for the corrected motivation list (iteration 2, ~23:55).
+ *
+ * ## Trust boundary
+ *
+ * Incoming requests carry a `[<origin-host>:<origin-agent>]` signature per
+ * the /wormhole skill v0.1 spec. The trust-check is split into two tiers:
+ *
+ *   - **Readonly commands** (`/dig`, `/trace`, `/recap`, `/standup`, grep-only
+ *     reads of `ψ/memory/`): always permitted regardless of origin. This is
+ *     the same policy as the tmux-hey wormhole transport.
+ *   - **Shell / write / mutate commands**: require the origin-host to appear
+ *     in `config.wormhole.shellPeers`. Browser visitors carry
+ *     `[<origin>:anon-<nonce>]` signatures; by convention `anon-*` never
+ *     appears in shellPeers, so anonymous browser calls are permanently
+ *     read-only.
+ *
+ * ## Same-origin cookie (Path B mitigation)
+ *
+ * `src/lib/federation-auth.ts` has a known weakness (#191 Path B): a local
+ * cloudflared sidecar forwarding to `127.0.0.1` makes the TCP source look
+ * legitimately loopback, bypassing HMAC entirely. For the wormhole endpoint
+ * specifically, we CANNOT rely on loopback bypass because the browser will
+ * almost certainly reach us via cloudflared when deployed to a public origin.
+ *
+ * Instead, this endpoint issues a localhost-only cookie on first request
+ * (`wh_session`) and verifies it on subsequent calls. The cookie is a random
+ * 128-bit token generated at server startup, stored in memory only. Rotating
+ * maw-js invalidates all browser sessions, which is the correct security
+ * posture for a prototype. A future iteration can harden this with a
+ * persisted token + rotation schedule.
+ *
+ * ## Status
+ *
+ * - **Iteration 3 prototype** — drafted on `feat/wormhole-http-endpoint-draft`
+ *   branch, NOT merged to main, NOT part of a PR yet.
+ * - Design-locked with mawjs-oracle (oracle-world side) via maw hey coord
+ *   pings. Awaiting (a) Nat's confirmation on the hosted-URL deploy ownership
+ *   before this becomes a real PR, (b) optional white:mawjs /wormhole trace
+ *   findings if they wake and respond.
+ * - Coexists with the tmux-hey transport in the /wormhole skill v0.1. This
+ *   is the HTTP parallel transport planned for /wormhole v0.2.
+ */
+
+import { Hono } from "hono";
+import { randomBytes } from "crypto";
+import { loadConfig } from "../config";
+import { signHeaders } from "../lib/federation-auth";
+
+// --- Session cookie (in-memory, rotates on server restart) ---------------
+
+const WH_SESSION_TOKEN = randomBytes(16).toString("hex");
+const WH_COOKIE_NAME = "wh_session";
+const WH_COOKIE_MAX_AGE = 60 * 60 * 24; // 24 hours
+
+function setSessionCookie(c: any): void {
+  // HttpOnly so JS can't read it, SameSite=Strict so it's not sent cross-site,
+  // no Secure flag so it works on http://localhost dev servers.
+  c.header(
+    "Set-Cookie",
+    `${WH_COOKIE_NAME}=${WH_SESSION_TOKEN}; HttpOnly; SameSite=Strict; Path=/api/wormhole; Max-Age=${WH_COOKIE_MAX_AGE}`,
+  );
+}
+
+function hasValidSessionCookie(c: any): boolean {
+  const cookieHeader = c.req.header("cookie") || "";
+  const match = cookieHeader.match(new RegExp(`${WH_COOKIE_NAME}=([a-f0-9]+)`));
+  return match !== null && match[1] === WH_SESSION_TOKEN;
+}
+
+// --- Signature parsing ----------------------------------------------------
+
+interface ParsedSignature {
+  originHost: string;
+  originAgent: string;
+  isAnon: boolean;
+}
+
+export function parseSignature(signature: string): ParsedSignature | null {
+  const m = signature.match(/^\[([^:\]]+):([^\]]+)\]$/);
+  if (!m) return null;
+  const [, originHost, originAgent] = m;
+  return {
+    originHost,
+    originAgent,
+    isAnon: originAgent.startsWith("anon-"),
+  };
+}
+
+// --- Trust boundary -------------------------------------------------------
+
+/**
+ * Readonly command prefixes. These are always permitted regardless of origin.
+ * Mirrors the /wormhole skill v0.1 trust boundary (which auto-permits /dig,
+ * /trace, and read-only grep queries into ψ/memory/).
+ */
+const READONLY_CMD_PREFIXES = [
+  "/dig",
+  "/trace",
+  "/recap",
+  "/standup",
+  "/who-are-you",
+  "/philosophy",
+  "/where-we-are",
+];
+
+export function isReadOnlyCmd(cmd: string): boolean {
+  const trimmed = cmd.trim();
+  return READONLY_CMD_PREFIXES.some((prefix) =>
+    trimmed === prefix || trimmed.startsWith(prefix + " "),
+  );
+}
+
+export function isShellPeerAllowed(originHost: string): boolean {
+  if (originHost.startsWith("anon-")) return false;
+  const config = loadConfig() as any;
+  const allowed: string[] = config?.wormhole?.shellPeers ?? [];
+  return allowed.includes(originHost);
+}
+
+// --- Peer URL resolution --------------------------------------------------
+
+/**
+ * Resolve a peer name (e.g. "white", "oracle-world") to a base URL using
+ * the existing namedPeers config. Returns null if the peer is unknown.
+ */
+export function resolvePeerUrl(peer: string): string | null {
+  const config = loadConfig() as any;
+  const namedPeers: Array<{ name: string; url: string }> = config?.namedPeers ?? [];
+  const match = namedPeers.find((p) => p.name === peer);
+  if (match) return match.url;
+
+  // Also accept a literal host:port (no protocol) — default to http
+  if (/^[\w.-]+:\d+$/.test(peer)) return `http://${peer}`;
+
+  // Or a full URL
+  if (peer.startsWith("http://") || peer.startsWith("https://")) return peer;
+
+  return null;
+}
+
+// --- Relay ---------------------------------------------------------------
+
+interface RelayResult {
+  output: string;
+  from: string;
+  elapsedMs: number;
+  status: number;
+}
+
+/**
+ * Relay a wormhole request to a peer via HTTP, signing the outgoing call
+ * with the existing federation-auth HMAC. The peer's maw-js must be running
+ * and reachable from this backend's network (WG, LAN, or public).
+ *
+ * For the iteration-3 prototype, the relay simply forwards as a POST to the
+ * peer's own /api/wormhole/request endpoint (if it exists) — recursively.
+ * Iteration 4 will add a fallback to the existing /api/send endpoint for
+ * peers that don't yet support the wormhole route.
+ */
+async function relayToPeer(
+  peerUrl: string,
+  body: { cmd: string; args: string[]; signature: string },
+): Promise<RelayResult> {
+  const start = Date.now();
+  const path = "/api/wormhole/request";
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+
+  // Sign the outgoing relay with the existing HMAC mechanism. The peer's
+  // federation-auth middleware will verify if both sides share a token.
+  const config = loadConfig() as any;
+  const token = config?.federationToken;
+  if (token) {
+    Object.assign(headers, signHeaders(token, "POST", path));
+  }
+
+  const response = await fetch(`${peerUrl}${path}`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+
+  const text = await response.text();
+  return {
+    output: text,
+    from: peerUrl,
+    elapsedMs: Date.now() - start,
+    status: response.status,
+  };
+}
+
+// --- Route ---------------------------------------------------------------
+
+export const wormholeApi = new Hono();
+
+/**
+ * GET /api/wormhole/session — issue a session cookie to a same-origin caller.
+ * The UI calls this once on page load; subsequent POSTs carry the cookie.
+ */
+wormholeApi.get("/wormhole/session", (c) => {
+  setSessionCookie(c);
+  return c.json({ ok: true, rotates: "on_server_restart" });
+});
+
+/**
+ * POST /api/wormhole/request — relay a command to a peer.
+ *
+ * Body: { peer: string, cmd: string, args?: string[], signature: string }
+ *
+ * Trust flow:
+ *   1. Parse signature — reject malformed
+ *   2. Check session cookie — reject if missing (unless dev bypass)
+ *   3. If cmd is readonly → permit regardless of origin
+ *   4. If cmd is NOT readonly → require origin in config.wormhole.shellPeers
+ *   5. Resolve peer URL — reject if unknown
+ *   6. Relay via HTTP with HMAC-signed headers
+ *   7. Return peer's response verbatim
+ */
+wormholeApi.post("/wormhole/request", async (c) => {
+  const body = await c.req.json().catch(() => null);
+  if (!body || typeof body !== "object") {
+    return c.json({ error: "invalid_body" }, 400);
+  }
+
+  const { peer, cmd, args = [], signature } = body as {
+    peer?: string;
+    cmd?: string;
+    args?: string[];
+    signature?: string;
+  };
+
+  if (!peer || !cmd || !signature) {
+    return c.json({ error: "missing_fields", required: ["peer", "cmd", "signature"] }, 400);
+  }
+
+  // 1. Parse signature
+  const parsed = parseSignature(signature);
+  if (!parsed) {
+    return c.json({ error: "bad_signature", expected: "[host:agent]" }, 400);
+  }
+
+  // 2. Session cookie check (skipped in dev — loopback bypass is acceptable
+  //    for local development; production deployments behind cloudflared MUST
+  //    have a valid cookie).
+  const devBypass = process.env.NODE_ENV !== "production";
+  if (!devBypass && !hasValidSessionCookie(c)) {
+    return c.json({ error: "no_session", hint: "GET /api/wormhole/session first" }, 401);
+  }
+
+  // 3 + 4. Trust boundary
+  const readonly = isReadOnlyCmd(cmd);
+  if (!readonly) {
+    const allowed = isShellPeerAllowed(parsed.originHost);
+    if (!allowed) {
+      return c.json(
+        {
+          error: "shell_peer_denied",
+          origin: parsed.originHost,
+          hint: parsed.isAnon
+            ? "anonymous browser visitors are read-only; only /dig, /trace, /recap and similar work"
+            : "add this origin to config.wormhole.shellPeers to permit shell cmds",
+        },
+        403,
+      );
+    }
+  }
+
+  // 5. Resolve peer
+  const peerUrl = resolvePeerUrl(peer);
+  if (!peerUrl) {
+    return c.json({ error: "unknown_peer", peer }, 404);
+  }
+
+  // 6 + 7. Relay and return
+  try {
+    const result = await relayToPeer(peerUrl, { cmd, args, signature });
+    return c.json({
+      output: result.output,
+      from: result.from,
+      elapsed_ms: result.elapsedMs,
+      status: result.status,
+      trust_tier: readonly ? "readonly" : "shell_allowlisted",
+    });
+  } catch (err: any) {
+    return c.json({ error: "relay_failed", peer: peerUrl, reason: err?.message ?? String(err) }, 502);
+  }
+});

--- a/test/wormhole.integration.test.ts
+++ b/test/wormhole.integration.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Integration tests for POST /api/wormhole/request — exercises the FULL
+ * signed-relay path through a mocked-fetch stub peer instead of just the
+ * helper functions in isolation.
+ *
+ * PROTOTYPE — iteration 9 (convergence iteration) of the federation-join-easy
+ * /loop. Drafted on feat/wormhole-http-endpoint-draft. Companion to
+ * test/wormhole.test.ts (which covers the helpers + route 400/401/403/404
+ * paths in-process). See mawui-oracle/ψ/writing/federation-join-easy.md.
+ *
+ * ## Strategy
+ *
+ * The wormhole route's `relayToPeer()` calls `fetch(peerUrl + "/api/wormhole/request")`
+ * to forward signed requests to a peer. We can't easily run a second
+ * full hono server in the test runner, so instead we replace
+ * `globalThis.fetch` with a router that dispatches to a stub peer hono
+ * app via its own `app.request()` method. This gives us:
+ *
+ *   - Real wormhole route execution (in-process via app.request())
+ *   - Real signed outbound construction (relayToPeer calls signHeaders)
+ *   - Stub peer that records what it received and returns canned responses
+ *   - Round-trip assertions on body, headers, status, elapsed_ms
+ *
+ * The stub peer is intentionally simple — it doesn't run federation-auth
+ * verification because we're testing the WORMHOLE route, not the auth
+ * middleware (which has its own coverage). The stub just records the
+ * request and returns whatever the test specifies.
+ *
+ * ## What this catches that the unit tests miss
+ *
+ * The unit tests in test/wormhole.test.ts cover the route's pre-relay
+ * paths (validation, trust boundary, peer resolution). They short-circuit
+ * before the actual relay because all peers in those tests are unknown.
+ * This integration test exercises the bytes that go OUT to the peer and
+ * the bytes that come BACK — the part the unit tests deliberately don't
+ * touch.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { Hono } from "hono";
+import { wormholeApi } from "../src/api/wormhole";
+
+// ---- Stub peer infrastructure --------------------------------------------
+
+interface PeerCapture {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: string;
+}
+
+function buildStubPeerApp(
+  capture: PeerCapture[],
+  responseBuilder: (req: PeerCapture) => Response,
+): Hono {
+  const app = new Hono();
+  app.post("/api/wormhole/request", async (c) => {
+    const headers: Record<string, string> = {};
+    c.req.raw.headers.forEach((v, k) => {
+      headers[k] = v;
+    });
+    const body = await c.req.text();
+    const cap: PeerCapture = {
+      url: c.req.url,
+      method: c.req.method,
+      headers,
+      body,
+    };
+    capture.push(cap);
+    return responseBuilder(cap);
+  });
+  return app;
+}
+
+// ---- App-under-test ------------------------------------------------------
+
+function makeMawApp(): Hono {
+  const app = new Hono();
+  const apiSub = new Hono();
+  apiSub.route("/", wormholeApi);
+  app.route("/api", apiSub);
+  return app;
+}
+
+// ---- fetch mock router ---------------------------------------------------
+
+let originalFetch: typeof fetch;
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  // Default to dev mode so the session-cookie check doesn't get in the way
+  // — we test the cookie path explicitly in the unit tests.
+  process.env.NODE_ENV = "development";
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  delete process.env.NODE_ENV;
+});
+
+function installPeerRouter(stubPeerUrl: string, stubApp: Hono) {
+  globalThis.fetch = (async (input: any, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.url;
+    if (url.startsWith(stubPeerUrl)) {
+      // Strip the peer base and dispatch to the stub app
+      const path = url.slice(stubPeerUrl.length) || "/";
+      return stubApp.request(path, {
+        method: init?.method || "GET",
+        headers: init?.headers as any,
+        body: init?.body as any,
+      });
+    }
+    // Anything else falls through to the real fetch (unlikely in tests)
+    return originalFetch(input, init);
+  }) as typeof fetch;
+}
+
+// ---- Helpers -------------------------------------------------------------
+
+function makeWormholeBody(overrides: Partial<{
+  peer: string;
+  cmd: string;
+  args: string[];
+  signature: string;
+}> = {}) {
+  return JSON.stringify({
+    peer: "stub-peer-test:9999",
+    cmd: "/dig",
+    args: ["--all", "5"],
+    signature: "[mawui-test:anon-deadbeef]",
+    ...overrides,
+  });
+}
+
+// ---- Tests ---------------------------------------------------------------
+
+describe("wormhole integration — happy path", () => {
+  test("relays a signed request to the peer and returns the response verbatim", async () => {
+    const captures: PeerCapture[] = [];
+    const stubPeerUrl = "http://stub-peer-test:9999";
+    const stubApp = buildStubPeerApp(captures, () =>
+      new Response("dig output from stub peer", { status: 200 }),
+    );
+    installPeerRouter(stubPeerUrl, stubApp);
+
+    const app = makeMawApp();
+    const res = await app.request("/api/wormhole/request", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: makeWormholeBody(),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+
+    // The peer's response body comes back verbatim in the `output` field
+    expect(body.output).toBe("dig output from stub peer");
+    // The peer URL is reported in `from`
+    expect(body.from).toBe(stubPeerUrl);
+    // Trust tier was readonly because /dig is in the whitelist
+    expect(body.trust_tier).toBe("readonly");
+    // elapsed_ms is a positive number
+    expect(typeof body.elapsed_ms).toBe("number");
+    expect(body.elapsed_ms).toBeGreaterThanOrEqual(0);
+    // Status from the peer
+    expect(body.status).toBe(200);
+  });
+
+  test("the peer received exactly one POST with the forwarded body", async () => {
+    const captures: PeerCapture[] = [];
+    const stubPeerUrl = "http://stub-peer-test:9999";
+    const stubApp = buildStubPeerApp(captures, () =>
+      new Response("ok", { status: 200 }),
+    );
+    installPeerRouter(stubPeerUrl, stubApp);
+
+    const app = makeMawApp();
+    await app.request("/api/wormhole/request", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: makeWormholeBody({ cmd: "/trace", args: ["--deep"] }),
+    });
+
+    expect(captures.length).toBe(1);
+    const cap = captures[0];
+    expect(cap.method).toBe("POST");
+    // The relay forwards the original body envelope verbatim — the peer
+    // sees the same {peer, cmd, args, signature} shape that the browser
+    // sent us. (This is a deliberate design choice: the peer is itself
+    // a wormhole node and re-applies its own trust boundary.)
+    const peerBody = JSON.parse(cap.body);
+    expect(peerBody.cmd).toBe("/trace");
+    expect(peerBody.args).toEqual(["--deep"]);
+    expect(peerBody.signature).toBe("[mawui-test:anon-deadbeef]");
+  });
+});
+
+describe("wormhole integration — peer error paths", () => {
+  test("peer returns 500 → we return 200 with peer's status in body", async () => {
+    // Note: we return 200 from our route even when the peer errored.
+    // The peer's status is in the body's `status` field for the caller
+    // to inspect. This matches the unit tests' expectation that relay
+    // succeeds whenever the upstream call completes — only network-level
+    // failures cascade as 502 relay_failed.
+    const captures: PeerCapture[] = [];
+    const stubPeerUrl = "http://stub-peer-test:9999";
+    const stubApp = buildStubPeerApp(captures, () =>
+      new Response("internal error from peer", { status: 500 }),
+    );
+    installPeerRouter(stubPeerUrl, stubApp);
+
+    const app = makeMawApp();
+    const res = await app.request("/api/wormhole/request", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: makeWormholeBody(),
+    });
+
+    expect(res.status).toBe(200); // OUR route succeeded
+    const body = (await res.json()) as any;
+    expect(body.status).toBe(500); // The peer's status
+    expect(body.output).toBe("internal error from peer");
+  });
+
+  test("network failure → we return 502 relay_failed", async () => {
+    // Replace fetch with one that throws — simulates DNS failure / TCP reset
+    globalThis.fetch = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as typeof fetch;
+
+    const app = makeMawApp();
+    const res = await app.request("/api/wormhole/request", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: makeWormholeBody({ peer: "http://will-not-resolve.invalid:1234" }),
+    });
+
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as any;
+    expect(body.error).toBe("relay_failed");
+    expect(body.reason).toContain("ECONNREFUSED");
+  });
+});
+
+describe("wormhole integration — body round-trip", () => {
+  test("large response bodies round-trip cleanly", async () => {
+    // Locks the v0.1-over-HTTP "one JSON blob per response" behavior.
+    // Iteration 4+'s v0.2 protocol will replace this with chunked
+    // streaming; this test documents the v0.1 limit.
+    const captures: PeerCapture[] = [];
+    const stubPeerUrl = "http://stub-peer-test:9999";
+    const bigBody = "X".repeat(50000); // 50KB
+    const stubApp = buildStubPeerApp(captures, () =>
+      new Response(bigBody, { status: 200 }),
+    );
+    installPeerRouter(stubPeerUrl, stubApp);
+
+    const app = makeMawApp();
+    const res = await app.request("/api/wormhole/request", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: makeWormholeBody(),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.output.length).toBe(50000);
+    expect(body.output).toBe(bigBody);
+  });
+
+  test("UTF-8 bodies (Thai script) round-trip cleanly", async () => {
+    // Federation oracles use Thai phrases throughout. The relay must
+    // not corrupt unicode anywhere in the round-trip.
+    const captures: PeerCapture[] = [];
+    const stubPeerUrl = "http://stub-peer-test:9999";
+    const thaiBody = "บำเพ็ญเพียร 👁 mesh ไม่มีหน้า จนกว่า Mawui จะวาดให้";
+    const stubApp = buildStubPeerApp(captures, () =>
+      new Response(thaiBody, { status: 200, headers: { "content-type": "text/plain; charset=utf-8" } }),
+    );
+    installPeerRouter(stubPeerUrl, stubApp);
+
+    const app = makeMawApp();
+    const res = await app.request("/api/wormhole/request", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: makeWormholeBody(),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.output).toBe(thaiBody);
+  });
+});

--- a/test/wormhole.test.ts
+++ b/test/wormhole.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Tests for POST /api/wormhole/request — the HTTP transport prototype for
+ * the /wormhole protocol. Companion to src/api/wormhole.ts.
+ *
+ * PROTOTYPE — iteration 4 of the federation-join-easy /loop. Drafted on the
+ * feat/wormhole-http-endpoint-draft branch. See
+ * mawui-oracle/ψ/writing/federation-join-easy.md for full context.
+ *
+ * These tests follow the bud-root.test.ts + contacts.test.ts conventions:
+ * pure-function tests for the trust-boundary helpers, and in-process Hono
+ * app.request() tests for the POST route with a stubbed peer backend.
+ *
+ * The iteration-3 prototype is honest v0.1-over-HTTP: one JSON blob per
+ * response, regex signature parse, no request IDs. Iteration 4+ protocol
+ * refinements (request IDs, streaming, Zod, typed verbs) are tracked in the
+ * proof doc but not tested here — they belong to the v0.2 PR.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { Hono } from "hono";
+import {
+  parseSignature,
+  isReadOnlyCmd,
+  isShellPeerAllowed,
+  resolvePeerUrl,
+  wormholeApi,
+} from "../src/api/wormhole";
+
+// ---- Pure helper tests ---------------------------------------------------
+
+describe("parseSignature", () => {
+  test("parses [host:agent] into structured fields", () => {
+    const r = parseSignature("[oracle-world:mawjs-oracle]");
+    expect(r).toEqual({
+      originHost: "oracle-world",
+      originAgent: "mawjs-oracle",
+      isAnon: false,
+    });
+  });
+
+  test("flags anon-* agents", () => {
+    const r = parseSignature("[local.buildwithoracle.com:anon-a1b2c3d4]");
+    expect(r).not.toBeNull();
+    expect(r!.isAnon).toBe(true);
+    expect(r!.originAgent).toBe("anon-a1b2c3d4");
+  });
+
+  test("returns null for malformed signatures (missing brackets)", () => {
+    expect(parseSignature("oracle-world:mawjs-oracle")).toBeNull();
+  });
+
+  test("returns null for malformed signatures (missing colon)", () => {
+    expect(parseSignature("[oracle-world-mawjs-oracle]")).toBeNull();
+  });
+
+  test("returns null for empty signature", () => {
+    expect(parseSignature("")).toBeNull();
+  });
+
+  test("accepts hostnames with dots and hyphens (real-world shapes)", () => {
+    const r = parseSignature("[local.buildwithoracle.com:anon-12345678]");
+    expect(r?.originHost).toBe("local.buildwithoracle.com");
+    expect(r?.isAnon).toBe(true);
+  });
+
+  test("agent name containing dashes is preserved (not just the anon- prefix)", () => {
+    const r = parseSignature("[white:white-wormhole-oracle]");
+    expect(r?.originAgent).toBe("white-wormhole-oracle");
+    expect(r?.isAnon).toBe(false);
+  });
+});
+
+describe("isReadOnlyCmd", () => {
+  test.each([
+    "/dig",
+    "/dig --all 5",
+    "/trace",
+    "/trace --deep",
+    "/recap",
+    "/recap --now",
+    "/standup",
+    "/who-are-you",
+    "/philosophy",
+    "/where-we-are",
+  ])("permits %s", (cmd) => {
+    expect(isReadOnlyCmd(cmd)).toBe(true);
+  });
+
+  test.each([
+    "/awaken",
+    "/commit",
+    "/rrr",
+    "/incubate laris-co/foo",
+    "/diggy --deep", // starts with /dig but not the /dig verb
+    "rm -rf /",
+    "",
+    "dig", // no leading slash
+  ])("denies %s", (cmd) => {
+    expect(isReadOnlyCmd(cmd)).toBe(false);
+  });
+
+  test("guards against prefix-only matches (e.g. /digit is not /dig)", () => {
+    // Our whitelist uses exact match OR "prefix + ' '" so /digit should fail.
+    expect(isReadOnlyCmd("/digit --flag")).toBe(false);
+  });
+
+  test("trims leading/trailing whitespace before matching", () => {
+    expect(isReadOnlyCmd("  /dig --all 5  ")).toBe(true);
+  });
+});
+
+describe("isShellPeerAllowed", () => {
+  // Note: this test reads the real config via loadConfig(). The anon-* branch
+  // is deterministic regardless of config state, so we only test that path.
+
+  test("anon-* is ALWAYS denied regardless of config", () => {
+    expect(isShellPeerAllowed("anon-a1b2c3d4")).toBe(false);
+    expect(isShellPeerAllowed("anon-00000000")).toBe(false);
+  });
+
+  test("unknown origin is denied (no config.wormhole.shellPeers entry)", () => {
+    // The real config probably doesn't have any wormhole.shellPeers yet,
+    // so any origin returns false. This test locks that default.
+    expect(isShellPeerAllowed("some-random-host-xyz-does-not-exist")).toBe(false);
+  });
+});
+
+describe("resolvePeerUrl", () => {
+  test("resolves a bare host:port to http://host:port", () => {
+    expect(resolvePeerUrl("10.20.0.7:3456")).toBe("http://10.20.0.7:3456");
+    expect(resolvePeerUrl("localhost:3457")).toBe("http://localhost:3457");
+  });
+
+  test("returns a full http:// URL unchanged", () => {
+    expect(resolvePeerUrl("http://oracle-world.example:3456")).toBe(
+      "http://oracle-world.example:3456",
+    );
+  });
+
+  test("returns a full https:// URL unchanged", () => {
+    expect(resolvePeerUrl("https://local.buildwithoracle.com")).toBe(
+      "https://local.buildwithoracle.com",
+    );
+  });
+
+  test("returns null for an unknown bare peer name", () => {
+    // Assuming the real config doesn't have "ghost-peer-xyz" in namedPeers
+    expect(resolvePeerUrl("ghost-peer-xyz")).toBeNull();
+  });
+
+  test("returns null for empty input", () => {
+    expect(resolvePeerUrl("")).toBeNull();
+  });
+});
+
+// ---- In-process POST route tests ----------------------------------------
+
+// Mount wormholeApi on a bare Hono app so we can call it with app.request().
+// This avoids booting the full server and keeps the tests deterministic.
+
+function makeApp(): Hono {
+  const app = new Hono();
+  // Mount under /api to match the real mount point in src/api/index.ts
+  const apiSub = new Hono();
+  apiSub.route("/", wormholeApi);
+  app.route("/api", apiSub);
+  return app;
+}
+
+// Force production mode so the cookie check is active (dev bypass off).
+// We use beforeEach/afterEach to scope this to the POST tests only.
+let savedEnv: string | undefined;
+beforeEach(() => {
+  savedEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = "production";
+});
+afterEach(() => {
+  process.env.NODE_ENV = savedEnv;
+});
+
+describe("GET /api/wormhole/session", () => {
+  test("issues a wh_session cookie", async () => {
+    const app = makeApp();
+    const res = await app.request("/api/wormhole/session");
+    expect(res.status).toBe(200);
+    const cookie = res.headers.get("set-cookie");
+    expect(cookie).not.toBeNull();
+    expect(cookie!).toMatch(/wh_session=[a-f0-9]+/);
+    expect(cookie!).toContain("HttpOnly");
+    expect(cookie!).toContain("SameSite=Strict");
+  });
+
+  test("returns ok + rotation policy", async () => {
+    const app = makeApp();
+    const res = await app.request("/api/wormhole/session");
+    const body = (await res.json()) as any;
+    expect(body.ok).toBe(true);
+    expect(body.rotates).toBe("on_server_restart");
+  });
+});
+
+describe("POST /api/wormhole/request (trust flow)", () => {
+  async function sessionCookie(app: Hono): Promise<string> {
+    const res = await app.request("/api/wormhole/session");
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    const match = setCookie.match(/wh_session=([a-f0-9]+)/);
+    if (!match) throw new Error("no session cookie issued");
+    return `wh_session=${match[1]}`;
+  }
+
+  test("400 on missing fields (no peer)", async () => {
+    const app = makeApp();
+    const cookie = await sessionCookie(app);
+    const res = await app.request("/api/wormhole/request", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: cookie },
+      body: JSON.stringify({ cmd: "/dig", signature: "[local:anon-1]" }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(body.error).toBe("missing_fields");
+  });
+
+  test("400 on bad signature shape", async () => {
+    const app = makeApp();
+    const cookie = await sessionCookie(app);
+    const res = await app.request("/api/wormhole/request", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: cookie },
+      body: JSON.stringify({ peer: "white", cmd: "/dig", signature: "not-a-signature" }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(body.error).toBe("bad_signature");
+  });
+
+  test("401 when session cookie is missing (production mode)", async () => {
+    const app = makeApp();
+    const res = await app.request("/api/wormhole/request", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        peer: "white",
+        cmd: "/dig",
+        signature: "[local:anon-a1b2c3d4]",
+      }),
+    });
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as any;
+    expect(body.error).toBe("no_session");
+  });
+
+  test("403 when anon-* origin tries a non-readonly cmd", async () => {
+    const app = makeApp();
+    const cookie = await sessionCookie(app);
+    const res = await app.request("/api/wormhole/request", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: cookie },
+      body: JSON.stringify({
+        peer: "white",
+        cmd: "/awaken",
+        signature: "[local:anon-a1b2c3d4]",
+      }),
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as any;
+    expect(body.error).toBe("shell_peer_denied");
+    expect(body.hint).toContain("anonymous browser visitors are read-only");
+  });
+
+  test("404 on unknown peer name (readonly cmd that passes trust check)", async () => {
+    const app = makeApp();
+    const cookie = await sessionCookie(app);
+    const res = await app.request("/api/wormhole/request", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: cookie },
+      body: JSON.stringify({
+        peer: "ghost-peer-xyz",
+        cmd: "/dig",
+        signature: "[local:anon-a1b2c3d4]",
+      }),
+    });
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as any;
+    expect(body.error).toBe("unknown_peer");
+  });
+
+  test("invalid JSON body → 400 invalid_body", async () => {
+    const app = makeApp();
+    const cookie = await sessionCookie(app);
+    const res = await app.request("/api/wormhole/request", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: cookie },
+      body: "not-json-{",
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(body.error).toBe("invalid_body");
+  });
+
+  test("dev mode (NODE_ENV !== production) skips the session cookie check", async () => {
+    // Flip to development for this one test
+    process.env.NODE_ENV = "development";
+    const app = makeApp();
+    const res = await app.request("/api/wormhole/request", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" }, // no cookie
+      body: JSON.stringify({
+        peer: "ghost-peer-xyz", // unknown so we still get a reject, but further down the stack
+        cmd: "/dig",
+        signature: "[local:anon-a1b2c3d4]",
+      }),
+    });
+    // Should NOT be 401 (cookie bypassed), should be 404 (unknown peer)
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("trust boundary — anon-* can only run readonly cmds", () => {
+  // This is the load-bearing invariant: no matter what the config says,
+  // an anon-* origin never gets shell access. We test all 7 readonly cmds
+  // pass the trust check and a handful of non-readonly cmds fail.
+
+  const READONLY_CMDS = [
+    "/dig",
+    "/trace",
+    "/recap",
+    "/standup",
+    "/who-are-you",
+    "/philosophy",
+    "/where-we-are",
+  ];
+
+  const NON_READONLY_CMDS = ["/awaken", "/commit", "/rrr", "/oracle install"];
+
+  test.each(READONLY_CMDS)("anon-* permitted to run %s (trust check passes)", (cmd) => {
+    expect(isReadOnlyCmd(cmd)).toBe(true);
+    expect(isShellPeerAllowed("anon-a1b2c3d4")).toBe(false);
+    // Together: readonly = true short-circuits the allowlist check, so permitted.
+  });
+
+  test.each(NON_READONLY_CMDS)("anon-* DENIED from running %s", (cmd) => {
+    expect(isReadOnlyCmd(cmd)).toBe(false);
+    expect(isShellPeerAllowed("anon-a1b2c3d4")).toBe(false);
+    // Together: readonly = false AND allowlist = false, so denied.
+  });
+});


### PR DESCRIPTION
## Draft — federation-join-easy prototype

POST /api/wormhole/request — HTTP transport for the /wormhole protocol. Relays signed commands (/dig, /trace, /recap) to federation peers.

- 962 LOC (322 src + 347 unit tests + 293 integration tests)
- 60 tests all green (54 unit + 6 integration via stubbed-peer fetch swap)
- Trust boundary: readonly cmds always permitted, shell cmds require allowlist, anon-* permanently read-only
- Session cookie auth (Path B #191 mitigation)

See mawui-oracle/ψ/writing/federation-join-easy.md for full architectural context.

🤖 Co-authored by mawui-oracle