### PR TITLE
feat(oracle): prune + register verbs (#383)

### DIFF
--- a/src/commands/plugins/oracle/impl-prune.ts
+++ b/src/commands/plugins/oracle/impl-prune.ts
@@ -1,0 +1,237 @@
+/**
+ * maw oracle prune — dry-run by default; retires stale/orphan entries from
+ * the oracle registry (oracles.json).
+ *
+ * Decision criteria (without --stale):
+ *   Candidate = no positive signals: empty lineage AND no tmux AND no federation
+ *
+ * With --stale:
+ *   Candidate = STALE or DEAD tier from the alpha.112 classifier (#392)
+ *
+ * Safety: --force is required to retire entries. Default is always dry-run.
+ * "Nothing is Deleted" — retired entries move to retired[] in registry JSON,
+ * not deleted. The entry is preserved with a retired_at timestamp.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+import { CONFIG_DIR, listSessions } from "../../../sdk";
+import { runStaleScan, type StaleEntry } from "./impl-stale";
+import type { OracleEntry } from "../../../sdk";
+import { createInterface } from "readline";
+
+const CACHE_FILE = join(CONFIG_DIR, "oracles.json");
+
+export interface PruneOpts {
+  stale?: boolean;
+  force?: boolean;
+  json?: boolean;
+}
+
+export interface PruneCandidate {
+  entry: OracleEntry;
+  reasons: string[];
+  tier?: string;
+}
+
+export interface RetiredEntry extends OracleEntry {
+  retired_at: string;
+  retired_reasons: string[];
+}
+
+// ─── Pure helpers ─────────────────────────────────────────────────────────────
+
+function emptyLineage(e: OracleEntry): boolean {
+  return !e.has_psi && !e.has_fleet_config && !e.budded_from;
+}
+
+export function buildPruneCandidates(
+  entries: OracleEntry[],
+  awakeSet: Set<string>,
+): PruneCandidate[] {
+  return entries
+    .map((entry) => {
+      const awake = awakeSet.has(entry.name);
+      const reasons: string[] = [];
+      if (emptyLineage(entry)) reasons.push("empty lineage");
+      if (!entry.local_path) reasons.push("not cloned");
+      if (!awake) reasons.push("no tmux");
+      if (!entry.federation_node) reasons.push("no federation");
+      // Candidate only if all positive signals are absent
+      const isCandidate = emptyLineage(entry) && !awake && !entry.federation_node;
+      return isCandidate ? { entry, reasons } : null;
+    })
+    .filter((x): x is PruneCandidate => x !== null);
+}
+
+export function buildStaleCandidates(staleEntries: StaleEntry[]): PruneCandidate[] {
+  return staleEntries
+    .filter((e) => e.tier === "STALE" || e.tier === "DEAD")
+    .map((e) => ({
+      entry: {
+        org: e.org,
+        repo: e.repo,
+        name: e.name,
+        local_path: e.local_path,
+        has_psi: e.has_psi,
+        has_fleet_config: false,
+        budded_from: null,
+        budded_at: null,
+        federation_node: null,
+        detected_at: "",
+      } as OracleEntry,
+      reasons: [
+        e.tier === "DEAD" ? "DEAD (>90d)" : "STALE (30-90d)",
+        e.recommendation,
+        ...(!e.awake ? ["no tmux"] : []),
+      ],
+      tier: e.tier,
+    }));
+}
+
+// ─── Raw registry I/O ─────────────────────────────────────────────────────────
+
+function readRaw(file: string): Record<string, unknown> {
+  try {
+    if (existsSync(file)) return JSON.parse(readFileSync(file, "utf-8"));
+  } catch { /* fall through */ }
+  return {};
+}
+
+function writeRaw(file: string, data: Record<string, unknown>): void {
+  writeFileSync(file, JSON.stringify(data, null, 2) + "\n", "utf-8");
+}
+
+// ─── Driver ───────────────────────────────────────────────────────────────────
+
+export async function runPrune(
+  opts: PruneOpts = {},
+  deps: {
+    readEntries?: () => OracleEntry[];
+    listAwake?: () => Promise<Set<string>>;
+    runStale?: typeof runStaleScan;
+    promptConfirm?: (msg: string) => Promise<boolean>;
+    readRawCache?: () => Record<string, unknown>;
+    writeRawCache?: (data: Record<string, unknown>) => void;
+    now?: () => Date;
+  } = {},
+): Promise<PruneCandidate[]> {
+  const readRawCache = deps.readRawCache ?? (() => readRaw(CACHE_FILE));
+  const writeRawCache = deps.writeRawCache ?? ((data) => writeRaw(CACHE_FILE, data));
+
+  const rawCache = readRawCache();
+  const entries: OracleEntry[] = (rawCache.oracles as OracleEntry[] | undefined) ?? [];
+
+  let candidates: PruneCandidate[];
+
+  if (opts.stale) {
+    const staleRun = deps.runStale ?? runStaleScan;
+    const staleEntries = await staleRun({ all: false }, {
+      readEntries: deps.readEntries ? () => deps.readEntries!() : undefined,
+      listAwake: deps.listAwake,
+      now: deps.now,
+    });
+    candidates = buildStaleCandidates(staleEntries);
+  } else {
+    const listAwake = deps.listAwake ?? (async () => {
+      const sessions = await listSessions().catch(() => []);
+      const awake = new Set<string>();
+      for (const s of sessions) {
+        for (const w of s.windows) {
+          if (w.name.endsWith("-oracle")) awake.add(w.name.replace(/-oracle$/, ""));
+        }
+      }
+      return awake;
+    });
+    const awakeSet = await listAwake();
+    candidates = buildPruneCandidates(entries, awakeSet);
+  }
+
+  return candidates;
+}
+
+export async function cmdOraclePrune(
+  opts: PruneOpts = {},
+  deps: {
+    readEntries?: () => OracleEntry[];
+    listAwake?: () => Promise<Set<string>>;
+    runStale?: typeof runStaleScan;
+    promptConfirm?: (msg: string) => Promise<boolean>;
+    readRawCache?: () => Record<string, unknown>;
+    writeRawCache?: (data: Record<string, unknown>) => void;
+    now?: () => Date;
+  } = {},
+): Promise<void> {
+  const readRawCache = deps.readRawCache ?? (() => readRaw(CACHE_FILE));
+  const writeRawCache = deps.writeRawCache ?? ((data) => writeRaw(CACHE_FILE, data));
+
+  const candidates = await runPrune(opts, deps);
+
+  if (opts.json) {
+    console.log(JSON.stringify({ schema: 1, count: candidates.length, dry_run: !opts.force, candidates }, null, 2));
+    return;
+  }
+
+  if (candidates.length === 0) {
+    console.log(`\n  \x1b[32m✓\x1b[0m No prune candidates — registry is clean.\n`);
+    return;
+  }
+
+  const dryTag = opts.force ? "" : "  \x1b[90m[dry-run — use --force to retire]\x1b[0m";
+  console.log(`\n  \x1b[36mPrune candidates\x1b[0m (${candidates.length})${dryTag}\n`);
+
+  for (const c of candidates) {
+    const tier = c.tier ? `\x1b[${c.tier === "DEAD" ? 31 : 33}m${c.tier.padEnd(6)}\x1b[0m` : "      ";
+    const why = c.reasons.join(", ");
+    console.log(`  ${tier}  ${c.entry.name.padEnd(24)} \x1b[90m${why}\x1b[0m`);
+  }
+
+  if (!opts.force) {
+    console.log(`\n  Run with \x1b[36m--force\x1b[0m to retire these entries (moves to retired[] — reversible).\n`);
+    return;
+  }
+
+  // --force: prompt for confirmation, then retire
+  const promptConfirm = deps.promptConfirm ?? defaultPromptConfirm;
+  const confirmed = await promptConfirm(
+    `\n  Retire ${candidates.length} oracle(s)? This moves them to retired[] in the registry (reversible).`,
+  );
+
+  if (!confirmed) {
+    console.log(`  \x1b[33mAborted.\x1b[0m\n`);
+    return;
+  }
+
+  const retiredNames = new Set(candidates.map((c) => c.entry.name));
+  const rawCache = readRawCache();
+  const oracles: OracleEntry[] = (rawCache.oracles as OracleEntry[] | undefined) ?? [];
+  const existingRetired: RetiredEntry[] = (rawCache.retired as RetiredEntry[] | undefined) ?? [];
+  const now = new Date().toISOString();
+
+  const toRetire: RetiredEntry[] = candidates.map((c) => ({
+    ...c.entry,
+    retired_at: now,
+    retired_reasons: c.reasons,
+  }));
+
+  rawCache.oracles = oracles.filter((e) => !retiredNames.has(e.name));
+  rawCache.retired = [...existingRetired, ...toRetire];
+
+  writeRawCache(rawCache);
+
+  console.log(`\n  \x1b[32m✓\x1b[0m Retired ${toRetire.length} oracle(s) → retired[] in registry.\n`);
+  for (const r of toRetire) {
+    console.log(`    \x1b[90m→ ${r.name}\x1b[0m`);
+  }
+  console.log();
+}
+
+async function defaultPromptConfirm(msg: string): Promise<boolean> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(`${msg} [y/N] `, (answer) => {
+      rl.close();
+      resolve(answer.trim().toLowerCase() === "y");
+    });
+  });
+}

