### PR TITLE
sec(transport): curlFetch body size cap (closes #653)

### DIFF
--- a/src/core/transport/curl-fetch.ts
+++ b/src/core/transport/curl-fetch.ts
@@ -13,6 +13,12 @@ import { loadConfig } from "../../config";
 
 const IS_MACOS = process.platform === "darwin";
 
+// #653: cap response body to defend against a hostile peer returning an
+// unbounded stream. 10 MB matches the project convention for untrusted
+// HTTP bodies (see plugin-install tarball cap). Callers can override via
+// opts.maxBytes when a larger ceiling is genuinely needed.
+const DEFAULT_MAX_BYTES = 10 * 1024 * 1024;
+
 export interface CurlResponse {
   ok: boolean;
   status: number;
@@ -23,6 +29,7 @@ export async function curlFetch(url: string, opts?: {
   method?: string;
   body?: string;
   timeout?: number;
+  maxBytes?: number;
 }): Promise<CurlResponse> {
   // Build auth headers
   const headers: Record<string, string> = {};
@@ -53,6 +60,7 @@ export async function curlFetch(url: string, opts?: {
 }
 
 async function nativeFetch(url: string, opts: typeof curlFetch extends (u: string, o?: infer O) => any ? O : never, headers: Record<string, string>): Promise<CurlResponse> {
+  const maxBytes = opts?.maxBytes ?? DEFAULT_MAX_BYTES;
   try {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), opts?.timeout || 10000);
@@ -63,7 +71,37 @@ async function nativeFetch(url: string, opts: typeof curlFetch extends (u: strin
       signal: controller.signal,
     });
     clearTimeout(timeout);
-    const text = await res.text();
+
+    // #653: reject before buffering if the peer declares an oversized body.
+    const declared = Number(res.headers.get("content-length") ?? 0);
+    if (declared > maxBytes) {
+      controller.abort();
+      return { ok: false, status: res.status, data: { error: `body exceeded ${maxBytes} bytes` } };
+    }
+
+    // Stream-read with a running byte cap — Content-Length can be absent or
+    // spoofed, so we must enforce during the read, not only up front.
+    const reader = res.body?.getReader();
+    if (!reader) {
+      return { ok: res.ok, status: res.status, data: null };
+    }
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        try { await reader.cancel(); } catch { /* best effort */ }
+        controller.abort();
+        return { ok: false, status: res.status, data: { error: `body exceeded ${maxBytes} bytes` } };
+      }
+      chunks.push(value);
+    }
+    const buf = new Uint8Array(total);
+    let off = 0;
+    for (const c of chunks) { buf.set(c, off); off += c.byteLength; }
+    const text = new TextDecoder().decode(buf);
     const data = text ? JSON.parse(text) : null;
     return { ok: res.ok, status: res.status, data };
   } catch (err) {
@@ -80,8 +118,11 @@ async function nativeFetch(url: string, opts: typeof curlFetch extends (u: strin
 }
 
 async function curlSpawn(url: string, opts: typeof curlFetch extends (u: string, o?: infer O) => any ? O : never, headers: Record<string, string>): Promise<CurlResponse> {
+  const maxBytes = opts?.maxBytes ?? DEFAULT_MAX_BYTES;
   const timeoutSec = Math.ceil((opts?.timeout || 10000) / 1000);
-  const args = ["curl", "-sf", "--max-time", String(timeoutSec)];
+  // curl --max-filesize refuses the transfer if Content-Length exceeds the
+  // cap; we still track bytes on the pipe because the header can be missing.
+  const args = ["curl", "-sf", "--max-time", String(timeoutSec), "--max-filesize", String(maxBytes)];
   if (opts?.method) args.push("-X", opts.method);
   for (const [k, v] of Object.entries(headers)) {
     args.push("-H", `${k}: ${v}`);
@@ -91,9 +132,31 @@ async function curlSpawn(url: string, opts: typeof curlFetch extends (u: string,
 
   try {
     const proc = Bun.spawn(args, { stdout: "pipe", stderr: "pipe", windowsHide: true });
-    const text = await new Response(proc.stdout).text();
+    const reader = (proc.stdout as ReadableStream<Uint8Array>).getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    let exceeded = false;
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        exceeded = true;
+        try { await reader.cancel(); } catch { /* best effort */ }
+        try { proc.kill(); } catch { /* best effort */ }
+        break;
+      }
+      chunks.push(value);
+    }
     const code = await proc.exited;
+    if (exceeded) {
+      return { ok: false, status: 0, data: { error: `body exceeded ${maxBytes} bytes` } };
+    }
     if (code !== 0) return { ok: false, status: code, data: null };
+    const buf = new Uint8Array(total);
+    let off = 0;
+    for (const c of chunks) { buf.set(c, off); off += c.byteLength; }
+    const text = new TextDecoder().decode(buf);
     return { ok: true, status: 200, data: text ? JSON.parse(text) : null };
   } catch {
     return { ok: false, status: 0, data: null };

--- a/test/curl-fetch.test.ts
+++ b/test/curl-fetch.test.ts
@@ -131,6 +131,86 @@ describe("curlFetch", () => {
   });
 });
 
+describe("curlFetch body size cap (#653)", () => {
+  // Tests snapshot global.fetch per-case so they don't leak across the file.
+  // Pattern lifted from costs.test.ts fix (#649) to keep snapshot/restore safe.
+
+  test("rejects body exceeding maxBytes (streaming)", async () => {
+    const origFetch = globalThis.fetch;
+    try {
+      // Stream 20 chunks of 1 MB each — no Content-Length header, so the
+      // cap must fire mid-stream, not up-front.
+      globalThis.fetch = (async () => {
+        const chunk = new Uint8Array(1024 * 1024);
+        let n = 0;
+        const body = new ReadableStream<Uint8Array>({
+          async pull(controller) {
+            if (n++ < 20) { controller.enqueue(chunk); } else { controller.close(); }
+          },
+        });
+        return new Response(body, { status: 200, headers: { "content-type": "application/octet-stream" } });
+      }) as typeof fetch;
+
+      const res = await curlFetch("http://example.invalid/huge", { maxBytes: 1024 * 1024, timeout: 5000 });
+      expect(res.ok).toBe(false);
+      expect(res.data?.error).toMatch(/body exceeded/);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  test("rejects when Content-Length exceeds cap (before buffering)", async () => {
+    const origFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = (async () => {
+        const hdrs = new Headers({ "content-length": String(50 * 1024 * 1024) });
+        return new Response("{}", { status: 200, headers: hdrs });
+      }) as typeof fetch;
+
+      const res = await curlFetch("http://example.invalid/declared", { maxBytes: 1024, timeout: 5000 });
+      expect(res.ok).toBe(false);
+      expect(res.data?.error).toMatch(/body exceeded 1024 bytes/);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  test("passes through when body under cap", async () => {
+    const origFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = (async () => {
+        return new Response(JSON.stringify({ hello: "world" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }) as typeof fetch;
+
+      const res = await curlFetch("http://example.invalid/small", { maxBytes: 1024, timeout: 5000 });
+      expect(res.ok).toBe(true);
+      expect(res.data).toEqual({ hello: "world" });
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  test("default cap is 10 MB when maxBytes not supplied", async () => {
+    const origFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = (async () => {
+        const hdrs = new Headers({ "content-length": String(11 * 1024 * 1024) });
+        return new Response("{}", { status: 200, headers: hdrs });
+      }) as typeof fetch;
+
+      const res = await curlFetch("http://example.invalid/default", { timeout: 5000 });
+      expect(res.ok).toBe(false);
+      // 10 MB == 10485760 bytes
+      expect(res.data?.error).toMatch(/body exceeded 10485760 bytes/);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+});
+
 describe("curlFetch federation auth", () => {
   liveTest("protected endpoint with wrong token gets rejected", async () => {
     // Wrong token → signature mismatch → 401 from remote, but from white.local


### PR DESCRIPTION
## Summary
- Adds `maxBytes` option to `curlFetch`, default **10 MB**, closing #653.
- `nativeFetch`: short-circuits on oversized `Content-Length`; streams the body via `getReader()` with a running byte counter; aborts controller + cancels reader on exceed.
- `curlSpawn`: passes `--max-filesize` to curl for header-based rejection and also tracks bytes on the stdout pipe, killing the subprocess if it overruns.
- Returns `{ ok: false, data: { error: "body exceeded <N> bytes" } }` — no silent truncation.

Filed by adversarial-tests as FAIL-KNOWN: a hostile peer could return an unbounded stream and force the caller to buffer arbitrary memory.

## Test plan
- [x] New unit tests in `test/curl-fetch.test.ts` — streaming cap fires without Content-Length, Content-Length short-circuit, under-cap pass-through, default 10 MB.
- [x] `bun run test:all` — 358 pass / 0 fail locally.
- [ ] CI green.

Closes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)