### PR TITLE
feat(oracle): nickname field (Phase 1 of #643)

### DIFF
--- a/docs/fleet/nickname-design.md
+++ b/docs/fleet/nickname-design.md
@@ -1,0 +1,130 @@
+# Oracle Nickname — Design (Phase 1)
+
+> Issue #643, Phase 1. Adds an optional human-chosen `nickname` alongside the
+> canonical oracle `name`. Phase 2 (peer-probe surfacing, `maw hey <nickname>`
+> routing, emoji audit) is explicitly out of scope here.
+
+## Goals
+
+- Let each oracle own a short human label distinct from its repo-derived name
+  (e.g. `maw` can be called "Moe" without renaming `mawjs-oracle`).
+- Keep the authoritative write local to the oracle itself so nicknames travel
+  with the vault on clone/federation sync.
+- Provide fast lookup for display paths (`maw oracle ls`) without stat-ing
+  every oracle repo on every run.
+
+## Non-goals (Phase 1)
+
+- Nickname-based routing (`maw hey Moe`). Needs a collision story.
+- Remote peer surfacing via `/info`. Needs contract coordination.
+- Rendering policy for emoji/wide glyphs in aligned tables.
+
+## Storage — Option C from the RFC
+
+Authoritative: per-oracle file at `<oracle-repo>/ψ/nickname`.
+
+- **Format**: plain UTF-8 text, single line, no trailing newline required but
+  trimmed on read. No JSON envelope — this is a human-owned label.
+- **Absence**: file missing OR empty-after-trim → no nickname. These two
+  states collapse deliberately; an empty file is not a "clear" signal
+  different from missing.
+- **Clear**: `maw oracle set-nickname <oracle> ""` removes the file. Treats
+  empty string as an explicit unset.
+- **Why ψ/**: already the vault dir where oracle-owned metadata lives; already
+  in the vault-sync scope (per MEMORY: ψ/ is NOT fully cross-node synced, but
+  it *is* the convention for per-oracle state, and `has_psi` is already a
+  signal on OracleEntry).
+
+Cache: `~/.maw/nicknames.json` (under `resolveHome()`, honouring `MAW_HOME`).
+
+- **Shape**: `{ schema: 1, nicknames: { [oracleName]: string } }`
+- **Role**: read-through cache for the display path. Never authoritative. A
+  missing cache entry falls back to reading the ψ/nickname file; a present
+  cache entry is used as-is but refreshed on every write.
+- **Staleness**: accepted. The canonical file is on-disk and cheap to re-read;
+  if nickname drifts the next `set-nickname` or explicit refresh will reconcile.
+
+## Precedence
+
+1. Explicit flag (none in Phase 1 — reserved for Phase 2 CLI overrides).
+2. Cache entry in `~/.maw/nicknames.json`.
+3. On-disk file `<local_path>/ψ/nickname`.
+4. None → display canonical `name` only.
+
+Writer always writes (1) the on-disk file first, then (2) the cache — in that
+order — so a crash between steps leaves the cache stale but the truth intact.
+
+## Schema
+
+`OracleEntry` gains `nickname?: string` at
+`src/core/fleet/registry-oracle-types.ts`. Optional, untouched by existing
+scans; populated only by:
+
+- `cmdOracleList` when it wants to render rows (read-through cache hit).
+- Future Phase 2 enrichers (peer-probe `/info`).
+
+The registry cache file (`oracles.json`) does NOT persist `nickname`. Keeping
+it out avoids a third copy diverging from the ψ/nickname file. Consumers of
+`OracleEntry` in-memory see the field; on-disk cache deliberately omits it.
+
+## Edge cases
+
+| case | behaviour |
+|---|---|
+| oracle has no `local_path` (uncloned) | skip ψ/ read; nickname can't be set; `set-nickname` errors |
+| oracle has `local_path` but no ψ/ dir | create ψ/ on write (`recursive: true`) |
+| nickname with only whitespace | trimmed to empty → treated as unset, file removed |
+| nickname with newlines | rejected at write time (one-line invariant) |
+| nickname > 64 chars | rejected at write time with explicit error |
+| cache file malformed JSON | warn once, fall back to per-file reads |
+| cache dir missing | created on first write |
+
+Length cap of 64 is arbitrary but bounded — Phase 2 can revisit when terminal
+rendering is audited.
+
+## CLI surface
+
+```
+maw oracle set-nickname <oracle> "<nickname>"    # write (empty = clear)
+maw oracle get-nickname <oracle>                 # read (exit 1 if unset)
+```
+
+Both resolve `<oracle>` through the existing registry cache (`readCache`) to
+find `local_path`. No registry mutation. JSON mode via `--json`.
+
+## Display wire
+
+`impl-list.ts` `formatRow()` currently pads `e.name` to 22 chars. With a
+nickname present, render as `name (nickname)` — nickname shown in dim/gray so
+the canonical name stays dominant. Padding recalculated on the combined string
+width. JSON output includes `nickname` field on each oracle row.
+
+## File layout (delta)
+
+```
+src/core/fleet/
+  registry-oracle-types.ts   # + nickname?: string
+  nicknames.ts               # NEW — read/write helpers + cache
+src/commands/plugins/oracle/
+  impl-nickname.ts           # NEW — cmdOracleSetNickname / cmdOracleGetNickname
+  impl-list.ts               # modified — render nickname column
+  index.ts                   # modified — dispatch set-nickname / get-nickname
+  nickname.test.ts           # NEW — unit + integration
+docs/fleet/
+  nickname-design.md         # this doc
+```
+
+## Test plan
+
+- **Unit**: round-trip write → read via ψ/nickname file; whitespace trimming;
+  empty clears; invalid (newline / overlength) rejected; cache read-through.
+- **Integration**: CLI `set-nickname foo "Mo"` then `ls` output contains `Mo`;
+  `get-nickname` returns the value; unset oracle falls back to `name` only.
+- Uses `MAW_HOME` override to sandbox the cache file in tests.
+
+## Deferred (Phase 2 follow-ups)
+
+- `/info` response carries nickname; registry merges it on remote scan.
+- `maw hey <nickname>` resolves — needs conflict policy (first-wins? node-scoped?).
+- Emoji & wide-char rendering audit for aligned tables.
+- TTL / explicit refresh command for the nicknames cache.

--- a/src/commands/plugins/oracle/impl-list.ts
+++ b/src/commands/plugins/oracle/impl-list.ts
@@ -24,6 +24,7 @@ import {
   type OracleEntry,
 } from "../../../sdk";
 import { lineageOf, timeSince, type OracleLineage } from "./impl-helpers";
+import { resolveNickname } from "../../../core/fleet/nicknames";
 
 export interface OracleListOpts {
   awake?: boolean;
@@ -94,11 +95,20 @@ export async function cmdOracleList(opts: OracleListOpts = {}) {
     }
   }
 
-  // 4. Enrich each entry with awake state + lineage
+  // 4. Enrich each entry with awake state + lineage + nickname (read-through)
   const enriched: EnrichedEntry[] = entries.map((entry) => {
     const session = awakeByName.get(entry.name) ?? null;
     const awake = session !== null;
-    return { entry, awake, session, lineage: lineageOf(entry, awake, agents) };
+    const nickname = resolveNickname(entry.name, entry.local_path || null);
+    const enrichedEntry: OracleEntry = nickname
+      ? { ...entry, nickname }
+      : entry;
+    return {
+      entry: enrichedEntry,
+      awake,
+      session,
+      lineage: lineageOf(entry, awake, agents),
+    };
   });
 
   // 5. Apply filters
@@ -216,5 +226,13 @@ function formatRow(x: EnrichedEntry, fopts: { showPath: boolean }): string {
       ? `\n        \x1b[90m${e.local_path}\x1b[0m`
       : "";
 
-  return `    ${icon} ${tag}  ${e.name.padEnd(22)} ${lineageNote.padEnd(26)} ${node}${missing}${registerHint}${pathCol}`;
+  const displayName = e.nickname
+    ? `${e.name} \x1b[90m(${e.nickname})\x1b[0m`
+    : e.name;
+  // padEnd counts ANSI codes, so pad the plain width then re-embed.
+  const plainWidth = e.nickname
+    ? `${e.name} (${e.nickname})`.length
+    : e.name.length;
+  const padding = " ".repeat(Math.max(0, 22 - plainWidth));
+  return `    ${icon} ${tag}  ${displayName}${padding} ${lineageNote.padEnd(26)} ${node}${missing}${registerHint}${pathCol}`;
 }

--- a/src/commands/plugins/oracle/impl-nickname.ts
+++ b/src/commands/plugins/oracle/impl-nickname.ts
@@ -1,0 +1,94 @@
+/**
+ * maw oracle {set,get}-nickname — Phase 1 of #643.
+ *
+ * set-nickname writes the authoritative on-disk file first, then refreshes the
+ * read-through cache. Empty string is an explicit clear.
+ * get-nickname reads cache → on-disk fallback → null.
+ */
+
+import { readCache, type OracleEntry } from "../../../sdk";
+import {
+  setCachedNickname,
+  validateNickname,
+  writeNickname,
+  resolveNickname,
+} from "../../../core/fleet/nicknames";
+
+export interface NicknameOpts {
+  json?: boolean;
+}
+
+function findEntry(name: string): OracleEntry | null {
+  const cache = readCache();
+  if (!cache) return null;
+  return cache.oracles.find((e) => e.name === name) ?? null;
+}
+
+export function cmdOracleSetNickname(
+  name: string,
+  nickname: string,
+  opts: NicknameOpts = {},
+): void {
+  if (!name) throw new Error("usage: maw oracle set-nickname <oracle> \"<nickname>\"");
+
+  const entry = findEntry(name);
+  if (!entry) {
+    throw new Error(
+      `oracle '${name}' not found in registry — try: maw oracle scan`,
+    );
+  }
+  if (!entry.local_path) {
+    throw new Error(
+      `oracle '${name}' has no local path (not cloned) — clone it before setting a nickname`,
+    );
+  }
+
+  const v = validateNickname(nickname);
+  if (!v.ok) throw new Error(v.error);
+
+  // on-disk first (authoritative), then cache
+  writeNickname(entry.local_path, v.value);
+  setCachedNickname(name, v.value);
+
+  if (opts.json) {
+    console.log(
+      JSON.stringify(
+        { schema: 1, name, nickname: v.value === "" ? null : v.value, cleared: v.value === "" },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  if (v.value === "") {
+    console.log(`  \x1b[32m✓\x1b[0m cleared nickname for \x1b[36m${name}\x1b[0m`);
+  } else {
+    console.log(
+      `  \x1b[32m✓\x1b[0m \x1b[36m${name}\x1b[0m nickname set to \x1b[33m${v.value}\x1b[0m`,
+    );
+  }
+}
+
+export function cmdOracleGetNickname(
+  name: string,
+  opts: NicknameOpts = {},
+): void {
+  if (!name) throw new Error("usage: maw oracle get-nickname <oracle>");
+
+  const entry = findEntry(name);
+  const repoPath = entry?.local_path || null;
+  const value = resolveNickname(name, repoPath);
+
+  if (opts.json) {
+    console.log(JSON.stringify({ schema: 1, name, nickname: value }, null, 2));
+    return;
+  }
+
+  if (value === null) {
+    console.error(`  \x1b[90mno nickname set for ${name}\x1b[0m`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log(value);
+}

--- a/src/commands/plugins/oracle/index.ts
+++ b/src/commands/plugins/oracle/index.ts
@@ -2,6 +2,7 @@ import type { InvokeContext, InvokeResult } from "../../../plugin/types";
 import { cmdOracleList, cmdOracleAbout, cmdOracleScan, cmdOracleScanStale } from "./impl";
 import { cmdOraclePrune } from "./impl-prune";
 import { cmdOracleRegister } from "./impl-register";
+import { cmdOracleSetNickname, cmdOracleGetNickname } from "./impl-nickname";
 import { parseFlags } from "../../../cli/parse-args";
 
 export const command = {
@@ -105,10 +106,23 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         if (!name) return { ok: false, error: "usage: maw oracle register <name>" };
         const flags = parseFlags(args, { "--json": Boolean }, 2);
         await cmdOracleRegister(name, { json: flags["--json"] });
+      } else if (subcmd === "set-nickname") {
+        const name = args[1];
+        const nickname = args[2];
+        if (!name || nickname === undefined) {
+          return { ok: false, error: "usage: maw oracle set-nickname <oracle> \"<nickname>\"" };
+        }
+        const flags = parseFlags(args, { "--json": Boolean }, 3);
+        cmdOracleSetNickname(name, nickname, { json: flags["--json"] });
+      } else if (subcmd === "get-nickname") {
+        const name = args[1];
+        if (!name) return { ok: false, error: "usage: maw oracle get-nickname <oracle>" };
+        const flags = parseFlags(args, { "--json": Boolean }, 2);
+        cmdOracleGetNickname(name, { json: flags["--json"] });
       } else if (subcmd === "about" && args[1]) {
         await cmdOracleAbout(args[1]);
       } else {
-        return { ok: false, error: "usage: maw oracle [ls|scan|prune|register <name>|about <name>]" };
+        return { ok: false, error: "usage: maw oracle [ls|scan|prune|register <name>|set-nickname <name> <nickname>|get-nickname <name>|about <name>]" };
       }
     } else if (ctx.source === "api") {
       const query = ctx.args as Record<string, unknown>;
@@ -161,10 +175,20 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         await cmdOracleRegister(query.name as string, {
           json: query.json as boolean | undefined,
         });
+      } else if (sub === "set-nickname") {
+        const name = query.name as string | undefined;
+        const nickname = query.nickname as string | undefined;
+        if (!name || nickname === undefined) {
+          return { ok: false, error: "usage: query.sub=set-nickname + query.name + query.nickname" };
+        }
+        cmdOracleSetNickname(name, nickname, { json: query.json as boolean | undefined });
+      } else if (sub === "get-nickname") {
+        if (!query.name) return { ok: false, error: "usage: query.sub=get-nickname + query.name" };
+        cmdOracleGetNickname(query.name as string, { json: query.json as boolean | undefined });
       } else if (sub === "about" && query.name) {
         await cmdOracleAbout(query.name as string);
       } else {
-        return { ok: false, error: "usage: query.sub=[ls|scan|prune|register|about] + query.name for about/register" };
+        return { ok: false, error: "usage: query.sub=[ls|scan|prune|register|set-nickname|get-nickname|about] + query.name" };
       }
     }
 

--- a/src/commands/plugins/oracle/nickname.test.ts
+++ b/src/commands/plugins/oracle/nickname.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+import {
+  validateNickname,
+  readNickname,
+  writeNickname,
+  resolveNickname,
+  setCachedNickname,
+  readCache,
+  cacheFile,
+  psiNicknameFile,
+  NICKNAME_MAX_LEN,
+} from "../../../core/fleet/nicknames";
+
+// ─── Sandbox ──────────────────────────────────────────────────────────────────
+
+let prevMawHome: string | undefined;
+let sandbox: string;
+let home: string;      // $MAW_HOME — holds the cache
+let repo: string;      // fake oracle repo with ψ/
+
+beforeEach(() => {
+  sandbox = mkdtempSync(join(tmpdir(), "maw-nickname-"));
+  home = join(sandbox, "home");
+  repo = join(sandbox, "repo");
+  mkdirSync(home, { recursive: true });
+  mkdirSync(join(repo, "ψ"), { recursive: true });
+  prevMawHome = process.env.MAW_HOME;
+  process.env.MAW_HOME = home;
+});
+
+afterEach(() => {
+  if (prevMawHome === undefined) delete process.env.MAW_HOME;
+  else process.env.MAW_HOME = prevMawHome;
+  rmSync(sandbox, { recursive: true, force: true });
+});
+
+// ─── validateNickname ─────────────────────────────────────────────────────────
+
+describe("validateNickname", () => {
+  it("accepts a simple label", () => {
+    const v = validateNickname("Moe");
+    expect(v.ok).toBe(true);
+    if (v.ok) expect(v.value).toBe("Moe");
+  });
+
+  it("trims whitespace", () => {
+    const v = validateNickname("  Moe  ");
+    expect(v.ok).toBe(true);
+    if (v.ok) expect(v.value).toBe("Moe");
+  });
+
+  it("whitespace-only collapses to empty (clear)", () => {
+    const v = validateNickname("   ");
+    expect(v.ok).toBe(true);
+    if (v.ok) expect(v.value).toBe("");
+  });
+
+  it("rejects newline", () => {
+    const v = validateNickname("foo\nbar");
+    expect(v.ok).toBe(false);
+  });
+
+  it("rejects overlength", () => {
+    const v = validateNickname("a".repeat(NICKNAME_MAX_LEN + 1));
+    expect(v.ok).toBe(false);
+  });
+
+  it("accepts max length", () => {
+    const v = validateNickname("a".repeat(NICKNAME_MAX_LEN));
+    expect(v.ok).toBe(true);
+  });
+});
+
+// ─── ψ/nickname file round-trip ──────────────────────────────────────────────
+
+describe("readNickname / writeNickname", () => {
+  it("returns null when file absent", () => {
+    expect(readNickname(repo)).toBeNull();
+  });
+
+  it("round-trips a nickname", () => {
+    writeNickname(repo, "Moe");
+    expect(readNickname(repo)).toBe("Moe");
+    // file lives under ψ/
+    expect(existsSync(psiNicknameFile(repo))).toBe(true);
+    expect(readFileSync(psiNicknameFile(repo), "utf-8")).toBe("Moe\n");
+  });
+
+  it("empty string clears the file", () => {
+    writeNickname(repo, "Moe");
+    expect(readNickname(repo)).toBe("Moe");
+    writeNickname(repo, "");
+    expect(readNickname(repo)).toBeNull();
+    expect(existsSync(psiNicknameFile(repo))).toBe(false);
+  });
+
+  it("trims trailing newline on read", () => {
+    writeFileSync(psiNicknameFile(repo), "Moe\n\n");
+    expect(readNickname(repo)).toBe("Moe");
+  });
+
+  it("empty file reads as null", () => {
+    writeFileSync(psiNicknameFile(repo), "   \n");
+    expect(readNickname(repo)).toBeNull();
+  });
+
+  it("creates ψ/ directory if missing", () => {
+    const freshRepo = join(sandbox, "fresh-repo");
+    mkdirSync(freshRepo);
+    writeNickname(freshRepo, "Moe");
+    expect(readNickname(freshRepo)).toBe("Moe");
+  });
+});
+
+// ─── Cache ────────────────────────────────────────────────────────────────────
+
+describe("nicknames cache", () => {
+  it("reads empty cache when file absent", () => {
+    const c = readCache();
+    expect(c.schema).toBe(1);
+    expect(c.nicknames).toEqual({});
+  });
+
+  it("setCachedNickname writes and reads back", () => {
+    setCachedNickname("foo", "Mo");
+    const c = readCache();
+    expect(c.nicknames.foo).toBe("Mo");
+    // cache file lives under MAW_HOME
+    expect(cacheFile().startsWith(home)).toBe(true);
+  });
+
+  it("setCachedNickname with empty string removes entry", () => {
+    setCachedNickname("foo", "Mo");
+    setCachedNickname("foo", "");
+    const c = readCache();
+    expect(c.nicknames.foo).toBeUndefined();
+  });
+
+  it("malformed cache file falls back to empty", () => {
+    mkdirSync(home, { recursive: true });
+    writeFileSync(cacheFile(), "{not json");
+    const c = readCache();
+    expect(c.nicknames).toEqual({});
+  });
+});
+
+// ─── resolveNickname precedence ──────────────────────────────────────────────
+
+describe("resolveNickname", () => {
+  it("returns null when both sources empty", () => {
+    expect(resolveNickname("foo", repo)).toBeNull();
+  });
+
+  it("falls back to on-disk when cache empty", () => {
+    writeNickname(repo, "Moe");
+    expect(resolveNickname("foo", repo)).toBe("Moe");
+  });
+
+  it("cache wins over on-disk (read-through)", () => {
+    writeNickname(repo, "DiskValue");
+    setCachedNickname("foo", "CacheValue");
+    expect(resolveNickname("foo", repo)).toBe("CacheValue");
+  });
+
+  it("handles null repoPath (uncloned oracle)", () => {
+    setCachedNickname("foo", "CacheOnly");
+    expect(resolveNickname("foo", null)).toBe("CacheOnly");
+    expect(resolveNickname("bar", null)).toBeNull();
+  });
+});

--- a/src/commands/plugins/oracle/oracle.test.ts
+++ b/src/commands/plugins/oracle/oracle.test.ts
@@ -19,6 +19,15 @@ mock.module("./impl", () => ({
   },
 }));
 
+mock.module("./impl-nickname", () => ({
+  cmdOracleSetNickname: (name: string, nickname: string) => {
+    console.log(`set-nickname ${name}=${nickname}`);
+  },
+  cmdOracleGetNickname: (name: string) => {
+    console.log(`get-nickname ${name}`);
+  },
+}));
+
 describe("oracle plugin", () => {
   let handler: (ctx: InvokeContext) => Promise<any>;
 
@@ -55,6 +64,42 @@ describe("oracle plugin", () => {
     const result = await handler({ source: "cli", args: ["about", "neo"] });
     expect(result.ok).toBe(true);
     expect(result.output).toContain("Oracle — neo");
+  });
+
+  it("cli: set-nickname dispatches with name + nickname", async () => {
+    const result = await handler({
+      source: "cli",
+      args: ["set-nickname", "neo", "Moe"],
+    });
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("set-nickname neo=Moe");
+  });
+
+  it("cli: set-nickname with missing nickname arg returns usage error", async () => {
+    const result = await handler({ source: "cli", args: ["set-nickname", "neo"] });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/usage/i);
+  });
+
+  it("cli: get-nickname dispatches by name", async () => {
+    const result = await handler({ source: "cli", args: ["get-nickname", "neo"] });
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("get-nickname neo");
+  });
+
+  it("cli: get-nickname with no name returns usage error", async () => {
+    const result = await handler({ source: "cli", args: ["get-nickname"] });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/usage/i);
+  });
+
+  it("api: set-nickname via query dispatches", async () => {
+    const result = await handler({
+      source: "api",
+      args: { sub: "set-nickname", name: "neo", nickname: "Moe" },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("set-nickname neo=Moe");
   });
 
   // Behavior #7: fleet deprecation alias

--- a/src/core/fleet/nicknames.ts
+++ b/src/core/fleet/nicknames.ts
@@ -1,0 +1,137 @@
+/**
+ * Oracle nickname storage — Phase 1 of #643.
+ *
+ * Authoritative: `<oracle-repo>/ψ/nickname` (plain UTF-8, trimmed on read).
+ * Cache:        `<resolveHome()>/nicknames.json` — read-through, non-authoritative.
+ *
+ * See docs/fleet/nickname-design.md for the full spec (precedence, edge cases).
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
+import { dirname, join } from "path";
+import { resolveHome } from "../paths";
+
+export const NICKNAME_MAX_LEN = 64;
+
+export interface NicknameCache {
+  schema: 1;
+  nicknames: Record<string, string>;
+}
+
+export function cacheFile(): string {
+  return join(resolveHome(), "nicknames.json");
+}
+
+export function psiNicknameFile(repoPath: string): string {
+  return join(repoPath, "ψ", "nickname");
+}
+
+export interface ValidatedNickname {
+  ok: true;
+  value: string; // trimmed; empty means clear
+}
+export interface InvalidNickname {
+  ok: false;
+  error: string;
+}
+
+export function validateNickname(raw: string): ValidatedNickname | InvalidNickname {
+  const trimmed = raw.trim();
+  if (trimmed === "") return { ok: true, value: "" };
+  if (/[\r\n]/.test(trimmed)) {
+    return { ok: false, error: "nickname must be a single line (no newlines)" };
+  }
+  if (trimmed.length > NICKNAME_MAX_LEN) {
+    return {
+      ok: false,
+      error: `nickname too long (${trimmed.length} > ${NICKNAME_MAX_LEN})`,
+    };
+  }
+  return { ok: true, value: trimmed };
+}
+
+// ─── Per-oracle file (authoritative) ──────────────────────────────────────────
+
+export function readNickname(repoPath: string): string | null {
+  const file = psiNicknameFile(repoPath);
+  if (!existsSync(file)) return null;
+  try {
+    const raw = readFileSync(file, "utf-8").trim();
+    return raw === "" ? null : raw;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write nickname to the oracle's ψ/nickname file. Empty string clears.
+ * Caller is responsible for validating input via `validateNickname` first.
+ */
+export function writeNickname(repoPath: string, nickname: string): void {
+  const file = psiNicknameFile(repoPath);
+  if (nickname === "") {
+    if (existsSync(file)) rmSync(file, { force: true });
+    return;
+  }
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, nickname + "\n", "utf-8");
+}
+
+// ─── Cache (read-through, non-authoritative) ──────────────────────────────────
+
+export function readCache(): NicknameCache {
+  const file = cacheFile();
+  if (!existsSync(file)) return { schema: 1, nicknames: {} };
+  try {
+    const parsed = JSON.parse(readFileSync(file, "utf-8"));
+    if (parsed && typeof parsed === "object" && parsed.nicknames) {
+      return { schema: 1, nicknames: parsed.nicknames };
+    }
+  } catch {
+    // malformed — caller gets empty cache
+  }
+  return { schema: 1, nicknames: {} };
+}
+
+export function writeCache(cache: NicknameCache): void {
+  const file = cacheFile();
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, JSON.stringify(cache, null, 2) + "\n", "utf-8");
+}
+
+export function getCachedNickname(name: string): string | null {
+  const cache = readCache();
+  const v = cache.nicknames[name];
+  return v ?? null;
+}
+
+export function setCachedNickname(name: string, nickname: string): void {
+  const cache = readCache();
+  if (nickname === "") {
+    delete cache.nicknames[name];
+  } else {
+    cache.nicknames[name] = nickname;
+  }
+  writeCache(cache);
+}
+
+/**
+ * Resolve nickname for an oracle: cache first, then on-disk file.
+ * Returns null when neither source has a value.
+ */
+export function resolveNickname(
+  name: string,
+  repoPath: string | null | undefined,
+): string | null {
+  const cached = getCachedNickname(name);
+  if (cached !== null) return cached;
+  if (!repoPath) return null;
+  const onDisk = readNickname(repoPath);
+  return onDisk;
+}

--- a/src/core/fleet/registry-oracle-types.ts
+++ b/src/core/fleet/registry-oracle-types.ts
@@ -16,6 +16,9 @@ export interface OracleEntry {
   budded_at: string | null;
   federation_node: string | null;
   detected_at: string;     // ISO8601
+  // Optional human-chosen label, authoritative source is <local_path>/ψ/nickname.
+  // Not persisted to oracles.json — populated in-memory via read-through cache.
+  nickname?: string;
 }
 
 export interface RegistryCache {


### PR DESCRIPTION
## Summary

Phase 1 of #643 — optional human-chosen nickname for oracles.

- **Schema**: `OracleEntry.nickname?: string` (in-memory only; not persisted to oracles.json).
- **Storage**: authoritative on-disk at `<oracle-repo>/ψ/nickname` (plain UTF-8, one line, trimmed on read, empty/missing = unset). Read-through cache at `<MAW_HOME>/nicknames.json`.
- **CLI**: `maw oracle set-nickname <oracle> "<nickname>"` + `maw oracle get-nickname <oracle>` (both also via API). Empty string clears.
- **Display**: `maw oracle ls` renders `name (nickname)` in dim when set; JSON output carries the field via the spread of `OracleEntry`.
- **Validation**: max 64 chars, no newlines, whitespace-only collapses to clear.
- **Write order**: ψ/nickname first (authoritative), cache second (so crash between = stale cache, truth intact).

Design doc: `docs/fleet/nickname-design.md`.

### Deferred to Phase 2 (not in this PR)

- `/info` response carries nickname + registry merges it on remote scan.
- `maw hey <nickname>` resolves (needs collision policy).
- Emoji / wide-char rendering audit for aligned tables.

## Test plan

- [x] `bun run test:all` green locally (0 fail across all four stages: test, test:isolated, test:mock-smoke, test:plugin)
- [x] Unit: `validateNickname` rules, ψ/nickname round-trip (including create ψ/ on write, empty-clears, trim, whitespace-only), cache read/write/malformed-recovery, `resolveNickname` precedence (cache > disk), uncloned-oracle path (null `repoPath`)
- [x] Dispatch: CLI + API route `set-nickname` / `get-nickname` correctly; usage error when args missing
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)