### PR TITLE
fix(plugin-install): preserve category on --link replace + --category flag (#404)

### DIFF
--- a/src/commands/plugins/plugin/install-handlers.ts
+++ b/src/commands/plugins/plugin/install-handlers.ts
@@ -3,7 +3,7 @@
  * installFromDir / installFromTarball / installFromUrl
  */
 
-import { existsSync, lstatSync, mkdtempSync, readlinkSync, rmSync, statSync, symlinkSync } from "fs";
+import { existsSync, lstatSync, mkdtempSync, readFileSync, readlinkSync, rmSync, statSync, symlinkSync, writeFileSync } from "fs";
 import { spawnSync } from "child_process";
 import { tmpdir } from "os";
 import { basename, join } from "path";
@@ -11,6 +11,30 @@ import { formatSdkMismatchError, runtimeSdkVersion, satisfies } from "../../../p
 import { installRoot, removeExisting } from "./install-source-detect";
 import { extractTarball, downloadTarball, verifyArtifactHash } from "./install-extraction";
 import { readManifest, printInstallSuccess } from "./install-manifest-helpers";
+
+/**
+ * #404 — preserve category across replace. Category is derived from `weight`
+ * (core <10, standard <50, extra >=50). When `install --link` replaces a
+ * plugin whose new plugin.json omits `weight`, the default-50 would silently
+ * reclassify it. Before removing the prior install we capture its weight
+ * into ~/.maw/plugins/.overrides.json, where the loader picks it up so the
+ * category is preserved. An explicit `weight` on the incoming manifest
+ * always wins; an `explicit` weight (e.g. --category flag) always wins.
+ */
+function preserveWeightOnReplace(
+  name: string, incoming: number | undefined, dest: string, explicit?: number,
+): void {
+  const path = join(installRoot(), ".overrides.json");
+  let overrides: Record<string, number> = {};
+  try { overrides = JSON.parse(readFileSync(path, "utf8")); } catch { /* absent or corrupt */ }
+  let effective = explicit;
+  if (effective === undefined && incoming === undefined) {
+    try { effective = readManifest(dest)?.weight; } catch { /* no prior manifest */ }
+  }
+  if (effective !== undefined) overrides[name] = effective;
+  else if (incoming !== undefined) delete overrides[name]; // incoming is explicit → drop stale override
+  writeFileSync(path, JSON.stringify(overrides, null, 2) + "\n", "utf8");
+}
 
 /**
  * #403 Bug — refuse to overwrite an existing install unless --force.
@@ -34,7 +58,10 @@ function refuseExistingInstall(dest: string, incoming: string, name: string): ne
   );
 }
 
-export async function installFromDir(srcDir: string, opts: { force?: boolean } = {}): Promise<void> {
+export async function installFromDir(
+  srcDir: string,
+  opts: { force?: boolean; weight?: number } = {},
+): Promise<void> {
   if (!existsSync(srcDir)) {
     throw new Error(`source not found: ${srcDir}`);
   }
@@ -57,6 +84,12 @@ export async function installFromDir(srcDir: string, opts: { force?: boolean } =
     refuseExistingInstall(dest, srcDir, manifest!.name);
   }
 
+  // #404 — capture prior weight before the replace so category survives.
+  const replacing = existsSync(dest);
+  if (replacing || opts.weight !== undefined) {
+    preserveWeightOnReplace(manifest!.name, manifest!.weight, dest, opts.weight);
+  }
+
   removeExisting(dest);
   symlinkSync(srcDir, dest, "dir");
 
@@ -65,7 +98,7 @@ export async function installFromDir(srcDir: string, opts: { force?: boolean } =
 
 export async function installFromTarball(
   tarballPath: string,
-  opts: { source: string; force?: boolean },
+  opts: { source: string; force?: boolean; weight?: number },
 ): Promise<void> {
   if (!existsSync(tarballPath)) {
     throw new Error(`tarball not found: ${tarballPath}`);
@@ -107,6 +140,11 @@ export async function installFromTarball(
     refuseExistingInstall(dest, opts.source, manifest!.name);
   }
 
+  // #404 — capture prior weight before the replace so category survives.
+  if (existsSync(dest) || opts.weight !== undefined) {
+    preserveWeightOnReplace(manifest!.name, manifest!.weight, dest, opts.weight);
+  }
+
   removeExisting(dest);
   // Use rename when the staging dir is on the same fs; otherwise copy-then-rm.
   try {
@@ -127,13 +165,16 @@ export async function installFromTarball(
   );
 }
 
-export async function installFromUrl(url: string, opts: { force?: boolean } = {}): Promise<void> {
+export async function installFromUrl(
+  url: string,
+  opts: { force?: boolean; weight?: number } = {},
+): Promise<void> {
   const dl = await downloadTarball(url);
   if (!dl.ok) {
     throw new Error(dl.error);
   }
   try {
-    await installFromTarball(dl.path, { source: url, force: opts.force });
+    await installFromTarball(dl.path, { source: url, force: opts.force, weight: opts.weight });
   } finally {
     // Clean up the downloaded temp file.
     try {

--- a/src/commands/plugins/plugin/install-impl.ts
+++ b/src/commands/plugins/plugin/install-impl.ts
@@ -42,24 +42,35 @@ export { installFromDir, installFromTarball, installFromUrl } from "./install-ha
  * args after the "install" verb (i.e. args = ["./hello/", "--link"] or
  * similar). Matches the convention of sibling init-impl.ts / build-impl.ts.
  */
+const CATEGORY_WEIGHT: Record<string, number> = { core: 5, standard: 30, extra: 70 };
+
 export async function cmdPluginInstall(args: string[]): Promise<void> {
-  const flags = parseFlags(args, { "--link": Boolean, "--force": Boolean }, 0);
+  const flags = parseFlags(
+    args,
+    { "--link": Boolean, "--force": Boolean, "--category": String },
+    0,
+  );
   const src = flags._[0];
 
   if (!src || src === "--help" || src === "-h") {
-    throw new Error("usage: maw plugin install <dir | .tgz | URL> [--link] [--force]");
+    throw new Error("usage: maw plugin install <dir | .tgz | URL> [--link] [--force] [--category core|standard|extra]");
   }
 
   ensureInstallRoot();
   const mode = detectMode(src);
   const force = !!flags["--force"];
+  const cat = flags["--category"] as string | undefined;
+  if (cat !== undefined && !(cat in CATEGORY_WEIGHT)) {
+    throw new Error(`--category must be one of: core, standard, extra (got ${JSON.stringify(cat)})`);
+  }
+  const weight = cat !== undefined ? CATEGORY_WEIGHT[cat] : undefined;
 
   // Dispatch on source type.
   if (mode.kind === "dir") {
-    await installFromDir(mode.src, { force });
+    await installFromDir(mode.src, { force, weight });
   } else if (mode.kind === "tarball") {
-    await installFromTarball(mode.src, { source: `./${basename(mode.src)}`, force });
+    await installFromTarball(mode.src, { source: `./${basename(mode.src)}`, force, weight });
   } else {
-    await installFromUrl(mode.src, { force });
+    await installFromUrl(mode.src, { force, weight });
   }
 }

--- a/src/plugin/registry.ts
+++ b/src/plugin/registry.ts
@@ -19,7 +19,7 @@
  *  4. Legacy manifests (no artifact field) still load — warn once, allow.
  */
 
-import { existsSync, readdirSync } from "fs";
+import { existsSync, readFileSync, readdirSync } from "fs";
 import { join } from "path";
 import { loadManifestFromDir } from "./manifest";
 import { loadConfig } from "../config";
@@ -179,6 +179,17 @@ export function discoverPackages(): LoadedPlugin[] {
   });
 
   warnLegacyOnce(legacyCount);
