### PR TITLE
docs(federation): add topology diagram to docker-testing.md

### DIFF
--- a/docs/federation/docker-testing.md
+++ b/docs/federation/docker-testing.md
@@ -3,6 +3,36 @@
 Reproduce a GitHub-Actions-like environment locally: two maw-js
 containers on a shared Docker network, handshaking as peers.
 
+## Topology
+
+```mermaid
+flowchart LR
+    host(["Host machine"])
+    host -->|localhost:13456| A_port
+    host -->|localhost:13457| B_port
+
+    subgraph bridge["Docker bridge network"]
+        direction LR
+        subgraph A["node-a (maw-node-a)"]
+            A_port["port 3456"]
+            A_vol[("maw-a-data<br/>→ /root/.maw")]
+            A_hc{{"healthcheck:<br/>/api/plugins"}}
+        end
+        subgraph B["node-b (maw-node-b)"]
+            B_port["port 3456"]
+            B_vol[("maw-b-data<br/>→ /root/.maw")]
+            B_hc{{"healthcheck:<br/>/api/plugins"}}
+        end
+        A -->|"probe → http://node-b:3456/info"| B
+        B -->|"probe → http://node-a:3456/info"| A
+    end
+```
+
+Host ports `13456` / `13457` map to each container's `3456`. Inside the
+bridge network, containers reach each other by hostname (`node-a`,
+`node-b`) via Docker's embedded DNS — no `localhost` shortcut, so peer
+handshake bugs surface the same way they would across real hosts.
+
 ## Why this exists
 
 Peer handshake bugs only surface across real network boundaries — on a


### PR DESCRIPTION
## Summary

Adds a Mermaid topology diagram to [docs/federation/docker-testing.md](../blob/docs/federation-topology-diagram/docs/federation/docker-testing.md) so newcomers can see the 2-node harness at a glance:

- Host ↔ container port mappings (`13456/13457 → 3456`)
- Docker bridge network with embedded DNS (`node-a`, `node-b`)
- Mutual probe flow: `a → http://node-b:3456/info`, `b → http://node-a:3456/info`
- `/api/plugins` healthcheck and `maw-{a,b}-data → /root/.maw` volume mounts

Mermaid renders natively on GitHub — no build step required.

## Test plan

- [ ] PR preview renders the Mermaid block (GitHub auto-renders ` ```mermaid ` fences)
- [ ] Rest of the doc is unchanged (only additive `## Topology` section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)