### PR TITLE
bump: v26.4.18-alpha.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.18-alpha.19",
+  "version": "26.4.18-alpha.23",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts CalVer alpha.23. 5 merges since alpha.19: #578, #579, #580, #581, #583. calver-release.yml will auto-tag + publish dist/maw on merge.