### PR TITLE
fix(bud): extract oracle name from URL/slug in --from (#280)

### DIFF
--- a/src/commands/bud.ts
+++ b/src/commands/bud.ts
@@ -3,6 +3,7 @@ import { loadConfig } from "../config";
 import { loadFleetEntries } from "./fleet-load";
 import { cmdSoulSync } from "./soul-sync";
 import { cmdWake } from "./wake";
+import { parseWakeTarget, ensureCloned } from "./wake-target";
 import { FLEET_DIR } from "../paths";
 import { join } from "path";
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
@@ -48,6 +49,12 @@ export async function cmdBud(name: string, opts: BudOpts = {}) {
 
   // Resolve parent oracle (skip for --root)
   let parentName: string | null = opts.from || null;
+  // If --from is a URL or org/repo slug, extract oracle name and clone (#280)
+  const fromTarget = parentName ? parseWakeTarget(parentName) : null;
+  if (fromTarget) {
+    parentName = fromTarget.oracle;
+    if (!opts.repo) await ensureCloned(fromTarget.slug);
+  }
   if (!parentName && !opts.root) {
     try {
       const cwd = (await hostExec("tmux display-message -p '#{pane_current_path}'")).trim();


### PR DESCRIPTION
## Summary
- When `--from` receives a GitHub URL (e.g. `https://github.com/org/repo`) or org/repo slug, `parseWakeTarget()` now extracts the oracle name instead of storing the raw URL as `parentName`
- Also clones the repo via `ensureCloned()` if `--repo` wasn't already provided, matching existing `--repo` behavior
- ~5 line fix reusing existing `wake-target.ts` utilities

Closes #280

## Test plan
- [ ] `maw bud test1 --from https://github.com/Soul-Brews-Studio/neo-oracle --dry-run` → parentName should be `neo`, not the URL
- [ ] `maw bud test2 --from Soul-Brews-Studio/neo-oracle --dry-run` → parentName should be `neo`
- [ ] `maw bud test3 --from neo --dry-run` → parentName remains `neo` (no regression)
- [ ] `bun test` passes (461 pass, 6 pre-existing snapshot failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)