### PR TITLE
sec(update-lock): fd-based read/write to prevent path TOCTOU (#562)

### DIFF
--- a/src/cli/update-lock.ts
+++ b/src/cli/update-lock.ts
@@ -1,4 +1,4 @@
-import { openSync, closeSync, unlinkSync, existsSync, mkdirSync, writeFileSync, readFileSync } from "fs";
+import { openSync, closeSync, unlinkSync, existsSync, mkdirSync, writeSync, readSync, fstatSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 
@@ -39,13 +39,26 @@ export async function withUpdateLock<T>(fn: () => Promise<T>): Promise<T> {
   while (true) {
     try {
       fd = openSync(LOCK_PATH, "wx"); // O_EXCL — fails if exists
-      writeFileSync(LOCK_PATH, String(process.pid));
+      // fd-based write prevents path-TOCTOU (an attacker swapping LOCK_PATH for
+      // a symlink between openSync and the write would otherwise redirect the
+      // PID into an arbitrary file).  See #562 / #552.
+      const pidBytes = Buffer.from(String(process.pid));
+      writeSync(fd, pidBytes, 0, pidBytes.length, 0);
       break;
     } catch (e: any) {
       if (e.code !== "EEXIST") throw e;
       // Steal stale lock: if holder PID is dead, remove + retry immediately.
+      // fd-based read for the same TOCTOU reason as the write above.
       let holderPid = NaN;
-      try { holderPid = parseInt(readFileSync(LOCK_PATH, "utf-8").trim(), 10); } catch {}
+      let readFd: number | null = null;
+      try {
+        readFd = openSync(LOCK_PATH, "r");
+        const size = fstatSync(readFd).size;
+        const buf = Buffer.alloc(Math.min(size, 64));
+        readSync(readFd, buf, 0, buf.length, 0);
+        holderPid = parseInt(buf.toString("utf-8").trim(), 10);
+      } catch { /* treat as stale — holderPid stays NaN */ }
+      finally { if (readFd !== null) { try { closeSync(readFd); } catch {} } }
       if (!isAlive(holderPid)) {
         console.warn(`\x1b[33m⚠\x1b[0m stale update lock (pid ${holderPid || "?"} gone) — taking over`);
         try { unlinkSync(LOCK_PATH); } catch {}

--- a/test/isolated/update-lock.test.ts
+++ b/test/isolated/update-lock.test.ts
@@ -23,18 +23,29 @@ const realFs = await import("fs");
 // ── Shared spy state ──────────────────────────────────────────────────────
 interface Call { fn: string; args: unknown[] }
 let calls: Call[] = [];
+// openPlan governs the "wx" (acquire) opens only.  Stale-steal "r" opens are
+// handled separately and return a dedicated read-fd so the acquire plan
+// cursor is not consumed by the read path (#562 fd-based read/write).
 let openPlan: Array<number | { code: string }> = []; // fd number OR error spec
 let openCursor = 0;
+const READ_FD = 7777; // arbitrary fd handed back for stale-read opens
 let nowPlan: number[] = [];
 let nowCursor = 0;
 let realNow: () => number;
-let readFileSyncImpl: (path: string) => string = () => "";
+// readSyncImpl returns the bytes that the production code's readSync sees.
+// It used to be readSyncImpl returning a string; under the fd-based read
+// the impl writes into the caller-supplied buffer, so we model it that way.
+let readSyncImpl: () => string = () => "";
 
-// ── Install fs mock (openSync/closeSync/unlinkSync/existsSync/mkdirSync) ─
+// ── Install fs mock (openSync/closeSync/unlinkSync/existsSync/mkdirSync +
+//    writeSync/readSync/fstatSync for the fd-based TOCTOU-safe path) ──────
 await mock.module("fs", () => ({
   ...realFs,
   openSync: (path: string, flags: string) => {
     calls.push({ fn: "openSync", args: [path, flags] });
+    // Stale-steal read path uses "r"; route to a dedicated fd so the acquire
+    // plan cursor isn't consumed by reads.
+    if (flags === "r") return READ_FD;
     const next = openPlan[Math.min(openCursor, openPlan.length - 1)];
     openCursor++;
     if (typeof next === "number") return next;
@@ -55,12 +66,20 @@ await mock.module("fs", () => ({
   mkdirSync: (path: string, opts: unknown) => {
     calls.push({ fn: "mkdirSync", args: [path, opts] });
   },
-  writeFileSync: (path: string, data: string) => {
-    calls.push({ fn: "writeFileSync", args: [path, data] });
+  writeSync: (fd: number, buf: Buffer, _off: number, _len: number, _pos: number) => {
+    calls.push({ fn: "writeSync", args: [fd, buf.toString("utf-8")] });
+    return buf.length;
   },
-  readFileSync: (path: string, _enc: string) => {
-    calls.push({ fn: "readFileSync", args: [path] });
-    return readFileSyncImpl(path);
+  fstatSync: (fd: number) => {
+    calls.push({ fn: "fstatSync", args: [fd] });
+    return { size: Buffer.byteLength(readSyncImpl()) } as ReturnType<typeof realFs.fstatSync>;
+  },
+  readSync: (fd: number, buf: Buffer, _off: number, _len: number, _pos: number) => {
+    calls.push({ fn: "readSync", args: [fd] });
+    const data = Buffer.from(readSyncImpl());
+    const n = Math.min(buf.length, data.length);
+    data.copy(buf, 0, 0, n);
+    return n;
   },
 }));
 
@@ -121,7 +140,7 @@ describe("withUpdateLock — acquisition + release (#551)", () => {
     // Keep Date.now small so we stay under the 60s deadline.
     stubDateNow([1_000, 1_100, 1_200, 1_300, 1_400]);
     // Mock lock holder as OUR pid so it's alive → forces wait path (not stale-steal)
-    readFileSyncImpl = () => String(process.pid);
+    readSyncImpl = () => String(process.pid);
     const { withUpdateLock } = await import("../../src/cli/update-lock");
 
     const origLog = console.log;
@@ -137,8 +156,10 @@ describe("withUpdateLock — acquisition + release (#551)", () => {
       console.log = origLog;
     }
 
-    const opens = calls.filter((c) => c.fn === "openSync");
-    expect(opens.length).toBe(2);
+    // Only count acquire ("wx") opens — the fd-based stale-check also issues
+    // an "r" open per #562, which is not part of the acquire-attempt count.
+    const wxOpens = calls.filter((c) => c.fn === "openSync" && c.args[1] === "wx");
+    expect(wxOpens.length).toBe(2);
     // "waiting up to 60s" announcement printed once.
     expect(logs.some((l) => l.includes("waiting up to 60s"))).toBe(true);
   });
@@ -189,7 +210,7 @@ describe("withUpdateLock — acquisition + release (#551)", () => {
     ];
     // readFileSync returns a PID that's guaranteed dead (pid 999999 extremely unlikely
     // to be live on the test host). kill(pid, 0) throws ESRCH → isAlive returns false.
-    readFileSyncImpl = () => "999999";
+    readSyncImpl = () => "999999";
     stubDateNow([0, 500, 500]);
     const { withUpdateLock } = await import("../../src/cli/update-lock");
 
@@ -216,7 +237,7 @@ describe("withUpdateLock — acquisition + release (#551)", () => {
       { code: "EEXIST" },
       { code: "EEXIST" },
     ];
-    readFileSyncImpl = () => String(process.pid);
+    readSyncImpl = () => String(process.pid);
     stubDateNow([0, 500, 61_000]);
     const { withUpdateLock } = await import("../../src/cli/update-lock");
 


### PR DESCRIPTION
## Summary

Re-applies the TOCTOU-hardening originally introduced in #552 (commit 9898fc8) that was reverted on the #552 branch (commit c0b4924) when CI's `test-isolated` failed.

Closes #562.

### Source (`src/cli/update-lock.ts`)

- Drop `writeFileSync`/`readFileSync`, add `writeSync`/`readSync`/`fstatSync`.
- **Acquire path**: `openSync(LOCK_PATH, "wx")` + `writeSync(fd, pidBytes)` — closes the symlink-swap window between `openSync` and the write.
- **Stale-check path**: `openSync(LOCK_PATH, "r")` + `fstatSync` + `readSync` + `closeSync` (in finally) — same TOCTOU reasoning on the read side.

### Test (`test/isolated/update-lock.test.ts`)

The original revert was caused by the spy modelling only `writeFileSync`/`readFileSync`. Updated to match the fd-based contract:

- `mock.module("fs", ...)` gains `writeSync`/`readSync`/`fstatSync` stubs.
- `openSync` mock now distinguishes `"wx"` (consumes `openPlan`) from `"r"` (returns dedicated `READ_FD = 7777`) so stale-read opens don't burn acquire-plan slots.
- `readFileSyncImpl` renamed to `readSyncImpl`, writes into the caller-supplied buffer.
- Case 2 assertion now counts only `"wx"` opens (the new `"r"` open in the stale-check path is not part of the acquire-attempt count).

### Semantics preserved

withUpdateLock: clean acquire, EEXIST poll, stale-pid steal, live-pid timeout, finally release on both happy path and fn throw — all six existing test cases still cover them.

## Test plan

- [x] `bun run test` -> 1147 pass / 7 skip / 0 fail
- [x] `bun run test:isolated` -> 69/69 files pass (this is where it broke last time)
- [x] `bun run test:mock-smoke` -> 6 pass
- [x] `bun run test:plugin` -> 146 pass / 6 skip
- [ ] CI `test-isolated` job green

## History

- #552 commit 9898fc8 -> initial TOCTOU change
- #552 commit c0b4924 -> revert (test-isolated failure)
- #562 -> this PR, re-apply with the test fix the #552 sprint didn't have time for

LOC: +49 / -15 across 2 files.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>