### PR TITLE
feat(docker): compose.yml + dev helper for 2-node federation test

### DIFF
--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -1,0 +1,52 @@
+# 2-node federation test harness for maw-js.
+# Build: docker compose -f docker/compose.yml up -d --build
+# See scripts/dev-federation.sh for helper subcommands.
+
+services:
+  node-a:
+    image: maw-js:test
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    hostname: node-a
+    container_name: maw-node-a
+    environment:
+      NODE_NAME: node-a
+      PEER_URL: http://node-b:3456
+      PEER_ALIAS: peer
+      MAW_HOME: /root/.maw
+    ports:
+      - "13456:3456"
+    volumes:
+      - maw-a-data:/root/.maw
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3456/api/plugins"]
+      interval: 5s
+      retries: 20
+    restart: unless-stopped
+
+  node-b:
+    image: maw-js:test
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    hostname: node-b
+    container_name: maw-node-b
+    environment:
+      NODE_NAME: node-b
+      PEER_URL: http://node-a:3456
+      PEER_ALIAS: peer
+      MAW_HOME: /root/.maw
+    ports:
+      - "13457:3456"
+    volumes:
+      - maw-b-data:/root/.maw
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3456/api/plugins"]
+      interval: 5s
+      retries: 20
+    restart: unless-stopped
+
+volumes:
+  maw-a-data:
+  maw-b-data:

--- a/scripts/dev-federation.sh
+++ b/scripts/dev-federation.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# dev-federation.sh — 2-node maw-js federation harness driver.
+# Wraps `docker compose -f docker/compose.yml` with common dev actions.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPOSE_FILE="$REPO_ROOT/docker/compose.yml"
+COMPOSE=(docker compose -f "$COMPOSE_FILE")
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") <command> [args]
+
+Commands:
+  up                    Build + start node-a and node-b (detached)
+  down                  Stop containers and remove named volumes
+  logs [a|b]            Tail logs from one service (default: both)
+  shell [a|b]           Drop into container shell (default: a)
+  probe [a|b]           Run 'maw peers probe peer' inside node-<a|b> (default: a)
+  help                  Show this message
+
+Host ports: node-a → :13456, node-b → :13457 (both serve 3456 internally).
+EOF
+}
+
+resolve_service() {
+  case "${1:-a}" in
+    a|node-a) echo "node-a" ;;
+    b|node-b) echo "node-b" ;;
+    *) echo "unknown service: $1 (use a|b)" >&2; exit 2 ;;
+  esac
+}
+
+cmd="${1:-help}"
+shift || true
+
+case "$cmd" in
+  up)
+    "${COMPOSE[@]}" up -d --build
+    ;;
+  down)
+    "${COMPOSE[@]}" down -v
+    ;;
+  logs)
+    if [ $# -eq 0 ]; then
+      "${COMPOSE[@]}" logs -f --tail=200
+    else
+      svc=$(resolve_service "$1")
+      "${COMPOSE[@]}" logs -f --tail=200 "$svc"
+    fi
+    ;;
+  shell)
+    svc=$(resolve_service "${1:-a}")
+    "${COMPOSE[@]}" exec "$svc" sh
+    ;;
+  probe)
+    svc=$(resolve_service "${1:-a}")
+    "${COMPOSE[@]}" exec "$svc" maw peers probe peer
+    ;;
+  help|-h|--help|"")
+    usage
+    ;;
+  *)
+    echo "unknown command: $cmd" >&2
+    usage
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary

Team `docker-fed-0419` Task #2 (compose-author). Ships 2 files only:

- `docker/compose.yml` — 2-service v2 compose (no `version:` key), `node-a` + `node-b` sharing `maw-js:test`, host ports 13456/13457 → 3456, hostname-resolved peer URLs, named volumes (`maw-a-data`, `maw-b-data`), healthcheck re-declared per contract (`wget /api/plugins`, 5s/20). Default bridge network. 52 LOC.
- `scripts/dev-federation.sh` — bash driver with `up|down|logs|shell|probe|help` subcommands, resolves `a|b` shortcuts to `node-a|node-b`. 69 LOC, `+x`.

## Team contract (docker-fed-0419)

- Image `maw-js:test` (built by Task #1 `docker/Dockerfile`)
- Entrypoint/CMD inherited from Dockerfile (owned by Task #1/#3)
- Env matches contract: `NODE_NAME`, `PEER_URL`, `PEER_ALIAS=peer`, `MAW_HOME=/root/.maw`
- Peer URLs use compose DNS (`http://node-a:3456` / `http://node-b:3456`)
- Healthcheck uses `/api/plugins` (Dockerfile HEALTHCHECK inherited; re-declared here for visibility)

No changes outside `docker/compose.yml` and `scripts/dev-federation.sh`. Infrastructure-only — no `Closes` keyword.

## Test plan

- [x] `docker compose -f docker/compose.yml config --quiet` → OK (v5.1.1)
- [x] `bash -n scripts/dev-federation.sh` → OK; `./scripts/dev-federation.sh help` prints usage
- [x] LOC caps respected (compose.yml 52 ≤ 60, dev-federation.sh 69 ≤ 80)
- [x] `bun run test:all` → 4/4 suites green, 0 fail
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)