### PR TITLE
fix(wake-all): fail-soft per-session on remote ssh failure

### DIFF
--- a/src/commands/shared/fleet-wake-failsoft.ts
+++ b/src/commands/shared/fleet-wake-failsoft.ts
@@ -1,0 +1,71 @@
+/**
+ * fleet-wake-failsoft.ts — pure helpers for `maw wake all`'s fail-soft loop.
+ *
+ * Extracted so unit tests can import these without dragging in the full
+ * cmdWakeAll chain (tmux transport, wake-session, sdk, etc.) and without
+ * colliding with sibling test files that mock `../../sdk` narrowly.
+ *
+ * See: fleet-wake.ts (consumer) and test/fleet-wake-ssh-failsoft.test.ts.
+ */
+import { HostExecError } from "../../core/transport/ssh";
+
+/** First line of an unreachable-host error, for compact display. */
+export function firstStderrLine(e: unknown): string {
+  if (e instanceof HostExecError) {
+    return e.underlying.message.split("\n")[0].trim() || `exit ${e.exitCode ?? "?"}`;
+  }
+  const msg = e instanceof Error ? e.message : String(e);
+  return msg.split("\n")[0].trim();
+}
+
+/** True when a hostExec failure is an ssh transport failure (DNS / refused / timeout / non-zero). */
+export function isSshTransportError(e: unknown): boolean {
+  return e instanceof HostExecError && e.transport === "ssh";
+}
+
+export interface WakeStep {
+  sessName: string;
+  /** Simulates the per-session tmux work. Throws to signal failure. */
+  run: () => Promise<void>;
+}
+
+export interface WakeLoopResult {
+  sessCount: number;
+  remoteSkipped: number;
+  warnings: string[];
+}
+
+/**
+ * Fail-soft session-wake loop.
+ *
+ * Given an ordered list of wake steps, invoke each. On HostExecError with
+ * transport === "ssh", capture a compact warning string and skip the session
+ * without aborting the loop. Non-ssh errors propagate (don't silently swallow
+ * bugs). Returns counters the caller uses for the summary line.
+ */
+export async function runWakeLoopFailSoft(steps: WakeStep[]): Promise<WakeLoopResult> {
+  let sessCount = 0;
+  let remoteSkipped = 0;
+  const warnings: string[] = [];
+
+  for (let si = 0; si < steps.length; si++) {
+    const step = steps[si];
+    const progress = `[${si + 1}/${steps.length}]`;
+    try {
+      await step.run();
+      sessCount++;
+    } catch (e) {
+      if (isSshTransportError(e)) {
+        const err = e as HostExecError;
+        warnings.push(
+          `${progress} ${step.sessName} — [ssh:${err.target}] unreachable: ${firstStderrLine(err)}`
+        );
+        remoteSkipped++;
+        continue;
+      }
+      throw e;
+    }
+  }
+
+  return { sessCount, remoteSkipped, warnings };
+}

--- a/src/commands/shared/fleet-wake.ts
+++ b/src/commands/shared/fleet-wake.ts
@@ -4,6 +4,15 @@ import { loadConfig, buildCommand, getEnvVars } from "../../config";
 import { ensureSessionRunning } from "./wake";
 import { loadFleet } from "./fleet-load";
 import { respawnMissingWorktrees, resumeActiveItems } from "./fleet-resume";
