### PR TITLE
feat(federation): maw federation --verify — pair-symmetric health check

### DIFF
--- a/src/commands/plugins/federation/index.ts
+++ b/src/commands/plugins/federation/index.ts
@@ -23,8 +23,16 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     const sub = args[0]?.toLowerCase();
 
     if (!sub || sub === "status" || sub === "ls") {
-      const { cmdFederationStatus } = await import("../../shared/federation");
-      await cmdFederationStatus();
+      if (args.includes("--verify")) {
+        const { cmdFederationStatusVerify } = await import("../../shared/federation");
+        const res = await cmdFederationStatusVerify();
+        if (!res.ok) {
+          return { ok: false, error: "one or more pairs are non-healthy", output: logs.join("\n") || undefined };
+        }
+      } else {
+        const { cmdFederationStatus } = await import("../../shared/federation");
+        await cmdFederationStatus();
+      }
     } else if (sub === "sync") {
       const { cmdFederationSync } = await import("../../shared/federation-sync");
       await cmdFederationSync({
@@ -37,7 +45,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     } else {
       return {
         ok: false,
-        error: "usage: maw federation <status|sync> [--dry-run|--check|--prune|--force|--json]",
+        error: "usage: maw federation <status|sync> [--verify|--dry-run|--check|--prune|--force|--json]",
       };
     }
 

--- a/src/commands/shared/federation.ts
+++ b/src/commands/shared/federation.ts
@@ -94,5 +94,63 @@ export async function cmdFederationStatus() {
     console.log(`     \x1b[90m${url}\x1b[0m`);
   }
 
-  console.log(`\n\x1b[90m${online}/${totalNodes} reachable (one-way; pair-symmetric verify TBD)\x1b[0m\n`);
+  console.log(`\n\x1b[90m${online}/${totalNodes} reachable (one-way; use --verify for pair-symmetric check)\x1b[0m\n`);
+}
+
+/**
+ * maw federation --verify — pair-symmetric check.
+ *
+ * Runs the one-way `maw federation` output first, then for each reachable peer
+ * asks their `/api/federation/status` whether local is in their peer list and
+ * marked reachable. Classifies each pair as healthy / half-up / down / unknown
+ * and exits non-zero if any pair is non-healthy.
+ *
+ * Exit codes (when called from CLI handler — see federation/index.ts):
+ *   0 : all pairs healthy
+ *   1 : at least one pair non-healthy
+ */
+export async function cmdFederationStatusVerify(): Promise<{ ok: boolean }> {
+  const { getFederationStatusSymmetric } = await import("../../core/transport/peers");
+  const config = loadConfig();
+  const named = config.namedPeers ?? [];
+  const result = await getFederationStatusSymmetric();
+
+  console.log(
+    `\n\x1b[36;1mFederation Status — Symmetric\x1b[0m  ` +
+    `\x1b[90m${result.totalPairs} pair${result.totalPairs !== 1 ? "s" : ""} · local: ${result.localNode}\x1b[0m\n`
+  );
+
+  if (result.totalPairs === 0) {
+    console.log("\x1b[90mNo peers configured. Add namedPeers[] to maw.config.json.\x1b[0m\n");
+    return { ok: true };
+  }
+
+  for (const p of result.pairs) {
+    const label = labelForPeer(p.url, named);
+    let dot: string, state: string;
+    switch (p.pair) {
+      case "healthy":
+        dot = "\x1b[32m●\x1b[0m";
+        state = "\x1b[32mhealthy\x1b[0m  \x1b[90m(A↔B)\x1b[0m";
+        break;
+      case "half-up":
+        dot = "\x1b[33m◐\x1b[0m";
+        state = `\x1b[33mhalf-up\x1b[0m  \x1b[90m(A→B OK, B→A failed${p.reason ? `: ${p.reason}` : ""})\x1b[0m`;
+        break;
+      case "down":
+        dot = "\x1b[31m●\x1b[0m";
+        state = `\x1b[31mdown\x1b[0m  \x1b[90m(${p.reason ?? "both directions failing"})\x1b[0m`;
+        break;
+      case "unknown":
+      default:
+        dot = "\x1b[90m○\x1b[0m";
+        state = `\x1b[90munknown\x1b[0m  \x1b[90m(${p.reason ?? "reverse check inconclusive"})\x1b[0m`;
+        break;
+    }
+    console.log(`  ${dot}  \x1b[37m${label}\x1b[0m  ${state}`);
+    console.log(`     \x1b[90m${p.url}\x1b[0m`);
+  }
+
+  console.log(`\n\x1b[90m${result.healthyPairs}/${result.totalPairs} pairs healthy\x1b[0m\n`);
+  return { ok: result.healthyPairs === result.totalPairs };
 }

--- a/src/core/transport/peers.ts
+++ b/src/core/transport/peers.ts
@@ -194,6 +194,116 @@ export async function getFederationStatus(): Promise<{
 }
 
 /**
+ * Pair-health verification — cross-check that the peer's view includes us.
+ *
+ * `getFederationStatus()` only measures local→peer reach. This function
+ * classifies the pair state by also asking the peer "do you see me?":
+ *
+ *   - healthy : forward reach OK AND local appears in peer's peer list marked reachable
+ *   - half-up : forward reach OK but reverse is not (we're missing from peer's view,
+ *               or they have us but mark us unreachable)
+ *   - down    : forward reach itself fails
+ *   - unknown : forward OK but we couldn't fetch peer's /api/federation/status
+ *
+ * See ψ/lab/federation-audit/pair-health-failure.md (mawjs-no2-oracle) for
+ * the full invariant + failure-scenario catalogue.
+ */
+export interface PairStatus {
+  url: string;
+  node?: string;
+  pair: "healthy" | "half-up" | "down" | "unknown";
+  forward: boolean;
+  reverse: boolean | null;
+  reason?: string;
+  latency?: number;
+  agents?: string[];
+  clockWarning?: boolean;
+}
+
+export async function getFederationStatusSymmetric(): Promise<{
+  localUrl: string;
+  localNode: string;
+  pairs: PairStatus[];
+  healthyPairs: number;
+  totalPairs: number;
+}> {
+  const config = loadConfig();
+  const localNode = config.node ?? "local";
+  const base = await getFederationStatus();
+
+  const pairs = await Promise.all(base.peers.map(async (peer): Promise<PairStatus> => {
+    const shared = {
+      url: peer.url,
+      node: peer.node,
+      latency: peer.latency,
+      agents: peer.agents,
+      clockWarning: peer.clockWarning,
+    };
+
+    if (!peer.reachable) {
+      return { ...shared, pair: "down", forward: false, reverse: null, reason: "forward unreachable" };
+    }
+
+    // Forward works; ask the peer for its view and look for ourselves in it.
+    try {
+      const res = await curlFetch(`${peer.url}/api/federation/status`, { timeout: cfgTimeout("http") });
+      if (!res.ok || !res.data) {
+        return {
+          ...shared,
+          pair: "unknown",
+          forward: true,
+          reverse: null,
+          reason: `peer /api/federation/status returned ${res.status}`,
+        };
+      }
+      const peerView = res.data as { peers?: Array<{ url?: string; node?: string; reachable?: boolean }> };
+      const peerPeers = peerView.peers ?? [];
+      const meInPeerView = peerPeers.find(p => {
+        if (p.node && localNode && p.node === localNode) return true;
+        if (p.url && p.url === base.localUrl) return true;
+        return false;
+      });
+      if (!meInPeerView) {
+        return {
+          ...shared,
+          pair: "half-up",
+          forward: true,
+          reverse: false,
+          reason: "local node not in peer's peer list",
+        };
+      }
+      if (meInPeerView.reachable === false) {
+        return {
+          ...shared,
+          pair: "half-up",
+          forward: true,
+          reverse: false,
+          reason: "peer's view of local is unreachable",
+        };
+      }
+      return { ...shared, pair: "healthy", forward: true, reverse: true };
+    } catch (err) {
+      return {
+        ...shared,
+        pair: "unknown",
+        forward: true,
+        reverse: null,
+        reason: `peer status fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+  }));
+
+  const healthyPairs = pairs.filter(p => p.pair === "healthy").length;
+  return {
+    localUrl: base.localUrl,
+    localNode,
+    pairs,
+    healthyPairs,
+    totalPairs: pairs.length,
+  };
+}
+
+/**
  * Find which peer a target session comes from, or return null if local
  */
 export async function findPeerForTarget(target: string, localSessions: Session[]): Promise<string | null> {


### PR DESCRIPTION
## Summary

Implements the full pair-symmetric check proposed in [`ψ/lab/federation-audit/pair-health-failure.md`](https://github.com/Soul-Brews-Studio/mawjs-no2-oracle/blob/main/%CF%88/lab/federation-audit/pair-health-failure.md) (Sketch A). Stacked on top of #397 (which did the truthful rename). Target this branch at #397's branch to keep history clean; retarget to `main` after #397 merges.

## The gap

`maw federation` only measures `local → peer` reach. When peer can't reach back (asymmetric NAT, one-sided firewall, stale URL, port/TLS mismatch), the pair is **half-up** but rendered as "reachable." Messages out-bound work; peer events drop silently.

## What this adds

- **`getFederationStatusSymmetric()`** in `src/core/transport/peers.ts` — runs the one-way baseline, then for each reachable peer fetches `peer/api/federation/status` (already public, sdk.ts:73 + api/federation.ts:20) and cross-checks whether local appears in the peer's peer-list marked reachable. Classifies each pair: **healthy / half-up / down / unknown**.
- **`cmdFederationStatusVerify()`** renders the pair-state output:
  ```
  ● white (local)  healthy   (A↔B)
  ◐ mba            half-up   (A→B OK, B→A failed: local not in peer's peer list)
  ● paladin        down      (forward unreachable)
  ○ charlie        unknown   (peer status fetch failed)

  1/3 pairs healthy
  ```
- **`maw federation --verify`** CLI flag. Returns non-zero via `InvokeResult` when any pair is non-healthy, so scripts can pipe the result into monitoring.

## Test gap (honest disclosure)

I wrote 8 mocked-curl-fetch unit tests for the symmetric function. All 8 passed in isolation. In the full suite, they caused **7 cross-file regressions** because `mock.module` is process-global and my curl-fetch wrapper perturbed pre-existing isolated-test expectations.

Reduced to mock-only-config tests → still caused 1 cross-file regression: two isolated test files both mocking `src/config` fight each other at module-load time.

Rather than ship a fragile test, the file was removed. A safer approach — inject `curlFetch` as a function parameter, or use a request-level fetch interceptor — is a follow-up. Until then:

**Manual verification path** for reviewers:
1. Bring up two nodes with mutual peer config.
2. `iptables -A INPUT -s <peer-ip> -p tcp --dport 3456 -j DROP` on one node.
3. `maw federation --verify` on the other node should report `half-up` with reason `peer's view of local is unreachable` (or similar).
4. Remove the rule; re-run; should report `healthy`.

## Surprise worth recording

"Isolated" tests aren't truly isolated when two files both mock the same module. `mock.module` installs process-globally; the passthrough layer between multiple wrappers depends on load order. This is a real testing-infrastructure gap in the repo that's worth a separate issue + cleanup.

## Regressions

Zero. 1706 tests, 128 pre-existing failures, same as `main`. Federation-specific: 62/0.

## Chain

- #396 — peers-require-token
- #397 — reachable-not-online (base for this)
- #398 (this) — `--verify` pair-symmetric
- Follow-ups: curl-fetch dependency-injection refactor + body-hash in HMAC + close Path B loopback

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Oracle: Bloom 🌸 (federation-audit /loop iteration 4, 2026-04-17)