### PR TITLE
bump: v26.4.18-alpha.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.18-alpha.24",
+  "version": "26.4.18-alpha.25",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
19 commits since v26.4.18-alpha.24:

**feat(bud):**
- `--force` + `--track-vault` + fleet entry + `--from` lineage (#588, #611)
- URL-mode + `--pr` flag for `--from-repo` (#588, #606)
- implement `--from-repo` local-path full run (#588, #595)
- scaffold `--from-repo` flag + dry-run plan (#588, #591)

**feat(transport):**
- `/info` endpoint for peer handshake (closes #596, #603)

**feat(docker):**
- integration test script — 2-node probe round-trip (#601)
- `entrypoint.sh` — idempotent peer bootstrap (#600)
- compose.yml + dev helper for 2-node federation test (#598)
- Dockerfile + `.dockerignore` for `maw-js:test` image (#597)

**fix(peers):**
- classify `ENOTIMP` / `EAI_*` as DNS-family (#593, #594)

**sec:**
- transport: audit `js/file-access-to-http` × 4 (#474, #608)
- view: `execFileSync` + argv for tmux/ssh attach (#474, #604)
- demo: guard `ev.oracle` against prototype pollution in `demo/agents.html` (#474, #602)
- toctou: fd-based lock ops in `peers/lock` + `instance-pid` (#474, #590)
- codeql: stance doc + `lgtm` suppressions for 11 private-path file-system-race sites (#474, #592)

**ci:**
- docker: federation integration workflow + docs (#599)

**docs:**
- security: #474 — audit `js/http-to-file-access` × 4 sites (#610)
- federation: fill TODO link to #596 + note harness build regression #607 (#609)
- security: #474 — `lgtm` doesn't close; replace with Code Scanning dismissal (#605)

Tag `v26.4.18-alpha.25` will be cut post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)