### PR TITLE
feat(peers): probe-all — parallel federation ping (closes #669)

### DIFF
--- a/src/commands/plugins/peers/index.ts
+++ b/src/commands/plugins/peers/index.ts
@@ -34,15 +34,17 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
 
   const out = () => logs.join("\n");
   const help = () => [
-    "usage: maw peers <add|list|info|probe|remove> [...]",
-    "  add    <alias> <url> [--node <name>] [--allow-unreachable]",
-    "         — register alias (auto-probes /info). Exits non-zero on handshake failure:",
-    "           2=UNKNOWN/BAD_BODY/TLS  3=DNS  4=REFUSED  5=TIMEOUT  6=HTTP_4XX/5XX",
-    "         --allow-unreachable keeps exit 0 even when the probe fails (CI/bootstrap).",
-    "  list                                   — tabular list of all peers",
-    "  info   <alias>                         — JSON details for one peer (includes lastError if set)",
-    "  probe  <alias>                         — re-run /info handshake; updates lastSeen / lastError (#565)",
-    "  remove <alias>                         — remove (idempotent)",
+    "usage: maw peers <add|list|info|probe|probe-all|remove> [...]",
+    "  add       <alias> <url> [--node <name>] [--allow-unreachable]",
+    "            — register alias (auto-probes /info). Exits non-zero on handshake failure:",
+    "              2=UNKNOWN/BAD_BODY/TLS  3=DNS  4=REFUSED  5=TIMEOUT  6=HTTP_4XX/5XX",
+    "            --allow-unreachable keeps exit 0 even when the probe fails (CI/bootstrap).",
+    "  list                                      — tabular list of all peers",
+    "  info      <alias>                         — JSON details for one peer (includes lastError if set)",
+    "  probe     <alias>                         — re-run /info handshake; updates lastSeen / lastError (#565)",
+    "  probe-all [--timeout <ms>] [--allow-unreachable]",
+    "            — probe every peer in parallel; prints liveness table. Exit = worst PROBE_EXIT_CODE (#669).",
+    "  remove    <alias>                         — remove (idempotent)",
     "",
     "storage: ~/.maw/peers.json (v1)",
   ].join("\n");
@@ -100,6 +102,31 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         console.error(formatProbeError(r.error!, existing.url, alias));
         return { ok: false, error: `probe failed: ${r.error!.code}`, output: out() };
       }
+      case "probe-all": {
+        const timeoutIdx = args.indexOf("--timeout");
+        let timeoutMs = 2000;
+        if (timeoutIdx >= 0) {
+          const raw = args[timeoutIdx + 1];
+          const parsed = Number(raw);
+          if (!Number.isFinite(parsed) || parsed <= 0) {
+            return { ok: false, error: `usage: maw peers probe-all [--timeout <ms>]  (got --timeout ${raw ?? ""})` };
+          }
+          timeoutMs = parsed;
+        }
+        const allowUnreachable = args.includes("--allow-unreachable");
+        const { cmdProbeAll, formatProbeAll } = await import("./probe-all");
+        const r = await cmdProbeAll(timeoutMs);
+        console.log(formatProbeAll(r));
+        if (r.failCount > 0 && !allowUnreachable) {
+          return {
+            ok: false,
+            output: out(),
+            error: `probe-all: ${r.failCount}/${r.rows.length} peer(s) failed — pass --allow-unreachable to exit 0`,
+            exitCode: r.worstExitCode || 2,
+          };
+        }
+        return { ok: true, output: out() };
+      }
       case "list":
       case "ls": {
         console.log(impl.formatList(impl.cmdList()));
@@ -125,7 +152,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         console.log(help());
         return {
           ok: false,
-          error: `maw peers: unknown subcommand "${sub}" (expected add|list|info|probe|remove)`,
+          error: `maw peers: unknown subcommand "${sub}" (expected add|list|info|probe|probe-all|remove)`,
           output: out() || help(),
         };
       }

