### PR TITLE
fix(test): ignore agents/ worktrees in bun run test (#467, #489)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "bun build src/cli.ts --outfile dist/maw --target=bun --minify",
     "deploy": "bun run build && bun src/cli.ts fleet sync && pm2 restart maw",
     "dev": "pm2 start ecosystem.config.cjs",
-    "test": "bun test test/ --path-ignore-patterns '**/test/isolated/**' --path-ignore-patterns '**/zz-mock-tmux-smoke*'",
+    "test": "bun test test/ --path-ignore-patterns '**/test/isolated/**' --path-ignore-patterns '**/zz-mock-tmux-smoke*' --path-ignore-patterns '**/agents/**'",
     "test:isolated": "bash scripts/test-isolated.sh",
     "test:isolated:random": "bash scripts/test-isolated.sh --randomize",
     "test:isolated:legacy": "bun test test/isolated/",


### PR DESCRIPTION
## Summary

`bun test test/` treats the positional as a **substring filter**, not a path. It walks the whole repo and matches every `*.test.ts` whose path contains `test/` — including all 8 active worktrees under `agents/`.

Stale snapshots there (older `src/cli.ts`) fail on `update-help.test.ts`, `plugin-install-url-validation.test.ts`, and `cmd-update-ref-validation.test.ts` → the 35 failures tracked in #489 and the batch failure in #467.

Pattern already existed on `test:mock-smoke` and `test:plugin`; this was a missed-on-one-script omission, not `mock.module` pollution.

## Numbers
- Before: `8932 tests across 652 files — 35 fail` (the ~7.9k beyond the real 1029 were duplicate runs across 8 worktrees)
- After: `1029 tests across 74 files — 0 fail`

## Test plan
- [x] `bun run test` — 1023 pass, 0 fail
- [x] `bun test test/update-help.test.ts` alone still passes (36 pass)
- [ ] CI `test:all` on fresh container stays green

## Supersedes
Replaces PR #490 (which accidentally bundled the #484 test file from a parallel-agent shared-checkout incident). #484 stands alone in PR #491.

Closes #467
Closes #489

Co-Authored-By: pollution-hunter <noreply@soulbrews.studio>