### PR TITLE
ci(docker): federation integration workflow + docs

### DIFF
--- a/.github/workflows/federation-docker.yml
+++ b/.github/workflows/federation-docker.yml
@@ -7,7 +7,6 @@ on:
       - 'scripts/test-docker-federation.sh'
       - 'src/commands/plugins/peers/**'
       - 'src/transports/**'
-      - '.github/workflows/federation-docker.yml'
 
 jobs:
   federation:

--- a/.github/workflows/federation-docker.yml
+++ b/.github/workflows/federation-docker.yml
@@ -1,0 +1,39 @@
+name: Federation (Docker) integration
+
+on:
+  pull_request:
+    paths:
+      - 'docker/**'
+      - 'scripts/test-docker-federation.sh'
+      - 'src/commands/plugins/peers/**'
+      - 'src/transports/**'
+      - '.github/workflows/federation-docker.yml'
+
+jobs:
+  federation:
+    name: 2-node probe round-trip
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Run federation integration test
+        run: bash scripts/test-docker-federation.sh
+
+      - name: Collect container logs on failure
+        if: failure()
+        run: |
+          mkdir -p /tmp/fed-logs
+          docker compose -f docker/compose.yml logs --no-color > /tmp/fed-logs/compose.log 2>&1 || true
+          docker compose -f docker/compose.yml ps > /tmp/fed-logs/ps.txt 2>&1 || true
+
+      - name: Upload container logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: federation-docker-logs
+          path: /tmp/fed-logs
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -187,3 +187,18 @@ Mar 2026   maw-js + maw-ui        Backend/frontend split
 Apr 2026   v2.0.0-alpha.66        Plugin OS, 896 commits, 57 commands,
                                    19 API endpoints, 1043 tests
 ```
+
+## Federation testing
+
+Peer handshake regressions hide on a single host. The Docker harness
+spins up two `maw-js:test` containers on a shared network and runs
+`maw peers probe` both directions as a round-trip smoke test.
+
+```bash
+bash scripts/test-docker-federation.sh   # build + up + probe + teardown
+bash scripts/dev-federation.sh up        # leave the 2-node stack running
+```
+
+CI runs the same script via `.github/workflows/federation-docker.yml`
+on any PR that touches `docker/**`, `src/transports/**`, or the peers
+plugin. Full runbook: [`docs/federation/docker-testing.md`](docs/federation/docker-testing.md).

--- a/docs/federation/docker-testing.md
+++ b/docs/federation/docker-testing.md
@@ -1,0 +1,67 @@
+# Federation testing in Docker
+
+Reproduce a GitHub-Actions-like environment locally: two maw-js
+containers on a shared Docker network, handshaking as peers.
+
+## Why this exists
+
+Peer handshake bugs only surface across real network boundaries — on a
+single host everything talks via `localhost` and subtle URL / DNS /
+CORS issues hide. Running two containers behind Docker's internal DNS
+gives us a cheap, reproducible 2-node cluster that mirrors what CI and
+production peer pairs actually see.
+
+## Run it locally
+
+```bash
+# One-shot: build + up + probe + teardown
+bash scripts/test-docker-federation.sh
+
+# Or step-through (leaves containers running):
+bash scripts/dev-federation.sh up
+docker compose -f docker/compose.yml exec node-a maw peers probe peer
+docker compose -f docker/compose.yml exec node-b maw peers probe peer
+bash scripts/dev-federation.sh down
+```
+
+Requires Docker Engine 24+ and `docker compose` v2.
+
+## Expected output
+
+```
+## Docker federation probe result
+a → b: PASS, code: 0, hint: -
+b → a: PASS, code: 0, hint: -
+```
+
+The script exits `0` only if both probe calls exit `0` **and** the
+output contains no `handshake failed` substring. Any other shape is a
+regression.
+
+## Debugging failures
+
+1. Re-run with the stack left up: `bash scripts/dev-federation.sh up`
+2. Shell into a node: `docker compose -f docker/compose.yml exec node-a sh`
+3. Inspect logs: `docker compose -f docker/compose.yml logs node-a node-b`
+4. Check healthchecks: `docker compose -f docker/compose.yml ps`
+5. Manual probe inside a node: `maw peers probe peer`
+
+On CI, the `Federation (Docker) integration` workflow uploads compose
+logs as a `federation-docker-logs` artifact when the job fails.
+
+## Known gaps
+
+- `maw-js` does not yet register a `/info` endpoint, so
+  `src/commands/plugins/peers/probe.ts` will surface `HTTP_4XX` against
+  any currently-built image. The probe round-trip is still useful for
+  catching transport / DNS / compose-wiring regressions, but the
+  handshake classifier will stay red until `/info` lands.
+  Tracking: <TODO: link issue #N once tester files it>.
+
+## Related
+
+- `docker/Dockerfile` — the `maw-js:test` image (single-stage, bun-alpine)
+- `docker/compose.yml` — 2-node wiring with mutual `PEER_URL`s
+- `scripts/dev-federation.sh` — local up/down helper
+- `scripts/test-docker-federation.sh` — end-to-end probe driver
+- `.github/workflows/federation-docker.yml` — CI wrapper


### PR DESCRIPTION
## Summary
- `.github/workflows/federation-docker.yml` — single-job CI that runs `scripts/test-docker-federation.sh` on PRs touching `docker/**`, the test script, the peers plugin, or transports. Uploads compose logs as an artifact on failure.
- `docs/federation/docker-testing.md` — ~1-page runbook: why, how to run locally, expected structured output, how to debug failures, link to the /info known-gap issue (placeholder `#N` — lead fills on merge).
- `README.md` — adds a 14-line `## Federation testing` section pointing at the doc.

## Team contract
Part of the **docker-fed-0419** team. Shared image/compose contract lives on Task #1; this PR only wires the 3 CI/docs files (Task #5 scope). Companion PRs from the other 4 agents (Dockerfile, compose.yml + dev-federation.sh, entrypoint.sh, test-docker-federation.sh + /info issue) land alongside.

## LOC
- workflow: 39 / 50
- doc: 67 / 150
- README section: 14 / 15

## Test plan
- [x] `bun run test:all` green locally (4 suites, exit 0)
- [x] Workflow parses as valid YAML (`python3 -c "yaml.safe_load(...)"`)
- [ ] CI green on this PR
- [ ] `Federation (Docker) integration` workflow runs once the sibling PRs land the `docker/` + `scripts/test-docker-federation.sh` paths it watches

🤖 Generated with [Claude Code](https://claude.com/claude-code)