### PR TITLE
feat(oracle): scan --stale classifier (#392)

### DIFF
--- a/src/commands/plugins/oracle/impl-stale.test.ts
+++ b/src/commands/plugins/oracle/impl-stale.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from "bun:test";
+import {
+  classifyStaleness,
+  sortByStaleness,
+  runStaleScan,
+  type StaleEntry,
+} from "./impl-stale";
+import type { OracleEntry } from "../../../sdk";
+
+const NOW = new Date("2026-04-17T12:00:00Z");
+
+function entry(partial: Partial<OracleEntry> = {}): OracleEntry {
+  return {
+    org: "Soul-Brews-Studio",
+    repo: "test-oracle",
+    name: "test",
+    local_path: "/tmp/test-oracle",
+    has_psi: true,
+    has_fleet_config: true,
+    budded_from: null,
+    budded_at: null,
+    federation_node: null,
+    detected_at: NOW.toISOString(),
+    ...partial,
+  };
+}
+
+function iso(daysAgo: number): string {
+  return new Date(NOW.getTime() - daysAgo * 86_400_000).toISOString();
+}
+
+describe("classifyStaleness", () => {
+  it("awake oracles are always ACTIVE regardless of age", () => {
+    const r = classifyStaleness({ entry: entry(), lastCommitISO: iso(200), awake: true, now: NOW });
+    expect(r.tier).toBe("ACTIVE");
+    expect(r.recommendation).toContain("awake");
+  });
+
+  it("< 7 days = ACTIVE", () => {
+    expect(classifyStaleness({ entry: entry(), lastCommitISO: iso(3), awake: false, now: NOW }).tier).toBe("ACTIVE");
+  });
+
+  it("7–30 days = SLOW", () => {
+    expect(classifyStaleness({ entry: entry(), lastCommitISO: iso(15), awake: false, now: NOW }).tier).toBe("SLOW");
+  });
+
+  it("30–90 days = STALE", () => {
+    expect(classifyStaleness({ entry: entry(), lastCommitISO: iso(60), awake: false, now: NOW }).tier).toBe("STALE");
+  });
+
+  it("> 90 days = DEAD", () => {
+    const r = classifyStaleness({ entry: entry({ has_psi: false }), lastCommitISO: iso(120), awake: false, now: NOW });
+    expect(r.tier).toBe("DEAD");
+    expect(r.recommendation).toContain("prune");
+  });
+
+  it("DEAD with ψ/ recommends archive not prune", () => {
+    const r = classifyStaleness({ entry: entry({ has_psi: true }), lastCommitISO: iso(120), awake: false, now: NOW });
+    expect(r.tier).toBe("DEAD");
+    expect(r.recommendation).toContain("archive");
+  });
+
+  it("null commit date = DEAD", () => {
+    const r = classifyStaleness({ entry: entry(), lastCommitISO: null, awake: false, now: NOW });
+    expect(r.tier).toBe("DEAD");
+    expect(r.days_since_commit).toBeNull();
+  });
+
+  it("boundary day 7 is SLOW (not ACTIVE)", () => {
+    expect(classifyStaleness({ entry: entry(), lastCommitISO: iso(7), awake: false, now: NOW }).tier).toBe("SLOW");
+  });
+
+  it("boundary day 90 is DEAD (not STALE)", () => {
+    expect(classifyStaleness({ entry: entry(), lastCommitISO: iso(90), awake: false, now: NOW }).tier).toBe("DEAD");
+  });
+});
+
+describe("sortByStaleness", () => {
+  it("DEAD first, then STALE, then SLOW, then ACTIVE", () => {
+    const input: StaleEntry[] = [
+      { ...stub("a"), tier: "ACTIVE", days_since_commit: 2 },
+      { ...stub("b"), tier: "DEAD", days_since_commit: 200 },
+      { ...stub("c"), tier: "STALE", days_since_commit: 60 },
+      { ...stub("d"), tier: "SLOW", days_since_commit: 20 },
+    ];
+    const out = sortByStaleness(input);
+    expect(out.map((e) => e.tier)).toEqual(["DEAD", "STALE", "SLOW", "ACTIVE"]);
+  });
+
+  it("within tier, oldest first", () => {
+    const input: StaleEntry[] = [
+      { ...stub("young"), tier: "STALE", days_since_commit: 31 },
+      { ...stub("old"), tier: "STALE", days_since_commit: 85 },
+      { ...stub("mid"), tier: "STALE", days_since_commit: 60 },
+    ];
+    const out = sortByStaleness(input);
+    expect(out.map((e) => e.name)).toEqual(["old", "mid", "young"]);
+  });
+});
+
+describe("runStaleScan (injected deps)", () => {
+  it("classifies from mocked fleet + tmux + git", async () => {
+    const entries = [
+      entry({ name: "alive", local_path: "/tmp/alive" }),
+      entry({ name: "dusty", local_path: "/tmp/dusty" }),
+      entry({ name: "dead", local_path: "/tmp/dead", has_psi: false }),
+      entry({ name: "awake", local_path: "/tmp/awake" }),
+    ];
+    const commits: Record<string, string | null> = {
+      "/tmp/alive": iso(1),
+      "/tmp/dusty": iso(60),
+      "/tmp/dead": iso(120),
+      "/tmp/awake": iso(200),
+    };
+    const result = await runStaleScan(
+      { all: true },
+      {
+        readEntries: () => entries,
+        listAwake: async () => new Set(["awake"]),
+        getLastCommit: (p) => commits[p] ?? null,
+        now: () => NOW,
+      },
+    );
+    const byName = Object.fromEntries(result.map((r) => [r.name, r.tier]));
+    expect(byName.alive).toBe("ACTIVE");
+    expect(byName.dusty).toBe("STALE");
+    expect(byName.dead).toBe("DEAD");
+    expect(byName.awake).toBe("ACTIVE");  // tmux overrides old commit
+  });
+
+  it("default filter hides ACTIVE + SLOW", async () => {
+    const entries = [
+      entry({ name: "fresh", local_path: "/tmp/fresh" }),
+      entry({ name: "rotting", local_path: "/tmp/rotting" }),
+    ];
+    const result = await runStaleScan(
+      {},  // no --all
+      {
+        readEntries: () => entries,
+        listAwake: async () => new Set(),
+        getLastCommit: (p) => (p === "/tmp/fresh" ? iso(1) : iso(60)),
+        now: () => NOW,
+      },
+    );
+    expect(result.map((r) => r.name)).toEqual(["rotting"]);
+  });
+
+  it("handles missing git history (null commit) → DEAD", async () => {
+    const entries = [entry({ name: "ghost", local_path: "" })];
+    const result = await runStaleScan(
+      {},
+      {
+        readEntries: () => entries,
+        listAwake: async () => new Set(),
+        getLastCommit: () => null,
+        now: () => NOW,
+      },
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].tier).toBe("DEAD");
+  });
+});
+
+function stub(name: string): StaleEntry {
+  return {
+    name,
+    org: "x",
+    repo: `${name}-oracle`,
+    local_path: `/tmp/${name}`,
+    has_psi: true,
+    awake: false,
+    last_commit: null,
+    days_since_commit: null,
+    tier: "DEAD",
+    recommendation: "",
+  };
+}

