### PR TITLE
audit: plugin install download flow (CodeQL) + defensive caps

### DIFF
--- a/src/commands/plugins/plugin/install-extraction.ts
+++ b/src/commands/plugins/plugin/install-extraction.ts
@@ -9,12 +9,26 @@ import { tmpdir } from "os";
 import { basename, join } from "path";
 import { hashFile } from "../../../plugin/registry";
 
+const MAX_DOWNLOAD_BYTES = 50 * 1024 * 1024; // 50 MB
+
 /**
  * Run `tar -xzf <tarball> -C <destDir>` synchronously. Returns true on success.
  * We shell out to GNU tar rather than adding a `tar` npm dep — Bun ships without
  * streaming tar, and adding a dep for a single call is not worth it.
  */
 export function extractTarball(tarballPath: string, destDir: string): { ok: true } | { ok: false; error: string } {
+  // Path-traversal guard: list entries first, reject any that escape the staging dir.
+  // GNU tar does not strip "../" by default; -C alone does not prevent traversal.
+  const list = spawnSync("tar", ["-tzf", tarballPath], { encoding: "utf8" });
+  if (list.status !== 0) {
+    return { ok: false, error: `tar list failed: ${list.stderr || list.stdout || `exit ${list.status}`}` };
+  }
+  for (const entry of list.stdout.split("\n").filter(Boolean)) {
+    if (entry.startsWith("/") || entry.split("/").includes("..")) {
+      return { ok: false, error: `tarball rejected: path traversal in entry "${entry}"` };
+    }
+  }
+
   const r = spawnSync("tar", ["-xzf", tarballPath, "-C", destDir], {
     encoding: "utf8",
   });
@@ -29,6 +43,12 @@ export function extractTarball(tarballPath: string, destDir: string): { ok: true
  * before writing (per brief: "verify content-type is gzip/tar").
  */
 export async function downloadTarball(url: string): Promise<{ ok: true; path: string } | { ok: false; error: string }> {
+  // Scheme gate — defense in depth; detectMode already filters callers from cmdPluginInstall
+  // but direct callers of this function would bypass that upstream check.
+  if (!/^https?:\/\//i.test(url)) {
+    return { ok: false, error: `download refused: only http/https URLs are allowed (got ${JSON.stringify(url.slice(0, 32))})` };
+  }
+
   let res: Response;
   try {
     res = await fetch(url);
@@ -38,6 +58,13 @@ export async function downloadTarball(url: string): Promise<{ ok: true; path: st
   if (!res.ok) {
     return { ok: false, error: `download failed: HTTP ${res.status} ${res.statusText}` };
   }
+
+  // Size cap: reject before buffering if Content-Length already exceeds limit.
+  const declared = Number(res.headers.get("content-length") ?? 0);
+  if (declared > MAX_DOWNLOAD_BYTES) {
+    return { ok: false, error: `download refused: Content-Length ${declared} exceeds ${MAX_DOWNLOAD_BYTES} byte limit` };
+  }
+
   const ct = (res.headers.get("content-type") ?? "").toLowerCase();
   const ctOk =
     ct.includes("gzip") ||
@@ -48,7 +75,13 @@ export async function downloadTarball(url: string): Promise<{ ok: true; path: st
   if (!ctOk) {
     return { ok: false, error: `unexpected content-type ${JSON.stringify(ct)} — expected gzip/tar` };
   }
+
   const buf = new Uint8Array(await res.arrayBuffer());
+  // Cap actual bytes too — Content-Length can be absent or spoofed.
+  if (buf.byteLength > MAX_DOWNLOAD_BYTES) {
+    return { ok: false, error: `download refused: response body (${buf.byteLength} bytes) exceeds ${MAX_DOWNLOAD_BYTES} byte limit` };
+  }
+
   const tmp = mkdtempSync(join(tmpdir(), "maw-dl-"));
   const filename = basename(new URL(url).pathname) || "plugin.tgz";
   const outPath = join(tmp, filename);

--- a/test/isolated/plugin-install-url.test.ts
+++ b/test/isolated/plugin-install-url.test.ts
@@ -197,7 +197,7 @@ describe("cmdPluginInstall — URL source (real Bun.serve)", () => {
     expect(exitCode).toBe(1);
     // Error surface can be "tar extract failed" OR "no plugin.json" — both are
     // actionable. Just assert one of the two.
-    const actionable = /tar extract failed|no plugin\.json|invalid plugin\.json/;
+    const actionable = /tar list failed|tar extract failed|no plugin\.json|invalid plugin\.json/;
     expect(stderr).toMatch(actionable);
     expect(existsSync(join(pluginsDir, "url-test-plugin"))).toBe(false);
   });


### PR DESCRIPTION
## Summary

CodeQL audit of the `js/file-access-to-http` + `js/http-to-file-access` warnings in the plugin install download flow. Three defensive fixes shipped; one architectural gap filed as a separate issue.

**Files changed**: `src/commands/plugins/plugin/install-extraction.ts`, `test/isolated/plugin-install-url.test.ts`
**Bloom collision avoided**: `hub-connection.ts` not touched.

## Fixes shipped

- **Path-traversal guard** (`extractTarball`): pre-lists tarball entries with `tar -tzf` before extracting; rejects any entry with `..` components or absolute paths. Prevents staging-dir escape regardless of GNU tar version. This is the critical finding — extraction happened before hash verification, so a traversal could write files even if the hash gate later aborted.
- **Response size cap** (`downloadTarball`): checks `Content-Length` header and actual buffer size against a 50 MB limit. Prevents OOM/disk exhaustion from a malicious server serving a streaming response.
- **URL scheme gate inside `downloadTarball`**: rejects non-http/https URLs at the function boundary (defense in depth — `detectMode` in `cmdPluginInstall` already filters, but direct callers bypass that).

## Issue filed

- #487 — `verifyArtifactHash` uses manifest embedded in the untrusted tarball; provides no supply-chain integrity against a malicious server. Needs registry-pinned hashes or signed manifests (non-trivial architectural change).

## Test plan

- [x] `bun run test:all` — 57/57 files pass, 0 fail
- [x] Truncated tarball test updated: now accepts `"tar list failed"` as actionable error (the listing step fires before extraction for corrupt/truncated tarballs)
- [x] Happy-path URL install test unchanged and passing
- [x] Bloom's lines (`hub-connection.ts:54,83,86,95`) untouched

## Audit doc

`ψ/writing/2026-04-18/codeql-download-flow-audit.md` (in mawjs-oracle vault)

🤖 Generated with [Claude Code](https://claude.com/claude-code)