### PR TITLE
fix(peers): reject non-object store shape (follow-up to #579)

### DIFF
--- a/src/commands/plugins/peers/peers.test.ts
+++ b/src/commands/plugins/peers/peers.test.ts
@@ -146,6 +146,62 @@ describe("peers store — corruption + cleanup + lock (#572)", () => {
     expect(errs.some(e => e.includes("failed to parse"))).toBe(true);
   });
 
+  it("wrong-shape peers.json (array) → loadPeers returns empty + renames aside + warns (#579 follow-up)", async () => {
+    const { loadPeers, peersPath } = await import("./store");
+    const path = peersPath();
+    // Parses fine as JSON, but `peers` is an array — would silently
+    // no-op every write. Before the fix this returned the array unchanged.
+    writeFileSync(path, '{"peers":[]}');
+    const errs: string[] = [];
+    const orig = console.error;
+    console.error = (msg: string) => { errs.push(String(msg)); };
+    try {
+      const data = loadPeers();
+      expect(data.peers).toEqual({});
+      expect(Array.isArray(data.peers)).toBe(false);
+    } finally {
+      console.error = orig;
+    }
+    expect(existsSync(path)).toBe(false);
+    const { readdirSync } = await import("fs");
+    const aside = readdirSync(dir).find(f => f.startsWith("peers.json.corrupt-"));
+    expect(aside).toBeDefined();
+    expect(errs.some(e => e.includes("invalid store shape"))).toBe(true);
+  });
+
+  it("wrong-shape peers.json (top-level array) → loadPeers returns empty + renames aside", async () => {
+    const { loadPeers, peersPath } = await import("./store");
+    const path = peersPath();
+    writeFileSync(path, '[]');
+    const orig = console.error;
+    console.error = () => {};
+    try {
+      const data = loadPeers();
+      expect(data.peers).toEqual({});
+    } finally {
+      console.error = orig;
+    }
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it("add after wrong-shape recovery actually persists (reproduces the silent-drop bug)", async () => {
+    const { peersPath } = await import("./store");
+    const path = peersPath();
+    writeFileSync(path, '{"peers":[]}');
+    const orig = console.error;
+    console.error = () => {};
+    try {
+      const { cmdAdd, cmdList } = await import("./impl");
+      const res = await cmdAdd({ alias: "x", url: "http://1.2.3.4", node: null });
+      expect(res.alias).toBe("x");
+      const rows = cmdList();
+      expect(rows).toHaveLength(1);
+      expect(rows[0].alias).toBe("x");
+    } finally {
+      console.error = orig;
+    }
+  });
+
   it("stale .tmp on startup → loadPeers cleans it up", async () => {
     const { loadPeers, peersPath } = await import("./store");
     const tmp = peersPath() + ".tmp";

--- a/src/commands/plugins/peers/store.ts
+++ b/src/commands/plugins/peers/store.ts
@@ -17,9 +17,10 @@
  * read-modify-write critical section so concurrent `maw peers add`
  * calls don't lose each other's updates (#572 nit 3). See ./lock.ts.
  *
- * Corruption: if the live file fails to parse, we rename it aside to
- * `peers.json.corrupt-<ISO>` and start fresh — non-destructive, with
- * an audit trail (#572 nit 1).
+ * Corruption: if the live file fails to parse, OR if it parses but
+ * the shape is wrong (e.g. `{"peers":[]}` — array instead of object),
+ * we rename it aside to `peers.json.corrupt-<ISO>` and start fresh —
+ * non-destructive, with an audit trail (#572 nit 1, follow-up to #579).
  */
 import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync, unlinkSync } from "fs";
 import { join, dirname } from "path";
@@ -58,10 +59,10 @@ export function loadPeers(): PeersFile {
   }
   try {
     const parsed = JSON.parse(raw) as Partial<PeersFile>;
-    if (!parsed || typeof parsed !== "object") throw new Error("not an object");
+    if (!isValidStoreShape(parsed)) throw new Error("invalid store shape (expected { peers: { ... } } object)");
     return {
       version: 1,
-      peers: parsed.peers && typeof parsed.peers === "object" ? parsed.peers : {},
+      peers: (parsed.peers ?? {}) as Record<string, Peer>,
     };
   } catch (e: any) {
     const stamp = new Date().toISOString().replace(/[:.]/g, "-");
@@ -70,6 +71,20 @@ export function loadPeers(): PeersFile {
     console.error(`\x1b[33m⚠\x1b[0m peers store at ${path} failed to parse (${e?.message || e}); moved aside to ${aside}`);
     return emptyStore();
   }
+}
+
+/**
+ * Validate the parsed JSON matches the expected store shape:
+ * a non-null object whose `peers` field is itself a non-null,
+ * non-array object. Guards against `{"peers":[]}` (array) and
+ * other junk that would silently no-op every write (follow-up
+ * to #579).
+ */
+function isValidStoreShape(parsed: unknown): parsed is PeersFile {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return false;
+  const peers = (parsed as { peers?: unknown }).peers;
+  if (peers === undefined) return true; // missing peers is ok — we default to {}
+  return typeof peers === "object" && peers !== null && !Array.isArray(peers);
 }
 
 export function savePeers(data: PeersFile): void {
@@ -100,10 +115,10 @@ function readUnlocked(path: string): PeersFile {
   if (!existsSync(path)) return emptyStore();
   try {
     const parsed = JSON.parse(readFileSync(path, "utf-8")) as Partial<PeersFile>;
-    if (!parsed || typeof parsed !== "object") return emptyStore();
+    if (!isValidStoreShape(parsed)) return emptyStore();
     return {
       version: 1,
-      peers: parsed.peers && typeof parsed.peers === "object" ? parsed.peers : {},
+      peers: (parsed.peers ?? {}) as Record<string, Peer>,
     };
   } catch {
     return emptyStore();


### PR DESCRIPTION
## Summary

Follow-up to #579. Fixes a silent-drop bug where a wrong-shape `peers.json` (e.g. `{"peers":[]}` — `peers` as an array instead of an object) would pass the loader's weak `typeof === "object"` check and cause every subsequent `maw peers add` to report success but never persist anything.

Live repro (confirmed today):
```bash
echo '{"peers":[]}' > ~/.maw/peers.json
maw peers add x http://1.2.3.4    # before: prints "added x"
maw peers ls                       # before: "no peers" — silent drop
                                   # after:  warning + fresh store + peer persisted
```

## Fix

- New `isValidStoreShape()` guard: requires non-null object whose `peers` field (when present) is a non-null, non-array object.
- `loadPeers()`: on shape mismatch, renames the bad file to `peers.json.corrupt-<ISO>` and logs a ⚠ warning — same recovery path as #579's invalid-JSON branch.
- `readUnlocked()` (used inside the mutate lock): also validates shape; returns empty store on mismatch so the atomic write overwrites the bad file in place.
- Guards against both `{"peers":[]}` and top-level `[]`.

## Tests

3 new cases in `src/commands/plugins/peers/peers.test.ts`:
- `wrong-shape peers.json (array) → loadPeers returns empty + renames aside + warns`
- `wrong-shape peers.json (top-level array) → loadPeers returns empty + renames aside`
- `add after wrong-shape recovery actually persists (reproduces the silent-drop bug)`

All 22 peers.test.ts cases pass, plus the 12 isolated peers/peers-reachable/peers-send tests.

## Diff size

+78 / -7 across 2 files (real changes well under the <60 LOC target for the fix itself; most of the delta is the new test cases).

## Test plan

- [x] `bun test src/commands/plugins/peers/peers.test.ts` — 22/22 pass
- [x] `bun test test/isolated/peers*.test.ts` — 12/12 pass
- [x] Manual repro: `{"peers":[]}` + `cmdAdd` now persists correctly
- [ ] CI green

Co-Authored-By: mawjs (he/him) <noreply@soulbrews.studio>