--- a/src/commands/plugins/peers/peers-probe-all.test.ts
+++ b/src/commands/plugins/peers/peers-probe-all.test.ts
@@ -1,0 +1,215 @@
+/**
+ * maw peers probe-all — parallel federation ping tests (#669).
+ *
+ * Kept in its own file (parallel with peers-probe.test.ts) to respect
+ * CONTRIBUTING's per-file size cap and keep subcommand coverage grouped.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+let dir: string;
+const servers: Array<{ stop: (force?: boolean) => void }> = [];
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "maw-peers-probe-all-"));
+  process.env.PEERS_FILE = join(dir, "peers.json");
+});
+afterEach(() => {
+  for (const s of servers.splice(0)) {
+    try { s.stop(true); } catch { /* ignore */ }
+  }
+  rmSync(dir, { recursive: true, force: true });
+  delete process.env.PEERS_FILE;
+});
+
+function spawnInfoServer(node: string, opts: { status?: number } = {}): { port: number } {
+  const server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/info") {
+        if (opts.status && opts.status >= 400) {
+          return new Response("bad", { status: opts.status });
+        }
+        return Response.json({ node, maw: true });
+      }
+      return new Response("nope", { status: 404 });
+    },
+  });
+  servers.push(server);
+  return { port: server.port };
+}
+
+describe("cmdProbeAll — 3-peer mixed fleet (2 ok, 1 fail)", () => {
+  it("returns a row per peer with ok/ms/error and worstExitCode set to the failure family", async () => {
+    const a = spawnInfoServer("alpha");
+    const b = spawnInfoServer("bravo");
+    const { cmdAdd } = await import("./impl");
+    await cmdAdd({ alias: "a", url: `http://127.0.0.1:${a.port}` });
+    await cmdAdd({ alias: "b", url: `http://127.0.0.1:${b.port}` });
+    await cmdAdd({
+      alias: "c",
+      url: "http://does-not-exist.invalid:9999",
+      node: "manual",
+    });
+
+    const { cmdProbeAll } = await import("./probe-all");
+    const r = await cmdProbeAll(1500);
+
+    expect(r.rows).toHaveLength(3);
+    expect(r.okCount).toBe(2);
+    expect(r.failCount).toBe(1);
+    // DNS → exit code 3 per PROBE_EXIT_CODES.
+    expect(r.worstExitCode).toBe(3);
+
+    const rowA = r.rows.find(x => x.alias === "a")!;
+    const rowB = r.rows.find(x => x.alias === "b")!;
+    const rowC = r.rows.find(x => x.alias === "c")!;
+
+    expect(rowA.ok).toBe(true);
+    expect(rowA.node).toBe("alpha");
+    expect(rowA.ms).toBeGreaterThanOrEqual(0);
+    expect(rowA.error).toBeUndefined();
+
+    expect(rowB.ok).toBe(true);
+    expect(rowB.node).toBe("bravo");
+
+    expect(rowC.ok).toBe(false);
+    expect(rowC.error?.code).toBe("DNS");
+  });
+
+  it("persists lastSeen on success and lastError on failure in a single store mutation", async () => {
+    const a = spawnInfoServer("alpha");
+    const { cmdAdd, cmdInfo } = await import("./impl");
+    await cmdAdd({ alias: "a", url: `http://127.0.0.1:${a.port}` });
+    await cmdAdd({ alias: "c", url: "http://does-not-exist.invalid:9999", node: "manual" });
+
+    const { cmdProbeAll } = await import("./probe-all");
+    await cmdProbeAll(1500);
+
+    const infoA = cmdInfo("a")!;
+    const infoC = cmdInfo("c")!;
+    expect(infoA.lastError).toBeUndefined();
+    expect(infoA.lastSeen).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(infoC.lastError?.code).toBe("DNS");
+    expect(infoC.node).toBe("manual"); // not overwritten on failure
+  });
+
+  it("empty peers.json → no rows, worstExitCode 0, okCount 0", async () => {
+    const { cmdProbeAll } = await import("./probe-all");
+    const r = await cmdProbeAll(1500);
+    expect(r.rows).toEqual([]);
+    expect(r.okCount).toBe(0);
+    expect(r.failCount).toBe(0);
+    expect(r.worstExitCode).toBe(0);
+  });
+});
+
+describe("formatProbeAll", () => {
+  it("renders header + row per peer + ok/fail footer", async () => {
+    const { formatProbeAll } = await import("./probe-all");
+    const out = formatProbeAll({
+      rows: [
+        { alias: "a", url: "http://a", node: "alpha", lastSeen: "2026-04-19T00:00:00Z", ok: true, ms: 42 },
+        {
+          alias: "c", url: "http://c", node: "manual", lastSeen: null, ok: false, ms: 1500,
+          error: { code: "DNS", message: "x", at: "2026-04-19T00:00:00Z" },
+        },
+      ],
+      okCount: 1,
+      failCount: 1,
+      worstExitCode: 3,
+    });
+
+    expect(out).toContain("alias");
+    expect(out).toContain("result");
+    expect(out).toContain("a");
+    expect(out).toContain("http://a");
+    expect(out).toContain("ok (42ms)");
+    expect(out).toContain("DNS");
+    expect(out).toContain("1/2 ok, 1 failed");
+  });
+
+  it("'no peers' banner when rows empty", async () => {
+    const { formatProbeAll } = await import("./probe-all");
+    const out = formatProbeAll({ rows: [], okCount: 0, failCount: 0, worstExitCode: 0 });
+    expect(out).toBe("no peers");
+  });
+});
+
+describe("dispatcher — probe-all subcommand", () => {
+  it("all peers ok → ok:true, exitCode undefined, table printed", async () => {
+    const a = spawnInfoServer("alpha");
+    const b = spawnInfoServer("bravo");
+    const { default: handler } = await import("./index");
+    await handler({ source: "cli", args: ["add", "a", `http://127.0.0.1:${a.port}`] });
+    await handler({ source: "cli", args: ["add", "b", `http://127.0.0.1:${b.port}`] });
+
+    const res = await handler({ source: "cli", args: ["probe-all"] });
+    expect(res.ok).toBe(true);
+    expect(res.exitCode).toBeUndefined();
+    expect(res.output).toContain("a");
+    expect(res.output).toContain("b");
+    expect(res.output).toContain("2/2 ok");
+  });
+
+  it("any peer fails → ok:false with DNS exitCode 3 (fail loud)", async () => {
+    const a = spawnInfoServer("alpha");
+    const { default: handler } = await import("./index");
+    await handler({ source: "cli", args: ["add", "a", `http://127.0.0.1:${a.port}`] });
+    await handler({
+      source: "cli",
+      args: ["add", "c", "http://does-not-exist.invalid:9999", "--allow-unreachable"],
+    });
+
+    const res = await handler({ source: "cli", args: ["probe-all", "--timeout", "1500"] });
+    expect(res.ok).toBe(false);
+    expect(res.exitCode).toBe(3);
+    expect(res.error).toContain("probe-all");
+    expect(res.error).toContain("--allow-unreachable");
+    expect(res.output).toContain("1/2 ok, 1 failed");
+  });
+
+  it("--allow-unreachable → ok:true even when peers fail", async () => {
+    const { default: handler } = await import("./index");
+    await handler({
+      source: "cli",
+      args: ["add", "c", "http://does-not-exist.invalid:9999", "--allow-unreachable"],
+    });
+
+    const res = await handler({
+      source: "cli",
+      args: ["probe-all", "--timeout", "1500", "--allow-unreachable"],
+    });
+    expect(res.ok).toBe(true);
+    expect(res.exitCode).toBeUndefined();
+    expect(res.output).toContain("0/1 ok, 1 failed");
+  });
+
+  it("rejects non-numeric / non-positive --timeout", async () => {
+    const { default: handler } = await import("./index");
+    const bad = await handler({ source: "cli", args: ["probe-all", "--timeout", "nope"] });
+    expect(bad.ok).toBe(false);
+    expect(bad.error).toContain("--timeout");
+
+    const zero = await handler({ source: "cli", args: ["probe-all", "--timeout", "0"] });
+    expect(zero.ok).toBe(false);
+    expect(zero.error).toContain("--timeout");
+  });
+
+  it("empty peers.json → ok:true, 'no peers' printed, no failure", async () => {
+    const { default: handler } = await import("./index");
+    const res = await handler({ source: "cli", args: ["probe-all"] });
+    expect(res.ok).toBe(true);
+    expect(res.output).toContain("no peers");
+  });
+
+  it("help lists probe-all", async () => {
+    const { default: handler } = await import("./index");
+    const res = await handler({ source: "cli", args: [] });
+    expect(res.output).toContain("probe-all");
+  });
+});

