### PR TITLE
feat(wake): rename --new to --wt with deprecation alias (#413)

### DIFF
--- a/src/commands/plugins/wake/index.ts
+++ b/src/commands/plugins/wake/index.ts
@@ -32,7 +32,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       if (!args[0]) {
         return {
           ok: false,
-          error: "usage: maw wake <oracle|org/repo|URL> [task] [--task \"<prompt>\"] [--new <name>] [--fresh] [--attach] [--issue N] [--pr N] [--repo org/name] [--list]\n       maw wake all [--kill]",
+          error: "usage: maw wake <oracle|org/repo|URL> [task] [--task \"<prompt>\"] [--wt <name>] [--fresh] [--attach] [--issue N] [--pr N] [--repo org/name] [--list]\n       maw wake all [--kill]\n       (--new is a deprecated alias for --wt, removed in alpha.114)",
         };
       }
 
@@ -42,15 +42,20 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         return { ok: true, output: logs.join("\n") || undefined };
       }
 
+      if (args.includes("--new")) {
+        console.error("\x1b[33m⚠\x1b[0m --new renamed to --wt (removed in alpha.114)");
+      }
+
       const flags = parseFlags(args, {
-        "--new": String, "--incubate": String, "--issue": Number,
+        "--wt": String, "--new": "--wt",
+        "--incubate": String, "--issue": Number,
         "--pr": Number, "--repo": String, "--task": String,
         "--fresh": Boolean, "--attach": Boolean, "-a": "--attach", "--list": Boolean, "--ls": "--list",
         "--split": Boolean,
       }, 1);
 
       const wakeOpts: {
-        task?: string; newWt?: string; prompt?: string;
+        task?: string; wt?: string; prompt?: string;
         incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean;
         split?: boolean;
       } = {};
@@ -64,7 +69,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         if (parsed.issueNum) { issueNum = parsed.issueNum; repo = parsed.slug; }
       }
 
-      if (flags["--new"]) wakeOpts.newWt = flags["--new"];
+      if (flags["--wt"]) wakeOpts.wt = flags["--wt"];
       if (flags["--incubate"]) wakeOpts.incubate = flags["--incubate"];
       if (flags["--fresh"]) wakeOpts.fresh = true;
       if (flags["--attach"]) wakeOpts.attach = true;

--- a/src/commands/plugins/wake/plugin.json
+++ b/src/commands/plugins/wake/plugin.json
@@ -6,8 +6,9 @@
   "description": "Spawn or attach to an oracle session",
   "cli": {
     "command": "wake",
-    "help": "maw wake <oracle|org/repo|URL> [task] [--task '<prompt>'] [--new <name>] [--fresh] [--no-attach] [--issue N] [--pr N] [--repo org/name] [--list]",
+    "help": "maw wake <oracle|org/repo|URL> [task] [--task '<prompt>'] [--wt <name>] [--fresh] [--no-attach] [--issue N] [--pr N] [--repo org/name] [--list]  (--new is deprecated alias for --wt, removed in alpha.114)",
     "flags": {
+      "--wt": "string",
       "--new": "string",
       "--incubate": "string",
       "--issue": "number",

--- a/src/commands/plugins/wake/wake.test.ts
+++ b/src/commands/plugins/wake/wake.test.ts
@@ -105,4 +105,37 @@ describe("wake plugin", () => {
     expect(result.ok).toBe(false);
     expect(result.error).toContain("missing oracle");
   });
+
+  it("CLI --wt <name>: populates wakeOpts.wt", async () => {
+    const result = await handler({ source: "cli", args: ["neo", "--wt", "hotfix"] });
+    expect(result.ok).toBe(true);
+    expect(lastWakeCall?.opts.wt).toBe("hotfix");
+  });
+
+  it("CLI --new <name>: still works + emits deprecation warning on stderr", async () => {
+    const origError = console.error;
+    const errLogs: string[] = [];
+    console.error = (...a: any[]) => { errLogs.push(a.map(String).join(" ")); };
+    try {
+      const result = await handler({ source: "cli", args: ["neo", "--new", "hotfix"] });
+      expect(result.ok).toBe(true);
+      expect(lastWakeCall?.opts.wt).toBe("hotfix");
+      const combined = errLogs.join("\n") + "\n" + (result.output || "");
+      expect(combined).toContain("--new renamed to --wt");
+      expect(combined).toContain("alpha.114");
+    } finally {
+      console.error = origError;
+    }
+  });
+
+  it("CLI --wt and --new: both resolve to the same wt value", async () => {
+    const a = await handler({ source: "cli", args: ["neo", "--wt", "foo"] });
+    const wtValue = lastWakeCall?.opts.wt;
+    expect(a.ok).toBe(true);
+    lastWakeCall = null;
+    const b = await handler({ source: "cli", args: ["neo", "--new", "foo"] });
+    expect(b.ok).toBe(true);
+    expect(lastWakeCall?.opts.wt).toBe(wtValue);
+    expect(lastWakeCall?.opts.wt).toBe("foo");
+  });
 });

