### PR TITLE
chore(test): migrate predictable tmpdir paths to mkdtempSync (CodeQL js/insecure-temporary-file)

### DIFF
--- a/test/isolated/merge-alive-zero.test.ts
+++ b/test/isolated/merge-alive-zero.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "fs";
+import { mkdirSync, mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { _setDirs } from "../../src/commands/plugins/team/impl";
@@ -21,7 +21,7 @@ let originalCwd: string;
 
 beforeEach(() => {
   originalCwd = process.cwd();
-  testDir = join(tmpdir(), `maw-mergeG-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  testDir = mkdtempSync(join(tmpdir(), "maw-mergeG-"));
   teamsDir = join(testDir, "teams");
   tasksDir = join(testDir, "tasks");
   psiDir = join(testDir, "oracle");

--- a/test/isolated/plugin-install-refuse-overwrite.test.ts
+++ b/test/isolated/plugin-install-refuse-overwrite.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdirSync, writeFileSync, existsSync, symlinkSync, readlinkSync, rmSync } from "fs";
+import { mkdirSync, mkdtempSync, writeFileSync, existsSync, symlinkSync, readlinkSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { installFromDir } from "../../src/commands/plugins/plugin/install-handlers";
@@ -16,7 +16,7 @@ let pluginsRoot: string;
 let originalEnv: string | undefined;
 
 beforeEach(() => {
-  testRoot = join(tmpdir(), `maw-bug403-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  testRoot = mkdtempSync(join(tmpdir(), "maw-bug403-"));
   pluginsRoot = join(testRoot, "plugins");
   mkdirSync(pluginsRoot, { recursive: true });
   originalEnv = process.env.MAW_PLUGINS_DIR;

--- a/test/isolated/resolve-psi.test.ts
+++ b/test/isolated/resolve-psi.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdirSync, writeFileSync, rmSync } from "fs";
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { resolvePsi } from "../../src/commands/plugins/team/team-helpers";
@@ -13,7 +13,7 @@ let originalCwd: string;
 
 beforeEach(() => {
   originalCwd = process.cwd();
-  oracleRoot = join(tmpdir(), `maw-resolvepsi-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  oracleRoot = mkdtempSync(join(tmpdir(), "maw-resolvepsi-test-"));
   mkdirSync(join(oracleRoot, "ψ", "memory", "mailbox"), { recursive: true });
   writeFileSync(join(oracleRoot, "CLAUDE.md"), "# test oracle\n");
 });
@@ -54,8 +54,7 @@ describe("resolvePsi — walks up from cwd (#393 Bug A)", () => {
   });
 
   test("fallback — no oracle root up the tree returns cwd/ψ", () => {
-    const orphan = join(tmpdir(), `maw-orphan-${Date.now()}`);
-    mkdirSync(orphan, { recursive: true });
+    const orphan = mkdtempSync(join(tmpdir(), "maw-orphan-"));
     try {
       process.chdir(orphan);
       expect(resolvePsi()).toBe(join(orphan, "ψ"));
@@ -65,7 +64,7 @@ describe("resolvePsi — walks up from cwd (#393 Bug A)", () => {
   });
 
   test("requires BOTH markers: ψ/ alone without CLAUDE.md falls through", () => {
-    const fakeOracle = join(tmpdir(), `maw-fake-${Date.now()}`);
+    const fakeOracle = mkdtempSync(join(tmpdir(), "maw-fake-"));
     mkdirSync(join(fakeOracle, "ψ"), { recursive: true });
     // no CLAUDE.md written
     const sub = join(fakeOracle, "ψ", "writing");

--- a/test/isolated/team-list-vault-teams.test.ts
+++ b/test/isolated/team-list-vault-teams.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdirSync, writeFileSync, rmSync } from "fs";
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { _setDirs } from "../../src/commands/plugins/team/impl";
@@ -17,7 +17,7 @@ let originalCwd: string;
 
 beforeEach(() => {
   originalCwd = process.cwd();
-  testDir = join(tmpdir(), `maw-bugB-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  testDir = mkdtempSync(join(tmpdir(), "maw-bugB-"));
   toolTeamsDir = join(testDir, "tool-teams");
   tasksDir = join(testDir, "tasks");
   oracleRoot = join(testDir, "oracle");

--- a/test/isolated/team-spawn-exec.test.ts
+++ b/test/isolated/team-spawn-exec.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdirSync, writeFileSync, existsSync, rmSync } from "fs";
+import { mkdirSync, mkdtempSync, writeFileSync, existsSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { cmdTeamSpawn } from "../../src/commands/plugins/team/team-lifecycle";
@@ -19,7 +19,7 @@ let originalTMUX: string | undefined;
 beforeEach(() => {
   originalCwd = process.cwd();
   originalTMUX = process.env.TMUX;
-  testDir = join(tmpdir(), `maw-bugC-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  testDir = mkdtempSync(join(tmpdir(), "maw-bugC-"));
   // Oracle root markers for resolvePsi
   mkdirSync(join(testDir, "ψ/memory/mailbox/teams/test-team"), { recursive: true });
   writeFileSync(join(testDir, "CLAUDE.md"), "# test oracle\n");

--- a/test/team-reincarnation.test.ts
+++ b/test/team-reincarnation.test.ts
@@ -10,7 +10,7 @@
  */
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import {
-  mkdirSync, writeFileSync, readFileSync, existsSync, rmSync, readdirSync,
+  mkdirSync, mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, readdirSync,
 } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -31,7 +31,7 @@ let psiDir: string;
 let origCwd: string;
 
 beforeEach(() => {
-  testDir = join(tmpdir(), `maw-reincarn-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  testDir = mkdtempSync(join(tmpdir(), "maw-reincarn-"));
   teamsDir = join(testDir, "teams");
   tasksDir = join(testDir, "tasks");
   psiDir = join(testDir, "ψ");

--- a/test/team.test.ts
+++ b/test/team.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "fs";
+import { mkdirSync, mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { loadTeam, writeShutdownRequest, _setDirs, cmdTeamList, cmdCleanupZombies } from "../src/commands/plugins/team/impl";
@@ -9,7 +9,7 @@ let teamsDir: string;
 let tasksDir: string;
 
 beforeEach(() => {
-  testDir = join(tmpdir(), `maw-team-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  testDir = mkdtempSync(join(tmpdir(), "maw-team-test-"));
   teamsDir = join(testDir, "teams");
   tasksDir = join(testDir, "tasks");
   mkdirSync(teamsDir, { recursive: true });


### PR DESCRIPTION
## Summary

- Fixes all 40 `js/insecure-temporary-file` CodeQL alerts across 7 test files
- Replaces `join(tmpdir(), \`<prefix>-\${Date.now()}-...\`)` with `mkdtempSync(join(tmpdir(), "<prefix>-"))` — OS-level atomic, unpredictable temp dirs
- Adds `mkdtempSync` import to each affected file
- `src/commands/plugins/team/team-helpers.ts:77,99` alerts resolve automatically (CodeQL taint flow from test tmpdir calls, not direct tmpdir usage in src)

**Files changed (7):**
- `test/team.test.ts`
- `test/team-reincarnation.test.ts`
- `test/isolated/team-spawn-exec.test.ts`
- `test/isolated/team-list-vault-teams.test.ts`
- `test/isolated/resolve-psi.test.ts` (3 callsites: beforeEach + 2 inline test locals)
- `test/isolated/plugin-install-refuse-overwrite.test.ts`
- `test/isolated/merge-alive-zero.test.ts`

**Before:**
\`\`\`ts
testDir = join(tmpdir(), \`maw-team-test-\${Date.now()}-\${Math.random().toString(36).slice(2)}\`);
mkdirSync(testDir, { recursive: true });
\`\`\`

**After:**
\`\`\`ts
testDir = mkdtempSync(join(tmpdir(), "maw-team-test-"));
\`\`\`

**CodeQL rule:** [js/insecure-temporary-file](https://codeql.github.com/codeql-query-help/javascript/js-insecure-temporary-file/)

## Test plan

- [x] `bun run test` — 993 pass, 0 fail
- [x] `bun run test:isolated` — 57/57 files passed, 0 failed
- [x] `bun run test:mock-smoke` — 6 pass, 0 fail
- [x] `bun run test:plugin` — 136 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)