### PR TITLE
fix(wake): implement #539 P1+P4 — clearer --split warning + tmux-server probe

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -6,6 +6,7 @@ import { normalizeTarget } from "../../core/matcher/normalize-target";
 import { assertValidOracleName } from "../../core/fleet/validate";
 import { resolveOracle, findWorktrees, getSessionMap, resolveFleetSession, detectSession, setSessionEnv, sanitizeBranchName } from "./wake-resolve";
 import { attachToSession, ensureSessionRunning, createWorktree } from "./wake-session";
+import { maybeSplit } from "./wake-maybe-split";
 
 export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; split?: boolean; repoPath?: string }): Promise<string> {
   // Canonicalize the bare name before any lookup — strips trailing `/`, `/.git`, `/.git/`
@@ -208,18 +209,3 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
   return `${session}:${windowName}`;
 }
 
-// #533 — split ran only on the new-window path; existing-window early returns
-// silently skipped it. Extract so every path that resolves a target honours --split.
-async function maybeSplit(target: string, opts: { split?: boolean }): Promise<void> {
-  if (!opts.split) return;
-  if (!process.env.TMUX) {
-    console.log(`  \x1b[33m⚠\x1b[0m --split requires tmux session (TMUX env var not set)`);
-    return;
-  }
-  try {
-    const { cmdSplit } = await import("../plugins/split/impl");
-    await cmdSplit(target);
-  } catch (e: any) {
-    console.log(`  \x1b[33m⚠\x1b[0m split failed: ${e.message || e}`);
-  }
-}

