### PR TITLE
test(federation): DI seam for getFederationStatusSymmetric + 11 unit tests

### DIFF
--- a/src/core/transport/peers.ts
+++ b/src/core/transport/peers.ts
@@ -220,16 +220,31 @@ export interface PairStatus {
   clockWarning?: boolean;
 }
 
-export async function getFederationStatusSymmetric(): Promise<{
+/**
+ * Optional dependency injections for `getFederationStatusSymmetric`.
+ * Passing nothing uses production behavior; tests inject to avoid the
+ * mock.module process-global-pollution finding from Bloom's federation-audit
+ * iteration 4 (3 PR #398 description explains).
+ */
+export interface SymmetricDeps {
+  /** Pre-computed baseline. If omitted, `getFederationStatus()` is called. */
+  baseStatus?: Awaited<ReturnType<typeof getFederationStatus>>;
+  /** Fetcher used for peer /api/federation/status cross-queries. Defaults to curlFetch. */
+  fetch?: typeof curlFetch;
+  /** Local node identity. Defaults to loadConfig().node ?? "local". */
+  localNode?: string;
+}
+
+export async function getFederationStatusSymmetric(deps: SymmetricDeps = {}): Promise<{
   localUrl: string;
   localNode: string;
   pairs: PairStatus[];
   healthyPairs: number;
   totalPairs: number;
 }> {
-  const config = loadConfig();
-  const localNode = config.node ?? "local";
-  const base = await getFederationStatus();
+  const localNode = deps.localNode ?? loadConfig().node ?? "local";
+  const fetchImpl = deps.fetch ?? curlFetch;
+  const base = deps.baseStatus ?? await getFederationStatus();
 
   const pairs = await Promise.all(base.peers.map(async (peer): Promise<PairStatus> => {
     const shared = {
@@ -246,7 +261,7 @@ export async function getFederationStatusSymmetric(): Promise<{
 
     // Forward works; ask the peer for its view and look for ourselves in it.
     try {
-      const res = await curlFetch(`${peer.url}/api/federation/status`, { timeout: cfgTimeout("http") });
+      const res = await fetchImpl(`${peer.url}/api/federation/status`, { timeout: cfgTimeout("http") });
       if (!res.ok || !res.data) {
         return {
           ...shared,

--- a/test/federation-symmetric.test.ts
+++ b/test/federation-symmetric.test.ts
@@ -1,0 +1,207 @@
+/**
+ * federation-symmetric — getFederationStatusSymmetric pair-health classifier.
+ *
+ * These tests use the `SymmetricDeps` injection API to drive the function
+ * with synthetic baseline + fetcher data. No mock.module — deliberately
+ * placed in `test/` (not `test/isolated/`) because the DI seam means we
+ * don't need process-global mocking at all.
+ *
+ * Iteration 4 of Bloom's federation audit caught a bug in bun-test's
+ * `mock.module()`: two "isolated" test files both mocking the same
+ * module cause cross-file wrapper layering that flips unrelated tests
+ * from pass to fail. This file sidesteps the problem entirely by taking
+ * the seam at the function parameter level, not the module level.
+ *
+ * See ψ/lab/federation-audit/pair-health-failure.md (mawjs-no2-oracle)
+ * for the full invariant + failure-scenario catalogue.
+ */
+import { describe, test, expect } from "bun:test";
+import {
+  getFederationStatusSymmetric,
+  type PairStatus,
+  type PeerStatus,
+} from "../src/core/transport/peers";
+
+type FetchFn = (url: string, opts?: unknown) => Promise<{ ok: boolean; status: number; data?: unknown }>;
+function fakeFetch(responses: Record<string, { ok: boolean; status: number; data?: unknown }>): FetchFn {
+  return async (url: string) => responses[url] ?? { ok: false, status: 0 };
+}
+
+function baseWith(peers: PeerStatus[], localUrl = "http://localhost:3456") {
+  return {
+    localUrl,
+    peers,
+    totalPeers: peers.length,
+    reachablePeers: peers.filter(p => p.reachable).length,
+    clockHealth: { clockUtc: new Date().toISOString(), timezone: "UTC", uptimeSeconds: 0 },
+  };
+}
+
+describe("getFederationStatusSymmetric — DI-testable classifier", () => {
+  test("no peers → empty pairs, zero healthy/total", async () => {
+    const res = await getFederationStatusSymmetric({
+      baseStatus: baseWith([]),
+      fetch: fakeFetch({}),
+      localNode: "white",
+    });
+    expect(res.pairs).toEqual([]);
+    expect(res.totalPairs).toBe(0);
+    expect(res.healthyPairs).toBe(0);
+    expect(res.localNode).toBe("white");
+  });
+
+  test("peer reachable AND local in peer's view marked reachable → healthy", async () => {
+    const res = await getFederationStatusSymmetric({
+      baseStatus: baseWith([{ url: "http://mba:3456", reachable: true, latency: 40, node: "mba" }]),
+      fetch: fakeFetch({
+        "http://mba:3456/api/federation/status": {
+          ok: true, status: 200,
+          data: { peers: [{ url: "http://localhost:3456", node: "white", reachable: true }] },
+        },
+      }),
+      localNode: "white",
+    });
+    expect(res.pairs[0].pair).toBe("healthy");
+    expect(res.pairs[0].forward).toBe(true);
+    expect(res.pairs[0].reverse).toBe(true);
+    expect(res.healthyPairs).toBe(1);
+  });
+
+  test("peer reachable, local MISSING from peer's peer list → half-up", async () => {
+    const res = await getFederationStatusSymmetric({
+      baseStatus: baseWith([{ url: "http://mba:3456", reachable: true, latency: 40, node: "mba" }]),
+      fetch: fakeFetch({
+        "http://mba:3456/api/federation/status": {
+          ok: true, status: 200,
+          data: { peers: [] },
+        },
+      }),
+      localNode: "white",
+    });
+    expect(res.pairs[0].pair).toBe("half-up");
+    expect(res.pairs[0].forward).toBe(true);
+    expect(res.pairs[0].reverse).toBe(false);
+    expect(res.pairs[0].reason).toMatch(/not in peer/);
+  });
+
+  test("peer has local in view but marks us unreachable → half-up", async () => {
+    const res = await getFederationStatusSymmetric({
+      baseStatus: baseWith([{ url: "http://mba:3456", reachable: true, latency: 40, node: "mba" }]),
+      fetch: fakeFetch({
+        "http://mba:3456/api/federation/status": {
+          ok: true, status: 200,
+          data: { peers: [{ url: "http://localhost:3456", node: "white", reachable: false }] },
+        },
+      }),
+      localNode: "white",
+    });
+    expect(res.pairs[0].pair).toBe("half-up");
+    expect(res.pairs[0].reason).toMatch(/unreachable/);
+  });
+
+  test("peer forward-unreachable → down (no reverse check attempted)", async () => {
+    const res = await getFederationStatusSymmetric({
+      baseStatus: baseWith([{ url: "http://mba:3456", reachable: false, latency: 0 }]),
+      fetch: fakeFetch({}),
+      localNode: "white",
+    });
+    expect(res.pairs[0].pair).toBe("down");
+    expect(res.pairs[0].forward).toBe(false);
+    expect(res.pairs[0].reverse).toBeNull();
+    expect(res.pairs[0].reason).toMatch(/forward unreachable/);
+  });
+
+  test("forward OK but peer /api/federation/status returns non-ok → unknown", async () => {
+    const res = await getFederationStatusSymmetric({
+      baseStatus: baseWith([{ url: "http://mba:3456", reachable: true, latency: 40, node: "mba" }]),
+      fetch: fakeFetch({
+        "http://mba:3456/api/federation/status": { ok: false, status: 500 },
+      }),
+      localNode: "white",
+    });
+    expect(res.pairs[0].pair).toBe("unknown");
+    expect(res.pairs[0].forward).toBe(true);
+    expect(res.pairs[0].reverse).toBeNull();
+    expect(res.pairs[0].reason).toMatch(/returned 500/);
+  });
+
+  test("forward OK but peer fetch throws → unknown with reason", async () => {
+    const res = await getFederationStatusSymmetric({
+      baseStatus: baseWith([{ url: "http://mba:3456", reachable: true, latency: 40, node: "mba" }]),
+      fetch: async () => { throw new Error("network cable unplugged"); },
+      localNode: "white",
+    });
+    expect(res.pairs[0].pair).toBe("unknown");
+    expect(res.pairs[0].reason).toMatch(/network cable/);
+  });
+
+  test("matches local by node identity when URL differs (peer uses WG IP, we use localhost)", async () => {
+    const res = await getFederationStatusSymmetric({
+      baseStatus: baseWith([{ url: "http://mba:3456", reachable: true, latency: 40, node: "mba" }]),
+      fetch: fakeFetch({
+        "http://mba:3456/api/federation/status": {
+          ok: true, status: 200,
+          data: { peers: [{ url: "http://10.0.0.1:3456", node: "white", reachable: true }] },
+        },
+      }),
+      localNode: "white",
+    });
+    expect(res.pairs[0].pair).toBe("healthy");
+  });
+
+  test("matches local by URL when node identity is absent (legacy peer)", async () => {
+    const res = await getFederationStatusSymmetric({
+      baseStatus: baseWith(
+        [{ url: "http://mba:3456", reachable: true, latency: 40 }],
+        "http://localhost:3456",
+      ),
+      fetch: fakeFetch({
+        "http://mba:3456/api/federation/status": {
+          ok: true, status: 200,
+          data: { peers: [{ url: "http://localhost:3456", reachable: true }] },
+        },
+      }),
+      localNode: "white",
+    });
+    expect(res.pairs[0].pair).toBe("healthy");
+  });
+
+  test("three-peer mesh with mixed states → 1 healthy, 1 half-up, 1 down", async () => {
+    const res = await getFederationStatusSymmetric({
+      baseStatus: baseWith([
+        { url: "http://alpha:3456", reachable: true, latency: 10, node: "alpha" },
+        { url: "http://bravo:3456", reachable: true, latency: 20, node: "bravo" },
+        { url: "http://charlie:3456", reachable: false, latency: 0 },
+      ]),
+      fetch: fakeFetch({
+        "http://alpha:3456/api/federation/status": {
+          ok: true, status: 200,
+          data: { peers: [{ url: "http://localhost:3456", node: "white", reachable: true }] },
+        },
+        "http://bravo:3456/api/federation/status": {
+          ok: true, status: 200,
+          data: { peers: [] }, // we're not in bravo's view
+        },
+      }),
+      localNode: "white",
+    });
+    expect(res.totalPairs).toBe(3);
+    expect(res.healthyPairs).toBe(1);
+    const states: PairStatus["pair"][] = res.pairs.map(p => p.pair).sort();
+    expect(states).toEqual(["down", "half-up", "healthy"]);
+  });
+
+  test("peer response lacks `peers` field entirely → half-up (defensive)", async () => {
+    const res = await getFederationStatusSymmetric({
+      baseStatus: baseWith([{ url: "http://mba:3456", reachable: true, latency: 40, node: "mba" }]),
+      fetch: fakeFetch({
+        "http://mba:3456/api/federation/status": {
+          ok: true, status: 200,
+          data: {},  // no peers field at all
+        },
+      }),
+      localNode: "white",
+    });
+    expect(res.pairs[0].pair).toBe("half-up");
+  });
+});


### PR DESCRIPTION
## Summary

Adds back the test coverage that was dropped from #398 due to `mock.module()` cross-file pollution. The fix is **architectural**, not test-framework-level: add a `SymmetricDeps` parameter to `getFederationStatusSymmetric()` so tests can inject synthetic baseline + fetcher directly — no module mocking required.

Stacked on #398. Retarget to `main` after #396 → #397 → #398 land in that order.

## The problem this solves

Iteration 4 of Bloom's federation audit found: bun-test's `mock.module()` is process-global. Two "isolated" test files both mocking `src/config` (and one also mocking `src/core/transport/curl-fetch`) caused **7 unrelated tests** to flip from pass to fail. The mock wrappers layer across files non-deterministically.

Rather than fight the mock system, we take the seam at the function parameter level.

## Change

```ts
export interface SymmetricDeps {
  baseStatus?: Awaited<ReturnType<typeof getFederationStatus>>;
  fetch?: typeof curlFetch;
  localNode?: string;
}

export async function getFederationStatusSymmetric(
  deps: SymmetricDeps = {}
): Promise<{...}> {
  const localNode = deps.localNode ?? loadConfig().node ?? "local";
  const fetchImpl = deps.fetch ?? curlFetch;
  const base = deps.baseStatus ?? await getFederationStatus();
  // ... unchanged classification logic
}
```

Production callers pass nothing (unchanged). Tests inject everything.

## Test coverage (11 new tests, all passing)

- Empty-peers degenerate case
- **healthy**: forward OK + local in peer's view marked reachable
- **half-up** variant A: local missing from peer's peer list
- **half-up** variant B: local in list but marked unreachable
- **down**: forward unreachable, reverse not attempted
- **unknown** on non-ok reverse response (500)
- **unknown** on thrown reverse fetch (network error)
- Node-identity match when URL differs (peer knows us by WG IP, we know ourselves by localhost)
- URL-fallback match when node identity absent (legacy peer)
- Three-peer mesh with mixed states (1 healthy / 1 half-up / 1 down)
- Defensive: peer response missing `peers` field entirely → half-up

## File placement

`test/federation-symmetric.test.ts` — deliberately in `test/`, NOT `test/isolated/`. The DI seam means we don't need mock-module isolation at all, so the test file belongs in the broader test pool. Lives alongside `test/federation-auth.test.ts` (which tests the same module's pure functions).

## Regressions

Zero. Full suite: **1717 tests** (main 1706 + 11 new), **128 pre-existing failures** — same as main.

## Follow-ups enabled by this

D#2 (body-hash HMAC) can now use the same DI pattern for clean unit tests of captured-sig body-swap scenarios. D#4 (close Path B) can test local-CLI signing paths without mocking. Iteration-4's "isolated tests aren't isolated" finding should also be filed as a standalone issue for repo-wide cleanup.

## Chain

- #396 peers-require-token
- #397 reachable-not-online
- #398 pair-symmetric --verify
- #399 (this) DI seam + tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Oracle: Bloom 🌸 (federation-audit /loop iteration 6, 2026-04-17)