### PR TITLE
refactor: rename wormhole → peer/exec in public API surface

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -15,7 +15,7 @@ import { triggersApi } from "./triggers";
 import { avengersApi } from "./avengers";
 import { transportApi } from "./transport";
 import { workspaceApi } from "./workspace";
-import { wormholeApi } from "./wormhole";
+import { peerExecApi } from "./peer-exec";
 import { proxyApi } from "./proxy";
 import { federationAuth } from "../lib/federation-auth";
 
@@ -40,5 +40,5 @@ api.route("/", triggersApi);
 api.route("/", avengersApi);
 api.route("/", transportApi);
 api.route("/", workspaceApi);
-api.route("/", wormholeApi);
+api.route("/", peerExecApi);
 api.route("/", proxyApi);

--- a/src/api/peer-exec.ts
+++ b/src/api/peer-exec.ts
@@ -1,10 +1,10 @@
 /**
- * POST /api/wormhole/request — HTTP transport layer for the /wormhole protocol.
+ * POST /api/peer/exec — HTTP transport layer for the /wormhole protocol.
  *
  * PROTOTYPE — iteration 3 of the federation-join-easy proof. See
  * `mawui-oracle/ψ/writing/federation-join-easy.md` for the full architectural
  * context. This file is the server half of the "global maw-ui + ?host= via
- * wormhole relay" pattern — a companion to `wormholeClient.ts` in maw-ui.
+ * peer-exec relay" pattern — a companion to `wormholeClient.ts` in maw-ui.
  *
  * ## Why this endpoint exists
  *
@@ -22,7 +22,7 @@
  *   3. **Unified auth**: browsers don't know `federationToken`. Giving every
  *      visitor an HMAC token is a non-starter.
  *
- * The wormhole relay fixes all three by making the local backend the trust
+ * The peer-exec relay fixes all three by making the local backend the trust
  * gateway: browser → local backend is same-origin (no mixed-content, no CORS,
  * no new auth); local backend → peer uses the existing `signHeaders()` HMAC
  * mechanism.
@@ -30,7 +30,7 @@
  * NOTE: this does NOT sidestep CORS — `src/server.ts:40` already runs
  * `app.use("/api/*", cors())` (default permissive) and lines 36-39 set
  * `Access-Control-Allow-Private-Network: true`. CORS and PNA are already
- * handled for the direct-fetch path. The wormhole relay exists for the
+ * handled for the direct-fetch path. The peer-exec relay exists for the
  * mixed-content + WG + unified-auth problems, not for CORS. See the proof
  * doc for the corrected motivation list (iteration 2, ~23:55).
  *
@@ -52,12 +52,12 @@
  *
  * `src/lib/federation-auth.ts` has a known weakness (#191 Path B): a local
  * cloudflared sidecar forwarding to `127.0.0.1` makes the TCP source look
- * legitimately loopback, bypassing HMAC entirely. For the wormhole endpoint
+ * legitimately loopback, bypassing HMAC entirely. For the peer-exec endpoint
  * specifically, we CANNOT rely on loopback bypass because the browser will
  * almost certainly reach us via cloudflared when deployed to a public origin.
  *
  * Instead, this endpoint issues a localhost-only cookie on first request
- * (`wh_session`) and verifies it on subsequent calls. The cookie is a random
+ * (`pe_session`) and verifies it on subsequent calls. The cookie is a random
  * 128-bit token generated at server startup, stored in memory only. Rotating
  * maw-js invalidates all browser sessions, which is the correct security
  * posture for a prototype. A future iteration can harden this with a
@@ -82,23 +82,23 @@ import { signHeaders } from "../lib/federation-auth";
 
 // --- Session cookie (in-memory, rotates on server restart) ---------------
 
-const WH_SESSION_TOKEN = randomBytes(16).toString("hex");
-const WH_COOKIE_NAME = "wh_session";
-const WH_COOKIE_MAX_AGE = 60 * 60 * 24; // 24 hours
+const PE_SESSION_TOKEN = randomBytes(16).toString("hex");
+const PE_COOKIE_NAME = "pe_session";
+const PE_COOKIE_MAX_AGE = 60 * 60 * 24; // 24 hours
 
 function setSessionCookie(c: any): void {
   // HttpOnly so JS can't read it, SameSite=Strict so it's not sent cross-site,
   // no Secure flag so it works on http://localhost dev servers.
   c.header(
     "Set-Cookie",
-    `${WH_COOKIE_NAME}=${WH_SESSION_TOKEN}; HttpOnly; SameSite=Strict; Path=/api/wormhole; Max-Age=${WH_COOKIE_MAX_AGE}`,
+    `${PE_COOKIE_NAME}=${PE_SESSION_TOKEN}; HttpOnly; SameSite=Strict; Path=/api/peer; Max-Age=${PE_COOKIE_MAX_AGE}`,
   );
 }
 
 function hasValidSessionCookie(c: any): boolean {
   const cookieHeader = c.req.header("cookie") || "";
-  const match = cookieHeader.match(new RegExp(`${WH_COOKIE_NAME}=([a-f0-9]+)`));
-  return match !== null && match[1] === WH_SESSION_TOKEN;
+  const match = cookieHeader.match(new RegExp(`${PE_COOKIE_NAME}=([a-f0-9]+)`));
+  return match !== null && match[1] === PE_SESSION_TOKEN;
 }
 
 // --- Signature parsing ----------------------------------------------------
@@ -123,11 +123,11 @@ export function parseSignature(signature: string): ParsedSignature | null {
 // --- Trust boundary -------------------------------------------------------
 
 /**
- * Readonly command prefixes. These are always permitted regardless of origin.
+ * Readonly commands. These are always permitted regardless of origin.
  * Mirrors the /wormhole skill v0.1 trust boundary (which auto-permits /dig,
  * /trace, and read-only grep queries into ψ/memory/).
  */
