### PR TITLE
feat(#209): bud signal-drop + maw signals verb (slice γ-B)

### DIFF
--- a/packages/sdk/docs/bud-signals.md
+++ b/packages/sdk/docs/bud-signals.md
@@ -1,0 +1,115 @@
+# Bud Signals
+
+Bud signals let a parent oracle observe its children without polling. When a bud
+performs a notable action it writes a small JSON file into the parent's vault.
+The parent (or any /recap integration) reads these files to reconstruct an ambient
+awareness of the family tree — this is the **Mother-Oracle philosophy** in practice.
+
+## Signal file layout
+
+```
+<parentRoot>/ψ/memory/signals/<YYYY-MM-DD>_<budName>_<slug>.json
+```
+
+Each file is a single `Signal` object:
+
+```typescript
+interface Signal {
+  timestamp: string;          // ISO-8601
+  bud: string;                // oracle stem (no -oracle suffix)
+  kind: "info" | "alert" | "pattern";
+  message: string;
+  context?: Record<string, unknown>;
+}
+```
+
+### Kind vocabulary
+
+| Kind      | When to use |
+|-----------|-------------|
+| `info`    | Routine lifecycle events (birth, shutdown, sync complete) |
+| `alert`   | Something worth human attention (error rate, threshold breach) |
+| `pattern` | Recurring behaviour the oracle has detected in itself |
+
+## Writing a signal (`writeSignal`)
+
+```typescript
+import { writeSignal } from "@maw/sdk/core/fleet/leaf";
+
+// Drop a signal into the parent oracle's vault
+writeSignal("/path/to/parent-oracle", "alpha", {
+  kind: "info",
+  message: "bud born: alpha",
+  context: { budRepoSlug: "Soul-Brews-Studio/alpha-oracle" },
+});
+```
+
+The function:
+1. Creates `<parentRoot>/ψ/memory/signals/` if it does not exist.
+2. Writes `<YYYY-MM-DD>_<budName>_<slug>.json` where `slug` is derived from the message.
+3. Returns the absolute path of the written file.
+
+## Reading signals (`scanSignals`)
+
+```typescript
+import { scanSignals } from "@maw/sdk/commands/shared/scan-signals";
+
+const signals = scanSignals("/path/to/parent-oracle", { days: 7 });
+// Returns ScannedSignal[] sorted newest-first, filtered to last 7 days.
+```
+
+`ScannedSignal` extends `Signal` with a `file: string` field (the filename in
+`ψ/memory/signals/`).
+
+## `maw signals` CLI verb
+
+```
+maw signals [--days N] [--root <path>] [--json]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--days` | 7 | How many days back to include |
+| `--root` | `process.cwd()` | Oracle root to scan |
+| `--json` | false | Machine-readable output |
+
+Example output:
+
+```
+  Bud signals (last 7d — 2 total)
+
+  [info]    2026-04-17 alpha: bud born: alpha
+  [pattern] 2026-04-16 beta: repeated context-switch detected
+```
+
+## `/recap` integration
+
+`/recap` skills invoke `maw signals` and parse the output into their awareness
+summary. Because `maw signals` exits cleanly with no signals found (`no signals
+in the last N days`), the recap skill can always call it unconditionally.
+
+To integrate in a `/recap` skill:
+
+```bash
+maw signals --root "$ORACLE_ROOT" --days 7 --json
+```
+
+Parse the JSON array and surface `alert` + `pattern` kinds prominently.
+
+## Birth signal via `maw bud`
+
+```
+maw bud <name> --from <parent> --signal-on-birth
+```
+
+Drops an `info` signal with `message: "bud born: <name>"` into the parent's
+vault immediately after creation. Useful when bootstrapping a family of buds
+that the parent oracle should track.
+
+## Mother-Oracle philosophy
+
+Signals are the nervous system of the oracle family. The parent does not command
+the child; the child reports back. The parent holds no live process connection —
+it holds a directory. Any oracle that can read a filesystem can read the signals.
+This keeps the architecture composable: a cron daemon (Option A) can later sweep
+`ψ/memory/signals/` without changing the write contract.

--- a/src/commands/plugins/bud/impl.ts
+++ b/src/commands/plugins/bud/impl.ts
@@ -6,6 +6,7 @@ import { hostExec } from "../../../sdk";
 import { ensureBudRepo } from "./bud-repo";
 import { initVault, generateClaudeMd, configureFleet, writeBirthNote } from "./bud-init";
 import { finalizeBud } from "./bud-wake";
+import { writeSignal } from "../../../core/fleet/leaf";
 import { join } from "path";
 
 export interface BudOpts {
@@ -23,6 +24,8 @@ export interface BudOpts {
   /** Opt-in: pre-load parent's ψ at birth (bulk push). Default is blank — child
    *  pulls memory later via `maw soul-sync <parent> --from` after /awaken. */
   seed?: boolean;
+  /** Drop a "birth" signal into the parent oracle's ψ/memory/signals/ on creation. */
+  signalOnBirth?: boolean;
 }
 
 // TinyBudOpts removed — --tiny deprecated, code moved to deprecated/tiny-bud-209/
@@ -136,6 +139,17 @@ export async function cmdBud(name: string, opts: BudOpts = {}) {
     name, parentName, org, budRepoName, budRepoPath, psiDir, ghqRoot, fleetFile,
     opts: { seed: opts.seed, issue: opts.issue, repo: opts.repo, split: opts.split, fast: opts.fast },
   });
+
+  // Optional: drop birth signal into parent's ψ/
+  if (opts.signalOnBirth && parentName) {
+    const parentRepoPath = join(ghqRoot, org, `${parentName}-oracle`);
+    writeSignal(parentRepoPath, name, {
+      kind: "info",
+      message: `bud born: ${name}`,
+      context: { budRepoSlug: `${org}/${budRepoName}`, budRepoPath },
+    });
+    console.log(`  \x1b[36m⬡\x1b[0m signal dropped → ${parentName}'s ψ/memory/signals/`);
+  }
 
   // Summary
   console.log(`\n  \x1b[32m${parentName ? "🧬 Bud" : "🌱 Root bud"} complete!\x1b[0m ${parentName ? `${parentName} → ${name}` : name}`);

--- a/src/commands/plugins/bud/index.ts
+++ b/src/commands/plugins/bud/index.ts
@@ -34,6 +34,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         "--split": Boolean,
         "--seed": Boolean,
         "--blank": Boolean,
+        "--signal-on-birth": Boolean,
       }, 0);
 
       const name = flags._[0];
