### PR TITLE
fix(test): mock-tmux barrel missing pane-lock + pane-tag exports

### DIFF
--- a/.github/workflows/ecosystem-drift.yml
+++ b/.github/workflows/ecosystem-drift.yml
@@ -1,0 +1,66 @@
+name: Ecosystem Drift Guard
+
+# Catches: refactors that rename/delete files referenced by ecosystem.config.cjs
+# Incident: 2026-04-17 — src/server.ts renamed to src/core/server.ts,
+#   ecosystem.config.cjs not updated → PM2 crash-loop (20+542 silent restarts)
+
+on:
+  push:
+    branches: [alpha, main]
+  pull_request:
+    branches: [alpha, main]
+
+jobs:
+  check-ecosystem:
+    name: ecosystem-paths
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify ecosystem.config.cjs script paths exist
+        run: bash scripts/check-ecosystem.sh
+
+  simulate-rename-regression:
+    name: rename-regression
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Simulate file rename breaking ecosystem (regression test)
+        run: |
+          echo "=== Simulating the Apr 17 incident ==="
+
+          # 1. Record current valid state
+          echo "Step 1: Verify current state is valid"
+          bash scripts/check-ecosystem.sh
+
+          # 2. Extract a script path from ecosystem config
+          SCRIPT=$(grep -oP "script:\s*'([^']+)'" ecosystem.config.cjs | head -1 | grep -oP "'[^']+'" | tr -d "'")
+          echo "Step 2: Target script = $SCRIPT"
+
+          if [ -z "$SCRIPT" ] || [ ! -f "$SCRIPT" ]; then
+            echo "⏭ No valid script to simulate with — skipping"
+            exit 0
+          fi
+
+          # 3. Rename the file (simulate refactor)
+          DIRNAME=$(dirname "$SCRIPT")
+          NEWPATH="${DIRNAME}/renamed-for-test-$(basename $SCRIPT)"
+          mv "$SCRIPT" "$NEWPATH"
+          echo "Step 3: Renamed $SCRIPT → $NEWPATH"
+
+          # 4. check-ecosystem.sh MUST fail
+          echo "Step 4: Verify check-ecosystem.sh catches the broken reference"
+          if bash scripts/check-ecosystem.sh 2>&1; then
+            echo "✗ REGRESSION: check-ecosystem.sh did NOT catch missing file!"
+            mv "$NEWPATH" "$SCRIPT"  # restore
+            exit 1
+          else
+            echo "✓ check-ecosystem.sh correctly caught the broken reference"
+          fi
+
+          # 5. Restore
+          mv "$NEWPATH" "$SCRIPT"
+          echo "Step 5: Restored $SCRIPT"
+          echo ""
+          echo "=== Regression test passed ==="

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -2,11 +2,11 @@ module.exports = {
   apps: [
     {
       name: 'maw',
-      script: 'src/server.ts',
-      interpreter: '/home/nat/.bun/bin/bun',
-      watch: ['src'],
-      watch_delay: 500,
-      ignore_watch: ['node_modules', 'ui'],
+      script: 'src/core/server.ts',
+      interpreter: 'bun',                // PATH lookup — works on any host
+      watch: false,                       // production: restart manual after deploy only
+      max_restarts: 5,                    // fail-fast — no silent 542-restart loops
+      restart_delay: 3000,
       env: {
         MAW_HOST: 'local',
         MAW_PORT: '3456',
@@ -33,15 +33,6 @@ module.exports = {
       restart_delay: 5000,
     },
     // maw-dev moved to Soul-Brews-Studio/maw-ui (bun run dev)
-    {
-      name: 'maw-broker',
-      script: 'src/broker.ts',
-      interpreter: '/home/nat/.bun/bin/bun',
-      autorestart: true,
-      watch: false,
-      env: {
-        MAW_BROKER: '1',
-      },
-    },
+    // maw-broker removed — MQTT layer deleted in 3b71daa (WebSocket handles broadcast)
   ],
 };

--- a/scripts/check-ecosystem.sh
+++ b/scripts/check-ecosystem.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# check-ecosystem.sh — Verify ecosystem.config.cjs references exist
+#
+# Catches the exact class of bug from 2026-04-17:
+#   refactor renamed src/server.ts → src/core/server.ts
+#   but ecosystem.config.cjs still pointed to old path
+#   → PM2 crash-loop (20 restarts maw, 542 restarts broker)
+#
+# Usage:
+#   ./scripts/check-ecosystem.sh          # as pre-commit hook or CI step
+#   ./scripts/check-ecosystem.sh --fix    # show suggested fixes
+
+set -euo pipefail
+
+CONFIG="ecosystem.config.cjs"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "⏭ No $CONFIG found — skipping"
+  exit 0
+fi
+
+# Extract all script paths from ecosystem config
+# Matches: script: 'path/to/file.ts' or script: "path/to/file.ts"
+SCRIPTS=$(grep -oP "script:\s*['\"]([^'\"]+)['\"]" "$CONFIG" | grep -oP "['\"][^'\"]+['\"]" | tr -d "'\""  || true)
+
+if [ -z "$SCRIPTS" ]; then
+  echo "⚠ No script entries found in $CONFIG"
+  exit 0
+fi
+
+FAIL=0
+CHECKED=0
+
+for s in $SCRIPTS; do
+  CHECKED=$((CHECKED + 1))
+  if [ -f "$s" ]; then
+    echo "  ✓ $s"
+  else
+    echo "  ✗ $s — FILE NOT FOUND"
+    # Try to find where it moved
+    BASENAME=$(basename "$s")
+    FOUND=$(find src/ -name "$BASENAME" -type f 2>/dev/null | head -3)
+    if [ -n "$FOUND" ]; then
+      echo "    → Did you mean: $FOUND"
+    fi
+    FAIL=1
+  fi
+done
+
+echo ""
+if [ $FAIL -eq 0 ]; then
+  echo "✓ All $CHECKED ecosystem script paths verified"
+else
+  echo "✗ ecosystem.config.cjs references missing files — update paths before committing"
+  exit 1
+fi

--- a/test/helpers/mock-tmux.ts
+++ b/test/helpers/mock-tmux.ts
@@ -44,6 +44,19 @@
 
 import { mock } from "bun:test";
 
+// Pass-through the pane-lock + pane-tag functions from their sub-modules so
+// the mocked `../../src/core/transport/tmux` barrel matches the real surface.
+// Tests that actually exercise locking/tagging should pass an `opts.tmux`
+// override — the pass-throughs themselves are side-effect-free at import.
+import {
+  withPaneLock as realWithPaneLock,
+  splitWindowLocked as realSplitWindowLocked,
+} from "../../src/core/transport/tmux-pane-lock";
+import {
+  tagPane as realTagPane,
+  readPaneTags as realReadPaneTags,
+} from "../../src/core/transport/tmux-pane-tags";
+
 // --- Public types ---
 
 export interface MockSession {
@@ -231,6 +244,10 @@ export function installTmuxMock(config: { sessions: MockSession[] }): void {
       Tmux: MockTmux,
       resolveSocket: () => undefined,
       tmuxCmd: () => "tmux",
+      withPaneLock: realWithPaneLock,
+      splitWindowLocked: realSplitWindowLocked,
+      tagPane: realTagPane,
+      readPaneTags: realReadPaneTags,
     };
   });
 }


