### PR TITLE
fix(peers): classify ENOTIMP/EAI_* as DNS-family (#593)

### DIFF
--- a/src/commands/plugins/peers/peers-probe.test.ts
+++ b/src/commands/plugins/peers/peers-probe.test.ts
@@ -26,9 +26,15 @@ describe("classifyProbeError", () => {
     expect(classifyProbeError({ cause: { code: "ENOTFOUND" } })).toBe("DNS");
   });
 
-  it("EAI_AGAIN → DNS", async () => {
-    const { classifyProbeError } = await import("./probe");
-    expect(classifyProbeError({ cause: { code: "EAI_AGAIN" } })).toBe("DNS");
+  it.each([
+    ["EAI_AGAIN",  /Host does not resolve/],
+    ["EAI_NODATA", /Host does not resolve/],
+    ["EAI_FAIL",   /Host does not resolve/],
+    ["ENOTIMP",    /avahi-daemon.*etc\/hosts/],
+  ])("%s → DNS bucket with expected hint (#593)", async (code, hintRe) => {
+    const { classifyProbeError, pickHint } = await import("./probe");
+    expect(classifyProbeError({ cause: { code } })).toBe("DNS");
+    expect(pickHint({ code: "DNS", message: `getaddrinfo ${code} x`, at: "" })).toMatch(hintRe);
   });
 
   it("ECONNREFUSED → REFUSED", async () => {

--- a/src/commands/plugins/peers/probe.ts
+++ b/src/commands/plugins/peers/probe.ts
@@ -50,7 +50,8 @@ export function classifyProbeError(input: unknown): ProbeErrorCode {
   if (!err || typeof err !== "object") return "UNKNOWN";
 
   const code = err.cause?.code ?? err.code;
-  if (code === "ENOTFOUND" || code === "EAI_AGAIN" || code === "EAI_NODATA") return "DNS";
+  // ENOTIMP = resolver method unimplemented (e.g. mDNS/.local without Avahi); EAI_FAIL = unrecoverable DNS (#593).
+  if (code === "ENOTFOUND" || code === "ENOTIMP" || code === "EAI_FAIL" || code === "EAI_AGAIN" || code === "EAI_NODATA") return "DNS";
   // Bun conflates DNS + refused into "ConnectionRefused" — we run a DNS
   // precheck upstream, so any code that reaches here means connect failed.
   if (code === "ECONNREFUSED" || code === "ConnectionRefused") return "REFUSED";
@@ -158,9 +159,17 @@ export async function probePeer(url: string, timeoutMs = 2000): Promise<ProbeRes
   return { node };
 }
 
+/** Hint chooser — DNS bucket sub-types for ENOTIMP get a distinct hint (#593). */
+export function pickHint(err: LastError): string {
+  if (err.code === "DNS" && /ENOTIMP/i.test(err.message)) {
+    return "install avahi-daemon (Linux) for mDNS, or add white.local to /etc/hosts";
+  }
+  return PROBE_HINTS[err.code] ?? PROBE_HINTS.UNKNOWN;
+}
+
 /** Colored, multi-line stderr block with actionable hint. */
 export function formatProbeError(err: LastError, url: string, alias: string): string {
-  const hint = PROBE_HINTS[err.code] ?? PROBE_HINTS.UNKNOWN;
+  const hint = pickHint(err);
   const host = safeHost(url);
   return [
     `\x1b[33m⚠\x1b[0m peer handshake failed: \x1b[1m${err.code}\x1b[0m`,


### PR DESCRIPTION
## Summary
- Extend `classifyProbeError` DNS bucket to include `ENOTIMP` and `EAI_FAIL` (ENOTFOUND/EAI_AGAIN/EAI_NODATA already handled)
- Add `pickHint(err)` helper so `ENOTIMP` gets a distinct, actionable hint (avahi-daemon / `/etc/hosts`) while EAI_* keep the generic DNS hint
- Table-driven test covering all four codes — bucket + hint

Closes #593

## Before

```
$ maw peers probe white-mdns
⚠ peer handshake failed: UNKNOWN
   error: queryA ENOTIMP white.local:3456
   hint: Probe failed for an unclassified reason.
```

## After

```
$ maw peers probe white-mdns
⚠ peer handshake failed: DNS
   error: queryA ENOTIMP white.local:3456
   hint: install avahi-daemon (Linux) for mDNS, or add white.local to /etc/hosts
```

## Reproducer
Real-world repro from the federation health sweep:
`ψ/reports/federation-20260419-0223.md`

## Diff size
- impl: +11/-2 LOC (probe.ts now 191 LOC, well under 200 cap)
- tests: +9/-3 LOC (table-driven)
- total: 25 LOC

## Test plan
- [x] `bun test src/commands/plugins/peers/peers-probe.test.ts` — 29 pass
- [x] `bun run test:all` — 220 pass, 6 skip, 0 fail
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)