### PR TITLE
feat(info): self-describing contract — schema + capabilities (closes #628 enrichment)

### DIFF
--- a/docs/federation/stale-peer-diagnosis.md
+++ b/docs/federation/stale-peer-diagnosis.md
@@ -20,7 +20,7 @@ $ bun run src/core/server.ts  # MAW_PORT=3457
 maw v26.4.18-alpha.26 (…) serve → http://localhost:3457 (…) [127.0.0.1]
 
 $ curl -s localhost:3457/info
-{"node":"white","version":"26.4.18-alpha.26","ts":"2026-04-19T01:08:18Z","maw":true}
+{"node":"white","version":"26.4.18-alpha.27","ts":"2026-04-19T01:08:18Z","maw":{"schema":"1","plugins":{"manifestEndpoint":"/api/plugins"},"capabilities":["plugin.listManifest","peer.handshake","info"]}}
 $ echo $?
 0  # HTTP 200 — /info is correctly mounted
 ```
@@ -116,7 +116,7 @@ wording doesn't silently regress.
 
 - PR #603 (`09ee0b9`) — `feat(transport): add /info endpoint for peer handshake (closes #596)`
 - `src/views/index.ts:10` — `/info` route registration (confirmed mounted)
-- `src/views/info.ts` — handler, returns `{node, version, ts, maw: true}`
+- `src/views/info.ts` — handler, returns `{node, version, ts, maw: {schema, plugins, capabilities}}` as of #628; pre-#628 peers return `{…, maw: true}` and are still accepted by the probe gate.
 - `src/commands/plugins/peers/probe.ts:27` — current `HTTP_4XX` hint
 - `ecosystem.config.cjs` — pm2 config (correct path, `watch: false`)
 - `docs/federation/peer-handshake-errors.md` — #565 sibling doc

--- a/src/commands/plugins/peers/peers-probe.test.ts
+++ b/src/commands/plugins/peers/peers-probe.test.ts
@@ -287,6 +287,127 @@ describe("dispatcher — probe subcommand + loud add", () => {
   });
 });
 
