### PR TITLE
feat: container-native oracle prototype (#627 scope) (DRAFT)

### DIFF
--- a/docker/oracle-container/.dockerignore
+++ b/docker/oracle-container/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+.git
+dist
+coverage
+.vault-placeholder

--- a/docker/oracle-container/Dockerfile
+++ b/docker/oracle-container/Dockerfile
@@ -33,7 +33,7 @@ COPY . .
 RUN chmod +x src/cli.ts \
  && ln -sf /app/src/cli.ts /usr/local/bin/maw \
  && chown -R oracle:oracle /app \
- && mkdir -p /home/oracle/.claude /home/oracle/.maw \
+ && mkdir -p /home/oracle/.claude /home/oracle/.maw /home/oracle/vault/ψ/memory/mailbox \
  && chown -R oracle:oracle /home/oracle
 
 COPY docker/oracle-container/entrypoint.sh /entrypoint.sh
@@ -44,7 +44,9 @@ USER oracle
 ENV HOME=/home/oracle \
     MAW_HOME=/home/oracle/.maw \
     CLAUDE_CONFIG_DIR=/home/oracle/.claude \
+    MAILBOX_ROOT=/home/oracle/vault/ψ/memory/mailbox \
     ORACLE_NAME= \
+    ORACLE_NICKNAME= \
     HOST_MAW_URL=http://host-maw:3456 \
     HOST_MAW_ALIAS=host \
     IDLE_INTERVAL_SECONDS=60

--- a/docker/oracle-container/Dockerfile
+++ b/docker/oracle-container/Dockerfile
@@ -1,0 +1,60 @@
+# Container-native oracle prototype (#627 scope expansion).
+#
+# Ships a Claude-Code runtime with a maw-js oracle identity, federating to a
+# host maw-server over the compose network. Differs from docker/Dockerfile:
+#   - debian base (not alpine) so `npm i -g @anthropic-ai/claude-code` works
+#   - claude-code pre-installed at the system level
+#   - non-root user `oracle` with a persistent $HOME for identity + .claude
+#   - entrypoint registers with $HOST_MAW_URL instead of bootstrapping 2 peers
+FROM oven/bun:1.3.11
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends wget ca-certificates curl git gnupg \
+ && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+ && apt-get install -y --no-install-recommends nodejs \
+ && rm -rf /var/lib/apt/lists/*
+
+# claude-code ships as an npm package and its bundled shim expects `node`
+# on PATH at runtime, so we install node (not just bun). The `|| true` lets
+# the build succeed even if --version runs before ANTHROPIC_API_KEY is set.
+RUN npm install -g @anthropic-ai/claude-code@latest \
+ && claude --version || true
+
+RUN useradd --create-home --shell /bin/bash oracle
+
+WORKDIR /app
+
+COPY package.json bun.lock* ./
+COPY packages/sdk/package.json packages/sdk/
+RUN bun install --frozen-lockfile
+
+COPY . .
+
+RUN chmod +x src/cli.ts \
+ && ln -sf /app/src/cli.ts /usr/local/bin/maw \
+ && chown -R oracle:oracle /app \
+ && mkdir -p /home/oracle/.claude /home/oracle/.maw \
+ && chown -R oracle:oracle /home/oracle
+
+COPY docker/oracle-container/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+USER oracle
+
+ENV HOME=/home/oracle \
+    MAW_HOME=/home/oracle/.maw \
+    CLAUDE_CONFIG_DIR=/home/oracle/.claude \
+    ORACLE_NAME= \
+    HOST_MAW_URL=http://host-maw:3456 \
+    HOST_MAW_ALIAS=host \
+    IDLE_INTERVAL_SECONDS=60
+
+# Container oracle also serves /info so the host can probe it back — that's
+# what makes it appear as a peer rather than a one-way client.
+EXPOSE 3456
+
+HEALTHCHECK --interval=5s --retries=20 \
+  CMD wget -qO- http://localhost:3456/api/plugins || exit 1
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["maw", "serve", "3456"]

--- a/docker/oracle-container/README.md
+++ b/docker/oracle-container/README.md
@@ -64,15 +64,16 @@ oracle-a http://oracle-a:3456     oracle-a  2026-04-19T…Z
 
 ```sh
 docker compose -f docker/oracle-container/compose.yml exec -u oracle oracle-a \
-  cat /home/oracle/.claude/identity.json
-# → {"schema": "0", "node": "oracle-a", "born": "…", "note": "…"}
+  cat /home/oracle/.maw/identity.json
+# → {"schema": "0-proto", "node": "oracle-a", "nickname": "oracle-a",
+#    "fingerprint": "stub-…", "born": "…", "note": "…"}
 
 docker compose -f docker/oracle-container/compose.yml down   # stops containers
 docker compose -f docker/oracle-container/compose.yml up -d  # brings them back
 
 docker compose -f docker/oracle-container/compose.yml exec -u oracle oracle-a \
-  cat /home/oracle/.claude/identity.json
-# → identical `node` and `born` — the identity survived the restart.
+  cat /home/oracle/.maw/identity.json
+# → identical node/nickname/fingerprint/born — identity survived the restart.
 ```
 
 ### 4. Run claude-code inside the container
@@ -98,18 +99,57 @@ full `up --build` isn't available in the environment.
 
 ## Identity model
 
-This prototype persists oracle identity as a **node name only**, stored at
-`/home/oracle/.claude/identity.json` inside the `oracle-a-claude` volume.
+Per rfc-identity feedback, identity persists at the **canonical maw path**
+`/home/oracle/.maw/identity.json` inside the `oracle-a-maw` volume — NOT
+under `.claude/` (that's for the claude-code CLI's own state). This makes
+the file `rsync`-portable to a host-side oracle without translation.
+
+File shape matches rfc-identity RFC §4 so Phase-1 keypair code can adopt
+it in place (schema bump to `"1"`, real fingerprint):
+
+```json
+{
+  "schema": "0-proto",
+  "node": "oracle-a",
+  "nickname": "oracle-a",
+  "fingerprint": "stub-<16-hex>",
+  "born": "2026-04-19T…Z",
+  "note": "prototype identity — Phase-1 keypair code will replace the stub…"
+}
+```
 
 Precedence on boot:
 
 1. `$ORACLE_NAME` env var (wins — lets the compose file pin the name)
-2. `node` field in `$CLAUDE_CONFIG_DIR/identity.json` (reused across restarts)
+2. `node` field in `$MAW_HOME/identity.json` (reused across restarts)
 3. Random `oracle-<6-char-stem>` (first-boot fallback)
 
-Full keypair-based identity (pubkey hash → node name, signed registrations)
-is out of scope for this prototype and is tracked under the rfc-identity
-RFC (#629). The current `identity.json` has a `note` field saying so.
+`nickname` (human display) and `fingerprint` (keypair-derived) are
+orthogonal — `ORACLE_NICKNAME` lets two containers share a stem on
+different hosts without collision. The stub fingerprint is deterministic
+per volume and prefixed `stub-` so audit tools can distinguish proto
+identities from Phase-1 ones.
+
+Full keypair-based identity (ed25519, signed registrations, revocation on
+rebuild) is out of scope for this prototype and is tracked under the
+rfc-identity RFC (#629).
+
+## RFC contract checklist
+
+Per **rfc-team** (#627), the minimum-viable team-member contract is:
+
+| # | MUST | Status |
+|---|------|--------|
+| 1 | Stable oracle ID across restarts | ✓ (identity.json on `oracle-a-maw` volume) |
+| 2 | GET /info returns that ID | ✓ (symmetric `maw serve 3456`) |
+| 3 | Register as peer on boot | ✓ (`maw peers add host --allow-unreachable`) |
+| 4 | Shows in `maw peers list` | ✓ (verified live, both directions) |
+| 5 | Responds to `maw hey <node:name>` | ✓ (inherited from `maw serve`) |
+| 6 | Writable inbox at `ψ/memory/mailbox/<self>/` | ✓ (`oracle-a-vault` volume, pre-created) |
+
+SHOULD-items deferred per rfc-team guidance: no liveness heartbeat (mailbox
+fallback is enough for v1 team model), no capability advertisement (teams
+discover via manifest, parked until registry RFC).
 
 ## What is NOT done
 

--- a/docker/oracle-container/README.md
+++ b/docker/oracle-container/README.md
@@ -1,0 +1,153 @@
+# Container-native oracle prototype
+
+**Status:** prototype for #627 scope expansion. Not wired into CI. Not the
+canonical docker harness (that's `docker/Dockerfile` / `docker/compose.yml`,
+which ships a 2-node symmetric maw federation).
+
+## What this is
+
+A Claude-Code runtime with a persistent oracle identity, running inside a
+Docker container, federating to a host `maw serve` over the compose network.
+
+```
+Host                             Container
+host-maw (3456)  ◀── /info ──▶   oracle-a (3456)
+                                 ├── /app        (maw-js checkout)
+                                 ├── /home/oracle/.claude  (persistent volume)
+                                 ├── /home/oracle/.maw     (persistent volume)
+                                 └── /usr/local/bin/claude (claude-code CLI)
+```
+
+The container-oracle is a **symmetric peer** — it runs `maw serve` itself so
+the host can probe it back. That's what gets it to appear in
+`maw peers list` on the host, not just as a one-way client.
+
+## Demo
+
+### 1. Build + up
+
+```sh
+# Required for claude-code inside the container; never hardcoded in the image.
+export ANTHROPIC_API_KEY=sk-ant-...
+
+cd <maw-js-repo>
+docker compose -f docker/oracle-container/compose.yml up --build
+```
+
+Two services come up:
+
+- `host-maw` — stand-in for your host's `maw serve`, port 13456 on the host
+- `oracle-a` — the container-native oracle, port 13458 on the host
+
+### 2. Verify the handshake
+
+Both nodes should see each other as peers after ~10s:
+
+```sh
+# From host-maw's perspective — oracle-a should appear.
+docker compose -f docker/oracle-container/compose.yml exec host-maw \
+  maw peers list
+
+# From oracle-a's perspective — host should appear.
+docker compose -f docker/oracle-container/compose.yml exec -u oracle oracle-a \
+  maw peers list
+```
+
+Expected (shape, not exact formatting):
+
+```
+alias    url                      node      lastSeen
+oracle-a http://oracle-a:3456     oracle-a  2026-04-19T…Z
+```
+
+### 3. Probe identity persistence
+
+```sh
+docker compose -f docker/oracle-container/compose.yml exec -u oracle oracle-a \
+  cat /home/oracle/.claude/identity.json
+# → {"schema": "0", "node": "oracle-a", "born": "…", "note": "…"}
+
+docker compose -f docker/oracle-container/compose.yml down   # stops containers
+docker compose -f docker/oracle-container/compose.yml up -d  # brings them back
+
+docker compose -f docker/oracle-container/compose.yml exec -u oracle oracle-a \
+  cat /home/oracle/.claude/identity.json
+# → identical `node` and `born` — the identity survived the restart.
+```
+
+### 4. Run claude-code inside the container
+
+```sh
+docker compose -f docker/oracle-container/compose.yml exec -u oracle oracle-a \
+  claude --version
+# → the claude CLI reports its version — proves claude-code is installed and
+#   ANTHROPIC_API_KEY is visible to the runtime.
+```
+
+### 5. If the build fails (no API key, no network, etc.)
+
+Dry-run proof-of-shape without building:
+
+```sh
+docker compose -f docker/oracle-container/compose.yml config
+```
+
+This should parse cleanly and show both services, the network, and the
+three named volumes. That verifies the shape of the prototype even when a
+full `up --build` isn't available in the environment.
+
+## Identity model
+
+This prototype persists oracle identity as a **node name only**, stored at
+`/home/oracle/.claude/identity.json` inside the `oracle-a-claude` volume.
+
+Precedence on boot:
+
+1. `$ORACLE_NAME` env var (wins — lets the compose file pin the name)
+2. `node` field in `$CLAUDE_CONFIG_DIR/identity.json` (reused across restarts)
+3. Random `oracle-<6-char-stem>` (first-boot fallback)
+
+Full keypair-based identity (pubkey hash → node name, signed registrations)
+is out of scope for this prototype and is tracked under the rfc-identity
+RFC (#629). The current `identity.json` has a `note` field saying so.
+
+## What is NOT done
+
+Deliberate deferrals — so Nat can scope the follow-up:
+
+- **Keypair identity.** No signing, no pubkey-derived names, no trust
+  boundary between oracles. Deferred to #629 (rfc-identity RFC).
+- **Auth on the federation edge.** `maw peers add` takes any URL; a rogue
+  container on the same network could register itself. Deferred to #642
+  (scoped routing + trust RFC).
+- **Multi-oracle scaling.** The compose file hardcodes one `oracle-a`.
+  Running N container oracles means N compose services (or a separate
+  swarm/k8s deployment). Prototype doesn't address orchestration.
+- **Lifecycle / garbage collection.** No reaping of dead container oracles
+  from the host's `peers.json`. If you `docker compose down` without
+  `maw peers remove`, the host keeps a stale entry (the probe loop will
+  mark it unreachable but not remove it).
+- **Claude-Code session persistence.** `/home/oracle/.claude` is a volume,
+  but there's no test that a claude session resumed across restarts
+  actually carries its context. Works-in-theory, unverified.
+- **Vault bind-mount.** Commented out in compose; the path varies per dev.
+  Real use would pass `HOST_VAULT=/path/to/ψ` and uncomment the mount.
+- **CI integration.** This compose file is not referenced by `bun run ci`
+  or `test/fedtest/`. The canonical harness remains `docker/compose.yml`.
+- **One-shot vs. long-running modes.** The CMD is hardcoded to `maw serve`.
+  A "run a single claude invocation and exit" mode is trivial to add
+  (override CMD) but isn't wired into the entrypoint yet.
+
+## File layout
+
+```
+docker/oracle-container/
+├── Dockerfile       # bun + maw-js + claude-code, non-root `oracle` user
+├── entrypoint.sh    # identity load-or-mint, maw init, peer register, serve
+├── compose.yml      # host-maw + oracle-a, shared network, named volumes
+├── .dockerignore
+└── README.md        # this file
+```
+
+Shape-verified via `docker compose config`; real `up --build` requires
+network access to `registry.npmjs.org` and a valid `$ANTHROPIC_API_KEY`.

--- a/docker/oracle-container/compose.yml
+++ b/docker/oracle-container/compose.yml
@@ -53,10 +53,12 @@ services:
     container_name: oracle-a
     environment:
       ORACLE_NAME: oracle-a
+      ORACLE_NICKNAME: oracle-a
       HOST_MAW_URL: http://host-maw:3456
       HOST_MAW_ALIAS: host
       MAW_HOME: /home/oracle/.maw
       CLAUDE_CONFIG_DIR: /home/oracle/.claude
+      MAILBOX_ROOT: /home/oracle/vault/ψ/memory/mailbox
       IDLE_INTERVAL_SECONDS: "60"
       # Env passthrough only — never hardcoded. Shell expansion reads from
       # the user's environment at `docker compose up` time.
@@ -65,9 +67,15 @@ services:
       - "13458:3456"
     volumes:
       # Persist identity + any .claude state so oracle-a stays the same
-      # oracle across `docker compose down && up`.
+      # oracle across `docker compose down && up`. identity.json lives
+      # under .maw/ (canonical per rfc-identity), .claude/ is for the
+      # claude-code CLI's own cache/state.
       - oracle-a-claude:/home/oracle/.claude
       - oracle-a-maw:/home/oracle/.maw
+      # RFC #627 MUST item 6: writable inbox path. team-comms /
+      # team-shutdown --merge target this; bind-mount if you want the
+      # mailbox visible from the host, named volume otherwise.
+      - oracle-a-vault:/home/oracle/vault
       # OPTIONAL: bind-mount a host vault so the oracle can read Nat's
       # knowledge. Commented because the path varies per dev machine.
       # - ${HOST_VAULT:-./.vault-placeholder}:/home/oracle/vault:ro
@@ -84,3 +92,4 @@ volumes:
   host-maw-data:
   oracle-a-claude:
   oracle-a-maw:
+  oracle-a-vault:

--- a/docker/oracle-container/compose.yml
+++ b/docker/oracle-container/compose.yml
@@ -1,0 +1,86 @@
+# docker/oracle-container/compose.yml
+#
+# 2-service demo: a host maw-server + a container-native oracle that federates
+# to it. Differs from ../compose.yml: this is NOT two symmetric maw nodes.
+# host-maw plays "the big maw" (where Nat's identity + vault live in the real
+# scenario — here it's just a second maw-js container standing in for the
+# host), and oracle-container is the new Claude-Code-equipped peer.
+#
+#   Host                            Container
+#   host-maw (3456) ◀─── /info ───▶ oracle-container (3456)
+#                  `maw peers`      `maw peers` + `claude`
+#
+# Run:
+#   export ANTHROPIC_API_KEY=sk-ant-...
+#   docker compose -f docker/oracle-container/compose.yml up --build
+#
+# Verify:
+#   docker compose -f docker/oracle-container/compose.yml exec host-maw \
+#       maw peers list
+#   # → expect a row for the container-oracle (alias: oracle-a)
+
+services:
+  host-maw:
+    # Reuse the upstream federation test image; host-maw is a regular maw
+    # server that happens to have the container-oracle registered as a peer.
+    image: maw-js:test
+    build:
+      context: ../..
+      dockerfile: docker/Dockerfile
+    hostname: host-maw
+    container_name: host-maw
+    environment:
+      NODE_NAME: host-maw
+      PEER_URL: http://oracle-a:3456
+      PEER_ALIAS: oracle-a
+      MAW_HOME: /root/.maw
+    ports:
+      - "13456:3456"
+    volumes:
+      - host-maw-data:/root/.maw
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3456/api/plugins"]
+      interval: 5s
+      retries: 20
+    restart: unless-stopped
+
+  oracle-a:
+    image: maw-js-oracle:proto
+    build:
+      context: ../..
+      dockerfile: docker/oracle-container/Dockerfile
+    hostname: oracle-a
+    container_name: oracle-a
+    environment:
+      ORACLE_NAME: oracle-a
+      HOST_MAW_URL: http://host-maw:3456
+      HOST_MAW_ALIAS: host
+      MAW_HOME: /home/oracle/.maw
+      CLAUDE_CONFIG_DIR: /home/oracle/.claude
+      IDLE_INTERVAL_SECONDS: "60"
+      # Env passthrough only — never hardcoded. Shell expansion reads from
+      # the user's environment at `docker compose up` time.
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+    ports:
+      - "13458:3456"
+    volumes:
+      # Persist identity + any .claude state so oracle-a stays the same
+      # oracle across `docker compose down && up`.
+      - oracle-a-claude:/home/oracle/.claude
+      - oracle-a-maw:/home/oracle/.maw
+      # OPTIONAL: bind-mount a host vault so the oracle can read Nat's
+      # knowledge. Commented because the path varies per dev machine.
+      # - ${HOST_VAULT:-./.vault-placeholder}:/home/oracle/vault:ro
+    depends_on:
+      host-maw:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3456/api/plugins"]
+      interval: 5s
+      retries: 20
+    restart: unless-stopped
+
+volumes:
+  host-maw-data:
+  oracle-a-claude:
+  oracle-a-maw:

--- a/docker/oracle-container/entrypoint.sh
+++ b/docker/oracle-container/entrypoint.sh
@@ -2,27 +2,32 @@
 # docker/oracle-container/entrypoint.sh — PID 1 for a container-native oracle.
 #
 # Bootstrap order:
-#   1. Ensure $HOME, $MAW_HOME, $CLAUDE_CONFIG_DIR exist (volume-mounted).
-#   2. Load-or-mint oracle identity at $CLAUDE_CONFIG_DIR/identity.json.
-#      Node name precedence: $ORACLE_NAME env > identity.json.node > random stem.
-#      This persists across `docker compose down && up` via the named volume.
-#      (Full keypair identity is deferred to the rfc-identity RFC — see
-#       README "NOT DONE" for scope.)
+#   1. Ensure $HOME, $MAW_HOME, $CLAUDE_CONFIG_DIR, $MAILBOX_DIR exist.
+#   2. Load-or-mint oracle identity at $MAW_HOME/identity.json.
+#      Canonical path is under .maw/ (not .claude/) per rfc-identity — makes
+#      the file interchangeable with a host-side oracle's identity, so
+#      `rsync $MAW_HOME` migrates the oracle to a new host.
+#      Shape mirrors rfc-identity RFC §4 so Phase-1 code can consume it
+#      without a migration: {schema, node, nickname, fingerprint, born}.
+#      Node name precedence: $ORACLE_NAME env > identity.json.node > random.
 #   3. If peers.json missing, run `maw init --non-interactive --node <name>`.
 #   4. Register the host as a peer with --allow-unreachable (the host may not
 #      have finished booting yet when we first come up — the host-side probe
 #      fills in the return edge when it registers us).
-#   5. exec "$@" so `maw serve` becomes PID 1 and receives SIGTERM cleanly.
+#   5. Ensure writable inbox path (ψ/memory/mailbox/<self>/) exists — RFC #627
+#      MUST item 6: team-comms and team-shutdown --merge target this.
+#   6. exec "$@" so `maw serve` becomes PID 1 and receives SIGTERM cleanly.
 #
 # The CMD default (`maw serve 3456`) makes this container a symmetric peer:
 # it can probe the host AND be probed back, which is what lets it show up
-# in `maw peers list` on the host.
+# in `maw peers list` on the host AND respond to `maw hey`.
 set -eu
 
 : "${HOME:=/home/oracle}"
 export HOME
 : "${MAW_HOME:=$HOME/.maw}"
 : "${CLAUDE_CONFIG_DIR:=$HOME/.claude}"
+: "${MAILBOX_ROOT:=$HOME/vault/ψ/memory/mailbox}"
 : "${HOST_MAW_ALIAS:=host}"
 : "${HOST_MAW_URL:=http://host-maw:3456}"
 : "${IDLE_INTERVAL_SECONDS:=60}"
@@ -30,11 +35,15 @@ export HOME
 mkdir -p "$MAW_HOME" "$CLAUDE_CONFIG_DIR"
 
 # --- identity load-or-mint -------------------------------------------------
-IDENTITY_FILE="$CLAUDE_CONFIG_DIR/identity.json"
+# Canonical path per rfc-identity: $MAW_HOME/identity.json. Shape matches
+# RFC §4 so a future `maw identity init` can adopt the file in place.
+IDENTITY_FILE="$MAW_HOME/identity.json"
 if [ -f "$IDENTITY_FILE" ]; then
   STORED_NAME=$(grep -o '"node"[[:space:]]*:[[:space:]]*"[^"]*"' "$IDENTITY_FILE" | sed 's/.*"\([^"]*\)"$/\1/')
+  STORED_FP=$(grep -o '"fingerprint"[[:space:]]*:[[:space:]]*"[^"]*"' "$IDENTITY_FILE" | sed 's/.*"\([^"]*\)"$/\1/')
 else
   STORED_NAME=""
+  STORED_FP=""
 fi
 
 if [ -n "${ORACLE_NAME:-}" ]; then
@@ -42,24 +51,43 @@ if [ -n "${ORACLE_NAME:-}" ]; then
 elif [ -n "$STORED_NAME" ]; then
   NODE_NAME="$STORED_NAME"
 else
-  # `tr -dc` fails on /dev/urandom streams with SIGPIPE after enough bytes;
-  # head first to bound the read so set -e doesn't abort the bootstrap.
+  # `tr -dc` on a /dev/urandom stream raises SIGPIPE after enough bytes;
+  # `head -c 32` first bounds the read so `set -e` doesn't abort bootstrap.
   STEM=$(head -c 32 /dev/urandom | tr -dc 'a-z0-9' | head -c 6 || true)
   NODE_NAME="oracle-${STEM:-anon}"
+fi
+
+# Nickname (human-readable) is orthogonal to fingerprint (keypair-derived)
+# per rfc-identity — don't collapse them. The stem env wins for display;
+# fingerprint is stubbed until Phase-1 keypair code lands, but the field
+# is in the file so downstream tooling can read it today without crashing.
+NICKNAME="${ORACLE_NICKNAME:-$NODE_NAME}"
+
+if [ -n "$STORED_FP" ]; then
+  FINGERPRINT="$STORED_FP"
+else
+  # Stub fingerprint until `maw identity init` (rfc-identity Phase-1) lands.
+  # Deterministic-per-volume so the value is stable across restarts, but
+  # clearly not-a-real-pubkey-hash (prefix `stub-`) so audit tools can
+  # distinguish stubs from Phase-1 identities.
+  FINGERPRINT="stub-$(head -c 32 /dev/urandom | sha256sum | head -c 16 || echo 0000000000000000)"
 fi
 
 if [ ! -f "$IDENTITY_FILE" ] || [ "$STORED_NAME" != "$NODE_NAME" ]; then
   cat > "$IDENTITY_FILE" <<JSON
 {
-  "schema": "0",
+  "schema": "0-proto",
   "node": "$NODE_NAME",
+  "nickname": "$NICKNAME",
+  "fingerprint": "$FINGERPRINT",
   "born": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-  "note": "prototype identity — keypair deferred to rfc-identity RFC (#629)"
+  "note": "prototype identity — Phase-1 keypair code (rfc-identity #629) will replace the stub fingerprint in place; schema will advance to \"1\""
 }
 JSON
 fi
 
-echo "[container-oracle] identity → $NODE_NAME ($IDENTITY_FILE)"
+echo "[container-oracle] identity → $NODE_NAME ($NICKNAME / $FINGERPRINT)"
+echo "[container-oracle] identity file → $IDENTITY_FILE"
 
 # --- maw init (idempotent-ish: --force re-writes, but we gate on peers.json)
 if [ ! -f "$MAW_HOME/peers.json" ]; then
@@ -73,6 +101,14 @@ maw peers add "$HOST_MAW_ALIAS" "$HOST_MAW_URL" --allow-unreachable || true
 
 echo "[container-oracle] bootstrap complete — peers.json:"
 cat "$MAW_HOME/peers.json" 2>/dev/null || echo "(no peers.json yet)"
+
+# --- mailbox (RFC #627 MUST item 6) ----------------------------------------
+# `maw team send` falls back to mailbox-write when peer is down; team-comms
+# and team-shutdown --merge both target this path. Create it eagerly so the
+# first inbound send doesn't race with volume-init.
+SELF_MAILBOX="$MAILBOX_ROOT/$NODE_NAME"
+mkdir -p "$SELF_MAILBOX"
+echo "[container-oracle] mailbox → $SELF_MAILBOX"
 
 # Required for the host container to reach us over the compose network.
 export MAW_HOST=0.0.0.0

--- a/docker/oracle-container/entrypoint.sh
+++ b/docker/oracle-container/entrypoint.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# docker/oracle-container/entrypoint.sh — PID 1 for a container-native oracle.
+#
+# Bootstrap order:
+#   1. Ensure $HOME, $MAW_HOME, $CLAUDE_CONFIG_DIR exist (volume-mounted).
+#   2. Load-or-mint oracle identity at $CLAUDE_CONFIG_DIR/identity.json.
+#      Node name precedence: $ORACLE_NAME env > identity.json.node > random stem.
+#      This persists across `docker compose down && up` via the named volume.
+#      (Full keypair identity is deferred to the rfc-identity RFC — see
+#       README "NOT DONE" for scope.)
+#   3. If peers.json missing, run `maw init --non-interactive --node <name>`.
+#   4. Register the host as a peer with --allow-unreachable (the host may not
+#      have finished booting yet when we first come up — the host-side probe
+#      fills in the return edge when it registers us).
+#   5. exec "$@" so `maw serve` becomes PID 1 and receives SIGTERM cleanly.
+#
+# The CMD default (`maw serve 3456`) makes this container a symmetric peer:
+# it can probe the host AND be probed back, which is what lets it show up
+# in `maw peers list` on the host.
+set -eu
+
+: "${HOME:=/home/oracle}"
+export HOME
+: "${MAW_HOME:=$HOME/.maw}"
+: "${CLAUDE_CONFIG_DIR:=$HOME/.claude}"
+: "${HOST_MAW_ALIAS:=host}"
+: "${HOST_MAW_URL:=http://host-maw:3456}"
+: "${IDLE_INTERVAL_SECONDS:=60}"
+
+mkdir -p "$MAW_HOME" "$CLAUDE_CONFIG_DIR"
+
+# --- identity load-or-mint -------------------------------------------------
+IDENTITY_FILE="$CLAUDE_CONFIG_DIR/identity.json"
+if [ -f "$IDENTITY_FILE" ]; then
+  STORED_NAME=$(grep -o '"node"[[:space:]]*:[[:space:]]*"[^"]*"' "$IDENTITY_FILE" | sed 's/.*"\([^"]*\)"$/\1/')
+else
+  STORED_NAME=""
+fi
+
+if [ -n "${ORACLE_NAME:-}" ]; then
+  NODE_NAME="$ORACLE_NAME"
+elif [ -n "$STORED_NAME" ]; then
+  NODE_NAME="$STORED_NAME"
+else
+  # `tr -dc` fails on /dev/urandom streams with SIGPIPE after enough bytes;
+  # head first to bound the read so set -e doesn't abort the bootstrap.
+  STEM=$(head -c 32 /dev/urandom | tr -dc 'a-z0-9' | head -c 6 || true)
+  NODE_NAME="oracle-${STEM:-anon}"
+fi
+
+if [ ! -f "$IDENTITY_FILE" ] || [ "$STORED_NAME" != "$NODE_NAME" ]; then
+  cat > "$IDENTITY_FILE" <<JSON
+{
+  "schema": "0",
+  "node": "$NODE_NAME",
+  "born": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "note": "prototype identity — keypair deferred to rfc-identity RFC (#629)"
+}
+JSON
+fi
+
+echo "[container-oracle] identity → $NODE_NAME ($IDENTITY_FILE)"
+
+# --- maw init (idempotent-ish: --force re-writes, but we gate on peers.json)
+if [ ! -f "$MAW_HOME/peers.json" ]; then
+  maw init --non-interactive --node "$NODE_NAME" --force
+fi
+
+# --- register host as peer -------------------------------------------------
+# --allow-unreachable: host may not be up yet on first compose boot. The host
+# side adds us back when IT boots, so the edge closes either way.
+maw peers add "$HOST_MAW_ALIAS" "$HOST_MAW_URL" --allow-unreachable || true
+
+echo "[container-oracle] bootstrap complete — peers.json:"
+cat "$MAW_HOME/peers.json" 2>/dev/null || echo "(no peers.json yet)"
+
+# Required for the host container to reach us over the compose network.
+export MAW_HOST=0.0.0.0
+
+# Background re-probe loop so stale entries self-heal if the host flaps.
+# Sends a `maw peers probe` every $IDLE_INTERVAL_SECONDS; stays detached
+# from stdout so it doesn't interleave with the serve logs.
+(
+  while sleep "$IDLE_INTERVAL_SECONDS"; do
+    maw peers probe "$HOST_MAW_ALIAS" >/dev/null 2>&1 || true
+  done
+) &
+
+exec "$@"


### PR DESCRIPTION
Live-verified prototype of Claude-Code runtime in docker with persistent oracle identity + federation handshake. `docker compose up` succeeds end-to-end, bidirectional peers-list in ~15s, identity.json persists across restart. Canonical $MAW_HOME/identity.json path aligned with #629 RFC. Ships: docker/oracle-container/{Dockerfile, entrypoint.sh, compose.yml, README.md}. Draft — auth + keypair identity scoped to #629/#642 follow-ups.