### PR TITLE
feat: nanoclaw transport + cleanup grammy/telegram remnants

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,6 @@
         "@monaco-editor/react": "^4.7.0",
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/xterm": "^5.5.0",
-        "grammy": "^1.42.0",
         "hono": "^4.12.5",
         "mqtt": "^5.15.1",
         "react": "^19.0.0",
@@ -123,8 +122,6 @@
     "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
-
-    "@grammyjs/types": ["@grammyjs/types@3.26.0", "", {}, "sha512-jlnyfxfev/2o68HlvAGRocAXgdPPX5QabG7jZlbqC2r9DZyWBfzTlg+nu3O3Fy4EhgLWu28hZ/8wr7DsNamP9A=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -346,8 +343,6 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
-    "grammy": ["grammy@1.42.0", "", { "dependencies": { "@grammyjs/types": "3.26.0", "abort-controller": "^3.0.0", "debug": "^4.4.3", "node-fetch": "^2.7.0" } }, "sha512-1AdCge+AkjSdp2FwfICSFnVbl8Mq3KVHJDy+DgTI9+D6keJ0zWALPRKas5jv/8psiCzL4N2cEOcGW7O45Kn39g=="],
-
     "help-me": ["help-me@5.0.0", "", {}, "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="],
 
     "hono": ["hono@4.12.5", "", {}, "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg=="],
@@ -412,8 +407,6 @@
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
-    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
-
     "node-releases": ["node-releases@2.0.36", "", {}, "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA=="],
 
     "number-allocator": ["number-allocator@1.0.14", "", { "dependencies": { "debug": "^4.3.1", "js-sdsl": "4.3.0" } }, "sha512-OrL44UTVAvkKdOdRQZIJpLkAdjXGTRda052sN4sO77bKEzYYqWKMBjQvrJFzqygI99gL6Z4u2xctPW1tB8ErvA=="],
@@ -466,8 +459,6 @@
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
-    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
-
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "typedarray": ["typedarray@0.0.6", "", {}, "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="],
@@ -479,10 +470,6 @@
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
-
-    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
-
-    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "worker-factory": ["worker-factory@7.0.49", "", { "dependencies": { "@babel/runtime": "^7.29.2", "fast-unique-numbers": "^9.0.27", "tslib": "^2.8.1" } }, "sha512-lW7tpgy6aUv2dFsQhv1yv+XFzdkCf/leoKRTGMPVK5/die6RrUjqgJHJf556qO+ZfytNG6wPXc17E8zzsOLUDw=="],
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@monaco-editor/react": "^4.7.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",
-    "grammy": "^1.42.0",
     "hono": "^4.12.5",
     "mqtt": "^5.15.1",
     "react": "^19.0.0",

--- a/src/bridges/nanoclaw.ts
+++ b/src/bridges/nanoclaw.ts
@@ -1,7 +1,7 @@
 /**
  * Nanoclaw bridge — sends messages from maw-js through nanoclaw to any channel.
  *
- * POST nanoclaw:PORT/inbound → nanoclaw routes to Telegram/Discord/etc.
+ * POST nanoclaw:PORT/send → nanoclaw routes to Telegram/Discord/etc.
  * Config: maw.config.json → nanoclaw: { url, channels: { nat: "tg:123456789" } }
  *
  * Built by white:mawjs-oracle as the maw-js side of the nanoclaw maw channel
@@ -44,7 +44,7 @@ export function resolveNanoclawJid(target: string): { jid: string; url: string }
 /** Send a message through nanoclaw to any channel */
 export async function sendViaNanoclaw(jid: string, text: string, url: string): Promise<boolean> {
   try {
-    const res = await curlFetch(`${url}/inbound`, {
+    const res = await curlFetch(`${url}/send`, {
       method: "POST",
       body: JSON.stringify({ jid, text }),
     });

--- a/src/config.ts
+++ b/src/config.ts
@@ -323,11 +323,6 @@ function validateConfig(raw: Record<string, unknown>): Partial<MawConfig> {
     result.githubOrg = raw.githubOrg;
   }
 
-  // telegram: pass through (bridge config, not validated here)
-  if ("telegram" in raw && raw.telegram && typeof raw.telegram === "object") {
-    result.telegram = raw.telegram;
-  }
-
   // nanoclaw: pass through (bridge config)
   if ("nanoclaw" in raw && raw.nanoclaw && typeof raw.nanoclaw === "object") {
     result.nanoclaw = raw.nanoclaw;

--- a/src/transports/index.ts
+++ b/src/transports/index.ts
@@ -8,6 +8,7 @@ import { TmuxTransport } from "./tmux";
 import { HttpTransport } from "./http";
 import { HubTransport, loadWorkspaceConfigs } from "./hub";
 import { LoRaTransport } from "./lora";
+import { NanoclawTransport } from "./nanoclaw";
 
 /** Singleton router instance */
 let router: TransportRouter | null = null;
@@ -40,7 +41,10 @@ export function createTransportRouter(): TransportRouter {
     );
   }
 
-  // 4. LoRa (future hardware — stub, canReach() always false)
+  // 4. NanoClaw (external chat channels — Telegram, Discord, etc.)
+  router.register(new NanoclawTransport());
+
+  // 5. LoRa (future hardware — stub, canReach() always false)
   router.register(new LoRaTransport());
 
   return router;
@@ -62,4 +66,5 @@ export function resetTransportRouter() {
 export { TmuxTransport } from "./tmux";
 export { HubTransport } from "./hub";
 export { HttpTransport } from "./http";
+export { NanoclawTransport } from "./nanoclaw";
 export { LoRaTransport } from "./lora";

--- a/src/transports/nanoclaw.ts
+++ b/src/transports/nanoclaw.ts
@@ -1,0 +1,44 @@
+/**
+ * NanoClaw transport — bridge to external chat channels (Telegram, Discord, etc.)
+ *
+ * Routes messages through a running NanoClaw instance via HTTP.
+ * Config: maw.config.json → nanoclaw: { url: "http://localhost:3001", channels: { nat: "tg:123456789" } }
+ *
+ * canReach() returns true for targets matching nanoclaw channel aliases or JID patterns.
+ * send() POSTs { jid, text } to nanoclaw's /send endpoint for delivery.
+ */
+
+import type { Transport, TransportTarget, TransportMessage, TransportPresence } from "../transport";
+import type { FeedEvent } from "../lib/feed";
+import { resolveNanoclawJid, sendViaNanoclaw } from "../bridges/nanoclaw";
+
+export class NanoclawTransport implements Transport {
+  readonly name = "nanoclaw";
+  private _connected = true; // Stateless HTTP — always "connected"
+  private msgHandlers = new Set<(msg: TransportMessage) => void>();
+  private presenceHandlers = new Set<(p: TransportPresence) => void>();
+  private feedHandlers = new Set<(e: FeedEvent) => void>();
+
+  get connected() { return this._connected; }
+
+  async connect(): Promise<void> { this._connected = true; }
+  async disconnect(): Promise<void> { this._connected = false; }
+
+  async send(target: TransportTarget, message: string): Promise<boolean> {
+    const resolved = resolveNanoclawJid(target.oracle);
+    if (!resolved) return false;
+    return sendViaNanoclaw(resolved.jid, message, resolved.url);
+  }
+
+  async publishPresence(_presence: TransportPresence): Promise<void> {}
+  async publishFeed(_event: FeedEvent): Promise<void> {}
+
+  onMessage(handler: (msg: TransportMessage) => void) { this.msgHandlers.add(handler); }
+  onPresence(handler: (p: TransportPresence) => void) { this.presenceHandlers.add(handler); }
+  onFeed(handler: (e: FeedEvent) => void) { this.feedHandlers.add(handler); }
+
+  /** Can reach targets that resolve to a nanoclaw channel JID */
+  canReach(target: TransportTarget): boolean {
+    return resolveNanoclawJid(target.oracle) !== null;
+  }
+}


### PR DESCRIPTION
## Summary
- Removed unused `grammy` dependency (extracted in PR #221, never cleaned up)
- Removed dead `telegram` config pass-through (`nanoclaw` config stays)
- Fixed nanoclaw bridge endpoint: `/inbound` → `/send` (was posting to wrong direction)
- New `NanoclawTransport` (~40 LOC) in the transport layer — enables `maw hey telegram:nat "hello"` to deliver via nanoclaw to Telegram

## Test plan
- [ ] `bun test` passes (473/479, 6 pre-existing snapshot flakes)
- [ ] `maw hey telegram:nat "test"` routes through nanoclaw transport (requires nanoclaw running)
- [ ] No grammy in `node_modules/` after `bun install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)