### PR TITLE
feat(consent): gate team invite behind PIN (#644 Phase 2)

### DIFF
--- a/src/commands/plugins/team/index.ts
+++ b/src/commands/plugins/team/index.ts
@@ -163,9 +163,27 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       if (!args[1]) { return { ok: false, error: "usage: maw team delete <team-name>" }; }
       await cmdTeamDelete(args[1]);
 
+    } else if (sub === "invite") {
+      // maw team invite <team> <peer> [--scope <scope>] [--lead <lead>]
+      const { cmdTeamInvite } = await import("./team-invite");
+      const flags = parseFlags(args, {
+        "--scope": String,
+        "--lead": String,
+      }, 1);
+      const team = flags._[0];
+      const peer = flags._[1];
+      if (!team || !peer) {
+        logs.push("usage: maw team invite <team> <peer> [--scope <scope>] [--lead <lead>]");
+        return { ok: false, error: "team and peer required", output: logs.join("\n") };
+      }
+      await cmdTeamInvite(team, peer, {
+        scope: flags["--scope"] as string | undefined,
+        lead: flags["--lead"] as string | undefined,
+      });
+
     } else {
       logs.push(`unknown team subcommand: ${sub}`);
-      logs.push("usage: maw team <create|spawn|send|shutdown|resume|lives|list|status|add|tasks|done|assign|delete>");
+      logs.push("usage: maw team <create|spawn|send|shutdown|resume|lives|list|status|add|tasks|done|assign|delete|invite>");
       return { ok: false, error: `unknown subcommand: ${sub}`, output: logs.join("\n") };
     }
 

