### PR TITLE
feat(doctor): detect running-process vs source version drift (#638)

### DIFF
--- a/src/commands/plugins/doctor/impl.ts
+++ b/src/commands/plugins/doctor/impl.ts
@@ -1,4 +1,4 @@
-import { existsSync, readlinkSync } from "fs";
+import { existsSync, readFileSync, readlinkSync } from "fs";
 import { execSync } from "child_process";
 import { homedir } from "os";
 import { join, dirname, resolve } from "path";
@@ -15,14 +15,23 @@ export interface DoctorResult {
 }
 
 export async function cmdDoctor(args: string[] = []): Promise<DoctorResult> {
-  const only = args[0];
+  const flags = new Set(args.filter(a => a.startsWith("--")));
+  const positional = args.filter(a => !a.startsWith("--"));
+  const only = positional[0];
+  const allowDrift = flags.has("--allow-drift");
   const checks: DoctorResult["checks"] = [];
 
   if (!only || only === "install" || only === "all") {
     checks.push(await checkInstall());
   }
+  if (!only || only === "version" || only === "all") {
+    const vChecks = await checkVersionDrift();
+    for (const c of vChecks) checks.push(c);
+  }
 
-  const ok = checks.every(c => c.ok);
+  const hardOk = checks.every(c => c.ok);
+  const onlyDriftFails = !hardOk && checks.every(c => c.ok || c.name.startsWith("version:"));
+  const ok = hardOk || (allowDrift && onlyDriftFails);
   renderResults(checks, ok);
   return { ok, checks };
 }
@@ -57,12 +66,121 @@ async function checkInstall(): Promise<{ name: string; ok: boolean; message: str
   return { name: "install", ok: true, message: "maw binary present and resolvable" };
 }
 
+/**
+ * Version drift: compare source package.json version to each running maw
+ * process's `/info` endpoint version (#638). MVP covers pm2 only.
+ *
+ * Returns a list (one per running maw, or a single synthetic entry when
+ * pm2/source lookup fails). Drift → ok:false; exit code gating lives in
+ * cmdDoctor via the --allow-drift flag.
+ */
+async function checkVersionDrift(): Promise<DoctorResult["checks"]> {
+  const source = readSourceVersion();
+  if (!source) {
+    return [{ name: "version:source", ok: false, message: "could not read package.json version" }];
+  }
+
+  const procs = listPm2MawProcs();
+  if (procs === null) {
+    return [{ name: "version:pm2", ok: true, message: `pm2 unavailable — source ${source} (no running maw to compare)` }];
+  }
+  if (procs.length === 0) {
+    return [{ name: "version:pm2", ok: true, message: `no running maw — source ${source}` }];
+  }
+
+  const results: DoctorResult["checks"] = [];
+  for (const p of procs) {
+    const port = p.port ?? defaultPort();
+    const label = `version:${p.name}${p.pmId != null ? `#${p.pmId}` : ""}`;
+    try {
+      const running = await fetchInfoVersion(port);
+      if (running === null) {
+        results.push({ name: label, ok: false, message: `unreachable at :${port} — source ${source}` });
+      } else if (running === source) {
+        results.push({ name: label, ok: true, message: `aligned (${source}) :${port}` });
+      } else {
+        results.push({ name: label, ok: false, message: `drift — running ${running}, source ${source} :${port}` });
+      }
+    } catch (e: any) {
+      results.push({ name: label, ok: false, message: `probe failed: ${e?.message || e} :${port}` });
+    }
+  }
+  return results;
+}
+
+function readSourceVersion(): string | null {
+  try {
+    const pkgPath = join(import.meta.dir, "..", "..", "..", "..", "package.json");
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+    return typeof pkg.version === "string" ? pkg.version : null;
+  } catch {
+    return null;
+  }
+}
+
+function defaultPort(): number {
+  const envPort = Number(process.env.MAW_PORT);
+  return Number.isFinite(envPort) && envPort > 0 ? envPort : 3456;
+}
+
+interface Pm2Proc {
+  name: string;
+  pmId?: number;
+  port?: number;
+}
+
+function listPm2MawProcs(): Pm2Proc[] | null {
+  let raw: string;
+  try {
+    raw = execSync("pm2 jlist 2>/dev/null", { encoding: "utf-8" });
+  } catch {
+    return null;
+  }
+  let procs: any[];
+  try {
+    procs = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(procs)) return [];
+  const out: Pm2Proc[] = [];
+  for (const p of procs) {
+    if (!p || typeof p.name !== "string") continue;
+    if (p.name !== "maw" && !p.name.startsWith("maw-")) continue;
+    const env = p.pm2_env?.env || p.pm2_env || {};
+    const envPort = Number(env?.MAW_PORT ?? env?.PORT);
+    out.push({
+      name: p.name,
+      pmId: typeof p.pm_id === "number" ? p.pm_id : undefined,
+      port: Number.isFinite(envPort) && envPort > 0 ? envPort : undefined,
+    });
+  }
+  return out;
+}
+
+async function fetchInfoVersion(port: number): Promise<string | null> {
+  try {
+    const res = await fetch(`http://localhost:${port}/info`, { signal: AbortSignal.timeout(2000) });
+    if (!res.ok) return null;
+    const body: any = await res.json();
+    return typeof body?.version === "string" ? body.version : null;
+  } catch {
+    return null;
+  }
+}
+
 function renderResults(checks: DoctorResult["checks"], ok: boolean): void {
   console.log("");
   console.log(`  ${ok ? GREEN + "✓" : RED + "✗"} maw doctor${RESET}`);
   for (const c of checks) {
-    const icon = c.ok ? GREEN + "✓" : RED + "✗";
+    const icon = iconFor(c);
     console.log(`    ${icon} ${c.name}${RESET}: ${c.message}`);
   }
   console.log("");
+}
+
+function iconFor(c: { name: string; ok: boolean; message: string }): string {
+  if (c.ok) return GREEN + "✓";
+  if (c.name.startsWith("version:") && c.message.startsWith("drift")) return YELLOW + "⚠";
+  return RED + "✗";
 }

--- a/test/isolated/doctor-install-check.test.ts
+++ b/test/isolated/doctor-install-check.test.ts
@@ -113,11 +113,11 @@ describe("cmdDoctor install — binary present", () => {
     const out = await run(() => cmdDoctor([]));
 
     expect(out.ok).toBe(true);
-    expect(out.checks).toHaveLength(1);
-    expect(out.checks[0].name).toBe("install");
-    expect(out.checks[0].ok).toBe(true);
-    expect(out.checks[0].message).toContain("present and resolvable");
-    expect(execSyncCalls).toHaveLength(0);
+    expect(out.checks.find(c => c.name === "install")).toBeDefined();
+    const install = out.checks.find(c => c.name === "install")!;
+    expect(install.ok).toBe(true);
+    expect(install.message).toContain("present and resolvable");
+    expect(execSyncCalls.filter(c => c.cmd.startsWith("bun add"))).toHaveLength(0);
   });
 
   test("relative symlink resolved against bin dir → ok true", async () => {
@@ -130,7 +130,7 @@ describe("cmdDoctor install — binary present", () => {
     const out = await run(() => cmdDoctor([]));
 
     expect(out.ok).toBe(true);
-    expect(out.checks[0].message).toContain("present and resolvable");
+    expect(out.checks.find(c => c.name === "install")!.message).toContain("present and resolvable");
   });
 
   test("dangling symlink (link target missing) → ok false, message 'broken symlink'", async () => {
@@ -142,10 +142,11 @@ describe("cmdDoctor install — binary present", () => {
     const out = await run(() => cmdDoctor([]));
 
     expect(out.ok).toBe(false);
-    expect(out.checks[0].ok).toBe(false);
-    expect(out.checks[0].message).toContain("broken symlink");
-    expect(out.checks[0].message).toContain(target);
-    expect(execSyncCalls).toHaveLength(0);
+    const install = out.checks.find(c => c.name === "install")!;
+    expect(install.ok).toBe(false);
+    expect(install.message).toContain("broken symlink");
+    expect(install.message).toContain(target);
+    expect(execSyncCalls.filter(c => c.cmd.startsWith("bun add"))).toHaveLength(0);
   });
 
   test("not a symlink (readlinkSync throws EINVAL) → ok true", async () => {
@@ -155,8 +156,9 @@ describe("cmdDoctor install — binary present", () => {
     const out = await run(() => cmdDoctor([]));
 
     expect(out.ok).toBe(true);
-    expect(out.checks[0].ok).toBe(true);
-    expect(out.checks[0].message).toContain("present and resolvable");
+    const install = out.checks.find(c => c.name === "install")!;
+    expect(install.ok).toBe(true);
+    expect(install.message).toContain("present and resolvable");
   });
 });
 
@@ -169,39 +171,43 @@ describe("cmdDoctor install — binary missing → reinstall", () => {
     existsMap[BIN_PATH] = false;
     execSyncFlipBinaryPresent = true; // side-effect: install creates the binary
 
-    const out = await run(() => cmdDoctor([]));
+    const out = await run(() => cmdDoctor(["install"]));
 
     expect(out.ok).toBe(true);
-    expect(out.checks[0].ok).toBe(true);
-    expect(out.checks[0].message).toContain("reinstalled");
-    expect(out.checks[0].message).toContain("github:Soul-Brews-Studio/maw-js");
-    expect(execSyncCalls).toHaveLength(1);
-    expect(execSyncCalls[0].cmd).toContain("bun add -g");
-    expect(execSyncCalls[0].cmd).toContain("Soul-Brews-Studio/maw-js");
+    const install = out.checks.find(c => c.name === "install")!;
+    expect(install.ok).toBe(true);
+    expect(install.message).toContain("reinstalled");
+    expect(install.message).toContain("github:Soul-Brews-Studio/maw-js");
+    const addCalls = execSyncCalls.filter(c => c.cmd.startsWith("bun add"));
+    expect(addCalls).toHaveLength(1);
+    expect(addCalls[0].cmd).toContain("bun add -g");
+    expect(addCalls[0].cmd).toContain("Soul-Brews-Studio/maw-js");
   });
 
   test("execSync succeeds + binary still missing → ok false, message 'did not produce'", async () => {
     existsMap[BIN_PATH] = false;
     execSyncFlipBinaryPresent = false; // install "succeeds" but binary doesn't appear
 
-    const out = await run(() => cmdDoctor([]));
+    const out = await run(() => cmdDoctor(["install"]));
 
     expect(out.ok).toBe(false);
-    expect(out.checks[0].ok).toBe(false);
-    expect(out.checks[0].message).toContain("did not produce");
-    expect(execSyncCalls).toHaveLength(1);
+    const install = out.checks.find(c => c.name === "install")!;
+    expect(install.ok).toBe(false);
+    expect(install.message).toContain("did not produce");
+    expect(execSyncCalls.filter(c => c.cmd.startsWith("bun add"))).toHaveLength(1);
   });
 
   test("execSync throws → ok false, message starts with 'reinstall failed:'", async () => {
     existsMap[BIN_PATH] = false;
     execSyncThrow = new Error("network unreachable");
 
-    const out = await run(() => cmdDoctor([]));
+    const out = await run(() => cmdDoctor(["install"]));
 
     expect(out.ok).toBe(false);
-    expect(out.checks[0].ok).toBe(false);
-    expect(out.checks[0].message).toMatch(/^reinstall failed:/);
-    expect(out.checks[0].message).toContain("network unreachable");
+    const install = out.checks.find(c => c.name === "install")!;
+    expect(install.ok).toBe(false);
+    expect(install.message).toMatch(/^reinstall failed:/);
+    expect(install.message).toContain("network unreachable");
   });
 });
 
@@ -210,20 +216,22 @@ describe("cmdDoctor install — binary missing → reinstall", () => {
 // ════════════════════════════════════════════════════════════════════════════
 
 describe("cmdDoctor args dispatch", () => {
-  test("args=[] runs install check", async () => {
+  test("args=[] runs install + version checks", async () => {
     existsMap[BIN_PATH] = true;
 
     const out = await run(() => cmdDoctor([]));
 
-    expect(out.checks.map(c => c.name)).toEqual(["install"]);
+    expect(out.checks.map(c => c.name)).toContain("install");
+    expect(out.checks.some(c => c.name.startsWith("version:"))).toBe(true);
   });
 
-  test("args=['all'] runs install check", async () => {
+  test("args=['all'] runs install + version checks", async () => {
     existsMap[BIN_PATH] = true;
 
     const out = await run(() => cmdDoctor(["all"]));
 
-    expect(out.checks.map(c => c.name)).toEqual(["install"]);
+    expect(out.checks.map(c => c.name)).toContain("install");
+    expect(out.checks.some(c => c.name.startsWith("version:"))).toBe(true);
   });
 
   test("args=['install'] runs install check only", async () => {

--- a/test/isolated/doctor-version-drift.test.ts
+++ b/test/isolated/doctor-version-drift.test.ts
@@ -1,0 +1,256 @@
+/**
+ * maw doctor — version drift check (#638).
+ *
+ * Compares source `package.json` version to each running maw process's
+ * `/info` endpoint `version` field. MVP covers pm2 only.
+ *
+ * Covered branches (see src/commands/plugins/doctor/impl.ts):
+ *   - pm2 unavailable (execSync throws / non-JSON)   → ok, "pm2 unavailable"
+ *   - pm2 available, no maw process                  → ok, "no running maw"
+ *   - pm2 has maw, /info aligned                     → ok, "aligned"
+ *   - pm2 has maw, /info drift                       → NOT ok, "drift"
+ *   - pm2 has maw, /info unreachable                 → NOT ok, "unreachable"
+ *   - --allow-drift gate flips drift-only fail → ok true
+ *   - args=['version'] runs only version checks
+ *
+ * Isolated: we mock `child_process.execSync` + global `fetch`. Real refs
+ * captured before mocks are installed, per the #429 / fleet-doctor pattern.
+ */
+
+import { describe, test, expect, mock, beforeEach, afterEach, afterAll } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+// Gate so tests-not-using-the-mock fall through to real impls.
+let mockActive = false;
+
+// Capture real refs BEFORE mocks.
+const realChildProcess = await import("child_process");
+const realFetch = globalThis.fetch;
+
+// Mutable controls per-test.
+let pm2Behavior: { kind: "throw"; err: Error } | { kind: "return"; json: unknown } | { kind: "raw"; value: string } =
+  { kind: "return", json: [] };
+
+let fetchBehavior: {
+  status: number;
+  body: unknown;
+  throws?: Error;
+} = { status: 200, body: {} };
+let fetchCalls: Array<{ url: string }> = [];
+
+// ─── Install mocks ──────────────────────────────────────────────────────────
+
+await mock.module("child_process", () => ({
+  ...realChildProcess,
+  execSync: (cmd: string, opts?: unknown): Buffer | string => {
+    if (!mockActive) return realChildProcess.execSync(cmd, opts as never);
+    if (typeof cmd === "string" && cmd.includes("pm2 jlist")) {
+      if (pm2Behavior.kind === "throw") throw pm2Behavior.err;
+      if (pm2Behavior.kind === "raw") return pm2Behavior.value;
+      return JSON.stringify(pm2Behavior.json);
+    }
+    // Pass anything else through; avoids loops for unrelated calls.
+    return realChildProcess.execSync(cmd, opts as never);
+  },
+}));
+
+// Swap global fetch with a per-test stub.
+(globalThis as any).fetch = async (url: any, _init?: any) => {
+  if (!mockActive) return realFetch(url, _init);
+  fetchCalls.push({ url: String(url) });
+  if (fetchBehavior.throws) throw fetchBehavior.throws;
+  const body = fetchBehavior.body;
+  return {
+    ok: fetchBehavior.status >= 200 && fetchBehavior.status < 300,
+    status: fetchBehavior.status,
+    json: async () => body,
+  } as any;
+};
+
+// Import target after mocks.
+const { cmdDoctor } = await import("../../src/commands/plugins/doctor/impl");
+
+// Read the real source version once — the impl uses the real fs to read it.
+const SRC_VERSION: string = (() => {
+  const pkgPath = join(import.meta.dir, "..", "..", "package.json");
+  const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+  return String(pkg.version);
+})();
+
+// Silence the renderer.
+const origLog = console.log;
+async function run<T>(fn: () => Promise<T>): Promise<T> {
+  console.log = () => {};
+  try { return await fn(); }
+  finally { console.log = origLog; }
+}
+
+beforeEach(() => {
+  mockActive = true;
+  pm2Behavior = { kind: "return", json: [] };
+  fetchBehavior = { status: 200, body: {} };
+  fetchCalls = [];
+});
+afterEach(() => { mockActive = false; });
+afterAll(() => {
+  mockActive = false;
+  console.log = origLog;
+  (globalThis as any).fetch = realFetch;
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+
+describe("cmdDoctor version — pm2 branch coverage", () => {
+  test("pm2 unavailable (execSync throws) → ok true, 'pm2 unavailable' message", async () => {
+    pm2Behavior = { kind: "throw", err: new Error("pm2: command not found") };
+
+    const out = await run(() => cmdDoctor(["version"]));
+
+    expect(out.ok).toBe(true);
+    expect(out.checks).toHaveLength(1);
+    expect(out.checks[0].name).toBe("version:pm2");
+    expect(out.checks[0].ok).toBe(true);
+    expect(out.checks[0].message).toContain("pm2 unavailable");
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  test("pm2 returns non-JSON → ok true, 'pm2 unavailable' message", async () => {
+    pm2Behavior = { kind: "raw", value: "not json" };
+
+    const out = await run(() => cmdDoctor(["version"]));
+
+    expect(out.ok).toBe(true);
+    expect(out.checks[0].name).toBe("version:pm2");
+    expect(out.checks[0].message).toContain("pm2 unavailable");
+  });
+
+  test("pm2 returns empty array → ok true, 'no running maw' message", async () => {
+    pm2Behavior = { kind: "return", json: [] };
+
+    const out = await run(() => cmdDoctor(["version"]));
+
+    expect(out.ok).toBe(true);
+    expect(out.checks[0].name).toBe("version:pm2");
+    expect(out.checks[0].message).toContain("no running maw");
+    expect(out.checks[0].message).toContain(SRC_VERSION);
+  });
+
+  test("pm2 has only non-maw procs → ok true, 'no running maw'", async () => {
+    pm2Behavior = { kind: "return", json: [
+      { name: "nginx", pm_id: 0, pm2_env: { status: "online" } },
+      { name: "postgres", pm_id: 1, pm2_env: { status: "online" } },
+    ]};
+
+    const out = await run(() => cmdDoctor(["version"]));
+
+    expect(out.ok).toBe(true);
+    expect(out.checks[0].message).toContain("no running maw");
+  });
+});
+
+describe("cmdDoctor version — drift states", () => {
+  test("pm2 has maw + /info aligned → ok true, 'aligned'", async () => {
+    pm2Behavior = { kind: "return", json: [
+      { name: "maw", pm_id: 3, pm2_env: { env: { MAW_PORT: "3456" } } },
+    ]};
+    fetchBehavior = { status: 200, body: { version: SRC_VERSION } };
+
+    const out = await run(() => cmdDoctor(["version"]));
+
+    expect(out.ok).toBe(true);
+    const vc = out.checks.find(c => c.name === "version:maw#3")!;
+    expect(vc).toBeDefined();
+    expect(vc.ok).toBe(true);
+    expect(vc.message).toContain("aligned");
+    expect(vc.message).toContain(SRC_VERSION);
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0].url).toBe("http://localhost:3456/info");
+  });
+
+  test("pm2 has maw + /info drift → ok false, 'drift'", async () => {
+    pm2Behavior = { kind: "return", json: [
+      { name: "maw", pm_id: 3, pm2_env: { env: { MAW_PORT: "3456" } } },
+    ]};
+    fetchBehavior = { status: 200, body: { version: "0.0.0-stale" } };
+
+    const out = await run(() => cmdDoctor(["version"]));
+
+    expect(out.ok).toBe(false);
+    const vc = out.checks.find(c => c.name === "version:maw#3")!;
+    expect(vc.ok).toBe(false);
+    expect(vc.message).toContain("drift");
+    expect(vc.message).toContain("0.0.0-stale");
+    expect(vc.message).toContain(SRC_VERSION);
+  });
+
+  test("pm2 has maw but /info unreachable (fetch throws) → ok false, 'unreachable'", async () => {
+    pm2Behavior = { kind: "return", json: [
+      { name: "maw", pm_id: 0, pm2_env: { env: { MAW_PORT: "3456" } } },
+    ]};
+    fetchBehavior = { status: 500, body: {}, throws: new Error("ECONNREFUSED") };
+
+    const out = await run(() => cmdDoctor(["version"]));
+
+    expect(out.ok).toBe(false);
+    const vc = out.checks.find(c => c.name === "version:maw#0")!;
+    expect(vc.ok).toBe(false);
+    expect(vc.message).toContain("unreachable");
+  });
+
+  test("pm2 has maw but /info returns HTTP 500 → ok false, 'unreachable'", async () => {
+    pm2Behavior = { kind: "return", json: [
+      { name: "maw", pm_id: 7, pm2_env: { env: { MAW_PORT: "3456" } } },
+    ]};
+    fetchBehavior = { status: 500, body: {} };
+
+    const out = await run(() => cmdDoctor(["version"]));
+
+    expect(out.ok).toBe(false);
+    const vc = out.checks.find(c => c.name === "version:maw#7")!;
+    expect(vc.ok).toBe(false);
+    expect(vc.message).toContain("unreachable");
+  });
+
+  test("maw-* named processes are included", async () => {
+    pm2Behavior = { kind: "return", json: [
+      { name: "maw-secondary", pm_id: 5, pm2_env: { env: { MAW_PORT: "3457" } } },
+    ]};
+    fetchBehavior = { status: 200, body: { version: SRC_VERSION } };
+
+    const out = await run(() => cmdDoctor(["version"]));
+
+    expect(out.ok).toBe(true);
+    const vc = out.checks.find(c => c.name === "version:maw-secondary#5")!;
+    expect(vc).toBeDefined();
+    expect(vc.ok).toBe(true);
+    expect(fetchCalls[0].url).toBe("http://localhost:3457/info");
+  });
+});
+
+describe("cmdDoctor version — --allow-drift flag", () => {
+  test("drift without --allow-drift → ok false", async () => {
+    pm2Behavior = { kind: "return", json: [
+      { name: "maw", pm_id: 0, pm2_env: { env: { MAW_PORT: "3456" } } },
+    ]};
+    fetchBehavior = { status: 200, body: { version: "0.0.0-stale" } };
+
+    const out = await run(() => cmdDoctor(["version"]));
+
+    expect(out.ok).toBe(false);
+  });
+
+  test("drift with --allow-drift → ok true (individual check still ok:false)", async () => {
+    pm2Behavior = { kind: "return", json: [
+      { name: "maw", pm_id: 0, pm2_env: { env: { MAW_PORT: "3456" } } },
+    ]};
+    fetchBehavior = { status: 200, body: { version: "0.0.0-stale" } };
+
+    const out = await run(() => cmdDoctor(["version", "--allow-drift"]));
+
+    expect(out.ok).toBe(true);
+    const vc = out.checks.find(c => c.name === "version:maw#0")!;
+    expect(vc.ok).toBe(false);
+    expect(vc.message).toContain("drift");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds version-drift check to `maw doctor` — compares `package.json` version to each running maw process's `/info` endpoint.
- MVP covers pm2 only (`pm2 jlist` → per-proc `/info` probe). tmux-pane detection deferred.
- `✓ aligned` / `⚠ drift (running X, source Y)` / `✗ unreachable` — non-zero exit on drift unless `--allow-drift`.

Closes #638.

## Behavior
- `maw doctor` → runs install + version checks (default).
- `maw doctor version` → runs version check only.
- `maw doctor install` → unchanged (install only).
- `maw doctor --allow-drift` → drift reported but exit 0.

Port resolution: `pm2_env.env.MAW_PORT` / `PORT`, else `process.env.MAW_PORT`, else 3456.

## Why this exists
Exactly the blocker that killed the last dogfood pass: the long-running pm2 `maw` was on a stale alpha while source had advanced several releases. Silent drift — no visible error, just wrong behavior. This makes it discoverable before it bites.

## Test plan
- [x] `bun run test:plugin` — 352 pass, 0 fail
- [x] `bun run test:all` — all stages pass
- [x] 11 new isolated tests covering: pm2-unavailable (throws + non-JSON), empty pm2, non-maw procs only, aligned, drift, unreachable (fetch throw + HTTP 500), maw-* named procs, --allow-drift gate on/off
- [x] Existing install-check tests updated to tolerate the new version entries alongside install

🤖 Generated with maw-doctor