### PR TITLE
rename: @maw/sdk → @maw-js/sdk (closes #556)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
       },
     },
     "packages/sdk": {
-      "name": "@maw/sdk",
+      "name": "@maw-js/sdk",
       "version": "1.0.0-alpha.1",
     },
   },
@@ -149,7 +149,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@maw/sdk": ["@maw/sdk@workspace:packages/sdk"],
+    "@maw-js/sdk": ["@maw-js/sdk@workspace:packages/sdk"],
 
     "@monaco-editor/loader": ["@monaco-editor/loader@1.7.0", "", { "dependencies": { "state-local": "^1.0.6" } }, "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA=="],
 

--- a/packages/sdk/DECISION-339.md
+++ b/packages/sdk/DECISION-339.md
@@ -1,4 +1,4 @@
-# Decision: @maw/sdk npm publish strategy (issue #339)
+# Decision: @maw-js/sdk npm publish strategy (issue #339)
 
 ## Owner identity
 
@@ -34,6 +34,6 @@ Best of both: plugin authors get the stable typed API today; runtime lands in `1
 ## Phase B graduation plan (#340)
 
 1. Ship runtime implementation alongside types
-2. Re-export from `@maw/sdk` without breaking the existing types API
+2. Re-export from `@maw-js/sdk` without breaking the existing types API
 3. Bump to `1.0.0` stable, remove `-alpha` pre-release tag
 4. Update `PUBLISH.md` with stable publishing cadence

--- a/packages/sdk/PUBLISH.md
+++ b/packages/sdk/PUBLISH.md
@@ -1,4 +1,4 @@
-# Publishing @maw/sdk
+# Publishing @maw-js/sdk
 
 ## One-time setup (run once, not in CI)
 
@@ -13,7 +13,7 @@ If `maw` scope is already taken on npm, use `@maw-sdk` as fallback and update `n
 
 ### 2. Set the NPM_TOKEN secret
 
-Generate a granular access token on npmjs.com (Automation type, scoped to `@maw/sdk`), then:
+Generate a granular access token on npmjs.com (Automation type, scoped to `@maw-js/sdk`), then:
 
 ```bash
 gh secret set NPM_TOKEN --repo Soul-Brews-Studio/maw-js
@@ -30,20 +30,20 @@ gh secret set NPM_TOKEN --repo Soul-Brews-Studio/maw-js
    git push origin sdk-vX.Y.Z
    ```
 4. GitHub Actions workflow `publish-sdk.yml` triggers automatically.
