### PR TITLE
fix(test): anchor regex in workspace test stub (js/regex/missing-regexp-anchor)

### DIFF
--- a/test/isolated/workspace.test.ts
+++ b/test/isolated/workspace.test.ts
@@ -165,7 +165,7 @@ describe("cmdWorkspaceCreate", () => {
 
   test("explicit hub + ok response → writes ws config to disk", async () => {
     curlStubs = [{
-      match: /example\.com\/api\/workspace\/create/,
+      match: /^https?:\/\/example\.com\/api\/workspace\/create(?:\?|$)/,
       response: { ok: true, status: 200, data: { id: "ws-1", name: "alpha", joinCode: "abc123" } },
     }];
     configOverride = { node: "white" };


### PR DESCRIPTION
## Summary

Closes CodeQL alert #60 (`js/regex/missing-regexp-anchor`) at `test/isolated/workspace.test.ts:168`.

The `curlStubs` matcher used unanchored regex `/example\.com\/api\/workspace\/create/` which would substring-match URLs like `https://attacker.com/example.com/api/workspace/create`.

Now anchored to `/^https?:\/\/example\.com\/api\/workspace\/create(?:\?|$)/` — requires scheme, exact host, exact path, allowing only trailing query.

## Test plan
- [x] `bun test test/isolated/workspace.test.ts` — 441 pass, 0 fail (the test under audit still hits the stub correctly)

Refs #474

🤖 Per `make-all-r3` codeql-cleaner reassignment