### PR TITLE
sec(peer): cross-check /info node against peers.json identity (closes #651)

### DIFF
--- a/src/commands/plugins/plugin/index.ts
+++ b/src/commands/plugins/plugin/index.ts
@@ -111,7 +111,8 @@ async function runSearchCmd(args: string[]): Promise<void> {
         ? `@${h.peerName}${h.peerNode && h.peerNode !== h.peerName ? `(${h.peerNode})` : ""}`
         : `@${h.peerUrl}`;
       const summary = h.summary ?? "";
-      console.log(`  ${h.name}@${h.version}  ${summary}  ${tag}`);
+      const warn = h.identityMismatch ? " \x1b[33m[identity-mismatch]\x1b[0m" : "";
+      console.log(`  ${h.name}@${h.version}  ${summary}  ${tag}${warn}`);
     }
   }
   for (const e of result.errors) {

--- a/src/commands/plugins/plugin/search-peers.ts
+++ b/src/commands/plugins/plugin/search-peers.ts
@@ -37,6 +37,13 @@ export interface PluginSearchHit {
   peerUrl: string;
   peerNode?: string;
   sha256?: string | null;
+  /**
+   * True when the peer's self-reported `manifest.node` disagrees with the
+   * config-trusted `namedPeers[].name` (#651). When set, callers should treat
+   * `peerNode` as attacker-controlled and refuse to route install/trust
+   * decisions through it.
+   */
+  identityMismatch?: boolean;
 }
 
 export interface PeerError {
@@ -272,6 +279,18 @@ export async function searchPeers(
     const peer = peers[idx]!;
     if (outcome.ok && outcome.manifest) {
       responded++;
+      // Cross-check peer identity (#651): if the config pins this peer to a
+      // name, the peer's self-reported manifest.node should match. A hostile
+      // peer at a known URL can otherwise forge another oracle's name in
+      // every hit.
+      const identityMismatch =
+        peer.name != null && outcome.manifest.node !== peer.name;
+      if (identityMismatch) {
+        console.warn(
+          `[search-peers] identity mismatch: ${peer.url} (configured as '${peer.name}') ` +
+          `reports node='${outcome.manifest.node}' — treating peerNode as untrusted`,
+        );
+      }
       for (const entry of outcome.manifest.plugins) {
         if (!matches(query, entry)) continue;
         const hit: PluginSearchHit = {
@@ -284,6 +303,7 @@ export async function searchPeers(
         if (entry.author) hit.author = entry.author;
         if (peer.name) hit.peerName = peer.name;
         if (entry.sha256 !== undefined) hit.sha256 = entry.sha256;
+        if (identityMismatch) hit.identityMismatch = true;
         hits.push(hit);
       }
     } else if (outcome.error) {

--- a/test/security/peer-manifest-adversarial.test.ts
+++ b/test/security/peer-manifest-adversarial.test.ts
@@ -108,35 +108,99 @@ describe("manifest-vs-tarball sha256 mismatch", () => {
 });
 
 // ─── Case 3 — Identity swap ─────────────────────────────────────────────────
-// Classification: FAIL-KNOWN (follow-up).
-// Reason: searchPeers trusts `manifest.node` verbatim as `peerNode` on the
-// hit. A hostile peer at `http://white:3456` can claim `node: "attacker"`
-// (or any other oracle's name) and the hit will show that node name.
-// There is no cross-check against /info or the namedPeers known-node
-// map. Mitigation lives upstream (HMAC auth ensures only authorized
-// peers can reach /api at all), so the blast radius is bounded to
-// "namedPeer lies about which node it is". Follow-up: file an issue to
-// cross-reference node names with /info.
+// Classification: FIXED (#651, PR that flipped this test).
+// Reason: searchPeers now cross-checks `manifest.node` against the
+// config-trusted `namedPeers[].name`. A hostile peer at `http://white:3456`
+// that claims `node: "attacker"` still gets the forged value surfaced (so
+// callers can see what was claimed), but `identityMismatch: true` flags
+// the hit and a stderr warning is emitted. Callers (install, trust
+// decisions) MUST check `identityMismatch` before routing through
+// `peerNode`.
 describe("identity swap (peer claims another node's name)", () => {
-  test("FAIL-KNOWN: manifest.node is echoed as peerNode without cross-check", async () => {
+  test("mismatch is flagged: identityMismatch=true + stderr warn, peerNode preserved as evidence", async () => {
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = ((...args: unknown[]) => {
+      warnings.push(args.map(a => (typeof a === "string" ? a : JSON.stringify(a))).join(" "));
+    }) as typeof console.warn;
+    try {
+      const fetchImpl = mockPeer({
+        schemaVersion: 1,
+        node: "attacker", // lies — real peer is "white"
+        pluginCount: 1,
+        plugins: [{ name: "example", version: "1.0.0" }],
+      });
+      const r = await searchPeers("example", {
+        peers: [{ url: "http://white:3456", name: "white" }],
+        fetch: fetchImpl,
+        noCache: true,
+        cacheDir,
+      });
+      expect(r.hits).toHaveLength(1);
+      // The forged value is still surfaced so operators can see what the
+      // peer tried to claim — but identityMismatch flags it as untrusted.
+      expect(r.hits[0]!.peerNode).toBe("attacker");
+      expect(r.hits[0]!.peerName).toBe("white");
+      expect(r.hits[0]!.peerUrl).toBe("http://white:3456");
+      expect(r.hits[0]!.identityMismatch).toBe(true);
+      // Stderr warning names the peer URL, configured name, and claimed node.
+      expect(warnings.some(w =>
+        w.includes("identity mismatch") &&
+        w.includes("http://white:3456") &&
+        w.includes("'white'") &&
+        w.includes("'attacker'"),
+      )).toBe(true);
+    } finally {
+      console.warn = origWarn;
+    }
+  });
+
+  test("honest peer (node matches configured name) → no mismatch flag, no warn", async () => {
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = ((...args: unknown[]) => {
+      warnings.push(args.map(a => (typeof a === "string" ? a : JSON.stringify(a))).join(" "));
+    }) as typeof console.warn;
+    try {
+      const fetchImpl = mockPeer({
+        schemaVersion: 1,
+        node: "white",
+        pluginCount: 1,
+        plugins: [{ name: "example", version: "1.0.0" }],
+      });
+      const r = await searchPeers("example", {
+        peers: [{ url: "http://white:3456", name: "white" }],
+        fetch: fetchImpl,
+        noCache: true,
+        cacheDir,
+      });
+      expect(r.hits).toHaveLength(1);
+      expect(r.hits[0]!.identityMismatch).toBeUndefined();
+      expect(warnings.some(w => w.includes("identity mismatch"))).toBe(false);
+    } finally {
+      console.warn = origWarn;
+    }
+  });
+
+  test("unnamed peer (no configured name) → no mismatch flag (nothing to compare against)", async () => {
+    // When a peer is listed only by URL (flat peers[], not namedPeers[]),
+    // there is no trusted name to compare against. Don't flag — the
+    // operator explicitly opted into an unnamed peer.
     const fetchImpl = mockPeer({
       schemaVersion: 1,
-      node: "attacker", // lies — real peer is "white"
+      node: "whoever",
       pluginCount: 1,
       plugins: [{ name: "example", version: "1.0.0" }],
     });
     const r = await searchPeers("example", {
-      peers: [{ url: "http://white:3456", name: "white" }],
+      peers: [{ url: "http://anon:3456" }], // no name
       fetch: fetchImpl,
       noCache: true,
       cacheDir,
     });
     expect(r.hits).toHaveLength(1);
-    // Documents current behavior: the peer's self-reported node is echoed.
-    // If/when a cross-check lands, flip this assertion to `expect(...).toBe("white")`.
-    expect(r.hits[0]!.peerNode).toBe("attacker");
-    expect(r.hits[0]!.peerName).toBe("white");
-    expect(r.hits[0]!.peerUrl).toBe("http://white:3456");
+    expect(r.hits[0]!.identityMismatch).toBeUndefined();
+    expect(r.hits[0]!.peerNode).toBe("whoever");
   });
 });
 


### PR DESCRIPTION
## Summary
- Cross-check peer-reported `manifest.node` against the config-trusted `namedPeers[].name` at search-peers time (#651).
- When they disagree: emit a stderr warning, set `identityMismatch: true` on every hit from that peer, and render `[identity-mismatch]` in CLI output. Forged `peerNode` value is preserved as evidence — callers routing install/trust decisions MUST check `identityMismatch` before using `peerNode`.
- Unnamed peers (listed only by URL in flat `peers[]`) skip the check — nothing to compare against.

## Test plan
- [x] Flipped adversarial Case 3 (`test/security/peer-manifest-adversarial.test.ts`) from FAIL-KNOWN → FIXED: now asserts `identityMismatch=true`, forged `peerNode` preserved, stderr warning shape
- [x] Added honest-peer case: matching `node` name → no flag, no warn
- [x] Added unnamed-peer case: skips check cleanly
- [x] `bun run test:all` green (1276 pass / 0 fail + all 4 stages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)