### PR TITLE
feat(plugin): maw incubate — core plugin scaffold (closes #522)

### DIFF
--- a/src/commands/plugins/incubate/impl.ts
+++ b/src/commands/plugins/incubate/impl.ts
@@ -1,0 +1,58 @@
+/**
+ * maw incubate — stub implementation (#522).
+ *
+ * Migration scaffold for Oracle skill /incubate. Real flow (ghq clone/create,
+ * origin symlink into ψ/incubate/<owner>/<repo>/origin, .origins manifest,
+ * .claude/INCUBATED_BY breadcrumb, hub file, and the --flash / --contribute /
+ * --status / --offload workflow modes) is tracked as follow-up work.
+ *
+ * Until that lands, this stub:
+ *   - Accepts <repo> + mode (default | flash | contribute | status | offload)
+ *   - Returns a well-shaped stub message with the selected mode
+ *   - Points users at the Oracle skill for actual incubation runs
+ *
+ * The function is pure (no I/O, no process spawning) so it's safe to unit
+ * test and safe to wire into the CLI ahead of the real impl.
+ */
+
+export type IncubateMode = "default" | "flash" | "contribute" | "status" | "offload";
+
+export interface IncubateOptions {
+  repo: string;
+  mode: IncubateMode;
+}
+
+/**
+ * Return a stub message for `maw incubate`. Will be replaced by the real
+ * ghq + symlink + workflow flow once the migration PR ships.
+ */
+export async function cmdIncubate(repo: string, mode: IncubateMode = "default"): Promise<string> {
+  const target = repo || "(none)";
+  const lines = [
+    `incubate: ${mode} mode on "${target}" — not yet implemented in core plugin; use Oracle skill /incubate for full behavior.`,
+    `  planned: ghq clone/create → symlink ψ/incubate/<owner>/<repo>/origin → hub file + .origins manifest`,
+    `  track:   https://github.com/Soul-Brews-Studio/maw-js/issues/522`,
+  ];
+  const message = lines.join("\n");
+  console.log(message);
+  return message;
+}
+
+/**
+ * Resolve mode from flag booleans. Exposed for tests and for future CLI
+ * wiring that may accept a single `--mode` string alternative.
+ */
+export function resolveMode(
+  flash: boolean,
+  contribute: boolean,
+  status: boolean,
+  offload: boolean,
+): IncubateMode {
+  const count = [flash, contribute, status, offload].filter(Boolean).length;
+  if (count > 1) throw new Error("--flash, --contribute, --status, --offload are mutually exclusive");
+  if (flash) return "flash";
+  if (contribute) return "contribute";
+  if (status) return "status";
+  if (offload) return "offload";
+  return "default";
+}

--- a/src/commands/plugins/incubate/index.ts
+++ b/src/commands/plugins/incubate/index.ts
@@ -1,0 +1,82 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+
+export const command = {
+  name: "incubate",
+  description: "Scaffold (stub): clone or create repos for active development.",
+};
+
+/**
+ * maw incubate — core plugin scaffold (#522).
+ *
+ * This is a migration scaffold for the Oracle skill `/incubate`. The full
+ * implementation (ghq clone/create, origin symlink, .origins manifest,
+ * INCUBATED_BY breadcrumb, hub file, --flash/--contribute/--status/--offload
+ * workflow modes) lives in ~/.claude/skills/incubate/SKILL.md and ships in a
+ * follow-up PR.
+ *
+ * Today the plugin only:
+ *   - registers the CLI verb + flags
+ *   - validates positional args + flag shape
+ *   - returns a stub message pointing users at the Oracle skill
+ *
+ * See issue #522 for the follow-up implementation tracker.
+ */
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const { cmdIncubate } = await import("./impl");
+
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+
+  try {
+    const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+
+    const flash = args.includes("--flash");
+    const contribute = args.includes("--contribute");
+    const status = args.includes("--status");
+    const offload = args.includes("--offload");
+
+    const modes = [flash, contribute, status, offload].filter(Boolean).length;
+    if (modes > 1) {
+      return {
+        ok: false,
+        error: "maw incubate: --flash, --contribute, --status, --offload are mutually exclusive",
+      };
+    }
+
+    const known = new Set(["--flash", "--contribute", "--status", "--offload"]);
+    const positional = args.filter(a => !a.startsWith("--"));
+    const unknown = args.filter(a => a.startsWith("--") && !known.has(a));
+    if (unknown.length > 0) {
+      return {
+        ok: false,
+        error: `maw incubate: unknown flag(s) ${unknown.join(", ")} (accepts --flash, --contribute, --status, --offload)`,
+      };
+    }
+
+    const mode = flash ? "flash" : contribute ? "contribute" : status ? "status" : offload ? "offload" : "default";
+
+    if (mode !== "status" && !positional[0]) {
+      return {
+        ok: false,
+        error: "usage: maw incubate <repo> [--flash|--contribute|--status|--offload]",
+      };
+    }
+
+    const result = await cmdIncubate(positional[0] ?? "", mode);
+    return { ok: true, output: logs.join("\n") || result };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/src/commands/plugins/incubate/plugin.json
+++ b/src/commands/plugins/incubate/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "incubate",
+  "version": "0.1.0-alpha.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Scaffold (stub): clone or create repos for active development — the right hand of /learn. Full impl lives in the Oracle /incubate skill — core plugin is a dispatcher shape only.",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "incubate",
+    "help": "maw incubate <repo> [--flash|--contribute|--status|--offload] — scaffold stub (impl pending, see Oracle skill /incubate)",
+    "flags": {
+      "--flash": "boolean",
+      "--contribute": "boolean",
+      "--status": "boolean",
+      "--offload": "boolean"
+    }
+  },
+  "weight": 50
+}


### PR DESCRIPTION
## Summary

Mirrors #524 (learn scaffold). Ships a stub-only core plugin for `maw incubate` under `src/commands/plugins/incubate/` with the same 3-file shape as `learn/`:

- `plugin.json` — declares verb, flags, weight, sdk range
- `index.ts` — handler + arg/flag validation, stub dispatch
- `impl.ts` — pure stub `cmdIncubate` + `resolveMode` helper

Flags: `--flash`, `--contribute`, `--status`, `--offload` (mutually exclusive). `--status` is the only mode that doesn't require a `<repo>` positional. Every mode currently returns a stub message pointing users at `~/.claude/skills/incubate/SKILL.md` for the full ghq + symlink + workflow behaviour.

Follow-up work (ghq clone/create, origin symlink into `ψ/incubate/<owner>/<repo>/origin`, `.origins` manifest, `.claude/INCUBATED_BY` breadcrumb, hub file, and the `--flash` / `--contribute` / `--status` / `--offload` flows) tracked on #522.

## Scope

- 159 LOC across 3 files (under the 150-200/file and 300/PR caps)
- No changes outside `src/commands/plugins/incubate/`
- Closes #522

## Test plan

- [x] `bun install` succeeds
- [x] `bun run test` green — 1115 pass, 7 skip, 0 fail (1122 across 82 files)
- [x] `bun run build` succeeds — bundled 580 modules
- [x] `maw incubate` prints usage, doesn't crash
- [x] `maw incubate myrepo` prints default-mode stub
- [x] `maw incubate myrepo --flash` prints flash-mode stub
- [x] `maw incubate --status` (no repo) prints status-mode stub
- [x] `maw incubate myrepo --flash --offload` rejects with mutex error
- [ ] CI green (lead to verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)