### PR TITLE
chore(oss): scaffold ship-this-week subset — badges + templates + CODEOWNERS + Dependabot (#452)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Catch-all
+*  @nazt
+
+# SDK — published package, higher review bar
+/packages/sdk/  @nazt
+
+# Core transport — federation + ssh + tmux are security-sensitive
+/src/core/  @nazt
+
+# CI / release
+/.github/  @nazt

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [nazt]

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,84 @@
+name: Bug report
+description: Something is broken — help us fix it.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill this out. The more detail you provide, the faster we can triage.
+
+  - type: input
+    id: maw-version
+    attributes:
+      label: maw version
+      description: Run `maw --version` and paste the output.
+      placeholder: "e.g. v2.0.0-alpha.121"
+    validations:
+      required: true
+
+  - type: input
+    id: command
+    attributes:
+      label: What command did you run?
+      description: Exact command, flags included.
+      placeholder: "e.g. maw hey node:agent hello"
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: What actually happened? Paste any error output here.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps that reproduce the issue every time.
+      placeholder: |
+        1. Start maw with `maw start`
+        2. Run `maw hey ...`
+        3. See error
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: OS
+      placeholder: "e.g. macOS 14.4 / Ubuntu 22.04"
+    validations:
+      required: true
+
+  - type: input
+    id: bun-version
+    attributes:
+      label: Bun version
+      description: Run `bun --version`.
+      placeholder: "e.g. 1.3.0"
+    validations:
+      required: true
+
+  - type: input
+    id: tmux-version
+    attributes:
+      label: tmux version (if relevant)
+      description: Run `tmux -V`. Leave blank if tmux is not involved.
+      placeholder: "e.g. tmux 3.4"
+
+  - type: textarea
+    id: anything-else
+    attributes:
+      label: Anything else?
+      description: Logs, config snippets, related issues — anything that might help.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/Soul-Brews-Studio/maw-js/security/advisories/new
+    about: Report privately via GitHub Security Advisory — NOT a public issue.
+  - name: Discussions / design proposals
+    url: https://github.com/Soul-Brews-Studio/maw-js/discussions
+    about: Talk it out before filing.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: Feature request
+description: Propose a new capability or improvement.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before opening, check [Discussions](https://github.com/Soul-Brews-Studio/maw-js/discussions) — design proposals land there first.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What problem does this solve? Who is affected?
+      placeholder: "As a maw user I want to ... so that ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+      description: Describe your ideal solution. Rough is fine.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about and why you ruled them out.
+
+  - type: textarea
+    id: related-issues
+    attributes:
+      label: Related issues / PRs
+      description: Paste any related issue or PR numbers.
+      placeholder: "Related to #123, see also #456"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Summary
+
+<!-- One sentence: what does this PR do and why? -->
+
+## Closes
+
+Closes #
+
+## Test plan
+
+- [ ] `bun run test:all` passes locally
+- [ ] Manually tested the affected command(s)
+- [ ] No existing tests deleted without replacement
+
+## Breaking changes?
+
+<!-- Yes / No. If yes, describe the impact and migration path. -->
+
+## Screenshots (if UI change)
+
+<!-- Drag images here or delete this section. -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "npm"
+    directory: "/packages/sdk"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # maw
 
+[![CI](https://github.com/Soul-Brews-Studio/maw-js/actions/workflows/ci.yml/badge.svg)](https://github.com/Soul-Brews-Studio/maw-js/actions/workflows/ci.yml) [![License](https://img.shields.io/badge/license-BUSL--1.1-blue)](./LICENSE) [![Version](https://img.shields.io/badge/version-2.0.0--alpha.121-orange)](https://github.com/Soul-Brews-Studio/maw-js/releases) [![Bun](https://img.shields.io/badge/runtime-Bun%201.3%2B-f9f1e1)](https://bun.sh)
+
 > Multi-Agent Workflow — wake oracles, talk across machines, see the mesh.
 
 ## Install


### PR DESCRIPTION
## Summary

Lands the ship-this-week subset of #452: 7 additive scaffold files that require no code changes and unblock OSS community contributions immediately.

## Surface area

| File | What it does |
|------|-------------|
| `README.md` | Badges row (CI, license, version, Bun) under H1 |
| `.github/ISSUE_TEMPLATE/bug_report.yml` | Structured bug form — maw version, command, expected/actual, repro, env |
| `.github/ISSUE_TEMPLATE/feature_request.yml` | Structured feature form — problem, solution, alternatives, related issues |
| `.github/ISSUE_TEMPLATE/config.yml` | Disables blank issues; links to Security Advisory + Discussions |
| `.github/PULL_REQUEST_TEMPLATE.md` | Summary, Closes #, test plan checklist, breaking changes, screenshots |
| `.github/CODEOWNERS` | `@nazt` owns `*`, `/packages/sdk/`, `/src/core/`, `/.github/` |
| `.github/FUNDING.yml` | `github: [nazt]` — enables Sponsor button |
| `.github/dependabot.yml` | Weekly npm (root + packages/sdk, patch/minor grouped, majors ignored) + GH Actions |

## Open questions for @nazt

- **FUNDING.yml**: Username `nazt` confirmed? Any other sponsor platforms to add (e.g. `open_collective`, `ko_fi`)?
- **Issue labels**: `bug` and `enhancement` are defaults — want a custom label taxonomy before templates go live (e.g. `plugin`, `federation`, `transport`)?
- **CODEOWNERS granularity**: Should individual plugin directories (e.g. `/src/commands/plugins/team/`) get separate owners as the team grows?

## Test plan

- [x] `bun run test:all` — 130 pass, 6 skip, 0 fail (pure scaffold, no logic changed)
- [x] All 7 files are additive only — zero modifications to existing code

## Not in this PR

- CHANGELOG.md — needs human curation
- README hero/GIF — blocked on #453 asciinema
- CodeQL workflow — separate PR, needs testing

---

Closes partial — ship-this-week subset of #452. CHANGELOG + CodeQL + README hero deferred. Do not auto-merge — @nazt review.