### PR TITLE
docs(calver): CHANGELOG migration note + README badge (closes #530)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,26 @@
 
 All notable changes to `maw` are documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-Pre-1.0 alpha releases may introduce breaking changes at any time.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## Versioning — CalVer (since 2026-04-18)
+
+On **2026-04-18**, `maw-js` migrated from SemVer alpha (`2.0.0-alpha.N`) to
+**CalVer** (`v{yy}.{m}.{d}[-alpha.{hour}]`). The first CalVer cut is
+[`v26.4.18-alpha.19`](https://github.com/Soul-Brews-Studio/maw-js/releases/tag/v26.4.18-alpha.19),
+matching the scheme already adopted by [skills-cli `v26.4.18`](https://github.com/Soul-Brews-Studio/skills-cli)
+(the precedent).
+
+- **Why**: dates carry meaning, alpha numbers don't. CalVer makes "how old is
+  this build?" answerable at a glance, and the 24/day cap is sufficient for
+  an alpha cadence.
+- **Rollover**: `-alpha.{hour}` (0–23) — at most 24 alpha cuts per UTC day.
+- **Old tags resolvable**: existing `v2.0.0-alpha.117` through `alpha.137`
+  tags are **not** rewritten — `plugins.lock` references and historical
+  changelog entries below remain valid forever.
+- **Umbrella**: [#526](https://github.com/Soul-Brews-Studio/maw-js/issues/526).
+
+Pre-1.0 alpha releases may still introduce breaking changes at any time.
 
 ## [Unreleased]
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # maw
 
-[![CI](https://github.com/Soul-Brews-Studio/maw-js/actions/workflows/ci.yml/badge.svg)](https://github.com/Soul-Brews-Studio/maw-js/actions/workflows/ci.yml) [![License](https://img.shields.io/badge/license-BUSL--1.1-blue)](./LICENSE) [![Version](https://img.shields.io/badge/version-2.0.0--alpha.134-orange)](https://github.com/Soul-Brews-Studio/maw-js/releases) [![Bun](https://img.shields.io/badge/runtime-Bun%201.3%2B-f9f1e1)](https://bun.sh)
+[![CI](https://github.com/Soul-Brews-Studio/maw-js/actions/workflows/ci.yml/badge.svg)](https://github.com/Soul-Brews-Studio/maw-js/actions/workflows/ci.yml) [![License](https://img.shields.io/badge/license-BUSL--1.1-blue)](./LICENSE) [![CalVer](https://img.shields.io/badge/calver-v26.4.18--alpha.19-blue)](https://calver.org) [![Bun](https://img.shields.io/badge/runtime-Bun%201.3%2B-f9f1e1)](https://bun.sh)
 
 > Multi-Agent Workflow — wake agents, talk across machines, see the mesh.
 
@@ -24,6 +24,8 @@ bun add -g github:Soul-Brews-Studio/maw-js
 # Or from source:
 ghq get Soul-Brews-Studio/maw-js && cd "$(ghq root)/github.com/Soul-Brews-Studio/maw-js" && bun install && bun link
 ```
+
+> **Versioning**: `maw-js` uses [CalVer](https://calver.org) — `v{yy}.{m}.{d}[-alpha.{hour}]` (e.g. `v26.4.18-alpha.19`). Migrated from SemVer alpha on 2026-04-18 (see [CHANGELOG](./CHANGELOG.md#versioning--calver-since-2026-04-18) and umbrella [#526](https://github.com/Soul-Brews-Studio/maw-js/issues/526)).
 
 ## Recovering from `maw: command not found`
 


### PR DESCRIPTION
## Summary

Docs-only ship for child issue #530 of the CalVer umbrella (#526). The actual transition landed today via #575 (`v26.4.18-alpha.19`); this PR makes it discoverable to readers.

- **CHANGELOG.md**: new `## Versioning — CalVer (since 2026-04-18)` section above `[Unreleased]` explaining the scheme (`v{yy}.{m}.{d}[-alpha.{hour}]`), the 24/day cap, old-tag resolvability (alpha.117–137 stay valid), and linking umbrella #526.
- **README.md**: swapped the stale orange `Version 2.0.0-alpha.134` badge for a CalVer badge pinned to `v26.4.18-alpha.19`; added a one-line note under Install pointing readers at the CHANGELOG section.

No code changes. Existing CHANGELOG entries preserved verbatim.

## Test plan

- [x] `bun run test` — 1147 pass, 7 skip, 0 fail (1154 across 86 files)
- [x] README badge URL renders (shields.io standard format)
- [x] CHANGELOG anchor link resolves (`#versioning--calver-since-2026-04-18`)

Closes #530. Refs #526, #575.

🤖 Generated with [Claude Code](https://claude.com/claude-code)