### PR TITLE
feat(sdk): expand exports — cmdBud + cmdOracle* + getTransportRouter (closes #626)

### DIFF
--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -92,6 +92,44 @@ export { registerCommand, matchCommand, listCommands } from "../cli/command-regi
 
 export { parseFlags } from "../cli/parse-args";
 
+// ─── Transport Router ────────────────────────────────────────────────────────
+
+export {
+  createTransportRouter, getTransportRouter, resetTransportRouter,
+} from "../transports";
+export { TransportRouter, classifyError } from "../core/transport/transport";
+export type {
+  Transport, TransportTarget, TransportMessage, TransportPresence,
+  TransportResult, TransportFailureReason,
+} from "../core/transport/transport";
+
+// ─── Bud (create a new oracle) ───────────────────────────────────────────────
+
+export { cmdBud } from "../commands/plugins/bud/impl";
+export type { BudOpts } from "../commands/plugins/bud/impl";
+export {
+  cmdBudFromRepo, looksLikeUrl, planFromRepoInjection, formatPlan,
+} from "../commands/plugins/bud/from-repo";
+export {
+  initVault, generateClaudeMd, configureFleet, writeBirthNote,
+} from "../commands/plugins/bud/bud-init";
+export { finalizeBud } from "../commands/plugins/bud/bud-wake";
+export type { BudFinalizeCtx } from "../commands/plugins/bud/bud-wake";
+export { ensureBudRepo } from "../commands/plugins/bud/bud-repo";
+export type { FromRepoOpts, InjectionPlan, InjectionAction } from "../commands/plugins/bud/types";
+
+// ─── Oracle management ───────────────────────────────────────────────────────
+
+export {
+  cmdOracleAbout,
+  cmdOracleList,
+  cmdOracleScan,
+  cmdOracleFleet,
+  cmdOracleScanStale,
+  cmdOraclePrune,
+  cmdOracleRegister,
+} from "../commands/plugins/oracle/impl";
+
 // ─── definePlugin — the plugin contract ──────────────────────────────────────
 
 import type { InvokeContext, InvokeResult } from "../plugin/types";

--- a/test/isolated/zombie-view-exclusion.test.ts
+++ b/test/isolated/zombie-view-exclusion.test.ts
@@ -15,11 +15,13 @@ import type { TmuxPane } from "../../src/sdk";
 // at module init time via env var, so we can't use a temp-dir approach
 // once another test has already imported paths.ts. Mock the helper instead.
 mock.module("../../src/commands/shared/fleet-load", () => ({
+  loadFleet: () => [],
   loadFleetEntries: () => [
     { file: "101-mawjs.json", data: { name: "mawjs", windows: [] } },
     { file: "112-fusion.json", data: { name: "fusion", windows: [] } },
   ],
   loadFleetData: () => [],
+  getSessionNames: async () => [],
 }));
 
 // Also need ~/.claude/teams/ to exist (or not trip up knownTeamPaneIds


### PR DESCRIPTION
## Summary
- Adds the SDK re-exports needed so the Shape A standalone plugins (50-bud, 50-oracle, 50-about, 20-transport) can drop their fail-graceful stubs and become thin re-exports.
- New surface area exposed from `maw-js/sdk`:
  - **Transport router**: `createTransportRouter`, `getTransportRouter`, `resetTransportRouter`, `TransportRouter`, `classifyError` (+ types `Transport`, `TransportTarget`, `TransportMessage`, `TransportPresence`, `TransportResult`, `TransportFailureReason`)
  - **Bud**: `cmdBud`, `cmdBudFromRepo`, `looksLikeUrl`, `planFromRepoInjection`, `formatPlan`, `initVault`, `generateClaudeMd`, `configureFleet`, `writeBirthNote`, `finalizeBud`, `ensureBudRepo` (+ types `BudOpts`, `BudFinalizeCtx`, `FromRepoOpts`, `InjectionPlan`, `InjectionAction`)
  - **Oracle management**: `cmdOracleAbout`, `cmdOracleList`, `cmdOracleScan`, `cmdOracleFleet`, `cmdOracleScanStale`, `cmdOraclePrune`, `cmdOracleRegister`

Closes #626. Unblocks `maw-plugins#1` stubs.

## Test plan
- [x] `bun run test` — 1176 pass / 0 fail / 7 skip (90 files)
- [x] `bun build src/sdk/index.ts` — bundles clean
- [x] `bun build src/cli.ts` — bundles clean
- [x] Empirical: symlink `maw-plugins/node_modules/maw-js → this branch`, install `50-bud` via `maw plugin install --link packages/50-bud --force`, confirm plugin loads and `maw bud --help` succeeds
- [x] Empirical: script importing all 20 new symbols from `maw-js/sdk` runs and prints `OK: 20 symbols resolved`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: sdk-expander <noreply@anthropic.com>