### PR TITLE
fix(tmux): flush-wait before Enter to avoid paste/submit race

### DIFF
--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -239,6 +239,9 @@ export class Tmux {
       // Buffer method — reliable for multiline/long content
       await this.loadBuffer(text);
       await this.pasteBuffer(target);
+      // Flush-wait: let TUI finish rendering the paste before Enter hits.
+      // Without this, Enter races the paste-buffer commit in Claude Code.
+      await new Promise(r => setTimeout(r, 250));
       // Staggered Enter — submit immediately + 2 fallbacks
       await this.sendKeys(target, "Enter");
       await new Promise(r => setTimeout(r, 500));
@@ -248,6 +251,8 @@ export class Tmux {
     } else {
       // Literal send — -l prevents tmux from interpreting special chars like |
       await this.sendKeysLiteral(target, text);
+      // Flush-wait: same reason as above — avoid paste/submit race.
+      await new Promise(r => setTimeout(r, 250));
       // Staggered Enter — submit immediately + 2 fallbacks
       await this.sendKeys(target, "Enter");
       await new Promise(r => setTimeout(r, 500));


### PR DESCRIPTION
## Summary

- Adds a 250 ms flush delay between tmux `paste-buffer` / `send-keys -l` and the first `Enter` in `Tmux.sendText()`.
- Fixes the race where Claude Code TUI has not yet rendered the paste when the first Enter fires, producing a no-op submit and leaving the pasted text orphaned in the input buffer.
- Reported by VELA via HELM 2026-04-17 ("maw hey ส่งข้อความไปแต่ไม่เข้า Claude prompt — ต้องกด Enter ซ้ำ"). Diagnosed by NEXUS via live pane capture (`tmux capture-pane`) + source trace.

## Why the existing 3-Enter stagger doesn't recover

The 500 ms / 1500 ms retries all fire on the **new** empty prompt produced by the first no-op submit. They submit empty lines rather than recovering the orphaned paste. User visible result: "text in my prompt but I must press Enter myself."

## Trade-off

Each `maw hey` gets 250 ms slower. Total user-visible delay is still under 2 s (paste + flush + 3 staggered Enters). Worth it for the reliability win.

## Test plan

- [ ] `bun install && bun test` green
- [ ] `pm2 restart maw`
- [ ] `maw hey <target> "verify-$(date +%s)"` — target session should process the message without requiring a manual Enter
- [ ] Run against a mid-tool-use target (known-flaky case) — paste should still commit and submit

## Scope boundary

Only touches `src/tmux.ts:sendText()`. No change to `comm.ts` / `ssh.ts` / config layer. Reversible via `git revert`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)