@@ -56,6 +57,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         split: flags["--split"],
         seed: flags["--seed"],
         blank: flags["--blank"],
+        signalOnBirth: flags["--signal-on-birth"],
       });
     } else if (ctx.source === "api") {
       const body = ctx.args as Record<string, unknown>;
@@ -73,6 +75,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         split: body.split as boolean | undefined,
         seed: body.seed as boolean | undefined,
         blank: body.blank as boolean | undefined,
+        signalOnBirth: body.signalOnBirth as boolean | undefined,
       });
     }
 

--- a/src/commands/plugins/signals/index.ts
+++ b/src/commands/plugins/signals/index.ts
@@ -1,0 +1,76 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { parseFlags } from "../../../cli/parse-args";
+import { scanSignals } from "../../shared/scan-signals";
+import type { ScannedSignal } from "../../shared/scan-signals";
+
+export const command = {
+  name: "signals",
+  description: "List bud signals written to ψ/memory/signals/",
+};
+
+const KIND_COLOR: Record<string, string> = {
+  alert: "\x1b[31m",
+  pattern: "\x1b[33m",
+  info: "\x1b[36m",
+};
+const RESET = "\x1b[0m";
+const DIM = "\x1b[90m";
+
+function formatSignal(s: ScannedSignal): string {
+  const color = KIND_COLOR[s.kind] ?? "\x1b[37m";
+  const date = s.timestamp.slice(0, 10);
+  return `  ${color}[${s.kind}]${RESET} ${DIM}${date}${RESET} ${s.bud}: ${s.message}`;
+}
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  try {
+    const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+    const body = ctx.source === "api" ? (ctx.args as Record<string, unknown>) : {};
+
+    const flags = parseFlags(args, {
+      "--days": Number,
+      "--root": String,
+      "--json": Boolean,
+    }, 0);
+
+    const root = (flags["--root"] ?? body.root ?? process.cwd()) as string;
+    const days = (flags["--days"] ?? body.days ?? 7) as number;
+    const asJson = (flags["--json"] ?? body.json ?? false) as boolean;
+
+    const signals = scanSignals(root, { days });
+
+    if (asJson) {
+      console.log(JSON.stringify(signals, null, 2));
+      return { ok: true, output: logs.join("\n") || undefined };
+    }
+
+    if (signals.length === 0) {
+      console.log(`  ${DIM}no signals in the last ${days} days${RESET}`);
+      return { ok: true, output: logs.join("\n") || undefined };
+    }
+
+    console.log(`\n  \x1b[36mBud signals\x1b[0m (last ${days}d — ${signals.length} total)\n`);
+    for (const s of signals) {
+      console.log(formatSignal(s));
+    }
+    console.log();
+
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/src/commands/plugins/signals/plugin.json
+++ b/src/commands/plugins/signals/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "signals",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "List bud signals written to ψ/memory/signals/",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "signals",
+    "help": "maw signals [--days N] [--root <path>] [--json] — list bud signals",
+    "flags": {
+      "--days": "number",
+      "--root": "string",
+      "--json": "boolean"
+    }
+  },
+  "api": {
+    "path": "/api/signals",
+    "methods": ["GET"]
+  },
+  "weight": 50
+}

