### PR TITLE
fix(test): bud-repo + bud-wake tests catch up with #421 post-clone verify

### DIFF
--- a/test/isolated/bud-repo.test.ts
+++ b/test/isolated/bud-repo.test.ts
@@ -27,6 +27,7 @@ interface ExecResponse {
   match?: RegExp;        // cmd substring/regex to match
   result?: string;       // string to resolve with
   error?: string;        // message to reject with
+  sideEffect?: () => void; // run before resolving (e.g. mkdirSync to simulate `ghq get` landing)
 }
 
 let execCalls: string[] = [];
@@ -37,6 +38,7 @@ const mockExec = async (cmd: string): Promise<string> => {
   for (const r of execResponses) {
     if (r.match && r.match.test(cmd)) {
       if (r.error) throw new Error(r.error);
+      r.sideEffect?.();
       return r.result ?? "";
     }
   }
@@ -91,6 +93,7 @@ describe("ensureBudRepo — gh repo view pre-check", () => {
     const missingPath = join(tmpBase, "view-hit");
     execResponses = [
       { match: /^gh repo view /, result: `{"name":"view-hit-oracle"}` },
+      { match: /^ghq get /, sideEffect: () => mkdirSync(missingPath, { recursive: true }) },
     ];
 
     await ensureBudRepo(
@@ -112,6 +115,7 @@ describe("ensureBudRepo — gh repo view pre-check", () => {
     execResponses = [
       { match: /^gh repo view /, error: "not found" },
       // No response for `gh repo create` → default "" which means "success".
+      { match: /^ghq get /, sideEffect: () => mkdirSync(missingPath, { recursive: true }) },
     ];
 
     await ensureBudRepo(
@@ -141,6 +145,7 @@ describe("ensureBudRepo — gh repo view pre-check", () => {
     const missingPath = join(tmpBase, "view-other");
     execResponses = [
       { match: /^gh repo view /, result: `{"name":"some-other-repo"}` },
+      { match: /^ghq get /, sideEffect: () => mkdirSync(missingPath, { recursive: true }) },
     ];
 
     await ensureBudRepo(
@@ -160,6 +165,7 @@ describe("ensureBudRepo — gh repo create error branches", () => {
     execResponses = [
       { match: /^gh repo view /, error: "not found" },
       { match: /^gh repo create /, error: "repository already exists on remote" },
+      { match: /^ghq get /, sideEffect: () => mkdirSync(missingPath, { recursive: true }) },
     ];
 
     await ensureBudRepo(
@@ -260,6 +266,7 @@ describe("ensureBudRepo — ghq clone command shape", () => {
     const missingPath = join(tmpBase, "clone-shape");
     execResponses = [
       { match: /^gh repo view /, error: "not found" },
+      { match: /^ghq get /, sideEffect: () => mkdirSync(missingPath, { recursive: true }) },
     ];
 
     await ensureBudRepo(

--- a/test/isolated/bud-wake.test.ts
+++ b/test/isolated/bud-wake.test.ts
@@ -472,13 +472,13 @@ describe("finalizeBud — step 7 (parent sync_peers)", () => {
 // ─── Step 8: wake the bud ───────────────────────────────────────────────────
 
 describe("finalizeBud — step 8 (wake)", () => {
-  test("default opts → cmdWake(name, { noAttach: true })", async () => {
+  test("default opts → cmdWake(name, { noAttach: true, repoPath })", async () => {
     const ctx = makeCtx({ name: "wakebud", parentName: null, opts: {} });
     await finalizeBud(ctx);
 
     expect(cmdWakeCalls).toHaveLength(1);
     expect(cmdWakeCalls[0].name).toBe("wakebud");
-    expect(cmdWakeCalls[0].opts).toEqual({ noAttach: true });
+    expect(cmdWakeCalls[0].opts).toEqual({ noAttach: true, repoPath: ctx.budRepoPath });
   });
 
   test("--issue → fetchIssuePrompt called with (issue, `${org}/${repo}`) + wakeOpts has prompt + task", async () => {
@@ -496,6 +496,7 @@ describe("finalizeBud — step 8 (wake)", () => {
     expect(cmdWakeCalls).toHaveLength(1);
     expect(cmdWakeCalls[0].opts).toEqual({
       noAttach: true,
+      repoPath: ctx.budRepoPath,
       prompt: "<fetched-issue-body>",
       task: "issue-201",
     });


### PR DESCRIPTION
## Problem
After #421 (--org flag propagation via \`bud-repo.ts:44\` \`existsSync(budRepoPath)\` post-clone verify + \`wake-cmd.ts\` \`repoPath\` opt), 7 tests in \`test/isolated/\` were left failing against the new contract:
- **bud-repo.test.ts**: 5 fails — mocked \`hostExec\` never creates the path → new \`existsSync\` guard throws
- **bud-wake.test.ts**: 2 fails — tests still asserted \`{ noAttach: true }\` wake opts shape (missing \`repoPath: ctx.budRepoPath\`)

Not mock pollution, not flake — **real test regressions** from the #421 contract change.

## Fix (10 LOC total, zero src changes)
- \`test/isolated/bud-repo.test.ts\` (+7): add \`sideEffect?: () => void\` to \`ExecResponse\` interface; 5 tests now \`mkdirSync(missingPath)\` on \`^ghq get\` match (simulates successful clone landing)
- \`test/isolated/bud-wake.test.ts\` (+3 −2): two \`toEqual\` assertions gain \`repoPath: ctx.budRepoPath\`

## Verification
\`\`\`
$ bun run test:isolated
=== summary: 43/43 files passed, 0 failed ===
\`\`\`

Confirmed clean. This unblocks CI for all future PRs against main.

## Pre-existing surprises (not fixed here — follow-up worthy)
1. **\`test:isolated:random\` still fails** — \`tmux.test.ts\` has 4 in-test \`mock.module()\` calls that don't restore (module-level mock overwritten, no \`beforeEach\` reset). Within-file order-dependent. Doesn't affect CI (runs in stable file order). Worth an issue: extract the 4 override-mock tests OR reinstall the default mock in a \`beforeEach\`.
2. **\`test:mock-smoke\` explodes** with 38523 "files" inside a worktree — bun test globs up through nested \`agents/*/maw-js/agents/...\` because that script doesn't pass \`--path-ignore-patterns\`. Pre-existing env bug, not triggered by CI (clean checkout). Follow-up: add the ignore flag to \`test:mock-smoke\`.

## Commits
- \`7b6aea3\` fix(test): bud-repo simulates ghq-get clone landing on disk
- \`8c7c213\` fix(test): bud-wake expects repoPath in wake opts
- \`69484e5\` wip(isolated): baseline classification

(The wip commit documents the investigation — can be squash-merged if preferred.)

This lands the true 43/43 green state → #430 and #431 (and all future PRs) can merge without \`--admin\` overrides.