### PR TITLE
fix(serve): bind 0.0.0.0 on MAW_HOST env or peers.json presence (closes #616)

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -36,4 +36,10 @@ fi
 echo "[${NODE_NAME}] bootstrap complete — peers.json:"
 cat "$MAW_HOME/peers.json" 2>/dev/null || echo "(no peers.json yet)"
 
+# Force 0.0.0.0 bind even if peers.json hasn't been populated yet (#616).
+# maw serve's resolveBindHost() treats MAW_HOST="0.0.0.0" as an explicit
+# opt-in. Without this, a container whose first `maw peers add` failed
+# (peer not up yet) would stay on loopback and be unreachable for retry.
+export MAW_HOST=0.0.0.0
+
 exec "$@"

--- a/src/core/bind-host.ts
+++ b/src/core/bind-host.ts
@@ -1,0 +1,53 @@
+/**
+ * Bind-host heuristic (#616).
+ *
+ * Decide between 0.0.0.0 (federation-exposed) and 127.0.0.1 (loopback only).
+ * Returns both the hostname and the reason that triggered a non-loopback
+ * bind (null when we stay on loopback) so the startup log can explain itself.
+ *
+ * Triggers for 0.0.0.0, in priority order:
+ *   1. config.peers — legacy positional peers list
+ *   2. config.namedPeers — newer named-peer list
+ *   3. MAW_HOST === "0.0.0.0" — explicit env opt-in (docker / CI)
+ *   4. ~/.maw/peers.json non-empty — federation runtime state (container
+ *      entrypoints write this via `maw peers add` before `maw serve`)
+ *
+ * Env opt-in wins over the file check so tests don't have to touch disk;
+ * passing a non-null PeersStoreReader lets tests inject a fake.
+ *
+ * Extracted into its own module (not src/core/server.ts) so tests can import
+ * it without triggering server.ts's auto-start side effect.
+ */
+export type BindHostReason = "config.peers" | "config.namedPeers" | "MAW_HOST" | "peers.json" | null;
+
+export interface BindConfig {
+  peers?: unknown[] | null;
+  namedPeers?: unknown[] | null;
+}
+
+export interface BindHostEnv {
+  MAW_HOST?: string;
+}
+
+export type PeersStoreReader = () => { peers: Record<string, unknown> };
+
+export function resolveBindHost(
+  config: BindConfig,
+  env: BindHostEnv = process.env,
+  readPeers: PeersStoreReader | null = null,
+): { hostname: string; reason: BindHostReason } {
+  if ((config.peers?.length ?? 0) > 0) return { hostname: "0.0.0.0", reason: "config.peers" };
+  if ((config.namedPeers?.length ?? 0) > 0) return { hostname: "0.0.0.0", reason: "config.namedPeers" };
+  if (env.MAW_HOST === "0.0.0.0") return { hostname: "0.0.0.0", reason: "MAW_HOST" };
+  const reader = readPeers ?? (() => {
+    try {
+      // Lazy-require to keep this heuristic importable without the plugin bundle.
+      return require("../commands/plugins/peers/store").loadPeers();
+    } catch { return { peers: {} }; }
+  });
+  try {
+    const store = reader();
+    if (store && Object.keys(store.peers ?? {}).length > 0) return { hostname: "0.0.0.0", reason: "peers.json" };
+  } catch { /* ignore — stay on loopback */ }
+  return { hostname: "127.0.0.1", reason: null };
+}

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -35,50 +35,9 @@ function getVersionString(): string {
 
 export const VERSION = getVersionString();
 
-// --- Bind heuristic (#616) ---
-//
-// Decide between 0.0.0.0 (federation-exposed) and 127.0.0.1 (loopback only).
-// Return both the hostname and the reason that triggered a non-loopback bind
-// (null when we stay on loopback) so the startup log can explain itself.
-//
-// Triggers for 0.0.0.0, in priority order:
-//   1. config.peers — legacy positional peers list
-//   2. config.namedPeers — newer named-peer list
-//   3. MAW_HOST === "0.0.0.0" — explicit env opt-in (docker / CI)
-//   4. ~/.maw/peers.json non-empty — federation runtime state (container
-//      entrypoints write this via `maw peers add` before `maw serve`)
-//
-// Env opt-in wins over the file check so tests don't have to touch disk;
-// passing a non-null PeersStoreReader lets tests inject a fake.
-export type BindHostReason = "config.peers" | "config.namedPeers" | "MAW_HOST" | "peers.json" | null;
-export interface BindConfig {
-  peers?: unknown[] | null;
-  namedPeers?: unknown[] | null;
-}
-export interface BindHostEnv {
-  MAW_HOST?: string;
-}
-export type PeersStoreReader = () => { peers: Record<string, unknown> };
-export function resolveBindHost(
-  config: BindConfig,
-  env: BindHostEnv = process.env,
-  readPeers: PeersStoreReader | null = null,
-): { hostname: string; reason: BindHostReason } {
-  if ((config.peers?.length ?? 0) > 0) return { hostname: "0.0.0.0", reason: "config.peers" };
-  if ((config.namedPeers?.length ?? 0) > 0) return { hostname: "0.0.0.0", reason: "config.namedPeers" };
-  if (env.MAW_HOST === "0.0.0.0") return { hostname: "0.0.0.0", reason: "MAW_HOST" };
-  const reader = readPeers ?? (() => {
-    try {
-      // Lazy-require to keep the heuristic importable without the plugin bundle.
-      return require("../commands/plugins/peers/store").loadPeers();
-    } catch { return { peers: {} }; }
-  });
-  try {
-    const store = reader();
-    if (store && Object.keys(store.peers ?? {}).length > 0) return { hostname: "0.0.0.0", reason: "peers.json" };
-  } catch { /* ignore — stay on loopback */ }
-  return { hostname: "127.0.0.1", reason: null };
-}
+// Bind heuristic lives in ./bind-host.ts so tests can import it without
+// pulling in server.ts's module-level auto-start side effects.
+import { resolveBindHost } from "./bind-host";
 
 // --- Views + static (Hono keeps these) ---
 

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -35,6 +35,51 @@ function getVersionString(): string {
 
 export const VERSION = getVersionString();
 
+// --- Bind heuristic (#616) ---
+//
+// Decide between 0.0.0.0 (federation-exposed) and 127.0.0.1 (loopback only).
+// Return both the hostname and the reason that triggered a non-loopback bind
+// (null when we stay on loopback) so the startup log can explain itself.
+//
+// Triggers for 0.0.0.0, in priority order:
+//   1. config.peers — legacy positional peers list
+//   2. config.namedPeers — newer named-peer list
+//   3. MAW_HOST === "0.0.0.0" — explicit env opt-in (docker / CI)
+//   4. ~/.maw/peers.json non-empty — federation runtime state (container
+//      entrypoints write this via `maw peers add` before `maw serve`)
+//
+// Env opt-in wins over the file check so tests don't have to touch disk;
+// passing a non-null PeersStoreReader lets tests inject a fake.
+export type BindHostReason = "config.peers" | "config.namedPeers" | "MAW_HOST" | "peers.json" | null;
+export interface BindConfig {
+  peers?: unknown[] | null;
+  namedPeers?: unknown[] | null;
+}
+export interface BindHostEnv {
+  MAW_HOST?: string;
+}
+export type PeersStoreReader = () => { peers: Record<string, unknown> };
+export function resolveBindHost(
+  config: BindConfig,
+  env: BindHostEnv = process.env,
+  readPeers: PeersStoreReader | null = null,
+): { hostname: string; reason: BindHostReason } {
+  if ((config.peers?.length ?? 0) > 0) return { hostname: "0.0.0.0", reason: "config.peers" };
+  if ((config.namedPeers?.length ?? 0) > 0) return { hostname: "0.0.0.0", reason: "config.namedPeers" };
+  if (env.MAW_HOST === "0.0.0.0") return { hostname: "0.0.0.0", reason: "MAW_HOST" };
+  const reader = readPeers ?? (() => {
+    try {
+      // Lazy-require to keep the heuristic importable without the plugin bundle.
+      return require("../commands/plugins/peers/store").loadPeers();
+    } catch { return { peers: {} }; }
+  });
+  try {
+    const store = reader();
+    if (store && Object.keys(store.peers ?? {}).length > 0) return { hostname: "0.0.0.0", reason: "peers.json" };
+  } catch { /* ignore — stay on loopback */ }
+  return { hostname: "127.0.0.1", reason: null };
+}
+
 // --- Views + static (Hono keeps these) ---
 
 const views = new Hono();
@@ -179,10 +224,10 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
   };
 
   // HTTP server (always)
-  // Security: bind to localhost unless peers are configured (federation needs network access)
+  // Security: bind to localhost unless federation is active (see resolveBindHost).
   const config = loadConfig();
-  const hasPeers = (config.peers?.length ?? 0) > 0 || (config.namedPeers?.length ?? 0) > 0;
-  const hostname = hasPeers ? "0.0.0.0" : "127.0.0.1";
+  const { hostname, reason } = resolveBindHost(config);
+  const hasPeers = reason !== null;
 
   if (hasPeers && !config.federationToken) {
     console.warn(`\x1b[31m⚠ WARNING: peers configured but no federationToken set!\x1b[0m`);
@@ -192,7 +237,8 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
 
   const server = Bun.serve({ port, hostname, fetch: fetchHandler, websocket: wsHandler });
   setBunServer(server);
-  console.log(`maw ${VERSION} serve → ${HTTP_URL} (${WS_URL}) [${hostname}]`);
+  const bindNote = reason ? ` (${reason})` : "";
+  console.log(`maw ${VERSION} serve → ${HTTP_URL} (${WS_URL}) [${hostname}]${bindNote}`);
 
   // HTTPS server (if TLS configured)
   const tlsCfg = loadConfig().tls;

--- a/test/bind-heuristic.test.ts
+++ b/test/bind-heuristic.test.ts
@@ -1,9 +1,5 @@
-// server.ts auto-starts Bun.serve when imported without MAW_CLI — suppress
-// that side effect for these pure unit tests. Must be set BEFORE the import.
-process.env.MAW_CLI = "1";
-
 import { describe, test, expect } from "bun:test";
-import { resolveBindHost, type BindConfig } from "../src/core/server";
+import { resolveBindHost, type BindConfig } from "../src/core/bind-host";
 
 const EMPTY: BindConfig = {};
 const EMPTY_ENV = {};

--- a/test/bind-heuristic.test.ts
+++ b/test/bind-heuristic.test.ts
@@ -1,0 +1,76 @@
+// server.ts auto-starts Bun.serve when imported without MAW_CLI — suppress
+// that side effect for these pure unit tests. Must be set BEFORE the import.
+process.env.MAW_CLI = "1";
+
+import { describe, test, expect } from "bun:test";
+import { resolveBindHost, type BindConfig } from "../src/core/server";
+
+const EMPTY: BindConfig = {};
+const EMPTY_ENV = {};
+const EMPTY_STORE = () => ({ peers: {} });
+
+describe("resolveBindHost (#616)", () => {
+  test("loopback when nothing is configured", () => {
+    const r = resolveBindHost(EMPTY, EMPTY_ENV, EMPTY_STORE);
+    expect(r.hostname).toBe("127.0.0.1");
+    expect(r.reason).toBe(null);
+  });
+
+  test("trigger 1: config.peers populated", () => {
+    const r = resolveBindHost({ peers: ["http://host:7777"] }, EMPTY_ENV, EMPTY_STORE);
+    expect(r.hostname).toBe("0.0.0.0");
+    expect(r.reason).toBe("config.peers");
+  });
+
+  test("trigger 2: config.namedPeers populated", () => {
+    const r = resolveBindHost({ namedPeers: [{ alias: "a", url: "http://a:7777" }] }, EMPTY_ENV, EMPTY_STORE);
+    expect(r.hostname).toBe("0.0.0.0");
+    expect(r.reason).toBe("config.namedPeers");
+  });
+
+  test("trigger 3: MAW_HOST=0.0.0.0 env opt-in", () => {
+    const r = resolveBindHost(EMPTY, { MAW_HOST: "0.0.0.0" }, EMPTY_STORE);
+    expect(r.hostname).toBe("0.0.0.0");
+    expect(r.reason).toBe("MAW_HOST");
+  });
+
+  test("trigger 4: peers.json non-empty", () => {
+    const store = () => ({ peers: { white: { url: "http://white:7777", node: "white", addedAt: "", lastSeen: null } as unknown } });
+    const r = resolveBindHost(EMPTY, EMPTY_ENV, store);
+    expect(r.hostname).toBe("0.0.0.0");
+    expect(r.reason).toBe("peers.json");
+  });
+
+  test("empty peers.json stays on loopback", () => {
+    const r = resolveBindHost(EMPTY, EMPTY_ENV, () => ({ peers: {} }));
+    expect(r.hostname).toBe("127.0.0.1");
+    expect(r.reason).toBe(null);
+  });
+
+  test("MAW_HOST set to a non-0.0.0.0 value (e.g. node name 'white') does not trigger", () => {
+    // MAW_HOST is also used elsewhere as a node-name identifier; only literal
+    // "0.0.0.0" should flip the bind — "white" / "local" / etc. must not.
+    const r = resolveBindHost(EMPTY, { MAW_HOST: "white" }, EMPTY_STORE);
+    expect(r.hostname).toBe("127.0.0.1");
+    expect(r.reason).toBe(null);
+  });
+
+  test("empty peers array does not trigger", () => {
+    const r = resolveBindHost({ peers: [], namedPeers: [] }, EMPTY_ENV, EMPTY_STORE);
+    expect(r.hostname).toBe("127.0.0.1");
+    expect(r.reason).toBe(null);
+  });
+
+  test("peers-store reader that throws falls through to loopback", () => {
+    const thrower = () => { throw new Error("disk read failed"); };
+    const r = resolveBindHost(EMPTY, EMPTY_ENV, thrower);
+    expect(r.hostname).toBe("127.0.0.1");
+    expect(r.reason).toBe(null);
+  });
+
+  test("config.peers takes priority over MAW_HOST (reason attribution)", () => {
+    const r = resolveBindHost({ peers: ["http://x:7777"] }, { MAW_HOST: "0.0.0.0" }, EMPTY_STORE);
+    expect(r.hostname).toBe("0.0.0.0");
+    expect(r.reason).toBe("config.peers");
+  });
+});


### PR DESCRIPTION
## Summary
- Extend `maw serve`'s bind heuristic: the old check only read `config.peers` / `config.namedPeers`, missing two real federation paths — the `~/.maw/peers.json` runtime store and an explicit env opt-in. Refactor the logic into `resolveBindHost()` (new `src/core/bind-host.ts`) with 4 triggers, priority-ordered, each producing an attributable `reason` that we log at startup.
- Update `docker/entrypoint.sh` to export `MAW_HOST=0.0.0.0` before `exec "$@"` so a container whose first `maw peers add` failed (peer not yet up) still binds 0.0.0.0 and can receive retry traffic.
- Add `test/bind-heuristic.test.ts` — 10 pure unit tests covering each of the 4 triggers, empty-array regression guards, `MAW_HOST="white"` (node-name use) *not* triggering, reader-throws falling through to loopback, and priority attribution when multiple triggers apply.

Triggers for 0.0.0.0 (priority order):
1. `config.peers?.length > 0` (existing)
2. `config.namedPeers?.length > 0` (existing)
3. `process.env.MAW_HOST === "0.0.0.0"` (new — explicit opt-in)
4. `~/.maw/peers.json` non-empty (new — federation runtime state)

Unblocks the docker federation harness end-to-end — once this lands, `bash scripts/test-docker-federation.sh` should PASS.

## Test plan
- [x] `bun test test/bind-heuristic.test.ts` — 10 pass, 0 fail
- [x] `bun run test:all` — green (1173 existing tests + 10 new)
- [ ] CI green on this PR
- [ ] `bash scripts/test-docker-federation.sh` end-to-end (followup: task #4)

Closes #616.

Co-Authored-By: bind-heuristic <noreply@anthropic.com>