### PR TITLE
feat(docker): entrypoint.sh — idempotent peer bootstrap for federation test containers

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# docker/entrypoint.sh — PID 1 bootstrap for the federation test container.
+#
+# Bootstrap order:
+#   1. Ensure HOME and MAW_HOME exist ($MAW_HOME/peers.json is the peers store).
+#   2. If peers.json is missing, run `maw init --non-interactive --force` to
+#      write ~/.config/maw/maw.config.json. (init does NOT create peers.json —
+#      that only happens on the first successful `maw peers add`.)
+#   3. Register the peer via `maw peers add` — tolerant on restart with the
+#      same volume (add overwrites cleanly; `|| true` swallows probe failures
+#      when the peer container hasn't come up yet).
+#   4. exec "$@" so the CMD (e.g. `maw serve`) becomes PID 1 and receives
+#      SIGTERM directly from the container runtime.
+#
+# `maw init` supports --non-interactive with --node/--ghq-root/--force/--federate
+# flags (src/commands/plugins/init/non-interactive.ts). No stdin blocking.
+set -eu
+
+: "${HOME:=/root}"
+export HOME
+
+: "${MAW_HOME:=$HOME/.maw}"
+: "${NODE_NAME:=$(hostname)}"
+: "${PEER_ALIAS:=peer}"
+
+mkdir -p "$MAW_HOME"
+
+if [ ! -f "$MAW_HOME/peers.json" ]; then
+  maw init --non-interactive --node "$NODE_NAME" --force
+fi
+
+if [ -n "${PEER_URL:-}" ]; then
+  maw peers add "$PEER_ALIAS" "$PEER_URL" || true
+fi
+
+echo "[${NODE_NAME}] bootstrap complete — peers.json:"
+cat "$MAW_HOME/peers.json" 2>/dev/null || echo "(no peers.json yet)"
+
+exec "$@"


### PR DESCRIPTION
## Summary
- Adds `docker/entrypoint.sh` — PID 1 wrapper for the federation test image.
- Seeds `~/.config/maw/maw.config.json` via `maw init --non-interactive --force` on first boot (gated on `$MAW_HOME/peers.json` absence for idempotency across restarts with the same volume).
- Registers `PEER_ALIAS → PEER_URL` via `maw peers add || true` — tolerant when the peer container hasn't booted yet (probe failures surface via `lastError` but don't fail the bootstrap) and on restart (cmdAdd overwrites with a warning).
- `exec "$@"` hands PID 1 to the CMD (e.g. `maw serve`) so SIGTERM from the runtime hits the daemon directly.

## Team contract (docker-fed-0419, Task #3)
- Runs under `/bin/sh` at `/entrypoint.sh` (alpine base per Task #1 Dockerfile).
- Inputs from env: `MAW_HOME`, `NODE_NAME`, `PEER_URL`, `PEER_ALIAS` (all have safe defaults).
- 39 LOC, under the 80-line cap.
- Top-of-file comment documents the bootstrap order and notes that `maw init` has a real `--non-interactive` flag (verified in `src/commands/plugins/init/non-interactive.ts`), so we drive it with flags rather than seeding config directly.

## Test plan
- [x] `bun run test:all` green (unit + isolated + plugin + mock-smoke, 0 fail across all suites)
- [x] `sh -n docker/entrypoint.sh` syntax check passes
- [x] `chmod +x` applied
- [ ] End-to-end federation smoke under `docker compose -f docker/compose.yml up` — covered by sibling Tasks #2/#4 once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)