### PR TITLE
fix(windows): normalize ghq paths for Windows compatibility

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -138,7 +138,7 @@ if (cmd === "--version" || cmd === "-v" || cmd === "version") {
   // Link SDK so plugins can `import { maw } from "@maw/sdk"` (workspace package at packages/sdk/)
   // Legacy plugins using bare `maw/sdk` are still resolved via `bun link maw`.
   try {
-    const mawDir = join(execSync(`ghq list --full-path | grep 'Soul-Brews-Studio/maw-js$'`, { encoding: "utf-8" }).trim());
+    const mawDir = join(execSync(`ghq list --full-path | tr '\\\\' '/' | grep 'Soul-Brews-Studio/maw-js$'`, { encoding: "utf-8" }).trim());
     if (mawDir) {
       // #346: Gate link on version match — stale ghq clone would override the fresh global install
       const cloneVersion: string = require(join(mawDir, "package.json")).version;

--- a/src/commands/plugins/fleet/fleet-init-scan.ts
+++ b/src/commands/plugins/fleet/fleet-init-scan.ts
@@ -58,7 +58,7 @@ export async function cmdFleetInit() {
   // Scan ghq for oracle repos
   console.log(`\n  \x1b[36mScanning for oracle repos...\x1b[0m\n`);
 
-  const ghqOut = await hostExec("ghq list --full-path");
+  const ghqOut = await hostExec("ghq list --full-path | tr '\\\\' '/'");
   const allRepos = ghqOut.trim().split("\n").filter(Boolean);
 
   // Find oracle repos

--- a/src/commands/plugins/oracle/impl-helpers.ts
+++ b/src/commands/plugins/oracle/impl-helpers.ts
@@ -6,10 +6,10 @@ import { join } from "path";
 export async function resolveOracleSafe(oracle: string): Promise<{ repoPath: string; repoName: string; parentDir: string } | { parentDir: ""; repoName: ""; repoPath: "" }> {
   try {
     // Try oracle-oracle pattern first
-    let ghqOut = await hostExec(`ghq list --full-path | grep -i '/${oracle}-oracle$' | head -1`).catch(() => "");
+    let ghqOut = await hostExec(`ghq list --full-path | tr '\\\\' '/' | grep -i '/${oracle}-oracle$' | head -1`).catch(() => "");
     if (!ghqOut.trim()) {
       // Try direct name (e.g., homekeeper → homelab)
-      ghqOut = await hostExec(`ghq list --full-path | grep -i '/${oracle}$' | head -1`).catch(() => "");
+      ghqOut = await hostExec(`ghq list --full-path | tr '\\\\' '/' | grep -i '/${oracle}$' | head -1`).catch(() => "");
     }
     if (!ghqOut.trim()) return { parentDir: "", repoName: "", repoPath: "" };
     const repoPath = ghqOut.trim();

--- a/src/commands/plugins/restart/impl.ts
+++ b/src/commands/plugins/restart/impl.ts
@@ -71,7 +71,7 @@ export async function cmdRestart(opts: { noUpdate?: boolean; ref?: string; help?
       console.log(`    ${before} → ${after || "updated"}`);
       // Link SDK for plugins
       try {
-        const mawDir = execSync(`ghq list --full-path | grep 'Soul-Brews-Studio/maw-js$'`, { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
+        const mawDir = execSync(`ghq list --full-path | tr '\\\\' '/' | grep 'Soul-Brews-Studio/maw-js$'`, { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
         if (mawDir) {
           execSync(`cd ${mawDir} && bun link`, { stdio: "pipe" });
           const oDir = require("os").homedir() + "/.oracle";

--- a/src/commands/plugins/soul-sync/resolve.ts
+++ b/src/commands/plugins/soul-sync/resolve.ts
@@ -16,7 +16,7 @@ export async function resolveOraclePath(name: string): Promise<string | null> {
   // Strip trailing -oracle so "neo" and "neo-oracle" both resolve identically.
   const stem = name.replace(/-oracle$/, "");
   try {
-    const out = await hostExec(`ghq list --full-path | grep -i '/${stem}-oracle$' | head -1`);
+    const out = await hostExec(`ghq list --full-path | tr '\\\\' '/' | grep -i '/${stem}-oracle$' | head -1`);
     if (out?.trim()) return out.trim();
   } catch { /* not found */ }
 

--- a/src/commands/plugins/ui/impl-helpers.ts
+++ b/src/commands/plugins/ui/impl-helpers.ts
@@ -70,7 +70,7 @@ export function isUiDistInstalled(): boolean {
 export function findMawUiSrcDir(): string | null {
   // Try ghq path first (the standard oracle convention)
   try {
-    const ghqPath = execSync("ghq list --full-path 2>/dev/null", { encoding: "utf-8" })
+    const ghqPath = execSync("ghq list --full-path 2>/dev/null | tr '\\\\' '/'", { encoding: "utf-8" })
       .split("\n")
       .find((p: string) => p.endsWith("/maw-ui"));
     if (ghqPath && existsSync(join(ghqPath, "package.json"))) return ghqPath;

--- a/src/commands/plugins/workon/impl.ts
+++ b/src/commands/plugins/workon/impl.ts
@@ -7,7 +7,7 @@ import { resolveWorktreeTarget } from "../../../core/matcher/resolve-target";
 async function resolveRepo(repo: string): Promise<{ repoPath: string; repoName: string; parentDir: string }> {
   // Support "org/repo" or bare "repo" — always search by last segment
   const searchTerm = repo.includes("/") ? repo.split("/").pop()! : repo;
-  const ghqOut = await hostExec(`ghq list --full-path | grep -i '/${searchTerm}$' | head -1`);
+  const ghqOut = await hostExec(`ghq list --full-path | tr '\\\\' '/' | grep -i '/${searchTerm}$' | head -1`);
   if (!ghqOut?.trim()) {
     console.error(`repo not found: ${repo}`);
     process.exit(1);

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -20,7 +20,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; newWt?: str
     const repoSlug = slug.includes("github.com") ? slug : `github.com/${slug}`;
     console.log(`\x1b[36m⚡\x1b[0m incubating ${slug}...`);
     await hostExec(`ghq get -u ${repoSlug}`);
-    const fullPath = await hostExec(`ghq list --full-path | grep -i '${repoSlug}$' | head -1`);
+    const fullPath = await hostExec(`ghq list --full-path | tr '\\\\' '/' | grep -i '${repoSlug}$' | head -1`);
     if (!fullPath?.trim()) throw new Error(`ghq could not find ${slug} after clone`);
     const repoPath = fullPath.trim();
     resolved = { repoPath, repoName: repoPath.split("/").pop()!, parentDir: repoPath.replace(/\/[^/]+$/, "") };

--- a/src/commands/shared/wake-resolve.ts
+++ b/src/commands/shared/wake-resolve.ts
@@ -53,7 +53,7 @@ export async function fetchGitHubPrompt(type: "issue" | "pr", num: number, repo?
 export const fetchIssuePrompt = (num: number, repo?: string) => fetchGitHubPrompt("issue", num, repo);
 
 export async function resolveOracle(oracle: string): Promise<{ repoPath: string; repoName: string; parentDir: string }> {
-  const ghqOut = await hostExec(`ghq list --full-path | grep -i '/${oracle}-oracle$' | head -1`);
+  const ghqOut = await hostExec(`ghq list --full-path | tr '\\\\' '/' | grep -i '/${oracle}-oracle$' | head -1`);
   if (ghqOut?.trim()) {
     const repoPath = ghqOut.trim();
     return { repoPath, repoName: repoPath.split("/").pop()!, parentDir: repoPath.replace(/\/[^/]+$/, "") };
@@ -66,7 +66,7 @@ export async function resolveOracle(oracle: string): Promise<{ repoPath: string;
       const config = JSON.parse(readFileSync(join(FLEET_DIR, file), "utf-8"));
       const win = (config.windows || []).find((w: any) => w.name === `${oracle}-oracle`);
       if (win?.repo) {
-        const fullPath = await hostExec(`ghq list --full-path | grep -i '/${win.repo.replace(/^[^/]+\//, "")}$' | head -1`);
+        const fullPath = await hostExec(`ghq list --full-path | tr '\\\\' '/' | grep -i '/${win.repo.replace(/^[^/]+\//, "")}$' | head -1`);
         if (fullPath?.trim()) {
           const repoPath = fullPath.trim();
           return { repoPath, repoName: repoPath.split("/").pop()!, parentDir: repoPath.replace(/\/[^/]+$/, "") };
@@ -96,7 +96,7 @@ export async function resolveOracle(oracle: string): Promise<{ repoPath: string;
         console.error(`\x1b[33m⚠\x1b[0m  clone failed for ${slug}: ${String(e?.message || e).split("\n")[0]}`);
         continue;
       }
-      const cloned = await hostExec(`ghq list --full-path | grep -i '/${slug.split("/").pop()}$' | head -1`);
+      const cloned = await hostExec(`ghq list --full-path | tr '\\\\' '/' | grep -i '/${slug.split("/").pop()}$' | head -1`);
       if (cloned?.trim()) {
         const repoPath = cloned.trim();
         console.log(`\x1b[32m✓\x1b[0m cloned to ${repoPath}`);

--- a/src/commands/shared/wake-target.ts
+++ b/src/commands/shared/wake-target.ts
@@ -73,7 +73,7 @@ export function parseWakeTarget(target: string): ParsedWakeTarget | null {
  * resolveOracle handle the error downstream.
  */
 export async function ensureCloned(slug: string): Promise<void> {
-  const ghqHit = await hostExec(`ghq list --full-path | grep -i '/${slug}$' | head -1`).catch(() => "");
+  const ghqHit = await hostExec(`ghq list --full-path | tr '\\\\' '/' | grep -i '/${slug}$' | head -1`).catch(() => "");
   if (ghqHit.trim()) return;
   console.log(`\x1b[36m⚡\x1b[0m cloning ${slug}...`);
   try {


### PR DESCRIPTION
## Summary
- On Windows, `ghq list --full-path` returns backslash paths (`C:\Users\...`) but all grep patterns use forward slashes (`/oracle-name$`), causing **silent match failures** on every ghq-dependent command
- Fix: pipe through `tr '\' '/'` to normalize paths before grep matching — no-op on Linux/macOS
- Applied to **13 call sites** across **10 files**: cli, fleet-init-scan, oracle helpers, restart, soul-sync resolve, ui helpers, workon, wake-cmd, wake-resolve, wake-target

## Test plan
- [ ] `maw wake <oracle>` on Windows — should resolve oracle path
- [ ] `maw oracle ls` on Windows — should list all oracles
- [ ] `maw workon <repo>` on Windows — should resolve repo path
- [ ] `maw fleet init` on Windows — should scan ghq repos
- [ ] Verify no regression on Linux/macOS (`tr` is a no-op when paths have no backslashes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)