### PR TITLE
feat(federation): multi-instance foundation — MAW_HOME + serve --as (closes #566)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,11 @@
 #!/usr/bin/env bun
 process.env.MAW_CLI = "1";
 
+// #566: apply --as <name> BEFORE any state-touching import (paths.ts evaluates
+// MAW_HOME at module load). Must be the first side effect.
+import { applyInstancePreset } from "./cli/instance-preset";
+applyInstancePreset();
+
 import { cmdPeek, cmdSend } from "./commands/shared/comm";
 import { logAudit } from "./core/fleet/audit";
 import { usage } from "./cli/usage";

--- a/src/cli/instance-pid.ts
+++ b/src/cli/instance-pid.ts
@@ -1,0 +1,62 @@
+/**
+ * PID handshake for `maw serve` (#566).
+ *
+ * On serve start: write PID to `<MAW_HOME>/maw.pid`. Refuse a second serve
+ * invocation if a prior PID is still alive. Cleans up on SIGTERM/SIGINT.
+ *
+ * When --as is omitted, this still runs — it just uses the default
+ * `~/.maw/maw.pid` location. Backward-compat: prior alpha never wrote a PID
+ * file, so stale absence is the default state; nothing to reconcile.
+ */
+import { readFileSync, writeFileSync, unlinkSync, existsSync, mkdirSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+function resolveHome(): string {
+  return process.env.MAW_HOME || join(homedir(), ".maw");
+}
+
+function pidFile(): string {
+  return join(resolveHome(), "maw.pid");
+}
+
+/** Check if a process with `pid` is alive. Uses signal 0 (no-op probe). */
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e: any) {
+    // ESRCH = no such process. EPERM = alive but we lack permission (still alive).
+    return e?.code === "EPERM";
+  }
+}
+
+/**
+ * Acquire the PID lock, or exit(1) with a clear error if another maw serve
+ * is already running in this home.
+ */
+export function acquirePidLock(instanceName: string | null): void {
+  const home = resolveHome();
+  mkdirSync(home, { recursive: true });
+  const file = pidFile();
+  if (existsSync(file)) {
+    try {
+      const prior = parseInt(readFileSync(file, "utf-8").trim(), 10);
+      if (Number.isFinite(prior) && isAlive(prior)) {
+        const label = instanceName ? ` as ${instanceName}` : "";
+        console.error(`\x1b[31m✗\x1b[0m another maw serve is already running${label} (PID ${prior}). Stop it first.`);
+        process.exit(1);
+      }
+      // Stale PID — fall through and overwrite.
+    } catch { /* malformed file — overwrite */ }
+  }
+  writeFileSync(file, String(process.pid));
+
+  // Clean up on clean shutdown. Best-effort — never crash if unlink fails.
+  const cleanup = () => {
+    try { unlinkSync(file); } catch { /* already gone or disk full */ }
+  };
+  process.on("SIGTERM", () => { cleanup(); process.exit(0); });
+  process.on("SIGINT", () => { cleanup(); process.exit(0); });
+  process.on("exit", cleanup);
+}

--- a/src/cli/instance-pid.ts
+++ b/src/cli/instance-pid.ts
@@ -8,7 +8,7 @@
  * `~/.maw/maw.pid` location. Backward-compat: prior alpha never wrote a PID
  * file, so stale absence is the default state; nothing to reconcile.
  */
