### PR TITLE
feat(.claude): PR-size soft-warning hook + README (refs #509)

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,41 @@
+# `.claude/` — project-scoped Claude Code config
+
+Soft-warning hooks for the size discipline documented in [CONTRIBUTING.md](../CONTRIBUTING.md#pr-size).
+
+## What's here
+
+| File | Purpose |
+|------|---------|
+| `settings.json` | Registers PostToolUse + Stop hooks |
+| `hooks/check-file-size.sh` | Warn when a touched file exceeds 200 LOC (per-file cap) — installed at incubation from mawui-oracle (2026-04-11) |
+| `hooks/check-pr-size.sh` | Warn when current branch diff exceeds 300 LOC (PR cap) — added 2026-04-18 alongside the documented cap |
+| `INCUBATED_BY` | Provenance breadcrumb (incubator + date) |
+
+## How it works
+
+Claude Code auto-loads `.claude/settings.json` when invoked in this repo and runs the registered hooks at the lifecycle points:
+
+- **PostToolUse on Write/Edit**: each file write triggers a line-count check on the touched file; emits an `additionalContext` JSON line if > 200 LOC. The notification surfaces back to the agent's next turn.
+- **Stop**: at the end of each AI turn, sums production-code additions vs `origin/main`; warns to stderr if > 300 LOC.
+
+Both are **soft warnings — non-blocking** (exit 0 always). They surface drift early but never prevent shipping.
+
+## Exemptions
+
+Per CONTRIBUTING.md, the **per-file cap** is conceptually exempt for:
+- Markdown, JSON, YAML, TOML, lockfiles, snapshots
+- Anything under `test/`, `tests/`, `__tests__/`, `fixtures/`
+- Anything under `dist/`, `build/`, `node_modules/`, `coverage/`
+- Type-definition files (`*types.ts`, `*.d.ts`)
+
+(The current `check-file-size.sh` is broader — flags any Write/Edit > 200 LOC without filtering. A future tightening pass can add the exemptions; until then the false-positive rate is the trade-off for simplicity.)
+
+The **PR cap** in `check-pr-size.sh` already filters tests / fixtures / generated / docs.
+
+## Disabling locally
+
+Contributors who don't want these warnings can override in `~/.claude/settings.json` or `.claude/settings.local.json`. Hooks can also be toggled per-project in Claude Code settings.
+
+## Adding more hooks
+
+Drop a new `.sh` in `hooks/` and register it in `settings.json`. Keep each hook ≤ 150 LOC and non-blocking unless absolutely necessary — the [arra-safety-hooks](https://github.com/Soul-Brews-Studio/arra-safety-hooks) global repo handles destructive-op blocks.

--- a/.claude/hooks/check-pr-size.sh
+++ b/.claude/hooks/check-pr-size.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# .claude/hooks/check-pr-size.sh
+#
+# Stop hook — runs when Claude finishes a turn.
+# Soft warning (non-blocking) when the working branch's diff exceeds the PR LOC cap.
+#
+# Cap (per CONTRIBUTING.md): 300 LOC of production code per PR.
+# Excludes: test files, fixtures, dist/, lockfiles, vendored deps, generated.
+#
+# Exit code: always 0 (warnings only).
+# Output: warning to stderr if cap exceeded.
+
+set -u
+
+CAP=300
+
+# Must be in a git repo
+git rev-parse --git-dir >/dev/null 2>&1 || exit 0
+
+# Pick a base branch — try origin/main, then main
+base="origin/main"
+git merge-base HEAD "$base" >/dev/null 2>&1 || base="main"
+git merge-base HEAD "$base" >/dev/null 2>&1 || exit 0
+
+# Don't warn when ON main (no PR)
+current=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+[ "$current" = "main" ] || [ "$current" = "alpha" ] && exit 0
+
+# Sum production-code additions, excluding tests/fixtures/generated/docs
+loc=$(git diff "$base"...HEAD --numstat 2>/dev/null | awk '
+  # Skip test paths
+  $3 ~ /(^|\/)test(s|_isolated)?\// { next }
+  $3 ~ /(^|\/)__tests__\// { next }
+  $3 ~ /(^|\/)fixtures?\// { next }
+  $3 ~ /(^|\/)test-helpers\// { next }
+  # Skip generated / vendored
+  $3 ~ /(^|\/)dist\// { next }
+  $3 ~ /(^|\/)build\// { next }
+  $3 ~ /(^|\/)node_modules\// { next }
+  $3 ~ /(^|\/)\.next\// { next }
+  $3 ~ /(^|\/)coverage\// { next }
+  $3 ~ /\.snap$/ { next }
+  $3 ~ /\.lock$/ { next }
+  # Skip docs / config
+  $3 ~ /\.(md|json|ya?ml|toml|svg|html|css)$/ { next }
+  # Numstat marks binary files with "-" — skip
+  $1 == "-" { next }
+  { sum += $1 }
+  END { print sum+0 }
+')
+
+if [ "$loc" -gt "$CAP" ]; then
+  printf '\033[33m⚠\033[0m branch %s has %s production LOC vs %s (soft cap %s)\n' "$current" "$loc" "$base" "$CAP" >&2
+  printf '   See CONTRIBUTING.md#pr-size — consider splitting (scaffold → logic → integration)\n' >&2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,17 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/check-pr-size.sh",
+            "timeout": 5
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
Pure additive change to the project-scoped `.claude/` hook setup. Complements the new size-discipline rules landing in PR #512 (CONTRIBUTING.md).

## What's added

- **`.claude/hooks/check-pr-size.sh`** (57 LOC) — Stop hook that sums production-code additions on the current branch vs `origin/main`. Warns to stderr if > 300 LOC. Skips tests, fixtures, dist/, lockfiles, docs, generated.
- **`.claude/README.md`** (38 LOC) — documents both hooks: the existing `check-file-size.sh` (200 per file, installed at incubation 2026-04-11) and the new PR-size hook.
- **`.claude/settings.json`** — adds the Stop hook registration. Existing PostToolUse for `check-file-size.sh` is preserved unchanged.

## What's NOT changed
- Existing `check-file-size.sh` left untouched. It works as designed (200 threshold, additionalContext output style). A future tightening pass could add the exemption list documented in CONTRIBUTING.md, but that's separate.

## Soft, not hard

Both hooks exit 0 on warning. They surface drift early but never block. Per CONTRIBUTING.md:
- > 200 LOC per file: smell, suggest split
- > 300 LOC per PR: smell, suggest split (scaffold → logic → integration)

## Sizes within their own caps

- `check-pr-size.sh` = 57 LOC ✓
- `settings.json` exempt (config)
- `README.md` exempt (docs)
- Total PR diff = ~110 LOC ✓ well under PR cap

Refs #509