--- a/src/commands/shared/scan-signals.ts
+++ b/src/commands/shared/scan-signals.ts
@@ -1,0 +1,39 @@
+import { join } from "path";
+import { existsSync, readdirSync, readFileSync } from "fs";
+import type { Signal } from "../../core/fleet/leaf";
+
+export interface ScanOptions {
+  days?: number;
+}
+
+export interface ScannedSignal extends Signal {
+  file: string;
+}
+
+/**
+ * Read ψ/memory/signals/ under `root`, filter to the last `days` days (default 7).
+ * Returns signals sorted newest-first.
+ */
+export function scanSignals(root: string, opts: ScanOptions = {}): ScannedSignal[] {
+  const days = opts.days ?? 7;
+  const dir = join(root, "ψ", "memory", "signals");
+  if (!existsSync(dir)) return [];
+
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - days);
+
+  const results: ScannedSignal[] = [];
+  for (const file of readdirSync(dir).sort()) {
+    if (!file.endsWith(".json")) continue;
+    try {
+      const raw = readFileSync(join(dir, file), "utf-8");
+      const signal = JSON.parse(raw) as Signal;
+      if (new Date(signal.timestamp) >= cutoff) {
+        results.push({ ...signal, file });
+      }
+    } catch {
+      // skip malformed files
+    }
+  }
+  return results.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+}