+import {
+  isSshTransportError,
+  runWakeLoopFailSoft,
+  type WakeStep,
+} from "./fleet-wake-failsoft";
+
+// Re-export for back-compat with existing callers/tests.
+export { firstStderrLine, isSshTransportError, runWakeLoopFailSoft } from "./fleet-wake-failsoft";
+export type { WakeStep, WakeLoopResult } from "./fleet-wake-failsoft";
 
 export async function cmdSleep() {
   const sessions = loadFleet();
@@ -44,56 +53,62 @@ export async function cmdWakeAll(opts: { kill?: boolean; all?: boolean; resume?:
   const skipMsg = skipped > 0 ? `, ${skipped} dormant skipped` : "";
   console.log(`\n  \x1b[36mWaking fleet...\x1b[0m  (${sessions.length} sessions${disabled ? `, ${disabled} disabled` : ""}${skipMsg})\n`);
 
-  let sessCount = 0;
   let winCount = 0;
+  let sessCount = 0;
 
-  for (let si = 0; si < sessions.length; si++) {
-    const sess = sessions[si];
-    const progress = `[${si + 1}/${sessions.length}]`;
+  const steps: WakeStep[] = sessions.map((sess, si) => ({
+    sessName: sess.name,
+    run: async () => {
+      const progress = `[${si + 1}/${sessions.length}]`;
 
-    // Check if session already exists
-    if (await tmux.hasSession(sess.name)) {
-      console.log(`  \x1b[33m●\x1b[0m ${progress} ${sess.name} — already awake`);
-      continue;
-    }
-
-    process.stdout.write(`  \x1b[90m⏳\x1b[0m ${progress} ${sess.name}...`);
-
-    // Create session with first window
-    const first = sess.windows[0];
-    const firstPath = `${loadConfig().ghqRoot}/${first.repo}`;
-    await tmux.newSession(sess.name, { window: first.name, cwd: firstPath });
-    // Set env vars on session (not visible in tmux output)
-    for (const [key, val] of Object.entries(getEnvVars())) {
-      await tmux.setEnvironment(sess.name, key, val);
-    }
-
-    if (!sess.skip_command) {
-      await new Promise(r => setTimeout(r, 300));
-      try { await tmux.sendText(`${sess.name}:${first.name}`, buildCommand(first.name)); } catch { /* ok */ }
-    }
-    winCount++;
-
-    // Add remaining windows
-    for (let i = 1; i < sess.windows.length; i++) {
-      const win = sess.windows[i];
-      const winPath = `${loadConfig().ghqRoot}/${win.repo}`;
-      try {
-        await tmux.newWindow(sess.name, win.name, { cwd: winPath });
-        if (!sess.skip_command) {
-          await new Promise(r => setTimeout(r, 300));
-          await tmux.sendText(`${sess.name}:${win.name}`, buildCommand(win.name));
-        }
-        winCount++;
-      } catch {
-        // Window creation might fail (duplicate name, bad path)
+      if (await tmux.hasSession(sess.name)) {
+        console.log(`  \x1b[33m●\x1b[0m ${progress} ${sess.name} — already awake`);
+        return;
       }
-    }
 
-    // Select first window
-    await tmux.selectWindow(`${sess.name}:1`);
-    sessCount++;
-    console.log(` \x1b[32m✓\x1b[0m ${sess.windows.length} windows`);
+      process.stdout.write(`  \x1b[90m⏳\x1b[0m ${progress} ${sess.name}...`);
+
+      const first = sess.windows[0];
+      const firstPath = `${loadConfig().ghqRoot}/${first.repo}`;
+      await tmux.newSession(sess.name, { window: first.name, cwd: firstPath });
+      for (const [key, val] of Object.entries(getEnvVars())) {
+        await tmux.setEnvironment(sess.name, key, val);
+      }
+
+      if (!sess.skip_command) {
+        await new Promise(r => setTimeout(r, 300));
+        try { await tmux.sendText(`${sess.name}:${first.name}`, buildCommand(first.name)); } catch { /* ok */ }
+      }
+      winCount++;
+
+      for (let i = 1; i < sess.windows.length; i++) {
+        const win = sess.windows[i];
+        const winPath = `${loadConfig().ghqRoot}/${win.repo}`;
+        try {
+          await tmux.newWindow(sess.name, win.name, { cwd: winPath });
+          if (!sess.skip_command) {
+            await new Promise(r => setTimeout(r, 300));
+            await tmux.sendText(`${sess.name}:${win.name}`, buildCommand(win.name));
+          }
+          winCount++;
+        } catch (e) {
+          // Window creation may fail (duplicate name, bad path). Propagate
+          // ssh transport errors so the outer loop records a remote-skip.
+          if (isSshTransportError(e)) throw e;
+        }
+      }
+
+      await tmux.selectWindow(`${sess.name}:1`);
+      sessCount++;
+      console.log(` \x1b[32m✓\x1b[0m ${sess.windows.length} windows`);
+    },
+  }));
+
+  const { remoteSkipped, warnings } = await runWakeLoopFailSoft(steps);
+  for (const w of warnings) {
+    // Clear any in-progress "⏳ [n/m] name..." line before emitting.
+    process.stdout.write("\r\x1b[2K");
+    console.log(`  \x1b[33m⚠\x1b[0m ${w}`);
   }
 
   // Scan disk for worktrees not covered by fleet configs and spawn them
@@ -107,7 +122,12 @@ export async function cmdWakeAll(opts: { kill?: boolean; all?: boolean; resume?:
     let totalRetried = 0;
     for (const sess of sessions) {
       if (sess.skip_command) continue;
-      totalRetried += await ensureSessionRunning(sess.name);
+      try {
+        totalRetried += await ensureSessionRunning(sess.name);
+      } catch (e) {
+        if (isSshTransportError(e)) continue; // already counted as remote-skipped
+        throw e;
+      }
     }
     if (totalRetried > 0) {
       console.log(`  \x1b[33m${totalRetried} window(s) retried.\x1b[0m`);
@@ -119,13 +139,19 @@ export async function cmdWakeAll(opts: { kill?: boolean; all?: boolean; resume?:
   // Restore saved tab order (from previous sleep)
   let totalReordered = 0;
   for (const sess of sessions) {
-    totalReordered += await restoreTabOrder(sess.name);
+    try {
+      totalReordered += await restoreTabOrder(sess.name);
+    } catch (e) {
+      if (isSshTransportError(e)) continue; // already counted as remote-skipped
+      throw e;
+    }
   }
   if (totalReordered > 0) {
     console.log(`  \x1b[36m↻ ${totalReordered} window(s) reordered to saved positions.\x1b[0m`);
   }
 
-  console.log(`\n  \x1b[32m${sessCount} sessions, ${winCount} windows woke up.\x1b[0m\n`);
+  const skippedSuffix = remoteSkipped > 0 ? ` \x1b[33m${remoteSkipped} remote skipped.\x1b[0m` : "";
+  console.log(`\n  \x1b[32m${sessCount} sessions, ${winCount} windows woke up.\x1b[0m${skippedSuffix}\n`);
 
   if (opts.resume) {
     console.log("  \x1b[36mResuming active board items...\x1b[0m\n");

--- a/test/fleet-wake-ssh-failsoft.test.ts
+++ b/test/fleet-wake-ssh-failsoft.test.ts
@@ -1,0 +1,170 @@
+/**
+ * fleet-wake-ssh-failsoft.test.ts — Nat's repro (oracle-world → white DNS)
+ *
+ * Before this fix, `maw wake all` would print a single session entry, emit the
+ * ssh DNS error, and silently stop — the whole loop halted because the first
+ * remote-routed tmux call's rejection wasn't caught.
+ *
+ * The fix adds a pure helper `runWakeLoopFailSoft()` that:
+ *   - catches HostExecError with transport === "ssh" per-step,
+ *   - emits a compact "⚠ [N/M] <name> — [ssh:<host>] unreachable: …" warning,
+ *   - increments a remoteSkipped counter,
+ *   - and continues the loop.
+ *
+ * These tests pin that logic without mocking the sdk/tmux graph — which is
+ * deliberately fragile across test files (mock.module is process-global;
+ * see #375). A separate integration stack exercises cmdWakeAll end-to-end.
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  firstStderrLine,
+  isSshTransportError,
+  runWakeLoopFailSoft,
+  type WakeStep,
+} from "../src/commands/shared/fleet-wake-failsoft";
+import { HostExecError } from "../src/core/transport/ssh";
+
+// ─── isSshTransportError ────────────────────────────────────────────────────
+
+describe("isSshTransportError", () => {
+  test("true for HostExecError with transport=ssh", () => {
+    const e = new HostExecError("white", "ssh", new Error("no route"), 255);
+    expect(isSshTransportError(e)).toBe(true);
+  });
+
+  test("false for HostExecError with transport=local", () => {
+    const e = new HostExecError("local", "local", new Error("command not found"), 127);
+    expect(isSshTransportError(e)).toBe(false);
+  });
+
+  test("false for plain Error (unrelated failure)", () => {
+    expect(isSshTransportError(new Error("generic boom"))).toBe(false);
+  });
+
+  test("false for non-Error values", () => {
+    expect(isSshTransportError("nope")).toBe(false);
+    expect(isSshTransportError(undefined)).toBe(false);
+    expect(isSshTransportError(null)).toBe(false);
+  });
+});
+
+// ─── firstStderrLine ────────────────────────────────────────────────────────
+
+describe("firstStderrLine", () => {
+  test("HostExecError: returns first line of stderr message", () => {
+    const stderr = "ssh: Could not resolve hostname white: Temporary failure in name resolution\nextra line\nsecond";
+    const e = new HostExecError("white", "ssh", new Error(stderr), 255);
+    expect(firstStderrLine(e)).toBe("ssh: Could not resolve hostname white: Temporary failure in name resolution");
+  });
+
+  test("HostExecError with empty stderr falls back to exit code", () => {
+    const e = new HostExecError("white", "ssh", new Error(""), 42);
+    expect(firstStderrLine(e)).toBe("exit 42");
+  });
+
+  test("generic Error: first line only", () => {
+    expect(firstStderrLine(new Error("boom\nstacktrace"))).toBe("boom");
+  });
+
+  test("non-Error value: stringified first line", () => {
+    expect(firstStderrLine("oops\nmore")).toBe("oops");
+  });
+});
+
+// ─── runWakeLoopFailSoft ────────────────────────────────────────────────────
+
+describe("runWakeLoopFailSoft — fail-soft on ssh transport failure", () => {
+  test("Nat's repro: ssh DNS failure in 1st session, loop finishes 2nd", async () => {
+    const calls: string[] = [];
+    const steps: WakeStep[] = [
+      {
+        sessName: "100-boonkeeper",
+        run: async () => {
+          calls.push("100-boonkeeper");
+          throw new HostExecError(
+            "white",
+            "ssh",
+            new Error("ssh: Could not resolve hostname white: Temporary failure in name resolution"),
+            255,
+          );
+        },
+      },
+      {
+        sessName: "200-localfriend",
+        run: async () => { calls.push("200-localfriend"); },
+      },
+    ];
+
+    const result = await runWakeLoopFailSoft(steps);
+
+    // Loop did NOT halt — second step ran
+    expect(calls).toEqual(["100-boonkeeper", "200-localfriend"]);
+
+    // Counters reflect 1 success + 1 remote-skip
+    expect(result.sessCount).toBe(1);
+    expect(result.remoteSkipped).toBe(1);
+
+    // Warning format matches the spec in the task brief
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("[1/2]");
+    expect(result.warnings[0]).toContain("100-boonkeeper");
+    expect(result.warnings[0]).toContain("[ssh:white]");
+    expect(result.warnings[0]).toContain("unreachable:");
+    expect(result.warnings[0]).toContain("Could not resolve hostname white");
+  });
+
+  test("all sessions succeed → no warnings, no remote-skipped", async () => {
+    const steps: WakeStep[] = [
+      { sessName: "a", run: async () => {} },
+      { sessName: "b", run: async () => {} },
+    ];
+    const result = await runWakeLoopFailSoft(steps);
+    expect(result.sessCount).toBe(2);
+    expect(result.remoteSkipped).toBe(0);
+    expect(result.warnings).toEqual([]);
+  });
+
+  test("all sessions fail via ssh → all skipped, none succeed, loop still completes", async () => {
+    const steps: WakeStep[] = ["a", "b", "c"].map(name => ({
+      sessName: name,
+      run: async () => {
+        throw new HostExecError(name, "ssh", new Error("no route to host"), 255);
+      },
+    }));
+
+    const result = await runWakeLoopFailSoft(steps);
+    expect(result.sessCount).toBe(0);
+    expect(result.remoteSkipped).toBe(3);
+    expect(result.warnings).toHaveLength(3);
+  });
+
+  test("non-ssh errors propagate (regression guard — don't silently swallow bugs)", async () => {
+    const steps: WakeStep[] = [
+      {
+        sessName: "broken",
+        run: async () => { throw new Error("something else entirely"); },
+      },
+    ];
+    await expect(runWakeLoopFailSoft(steps)).rejects.toThrow("something else entirely");
+  });
+
+  test("HostExecError with transport=local propagates (not an ssh skip)", async () => {
+    const steps: WakeStep[] = [
+      {
+        sessName: "local-broken",
+        run: async () => {
+          throw new HostExecError("local", "local", new Error("tmux not installed"), 127);
+        },
+      },
+    ];
+    await expect(runWakeLoopFailSoft(steps)).rejects.toThrow();
+  });
+
+  test("empty steps list → zero counters, no throw", async () => {
+    const result = await runWakeLoopFailSoft([]);
+    expect(result.sessCount).toBe(0);
+    expect(result.remoteSkipped).toBe(0);
+    expect(result.warnings).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Repro (Nat, oracle-world VPS)

```
neo@oracle-world:~$ maw wake all
  Waking fleet...  (15 sessions)
  ⏳ [1/15] 100-boonkeeper...[ssh:white] ssh: Could not resolve hostname white: Temporary failure in name resolution
neo@oracle-world:~$
```

One unreachable remote = the entire wake loop halts after the first rejection. 14 other sessions never come online. VPS had no \`white\` in /etc/hosts, so the per-session ssh call fails with DNS → rejection → unhandled → loop exits.

## Root cause (code path)

\`src/commands/shared/fleet-wake.ts::cmdWakeAll\` runs a per-session block that calls \`tmux.hasSession\` / \`newSession\` / \`newWindow\` etc. When \`config.host\` (or \`MAW_HOST\`) is set to a remote host, \`src/core/transport/ssh.ts::hostExec\` routes every call through \`ssh\` and throws \`HostExecError\` with \`transport: \"ssh\"\` on failure. The original loop had no per-session catch → first rejection bubbles out of the \`for\` loop.

## Fix

- New \`src/commands/shared/fleet-wake-failsoft.ts\` with a pure \`runWakeLoopFailSoft()\` helper:
  - catches \`HostExecError\` with \`transport === \"ssh\"\` per-step,
  - records a compact \"⚠ [N/M] <name> — [ssh:<host>] unreachable: <first stderr line>\" warning,
  - increments \`remoteSkipped\`,
  - and continues the loop.
- \`cmdWakeAll\` now maps the per-session block into \`WakeStep\`s and drives it through \`runWakeLoopFailSoft\`. \`ensureSessionRunning\` and \`restoreTabOrder\` sub-loops get the same \`isSshTransportError\` guard.
- Summary line extends:
  \`\`\`
  X sessions, Y windows woke up. Z remote skipped.
  \`\`\`
- Non-ssh errors still propagate (regression guard — pure \`Error\`, \`HostExecError\` with \`transport: \"local\"\` both rethrow).

The helper lives in its own module so unit tests can import it without dragging in the sdk/tmux/wake-session import chain, which is brittle across test files in bun's process-global \`mock.module\` registry (see #375).

## Tests (14 new, all pass)

- \`isSshTransportError\`: HostExecError ssh → true; local → false; plain Error → false; non-Error → false.
- \`firstStderrLine\`: first-line extraction; empty stderr → \`exit N\`; generic Error; non-Error value.
- \`runWakeLoopFailSoft\`:
  - Nat's repro: first session ssh-rejects with exact DNS message, second still runs; counters + warning content asserted.
  - Happy path: no warnings, no remote-skipped.
  - All-fail: 3 ssh-rejections → 0 succeed, 3 skipped, loop completes.
  - Non-ssh error propagates (regression guard).
  - HostExecError with transport=local propagates.
  - Empty steps → zero counters, no throw.

Full suite: \`bun run test\` → **1300 pass, 7 skip, 0 fail**.

## Test plan

- [x] Unit tests pass (14 new + 1300 existing).
- [x] Verified on-disk that \`[ssh:<host>]\` is the HostExecError format (\`src/core/transport/ssh.ts:17\`).
- [x] Verified loop continues to subsequent sessions in the first test.
- [ ] Smoke test on oracle-world once merged: run \`maw wake all\` from VPS with \`config.host=white\`, confirm \"N remote skipped\" in summary and no halt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)