### PR TITLE
feat(federation): maw federation --verify — pair-symmetric health check (replaces #398)

### DIFF
--- a/src/commands/plugins/federation/index.ts
+++ b/src/commands/plugins/federation/index.ts
@@ -23,8 +23,16 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     const sub = args[0]?.toLowerCase();
 
     if (!sub || sub === "status" || sub === "ls") {
-      const { cmdFederationStatus } = await import("../../shared/federation");
-      await cmdFederationStatus();
+      if (args.includes("--verify")) {
+        const { cmdFederationStatusVerify } = await import("../../shared/federation");
+        const res = await cmdFederationStatusVerify();
+        if (!res.ok) {
+          return { ok: false, error: "one or more pairs are non-healthy", output: logs.join("\n") || undefined };
+        }
+      } else {
+        const { cmdFederationStatus } = await import("../../shared/federation");
+        await cmdFederationStatus();
+      }
     } else if (sub === "sync") {
       const { cmdFederationSync } = await import("../../shared/federation-sync");
       await cmdFederationSync({
@@ -37,7 +45,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     } else {
       return {
         ok: false,
-        error: "usage: maw federation <status|sync> [--dry-run|--check|--prune|--force|--json]",
+        error: "usage: maw federation <status|sync> [--verify|--dry-run|--check|--prune|--force|--json]",
       };
     }
 

--- a/src/commands/shared/federation.ts
+++ b/src/commands/shared/federation.ts
@@ -95,3 +95,61 @@ export async function cmdFederationStatus() {
 
   console.log(`\n\x1b[90m${reachableCount}/${totalNodes} reachable (one-way; use --verify for pair-symmetric check — PR #398)\x1b[0m\n`);
 }
+
+/**
+ * maw federation --verify — pair-symmetric check.
+ *
+ * Runs the one-way `maw federation` output first, then for each reachable peer
+ * asks their `/api/federation/status` whether local is in their peer list and
+ * marked reachable. Classifies each pair as healthy / half-up / down / unknown
+ * and exits non-zero if any pair is non-healthy.
+ *
+ * Exit codes (when called from CLI handler — see federation/index.ts):
+ *   0 : all pairs healthy
+ *   1 : at least one pair non-healthy
+ */
+export async function cmdFederationStatusVerify(): Promise<{ ok: boolean }> {
+  const { getFederationStatusSymmetric } = await import("../../core/transport/peers");
+  const config = loadConfig();
+  const named = config.namedPeers ?? [];
+  const result = await getFederationStatusSymmetric();
+
+  console.log(
+    `\n\x1b[36;1mFederation Status — Symmetric\x1b[0m  ` +
+    `\x1b[90m${result.totalPairs} pair${result.totalPairs !== 1 ? "s" : ""} · local: ${result.localNode}\x1b[0m\n`
+  );
+
+  if (result.totalPairs === 0) {
+    console.log("\x1b[90mNo peers configured. Add namedPeers[] to maw.config.json.\x1b[0m\n");
+    return { ok: true };
+  }
+
+  for (const p of result.pairs) {
+    const label = labelForPeer(p.url, named);
+    let dot: string, state: string;
+    switch (p.pair) {
+      case "healthy":
+        dot = "\x1b[32m●\x1b[0m";
+        state = "\x1b[32mhealthy\x1b[0m  \x1b[90m(A↔B)\x1b[0m";
+        break;
+      case "half-up":
+        dot = "\x1b[33m◐\x1b[0m";
+        state = `\x1b[33mhalf-up\x1b[0m  \x1b[90m(A→B OK, B→A failed${p.reason ? `: ${p.reason}` : ""})\x1b[0m`;
+        break;
+      case "down":
+        dot = "\x1b[31m●\x1b[0m";
+        state = `\x1b[31mdown\x1b[0m  \x1b[90m(${p.reason ?? "both directions failing"})\x1b[0m`;
+        break;
+      case "unknown":
+      default:
+        dot = "\x1b[90m○\x1b[0m";
+        state = `\x1b[90munknown\x1b[0m  \x1b[90m(${p.reason ?? "reverse check inconclusive"})\x1b[0m`;
+        break;
+    }
+    console.log(`  ${dot}  \x1b[37m${label}\x1b[0m  ${state}`);
+    console.log(`     \x1b[90m${p.url}\x1b[0m`);
+  }
+
+  console.log(`\n\x1b[90m${result.healthyPairs}/${result.totalPairs} pairs healthy\x1b[0m\n`);
+  return { ok: result.healthyPairs === result.totalPairs };
+}


### PR DESCRIPTION
Recreates #398 (closed/conflicting). Content rebased onto main after #399 (DI seam) + #401 (trustLoopback) landed.

Original #398: https://github.com/Soul-Brews-Studio/maw-js/pull/398

## Summary
- Adds `maw federation --verify` — pair-symmetric health check (healthy / half-up / down / unknown)
- Uses the DI-seam version of `getFederationStatusSymmetric` that landed in #399
- Exit code 1 if any pair non-healthy, 0 otherwise

## Test plan
- [x] rebased cleanly (1 commit on top of main)
- [ ] scoped tests to run after merge