### PR TITLE
sec(bud): fix js/indirect-command-line-injection #96 in from-repo-fleet.ts (#474)

### DIFF
--- a/src/commands/plugins/bud/from-repo-fleet.test.ts
+++ b/src/commands/plugins/bud/from-repo-fleet.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync } from "fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { basename, join } from "path";
-import { parseRemoteUrl, resolveSlug } from "./from-repo-fleet";
+import { parseRemoteUrl, readOriginRemote, resolveSlug } from "./from-repo-fleet";
 
 function mkGitRepo(): string {
   const dir = mkdtempSync(join(tmpdir(), "maw-fleet-test-"));
@@ -38,6 +38,36 @@ describe("from-repo-fleet: resolveSlug", () => {
       const slug = resolveSlug(dir);
       expect(slug.org).toBe("<unknown>");
       expect(slug.repo).toBe(basename(dir));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("from-repo-fleet: readOriginRemote shell-injection guard (#474)", () => {
+  // execFileSync + argv ensures shell metacharacters in `target` are treated
+  // as literal path bytes, not shell syntax. Regression guard for the
+  // js/indirect-command-line-injection sink on line 38 (pre-fix).
+  it("does not execute injected commands via target path", () => {
+    const sentinel = mkdtempSync(join(tmpdir(), "maw-inject-sentinel-"));
+    const marker = join(sentinel, "pwned");
+    try {
+      // A shell-interpreted execSync(`git -C ${target} …`) would run `touch`
+      // through $(…) substitution. With execFileSync + argv, the whole
+      // string is passed as a single -C path → git fails, marker stays absent.
+      const malicious = `/tmp/nonexistent$(touch ${marker})`;
+      const result = readOriginRemote(malicious);
+      expect(result).toBeNull();
+      expect(existsSync(marker)).toBe(false);
+    } finally {
+      rmSync(sentinel, { recursive: true, force: true });
+    }
+  });
+
+  it("returns null for a path with no git repo (benign)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "maw-no-git-"));
+    try {
+      expect(readOriginRemote(dir)).toBeNull();
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/src/commands/plugins/bud/from-repo-fleet.ts
+++ b/src/commands/plugins/bud/from-repo-fleet.ts
@@ -10,7 +10,7 @@
 
 import { existsSync, readdirSync, readFileSync, writeFileSync } from "fs";
 import { basename, join } from "path";
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { FLEET_DIR } from "../../../core/paths";
 
 /** Parsed `org/repo` slug from a remote URL. */
@@ -32,10 +32,16 @@ export function parseRemoteUrl(url: string): RepoSlug | null {
   return { org: m[1], repo: m[2] };
 }
 
-/** Read `git -C <target> remote get-url origin`; returns null on any failure. */
+/**
+ * Read `git -C <target> remote get-url origin`; returns null on any failure.
+ *
+ * Uses execFileSync + argv to avoid shell interpretation of `target`
+ * (js/indirect-command-line-injection, #474). Matches the pattern proven
+ * in view/impl.ts (#604) and wake.ts attachToSession.
+ */
 export function readOriginRemote(target: string): string | null {
   try {
-    return execSync(`git -C ${JSON.stringify(target)} remote get-url origin`, {
+    return execFileSync("git", ["-C", target, "remote", "get-url", "origin"], {
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "ignore"],
     }).trim();


### PR DESCRIPTION
## Summary
- CodeQL alert #96 (`js/indirect-command-line-injection`) flagged `execSync` with an interpolated `target` path in `readOriginRemote` (introduced by #611).
- Switched to `execFileSync("git", ["-C", target, "remote", "get-url", "origin"], …)` so shell metacharacters in `target` are treated as literal path bytes, matching the pattern proven in `view/impl.ts` (#604) and `wake.ts` `attachToSession`.
- Added regression test that feeds a `$(touch $marker)` payload as `target` and asserts the sentinel file is never created.

## Test plan
- [x] `bun test src/commands/plugins/bud/from-repo-fleet.test.ts` — 7 pass / 0 fail
- [x] `bun run test:all` — all 4 suites green, 0 fail
- [ ] CodeQL re-scan clears alert #96 (post-merge)

Refs #474