### PR TITLE
feat(api): POST /api/wake and /api/sleep for Dashboard Pro

### DIFF
--- a/src/api/sessions.ts
+++ b/src/api/sessions.ts
@@ -117,3 +117,27 @@ sessionsApi.post("/select", async (c) => {
   await selectWindow(target);
   return c.json({ ok: true, target });
 });
+
+sessionsApi.post("/wake", async (c) => {
+  try {
+    const { target, task } = await c.req.json();
+    if (!target) return c.json({ error: "target required" }, 400);
+    const { cmdWake } = await import("../commands/wake");
+    await cmdWake(target, { noAttach: true, task });
+    return c.json({ ok: true, target });
+  } catch (err) {
+    return c.json({ error: String(err) }, 500);
+  }
+});
+
+sessionsApi.post("/sleep", async (c) => {
+  try {
+    const { target } = await c.req.json();
+    if (!target) return c.json({ error: "target required" }, 400);
+    const { cmdSleepOne } = await import("../commands/sleep");
+    await cmdSleepOne(target);
+    return c.json({ ok: true, target });
+  } catch (err) {
+    return c.json({ error: String(err) }, 500);
+  }
+});


### PR DESCRIPTION
## Summary
- `POST /api/wake { target, task? }` — wake agent in tmux (noAttach)
- `POST /api/sleep { target }` — sleep agent
- Dashboard Pro can now wake/sleep agents from the browser

## Test plan
- [ ] `curl -X POST localhost:3456/api/wake -d '{"target":"neo"}'` wakes neo
- [ ] `curl -X POST localhost:3456/api/sleep -d '{"target":"neo"}'` sleeps neo
- [ ] Dashboard Pro wake button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)