### PR TITLE
fix(docker): align bun version with lockfile (closes #607)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,6 +10,8 @@ RUN bun install --frozen-lockfile
 
 COPY . .
 
+RUN chmod +x src/cli.ts && ln -sf /app/src/cli.ts /usr/local/bin/maw
+
 COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.3-alpine
+FROM oven/bun:1.3.11-alpine
 
 RUN apk add --no-cache wget
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,7 @@ RUN apk add --no-cache wget
 WORKDIR /app
 
 COPY package.json bun.lock* ./
+COPY packages/sdk/package.json packages/sdk/
 RUN bun install --frozen-lockfile
 
 COPY . .


### PR DESCRIPTION
## Summary

**Closes the BUILD failures in #607 only.** Makes `docker/Dockerfile` build end-to-end again, with two additional pre-existing Dockerfile bugs surfaced and fixed along the way. Fixing the runtime federation probe is tracked separately in **#616**.

## Three commits

1. **Pin `oven/bun:1.3.11-alpine`** (was `1.3-alpine`, which floats to 1.3.12). Keeps the container on the same bun that wrote `bun.lock`.
2. **Copy `packages/sdk/package.json`** before install. Root cause of the frozen-install failure was not the version drift alone — maw-js is a bun workspace (`workspaces: ["packages/*"]`), and the previous Dockerfile only COPYed the root `package.json` + lockfile. Without the workspace manifest, bun reports "lockfile had changes" regardless of bun version.
3. **Symlink `maw` onto PATH**. The root package declares `"bin": { "maw": "./src/cli.ts" }`, but bun doesn't auto-create a PATH-visible symlink for the root package. Before this fix, `entrypoint.sh` line 29 (`maw init ...`) died with `maw: not found` as soon as the image actually started — this had been masked by (1) and (2) blocking the build entirely.

## Option chosen + why

Per #607 proposals, picked **option 1** (pin `1.3.11-alpine`) rather than option 2 (regenerate lockfile): my local bun is 1.3.11, so I couldn't regenerate at 1.3.12 without upgrading the toolchain. The workspace-COPY fix is independent of the version decision. When we later upgrade local bun to 1.3.12 and regen the lockfile in a follow-up, we can relax the pin back to `1.3-alpine`.

## Known gap — tracked in #616

`.github/workflows/federation-docker.yml` (`2-node probe round-trip`) is still failing on this PR. It is **not** a regression from these commits — the workflow has never actually been green, because the Dockerfile never built end-to-end before. With the build now working, the probe reaches the app layer and gets `REFUSED` during the inter-container handshake.

Root cause: `src/core/server.ts:184-185` binds `maw serve` to `127.0.0.1` unless `config.peers`/`config.namedPeers` is populated in `maw.config.json`. `docker/entrypoint.sh` seeds peers via `maw peers add`, which writes `peers.json` — a **different** store — so the server stays bound to loopback. HEALTHCHECK runs inside the container so it still passes, but cross-container probes fail.

Tracked in **#616**: `fix(serve): bind 0.0.0.0 when peers.json has entries (docker federation blocked by src/core/server.ts:184 heuristic)`. That PR will also drop the stale hedge comment in `scripts/test-docker-federation.sh` (it references an issue that already shipped).

This PR is explicitly scoped to Dockerfile + `bun.lock` per the task brief — the `server.ts` binding fix is out of scope here.

## Test plan

- [x] `bun run test:all` green — 245 pass / 6 skip / 0 fail across 28 files
- [x] `docker build -f docker/Dockerfile -t maw-js:test .` succeeds locally (docker 29.4.0)
- [x] `docker run --rm maw-js:test maw --version` → `maw v26.4.18-alpha.24`
- [x] CI green **except** `2-node probe round-trip` (blocked on #616, not this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
