### PR TITLE
feat(plugin): cross-team-queue scan + parser (PR-B of 3, #515)

### DIFF
--- a/src/commands/plugins/cross-team-queue/scan.ts
+++ b/src/commands/plugins/cross-team-queue/scan.ts
@@ -1,0 +1,151 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import type { InboxItem, ParseError } from "./types";
+
+type Frontmatter = Record<string, string | string[] | number>;
+
+interface ParsedDoc {
+  frontmatter: Frontmatter;
+  body: string;
+}
+
+function parseScalar(raw: string): string | number {
+  const v = raw.trim();
+  if (v.startsWith('"') && v.endsWith('"')) return v.slice(1, -1);
+  if (v.startsWith("'") && v.endsWith("'")) return v.slice(1, -1);
+  if (/^-?\d+(\.\d+)?$/.test(v)) return Number(v);
+  return v;
+}
+
+function parseList(raw: string): string[] {
+  const inner = raw.trim().slice(1, -1).trim();
+  if (!inner) return [];
+  return inner.split(",").map((s) => {
+    const t = s.trim();
+    if (t.startsWith('"') && t.endsWith('"')) return t.slice(1, -1);
+    if (t.startsWith("'") && t.endsWith("'")) return t.slice(1, -1);
+    return t;
+  });
+}
+
+export function parseFrontmatter(content: string): ParsedDoc {
+  if (!content.startsWith("---\n") && !content.startsWith("---\r\n")) {
+    return { frontmatter: {}, body: content };
+  }
+  const afterOpen = content.indexOf("\n") + 1;
+  const closeIdx = content.indexOf("\n---", afterOpen);
+  if (closeIdx === -1) {
+    throw new Error("unclosed frontmatter fence");
+  }
+  const block = content.slice(afterOpen, closeIdx);
+  const rest = content.slice(closeIdx + 4).replace(/^\r?\n/, "");
+
+  const fm: Frontmatter = {};
+  for (const line of block.split(/\r?\n/)) {
+    if (!line.trim() || line.trim().startsWith("#")) continue;
+    const colonIdx = line.indexOf(":");
+    if (colonIdx === -1) {
+      throw new Error(`malformed frontmatter line: ${line}`);
+    }
+    const key = line.slice(0, colonIdx).trim();
+    const rawVal = line.slice(colonIdx + 1).trim();
+    if (!key) throw new Error(`empty key in frontmatter`);
+    if (rawVal.startsWith("[") && rawVal.endsWith("]")) {
+      fm[key] = parseList(rawVal);
+    } else if (rawVal === "") {
+      fm[key] = "";
+    } else {
+      fm[key] = parseScalar(rawVal);
+    }
+  }
+  return { frontmatter: fm, body: rest };
+}
+
+function firstNonEmptyLine(body: string): string {
+  for (const line of body.split(/\r?\n/)) {
+    const t = line.trim();
+    if (t) return t.replace(/^#+\s*/, "");
+  }
+  return "";
+}
+
+function listMdFiles(dir: string): string[] {
+  try {
+    return readdirSync(dir)
+      .filter((n) => n.endsWith(".md"))
+      .map((n) => join(dir, n));
+  } catch {
+    return [];
+  }
+}
+
+function listOracleDirs(vaultRoot: string): string[] {
+  try {
+    return readdirSync(vaultRoot, { withFileTypes: true })
+      .filter((e) => e.isDirectory() && !e.name.startsWith("."))
+      .map((e) => join(vaultRoot, e.name));
+  } catch {
+    return [];
+  }
+}
+
+export async function scanInboxes(
+  vaultRoot: string,
+  opts?: { maxFiles?: number },
+): Promise<{ items: InboxItem[]; errors: ParseError[] }> {
+  const items: InboxItem[] = [];
+  const errors: ParseError[] = [];
+  const max = opts?.maxFiles ?? Infinity;
+  const now = Date.now();
+
+  for (const oracleDir of listOracleDirs(vaultRoot)) {
+    for (const filePath of listMdFiles(join(oracleDir, "inbox"))) {
+      if (items.length + errors.length >= max) return { items, errors };
+      let raw: string;
+      let mtime: number;
+      try {
+        raw = readFileSync(filePath, "utf8");
+        mtime = statSync(filePath).mtimeMs;
+      } catch (e) {
+        errors.push({ path: filePath, reason: `read failed: ${(e as Error).message}` });
+        continue;
+      }
+
+      let parsed: ParsedDoc;
+      try {
+        parsed = parseFrontmatter(raw);
+      } catch (e) {
+        errors.push({ path: filePath, reason: (e as Error).message });
+        continue;
+      }
+
+      const fm = parsed.frontmatter;
+      const missing = ["recipient", "sender", "type"].filter(
+        (k) => typeof fm[k] !== "string" || !(fm[k] as string),
+      );
+      if (missing.length) {
+        errors.push({ path: filePath, reason: `missing required: ${missing.join(", ")}` });
+        continue;
+      }
+
+      const subject =
+        (typeof fm.subject === "string" && fm.subject) || firstNonEmptyLine(parsed.body) || "";
+      const team = typeof fm.team === "string" ? fm.team : undefined;
+
+      items.push({
+        recipient: fm.recipient as string,
+        sender: fm.sender as string,
+        team,
+        type: fm.type as string,
+        subject,
+        body: parsed.body,
+        path: filePath,
+        mtime,
+        ageHours: Math.max(0, (now - mtime) / 3600000),
+        schemaVersion: 1,
+      });
+    }
+  }
+
+  return { items, errors };
+}

--- a/test/cross-team-queue-scan.test.ts
+++ b/test/cross-team-queue-scan.test.ts
@@ -1,0 +1,234 @@
+/**
+ * #515 PR-B — cross-team-queue scan + frontmatter parser.
+ *
+ * Tests the pure scanInboxes() module against real fs fixtures under tmpdir.
+ * Adversarial: missing-field-as-error, malformed-frontmatter-as-error
+ * (no silent-drop).
+ */
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync, utimesSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { scanInboxes, parseFrontmatter } from "../src/commands/plugins/cross-team-queue/scan";
+
+let vaultRoot: string;
+
+function writeMd(oracle: string, name: string, content: string): string {
+  const dir = join(vaultRoot, oracle, "inbox");
+  mkdirSync(dir, { recursive: true });
+  const p = join(dir, name);
+  writeFileSync(p, content);
+  return p;
+}
+
+beforeAll(() => {
+  vaultRoot = mkdtempSync(join(tmpdir(), "ctq-scan-"));
+});
+
+afterAll(() => {
+  rmSync(vaultRoot, { recursive: true, force: true });
+});
+
+describe("parseFrontmatter", () => {
+  test("string values", () => {
+    const { frontmatter, body } = parseFrontmatter(
+      "---\nrecipient: alice\nsender: bob\n---\nhello\n",
+    );
+    expect(frontmatter.recipient).toBe("alice");
+    expect(frontmatter.sender).toBe("bob");
+    expect(body).toBe("hello\n");
+  });
+
+  test("list values", () => {
+    const { frontmatter } = parseFrontmatter(
+      "---\ntags: [a, b, c]\n---\n\n",
+    );
+    expect(frontmatter.tags).toEqual(["a", "b", "c"]);
+  });
+
+  test("number values (no quotes)", () => {
+    const { frontmatter } = parseFrontmatter(
+      "---\nattempt: 42\nage: 3.5\n---\n\n",
+    );
+    expect(frontmatter.attempt).toBe(42);
+    expect(frontmatter.age).toBe(3.5);
+  });
+
+  test("unclosed fence throws", () => {
+    expect(() =>
+      parseFrontmatter("---\nrecipient: alice\nno close fence\n"),
+    ).toThrow(/unclosed/);
+  });
+
+  test("no frontmatter returns empty fm + full body", () => {
+    const { frontmatter, body } = parseFrontmatter("just a body\n");
+    expect(frontmatter).toEqual({});
+    expect(body).toBe("just a body\n");
+  });
+
+  test("quoted string strips quotes", () => {
+    const { frontmatter } = parseFrontmatter(
+      `---\nsubject: "hello world"\n---\n`,
+    );
+    expect(frontmatter.subject).toBe("hello world");
+  });
+});
+
+describe("scanInboxes", () => {
+  test("happy path: 3 files in 2 oracle dirs → 3 items", async () => {
+    const sub = mkdtempSync(join(tmpdir(), "ctq-happy-"));
+    const prev = vaultRoot;
+    vaultRoot = sub;
+    try {
+      writeMd(
+        "alpha-oracle",
+        "m1.md",
+        "---\nrecipient: alice\nsender: bob\ntype: handoff\nsubject: first\n---\nbody1\n",
+      );
+      writeMd(
+        "alpha-oracle",
+        "m2.md",
+        "---\nrecipient: alice\nsender: carol\ntype: fyi\nsubject: second\n---\nbody2\n",
+      );
+      writeMd(
+        "beta-oracle",
+        "m3.md",
+        "---\nrecipient: dave\nsender: eve\ntype: task\nsubject: third\n---\nbody3\n",
+      );
+      const { items, errors } = await scanInboxes(vaultRoot);
+      expect(items).toHaveLength(3);
+      expect(errors).toHaveLength(0);
+      const subjects = items.map((i) => i.subject).sort();
+      expect(subjects).toEqual(["first", "second", "third"]);
+    } finally {
+      rmSync(sub, { recursive: true, force: true });
+      vaultRoot = prev;
+    }
+  });
+
+  test("missing recipient → error, not item", async () => {
+    const sub = mkdtempSync(join(tmpdir(), "ctq-miss-"));
+    const prev = vaultRoot;
+    vaultRoot = sub;
+    try {
+      writeMd(
+        "alpha-oracle",
+        "bad.md",
+        "---\nsender: bob\ntype: handoff\nsubject: x\n---\nbody\n",
+      );
+      const { items, errors } = await scanInboxes(vaultRoot);
+      expect(items).toHaveLength(0);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].reason).toMatch(/recipient/);
+      expect(errors[0].path).toMatch(/bad\.md$/);
+    } finally {
+      rmSync(sub, { recursive: true, force: true });
+      vaultRoot = prev;
+    }
+  });
+
+  test("malformed frontmatter (unclosed fence) → error", async () => {
+    const sub = mkdtempSync(join(tmpdir(), "ctq-mal-"));
+    const prev = vaultRoot;
+    vaultRoot = sub;
+    try {
+      writeMd(
+        "alpha-oracle",
+        "broken.md",
+        "---\nrecipient: alice\nsender: bob\nno-close-fence\nsomething: else\n",
+      );
+      const { items, errors } = await scanInboxes(vaultRoot);
+      expect(items).toHaveLength(0);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].reason).toMatch(/unclosed/i);
+    } finally {
+      rmSync(sub, { recursive: true, force: true });
+      vaultRoot = prev;
+    }
+  });
+
+  test("empty / missing inbox dir → no items, no errors", async () => {
+    const sub = mkdtempSync(join(tmpdir(), "ctq-empty-"));
+    try {
+      mkdirSync(join(sub, "alpha-oracle", "inbox"), { recursive: true });
+      mkdirSync(join(sub, "beta-oracle"), { recursive: true });
+      const { items, errors } = await scanInboxes(sub);
+      expect(items).toEqual([]);
+      expect(errors).toEqual([]);
+    } finally {
+      rmSync(sub, { recursive: true, force: true });
+    }
+  });
+
+  test("list-style frontmatter parses correctly", async () => {
+    const sub = mkdtempSync(join(tmpdir(), "ctq-list-"));
+    try {
+      mkdirSync(join(sub, "alpha-oracle", "inbox"), { recursive: true });
+      writeFileSync(
+        join(sub, "alpha-oracle", "inbox", "m.md"),
+        "---\nrecipient: alice\nsender: bob\ntype: handoff\nsubject: list-test\ntags: [foo, bar]\n---\nbody\n",
+      );
+      const { items, errors } = await scanInboxes(sub);
+      expect(errors).toHaveLength(0);
+      expect(items).toHaveLength(1);
+      expect(items[0].subject).toBe("list-test");
+    } finally {
+      rmSync(sub, { recursive: true, force: true });
+    }
+  });
+
+  test("number-style frontmatter (no quotes)", async () => {
+    const sub = mkdtempSync(join(tmpdir(), "ctq-num-"));
+    try {
+      mkdirSync(join(sub, "alpha-oracle", "inbox"), { recursive: true });
+      writeFileSync(
+        join(sub, "alpha-oracle", "inbox", "m.md"),
+        "---\nrecipient: alice\nsender: bob\ntype: handoff\nsubject: num\nattempt: 7\n---\nbody\n",
+      );
+      const { items, errors } = await scanInboxes(sub);
+      expect(errors).toHaveLength(0);
+      expect(items).toHaveLength(1);
+    } finally {
+      rmSync(sub, { recursive: true, force: true });
+    }
+  });
+
+  test("mtime + ageHours populated, ageHours >= 0", async () => {
+    const sub = mkdtempSync(join(tmpdir(), "ctq-time-"));
+    try {
+      mkdirSync(join(sub, "alpha-oracle", "inbox"), { recursive: true });
+      const p = join(sub, "alpha-oracle", "inbox", "m.md");
+      writeFileSync(
+        p,
+        "---\nrecipient: alice\nsender: bob\ntype: handoff\nsubject: t\n---\nbody\n",
+      );
+      // Backdate to 2h ago so ageHours is clearly positive.
+      const past = new Date(Date.now() - 2 * 3600_000);
+      utimesSync(p, past, past);
+      const { items } = await scanInboxes(sub);
+      expect(items).toHaveLength(1);
+      expect(items[0].mtime).toBeGreaterThan(0);
+      expect(items[0].ageHours).toBeGreaterThanOrEqual(0);
+      expect(items[0].ageHours).toBeGreaterThan(1.5);
+      expect(items[0].schemaVersion).toBe(1);
+    } finally {
+      rmSync(sub, { recursive: true, force: true });
+    }
+  });
+
+  test("subject falls back to first non-empty body line", async () => {
+    const sub = mkdtempSync(join(tmpdir(), "ctq-fallback-"));
+    try {
+      mkdirSync(join(sub, "alpha-oracle", "inbox"), { recursive: true });
+      writeFileSync(
+        join(sub, "alpha-oracle", "inbox", "m.md"),
+        "---\nrecipient: alice\nsender: bob\ntype: handoff\n---\n\n# Derived Subject\nmore body\n",
+      );
+      const { items } = await scanInboxes(sub);
+      expect(items).toHaveLength(1);
+      expect(items[0].subject).toBe("Derived Subject");
+    } finally {
+      rmSync(sub, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

PR-B of 3 for #515 (cross-team-queue plugin). Ships the pure scanner module + frontmatter parser + unit tests. No handler wiring yet — that lands in PR-C.

- `src/commands/plugins/cross-team-queue/scan.ts` (151 LOC): walks `<vaultRoot>/<oracle>/inbox/*.md`, extracts YAML-subset frontmatter, builds `InboxItem`, surfaces malformed files as `ParseError`.
- Minimal frontmatter parser inline (~40 LOC) — no full YAML dep. Supports `key: string`, `key: [a, b, c]`, `key: 42`, quoted strings.
- `test/cross-team-queue-scan.test.ts` — 14 unit tests, `mkdtempSync` fixtures.

## Contract (from #515)

- Required frontmatter: `recipient`, `sender`, `type`. Missing → `errors[]`, not `items[]`.
- `subject` falls back to first non-empty body line if absent.
- `mtime` raw + `ageHours` derived; `schemaVersion: 1`.
- **Missing-field-as-error**, not silent drop — matches the adversarial-test design from #515.

## Depends on PR-A merging

This branch imports `{ InboxItem, ParseError }` from `./types`, which PR-A owns. Until PR-A lands:
- `tsc` / `bun run typecheck` will fail here on the missing import.
- Locally verified with a temporary `types.ts` stub matching the contract in #515 — all 14 tests pass. Stub removed before commit; PR-A owns that file.

This is the intentional split per #515 — PR-A (types + scaffold) → PR-B (scan, this PR) → PR-C (filter/aggregate + handler).

## Out of scope

- No handler wiring (PR-C).
- No `src/api/` touch — did not modify #505's `src/api/cross-team-queue-scan.ts`; this is a fresh plugin-first implementation per the plan in #515.

## Test plan

- [x] `bun test test/cross-team-queue-scan.test.ts` — 14 pass / 0 fail locally (with temp types stub).
- [ ] CI: will be red until PR-A merges — expected.
- [ ] After PR-A merges: rebase and confirm CI green.

Refs #515