### PR TITLE
bump: v26.4.18-alpha.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.18-alpha.23",
+  "version": "26.4.18-alpha.24",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
3 commits since v26.4.18-alpha.23:

**feat:**
- cross-team-queue plugin — unified inbox across oracle vaults (#515, #585)
- peers: loud handshake errors — DNS / REFUSED / TIMEOUT / TLS / HTTP / BAD_BODY with opt-in `lastError` + `maw peers probe` subcommand (#565, #587)

**sec:**
- codeql: model `sanitizeLogField` as `js/log-injection` sanitizer via inline lgtm suppressions on 4 hub-connection.ts sites — closes log-injection bucket of #474, #586

Tag `v26.4.18-alpha.24` will be cut post-merge.