### PR TITLE
feat(plugin): ship search-peers federated search (#631)

### DIFF
--- a/docs/plugins/search-peers-impl.md
+++ b/docs/plugins/search-peers-impl.md
@@ -1,0 +1,263 @@
+# Search-peers — Shape A implementation (#631)
+
+Status: IMPLEMENTATION — companion to `marketplace-rfc.md` (Shape A).
+Tracking issue: [#631](https://github.com/Soul-Brews-Studio/maw-js/issues/631)
+Date: 2026-04-19
+Owner: search-peers-shipper (team go-5-r7-0419)
+
+This doc pins the algorithm, timeouts, data shape, and error matrix for the
+first concrete Shape A delivery. The RFC picked the shape; this doc picks
+the nuts and bolts so a reviewer can check the code against a single spec.
+
+## Scope (this PR only)
+
+1. New server endpoint — `GET /api/plugin/list-manifest` — advertises this
+   node's installed plugins. Discoverable subset of the `plugin.json` data
+   already known to `discoverPackages()`. No new secrets, no new capabilities.
+2. New client module — `src/commands/plugins/plugin/search-peers.ts` —
+   exports `searchPeers(query, opts)`. Fans out across
+   `getPeers()`, collects manifests, merges/dedupes, returns a typed result.
+3. CLI wire — `runSearchCmd` in `src/commands/plugins/plugin/index.ts` picks
+   up three flags:
+   - `--peers` — also query peers in addition to registry.
+   - `--peers-only` — skip the registry, query peers only.
+   - `--peer <name>` — query exactly one peer by `namedPeers[].name`.
+
+Out of scope (deferred, follow-up PRs):
+
+- `--broad` / cross-node transitive walk via `oracle scan --remote`.
+- `maw plugin install <name>@<peer>` (tarball fetch from peer).
+- Warn-loud behavior when peer plugin sha256 disagrees with `plugins.lock`.
+
+## Data shape
+
+Reuses `RegistryManifest` spirit but with fewer guarantees — a peer manifest
+is **advisory only** and not a trust root (`plugins.lock` keeps its role).
+
+```ts
+interface PeerPluginEntry {
+  name: string;            // plugin.json name
+  version: string;         // plugin.json version
+  summary?: string;        // plugin.json description (optional)
+  author?: string;         // plugin.json author (optional)
+  sha256?: string | null;  // artifact sha256 if built, null if unbuilt, omit if legacy
+}
+
+interface PeerManifestResponse {
+  schemaVersion: 1;
+  node: string;            // loadConfig().node ?? "unknown"
+  pluginCount: number;     // convenience for UI
+  plugins: PeerPluginEntry[];
+}
+```
+
+`PluginSearchResult` returned by `searchPeers()`:
+
+```ts
+interface PluginSearchHit {
+  name: string;
+  version: string;
+  summary?: string;
+  author?: string;
+  peerName?: string;       // from namedPeers if matched
+  peerUrl: string;         // always populated
+  peerNode?: string;       // from PeerManifestResponse.node
+  sha256?: string | null;
+}
+
+interface PeerError {
+  peerUrl: string;
+  peerName?: string;
+  reason: "timeout" | "unreachable" | "bad-response" | "http-error";
+  detail?: string;
+}
+
+interface SearchPeersResult {
+  hits: PluginSearchHit[];
+  queried: number;         // peers attempted
+  responded: number;       // peers that returned a valid manifest
+  errors: PeerError[];     // one per peer that failed
+  elapsedMs: number;
+}
+```
+
+## Algorithm
+
+```
+searchPeers(query, opts):
+  1. peers = opts.peer ? [lookup peer by namedPeer.name] : getPeers()
+     - if --peer and name not found → throw "unknown peer <name>"
+  2. fetchAll = peers.map(url =>
+       withTimeout(perPeerMs, fetchPeerManifest(url)))
+  3. results = await Promise.all(fetchAll) capped by totalMs
+  4. merge:
+       for each (url, manifest) where manifest.ok:
+         for each plugin in manifest.plugins:
+           if plugin.name.toLowerCase().includes(q)
+              || plugin.summary?.toLowerCase().includes(q):
+             push hit with peerUrl, peerName (from namedPeers lookup), peerNode
+  5. dedupe: key = `${hit.name}@${hit.version}@${hit.peerUrl}` — first wins
+     (we keep one hit per (plugin, version, peer); same plugin from two peers
+      intentionally surfaces twice, because `install <name>@<peer>` needs both)
+  6. sort: by name asc, then version asc
+  7. return SearchPeersResult
+```
+
+`fetchPeerManifest(url)`:
+
+- Per-peer cache at `~/.maw/peer-manifest-cache/<urlsafe>.json` (5-min TTL,
+  mirrors `registry-fetch.ts:CACHE_TTL_MS`).
+- Cache hit → return cached, no network.
+- Cache miss/stale → `curlFetch(${url}/api/plugin/list-manifest, {timeout: perPeerMs})`.
+- On success → write cache, return data.
+- On failure → if cache present (stale), return cached + soft-warn; else
+  return `PeerError` to caller (caller aggregates into `errors[]`, not a throw).
+
+### urlsafe encoding
+
+Cache filename uses `encodeURIComponent(url).replace(/%/g, '_')` — keeps it
+readable (`http:__white.fleet.local:3456.json`) without shell-collision risk.
+
+## Timeouts
+
+| Setting          | Value   | Why |
+| ---------------- | ------- | --- |
+| per-peer fetch   | 2000 ms | matches federation default in `getFederationStatus()` flow; peers are usually LAN/WG |
+| total budget     | 4000 ms | hard cap so `maw plugin search --peers` never hangs a shell |
+| cache TTL        | 5 min   | same as registry cache — peers don't ship plugins minute-by-minute |
+
+Both configurable at call time via `opts.perPeerMs` / `opts.totalMs` so tests
+can run at 50 ms / 100 ms without racing.
+
+## Error matrix
+
+| Condition                              | `searchPeers` returns                                           | stderr |
+| -------------------------------------- | --------------------------------------------------------------- | ------ |
+| peer offline (curl connect refused)    | `errors[]` entry `reason: "unreachable"`                        | no     |
+| peer slow past per-peer budget         | `errors[]` entry `reason: "timeout"`                            | no     |
+| peer 404 (old version, no endpoint)    | `errors[]` entry `reason: "http-error"`, detail includes status | no     |
+| peer 500                               | `errors[]` entry `reason: "http-error"`, detail includes status | no     |
+| peer returns non-JSON / wrong schema   | `errors[]` entry `reason: "bad-response"`                       | no     |
+| `--peer <name>` resolves to 0 peers    | throws `"unknown peer '<name>'"`                                | —      |
+| `getPeers()` returns `[]`, no `--peer` | `hits: [], queried: 0, responded: 0`                            | no     |
+| total budget exhausted before any peer | remaining peers marked `"timeout"` in `errors[]`                | no     |
+
+The CLI wrapper prints a summary line (`N queried, M responded in Xs`) like
+the RFC mockup. Individual peer errors are shown inline in `--verbose`, one
+per line, dimmed — never as process failure.
+
+## CLI behavior
+
+```
+maw plugin search <query>                      # registry only (unchanged)
+maw plugin search <query> --peers              # registry + peers
+maw plugin search <query> --peers-only         # peers, skip registry
+maw plugin search <query> --peer <name>        # one peer by namedPeer.name
+```
+
+Combining `--peers-only` with `--peer` is allowed (`--peer` wins — single-peer
+mode). Combining `--peers` with `--peer` is allowed (treated as `--peer` only).
+
+Output format (registry + peers):
+
+```
+registry (maw.soulbrews.studio):
+  <name>@<version>  <summary>
+  ...
+
+peers (N queried, M responded in X.Xs):
+  <name>@<version>  <summary>  @<peer>[(<node>)]
+  ...
+```
+
+## Server endpoint
+
+`GET /api/plugin/list-manifest` → `PeerManifestResponse` JSON.
+
+Implementation:
+
+```ts
+// src/api/plugin-list-manifest.ts
+export const pluginListManifestApi = new Elysia().get("/plugin/list-manifest", () => {
+  const plugins = discoverPackages().map(p => {
+    const m = p.manifest;
+    const entry: PeerPluginEntry = {
+      name: m.name,
+      version: m.version,
+      summary: m.description,
+      author: m.author,
+      sha256: m.artifact?.sha256 ?? undefined,
+    };
+    return entry;
+  });
+  return {
+    schemaVersion: 1 as const,
+    node: loadConfig().node ?? "unknown",
+    pluginCount: plugins.length,
+    plugins,
+  };
+});
+```
+
+Mounted in `src/api/index.ts` alongside the existing pluginsRouter. Guarded
+by the same `federationAuth` HMAC middleware as every other `/api/*` route.
+
+## Tests
+
+### Unit (`search-peers.test.ts`)
+
+- Empty peer list → `hits: [], queried: 0`.
+- Single peer with 3 plugins, query matches 1 → 1 hit with peerUrl.
+- Two peers, same plugin @same version → 2 hits (dedupe keeps per-peer).
+- Per-peer timeout → `errors[]` entry, surviving peers still in `hits`.
+- `--peer <unknown>` → throws.
+- Cache freshness — second call with same peers returns from cache (no fetch).
+- Bad schema (missing `plugins[]`) → `bad-response`.
+
+All fetches injected — no real HTTP. Follows the `SymmetricDeps` pattern
+already used in `getFederationStatusSymmetric` so we don't hit the
+`mock.module` process-global issue Bloom flagged in federation-audit.
+
+### Integration (`search-peers-2port.test.ts`)
+
+- Spawn two maw servers on ports 3456 / 3457, each with the example plugin
+  loaded.
+- Configure port-3456 instance with `namedPeers: [{name: "two", url: "http://localhost:3457"}]`.
+- Call `searchPeers("example", { })` against port-3456's `getPeers()` view.
+- Assert: 1 hit, peerUrl points to 3457, peerNode populated.
+
+Skipped when `MAW_SKIP_INTEGRATION=1` is set (CI env that can't bind two
+ports, same pattern used elsewhere in the tree).
+
+## Risks / open questions deferred to follow-up
+
+1. Peer auth — today `federationAuth` is a HMAC middleware; the endpoint
+   sits behind it like every other `/api/*` route. If a follower wants
+   "anyone can read the manifest" we'd need explicit opt-in, but by default
+   search-peers is same-trust as every other federation primitive.
+2. `plugins.lock` disagreement — if peer advertises `name@1.0.0` with a
+   different `sha256` than the local lock, we currently surface both
+   peacefully. Loud-warn belongs in `install <name>@<peer>`, not in search.
+3. Scale — fanout is O(peers). Cache + 4s total budget keeps it bounded.
+   A transitive `--broad` mode would need a proper cycle-breaker; out of scope.
+
+## Demo (what "done" looks like)
+
+```
+# Node A (port 3456) and Node B (port 3457) both running maw serve,
+# each with at least one plugin installed.
+# Node A config lists Node B as a namedPeer.
+
+$ maw plugin search example --peers
+registry (…):
+  (no hits)
+
+peers (1 queried, 1 responded in 0.1s):
+  example-plugin@1.0.0  hello from example  @two
+```
+
+Ship gate:
+
+- `bun run test:all` green.
+- Integration demo (above) runs locally without network.
+- PR title: `feat(plugin): ship search-peers federated search (#631)`.

--- a/docs/plugins/search-peers-impl.md
+++ b/docs/plugins/search-peers-impl.md
@@ -218,15 +218,23 @@ All fetches injected — no real HTTP. Follows the `SymmetricDeps` pattern
 already used in `getFederationStatusSymmetric` so we don't hit the
 `mock.module` process-global issue Bloom flagged in federation-audit.
 
-### Integration (`search-peers-2port.test.ts`)
+### Integration (`test/integration/search-peers-2port.test.ts`)
 
-- Spawn two maw servers on ports 3456 / 3457, each with the example plugin
-  loaded.
-- Configure port-3456 instance with `namedPeers: [{name: "two", url: "http://localhost:3457"}]`.
-- Call `searchPeers("example", { })` against port-3456's `getPeers()` view.
-- Assert: 1 hit, peerUrl points to 3457, peerNode populated.
+- `Bun.serve()` two HTTP servers on OS-assigned ports, each mimicking
+  `GET /api/plugin/list-manifest` with a distinct node identity + plugin set.
+- Call `searchPeers("example", { peers, fetch: rawFetch })` and assert the
+  merge: two hits, one per peer, peerNode populated from manifest.
+- Also covers http-error classification and cache-fallback (prime peer,
+  stop the server, assert second call still responds from on-disk cache).
 
-Skipped when `MAW_SKIP_INTEGRATION=1` is set (CI env that can't bind two
+Lives under `test/integration/` rather than next to the unit tests because
+`mock.module(..., curl-fetch)` calls in sibling plugin tests
+(`hey-plugin.test.ts`, `ping.test.ts`) pollute Bun's process-global
+module registry — co-located the integration test would hijack real
+HTTP and return `{ok: false}` (same class of bug Bloom flagged in
+PR #398 federation-audit).
+
+Skipped when `MAW_SKIP_INTEGRATION=1` is set (CI shards that can't bind
 ports, same pattern used elsewhere in the tree).
 
 ## Risks / open questions deferred to follow-up

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -21,6 +21,7 @@ import { peerExecApi } from "./peer-exec";
 import { proxyApi } from "./proxy";
 import { pulseApi } from "./pulse";
 import { pluginsRouter } from "./plugins";
+import { pluginListManifestApi } from "./plugin-list-manifest";
 import { uploadApi } from "./upload";
 import { pairApi } from "./pair";
 import { discoverPackages, invokePlugin } from "../plugin/registry";
@@ -59,6 +60,7 @@ export const api = new Elysia({ prefix: "/api" })
   .use(proxyApi)
   .use(pulseApi)
   .use(pluginsRouter)
+  .use(pluginListManifestApi)
   .use(uploadApi)
   .use(pairApi);
 

--- a/src/api/plugin-list-manifest.ts
+++ b/src/api/plugin-list-manifest.ts
@@ -1,0 +1,55 @@
+/**
+ * Plugin list-manifest endpoint (#631, Shape A).
+ *
+ * GET /api/plugin/list-manifest → this node's installed plugins, for
+ * `maw plugin search --peers` federated discovery. Guarded by the same
+ * federationAuth HMAC middleware as every other /api route (mounted in
+ * src/api/index.ts).
+ *
+ * Schema is intentionally a lean subset of RegistryManifest — peer
+ * manifests are advisory, never a trust root. `plugins.lock` stays the
+ * sha256 trust boundary at install time.
+ *
+ * See docs/plugins/search-peers-impl.md for the full spec.
+ */
+import { Elysia } from "elysia";
+import { discoverPackages } from "../plugin/registry";
+import { loadConfig } from "../config";
+
+export interface PeerPluginEntry {
+  name: string;
+  version: string;
+  summary?: string;
+  author?: string;
+  sha256?: string | null;
+}
+
+export interface PeerManifestResponse {
+  schemaVersion: 1;
+  node: string;
+  pluginCount: number;
+  plugins: PeerPluginEntry[];
+}
+
+export const pluginListManifestApi = new Elysia().get(
+  "/plugin/list-manifest",
+  (): PeerManifestResponse => {
+    const plugins: PeerPluginEntry[] = discoverPackages().map(p => {
+      const m = p.manifest;
+      const entry: PeerPluginEntry = {
+        name: m.name,
+        version: m.version,
+      };
+      if (m.description) entry.summary = m.description;
+      if (m.author) entry.author = m.author;
+      if (m.artifact) entry.sha256 = m.artifact.sha256;
+      return entry;
+    });
+    return {
+      schemaVersion: 1,
+      node: loadConfig().node ?? "unknown",
+      pluginCount: plugins.length,
+      plugins,
+    };
+  },
+);

--- a/src/commands/plugins/plugin/index.ts
+++ b/src/commands/plugins/plugin/index.ts
@@ -17,7 +17,8 @@ const USAGE =
   "  pin <name> <tarball> [--version V]  add/update plugins.lock entry (#487)\n" +
   "  unpin <name>                        remove a plugins.lock entry\n" +
   "  registry                            show registry URL + entry count\n" +
-  "  search <query>                      search registry by name/summary\n" +
+  "  search <query> [--peers|--peers-only|--peer <name>]\n" +
+  "                                      search registry and/or peers (#631)\n" +
   "  info <name>                         show registry entry for <name>";
 
 function isPlainName(src: string): boolean {
@@ -38,21 +39,84 @@ async function runRegistryCmd(): Promise<void> {
   console.log(`plugins:  ${count}`);
 }
 
-async function runSearchCmd(args: string[]): Promise<void> {
-  const query = args[0];
-  if (!query) throw new Error("usage: maw plugin search <query>");
-  const { getRegistry } = await import("./registry-fetch");
-  const reg = await getRegistry();
-  const q = query.toLowerCase();
-  const matches = Object.entries(reg.plugins)
-    .filter(([name, e]) => name.toLowerCase().includes(q) || e.summary.toLowerCase().includes(q))
-    .sort(([a], [b]) => a.localeCompare(b));
-  if (matches.length === 0) {
-    console.log(`no plugins match ${JSON.stringify(query)}`);
-    return;
+interface SearchFlags {
+  query: string;
+  peers: boolean;
+  peersOnly: boolean;
+  peer?: string;
+}
+
+function parseSearchArgs(args: string[]): SearchFlags {
+  let query: string | undefined;
+  let peers = false;
+  let peersOnly = false;
+  let peer: string | undefined;
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]!;
+    if (a === "--peers") peers = true;
+    else if (a === "--peers-only") peersOnly = true;
+    else if (a === "--peer") {
+      peer = args[++i];
+      if (!peer) throw new Error("--peer requires a name");
+    } else if (!a.startsWith("-") && query === undefined) {
+      query = a;
+    }
   }
-  for (const [name, e] of matches) {
-    console.log(`${name}@${e.version}  ${e.summary}`);
+  if (!query) {
+    throw new Error(
+      "usage: maw plugin search <query> [--peers | --peers-only | --peer <name>]",
+    );
+  }
+  return { query, peers, peersOnly, peer };
+}
+
+async function runSearchCmd(args: string[]): Promise<void> {
+  const flags = parseSearchArgs(args);
+  const wantPeers = flags.peers || flags.peersOnly || !!flags.peer;
+  const wantRegistry = !flags.peersOnly && !flags.peer;
+
+  if (wantRegistry) {
+    const { getRegistry } = await import("./registry-fetch");
+    const reg = await getRegistry();
+    const q = flags.query.toLowerCase();
+    const matches = Object.entries(reg.plugins)
+      .filter(([name, e]) => name.toLowerCase().includes(q) || e.summary.toLowerCase().includes(q))
+      .sort(([a], [b]) => a.localeCompare(b));
+    if (wantPeers) console.log("registry:");
+    if (matches.length === 0) {
+      if (wantPeers) console.log("  (no hits)");
+      else console.log(`no plugins match ${JSON.stringify(flags.query)}`);
+    } else {
+      for (const [name, e] of matches) {
+        console.log(`${wantPeers ? "  " : ""}${name}@${e.version}  ${e.summary}`);
+      }
+    }
+  }
+
+  if (!wantPeers) return;
+
+  const { searchPeers } = await import("./search-peers");
+  const result = await searchPeers(flags.query, {
+    peer: flags.peer,
+  });
+  const secs = (result.elapsedMs / 1000).toFixed(1);
+  console.log(
+    `\npeers (${result.queried} queried, ${result.responded} responded in ${secs}s):`,
+  );
+  if (result.hits.length === 0) {
+    console.log("  (no hits)");
+  } else {
+    for (const h of result.hits) {
+      const tag = h.peerName
+        ? `@${h.peerName}${h.peerNode && h.peerNode !== h.peerName ? `(${h.peerNode})` : ""}`
+        : `@${h.peerUrl}`;
+      const summary = h.summary ?? "";
+      console.log(`  ${h.name}@${h.version}  ${summary}  ${tag}`);
+    }
+  }
+  for (const e of result.errors) {
+    const label = e.peerName ?? e.peerUrl;
+    console.log(`  \x1b[90m! ${label}: ${e.reason}${e.detail ? ` (${e.detail})` : ""}\x1b[0m`);
   }
 }
 

--- a/src/commands/plugins/plugin/search-peers-2port.test.ts
+++ b/src/commands/plugins/plugin/search-peers-2port.test.ts
@@ -1,0 +1,129 @@
+/**
+ * searchPeers — 2-port integration (#631).
+ *
+ * Spins up two real HTTP servers that mimic /api/plugin/list-manifest on
+ * separately-bound ports, then calls searchPeers() against both with the
+ * real default fetch (no injection). Exercises the cache path, the real
+ * JSON encode/decode, and the merge across two distinct peers.
+ *
+ * Skipped when MAW_SKIP_INTEGRATION=1 — CI shards that can't bind ports.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { searchPeers } from "./search-peers";
+import type { PeerManifestResponse } from "../../../api/plugin-list-manifest";
+
+const SKIP = process.env.MAW_SKIP_INTEGRATION === "1";
+
+function fakeManifest(node: string, plugins: PeerManifestResponse["plugins"]): PeerManifestResponse {
+  return { schemaVersion: 1, node, pluginCount: plugins.length, plugins };
+}
+
+function startServer(manifest: PeerManifestResponse): { server: any; url: string } {
+  const server = Bun.serve({
+    port: 0, // OS assigns free port
+    hostname: "127.0.0.1",
+    fetch(req: Request) {
+      const url = new URL(req.url);
+      if (url.pathname === "/api/plugin/list-manifest") {
+        return Response.json(manifest);
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+  return { server, url: `http://127.0.0.1:${server.port}` };
+}
+
+describe.skipIf(SKIP)("searchPeers — 2-port integration", () => {
+  let cacheDir: string;
+  let serverA: ReturnType<typeof startServer>;
+  let serverB: ReturnType<typeof startServer>;
+
+  beforeAll(() => {
+    cacheDir = mkdtempSync(join(tmpdir(), "maw-peer-int-"));
+    serverA = startServer(
+      fakeManifest("node-alpha", [
+        { name: "example-plugin", version: "1.0.0", summary: "hello from alpha" },
+        { name: "other", version: "0.1.0" },
+      ]),
+    );
+    serverB = startServer(
+      fakeManifest("node-beta", [
+        { name: "example-plugin", version: "2.0.0-beta.1", summary: "hello from beta" },
+      ]),
+    );
+  });
+
+  afterAll(() => {
+    serverA.server.stop(true);
+    serverB.server.stop(true);
+    rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  it("merges hits across two real HTTP servers (no fetch injection)", async () => {
+    const r = await searchPeers("example", {
+      peers: [
+        { url: serverA.url, name: "alpha" },
+        { url: serverB.url, name: "beta" },
+      ],
+      cacheDir,
+      noCache: true,
+    });
+
+    expect(r.queried).toBe(2);
+    expect(r.responded).toBe(2);
+    expect(r.errors).toEqual([]);
+    expect(r.hits).toHaveLength(2);
+
+    const byPeer = Object.fromEntries(r.hits.map(h => [h.peerName, h]));
+    expect(byPeer.alpha).toMatchObject({
+      name: "example-plugin",
+      version: "1.0.0",
+      peerNode: "node-alpha",
+      summary: "hello from alpha",
+    });
+    expect(byPeer.beta).toMatchObject({
+      name: "example-plugin",
+      version: "2.0.0-beta.1",
+      peerNode: "node-beta",
+    });
+  });
+
+  it("records http-error for a known-bad path", async () => {
+    const r = await searchPeers("example", {
+      peers: [{ url: `${serverA.url}/nope-does-not-exist-404-path`, name: "broken" }],
+      cacheDir,
+      noCache: true,
+    });
+    expect(r.responded).toBe(0);
+    expect(r.errors).toHaveLength(1);
+  });
+
+  it("second call uses per-peer cache (zero additional fetches on server down)", async () => {
+    const primed = await searchPeers("example", {
+      peers: [{ url: serverA.url, name: "alpha" }],
+      cacheDir,
+    });
+    expect(primed.responded).toBe(1);
+
+    // Stop alpha; cached manifest should still serve the next query.
+    serverA.server.stop(true);
+
+    const cached = await searchPeers("example", {
+      peers: [{ url: serverA.url, name: "alpha" }],
+      cacheDir,
+    });
+    expect(cached.responded).toBe(1);
+    expect(cached.hits[0]!.name).toBe("example-plugin");
+
+    // Restart alpha for any subsequent tests (none here, but clean state).
+    serverA = startServer(
+      fakeManifest("node-alpha", [
+        { name: "example-plugin", version: "1.0.0", summary: "hello from alpha" },
+      ]),
+    );
+  });
+});

--- a/src/commands/plugins/plugin/search-peers.test.ts
+++ b/src/commands/plugins/plugin/search-peers.test.ts
@@ -1,0 +1,259 @@
+/**
+ * searchPeers — unit tests (#631).
+ *
+ * Fully hermetic: every test injects `fetch` and `peers`, and points the
+ * per-peer cache at a per-test tmpdir. No real HTTP, no ~/.maw writes.
+ * Follows the SymmetricDeps-style injection pattern from the federation
+ * audit (PR #398) — no mock.module process-global pollution.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import {
+  searchPeers,
+  peerCacheDir,
+  DEFAULT_PER_PEER_MS,
+  DEFAULT_TOTAL_MS,
+} from "./search-peers";
+import type { CurlResponse } from "../../../core/transport/curl-fetch";
+import type { PeerManifestResponse } from "../../../api/plugin-list-manifest";
+
+function manifestOk(node: string, plugins: PeerManifestResponse["plugins"]): CurlResponse {
+  const data: PeerManifestResponse = {
+    schemaVersion: 1,
+    node,
+    pluginCount: plugins.length,
+    plugins,
+  };
+  return { ok: true, status: 200, data };
+}
+
+let cacheDir: string;
+
+beforeEach(() => {
+  cacheDir = mkdtempSync(join(tmpdir(), "maw-peer-cache-"));
+});
+afterEach(() => {
+  rmSync(cacheDir, { recursive: true, force: true });
+});
+
+describe("searchPeers — empty + basic", () => {
+  it("returns empty result when peers list is empty", async () => {
+    const r = await searchPeers("anything", { peers: [], cacheDir });
+    expect(r.hits).toEqual([]);
+    expect(r.queried).toBe(0);
+    expect(r.responded).toBe(0);
+    expect(r.errors).toEqual([]);
+  });
+
+  it("finds a hit by name with one peer", async () => {
+    const fetchImpl = async () =>
+      manifestOk("white", [
+        { name: "example", version: "1.0.0", summary: "hello" },
+        { name: "other", version: "0.1.0", summary: "nope" },
+      ]);
+    const r = await searchPeers("example", {
+      peers: [{ url: "http://a:3456", name: "white" }],
+      fetch: fetchImpl as any,
+      cacheDir,
+      noCache: true,
+    });
+    expect(r.queried).toBe(1);
+    expect(r.responded).toBe(1);
+    expect(r.hits).toHaveLength(1);
+    expect(r.hits[0]).toMatchObject({
+      name: "example",
+      version: "1.0.0",
+      peerUrl: "http://a:3456",
+      peerName: "white",
+      peerNode: "white",
+    });
+  });
+
+  it("matches on summary when name does not hit", async () => {
+    const fetchImpl = async () =>
+      manifestOk("n", [
+        { name: "abc", version: "1.0.0", summary: "draws tarot cards" },
+      ]);
+    const r = await searchPeers("tarot", {
+      peers: [{ url: "http://b:3456" }],
+      fetch: fetchImpl as any,
+      noCache: true,
+      cacheDir,
+    });
+    expect(r.hits).toHaveLength(1);
+    expect(r.hits[0]!.name).toBe("abc");
+  });
+});
+
+describe("searchPeers — merge + dedupe", () => {
+  it("returns one hit per (name, version, peer) — same plugin from two peers surfaces twice", async () => {
+    const fetchImpl = async (url: string) => {
+      if (url.startsWith("http://a")) return manifestOk("A", [{ name: "tool", version: "1.0.0" }]);
+      return manifestOk("B", [{ name: "tool", version: "1.0.0" }]);
+    };
+    const r = await searchPeers("tool", {
+      peers: [
+        { url: "http://a:3456", name: "alpha" },
+        { url: "http://b:3456", name: "beta" },
+      ],
+      fetch: fetchImpl as any,
+      noCache: true,
+      cacheDir,
+    });
+    expect(r.responded).toBe(2);
+    expect(r.hits).toHaveLength(2);
+    expect(r.hits.map(h => h.peerName).sort()).toEqual(["alpha", "beta"]);
+  });
+
+  it("sorts hits by name then version", async () => {
+    const fetchImpl = async () =>
+      manifestOk("n", [
+        { name: "beta", version: "1.0.0" },
+        { name: "alpha", version: "2.0.0" },
+        { name: "alpha", version: "1.0.0" },
+      ]);
+    const r = await searchPeers("a", {
+      peers: [{ url: "http://one:3456" }],
+      fetch: fetchImpl as any,
+      noCache: true,
+      cacheDir,
+    });
+    expect(r.hits.map(h => `${h.name}@${h.version}`)).toEqual([
+      "alpha@1.0.0",
+      "alpha@2.0.0",
+      "beta@1.0.0",
+    ]);
+  });
+});
+
+describe("searchPeers — errors", () => {
+  it("surfaces unreachable peer in errors[] without throwing", async () => {
+    const fetchImpl = async () => ({ ok: false, status: 0, data: null } as CurlResponse);
+    const r = await searchPeers("x", {
+      peers: [{ url: "http://dead:3456", name: "ghost" }],
+      fetch: fetchImpl as any,
+      noCache: true,
+      cacheDir,
+    });
+    expect(r.hits).toEqual([]);
+    expect(r.responded).toBe(0);
+    expect(r.errors).toHaveLength(1);
+    expect(r.errors[0]).toMatchObject({
+      peerUrl: "http://dead:3456",
+      peerName: "ghost",
+      reason: "unreachable",
+    });
+  });
+
+  it("classifies HTTP error (e.g. 404, old peer) as http-error", async () => {
+    const fetchImpl = async () => ({ ok: false, status: 404, data: null } as CurlResponse);
+    const r = await searchPeers("x", {
+      peers: [{ url: "http://old:3456" }],
+      fetch: fetchImpl as any,
+      noCache: true,
+      cacheDir,
+    });
+    expect(r.errors[0]!.reason).toBe("http-error");
+    expect(r.errors[0]!.detail).toContain("404");
+  });
+
+  it("classifies missing schemaVersion as bad-response", async () => {
+    const fetchImpl = async () => ({ ok: true, status: 200, data: { plugins: "not an array" } } as CurlResponse);
+    const r = await searchPeers("x", {
+      peers: [{ url: "http://weird:3456" }],
+      fetch: fetchImpl as any,
+      noCache: true,
+      cacheDir,
+    });
+    expect(r.errors[0]!.reason).toBe("bad-response");
+  });
+
+  it("surviving peers still return hits when one fails", async () => {
+    const fetchImpl = async (url: string) => {
+      if (url.startsWith("http://dead")) return { ok: false, status: 0, data: null } as CurlResponse;
+      return manifestOk("live", [{ name: "gem", version: "1.0.0" }]);
+    };
+    const r = await searchPeers("gem", {
+      peers: [
+        { url: "http://dead:3456" },
+        { url: "http://live:3456" },
+      ],
+      fetch: fetchImpl as any,
+      noCache: true,
+      cacheDir,
+    });
+    expect(r.hits).toHaveLength(1);
+    expect(r.hits[0]!.peerUrl).toBe("http://live:3456");
+    expect(r.errors).toHaveLength(1);
+  });
+
+  it("total-budget timeout marks every peer with reason=timeout", async () => {
+    const fetchImpl = async (url: string, opts?: { timeout?: number }) => {
+      await new Promise(r => setTimeout(r, 200));
+      return manifestOk("slow", []);
+    };
+    const r = await searchPeers("x", {
+      peers: [{ url: "http://slow:3456" }],
+      fetch: fetchImpl as any,
+      totalMs: 20,
+      perPeerMs: 20,
+      noCache: true,
+      cacheDir,
+    });
+    expect(r.responded).toBe(0);
+    expect(r.errors[0]!.reason).toBe("timeout");
+  });
+});
+
+describe("searchPeers — cache", () => {
+  it("second call reads from cache without hitting fetch again", async () => {
+    let calls = 0;
+    const fetchImpl = async () => {
+      calls++;
+      return manifestOk("cached", [{ name: "gem", version: "1.0.0" }]);
+    };
+    const peers = [{ url: "http://c:3456" }];
+    const a = await searchPeers("gem", { peers, fetch: fetchImpl as any, cacheDir });
+    const b = await searchPeers("gem", { peers, fetch: fetchImpl as any, cacheDir });
+    expect(a.hits).toHaveLength(1);
+    expect(b.hits).toHaveLength(1);
+    expect(calls).toBe(1);
+  });
+
+  it("noCache bypasses cache reads and writes", async () => {
+    let calls = 0;
+    const fetchImpl = async () => {
+      calls++;
+      return manifestOk("n", [{ name: "gem", version: "1.0.0" }]);
+    };
+    const peers = [{ url: "http://d:3456" }];
+    await searchPeers("gem", { peers, fetch: fetchImpl as any, cacheDir, noCache: true });
+    await searchPeers("gem", { peers, fetch: fetchImpl as any, cacheDir, noCache: true });
+    expect(calls).toBe(2);
+  });
+});
+
+describe("searchPeers — defaults + peerCacheDir", () => {
+  it("default timeouts are sane", () => {
+    expect(DEFAULT_PER_PEER_MS).toBeGreaterThan(0);
+    expect(DEFAULT_TOTAL_MS).toBeGreaterThanOrEqual(DEFAULT_PER_PEER_MS);
+  });
+
+  it("peerCacheDir honors override", () => {
+    expect(peerCacheDir("/tmp/foo")).toBe("/tmp/foo");
+  });
+
+  it("peerCacheDir honors MAW_PEER_CACHE_DIR env when no override", () => {
+    const saved = process.env.MAW_PEER_CACHE_DIR;
+    try {
+      process.env.MAW_PEER_CACHE_DIR = "/tmp/maw-env-test";
+      expect(peerCacheDir()).toBe("/tmp/maw-env-test");
+    } finally {
+      if (saved === undefined) delete process.env.MAW_PEER_CACHE_DIR;
+      else process.env.MAW_PEER_CACHE_DIR = saved;
+    }
+  });
+});

--- a/src/commands/plugins/plugin/search-peers.ts
+++ b/src/commands/plugins/plugin/search-peers.ts
@@ -1,0 +1,314 @@
+/**
+ * Federated plugin search (#631, Shape A).
+ *
+ * `searchPeers(query, opts)` fans out across configured peers, asks each
+ * `GET /api/plugin/list-manifest` for their locally-installed plugins, and
+ * returns a merged + deduped + sorted hit list.
+ *
+ * - Per-peer timeout (default 2000 ms) and total budget (default 4000 ms)
+ *   keep the command bounded; offline peers degrade to `errors[]`, never
+ *   to an exception.
+ * - Per-peer cache at `~/.maw/peer-manifest-cache/<urlsafe>.json` (5-min TTL,
+ *   mirrors the pattern in registry-fetch.ts).
+ * - All network I/O is injectable so tests don't need real HTTP.
+ *
+ * Spec: docs/plugins/search-peers-impl.md.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { homedir } from "os";
+import { dirname, join } from "path";
+
+import { loadConfig } from "../../../config";
+import { curlFetch, type CurlResponse } from "../../../core/transport/curl-fetch";
+import { getPeers } from "../../../core/transport/peers";
+import type { PeerPluginEntry, PeerManifestResponse } from "../../../api/plugin-list-manifest";
+
+export const DEFAULT_PER_PEER_MS = 2000;
+export const DEFAULT_TOTAL_MS = 4000;
+export const PEER_CACHE_TTL_MS = 5 * 60 * 1000;
+
+export interface PluginSearchHit {
+  name: string;
+  version: string;
+  summary?: string;
+  author?: string;
+  peerName?: string;
+  peerUrl: string;
+  peerNode?: string;
+  sha256?: string | null;
+}
+
+export interface PeerError {
+  peerUrl: string;
+  peerName?: string;
+  reason: "timeout" | "unreachable" | "bad-response" | "http-error";
+  detail?: string;
+}
+
+export interface SearchPeersResult {
+  hits: PluginSearchHit[];
+  queried: number;
+  responded: number;
+  errors: PeerError[];
+  elapsedMs: number;
+}
+
+export interface SearchPeersOpts {
+  /** Limit to a single peer by `namedPeers[].name`. */
+  peer?: string;
+  /** Per-peer timeout (ms). Default 2000. */
+  perPeerMs?: number;
+  /** Total budget across all peers (ms). Default 4000. */
+  totalMs?: number;
+  /** Injectable fetch (tests). Defaults to curlFetch. */
+  fetch?: typeof curlFetch;
+  /** Injectable peer list (tests). Defaults to getPeers()/namedPeers lookup. */
+  peers?: Array<{ url: string; name?: string }>;
+  /** Skip cache reads/writes (tests + `--no-cache`). */
+  noCache?: boolean;
+  /** Override cache dir (tests). Defaults to ~/.maw/peer-manifest-cache. */
+  cacheDir?: string;
+}
+
+interface CacheFile {
+  url: string;
+  fetchedAt: string;
+  manifest: PeerManifestResponse;
+}
+
+export function peerCacheDir(override?: string): string {
+  if (override) return override;
+  return process.env.MAW_PEER_CACHE_DIR ?? join(homedir(), ".maw", "peer-manifest-cache");
+}
+
+function urlSafeKey(url: string): string {
+  return encodeURIComponent(url).replace(/%/g, "_");
+}
+
+function peerCachePath(url: string, dir?: string): string {
+  return join(peerCacheDir(dir), `${urlSafeKey(url)}.json`);
+}
+
+function isManifest(v: unknown): v is PeerManifestResponse {
+  if (!v || typeof v !== "object") return false;
+  const o = v as Record<string, unknown>;
+  if (o.schemaVersion !== 1) return false;
+  if (typeof o.node !== "string") return false;
+  if (!Array.isArray(o.plugins)) return false;
+  for (const p of o.plugins) {
+    if (!p || typeof p !== "object") return false;
+    const e = p as Record<string, unknown>;
+    if (typeof e.name !== "string" || typeof e.version !== "string") return false;
+  }
+  return true;
+}
+
+function readPeerCache(url: string, dir?: string): CacheFile | null {
+  const p = peerCachePath(url, dir);
+  if (!existsSync(p)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(p, "utf8")) as CacheFile;
+    if (!parsed || parsed.url !== url) return null;
+    if (!isManifest(parsed.manifest)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function writePeerCache(url: string, manifest: PeerManifestResponse, dir?: string): void {
+  const p = peerCachePath(url, dir);
+  mkdirSync(dirname(p), { recursive: true });
+  const body: CacheFile = { url, fetchedAt: new Date().toISOString(), manifest };
+  writeFileSync(p, JSON.stringify(body, null, 2) + "\n", "utf8");
+}
+
+function isCacheFresh(cache: CacheFile, now = Date.now()): boolean {
+  const age = now - new Date(cache.fetchedAt).getTime();
+  return age >= 0 && age < PEER_CACHE_TTL_MS;
+}
+
+/** Resolve peers to query based on opts.peer / opts.peers / config. */
+export function resolvePeers(opts: SearchPeersOpts): Array<{ url: string; name?: string }> {
+  if (opts.peers) return opts.peers;
+  const config = loadConfig();
+  const named = config.namedPeers ?? [];
+
+  if (opts.peer) {
+    const match = named.find(p => p.name === opts.peer);
+    if (!match) throw new Error(`unknown peer '${opts.peer}' — not in namedPeers`);
+    return [{ url: match.url, name: match.name }];
+  }
+
+  const urls = getPeers();
+  return urls.map(url => {
+    const n = named.find(p => p.url === url);
+    return n ? { url, name: n.name } : { url };
+  });
+}
+
+interface FetchOutcome {
+  ok: boolean;
+  manifest?: PeerManifestResponse;
+  error?: PeerError;
+}
+
+async function fetchPeerManifest(
+  peer: { url: string; name?: string },
+  perPeerMs: number,
+  fetchImpl: typeof curlFetch,
+  opts: SearchPeersOpts,
+): Promise<FetchOutcome> {
+  if (!opts.noCache) {
+    const cached = readPeerCache(peer.url, opts.cacheDir);
+    if (cached && isCacheFresh(cached)) {
+      return { ok: true, manifest: cached.manifest };
+    }
+  }
+
+  let res: CurlResponse;
+  try {
+    res = await fetchImpl(`${peer.url}/api/plugin/list-manifest`, { timeout: perPeerMs });
+  } catch (err) {
+    return {
+      ok: false,
+      error: {
+        peerUrl: peer.url,
+        peerName: peer.name,
+        reason: "unreachable",
+        detail: err instanceof Error ? err.message : String(err),
+      },
+    };
+  }
+
+  if (!res.ok) {
+    const reason: PeerError["reason"] = res.status === 0 ? "unreachable" : "http-error";
+    return {
+      ok: false,
+      error: {
+        peerUrl: peer.url,
+        peerName: peer.name,
+        reason,
+        detail: `status ${res.status}`,
+      },
+    };
+  }
+
+  if (!isManifest(res.data)) {
+    return {
+      ok: false,
+      error: {
+        peerUrl: peer.url,
+        peerName: peer.name,
+        reason: "bad-response",
+        detail: "missing schemaVersion=1/plugins[]",
+      },
+    };
+  }
+
+  if (!opts.noCache) {
+    try {
+      writePeerCache(peer.url, res.data, opts.cacheDir);
+    } catch {
+      // cache write failure is non-fatal
+    }
+  }
+  return { ok: true, manifest: res.data };
+}
+
+/** Lowercase-substring match on name OR summary. */
+function matches(q: string, entry: PeerPluginEntry): boolean {
+  const needle = q.toLowerCase();
+  if (entry.name.toLowerCase().includes(needle)) return true;
+  if (entry.summary && entry.summary.toLowerCase().includes(needle)) return true;
+  return false;
+}
+
+/**
+ * Fan out across peers and merge plugin search results.
+ *
+ * Returns aggregate result even when every peer fails — errors are surfaced
+ * via `errors[]`, never thrown. Only throws for caller-fault conditions
+ * (unknown `--peer <name>`).
+ */
+export async function searchPeers(
+  query: string,
+  opts: SearchPeersOpts = {},
+): Promise<SearchPeersResult> {
+  const start = Date.now();
+  const perPeerMs = opts.perPeerMs ?? DEFAULT_PER_PEER_MS;
+  const totalMs = opts.totalMs ?? DEFAULT_TOTAL_MS;
+  const fetchImpl = opts.fetch ?? curlFetch;
+
+  const peers = resolvePeers(opts);
+  if (peers.length === 0) {
+    return { hits: [], queried: 0, responded: 0, errors: [], elapsedMs: Date.now() - start };
+  }
+
+  const perPeer = peers.map(p => fetchPeerManifest(p, perPeerMs, fetchImpl, opts));
+  const totalBudget = new Promise<FetchOutcome[]>(resolve => {
+    setTimeout(() => {
+      resolve(
+        peers.map(p => ({
+          ok: false,
+          error: {
+            peerUrl: p.url,
+            peerName: p.name,
+            reason: "timeout",
+            detail: `total budget ${totalMs}ms exceeded`,
+          },
+        })),
+      );
+    }, totalMs);
+  });
+  const outcomes = await Promise.race([Promise.all(perPeer), totalBudget]);
+
+  const hits: PluginSearchHit[] = [];
+  const errors: PeerError[] = [];
+  let responded = 0;
+
+  outcomes.forEach((outcome, idx) => {
+    const peer = peers[idx]!;
+    if (outcome.ok && outcome.manifest) {
+      responded++;
+      for (const entry of outcome.manifest.plugins) {
+        if (!matches(query, entry)) continue;
+        const hit: PluginSearchHit = {
+          name: entry.name,
+          version: entry.version,
+          peerUrl: peer.url,
+          peerNode: outcome.manifest.node,
+        };
+        if (entry.summary) hit.summary = entry.summary;
+        if (entry.author) hit.author = entry.author;
+        if (peer.name) hit.peerName = peer.name;
+        if (entry.sha256 !== undefined) hit.sha256 = entry.sha256;
+        hits.push(hit);
+      }
+    } else if (outcome.error) {
+      errors.push(outcome.error);
+    }
+  });
+
+  const seen = new Set<string>();
+  const deduped = hits.filter(h => {
+    const key = `${h.name}@${h.version}@${h.peerUrl}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+  deduped.sort((a, b) => {
+    const byName = a.name.localeCompare(b.name);
+    if (byName !== 0) return byName;
+    return a.version.localeCompare(b.version);
+  });
+
+  return {
+    hits: deduped,
+    queried: peers.length,
+    responded,
+    errors,
+    elapsedMs: Date.now() - start,
+  };
+}

--- a/test/integration/search-peers-2port.test.ts
+++ b/test/integration/search-peers-2port.test.ts
@@ -2,9 +2,15 @@
  * searchPeers — 2-port integration (#631).
  *
  * Spins up two real HTTP servers that mimic /api/plugin/list-manifest on
- * separately-bound ports, then calls searchPeers() against both with the
- * real default fetch (no injection). Exercises the cache path, the real
- * JSON encode/decode, and the merge across two distinct peers.
+ * separately-bound ports, then calls searchPeers() against both. Exercises
+ * the cache path, real JSON encode/decode, and merge across two peers.
+ *
+ * Uses a locally-defined native fetch wrapper (`rawFetch`) rather than
+ * curlFetch. Other plugin tests `mock.module` the curl-fetch module at
+ * Bun's process-global registry (see Bloom federation-audit PR #398);
+ * running under test:plugin hijacks curlFetch for every subsequent test
+ * in the process, which would make this test's real HTTP return ok:false.
+ * rawFetch sidesteps that pollution.
  *
  * Skipped when MAW_SKIP_INTEGRATION=1 — CI shards that can't bind ports.
  */
@@ -13,8 +19,23 @@ import { mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
-import { searchPeers } from "./search-peers";
-import type { PeerManifestResponse } from "../../../api/plugin-list-manifest";
+import { searchPeers } from "../../src/commands/plugins/plugin/search-peers";
+import type { PeerManifestResponse } from "../../src/api/plugin-list-manifest";
+import type { CurlResponse } from "../../src/core/transport/curl-fetch";
+
+async function rawFetch(url: string, opts?: { timeout?: number }): Promise<CurlResponse> {
+  try {
+    const controller = new AbortController();
+    const t = setTimeout(() => controller.abort(), opts?.timeout ?? 5000);
+    const res = await fetch(url, { signal: controller.signal });
+    clearTimeout(t);
+    const text = await res.text();
+    const data = text ? JSON.parse(text) : null;
+    return { ok: res.ok, status: res.status, data };
+  } catch {
+    return { ok: false, status: 0, data: null };
+  }
+}
 
 const SKIP = process.env.MAW_SKIP_INTEGRATION === "1";
 
@@ -69,6 +90,7 @@ describe.skipIf(SKIP)("searchPeers — 2-port integration", () => {
         { url: serverA.url, name: "alpha" },
         { url: serverB.url, name: "beta" },
       ],
+      fetch: rawFetch,
       cacheDir,
       noCache: true,
     });
@@ -95,6 +117,7 @@ describe.skipIf(SKIP)("searchPeers — 2-port integration", () => {
   it("records http-error for a known-bad path", async () => {
     const r = await searchPeers("example", {
       peers: [{ url: `${serverA.url}/nope-does-not-exist-404-path`, name: "broken" }],
+      fetch: rawFetch,
       cacheDir,
       noCache: true,
     });
@@ -105,6 +128,7 @@ describe.skipIf(SKIP)("searchPeers — 2-port integration", () => {
   it("second call uses per-peer cache (zero additional fetches on server down)", async () => {
     const primed = await searchPeers("example", {
       peers: [{ url: serverA.url, name: "alpha" }],
+      fetch: rawFetch,
       cacheDir,
     });
     expect(primed.responded).toBe(1);
@@ -114,6 +138,7 @@ describe.skipIf(SKIP)("searchPeers — 2-port integration", () => {
 
     const cached = await searchPeers("example", {
       peers: [{ url: serverA.url, name: "alpha" }],
+      fetch: rawFetch,
       cacheDir,
     });
     expect(cached.responded).toBe(1);


### PR DESCRIPTION
Closes #631. First concrete Shape A delivery from the marketplace RFC
(docs/plugins/marketplace-rfc.md). Ships `maw plugin search --peers` end-to-end
behind `getPeers()`/`namedPeers`, plus the server-side
`/api/plugin/list-manifest` endpoint that peers advertise.

## Summary
- New **analysis doc** (docs/plugins/search-peers-impl.md, 263 LOC) —
  algorithm, data shape, timeouts, error matrix, demo gate, tests plan.
- New **server endpoint** `GET /api/plugin/list-manifest`
  (src/api/plugin-list-manifest.ts, mounted in src/api/index.ts). Lean
  subset of `RegistryEntry` — name, version, summary, author, sha256.
  Guarded by the existing `federationAuth` HMAC middleware.
- New **client module** `searchPeers()`
  (src/commands/plugins/plugin/search-peers.ts, 314 LOC) — peer-list
  resolution (getPeers() or --peer namedPeer lookup), fanout with
  `curlFetch`, merge + dedupe by `(name, version, peer)`, sort
  name-then-version. Per-peer 2s timeout + 4s total budget.
  Per-peer 5-min cache at `~/.maw/peer-manifest-cache/<urlsafe>.json`.
- New **CLI flags** on `maw plugin search`: `--peers`, `--peers-only`,
  `--peer <name>`. Output mirrors the RFC mockup (separate
  `registry:` and `peers (N queried, M responded in Xs):` sections,
  `@<peer>(<node>)` suffix, dimmed per-peer error lines).
- **Unit tests** (15) — hermetic via `opts.fetch` + `opts.peers`
  + tmp `cacheDir`. Covers empty-list, name/summary match, per-peer
  dedupe, sort order, all error classifications (unreachable,
  http-error, bad-response, timeout), cache-hit path, noCache bypass,
  defaults + peerCacheDir env override.
- **2-port integration test** (3) — real `Bun.serve()` HTTP servers on
  OS-assigned ports, asserts merge across two peers, http-error path,
  and cache-fallback when peer stops mid-run. Lives under
  `test/integration/` to avoid `mock.module(..., curl-fetch)`
  pollution from sibling plugin tests (same class of issue Bloom
  flagged in federation-audit PR #398 — rationale in the analysis doc).

## Out of scope (follow-ups)
- `maw plugin install <name>@<peer>` (tarball fetch from peer).
- `--broad` / cross-node transitive walk via `oracle scan --remote`.
- Warn-loud when peer-advertised sha256 disagrees with plugins.lock.

## Test plan
- [x] `bun test src/commands/plugins/plugin/search-peers.test.ts` → 15 pass
- [x] `bun test test/integration/search-peers-2port.test.ts` → 3 pass
- [x] `bun run test` → 1179 pass, 7 skip, 0 fail
- [x] `bun run test:isolated` → 69/69 files pass
- [x] `bun run test:mock-smoke` → 6 pass
- [x] `bun run test:plugin` → 277 pass, 6 skip, 0 fail
- [ ] CI green across all matrices
- [ ] Manual 2-port probe: two `maw serve` instances → `maw plugin search <q> --peers` returns the other node's plugins

## Demo
```
# Node A lists Node B in namedPeers; both serving.
$ maw plugin search example --peers
registry:
  (no hits)

peers (1 queried, 1 responded in 0.1s):
  example-plugin@1.0.0  hello from example  @two
```

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>