### PR TITLE
fix(tmux): flush-wait before Enter to avoid paste/submit race

### DIFF
--- a/src/core/transport/tmux-class.ts
+++ b/src/core/transport/tmux-class.ts
@@ -262,6 +262,9 @@ export class Tmux {
       // Buffer method — reliable for multiline/long content
       await this.loadBuffer(text);
       await this.pasteBuffer(target);
+      // Flush-wait: let TUI finish rendering the paste before Enter hits.
+      // Without this, Enter races the paste-buffer commit in Claude Code.
+      await new Promise(r => setTimeout(r, 250));
       // Staggered Enter — submit immediately + 2 fallbacks
       await this.sendKeys(target, "Enter");
       await new Promise(r => setTimeout(r, 500));
@@ -271,6 +274,8 @@ export class Tmux {
     } else {
       // Literal send — -l prevents tmux from interpreting special chars like |
       await this.sendKeysLiteral(target, text);
+      // Flush-wait: same reason as above — avoid paste/submit race.
+      await new Promise(r => setTimeout(r, 250));
       // Staggered Enter — submit immediately + 2 fallbacks
       await this.sendKeys(target, "Enter");
       await new Promise(r => setTimeout(r, 500));


### PR DESCRIPTION
## Summary

Cherry-pick of @leo21052545's fix from #449 (kept conflicting after our PR-A tmux chain landed — our H1/H2/H6 bundle restructured the file, breaking the original patch). Fix is identical: 250ms delay between paste and first Enter in `sendText()`, both short-text and long-text branches.

## Credit

Originally filed: https://github.com/Soul-Brews-Studio/maw-js/pull/449 by @leo21052545
This PR carries the author line: `Leo <leo21052545@gmail.com>`
Full co-authored-by preserved on the commit.

## Why not just rebase #449

The force-push to leo's fork was rejected (stale info). Cleanest path was to cherry-pick the commit onto a maintainer branch; preserves authorship via git, closes the loop without blocking on external rebase.

## Surface

| File | Lines | Risk |
|---|---|---|
| src/core/transport/tmux-class.ts | +5 | Low — two `setTimeout 250` awaits |

## Test plan

- [x] `bun run test:all` — 2906 pass / 3 fail (same pre-existing #467 batch-pollution, unrelated)
- [x] Cherry-pick auto-merged clean (original path `src/tmux.ts` renamed to `src/core/transport/tmux-class.ts` in later refactor)
- [ ] CI
- [ ] Field-verify: `maw hey <target> "test"` no longer leaves orphaned paste

## Closes

Supersedes #449. Will close that one on merge with a thank-you comment.

Co-Authored-By: Leo <leo21052545@gmail.com>