### PR TITLE
rename: npm package 'maw' → 'maw-js' (fixes #554, closes #555)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@ Pre-1.0 alpha releases may introduce breaking changes at any time.
 
 ## [Unreleased]
 
+### Changed
+- **Renamed npm package** `maw` → `maw-js` to eliminate bun `DependencyLoop` caused by collision with unrelated stale `maw@0.6.0` on npm. Binary name unchanged — users still run `maw`. Fixes #554, closes #555, eliminates root cause of #531.
+
 ### Added
-- `docs/install-recovery.md` — runbook for `maw: command not found` recovery, plus README pointer (#531 mitigation ship; root cause still under investigation)
+- `docs/install-recovery.md` — runbook for `maw: command not found` recovery, plus README pointer (#531 mitigation ship; root cause fixed by package rename above)
 
 ## [v2.0.0-alpha.134] - 2026-04-18
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "maw",
+  "name": "maw-js",
   "version": "2.0.0-alpha.137",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",


### PR DESCRIPTION
## Summary
- Rename npm package `maw` → `maw-js` to eliminate bun `DependencyLoop` root cause
- 2 files changed (package.json name + CHANGELOG entry), +5 / -2 LOC
- Binary name unchanged — users still type `maw`

## Why

Our package.json declared `"name": "maw"`. npm has an unrelated stale `maw@0.6.0` ("Make a website with Handlebars, LESS, and JS modules", 8+ years, no author). Every bun install caches that `maw@0.6.0`; when bun then resolves our github install, the cached npm package mixes in → `DependencyLoop` error, install fails.

`maw-js` is unclaimed on npm (verified 2026-04-18: HTTP 404 on registry.npmjs.org/maw-js).

## Relationship to #552 / #531

- **#552** (stash-restore + flock) mitigates the symptom when bun fails — stash binary, retry, restore. Belt-and-suspenders.
- **This PR** eliminates the root cause. Once merged + published to npm, the DependencyLoop cannot occur in the first place.
- Confirmed as true #531 root cause via cross-oracle review (white:mawjs).

## Test plan

- [x] `bun run test` locally: 1110 pass / 0 fail / 7 skip
- [ ] CI: full `bun run test:all` (test + test:isolated + test:mock-smoke + test:plugin)
- [ ] Post-merge manual: `npm publish` (needs npm credentials)
- [ ] Post-publish manual: `bun add -g maw-js` on a machine with stale bun cache — verify no DependencyLoop

## Followups (not in this PR)

- #556 — SDK rename `@maw/sdk` → `@maw-js/sdk` (bigger, 4-6 files)
- Actual `npm publish` of `maw-js`
- Claim `@maw-js` npm scope to lock down the namespace

## Out of scope

- Version bump — still `2.0.0-alpha.137`. Release strategy (alpha.138 semver vs v26.4.18 CalVer) is a separate decision per white:mawjs's 12:32 heads-up.