### PR TITLE
docs(security): #474 — lgtm doesn't close; replace with Code Scanning dismissal

### DIFF
--- a/docs/security/codeql-sanitizer-model.md
+++ b/docs/security/codeql-sanitizer-model.md
@@ -46,11 +46,21 @@ truncates with a visible marker. It is a sanitizer by construction.
    for an unpublished local path. Publishing a model pack to the CodeQL
    registry is out of scope for this fix — it would require a separate
    pipeline, versioning decisions, and trust setup.
-2. **OPTION B — Inline suppression (shipped).** Add
-   `// lgtm[js/log-injection]` comments on the 4 lines, each citing the
-   sanitizer + tracking issues. GitHub CodeQL still honors the legacy
-   LGTM annotation format for backwards compatibility, which routes
-   through SARIF as a fingerprint suppression.
+2. **OPTION B — Inline suppression (shipped; empirically does not
+   close).** Add `// lgtm[js/log-injection]` comments on the 4 lines,
+   each citing the sanitizer + tracking issues. **Correction
+   (2026-04-19):** the original claim that "GitHub CodeQL still
+   honors the legacy LGTM annotation format for backwards
+   compatibility" is empirically false. The `// lgtm[query-id]`
+   convention belonged to LGTM.com (sunset 2022-12-16); the
+   GitHub-hosted CodeQL analyzer does not parse it. All 4
+   log-injection alerts remain open as of the 2026-04-19 Code
+   Scanning API check. See
+   `docs/security/lgtm-annotation-investigation.md`. Comments are
+   retained in source as human-readable rationale, not as
+   suppressions. Closing the alerts requires either the Code
+   Scanning dismissal API or OPTION A (a published sanitizer model
+   pack).
 3. **OPTION C — `query-filters` exclude (rejected).** Would suppress
    *every* `js/log-injection` finding in the repo, including real
    future ones.
@@ -79,13 +89,18 @@ CodeQL can't be run locally without a paid Semmle setup. Instead:
 - `bun run test:all` must stay green — the change is a comment plus a
   reverted workflow edit; no code paths touched.
 - After merge, the next scheduled scan (Monday 06:37 UTC) re-runs
-  CodeQL on `main`. Expected-closed alerts:
+  CodeQL on `main`. Expected-closed alerts were:
   - `js/log-injection` on the `auth-ok` log line (workspaceId)
   - `js/log-injection` on the `node-joined` log line (nodeId)
   - `js/log-injection` on the `node-left` log line (nodeId)
   - `js/log-injection` on the `error` log line (message/reason)
-- If any of the 4 remain after the next scan, the `// lgtm` syntax is
-  no longer honored — follow up with OPTION A via a published pack.
+- **Outcome (2026-04-19):** all 4 alerts remained open after the
+  post-#586 scan. Per
+  `docs/security/lgtm-annotation-investigation.md`, the hosted
+  analyzer does not honor `// lgtm[query-id]`. Follow-up is either
+  the Code Scanning dismissal API (per-alert, cheap) or OPTION A via
+  a published pack (structural, bundles well if a second sanitizer
+  arrives).
 
 ## Related
 

--- a/docs/security/file-system-race-stance.md
+++ b/docs/security/file-system-race-stance.md
@@ -1,7 +1,8 @@
 ---
 title: File-system-race stance
 status: adopted
