### PR TITLE
fix(wake): honour --split on existing-window path (#533)

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -176,6 +176,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
         const escaped = opts.prompt.replace(/'/g, "'\\''");
         await tmux.sendText(`${session}:${existingWindow}`, `${buildCommandInDir(existingWindow, targetPath)} -p '${escaped}'`);
         if (opts.attach) await attachToSession(session);
+        await maybeSplit(`${session}:${existingWindow}`, opts);
         return `${session}:${existingWindow}`;
       }
       console.log(`\x1b[33m⚡\x1b[0m '${existingWindow}' already running in ${session}`);
@@ -183,6 +184,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
         await tmux.selectWindow(`${session}:${existingWindow}`);
         await attachToSession(session);
       }
+      await maybeSplit(`${session}:${existingWindow}`, opts);
       return `${session}:${existingWindow}`;
     }
   } catch { /* session might be fresh */ }
@@ -200,18 +202,24 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
   console.log(`\x1b[32m✅\x1b[0m woke '${windowName}' in ${session} → ${targetPath}`);
   if (opts.attach) await attachToSession(session);
 
-  // Optional --split: show the new window in a pane beside the caller.
-  if (opts.split && process.env.TMUX) {
-    try {
-      const { cmdSplit } = await import("../plugins/split/impl");
-      await cmdSplit(`${session}:${windowName}`);
-    } catch (e: any) {
-      console.log(`  \x1b[33m⚠\x1b[0m split failed: ${e.message || e}`);
-    }
-  } else if (opts.split && !process.env.TMUX) {
-    console.log(`  \x1b[33m⚠\x1b[0m --split requires tmux session (TMUX env var not set)`);
-  }
+  await maybeSplit(`${session}:${windowName}`, opts);
 
   takeSnapshot("wake").catch(() => {});
   return `${session}:${windowName}`;
+}
+
+// #533 — split ran only on the new-window path; existing-window early returns
+// silently skipped it. Extract so every path that resolves a target honours --split.
+async function maybeSplit(target: string, opts: { split?: boolean }): Promise<void> {
+  if (!opts.split) return;
+  if (!process.env.TMUX) {
+    console.log(`  \x1b[33m⚠\x1b[0m --split requires tmux session (TMUX env var not set)`);
+    return;
+  }
+  try {
+    const { cmdSplit } = await import("../plugins/split/impl");
+    await cmdSplit(target);
+  } catch (e: any) {
+    console.log(`  \x1b[33m⚠\x1b[0m split failed: ${e.message || e}`);
+  }
 }


### PR DESCRIPTION
## Summary
- Fixes #533 — `maw wake <oracle> --split` silently skipped the split on the existing-window path (the common case)
- Extracts `maybeSplit(target, opts)` helper; calls it from all three resolution paths (prompt-existing, bare-existing, new-window)
- Mirrors the composition pattern `bud-wake.ts` already uses — split runs after the target is resolved, regardless of whether the window was created or found
- No version bump: deferring to CalVer cutover (#526 umbrella). The bug fix is orthogonal to the version-scheme decision.

## Before / After

**Before** (existing-window):
```
$ maw wake mawjs --split
⚡ resolving mawjs...
→ session exists: 101-mawjs
⚡ 'mawjs-oracle' already running in 101-mawjs
# no split happened
```

**After** (existing-window):
```
$ bun src/cli.ts wake mawjs --split   # dev-mode verified
⚡ resolving mawjs...
→ session exists: 101-mawjs
⚡ 'mawjs-oracle' already running in 101-mawjs
  ✓ split beside — 101-mawjs:mawjs-oracle (50%)
```

## Root cause

`wake-cmd.ts:180` and `:187` early-returned from `cmdWake()` before the `--split` block at the bottom of the function. Only the new-window path (line 190+) reached split.

## Fix

Replace the inline split block with `maybeSplit(target, opts)` helper; invoke at the three resolution points. Same `cmdSplit` import, same TMUX env-var check, same warning behaviour — just reachable from every return path.

## Test plan
- [x] `bun run test` — 1083 pass / 7 skip / 0 fail
- [x] `bun run test:all` — all canonical suites green
- [x] Manual: `bun src/cli.ts wake mawjs --split` → split fires on existing session
- [ ] CI — awaiting

## Risk: minimal
- Pure additive refactor; no new surface area
- Same split impl already running on new-window path
- ~19 LOC changed; well under 300-LOC cap

## Related
- trace `ψ/memory/traces/2026-04-15/1013_wake-bud-split-composition.md` — composition principle
- #533 — issue with full root-cause diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)