--- a/src/commands/plugins/oracle/impl-register.ts
+++ b/src/commands/plugins/oracle/impl-register.ts
@@ -1,0 +1,223 @@
+/**
+ * maw oracle register <name> — adopt a discovered oracle into the registry.
+ *
+ * Source priority: fleet config > tmux session > local filesystem.
+ *
+ * Errors:
+ *   - Collision: name already in oracles[] → "already registered"
+ *   - Missing: not found in any source → "oracle not found"
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from "fs";
+import { join } from "path";
+import { CONFIG_DIR, FLEET_DIR, listSessions, loadConfig } from "../../../sdk";
+import type { OracleEntry } from "../../../sdk";
+
+const CACHE_FILE = join(CONFIG_DIR, "oracles.json");
+
+export interface RegisterOpts {
+  json?: boolean;
+}
+
+// ─── Discovery sources ────────────────────────────────────────────────────────
+
+export interface DiscoveredOracle {
+  source: "fleet" | "tmux" | "filesystem";
+  entry: OracleEntry;
+}
+
+export function findInFleet(
+  name: string,
+  fleetDir: string = FLEET_DIR,
+): DiscoveredOracle | null {
+  try {
+    for (const file of readdirSync(fleetDir).filter((f) => f.endsWith(".json"))) {
+      let config: any;
+      try {
+        config = JSON.parse(readFileSync(join(fleetDir, file), "utf-8"));
+      } catch { continue; }
+
+      const windows: any[] = config.windows || [];
+      const hasThis = windows.some(
+        (w) => w.name === `${name}-oracle` || w.name === name,
+      );
+      if (!hasThis) continue;
+
+      // Derive repo from fleet file or windows
+      const repos: string[] = config.project_repos || [];
+      const repoFull = repos.find((r) => r.endsWith(`/${name}-oracle`) || r.endsWith(`/${name}`));
+      const parts = repoFull ? repoFull.split("/") : [];
+      const org = parts[0] || "(unknown)";
+      const repo = parts[1] || `${name}-oracle`;
+      const now = new Date().toISOString();
+
+      return {
+        source: "fleet",
+        entry: {
+          org,
+          repo,
+          name,
+          local_path: "",
+          has_psi: false,
+          has_fleet_config: true,
+          budded_from: config.budded_from || null,
+          budded_at: config.budded_at || null,
+          federation_node: null,
+          detected_at: now,
+        },
+      };
+    }
+  } catch { /* fleet dir may not exist */ }
+  return null;
+}
+
+export async function findInTmux(
+  name: string,
+  listSessionsFn: typeof listSessions = listSessions,
+): Promise<DiscoveredOracle | null> {
+  try {
+    const sessions = await listSessionsFn();
+    for (const s of sessions) {
+      for (const w of s.windows) {
+        if (w.name === `${name}-oracle` || w.name === name) {
+          const now = new Date().toISOString();
+          return {
+            source: "tmux",
+            entry: {
+              org: "(unregistered)",
+              repo: `${name}-oracle`,
+              name,
+              local_path: "",
+              has_psi: false,
+              has_fleet_config: false,
+              budded_from: null,
+              budded_at: null,
+              federation_node: null,
+              detected_at: now,
+            },
+          };
+        }
+      }
+    }
+  } catch { /* tmux not running */ }
+  return null;
+}
+
+export function findInFilesystem(
+  name: string,
+  ghqRoot: string,
+): DiscoveredOracle | null {
+  try {
+    for (const org of readdirSync(ghqRoot)) {
+      const orgPath = join(ghqRoot, org);
+      try {
+        if (!statSync(orgPath).isDirectory()) continue;
+      } catch { continue; }
+
+      for (const candidate of [`${name}-oracle`, name]) {
+        const repoPath = join(orgPath, candidate);
+        try {
+          if (!statSync(repoPath).isDirectory()) continue;
+        } catch { continue; }
+
+        const hasPsi = existsSync(join(repoPath, "ψ"));
+        const now = new Date().toISOString();
+        return {
+          source: "filesystem",
+          entry: {
+            org,
+            repo: candidate,
+            name,
+            local_path: repoPath,
+            has_psi: hasPsi,
+            has_fleet_config: false,
+            budded_from: null,
+            budded_at: null,
+            federation_node: null,
+            detected_at: now,
+          },
+        };
+      }
+    }
+  } catch { /* ghq root may not exist */ }
+  return null;
+}
+
+// ─── Raw registry I/O ─────────────────────────────────────────────────────────
+
+function readRaw(file: string): Record<string, unknown> {
+  try {
+    if (existsSync(file)) return JSON.parse(readFileSync(file, "utf-8"));
+  } catch { /* fall through */ }
+  return {};
+}
+
+function writeRaw(file: string, data: Record<string, unknown>): void {
+  writeFileSync(file, JSON.stringify(data, null, 2) + "\n", "utf-8");
+}
+
+// ─── Driver ───────────────────────────────────────────────────────────────────
+
+export async function cmdOracleRegister(
+  name: string,
+  opts: RegisterOpts = {},
+  deps: {
+    readRawCache?: () => Record<string, unknown>;
+    writeRawCache?: (data: Record<string, unknown>) => void;
+    findInFleetFn?: (name: string) => DiscoveredOracle | null;
+    findInTmuxFn?: (name: string) => Promise<DiscoveredOracle | null>;
+    findInFilesystemFn?: (name: string) => DiscoveredOracle | null;
+  } = {},
+): Promise<void> {
+  if (!name) throw new Error("register requires a name: maw oracle register <name>");
+
+  const readRawCache = deps.readRawCache ?? (() => readRaw(CACHE_FILE));
+  const writeRawCache = deps.writeRawCache ?? ((data) => writeRaw(CACHE_FILE, data));
+
+  const rawCache = readRawCache();
+  const oracles: OracleEntry[] = (rawCache.oracles as OracleEntry[] | undefined) ?? [];
+
+  // Collision check
+  const existing = oracles.find((e) => e.name === name);
+  if (existing) {
+    throw new Error(`oracle '${name}' is already registered (org: ${existing.org})`);
+  }
+
+  // Discovery — fleet > tmux > filesystem
+  const config = loadConfig();
+  const ghqRoot = config.ghqRoot ?? "";
+
+  const fleetFn = deps.findInFleetFn ?? findInFleet;
+  const tmuxFn = deps.findInTmuxFn ?? findInTmux;
+  const fsFn = deps.findInFilesystemFn ?? ((n) => findInFilesystem(n, ghqRoot));
+
+  const discovered =
+    fleetFn(name) ??
+    (await tmuxFn(name)) ??
+    fsFn(name);
+
+  if (!discovered) {
+    throw new Error(
+      `oracle '${name}' not found in fleet, tmux, or filesystem — try: maw oracle scan`,
+    );
+  }
+
+  // Add to registry
+  oracles.push(discovered.entry);
+  rawCache.oracles = oracles;
+  writeRawCache(rawCache);
+
+  if (opts.json) {
+    console.log(JSON.stringify({ schema: 1, registered: discovered.entry, source: discovered.source }, null, 2));
+    return;
+  }
+
+  console.log(`\n  \x1b[32m✓\x1b[0m Registered \x1b[36m${name}\x1b[0m`);
+  console.log(`  Source:  ${discovered.source}`);
+  console.log(`  Org:     ${discovered.entry.org}`);
+  console.log(`  Repo:    ${discovered.entry.repo}`);
+  if (discovered.entry.local_path) {
+    console.log(`  Path:    ${discovered.entry.local_path}`);
+  }
+  console.log();
+}

