### PR TITLE
sec(codeql): stance doc + lgtm suppressions for 11 private-path file-system-race sites (#474)

### DIFF
--- a/docs/security/file-system-race-stance.md
+++ b/docs/security/file-system-race-stance.md
@@ -1,0 +1,104 @@
+---
+title: File-system-race stance
+status: adopted
+related: [#474, #581]
+---
+
+# File-system-race stance
+
+This document is the policy we apply when CodeQL's
+`js/file-system-race` query fires on maw-js. It closes the
+`js/file-system-race` bucket of #474 and is the rubric every future
+flagged site must pass before merging.
+
+## Threat model
+
+`maw` is a local, single-user CLI. It runs as the invoking user's uid
+and operates against that user's own state:
+
+- `~/.maw/` — teams, inboxes, task artifacts, fleet cache, lockfiles
+- project working directories the user owns (scaffold destinations
+  like a freshly-budded oracle repo)
+
+An attacker who can place a file inside `~/.maw/` at a racing moment
+already has a local shell running as the same uid as the user. In that
+posture, every file the user can read or write is already reachable
+without racing the CLI — the TOCTOU is redundant with shell access.
+This is distinct from a multi-tenant daemon guarding root-owned paths,
+where a lower-privileged attacker can race a privileged check; that
+threat model doesn't apply here.
+
+This framing matches the POSIX convention that per-user state under
+`$HOME` is trusted relative to other uids, untrusted relative to the
+user themselves (for which we have no defense and no mandate).
+
+## Classification rubric
+
+Every `js/file-system-race` alert on a maw-js PR must be tagged with
+exactly one of:
+
+| Class             | Action    | When                                                                        |
+|-------------------|-----------|-----------------------------------------------------------------------------|
+| **TRUE-TOCTOU**   | Fix       | Shared/system path, or per-user path where racing changes a privilege/trust boundary (e.g. single-writer lockfile, pid ownership). Apply fd-based open/read/write like #581. |
+| **PRIVATE-PATH**  | Suppress  | Path lives entirely under the user's own `~/.maw/` or the user-owned scaffold destination. Racing requires same-uid shell, which is out of our threat model. |
+| **POST-FIX-STALE**| Suppress with ref | Site was already converted to fd-based I/O in a prior fix; CodeQL's next scan hasn't cleared the alert yet. Cite the fix PR. |
+
+New alerts that do not fit any of the three classes are not covered by
+this stance and must be triaged on their own merits (typically: fix).
+
+## The 10+1 sites suppressed in this PR
+
+All 10 PRIVATE-PATH sites write JSON metadata, scaffold boilerplate,
+or inbox files under a path rooted in `~/.maw/` or a user-owned
+scaffold destination. None guards a privilege boundary.
+
+| Site                                              | Class          | Justification                                                              |
+|---------------------------------------------------|----------------|----------------------------------------------------------------------------|
+| `src/commands/plugins/bud/bud-init.ts:31`         | PRIVATE-PATH   | Writes `CLAUDE.md` stub into freshly-budded user-owned repo.               |
+| `src/commands/plugins/team/task-ops.ts:34`        | PRIVATE-PATH   | Writes `counter.json` under `~/.maw/teams/<team>/`.                        |
+| `src/commands/plugins/team/team-helpers.ts:77`    | PRIVATE-PATH   | Writes teammate shutdown-request inbox under `~/.maw/teams/<team>/inboxes/`. |
+| `src/commands/plugins/team/team-helpers.ts:98`    | PRIVATE-PATH   | Writes teammate message inbox under `~/.maw/teams/<team>/inboxes/`.        |
+| `src/commands/plugins/team/team-lifecycle.ts:221` | PRIVATE-PATH   | Writes team manifest under `~/.maw/teams/<team>/`.                         |
+| `src/commands/plugins/team/team-lifecycle.ts:232` | PRIVATE-PATH   | Writes tool-store `config.json` under `~/.maw/teams/<team>/` (#393 bridge). |
+| `src/commands/shared/plugin-create-as.ts:21`      | PRIVATE-PATH   | Rewrites `package.json` inside user-owned scaffold destination.            |
+| `src/core/fleet/registry-oracle-cache.ts:55`      | PRIVATE-PATH   | Writes merged fleet registry cache under `~/.maw/`.                        |
+| `src/lib/artifacts.ts:62`                         | PRIVATE-PATH   | Updates artifact `meta.json` under `~/.maw/artifacts/<team>/<task>/`.      |
+| `src/plugin/registry-helpers.ts:92`               | PRIVATE-PATH   | Writes `legacy-plugin-warning` throttle state under user state dir.        |
+| `src/cli/update-lock.ts:55`                       | POST-FIX-STALE | Fd-based read; site was converted in #581 — alert is pre-fix stale.        |
+
+Not in this PR (handed to the TOCTOU fix, task #1): the three sites
+that cross a trust boundary on a shared lockfile / pid file —
+`src/core/peers/lock.ts:42`, `src/core/peers/lock.ts:47`,
+`src/core/runtime/instance-pid.ts:56`.
+
+## Policy
+
+Before merging any PR that lands a new `js/file-system-race` finding:
+
+1. Each new finding is classified per the rubric above.
+2. PRIVATE-PATH and POST-FIX-STALE findings get a `// lgtm[js/file-system-race]`
+   comment with a one-line rationale naming either this doc or the
+   prior fix PR.
+3. TRUE-TOCTOU findings get fixed (fd-based open + read/write under
+   the opened descriptor, like #581) — never suppressed.
+4. If the classification is genuinely ambiguous, default to fixing, or
+   open a discussion issue rather than suppressing.
+
+## Revisit triggers
+
+Re-open this stance and re-audit the suppressed sites if any of:
+
+- `maw` grows a privileged/daemon mode that runs as a different uid
+  than the calling user.
+- The `~/.maw/` directory gains a mode that is group- or
+  world-writable, or we begin honoring `$MAW_STATE_DIR` pointing
+  outside the user's home.
+- A scaffold destination moves to a shared path (e.g. `/var/lib/maw`)
+  — PRIVATE-PATH no longer holds there.
+
+## Related
+
+- #474 — CodeQL first-scan bucket.
+- #581 — fd-based write for `update-lock` (informs POST-FIX-STALE).
+- `docs/security/codeql-sanitizer-model.md` — parallel stance for the
+  `js/log-injection` bucket of #474.

--- a/src/cli/update-lock.ts
+++ b/src/cli/update-lock.ts
@@ -52,6 +52,7 @@ export async function withUpdateLock<T>(fn: () => Promise<T>): Promise<T> {
       let holderPid = NaN;
       let readFd: number | null = null;
       try {
+        // lgtm[js/file-system-race] — POST-FIX-STALE: fd-based read per #581, alert is pre-fix stale; see docs/security/file-system-race-stance.md
         readFd = openSync(LOCK_PATH, "r");
         const size = fstatSync(readFd).size;
         const buf = Buffer.alloc(Math.min(size, 64));

--- a/src/commands/plugins/bud/bud-init.ts
+++ b/src/commands/plugins/bud/bud-init.ts
@@ -28,6 +28,7 @@ export function generateClaudeMd(budRepoPath: string, name: string, parentName: 
   const lineageField = parentName
     ? `- **Budded from**: ${parentName}`
     : `- **Origin**: root (no parent)`;
+  // lgtm[js/file-system-race] — PRIVATE-PATH: scaffold dest is user-owned, see docs/security/file-system-race-stance.md
   writeFileSync(claudeMd, `# ${name}-oracle
 
 ${lineageHeader}

--- a/src/commands/plugins/team/task-ops.ts
+++ b/src/commands/plugins/team/task-ops.ts
@@ -31,6 +31,7 @@ function nextId(team: string): number {
     try { counter = JSON.parse(readFileSync(p, "utf-8")); } catch { /**/ }
   }
   const id = counter.next;
+  // lgtm[js/file-system-race] — PRIVATE-PATH: counter under ~/.maw/teams/, see docs/security/file-system-race-stance.md
   writeFileSync(p, JSON.stringify({ next: id + 1 }));
   return id;
 }

--- a/src/commands/plugins/team/team-helpers.ts
+++ b/src/commands/plugins/team/team-helpers.ts
@@ -74,6 +74,7 @@ export function writeShutdownRequest(teamName: string, memberName: string, reaso
     timestamp: new Date().toISOString(),
     read: false,
   });
+  // lgtm[js/file-system-race] — PRIVATE-PATH: inbox under ~/.maw/teams/<team>/inboxes/, see docs/security/file-system-race-stance.md
   writeFileSync(inboxPath, JSON.stringify(messages, null, 2));
 }
 
@@ -95,6 +96,7 @@ export function writeMessage(teamName: string, memberName: string, from: string,
     read: false,
   });
   mkdirSync(join(TEAMS_DIR, teamName, "inboxes"), { recursive: true });
+  // lgtm[js/file-system-race] — PRIVATE-PATH: inbox under ~/.maw/teams/<team>/inboxes/, see docs/security/file-system-race-stance.md
   writeFileSync(inboxPath, JSON.stringify(messages, null, 2));
 }
 

--- a/src/commands/plugins/team/team-lifecycle.ts
+++ b/src/commands/plugins/team/team-lifecycle.ts
@@ -218,6 +218,7 @@ export async function cmdTeamSpawn(
   const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
   if (!manifest.members.includes(role)) {
     manifest.members.push(role);
+    // lgtm[js/file-system-race] — PRIVATE-PATH: manifest under ~/.maw/teams/<team>/, see docs/security/file-system-race-stance.md
     writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
   }
 
@@ -229,6 +230,7 @@ export async function cmdTeamSpawn(
       const member: TeamMember = { name: role, model };
       if (!toolConfig.members.some((m: any) => m.name === role)) {
         toolConfig.members.push(member);
+        // lgtm[js/file-system-race] — PRIVATE-PATH: tool config under ~/.maw/teams/<team>/ (#393), see docs/security/file-system-race-stance.md
         writeFileSync(toolConfigPath, JSON.stringify(toolConfig, null, 2));
       }
     } catch { /* best effort */ }

--- a/src/commands/shared/plugin-create-as.ts
+++ b/src/commands/shared/plugin-create-as.ts
@@ -18,6 +18,7 @@ export function scaffoldAs(name: string, dest: string, templateDir = TEMPLATE_AS
   if (existsSync(pkgPath)) {
     const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
     pkg.name = name;
+    // lgtm[js/file-system-race] — PRIVATE-PATH: rewrites package.json in user-owned scaffold dest, see docs/security/file-system-race-stance.md
     writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
   }
 

--- a/src/core/fleet/registry-oracle-cache.ts
+++ b/src/core/fleet/registry-oracle-cache.ts
@@ -52,6 +52,7 @@ export function writeCache(cache: RegistryCache, targetFile: string = CACHE_FILE
   } catch { /* malformed existing file — fall back to writing fresh */ }
 
   const merged = mergeRegistry(existing, cache);
+  // lgtm[js/file-system-race] — PRIVATE-PATH: fleet registry cache under ~/.maw/, see docs/security/file-system-race-stance.md
   writeFileSync(targetFile, JSON.stringify(merged, null, 2) + "\n", "utf-8");
 }
 

--- a/src/lib/artifacts.ts
+++ b/src/lib/artifacts.ts
@@ -59,6 +59,7 @@ export function updateArtifact(team: string, taskId: string, updates: Partial<Ar
   if (!existsSync(metaPath)) return;
   const meta: ArtifactMeta = JSON.parse(readFileSync(metaPath, "utf-8"));
   Object.assign(meta, updates, { updatedAt: new Date().toISOString() });
+  // lgtm[js/file-system-race] — PRIVATE-PATH: artifacts under ~/.maw/artifacts/<team>/<task>/, see docs/security/file-system-race-stance.md
   writeFileSync(metaPath, JSON.stringify(meta, null, 2));
 }
 

--- a/src/plugin/registry-helpers.ts
+++ b/src/plugin/registry-helpers.ts
@@ -89,6 +89,7 @@ function markLegacyWarningShown(): void {
       try { state = JSON.parse(readFileSync(stateFile, "utf8")); } catch { /* corrupt — start fresh */ }
     }
     state["legacy-plugin-warning"] = { lastShownMs: Date.now() };
+    // lgtm[js/file-system-race] — PRIVATE-PATH: plugin throttle state under user state dir, see docs/security/file-system-race-stance.md
     writeFileSync(stateFile, JSON.stringify(state), "utf8");
   } catch { /* non-critical — ignore write errors */ }
 }


### PR DESCRIPTION
## Summary

Closes the `js/file-system-race` bucket of #474 by adopting a policy
(what we fix vs what we suppress) and applying it to the 10 PRIVATE-PATH
sites plus 1 POST-FIX-STALE site carried over from #581.

The 3 TRUE-TOCTOU sites (`src/core/peers/lock.ts:42/47`,
`src/core/runtime/instance-pid.ts:56`) are **not** in this PR — they
get a real fd-based fix in a sibling PR mirroring #581.

## Stance — `docs/security/file-system-race-stance.md`

- **Threat model**: `maw` is a local single-user CLI; state lives under
  `~/.maw/` or user-owned scaffold dests. Racing either path requires
  same-uid shell access, which is out of our threat model.
- **Rubric**: TRUE-TOCTOU (fix) vs PRIVATE-PATH (suppress) vs
  POST-FIX-STALE (suppress with ref to prior fix).
- **Policy**: every new `js/file-system-race` finding must be
  classified per the rubric before merging.
- **Revisit triggers**: daemon mode, group/world-writable state dir,
  scaffold moving to a shared path.

## Suppressed sites (11)

PRIVATE-PATH — writes under `~/.maw/` or user-owned scaffold dest:

| Site                                                | Rationale                          |
|-----------------------------------------------------|------------------------------------|
| `src/commands/plugins/bud/bud-init.ts:31`           | scaffold CLAUDE.md stub             |
| `src/commands/plugins/team/task-ops.ts:34`          | team counter.json                   |
| `src/commands/plugins/team/team-helpers.ts:77`      | shutdown-request inbox              |
| `src/commands/plugins/team/team-helpers.ts:98`      | message inbox                       |
| `src/commands/plugins/team/team-lifecycle.ts:221`   | team manifest                       |
| `src/commands/plugins/team/team-lifecycle.ts:232`   | tool-store config (#393 bridge)     |
| `src/commands/shared/plugin-create-as.ts:21`        | scaffold package.json rewrite       |
| `src/core/fleet/registry-oracle-cache.ts:55`        | fleet registry cache                |
| `src/lib/artifacts.ts:62`                           | artifact meta.json                  |
| `src/plugin/registry-helpers.ts:92`                 | legacy-plugin-warning throttle      |

POST-FIX-STALE — already converted in a prior fix:

| Site                                  | Reference |
|---------------------------------------|-----------|
| `src/cli/update-lock.ts:55`           | #581 fd-based read    |

## What this PR does not change

- No code paths altered — every change is a single `// lgtm[js/file-system-race]`
  comment line above the flagged call with a one-line justification.
- The 3 TRUE-TOCTOU sites are handed to the sibling PR.

## Test plan

- [x] Stance doc committed first (`76bbca8`)
- [x] `bun run test:all` green (test + test:isolated 69/69 + mock-smoke + plugin)
- [ ] `gh pr checks` → 0 failures before this task is marked done

Refs: #474, #486, #581.

🤖 Generated with [Claude Code](https://claude.com/claude-code)