### PR TITLE
feat(security): HMAC body-hash signatures (v2) — prevents body-swap replay (replaces #400)

### DIFF
--- a/src/lib/federation-auth.ts
+++ b/src/lib/federation-auth.ts
@@ -3,17 +3,33 @@
  *
  * Design:
  *   - Each node shares a `federationToken` (config field, min 16 chars)
- *   - Outgoing HTTP calls sign: HMAC-SHA256(token, "METHOD:PATH:TIMESTAMP")
+ *   - Outgoing HTTP calls sign: HMAC-SHA256(token, "METHOD:PATH:TIMESTAMP[:BODY_SHA256]")
  *   - Incoming requests verify signature within ±5 min window
  *   - No token configured → all requests pass (backwards compat)
  *   - Loopback requests always pass (local CLI / browser)
+ *
+ * Signature versions:
+ *   - v1 (legacy): payload is METHOD:PATH:TIMESTAMP. Body is NOT signed — a
+ *     captured v1 signature allows arbitrary body substitution within the
+ *     5-min window (this is the attack D#2 closes).
+ *   - v2 (preferred): payload is METHOD:PATH:TIMESTAMP:BODY_SHA256. Body hash
+ *     binds the signature to the exact bytes sent. Body-swap replay is 401.
+ *   - Version is signaled via `X-Maw-Auth-Version: v2` header. Absent header
+ *     = v1 (for outbound: signHeaders without body; for inbound: legacy peer).
  */
 
-import { createHmac, timingSafeEqual } from "crypto";
+import { createHash, createHmac, timingSafeEqual } from "crypto";
 import type { MiddlewareHandler } from "hono";
 import { loadConfig } from "../config";
 
 const WINDOW_SEC = 300; // ±5 minutes
+
+/** Stable body-hash for the signed payload. Empty body → empty string. */
+export function hashBody(body: string | Uint8Array | undefined | null): string {
+  if (body == null || (typeof body === "string" && body.length === 0)) return "";
+  if (body instanceof Uint8Array && body.length === 0) return "";
+  return createHash("sha256").update(body as string | Buffer).digest("hex");
+}
 
 /** Protected paths — write/control operations, require auth from non-loopback clients */
 const PROTECTED = new Set([
@@ -35,17 +51,31 @@ const PROTECTED_POST = new Set([
 
 // --- Core crypto ---
 
-export function sign(token: string, method: string, path: string, timestamp: number): string {
-  const payload = `${method}:${path}:${timestamp}`;
+/**
+ * Sign a request. When `bodyHash` is provided, produces a v2 signature that
+ * binds the signature to the body bytes. When omitted or empty, produces a
+ * v1 signature (legacy, body-unsigned).
+ */
+export function sign(token: string, method: string, path: string, timestamp: number, bodyHash = ""): string {
+  const payload = bodyHash
+    ? `${method}:${path}:${timestamp}:${bodyHash}`
+    : `${method}:${path}:${timestamp}`;
   return createHmac("sha256", token).update(payload).digest("hex");
 }
 
-export function verify(token: string, method: string, path: string, timestamp: number, signature: string): boolean {
+/**
+ * Verify a signature. `bodyHash` must match what was signed:
+ *   - omitted/empty → verifies v1 (legacy)
+ *   - provided     → verifies v2 (body-bound)
+ * The caller is responsible for passing the right value based on the
+ * `X-Maw-Auth-Version` header on the incoming request.
+ */
+export function verify(token: string, method: string, path: string, timestamp: number, signature: string, bodyHash = ""): boolean {
   const now = Math.floor(Date.now() / 1000);
   const delta = Math.abs(now - timestamp);
   if (delta > WINDOW_SEC) return false;
 
-  const expected = sign(token, method, path, timestamp);
+  const expected = sign(token, method, path, timestamp, bodyHash);
   if (expected.length !== signature.length) return false;
 
   try {
@@ -66,13 +96,29 @@ export function isLoopback(address: string | undefined): boolean {
     || address.startsWith("127.");
 }
 
-/** Produce auth headers for outgoing federation HTTP calls */
-export function signHeaders(token: string, method: string, path: string): Record<string, string> {
+/**
+ * Produce auth headers for outgoing federation HTTP calls.
+ *
+ * When `body` is provided (and non-empty), emits v2 signature + the
+ * `X-Maw-Auth-Version: v2` header so the peer knows to re-hash the body
+ * and verify accordingly. When omitted, produces v1 for backward compat
+ * (but callers SHOULD pass the body whenever possible — body-swap replay
+ * is a real attack path otherwise).
+ */
+export function signHeaders(
+  token: string,
+  method: string,
+  path: string,
+  body?: string | Uint8Array,
+): Record<string, string> {
   const ts = Math.floor(Date.now() / 1000);
-  return {
+  const bh = body != null ? hashBody(body) : "";
+  const headers: Record<string, string> = {
     "X-Maw-Timestamp": String(ts),
-    "X-Maw-Signature": sign(token, method, path, ts),
+    "X-Maw-Signature": sign(token, method, path, ts, bh),
   };
+  if (bh) headers["X-Maw-Auth-Version"] = "v2";
+  return headers;
 }
 
 // --- Hono middleware ---
@@ -142,6 +188,7 @@ export function federationAuth(): MiddlewareHandler {
     // Check for HMAC signature
     const sig = c.req.header("x-maw-signature");
     const ts = c.req.header("x-maw-timestamp");
+    const authVersion = (c.req.header("x-maw-auth-version") ?? "v1").toLowerCase();
 
     if (!sig || !ts) {
       return c.json({ error: "federation auth required", reason: "missing_signature" }, 401);
@@ -152,12 +199,35 @@ export function federationAuth(): MiddlewareHandler {
       return c.json({ error: "federation auth failed", reason: "invalid_timestamp" }, 401);
     }
 
-    if (!verify(token, c.req.method, path, timestamp, sig)) {
+    // Body hash is load-bearing for v2; absent/empty for v1.
+    // Reading the body here consumes the stream; subsequent handlers must
+    // rely on c.req.text() / c.req.json() which Hono re-reads from the
+    // cached raw request. In Hono 4+, c.req.raw.clone() + arrayBuffer()
+    // is the safe pattern — the middleware reads a clone, the handler
+    // reads the original.
+    let bodyHash = "";
+    if (authVersion === "v2") {
+      try {
+        const clone = c.req.raw.clone();
+        const buf = new Uint8Array(await clone.arrayBuffer());
+        bodyHash = hashBody(buf);
+      } catch (err) {
+        console.warn(`[auth] v2 body read failed for ${c.req.method} ${path}: ${err instanceof Error ? err.message : String(err)}`);
+        return c.json({ error: "federation auth failed", reason: "body_read_failed" }, 401);
+      }
+    }
+
+    if (!verify(token, c.req.method, path, timestamp, sig, bodyHash)) {
       const now = Math.floor(Date.now() / 1000);
       const delta = Math.abs(now - timestamp);
       const reason = delta > WINDOW_SEC ? "timestamp_expired" : "signature_invalid";
-      console.warn(`[auth] rejected ${c.req.method} ${path} from ${clientIp}: ${reason} (delta=${delta}s)`);
+      console.warn(`[auth] rejected ${c.req.method} ${path} from ${clientIp}: ${reason} (delta=${delta}s, version=${authVersion})`);
       return c.json({ error: "federation auth failed", reason, ...(delta > WINDOW_SEC ? { delta } : {}) }, 401);
+    }
+
+    // v1 is a deprecation path — warn so operators see the attack surface.
+    if (authVersion === "v1") {
+      console.warn(`[auth] v1 (body-unsigned) accepted for ${c.req.method} ${path} from ${clientIp} — peer should upgrade to v2; body-swap replay is possible until they do`);
     }
 
     return next();

--- a/test/federation-auth.test.ts
+++ b/test/federation-auth.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import { readFileSync } from "fs";
-import { sign, verify, isLoopback, signHeaders } from "../src/lib/federation-auth";
+import { sign, verify, isLoopback, signHeaders, hashBody } from "../src/lib/federation-auth";
 
 // --- isLoopback ---
 
@@ -102,6 +102,122 @@ describe("signHeaders", () => {
     const ts = parseInt(headers["X-Maw-Timestamp"], 10);
     const sig = headers["X-Maw-Signature"];
     expect(verify(token, "POST", "/api/send", ts, sig)).toBe(true);
+  });
+});
+
+// --- v2 body-hash signatures (D#2 — prevents captured-sig body-swap) ---
+
+describe("hashBody", () => {
+  const token = "test-federation-token-minimum-16-chars";
+
+  test("empty/undefined/null body → empty string (v1 marker)", () => {
+    expect(hashBody("")).toBe("");
+    expect(hashBody(undefined)).toBe("");
+    expect(hashBody(null)).toBe("");
+    expect(hashBody(new Uint8Array(0))).toBe("");
+  });
+
+  test("string body → 64-char hex digest", () => {
+    expect(hashBody("hello")).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("same string → same hash (deterministic)", () => {
+    expect(hashBody("hello")).toBe(hashBody("hello"));
+  });
+
+  test("different strings → different hashes", () => {
+    expect(hashBody("hello")).not.toBe(hashBody("hello2"));
+  });
+
+  test("Uint8Array body hashes same bytes as string", () => {
+    const s = '{"target":"x","text":"y"}';
+    const u = new TextEncoder().encode(s);
+    expect(hashBody(s)).toBe(hashBody(u));
+  });
+});
+
+describe("sign/verify with bodyHash (v2)", () => {
+  const token = "test-federation-token-minimum-16-chars";
+
+  test("v2 round-trip — same body hash verifies", () => {
+    const ts = Math.floor(Date.now() / 1000);
+    const bh = hashBody('{"target":"x","text":"hello"}');
+    const sig = sign(token, "POST", "/api/send", ts, bh);
+    expect(verify(token, "POST", "/api/send", ts, sig, bh)).toBe(true);
+  });
+
+  test("v2 sig + different body-hash → false (the body-swap attack is blocked)", () => {
+    const ts = Math.floor(Date.now() / 1000);
+    const bhSigned = hashBody('{"target":"x","text":"original"}');
+    const bhReplayed = hashBody('{"target":"x","text":"attacker-payload"}');
+    const sig = sign(token, "POST", "/api/send", ts, bhSigned);
+    expect(verify(token, "POST", "/api/send", ts, sig, bhReplayed)).toBe(false);
+  });
+
+  test("v1 sig + any body-hash on verify → false (version mismatch)", () => {
+    const ts = Math.floor(Date.now() / 1000);
+    const sigV1 = sign(token, "POST", "/api/send", ts);
+    // Verifier thinks it's v2 (has a body hash), but signature is v1
+    const bh = hashBody('{"target":"x"}');
+    expect(verify(token, "POST", "/api/send", ts, sigV1, bh)).toBe(false);
+  });
+
+  test("v2 sig verified as v1 (no body hash) → false (version mismatch)", () => {
+    const ts = Math.floor(Date.now() / 1000);
+    const sigV2 = sign(token, "POST", "/api/send", ts, hashBody("any"));
+    expect(verify(token, "POST", "/api/send", ts, sigV2)).toBe(false);
+  });
+
+  test("v1 sig + no bodyHash on verify → true (backward compat path)", () => {
+    const ts = Math.floor(Date.now() / 1000);
+    const sigV1 = sign(token, "POST", "/api/send", ts);
+    expect(verify(token, "POST", "/api/send", ts, sigV1)).toBe(true);
+  });
+
+  test("timestamp still enforced in v2 (old captured sig rejected)", () => {
+    const oldTs = Math.floor(Date.now() / 1000) - 400;
+    const bh = hashBody('{"x":1}');
+    const sig = sign(token, "POST", "/api/send", oldTs, bh);
+    expect(verify(token, "POST", "/api/send", oldTs, sig, bh)).toBe(false);
+  });
+});
+
+describe("signHeaders with body (v2)", () => {
+  const token = "test-federation-token-minimum-16-chars";
+
+  test("no body → v1 headers (no version header)", () => {
+    const h = signHeaders(token, "POST", "/api/send");
+    expect(h["X-Maw-Timestamp"]).toBeDefined();
+    expect(h["X-Maw-Signature"]).toMatch(/^[0-9a-f]{64}$/);
+    expect(h["X-Maw-Auth-Version"]).toBeUndefined();
+  });
+
+  test("body provided → v2 headers (includes version)", () => {
+    const h = signHeaders(token, "POST", "/api/send", '{"x":1}');
+    expect(h["X-Maw-Auth-Version"]).toBe("v2");
+    expect(h["X-Maw-Signature"]).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("empty body string → v1 (no version header; matches 'no body')", () => {
+    const h = signHeaders(token, "POST", "/api/send", "");
+    expect(h["X-Maw-Auth-Version"]).toBeUndefined();
+  });
+
+  test("v2 signature verifies when reconstructed with same body hash", () => {
+    const body = '{"target":"x","text":"hello"}';
+    const h = signHeaders(token, "POST", "/api/send", body);
+    const ts = parseInt(h["X-Maw-Timestamp"], 10);
+    const bh = hashBody(body);
+    expect(verify(token, "POST", "/api/send", ts, h["X-Maw-Signature"], bh)).toBe(true);
+  });
+
+  test("v2 signature does NOT verify with swapped body hash (the attack)", () => {
+    const realBody = '{"target":"x","text":"original"}';
+    const attackerBody = '{"target":"x","text":"payload"}';
+    const h = signHeaders(token, "POST", "/api/send", realBody);
+    const ts = parseInt(h["X-Maw-Timestamp"], 10);
+    const bhAttacker = hashBody(attackerBody);
+    expect(verify(token, "POST", "/api/send", ts, h["X-Maw-Signature"], bhAttacker)).toBe(false);
   });
 });
 


### PR DESCRIPTION
Recreates #400 (closed/conflicting). Content rebased onto main after #399 + #401 + #417 landed.

Original #400: https://github.com/Soul-Brews-Studio/maw-js/pull/400

## Summary
- HMAC v2: include request body hash in signature payload to block body-swap replay
- Backwards compatible with v1 signers during transition

## Test plan
- [x] rebased cleanly (1 commit on top of main)
- [ ] scoped tests to run after merge