### PR TITLE
fix(security): close js/identity-replacement alerts via dead-code removal

### DIFF
--- a/src/lib/federation-auth.ts
+++ b/src/lib/federation-auth.ts
@@ -138,7 +138,7 @@ export function federationAuth(): MiddlewareHandler {
     const allowPeersWithoutToken = config.allowPeersWithoutToken === true;
 
     const url = new URL(c.req.url);
-    const path = url.pathname.replace(/^\/api/, "/api"); // normalize
+    const path = url.pathname;
 
     // Not a protected path → pass (reads remain public so the Office UI works)
     if (!isProtected(path, c.req.method)) return next();

--- a/src/views/demo.ts
+++ b/src/views/demo.ts
@@ -5,7 +5,4 @@ import { MAW_ROOT } from "../core/paths";
 export const demoView = new Hono();
 
 demoView.get("/", serveStatic({ root: `${MAW_ROOT}/demo`, path: "/index.html" }));
-demoView.get("/*", serveStatic({
-  root: MAW_ROOT,
-  rewriteRequestPath: (p) => p.replace(/^\/demo/, "/demo"),
-}));
+demoView.get("/*", serveStatic({ root: MAW_ROOT }));


### PR DESCRIPTION
## Summary

Closes two `js/identity-replacement` CodeQL alerts. Both sites were
calling `str.replace(pattern, same-pattern)` — a no-op carried over from
prior refactors. CodeQL flags these because replacing something with
itself is almost always a latent bug (typo, missed refactor, or intent
lost).

Neither is a real bug in this codebase — both are dead code that looks
like it's doing something. Removed.

## CodeQL alerts closed

| Alert | File | Line | Change |
|-------|------|------|--------|
| #7 | `src/views/demo.ts` | 10 | Drop `rewriteRequestPath: p => p.replace(/^\/demo/, "/demo")`. With `root: MAW_ROOT` the `/demo` prefix already maps to the correct path. |
| #6 | `src/lib/federation-auth.ts` | 141 | Drop `url.pathname.replace(/^\/api/, "/api") // normalize`. Use `url.pathname` directly — the replace normalizes nothing. |

## Prior art

Follows the pattern from #485 (idempotent `mkdirSync` for TOCTOU) and
#486 (`sanitize-log.ts` for log-injection): fix the CodeQL category that
closes cleanly, document the ones that require design changes.

## Test plan

- [x] `bun run test:all` — 62/62 files pass (no regression)

Refs #474 — there are still ~27 open CodeQL alerts across other rule
categories after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Oracle: mawjs