### PR TITLE
feat(bud): scaffold --from-repo flag + dry-run plan (#588)

### DIFF
--- a/docs/bud/from-repo-design.md
+++ b/docs/bud/from-repo-design.md
@@ -1,0 +1,148 @@
+# `maw bud --from-repo` — design
+
+Issue: #588
+Status: scaffold-only (this PR) → full injection lands in follow-up PRs.
+
+## Problem
+
+Today `maw bud <name>` creates a brand-new repo (`<name>-oracle`) under the
+configured GitHub org and initialises oracle scaffolding inside it (ψ/,
+CLAUDE.md, fleet config). There is no supported way to take an **existing**
+repository and "oracle-ise" it in place — to add ψ/, append to its CLAUDE.md,
+and drop the minimal `.claude/` hooks without disturbing source code.
+
+`--from-repo <target>` injects the oracle-side scaffolding into a target repo.
+
+## Flag shape
+
+```
+maw bud --from-repo <path-or-url> --stem <stem> [--pr] [--dry-run]
+```
+
+- `--from-repo <target>` — the repo to inject into. Accepts:
+  - a local absolute path to a checked-out repo
+  - `org/repo` slug (resolved via `ghq get`, see `shared/wake-target`)
+  - a full git URL (`https://github.com/...` or `git@github.com:...`)
+- `--stem <stem>` — the oracle stem (no `-oracle` suffix; the bud naming
+  guard in `impl.ts` already rejects trailing `-oracle`). Used for CLAUDE.md
+  identity block + fleet entry name in later PRs.
+- `--pr` — instead of committing to the default branch, create a branch
+  `oracle-scaffold` and open a PR. **Not implemented in this PR.**
+- `--dry-run` — print the injection plan (list of files to add / append)
+  and exit without writing. **Implemented in this PR.**
+
+`--stem` is required (we don't try to infer from repo path, because the
+"arra-oracle-v3 → arra-oracle-v3-oracle" bud-naming pitfall applies here
+too — user must state the stem explicitly). If omitted, we error with the
+existing naming-guard message style.
+
+## What gets injected (exact list)
+
+Four groups, in order:
+
+1. **`ψ/` vault directory** — same structure as `bud-init.ts::initVault`:
+   ```
+   ψ/memory/learnings/
+   ψ/memory/retrospectives/
+   ψ/memory/traces/
+   ψ/memory/resonance/
+   ψ/memory/collaborations/
+   ψ/inbox/
+   ψ/outbox/
+   ψ/plans/
+   ```
+   All empty — no seed content. (Follow-up PR: optional `--seed` from a parent.)
+
+2. **`CLAUDE.md`** — if absent, write the full `generateClaudeMd` template
+   (identity + Rule 6). If present, **append** an `## Oracle scaffolding`
+   section with Rule 6 + lineage pointer. We never overwrite a host repo's
+   CLAUDE.md — that is a collision rule below.
+
+3. **`.claude/` minimal** — just enough for skills to resolve:
+   ```
+   .claude/settings.local.json   (empty JSON object)
+   ```
+   We deliberately skip hooks / commands / MCP wiring in this PR. Follow-up
+   PR can add a `.claude/hooks/` directory for rtk + oraclenet.
+
+4. **Fleet entry** — reuse `configureFleet` from `bud-init.ts`, pointing
+   `windows[0].repo` at the target repo slug. Parent lineage is optional
+   here (a host-repo oracle may be a root-style oracle with no parent).
+   **Not written in this PR** — the scaffold module only returns the plan.
+
+## Collision rules
+
+Hard stops (abort before writing anything):
+
+- `ψ/` already exists at target → `error: ψ/ already present — looks like
+  an existing oracle repo. Use maw soul-sync or maw wake.`
+- Target path is not a git repo (`.git` absent and not a valid work-tree)
+  → error. (URL targets are cloned via `ghq` first, so they always land
+  in a git repo.)
+- `--stem` ends with `-oracle` → reuse the existing runtime guard message
+  from `impl.ts`.
+
+Soft merges:
+
+- `CLAUDE.md` exists → append, never overwrite. The appended block is
+  fenced with an HTML comment marker (`<!-- oracle-scaffold: begin -->`)
+  so re-running the injector can detect idempotency.
+- `.claude/settings.local.json` exists → leave it alone. Only create if
+  absent.
+- Fleet entry already exists for this stem → reuse it (existing
+  `configureFleet` already handles idempotency).
+
+## Lifecycle — which bud steps run when `--from-repo`
+
+`maw bud` today runs eight steps (see `impl.ts::cmdBud`):
+
+| # | Step                      | --from-repo runs? | Why |
+|---|---------------------------|-------------------|-----|
+| 1 | `ensureBudRepo` (create gh repo + ghq get) | **skip** | target already exists; we only need a local checkout |
+| 2 | `initVault` (ψ/)          | **run** | core of the injection |
+| 3 | `generateClaudeMd`        | **run (modified)** | append if file exists; write full if not |
+| 4 | `configureFleet`          | run — follow-up PR | fleet needs the target slug + stem |
+| 4.5 | `writeBirthNote` (opt-in on `--note`) | run — follow-up PR | |
+| 5 | soul-sync `--seed`        | **skip** | out of scope for injection (follow-up) |
+| 6 | initial commit + push     | **skip** | host repo owner decides when/how to commit |
+| 7 | parent `sync_peers` update | run — follow-up PR | only if `--from` is also given |
+| 8 | `cmdWake`                 | **skip** | injection is not a session — user runs `maw wake` manually |
+
+Identity creation: same as regular bud (name must pass `assertValidOracleName`).
+Issue creation: no — existing `--issue` is for fetching a prompt on wake; not
+relevant here.
+
+## Where the code lives
+
+```
+src/commands/plugins/bud/
+  index.ts          # add --from-repo + --stem + --pr to parseFlags spec
+  impl.ts           # branch early: if opts.fromRepo, call cmdBudFromRepo
+  from-repo.ts      # NEW — planFromRepoInjection(opts) → InjectionPlan
+                    #       cmdBudFromRepo(opts) → orchestrator (dry-run only this PR)
+  types.ts          # NEW — FromRepoOpts + InjectionPlan
+  from-repo.test.ts # NEW — parser wiring + plan assertions
+```
+
+`from-repo.ts` stays ≤200 LOC. If it grows in follow-ups, split the
+actual-write path into `from-repo-apply.ts` to keep the planner pure.
+
+## This PR's ship criterion
+
+- `maw bud --from-repo <path> --stem x --dry-run` prints the injection
+  plan and exits 0 without touching the target.
+- `maw bud --from-repo <path> --stem x` (no `--dry-run`) exits non-zero
+  with `not yet implemented — see #588`. No partial writes ever.
+- Types exported so the follow-up PR can `import { FromRepoOpts } from "./types"`.
+- Tests cover: parser routes `--from-repo` to the new module; planner
+  returns the expected file list for a clean target; collision on
+  pre-existing ψ/ is reported (planner-level — doesn't need to write).
+
+## Explicit TODO — not in this PR
+
+1. Actually writing ψ/ + CLAUDE.md append + `.claude/settings.local.json`.
+2. URL / `org/repo` resolution via `ensureCloned` (only local paths in dry-run).
+3. `--pr` branch-and-PR path.
+4. Fleet entry creation (step 4 of the lifecycle).
+5. Idempotency marker detection on re-run.
+6. Optional `--from <parent>` for lineage in the injected CLAUDE.md.

--- a/src/commands/plugins/bud/from-repo.test.ts
+++ b/src/commands/plugins/bud/from-repo.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import type { InvokeContext } from "../../../plugin/types";
+import { planFromRepoInjection, looksLikeUrl, cmdBudFromRepo } from "./from-repo";
+
+function mkGitRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "maw-from-repo-test-"));
+  mkdirSync(join(dir, ".git"));
+  return dir;
+}
+
+describe("from-repo: looksLikeUrl", () => {
+  it("https URL", () => expect(looksLikeUrl("https://github.com/x/y")).toBe(true));
+  it("git@ URL", () => expect(looksLikeUrl("git@github.com:x/y.git")).toBe(true));
+  it("org/repo slug", () => expect(looksLikeUrl("Soul-Brews-Studio/maw-js")).toBe(true));
+  it("absolute path", () => expect(looksLikeUrl("/home/nat/code/repo")).toBe(false));
+  it("relative path", () => expect(looksLikeUrl("./repo")).toBe(false));
+});
+
+describe("from-repo: planFromRepoInjection", () => {
+  it("plans a clean local repo (no CLAUDE.md, no ψ/)", () => {
+    const dir = mkGitRepo();
+    try {
+      const plan = planFromRepoInjection({
+        target: dir, stem: "demo", isUrl: false, pr: false, dryRun: true,
+      });
+      expect(plan.blockers).toEqual([]);
+      const kinds = plan.actions.map(a => `${a.kind}:${a.path}`);
+      expect(kinds).toContain("mkdir:ψ/memory/learnings");
+      expect(kinds).toContain("mkdir:ψ/inbox");
+      expect(kinds).toContain("write:CLAUDE.md");
+      expect(kinds).toContain("write:.claude/settings.local.json");
+      expect(kinds.some(k => k.startsWith("skip:fleet/"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("appends (not overwrites) when CLAUDE.md already exists", () => {
+    const dir = mkGitRepo();
+    try {
+      writeFileSync(join(dir, "CLAUDE.md"), "# existing\n");
+      const plan = planFromRepoInjection({
+        target: dir, stem: "demo", isUrl: false, pr: false, dryRun: true,
+      });
+      const claude = plan.actions.find(a => a.path === "CLAUDE.md");
+      expect(claude?.kind).toBe("append");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks when ψ/ already present", () => {
+    const dir = mkGitRepo();
+    try {
+      mkdirSync(join(dir, "ψ"));
+      const plan = planFromRepoInjection({
+        target: dir, stem: "demo", isUrl: false, pr: false, dryRun: true,
+      });
+      expect(plan.blockers.length).toBeGreaterThan(0);
+      expect(plan.blockers[0]).toContain("ψ/ already present");
+      expect(plan.actions).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks when target is not a git repo", () => {
+    const dir = mkdtempSync(join(tmpdir(), "maw-nongit-"));
+    try {
+      const plan = planFromRepoInjection({
+        target: dir, stem: "demo", isUrl: false, pr: false, dryRun: true,
+      });
+      expect(plan.blockers.some(b => b.includes("not a git repo"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks when target path does not exist", () => {
+    const plan = planFromRepoInjection({
+      target: "/nonexistent/path/for-maw-test",
+      stem: "demo", isUrl: false, pr: false, dryRun: true,
+    });
+    expect(plan.blockers.some(b => b.includes("does not exist"))).toBe(true);
+  });
+
+  it("blocks URL targets as not-yet-supported", () => {
+    const plan = planFromRepoInjection({
+      target: "https://github.com/x/y", stem: "demo", isUrl: true, pr: false, dryRun: true,
+    });
+    expect(plan.blockers.some(b => b.includes("not yet supported"))).toBe(true);
+  });
+});
+
+describe("from-repo: cmdBudFromRepo", () => {
+  it("dry-run on clean repo completes without throwing", async () => {
+    const dir = mkGitRepo();
+    try {
+      await cmdBudFromRepo({ target: dir, stem: "demo", isUrl: false, pr: false, dryRun: true });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("dry-run on blocked target throws with blocker count", async () => {
+    const dir = mkGitRepo();
+    mkdirSync(join(dir, "ψ"));
+    try {
+      await expect(cmdBudFromRepo({
+        target: dir, stem: "demo", isUrl: false, pr: false, dryRun: true,
+      })).rejects.toThrow(/blocker/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("non-dry-run always refuses with pointer to #588", async () => {
+    const dir = mkGitRepo();
+    try {
+      await expect(cmdBudFromRepo({
+        target: dir, stem: "demo", isUrl: false, pr: false, dryRun: false,
+      })).rejects.toThrow(/not yet implemented — see #588/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("from-repo: handler wiring", () => {
+  let handler: (ctx: InvokeContext) => Promise<any>;
+
+  beforeEach(async () => {
+    mock.module("./impl", () => ({
+      cmdBud: async (name: string) => { console.log(`budding ${name}`); },
+    }));
+    // re-import to pick up mock
+    delete (require.cache as any)[require.resolve("./index")];
+    const mod = await import("./index");
+    handler = mod.default;
+  });
+
+  it("--from-repo without --stem returns error", async () => {
+    const result = await handler({ source: "cli", args: ["--from-repo", "/tmp/x"] });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("--stem");
+  });
+
+  it("--stem ending with -oracle rejected", async () => {
+    const result = await handler({
+      source: "cli",
+      args: ["--from-repo", "/tmp/x", "--stem", "foo-oracle"],
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("-oracle");
+  });
+
+  it("--from-repo --dry-run on clean local repo succeeds", async () => {
+    const dir = mkGitRepo();
+    try {
+      const result = await handler({
+        source: "cli",
+        args: ["--from-repo", dir, "--stem", "demo", "--dry-run"],
+      });
+      expect(result.ok).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/commands/plugins/bud/from-repo.ts
+++ b/src/commands/plugins/bud/from-repo.ts
@@ -1,0 +1,149 @@
+/**
+ * `maw bud --from-repo <target> --stem <stem>` — scaffold-only implementation.
+ *
+ * SCOPE (this PR, #588): planning + dry-run printing only. Any non-dry-run
+ * invocation exits with "not yet implemented — see #588". No filesystem
+ * writes happen from this module in any path.
+ *
+ * Design: docs/bud/from-repo-design.md
+ */
+
+import { existsSync, statSync } from "fs";
+import { join, isAbsolute } from "path";
+import type { FromRepoOpts, InjectionAction, InjectionPlan } from "./types";
+
+/** Heuristic: is `target` a URL or `org/repo` slug rather than a local path? */
+export function looksLikeUrl(target: string): boolean {
+  if (target.startsWith("http://") || target.startsWith("https://")) return true;
+  if (target.startsWith("git@")) return true;
+  // `org/repo` slug — exactly one slash, no leading dot/slash, no absolute path
+  if (!isAbsolute(target) && !target.startsWith(".") && target.split("/").length === 2) return true;
+  return false;
+}
+
+/** The directory tree that `ψ/` injection needs to create — mirrors bud-init.ts. */
+const PSI_DIRS = [
+  "ψ/memory/learnings",
+  "ψ/memory/retrospectives",
+  "ψ/memory/traces",
+  "ψ/memory/resonance",
+  "ψ/memory/collaborations",
+  "ψ/inbox",
+  "ψ/outbox",
+  "ψ/plans",
+];
+
+/**
+ * Compute the injection plan for a target repo. Pure / read-only —
+ * never writes, never mutates. The returned plan is safe to print.
+ *
+ * Blockers are hard stops that the caller must refuse to proceed past.
+ */
+export function planFromRepoInjection(opts: FromRepoOpts): InjectionPlan {
+  const blockers: string[] = [];
+  const actions: InjectionAction[] = [];
+
+  if (opts.isUrl) {
+    blockers.push(
+      `URL / org-slug targets not yet supported — see #588 TODO. Pass a local path for dry-run.`,
+    );
+    return { target: opts.target, stem: opts.stem, actions, blockers };
+  }
+
+  const target = opts.target;
+  if (!existsSync(target)) {
+    blockers.push(`target path does not exist: ${target}`);
+    return { target, stem: opts.stem, actions, blockers };
+  }
+  if (!statSync(target).isDirectory()) {
+    blockers.push(`target is not a directory: ${target}`);
+    return { target, stem: opts.stem, actions, blockers };
+  }
+  if (!existsSync(join(target, ".git"))) {
+    blockers.push(`target is not a git repo (no .git): ${target}`);
+    return { target, stem: opts.stem, actions, blockers };
+  }
+
+  // Collision: ψ/ already present
+  if (existsSync(join(target, "ψ"))) {
+    blockers.push(
+      `ψ/ already present at ${target} — looks like an existing oracle repo. Use maw soul-sync or maw wake.`,
+    );
+    return { target, stem: opts.stem, actions, blockers };
+  }
+
+  // 1. ψ/ vault directories
+  for (const d of PSI_DIRS) {
+    actions.push({ kind: "mkdir", path: d });
+  }
+
+  // 2. CLAUDE.md — write if absent, append if present
+  const claudePath = join(target, "CLAUDE.md");
+  if (existsSync(claudePath)) {
+    actions.push({
+      kind: "append",
+      path: "CLAUDE.md",
+      reason: "exists — will append ## Oracle scaffolding section (never overwrite)",
+    });
+  } else {
+    actions.push({
+      kind: "write",
+      path: "CLAUDE.md",
+      reason: "absent — will write full oracle identity + Rule 6 template",
+    });
+  }
+
+  // 3. .claude/settings.local.json — minimal, only if absent
+  const settingsPath = join(target, ".claude", "settings.local.json");
+  if (existsSync(settingsPath)) {
+    actions.push({ kind: "skip", path: ".claude/settings.local.json", reason: "exists — leave untouched" });
+  } else {
+    actions.push({ kind: "write", path: ".claude/settings.local.json", reason: "empty {} scaffold" });
+  }
+
+  // 4. fleet entry — deferred; listed as skip so operators see the gap
+  actions.push({
+    kind: "skip",
+    path: `fleet/<NN>-${opts.stem}.json`,
+    reason: "fleet entry creation deferred to follow-up PR (#588)",
+  });
+
+  return { target, stem: opts.stem, actions, blockers };
+}
+
+/** Render the plan for human reading. Caller prints — no side effects here. */
+export function formatPlan(plan: InjectionPlan): string {
+  const lines: string[] = [];
+  lines.push(`\n  \x1b[36m🧪 Oracle scaffold plan\x1b[0m — ${plan.stem} → ${plan.target}\n`);
+  if (plan.blockers.length > 0) {
+    lines.push(`  \x1b[31m✗ blocked:\x1b[0m`);
+    for (const b of plan.blockers) lines.push(`    - ${b}`);
+    return lines.join("\n") + "\n";
+  }
+  for (const a of plan.actions) {
+    const tag = a.kind === "mkdir" ? "mkdir" : a.kind === "write" ? "write" : a.kind === "append" ? "append" : "skip ";
+    const color = a.kind === "skip" ? "\x1b[90m" : "\x1b[36m";
+    const reason = a.reason ? `  \x1b[90m(${a.reason})\x1b[0m` : "";
+    lines.push(`  ${color}${tag}\x1b[0m  ${a.path}${reason}`);
+  }
+  return lines.join("\n") + "\n";
+}
+
+/**
+ * Orchestrator. Dry-run: print the plan. Non-dry-run: refuse with a pointer
+ * to #588 — the actual write path is a follow-up PR.
+ */
+export async function cmdBudFromRepo(opts: FromRepoOpts): Promise<void> {
+  const plan = planFromRepoInjection(opts);
+  if (opts.dryRun) {
+    console.log(formatPlan(plan));
+    if (plan.blockers.length > 0) {
+      throw new Error(`plan has ${plan.blockers.length} blocker(s) — see above`);
+    }
+    return;
+  }
+  throw new Error(
+    `maw bud --from-repo: not yet implemented — see #588.\n` +
+    `  Re-run with --dry-run to preview the injection plan.`,
+  );
+}

--- a/src/commands/plugins/bud/index.ts
+++ b/src/commands/plugins/bud/index.ts
@@ -1,5 +1,6 @@
 import type { InvokeContext, InvokeResult } from "../../../plugin/types";
 import { cmdBud } from "./impl";
+import { cmdBudFromRepo, looksLikeUrl } from "./from-repo";
 import { parseFlags } from "../../../cli/parse-args";
 
 export const command = {
@@ -24,6 +25,8 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       const args = ctx.args as string[];
       const flags = parseFlags(args, {
         "--from": String,
+        "--from-repo": String,
+        "--stem": String,
         "--org": String,
         "--repo": String,
         "--issue": Number,
@@ -31,15 +34,37 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         "--fast": Boolean,
         "--root": Boolean,
         "--dry-run": Boolean,
+        "--pr": Boolean,
         "--split": Boolean,
         "--seed": Boolean,
         "--blank": Boolean,
         "--signal-on-birth": Boolean,
       }, 0);
 
+      // --from-repo branches early: inject scaffolding into an existing repo (#588).
+      // Scaffold-only this PR — see docs/bud/from-repo-design.md.
+      if (flags["--from-repo"]) {
+        const target = flags["--from-repo"];
+        const stem = flags["--stem"];
+        if (!stem) {
+          return { ok: false, error: "--from-repo requires --stem <stem> (oracle stem, no -oracle suffix)" };
+        }
+        if (stem.endsWith("-oracle")) {
+          return { ok: false, error: `--stem must NOT end with '-oracle' — got '${stem}'. Try: --stem ${stem.replace(/-oracle$/, "")}` };
+        }
+        await cmdBudFromRepo({
+          target,
+          stem,
+          isUrl: looksLikeUrl(target),
+          pr: !!flags["--pr"],
+          dryRun: !!flags["--dry-run"],
+        });
+        return { ok: true, output: logs.join("\n") || undefined };
+      }
+
       const name = flags._[0];
       if (!name || name === "--help" || name === "-h") {
-        return { ok: false, error: "usage: maw bud <name> [--from <oracle>] [--root] [--seed] [--org <org>] [--repo org/repo] [--issue N] [--note <text>] [--fast] [--split] [--dry-run]\n       Default: born blank. Use --seed to pre-load parent's ψ at birth.\n       Pull memory later: maw soul-sync <parent> --from" };
+        return { ok: false, error: "usage: maw bud <name> [--from <oracle>] [--root] [--seed] [--org <org>] [--repo org/repo] [--issue N] [--note <text>] [--fast] [--split] [--dry-run]\n       Or:    maw bud --from-repo <path> --stem <stem> [--pr] [--dry-run]  (#588, scaffold-only)\n       Default: born blank. Use --seed to pre-load parent's ψ at birth.\n       Pull memory later: maw soul-sync <parent> --from" };
       }
       if (name.startsWith("-")) {
         return { ok: false, error: `"${name}" looks like a flag, not an oracle name.\n  usage: maw bud <name> ${args.join(" ")}` };

--- a/src/commands/plugins/bud/plugin.json
+++ b/src/commands/plugins/bud/plugin.json
@@ -6,9 +6,11 @@
   "description": "Create a new oracle (bud from parent)",
   "cli": {
     "command": "bud",
-    "help": "maw bud <name> [--from <oracle>] [--root] [--seed] [--org <org>] [--repo org/repo] [--issue N] [--note <text>] [--fast] [--split] [--dry-run]\n       Default: born blank. Use --seed to pre-load parent's ψ at birth.\n       Pull memory later: maw soul-sync <parent> --from\n       NOTE: <name> is the STEM. Repo created as <name>-oracle.\n       e.g. 'maw bud fusion' → 'fusion-oracle'. 'maw bud fusion-oracle' → 'fusion-oracle-oracle' ✗",
+    "help": "maw bud <name> [--from <oracle>] [--root] [--seed] [--org <org>] [--repo org/repo] [--issue N] [--note <text>] [--fast] [--split] [--dry-run]\n       Or:    maw bud --from-repo <path> --stem <stem> [--pr] [--dry-run]  (#588, scaffold-only)\n       Default: born blank. Use --seed to pre-load parent's ψ at birth.\n       Pull memory later: maw soul-sync <parent> --from\n       NOTE: <name> is the STEM. Repo created as <name>-oracle.\n       e.g. 'maw bud fusion' → 'fusion-oracle'. 'maw bud fusion-oracle' → 'fusion-oracle-oracle' ✗",
     "flags": {
       "--from": "string",
+      "--from-repo": "string",
+      "--stem": "string",
       "--org": "string",
       "--repo": "string",
       "--issue": "number",
@@ -16,10 +18,10 @@
       "--fast": "boolean",
       "--root": "boolean",
       "--blank": "boolean",
+      "--pr": "boolean",
       "--split": "boolean",
       "--seed": "boolean",
-      "--dry-run": "boolean",
-      "--seed": "boolean"
+      "--dry-run": "boolean"
     }
   },
   "api": {

--- a/src/commands/plugins/bud/types.ts
+++ b/src/commands/plugins/bud/types.ts
@@ -1,0 +1,36 @@
+/**
+ * Bud plugin — shared types.
+ *
+ * `BudOpts` lives in impl.ts for historical reasons; new-feature types land here.
+ * See docs/bud/from-repo-design.md for the `--from-repo` design.
+ */
+
+/** Options for `maw bud --from-repo <target> --stem <stem>`. Issue #588. */
+export interface FromRepoOpts {
+  /** The target repo. Accepts a local absolute path, `org/repo` slug, or git URL. */
+  target: string;
+  /** Stem of the oracle name; `-oracle` MUST NOT be included (impl.ts rejects it). */
+  stem: string;
+  /** Heuristic — `target` parses as a URL / slug rather than a filesystem path. */
+  isUrl: boolean;
+  /** Open a PR on the target instead of committing to the default branch. */
+  pr: boolean;
+  /** Print the injection plan and exit without writing. */
+  dryRun: boolean;
+}
+
+/** One file in the injection plan — what would be added or appended. */
+export interface InjectionAction {
+  kind: "mkdir" | "write" | "append" | "skip";
+  path: string;
+  reason?: string;
+}
+
+/** Result of `planFromRepoInjection` — a read-only preview. */
+export interface InjectionPlan {
+  target: string;
+  stem: string;
+  actions: InjectionAction[];
+  /** If non-empty, the plan cannot proceed — `cmdBudFromRepo` must refuse. */
+  blockers: string[];
+}


### PR DESCRIPTION
## Summary

Scaffolds `maw bud --from-repo <path> --stem <stem>` — the entrypoint that will inject oracle scaffolding (`ψ/`, `CLAUDE.md` append, minimal `.claude/`) into an existing repo. This PR is **scaffold + analysis only** — the actual filesystem writes are deferred to a follow-up per #588.

- `docs/bud/from-repo-design.md` — 1-page design: file list, collision rules, flag shape, which bud lifecycle steps run vs skip, code layout.
- `src/commands/plugins/bud/types.ts` — `FromRepoOpts` + `InjectionPlan`.
- `src/commands/plugins/bud/from-repo.ts` (149 LOC) — pure `planFromRepoInjection` planner + `formatPlan` renderer + `cmdBudFromRepo` orchestrator. Never writes in any path.
- `src/commands/plugins/bud/index.ts` — adds `--from-repo`, `--stem`, `--pr`; branches early so regular bud is untouched.
- `src/commands/plugins/bud/from-repo.test.ts` — 17 new tests (planner, URL detection, handler wiring).

Closes scaffolding portion of #588.

## Dry-run output sample

```
  🧪 Oracle scaffold plan — demo → /tmp/my-repo

  mkdir  ψ/memory/learnings
  mkdir  ψ/memory/retrospectives
  mkdir  ψ/memory/traces
  mkdir  ψ/memory/resonance
  mkdir  ψ/memory/collaborations
  mkdir  ψ/inbox
  mkdir  ψ/outbox
  mkdir  ψ/plans
  write  CLAUDE.md  (absent — will write full oracle identity + Rule 6 template)
  write  .claude/settings.local.json  (empty {} scaffold)
  skip   fleet/<NN>-demo.json  (fleet entry creation deferred to follow-up PR (#588))
```

Non-dry-run invocation today:
```
maw bud --from-repo /tmp/my-repo --stem demo
→ Error: maw bud --from-repo: not yet implemented — see #588.
  Re-run with --dry-run to preview the injection plan.
```

## Ship criteria (all met)

- [x] `--from-repo --dry-run` on a clean local git repo prints the plan and exits 0.
- [x] `--from-repo` without `--dry-run` exits non-zero with `#588` pointer — **zero filesystem writes in any path**.
- [x] `--stem` required; `-oracle` suffix rejected (mirrors existing bud guard).
- [x] Types exported so follow-up PR can `import { FromRepoOpts, InjectionPlan } from "./types"`.
- [x] Each file ≤200 LOC (from-repo.ts = 149, types.ts = 36, index.ts = 114).
- [x] `bun run test:all` green — 217 pass / 0 fail / 6 skip.

## NOT in this PR (follow-up TODO list)

1. **Actual filesystem writes** — mkdir ψ/, write/append CLAUDE.md, create `.claude/settings.local.json`.
2. **URL / `org/repo` resolution** — today URLs are a hard blocker. Follow-up wires `ensureCloned` from `shared/wake-target`.
3. **`--pr` branch-and-PR flow** — create `oracle-scaffold` branch, commit, push, `gh pr create`.
4. **Fleet entry creation** — call `configureFleet` against the target repo slug.
5. **CLAUDE.md append idempotency** — HTML-comment markers so re-running the injector is a no-op.
6. **Optional `--from <parent>` lineage** — so the injected CLAUDE.md names a parent oracle.
7. **Optional `--seed` soul-sync from a parent oracle** at injection time.
8. **Parent `sync_peers` update** when `--from` is passed alongside `--from-repo`.

## Test plan

- [x] `bun test src/commands/plugins/bud/from-repo.test.ts` — 17 pass
- [x] `bun run test:all` — 217 pass / 0 fail
- [ ] CI green on this PR

🤖 ตอบโดย budrepo-scaffolder จาก [Nat] → mawjs-oracle