### PR TITLE
fix(view): auto-wake fleet-known oracles (skip y/N prompt)

### DIFF
--- a/src/commands/plugins/view/impl.ts
+++ b/src/commands/plugins/view/impl.ts
@@ -100,9 +100,23 @@ export async function cmdView(
   if (!sessionName) {
     // #549 — offer to wake the missing target before erroring out.
     // Decision matrix encoded in decideWakePrompt; see WakePromptDecision.
+    //
+    // Fleet-known oracles skip the y/N prompt — if the user typed `maw a <x>`
+    // and fleet configs pin <x>, we're confident this isn't a typo. Typos
+    // (unknown names) still hit the prompt as a guard against accidental wake.
+    let autoWake = extraOpts.wake;
+    if (!autoWake && !extraOpts.noWake) {
+      try {
+        const { resolveFleetSession } = await import("../../shared/wake-resolve");
+        if (resolveFleetSession(agent)) {
+          console.log(`\x1b[36m⚡\x1b[0m '${agent}' is fleet-known — auto-wake`);
+          autoWake = true;
+        }
+      } catch { /* fleet check best-effort — fall through to prompt */ }
+    }
     const decision = decideWakePrompt({
       isTTY: Boolean(process.stdin.isTTY),
-      wake: extraOpts.wake,
+      wake: autoWake,
       noWake: extraOpts.noWake,
     });
 


### PR DESCRIPTION
## Summary
- \`maw a <oracle>\` was prompting \`Wake it now? [y/N]\` even for fleet-pinned oracles. Typing the full name of a known oracle is enough evidence the user meant to wake.
- Fleet-known → auto-wake, logs \`⚡ '<name>' is fleet-known — auto-wake\`.
- Unknown names still hit the y/N prompt as typo protection.
- \`--no-wake\` still works (skip), \`--wake\` still works (force).

## Repro (before)
\`\`\`
❯ maw a mawjs
? Oracle 'mawjs' is not running. Wake it now? [y/N]:    ← friction
\`\`\`

## After
\`\`\`
❯ maw a mawjs
⚡ 'mawjs' is fleet-known — auto-wake
⚡ waking 'mawjs'...
\`\`\`

## Test plan
- [x] \`bun run test\` — 1305 pass / 0 fail / 7 skip
- [ ] CI green (docker mirror from #683)

🤖 Generated with [Claude Code](https://claude.com/claude-code)