### PR TITLE
feat(api): proper 410 Gone rotation for deprecated endpoints

### DIFF
--- a/src/api/deprecated.ts
+++ b/src/api/deprecated.ts
@@ -1,0 +1,44 @@
+// deprecated.ts — proper 410 Gone rotation for retired endpoints
+//
+// Author: FORGE Oracle — 2026-04-18
+// Rationale: VELA's silent-errors-deprecated-endpoints pattern (~/david-oracle/
+// ψ/memory/vela/patterns/2026-04-18_silent-errors-deprecated-endpoints.md).
+// Previous cleanup commit b0b0de2 removed the stub-corpse handlers, but that
+// produced silent 404s from the framework instead of a loud deprecation signal.
+// This restores handlers that issue 410 Gone with RFC-compliant migration
+// metadata (Link, Deprecation, Sunset headers) pointing at the replacement.
+//
+// Three routes covered:
+//   GET /api/tokens       → 410 + Link: /api/feed      (was: 410 no-link)
+//   GET /api/tokens/rate  → 410 + Link: /api/costs     (was: 200 zero-stub)
+//   GET /api/maw-log      → 410 + Link: /api/feed      (was: 200 empty-stub)
+
+import { Elysia } from "elysia";
+
+const SUNSET = "2026-05-01"; // hard cutoff; route removal after this date
+
+interface DeprecatedBody {
+  error: "removed";
+  replacement: string;
+  sunset: string;
+  message: string;
+}
+
+function gone(set: { status: number; headers: Record<string, string> }, replacement: string): DeprecatedBody {
+  set.status = 410;
+  set.headers["Link"] = `<${replacement}>; rel="alternate"`;
+  set.headers["Deprecation"] = "true";
+  set.headers["Sunset"] = SUNSET;
+  return {
+    error: "removed",
+    replacement,
+    sunset: SUNSET,
+    message: `This endpoint was removed. Use ${replacement} instead.`,
+  };
+}
+
+export const deprecatedApi = new Elysia();
+
+deprecatedApi.get("/tokens", ({ set }) => gone(set, "/api/feed"));
+deprecatedApi.get("/tokens/rate", ({ set }) => gone(set, "/api/costs"));
+deprecatedApi.get("/maw-log", ({ set }) => gone(set, "/api/feed"));

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -11,7 +11,7 @@ import { oracleApi } from "./oracle";
 import { federationApi } from "./federation";
 import { worktreesApi } from "./worktrees";
 import { uiStateApi } from "./ui-state";
-// deprecated.ts removed — 410 stubs for tokens/maw-log APIs no longer needed
+import { deprecatedApi } from "./deprecated";
 import { costsApi } from "./costs";
 import { triggersApi } from "./triggers";
 import { avengersApi } from "./avengers";
@@ -48,6 +48,7 @@ export const api = new Elysia({ prefix: "/api" })
   .use(federationApi)
   .use(worktreesApi)
   .use(uiStateApi)
+  .use(deprecatedApi)
   .use(costsApi)
   .use(triggersApi)
   .use(avengersApi)

