### PR TITLE
feat(wake): --pr flag + unified fetchGitHubPrompt

### DIFF
--- a/src/cli/route-agent.ts
+++ b/src/cli/route-agent.ts
@@ -1,4 +1,5 @@
-import { cmdWake, fetchIssuePrompt } from "../commands/wake";
+import { cmdWake } from "../commands/wake";
+import { fetchGitHubPrompt } from "../commands/wake-resolve";
 import { parseWakeTarget, ensureCloned } from "../commands/wake-target";
 import { cmdWakeAll, cmdSleep } from "../commands/fleet";
 import { cmdDone } from "../commands/done";
@@ -19,6 +20,7 @@ export async function routeAgent(cmd: string, args: string[]): Promise<boolean> 
         "--new": String,
         "--incubate": String,
         "--issue": Number,
+        "--pr": Number,
         "--repo": String,
         "--fresh": Boolean,
         "--no-attach": Boolean,
@@ -50,10 +52,15 @@ export async function routeAgent(cmd: string, args: string[]): Promise<boolean> 
       if (positionals.length > 1) wakeOpts.prompt = positionals.slice(1).join(" ");
 
       if (wakeOpts.incubate && !repo) { repo = wakeOpts.incubate; }
+      const prNum: number | null = flags["--pr"] ?? null;
       if (issueNum) {
         console.log(`\x1b[36m⚡\x1b[0m fetching issue #${issueNum}...`);
-        wakeOpts.prompt = await fetchIssuePrompt(issueNum, repo);
+        wakeOpts.prompt = await fetchGitHubPrompt("issue", issueNum, repo);
         if (!wakeOpts.task) wakeOpts.task = `issue-${issueNum}`;
+      } else if (prNum) {
+        console.log(`\x1b[36m⚡\x1b[0m fetching PR #${prNum}...`);
+        wakeOpts.prompt = await fetchGitHubPrompt("pr", prNum, repo);
+        if (!wakeOpts.task) wakeOpts.task = `pr-${prNum}`;
       }
       await cmdWake(oracleName, wakeOpts);
     }

--- a/src/cli/usage.ts
+++ b/src/cli/usage.ts
@@ -9,6 +9,7 @@ export function usage() {
   maw wire <agent> <msg...>   Send via federation (curl over WireGuard)
   maw wake <oracle> [task]    Wake oracle in tmux window + claude
   maw wake <oracle> --issue N Wake oracle with GitHub issue as prompt
+  maw wake <oracle> --pr N   Wake oracle with GitHub PR as prompt
   maw wake <oracle> --incubate org/repo  Clone repo + worktree
   maw fleet init              Scan ghq repos, generate fleet/*.json
   maw fleet init --agents     Reconcile config.agents from fleet + peers

--- a/src/commands/wake-resolve.ts
+++ b/src/commands/wake-resolve.ts
@@ -6,28 +6,53 @@ import { join } from "path";
 import { FLEET_DIR } from "../paths";
 import { curlFetch } from "../curl-fetch";
 
-/** Fetch a GitHub issue and build a prompt for claude -p */
-export async function fetchIssuePrompt(issueNum: number, repo?: string): Promise<string> {
-  let repoSlug = repo;
-  if (!repoSlug) {
-    try {
-      const remote = await hostExec("git remote get-url origin 2>/dev/null");
-      const m = remote.match(/github\.com[:/](.+?)(?:\.git)?$/);
-      if (m) repoSlug = m[1];
-    } catch { /* expected */ }
-  }
-  if (!repoSlug) throw new Error("Could not detect repo — pass --repo org/name");
+/** Resolve repo slug from git remote or --repo flag */
+async function resolveRepo(repo?: string): Promise<string> {
+  if (repo) return repo;
+  try {
+    const remote = await hostExec("git remote get-url origin 2>/dev/null");
+    const m = remote.match(/github\.com[:/](.+?)(?:\.git)?$/);
+    if (m) return m[1];
+  } catch { /* expected */ }
+  throw new Error("Could not detect repo — pass --repo org/name");
+}
 
-  const json = await hostExec(`gh issue view ${issueNum} --repo '${repoSlug}' --json title,body,labels`);
-  const issue = JSON.parse(json);
-  const labels = (issue.labels || []).map((l: any) => l.name).join(", ");
+/**
+ * Fetch a GitHub issue or PR and build a prompt for claude -p.
+ * One function, two modes: --issue and --pr both call this.
+ */
+export async function fetchGitHubPrompt(type: "issue" | "pr", num: number, repo?: string): Promise<string> {
+  const repoSlug = await resolveRepo(repo);
+  const cmd = type === "pr" ? "pr" : "issue";
+
+  const json = await hostExec(
+    `gh ${cmd} view ${num} --repo '${repoSlug}' --json title,body,labels` +
+    (type === "pr" ? ",state,headRefName,files" : "")
+  );
+  const item = JSON.parse(json);
+  const labels = (item.labels || []).map((l: { name: string }) => l.name).join(", ");
+
+  if (type === "pr") {
+    return [
+      `Review PR #${num}: ${item.title}`,
+      `Branch: ${item.headRefName} | State: ${item.state}`,
+      labels ? `Labels: ${labels}` : "",
+      item.files?.length ? `Files changed: ${item.files.length}` : "",
+      "",
+      item.body || "(no description)",
+    ].filter(Boolean).join("\n");
+  }
+
   return [
-    `Work on issue #${issueNum}: ${issue.title}`,
+    `Work on issue #${num}: ${item.title}`,
     labels ? `Labels: ${labels}` : "",
     "",
-    issue.body || "(no description)",
+    item.body || "(no description)",
   ].filter(Boolean).join("\n");
 }
+
+/** @deprecated Use fetchGitHubPrompt("issue", ...) */
+export const fetchIssuePrompt = (num: number, repo?: string) => fetchGitHubPrompt("issue", num, repo);
 
 export async function resolveOracle(oracle: string): Promise<{ repoPath: string; repoName: string; parentDir: string }> {
   const ghqOut = await hostExec(`ghq list --full-path | grep -i '/${oracle}-oracle$' | head -1`);

--- a/src/commands/wake.ts
+++ b/src/commands/wake.ts
@@ -15,11 +15,11 @@ async function attachToSession(session: string) {
 }
 import {
   resolveOracle, findWorktrees, getSessionMap, resolveFleetSession,
-  detectSession, setSessionEnv, sanitizeBranchName, fetchIssuePrompt,
+  detectSession, setSessionEnv, sanitizeBranchName, fetchIssuePrompt, fetchGitHubPrompt,
 } from "./wake-resolve";
 
 // Re-export for external consumers
-export { fetchIssuePrompt, findWorktrees, detectSession, resolveFleetSession };
+export { fetchIssuePrompt, fetchGitHubPrompt, findWorktrees, detectSession, resolveFleetSession };
 
 /**
  * Check whether a tmux pane's shell is idle (no child processes).


### PR DESCRIPTION
## Summary
- `maw wake neo --pr 42` — wake oracle with PR context (title, branch, state, files, description)
- Unified `fetchGitHubPrompt(type, num, repo)` handles both issues and PRs
- `fetchIssuePrompt()` preserved as deprecated alias
- Same pattern: `gh pr view` → formatted prompt → `claude -p`

## Test plan
- [ ] `maw wake neo --issue 5` still works (unchanged)
- [ ] `maw wake neo --pr 42 --repo Soul-Brews-Studio/maw-js --no-attach`
- [ ] PR prompt includes title, branch, state, files changed, body

🤖 Generated with [Claude Code](https://claude.com/claude-code)