### PR TITLE
feat(peers): fail loud on handshake failure — exit non-zero; --allow-unreachable opt-out

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -88,7 +88,7 @@ async function main(): Promise<void> {
           const remaining = args.slice(matchedWords);
           const result = await invokePlugin(dispatch.plugin, { source: "cli", args: remaining });
           if (result.ok && result.output) console.log(result.output);
-          else if (!result.ok) { console.error(result.error); process.exit(1); }
+          else if (!result.ok) { console.error(result.error); process.exit(result.exitCode ?? 1); }
           process.exit(0);
         }
         // #388.2 — unknown command: fuzzy-suggest against the plugin registry.

--- a/src/commands/plugins/peers/index.ts
+++ b/src/commands/plugins/peers/index.ts
@@ -35,7 +35,10 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
   const out = () => logs.join("\n");
   const help = () => [
     "usage: maw peers <add|list|info|probe|remove> [...]",
-    "  add    <alias> <url> [--node <name>]  — register alias (auto-probes /info; loud on failure)",
+    "  add    <alias> <url> [--node <name>] [--allow-unreachable]",
+    "         — register alias (auto-probes /info). Exits non-zero on handshake failure:",
+    "           2=UNKNOWN/BAD_BODY/TLS  3=DNS  4=REFUSED  5=TIMEOUT  6=HTTP_4XX/5XX",
+    "         --allow-unreachable keeps exit 0 even when the probe fails (CI/bootstrap).",
     "  list                                   — tabular list of all peers",
     "  info   <alias>                         — JSON details for one peer (includes lastError if set)",
     "  probe  <alias>                         — re-run /info handshake; updates lastSeen / lastError (#565)",
@@ -59,16 +62,25 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         const alias = positional[1];
         const url = positional[2];
         if (!alias || !url) {
-          return { ok: false, error: "usage: maw peers add <alias> <url> [--node <name>]" };
+          return { ok: false, error: "usage: maw peers add <alias> <url> [--node <name>] [--allow-unreachable]" };
         }
         const nodeIdx = args.indexOf("--node");
         const node = nodeIdx >= 0 ? args[nodeIdx + 1] : undefined;
+        const allowUnreachable = args.includes("--allow-unreachable");
         const res = await impl.cmdAdd({ alias, url, node });
         if (res.overwrote) console.log(`warning: alias "${alias}" already existed — overwriting`);
         console.log(`added ${alias} → ${url}${res.peer.node ? ` (${res.peer.node})` : ""}`);
         if (res.probeError) {
-          const { formatProbeError } = await import("./probe");
+          const { formatProbeError, PROBE_EXIT_CODES } = await import("./probe");
           console.error(formatProbeError(res.probeError, url, alias));
+          if (!allowUnreachable) {
+            return {
+              ok: false,
+              output: out(),
+              error: `peer handshake failed: ${res.probeError.code} — pass --allow-unreachable to bypass`,
+              exitCode: PROBE_EXIT_CODES[res.probeError.code] ?? 2,
+            };
+          }
         }
         return { ok: true, output: out() };
       }

--- a/src/commands/plugins/peers/peers-probe.test.ts
+++ b/src/commands/plugins/peers/peers-probe.test.ts
@@ -91,6 +91,25 @@ describe("PROBE_HINTS", () => {
   });
 });
 