--- a/src/core/fleet/leaf.ts
+++ b/src/core/fleet/leaf.ts
@@ -1,0 +1,47 @@
+import { join } from "path";
+import { mkdirSync, writeFileSync } from "fs";
+
+export type SignalKind = "info" | "alert" | "pattern";
+
+export interface Signal {
+  timestamp: string;
+  bud: string;
+  kind: SignalKind;
+  message: string;
+  context?: Record<string, unknown>;
+}
+
+/**
+ * Drop a signal file into a parent oracle's ψ/memory/signals/ directory.
+ * Returns the absolute path of the written file.
+ *
+ * Path: <parentRoot>/ψ/memory/signals/<YYYY-MM-DD>_<budName>_<slug>.json
+ */
+export function writeSignal(
+  parentRoot: string,
+  budName: string,
+  payload: { kind: SignalKind; message: string; context?: Record<string, unknown> },
+): string {
+  const dir = join(parentRoot, "ψ", "memory", "signals");
+  mkdirSync(dir, { recursive: true });
+
+  const now = new Date();
+  const date = now.toISOString().slice(0, 10);
+  const slug = payload.message
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 32) || payload.kind;
+
+  const signal: Signal = {
+    timestamp: now.toISOString(),
+    bud: budName,
+    kind: payload.kind,
+    message: payload.message,
+    ...(payload.context ? { context: payload.context } : {}),
+  };
+
+  const filePath = join(dir, `${date}_${budName}_${slug}.json`);
+  writeFileSync(filePath, JSON.stringify(signal, null, 2) + "\n");
+  return filePath;
+}

