### PR TITLE
refactor(tmux): route legacy hostExec calls through Tmux class

### DIFF
--- a/src/commands/plugins/pr/impl.ts
+++ b/src/commands/plugins/pr/impl.ts
@@ -1,4 +1,4 @@
-import { hostExec } from "../../../sdk";
+import { Tmux } from "../../../core/transport/tmux";
 
 function branchToTitle(branch: string): string {
   // Strip prefix like "agents/" or "feature/"
@@ -19,23 +19,29 @@ export async function cmdPr(window?: string): Promise<void> {
     throw new Error("not in a tmux session — run inside tmux");
   }
 
+  const t = new Tmux();
+
   // Get cwd of target window (or current pane)
   let cwd: string;
   if (window) {
-    const session = (await hostExec("tmux display-message -p '#{session_name}'")).trim();
-    cwd = (await hostExec(`tmux display-message -t '${session}:${window}' -p '#{pane_current_path}'`)).trim();
+    const session = (await t.run("display-message", "-p", "#{session_name}")).trim();
+    cwd = (await t.run("display-message", "-t", `${session}:${window}`, "-p", "#{pane_current_path}")).trim();
   } else {
-    cwd = (await hostExec("tmux display-message -p '#{pane_current_path}'")).trim();
+    cwd = (await t.run("display-message", "-p", "#{pane_current_path}")).trim();
   }
 
   if (!cwd) {
     throw new Error("could not detect working directory");
   }
 
-  // Get current branch
+  // Get current branch — use Bun.spawn arg-array to avoid cwd single-quote injection
   let branch: string;
   try {
-    branch = (await hostExec(`git -C '${cwd}' branch --show-current`)).trim();
+    const proc = Bun.spawn(["git", "-C", cwd, "branch", "--show-current"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    branch = (await new Response(proc.stdout).text()).trim();
   } catch {
     throw new Error(`not a git repo: ${cwd}`);
   }
@@ -50,11 +56,20 @@ export async function cmdPr(window?: string): Promise<void> {
   if (issueNum) console.log(`\x1b[36m⚡\x1b[0m linking to issue #${issueNum}`);
 
   const body = issueNum ? `Closes #${issueNum}` : "";
-  const bodyFlag = body ? `--body '${body}'` : "--body ''";
-  const titleEscaped = title.replace(/'/g, "'\\''");
 
+  // Use Bun.spawn arg-array with cwd option — eliminates cd + shell-quoting workarounds
   try {
-    const result = await hostExec(`cd '${cwd}' && gh pr create --title '${titleEscaped}' ${bodyFlag}`);
+    const ghArgs = ["pr", "create", "--title", title];
+    if (body) ghArgs.push("--body", body);
+    else ghArgs.push("--body", "");
+    const ghProc = Bun.spawn(["gh", ...ghArgs], { stdout: "pipe", stderr: "pipe", cwd });
+    const [out, , code] = await Promise.all([
+      new Response(ghProc.stdout).text(),
+      new Response(ghProc.stderr).text(),
+      ghProc.exited,
+    ]);
+    if (code !== 0) throw new Error(`gh pr create failed (exit ${code})`);
+    const result = out.trim();
     console.log(`\x1b[32m✅\x1b[0m ${result}`);
   } catch (e: any) {
     throw new Error(e.message);

--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -4,8 +4,9 @@
 
 import {
   listSessions, capture, sendKeys, getPaneCommand, findPeerForTarget, resolveTarget,
-  curlFetch, runHook, hostExec,
+  curlFetch, runHook,
 } from "../../sdk";
+import { Tmux } from "../../core/transport/tmux";
 import { loadConfig, cfgLimit } from "../../config";
 import { logMessage, emitFeed } from "./comm-log-feed";
 import { writeInboxFile } from "../plugins/inbox/impl";
@@ -44,10 +45,9 @@ export async function resolveOraclePane(target: string): Promise<string> {
   if (/\.[0-9]+$/.test(target)) return target;
 
   try {
-    const raw = await hostExec(
-      `tmux list-panes -t '${target}' -F '#{pane_index} #{pane_current_command}'`,
-    );
-    const lines = raw.split("\n").map(l => l.trim()).filter(Boolean);
+    const t = new Tmux();
+    const raw = await t.run("list-panes", "-t", target, "-F", "#{pane_index} #{pane_current_command}");
+    const lines = raw.split("\n").map((l: string) => l.trim()).filter(Boolean);
     if (lines.length <= 1) return target; // single-pane window: active pane is the only pane
 
     const agentIndexes: number[] = [];

--- a/src/core/transport/ssh.ts
+++ b/src/core/transport/ssh.ts
@@ -1,5 +1,5 @@
 import { loadConfig } from "../../config";
-import { tmuxCmd } from "./tmux";
+import { tmuxCmd, Tmux } from "./tmux";
 
 const DEFAULT_HOST = process.env.MAW_HOST || loadConfig().host || "local";
 const IS_LOCAL = DEFAULT_HOST === "local" || DEFAULT_HOST === "localhost";
@@ -50,40 +50,18 @@ export const ssh = hostExec;
 import type { Session } from "../runtime/find-window";
 
 export async function listSessions(host?: string): Promise<Session[]> {
-  let raw: string;
-  try { raw = await hostExec(`${tmuxCmd()} list-sessions -F '#{session_name}' 2>/dev/null`, host); }
-  catch { return []; }
-  const sessions: Session[] = [];
-  for (const s of raw.split("\n").filter(Boolean)) {
-    try {
-      const winRaw = await hostExec(
-        `${tmuxCmd()} list-windows -t '${s}' -F '#{window_index}:#{window_name}:#{window_active}' 2>/dev/null`,
-        host,
-      );
-      const windows = winRaw.split("\n").filter(Boolean).map(w => {
-        const [idx, name, active] = w.split(":");
-        return { index: +idx, name, active: active === "1" };
-      });
-      sessions.push({ name: s, windows });
-    } catch {
-      // Session may have died between list-sessions and list-windows
-      sessions.push({ name: s, windows: [] });
-    }
-  }
-  return sessions;
+  const t = new Tmux(host);
+  return t.listSessions();
 }
 
 export async function capture(target: string, lines = 80, host?: string): Promise<string> {
-  // -e preserves ANSI escape sequences (colors), -S captures scroll-back
-  if (lines > 50) {
-    // Grab full visible pane + some scrollback
-    return hostExec(`${tmuxCmd()} capture-pane -t '${target}' -e -p -S -${lines} 2>/dev/null`, host);
-  }
-  return hostExec(`${tmuxCmd()} capture-pane -t '${target}' -e -p 2>/dev/null | tail -${lines}`, host);
+  const t = new Tmux(host);
+  return t.capture(target, lines);
 }
 
 export async function selectWindow(target: string, host?: string): Promise<void> {
-  await hostExec(`${tmuxCmd()} select-window -t '${target}' 2>/dev/null`, host);
+  const t = new Tmux(host);
+  await t.selectWindow(target);
 }
 
 export async function switchClient(session: string, host?: string): Promise<void> {

--- a/test/isolated/comm-send-resolve-pane.test.ts
+++ b/test/isolated/comm-send-resolve-pane.test.ts
@@ -1,0 +1,126 @@
+/**
+ * test/isolated/comm-send-resolve-pane.test.ts
+ *
+ * Unit tests for resolveOraclePane() after the defensive refactor (H1).
+ * Verifies that target strings are passed as discrete args to Tmux.run()
+ * rather than interpolated into a shell string — which means injection
+ * characters in target values cannot break out of the tmux target context.
+ *
+ * Isolated because mock.module is process-global and stubs the tmux transport.
+ */
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+import { join } from "path";
+import { mockConfigModule } from "../helpers/mock-config";
+
+const srcRoot = join(import.meta.dir, "../..");
+
+// --- Capture real Tmux refs BEFORE any mock.module installs ---
+const _rTmux = await import("../../src/core/transport/tmux");
+
+// --- Mutable run stub ---
+type RunCall = { subcommand: string; args: (string | number)[] };
+let runCalls: RunCall[] = [];
+let runReturnValue = "";
+
+// --- Mock tmux module ---
+mock.module(join(srcRoot, "src/core/transport/tmux"), () => {
+  class MockTmux {
+    constructor(public host?: string, public socket?: string) {}
+    async run(subcommand: string, ...args: (string | number)[]): Promise<string> {
+      runCalls.push({ subcommand, args });
+      return runReturnValue;
+    }
+    async tryRun(subcommand: string, ...args: (string | number)[]): Promise<string> {
+      return this.run(subcommand, ...args);
+    }
+  }
+  return {
+    ..._rTmux,
+    Tmux: MockTmux,
+    tmux: new MockTmux(),
+  };
+});
+
+// --- Mock config ---
+mock.module(join(srcRoot, "src/config"), () =>
+  mockConfigModule(() => ({ node: "test-node" })),
+);
+
+// --- Mock sdk (need to stub listSessions etc but not hostExec) ---
+mock.module(join(srcRoot, "src/sdk"), () => ({
+  listSessions: async () => [],
+  capture: async () => "",
+  sendKeys: async () => {},
+  getPaneCommand: async () => "claude",
+  findPeerForTarget: async () => null,
+  resolveTarget: () => null,
+  curlFetch: async () => ({ ok: false, status: 0, data: null }),
+  runHook: async () => {},
+  hostExec: async () => "",
+}));
+
+// --- Import the module under test AFTER all mock.module installs ---
+const { resolveOraclePane } = await import("../../src/commands/shared/comm-send");
+
+describe("resolveOraclePane — H1 defensive refactor", () => {
+  beforeEach(() => {
+    runCalls = [];
+    runReturnValue = "";
+  });
+
+  test("Case 1 — benign target: Tmux.run called with correct args, agent pane selected", async () => {
+    // Two panes: index 0 = claude (agent), index 1 = zsh
+    runReturnValue = "0 claude\n1 zsh\n";
+    const result = await resolveOraclePane("mawjs-session:mawjs-oracle");
+    // Should resolve to pane 0 (agent at index 0)
+    expect(result).toBe("mawjs-session:mawjs-oracle.0");
+    // Should have called Tmux.run with discrete args
+    expect(runCalls).toHaveLength(1);
+    expect(runCalls[0].subcommand).toBe("list-panes");
+    expect(runCalls[0].args).toEqual(["-t", "mawjs-session:mawjs-oracle", "-F", "#{pane_index} #{pane_current_command}"]);
+  });
+
+  test("Case 2 — injection character in target does NOT reach shell as interpreted text", async () => {
+    // Single-pane result so we don't alter the return value
+    runReturnValue = "0 claude\n";
+    const injectionTarget = "a'; touch /tmp/pwned; tmux #";
+    await resolveOraclePane(injectionTarget);
+    // Tmux.run must have been called with the literal injection string as a separate arg
+    expect(runCalls).toHaveLength(1);
+    // The target must appear as a discrete argument element, not inside a shell string
+    const targetArgIndex = runCalls[0].args.indexOf(injectionTarget);
+    expect(targetArgIndex).toBeGreaterThanOrEqual(0);
+    // Verify the injection string is the exact value of args[1] (after "-t")
+    expect(runCalls[0].args[0]).toBe("-t");
+    expect(runCalls[0].args[1]).toBe(injectionTarget);
+  });
+
+  test("Case 3 — pane-specific target passes through untouched (no Tmux.run call)", async () => {
+    const result = await resolveOraclePane("session:window.2");
+    // Regex short-circuit: already has .N suffix
+    expect(result).toBe("session:window.2");
+    expect(runCalls).toHaveLength(0);
+  });
+
+  test("Case 4 — single-pane window: returns target unchanged", async () => {
+    runReturnValue = "0 zsh\n";
+    const result = await resolveOraclePane("my-session:oracle");
+    expect(result).toBe("my-session:oracle");
+  });
+
+  test("Case 5 — no agent pane found: returns target unchanged", async () => {
+    runReturnValue = "0 zsh\n1 bash\n";
+    const result = await resolveOraclePane("my-session:oracle");
+    expect(result).toBe("my-session:oracle");
+  });
+
+  test("Case 6 — Tmux.run throws: returns target unchanged (error swallowed)", async () => {
+    // Override run to throw
+    const _rTmuxAgain = await import("../../src/core/transport/tmux");
+    const origRun = (_rTmuxAgain.Tmux.prototype as any).run;
+    (_rTmuxAgain.Tmux.prototype as any).run = async () => { throw new Error("tmux not running"); };
+    const result = await resolveOraclePane("my-session:oracle");
+    expect(result).toBe("my-session:oracle");
+    (_rTmuxAgain.Tmux.prototype as any).run = origRun;
+  });
+});

--- a/test/isolated/pr-impl.test.ts
+++ b/test/isolated/pr-impl.test.ts
@@ -1,0 +1,238 @@
+/**
+ * test/isolated/pr-impl.test.ts
+ *
+ * Unit tests for cmdPr() after the H6 defensive refactor.
+ * Verifies that tmux display-message calls are routed through Tmux.run
+ * (arg-array, q()-escaped) and that git/gh subprocesses use Bun.spawn
+ * arg-arrays rather than shell-interpolated strings.
+ *
+ * Isolated because mock.module is process-global and stubs the Tmux class
+ * and Bun.spawn.
+ */
+import { describe, test, expect, mock, spyOn, beforeEach, afterEach } from "bun:test";
+import { join } from "path";
+import { mockConfigModule } from "../helpers/mock-config";
+
+const srcRoot = join(import.meta.dir, "../..");
+
+// --- Capture real Tmux refs BEFORE any mock.module installs ---
+const _rTmux = await import("../../src/core/transport/tmux");
+
+// --- Mutable stub state ---
+type RunCall = { subcommand: string; args: (string | number)[] };
+let runCalls: RunCall[] = [];
+let runResponses: Map<string, string> = new Map();
+
+// --- Mock tmux module ---
+mock.module(join(srcRoot, "src/core/transport/tmux"), () => {
+  class MockTmux {
+    constructor(public host?: string, public socket?: string) {}
+
+    async run(subcommand: string, ...args: (string | number)[]): Promise<string> {
+      runCalls.push({ subcommand, args });
+      // Key by subcommand + first few args for routing
+      const key = [subcommand, ...args].join(" ");
+      for (const [pattern, val] of runResponses) {
+        if (key.includes(pattern)) return val;
+      }
+      return "";
+    }
+
+    async tryRun(subcommand: string, ...args: (string | number)[]): Promise<string> {
+      return this.run(subcommand, ...args);
+    }
+  }
+
+  return {
+    ..._rTmux,
+    Tmux: MockTmux,
+    tmux: new MockTmux(),
+  };
+});
+
+// --- Mock config ---
+mock.module(join(srcRoot, "src/config"), () =>
+  mockConfigModule(() => ({ node: "test-node" })),
+);
+
+// --- Bun.spawn spy setup ---
+type SpawnCall = { cmd: string[]; opts?: Record<string, unknown> };
+let spawnCalls: SpawnCall[] = [];
+
+// --- Import module under test AFTER all mock.module installs ---
+const { cmdPr } = await import("../../src/commands/plugins/pr/impl");
+
+// --- Helper to make a mock spawn proc ---
+function makeMockProc(stdout: string, exitCode = 0) {
+  const enc = new TextEncoder();
+  const rs = new ReadableStream({
+    start(controller) {
+      controller.enqueue(enc.encode(stdout));
+      controller.close();
+    },
+  });
+  const errRs = new ReadableStream({ start(c) { c.close(); } });
+  return {
+    stdout: rs,
+    stderr: errRs,
+    exited: Promise.resolve(exitCode),
+  };
+}
+
+describe("cmdPr — H6 defensive refactor", () => {
+  const origTmux = process.env.TMUX;
+  let spawnSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    runCalls = [];
+    spawnCalls = [];
+    runResponses = new Map();
+    process.env.TMUX = "/tmp/tmux-1000/default,1,0";
+
+    // Spy on Bun.spawn to capture calls without actually spawning processes
+    spawnSpy = spyOn(Bun, "spawn").mockImplementation((cmd: any, opts?: any) => {
+      spawnCalls.push({ cmd: Array.isArray(cmd) ? cmd : [cmd], opts });
+      const cmdStr = Array.isArray(cmd) ? cmd[0] : cmd;
+      // Return appropriate mock proc based on command
+      if (cmdStr === "git") return makeMockProc("feat/issue-42\n") as any;
+      if (cmdStr === "gh") return makeMockProc("https://github.com/org/repo/pull/99\n") as any;
+      return makeMockProc("") as any;
+    });
+  });
+
+  afterEach(() => {
+    if (origTmux === undefined) delete process.env.TMUX;
+    else process.env.TMUX = origTmux;
+    spawnSpy.mockRestore();
+  });
+
+  test("Case 1 — cmdPr without window: uses current pane path via Tmux.run", async () => {
+    // Setup: display-message -p #{pane_current_path} → /home/neo/repos/maw-js
+    runResponses.set("display-message", "/home/neo/repos/maw-js");
+
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: any[]) => logs.push(args.join(" "));
+
+    try {
+      await cmdPr();
+    } finally {
+      console.log = origLog;
+    }
+
+    // Tmux.run must have been called with display-message args (no window)
+    const displayCall = runCalls.find(c => c.subcommand === "display-message");
+    expect(displayCall).toBeDefined();
+    expect(displayCall!.args).toContain("#{pane_current_path}");
+
+    // git spawn should have been called with cwd as a separate arg (not in shell string)
+    const gitCall = spawnCalls.find(c => c.cmd[0] === "git");
+    expect(gitCall).toBeDefined();
+    expect(gitCall!.cmd).toEqual(["git", "-C", "/home/neo/repos/maw-js", "branch", "--show-current"]);
+    expect(gitCall!.opts?.cwd).toBeUndefined(); // cwd is passed as -C arg, not spawn option
+
+    // gh spawn should use cwd option instead of cd-in-shell
+    const ghCall = spawnCalls.find(c => c.cmd[0] === "gh");
+    expect(ghCall).toBeDefined();
+    expect(ghCall!.opts?.cwd).toBe("/home/neo/repos/maw-js");
+    expect(ghCall!.cmd).toContain("--title");
+    // gh cmd must NOT contain any single-quote shell quoting
+    const hasShellQuotes = ghCall!.cmd.some(a => typeof a === "string" && a.includes("'"));
+    expect(hasShellQuotes).toBe(false);
+
+    // Should have logged success
+    expect(logs.some(l => l.includes("✅"))).toBe(true);
+  });
+
+  test("Case 2 — single quote in window name reaches Tmux.run as separate argv", async () => {
+    // Setup two display-message calls: one for session_name, one for pane_current_path
+    let runCallIndex = 0;
+    const _rTmuxAgain = await import("../../src/core/transport/tmux");
+    const MockTmuxClass = _rTmuxAgain.Tmux as any;
+    const origRun = MockTmuxClass.prototype.run;
+    MockTmuxClass.prototype.run = async function(subcommand: string, ...args: (string | number)[]) {
+      runCalls.push({ subcommand, args });
+      if (subcommand === "display-message" && args.includes("#{session_name}")) return "test-session";
+      if (subcommand === "display-message" && args.includes("#{pane_current_path}")) return "/home/neo/repo";
+      return "";
+    };
+
+    const windowWithQuote = "a'b";
+
+    try {
+      await cmdPr(windowWithQuote);
+    } catch {
+      // May throw on git/gh errors, that's OK — we just check the tmux calls
+    } finally {
+      MockTmuxClass.prototype.run = origRun;
+    }
+
+    // Find the call that uses the window-based target
+    const targetCall = runCalls.find(c =>
+      c.subcommand === "display-message" &&
+      c.args.some(a => typeof a === "string" && a.includes("a'b")),
+    );
+    expect(targetCall).toBeDefined();
+    // The window value must appear inside the target arg as a literal string
+    const targetArg = targetCall!.args.find(a => typeof a === "string" && a.includes(windowWithQuote));
+    expect(targetArg).toBeDefined();
+    // The target arg must be the combined "session:window" value, NOT a shell-expanded string
+    expect(String(targetArg)).toContain(windowWithQuote);
+  });
+
+  test("Case 3 — gh pr create uses Bun.spawn cwd option instead of cd in shell", async () => {
+    runResponses.set("display-message", "/home/neo/repos/maw-js");
+
+    try {
+      await cmdPr();
+    } catch { /* ignore errors — checking spawn calls */ }
+
+    const ghCall = spawnCalls.find(c => c.cmd[0] === "gh");
+    if (ghCall) {
+      // cwd option must be set on the spawn call
+      expect(ghCall.opts?.cwd).toBe("/home/neo/repos/maw-js");
+      // gh cmd must NOT start with "cd " (no shell cd prepended)
+      expect(ghCall.cmd[0]).toBe("gh");
+      // gh cmd must NOT include any `cd '...'` pattern
+      const hasShellCd = ghCall.cmd.some(a => typeof a === "string" && a.startsWith("cd "));
+      expect(hasShellCd).toBe(false);
+    }
+  });
+
+  test("Case 4 — outside tmux: throws immediately without calling Tmux.run", async () => {
+    delete process.env.TMUX;
+    await expect(cmdPr()).rejects.toThrow("not in a tmux session");
+    expect(runCalls).toHaveLength(0);
+  });
+
+  test("Case 5 — branchToTitle handles issue branch correctly", async () => {
+    runResponses.set("display-message", "/home/neo/repos/maw-js");
+    // git returns an issue-prefixed branch
+    spawnSpy.mockImplementation((cmd: any, opts?: any) => {
+      spawnCalls.push({ cmd: Array.isArray(cmd) ? cmd : [cmd], opts });
+      if (cmd[0] === "git") return makeMockProc("feat/issue-123-tmux-refactor\n") as any;
+      if (cmd[0] === "gh") return makeMockProc("https://github.com/org/repo/pull/100\n") as any;
+      return makeMockProc("") as any;
+    });
+
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: any[]) => logs.push(args.join(" "));
+    try {
+      await cmdPr();
+    } finally {
+      console.log = origLog;
+    }
+
+    // Should have logged issue link and PR success
+    expect(logs.some(l => l.includes("#123"))).toBe(true);
+    expect(logs.some(l => l.includes("✅"))).toBe(true);
+
+    // gh command body should contain "Closes #123"
+    const ghCall = spawnCalls.find(c => c.cmd[0] === "gh");
+    expect(ghCall).toBeDefined();
+    const bodyIdx = ghCall!.cmd.indexOf("--body");
+    expect(bodyIdx).toBeGreaterThan(-1);
+    expect(ghCall!.cmd[bodyIdx + 1]).toContain("Closes #123");
+  });
+});

--- a/test/isolated/ssh-transport.test.ts
+++ b/test/isolated/ssh-transport.test.ts
@@ -1,0 +1,175 @@
+/**
+ * test/isolated/ssh-transport.test.ts
+ *
+ * Unit tests for ssh.ts transport functions after the H2 defensive refactor.
+ * Verifies that listSessions, capture, and selectWindow delegate to the
+ * Tmux class (which routes all args through q()) rather than building raw
+ * shell strings with single-quote interpolation.
+ *
+ * Isolated because mock.module is process-global and stubs the Tmux class
+ * which is shared across many modules.
+ */
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+import { join } from "path";
+import { mockConfigModule } from "../helpers/mock-config";
+
+const srcRoot = join(import.meta.dir, "../..");
+
+// --- Capture real Tmux refs BEFORE any mock.module installs ---
+const _rTmux = await import("../../src/core/transport/tmux");
+
+// --- Mutable stub state ---
+type RunCall = { subcommand: string; args: (string | number)[] };
+let runCalls: RunCall[] = [];
+let runReturnValue = "";
+let listSessionsReturn: { name: string; windows: { index: number; name: string; active: boolean }[] }[] = [];
+let captureReturnValue = "";
+let selectWindowCalls: string[] = [];
+
+// --- Mock tmux module ---
+mock.module(join(srcRoot, "src/core/transport/tmux"), () => {
+  class MockTmux {
+    constructor(public host?: string, public socket?: string) {}
+
+    async run(subcommand: string, ...args: (string | number)[]): Promise<string> {
+      runCalls.push({ subcommand, args });
+      return runReturnValue;
+    }
+
+    async tryRun(subcommand: string, ...args: (string | number)[]): Promise<string> {
+      return this.run(subcommand, ...args);
+    }
+
+    async listSessions(): Promise<typeof listSessionsReturn> {
+      runCalls.push({ subcommand: "list-sessions", args: [] });
+      return listSessionsReturn;
+    }
+
+    async capture(target: string, lines = 80): Promise<string> {
+      runCalls.push({ subcommand: "capture-pane", args: ["-t", target, lines] });
+      return captureReturnValue;
+    }
+
+    async selectWindow(target: string): Promise<void> {
+      selectWindowCalls.push(target);
+      runCalls.push({ subcommand: "select-window", args: ["-t", target] });
+    }
+
+    async listWindows(session: string) {
+      return [];
+    }
+  }
+
+  return {
+    ..._rTmux,
+    Tmux: MockTmux,
+    tmux: new MockTmux(),
+    tmuxCmd: () => "tmux",
+  };
+});
+
+// --- Mock config ---
+mock.module(join(srcRoot, "src/config"), () =>
+  mockConfigModule(() => ({ node: "test-node", host: "local" })),
+);
+
+// --- Import module under test AFTER all mock.module installs ---
+const { listSessions, capture, selectWindow } = await import("../../src/core/transport/ssh");
+
+describe("ssh.ts transport — H2 defensive refactor", () => {
+  beforeEach(() => {
+    runCalls = [];
+    runReturnValue = "";
+    listSessionsReturn = [];
+    captureReturnValue = "";
+    selectWindowCalls = [];
+  });
+
+  describe("listSessions — delegates to Tmux.listSessions", () => {
+    test("Case 1 — returns sessions from Tmux.listSessions", async () => {
+      listSessionsReturn = [{ name: "mysession", windows: [] }];
+      const result = await listSessions();
+      expect(result).toEqual([{ name: "mysession", windows: [] }]);
+      // Verify it called through Tmux class
+      const listCall = runCalls.find(c => c.subcommand === "list-sessions");
+      expect(listCall).toBeDefined();
+    });
+
+    test("Case 2 — empty sessions return empty array", async () => {
+      listSessionsReturn = [];
+      const result = await listSessions();
+      expect(result).toEqual([]);
+    });
+
+    test("Case 3 — session names with shell metacharacters pass through without interpolation", async () => {
+      // If a malicious peer injects such a name, it arrives here already as data
+      // The key is that Tmux.listSessions receives it as structured data, not shell
+      listSessionsReturn = [{ name: "safe-session", windows: [{ index: 0, name: "oracle", active: true }] }];
+      const result = await listSessions();
+      expect(result[0].name).toBe("safe-session");
+      // No shell string should appear in any run() call with the session name interpolated
+      const anyShellString = runCalls.some(c =>
+        typeof c.subcommand === "string" && c.subcommand.includes("'safe-session'"),
+      );
+      expect(anyShellString).toBe(false);
+    });
+  });
+
+  describe("capture — delegates to Tmux.capture", () => {
+    test("Case 1 — delegates to Tmux.capture with same args", async () => {
+      captureReturnValue = "pane content here";
+      const result = await capture("session:window.0", 50);
+      expect(result).toBe("pane content here");
+      const captureCall = runCalls.find(c => c.subcommand === "capture-pane");
+      expect(captureCall).toBeDefined();
+      // Target should appear as a discrete arg, not interpolated
+      expect(captureCall!.args).toContain("session:window.0");
+    });
+
+    test("Case 2 — single-quote in target reaches Tmux as discrete arg (not shell string)", async () => {
+      const injectionTarget = "sess'; rm -rf /'";
+      captureReturnValue = "";
+      await capture(injectionTarget, 20);
+      const captureCall = runCalls.find(c => c.subcommand === "capture-pane");
+      expect(captureCall).toBeDefined();
+      // The injection string must appear as a literal discrete argument element
+      expect(captureCall!.args).toContain(injectionTarget);
+      // It must NOT appear embedded in a shell string like `tmux capture-pane -t '...'`
+      const hasShellInterpolation = runCalls.some(c =>
+        c.subcommand.includes(`-t '${injectionTarget}'`),
+      );
+      expect(hasShellInterpolation).toBe(false);
+    });
+
+    test("Case 3 — default lines value passes through", async () => {
+      await capture("mysession:0");
+      const captureCall = runCalls.find(c => c.subcommand === "capture-pane");
+      expect(captureCall).toBeDefined();
+    });
+  });
+
+  describe("selectWindow — delegates to Tmux.selectWindow", () => {
+    test("Case 1 — delegates to Tmux.selectWindow", async () => {
+      await selectWindow("mysession:2");
+      expect(selectWindowCalls).toContain("mysession:2");
+    });
+
+    test("Case 2 — injection target reaches selectWindow as discrete value", async () => {
+      const injectionTarget = "session'; touch /tmp/pwned; tmux #";
+      await selectWindow(injectionTarget);
+      // Must appear in select-window call
+      expect(selectWindowCalls).toContain(injectionTarget);
+      // Must NOT appear as a shell-interpolated string
+      const hasShellInterpolation = runCalls.some(c =>
+        typeof c.subcommand === "string" && c.subcommand.includes(`-t '${injectionTarget}'`),
+      );
+      expect(hasShellInterpolation).toBe(false);
+    });
+
+    test("Case 3 — host parameter is forwarded to Tmux constructor", async () => {
+      // This test verifies the host is passed through (behavior: same for local)
+      await selectWindow("mysession:1", undefined);
+      expect(selectWindowCalls).toContain("mysession:1");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **H1**: `comm-send.ts` — `resolveOraclePane` used bare `hostExec` with single-quote interpolation of a user-supplied `target` into `tmux list-panes -t '${target}'`. Replaced with `Tmux.run("list-panes", "-t", target, ...)` arg-array.
- **H2**: `ssh.ts` — three legacy functions (`listSessions`, `capture`, `selectWindow`) built tmux shell strings with single-quote interpolation of caller-supplied args. Delegated to equivalent `Tmux` class methods. Net -20 LOC.
- **H6**: `pr/impl.ts` — `cmdPr()` used `hostExec` shell strings for `tmux display-message`, `git -C '${cwd}'`, and `cd '${cwd}' && gh pr create`. Replaced with `Tmux.run()` arg-arrays and `Bun.spawn` with `cwd` option. Removed `titleEscaped`/`bodyFlag` shell-quoting workarounds.

All three are **defensive refactors** — unifying tmux call sites to the established `Tmux` class pattern. No new capabilities added.

---

## Per-Item Root Cause + Fix

### H1 — `comm-send.ts:47-48`

**Root cause**: `resolveOraclePane()` built `tmux list-panes -t '${target}'` as a shell string. `target` originates from `resolveTarget(query, ...)` where `query` is the raw `maw hey <query>` CLI arg. A single quote in `query` breaks out of the tmux target quoting context.

**Fix**: `new Tmux().run("list-panes", "-t", target, "-F", "...")` — all args pass through `q()` in `Tmux.run()`.

**Note on upstream mitigation**: H5 (alpha.127 — `#470`) added TypeBox schema validation for peer session names at the federation intake boundary, rejecting names with shell metacharacters before they reach `resolveTarget()`. H1's sink is therefore partly mitigated upstream for the peer-data attack path. The local CLI path (`maw hey "evil' ..."`) remains and H1 closes it at the sink. This PR is defense-in-depth.

### H2 — `ssh.ts:59-62, 80-82, 86`

**Root cause**: Three functions built raw tmux shell strings with `'${s}'` / `'${target}'` interpolation:
- `listSessions()`: `list-windows -t '${s}'` — `s` from local tmux `list-sessions` output (reduced severity — local trusted source, not direct user input)
- `capture()`: `capture-pane -t '${target}'` — caller-supplied target
- `selectWindow()`: `select-window -t '${target}'` — caller-supplied target

**Fix**: Each function now delegates to the corresponding `Tmux` class method (`t.listSessions()`, `t.capture()`, `t.selectWindow()`). The `Tmux` class was already the canonical implementation; these were unreachable legacy duplicates.

**Note on `listSessions` severity**: The `s` variable in the old `list-windows` interpolation comes from tmux's own `list-sessions` output — not from user input. Exploit realism is low (requires prior local compromise or H5 chain). Still a good hygiene fix to eliminate the dead code and consolidate to Tmux class.

### H6 — `pr/impl.ts:26`

**Root cause**: `cmdPr()` used `hostExec` shell strings for all subprocess calls. The `window` arg (from `maw pr <window>` CLI) was interpolated into `tmux display-message -t '${session}:${window}'`. Additionally, `cwd` (from tmux output) was interpolated into `git -C '${cwd}'` and `cd '${cwd}' && gh pr create`.

**Fix**: All three call sites replaced:
- tmux calls → `t.run("display-message", "-p"/""-t"", ...)` arg-arrays
- `git branch --show-current` → `Bun.spawn(["git", "-C", cwd, "branch", "--show-current"])`
- `gh pr create` → `Bun.spawn(["gh", "pr", "create", "--title", title, ...], { cwd })`

**Note on severity**: Attacker must supply the malicious window name themselves via `maw pr '...'` (self-injection only). No privilege escalation possible. Treated as code quality + consistency, not urgent hardening.

---

## Surface Area Table

| # | File | Lines changed | Prod LOC delta | Injection type |
|---|------|---------------|----------------|----------------|
| H1 | `src/commands/shared/comm-send.ts` | 5 changed | -2 | User CLI arg → tmux target |
| H2 | `src/core/transport/ssh.ts` | 29 deleted, 7 added | -22 | Caller-supplied / tmux-local → tmux target |
| H6 | `src/commands/plugins/pr/impl.ts` | 33 changed | +15 | CLI arg / tmux path → tmux/git/gh |
| **Total prod** | | | **~-9** | |

---

## Test Plan

| File | Cases | Location |
|------|-------|----------|
| `test/isolated/comm-send-resolve-pane.test.ts` | 6 | `test/isolated/` (mock.module) |
| `test/isolated/ssh-transport.test.ts` | 9 | `test/isolated/` (mock.module) |
| `test/isolated/pr-impl.test.ts` | 5 | `test/isolated/` (mock.module) |

**Key assertions per file**:
- `comm-send-resolve-pane.test.ts`: injection target arrives as `args[1]` discrete element (not shell string), pane-specific short-circuit, error swallow
- `ssh-transport.test.ts`: delegation verified, injection args don't appear in any shell-interpolated subcommand key
- `pr-impl.test.ts`: `gh` spawn uses `cwd` option (not `cd`), `window` arg with single-quote arrives as discrete argv in `display-message` target, outside-tmux throw

All new test files live in `test/isolated/` per `mock.module` placement rule (#387).

**CI**: `bun run test:all` — 55/55 files pass, 0 failures. Pre-existing 3 batch-pollution failures (#467) not present in this run.

---

## Open Questions for @nazt

1. **`switchClient` in `ssh.ts:69`**: Still uses `ssh(\`${tmuxCmd()} switch-client -t '${session}'\`)` with single-quote interpolation. Same pattern as H2 but only triggered when `process.env.TMUX` is set (user is inside tmux). Scope: include in this PR or follow-up?
2. **`Tmux.capture()` behavior parity**: The old `ssh.ts` capture used `2>/dev/null` stderr suppression. `Tmux.capture()` also suppresses stderr for the short-capture path but goes through `this.run()` for the long-capture path which doesn't add `2>/dev/null`. Is this acceptable or should `Tmux.capture()` add stderr suppression via `tryRun`?
3. **H6 empty-body `gh pr create`**: Old code used `--body ''`; new code uses `ghArgs.push("--body", "")`. Both pass empty string as `--body` argument. Confirmed same behavior, but worth a quick smoke test on the next alpha deploy if `gh pr create` behavior with empty `--body` vs no `--body` differs across `gh` versions.

---

## H5 Upstream Mitigation Note (for H1 context)

H5 shipped in alpha.127 (`#470`) — peer JSON validation now rejects crafted session names at the federation intake boundary before they reach `resolveTarget()` → `resolveOraclePane()`. For the **remote attack path** (malicious peer), H5 is the primary defense. H1 (this PR) is defense-in-depth at the sink — closes the **local CLI path** (`maw hey "evil'"`) and provides a second layer if H5 validation is somehow bypassed or circumvented in future.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)