### PR TITLE
feat(info): surface nickname in /info + peer display (#643 Phase 2)

### DIFF
--- a/src/commands/plugins/peers/impl.ts
+++ b/src/commands/plugins/peers/impl.ts
@@ -74,6 +74,7 @@ export async function cmdAdd(opts: AddOptions): Promise<AddResult> {
     lastSeen: probe.error ? null : new Date().toISOString(),
   };
   if (probe.error) peer.lastError = probe.error;
+  if (probe.nickname) peer.nickname = probe.nickname;
 
   let existed = false;
   mutatePeers((data) => {
@@ -114,6 +115,9 @@ export async function cmdProbe(alias: string): Promise<ProbeResult> {
       delete p.lastError;
       p.lastSeen = now;
       if (probe.node) p.node = probe.node;
+      // Refresh nickname on success: string updates, null clears.
+      if (probe.nickname) p.nickname = probe.nickname;
+      else if (probe.nickname === null) delete p.nickname;
     }
   });
 
@@ -152,8 +156,14 @@ export function cmdRemove(alias: string): boolean {
 
 export function formatList(rows: Array<{ alias: string } & Peer>): string {
   if (!rows.length) return "no peers";
-  const header = ["alias", "url", "node", "lastSeen"];
-  const lines = rows.map(r => [r.alias, r.url, r.node ?? "-", r.lastSeen ?? "-"]);
+  const header = ["alias", "url", "node", "nickname", "lastSeen"];
+  const lines = rows.map(r => [
+    r.alias,
+    r.url,
+    r.node ?? "-",
+    r.nickname ?? "-",
+    r.lastSeen ?? "-",
+  ]);
   const widths = header.map((h, i) =>
     Math.max(h.length, ...lines.map(l => l[i].length)));
   const fmt = (cols: string[]) => cols.map((c, i) => c.padEnd(widths[i])).join("  ");

--- a/src/commands/plugins/peers/peers-probe.test.ts
+++ b/src/commands/plugins/peers/peers-probe.test.ts
@@ -428,6 +428,109 @@ describe("probePeer — maw handshake gate (#628)", () => {
       server.stop(true);
     }
   });
+
+  // ─── Nickname propagation (#643 Phase 2) ──────────────────────────────────
+  it("extracts optional nickname string from /info body", async () => {
+    const server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname === "/info") {
+          return Response.json({
+            node: "enriched-peer",
+            nickname: "Mo",
+            maw: { schema: "1", plugins: { manifestEndpoint: "/api/plugins" }, capabilities: [] },
+          });
+        }
+        return new Response("nope", { status: 404 });
+      },
+    });
+    try {
+      const { probePeer } = await import("./probe");
+      const r = await probePeer(`http://127.0.0.1:${server.port}`, 1500);
+      expect(r.error).toBeUndefined();
+      expect(r.node).toBe("enriched-peer");
+      expect(r.nickname).toBe("Mo");
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  it("nickname is null when /info omits the field", async () => {
+    const server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname === "/info") {
+          return Response.json({ node: "plain-peer", maw: true });
+        }
+        return new Response("nope", { status: 404 });
+      },
+    });
+    try {
+      const { probePeer } = await import("./probe");
+      const r = await probePeer(`http://127.0.0.1:${server.port}`, 1500);
+      expect(r.error).toBeUndefined();
+      expect(r.nickname).toBeNull();
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  it("empty-string nickname in /info resolves to null (not '')", async () => {
+    const server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname === "/info") {
+          return Response.json({ node: "blank", nickname: "", maw: true });
+        }
+        return new Response("nope", { status: 404 });
+      },
+    });
+    try {
+      const { probePeer } = await import("./probe");
+      const r = await probePeer(`http://127.0.0.1:${server.port}`, 1500);
+      expect(r.error).toBeUndefined();
+      expect(r.nickname).toBeNull();
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  it("cmdAdd persists nickname and cmdProbe clears it when peer drops it", async () => {
+    let currentNickname: string | null = "Moe";
+    const server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname === "/info") {
+          const body: Record<string, unknown> = { node: "roundtrip", maw: true };
+          if (currentNickname !== null) body.nickname = currentNickname;
+          return Response.json(body);
+        }
+        return new Response("nope", { status: 404 });
+      },
+    });
+    try {
+      const { cmdAdd, cmdInfo, cmdProbe } = await import("./impl");
+      const add = await cmdAdd({ alias: "r", url: `http://127.0.0.1:${server.port}` });
+      expect(add.peer.nickname).toBe("Moe");
+      expect(cmdInfo("r")?.nickname).toBe("Moe");
+
+      // Peer drops its nickname — re-probe should clear it on the store.
+      currentNickname = null;
+      const probed = await cmdProbe("r");
+      expect(probed.ok).toBe(true);
+      expect(cmdInfo("r")?.nickname).toBeUndefined();
+    } finally {
+      server.stop(true);
+    }
+  });
 });
 
 describe("back-compat", () => {

--- a/src/commands/plugins/peers/peers.test.ts
+++ b/src/commands/plugins/peers/peers.test.ts
@@ -101,6 +101,22 @@ describe("peers impl", () => {
     expect(out).toContain("w");
     expect(out).toContain("http://w.local");
   });
+
+  it("formatList includes a nickname column (#643 Phase 2)", async () => {
+    const { formatList } = await import("./impl");
+    const now = new Date().toISOString();
+    const out = formatList([
+      { alias: "w", url: "http://w.local", node: "white", addedAt: now, lastSeen: now, nickname: "Moe" },
+      { alias: "b", url: "http://b.local", node: "black", addedAt: now, lastSeen: now },
+    ]);
+    // Header names the column.
+    expect(out).toMatch(/nickname/);
+    // Set nickname renders; missing renders as "-".
+    expect(out).toContain("Moe");
+    const blackLine = out.split("\n").find(l => l.startsWith("b  "));
+    expect(blackLine).toBeDefined();
+    expect(blackLine).toMatch(/\s-\s/);
+  });
 });
 
 describe("peers store — atomic write crash-safety", () => {

--- a/src/commands/plugins/peers/probe.ts
+++ b/src/commands/plugins/peers/probe.ts
@@ -14,6 +14,8 @@ export type ProbeErrorCode = LastError["code"];
 
 export interface ProbeResult {
   node: string | null;
+  /** Peer's self-reported nickname from /info (#643 Phase 2). Null means peer did not advertise one. */
+  nickname?: string | null;
   error?: LastError;
 }
 
@@ -151,9 +153,9 @@ export async function probePeer(url: string, timeoutMs = 2000): Promise<ProbeRes
     };
   }
 
