### PR TITLE
feat(plugin): maw peers — node aliases for federation (closes #568)

### DIFF
--- a/src/commands/plugins/peers/impl.ts
+++ b/src/commands/plugins/peers/impl.ts
@@ -1,0 +1,113 @@
+/**
+ * maw peers — subcommand implementations (#568).
+ *
+ * Pure(-ish) functions for CRUD over `~/.maw/peers.json`. No CLI
+ * parsing here — the dispatcher in index.ts peels off `args[0]` and
+ * hands typed positional + flag data to these functions.
+ *
+ * Node resolution (when `--node` is not given) is intentionally
+ * best-effort: we try `<url>/info`, and on any error (missing endpoint,
+ * DNS, timeout) we store `node: null`. An alias without a node is still
+ * valid — it just means `alias:<agent>` routing needs the URL-to-node
+ * map from another source. That's a follow-up concern.
+ */
+import { loadPeers, savePeers, type Peer } from "./store";
+
+const ALIAS_RE = /^[a-z0-9][a-z0-9_-]{0,31}$/;
+
+export function validateAlias(alias: string): string | null {
+  if (!ALIAS_RE.test(alias)) {
+    return `invalid alias "${alias}" (must match ^[a-z0-9][a-z0-9_-]{0,31}$)`;
+  }
+  return null;
+}
+
+export function validateUrl(raw: string): string | null {
+  let parsed: URL;
+  try { parsed = new URL(raw); } catch { return `invalid URL "${raw}"`; }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return `invalid URL "${raw}" (must be http:// or https://)`;
+  }
+  return null;
+}
+
+/** Best-effort fetch of <url>/info to resolve node name. Returns null on any failure. */
+export async function resolveNode(url: string): Promise<string | null> {
+  try {
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), 2000);
+    const res = await fetch(new URL("/info", url), { signal: ctrl.signal });
+    clearTimeout(t);
+    if (!res.ok) return null;
+    const body = await res.json() as { node?: unknown; name?: unknown };
+    const node = (typeof body.node === "string" && body.node)
+      || (typeof body.name === "string" && body.name)
+      || null;
+    return node || null;
+  } catch {
+    return null;
+  }
+}
+
+export interface AddOptions {
+  alias: string;
+  url: string;
+  node?: string;
+}
+
+export interface AddResult {
+  alias: string;
+  overwrote: boolean;
+  peer: Peer;
+}
+
+export async function cmdAdd(opts: AddOptions): Promise<AddResult> {
+  const aliasErr = validateAlias(opts.alias);
+  if (aliasErr) throw new Error(aliasErr);
+  const urlErr = validateUrl(opts.url);
+  if (urlErr) throw new Error(urlErr);
+
+  const data = loadPeers();
+  const existed = Boolean(data.peers[opts.alias]);
+  const node = opts.node ?? await resolveNode(opts.url);
+  const peer: Peer = {
+    url: opts.url,
+    node: node || null,
+    addedAt: new Date().toISOString(),
+    lastSeen: null,
+  };
+  data.peers[opts.alias] = peer;
+  savePeers(data);
+  return { alias: opts.alias, overwrote: existed, peer };
+}
+
+export function cmdList(): Array<{ alias: string } & Peer> {
+  const data = loadPeers();
+  return Object.entries(data.peers)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([alias, p]) => ({ alias, ...p }));
+}
+
+export function cmdInfo(alias: string): ({ alias: string } & Peer) | null {
+  const data = loadPeers();
+  const p = data.peers[alias];
+  return p ? { alias, ...p } : null;
+}
+
+export function cmdRemove(alias: string): boolean {
+  const data = loadPeers();
+  if (!data.peers[alias]) return false;
+  delete data.peers[alias];
+  savePeers(data);
+  return true;
+}
+
+export function formatList(rows: Array<{ alias: string } & Peer>): string {
+  if (!rows.length) return "no peers";
+  const header = ["alias", "url", "node", "lastSeen"];
+  const lines = rows.map(r => [r.alias, r.url, r.node ?? "-", r.lastSeen ?? "-"]);
+  const widths = header.map((h, i) =>
+    Math.max(h.length, ...lines.map(l => l[i].length)));
+  const fmt = (cols: string[]) => cols.map((c, i) => c.padEnd(widths[i])).join("  ");
+  return [fmt(header), fmt(widths.map(w => "-".repeat(w))), ...lines.map(fmt)].join("\n");
+}

