### PR TITLE
Fix #393: bridge vault teams to tool store for shutdown/status

### DIFF
--- a/.github/workflows/ecosystem-drift.yml
+++ b/.github/workflows/ecosystem-drift.yml
@@ -1,0 +1,66 @@
+name: Ecosystem Drift Guard
+
+# Catches: refactors that rename/delete files referenced by ecosystem.config.cjs
+# Incident: 2026-04-17 — src/server.ts renamed to src/core/server.ts,
+#   ecosystem.config.cjs not updated → PM2 crash-loop (20+542 silent restarts)
+
+on:
+  push:
+    branches: [alpha, main]
+  pull_request:
+    branches: [alpha, main]
+
+jobs:
+  check-ecosystem:
+    name: ecosystem-paths
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify ecosystem.config.cjs script paths exist
+        run: bash scripts/check-ecosystem.sh
+
+  simulate-rename-regression:
+    name: rename-regression
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Simulate file rename breaking ecosystem (regression test)
+        run: |
+          echo "=== Simulating the Apr 17 incident ==="
+
+          # 1. Record current valid state
+          echo "Step 1: Verify current state is valid"
+          bash scripts/check-ecosystem.sh
+
+          # 2. Extract a script path from ecosystem config
+          SCRIPT=$(grep -oP "script:\s*'([^']+)'" ecosystem.config.cjs | head -1 | grep -oP "'[^']+'" | tr -d "'")
+          echo "Step 2: Target script = $SCRIPT"
+
+          if [ -z "$SCRIPT" ] || [ ! -f "$SCRIPT" ]; then
+            echo "⏭ No valid script to simulate with — skipping"
+            exit 0
+          fi
+
+          # 3. Rename the file (simulate refactor)
+          DIRNAME=$(dirname "$SCRIPT")
+          NEWPATH="${DIRNAME}/renamed-for-test-$(basename $SCRIPT)"
+          mv "$SCRIPT" "$NEWPATH"
+          echo "Step 3: Renamed $SCRIPT → $NEWPATH"
+
+          # 4. check-ecosystem.sh MUST fail
+          echo "Step 4: Verify check-ecosystem.sh catches the broken reference"
+          if bash scripts/check-ecosystem.sh 2>&1; then
+            echo "✗ REGRESSION: check-ecosystem.sh did NOT catch missing file!"
+            mv "$NEWPATH" "$SCRIPT"  # restore
+            exit 1
+          else
+            echo "✓ check-ecosystem.sh correctly caught the broken reference"
+          fi
+
+          # 5. Restore
+          mv "$NEWPATH" "$SCRIPT"
+          echo "Step 5: Restored $SCRIPT"
+          echo ""
+          echo "=== Regression test passed ==="

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -2,11 +2,11 @@ module.exports = {
   apps: [
     {
       name: 'maw',
-      script: 'src/server.ts',
-      interpreter: '/home/nat/.bun/bin/bun',
-      watch: ['src'],
-      watch_delay: 500,
-      ignore_watch: ['node_modules', 'ui'],
+      script: 'src/core/server.ts',
+      interpreter: 'bun',                // PATH lookup — works on any host
+      watch: false,                       // production: restart manual after deploy only
+      max_restarts: 5,                    // fail-fast — no silent 542-restart loops
+      restart_delay: 3000,
       env: {
         MAW_HOST: 'local',
         MAW_PORT: '3456',
@@ -33,15 +33,6 @@ module.exports = {
       restart_delay: 5000,
     },
     // maw-dev moved to Soul-Brews-Studio/maw-ui (bun run dev)
-    {
-      name: 'maw-broker',
-      script: 'src/broker.ts',
-      interpreter: '/home/nat/.bun/bin/bun',
-      autorestart: true,
-      watch: false,
-      env: {
-        MAW_BROKER: '1',
-      },
-    },
+    // maw-broker removed — MQTT layer deleted in 3b71daa (WebSocket handles broadcast)
   ],
 };

--- a/scripts/check-ecosystem.sh
+++ b/scripts/check-ecosystem.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# check-ecosystem.sh — Verify ecosystem.config.cjs references exist
+#
+# Catches the exact class of bug from 2026-04-17:
+#   refactor renamed src/server.ts → src/core/server.ts
+#   but ecosystem.config.cjs still pointed to old path
+#   → PM2 crash-loop (20 restarts maw, 542 restarts broker)
+#
+# Usage:
+#   ./scripts/check-ecosystem.sh          # as pre-commit hook or CI step
+#   ./scripts/check-ecosystem.sh --fix    # show suggested fixes
+
+set -euo pipefail
+
+CONFIG="ecosystem.config.cjs"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "⏭ No $CONFIG found — skipping"
+  exit 0
+fi
+
+# Extract all script paths from ecosystem config
+# Matches: script: 'path/to/file.ts' or script: "path/to/file.ts"
+SCRIPTS=$(grep -oP "script:\s*['\"]([^'\"]+)['\"]" "$CONFIG" | grep -oP "['\"][^'\"]+['\"]" | tr -d "'\""  || true)
+
+if [ -z "$SCRIPTS" ]; then
+  echo "⚠ No script entries found in $CONFIG"
+  exit 0
+fi
+
+FAIL=0
+CHECKED=0
+
+for s in $SCRIPTS; do
+  CHECKED=$((CHECKED + 1))
+  if [ -f "$s" ]; then
+    echo "  ✓ $s"
+  else
+    echo "  ✗ $s — FILE NOT FOUND"
+    # Try to find where it moved
+    BASENAME=$(basename "$s")
+    FOUND=$(find src/ -name "$BASENAME" -type f 2>/dev/null | head -3)
+    if [ -n "$FOUND" ]; then
+      echo "    → Did you mean: $FOUND"
+    fi
+    FAIL=1
+  fi
+done
+
+echo ""
+if [ $FAIL -eq 0 ]; then
+  echo "✓ All $CHECKED ecosystem script paths verified"
+else
+  echo "✗ ecosystem.config.cjs references missing files — update paths before committing"
+  exit 1
+fi

--- a/src/commands/plugins/team/team-lifecycle.ts
+++ b/src/commands/plugins/team/team-lifecycle.ts
@@ -2,7 +2,7 @@ import { readdirSync, readFileSync, writeFileSync, existsSync, mkdirSync, copyFi
 import { join } from "path";
 import { tmux } from "../../../sdk";
 import { assertValidOracleName } from "../../../core/fleet/validate";
-import { TEAMS_DIR, loadTeam, resolvePsi, writeShutdownRequest, cleanupTeamDir } from "./team-helpers";
+import { TEAMS_DIR, loadTeam, resolvePsi, writeShutdownRequest, cleanupTeamDir, type TeamConfig, type TeamMember } from "./team-helpers";
 
 const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
 
@@ -144,6 +144,19 @@ export function cmdTeamCreate(name: string, opts: { description?: string } = {})
   };
   writeFileSync(join(teamDir, "manifest.json"), JSON.stringify(manifest, null, 2));
 
+  // Bridge: write stub to tool store so list/status/shutdown can see this team (#393)
+  const toolTeamDir = join(TEAMS_DIR, name);
+  if (!existsSync(toolTeamDir)) {
+    mkdirSync(toolTeamDir, { recursive: true });
+    const stubConfig: TeamConfig = {
+      name,
+      description: opts.description || "",
+      members: [],
+      createdAt: Date.now(),
+    };
+    writeFileSync(join(toolTeamDir, "config.json"), JSON.stringify(stubConfig, null, 2));
+  }
+
   console.log(`\x1b[32m✓\x1b[0m team '${name}' created`);
   console.log(`  \x1b[90m${teamDir}/manifest.json\x1b[0m`);
 }
@@ -206,6 +219,19 @@ export function cmdTeamSpawn(
   if (!manifest.members.includes(role)) {
     manifest.members.push(role);
     writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+  }
+
+  // Bridge: sync member to tool store config (#393)
+  const toolConfigPath = join(TEAMS_DIR, teamName, "config.json");
+  if (existsSync(toolConfigPath)) {
+    try {
+      const toolConfig = JSON.parse(readFileSync(toolConfigPath, "utf-8"));
+      const member: TeamMember = { name: role, model };
+      if (!toolConfig.members.some((m: any) => m.name === role)) {
+        toolConfig.members.push(member);
+        writeFileSync(toolConfigPath, JSON.stringify(toolConfig, null, 2));
+      }
+    } catch { /* best effort */ }
   }
 
   console.log(`\x1b[32m✓\x1b[0m spawn prompt written for '${role}'`);

--- a/test/isolated/team-list-vault-teams.test.ts
+++ b/test/isolated/team-list-vault-teams.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdirSync, writeFileSync, rmSync } from "fs";
+import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { _setDirs } from "../../src/commands/plugins/team/impl";
@@ -146,5 +146,44 @@ describe("listVaultOnlyTeams + cmdTeamList — #393 Bug B", () => {
 
     const { cmdTeamList } = await import("../../src/commands/plugins/team/impl");
     await expect(cmdTeamList()).resolves.toBeUndefined();
+  });
+});
+
+describe("cmdTeamCreate bridge — #393 Bug B extension", () => {
+  test("create writes stub config.json to tool store", async () => {
+    const { cmdTeamCreate } = await import("../../src/commands/plugins/team/impl");
+    const origLog = console.log;
+    console.log = () => {};
+    try {
+      cmdTeamCreate("bridge-test", { description: "testing bridge" });
+    } finally {
+      console.log = origLog;
+    }
+    // Vault manifest exists
+    const vaultManifest = join(oracleRoot, "ψ/memory/mailbox/teams/bridge-test/manifest.json");
+    expect(existsSync(vaultManifest)).toBe(true);
+    // Tool store stub also exists
+    const toolConfig = join(toolTeamsDir, "bridge-test/config.json");
+    expect(existsSync(toolConfig)).toBe(true);
+    const config = JSON.parse(readFileSync(toolConfig, "utf-8"));
+    expect(config.name).toBe("bridge-test");
+    expect(config.members).toEqual([]);
+  });
+
+  test("spawn syncs member to tool store config", async () => {
+    const { cmdTeamCreate, cmdTeamSpawn } = await import("../../src/commands/plugins/team/impl");
+    const origLog = console.log;
+    console.log = () => {};
+    try {
+      cmdTeamCreate("spawn-bridge", { description: "spawn test" });
+      cmdTeamSpawn("spawn-bridge", "researcher", { model: "sonnet" });
+    } finally {
+      console.log = origLog;
+    }
+    // Tool store config should have the member
+    const toolConfig = join(toolTeamsDir, "spawn-bridge/config.json");
+    expect(existsSync(toolConfig)).toBe(true);
+    const config = JSON.parse(readFileSync(toolConfig, "utf-8"));
+    expect(config.members.some((m: any) => m.name === "researcher")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #393 (two-store split): CLI-created teams were written to the vault manifest only, leaving `shutdown`/`status`/`list` unable to find them via the tool store at `~/.claude/teams/`.

- `cmdTeamCreate` now writes a stub `config.json` to `~/.claude/teams/` after creating the vault manifest, so all lifecycle verbs resolve CLI-created teams
- `cmdTeamSpawn` syncs new members to the tool store config
- Regression tests cover both bridges

Also on this branch (related stability work):
- `c43c5a3` — harden `ecosystem.config.cjs` to prevent crash-loop class of failures
- `f03e2a8` — CI ecosystem drift guard to prevent PM2 crash-loop from refactors

## Test plan

- [ ] `npm test` — 0 new failures vs `main` (verified locally on 2026-04-17; 154 fail / 39 errors are pre-existing `withPaneLock` export issue, unrelated)
- [ ] Create a team via CLI, confirm it appears in `team list` and responds to `team status`
- [ ] `team shutdown <name>` finds the CLI-created team
- [ ] Regression tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)