### PR TITLE
feat(plugin): maw learn core plugin scaffold (#521)

### DIFF
--- a/src/commands/plugins/learn/impl.ts
+++ b/src/commands/plugins/learn/impl.ts
@@ -1,0 +1,50 @@
+/**
+ * maw learn — stub implementation (#521).
+ *
+ * Migration scaffold for Oracle skill /learn. Real flow (parallel Haiku
+ * agents, ghq clone, symlink into ψ/learn/<owner>/<repo>/origin, date/time
+ * folder layout, .origins manifest, hub file) is tracked as follow-up work.
+ *
+ * Until that lands, this stub:
+ *   - Accepts <repo> + mode (default | fast | deep)
+ *   - Returns a well-shaped stub message with the selected mode
+ *   - Points users at the Oracle skill for actual learning runs
+ *
+ * The function is pure (no I/O, no process spawning) so it's safe to unit
+ * test and safe to wire into the CLI ahead of the real impl.
+ */
+
+export type LearnMode = "default" | "fast" | "deep";
+
+export interface LearnOptions {
+  repo: string;
+  mode: LearnMode;
+}
+
+/**
+ * Return a stub message for `maw learn`. Will be replaced by the real
+ * agent-spawning flow once the migration PR ships.
+ */
+export async function cmdLearn(repo: string, mode: LearnMode = "default"): Promise<string> {
+  const agents = mode === "fast" ? 1 : mode === "deep" ? 5 : 3;
+
+  const lines = [
+    `learn: ${mode} mode on "${repo}" — not yet implemented in core plugin; use Oracle skill /learn for full behavior.`,
+    `  planned: ${agents} parallel agent(s), write docs to ψ/learn/<owner>/<repo>/YYYY-MM-DD/HHMM_*.md`,
+    `  track:   https://github.com/Soul-Brews-Studio/maw-js/issues/521`,
+  ];
+  const message = lines.join("\n");
+  console.log(message);
+  return message;
+}
+
+/**
+ * Resolve mode from flag booleans. Exposed for tests and for future CLI
+ * wiring that may accept a single `--mode` string alternative.
+ */
+export function resolveMode(fast: boolean, deep: boolean): LearnMode {
+  if (fast && deep) throw new Error("--fast and --deep are mutually exclusive");
+  if (fast) return "fast";
+  if (deep) return "deep";
+  return "default";
+}

--- a/src/commands/plugins/learn/index.ts
+++ b/src/commands/plugins/learn/index.ts
@@ -1,0 +1,75 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+
+export const command = {
+  name: "learn",
+  description: "Scaffold (stub): explore a codebase with parallel agents.",
+};
+
+/**
+ * maw learn — core plugin scaffold (#521).
+ *
+ * This is a migration scaffold for the Oracle skill `/learn`. The full
+ * implementation (parallel Haiku agents, ghq + symlink flow, .origins
+ * manifest, docs generation) lives in ~/.claude/skills/learn/SKILL.md
+ * and ships in a follow-up PR.
+ *
+ * Today the plugin only:
+ *   - registers the CLI verb + flags
+ *   - validates positional args + flag shape
+ *   - returns a stub message pointing users at the Oracle skill
+ *
+ * See issue #521 for the follow-up implementation tracker.
+ */
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const { cmdLearn } = await import("./impl");
+
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+
+  try {
+    const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+
+    const fast = args.includes("--fast");
+    const deep = args.includes("--deep");
+    if (fast && deep) {
+      return {
+        ok: false,
+        error: "maw learn: --fast and --deep are mutually exclusive",
+      };
+    }
+
+    const positional = args.filter(a => !a.startsWith("--"));
+    const unknown = args.filter(a => a.startsWith("--") && a !== "--fast" && a !== "--deep");
+    if (unknown.length > 0) {
+      return {
+        ok: false,
+        error: `maw learn: unknown flag(s) ${unknown.join(", ")} (accepts --fast, --deep)`,
+      };
+    }
+
+    if (!positional[0]) {
+      return {
+        ok: false,
+        error: "usage: maw learn <repo> [--fast|--deep]",
+      };
+    }
+
+    const mode = fast ? "fast" : deep ? "deep" : "default";
+    const result = await cmdLearn(positional[0], mode);
+    return { ok: true, output: logs.join("\n") || result };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/src/commands/plugins/learn/plugin.json
+++ b/src/commands/plugins/learn/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "learn",
+  "version": "0.1.0-alpha.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Scaffold (stub): explore a codebase with parallel agents. Full impl lives in the Oracle /learn skill — core plugin is a dispatcher shape only.",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "learn",
+    "help": "maw learn <repo> [--fast|--deep] — scaffold stub (impl pending, see Oracle skill /learn)",
+    "flags": {
+      "--fast": "boolean",
+      "--deep": "boolean"
+    }
+  },
+  "weight": 50
+}

