### PR TITLE
feat(docker): Dockerfile for maw-js:test image (part of federation test harness)

### DIFF
--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,8 @@
+agents/
+node_modules/
+.git/
+ψ/
+*.log
+.DS_Store
+dist/
+coverage/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,26 @@
+FROM oven/bun:1.3-alpine
+
+RUN apk add --no-cache wget
+
+WORKDIR /app
+
+COPY package.json bun.lock* ./
+RUN bun install --frozen-lockfile
+
+COPY . .
+
+COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENV MAW_HOME=/root/.maw \
+    NODE_NAME=node-a \
+    PEER_URL=http://node-b:3456 \
+    PEER_ALIAS=peer
+
+EXPOSE 3456
+
+HEALTHCHECK --interval=5s --retries=20 \
+  CMD wget -qO- http://localhost:3456/api/plugins || exit 1
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["maw", "serve", "3456"]


### PR DESCRIPTION
## Summary

Ships `docker/Dockerfile` + `docker/.dockerignore` for the `maw-js:test` image — part of the **docker-fed-0419** federation test harness (5-agent team: A=Dockerfile, B=compose, C=entrypoint, D=integration tests, E=CI+docs).

- Base: `oven/bun:1.3-alpine` (matches local bun 1.3.11)
- `apk add wget` so `HEALTHCHECK` works on alpine
- `bun install --frozen-lockfile` → `COPY . .` → COPY + chmod `/entrypoint.sh`
- ENV defaults: `MAW_HOME=/root/.maw`, `NODE_NAME=node-a`, `PEER_URL=http://node-b:3456`, `PEER_ALIAS=peer`
- EXPOSE 3456 · HEALTHCHECK hits `/api/plugins` (since `/info` returns 404 today)
- ENTRYPOINT `["/entrypoint.sh"]` · CMD `["maw","serve","3456"]`
- 28 lines (≤40 cap)

`.dockerignore` excludes: `agents/`, `node_modules/`, `.git/`, `ψ/`, `*.log`, `.DS_Store`, `dist/`, `coverage/`.

## Test plan

- [x] `bun run test:all` — 226 pass / 0 fail / 6 skip
- [x] `docker build -t maw-js:test -f docker/Dockerfile .` — validates base pull, apk, workdir, install, COPY . (fails at step 7 because `docker/entrypoint.sh` is owned by Docker C / scripter; will pass end-to-end once C merges)
- [ ] Full end-to-end build after Docker C lands
- [ ] Federation harness green via Docker D/E

🤖 Generated with [Claude Code](https://claude.com/claude-code)