-  let body: { node?: unknown; name?: unknown; maw?: unknown };
+  let body: { node?: unknown; name?: unknown; nickname?: unknown; maw?: unknown };
   try {
-    body = await res.json() as { node?: unknown; name?: unknown; maw?: unknown };
+    body = await res.json() as { node?: unknown; name?: unknown; nickname?: unknown; maw?: unknown };
   } catch (e) {
     return {
       node: null,
@@ -195,7 +197,12 @@ export async function probePeer(url: string, timeoutMs = 2000): Promise<ProbeRes
     };
   }
 
-  return { node };
+  // Nickname is optional and strictly cosmetic — only accept non-empty strings.
+  const nickname = typeof body.nickname === "string" && body.nickname.length > 0
+    ? body.nickname
+    : null;
+
+  return { node, nickname };
 }
 
 /**

--- a/src/commands/plugins/peers/store.ts
+++ b/src/commands/plugins/peers/store.ts
@@ -50,6 +50,8 @@ export interface Peer {
   lastSeen: string | null;
   /** Optional — set by probePeer() when handshake fails; cleared on success. */
   lastError?: LastError;
+  /** Optional human-friendly nickname, propagated from peer's /info (#643 Phase 2). */
+  nickname?: string | null;
 }
 
 export interface PeersFile {

--- a/src/views/info.ts
+++ b/src/views/info.ts
@@ -3,6 +3,7 @@ import { hostname } from "os";
 import { readFileSync } from "fs";
 import { join } from "path";
 import { loadConfig } from "../config";
+import { resolveNickname } from "../core/fleet/nicknames";
 
 /**
  * Self-describing maw field — schema "1" (#628).
@@ -24,6 +25,8 @@ export interface InfoResponse {
   node: string;
   version: string;
   ts: string;
+  /** Optional human-friendly nickname for this oracle (#643 Phase 2). */
+  nickname?: string;
   maw: InfoMaw;
 }
 
@@ -45,9 +48,28 @@ function readNode(): string {
   return hostname();
 }
 
