### PR TITLE
docs(calver): contributor discoverability — CONTRIBUTING section + ship-alpha banner

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,9 +49,34 @@ Exempt: type-definition files, specs/docs, generated/scaffolded boilerplate.
 - **Features**: open a short issue describing the problem first. If we align on the shape, a PR is welcome.
 - **Proposals / design docs**: use GitHub Discussions, not issues. Issues are for work; discussions are for thought.
 
-## Releases
+## Versioning
 
-Alphas ship from `main` via `bun run ship:alpha`. The script lints, tags, and force-pushes the rolling `alpha` branch. See `scripts/ship-alpha.sh`.
+**maw-js uses CalVer as of 2026-04-18.**
+
+Scheme: `v{yy}.{m}.{d}[-alpha.{hour}]` — e.g. `v26.4.18` (stable) or `v26.4.18-alpha.19` (alpha cut at 19:xx ICT). Up to 24 alpha cuts per day (one per hour). Spec lives in [umbrella #526](https://github.com/Soul-Brews-Studio/maw-js/issues/526) and the [CHANGELOG](./CHANGELOG.md#versioning--calver-since-2026-04-18).
+
+### Cut a release
+
+```bash
+TZ=Asia/Bangkok bun scripts/calver.ts            # alpha at current hour, e.g. v26.4.18-alpha.19
+TZ=Asia/Bangkok bun scripts/calver.ts --stable   # stable cut, e.g. v26.4.18
+TZ=Asia/Bangkok bun scripts/calver.ts --hour 14  # alpha at 14:xx
+TZ=Asia/Bangkok bun scripts/calver.ts --check    # dry-run, no writes
+```
+
+Or via the npm script alias: `bun run calver [--stable|--hour N|--check]` (TZ still recommended).
+
+Then commit + open a PR + merge into `main`. The `.github/workflows/calver-release.yml` workflow auto-tags `v<version>`, cuts a GitHub Release, and attaches the `dist/maw` build artifact. Single job — no cascade gaps.
+
+### Do NOT manually bump semver
+
+- Don't hand-edit `package.json` `version`. Always go through `scripts/calver.ts`.
+- Old semver tags (`v2.0.0-alpha.117` → `v2.0.0-alpha.137`) remain readable for history but no new semver tags should be cut.
+- The legacy `bun run ship:alpha` (`scripts/ship-alpha.sh`) still exists for emergency use during transition. It now prints a banner directing you to CalVer — please follow it.
+
+## Releases (legacy — pre-2026-04-18)
+
+Pre-CalVer alphas shipped from `main` via `bun run ship:alpha`. See `scripts/ship-alpha.sh`. Kept for historical reference; prefer the CalVer flow above.
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ bun add -g github:Soul-Brews-Studio/maw-js
 ghq get Soul-Brews-Studio/maw-js && cd "$(ghq root)/github.com/Soul-Brews-Studio/maw-js" && bun install && bun link
 ```
 
-> **Versioning**: `maw-js` uses [CalVer](https://calver.org) — `v{yy}.{m}.{d}[-alpha.{hour}]` (e.g. `v26.4.18-alpha.19`). Migrated from SemVer alpha on 2026-04-18 (see [CHANGELOG](./CHANGELOG.md#versioning--calver-since-2026-04-18) and umbrella [#526](https://github.com/Soul-Brews-Studio/maw-js/issues/526)).
+> **Versioning**: `maw-js` uses [CalVer](https://calver.org) — `v{yy}.{m}.{d}[-alpha.{hour}]` (e.g. `v26.4.18-alpha.19`). Migrated from SemVer alpha on 2026-04-18. Cutting a release? See [CONTRIBUTING.md → Versioning](./CONTRIBUTING.md#versioning). Background: [CHANGELOG](./CHANGELOG.md#versioning--calver-since-2026-04-18) · umbrella [#526](https://github.com/Soul-Brews-Studio/maw-js/issues/526).
 
 ## Recovering from `maw: command not found`
 

--- a/scripts/ship-alpha.sh
+++ b/scripts/ship-alpha.sh
@@ -27,6 +27,25 @@ cyan()   { printf '\033[36m%s\033[0m\n' "$*"; }
 green()  { printf '\033[32m%s\033[0m\n' "$*"; }
 red()    { printf '\033[31m%s\033[0m\n' "$*" >&2; }
 dim()    { printf '\033[90m%s\033[0m\n' "$*"; }
+yellow() { printf '\033[33m%s\033[0m\n' "$*"; }
+
+# CalVer notice (added 2026-04-18 for #553) ------------------------------------
+# This is the legacy semver flow. The new path is CalVer via scripts/calver.ts.
+# Print a loud banner, sleep 5s so humans see it (non-blocking, can Ctrl-C).
+yellow "╭───────────────────────────────────────────────────────╮"
+yellow "│  maw-js is now on CalVer as of 2026-04-18             │"
+yellow "│                                                       │"
+yellow "│  Instead of \`bash scripts/ship-alpha.sh\`, use:        │"
+yellow "│    TZ=Asia/Bangkok bun scripts/calver.ts [--stable]   │"
+yellow "│                                                       │"
+yellow "│  Then commit + PR + merge → calver-release.yml        │"
+yellow "│  auto-tags and publishes (single-job, no cascade).    │"
+yellow "│                                                       │"
+yellow "│  See CONTRIBUTING.md → Versioning for details.        │"
+yellow "│  (Press Ctrl-C to abort, or wait 5s to continue.)     │"
+yellow "╰───────────────────────────────────────────────────────╯"
+sleep 5
+# -----------------------------------------------------------------------------
 
 # 1. Preflight
 VERSION=$(grep '"version"' package.json | head -1 | sed -E 's/.*"([^"]+)".*/\1/')


### PR DESCRIPTION
Closes #553.

## Why

CalVer infra landed on main at 2026-04-18 12:32 ICT (#538) and the first cut shipped as `v26.4.18-alpha.19` via #575. But contributors working in parallel sessions kept reaching for semver out of habit because there was nothing in the codebase that surfaced the change. The fix: discoverability via docs + a loud workflow banner.

## What

Three thin surfaces:

1. **`CONTRIBUTING.md`** — new `## Versioning` section with:
   - scheme (`v{yy}.{m}.{d}[-alpha.{hour}]`) and effective date (2026-04-18)
   - cut-a-release recipe: `TZ=Asia/Bangkok bun scripts/calver.ts [--stable|--hour N|--check]` (or the `bun run calver` alias which already exists in `package.json`)
   - explicit "do NOT manually bump semver" rule
   - note that `bun run ship:alpha` (legacy) still works but now warns
2. **`scripts/ship-alpha.sh`** — yellow banner at the top, then `sleep 5` before the legacy flow runs. Non-blocking, Ctrl-C aborts. Safe to add the sleep because the script is human-invoked via `bun run ship:alpha` only — `.github/workflows/release.yml` references it only in a comment.
3. **`README.md`** — updated the existing Versioning hint near the badge to point at `CONTRIBUTING.md → Versioning` (previously only linked CHANGELOG + umbrella #526).

## LOC

- `CONTRIBUTING.md`: +27 / -2
- `scripts/ship-alpha.sh`: +19 / -0
- `README.md`: +1 / -1
- **Total: +47 / -3** (well under the 50-80 target). No TS changes.

## Acceptance

- [x] CONTRIBUTING.md has a discoverable `## Versioning` section
- [x] `scripts/ship-alpha.sh` shows the banner BEFORE doing any work (smoke-tested via `--dry-run`; banner prints, then preflight runs)
- [x] README points to CONTRIBUTING for versioning
- [x] No TS code changes — `bun run test` shows the same pre-existing failures as `origin/main` (module-link errors in soul-sync etc., unrelated to this PR)

## Did I add `bump:calver`?

No — `package.json` already has a `calver` script (`"calver": "bun scripts/calver.ts"`). Adding `bump:calver` as a synonym would be redundant; I documented `bun run calver` instead.