### PR TITLE
ci: add CodeQL static analysis (#452 follow-up)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+name: CodeQL
+
+# Static application security testing via GitHub's CodeQL.
+# Free for public repos; runs on push to main/alpha + weekly schedule.
+# Surfaces findings on the repo's Security tab. Required by SECURITY.md
+# scope (command injection, auth bypass) as a detection layer.
+
+on:
+  push:
+    branches: [main, alpha]
+  pull_request:
+    branches: [main, alpha]
+  schedule:
+    # Mondays at 06:37 UTC — offset from :00 to avoid fleet clumping.
+    - cron: "37 6 * * 1"
+
+permissions:
+  security-events: write
+  contents: read
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # security-extended: more queries, higher signal; security-and-quality
+          # would add style, which isn't useful here.
+          queries: security-extended
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/codeql.yml` — GitHub's free SAST, `security-extended` query pack, runs on push/PR to main+alpha plus weekly schedule (Monday 06:37 UTC, offset from :00 to reduce fleet clumping).

## Why

Noted in original OSS audit (fifth gap) and deferred in #452 as a separate PR. Fills SECURITY.md's 'supply chain / code-level scanning' implicit need. Findings surface on the repo's Security tab.

## Surface area

| File | Lines | Risk |
|---|---|---|
| `.github/workflows/codeql.yml` | new, ~45 | None — additive scaffold |

## Test plan

- [x] YAML structure sanity
- [ ] CI — first run of the workflow should succeed against HEAD (verifies autobuild detects the TS project)
- [ ] Security tab populates within 10-15 min of merge

## Notes

- Uses `security-extended`, not `security-and-quality` (the latter adds style checks that aren't useful here)
- `javascript-typescript` language covers the `src/` tree fully
- Autobuild is fine — no custom compilation needed for CodeQL's purposes

## Follow-up

If CodeQL flags real findings, they become their own issues. This PR just wires the scanner.

Co-Authored-By: mawjs <noreply@soulbrews.studio>