+/**
+ * Look up the nickname for the local oracle (#643 Phase 2).
+ *
+ * Resolution: read-through cache keyed by node name, with cwd's
+ * `ψ/nickname` as on-disk fallback (the maw-js server runs from the
+ * oracle repo, so cwd == local oracle repo in the common case).
+ * Any error → omit silently; nickname is strictly cosmetic.
+ */
+function readLocalNickname(node: string): string | undefined {
+  try {
+    const v = resolveNickname(node, process.cwd());
+    return v ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function buildInfo(): InfoResponse {
-  return {
-    node: readNode(),
+  const node = readNode();
+  const nickname = readLocalNickname(node);
+  const resp: InfoResponse = {
+    node,
     version: readVersion(),
     ts: new Date().toISOString(),
     maw: {
@@ -58,6 +80,8 @@ export function buildInfo(): InfoResponse {
       capabilities: ["plugin.listManifest", "peer.handshake", "info"],
     },
   };
+  if (nickname) resp.nickname = nickname;
+  return resp;
 }
 
 export const infoView = new Hono();

--- a/test/info-endpoint.test.ts
+++ b/test/info-endpoint.test.ts
@@ -5,10 +5,14 @@
  * consumed by src/commands/plugins/peers/probe.ts:111.
  */
 
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { Hono } from "hono";
 import { hostname } from "os";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 import { buildInfo, infoView } from "../src/views/info";
+import { setCachedNickname } from "../src/core/fleet/nicknames";
 
 describe("buildInfo()", () => {
   test("returns required fields with correct types", () => {
@@ -46,6 +50,46 @@ describe("buildInfo()", () => {
     // Either cfg.node was set, or os.hostname() — both non-empty.
     const h = hostname();
     expect([info.node, h].every(s => typeof s === "string" && s.length > 0)).toBe(true);
+  });
+});
+
+describe("buildInfo() nickname propagation (#643 Phase 2)", () => {
+  let prevMawHome: string | undefined;
+  let sandbox: string;
+
+  beforeEach(() => {
+    sandbox = mkdtempSync(join(tmpdir(), "maw-info-nickname-"));
+    prevMawHome = process.env.MAW_HOME;
+    process.env.MAW_HOME = sandbox;
+  });
+
+  afterEach(() => {
+    if (prevMawHome === undefined) delete process.env.MAW_HOME;
+    else process.env.MAW_HOME = prevMawHome;
+    rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  test("nickname field is omitted when unset", () => {
+    const info = buildInfo();
+    expect(info.nickname).toBeUndefined();
+    // Serializes without the field at all — optional by shape.
+    const json = JSON.parse(JSON.stringify(info));
+    expect("nickname" in json).toBe(false);
+  });
+
+  test("nickname field is populated when cache has an entry for the local node", () => {
+    const { node } = buildInfo();
+    setCachedNickname(node, "Moe");
+    const info = buildInfo();
+    expect(info.nickname).toBe("Moe");
+  });
+
+  test("empty-string cache entry does not surface as a nickname", () => {
+    const { node } = buildInfo();
+    // Explicit clear — should behave as "unset".
+    setCachedNickname(node, "");
+    const info = buildInfo();
+    expect(info.nickname).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary
- `/info` response now carries an optional `nickname` field — resolved via the nickname cache (node-name keyed) with cwd's `ψ/nickname` as fallback. Field is omitted when unset, so pre-#643 consumers remain unaffected.
- `probePeer()` extracts peer-advertised nickname from `/info`; `cmdAdd` / `cmdProbe` persist it on the `Peer` record and refresh it on re-probe (non-empty → set, null/empty → clear).
- `maw peers list` renders a `nickname` column; `maw peers info <alias>` surfaces it through the unchanged JSON spread.

## Why
Phase 2 of #643 — Phase 1 (#647) shipped local nickname storage + CLI; #648 gave `/info` a self-describing shape that now takes structured optional fields. This wires those pieces together so nicknames travel across the federation.

## Test plan
- [x] `bun test test/info-endpoint.test.ts` — 9/9 (3 new nickname cases)
- [x] `bun test src/commands/plugins/peers/` — 69/69 (4 new probe cases + 1 formatList column case)
- [x] `bun run test:all` — all 4 stages green, 0 fail
- [x] Backwards-compat: peers advertising only `{ maw: true }` still handshake; nickname resolves to null

🤖 Generated with [Claude Code](https://claude.com/claude-code)