### PR TITLE
fix(update): atomic install + source-order regression guard

### DIFF
--- a/src/cli/cmd-update.ts
+++ b/src/cli/cmd-update.ts
@@ -124,18 +124,27 @@ export async function runUpdate(args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  // Remove first to avoid bun dependency loop (#214)
-  // Required: purges stale global refs that cause dep loops (#347)
-  // NOTE: only runs AFTER ref validation above, so a rejected ref can't
-  // leave the user with an uninstalled maw.
-  try { execSync(`bun remove -g maw`, { stdio: "pipe" }); } catch {}
-
-  const installProc = Bun.spawn(["bun", "add", "-g", `github:${repository}#${ref}`], {
+  // Atomic install sequence — try install over existing FIRST so that a
+  // transient failure (network, auth, bun version) cannot leave the user
+  // with an uninstalled maw. `bun remove` only runs as a fallback when the
+  // initial install fails — the historical reason for remove-first was a
+  // dep-loop class (#214/#347), which is narrower than "every install".
+  //
+  // Order matters: validation (above) → try add → on fail, remove + retry →
+  // on still-fail, print recovery command. User always has a working maw
+  // unless BOTH adds fail.
+  const spawnInstall = () => Bun.spawn(["bun", "add", "-g", `github:${repository}#${ref}`], {
     stdio: ["inherit", "inherit", "inherit"],
   });
-  const installCode = await installProc.exited;
+
+  let installCode = await spawnInstall().exited;
   if (installCode !== 0) {
-    console.error(`\x1b[31merror\x1b[0m: bun add failed with exit ${installCode} — maw is not reinstalled`);
+    console.warn(`\x1b[33m⚠\x1b[0m first install attempt failed — clearing stale global refs and retrying`);
+    try { execSync(`bun remove -g maw`, { stdio: "pipe" }); } catch {}
+    installCode = await spawnInstall().exited;
+  }
+  if (installCode !== 0) {
+    console.error(`\x1b[31merror\x1b[0m: bun add failed with exit ${installCode} — maw may be uninstalled`);
     console.error(`  manual recovery: bun add -g github:${repository}#alpha`);
     process.exit(installCode);
   }

--- a/test/isolated/cmd-update-order.test.ts
+++ b/test/isolated/cmd-update-order.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Regression guard — source-order invariant for maw update command.
+ *
+ * Backstory: the original cmd-update ran `bun remove -g maw` BEFORE ref
+ * validation. A rejected ref or a subsequent install failure would leave
+ * the user with no maw binary. Fixed in #476 (emergency alpha.130) + the
+ * atomic flow that followed.
+ *
+ * This test reads the source file and asserts two invariants:
+ *   1. The REF_RE allowlist check appears BEFORE any `bun remove` call
+ *   2. `bun add` appears BEFORE `bun remove` in the atomic happy-path
+ *      (the remove-as-fallback is only on failure, and still only after
+ *      at least one install attempt)
+ *
+ * If someone refactors this file without preserving the invariants, this
+ * test catches it — not by behavior (hard to test spawn ordering in unit
+ * test) but by text structure. Crude but targeted.
+ */
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const cmdUpdatePath = join(import.meta.dir, "../../src/cli/cmd-update.ts");
+
+describe("cmd-update source-order invariants", () => {
+  const src = readFileSync(cmdUpdatePath, "utf-8");
+
+  // Find the actual execSync(`bun remove -g maw`) call — not any comment or
+  // docstring that mentions the invariant. Must look for the execSync call
+  // specifically with the bun remove template-literal.
+  const REMOVE_CALL_RE = /execSync\s*\(\s*`bun remove -g maw`/;
+  const ADD_SPAWN_RE = /Bun\.spawn\s*\(\s*\["bun",\s*"add"/;
+
+  it("REF_RE validation precedes the actual `bun remove` execSync call", () => {
+    const refReIdx = src.indexOf("REF_RE");
+    const removeCallMatch = src.match(REMOVE_CALL_RE);
+    expect(refReIdx).toBeGreaterThan(-1);
+    expect(removeCallMatch).not.toBeNull();
+    const removeCallIdx = removeCallMatch!.index!;
+    expect(refReIdx).toBeLessThan(removeCallIdx);
+  });
+
+  it("`Bun.spawn(['bun', 'add', ...])` appears before the `bun remove` execSync (atomic: try add first)", () => {
+    const addSpawnMatch = src.match(ADD_SPAWN_RE);
+    const removeCallMatch = src.match(REMOVE_CALL_RE);
+    expect(addSpawnMatch).not.toBeNull();
+    expect(removeCallMatch).not.toBeNull();
+    expect(addSpawnMatch!.index!).toBeLessThan(removeCallMatch!.index!);
+  });
+
+  it("install retry path exists (bun remove is only reached on failure)", () => {
+    // The remove step should be inside a fallback branch, not in the
+    // primary install path. Look for the fallback warning text.
+    expect(src).toContain("first install attempt failed");
+    expect(src).toContain("clearing stale global refs");
+  });
+
+  it("failure path prints recovery command", () => {
+    expect(src).toMatch(/manual recovery: bun add -g github:/);
+  });
+});


### PR DESCRIPTION
## Summary

Two-layer follow-up to the alpha.130 emergency (PR #476):

**A. Atomic install** — `bun add` now runs FIRST over existing install. `bun remove` only as fallback when add fails. User always has a working maw unless BOTH attempts fail (rare), and even then gets explicit recovery instructions.

**B. Regression guard** — new isolated test reads the source and asserts the text-order invariants that would have caught #476 pre-merge:
- REF_RE validation precedes any `bun remove`
- `bun add` appears before any `bun remove` (atomic happy path)
- Fallback retry branch exists
- Recovery command present on final failure

## Why text-order test, not behavioral

Instrumenting the real subprocess sequence in a unit test requires mocking bun's global install surface — high-effort, brittle. A source-text invariant is crude but catches the exact refactor mistake that caused the field incident. When cmd-update is refactored in the future, test will scream if someone puts `bun remove` before the add again.

## Surface

| File | Lines | Risk |
|---|---|---|
| src/cli/cmd-update.ts | +12/-6 | Low — structural reorder + one warn branch |
| test/isolated/cmd-update-order.test.ts | new (~60) | None |

## Test plan

- [x] 12/12 existing update-help.test.ts still pass
- [x] 4/4 new cmd-update-order.test.ts pass
- [x] `bun run test:all` green (same 3 pre-existing #467 batch-pollution failures)
- [ ] CI
- [ ] Field-verify: `maw update alpha` on a test machine, binary survives

Closes the class opened by #476. No public issue ref for this one — it's a follow-up hardening pass on the emergency fix.

Co-Authored-By: mawjs <noreply@soulbrews.studio>