### PR TITLE
fix(#411): local-first resolve — surface remote fetch failure explicitly

### DIFF
--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -141,7 +141,9 @@ export async function cmdSend(query: string, message: string, force = false) {
       await runHook("after_send", { to: query, message });
       return;
     }
-    console.error(`\x1b[31mfailed\x1b[0m ⚡ ${result.node} → ${result.target}: ${res.data?.error || "send failed"}`);
+    const underlying = res.data?.error || (res.status ? `HTTP ${res.status}` : "connection failed");
+    console.error(`\x1b[31merror\x1b[0m: Remote fetch failed for peer ${result.peerUrl} (${result.node}): ${underlying}`);
+    console.error(`\x1b[33mhint\x1b[0m:  check peer connectivity: maw health`);
     process.exit(1);
   }
 
@@ -168,9 +170,9 @@ export async function cmdSend(query: string, message: string, force = false) {
     process.exit(1);
   }
 
-  // Local-only miss — no network was attempted (#411).
+  // Local-only miss — no network was attempted (#411). Show resolver's own detail.
   if (result?.type === "error") {
-    console.error(`\x1b[31merror\x1b[0m: Local target not found on this node: ${query}`);
+    console.error(`\x1b[31merror\x1b[0m: ${result.detail}`);
     if (result.hint) console.error(`\x1b[33mhint\x1b[0m:  ${result.hint}`);
   } else {
     console.error(`\x1b[31merror\x1b[0m: window not found: ${query}`);

--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -145,7 +145,9 @@ export async function cmdSend(query: string, message: string, force = false) {
     process.exit(1);
   }
 
-  // Fallback: async peer discovery (network scan — slow path)
+  // Fallback: async peer discovery (network scan — slow path).
+  // Only reached when resolveTarget found no local session AND no config-mapped peer.
+  // Local sessions were already checked above — if we reach here, local genuinely missed.
   const peerUrl = await findPeerForTarget(query, sessions);
   if (peerUrl) {
     const res = await curlFetch(`${peerUrl}/api/send`, {
@@ -158,11 +160,17 @@ export async function cmdSend(query: string, message: string, force = false) {
       await runHook("after_send", { to: query, message });
       return;
     }
+    // Remote fetch was attempted but failed — surface the remote failure explicitly (#411).
+    // Never fall through to "not found in local sessions" when the real problem is network.
+    const underlying = res.data?.error || (res.status ? `HTTP ${res.status}` : "connection failed");
+    console.error(`\x1b[31merror\x1b[0m: Remote fetch failed for peer ${peerUrl}: ${underlying}`);
+    console.error(`\x1b[33mhint\x1b[0m:  check peer connectivity: maw health`);
+    process.exit(1);
   }
 
-  // Not found — surface error details from resolveTarget (#216)
+  // Local-only miss — no network was attempted (#411).
   if (result?.type === "error") {
-    console.error(`\x1b[31merror\x1b[0m: ${result.detail}`);
+    console.error(`\x1b[31merror\x1b[0m: Local target not found on this node: ${query}`);
     if (result.hint) console.error(`\x1b[33mhint\x1b[0m:  ${result.hint}`);
   } else {
     console.error(`\x1b[31merror\x1b[0m: window not found: ${query}`);

--- a/test/isolated/comm-list.test.ts
+++ b/test/isolated/comm-list.test.ts
@@ -909,7 +909,9 @@ describe("cmdSend — peer target (federation)", () => {
     await run(() => cmdSend("mba:mawjs", "ping"));
 
     expect(exitCode).toBe(1);
-    expect(errs.join("\n")).toContain("send failed");
+    // #411: remote fetch failure surfaces peer URL + underlying, not "send failed"
+    expect(errs.join("\n")).toContain("Remote fetch failed for peer");
+    expect(errs.join("\n")).toContain("mba.example");
   });
 
   test("peer success without data.lastLine → no ⤷ follow-up", async () => {
@@ -947,7 +949,7 @@ describe("cmdSend — async peer discovery fallback", () => {
     expect(exitCode).toBeUndefined();
   });
 
-  test("fallback peer curlFetch non-ok → falls through to generic window-not-found", async () => {
+  test("fallback peer curlFetch non-ok → surfaces remote failure, not window-not-found (#411)", async () => {
     configOverride = { node: "white" };
     resolveTargetReturn = null;
     findPeerForTargetReturn = "https://broken.example";
@@ -959,7 +961,10 @@ describe("cmdSend — async peer discovery fallback", () => {
     await run(() => cmdSend("mawjs", "ping"));
 
     expect(exitCode).toBe(1);
-    expect(errs.join("\n")).toContain("window not found: mawjs");
+    // #411: must surface the remote failure, not the local-miss message
+    expect(errs.join("\n")).toContain("Remote fetch failed for peer");
+    expect(errs.join("\n")).toContain("broken.example");
+    expect(errs.join("\n")).not.toContain("window not found: mawjs");
   });
 });
 

--- a/test/isolated/resolve-local-first.test.ts
+++ b/test/isolated/resolve-local-first.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Isolated tests for local-first routing in cmdSend (#411).
+ *
+ * Three cases:
+ *   1. local hit  — target in tmux sessions → sendKeys, no network
+ *   2. local miss + remote hit — agents config peer is reachable → delivered
+ *   3. local miss + remote peer unreachable — error says "Remote fetch failed"
+ *      NOT "not found in local sessions"
+ *
+ * Uses real resolveTarget so routing logic is validated end-to-end.
+ * Network is mocked via curlFetch stub.
+ */
+
+import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
+
+// ─── Mutable stubs — each test sets these ────────────────────────────────────
+
+let fakeSessions: Array<{ name: string; windows: Array<{ index: number; name: string; active: boolean }> }> = [];
+let fakeCurlResponse: { ok: boolean; status: number; data: unknown } = { ok: false, status: 0, data: null };
+let fakePeerForTarget: string | null = null;
+let sendKeysCalled = false;
+let curlFetchCalled = false;
+let curlFetchUrl = "";
+
+// ─── Module mocks (must be before any imports of the modules under test) ─────
+
+import { mockConfigModule } from "../helpers/mock-config";
+
+mock.module("../../src/config", () => mockConfigModule(() => ({
+  node: "white",
+  port: 3456,
+  namedPeers: [{ name: "mba", url: "http://mba.wg:3457" }],
+  agents: { homekeeper: "mba" },
+  sessions: {},
+})));
+
+mock.module("../../src/core/transport/ssh", () => ({
+  listSessions: async () => fakeSessions,
+  sendKeys: async () => { sendKeysCalled = true; },
+  capture: async () => "",
+  getPaneCommand: async () => "claude",
+  getPaneCommands: async () => [],
+  getPaneInfos: async () => ({}),
+  hostExec: async () => { throw new Error("tmux unavailable in test"); },
+  HostExecError: class HostExecError extends Error {},
+}));
+
+mock.module("../../src/core/transport/curl-fetch", () => ({
+  curlFetch: async (url: string) => {
+    curlFetchCalled = true;
+    curlFetchUrl = url;
+    return fakeCurlResponse;
+  },
+}));
+
+mock.module("../../src/core/transport/peers", () => ({
+  findPeerForTarget: async () => fakePeerForTarget,
+  getPeers: () => [],
+  getFederationStatus: async () => ({ peers: [], totalPeers: 0, reachablePeers: 0 }),
+}));
+
+mock.module("../../src/core/runtime/hooks", () => ({ runHook: async () => {} }));
+
+mock.module("../../src/core/fleet/worktrees", () => ({
+  scanWorktrees: async () => [],
+  cleanupWorktree: async () => {},
+}));
+
+mock.module("../../src/commands/shared/wake", () => ({
+  resolveFleetSession: () => null,
+}));
+
+mock.module("../../src/commands/shared/comm-log-feed", () => ({
+  logMessage: () => {},
+  emitFeed: () => {},
+}));
+
+// tmux module — stub so sdk can import without a real tmux socket
+mock.module("../../src/core/transport/tmux", () => ({
+  tmux: {},
+  Tmux: class {},
+  tmuxCmd: () => "tmux",
+  resolveSocket: () => null,
+  withPaneLock: async (_target: string, fn: () => Promise<unknown>) => fn(),
+  splitWindowLocked: async () => "",
+  tagPane: async () => {},
+  readPaneTags: async () => ({}),
+}));
+
+// Suppress plugin registry (not used in these tests)
+mock.module("../../src/plugin/registry", () => ({
+  discoverPackages: () => [],
+  invokePlugin: async () => ({ ok: false }),
+}));
+
+import { cmdSend } from "../../src/commands/shared/comm";
+
+// ─── Test harness ─────────────────────────────────────────────────────────────
+
+describe("local-first routing (#411)", () => {
+  let exitCode: number | undefined;
+  let consoleOut: string[] = [];
+  let consoleErr: string[] = [];
+  let originalExit: typeof process.exit;
+  let originalLog: typeof console.log;
+  let originalError: typeof console.error;
+
+  beforeEach(() => {
+    exitCode = undefined;
+    consoleOut = [];
+    consoleErr = [];
+    sendKeysCalled = false;
+    curlFetchCalled = false;
+    curlFetchUrl = "";
+    fakeSessions = [];
+    fakeCurlResponse = { ok: false, status: 0, data: null };
+    fakePeerForTarget = null;
+
+    originalExit = process.exit;
+    originalLog = console.log;
+    originalError = console.error;
+
+    process.exit = ((code?: number) => {
+      exitCode = code ?? 0;
+      throw new Error(`process.exit(${code})`);
+    }) as typeof process.exit;
+    console.log = (...args: unknown[]) => { consoleOut.push(args.map(String).join(" ")); };
+    console.error = (...args: unknown[]) => { consoleErr.push(args.map(String).join(" ")); };
+
+    process.env.MAW_QUIET = "1";
+  });
+
+  afterEach(() => {
+    process.exit = originalExit;
+    console.log = originalLog;
+    console.error = originalError;
+    delete process.env.MAW_QUIET;
+  });
+
+  // ── Case 1: local hit ──────────────────────────────────────────────────────
+
+  test("(1) local hit — routes via tmux, no network", async () => {
+    fakeSessions = [
+      { name: "08-mawjs", windows: [{ index: 1, name: "mawjs-oracle", active: true }] },
+    ];
+
+    await cmdSend("mawjs", "hello local");
+
+    expect(exitCode).toBeUndefined();
+    expect(sendKeysCalled).toBe(true);
+    expect(curlFetchCalled).toBe(false);
+    expect(consoleOut.some(l => l.includes("delivered"))).toBe(true);
+  });
+
+  // ── Case 2: local miss + remote hit ───────────────────────────────────────
+
+  test("(2) local miss + remote hit — routes to peer, delivered", async () => {
+    fakeSessions = [];
+    fakeCurlResponse = {
+      ok: true,
+      status: 200,
+      data: { ok: true, target: "homekeeper", lastLine: "" },
+    };
+
+    await cmdSend("homekeeper", "hello remote");
+
+    expect(exitCode).toBeUndefined();
+    expect(sendKeysCalled).toBe(false);
+    expect(curlFetchCalled).toBe(true);
+    expect(curlFetchUrl).toContain("mba.wg:3457");
+    expect(consoleOut.some(l => l.includes("delivered"))).toBe(true);
+  });
+
+  // ── Case 3: local miss + remote peer unreachable ───────────────────────────
+
+  test("(3) local miss + remote peer unreachable — surfaces remote failure, not local-miss", async () => {
+    fakeSessions = [];
+    // curlFetch returns failure (peer unreachable)
+    fakeCurlResponse = { ok: false, status: 0, data: null };
+
+    await expect(
+      cmdSend("homekeeper", "hello unreachable"),
+    ).rejects.toThrow("process.exit");
+
+    expect(exitCode).toBe(1);
+    expect(curlFetchCalled).toBe(true);
+
+    const errOutput = consoleErr.join("\n");
+
+    // Must surface the remote failure explicitly
+    expect(errOutput).toContain("Remote fetch failed for peer");
+    expect(errOutput).toContain("mba.wg:3457");
+
+    // Must NOT claim this was a local miss — local was never the issue
+    expect(errOutput).not.toContain("not found in local sessions");
+    expect(errOutput).not.toContain("not in local sessions");
+  });
+});

--- a/test/isolated/resolve-local-first.test.ts
+++ b/test/isolated/resolve-local-first.test.ts
@@ -187,12 +187,11 @@ describe("local-first routing (#411)", () => {
 
     const errOutput = consoleErr.join("\n");
 
-    // Must surface the remote failure explicitly
+    // Must surface the remote failure explicitly — not a local-miss message
     expect(errOutput).toContain("Remote fetch failed for peer");
     expect(errOutput).toContain("mba.wg:3457");
 
-    // Must NOT claim this was a local miss — local was never the issue
-    expect(errOutput).not.toContain("not found in local sessions");
-    expect(errOutput).not.toContain("not in local sessions");
+    // Must NOT say "not in local sessions" when the real failure was network (#411)
+    expect(errOutput).not.toContain("not in local sessions or agents map");
   });
 });


### PR DESCRIPTION
## Summary
When a remote federation peer is unreachable, `maw hey <target>` now shows "Remote fetch failed for peer X: connection failed" instead of silently falling through to "not found in local sessions or agents map".

## Problem (root cause)

**Root cause**: `cmdSend` has two peer-send paths and a fallback, all of which previously surfaced misleading error messages when a remote peer was unreachable.

**Path 1** (`resolveTarget` returns `{ type: "peer" }` — config-mapped agent): when `curlFetch` failed, showed `"failed ⚡ mba → target: send failed"` with no underlying cause (connection refused, HTTP 503, etc. were swallowed).

**Path 2** (async `findPeerForTarget` fallback — peer discovered via cached aggregation): when `curlFetch` failed, the code fell through to show the original `resolveTarget` error — `"not in local sessions or agents map"`. This is the core bug: local WAS already checked and missed; the real failure was the remote network. Showing the local-miss message after a remote failure hides what actually went wrong.

**Trace**: `cmdSend` → `resolveTarget` (local-first, sync, pure — correct) → on miss → `findPeerForTarget` (aggregates local + peer sessions via cache) → peer URL returned from stale cache → `curlFetch` to `mba.wg:3457` → fails → falls through to `result.detail` ("not in local sessions or agents map").

## Option space
- A: Local-first — check tmux map, fall back to remote only on miss; surface remote failure explicitly
- B: Keep remote-first, improve error text
- C: Gate remote lookup behind --federated flag

## Pick + justification
Option A. Local sessions are always checked first (via `resolveTarget`) before any network call — this was already the order. The bug was in error SURFACING not routing order. Both peer paths now exit with "Remote fetch failed for peer X: <underlying>" when network is attempted but fails. This clearly separates "local miss (no network)" from "remote unreachable (network attempted)".

## Surface area
| File | Lines | Risk |
|---|---|---|
| `src/commands/shared/comm-send.ts` | +11 / -3 | Low — error path only, no happy-path change |
| `test/isolated/resolve-local-first.test.ts` | +198 (new) | Low — test-only |
| `test/isolated/comm-list.test.ts` | +5 / -4 | Low — updates assertions that tested old buggy behavior |

## Alternatives rejected
- B: Improving text without fixing the fall-through would still show wrong root cause when cache has stale peer data
- C: --federated gate adds API surface; the problem is about error messages not routing policy

## Open questions for @nazt
- [ ] Path 1 now shows peer URL (`http://mba.wg:3457`) instead of just node name (`mba`) — more diagnostic but slightly more verbose. Preferred?
- [ ] Should the "check peer connectivity: maw health" hint be suppressed when `MAW_QUIET=1`?

## Test plan
- [x] bun run test:all local (45/45 files pass)
- [ ] CI (6 checks)

Closes #411. Do not auto-merge — @nazt ultrathink review required.

Co-Authored-By: mawjs <noreply@soulbrews.studio>