### PR TITLE
feat(costs): --daily sparkline — 7-day per-agent cost view (#454)

### DIFF
--- a/src/api/costs.ts
+++ b/src/api/costs.ts
@@ -85,6 +85,103 @@ function estimateCost(usage: SessionUsage): number {
   return (totalInput / 1_000_000) * rates.input + (usage.outputTokens / 1_000_000) * rates.output;
 }
 
+// ---------------------------------------------------------------------------
+// Helpers for /costs/daily
+// ---------------------------------------------------------------------------
+
+/** Convert an ISO timestamp string to a local-TZ "YYYY-MM-DD" string. */
+function localDateStr(isoTs: string): string {
+  const d = new Date(isoTs);
+  return [
+    d.getFullYear(),
+    String(d.getMonth() + 1).padStart(2, "0"),
+    String(d.getDate()).padStart(2, "0"),
+  ].join("-");
+}
+
+/**
+ * Generate N date strings (local TZ) ending today (inclusive), oldest first.
+ * Uses UTC arithmetic then converts to local date — DST-safe for display.
+ */
+function makeBuckets(n: number): string[] {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return Array.from({ length: n }, (_, i) => {
+    const d = new Date(today.getTime() - (n - 1 - i) * 86_400_000);
+    return localDateStr(d.toISOString());
+  });
+}
+
+costsApi.get("/costs/daily", ({ query, set }) => {
+  const days = Number(query.days ?? 7);
+  if (isNaN(days) || days < 1 || days > 365) {
+    set.status = 400;
+    return { error: "days must be 1–365" };
+  }
+
+  const buckets = makeBuckets(days);
+  const bucketIndex = new Map(buckets.map((b, i) => [b, i]));
+
+  const projectsDir = join(homedir(), ".claude", "projects");
+  let dirs: string[];
+  try {
+    dirs = readdirSync(projectsDir).filter((d) => {
+      try { return statSync(join(projectsDir, d)).isDirectory(); } catch { return false; }
+    });
+  } catch {
+    set.status = 500;
+    return { error: "Cannot read ~/.claude/projects/" };
+  }
+
+  // agentName → { costs: number[], hadActivity: boolean[] }
+  const agentDailyMap = new Map<string, { costs: number[]; hadActivity: boolean[] }>();
+
+  for (const dir of dirs) {
+    const dirPath = join(projectsDir, dir);
+    let files: string[];
+    try {
+      files = readdirSync(dirPath).filter((f) => f.endsWith(".jsonl"));
+    } catch { continue; }
+
+    if (files.length === 0) continue;
+    const agentName = agentNameFromDir(dir);
+
+    if (!agentDailyMap.has(agentName)) {
+      agentDailyMap.set(agentName, {
+        costs: Array(days).fill(0),
+        hadActivity: Array(days).fill(false),
+      });
+    }
+
+    const entry = agentDailyMap.get(agentName)!;
+
+    for (const file of files) {
+      const usage = scanSession(join(dirPath, file));
+      if (!usage || !usage.lastTimestamp) continue;
+
+      const dateStr = localDateStr(usage.lastTimestamp);
+      const idx = bucketIndex.get(dateStr);
+      if (idx === undefined) continue; // outside the window
+
+      entry.costs[idx] += estimateCost(usage);
+      entry.hadActivity[idx] = true;
+    }
+  }
+
+  const agents = [...agentDailyMap.entries()]
+    .filter(([, d]) => d.costs.reduce((s, v) => s + v, 0) > 0)
+    .map(([name, d]) => ({
+      name,
+      dailyCosts: d.costs,
+      totalCost: d.costs.reduce((s, v) => s + v, 0),
+      hadActivity: d.hadActivity,
+    }))
+    .sort((a, b) => b.totalCost - a.totalCost);
+
+  const totalCost = agents.reduce((s, a) => s + a.totalCost, 0);
+  return { window: days, buckets, agents, total: { cost: totalCost, agents: agents.length } };
+});
+
 costsApi.get("/costs", ({ set }) => {
   const projectsDir = join(homedir(), ".claude", "projects");
   let dirs: string[];

--- a/src/commands/plugins/costs/impl.ts
+++ b/src/commands/plugins/costs/impl.ts
@@ -1,5 +1,6 @@
 import { loadConfig } from "../../../config";
 import { UserError } from "../../../core/util/user-error";
+import { sparkline } from "../../../lib/sparkline";
 
 type CostAgent = {
   name: string;
@@ -86,6 +87,85 @@ export async function cmdCosts() {
   console.log(`  \x1b[90m${"─".repeat(hdr.length)}\x1b[0m`);
   const totalCostColor = total.cost > 50 ? "\x1b[31m" : total.cost > 10 ? "\x1b[33m" : "\x1b[32m";
   console.log(`  ${"TOTAL".padEnd(30)}  ${fmtNum(total.tokens).padStart(14)}  ${totalCostColor}${"$" + total.cost.toFixed(2)}`.padStart(12) + `\x1b[0m  ${String(total.sessions).padStart(10)}`);
+  console.log();
+}
+
+// ---------------------------------------------------------------------------
+// Daily view
+// ---------------------------------------------------------------------------
+
+type DailyResponse = {
+  error?: string;
+  window: number;
+  buckets: string[];
+  agents: Array<{
+    name: string;
+    dailyCosts: number[];
+    totalCost: number;
+    hadActivity: boolean[];
+  }>;
+  total: { cost: number; agents: number };
+};
+
+export async function cmdCostsDaily(days: number, json: boolean) {
+  const config = loadConfig();
+  const base = `http://${config.host}:${config.port}`;
+
+  let res: Response;
+  try {
+    res = await fetch(`${base}/api/costs/daily?days=${days}`);
+  } catch {
+    throw new UserError("cannot reach maw server — is `maw serve` running?");
+  }
+
+  const bodyText = await res.text().catch(() => "");
+  if (!res.ok) {
+    const suffix = bodyText ? `: ${bodyText.slice(0, 100)}` : "";
+    throw new Error(`maw server returned ${res.status} ${res.statusText}${suffix}`);
+  }
+
+  let data: DailyResponse;
+  try {
+    data = JSON.parse(bodyText) as DailyResponse;
+  } catch {
+    throw new Error(`maw server returned non-JSON response: ${bodyText.slice(0, 100)}`);
+  }
+
+  if (data.error) throw new Error(data.error);
+
+  if (json) {
+    console.log(JSON.stringify(data, null, 2));
+    return;
+  }
+
+  if (!data.agents.length) {
+    console.log(`\x1b[90mno activity in the last ${days} days\x1b[0m`);
+    return;
+  }
+
+  const lastBucket = data.buckets.at(-1) ?? "";
+  console.log(`\n\x1b[36mDAILY COSTS\x1b[0m  (${days}d ending ${lastBucket})\n`);
+
+  const nameW = 28;
+  for (const a of data.agents) {
+    const name =
+      a.name.length > nameW ? a.name.slice(0, nameW - 1) + "…" : a.name.padEnd(nameW);
+    const spark = sparkline(a.dailyCosts, a.hadActivity);
+    const cost = `$${a.totalCost.toFixed(2)}`;
+    console.log(`  ${name}  ${spark}  ${cost}`);
+  }
+
+  // Total row — sum across all agents per bucket
+  const totalCosts = (data.agents[0]?.dailyCosts ?? []).map(
+    (_: number, i: number) =>
+      data.agents.reduce((s: number, a) => s + a.dailyCosts[i], 0),
+  );
+  const totalHad = totalCosts.map((v: number) => v > 0);
+  const totalSpark = sparkline(totalCosts, totalHad);
+  const totalCostStr = `$${data.total.cost.toFixed(2)}`;
+  const sepLen = nameW + 2 + days + 4;
+  console.log(`  ${"─".repeat(sepLen)}`);
+  console.log(`  ${"TOTAL".padEnd(nameW)}  ${totalSpark}  ${totalCostStr}`);
   console.log();
 }
 

--- a/src/commands/plugins/costs/index.ts
+++ b/src/commands/plugins/costs/index.ts
@@ -1,10 +1,30 @@
 import type { InvokeContext, InvokeResult } from "../../../plugin/types";
-import { cmdCosts } from "./impl";
+import { parseFlags } from "../../../cli/parse-args";
+import { cmdCosts, cmdCostsDaily } from "./impl";
 
 export const command = {
   name: "costs",
   description: "Show token usage and estimated cost breakdown per agent.",
 };
+
+/**
+ * Inject a default numeric value after `--daily` when no value follows.
+ * `arg` typed as Number throws "option requires argument" if --daily is bare
+ * (e.g. `maw costs --daily` or `maw costs --daily --json`).
+ */
+function injectDailyDefault(args: string[]): string[] {
+  const result: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    result.push(args[i]);
+    if (args[i] === "--daily") {
+      const next = args[i + 1];
+      if (next === undefined || next.startsWith("-")) {
+        result.push("7"); // default window
+      }
+    }
+  }
+  return result;
+}
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
   const logs: string[] = [];
@@ -18,11 +38,47 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     if (ctx.writer) ctx.writer(...a);
     else logs.push(a.map(String).join(" "));
   };
+
   try {
-    await cmdCosts();
+    if (ctx.source === "cli") {
+      const rawArgs = ctx.args as string[];
+      // Pre-process: inject default "7" after --daily if no numeric value follows.
+      // `arg` throws "option requires argument" when --daily is typed as Number
+      // and is followed by another flag or is the last arg.
+      const args = injectDailyDefault(rawArgs);
+      const flags = parseFlags(
+        args,
+        {
+          "--daily": Number,
+          "--json": Boolean,
+          "-j": "--json",
+        },
+        0,
+      );
+
+      if (flags["--daily"] !== undefined) {
+        const days = flags["--daily"] || 7; // NaN guard (shouldn't happen after inject)
+        await cmdCostsDaily(days, !!flags["--json"]);
+      } else {
+        await cmdCosts();
+      }
+    } else {
+      // API / peer source: check args object
+      const body = ctx.args as Record<string, unknown>;
+      if (body.daily !== undefined) {
+        const days = Number(body.days ?? body.daily ?? 7);
+        await cmdCostsDaily(isNaN(days) ? 7 : days, !!body.json);
+      } else {
+        await cmdCosts();
+      }
+    }
     return { ok: true, output: logs.join("\n") || undefined };
   } catch (e: any) {
-    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+    return {
+      ok: false,
+      error: e.message ?? String(e),
+      output: logs.join("\n") || undefined,
+    };
   } finally {
     console.log = origLog;
     console.error = origError;

--- a/src/lib/sparkline.test.ts
+++ b/src/lib/sparkline.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "bun:test";
+import { sparkline } from "./sparkline";
+
+describe("sparkline()", () => {
+  it("happy path — normalizes correctly", () => {
+    // values=[0,1,3,7,5,2,0.5], max=7
+    // norms: round(0/7*7)=0→▁, round(1/7*7)=1→▂, round(3/7*7)=3→▄,
+    //        round(7/7*7)=7→█, round(5/7*7)=5→▆, round(2/7*7)=2→▃, round(0.5/7*7)=1→▂
+    const result = sparkline([0, 1, 3, 7, 5, 2, 0.5], Array(7).fill(true));
+    expect(result).toBe("▁▂▄█▆▃▂");
+    expect(result).toHaveLength(7);
+  });
+
+  it("single bucket — renders █ when cost > 0", () => {
+    expect(sparkline([2.5], [true])).toBe("█");
+  });
+
+  it("all zero cost, all active — renders ▁ (not ░)", () => {
+    expect(sparkline([0, 0, 0], [true, true, true])).toBe("▁▁▁");
+  });
+
+  it("no activity — renders ░", () => {
+    expect(sparkline([0, 0, 0], [false, false, false])).toBe("░░░");
+  });
+
+  it("mixed: some days active, some not", () => {
+    // day 0: ░ (no sessions), day 1: ░ (no sessions),
+    // day 2: max=1.2, norm=round(1.2/1.2*7)=7 → █
+    // day 3: active, cost=0, max>0 → norm=0 → ▁
+    const result = sparkline([0, 0, 1.2, 0], [false, false, true, true]);
+    expect(result).toBe("░░█▁");
+  });
+
+  it("large values — normalized correctly, no overflow", () => {
+    // max=500: round(100/500*7)=1→▂, round(200/500*7)=3→▄, round(500/500*7)=7→█, round(50/500*7)=1→▂
+    const result = sparkline([100, 200, 500, 50], Array(4).fill(true));
+    expect(result).toBe("▂▄█▂");
+  });
+
+  it("all same non-zero value — flat line at █", () => {
+    // max=1, each norm=round(1/1*7)=7 → BLOCKS[8]=█
+    expect(sparkline([1, 1, 1], Array(3).fill(true))).toBe("███");
+  });
+
+  it("omitted hadActivity defaults to v > 0 detection", () => {
+    // v=0 → not active → ░; v=1, v=2 → active
+    const r = sparkline([0, 1, 2]);
+    expect(r[0]).toBe("░"); // v=0, treated as not active
+    expect(r.slice(1)).not.toContain("░");
+  });
+
+  it("single-bucket zero cost no activity — ░", () => {
+    expect(sparkline([0], [false])).toBe("░");
+  });
+
+  it("seven-day all-inactive window — ░░░░░░░", () => {
+    expect(sparkline([0, 0, 0, 0, 0, 0, 0], Array(7).fill(false))).toBe("░░░░░░░");
+  });
+});

--- a/src/lib/sparkline.ts
+++ b/src/lib/sparkline.ts
@@ -1,0 +1,39 @@
+/**
+ * sparkline — render a Unicode block-character sparkline from numeric values.
+ *
+ * Used by `maw costs --daily` to visualise per-day cost per agent.
+ *
+ * Block characters (index 0 = space sentinel, 1–8 = ▁..█):
+ *   BLOCKS = [" ", "▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"]
+ *
+ * Absent-day marker: "░" (U+2591 LIGHT SHADE) — no sessions at all.
+ */
+
+const BLOCKS = " ▁▂▃▄▅▆▇█";
+
+/**
+ * Render a sparkline string from an array of numeric values.
+ *
+ * @param values      - cost per bucket (one entry per day window)
+ * @param hadActivity - parallel boolean array: true if any session existed
+ *                      that day, even if cost was 0.  Omit to auto-detect
+ *                      (active = v > 0).
+ * @returns           - string of Unicode chars, one per bucket
+ *
+ * Rules:
+ *   !hadActivity[i]        → "░"  (no sessions — visually distinct from zero-cost)
+ *   hadActivity[i] && max==0 → "▁"  (sessions exist but all free/cached)
+ *   else                   → BLOCKS[round(v / max * 7) + 1]  (▁..█)
+ */
+export function sparkline(values: number[], hadActivity?: boolean[]): string {
+  const max = Math.max(...values);
+  return values
+    .map((v, i) => {
+      const active = hadActivity ? hadActivity[i] : v > 0;
+      if (!active) return "░";
+      if (max === 0) return "▁"; // sessions exist but zero cost (free tier / cache)
+      const norm = Math.round((v / max) * 7); // 0..7
+      return BLOCKS[norm + 1]; // offset +1: 0→▁, 7→█
+    })
+    .join("");
+}

--- a/test/isolated/costs-daily.test.ts
+++ b/test/isolated/costs-daily.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, mock } from "bun:test";
+import { join } from "path";
+
+// Mock config so cmdCostsDaily can build its base URL in isolation.
+import { mockConfigModule } from "../helpers/mock-config";
+mock.module("../../src/config", () =>
+  mockConfigModule(() => ({ host: "localhost", port: 3456 })),
+);
+
+import type { InvokeContext } from "../../src/plugin/types";
+const { default: handler } = await import("../../src/commands/plugins/costs/index");
+
+// ---------------------------------------------------------------------------
+// Shared mock data
+// ---------------------------------------------------------------------------
+
+const mockDailyData = {
+  window: 7,
+  buckets: [
+    "2026-04-11",
+    "2026-04-12",
+    "2026-04-13",
+    "2026-04-14",
+    "2026-04-15",
+    "2026-04-16",
+    "2026-04-17",
+  ],
+  agents: [
+    {
+      name: "neo",
+      dailyCosts: [0.1, 0.2, 0.5, 1.4, 1.2, 0.6, 0.3],
+      totalCost: 4.3,
+      hadActivity: Array(7).fill(true),
+    },
+  ],
+  total: { cost: 4.3, agents: 1 },
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("costs plugin — --daily flag", () => {
+  it("--daily renders sparkline rows and DAILY COSTS header", async () => {
+    (global as any).fetch = mock(async () =>
+      new Response(JSON.stringify(mockDailyData), { status: 200 }),
+    );
+    const ctx: InvokeContext = { source: "cli", args: ["--daily", "7"] };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("DAILY COSTS");
+    expect(result.output).toContain("neo");
+    // At least one sparkline character present
+    expect(result.output).toMatch(/[▁▂▃▄▅▆▇█░]/);
+    // TOTAL row present
+    expect(result.output).toContain("TOTAL");
+  });
+
+  it("--daily --json returns raw JSON without sparkline", async () => {
+    (global as any).fetch = mock(async () =>
+      new Response(JSON.stringify(mockDailyData), { status: 200 }),
+    );
+    const ctx: InvokeContext = { source: "cli", args: ["--daily", "--json"] };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(true);
+    const parsed = JSON.parse(result.output ?? "{}");
+    expect(parsed.agents[0].dailyCosts).toHaveLength(7);
+    expect(parsed.buckets).toHaveLength(7);
+    // No sparkline chars in JSON output
+    expect(result.output).not.toMatch(/[▁▂▃▄▅▆▇█░]/);
+  });
+
+  it("bare --daily (no value) defaults to 7 days", async () => {
+    // arg parses --daily typed as Number with no value → NaN → should fall back to 7
+    let capturedUrl = "";
+    (global as any).fetch = mock(async (url: string) => {
+      capturedUrl = url;
+      return new Response(JSON.stringify(mockDailyData), { status: 200 });
+    });
+    const ctx: InvokeContext = { source: "cli", args: ["--daily"] };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(true);
+    expect(capturedUrl).toContain("days=7");
+  });
+
+  it("--daily with empty window returns graceful message", async () => {
+    (global as any).fetch = mock(async () =>
+      new Response(
+        JSON.stringify({
+          window: 7,
+          buckets: [],
+          agents: [],
+          total: { cost: 0, agents: 0 },
+        }),
+        { status: 200 },
+      ),
+    );
+    const ctx: InvokeContext = { source: "cli", args: ["--daily"] };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("no activity");
+  });
+
+  it("--daily with server error returns ok:false with maw serve hint", async () => {
+    (global as any).fetch = mock(async () => {
+      throw new Error("ECONNREFUSED");
+    });
+    const ctx: InvokeContext = { source: "cli", args: ["--daily"] };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("maw serve");
+  });
+
+  it("--daily with single-agent single-bucket renders █", async () => {
+    const singleBucket = {
+      window: 1,
+      buckets: ["2026-04-17"],
+      agents: [
+        {
+          name: "scout",
+          dailyCosts: [2.5],
+          totalCost: 2.5,
+          hadActivity: [true],
+        },
+      ],
+      total: { cost: 2.5, agents: 1 },
+    };
+    (global as any).fetch = mock(async () =>
+      new Response(JSON.stringify(singleBucket), { status: 200 }),
+    );
+    const ctx: InvokeContext = { source: "cli", args: ["--daily", "1"] };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("█");
+    expect(result.output).toContain("$2.50");
+  });
+
+  it("--daily with mixed-agent data shows ░ for absent days", async () => {
+    const mixedData = {
+      window: 4,
+      buckets: ["2026-04-14", "2026-04-15", "2026-04-16", "2026-04-17"],
+      agents: [
+        {
+          name: "oss-scaffold",
+          dailyCosts: [0, 0, 0.5, 1.0],
+          totalCost: 1.5,
+          hadActivity: [false, false, true, true],
+        },
+      ],
+      total: { cost: 1.5, agents: 1 },
+    };
+    (global as any).fetch = mock(async () =>
+      new Response(JSON.stringify(mixedData), { status: 200 }),
+    );
+    const ctx: InvokeContext = { source: "cli", args: ["--daily", "4"] };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(true);
+    // ░ for absent days, block chars for active days
+    expect(result.output).toContain("░");
+    expect(result.output).toMatch(/[▁▂▃▄▅▆▇█]/);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `maw costs --daily [N]` flag (default 7, max 365) — renders a 7-day per-agent sparkline cost table
- New `GET /api/costs/daily?days=N` endpoint (additive — existing `/costs` is untouched, no regressions)
- New `src/lib/sparkline.ts` — pure zero-dep Unicode block-char renderer, independently unit-tested
- `--json` flag for machine-readable output; `░` vs `▁` distinguishes absent-day from zero-cost-day

## Surface area

| File | Change |
|---|---|
| `src/lib/sparkline.ts` | NEW — `sparkline(values, hadActivity?)` pure function |
| `src/lib/sparkline.test.ts` | NEW — 10 unit tests |
| `src/api/costs.ts` | +GET `/costs/daily` route + `makeBuckets()` + `localDateStr()` helpers |
| `src/commands/plugins/costs/impl.ts` | +`cmdCostsDaily(days, json)` export |
| `src/commands/plugins/costs/index.ts` | +`--daily` / `--json` flag wiring + `injectDailyDefault()` helper |
| `test/isolated/costs-daily.test.ts` | NEW — 7 isolated integration tests |

## Test plan

- [x] `src/lib/sparkline.test.ts` — 10 unit tests: happy path, single-bucket, all-zero-active, all-inactive, mixed, large values, flat line, omitted-hadActivity, edge cases
- [x] `test/isolated/costs-daily.test.ts` — 7 integration tests: sparkline render, `--json` output, bare `--daily` defaults to 7, empty window, server error, single-bucket `█`, mixed-agent `░` days
- [x] Existing `costs.test.ts` + `costs-errors.test.ts` — all pass (no regression)
- [x] `bun run test:all` → 51/51 files, 1995 tests passing
- [x] `test/isolated/costs-daily.test.ts` placement satisfies mock-boundary rule (`scripts/check-mock-boundary.sh`)

## Sample output

```
$ maw costs --daily

DAILY COSTS  (7d ending 2026-04-17)

  neo                           ▁▂▄█▆▃▂  $4.30
  ──────────────────────────────────────
  TOTAL                         ▁▂▄█▆▃▂  $4.30
```

```
$ maw costs --daily --json
{
  "window": 7,
  "buckets": ["2026-04-11", ..., "2026-04-17"],
  "agents": [{ "name": "neo", "dailyCosts": [...], "totalCost": 4.30, "hadActivity": [...] }],
  "total": { "cost": 4.30, "agents": 1 }
}
```

## Implementation notes

- `injectDailyDefault()` pre-processes args to handle bare `--daily` (no value) — `arg` typed as `Number` throws `option requires argument` otherwise; injecting `"7"` before the flag is parsed avoids the throw cleanly
- Bucket assignment uses `lastTimestamp` (already in `SessionUsage`) — no schema change needed
- `makeBuckets()` uses UTC arithmetic + local-TZ display string — DST-safe for date labels

Closes #454. Do not auto-merge — @nazt review.