### PR TITLE
bump: v26.4.18-alpha.19 — first CalVer cut on maw-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "2.0.0-alpha.137",
+  "version": "26.4.18-alpha.19",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
## Summary
- Transitions maw-js from semver-alpha (\`2.0.0-alpha.137\`) → CalVer (\`v{yy}.{m}.{d}-alpha.{hour}\`)
- Scheme matches skills-cli's v26.4.18 precedent (PR #263)
- Single-line change: `package.json` version field
- `calver-release.yml` workflow will auto-tag + create GitHub release on merge

## Why

CalVer infra landed via #538. Today shipped 10 PRs. Natural cutover moment per proposal #565 umbrella #526.

## Today's merges in this cut

| # | What |
|---|---|
| #552 | stash+flock (#531 defensive) |
| #557 | rename `maw` → `maw-js` — kills npm DependencyLoop root cause |
| #558 | rename `@maw/sdk` → `@maw-js/sdk` |
| #559 | `maw incubate` core plugin scaffold (#522) |
| #560 | `maw project` core plugin scaffold (#523) |
| #561 | fleet snapshot import path (external — @MEYD-605) |
| #569 | ambiguous-match UX fix — actionable error not stack trace (#567) |
| #570 | multi-instance foundation — `MAW_HOME` + `serve --as` (#566) |
| #571 | `maw peers` plugin — federation aliases (#568) |
| #574 | `maw pair` — HTTP server-to-server pairing (#573) |

## Test plan

- [x] `bun scripts/calver.ts --check` confirmed target: `v26.4.18-alpha.19`
- [x] Single-file diff (package.json line 3 only)
- [ ] CI green
- [ ] Post-merge: `calver-release.yml` creates tag + GH release
- [ ] Post-tag: users can `bun add -g github:Soul-Brews-Studio/maw-js#v26.4.18-alpha.19` and get a working CLI

## Followups (not in this PR)

- Close #527, #528, #529 if #538's infra already fulfilled them (audit)
- #530 CalVer CHANGELOG migration note + README badge
- #553 CalVer discoverability (contributor-facing signal)
- Stable `v26.4.18` cut once tomorrow's work settles

Closes #526 — CalVer cutover decision taken.