### PR TITLE
bump: v26.4.19-alpha.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.18-alpha.28",
+  "version": "26.4.19-alpha.15",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
First alpha of Apr 19 — current calendar day + hour 15.

Bundles since v26.4.18-alpha.28:
- #687 fix(wake): fleet-pinned repo skips 24-org scan (#686)
- #684 fix(wake-all): fail-soft per-session on remote ssh failure
- #683 ci: docker-compose local reproducer for GH Actions env
- #682 fix(wake): scan prompt tolerates leftover newline
- #680 feat(plugins.lock): sha256 trust flow (4 asks + integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)