--- a/src/commands/plugins/oracle/impl.ts
+++ b/src/commands/plugins/oracle/impl.ts
@@ -4,3 +4,5 @@ export { cmdOracleAbout } from "./impl-about";
 export { cmdOracleList } from "./impl-list";
 export { cmdOracleScan, cmdOracleFleet } from "./impl-scan";
 export { cmdOracleScanStale } from "./impl-stale";
+export { cmdOraclePrune } from "./impl-prune";
+export { cmdOracleRegister } from "./impl-register";

--- a/src/commands/plugins/oracle/index.ts
+++ b/src/commands/plugins/oracle/index.ts
@@ -1,10 +1,12 @@
 import type { InvokeContext, InvokeResult } from "../../../plugin/types";
 import { cmdOracleList, cmdOracleAbout, cmdOracleScan, cmdOracleScanStale } from "./impl";
+import { cmdOraclePrune } from "./impl-prune";
+import { cmdOracleRegister } from "./impl-register";
 import { parseFlags } from "../../../cli/parse-args";
 
 export const command = {
   name: ["oracle", "oracles"],
-  description: "Oracle management — list, scan, about (fleet deprecated → ls)",
+  description: "Oracle management — list, scan, about, prune, register",
 };
 
 // Shared spec for `ls` flags — used by both ls and the fleet alias.