--- a/src/commands/plugins/team/team-invite.ts
+++ b/src/commands/plugins/team/team-invite.ts
@@ -33,6 +33,10 @@ export interface TeamInviteOptions {
   scope?: string;
   /** Team lead name surfaced in the consent summary. Defaults to config.node. */
   lead?: string;
+  /** Test injection — override peer lookup. Defaults to config.namedPeers. */
+  peerLookup?: (peerName: string) => NamedPeer | null;
+  /** Test injection — override local node. Defaults to config.node. */
+  myNode?: string;
 }
 
 export interface TeamInviteDecision {
@@ -44,13 +48,13 @@ export interface TeamInviteDecision {
 
 const SCOPE_DEFAULT = "member";
 
-interface NamedPeer {
+export interface NamedPeer {
   name: string;
   url: string;
   node?: string;
 }
 
-function findPeer(peerName: string): NamedPeer | null {
+function defaultPeerLookup(peerName: string): NamedPeer | null {
   const cfg = loadConfig() as { namedPeers?: NamedPeer[] };
   const named = cfg.namedPeers ?? [];
   return named.find(p => p.name === peerName) ?? null;
@@ -107,7 +111,8 @@ export async function runTeamInvite(
     };
   }
 
-  const peer = findPeer(peerName);
+  const lookup = opts.peerLookup ?? defaultPeerLookup;
+  const peer = lookup(peerName);
   if (!peer) {
     return {
       ok: false,
@@ -127,7 +132,7 @@ export async function runTeamInvite(
     return { ok: true };
   }
 
-  const myNode = loadConfig().node ?? "local";
+  const myNode = opts.myNode ?? (loadConfig().node ?? "local");
   const lead = opts.lead || myNode;
 
   // Trust key falls back to peerName when peer didn't advertise a node.

--- a/src/commands/plugins/team/team-invite.ts
+++ b/src/commands/plugins/team/team-invite.ts
@@ -1,0 +1,198 @@
+/**
+ * maw team invite — invite a remote oracle to a local team (#644 Phase 2).
+ *
+ * Completes the 3-layer consent story (Phase 1: hey, Phase 3: plugin-install).
+ * Adding a remote oracle to a team is a privileged action — the invitee will
+ * receive team messages, tasks, and eventually share knowledge at shutdown
+ * via --merge. Phase 2 gates this with the same PIN-consent primitive.
+ *
+ * Default OFF. Opt in via MAW_CONSENT=1 (same convention as Phase 1 + 3).
+ *
+ * When consent IS required and not yet trusted, we:
+ *   1. Resolve the peer in namedPeers → peerUrl (the "hard ID").
+ *   2. requestConsent(action="team-invite") with a summary containing
+ *      team + lead + invitee + scope so the approver has full context.
+ *   3. Print the PIN + "on <peer>: maw consent approve ..." + exit 2.
+ *
+ * Once the peer has approved (or an existing trust entry matches), we add
+ * the peer to the team manifest under `invitees` and return. The caller
+ * re-runs `maw team invite` after OOB PIN relay.
+ *
+ * Trust-key scope note: trust is bound to (myNode, peerNode, "team-invite").
+ * A `hey` or `plugin-install` trust entry does NOT allow a team invite — the
+ * scopes are intentionally distinct (see gate-plugin-install.ts §2).
+ */
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
+import { join } from "path";
+import { loadConfig } from "../../../config";
+import { isTrusted, requestConsent } from "../../../core/consent";
+import { resolvePsi } from "./team-helpers";
+
+export interface TeamInviteOptions {
+  /** Scope string surfaced in the consent summary (default: "member"). */
+  scope?: string;
+  /** Team lead name surfaced in the consent summary. Defaults to config.node. */
+  lead?: string;
+}
+
+export interface TeamInviteDecision {
+  ok: boolean;
+  exitCode?: number;
+  /** Message to print to stderr when ok=false. */
+  message?: string;
+}
+
+const SCOPE_DEFAULT = "member";
+
+interface NamedPeer {
+  name: string;
+  url: string;
+  node?: string;
+}
+
+function findPeer(peerName: string): NamedPeer | null {
+  const cfg = loadConfig() as { namedPeers?: NamedPeer[] };
+  const named = cfg.namedPeers ?? [];
+  return named.find(p => p.name === peerName) ?? null;
+}
+
+function manifestPath(teamName: string): string {
+  return join(resolvePsi(), "memory", "mailbox", "teams", teamName, "manifest.json");
+}
+
+/**
+ * Record the invitee in the team manifest. Idempotent — repeat invites
+ * are no-ops so post-consent re-runs don't duplicate entries.
+ */
+export function recordInvitee(teamName: string, peer: NamedPeer, scope: string): void {
+  const path = manifestPath(teamName);
+  if (!existsSync(path)) {
+    throw new Error(`team '${teamName}' not found — run: maw team create ${teamName}`);
+  }
+  const manifest = JSON.parse(readFileSync(path, "utf-8"));
+  manifest.invitees = Array.isArray(manifest.invitees) ? manifest.invitees : [];
+  const existing = manifest.invitees.findIndex((i: any) => i?.name === peer.name);
+  const entry = {
+    name: peer.name,
+    url: peer.url,
+    node: peer.node,
+    scope,
+    invitedAt: new Date().toISOString(),
+  };
+  if (existing >= 0) {
+    manifest.invitees[existing] = entry;
+  } else {
+    manifest.invitees.push(entry);
+  }
+  mkdirSync(join(resolvePsi(), "memory", "mailbox", "teams", teamName), { recursive: true });
+  // lgtm[js/file-system-race] — PRIVATE-PATH: manifest under ψ/memory/mailbox/teams/<team>/
+  writeFileSync(path, JSON.stringify(manifest, null, 2));
+}
+
+/**
+ * Pure decision function — easier to unit-test than the CLI wrapper.
+ * Returns ok=true iff the invite was recorded; ok=false carries the
+ * stderr message + exit code the CLI should print.
+ */
+export async function runTeamInvite(
+  teamName: string,
+  peerName: string,
+  opts: TeamInviteOptions = {},
+): Promise<TeamInviteDecision> {
+  if (!existsSync(manifestPath(teamName))) {
+    return {
+      ok: false,
+      exitCode: 1,
+      message: `\x1b[31m✗\x1b[0m team '${teamName}' not found — run: maw team create ${teamName}`,
+    };
+  }
+
+  const peer = findPeer(peerName);
+  if (!peer) {
+    return {
+      ok: false,
+      exitCode: 1,
+      message:
+        `\x1b[31m✗\x1b[0m unknown peer '${peerName}' — not in namedPeers.\n` +
+        `  hint: add ${peerName} to maw.config.json namedPeers`,
+    };
+  }
+
+  const scope = opts.scope || SCOPE_DEFAULT;
+
+  // Default OFF — opt in via MAW_CONSENT=1. When off, skip the PIN round-trip
+  // entirely and record the invite directly (legacy path).
+  if (process.env.MAW_CONSENT !== "1") {
+    recordInvitee(teamName, peer, scope);
+    return { ok: true };
+  }
+
+  const myNode = loadConfig().node ?? "local";
+  const lead = opts.lead || myNode;
+
+  // Trust key falls back to peerName when peer didn't advertise a node.
+  // Same convention as gate-plugin-install.ts — keeps trust decisions
+  // expressible even for legacy peers.
+  const peerIdForTrust = peer.node || peer.name;
+  if (isTrusted(myNode, peerIdForTrust, "team-invite")) {
+    recordInvitee(teamName, peer, scope);
+    return { ok: true };
+  }
+
+  const summary =
+    `team-invite: team='${teamName}' lead='${lead}' ` +
+    `invitee='${peer.name}'${peer.node ? ` (${peer.node})` : ""} ` +
+    `url='${peer.url}' scope='${scope}'`;
+
+  const r = await requestConsent({
+    from: myNode,
+    to: peerIdForTrust,
+    action: "team-invite",
+    summary,
+    peerUrl: peer.url,
+  });
+
+  if (!r.ok) {
+    return {
+      ok: false,
+      exitCode: 1,
+      message: [
+        `\x1b[31m✗ consent request failed\x1b[0m: ${r.error}`,
+        r.requestId ? `  request id (local mirror): ${r.requestId}` : "",
+        `  hint: peer may be down, or /api/consent/request not yet deployed`,
+      ].filter(Boolean).join("\n"),
+    };
+  }
+
+  return {
+    ok: false,
+    exitCode: 2,
+    message: [
+      `\x1b[33m⏸  consent required\x1b[0m → team-invite`,
+      `   team:   ${teamName}  (lead: ${lead})`,
+      `   peer:   ${peer.name}${peer.node ? ` (${peer.node})` : ""}  [${peer.url}]`,
+      `   scope:  ${scope}`,
+      `   request id: ${r.requestId}`,
+      `   PIN (relay OOB to ${peerIdForTrust} operator): \x1b[1m${r.pin}\x1b[0m`,
+      `   expires: ${r.expiresAt}`,
+      ``,
+      `   on ${peerIdForTrust}: \x1b[36mmaw consent approve ${r.requestId} ${r.pin}\x1b[0m`,
+      `   then re-run: \x1b[36mmaw team invite ${teamName} ${peer.name}\x1b[0m`,
+    ].join("\n"),
+  };
+}
+
+/** CLI entry — prints outcome, returns void. Throws only on programmer error. */
+export async function cmdTeamInvite(
+  teamName: string,
+  peerName: string,
+  opts: TeamInviteOptions = {},
+): Promise<void> {
+  const decision = await runTeamInvite(teamName, peerName, opts);
+  if (decision.ok) {
+    console.log(`\x1b[32m✓\x1b[0m invited '${peerName}' to team '${teamName}' (scope: ${opts.scope || SCOPE_DEFAULT})`);
+    return;
+  }
+  if (decision.message) console.error(decision.message);
+  process.exit(decision.exitCode ?? 1);
+}

--- a/src/commands/plugins/team/team-invite.ts
+++ b/src/commands/plugins/team/team-invite.ts
@@ -22,7 +22,7 @@
  * A `hey` or `plugin-install` trust entry does NOT allow a team invite — the
  * scopes are intentionally distinct (see gate-plugin-install.ts §2).
  */
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
+import { readFileSync, writeFileSync, existsSync } from "fs";
 import { join } from "path";
 import { loadConfig } from "../../../config";
 import { isTrusted, requestConsent } from "../../../core/consent";
@@ -67,13 +67,25 @@ function manifestPath(teamName: string): string {
 /**
  * Record the invitee in the team manifest. Idempotent — repeat invites
  * are no-ops so post-consent re-runs don't duplicate entries.
+ *
+ * No `existsSync` precheck: catch ENOENT on the read instead. CodeQL's
+ * `js/file-system-race` flags check-then-use patterns regardless of path
+ * ownership, and inline `// lgtm` markers don't suppress alerts under the
+ * current GHAS scanner (see .github/codeql/codeql-config.yml). The
+ * read-then-write pattern matches team-lifecycle.ts (#393) which ships
+ * without an alert.
  */
 export function recordInvitee(teamName: string, peer: NamedPeer, scope: string): void {
   const path = manifestPath(teamName);
-  if (!existsSync(path)) {
-    throw new Error(`team '${teamName}' not found — run: maw team create ${teamName}`);
+  let manifest: any;
+  try {
+    manifest = JSON.parse(readFileSync(path, "utf-8"));
+  } catch (e: any) {
+    if (e?.code === "ENOENT") {
+      throw new Error(`team '${teamName}' not found — run: maw team create ${teamName}`);
+    }
+    throw e;
   }
-  const manifest = JSON.parse(readFileSync(path, "utf-8"));
   manifest.invitees = Array.isArray(manifest.invitees) ? manifest.invitees : [];
   const existing = manifest.invitees.findIndex((i: any) => i?.name === peer.name);
   const entry = {
@@ -88,8 +100,7 @@ export function recordInvitee(teamName: string, peer: NamedPeer, scope: string):
   } else {
     manifest.invitees.push(entry);
   }
-  mkdirSync(join(resolvePsi(), "memory", "mailbox", "teams", teamName), { recursive: true });
-  // lgtm[js/file-system-race] — PRIVATE-PATH: manifest under ψ/memory/mailbox/teams/<team>/
+  // lgtm[js/file-system-race] — PRIVATE-PATH: manifest under ψ/memory/mailbox/teams/<team>/, see docs/security/file-system-race-stance.md
   writeFileSync(path, JSON.stringify(manifest, null, 2));
 }
 

--- a/test/isolated/team-invite.test.ts
+++ b/test/isolated/team-invite.test.ts
@@ -1,0 +1,293 @@
+/**
+ * runTeamInvite — unit tests (#644 Phase 2).
+ *
+ * Mirrors the gate-plugin-install.test.ts shape: decision-only, no CLI
+ * side-effects. Network I/O is stubbed via globalThis.fetch override.
+ *
+ * Peer/node lookup is injected (peerLookup + myNode opts) so tests don't
+ * depend on maw.config.json — `loadConfig()` is module-cached and its
+ * backing path is evaluated at import time, making env-based overrides
+ * brittle in a test process.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+import {
+  runTeamInvite,
+  recordInvitee,
+  type NamedPeer,
+} from "../../src/commands/plugins/team/team-invite";
+import { recordTrust, listPending, listTrust } from "../../src/core/consent";
+
+let testDir: string;
+let originalCwd: string;
+let consentDir: string;
+let originalConsent: string | undefined;
+let originalTrust: string | undefined;
+let originalPending: string | undefined;
+
+const WHITE_PEER: NamedPeer = { name: "white-peer", url: "http://white:3456", node: "white" };
+const stubLookup = (want: NamedPeer | null) => (_name: string): NamedPeer | null => want;
+
+beforeEach(() => {
+  originalCwd = process.cwd();
+  testDir = mkdtempSync(join(tmpdir(), "team-invite-"));
+  // Oracle-root markers so resolvePsi() walks to testDir/ψ
+  mkdirSync(join(testDir, "ψ/memory/mailbox/teams/test-team"), { recursive: true });
+  writeFileSync(join(testDir, "CLAUDE.md"), "# test oracle\n");
+  writeFileSync(
+    join(testDir, "ψ/memory/mailbox/teams/test-team/manifest.json"),
+    JSON.stringify({ name: "test-team", members: [], description: "test" }),
+  );
+  process.chdir(testDir);
+
+  // Isolate consent stores per-test
+  consentDir = mkdtempSync(join(tmpdir(), "team-invite-consent-"));
+  originalTrust = process.env.CONSENT_TRUST_FILE;
+  originalPending = process.env.CONSENT_PENDING_DIR;
+  process.env.CONSENT_TRUST_FILE = join(consentDir, "trust.json");
+  process.env.CONSENT_PENDING_DIR = join(consentDir, "pending");
+
+  // Default OFF — each test opts in explicitly where needed
+  originalConsent = process.env.MAW_CONSENT;
+  delete process.env.MAW_CONSENT;
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  if (originalConsent === undefined) delete process.env.MAW_CONSENT;
+  else process.env.MAW_CONSENT = originalConsent;
+  if (originalTrust === undefined) delete process.env.CONSENT_TRUST_FILE;
+  else process.env.CONSENT_TRUST_FILE = originalTrust;
+  if (originalPending === undefined) delete process.env.CONSENT_PENDING_DIR;
+  else process.env.CONSENT_PENDING_DIR = originalPending;
+  try { rmSync(testDir, { recursive: true, force: true }); } catch { /* ok */ }
+  try { rmSync(consentDir, { recursive: true, force: true }); } catch { /* ok */ }
+});
+
+function readManifest(): any {
+  const path = join(testDir, "ψ/memory/mailbox/teams/test-team/manifest.json");
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+describe("runTeamInvite — consent OFF (default)", () => {
+  test("records invitee directly when MAW_CONSENT is not set", async () => {
+    const r = await runTeamInvite("test-team", "white-peer", {
+      peerLookup: stubLookup(WHITE_PEER),
+      myNode: "neo",
+    });
+    expect(r.ok).toBe(true);
+    const m = readManifest();
+    expect(m.invitees).toHaveLength(1);
+    expect(m.invitees[0]).toMatchObject({
+      name: "white-peer",
+      url: "http://white:3456",
+      node: "white",
+      scope: "member",
+    });
+    // No consent round-trip at all
+    expect(listPending()).toHaveLength(0);
+  });
+
+  test("honors --scope override", async () => {
+    const r = await runTeamInvite("test-team", "white-peer", {
+      peerLookup: stubLookup(WHITE_PEER),
+      myNode: "neo",
+      scope: "observer",
+    });
+    expect(r.ok).toBe(true);
+    expect(readManifest().invitees[0].scope).toBe("observer");
+  });
+
+  test("fails with exit 1 when team does not exist", async () => {
+    const r = await runTeamInvite("ghost", "white-peer", {
+      peerLookup: stubLookup(WHITE_PEER),
+      myNode: "neo",
+    });
+    expect(r.ok).toBe(false);
+    expect(r.exitCode).toBe(1);
+    expect(r.message).toContain("team 'ghost' not found");
+  });
+
+  test("fails with exit 1 when peer not in namedPeers", async () => {
+    const r = await runTeamInvite("test-team", "ghost-peer", {
+      peerLookup: stubLookup(null),
+      myNode: "neo",
+    });
+    expect(r.ok).toBe(false);
+    expect(r.exitCode).toBe(1);
+    expect(r.message).toContain("unknown peer 'ghost-peer'");
+    expect(r.message).toContain("namedPeers");
+  });
+});
+
+describe("runTeamInvite — consent ON (MAW_CONSENT=1)", () => {
+  beforeEach(() => { process.env.MAW_CONSENT = "1"; });
+
+  test("allows when peer is already trusted for team-invite", async () => {
+    recordTrust({
+      from: "neo", to: "white", action: "team-invite",
+      approvedAt: new Date().toISOString(), approvedBy: "human", requestId: null,
+    });
+    const r = await runTeamInvite("test-team", "white-peer", {
+      peerLookup: stubLookup(WHITE_PEER),
+      myNode: "neo",
+    });
+    expect(r.ok).toBe(true);
+    expect(readManifest().invitees).toHaveLength(1);
+    // No new pending request — trust entry bypassed the network
+    expect(listPending()).toHaveLength(0);
+  });
+
+  test("does NOT cross trust scopes — a 'hey' trust entry does not allow team-invite", async () => {
+    recordTrust({
+      from: "neo", to: "white", action: "hey",
+      approvedAt: new Date().toISOString(), approvedBy: "human", requestId: null,
+    });
+    const origFetch = globalThis.fetch;
+    (globalThis as any).fetch = async () => ({ ok: true, status: 201 } as Response);
+    try {
+      const r = await runTeamInvite("test-team", "white-peer", {
+        peerLookup: stubLookup(WHITE_PEER),
+        myNode: "neo",
+      });
+      expect(r.ok).toBe(false);
+      expect(r.exitCode).toBe(2);
+      // Manifest untouched — invite NOT recorded pre-approval
+      expect(readManifest().invitees).toBeUndefined();
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  test("denies and surfaces PIN + team context when peer reachable", async () => {
+    const origFetch = globalThis.fetch;
+    (globalThis as any).fetch = async () => ({ ok: true, status: 201 } as Response);
+    try {
+      const r = await runTeamInvite("test-team", "white-peer", {
+        peerLookup: stubLookup(WHITE_PEER),
+        myNode: "neo",
+        scope: "observer",
+        lead: "neo",
+      });
+      expect(r.ok).toBe(false);
+      expect(r.exitCode).toBe(2);
+      expect(r.message).toContain("consent required");
+      expect(r.message).toContain("team-invite");
+      // Team context
+      expect(r.message).toContain("test-team");
+      expect(r.message).toContain("lead: neo");
+      // Peer context — nickname + node + URL
+      expect(r.message).toContain("white-peer");
+      expect(r.message).toContain("white");
+      expect(r.message).toContain("http://white:3456");
+      // Scope surfaced
+      expect(r.message).toContain("observer");
+      // PIN format — 6 chars from A-Z2-9
+      expect(r.message).toMatch(/[A-Z2-9]{6}/);
+      // Pending mirror written + action scoped correctly
+      expect(listPending()).toHaveLength(1);
+      expect(listPending()[0]!.action).toBe("team-invite");
+      // Manifest untouched
+      expect(readManifest().invitees).toBeUndefined();
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  test("returns exitCode 1 with error message when peer unreachable", async () => {
+    const origFetch = globalThis.fetch;
+    (globalThis as any).fetch = async () => { throw new Error("ECONNREFUSED"); };
+    try {
+      const r = await runTeamInvite("test-team", "white-peer", {
+        peerLookup: stubLookup(WHITE_PEER),
+        myNode: "neo",
+      });
+      expect(r.ok).toBe(false);
+      expect(r.exitCode).toBe(1);
+      expect(r.message).toContain("consent request failed");
+      expect(r.message).toContain("ECONNREFUSED");
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  test("falls back to peerName for trust key when peerNode is absent", async () => {
+    const legacyPeer: NamedPeer = { name: "legacy-peer", url: "http://legacy:3456" };
+    recordTrust({
+      from: "neo", to: "legacy-peer", action: "team-invite",
+      approvedAt: new Date().toISOString(), approvedBy: "human", requestId: null,
+    });
+    const r = await runTeamInvite("test-team", "legacy-peer", {
+      peerLookup: stubLookup(legacyPeer),
+      myNode: "neo",
+    });
+    expect(r.ok).toBe(true);
+    expect(readManifest().invitees[0].name).toBe("legacy-peer");
+    expect(listTrust()).toHaveLength(1);
+  });
+});
+
+describe("recordInvitee", () => {
+  test("is idempotent — re-invite updates instead of duplicating", () => {
+    recordInvitee("test-team", WHITE_PEER, "member");
+    recordInvitee("test-team", WHITE_PEER, "observer");
+    const m = readManifest();
+    expect(m.invitees).toHaveLength(1);
+    expect(m.invitees[0].scope).toBe("observer");
+  });
+
+  test("throws when team manifest missing", () => {
+    expect(() => recordInvitee("ghost", WHITE_PEER, "member")).toThrow(/not found/);
+  });
+
+  test("preserves existing manifest fields (members, description)", () => {
+    recordInvitee("test-team", WHITE_PEER, "member");
+    const m = readManifest();
+    expect(m.name).toBe("test-team");
+    expect(m.description).toBe("test");
+    expect(m.members).toEqual([]);
+  });
+});
+
+describe("runTeamInvite — re-run after approval flow", () => {
+  test("denied → approve locally → re-run succeeds and records invite", async () => {
+    process.env.MAW_CONSENT = "1";
+    const origFetch = globalThis.fetch;
+    (globalThis as any).fetch = async () => ({ ok: true, status: 201 } as Response);
+    try {
+      // First run — consent required
+      const r1 = await runTeamInvite("test-team", "white-peer", {
+        peerLookup: stubLookup(WHITE_PEER),
+        myNode: "neo",
+      });
+      expect(r1.ok).toBe(false);
+      expect(r1.exitCode).toBe(2);
+      // No invitee recorded yet
+      expect(readManifest().invitees).toBeUndefined();
+
+      // Simulate approval by writing a trust entry (the `maw consent approve`
+      // path does this on the target side — on re-run, the initiator sees
+      // their OWN trust entry, not the target's. For this test, we record
+      // the initiator-side trust directly to model "post-approval re-run".
+      recordTrust({
+        from: "neo", to: "white", action: "team-invite",
+        approvedAt: new Date().toISOString(), approvedBy: "human", requestId: null,
+      });
+
+      // Second run — trusted, no network, invite recorded
+      const r2 = await runTeamInvite("test-team", "white-peer", {
+        peerLookup: stubLookup(WHITE_PEER),
+        myNode: "neo",
+      });
+      expect(r2.ok).toBe(true);
+      const m = readManifest();
+      expect(m.invitees).toHaveLength(1);
+      expect(m.invitees[0].name).toBe("white-peer");
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Completes the 3-layer consent stack: Phase 1 (hey) ✓, Phase 2 (team-invite) ← this, Phase 3 (plugin-install) ✓
- Introduces \`maw team invite <team> <peer> [--scope <s>] [--lead <l>]\` — gates invite behind the same PIN-consent primitive as Phases 1+3
- Default OFF; opt in via \`MAW_CONSENT=1\`
- Reuses \`src/core/consent/\` primitive (\`isTrusted\`, \`requestConsent\`) — no rebuild
- Trust key: \`myNode→peerNode:team-invite\`; scope is distinct from hey/plugin-install (verified by test)

## Behavior
- \`MAW_CONSENT\` unset → legacy path: records invitee in team manifest directly
- \`MAW_CONSENT=1\` + already-trusted (myNode, peerNode, "team-invite") → records + skips prompt
- \`MAW_CONSENT=1\` + untrusted → posts to peer's \`/api/consent/request\`, mirrors locally, prints PIN + \`maw consent approve\` instructions, exits 2. Manifest untouched until post-approval re-run.
- Peer unreachable → exit 1 with actionable error
- Summary surfaced to approver includes team name, lead, invitee nickname + node + URL (hard ID), and scope

## File ownership
- \`src/commands/plugins/team/team-invite.ts\` (new) — invite logic with inline consent calls
- \`src/commands/plugins/team/index.ts\` — wires \`sub === "invite"\` branch
- \`test/isolated/team-invite.test.ts\` — 13 tests (unit + flow)
- No changes to \`src/core/consent/*\` (respects ownership constraint between parallel Phase-2/3 agents)

## Test plan
- [x] \`bun test test/isolated/team-invite.test.ts\` — 13/13 pass, 52 expects
- [x] \`bun run test:all\` — 358/358 pass, 0 fail
- [x] \`bash scripts/test-isolated.sh\` — 71/71 files pass
- [ ] CI green

Closes the Phase 2 strand of #644.

🤖 Generated with [Claude Code](https://claude.com/claude-code)