-related: [#474, #581]
+related: [#474, #581, #592]
+last_verified: 2026-04-19
 ---
 
 # File-system-race stance
@@ -40,17 +41,24 @@ exactly one of:
 | Class             | Action    | When                                                                        |
 |-------------------|-----------|-----------------------------------------------------------------------------|
 | **TRUE-TOCTOU**   | Fix       | Shared/system path, or per-user path where racing changes a privilege/trust boundary (e.g. single-writer lockfile, pid ownership). Apply fd-based open/read/write like #581. |
-| **PRIVATE-PATH**  | Suppress  | Path lives entirely under the user's own `~/.maw/` or the user-owned scaffold destination. Racing requires same-uid shell, which is out of our threat model. |
-| **POST-FIX-STALE**| Suppress with ref | Site was already converted to fd-based I/O in a prior fix; CodeQL's next scan hasn't cleared the alert yet. Cite the fix PR. |
+| **PRIVATE-PATH**  | Accept    | Path lives entirely under the user's own `~/.maw/` or the user-owned scaffold destination. Racing requires same-uid shell, which is out of our threat model. |
+| **POST-FIX-STALE**| Accept with ref | Site was already converted to fd-based I/O in a prior fix; CodeQL's next scan hasn't cleared the alert yet. Cite the fix PR. |
 
 New alerts that do not fit any of the three classes are not covered by
 this stance and must be triaged on their own merits (typically: fix).
 
-## The 10+1 sites suppressed in this PR
+"Accept" means: the alert stays surfaced by CodeQL until it is
+explicitly dismissed via the Code Scanning API (see *Acceptance
+mechanism* below). An inline comment alone does not close the alert.
+
+## The 10+1 accepted sites from #592
 
 All 10 PRIVATE-PATH sites write JSON metadata, scaffold boilerplate,
 or inbox files under a path rooted in `~/.maw/` or a user-owned
-scaffold destination. None guards a privilege boundary.
+scaffold destination. None guards a privilege boundary. As of
+2026-04-19 the alerts are still open because #592 relied on an
+inline `// lgtm[...]` comment; see *Acceptance mechanism* — the
+follow-up dismissal sweep is tracked off #474.
 
 | Site                                              | Class          | Justification                                                              |
 |---------------------------------------------------|----------------|----------------------------------------------------------------------------|
@@ -71,18 +79,66 @@ that cross a trust boundary on a shared lockfile / pid file —
 `src/core/peers/lock.ts:42`, `src/core/peers/lock.ts:47`,
 `src/core/runtime/instance-pid.ts:56`.
 
+## Acceptance mechanism
+
+For the accepted classes (PRIVATE-PATH, POST-FIX-STALE), the alert is
+closed by **dismissing it via the Code Scanning API** with a
+justification pointer back to this document. The inline comment that
+sits next to the accepted site is human documentation, not a
+suppression signal.
+
+```
+PATCH /repos/Soul-Brews-Studio/maw-js/code-scanning/alerts/{number}
+{
+  "state": "dismissed",
+  "dismissed_reason": "won't fix",          // PRIVATE-PATH
+  "dismissed_comment": "PRIVATE-PATH under ~/.maw/<...>; out of threat model per docs/security/file-system-race-stance.md"
+}
+```
+
+or `"dismissed_reason": "false positive"` for POST-FIX-STALE, citing
+the fix PR.
+
+### Why not inline `// lgtm[js/file-system-race]`
+
+See `docs/security/lgtm-annotation-investigation.md` for the full
+audit. Short version: the GitHub-hosted CodeQL analyzer does not
+parse `// lgtm[query-id]` comments as suppressions. That convention
+belonged to LGTM.com (sunset 2022-12-16). All 10 such comments
+shipped in #592 left their alerts open on the next scan.
+
+The inline comments placed in #592 are kept in source as a
+convenient breadcrumb from a flagged line to this stance doc. They
+are not load-bearing for alert closure.
+
+### Why not broader `paths-ignore`
+
+`paths-ignore` is the correct tool only when dropping *every* query
+on a file is acceptable. It is already applied to four
+tightly-scoped, pre-reviewed files where the lost query coverage is
+genuinely low-value (lock primitives + the from-repo scaffold
+writer). Extending it to the rest of the PRIVATE-PATH list would
+shed coverage on large files where other security queries still
+carry signal — e.g. `team-lifecycle.ts` is 250+ LOC of team
+orchestration, not a 40-LOC primitive.
+
 ## Policy
 
 Before merging any PR that lands a new `js/file-system-race` finding:
 
 1. Each new finding is classified per the rubric above.
-2. PRIVATE-PATH and POST-FIX-STALE findings get a `// lgtm[js/file-system-race]`
-   comment with a one-line rationale naming either this doc or the
-   prior fix PR.
-3. TRUE-TOCTOU findings get fixed (fd-based open + read/write under
-   the opened descriptor, like #581) — never suppressed.
-4. If the classification is genuinely ambiguous, default to fixing, or
-   open a discussion issue rather than suppressing.
+2. TRUE-TOCTOU findings get fixed (fd-based open + read/write under
+   the opened descriptor, like #581) — never accepted.
+3. PRIVATE-PATH and POST-FIX-STALE findings are accepted by
+   dismissing the alert via the Code Scanning API with a
+   `dismissed_comment` pointing at this doc (and, for
+   POST-FIX-STALE, the fix PR).
+4. An inline `// lgtm[js/file-system-race]` or plain `// CodeQL:
+   accepted per docs/security/file-system-race-stance.md` comment
+   may be added next to the site as human documentation, but does
+   not replace the dismissal step.
+5. If the classification is genuinely ambiguous, default to fixing,
+   or open a discussion issue rather than accepting.
 
 ## Revisit triggers
 
@@ -100,5 +156,9 @@ Re-open this stance and re-audit the suppressed sites if any of:
 
 - #474 — CodeQL first-scan bucket.
 - #581 — fd-based write for `update-lock` (informs POST-FIX-STALE).
+- #592 — shipped the original 10 inline `// lgtm[...]` annotations
+  (kept as breadcrumbs; no longer described as suppressions).
 - `docs/security/codeql-sanitizer-model.md` — parallel stance for the
   `js/log-injection` bucket of #474.
+- `docs/security/lgtm-annotation-investigation.md` — audit behind the
+  acceptance-mechanism update in this doc.

--- a/docs/security/lgtm-annotation-investigation.md
+++ b/docs/security/lgtm-annotation-investigation.md
@@ -1,0 +1,175 @@
+---
+title: Inline `// lgtm[rule]` annotations don't close CodeQL alerts (investigation)
+status: closed
+related: [#474, #486, #586, #590, #592]
+verified_on: 2026-04-19
+---
+
+# Why inline `// lgtm[rule]` annotations don't close CodeQL alerts on maw-js
+
+This is the investigation log behind the policy shift in
+`docs/security/file-system-race-stance.md` and the correction to
+`docs/security/codeql-sanitizer-model.md`. It records what we shipped,
+what we expected, what actually happened, and why.
+
+## TL;DR
+
+`// lgtm[query-id]` was an **LGTM.com** comment convention, not a
+CodeQL-native suppression mechanism. The GitHub-hosted CodeQL analyzer
+that powers `github/codeql-action/analyze` does not parse those
+comments as alert suppressions. Every site we annotated in #586
+(log-injection × 4) and #592 (file-system-race × 10) still shows
+`state: "open"` on the code-scanning API, with `dismissed_reason:
+null` and an empty `classifications` array.
+
+The comments do no harm — they are still useful as inline rationale
+for human reviewers — but they should not be described as a
+suppression mechanism.
+
+## What we expected
+
+Per the claim committed into `docs/security/codeql-sanitizer-model.md`
+§OPTION B (PR #586):
+
+> GitHub CodeQL still honors the legacy LGTM annotation format for
+> backwards compatibility, which routes through SARIF as a fingerprint
+> suppression.
+
+And per the classification rubric in
+`docs/security/file-system-race-stance.md` (PR #592):
+
+> PRIVATE-PATH and POST-FIX-STALE findings get a
+> `// lgtm[js/file-system-race]` comment with a one-line rationale …
+
+Implication: after the next scheduled CodeQL scan on `main`, the 14
+annotated alerts should transition to `closed`/`dismissed`.
+
+## What actually happened
+
+Verified 2026-04-19 against
+`GET /repos/Soul-Brews-Studio/maw-js/code-scanning/alerts?state=open`:
+
+| Rule | Count open | Alert numbers | PR that added `// lgtm` |
+|------|-----------:|---------------|-------------------------|
+| `js/log-injection` | 4 | #74, #75, #76, #77 | #586 |
+| `js/file-system-race` | 10 | #65–#68, #70–#73, #85, #86 | #592 |
+
+Every one of the 14 alerts:
+- `state`: `open`
+- `dismissed_by`: `null`
+- `dismissed_reason`: `null`
+- `most_recent_instance.classifications`: `[]`
+
+Annotation placement is correct — `grep -n 'lgtm\['` shows each
+comment on the line immediately above the flagged source line, which
+matches the LGTM.com convention. Placement is not the bug.
+
+## Root cause
+
+`// lgtm[<query-id>]` is documented at lgtm.com/help as an
+LGTM.com-specific in-source suppression. LGTM.com was sunset by GitHub
+on 2022-12-16. The GitHub-hosted CodeQL analyzer that replaced it
+does not implement an in-source suppression comment of any form:
+
+- The CodeQL CLI reads `codeql-config.yml` (`paths`, `paths-ignore`,
+  `queries`, `query-filters`, `packs`) — no comment-based suppression.
+- The CodeQL Action uploads SARIF to Code Scanning, which only honors
+  dismissals recorded via the Code Scanning API or UI (`Dismiss
+  alert`) and path-based exclusions expressed in config.
+- `classifications: []` on every annotated alert confirms the
+  analyzer did not recognize the comments as a suppression signal.
+
+The trailing note already sitting in `.github/codeql/codeql-config.yml`
+on `from-repo-exec.ts` captured the same observation empirically:
+
+> Inline `// lgtm` markers are retained as context but do not
+> suppress new alerts under the current GHAS CodeQL scanner.
+
+This investigation generalizes that observation to all 14 sites.
+
+## Why the #586 fix looked plausible at the time
+
+Three signals made the LGTM-honors hypothesis reasonable:
+1. CodeQL's documentation references the LGTM query-id namespace
+   (`js/log-injection`, `js/file-system-race`) — the IDs are
+   identical, so the comment *looks* like it should be parsed.
+2. Some third-party integrations and older CodeQL CLI versions
+   (pre-sunset) did strip `// lgtm[...]` at the SARIF fingerprint
+   layer. Documentation search still surfaces those pages.
+3. We had no way to run CodeQL locally (no Semmle licence), so
+   verification was deferred to "the next scheduled scan" — which
+   arrived, stayed red, and the signal was lost in the #474 triage
+   backlog until this pass.
+
+## Options going forward (ranked)
+
+1. **Dismiss via Code Scanning API, per-alert, with justification.**
+   `PATCH /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}`
+   with `state: dismissed`, `dismissed_reason: "won't fix"` (or
+   `"false positive"`), `dismissed_comment: <ref to stance doc>`.
+   Preserves query coverage on the file, records rationale on the
+   alert itself. Downside: manual or scripted; dismissal does not
+   follow if the file is renamed, and a re-introduced alert on a
+   nearby line re-opens.
+
+2. **Publish a sanitizer model pack** (revisit OPTION A from
+   `codeql-sanitizer-model.md`). Addresses the log-injection bucket
+   permanently by teaching CodeQL about `sanitizeLogField`. Does not
+   help the file-system-race bucket, which needs a path-level or
+   policy-level accept, not a sanitizer.
+
+3. **`paths-ignore` for entire files** in `codeql-config.yml`.
+   Nuclear — drops every query on the file, not just the accepted
+   rule. Already applied narrowly to `update-lock.ts`,
+   `instance-pid.ts`, `peers/lock.ts`, `from-repo-exec.ts`. Extending
+   to the remaining 7 PRIVATE-PATH files would lose coverage we do
+   still want (e.g. `team-lifecycle.ts` is a large file where other
+   security queries remain valuable).
+
+4. **SARIF post-filter step** in the workflow (e.g.
+   `advanced-security/filter-sarif`) between `analyze` and upload.
+   Per-rule per-path precision, but adds a third-party dependency in
+   the security pipeline — fragile and widens the trust surface.
+
+5. **Accept the noise.** Alerts stay open; reviewers rely on the
+   stance doc to tell signal from accepted noise. Works today, but
+   erodes the useful property that an unacked alert means "look at
+   me". The 14 PRIVATE-PATH/POST-FIX-STALE alerts are a sizeable
+   fraction of the open list already.
+
+## Recommendation
+
+Combine (1) and (3):
+
+- Keep `paths-ignore` for the four narrow files it already covers
+  (lock primitives + `from-repo-exec.ts`) — coverage loss is
+  acceptable and they are pre-reviewed.
+- Dismiss the remaining 10 alerts (4 log-injection + 6
+  file-system-race PRIVATE-PATH sites not under `paths-ignore`) via
+  the Code Scanning API, one-shot script, with `dismissed_comment`
+  citing `docs/security/file-system-race-stance.md` or
+  `docs/security/codeql-sanitizer-model.md`.
+- Keep the existing `// lgtm[...]` comments in source as
+  human-readable rationale. Do not describe them as a suppression
+  mechanism in any doc going forward.
+- Revisit the sanitizer model pack (OPTION A) only when a second
+  sanitizer is introduced — same threshold as the original analysis.
+
+Dismissal-API tooling is out of scope for this investigation PR; this
+document is the input to that follow-up ticket.
+
+## Related
+
+- #474 — CodeQL first-scan bucket (parent).
+- #486 — log-injection triage (led to #586 inline lgtm, observed
+  non-closing).
+- #586 — shipped inline `// lgtm[js/log-injection]` × 4 expecting
+  closure.
+- #590 — fd-bound lock primitives; first empirical hint that inline
+  lgtm does not close `js/file-system-race`.
+- #592 — shipped inline `// lgtm[js/file-system-race]` × 10
+  expecting closure.
+- `docs/security/file-system-race-stance.md` — updated in this PR to
+  reflect the empirical reality.
+- `docs/security/codeql-sanitizer-model.md` — updated in this PR to
+  retract the "LGTM comments still honored" claim.


### PR DESCRIPTION
## Summary

- Audit (2026-04-19) of `/repos/Soul-Brews-Studio/maw-js/code-scanning/alerts?state=open` confirms **all 14 inline `// lgtm[...]` annotations** from #586 (log-injection × 4) and #592 (file-system-race × 10) left their alerts OPEN with empty `classifications` and null `dismissed_*` fields.
- Root cause: `// lgtm[query-id]` was an LGTM.com convention (sunset 2022-12-16). The GitHub-hosted CodeQL analyzer does not parse it — there is no in-source suppression comment on GHAS. The "backwards compatibility" wording in `codeql-sanitizer-model.md` §OPTION B was empirically wrong.
- Closes out the lgtm-doesn't-close sub-thread of #474 by correcting the docs and pointing at the Code Scanning dismissal API as the actual closure path.

## What changed

| File | Change |
|------|--------|
| `docs/security/lgtm-annotation-investigation.md` (new) | Full audit: expected vs observed, evidence table, options ranked, recommendation. |
| `docs/security/file-system-race-stance.md` | "Suppress" → "Accept"; new "Acceptance mechanism" section documenting the dismissal API; "Why not inline // lgtm" and "Why not broader paths-ignore" subsections; Policy list re-ordered to dismissal-first. 164 lines (≤200 budget). |
| `docs/security/codeql-sanitizer-model.md` | OPTION B flagged with the empirical correction; test-strategy outcome recorded. |

**No code changes.** The 14 existing `// lgtm[...]` comments in `src/` are kept as human breadcrumbs from a flagged line to the stance doc — they do no harm and make manual review easier. They are simply no longer *described* as suppressions.

## Options the investigation doc ranks

1. **Dismiss per alert via Code Scanning API** (`PATCH /code-scanning/alerts/{n}` with `dismissed_reason` + `dismissed_comment`) — recommended for the 10 PRIVATE-PATH/POST-FIX-STALE sites not already covered by `paths-ignore`. Cheap, preserves query coverage.
2. Publish a sanitizer model pack (OPTION A from #586) — worth it only when a second sanitizer arrives.
3. Broader `paths-ignore` — nuclear; already applied to 4 narrow files, not worth extending.
4. SARIF post-filter step — adds fragility + trust surface.
5. Accept the noise — erodes the signal/noise ratio on the open-alerts list.

Recommendation lands on (1) + keep the existing narrow (3). Tooling for the dismissal sweep is a follow-up ticket.

## Test plan

- [x] `bun run test:all` — 226/226 pass, 0 fail (full `test` + `test:isolated` + `test:mock-smoke` + `test:plugin` chain, all phases green).
- [x] `grep -n 'lgtm\[' src/...` — confirmed placement of all 14 annotations.
- [x] CodeQL API audit — 14 expected alerts confirmed open, 0 dismissed.
- [ ] CodeQL Analyze CI job stays green (docs-only diff; expected trivially).

## Related

- Closes the lgtm-doesn't-close sub-thread of #474. The dismissal-sweep follow-up will be filed separately.
- Feeds #486 (log-injection triage), #592 (file-system-race stance), #590 (lock primitives paths-ignore).