@@ -87,10 +89,26 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
           stale: flags["--stale"],
           path: flags["--path"],
         });
+      } else if (subcmd === "prune") {
+        const flags = parseFlags(args, {
+          "--stale": Boolean,
+          "--force": Boolean,
+          "--json": Boolean,
+        }, 1);
+        await cmdOraclePrune({
+          stale: flags["--stale"],
+          force: flags["--force"],
+          json: flags["--json"],
+        });
+      } else if (subcmd === "register") {
+        const name = args[1];
+        if (!name) return { ok: false, error: "usage: maw oracle register <name>" };
+        const flags = parseFlags(args, { "--json": Boolean }, 2);
+        await cmdOracleRegister(name, { json: flags["--json"] });
       } else if (subcmd === "about" && args[1]) {
         await cmdOracleAbout(args[1]);
       } else {
-        return { ok: false, error: "usage: maw oracle [ls|scan|about <name>]" };
+        return { ok: false, error: "usage: maw oracle [ls|scan|prune|register <name>|about <name>]" };
       }
     } else if (ctx.source === "api") {
       const query = ctx.args as Record<string, unknown>;
@@ -132,10 +150,21 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
           stale: query.stale as boolean | undefined,
           path: query.path as boolean | undefined,
         });
+      } else if (sub === "prune") {
+        await cmdOraclePrune({
+          stale: query.stale as boolean | undefined,
+          force: query.force as boolean | undefined,
+          json: query.json as boolean | undefined,
+        });
+      } else if (sub === "register") {
+        if (!query.name) return { ok: false, error: "usage: query.sub=register + query.name" };
+        await cmdOracleRegister(query.name as string, {
+          json: query.json as boolean | undefined,
+        });
       } else if (sub === "about" && query.name) {
         await cmdOracleAbout(query.name as string);
       } else {
-        return { ok: false, error: "usage: query.sub=[ls|scan|about] + query.name for about" };
+        return { ok: false, error: "usage: query.sub=[ls|scan|prune|register|about] + query.name for about/register" };
       }
     }
 

