### PR TITLE
fix(#680): plugins.lock trust flow — writer + verifier + init bootstrap + e2e test

### DIFF
--- a/src/commands/plugins/init/bootstrap-plugins-lock.ts
+++ b/src/commands/plugins/init/bootstrap-plugins-lock.ts
@@ -1,0 +1,24 @@
+import { existsSync, mkdirSync } from "fs";
+import { dirname } from "path";
+import { LOCK_SCHEMA, lockPath, writeLock } from "../plugin/lock";
+
+export interface BootstrapPluginsLockResult {
+  created: boolean;
+  path: string;
+}
+
+/**
+ * First-run bootstrap for ~/.maw/plugins.lock (#680 ask 4).
+ *
+ * If the lockfile is absent, create it with an empty-but-valid shape so every
+ * subsequent `maw plugin install` has a truth file to write into. If present,
+ * leave it alone — never overwrite, never merge.
+ */
+export function bootstrapPluginsLock(): BootstrapPluginsLockResult {
+  const path = lockPath();
+  if (existsSync(path)) return { created: false, path };
+
+  mkdirSync(dirname(path), { recursive: true });
+  writeLock({ schema: LOCK_SCHEMA, updated: new Date().toISOString(), plugins: {} });
+  return { created: true, path };
+}

--- a/src/commands/plugins/init/impl.ts
+++ b/src/commands/plugins/init/impl.ts
@@ -12,6 +12,7 @@ import {
   writeConfigAtomic,
 } from "./write-config";
 import { generateFederationToken } from "./federation";
+import { bootstrapPluginsLock } from "./bootstrap-plugins-lock";
 
 const CYAN = "\x1b[36m";
 const GREEN = "\x1b[32m";
@@ -102,6 +103,12 @@ export async function cmdInit(opts: CmdInitOpts): Promise<CmdInitResult> {
 
     writeConfigAtomic(CONFIG_FILE, config, /* overwrite */ true);
     write(`${GREEN}✓${RESET} Wrote ${CONFIG_FILE}`);
+    try {
+      const boot = bootstrapPluginsLock();
+      if (boot.created) write(`${GREEN}✓${RESET} plugins.lock (bootstrap) ${GRAY}${boot.path}${RESET}`);
+    } catch (e: any) {
+      write(`${GRAY}warning: plugins.lock bootstrap skipped — ${e?.message ?? String(e)}${RESET}`);
+    }
     if (federationToken && parsed.opts.federate) {
       write(`${CYAN}federation token${RESET}: ${federationToken}`);
       write(`${GRAY}  share with each peer in their maw.config.json${RESET}`);
@@ -148,6 +155,12 @@ export async function cmdInit(opts: CmdInitOpts): Promise<CmdInitResult> {
 
   write("");
   write(`${GREEN}✓${RESET} Wrote ${CONFIG_FILE}`);
+  try {
+    const boot = bootstrapPluginsLock();
+    if (boot.created) write(`${GREEN}✓${RESET} plugins.lock (bootstrap) ${GRAY}${boot.path}${RESET}`);
+  } catch (e: any) {
+    write(`${GRAY}warning: plugins.lock bootstrap skipped — ${e?.message ?? String(e)}${RESET}`);
+  }
   if (existsSync(FLEET_DIR)) {
     const fleetCount = readdirSync(FLEET_DIR).filter(f => f.endsWith(".json")).length;
     write(`${GREEN}✓${RESET} Fleet dir ready: ${FLEET_DIR} ${GRAY}(${fleetCount} entr${fleetCount === 1 ? "y" : "ies"})${RESET}`);

--- a/src/commands/plugins/plugin/install-handlers.ts
+++ b/src/commands/plugins/plugin/install-handlers.ts
@@ -11,7 +11,8 @@ import { formatSdkMismatchError, runtimeSdkVersion, satisfies } from "../../../p
 import { installRoot, removeExisting } from "./install-source-detect";
 import { extractTarball, downloadTarball, verifyArtifactHash, verifyArtifactHashAgainst } from "./install-extraction";
 import { readManifest, printInstallSuccess } from "./install-manifest-helpers";
-import { readLock, pinPlugin } from "./lock";
+import { readLock, recordInstall } from "./lock";
+import { createHash } from "crypto";
 
 /**
  * #404 — preserve category across replace. Category is derived from `weight`
@@ -145,6 +146,20 @@ export async function installFromDir(
   // the author never has to run a per-repo setup.sh.
   ensurePluginMawJsLink(srcDir);
 
+  // #680 ask #1 — persist lock entry for --link installs. sha256 is of the
+  // plugin.json content (stable identity; the symlinked source isn't a
+  // sealed artifact so there's no tarball hash to record).
+  const absSrc = resolve(srcDir);
+  const pluginJsonBytes = readFileSync(join(absSrc, "plugin.json"));
+  const sha = createHash("sha256").update(pluginJsonBytes).digest("hex");
+  recordInstall({
+    name: manifest!.name,
+    version: manifest!.version,
+    sha256: sha,
+    source: `link:${absSrc}`,
+    linked: true,
+  });
+
   printInstallSuccess(manifest!, dest, "linked (dev)");
 }
 
@@ -198,16 +213,13 @@ export async function installFromTarball(
   }
   const pinned = lock.plugins[manifest!.name];
   if (!pinned) {
-    if (!opts.pin) {
-      rmSync(staging, { recursive: true, force: true });
-      throw new Error(
-        `plugin '${manifest!.name}' not in plugins.lock — run: maw plugin pin ${manifest!.name} ${opts.source}\n` +
-        `  (or re-run install with --pin to add it now)`,
-      );
-    }
-    // --pin: accept this install AND stage the lock entry using the hash we
-    // just verified via the manifest. Safe because we already asserted the
-    // tarball is internally consistent; --pin is an explicit trust handshake.
+    // #680 ask #1 — first install auto-initializes the lock entry (see
+    // recordInstall() below). No --pin required for TOFU: the self-hash
+    // check above already proved the tarball is internally consistent.
+    // --pin remains a no-op signal for now; kept as a flag for future
+    // "explicit trust handshake" UX that wants to distinguish first-pin
+    // from auto-pin in command output.
+    void opts.pin;
   } else {
     if (pinned.version !== manifest!.version) {
       rmSync(staging, { recursive: true, force: true });
@@ -250,12 +262,17 @@ export async function installFromTarball(
     rmSync(staging, { recursive: true, force: true });
   }
 
-  // --pin: after a successful install, stage the lockfile entry. We pin using
-  // the original tarball path so `maw plugin pin --verify` (future) can
-  // re-hash from the same source.
-  if (opts.pin && !lock.plugins[manifest!.name]) {
-    pinPlugin(manifest!.name, tarballPath);
-  }
+  // #680 ask #1 — persist lock entry on every successful tarball install.
+  // The manifest's artifact.sha256 has already been verified (self-hash +
+  // optional registry-pinned check above), so we can trust it here rather
+  // than re-hashing. --pin retains its semantic: explicit trust handshake
+  // for a first-time install; both paths land the same entry shape now.
+  recordInstall({
+    name: manifest!.name,
+    version: manifest!.version,
+    sha256: manifest!.artifact!.sha256!,
+    source: opts.source,
+  });
 
   const sourceNote = opts.source.startsWith("http") ? `from ${opts.source}` : "";
   printInstallSuccess(

--- a/src/commands/plugins/plugin/install-handlers.ts
+++ b/src/commands/plugins/plugin/install-handlers.ts
@@ -201,9 +201,16 @@ export async function installFromTarball(
     throw new Error(selfHashResult.error);
   }
 
-  // Registry-pinned verification (#487 Option A). The expected hash comes from
-  // the operator-curated lockfile, not the tarball itself — this is what
-  // closes the MITM / CDN-swap threat.
+  // Registry-pinned verification (#487 Option A, #680 ask 2). The expected
+  // hash comes from the operator-curated lockfile, not the tarball itself —
+  // this is what closes the MITM / CDN-swap threat.
+  //
+  // Gate behavior (#680 ask 2):
+  //   • No entry for <name>  → proceed (writer agent, #680 ask 1, persists).
+  //   • Entry + sha matches  → proceed.
+  //   • Entry + sha differs  → refuse unless --force OR --pin.
+  //       --force: override, re-write lock to new sha.
+  //       --pin:   re-pin, same effect — semantically an explicit re-trust.
   let lock;
   try {
     lock = readLock();
@@ -213,12 +220,6 @@ export async function installFromTarball(
   }
   const pinned = lock.plugins[manifest!.name];
   if (!pinned) {
-    // #680 ask #1 — first install auto-initializes the lock entry (see
-    // recordInstall() below). No --pin required for TOFU: the self-hash
-    // check above already proved the tarball is internally consistent.
-    // --pin remains a no-op signal for now; kept as a flag for future
-    // "explicit trust handshake" UX that wants to distinguish first-pin
-    // from auto-pin in command output.
     void opts.pin;
   } else {
     if (pinned.version !== manifest!.version) {
@@ -229,11 +230,17 @@ export async function installFromTarball(
     }
     const pinnedResult = verifyArtifactHashAgainst(staging, manifest!, pinned.sha256);
     if (!pinnedResult.ok) {
-      rmSync(staging, { recursive: true, force: true });
-      throw new Error(
-        `plugin '${manifest!.name}' ${pinnedResult.error}\n` +
-        `  lockfile hash did not match — this is the real adversarial check (#487).`,
-      );
+      if (!opts.force && !opts.pin) {
+        rmSync(staging, { recursive: true, force: true });
+        const observed = manifest!.artifact?.sha256 ?? "(unknown)";
+        throw new Error(
+          `plugin '${manifest!.name}' sha256 mismatch — refusing to install.\n` +
+          `  plugins.lock: ${pinned.sha256}\n` +
+          `  tarball:      ${observed}\n` +
+          `  --force to override (updates lock), --pin to re-pin`,
+        );
+      }
+      // --force / --pin: operator re-trusted; recordInstall() below overwrites.
     }
   }
 
@@ -262,11 +269,8 @@ export async function installFromTarball(
     rmSync(staging, { recursive: true, force: true });
   }
 
-  // #680 ask #1 — persist lock entry on every successful tarball install.
-  // The manifest's artifact.sha256 has already been verified (self-hash +
-  // optional registry-pinned check above), so we can trust it here rather
-  // than re-hashing. --pin retains its semantic: explicit trust handshake
-  // for a first-time install; both paths land the same entry shape now.
+  // #680 — persist lock entry on every successful tarball install. TOFU on
+  // first install; overwrites on --force/--pin re-trust.
   recordInstall({
     name: manifest!.name,
     version: manifest!.version,

--- a/src/commands/plugins/plugin/install-handlers.ts
+++ b/src/commands/plugins/plugin/install-handlers.ts
@@ -151,7 +151,7 @@ export async function installFromDir(
   // sealed artifact so there's no tarball hash to record).
   const absSrc = resolve(srcDir);
   const pluginJsonBytes = readFileSync(join(absSrc, "plugin.json"));
-  const sha = createHash("sha256").update(pluginJsonBytes).digest("hex");
+  const sha = `sha256:${createHash("sha256").update(pluginJsonBytes).digest("hex")}`;
   recordInstall({
     name: manifest!.name,
     version: manifest!.version,

--- a/src/commands/plugins/plugin/lock.test.ts
+++ b/src/commands/plugins/plugin/lock.test.ts
@@ -1,0 +1,185 @@
+/**
+ * plugins.lock — recordInstall() unit tests for #680 ask #1.
+ *
+ * Happy-path writer: every successful install stages a lock entry. Covers
+ * idempotent re-install, --link entry shape, rejection of malformed input,
+ * and preservation of `added` across updates.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { readLock, recordInstall, writeLock, LOCK_SCHEMA } from "./lock";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "mawlock-"));
+  process.env.MAW_PLUGINS_LOCK = join(tmp, "plugins.lock");
+});
+
+afterEach(() => {
+  delete process.env.MAW_PLUGINS_LOCK;
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+const HASH_A = "a".repeat(64);
+const HASH_B = "b".repeat(64);
+
+describe("recordInstall — happy path", () => {
+  it("creates plugins.lock on first call", () => {
+    expect(existsSync(process.env.MAW_PLUGINS_LOCK!)).toBe(false);
+    recordInstall({ name: "health", version: "1.0.0", sha256: HASH_A, source: "./health-1.0.0.tgz" });
+    expect(existsSync(process.env.MAW_PLUGINS_LOCK!)).toBe(true);
+  });
+
+  it("persists sha256/source/version for tarball install", () => {
+    recordInstall({ name: "health", version: "1.0.0", sha256: HASH_A, source: "./health-1.0.0.tgz" });
+    const lock = readLock();
+    expect(lock.schema).toBe(LOCK_SCHEMA);
+    expect(lock.plugins.health).toMatchObject({
+      version: "1.0.0",
+      sha256: HASH_A,
+      source: "./health-1.0.0.tgz",
+    });
+    expect(lock.plugins.health.linked).toBeUndefined();
+    expect(typeof lock.plugins.health.added).toBe("string");
+  });
+
+  it("records linked=true + link: source for --link installs", () => {
+    recordInstall({
+      name: "health", version: "1.0.0", sha256: HASH_A,
+      source: "link:/home/dev/health", linked: true,
+    });
+    const entry = readLock().plugins.health;
+    expect(entry.linked).toBe(true);
+    expect(entry.source).toBe("link:/home/dev/health");
+  });
+
+  it("omits linked field on non-link installs (not stored as false)", () => {
+    recordInstall({ name: "health", version: "1.0.0", sha256: HASH_A, source: "./x.tgz" });
+    const raw = JSON.parse(readFileSync(process.env.MAW_PLUGINS_LOCK!, "utf8"));
+    expect("linked" in raw.plugins.health).toBe(false);
+  });
+});
+
+describe("recordInstall — idempotency", () => {
+  it("preserves `added` timestamp across re-install with new sha", async () => {
+    recordInstall({ name: "health", version: "1.0.0", sha256: HASH_A, source: "./v1.tgz" });
+    const firstAdded = readLock().plugins.health.added;
+    // Tick so any wall-clock-based update is visibly later.
+    await new Promise(r => setTimeout(r, 5));
+    recordInstall({ name: "health", version: "1.0.1", sha256: HASH_B, source: "./v2.tgz" });
+    const after = readLock().plugins.health;
+    expect(after.added).toBe(firstAdded);
+    expect(after.version).toBe("1.0.1");
+    expect(after.sha256).toBe(HASH_B);
+    expect(after.source).toBe("./v2.tgz");
+  });
+
+  it("does not duplicate entries (map keyed by name)", () => {
+    recordInstall({ name: "health", version: "1.0.0", sha256: HASH_A, source: "./v1.tgz" });
+    recordInstall({ name: "health", version: "1.0.1", sha256: HASH_B, source: "./v2.tgz" });
+    const lock = readLock();
+    expect(Object.keys(lock.plugins)).toEqual(["health"]);
+  });
+
+  it("toggles linked flag when switching from --link to tarball", () => {
+    recordInstall({
+      name: "health", version: "1.0.0", sha256: HASH_A,
+      source: "link:/home/dev/health", linked: true,
+    });
+    expect(readLock().plugins.health.linked).toBe(true);
+    recordInstall({ name: "health", version: "1.0.0", sha256: HASH_B, source: "./health.tgz" });
+    expect(readLock().plugins.health.linked).toBeUndefined();
+  });
+
+  it("coexists with other plugins untouched", () => {
+    recordInstall({ name: "health", version: "1.0.0", sha256: HASH_A, source: "./h.tgz" });
+    recordInstall({ name: "echo", version: "0.1.0", sha256: HASH_B, source: "./e.tgz" });
+    const lock = readLock();
+    expect(Object.keys(lock.plugins).sort()).toEqual(["echo", "health"]);
+    expect(lock.plugins.health.sha256).toBe(HASH_A);
+    expect(lock.plugins.echo.sha256).toBe(HASH_B);
+  });
+});
+
+describe("recordInstall — validation", () => {
+  it("rejects invalid name", () => {
+    expect(() =>
+      recordInstall({ name: "BadName", version: "1.0.0", sha256: HASH_A, source: "./x.tgz" }),
+    ).toThrow(/invalid plugin name/);
+  });
+
+  it("rejects invalid sha256 (wrong length)", () => {
+    expect(() =>
+      recordInstall({ name: "health", version: "1.0.0", sha256: "abc123", source: "./x.tgz" }),
+    ).toThrow(/invalid sha256/);
+  });
+
+  it("rejects empty version", () => {
+    expect(() =>
+      recordInstall({ name: "health", version: "", sha256: HASH_A, source: "./x.tgz" }),
+    ).toThrow(/version required/);
+  });
+
+  it("rejects empty source", () => {
+    expect(() =>
+      recordInstall({ name: "health", version: "1.0.0", sha256: HASH_A, source: "" }),
+    ).toThrow(/source required/);
+  });
+
+  it("accepts sha256: prefix form", () => {
+    recordInstall({
+      name: "health", version: "1.0.0",
+      sha256: `sha256:${HASH_A}`,
+      source: "./x.tgz",
+    });
+    expect(readLock().plugins.health.sha256).toBe(`sha256:${HASH_A}`);
+  });
+});
+
+describe("recordInstall — persistence + schema", () => {
+  it("round-trips through JSON with correct schema version", () => {
+    recordInstall({ name: "health", version: "1.0.0", sha256: HASH_A, source: "./x.tgz" });
+    const raw = JSON.parse(readFileSync(process.env.MAW_PLUGINS_LOCK!, "utf8"));
+    expect(raw.schema).toBe(LOCK_SCHEMA);
+    expect(typeof raw.updated).toBe("string");
+    expect(raw.plugins.health.sha256).toBe(HASH_A);
+  });
+
+  it("merges into a pre-existing lock without wiping prior entries", () => {
+    // Seed a lock the init-bootstrap agent would have written.
+    writeLock({
+      schema: LOCK_SCHEMA,
+      updated: new Date().toISOString(),
+      plugins: {
+        preexisting: {
+          version: "0.1.0",
+          sha256: HASH_B,
+          source: "./preexisting.tgz",
+          added: "2026-04-01T00:00:00.000Z",
+        },
+      },
+    });
+    recordInstall({ name: "health", version: "1.0.0", sha256: HASH_A, source: "./h.tgz" });
+    const lock = readLock();
+    expect(Object.keys(lock.plugins).sort()).toEqual(["health", "preexisting"]);
+    expect(lock.plugins.preexisting.added).toBe("2026-04-01T00:00:00.000Z");
+  });
+
+  it("survives reinstall after manual lockfile edit (re-validates schema)", () => {
+    recordInstall({ name: "health", version: "1.0.0", sha256: HASH_A, source: "./h.tgz" });
+    // Operator hand-adds another entry.
+    const raw = JSON.parse(readFileSync(process.env.MAW_PLUGINS_LOCK!, "utf8"));
+    raw.plugins.manual = {
+      version: "9.9.9", sha256: HASH_B, source: "./manual.tgz",
+      added: "2026-04-01T00:00:00.000Z",
+    };
+    writeFileSync(process.env.MAW_PLUGINS_LOCK!, JSON.stringify(raw, null, 2));
+    recordInstall({ name: "health", version: "1.0.1", sha256: HASH_B, source: "./h2.tgz" });
+    const lock = readLock();
+    expect(lock.plugins.manual).toBeDefined();
+    expect(lock.plugins.health.version).toBe("1.0.1");
+  });
+});

--- a/src/commands/plugins/plugin/lock.ts
+++ b/src/commands/plugins/plugin/lock.ts
@@ -27,6 +27,8 @@ export interface LockEntry {
   source: string;
   added: string;
   signers?: string[];
+  /** True iff entry was written by a `--link` (dev-clone) install. */
+  linked?: boolean;
 }
 
 export interface Lock {
@@ -115,6 +117,7 @@ export function validateSchema(parsed: unknown): { ok: true; lock: Lock } | { ok
       source: e.source,
       added: typeof e.added === "string" ? e.added : updated,
       signers: Array.isArray(e.signers) ? (e.signers as string[]).filter(s => typeof s === "string") : undefined,
+      ...(e.linked === true ? { linked: true } : {}),
     };
   }
   return { ok: true, lock: { schema: LOCK_SCHEMA, updated, plugins: out } };
@@ -241,6 +244,57 @@ export function pinPlugin(name: string, source: string, opts: PinOptions = {}): 
   lock.plugins[name] = entry;
   writeLock(lock);
   return { name, entry, previous };
+}
+
+/**
+ * #680 ask #1 — happy-path install writer.
+ *
+ * Called after a successful `maw plugin install`. Persists the artifact's
+ * sha256 into plugins.lock so subsequent installs have local truth to verify
+ * against. Idempotent: re-installing `<name>` updates the entry but preserves
+ * the original `added` timestamp.
+ *
+ * Separate from `pinPlugin` (which hashes a tarball on disk): this one trusts
+ * the caller's already-verified sha256 so we don't double-hash the artifact
+ * in the common install flow.
+ */
+export interface RecordInstallInput {
+  name: string;
+  version: string;
+  /** Canonical 64-hex sha256. For --link installs, hash of plugin.json content. */
+  sha256: string;
+  /** Tarball path, URL, or `link:<abs-path>` for --link. */
+  source: string;
+  /** True iff this was a --link (dev-clone) install. */
+  linked?: boolean;
+  signers?: string[];
+}
+
+export function recordInstall(input: RecordInstallInput): LockEntry {
+  const nv = validateName(input.name);
+  if (!nv.ok) throw new Error(nv.error);
+  const hv = validateSha256(input.sha256);
+  if (!hv.ok) throw new Error(`recordInstall(${input.name}): ${hv.error}`);
+  if (typeof input.version !== "string" || !input.version) {
+    throw new Error(`recordInstall(${input.name}): version required`);
+  }
+  if (typeof input.source !== "string" || !input.source) {
+    throw new Error(`recordInstall(${input.name}): source required`);
+  }
+  const lock = readLock();
+  const previous = lock.plugins[input.name];
+  const now = new Date().toISOString();
+  const entry: LockEntry = {
+    version: input.version,
+    sha256: input.sha256,
+    source: input.source,
+    added: previous?.added ?? now,
+    ...(input.linked === true ? { linked: true } : {}),
+    ...(input.signers && input.signers.length ? { signers: input.signers } : {}),
+  };
+  lock.plugins[input.name] = entry;
+  writeLock(lock);
+  return entry;
 }
 
 export interface UnpinResult {

--- a/src/commands/plugins/plugin/lock.ts
+++ b/src/commands/plugins/plugin/lock.ts
@@ -10,9 +10,9 @@
  * See ψ/writing/2026-04-18/plugin-hash-supply-chain-spec.md for the spec.
  */
 
-import { chmodSync, existsSync, readFileSync, renameSync, statSync, writeFileSync } from "fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from "fs";
 import { homedir } from "os";
-import { join } from "path";
+import { dirname, join } from "path";
 import { hashFile } from "../../../plugin/registry";
 import { readManifest } from "./install-manifest-helpers";
 import { extractTarball } from "./install-extraction";
@@ -164,6 +164,8 @@ export function writeLock(lock: Lock): void {
   const path = lockPath();
   const tmp = `${path}.tmp`;
   const content = JSON.stringify({ ...lock, updated: new Date().toISOString() }, null, 2) + "\n";
+  // Parent dir may not exist yet on fresh installs that haven't run `maw init`.
+  mkdirSync(dirname(path), { recursive: true });
   // Exclusive create on the tmp path — if a prior write crashed and left
   // <path>.tmp behind, we refuse to clobber without surfacing it.
   try {

--- a/test/integration/plugins-lock-trust.test.ts
+++ b/test/integration/plugins-lock-trust.test.ts
@@ -1,0 +1,279 @@
+/**
+ * plugins.lock trust flow — e2e proof for #680.
+ *
+ * Asserts the four behaviours the "lock-file is truth" model requires:
+ *
+ *   1. `maw init` on a clean HOME bootstraps an empty plugins.lock.
+ *   2. `maw plugin install <tarball>` persists a sha256 entry to the lock.
+ *   3. A second install of DIFFERENT bytes under the same name is REFUSED.
+ *   4. --force overrides that refusal and updates the lock.
+ *   5. `maw plugin install <dir> --link` records a `linked: true` +
+ *      `source: "link:<dir>"` entry instead of a sha.
+ *   6. `maw plugin pin` / `unpin` CLI round-trip updates the lock.
+ *
+ * Hermetic: MAW_HOME, MAW_PLUGINS_DIR, MAW_PLUGINS_LOCK redirect every side
+ * effect to a per-suite tmpdir. No real HOME is touched.
+ *
+ * Written against the merged shape of three sibling branches (#680):
+ *   • lock-writer     — adds auto-pin + --link lock entry
+ *   • lock-verifier   — adds --force override on sha-mismatch refusal
+ *   • init-bootstrap  — has `maw init` seed plugins.lock with schema 1
+ *
+ * If assertions fail against one branch alone, that's expected — the lead
+ * runs this against all three merged together.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
+import { spawnSync } from "child_process";
+import { tmpdir } from "os";
+import { createHash } from "crypto";
+import { join } from "path";
+
+import {
+  installFromDir,
+  installFromTarball,
+} from "../../src/commands/plugins/plugin/install-handlers";
+import {
+  cmdPluginPin,
+  cmdPluginUnpin,
+} from "../../src/commands/plugins/plugin/lock-cli";
+import { runtimeSdkVersion } from "../../src/plugin/registry";
+
+const SKIP = process.env.MAW_SKIP_INTEGRATION === "1";
+
+function sha256File(path: string): string {
+  return `sha256:${createHash("sha256").update(readFileSync(path)).digest("hex")}`;
+}
+
+/**
+ * Build a tiny but complete plugin source dir (plugin.json + dist/index.js)
+ * and pack it into a .tgz. `marker` lets the test generate two tarballs with
+ * the SAME name/version but DIFFERENT bytes (different sha256).
+ */
+function buildFakePlugin(
+  srcDir: string,
+  tarballPath: string,
+  name: string,
+  version: string,
+  marker: string,
+): { sha256: string } {
+  mkdirSync(srcDir, { recursive: true });
+  mkdirSync(join(srcDir, "dist"), { recursive: true });
+  const artifactRel = "dist/index.js";
+  const artifactAbs = join(srcDir, artifactRel);
+  writeFileSync(
+    artifactAbs,
+    `// #680 fake plugin — marker=${marker}\n` +
+      `export default { name: ${JSON.stringify(name)}, marker: ${JSON.stringify(marker)} };\n`,
+  );
+  const sha256 = sha256File(artifactAbs);
+  const manifest = {
+    name,
+    version,
+    sdk: runtimeSdkVersion(),
+    description: `Integration-test plugin for #680 (marker=${marker})`,
+    artifact: { path: artifactRel, sha256 },
+  };
+  writeFileSync(join(srcDir, "plugin.json"), JSON.stringify(manifest, null, 2) + "\n");
+
+  const tar = spawnSync("tar", ["-czf", tarballPath, "-C", srcDir, "."], {
+    encoding: "utf8",
+  });
+  if (tar.status !== 0) throw new Error(`tar failed: ${tar.stderr}`);
+  return { sha256 };
+}
+
+function readLockFile(path: string): any {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+describe.skipIf(SKIP)("plugins.lock trust flow (#680)", () => {
+  let suiteRoot: string;
+  const prev = {
+    home: process.env.MAW_HOME,
+    pluginsDir: process.env.MAW_PLUGINS_DIR,
+    lock: process.env.MAW_PLUGINS_LOCK,
+  };
+
+  // Per-test working dirs — recreated in beforeEach so every case starts clean.
+  let caseDir: string;
+  let pluginsDir: string;
+  let lockFile: string;
+
+  beforeAll(() => {
+    // MAW_HOME must be set BEFORE the init module is imported; CONFIG_FILE in
+    // core/paths is resolved at module-load time from MAW_HOME. Lock/plugins
+    // paths are read at call time, so those can be rewritten per test.
+    suiteRoot = mkdtempSync(join(tmpdir(), "maw-lock-trust-"));
+    process.env.MAW_HOME = join(suiteRoot, "maw-home");
+    mkdirSync(process.env.MAW_HOME, { recursive: true });
+  });
+
+  afterAll(() => {
+    rmSync(suiteRoot, { recursive: true, force: true });
+    for (const [k, v] of [
+      ["MAW_HOME", prev.home],
+      ["MAW_PLUGINS_DIR", prev.pluginsDir],
+      ["MAW_PLUGINS_LOCK", prev.lock],
+    ] as const) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  beforeEach(() => {
+    caseDir = mkdtempSync(join(suiteRoot, "case-"));
+    pluginsDir = join(caseDir, "plugins");
+    lockFile = join(caseDir, "plugins.lock");
+    mkdirSync(pluginsDir, { recursive: true });
+    process.env.MAW_PLUGINS_DIR = pluginsDir;
+    process.env.MAW_PLUGINS_LOCK = lockFile;
+  });
+
+  it("1. `maw init` on clean HOME creates plugins.lock with empty schema", async () => {
+    expect(existsSync(lockFile)).toBe(false);
+
+    // init-bootstrap wires plugins.lock creation into cmdInit. Dynamic import
+    // so we pick up the merged branch even though the top-level imports don't
+    // touch core/paths.
+    const { cmdInit } = await import("../../src/commands/plugins/init/impl");
+    const result = await cmdInit({
+      args: ["--non-interactive", "--node", "lock-trust-node", "--force"],
+      writer: () => {},
+    });
+    expect(result.ok).toBe(true);
+
+    expect(existsSync(lockFile)).toBe(true);
+    const lock = readLockFile(lockFile);
+
+    // Canonical field is `schema` (confirmed by init-bootstrap + lock-writer);
+    // the issue body's "schemaVersion" was inexact.
+    expect(lock.schema).toBe(1);
+    expect(lock.plugins).toEqual({});
+    expect(typeof lock.updated).toBe("string");
+  });
+
+  it("2. `maw plugin install <tarball>` writes a sha entry", async () => {
+    const name = "lock-trust-install";
+    const srcDir = join(caseDir, "src-install");
+    const tarball = join(caseDir, "lock-trust-install.tgz");
+    const { sha256 } = buildFakePlugin(srcDir, tarball, name, "1.0.0", "first");
+
+    // lock-writer TOFU: first install of an unpinned name auto-adds the
+    // entry — no --pin flag required. Also proves `added` is set.
+    expect(existsSync(lockFile)).toBe(false);
+    await installFromTarball(tarball, { source: tarball });
+
+    expect(existsSync(lockFile)).toBe(true);
+    const lock = readLockFile(lockFile);
+    expect(lock.plugins[name]).toBeDefined();
+    expect(lock.plugins[name].sha256).toBe(sha256);
+    expect(lock.plugins[name].version).toBe("1.0.0");
+    expect(lock.plugins[name].source).toBe(tarball);
+    expect(typeof lock.plugins[name].added).toBe("string");
+  });
+
+  it("3. second install of a DIFFERENT tarball under the same name is refused", async () => {
+    const name = "lock-trust-mismatch";
+    const tarA = join(caseDir, "a.tgz");
+    const tarB = join(caseDir, "b.tgz");
+    const { sha256: shaA } = buildFakePlugin(
+      join(caseDir, "src-a"), tarA, name, "1.0.0", "alpha",
+    );
+    const { sha256: shaB } = buildFakePlugin(
+      join(caseDir, "src-b"), tarB, name, "1.0.0", "bravo",
+    );
+    expect(shaA).not.toBe(shaB); // sanity — our fake plugins really differ.
+
+    // First install TOFU-pins shaA.
+    await installFromTarball(tarA, { source: tarA });
+    const lockAfterA = readLockFile(lockFile);
+    expect(lockAfterA.plugins[name].sha256).toBe(shaA);
+
+    // Second install of DIFFERENT bytes under SAME name → REFUSED.
+    // lock-verifier's exact wording is
+    // `plugin 'NAME' sha256 mismatch — refusing to install.`
+    await expect(
+      installFromTarball(tarB, { source: tarB, force: false }),
+    ).rejects.toThrow(/sha256 mismatch/);
+
+    // Lock must be unchanged — a refused install cannot mutate truth.
+    const lockAfterRefusal = readLockFile(lockFile);
+    expect(lockAfterRefusal.plugins[name].sha256).toBe(shaA);
+  });
+
+  it("4. --force overrides the refusal and updates the lock", async () => {
+    const name = "lock-trust-force";
+    const tarA = join(caseDir, "a.tgz");
+    const tarB = join(caseDir, "b.tgz");
+    const { sha256: shaA } = buildFakePlugin(
+      join(caseDir, "src-a"), tarA, name, "1.0.0", "alpha",
+    );
+    const { sha256: shaB } = buildFakePlugin(
+      join(caseDir, "src-b"), tarB, name, "1.0.0", "bravo",
+    );
+
+    await installFromTarball(tarA, { source: tarA });
+    const addedOriginal = readLockFile(lockFile).plugins[name].added;
+
+    // lock-verifier: --force bypasses the sha-mismatch refusal AND silently
+    // re-pins the lock entry to the new sha. Before the verifier branch,
+    // --force only affects the overwrite-refusal path in install-handlers,
+    // not the lock-mismatch path.
+    await installFromTarball(tarB, { source: tarB, force: true });
+
+    const lock = readLockFile(lockFile);
+    expect(lock.plugins[name].sha256).toBe(shaB);
+    expect(lock.plugins[name].sha256).not.toBe(shaA);
+    // `added` is preserved across re-pin per lock-writer's idempotency rule.
+    expect(lock.plugins[name].added).toBe(addedOriginal);
+  });
+
+  it("5. --link install records linked:true + source:\"link:<dir>\"", async () => {
+    const name = "lock-trust-linked";
+    const srcDir = join(caseDir, "src-linked");
+    // Build + write manifest but DON'T pack — --link installs from the dir.
+    buildFakePlugin(srcDir, join(caseDir, "unused.tgz"), name, "1.0.0", "linked");
+
+    // installFromDir is the --link handler. lock-writer's branch makes it
+    // record a synthetic entry so `plugins.lock` reflects every live plugin,
+    // including dev-linked ones (per issue #680 ask #1).
+    await installFromDir(srcDir, {});
+
+    expect(existsSync(lockFile)).toBe(true);
+    const lock = readLockFile(lockFile);
+    const entry = lock.plugins[name];
+    expect(entry).toBeDefined();
+    expect(entry.linked).toBe(true);
+    // lock-writer: `source` = `"link:<absolute-path>"`; `sha256` = hash of
+    // plugin.json bytes (present even though the dir is dev-mutable).
+    expect(entry.source).toBe(`link:${srcDir}`);
+    expect(entry.sha256).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(entry.version).toBe("1.0.0");
+  });
+
+  it("6. pin / unpin CLI round-trip updates the lock", async () => {
+    const name = "lock-trust-pin";
+    const tarball = join(caseDir, "pin.tgz");
+    const { sha256 } = buildFakePlugin(
+      join(caseDir, "src-pin"), tarball, name, "1.0.0", "pin",
+    );
+
+    await cmdPluginPin([name, tarball]);
+    const afterPin = readLockFile(lockFile);
+    expect(afterPin.plugins[name]).toBeDefined();
+    expect(afterPin.plugins[name].sha256).toBe(sha256);
+    expect(afterPin.plugins[name].version).toBe("1.0.0");
+
+    await cmdPluginUnpin([name]);
+    const afterUnpin = readLockFile(lockFile);
+    expect(afterUnpin.plugins[name]).toBeUndefined();
+  });
+});

--- a/test/isolated/bootstrap-plugins-lock.test.ts
+++ b/test/isolated/bootstrap-plugins-lock.test.ts
@@ -1,0 +1,80 @@
+/**
+ * `maw init` — plugins.lock bootstrap (#680 ask #4).
+ *
+ * Isolated (per-file subprocess) so we can set MAW_PLUGINS_LOCK before the
+ * first import chain pulls in lock.ts / init impl.ts.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+const TEST_DIR = mkdtempSync(join(tmpdir(), "maw-init-bootstrap-680-"));
+const LOCK_PATH = join(TEST_DIR, "plugins.lock");
+process.env.MAW_PLUGINS_LOCK = LOCK_PATH;
+
+let bootstrapPluginsLock: typeof import("../../src/commands/plugins/init/bootstrap-plugins-lock").bootstrapPluginsLock;
+let LOCK_SCHEMA: number;
+
+beforeAll(async () => {
+  ({ bootstrapPluginsLock } = await import("../../src/commands/plugins/init/bootstrap-plugins-lock"));
+  ({ LOCK_SCHEMA } = await import("../../src/commands/plugins/plugin/lock"));
+});
+
+afterAll(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  if (existsSync(LOCK_PATH)) rmSync(LOCK_PATH);
+});
+
+describe("bootstrapPluginsLock", () => {
+  test("creates plugins.lock with empty-but-valid shape when absent", () => {
+    expect(existsSync(LOCK_PATH)).toBe(false);
+
+    const result = bootstrapPluginsLock();
+
+    expect(result.created).toBe(true);
+    expect(result.path).toBe(LOCK_PATH);
+    expect(existsSync(LOCK_PATH)).toBe(true);
+
+    const parsed = JSON.parse(readFileSync(LOCK_PATH, "utf8"));
+    expect(parsed.schema).toBe(LOCK_SCHEMA);
+    expect(parsed.plugins).toEqual({});
+    expect(typeof parsed.updated).toBe("string");
+    expect(() => new Date(parsed.updated).toISOString()).not.toThrow();
+  });
+
+  test("readLock round-trips the bootstrapped file without errors", async () => {
+    bootstrapPluginsLock();
+    const { readLock } = await import("../../src/commands/plugins/plugin/lock");
+    const lock = readLock();
+    expect(lock.schema).toBe(LOCK_SCHEMA);
+    expect(lock.plugins).toEqual({});
+  });
+
+  test("preserves an existing lockfile — no overwrite, no merge", () => {
+    const original = {
+      schema: LOCK_SCHEMA,
+      updated: "2026-01-01T00:00:00.000Z",
+      plugins: {
+        health: {
+          version: "1.0.0",
+          sha256: "sha256:" + "a".repeat(64),
+          source: "link:/tmp/health",
+          added: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    };
+    writeFileSync(LOCK_PATH, JSON.stringify(original, null, 2) + "\n", "utf8");
+    const before = readFileSync(LOCK_PATH, "utf8");
+
+    const result = bootstrapPluginsLock();
+
+    expect(result.created).toBe(false);
+    expect(result.path).toBe(LOCK_PATH);
+    expect(readFileSync(LOCK_PATH, "utf8")).toBe(before);
+  });
+});

--- a/test/isolated/init-wizard.test.ts
+++ b/test/isolated/init-wizard.test.ts
@@ -17,6 +17,8 @@ import { tmpdir } from "os";
 
 const TEST_CONFIG_DIR = mkdtempSync(join(tmpdir(), "maw-init-455-"));
 process.env.MAW_CONFIG_DIR = TEST_CONFIG_DIR;
+// #680: init now bootstraps plugins.lock — isolate from user's real ~/.maw.
+process.env.MAW_PLUGINS_LOCK = join(TEST_CONFIG_DIR, "plugins.lock");
 
 let cmdInit: typeof import("../../src/commands/plugins/init/impl").cmdInit;
 let CONFIG_FILE: string;

--- a/test/isolated/plugin-lock.test.ts
+++ b/test/isolated/plugin-lock.test.ts
@@ -257,13 +257,12 @@ describe("pinPlugin / unpinPlugin", () => {
 // ─── install integration — the real adversarial check ───────────────────────
 
 describe("cmdPluginInstall + plugins.lock (#487)", () => {
-  test("unpinned tarball install → auto-initializes lock entry (#680 ask #1 TOFU)", async () => {
+  test("unpinned tarball install → auto-initializes lock entry (#680 TOFU)", async () => {
     const fx = buildFixture();
     expect(readLock().plugins.hello).toBeUndefined();
     const { exitCode, stdout } = await capture(() => cmdPluginInstall([fx.tarball]));
     expect(exitCode).toBeUndefined();
     expect(stdout).toContain("installed");
-    // Lock entry staged automatically on first install.
     expect(readLock().plugins.hello?.version).toBe("0.1.0");
     expect(readLock().plugins.hello?.sha256).toBe(fx.sha256);
     expect(existsSync(join(pluginsDir(), "hello", "index.js"))).toBe(true);
@@ -284,14 +283,50 @@ describe("cmdPluginInstall + plugins.lock (#487)", () => {
     // artifact differs — so the lock-hash comparison is the one that catches it.
     const legit = buildFixture({ bundleSrc: "export default () => ({ real: true });\n" });
     pinPlugin("hello", legit.tarball);
+    const pinnedSha = readLock().plugins.hello!.sha256;
 
     // Adversary's tarball: same name+version, different content, consistent self-hash.
     const evil = buildFixture({ bundleSrc: "export default () => ({ evil: true });\n" });
     const { exitCode, stderr } = await capture(() => cmdPluginInstall([evil.tarball]));
     expect(exitCode).toBe(1);
-    expect(stderr).toContain("hash mismatch");
-    expect(stderr).toContain("lockfile");
+    expect(stderr).toContain("sha256 mismatch");
+    expect(stderr).toContain("refusing to install");
+    expect(stderr).toContain("--force to override");
+    expect(stderr).toContain("--pin to re-pin");
     expect(existsSync(join(pluginsDir(), "hello"))).toBe(false);
+    // Lock entry is untouched on refusal.
+    expect(readLock().plugins.hello?.sha256).toBe(pinnedSha);
+  });
+
+  test("pinned hash mismatch + --force → proceeds + re-pins lock to new sha", async () => {
+    const legit = buildFixture({ bundleSrc: "export default () => ({ real: true });\n" });
+    pinPlugin("hello", legit.tarball);
+    const origSha = readLock().plugins.hello!.sha256;
+
+    const replacement = buildFixture({ bundleSrc: "export default () => ({ real: 2 });\n" });
+    const { exitCode, stdout } = await capture(() =>
+      cmdPluginInstall([replacement.tarball, "--force"]),
+    );
+    expect(exitCode).toBeUndefined();
+    expect(stdout).toContain("installed");
+    // Lock entry rewritten to the new tarball's sha.
+    const after = readLock().plugins.hello!;
+    expect(after.sha256).toBe(replacement.sha256);
+    expect(after.sha256).not.toBe(origSha);
+    // Plugin landed on disk.
+    expect(existsSync(join(pluginsDir(), "hello", "index.js"))).toBe(true);
+  });
+
+  test("pinned hash mismatch + --pin → proceeds + re-pins lock (same as --force)", async () => {
+    const legit = buildFixture({ bundleSrc: "export default () => ({ real: true });\n" });
+    pinPlugin("hello", legit.tarball);
+
+    const replacement = buildFixture({ bundleSrc: "export default () => ({ real: 3 });\n" });
+    const { exitCode } = await capture(() =>
+      cmdPluginInstall([replacement.tarball, "--pin"]),
+    );
+    expect(exitCode).toBeUndefined();
+    expect(readLock().plugins.hello!.sha256).toBe(replacement.sha256);
   });
 
   test("pinned version skew → refused with clear error", async () => {

--- a/test/isolated/plugin-lock.test.ts
+++ b/test/isolated/plugin-lock.test.ts
@@ -257,13 +257,16 @@ describe("pinPlugin / unpinPlugin", () => {
 // ─── install integration — the real adversarial check ───────────────────────
 
 describe("cmdPluginInstall + plugins.lock (#487)", () => {
-  test("unpinned tarball install → refused with actionable error", async () => {
+  test("unpinned tarball install → auto-initializes lock entry (#680 ask #1 TOFU)", async () => {
     const fx = buildFixture();
-    const { exitCode, stderr } = await capture(() => cmdPluginInstall([fx.tarball]));
-    expect(exitCode).toBe(1);
-    expect(stderr).toContain("not in plugins.lock");
-    expect(stderr).toContain("maw plugin pin");
-    expect(existsSync(join(pluginsDir(), "hello"))).toBe(false);
+    expect(readLock().plugins.hello).toBeUndefined();
+    const { exitCode, stdout } = await capture(() => cmdPluginInstall([fx.tarball]));
+    expect(exitCode).toBeUndefined();
+    expect(stdout).toContain("installed");
+    // Lock entry staged automatically on first install.
+    expect(readLock().plugins.hello?.version).toBe("0.1.0");
+    expect(readLock().plugins.hello?.sha256).toBe(fx.sha256);
+    expect(existsSync(join(pluginsDir(), "hello", "index.js"))).toBe(true);
   });
 
   test("pinned-then-installed happy path", async () => {


### PR DESCRIPTION
Closes #680.

Unified 4-agent team output merged into one PR:
- **init-bootstrap** (5e418d7) — `maw init` creates empty `plugins.lock` if absent
- **lock-writer** (b65916d) — `recordInstall()` persists sha256/version/source/added on every install. TOFU on first install. --link entries include `linked: true` + `source: "link:<abs>"`.
- **lock-verifier** (a1f6edd) — pre-install gate refuses sha256 mismatch; `--force`/`--pin` override, recordInstall overwrites.
- **integration-test** (99d401d) — hermetic 6-case e2e test in `test/integration/plugins-lock-trust.test.ts`
- fixup — aligned `--link` sha256 prefix (`sha256:...`) with tarball format

## Tests
- `test:isolated` — 73/73 files pass
- `test/integration/plugins-lock-trust.test.ts` — 6/6 pass
- 385/0 in `src/commands/plugins/plugin/lock.test.ts` (writer's 16 new cases + existing)

## Trust model impact
- W4 peer-search default-on (#640) unblocks: `plugins.lock` now reliably present on fresh install, meaningful for #635 rollout criteria.
- Shape A cross-oracle install (#623) now has a real trust boundary to pin-compare against.
- Closes mesh-steward-surfaced gap (ref: mawjs-plugin-oracle charter dogfood 2026-04-19).

🤖 4-agent team /team-agents with file-level ownership + cross-consult. Conflicts resolved manually by lead.