### PR TITLE
fix(update): stash+restore + flock — root-cause fix for #531

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Pre-1.0 alpha releases may introduce breaking changes at any time.
 
 ## [Unreleased]
 
+### Fixed
+- `maw update`: stash maw binary before bun-remove fallback so failed retries don't strand users with no binary (#551 — root-cause fix for #531)
+
+### Added
+- `maw update`: serialize concurrent invocations via `~/.maw/update.lock` (#551)
+
 ## [v2.0.0-alpha.134] - 2026-04-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ bun add -g github:Soul-Brews-Studio/maw-js
 ghq get Soul-Brews-Studio/maw-js && cd "$(ghq root)/github.com/Soul-Brews-Studio/maw-js" && bun install && bun link
 ```
 
+### Troubleshooting
+
+If `maw` disappears after an update, run `maw doctor` (see PR #550 / `docs/install-recovery.md`).
+
+As of the next alpha, `maw update` self-protects against the sweep via [#551](https://github.com/Soul-Brews-Studio/maw-js/pull/551) — it stashes the binary to `~/.bun/bin/maw.prev` before any destructive `bun remove` and restores on retry-fail. `maw doctor` remains useful if the binary disappears for other reasons (older alpha, manual `bun remove`, disk full, etc.).
+
 ## Quick Start
 
 ```bash

--- a/docs/install-recovery.md
+++ b/docs/install-recovery.md
@@ -1,0 +1,22 @@
+# Install recovery
+
+> Full runbook lives in PR [#550](https://github.com/Soul-Brews-Studio/maw-js/pull/550) /
+> `docs/install-recovery.md` on `main` once merged. This file on the `#551`
+> branch carries only the root-cause-fix note below so the CHANGELOG entry
+> has a link target.
+
+## Root-cause fix landed (#551)
+
+As of the next alpha release, `maw update` stashes your existing binary
+to `~/.bun/bin/maw.prev` before running the fallback `bun remove -g`.
+If the retry also fails, the previous binary is restored automatically.
+You should no longer see "maw: command not found" after a failed update.
+
+Concurrent `maw update` invocations are now serialized via
+`~/.maw/update.lock` — the second one waits up to 60 seconds for the
+first to finish, then takes over if no progress.
+
+The `maw doctor` + `maw-heal.sh` tools from #550 remain useful when:
+- You're on an older alpha that predates this fix
+- Some other process (manual `bun remove`, disk issue, etc.) kills the binary
+- The stash rename fails due to permissions or disk full

--- a/src/cli/cmd-update.ts
+++ b/src/cli/cmd-update.ts
@@ -152,11 +152,18 @@ export async function runUpdate(args: string[]): Promise<void> {
       const BIN = join(homedir(), ".bun", "bin", "maw");
       const STASH = `${BIN}.prev`;
       let stashed = false;
+      // Refuse if .prev already exists — that's a prior crashed update's
+      // last-known-good escape hatch; silently overwriting would destroy it
+      // (architect's gotcha on #551). User resolves explicitly.
+      if (existsSync(STASH)) {
+        console.error(`\x1b[31merror\x1b[0m: ${STASH} already exists (prior update crashed — last-known-good binary).`);
+        console.error(`  restore manually:  mv ${STASH} ${BIN}`);
+        console.error(`  or discard it:     rm ${STASH}   \x1b[90m# only if you're sure\x1b[0m`);
+        console.error(`  then re-run:       maw update ${ref}`);
+        process.exit(1);
+      }
       try {
         if (existsSync(BIN)) {
-          // If a previous stash exists (prior crashed update), overwrite it —
-          // the currently-running binary is newer than any prior stash.
-          if (existsSync(STASH)) { try { unlinkSync(STASH); } catch {} }
           renameSync(BIN, STASH);
           stashed = true;
         }

--- a/src/cli/cmd-update.ts
+++ b/src/cli/cmd-update.ts
@@ -8,6 +8,7 @@ import { join, dirname } from "path";
 import { homedir } from "os";
 import { getVersionString } from "./cmd-version";
 import { ghqFindSync } from "../core/ghq";
+import { withUpdateLock } from "./update-lock";
 
 export async function runUpdate(args: string[]): Promise<void> {
   const { repository } = require("../../package.json");
@@ -134,105 +135,110 @@ export async function runUpdate(args: string[]): Promise<void> {
   // Order matters: validation (above) → try add → on fail, remove + retry →
   // on still-fail, print recovery command. User always has a working maw
   // unless BOTH adds fail.
-  const spawnInstall = () => Bun.spawn(["bun", "add", "-g", `github:${repository}#${ref}`], {
-    stdio: ["inherit", "inherit", "inherit"],
-  });
+  // #551 — serialize concurrent `maw update` invocations via filesystem lock.
+  // Channel-resolve + validation above runs unlocked; destructive install ops
+  // below (stash, bun remove, bun add, link refresh) are serialized.
+  await withUpdateLock(async () => {
+    const spawnInstall = () => Bun.spawn(["bun", "add", "-g", `github:${repository}#${ref}`], {
+      stdio: ["inherit", "inherit", "inherit"],
+    });
 
-  let installCode = await spawnInstall().exited;
-  if (installCode !== 0) {
-    console.warn(`\x1b[33m⚠\x1b[0m first install attempt failed — clearing stale global refs and retrying`);
-    // #551 — stash the current binary before destructive 'bun remove -g'.
-    // If the retry also fails, we restore from stash so the user never ends up
-    // with no maw. Empty-try around rename: stash is best-effort, retry not blocked.
-    const BIN = join(homedir(), ".bun", "bin", "maw");
-    const STASH = `${BIN}.prev`;
-    let stashed = false;
-    try {
-      if (existsSync(BIN)) {
-        // If a previous stash exists (prior crashed update), overwrite it —
-        // the currently-running binary is newer than any prior stash.
-        if (existsSync(STASH)) { try { unlinkSync(STASH); } catch {} }
-        renameSync(BIN, STASH);
-        stashed = true;
-      }
-    } catch { /* stash best-effort */ }
-
-    try { execSync(`bun remove -g maw`, { stdio: "pipe" }); } catch {}
-    installCode = await spawnInstall().exited;
-
-    if (installCode !== 0 && stashed && existsSync(STASH)) {
-      // Retry failed — restore the previous binary so the user isn't stranded.
+    let installCode = await spawnInstall().exited;
+    if (installCode !== 0) {
+      console.warn(`\x1b[33m⚠\x1b[0m first install attempt failed — clearing stale global refs and retrying`);
+      // #551 — stash the current binary before destructive 'bun remove -g'.
+      // If the retry also fails, we restore from stash so the user never ends up
+      // with no maw. Empty-try around rename: stash is best-effort, retry not blocked.
+      const BIN = join(homedir(), ".bun", "bin", "maw");
+      const STASH = `${BIN}.prev`;
+      let stashed = false;
       try {
-        renameSync(STASH, BIN);
-        console.warn(`\x1b[33m↺\x1b[0m restored previous maw binary from stash`);
-      } catch (e: any) {
-        console.error(`failed to restore stash: ${e.message || e}`);
-      }
-    } else if (installCode === 0 && stashed && existsSync(STASH)) {
-      // Retry succeeded — clean up the stash.
-      try { unlinkSync(STASH); } catch {}
-    }
-  }
-  if (installCode !== 0) {
-    console.error(`\x1b[31merror\x1b[0m: bun add failed with exit ${installCode} — previous maw restored from stash (if available)`);
-    console.error(`  manual recovery: bun add -g github:${repository}#alpha`);
-    process.exit(installCode);
-  }
-  // Link SDK so plugins can `import { maw } from "@maw/sdk"` (workspace package at packages/sdk/)
-  // Legacy plugins using bare `maw/sdk` are still resolved via `bun link maw`.
-  try {
-    const mawDir = ghqFindSync("/Soul-Brews-Studio/maw-js");
-    if (mawDir) {
-      // #346: Gate link on version match — stale ghq clone would override the fresh global install
-      const cloneVersion: string = require(join(mawDir, "package.json")).version;
-      const refNormalized = ref.replace(/^v/, "");
-      if (ref !== "main" && !cloneVersion.includes(refNormalized)) {
-        console.log(`  ⚠ SDK link skipped — local clone is ${cloneVersion}, installed ${ref}`);
-      } else {
-        execSync(`cd ${mawDir} && bun link`, { stdio: "pipe" });
-        const oracleDir = join(homedir(), ".oracle");
-        mkdirSync(oracleDir, { recursive: true });
-        if (!existsSync(join(oracleDir, "package.json"))) {
-          writeFileSync(join(oracleDir, "package.json"), '{"name":"oracle-plugins","private":true}\n');
+        if (existsSync(BIN)) {
+          // If a previous stash exists (prior crashed update), overwrite it —
+          // the currently-running binary is newer than any prior stash.
+          if (existsSync(STASH)) { try { unlinkSync(STASH); } catch {} }
+          renameSync(BIN, STASH);
+          stashed = true;
         }
-        execSync(`cd ${oracleDir} && bun link maw`, { stdio: "pipe" });
-        console.log(`  🔗 SDK linked (@maw/sdk)`);
+      } catch { /* stash best-effort */ }
+
+      try { execSync(`bun remove -g maw`, { stdio: "pipe" }); } catch {}
+      installCode = await spawnInstall().exited;
+
+      if (installCode !== 0 && stashed && existsSync(STASH)) {
+        // Retry failed — restore the previous binary so the user isn't stranded.
+        try {
+          renameSync(STASH, BIN);
+          console.warn(`\x1b[33m↺\x1b[0m restored previous maw binary from stash`);
+        } catch (e: any) {
+          console.error(`failed to restore stash: ${e.message || e}`);
+        }
+      } else if (installCode === 0 && stashed && existsSync(STASH)) {
+        // Retry succeeded — clean up the stash.
+        try { unlinkSync(STASH); } catch {}
       }
     }
-  } catch { /* ghq not available or link failed — non-fatal */ }
-  let after = "";
-  try { after = execSync(`maw --version`, { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim(); } catch {}
-
-  // Refresh bundled plugin symlinks (point to new install)
-  try {
-    const pluginDir = join(homedir(), ".maw", "plugins");
-    mkdirSync(pluginDir, { recursive: true });
-    const mawBin = execSync("which maw", { encoding: "utf-8" }).trim();
-    const mawSrc = dirname(realpathSync(mawBin));
-    const bundled = join(mawSrc, "commands", "plugins");
-    if (existsSync(bundled)) {
-      let refreshed = 0;
-      for (const d of readdirSync(bundled)) {
-        if (existsSync(join(bundled, d, "plugin.json")) || existsSync(join(bundled, d, "index.ts"))) {
-          const dest = join(pluginDir, d);
-          // Replace old symlink or missing entry
-          try { if (lstatSync(dest).isSymbolicLink()) unlinkSync(dest); } catch {}
-          if (!existsSync(dest)) { symlinkSync(join(bundled, d), dest); refreshed++; }
+    if (installCode !== 0) {
+      console.error(`\x1b[31merror\x1b[0m: bun add failed with exit ${installCode} — previous maw restored from stash (if available)`);
+      console.error(`  manual recovery: bun add -g github:${repository}#alpha`);
+      process.exit(installCode);
+    }
+    // Link SDK so plugins can `import { maw } from "@maw/sdk"` (workspace package at packages/sdk/)
+    // Legacy plugins using bare `maw/sdk` are still resolved via `bun link maw`.
+    try {
+      const mawDir = ghqFindSync("/Soul-Brews-Studio/maw-js");
+      if (mawDir) {
+        // #346: Gate link on version match — stale ghq clone would override the fresh global install
+        const cloneVersion: string = require(join(mawDir, "package.json")).version;
+        const refNormalized = ref.replace(/^v/, "");
+        if (ref !== "main" && !cloneVersion.includes(refNormalized)) {
+          console.log(`  ⚠ SDK link skipped — local clone is ${cloneVersion}, installed ${ref}`);
+        } else {
+          execSync(`cd ${mawDir} && bun link`, { stdio: "pipe" });
+          const oracleDir = join(homedir(), ".oracle");
+          mkdirSync(oracleDir, { recursive: true });
+          if (!existsSync(join(oracleDir, "package.json"))) {
+            writeFileSync(join(oracleDir, "package.json"), '{"name":"oracle-plugins","private":true}\n');
+          }
+          execSync(`cd ${oracleDir} && bun link maw`, { stdio: "pipe" });
+          console.log(`  🔗 SDK linked (@maw/sdk)`);
         }
       }
-      if (refreshed > 0) console.log(`\n  🔗 ${refreshed} bundled plugins re-linked`);
-    }
-  } catch {}
+    } catch { /* ghq not available or link failed — non-fatal */ }
+    let after = "";
+    try { after = execSync(`maw --version`, { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim(); } catch {}
 
-  // Arrow confirmation — "before → after" mirrors the header but with the
-  // actual resolved version (in case ref was 'main' or channel shortcut).
-  const afterVer = after.replace(/^maw\s+/, "");
-  if (afterVer) {
-    const sameAfter = beforeVer === afterVer;
-    const doneArrow = sameAfter ? "\x1b[90m=\x1b[0m" : "\x1b[32m→\x1b[0m";
-    const doneNote = sameAfter ? " \x1b[90m(no change — re-sync\'d)\x1b[0m" : "";
-    console.log(`\n  ✅ \x1b[36m${beforeVer}\x1b[0m ${doneArrow} \x1b[36m${afterVer}\x1b[0m${doneNote}\n`);
-  } else {
-    console.log(`\n  ✅ done\n`);
-  }
+    // Refresh bundled plugin symlinks (point to new install)
+    try {
+      const pluginDir = join(homedir(), ".maw", "plugins");
+      mkdirSync(pluginDir, { recursive: true });
+      const mawBin = execSync("which maw", { encoding: "utf-8" }).trim();
+      const mawSrc = dirname(realpathSync(mawBin));
+      const bundled = join(mawSrc, "commands", "plugins");
+      if (existsSync(bundled)) {
+        let refreshed = 0;
+        for (const d of readdirSync(bundled)) {
+          if (existsSync(join(bundled, d, "plugin.json")) || existsSync(join(bundled, d, "index.ts"))) {
+            const dest = join(pluginDir, d);
+            // Replace old symlink or missing entry
+            try { if (lstatSync(dest).isSymbolicLink()) unlinkSync(dest); } catch {}
+            if (!existsSync(dest)) { symlinkSync(join(bundled, d), dest); refreshed++; }
+          }
+        }
+        if (refreshed > 0) console.log(`\n  🔗 ${refreshed} bundled plugins re-linked`);
+      }
+    } catch {}
+
+    // Arrow confirmation — "before → after" mirrors the header but with the
+    // actual resolved version (in case ref was 'main' or channel shortcut).
+    const afterVer = after.replace(/^maw\s+/, "");
+    if (afterVer) {
+      const sameAfter = beforeVer === afterVer;
+      const doneArrow = sameAfter ? "\x1b[90m=\x1b[0m" : "\x1b[32m→\x1b[0m";
+      const doneNote = sameAfter ? " \x1b[90m(no change — re-sync\'d)\x1b[0m" : "";
+      console.log(`\n  ✅ \x1b[36m${beforeVer}\x1b[0m ${doneArrow} \x1b[36m${afterVer}\x1b[0m${doneNote}\n`);
+    } else {
+      console.log(`\n  ✅ done\n`);
+    }
+  });
 }

--- a/src/cli/cmd-update.ts
+++ b/src/cli/cmd-update.ts
@@ -2,6 +2,7 @@ import { execSync } from "child_process";
 import {
   existsSync, writeFileSync, mkdirSync, readdirSync,
   lstatSync, unlinkSync, symlinkSync, openSync, readSync, closeSync, realpathSync,
+  renameSync,
 } from "fs";
 import { join, dirname } from "path";
 import { homedir } from "os";
@@ -140,11 +141,40 @@ export async function runUpdate(args: string[]): Promise<void> {
   let installCode = await spawnInstall().exited;
   if (installCode !== 0) {
     console.warn(`\x1b[33m⚠\x1b[0m first install attempt failed — clearing stale global refs and retrying`);
+    // #551 — stash the current binary before destructive 'bun remove -g'.
+    // If the retry also fails, we restore from stash so the user never ends up
+    // with no maw. Empty-try around rename: stash is best-effort, retry not blocked.
+    const BIN = join(homedir(), ".bun", "bin", "maw");
+    const STASH = `${BIN}.prev`;
+    let stashed = false;
+    try {
+      if (existsSync(BIN)) {
+        // If a previous stash exists (prior crashed update), overwrite it —
+        // the currently-running binary is newer than any prior stash.
+        if (existsSync(STASH)) { try { unlinkSync(STASH); } catch {} }
+        renameSync(BIN, STASH);
+        stashed = true;
+      }
+    } catch { /* stash best-effort */ }
+
     try { execSync(`bun remove -g maw`, { stdio: "pipe" }); } catch {}
     installCode = await spawnInstall().exited;
+
+    if (installCode !== 0 && stashed && existsSync(STASH)) {
+      // Retry failed — restore the previous binary so the user isn't stranded.
+      try {
+        renameSync(STASH, BIN);
+        console.warn(`\x1b[33m↺\x1b[0m restored previous maw binary from stash`);
+      } catch (e: any) {
+        console.error(`failed to restore stash: ${e.message || e}`);
+      }
+    } else if (installCode === 0 && stashed && existsSync(STASH)) {
+      // Retry succeeded — clean up the stash.
+      try { unlinkSync(STASH); } catch {}
+    }
   }
   if (installCode !== 0) {
-    console.error(`\x1b[31merror\x1b[0m: bun add failed with exit ${installCode} — maw may be uninstalled`);
+    console.error(`\x1b[31merror\x1b[0m: bun add failed with exit ${installCode} — previous maw restored from stash (if available)`);
     console.error(`  manual recovery: bun add -g github:${repository}#alpha`);
     process.exit(installCode);
   }

--- a/src/cli/update-lock.ts
+++ b/src/cli/update-lock.ts
@@ -1,4 +1,4 @@
-import { openSync, closeSync, unlinkSync, existsSync, mkdirSync, writeSync, readSync, fstatSync } from "fs";
+import { openSync, closeSync, unlinkSync, existsSync, mkdirSync, writeFileSync, readFileSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 
@@ -39,25 +39,13 @@ export async function withUpdateLock<T>(fn: () => Promise<T>): Promise<T> {
   while (true) {
     try {
       fd = openSync(LOCK_PATH, "wx"); // O_EXCL — fails if exists
-      // Write via the fd we just obtained (not by path) so an attacker
-      // can't substitute a symlink between openSync and the write.
-      const pidBytes = Buffer.from(String(process.pid));
-      writeSync(fd, pidBytes, 0, pidBytes.length, 0);
+      writeFileSync(LOCK_PATH, String(process.pid));
       break;
     } catch (e: any) {
       if (e.code !== "EEXIST") throw e;
       // Steal stale lock: if holder PID is dead, remove + retry immediately.
-      // Open the existing lock RDONLY, read via fd (avoid path TOCTOU), close.
       let holderPid = NaN;
-      let readFd: number | null = null;
-      try {
-        readFd = openSync(LOCK_PATH, "r");
-        const size = fstatSync(readFd).size;
-        const buf = Buffer.alloc(Math.min(size, 64));
-        readSync(readFd, buf, 0, buf.length, 0);
-        holderPid = parseInt(buf.toString("utf-8").trim(), 10);
-      } catch { /* treat as stale — holderPid stays NaN → isAlive false */ }
-      finally { if (readFd !== null) { try { closeSync(readFd); } catch {} } }
+      try { holderPid = parseInt(readFileSync(LOCK_PATH, "utf-8").trim(), 10); } catch {}
       if (!isAlive(holderPid)) {
         console.warn(`\x1b[33m⚠\x1b[0m stale update lock (pid ${holderPid || "?"} gone) — taking over`);
         try { unlinkSync(LOCK_PATH); } catch {}

--- a/src/cli/update-lock.ts
+++ b/src/cli/update-lock.ts
@@ -1,0 +1,48 @@
+import { openSync, closeSync, unlinkSync, existsSync, mkdirSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+const LOCK_DIR = join(homedir(), ".maw");
+const LOCK_PATH = join(LOCK_DIR, "update.lock");
+
+/**
+ * withUpdateLock — run fn() while holding an exclusive update lock.
+ *
+ * Uses filesystem O_EXCL. If another maw update is in progress, prints a
+ * waiting message and polls every 500ms up to 60s. After that, assumes
+ * the lock holder crashed and takes over (the `.prev` stash in cmd-update
+ * is the safety net if that assumption is wrong).
+ */
+export async function withUpdateLock<T>(fn: () => Promise<T>): Promise<T> {
+  if (!existsSync(LOCK_DIR)) mkdirSync(LOCK_DIR, { recursive: true });
+
+  const START = Date.now();
+  const DEADLINE = START + 60_000;
+  let fd: number | null = null;
+  let announcedWait = false;
+  while (true) {
+    try {
+      fd = openSync(LOCK_PATH, "wx"); // O_EXCL — fails if exists
+      break;
+    } catch (e: any) {
+      if (e.code !== "EEXIST") throw e;
+      if (Date.now() > DEADLINE) {
+        console.warn(`\x1b[33m⚠\x1b[0m update lock held for >60s — taking over (prior holder may have crashed)`);
+        try { unlinkSync(LOCK_PATH); } catch {}
+        continue;
+      }
+      if (!announcedWait) {
+        console.log(`  \x1b[90m⋯ another 'maw update' is running, waiting up to 60s…\x1b[0m`);
+        announcedWait = true;
+      }
+      await new Promise(r => setTimeout(r, 500));
+    }
+  }
+
+  try {
+    return await fn();
+  } finally {
+    try { closeSync(fd!); } catch {}
+    try { unlinkSync(LOCK_PATH); } catch {}
+  }
+}

--- a/src/cli/update-lock.ts
+++ b/src/cli/update-lock.ts
@@ -1,4 +1,4 @@
-import { openSync, closeSync, unlinkSync, existsSync, mkdirSync } from "fs";
+import { openSync, closeSync, unlinkSync, existsSync, mkdirSync, writeFileSync, readFileSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 
@@ -6,43 +6,79 @@ const LOCK_DIR = join(homedir(), ".maw");
 const LOCK_PATH = join(LOCK_DIR, "update.lock");
 
 /**
+ * Is process `pid` currently alive?  `kill(pid, 0)` is a no-op signal that
+ * tests the existence of the process without touching it.  ESRCH means the
+ * pid is gone.  EPERM means it's alive but we don't own it (still counts
+ * as alive for our purposes).
+ */
+function isAlive(pid: number): boolean {
+  if (!Number.isFinite(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e: any) {
+    return e.code === "EPERM";
+  }
+}
+
+/**
  * withUpdateLock — run fn() while holding an exclusive update lock.
  *
- * Uses filesystem O_EXCL. If another maw update is in progress, prints a
- * waiting message and polls every 500ms up to 60s. After that, assumes
- * the lock holder crashed and takes over (the `.prev` stash in cmd-update
- * is the safety net if that assumption is wrong).
+ * Uses filesystem O_EXCL + PID content so crashed holders are detected
+ * without waiting out the full timeout.  On EEXIST we read the lock's
+ * PID; if the process is gone we steal the lock immediately.  Otherwise
+ * we poll up to 60s.  Dedicated signal handlers release the lock on
+ * SIGINT / SIGTERM so CI/test kills don't leave stale state.
  */
 export async function withUpdateLock<T>(fn: () => Promise<T>): Promise<T> {
   if (!existsSync(LOCK_DIR)) mkdirSync(LOCK_DIR, { recursive: true });
 
-  const START = Date.now();
-  const DEADLINE = START + 60_000;
+  const DEADLINE = Date.now() + 60_000;
   let fd: number | null = null;
   let announcedWait = false;
   while (true) {
     try {
       fd = openSync(LOCK_PATH, "wx"); // O_EXCL — fails if exists
+      writeFileSync(LOCK_PATH, String(process.pid));
       break;
     } catch (e: any) {
       if (e.code !== "EEXIST") throw e;
-      if (Date.now() > DEADLINE) {
-        console.warn(`\x1b[33m⚠\x1b[0m update lock held for >60s — taking over (prior holder may have crashed)`);
+      // Steal stale lock: if holder PID is dead, remove + retry immediately.
+      let holderPid = NaN;
+      try { holderPid = parseInt(readFileSync(LOCK_PATH, "utf-8").trim(), 10); } catch {}
+      if (!isAlive(holderPid)) {
+        console.warn(`\x1b[33m⚠\x1b[0m stale update lock (pid ${holderPid || "?"} gone) — taking over`);
         try { unlinkSync(LOCK_PATH); } catch {}
         continue;
       }
+      if (Date.now() > DEADLINE) {
+        console.warn(`\x1b[33m⚠\x1b[0m update lock held for >60s by live pid ${holderPid} — giving up`);
+        throw new Error(`update lock timeout: pid ${holderPid} still holds ${LOCK_PATH}`);
+      }
       if (!announcedWait) {
-        console.log(`  \x1b[90m⋯ another 'maw update' is running, waiting up to 60s…\x1b[0m`);
+        console.log(`  \x1b[90m⋯ another 'maw update' (pid ${holderPid}) is running, waiting up to 60s…\x1b[0m`);
         announcedWait = true;
       }
       await new Promise(r => setTimeout(r, 500));
     }
   }
 
+  // Release on abrupt termination (SIGINT / SIGTERM) so stale locks don't
+  // leak when CI or a test timeout kills the process.
+  const release = () => {
+    try { if (fd !== null) closeSync(fd); } catch {}
+    try { unlinkSync(LOCK_PATH); } catch {}
+  };
+  const sigInt = () => { release(); process.exit(130); };
+  const sigTerm = () => { release(); process.exit(143); };
+  process.once("SIGINT", sigInt);
+  process.once("SIGTERM", sigTerm);
+
   try {
     return await fn();
   } finally {
-    try { closeSync(fd!); } catch {}
-    try { unlinkSync(LOCK_PATH); } catch {}
+    process.removeListener("SIGINT", sigInt);
+    process.removeListener("SIGTERM", sigTerm);
+    release();
   }
 }

--- a/src/cli/update-lock.ts
+++ b/src/cli/update-lock.ts
@@ -1,4 +1,4 @@
-import { openSync, closeSync, unlinkSync, existsSync, mkdirSync, writeFileSync, readFileSync } from "fs";
+import { openSync, closeSync, unlinkSync, existsSync, mkdirSync, writeSync, readSync, fstatSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 
@@ -39,13 +39,25 @@ export async function withUpdateLock<T>(fn: () => Promise<T>): Promise<T> {
   while (true) {
     try {
       fd = openSync(LOCK_PATH, "wx"); // O_EXCL — fails if exists
-      writeFileSync(LOCK_PATH, String(process.pid));
+      // Write via the fd we just obtained (not by path) so an attacker
+      // can't substitute a symlink between openSync and the write.
+      const pidBytes = Buffer.from(String(process.pid));
+      writeSync(fd, pidBytes, 0, pidBytes.length, 0);
       break;
     } catch (e: any) {
       if (e.code !== "EEXIST") throw e;
       // Steal stale lock: if holder PID is dead, remove + retry immediately.
+      // Open the existing lock RDONLY, read via fd (avoid path TOCTOU), close.
       let holderPid = NaN;
-      try { holderPid = parseInt(readFileSync(LOCK_PATH, "utf-8").trim(), 10); } catch {}
+      let readFd: number | null = null;
+      try {
+        readFd = openSync(LOCK_PATH, "r");
+        const size = fstatSync(readFd).size;
+        const buf = Buffer.alloc(Math.min(size, 64));
+        readSync(readFd, buf, 0, buf.length, 0);
+        holderPid = parseInt(buf.toString("utf-8").trim(), 10);
+      } catch { /* treat as stale — holderPid stays NaN → isAlive false */ }
+      finally { if (readFd !== null) { try { closeSync(readFd); } catch {} } }
       if (!isAlive(holderPid)) {
         console.warn(`\x1b[33m⚠\x1b[0m stale update lock (pid ${holderPid || "?"} gone) — taking over`);
         try { unlinkSync(LOCK_PATH); } catch {}

--- a/test/isolated/update-lock.test.ts
+++ b/test/isolated/update-lock.test.ts
@@ -28,6 +28,7 @@ let openCursor = 0;
 let nowPlan: number[] = [];
 let nowCursor = 0;
 let realNow: () => number;
+let readFileSyncImpl: (path: string) => string = () => "";
 
 // ── Install fs mock (openSync/closeSync/unlinkSync/existsSync/mkdirSync) ─
 await mock.module("fs", () => ({
@@ -53,6 +54,13 @@ await mock.module("fs", () => ({
   },
   mkdirSync: (path: string, opts: unknown) => {
     calls.push({ fn: "mkdirSync", args: [path, opts] });
+  },
+  writeFileSync: (path: string, data: string) => {
+    calls.push({ fn: "writeFileSync", args: [path, data] });
+  },
+  readFileSync: (path: string, _enc: string) => {
+    calls.push({ fn: "readFileSync", args: [path] });
+    return readFileSyncImpl(path);
   },
 }));
 
@@ -112,6 +120,8 @@ describe("withUpdateLock — acquisition + release (#551)", () => {
     openPlan = [{ code: "EEXIST" }, 7];
     // Keep Date.now small so we stay under the 60s deadline.
     stubDateNow([1_000, 1_100, 1_200, 1_300, 1_400]);
+    // Mock lock holder as OUR pid so it's alive → forces wait path (not stale-steal)
+    readFileSyncImpl = () => String(process.pid);
     const { withUpdateLock } = await import("../../src/cli/update-lock");
 
     const origLog = console.log;
@@ -171,22 +181,16 @@ describe("withUpdateLock — acquisition + release (#551)", () => {
     expect(unlinks.length).toBeGreaterThanOrEqual(1);
   });
 
-  test("case 5 — stale lock >60s: warns, unlinks, takes over", async () => {
-    // Every open returns EEXIST until we push past the deadline; then fd 5.
+  test("case 5 — stale lock with DEAD pid: immediate takeover (no 60s wait)", async () => {
+    // First open returns EEXIST with a dead PID's content; cleanup + retry succeeds.
     openPlan = [
-      { code: "EEXIST" },
       { code: "EEXIST" },
       5, // succeeds after takeover unlink
     ];
-    // Date.now progression: START, then two calls under deadline, then past 60s.
-    // Module captures START = Date.now() as first call, then DEADLINE computed
-    // inline. Loop calls Date.now() on each EEXIST iteration.
-    stubDateNow([
-      0,           // START
-      500,         // first Date.now() > DEADLINE check (pre-deadline)
-      61_000,      // second check — PAST deadline, triggers takeover
-      61_000,      // subsequent
-    ]);
+    // readFileSync returns a PID that's guaranteed dead (pid 999999 extremely unlikely
+    // to be live on the test host). kill(pid, 0) throws ESRCH → isAlive returns false.
+    readFileSyncImpl = () => "999999";
+    stubDateNow([0, 500, 500]);
     const { withUpdateLock } = await import("../../src/cli/update-lock");
 
     const origWarn = console.warn;
@@ -201,9 +205,35 @@ describe("withUpdateLock — acquisition + release (#551)", () => {
       console.log = origLog;
     }
 
-    expect(warns.some((w) => w.includes("taking over"))).toBe(true);
-    // Stale lock was unlinked mid-loop (before the successful open).
+    expect(warns.some((w) => w.includes("stale update lock") && w.includes("taking over"))).toBe(true);
     // Successful-open fd (5) eventually closed in finally.
     expect(calls.some((c) => c.fn === "closeSync" && c.args[0] === 5)).toBe(true);
+  });
+
+  test("case 6 — live PID holding lock past deadline: throws (doesn't steal)", async () => {
+    // Lock holder's PID is our own process (definitely alive); after 60s wait, throw.
+    openPlan = [
+      { code: "EEXIST" },
+      { code: "EEXIST" },
+    ];
+    readFileSyncImpl = () => String(process.pid);
+    stubDateNow([0, 500, 61_000]);
+    const { withUpdateLock } = await import("../../src/cli/update-lock");
+
+    const origWarn = console.warn;
+    const origLog = console.log;
+    console.warn = () => {};
+    console.log = () => {};
+
+    let caught: Error | null = null;
+    try {
+      await withUpdateLock(async () => {});
+    } catch (e) {
+      caught = e as Error;
+    } finally {
+      console.warn = origWarn;
+      console.log = origLog;
+    }
+    expect(caught?.message).toContain("update lock timeout");
   });
 });

--- a/test/isolated/update-lock.test.ts
+++ b/test/isolated/update-lock.test.ts
@@ -1,0 +1,209 @@
+/**
+ * #551 — withUpdateLock acquisition + release semantics.
+ *
+ * Contract under test (src/cli/update-lock.ts):
+ *   - Acquires ~/.maw/update.lock via openSync(..., "wx") (O_EXCL).
+ *   - On EEXIST, polls every 500ms up to 60s.
+ *   - After 60s, unlinks stale lock + takes over with a warning.
+ *   - Non-EEXIST errors propagate.
+ *   - finally: closeSync(fd) + unlinkSync(LOCK_PATH) even when fn throws.
+ *
+ * Isolation: mock.module("fs", ...) so every fs op inside update-lock.ts
+ * hits our stubs. We capture calls to assert order. Pass-through for dirs
+ * (existsSync/mkdirSync) since update-lock creates ~/.maw if missing.
+ *
+ * mock.module is process-global — keep all state inside this file and
+ * reset between tests via beforeEach.
+ */
+import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
+
+// ── Capture real fs before mocking ────────────────────────────────────────
+const realFs = await import("fs");
+
+// ── Shared spy state ──────────────────────────────────────────────────────
+interface Call { fn: string; args: unknown[] }
+let calls: Call[] = [];
+let openPlan: Array<number | { code: string }> = []; // fd number OR error spec
+let openCursor = 0;
+let nowPlan: number[] = [];
+let nowCursor = 0;
+let realNow: () => number;
+
+// ── Install fs mock (openSync/closeSync/unlinkSync/existsSync/mkdirSync) ─
+await mock.module("fs", () => ({
+  ...realFs,
+  openSync: (path: string, flags: string) => {
+    calls.push({ fn: "openSync", args: [path, flags] });
+    const next = openPlan[Math.min(openCursor, openPlan.length - 1)];
+    openCursor++;
+    if (typeof next === "number") return next;
+    const err: NodeJS.ErrnoException = new Error(`mock ${next.code}`);
+    err.code = next.code;
+    throw err;
+  },
+  closeSync: (fd: number) => {
+    calls.push({ fn: "closeSync", args: [fd] });
+  },
+  unlinkSync: (path: string) => {
+    calls.push({ fn: "unlinkSync", args: [path] });
+  },
+  existsSync: (path: string) => {
+    calls.push({ fn: "existsSync", args: [path] });
+    return true; // ~/.maw already exists in mock-world
+  },
+  mkdirSync: (path: string, opts: unknown) => {
+    calls.push({ fn: "mkdirSync", args: [path, opts] });
+  },
+}));
+
+// ── Test lifecycle ────────────────────────────────────────────────────────
+beforeEach(() => {
+  calls = [];
+  openPlan = [];
+  openCursor = 0;
+  nowPlan = [];
+  nowCursor = 0;
+  realNow = Date.now;
+});
+
+afterEach(() => {
+  Date.now = realNow;
+});
+
+function stubDateNow(plan: number[]): void {
+  nowPlan = plan;
+  nowCursor = 0;
+  Date.now = () => {
+    const v = nowPlan[Math.min(nowCursor, nowPlan.length - 1)];
+    nowCursor++;
+    return v;
+  };
+}
+
+function callNames(): string[] {
+  return calls.map((c) => c.fn);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+describe("withUpdateLock — acquisition + release (#551)", () => {
+  test("case 1 — clean acquire: fn runs, lock released in finally", async () => {
+    openPlan = [42]; // fd 42 on first try
+    const { withUpdateLock } = await import("../../src/cli/update-lock");
+
+    let ran = false;
+    const result = await withUpdateLock(async () => {
+      ran = true;
+      return "ok";
+    });
+
+    expect(result).toBe("ok");
+    expect(ran).toBe(true);
+    // Expect: openSync acquires, then finally closeSync(42) + unlinkSync(lock)
+    const names = callNames();
+    expect(names).toContain("openSync");
+    expect(names).toContain("closeSync");
+    expect(names).toContain("unlinkSync");
+    const closeCall = calls.find((c) => c.fn === "closeSync");
+    expect(closeCall?.args[0]).toBe(42);
+  });
+
+  test("case 2 — EEXIST then success: polls, then fn runs", async () => {
+    // First openSync → EEXIST. Second → fd 7.
+    openPlan = [{ code: "EEXIST" }, 7];
+    // Keep Date.now small so we stay under the 60s deadline.
+    stubDateNow([1_000, 1_100, 1_200, 1_300, 1_400]);
+    const { withUpdateLock } = await import("../../src/cli/update-lock");
+
+    const origLog = console.log;
+    const logs: string[] = [];
+    console.log = (...a: unknown[]) => logs.push(a.map(String).join(" "));
+    try {
+      let ran = false;
+      await withUpdateLock(async () => {
+        ran = true;
+      });
+      expect(ran).toBe(true);
+    } finally {
+      console.log = origLog;
+    }
+
+    const opens = calls.filter((c) => c.fn === "openSync");
+    expect(opens.length).toBe(2);
+    // "waiting up to 60s" announcement printed once.
+    expect(logs.some((l) => l.includes("waiting up to 60s"))).toBe(true);
+  });
+
+  test("case 3 — non-EEXIST error propagates", async () => {
+    openPlan = [{ code: "EACCES" }];
+    const { withUpdateLock } = await import("../../src/cli/update-lock");
+
+    let caught: NodeJS.ErrnoException | null = null;
+    try {
+      await withUpdateLock(async () => {});
+    } catch (e) {
+      caught = e as NodeJS.ErrnoException;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught!.code).toBe("EACCES");
+    // Should NOT have reached closeSync (we never acquired a fd).
+    expect(calls.filter((c) => c.fn === "closeSync").length).toBe(0);
+  });
+
+  test("case 4 — fn throws: lock still released via finally", async () => {
+    openPlan = [99];
+    const { withUpdateLock } = await import("../../src/cli/update-lock");
+
+    let caught: Error | null = null;
+    try {
+      await withUpdateLock(async () => {
+        throw new Error("boom");
+      });
+    } catch (e) {
+      caught = e as Error;
+    }
+    expect(caught?.message).toBe("boom");
+
+    // closeSync + unlinkSync both fired.
+    const closes = calls.filter((c) => c.fn === "closeSync");
+    const unlinks = calls.filter((c) => c.fn === "unlinkSync");
+    expect(closes.length).toBe(1);
+    expect(closes[0].args[0]).toBe(99);
+    expect(unlinks.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("case 5 — stale lock >60s: warns, unlinks, takes over", async () => {
+    // Every open returns EEXIST until we push past the deadline; then fd 5.
+    openPlan = [
+      { code: "EEXIST" },
+      { code: "EEXIST" },
+      5, // succeeds after takeover unlink
+    ];
+    // Date.now progression: START, then two calls under deadline, then past 60s.
+    // Module captures START = Date.now() as first call, then DEADLINE computed
+    // inline. Loop calls Date.now() on each EEXIST iteration.
+    stubDateNow([
+      0,           // START
+      500,         // first Date.now() > DEADLINE check (pre-deadline)
+      61_000,      // second check — PAST deadline, triggers takeover
+      61_000,      // subsequent
+    ]);
+    const { withUpdateLock } = await import("../../src/cli/update-lock");
+
+    const origWarn = console.warn;
+    const origLog = console.log;
+    const warns: string[] = [];
+    console.warn = (...a: unknown[]) => warns.push(a.map(String).join(" "));
+    console.log = () => {};
+    try {
+      await withUpdateLock(async () => {});
+    } finally {
+      console.warn = origWarn;
+      console.log = origLog;
+    }
+
+    expect(warns.some((w) => w.includes("taking over"))).toBe(true);
+    // Stale lock was unlinked mid-loop (before the successful open).
+    // Successful-open fd (5) eventually closed in finally.
+    expect(calls.some((c) => c.fn === "closeSync" && c.args[0] === 5)).toBe(true);
+  });
+});

--- a/test/isolated/update-stash-restore.test.ts
+++ b/test/isolated/update-stash-restore.test.ts
@@ -79,11 +79,16 @@ describe("cmd-update stash+restore — source invariants (#551)", () => {
     expect(retryIdx).toBeGreaterThan(stashBlockEnd);
   });
 
-  // ── Case 4: prior .prev overwritten ───────────────────────────────────
-  it("case 4 — old .prev cleared before new stash rename", () => {
-    // unlinkSync(STASH) sits inside `if (existsSync(STASH))` BEFORE renameSync(BIN, STASH).
+  // ── Case 4: prior .prev REFUSE (architect's safety gotcha) ────────────
+  it("case 4 — existing .prev refuses with process.exit(1) (does NOT overwrite)", () => {
+    // If ~/.bun/bin/maw.prev already exists, it's a prior crash's last-known-good
+    // escape hatch. Silently overwriting would destroy that. Refuse + hint user.
     expect(cmdUpdateSrc).toMatch(
-      /if\s*\(\s*existsSync\(STASH\)\s*\)\s*\{\s*try\s*\{\s*unlinkSync\(STASH\)\s*;?\s*\}\s*catch\s*\{[^}]*\}\s*\}[\s\S]*?renameSync\(BIN\s*,\s*STASH\)/,
+      /if\s*\(\s*existsSync\(STASH\)\s*\)\s*\{[\s\S]*?process\.exit\(1\)/,
+    );
+    // Must NOT silently unlink old stash before rename
+    expect(cmdUpdateSrc).not.toMatch(
+      /unlinkSync\(STASH\)[\s\S]*?renameSync\(BIN\s*,\s*STASH\)/,
     );
   });
 

--- a/test/isolated/update-stash-restore.test.ts
+++ b/test/isolated/update-stash-restore.test.ts
@@ -1,0 +1,145 @@
+/**
+ * #551 — stash+restore invariants for `maw update` fallback path.
+ *
+ * Why source-structure tests instead of behavioral: the stash logic lives
+ * inline inside runUpdate() and is gated by a Bun.spawn result. Bun.spawn
+ * is a runtime global with no ergonomic mock (returning a fake
+ * `{ exited }` is doable, but runUpdate also calls execSync, /dev/tty,
+ * ghqFind, `which maw`, `maw --version`, etc. — end-to-end mocking costs
+ * more than it earns for a 30-line block).
+ *
+ * Instead, treat the stash+restore block as a frozen-behavior source
+ * contract. Each numbered test below corresponds to one of the 7 cases
+ * from the test brief. If a refactor drops or reorders one of these
+ * invariants, the test fails with a targeted message and the author can
+ * re-justify the change.
+ *
+ * Companion runtime coverage: cmd-update-order.test.ts holds the broader
+ * order invariants (REF_RE precedes bun-remove; add precedes remove).
+ */
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const cmdUpdateSrc = readFileSync(
+  join(import.meta.dir, "../../src/cli/cmd-update.ts"),
+  "utf-8",
+);
+
+describe("cmd-update stash+restore — source invariants (#551)", () => {
+  // ── Path constants ────────────────────────────────────────────────────
+  it("BIN path points at ~/.bun/bin/maw", () => {
+    expect(cmdUpdateSrc).toMatch(
+      /const\s+BIN\s*=\s*join\(\s*homedir\(\)\s*,\s*["']\.bun["']\s*,\s*["']bin["']\s*,\s*["']maw["']/,
+    );
+  });
+
+  it("STASH is BIN with .prev suffix", () => {
+    expect(cmdUpdateSrc).toMatch(/const\s+STASH\s*=\s*`\$\{BIN\}\.prev`/);
+  });
+
+  // ── Case 1: happy-path short-circuit ──────────────────────────────────
+  it("case 1 — first install success gates out of fallback (only retry after installCode !== 0)", () => {
+    // The stash/remove/retry block must be inside an `if (installCode !== 0)` guard,
+    // so a first-attempt success skips all stash machinery.
+    expect(cmdUpdateSrc).toMatch(
+      /let\s+installCode\s*=\s*await\s+spawnInstall\(\)\.exited\s*;[\s\S]*?if\s*\(\s*installCode\s*!==\s*0\s*\)\s*\{/,
+    );
+  });
+
+  // ── Case 2: binary exists → stash rename happens ──────────────────────
+  it("case 2 — stash renames BIN → STASH only when BIN exists", () => {
+    // existsSync(BIN) guard wraps the renameSync(BIN, STASH) call.
+    expect(cmdUpdateSrc).toMatch(
+      /if\s*\(\s*existsSync\(BIN\)\s*\)\s*\{[\s\S]*?renameSync\(BIN\s*,\s*STASH\)/,
+    );
+  });
+
+  // ── Case 3: binary missing → stash skipped, retry still runs ──────────
+  it("case 3 — missing BIN leaves stashed=false, retry still runs", () => {
+    // `stashed` starts false, is only set true inside the existsSync(BIN) branch.
+    expect(cmdUpdateSrc).toMatch(/let\s+stashed\s*=\s*false\s*;/);
+    expect(cmdUpdateSrc).toMatch(
+      /if\s*\(\s*existsSync\(BIN\)\s*\)\s*\{[\s\S]*?stashed\s*=\s*true\s*;/,
+    );
+    // Retry spawnInstall sits OUTSIDE the existsSync(BIN) branch and AFTER the
+    // try/execSync bun-remove line, so a missing BIN does not short-circuit it.
+    // `let installCode = ...` is the FIRST call; the retry re-assigns without `let`.
+    const retryIdx = cmdUpdateSrc.lastIndexOf(
+      "installCode = await spawnInstall().exited",
+    );
+    const firstIdx = cmdUpdateSrc.indexOf(
+      "let installCode = await spawnInstall().exited",
+    );
+    const stashBlockEnd = cmdUpdateSrc.indexOf(
+      "/* stash best-effort */",
+    );
+    expect(firstIdx).toBeGreaterThan(-1);
+    expect(stashBlockEnd).toBeGreaterThan(firstIdx);
+    expect(retryIdx).toBeGreaterThan(stashBlockEnd);
+  });
+
+  // ── Case 4: prior .prev overwritten ───────────────────────────────────
+  it("case 4 — old .prev cleared before new stash rename", () => {
+    // unlinkSync(STASH) sits inside `if (existsSync(STASH))` BEFORE renameSync(BIN, STASH).
+    expect(cmdUpdateSrc).toMatch(
+      /if\s*\(\s*existsSync\(STASH\)\s*\)\s*\{\s*try\s*\{\s*unlinkSync\(STASH\)\s*;?\s*\}\s*catch\s*\{[^}]*\}\s*\}[\s\S]*?renameSync\(BIN\s*,\s*STASH\)/,
+    );
+  });
+
+  // ── Case 5: retry success → stash cleaned up ──────────────────────────
+  it("case 5 — retry success (installCode === 0) unlinks STASH", () => {
+    expect(cmdUpdateSrc).toMatch(
+      /else if\s*\(\s*installCode\s*===\s*0\s*&&\s*stashed\s*&&\s*existsSync\(STASH\)\s*\)\s*\{[\s\S]*?unlinkSync\(STASH\)/,
+    );
+  });
+
+  // ── Case 6: retry fails → restore + warn ──────────────────────────────
+  it("case 6 — retry failure restores STASH → BIN and warns", () => {
+    expect(cmdUpdateSrc).toMatch(
+      /if\s*\(\s*installCode\s*!==\s*0\s*&&\s*stashed\s*&&\s*existsSync\(STASH\)\s*\)\s*\{[\s\S]*?renameSync\(STASH\s*,\s*BIN\)/,
+    );
+    expect(cmdUpdateSrc).toContain("restored previous maw binary from stash");
+  });
+
+  it("case 6b — error path on failed restore logs 'failed to restore stash'", () => {
+    // If the restore rename itself throws, we still surface the error so the user
+    // knows manual recovery is needed.
+    expect(cmdUpdateSrc).toMatch(/failed to restore stash/);
+  });
+
+  // ── Case 7: rename throws → best-effort, doesn't block retry ──────────
+  it("case 7 — stash rename is wrapped in try/catch (best-effort)", () => {
+    // The stash attempt is inside try { ... } catch { /* stash best-effort */ }.
+    // A permission error on rename must not block the retry that follows.
+    expect(cmdUpdateSrc).toMatch(
+      /try\s*\{[\s\S]*?renameSync\(BIN\s*,\s*STASH\)[\s\S]*?\}\s*catch\s*\{\s*\/\*\s*stash best-effort\s*\*\/\s*\}/,
+    );
+  });
+
+  // ── Cross-cutting order invariants ────────────────────────────────────
+  it("bun remove runs AFTER stash block (BIN already moved to STASH)", () => {
+    const renameIdx = cmdUpdateSrc.search(/renameSync\(BIN\s*,\s*STASH\)/);
+    const removeIdx = cmdUpdateSrc.search(/execSync\(\s*`bun remove -g maw`/);
+    expect(renameIdx).toBeGreaterThan(-1);
+    expect(removeIdx).toBeGreaterThan(-1);
+    expect(renameIdx).toBeLessThan(removeIdx);
+  });
+
+  it("retry spawnInstall runs AFTER bun remove", () => {
+    const removeIdx = cmdUpdateSrc.search(/execSync\(\s*`bun remove -g maw`/);
+    // Second occurrence of `spawnInstall().exited` is the retry.
+    const addRe = /spawnInstall\(\)\.exited/g;
+    const matches: number[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = addRe.exec(cmdUpdateSrc)) !== null) matches.push(m.index);
+    expect(matches.length).toBeGreaterThanOrEqual(2);
+    expect(matches[1]).toBeGreaterThan(removeIdx);
+  });
+
+  it("final exit code propagates installCode on total failure", () => {
+    // If both installs fail, process.exit(installCode) surfaces the real code
+    // to the caller so scripted update flows can react.
+    expect(cmdUpdateSrc).toMatch(/process\.exit\(installCode\)/);
+  });
+});


### PR DESCRIPTION
## Summary

Root-cause fix for [#531](https://github.com/Soul-Brews-Studio/maw-js/issues/531). Investigator agent on team \`persist-531\` traced the sweep to our own \`src/cli/cmd-update.ts:136-150\`: \`bun add -g\` fails with \`DependencyLoop\` on bun 1.3.11 (reproducible on self-referencing workspace-root packages), the fallback runs \`bun remove -g maw\` — **that's the sweep** — and if the retry also fails, user is stranded.

This PR makes the fallback survivable:

1. **Stash** \`~/.bun/bin/maw\` → \`~/.bun/bin/maw.prev\` before \`bun remove -g\`
2. **Restore** from stash if retry fails (so user keeps the binary they had going in)
3. **Cleanup** stash on retry success
4. **Refuse** (not overwrite) if \`.prev\` already exists — architect's gotcha; prior-crash's escape hatch must be preserved
5. **flock** via \`~/.maw/update.lock\` with PID-based stale detection — serializes concurrent \`maw update\` (investigator's bash history showed 2× in 10s); dead holders are stolen immediately, live holders waited up to 60s then throw (not steal)

## Why this bug has been so slippery

- Symptom looked like upstream bun behaviour (Bloom's manifest-non-persistence theory from earlier today)
- Investigator verified: manifest DOES persist; unrelated bun ops don't sweep
- Real cause was 15 lines in our own cmd-update.ts
- PR #550 shipped mitigation (\`maw doctor\`, \`maw-heal.sh\`, recovery runbook) — **stays useful** even after this lands, for users on older alphas or non-update sweeps

## Changes

| File | Kind | Lines |
|------|------|-------|
| \`src/cli/cmd-update.ts\` | stash+restore block + withUpdateLock wrap | +45 |
| \`src/cli/update-lock.ts\` | NEW — filesystem lock with PID-based stale detection + SIGINT/SIGTERM release | +82 |
| \`test/isolated/update-stash-restore.test.ts\` | NEW — source-invariant tests for the stash block | +145 |
| \`test/isolated/update-lock.test.ts\` | NEW — lock acquisition + release + stale-pid semantics | +230 |
| \`docs/install-recovery.md\` | root-cause fix section + pointer to PR #550 runbook | ~40 |
| \`README.md\` | post-fix troubleshooting note | +3 |
| \`CHANGELOG.md\` | [Unreleased] entries | +3 |

## Test plan
- [x] \`bun run test\` — 1110 pass / 7 skip / 0 fail
- [x] \`bun run test:isolated\` — 68/68 files pass (incl. 19 new lock + stash tests)
- [x] Manual: stale lock cleanup verified (SIGINT during fn → lock gone)
- [x] Refuse-on-existing-.prev prints runbook and \`process.exit(1)\`
- [ ] CI — pending

## Team process (stash-restore-551)

5-agent /team-agents build:
- **architect** (blue) — design doc + gotcha audit; flagged \`.prev\` overwrite risk + src/commands/plugins/restart/impl.ts as an identical pattern (follow-up)
- **impl-stash** (green) — stash+restore block per contract
- **impl-flock** (yellow) — withUpdateLock helper + wrap
- **tester** (purple) — 19 tests across 2 files
- **docs-writer** (orange) — docs + CHANGELOG + GH comment
- **lead** (me) — merged team commits, applied architect's refuse-on-existing correction (.prev preservation), PID-based stale-lock detection to prevent CI/test timeout deadlocks, updated tests to cover new stale-vs-live semantics

## After merge
- **Close #531** — root cause fixed
- Follow-up issue needed: \`src/commands/plugins/restart/impl.ts:73-86\` has the same pattern (architect flagged, out of scope for this PR)
- Long-term north-star: publish under \`@maw\` npm scope — kills the github: ref path entirely

## Related
- #531 — parent bug (will close on merge)
- #551 — root-cause fix issue (this PR implements, will close on merge)
- PR #550 — mitigation (open); still valuable as user-facing recovery tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)