### PR TITLE
feat(plugin): maw project — core plugin scaffold with subcommand dispatcher (closes #523)

### DIFF
--- a/src/commands/plugins/project/impl.ts
+++ b/src/commands/plugins/project/impl.ts
@@ -1,0 +1,70 @@
+/**
+ * maw project — stub implementation (#523).
+ *
+ * Migration scaffold for Oracle skill /project. Real flow (ghq clone,
+ * symlink into ψ/learn/<owner>/<repo> or ψ/incubate/<owner>/<repo>,
+ * tracked-repo search, list across both roots, --offload/--contribute/
+ * --flash workflow flags for `incubate`) is tracked as follow-up work.
+ *
+ * Until that lands, each action stub:
+ *   - Echoes a well-shaped stub message naming the action + args
+ *   - Points users at the Oracle skill for actual behavior
+ *
+ * The functions are pure (no I/O, no process spawning) so they are
+ * safe to unit test and safe to wire into the CLI ahead of the real
+ * impl. Keeping one function per action gives the follow-up PR clear
+ * attachment points (swap the body, keep the signature).
+ */
+
+export type ProjectAction = "learn" | "incubate" | "find" | "list";
+
+const TRACK_URL = "https://github.com/Soul-Brews-Studio/maw-js/issues/523";
+const ORACLE_SKILL = "Oracle skill /project";
+
+function stubLine(action: ProjectAction, detail: string): string {
+  return [
+    `project ${action}: ${detail} — not yet implemented in core plugin; use ${ORACLE_SKILL} for full behavior.`,
+    `  track: ${TRACK_URL}`,
+  ].join("\n");
+}
+
+/** Stub: clone repo for study (symlink into ψ/learn/<owner>/<repo>). */
+export async function stubLearn(url: string): Promise<string> {
+  const message = stubLine("learn", `would clone "${url}" and symlink into ψ/learn/<owner>/<repo>`);
+  console.log(message);
+  return message;
+}
+
+/** Stub: clone repo for development (symlink into ψ/incubate/<owner>/<repo>). */
+export async function stubIncubate(url: string): Promise<string> {
+  const message = stubLine("incubate", `would clone "${url}" and symlink into ψ/incubate/<owner>/<repo>`);
+  console.log(message);
+  return message;
+}
+
+/** Stub: search tracked repos by query. */
+export async function stubFind(query: string): Promise<string> {
+  const message = stubLine("find", `would search tracked repos for "${query}" across ψ/learn and ψ/incubate`);
+  console.log(message);
+  return message;
+}
+
+/** Stub: list all tracked repos (learn + incubate). */
+export async function stubList(): Promise<string> {
+  const message = stubLine("list", `would list all tracked repos from ψ/learn and ψ/incubate`);
+  console.log(message);
+  return message;
+}
+
+/** Dispatcher help text — printed on missing / unknown subcommand. */
+export function helpText(): string {
+  return [
+    "usage: maw project <learn|incubate|find|list> [args...]",
+    "  learn    <url>   — clone repo for study (symlink in ψ/learn/)",
+    "  incubate <url>   — clone repo for development (symlink in ψ/incubate/)",
+    "  find     <query> — search tracked repos (alias: search)",
+    "  list             — list all tracked repos",
+    "",
+    `see ${ORACLE_SKILL} for the full implementation (scaffold tracks ${TRACK_URL}).`,
+  ].join("\n");
+}

--- a/src/commands/plugins/project/index.ts
+++ b/src/commands/plugins/project/index.ts
@@ -1,0 +1,87 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+
+export const command = {
+  name: "project",
+  description: "Scaffold (stub): clone and track external repos (learn/incubate/find/list).",
+};
+
+/**
+ * maw project — core plugin scaffold (#523).
+ *
+ * This is a migration scaffold for the Oracle skill `/project`. The full
+ * implementation (ghq clone + symlink flow into ψ/learn and ψ/incubate,
+ * search across tracked repos, list across both roots, --offload /
+ * --contribute / --flash workflow flags) lives in ~/.claude/skills/
+ * project/SKILL.md and ships in a follow-up PR.
+ *
+ * Today the plugin only:
+ *   - registers the CLI verb
+ *   - dispatches on the first positional arg to one of four stubs
+ *   - prints help on missing / unknown subcommand
+ *
+ * See issue #523 for the follow-up implementation tracker.
+ */
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const { stubLearn, stubIncubate, stubFind, stubList, helpText } = await import("./impl");
+
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+
+  try {
+    const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+    const positional = args.filter(a => !a.startsWith("--"));
+    const sub = positional[0];
+    const rest = positional.slice(1);
+
+    if (!sub) {
+      const help = helpText();
+      console.log(help);
+      return { ok: true, output: logs.join("\n") || help };
+    }
+
+    let result: string;
+    switch (sub) {
+      case "learn":
+        if (!rest[0]) return { ok: false, error: "usage: maw project learn <url>" };
+        result = await stubLearn(rest[0]);
+        break;
+      case "incubate":
+        if (!rest[0]) return { ok: false, error: "usage: maw project incubate <url>" };
+        result = await stubIncubate(rest[0]);
+        break;
+      case "find":
+      case "search":
+        if (!rest[0]) return { ok: false, error: "usage: maw project find <query>" };
+        result = await stubFind(rest[0]);
+        break;
+      case "list":
+        result = await stubList();
+        break;
+      default: {
+        const help = helpText();
+        console.log(help);
+        return {
+          ok: false,
+          error: `maw project: unknown subcommand "${sub}" (expected learn|incubate|find|list)`,
+          output: logs.join("\n") || help,
+        };
+      }
+    }
+
+    return { ok: true, output: logs.join("\n") || result };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/src/commands/plugins/project/plugin.json
+++ b/src/commands/plugins/project/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "project",
+  "version": "0.1.0-alpha.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Scaffold (stub): clone and track external repos (learn/incubate/find/list). Full impl lives in the Oracle /project skill — core plugin is a dispatcher shape only.",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "project",
+    "help": "maw project <learn|incubate|find|list> ... — scaffold stub (impl pending, see Oracle skill /project)"
+  },
+  "weight": 50
+}


