### PR TITLE
bump: v26.4.18-alpha.27

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.18-alpha.26",
+  "version": "26.4.18-alpha.27",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
## Summary

Cut alpha.27 — 14 commits on main past v26.4.18-alpha.26.

## Changes

### feat
- Shape A federated search — `maw plugin search-peers` (#650)
- @peer install syntax — `maw plugin install @peer/name` (#658)
- Self-describing `maw info` contract — schema + capabilities (#648)
- PIN-consent primitive for `maw hey` (#657, Phase 1 of #644)
- Oracle nickname field — Phase 1 (#647) + Phase 2 propagation in /info + peer display (#656)
- SDK expansion — cmdBud + cmdOracle* + getTransportRouter (#646)
- Peers fail loud on handshake failure; opt-in `--allow-peer-failure` (no PR#, c6bc746/1c43d1a)

### fix
- Auto-link maw-js on `plugin install --link` (#645)
- Peers HTTP_4XX hint names stale-peer case (#637)
- `maw bud` uses ghq root for post-clone scaffolding path (#630)

### test
- Peer manifest adversarial harness (#654)

### docs
- Cross-oracle dogfood protocol for plugins (#652)
- Surface existing 6-char pair flow from #573 (c6bc746)

## Test plan

- [x] `bun run test:all` — 344 pass / 0 fail / 6 skip
- [ ] CI green on this PR
- [ ] Tag post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)