### PR TITLE
feat(consent): gate @peer plugin install behind PIN (#644 Phase 3)

### DIFF
--- a/docs/plugins/at-peer-install.md
+++ b/docs/plugins/at-peer-install.md
@@ -204,6 +204,59 @@ acceptance criterion from the task.
 
 ---
 
+## 7.3. PIN-consent gate (#644 Phase 3)
+
+When `MAW_CONSENT=1`, `cmdPluginInstall` gates `<name>@<peer>` installs
+from untrusted peers behind a PIN handshake before any artifact bytes
+are fetched:
+
+```text
+$ MAW_CONSENT=1 maw plugin install ping@mawjs-parent
+→ mawjs-parent (mawjs-parent) advertises: ping@1.0.0 (sha256: 9a34beefdead…)
+⏸  consent required → plugin-install
+   peer:   mawjs-parent (mawjs-parent)  [http://mawjs-parent.internal:2700]
+   plugin: ping@1.0.0  sha256:9a34beef…
+   request id: 5f2c…
+   PIN (relay OOB to mawjs-parent operator): K7X3M9
+   expires: 2026-04-19T17:22:00.000Z
+
+   on mawjs-parent: maw consent approve 5f2c… K7X3M9
+   then re-run: maw plugin install ping@mawjs-parent
+```
+
+Flow:
+
+1. `resolvePeerInstall` returns the advertised version + sha256 + peer URL.
+2. `maybeGatePluginInstall` checks `trust.json` for
+   `myNode → peerNode : plugin-install`. If present → allow.
+3. Otherwise, POST `/api/consent/request` to the peer, mirror the pending
+   entry locally, surface the PIN via stderr, exit 2.
+4. Operator on the peer runs `maw consent approve <id> <pin>`. That
+   writes a trust entry (the PIN is the OOB authentication of the
+   initiator's identity — an attacker who impersonates `from` can't
+   produce the PIN printed on the real initiator's terminal).
+5. Re-running `maw plugin install ping@mawjs-parent` now bypasses the
+   gate and proceeds to `installFromUrl`.
+
+Gate scope is intentionally narrow:
+
+- Only gates `kind: "peer"` (`<name>@<peer>`). Local paths, tarballs, and
+  raw URLs are unaffected — those are either the operator's own bytes or
+  already covered by `plugins.lock`.
+- Default OFF — users opt in via `MAW_CONSENT=1`, matching the Phase 1
+  (`maw hey`) and Phase 2 (`maw team invite`) convention.
+- Trust key is scoped to `plugin-install` — a trust entry for `hey` does
+  NOT authorize plugin installs (see `ConsentAction` in
+  `src/core/consent/store.ts`).
+- When the peer doesn't advertise its node name (legacy), the gate falls
+  back to the `namedPeer` nickname for the trust key so the entry is
+  still usable.
+
+Trust entries live in `~/.maw/trust.json`; revoke via the existing
+`maw consent revoke` command (or delete the key manually).
+
+---
+
 ## 8. File ownership
 
 - `src/commands/plugins/plugin/install-impl.ts` — new `@peer` dispatch branch
@@ -214,6 +267,9 @@ acceptance criterion from the task.
 - `src/api/plugin-download.ts` — NEW, `/plugin/download/:name` endpoint
 - `src/api/index.ts` — mount the new endpoint
 - `test/integration/plugin-install-at-peer.test.ts` — NEW, 2-port demo
+- `src/core/consent/gate-plugin-install.ts` — NEW (#644 Phase 3), gate helper
+- `test/core/consent/gate-plugin-install.test.ts` — NEW (#644 Phase 3), unit tests
+- `test/integration/plugin-install-consent.test.ts` — NEW (#644 Phase 3), 2-port consent demo
 - `docs/plugins/at-peer-install.md` — this doc
 
 No changes to `plugins.lock` semantics, `installFromTarball`, or

--- a/src/commands/plugins/plugin/install-impl.ts
+++ b/src/commands/plugins/plugin/install-impl.ts
@@ -82,6 +82,30 @@ export async function cmdPluginInstall(args: string[]): Promise<void> {
       `${mode.name}@${resolved.version}` +
       (resolved.peerSha256 ? ` (sha256: ${resolved.peerSha256.slice(0, 12)}…)` : ""),
     );
+
+    // #644 Phase 3 — PIN consent before we touch the network for the artifact.
+    // Default OFF; opt in via MAW_CONSENT=1. Gate lives here (not in resolver)
+    // so the operator sees what the peer advertised BEFORE being asked to
+    // approve — the decision context is on-screen.
+    if (process.env.MAW_CONSENT === "1") {
+      const { maybeGatePluginInstall } = await import("../../../core/consent/gate-plugin-install");
+      const { loadConfig } = await import("../../../config");
+      const myNode = loadConfig().node ?? "local";
+      const decision = await maybeGatePluginInstall({
+        myNode,
+        peerName: resolved.peerName,
+        peerNode: resolved.peerNode,
+        peerUrl: resolved.peerUrl,
+        pluginName: mode.name,
+        pluginVersion: resolved.version,
+        pluginSha256: resolved.peerSha256,
+      });
+      if (!decision.allow) {
+        if (decision.message) console.error(decision.message);
+        process.exit(decision.exitCode ?? 1);
+      }
+    }
+
     console.log(`→ downloading ${resolved.downloadUrl}…`);
     await installFromUrl(resolved.downloadUrl, { force, weight, pin });
   } else {

--- a/src/commands/plugins/plugin/install-peer-resolver.test.ts
+++ b/src/commands/plugins/plugin/install-peer-resolver.test.ts
@@ -35,6 +35,8 @@ describe("resolvePeerInstall — happy path", () => {
     expect(r.peerName).toBe("mawjs-parent");
     expect(r.peerNode).toBe("mawjs-parent");
     expect(r.version).toBe("1.0.0");
+    // #644 Phase 3 — peerUrl threaded through for the consent gate.
+    expect(r.peerUrl).toBe("http://peer.internal:2700");
   });
 
   it("percent-encodes the plugin name in the download URL", async () => {

--- a/src/commands/plugins/plugin/install-peer-resolver.ts
+++ b/src/commands/plugins/plugin/install-peer-resolver.ts
@@ -20,6 +20,8 @@ export interface ResolvedPeerSource {
   peerNode?: string;
   /** The version the peer advertised — surfaced in the success label. */
   version: string;
+  /** Peer base URL — used by the #644 Phase 3 consent gate to POST /api/consent/request. */
+  peerUrl: string;
 }
 
 export interface ResolvePeerInstallOpts {
@@ -87,6 +89,7 @@ export async function resolvePeerInstall(
     peerSha256: hit.sha256,
     peerName: hit.peerName ?? peer,
     version: hit.version,
+    peerUrl: hit.peerUrl,
   };
   if (hit.peerNode) resolved.peerNode = hit.peerNode;
   return resolved;

--- a/src/core/consent/gate-plugin-install.ts
+++ b/src/core/consent/gate-plugin-install.ts
@@ -1,0 +1,107 @@
+/**
+ * Consent gate for `maw plugin install <name>@<peer>` (#644 Phase 3).
+ *
+ * Plugin install is the highest-risk consent action — the artifact becomes
+ * executable code under the caller's ambient privilege. Phase 3 gates it
+ * behind the same PIN-consent dance as `maw hey` + `maw team invite`:
+ *
+ *   1. If the peer/action pair is already trusted → allow.
+ *   2. Otherwise, generate a PIN, POST to the peer's /api/consent/request,
+ *      mirror locally, and surface the PIN via the terminal. The operator
+ *      on the PEER side types `maw consent approve <id> <pin>` and then
+ *      the caller re-runs `maw plugin install`.
+ *
+ * This gate DOES NOT gate local-path, tarball, or URL installs — only
+ * `<name>@<peer>` (see cmdPluginInstall). Local installs are already the
+ * operator's own bytes; URL installs are blocked by plugins.lock pinning.
+ *
+ * Default OFF. Opt-in via MAW_CONSENT=1 (same convention as Phase 1/2).
+ */
+import { isTrusted, requestConsent } from "./index";
+
+export interface PluginInstallGateContext {
+  /** Caller's node name. Trust keys are `myNode→peerNode:plugin-install`. */
+  myNode: string;
+  /** Peer nickname (namedPeers[].name) — shown in the summary. */
+  peerName: string;
+  /** Peer node name from manifest. May be absent on legacy peers. */
+  peerNode?: string;
+  /** Peer base URL — the "hard ID" + the target for POST /api/consent/request. */
+  peerUrl: string;
+  /** Plugin name being installed. */
+  pluginName: string;
+  /** Plugin version the peer advertised. */
+  pluginVersion: string;
+  /** sha256 the peer advertised. Truncated to first 8 hex chars in the summary. */
+  pluginSha256?: string | null;
+}
+
+export interface PluginInstallGateDecision {
+  allow: boolean;
+  exitCode?: number;
+  /** Multi-line message for stderr. Set when allow=false. */
+  message?: string;
+}
+
+/** First 8 hex chars of an sha256:… string (or plain hex), for display only. */
+export function shortSha(sha?: string | null): string {
+  if (!sha) return "<no sha>";
+  const hex = sha.startsWith("sha256:") ? sha.slice("sha256:".length) : sha;
+  return hex.slice(0, 8);
+}
+
+export async function maybeGatePluginInstall(
+  ctx: PluginInstallGateContext,
+): Promise<PluginInstallGateDecision> {
+  const { myNode, peerName, peerNode, peerUrl, pluginName, pluginVersion, pluginSha256 } = ctx;
+
+  // Trust key requires a stable peer node identifier. Fall back to peerName
+  // when the peer didn't advertise its node (legacy) so install isn't silently
+  // un-trustable — the trust decision just binds to nickname instead.
+  const peerIdForTrust = peerNode || peerName;
+  if (isTrusted(myNode, peerIdForTrust, "plugin-install")) {
+    return { allow: true };
+  }
+
+  const sha8 = shortSha(pluginSha256);
+  const summary =
+    `plugin-install ${pluginName}@${pluginVersion} from ${peerName}` +
+    `${peerNode ? ` (${peerNode})` : ""}` +
+    ` sha256:${sha8}…`;
+
+  const r = await requestConsent({
+    from: myNode,
+    to: peerIdForTrust,
+    action: "plugin-install",
+    summary,
+    peerUrl,
+  });
+
+  if (!r.ok) {
+    return {
+      allow: false,
+      exitCode: 1,
+      message: [
+        `\x1b[31m✗ consent request failed\x1b[0m: ${r.error}`,
+        r.requestId ? `  request id (local mirror): ${r.requestId}` : "",
+        `  hint: peer may be down, or /api/consent/request not yet deployed`,
+      ].filter(Boolean).join("\n"),
+    };
+  }
+
+  return {
+    allow: false,
+    exitCode: 2,
+    message: [
+      `\x1b[33m⏸  consent required\x1b[0m → plugin-install`,
+      `   peer:   ${peerName}${peerNode ? ` (${peerNode})` : ""}  [${peerUrl}]`,
+      `   plugin: ${pluginName}@${pluginVersion}  sha256:${sha8}…`,
+      `   request id: ${r.requestId}`,
+      `   PIN (relay OOB to ${peerIdForTrust} operator): \x1b[1m${r.pin}\x1b[0m`,
+      `   expires: ${r.expiresAt}`,
+      ``,
+      `   on ${peerIdForTrust}: \x1b[36mmaw consent approve ${r.requestId} ${r.pin}\x1b[0m`,
+      `   then re-run: \x1b[36mmaw plugin install ${pluginName}@${peerName}\x1b[0m`,
+    ].join("\n"),
+  };
+}

--- a/src/core/consent/index.ts
+++ b/src/core/consent/index.ts
@@ -19,3 +19,7 @@ export {
   type ConsentRequest, type ConsentResult,
   newRequestId, requestConsent, approveConsent, rejectConsent,
 } from "./request";
+export {
+  type PluginInstallGateContext, type PluginInstallGateDecision,
+  maybeGatePluginInstall, shortSha,
+} from "./gate-plugin-install";

--- a/test/core/consent/gate-plugin-install.test.ts
+++ b/test/core/consent/gate-plugin-install.test.ts
@@ -1,0 +1,152 @@
+/**
+ * maybeGatePluginInstall — unit tests (#644 Phase 3).
+ *
+ * Gate is decision-only: it doesn't print or exit. We assert the decision
+ * shape and on side-effects to the local stores (pending mirror + trust).
+ *
+ * Network I/O is stubbed via globalThis.fetch override — same pattern as
+ * the Phase 1 gate.test.ts.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+import {
+  maybeGatePluginInstall,
+  shortSha,
+} from "../../../src/core/consent/gate-plugin-install";
+import { recordTrust, listPending } from "../../../src/core/consent";
+
+let workdir: string;
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), "consent-pi-gate-"));
+  process.env.CONSENT_TRUST_FILE = join(workdir, "trust.json");
+  process.env.CONSENT_PENDING_DIR = join(workdir, "consent-pending");
+});
+
+afterEach(() => {
+  delete process.env.CONSENT_TRUST_FILE;
+  delete process.env.CONSENT_PENDING_DIR;
+  rmSync(workdir, { recursive: true, force: true });
+});
+
+function ctx(over: Partial<Parameters<typeof maybeGatePluginInstall>[0]> = {}) {
+  return {
+    myNode: "neo",
+    peerName: "white-peer",
+    peerNode: "white",
+    peerUrl: "http://white:3456",
+    pluginName: "ping",
+    pluginVersion: "1.0.0",
+    pluginSha256: "sha256:9a34beefdeadcafe00112233",
+    ...over,
+  };
+}
+
+describe("shortSha", () => {
+  it("strips sha256: prefix and returns first 8 hex chars", () => {
+    expect(shortSha("sha256:9a34beefdeadcafe")).toBe("9a34beef");
+  });
+  it("handles bare hex without prefix", () => {
+    expect(shortSha("9a34beefdeadcafe")).toBe("9a34beef");
+  });
+  it("returns <no sha> for null/undefined/empty", () => {
+    expect(shortSha(null)).toBe("<no sha>");
+    expect(shortSha(undefined)).toBe("<no sha>");
+    expect(shortSha("")).toBe("<no sha>");
+  });
+});
+
+describe("maybeGatePluginInstall", () => {
+  it("allows when peer is already trusted for plugin-install", async () => {
+    recordTrust({
+      from: "neo", to: "white", action: "plugin-install",
+      approvedAt: new Date().toISOString(), approvedBy: "human", requestId: null,
+    });
+    const r = await maybeGatePluginInstall(ctx());
+    expect(r.allow).toBe(true);
+    // No pending mirror should have been created.
+    expect(listPending().length).toBe(0);
+  });
+
+  it("does NOT cross trust scopes — a 'hey' trust entry does not allow plugin-install", async () => {
+    recordTrust({
+      from: "neo", to: "white", action: "hey",
+      approvedAt: new Date().toISOString(), approvedBy: "human", requestId: null,
+    });
+    const origFetch = globalThis.fetch;
+    (globalThis as any).fetch = async () => ({ ok: true, status: 201 } as Response);
+    try {
+      const r = await maybeGatePluginInstall(ctx());
+      expect(r.allow).toBe(false);
+      expect(r.exitCode).toBe(2);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it("denies and surfaces PIN + plugin context when peer reachable", async () => {
+    const origFetch = globalThis.fetch;
+    (globalThis as any).fetch = async () => ({ ok: true, status: 201 } as Response);
+    try {
+      const r = await maybeGatePluginInstall(ctx());
+      expect(r.allow).toBe(false);
+      expect(r.exitCode).toBe(2);
+      expect(r.message).toContain("consent required");
+      expect(r.message).toContain("plugin-install");
+      // Peer context shown
+      expect(r.message).toContain("white-peer");
+      expect(r.message).toContain("white");
+      expect(r.message).toContain("http://white:3456");
+      // Plugin context shown
+      expect(r.message).toContain("ping@1.0.0");
+      // Short sha — first 8 hex chars of the sha256
+      expect(r.message).toContain("9a34beef");
+      // PIN format (6 chars, A-Z2-9)
+      expect(r.message).toMatch(/[A-Z2-9]{6}/);
+      // Pending mirror was written
+      expect(listPending().length).toBe(1);
+      expect(listPending()[0]!.action).toBe("plugin-install");
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it("returns exitCode 1 with error message when peer unreachable", async () => {
+    const origFetch = globalThis.fetch;
+    (globalThis as any).fetch = async () => { throw new Error("ECONNREFUSED"); };
+    try {
+      const r = await maybeGatePluginInstall(ctx());
+      expect(r.allow).toBe(false);
+      expect(r.exitCode).toBe(1);
+      expect(r.message).toContain("consent request failed");
+      expect(r.message).toContain("ECONNREFUSED");
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it("falls back to peerName for trust key when peerNode is absent", async () => {
+    // Record trust under peerName (the fallback identifier).
+    recordTrust({
+      from: "neo", to: "white-peer", action: "plugin-install",
+      approvedAt: new Date().toISOString(), approvedBy: "human", requestId: null,
+    });
+    const r = await maybeGatePluginInstall(ctx({ peerNode: undefined }));
+    expect(r.allow).toBe(true);
+  });
+
+  it("handles a missing sha256 gracefully (shows <no sha>)", async () => {
+    const origFetch = globalThis.fetch;
+    (globalThis as any).fetch = async () => ({ ok: true, status: 201 } as Response);
+    try {
+      const r = await maybeGatePluginInstall(ctx({ pluginSha256: null }));
+      expect(r.allow).toBe(false);
+      expect(r.message).toContain("<no sha>");
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+});

--- a/test/integration/plugin-install-consent.test.ts
+++ b/test/integration/plugin-install-consent.test.ts
@@ -1,0 +1,288 @@
+/**
+ * @peer install + consent gate — 2-port integration demo (#644 Phase 3).
+ *
+ * Variant of plugin-install-at-peer.test.ts that drives the PIN-consent
+ * flow end-to-end:
+ *
+ *   1. Untrusted pair — gate blocks, PIN surfaced, pending mirror written
+ *      locally + peer received the /api/consent/request POST.
+ *   2. After recording a trust entry for myNode → peerNode : plugin-install,
+ *      the gate allows and the real install proceeds.
+ *
+ * Hermetic: MAW_PLUGINS_DIR, MAW_PLUGINS_LOCK, CONSENT_TRUST_FILE,
+ * CONSENT_PENDING_DIR all redirect to a per-test tmpdir.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
+import { spawnSync } from "child_process";
+import { tmpdir } from "os";
+import { createHash } from "crypto";
+import { join } from "path";
+
+import { resolvePeerInstall } from "../../src/commands/plugins/plugin/install-peer-resolver";
+import { installFromUrl } from "../../src/commands/plugins/plugin/install-handlers";
+import { maybeGatePluginInstall } from "../../src/core/consent/gate-plugin-install";
+import { listPending, recordTrust } from "../../src/core/consent";
+import { runtimeSdkVersion } from "../../src/plugin/registry";
+import type { PeerManifestResponse } from "../../src/api/plugin-list-manifest";
+import type { CurlResponse } from "../../src/core/transport/curl-fetch";
+
+const SKIP = process.env.MAW_SKIP_INTEGRATION === "1";
+
+async function rawFetch(url: string, opts?: { timeout?: number }): Promise<CurlResponse> {
+  try {
+    const controller = new AbortController();
+    const t = setTimeout(() => controller.abort(), opts?.timeout ?? 5000);
+    const res = await fetch(url, { signal: controller.signal });
+    clearTimeout(t);
+    const text = await res.text();
+    const data = text ? JSON.parse(text) : null;
+    return { ok: res.ok, status: res.status, data };
+  } catch {
+    return { ok: false, status: 0, data: null };
+  }
+}
+
+function sha256File(path: string): string {
+  return `sha256:${createHash("sha256").update(readFileSync(path)).digest("hex")}`;
+}
+
+function buildFakePlugin(root: string, name: string, version: string): { sha256: string } {
+  mkdirSync(root, { recursive: true });
+  const artifactRel = "dist/index.js";
+  const artifactAbs = join(root, artifactRel);
+  mkdirSync(join(root, "dist"), { recursive: true });
+  writeFileSync(
+    artifactAbs,
+    `// Fake built plugin for consent integration test.\nexport default { name: ${JSON.stringify(name)} };\n`,
+  );
+  const sha256 = sha256File(artifactAbs);
+  const manifest = {
+    name,
+    version,
+    sdk: runtimeSdkVersion(),
+    description: "Integration-test plugin for #644 Phase 3",
+    artifact: { path: artifactRel, sha256 },
+  };
+  writeFileSync(join(root, "plugin.json"), JSON.stringify(manifest, null, 2) + "\n");
+  return { sha256 };
+}
+
+/**
+ * Peer server that additionally accepts POST /api/consent/request so the
+ * gate's request-consent HTTP call succeeds against real bytes.
+ */
+function startPeerServer(opts: {
+  node: string;
+  plugins: Array<{ name: string; version: string; sha256: string; dir: string }>;
+  receivedConsent: Array<unknown>;
+}) {
+  const byName = new Map(opts.plugins.map(p => [p.name, p]));
+  const server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    async fetch(req: Request) {
+      const url = new URL(req.url);
+
+      if (url.pathname === "/api/consent/request" && req.method === "POST") {
+        try {
+          opts.receivedConsent.push(await req.json());
+        } catch {
+          opts.receivedConsent.push({ error: "malformed body" });
+        }
+        return new Response(null, { status: 201 });
+      }
+
+      if (url.pathname === "/api/plugin/list-manifest") {
+        const body: PeerManifestResponse = {
+          schemaVersion: 1,
+          node: opts.node,
+          pluginCount: opts.plugins.length,
+          plugins: opts.plugins.map(p => ({
+            name: p.name,
+            version: p.version,
+            sha256: p.sha256,
+            downloadUrl: `/api/plugin/download/${encodeURIComponent(p.name)}`,
+          })),
+        };
+        return Response.json(body);
+      }
+      const dlMatch = url.pathname.match(/^\/api\/plugin\/download\/([^/]+)$/);
+      if (dlMatch) {
+        const name = decodeURIComponent(dlMatch[1]!);
+        const p = byName.get(name);
+        if (!p) return new Response(JSON.stringify({ error: "not installed" }), { status: 404 });
+        const tar = spawnSync("tar", ["-czf", "-", "-C", p.dir, "."], { encoding: "buffer" });
+        if (tar.status !== 0) return new Response("tar failed", { status: 500 });
+        return new Response(tar.stdout, {
+          status: 200,
+          headers: {
+            "Content-Type": "application/gzip",
+            "Content-Disposition": `attachment; filename="${name}-${p.version}.tgz"`,
+          },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+  return { server, url: `http://127.0.0.1:${server.port}` };
+}
+
+describe.skipIf(SKIP)("plugin install — @peer + consent gate (#644 Phase 3)", () => {
+  let workRoot: string;
+  let pluginSrc: string;
+  let pluginsDir: string;
+  let lockFile: string;
+  let trustFile: string;
+  let pendingDirPath: string;
+  let peer: ReturnType<typeof startPeerServer>;
+  let pluginSha: string;
+  let receivedConsent: Array<unknown>;
+  const pluginName = "integ-consent-ping";
+  const pluginVersion = "1.0.0";
+  const myNode = "client-node";
+  const peerNode = "peer-alpha";
+
+  const prev = {
+    pluginsDir: process.env.MAW_PLUGINS_DIR,
+    lock: process.env.MAW_PLUGINS_LOCK,
+    trust: process.env.CONSENT_TRUST_FILE,
+    pending: process.env.CONSENT_PENDING_DIR,
+  };
+
+  beforeAll(() => {
+    workRoot = mkdtempSync(join(tmpdir(), "maw-consent-install-"));
+    pluginSrc = join(workRoot, "src-plugin");
+    pluginsDir = join(workRoot, "client-plugins");
+    lockFile = join(workRoot, "plugins.lock");
+    trustFile = join(workRoot, "trust.json");
+    pendingDirPath = join(workRoot, "consent-pending");
+    mkdirSync(pluginsDir, { recursive: true });
+
+    const { sha256 } = buildFakePlugin(pluginSrc, pluginName, pluginVersion);
+    pluginSha = sha256;
+
+    receivedConsent = [];
+    peer = startPeerServer({
+      node: peerNode,
+      plugins: [{ name: pluginName, version: pluginVersion, sha256: pluginSha, dir: pluginSrc }],
+      receivedConsent,
+    });
+
+    process.env.MAW_PLUGINS_DIR = pluginsDir;
+    process.env.MAW_PLUGINS_LOCK = lockFile;
+    process.env.CONSENT_TRUST_FILE = trustFile;
+    process.env.CONSENT_PENDING_DIR = pendingDirPath;
+  });
+
+  afterAll(() => {
+    peer.server.stop(true);
+    rmSync(workRoot, { recursive: true, force: true });
+    for (const [k, v] of [
+      ["MAW_PLUGINS_DIR", prev.pluginsDir],
+      ["MAW_PLUGINS_LOCK", prev.lock],
+      ["CONSENT_TRUST_FILE", prev.trust],
+      ["CONSENT_PENDING_DIR", prev.pending],
+    ] as const) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  beforeEach(() => {
+    // Reset consent state between cases so each test sees a clean store.
+    rmSync(trustFile, { force: true });
+    rmSync(pendingDirPath, { recursive: true, force: true });
+    receivedConsent.length = 0;
+  });
+
+  it("gates untrusted install — denies, POSTs to peer, mirrors pending locally", async () => {
+    const resolved = await resolvePeerInstall(pluginName, "alpha", {
+      searchOpts: {
+        peers: [{ url: peer.url, name: "alpha" }],
+        fetch: rawFetch,
+        noCache: true,
+      },
+    });
+
+    const decision = await maybeGatePluginInstall({
+      myNode,
+      peerName: resolved.peerName,
+      peerNode: resolved.peerNode,
+      peerUrl: resolved.peerUrl,
+      pluginName,
+      pluginVersion: resolved.version,
+      pluginSha256: resolved.peerSha256,
+    });
+
+    expect(decision.allow).toBe(false);
+    expect(decision.exitCode).toBe(2);
+    expect(decision.message).toContain("consent required");
+    expect(decision.message).toContain(pluginName);
+    expect(decision.message).toMatch(/[A-Z2-9]{6}/);
+
+    // Peer received the POST (real HTTP, not injected).
+    expect(receivedConsent.length).toBe(1);
+    const body = receivedConsent[0] as { action: string; from: string; to: string };
+    expect(body.action).toBe("plugin-install");
+    expect(body.from).toBe(myNode);
+    expect(body.to).toBe(peerNode);
+
+    // Local pending mirror exists with matching action.
+    const pending = listPending();
+    expect(pending.length).toBe(1);
+    expect(pending[0]!.action).toBe("plugin-install");
+
+    // Plugin was NOT installed — gate short-circuited before download.
+    expect(existsSync(join(pluginsDir, pluginName))).toBe(false);
+  });
+
+  it("bypasses gate for pre-approved trust entry, then installs normally", async () => {
+    recordTrust({
+      from: myNode,
+      to: peerNode,
+      action: "plugin-install",
+      approvedAt: new Date().toISOString(),
+      approvedBy: "human",
+      requestId: null,
+    });
+
+    const resolved = await resolvePeerInstall(pluginName, "alpha", {
+      searchOpts: {
+        peers: [{ url: peer.url, name: "alpha" }],
+        fetch: rawFetch,
+        noCache: true,
+      },
+    });
+
+    const decision = await maybeGatePluginInstall({
+      myNode,
+      peerName: resolved.peerName,
+      peerNode: resolved.peerNode,
+      peerUrl: resolved.peerUrl,
+      pluginName,
+      pluginVersion: resolved.version,
+      pluginSha256: resolved.peerSha256,
+    });
+    expect(decision.allow).toBe(true);
+
+    // No consent POST, no pending mirror.
+    expect(receivedConsent.length).toBe(0);
+    expect(listPending().length).toBe(0);
+
+    // Install proceeds end-to-end.
+    await installFromUrl(resolved.downloadUrl, { pin: true, force: true });
+    const installedManifestPath = join(pluginsDir, pluginName, "plugin.json");
+    expect(existsSync(installedManifestPath)).toBe(true);
+    const m = JSON.parse(readFileSync(installedManifestPath, "utf8"));
+    expect(m.version).toBe(pluginVersion);
+    expect(m.artifact.sha256).toBe(pluginSha);
+  });
+});


### PR DESCRIPTION
## Summary

Wires the `#657` consent primitive into `cmdPluginInstall`'s `@peer` branch
so cross-oracle plugin installs from untrusted peers require a PIN handshake
before any artifact bytes are downloaded.

Plugin install = executable code under ambient privilege — highest-risk
consent action in the #644 stack. This is the third and final wire-up
following Phase 1 (`maw hey`) and Phase 2 (`maw team invite`).

- New gate `src/core/consent/gate-plugin-install.ts` — `maybeGatePluginInstall`
- Wired in `install-impl.ts` peer branch, BEFORE download
- `peerUrl` threaded through `ResolvedPeerSource` so the gate POSTs
  `/api/consent/request` at the right host
- Default OFF — opt-in via `MAW_CONSENT=1` (matches Phase 1/2 convention)
- Trusted pairs (`myNode → peerNode : plugin-install`) bypass the prompt
- Trust scope is `plugin-install` only — a `hey` trust entry does NOT
  authorize plugin installs
- Local-path / tarball / URL installs are unaffected — only `<name>@<peer>`

## Closes

Part of #644 (Phase 3 of 3).

## Test plan

- [x] `bun test test/core/consent/gate-plugin-install.test.ts` — 9 pass
- [x] `bun test src/commands/plugins/plugin/install-peer-resolver.test.ts` — 9 pass (adds `peerUrl` assertion)
- [x] `bun test test/integration/plugin-install-consent.test.ts` — 2 pass (2-port real HTTP: untrusted denies + peer receives POST + pending mirror written; trusted allows + install completes)
- [x] `bun run test:all` — 0 fail across all four suites
- [ ] CI green

## Flow preview

```text
$ MAW_CONSENT=1 maw plugin install ping@mawjs-parent
→ mawjs-parent (mawjs-parent) advertises: ping@1.0.0 (sha256: 9a34beefdead…)
⏸  consent required → plugin-install
   peer:   mawjs-parent (mawjs-parent)  [http://mawjs-parent.internal:2700]
   plugin: ping@1.0.0  sha256:9a34beef…
   request id: 5f2c…
   PIN (relay OOB to mawjs-parent operator): K7X3M9
   expires: ...

   on mawjs-parent: maw consent approve 5f2c… K7X3M9
   then re-run: maw plugin install ping@mawjs-parent
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)