### PR TITLE
refactor(scan-remote): use execFileSync + org name allowlist (#473)

### DIFF
--- a/src/core/fleet/registry-oracle-scan-remote.ts
+++ b/src/core/fleet/registry-oracle-scan-remote.ts
@@ -9,7 +9,13 @@
  * laris-co scans to ~50s. Bun.spawn with batch concurrency drops it 3-5×.
  */
 
-import { execSync } from "child_process";
+import { execSync, execFileSync } from "child_process";
+
+// Org name allowlist — rejects shell metacharacters. Matches GitHub's
+// org name rules (alphanumeric + dash, no consecutive dashes, not
+// starting with a dash). Defense in depth — execFileSync below doesn't
+// invoke a shell, but keeps config values honest.
+const ORG_NAME_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$/;
 import { loadConfig } from "../../config";
 import type { OracleEntry } from "./registry-oracle-types";
 import { deriveName } from "./registry-oracle-scan-local";
@@ -39,14 +45,29 @@ export async function scanRemote(orgs?: string[], verbose = true): Promise<Oracl
   for (const org of targetOrgs) {
     const orgStart = Date.now();
     try {
+      // Allowlist check — invalid org names skip with a clear error rather
+      // than potentially leaking metacharacters into gh api calls (closes #473).
+      if (!ORG_NAME_RE.test(org)) {
+        console.error(`\x1b[31m✗\x1b[0m invalid org name "${org}" — skipping`);
+        continue;
+      }
+
       // Per-org progress — always shown so the user sees something during the
       // multi-second gh API call. Was behind `if (verbose)` until 2026-04-16
       // (silent dead air for 10-30s confused users — see gist 773655c4).
       process.stdout.write(`  \x1b[90m⏳ scanning ${org}...\x1b[0m`);
 
-      // Use gh CLI for auth-handled pagination
-      const out = execSync(
-        `gh api "/orgs/${org}/repos?per_page=100&type=all" --paginate --jq '.[] | .full_name + " " + .name'`,
+      // Use gh CLI for auth-handled pagination. execFileSync passes args
+      // discretely (no shell) — shell metacharacters in org can't escape.
+      const out = execFileSync(
+        "gh",
+        [
+          "api",
+          `/orgs/${org}/repos?per_page=100&type=all`,
+          "--paginate",
+          "--jq",
+          '.[] | .full_name + " " + .name',
+        ],
         { encoding: "utf-8", timeout: 30000 },
       );
 

--- a/test/isolated/scan-remote-org-allowlist.test.ts
+++ b/test/isolated/scan-remote-org-allowlist.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Closes #473 — regression guard for org-name allowlist in
+ * registry-oracle-scan-remote.ts.
+ *
+ * Unit-tests the ORG_NAME_RE pattern directly. The full scanRemote
+ * flow isn't exercised (requires network + gh auth) — this guards
+ * the shell-safety at the allowlist seam.
+ */
+import { describe, it, expect } from "bun:test";
+
+// Mirror of the pattern in src/core/fleet/registry-oracle-scan-remote.ts.
+// Keep in sync — if the module's pattern changes, update this and the
+// corresponding test cases.
+const ORG_NAME_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$/;
+
+describe("org name allowlist (#473)", () => {
+  describe("accepts real GitHub org names", () => {
+    const good = [
+      "Soul-Brews-Studio",
+      "laris-co",
+      "nazt",
+      "github",
+      "a",
+      "a1",
+      "A-B-C",
+      "x1234567890",
+    ];
+    for (const org of good) {
+      it(`accepts "${org}"`, () => {
+        expect(ORG_NAME_RE.test(org)).toBe(true);
+      });
+    }
+  });
+
+  describe("rejects shell-injection attempts", () => {
+    const bad = [
+      'laris-co"; rm -rf ~; echo "',
+      "laris-co && curl evil.com",
+      "laris-co | cat /etc/passwd",
+      "laris-co$(whoami)",
+      "laris-co`id`",
+      "-laris", // leading dash
+      "laris-", // trailing dash
+      "laris co", // space
+      "laris;rm", // semicolon
+      "laris\nrm", // newline
+      "", // empty
+      "a".repeat(41), // length boundary
+    ];
+    for (const org of bad) {
+      it(`rejects ${JSON.stringify(org)}`, () => {
+        expect(ORG_NAME_RE.test(org)).toBe(false);
+      });
+    }
+  });
+
+  describe("length boundary", () => {
+    it("accepts 39-char org (GitHub max)", () => {
+      const maxLen = "a" + "1".repeat(37) + "z"; // 39 chars
+      expect(maxLen.length).toBe(39);
+      expect(ORG_NAME_RE.test(maxLen)).toBe(true);
+    });
+    it("rejects 40-char org", () => {
+      const over = "a" + "1".repeat(38) + "z"; // 40 chars
+      expect(over.length).toBe(40);
+      expect(ORG_NAME_RE.test(over)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

CodeQL `js/shell-command-constructed-from-input` error caught `scan-remote.ts:49` — `gh api "/orgs/${org}/..."` interpolated org from config into a shell command. Attacker with config-write (direct or via federation sync) could escape quotes via `"; rm -rf ~; echo "`.

## Change

- `execSync` with shell string → `execFileSync("gh", ["api", ...])` arg array
- Added `ORG_NAME_RE` allowlist matching GitHub org rules (1-39 chars alphanum + non-leading/trailing hyphens)
- Invalid org names skip with a clear `✗ invalid org name ...` error, don't stop the scan

## Surface area

| File | Lines | Risk |
|---|---|---|
| src/core/fleet/registry-oracle-scan-remote.ts | +17/-3 | Low — defensive refactor |
| test/isolated/scan-remote-org-allowlist.test.ts | new (~80) | None |

## Test plan

- [x] 22 new allowlist cases: real GH orgs accepted, shell-injection payloads rejected, length boundaries covered
- [x] `bun run test:all` — 2887 pass / 3 fail (same pre-existing #467 batch-pollution, unrelated)
- [ ] CI

## Defense in depth

`execFileSync` alone eliminates the shell injection (no shell invoked). The allowlist is defense-in-depth — keeps config values honest + rejects garbage before even calling gh.

Closes #473. Narrows CodeQL's 5-error count by 1. The 4 remaining errors are `js/log-injection` in `hub-connection.ts` — tracked in #474.

Co-Authored-By: mawjs <noreply@soulbrews.studio>