### PR TITLE
refactor: idempotent mkdir for TOCTOU-class CodeQL findings

### DIFF
--- a/src/commands/plugins/team/team-helpers.ts
+++ b/src/commands/plugins/team/team-helpers.ts
@@ -94,8 +94,7 @@ export function writeMessage(teamName: string, memberName: string, from: string,
     timestamp: new Date().toISOString(),
     read: false,
   });
-  const dir = join(TEAMS_DIR, teamName, "inboxes");
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  mkdirSync(join(TEAMS_DIR, teamName, "inboxes"), { recursive: true });
   writeFileSync(inboxPath, JSON.stringify(messages, null, 2));
 }
 

--- a/src/plugin/registry-helpers.ts
+++ b/src/plugin/registry-helpers.ts
@@ -92,7 +92,7 @@ function markLegacyWarningShown(): void {
   try {
     const stateFile = warnStatePath();
     const dir = join(stateFile, "..");
-    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    mkdirSync(dir, { recursive: true });
     let state: Record<string, unknown> = {};
     if (existsSync(stateFile)) {
       try { state = JSON.parse(readFileSync(stateFile, "utf8")); } catch { /* corrupt — start fresh */ }


### PR DESCRIPTION
## Summary

- Removes two redundant `existsSync` guards before `mkdirSync({recursive:true})` calls.
  `mkdirSync` with `recursive:true` is idempotent — the guard creates a TOCTOU window and
  adds no value.
- Closes CodeQL `js/file-system-race` alerts at `registry-helpers.ts:101` and `team-helpers.ts:99`.

## Triage doc

Full classification of all 10 `js/file-system-race` prod findings:
`ψ/writing/2026-04-18/codeql-toctou-triage.md` (mawjs-oracle vault)

## CodeQL alerts addressed

| Alert | File | Line | Classification | Action |
|-------|------|------|---------------|--------|
| `js/file-system-race` | `src/plugin/registry-helpers.ts` | 101 | (c) SIMPLE-FIX | ✅ Fixed |
| `js/file-system-race` | `src/commands/plugins/team/team-helpers.ts` | 99 | (c) SIMPLE-FIX | ✅ Fixed |
| `js/file-system-race` | `src/api/config.ts` | 120 | (b) REAL-FIX | 📋 #484 |
| `js/file-system-race` | `src/lib/artifacts.ts` | 62 | (a) ACCEPTED-RISK | Documented |
| `js/file-system-race` | `src/core/fleet/registry-oracle-cache.ts` | 55 | (a) ACCEPTED-RISK | Documented |
| `js/file-system-race` | `src/commands/shared/plugin-create-as.ts` | 21 | (a) ACCEPTED-RISK | Documented |
| `js/file-system-race` | `src/commands/plugins/team/team-lifecycle.ts` | 208 | (a) ACCEPTED-RISK | Documented |
| `js/file-system-race` | `src/commands/plugins/team/team-helpers.ts` | 77 | (a) ACCEPTED-RISK | Documented |
| `js/file-system-race` | `src/commands/plugins/team/task-ops.ts` | 34 | (a) ACCEPTED-RISK | Documented |
| `js/file-system-race` | `src/commands/plugins/bud/bud-init.ts` | 31 | (a) ACCEPTED-RISK | Documented |

## Issues filed for (b) REAL-FIX

- #484 — `src/api/config.ts:120` — atomic `wx` flag for PUT /config-file 409 guard

## Test plan

- [x] `bun run test:all` — 130 pass, 0 fail, 6 skip (no regression)
- [x] Both changed functions are non-critical paths (warn-throttle state write + inbox dir init)
- [x] `mkdirSync({recursive:true})` is idempotent — no behavior change when dir already exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)