### PR TITLE
fix(peers): corruption + stale-tmp + writer lock (closes #572)

### DIFF
--- a/src/commands/plugins/peers/impl.ts
+++ b/src/commands/plugins/peers/impl.ts
@@ -11,7 +11,7 @@
  * valid — it just means `alias:<agent>` routing needs the URL-to-node
  * map from another source. That's a follow-up concern.
  */
-import { loadPeers, savePeers, type Peer } from "./store";
+import { loadPeers, mutatePeers, type Peer } from "./store";
 
 const ALIAS_RE = /^[a-z0-9][a-z0-9_-]{0,31}$/;
 
@@ -67,8 +67,7 @@ export async function cmdAdd(opts: AddOptions): Promise<AddResult> {
   const urlErr = validateUrl(opts.url);
   if (urlErr) throw new Error(urlErr);
 
-  const data = loadPeers();
-  const existed = Boolean(data.peers[opts.alias]);
+  // Resolve node OUTSIDE the lock — it does network I/O.
   const node = opts.node ?? await resolveNode(opts.url);
   const peer: Peer = {
     url: opts.url,
@@ -76,8 +75,11 @@ export async function cmdAdd(opts: AddOptions): Promise<AddResult> {
     addedAt: new Date().toISOString(),
     lastSeen: null,
   };
-  data.peers[opts.alias] = peer;
-  savePeers(data);
+  let existed = false;
+  mutatePeers((data) => {
+    existed = Boolean(data.peers[opts.alias]);
+    data.peers[opts.alias] = peer;
+  });
   return { alias: opts.alias, overwrote: existed, peer };
 }
 
@@ -95,11 +97,14 @@ export function cmdInfo(alias: string): ({ alias: string } & Peer) | null {
 }
 
 export function cmdRemove(alias: string): boolean {
-  const data = loadPeers();
-  if (!data.peers[alias]) return false;
-  delete data.peers[alias];
-  savePeers(data);
-  return true;
+  let existed = false;
+  mutatePeers((data) => {
+    if (data.peers[alias]) {
+      existed = true;
+      delete data.peers[alias];
+    }
+  });
+  return existed;
 }
 
 export function formatList(rows: Array<{ alias: string } & Peer>): string {

--- a/src/commands/plugins/peers/lock.ts
+++ b/src/commands/plugins/peers/lock.ts
@@ -1,0 +1,65 @@
+/**
+ * maw peers — file lock for concurrent writers (#572 nit 3).
+ *
+ * Mirrors the pattern in src/cli/update-lock.ts: O_EXCL create on a
+ * sibling `.lock` file, write our pid, retry on EEXIST. If the holder
+ * pid is gone (kill -0 → ESRCH) we steal the lock immediately rather
+ * than waiting out the timeout. Synchronous (no await) so it composes
+ * with the existing sync savePeers signature without a contract change.
+ *
+ * Sized for CLI use: 5s deadline, 50ms poll. peers.json writes are
+ * sub-millisecond, so racing CLIs almost always succeed on first try.
+ */
+import { openSync, closeSync, unlinkSync, writeFileSync, readFileSync, existsSync } from "fs";
+
+const DEADLINE_MS = 5_000;
+const POLL_MS = 50;
+
+function isAlive(pid: number): boolean {
+  if (!Number.isFinite(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e: any) {
+    return e.code === "EPERM";
+  }
+}
+
+function sleepSync(ms: number): void {
+  const end = Date.now() + ms;
+  while (Date.now() < end) { /* spin — short waits only */ }
+}
+
+/** Run fn() while holding an exclusive lock on `<path>.lock`. Synchronous. */
+export function withPeersLock<T>(path: string, fn: () => T): T {
+  const lockPath = `${path}.lock`;
+  const deadline = Date.now() + DEADLINE_MS;
+  let fd: number | null = null;
+
+  while (true) {
+    try {
+      fd = openSync(lockPath, "wx"); // O_CREAT | O_EXCL
+      writeFileSync(lockPath, String(process.pid));
+      break;
+    } catch (e: any) {
+      if (e.code !== "EEXIST") throw e;
+      let holderPid = NaN;
+      try { holderPid = parseInt(readFileSync(lockPath, "utf-8").trim(), 10); } catch { /* empty/racy */ }
+      if (!isAlive(holderPid)) {
+        try { unlinkSync(lockPath); } catch { /* race with another stealer is fine */ }
+        continue;
+      }
+      if (Date.now() > deadline) {
+        throw new Error(`peers lock timeout: pid ${holderPid} still holds ${lockPath}`);
+      }
+      sleepSync(POLL_MS);
+    }
+  }
+
+  try {
+    return fn();
+  } finally {
+    try { if (fd !== null) closeSync(fd); } catch { /* ignore */ }
+    try { if (existsSync(lockPath)) unlinkSync(lockPath); } catch { /* ignore */ }
+  }
+}

--- a/src/commands/plugins/peers/peers.test.ts
+++ b/src/commands/plugins/peers/peers.test.ts
@@ -125,6 +125,50 @@ describe("peers store — atomic write crash-safety", () => {
   });
 });
 
+describe("peers store — corruption + cleanup + lock (#572)", () => {
+  it("corrupt peers.json → loadPeers returns empty + renames aside + warns", async () => {
+    const { loadPeers, peersPath } = await import("./store");
+    const path = peersPath();
+    writeFileSync(path, "{ this is not valid json");
+    const errs: string[] = [];
+    const orig = console.error;
+    console.error = (msg: string) => { errs.push(String(msg)); };
+    try {
+      const data = loadPeers();
+      expect(data.peers).toEqual({});
+    } finally {
+      console.error = orig;
+    }
+    expect(existsSync(path)).toBe(false);
+    const { readdirSync } = await import("fs");
+    const aside = readdirSync(dir).find(f => f.startsWith("peers.json.corrupt-"));
+    expect(aside).toBeDefined();
+    expect(errs.some(e => e.includes("failed to parse"))).toBe(true);
+  });
+
+  it("stale .tmp on startup → loadPeers cleans it up", async () => {
+    const { loadPeers, peersPath } = await import("./store");
+    const tmp = peersPath() + ".tmp";
+    writeFileSync(tmp, "leftover from a crashed write");
+    expect(existsSync(tmp)).toBe(true);
+    loadPeers();
+    expect(existsSync(tmp)).toBe(false);
+  });
+
+  it("two concurrent addPeer promises → both aliases survive", async () => {
+    const { cmdAdd, cmdList } = await import("./impl");
+    const [a, b] = await Promise.all([
+      cmdAdd({ alias: "alpha", url: "http://a.local", node: "a" }),
+      cmdAdd({ alias: "beta", url: "http://b.local", node: "b" }),
+    ]);
+    expect(a.alias).toBe("alpha");
+    expect(b.alias).toBe("beta");
+    const rows = cmdList();
+    const aliases = rows.map(r => r.alias).sort();
+    expect(aliases).toEqual(["alpha", "beta"]);
+  });
+});
+
 describe("peers dispatcher (index.ts)", () => {
   it("no args → prints help", async () => {
     const { default: handler } = await import("./index");

--- a/src/commands/plugins/peers/store.ts
+++ b/src/commands/plugins/peers/store.ts
@@ -1,21 +1,30 @@
 /**
- * maw peers — storage layer (#568).
+ * maw peers — storage layer (#568, #572).
  *
  * Atomic read/write of `~/.maw/peers.json`. Writes go via a temp file
  * and rename(2) so a crash mid-write leaves either the old file intact
  * or the new file fully in place — never a truncated file. A stale tmp
- * file from a crashed previous write is ignored on load (the live file
- * is still valid).
+ * file from a crashed previous write is cleaned on load (the live file
+ * is still valid; the tmp is leftover from a crashed writer).
  *
  * Schema v1:
  *   { version: 1, peers: { <alias>: { url, node, addedAt, lastSeen } } }
  *
  * Path resolution is a function (not a const) so tests can override
  * `HOME` / the path via `PEERS_FILE` and get a fresh value each call.
+ *
+ * Concurrency: savePeers takes a short-lived file lock around the
+ * read-modify-write critical section so concurrent `maw peers add`
+ * calls don't lose each other's updates (#572 nit 3). See ./lock.ts.
+ *
+ * Corruption: if the live file fails to parse, we rename it aside to
+ * `peers.json.corrupt-<ISO>` and start fresh — non-destructive, with
+ * an audit trail (#572 nit 1).
  */
 import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync, unlinkSync } from "fs";
 import { join, dirname } from "path";
 import { homedir } from "os";
+import { withPeersLock } from "./lock";
 
 export interface Peer {
   url: string;
@@ -38,7 +47,56 @@ export function emptyStore(): PeersFile {
 }
 
 export function loadPeers(): PeersFile {
+  clearStaleTmp();
   const path = peersPath();
+  if (!existsSync(path)) return emptyStore();
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch {
+    return emptyStore();
+  }
+  try {
+    const parsed = JSON.parse(raw) as Partial<PeersFile>;
+    if (!parsed || typeof parsed !== "object") throw new Error("not an object");
+    return {
+      version: 1,
+      peers: parsed.peers && typeof parsed.peers === "object" ? parsed.peers : {},
+    };
+  } catch (e: any) {
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const aside = `${path}.corrupt-${stamp}`;
+    try { renameSync(path, aside); } catch { /* ignore — caller still gets empty store */ }
+    console.error(`\x1b[33m⚠\x1b[0m peers store at ${path} failed to parse (${e?.message || e}); moved aside to ${aside}`);
+    return emptyStore();
+  }
+}
+
+export function savePeers(data: PeersFile): void {
+  const path = peersPath();
+  mkdirSync(dirname(path), { recursive: true });
+  withPeersLock(path, () => writeAtomic(path, data));
+}
+
+/**
+ * Atomic read-modify-write under the peers lock. Use this whenever a
+ * mutation depends on current contents (add/remove) — it re-reads
+ * inside the lock so concurrent writers don't lose each other's
+ * updates. The mutator runs synchronously inside the critical section.
+ */
+export function mutatePeers(mutate: (data: PeersFile) => void): PeersFile {
+  const path = peersPath();
+  mkdirSync(dirname(path), { recursive: true });
+  return withPeersLock(path, () => {
+    const fresh = readUnlocked(path);
+    mutate(fresh);
+    writeAtomic(path, fresh);
+    return fresh;
+  });
+}
+
+/** Read + parse without taking the lock or doing corruption-handling rename. */
+function readUnlocked(path: string): PeersFile {
   if (!existsSync(path)) return emptyStore();
   try {
     const parsed = JSON.parse(readFileSync(path, "utf-8")) as Partial<PeersFile>;
@@ -52,9 +110,7 @@ export function loadPeers(): PeersFile {
   }
 }
 
-export function savePeers(data: PeersFile): void {
-  const path = peersPath();
-  mkdirSync(dirname(path), { recursive: true });
+function writeAtomic(path: string, data: PeersFile): void {
   const tmp = `${path}.tmp`;
   writeFileSync(tmp, JSON.stringify(data, null, 2) + "\n");
   renameSync(tmp, path);


### PR DESCRIPTION
## Summary

Addresses the 3 non-blocking nits from pre-merge review of #571 (peers plugin), filed as #572.

### Nit 1 — Silent corruption fallback in `loadPeers`
Before: `JSON.parse` failure → silent reset to empty store, user loses all aliases without warning.
After: parse failure → warn on stderr (yellow `⚠`) AND rename the corrupt file aside to `peers.json.corrupt-<ISO-timestamp>` before returning the empty store. Non-destructive, audit-trail preserving.

### Nit 2 — `clearStaleTmp` was dead code
Before: function exported, never called.
After: invoked at the top of `loadPeers` — every load now cleans up any lingering `.tmp` file from a prior crashed write.

### Nit 3 — Concurrent writer race
Before: two `maw peers add` could `loadPeers` → mutate → `savePeers` interleaved; last writer wins, first writer's alias vanishes. Atomic rename only protects against torn writes, not lost updates.
After: introduced `src/commands/plugins/peers/lock.ts` (~65 LOC) with a sync `withPeersLock(path, fn)` that mirrors `src/cli/update-lock.ts`: `O_EXCL` create on `<path>.lock`, write pid, retry on `EEXIST`, steal stale locks via `kill -0` liveness probe (5s deadline, 50ms poll). Added `mutatePeers(mutator)` in `store.ts` that does read-modify-write inside the lock, and rewired `cmdAdd` / `cmdRemove` to use it. `resolveNode` (network I/O) stays outside the lock.

Lock is in its own file so `store.ts` stays under the 200 LOC cap.

## LOC

| File | LOC |
|---|---|
| `store.ts` | 123 (was 67) |
| `lock.ts` | 65 (new) |
| `impl.ts` | 118 (was 114) |
| `peers.test.ts` | 204 (was 160) |

## Tests

- Existing 16 peers tests: green
- 3 new tests: corrupt `peers.json` → empty + rename-aside + warn; stale `.tmp` on startup → removed; two concurrent `addPeer` promises → both aliases survive
- Total: **19/19** in peers plugin (`bun test src/commands/plugins/peers/`)

Plugin-test totals went from 63 pass → 66 pass with the same 26 pre-existing failures (all unrelated: oracle/wake/bud plugin tests already broken on `origin/main`).

## Test plan

- [ ] CI green
- [ ] `bun test src/commands/plugins/peers/` shows 19 pass / 0 fail
- [ ] Manual: corrupt `~/.maw/peers.json` → run `maw peers list` → see warning + `.corrupt-*` file alongside

Closes #572. Followup to #571.

🤖 Generated with [Claude Code](https://claude.com/claude-code)