### PR TITLE
sec(demo): address js/remote-property-injection × 2 in demo/agents.html (#474)

### DIFF
--- a/demo/agents.html
+++ b/demo/agents.html
@@ -86,6 +86,8 @@
                 const events = data.type === 'feed' ? [data.event] : data.events || []
                 for (const ev of events) {
                   const name = ev.oracle
+                  // #474: reject unsafe keys from untrusted WS payload to block js/remote-property-injection.
+                  if (typeof name !== 'string' || name === '__proto__' || name === 'constructor' || name === 'prototype') continue
                   // Match to agent: "neo" → "neo-oracle" or worktree derivation
                   const wtMatch = (ev.project || '').match(/[.-]wt-(?:\d+-)?(.+)$/)
                   const windowName = wtMatch ? name + '-' + wtMatch[1] : name + '-oracle'


### PR DESCRIPTION
## Summary

- Two CodeQL `js/remote-property-injection` alerts on `demo/agents.html` L95 + L98 — `statusRef.current[name]` where `name = ev.oracle` arrives via WebSocket feed.
- **Stance: fix, not suppress.** A single whitelist guard rejects `__proto__` / `constructor` / `prototype` (and non-strings) before the key write, which is the root cause the query flags.
- No `.github/codeql/codeql-config.yml` change. `paths-ignore` on `demo/` would hide real future bugs in the demo surface; a 2-line guard is cheaper and more durable than suppression.

## Why fix over suppress

`demo/` is a public, client-side static surface. Inline `// lgtm` markers have been observed not closing alerts under the current GHAS CodeQL scanner (see #590 / memory: CodeQL per-file per-rule suppression). A real sanitizer is the simplest way to get green CI *and* the right security posture here.

## Test plan

- [x] `bun run test:all` — 226 pass / 0 fail / 6 skip (pre-existing)
- [ ] CodeQL scan on this PR shows 0 `js/remote-property-injection` alerts on `demo/agents.html`
- [ ] Merge queue / required checks green

Refs #474.

🤖 Generated with [Claude Code](https://claude.com/claude-code)