### PR TITLE
ci: auto-regenerate bun.lock on dependabot PRs (#466)

### DIFF
--- a/.github/workflows/dependabot-bunlock.yml
+++ b/.github/workflows/dependabot-bunlock.yml
@@ -1,0 +1,59 @@
+name: Dependabot — regenerate bun.lock
+
+# Fixes #466 — dependabot bumps package.json but doesn't regenerate bun.lock,
+# so CI's `bun install --frozen-lockfile` rejects with "lockfile had changes,
+# but lockfile is frozen". This workflow runs `bun install` on dependabot PRs
+# and commits the updated lockfile back to the PR branch.
+#
+# Loop prevention:
+#   - `if: github.actor == 'dependabot[bot]'` gates the job.
+#   - When this workflow pushes a commit, github.actor becomes
+#     github-actions[bot], so the job condition is false → no recursion.
+#   - Dependabot does not re-run on non-dependabot pushes.
+
+on:
+  pull_request:
+    branches: [alpha, main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  regen-lockfile:
+    name: Regenerate bun.lock if stale
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - name: Regenerate lockfile
+        run: bun install
+
+      - name: Check if lockfile changed
+        id: diff
+        run: |
+          if git diff --exit-code bun.lock; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit updated lockfile
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add bun.lock
+          git commit -m "chore(deps): update bun.lock for dependabot PR"
+          git push


### PR DESCRIPTION
## Summary

Fixes #466 — auto-regenerate `bun.lock` on dependabot PRs so `bun install --frozen-lockfile` in CI no longer rejects them.

## How

New workflow `.github/workflows/dependabot-bunlock.yml`:

1. Fires on `pull_request` events targeting `alpha` or `main`
2. Guard: `if: github.actor == 'dependabot[bot]'` — runs ONLY for dependabot-authored PRs
3. Checks out the PR branch head
4. Runs `bun install` (NOT `--frozen-lockfile`) to regenerate the lockfile
5. If the lockfile changed, commits as `github-actions[bot]` with message `chore(deps): update bun.lock for dependabot PR`
6. Pushes back to the PR branch, triggering CI rerun

## Loop prevention

The guard `if: github.actor == 'dependabot[bot]'` is the single point of control. When this workflow pushes a commit, `github.actor` becomes `github-actions[bot]`, the job condition is false, no recursion. Dependabot does not re-run on non-dependabot pushes. At most 2 CI runs per bump.

## Test plan

- [x] YAML parses (no syntax errors)
- [ ] CI (standard gh-actions lint, any repo checks)
- [ ] Post-merge: verify #461 auto-retries within ~10 min of next dependabot cycle (or manually `@dependabot rebase`)
- [ ] Edge case: when lockfile has no diff, workflow exits cleanly without committing

## Permissions

`contents: write` + `pull-requests: write` scoped to this job only. `GITHUB_TOKEN` sufficient (no PAT).

## Open question for @nazt

Branch-protection policy on `alpha` / `main` — if rules block `github-actions[bot]` pushes to PR branches, we'll need a PAT. Unblocks with a one-line `token: ${{ secrets.PAT }}` swap later.

Closes #466. Unblocks #461.

Co-Authored-By: mawjs <noreply@soulbrews.studio>