### PR TITLE
docs(federation): fill TODO link post-#596 + note harness build regression (#607)

### DIFF
--- a/docs/federation/docker-testing.md
+++ b/docs/federation/docker-testing.md
@@ -51,12 +51,17 @@ logs as a `federation-docker-logs` artifact when the job fails.
 
 ## Known gaps
 
-- `maw-js` does not yet register a `/info` endpoint, so
-  `src/commands/plugins/peers/probe.ts` will surface `HTTP_4XX` against
-  any currently-built image. The probe round-trip is still useful for
-  catching transport / DNS / compose-wiring regressions, but the
-  handshake classifier will stay red until `/info` lands.
-  Tracking: <TODO: link issue #N once tester files it>.
+- **Historical (resolved, #596 / #603):** `maw-js` did not register a
+  `/info` endpoint, so `src/commands/plugins/peers/probe.ts` surfaced
+  `HTTP_4XX` against any currently-built image. The probe round-trip was
+  still useful for catching transport / DNS / compose-wiring regressions,
+  but the handshake classifier stayed red until `/info` shipped. Tracking
+  issue: [#596](https://github.com/Soul-Brews-Studio/maw-js/issues/596)
+  (closed by [#603](https://github.com/Soul-Brews-Studio/maw-js/pull/603)).
+- **Current:** the image build may fail at `bun install --frozen-lockfile`
+  if the committed `bun.lock` was written by a bun version older than the
+  one resolved by `oven/bun:1.3-alpine`. Tracking:
+  [#607](https://github.com/Soul-Brews-Studio/maw-js/issues/607).
 
 ## Related
 


### PR DESCRIPTION
## Summary

- Fills the `<TODO: link issue #N once tester files it>` placeholder in `docs/federation/docker-testing.md` (the "Known gaps" section) with a concrete link to #596 (the `/info` endpoint tracking issue, resolved by #603).
- Adds a current gap entry pointing to new issue #607 for the bun-version / lockfile frozen-install regression that currently blocks the docker harness build.

Docs-only change — no harness, Dockerfile, compose, workflow, or lockfile edits. File ownership respected per task #5 dispatch.

## Context

Task #5 was to live-verify the docker federation harness now that #603 (the `/info` endpoint) has merged, capture real probe output, and fill the TODO link.

Live-verify status: **blocked upstream by #607, not by #596**.

Docker is available locally. `bash scripts/test-docker-federation.sh` fails during image build at `RUN bun install --frozen-lockfile`:

```
0.198 bun install v1.3.12 (700fc117)
0.203 error: lockfile had changes, but lockfile is frozen
0.203 note: try re-running without --frozen-lockfile and commit the updated lockfile
```

Reproduced in a clean `oven/bun:1.3-alpine` container with only `package.json` + `bun.lock` mounted. Host bun (1.3.11) accepts the same lockfile cleanly — so the committed `bun.lock` was written by bun ≤ 1.3.11 and is silently incompatible with the 1.3.12 that `oven/bun:1.3-alpine` currently resolves to.

Full diagnosis + repro + proposed fixes captured in #607. Once that lands, an "Expected output" section with real probe output can be added in a follow-up.

## Why ship this docs-only PR now

The TODO-link fill is valuable independent of the live verify:

- readers hitting `docs/federation/docker-testing.md` today see a meaningful pointer (#596 / #603 / #607) instead of a placeholder.
- the "Known gaps" section stops lying about the `/info` endpoint being absent — that's now a historical note.
- any contributor attempting to run the harness will find #607 and know about the upstream block.

## Test plan

- [x] `rtk git diff main -- docs/federation/docker-testing.md` — docs-only; no code/config touched
- [x] Markdown renders — all three issue links resolve (#596, #603, #607)
- [ ] CI green (docs-only, should be trivial)

## Follow-ups (not in this PR)

- #607 — fix bun-version mismatch so harness builds
- After #607 merges: re-run `bash scripts/test-docker-federation.sh`, capture probe output, add an "Expected output — real run" block to this same file.

---
Shipped by harness-verifier on team go-5-r2-0419.

🤖 Generated with [Claude Code](https://claude.com/claude-code)