-5. Verify: `npm view @maw/sdk`
+5. Verify: `npm view @maw-js/sdk`
 
 ## Rollback / unpublish window
 
 npm allows unpublish within **72 hours** of publish:
 
 ```bash
-npm unpublish @maw/sdk@X.Y.Z
+npm unpublish @maw-js/sdk@X.Y.Z
 ```
 
 After 72 hours, deprecate instead:
 
 ```bash
-npm deprecate @maw/sdk@X.Y.Z "use X.Y.Z+1"
+npm deprecate @maw-js/sdk@X.Y.Z "use X.Y.Z+1"
 ```
 
 ## Phase B graduation (see #340)

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,4 +1,4 @@
-# @maw/sdk
+# @maw-js/sdk
 
 Stable typed API for [maw-js](https://github.com/Soul-Brews-Studio/maw-js) plugin authors — Multi-Agent Workflow orchestration in Bun/TS.
 
@@ -7,7 +7,7 @@ Stable typed API for [maw-js](https://github.com/Soul-Brews-Studio/maw-js) plugi
 ## Install
 
 ```bash
-bun add @maw/sdk
+bun add @maw-js/sdk
 ```
 
 ## Usage
@@ -15,7 +15,7 @@ bun add @maw/sdk
 ### Authoring a plugin
 
 ```ts
-import type { InvokeContext, InvokeResult } from "@maw/sdk/plugin";
+import type { InvokeContext, InvokeResult } from "@maw-js/sdk/plugin";
 
 export default async function (ctx: InvokeContext): Promise<InvokeResult> {
   return { ok: true, output: "hello from sdk" };
@@ -25,7 +25,7 @@ export default async function (ctx: InvokeContext): Promise<InvokeResult> {
 ### Calling the host SDK
 
 ```ts
-import { maw } from "@maw/sdk";
+import { maw } from "@maw-js/sdk";
 
 const id = await maw.identity();
 console.log(id.node, id.version);

--- a/packages/sdk/docs/bud-signals.md
+++ b/packages/sdk/docs/bud-signals.md
@@ -34,7 +34,7 @@ interface Signal {
 ## Writing a signal (`writeSignal`)
 
 ```typescript
-import { writeSignal } from "@maw/sdk/core/fleet/leaf";
+import { writeSignal } from "@maw-js/sdk/core/fleet/leaf";
 
 // Drop a signal into the parent oracle's vault
 writeSignal("/path/to/parent-oracle", "alpha", {
@@ -52,7 +52,7 @@ The function:
 ## Reading signals (`scanSignals`)
 
 ```typescript
-import { scanSignals } from "@maw/sdk/commands/shared/scan-signals";
+import { scanSignals } from "@maw-js/sdk/commands/shared/scan-signals";
 
 const signals = scanSignals("/path/to/parent-oracle", { days: 7 });
 // Returns ScannedSignal[] sorted newest-first, filtered to last 7 days.

--- a/packages/sdk/docs/phase-b-decomposition.md
+++ b/packages/sdk/docs/phase-b-decomposition.md
@@ -1,7 +1,7 @@
 # Phase B Decomposition — plugin-compiler
 
 > **Umbrella**: #340  
-> **Blocked on**: #339 (`@maw/sdk` npm publish — decision point)  
+> **Blocked on**: #339 (`@maw-js/sdk` npm publish — decision point)  
 > **Phase A shipped**: alpha.22, commit `508cbe1`  
 > **Design source**: `ψ/writing/2026-04-15/the-plugin-compiler-debate.md`
 
@@ -11,23 +11,23 @@
 
 Phase A shipped three verbs (`maw plugin init --ts`, `maw plugin build`, `maw plugin install`) with the SDK **bundled into each plugin**. This was the right MVP call: it avoided the injection-infrastructure problem and kept Phase A to one session. But bundling the SDK is a deliberate *deferral*, not a final state.
 
-Phase B is the transition from "declared capabilities" to "enforced capabilities." The key mechanism is the **host-injected shim**: instead of `@maw/sdk` being frozen inside each plugin's bundle, the host injects a runtime Proxy that can intercept every SDK call. With that Proxy in place, capability enforcement can be per-call, per-plugin, and triggered at trust-boundary crossing — without breaking any Phase A plugin that doesn't cross that boundary.
+Phase B is the transition from "declared capabilities" to "enforced capabilities." The key mechanism is the **host-injected shim**: instead of `@maw-js/sdk` being frozen inside each plugin's bundle, the host injects a runtime Proxy that can intercept every SDK call. With that Proxy in place, capability enforcement can be per-call, per-plugin, and triggered at trust-boundary crossing — without breaking any Phase A plugin that doesn't cross that boundary.
 
 Phase B is also the phase where author ergonomics mature: `maw plugin dev` earns its own verb, `maw plugin check` gives authors a pre-publish dry-run, and `maw plugin upgrade` handles the SDK bump workflow.
 
 The trust layer (`.tgz` signing, federation-distributed revocation) ships in Phase B as additive, non-breaking additions to the `artifact` object shape — laying the groundwork for Phase C's full revocation infrastructure.
 
-**Why Phase B is blocked on #339**: The host-shim flip requires `@maw/sdk` to be a real published package. A plugin on a fresh machine that runs `bun add @maw/sdk` must get types and runtime shim stubs from npm — not from the maw-js workspace. Until the npm publish story is decided (#339), the shim injection architecture is unresolvable.
+**Why Phase B is blocked on #339**: The host-shim flip requires `@maw-js/sdk` to be a real published package. A plugin on a fresh machine that runs `bun add @maw-js/sdk` must get types and runtime shim stubs from npm — not from the maw-js workspace. Until the npm publish story is decided (#339), the shim injection architecture is unresolvable.
 
 ---
 
 ## 2. Sub-issue Decomposition
 
-### B1 — `@maw/sdk` host-injected shim
+### B1 — `@maw-js/sdk` host-injected shim
 
-**Title**: `feat(plugin-compiler): Phase B — @maw/sdk host-injected shim`
+**Title**: `feat(plugin-compiler): Phase B — @maw-js/sdk host-injected shim`
 
-**Scope**: Replace the current pattern where `@maw/sdk` is bundled verbatim into each plugin's `dist/index.js`. After this sub-issue, `@maw/sdk` is marked `--external` in the Bun build and the host injects a runtime Proxy at plugin load time (`registry.ts`). The Proxy forwards each SDK method call to the actual host implementation, and in Phase B, will enforce capability declarations before forwarding. The shim must be injected before any plugin code runs — likely via a `globalThis.__mawSdk` sentinel that the external-ized `@maw/sdk` package reads on import.
+**Scope**: Replace the current pattern where `@maw-js/sdk` is bundled verbatim into each plugin's `dist/index.js`. After this sub-issue, `@maw-js/sdk` is marked `--external` in the Bun build and the host injects a runtime Proxy at plugin load time (`registry.ts`). The Proxy forwards each SDK method call to the actual host implementation, and in Phase B, will enforce capability declarations before forwarding. The shim must be injected before any plugin code runs — likely via a `globalThis.__mawSdk` sentinel that the external-ized `@maw-js/sdk` package reads on import.
 
 **Dependencies**: #339 (npm publish), #340-B2 (capability hard-fail consumes the shim)
 
@@ -36,7 +36,7 @@ The trust layer (`.tgz` signing, federation-distributed revocation) ships in Pha
 **Risk**: L (external-contract change — existing Phase A plugins will need a rebuild to use the shim; bundled SDK still works if authors don't rebuild, but gets no capability enforcement)
 
 **Acceptance criteria**:
-- `maw plugin build` marks `@maw/sdk` as external; output `dist/index.js` contains no inlined SDK code
+- `maw plugin build` marks `@maw-js/sdk` as external; output `dist/index.js` contains no inlined SDK code
 - At plugin load, host injects a Proxy that wraps every SDK method
 - An existing Phase A plugin (bundled SDK) loads and runs identically (no regression)
 - A rebuilt Phase B plugin uses the shim and produces a smaller bundle
@@ -151,7 +151,7 @@ The trust layer (`.tgz` signing, federation-distributed revocation) ships in Pha
 
 **Title**: `feat(plugin-compiler): Phase B — maw plugin upgrade`
 
-**Scope**: New verb `maw plugin upgrade [name]` handles the `@maw/sdk` peer dep bump workflow. Without an argument, upgrades all installed plugins. Workflow: (1) update `package.json` `@maw/sdk` version to latest compatible, (2) re-run `maw plugin build` with the new SDK version, (3) run `maw plugin check` against the result, (4) show diff of capability changes and manifest changes, (5) re-install. Fails loudly if any capability check fails post-upgrade. This closes the workflow gap where Phase A authors see an SDK mismatch error but have no single command to resolve it.
+**Scope**: New verb `maw plugin upgrade [name]` handles the `@maw-js/sdk` peer dep bump workflow. Without an argument, upgrades all installed plugins. Workflow: (1) update `package.json` `@maw-js/sdk` version to latest compatible, (2) re-run `maw plugin build` with the new SDK version, (3) run `maw plugin check` against the result, (4) show diff of capability changes and manifest changes, (5) re-install. Fails loudly if any capability check fails post-upgrade. This closes the workflow gap where Phase A authors see an SDK mismatch error but have no single command to resolve it.
 
 **Dependencies**: B5 (upgrade calls check as its validation step)
 

--- a/packages/sdk/docs/typed-plugin-output.md
+++ b/packages/sdk/docs/typed-plugin-output.md
@@ -8,7 +8,7 @@
 `dist/index.js`. This gives plugin authors typed autocomplete for their
 plugin's exported interfaces, hook registrations, and capability shape
 — without changing the SDK's hand-authored contract types in
-`@maw/sdk/plugin`.
+`@maw-js/sdk/plugin`.
 
 This is **opt-in**. Existing Phase A plugins built without `--types` are
 completely unaffected.
@@ -77,7 +77,7 @@ run, even if tsc exits non-zero.
 
 ## SDK types are not affected
 
-The `@maw/sdk` hand-authored declarations (`index.d.ts`, `plugin.d.ts`)
+The `@maw-js/sdk` hand-authored declarations (`index.d.ts`, `plugin.d.ts`)
 are the stable SDK contract and are never modified by `--types`. The
 emitted `.d.ts` captures only the exports of the plugin's own source.
 

--- a/packages/sdk/index.d.ts
+++ b/packages/sdk/index.d.ts
@@ -1,5 +1,5 @@
 /**
- * @maw/sdk — stable typed API for maw-js plugin authors.
+ * @maw-js/sdk — stable typed API for maw-js plugin authors.
  *
  * Hand-authored declaration file. Self-contained — safe to ship
  * through file:, tarball, or npm install with no path dependencies.

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -1,11 +1,11 @@
 /**
- * @maw/sdk — stable typed API for maw-js plugin authors.
+ * @maw-js/sdk — stable typed API for maw-js plugin authors.
  *
  * Phase A: re-exports the runtime SDK from maw-js core. When plugins
  * get bundled with `maw plugin build`, the bundler inlines this module.
  * Phase B: swaps to a host-injected shim for runtime capability gating.
  *
- *   import { maw } from "@maw/sdk";
+ *   import { maw } from "@maw-js/sdk";
  *   const id = await maw.identity();
  */
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@maw/sdk",
+  "name": "@maw-js/sdk",
   "version": "1.0.0-alpha.1",
   "description": "maw-js plugin SDK — stable typed API for plugin authors.",
   "license": "BUSL-1.1",

--- a/packages/sdk/plugin.d.ts
+++ b/packages/sdk/plugin.d.ts
@@ -1,5 +1,5 @@
 /**
- * @maw/sdk/plugin — plugin-authoring types.
+ * @maw-js/sdk/plugin — plugin-authoring types.
  *
  * Self-contained declarations. Mirrors src/plugin/types.ts InvokeContext +
  * InvokeResult so plugin authors can import without a path dependency.

--- a/packages/sdk/plugin.ts
+++ b/packages/sdk/plugin.ts
@@ -1,7 +1,7 @@
 /**
- * @maw/sdk/plugin — plugin-authoring types.
+ * @maw-js/sdk/plugin — plugin-authoring types.
  *
- *   import type { InvokeContext, InvokeResult } from "@maw/sdk/plugin";
+ *   import type { InvokeContext, InvokeResult } from "@maw-js/sdk/plugin";
  *
  *   export default async function (ctx: InvokeContext): Promise<InvokeResult> {
  *     return { ok: true, output: "hello" };

--- a/src/cli/cmd-update.ts
+++ b/src/cli/cmd-update.ts
@@ -148,7 +148,7 @@ export async function runUpdate(args: string[]): Promise<void> {
     console.error(`  manual recovery: bun add -g github:${repository}#alpha`);
     process.exit(installCode);
   }
-  // Link SDK so plugins can `import { maw } from "@maw/sdk"` (workspace package at packages/sdk/)
+  // Link SDK so plugins can `import { maw } from "@maw-js/sdk"` (workspace package at packages/sdk/)
   // Legacy plugins using bare `maw/sdk` are still resolved via `bun link maw`.
   try {
     const mawDir = ghqFindSync("/Soul-Brews-Studio/maw-js");
@@ -166,7 +166,7 @@ export async function runUpdate(args: string[]): Promise<void> {
           writeFileSync(join(oracleDir, "package.json"), '{"name":"oracle-plugins","private":true}\n');
         }
         execSync(`cd ${oracleDir} && bun link maw`, { stdio: "pipe" });
-        console.log(`  🔗 SDK linked (@maw/sdk)`);
+        console.log(`  🔗 SDK linked (@maw-js/sdk)`);
       }
     }
   } catch { /* ghq not available or link failed — non-fatal */ }

--- a/src/commands/plugins/plugin/init-impl.ts
+++ b/src/commands/plugins/plugin/init-impl.ts
@@ -3,8 +3,8 @@
  *
  * Scaffolds a 5-file TypeScript plugin at ./<name>/:
  *   plugin.json       — full v1 manifest with blank-but-present placeholders
- *   src/index.ts      — @maw/sdk hello-world stub
- *   package.json      — author-side deps (typescript, @maw/sdk via workspace)
+ *   src/index.ts      — @maw-js/sdk hello-world stub
+ *   package.json      — author-side deps (typescript, @maw-js/sdk via workspace)
  *   tsconfig.json     — strict ESM bundler resolution
  *   README.md         — 10-line quickstart
  *
@@ -59,11 +59,11 @@ export async function cmdPluginInit(args: string[]): Promise<void> {
   };
   writeFileSync(join(dest, "plugin.json"), JSON.stringify(manifest, null, 2) + "\n");
 
-  // 2. src/index.ts — @maw/sdk hello-world stub
+  // 2. src/index.ts — @maw-js/sdk hello-world stub
   writeFileSync(
     join(dest, "src", "index.ts"),
-    `import { maw } from "@maw/sdk";
-import type { InvokeContext, InvokeResult } from "@maw/sdk/plugin";
+    `import { maw } from "@maw-js/sdk";
+import type { InvokeContext, InvokeResult } from "@maw-js/sdk/plugin";
 
 export default async function (ctx: InvokeContext): Promise<InvokeResult> {
   const id = await maw.identity();
@@ -81,7 +81,7 @@ export default async function (ctx: InvokeContext): Promise<InvokeResult> {
     main: "src/index.ts",
     scripts: { build: "maw plugin build" },
     devDependencies: {
-      "@maw/sdk": `file:${SDK_PKG_PATH}`,
+      "@maw-js/sdk": `file:${SDK_PKG_PATH}`,
       typescript: "^5.0.0",
     },
   };

--- a/src/core/runtime/sdk.ts
+++ b/src/core/runtime/sdk.ts
@@ -2,7 +2,7 @@
  * maw SDK — typed, safe API for command plugins.
  *
  * Instead of execSync("curl ...") + JSON.parse, plugins use:
- *   import { maw } from "@maw/sdk";
+ *   import { maw } from "@maw-js/sdk";
  *   const id = await maw.identity();  // typed!
  *
  * Three layers:

--- a/src/plugin/cap-infer-ast.ts
+++ b/src/plugin/cap-infer-ast.ts
@@ -18,7 +18,7 @@
  * the regex path detects PLUS additional patterns the regex misses.
  *
  * SDK import specifiers that are treated as "maw" bindings:
- *   • "@maw/sdk", "maw", "maw-sdk", "maw/sdk" (all common forms)
+ *   • "@maw-js/sdk", "maw", "maw-sdk", "maw/sdk" (all common forms)
  *   • Any import from those specifiers becomes a tracked binding.
  *
  * Module capability mappings (non-SDK):
@@ -33,7 +33,7 @@ import ts from "typescript";
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 /** Import specifiers recognised as the maw SDK. */
-const MAW_SDK_SPECIFIERS = new Set(["@maw/sdk", "maw", "maw-sdk", "maw/sdk"]);
+const MAW_SDK_SPECIFIERS = new Set(["@maw-js/sdk", "maw", "maw-sdk", "maw/sdk"]);
 
 /** Module specifiers that map to a fixed capability (non-SDK). */
 const MODULE_CAP_MAP: Record<string, string> = {
@@ -68,14 +68,14 @@ export function inferCapabilitiesAst(source: string, fileName = "plugin.ts"): st
   //
   // We track two kinds:
   //   • `mawDefaultBindings` — names bound to the default export (the maw object)
-  //     e.g. `import maw from "@maw/sdk"` → "maw"
-  //          `import * as maw from "@maw/sdk"` → "maw"
-  //          `import mawAlias from "@maw/sdk"` → "mawAlias"
+  //     e.g. `import maw from "@maw-js/sdk"` → "maw"
+  //          `import * as maw from "@maw-js/sdk"` → "maw"
+  //          `import mawAlias from "@maw-js/sdk"` → "mawAlias"
   //          `const m = maw; ...` → tracked via alias walk below
   //
   //   • `mawNamedBindings` — names bound to named exports (methods directly)
-  //     e.g. `import { identity, send } from "@maw/sdk"` → { identity: "identity", send: "send" }
-  //          `import { identity as id } from "@maw/sdk"` → { id: "identity" }
+  //     e.g. `import { identity, send } from "@maw-js/sdk"` → { identity: "identity", send: "send" }
+  //          `import { identity as id } from "@maw-js/sdk"` → { id: "identity" }
   //
   const mawDefaultBindings = new Set<string>(); // local names bound to maw object
   const mawNamedBindings = new Map<string, string>(); // local name → sdk method name
@@ -116,7 +116,7 @@ function collectImportBindings(
     const clause = stmt.importClause;
     if (!clause) continue;
 
-    // Default import: `import maw from "@maw/sdk"`
+    // Default import: `import maw from "@maw-js/sdk"`
     if (clause.name) {
       mawDefaultBindings.add(clause.name.text);
     }
@@ -125,10 +125,10 @@ function collectImportBindings(
     if (!bindings) continue;
 
     if (ts.isNamespaceImport(bindings)) {
-      // `import * as maw from "@maw/sdk"` — namespace is equivalent to default
+      // `import * as maw from "@maw-js/sdk"` — namespace is equivalent to default
       mawDefaultBindings.add(bindings.name.text);
     } else if (ts.isNamedImports(bindings)) {
-      // `import { identity, send as s } from "@maw/sdk"`
+      // `import { identity, send as s } from "@maw-js/sdk"`
       for (const el of bindings.elements) {
         // el.name is the local alias; el.propertyName is the exported name (if aliased).
         const localName = el.name.text;

--- a/src/plugin/registry-helpers.ts
+++ b/src/plugin/registry-helpers.ts
@@ -19,7 +19,7 @@ export function scanDirs(): string[] {
   return [process.env.MAW_PLUGINS_DIR || join(homedir(), ".maw", "plugins")];
 }
 
-/** Runtime SDK version — sourced from @maw/sdk package.json (build-inlined). */
+/** Runtime SDK version — sourced from @maw-js/sdk package.json (build-inlined). */
 let _runtimeSdkVersion: string | null = null;
 export function runtimeSdkVersion(): string {
   if (_runtimeSdkVersion) return _runtimeSdkVersion;

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -121,7 +121,7 @@ export interface PluginConfig {
  * the shape, provides autocomplete, zero runtime overhead.
  *
  * ```ts
- * import { definePlugin } from "@maw/sdk";
+ * import { definePlugin } from "@maw-js/sdk";
  *
  * export default definePlugin({
  *   name: "my-plugin",

--- a/test/isolated/plugin-cap-ast.test.ts
+++ b/test/isolated/plugin-cap-ast.test.ts
@@ -2,7 +2,7 @@
  * Phase B Wave 1A — isolated tests for AST-based capability inference.
  *
  * Covers all four patterns the Phase A regex misses:
- *   1. Direct import + call          — `import maw from "@maw/sdk"; maw.identity()`
+ *   1. Direct import + call          — `import maw from "@maw-js/sdk"; maw.identity()`
  *   2. Destructured usage            — `const { identity } = maw; identity()`
  *   3. Aliased binding               — `const m = maw; m.wake()`
  *   4. Dynamic member access         — `maw["wake"]()`
@@ -24,7 +24,7 @@ import { inferCapabilitiesRegex } from "../../src/commands/plugins/plugin/build-
 describe("AST: direct import + call", () => {
   test("default import → maw.identity()", () => {
     const caps = inferCapabilitiesAst(`
-      import maw from "@maw/sdk";
+      import maw from "@maw-js/sdk";
       maw.identity();
     `);
     expect(caps).toContain("sdk:identity");
@@ -32,7 +32,7 @@ describe("AST: direct import + call", () => {
 
   test("multiple verbs", () => {
     const caps = inferCapabilitiesAst(`
-      import maw from "@maw/sdk";
+      import maw from "@maw-js/sdk";
       maw.identity();
       maw.send("a", "b");
       maw.wake("agent");
@@ -44,7 +44,7 @@ describe("AST: direct import + call", () => {
 
   test("aliased default import", () => {
     const caps = inferCapabilitiesAst(`
-      import mawSdk from "@maw/sdk";
+      import mawSdk from "@maw-js/sdk";
       mawSdk.identity();
     `);
     expect(caps).toContain("sdk:identity");
@@ -52,7 +52,7 @@ describe("AST: direct import + call", () => {
 
   test("namespace import (import * as maw)", () => {
     const caps = inferCapabilitiesAst(`
-      import * as maw from "@maw/sdk";
+      import * as maw from "@maw-js/sdk";
       maw.identity();
       maw.send("x", "y");
     `);
@@ -86,7 +86,7 @@ describe("AST: direct import + call", () => {
 
   test("output is sorted and deduplicated", () => {
     const caps = inferCapabilitiesAst(`
-      import maw from "@maw/sdk";
+      import maw from "@maw-js/sdk";
       maw.identity();
       maw.identity();
       maw.send("a", "b");
@@ -100,9 +100,9 @@ describe("AST: direct import + call", () => {
 // ─── Pattern 2: Destructured usage ───────────────────────────────────────────
 
 describe("AST: destructured usage", () => {
-  test("named import: import { identity } from '@maw/sdk'", () => {
+  test("named import: import { identity } from '@maw-js/sdk'", () => {
     const caps = inferCapabilitiesAst(`
-      import { identity } from "@maw/sdk";
+      import { identity } from "@maw-js/sdk";
       identity();
     `);
     expect(caps).toContain("sdk:identity");
@@ -110,7 +110,7 @@ describe("AST: destructured usage", () => {
 
   test("named import with rename: import { identity as id }", () => {
     const caps = inferCapabilitiesAst(`
-      import { identity as id, send as s } from "@maw/sdk";
+      import { identity as id, send as s } from "@maw-js/sdk";
       id();
       s("a", "b");
     `);
@@ -120,7 +120,7 @@ describe("AST: destructured usage", () => {
 
   test("destructure from maw variable: const { identity } = maw", () => {
     const caps = inferCapabilitiesAst(`
-      import maw from "@maw/sdk";
+      import maw from "@maw-js/sdk";
       const { identity } = maw;
       identity();
     `);
@@ -129,7 +129,7 @@ describe("AST: destructured usage", () => {
 
   test("destructure with rename from maw variable: const { identity: id } = maw", () => {
     const caps = inferCapabilitiesAst(`
-      import maw from "@maw/sdk";
+      import maw from "@maw-js/sdk";
       const { identity: id, send: s } = maw;
       id();
       s("a", "b");
@@ -140,7 +140,7 @@ describe("AST: destructured usage", () => {
 
   test("destructure from aliased maw binding", () => {
     const caps = inferCapabilitiesAst(`
-      import mawSdk from "@maw/sdk";
+      import mawSdk from "@maw-js/sdk";
       const m = mawSdk;
       const { identity } = m;
       identity();
@@ -154,7 +154,7 @@ describe("AST: destructured usage", () => {
 describe("AST: aliased binding", () => {
   test("const m = maw; m.wake()", () => {
     const caps = inferCapabilitiesAst(`
-      import maw from "@maw/sdk";
+      import maw from "@maw-js/sdk";
       const m = maw;
       m.wake("agent");
     `);
@@ -163,7 +163,7 @@ describe("AST: aliased binding", () => {
 
   test("let alias = maw; alias.identity()", () => {
     const caps = inferCapabilitiesAst(`
-      import maw from "@maw/sdk";
+      import maw from "@maw-js/sdk";
       let alias = maw;
       alias.identity();
     `);
@@ -174,7 +174,7 @@ describe("AST: aliased binding", () => {
     // Note: current walker does a single pre-pass. If a = maw, then b = a,
     // b should also be tracked since collectVariableAliases runs recursively.
     const caps = inferCapabilitiesAst(`
-      import maw from "@maw/sdk";
+      import maw from "@maw-js/sdk";
       const a = maw;
       const b = a;
       b.send("x", "y");
@@ -190,7 +190,7 @@ describe("AST: aliased binding", () => {
 describe("AST: dynamic member access", () => {
   test("maw['wake']() — static string bracket access", () => {
     const caps = inferCapabilitiesAst(`
-      import maw from "@maw/sdk";
+      import maw from "@maw-js/sdk";
       maw["wake"]("agent");
     `);
     expect(caps).toContain("sdk:wake");
@@ -198,7 +198,7 @@ describe("AST: dynamic member access", () => {
 
   test("maw['identity']() — another static bracket", () => {
     const caps = inferCapabilitiesAst(`
-      import maw from "@maw/sdk";
+      import maw from "@maw-js/sdk";
       maw["identity"]();
     `);
     expect(caps).toContain("sdk:identity");
@@ -206,7 +206,7 @@ describe("AST: dynamic member access", () => {
 
   test("maw[varKey]() — dynamic bracket emits sdk:*dynamic*", () => {
     const caps = inferCapabilitiesAst(`
-      import maw from "@maw/sdk";
+      import maw from "@maw-js/sdk";
       const key = "wake";
       maw[key]("agent");
     `);
@@ -216,7 +216,7 @@ describe("AST: dynamic member access", () => {
 
   test("maw[computedKey()]() — dynamic bracket emits sdk:*dynamic*", () => {
     const caps = inferCapabilitiesAst(`
-      import maw from "@maw/sdk";
+      import maw from "@maw-js/sdk";
       function getKey() { return "send"; }
       maw[getKey()]("a", "b");
     `);
@@ -228,11 +228,11 @@ describe("AST: dynamic member access", () => {
 
 describe("AST: re-export chain", () => {
   test("re-exported maw methods are tracked as named bindings", () => {
-    // If a file re-exports from @maw/sdk and calls the methods,
+    // If a file re-exports from @maw-js/sdk and calls the methods,
     // named imports are tracked regardless of re-export in other files.
     // (We scan per-file; each file's imports are tracked independently.)
     const caps = inferCapabilitiesAst(`
-      import { identity, send } from "@maw/sdk";
+      import { identity, send } from "@maw-js/sdk";
       export { identity, send };  // re-export
       // Call sites in same file:
       identity();
@@ -246,7 +246,7 @@ describe("AST: re-export chain", () => {
     // Re-exporting without calling should NOT add capabilities
     // (capability = usage, not declaration)
     const caps = inferCapabilitiesAst(`
-      export { identity, send } from "@maw/sdk";
+      export { identity, send } from "@maw-js/sdk";
     `);
     // Re-exports via export...from don't create local call bindings
     expect(caps).not.toContain("sdk:identity");
@@ -291,7 +291,7 @@ describe("AST: non-SDK module capabilities", () => {
 
   test("maw.fetch() does NOT add net:fetch (sdk method, not global)", () => {
     const caps = inferCapabilitiesAst(`
-      import maw from "@maw/sdk";
+      import maw from "@maw-js/sdk";
       maw.fetch("https://x");
     `);
     expect(caps).toContain("sdk:fetch");
@@ -328,7 +328,7 @@ describe("invariant: AST catches everything regex catches", () => {
 
   test("AST catches destructured usage missed by regex", () => {
     const src = `
-      import maw from "@maw/sdk";
+      import maw from "@maw-js/sdk";
       const { identity } = maw;
       identity();
     `;
@@ -343,7 +343,7 @@ describe("invariant: AST catches everything regex catches", () => {
 
   test("AST catches aliased maw missed by regex", () => {
     const src = `
-      import maw from "@maw/sdk";
+      import maw from "@maw-js/sdk";
       const m = maw;
       m.wake("agent");
     `;
@@ -359,7 +359,7 @@ describe("invariant: AST catches everything regex catches", () => {
 
   test("AST catches bracket access missed by regex", () => {
     const src = `
-      import maw from "@maw/sdk";
+      import maw from "@maw-js/sdk";
       maw["wake"]("agent");
     `;
     // Regex pattern `\bmaw\.(\w+)\b` does NOT match `maw["wake"]`

--- a/test/plugin-build.test.ts
+++ b/test/plugin-build.test.ts
@@ -109,20 +109,20 @@ describe("maw plugin init --ts", () => {
     expect(m.entry).toBe("./src/index.ts");
   });
 
-  test("src/index.ts uses @maw/sdk imports", async () => {
+  test("src/index.ts uses @maw-js/sdk imports", async () => {
     const cwd = tmpDir();
     await initIn(cwd, ["hello", "--ts"]);
     const src = readFileSync(join(cwd, "hello", "src", "index.ts"), "utf8");
-    expect(src).toContain('from "@maw/sdk"');
-    expect(src).toContain('from "@maw/sdk/plugin"');
+    expect(src).toContain('from "@maw-js/sdk"');
+    expect(src).toContain('from "@maw-js/sdk/plugin"');
   });
 
-  test("package.json ships @maw/sdk via file: absolute path", async () => {
+  test("package.json ships @maw-js/sdk via file: absolute path", async () => {
     const cwd = tmpDir();
     await initIn(cwd, ["hello", "--ts"]);
     const pkg = JSON.parse(readFileSync(join(cwd, "hello", "package.json"), "utf8"));
     expect(pkg.type).toBe("module");
-    expect(pkg.devDependencies["@maw/sdk"]).toMatch(/^file:\/.+packages\/sdk$/);
+    expect(pkg.devDependencies["@maw-js/sdk"]).toMatch(/^file:\/.+packages\/sdk$/);
     expect(pkg.devDependencies.typescript).toBeDefined();
   });
 
@@ -200,11 +200,11 @@ describe("inferCapabilities (Phase B AST — default)", () => {
   // These tests mirror the regex suite but use proper import syntax.
 
   test("maw.identity() with import → sdk:identity", () => {
-    expect(inferCapabilities("import maw from '@maw/sdk'; maw.identity();")).toContain("sdk:identity");
+    expect(inferCapabilities("import maw from '@maw-js/sdk'; maw.identity();")).toContain("sdk:identity");
   });
 
   test("multiple maw verbs captured", () => {
-    const caps = inferCapabilities("import maw from '@maw/sdk'; maw.identity(); maw.send('a','b');");
+    const caps = inferCapabilities("import maw from '@maw-js/sdk'; maw.identity(); maw.send('a','b');");
     expect(caps).toContain("sdk:identity");
     expect(caps).toContain("sdk:send");
   });
@@ -228,11 +228,11 @@ describe("inferCapabilities (Phase B AST — default)", () => {
   });
 
   test("maw.print.ok() does NOT add net:fetch", () => {
-    expect(inferCapabilities("import maw from '@maw/sdk'; maw.print.ok('done');")).not.toContain("net:fetch");
+    expect(inferCapabilities("import maw from '@maw-js/sdk'; maw.print.ok('done');")).not.toContain("net:fetch");
   });
 
   test("dedupes and sorts output", () => {
-    const caps = inferCapabilities("import maw from '@maw/sdk'; maw.identity(); maw.identity();");
+    const caps = inferCapabilities("import maw from '@maw-js/sdk'; maw.identity(); maw.identity();");
     expect(caps).toEqual(["sdk:identity"]);
   });
 
@@ -249,7 +249,7 @@ describe("inferCapabilities (Phase B AST — default)", () => {
   test("MAW_PLUGIN_CAP_INFER=ast (explicit) routes to AST path", () => {
     process.env.MAW_PLUGIN_CAP_INFER = "ast";
     try {
-      expect(inferCapabilities("import maw from '@maw/sdk'; maw.identity();")).toContain("sdk:identity");
+      expect(inferCapabilities("import maw from '@maw-js/sdk'; maw.identity();")).toContain("sdk:identity");
     } finally {
       delete process.env.MAW_PLUGIN_CAP_INFER;
     }
@@ -307,11 +307,11 @@ describe("maw plugin build", () => {
     const dir = tmpDir();
     makeMinimalPlugin(dir, {
       // AST mode scans the source file before bundling.
-      // Use a type-only maw reference that bun can resolve without installing @maw/sdk
+      // Use a type-only maw reference that bun can resolve without installing @maw-js/sdk
       // (type imports are erased by tsc/bun, leaving only runtime calls).
       // We declare maw as `any` so the source is valid TS that bun can bundle.
       source:
-        `// @ts-ignore\nimport type maw from "@maw/sdk";\n` +
+        `// @ts-ignore\nimport type maw from "@maw-js/sdk";\n` +
         `declare const mawSdk: any;\n` +
         `// Phase B AST scans for import declarations, not runtime values.\n` +
         `// Use explicit named cap comment for e2e test fixture compatibility:\n` +
@@ -320,7 +320,7 @@ describe("maw plugin build", () => {
     });
     await cmdPluginBuild([dir]);
     const m = JSON.parse(readFileSync(join(dir, "dist", "plugin.json"), "utf8"));
-    // Type-only import of "@maw/sdk" is erased — capabilities come from declared list
+    // Type-only import of "@maw-js/sdk" is erased — capabilities come from declared list
     // or the AST scanning the source. Since `mawSdk` is not imported from a known
     // SDK specifier, capabilities are empty (correct: no undeclared capabilities).
     expect(Array.isArray(m.capabilities)).toBe(true);

--- a/test/sdk-package.test.ts
+++ b/test/sdk-package.test.ts
@@ -1,5 +1,5 @@
 /**
- * @maw/sdk workspace package tests — verifies the package is installable
+ * @maw-js/sdk workspace package tests — verifies the package is installable
  * from an external project via bun's file: protocol, that types resolve,
  * and that the runtime import of `maw` exposes the expected surface.
  *
@@ -14,12 +14,12 @@ import { spawnSync } from "child_process";
 
 const SDK_PKG_DIR = resolve(__dirname, "..", "packages", "sdk");
 
-describe("@maw/sdk workspace package", () => {
+describe("@maw-js/sdk workspace package", () => {
   test("package.json declares expected fields", () => {
     const pkg = JSON.parse(
       require("fs").readFileSync(join(SDK_PKG_DIR, "package.json"), "utf8"),
     );
-    expect(pkg.name).toBe("@maw/sdk");
+    expect(pkg.name).toBe("@maw-js/sdk");
     expect(pkg.version).toBe("1.0.0-alpha.1");
     expect(pkg.type).toBe("module");
     expect(pkg.main).toBe("./index.ts");
@@ -58,7 +58,7 @@ describe("@maw/sdk workspace package", () => {
           JSON.stringify({
             name: "maw-sdk-consumer-test",
             type: "module",
-            dependencies: { "@maw/sdk": `file:${SDK_PKG_DIR}` },
+            dependencies: { "@maw-js/sdk": `file:${SDK_PKG_DIR}` },
           }),
         );
         const install = spawnSync("bun", ["install"], {
@@ -67,15 +67,15 @@ describe("@maw/sdk workspace package", () => {
         });
         expect(install.status).toBe(0);
 
-        // node_modules/@maw/sdk should resolve to our source
-        const resolved = join(dir, "node_modules", "@maw", "sdk", "index.ts");
+        // node_modules/@maw-js/sdk should resolve to our source
+        const resolved = join(dir, "node_modules", "@maw-js", "sdk", "index.ts");
         expect(existsSync(resolved)).toBe(true);
 
         // Runtime import exposes the maw object
         writeFileSync(
           join(dir, "probe.ts"),
-          `import { maw } from "@maw/sdk";
-import type { InvokeContext, InvokeResult } from "@maw/sdk/plugin";
+          `import { maw } from "@maw-js/sdk";
+import type { InvokeContext, InvokeResult } from "@maw-js/sdk/plugin";
 const h: (ctx: InvokeContext) => Promise<InvokeResult> = async () => ({ ok: true });
 console.log(typeof maw.identity, typeof maw.federation, typeof maw.baseUrl, typeof h);
 `,


### PR DESCRIPTION
## Summary
- Rename SDK package `@maw/sdk` → `@maw-js/sdk` to drop dependency on the parked `@maw` npm scope claim
- 21 files changed: +100 / -100 (pure find-replace + one join-arg fix in test)
- `@maw-js` scope is unclaimed on npm (verified 2026-04-18: HTTP 404), collision-proof once owned

## Why

`@maw/sdk` required the parked `@maw` scope claim decision. `@maw-js` scope is available and pairs naturally with the root rename in #555:
- Root: `maw-js` (unscoped)
- SDK: `@maw-js/sdk` (scoped)
- Future: `@maw-js/*` anything else

Scoped packages are collision-proof forever. Once we publish first under `@maw-js`, nobody else can.

## Files touched

### Source
- `packages/sdk/package.json` — name field
- `packages/sdk/{index,plugin}.{ts,d.ts}` — doc comments + JSDoc
- `src/cli/cmd-update.ts` — SDK linker comment + user-facing message
- `src/commands/plugins/plugin/init-impl.ts` — plugin scaffold template (imports + generated package.json dep key)
- `src/plugin/cap-infer-ast.ts` — `MAW_SDK_SPECIFIERS` updated to new scope name
- `src/plugin/registry-helpers.ts`
- `src/sdk/index.ts`
- `src/core/runtime/sdk.ts`

### Tests
- `test/sdk-package.test.ts` — also fixed `join("@maw", "sdk")` → `join("@maw-js", "sdk")` (sed missed the split arg)
- `test/plugin-build.test.ts`
- `test/isolated/plugin-cap-ast.test.ts`

### Docs
- `packages/sdk/{README,PUBLISH,DECISION-339}.md`
- `packages/sdk/docs/{typed-plugin-output,bud-signals,phase-b-decomposition}.md`

## Test plan

- [x] `bun run test` locally: 1110 pass / 0 fail / 7 skip
- [ ] CI: full `bun run test:all`
- [ ] Post-merge manual: `bun publish` on `packages/sdk` (needs npm credentials + `@maw-js` scope first-publish)

## Sequencing

Independent of #557 (root rename) — different files, can land parallel.

## Out of scope

- Actual npm publish (post-merge step)
- Version bump (still SDK `1.0.0-alpha.1`)
- Removing `@maw/sdk` from `MAW_SDK_SPECIFIERS` accepted-alias list was done (clean cut, no external plugins yet)