### PR TITLE
refactor(api): require explicit NODE_ENV=development for peer-exec/proxy session bypass

### DIFF
--- a/src/api/peer-exec.ts
+++ b/src/api/peer-exec.ts
@@ -89,7 +89,8 @@ peerExecApi.post("/peer/exec", async ({ body, headers, set}) => {
   }
 
   // 2. Session cookie check
-  const devBypass = process.env.NODE_ENV !== "production";
+  // Bypass ONLY when explicitly in dev mode. Default (unset NODE_ENV) = secure.
+  const devBypass = process.env.NODE_ENV === "development";
   if (!devBypass && !hasValidSessionCookie(headers)) {
     set.status = 401; return { error: "no_session", hint: "GET /api/peer/session first" };
   }

--- a/src/api/proxy-routes.ts
+++ b/src/api/proxy-routes.ts
@@ -46,8 +46,9 @@ proxyApi.post("/proxy", async ({ body, set, request }) => {
     return { error: "bad_signature", expected: "[host:agent]" };
   }
 
-  // 2. Session cookie check (dev bypass on NODE_ENV !== production)
-  const devBypass = process.env.NODE_ENV !== "production";
+  // 2. Session cookie check
+  // Bypass ONLY when explicitly in dev mode. Default (unset NODE_ENV) = secure.
+  const devBypass = process.env.NODE_ENV === "development";
   if (!devBypass && !hasValidProxySessionCookie(request)) {
     set.status = 401;
     return { error: "no_session", hint: "GET /api/proxy/session first" };


### PR DESCRIPTION
## Summary

Both `/api/peer/exec` (peer-exec.ts:92) and `/api/proxy` (proxy-routes.ts:50) gated the session cookie check with `const devBypass = process.env.NODE_ENV !== "production"`.

Since `NODE_ENV` is unset in most environments — local dev, unconfigured production deployments, CI containers — this defaulted to `devBypass === true`, skipping the session cookie check entirely. Opposite of the intent.

## Change

Inverted: session bypass now requires `NODE_ENV === "development"` explicitly. Unset = secure (cookie required).

## Surface area

| File | Lines | Risk |
|---|---|---|
| src/api/peer-exec.ts | +2/-1 | Low |
| src/api/proxy-routes.ts | +2/-1 | Low |

## Test plan

- [x] `bun run test:all` — 2865 pass / 18 skip / 3 fail (same 3 #467 batch-pollution failures, not caused by this change)
- [ ] CI
- [ ] Follow-up PR: add isolated test that spawns API without NODE_ENV and asserts 401 (deferred to keep this minimal)

## Rollout

Anyone running maw locally with `NODE_ENV` unset will now need a session cookie for these routes. The fix is obvious: `export NODE_ENV=development` in dev shells. README can mention this in the contributor setup section.

Part of the internal defensive-refactor pass.

Co-Authored-By: mawjs <noreply@soulbrews.studio>