### PR TITLE
fix(ssh): wrap hostExec stderr with target+transport context (#415, #406/1b)

### DIFF
--- a/src/core/transport/ssh.ts
+++ b/src/core/transport/ssh.ts
@@ -4,16 +4,37 @@ import { tmuxCmd } from "./tmux";
 const DEFAULT_HOST = process.env.MAW_HOST || loadConfig().host || "local";
 const IS_LOCAL = DEFAULT_HOST === "local" || DEFAULT_HOST === "localhost";
 
+export type HostExecTransport = "local" | "ssh";
+
+/** Error from hostExec — carries target + transport so callers can format. */
+export class HostExecError extends Error {
+  readonly target: string;
+  readonly transport: HostExecTransport;
+  readonly underlying: Error;
+  readonly exitCode?: number;
+
+  constructor(target: string, transport: HostExecTransport, underlying: Error, exitCode?: number) {
+    super(`[${transport}:${target}] ${underlying.message}`);
+    this.name = "HostExecError";
+    this.target = target;
+    this.transport = transport;
+    this.underlying = underlying;
+    this.exitCode = exitCode;
+  }
+}
+
 /** Transport — run on oracle host. local → bash -c | remote → ssh */
 export async function hostExec(cmd: string, host = DEFAULT_HOST): Promise<string> {
   const local = host === "local" || host === "localhost" || IS_LOCAL;
+  const transport: HostExecTransport = local ? "local" : "ssh";
   const args = local ? ["bash", "-c", cmd] : ["ssh", host, cmd];
   const proc = Bun.spawn(args, { stdout: "pipe", stderr: "pipe", windowsHide: true });
   const text = await new Response(proc.stdout).text();
   const code = await proc.exited;
   if (code !== 0) {
     const err = await new Response(proc.stderr).text();
-    throw new Error(err.trim() || `exit ${code}`);
+    const underlying = new Error(err.trim() || `exit ${code}`);
+    throw new HostExecError(host, transport, underlying, code);
   }
   return text.trim();
 }

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -39,8 +39,9 @@ export type {
 export {
   hostExec, listSessions, capture, sendKeys,
   getPaneCommand, getPaneCommands, getPaneInfos,
+  HostExecError,
 } from "../core/transport/ssh";
-export type { Session as SshSession } from "../core/transport/ssh";
+export type { Session as SshSession, HostExecTransport } from "../core/transport/ssh";
 export { curlFetch } from "../core/transport/curl-fetch";
 export {
   getPeers, getFederationStatus, findPeerForTarget,

--- a/test/isolated/host-exec-error.test.ts
+++ b/test/isolated/host-exec-error.test.ts
@@ -1,0 +1,88 @@
+import { describe, test, expect } from "bun:test";
+import { HostExecError } from "../../src/core/transport/ssh";
+
+describe("HostExecError", () => {
+  test("carries target + transport + underlying as structured fields", () => {
+    const underlying = new Error("not in a mode");
+    const err = new HostExecError("white", "ssh", underlying, 1);
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(HostExecError);
+    expect(err.target).toBe("white");
+    expect(err.transport).toBe("ssh");
+    expect(err.underlying).toBe(underlying);
+    expect(err.exitCode).toBe(1);
+    expect(err.name).toBe("HostExecError");
+  });
+
+  test("message is prefixed with [transport:target] so log-err.message shows context", () => {
+    const err = new HostExecError("white", "ssh", new Error("not in a mode"));
+    expect(err.message).toBe("[ssh:white] not in a mode");
+  });
+
+  test("local transport renders as [local:...]", () => {
+    const err = new HostExecError("local", "local", new Error("boom"));
+    expect(err.message).toBe("[local:local] boom");
+    expect(err.transport).toBe("local");
+  });
+
+  test("caller can layer their own context on top (e.g. 'from: getPaneCommands')", () => {
+    // Simulating how a caller like getPaneCommands would re-wrap with origin info.
+    const raw = new HostExecError("white", "ssh", new Error("not in a mode"));
+    const wrapped = new Error(`${raw.message} (from: getPaneCommands)`);
+    expect(wrapped.message).toBe("[ssh:white] not in a mode (from: getPaneCommands)");
+  });
+
+  test("SSH-unreachable peer surfaces node name, not bare tmux error", () => {
+    // Regression: #415 — before the wrap, this was just "not in a mode"
+    // with no way to tell which peer produced it.
+    const err = new HostExecError(
+      "white",
+      "ssh",
+      new Error("not in a mode"),
+    );
+    expect(err.message).toContain("white");
+    expect(err.message).toContain("ssh");
+    expect(err.target).toBe("white");
+  });
+
+  test("preserves empty-stderr fallback message from hostExec", () => {
+    // hostExec uses `exit ${code}` when stderr is empty; that still flows
+    // through as the underlying.
+    const err = new HostExecError("local", "local", new Error("exit 1"), 1);
+    expect(err.message).toBe("[local:local] exit 1");
+    expect(err.exitCode).toBe(1);
+  });
+});
+
+describe("hostExec throw integration", () => {
+  test("failing bash -c throws HostExecError with local transport + host", async () => {
+    // MAW_HOST is read at module-load time; we exercise hostExec against
+    // a guaranteed-fail shell command and inspect the error shape.
+    const { hostExec } = await import("../../src/core/transport/ssh");
+    try {
+      await hostExec("exit 7", "local");
+      throw new Error("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(HostExecError);
+      const err = e as HostExecError;
+      expect(err.target).toBe("local");
+      expect(err.transport).toBe("local");
+      expect(err.exitCode).toBe(7);
+      expect(err.message).toMatch(/^\[local:local\] /);
+    }
+  });
+
+  test("failing bash -c propagates stderr into underlying.message", async () => {
+    const { hostExec } = await import("../../src/core/transport/ssh");
+    try {
+      await hostExec("echo oh-no >&2; exit 1", "local");
+      throw new Error("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(HostExecError);
+      const err = e as HostExecError;
+      expect(err.underlying.message).toBe("oh-no");
+      expect(err.message).toBe("[local:local] oh-no");
+    }
+  });
+});


### PR DESCRIPTION
## Problem
\`src/core/transport/ssh.ts\` leaked raw stderr (e.g. "not in a mode" ×17) without context. Non-deterministic first-call failures made debugging hard — couldn't tell which target, which transport.

## Fix
\`HostExecError extends Error\` with structured fields: \`.target\` / \`.transport\` / \`.underlying\` / \`.exitCode\`.

### Design choice: class not plain object
- \`instanceof\` check for callers that want to format specially
- Message auto-prefixed \`[ssh:white] not in a mode\` — existing \`log(err.message)\` callers get context **for free** (no caller churn)
- Structured fields for resolver/fleet to branch on without string parsing

## Changes
- \`src/core/transport/ssh.ts\` (+22) — \`HostExecError\` class + throw paths wrapped
- \`src/sdk/index.ts\` — re-export
- \`test/isolated/host-exec-error.test.ts\` (new, +85)

## Tests (8/8 pass, 72ms)
- field shape
- message format (local + ssh)
- SSH-unreachable surfaces node name
- caller-layered \`(from: getPaneCommands)\` composition
- bash -c failure integration
- empty-stderr \`exit N\` fallback

## Caller impact
**None immediate** — HostExecError IS-A Error so all existing throw paths (listSessions try/catch, switchClient .catch, etc.) keep working. Callers opt-in to structured branching incrementally.

Closes #415, #406/1b.