### PR TITLE
fix(overview): remove backslash escape so sh expands $(tput lines)

### DIFF
--- a/src/commands/plugins/overview/impl.ts
+++ b/src/commands/plugins/overview/impl.ts
@@ -63,7 +63,7 @@ export function processMirror(raw: string, lines: number): string {
 export function mirrorCmd(t: OverviewTarget): string {
   const target = encodeURIComponent(`${t.session}:${t.window}`);
   const port = loadConfig().port;
-  return `watch --color -t -n0.5 'curl -s "http://localhost:${port}/api/mirror?target=${target}&lines=\\$(tput lines)"'`;
+  return `watch --color -t -n0.5 'curl -s "http://localhost:${port}/api/mirror?target=${target}&lines=$(tput lines)"'`;
 }
 
 export function pickLayout(count: number): string {


### PR DESCRIPTION
## Summary

- `maw overview` rendered pane borders but the content stayed blank because `curl` was rejecting the mirror URL with `URL rejected: Malformed input to a URL function`.
- `mirrorCmd` embedded `\$(tput lines)` inside the single-quoted `watch` argument. bash left the backslash alone, then `watch`'s `sh -c` processed `\$` inside double quotes as a literal `$`, so the URL contained the string `$(tput lines)` verbatim instead of the terminal height.
- One-character fix: drop the backslash so `sh` performs the command substitution on each tick and `lines=` resolves to the real row count.

## Reproduction

1. `maw serve` (must be online)
2. `maw overview` — panes are created successfully
3. `tmux attach -t 0-overview` — borders visible but panes are empty
4. Inside a watch pane, `curl -v "http://localhost:<port>/api/mirror?target=<t>&lines=\$(tput lines)"` prints `curl: (3) URL rejected: Malformed input to a URL function`

After this change the same `maw overview` session populates each pane immediately on attach.

## Verification

- Verified the emitted command is now `watch --color -t -n0.5 'curl -s "http://localhost:PORT/api/mirror?target=SESSION%3AWINDOW&lines=$(tput lines)"'`, which lets `sh` substitute `tput lines` at runtime.
- Confirmed fix on a local build against `v2.0.0-alpha.64` (Zeus's machine): panes mirror immediately once the backslash is removed.

## Test plan

- [ ] `maw serve` up, run `maw overview`, attach to `0-overview`, confirm panes stream content.
- [ ] Inspect a watch pane's URL (e.g. via `curl -v`) and confirm `lines=<N>` is numeric, not literal.