### PR TITLE
feat(plugin): cross-team-queue scaffold (PR-A of 3, #515)

### DIFF
--- a/src/commands/plugins/cross-team-queue/index.ts
+++ b/src/commands/plugins/cross-team-queue/index.ts
@@ -1,0 +1,39 @@
+/**
+ * cross-team-queue — plugin-first unified inbox across oracle vaults.
+ *
+ * PR-A (this file): scaffold only — returns an empty QueueResponse so the
+ * wire contract + /api/plugins/cross-team-queue auto-mount is live.
+ * PR-B adds scan.ts (fs walker + minimal YAML-subset frontmatter parser).
+ * PR-C wires filter + aggregate + adversarial tests.
+ *
+ * Inspired by #505 (david-oracle). Not derived from it — fresh impl that
+ * lives under src/commands/plugins/ per our plugin-first convention.
+ */
+
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { QueueResponse } from "./types";
+
+export const command = {
+  name: "cross-team-queue",
+  description: "Unified inbox view across oracle vaults (plugin-first).",
+};
+
+export function emptyQueueResponse(): QueueResponse {
+  return {
+    items: [],
+    stats: {
+      totalItems: 0,
+      byRecipient: {},
+      byType: {},
+      oldestAgeHours: null,
+      newestAgeHours: null,
+    },
+    errors: [],
+    schemaVersion: 1,
+  };
+}
+
+export default async function handler(_ctx: InvokeContext): Promise<InvokeResult> {
+  const response = emptyQueueResponse();
+  return { ok: true, output: JSON.stringify(response) };
+}

--- a/src/commands/plugins/cross-team-queue/plugin.json
+++ b/src/commands/plugins/cross-team-queue/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "cross-team-queue",
+  "version": "0.1.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Unified inbox view across oracle vaults — scan + frontmatter parse + filter/aggregate. Plugin-first, inspired by #505.",
+  "author": "Soul-Brews-Studio",
+  "api": {
+    "path": "/cross-team-queue",
+    "methods": ["GET"]
+  },
+  "weight": 50
+}

--- a/src/commands/plugins/cross-team-queue/types.ts
+++ b/src/commands/plugins/cross-team-queue/types.ts
@@ -1,0 +1,39 @@
+export interface InboxItem {
+  recipient: string;          // who the message is FOR
+  sender: string;             // who sent it
+  team?: string;              // optional team grouping
+  type: string;               // e.g. "handoff", "review", "question", "fyi"
+  subject: string;            // first line / title
+  body: string;               // markdown body (post-frontmatter)
+  path: string;               // absolute file path
+  mtime: number;              // raw modification time (epoch ms)
+  ageHours: number;           // derived: (Date.now() - mtime) / 3600000
+  schemaVersion: 1;           // wire-contract version literal
+}
+
+export interface QueueFilter {
+  recipient?: string;         // exact match (case-insensitive)
+  team?: string;              // exact match
+  type?: string;              // exact match
+  maxAgeHours?: number;       // include items with ageHours <= this
+}
+
+export interface QueueStats {
+  totalItems: number;
+  byRecipient: Record<string, number>;
+  byType: Record<string, number>;
+  oldestAgeHours: number | null;
+  newestAgeHours: number | null;
+}
+
+export interface ParseError {
+  path: string;
+  reason: string;             // human-readable; no stack traces
+}
+
+export interface QueueResponse {
+  items: InboxItem[];
+  stats: QueueStats;
+  errors: ParseError[];
+  schemaVersion: 1;
+}

