### PR TITLE
fix(bud): guard flags-as-name + fix maw update git errors

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,10 +19,10 @@ logAudit(cmd || "", args);
 function getVersionString(): string {
   const pkg = require("../package.json");
   let hash = "";
-  try { hash = require("child_process").execSync("git rev-parse --short HEAD", { cwd: import.meta.dir }).toString().trim(); } catch {}
+  try { hash = require("child_process").execSync("git rev-parse --short HEAD", { cwd: import.meta.dir, stdio: "pipe" }).toString().trim(); } catch {}
   let buildDate = "";
   try {
-    const raw = require("child_process").execSync("git log -1 --format=%ci", { cwd: import.meta.dir }).toString().trim();
+    const raw = require("child_process").execSync("git log -1 --format=%ci", { cwd: import.meta.dir, stdio: "pipe" }).toString().trim();
     const d = new Date(raw);
     const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
     buildDate = `${raw.slice(0, 10)} ${days[d.getDay()]} ${raw.slice(11, 16)}`;
@@ -43,7 +43,7 @@ if (cmd === "--version" || cmd === "-v" || cmd === "version") {
   try { execSync(`bun remove -g maw`, { stdio: "pipe" }); } catch {}
   execSync(`bun add -g github:${repository}#${ref}`, { stdio: "inherit" });
   let after = "";
-  try { after = execSync(`maw --version`, { encoding: "utf-8" }).trim(); } catch {}
+  try { after = execSync(`maw --version`, { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim(); } catch {}
   console.log(`\n  ✅ done`);
   if (after) console.log(`  to:   ${after}\n`);
   else console.log("");

--- a/src/cli/route-agent.ts
+++ b/src/cli/route-agent.ts
@@ -79,6 +79,12 @@ export async function routeAgent(cmd: string, args: string[]): Promise<boolean> 
   }
   if (cmd === "bud") {
     if (!args[1] || args[1] === "--help" || args[1] === "-h") { console.error("usage: maw bud <name> [--from <oracle>] [--root] [--org <org>] [--repo org/repo] [--issue N] [--note <text>] [--fast] [--dry-run]"); process.exit(1); }
+    // Guard: if first arg looks like a flag, user forgot the name
+    if (args[1].startsWith("--")) {
+      console.error(`  \x1b[31m✗\x1b[0m "${args[1]}" looks like a flag, not an oracle name.`);
+      console.error(`  \x1b[90m  usage: maw bud <name> ${args.slice(1).join(" ")}\x1b[0m`);
+      process.exit(1);
+    }
     const budOpts: { from?: string; repo?: string; org?: string; issue?: number; fast?: boolean; root?: boolean; dryRun?: boolean; note?: string } = {};
     for (let i = 2; i < args.length; i++) {
       if (args[i] === "--from" && args[i + 1]) budOpts.from = args[++i];


### PR DESCRIPTION
## Summary
- `maw bud --from <url>` no longer creates `--from-oracle` repo on GitHub. Guards against flags parsed as oracle names.
- `maw update` / `maw --version` no longer prints `fatal: not a git repository` when installed via `bun add -g`

## Test plan
- [ ] `maw bud --from neo` → error: `"--from" looks like a flag, not an oracle name`
- [ ] `maw bud myoracle --from neo` → works normally
- [ ] `maw --version` from `~` → no git errors in output
- [ ] `maw update` → clean from/to output, no fatal messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)