### PR TITLE
fix(security): close js/incomplete-sanitization alerts via POSIX shell quoting

### DIFF
--- a/src/commands/plugins/find/impl.ts
+++ b/src/commands/plugins/find/impl.ts
@@ -4,6 +4,15 @@ import { loadFleet } from "../../shared/fleet-load";
 import { join } from "path";
 import { existsSync } from "fs";
 
+// POSIX-correct single-quote escape: inside '…' the only metacharacter is
+// the quote itself, and the shell has no escape for it — you must close,
+// emit a literal quote, reopen. The prior `.replace(/'/g, "\\'")` left
+// backslashes un-escaped, which CodeQL flagged as js/incomplete-sanitization
+// (input `\\'` would break out of the quoting).
+function shSingleQuote(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
 /**
  * maw find <keyword> [--oracle <name>]
  *
@@ -51,13 +60,13 @@ export async function cmdFind(keyword: string, opts: { oracle?: string } = {}) {
   // Search each oracle
   for (const { name, psiPath } of targets) {
     try {
-      const out = await hostExec(`grep -ril '${keyword.replace(/'/g, "\\'")}' '${psiPath}' 2>/dev/null || true`);
+      const out = await hostExec(`grep -ril ${shSingleQuote(keyword)} ${shSingleQuote(psiPath)} 2>/dev/null || true`);
       const files = out.trim().split("\n").filter(Boolean);
 
       for (const file of files) {
         // Get matching line for context
         try {
-          const match = await hostExec(`grep -m1 -i '${keyword.replace(/'/g, "\\'")}' '${file}' 2>/dev/null || true`);
+          const match = await hostExec(`grep -m1 -i ${shSingleQuote(keyword)} ${shSingleQuote(file)} 2>/dev/null || true`);
           results.push({
             oracle: name,
             file: file.replace(psiPath + "/", ""),


### PR DESCRIPTION
## Summary

Closes two `js/incomplete-sanitization` CodeQL alerts in
`src/commands/plugins/find/impl.ts`. Both sites called
`hostExec` with the user's `keyword` CLI arg embedded in a shell
command wrapped in single quotes, escaping `'` → `\'`.

That escape is POSIX-incorrect. Inside `'…'` the shell has no escape
mechanism for the quote character — so `\'` terminates the quoted
region rather than producing a literal. CodeQL flagged this because
an input containing `\\'` (or even just a backslash run into a quote)
would break out of the quoting.

## Fix

Added a small `shSingleQuote` helper using the POSIX-correct
close-quote / literal-quote / reopen-quote idiom:

```ts
function shSingleQuote(s: string): string {
  return `'${s.replace(/'/g, "'\\''")}'`;
}
```

Both `hostExec` callsites now route `keyword`, `psiPath`, and `file`
through the helper. Quoting the paths too is belt-and-suspenders —
they're internal but may contain metacharacters (repo names with
spaces, etc.) and the consistency costs nothing.

## CodeQL alerts closed

| Alert | File | Line | Change |
|-------|------|------|--------|
| #1 | `src/commands/plugins/find/impl.ts` | 54 | Replace broken `\'` escape with `shSingleQuote()` |
| #2 | `src/commands/plugins/find/impl.ts` | 60 | Replace broken `\'` escape with `shSingleQuote()` |

## Prior art

Follows the pattern from #486 (`sanitize-log.ts` helper for
log-injection): scope fix to the category, helper co-located with
the single usage site.

## Test plan

- [x] `bun run test:all` — 62/62 files pass (no regression)
- [x] `maw find` still exercises the same code path; the quoting
  change is a strict superset of the prior behavior for ASCII-only
  keywords (no behavior change), and now correct for keywords
  containing `'` or `\`

Refs #474 — there are still ~27 open CodeQL alerts across other rule
categories after this lands (and after #498).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Oracle: mawjs