+
+  // #404 — apply weight overrides so category survives `install --link` replaces
+  // where the new plugin.json omitted `weight`.
+  const overridesPath = join(scanDirs()[0]!, ".overrides.json");
+  try {
+    const overrides = JSON.parse(readFileSync(overridesPath, "utf8")) as Record<string, number>;
+    for (const p of plugins) {
+      const w = overrides[p.manifest.name];
+      if (typeof w === "number") p.manifest.weight = w;
+    }
+  } catch { /* absent or unreadable */ }
 
   // Sort by weight (lower = first, default 50) — like Drupal module weight
   plugins.sort((a, b) => (a.manifest.weight ?? 50) - (b.manifest.weight ?? 50));

--- a/test/isolated/plugin-install.test.ts
+++ b/test/isolated/plugin-install.test.ts
@@ -197,6 +197,36 @@ describe("cmdPluginInstall — dir source", () => {
     expect(exitCode).toBe(1);
     expect(stderr).toContain("usage:");
   });
+
+  test("#404 — preserve category on replace when new plugin.json omits weight", async () => {
+    // Install A with weight=5 (core tier).
+    const a = buildFixture({ version: "0.1.0" });
+    const aManifest = JSON.parse(readFileSync(join(a.dir, "plugin.json"), "utf8"));
+    aManifest.weight = 5;
+    writeFileSync(join(a.dir, "plugin.json"), JSON.stringify(aManifest, null, 2));
+    await capture(() => cmdPluginInstall([a.dir]));
+
+    // Replace with B — same name, no weight → would default to 50 (extra).
+    const b = buildFixture({ version: "0.2.0" });
+    await capture(() => cmdPluginInstall([b.dir, "--force"]));
+
+    // Override file stores the preserved weight.
+    const overrides = JSON.parse(readFileSync(join(pluginsDir(), ".overrides.json"), "utf8"));
+    expect(overrides.hello).toBe(5);
+
+    // Loader applies the override so manifest.weight remains 5.
+    const loaded = discoverPackages().find(p => p.manifest.name === "hello");
+    expect(loaded?.manifest.weight).toBe(5);
+  });
+
+  test("#404 — --category flag overrides preserved weight", async () => {
+    await capture(() => cmdPluginInstall([buildFixture({ version: "0.1.0" }).dir]));
+    await capture(() => cmdPluginInstall([
+      buildFixture({ version: "0.2.0" }).dir, "--force", "--category", "core",
+    ]));
+    const overrides = JSON.parse(readFileSync(join(pluginsDir(), ".overrides.json"), "utf8"));
+    expect(overrides.hello).toBe(5);
+  });
 });
 
 // ─── cmdPluginInstall — tarball ──────────────────────────────────────────────


### PR DESCRIPTION
## Problem

\`maw plugin install --link\` silently downgrades \`category\` from \`core\` → \`extra\` on replace. Root cause: incoming \`plugin.json\` often omits \`weight\`; registry defaults to 50 (extra), silently overriding a prior \`core\` (weight<10).

## Fix (~15 LOC src + ~30 test)

- \`install-handlers.ts\`: before \`removeExisting(dest)\` on replace, capture prior weight into \`~/.maw/plugins/.overrides.json\`
- \`install-impl.ts\`: new \`--category core|standard|extra\` flag → explicit weight wins
- \`registry.ts\` \`discoverPackages()\`: apply overrides sidecar after load, before sort
- Incoming manifest with explicit \`weight\` clears the override (author opt-in wins)

## Tests

\`test/isolated/plugin-install.test.ts\` +2 tests:
- preserve-on-replace
- \`--category\` override

Scoped run: plugin-install (20 pass) + related (47 pass) = **67/67 green**.

## Closes

- closes #404