### PR TITLE
fix(view): don't auto-cleanup grouped view on detach (#420)

### DIFF
--- a/src/commands/plugins/view/impl.ts
+++ b/src/commands/plugins/view/impl.ts
@@ -5,7 +5,7 @@ import { resolveSessionTarget } from "../../../core/matcher/resolve-target";
 import { logAnomaly } from "../../../core/fleet/audit";
 import { execSync } from "child_process";
 
-export async function cmdView(agent: string, windowHint?: string, clean = false) {
+export async function cmdView(agent: string, windowHint?: string, clean = false, kill = false) {
   // Find the session
   const sessions = await listSessions();
   const allWindows = sessions.flatMap(s => s.windows.map(w => ({ session: s.name, ...w })));
@@ -115,11 +115,9 @@ export async function cmdView(agent: string, windowHint?: string, clean = false)
   // Reuse existing view if present — killing it would evict anyone else
   // already attached (e.g. a second terminal on the same view).
   const viewExists = await t.hasSession(viewName);
-  let weCreated = false;
   if (!viewExists) {
     await t.newGroupedSession(sessionName, viewName, { windowSize: "largest" });
     console.log(`\x1b[36mcreated\x1b[0m → ${viewName} (grouped with ${sessionName})`);
-    weCreated = true;
   } else {
     console.log(`\x1b[36mreuse\x1b[0m   → ${viewName} (existing grouped session — ${sessionName})`);
   }
@@ -182,12 +180,13 @@ export async function cmdView(agent: string, windowHint?: string, clean = false)
     console.error(`\x1b[33mwarn\x1b[0m: attach exited non-zero — ${msg}`);
   }
 
-  // Cleanup: kill grouped session after detach (or after failed attach) — but
-  // only if WE created it. A reused view may have other attached clients.
-  if (weCreated) {
+  // #420: no auto-cleanup on detach. The view is grouped (shares state with
+  // the oracle session), so keeping it idle is cheap — and killing it here
+  // forces the next `maw a <agent>` to pay the create cost again. Stale
+  // views are reaped by `maw cleanup --zombie-agents` (#400/#418) or by
+  // explicit `--kill` on this command.
+  if (kill) {
     await t.killSession(viewName);
     console.log(`\x1b[90mcleaned\x1b[0m → ${viewName}`);
   }
-  // Normal return — no process.exit. Letting the event loop drain naturally
-  // is safer than forcing an exit code that can race with parent shell state.
 }

--- a/src/commands/plugins/view/index.ts
+++ b/src/commands/plugins/view/index.ts
@@ -26,13 +26,14 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     if (!args[0]) {
       return {
         ok: false,
-        error: "usage: maw view <agent> [window] [--clean]",
+        error: "usage: maw view <agent> [window] [--clean] [--kill]",
       };
     }
 
     const clean = args.includes("--clean");
-    const filtered = args.filter(a => a !== "--clean");
-    await cmdView(filtered[0], filtered[1], clean);
+    const kill = args.includes("--kill");
+    const filtered = args.filter(a => a !== "--clean" && a !== "--kill");
+    await cmdView(filtered[0], filtered[1], clean, kill);
     return { ok: true, output: logs.join("\n") || undefined };
   } catch (e: any) {
     return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };

--- a/src/commands/plugins/view/plugin.json
+++ b/src/commands/plugins/view/plugin.json
@@ -12,9 +12,10 @@
       "attach",
       "a"
     ],
-    "help": "maw view <agent> [window] [--clean] — create or attach to an agent's tmux view",
+    "help": "maw view <agent> [window] [--clean] [--kill] — create or attach to an agent's tmux view",
     "flags": {
-      "--clean": "boolean"
+      "--clean": "boolean",
+      "--kill": "boolean"
     }
   },
   "weight": 10

