### PR TITLE
fix(bud): --repo uses ensureCloned instead of incubate (no worktree)

### DIFF
--- a/src/commands/bud.ts
+++ b/src/commands/bud.ts
@@ -282,7 +282,10 @@ Run \`/awaken\` for the full identity setup ceremony.
     wakeOpts.task = `issue-${opts.issue}`;
   }
   if (opts.repo) {
-    wakeOpts.incubate = opts.repo;
+    // Clone the target repo via ghq (resolve-first, no worktree).
+    // Previously set wakeOpts.incubate which auto-created a worktree — see #271.
+    const { ensureCloned } = await import("./wake-target");
+    await ensureCloned(opts.repo);
   }
 
   try {


### PR DESCRIPTION
## Bug

`maw bud --repo org/repo` creates an unwanted worktree window because `bud.ts:285` sets `wakeOpts.incubate` which triggers wake.ts's auto-worktree flow.

## Fix

Replace `wakeOpts.incubate = opts.repo` with `await ensureCloned(opts.repo)` from `wake-target.ts`. Same pattern as #269 — ghq clone with resolve-first, no worktree.

**1 file changed, 4 insertions, 1 deletion.**

## Test plan
- [x] 467 pass, 0 fail
- [x] Build clean
- [ ] Smoke: `maw bud test-oracle --root --repo org/repo` on white

Closes #271.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>