### PR TITLE
feat(view): maw a prompts to wake on missing target (closes #549)

### DIFF
--- a/src/commands/plugins/view/impl.ts
+++ b/src/commands/plugins/view/impl.ts
@@ -4,14 +4,68 @@ import { loadConfig } from "../../../config";
 import { resolveSessionTarget } from "../../../core/matcher/resolve-target";
 import { logAnomaly } from "../../../core/fleet/audit";
 import { execSync } from "child_process";
+import { ttyAsk } from "../init/prompts";
+
+/**
+ * Decide whether to offer a wake prompt on missing target. Extracted for
+ * testability — tests can stub `isTTY` and `wakeFlag` directly.
+ *
+ * #549 contract:
+ *  - --no-wake → never prompt, never wake (back-compat for scripts)
+ *  - --wake    → wake unconditionally, no prompt (force opt-in)
+ *  - non-TTY   → never prompt (CI/script safety, current behavior)
+ *  - TTY       → prompt y/N
+ */
+export type WakePromptDecision = "skip" | "force" | "ask";
+export function decideWakePrompt(opts: {
+  isTTY: boolean;
+  wake?: boolean;
+  noWake?: boolean;
+}): WakePromptDecision {
+  if (opts.noWake) return "skip";
+  if (opts.wake) return "force";
+  if (!opts.isTTY) return "skip";
+  return "ask";
+}
+
+export interface ViewOpts {
+  windowHint?: string;
+  clean?: boolean;
+  kill?: boolean;
+  splitAnchor?: string | true;
+  wake?: boolean;
+  noWake?: boolean;
+  /** Test seam: ask user yes/no. Default = ttyAsk via /dev/tty. */
+  ask?: (question: string) => Promise<string>;
+  /** Test seam: stand-in for cmdWake. Default = real cmdWake. */
+  wakeImpl?: (target: string) => Promise<void>;
+}
 
 export async function cmdView(
   agent: string,
-  windowHint?: string,
+  windowHintOrOpts?: string | ViewOpts,
   clean = false,
   kill = false,
   splitAnchor?: string | true,
+  extraOpts: Pick<ViewOpts, "wake" | "noWake" | "ask" | "wakeImpl"> = {},
 ) {
+  // Backward-compatible signature: callers pass either a windowHint string
+  // OR a full ViewOpts object as the second arg.
+  let windowHint: string | undefined;
+  if (typeof windowHintOrOpts === "object" && windowHintOrOpts !== null) {
+    windowHint = windowHintOrOpts.windowHint;
+    clean = windowHintOrOpts.clean ?? clean;
+    kill = windowHintOrOpts.kill ?? kill;
+    splitAnchor = windowHintOrOpts.splitAnchor ?? splitAnchor;
+    extraOpts = {
+      wake: windowHintOrOpts.wake,
+      noWake: windowHintOrOpts.noWake,
+      ask: windowHintOrOpts.ask,
+      wakeImpl: windowHintOrOpts.wakeImpl,
+    };
+  } else {
+    windowHint = windowHintOrOpts;
+  }
   // Find the session
   const sessions = await listSessions();
   const allWindows = sessions.flatMap(s => s.windows.map(w => ({ session: s.name, ...w })));
@@ -44,6 +98,43 @@ export async function cmdView(
     if (byWindow) sessionName = byWindow.name;
   }
   if (!sessionName) {
+    // #549 — offer to wake the missing target before erroring out.
+    // Decision matrix encoded in decideWakePrompt; see WakePromptDecision.
+    const decision = decideWakePrompt({
+      isTTY: Boolean(process.stdin.isTTY),
+      wake: extraOpts.wake,
+      noWake: extraOpts.noWake,
+    });
+
+    if (decision !== "skip") {
+      let proceed = decision === "force";
+      if (decision === "ask") {
+        const ask = extraOpts.ask ?? ttyAsk;
+        try {
+          const answer = (await ask(
+            `\x1b[36m?\x1b[0m Oracle '${agent}' is not running. Wake it now? [y/N]`,
+          )).trim().toLowerCase();
+          proceed = answer === "y" || answer === "yes";
+        } catch (e) {
+          // /dev/tty unavailable — fall through to the existing error.
+          proceed = false;
+        }
+      }
+
+      if (proceed) {
+        const wakeImpl =
+          extraOpts.wakeImpl ??
+          (async (target: string) => {
+            const { cmdWake } = await import("../../shared/wake-cmd");
+            await cmdWake(target, { attach: true });
+          });
+        console.log(`\x1b[36m⚡\x1b[0m waking '${agent}'...`);
+        await wakeImpl(agent);
+        // cmdWake({ attach: true }) handles the attach itself, so we're done.
+        return;
+      }
+    }
+
     if (resolved.kind === "none" && resolved.hints?.length) {
       console.error(`  \x1b[90mdid you mean:\x1b[0m`);
       for (const h of resolved.hints) {

--- a/src/commands/plugins/view/index.ts
+++ b/src/commands/plugins/view/index.ts
@@ -49,8 +49,12 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
 
     const clean = scanned.includes("--clean");
     const kill = scanned.includes("--kill");
-    const filtered = scanned.filter(a => a !== "--clean" && a !== "--kill");
-    await cmdView(filtered[0], filtered[1], clean, kill, splitAnchor);
+    const wake = scanned.includes("--wake");
+    const noWake = scanned.includes("--no-wake");
+    const filtered = scanned.filter(
+      a => a !== "--clean" && a !== "--kill" && a !== "--wake" && a !== "--no-wake",
+    );
+    await cmdView(filtered[0], filtered[1], clean, kill, splitAnchor, { wake, noWake });
     return { ok: true, output: logs.join("\n") || undefined };
   } catch (e: any) {
     return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };

--- a/src/commands/plugins/view/plugin.json
+++ b/src/commands/plugins/view/plugin.json
@@ -12,11 +12,13 @@
       "attach",
       "a"
     ],
-    "help": "maw view <agent> [window] [--clean] [--kill] [--split[=<anchor>]] — create or attach to an agent's tmux view. --split splits the caller's active pane; --split=<anchor> splits the pane hosting <anchor>'s view (auto-creates if missing).",
+    "help": "maw view <agent> [window] [--clean] [--kill] [--split[=<anchor>]] [--wake|--no-wake] — create or attach to an agent's tmux view. --split splits the caller's active pane; --split=<anchor> splits the pane hosting <anchor>'s view (auto-creates if missing). On missing target in a TTY, prompts y/N to wake; --wake skips the prompt and wakes; --no-wake skips the prompt and errors as before.",
     "flags": {
       "--clean": "boolean",
       "--kill": "boolean",
-      "--split": "string"
+      "--split": "string",
+      "--wake": "boolean",
+      "--no-wake": "boolean"
     }
   },
   "weight": 10

--- a/test/view-wake-prompt.test.ts
+++ b/test/view-wake-prompt.test.ts
@@ -1,0 +1,129 @@
+/**
+ * #549 — `maw a <target>` should offer to wake when session missing.
+ *
+ * Pure-unit tests for decideWakePrompt + the prompt+wake hand-off in cmdView.
+ * No tmux/sdk involved — we exercise the not-found branch by passing an agent
+ * name guaranteed to miss in an empty session list, with stub ask/wakeImpl.
+ */
+import { describe, it, expect, mock } from "bun:test";
+import { cmdView, decideWakePrompt } from "../src/commands/plugins/view/impl";
+
+// listSessions returns whatever tmux reports; in test env no tmux server is
+// running so the call returns an empty list. That's exactly the not-found
+// path we want to exercise. If the test env ever changes, the impossibly
+// random agent name keeps the resolver in `none`.
+const MISS = "no-such-oracle-zzzz-549";
+
+describe("#549 decideWakePrompt — decision matrix", () => {
+  it("--no-wake always skips, even in TTY", () => {
+    expect(decideWakePrompt({ isTTY: true, noWake: true })).toBe("skip");
+    expect(decideWakePrompt({ isTTY: false, noWake: true })).toBe("skip");
+  });
+
+  it("--wake always forces, no prompt", () => {
+    expect(decideWakePrompt({ isTTY: true, wake: true })).toBe("force");
+    expect(decideWakePrompt({ isTTY: false, wake: true })).toBe("force");
+  });
+
+  it("non-TTY without flags = skip (back-compat for CI/scripts)", () => {
+    expect(decideWakePrompt({ isTTY: false })).toBe("skip");
+  });
+
+  it("TTY without flags = ask", () => {
+    expect(decideWakePrompt({ isTTY: true })).toBe("ask");
+  });
+
+  it("--no-wake wins over --wake (explicit deny beats explicit allow)", () => {
+    expect(decideWakePrompt({ isTTY: true, wake: true, noWake: true })).toBe("skip");
+  });
+});
+
+describe("#549 cmdView — TTY prompt → wake hand-off", () => {
+  it("yes answer triggers wakeImpl with the requested target", async () => {
+    const wakeImpl = mock(async (_t: string) => {});
+    const ask = mock(async (_q: string) => "y");
+
+    await cmdView(MISS, undefined, false, false, undefined, {
+      wake: true, // bypass TTY detection — force = wake without ask
+      ask,
+      wakeImpl,
+    });
+
+    expect(wakeImpl).toHaveBeenCalledTimes(1);
+    expect(wakeImpl.mock.calls[0]![0]).toBe(MISS);
+    // force path doesn't ask
+    expect(ask).not.toHaveBeenCalled();
+  });
+
+  it("ask=yes path: ask is called, then wake is called, no error thrown", async () => {
+    const wakeImpl = mock(async (_t: string) => {});
+    const ask = mock(async (_q: string) => "yes");
+
+    // Use the opts-object overload to inject ask without depending on isTTY.
+    // We feed wake=false, noWake=false, but stub ask — decideWakePrompt
+    // returns "ask" only when isTTY is true. Since we can't reliably set
+    // process.stdin.isTTY in bun:test, we go through the --wake path for
+    // the success case and exercise the ask-prompt code path via a helper
+    // that exposes the prompt branch directly.
+    //
+    // To still cover the ask code path end-to-end, we monkey-patch
+    // process.stdin.isTTY for the duration of the call.
+    const origTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+    try {
+      await cmdView(MISS, { ask, wakeImpl });
+      expect(ask).toHaveBeenCalledTimes(1);
+      expect(wakeImpl).toHaveBeenCalledTimes(1);
+      expect(wakeImpl.mock.calls[0]![0]).toBe(MISS);
+    } finally {
+      Object.defineProperty(process.stdin, "isTTY", { value: origTTY, configurable: true });
+    }
+  });
+
+  it("ask=no path: ask is called, wake is NOT called, original error thrown", async () => {
+    const wakeImpl = mock(async (_t: string) => {});
+    const ask = mock(async (_q: string) => "n");
+
+    const origTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+    try {
+      await expect(cmdView(MISS, { ask, wakeImpl })).rejects.toThrow(/session not found/);
+      expect(ask).toHaveBeenCalledTimes(1);
+      expect(wakeImpl).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(process.stdin, "isTTY", { value: origTTY, configurable: true });
+    }
+  });
+
+  it("non-TTY (default) path: no prompt, original error thrown — back-compat", async () => {
+    const wakeImpl = mock(async (_t: string) => {});
+    const ask = mock(async (_q: string) => "y");
+
+    const origTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+    try {
+      await expect(cmdView(MISS, { ask, wakeImpl })).rejects.toThrow(/session not found/);
+      expect(ask).not.toHaveBeenCalled();
+      expect(wakeImpl).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(process.stdin, "isTTY", { value: origTTY, configurable: true });
+    }
+  });
+
+  it("--no-wake in a TTY: no prompt, original error thrown", async () => {
+    const wakeImpl = mock(async (_t: string) => {});
+    const ask = mock(async (_q: string) => "y");
+
+    const origTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+    try {
+      await expect(
+        cmdView(MISS, { ask, wakeImpl, noWake: true }),
+      ).rejects.toThrow(/session not found/);
+      expect(ask).not.toHaveBeenCalled();
+      expect(wakeImpl).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(process.stdin, "isTTY", { value: origTTY, configurable: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #549. When `maw a <target>` (alias for `maw view`) hits a missing
session in an interactive TTY, prompt `y/N` to wake the oracle inline
and continue, instead of erroring with "session not found".

- Non-TTY (CI / `maw hey` pipes / scripts): identical to today — no prompt, exits 1 with the same error.
- TTY: prompts `Oracle '<name>' is not running. Wake it now? [y/N]`.
  - `y` / `yes` -> calls `cmdWake(target, { attach: true })`.
  - anything else -> the original error.
- `--wake`: force wake without prompting (scripts that want opt-in).
- `--no-wake`: force the legacy error path even in a TTY.

## Implementation notes

- Touched only `src/commands/plugins/view/{impl.ts,index.ts,plugin.json}` and added one test file.
- Decision matrix extracted as `decideWakePrompt({ isTTY, wake, noWake })` -> `"skip" | "force" | "ask"` for direct unit testing.
- `cmdView` gains an opts-object overload that injects `ask` and `wakeImpl` seams so tests don't need a real tmux server.
- Reuses `ttyAsk` from `init/prompts.ts` (the same `/dev/tty` reader pattern Nat called out in the issue).
- Wake is dynamic-imported to avoid circular deps, and we delegate via `cmdWake({ attach: true })` rather than reimplementing.

## Test plan

- [x] `bun run test` -> 1157 pass / 0 fail / 7 skip
- [x] New test file `test/view-wake-prompt.test.ts` -> 10 / 10 pass
  - decision matrix: 5 cases covering `--no-wake`, `--wake`, non-TTY, TTY, conflict
  - end-to-end: TTY-yes wakes, TTY-no errors with original message, non-TTY skips prompt, `--no-wake` in TTY skips prompt
- [ ] Manual: `maw a no-such-oracle` in a real terminal prompts; `maw a no-such-oracle </dev/null` keeps the legacy error

## Size

- `impl.ts`: +93 LOC (decision fn, opts overload, prompt branch)
- `index.ts`: +6 LOC (flag plumbing)
- `plugin.json`: +2 keys (`--wake`, `--no-wake`)
- `view-wake-prompt.test.ts`: 129 LOC

Total: 231 insertions, 5 deletions across 4 files. Well under the 300 LOC cap.