### PR TITLE
feat(plugin-compiler): opt-in .d.ts generation (#340 Wave 1C)

### DIFF
--- a/packages/sdk/docs/typed-plugin-output.md
+++ b/packages/sdk/docs/typed-plugin-output.md
@@ -1,0 +1,109 @@
+# Typed Plugin Output (`--types`)
+
+> Phase B Wave 1C · Issue #340
+
+## Overview
+
+`maw plugin build --types` emits a `dist/<name>.d.ts` file alongside
+`dist/index.js`. This gives plugin authors typed autocomplete for their
+plugin's exported interfaces, hook registrations, and capability shape
+— without changing the SDK's hand-authored contract types in
+`@maw/sdk/plugin`.
+
+This is **opt-in**. Existing Phase A plugins built without `--types` are
+completely unaffected.
+
+## Usage
+
+```bash
+maw plugin build --types
+# or with an explicit directory
+maw plugin build ./my-plugin --types
+```
+
+The flag can be combined with `--watch`:
+
+```bash
+maw plugin build --watch --types
+```
+
+## What gets emitted
+
+Given a plugin with `src/index.ts`:
+
+```typescript
+export interface GreeterConfig {
+  greeting: string;
+  count?: number;
+}
+
+export default async function handler(ctx: { args: string[] }) {
+  return { ok: true, output: "hello" };
+}
+```
+
+Running `maw plugin build --types` produces `dist/greeter.d.ts`:
+
+```typescript
+export interface GreeterConfig {
+    greeting: string;
+    count?: number;
+}
+export default function handler(ctx: {
+    args: string[];
+}): Promise<{
+    ok: boolean;
+    output: string;
+}>;
+```
+
+The file name is always `dist/<pluginName>.d.ts`, derived from the `name`
+field in `plugin.json`.
+
+## How it works
+
+Internally, `dts-gen.ts` writes a temporary `tsconfig.emit.json` into
+`dist/`, runs `bun x tsc --emitDeclarationOnly`, then removes the
+temporary config. The `bun x tsc` invocation uses typescript from your
+plugin's `devDependencies` (or the global bun tool cache) — no separate
+`tsc` install is required.
+
+```
+src/index.ts → [bun x tsc --emitDeclarationOnly] → dist/<name>.d.ts
+```
+
+The `tsconfig.emit.json` is ephemeral: it is always removed after the
+run, even if tsc exits non-zero.
+
+## SDK types are not affected
+
+The `@maw/sdk` hand-authored declarations (`index.d.ts`, `plugin.d.ts`)
+are the stable SDK contract and are never modified by `--types`. The
+emitted `.d.ts` captures only the exports of the plugin's own source.
+
+## Type-checking your plugin
+
+To type-check before building, add this to your plugin's `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "strict": true,
+    "moduleResolution": "bundler"
+  }
+}
+```
+
+Then run:
+
+```bash
+bun x tsc --noEmit
+```
+
+## Non-breaking note
+
+- Phase A plugins that don't pass `--types` continue to work identically.
+- The `.d.ts` is not included in the packed `.tgz` (tarball contains only
+  `plugin.json` + `index.js`). The types file is a development artifact
+  for the plugin author's workspace — not part of the installed bundle.

--- a/src/commands/plugins/plugin/build-impl.ts
+++ b/src/commands/plugins/plugin/build-impl.ts
@@ -1,5 +1,5 @@
 /**
- * maw plugin build [dir] [--watch]
+ * maw plugin build [dir] [--watch] [--types]
  *
  * Phase B bundler (Wave 1A):
  *   1. Read + validate <dir>/plugin.json (reject target:"wasm" → Phase C).
@@ -11,6 +11,8 @@
  *   5. Emit dist/plugin.json — copy of source manifest with capabilities filled
  *      in and artifact.{path,sha256} rewritten to the built bundle.
  *   6. Pack <dir>/<name>-<version>.tgz (flat: plugin.json + index.js at root).
+ *   7. [--types only] Run tsc --emitDeclarationOnly → dist/<name>.d.ts
+ *      Phase B Wave 1C (#340): opt-in typed output for plugin authors.
  *
  * Feature flag: MAW_PLUGIN_CAP_INFER=regex|ast (default: ast)
  *   Set to "regex" to fall back to Phase A regex inference if AST hits edge cases.
@@ -85,19 +87,21 @@ interface BuildSummary {
   declaredOnly: string[];  // declared but not detected
   sha256: string;
   tgzPath: string;
+  dtsPath?: string;        // set when --types was passed
 }
 
 export async function cmdPluginBuild(args: string[]): Promise<void> {
-  const flags = parseFlags(args, { "--watch": Boolean }, 0);
+  const flags = parseFlags(args, { "--watch": Boolean, "--types": Boolean }, 0);
   const dir = resolve(flags._[0] || ".");
+  const emitTypes = flags["--types"] === true;
 
   if (flags["--watch"]) {
-    // `--watch` flag: watch mode without dev-link. Kept for backward compat.
-    await runWatch(dir);
+    // `--watch` flag: watch mode, threads emitTypes through.
+    await runWatch(dir, emitTypes);
     return;
   }
 
-  await runBuild(dir);
+  await runBuild(dir, emitTypes);
 }
 
 /**
@@ -110,22 +114,23 @@ export async function cmdPluginBuild(args: string[]): Promise<void> {
 export async function cmdPluginDev(args: string[]): Promise<void> {
   const flags = parseFlags(args, {}, 0);
   const dir = resolve(flags._[0] || ".");
+  const emitTypes = flags["--types"] === true;
   console.log(`\x1b[36mmaw plugin dev\x1b[0m — watch mode (Ctrl-C to stop)`);
   console.log(`  dir: ${dir}`);
-  await runWatch(dir);
+  await runWatch(dir, emitTypes);
 }
 
 /** Shared watch-mode loop used by both `build --watch` and `dev`. */
-async function runWatch(dir: string): Promise<void> {
+async function runWatch(dir: string, emitTypes = false): Promise<void> {
   // One initial build, then rebuild on src change. Tolerate failures.
-  await runBuild(dir).catch(() => {});
+  await runBuild(dir, emitTypes).catch(() => {});
   console.log(`\n\x1b[36m⧖\x1b[0m watching ${dir}/src for changes (Ctrl-C to stop)...`);
   let building = false;
   const trigger = async () => {
     if (building) return;
     building = true;
     try {
-      await runBuild(dir);
+      await runBuild(dir, emitTypes);
     } catch (e: any) {
       console.error(`\x1b[31m✗\x1b[0m rebuild failed: ${e.message}`);
     } finally {
@@ -141,7 +146,7 @@ async function runWatch(dir: string): Promise<void> {
   await new Promise(() => { /* keep alive */ });
 }
 
-async function runBuild(dir: string): Promise<BuildSummary> {
+async function runBuild(dir: string, emitTypes = false): Promise<BuildSummary> {
   const manifestPath = join(dir, "plugin.json");
   if (!existsSync(manifestPath)) {
     throw new Error(`no plugin.json in ${dir}`);
@@ -231,6 +236,19 @@ async function runBuild(dir: string): Promise<BuildSummary> {
     throw new Error(`tarball packing failed: ${tar.stderr || tar.stdout}`);
   }
 
+  // --- Optional .d.ts generation (Phase B Wave 1C, --types flag) ---
+  let dtsPath: string | undefined;
+  if (emitTypes) {
+    const { generatePluginDts } = await import("./dts-gen");
+    const dtsResult = generatePluginDts({
+      pluginDir: dir,
+      distDir,
+      pluginName: name,
+      entryPath: srcPath,
+    });
+    dtsPath = dtsResult.dtsPath;
+  }
+
   // --- Summary ---
   const sizeBytes = bundleBytes.byteLength;
   const sizeKb = (sizeBytes / 1024).toFixed(1);
@@ -246,10 +264,13 @@ async function runBuild(dir: string): Promise<BuildSummary> {
   }
   console.log(`  hash:         ${shaShort}…`);
   console.log(`  packed:       ${tgzName}`);
+  if (dtsPath) {
+    console.log(`  types:        dist/${name}.d.ts \x1b[2m(--types)\x1b[0m`);
+  }
   console.log(`\x1b[32m✓\x1b[0m ready. install with: maw plugin install ./${tgzName}`);
 
   return {
     name, version, dir, bundlePath: outFile, sizeBytes, elapsedMs,
-    capabilities: merged, inferredOnly, declaredOnly, sha256, tgzPath,
+    capabilities: merged, inferredOnly, declaredOnly, sha256, tgzPath, dtsPath,
   };
 }

--- a/src/commands/plugins/plugin/dts-gen.ts
+++ b/src/commands/plugins/plugin/dts-gen.ts
@@ -1,0 +1,108 @@
+/**
+ * dts-gen.ts — opt-in .d.ts generation for plugin-specific types.
+ *
+ * Phase B Wave 1C (#340): `maw plugin build --types` emits
+ * `dist/<name>.d.ts` alongside `dist/index.js`.
+ *
+ * Strategy: write a minimal tsconfig.emit.json into dist/, then run
+ *   bun x tsc --project <tsconfig.emit.json> --emitDeclarationOnly
+ * This avoids requiring tsc on PATH — bun x pulls typescript from
+ * devDependencies or the global bun tool cache.
+ *
+ * The .d.ts is named <pluginName>.d.ts so plugin authors can re-export
+ * or type-check against their specific plugin shape rather than the
+ * generic SDK surface.
+ *
+ * Non-breaking: nothing calls this unless --types is passed. Existing
+ * Phase A plugins are unaffected.
+ */
+
+import { existsSync, writeFileSync, unlinkSync, renameSync } from "fs";
+import { join } from "path";
+import { spawnSync } from "child_process";
+
+export interface DtsGenOptions {
+  /** Plugin source directory (contains src/, plugin.json). */
+  pluginDir: string;
+  /** Directory where dist/index.js was emitted. */
+  distDir: string;
+  /** Plugin name (used to name the output file). */
+  pluginName: string;
+  /** Absolute path to the plugin entry point (e.g. src/index.ts). */
+  entryPath: string;
+}
+
+export interface DtsGenResult {
+  /** Absolute path to the emitted .d.ts file. */
+  dtsPath: string;
+  /** tsc stderr output (may contain warnings even on success). */
+  diagnostics: string;
+}
+
+/**
+ * Generate `dist/<name>.d.ts` using `bun x tsc --emitDeclarationOnly`.
+ *
+ * Writes a temporary tsconfig.emit.json into distDir, runs tsc, then
+ * removes the temporary config. Throws on tsc failure.
+ */
+export function generatePluginDts(opts: DtsGenOptions): DtsGenResult {
+  const { pluginDir, distDir, pluginName, entryPath } = opts;
+
+  if (!existsSync(entryPath)) {
+    throw new Error(`dts-gen: entry not found: ${entryPath}`);
+  }
+
+  // Temporary tsconfig scoped to just the plugin source
+  const tsconfigPath = join(distDir, "tsconfig.emit.json");
+  const dtsPath = join(distDir, `${pluginName}.d.ts`);
+
+  const tsconfig = {
+    compilerOptions: {
+      target: "ES2022",
+      module: "ESNext",
+      moduleResolution: "bundler",
+      strict: true,
+      declaration: true,
+      emitDeclarationOnly: true,
+      outDir: distDir,
+      rootDir: join(pluginDir, "src"),
+      skipLibCheck: true,
+      noEmit: false,
+    },
+    include: [join(pluginDir, "src", "**", "*")],
+  };
+
+  writeFileSync(tsconfigPath, JSON.stringify(tsconfig, null, 2) + "\n");
+
+  let diagnostics = "";
+  try {
+    const result = spawnSync(
+      "bun",
+      ["x", "tsc", "--project", tsconfigPath],
+      { cwd: pluginDir, encoding: "utf8" },
+    );
+
+    diagnostics = (result.stderr || result.stdout || "").trim();
+
+    if (result.status !== 0) {
+      throw new Error(
+        `tsc declaration emit failed (exit ${result.status}):\n${diagnostics || "(no output)"}`,
+      );
+    }
+  } finally {
+    // Always clean up the temp tsconfig
+    try { unlinkSync(tsconfigPath); } catch { /* ignore */ }
+  }
+
+  // tsc emits index.d.ts (mirrors src/index.ts); rename to <pluginName>.d.ts
+  const indexDts = join(distDir, "index.d.ts");
+  if (existsSync(indexDts) && indexDts !== dtsPath) {
+    renameSync(indexDts, dtsPath);
+  }
+
+  if (!existsSync(dtsPath)) {
+    throw new Error(`dts-gen: expected ${dtsPath} but tsc did not emit it`);
+  }
+
+  return { dtsPath, diagnostics };
+}

--- a/src/commands/plugins/plugin/index.ts
+++ b/src/commands/plugins/plugin/index.ts
@@ -7,10 +7,11 @@ export const command = {
 
 const USAGE =
   "usage: maw plugin <init|build|dev|install> [args]\n" +
-  "  init <name> --ts              scaffold a TS plugin\n" +
-  "  build [dir] [--watch]         bundle + pack a plugin\n" +
-  "  dev [dir]                     watch mode (alias for build --watch, DX verb)\n" +
-  "  install <dir | .tgz | URL>    install a built plugin";
+  "  init <name> --ts                    scaffold a TS plugin\n" +
+  "  build [dir] [--watch] [--types]     bundle + pack a plugin\n" +
+  "                                        --types: emit dist/<name>.d.ts\n" +
+  "  dev [dir] [--types]                 watch mode (alias for build --watch, DX verb)\n" +
+  "  install <dir | .tgz | URL>          install a built plugin";
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
   const logs: string[] = [];

--- a/test/isolated/plugin-dts-gen.test.ts
+++ b/test/isolated/plugin-dts-gen.test.ts
@@ -1,0 +1,225 @@
+/**
+ * plugin-dts-gen.test.ts — Phase B Wave 1C (#340)
+ *
+ * Tests for opt-in .d.ts generation via `maw plugin build --types`.
+ *
+ * Strategy:
+ *   1. Create a minimal TypeScript plugin in a temp dir.
+ *   2. bun build it to dist/index.js (same as runBuild does).
+ *   3. Call generatePluginDts() directly (unit tests).
+ *   4. Call cmdPluginBuild with --types (integration test via console capture).
+ *
+ * Tests run per-file in a subprocess (isolated mode) to avoid mock pollution.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { spawnSync } from "child_process";
+import { generatePluginDts } from "../../src/commands/plugins/plugin/dts-gen";
+import { cmdPluginBuild } from "../../src/commands/plugins/plugin/build-impl";
+
+// ─── Harness ─────────────────────────────────────────────────────────────────
+
+const created: string[] = [];
+
+function tmpDir(prefix = "maw-dts-test-"): string {
+  const d = mkdtempSync(join(tmpdir(), prefix));
+  created.push(d);
+  return d;
+}
+
+afterEach(() => {
+  for (const d of created.splice(0)) {
+    if (existsSync(d)) rmSync(d, { recursive: true, force: true });
+  }
+});
+
+/** Capture console.log lines from an async fn. */
+async function capture(fn: () => Promise<unknown>): Promise<{
+  stdout: string; stderr: string; error?: Error;
+}> {
+  const orig = { log: console.log, error: console.error };
+  const outs: string[] = [];
+  const errs: string[] = [];
+  console.log = (...a: any[]) => outs.push(a.map(String).join(" "));
+  console.error = (...a: any[]) => errs.push(a.map(String).join(" "));
+  let error: Error | undefined;
+  try { await fn(); } catch (e: any) { error = e instanceof Error ? e : new Error(String(e)); }
+  finally { console.log = orig.log; console.error = orig.error; }
+  return { stdout: outs.join("\n"), stderr: errs.join("\n"), error };
+}
+
+/**
+ * Scaffold a minimal TS plugin dir.
+ * Returns the dir path with src/index.ts, plugin.json, dist/index.js.
+ */
+function scaffoldPlugin(opts: {
+  name?: string;
+  version?: string;
+  /** Extra exported TypeScript content appended to src/index.ts */
+  extraExports?: string;
+} = {}): string {
+  const name = opts.name ?? "hello";
+  const version = opts.version ?? "0.1.0";
+  const dir = tmpDir("maw-plugin-");
+
+  // plugin.json
+  writeFileSync(
+    join(dir, "plugin.json"),
+    JSON.stringify(
+      {
+        name,
+        version,
+        sdk: "^1.0.0",
+        target: "js",
+        entry: "./src/index.ts",
+        artifact: { path: "dist/index.js", sha256: null },
+        capabilities: [],
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+
+  // src/index.ts
+  mkdirSync(join(dir, "src"), { recursive: true });
+  writeFileSync(
+    join(dir, "src", "index.ts"),
+    `export interface ${name.charAt(0).toUpperCase() + name.slice(1)}Config {
+  greeting: string;
+  count?: number;
+}
+
+export default async function handler(ctx: { args: string[] }): Promise<{ ok: boolean; output: string }> {
+  return { ok: true, output: "hello from ${name}" };
+}
+` + (opts.extraExports ?? ""),
+  );
+
+  // Pre-build dist/index.js so generatePluginDts can be called without a full build
+  mkdirSync(join(dir, "dist"), { recursive: true });
+  const build = spawnSync(
+    "bun",
+    ["build", join(dir, "src", "index.ts"), "--outfile", join(dir, "dist", "index.js"), "--target=bun", "--format=esm"],
+    { cwd: dir, encoding: "utf8" },
+  );
+  if (build.status !== 0) {
+    throw new Error(`scaffold bun build failed:\n${build.stderr || build.stdout}`);
+  }
+
+  return dir;
+}
+
+// ─── Unit: generatePluginDts ─────────────────────────────────────────────────
+
+describe("generatePluginDts", () => {
+  test("emits dist/<name>.d.ts for a minimal TS plugin", () => {
+    const dir = scaffoldPlugin({ name: "hello" });
+    const result = generatePluginDts({
+      pluginDir: dir,
+      distDir: join(dir, "dist"),
+      pluginName: "hello",
+      entryPath: join(dir, "src", "index.ts"),
+    });
+
+    expect(result.dtsPath).toBe(join(dir, "dist", "hello.d.ts"));
+    expect(existsSync(result.dtsPath)).toBe(true);
+
+    const content = readFileSync(result.dtsPath, "utf8");
+    // Must contain the exported interface
+    expect(content).toContain("HelloConfig");
+    expect(content).toContain("greeting: string");
+    // Must contain the default export signature
+    expect(content).toContain("export default function handler");
+  });
+
+  test("emitted .d.ts contains exported types from plugin source", () => {
+    const dir = scaffoldPlugin({
+      name: "typed",
+      extraExports: `
+export type PluginMode = "read" | "write";
+export interface TypedOptions {
+  mode: PluginMode;
+  timeout: number;
+}
+`,
+    });
+
+    const result = generatePluginDts({
+      pluginDir: dir,
+      distDir: join(dir, "dist"),
+      pluginName: "typed",
+      entryPath: join(dir, "src", "index.ts"),
+    });
+
+    const content = readFileSync(result.dtsPath, "utf8");
+    expect(content).toContain("PluginMode");
+    expect(content).toContain('"read" | "write"');
+    expect(content).toContain("TypedOptions");
+    expect(content).toContain("timeout: number");
+  });
+
+  test("throws when entry file does not exist", () => {
+    const dir = tmpDir();
+    mkdirSync(join(dir, "dist"), { recursive: true });
+
+    expect(() =>
+      generatePluginDts({
+        pluginDir: dir,
+        distDir: join(dir, "dist"),
+        pluginName: "missing",
+        entryPath: join(dir, "src", "index.ts"),
+      }),
+    ).toThrow("dts-gen: entry not found");
+  });
+
+  test("cleans up tsconfig.emit.json even on failure", () => {
+    const dir = tmpDir();
+    mkdirSync(join(dir, "dist"), { recursive: true });
+    // entry doesn't exist → throws before tsc runs
+    try {
+      generatePluginDts({
+        pluginDir: dir,
+        distDir: join(dir, "dist"),
+        pluginName: "noop",
+        entryPath: join(dir, "src", "index.ts"),
+      });
+    } catch { /* expected */ }
+
+    // tsconfig.emit.json must not be left behind
+    expect(existsSync(join(dir, "dist", "tsconfig.emit.json"))).toBe(false);
+  });
+});
+
+// ─── Integration: cmdPluginBuild --types ─────────────────────────────────────
+
+describe("cmdPluginBuild --types flag", () => {
+  test("emits .d.ts when --types is passed", async () => {
+    const dir = scaffoldPlugin({ name: "greet" });
+
+    const { stdout, error } = await capture(() =>
+      cmdPluginBuild(["--types", dir]),
+    );
+
+    expect(error).toBeUndefined();
+    expect(existsSync(join(dir, "dist", "greet.d.ts"))).toBe(true);
+
+    const content = readFileSync(join(dir, "dist", "greet.d.ts"), "utf8");
+    expect(content).toContain("GreetConfig");
+
+    // Summary line includes types mention
+    expect(stdout).toContain("types:");
+    expect(stdout).toContain("greet.d.ts");
+  });
+
+  test("does NOT emit .d.ts when --types is absent", async () => {
+    const dir = scaffoldPlugin({ name: "notypes" });
+
+    const { error } = await capture(() => cmdPluginBuild([dir]));
+
+    expect(error).toBeUndefined();
+    expect(existsSync(join(dir, "dist", "notypes.d.ts"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `maw plugin build --types` flag: emits `dist/<name>.d.ts` via `bun x tsc --emitDeclarationOnly` alongside the existing bundle
- New `src/commands/plugins/plugin/dts-gen.ts` (~90 LOC): writes an ephemeral `tsconfig.emit.json` into `dist/`, runs tsc, renames `index.d.ts` → `<name>.d.ts`, then cleans up the config
- 6 isolated tests in `test/isolated/plugin-dts-gen.test.ts` — all green

## `--types` flag behaviour

```bash
maw plugin build --types          # emits dist/<name>.d.ts
maw plugin build --watch --types  # watches + re-emits on change
maw plugin build                  # no .d.ts (Phase A compat, unchanged)
```

The `.d.ts` is a **dev-only artifact**: it is not packed into the `.tgz` tarball, so installed plugins are unaffected. Plugin authors use it for typed autocomplete over their own exported interfaces.

## Sample output

Given `src/index.ts` exporting `GreeterConfig { greeting: string }`:

```typescript
// dist/greeter.d.ts
export interface GreeterConfig {
    greeting: string;
    count?: number;
}
export default function handler(ctx: {
    args: string[];
}): Promise<{ ok: boolean; output: string; }>;
```

## tsc command settled on

```
bun x tsc --project <tmpdir>/dist/tsconfig.emit.json
```

`bun x tsc` resolves typescript from the plugin's `devDependencies` or the global bun cache — no separate tsc install required. The tsconfig uses `emitDeclarationOnly: true`, `rootDir: src/`, `outDir: dist/`.

## Non-breaking note

- `--types` is opt-in; existing Phase A plugins with no flag are identical
- `@maw/sdk` hand-authored `index.d.ts` / `plugin.d.ts` are untouched
- `.d.ts` not included in `.tgz` pack (tarball = `plugin.json + index.js` only)

## Files changed

| File | Change |
|------|--------|
| `src/commands/plugins/plugin/dts-gen.ts` | new — ~90 LOC |
| `src/commands/plugins/plugin/build-impl.ts` | +20 LOC: `--types` flag, summary line |
| `src/commands/plugins/plugin/index.ts` | USAGE string update |
| `test/isolated/plugin-dts-gen.test.ts` | new — 6 tests, ~100 LOC active |
| `packages/sdk/docs/typed-plugin-output.md` | new — author guide |

🤖 Generated with [Claude Code](https://claude.com/claude-code)