--- a/src/commands/plugins/oracle/prune-register.test.ts
+++ b/src/commands/plugins/oracle/prune-register.test.ts
@@ -1,0 +1,488 @@
+import { describe, it, expect } from "bun:test";
+import {
+  buildPruneCandidates,
+  buildStaleCandidates,
+  runPrune,
+  cmdOraclePrune,
+} from "./impl-prune";
+import {
+  findInFleet,
+  findInFilesystem,
+  findInTmux,
+  cmdOracleRegister,
+} from "./impl-register";
+import type { OracleEntry } from "../../../sdk";
+import type { StaleEntry } from "./impl-stale";
+import { mkdirSync, writeFileSync, mkdtempSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function entry(partial: Partial<OracleEntry> = {}): OracleEntry {
+  return {
+    org: "Soul-Brews-Studio",
+    repo: "test-oracle",
+    name: "test",
+    local_path: "/tmp/test-oracle",
+    has_psi: true,
+    has_fleet_config: true,
+    budded_from: "neo",
+    budded_at: "2026-01-01T00:00:00Z",
+    federation_node: "white",
+    detected_at: "2026-04-17T00:00:00Z",
+    ...partial,
+  };
+}
+
+function orphan(name: string): OracleEntry {
+  return entry({
+    name,
+    repo: `${name}-oracle`,
+    has_psi: false,
+    has_fleet_config: false,
+    budded_from: null,
+    budded_at: null,
+    federation_node: null,
+  });
+}
+
+function staleEntry(name: string, tier: "STALE" | "DEAD"): StaleEntry {
+  return {
+    name,
+    org: "Soul-Brews-Studio",
+    repo: `${name}-oracle`,
+    local_path: `/tmp/${name}`,
+    has_psi: false,
+    awake: false,
+    last_commit: null,
+    days_since_commit: tier === "DEAD" ? 120 : 60,
+    tier,
+    recommendation: tier === "DEAD" ? "prune candidate (no ψ/)" : "investigate",
+  };
+}
+
+// ─── buildPruneCandidates ─────────────────────────────────────────────────────
+
+describe("buildPruneCandidates", () => {
+  it("marks orphan entry (no signals) as candidate", () => {
+    const candidates = buildPruneCandidates([orphan("ghost")], new Set());
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].entry.name).toBe("ghost");
+    expect(candidates[0].reasons).toContain("empty lineage");
+    expect(candidates[0].reasons).toContain("no tmux");
+    expect(candidates[0].reasons).toContain("no federation");
+  });
+
+  it("excludes oracle with federation_node", () => {
+    const e = orphan("federated");
+    e.federation_node = "white";
+    const candidates = buildPruneCandidates([e], new Set());
+    expect(candidates).toHaveLength(0);
+  });
+
+  it("excludes oracle that is awake in tmux", () => {
+    const candidates = buildPruneCandidates([orphan("active")], new Set(["active"]));
+    expect(candidates).toHaveLength(0);
+  });
+
+  it("excludes oracle with ψ/ (has_psi = true)", () => {
+    const e = orphan("psi-holder");
+    e.has_psi = true;
+    // has_psi breaks "empty lineage" → not a candidate
+    const candidates = buildPruneCandidates([e], new Set());
+    expect(candidates).toHaveLength(0);
+  });
+
+  it("excludes oracle with fleet config", () => {
+    const e = orphan("fleet-member");
+    e.has_fleet_config = true;
+    const candidates = buildPruneCandidates([e], new Set());
+    expect(candidates).toHaveLength(0);
+  });
+
+  it("excludes oracle with budded_from lineage", () => {
+    const e = orphan("budded");
+    e.budded_from = "neo";
+    const candidates = buildPruneCandidates([e], new Set());
+    expect(candidates).toHaveLength(0);
+  });
+
+  it("includes 'not cloned' reason when local_path is empty", () => {
+    const e = orphan("ghost");
+    e.local_path = "";
+    const candidates = buildPruneCandidates([e], new Set());
+    expect(candidates[0].reasons).toContain("not cloned");
+  });
+
+  it("handles mixed list — only orphans become candidates", () => {
+    const entries = [
+      entry({ name: "healthy" }),   // has all signals
+      orphan("ghost"),              // no signals → candidate
+    ];
+    const candidates = buildPruneCandidates(entries, new Set(["healthy"]));
+    expect(candidates.map((c) => c.entry.name)).toEqual(["ghost"]);
+  });
+});
+
+// ─── buildStaleCandidates ─────────────────────────────────────────────────────
+
+describe("buildStaleCandidates", () => {
+  it("includes STALE and DEAD tiers only", () => {
+    const stale = [
+      { ...staleEntry("active", "STALE"), tier: "ACTIVE" as any },
+      staleEntry("rotting", "STALE"),
+      staleEntry("dead", "DEAD"),
+    ];
+    const candidates = buildStaleCandidates(stale);
+    expect(candidates.map((c) => c.entry.name)).toEqual(["rotting", "dead"]);
+  });
+
+  it("carries tier through to candidate", () => {
+    const candidates = buildStaleCandidates([staleEntry("dusty", "STALE")]);
+    expect(candidates[0].tier).toBe("STALE");
+  });
+
+  it("includes tier as reason", () => {
+    const dead = buildStaleCandidates([staleEntry("ghost", "DEAD")]);
+    expect(dead[0].reasons.some((r) => r.includes("DEAD"))).toBe(true);
+
+    const stale = buildStaleCandidates([staleEntry("dusty", "STALE")]);
+    expect(stale[0].reasons.some((r) => r.includes("STALE"))).toBe(true);
+  });
+});
+
+// ─── runPrune (dry-run) ───────────────────────────────────────────────────────
+
+describe("runPrune — dry-run (no --force)", () => {
+  it("returns candidates without writing", async () => {
+    let written = false;
+    const candidates = await runPrune(
+      {},
+      {
+        readEntries: () => [orphan("ghost")],
+        listAwake: async () => new Set(),
+        readRawCache: () => ({ oracles: [orphan("ghost")] }),
+        writeRawCache: () => { written = true; },
+      },
+    );
+    expect(candidates).toHaveLength(1);
+    expect(written).toBe(false);
+  });
+
+  it("returns empty candidates for healthy registry", async () => {
+    const candidates = await runPrune(
+      {},
+      {
+        readEntries: () => [entry({ name: "healthy" })],
+        listAwake: async () => new Set(["healthy"]),
+        readRawCache: () => ({ oracles: [entry({ name: "healthy" })] }),
+        writeRawCache: () => {},
+      },
+    );
+    expect(candidates).toHaveLength(0);
+  });
+});
+
+// ─── runPrune --stale filter ──────────────────────────────────────────────────
+
+describe("runPrune --stale", () => {
+  it("delegates to stale classifier", async () => {
+    let calledStale = false;
+    const candidates = await runPrune(
+      { stale: true },
+      {
+        runStale: async () => {
+          calledStale = true;
+          return [staleEntry("dusty", "STALE")];
+        },
+        readRawCache: () => ({ oracles: [] }),
+        writeRawCache: () => {},
+      },
+    );
+    expect(calledStale).toBe(true);
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].entry.name).toBe("dusty");
+  });
+
+  it("excludes ACTIVE and SLOW tiers", async () => {
+    const candidates = await runPrune(
+      { stale: true },
+      {
+        runStale: async () => [
+          { ...staleEntry("fast", "STALE"), tier: "ACTIVE" as any },
+          { ...staleEntry("slow", "STALE"), tier: "SLOW" as any },
+          staleEntry("dead-one", "DEAD"),
+        ],
+        readRawCache: () => ({ oracles: [] }),
+        writeRawCache: () => {},
+      },
+    );
+    expect(candidates.map((c) => c.entry.name)).toEqual(["dead-one"]);
+  });
+});
+
+// ─── cmdOraclePrune --force confirm flow ─────────────────────────────────────
+
+describe("cmdOraclePrune --force", () => {
+  it("retires candidates when user confirms", async () => {
+    const initial = [orphan("ghost"), entry({ name: "healthy", federation_node: "white" })];
+    let written: Record<string, unknown> | null = null;
+
+    await cmdOraclePrune(
+      { force: true },
+      {
+        readEntries: () => initial,
+        listAwake: async () => new Set(),
+        readRawCache: () => ({ oracles: initial }),
+        writeRawCache: (data) => { written = data; },
+        promptConfirm: async () => true,
+      },
+    );
+
+    expect(written).not.toBeNull();
+    const oracles = written!.oracles as OracleEntry[];
+    expect(oracles.map((e) => e.name)).not.toContain("ghost");
+    expect(oracles.map((e) => e.name)).toContain("healthy");
+
+    const retired = written!.retired as any[];
+    expect(retired).toHaveLength(1);
+    expect(retired[0].name).toBe("ghost");
+    expect(retired[0].retired_at).toBeTruthy();
+    expect(retired[0].retired_reasons).toContain("empty lineage");
+  });
+
+  it("aborts when user denies confirmation", async () => {
+    let written = false;
+    await cmdOraclePrune(
+      { force: true },
+      {
+        readEntries: () => [orphan("ghost")],
+        listAwake: async () => new Set(),
+        readRawCache: () => ({ oracles: [orphan("ghost")] }),
+        writeRawCache: () => { written = true; },
+        promptConfirm: async () => false,
+      },
+    );
+    expect(written).toBe(false);
+  });
+
+  it("preserves existing retired entries", async () => {
+    const existingRetired = [{ name: "old", retired_at: "2026-01-01T00:00:00Z", retired_reasons: [] }];
+    let written: Record<string, unknown> | null = null;
+
+    await cmdOraclePrune(
+      { force: true },
+      {
+        readEntries: () => [orphan("ghost")],
+        listAwake: async () => new Set(),
+        readRawCache: () => ({ oracles: [orphan("ghost")], retired: existingRetired }),
+        writeRawCache: (data) => { written = data; },
+        promptConfirm: async () => true,
+      },
+    );
+
+    const retired = written!.retired as any[];
+    expect(retired).toHaveLength(2);
+    expect(retired.map((r) => r.name)).toContain("old");
+    expect(retired.map((r) => r.name)).toContain("ghost");
+  });
+
+  it("does not write when no candidates exist", async () => {
+    let written = false;
+    await cmdOraclePrune(
+      { force: true },
+      {
+        readEntries: () => [entry({ name: "healthy", federation_node: "white" })],
+        listAwake: async () => new Set(["healthy"]),
+        readRawCache: () => ({ oracles: [entry({ name: "healthy", federation_node: "white" })] }),
+        writeRawCache: () => { written = true; },
+        promptConfirm: async () => true,
+      },
+    );
+    expect(written).toBe(false);
+  });
+});
+
+// ─── findInFleet ─────────────────────────────────────────────────────────────
+
+describe("findInFleet", () => {
+  it("finds oracle in fleet config by window name", () => {
+    const dir = mkdtempSync(join(tmpdir(), "fleet-"));
+    writeFileSync(
+      join(dir, "mawjs.json"),
+      JSON.stringify({
+        windows: [{ name: "mawjs-oracle" }],
+        project_repos: ["Soul-Brews-Studio/mawjs-oracle"],
+        budded_from: "neo",
+        budded_at: "2026-04-07T00:00:00Z",
+      }),
+    );
+    const result = findInFleet("mawjs", dir);
+    expect(result).not.toBeNull();
+    expect(result!.source).toBe("fleet");
+    expect(result!.entry.name).toBe("mawjs");
+    expect(result!.entry.org).toBe("Soul-Brews-Studio");
+    expect(result!.entry.has_fleet_config).toBe(true);
+    expect(result!.entry.budded_from).toBe("neo");
+  });
+
+  it("returns null if oracle not found in fleet", () => {
+    const dir = mkdtempSync(join(tmpdir(), "fleet-"));
+    writeFileSync(join(dir, "other.json"), JSON.stringify({ windows: [{ name: "other-oracle" }] }));
+    expect(findInFleet("mawjs", dir)).toBeNull();
+  });
+
+  it("returns null for empty fleet dir", () => {
+    const dir = mkdtempSync(join(tmpdir(), "fleet-"));
+    expect(findInFleet("mawjs", dir)).toBeNull();
+  });
+});
+
+// ─── findInFilesystem ─────────────────────────────────────────────────────────
+
+describe("findInFilesystem", () => {
+  it("finds oracle by -oracle repo name with ψ/", () => {
+    const root = mkdtempSync(join(tmpdir(), "ghq-"));
+    const org = join(root, "Soul-Brews-Studio");
+    const repo = join(org, "newbie-oracle");
+    mkdirSync(join(repo, "ψ"), { recursive: true });
+    const result = findInFilesystem("newbie", root);
+    expect(result).not.toBeNull();
+    expect(result!.source).toBe("filesystem");
+    expect(result!.entry.name).toBe("newbie");
+    expect(result!.entry.has_psi).toBe(true);
+  });
+
+  it("returns null when oracle not on filesystem", () => {
+    const root = mkdtempSync(join(tmpdir(), "ghq-"));
+    mkdirSync(join(root, "Soul-Brews-Studio"), { recursive: true });
+    expect(findInFilesystem("ghost", root)).toBeNull();
+  });
+});
+
+// ─── findInTmux ──────────────────────────────────────────────────────────────
+
+describe("findInTmux", () => {
+  it("finds oracle from tmux window", async () => {
+    const sessions = [{ name: "mawjs", windows: [{ name: "mawjs-oracle", index: 0 }] }];
+    const result = await findInTmux("mawjs", async () => sessions as any);
+    expect(result).not.toBeNull();
+    expect(result!.source).toBe("tmux");
+    expect(result!.entry.name).toBe("mawjs");
+  });
+
+  it("returns null when oracle not in tmux", async () => {
+    const sessions = [{ name: "other", windows: [{ name: "other-oracle", index: 0 }] }];
+    const result = await findInTmux("mawjs", async () => sessions as any);
+    expect(result).toBeNull();
+  });
+});
+
+// ─── cmdOracleRegister — success ─────────────────────────────────────────────
+
+describe("cmdOracleRegister — success", () => {
+  it("adds discovered oracle to registry", async () => {
+    let written: Record<string, unknown> | null = null;
+    await cmdOracleRegister(
+      "newbie",
+      {},
+      {
+        readRawCache: () => ({ oracles: [] }),
+        writeRawCache: (data) => { written = data; },
+        findInFleetFn: () => null,
+        findInTmuxFn: async () => null,
+        findInFilesystemFn: (name) => ({
+          source: "filesystem",
+          entry: {
+            org: "Soul-Brews-Studio",
+            repo: `${name}-oracle`,
+            name,
+            local_path: `/tmp/${name}-oracle`,
+            has_psi: true,
+            has_fleet_config: false,
+            budded_from: null,
+            budded_at: null,
+            federation_node: null,
+            detected_at: new Date().toISOString(),
+          },
+        }),
+      },
+    );
+    expect(written).not.toBeNull();
+    const oracles = written!.oracles as OracleEntry[];
+    expect(oracles).toHaveLength(1);
+    expect(oracles[0].name).toBe("newbie");
+  });
+
+  it("uses fleet source when available (priority)", async () => {
+    let writtenEntry: OracleEntry | null = null;
+    await cmdOracleRegister(
+      "mawjs",
+      {},
+      {
+        readRawCache: () => ({ oracles: [] }),
+        writeRawCache: (data) => { writtenEntry = (data.oracles as OracleEntry[])[0]; },
+        findInFleetFn: (name) => ({
+          source: "fleet",
+          entry: {
+            org: "Soul-Brews-Studio",
+            repo: `${name}-oracle`,
+            name,
+            local_path: "",
+            has_psi: false,
+            has_fleet_config: true,
+            budded_from: "neo",
+            budded_at: null,
+            federation_node: null,
+            detected_at: new Date().toISOString(),
+          },
+        }),
+        findInTmuxFn: async () => { throw new Error("should not be called"); },
+        findInFilesystemFn: () => { throw new Error("should not be called"); },
+      },
+    );
+    expect(writtenEntry!.has_fleet_config).toBe(true);
+    expect(writtenEntry!.budded_from).toBe("neo");
+  });
+});
+
+// ─── cmdOracleRegister — collision error ─────────────────────────────────────
+
+describe("cmdOracleRegister — collision", () => {
+  it("throws when oracle already in registry", async () => {
+    await expect(
+      cmdOracleRegister(
+        "existing",
+        {},
+        {
+          readRawCache: () => ({ oracles: [entry({ name: "existing" })] }),
+          writeRawCache: () => {},
+          findInFleetFn: () => null,
+          findInTmuxFn: async () => null,
+          findInFilesystemFn: () => null,
+        },
+      ),
+    ).rejects.toThrow("already registered");
+  });
+});
+
+// ─── cmdOracleRegister — missing error ───────────────────────────────────────
+
+describe("cmdOracleRegister — missing", () => {
+  it("throws when oracle not found anywhere", async () => {
+    await expect(
+      cmdOracleRegister(
+        "ghost",
+        {},
+        {
+          readRawCache: () => ({ oracles: [] }),
+          writeRawCache: () => {},
+          findInFleetFn: () => null,
+          findInTmuxFn: async () => null,
+          findInFilesystemFn: () => null,
+        },
+      ),
+    ).rejects.toThrow("not found");
+  });
+});


