### PR TITLE
fix(fleet): correct snapshot module import + accept trigger arg

### DIFF
--- a/src/commands/plugins/fleet/index.ts
+++ b/src/commands/plugins/fleet/index.ts
@@ -55,7 +55,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       const { cmdFleetSync } = await import("../../shared/fleet");
       await cmdFleetSync();
     } else if (sub === "snapshots" || sub === "snapshot-ls") {
-      const { listSnapshots } = await import("../../../snapshot");
+      const { listSnapshots } = await import("../../../core/fleet/snapshot");
       const snaps = listSnapshots();
       if (snaps.length === 0) {
         console.log("no snapshots yet");
@@ -68,7 +68,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         console.log(`  ${s.file.replace(".json", "")}  ${local}  \x1b[90m${s.trigger}\x1b[0m  ${s.sessionCount} sessions, ${s.windowCount} windows`);
       }
     } else if (sub === "restore") {
-      const { loadSnapshot, latestSnapshot } = await import("../../../snapshot");
+      const { loadSnapshot, latestSnapshot } = await import("../../../core/fleet/snapshot");
       const snap = args[1] ? loadSnapshot(args[1]) : latestSnapshot();
       if (!snap) {
         return { ok: false, error: "no snapshot found" };
@@ -83,9 +83,10 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         }
       }
     } else if (sub === "snapshot") {
-      const { takeSnapshot } = await import("../../../snapshot");
-      const path = await takeSnapshot("manual");
-      console.log(`\x1b[32m📸\x1b[0m snapshot saved: ${path}`);
+      const { takeSnapshot } = await import("../../../core/fleet/snapshot");
+      const trigger = args[1] || "manual";
+      const path = await takeSnapshot(trigger);
+      console.log(`\x1b[32m📸\x1b[0m snapshot saved: ${path} (trigger: ${trigger})`);
     } else if (!sub) {
       const { cmdFleetLs } = await import("../../shared/fleet");
       await cmdFleetLs();


### PR DESCRIPTION
## Summary
- `maw fleet snapshot/snapshots/restore` was broken by incorrect relative import path pointing to non-existent `src/commands/snapshot`; module actually lives at `src/core/fleet/snapshot.ts`.
- While the snapshot path was being fixed, the CLI trigger argument (useful for labeling scheduled/cron runs) wasn't being forwarded — hard-coded `"manual"` is now overridable via positional arg with safe default.

## Context
Oracle Council fleet (AI-Core LXC 110) needs daily fleet snapshots for a new compliance audit initiative. When trying to enable them discovered `maw fleet snapshot` errored with `Cannot find module '../../../snapshot'`. Fix is a one-file diff.

## Changes
- `src/commands/plugins/fleet/index.ts`
  - Replace `import("../../../snapshot")` with `import("../../../core/fleet/snapshot")` in 3 places (`snapshots`, `restore`, `snapshot` subcommand handlers).
  - Accept optional positional trigger arg: `maw fleet snapshot <trigger>` (defaults to `"manual"` for backward compatibility). Echoes the trigger back in the success log line for easier ops debugging.

## Test plan
- [x] `maw fleet snapshot` → writes snapshot with `"trigger": "manual"` (backward compat)
- [x] `maw fleet snapshot cron-daily` → writes snapshot with `"trigger": "cron-daily"`
- [x] `maw fleet snapshots` → lists saved snapshots
- [x] `maw fleet restore <ts>` → displays snapshot state (read-only time machine)
- [x] Snapshot file content contains expected 7 tmux sessions + windows

No other behaviour change. No build step required (bun runs TS directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)