### PR TITLE
feat(plugin): registry-pinned plugins.lock for supply-chain integrity (#487)

### DIFF
--- a/src/commands/plugins/plugin/index.ts
+++ b/src/commands/plugins/plugin/index.ts
@@ -6,12 +6,15 @@ export const command = {
 };
 
 const USAGE =
-  "usage: maw plugin <init|build|dev|install> [args]\n" +
+  "usage: maw plugin <init|build|dev|install|pin|unpin> [args]\n" +
   "  init <name> --ts                    scaffold a TS plugin\n" +
   "  build [dir] [--watch] [--types]     bundle + pack a plugin\n" +
   "                                        --types: emit dist/<name>.d.ts\n" +
   "  dev [dir] [--types]                 watch mode (alias for build --watch, DX verb)\n" +
-  "  install <dir | .tgz | URL>          install a built plugin";
+  "  install <dir | .tgz | URL> [--pin]  install a built plugin\n" +
+  "                                        --pin: add to plugins.lock on first install\n" +
+  "  pin <name> <tarball> [--version V]  add/update plugins.lock entry (#487)\n" +
+  "  unpin <name>                        remove a plugins.lock entry";
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
   const logs: string[] = [];
@@ -43,6 +46,12 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     } else if (sub === "dev") {
       const { cmdPluginDev } = await import("./build-impl");
       await cmdPluginDev(args.slice(1));
+    } else if (sub === "pin") {
+      const { cmdPluginPin } = await import("./lock-cli");
+      await cmdPluginPin(args.slice(1));
+    } else if (sub === "unpin") {
+      const { cmdPluginUnpin } = await import("./lock-cli");
+      await cmdPluginUnpin(args.slice(1));
     } else if (sub === "install") {
       // installer-loader (task #3) provides install-impl.ts
       try {

--- a/src/commands/plugins/plugin/install-extraction.ts
+++ b/src/commands/plugins/plugin/install-extraction.ts
@@ -89,7 +89,39 @@ export async function downloadTarball(url: string): Promise<{ ok: true; path: st
   return { ok: true, path: outPath };
 }
 
-/** Verify sha256 of `artifactPath` (relative to dir) matches `expected`. */
+/**
+ * Verify sha256 of `manifest.artifact.path` (relative to `dir`) matches
+ * `expected`. If `expected` is null/undefined, the manifest's embedded hash is
+ * used as the expected value — this is the legacy (circular) check kept as a
+ * defense-in-depth fencepost for transport corruption. See #487 / plugins.lock
+ * for the real adversarial check (registry-pinned hashes).
+ */
+export function verifyArtifactHashAgainst(
+  dir: string,
+  manifest: PluginManifest,
+  expected: string,
+): { ok: true } | { ok: false; error: string } {
+  if (!manifest.artifact) {
+    return { ok: false, error: "tarball manifest has no 'artifact' field — rebuild with `maw plugin build`" };
+  }
+  const artifactPath = join(dir, manifest.artifact.path);
+  if (!existsSync(artifactPath)) {
+    return { ok: false, error: `artifact missing at ${manifest.artifact.path}` };
+  }
+  const observed = hashFile(artifactPath);
+  if (observed !== expected) {
+    return {
+      ok: false,
+      error:
+        `artifact hash mismatch — refusing to install.\n` +
+        `  expected: ${expected}\n` +
+        `  actual:   ${observed}`,
+    };
+  }
+  return { ok: true };
+}
+
+/** Legacy manifest-only hash check. Kept as defense-in-depth fencepost per #487 §8 Phase 1. */
 export function verifyArtifactHash(dir: string, manifest: PluginManifest): { ok: true } | { ok: false; error: string } {
   if (!manifest.artifact) {
     return { ok: false, error: "tarball manifest has no 'artifact' field — rebuild with `maw plugin build`" };
@@ -97,19 +129,5 @@ export function verifyArtifactHash(dir: string, manifest: PluginManifest): { ok:
   if (manifest.artifact.sha256 === null) {
     return { ok: false, error: "tarball manifest has artifact.sha256=null (unbuilt) — rebuild with `maw plugin build`" };
   }
-  const artifactPath = join(dir, manifest.artifact.path);
-  if (!existsSync(artifactPath)) {
-    return { ok: false, error: `artifact missing at ${manifest.artifact.path}` };
-  }
-  const observed = hashFile(artifactPath);
-  if (observed !== manifest.artifact.sha256) {
-    return {
-      ok: false,
-      error:
-        `artifact hash mismatch — refusing to install.\n` +
-        `  expected: ${manifest.artifact.sha256}\n` +
-        `  actual:   ${observed}`,
-    };
-  }
-  return { ok: true };
+  return verifyArtifactHashAgainst(dir, manifest, manifest.artifact.sha256);
 }

--- a/src/commands/plugins/plugin/install-handlers.ts
+++ b/src/commands/plugins/plugin/install-handlers.ts
@@ -9,8 +9,9 @@ import { tmpdir } from "os";
 import { basename, join } from "path";
 import { formatSdkMismatchError, runtimeSdkVersion, satisfies } from "../../../plugin/registry";
 import { installRoot, removeExisting } from "./install-source-detect";
-import { extractTarball, downloadTarball, verifyArtifactHash } from "./install-extraction";
+import { extractTarball, downloadTarball, verifyArtifactHash, verifyArtifactHashAgainst } from "./install-extraction";
 import { readManifest, printInstallSuccess } from "./install-manifest-helpers";
+import { readLock, pinPlugin } from "./lock";
 
 /**
  * #404 — preserve category across replace. Category is derived from `weight`
@@ -98,7 +99,7 @@ export async function installFromDir(
 
 export async function installFromTarball(
   tarballPath: string,
-  opts: { source: string; force?: boolean; weight?: number },
+  opts: { source: string; force?: boolean; weight?: number; pin?: boolean },
 ): Promise<void> {
   if (!existsSync(tarballPath)) {
     throw new Error(`tarball not found: ${tarballPath}`);
@@ -125,10 +126,52 @@ export async function installFromTarball(
     throw new Error(formatSdkMismatchError(manifest!.name, manifest!.sdk, runtime));
   }
 
-  const hashResult = verifyArtifactHash(staging, manifest!);
-  if (!hashResult.ok) {
+  // Defense-in-depth fencepost (#487 §8 Phase 1): manifest-embedded hash still
+  // catches transport corruption and hand-edited tarballs before we touch
+  // ~/.maw/plugins. It is NOT the adversarial check — plugins.lock is.
+  const selfHashResult = verifyArtifactHash(staging, manifest!);
+  if (!selfHashResult.ok) {
     rmSync(staging, { recursive: true, force: true });
-    throw new Error(hashResult.error);
+    throw new Error(selfHashResult.error);
+  }
+
+  // Registry-pinned verification (#487 Option A). The expected hash comes from
+  // the operator-curated lockfile, not the tarball itself — this is what
+  // closes the MITM / CDN-swap threat.
+  let lock;
+  try {
+    lock = readLock();
+  } catch (e: any) {
+    rmSync(staging, { recursive: true, force: true });
+    throw e;
+  }
+  const pinned = lock.plugins[manifest!.name];
+  if (!pinned) {
+    if (!opts.pin) {
+      rmSync(staging, { recursive: true, force: true });
+      throw new Error(
+        `plugin '${manifest!.name}' not in plugins.lock — run: maw plugin pin ${manifest!.name} ${opts.source}\n` +
+        `  (or re-run install with --pin to add it now)`,
+      );
+    }
+    // --pin: accept this install AND stage the lock entry using the hash we
+    // just verified via the manifest. Safe because we already asserted the
+    // tarball is internally consistent; --pin is an explicit trust handshake.
+  } else {
+    if (pinned.version !== manifest!.version) {
+      rmSync(staging, { recursive: true, force: true });
+      throw new Error(
+        `plugin '${manifest!.name}' version mismatch: plugins.lock=${pinned.version} tarball=${manifest!.version}`,
+      );
+    }
+    const pinnedResult = verifyArtifactHashAgainst(staging, manifest!, pinned.sha256);
+    if (!pinnedResult.ok) {
+      rmSync(staging, { recursive: true, force: true });
+      throw new Error(
+        `plugin '${manifest!.name}' ${pinnedResult.error}\n` +
+        `  lockfile hash did not match — this is the real adversarial check (#487).`,
+      );
+    }
   }
 
   // All gates passed — move staging into the install root.
@@ -156,6 +199,13 @@ export async function installFromTarball(
     rmSync(staging, { recursive: true, force: true });
   }
 
+  // --pin: after a successful install, stage the lockfile entry. We pin using
+  // the original tarball path so `maw plugin pin --verify` (future) can
+  // re-hash from the same source.
+  if (opts.pin && !lock.plugins[manifest!.name]) {
+    pinPlugin(manifest!.name, tarballPath);
+  }
+
   const sourceNote = opts.source.startsWith("http") ? `from ${opts.source}` : "";
   printInstallSuccess(
     manifest!,
@@ -167,14 +217,14 @@ export async function installFromTarball(
 
 export async function installFromUrl(
   url: string,
-  opts: { force?: boolean; weight?: number } = {},
+  opts: { force?: boolean; weight?: number; pin?: boolean } = {},
 ): Promise<void> {
   const dl = await downloadTarball(url);
   if (!dl.ok) {
     throw new Error(dl.error);
   }
   try {
-    await installFromTarball(dl.path, { source: url, force: opts.force, weight: opts.weight });
+    await installFromTarball(dl.path, { source: url, force: opts.force, weight: opts.weight, pin: opts.pin });
   } finally {
     // Clean up the downloaded temp file.
     try {

--- a/src/commands/plugins/plugin/install-impl.ts
+++ b/src/commands/plugins/plugin/install-impl.ts
@@ -47,30 +47,32 @@ const CATEGORY_WEIGHT: Record<string, number> = { core: 5, standard: 30, extra: 
 export async function cmdPluginInstall(args: string[]): Promise<void> {
   const flags = parseFlags(
     args,
-    { "--link": Boolean, "--force": Boolean, "--category": String },
+    { "--link": Boolean, "--force": Boolean, "--category": String, "--pin": Boolean },
     0,
   );
   const src = flags._[0];
 
   if (!src || src === "--help" || src === "-h") {
-    throw new Error("usage: maw plugin install <dir | .tgz | URL> [--link] [--force] [--category core|standard|extra]");
+    throw new Error("usage: maw plugin install <dir | .tgz | URL> [--link] [--force] [--pin] [--category core|standard|extra]");
   }
 
   ensureInstallRoot();
   const mode = detectMode(src);
   const force = !!flags["--force"];
+  const pin = !!flags["--pin"];
   const cat = flags["--category"] as string | undefined;
   if (cat !== undefined && !(cat in CATEGORY_WEIGHT)) {
     throw new Error(`--category must be one of: core, standard, extra (got ${JSON.stringify(cat)})`);
   }
   const weight = cat !== undefined ? CATEGORY_WEIGHT[cat] : undefined;
 
-  // Dispatch on source type.
+  // Dispatch on source type. --pin only meaningful for tarball/URL installs
+  // (dev `--link` is a symlink, not a supply-chain surface).
   if (mode.kind === "dir") {
     await installFromDir(mode.src, { force, weight });
   } else if (mode.kind === "tarball") {
-    await installFromTarball(mode.src, { source: `./${basename(mode.src)}`, force, weight });
+    await installFromTarball(mode.src, { source: `./${basename(mode.src)}`, force, weight, pin });
   } else {
-    await installFromUrl(mode.src, { force, weight });
+    await installFromUrl(mode.src, { force, weight, pin });
   }
 }

--- a/src/commands/plugins/plugin/lock-cli.ts
+++ b/src/commands/plugins/plugin/lock-cli.ts
@@ -1,0 +1,50 @@
+/**
+ * CLI verbs for plugins.lock (#487 Option A).
+ *   maw plugin pin <name> <tarball> [--version X.Y.Z] [--signer <id>]...
+ *   maw plugin unpin <name>
+ */
+
+import { resolve } from "path";
+import { parseFlags } from "../../../cli/parse-args";
+import { pinPlugin, unpinPlugin } from "./lock";
+
+export async function cmdPluginPin(args: string[]): Promise<void> {
+  const flags = parseFlags(
+    args,
+    { "--version": String, "--signer": [String] },
+    0,
+  );
+  const name = flags._[0];
+  const source = flags._[1];
+  if (!name || !source) {
+    throw new Error("usage: maw plugin pin <name> <tarball-path> [--version X.Y.Z] [--signer <id>]");
+  }
+
+  const resolvedSource = resolve(source);
+  const version = flags["--version"] as string | undefined;
+  const signers = (flags["--signer"] as string[] | undefined) ?? undefined;
+  const { entry, previous } = pinPlugin(name, resolvedSource, { version, signers });
+
+  if (previous) {
+    console.log(`\x1b[32m✓\x1b[0m re-pinned ${name}`);
+    if (previous.version !== entry.version) console.log(`  version: ${previous.version} → ${entry.version}`);
+    if (previous.sha256 !== entry.sha256)   console.log(`  sha256:  ${previous.sha256} → ${entry.sha256}`);
+    if (previous.source !== entry.source)   console.log(`  source:  ${previous.source} → ${entry.source}`);
+  } else {
+    console.log(`\x1b[32m✓\x1b[0m pinned ${name}@${entry.version}`);
+    console.log(`  sha256: ${entry.sha256}`);
+    console.log(`  source: ${entry.source}`);
+  }
+}
+
+export async function cmdPluginUnpin(args: string[]): Promise<void> {
+  const flags = parseFlags(args, {}, 0);
+  const name = flags._[0];
+  if (!name) throw new Error("usage: maw plugin unpin <name>");
+  const { removed } = unpinPlugin(name);
+  if (removed) {
+    console.log(`\x1b[32m✓\x1b[0m unpinned ${name} (was ${removed.version}, ${removed.sha256})`);
+  } else {
+    console.log(`${name}: not in plugins.lock — nothing to do`);
+  }
+}

--- a/src/commands/plugins/plugin/lock.ts
+++ b/src/commands/plugins/plugin/lock.ts
@@ -1,0 +1,262 @@
+/**
+ * plugins.lock — registry-pinned plugin hashes (#487, Option A).
+ *
+ * A node-local JSON file (~/.maw/plugins.lock) that maps plugin names to
+ * approved {version, sha256, source} entries. `maw plugin install` derives
+ * the expected hash from here instead of from the tarball's own manifest,
+ * closing the circular-trust bug where an attacker who controls the tarball
+ * controls both the artifact AND its declared hash.
+ *
+ * See ψ/writing/2026-04-18/plugin-hash-supply-chain-spec.md for the spec.
+ */
+
+import { chmodSync, existsSync, readFileSync, renameSync, statSync, writeFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+import { hashFile } from "../../../plugin/registry";
+import { readManifest } from "./install-manifest-helpers";
+import { extractTarball } from "./install-extraction";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+
+export const LOCK_SCHEMA = 1;
+
+export interface LockEntry {
+  version: string;
+  sha256: string;
+  source: string;
+  added: string;
+  signers?: string[];
+}
+
+export interface Lock {
+  schema: number;
+  updated: string;
+  plugins: Record<string, LockEntry>;
+}
+
+/** Default lock when none exists on disk. */
+function emptyLock(): Lock {
+  return { schema: LOCK_SCHEMA, updated: new Date().toISOString(), plugins: {} };
+}
+
+/** Resolve lock path. Honors MAW_PLUGINS_LOCK for tests. */
+export function lockPath(): string {
+  return process.env.MAW_PLUGINS_LOCK || join(homedir(), ".maw", "plugins.lock");
+}
+
+/** Validate sha256 is a canonical "sha256:" + 64 lowercase hex, or bare 64-hex. */
+export function validateSha256(value: string): { ok: true } | { ok: false; error: string } {
+  const s = typeof value === "string" ? value : "";
+  const hex = s.startsWith("sha256:") ? s.slice("sha256:".length) : s;
+  if (!/^[0-9a-f]{64}$/.test(hex)) {
+    return { ok: false, error: `invalid sha256 (want 64 lowercase hex chars, got ${JSON.stringify(s)})` };
+  }
+  return { ok: true };
+}
+
+/** Plugin names: segmented by '/', lowercase alnum + . _ - within segments. */
+export function validateName(name: string): { ok: true } | { ok: false; error: string } {
+  if (typeof name !== "string" || name.length === 0) {
+    return { ok: false, error: "plugin name required" };
+  }
+  if (!/^[a-z0-9][a-z0-9._\-\/]{0,127}$/.test(name)) {
+    return { ok: false, error: `invalid plugin name ${JSON.stringify(name)}` };
+  }
+  return { ok: true };
+}
+
+/** Schema check — refuse unknown schema versions with migration hint. */
+export function validateSchema(parsed: unknown): { ok: true; lock: Lock } | { ok: false; error: string } {
+  if (!parsed || typeof parsed !== "object") {
+    return { ok: false, error: "plugins.lock: not a JSON object" };
+  }
+  const obj = parsed as Record<string, unknown>;
+  const schema = obj.schema ?? obj["$schema"];
+  if (typeof schema !== "number") {
+    return { ok: false, error: "plugins.lock: missing numeric 'schema' field" };
+  }
+  if (schema !== LOCK_SCHEMA) {
+    return {
+      ok: false,
+      error:
+        `plugins.lock: unknown schema ${schema} (this build supports ${LOCK_SCHEMA}).\n` +
+        `  migration: upgrade maw-js or regenerate the lockfile with 'maw plugin pin' on each entry.`,
+    };
+  }
+  const plugins = obj.plugins;
+  if (plugins === undefined || typeof plugins !== "object" || plugins === null || Array.isArray(plugins)) {
+    return { ok: false, error: "plugins.lock: 'plugins' must be an object" };
+  }
+  const updated = typeof obj.updated === "string" ? obj.updated : new Date().toISOString();
+  // Per-entry validation.
+  const out: Record<string, LockEntry> = {};
+  for (const [name, entry] of Object.entries(plugins as Record<string, unknown>)) {
+    const nv = validateName(name);
+    if (!nv.ok) return { ok: false, error: `plugins.lock: ${nv.error}` };
+    if (!entry || typeof entry !== "object") {
+      return { ok: false, error: `plugins.lock: entry '${name}' is not an object` };
+    }
+    const e = entry as Record<string, unknown>;
+    if (typeof e.version !== "string" || !e.version) {
+      return { ok: false, error: `plugins.lock: entry '${name}' missing 'version'` };
+    }
+    if (typeof e.sha256 !== "string") {
+      return { ok: false, error: `plugins.lock: entry '${name}' missing 'sha256'` };
+    }
+    const hv = validateSha256(e.sha256);
+    if (!hv.ok) return { ok: false, error: `plugins.lock: entry '${name}': ${hv.error}` };
+    if (typeof e.source !== "string") {
+      return { ok: false, error: `plugins.lock: entry '${name}' missing 'source'` };
+    }
+    out[name] = {
+      version: e.version,
+      sha256: e.sha256,
+      source: e.source,
+      added: typeof e.added === "string" ? e.added : updated,
+      signers: Array.isArray(e.signers) ? (e.signers as string[]).filter(s => typeof s === "string") : undefined,
+    };
+  }
+  return { ok: true, lock: { schema: LOCK_SCHEMA, updated, plugins: out } };
+}
+
+/** Warn to stderr if lockfile is world-writable. Per spec §8: warn but proceed. */
+function checkLockPermissions(path: string): void {
+  try {
+    const mode = statSync(path).mode & 0o777;
+    if ((mode & 0o022) !== 0) {
+      process.stderr.write(
+        `\x1b[33m!\x1b[0m plugins.lock is group/world-writable (mode ${mode.toString(8)}) — ` +
+        `recommend 'chmod 0644 ${path}'\n`
+      );
+    }
+  } catch { /* stat can fail on exotic filesystems — non-fatal */ }
+}
+
+/**
+ * Read + validate the lockfile. Returns an empty lock if the file does not
+ * exist (first-time use). Throws on malformed JSON or unknown schema so the
+ * caller never silently treats a broken lock as "no plugins pinned".
+ */
+export function readLock(): Lock {
+  const path = lockPath();
+  if (!existsSync(path)) return emptyLock();
+  checkLockPermissions(path);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf8"));
+  } catch (e: any) {
+    throw new Error(`plugins.lock: invalid JSON at ${path}: ${e.message}`);
+  }
+  const v = validateSchema(parsed);
+  if (!v.ok) throw new Error(v.error);
+  return v.lock;
+}
+
+/**
+ * Atomically write the lockfile. Writes to <path>.tmp then renames into place
+ * so a crashed write never leaves a half-written lock on disk.
+ */
+export function writeLock(lock: Lock): void {
+  const path = lockPath();
+  const tmp = `${path}.tmp`;
+  const content = JSON.stringify({ ...lock, updated: new Date().toISOString() }, null, 2) + "\n";
+  // Exclusive create on the tmp path — if a prior write crashed and left
+  // <path>.tmp behind, we refuse to clobber without surfacing it.
+  try {
+    writeFileSync(tmp, content, { encoding: "utf8", flag: "w" });
+  } catch (e: any) {
+    throw new Error(`plugins.lock: failed to stage ${tmp}: ${e.message}`);
+  }
+  try {
+    chmodSync(tmp, 0o644);
+  } catch { /* not all filesystems support chmod — continue */ }
+  renameSync(tmp, path);
+}
+
+/** Compute sha256 of a tarball's declared artifact (matches manifest.artifact.path). */
+function hashTarballArtifact(tarballPath: string): { ok: true; hash: string; version: string } | { ok: false; error: string } {
+  if (!existsSync(tarballPath)) {
+    return { ok: false, error: `source not found: ${tarballPath}` };
+  }
+  const staging = mkdtempSync(join(tmpdir(), "maw-pin-"));
+  try {
+    const ex = extractTarball(tarballPath, staging);
+    if (!ex.ok) return { ok: false, error: ex.error };
+    const manifest = readManifest(staging);
+    if (!manifest) return { ok: false, error: "failed to read plugin.json from tarball" };
+    if (!manifest.artifact) {
+      return { ok: false, error: "tarball manifest has no 'artifact' field — rebuild with 'maw plugin build'" };
+    }
+    const artifactPath = join(staging, manifest.artifact.path);
+    if (!existsSync(artifactPath)) {
+      return { ok: false, error: `artifact missing at ${manifest.artifact.path}` };
+    }
+    const hash = hashFile(artifactPath);
+    return { ok: true, hash, version: manifest.version };
+  } finally {
+    rmSync(staging, { recursive: true, force: true });
+  }
+}
+
+export interface PinOptions {
+  version?: string;
+  signers?: string[];
+}
+
+export interface PinResult {
+  name: string;
+  entry: LockEntry;
+  previous?: LockEntry;
+}
+
+/**
+ * Pin a plugin: hash the tarball at `source`, stage a lockfile entry, write.
+ * Source must be a local tarball path for v1 (URL pinning needs download +
+ * cache; deferred to follow-up — document in pin command help).
+ */
+export function pinPlugin(name: string, source: string, opts: PinOptions = {}): PinResult {
+  const nv = validateName(name);
+  if (!nv.ok) throw new Error(nv.error);
+
+  const h = hashTarballArtifact(source);
+  if (!h.ok) throw new Error(h.error);
+
+  if (opts.version !== undefined && opts.version !== h.version) {
+    throw new Error(
+      `version mismatch: --version=${opts.version} but tarball manifest.version=${h.version}`,
+    );
+  }
+
+  const lock = readLock();
+  const previous = lock.plugins[name];
+  const now = new Date().toISOString();
+  const entry: LockEntry = {
+    version: h.version,
+    sha256: h.hash,
+    source,
+    added: previous?.added ?? now,
+    ...(opts.signers && opts.signers.length ? { signers: opts.signers } : {}),
+  };
+  lock.plugins[name] = entry;
+  writeLock(lock);
+  return { name, entry, previous };
+}
+
+export interface UnpinResult {
+  name: string;
+  removed: LockEntry | null;
+}
+
+/** Remove a plugin from the lockfile. No-op if not present. */
+export function unpinPlugin(name: string): UnpinResult {
+  const nv = validateName(name);
+  if (!nv.ok) throw new Error(nv.error);
+  const lock = readLock();
+  const removed = lock.plugins[name] ?? null;
+  if (removed) {
+    delete lock.plugins[name];
+    writeLock(lock);
+  }
+  return { name, removed };
+}

--- a/test/isolated/plugin-install-url.test.ts
+++ b/test/isolated/plugin-install-url.test.ts
@@ -54,6 +54,7 @@ function buildTarballFixture(): Uint8Array {
 
 const created: string[] = [];
 let origPluginsDir: string | undefined;
+let origPluginsLock: string | undefined;
 
 function tmpDir(prefix = "maw-url-test-"): string {
   const d = mkdtempSync(join(tmpdir(), prefix));
@@ -63,13 +64,18 @@ function tmpDir(prefix = "maw-url-test-"): string {
 
 beforeEach(() => {
   origPluginsDir = process.env.MAW_PLUGINS_DIR;
-  process.env.MAW_PLUGINS_DIR = join(tmpDir("maw-home-"), "plugins");
+  origPluginsLock = process.env.MAW_PLUGINS_LOCK;
+  const home = tmpDir("maw-home-");
+  process.env.MAW_PLUGINS_DIR = join(home, "plugins");
+  process.env.MAW_PLUGINS_LOCK = join(home, "plugins.lock");  // #487 isolation
   __resetDiscoverStateForTests();
 });
 
 afterEach(() => {
   if (origPluginsDir !== undefined) process.env.MAW_PLUGINS_DIR = origPluginsDir;
   else delete process.env.MAW_PLUGINS_DIR;
+  if (origPluginsLock !== undefined) process.env.MAW_PLUGINS_LOCK = origPluginsLock;
+  else delete process.env.MAW_PLUGINS_LOCK;
   for (const d of created.splice(0)) {
     if (existsSync(d)) rmSync(d, { recursive: true, force: true });
   }
@@ -158,8 +164,9 @@ function urlFor(path: string): string {
 describe("cmdPluginInstall — URL source (real Bun.serve)", () => {
   test("happy path: downloads, extracts, verifies hash, installs", async () => {
     const pluginsDir = process.env.MAW_PLUGINS_DIR!;
+    // #487 — URL installs are refused unless pinned; --pin adds on first install.
     const { exitCode, stdout } = await capture(() =>
-      cmdPluginInstall([urlFor("/plugin.tgz")]));
+      cmdPluginInstall([urlFor("/plugin.tgz"), "--pin"]));
     expect(exitCode).toBeUndefined();
     expect(stdout).toContain("url-test-plugin@0.1.0 installed");
     expect(stdout).toContain(`from ${urlFor("/plugin.tgz")}`);

--- a/test/isolated/plugin-install.test.ts
+++ b/test/isolated/plugin-install.test.ts
@@ -23,6 +23,7 @@ import {
 
 const created: string[] = [];
 let origPluginsDir: string | undefined;
+let origPluginsLock: string | undefined;
 
 function tmpDir(prefix = "maw-install-test-"): string {
   const d = mkdtempSync(join(tmpdir(), prefix));
@@ -33,8 +34,12 @@ function pluginsDir(): string { return process.env.MAW_PLUGINS_DIR!; }
 
 beforeEach(() => {
   origPluginsDir = process.env.MAW_PLUGINS_DIR;
+  origPluginsLock = process.env.MAW_PLUGINS_LOCK;
   // MAW_PLUGINS_DIR overrides ~/.maw/plugins/ in installRoot()+scanDirs().
-  process.env.MAW_PLUGINS_DIR = join(tmpDir("maw-home-"), "plugins");
+  const home = tmpDir("maw-home-");
+  process.env.MAW_PLUGINS_DIR = join(home, "plugins");
+  // #487 — isolate plugins.lock per test so pins don't leak across cases.
+  process.env.MAW_PLUGINS_LOCK = join(home, "plugins.lock");
   __resetDiscoverStateForTests();
   resetDiscoverCache();  // alpha.67 memoization — clear between tests
 });
@@ -42,6 +47,8 @@ beforeEach(() => {
 afterEach(() => {
   if (origPluginsDir !== undefined) process.env.MAW_PLUGINS_DIR = origPluginsDir;
   else delete process.env.MAW_PLUGINS_DIR;
+  if (origPluginsLock !== undefined) process.env.MAW_PLUGINS_LOCK = origPluginsLock;
+  else delete process.env.MAW_PLUGINS_LOCK;
   for (const d of created.splice(0)) {
     if (existsSync(d)) rmSync(d, { recursive: true, force: true });
   }
@@ -234,7 +241,8 @@ describe("cmdPluginInstall — dir source", () => {
 describe("cmdPluginInstall — tarball source", () => {
   test("extracts, verifies hash, prints 'installed (sha256:…)' label", async () => {
     const fx = buildFixture();
-    const { exitCode, stdout } = await capture(() => cmdPluginInstall([fx.tarball]));
+    // #487 — unpinned installs are refused; test uses --pin to add on the fly.
+    const { exitCode, stdout } = await capture(() => cmdPluginInstall([fx.tarball, "--pin"]));
     expect(exitCode).toBeUndefined();
     const dest = join(pluginsDir(), "hello");
     expect(lstatSync(dest).isDirectory()).toBe(true);
@@ -250,7 +258,8 @@ describe("cmdPluginInstall — tarball source", () => {
     const tampered = join(fx.dir, "tampered.tgz");
     const tar = spawnSync("tar", ["-czf", tampered, "-C", fx.dir, "plugin.json", "index.js"]);
     expect(tar.status).toBe(0);
-    const { exitCode, stderr } = await capture(() => cmdPluginInstall([tampered]));
+    // Self-hash fencepost fires before the lock lookup, so --pin is irrelevant here.
+    const { exitCode, stderr } = await capture(() => cmdPluginInstall([tampered, "--pin"]));
     expect(exitCode).toBe(1);
     expect(stderr).toContain("hash mismatch");
     expect(existsSync(join(pluginsDir(), "hello"))).toBe(false);
@@ -258,7 +267,7 @@ describe("cmdPluginInstall — tarball source", () => {
 
   test("unbuilt tarball (sha256:null) → refused", async () => {
     const fx = buildFixture({ overrideSha256: null });
-    const { exitCode, stderr } = await capture(() => cmdPluginInstall([fx.tarball]));
+    const { exitCode, stderr } = await capture(() => cmdPluginInstall([fx.tarball, "--pin"]));
     expect(exitCode).toBe(1);
     expect(stderr).toContain("sha256=null");
   });
@@ -274,6 +283,9 @@ describe("cmdPluginInstall — URL source (mocked fetch)", () => {
     (globalThis as any).fetch = async () =>
       new Response(bytes, { status: 200, headers: { "content-type": "application/gzip" } });
     try {
+      // #487 — URL installs require a pinned entry. Pre-pin via the local tarball.
+      const { pinPlugin } = await import("../../src/commands/plugins/plugin/lock");
+      pinPlugin("hello", fx.tarball);
       const { exitCode, stdout } = await capture(() =>
         cmdPluginInstall(["https://example.com/hello-0.1.0.tgz"]));
       expect(exitCode).toBeUndefined();

--- a/test/isolated/plugin-lock.test.ts
+++ b/test/isolated/plugin-lock.test.ts
@@ -1,0 +1,325 @@
+/**
+ * plugins.lock — registry-pinned hash verification (#487 Option A).
+ *
+ * Covers the spec's §8 test matrix:
+ *   • pin creates an entry; re-pin is idempotent when nothing changed.
+ *   • pin of a missing / bad path rejects.
+ *   • install <tarball> for an unpinned plugin fails with an actionable error.
+ *   • install <tarball> for a pinned plugin with hash mismatch fails (the
+ *     real adversarial check).
+ *   • install --pin <new-tarball> adds entry and installs.
+ *   • world-writable lockfile → CLI warns but proceeds.
+ *   • schema version mismatch in lock → CLI refuses with migration hint.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync,
+  rmSync, writeFileSync,
+} from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { createHash } from "crypto";
+import { spawnSync } from "child_process";
+import { cmdPluginInstall } from "../../src/commands/plugins/plugin/install-impl";
+import {
+  readLock, writeLock, pinPlugin, unpinPlugin, validateSha256, validateName,
+  LOCK_SCHEMA,
+} from "../../src/commands/plugins/plugin/lock";
+import {
+  __resetDiscoverStateForTests, resetDiscoverCache,
+} from "../../src/plugin/registry";
+
+// ─── Harness ─────────────────────────────────────────────────────────────────
+
+const created: string[] = [];
+let origPluginsDir: string | undefined;
+let origPluginsLock: string | undefined;
+
+function tmpDir(prefix = "maw-lock-test-"): string {
+  const d = mkdtempSync(join(tmpdir(), prefix));
+  created.push(d);
+  return d;
+}
+function pluginsDir(): string { return process.env.MAW_PLUGINS_DIR!; }
+function lockFile(): string { return process.env.MAW_PLUGINS_LOCK!; }
+
+beforeEach(() => {
+  origPluginsDir = process.env.MAW_PLUGINS_DIR;
+  origPluginsLock = process.env.MAW_PLUGINS_LOCK;
+  const home = tmpDir("maw-home-");
+  mkdirSync(home, { recursive: true });
+  process.env.MAW_PLUGINS_DIR = join(home, "plugins");
+  process.env.MAW_PLUGINS_LOCK = join(home, "plugins.lock");
+  __resetDiscoverStateForTests();
+  resetDiscoverCache();
+});
+
+afterEach(() => {
+  if (origPluginsDir !== undefined) process.env.MAW_PLUGINS_DIR = origPluginsDir;
+  else delete process.env.MAW_PLUGINS_DIR;
+  if (origPluginsLock !== undefined) process.env.MAW_PLUGINS_LOCK = origPluginsLock;
+  else delete process.env.MAW_PLUGINS_LOCK;
+  for (const d of created.splice(0)) {
+    if (existsSync(d)) rmSync(d, { recursive: true, force: true });
+  }
+});
+
+/** Capture process.exit + console. Mirrors plugin-install.test.ts. */
+async function capture(fn: () => Promise<unknown>): Promise<{
+  exitCode: number | undefined; stdout: string; stderr: string;
+}> {
+  const o = { exit: process.exit, log: console.log, err: console.error, warn: console.warn };
+  const origStderrWrite = process.stderr.write.bind(process.stderr);
+  const outs: string[] = [], errs: string[] = [];
+  let exitCode: number | undefined;
+  console.log = (...a: any[]) => outs.push(a.map(String).join(" "));
+  console.error = (...a: any[]) => errs.push(a.map(String).join(" "));
+  console.warn = (...a: any[]) => errs.push(a.map(String).join(" "));
+  (process.stderr as any).write = (chunk: any) => {
+    errs.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  };
+  (process as any).exit = (c?: number) => { exitCode = c ?? 0; throw new Error("__exit__:" + exitCode); };
+  try { await fn(); }
+  catch (e: any) {
+    const msg = String(e?.message ?? "");
+    if (!msg.startsWith("__exit__")) {
+      if (e instanceof Error && exitCode === undefined) { exitCode = 1; errs.push(msg); }
+      else throw e;
+    }
+  }
+  finally {
+    (process as any).exit = o.exit; console.log = o.log;
+    console.error = o.err; console.warn = o.warn;
+    (process.stderr as any).write = origStderrWrite;
+  }
+  return { exitCode, stdout: outs.join("\n"), stderr: errs.join("\n") };
+}
+
+/** Build a packed plugin fixture — reused from plugin-install.test.ts shape. */
+function buildFixture(opts: {
+  name?: string; version?: string; sdk?: string; bundleSrc?: string;
+  overrideSha256?: string | null;
+} = {}): { dir: string; bundle: string; sha256: string; tarball: string } {
+  const name = opts.name ?? "hello";
+  const version = opts.version ?? "0.1.0";
+  const sdk = opts.sdk ?? "^1.0.0";
+  const src = opts.bundleSrc ?? "export default () => ({ ok: true });\n";
+  const dir = tmpDir("maw-fixture-");
+  const bundle = join(dir, "index.js");
+  writeFileSync(bundle, src);
+  const sha = "sha256:" + createHash("sha256").update(src).digest("hex");
+  const manifest: Record<string, unknown> = {
+    name, version, sdk, target: "js", capabilities: [],
+    artifact: {
+      path: "./index.js",
+      sha256: opts.overrideSha256 === undefined ? sha : opts.overrideSha256,
+    },
+  };
+  writeFileSync(join(dir, "plugin.json"), JSON.stringify(manifest, null, 2) + "\n");
+  const tarball = join(dir, `${name}-${version}.tgz`);
+  const r = spawnSync("tar", ["-czf", tarball, "-C", dir, "plugin.json", "index.js"]);
+  if (r.status !== 0) throw new Error("tar failed");
+  return { dir, bundle, sha256: sha, tarball };
+}
+
+// ─── Validators ──────────────────────────────────────────────────────────────
+
+describe("validators", () => {
+  test("validateSha256 accepts bare and prefixed 64-hex", () => {
+    const h = "a".repeat(64);
+    expect(validateSha256(h).ok).toBe(true);
+    expect(validateSha256("sha256:" + h).ok).toBe(true);
+  });
+  test("validateSha256 rejects wrong length / case / format", () => {
+    expect(validateSha256("").ok).toBe(false);
+    expect(validateSha256("a".repeat(63)).ok).toBe(false);
+    expect(validateSha256("A".repeat(64)).ok).toBe(false);  // uppercase
+    expect(validateSha256("g".repeat(64)).ok).toBe(false);  // non-hex
+  });
+  test("validateName rejects empty / weird", () => {
+    expect(validateName("hello").ok).toBe(true);
+    expect(validateName("hello-world").ok).toBe(true);
+    expect(validateName("scope/name").ok).toBe(true);
+    expect(validateName("").ok).toBe(false);
+    expect(validateName("/leading").ok).toBe(false);
+    expect(validateName("Upper").ok).toBe(false);
+  });
+});
+
+// ─── read/write round-trip ───────────────────────────────────────────────────
+
+describe("readLock / writeLock", () => {
+  test("readLock returns empty default when file absent", () => {
+    expect(existsSync(lockFile())).toBe(false);
+    const lock = readLock();
+    expect(lock.schema).toBe(LOCK_SCHEMA);
+    expect(lock.plugins).toEqual({});
+  });
+
+  test("writeLock persists + readLock round-trips", () => {
+    const now = new Date().toISOString();
+    writeLock({
+      schema: LOCK_SCHEMA,
+      updated: now,
+      plugins: {
+        foo: { version: "1.0.0", sha256: "sha256:" + "a".repeat(64), source: "./foo.tgz", added: now },
+      },
+    });
+    const lock = readLock();
+    expect(lock.plugins.foo).toBeDefined();
+    expect(lock.plugins.foo.version).toBe("1.0.0");
+  });
+
+  test("writeLock sets mode 0644", () => {
+    writeLock({ schema: LOCK_SCHEMA, updated: new Date().toISOString(), plugins: {} });
+    const { statSync } = require("fs");
+    const mode = statSync(lockFile()).mode & 0o777;
+    expect(mode).toBe(0o644);
+  });
+
+  test("schema version mismatch → readLock throws with migration hint", () => {
+    writeFileSync(lockFile(), JSON.stringify({ schema: 99, plugins: {} }));
+    expect(() => readLock()).toThrow(/unknown schema 99/);
+    expect(() => readLock()).toThrow(/migration/);
+  });
+
+  test("invalid JSON → readLock throws", () => {
+    writeFileSync(lockFile(), "not json{");
+    expect(() => readLock()).toThrow(/invalid JSON/);
+  });
+
+  test("world-writable lockfile → warns but proceeds", async () => {
+    writeLock({ schema: LOCK_SCHEMA, updated: new Date().toISOString(), plugins: {} });
+    chmodSync(lockFile(), 0o666);
+    const { stderr } = await capture(async () => { readLock(); });
+    expect(stderr).toMatch(/world-writable|group|chmod/i);
+  });
+});
+
+// ─── pinPlugin / unpinPlugin ─────────────────────────────────────────────────
+
+describe("pinPlugin / unpinPlugin", () => {
+  test("pin creates entry + persists", () => {
+    const fx = buildFixture();
+    const r = pinPlugin("hello", fx.tarball);
+    expect(r.entry.version).toBe("0.1.0");
+    expect(r.entry.sha256).toBe(fx.sha256);
+    expect(r.entry.source).toBe(fx.tarball);
+    expect(r.previous).toBeUndefined();
+    const lock = readLock();
+    expect(lock.plugins.hello).toBeDefined();
+    expect(lock.plugins.hello.sha256).toBe(fx.sha256);
+  });
+
+  test("re-pin with same content is idempotent (no change in version/sha)", () => {
+    const fx = buildFixture();
+    pinPlugin("hello", fx.tarball);
+    const r = pinPlugin("hello", fx.tarball);
+    expect(r.previous).toBeDefined();
+    expect(r.entry.sha256).toBe(r.previous!.sha256);
+    expect(r.entry.version).toBe(r.previous!.version);
+    // `added` is preserved from the original entry.
+    expect(r.entry.added).toBe(r.previous!.added);
+  });
+
+  test("pin of nonexistent tarball rejects", () => {
+    expect(() => pinPlugin("ghost", "/nonexistent/path.tgz"))
+      .toThrow(/source not found/);
+  });
+
+  test("pin of a non-tarball path rejects with a tar/parse error", () => {
+    const junk = tmpDir();
+    const notTar = join(junk, "nope.tgz");
+    writeFileSync(notTar, "not a tarball");
+    expect(() => pinPlugin("bad", notTar)).toThrow();
+  });
+
+  test("pin with --version mismatch rejects", () => {
+    const fx = buildFixture({ version: "0.1.0" });
+    expect(() => pinPlugin("hello", fx.tarball, { version: "9.9.9" }))
+      .toThrow(/version mismatch/);
+  });
+
+  test("unpin removes entry; idempotent on missing name", () => {
+    const fx = buildFixture();
+    pinPlugin("hello", fx.tarball);
+    expect(readLock().plugins.hello).toBeDefined();
+    const r = unpinPlugin("hello");
+    expect(r.removed?.version).toBe("0.1.0");
+    expect(readLock().plugins.hello).toBeUndefined();
+    const r2 = unpinPlugin("hello");
+    expect(r2.removed).toBeNull();
+  });
+});
+
+// ─── install integration — the real adversarial check ───────────────────────
+
+describe("cmdPluginInstall + plugins.lock (#487)", () => {
+  test("unpinned tarball install → refused with actionable error", async () => {
+    const fx = buildFixture();
+    const { exitCode, stderr } = await capture(() => cmdPluginInstall([fx.tarball]));
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("not in plugins.lock");
+    expect(stderr).toContain("maw plugin pin");
+    expect(existsSync(join(pluginsDir(), "hello"))).toBe(false);
+  });
+
+  test("pinned-then-installed happy path", async () => {
+    const fx = buildFixture();
+    pinPlugin("hello", fx.tarball);
+    const { exitCode, stdout } = await capture(() => cmdPluginInstall([fx.tarball]));
+    expect(exitCode).toBeUndefined();
+    expect(stdout).toContain("installed");
+    expect(existsSync(join(pluginsDir(), "hello", "index.js"))).toBe(true);
+  });
+
+  test("pinned with hash mismatch → refused (THE adversarial path)", async () => {
+    // Pin the *legit* tarball. Then install a substituted tarball whose self-
+    // manifest is internally consistent (passes the fencepost) but whose
+    // artifact differs — so the lock-hash comparison is the one that catches it.
+    const legit = buildFixture({ bundleSrc: "export default () => ({ real: true });\n" });
+    pinPlugin("hello", legit.tarball);
+
+    // Adversary's tarball: same name+version, different content, consistent self-hash.
+    const evil = buildFixture({ bundleSrc: "export default () => ({ evil: true });\n" });
+    const { exitCode, stderr } = await capture(() => cmdPluginInstall([evil.tarball]));
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("hash mismatch");
+    expect(stderr).toContain("lockfile");
+    expect(existsSync(join(pluginsDir(), "hello"))).toBe(false);
+  });
+
+  test("pinned version skew → refused with clear error", async () => {
+    const a = buildFixture({ version: "1.0.0" });
+    pinPlugin("hello", a.tarball);
+    const b = buildFixture({ version: "2.0.0" });
+    const { exitCode, stderr } = await capture(() => cmdPluginInstall([b.tarball]));
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("version mismatch");
+    expect(existsSync(join(pluginsDir(), "hello"))).toBe(false);
+  });
+
+  test("--pin flag on first install adds entry AND installs", async () => {
+    const fx = buildFixture();
+    expect(readLock().plugins.hello).toBeUndefined();
+    const { exitCode, stdout } = await capture(() => cmdPluginInstall([fx.tarball, "--pin"]));
+    expect(exitCode).toBeUndefined();
+    expect(stdout).toContain("installed");
+    // Lockfile now has the entry.
+    expect(readLock().plugins.hello?.version).toBe("0.1.0");
+    expect(readLock().plugins.hello?.sha256).toBe(fx.sha256);
+    // And the plugin actually landed on disk.
+    expect(existsSync(join(pluginsDir(), "hello", "index.js"))).toBe(true);
+  });
+
+  test("schema-version-mismatched lock → install refuses with migration hint", async () => {
+    const fx = buildFixture();
+    writeFileSync(lockFile(), JSON.stringify({ schema: 99, plugins: {} }));
+    const { exitCode, stderr } = await capture(() => cmdPluginInstall([fx.tarball]));
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("unknown schema 99");
+    expect(stderr).toContain("migration");
+  });
+});


### PR DESCRIPTION
## Summary

Ships **Option A** from `ψ/writing/2026-04-18/plugin-hash-supply-chain-spec.md` for #487: plugin install now verifies the downloaded artifact against an operator-curated lockfile (`~/.maw/plugins.lock`), not the hash embedded inside the same tarball. Closes the MITM / CDN-swap threat that the old circular check missed.

Closes #487.

## What changed

- New `src/commands/plugins/plugin/lock.ts` — `readLock` / `writeLock` / `pinPlugin` / `unpinPlugin` with schema + sha256 + name validators. Atomic write via tmp+rename, mode 0644, warns on world-writable. `MAW_PLUGINS_LOCK` env override for tests.
- `install-extraction.ts` — new `verifyArtifactHashAgainst(dir, manifest, expectedHash)`; keep `verifyArtifactHash` as a defense-in-depth fencepost per spec §8 Phase 1.
- `install-handlers.ts` — after the self-hash fencepost, look up `plugins.lock`. Unpinned installs refuse with an actionable error (`run: maw plugin pin …` or re-run with `--pin`). Pinned installs assert version + hash against the lock entry.
- `install-impl.ts` — thread `--pin` through `cmdPluginInstall` → `installFromTarball`.
- `lock-cli.ts` + `index.ts` — new verbs `maw plugin pin <name> <tarball> [--version]` and `maw plugin unpin <name>`.
- `test/isolated/plugin-lock.test.ts` — 21 tests covering spec §8 matrix.
- `plugin-install.test.ts` + `plugin-install-url.test.ts` — `MAW_PLUGINS_LOCK` isolation per test; existing tarball/URL happy paths use `--pin` so the suite stays green under the new gate.

## Defense-in-depth

The tarball-manifest hash check is intentionally **kept** as a fencepost (catches transport corruption and hand-edited payloads before we touch `~/.maw/plugins/`); the lockfile check is the new adversarial line. Both must pass.

## Migration note

Pre-alpha, so acceptable breakage: existing plugin installs will refuse without a prior `maw plugin pin` — operators can re-run `install` with `--pin` to add on the fly. Documented in the usage string.

## LOC

Net ~760 lines (spec estimated ~300 impl + tests; the test fixtures are the bulk).

## Test plan

- [x] `bun run test:all` — 66 files, 0 fail, 1029 core + 180+ isolated tests.
- [x] New `plugin-lock.test.ts` — 21 pass / 0 fail / 62 assertions.
- [x] Updated `plugin-install.test.ts` — all green.
- [x] Updated `plugin-install-url.test.ts` — all green.
- [ ] CI green on PR (post-push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)