### PR TITLE
fix(oracle): default scan to local, --all for remote

### DIFF
--- a/src/cli/route-agent.ts
+++ b/src/cli/route-agent.ts
@@ -108,8 +108,9 @@ export async function routeAgent(cmd: string, args: string[]): Promise<boolean> 
       const force = args.includes("--force");
       const local = args.includes("--local");
       const remote = args.includes("--remote");
+      const all = args.includes("--all");
       const verbose = args.includes("--verbose") || args.includes("-v");
-      await cmdOracleScan({ json, force, local, remote, verbose });
+      await cmdOracleScan({ json, force, local, remote, all, verbose });
     } else if (subcmd === "fleet") {
       const json = args.includes("--json");
       const stale = args.includes("--stale");

--- a/src/commands/oracle.ts
+++ b/src/commands/oracle.ts
@@ -208,10 +208,11 @@ export async function cmdOracleList() {
 
 // --- Fleet-wide scan + cache (#208) ---
 
-export async function cmdOracleScan(opts: { force?: boolean; json?: boolean; local?: boolean; remote?: boolean; verbose?: boolean } = {}) {
+export async function cmdOracleScan(opts: { force?: boolean; json?: boolean; local?: boolean; remote?: boolean; all?: boolean; verbose?: boolean } = {}) {
   const start = Date.now();
 
-  const mode = opts.remote ? "remote" : opts.local ? "local" : "both";
+  // Default to local (fast). Use --all or --remote for GitHub API scan.
+  const mode = opts.all ? "both" : opts.remote ? "remote" : "local";
 
   if (mode === "remote") {
     // Remote only — GitHub API


### PR DESCRIPTION
## Summary
- `maw oracle scan` now defaults to local only (fast filesystem scan)
- `maw oracle scan --all` for local + remote (GitHub API)
- `maw oracle scan --remote` for remote only

Previously defaulted to both, which meant 40+ GitHub API calls every time.

## Test plan
- [ ] `maw oracle scan` → fast, local only
- [ ] `maw oracle scan --all -v` → shows both local + remote progress
- [ ] `maw oracle scan --remote` → GitHub only

🤖 Generated with [Claude Code](https://claude.com/claude-code)