### PR TITLE
feat(soul-sync): Phase 1 of collab docs redundancy — seed collaborations/ dir (#363)

### DIFF
--- a/src/commands/plugins/bud/bud-init.ts
+++ b/src/commands/plugins/bud/bud-init.ts
@@ -8,7 +8,7 @@ export function initVault(budRepoPath: string): string {
   const psiDir = join(budRepoPath, "ψ");
   const psiDirs = [
     "memory/learnings", "memory/retrospectives", "memory/traces",
-    "memory/resonance", "inbox", "outbox", "plans",
+    "memory/resonance", "memory/collaborations", "inbox", "outbox", "plans",
   ];
   for (const d of psiDirs) {
     mkdirSync(join(psiDir, d), { recursive: true });

--- a/src/commands/plugins/reunion/impl.ts
+++ b/src/commands/plugins/reunion/impl.ts
@@ -2,7 +2,7 @@ import { listSessions, hostExec } from "../../../sdk";
 import { existsSync, readdirSync, copyFileSync, mkdirSync } from "fs";
 import { join, dirname } from "path";
 
-const SYNC_DIRS = ["memory/learnings", "memory/retrospectives", "memory/traces"];
+const SYNC_DIRS = ["memory/learnings", "memory/retrospectives", "memory/traces", "memory/collaborations"];
 
 /**
  * Resolve the main oracle repo root from a worktree cwd.

--- a/src/commands/plugins/soul-sync/sync-helpers.ts
+++ b/src/commands/plugins/soul-sync/sync-helpers.ts
@@ -2,7 +2,7 @@ import { existsSync, readdirSync, copyFileSync, mkdirSync, appendFileSync } from
 import { join } from "path";
 import { loadFleet } from "../../shared/fleet-load";
 
-const SYNC_DIRS = ["memory/learnings", "memory/retrospectives", "memory/traces"];
+const SYNC_DIRS = ["memory/learnings", "memory/retrospectives", "memory/traces", "memory/collaborations"];
 
 /**
  * Sync new files from src dir to dst dir (skip existing).

--- a/test/soul-sync.test.ts
+++ b/test/soul-sync.test.ts
@@ -215,4 +215,65 @@ describe("soul-sync", () => {
       expect(findPeersForTest("floodboy", fleet)).toEqual([]);
     });
   });
+
+  // #363 phase 1 — canonical collaboration docs (treaty-class) must ride
+  // through soul-sync so child oracles inherit them, not just learnings/
+  // retros/traces. Regression guard against dropping the subdir.
+  describe("collaborations propagation (#363 phase 1)", () => {
+    test("parent's memory/collaborations/ propagates to bud via syncOracleVaults", () => {
+      const { syncOracleVaults } = require("../src/commands/plugins/soul-sync/sync-helpers");
+
+      const budRoot = join(TEST_DIR, "bud-oracle");
+      const parentRoot = join(TEST_DIR, "mawjs-oracle");
+      const parentCollab = join(parentRoot, "ψ/memory/collaborations/white-wormhole/topics");
+
+      mkdirSync(parentCollab, { recursive: true });
+      writeFileSync(
+        join(parentCollab, "claim-chain-and-sync-protocol.md"),
+        "# ACCEPT primitive — 11 ratified agreements",
+      );
+      mkdirSync(budRoot, { recursive: true });
+
+      const result = syncOracleVaults(parentRoot, budRoot, "mawjs", "bud");
+
+      const budFile = join(budRoot, "ψ/memory/collaborations/white-wormhole/topics/claim-chain-and-sync-protocol.md");
+      expect(existsSync(budFile)).toBe(true);
+      expect(readFileSync(budFile, "utf-8")).toContain("ACCEPT primitive");
+      expect(result.synced["memory/collaborations"]).toBe(1);
+      expect(result.total).toBe(1);
+    });
+
+    test("collaborations sync skips files already present in bud (new-files-only)", () => {
+      const { syncOracleVaults } = require("../src/commands/plugins/soul-sync/sync-helpers");
+
+      const budRoot = join(TEST_DIR, "bud-oracle");
+      const parentRoot = join(TEST_DIR, "mawjs-oracle");
+      const parentCollab = join(parentRoot, "ψ/memory/collaborations/peer-x/topics");
+      const budCollab = join(budRoot, "ψ/memory/collaborations/peer-x/topics");
+
+      mkdirSync(parentCollab, { recursive: true });
+      mkdirSync(budCollab, { recursive: true });
+      writeFileSync(join(parentCollab, "treaty.md"), "# PARENT TREATY");
+      writeFileSync(join(budCollab, "treaty.md"), "# BUD-LOCAL EDIT — must not be overwritten");
+
+      const result = syncOracleVaults(parentRoot, budRoot, "mawjs", "bud");
+
+      expect(readFileSync(join(budCollab, "treaty.md"), "utf-8")).toContain("BUD-LOCAL EDIT");
+      expect(result.total).toBe(0);
+    });
+
+    test("no memory/collaborations on parent → bud sync is a no-op (no error)", () => {
+      const { syncOracleVaults } = require("../src/commands/plugins/soul-sync/sync-helpers");
+
+      const budRoot = join(TEST_DIR, "bud-oracle");
+      const parentRoot = join(TEST_DIR, "mawjs-oracle");
+      mkdirSync(join(parentRoot, "ψ/memory/learnings"), { recursive: true });
+      mkdirSync(budRoot, { recursive: true });
+
+      const result = syncOracleVaults(parentRoot, budRoot, "mawjs", "bud");
+
+      expect(existsSync(join(budRoot, "ψ/memory/collaborations"))).toBe(false);
+      expect(result.synced["memory/collaborations"]).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
## Problem
\`ψ/memory/collaborations/\` didn't propagate from parent to child on \`maw bud\`. #363 proposed 3 phases; this ships **Phase 1** only (soul-sync seed).

## Scope
- Phase 1: soul-sync seeds \`collaborations/\` ✓ (this PR, ~3 LOC src)
- Phase 2: auto-mirror on ratification (peer transport) — **deferred to #371 Proposal VII**
- Phase 3: hash-compare on load + divergence alerts — **deferred to #371**

## Changes (src, 3 LOC)
- \`src/commands/plugins/soul-sync/sync-helpers.ts\` — \`memory/collaborations\` added to \`SYNC_DIRS\` (drives --seed bud-time sync + later \`ss --from\` pulls)
- \`src/commands/plugins/reunion/impl.ts\` — same addition (reunion maintains its own SYNC_DIRS; kept in lockstep)
- \`src/commands/plugins/bud/bud-init.ts\` — seed empty \`memory/collaborations/\` dir at vault init, consistent with other memory subdirs

## Tests (61 LOC)
\`test/soul-sync.test.ts\` exercises \`syncOracleVaults\` directly (uses real \`SYNC_DIRS\` — no constant duplication):
- parent has \`collaborations/white-wormhole/topics/claim-chain-and-sync-protocol.md\` → bud inherits it
- bud-local edit to same treaty NOT overwritten (new-files-only invariant)
- no parent collaborations/ → no-op, no error

## Test result
\`bun run test\` → **942 pass / 0 fail / 6 skip** (69 files).

Fusion-oracle's \`/time-travel --prove "collaborations are soul-synced to child oracles"\` should now flip to PROVEN for buds going forward.

Closes (partial) #363 — full close when #371 Phase 2/3 land.