+describe("isValidMawHandshake (#628 back-compat gate)", () => {
+  it("accepts old shape — maw: true", async () => {
+    const { isValidMawHandshake } = await import("./probe");
+    expect(isValidMawHandshake(true)).toBe(true);
+  });
+
+  it("accepts new shape — maw: { schema: '1', ... }", async () => {
+    const { isValidMawHandshake } = await import("./probe");
+    expect(isValidMawHandshake({
+      schema: "1",
+      plugins: { manifestEndpoint: "/api/plugins" },
+      capabilities: ["info"],
+    })).toBe(true);
+  });
+
+  it("accepts any future schema string — forward-compat", async () => {
+    const { isValidMawHandshake } = await import("./probe");
+    expect(isValidMawHandshake({ schema: "2" })).toBe(true);
+    expect(isValidMawHandshake({ schema: "99-beta" })).toBe(true);
+  });
+
+  it("rejects missing/falsy maw", async () => {
+    const { isValidMawHandshake } = await import("./probe");
+    expect(isValidMawHandshake(undefined)).toBe(false);
+    expect(isValidMawHandshake(null)).toBe(false);
+    expect(isValidMawHandshake(false)).toBe(false);
+    expect(isValidMawHandshake(0)).toBe(false);
+    expect(isValidMawHandshake("")).toBe(false);
+  });
+
+  it("rejects object without schema (avoids typo silently passing)", async () => {
+    const { isValidMawHandshake } = await import("./probe");
+    expect(isValidMawHandshake({})).toBe(false);
+    expect(isValidMawHandshake({ plugins: {} })).toBe(false);
+    expect(isValidMawHandshake({ schema: 1 })).toBe(false); // must be string
+    expect(isValidMawHandshake({ schema: "" })).toBe(false); // non-empty
+  });
+
+  it("rejects truthy-but-wrong types — maw: 'yes' / maw: 1 must NOT slip past", async () => {
+    const { isValidMawHandshake } = await import("./probe");
+    expect(isValidMawHandshake("yes")).toBe(false);
+    expect(isValidMawHandshake(1)).toBe(false);
+    expect(isValidMawHandshake([])).toBe(false);
+  });
+});
+
+describe("probePeer — maw handshake gate (#628)", () => {
+  it("accepts old {maw:true} shape end-to-end", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname === "/info") {
+          return Response.json({ node: "legacy-peer", maw: true });
+        }
+        return new Response("nope", { status: 404 });
+      },
+    });
+    try {
+      const { probePeer } = await import("./probe");
+      const r = await probePeer(`http://localhost:${server.port}`, 1500);
+      expect(r.error).toBeUndefined();
+      expect(r.node).toBe("legacy-peer");
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  it("accepts new {maw:{schema:'1',...}} shape end-to-end", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname === "/info") {
+          return Response.json({
+            node: "enriched-peer",
+            version: "26.4.18-alpha.27",
+            ts: new Date().toISOString(),
+            maw: {
+              schema: "1",
+              plugins: { manifestEndpoint: "/api/plugins" },
+              capabilities: ["plugin.listManifest", "peer.handshake", "info"],
+            },
+          });
+        }
+        return new Response("nope", { status: 404 });
+      },
+    });
+    try {
+      const { probePeer } = await import("./probe");
+      const r = await probePeer(`http://localhost:${server.port}`, 1500);
+      expect(r.error).toBeUndefined();
+      expect(r.node).toBe("enriched-peer");
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  it("rejects /info with node but no maw → BAD_BODY", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname === "/info") {
+          return Response.json({ node: "impostor" }); // no maw field
+        }
+        return new Response("nope", { status: 404 });
+      },
+    });
+    try {
+      const { probePeer } = await import("./probe");
+      const r = await probePeer(`http://localhost:${server.port}`, 1500);
+      expect(r.node).toBeNull();
+      expect(r.error?.code).toBe("BAD_BODY");
+      expect(r.error?.message).toMatch(/maw/i);
+    } finally {
+      server.stop(true);
+    }
+  });
+});
+
 describe("back-compat", () => {
   it("resolveNode still returns string | null and swallows errors", async () => {
     const { resolveNode } = await import("./impl");

--- a/src/commands/plugins/peers/peers-probe.test.ts
+++ b/src/commands/plugins/peers/peers-probe.test.ts
@@ -334,9 +334,29 @@ describe("isValidMawHandshake (#628 back-compat gate)", () => {
 });
 
 describe("probePeer — maw handshake gate (#628)", () => {
+  // costs.test.ts (and potentially others) monkey-patch `global.fetch`
+  // without restoring it. Under `bun run test:plugin` our file runs
+  // after them and inherits a mock that throws ECONNREFUSED for every
+  // URL — poisoning these real-server round-trips. Snapshot + restore
+  // the native fetch around each test so we're robust to that.
+  let savedFetch: typeof fetch | undefined;
+  beforeEach(() => {
+    savedFetch = globalThis.fetch;
+    // Reset to the genuine Bun fetch — look it up off the Response/Bun
+    // prototype chain via the platform-provided binding.
+    // In practice, `Bun.fetch` is the native impl; falling back to
+    // savedFetch is fine when no pollution has occurred.
+    const bunFetch = (globalThis as any).Bun?.fetch;
+    if (typeof bunFetch === "function") globalThis.fetch = bunFetch;
+  });
+  afterEach(() => {
+    if (savedFetch) globalThis.fetch = savedFetch;
+  });
+
   it("accepts old {maw:true} shape end-to-end", async () => {
     const server = Bun.serve({
       port: 0,
+      hostname: "127.0.0.1",
       fetch(req) {
         const url = new URL(req.url);
         if (url.pathname === "/info") {
@@ -347,7 +367,7 @@ describe("probePeer — maw handshake gate (#628)", () => {
     });
     try {
       const { probePeer } = await import("./probe");
-      const r = await probePeer(`http://localhost:${server.port}`, 1500);
+      const r = await probePeer(`http://127.0.0.1:${server.port}`, 1500);
       expect(r.error).toBeUndefined();
       expect(r.node).toBe("legacy-peer");
     } finally {
@@ -358,6 +378,7 @@ describe("probePeer — maw handshake gate (#628)", () => {
   it("accepts new {maw:{schema:'1',...}} shape end-to-end", async () => {
     const server = Bun.serve({
       port: 0,
+      hostname: "127.0.0.1",
       fetch(req) {
         const url = new URL(req.url);
         if (url.pathname === "/info") {
@@ -377,7 +398,7 @@ describe("probePeer — maw handshake gate (#628)", () => {
     });
     try {
       const { probePeer } = await import("./probe");
-      const r = await probePeer(`http://localhost:${server.port}`, 1500);
+      const r = await probePeer(`http://127.0.0.1:${server.port}`, 1500);
       expect(r.error).toBeUndefined();
       expect(r.node).toBe("enriched-peer");
     } finally {
@@ -388,6 +409,7 @@ describe("probePeer — maw handshake gate (#628)", () => {
   it("rejects /info with node but no maw → BAD_BODY", async () => {
     const server = Bun.serve({
       port: 0,
+      hostname: "127.0.0.1",
       fetch(req) {
         const url = new URL(req.url);
         if (url.pathname === "/info") {
@@ -398,7 +420,7 @@ describe("probePeer — maw handshake gate (#628)", () => {
     });
     try {
       const { probePeer } = await import("./probe");
-      const r = await probePeer(`http://localhost:${server.port}`, 1500);
+      const r = await probePeer(`http://127.0.0.1:${server.port}`, 1500);
       expect(r.node).toBeNull();
       expect(r.error?.code).toBe("BAD_BODY");
       expect(r.error?.message).toMatch(/maw/i);

--- a/src/commands/plugins/peers/probe.ts
+++ b/src/commands/plugins/peers/probe.ts
@@ -151,15 +151,30 @@ export async function probePeer(url: string, timeoutMs = 2000): Promise<ProbeRes
     };
   }
 
-  let body: { node?: unknown; name?: unknown };
+  let body: { node?: unknown; name?: unknown; maw?: unknown };
   try {
-    body = await res.json() as { node?: unknown; name?: unknown };
+    body = await res.json() as { node?: unknown; name?: unknown; maw?: unknown };
   } catch (e) {
     return {
       node: null,
       error: {
         code: "BAD_BODY",
         message: `/info body was not valid JSON`,
+        at: new Date().toISOString(),
+      },
+    };
+  }
+
+  // Accept both the old handshake (#596 — `maw: true`) and the new
+  // self-describing shape (#628 — `maw: { schema: "1", ... }`). Any
+  // truthy `maw` value passes; missing/falsy fails as BAD_BODY so we
+  // don't paint random HTTP 200 endpoints as maw peers.
+  if (!isValidMawHandshake(body.maw)) {
+    return {
+      node: null,
+      error: {
+        code: "BAD_BODY",
+        message: `/info response missing valid "maw" handshake field`,
         at: new Date().toISOString(),
       },
     };
@@ -181,6 +196,24 @@ export async function probePeer(url: string, timeoutMs = 2000): Promise<ProbeRes
   }
 
   return { node };
+}
+
+/**
+ * Handshake gate — accepts the pre-#628 `maw: true` form AND the new
+ * `maw: { schema: "1", ... }` form. Objects must carry at least a
+ * `schema` string to count as a valid new-shape handshake (bare `{}`
+ * is rejected so a typo doesn't silently pass). Anything truthy but
+ * not one of these shapes (e.g. `maw: "yes"`, `maw: 1`) is rejected —
+ * future shapes should bump the schema field rather than changing the
+ * outer type.
+ */
+export function isValidMawHandshake(maw: unknown): boolean {
+  if (maw === true) return true;
+  if (maw && typeof maw === "object") {
+    const m = maw as { schema?: unknown };
+    return typeof m.schema === "string" && m.schema.length > 0;
+  }
+  return false;
 }
 
 /** Hint chooser — DNS bucket sub-types for ENOTIMP get a distinct hint (#593). */

--- a/src/views/info.ts
+++ b/src/views/info.ts
@@ -4,11 +4,27 @@ import { readFileSync } from "fs";
 import { join } from "path";
 import { loadConfig } from "../config";
 
+/**
+ * Self-describing maw field — schema "1" (#628).
+ *
+ * Lets peers discover capabilities in a single /info round-trip instead
+ * of probing multiple endpoints. Back-compat: old clients that check
+ * `body.maw === true` break; new clients should gate on any truthy
+ * `body.maw` (see src/commands/plugins/peers/probe.ts).
+ */
+export interface InfoMaw {
+  schema: "1";
+  plugins: {
+    manifestEndpoint: string;
+  };
+  capabilities: string[];
+}
+
 export interface InfoResponse {
   node: string;
   version: string;
   ts: string;
-  maw: true;
+  maw: InfoMaw;
 }
 
 function readVersion(): string {
@@ -34,7 +50,13 @@ export function buildInfo(): InfoResponse {
     node: readNode(),
     version: readVersion(),
     ts: new Date().toISOString(),
-    maw: true,
+    maw: {
+      schema: "1",
+      plugins: {
+        manifestEndpoint: "/api/plugins",
+      },
+      capabilities: ["plugin.listManifest", "peer.handshake", "info"],
+    },
   };
 }
 

--- a/test/info-endpoint.test.ts
+++ b/test/info-endpoint.test.ts
@@ -17,7 +17,14 @@ describe("buildInfo()", () => {
     expect(info.node.length).toBeGreaterThan(0);
     expect(typeof info.version).toBe("string");
     expect(typeof info.ts).toBe("string");
-    expect(info.maw).toBe(true);
+    // Post-#628: maw is a self-describing object, not a bare boolean.
+    expect(typeof info.maw).toBe("object");
+    expect(info.maw.schema).toBe("1");
+    expect(info.maw.plugins.manifestEndpoint).toBe("/api/plugins");
+    expect(Array.isArray(info.maw.capabilities)).toBe(true);
+    expect(info.maw.capabilities).toContain("plugin.listManifest");
+    expect(info.maw.capabilities).toContain("peer.handshake");
+    expect(info.maw.capabilities).toContain("info");
   });
 
   test("ts is a valid ISO-8601 timestamp", () => {
@@ -55,7 +62,13 @@ describe("GET /info (Hono route)", () => {
     expect(typeof body.node).toBe("string");
     expect(typeof body.version).toBe("string");
     expect(typeof body.ts).toBe("string");
-    expect(body.maw).toBe(true);
+    // Post-#628: maw is a truthy self-describing object.
+    expect(typeof body.maw).toBe("object");
+    expect(body.maw).toBeTruthy();
+    const maw = body.maw as { schema: string; plugins: { manifestEndpoint: string }; capabilities: string[] };
+    expect(maw.schema).toBe("1");
+    expect(typeof maw.plugins.manifestEndpoint).toBe("string");
+    expect(Array.isArray(maw.capabilities)).toBe(true);
   });
 
   test("body satisfies probe.ts consumer — body.node is a non-empty string", async () => {

--- a/test/integration/federation-local.test.ts
+++ b/test/integration/federation-local.test.ts
@@ -46,7 +46,10 @@ async function waitForInfo(url: string, timeoutMs = 20_000): Promise<void> {
       const res = await fetch(`${url}/info`);
       if (res.ok) {
         const body = (await res.json()) as { maw?: unknown; node?: unknown };
-        if (body.maw === true && typeof body.node === "string" && body.node) return;
+        // Accept both pre-#628 `maw: true` and post-#628 object shape.
+        const mawOk = body.maw === true
+          || (!!body.maw && typeof body.maw === "object");
+        if (mawOk && typeof body.node === "string" && body.node) return;
       }
     } catch (e) {
       lastErr = e;
@@ -138,12 +141,15 @@ describe.skipIf(SKIP)("federation — 2-port localhost /info + probe round-trip"
     if (tmp) rmSync(tmp, { recursive: true, force: true });
   });
 
-  test("each node's /info returns 200 with maw:true and the configured node name", async () => {
+  test("each node's /info returns 200 with a truthy maw handshake and the configured node name", async () => {
     for (const n of [nodeA, nodeB]) {
       const res = await fetch(`${n.url}/info`);
       expect(res.status).toBe(200);
       const body = (await res.json()) as { node?: unknown; maw?: unknown; ts?: unknown };
-      expect(body.maw).toBe(true);
+      // Post-#628: maw is a self-describing object (`{schema,plugins,capabilities}`).
+      // The probe gate accepts both, so we assert only the generic "truthy"
+      // contract here — the shape specifics are covered in info-endpoint.test.ts.
+      expect(body.maw).toBeTruthy();
       expect(body.node).toBe(n.name);
       expect(typeof body.ts).toBe("string");
     }


### PR DESCRIPTION
## Summary

Enriches `/info` with a self-describing `maw` field so peers can discover capabilities in a single round-trip (Shape A zero-RT discovery, #628):

- **Before:** `{ node, version, ts, maw: true }`
- **After:**  `{ node, version, ts, maw: { schema: "1", plugins: { manifestEndpoint: "/api/plugins" }, capabilities: ["plugin.listManifest", "peer.handshake", "info"] } }`

The proposed shape in #628 named `/api/plugin/list-manifest`; advertising the real endpoint (`/api/plugins` — `src/core/server.ts:141`) avoids a phantom 404 on capability dereference.

## Back-compat

`src/commands/plugins/peers/probe.ts` now has an explicit handshake gate, `isValidMawHandshake()`, that accepts **both**:

- pre-#628 `maw: true`
- post-#628 `maw: { schema: "1", ... }`

Anything else (missing, falsy, truthy-but-wrong-type) → `BAD_BODY`. Future schema bumps just change `schema` without touching the outer contract.

Integration test (`federation-local.test.ts`) relaxed from `body.maw === true` to "any truthy maw" — matches the probe gate's actual contract.

## Tests

- `test/info-endpoint.test.ts` — new shape assertions on `buildInfo()` + the Hono route body.
- `src/commands/plugins/peers/peers-probe.test.ts`:
  - `isValidMawHandshake` unit suite (old, new, forward-compat, missing, wrong-type cases).
  - `probePeer` end-to-end round-trip against a live `Bun.serve` peer emitting each shape + a missing-maw → `BAD_BODY` case.
  - `beforeEach`/`afterEach` restore `globalThis.fetch` — `costs.test.ts` leaks a mock that throws `ECONNREFUSED` when files run together under `test:plugin`.
- `test/integration/federation-local.test.ts` — relaxed `maw` gate.

All four suites (`test`, `test:isolated`, `test:mock-smoke`, `test:plugin`) pass locally.

## Docs

- `docs/federation/stale-peer-diagnosis.md` — updated example payload + reference line. `pair-code.md` didn't contain `/info` shape snippets, so no change there.

## Test plan

- [x] `bun run test` green
- [x] `bun run test:all` green (all four sub-suites)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)