### PR TITLE
fix(federation): say "reachable" not "online" — one-way truth

### DIFF
--- a/src/commands/shared/federation.ts
+++ b/src/commands/shared/federation.ts
@@ -69,22 +69,21 @@ export async function cmdFederationStatus() {
     return;
   }
 
-  // Fetch peer agent counts in parallel for online peers
+  // Fetch peer agent counts in parallel for reachable peers
   const counts = await Promise.all(
     statuses.map(p => p.reachable ? fetchPeerAgentCount(p.url) : Promise.resolve(0))
   );
 
-  let online = 1; // local is always online (we're executing in it)
+  let reachableCount = 1; // local is always reachable (we're executing in it)
   for (let i = 0; i < statuses.length; i++) {
     const { url, reachable, latency } = statuses[i];
     const agentCount = counts[i];
-    if (reachable) online++;
+    if (reachable) reachableCount++;
 
     const dot = reachable ? "\x1b[32m●\x1b[0m" : "\x1b[31m●\x1b[0m";
     // "reachable" is truthful — we only verified local→peer direction.
-    // The reverse direction (peer→local) is NOT checked here. See
-    // federation-audit/pair-health-failure.md in mawjs-no2-oracle for the
-    // symmetric-pair proposal (iteration 4+).
+    // The reverse direction (peer→local) is NOT checked here. See PR #398
+    // for the symmetric-pair proposal (`maw federation --verify`).
     const status = reachable
       ? `\x1b[32mreachable\x1b[0m  \x1b[90m${latency}ms · ${agentCount} agent${agentCount !== 1 ? "s" : ""}\x1b[0m`
       : "\x1b[31munreachable\x1b[0m";
@@ -94,5 +93,5 @@ export async function cmdFederationStatus() {
     console.log(`     \x1b[90m${url}\x1b[0m`);
   }
 
-  console.log(`\n\x1b[90m${online}/${totalNodes} reachable (one-way; pair-symmetric verify TBD)\x1b[0m\n`);
+  console.log(`\n\x1b[90m${reachableCount}/${totalNodes} reachable (one-way; use --verify for pair-symmetric check — PR #398)\x1b[0m\n`);
 }

--- a/src/commands/shared/federation.ts
+++ b/src/commands/shared/federation.ts
@@ -81,14 +81,18 @@ export async function cmdFederationStatus() {
     if (reachable) online++;
 
     const dot = reachable ? "\x1b[32m●\x1b[0m" : "\x1b[31m●\x1b[0m";
+    // "reachable" is truthful — we only verified local→peer direction.
+    // The reverse direction (peer→local) is NOT checked here. See
+    // federation-audit/pair-health-failure.md in mawjs-no2-oracle for the
+    // symmetric-pair proposal (iteration 4+).
     const status = reachable
-      ? `\x1b[32monline\x1b[0m  \x1b[90m${latency}ms · ${agentCount} agent${agentCount !== 1 ? "s" : ""}\x1b[0m`
-      : "\x1b[31moffline\x1b[0m";
+      ? `\x1b[32mreachable\x1b[0m  \x1b[90m${latency}ms · ${agentCount} agent${agentCount !== 1 ? "s" : ""}\x1b[0m`
+      : "\x1b[31munreachable\x1b[0m";
 
     const label = labelForPeer(url, named);
     console.log(`  ${dot}  \x1b[37m${label}\x1b[0m  ${status}`);
     console.log(`     \x1b[90m${url}\x1b[0m`);
   }
 
-  console.log(`\n\x1b[90m${online}/${totalNodes} online\x1b[0m\n`);
+  console.log(`\n\x1b[90m${online}/${totalNodes} reachable (one-way; pair-symmetric verify TBD)\x1b[0m\n`);
 }

--- a/src/core/transport/peers.ts
+++ b/src/core/transport/peers.ts
@@ -27,8 +27,8 @@ const CLOCK_WARN_MS = 3 * 60 * 1000;
  * rules, and one-sided WireGuard configs all produce the state where
  * `reachable: true` but the peer cannot message us.
  *
- * For symmetric pair verification, see the proposed `getFederationStatusSymmetric`
- * in mawjs-no2-oracle/ψ/lab/federation-audit/pair-health-failure.md (Sketch A).
+ * For symmetric pair verification, see `getFederationStatusSymmetric()`
+ * (PR #398) and the `maw federation --verify` CLI flag.
  */
 async function checkPeerReachable(url: string): Promise<{
   reachable: boolean; latency: number; node?: string; agents?: string[]; clockDeltaMs?: number;

--- a/src/core/transport/peers.ts
+++ b/src/core/transport/peers.ts
@@ -20,7 +20,15 @@ export interface PeerStatus {
 const CLOCK_WARN_MS = 3 * 60 * 1000;
 
 /**
- * Check if a peer is reachable by making a HEAD request
+ * Check if a peer is reachable by making a GET /api/sessions request.
+ *
+ * ONE-WAY ONLY. This verifies local→peer reach. It does NOT verify that
+ * the peer can reach back (peer→local). Asymmetric-NAT, one-sided firewall
+ * rules, and one-sided WireGuard configs all produce the state where
+ * `reachable: true` but the peer cannot message us.
+ *
+ * For symmetric pair verification, see the proposed `getFederationStatusSymmetric`
+ * in mawjs-no2-oracle/ψ/lab/federation-audit/pair-health-failure.md (Sketch A).
  */
 async function checkPeerReachable(url: string): Promise<{
   reachable: boolean; latency: number; node?: string; agents?: string[]; clockDeltaMs?: number;


### PR DESCRIPTION
## Summary

`maw federation` says peers are `online` when really only one direction was checked. That's a lie we need to stop telling.

`checkPeerReachable` (`src/core/transport/peers.ts:25-68`) only does `local → peer GET /api/sessions`. The reverse (`peer → local`) is never exercised. Scenarios where `reachable: true` but the pair is half-up: asymmetric NAT, one-sided firewall ingress, one-sided WireGuard peer lists, stale peer URL, port/TLS mismatch.

## What this PR does / doesn't do

**Does** — stop saying "online" when we only checked one direction:
- Peer rows: `reachable` / `unreachable` instead of `online` / `offline`
- Footer: `N/M reachable (one-way; pair-symmetric verify TBD)`
- `checkPeerReachable` JSDoc spells out the one-way limitation with a pointer to the symmetric proposal
- Local row stays `online` — we ARE there.

**Does not** — actually verify the reverse direction. That's the bigger follow-up (Sketch A in `ψ/lab/federation-audit/pair-health-failure.md` in mawjs-no2-oracle): add `getFederationStatusSymmetric()` + `maw federation --verify`.

## Why now, not wait for the full fix

Shipping truthful wording today is strictly better than waiting for the perfect measurement. "Online" is currently a lie; "reachable" is the smallest true word.

## Test plan

- [x] Federation-specific tests: 62 pass, 0 fail
- [x] Full suite: 1706 tests, 128 pre-existing failures (same on main, zero regressions)
- [x] No test assertions on the old peer labels

## Related

- Bloom's federation-audit loop, iteration 3
- Parent PR: #396 (peers-require-token invariant)
- Follow-up: symmetric-verify PR will cite this one

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Oracle: Bloom 🌸 (federation-audit /loop iteration 3, 2026-04-17)