### PR TITLE
feat(test): mock-export-sync lint rule (#435)

### DIFF
--- a/scripts/check-mock-export-sync.sh
+++ b/scripts/check-mock-export-sync.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# check-mock-export-sync.sh — verify mock helpers re-export every symbol
+# from their target src module (#435).
+#
+# Why: mock.module writes to a process-global registry. If the real module
+# gains an export (e.g. #431 added HostExecError to src/core/transport/ssh.ts)
+# and the canonical mock isn't updated, later tests importing the real module
+# get the polluted mock and fail with "Export named X not found".
+#
+# Opt-in via JSDoc tag in each mock file:
+#   @target-module src/core/transport/ssh.ts
+#
+# Mocks without the tag are skipped. For each tagged mock:
+#   1. Read the target src path from the @target-module tag
+#   2. Extract named runtime exports from the target (class/function/const/
+#      let/var + `export { a, b } from "..."` re-exports)
+#   3. For each name, verify it appears in the mock file
+#   4. Exit nonzero with a file + missing-exports list if any drift
+#
+# Exit 0 on clean tree, exit 1 on any mismatch.
+
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+fails=0
+
+extract_src_exports() {
+  local src="$1"
+  {
+    # Direct declarations: export [async] class|function|const|let|var X
+    grep -oE '^[[:space:]]*export[[:space:]]+(async[[:space:]]+)?(class|function|const|let|var)[[:space:]]+[A-Za-z_][A-Za-z0-9_]*' "$src" 2>/dev/null \
+      | awk '{print $NF}'
+    # Brace-style re-exports: export { a, b as c } [from "..."]
+    # Skip `export type {` — runtime mocks don't need type-only symbols
+    grep -nE '^[[:space:]]*export[[:space:]]*\{' "$src" 2>/dev/null \
+      | sed -E 's/.*export[[:space:]]*\{([^}]*)\}.*/\1/' \
+      | tr ',' '\n' \
+      | sed -E 's#^[[:space:]]+##; s#[[:space:]]+$##; s#.* as ##' \
+      | grep -E '^[A-Za-z_][A-Za-z0-9_]*$' || true
+  } | sort -u
+}
+
+while IFS= read -r mock; do
+  [[ -z "$mock" ]] && continue
+  target=$(grep -oE '@target-module[[:space:]]+\S+' "$mock" | awk '{print $2}' | head -1)
+  [[ -z "$target" ]] && continue
+  if [[ ! -f "$target" ]]; then
+    echo "$mock: @target-module points to missing file: $target" >&2
+    fails=$((fails + 1))
+    continue
+  fi
+  missing=()
+  while IFS= read -r name; do
+    [[ -z "$name" ]] && continue
+    grep -qE "\b${name}\b" "$mock" || missing+=("$name")
+  done < <(extract_src_exports "$target")
+  if (( ${#missing[@]} > 0 )); then
+    echo "$mock (target: $target) missing: ${missing[*]}" >&2
+    fails=$((fails + 1))
+  fi
+done < <(git ls-files -- 'test/helpers/mock-*.ts')
+
+if (( fails > 0 )); then
+  echo "" >&2
+  echo "✗ mock-export-sync violation (#435): $fails mock(s) drifted from target src" >&2
+  echo "  Fix: add the missing export to the mock helper, or remove the" >&2
+  echo "       @target-module tag if the mapping no longer applies." >&2
+  exit 1
+fi
+exit 0

--- a/scripts/check-mock-export-sync.sh
+++ b/scripts/check-mock-export-sync.sh
@@ -28,21 +28,21 @@ extract_src_exports() {
   local src="$1"
   {
     # Direct declarations: export [async] class|function|const|let|var X
-    grep -oE '^[[:space:]]*export[[:space:]]+(async[[:space:]]+)?(class|function|const|let|var)[[:space:]]+[A-Za-z_][A-Za-z0-9_]*' "$src" 2>/dev/null \
+    (grep -oE '^[[:space:]]*export[[:space:]]+(async[[:space:]]+)?(class|function|const|let|var)[[:space:]]+[A-Za-z_][A-Za-z0-9_]*' "$src" 2>/dev/null || true) \
       | awk '{print $NF}'
     # Brace-style re-exports: export { a, b as c } [from "..."]
     # Skip `export type {` — runtime mocks don't need type-only symbols
-    grep -nE '^[[:space:]]*export[[:space:]]*\{' "$src" 2>/dev/null \
+    (grep -E '^[[:space:]]*export[[:space:]]*\{' "$src" 2>/dev/null || true) \
       | sed -E 's/.*export[[:space:]]*\{([^}]*)\}.*/\1/' \
       | tr ',' '\n' \
       | sed -E 's#^[[:space:]]+##; s#[[:space:]]+$##; s#.* as ##' \
-      | grep -E '^[A-Za-z_][A-Za-z0-9_]*$' || true
+      | (grep -E '^[A-Za-z_][A-Za-z0-9_]*$' || true)
   } | sort -u
 }
 
 while IFS= read -r mock; do
   [[ -z "$mock" ]] && continue
-  target=$(grep -oE '@target-module[[:space:]]+\S+' "$mock" | awk '{print $2}' | head -1)
+  target=$(grep -oE '@target-module[[:space:]]+\S+' "$mock" 2>/dev/null | awk '{print $2}' | head -1 || true)
   [[ -z "$target" ]] && continue
   if [[ ! -f "$target" ]]; then
     echo "$mock: @target-module points to missing file: $target" >&2

--- a/scripts/ship-alpha.sh
+++ b/scripts/ship-alpha.sh
@@ -53,6 +53,7 @@ if git rev-parse "$TAG" >/dev/null 2>&1; then
 fi
 
 bash "$(dirname "$0")/check-mock-boundary.sh" || { red "error: mock-boundary check failed (see #387)"; exit 1; }
+bash "$(dirname "$0")/check-mock-export-sync.sh" || { red "error: mock-export-sync check failed (see #435)"; exit 1; }
 
 cyan "🚢 ship-alpha — $TAG"
 dim "  version: $VERSION"

--- a/test/helpers/mock-config.ts
+++ b/test/helpers/mock-config.ts
@@ -3,6 +3,9 @@
  * mock.module("../src/config") needs to provide so bun's global
  * mock pollution doesn't drop D/cfgInterval/cfgTimeout/cfgLimit
  * from unrelated test files.
+ *
+ * @target-module src/config.ts
+ * (Checked by scripts/check-mock-export-sync.sh — #435)
  */
 import type { MawConfig, MawIntervals, MawTimeouts, MawLimits } from "../../src/config";
 
@@ -35,7 +38,8 @@ export function mockConfigModule(loadConfig: () => Partial<MawConfig>) {
     loadConfig,
     resetConfig: () => {},
     saveConfig: () => {},
-    validateConfig: (c: any) => c,
+    validateConfigShape: (c: any) => c,
+    configForDisplay: () => ({}),
     buildCommand: (_name: string) => "echo test",
     buildCommandInDir: (_name: string, cwd: string) => `cd '${cwd}' && echo test`,
     getEnvVars: () => ({}),

--- a/test/helpers/mock-ssh.ts
+++ b/test/helpers/mock-ssh.ts
@@ -1,6 +1,9 @@
 /**
  * Canonical ssh.ts mock — USE THIS for all mock.module calls on ssh.ts.
  *
+ * @target-module src/core/transport/ssh.ts
+ * (Checked by scripts/check-mock-export-sync.sh — #435)
+ *
  * Why: mock.module writes to a process-global module registry. When test A
  * mocks ssh.ts with N exports and test B mocks it with N-3, test B leaves
  * the global polluted. When later test C imports the real ssh.ts, its


### PR DESCRIPTION
## Summary
Adds \`scripts/check-mock-export-sync.sh\` — a pre-tag lint that verifies canonical test mock helpers re-export every runtime symbol from their target src module.

Prevents the alpha.114 hotfix pattern: #431 added \`HostExecError\` to \`src/core/transport/ssh.ts\` but forgot to update \`test/helpers/mock-ssh.ts\`, causing 2 isolated tests to fail on main.

## Design
- **Opt-in** via JSDoc tag \`@target-module <path>\` in each mock file (added to \`mock-ssh.ts\` and \`mock-config.ts\`)
- Mocks without the tag are skipped
- Extracts runtime exports (class/function/const/let/var + brace re-exports); ignores \`export type {...}\`
- Reports missing symbols per mock with a fix hint
- Wired into \`ship-alpha.sh\` preflight after \`check-mock-boundary.sh\` (#387)

## Test plan
- [x] Clean tree → exit 0
- [x] Negative test: added \`fakeNewExport\` to ssh.ts → caught + listed + exit 1
- [x] \`bash scripts/check-mock-export-sync.sh\` passes on HEAD
- [ ] CI (6 checks)

Closes #435.

Co-Authored-By: mawjs <noreply@soulbrews.studio>