--- a/src/commands/plugins/peers/probe-all.ts
+++ b/src/commands/plugins/peers/probe-all.ts
@@ -1,0 +1,128 @@
+/**
+ * maw peers probe-all — parallel federation ping (#669).
+ *
+ * Loops over every alias in peers.json, runs probePeer() concurrently
+ * via Promise.all, and returns a per-peer row with timing + result.
+ * Keeps store mutation minimal: on success bumps lastSeen and clears
+ * lastError; on failure records lastError. Mirrors cmdProbe()'s write
+ * semantics so the store stays consistent whether you probe one or all.
+ *
+ * Exit semantics live in the dispatcher: 0 if every peer is ok, else
+ * the exit code of the worst failure family (PROBE_EXIT_CODES) unless
+ * the caller passed --allow-unreachable.
+ */
+import { loadPeers, mutatePeers, type LastError, type Peer } from "./store";
+import { probePeer, PROBE_EXIT_CODES, type ProbeErrorCode } from "./probe";
+
+export interface ProbeAllRow {
+  alias: string;
+  url: string;
+  node: string | null;
+  lastSeen: string | null;
+  ok: boolean;
+  /** Elapsed wall-clock ms for this peer's probe. */
+  ms: number;
+  error?: LastError;
+}
+
+export interface ProbeAllResult {
+  rows: ProbeAllRow[];
+  okCount: number;
+  failCount: number;
+  /** The numerically-highest PROBE_EXIT_CODE seen across failures; 0 if all ok. */
+  worstExitCode: number;
+}
+
+export async function cmdProbeAll(timeoutMs = 2000): Promise<ProbeAllResult> {
+  const data = loadPeers();
+  const entries = Object.entries(data.peers).sort(([a], [b]) => a.localeCompare(b));
+
+  const settled = await Promise.all(
+    entries.map(async ([alias, peer]): Promise<ProbeAllRow> => {
+      const started = Date.now();
+      const probe = await probePeer(peer.url, timeoutMs);
+      const ms = Date.now() - started;
+      return {
+        alias,
+        url: peer.url,
+        node: probe.node ?? peer.node,
+        lastSeen: peer.lastSeen,
+        ok: !probe.error,
+        ms,
+        error: probe.error,
+      };
+    }),
+  );
+
+  // Batch-apply all mutations under a single lock — avoids one lock
+  // acquisition per peer for large fleets and keeps the store update
+  // atomic from the caller's perspective.
+  if (settled.length > 0) {
+    const now = new Date().toISOString();
+    mutatePeers((d) => {
+      for (const row of settled) {
+        const p = d.peers[row.alias];
+        if (!p) continue; // removed between load and mutate
+        if (row.ok) {
+          delete p.lastError;
+          p.lastSeen = now;
+          if (row.node) p.node = row.node;
+        } else if (row.error) {
+          p.lastError = row.error;
+        }
+      }
+    });
+    for (const row of settled) {
+      if (row.ok) row.lastSeen = now;
+    }
+  }
+
+  const okCount = settled.filter(r => r.ok).length;
+  const failCount = settled.length - okCount;
+  const worstExitCode = settled
+    .filter(r => !r.ok && r.error)
+    .reduce((worst, r) => {
+      const code = PROBE_EXIT_CODES[r.error!.code as ProbeErrorCode] ?? 2;
+      return code > worst ? code : worst;
+    }, 0);
+
+  return { rows: settled, okCount, failCount, worstExitCode };
+}
+
+/**
+ * Render a fixed-width table:
+ *   alias  url  node  lastSeen  result
+ * Result cell: "✓ ok (Nms)" on success, "✗ CODE" on failure.
+ * Color is applied to the result column only; everything else is plain
+ * so the output stays readable in non-TTY logs.
+ */
+export function formatProbeAll(result: ProbeAllResult): string {
+  if (result.rows.length === 0) return "no peers";
+
+  const header = ["alias", "url", "node", "lastSeen", "result"];
+  const rows = result.rows.map(r => [
+    r.alias,
+    r.url,
+    r.node ?? "-",
+    r.lastSeen ?? "-",
+    r.ok ? `\x1b[32m✓\x1b[0m ok (${r.ms}ms)` : `\x1b[31m✗\x1b[0m ${r.error?.code ?? "UNKNOWN"}`,
+  ]);
+
+  // Width calc must ignore ANSI escapes in the result column — otherwise
+  // the color codes shove other columns right. strip-ansi for width only.
+  const strip = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, "");
+  const widths = header.map((h, i) =>
+    Math.max(h.length, ...rows.map(row => strip(row[i]).length)));
+
+  const fmt = (cols: string[]) =>
+    cols.map((c, i) => c + " ".repeat(Math.max(0, widths[i] - strip(c).length))).join("  ");
+
+  const lines = [
+    fmt(header),
+    fmt(widths.map(w => "-".repeat(w))),
+    ...rows.map(fmt),
+    "",
+    `${result.okCount}/${result.rows.length} ok${result.failCount > 0 ? `, ${result.failCount} failed` : ""}`,
+  ];
+  return lines.join("\n");
+}


