### PR TITLE
fix(find-window): exact-match-first bare-name resolver + AmbiguousMatchError (#414, #406/1a)

### DIFF
--- a/src/core/runtime/find-window.ts
+++ b/src/core/runtime/find-window.ts
@@ -23,6 +23,21 @@ export interface Session {
 }
 
 /**
+ * Thrown when a bare-name query matches multiple candidates and no exact
+ * match can disambiguate. See #414 / #406-1a.
+ */
+export class AmbiguousMatchError extends Error {
+  readonly query: string;
+  readonly candidates: string[];
+  constructor(query: string, candidates: string[]) {
+    super(`Ambiguous match for "${query}" — candidates: ${candidates.join(", ")}`);
+    this.name = "AmbiguousMatchError";
+    this.query = query;
+    this.candidates = candidates;
+  }
+}
+
+/**
  * Match a session by name part. Tries (in order):
  *   1. Exact match
  *   2. Oracle-name match (strip leading `\d+-` from session name)
@@ -64,18 +79,36 @@ export function findWindow(sessions: Session[], query: string): string | null {
     // Fall through if no semantic match
   }
 
-  // Match window names first (most specific)
+  // Two-pass bare-name resolution (#414):
+  //   Pass 1 collects exact matches (window name, session name, stripped
+  //   oracle-name). Pass 2 collects substring matches only if Pass 1 was
+  //   empty. Multi-candidate in either pass → AmbiguousMatchError.
+  const exact = new Set<string>();
   for (const s of sessions) {
     for (const w of s.windows) {
-      if (w.name.toLowerCase().includes(q)) return `${s.name}:${w.index}`;
+      if (w.name.toLowerCase() === q) exact.add(`${s.name}:${w.index}`);
+    }
+    if (s.windows.length > 0) {
+      const sn = s.name.toLowerCase();
+      if (sn === q || sn.replace(/^\d+-/, "") === q) {
+        exact.add(`${s.name}:${s.windows[0].index}`);
+      }
     }
   }
-  // Match session names — return first window of matching session
+  if (exact.size === 1) return [...exact][0];
+  if (exact.size > 1) throw new AmbiguousMatchError(query, [...exact]);
+
+  const sub = new Set<string>();
   for (const s of sessions) {
+    for (const w of s.windows) {
+      if (w.name.toLowerCase().includes(q)) sub.add(`${s.name}:${w.index}`);
+    }
     if (s.name.toLowerCase().includes(q) && s.windows.length > 0) {
-      return `${s.name}:${s.windows[0].index}`;
+      sub.add(`${s.name}:${s.windows[0].index}`);
     }
   }
+  if (sub.size === 1) return [...sub][0];
+  if (sub.size > 1) throw new AmbiguousMatchError(query, [...sub]);
   // If query has ":" and the SESSION part matched a real session but the
   // WINDOW part didn't → return raw query (user may mean index, e.g. "08-mawjs:1").
   // If the SESSION part didn't match anything local → return null so cmdSend

--- a/test/00-ssh.test.ts
+++ b/test/00-ssh.test.ts
@@ -4,7 +4,7 @@ import { describe, test, expect } from "bun:test";
 // replaces the ssh module, breaking findWindow for anyone importing
 // from there. The real implementation lives in find-window.ts which
 // no test mocks, so imports here stay stable.
-import { findWindow } from "../src/core/runtime/find-window";
+import { findWindow, AmbiguousMatchError } from "../src/core/runtime/find-window";
 import type { Session } from "../src/core/runtime/find-window";
 
 const MOCK_SESSIONS: Session[] = [
@@ -59,9 +59,68 @@ describe("findWindow", () => {
     expect(findWindow(MOCK_SESSIONS, "herm")).toBe("1-oracles:2");
   });
 
-  test("returns first match when multiple match", () => {
-    // "oracle" matches all in 1-oracles session
-    expect(findWindow(MOCK_SESSIONS, "oracle")).toBe("1-oracles:0");
+  test("throws AmbiguousMatchError when multiple substring matches and no exact (#414)", () => {
+    // "oracle" substring-matches 4 windows (neo/pulse/hermes/nexus-oracle) with no
+    // exact hit. Pre-#414 this silently picked the first; now it must error.
+    expect(() => findWindow(MOCK_SESSIONS, "oracle")).toThrow(AmbiguousMatchError);
+    try {
+      findWindow(MOCK_SESSIONS, "oracle");
+    } catch (e) {
+      expect(e).toBeInstanceOf(AmbiguousMatchError);
+      const err = e as AmbiguousMatchError;
+      expect(err.query).toBe("oracle");
+      expect(err.candidates.length).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  describe("exact-match-first bare resolution (#414 / #406-1a)", () => {
+    const MOTHER_SESSIONS: Session[] = [
+      { name: "109-mother-roots", windows: [
+        { index: 1, name: "mother-roots-oracle", active: true },
+      ]},
+      { name: "13-mother", windows: [
+        { index: 1, name: "mother-oracle", active: true },
+      ]},
+      { name: "mother-view", windows: [
+        { index: 1, name: "view", active: true },
+      ]},
+    ];
+
+    test("bare 'mother' single exact oracle-name match resolves (13-mother)", () => {
+      // '13-mother' strips to 'mother' (oracle-name exact); '109-mother-roots'
+      // strips to 'mother-roots' (no exact); 'mother-view' (no NN- prefix, no exact).
+      // Pre-fix iteration order surfaced '109-mother-roots' via window substring.
+      expect(findWindow(MOTHER_SESSIONS, "mother")).toBe("13-mother:1");
+    });
+
+    test("bare 'mother' still resolves when 109-mother-roots listed first", () => {
+      // Guard against tmux list ordering (`13` < `109` lexical) — exact beats
+      // iteration position.
+      const reordered = [MOTHER_SESSIONS[0], MOTHER_SESSIONS[2], MOTHER_SESSIONS[1]];
+      expect(findWindow(reordered, "mother")).toBe("13-mother:1");
+    });
+
+    test("bare 'foo' with only prefix/substring matches → AmbiguousMatchError", () => {
+      const foo: Session[] = [
+        { name: "101-foo-bar", windows: [{ index: 1, name: "foo-bar-oracle", active: true }] },
+        { name: "102-foo-baz", windows: [{ index: 1, name: "foo-baz-oracle", active: true }] },
+      ];
+      expect(() => findWindow(foo, "foo")).toThrow(AmbiguousMatchError);
+      try {
+        findWindow(foo, "foo");
+      } catch (e) {
+        const err = e as AmbiguousMatchError;
+        expect(err.candidates).toContain("101-foo-bar:1");
+        expect(err.candidates).toContain("102-foo-baz:1");
+      }
+    });
+
+    test("bare 'view' unique exact window-name match resolves", () => {
+      // 'mother-view' session has a window literally named 'view'. Exact window
+      // match is unique → resolves even though 'view' substring-hits mother-view
+      // session name too (dedup keeps them consistent).
+      expect(findWindow(MOTHER_SESSIONS, "view")).toBe("mother-view:1");
+    });
   });
 
   describe("session:window syntax (#186)", () => {


### PR DESCRIPTION
## Problem
\`findWindow\` in \`src/core/runtime/find-window.ts\` used substring matching + first-match-wins iteration order. Bare \`mother\` hit \`109-mother-roots\` first because window-name pass found it before session-name pass would find \`13-mother\`.

## Fix
Two-pass resolver (session:window form preserved):

1. **Pass 1 — exact**: window name, session name, stripped \`^\\d+-\` oracle-name. Single hit resolves. Multi → throws \`AmbiguousMatchError{query, candidates}\`.
2. **Pass 2 — substring** (only if Pass 1 empty): same single/multi rule.

## Changes
- \`src/core/runtime/find-window.ts\` (+37/-4) — two-pass logic + AmbiguousMatchError class
- \`test/00-ssh.test.ts\` (+63/-4) — 4 regression tests

## Tests
\`bun test test/\` with canonical path-ignore → **950 pass / 0 fail / 6 skip** (956 tests).

- bare \`mother\` → resolves \`13-mother:1\` even with \`109-mother-roots\` iterated first
- bare \`foo\` (only prefix hits) → \`AmbiguousMatchError\` listing all candidates
- bare \`view\` unique exact window match → resolves
- existing "first match wins on oracle" test rewritten to assert throw (this was the bug behavior)

## ⚠️ Behavior change at CLI boundary
\`findWindow\` now **throws on ambiguity** — previously silently picked first match. Callers (\`routing.ts\`, \`engine/index.ts\`, \`api/sessions.ts\`, \`commands/plugins/talk-to/impl.ts\`, \`transports/{tmux,http}.ts\`, \`commands/shared/comm-peek.ts\`) propagate the error. Surfaces "Ambiguous: X, Y" to user at CLI.

No callers try/catch yet. Follow-up option: add catch in \`resolveTarget\` to return error-typed result rather than throw. Flagging as behavior change for reviewer awareness.

Closes #414, #406/1a.