### PR TITLE
feat: maw restart — clean views + update + stop + wake all

### DIFF
--- a/src/cli/route-fleet.ts
+++ b/src/cli/route-fleet.ts
@@ -12,8 +12,16 @@ import { cmdFleetDoctor } from "../commands/fleet-doctor";
 import { cmdFleetConsolidate } from "../commands/fleet-consolidate";
 import { cmdArchive } from "../commands/archive";
 import { cmdFind } from "../commands/find";
+import { cmdRestart } from "../commands/restart";
 
 export async function routeFleet(cmd: string, args: string[]): Promise<boolean> {
+  if (cmd === "restart" || cmd === "reboot") {
+    const noUpdate = args.includes("--no-update");
+    const refIdx = args.indexOf("--ref");
+    const ref = refIdx >= 0 ? args[refIdx + 1] : undefined;
+    await cmdRestart({ noUpdate, ref });
+    return true;
+  }
   if (cmd === "fleet") {
     const sub = args[1];
     if (sub === "init") {

--- a/src/cli/usage.ts
+++ b/src/cli/usage.ts
@@ -23,6 +23,7 @@ export function usage() {
   maw wake all --resume       Wake fleet + send /recap to active board items
   maw sleep <oracle> [window] Gracefully stop one oracle window
   maw stop                    Stop all fleet sessions
+  maw restart                 Clean views + update + stop + wake all
   maw about <oracle>           Oracle profile — session, worktrees, fleet
   maw oracle ls               Fleet status (awake/sleeping/worktrees)
   maw overview              War-room: all oracles in split panes

--- a/src/commands/restart.ts
+++ b/src/commands/restart.ts
@@ -1,0 +1,63 @@
+/**
+ * maw restart — clean slate: kill stale views, update, stop fleet, wake all.
+ *
+ * Like restarting Claude Code but for the whole fleet.
+ *
+ * Steps:
+ *   1. Kill all *-view sessions (stale grouped sessions)
+ *   2. Update maw-js (optional, --no-update to skip)
+ *   3. Stop fleet (maw stop)
+ *   4. Wake fleet (maw wake all)
+ */
+
+import { listSessions } from "../ssh";
+import { Tmux } from "../tmux";
+import { cmdSleep, cmdWakeAll } from "./fleet";
+import { execSync } from "child_process";
+
+export async function cmdRestart(opts: { noUpdate?: boolean; ref?: string } = {}) {
+  const tmux = new Tmux();
+  console.log(`\n  \x1b[36m🔄 maw restart\x1b[0m\n`);
+
+  // 1. Kill stale view sessions
+  const sessions = await listSessions();
+  const views = sessions.filter(s => s.name.endsWith("-view"));
+  if (views.length > 0) {
+    console.log(`  \x1b[33m1. Cleaning ${views.length} stale view sessions...\x1b[0m`);
+    for (const v of views) {
+      await tmux.killSession(v.name);
+      console.log(`    \x1b[90m✗ ${v.name}\x1b[0m`);
+    }
+  } else {
+    console.log(`  \x1b[90m1. No stale views\x1b[0m`);
+  }
+
+  // 2. Update maw-js
+  if (!opts.noUpdate) {
+    const ref = opts.ref || "main";
+    console.log(`\n  \x1b[33m2. Updating maw-js (${ref})...\x1b[0m`);
+    try {
+      const pkg = require("../../package.json");
+      const before = `v${pkg.version}`;
+      try { execSync(`bun remove -g maw`, { stdio: "pipe" }); } catch {}
+      execSync(`bun add -g github:${pkg.repository}#${ref}`, { stdio: "pipe" });
+      let after = "";
+      try { after = execSync(`maw --version`, { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim(); } catch {}
+      console.log(`    ${before} → ${after || "updated"}`);
+    } catch (e: any) {
+      console.log(`    \x1b[33m⚠ update failed: ${e.message?.slice(0, 80) || e}\x1b[0m`);
+    }
+  } else {
+    console.log(`\n  \x1b[90m2. Update skipped (--no-update)\x1b[0m`);
+  }
+
+  // 3. Stop fleet
+  console.log(`\n  \x1b[33m3. Stopping fleet...\x1b[0m`);
+  await cmdSleep();
+
+  // 4. Wake fleet
+  console.log(`  \x1b[33m4. Waking fleet...\x1b[0m`);
+  await cmdWakeAll();
+
+  console.log(`\n  \x1b[32m✓ restart complete\x1b[0m\n`);
+}


### PR DESCRIPTION
## Summary
One command to refresh the entire fleet:
1. Kill stale `*-view` sessions (duplicate grouped sessions)
2. `maw update` (optional, `--no-update` to skip, `--ref alpha` for branch)
3. `maw stop` (kill all fleet sessions)
4. `maw wake all` (restart everything fresh)

Also: `maw reboot` as alias.

## Test plan
- [ ] `maw restart --no-update` — cleans views, stops, wakes
- [ ] `maw restart` — includes update from main
- [ ] `maw restart --ref alpha` — updates from alpha
- [ ] Stale `*-view` sessions killed before restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)