--- a/src/commands/plugins/oracle/impl-stale.ts
+++ b/src/commands/plugins/oracle/impl-stale.ts
@@ -1,0 +1,206 @@
+/**
+ * maw oracle scan --stale — read-only staleness classifier (issue #392).
+ *
+ * Scope: SCAN ONLY. Prune / register / delete verbs deferred to #383.
+ *
+ * Tiers (per gist 0721cb33):
+ *   ACTIVE  commit < 7d (or awake in tmux)
+ *   SLOW    commit 7–30d
+ *   STALE   commit 30–90d
+ *   DEAD    commit > 90d, or no commits found
+ *
+ * Source of truth: registry cache (oracle entries with local_path) + tmux
+ * liveness. For each cloned repo we read the last commit date via git log;
+ * missing clones or commit-less repos fall into DEAD.
+ */
+import { readCache, scanAndCache, listSessions, type OracleEntry } from "../../../sdk";
+import { execSync } from "child_process";
+
+export type StaleTier = "ACTIVE" | "SLOW" | "STALE" | "DEAD";
+
+export interface StaleEntry {
+  name: string;
+  org: string;
+  repo: string;
+  local_path: string;
+  has_psi: boolean;
+  awake: boolean;
+  last_commit: string | null;   // ISO8601
+  days_since_commit: number | null;
+  tier: StaleTier;
+  recommendation: string;
+}
+
+const ACTIVE_MAX_DAYS = 7;
+const SLOW_MAX_DAYS = 30;
+const STALE_MAX_DAYS = 90;
+
+const TIER_ORDER: Record<StaleTier, number> = { DEAD: 0, STALE: 1, SLOW: 2, ACTIVE: 3 };
+
+export function classifyStaleness(args: {
+  entry: OracleEntry;
+  lastCommitISO: string | null;
+  awake: boolean;
+  now?: Date;
+}): StaleEntry {
+  const { entry, lastCommitISO, awake } = args;
+  const now = args.now ?? new Date();
+
+  let daysSince: number | null = null;
+  if (lastCommitISO) {
+    const ms = now.getTime() - new Date(lastCommitISO).getTime();
+    daysSince = Math.floor(ms / 86_400_000);
+  }
+
+  let tier: StaleTier;
+  let recommendation: string;
+
+  if (awake) {
+    tier = "ACTIVE";
+    recommendation = "awake in tmux";
+  } else if (daysSince === null) {
+    tier = "DEAD";
+    recommendation = entry.local_path
+      ? "no commits found — investigate"
+      : "not cloned — investigate";
+  } else if (daysSince < ACTIVE_MAX_DAYS) {
+    tier = "ACTIVE";
+    recommendation = "recent activity";
+  } else if (daysSince < SLOW_MAX_DAYS) {
+    tier = "SLOW";
+    recommendation = "monitor";
+  } else if (daysSince < STALE_MAX_DAYS) {
+    tier = "STALE";
+    recommendation = "investigate";
+  } else {
+    tier = "DEAD";
+    recommendation = entry.has_psi
+      ? "archive (has ψ/)"
+      : "prune candidate (no ψ/)";
+  }
+
+  return {
+    name: entry.name,
+    org: entry.org,
+    repo: entry.repo,
+    local_path: entry.local_path,
+    has_psi: entry.has_psi,
+    awake,
+    last_commit: lastCommitISO,
+    days_since_commit: daysSince,
+    tier,
+    recommendation,
+  };
+}
+
+export function sortByStaleness(entries: StaleEntry[]): StaleEntry[] {
+  return [...entries].sort((a, b) => {
+    if (a.tier !== b.tier) return TIER_ORDER[a.tier] - TIER_ORDER[b.tier];
+    const aD = a.days_since_commit ?? Infinity;
+    const bD = b.days_since_commit ?? Infinity;
+    if (aD !== bD) return bD - aD;  // oldest first within tier
+    return a.name.localeCompare(b.name);
+  });
+}
+
+/** Read the last commit date (ISO) from a repo. Returns null on any failure. */
+export function lastCommitAt(localPath: string): string | null {
+  if (!localPath) return null;
+  try {
+    const out = execSync(
+      "git log -1 --format=%cI",
+      { cwd: localPath, stdio: ["ignore", "pipe", "ignore"], encoding: "utf-8" },
+    ).trim();
+    return out || null;
+  } catch {
+    return null;
+  }
+}
+
+export interface StaleScanOpts {
+  json?: boolean;
+  all?: boolean;   // include ACTIVE+SLOW in output; default shows STALE+DEAD
+}
+
+/**
+ * Drive the scan: entries come from registry cache, tmux liveness from tmux.
+ * Injectable deps keep the driver testable without touching disk or tmux.
+ */
+export async function runStaleScan(
+  opts: StaleScanOpts = {},
+  deps: {
+    readEntries?: () => OracleEntry[];
+    listAwake?: () => Promise<Set<string>>;
+    getLastCommit?: (localPath: string) => string | null;
+    now?: () => Date;
+  } = {},
+): Promise<StaleEntry[]> {
+  const readEntries = deps.readEntries ?? (() => {
+    const cache = readCache() ?? scanAndCache("local");
+    return cache.oracles;
+  });
+  const listAwake = deps.listAwake ?? (async () => {
+    const sessions = await listSessions().catch(() => []);
+    const awake = new Set<string>();
+    for (const s of sessions) {
+      for (const w of s.windows) {
+        if (w.name.endsWith("-oracle")) awake.add(w.name.replace(/-oracle$/, ""));
+      }
+    }
+    return awake;
+  });
+  const getLastCommit = deps.getLastCommit ?? lastCommitAt;
+  const now = deps.now ?? (() => new Date());
+
+  const entries = readEntries();
+  const awakeSet = await listAwake();
+  const nowDate = now();
+
+  const classified = entries.map((entry) =>
+    classifyStaleness({
+      entry,
+      lastCommitISO: getLastCommit(entry.local_path),
+      awake: awakeSet.has(entry.name),
+      now: nowDate,
+    }),
+  );
+
+  const sorted = sortByStaleness(classified);
+  return opts.all ? sorted : sorted.filter((e) => e.tier === "STALE" || e.tier === "DEAD");
+}
+
+export async function cmdOracleScanStale(opts: StaleScanOpts = {}): Promise<void> {
+  const results = await runStaleScan(opts);
+
+  if (opts.json) {
+    console.log(JSON.stringify({ schema: 1, count: results.length, oracles: results }, null, 2));
+    return;
+  }
+
+  if (results.length === 0) {
+    console.log(`\n  \x1b[32m✓\x1b[0m No stale oracles — all clear.\n`);
+    return;
+  }
+
+  const counts: Record<StaleTier, number> = { ACTIVE: 0, SLOW: 0, STALE: 0, DEAD: 0 };
+  for (const r of results) counts[r.tier]++;
+  const banner =
+    `DEAD ${counts.DEAD}  STALE ${counts.STALE}` +
+    (opts.all ? `  SLOW ${counts.SLOW}  ACTIVE ${counts.ACTIVE}` : "");
+  console.log(`\n  \x1b[36mStale oracle scan\x1b[0m  (${banner})\n`);
+
+  let currentTier: StaleTier | null = null;
+  for (const r of results) {
+    if (r.tier !== currentTier) {
+      currentTier = r.tier;
+      const color = r.tier === "DEAD" ? 31 : r.tier === "STALE" ? 33 : r.tier === "SLOW" ? 90 : 32;
+      console.log(`  \x1b[${color}m${r.tier}\x1b[0m`);
+    }
+    const age = r.days_since_commit === null ? "?" : `${r.days_since_commit}d`;
+    const psi = r.has_psi ? "ψ/" : "  ";
+    console.log(
+      `    ${psi}  ${r.name.padEnd(22)} ${age.padStart(5)} ago  \x1b[90m${r.recommendation}\x1b[0m`,
+    );
+  }
+  console.log();
+}

