### PR TITLE
fix(security): anchor github.com slug detection in wake (js/incomplete-url-substring-sanitization)

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -24,7 +24,13 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
     resolved = { repoPath, repoName: repoPath.split("/").pop()!, parentDir: repoPath.replace(/\/[^/]+$/, "") };
   } else if (opts.incubate) {
     const slug = opts.incubate;
-    const repoSlug = slug.includes("github.com") ? slug : `github.com/${slug}`;
+    // CodeQL js/incomplete-url-substring-sanitization: use prefix anchor, not
+    // substring match — `attacker.com/github.com/...` would have passed .includes.
+    const repoSlug = (
+      slug.startsWith("github.com/") ||
+      slug.startsWith("https://github.com/") ||
+      slug.startsWith("http://github.com/")
+    ) ? slug : `github.com/${slug}`;
     console.log(`\x1b[36m⚡\x1b[0m incubating ${slug}...`);
     await hostExec(`ghq get -u ${repoSlug}`);
     const fullPath = await ghqFind(repoSlug);


### PR DESCRIPTION
## Summary

Closes CodeQL alert #4 (`js/incomplete-url-substring-sanitization`) at `src/commands/shared/wake-cmd.ts:27`.

`slug.includes("github.com")` would substring-match malicious strings like `attacker.com/github.com/owner/repo` and treat them as github.com URLs.

Replaced with explicit prefix-anchored check covering the three legitimate forms:
- `github.com/owner/repo`
- `https://github.com/owner/repo`
- `http://github.com/owner/repo`

Anything else (including substring-host-confusion strings) falls into the "treat as bare owner/repo" branch — `ghq get` will reject the malformed URL.

## Test plan
- [x] No existing test failure (wake-cmd has no direct unit test; CI test:all + test:plugin verify integration)

Refs #474