### PR TITLE
fix(wake): ghq resolve-first, no auto-worktree for URL targets

### DIFF
--- a/src/cli/route-agent.ts
+++ b/src/cli/route-agent.ts
@@ -1,5 +1,5 @@
 import { cmdWake, fetchIssuePrompt } from "../commands/wake";
-import { parseWakeTarget } from "../commands/wake-resolve";
+import { parseWakeTarget, ensureCloned } from "../commands/wake-resolve";
 import { cmdWakeAll, cmdSleep } from "../commands/fleet";
 import { cmdDone } from "../commands/done";
 import { cmdSleepOne } from "../commands/sleep";
@@ -16,12 +16,12 @@ export async function routeAgent(cmd: string, args: string[]): Promise<boolean> 
       const wakeOpts: { task?: string; newWt?: string; prompt?: string; incubate?: string; fresh?: boolean; noAttach?: boolean; listWt?: boolean } = {};
       let issueNum: number | null = null;
       let repo: string | undefined;
-      // Detect URL or org/repo slug → auto-incubate
+      // Detect URL or org/repo slug → clone via ghq, then let resolveOracle find it
       const parsed = parseWakeTarget(args[1]);
       const oracleName = parsed ? parsed.oracle : args[1];
       if (parsed) {
-        wakeOpts.incubate = parsed.slug;
-        if (parsed.issueNum) { issueNum = parsed.issueNum; }
+        await ensureCloned(parsed.slug);
+        if (parsed.issueNum) { issueNum = parsed.issueNum; repo = parsed.slug; }
       }
       for (let i = 2; i < args.length; i++) {
         if (args[i] === "--new" && args[i + 1]) { wakeOpts.newWt = args[++i]; }

--- a/src/commands/wake-resolve.ts
+++ b/src/commands/wake-resolve.ts
@@ -217,3 +217,19 @@ export function parseWakeTarget(target: string): ParsedWakeTarget | null {
   // Plain oracle name — let existing resolution handle it
   return null;
 }
+
+/**
+ * Ensure a repo is cloned via ghq. Checks locally first (fast),
+ * clones from GitHub only if not found. Silent on failure — lets
+ * resolveOracle handle the error downstream.
+ */
+export async function ensureCloned(slug: string): Promise<void> {
+  const ghqHit = await hostExec(`ghq list --full-path | grep -i '/${slug}$' | head -1`).catch(() => "");
+  if (ghqHit.trim()) return;
+  console.log(`\x1b[36m⚡\x1b[0m cloning ${slug}...`);
+  try {
+    await hostExec(`ghq get -p github.com/${slug}`);
+  } catch (e: any) {
+    console.log(`\x1b[33m⚠\x1b[0m clone failed: ${e.message || e}\n  falling back to normal resolution`);
+  }
+}

--- a/test/ui.test.ts
+++ b/test/ui.test.ts
@@ -161,7 +161,8 @@ describe("parseUiArgs", () => {
 describe("renderUiOutput — bare mode", () => {
   test("no args → just the local URL on one line", () => {
     const out = renderUiOutput({});
-    expect(out).toBe("http://localhost:5173/federation_2d.html");
+    // Port depends on Shape A: 3456 if ~/.maw/ui/dist installed, 5173 otherwise
+    expect(out).toMatch(/^http:\/\/localhost:\d+\/federation_2d\.html$/);
     // No comments, no extra noise — pipe-friendly.
     expect(out).not.toContain("#");
     expect(out.split("\n").length).toBe(1);
@@ -169,14 +170,14 @@ describe("renderUiOutput — bare mode", () => {
 
   test("--3d → federation.html", () => {
     const out = renderUiOutput({ threeD: true });
-    expect(out).toBe("http://localhost:5173/federation.html");
+    expect(out).toMatch(/^http:\/\/localhost:\d+\/federation\.html$/);
   });
 });
 
 describe("renderUiOutput — peer mode", () => {
   test("literal peer → URL with encoded ?host=", () => {
     const out = renderUiOutput({ peer: "10.20.0.7:3456" });
-    expect(out).toBe("http://localhost:5173/federation_2d.html?host=10.20.0.7%3A3456");
+    expect(out).toMatch(/^http:\/\/localhost:\d+\/federation_2d\.html\?host=10\.20\.0\.7%3A3456$/);
     expect(out.split("\n").length).toBe(1);
   });
 
@@ -202,8 +203,8 @@ describe("renderUiOutput — tunnel mode", () => {
     expect(out).toContain("-L 3456:localhost:3456");
     expect(out).toContain("@10.20.0.16");
 
-    // The URL is on its own line for easy copy
-    expect(out).toContain("http://localhost:5173/federation_2d.html");
+    // The URL is on its own line for easy copy (port depends on Shape A install state)
+    expect(out).toMatch(/http:\/\/localhost:\d+\/federation_2d\.html/);
   });
 
   test("--tunnel without peer → usage hint", () => {
@@ -254,12 +255,13 @@ describe("the pipe-friendliness invariant", () => {
     // The SSH command is its own line with NO leading text
     const sshLine = lines.find((l) => l.startsWith("ssh "));
     expect(sshLine).not.toBeUndefined();
-    expect(sshLine).toBe("ssh -N -L 5173:localhost:5173 -L 3456:localhost:3456 " + (process.env.USER || "neo") + "@10.20.0.16");
+    expect(sshLine).toContain("-L 3456:localhost:3456");
+    expect(sshLine).toContain("@10.20.0.16");
 
     // The URL is its own line with NO leading text
     const urlLine = lines.find((l) => l.startsWith("http://"));
     expect(urlLine).not.toBeUndefined();
-    expect(urlLine).toBe("http://localhost:5173/federation_2d.html");
+    expect(urlLine).toMatch(/^http:\/\/localhost:\d+\/federation_2d\.html$/);
   });
 
   test("no ANSI escapes anywhere in tunnel mode output", () => {


### PR DESCRIPTION
## The bug Nat hit

```
$ maw wake https://github.com/Arkkra-Co/colab-pro-max-oracle
⚡ incubating Arkkra-Co/colab-pro-max-oracle...
⚡ reusing worktree: .../colab-pro-max-oracle.wt-1-colabpromaxoracle
⚡ 'colab-pro-max-colabpromaxoracle' already running in colab-pro-max
```

"too complex we just start? use ghq?" — Nat

## What went wrong

PR #265 set `opts.incubate = parsed.slug` which triggered wake.ts's incubate flow. That flow auto-creates a worktree (`opts.newWt = repoName.replace(/-/g, "")`) and mangles the session name. The user wanted: clone + wake in main repo. They got: clone + worktree + mangled name.

## The fix (2 changes)

**1. ghq clone directly, no opts.incubate:**
```ts
// Before (triggered worktree):
wakeOpts.incubate = parsed.slug;

// After (simple clone, resolveOracle finds it):
const ghqHit = await hostExec(`ghq list --full-path | grep -i '/${parsed.slug}$'`).catch(() => "");
if (!ghqHit.trim()) {
  await hostExec(`ghq get -p github.com/${parsed.slug}`);
}
```

**2. Resolve first:** checks ghq locally BEFORE cloning (fast path when already cloned).

**3. Error visibility:** clone failures now print a warning instead of silent `catch {}`.

## Also fixes 5 pre-existing test failures

Shape A (#262) changed the default port from 5173 → 3456 but `test/ui.test.ts` still hardcoded 5173. Tests now use port-agnostic regex patterns.

## Test plan
- [x] 467 pass, 0 fail (was 5 fail before this PR)
- [x] Build clean
- [ ] Smoke: `maw wake Arkkra-Co/colab-pro-max-oracle` on white

+22/-10 across 2 files.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>