-const READONLY_CMD_PREFIXES = [
+const READONLY_CMDS = [
   "/dig",
   "/trace",
   "/recap",
@@ -139,7 +139,7 @@ const READONLY_CMD_PREFIXES = [
 
 export function isReadOnlyCmd(cmd: string): boolean {
   const trimmed = cmd.trim();
-  return READONLY_CMD_PREFIXES.some((prefix) =>
+  return READONLY_CMDS.some((prefix) =>
     trimmed === prefix || trimmed.startsWith(prefix + " "),
   );
 }
@@ -182,21 +182,21 @@ interface RelayResult {
 }
 
 /**
- * Relay a wormhole request to a peer via HTTP, signing the outgoing call
+ * Relay a peer-exec request to a peer via HTTP, signing the outgoing call
  * with the existing federation-auth HMAC. The peer's maw-js must be running
  * and reachable from this backend's network (WG, LAN, or public).
  *
  * For the iteration-3 prototype, the relay simply forwards as a POST to the
- * peer's own /api/wormhole/request endpoint (if it exists) — recursively.
+ * peer's own /api/peer/exec endpoint (if it exists) — recursively.
  * Iteration 4 will add a fallback to the existing /api/send endpoint for
- * peers that don't yet support the wormhole route.
+ * peers that don't yet support the peer-exec route.
  */
 async function relayToPeer(
   peerUrl: string,
   body: { cmd: string; args: string[]; signature: string },
 ): Promise<RelayResult> {
   const start = Date.now();
-  const path = "/api/wormhole/request";
+  const path = "/api/peer/exec";
   const headers: Record<string, string> = { "Content-Type": "application/json" };
 
   // Sign the outgoing relay with the existing HMAC mechanism. The peer's
@@ -224,19 +224,19 @@ async function relayToPeer(
 
 // --- Route ---------------------------------------------------------------
 
-export const wormholeApi = new Hono();
+export const peerExecApi = new Hono();
 
 /**
- * GET /api/wormhole/session — issue a session cookie to a same-origin caller.
+ * GET /api/peer/session — issue a session cookie to a same-origin caller.
  * The UI calls this once on page load; subsequent POSTs carry the cookie.
  */
-wormholeApi.get("/wormhole/session", (c) => {
+peerExecApi.get("/peer/session", (c) => {
   setSessionCookie(c);
   return c.json({ ok: true, rotates: "on_server_restart" });
 });
 
 /**
- * POST /api/wormhole/request — relay a command to a peer.
+ * POST /api/peer/exec — relay a command to a peer.
  *
  * Body: { peer: string, cmd: string, args?: string[], signature: string }
  *
@@ -249,7 +249,7 @@ wormholeApi.get("/wormhole/session", (c) => {
  *   6. Relay via HTTP with HMAC-signed headers
  *   7. Return peer's response verbatim
  */
-wormholeApi.post("/wormhole/request", async (c) => {
+peerExecApi.post("/peer/exec", async (c) => {
   const body = await c.req.json().catch(() => null);
   if (!body || typeof body !== "object") {
     return c.json({ error: "invalid_body" }, 400);
@@ -277,7 +277,7 @@ wormholeApi.post("/wormhole/request", async (c) => {
   //    have a valid cookie).
   const devBypass = process.env.NODE_ENV !== "production";
   if (!devBypass && !hasValidSessionCookie(c)) {
-    return c.json({ error: "no_session", hint: "GET /api/wormhole/session first" }, 401);
+    return c.json({ error: "no_session", hint: "GET /api/peer/session first" }, 401);
   }
 
   // 3 + 4. Trust boundary

--- a/test/peer-exec.integration.test.ts
+++ b/test/peer-exec.integration.test.ts
@@ -1,34 +1,34 @@
 /**
- * Integration tests for POST /api/wormhole/request — exercises the FULL
+ * Integration tests for POST /api/peer/exec — exercises the FULL
  * signed-relay path through a mocked-fetch stub peer instead of just the
  * helper functions in isolation.
  *
  * PROTOTYPE — iteration 9 (convergence iteration) of the federation-join-easy
  * /loop. Drafted on feat/wormhole-http-endpoint-draft. Companion to
- * test/wormhole.test.ts (which covers the helpers + route 400/401/403/404
+ * test/peer-exec.test.ts (which covers the helpers + route 400/401/403/404
  * paths in-process). See mawui-oracle/ψ/writing/federation-join-easy.md.
  *
  * ## Strategy
  *
- * The wormhole route's `relayToPeer()` calls `fetch(peerUrl + "/api/wormhole/request")`
+ * The peer-exec route's `relayToPeer()` calls `fetch(peerUrl + "/api/peer/exec")`
  * to forward signed requests to a peer. We can't easily run a second
  * full hono server in the test runner, so instead we replace
  * `globalThis.fetch` with a router that dispatches to a stub peer hono
  * app via its own `app.request()` method. This gives us:
  *
- *   - Real wormhole route execution (in-process via app.request())
+ *   - Real peer-exec route execution (in-process via app.request())
  *   - Real signed outbound construction (relayToPeer calls signHeaders)
  *   - Stub peer that records what it received and returns canned responses
  *   - Round-trip assertions on body, headers, status, elapsed_ms
  *
  * The stub peer is intentionally simple — it doesn't run federation-auth
- * verification because we're testing the WORMHOLE route, not the auth
+ * verification because we're testing the peer-exec route, not the auth
  * middleware (which has its own coverage). The stub just records the
  * request and returns whatever the test specifies.
  *
  * ## What this catches that the unit tests miss
  *
- * The unit tests in test/wormhole.test.ts cover the route's pre-relay
+ * The unit tests in test/peer-exec.test.ts cover the route's pre-relay
  * paths (validation, trust boundary, peer resolution). They short-circuit
  * before the actual relay because all peers in those tests are unknown.
  * This integration test exercises the bytes that go OUT to the peer and
@@ -38,7 +38,7 @@
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { Hono } from "hono";
-import { wormholeApi } from "../src/api/wormhole";
+import { peerExecApi } from "../src/api/peer-exec";
 
 // ---- Stub peer infrastructure --------------------------------------------
 
@@ -54,7 +54,7 @@ function buildStubPeerApp(
   responseBuilder: (req: PeerCapture) => Response,
 ): Hono {
   const app = new Hono();
-  app.post("/api/wormhole/request", async (c) => {
+  app.post("/api/peer/exec", async (c) => {
     const headers: Record<string, string> = {};
     c.req.raw.headers.forEach((v, k) => {
       headers[k] = v;
@@ -77,7 +77,7 @@ function buildStubPeerApp(
 function makeMawApp(): Hono {
   const app = new Hono();
   const apiSub = new Hono();
-  apiSub.route("/", wormholeApi);
+  apiSub.route("/", peerExecApi);
   app.route("/api", apiSub);
   return app;
 }
@@ -117,7 +117,7 @@ function installPeerRouter(stubPeerUrl: string, stubApp: Hono) {
 
 // ---- Helpers -------------------------------------------------------------
 
-function makeWormholeBody(overrides: Partial<{
+function makePeerExecBody(overrides: Partial<{
   peer: string;
   cmd: string;
   args: string[];
@@ -134,7 +134,7 @@ function makeWormholeBody(overrides: Partial<{
 
 // ---- Tests ---------------------------------------------------------------
 
-describe("wormhole integration — happy path", () => {
+describe("peer-exec integration — happy path", () => {
   test("relays a signed request to the peer and returns the response verbatim", async () => {
     const captures: PeerCapture[] = [];
     const stubPeerUrl = "http://stub-peer-test:9999";
@@ -144,10 +144,10 @@ describe("wormhole integration — happy path", () => {
     installPeerRouter(stubPeerUrl, stubApp);
 
     const app = makeMawApp();
-    const res = await app.request("/api/wormhole/request", {
+    const res = await app.request("/api/peer/exec", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: makeWormholeBody(),
+      body: makePeerExecBody(),
     });
 
     expect(res.status).toBe(200);
@@ -175,10 +175,10 @@ describe("wormhole integration — happy path", () => {
     installPeerRouter(stubPeerUrl, stubApp);
 
     const app = makeMawApp();
-    await app.request("/api/wormhole/request", {
+    await app.request("/api/peer/exec", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: makeWormholeBody({ cmd: "/trace", args: ["--deep"] }),
+      body: makePeerExecBody({ cmd: "/trace", args: ["--deep"] }),
     });
 
     expect(captures.length).toBe(1);
@@ -195,7 +195,7 @@ describe("wormhole integration — happy path", () => {
   });
 });
 
-describe("wormhole integration — peer error paths", () => {
+describe("peer-exec integration — peer error paths", () => {
   test("peer returns 500 → we return 200 with peer's status in body", async () => {
     // Note: we return 200 from our route even when the peer errored.
     // The peer's status is in the body's `status` field for the caller
@@ -210,10 +210,10 @@ describe("wormhole integration — peer error paths", () => {
     installPeerRouter(stubPeerUrl, stubApp);
 
     const app = makeMawApp();
-    const res = await app.request("/api/wormhole/request", {
+    const res = await app.request("/api/peer/exec", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: makeWormholeBody(),
+      body: makePeerExecBody(),
     });
 
     expect(res.status).toBe(200); // OUR route succeeded
@@ -229,10 +229,10 @@ describe("wormhole integration — peer error paths", () => {
     }) as typeof fetch;
 
     const app = makeMawApp();
-    const res = await app.request("/api/wormhole/request", {
+    const res = await app.request("/api/peer/exec", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: makeWormholeBody({ peer: "http://will-not-resolve.invalid:1234" }),
+      body: makePeerExecBody({ peer: "http://will-not-resolve.invalid:1234" }),
     });
 
     expect(res.status).toBe(502);
@@ -242,7 +242,7 @@ describe("wormhole integration — peer error paths", () => {
   });
 });
 
-describe("wormhole integration — body round-trip", () => {
+describe("peer-exec integration — body round-trip", () => {
   test("large response bodies round-trip cleanly", async () => {
     // Locks the v0.1-over-HTTP "one JSON blob per response" behavior.
     // Iteration 4+'s v0.2 protocol will replace this with chunked
@@ -256,10 +256,10 @@ describe("wormhole integration — body round-trip", () => {
     installPeerRouter(stubPeerUrl, stubApp);
 
     const app = makeMawApp();
-    const res = await app.request("/api/wormhole/request", {
+    const res = await app.request("/api/peer/exec", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: makeWormholeBody(),
+      body: makePeerExecBody(),
     });
 
     expect(res.status).toBe(200);
@@ -280,10 +280,10 @@ describe("wormhole integration — body round-trip", () => {
     installPeerRouter(stubPeerUrl, stubApp);
 
     const app = makeMawApp();
-    const res = await app.request("/api/wormhole/request", {
+    const res = await app.request("/api/peer/exec", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: makeWormholeBody(),
+      body: makePeerExecBody(),
     });
 
     expect(res.status).toBe(200);

--- a/test/peer-exec.test.ts
+++ b/test/peer-exec.test.ts
@@ -1,6 +1,6 @@
 /**
- * Tests for POST /api/wormhole/request — the HTTP transport prototype for
- * the /wormhole protocol. Companion to src/api/wormhole.ts.
+ * Tests for POST /api/peer/exec — the HTTP transport prototype for
+ * the /wormhole protocol. Companion to src/api/peer-exec.ts.
  *
  * PROTOTYPE — iteration 4 of the federation-join-easy /loop. Drafted on the
  * feat/wormhole-http-endpoint-draft branch. See
@@ -23,8 +23,8 @@ import {
   isReadOnlyCmd,
   isShellPeerAllowed,
   resolvePeerUrl,
-  wormholeApi,
-} from "../src/api/wormhole";
+  peerExecApi,
+} from "../src/api/peer-exec";
 
 // ---- Pure helper tests ---------------------------------------------------
 
@@ -155,14 +155,14 @@ describe("resolvePeerUrl", () => {
 
 // ---- In-process POST route tests ----------------------------------------
 
-// Mount wormholeApi on a bare Hono app so we can call it with app.request().
+// Mount peerExecApi on a bare Hono app so we can call it with app.request().
 // This avoids booting the full server and keeps the tests deterministic.
 
 function makeApp(): Hono {
   const app = new Hono();
   // Mount under /api to match the real mount point in src/api/index.ts
   const apiSub = new Hono();
-  apiSub.route("/", wormholeApi);
+  apiSub.route("/", peerExecApi);
   app.route("/api", apiSub);
   return app;
 }
@@ -178,40 +178,40 @@ afterEach(() => {
   process.env.NODE_ENV = savedEnv;
 });
 
-describe("GET /api/wormhole/session", () => {
-  test("issues a wh_session cookie", async () => {
+describe("GET /api/peer/session", () => {
+  test("issues a pe_session cookie", async () => {
     const app = makeApp();
-    const res = await app.request("/api/wormhole/session");
+    const res = await app.request("/api/peer/session");
     expect(res.status).toBe(200);
     const cookie = res.headers.get("set-cookie");
     expect(cookie).not.toBeNull();
-    expect(cookie!).toMatch(/wh_session=[a-f0-9]+/);
+    expect(cookie!).toMatch(/pe_session=[a-f0-9]+/);
     expect(cookie!).toContain("HttpOnly");
     expect(cookie!).toContain("SameSite=Strict");
   });
 
   test("returns ok + rotation policy", async () => {
     const app = makeApp();
-    const res = await app.request("/api/wormhole/session");
+    const res = await app.request("/api/peer/session");
     const body = (await res.json()) as any;
     expect(body.ok).toBe(true);
     expect(body.rotates).toBe("on_server_restart");
   });
 });
 
-describe("POST /api/wormhole/request (trust flow)", () => {
+describe("POST /api/peer/exec (trust flow)", () => {
   async function sessionCookie(app: Hono): Promise<string> {
-    const res = await app.request("/api/wormhole/session");
+    const res = await app.request("/api/peer/session");
     const setCookie = res.headers.get("set-cookie") ?? "";
-    const match = setCookie.match(/wh_session=([a-f0-9]+)/);
+    const match = setCookie.match(/pe_session=([a-f0-9]+)/);
     if (!match) throw new Error("no session cookie issued");
-    return `wh_session=${match[1]}`;
+    return `pe_session=${match[1]}`;
   }
 
   test("400 on missing fields (no peer)", async () => {
     const app = makeApp();
     const cookie = await sessionCookie(app);
-    const res = await app.request("/api/wormhole/request", {
+    const res = await app.request("/api/peer/exec", {
       method: "POST",
       headers: { "Content-Type": "application/json", Cookie: cookie },
       body: JSON.stringify({ cmd: "/dig", signature: "[local:anon-1]" }),
@@ -224,7 +224,7 @@ describe("POST /api/wormhole/request (trust flow)", () => {
   test("400 on bad signature shape", async () => {
     const app = makeApp();
     const cookie = await sessionCookie(app);
-    const res = await app.request("/api/wormhole/request", {
+    const res = await app.request("/api/peer/exec", {
       method: "POST",
       headers: { "Content-Type": "application/json", Cookie: cookie },
       body: JSON.stringify({ peer: "white", cmd: "/dig", signature: "not-a-signature" }),
@@ -236,7 +236,7 @@ describe("POST /api/wormhole/request (trust flow)", () => {
 
   test("401 when session cookie is missing (production mode)", async () => {
     const app = makeApp();
-    const res = await app.request("/api/wormhole/request", {
+    const res = await app.request("/api/peer/exec", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -253,7 +253,7 @@ describe("POST /api/wormhole/request (trust flow)", () => {
   test("403 when anon-* origin tries a non-readonly cmd", async () => {
     const app = makeApp();
     const cookie = await sessionCookie(app);
-    const res = await app.request("/api/wormhole/request", {
+    const res = await app.request("/api/peer/exec", {
       method: "POST",
       headers: { "Content-Type": "application/json", Cookie: cookie },
       body: JSON.stringify({
@@ -271,7 +271,7 @@ describe("POST /api/wormhole/request (trust flow)", () => {
   test("404 on unknown peer name (readonly cmd that passes trust check)", async () => {
     const app = makeApp();
     const cookie = await sessionCookie(app);
-    const res = await app.request("/api/wormhole/request", {
+    const res = await app.request("/api/peer/exec", {
       method: "POST",
       headers: { "Content-Type": "application/json", Cookie: cookie },
       body: JSON.stringify({
@@ -288,7 +288,7 @@ describe("POST /api/wormhole/request (trust flow)", () => {
   test("invalid JSON body → 400 invalid_body", async () => {
     const app = makeApp();
     const cookie = await sessionCookie(app);
-    const res = await app.request("/api/wormhole/request", {
+    const res = await app.request("/api/peer/exec", {
       method: "POST",
       headers: { "Content-Type": "application/json", Cookie: cookie },
       body: "not-json-{",
@@ -302,7 +302,7 @@ describe("POST /api/wormhole/request (trust flow)", () => {
     // Flip to development for this one test
     process.env.NODE_ENV = "development";
     const app = makeApp();
-    const res = await app.request("/api/wormhole/request", {
+    const res = await app.request("/api/peer/exec", {
       method: "POST",
       headers: { "Content-Type": "application/json" }, // no cookie
       body: JSON.stringify({


### PR DESCRIPTION
Mechanical rename. Zero logic changes. See mawjs-oracle's recommendation in the maw hey thread. Nat approved.

## Summary
- `/api/wormhole/request` → `/api/peer/exec`
- `/api/wormhole/session` → `/api/peer/session`
- `wormholeApi` → `peerExecApi`
- `wh_session` cookie → `pe_session` cookie
- `READONLY_CMD_PREFIXES` → `READONLY_CMDS` (accuracy fix per code review)
- `src/api/wormhole.ts` → `src/api/peer-exec.ts`
- `test/wormhole.*.ts` → `test/peer-exec.*.ts`

Internal `/wormhole` skill name unchanged — this is ONLY the HTTP API surface.

## Test plan
- [x] `bun run build` passes (165 modules bundled)
- [x] `bun test` passes (445 pass, 0 fail — same count as before rename)
- [x] All remaining "wormhole" references are intentional (skill name, config keys, historical branch names, agent names in test data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)