### PR DESCRIPTION
## Summary

Migrates the Oracle `/project` skill into a core plugin scaffold under
`src/commands/plugins/project/`. Mirrors the `learn/` plugin shape but
adds a 4-way subcommand dispatcher for the `/project` actions.

- `maw project learn <url>` — clone repo for study (symlink in ψ/learn/)
- `maw project incubate <url>` — clone repo for development (symlink in ψ/incubate/)
- `maw project find <query>` — search tracked repos (alias: `search`)
- `maw project list` — list all tracked repos

Stub-only — each action has its own function (`stubLearn` / `stubIncubate`
/ `stubFind` / `stubList`) so the follow-up impl PR has a clean
attachment point per action. No I/O yet — real ghq + symlink flow lives
in Oracle skill `/project` and ships in a follow-up.

## Scope

- `src/commands/plugins/project/plugin.json` — manifest (13 lines)
- `src/commands/plugins/project/index.ts` — dispatcher handler (87 lines)
- `src/commands/plugins/project/impl.ts` — per-action stubs + help text (70 lines)
- No changes outside the new plugin directory.
- Total: 170 LOC (well under the 300 LOC PR cap and 200 LOC per-file cap).

## Test plan

- [x] `bun install` succeeds
- [x] `bun run test` green (1115 pass, 7 skip, 0 fail)
- [x] `bun run build` succeeds; plugin loader picks up the new plugin (66 plugins loaded, was 65)
- [x] `maw project` prints help
- [x] `maw project list` prints list stub
- [x] `maw project learn <url>` / `incubate <url>` / `find <query>` / `search <query>` each dispatch to the right stub
- [x] `maw project learn` (no arg) prints `usage:` error; `maw project wat` prints help + unknown-subcommand error
- [ ] CI green on this PR

Closes #523.

Co-authored with mawjs <noreply@soulbrews.studio>.