### PR TITLE
fix(install): atomic install in install.sh + restart H3 sweep (#507 CRIT)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -27,8 +27,9 @@ REPO="Soul-Brews-Studio/maw-js"
 REF=""
 REF_TYPE=""
 USE_BUNX=0
+FORCE=0
 
-# ── Parse args ─��──���───────────────────────────────���─────────
+# ── Parse args ─────────────────────────────────────────────
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -42,14 +43,17 @@ while [ $# -gt 0 ]; do
       MAW_GHQ=1; shift ;;
     --skip-pm2)
       MAW_SKIP_PM2=1; shift ;;
+    --force|-f)
+      FORCE=1; shift ;;
     --help|-h)
-      echo "Usage: install.sh [--branch <name>] [--tag <version>] [--bunx] [--ghq] [--skip-pm2]"
+      echo "Usage: install.sh [--branch <name>] [--tag <version>] [--bunx] [--ghq] [--skip-pm2] [--force]"
       echo ""
       echo "  --branch, -b <name>    Install from branch (e.g. alpha, main)"
       echo "  --tag, -t <version>    Install from tag (e.g. v1.7.2, v1.8.0)"
       echo "  --bunx                 Create bunx wrapper instead of global install"
       echo "  --ghq                  Also clone repo via ghq"
       echo "  --skip-pm2             Skip PM2 setup hints"
+      echo "  --force, -f            Reinstall even if already at desired ref"
       echo ""
       echo "  No flag = latest release via bun add -g."
       echo "  Shorthand: install.sh alpha = --branch alpha"
@@ -134,8 +138,27 @@ WRAPPER
   echo "  Mode: bunx (fetches latest on every run)"
 else
   # ── bun add -g mode (persistent) ───────────────────────────
+  #
+  # Fast-path: skip reinstall if maw is already at the desired tag and the
+  # user did not pass --force. Reason: `bun add -g <github>` mutates the
+  # global node_modules in place over a multi-second window, during which
+  # `~/.bun/bin/maw` points at a half-extracted target. Concurrent `maw`
+  # invocations during that window fail with "No such file or directory"
+  # (#507 regression — observed live 2026-04-18 mid-session).
+  if [ "$FORCE" != "1" ] && [ "$REF_TYPE" = "tag" ] && command -v maw >/dev/null 2>&1; then
+    CURRENT=$(maw --version 2>/dev/null | head -1 | awk '{print $NF}')
+    if [ -n "$CURRENT" ] && [ "$CURRENT" = "$REF" ]; then
+      echo ""
+      echo "  ✅ maw already at $CURRENT — skipping reinstall (use --force to override)"
+      echo ""
+      echo "  🍺 Done!"
+      exit 0
+    fi
+  fi
+
   echo ""
   echo "📦 Installing maw from ${PKG}..."
+  echo "  ⚠️  Don't run maw commands for the next ~10s — bun re-extracts the global package."
   bun add -g "${PKG}"
 
   echo "  Mode: persistent (binary linked)"

--- a/src/commands/plugins/restart/impl.ts
+++ b/src/commands/plugins/restart/impl.ts
@@ -65,8 +65,25 @@ export async function cmdRestart(opts: { noUpdate?: boolean; ref?: string; help?
     try {
       const pkg = require("../../../../package.json");
       const before = `v${pkg.version}`;
-      try { execSync(`bun remove -g maw`, { stdio: "pipe" }); } catch {}
-      execSync(`bun add -g github:${pkg.repository}#${ref}`, { stdio: "pipe" });
+      // Atomic install sequence — try install over existing FIRST so that a
+      // transient failure (network, auth, bun version) cannot leave the user
+      // with an uninstalled maw. `bun remove` only runs as a fallback when
+      // the initial install fails. Mirrors the alpha.132 fix in cmd-update.ts
+      // (regression #507 — this site was missed in the original sweep).
+      const tryInstall = (): boolean => {
+        try {
+          execSync(`bun add -g github:${pkg.repository}#${ref}`, { stdio: "pipe" });
+          return true;
+        } catch { return false; }
+      };
+      if (!tryInstall()) {
+        console.log(`    \x1b[33m⚠ first install attempt failed — clearing stale global refs and retrying\x1b[0m`);
+        try { execSync(`bun remove -g maw`, { stdio: "pipe" }); } catch {}
+        if (!tryInstall()) {
+          console.log(`    \x1b[31m✗ update failed — manual recovery: bun add -g github:${pkg.repository}#alpha\x1b[0m`);
+          return;
+        }
+      }
       let after = "";
       try { after = execSync(`maw --version`, { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim(); } catch {}
       console.log(`    ${before} → ${after || "updated"}`);


### PR DESCRIPTION
## Summary

Two independent regressions both letting the `maw` binary disappear mid-stream during install/update. User experienced this **live** today (second incident this session — first was H3 in `cmd-update.ts`, fixed in alpha.130/.132).

### 1. `install.sh` — `bun add -g` not atomic for GitHub tarballs

`bun add -g github:...#alpha` mutates the global `node_modules` in-place over a multi-second extract window. `~/.bun/bin/maw` points at a half-extracted target during that window — concurrent `maw <cmd>` invocations fail with "No such file or directory".

Mitigations:
- New `--force` / `-f` flag.
- **Fast-path**: when installing by `--tag` and the current binary already matches the desired tag, skip the reinstall entirely. Zero gap.
- Explicit warning printed before `bun add -g` runs: "Don't run maw commands for the next ~10s — bun re-extracts the global package."

This does NOT fully close the gap when an actual install happens. A full staged-install (install to stash prefix → verify → atomic `ln -sfn` swap) is a follow-up. The fast-path eliminates the most common case (re-running `curl install.sh | bash` when already at the latest tag).

### 2. `restart/impl.ts` — H3 anti-pattern that was missed in the alpha.130/.132 sweep

```ts
try { execSync(`bun remove -g maw`, { stdio: "pipe" }); } catch {}
execSync(`bun add -g github:${pkg.repository}#${ref}`, { stdio: "pipe" });
```

Same bug class as the original H3 in `cmd-update.ts`. Fixed by mirroring the atomic pattern from `cmd-update.ts:127-150` — try-add-first, remove-then-retry on failure, surface recovery command on double-failure.

## Audit credit

Diagnosed by `install-archaeologist` agent (team `init-wizard`), 2026-04-18 08:35 +07. Full audit findings in the comment on #507.

## Test plan
- [x] `bun run test:all` from fresh /tmp worktree — 1023 pass / 0 fail
- [x] `bash -n install.sh` — shell syntax OK
- [ ] Live install on clean machine — deferred (this session can't safely repro without uninstalling the active binary)

Closes #507

Co-Authored-By: mawjs <noreply@soulbrews.studio>