### PR TITLE
feat(bud): --nickname flag sets pretty name at birth (#643 Phase 3)

### DIFF
--- a/src/commands/plugins/bud/bud.test.ts
+++ b/src/commands/plugins/bud/bud.test.ts
@@ -1,52 +1,86 @@
-import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
+import { describe, it, expect, mock, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, mkdirSync, rmSync, existsSync, readFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import type { InvokeContext } from "../../../plugin/types";
 
-// Load the real impl once, before any mock.module(./impl, …) rewrites the
-// module cache. Capture the function reference into a local so it survives
-// the later cache rewrite (namespace bindings are live and would otherwise
-// resolve to the mock, causing infinite recursion).
+// Capture real modules BEFORE any mock.module rewrites the cache.
+// Namespace imports are live bindings, so we copy function references into
+// locals to survive the rewrite (otherwise delegating to them would recurse
+// into the mock itself).
 import * as rawImpl from "./impl";
+import * as rawBudRepo from "./bud-repo";
+import * as rawBudWake from "./bud-wake";
+import * as rawBudInit from "./bud-init";
+import * as rawConfig from "../../../config";
+
 const realCmdBud = rawImpl.cmdBud;
+const realEnsureBudRepo = rawBudRepo.ensureBudRepo;
+const realFinalizeBud = rawBudWake.finalizeBud;
+const realInitVault = rawBudInit.initVault;
+const realGenerateClaudeMd = rawBudInit.generateClaudeMd;
+const realConfigureFleet = rawBudInit.configureFleet;
+const realWriteBirthNote = rawBudInit.writeBirthNote;
+const realConfigModule = { ...rawConfig };
 
 let lastOpts: any = null;
 let useReal = false;
 let budRepoPath = "";
 
-mock.module("./impl", () => ({
-  cmdBud: async (name: string, opts: any) => {
-    lastOpts = opts;
-    if (useReal) return realCmdBud(name, opts);
-    console.log(`budding ${name}`);
-  },
-}));
-
-// Stub repo/fleet/wake seams so #643 Phase 3 integration runs against a tmp dir.
-mock.module("./bud-repo", () => ({
-  ensureBudRepo: async () => budRepoPath,
-}));
-mock.module("./bud-wake", () => ({
-  finalizeBud: async () => {},
-}));
-mock.module("./bud-init", () => {
-  const { mkdirSync } = require("fs");
-  const { join } = require("path");
-  return {
-    initVault: (p: string) => {
-      const psi = join(p, "ψ");
-      mkdirSync(psi, { recursive: true });
-      return psi;
+function installMocks() {
+  mock.module("../../../config", () => ({
+    ...realConfigModule,
+    loadConfig: () => ({ ghqRoot: "/tmp/nope", githubOrg: "Soul-Brews-Studio", env: {}, commands: {}, sessions: {} }),
+  }));
+  mock.module("./impl", () => ({
+    cmdBud: async (name: string, opts: any) => {
+      lastOpts = opts;
+      if (useReal) return realCmdBud(name, opts);
+      console.log(`budding ${name}`);
     },
-    generateClaudeMd: () => {},
-    configureFleet: () => "/tmp/fake-fleet.json",
-    writeBirthNote: () => {},
-  };
-});
+  }));
+  mock.module("./bud-repo", () => ({
+    ensureBudRepo: async () => budRepoPath,
+  }));
+  mock.module("./bud-wake", () => ({
+    finalizeBud: async () => {},
+  }));
+  mock.module("./bud-init", () => {
+    const { mkdirSync } = require("fs");
+    const { join } = require("path");
+    return {
+      initVault: (p: string) => {
+        const psi = join(p, "ψ");
+        mkdirSync(psi, { recursive: true });
+        return psi;
+      },
+      generateClaudeMd: () => {},
+      configureFleet: () => "/tmp/fake-fleet.json",
+      writeBirthNote: () => {},
+    };
+  });
+}
+
+function restoreMocks() {
+  // Re-register the real modules — bun has no "unmock" primitive, so we
+  // install passthrough mocks that point back at the real implementations.
+  mock.module("../../../config", () => realConfigModule);
+  mock.module("./impl", () => ({ cmdBud: realCmdBud }));
+  mock.module("./bud-repo", () => ({ ensureBudRepo: realEnsureBudRepo }));
+  mock.module("./bud-wake", () => ({ finalizeBud: realFinalizeBud }));
+  mock.module("./bud-init", () => ({
+    initVault: realInitVault,
+    generateClaudeMd: realGenerateClaudeMd,
+    configureFleet: realConfigureFleet,
+    writeBirthNote: realWriteBirthNote,
+  }));
+}
 
 describe("bud plugin", () => {
   let handler: (ctx: InvokeContext) => Promise<any>;
+
+  beforeAll(() => installMocks());
+  afterAll(() => restoreMocks());
 
   beforeEach(async () => {
     lastOpts = null;
@@ -101,6 +135,9 @@ describe("bud plugin", () => {
 describe("cmdBud --nickname (#643 Phase 3)", () => {
   let prevMawHome: string | undefined;
   let sandbox: string;
+
+  beforeAll(() => installMocks());
+  afterAll(() => restoreMocks());
 
   beforeEach(() => {
     useReal = true;

--- a/src/commands/plugins/bud/bud.test.ts
+++ b/src/commands/plugins/bud/bud.test.ts
@@ -1,16 +1,56 @@
-import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, existsSync, readFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 import type { InvokeContext } from "../../../plugin/types";
 
+// Load the real impl once, before any mock.module(./impl, …) rewrites the
+// module cache. Capture the function reference into a local so it survives
+// the later cache rewrite (namespace bindings are live and would otherwise
+// resolve to the mock, causing infinite recursion).
+import * as rawImpl from "./impl";
+const realCmdBud = rawImpl.cmdBud;
+
+let lastOpts: any = null;
+let useReal = false;
+let budRepoPath = "";
+
 mock.module("./impl", () => ({
-  cmdBud: async (name: string, _opts: any) => {
+  cmdBud: async (name: string, opts: any) => {
+    lastOpts = opts;
+    if (useReal) return realCmdBud(name, opts);
     console.log(`budding ${name}`);
   },
 }));
+
+// Stub repo/fleet/wake seams so #643 Phase 3 integration runs against a tmp dir.
+mock.module("./bud-repo", () => ({
+  ensureBudRepo: async () => budRepoPath,
+}));
+mock.module("./bud-wake", () => ({
+  finalizeBud: async () => {},
+}));
+mock.module("./bud-init", () => {
+  const { mkdirSync } = require("fs");
+  const { join } = require("path");
+  return {
+    initVault: (p: string) => {
+      const psi = join(p, "ψ");
+      mkdirSync(psi, { recursive: true });
+      return psi;
+    },
+    generateClaudeMd: () => {},
+    configureFleet: () => "/tmp/fake-fleet.json",
+    writeBirthNote: () => {},
+  };
+});
 
 describe("bud plugin", () => {
   let handler: (ctx: InvokeContext) => Promise<any>;
 
   beforeEach(async () => {
+    lastOpts = null;
+    useReal = false;
     const mod = await import("./index");
     handler = mod.default;
   });
@@ -31,5 +71,85 @@ describe("bud plugin", () => {
     const result = await handler({ source: "cli", args: ["--unknown-flag"] });
     expect(result.ok).toBe(false);
     expect(result.error).toContain("looks like a flag");
+  });
+
+  it("cli: --nickname flag reaches cmdBud opts (#643 Phase 3)", async () => {
+    const result = await handler({
+      source: "cli",
+      args: ["myplugin", "--nickname", "Bloom Two", "--dry-run"],
+    });
+    expect(result.ok).toBe(true);
+    expect(lastOpts).not.toBeNull();
+    expect(lastOpts.nickname).toBe("Bloom Two");
+  });
+
+  it("api: nickname passes through", async () => {
+    const result = await handler({
+      source: "api",
+      args: { name: "myplugin", nickname: "Bloom Two", dryRun: true },
+    });
+    expect(result.ok).toBe(true);
+    expect(lastOpts.nickname).toBe("Bloom Two");
+  });
+});
+
+// ─── Integration: cmdBud --nickname writes ψ/nickname at birth (#643 Phase 3) ─
+//
+// Runs the real cmdBud (via `useReal = true`) but with repo/fleet/wake seams
+// stubbed above. Verifies the authoritative on-disk write.
+
+describe("cmdBud --nickname (#643 Phase 3)", () => {
+  let prevMawHome: string | undefined;
+  let sandbox: string;
+
+  beforeEach(() => {
+    useReal = true;
+    sandbox = mkdtempSync(join(tmpdir(), "maw-bud-nickname-"));
+    budRepoPath = join(sandbox, "repo");
+    mkdirSync(budRepoPath, { recursive: true });
+    prevMawHome = process.env.MAW_HOME;
+    process.env.MAW_HOME = join(sandbox, "home");
+    mkdirSync(process.env.MAW_HOME, { recursive: true });
+  });
+
+  afterEach(() => {
+    useReal = false;
+    if (prevMawHome === undefined) delete process.env.MAW_HOME;
+    else process.env.MAW_HOME = prevMawHome;
+    rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  it("writes ψ/nickname when --nickname is provided", async () => {
+    await realCmdBud("myplugin", { from: "mawjs", nickname: "Bloom Two" });
+
+    const file = join(budRepoPath, "ψ", "nickname");
+    expect(existsSync(file)).toBe(true);
+    expect(readFileSync(file, "utf-8")).toBe("Bloom Two\n");
+  });
+
+  it("does NOT write ψ/nickname when --nickname is absent", async () => {
+    await realCmdBud("plainbud", { from: "mawjs" });
+    expect(existsSync(join(budRepoPath, "ψ", "nickname"))).toBe(false);
+  });
+
+  it("trims surrounding whitespace before writing", async () => {
+    await realCmdBud("trimmed", { from: "mawjs", nickname: "  Bloom  " });
+    expect(readFileSync(join(budRepoPath, "ψ", "nickname"), "utf-8")).toBe("Bloom\n");
+  });
+
+  it("rejects multi-line nickname before touching repo", async () => {
+    await expect(
+      realCmdBud("badbud", { from: "mawjs", nickname: "line1\nline2" }),
+    ).rejects.toThrow(/single line/);
+  });
+
+  it("whitespace-only nickname is a no-op (no file written)", async () => {
+    await realCmdBud("whitespace", { from: "mawjs", nickname: "   " });
+    expect(existsSync(join(budRepoPath, "ψ", "nickname"))).toBe(false);
+  });
+
+  it("dry-run previews the nickname without writing", async () => {
+    await realCmdBud("previewbud", { from: "mawjs", nickname: "Bloom", dryRun: true });
+    expect(existsSync(join(budRepoPath, "ψ", "nickname"))).toBe(false);
   });
 });

--- a/src/commands/plugins/bud/impl.ts
+++ b/src/commands/plugins/bud/impl.ts
@@ -7,6 +7,7 @@ import { ensureBudRepo } from "./bud-repo";
 import { initVault, generateClaudeMd, configureFleet, writeBirthNote } from "./bud-init";
 import { finalizeBud } from "./bud-wake";
 import { writeSignal } from "../../../core/fleet/leaf";
+import { validateNickname, writeNickname, setCachedNickname } from "../../../core/fleet/nicknames";
 import { join } from "path";
 
 export interface BudOpts {
@@ -26,6 +27,8 @@ export interface BudOpts {
   seed?: boolean;
   /** Drop a "birth" signal into the parent oracle's ψ/memory/signals/ on creation. */
   signalOnBirth?: boolean;
+  /** Pretty display name — written to ψ/nickname at birth (#643 Phase 3). */
+  nickname?: string;
 }
 
 // TinyBudOpts removed — --tiny deprecated, code moved to deprecated/tiny-bud-209/
@@ -73,6 +76,14 @@ export async function cmdBud(name: string, opts: BudOpts = {}) {
     );
   }
 
+  // Validate nickname early — fail fast before any repo work (#643 Phase 3).
+  let nicknameValue = "";
+  if (opts.nickname !== undefined) {
+    const v = validateNickname(opts.nickname);
+    if (!v.ok) throw new Error(v.error);
+    nicknameValue = v.value;
+  }
+
   const config = loadConfig();
   const ghqRoot = config.ghqRoot;
   const org = opts.org || config.githubOrg || "Soul-Brews-Studio";
@@ -102,16 +113,20 @@ export async function cmdBud(name: string, opts: BudOpts = {}) {
   // post-clone path; use that for all scaffolding below.
   const predictedRepoPath = join(ghqRoot, org, budRepoName);
 
+  const nickSuffix = nicknameValue ? ` (${nicknameValue})` : "";
   if (opts.root) {
-    console.log(`\n  \x1b[36m🌱 Root Bud\x1b[0m — ${name} (no parent lineage)\n`);
+    console.log(`\n  \x1b[36m🌱 Root Bud\x1b[0m — ${name}${nickSuffix} (no parent lineage)\n`);
   } else {
-    console.log(`\n  \x1b[36m🧬 Budding\x1b[0m — ${parentName} → ${name}\n`);
+    console.log(`\n  \x1b[36m🧬 Budding\x1b[0m — ${parentName} → ${name}${nickSuffix}\n`);
   }
 
   if (opts.dryRun) {
     console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would create repo: ${budRepoSlug}`);
     console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would init ψ/ vault at: ${predictedRepoPath}`);
     console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would generate CLAUDE.md`);
+    if (nicknameValue) {
+      console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would write nickname: ${nicknameValue}`);
+    }
     console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would create fleet config`);
     if (opts.seed && parentName) {
       console.log(`  \x1b[36m⬡\x1b[0m [dry-run] --seed: would bulk soul-sync from ${parentName}`);
@@ -131,9 +146,16 @@ export async function cmdBud(name: string, opts: BudOpts = {}) {
   // 1. Create oracle repo — returns the ACTUAL clone path per ghq (#630).
   const budRepoPath = await ensureBudRepo(budRepoSlug, predictedRepoPath, budRepoName, org);
 
-  // 2-4.5. Initialize vault, CLAUDE.md, fleet config, birth note
+  // 2-4.5. Initialize vault, CLAUDE.md, nickname, fleet config, birth note
   const psiDir = initVault(budRepoPath);
   generateClaudeMd(budRepoPath, name, parentName);
+  if (nicknameValue) {
+    // Authoritative on-disk write (staged by finalizeBud's `git add -A`),
+    // then refresh the read-through cache so /info + peers pick it up immediately.
+    writeNickname(budRepoPath, nicknameValue);
+    setCachedNickname(name, nicknameValue);
+    console.log(`  \x1b[32m✓\x1b[0m nickname set: \x1b[33m${nicknameValue}\x1b[0m`);
+  }
   const fleetFile = configureFleet(name, org, budRepoName, parentName);
   if (opts.note) writeBirthNote(psiDir, name, parentName, opts.note);
 

--- a/src/commands/plugins/bud/index.ts
+++ b/src/commands/plugins/bud/index.ts
@@ -31,6 +31,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         "--repo": String,
         "--issue": Number,
         "--note": String,
+        "--nickname": String,
         "--fast": Boolean,
         "--root": Boolean,
         "--dry-run": Boolean,
@@ -72,7 +73,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
 
       const name = flags._[0];
       if (!name || name === "--help" || name === "-h") {
-        return { ok: false, error: "usage: maw bud <name> [--from <oracle>] [--root] [--seed] [--org <org>] [--repo org/repo] [--issue N] [--note <text>] [--fast] [--split] [--dry-run]\n       Or:    maw bud --from-repo <path|url> --stem <stem> [--pr] [--from <parent>] [--seed] [--sync-peers] [--force] [--track-vault] [--dry-run]  (#588)\n       Default: born blank. Use --seed to pre-load parent's ψ at birth.\n       Pull memory later: maw soul-sync <parent> --from" };
+        return { ok: false, error: "usage: maw bud <name> [--from <oracle>] [--root] [--seed] [--org <org>] [--repo org/repo] [--issue N] [--note <text>] [--nickname <pretty>] [--fast] [--split] [--dry-run]\n       Or:    maw bud --from-repo <path|url> --stem <stem> [--pr] [--from <parent>] [--seed] [--sync-peers] [--force] [--track-vault] [--dry-run]  (#588)\n       Default: born blank. Use --seed to pre-load parent's ψ at birth.\n       Pull memory later: maw soul-sync <parent> --from" };
       }
       if (name.startsWith("-")) {
         return { ok: false, error: `"${name}" looks like a flag, not an oracle name.\n  usage: maw bud <name> ${args.join(" ")}` };
@@ -84,6 +85,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         org: flags["--org"],
         issue: flags["--issue"],
         note: flags["--note"],
+        nickname: flags["--nickname"],
         fast: flags["--fast"],
         root: flags["--root"],
         dryRun: flags["--dry-run"],
@@ -102,6 +104,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         org: body.org as string | undefined,
         issue: body.issue as number | undefined,
         note: body.note as string | undefined,
+        nickname: body.nickname as string | undefined,
         fast: body.fast as boolean | undefined,
         root: body.root as boolean | undefined,
         dryRun: body.dryRun as boolean | undefined,


### PR DESCRIPTION
## Summary
- `maw bud <stem> --nickname \"<pretty>\"` writes the nickname to `<bud>/ψ/nickname` at birth.
- Refreshes the read-through cache (`setCachedNickname`) so `/info` + peers see the name immediately.
- Header now reads `🧬 Budding — <parent> → <stem> (<nickname>)`; dry-run previews the write.

## Scope
- Flag parsing in `src/commands/plugins/bud/index.ts` (CLI + API paths).
- `cmdBud` validates the nickname up front (fail fast, before repo creation) via the existing `validateNickname` helper from Phase 1.
- Write happens after `initVault`; `finalizeBud`'s `git add -A` stages the new file as part of the initial birth commit.
- No auto-generation — opt-in only. No changes to cross-node sync (Phase 2 already covers display).

## Test plan
- [x] `src/commands/plugins/bud/bud.test.ts` — 5 CLI/API flag tests + 6 integration tests (write, trim, reject newline, whitespace=no-op, dry-run no-write).
- [x] `bun run test:all` green locally (352 pass, 0 fail, 6 skip).
- [x] Scoped `mock.module` via install/restore helpers so `bud-repo.test.ts` and the rest of `test:plugin` stay green.

🤖 ตอบโดย mawjs จาก [Human] → mawjs-oracle