### PR TITLE
fix(test): costs.test.ts global.fetch snapshot/restore (closes #649)

### DIFF
--- a/src/commands/plugins/costs/costs.test.ts
+++ b/src/commands/plugins/costs/costs.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, mock } from "bun:test";
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
 import { join } from "path";
 import type { InvokeContext } from "../../../plugin/types";
 
@@ -21,11 +21,20 @@ const mockAgentData = {
   total: { agents: 1, sessions: 3, tokens: 12000, cost: 0.5 },
 };
 
-(global as any).fetch = mock(async (_url: string) =>
-  new Response(JSON.stringify(mockAgentData), { status: 200 }),
-);
-
 const { default: handler } = await import("./index");
+
+// Snapshot/restore global.fetch around every test so this suite doesn't
+// leak a mock into sibling suites (#649).
+let savedFetch: typeof fetch;
+beforeEach(() => {
+  savedFetch = globalThis.fetch;
+  (globalThis as any).fetch = mock(async (_url: string) =>
+    new Response(JSON.stringify(mockAgentData), { status: 200 }),
+  );
+});
+afterEach(() => {
+  globalThis.fetch = savedFetch;
+});
 
 describe("costs plugin", () => {
   it("CLI surface — returns ok with cost table", async () => {
@@ -44,7 +53,7 @@ describe("costs plugin", () => {
   });
 
   it("handles empty agents gracefully", async () => {
-    (global as any).fetch = mock(async () =>
+    (globalThis as any).fetch = mock(async () =>
       new Response(JSON.stringify({ agents: [], total: { agents: 0, sessions: 0, tokens: 0, cost: 0 } }), { status: 200 }),
     );
     const ctx: InvokeContext = { source: "cli", args: [] };
@@ -54,7 +63,7 @@ describe("costs plugin", () => {
   });
 
   it("returns ok:false when server is unreachable", async () => {
-    (global as any).fetch = mock(async () => { throw new Error("ECONNREFUSED"); });
+    (globalThis as any).fetch = mock(async () => { throw new Error("ECONNREFUSED"); });
     const ctx: InvokeContext = { source: "cli", args: [] };
     const result = await handler(ctx);
     expect(result.ok).toBe(false);

--- a/src/commands/plugins/peers/peers-probe.test.ts
+++ b/src/commands/plugins/peers/peers-probe.test.ts
@@ -334,25 +334,6 @@ describe("isValidMawHandshake (#628 back-compat gate)", () => {
 });
 
 describe("probePeer — maw handshake gate (#628)", () => {
-  // costs.test.ts (and potentially others) monkey-patch `global.fetch`
-  // without restoring it. Under `bun run test:plugin` our file runs
-  // after them and inherits a mock that throws ECONNREFUSED for every
-  // URL — poisoning these real-server round-trips. Snapshot + restore
-  // the native fetch around each test so we're robust to that.
-  let savedFetch: typeof fetch | undefined;
-  beforeEach(() => {
-    savedFetch = globalThis.fetch;
-    // Reset to the genuine Bun fetch — look it up off the Response/Bun
-    // prototype chain via the platform-provided binding.
-    // In practice, `Bun.fetch` is the native impl; falling back to
-    // savedFetch is fine when no pollution has occurred.
-    const bunFetch = (globalThis as any).Bun?.fetch;
-    if (typeof bunFetch === "function") globalThis.fetch = bunFetch;
-  });
-  afterEach(() => {
-    if (savedFetch) globalThis.fetch = savedFetch;
-  });
-
   it("accepts old {maw:true} shape end-to-end", async () => {
     const server = Bun.serve({
       port: 0,


### PR DESCRIPTION
## Summary
- costs.test.ts monkey-patched `global.fetch` at module scope without restoring it, poisoning sibling suites under `bun run test:plugin`.
- Wrap in `beforeEach`/`afterEach` snapshot + restore pattern. Per-test overrides stay inside each test and no longer leak.
- Remove the defensive snapshot/restore block that #648 added to `peers-probe.test.ts` describe("probePeer — maw handshake gate (#628)") — the root cause is fixed.

## Test plan
- [x] `bun test src/commands/plugins/costs/costs.test.ts` — 4/4 pass
- [x] `bun test src/commands/plugins/peers/peers-probe.test.ts` — 46/46 pass
- [x] both files together — 50/50 pass (no cross-suite leak)
- [x] `bun run test:all` — 352 pass, 6 skip, 0 fail

Closes #649