### PR TITLE
feat(cli): pluggable command system (beta)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,9 @@ import { routeFleet } from "./cli/route-fleet";
 import { routeWorkspace } from "./cli/route-workspace";
 import { routeTools } from "./cli/route-tools";
 import { routeTeam } from "./cli/route-team";
+import { scanCommands, matchCommand, executeCommand, listCommands } from "./cli/command-registry";
+import { join } from "path";
+import { homedir } from "os";
 
 const args = process.argv.slice(2);
 const cmd = args[0]?.toLowerCase();
@@ -47,9 +50,15 @@ if (cmd === "--version" || cmd === "-v" || cmd === "version") {
   console.log(`\n  ✅ done`);
   if (after) console.log(`  to:   ${after}\n`);
   else console.log("");
-} else if (!cmd || cmd === "--help" || cmd === "-h") {
-  usage();
 } else {
+  // Load command plugins (beta) — ~/.oracle/commands/ and src/commands/plugins/
+  await scanCommands(join(import.meta.dir, "commands", "plugins"), "builtin");
+  await scanCommands(join(homedir(), ".oracle", "commands"), "user");
+
+  if (!cmd || cmd === "--help" || cmd === "-h") {
+    usage();
+  } else {
+
   const handled =
     await routeComm(cmd, args) ||
     await routeTeam(cmd, args) ||
@@ -59,13 +68,20 @@ if (cmd === "--version" || cmd === "-v" || cmd === "version") {
     await routeTools(cmd, args);
 
   if (!handled) {
-    // Default: agent name shorthand (maw <agent> <msg> or maw <agent>)
-    if (args.length >= 2) {
-      const f = args.includes("--force");
-      const m = args.slice(1).filter(a => a !== "--force");
-      await cmdSend(args[0], m.join(" "), f);
+    // Try plugin commands (beta) — after core routes, before fallback
+    const pluginMatch = matchCommand(args);
+    if (pluginMatch) {
+      await executeCommand(pluginMatch.desc, pluginMatch.remaining);
     } else {
-      await cmdPeek(args[0]);
+      // Default: agent name shorthand (maw <agent> <msg> or maw <agent>)
+      if (args.length >= 2) {
+        const f = args.includes("--force");
+        const m = args.slice(1).filter(a => a !== "--force");
+        await cmdSend(args[0], m.join(" "), f);
+      } else {
+        await cmdPeek(args[0]);
+      }
     }
+  }
   }
 }

--- a/src/cli/command-registry.ts
+++ b/src/cli/command-registry.ts
@@ -1,0 +1,99 @@
+/**
+ * Command Plugin Registry (beta) — pluggable CLI commands.
+ *
+ * Drop a .ts/.js file in ~/.oracle/commands/ with:
+ *   export const command = { name: "hello", description: "Say hello" };
+ *   export default async function(args, flags) { ... }
+ *
+ * Supports subcommands: name: "fleet doctor" or ["fleet doctor", "fleet dr"]
+ * Longest prefix match wins. Core routes always take priority.
+ */
+
+import { readdirSync, existsSync } from "fs";
+import { join } from "path";
+import { parseFlags } from "./parse-args";
+
+export interface CommandDescriptor {
+  name: string | string[];
+  description: string;
+  usage?: string;
+  flags?: Record<string, any>;
+  /** Resolved at registration */
+  patterns?: string[][];
+  path?: string;
+  scope?: "builtin" | "user";
+}
+
+const commands = new Map<string, { desc: CommandDescriptor; path: string }>();
+
+/** Register a command from a descriptor + file path */
+export function registerCommand(desc: CommandDescriptor, path: string, scope: "builtin" | "user") {
+  const names = Array.isArray(desc.name) ? desc.name : [desc.name];
+  for (const n of names) {
+    const key = n.toLowerCase().trim();
+    if (commands.has(key)) {
+      console.log(`[commands] overriding "${key}" (was: ${commands.get(key)!.desc.scope}, now: ${scope})`);
+    }
+    commands.set(key, { desc: { ...desc, scope, path }, path });
+  }
+}
+
+/** Match args against registered commands. Longest prefix wins. */
+export function matchCommand(args: string[]): { desc: CommandDescriptor; remaining: string[]; key: string } | null {
+  let best: { desc: CommandDescriptor; remaining: string[]; key: string; len: number } | null = null;
+
+  for (const [key, entry] of commands) {
+    const parts = key.split(/\s+/);
+    // Check if args start with this command's parts
+    let match = true;
+    for (let i = 0; i < parts.length; i++) {
+      if (!args[i] || args[i].toLowerCase() !== parts[i]) { match = false; break; }
+    }
+    if (match && parts.length > (best?.len ?? 0)) {
+      best = { desc: entry.desc, remaining: args.slice(parts.length), key, len: parts.length };
+    }
+  }
+
+  return best;
+}
+
+/** Execute a matched command — lazy import + parseFlags + call handler */
+export async function executeCommand(desc: CommandDescriptor, remaining: string[]): Promise<void> {
+  const mod = await import(desc.path!);
+  const handler = mod.default || mod.handler;
+  if (!handler) { console.error(`[commands] ${desc.name}: no default export or handler`); return; }
+  const flags = desc.flags ? parseFlags(["_", ...remaining], desc.flags, 1) : { _: remaining };
+  await handler(flags._, flags);
+}
+
+/** Scan a directory for command plugins */
+export async function scanCommands(dir: string, scope: "builtin" | "user"): Promise<number> {
+  if (!existsSync(dir)) return 0;
+  let count = 0;
+  for (const file of readdirSync(dir).filter(f => /\.(ts|js)$/.test(f))) {
+    try {
+      const path = join(dir, file);
+      const mod = await import(path);
+      if (mod.command?.name) {
+        registerCommand(mod.command, path, scope);
+        count++;
+      }
+    } catch (err: any) {
+      console.error(`[commands] failed to load ${file}: ${err.message?.slice(0, 80)}`);
+    }
+  }
+  return count;
+}
+
+/** List all registered commands (for --help and completions) */
+export function listCommands(): CommandDescriptor[] {
+  const seen = new Set<string>();
+  const result: CommandDescriptor[] = [];
+  for (const [, entry] of commands) {
+    const key = entry.path;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(entry.desc);
+  }
+  return result;
+}

--- a/src/cli/usage.ts
+++ b/src/cli/usage.ts
@@ -133,4 +133,18 @@ export function usage() {
   maw pulse add "Fix IME" --oracle neo --priority P1
   maw hey neo what is your status
   maw serve 8080`);
+
+  // Plugin commands (beta)
+  try {
+    const { listCommands } = require("./command-registry");
+    const cmds = listCommands();
+    if (cmds.length > 0) {
+      console.log(`\n\x1b[33mPlugin Commands (beta):\x1b[0m`);
+      for (const c of cmds) {
+        const name = Array.isArray(c.name) ? c.name[0] : c.name;
+        const scope = c.scope === "user" ? "\x1b[90m(user)\x1b[0m" : "";
+        console.log(`  maw ${name.padEnd(24)} ${c.description} ${scope}`);
+      }
+    }
+  } catch { /* registry not loaded yet */ }
 }


### PR DESCRIPTION
## Summary
Drop `.ts` files in `~/.oracle/commands/` → they become `maw` commands.

```bash
# ~/.oracle/commands/hello.ts
export const command = { name: "hello", description: "Say hello" };
export default async function() { console.log("Hello!"); }
```

```
$ maw hello
  👋 Hello from a command plugin!
```

- Subcommand support: `name: "fleet doctor"`
- Typed flags via `arg`
- Core routes always win (plugins checked after)
- `maw --help` shows "Plugin Commands (beta)" section
- Scan: `src/commands/plugins/` (builtin) + `~/.oracle/commands/` (user)

## Test plan
- [ ] `maw hello` runs plugin command
- [ ] `maw --help` shows plugin section
- [ ] `maw ls` / `maw hey` / core commands unchanged
- [ ] Bad plugin file → logged error, other commands work

🤖 Generated with [Claude Code](https://claude.com/claude-code)