### PR TITLE
feat(sdk): publish workflow + packaging docs (#339)

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -1,0 +1,60 @@
+name: Publish SDK
+
+on:
+  push:
+    tags:
+      - 'sdk-v*'
+
+jobs:
+  verify-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check tag matches package version
+        run: |
+          TAG="${GITHUB_REF_NAME#sdk-v}"
+          PKG=$(node -p "require('./packages/sdk/package.json').version")
+          echo "Tag version: $TAG"
+          echo "Package version: $PKG"
+          if [ "$TAG" != "$PKG" ]; then
+            echo "ERROR: tag sdk-v$TAG does not match packages/sdk version $PKG"
+            exit 1
+          fi
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: verify-version
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - name: Cache bun deps
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run SDK tests
+        run: bun test packages/sdk/
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Publish @maw/sdk
+        working-directory: packages/sdk
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/sdk/DECISION-339.md
+++ b/packages/sdk/DECISION-339.md
@@ -1,0 +1,39 @@
+# Decision: @maw/sdk npm publish strategy (issue #339)
+
+## Owner identity
+
+**`neo-oracle`** — the GitHub identity that owns the Soul-Brews-Studio org and the maw-js repo.
+
+Rationale: zero new account setup, 2FA already enabled, most direct path to a first publish. The npm scope is `@maw` (org-style scoping), which is independent of the publisher identity.
+
+Alternative considered: create a dedicated `soulbrews` npm org account. Deferred to Phase B when organizational publishing hygiene matters more.
+
+## Types-only alpha.1 (Option C from debate)
+
+### Option A — Ship types-only alpha.1 now (tarball ready)
+Unblocks plugin authors immediately. No runtime shipped yet.
+
+### Option B — Wait for Phase B (runtime + types together)
+Cleaner first release, but delays ecosystem adoption for weeks.
+
+### Option C (selected) — Ship A now, graduate to stable at Phase B
+Best of both: plugin authors get the stable typed API today; runtime lands in `1.0.0` when Phase B (#340) completes. Alpha semver (`1.0.0-alpha.1`) signals pre-stable clearly.
+
+## What ships now (this PR)
+
+- GitHub Actions workflow `publish-sdk.yml` — tag-gated, provenance-enabled
+- `PUBLISH.md` — one-time scope claim + secret setup instructions
+- `packages/sdk/package.json` — already complete (name, version, publishConfig, files, exports)
+
+## What does NOT ship now
+
+- The actual `npm publish` invocation — @nazt does this interactively after workflow lands
+- Runtime code — types-only until Phase B
+- npm org account / secrets — manual one-time steps documented in PUBLISH.md
+
+## Phase B graduation plan (#340)
+
+1. Ship runtime implementation alongside types
+2. Re-export from `@maw/sdk` without breaking the existing types API
+3. Bump to `1.0.0` stable, remove `-alpha` pre-release tag
+4. Update `PUBLISH.md` with stable publishing cadence

--- a/packages/sdk/PUBLISH.md
+++ b/packages/sdk/PUBLISH.md
@@ -1,0 +1,51 @@
+# Publishing @maw/sdk
+
+## One-time setup (run once, not in CI)
+
+### 1. Claim the `@maw` npm scope
+
+```bash
+npm login  # authenticate as neo-oracle
+npm org create maw
+```
+
+If `maw` scope is already taken on npm, use `@maw-sdk` as fallback and update `name` in `package.json`.
+
+### 2. Set the NPM_TOKEN secret
+
+Generate a granular access token on npmjs.com (Automation type, scoped to `@maw/sdk`), then:
+
+```bash
+gh secret set NPM_TOKEN --repo Soul-Brews-Studio/maw-js
+# paste token at prompt
+```
+
+## Publishing a new version
+
+1. Update `version` in `packages/sdk/package.json`
+2. Commit: `git commit -m "sdk: bump to X.Y.Z"`
+3. Tag and push:
+   ```bash
+   git tag sdk-vX.Y.Z
+   git push origin sdk-vX.Y.Z
+   ```
+4. GitHub Actions workflow `publish-sdk.yml` triggers automatically.
+5. Verify: `npm view @maw/sdk`
+
+## Rollback / unpublish window
+
+npm allows unpublish within **72 hours** of publish:
+
+```bash
+npm unpublish @maw/sdk@X.Y.Z
+```
+
+After 72 hours, deprecate instead:
+
+```bash
+npm deprecate @maw/sdk@X.Y.Z "use X.Y.Z+1"
+```
+
+## Phase B graduation (see #340)
+
+Alpha releases (`1.0.0-alpha.*`) ship types-only. Phase B ships runtime + types together and promotes to a stable `1.0.0` release. See `DECISION-339.md` for rationale.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -26,6 +26,9 @@
       "default": "./plugin.ts"
     }
   },