--- a/src/commands/plugins/oracle/impl.ts
+++ b/src/commands/plugins/oracle/impl.ts
@@ -3,3 +3,4 @@ export type { OracleStatus } from "./impl-helpers";
 export { cmdOracleAbout } from "./impl-about";
 export { cmdOracleList } from "./impl-list";
 export { cmdOracleScan, cmdOracleFleet } from "./impl-scan";
+export { cmdOracleScanStale } from "./impl-stale";

--- a/src/commands/plugins/oracle/index.ts
+++ b/src/commands/plugins/oracle/index.ts
@@ -1,5 +1,5 @@
 import type { InvokeContext, InvokeResult } from "../../../plugin/types";
-import { cmdOracleList, cmdOracleAbout, cmdOracleScan } from "./impl";
+import { cmdOracleList, cmdOracleAbout, cmdOracleScan, cmdOracleScanStale } from "./impl";
 import { parseFlags } from "../../../cli/parse-args";
 
 export const command = {
@@ -51,20 +51,28 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
           "--local": Boolean,
           "--remote": Boolean,
           "--all": Boolean,
+          "--stale": Boolean,
           "--verbose": Boolean,
           "-v": "--verbose",
           "--quiet": Boolean,
           "-q": "--quiet",
         }, 1);
-        await cmdOracleScan({
-          json: flags["--json"],
-          force: flags["--force"],
-          local: flags["--local"],
-          remote: flags["--remote"],
-          all: flags["--all"],
-          verbose: flags["--verbose"],
-          quiet: flags["--quiet"],
-        });
+        if (flags["--stale"]) {
+          await cmdOracleScanStale({
+            json: flags["--json"],
+            all: flags["--all"],
+          });
+        } else {
+          await cmdOracleScan({
+            json: flags["--json"],
+            force: flags["--force"],
+            local: flags["--local"],
+            remote: flags["--remote"],
+            all: flags["--all"],
+            verbose: flags["--verbose"],
+            quiet: flags["--quiet"],
+          });
+        }
       } else if (subcmd === "fleet") {
         // Deprecated alias — warn then delegate to ls.
         console.error(
@@ -97,14 +105,21 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
           path: query.path as boolean | undefined,
         });
       } else if (sub === "scan") {
-        await cmdOracleScan({
-          json: query.json as boolean | undefined,
-          force: query.force as boolean | undefined,
-          local: query.local as boolean | undefined,
-          remote: query.remote as boolean | undefined,
-          all: query.all as boolean | undefined,
-          verbose: query.verbose as boolean | undefined,
-        });
+        if (query.stale) {
+          await cmdOracleScanStale({
+            json: query.json as boolean | undefined,
+            all: query.all as boolean | undefined,
+          });
+        } else {
+          await cmdOracleScan({
+            json: query.json as boolean | undefined,
+            force: query.force as boolean | undefined,
+            local: query.local as boolean | undefined,
+            remote: query.remote as boolean | undefined,
+            all: query.all as boolean | undefined,
+            verbose: query.verbose as boolean | undefined,
+          });
+        }
       } else if (sub === "fleet") {
         console.error(
           `\x1b[33m⚠  oracle.fleet is deprecated — use oracle.ls\x1b[0m`,

--- a/src/commands/plugins/oracle/oracle.test.ts
+++ b/src/commands/plugins/oracle/oracle.test.ts
@@ -8,6 +8,9 @@ mock.module("./impl", () => ({
   cmdOracleScan: async (_opts: any) => {
     console.log("Scanned 5 oracles locally");
   },
+  cmdOracleScanStale: async (_opts: any) => {
+    console.log("Stale oracle scan  (DEAD 1  STALE 2)");
+  },
   cmdOracleFleet: async (_opts: any) => {
     console.log("Oracle Fleet  (5 oracles)");
   },
@@ -34,6 +37,12 @@ describe("oracle plugin", () => {
     const result = await handler({ source: "cli", args: ["scan"] });
     expect(result.ok).toBe(true);
     expect(result.output).toContain("Scanned");
+  });
+
+  it("cli: scan --stale dispatches to stale classifier", async () => {
+    const result = await handler({ source: "cli", args: ["scan", "--stale"] });
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("Stale oracle scan");
   });
 
   it("cli: fleet shows fleet", async () => {


### PR DESCRIPTION
## Scope
Implement the **scan side** of #392 only. Prune/register/archive capabilities stay deferred to #383 (scope cut per team triage — #383 + #392 overlap, split explicitly here).

## Behavior
\`maw oracle scan --stale\` classifies every oracle registry entry into 4 tiers (per gist \`0721cb33\` boundaries):

| Tier | Age (commits) | Live tmux? |
|------|--------------|-----------|
| ACTIVE | < 7 d | yes → always ACTIVE |
| SLOW   | 7-30 d | no |
| STALE  | 30-90 d | no |
| DEAD   | 90+ d or missing | no |

Default output hides ACTIVE + SLOW. \`--all\` shows all tiers. \`--json\` for scripts.

## Example live output
\`\`\`
  Stale oracle scan  (DEAD 28  STALE 0)
  DEAD
    ψ/  arra-oracle-v3             ? ago  not cloned — investigate
        boon_v2                    ? ago  not cloned — investigate
    ψ/  liquid                     ? ago  not cloned — investigate
    ...
\`\`\`

## Changes
- \`src/commands/plugins/oracle/impl-stale.ts\` (new, 171 LOC) — classifier + sort + driver + cmd
- \`src/commands/plugins/oracle/impl-stale.test.ts\` (new, 171 LOC, 14 tests)
- \`src/commands/plugins/oracle/impl.ts\` (+1 export)
- \`src/commands/plugins/oracle/index.ts\` — dispatcher for \`--stale\`
- \`src/commands/plugins/oracle/oracle.test.ts\` (+8 LOC — mock + dispatcher test)

## Tests
\`bun test ./src/commands/plugins/oracle/\` → **20/20 pass** (6 existing + 14 new).

## Implementation notes
Used registry cache + local \`git log -1 --format=%cI\` for commit age rather than gh API — simpler, offline-capable, read-only. Remote gh-API path can be added later if #383 wants tier classification without a local clone.

## NOT in this PR (deferred to #383)
- No prune / delete capability
- No \`maw oracle register\` verb
- No \`gh repo archive\` automation

Closes (partial) #392 — full close when #383 adds prune.