### PR TITLE
fix(security): door.html setStatus uses textContent + CSS spinner (js/xss-through-dom)

### DIFF
--- a/src/static/door.html
+++ b/src/static/door.html
@@ -54,12 +54,13 @@
   .status.err { color: #c44; }
   .status.ok { color: #4a4; }
   @keyframes spin { to { transform: rotate(360deg); } }
-  .spinner {
+  .spinner, .status.loading::before {
     display: inline-block; width: 14px; height: 14px;
     border: 2px solid #333; border-top-color: #888;
     border-radius: 50%; animation: spin 0.6s linear infinite;
     vertical-align: middle; margin-right: 0.4rem;
   }
+  .status.loading::before { content: ""; }
 </style>
 </head>
 <body>
@@ -123,7 +124,9 @@ function esc(s) {
 
 function setStatus(msg, cls) {
   $status.className = "status" + (cls ? " " + cls : "");
-  $status.innerHTML = msg;
+  // CodeQL js/xss-through-dom: textContent escapes; spinner is now a CSS
+  // pseudo-element on .status.loading rather than embedded HTML.
+  $status.textContent = msg;
 }
 
 function normalizeHost(raw) {
@@ -134,7 +137,7 @@ function normalizeHost(raw) {
 }
 
 async function connect(host) {
-  setStatus('<span class="spinner"></span>connecting...', "");
+  setStatus("connecting...", "loading");
   $go.disabled = true;
   try {
     const res = await fetch(host + "/api/config", { signal: AbortSignal.timeout(6000) });


### PR DESCRIPTION
## Summary

Closes CodeQL alert #5 (`js/xss-through-dom`) at `src/static/door.html:126`.

`setStatus(msg, cls)` used `innerHTML`. Most callers passed safe text, but the connecting case embedded `<span class="spinner"></span>` HTML, and the error path concatenated user-typed `host` (`setStatus("could not reach " + host, "err")`) — both reachable.

## Fix

1. `setStatus` now uses `textContent` (kernel-safe escaping)
2. The spinner moved from inline `<span>` HTML to a CSS `::before` pseudo-element on `.status.loading`, sharing the same shape rules as `.spinner`
3. The connecting call site now passes the `loading` class instead of HTML

Visual behavior unchanged (spinner still rotates same speed, same size).

## Test plan
- [x] door.html is a static asset; renders identically (verified by inspection — same CSS animation, same inline color/size)
- [x] No JS test coverage for door.html UI (it's the federation onboarding page)

Refs #474