### PR TITLE
bump: v26.4.18-alpha.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.18-alpha.25",
+  "version": "26.4.18-alpha.26",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
## Summary

Cut **v26.4.18-alpha.26** — 7 commits past alpha.25.

## Changelog

### Features
- **feat(bud)**: `--seed` + `--sync-peers` complete (#620) — closes #588
  - Portable seed from host peers.json, no `~/.maw/` mutation

### Fixes
- **fix(serve)**: bind `0.0.0.0` on `MAW_HOST` env or peers.json presence (#619) — closes #616
- **fix(docker)**: align bun version with lockfile (#614) — closes #607

### Security
- **sec(bud)**: fix `js/indirect-command-line-injection` #96 in `from-repo-fleet.ts` (#618)

### Docs
- **docs(demo)**: asciinema 15-command tour script (#617) — closes #453
- **docs(federation)**: harness verified live end-to-end after #619 (#621)

### Tests
- **test(federation)**: local 2-port `/info` + probe round-trip integration test

## Test plan
- [x] `bun run test:all` — 255 pass, 6 skip, 0 fail (261 tests across 28 files)
- [ ] CI green
- [ ] Lead merges + tags v26.4.18-alpha.26

🤖 Generated with [Claude Code](https://claude.com/claude-code)