+  "scripts": {
+    "prepublishOnly": "bun test packages/sdk/"
+  },
   "files": [
     "index.ts",
     "index.d.ts",


### PR DESCRIPTION
## Summary
Ships the GitHub Actions publish workflow and packaging docs for `@maw/sdk`; does **not** run `npm publish` itself.

## Problem (root cause)
`@maw/sdk` is the stable typed contract between maw-js core and plugin authors. The tarball has been publish-ready since alpha.26 (commit 36199c5), but no automated publish pipeline existed and the owner identity decision was unresolved. This PR adds the workflow triggered on `sdk-v*` tags, documents the one-time scope claim and secret setup, and records the owner identity decision — so the first publish is a single interactive `git tag + push` by @nazt, not a manual `npm publish` in a terminal.

What this PR adds: `.github/workflows/publish-sdk.yml` (tag-gated, provenance-enabled), `packages/sdk/PUBLISH.md` (one-time setup + rollback), `packages/sdk/DECISION-339.md` (owner rationale + graduation plan), and a `prepublishOnly` script in `packages/sdk/package.json`.

What this PR does NOT do: run `npm publish`, set the `NPM_TOKEN` secret, or create the `@maw` npm scope — those are intentional one-time manual steps documented in `PUBLISH.md`.

## Option space
- A: Ship types-only alpha.1 now (tarball ready)
- B: Wait for Phase B — ship runtime + types together
- C: Ship A now, graduate to stable at Phase B (this PR)

## Pick + justification
Option C + owner `neo-oracle`. Plugin authors get the stable typed API immediately via `1.0.0-alpha.1`, while the `-alpha` semver clearly signals pre-stable. Runtime ships in `1.0.0` at Phase B (#340) without breaking the existing types contract.

## Surface area
| File | Lines | Risk |
|---|---|---|
| `.github/workflows/publish-sdk.yml` | ~45 | Low (tag-gated) |
| `packages/sdk/PUBLISH.md` | ~45 | None |
| `packages/sdk/DECISION-339.md` | ~50 | None |
| `packages/sdk/package.json` | +4 | Low |

## Alternatives rejected
- A types-only without graduation path: no clear signal for when runtime arrives or how semver will evolve.
- B blocking on Phase B: delays ecosystem adoption by weeks with no benefit to current plugin authors.

## Open questions for @nazt
- [ ] Owner identity: `neo-oracle` default. Override? (laris-co / fresh soulbrews / ...)
- [ ] Scope `@maw` vs `maw-sdk` unscoped? (issue probe says @maw free — this PR assumes scoped)
- [ ] Is types-only alpha.1 the right opener? (vs 0.0.1 vs 1.0.0-next)

## Test plan
- [x] bun run test:all
- [ ] CI
- [ ] Workflow dry-run (via `act` or push/delete dummy tag)

Closes #339 (scope workflow). Unblocks #340 (Phase B runtime). Do not auto-merge.

Co-Authored-By: mawjs <noreply@soulbrews.studio>