### PR TITLE
docs(hey): tip reflects exact-match semantics (#416)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ maw bud myname --from neo                # bud from an existing oracle
 Talk across machines with HMAC-SHA256 signing.
 
 ```bash
-maw hey neo "hello"                      # bare name — resolves on local node
+maw hey neo "hello"                      # bare name — exact local match (errors on ambiguity)
 maw hey white:neo "hello"                # canonical form — remote node, window 1
 maw hey white:neo:3 "hello hermes"       # pick a specific tmux window (#410)
 maw peek white:neo                       # see their screen

--- a/src/cli/route-comm.ts
+++ b/src/cli/route-comm.ts
@@ -16,7 +16,7 @@ export async function routeComm(cmd: string, args: string[]): Promise<boolean> {
     if (!target) {
       console.error("usage: maw hey <target> <message> [--force]");
       console.error("  target forms:");
-      console.error("    <agent>                      bare name, resolves on local node");
+      console.error("    <agent>                      bare name (exact local match, errors on ambiguity)");
       console.error("    <node>:<session>             canonical cross-node form (window 1)");
       console.error("    <node>:<session>:<window>    target a specific tmux window (#410)");
       console.error("  e.g. maw hey mawjs \"hello from neo\"");

--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -76,7 +76,7 @@ export async function cmdSend(query: string, message: string, force = false) {
   // scripts should use the prefixed form for fleet portability. Silent when
   // MAW_QUIET=1.
   if (!query.includes(":") && !query.includes("/") && !process.env.MAW_QUIET && config.node) {
-    console.error(`\x1b[90mℹ tip: use canonical form 'maw hey ${config.node}:${query}' for cross-node scripts — append ':<window>' to target a specific window (bare name resolves locally)\x1b[0m`);
+    console.error(`\x1b[90mℹ tip: use canonical form 'maw hey ${config.node}:${query}' for cross-node scripts — append ':<window>' to target a specific window (bare name = exact match locally; errors on ambiguity)\x1b[0m`);
   }
 
   // --- Plugin routing: maw hey plugin:<name> <msg> ---


### PR DESCRIPTION
## Problem
After #414 / #434 (find-window exact-match-first resolver), the tip text saying "bare name resolves locally" was true but incomplete. Didn't convey that bare-name now uses **exact match** (not substring) and errors on ambiguity.

## Fix (3 files, +3/-3)
- \`src/commands/shared/comm-send.ts\` — updated tip text
- \`src/cli/route-comm.ts\` — updated \`maw hey\` usage line
- \`README.md\` — federation example comment

## New tip text
\`\`\`
ℹ tip: use canonical form 'maw hey white:neo' for cross-node scripts — append ':<window>' to target a specific window (bare name = exact match locally; errors on ambiguity)
\`\`\`

## route-comm.ts usage line
\`\`\`
    <agent>                      bare name (exact local match, errors on ambiguity)
\`\`\`

## Tests
Docs only, no behavior change. Existing isolated comm-list/comm-peek tip tests assert on \`"tip:"\` and \`"maw hey white:mawjs"\` substring only — both preserved.

## Closes
- closes #416
- resolves #406 (umbrella) when this + #414 + #415 are all on main (all three sub-issues done)