### PR TITLE
feat(plugin-compiler): maw plugin dev verb (#340 Wave 1B)

### DIFF
--- a/packages/sdk/docs/phase-b-decomposition.md
+++ b/packages/sdk/docs/phase-b-decomposition.md
@@ -127,7 +127,11 @@ The trust layer (`.tgz` signing, federation-distributed revocation) ships in Pha
 
 **Title**: `feat(plugin-compiler): Phase B — maw plugin dev verb`
 
+**Status**: Wave 1B shipped (`feat/pb-maw-plugin-dev`). See #340 Wave 1B.
+
 **Scope**: Promote `maw plugin build --watch` to a first-class `maw plugin dev` verb. `maw plugin dev [dir]` is a convenience wrapper: builds in watch mode + installs with `--link` (symlink, skips hash verification). The `--watch` flag on `build` remains for users who want watch without the auto-link. The round-trip time goal: under 200ms rebuild notification after a source file save (Bun's fast bundler baseline). sdk-consumer earned this — they deferred it in Phase A; Phase B is where it ships.
+
+**Wave 1B delivery**: `maw plugin dev` is wired as a first-class verb sharing the `runWatch()` loop from `build --watch`. The `--watch` flag alias is preserved (backward-compat invariant). The `--link` integration (auto-symlink after each build) is deferred to after B1 (host-injected shim) since symlink installs against the shim need that infrastructure first.
 
 **Dependencies**: B1 (symlink installs against the shim should work correctly)
 

--- a/src/commands/plugins/plugin/build-impl.ts
+++ b/src/commands/plugins/plugin/build-impl.ts
@@ -64,32 +64,53 @@ export async function cmdPluginBuild(args: string[]): Promise<void> {
   const dir = resolve(flags._[0] || ".");
 
   if (flags["--watch"]) {
-    // One initial build, then rebuild on src change. Tolerate failures.
-    await runBuild(dir).catch(() => {});
-    console.log(`\n\x1b[36m⧖\x1b[0m watching ${dir}/src for changes (Ctrl-C to stop)...`);
-    let building = false;
-    const trigger = async () => {
-      if (building) return;
-      building = true;
-      try {
-        await runBuild(dir);
-      } catch (e: any) {
-        console.error(`\x1b[31m✗\x1b[0m rebuild failed: ${e.message}`);
-      } finally {
-        building = false;
-      }
-    };
-    const srcDir = join(dir, "src");
-    if (existsSync(srcDir)) {
-      watch(srcDir, { recursive: true }, () => {
-        void trigger();
-      });
-    }
-    await new Promise(() => { /* keep alive */ });
+    // `--watch` flag: watch mode without dev-link. Kept for backward compat.
+    await runWatch(dir);
     return;
   }
 
   await runBuild(dir);
+}
+
+/**
+ * maw plugin dev [dir]
+ *
+ * First-class DX verb (Phase B6). Equivalent to `build --watch` today;
+ * in a future sub-issue it will also `--link` the plugin after each build.
+ * Keeping the two paths separate lets us diverge them without touching build.
+ */
+export async function cmdPluginDev(args: string[]): Promise<void> {
+  const flags = parseFlags(args, {}, 0);
+  const dir = resolve(flags._[0] || ".");
+  console.log(`\x1b[36mmaw plugin dev\x1b[0m — watch mode (Ctrl-C to stop)`);
+  console.log(`  dir: ${dir}`);
+  await runWatch(dir);
+}
+
+/** Shared watch-mode loop used by both `build --watch` and `dev`. */
+async function runWatch(dir: string): Promise<void> {
+  // One initial build, then rebuild on src change. Tolerate failures.
+  await runBuild(dir).catch(() => {});
+  console.log(`\n\x1b[36m⧖\x1b[0m watching ${dir}/src for changes (Ctrl-C to stop)...`);
+  let building = false;
+  const trigger = async () => {
+    if (building) return;
+    building = true;
+    try {
+      await runBuild(dir);
+    } catch (e: any) {
+      console.error(`\x1b[31m✗\x1b[0m rebuild failed: ${e.message}`);
+    } finally {
+      building = false;
+    }
+  };
+  const srcDir = join(dir, "src");
+  if (existsSync(srcDir)) {
+    watch(srcDir, { recursive: true }, () => {
+      void trigger();
+    });
+  }
+  await new Promise(() => { /* keep alive */ });
 }
 
 async function runBuild(dir: string): Promise<BuildSummary> {

--- a/src/commands/plugins/plugin/index.ts
+++ b/src/commands/plugins/plugin/index.ts
@@ -2,13 +2,14 @@ import type { InvokeContext, InvokeResult } from "../../../plugin/types";
 
 export const command = {
   name: "plugin",
-  description: "Plugin lifecycle — init, build, install.",
+  description: "Plugin lifecycle — init, build, dev, install.",
 };
 
 const USAGE =
-  "usage: maw plugin <init|build|install> [args]\n" +
+  "usage: maw plugin <init|build|dev|install> [args]\n" +
   "  init <name> --ts              scaffold a TS plugin\n" +
   "  build [dir] [--watch]         bundle + pack a plugin\n" +
+  "  dev [dir]                     watch mode (alias for build --watch, DX verb)\n" +
   "  install <dir | .tgz | URL>    install a built plugin";
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
@@ -38,6 +39,9 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     } else if (sub === "build") {
       const { cmdPluginBuild } = await import("./build-impl");
       await cmdPluginBuild(args.slice(1));
+    } else if (sub === "dev") {
+      const { cmdPluginDev } = await import("./build-impl");
+      await cmdPluginDev(args.slice(1));
     } else if (sub === "install") {
       // installer-loader (task #3) provides install-impl.ts
       try {

--- a/src/commands/plugins/plugin/plugin.json
+++ b/src/commands/plugins/plugin/plugin.json
@@ -3,11 +3,11 @@
   "version": "1.0.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "Plugin lifecycle — init, build, install.",
+  "description": "Plugin lifecycle — init, build, dev, install.",
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "plugin",
-    "help": "maw plugin <init|build|install> [args]"
+    "help": "maw plugin <init|build|dev|install> [args]"
   },
   "weight": 10
 }

--- a/test/isolated/plugin-dev-verb.test.ts
+++ b/test/isolated/plugin-dev-verb.test.ts
@@ -1,0 +1,213 @@
+/**
+ * maw plugin dev — Phase B6 Wave 1B
+ *
+ * Verifies that `cmdPluginDev` / `cmdPluginBuild --watch`:
+ *   1. Start with an initial build (dist/index.js + dist/plugin.json written).
+ *   2. Log the "maw plugin dev" header (dev verb) or "watching" (build --watch).
+ *   3. Register an fs.watch watcher on <dir>/src.
+ *   4. `build --watch` alias still works (backward-compat invariant).
+ *
+ * Isolated because we mock.module `fs` to replace `watch` with a spy that
+ * captures calls without blocking, and replace the keep-alive Promise with one
+ * that resolves immediately so the test can finish.
+ *
+ * Per-file subprocess isolation per #429 pattern: mock.module is
+ * process-global; capture real refs BEFORE installing any mocks.
+ */
+
+import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
+import {
+  existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync,
+} from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+// ─── Capture real `fs` refs before any mock.module installs ─────────────────
+const realFs = await import("fs");
+const realWatch = realFs.watch;
+
+// ─── Spy state (reset per-test) ──────────────────────────────────────────────
+let watchSpy: { path: string; opts: unknown }[] = [];
+let keepAliveResolve: (() => void) | null = null;
+
+// ─── Install fs mock (watch spy + pass-through for everything else) ──────────
+await mock.module("fs", () => {
+  return {
+    ...realFs,
+    watch: (path: string, opts: unknown, _cb: unknown) => {
+      watchSpy.push({ path, opts });
+      // Return a minimal fake FSWatcher that does nothing.
+      return { close: () => {}, ref: () => {}, unref: () => {} };
+    },
+  };
+});
+
+// ─── Patch global Promise to break keep-alive on next tick ───────────────────
+// We replace the keep-alive `new Promise(() => {})` inside runWatch by
+// intercepting it at the module level via a re-export hook.  Simpler approach:
+// import the function fresh each test so the mock.module replacement above has
+// already taken effect, then race the call with a short-circuit.
+
+// ─── Harness ─────────────────────────────────────────────────────────────────
+const created: string[] = [];
+
+function tmpDir(prefix = "maw-dev-test-"): string {
+  const d = mkdtempSync(join(tmpdir(), prefix));
+  created.push(d);
+  return d;
+}
+
+/** Scaffold a minimal buildable plugin directory. */
+function scaffoldPlugin(dir: string, name = "hello-dev"): void {
+  const srcDir = join(dir, "src");
+  mkdirSync(srcDir, { recursive: true });
+  writeFileSync(
+    join(dir, "plugin.json"),
+    JSON.stringify({
+      name,
+      version: "0.1.0",
+      entry: "./src/index.ts",
+      sdk: "^1.0.0",
+      capabilities: [],
+    }, null, 2),
+  );
+  writeFileSync(join(srcDir, "index.ts"), "export default () => ({ ok: true });\n");
+}
+
+/** Capture console output while running fn, with a timeout escape hatch.
+ *  The escape hatch resolves after `ms` ms so watch-mode never-resolve
+ *  functions can still be observed. */
+async function captureWithTimeout(
+  fn: () => Promise<void>,
+  ms = 3000,
+): Promise<{ stdout: string; stderr: string; timedOut: boolean }> {
+  const origLog = console.log;
+  const origErr = console.error;
+  const outs: string[] = [];
+  const errs: string[] = [];
+  console.log = (...a: unknown[]) => outs.push(a.map(String).join(" "));
+  console.error = (...a: unknown[]) => errs.push(a.map(String).join(" "));
+  let timedOut = false;
+  try {
+    await Promise.race([
+      fn(),
+      new Promise<void>((resolve) => setTimeout(() => { timedOut = true; resolve(); }, ms)),
+    ]);
+  } finally {
+    console.log = origLog;
+    console.error = origErr;
+  }
+  return { stdout: outs.join("\n"), stderr: errs.join("\n"), timedOut };
+}
+
+beforeEach(() => {
+  watchSpy = [];
+});
+
+afterEach(() => {
+  for (const d of created.splice(0)) {
+    if (existsSync(d)) rmSync(d, { recursive: true, force: true });
+  }
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("maw plugin dev verb", () => {
+  test("cmdPluginDev: enters watch mode and registers fs.watch on src/", async () => {
+    const dir = tmpDir();
+    scaffoldPlugin(dir);
+
+    const { cmdPluginDev } = await import("../../src/commands/plugins/plugin/build-impl");
+    const { stdout, timedOut } = await captureWithTimeout(() => cmdPluginDev([dir]), 3000);
+
+    // Should have timed out (watch mode never resolves)
+    expect(timedOut).toBe(true);
+
+    // Initial build should have produced dist/index.js
+    expect(existsSync(join(dir, "dist", "index.js"))).toBe(true);
+
+    // dev verb header logged
+    expect(stdout).toContain("maw plugin dev");
+
+    // watching... message logged
+    expect(stdout).toContain("watching");
+
+    // fs.watch registered on <dir>/src
+    expect(watchSpy.length).toBeGreaterThanOrEqual(1);
+    expect(watchSpy[0].path).toBe(join(dir, "src"));
+  });
+
+  test("cmdPluginDev: initial build populates dist/plugin.json with artifact field", async () => {
+    const dir = tmpDir();
+    scaffoldPlugin(dir, "hello-artifact");
+
+    const { cmdPluginDev } = await import("../../src/commands/plugins/plugin/build-impl");
+    await captureWithTimeout(() => cmdPluginDev([dir]), 3000);
+
+    const manifestPath = join(dir, "dist", "plugin.json");
+    expect(existsSync(manifestPath)).toBe(true);
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    expect(manifest.artifact).toBeDefined();
+    expect(manifest.artifact.sha256).toMatch(/^sha256:/);
+  });
+
+  test("cmdPluginBuild --watch: backward-compat alias still enters watch mode", async () => {
+    const dir = tmpDir();
+    scaffoldPlugin(dir, "hello-watch-flag");
+
+    const { cmdPluginBuild } = await import("../../src/commands/plugins/plugin/build-impl");
+    const { stdout, timedOut } = await captureWithTimeout(() => cmdPluginBuild([dir, "--watch"]), 3000);
+
+    expect(timedOut).toBe(true);
+    expect(existsSync(join(dir, "dist", "index.js"))).toBe(true);
+
+    // --watch should still log the "watching" message
+    expect(stdout).toContain("watching");
+
+    // fs.watch registered on <dir>/src
+    expect(watchSpy.some((w) => w.path === join(dir, "src"))).toBe(true);
+  });
+
+  test("cmdPluginBuild --watch: does NOT log the dev verb header", async () => {
+    const dir = tmpDir();
+    scaffoldPlugin(dir, "hello-no-dev-header");
+
+    const { cmdPluginBuild } = await import("../../src/commands/plugins/plugin/build-impl");
+    const { stdout } = await captureWithTimeout(() => cmdPluginBuild([dir, "--watch"]), 3000);
+
+    // The "maw plugin dev" header is only printed by cmdPluginDev, not --watch
+    expect(stdout).not.toContain("maw plugin dev");
+  });
+
+  test("help text lists dev alongside build", async () => {
+    const handler = (await import("../../src/commands/plugins/plugin/index")).default;
+    const result = await handler({
+      source: "cli",
+      args: ["--help"],
+      writer: undefined,
+    } as any);
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("dev");
+    expect(result.output).toContain("build");
+  });
+
+  test("plugin index routes dev subcommand without error", async () => {
+    const dir = tmpDir();
+    scaffoldPlugin(dir, "hello-route");
+
+    const handler = (await import("../../src/commands/plugins/plugin/index")).default;
+    // Race: invoke dev via the index handler, escape after initial build completes
+    const resultP = handler({
+      source: "cli",
+      args: ["dev", dir],
+      writer: undefined,
+    } as any);
+
+    // Let initial build run then check via timeout
+    await new Promise<void>((resolve) => setTimeout(resolve, 3000));
+
+    // Built artifact should exist regardless of whether resultP resolved
+    expect(existsSync(join(dir, "dist", "index.js"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Promotes `maw plugin build --watch` to a first-class `maw plugin dev` verb (Phase B6 of #340)
- Extracts shared `runWatch()` loop so `build --watch` and `dev` share the identical watcher behavior
- `build --watch` alias fully preserved — no existing muscle memory breaks

## Surface area

| File | Change |
|---|---|
| `src/commands/plugins/plugin/build-impl.ts` | Add `cmdPluginDev`; extract `runWatch()`; `build --watch` delegates to `runWatch()` |
| `src/commands/plugins/plugin/index.ts` | Route `dev` subcommand; update USAGE string |
| `src/commands/plugins/plugin/plugin.json` | Update description + help to list `dev` |
| `packages/sdk/docs/phase-b-decomposition.md` | Add Wave 1B delivery note to B6 section |
| `test/isolated/plugin-dev-verb.test.ts` | 6 isolated tests (bun test, all pass) |

## Backward-compat note

`maw plugin build --watch` continues to work identically — it now delegates to the same `runWatch()` function that `dev` uses. The only behavioral difference: `maw plugin dev` prints a `maw plugin dev — watch mode` header line first; `build --watch` does not (tested explicitly).

## Help text diff

Before:
```
usage: maw plugin <init|build|install> [args]
  init <name> --ts              scaffold a TS plugin
  build [dir] [--watch]         bundle + pack a plugin
  install <dir | .tgz | URL>    install a built plugin
```

After:
```
usage: maw plugin <init|build|dev|install> [args]
  init <name> --ts              scaffold a TS plugin
  build [dir] [--watch]         bundle + pack a plugin
  dev [dir]                     watch mode (alias for build --watch, DX verb)
  install <dir | .tgz | URL>    install a built plugin
```

## Test plan

- [x] `bun test test/isolated/plugin-dev-verb.test.ts` — 6 pass, 0 fail
- [x] `cmdPluginDev`: initial build runs, `dist/index.js` produced, `fs.watch` registered on `src/`
- [x] `cmdPluginBuild --watch`: backward-compat confirmed, no dev header printed
- [x] Help text lists `dev` alongside `build`
- [x] Index handler routes `dev` subcommand without error

## Deferred (pending B1)

Auto-link after each rebuild (`--link` symlink) is deferred until the host-injected shim (B1) lands — symlink installs against the shim need that infrastructure first.

Closes #340 Wave 1B

🤖 Generated with [Claude Code](https://claude.com/claude-code)