### PR TITLE
docs(hey): document <node>:<session>:<window> routing (#410)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ maw bud myname --from neo                # bud from an existing oracle
 Talk across machines with HMAC-SHA256 signing.
 
 ```bash
-maw hey white:neo "hello"                # send to oracle on another node
+maw hey neo "hello"                      # bare name — resolves on local node
+maw hey white:neo "hello"                # canonical form — remote node, window 1
+maw hey white:neo:3 "hello hermes"       # pick a specific tmux window (#410)
 maw peek white:neo                       # see their screen
 maw ping                                 # check peer connectivity
 

--- a/src/cli/route-comm.ts
+++ b/src/cli/route-comm.ts
@@ -14,8 +14,13 @@ export async function routeComm(cmd: string, args: string[]): Promise<boolean> {
     // same "usage:" error. Now the missing-message case names the target
     // so the user sees their input got through.
     if (!target) {
-      console.error("usage: maw hey <agent> <message> [--force]");
+      console.error("usage: maw hey <target> <message> [--force]");
+      console.error("  target forms:");
+      console.error("    <agent>                      bare name, resolves on local node");
+      console.error("    <node>:<session>             canonical cross-node form (window 1)");
+      console.error("    <node>:<session>:<window>    target a specific tmux window (#410)");
       console.error("  e.g. maw hey mawjs \"hello from neo\"");
+      console.error("       maw hey phaith:01-hojo:3 \"hello hojo-hermes\"");
       throw new UserError("missing target and message");
     }
     if (!msgArgs.length) {

--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -71,10 +71,12 @@ export async function cmdSend(query: string, message: string, force = false) {
   const config = loadConfig();
 
   // #362b — inform users when they omit the node prefix. Canonical form is
-  // `<node>:<oracle>`. Bare name works locally but scripts should use the
-  // prefixed form for fleet portability. Silent when MAW_QUIET=1.
+  // `<node>:<oracle>` (add `:<window>` to target a specific tmux window when
+  // the session has more than one — see #410). Bare name works locally but
+  // scripts should use the prefixed form for fleet portability. Silent when
+  // MAW_QUIET=1.
   if (!query.includes(":") && !query.includes("/") && !process.env.MAW_QUIET && config.node) {
-    console.error(`\x1b[90mℹ tip: use canonical form 'maw hey ${config.node}:${query}' for cross-node scripts (bare name resolves locally)\x1b[0m`);
+    console.error(`\x1b[90mℹ tip: use canonical form 'maw hey ${config.node}:${query}' for cross-node scripts — append ':<window>' to target a specific window (bare name resolves locally)\x1b[0m`);
   }
 
   // --- Plugin routing: maw hey plugin:<name> <msg> ---


### PR DESCRIPTION
## Problem
\`maw hey <node>:<session>:<window>\` routes to a specific tmux window, but only the 2-part form (\`<node>:<session>\`) was documented. #410 asked for docs.

## Fix
Pure docs. No code behavior changes. No \`--window\` / \`-w\` alias (deferred — not in scope).

## Files (+14 / -5)
- \`src/commands/shared/comm-send.ts\` — bare-name tip now mentions \`:<window>\` suffix
- \`src/cli/route-comm.ts\` — \`maw hey\` no-target usage error lists all 3 address forms
- \`README.md\` — Federation block shows all 3 forms side-by-side

## Example new usage output

\`\`\`
usage: maw hey <target> <message> [--force]
  target forms:
    <agent>                      bare name, resolves on local node
    <node>:<session>             canonical cross-node form (window 1)
    <node>:<session>:<window>    target a specific tmux window (#410)
\`\`\`

## Note
\`hey\` isn't a plugin (it's a core route in \`cli/route-comm.ts\`) — no \`plugin.json\` to edit.

Closes #410.