### PR DESCRIPTION
## Summary
- Adds \`maw peers probe-all\` — loops over \`peers.json\`, probes each peer in parallel via \`Promise.all\`, prints a liveness table (alias / url / node / lastSeen / result).
- Reuses \`probePeer()\` from \`probe.ts\` — no change to classification; inherits the full DNS/REFUSED/TIMEOUT/TLS/HTTP_4XX/5XX/BAD_BODY matrix.
- Batch-writes \`lastSeen\` + \`lastError\` under a single store lock (one lock acquisition for the whole sweep — not N).
- Exit semantics: 0 when every peer ok; worst \`PROBE_EXIT_CODE\` across failures otherwise. \`--allow-unreachable\` forces exit 0 (parity with \`maw peers add\`).
- \`--timeout <ms>\` overrides the 2s default; rejected when non-numeric or ≤0.

## Files
- \`src/commands/plugins/peers/probe-all.ts\` (new) — \`cmdProbeAll()\` + \`formatProbeAll()\`
- \`src/commands/plugins/peers/index.ts\` — dispatcher case + help text
- \`src/commands/plugins/peers/peers-probe-all.test.ts\` (new) — 11 tests / 48 assertions

## Test plan
- [x] \`bun test src/commands/plugins/peers/peers-probe-all.test.ts\` — 11/11 green
- [x] \`bun run test:all\` — canonical suite green (369 pass, 0 fail in the plugin bucket; all 4 buckets ran sequentially with exit 0)
- [ ] CI green on this PR
- [ ] Dogfood on a real fleet (\`maw peers probe-all\` with live aliases)

Closes #669.

🤖 Generated with [Claude Code](https://claude.com/claude-code)