### PR TITLE
feat(test): fedtest scenarios 02-05 (#655 Phase 2)

### DIFF
--- a/test/fedtest/backend.ts
+++ b/test/fedtest/backend.ts
@@ -1,20 +1,67 @@
 /**
- * fedtest — backend interface (#655 Phase 1).
+ * fedtest — backend interface (#655 Phase 1 + Phase 2 mutation API).
  *
  * Both EmulatedBackend (in-process Bun.serve) and DockerBackend (wrapped
  * compose stack) implement this contract so scenarios can run against
- * either without branching. Phase 1 keeps PeerHandle intentionally small
- * — richer mutation hooks (setSlow/setOffline/spoofSha) land in later
- * phases as scenarios demand them, not speculatively.
+ * either without branching.
+ *
+ * Phase 2 adds a minimal mutation API to PeerHandle:
+ *   • installPlugin  — advertise a plugin on this peer's list-manifest
+ *   • setOffline     — simulate unreachable peer (stops/starts listener)
+ *   • setSlow        — inject response delay (exercises timeout paths)
+ *   • spoofSha       — override advertised sha256 (for adversarial tests)
+ *
+ * The emulated backend implements these in-process. Docker scenarios are
+ * deferred to Phase 3 — the docker backend throws on mutation calls, and
+ * scenarios that need mutations declare `backends: ["emulated"]`.
  */
 
 export type BackendName = "emulated" | "docker";
+
+/** A single peer advertised entry used by `/api/plugin/list-manifest`. */
+export interface EmulatedPluginEntry {
+  name: string;
+  version: string;
+  summary?: string;
+  author?: string;
+  /** Raw tarball bytes served by `/api/plugin/download/:name`. Optional. */
+  tarball?: Uint8Array;
+  /** Advertised sha256. `spoofSha` overrides this value without touching `tarball`. */
+  sha256?: string | null;
+}
 
 export interface PeerHandle {
   /** Base URL (no trailing slash). Reachable from the test process. */
   url: string;
   /** Node identity as reported by this peer's /info body.node. */
   node: string;
+
+  /**
+   * Advertise a plugin on this peer's `/api/plugin/list-manifest` and
+   * make its tarball (if provided) downloadable at
+   * `/api/plugin/download/<name>`.
+   */
+  installPlugin(entry: EmulatedPluginEntry): Promise<void>;
+
+  /**
+   * Simulate this peer going offline (connection refused). Pass `false`
+   * to bring it back. Idempotent.
+   */
+  setOffline(offline: boolean): Promise<void>;
+
+  /**
+   * Inject a pre-response delay. Pass `null` (or 0) to clear. Applies to
+   * every endpoint — callers tune `perPeerMs` / `totalMs` against this
+   * to exercise slow-peer paths.
+   */
+  setSlow(delayMs: number | null): Promise<void>;
+
+  /**
+   * Override the sha256 advertised for a specific plugin without changing
+   * the served tarball bytes. Simulates a peer that lies about hashes —
+   * used by adversarial scenarios.
+   */
+  spoofSha(pluginName: string, sha256: string | null): Promise<void>;
 }
 
 export interface SetUpOpts {

--- a/test/fedtest/docker.ts
+++ b/test/fedtest/docker.ts
@@ -14,8 +14,23 @@
  * matches the test/integration/* pattern used elsewhere in this repo.
  */
 
-import type { BaseFederationBackend, PeerHandle, SetUpOpts } from "./backend";
+import type { BaseFederationBackend, EmulatedPluginEntry, PeerHandle, SetUpOpts } from "./backend";
 import { spawnSync } from "child_process";
+
+function mutationUnsupported(op: string): never {
+  throw new Error(
+    `DockerBackend Phase 1/2 does not support PeerHandle.${op}() — ` +
+    `scenarios that mutate peer state must declare backends: ["emulated"]`,
+  );
+}
+
+class DockerPeerHandle implements PeerHandle {
+  constructor(readonly url: string, readonly node: string) {}
+  installPlugin(_e: EmulatedPluginEntry): Promise<void> { return mutationUnsupported("installPlugin"); }
+  setOffline(_o: boolean): Promise<void> { return mutationUnsupported("setOffline"); }
+  setSlow(_d: number | null): Promise<void> { return mutationUnsupported("setSlow"); }
+  spoofSha(_n: string, _s: string | null): Promise<void> { return mutationUnsupported("spoofSha"); }
+}
 
 const COMPOSE_FILE = "docker/compose.yml";
 const HEALTHY_TIMEOUT_MS = 90_000;
@@ -44,8 +59,8 @@ export class DockerBackend implements BaseFederationBackend {
     await waitHealthy(HEALTHY_TIMEOUT_MS);
 
     return [
-      { url: "http://127.0.0.1:13456", node: "node-a" },
-      { url: "http://127.0.0.1:13457", node: "node-b" },
+      new DockerPeerHandle("http://127.0.0.1:13456", "node-a"),
+      new DockerPeerHandle("http://127.0.0.1:13457", "node-b"),
     ];
   }
 

--- a/test/fedtest/emulated.ts
+++ b/test/fedtest/emulated.ts
@@ -1,20 +1,140 @@
 /**
- * fedtest — EmulatedBackend (#655 Phase 1).
+ * fedtest — EmulatedBackend (#655 Phase 1 + Phase 2 mutation API).
  *
- * Spawns N `Bun.serve` instances on ephemeral ports. Each responds to
- * GET /info with the real buildInfo() body so probePeer()'s handshake
- * contract stays in sync with production — only `node` is overridden
- * per peer.
+ * Spawns N `Bun.serve` instances on ephemeral ports. Each responds to:
+ *   GET /info                         — real buildInfo() body w/ node overridden
+ *   GET /api/plugin/list-manifest     — in-memory plugin list per peer
+ *   GET /api/plugin/download/:name    — serves advertised tarball bytes
+ *
+ * Phase 2 mutations (installPlugin / setOffline / setSlow / spoofSha) are
+ * implemented in-process by flipping per-peer state read by the handlers.
+ * Offline is modeled by stopping the listener (connection refused), so
+ * fetch failure shape matches a real down peer. Bringing a peer back
+ * online rebinds the same port.
  */
 
-import type { BaseFederationBackend, PeerHandle, SetUpOpts } from "./backend";
+import type {
+  BaseFederationBackend,
+  EmulatedPluginEntry,
+  PeerHandle,
+  SetUpOpts,
+} from "./backend";
 import { buildInfo } from "../../src/views/info";
 
-type EmuServer = { stop: (closeActive?: boolean) => void; port: number };
+type BunServer = { stop: (closeActive?: boolean) => void; port: number };
+
+interface PeerState {
+  node: string;
+  port: number;
+  server: BunServer | null;
+  /** When non-null, every response waits this many ms before returning. */
+  slowMs: number | null;
+  plugins: Map<string, EmulatedPluginEntry>;
+  /** sha256 overrides by plugin name — wins over entry.sha256 when set. */
+  shaOverrides: Map<string, string | null>;
+}
+
+function startServer(state: PeerState): BunServer {
+  return Bun.serve({
+    port: state.port,
+    hostname: "127.0.0.1",
+    async fetch(req: Request) {
+      if (state.slowMs != null && state.slowMs > 0) {
+        await new Promise(r => setTimeout(r, state.slowMs!));
+      }
+      const u = new URL(req.url);
+
+      if (u.pathname === "/info") {
+        const body = { ...buildInfo(), node: state.node };
+        return Response.json(body);
+      }
+
+      if (u.pathname === "/api/plugin/list-manifest") {
+        const plugins = [...state.plugins.values()].map(e => {
+          const override = state.shaOverrides.get(e.name);
+          const sha = override !== undefined ? override : e.sha256 ?? null;
+          const entry: Record<string, unknown> = {
+            name: e.name,
+            version: e.version,
+            downloadUrl: `/api/plugin/download/${encodeURIComponent(e.name)}`,
+          };
+          if (e.summary) entry.summary = e.summary;
+          if (e.author) entry.author = e.author;
+          if (sha !== undefined) entry.sha256 = sha;
+          return entry;
+        });
+        return Response.json({
+          schemaVersion: 1,
+          node: state.node,
+          pluginCount: plugins.length,
+          plugins,
+        });
+      }
+
+      const downloadPrefix = "/api/plugin/download/";
+      if (u.pathname.startsWith(downloadPrefix)) {
+        const name = decodeURIComponent(u.pathname.slice(downloadPrefix.length));
+        const entry = state.plugins.get(name);
+        if (!entry) {
+          return Response.json({ error: "plugin not installed", name }, { status: 404 });
+        }
+        if (!entry.tarball) {
+          return Response.json(
+            { error: "emulated peer has no tarball bytes for this plugin", name },
+            { status: 404 },
+          );
+        }
+        return new Response(entry.tarball, {
+          status: 200,
+          headers: {
+            "Content-Type": "application/gzip",
+            "Content-Disposition": `attachment; filename="${name}-${entry.version}.tgz"`,
+          },
+        });
+      }
+
+      return new Response("not found", { status: 404 });
+    },
+  });
+}
+
+class EmulatedPeerHandle implements PeerHandle {
+  constructor(private readonly state: PeerState) {}
+  get url(): string { return `http://127.0.0.1:${this.state.port}`; }
+  get node(): string { return this.state.node; }
+
+  async installPlugin(entry: EmulatedPluginEntry): Promise<void> {
+    this.state.plugins.set(entry.name, entry);
+  }
+
+  async setOffline(offline: boolean): Promise<void> {
+    if (offline) {
+      if (this.state.server) {
+        try { this.state.server.stop(true); } catch { /* idempotent */ }
+        this.state.server = null;
+      }
+      return;
+    }
+    if (!this.state.server) {
+      this.state.server = startServer(this.state);
+      // rebind ephemeral port — real port may have moved. For the offline
+      // scenario we restore the same port, so we tell Bun to bind the port
+      // we remembered at first startup.
+    }
+  }
+
+  async setSlow(delayMs: number | null): Promise<void> {
+    this.state.slowMs = delayMs == null || delayMs <= 0 ? null : delayMs;
+  }
+
+  async spoofSha(pluginName: string, sha256: string | null): Promise<void> {
+    this.state.shaOverrides.set(pluginName, sha256);
+  }
+}
 
 export class EmulatedBackend implements BaseFederationBackend {
   readonly name = "emulated" as const;
-  private servers: EmuServer[] = [];
+  private states: PeerState[] = [];
 
   async setUp(opts: SetUpOpts): Promise<PeerHandle[]> {
     if (opts.peers < 1) throw new Error("peers must be >= 1");
@@ -25,29 +145,31 @@ export class EmulatedBackend implements BaseFederationBackend {
     const handles: PeerHandle[] = [];
     for (let i = 0; i < opts.peers; i++) {
       const node = `emu-node-${String.fromCharCode(97 + i)}`; // emu-node-a, -b, ...
-      const port = opts.ports?.[i] ?? 0;
-      const server = Bun.serve({
-        port,
-        hostname: "127.0.0.1",
-        fetch(req: Request) {
-          const u = new URL(req.url);
-          if (u.pathname === "/info") {
-            const body = { ...buildInfo(), node };
-            return Response.json(body);
-          }
-          return new Response("not found", { status: 404 });
-        },
-      });
-      this.servers.push(server);
-      handles.push({ url: `http://127.0.0.1:${server.port}`, node });
+      const state: PeerState = {
+        node,
+        port: opts.ports?.[i] ?? 0,
+        server: null,
+        slowMs: null,
+        plugins: new Map(),
+        shaOverrides: new Map(),
+      };
+      state.server = startServer(state);
+      // Pin the resolved port so a later setOffline(false) rebinds the same
+      // port — callers may have cached handle.url.
+      state.port = state.server.port;
+      this.states.push(state);
+      handles.push(new EmulatedPeerHandle(state));
     }
     return handles;
   }
 
   async teardown(): Promise<void> {
-    for (const s of this.servers) {
-      try { s.stop(true); } catch { /* idempotent */ }
+    for (const s of this.states) {
+      if (s.server) {
+        try { s.server.stop(true); } catch { /* idempotent */ }
+        s.server = null;
+      }
     }
-    this.servers = [];
+    this.states = [];
   }
 }

--- a/test/fedtest/scenarios/02-search-happy.ts
+++ b/test/fedtest/scenarios/02-search-happy.ts
@@ -1,0 +1,62 @@
+/**
+ * Scenario 02 — federated search happy path (#655 Phase 2).
+ *
+ * Two peers each advertise a plugin via /api/plugin/list-manifest. A
+ * search whose query matches both names returns one hit per peer, each
+ * tagged with the right peerUrl and peerNode. Proves the fan-out + merge
+ * path in `searchPeers()` actually reaches a live list-manifest endpoint
+ * and reads the real response shape, not a hand-rolled mock.
+ */
+
+import type { Scenario } from "../scenario";
+import { searchPeers } from "../../../src/commands/plugins/plugin/search-peers";
+
+const scenario: Scenario = {
+  name: "02-search-happy",
+  backends: ["emulated"],
+  peers: 2,
+  async setUp(peers) {
+    await peers[0]!.installPlugin({
+      name: "alpha-tool",
+      version: "1.0.0",
+      summary: "alpha thing",
+    });
+    await peers[1]!.installPlugin({
+      name: "beta-tool",
+      version: "0.2.0",
+      summary: "beta thing",
+    });
+  },
+  async assert(peers) {
+    const result = await searchPeers("tool", {
+      peers: peers.map(p => ({ url: p.url, name: p.node })),
+      noCache: true,
+      perPeerMs: 2000,
+      totalMs: 4000,
+    });
+
+    if (result.errors.length !== 0) {
+      throw new Error(`expected zero errors, got ${JSON.stringify(result.errors)}`);
+    }
+    if (result.queried !== 2 || result.responded !== 2) {
+      throw new Error(`expected queried=2 responded=2, got ${result.queried}/${result.responded}`);
+    }
+    if (result.hits.length !== 2) {
+      throw new Error(`expected 2 hits, got ${result.hits.length}: ${JSON.stringify(result.hits)}`);
+    }
+
+    const byName = Object.fromEntries(result.hits.map(h => [h.name, h]));
+    const alpha = byName["alpha-tool"];
+    const beta = byName["beta-tool"];
+    if (!alpha) throw new Error(`missing alpha-tool hit: ${JSON.stringify(result.hits)}`);
+    if (!beta) throw new Error(`missing beta-tool hit: ${JSON.stringify(result.hits)}`);
+    if (alpha.peerUrl !== peers[0]!.url || alpha.peerNode !== peers[0]!.node) {
+      throw new Error(`alpha-tool tagged wrong peer: ${JSON.stringify(alpha)}`);
+    }
+    if (beta.peerUrl !== peers[1]!.url || beta.peerNode !== peers[1]!.node) {
+      throw new Error(`beta-tool tagged wrong peer: ${JSON.stringify(beta)}`);
+    }
+  },
+};
+
+export default scenario;

--- a/test/fedtest/scenarios/03-search-offline.ts
+++ b/test/fedtest/scenarios/03-search-offline.ts
@@ -1,0 +1,60 @@
+/**
+ * Scenario 03 — offline peer surfaces as an error without dropping live hits (#655 Phase 2).
+ *
+ * Two peers: one is taken offline via PeerHandle.setOffline(true) before
+ * the search. Expected: the live peer's hit is still returned, and the
+ * offline peer shows up in `errors[]` with reason=unreachable — never
+ * silently dropped. This is the "partial success" contract that keeps
+ * federated discovery useful when one node is down.
+ */
+
+import type { Scenario } from "../scenario";
+import { searchPeers } from "../../../src/commands/plugins/plugin/search-peers";
+
+const scenario: Scenario = {
+  name: "03-search-offline",
+  backends: ["emulated"],
+  peers: 2,
+  async setUp(peers) {
+    await peers[0]!.installPlugin({ name: "livegem", version: "1.0.0" });
+    await peers[1]!.installPlugin({ name: "deadgem", version: "1.0.0" });
+    await peers[1]!.setOffline(true);
+  },
+  async assert(peers) {
+    const result = await searchPeers("gem", {
+      peers: peers.map(p => ({ url: p.url, name: p.node })),
+      noCache: true,
+      perPeerMs: 1000,
+      totalMs: 3000,
+    });
+
+    if (result.queried !== 2) {
+      throw new Error(`expected queried=2, got ${result.queried}`);
+    }
+    if (result.responded !== 1) {
+      throw new Error(`expected responded=1 (one peer offline), got ${result.responded}`);
+    }
+
+    if (result.hits.length !== 1 || result.hits[0]!.name !== "livegem") {
+      throw new Error(`expected exactly livegem hit, got ${JSON.stringify(result.hits)}`);
+    }
+    if (result.hits[0]!.peerUrl !== peers[0]!.url) {
+      throw new Error(`livegem tagged wrong peer: ${JSON.stringify(result.hits[0])}`);
+    }
+
+    if (result.errors.length !== 1) {
+      throw new Error(`expected 1 error (offline peer), got ${JSON.stringify(result.errors)}`);
+    }
+    const err = result.errors[0]!;
+    if (err.peerUrl !== peers[1]!.url) {
+      throw new Error(`expected offline error on peer[1], got ${JSON.stringify(err)}`);
+    }
+    // Bun fetch failure on a closed port surfaces as "unreachable" (status=0
+    // → reason=unreachable in fetchPeerManifest's classifier).
+    if (err.reason !== "unreachable") {
+      throw new Error(`expected reason=unreachable for offline peer, got ${err.reason}`);
+    }
+  },
+};
+
+export default scenario;

--- a/test/fedtest/scenarios/04-search-slow.ts
+++ b/test/fedtest/scenarios/04-search-slow.ts
@@ -1,0 +1,67 @@
+/**
+ * Scenario 04 — slow peer exceeds total budget → reason=timeout (#655 Phase 2).
+ *
+ * A single peer delays every response past the total search budget. The
+ * Promise.race inside `searchPeers()` fires the synthesized timeout
+ * outcome, which classifies the peer with reason="timeout" — distinct
+ * from "unreachable" so operators can diagnose hung peers vs. hard-down
+ * peers. Contract: slow peers never corrupt the aggregate; caller always
+ * gets a clean result within `totalMs + epsilon`.
+ */
+
+import type { Scenario } from "../scenario";
+import { searchPeers } from "../../../src/commands/plugins/plugin/search-peers";
+
+const SLOW_MS = 600;
+const TOTAL_MS = 150;
+
+const scenario: Scenario = {
+  name: "04-search-slow",
+  backends: ["emulated"],
+  peers: 1,
+  async setUp(peers) {
+    await peers[0]!.installPlugin({ name: "slowgem", version: "1.0.0" });
+    await peers[0]!.setSlow(SLOW_MS);
+  },
+  async assert(peers) {
+    const start = Date.now();
+    const result = await searchPeers("slowgem", {
+      peers: peers.map(p => ({ url: p.url, name: p.node })),
+      noCache: true,
+      perPeerMs: 5000, // per-peer budget deliberately generous — we want the TOTAL budget to fire
+      totalMs: TOTAL_MS,
+    });
+    const elapsed = Date.now() - start;
+
+    // Result should land close to totalMs, not near SLOW_MS — proves the race fired.
+    if (elapsed >= SLOW_MS) {
+      throw new Error(
+        `expected search to return near totalMs=${TOTAL_MS}ms, but took ${elapsed}ms — total-budget race did not fire`,
+      );
+    }
+
+    if (result.responded !== 0) {
+      throw new Error(`expected responded=0 on total timeout, got ${result.responded}`);
+    }
+    if (result.hits.length !== 0) {
+      throw new Error(`expected zero hits on total timeout, got ${JSON.stringify(result.hits)}`);
+    }
+    if (result.errors.length !== 1) {
+      throw new Error(`expected 1 error (slow peer), got ${JSON.stringify(result.errors)}`);
+    }
+    const err = result.errors[0]!;
+    if (err.reason !== "timeout") {
+      throw new Error(`expected reason=timeout, got reason=${err.reason} detail=${err.detail}`);
+    }
+    if (err.peerUrl !== peers[0]!.url) {
+      throw new Error(`timeout tagged wrong peer: ${JSON.stringify(err)}`);
+    }
+  },
+  async teardown(peers) {
+    // Clear the slow override so the Bun.serve fetch handler doesn't keep
+    // sleeping while backend.teardown() tries to stop it.
+    await peers[0]!.setSlow(null);
+  },
+};
+
+export default scenario;

--- a/test/fedtest/scenarios/05-install-at-peer.ts
+++ b/test/fedtest/scenarios/05-install-at-peer.ts
@@ -1,0 +1,96 @@
+/**
+ * Scenario 05 — @peer install end-to-end via emulated backend (#655 Phase 2).
+ *
+ * Proves the `<name>@<peer>` install chain holds together against a live
+ * local HTTP listener:
+ *
+ *   searchPeers /api/plugin/list-manifest  (resolvePeerInstall)
+ *     → synthesize downloadUrl from peerUrl + plugin name
+ *     → fetch /api/plugin/download/:name
+ *     → receive real tarball bytes (200, Content-Type gzip)
+ *
+ * Parallel proof to the mesh-child dogfood: if the cross-oracle install
+ * flow regresses — say a future refactor changes the download URL shape
+ * or the list-manifest schema — this scenario fails on emulated without
+ * needing a docker stack.
+ *
+ * The plugins.lock enforcement path is intentionally out of scope here.
+ * That lives in installFromTarball() and is a production trust boundary
+ * (#487) exercised by dedicated lockfile tests — not federation harness
+ * scope.
+ */
+
+import type { Scenario } from "../scenario";
+import { resolvePeerInstall } from "../../../src/commands/plugins/plugin/install-peer-resolver";
+
+const FAKE_TARBALL = new TextEncoder().encode("FAKE_TGZ_BYTES_FOR_FEDTEST_05");
+const FAKE_SHA = "sha256:feedbeef";
+
+const scenario: Scenario = {
+  name: "05-install-at-peer",
+  backends: ["emulated"],
+  peers: 2,
+  async setUp(peers) {
+    await peers[0]!.installPlugin({
+      name: "ping",
+      version: "1.0.0",
+      summary: "pingbeacon",
+      author: "fedtest",
+      tarball: FAKE_TARBALL,
+      sha256: FAKE_SHA,
+    });
+    // peer[1] is the distractor — it must NOT resolve as the install source.
+    await peers[1]!.installPlugin({ name: "other", version: "0.1.0" });
+  },
+  async assert(peers) {
+    const peerName = peers[0]!.node;
+
+    // Step 1: resolve — hits list-manifest on every peer, picks peer 0.
+    const resolved = await resolvePeerInstall("ping", peerName, {
+      searchOpts: {
+        peers: peers.map(p => ({ url: p.url, name: p.node })),
+        noCache: true,
+        perPeerMs: 2000,
+        totalMs: 4000,
+      },
+    });
+
+    if (resolved.version !== "1.0.0") {
+      throw new Error(`expected version=1.0.0, got ${resolved.version}`);
+    }
+    if (resolved.peerUrl !== peers[0]!.url) {
+      throw new Error(`expected peerUrl=${peers[0]!.url}, got ${resolved.peerUrl}`);
+    }
+    const expectedDownload = `${peers[0]!.url}/api/plugin/download/ping`;
+    if (resolved.downloadUrl !== expectedDownload) {
+      throw new Error(`expected downloadUrl=${expectedDownload}, got ${resolved.downloadUrl}`);
+    }
+    if (resolved.peerSha256 !== FAKE_SHA) {
+      throw new Error(`expected peerSha256=${FAKE_SHA}, got ${resolved.peerSha256}`);
+    }
+    if (resolved.peerNode !== peers[0]!.node) {
+      throw new Error(`expected peerNode=${peers[0]!.node}, got ${resolved.peerNode}`);
+    }
+
+    // Step 2: fetch the synthesized downloadUrl — the last link in the chain.
+    const res = await fetch(resolved.downloadUrl);
+    if (!res.ok) {
+      throw new Error(`download fetch failed: status=${res.status}`);
+    }
+    const ctype = res.headers.get("content-type") ?? "";
+    if (!ctype.includes("gzip")) {
+      throw new Error(`expected Content-Type gzip, got ${ctype}`);
+    }
+    const bytes = new Uint8Array(await res.arrayBuffer());
+    if (bytes.length !== FAKE_TARBALL.length) {
+      throw new Error(`tarball length mismatch: expected ${FAKE_TARBALL.length}, got ${bytes.length}`);
+    }
+    for (let i = 0; i < bytes.length; i++) {
+      if (bytes[i] !== FAKE_TARBALL[i]) {
+        throw new Error(`tarball byte mismatch at index ${i}`);
+      }
+    }
+  },
+};
+
+export default scenario;


### PR DESCRIPTION
## Summary

Ship the four fedtest scenarios that Phase 1 (#661) deferred — all against the emulated backend; docker scenarios stay deferred to Phase 3.

- **02-search-happy** — 2 peers advertise a plugin each; `searchPeers` returns both, correctly tagged with peerUrl + peerNode.
- **03-search-offline** — one peer closes its listener; live peer's hit lands, offline peer appears in `errors[]` with `reason=unreachable`.
- **04-search-slow** — one peer sleeps past `totalMs`; the race fires, `reason=timeout`, wall-clock bounded near `totalMs`.
- **05-install-at-peer** — end-to-end resolve → download chain: `resolvePeerInstall` produces the canonical download URL and a follow-up fetch returns the advertised tarball bytes + gzip content-type.

## PeerHandle mutation API

#655 deferred the mutation API to Phase 2. Shipped:

```ts
interface PeerHandle {
  installPlugin(entry: EmulatedPluginEntry): Promise<void>;
  setOffline(offline: boolean): Promise<void>;
  setSlow(delayMs: number | null): Promise<void>;
  spoofSha(pluginName: string, sha256: string | null): Promise<void>;
}
```

Emulated backend implements all four in-process; docker stubs with a clear "use emulated" error. Scenarios that mutate state declare `backends: ["emulated"]`.

## Scope discipline

Scenario 05 stops at wire-level chain integrity. The plugins.lock enforcement path is a production trust boundary (#487) — exercised by dedicated lockfile tests, not the federation harness. The RFC framing ("parallel proof to mesh-child dogfood") treats emulated install as the chain-holds proof, not a full install replay.

## Test plan
- [x] `BACKEND=emulated bun test ./test/fedtest/runner.ts` → 5 pass
- [x] `bun run test` → 1274 pass / 7 skip / 0 fail
- [x] `bun run test:plugin` → 352 pass / 6 skip / 0 fail
- [x] `bun run test:mock-smoke` → 6 pass / 0 fail
- [x] `bun run test:isolated` → 70/70 files pass
- [ ] CI green

Closes #655 Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)