### PR TITLE
feat(bud): URL-mode + --pr flag for --from-repo (#588)

### DIFF
--- a/docs/bud/from-repo-impl.md
+++ b/docs/bud/from-repo-impl.md
@@ -1,23 +1,23 @@
-# `maw bud --from-repo` — implementation analysis (PR for #588)
+# `maw bud --from-repo` — implementation analysis (#588)
 
-Builds on `docs/bud/from-repo-design.md` + #591 scaffold. Scope: **local-path full run**.
+Builds on `docs/bud/from-repo-design.md` + #591 scaffold + #595 local-path impl. This PR extends to **URL clone + `--pr` branch-and-PR flow**.
 
 ## (a) 8-TODO scope — this PR vs deferred
 
 From #591 body:
 
-| # | TODO                                            | This PR | Defer |
-|---|-------------------------------------------------|---------|-------|
-| 1 | Actual fs writes (ψ/ + CLAUDE.md + .claude/)    | ✅ ship | —     |
-| 2 | URL / `org/repo` resolution via `ensureCloned`  | —       | ✅    |
-| 3 | `--pr` branch-and-PR flow                       | —       | ✅    |
-| 4 | Fleet entry creation (`configureFleet`)         | —       | ✅    |
-| 5 | CLAUDE.md append idempotency marker             | ✅ ship | —     |
-| 6 | Optional `--from <parent>` lineage in CLAUDE.md | —       | ✅    |
-| 7 | Optional `--seed` soul-sync from parent         | —       | ✅    |
-| 8 | Parent `sync_peers` update when `--from` given  | —       | ✅    |
+| # | TODO                                            | #595   | This PR | Defer |
+|---|-------------------------------------------------|--------|---------|-------|
+| 1 | Actual fs writes (ψ/ + CLAUDE.md + .claude/)    | ✅ ship | —       | —     |
+| 2 | URL / `org/repo` resolution via clone           | —      | ✅ ship | —     |
+| 3 | `--pr` branch-and-PR flow                       | —      | ✅ ship | —     |
+| 4 | Fleet entry creation (`configureFleet`)         | —      | —       | ✅    |
+| 5 | CLAUDE.md append idempotency marker             | ✅ ship | —       | —     |
+| 6 | Optional `--from <parent>` lineage in CLAUDE.md | —      | —       | ✅    |
+| 7 | Optional `--seed` soul-sync from parent         | —      | —       | ✅    |
+| 8 | Parent `sync_peers` update when `--from` given  | —      | —       | ✅    |
 
-Three of eight shipped (1, 5, partial of what #591 called out); five deferred to follow-ups. #588 stays open.
+Cumulatively 5 of 8 shipped after this PR; 3 defer (fleet entry, `--from` lineage, `--seed`/`sync_peers`). `--force` still deferred — safe default remains "refuse if `ψ/` present." #588 stays open until the remaining three land.
 
 ## (b) File-write sequencing
 
@@ -31,9 +31,13 @@ Non-transactional — but **fail-fast + fail-before-mutate**:
 
 ## (c) URL clone strategy
 
-Deferred. URL targets still hit the planner blocker from #591 (`not yet supported`). The executor never sees them — `cmdBudFromRepo` short-circuits on `plan.blockers.length > 0` before reaching the executor.
+Shallow-clone to an OS tmpdir, then delegate to the local-path executor. On exit — success or failure — the tmpdir is `rmSync`'d.
 
-Follow-up PR: wire `ensureCloned` from `shared/wake-target` (already exists for `maw wake`), resolve URL → local path → call executor.
+- Detection: `looksLikeUrl` matches `https://`, `http://`, `git@…`, and `org/repo` slugs.
+- Clone: `git clone --depth 1 <url> <tmp>` via `hostExec`. If clone fails, the tmpdir is removed and the error bubbles. (We do NOT reuse the `ensureCloned` / `ghq get` path here because those seat the clone in `~/ghq` where the operator might later tab-complete into a half-scaffolded directory — ephemeral is safer.)
+- On URL the flow *always* opens a PR: the tmpdir gets thrown away, so committing-only would be wasted work. `--pr` is implied when the target is a URL; it's still accepted explicitly for symmetry.
+
+Git/gh calls live in a dedicated module (`from-repo-git.ts`) so tests can swap them out via `mock.module("./from-repo-git", …)`. The orchestrator never shells out directly — keeps `from-repo.ts` pure/testable-without-shell.
 
 ## (d) CLAUDE.md append shape + idempotency
 
@@ -55,9 +59,20 @@ Idempotency: on re-run the executor greps for `<!-- oracle-scaffold: begin stem=
 Executor re-uses the planner: anything the planner flags as a blocker is a hard stop (throw → handler returns `{ ok: false }`). Specifically:
 - `ψ/` already present → throw, match planner message.
 - Target not a git repo → throw.
-- URL target → throw with pointer to follow-up PR.
+- URL target → clone to tmpdir, then the tmpdir is the `target` the planner sees (so the normal blockers still apply — e.g. if a repo already has `ψ/`, the PR flow refuses the same way).
 
 No `--force` in this PR. Defer.
+
+## (g) `--pr` flow
+
+After a successful local-path injection we open a PR on the target repo:
+
+1. `git checkout -b oracle/scaffold-<stem>` — branch name is deterministic + predictable for re-runs. If the branch already exists (rare — would mean a prior aborted run), `checkout -b` fails and the error surfaces; operator decides whether to `git branch -D` and retry.
+2. `git add -A` then `git commit -m 'oracle: scaffold from maw bud --from-repo'`.
+3. `git push -u origin oracle/scaffold-<stem>`.
+4. `gh pr create --fill --head oracle/scaffold-<stem>` — `--fill` uses the commit message as the PR title/body. gh auto-detects the target repo from `origin`. The returned URL is echoed to the log.
+
+No cleanup of the local branch on failure — the operator owns git state and may want to fix + retry. Tmpdir (URL-mode) *is* cleaned up unconditionally.
 
 ## (f) Test strategy
 
@@ -72,8 +87,9 @@ Real-fs integration tests, no mocks:
 
 ## File layout
 
-- `src/commands/plugins/bud/from-repo.ts` — planner unchanged. Orchestrator updated to delegate to executor when `!dryRun`. Stays ≤200 LOC.
-- `src/commands/plugins/bud/from-repo-exec.ts` — **new**. Pure executor: `applyFromRepoInjection(plan, opts): Promise<void>`. ≤200 LOC.
-- `src/commands/plugins/bud/from-repo.test.ts` — add executor tests alongside existing planner tests.
+- `src/commands/plugins/bud/from-repo.ts` — planner + orchestrator. Removes the URL blocker; clones URL targets via `from-repo-git.ts`, then re-invokes planner on the tmpdir. Invokes `--pr` path after the executor when requested. ≤200 LOC.
+- `src/commands/plugins/bud/from-repo-exec.ts` — executor: `applyFromRepoInjection`. Unchanged for local-path writes; stays ≤200 LOC.
+- `src/commands/plugins/bud/from-repo-git.ts` — **new**. Thin wrappers over `hostExec` for `cloneShallow`, `branchCommitPushPR`, `cleanupClone`. Only module that shells out for git/gh. Kept small (<100 LOC) so tests can `mock.module` it cleanly.
+- `src/commands/plugins/bud/from-repo.test.ts` — add URL-mode tests (mock git helper) + `--pr` tests (mock git helper).
 
-Planner stays pure (read-only). Executor is the only place that writes. Makes the split testable and makes future `--force`/`--pr` flags land cleanly.
+Planner stays pure. Executor only writes files. All shell-outs for git/gh live in one place.

--- a/src/commands/plugins/bud/from-repo-git.ts
+++ b/src/commands/plugins/bud/from-repo-git.ts
@@ -1,0 +1,87 @@
+/**
+ * Git + gh shell-outs for `maw bud --from-repo` (#588).
+ *
+ * Only module that shells out for git/gh. Kept small so tests can
+ * swap the whole module via `mock.module("./from-repo-git", …)`.
+ *
+ * Design: docs/bud/from-repo-impl.md sections (c) and (g).
+ */
+
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { hostExec } from "../../../sdk";
+
+/** Single-quote escape for bash. Safe for unknown input (URLs, paths, branches). */
+function sh(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+/** Deterministic branch name for the scaffold PR. */
+export function scaffoldBranchName(stem: string): string {
+  return `oracle/scaffold-${stem}`;
+}
+
+/**
+ * `git clone --depth 1 <url> <tmpdir>` — returns the tmpdir path.
+ *
+ * On clone failure the tmpdir is removed before the error bubbles, so
+ * the caller never has to clean up a half-cloned tree.
+ */
+export async function cloneShallow(url: string): Promise<string> {
+  const dir = mkdtempSync(join(tmpdir(), "maw-bud-from-repo-"));
+  try {
+    await hostExec(`git clone --depth 1 ${sh(url)} ${sh(dir)}`);
+  } catch (e) {
+    rmSync(dir, { recursive: true, force: true });
+    throw e;
+  }
+  return dir;
+}
+
+/** Recursively `rmSync` a tmpdir. Idempotent — never throws on missing. */
+export function cleanupClone(dir: string): void {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+/** Log callback shape — mirrors from-repo-exec.ts. */
+type Log = (msg: string) => void;
+
+/**
+ * After injection: branch → add → commit → push → `gh pr create`.
+ * Returns the PR URL printed by gh.
+ *
+ * No rollback on failure: the operator owns git state. If push or
+ * `gh pr create` fails the branch stays local, fully committed; re-run
+ * after fixing the underlying cause (auth, remote, etc).
+ */
+export async function branchCommitPushPR(
+  cwd: string,
+  stem: string,
+  log: Log,
+): Promise<string> {
+  const branch = scaffoldBranchName(stem);
+  const cd = `cd ${sh(cwd)}`;
+  const msg = `oracle: scaffold from maw bud --from-repo (stem=${stem})`;
+
+  log(`  \x1b[36m⏳\x1b[0m creating branch ${branch}...`);
+  await hostExec(`${cd} && git checkout -b ${sh(branch)}`);
+  await hostExec(`${cd} && git add -A`);
+  await hostExec(`${cd} && git commit -m ${sh(msg)}`);
+  log(`  \x1b[32m✓\x1b[0m commit created on ${branch}`);
+
+  log(`  \x1b[36m⏳\x1b[0m pushing ${branch} to origin...`);
+  await hostExec(`${cd} && git push -u origin ${sh(branch)}`);
+
+  log(`  \x1b[36m⏳\x1b[0m opening PR via gh...`);
+  const out = await hostExec(`${cd} && gh pr create --fill --head ${sh(branch)}`);
+  const prUrl = extractPrUrl(out);
+  log(`  \x1b[32m✓\x1b[0m PR opened: ${prUrl}`);
+  return prUrl;
+}
+
+/** Pull the first `https://…` URL out of gh's output. Falls back to trimmed output. */
+function extractPrUrl(out: string): string {
+  const m = out.match(/https?:\/\/\S+/);
+  return m ? m[0] : out.trim();
+}

--- a/src/commands/plugins/bud/from-repo.test.ts
+++ b/src/commands/plugins/bud/from-repo.test.ts
@@ -88,11 +88,11 @@ describe("from-repo: planFromRepoInjection", () => {
     expect(plan.blockers.some(b => b.includes("does not exist"))).toBe(true);
   });
 
-  it("blocks URL targets as not-yet-supported", () => {
+  it("blocks URL dry-run (clone is a side-effect)", () => {
     const plan = planFromRepoInjection({
       target: "https://github.com/x/y", stem: "demo", isUrl: true, pr: false, dryRun: true,
     });
-    expect(plan.blockers.some(b => b.includes("not yet supported"))).toBe(true);
+    expect(plan.blockers.some(b => b.includes("dry-run"))).toBe(true);
   });
 });
 
@@ -127,19 +127,6 @@ describe("from-repo: cmdBudFromRepo", () => {
       expect(existsSync(join(dir, "CLAUDE.md"))).toBe(true);
       expect(readFileSync(join(dir, "CLAUDE.md"), "utf-8")).toContain("demo-oracle");
       expect(readFileSync(join(dir, ".claude", "settings.local.json"), "utf-8")).toBe("{}\n");
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  it("non-dry-run with --pr refuses with pointer to follow-up", async () => {
-    const dir = mkGitRepo();
-    try {
-      await expect(cmdBudFromRepo({
-        target: dir, stem: "demo", isUrl: false, pr: true, dryRun: false,
-      })).rejects.toThrow(/--pr is not yet implemented/);
-      // refuse BEFORE writing — no ψ/ created
-      expect(existsSync(join(dir, "ψ"))).toBe(false);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -216,6 +203,138 @@ describe("from-repo: applyFromRepoInjection (executor)", () => {
     const opts = { target: "/nonexistent/zzz", stem: "demo", isUrl: false, pr: false, dryRun: false };
     const plan = planFromRepoInjection(opts);
     await expect(applyFromRepoInjection(plan, opts, () => {})).rejects.toThrow(/blocker/);
+  });
+});
+
+describe("from-repo: URL-mode + --pr (mocked git/gh)", () => {
+  let cmdBudFromRepoMocked: typeof cmdBudFromRepo;
+  let calls: { fn: string; args: any[] }[] = [];
+
+  beforeEach(async () => {
+    calls = [];
+    mock.module("./from-repo-git", () => ({
+      scaffoldBranchName: (stem: string) => `oracle/scaffold-${stem}`,
+      cloneShallow: async (url: string) => {
+        calls.push({ fn: "cloneShallow", args: [url] });
+        const d = mkGitRepo();
+        return d;
+      },
+      cleanupClone: (dir: string) => {
+        calls.push({ fn: "cleanupClone", args: [dir] });
+        rmSync(dir, { recursive: true, force: true });
+      },
+      branchCommitPushPR: async (cwd: string, stem: string, _log: any) => {
+        calls.push({ fn: "branchCommitPushPR", args: [cwd, stem] });
+        return `https://github.com/fake/pr/1`;
+      },
+    }));
+    delete (require.cache as any)[require.resolve("./from-repo")];
+    const mod = await import("./from-repo");
+    cmdBudFromRepoMocked = mod.cmdBudFromRepo;
+  });
+
+  it("URL target: clones, injects, opens PR, cleans up", async () => {
+    await cmdBudFromRepoMocked({
+      target: "https://github.com/fake/repo", stem: "demo",
+      isUrl: true, pr: false, dryRun: false,
+    });
+    const fns = calls.map(c => c.fn);
+    expect(fns).toContain("cloneShallow");
+    expect(fns).toContain("branchCommitPushPR");
+    expect(fns).toContain("cleanupClone");
+    // order: clone must precede PR, which must precede cleanup
+    expect(fns.indexOf("cloneShallow")).toBeLessThan(fns.indexOf("branchCommitPushPR"));
+    expect(fns.indexOf("branchCommitPushPR")).toBeLessThan(fns.indexOf("cleanupClone"));
+    // PR passed the stem, not the URL
+    const prCall = calls.find(c => c.fn === "branchCommitPushPR")!;
+    expect(prCall.args[1]).toBe("demo");
+  });
+
+  it("URL target dry-run throws without cloning", async () => {
+    await expect(cmdBudFromRepoMocked({
+      target: "https://github.com/fake/repo", stem: "demo",
+      isUrl: true, pr: false, dryRun: true,
+    })).rejects.toThrow(/blocker/);
+    expect(calls.some(c => c.fn === "cloneShallow")).toBe(false);
+  });
+
+  it("URL target cleans up even when PR fails", async () => {
+    // Re-mock: branchCommitPushPR throws
+    mock.module("./from-repo-git", () => ({
+      scaffoldBranchName: (stem: string) => `oracle/scaffold-${stem}`,
+      cloneShallow: async (url: string) => {
+        calls.push({ fn: "cloneShallow", args: [url] });
+        return mkGitRepo();
+      },
+      cleanupClone: (dir: string) => {
+        calls.push({ fn: "cleanupClone", args: [dir] });
+        rmSync(dir, { recursive: true, force: true });
+      },
+      branchCommitPushPR: async () => {
+        calls.push({ fn: "branchCommitPushPR", args: [] });
+        throw new Error("gh pr create failed");
+      },
+    }));
+    delete (require.cache as any)[require.resolve("./from-repo")];
+    const mod = await import("./from-repo");
+    await expect(mod.cmdBudFromRepo({
+      target: "https://github.com/fake/repo", stem: "demo",
+      isUrl: true, pr: false, dryRun: false,
+    })).rejects.toThrow(/gh pr create failed/);
+    expect(calls.some(c => c.fn === "cleanupClone")).toBe(true);
+  });
+
+  it("local path + --pr: injects then opens PR without cloning", async () => {
+    const dir = mkGitRepo();
+    try {
+      await cmdBudFromRepoMocked({
+        target: dir, stem: "demo", isUrl: false, pr: true, dryRun: false,
+      });
+      const fns = calls.map(c => c.fn);
+      expect(fns).not.toContain("cloneShallow");
+      expect(fns).not.toContain("cleanupClone");
+      expect(fns).toContain("branchCommitPushPR");
+      // Injection actually happened
+      expect(existsSync(join(dir, "ψ", "inbox"))).toBe(true);
+      // PR was opened against the local path, not a tmpdir
+      const prCall = calls.find(c => c.fn === "branchCommitPushPR")!;
+      expect(prCall.args[0]).toBe(dir);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("local path without --pr: no PR helper called", async () => {
+    const dir = mkGitRepo();
+    try {
+      await cmdBudFromRepoMocked({
+        target: dir, stem: "demo", isUrl: false, pr: false, dryRun: false,
+      });
+      expect(calls.some(c => c.fn === "branchCommitPushPR")).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("local + --pr: PR failure does NOT swallow the error", async () => {
+    mock.module("./from-repo-git", () => ({
+      scaffoldBranchName: (stem: string) => `oracle/scaffold-${stem}`,
+      cloneShallow: async () => { throw new Error("should not clone"); },
+      cleanupClone: () => {},
+      branchCommitPushPR: async () => { throw new Error("push rejected"); },
+    }));
+    delete (require.cache as any)[require.resolve("./from-repo")];
+    const mod = await import("./from-repo");
+    const dir = mkGitRepo();
+    try {
+      await expect(mod.cmdBudFromRepo({
+        target: dir, stem: "demo", isUrl: false, pr: true, dryRun: false,
+      })).rejects.toThrow(/push rejected/);
+      // injection happened before PR attempt — ψ/ present
+      expect(existsSync(join(dir, "ψ", "inbox"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/commands/plugins/bud/from-repo.ts
+++ b/src/commands/plugins/bud/from-repo.ts
@@ -1,9 +1,10 @@
 /**
  * `maw bud --from-repo <target> --stem <stem>` — planner + orchestrator.
  *
- * SCOPE: local-path full run (#588 partial). URL clone / --pr / --force /
- * fleet entry / --from lineage / --seed / sync_peers still deferred.
- * Writes live in from-repo-exec.ts; planner stays pure/read-only.
+ * SCOPE: local-path + URL clone + `--pr` branch-and-PR flow (#588).
+ * Deferred: --force, --seed, fleet entry, --from lineage, sync_peers.
+ * Writes live in from-repo-exec.ts; git/gh shell-outs in from-repo-git.ts.
+ * Planner stays pure / read-only.
  *
  * Design: docs/bud/from-repo-design.md + docs/bud/from-repo-impl.md
  */
@@ -12,6 +13,7 @@ import { existsSync, statSync } from "fs";
 import { join, isAbsolute } from "path";
 import type { FromRepoOpts, InjectionAction, InjectionPlan } from "./types";
 import { applyFromRepoInjection } from "./from-repo-exec";
+import { cloneShallow, cleanupClone, branchCommitPushPR } from "./from-repo-git";
 
 /** Heuristic: is `target` a URL or `org/repo` slug rather than a local path? */
 export function looksLikeUrl(target: string): boolean {
@@ -44,9 +46,13 @@ export function planFromRepoInjection(opts: FromRepoOpts): InjectionPlan {
   const blockers: string[] = [];
   const actions: InjectionAction[] = [];
 
+  // URL / slug targets: the orchestrator resolves them to a tmpdir via
+  // cloneShallow and calls the planner again with isUrl=false. If a URL
+  // reaches the planner directly, it's a dry-run — surface a blocker so
+  // we don't attempt a clone during a read-only preview.
   if (opts.isUrl) {
     blockers.push(
-      `URL / org-slug targets not yet supported — see #588 TODO. Pass a local path for dry-run.`,
+      `URL / org-slug dry-run not supported — clone would be a side effect. Re-run without --dry-run.`,
     );
     return { target: opts.target, stem: opts.stem, actions, blockers };
   }
@@ -131,20 +137,47 @@ export function formatPlan(plan: InjectionPlan): string {
 }
 
 /**
- * Orchestrator. Dry-run: print the plan. Non-dry-run: print plan, then apply.
- * Local-path only; URL / --pr paths stay blocked (planner surfaces them).
+ * Orchestrator.
+ * - Dry-run (local only): print the plan and return.
+ * - Local path: print plan, apply injection; if --pr, open PR afterwards.
+ * - URL / slug: shallow-clone → tmpdir, delegate to local-path flow, always
+ *   open PR (the tmpdir is ephemeral so committing-only would be lost),
+ *   cleanup tmpdir on both success and failure.
  */
 export async function cmdBudFromRepo(opts: FromRepoOpts): Promise<void> {
+  if (opts.isUrl) {
+    if (opts.dryRun) {
+      // Preserve the dry-run safety rail (planner surfaces the blocker).
+      const plan = planFromRepoInjection(opts);
+      console.log(formatPlan(plan));
+      throw new Error(`plan has ${plan.blockers.length} blocker(s) — see above`);
+    }
+    console.log(`\n  \x1b[36m⚡\x1b[0m cloning ${opts.target}...`);
+    const tmp = await cloneShallow(opts.target);
+    console.log(`  \x1b[32m✓\x1b[0m cloned → ${tmp}`);
+    const localOpts: FromRepoOpts = { ...opts, target: tmp, isUrl: false, pr: true };
+    try {
+      await runLocal(localOpts);
+    } finally {
+      cleanupClone(tmp);
+      console.log(`  \x1b[90m○\x1b[0m cleaned up temp clone`);
+    }
+    return;
+  }
+  await runLocal(opts);
+}
+
+/** Local-path path — also used after URL clone. */
+async function runLocal(opts: FromRepoOpts): Promise<void> {
   const plan = planFromRepoInjection(opts);
   console.log(formatPlan(plan));
   if (plan.blockers.length > 0) {
     throw new Error(`plan has ${plan.blockers.length} blocker(s) — see above`);
   }
   if (opts.dryRun) return;
-  if (opts.pr) {
-    throw new Error(
-      `--pr is not yet implemented — see #588 follow-up. Re-run without --pr (commits nothing; you own the git state).`,
-    );
-  }
   await applyFromRepoInjection(plan, opts);
+  if (opts.pr) {
+    const url = await branchCommitPushPR(opts.target, opts.stem, (m) => console.log(m));
+    console.log(`\n  \x1b[32m🎉 PR opened:\x1b[0m ${url}\n`);
+  }
 }


### PR DESCRIPTION
## Summary

Extends `maw bud --from-repo` with URL-clone and `--pr` branch-and-PR flow. Builds on #591 (scaffold) and #595 (local-path impl).

- **URL target** (`https://`, `git@`, or `org/repo`): shallow-clone to an OS tmpdir, run the local-path injection, open a PR via `gh`, clean up the tmpdir on exit (success or failure).
- **Local path + `--pr`**: after injection, create branch `oracle/scaffold-<stem>`, `git add -A`, commit, push `-u origin`, then `gh pr create --fill`.
- **Local path without `--pr`**: unchanged from #595.
- **URL dry-run**: still blocked — cloning is a side effect the planner must not take.

## What's in here

- `src/commands/plugins/bud/from-repo-git.ts` — new, the only module that shells out for git/gh. Exports `cloneShallow`, `cleanupClone`, `branchCommitPushPR`, `scaffoldBranchName`. <100 LOC; single-quote bash escape on all user-controlled input.
- `src/commands/plugins/bud/from-repo.ts` — URL blocker repurposed to a dry-run safety rail; `cmdBudFromRepo` now dispatches URL → clone → local flow → PR, with guaranteed tmpdir cleanup. `runLocal` extracted so URL and local share the same `plan → apply → optional PR` tail.
- `src/commands/plugins/bud/from-repo.test.ts` — new describe block `URL-mode + --pr (mocked git/gh)` with 6 tests (clone-inject-PR-cleanup ordering, dry-run block before clone, cleanup-on-PR-failure, local+--pr with no clone, local without --pr, PR-failure surfacing).
- `docs/bud/from-repo-impl.md` — section (c) rewritten for the URL strategy, new section (g) for the `--pr` flow, TODO table updated (5/8 shipped cumulatively).

## TODOs still deferred (#588 stays open)

- `--force` (overwrite existing `ψ/`)
- Fleet entry creation (`configureFleet`)
- `--from <parent>` lineage in CLAUDE.md
- `--seed` soul-sync from parent + parent `sync_peers` update

## Test plan

- [x] `bun test src/commands/plugins/bud/from-repo.test.ts` — 28 pass, 0 fail, 57 expect calls
- [x] `bun run test:all` — 69/69 files passed, 0 failed
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)