### PR TITLE
feat(wake): accept GitHub URL or org/repo slug as wake target

### DIFF
--- a/src/cli/route-agent.ts
+++ b/src/cli/route-agent.ts
@@ -1,4 +1,5 @@
 import { cmdWake, fetchIssuePrompt } from "../commands/wake";
+import { parseWakeTarget } from "../commands/wake-resolve";
 import { cmdWakeAll, cmdSleep } from "../commands/fleet";
 import { cmdDone } from "../commands/done";
 import { cmdSleepOne } from "../commands/sleep";
@@ -8,13 +9,20 @@ import { cmdBud } from "../commands/bud";
 
 export async function routeAgent(cmd: string, args: string[]): Promise<boolean> {
   if (cmd === "wake") {
-    if (!args[1]) { console.error("usage: maw wake <oracle> [task] [--new <name>] [--fresh] [--no-attach] [--list]\n       maw wake all [--kill]"); process.exit(1); }
+    if (!args[1]) { console.error("usage: maw wake <oracle|org/repo|URL> [task] [--new <name>] [--fresh] [--no-attach] [--list]\n       maw wake all [--kill]"); process.exit(1); }
     if (args[1].toLowerCase() === "all") {
       await cmdWakeAll({ kill: args.includes("--kill"), all: args.includes("--all"), resume: args.includes("--resume") });
     } else {
       const wakeOpts: { task?: string; newWt?: string; prompt?: string; incubate?: string; fresh?: boolean; noAttach?: boolean; listWt?: boolean } = {};
       let issueNum: number | null = null;
       let repo: string | undefined;
+      // Detect URL or org/repo slug → auto-incubate
+      const parsed = parseWakeTarget(args[1]);
+      const oracleName = parsed ? parsed.oracle : args[1];
+      if (parsed) {
+        wakeOpts.incubate = parsed.slug;
+        if (parsed.issueNum) { issueNum = parsed.issueNum; }
+      }
       for (let i = 2; i < args.length; i++) {
         if (args[i] === "--new" && args[i + 1]) { wakeOpts.newWt = args[++i]; }
         else if (args[i] === "--incubate" && args[i + 1]) { wakeOpts.incubate = args[++i]; }
@@ -32,7 +40,7 @@ export async function routeAgent(cmd: string, args: string[]): Promise<boolean> 
         wakeOpts.prompt = await fetchIssuePrompt(issueNum, repo);
         if (!wakeOpts.task) wakeOpts.task = `issue-${issueNum}`;
       }
-      await cmdWake(args[1], wakeOpts);
+      await cmdWake(oracleName, wakeOpts);
     }
     return true;
   }

--- a/src/cli/usage.ts
+++ b/src/cli/usage.ts
@@ -112,8 +112,10 @@ export function usage() {
   maw wake neo --new free     Create worktree + wake
   maw wake neo --issue 5      Fetch issue #5 + send as claude -p prompt
   maw wake neo --issue 5 --repo org/repo   Explicit repo
-  maw wake neo --incubate org/repo         Clone via ghq + worktree
-  maw wake neo --incubate org/repo --issue 5  Incubate + issue prompt
+  maw wake org/repo                        Clone via ghq + wake (auto-detect name)
+  maw wake https://github.com/org/repo     Full GitHub URL works too
+  maw wake org/repo --issue 5              Clone + issue prompt
+  maw wake neo --incubate org/repo         Explicit incubate (legacy form)
 
 \x1b[33mPulse add:\x1b[0m
   maw pulse ls                Board table (terminal)

--- a/src/commands/wake-resolve.ts
+++ b/src/commands/wake-resolve.ts
@@ -158,3 +158,62 @@ export function sanitizeBranchName(name: string): string {
   return name.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9._\-]/g, "")
     .replace(/\.{2,}/g, ".").replace(/^[-.]|[-.]$/g, "").slice(0, 50);
 }
+
+// --- Wake target parsing (URL / org-repo slug detection) ------------------
+
+/** Matches "org/repo" — exactly two segments, GitHub-safe characters only */
+const ORG_REPO_SLUG = /^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/;
+
+/** Matches GitHub URLs: https://github.com/org/repo[.git][/issues/N][/...] and git@ SSH form */
+const GITHUB_URL = /^(?:https?:\/\/|git@)github\.com[:/]([^/]+)\/([^/.]+?)(?:\.git)?(?:\/issues\/(\d+))?(?:\/.*)?$/;
+
+function matchGitHubUrl(input: string): { org: string; repo: string; issueNum?: number } | null {
+  const m = input.match(GITHUB_URL);
+  if (!m) return null;
+  return { org: m[1], repo: m[2], ...(m[3] ? { issueNum: parseInt(m[3]) } : {}) };
+}
+
+function isOrgRepoSlug(input: string): boolean {
+  return ORG_REPO_SLUG.test(input);
+}
+
+function stripOracleSuffix(repoName: string): string {
+  return repoName.replace(/-oracle$/, "");
+}
+
+export interface ParsedWakeTarget {
+  /** Oracle name derived from repo (e.g. "mawjs" from "mawjs-oracle") */
+  oracle: string;
+  /** org/repo slug for ghq clone (e.g. "Soul-Brews-Studio/mawjs-oracle") */
+  slug: string;
+  /** Issue number if the URL contained /issues/N */
+  issueNum?: number;
+}
+
+/**
+ * Detect whether a wake target is a GitHub URL or org/repo slug.
+ * Returns null if the target is a plain oracle name (existing behavior).
+ */
+export function parseWakeTarget(target: string): ParsedWakeTarget | null {
+  const cleaned = target.trim();
+
+  // Full GitHub URL: https://github.com/org/repo, git@github.com:org/repo.git, etc.
+  const ghUrl = matchGitHubUrl(cleaned);
+  if (ghUrl) {
+    return {
+      oracle: stripOracleSuffix(ghUrl.repo),
+      slug: `${ghUrl.org}/${ghUrl.repo}`,
+      ...(ghUrl.issueNum ? { issueNum: ghUrl.issueNum } : {}),
+    };
+  }
+
+  // Short slug: "org/repo" (exactly one slash, no protocol prefix)
+  if (isOrgRepoSlug(cleaned)) {
+    const [org, rawRepo] = cleaned.split("/");
+    const repo = rawRepo.replace(/\.git$/, "");
+    return { oracle: stripOracleSuffix(repo), slug: `${org}/${repo}` };
+  }
+
+  // Plain oracle name — let existing resolution handle it
+  return null;
+}

--- a/test/wake-target-parser.test.ts
+++ b/test/wake-target-parser.test.ts
@@ -1,0 +1,122 @@
+import { describe, test, expect } from "bun:test";
+import { parseWakeTarget } from "../src/commands/wake-resolve";
+
+describe("parseWakeTarget — GitHub URLs", () => {
+  test("basic HTTPS URL", () => {
+    const r = parseWakeTarget("https://github.com/org/repo");
+    expect(r).toEqual({ oracle: "repo", slug: "org/repo" });
+  });
+
+  test("strips -oracle suffix from oracle name", () => {
+    const r = parseWakeTarget("https://github.com/org/repo-oracle");
+    expect(r).toEqual({ oracle: "repo", slug: "org/repo-oracle" });
+  });
+
+  test("strips .git suffix", () => {
+    const r = parseWakeTarget("https://github.com/org/repo.git");
+    expect(r).toEqual({ oracle: "repo", slug: "org/repo" });
+  });
+
+  test("HTTP without TLS", () => {
+    const r = parseWakeTarget("http://github.com/org/repo");
+    expect(r).toEqual({ oracle: "repo", slug: "org/repo" });
+  });
+
+  test("git@ SSH with .git", () => {
+    const r = parseWakeTarget("git@github.com:org/repo.git");
+    expect(r).toEqual({ oracle: "repo", slug: "org/repo" });
+  });
+
+  test("git@ SSH without .git", () => {
+    const r = parseWakeTarget("git@github.com:org/repo");
+    expect(r).toEqual({ oracle: "repo", slug: "org/repo" });
+  });
+
+  test("extracts issue number from URL", () => {
+    const r = parseWakeTarget("https://github.com/org/repo/issues/42");
+    expect(r).toEqual({ oracle: "repo", slug: "org/repo", issueNum: 42 });
+  });
+
+  test("extracts issue number and strips -oracle suffix", () => {
+    const r = parseWakeTarget("https://github.com/org/repo-oracle/issues/7");
+    expect(r).toEqual({ oracle: "repo", slug: "org/repo-oracle", issueNum: 7 });
+  });
+
+  test("trailing slash is ignored", () => {
+    const r = parseWakeTarget("https://github.com/org/repo/");
+    expect(r).toEqual({ oracle: "repo", slug: "org/repo" });
+  });
+
+  test("real-world long org name with -oracle repo (Nat's use case)", () => {
+    const r = parseWakeTarget("https://github.com/the-oracle-keeps-the-human-human/graph-oracle");
+    expect(r).toEqual({ oracle: "graph", slug: "the-oracle-keeps-the-human-human/graph-oracle" });
+  });
+});
+
+describe("parseWakeTarget — org/repo slugs", () => {
+  test("Soul-Brews-Studio/mawjs-oracle → oracle 'mawjs', slug preserved", () => {
+    const r = parseWakeTarget("Soul-Brews-Studio/mawjs-oracle");
+    expect(r).not.toBeNull();
+    expect(r!.oracle).toBe("mawjs");
+    expect(r!.slug).toBe("Soul-Brews-Studio/mawjs-oracle");
+    expect(r!.issueNum).toBeUndefined();
+  });
+
+  test("acme/my-project → oracle 'my-project' (no -oracle suffix)", () => {
+    const r = parseWakeTarget("acme/my-project");
+    expect(r).not.toBeNull();
+    expect(r!.oracle).toBe("my-project");
+    expect(r!.slug).toBe("acme/my-project");
+  });
+
+  test("acme/my-project.git → strips .git suffix", () => {
+    const r = parseWakeTarget("acme/my-project.git");
+    expect(r).not.toBeNull();
+    expect(r!.oracle).toBe("my-project");
+    expect(r!.slug).toBe("acme/my-project");
+  });
+
+  test("long org name with -oracle suffix stripped (Nat's real case)", () => {
+    const r = parseWakeTarget("the-oracle-keeps-the-human-human/graph-oracle");
+    expect(r).not.toBeNull();
+    expect(r!.oracle).toBe("graph");
+    expect(r!.slug).toBe("the-oracle-keeps-the-human-human/graph-oracle");
+  });
+
+  test("leading/trailing whitespace is trimmed", () => {
+    const r = parseWakeTarget("  Soul-Brews-Studio/mawjs-oracle  ");
+    expect(r).not.toBeNull();
+    expect(r!.oracle).toBe("mawjs");
+    expect(r!.slug).toBe("Soul-Brews-Studio/mawjs-oracle");
+  });
+});
+
+describe("parseWakeTarget — null returns (plain oracle names)", () => {
+  test("bare name 'neo' → null", () => {
+    expect(parseWakeTarget("neo")).toBeNull();
+  });
+
+  test("hyphenated bare name 'maw-js' → null", () => {
+    expect(parseWakeTarget("maw-js")).toBeNull();
+  });
+
+  test("keyword 'all' → null", () => {
+    expect(parseWakeTarget("all")).toBeNull();
+  });
+
+  test("multi-segment path 'a/b/c' → null (not a valid slug)", () => {
+    expect(parseWakeTarget("a/b/c")).toBeNull();
+  });
+
+  test("absolute path '/home/user/repo' → null", () => {
+    expect(parseWakeTarget("/home/user/repo")).toBeNull();
+  });
+
+  test("flag-like arg '--flag' → null", () => {
+    expect(parseWakeTarget("--flag")).toBeNull();
+  });
+
+  test("empty string → null", () => {
+    expect(parseWakeTarget("")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

`maw wake` now accepts GitHub URLs and org/repo slugs directly:

```bash
maw wake org/repo                                      # auto-clone + wake
maw wake https://github.com/org/repo                   # full URL works too
maw wake https://github.com/org/repo/issues/5          # extracts issue number
maw wake the-oracle-keeps-the-human-human/graph-oracle  # Nat's exact use case
```

All existing flags compose: `--issue`, `--new`, `--fresh`, `--no-attach`. Bare oracle names (`maw wake neo`) still work as before.

## How it works

New pure helper `parseWakeTarget()` in `wake-resolve.ts` detects URLs/slugs at the arg-parsing layer. When detected, oracle name is derived (strip `-oracle` suffix) and `opts.incubate` is set — the **existing** incubate flow handles the clone. Zero changes to `wake.ts` or `resolveOracle()`.

Named regex constants + small helpers (per Nat's code review feedback):
- `GITHUB_URL` / `ORG_REPO_SLUG` — named patterns instead of inline regex walls
- `matchGitHubUrl()` / `isOrgRepoSlug()` / `stripOracleSuffix()` — readable helpers

## Test plan
- [x] 22 new tests (3 describe blocks: GitHub URLs, org/repo slugs, null returns)
- [x] 479 existing tests pass, 0 regressions
- [x] Build clean (165 modules)
- [ ] Smoke: `maw wake the-oracle-keeps-the-human-human/graph-oracle --no-attach`

## Diff: +195/-4 across 4 files

Closes #263.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>