### PR TITLE
security(ssh): command-substitution tripwire (cherry-picked from #270)

### DIFF
--- a/src/ssh.ts
+++ b/src/ssh.ts
@@ -4,8 +4,19 @@ import { tmuxCmd } from "./tmux";
 const DEFAULT_HOST = process.env.MAW_HOST || loadConfig().host || "local";
 const IS_LOCAL = DEFAULT_HOST === "local" || DEFAULT_HOST === "localhost";
 
+/**
+ * Tripwire for command-substitution injection. Rejects backtick or $( sequences.
+ * Zero legitimate call sites use these patterns (verified via grep).
+ * Cherry-picked from evilelfza's PR #270 (R4C3 security audit).
+ */
+const SHELL_SUBSTITUTION = /`|\$\(/;
+
 /** Transport — run on oracle host. local → bash -c | remote → ssh */
 export async function hostExec(cmd: string, host = DEFAULT_HOST): Promise<string> {
+  if (SHELL_SUBSTITUTION.test(cmd)) {
+    console.warn(`[ssh] refused cmd with shell-substitution marker (len=${cmd.length})`);
+    throw new Error("ssh: refused cmd with shell-substitution marker");
+  }
   const local = host === "local" || host === "localhost" || IS_LOCAL;
   const args = local ? ["bash", "-c", cmd] : ["ssh", host, cmd];
   const proc = Bun.spawn(args, { stdout: "pipe", stderr: "pipe", windowsHide: true });


### PR DESCRIPTION
## Summary
Rejects backtick and `$(` in `hostExec()` commands — defense-in-depth against command injection.

Cherry-picked from @evilelfza's PR #270 (R4C3 security audit). The original PR bundled 100 files; this extracts just the security tripwire.

## Test plan
- [ ] `bun test` passes
- [ ] Commands with backticks are rejected
- [ ] Normal commands (pipes, &&) still work

Credit: @evilelfza

🤖 Generated with [Claude Code](https://claude.com/claude-code)