### PR TITLE
fix(transport): atomic PUT /config-file (TOCTOU) (#484)

### DIFF
--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -115,9 +115,16 @@ configApi.put("/config-file", async ({ body, set}) => {
   if (!name || !name.endsWith(".json")) { set.status = 400; return { error: "name must end with .json" }; }
   const safeName = basename(name);
   const fullPath = join(fleetDir, safeName);
-  if (existsSync(fullPath)) { set.status = 409; return { error: "file already exists" }; }
   try { JSON.parse(content); } catch { set.status = 400; return { error: "invalid JSON" }; }
-  writeFileSync(fullPath, content + "\n", "utf-8");
+  // Atomic create: O_CREAT | O_EXCL. Kernel rejects on EEXIST — no TOCTOU window. (#484)
+  try {
+    writeFileSync(fullPath, content + "\n", { encoding: "utf-8", flag: "wx" });
+  } catch (e: unknown) {
+    if ((e as NodeJS.ErrnoException).code === "EEXIST") {
+      set.status = 409; return { error: "file already exists" };
+    }
+    throw e;
+  }
   return { ok: true, path: `fleet/${safeName}` };
 }, {
   body: t.Object({ name: t.String(), content: t.String() }),

--- a/test/isolated/api-config-file-atomic.test.ts
+++ b/test/isolated/api-config-file-atomic.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Regression test for #484 — PUT /config-file must be atomic (O_CREAT | O_EXCL).
+ *
+ * The old handler used `existsSync` guard followed by `writeFileSync` — a
+ * TOCTOU window where two concurrent requests for the same filename could
+ * both pass the guard and both write, silently bypassing the 409 constraint.
+ *
+ * The fix uses `writeFileSync(..., { flag: "wx" })`, which maps to O_CREAT |
+ * O_EXCL: the kernel rejects atomically if the file already exists.
+ *
+ * Isolated (per-file subprocess) because we mutate process.env before a
+ * module-load that reads it — poisons other tests otherwise.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync, readFileSync, readdirSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { Elysia } from "elysia";
+
+const TEST_CONFIG_DIR = mkdtempSync(join(tmpdir(), "maw-config-484-"));
+process.env.MAW_CONFIG_DIR = TEST_CONFIG_DIR;
+
+let app: Elysia;
+let fleetDir: string;
+
+beforeAll(async () => {
+  const paths = await import("../../src/core/paths");
+  fleetDir = paths.FLEET_DIR;
+  const { configApi } = await import("../../src/api/config");
+  app = new Elysia().use(configApi);
+});
+
+afterAll(() => {
+  rmSync(TEST_CONFIG_DIR, { recursive: true, force: true });
+});
+
+function put(name: string, content: string) {
+  return app.handle(
+    new Request("http://localhost/config-file", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name, content }),
+    }),
+  );
+}
+
+describe("PUT /config-file (atomic creation, #484)", () => {
+  test("first PUT creates the file; second PUT for same name returns 409", async () => {
+    const name = "serial-484.json";
+    const first = await put(name, JSON.stringify({ a: 1 }));
+    expect(first.status).toBe(200);
+    expect(await first.json()).toEqual({ ok: true, path: `fleet/${name}` });
+
+    const second = await put(name, JSON.stringify({ b: 2 }));
+    expect(second.status).toBe(409);
+    expect(await second.json()).toEqual({ error: "file already exists" });
+
+    // Original content is preserved — second PUT did not overwrite.
+    const written = readFileSync(join(fleetDir, name), "utf-8");
+    expect(JSON.parse(written)).toEqual({ a: 1 });
+  });
+
+  test("concurrent PUTs for the same name: exactly one wins, others 409", async () => {
+    const name = "concurrent-484.json";
+    const N = 20;
+    const payloads = Array.from({ length: N }, (_, i) =>
+      JSON.stringify({ writer: i }),
+    );
+
+    // Fire them off in parallel — this is the TOCTOU race.
+    const responses = await Promise.all(payloads.map((p) => put(name, p)));
+    const statuses = responses.map((r) => r.status).sort();
+
+    const wins = statuses.filter((s) => s === 200).length;
+    const losses = statuses.filter((s) => s === 409).length;
+
+    // Exactly one winner. The TOCTOU bug would let 2+ through.
+    expect(wins).toBe(1);
+    expect(losses).toBe(N - 1);
+
+    // Exactly one file on disk with that name, and its content matches
+    // one of the payloads (whichever writer won the race).
+    const written = readFileSync(join(fleetDir, name), "utf-8");
+    const parsed = JSON.parse(written);
+    expect(parsed).toHaveProperty("writer");
+    expect(typeof parsed.writer).toBe("number");
+
+    const entries = readdirSync(fleetDir).filter((f) => f === name);
+    expect(entries).toEqual([name]);
+  });
+
+  test("invalid JSON rejected with 400 before any file is created", async () => {
+    const name = "invalid-484.json";
+    const res = await put(name, "{not json");
+    expect(res.status).toBe(400);
+    const files = readdirSync(fleetDir).filter((f) => f === name);
+    expect(files).toEqual([]);
+  });
+
+  test("name must end with .json (400)", async () => {
+    const res = await put("not-json-484.txt", JSON.stringify({}));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "name must end with .json" });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #484 — `PUT /config-file` had a TOCTOU window between `existsSync(fullPath)` and `writeFileSync(fullPath, ...)`. Two concurrent requests for the same filename could both pass the existence guard before either completed the write, silently bypassing the 409 uniqueness constraint.

## Fix

Replace the `existsSync` guard with an atomic `writeFileSync(..., { flag: "wx" })`. The `wx` flag maps to `O_CREAT | O_EXCL`: the kernel rejects the open atomically if the file already exists. On `EEXIST`, translate to 409. No check-then-act window.

```ts
try {
  writeFileSync(fullPath, content + "\n", { encoding: "utf-8", flag: "wx" });
} catch (e: unknown) {
  if ((e as NodeJS.ErrnoException).code === "EEXIST") {
    set.status = 409; return { error: "file already exists" };
  }
  throw e;
}
```

Also moves `JSON.parse(content)` ahead of the file write so invalid payloads return 400 without any fs touch. (Previously, a 409 could shadow a 400 — now the 400 wins.)

## Test

`test/isolated/api-config-file-atomic.test.ts` — 4 cases (serial 409, 20-way concurrent PUT with exactly-one-winner assertion, invalid-JSON 400, invalid-name 400). Isolated/per-subprocess because it mutates `process.env.MAW_CONFIG_DIR` before a module-load that reads it.

Bun's single-threaded event loop + sync fs means handler-level tests can't actually expose the TOCTOU race, but the concurrent test locks in the contract: if anyone later converts to `fsPromises.writeFile`, a regression would immediately surface.

## test:all

- `bun run test` — **35 fail** (all 35 = known #489 H4 baseline; `agents/pb-maw-demo/test/plugin-install-url-validation.test.ts` file://+ftp:// exit-code assertions)
- `bun run test:isolated` — **62/62 files pass** including the new 4 tests
- No new failures introduced

## CodeQL

Clears `js/file-system-race` on this endpoint. Triage doc: `ψ/writing/2026-04-18/codeql-toctou-triage.md` (mawjs-oracle vault).

## Priority

Low — maw-ui runs single-tenant on a dev machine. The race is a logic bug (duplicate silently-created files), not a security exploit. Fix lands before any multi-tenant rollout.

## Test plan

- [x] New isolated test passes
- [x] test:isolated 62/62
- [x] test: fail-count unchanged (35 = #489 baseline)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)