### PR DESCRIPTION
## Summary
Ship `maw oracle prune` (dry-run default) + `maw oracle register <name>`.

## Problem (root cause)

As the oracle fleet grows, `oracles.json` accumulates entries with no active signals — no tmux session, no federation node, no lineage (ψ/, fleet config, or bud history). These orphaned entries silently inflate the registry and clutter `maw oracle ls`. There was no way to clean them without hand-editing JSON.

Separately, oracles discovered via tmux or fleet configs that land in the cache still require manual JSON editing if they need to be explicitly adopted. The `(not registered)` hint shown by `maw oracle ls` had no corresponding command to act on it.

Both gaps share a root cause: the registry had no lifecycle verbs — only scan (populate) and list (read).

## Option space
- A: Ship prune + register together (this PR)
- B: Prune first, register later
- C: One monolithic "oracle sync" verb that does both implicitly

## Pick + justification
Option A. `prune` and `register` are natural complements — together they complete the oracle lifecycle (discover → register → list → prune). Dry-run default makes prune safe to ship immediately. `register` unblocks adoption of tmux/fleet-discovered oracles without JSON surgery.

## Surface area
| File | Lines | Risk |
|---|---|---|
| src/commands/plugins/oracle/impl-prune.ts | new (+230) | Medium (destructive path) |
| src/commands/plugins/oracle/impl-register.ts | new (+230) | Low |
| src/commands/plugins/oracle/index.ts | +~30 | Low |
| src/commands/plugins/oracle/impl.ts | +2 | Low |
| src/commands/plugins/oracle/prune-register.test.ts | new (+488) | Low |

## Safety
- `prune` default is dry-run — never writes without `--force`
- `--force` requires interactive confirmation before any write
- Removed entries: moved to `retired[]` in registry JSON, not deleted (Nothing is Deleted)
- `mergeRegistry` preserves `retired[]` across future `maw oracle scan` runs
- `register` refuses if name collides with existing entry in `oracles[]`

## Alternatives rejected
- B: Splits a natural paired lifecycle — register with no cleanup path is incomplete.
- C: Implicit sync magic surprises; explicit verbs match the oracle CLI's verb-per-action convention.

## Open questions for @nazt
- [ ] `prune --stale` uses alpha.112 classifier thresholds (7/30/90d) — ok?
- [ ] `register` source priority order: fleet > tmux > filesystem. Ok?

## Test plan
- [x] bun run test:all (130 pass, 0 fail — 30 new tests in prune-register.test.ts)
- [ ] CI
- [ ] Manual: `bun run maw oracle prune --dry` on your registry

Closes #383. Do not auto-merge — @nazt ultrathink review required.

Co-Authored-By: mawjs <noreply@soulbrews.studio>