### PR TITLE
fix(feed): remove hardcoded GMT+7 offset, use system timezone (#267)

### DIFF
--- a/src/lib/feed.ts
+++ b/src/lib/feed.ts
@@ -69,8 +69,8 @@ export function parseLine(line: string): FeedEvent | null {
     sessionId = rest.trim();
   }
 
-  // Parse timestamp to epoch ms
-  const ts = new Date(timestamp.replace(" ", "T") + "+07:00").getTime();
+  // Parse timestamp to epoch ms (no offset → parsed as system local time)
+  const ts = new Date(timestamp.replace(" ", "T")).getTime();
   if (isNaN(ts)) return null;
 
   return { timestamp, oracle, host, event, project, sessionId, message, ts };


### PR DESCRIPTION
## Summary
- Removed hardcoded `+07:00` offset appended to feed timestamps in `src/lib/feed.ts`
- `new Date()` now parses timestamps as local time (per JS spec), so each node uses its own system timezone

Closes #267

## Test plan
- [ ] Feed timestamps render correctly on GMT+7 nodes (unchanged behavior)
- [ ] Feed timestamps render correctly on nodes in other timezones

🤖 Generated with [Claude Code](https://claude.com/claude-code)