--- a/test/view-no-cleanup-on-detach.test.ts
+++ b/test/view-no-cleanup-on-detach.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Regression tests for #420 — `maw a <agent>` must NOT clean up the
+ * grouped view session on normal detach.
+ *
+ * #419 ("skip cleanup unless creator") still killed the view whenever the
+ * creator was the sole viewer, which is the common case. As a result, the
+ * next `maw a <agent>` paid the create cost every time instead of reusing
+ * the grouped view.
+ *
+ * Fix: cmdView never auto-kills the view session. Cleanup is now the sole
+ * responsibility of `maw cleanup --zombie-agents` (#400/#418) or an
+ * explicit `tmux kill-session -t <viewName>`.
+ *
+ * Style matches view-grouped-session.test.ts: a CapturingTmux subclass
+ * records argv-level calls, no process-global mocking, test/ (not
+ * test/isolated/).
+ */
+import { describe, test, expect } from "bun:test";
+import { Tmux } from "../src/core/transport/tmux-class";
+
+type Call = { subcommand: string; args: (string | number)[] };
+
+class CapturingTmux extends Tmux {
+  runCalls: Call[] = [];
+  killSessionCalls: string[] = [];
+  hasSessionReturn = false;
+
+  constructor() {
+    super(undefined, "");
+  }
+
+  async run(subcommand: string, ...args: (string | number)[]): Promise<string> {
+    this.runCalls.push({ subcommand, args });
+    return "";
+  }
+
+  async tryRun(subcommand: string, ...args: (string | number)[]): Promise<string> {
+    this.runCalls.push({ subcommand, args });
+    return "";
+  }
+
+  async hasSession(_name: string): Promise<boolean> {
+    return this.hasSessionReturn;
+  }
+
+  async killSession(name: string): Promise<void> {
+    this.killSessionCalls.push(name);
+  }
+
+  async setOption(_t: string, _o: string, _v: string): Promise<void> {}
+}
+
+/**
+ * Mirror of the cmdView cleanup decision post-#420. The function captures
+ * the contract under test: after a normal attach+detach cycle, the view
+ * session must remain alive regardless of whether the current caller was
+ * the creator or a subsequent reuser.
+ *
+ * Before #420: `if (weCreated) await t.killSession(viewName);`
+ * After  #420: `if (kill) await t.killSession(viewName);` — opt-in only.
+ */
+async function simulateDetachCleanup(
+  t: CapturingTmux,
+  viewName: string,
+  kill: boolean,
+): Promise<void> {
+  if (kill) await t.killSession(viewName);
+}
+
+describe("#420 — grouped view session survives normal detach", () => {
+  test("default detach (kill=false) → killSession NOT called (view reusable next time)", async () => {
+    const t = new CapturingTmux();
+    await simulateDetachCleanup(t, "mawjs-view", /* kill */ false);
+    expect(t.killSessionCalls).toEqual([]);
+  });
+
+  test("full sequence: create-on-miss then detach → new-session ran, no kill-session", async () => {
+    const t = new CapturingTmux();
+    t.hasSessionReturn = false;
+
+    // 1. hasSession says view doesn't exist → impl creates it
+    const exists = await t.hasSession("mawjs-view");
+    expect(exists).toBe(false);
+    await t.newGroupedSession("101-mawjs", "mawjs-view", { windowSize: "largest" });
+
+    // 2. attach happens (execSync — not modelled here)
+
+    // 3. detach-cleanup path — must be a no-op by default post-#420
+    await simulateDetachCleanup(t, "mawjs-view", /* kill */ false);
+
+    // new-session should have been emitted once, kill-session never.
+    const newSessionCalls = t.runCalls.filter(c => c.subcommand === "new-session");
+    expect(newSessionCalls).toHaveLength(1);
+    expect(t.killSessionCalls).toEqual([]);
+  });
+
+  test("full sequence: reuse-on-hit then detach → no new-session, no kill-session", async () => {
+    const t = new CapturingTmux();
+    t.hasSessionReturn = true;
+
+    const exists = await t.hasSession("mawjs-view");
+    expect(exists).toBe(true);
+
+    await simulateDetachCleanup(t, "mawjs-view", /* kill */ false);
+
+    const newSessionCalls = t.runCalls.filter(c => c.subcommand === "new-session");
+    expect(newSessionCalls).toEqual([]);
+    expect(t.killSessionCalls).toEqual([]);
+  });
+
+  test("two back-to-back maw-a cycles reuse the same view (no create on second)", async () => {
+    const t = new CapturingTmux();
+
+    // Cycle 1 — view doesn't exist yet → create.
+    t.hasSessionReturn = false;
+    if (!(await t.hasSession("mawjs-view"))) {
+      await t.newGroupedSession("101-mawjs", "mawjs-view", { windowSize: "largest" });
+    }
+    await simulateDetachCleanup(t, "mawjs-view", /* kill */ false);
+
+    // Between cycles: view is still alive (we didn't kill it) → toggle to true.
+    t.hasSessionReturn = true;
+
+    // Cycle 2 — view exists → reuse branch, no new-session.
+    const runCountBeforeCycle2 = t.runCalls.length;
+    if (!(await t.hasSession("mawjs-view"))) {
+      await t.newGroupedSession("101-mawjs", "mawjs-view", { windowSize: "largest" });
+    }
+    await simulateDetachCleanup(t, "mawjs-view", /* kill */ false);
+
+    expect(t.runCalls.length).toBe(runCountBeforeCycle2);
+    expect(t.killSessionCalls).toEqual([]);
+  });
+
+  test("explicit --kill opt-in → killSession IS called (escape hatch preserved)", async () => {
+    const t = new CapturingTmux();
+    await simulateDetachCleanup(t, "mawjs-view", /* kill */ true);
+    expect(t.killSessionCalls).toEqual(["mawjs-view"]);
+  });
+});
+
+describe("#420 — impl.ts source-level guard (prevents regression)", () => {
+  // The simulate helper above captures the contract. This test also pins the
+  // real impl against re-introducing the weCreated auto-kill gate — the
+  // specific pattern that caused #420 — without needing a DI refactor of
+  // cmdView.
+  test("impl.ts has no unconditional/weCreated-gated killSession on detach path", async () => {
+    const src = await Bun.file(
+      new URL("../src/commands/plugins/view/impl.ts", import.meta.url).pathname,
+    ).text();
+    expect(src).not.toMatch(/if\s*\(\s*weCreated\s*\)\s*{[^}]*killSession/);
+    expect(src).toMatch(/if\s*\(\s*kill\s*\)/);
+  });
+});


### PR DESCRIPTION
## Problem

With #419's view-sharing fix (\`check-before-create\` + \`skip cleanup unless creator\` + \`window-size=largest\`), \`maw a <agent>\` still killed the grouped view when the sole viewer (the creator) detached — defeating the reuse goal.

Live repro on alpha.110 (f4345d0):
\`\`\`
$ maw a mawjs
created → mawjs-view (grouped with 101-mawjs)
attach  → mawjs-view                                                    [exited]
cleaned → mawjs-view    ← next attach pays create cost again
\`\`\`

## Root cause

\`src/commands/plugins/view/impl.ts:185-190\`. The \`weCreated\` gate fired on the common case (creator is sole viewer detaching). There is no separate "attach" plugin — \`maw a\` is an alias for \`maw view\`.

## Fix

- Remove auto-kill entirely; drop \`weCreated\` tracking
- Add explicit opt-in: \`maw view <agent> --kill\` (new flag in \`plugin.json\` + \`index.ts\` wiring) for one-shot use
- Zombie sweep pathway (\`maw cleanup --zombie-agents\`) unchanged — still the way to reap stale views

Diff: impl.ts ~8 LOC, index.ts + plugin.json +3 LOC.

## Tests

\`test/view-no-cleanup-on-detach.test.ts\` — 6 cases:
- default detach → no killSession
- create-on-miss then detach → new-session ran, no kill-session
- reuse-on-hit then detach → no create, no kill
- two back-to-back cycles reuse same grouped view
- explicit \`--kill\` → killSession IS called
- source-level guard: impl.ts has no \`weCreated\`-gated killSession (regression pin)

Scoped suite (excluding isolated + agents worktrees):
- Before: 1844 pass / 18 fail
- After:  **1845 pass / 17 fail** (net +1 pass)

Remaining 17 fails are pre-existing mock-pollution (all pass individually — known).

## Closes

- closes #420