--- a/test/api-deprecated-410.test.ts
+++ b/test/api-deprecated-410.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for src/api/deprecated.ts — 410 Gone rotation for retired endpoints.
+ *
+ * Companion to VELA's silent-errors-deprecated-endpoints pattern
+ * (~/david-oracle/ψ/memory/vela/patterns/2026-04-18_silent-errors-deprecated-endpoints.md).
+ *
+ * Verifies Lens 1 (server-side deprecation signal): status 410, migration
+ * Link header, Deprecation + Sunset headers, body with replacement path.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { Elysia } from "elysia";
+import { deprecatedApi } from "../src/api/deprecated";
+
+const app = new Elysia({ prefix: "/api" }).use(deprecatedApi);
+
+async function hit(path: string) {
+  return app.handle(new Request(`http://localhost${path}`));
+}
+
+describe("deprecated endpoint rotation — 410 Gone", () => {
+  test.each([
+    ["/api/tokens", "/api/feed"],
+    ["/api/tokens/rate", "/api/costs"],
+    ["/api/maw-log", "/api/feed"],
+  ])("%s → 410 with migration link to %s", async (path, replacement) => {
+    const res = await hit(path);
+
+    // Status
+    expect(res.status).toBe(410);
+
+    // Headers — Lens 1 signal
+    expect(res.headers.get("Link")).toBe(`<${replacement}>; rel="alternate"`);
+    expect(res.headers.get("Deprecation")).toBe("true");
+    expect(res.headers.get("Sunset")).toBe("2026-05-01");
+
+    // Body
+    const body: any = await res.json();
+    expect(body.error).toBe("removed");
+    expect(body.replacement).toBe(replacement);
+    expect(body.sunset).toBe("2026-05-01");
+    expect(body.message).toContain(replacement);
+  });
+
+  test("no more zeroed-stub pattern on /api/tokens/rate", async () => {
+    const res = await hit("/api/tokens/rate");
+    const body: any = await res.json();
+    // Explicit anti-regression: the pre-rotation stub returned
+    // { totalTokens: 0, totalPerMin: 0, ... }. If any of those fields
+    // reappear, the rotation regressed to the stubbed-corpse pattern.
+    expect(body.totalTokens).toBeUndefined();
+    expect(body.totalPerMin).toBeUndefined();
+    expect(body.turns).toBeUndefined();
+  });
+
+  test("no more empty-stub pattern on /api/maw-log", async () => {
+    const res = await hit("/api/maw-log");
+    const body: any = await res.json();
+    // Pre-rotation returned { entries: [], total: 0 }.
+    expect(body.entries).toBeUndefined();
+    expect(body.total).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Restores `src/api/deprecated.ts` (removed in `b0b0de2`) with proper 410 Gone semantics for 3 retired routes: `/api/tokens`, `/api/tokens/rate`, `/api/maw-log`
- Each response now includes RFC-compliant migration metadata: `Link: <replacement>; rel=\"alternate\"` + `Deprecation: true` + `Sunset: 2026-05-01` headers + body `{ error, replacement, sunset, message }`
- Replaces two prior anti-patterns: the 200-OK zero-stub on `/tokens/rate` + `/maw-log` (silently dead — clients can't distinguish \"idle\" from \"endpoint gone\") AND the framework-default 404 post-cleanup (silent — no migration breadcrumb)

## Why now
Silent-error anti-pattern analysis from maw-ui#31 surfaced this: `StatusBar.tsx` was guarding `/api/tokens/rate` with `data.totalTokens > 0`, so the zero-stub made the token chip invisibly dead for weeks. Server-side fix was owed as the complement to the client-side rewire.

## Test plan
- [x] `bun test test/api-deprecated-410.test.ts` — **5/5 pass, 29 expects**
- [x] Each route asserts: status 410, Link header to correct replacement, Deprecation+Sunset headers, body shape
- [x] Anti-regression: test fails if zero-stub fields (`totalTokens`, `entries`, `total`, etc.) reappear in response body
- [x] `bun build --target=bun src/api/deprecated.ts` — 313 modules clean, 15ms
- [ ] Manual curl post-deploy: `curl -I http://localhost:3456/api/tokens/rate` should show `HTTP/1.1 410 Gone` + `Link: </api/costs>; rel=\"alternate\"`

## Scope
3 files, +109/-1:
- `src/api/deprecated.ts` (new, 44 lines)
- `src/api/index.ts` (+1 import, +1 `.use`)
- `test/api-deprecated-410.test.ts` (new, 63 lines)

Sub-20-line-of-logic change per FORGE's ADR-exempt threshold (Golden Rule #2).

## References
- Anti-pattern analysis: \`~/david-oracle/ψ/memory/vela/patterns/2026-04-18_silent-errors-deprecated-endpoints.md\`
- Companion pattern: \`~/david-oracle/ψ/memory/forge/patterns/2026-04-18_adversarial-test-design.md\`
- Original cleanup this restores a loud-signal version of: \`b0b0de2\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)