### PR TITLE
fix(test): test:mock-smoke + test:plugin honor path-ignore for worktree recursion (#437)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "test:isolated": "bash scripts/test-isolated.sh",
     "test:isolated:random": "bash scripts/test-isolated.sh --randomize",
     "test:isolated:legacy": "bun test test/isolated/ --path-ignore-patterns '**/maw-js/**'",
-    "test:mock-smoke": "bun test test/zz-mock-tmux-smoke.test.ts",
-    "test:plugin": "bun test src/commands/plugins/",
+    "test:mock-smoke": "bun test test/zz-mock-tmux-smoke.test.ts --path-ignore-patterns '**/maw-js/**' --path-ignore-patterns '**/agents/**'",
+    "test:plugin": "bun test src/commands/plugins/ --path-ignore-patterns '**/maw-js/**' --path-ignore-patterns '**/agents/**'",
     "test:all": "bun run test && bun run test:isolated && bun run test:mock-smoke && bun run test:plugin",
     "ship:alpha": "bash scripts/ship-alpha.sh",
     "ship:alpha:dry": "bash scripts/ship-alpha.sh --dry-run"


### PR DESCRIPTION
## Problem
\`test:mock-smoke\` and \`test:plugin\` package.json scripts lacked \`--path-ignore-patterns\` — so bun test globbed up through nested \`agents/*/maw-js/agents/...\` worktree symlinks, producing 30k+ phantom tests (EMFILE).

\`test:isolated\` already had the ignore via the per-file subprocess script (#429), but these two were missed.

## Fix
Add \`--path-ignore-patterns '**/maw-js/**'\` + \`'**/agents/**'\` to both scripts (matching the pattern already used by \`test\` and \`test:isolated:legacy\`).

## Verification
- \`bun run test:mock-smoke\` → **6 pass / 0 fail / 14 expect** (45ms)
- \`bun run test:plugin\` → **100 pass / 0 fail / 6 skip / 205 expect** (213ms)

## Closes
- closes #437