### PR TITLE
fix(update): validate ref BEFORE bun remove — regression from #470

### DIFF
--- a/src/cli/cmd-update.ts
+++ b/src/cli/cmd-update.ts
@@ -112,23 +112,33 @@ export async function runUpdate(args: string[]): Promise<void> {
     }
   }
 
-  // Remove first to avoid bun dependency loop (#214)
-  // Required: purges stale global refs that cause dep loops (#347)
-  try { execSync(`bun remove -g maw`, { stdio: "pipe" }); } catch {}
-
   // Allowlist: git tag names, branch names, commit SHAs — no shell metacharacters.
   // Channel shortcuts ("alpha"/"beta") resolve to a validated tag above; all
   // resolved refs must still pass this gate (defense-in-depth after channel resolve).
+  // CRITICAL: this MUST run BEFORE `bun remove -g maw` below. If validation
+  // fails after remove, the user is left with maw uninstalled and no reinstall.
+  // (Regression: #356/#473-class. Fix 2026-04-18 — emergency after user report.)
   const REF_RE = /^[a-zA-Z0-9._\-\/]+$/;
   if (!REF_RE.test(ref)) {
     console.error(`\x1b[31merror\x1b[0m: invalid ref "${ref}" — only [a-zA-Z0-9._-/] characters permitted`);
     process.exit(1);
   }
+
+  // Remove first to avoid bun dependency loop (#214)
+  // Required: purges stale global refs that cause dep loops (#347)
+  // NOTE: only runs AFTER ref validation above, so a rejected ref can't
+  // leave the user with an uninstalled maw.
+  try { execSync(`bun remove -g maw`, { stdio: "pipe" }); } catch {}
+
   const installProc = Bun.spawn(["bun", "add", "-g", `github:${repository}#${ref}`], {
     stdio: ["inherit", "inherit", "inherit"],
   });
   const installCode = await installProc.exited;
-  if (installCode !== 0) process.exit(installCode);
+  if (installCode !== 0) {
+    console.error(`\x1b[31merror\x1b[0m: bun add failed with exit ${installCode} — maw is not reinstalled`);
+    console.error(`  manual recovery: bun add -g github:${repository}#alpha`);
+    process.exit(installCode);
+  }
   // Link SDK so plugins can `import { maw } from "@maw/sdk"` (workspace package at packages/sdk/)
   // Legacy plugins using bare `maw/sdk` are still resolved via `bun link maw`.
   try {


### PR DESCRIPTION
## EMERGENCY FIX — field-reported maw uninstall

A user ran `maw update` and ended up with `/home/neo/.bun/bin/maw: No such file or directory`. Root cause traced to this file.

## Bug

PR #470 (PR-B security bundle, H3 fix) added the REF_RE allowlist check AFTER `bun remove -g maw`. If validation rejects the ref, maw is already uninstalled with no reinstall path. Additionally, if `bun add` fails for any reason (network, bun version, auth), maw stays gone silently.

## Fix

1. Move `REF_RE` validation to BEFORE `bun remove -g maw`
2. Add explicit error message + manual-recovery command on `bun add` failure

New order:
- Resolve channel tag (alpha/beta)
- Validate ref (NEW position — before remove)
- Confirmation prompt  
- `bun remove -g maw`
- `bun add -g github:...` with visible error on failure

## Surface

| File | Lines | Risk |
|---|---|---|
| src/cli/cmd-update.ts | +10/-5 | LOW — reorder + error message |

## Test plan

- [x] `bun test test/update-help.test.ts` — 12/12 pass (existing regression guards still green)
- [x] Existing `--notaflag` rejection test still enforced (layer 2 of cmd-update)
- [ ] CI
- [ ] Field-verify: user runs `maw update` successfully

## Recovery for affected users

```
bun add -g github:Soul-Brews-Studio/maw-js#alpha
```

## Why not revert #470 fully

H3's fix itself is sound — the REF_RE check is correct and closes the shell-injection vector. The regression is only the PLACEMENT. Keep the validation, move it one block up.

Co-Authored-By: mawjs <noreply@soulbrews.studio>