### PR TITLE
feat(bud): --force + --track-vault + fleet entry + --from lineage (#588)

### DIFF
--- a/docs/bud/from-repo-impl.md
+++ b/docs/bud/from-repo-impl.md
@@ -19,6 +19,81 @@ From #591 body:
 
 Cumulatively 5 of 8 shipped after this PR; 3 defer (fleet entry, `--from` lineage, `--seed`/`sync_peers`). `--force` still deferred — safe default remains "refuse if `ψ/` present." #588 stays open until the remaining three land.
 
+## (h) Continuation PR — `--force` + `--track-vault` + fleet entry + `--from` lineage
+
+The remaining six TODOs from #591 split into a "light quad" (this PR) and a "file-copy pair" (deferred):
+
+| # | TODO              | Continuation | Defer | Reason |
+|---|-------------------|--------------|-------|--------|
+| 1 | `--force`         | ✅           | —     | Tiny — flip a planner blocker into a warning + `overwrite` action |
+| 2 | Fleet entry       | ✅           | —     | Reuse `configureFleet` from `bud-init.ts`; isolate behind a thin module so tests can mock |
+| 3 | `--from` lineage  | ✅           | —     | Embed `<!-- oracle: budded from <parent> -->` + lineage line in CLAUDE.md template/append |
+| 4 | `--track-vault`   | ✅           | —     | Default = add `ψ/` to target's `.gitignore`; `--track-vault` skips that |
+| 5 | `--seed`          | —            | ✅    | Requires soul-sync file-copy from parent — needs separate scope |
+| 6 | `sync_peers`      | —            | ✅    | Same — depends on parent peers.json + #589 work |
+
+After this PR cumulatively 8 of 8 TODOs from #591 are shipped except `--seed` + `sync_peers`. #588 stays open until those land.
+
+### `--force` semantics
+
+Today the planner emits a hard blocker if `ψ/` already exists in the target. With `--force`:
+
+- The blocker downgrades to an `overwrite` action (same kind: `mkdir`, but a `force` reason annotation is attached for the planner-format output).
+- `mkdirSync({recursive: true})` is already idempotent on the directories themselves, so no destructive write of the existing tree happens — we never `rmSync` `ψ/`. `--force` only suppresses the *refusal*; it does not blow away pre-existing memory. (Aligns with "Nothing is Deleted".)
+- CLAUDE.md is unaffected by `--force` — it remains idempotent via the marker, and the executor still appends a new block if no marker is present (which is the normal append-on-existing-CLAUDE.md path). If the user wants to inject a SECOND oracle scaffold under a different stem, that already works without `--force` (stem-scoped marker).
+- `.claude/settings.local.json` continues to be left untouched if it exists.
+
+In short, `--force` means "don't refuse on the ψ/ collision blocker." Nothing more, nothing less.
+
+### Fleet-entry module — `from-repo-fleet.ts`
+
+Reuse the existing `configureFleet` from `bud-init.ts`? No — `configureFleet` takes `org` and `budRepoName` derived from the parent's bud flow. For `--from-repo` we instead derive the slug from the *target* repo:
+
+1. Read `git -C <target> remote get-url origin` to extract the `org/repo` slug. If no remote exists (rare, fresh local repo), fall back to using the target dir basename and emit a warning — fleet entry still gets written but with `repo: "<unknown>/<basename>"`.
+2. Write `<NN>-<stem>.json` to `FLEET_DIR` using the same idempotent shape as `configureFleet` (load existing entries, find next NN, write JSON with `windows` + `sync_peers: []`, plus `budded_from`/`budded_at` if `--from` was given).
+
+Lives in a dedicated module so:
+- Tests can `mock.module("./from-repo-fleet", …)` to prove the planner+executor wire it up correctly without touching real `~/.config/maw/fleet/`.
+- The module is the only place that reads `FLEET_DIR` from `core/paths.ts`, so future moves of fleet storage only touch one file.
+
+### `--from <parent>` lineage in CLAUDE.md
+
+Two effects, both in the executor:
+
+1. Full-write path (no existing CLAUDE.md): include the `Budded from: <parent>` lineage field in the identity block. Mirrors the existing `bud-init.ts:generateClaudeMd` shape.
+2. Append-under-marker path (existing CLAUDE.md): the appended block adds an `Origin: budded from <parent>` bullet inside the fenced section.
+
+A machine-readable HTML comment also goes inside the fence: `<!-- oracle-lineage: parent=<parent> -->`. Used by future tooling (`maw soul-sync --from`, `maw fleet`) to detect lineage without re-parsing markdown prose.
+
+If `--from` is omitted, no lineage line is emitted (current behavior preserved).
+
+### `--track-vault` semantics + `.gitignore`
+
+Today the executor does not touch `.gitignore`. Default behavior changes to:
+
+1. After successful injection, append `ψ/` to the target's `.gitignore` (creating the file if absent). Idempotent — if `^ψ/$` already matches a line, skip.
+2. `--track-vault` set: skip the `.gitignore` step. ψ/ becomes a tracked part of the host repo.
+
+Why default-ignore rather than default-track? Most existing repos that are getting the bud-into-existing-repo treatment will not want the entire memory vault checked in alongside source. Federation already has Vault sync (per memory entry on `vault sync scope`), so the default keeps the host repo's git history clean. Operators who *want* to track ψ/ opt in explicitly.
+
+### Test additions
+
+- `--force` allows ψ/ collision: `mkGitRepo` → pre-create `ψ/` → call with `force: true` → expect injection completes, CLAUDE.md exists.
+- `--from <parent>` writes lineage marker: assert CLAUDE.md contains both `Budded from: <parent>` and the `oracle-lineage` HTML comment.
+- `--track-vault` controls `.gitignore`: default run adds `ψ/`; `trackVault: true` does not.
+- Fleet wiring: mock `from-repo-fleet.ts` and assert the `register` function is called with `{stem, repoSlug, parent}` after a successful injection.
+
+### File layout — continuation PR
+
+- `src/commands/plugins/bud/types.ts` — extend `FromRepoOpts` with `force?: boolean`, `from?: string`, `trackVault?: boolean`.
+- `src/commands/plugins/bud/from-repo.ts` — planner: respect `--force` (downgrade ψ/ blocker), reflect lineage + .gitignore actions; orchestrator: invoke fleet register after executor.
+- `src/commands/plugins/bud/from-repo-exec.ts` — executor: lineage in CLAUDE.md (full-write + append-block), `.gitignore` write (default), pass-through of `force` (no destructive ops).
+- `src/commands/plugins/bud/from-repo-fleet.ts` — **new**. `registerFleetEntry({stem, target, parent})`. Reads remote, computes slug, writes `<NN>-<stem>.json` to `FLEET_DIR`. ≤100 LOC.
+- `src/commands/plugins/bud/index.ts` — wire new flags: `--force`, `--from` (only when `--from-repo` is set), `--track-vault`.
+- `src/commands/plugins/bud/from-repo.test.ts` — new test cases per above.
+
+All files ≤200 LOC.
+
 ## (b) File-write sequencing
 
 Non-transactional — but **fail-fast + fail-before-mutate**:

--- a/src/commands/plugins/bud/from-repo-exec.ts
+++ b/src/commands/plugins/bud/from-repo-exec.ts
@@ -39,15 +39,21 @@ export function oracleMarkerEnd(stem: string): string {
 }
 
 /** Full CLAUDE.md template — used when target repo has no CLAUDE.md. */
-function fullClaudeMd(stem: string, today: string): string {
+function fullClaudeMd(stem: string, today: string, parent?: string): string {
+  const lineageHeader = parent
+    ? `> Budded from **${parent}** on ${today} via \`maw bud --from-repo\``
+    : `> Oracle scaffolding injected on ${today} via \`maw bud --from-repo\``;
+  const originLine = parent
+    ? `- **Budded from**: ${parent}\n<!-- oracle-lineage: parent=${parent} -->`
+    : `- **Origin**: injected into existing repo (not budded from a parent)`;
   return `# ${stem}-oracle
 
-> Oracle scaffolding injected on ${today} via \`maw bud --from-repo\`
+${lineageHeader}
 
 ## Identity
 - **Name**: ${stem}
 - **Purpose**: (to be defined by /awaken)
-- **Origin**: injected into existing repo (not budded from a parent)
+${originLine}
 
 ## Principles (inherited from Oracle)
 1. Nothing is Deleted
@@ -63,13 +69,16 @@ Run \`/awaken\` for the full identity setup ceremony.
 }
 
 /** The appended block — fenced with markers so re-runs are idempotent. */
-function appendBlock(stem: string, today: string): string {
+function appendBlock(stem: string, today: string, parent?: string): string {
+  const lineageBullet = parent
+    ? `\n- **Budded from**: ${parent}\n<!-- oracle-lineage: parent=${parent} -->`
+    : "";
   return `\n${oracleMarkerBegin(stem)}
 ## Oracle scaffolding
 
 > Budded into this repo on ${today} via \`maw bud --from-repo --stem ${stem}\`
 
-- **Oracle stem**: ${stem}
+- **Oracle stem**: ${stem}${lineageBullet}
 - **Rule 6**: Oracle Never Pretends to Be Human — sign federation messages as \`[<host>:${stem}]\`
 - Run \`/awaken\` for the full identity setup ceremony.
 ${oracleMarkerEnd(stem)}
@@ -104,12 +113,12 @@ function writeSettings(target: string, log: Log): void {
 }
 
 /** Write or append CLAUDE.md. Idempotent via HTML-comment marker. */
-function writeClaudeMd(target: string, stem: string, today: string, log: Log): void {
+function writeClaudeMd(target: string, stem: string, today: string, log: Log, parent?: string): void {
   const claudePath = join(target, "CLAUDE.md");
   if (!existsSync(claudePath)) {
     // lgtm[js/file-system-race] — PRIVATE-PATH: scaffold dest is user-owned, see docs/security/file-system-race-stance.md
-    writeFileSync(claudePath, fullClaudeMd(stem, today));
-    log(`  \x1b[32m✓\x1b[0m CLAUDE.md written (full template)`);
+    writeFileSync(claudePath, fullClaudeMd(stem, today, parent));
+    log(`  \x1b[32m✓\x1b[0m CLAUDE.md written (full template)${parent ? ` — lineage: ${parent}` : ""}`);
     return;
   }
   const existing = readFileSync(claudePath, "utf-8");
@@ -119,8 +128,26 @@ function writeClaudeMd(target: string, stem: string, today: string, log: Log): v
   }
   const sep = existing.endsWith("\n") ? "" : "\n";
   // lgtm[js/file-system-race] — PRIVATE-PATH: scaffold dest is user-owned, see docs/security/file-system-race-stance.md
-  writeFileSync(claudePath, existing + sep + appendBlock(stem, today));
-  log(`  \x1b[32m✓\x1b[0m CLAUDE.md appended oracle-scaffold block for stem=${stem}`);
+  writeFileSync(claudePath, existing + sep + appendBlock(stem, today, parent));
+  log(`  \x1b[32m✓\x1b[0m CLAUDE.md appended oracle-scaffold block for stem=${stem}${parent ? ` — lineage: ${parent}` : ""}`);
+}
+
+/**
+ * Append `ψ/` to .gitignore unless --track-vault. Idempotent — skip if any
+ * non-comment line already matches `^ψ/?$`.
+ */
+function writeGitignore(target: string, log: Log): void {
+  const path = join(target, ".gitignore");
+  const existing = existsSync(path) ? readFileSync(path, "utf-8") : "";
+  const lines = existing.split("\n").map(l => l.trim());
+  if (lines.some(l => l === "ψ" || l === "ψ/")) {
+    log(`  \x1b[90m○\x1b[0m .gitignore already ignores ψ/ — skip`);
+    return;
+  }
+  const sep = existing.length === 0 || existing.endsWith("\n") ? "" : "\n";
+  // lgtm[js/file-system-race] — PRIVATE-PATH: scaffold dest is user-owned, see docs/security/file-system-race-stance.md
+  writeFileSync(path, existing + sep + "ψ/\n");
+  log(`  \x1b[32m✓\x1b[0m .gitignore now ignores ψ/ (pass --track-vault to keep tracked)`);
 }
 
 /**
@@ -139,6 +166,7 @@ export async function applyFromRepoInjection(
   log(`\n  \x1b[36m🌱 injecting oracle scaffolding\x1b[0m — ${opts.stem} → ${plan.target}\n`);
   writeVault(plan.target, log);
   writeSettings(plan.target, log);
-  writeClaudeMd(plan.target, opts.stem, today, log);
+  writeClaudeMd(plan.target, opts.stem, today, log, opts.from);
+  if (!opts.trackVault) writeGitignore(plan.target, log);
   log(`\n  \x1b[32m✓ done\x1b[0m — run \`maw wake ${opts.stem}\` to start a session\n`);
 }

--- a/src/commands/plugins/bud/from-repo-fleet.test.ts
+++ b/src/commands/plugins/bud/from-repo-fleet.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { basename, join } from "path";
+import { parseRemoteUrl, resolveSlug } from "./from-repo-fleet";
+
+function mkGitRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "maw-fleet-test-"));
+  mkdirSync(join(dir, ".git"));
+  return dir;
+}
+
+describe("from-repo-fleet: parseRemoteUrl", () => {
+  it("parses git@github.com:org/repo.git", () => {
+    expect(parseRemoteUrl("git@github.com:Soul-Brews-Studio/maw-js.git"))
+      .toEqual({ org: "Soul-Brews-Studio", repo: "maw-js" });
+  });
+
+  it("parses https URL with .git suffix", () => {
+    expect(parseRemoteUrl("https://github.com/Soul-Brews-Studio/maw-js.git"))
+      .toEqual({ org: "Soul-Brews-Studio", repo: "maw-js" });
+  });
+
+  it("parses https URL without .git suffix", () => {
+    expect(parseRemoteUrl("https://github.com/x/y"))
+      .toEqual({ org: "x", repo: "y" });
+  });
+
+  it("returns null on garbage", () => {
+    expect(parseRemoteUrl("not-a-url")).toBeNull();
+  });
+});
+
+describe("from-repo-fleet: resolveSlug", () => {
+  it("falls back to <unknown>/<basename> when no remote", () => {
+    const dir = mkGitRepo();
+    try {
+      const slug = resolveSlug(dir);
+      expect(slug.org).toBe("<unknown>");
+      expect(slug.repo).toBe(basename(dir));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/commands/plugins/bud/from-repo-fleet.ts
+++ b/src/commands/plugins/bud/from-repo-fleet.ts
@@ -1,0 +1,126 @@
+/**
+ * Fleet-entry registration for `maw bud --from-repo` (#588).
+ *
+ * Only module that touches FLEET_DIR for the from-repo flow. Tests can
+ * `mock.module("./from-repo-fleet", …)` to assert wiring without
+ * writing to ~/.config/maw/fleet/.
+ *
+ * Design: docs/bud/from-repo-impl.md section (h).
+ */
+
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "fs";
+import { basename, join } from "path";
+import { execSync } from "child_process";
+import { FLEET_DIR } from "../../../core/paths";
+
+/** Parsed `org/repo` slug from a remote URL. */
+export interface RepoSlug {
+  org: string;
+  repo: string;
+}
+
+/**
+ * Extract `org/repo` from a git remote URL.
+ *  - `git@github.com:org/repo.git` → `{org, repo}`
+ *  - `https://github.com/org/repo(.git)?` → `{org, repo}`
+ * Returns null if the URL doesn't match a recognized shape.
+ */
+export function parseRemoteUrl(url: string): RepoSlug | null {
+  const trimmed = url.trim();
+  let m = trimmed.match(/[:/]([^/:]+)\/([^/]+?)(?:\.git)?$/);
+  if (!m) return null;
+  return { org: m[1], repo: m[2] };
+}
+
+/** Read `git -C <target> remote get-url origin`; returns null on any failure. */
+export function readOriginRemote(target: string): string | null {
+  try {
+    return execSync(`git -C ${JSON.stringify(target)} remote get-url origin`, {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/** Resolve org/repo for the target; falls back to `<unknown>/<basename>`. */
+export function resolveSlug(target: string): RepoSlug {
+  const url = readOriginRemote(target);
+  if (url) {
+    const parsed = parseRemoteUrl(url);
+    if (parsed) return parsed;
+  }
+  return { org: "<unknown>", repo: basename(target) };
+}
+
+/** Find the next NN prefix by scanning existing fleet entries. */
+function nextFleetNum(): number {
+  if (!existsSync(FLEET_DIR)) return 1;
+  let max = 0;
+  for (const f of readdirSync(FLEET_DIR)) {
+    if (!f.endsWith(".json") || f.endsWith(".disabled")) continue;
+    const m = f.match(/^(\d+)-/);
+    if (m) max = Math.max(max, parseInt(m[1], 10));
+  }
+  return max + 1;
+}
+
+/** Find an existing fleet file for this stem (matches `NN-<stem>.json`). */
+function findExistingForStem(stem: string): string | null {
+  if (!existsSync(FLEET_DIR)) return null;
+  for (const f of readdirSync(FLEET_DIR)) {
+    if (f.endsWith(`-${stem}.json`)) return f;
+  }
+  return null;
+}
+
+export interface RegisterFleetOpts {
+  stem: string;
+  /** Local target dir — used to read git remote for slug. */
+  target: string;
+  /** Optional parent stem — sets `budded_from` + `budded_at`. */
+  parent?: string;
+}
+
+export interface RegisterFleetResult {
+  file: string;
+  created: boolean;
+  slug: RepoSlug;
+}
+
+/**
+ * Idempotent fleet registration. If `<NN>-<stem>.json` already exists,
+ * leave it alone (and merge lineage if `--from` adds it to a previously
+ * lineage-less entry). Otherwise create a new `<NN>-<stem>.json`.
+ */
+export function registerFleetEntry(opts: RegisterFleetOpts): RegisterFleetResult {
+  const slug = resolveSlug(opts.target);
+  const existing = findExistingForStem(opts.stem);
+  if (existing) {
+    const path = join(FLEET_DIR, existing);
+    const cfg = JSON.parse(readFileSync(path, "utf-8"));
+    let updated = false;
+    if (opts.parent && !cfg.budded_from) {
+      cfg.budded_from = opts.parent;
+      cfg.budded_at = new Date().toISOString();
+      updated = true;
+    }
+    if (updated) writeFileSync(path, JSON.stringify(cfg, null, 2) + "\n");
+    return { file: path, created: false, slug };
+  }
+  const num = nextFleetNum();
+  const padded = String(num).padStart(2, "0");
+  const file = join(FLEET_DIR, `${padded}-${opts.stem}.json`);
+  const cfg: Record<string, unknown> = {
+    name: `${padded}-${opts.stem}`,
+    windows: [{ name: `${opts.stem}-oracle`, repo: `${slug.org}/${slug.repo}` }],
+    sync_peers: [],
+  };
+  if (opts.parent) {
+    cfg.budded_from = opts.parent;
+    cfg.budded_at = new Date().toISOString();
+  }
+  writeFileSync(file, JSON.stringify(cfg, null, 2) + "\n");
+  return { file, created: true, slug };
+}

--- a/src/commands/plugins/bud/from-repo.test.ts
+++ b/src/commands/plugins/bud/from-repo.test.ts
@@ -6,6 +6,19 @@ import type { InvokeContext } from "../../../plugin/types";
 import { planFromRepoInjection, looksLikeUrl, cmdBudFromRepo } from "./from-repo";
 import { applyFromRepoInjection, oracleMarkerBegin } from "./from-repo-exec";
 
+// Hermetic default: stub the fleet module so the test suite never writes to
+// the real ~/.config/maw/fleet/. Individual describe blocks override as needed.
+const fleetCalls: { stem: string; target: string; parent?: string }[] = [];
+mock.module("./from-repo-fleet", () => ({
+  registerFleetEntry: (opts: { stem: string; target: string; parent?: string }) => {
+    fleetCalls.push(opts);
+    return { file: `/tmp/fake-fleet/${opts.stem}.json`, created: true, slug: { org: "fake", repo: "fake" } };
+  },
+  parseRemoteUrl: (_: string) => null,
+  resolveSlug: (_: string) => ({ org: "fake", repo: "fake" }),
+  readOriginRemote: (_: string) => null,
+}));
+
 function mkGitRepo(): string {
   const dir = mkdtempSync(join(tmpdir(), "maw-from-repo-test-"));
   mkdirSync(join(dir, ".git"));
@@ -33,7 +46,8 @@ describe("from-repo: planFromRepoInjection", () => {
       expect(kinds).toContain("mkdir:ψ/inbox");
       expect(kinds).toContain("write:CLAUDE.md");
       expect(kinds).toContain("write:.claude/settings.local.json");
-      expect(kinds.some(k => k.startsWith("skip:fleet/"))).toBe(true);
+      expect(kinds).toContain("append:.gitignore");
+      expect(kinds.some(k => k.startsWith("write:fleet/"))).toBe(true);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -379,3 +393,129 @@ describe("from-repo: handler wiring", () => {
     }
   });
 });
+
+describe("from-repo: --force / --from / --track-vault (#588 continuation)", () => {
+  it("--force lifts the ψ/ collision blocker", () => {
+    const dir = mkGitRepo();
+    try {
+      mkdirSync(join(dir, "ψ"));
+      const plan = planFromRepoInjection({
+        target: dir, stem: "demo", isUrl: false, pr: false, dryRun: true, force: true,
+      });
+      expect(plan.blockers).toEqual([]);
+      expect(plan.actions.find(a => a.path === "ψ/memory/learnings")?.kind).toBe("mkdir");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("without --force the ψ/ collision blocker mentions --force as a remedy", () => {
+    const dir = mkGitRepo();
+    try {
+      mkdirSync(join(dir, "ψ"));
+      const plan = planFromRepoInjection({
+        target: dir, stem: "demo", isUrl: false, pr: false, dryRun: true,
+      });
+      expect(plan.blockers[0]).toContain("--force");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("--from <parent> embeds lineage marker in CLAUDE.md (full-write path)", async () => {
+    const dir = mkGitRepo();
+    try {
+      await cmdBudFromRepo({
+        target: dir, stem: "demo", isUrl: false, pr: false, dryRun: false, from: "neo",
+      });
+      const claude = readFileSync(join(dir, "CLAUDE.md"), "utf-8");
+      expect(claude).toContain("Budded from");
+      expect(claude).toContain("neo");
+      expect(claude).toContain("<!-- oracle-lineage: parent=neo -->");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("--from <parent> embeds lineage marker in CLAUDE.md (append path)", async () => {
+    const dir = mkGitRepo();
+    try {
+      writeFileSync(join(dir, "CLAUDE.md"), "# host\n");
+      await cmdBudFromRepo({
+        target: dir, stem: "demo", isUrl: false, pr: false, dryRun: false, from: "neo",
+      });
+      const claude = readFileSync(join(dir, "CLAUDE.md"), "utf-8");
+      expect(claude).toContain("# host");
+      expect(claude).toContain("Budded from");
+      expect(claude).toContain("<!-- oracle-lineage: parent=neo -->");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("default appends `ψ/` to .gitignore (creates file if absent)", async () => {
+    const dir = mkGitRepo();
+    try {
+      await cmdBudFromRepo({ target: dir, stem: "demo", isUrl: false, pr: false, dryRun: false });
+      const gi = readFileSync(join(dir, ".gitignore"), "utf-8");
+      expect(gi).toContain("ψ/");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("--track-vault skips the .gitignore write", async () => {
+    const dir = mkGitRepo();
+    try {
+      await cmdBudFromRepo({
+        target: dir, stem: "demo", isUrl: false, pr: false, dryRun: false, trackVault: true,
+      });
+      expect(existsSync(join(dir, ".gitignore"))).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it(".gitignore append is idempotent", async () => {
+    const dir = mkGitRepo();
+    try {
+      writeFileSync(join(dir, ".gitignore"), "node_modules/\nψ/\n");
+      await cmdBudFromRepo({ target: dir, stem: "demo", isUrl: false, pr: false, dryRun: false });
+      const gi = readFileSync(join(dir, ".gitignore"), "utf-8");
+      expect(gi.match(/ψ\//g)?.length).toBe(1);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("plan reflects --track-vault as skip:.gitignore", () => {
+    const dir = mkGitRepo();
+    try {
+      const plan = planFromRepoInjection({
+        target: dir, stem: "demo", isUrl: false, pr: false, dryRun: true, trackVault: true,
+      });
+      const gi = plan.actions.find(a => a.path === ".gitignore");
+      expect(gi?.kind).toBe("skip");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("orchestrator wires registerFleetEntry with stem/target/parent", async () => {
+    const before = fleetCalls.length;
+    const dir = mkGitRepo();
+    try {
+      await cmdBudFromRepo({
+        target: dir, stem: "lineage-test", isUrl: false, pr: false, dryRun: false, from: "neo",
+      });
+      const newCalls = fleetCalls.slice(before);
+      expect(newCalls.length).toBe(1);
+      expect(newCalls[0].stem).toBe("lineage-test");
+      expect(newCalls[0].target).toBe(dir);
+      expect(newCalls[0].parent).toBe("neo");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+

--- a/src/commands/plugins/bud/from-repo.ts
+++ b/src/commands/plugins/bud/from-repo.ts
@@ -1,10 +1,10 @@
 /**
  * `maw bud --from-repo <target> --stem <stem>` — planner + orchestrator.
  *
- * SCOPE: local-path + URL clone + `--pr` branch-and-PR flow (#588).
- * Deferred: --force, --seed, fleet entry, --from lineage, sync_peers.
- * Writes live in from-repo-exec.ts; git/gh shell-outs in from-repo-git.ts.
- * Planner stays pure / read-only.
+ * SCOPE: local-path + URL clone + `--pr` + `--force` + `--from` lineage +
+ * `--track-vault` + fleet-entry registration (#588). Deferred: --seed, sync_peers.
+ * Writes live in from-repo-exec.ts; git/gh shell-outs in from-repo-git.ts;
+ * fleet writes in from-repo-fleet.ts. Planner stays pure / read-only.
  *
  * Design: docs/bud/from-repo-design.md + docs/bud/from-repo-impl.md
  */
@@ -14,6 +14,7 @@ import { join, isAbsolute } from "path";
 import type { FromRepoOpts, InjectionAction, InjectionPlan } from "./types";
 import { applyFromRepoInjection } from "./from-repo-exec";
 import { cloneShallow, cleanupClone, branchCommitPushPR } from "./from-repo-git";
+import { registerFleetEntry } from "./from-repo-fleet";
 
 /** Heuristic: is `target` a URL or `org/repo` slug rather than a local path? */
 export function looksLikeUrl(target: string): boolean {
@@ -71,17 +72,22 @@ export function planFromRepoInjection(opts: FromRepoOpts): InjectionPlan {
     return { target, stem: opts.stem, actions, blockers };
   }
 
-  // Collision: ψ/ already present
-  if (existsSync(join(target, "ψ"))) {
+  // Collision: ψ/ already present. --force downgrades the blocker to a warning.
+  const psiExists = existsSync(join(target, "ψ"));
+  if (psiExists && !opts.force) {
     blockers.push(
-      `ψ/ already present at ${target} — looks like an existing oracle repo. Use maw soul-sync or maw wake.`,
+      `ψ/ already present at ${target} — looks like an existing oracle repo. Use maw soul-sync, maw wake, or pass --force to merge into the existing vault.`,
     );
     return { target, stem: opts.stem, actions, blockers };
   }
 
   // 1. ψ/ vault directories
   for (const d of PSI_DIRS) {
-    actions.push({ kind: "mkdir", path: d });
+    actions.push({
+      kind: "mkdir",
+      path: d,
+      reason: psiExists ? "ψ/ exists — --force: mkdir is idempotent, merge into existing vault" : undefined,
+    });
   }
 
   // 2. CLAUDE.md — write if absent, append if present
@@ -108,11 +114,29 @@ export function planFromRepoInjection(opts: FromRepoOpts): InjectionPlan {
     actions.push({ kind: "write", path: ".claude/settings.local.json", reason: "empty {} scaffold" });
   }
 
-  // 4. fleet entry — deferred; listed as skip so operators see the gap
+  // 4. .gitignore — append `ψ/` unless --track-vault. Idempotent; reflected in
+  //    plan even if the line is already present (executor de-dupes).
+  if (opts.trackVault) {
+    actions.push({
+      kind: "skip",
+      path: ".gitignore",
+      reason: "--track-vault — leaving ψ/ unignored",
+    });
+  } else {
+    actions.push({
+      kind: "append",
+      path: ".gitignore",
+      reason: "add `ψ/` (default; pass --track-vault to keep ψ/ tracked)",
+    });
+  }
+
+  // 5. fleet entry — registered after the executor lands. Plan reflects intent.
   actions.push({
-    kind: "skip",
+    kind: "write",
     path: `fleet/<NN>-${opts.stem}.json`,
-    reason: "fleet entry creation deferred to follow-up PR (#588)",
+    reason: opts.from
+      ? `register in ~/.config/maw/fleet/ with budded_from=${opts.from}`
+      : "register in ~/.config/maw/fleet/",
   });
 
   return { target, stem: opts.stem, actions, blockers };
@@ -176,6 +200,16 @@ async function runLocal(opts: FromRepoOpts): Promise<void> {
   }
   if (opts.dryRun) return;
   await applyFromRepoInjection(plan, opts);
+  // Fleet entry — register the budded oracle so `maw wake <stem>` works.
+  // Failure to register is logged but never blocks the injection (the repo
+  // is the canonical artifact; fleet is a convenience index).
+  try {
+    const result = registerFleetEntry({ stem: opts.stem, target: opts.target, parent: opts.from });
+    const verb = result.created ? "registered" : "updated";
+    console.log(`  \x1b[32m✓\x1b[0m fleet entry ${verb}: ${result.file}`);
+  } catch (e: any) {
+    console.log(`  \x1b[33m!\x1b[0m fleet entry skipped: ${e.message}`);
+  }
   if (opts.pr) {
     const url = await branchCommitPushPR(opts.target, opts.stem, (m) => console.log(m));
     console.log(`\n  \x1b[32m🎉 PR opened:\x1b[0m ${url}\n`);

--- a/src/commands/plugins/bud/index.ts
+++ b/src/commands/plugins/bud/index.ts
@@ -39,6 +39,8 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         "--seed": Boolean,
         "--blank": Boolean,
         "--signal-on-birth": Boolean,
+        "--force": Boolean,
+        "--track-vault": Boolean,
       }, 0);
 
       // --from-repo branches early: inject scaffolding into an existing repo (#588).
@@ -58,13 +60,16 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
           isUrl: looksLikeUrl(target),
           pr: !!flags["--pr"],
           dryRun: !!flags["--dry-run"],
+          force: !!flags["--force"],
+          from: flags["--from"],
+          trackVault: !!flags["--track-vault"],
         });
         return { ok: true, output: logs.join("\n") || undefined };
       }
 
       const name = flags._[0];
       if (!name || name === "--help" || name === "-h") {
-        return { ok: false, error: "usage: maw bud <name> [--from <oracle>] [--root] [--seed] [--org <org>] [--repo org/repo] [--issue N] [--note <text>] [--fast] [--split] [--dry-run]\n       Or:    maw bud --from-repo <path> --stem <stem> [--pr] [--dry-run]  (#588, scaffold-only)\n       Default: born blank. Use --seed to pre-load parent's ψ at birth.\n       Pull memory later: maw soul-sync <parent> --from" };
+        return { ok: false, error: "usage: maw bud <name> [--from <oracle>] [--root] [--seed] [--org <org>] [--repo org/repo] [--issue N] [--note <text>] [--fast] [--split] [--dry-run]\n       Or:    maw bud --from-repo <path|url> --stem <stem> [--pr] [--from <parent>] [--force] [--track-vault] [--dry-run]  (#588)\n       Default: born blank. Use --seed to pre-load parent's ψ at birth.\n       Pull memory later: maw soul-sync <parent> --from" };
       }
       if (name.startsWith("-")) {
         return { ok: false, error: `"${name}" looks like a flag, not an oracle name.\n  usage: maw bud <name> ${args.join(" ")}` };

--- a/src/commands/plugins/bud/types.ts
+++ b/src/commands/plugins/bud/types.ts
@@ -17,6 +17,12 @@ export interface FromRepoOpts {
   pr: boolean;
   /** Print the injection plan and exit without writing. */
   dryRun: boolean;
+  /** Suppress the ψ/-collision blocker. Never destructive — mkdir is idempotent. */
+  force?: boolean;
+  /** Parent oracle stem — embedded as lineage in CLAUDE.md (and fleet entry). */
+  from?: string;
+  /** Keep ψ/ tracked in git. Default: append `ψ/` to target .gitignore. */
+  trackVault?: boolean;
 }
 
 /** One file in the injection plan — what would be added or appended. */


### PR DESCRIPTION
## Summary

Continuation of #588 (`maw bud --from-repo`). Ships **4 of 6** remaining TODOs from the original #591 punch list (after #595 local-path + #606 URL + `--pr` already landed); defers 2 to a follow-up.

### Shipped

- **`--force`** — when `ψ/` already exists in the target, downgrades the planner blocker to a `mkdir`-with-warning. `mkdir` is idempotent, so this is non-destructive (no \`rmSync\` of pre-existing memory). Aligns with "Nothing is Deleted."
- **Fleet entry** — after a successful injection, registers \`<NN>-<stem>.json\` in \`~/.config/maw/fleet/\` so \`maw wake <stem>\` works. New \`from-repo-fleet.ts\` module is the only place from-repo touches \`FLEET_DIR\`. Idempotent on stem; merges \`budded_from\`/\`budded_at\` into existing entries when \`--from\` is provided. Failure to register is logged but never blocks the injection.
- **`--from <parent>`** — embeds lineage in the CLAUDE.md template (full-write path) and the appended \`oracle-scaffold\` block (append path). Adds a machine-readable \`<!-- oracle-lineage: parent=<parent> --> \` HTML comment for future tooling. Also flows to the fleet entry.
- **`--track-vault`** — controls whether \`ψ/\` gets added to the target's \`.gitignore\`. Default: append \`ψ/\` (so the host repo's git history stays clean; federation handles vault sync). \`--track-vault\` opts in to keeping \`ψ/\` tracked. Idempotent — doesn't re-add if \`^ψ/?$\` already matches.

### Deferred

- **\`--seed\`** — pre-load parent oracle's \`ψ/memory/\` at bud time. Requires file-copy from parent; needs separate scope.
- **\`sync_peers\`** — inherit parent's \`peers.json\`. Same — depends on parent peers + federation work.

#588 stays open until those two land.

## Implementation

- \`types.ts\` — extend \`FromRepoOpts\` with \`force\` / \`from\` / \`trackVault\`.
- \`from-repo.ts\` — planner: respect \`--force\`, reflect \`.gitignore\` action (default vs \`--track-vault\`), reflect fleet write. Orchestrator: invoke \`registerFleetEntry\` after \`applyFromRepoInjection\`.
- \`from-repo-exec.ts\` — CLAUDE.md template + append-block embed lineage. New \`writeGitignore\` honors \`--track-vault\`.
- \`from-repo-fleet.ts\` (new) — \`registerFleetEntry\`, \`parseRemoteUrl\`, \`resolveSlug\`, \`readOriginRemote\`. Uses \`git -C <target> remote get-url origin\` to derive slug; falls back to \`<unknown>/<basename>\`.
- \`index.ts\` — parse \`--force\` / \`--track-vault\`; route \`--from\` into the from-repo flow.

All files ≤200 LOC.

## Tests

\`bun run test:all\`: **245 pass, 6 skip, 0 fail** (across 28 files).

New coverage (in \`from-repo.test.ts\` + new \`from-repo-fleet.test.ts\`):

- \`--force\` lifts ψ/ collision blocker
- without \`--force\` the blocker mentions \`--force\` as a remedy
- \`--from <parent>\` embeds lineage in CLAUDE.md (full-write path)
- \`--from <parent>\` embeds lineage in CLAUDE.md (append path)
- default appends \`ψ/\` to \`.gitignore\` (creates file if absent)
- \`--track-vault\` skips the \`.gitignore\` write
- \`.gitignore\` append is idempotent
- plan reflects \`--track-vault\` as \`skip:.gitignore\`
- \`registerFleetEntry\` called with stem/target/parent
- \`parseRemoteUrl\` parses \`git@\`, \`https\` (with/without \`.git\`)
- \`resolveSlug\` falls back to \`<unknown>/<basename>\` when no remote

Tests are hermetic: \`from-repo.test.ts\` ships a suite-wide \`mock.module\` for \`./from-repo-fleet\` so the suite never writes to the real \`~/.config/maw/fleet/\`. \`from-repo-fleet.test.ts\` lives standalone to avoid that shadowing for the parser tests.

## Test plan

- [x] \`bun run test:all\` green locally
- [x] \`tsc --noEmit\` clean
- [ ] CI green
- [ ] Manual smoke: \`maw bud --from-repo /tmp/foo --stem demo --from neo --dry-run\` emits expected plan
- [ ] Manual smoke: \`maw bud --from-repo /tmp/foo --stem demo --force\` succeeds on a repo with pre-existing ψ/

🤖 Generated with [Claude Code](https://claude.com/claude-code)