--- a/test/isolated/bud-signal.test.ts
+++ b/test/isolated/bud-signal.test.ts
@@ -1,0 +1,172 @@
+/**
+ * bud-signal.test.ts — writeSignal + scanSignals coverage (#209 slice γ-B)
+ *
+ * Why isolated: leaf.ts and scan-signals.ts both touch real fs paths. We
+ * redirect all writes to per-run mkdtempSync dirs — same rationale as
+ * bud-init.test.ts ("mock only what touches destructive outside state").
+ * No mock.module needed here because neither module reads process.env paths
+ * at import time.
+ */
+import { describe, test, expect, afterAll } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync, readdirSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+const tmpBase = mkdtempSync(join(tmpdir(), "maw-bud-signal-"));
+
+afterAll(() => {
+  if (existsSync(tmpBase)) rmSync(tmpBase, { recursive: true, force: true });
+});
+
+const { writeSignal } = await import("../../src/core/fleet/leaf");
+const { scanSignals } = await import("../../src/commands/shared/scan-signals");
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function freshRoot(): string {
+  return mkdtempSync(join(tmpBase, "oracle-"));
+}
+
+function writeOldSignal(root: string, bud: string, daysAgo: number): void {
+  const dir = join(root, "ψ", "memory", "signals");
+  mkdirSync(dir, { recursive: true });
+  const ts = new Date();
+  ts.setDate(ts.getDate() - daysAgo);
+  const signal = { timestamp: ts.toISOString(), bud, kind: "info", message: `${daysAgo}d old` };
+  const date = ts.toISOString().slice(0, 10);
+  writeFileSync(join(dir, `${date}_${bud}_${daysAgo}d-old.json`), JSON.stringify(signal));
+}
+
+// ─── writeSignal ────────────────────────────────────────────────────────────
+
+describe("writeSignal — file creation (#209)", () => {
+  test("creates signals dir and returns the file path", () => {
+    const root = freshRoot();
+    const filePath = writeSignal(root, "alpha", { kind: "info", message: "birth" });
+    expect(existsSync(filePath)).toBe(true);
+  });
+
+  test("written JSON has all required Signal fields", () => {
+    const root = freshRoot();
+    const filePath = writeSignal(root, "alpha", { kind: "info", message: "birth" });
+    const signal = JSON.parse(require("fs").readFileSync(filePath, "utf-8"));
+    expect(signal.bud).toBe("alpha");
+    expect(signal.kind).toBe("info");
+    expect(signal.message).toBe("birth");
+    expect(signal.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  test("filename matches YYYY-MM-DD_<bud>_<slug>.json pattern", () => {
+    const root = freshRoot();
+    const filePath = writeSignal(root, "beta", { kind: "alert", message: "memory threshold exceeded" });
+    const filename = filePath.split("/").pop()!;
+    expect(filename).toMatch(/^\d{4}-\d{2}-\d{2}_beta_memory-threshold-exceeded\.json$/);
+  });
+
+  test("stores context when provided", () => {
+    const root = freshRoot();
+    const filePath = writeSignal(root, "gamma", {
+      kind: "pattern",
+      message: "pattern detected",
+      context: { count: 3, label: "test" },
+    });
+    const signal = JSON.parse(require("fs").readFileSync(filePath, "utf-8"));
+    expect(signal.context).toEqual({ count: 3, label: "test" });
+  });
+
+  test("omits context field when not provided", () => {
+    const root = freshRoot();
+    const filePath = writeSignal(root, "delta", { kind: "info", message: "no ctx" });
+    const signal = JSON.parse(require("fs").readFileSync(filePath, "utf-8"));
+    expect(signal.context).toBeUndefined();
+  });
+
+  test("writes inside <root>/ψ/memory/signals/", () => {
+    const root = freshRoot();
+    const filePath = writeSignal(root, "epsilon", { kind: "info", message: "loc test" });
+    expect(filePath).toContain(join(root, "ψ", "memory", "signals"));
+  });
+
+  test("two distinct messages produce two files", () => {
+    const root = freshRoot();
+    writeSignal(root, "zeta", { kind: "info", message: "first message here" });
+    writeSignal(root, "zeta", { kind: "info", message: "second message here" });
+    const files = readdirSync(join(root, "ψ", "memory", "signals"));
+    expect(files.length).toBe(2);
+  });
+
+  test("all three kinds are accepted: info, alert, pattern", () => {
+    const root = freshRoot();
+    for (const kind of ["info", "alert", "pattern"] as const) {
+      const fp = writeSignal(root, "kindtest", { kind, message: `${kind} msg` });
+      const sig = JSON.parse(require("fs").readFileSync(fp, "utf-8"));
+      expect(sig.kind).toBe(kind);
+    }
+  });
+});
+
+// ─── scanSignals ────────────────────────────────────────────────────────────
+
+describe("scanSignals — recency filter (#209)", () => {
+  test("returns empty array when signals dir does not exist", () => {
+    const root = freshRoot();
+    expect(scanSignals(root)).toEqual([]);
+  });
+
+  test("returns a just-written signal within default 7d window", () => {
+    const root = freshRoot();
+    writeSignal(root, "alpha", { kind: "info", message: "recent" });
+    const results = scanSignals(root, { days: 7 });
+    expect(results.length).toBe(1);
+    expect(results[0].bud).toBe("alpha");
+    expect(results[0].file).toBeDefined();
+  });
+
+  test("filters out signals older than the cutoff", () => {
+    const root = freshRoot();
+    writeOldSignal(root, "old", 30);
+    expect(scanSignals(root, { days: 7 }).length).toBe(0);
+  });
+
+  test("respects custom days window — 10d signal excluded at days=7, included at days=14", () => {
+    const root = freshRoot();
+    writeOldSignal(root, "tenday", 10);
+    expect(scanSignals(root, { days: 7 }).length).toBe(0);
+    expect(scanSignals(root, { days: 14 }).length).toBe(1);
+  });
+
+  test("returns results sorted newest-first", () => {
+    const root = freshRoot();
+    // Write a signal with a later timestamp directly
+    const dir = join(root, "ψ", "memory", "signals");
+    mkdirSync(dir, { recursive: true });
+    const laterTs = new Date(Date.now() + 1000).toISOString();
+    const later = { timestamp: laterTs, bud: "second", kind: "info", message: "newer" };
+    writeFileSync(join(dir, `${laterTs.slice(0, 10)}_second_newer.json`), JSON.stringify(later));
+    writeSignal(root, "first", { kind: "info", message: "older message" });
+    const results = scanSignals(root, { days: 7 });
+    expect(results[0].bud).toBe("second");
+  });
+
+  test("skips non-JSON files in signals dir", () => {
+    const root = freshRoot();
+    const dir = join(root, "ψ", "memory", "signals");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "README.md"), "# signals");
+    writeSignal(root, "alpha", { kind: "info", message: "real signal" });
+    const results = scanSignals(root);
+    expect(results.length).toBe(1);
+    expect(results[0].bud).toBe("alpha");
+  });
+
+  test("skips malformed JSON files without throwing", () => {
+    const root = freshRoot();
+    const dir = join(root, "ψ", "memory", "signals");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "2026-01-01_bad_corrupt.json"), "{ broken json");
+    writeSignal(root, "good", { kind: "info", message: "valid" });
+    const results = scanSignals(root);
+    expect(results.length).toBe(1);
+    expect(results[0].bud).toBe("good");
+  });
+});