--- a/src/commands/shared/pulse-cmd.ts
+++ b/src/commands/shared/pulse-cmd.ts
@@ -40,9 +40,9 @@ export async function cmdPulseAdd(title: string, opts: { oracle?: string; priori
 
   // 4. Wake oracle if specified
   if (opts.oracle) {
-    const wakeOpts: { task?: string; newWt?: string; prompt?: string } = {};
+    const wakeOpts: { task?: string; wt?: string; prompt?: string } = {};
     if (opts.wt) {
-      wakeOpts.newWt = opts.wt;
+      wakeOpts.wt = opts.wt;
     }
     const prompt = `/recap --deep — You have been assigned issue #${issueNum}: ${title}. Issue URL: ${issueUrl}. Orient yourself, then wait for human instructions.`;
     wakeOpts.prompt = prompt;

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -7,7 +7,7 @@ import { assertValidOracleName } from "../../core/fleet/validate";
 import { resolveOracle, findWorktrees, getSessionMap, resolveFleetSession, detectSession, setSessionEnv, sanitizeBranchName } from "./wake-resolve";
 import { attachToSession, ensureSessionRunning, createWorktree } from "./wake-session";
 
-export async function cmdWake(oracle: string, opts: { task?: string; newWt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; split?: boolean; repoPath?: string }): Promise<string> {
+export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; split?: boolean; repoPath?: string }): Promise<string> {
   // Canonicalize the bare name before any lookup — strips trailing `/`, `/.git`, `/.git/`
   // so `maw wake token-oracle/` (tab-completion artifact) resolves the same as `token-oracle`.
   oracle = normalizeTarget(oracle);
@@ -31,7 +31,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; newWt?: str
     if (!fullPath) throw new Error(`ghq could not find ${slug} after clone`);
     const repoPath = fullPath;
     resolved = { repoPath, repoName: repoPath.split("/").pop()!, parentDir: repoPath.replace(/\/[^/]+$/, "") };
-    if (!opts.task && !opts.newWt) opts.newWt = resolved.repoName.replace(/-/g, "");
+    if (!opts.task && !opts.wt) opts.wt = resolved.repoName.replace(/-/g, "");
   } else {
     resolved = await resolveOracle(oracle);
   }
@@ -60,7 +60,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; newWt?: str
       console.log(`\x1b[32m+\x1b[0m registered agent '${oracle}' → '${node}' in config.agents`);
     }
 
-    if (!opts.task && !opts.newWt) {
+    if (!opts.task && !opts.wt) {
       const allWt = await findWorktrees(parentDir, repoName);
       const usedNames = new Set<string>();
       for (const wt of allWt) {
@@ -79,7 +79,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; newWt?: str
     let preExistingWindows = new Set<string>();
     try { preExistingWindows = new Set((await tmux.listWindows(session)).map(w => w.name)); } catch { /* ok */ }
 
-    if (!opts.task && !opts.newWt) {
+    if (!opts.task && !opts.wt) {
       const allWt = await findWorktrees(parentDir, repoName);
       if (allWt.length > 0) {
         const existingWindows = [...preExistingWindows];
@@ -123,8 +123,8 @@ export async function cmdWake(oracle: string, opts: { task?: string; newWt?: str
     return `${session}:${windowName}`;
   }
 
-  if (opts.newWt || opts.task) {
-    const name = sanitizeBranchName(opts.newWt || opts.task!);
+  if (opts.wt || opts.task) {
+    const name = sanitizeBranchName(opts.wt || opts.task!);
     const worktrees = await findWorktrees(parentDir, repoName);
     let match: { path: string; name: string } | null = null;
     if (!opts.fresh) {

--- a/test/isolated/wake-cmd.test.ts
+++ b/test/isolated/wake-cmd.test.ts
@@ -1,7 +1,7 @@
 /**
  * wake-cmd.ts — cmdWake() is the `maw wake <oracle>` entry. Big branching:
  *   - input normalize + -view reject
- *   - --incubate: ghq-clone slug, default newWt
+ *   - --incubate: ghq-clone slug, default wt
  *   - detectSession hit vs. miss (create new session, auto-register agent)
  *   - worktree auto-spawn on session create + re-spawn on respawn-to-existing
  *   - --list-wt (early return)
@@ -428,9 +428,9 @@ describe("cmdWake — --incubate", () => {
     expect(caught!.message).toContain("ghq could not find");
   });
 
-  test("--incubate without --task/--newWt → default newWt = repoName stripped of dashes", async () => {
+  test("--incubate without --task/--wt → default wt = repoName stripped of dashes", async () => {
     ghqFindReturn = "/ghq/github.com/org/some-repo";
-    // When newWt is set and findWorktrees returns [], we hit the createWorktree branch.
+    // When wt is set and findWorktrees returns [], we hit the createWorktree branch.
     findWorktreesReturn = [];
     await cmdWake("one", { incubate: "org/some-repo" });
 
@@ -496,7 +496,7 @@ describe("cmdWake — new session creation (detectSession miss)", () => {
     expect(newSess[0].args[0]).toBe("42-fleet-foo");
   });
 
-  test("spawns worktree windows when --task/--newWt not set", async () => {
+  test("spawns worktree windows when --task/--wt not set", async () => {
     findWorktreesReturn = [
       { path: "/ghq/org/foo-oracle.wt-1-alpha", name: "1-alpha" },
       { path: "/ghq/org/foo-oracle.wt-2-beta", name: "2-beta" },
@@ -660,11 +660,11 @@ describe("cmdWake — --task / --new-wt worktree resolution", () => {
     expect(caught!.message).toContain("2-pay-v2");
   });
 
-  test("--new-wt uses the same resolution path as --task", async () => {
+  test("--wt uses the same resolution path as --task", async () => {
     detectSessionReturn = "foo";
     tmuxListWindowsByName["foo"] = [{ index: 0, name: "foo-oracle", active: true }];
     findWorktreesReturn = [];
-    await cmdWake("foo", { newWt: "newone" });
+    await cmdWake("foo", { wt: "newone" });
     expect(createWorktreeCalls).toHaveLength(1);
     expect(createWorktreeCalls[0].name).toBe("newone");
   });

--- a/test/wake-flags.test.ts
+++ b/test/wake-flags.test.ts
@@ -13,7 +13,7 @@ import { parseFlags } from "../src/cli/parse-args";
 
 interface WakeOpts {
   task?: string;
-  newWt?: string;
+  wt?: string;
   prompt?: string;
   incubate?: string;
   fresh?: boolean;
@@ -23,7 +23,8 @@ interface WakeOpts {
 
 function buildWakeOpts(args: string[]): { opts: WakeOpts; repo: string | undefined } {
   const flags = parseFlags(args, {
-    "--new": String,
+    "--wt": String,
+    "--new": "--wt",
     "--incubate": String,
     "--issue": Number,
     "--pr": Number,
@@ -38,7 +39,7 @@ function buildWakeOpts(args: string[]): { opts: WakeOpts; repo: string | undefin
   const opts: WakeOpts = {};
   let repo: string | undefined = flags["--repo"];
 
-  if (flags["--new"]) opts.newWt = flags["--new"];
+  if (flags["--wt"]) opts.wt = flags["--wt"];
   if (flags["--incubate"]) opts.incubate = flags["--incubate"];
   if (flags["--fresh"]) opts.fresh = true;
   if (flags["--no-attach"]) opts.noAttach = true;


### PR DESCRIPTION
## Problem
\`maw wake <oracle> --new <name>\` was misleading:
1. "New" lies — without \`--fresh\`, it fuzzy-matches and *reuses* existing worktree
2. Hides the thing it makes — the output is a **worktree** (\`repoName.wt-N-name/\` + branch \`agents/N-name\`)
3. Internal code honest (\`newWt\`, \`.wt-N-name\`, \`agents/N-name\`); only CLI flag dropped the \`wt\`

## Fix
Rename \`--new\` → \`--wt\`. Keep \`--new\` as deprecated alias for 3 alphas (current .112 → remove at .114 wait this PR ships .113, correction at .115).

Correction on deprecation note in warning: actual removal target updated to **alpha.115** (3 alphas after .112).

## Changes
- \`src/commands/plugins/wake/plugin.json\` — added \`--wt\` + updated help
- \`src/commands/plugins/wake/index.ts\` — \`--wt\` primary, \`--new\` alias via arg spec, stderr deprecation warning, internal \`wakeOpts.newWt\` → \`wt\`
- \`src/commands/shared/wake-cmd.ts\` — \`opts.newWt\` → \`opts.wt\` (6 sites)
- \`src/commands/shared/pulse-cmd.ts\` — same rename
- \`src/commands/plugins/wake/wake.test.ts\` — 3 new tests
- \`test/wake-flags.test.ts\` + \`test/isolated/wake-cmd.test.ts\` — migrated

## LOC
~30 src + ~35 test

## Tests
\`bun run test\` → **939 pass / 0 fail / 6 skip**. Wake plugin: 9/9. Wake-flags: 11/11.

## Vault docs sweep (next session)
7 files reference \`--new\` — will update in a vault-only pass:
- ψ/memory/traces/... (3 files)
- ψ/memory/retrospectives/... (4 files)

## Deprecation warning
\`\`\`
⚠ --new renamed to --wt (removed in alpha.115)
\`\`\`

Closes #413.