--- a/src/commands/plugins/peers/index.ts
+++ b/src/commands/plugins/peers/index.ts
@@ -1,0 +1,106 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+
+export const command = {
+  name: "peers",
+  description: "Federation peer aliases — add, list, info, remove (#568).",
+};
+
+/**
+ * maw peers — core plugin (#568).
+ *
+ * Subcommand dispatcher over the impl.ts CRUD functions. Shape mirrors
+ * the `project` plugin (#560): peel off positional[0] as the verb,
+ * dispatch on a switch, print helpText() on missing/unknown.
+ *
+ * Integration with `maw hey`/`peek`/`send` (alias:agent resolution)
+ * is intentionally deferred — this PR stands on its own with CRUD.
+ * Follow-up: resolve `<alias>:<agent>` via loadPeers() before the
+ * existing federation node lookup.
+ */
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const impl = await import("./impl");
+
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+
+  const out = () => logs.join("\n");
+  const help = () => [
+    "usage: maw peers <add|list|info|remove> [...]",
+    "  add    <alias> <url> [--node <name>]  — register alias (auto-resolves node via /info)",
+    "  list                                   — tabular list of all peers",
+    "  info   <alias>                         — JSON details for one peer",
+    "  remove <alias>                         — remove (idempotent)",
+    "",
+    "storage: ~/.maw/peers.json (v1)",
+  ].join("\n");
+
+  try {
+    const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+    const positional = args.filter(a => !a.startsWith("--"));
+    const sub = positional[0];
+
+    if (!sub) {
+      console.log(help());
+      return { ok: true, output: out() || help() };
+    }
+
+    switch (sub) {
+      case "add": {
+        const alias = positional[1];
+        const url = positional[2];
+        if (!alias || !url) {
+          return { ok: false, error: "usage: maw peers add <alias> <url> [--node <name>]" };
+        }
+        const nodeIdx = args.indexOf("--node");
+        const node = nodeIdx >= 0 ? args[nodeIdx + 1] : undefined;
+        const res = await impl.cmdAdd({ alias, url, node });
+        if (res.overwrote) console.log(`warning: alias "${alias}" already existed — overwriting`);
+        console.log(`added ${alias} → ${url}${res.peer.node ? ` (${res.peer.node})` : ""}`);
+        return { ok: true, output: out() };
+      }
+      case "list":
+      case "ls": {
+        console.log(impl.formatList(impl.cmdList()));
+        return { ok: true, output: out() };
+      }
+      case "info": {
+        const alias = positional[1];
+        if (!alias) return { ok: false, error: "usage: maw peers info <alias>" };
+        const found = impl.cmdInfo(alias);
+        if (!found) return { ok: false, error: `peer "${alias}" not found` };
+        console.log(JSON.stringify(found, null, 2));
+        return { ok: true, output: out() };
+      }
+      case "remove":
+      case "rm": {
+        const alias = positional[1];
+        if (!alias) return { ok: false, error: "usage: maw peers remove <alias>" };
+        const removed = impl.cmdRemove(alias);
+        console.log(removed ? `removed ${alias}` : `no-op: ${alias} not present`);
+        return { ok: true, output: out() };
+      }
+      default: {
+        console.log(help());
+        return {
+          ok: false,
+          error: `maw peers: unknown subcommand "${sub}" (expected add|list|info|remove)`,
+          output: out() || help(),
+        };
+      }
+    }
+  } catch (e: any) {
+    return { ok: false, error: out() || e.message, output: out() || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/src/commands/plugins/peers/peers.test.ts
+++ b/src/commands/plugins/peers/peers.test.ts
@@ -1,0 +1,160 @@
+/**
+ * maw peers — unit tests (#568).
+ *
+ * Each test points PEERS_FILE at a unique tmp path so they are
+ * hermetic and parallel-safe. We exercise the impl layer directly
+ * (add/list/info/remove/validation/atomic-write) plus a thin
+ * end-to-end pass through the index.ts dispatcher.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, existsSync, writeFileSync, readFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "maw-peers-"));
+  process.env.PEERS_FILE = join(dir, "peers.json");
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+  delete process.env.PEERS_FILE;
+});
+
+describe("peers impl", () => {
+  it("validateAlias accepts lowercase + digits + -/_ up to 32 chars", async () => {
+    const { validateAlias } = await import("./impl");
+    expect(validateAlias("w")).toBeNull();
+    expect(validateAlias("white-01")).toBeNull();
+    expect(validateAlias("node_a")).toBeNull();
+    expect(validateAlias("")).not.toBeNull();
+    expect(validateAlias("-bad")).not.toBeNull();
+    expect(validateAlias("BAD")).not.toBeNull();
+    expect(validateAlias("a".repeat(33))).not.toBeNull();
+  });
+
+  it("validateUrl requires http(s)", async () => {
+    const { validateUrl } = await import("./impl");
+    expect(validateUrl("http://x.local:3456")).toBeNull();
+    expect(validateUrl("https://x.local")).toBeNull();
+    expect(validateUrl("ftp://x.local")).not.toBeNull();
+    expect(validateUrl("notaurl")).not.toBeNull();
+  });
+
+  it("add → list shows the peer", async () => {
+    const { cmdAdd, cmdList } = await import("./impl");
+    await cmdAdd({ alias: "w", url: "http://white.local:3456", node: "white" });
+    const rows = cmdList();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].alias).toBe("w");
+    expect(rows[0].url).toBe("http://white.local:3456");
+    expect(rows[0].node).toBe("white");
+  });
+
+  it("add rejects invalid alias", async () => {
+    const { cmdAdd } = await import("./impl");
+    await expect(cmdAdd({ alias: "BAD!", url: "http://x", node: "x" }))
+      .rejects.toThrow(/invalid alias/);
+  });
+
+  it("add rejects invalid URL", async () => {
+    const { cmdAdd } = await import("./impl");
+    await expect(cmdAdd({ alias: "x", url: "notaurl", node: "x" }))
+      .rejects.toThrow(/invalid URL/);
+  });
+
+  it("add over existing alias overwrites and reports it", async () => {
+    const { cmdAdd } = await import("./impl");
+    const first = await cmdAdd({ alias: "w", url: "http://a.local", node: "a" });
+    expect(first.overwrote).toBe(false);
+    const second = await cmdAdd({ alias: "w", url: "http://b.local", node: "b" });
+    expect(second.overwrote).toBe(true);
+    expect(second.peer.url).toBe("http://b.local");
+  });
+
+  it("remove existing returns true and list drops it", async () => {
+    const { cmdAdd, cmdRemove, cmdList } = await import("./impl");
+    await cmdAdd({ alias: "w", url: "http://w.local", node: "w" });
+    expect(cmdRemove("w")).toBe(true);
+    expect(cmdList()).toHaveLength(0);
+  });
+
+  it("remove non-existent is idempotent (returns false, no throw)", async () => {
+    const { cmdRemove } = await import("./impl");
+    expect(cmdRemove("ghost")).toBe(false);
+  });
+
+  it("info returns entry for known alias, null for unknown", async () => {
+    const { cmdAdd, cmdInfo } = await import("./impl");
+    await cmdAdd({ alias: "w", url: "http://w.local", node: "w" });
+    expect(cmdInfo("w")?.url).toBe("http://w.local");
+    expect(cmdInfo("ghost")).toBeNull();
+  });
+
+  it("formatList renders header + rows (non-empty) or placeholder (empty)", async () => {
+    const { cmdAdd, cmdList, formatList } = await import("./impl");
+    expect(formatList([])).toBe("no peers");
+    await cmdAdd({ alias: "w", url: "http://w.local", node: "w" });
+    const out = formatList(cmdList());
+    expect(out).toContain("alias");
+    expect(out).toContain("w");
+    expect(out).toContain("http://w.local");
+  });
+});
+
+describe("peers store — atomic write crash-safety", () => {
+  it("stale .tmp file from a crashed write does not corrupt load", async () => {
+    const { cmdAdd } = await import("./impl");
+    const { loadPeers, peersPath } = await import("./store");
+    await cmdAdd({ alias: "w", url: "http://w.local", node: "w" });
+    // Simulate a crash mid-write: the live file is intact, a stale .tmp exists.
+    writeFileSync(peersPath() + ".tmp", "{ corrupt partial write");
+    const loaded = loadPeers();
+    expect(loaded.peers.w?.url).toBe("http://w.local");
+  });
+
+  it("writes go via .tmp then rename (no partial file if rename fails)", async () => {
+    const { cmdAdd } = await import("./impl");
+    const { peersPath } = await import("./store");
+    await cmdAdd({ alias: "w", url: "http://w.local", node: "w" });
+    const body = readFileSync(peersPath(), "utf-8");
+    expect(body).toContain('"version"');
+    expect(body).toContain('"w"');
+    expect(existsSync(peersPath() + ".tmp")).toBe(false);
+  });
+});
+
+describe("peers dispatcher (index.ts)", () => {
+  it("no args → prints help", async () => {
+    const { default: handler } = await import("./index");
+    const res = await handler({ source: "cli", args: [] });
+    expect(res.ok).toBe(true);
+    expect(res.output).toContain("usage: maw peers");
+  });
+
+  it("unknown subcommand → error + help in output", async () => {
+    const { default: handler } = await import("./index");
+    const res = await handler({ source: "cli", args: ["wat"] });
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain("unknown subcommand");
+  });
+
+  it("add then list through dispatcher", async () => {
+    const { default: handler } = await import("./index");
+    const add = await handler({ source: "cli", args: ["add", "w", "http://w.local", "--node", "white"] });
+    expect(add.ok).toBe(true);
+    expect(add.output).toContain("added w");
+    const list = await handler({ source: "cli", args: ["list"] });
+    expect(list.ok).toBe(true);
+    expect(list.output).toContain("w");
+    expect(list.output).toContain("http://w.local");
+  });
+
+  it("remove non-existent via dispatcher is ok (no-op)", async () => {
+    const { default: handler } = await import("./index");
+    const res = await handler({ source: "cli", args: ["remove", "ghost"] });
+    expect(res.ok).toBe(true);
+    expect(res.output).toContain("no-op");
+  });
+});

--- a/src/commands/plugins/peers/plugin.json
+++ b/src/commands/plugins/peers/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "peers",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Manage federation peer aliases (#568).",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "peers",
+    "aliases": ["peer"],
+    "help": "maw peers <add|list|info|remove> [...] — federation peer aliases (see issue #568)"
+  },
+  "weight": 50
+}

--- a/src/commands/plugins/peers/store.ts
+++ b/src/commands/plugins/peers/store.ts
@@ -1,0 +1,67 @@
+/**
+ * maw peers — storage layer (#568).
+ *
+ * Atomic read/write of `~/.maw/peers.json`. Writes go via a temp file
+ * and rename(2) so a crash mid-write leaves either the old file intact
+ * or the new file fully in place — never a truncated file. A stale tmp
+ * file from a crashed previous write is ignored on load (the live file
+ * is still valid).
+ *
+ * Schema v1:
+ *   { version: 1, peers: { <alias>: { url, node, addedAt, lastSeen } } }
+ *
+ * Path resolution is a function (not a const) so tests can override
+ * `HOME` / the path via `PEERS_FILE` and get a fresh value each call.
+ */
+import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync, unlinkSync } from "fs";
+import { join, dirname } from "path";
+import { homedir } from "os";
+
+export interface Peer {
+  url: string;
+  node: string | null;
+  addedAt: string;
+  lastSeen: string | null;
+}
+
+export interface PeersFile {
+  version: 1;
+  peers: Record<string, Peer>;
+}
+
+export function peersPath(): string {
+  return process.env.PEERS_FILE || join(homedir(), ".maw", "peers.json");
+}
+
+export function emptyStore(): PeersFile {
+  return { version: 1, peers: {} };
+}
+
+export function loadPeers(): PeersFile {
+  const path = peersPath();
+  if (!existsSync(path)) return emptyStore();
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8")) as Partial<PeersFile>;
+    if (!parsed || typeof parsed !== "object") return emptyStore();
+    return {
+      version: 1,
+      peers: parsed.peers && typeof parsed.peers === "object" ? parsed.peers : {},
+    };
+  } catch {
+    return emptyStore();
+  }
+}
+
+export function savePeers(data: PeersFile): void {
+  const path = peersPath();
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, JSON.stringify(data, null, 2) + "\n");
+  renameSync(tmp, path);
+}
+
+/** Best-effort cleanup of a stale tmp file (ignore errors). */
+export function clearStaleTmp(): void {
+  const tmp = `${peersPath()}.tmp`;
+  try { if (existsSync(tmp)) unlinkSync(tmp); } catch { /* ignore */ }
+}