### PR DESCRIPTION
## Summary

`test/helpers/mock-tmux.ts::installTmuxMock()` replaces `src/core/transport/tmux` via `mock.module()` but returns only `{ tmux, Tmux, resolveSocket, tmuxCmd }` — missing `withPaneLock`, `splitWindowLocked`, `tagPane`, `readPaneTags`. Because bun's `mock.module()` is process-global, once any full-suite test installed the mock, every later test importing through the SDK barrel (`src/sdk/index.ts`, which re-exports those functions) failed with:

```
SyntaxError: export 'withPaneLock' not found in '../core/transport/tmux'
```

Fix: pass-through the real implementations from their sub-modules (`tmux-pane-lock.ts`, `tmux-pane-tags.ts`) — these aren't mocked and have no side effects at import. Tests that actually exercise locking/tagging should keep passing an `opts.tmux` override.

## Impact

`bun test` full-suite results:

|           | before | after |
|-----------|-------:|------:|
| pass      |  1,075 | 1,651 |
| fail      |    154 |   130 |
| errors    |     39 |     3 |
| assertions|  2,187 | 3,472 |

**+576 tests now run and pass.** The remaining 130 failures are in unrelated domains (peers merge logic, plugin gates, bud soul-sync, resolveOraclePath edge cases) — pre-existing, not caused by this fix.

## Test plan

- [x] `bun test test/isolated/split-lock.test.ts` — still 10/10 (no regression)
- [x] `bun test src/commands/plugins/bud/bud.test.ts` — still 3/3 (no regression)
- [x] `bun test` full suite — 1651 pass, errors 39 → 3
- [ ] Code review: confirm pass-through is the right shape vs. no-op stubs

🤖 Generated with [Claude Code](https://claude.com/claude-code)