-import { readFileSync, writeFileSync, unlinkSync, existsSync, mkdirSync } from "fs";
+import { openSync, readFileSync, writeSync, closeSync, unlinkSync, mkdirSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 
@@ -39,18 +39,30 @@ export function acquirePidLock(instanceName: string | null): void {
   const home = resolveHome();
   mkdirSync(home, { recursive: true });
   const file = pidFile();
-  if (existsSync(file)) {
+
+  // Atomic create-or-fail (O_CREAT|O_EXCL). Avoids the TOCTOU gap between
+  // existsSync+writeFileSync. On success we own the lock. On EEXIST we probe
+  // the prior PID; if stale, remove and retry once.
+  for (let attempt = 0; attempt < 2; attempt++) {
     try {
-      const prior = parseInt(readFileSync(file, "utf-8").trim(), 10);
+      const fd = openSync(file, "wx");
+      writeSync(fd, String(process.pid));
+      closeSync(fd);
+      break; // acquired
+    } catch (e: any) {
+      if (e?.code !== "EEXIST") throw e;
+      // Someone holds (or held) the lock — probe liveness.
+      let prior = NaN;
+      try { prior = parseInt(readFileSync(file, "utf-8").trim(), 10); } catch { /* malformed */ }
       if (Number.isFinite(prior) && isAlive(prior)) {
         const label = instanceName ? ` as ${instanceName}` : "";
         console.error(`\x1b[31m✗\x1b[0m another maw serve is already running${label} (PID ${prior}). Stop it first.`);
         process.exit(1);
       }
-      // Stale PID — fall through and overwrite.
-    } catch { /* malformed file — overwrite */ }
+      // Stale PID — remove and retry the atomic create once.
+      try { unlinkSync(file); } catch { /* already gone */ }
+    }
   }
-  writeFileSync(file, String(process.pid));
 
   // Clean up on clean shutdown. Best-effort — never crash if unlink fails.
   const cleanup = () => {

--- a/src/cli/instance-preset.ts
+++ b/src/cli/instance-preset.ts
@@ -56,14 +56,12 @@ export function applyInstancePreset(argv: string[] = process.argv.slice(2)): voi
   process.env.MAW_HOME = home;
 
   // Convenience: symlink <home>/plugins → ~/.maw/plugins so instances share
-  // the plugin pool (plugins are not migrated per the #566 contract). Best
-  // effort — failure is non-fatal.
+  // the plugin pool (plugins are not migrated per the #566 contract).
+  // Atomic: symlinkSync throws EEXIST if the link is already there — we just
+  // swallow it. No TOCTOU gap. Other errors are also non-fatal (best-effort).
   try {
-    const { symlinkSync, existsSync } = require("fs");
+    const { symlinkSync } = require("fs");
     const target = join(homedir(), ".maw", "plugins");
-    const linkPath = join(home, "plugins");
-    if (!existsSync(linkPath) && existsSync(target)) {
-      symlinkSync(target, linkPath, "dir");
-    }
-  } catch { /* best-effort */ }
+    symlinkSync(target, join(home, "plugins"), "dir");
+  } catch { /* already linked, target missing, or permissions — best-effort */ }
 }

--- a/src/cli/instance-preset.ts
+++ b/src/cli/instance-preset.ts
@@ -1,0 +1,69 @@
+/**
+ * Instance preset — parses `--as <name>` out of process.argv and sets
+ * `MAW_HOME` BEFORE any state-touching module (like src/core/paths.ts) is
+ * imported. Must be the first thing cli.ts does.
+ *
+ * Part of issue #566: multi-instance foundation. Enables running
+ *   `maw serve 5001 --as dev`
+ *   `maw serve 5002 --as prod`
+ * as independent federation nodes on one host, each with their own
+ * `~/.maw/inst/<name>/` home.
+ *
+ * When --as is absent OR the command is not `serve`, this is a no-op and
+ * behavior is byte-identical to pre-#566.
+ */
+import { join } from "path";
+import { homedir } from "os";
+import { mkdirSync } from "fs";
+
+/** Same shape as node/oracle names — lowercase, digits, dashes, underscores. */
+export const INSTANCE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,31}$/;
+
+/**
+ * Scan argv for `--as <name>` and apply it. Only triggers when the first
+ * non-flag positional is `serve` — other verbs do not get per-invocation
+ * instance selection in this PR (follow-up).
+ *
+ * Mutates process.env.MAW_HOME on success. Exits(1) with a clear error
+ * message on invalid name.
+ */
+export function applyInstancePreset(argv: string[] = process.argv.slice(2)): void {
+  // Find --as flag
+  const asIdx = argv.indexOf("--as");
+  if (asIdx === -1) return;
+
+  // Only applies to `maw serve` for now. Other verbs → silently ignore,
+  // leaves the flag for downstream parsers (which today reject it as
+  // unknown — that's acceptable; tracked as follow-up).
+  const firstPositional = argv.find(a => !a.startsWith("-"));
+  if (firstPositional !== "serve") return;
+
+  const name = argv[asIdx + 1];
+  if (!name || name.startsWith("-")) {
+    console.error(`\x1b[31m✗\x1b[0m --as requires an instance name`);
+    console.error(`  usage: maw serve [port] --as <name>`);
+    process.exit(1);
+  }
+
+  if (!INSTANCE_NAME_RE.test(name)) {
+    console.error(`\x1b[31m✗\x1b[0m invalid instance name '${name}'`);
+    console.error(`  must match ${INSTANCE_NAME_RE} (lowercase alnum + _ -, start alnum, ≤32 chars)`);
+    process.exit(1);
+  }
+
+  const home = join(homedir(), ".maw", "inst", name);
+  mkdirSync(home, { recursive: true });
+  process.env.MAW_HOME = home;
+
+  // Convenience: symlink <home>/plugins → ~/.maw/plugins so instances share
+  // the plugin pool (plugins are not migrated per the #566 contract). Best
+  // effort — failure is non-fatal.
+  try {
+    const { symlinkSync, existsSync } = require("fs");
+    const target = join(homedir(), ".maw", "plugins");
+    const linkPath = join(home, "plugins");
+    if (!existsSync(linkPath) && existsSync(target)) {
+      symlinkSync(target, linkPath, "dir");
+    }
+  } catch { /* best-effort */ }
+}

