### PR TITLE
fix(wake): auto-register agent in config.agents (#285)

### DIFF
--- a/src/commands/wake.ts
+++ b/src/commands/wake.ts
@@ -1,6 +1,6 @@
 import { hostExec } from "../ssh";
 import { tmux } from "../tmux";
-import { buildCommand, buildCommandInDir, cfgTimeout } from "../config";
+import { buildCommand, buildCommandInDir, cfgTimeout, loadConfig, saveConfig } from "../config";
 import { restoreTabOrder } from "../tab-order";
 import { takeSnapshot } from "../snapshot";
 import { execSync } from "child_process";
@@ -95,6 +95,15 @@ export async function cmdWake(oracle: string, opts: { task?: string; newWt?: str
     await new Promise(r => setTimeout(r, 300));
     await tmux.sendText(`${session}:${mainWindowName}`, buildCommandInDir(mainWindowName, repoPath));
     console.log(`\x1b[32m+\x1b[0m created session '${session}' (main: ${mainWindowName})`);
+
+    // Auto-register agent in config.agents so federation peers can route to it (#285)
+    const config = loadConfig();
+    const agents = config.agents || {};
+    if (!(oracle in agents)) {
+      const node = config.node || "local";
+      saveConfig({ agents: { ...agents, [oracle]: node } });
+      console.log(`\x1b[32m+\x1b[0m registered agent '${oracle}' → '${node}' in config.agents`);
+    }
 
     if (!opts.task && !opts.newWt) {
       const allWt = await findWorktrees(parentDir, repoName);


### PR DESCRIPTION
## Summary
- When `maw wake` creates a new tmux session, the oracle is now auto-added to `config.agents` with the current node name (`config.node` or `"local"`)
- Only adds if not already present — never overwrites user-set values
- Fixes federation routing gap where peers couldn't find newly waked agents until manual config edit

Closes #285

## Test plan
- [ ] `maw wake <new-oracle>` on a node with `config.node` set — verify agent appears in `maw.config.json` agents map with correct node name
- [ ] `maw wake <existing-oracle>` — verify no duplicate entry is created
- [ ] `maw wake <oracle>` on a node without `config.node` — verify agent registered as `"local"`
- [ ] Federation peer can route to the newly waked agent via `maw hey`

🤖 Generated with [Claude Code](https://claude.com/claude-code)