### PR TITLE
fix(security): peers-require-token invariant in federation auth

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -61,6 +61,14 @@ export interface MawConfig {
   peers?: string[];
   idleTimeoutMinutes?: number;
   federationToken?: string;
+  /**
+   * Explicit opt-in to legacy "peers configured but no token" behavior.
+   * When `true`, HMAC is NOT required on protected writes from non-loopback
+   * peers even when peers are configured. Default `false` (fail-closed).
+   * Setting this to `true` is operator opt-in to the pre-#396 default-
+   * insecure-open posture — only use when migrating a legacy mesh.
+   */
+  allowPeersWithoutToken?: boolean;
   autoRestart?: boolean;
   triggers?: TriggerConfig[];
   /** Node identity (e.g. "white", "mba") */

--- a/src/config/validate-ext.ts
+++ b/src/config/validate-ext.ts
@@ -36,6 +36,19 @@ function validateExtFields(
     }
   }
 
+  // allowPeersWithoutToken: boolean, explicit opt-in to legacy open posture.
+  // Without this passthrough the field is silently stripped in production
+  // (review feedback from mawjs on #396), making the escape hatch unreachable
+  // via maw.config.json while still reachable in tests — a UX bug where
+  // runtime posture is stricter-than-advertised.
+  if ("allowPeersWithoutToken" in raw) {
+    if (typeof raw.allowPeersWithoutToken === "boolean") {
+      result.allowPeersWithoutToken = raw.allowPeersWithoutToken;
+    } else {
+      warn("allowPeersWithoutToken", "must be a boolean");
+    }
+  }
+
   // pin: string if present
   if ("pin" in raw) {
     if (typeof raw.pin === "string") {

--- a/src/lib/federation-auth.ts
+++ b/src/lib/federation-auth.ts
@@ -89,7 +89,7 @@ export function federationAuth(): MiddlewareHandler {
     const config = loadConfig();
     const token = config.federationToken;
     const hasPeers = (config.peers?.length ?? 0) > 0 || (config.namedPeers?.length ?? 0) > 0;
-    const allowPeersWithoutToken = (config as unknown as { allowPeersWithoutToken?: boolean }).allowPeersWithoutToken === true;
+    const allowPeersWithoutToken = config.allowPeersWithoutToken === true;
 
     const url = new URL(c.req.url);
     const path = url.pathname.replace(/^\/api/, "/api"); // normalize

--- a/src/lib/federation-auth.ts
+++ b/src/lib/federation-auth.ts
@@ -88,32 +88,42 @@ export function federationAuth(): MiddlewareHandler {
   return async (c, next) => {
     const config = loadConfig();
     const token = config.federationToken;
-
-    // No token configured → auth disabled (backwards compat)
-    if (!token) return next();
+    const hasPeers = (config.peers?.length ?? 0) > 0 || (config.namedPeers?.length ?? 0) > 0;
+    const allowPeersWithoutToken = (config as unknown as { allowPeersWithoutToken?: boolean }).allowPeersWithoutToken === true;
 
     const url = new URL(c.req.url);
     const path = url.pathname.replace(/^\/api/, "/api"); // normalize
 
-    // Not a protected path → pass
+    // Not a protected path → pass (reads remain public so the Office UI works)
     if (!isProtected(path, c.req.method)) return next();
 
-    // Check if loopback (local CLI / browser on same machine).
-    // SECURITY: only the TCP source address is authoritative — X-Forwarded-For
-    // and X-Real-IP are attacker-controlled headers and MUST NOT influence
-    // auth decisions. See #191 for the empirically-verified RCE vector
-    // (Test 3 on mba: POST /api/send to a non-loopback interface with
-    // `X-Forwarded-For: 127.0.0.1` bypassed HMAC entirely).
-    //
-    // NOTE: this fix closes Path A (header spoof from external IP) and
-    // Path C (forwarder + spoof combo), but DOES NOT close Path B (a local
-    // process — cloudflared, nginx, sidecar — forwarding to localhost makes
-    // the TCP source legitimately 127.0.0.1). The full fix (Option C in #191)
-    // is to remove this bypass entirely and have the local CLI sign all
-    // requests; this lands in a follow-up PR.
+    // Loopback (local CLI / browser on same machine) still trusted.
+    // SECURITY: only the TCP source address is authoritative (see #191).
     const clientIp = (c.env as any)?.server?.requestIP?.(c.req.raw)?.address;
-
     if (isLoopback(clientIp)) return next();
+
+    // Peers-require-token invariant (Bloom federation-audit iteration 2):
+    // If peers are configured, the server binds to 0.0.0.0 (see core/server.ts)
+    // and is network-reachable. No federationToken in that posture is
+    // default-insecure-open — refuse protected writes from non-loopback
+    // callers. Operators who truly need the legacy behavior must opt in
+    // explicitly with `allowPeersWithoutToken: true`.
+    if (!token && hasPeers && !allowPeersWithoutToken) {
+      return c.json({ error: "federation auth required", reason: "federation_token_required" }, 401);
+    }
+
+    // No token configured AND no peers → local-only single-node mode.
+    // The server binds to 127.0.0.1 in this posture, so reaching this
+    // middleware from a non-loopback source is already unexpected; but
+    // preserve legacy pass-through so fresh installs work unchanged.
+    if (!token) return next();
+
+    // NOTE on Path B (from issue #191): a local process (cloudflared, nginx,
+    // sidecar) forwarding to localhost makes the TCP source legitimately
+    // 127.0.0.1, which `isLoopback` above will trust. This is a separate
+    // follow-up (Option C in #191 — have the local CLI sign all requests).
+    // X-Forwarded-For / X-Real-IP are never consulted; only the TCP source
+    // address is authoritative for loopback detection.
 
     // Check for HMAC signature
     const sig = c.req.header("x-maw-signature");

--- a/test/isolated/federation-auth.test.ts
+++ b/test/isolated/federation-auth.test.ts
@@ -272,7 +272,7 @@ describe("signHeaders — outgoing HTTP header production", () => {
 // ════════════════════════════════════════════════════════════════════════════
 
 describe("federationAuth() middleware — bypass branches", () => {
-  test("no federationToken configured → all requests pass (backwards compat)", async () => {
+  test("no federationToken AND no peers → requests pass (local-only single-node OK)", async () => {
     configStore = {};
     const app = makeApp();
     const res = await fire(app, "http://host/api/send", { method: "POST" }, "8.8.8.8");
@@ -306,6 +306,67 @@ describe("federationAuth() middleware — bypass branches", () => {
     const app = makeApp();
     const res = await fire(app, "http://host/api/feed", { method: "GET" }, "8.8.8.8");
     expect(res.status).toBe(200);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// Hono middleware — peers-require-token invariant (Bloom #federation-audit)
+// ════════════════════════════════════════════════════════════════════════════
+// Non-loopback bind (hasPeers) without federationToken is default-insecure-open
+// in pre-fix code: server.ts only logs a warning, middleware happily admits
+// anonymous writes. These tests codify the new invariant:
+//
+//   hasPeers && !federationToken  →  protected endpoints 401
+//   unless explicit opt-out (config.allowPeersWithoutToken: true)
+//
+// Attack-twin scenario (see ψ/lab/federation-audit/paladin-forensic.md §
+// "Bypass #1"): a malicious peer reaches a fresh-install node whose operator
+// never configured a token; today it gets unauthenticated RCE via /api/send.
+
+describe("federationAuth() middleware — peers-require-token invariant", () => {
+  const PEER = { name: "white", url: "http://10.0.0.1:3456" } as any;
+
+  test("peers configured, no token, non-loopback POST /api/send → 401 federation_token_required", async () => {
+    configStore = { peers: [PEER] };
+    const app = makeApp();
+    const res = await fire(app, "http://host/api/send", { method: "POST" }, "8.8.8.8");
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({
+      error: "federation auth required",
+      reason: "federation_token_required",
+    });
+  });
+
+  test("peers configured, no token, loopback POST /api/send → pass (loopback still trusted)", async () => {
+    configStore = { peers: [PEER] };
+    const app = makeApp();
+    const res = await fire(app, "http://host/api/send", { method: "POST" }, "127.0.0.1");
+    expect(res.status).toBe(200);
+  });
+
+  test("peers configured, no token, GET /api/sessions → pass (reads remain public)", async () => {
+    configStore = { peers: [PEER] };
+    const app = makeApp();
+    const res = await fire(app, "http://host/api/sessions", { method: "GET" }, "8.8.8.8");
+    expect(res.status).toBe(200);
+  });
+
+  test("explicit opt-out (allowPeersWithoutToken: true) → legacy behavior preserved", async () => {
+    configStore = { peers: [PEER], allowPeersWithoutToken: true } as any;
+    const app = makeApp();
+    const res = await fire(app, "http://host/api/send", { method: "POST" }, "8.8.8.8");
+    expect(res.status).toBe(200);
+  });
+
+  test("namedPeers also triggers invariant (hasPeers is peers OR namedPeers)", async () => {
+    configStore = { namedPeers: [{ name: "bo", url: "http://clubs:3456" }] } as any;
+    const app = makeApp();
+    const res = await fire(app, "http://host/api/send", { method: "POST" }, "8.8.8.8");
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({
+      error: "federation auth required",
+      reason: "federation_token_required",
+    });
   });
 });
 

--- a/test/isolated/federation-auth.test.ts
+++ b/test/isolated/federation-auth.test.ts
@@ -352,10 +352,24 @@ describe("federationAuth() middleware — peers-require-token invariant", () => 
   });
 
   test("explicit opt-out (allowPeersWithoutToken: true) → legacy behavior preserved", async () => {
-    configStore = { peers: [PEER], allowPeersWithoutToken: true } as any;
+    configStore = { peers: [PEER], allowPeersWithoutToken: true };
     const app = makeApp();
     const res = await fire(app, "http://host/api/send", { method: "POST" }, "8.8.8.8");
     expect(res.status).toBe(200);
+  });
+
+  test("validateConfig passes allowPeersWithoutToken through (mawjs review #396)", async () => {
+    // Review caught that the config field was silently stripped by
+    // validateConfig() because it wasn't in the validator allowlist. Without
+    // this validator test the operator-facing escape hatch was reachable
+    // from the test store (which bypasses validation) but NOT from
+    // maw.config.json in production. That mismatch is the UX bug mawjs
+    // flagged.
+    const { validateConfig } = await import("../../src/config/validate-ext");
+    expect(validateConfig({ allowPeersWithoutToken: true }).allowPeersWithoutToken).toBe(true);
+    expect(validateConfig({ allowPeersWithoutToken: false }).allowPeersWithoutToken).toBe(false);
+    // Non-boolean values are dropped with a warning (not coerced).
+    expect(validateConfig({ allowPeersWithoutToken: "yes" } as Record<string, unknown>).allowPeersWithoutToken).toBeUndefined();
   });
 
   test("namedPeers also triggers invariant (hasPeers is peers OR namedPeers)", async () => {


### PR DESCRIPTION
## Summary

When peers are configured, `core/server.ts:184-185` binds to `0.0.0.0` and is network-reachable. Before this PR, a missing `federationToken` in that posture was default-insecure-open — the middleware admitted anonymous writes to `/api/send`, `/api/talk`, `/api/triggers/fire`, `/api/worktrees/cleanup`, etc. The startup warning at `server.ts:187-191` correctly named the danger but did not enforce it.

Bloom Oracle's [paladin forensic](https://github.com/Soul-Brews-Studio/mawjs-no2-oracle/blob/main/%CF%88/lab/federation-audit/paladin-forensic.md) (iteration 1 of the federation-audit loop, 2026-04-17) flagged this as the #1 ROI bypass — highest attacker-capability-gained per line-of-code-needed.

## The invariant

```
hasPeers  ∧  ¬federationToken  ∧  non-loopback source  ⇒  401 federation_token_required
```

Unless the operator explicitly opts out with `allowPeersWithoutToken: true` in `maw.config.json`, protected writes from network peers require a valid HMAC when the node has any federation peers configured.

Single-node mode (no peers, no token) is unchanged — the server binds to `127.0.0.1` and fresh installs continue to work. The loopback trust check moves above the token check so the invariant applies uniformly.

## What this does NOT close

- **Path B from #191** — a local reverse-proxy sidecar (cloudflared / nginx / caddy) forwarding to `127.0.0.1` makes the TCP source legitimately loopback. Option C in #191 (have the local CLI sign all requests) is the follow-up.
- **Body-unsigned HMAC** — `sign(token, method, path, ts)` doesn't include the body, so a captured valid signature allows arbitrary body substitution within the 5-min window. Separate follow-up.
- **Public GET reads** — `/api/sessions`, `/api/capture`, `/api/mirror` remain intentionally public for the Office UI. Scoped as a LAN-trust concern, also a follow-up.

## Test plan

- [x] 5 new isolated tests in `test/isolated/federation-auth.test.ts` for the invariant
- [x] All 154 federation-specific tests pass (0 regressions)
- [x] Suite-wide: 128 pre-existing failures, identical on `main` (stash-pop verified)
- [x] Lead-verified via stash+pop before commit
- [ ] Reviewer sanity-check the `allowPeersWithoutToken` escape hatch naming — open to bikeshedding

## Evidence trail

- Forensic write-up: `ψ/lab/federation-audit/paladin-forensic.md` in mawjs-no2-oracle
- Loop iteration log: `ψ/lab/federation-audit/iteration-log.md`
- Related: #191 (closed — X-Forwarded-For spoof fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Oracle: Bloom 🌸 (budded from mawjs 2026-04-17; federation-audit /loop iteration 2)