### PR TITLE
feat: adopt arg for typed CLI flag parsing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@monaco-editor/react": "^4.7.0",
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/xterm": "^5.5.0",
+        "arg": "^5.0.2",
         "hono": "^4.12.5",
         "mqtt": "^5.15.1",
         "react": "^19.0.0",
@@ -286,6 +287,8 @@
     "@xterm/xterm": ["@xterm/xterm@5.5.0", "", {}, "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A=="],
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
+
+    "arg": ["arg@5.0.2", "", {}, "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="],
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@monaco-editor/react": "^4.7.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",
+    "arg": "^5.0.2",
     "hono": "^4.12.5",
     "mqtt": "^5.15.1",
     "react": "^19.0.0",

--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared CLI argument parsing via `arg`.
+ *
+ * Each command defines its flag spec. `parseFlags` wraps arg() with:
+ * - permissive mode (unknown flags don't throw — they go to argv._)
+ * - sliced argv (strips "maw" + command name)
+ *
+ * Usage:
+ *   const flags = parseFlags(args, { "--verbose": Boolean, "-v": "--verbose" }, 2);
+ *   flags["--verbose"]  // boolean | undefined
+ *   flags._             // positional args
+ */
+
+import arg from "arg";
+
+/**
+ * Parse flags from args array.
+ * @param args - raw process.argv.slice(2) array
+ * @param spec - arg spec (e.g. { "--verbose": Boolean, "--from": String })
+ * @param skip - number of leading positional args to skip (default 0)
+ *               e.g. skip=1 for "bud <name> --from neo" skips "bud"
+ */
+export function parseFlags<T extends arg.Spec>(
+  args: string[],
+  spec: T,
+  skip = 0,
+): arg.Result<T> {
+  return arg(spec, { argv: args.slice(skip), permissive: true });
+}

--- a/src/cli/route-agent.ts
+++ b/src/cli/route-agent.ts
@@ -6,34 +6,49 @@ import { cmdSleepOne } from "../commands/sleep";
 import { cmdOracleList, cmdOracleAbout, cmdOracleScan, cmdOracleFleet } from "../commands/oracle";
 import { cmdTake } from "../commands/take";
 import { cmdBud } from "../commands/bud";
+import { parseFlags } from "./parse-args";
 
 export async function routeAgent(cmd: string, args: string[]): Promise<boolean> {
   if (cmd === "wake") {
     if (!args[1]) { console.error("usage: maw wake <oracle|org/repo|URL> [task] [--new <name>] [--fresh] [--no-attach] [--list]\n       maw wake all [--kill]"); process.exit(1); }
     if (args[1].toLowerCase() === "all") {
-      await cmdWakeAll({ kill: args.includes("--kill"), all: args.includes("--all"), resume: args.includes("--resume") });
+      const flags = parseFlags(args, { "--kill": Boolean, "--all": Boolean, "--resume": Boolean }, 2);
+      await cmdWakeAll({ kill: flags["--kill"], all: flags["--all"], resume: flags["--resume"] });
     } else {
+      const flags = parseFlags(args, {
+        "--new": String,
+        "--incubate": String,
+        "--issue": Number,
+        "--repo": String,
+        "--fresh": Boolean,
+        "--no-attach": Boolean,
+        "--list": Boolean,
+        "--ls": "--list",
+      }, 2);
+
       const wakeOpts: { task?: string; newWt?: string; prompt?: string; incubate?: string; fresh?: boolean; noAttach?: boolean; listWt?: boolean } = {};
-      let issueNum: number | null = null;
-      let repo: string | undefined;
-      // Detect URL or org/repo slug → clone via ghq, then let resolveOracle find it
+      let issueNum: number | null = flags["--issue"] ?? null;
+      let repo: string | undefined = flags["--repo"];
+
+      // Detect URL or org/repo slug → clone via ghq
       const parsed = parseWakeTarget(args[1]);
       const oracleName = parsed ? parsed.oracle : args[1];
       if (parsed) {
         await ensureCloned(parsed.slug);
         if (parsed.issueNum) { issueNum = parsed.issueNum; repo = parsed.slug; }
       }
-      for (let i = 2; i < args.length; i++) {
-        if (args[i] === "--new" && args[i + 1]) { wakeOpts.newWt = args[++i]; }
-        else if (args[i] === "--incubate" && args[i + 1]) { wakeOpts.incubate = args[++i]; }
-        else if (args[i] === "--issue" && args[i + 1]) { issueNum = +args[++i]; }
-        else if (args[i] === "--repo" && args[i + 1]) { repo = args[++i]; }
-        else if (args[i] === "--fresh") { wakeOpts.fresh = true; }
-        else if (args[i] === "--no-attach") { wakeOpts.noAttach = true; }
-        else if (args[i] === "--list" || args[i] === "--ls") { wakeOpts.listWt = true; }
-        else if (!wakeOpts.task) { wakeOpts.task = args[i]; }
-        else if (!wakeOpts.prompt) { wakeOpts.prompt = args.slice(i).join(" "); break; }
-      }
+
+      if (flags["--new"]) wakeOpts.newWt = flags["--new"];
+      if (flags["--incubate"]) wakeOpts.incubate = flags["--incubate"];
+      if (flags["--fresh"]) wakeOpts.fresh = true;
+      if (flags["--no-attach"]) wakeOpts.noAttach = true;
+      if (flags["--list"]) wakeOpts.listWt = true;
+
+      // Positional args after oracle name: task, then prompt
+      const positionals = flags._;
+      if (positionals.length > 0) wakeOpts.task = positionals[0];
+      if (positionals.length > 1) wakeOpts.prompt = positionals.slice(1).join(" ");
+
       if (wakeOpts.incubate && !repo) { repo = wakeOpts.incubate; }
       if (issueNum) {
         console.log(`\x1b[36m⚡\x1b[0m fetching issue #${issueNum}...`);
@@ -57,10 +72,10 @@ export async function routeAgent(cmd: string, args: string[]): Promise<boolean> 
   }
   if (cmd === "done" || cmd === "finish") {
     if (!args[1]) { console.error("usage: maw done <window-name> [--force] [--dry-run]\n       e.g. maw done neo-freelance"); process.exit(1); }
-    const force = args.includes("--force");
-    const dryRun = args.includes("--dry-run");
-    const name = args.slice(1).find(a => !a.startsWith("--"))!;
-    await cmdDone(name, { force, dryRun });
+    const flags = parseFlags(args, { "--force": Boolean, "--dry-run": Boolean }, 1);
+    const name = flags._[0];
+    if (!name) { console.error("usage: maw done <window-name> [--force] [--dry-run]"); process.exit(1); }
+    await cmdDone(name, { force: flags["--force"], dryRun: flags["--dry-run"] });
     return true;
   }
   if (cmd === "stop" || cmd === "rest") {
@@ -78,25 +93,39 @@ export async function routeAgent(cmd: string, args: string[]): Promise<boolean> 
     return true;
   }
   if (cmd === "bud") {
-    if (!args[1] || args[1] === "--help" || args[1] === "-h") { console.error("usage: maw bud <name> [--from <oracle>] [--root] [--org <org>] [--repo org/repo] [--issue N] [--note <text>] [--fast] [--dry-run]"); process.exit(1); }
-    // Guard: if first arg looks like a flag, user forgot the name
-    if (args[1].startsWith("--")) {
-      console.error(`  \x1b[31m✗\x1b[0m "${args[1]}" looks like a flag, not an oracle name.`);
+    const flags = parseFlags(args, {
+      "--from": String,
+      "--org": String,
+      "--repo": String,
+      "--issue": Number,
+      "--note": String,
+      "--fast": Boolean,
+      "--root": Boolean,
+      "--dry-run": Boolean,
+    }, 1);
+
+    const name = flags._[0];
+    if (!name || name === "--help" || name === "-h") {
+      console.error("usage: maw bud <name> [--from <oracle>] [--root] [--org <org>] [--repo org/repo] [--issue N] [--note <text>] [--fast] [--dry-run]");
+      process.exit(1);
+    }
+    // Guard: if name looks like a flag, user forgot the name (e.g. "maw bud --from url")
+    if (name.startsWith("--")) {
+      console.error(`  \x1b[31m✗\x1b[0m "${name}" looks like a flag, not an oracle name.`);
       console.error(`  \x1b[90m  usage: maw bud <name> ${args.slice(1).join(" ")}\x1b[0m`);
       process.exit(1);
     }
-    const budOpts: { from?: string; repo?: string; org?: string; issue?: number; fast?: boolean; root?: boolean; dryRun?: boolean; note?: string } = {};
-    for (let i = 2; i < args.length; i++) {
-      if (args[i] === "--from" && args[i + 1]) budOpts.from = args[++i];
-      else if (args[i] === "--org" && args[i + 1]) budOpts.org = args[++i];
-      else if (args[i] === "--repo" && args[i + 1]) budOpts.repo = args[++i];
-      else if (args[i] === "--issue" && args[i + 1]) budOpts.issue = +args[++i];
-      else if (args[i] === "--note" && args[i + 1]) budOpts.note = args[++i];
-      else if (args[i] === "--fast") budOpts.fast = true;
-      else if (args[i] === "--root") budOpts.root = true;
-      else if (args[i] === "--dry-run") budOpts.dryRun = true;
-    }
-    await cmdBud(args[1], budOpts);
+
+    await cmdBud(name, {
+      from: flags["--from"],
+      repo: flags["--repo"],
+      org: flags["--org"],
+      issue: flags["--issue"],
+      note: flags["--note"],
+      fast: flags["--fast"],
+      root: flags["--root"],
+      dryRun: flags["--dry-run"],
+    });
     return true;
   }
   if (cmd === "oracle" || cmd === "oracles") {
@@ -104,19 +133,30 @@ export async function routeAgent(cmd: string, args: string[]): Promise<boolean> 
     if (!subcmd || subcmd === "ls" || subcmd === "list") {
       await cmdOracleList();
     } else if (subcmd === "scan") {
-      const json = args.includes("--json");
-      const force = args.includes("--force");
-      const local = args.includes("--local");
-      const remote = args.includes("--remote");
-      const all = args.includes("--all");
-      const verbose = args.includes("--verbose") || args.includes("-v");
-      await cmdOracleScan({ json, force, local, remote, all, verbose });
+      const flags = parseFlags(args, {
+        "--json": Boolean,
+        "--force": Boolean,
+        "--local": Boolean,
+        "--remote": Boolean,
+        "--all": Boolean,
+        "--verbose": Boolean,
+        "-v": "--verbose",
+      }, 2);
+      await cmdOracleScan({
+        json: flags["--json"],
+        force: flags["--force"],
+        local: flags["--local"],
+        remote: flags["--remote"],
+        all: flags["--all"],
+        verbose: flags["--verbose"],
+      });
     } else if (subcmd === "fleet") {
-      const json = args.includes("--json");
-      const stale = args.includes("--stale");
-      const orgIdx = args.indexOf("--org");
-      const org = orgIdx >= 0 ? args[orgIdx + 1] : undefined;
-      await cmdOracleFleet({ json, stale, org });
+      const flags = parseFlags(args, {
+        "--json": Boolean,
+        "--stale": Boolean,
+        "--org": String,
+      }, 2);
+      await cmdOracleFleet({ json: flags["--json"], stale: flags["--stale"], org: flags["--org"] });
     } else if (subcmd === "about" && args[2]) {
       await cmdOracleAbout(args[2]);
     } else {

--- a/src/cli/route-tools.ts
+++ b/src/cli/route-tools.ts
@@ -20,9 +20,9 @@ export async function routeTools(cmd: string, args: string[]): Promise<boolean> 
   }
   if (cmd === "view" || cmd === "create-view" || cmd === "attach" || cmd === "a") {
     if (!args[1]) { console.error("usage: maw view <agent> [window] [--clean]"); process.exit(1); }
-    const clean = args.includes("--clean");
-    const viewArgs = args.slice(1).filter(a => a !== "--clean");
-    await cmdView(viewArgs[0], viewArgs[1], clean);
+    const { parseFlags } = await import("./parse-args");
+    const flags = parseFlags(args, { "--clean": Boolean }, 1);
+    await cmdView(flags._[0], flags._[1], flags["--clean"]);
     return true;
   }
   if (cmd === "tab" || cmd === "tabs") {
@@ -67,11 +67,9 @@ export async function routeTools(cmd: string, args: string[]): Promise<boolean> 
   }
   if (cmd === "assign") {
     if (!args[1]) { console.error("usage: maw assign <issue-url> [--oracle <name>]"); process.exit(1); }
-    let oracle: string | undefined;
-    for (let i = 2; i < args.length; i++) {
-      if (args[i] === "--oracle" && args[i + 1]) { oracle = args[++i]; }
-    }
-    await cmdAssign(args[1], { oracle });
+    const { parseFlags } = await import("./parse-args");
+    const flags = parseFlags(args, { "--oracle": String }, 1);
+    await cmdAssign(flags._[0], { oracle: flags["--oracle"] });
     return true;
   }
   if (cmd === "costs" || cmd === "cost") {


### PR DESCRIPTION
## Summary
- Added `arg` (vercel/arg, 0 deps, 3KB) for typed CLI flag parsing
- Shared `parseFlags()` helper in `src/cli/parse-args.ts`
- Migrated `route-agent.ts` (wake, bud, done, oracle scan/fleet) and `route-tools.ts` (view, assign)
- Remaining route files can migrate incrementally

Before: `args.includes("--verbose")` — untyped, no aliases, no error on typos
After: `parseFlags(args, { "--verbose": Boolean, "-v": "--verbose" })` — typed, aliased, clean

## Test plan
- [ ] `maw bud test --from neo --root --dry-run` — all flags parsed correctly
- [ ] `maw oracle scan -v --all` — verbose alias + all flag work
- [ ] `maw wake neo --fresh --no-attach` — typed flags
- [ ] `maw a neo --clean` — view clean flag via arg

🤖 Generated with [Claude Code](https://claude.com/claude-code)