### PR TITLE
fix(view): deduplicate view sessions by using resolved name

### DIFF
--- a/src/commands/view.ts
+++ b/src/commands/view.ts
@@ -18,8 +18,11 @@ export async function cmdView(agent: string, windowHint?: string, clean = false)
   }
   if (!sessionName) { console.error(`session not found for: ${agent}`); process.exit(1); }
 
-  // Generate unique view name
-  const viewName = `${agent}-view${windowHint ? `-${windowHint}` : ""}`;
+  // Generate view name from RESOLVED session (not raw input) — prevents duplicates
+  // e.g. "maw a worm" and "maw a wormhole" both resolve to "102-white-wormhole"
+  // and should reuse the same view session instead of creating worm-view + wormhole-view
+  const viewBase = sessionName.replace(/^\d+-/, "");
+  const viewName = `${viewBase}-view${windowHint ? `-${windowHint}` : ""}`;
 
   // Kill existing view with same name
   const t = new Tmux();


### PR DESCRIPTION
## Summary
- View sessions now use the resolved session name (e.g. `white-wormhole-view`) instead of raw input (`worm-view`)
- Prevents duplicate view sessions when same oracle is attached via different name fragments

Root cause: `maw a worm` and `maw a wormhole` both resolve to `102-white-wormhole` but created different view names.

## Test plan
- [ ] `maw a wormhole` creates `white-wormhole-view`
- [ ] `maw a worm` reuses `white-wormhole-view` (kills + recreates, same name)
- [ ] No more duplicate `*-view` sessions in `maw ls`

🤖 Generated with [Claude Code](https://claude.com/claude-code)