--- a/test/learn-plugin.test.ts
+++ b/test/learn-plugin.test.ts
@@ -1,0 +1,80 @@
+/**
+ * maw learn — core plugin scaffold tests (#521).
+ *
+ * The impl is a stub — these tests pin the plugin SHAPE, not behavior:
+ *   - plugin.json is valid + matches the registered command
+ *   - stub returns a well-shaped string with mode + issue pointer
+ *   - CLI flag parsing rejects unknown flags and conflicting modes
+ *   - missing <repo> positional returns a usage error
+ *
+ * When the real impl lands (parallel agents, ghq, docs), these tests stay
+ * relevant as the outer plugin contract — the inner agent work gets its
+ * own tests.
+ */
+import { describe, it, expect } from "bun:test";
+import { join } from "path";
+import { readFileSync } from "fs";
+import type { InvokeContext } from "../src/plugin/types";
+
+const { default: learn, command } = await import("../src/commands/plugins/learn/index");
+const { cmdLearn, resolveMode } = await import("../src/commands/plugins/learn/impl");
+
+describe("learn plugin — scaffold", () => {
+  it("plugin.json has expected command + flags", () => {
+    const manifest = JSON.parse(
+      readFileSync(join(import.meta.dir, "../src/commands/plugins/learn/plugin.json"), "utf-8"),
+    );
+    expect(manifest.name).toBe("learn");
+    expect(manifest.cli.command).toBe("learn");
+    expect(manifest.cli.flags).toEqual({ "--fast": "boolean", "--deep": "boolean" });
+    expect(manifest.entry).toBe("./index.ts");
+  });
+
+  it("exports command metadata matching the manifest", () => {
+    expect(command.name).toBe("learn");
+  });
+
+  it("resolveMode: flag combinations → mode", () => {
+    expect(resolveMode(false, false)).toBe("default");
+    expect(resolveMode(true, false)).toBe("fast");
+    expect(resolveMode(false, true)).toBe("deep");
+    expect(() => resolveMode(true, true)).toThrow(/mutually exclusive/);
+  });
+
+  it("cmdLearn stub: returns well-shaped message with mode + issue link", async () => {
+    const out = await cmdLearn("owner/repo", "fast");
+    expect(out).toContain("not yet implemented");
+    expect(out).toContain("fast");
+    expect(out).toContain("owner/repo");
+    expect(out).toContain("issues/521");
+  });
+
+  it("CLI handler: missing <repo> returns usage error", async () => {
+    const ctx: InvokeContext = { source: "cli", args: [] };
+    const r = await learn(ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain("usage:");
+  });
+
+  it("CLI handler: --fast + --deep conflict returns error", async () => {
+    const ctx: InvokeContext = { source: "cli", args: ["x", "--fast", "--deep"] };
+    const r = await learn(ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain("mutually exclusive");
+  });
+
+  it("CLI handler: unknown flag returns error", async () => {
+    const ctx: InvokeContext = { source: "cli", args: ["x", "--nope"] };
+    const r = await learn(ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain("unknown flag");
+  });
+
+  it("CLI handler: valid invocation returns ok + stub output", async () => {
+    const ctx: InvokeContext = { source: "cli", args: ["some/repo", "--deep"] };
+    const r = await learn(ctx);
+    expect(r.ok).toBe(true);
+    expect(r.output).toContain("deep");
+    expect(r.output).toContain("some/repo");
+  });
+});


### PR DESCRIPTION
## Summary

Migration scaffold for Oracle skill `/learn` into a core maw plugin. Per proposal #520 (1 of 3 — also: #522 incubate, #523 project).

## What ships

- `src/commands/plugins/learn/plugin.json` — registers `maw learn <repo> [--fast|--deep]`
- `src/commands/plugins/learn/index.ts` — dispatcher boilerplate (mirrors `view/index.ts`: console.log/error capture, CLI flag validation, error shapes)
- `src/commands/plugins/learn/impl.ts` — stub `cmdLearn(repo, mode)` returning a mode-shaped message pointing at the Oracle skill
- `test/learn-plugin.test.ts` — 8 tests pinning plugin SHAPE (manifest valid, stub returns right shape, flag/positional validation)

## What does NOT ship

Stub only. No agent spawning, no ghq, no docs write. The full impl (parallel Haiku agents, ghq clone + symlink to `ψ/learn/<owner>/<repo>/origin`, `.origins` manifest, date/time folder layout, hub file) lands in a follow-up PR. Stub message directs users to the Oracle skill `/learn` for full behavior in the meantime.

## LOC

- Production: ~140 (plugin.json + index.ts + impl.ts)
- Tests: ~75

## Test plan

- [x] `bun run test:all` — 0 fail
- [x] `bun test test/learn-plugin.test.ts` — 8/8 pass
- [ ] Manual: `maw learn owner/repo --fast` should print the stub message

Closes #521

---
Rule 6: "Oracle Never Pretends to Be Human"
Written by mawjs — AI speaking as itself.