--- a/src/commands/shared/wake-maybe-split.ts
+++ b/src/commands/shared/wake-maybe-split.ts
@@ -1,0 +1,36 @@
+import { hostExec } from "../../sdk";
+
+export async function probeTmuxServer(): Promise<boolean> {
+  try {
+    await hostExec("tmux display-message -p '#S'");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function maybeSplit(target: string, opts: { split?: boolean }): Promise<void> {
+  if (!opts.split) return;
+  if (process.env.TMUX) {
+    try {
+      const { cmdSplit } = await import("../plugins/split/impl");
+      await cmdSplit(target);
+    } catch (e: any) {
+      console.log(`  \x1b[33m⚠\x1b[0m split failed: ${e.message || e}`);
+    }
+    return;
+  }
+  const serverUp = await probeTmuxServer();
+  const session = target.split(":")[0] || target;
+  if (serverUp) {
+    console.log(`  \x1b[33m⚠\x1b[0m --split skipped — shell is not attached to a tmux pane.`);
+    console.log(`      \x1b[90mstate created:    ${target}\x1b[0m`);
+    console.log(`      \x1b[90mto view:          tmux attach -t ${session}\x1b[0m`);
+    console.log(`      \x1b[90mto silence:       drop --split when running headless\x1b[0m`);
+  } else {
+    console.log(`  \x1b[33m⚠\x1b[0m --split skipped — tmux server not running.`);
+    console.log(`      \x1b[90mstate created:    ${target}\x1b[0m`);
+    console.log(`      \x1b[90mto start tmux:    tmux new -s work\x1b[0m`);
+    console.log(`      \x1b[90mto silence:       drop --split when running headless\x1b[0m`);
+  }
+}

--- a/test/isolated/wake-cmd.test.ts
+++ b/test/isolated/wake-cmd.test.ts
@@ -759,7 +759,9 @@ describe("cmdWake — --split", () => {
     await cmdWake("foo", { split: true });
 
     expect(cmdSplitCalls).toHaveLength(0);
-    expect(warns.some(w => w.includes("--split requires tmux session"))).toBe(true);
+    // #539 P1: warning text now reads as a runbook. Both the server-up and
+    // no-server branches share the "--split skipped" prefix.
+    expect(warns.some(w => w.includes("--split skipped"))).toBe(true);
   });
 
   test("--split + TMUX + cmdSplit throws → error caught, flow continues to takeSnapshot", async () => {

--- a/test/wake-maybe-split.test.ts
+++ b/test/wake-maybe-split.test.ts
@@ -45,10 +45,16 @@ const origLog = console.log;
 let logs: string[] = [];
 let savedTmux: string | undefined;
 
+// Strip ANSI color/style escapes so assertions can match literal text without
+// needing to know the exact color codes maybeSplit emits.
+const stripAnsi = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, "");
+
 function captureLogs() {
   logs = [];
   console.log = (...a: unknown[]) => {
-    logs.push(a.map((x) => (typeof x === "string" ? x : String(x))).join(" "));
+    logs.push(
+      stripAnsi(a.map((x) => (typeof x === "string" ? x : String(x))).join(" "))
+    );
   };
 }
 

--- a/test/wake-maybe-split.test.ts
+++ b/test/wake-maybe-split.test.ts
@@ -1,0 +1,188 @@
+/**
+ * wake-maybe-split.test.ts — #539 P1+P4 coverage.
+ *
+ * Covers src/commands/shared/wake-maybe-split.ts:
+ *   - maybeSplit: 2 no-op guards (opts.split undefined / false)
+ *   - maybeSplit: in-tmux happy path delegates to cmdSplit
+ *   - maybeSplit: in-tmux, cmdSplit throws → logs "split failed" line
+ *   - maybeSplit: out-of-tmux, tmux server up → logs attach runbook
+ *   - maybeSplit: out-of-tmux, no tmux server → logs start runbook
+ *   - probeTmuxServer: true when hostExec resolves, false when it rejects
+ *
+ * Mocked seams: src/sdk (hostExec), src/commands/plugins/split/impl (cmdSplit).
+ */
+import { describe, test, expect, mock, beforeEach, afterEach, afterAll } from "bun:test";
+import { join } from "path";
+
+// ─── Mutable stubs ───────────────────────────────────────────────────────────
+
+let hostExecImpl: (cmd: string) => Promise<string> = async () => "";
+let cmdSplitImpl: (target: string) => Promise<void> = async () => {};
+let cmdSplitCalls: string[] = [];
+
+// ─── Mocks (must install before importing the module-under-test) ─────────────
+
+mock.module(join(import.meta.dir, "../src/sdk"), () => ({
+  hostExec: (cmd: string) => hostExecImpl(cmd),
+}));
+
+mock.module(join(import.meta.dir, "../src/commands/plugins/split/impl"), () => ({
+  cmdSplit: async (target: string) => {
+    cmdSplitCalls.push(target);
+    return cmdSplitImpl(target);
+  },
+}));
+
+// ─── Import module-under-test (after mocks installed) ────────────────────────
+
+const { maybeSplit, probeTmuxServer } = await import(
+  "../src/commands/shared/wake-maybe-split"
+);
+
+// ─── Harness for capturing console.log + managing TMUX env ───────────────────
+
+const origLog = console.log;
+let logs: string[] = [];
+let savedTmux: string | undefined;
+
+function captureLogs() {
+  logs = [];
+  console.log = (...a: unknown[]) => {
+    logs.push(a.map((x) => (typeof x === "string" ? x : String(x))).join(" "));
+  };
+}
+
+beforeEach(() => {
+  savedTmux = process.env.TMUX;
+  delete process.env.TMUX;
+  cmdSplitCalls = [];
+  cmdSplitImpl = async () => {};
+  hostExecImpl = async () => "";
+  captureLogs();
+});
+
+afterEach(() => {
+  console.log = origLog;
+  if (savedTmux === undefined) delete process.env.TMUX;
+  else process.env.TMUX = savedTmux;
+});
+
+afterAll(() => {
+  console.log = origLog;
+});
+
+// ─── maybeSplit — no-op guards ───────────────────────────────────────────────
+
+describe("maybeSplit — no-op guards", () => {
+  test("opts.split undefined → nothing logged, cmdSplit not called, hostExec not called", async () => {
+    let hostExecCalled = false;
+    hostExecImpl = async () => {
+      hostExecCalled = true;
+      return "";
+    };
+    await maybeSplit("sess:win", {});
+    expect(logs.length).toBe(0);
+    expect(cmdSplitCalls.length).toBe(0);
+    expect(hostExecCalled).toBe(false);
+  });
+
+  test("opts.split false → nothing logged, cmdSplit not called, hostExec not called", async () => {
+    let hostExecCalled = false;
+    hostExecImpl = async () => {
+      hostExecCalled = true;
+      return "";
+    };
+    await maybeSplit("sess:win", { split: false });
+    expect(logs.length).toBe(0);
+    expect(cmdSplitCalls.length).toBe(0);
+    expect(hostExecCalled).toBe(false);
+  });
+});
+
+// ─── maybeSplit — in-tmux (TMUX set) ─────────────────────────────────────────
+
+describe("maybeSplit — in-tmux (TMUX set)", () => {
+  test("delegates to cmdSplit with the target", async () => {
+    process.env.TMUX = "/tmp/tmux-1000/default,1234,0";
+    await maybeSplit("work:oracle", { split: true });
+    expect(cmdSplitCalls).toEqual(["work:oracle"]);
+    // Happy path: no warning lines
+    const joined = logs.join("\n");
+    expect(joined).not.toContain("split failed");
+    expect(joined).not.toContain("--split skipped");
+  });
+
+  test("cmdSplit throws → logs split-failed warning with the error message", async () => {
+    process.env.TMUX = "/tmp/tmux-1000/default,1234,0";
+    cmdSplitImpl = async () => {
+      throw new Error("boom");
+    };
+    await maybeSplit("work:oracle", { split: true });
+    expect(cmdSplitCalls).toEqual(["work:oracle"]);
+    const joined = logs.join("\n");
+    expect(joined).toContain("⚠ split failed:");
+    expect(joined).toContain("boom");
+  });
+});
+
+// ─── maybeSplit — out-of-tmux, server up (attach runbook) ───────────────────
+
+describe("maybeSplit — out-of-tmux, tmux server up", () => {
+  test("logs 4-line attach runbook with target + derived session", async () => {
+    // TMUX unset (beforeEach) — probeTmuxServer → true (hostExec resolves)
+    hostExecImpl = async () => "work\n";
+    await maybeSplit("work:oracle", { split: true });
+
+    const joined = logs.join("\n");
+    expect(joined).toContain("⚠ --split skipped — shell is not attached to a tmux pane.");
+    expect(joined).toContain("state created:");
+    expect(joined).toContain("work:oracle");
+    expect(joined).toContain("to view:");
+    expect(joined).toContain("tmux attach -t work");
+    expect(joined).toContain("to silence:");
+    expect(joined).toContain("drop --split when running headless");
+
+    // cmdSplit must NOT be called in the out-of-tmux path
+    expect(cmdSplitCalls.length).toBe(0);
+  });
+});
+
+// ─── maybeSplit — out-of-tmux, no server (start runbook) ─────────────────────
+
+describe("maybeSplit — out-of-tmux, no tmux server", () => {
+  test("logs 4-line start runbook", async () => {
+    hostExecImpl = async () => {
+      throw new Error("no server running on /tmp/tmux-1000/default");
+    };
+    await maybeSplit("work:oracle", { split: true });
+
+    const joined = logs.join("\n");
+    expect(joined).toContain("⚠ --split skipped — tmux server not running.");
+    expect(joined).toContain("state created:");
+    expect(joined).toContain("work:oracle");
+    expect(joined).toContain("to start tmux:");
+    expect(joined).toContain("tmux new -s work");
+    expect(joined).toContain("to silence:");
+    expect(joined).toContain("drop --split when running headless");
+
+    expect(cmdSplitCalls.length).toBe(0);
+  });
+});
+
+// ─── probeTmuxServer ─────────────────────────────────────────────────────────
+
+describe("probeTmuxServer", () => {
+  test("returns true when hostExec resolves", async () => {
+    hostExecImpl = async () => "some-session\n";
+    const result = await probeTmuxServer();
+    expect(result).toBe(true);
+  });
+
+  test("returns false when hostExec rejects", async () => {
+    hostExecImpl = async () => {
+      throw new Error("no server running");
+    };
+    const result = await probeTmuxServer();
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Implements [issue #539](https://github.com/Soul-Brews-Studio/maw-js/issues/539) P1 + P4 — runbook-style warning + tmux-server probe
- Extracts private maybeSplit helper into \`src/commands/shared/wake-maybe-split.ts\` (testable seam)
- Adds \`probeTmuxServer()\` that shells out to \`tmux display-message\` to distinguish \"server running, shell not attached\" from \"server not running\"
- Warnings now read as runbooks — name the created target, attach command, and how to silence
- No behaviour change when caller is already inside tmux (happy path unchanged)
- Built by a /team-agents team: implementer + tester + lead verification

## Before / After

**Before** (out-of-tmux, cryptic):
\`\`\`
⚠ --split requires tmux session (TMUX env var not set)
\`\`\`

**After** (out-of-tmux, server up — verified live today):
\`\`\`
⚠ --split skipped — shell is not attached to a tmux pane.
    state created:    101-mawjs:mawjs-hello
    to view:          tmux attach -t 101-mawjs
    to silence:       drop --split when running headless
\`\`\`

**After** (out-of-tmux, no server):
\`\`\`
⚠ --split skipped — tmux server not running.
    state created:    101-mawjs:mawjs-hello
    to start tmux:    tmux new -s work
    to silence:       drop --split when running headless
\`\`\`

**After** (in-tmux — unchanged):
\`\`\`
✓ split beside — 101-mawjs:mawjs-hello (50%)
\`\`\`

## Changes

- NEW \`src/commands/shared/wake-maybe-split.ts\` (+37) — maybeSplit + probeTmuxServer
- MODIFIED \`src/commands/shared/wake-cmd.ts\` — drop the private helper, add import (−15, +2)
- NEW \`test/wake-maybe-split.test.ts\` (+188) — 8 tests covering 4 maybeSplit paths + probeTmuxServer true/false
- MODIFIED \`test/isolated/wake-cmd.test.ts\` (+3) — update the \`--split-without-TMUX\` assertion to the new \"--split skipped\" prefix

Total: ~215 LOC across 4 files, all under the 150-200 per-file cap and well under the 300 PR cap.

## Test plan
- [x] \`bun test test/wake-maybe-split.test.ts\` — 8 pass / 0 fail
- [x] \`bun run test\` — 1097 pass / 7 skip / 0 fail (+10 from baseline 1087)
- [x] \`bun run test:isolated\` — 64/64 files pass
- [x] Manual repro (dev-mode): both in-tmux and env -u TMUX out-of-tmux paths verified
- [ ] CI — awaiting

## Team process

Built with /team-agents:
- **implementer** (blue) — extracted module, 37 LOC
- **tester** (green) — 8 tests against frozen contract (committed BEFORE impl landed — contract-first parallel)
- **lead** (me) — verified, caught ANSI-escape in tester's .toContain() assertions, patched (\`stripAnsi\` helper), updated legacy isolated test for new warning text

Prior art:
- #534 — extracted the existing inline maybeSplit; this PR carves it into its own module
- trace \`ψ/memory/traces/2026-04-15/1013_wake-bud-split-composition.md\` — composition principle (cmdWake = structure, cmdSplit = view)
- memory \`feedback_contract_first_parallel_spawn\` — lead pre-defined the exports so tester could write without waiting

## Risk: low
- New module is pure refactor + additive (probeTmuxServer is new, but only consulted when TMUX is unset)
- Happy path (in-tmux) untouched
- 8 unit tests + 1 updated integration test lock the observable behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)