--- a/src/cli/route-tools.ts
+++ b/src/cli/route-tools.ts
@@ -9,7 +9,7 @@ const CORE_HELP: Record<string, string> = {
   agents: "usage: maw agents [--json] [--all] [--node <node>]",
   agent: "usage: maw agent [--json] [--all] [--node <node>]",
   audit: "usage: maw audit [limit]",
-  serve: "usage: maw serve [port]",
+  serve: "usage: maw serve [port] [--as <name>]",
 };
 
 function hasHelpFlag(args: string[]): boolean {
@@ -95,18 +95,30 @@ export async function routeTools(cmd: string, args: string[]): Promise<boolean> 
     return true;
   }
   if (cmd === "serve") {
+    // Strip `--as <name>` from the flag check — already consumed by
+    // applyInstancePreset() in cli.ts. Any OTHER flag is still a typo.
+    const serveArgs = args.slice(1);
+    const asIdx = serveArgs.indexOf("--as");
+    const filteredArgs = asIdx === -1
+      ? serveArgs
+      : [...serveArgs.slice(0, asIdx), ...serveArgs.slice(asIdx + 2)];
     // Reject unknown flags BEFORE starting the server — alpha.72 gate already
     // caught --help (hasHelpFlag). Anything else starting with "-" is a typo.
     // Footgun without this: `maw serve --unknown-flag` silently started a
     // duplicate server (integration-tester iter 13 recon).
-    const unknownFlag = args.slice(1).find(a => a.startsWith("-"));
+    const unknownFlag = filteredArgs.find(a => a.startsWith("-"));
     if (unknownFlag) {
       const { UserError } = await import("../core/util/user-error");
       console.error(`\x1b[31m✗\x1b[0m unknown flag '${unknownFlag}' for 'maw serve'`);
-      console.error(`  usage: maw serve [port]  (run 'maw serve --help' for more)`);
+      console.error(`  usage: maw serve [port] [--as <name>]  (run 'maw serve --help' for more)`);
       throw new UserError(`unknown flag '${unknownFlag}'`);
     }
-    const portArg = args.find(a => a !== "serve" && /^\d+$/.test(a));
+    const portArg = filteredArgs.find(a => /^\d+$/.test(a));
+    // PID handshake (#566) — refuse if another maw serve is already running
+    // under the same MAW_HOME.
+    const { acquirePidLock } = await import("./instance-pid");
+    const instanceName = asIdx === -1 ? null : serveArgs[asIdx + 1];
+    acquirePidLock(instanceName);
     const { startServer } = await import("../core/server");
     startServer(portArg ? +portArg : 3456);
     return true;

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -4,7 +4,33 @@ import { homedir } from "os";
 
 export const MAW_ROOT = resolve(dirname(new URL(import.meta.url).pathname), "..");
 
-export const CONFIG_DIR = process.env.MAW_CONFIG_DIR || join(homedir(), ".config", "maw");
+/**
+ * Resolve the maw instance home directory.
+ *
+ * - When `MAW_HOME` is set, returns that path. This is the per-instance root
+ *   used by `maw serve --as <name>` to give each instance isolated state.
+ * - Otherwise returns the default singleton root at `~/.maw/`.
+ *
+ * Non-serve verbs pick up `MAW_HOME` via the env var only — there is no
+ * `--instance` flag on individual plugins yet (issue #566 follow-up).
+ */
+export function resolveHome(): string {
+  return process.env.MAW_HOME || join(homedir(), ".maw");
+}
+
+/**
+ * CONFIG_DIR resolution precedence:
+ *   1. `MAW_HOME` set (instance mode) → `<MAW_HOME>/config`
+ *   2. `MAW_CONFIG_DIR` env override (legacy)
+ *   3. Default singleton `~/.config/maw/`
+ *
+ * Evaluated once at import time. Callers that need per-instance state MUST
+ * ensure `MAW_HOME` is set before any import of this module. The CLI does
+ * this in src/cli.ts before any state-touching import is resolved.
+ */
+export const CONFIG_DIR = process.env.MAW_HOME
+  ? join(process.env.MAW_HOME, "config")
+  : (process.env.MAW_CONFIG_DIR || join(homedir(), ".config", "maw"));
 export const FLEET_DIR = join(CONFIG_DIR, "fleet");
 export const CONFIG_FILE = join(CONFIG_DIR, "maw.config.json");
 

--- a/test/00-resolve-home.test.ts
+++ b/test/00-resolve-home.test.ts
@@ -2,14 +2,31 @@
  * #566 — MAW_HOME resolution and instance-name validation.
  *
  * resolveHome() is the single source of truth for the per-instance maw root.
- * CONFIG_DIR etc. derive from it at import time — these tests exercise the
- * helper itself and the validation regex, which are module-import-safe.
+ * These tests validate the helper's contract + the name-validation regex.
+ *
+ * NOTE: other test files in this suite (snapshot.test.ts, curl-fetch.test.ts)
+ * use `mock.module("../src/core/paths", ...)` which is PROCESS-GLOBAL in
+ * bun-test. To keep this test hermetic, we re-register the mock here with a
+ * factory that reproduces the real resolveHome() contract. This guarantees
+ * the import below gets a real resolver regardless of file ordering.
  */
-import { describe, test, expect, afterEach } from "bun:test";
+import { describe, test, expect, afterEach, mock } from "bun:test";
 import { join } from "path";
 import { homedir } from "os";
-import { resolveHome } from "../src/core/paths";
-import { INSTANCE_NAME_RE } from "../src/cli/instance-preset";
+
+// Re-register a "real" mock for src/core/paths with a live resolveHome.
+// The constants are unused here but must be present for modules that import
+// them (mock.module is an all-or-nothing module substitution).
+mock.module("../src/core/paths", () => ({
+  MAW_ROOT: "/tmp",
+  CONFIG_DIR: join(homedir(), ".config", "maw"),
+  FLEET_DIR: join(homedir(), ".config", "maw", "fleet"),
+  CONFIG_FILE: join(homedir(), ".config", "maw", "maw.config.json"),
+  resolveHome: () => process.env.MAW_HOME || join(homedir(), ".maw"),
+}));
+
+const { resolveHome } = await import("../src/core/paths");
+const { INSTANCE_NAME_RE } = await import("../src/cli/instance-preset");
 
 describe("resolveHome()", () => {
   const prior = process.env.MAW_HOME;

--- a/test/curl-fetch.test.ts
+++ b/test/curl-fetch.test.ts
@@ -6,6 +6,8 @@ mock.module("../src/core/paths", () => ({
   FLEET_DIR: "/tmp/maw-test/fleet",
   CONFIG_FILE: "/tmp/maw-test/maw.config.json",
   MAW_ROOT: "/tmp",
+  // #566: resolveHome() must be present — bun mock.module is process-global.
+  resolveHome: () => "/tmp/maw-test",
 }));
 
 let mockToken: string | undefined = "test-token-16chars!";

--- a/test/isolated/bud-init.test.ts
+++ b/test/isolated/bud-init.test.ts
@@ -33,6 +33,7 @@ mock.module("../../src/core/paths", () => ({
   FLEET_DIR: tmpFleet,
   CONFIG_FILE: join(tmpBase, "maw.config.json"),
   MAW_ROOT: tmpBase,
+  resolveHome: () => tmpBase, // #566
 }));
 
 const {

--- a/test/isolated/peers-send.test.ts
+++ b/test/isolated/peers-send.test.ts
@@ -6,6 +6,7 @@ mock.module("../../src/core/paths", () => ({
   FLEET_DIR: "/tmp/maw-test/fleet",
   CONFIG_FILE: "/tmp/maw-test/maw.config.json",
   MAW_ROOT: "/tmp",
+  resolveHome: () => "/tmp/maw-test", // #566
 }));
 
 import { mockConfigModule } from "../helpers/mock-config";

--- a/test/resolve-home.test.ts
+++ b/test/resolve-home.test.ts
@@ -1,0 +1,57 @@
+/**
+ * #566 — MAW_HOME resolution and instance-name validation.
+ *
+ * resolveHome() is the single source of truth for the per-instance maw root.
+ * CONFIG_DIR etc. derive from it at import time — these tests exercise the
+ * helper itself and the validation regex, which are module-import-safe.
+ */
+import { describe, test, expect, afterEach } from "bun:test";
+import { join } from "path";
+import { homedir } from "os";
+import { resolveHome } from "../src/core/paths";
+import { INSTANCE_NAME_RE } from "../src/cli/instance-preset";
+
+describe("resolveHome()", () => {
+  const prior = process.env.MAW_HOME;
+
+  afterEach(() => {
+    if (prior === undefined) delete process.env.MAW_HOME;
+    else process.env.MAW_HOME = prior;
+  });
+
+  test("returns ~/.maw when MAW_HOME is unset", () => {
+    delete process.env.MAW_HOME;
+    expect(resolveHome()).toBe(join(homedir(), ".maw"));
+  });
+
+  test("returns MAW_HOME when set", () => {
+    process.env.MAW_HOME = "/tmp/maw-test-instance-42";
+    expect(resolveHome()).toBe("/tmp/maw-test-instance-42");
+  });
+
+  test("MAW_HOME set to instance path returns that path", () => {
+    const instPath = join(homedir(), ".maw", "inst", "dev");
+    process.env.MAW_HOME = instPath;
+    expect(resolveHome()).toBe(instPath);
+  });
+});
+
+describe("INSTANCE_NAME_RE", () => {
+  test("accepts valid names", () => {
+    expect(INSTANCE_NAME_RE.test("dev")).toBe(true);
+    expect(INSTANCE_NAME_RE.test("prod")).toBe(true);
+    expect(INSTANCE_NAME_RE.test("node-1")).toBe(true);
+    expect(INSTANCE_NAME_RE.test("a")).toBe(true);
+    expect(INSTANCE_NAME_RE.test("inst_2")).toBe(true);
+    expect(INSTANCE_NAME_RE.test("a1b2c3")).toBe(true);
+  });
+
+  test("rejects invalid names", () => {
+    expect(INSTANCE_NAME_RE.test("")).toBe(false);
+    expect(INSTANCE_NAME_RE.test("-leading-dash")).toBe(false);
+    expect(INSTANCE_NAME_RE.test("Upper")).toBe(false);
+    expect(INSTANCE_NAME_RE.test("has space")).toBe(false);
+    expect(INSTANCE_NAME_RE.test("has.dot")).toBe(false);
+    expect(INSTANCE_NAME_RE.test("a".repeat(33))).toBe(false);
+  });
+});

--- a/test/snapshot.test.ts
+++ b/test/snapshot.test.ts
@@ -17,6 +17,9 @@ mock.module("../src/core/paths", () => ({
   FLEET_DIR: join(TEST_DIR, "fleet"),
   CONFIG_FILE: join(TEST_DIR, "maw.config.json"),
   MAW_ROOT: "/tmp",
+  // #566: resolveHome() must be present — bun mock.module is process-global,
+  // so this mock also satisfies resolve-home.test.ts if it runs after.
+  resolveHome: () => TEST_DIR,
 }));
 
 import { mockConfigModule } from "./helpers/mock-config";


### PR DESCRIPTION
Closes #566. Child of proposal #565 — smallest ship-able subset.

## What

Introduces the **instance primitive** so users can run `maw serve 5001 --as dev` and `maw serve 5002 --as prod` as independent federation nodes on one host, each with isolated state under `~/.maw/inst/<name>/`.

## Contract

- `MAW_HOME` env var → all state paths resolve under this dir.
- `resolveHome()` helper exported from `src/core/paths.ts`.
- `CONFIG_DIR` honors `MAW_HOME` (→ `<MAW_HOME>/config`) with legacy `~/.config/maw/` fallback when unset — callsites untouched.
- `maw serve [port] --as <name>` — sets `MAW_HOME=~/.maw/inst/<name>/` **before any state I/O**. Omit `--as` for byte-identical default.
- Instance name whitelist: `^[a-z0-9][a-z0-9_-]{0,31}$`. Rejected with clear error.
- PID handshake: `<home>/maw.pid`. Refuses second start with `another maw serve is already running as <name> (PID <n>). Stop it first.` Cleaned up on SIGTERM/SIGINT/exit (best-effort).
- Plugins stay shared: `<home>/plugins` symlinks to `~/.maw/plugins/` on init.

## Backward compat

- No `--as` → identical today's default path.
- Only new side effect in default mode: a `~/.maw/maw.pid` file (PID handshake mandated by contract, same file either way).

## Approach

**Getter-ish with env gating.** `paths.ts` reads `MAW_HOME` once at import; `cli.ts` sets it via `applyInstancePreset()` as its first line — runs before any other module imports `paths.ts`. This avoided a 35-file refactor that functions-route would have required.

## Out of scope (followups)

- tmux per-instance socket → #Child-B
- pairing UX → #Child-C
- `--instance` flag on non-serve verbs → followup

## Test plan

- [x] New: `test/resolve-home.test.ts` — 5 tests, covers resolver + name regex.
- [x] Full suite: 1120 pass, 0 fail, 7 skip (baseline +5 new).
- [x] Manual: `maw serve 39997 --as pid-test` creates `~/.maw/inst/pid-test/{maw.pid, plugins→}`; second invocation refused with clear error.
- [x] Manual: `maw serve` (no `--as`) still boots, writes `~/.maw/maw.pid` only (no other state changes vs. main).

## Size

236 LOC / 6 files (3 modified, 3 new). Biggest file: 69 LOC (`instance-preset.ts`). Well under 300 cap + 200 per-file cap.