### PR DESCRIPTION
## Summary

First layer of the selection improvements from #565 (child #568).
Stand-alone core plugin with `add`/`list`/`info`/`remove` subcommands
for federation peer aliases.

- Storage at `~/.maw/peers.json` (v1 schema)
- Atomic writes via tmp + rename (crash-safe)
- Validation on alias (`^[a-z0-9][a-z0-9_-]{0,31}$`) + URL (http/https)
- Best-effort node resolution via `<url>/info` (swallows errors — alias without node still valid)
- Mirrors plugin shape from #524 (learn) + #560 (project's subcommand dispatcher)

### Rename note

Renamed from `contacts` → `peers` during review. A `contacts` plugin
already exists (PR #258) with a different purpose (oracle-transport
directory: `{maw, thread, inbox, repo, notes}` at `ψ/contacts.json`).
Keeping it untouched; the federation-aliases feature lives at `peers`
which is the cleaner term anyway. Will update #568's title post-merge.

### Contract

```
maw peers add <alias> <url> [--node <name>]
maw peers list
maw peers info <alias>
maw peers remove <alias>    # idempotent
```

## Out of scope (follow-ups)

- Wire `<alias>:<agent>` resolution into `maw hey`/`peek`/`send`
- Per-instance peers (after #566 / `MAW_HOME` lands)
- Groups + predicates (later stages of #Child-D2)

## Files

| file | LOC |
|---|---|
| `src/commands/plugins/peers/plugin.json` | 14 |
| `src/commands/plugins/peers/index.ts` | 106 |
| `src/commands/plugins/peers/impl.ts` | 113 |
| `src/commands/plugins/peers/store.ts` | 67 |
| `src/commands/plugins/peers/peers.test.ts` | 160 |
| **source total** | **300** |

Under the 300-LOC PR cap; no changes outside `src/commands/plugins/peers/`.

## Test plan

- [x] `bun test src/commands/plugins/peers/` — 16 pass / 0 fail
- [x] `bun run test:plugin` — 146 pass / 6 skip / 0 fail
- [x] `bun run test` — 1115 pass / 7 skip / 0 fail (pre-existing `test/contacts.test.ts` still green — old plugin untouched)
- [x] `bun run build` — bundled 581 modules, no errors

### Design note worth review

`info` returns JSON (not a pretty format). Rationale: the follow-up PR
that wires `alias:agent` resolution will script against this output, and
a single well-shaped JSON object is cheaper to parse than a pretty table.
`list` is a pretty table since that's the interactive use case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: mawjs <noreply@soulbrews.studio>