### PR TITLE
feat(plugin): auto-link maw-js on --link install (closes #641)

### DIFF
--- a/src/commands/plugins/plugin/install-handlers.ts
+++ b/src/commands/plugins/plugin/install-handlers.ts
@@ -3,10 +3,10 @@
  * installFromDir / installFromTarball / installFromUrl
  */
 
-import { existsSync, lstatSync, mkdtempSync, readFileSync, readlinkSync, rmSync, statSync, symlinkSync, writeFileSync } from "fs";
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readlinkSync, rmSync, statSync, symlinkSync, unlinkSync, writeFileSync } from "fs";
 import { spawnSync } from "child_process";
 import { tmpdir } from "os";
-import { basename, join } from "path";
+import { basename, join, resolve } from "path";
 import { formatSdkMismatchError, runtimeSdkVersion, satisfies } from "../../../plugin/registry";
 import { installRoot, removeExisting } from "./install-source-detect";
 import { extractTarball, downloadTarball, verifyArtifactHash, verifyArtifactHashAgainst } from "./install-extraction";
@@ -59,6 +59,53 @@ function refuseExistingInstall(dest: string, incoming: string, name: string): ne
   );
 }
 
+/**
+ * #641 — Auto-link `maw-js` into the plugin source's `node_modules/` on
+ * `--link` install so `import "maw-js/sdk"` resolves without per-repo setup.sh.
+ *
+ * Resolution chain for the maw-js root:
+ *   1. `$MAW_JS_PATH` env override (used by tests + unusual layouts)
+ *   2. Walk up from this file (src/commands/plugins/plugin/) four levels →
+ *      the running maw-js repo root. That's where `package.json#name="maw-js"`
+ *      with `exports["./sdk"]` lives, which is what bun needs to resolve.
+ *
+ * Idempotent: if `<srcDir>/node_modules/maw-js` is already a symlink to the
+ * resolved root, no-op. If it points elsewhere, replace. If it's a real
+ * directory or file, leave it alone — the operator put something there
+ * intentionally.
+ */
+function resolveMawJsRoot(): string {
+  if (process.env.MAW_JS_PATH) return process.env.MAW_JS_PATH;
+  // this file: <mawJsRoot>/src/commands/plugins/plugin/install-handlers.ts
+  return resolve(import.meta.dir, "..", "..", "..", "..");
+}
+
+export function ensurePluginMawJsLink(srcDir: string): void {
+  const mawJsRoot = resolveMawJsRoot();
+  const nodeModulesDir = join(srcDir, "node_modules");
+  const target = join(nodeModulesDir, "maw-js");
+
+  let existing: import("fs").Stats | undefined;
+  try { existing = lstatSync(target); } catch { /* absent */ }
+
+  if (existing) {
+    if (existing.isSymbolicLink()) {
+      try {
+        const linkTarget = readlinkSync(target);
+        const resolved = resolve(nodeModulesDir, linkTarget);
+        if (resolved === mawJsRoot) return; // already correct
+      } catch { /* dangling — fall through to replace */ }
+      unlinkSync(target);
+    } else {
+      // Real directory or file — respect operator intent, don't clobber.
+      return;
+    }
+  }
+
+  mkdirSync(nodeModulesDir, { recursive: true });
+  symlinkSync(mawJsRoot, target, "dir");
+}
+
 export async function installFromDir(
   srcDir: string,
   opts: { force?: boolean; weight?: number } = {},
@@ -93,6 +140,10 @@ export async function installFromDir(
 
   removeExisting(dest);
   symlinkSync(srcDir, dest, "dir");
+
+  // #641 — arrange `maw-js/sdk` resolution from the plugin's perspective so
+  // the author never has to run a per-repo setup.sh.
+  ensurePluginMawJsLink(srcDir);
 
   printInstallSuccess(manifest!, dest, "linked (dev)");
 }

--- a/src/commands/plugins/plugin/install-impl.ts
+++ b/src/commands/plugins/plugin/install-impl.ts
@@ -29,7 +29,7 @@ import { basename } from "path";
 export { installRoot, detectMode, ensureInstallRoot, removeExisting } from "./install-source-detect";
 export { extractTarball, downloadTarball, verifyArtifactHash } from "./install-extraction";
 export { readManifest, shortHash, printInstallSuccess } from "./install-manifest-helpers";
-export { installFromDir, installFromTarball, installFromUrl } from "./install-handlers";
+export { installFromDir, installFromTarball, installFromUrl, ensurePluginMawJsLink } from "./install-handlers";
 
 // TODO(phase-b): trust-boundary enforcement. First tarball installed from a
 // non-first-party URL should flip capability enforcement on for that plugin.

--- a/test/isolated/plugin-install-auto-link-maw-js.test.ts
+++ b/test/isolated/plugin-install-auto-link-maw-js.test.ts
@@ -1,0 +1,175 @@
+/**
+ * #641 — On `maw plugin install <dir> --link`, the installer arranges
+ * `maw-js/sdk` resolution automatically by planting `node_modules/maw-js`
+ * in the plugin source directory (symlinked to the running maw-js root).
+ *
+ * These tests exercise `ensurePluginMawJsLink` directly (unit) plus an
+ * end-to-end path via `cmdPluginInstall` that asserts the link lands.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  existsSync, lstatSync, mkdirSync, mkdtempSync,
+  readlinkSync, realpathSync, rmSync, symlinkSync, writeFileSync,
+} from "fs";
+import { join, resolve } from "path";
+import { tmpdir } from "os";
+import { createHash } from "crypto";
+import {
+  cmdPluginInstall,
+  ensurePluginMawJsLink,
+} from "../../src/commands/plugins/plugin/install-impl";
+import { __resetDiscoverStateForTests, resetDiscoverCache } from "../../src/plugin/registry";
+
+const created: string[] = [];
+let origPluginsDir: string | undefined;
+let origPluginsLock: string | undefined;
+let origMawJsPath: string | undefined;
+
+function tmpDir(prefix = "maw-autolink-test-"): string {
+  const d = mkdtempSync(join(tmpdir(), prefix));
+  created.push(d);
+  return d;
+}
+
+function buildFixture(): { dir: string } {
+  const dir = tmpDir("maw-fixture-");
+  const src = "export default () => ({ ok: true });\n";
+  const sha = "sha256:" + createHash("sha256").update(src).digest("hex");
+  writeFileSync(join(dir, "index.js"), src);
+  writeFileSync(
+    join(dir, "plugin.json"),
+    JSON.stringify({
+      name: "hello", version: "0.1.0", sdk: "*",
+      target: "js", capabilities: [],
+      artifact: { path: "./index.js", sha256: sha },
+    }, null, 2),
+  );
+  return { dir };
+}
+
+/** A minimal fake maw-js root — a directory with package.json#name="maw-js".
+ *  We override $MAW_JS_PATH so the resolver picks this up instead of the
+ *  real running repo (keeps the test hermetic). */
+function fakeMawJsRoot(): string {
+  const root = tmpDir("fake-maw-js-");
+  writeFileSync(
+    join(root, "package.json"),
+    JSON.stringify({ name: "maw-js", version: "0.0.0" }, null, 2),
+  );
+  return root;
+}
+
+beforeEach(() => {
+  origPluginsDir = process.env.MAW_PLUGINS_DIR;
+  origPluginsLock = process.env.MAW_PLUGINS_LOCK;
+  origMawJsPath = process.env.MAW_JS_PATH;
+  const home = tmpDir("maw-home-");
+  process.env.MAW_PLUGINS_DIR = join(home, "plugins");
+  process.env.MAW_PLUGINS_LOCK = join(home, "plugins.lock");
+  __resetDiscoverStateForTests();
+  resetDiscoverCache();
+});
+
+afterEach(() => {
+  if (origPluginsDir !== undefined) process.env.MAW_PLUGINS_DIR = origPluginsDir;
+  else delete process.env.MAW_PLUGINS_DIR;
+  if (origPluginsLock !== undefined) process.env.MAW_PLUGINS_LOCK = origPluginsLock;
+  else delete process.env.MAW_PLUGINS_LOCK;
+  if (origMawJsPath !== undefined) process.env.MAW_JS_PATH = origMawJsPath;
+  else delete process.env.MAW_JS_PATH;
+  for (const d of created.splice(0)) {
+    if (existsSync(d)) rmSync(d, { recursive: true, force: true });
+  }
+});
+
+describe("ensurePluginMawJsLink — #641", () => {
+  test("creates node_modules/maw-js symlink pointing at MAW_JS_PATH", () => {
+    const mawJs = fakeMawJsRoot();
+    process.env.MAW_JS_PATH = mawJs;
+    const plugin = tmpDir("plugin-src-");
+
+    ensurePluginMawJsLink(plugin);
+
+    const link = join(plugin, "node_modules", "maw-js");
+    expect(lstatSync(link).isSymbolicLink()).toBe(true);
+    expect(realpathSync(link)).toBe(realpathSync(mawJs));
+  });
+
+  test("idempotent — second call on an already-correct symlink is a no-op", () => {
+    const mawJs = fakeMawJsRoot();
+    process.env.MAW_JS_PATH = mawJs;
+    const plugin = tmpDir("plugin-src-");
+
+    ensurePluginMawJsLink(plugin);
+    const first = readlinkSync(join(plugin, "node_modules", "maw-js"));
+    ensurePluginMawJsLink(plugin);
+    const second = readlinkSync(join(plugin, "node_modules", "maw-js"));
+
+    expect(second).toBe(first);
+  });
+
+  test("replaces a stale symlink pointing elsewhere", () => {
+    const mawJs = fakeMawJsRoot();
+    const stale = tmpDir("stale-maw-js-");
+    process.env.MAW_JS_PATH = mawJs;
+    const plugin = tmpDir("plugin-src-");
+    const nm = join(plugin, "node_modules");
+    mkdirSync(nm, { recursive: true });
+    symlinkSync(stale, join(nm, "maw-js"), "dir");
+
+    ensurePluginMawJsLink(plugin);
+
+    expect(realpathSync(join(nm, "maw-js"))).toBe(realpathSync(mawJs));
+  });
+
+  test("leaves a real directory alone (operator intent wins)", () => {
+    const mawJs = fakeMawJsRoot();
+    process.env.MAW_JS_PATH = mawJs;
+    const plugin = tmpDir("plugin-src-");
+    const nm = join(plugin, "node_modules");
+    mkdirSync(join(nm, "maw-js"), { recursive: true });
+    writeFileSync(join(nm, "maw-js", "marker.txt"), "real");
+
+    ensurePluginMawJsLink(plugin);
+
+    const t = lstatSync(join(nm, "maw-js"));
+    expect(t.isSymbolicLink()).toBe(false);
+    expect(t.isDirectory()).toBe(true);
+    expect(existsSync(join(nm, "maw-js", "marker.txt"))).toBe(true);
+  });
+
+  test("no MAW_JS_PATH → falls back to the running maw-js root", () => {
+    delete process.env.MAW_JS_PATH;
+    const plugin = tmpDir("plugin-src-");
+
+    ensurePluginMawJsLink(plugin);
+
+    const link = join(plugin, "node_modules", "maw-js");
+    expect(lstatSync(link).isSymbolicLink()).toBe(true);
+    // Target should resolve to a directory whose package.json declares "maw-js".
+    const target = realpathSync(link);
+    const pkg = JSON.parse(
+      require("fs").readFileSync(join(target, "package.json"), "utf8"),
+    );
+    expect(pkg.name).toBe("maw-js");
+  });
+});
+
+describe("cmdPluginInstall --link — #641 e2e", () => {
+  test("planting succeeds after install and survives a re-install", async () => {
+    const mawJs = fakeMawJsRoot();
+    process.env.MAW_JS_PATH = mawJs;
+    const { dir } = buildFixture();
+
+    await cmdPluginInstall([dir, "--link"]);
+
+    const link = join(dir, "node_modules", "maw-js");
+    expect(lstatSync(link).isSymbolicLink()).toBe(true);
+    expect(realpathSync(link)).toBe(realpathSync(mawJs));
+
+    // Re-install with --force should preserve the link.
+    await cmdPluginInstall([dir, "--link", "--force"]);
+    expect(realpathSync(link)).toBe(realpathSync(mawJs));
+  });
+});


### PR DESCRIPTION
## Summary

- `maw plugin install <dir> --link` now plants `<srcDir>/node_modules/maw-js` pointing at the running maw-js root, so `import "maw-js/sdk"` resolves from the plugin's perspective with zero per-repo setup.sh.
- Resolution chain: `$MAW_JS_PATH` env override → walk up from `import.meta.dir` four levels to the maw-js repo root.
- Idempotent: correct symlink is a no-op; stale symlink is replaced; real directory at the target path is left alone (operator intent wins).

## Closes

- Closes #641 — production fix for the `Cannot find module 'maw-js/sdk'` crash hit during mawjs-plugin-oracle dogfood on 2026-04-19.
- Drops the per-repo `scripts/setup.sh` workaround from maw-plugins#2.

## Test plan

- [x] New test file `test/isolated/plugin-install-auto-link-maw-js.test.ts` — 6 cases: creates link, idempotent, replaces stale symlink, preserves operator-placed real directory, fallback to running maw-js root via `import.meta.dir`, e2e through `cmdPluginInstall --link`.
- [x] `bun run test:plugin` — 262 pass, 0 fail (no regression on existing plugin suite incl. plugin-install.test.ts x20).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)