--- a/test/cross-team-queue-scaffold.test.ts
+++ b/test/cross-team-queue-scaffold.test.ts
@@ -1,0 +1,44 @@
+/**
+ * PR-A smoke test — invokes the cross-team-queue handler directly and
+ * asserts the empty QueueResponse wire contract.
+ *
+ * No mock.module (kept out of test/isolated/). In-process handler call
+ * via InvokeContext — same shape the real /api/plugins router uses.
+ */
+
+import { describe, it, expect } from "bun:test";
+import type { InvokeContext } from "../src/plugin/types";
+import type { QueueResponse } from "../src/commands/plugins/cross-team-queue/types";
+import handler, { emptyQueueResponse } from "../src/commands/plugins/cross-team-queue/index";
+
+describe("cross-team-queue scaffold (PR-A)", () => {
+  const ctx: InvokeContext = { source: "api", args: {} };
+
+  it("emptyQueueResponse() matches the wire contract", () => {
+    const r = emptyQueueResponse();
+    expect(r.items).toEqual([]);
+    expect(r.errors).toEqual([]);
+    expect(r.schemaVersion).toBe(1);
+    expect(r.stats).toEqual({
+      totalItems: 0,
+      byRecipient: {},
+      byType: {},
+      oldestAgeHours: null,
+      newestAgeHours: null,
+    });
+  });
+
+  it("handler returns ok + JSON-serialised empty QueueResponse", async () => {
+    const result = await handler(ctx);
+    expect(result.ok).toBe(true);
+    expect(typeof result.output).toBe("string");
+
+    const parsed = JSON.parse(result.output!) as QueueResponse;
+    expect(parsed.schemaVersion).toBe(1);
+    expect(parsed.items).toEqual([]);
+    expect(parsed.errors).toEqual([]);
+    expect(parsed.stats.totalItems).toBe(0);
+    expect(parsed.stats.oldestAgeHours).toBeNull();
+    expect(parsed.stats.newestAgeHours).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- First of three PRs landing the **cross-team-queue** plugin per #515.
- Ships the plugin skeleton + wire contract so `/api/plugins/cross-team-queue` auto-mounts and the shared types are live for PR-B and PR-C to consume.
- Handler returns an empty `QueueResponse` for now — real scan + filter/aggregate logic lands in the follow-ups.

## Contract (lead-authored, frozen for this split)

`src/commands/plugins/cross-team-queue/types.ts` exports:

- `InboxItem` — recipient, sender, team?, type, subject, body, path, mtime, ageHours, schemaVersion: 1
- `QueueFilter` — recipient?, team?, type?, maxAgeHours?
- `QueueStats` — totalItems, byRecipient, byType, oldestAgeHours, newestAgeHours
- `ParseError` — path, reason
- `QueueResponse` — items, stats, errors, schemaVersion: 1

Three agents are splitting this in parallel — the frozen shape is what makes that possible.

## What's in this PR

- `plugin.json` — manifest, `api: { path: "/cross-team-queue", methods: ["GET"] }`, no CLI verb in v1 (API-only)
- `types.ts` — the full wire contract above
- `index.ts` — handler (~40 LOC) returning `{ok:true, output: JSON.stringify(emptyQueueResponse())}`; also exports `emptyQueueResponse()` for reuse
- `test/cross-team-queue-scaffold.test.ts` — in-process smoke test: imports the handler, invokes with `InvokeContext { source: "api", args: {} }`, asserts `schemaVersion === 1` + empty shape. No `mock.module`.

Total: **135 LOC** across 4 files. Every file is well under the 200-LOC per-file cap; PR total well under the ~300-LOC per-PR cap.

## Relation to #505

Inspired by [#505](https://github.com/Soul-Brews-Studio/maw-js/pull/505) (david-oracle / Leo's team) — **not derived from, not a fork, no code reuse**. Same feature intent (unified inbox view), different shape:

- `#505` mounts a built-in router at `src/api/cross-team-queue.ts`.
- This lives under `src/commands/plugins/cross-team-queue/` and auto-mounts at `/api/plugins/cross-team-queue` like our 60+ other plugins.
- Both shapes can coexist at different URLs; adoption is up to their team.

Explicitly not touched in this PR: any file from #505 (`src/api/cross-team-queue.ts` and siblings are untouched).

## Follow-ups

- **PR-B** — `scan.ts` (fs walker + minimal YAML-subset frontmatter parser) + parser unit tests + fixtures.
- **PR-C** — filter/aggregate wiring + adversarial integration tests (no silent-200, no hardcoded `~/<name>-oracle/` defaults, loud signal on missing `MAW_VAULT_ROOT`).

This PR is **Refs #515** (not Closes) — the issue closes when all three land.

## Test plan

- [x] `bun run test:all` from `/tmp/ctq-scaffold`, 0 fail
- [x] New smoke test isolated (no `mock.module` outside `test/isolated/`)
- [x] Every file ≤ 200 LOC, PR total ≤ 250 LOC
- [x] No code reuse from #505 verified (no imports, no file overlap)
- [ ] CI green on this PR