+describe("PROBE_EXIT_CODES", () => {
+  it("maps every error family to a non-zero exit code", async () => {
+    const { PROBE_EXIT_CODES } = await import("./probe");
+    expect(PROBE_EXIT_CODES.DNS).toBe(3);
+    expect(PROBE_EXIT_CODES.REFUSED).toBe(4);
+    expect(PROBE_EXIT_CODES.TIMEOUT).toBe(5);
+    expect(PROBE_EXIT_CODES.HTTP_4XX).toBe(6);
+    expect(PROBE_EXIT_CODES.HTTP_5XX).toBe(6);
+    expect(PROBE_EXIT_CODES.TLS).toBe(2);
+    expect(PROBE_EXIT_CODES.BAD_BODY).toBe(2);
+    expect(PROBE_EXIT_CODES.UNKNOWN).toBe(2);
+    // No mapping should be 0 or 1 — that would mean "success" or "generic
+    // failure" and defeat the fail-loud point.
+    for (const v of Object.values(PROBE_EXIT_CODES)) {
+      expect(v).toBeGreaterThanOrEqual(2);
+    }
+  });
+});
+
 describe("formatProbeError", () => {
   it("renders host, error, hint, retry line", async () => {
     const { formatProbeError } = await import("./probe");
@@ -186,19 +205,46 @@ describe("dispatcher — probe subcommand + loud add", () => {
     expect(res.error).toContain('peer "ghost" not found');
   });
 
-  it("add on unreachable host still returns ok:true but writes warning to output", async () => {
+  it("add on unreachable host → ok:false with DNS-family exitCode (fail loud)", async () => {
     const { default: handler } = await import("./index");
     const res = await handler({
       source: "cli",
       args: ["add", "g", "http://does-not-exist.invalid:9999"],
     });
-    expect(res.ok).toBe(true);
+    expect(res.ok).toBe(false);
+    expect(res.exitCode).toBe(3); // DNS
+    expect(res.error).toContain("peer handshake failed: DNS");
+    expect(res.error).toContain("--allow-unreachable");
+    // Loud block + "added" line still end up in captured output.
     expect(res.output).toContain("added g");
-    // Loud block is on stderr, which the dispatcher captures into the
-    // same logs buffer — both streams end up in res.output.
     expect(res.output).toContain("peer handshake failed");
-    expect(res.output).toContain("DNS");
     expect(res.output).toContain("maw peers probe g");
+  });
+
+  it("add --allow-unreachable on unreachable host → ok:true (back-compat opt-out)", async () => {
+    const { default: handler } = await import("./index");
+    const res = await handler({
+      source: "cli",
+      args: ["add", "g", "http://does-not-exist.invalid:9999", "--allow-unreachable"],
+    });
+    expect(res.ok).toBe(true);
+    expect(res.exitCode).toBeUndefined();
+    expect(res.output).toContain("added g");
+    // Warning block still shown — silence requires a separate flag.
+    expect(res.output).toContain("peer handshake failed");
+  });
+
+  it("add still persists the peer even when handshake fails (ok:false)", async () => {
+    const { default: handler } = await import("./index");
+    const res = await handler({
+      source: "cli",
+      args: ["add", "g", "http://does-not-exist.invalid:9999"],
+    });
+    expect(res.ok).toBe(false);
+    // The peer was still written (so `maw peers probe g` can retry later).
+    const info = await handler({ source: "cli", args: ["info", "g"] });
+    expect(info.ok).toBe(true);
+    expect(info.output).toContain("lastError");
   });
 
   it("info output contains lastError after a failed add", async () => {

--- a/src/commands/plugins/peers/peers.test.ts
+++ b/src/commands/plugins/peers/peers.test.ts
@@ -241,8 +241,11 @@ describe("peers dispatcher (index.ts)", () => {
   });
 
   it("add then list through dispatcher", async () => {
+    // http://w.local doesn't resolve on most hosts; use --allow-unreachable
+    // so this test stays focused on the add→list flow rather than the
+    // fail-loud exit behavior (covered in peers-probe.test.ts).
     const { default: handler } = await import("./index");
-    const add = await handler({ source: "cli", args: ["add", "w", "http://w.local", "--node", "white"] });
+    const add = await handler({ source: "cli", args: ["add", "w", "http://w.local", "--node", "white", "--allow-unreachable"] });
     expect(add.ok).toBe(true);
     expect(add.output).toContain("added w");
     const list = await handler({ source: "cli", args: ["list"] });

--- a/src/commands/plugins/peers/probe.ts
+++ b/src/commands/plugins/peers/probe.ts
@@ -17,6 +17,30 @@ export interface ProbeResult {
   error?: LastError;
 }
 
+/**
+ * Exit code per probe error family — fail-loud for scripts.
+ *
+ * Scripts that chain `maw peers add` with subsequent commands need a
+ * non-zero exit to branch on. The old `ok:true + ⚠ block on stderr`
+ * behavior was easy to miss in CI logs.
+ *
+ *   2 — generic/structural (UNKNOWN, BAD_BODY, TLS)
+ *   3 — DNS (host does not resolve)
+ *   4 — REFUSED (resolved but port closed)
+ *   5 — TIMEOUT (no response in 2s)
+ *   6 — HTTP_4XX / HTTP_5XX (peer responded but /info failed)
+ */
+export const PROBE_EXIT_CODES: Record<ProbeErrorCode, number> = {
+  DNS: 3,
+  REFUSED: 4,
+  TIMEOUT: 5,
+  HTTP_4XX: 6,
+  HTTP_5XX: 6,
+  TLS: 2,
+  BAD_BODY: 2,
+  UNKNOWN: 2,
+};
+
 /** Actionable hint per error code — shown in CLI output. */
 export const PROBE_HINTS: Record<ProbeErrorCode, string> = {
   DNS: "Host does not resolve. Check /etc/hosts, DNS, or VPN.",

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -91,4 +91,10 @@ export interface InvokeResult {
   ok: boolean;
   output?: string;
   error?: string;
+  /**
+   * Non-zero exit code for `ok: false` results. When unset, the CLI
+   * defaults to exit 1 on failure. Plugins use this to distinguish
+   * failure modes for scripts (e.g. handshake vs DNS vs refused).
+   */
+  exitCode?: number;
 }


### PR DESCRIPTION
## Summary
- Closes Task #10 — mesh-child dogfood rec #4: \`maw peers add\` was exit-0 + ⚠ on handshake failure, easy to miss in CI.
- Now exits with a code encoding the error family so scripts can branch on it:
  - \`2\` — UNKNOWN / BAD_BODY / TLS
  - \`3\` — DNS (host does not resolve)
  - \`4\` — REFUSED (port closed)
  - \`5\` — TIMEOUT (no /info response in 2s)
  - \`6\` — HTTP_4XX / HTTP_5XX (peer responded but /info broke)
- Peer is still persisted with \`lastError\` (so \`maw peers probe <alias>\` can retry later) — only the exit code + \`ok:false\` are new.
- Back-compat: \`--allow-unreachable\` preserves the old exit-0 behavior for CI/bootstrap flows that register a peer before it's running.

## Wiring
- \`src/plugin/types.ts\`: add \`exitCode?: number\` to \`InvokeResult\`.
- \`src/cli.ts\`: honor \`result.exitCode\` on \`ok:false\` (defaults to \`1\` when unset — no behavior change for other plugins).
- \`src/commands/plugins/peers/probe.ts\`: new \`PROBE_EXIT_CODES\` map.
- \`src/commands/plugins/peers/index.ts\`: \`add\` dispatcher returns structured failure unless \`--allow-unreachable\`.
- \`src/commands/plugins/peers/peers-probe.test.ts\`: updated fail-loud test + added \`--allow-unreachable\` + exit-code-map coverage.
- \`src/commands/plugins/peers/peers.test.ts\`: one existing test threaded through \`--allow-unreachable\` (flow was add→list, not fail behavior).

## Test plan
- [x] \`bun test src/commands/plugins/peers/\` — 54/54 pass
- [x] \`bun run test:all\` — 258 pass / 6 skip / 0 fail across 28 files + 69/69 plugin mock-smoke
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)