### PR TITLE
fix(bud): use ghq root for post-clone scaffolding path (closes #630)

### DIFF
--- a/src/commands/plugins/bud/bud-repo.test.ts
+++ b/src/commands/plugins/bud/bud-repo.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+// Regression for #630 — config.ghqRoot can drift from the real `ghq root`
+// (e.g. stale override: "/tmp/nope"). When that happens, ensureBudRepo must
+// trust ghq's landing dir, not the predicted path.
+
+type ExecCall = string;
+const execCalls: ExecCall[] = [];
+// Sequential return values for successive `ghq list` calls.
+let ghqListQueue: string[] = [];
+
+mock.module("../../../sdk", () => ({
+  hostExec: async (cmd: string) => {
+    execCalls.push(cmd);
+    if (cmd.startsWith("ghq list")) return ghqListQueue.shift() ?? "";
+    if (cmd.startsWith("gh repo view")) return ""; // triggers create path
+    if (cmd.startsWith("gh repo create")) return "";
+    if (cmd.startsWith("ghq get")) return "";
+    return "";
+  },
+}));
+
+describe("ensureBudRepo (#630)", () => {
+  beforeEach(() => {
+    execCalls.length = 0;
+    ghqListQueue = [];
+  });
+
+  it("returns ghq's actual clone path when it diverges from predicted", async () => {
+    const actualClone = mkdtempSync(join(tmpdir(), "maw-bud-real-clone-"));
+    // First ghq list = pre-clone check (empty), second = post-clone resolve.
+    ghqListQueue = ["", actualClone + "\n"];
+
+    const { ensureBudRepo } = await import("./bud-repo");
+    const predicted = "/tmp/nope/Soul-Brews-Studio/widget-oracle";
+
+    try {
+      const resolved = await ensureBudRepo(
+        "Soul-Brews-Studio/widget-oracle",
+        predicted,
+        "widget-oracle",
+        "Soul-Brews-Studio",
+      );
+
+      expect(resolved).toBe(actualClone);
+      expect(resolved).not.toBe(predicted);
+      expect(execCalls.some(c => c.startsWith("ghq get github.com/Soul-Brews-Studio/widget-oracle"))).toBe(true);
+      expect(execCalls.some(c => c.includes("ghq list --exact --full-path"))).toBe(true);
+    } finally {
+      rmSync(actualClone, { recursive: true, force: true });
+    }
+  });
+
+  it("throws if ghq list cannot find the repo after ghq get", async () => {
+    ghqListQueue = ["", ""]; // pre-check empty, post-clone also empty
+    const { ensureBudRepo } = await import("./bud-repo");
+
+    await expect(
+      ensureBudRepo(
+        "Soul-Brews-Studio/ghost-oracle",
+        "/tmp/nope/Soul-Brews-Studio/ghost-oracle",
+        "ghost-oracle",
+        "Soul-Brews-Studio",
+      ),
+    ).rejects.toThrow(/ghq get succeeded but ghq list cannot find/);
+  });
+
+  it("short-circuits when repo is already cloned (via ghq) at a non-predicted path", async () => {
+    const preExisting = mkdtempSync(join(tmpdir(), "maw-bud-pre-clone-"));
+    ghqListQueue = [preExisting + "\n"];
+    const { ensureBudRepo } = await import("./bud-repo");
+
+    try {
+      const resolved = await ensureBudRepo(
+        "Soul-Brews-Studio/existing-oracle",
+        "/tmp/nope/Soul-Brews-Studio/existing-oracle",
+        "existing-oracle",
+        "Soul-Brews-Studio",
+      );
+
+      expect(resolved).toBe(preExisting);
+      // No gh/ghq-get should run when a pre-existing clone is found
+      expect(execCalls.some(c => c.startsWith("gh repo create"))).toBe(false);
+      expect(execCalls.some(c => c.startsWith("ghq get"))).toBe(false);
+    } finally {
+      rmSync(preExisting, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/commands/plugins/bud/bud-repo.ts
+++ b/src/commands/plugins/bud/bud-repo.ts
@@ -2,18 +2,43 @@ import { hostExec } from "../../../sdk";
 import { existsSync } from "fs";
 
 /**
+ * Ask ghq where it parked a repo. Authoritative over `config.ghqRoot` —
+ * which can drift (stale overrides, cross-host config sync). #630
+ */
+async function resolveGhqPath(slug: string): Promise<string | null> {
+  try {
+    const out = await hostExec(`ghq list --exact --full-path github.com/${slug}`);
+    const first = out.split("\n").map(s => s.trim()).find(Boolean);
+    return first && existsSync(first) ? first : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Step 1: Ensure the oracle's GitHub repo exists and is cloned locally.
  * Idempotent — skips creation/clone if already present.
+ *
+ * Returns the ACTUAL clone path reported by ghq, not the predicted
+ * `budRepoPath`. The two diverge when `config.ghqRoot` is stale or
+ * overridden (#630) — ghq always honors its own `ghq root`, so trust it.
  */
 export async function ensureBudRepo(
   budRepoSlug: string,
   budRepoPath: string,
   budRepoName: string,
   org: string,
-): Promise<void> {
+): Promise<string> {
   if (existsSync(budRepoPath)) {
     console.log(`  \x1b[90m○\x1b[0m repo already exists: ${budRepoPath}`);
-    return;
+    return budRepoPath;
+  }
+  // Pre-check ghq in case the repo is already cloned but at a different path
+  // than config.ghqRoot predicts — avoid re-creating on GitHub.
+  const preExisting = await resolveGhqPath(budRepoSlug);
+  if (preExisting) {
+    console.log(`  \x1b[90m○\x1b[0m repo already cloned (via ghq): ${preExisting}`);
+    return preExisting;
   }
   console.log(`  \x1b[36m⏳\x1b[0m creating repo: ${budRepoSlug}...`);
   try {
@@ -37,15 +62,23 @@ export async function ensureBudRepo(
     }
   }
   await hostExec(`ghq get github.com/${budRepoSlug}`);
-  // #421 — verify landing path matches stated org. ghq honors the URL so this
-  // should always pass; if it doesn't, a stale ghq entry or reroute is masking
-  // the real location. Fail loudly rather than let wake resolve to the wrong org.
-  if (!existsSync(budRepoPath)) {
+  // #630 — trust `ghq list`, not `config.ghqRoot`. The config value can be
+  // stale or overridden (observed: ghqRoot="/tmp/nope" while real ghq root was
+  // /home/neo/Code), which stranded the bud mid-scaffold. Resolve the real
+  // landing path and use that for all downstream ψ/ + fleet + wake steps.
+  const actualPath = await resolveGhqPath(budRepoSlug);
+  if (!actualPath) {
     throw new Error(
-      `clone landed outside expected path — expected ${budRepoPath} but not found on disk after ghq get.\n` +
+      `ghq get succeeded but ghq list cannot find github.com/${budRepoSlug}.\n` +
       `  Check: ghq list | grep ${budRepoName}\n` +
-      `  The --org flag may be shadowed by a stale clone in another org.`,
+      `  This indicates a broken ghq install or a reroute intercepting the URL.`,
     );
   }
-  console.log(`  \x1b[32m✓\x1b[0m cloned via ghq → ${budRepoPath}`);
+  if (actualPath !== budRepoPath) {
+    console.log(`  \x1b[33m⚠\x1b[0m config.ghqRoot predicted ${budRepoPath}`);
+    console.log(`  \x1b[33m  but ghq parked the clone at ${actualPath}\x1b[0m`);
+    console.log(`  \x1b[90m  using ghq's location — run 'maw init --force' to refresh config\x1b[0m`);
+  }
+  console.log(`  \x1b[32m✓\x1b[0m cloned via ghq → ${actualPath}`);
+  return actualPath;
 }

--- a/src/commands/plugins/bud/impl.ts
+++ b/src/commands/plugins/bud/impl.ts
@@ -97,7 +97,10 @@ export async function cmdBud(name: string, opts: BudOpts = {}) {
 
   const budRepoName = `${name}-oracle`;
   const budRepoSlug = `${org}/${budRepoName}`;
-  const budRepoPath = join(ghqRoot, org, budRepoName);
+  // Predicted path — may drift from ghq's actual landing dir when
+  // config.ghqRoot is stale (#630). ensureBudRepo returns the authoritative
+  // post-clone path; use that for all scaffolding below.
+  const predictedRepoPath = join(ghqRoot, org, budRepoName);
 
   if (opts.root) {
     console.log(`\n  \x1b[36m🌱 Root Bud\x1b[0m — ${name} (no parent lineage)\n`);
@@ -107,7 +110,7 @@ export async function cmdBud(name: string, opts: BudOpts = {}) {
 
   if (opts.dryRun) {
     console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would create repo: ${budRepoSlug}`);
-    console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would init ψ/ vault at: ${budRepoPath}`);
+    console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would init ψ/ vault at: ${predictedRepoPath}`);
     console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would generate CLAUDE.md`);
     console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would create fleet config`);
     if (opts.seed && parentName) {
@@ -125,8 +128,8 @@ export async function cmdBud(name: string, opts: BudOpts = {}) {
     return;
   }
 
-  // 1. Create oracle repo
-  await ensureBudRepo(budRepoSlug, budRepoPath, budRepoName, org);
+  // 1. Create oracle repo — returns the ACTUAL clone path per ghq (#630).
+  const budRepoPath = await ensureBudRepo(budRepoSlug, predictedRepoPath, budRepoName, org);
 
   // 2-4.5. Initialize vault, CLAUDE.md, fleet config, birth note
   const psiDir = initVault(budRepoPath);

--- a/test/isolated/bud-org-flag.test.ts
+++ b/test/isolated/bud-org-flag.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, mock, beforeEach } from "bun:test";
-import { mkdtempSync, mkdirSync, rmSync } from "fs";
+import { mkdtempSync, mkdirSync, rmSync, existsSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -34,6 +34,8 @@ describe("maw bud --org — #421 propagation", () => {
         if (cmd.startsWith("gh repo view")) throw new Error("not found");
         // ghq get lands the clone at budRepoPath (the good-path case)
         if (cmd.startsWith("ghq get")) mkdirSync(budRepoPath, { recursive: true });
+        // ghq list reports whatever exists on disk (mirrors real ghq).
+        if (cmd.startsWith("ghq list")) return existsSync(budRepoPath) ? `${budRepoPath}\n` : "";
         return "";
       },
     }));
@@ -49,11 +51,15 @@ describe("maw bud --org — #421 propagation", () => {
     rmSync(tmp, { recursive: true, force: true });
   });
 
-  test("ensureBudRepo FAILS LOUDLY when ghq lands the clone outside the expected path (stale-org reroute)", async () => {
+  test("ensureBudRepo FAILS LOUDLY when ghq list cannot find the clone after ghq get (#630)", async () => {
+    // Fixed in #630: we now trust `ghq list` as the post-clone source of truth.
+    // This test asserts the loud failure when ghq get "succeeds" but ghq list
+    // can't find the repo afterward (broken install / intercepted URL).
     mock.module("../../src/sdk", () => ({
       hostExec: async (cmd: string) => {
         if (cmd.startsWith("gh repo view")) throw new Error("not found");
-        return ""; // ghq "succeeds" but we never create the expected dir
+        // ghq list always empty — simulates broken ghq or URL reroute.
+        return "";
       },
     }));
 
@@ -63,7 +69,7 @@ describe("maw bud --org — #421 propagation", () => {
     const { ensureBudRepo } = await import("../../src/commands/plugins/bud/bud-repo");
     await expect(
       ensureBudRepo("laris-co/god-line-oracle", budRepoPath, "god-line-oracle", "laris-co"),
-    ).rejects.toThrow(/clone landed outside expected path/);
+    ).rejects.toThrow(/ghq get succeeded but ghq list cannot find/);
 
     rmSync(tmp, { recursive: true, force: true });
   });

--- a/test/isolated/bud-repo.test.ts
+++ b/test/isolated/bud-repo.test.ts
@@ -25,7 +25,7 @@ import { tmpdir } from "os";
 
 interface ExecResponse {
   match?: RegExp;        // cmd substring/regex to match
-  result?: string;       // string to resolve with
+  result?: string | (() => string); // static string or dynamic callback (for state-dependent stubs)
   error?: string;        // message to reject with
   sideEffect?: () => void; // run before resolving (e.g. mkdirSync to simulate `ghq get` landing)
 }
@@ -39,11 +39,18 @@ const mockExec = async (cmd: string): Promise<string> => {
     if (r.match && r.match.test(cmd)) {
       if (r.error) throw new Error(r.error);
       r.sideEffect?.();
-      return r.result ?? "";
+      return typeof r.result === "function" ? r.result() : (r.result ?? "");
     }
   }
   return "";
 };
+
+// Helper: stub `ghq list --exact --full-path` to reflect whether the clone
+// has happened yet. Returns `path` once `path` exists on disk, empty before.
+// Mirrors how real ghq behaves — it only lists repos it knows about.
+function stubGhqListTracking(path: string): ExecResponse {
+  return { match: /^ghq list /, result: () => existsSync(path) ? `${path}\n` : "" };
+}
 
 mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
   hostExec: mockExec,
@@ -92,6 +99,7 @@ describe("ensureBudRepo — gh repo view pre-check", () => {
   test("view returns matching repo name → skips create, still clones via ghq", async () => {
     const missingPath = join(tmpBase, "view-hit");
     execResponses = [
+      stubGhqListTracking(missingPath),
       { match: /^gh repo view /, result: `{"name":"view-hit-oracle"}` },
       { match: /^ghq get /, sideEffect: () => mkdirSync(missingPath, { recursive: true }) },
     ];
@@ -113,6 +121,7 @@ describe("ensureBudRepo — gh repo view pre-check", () => {
   test("view throws (.catch swallows) → proceeds to create → then ghq get", async () => {
     const missingPath = join(tmpBase, "view-miss");
     execResponses = [
+      stubGhqListTracking(missingPath),
       { match: /^gh repo view /, error: "not found" },
       // No response for `gh repo create` → default "" which means "success".
       { match: /^ghq get /, sideEffect: () => mkdirSync(missingPath, { recursive: true }) },
@@ -144,6 +153,7 @@ describe("ensureBudRepo — gh repo view pre-check", () => {
     // repo payload must NOT be treated as a hit.
     const missingPath = join(tmpBase, "view-other");
     execResponses = [
+      stubGhqListTracking(missingPath),
       { match: /^gh repo view /, result: `{"name":"some-other-repo"}` },
       { match: /^ghq get /, sideEffect: () => mkdirSync(missingPath, { recursive: true }) },
     ];
@@ -163,6 +173,7 @@ describe("ensureBudRepo — gh repo create error branches", () => {
   test('"already exists" error is swallowed, ghq get still runs', async () => {
     const missingPath = join(tmpBase, "create-already");
     execResponses = [
+      stubGhqListTracking(missingPath),
       { match: /^gh repo view /, error: "not found" },
       { match: /^gh repo create /, error: "repository already exists on remote" },
       { match: /^ghq get /, sideEffect: () => mkdirSync(missingPath, { recursive: true }) },
@@ -265,6 +276,7 @@ describe("ensureBudRepo — ghq clone command shape", () => {
   test("clone command is always `ghq get github.com/<slug>` (regression guard)", async () => {
     const missingPath = join(tmpBase, "clone-shape");
     execResponses = [
+      stubGhqListTracking(missingPath),
       { match: /^gh repo view /, error: "not found" },
       { match: /^ghq get /, sideEffect: () => mkdirSync(missingPath, { recursive: true }) },
     ];


### PR DESCRIPTION
## Summary

- `maw bud` now trusts `ghq list --exact --full-path` (not `config.ghqRoot`) to resolve where a freshly-cloned oracle repo landed
- Fixes a stranding bug where a stale/overridden `config.ghqRoot` made `ensureBudRepo` bail *after* creating the GitHub repo + cloning locally — leaving the bud with no ψ/, no CLAUDE.md, no fleet entry
- Preserves the #421 loud-fail guard; just shifts from "expected-path existsSync" to "ghq actually knows about it"

## Root cause

`src/commands/plugins/bud/impl.ts:100` computed `budRepoPath = join(ghqRoot, org, budRepoName)` from `config.ghqRoot`, then `bud-repo.ts:43` required that exact directory to exist after `ghq get`. But `ghq get` always writes to its own `ghq root` — when the two disagreed (observed: `ghqRoot: "/tmp/nope"` in config while real `ghq root` = `/home/neo/Code`), the post-clone check always failed.

## Fix

- Add `resolveGhqPath(slug)` — thin wrapper over `ghq list --exact --full-path github.com/<slug>`
- `ensureBudRepo` now:
  - pre-checks `ghq list` before clone (catches "already cloned at non-predicted path")
  - returns the **actual** landing path after `ghq get`
  - throws `"ghq get succeeded but ghq list cannot find …"` if ghq itself doesn't see the repo (broken install / URL reroute)
- `cmdBud` captures the returned path and threads it through `initVault`, `generateClaudeMd`, `finalizeBud`, and `signalOnBirth` — all scaffolding lands in the real dir
- If predicted ≠ actual, we log a loud ⚠ hint to `maw init --force`

## Test plan

- [x] New `src/commands/plugins/bud/bud-repo.test.ts`: 3 cases covering divergent-path, missing-post-clone, and pre-existing-clone branches
- [x] Updated `test/isolated/bud-repo.test.ts`: stubs `ghq list` alongside `ghq get` sideEffect so the 7 pre-existing branches still exercise their real paths
- [x] Updated `test/isolated/bud-org-flag.test.ts`: #421 loud-fail assertion folds into the new error message
- [x] `bun run test:all` — 69/69 files pass (264 tests, 0 failures)

Closes #630

🤖 ตอบโดย bud-bug-fixer จาก [Human] → mawjs-oracle

🤖 Generated with [Claude Code](https://claude.com/claude-code)