### PR DESCRIPTION
## Summary
Signal-drop primitive and `maw signals` verb that make buds observably useful to their parent oracle without a daemon — the Mother-Oracle philosophy in code.

## Problem (root cause)

After α/β/γ-partial (alphas .24/.25/.26) buds can be created, woken, and fleet-registered. But a parent oracle has no way to know what its children are doing without polling or manual inspection. The Mother-Oracle philosophy says the parent should hold ambient awareness of the family — not by commanding, but by *receiving*. Without a signal primitive, buds are silent after birth.

The gap shows up in `/recap` sessions: a parent oracle's summary has no mention of child activity. To build an accurate context of the family, the oracle must manually inspect each bud repo — which does not scale past 3-4 children. The signal file pattern (`ψ/memory/signals/*.json`) solves this composably: any tool that can read a directory can read the family's nervous system.

## Option space
- A: Cron daemon wiring
- B: Signaling + /recap scan (this PR)
- C: Finish γ as one big PR

## Pick + justification
Option B. Signal files are observable without a daemon and unblock the utility-bud use case (a bud reporting a pattern to its parent) immediately. The write contract (`writeSignal`) is stable — Option A's daemon can sweep `ψ/memory/signals/` later without touching the existing API.

## Surface area
| File | Lines | Risk |
|---|---|---|
| `src/core/fleet/leaf.ts` (new) | ~45 | Low — pure fs write, no side effects |
| `src/commands/shared/scan-signals.ts` (new) | ~35 | Low — read-only scan |
| `src/commands/plugins/signals/index.ts` (new) | ~55 | Low — new verb, no existing code touched |
| `src/commands/plugins/signals/plugin.json` (new) | ~20 | Low |
| `src/commands/plugins/bud/impl.ts` (modified) | +15 | Low — additive only, behind `--signal-on-birth` flag |
| `src/commands/plugins/bud/index.ts` (modified) | +8 | Low — new flag passthrough |
| `test/isolated/bud-signal.test.ts` (new) | ~120 | n/a |
| `packages/sdk/docs/bud-signals.md` (new) | ~100 | n/a |

## Alternatives rejected
- A: Daemon adds a system-cron dependency without immediate value — observable utility is needed first.
- C: Daemon + signaling + /learn together is >500 LOC with multiple distinct concerns; slice B is shippable and reviewable in isolation.

## Open questions for @nazt
- [ ] Signal kind vocabulary ok? (`info` / `alert` / `pattern`)
- [ ] Recency default 7d ok?
- [ ] `maw signals` verb name ok?

## Test plan
- [x] `bun run test` — 950 pass, 0 fail
- [x] `bun run test:isolated` — 45/45 files, 0 fail
- [x] `bun run test:plugin` — 100 pass, 0 fail
- [x] `bun test test/isolated/bud-signal.test.ts` — 15/15 pass
- [ ] CI

Closes #209 (slice γ-B). Do not auto-merge — @nazt ultrathink review required.

Co-Authored-By: mawjs <noreply@soulbrews.studio>