### PR TITLE
fix(hey): actionable error for ambiguous agent-name match (closes #567)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,8 @@ import { getVersionString } from "./cli/cmd-version";
 import { runUpdate } from "./cli/cmd-update";
 import { runBootstrap } from "./cli/plugin-bootstrap";
 import { UserError, isUserError } from "./core/util/user-error";
+import { AmbiguousMatchError } from "./core/runtime/find-window";
+import { renderAmbiguousMatch } from "./core/util/render-ambiguous";
 import { join } from "path";
 import { homedir } from "os";
 
@@ -162,6 +164,13 @@ async function main(): Promise<void> {
 // bugs still surface their full stack so we can debug them.
 main().catch((e: unknown) => {
   if (isUserError(e)) {
+    process.exit(1);
+  }
+  // #567 — AmbiguousMatchError escapes from findWindow via resolver chains
+  // (cmdSend, cmdPeek, talk-to, view, etc.). Render it as actionable CLI
+  // output instead of a minified stack trace. Exit 1 preserved.
+  if (e instanceof AmbiguousMatchError) {
+    console.error(renderAmbiguousMatch(e, args));
     process.exit(1);
   }
   console.error(e);

--- a/src/core/util/render-ambiguous.ts
+++ b/src/core/util/render-ambiguous.ts
@@ -1,0 +1,47 @@
+/**
+ * Render AmbiguousMatchError as a clean, actionable CLI message (#567).
+ *
+ * Pre-#567 the raw error (plus minified bundle frames) leaked to stderr.
+ * Now the top-level CLI catch calls this to produce:
+ *
+ *   error: 'X' matches N candidates:
+ *     • candidate-1
+ *     • candidate-2
+ *   rerun with one of:
+ *     maw hey candidate-1 "..."
+ *     maw hey candidate-2 "..."
+ *
+ * Colour scheme matches the rest of the CLI (red for error, cyan for hint).
+ */
+import { AmbiguousMatchError } from "../runtime/find-window";
+
+const RED = "\x1b[31m";
+const CYAN = "\x1b[36m";
+const RESET = "\x1b[0m";
+
+/**
+ * Reconstruct a rerun-hint command line from the original argv and a
+ * candidate. We locate the ambiguous query in argv (first occurrence)
+ * and substitute the candidate. Falls back to `maw <verb> <candidate>`
+ * if argv doesn't contain the query verbatim (e.g. resolved via alias).
+ */
+function buildRerunHint(argv: string[], query: string, candidate: string): string {
+  const quoteIfNeeded = (s: string): string => (s.includes(" ") ? `"${s}"` : s);
+  const idx = argv.indexOf(query);
+  if (idx === -1) {
+    const verb = argv[0] ?? "hey";
+    return `maw ${verb} ${candidate} "..."`;
+  }
+  const parts = argv.slice();
+  parts[idx] = candidate;
+  return `maw ${parts.map(quoteIfNeeded).join(" ")}`;
+}
+
+export function renderAmbiguousMatch(err: AmbiguousMatchError, argv: string[]): string {
+  const lines: string[] = [];
+  lines.push(`${RED}error${RESET}: '${err.query}' matches ${err.candidates.length} candidates:`);
+  for (const c of err.candidates) lines.push(`  • ${c}`);
+  lines.push(`${CYAN}rerun with one of:${RESET}`);
+  for (const c of err.candidates) lines.push(`  ${buildRerunHint(argv, err.query, c)}`);
+  return lines.join("\n");
+}

--- a/test/render-ambiguous.test.ts
+++ b/test/render-ambiguous.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "bun:test";
+import { AmbiguousMatchError } from "../src/core/runtime/find-window";
+import { renderAmbiguousMatch } from "../src/core/util/render-ambiguous";
+
+// #567 — the CLI must render AmbiguousMatchError as an actionable message,
+// not a minified stack. These tests lock the essentials: each candidate on
+// its own line, a "rerun with" hint per candidate, and query echoed in the
+// primary line. We deliberately don't assert on ANSI codes — tests are
+// brittle enough without encoding colour in string literals.
+
+describe("renderAmbiguousMatch (#567)", () => {
+  const err = new AmbiguousMatchError("mawjs-oracle", ["101-mawjs:0", "mawjs-view:0"]);
+  const argv = ["hey", "mawjs-oracle", "hello"];
+  const out = renderAmbiguousMatch(err, argv);
+
+  it("includes the ambiguous query in the primary error line", () => {
+    expect(out).toContain("'mawjs-oracle'");
+    expect(out).toContain("matches 2 candidates");
+  });
+
+  it("lists each candidate on its own line", () => {
+    expect(out).toContain("• 101-mawjs:0");
+    expect(out).toContain("• mawjs-view:0");
+  });
+
+  it("emits a rerun hint per candidate, substituting the query", () => {
+    expect(out).toContain("rerun with one of");
+    expect(out).toContain("maw hey 101-mawjs:0");
+    expect(out).toContain("maw hey mawjs-view:0");
+    // Ambiguous query string must not reappear in any rerun hint.
+    const hintLines = out.split("\n").filter(l => l.startsWith("  maw "));
+    expect(hintLines.length).toBe(2);
+    for (const h of hintLines) expect(h).not.toContain("mawjs-oracle");
+  });
+
+  it("falls back to a generic hint when argv doesn't contain the query", () => {
+    const out2 = renderAmbiguousMatch(err, ["send", "someOtherThing", "msg"]);
+    expect(out2).toContain("maw send 101-mawjs:0");
+    expect(out2).toContain("maw send mawjs-view:0");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #567. First "defensive UX" landing from the #565 multi-instance + federation pairing proposal.

Previously, `maw hey white:mawjs-oracle "..."` (and `maw send` / `maw peek` / `maw view` / `maw a`) would surface a raw `AmbiguousMatchError` plus ~5 lines of minified `dist/maw` stack frames when the bare-name resolver hit two or more candidates. The user was left to eyeball the first line of the message and guess the rerun form.

Now, the top-level CLI catch (`src/cli.ts`) intercepts `AmbiguousMatchError` and renders an actionable message using the existing red/cyan ANSI style:

```
error: 'mawjs-oracle' matches 2 candidates:
  • 101-mawjs:0
  • mawjs-view:0
rerun with one of:
  maw hey 101-mawjs:0 "..."
  maw hey mawjs-view:0 "..."
```

Exit code 1 preserved. No change to the matching algorithm in `find-window.ts`.

## Approach

- Central catch in `src/cli.ts` (top-level `main().catch`) rather than per-verb try/catch. Cleanest — any verb that routes through `findWindow` benefits (hey, send, tell, peek, a, view, talk-to, ...).
- Rendering lives in `src/core/util/render-ambiguous.ts`, consumed by the catch. Pure function, easy to test without mocking the CLI.
- Rerun hint reconstructs the original argv, substituting the ambiguous query with each candidate. Falls back to `maw <verb> <candidate> "..."` if the query isn't in argv verbatim (e.g. alias resolution).

## Scope

- In: catch path + renderer + test
- Out: matching algorithm (unchanged), TTY interactive picker (follow-up), `--instance` plumbing (that's #566)

## Test plan

- [x] New unit test `test/render-ambiguous.test.ts` (4 tests, 12 assertions): query echoed, each candidate listed, rerun hint per candidate, fallback hint when argv doesn't carry the query
- [x] `bun run test` green: 1119 pass / 0 fail / 7 skip / 1126 total
- [x] `bun build src/cli.ts` clean
- [x] LOC: 97 total (9 cli.ts + 47 render + 41 test); well under the 300 cap

## Files

- `src/cli.ts` — +9 (import + catch branch)
- `src/core/util/render-ambiguous.ts` — new, 47 LOC
- `test/render-ambiguous.test.ts` — new, 41 LOC

🤖 Generated with [Claude Code](https://claude.com/claude-code)