### PR TITLE
test+fix(ecosystem): bun test drift guard + launcher pre-flight

### DIFF
--- a/scripts/maw-boot.launcher.cjs
+++ b/scripts/maw-boot.launcher.cjs
@@ -48,6 +48,16 @@ const BUN_BIN = resolveBun();
 const CLI = path.join(__dirname, "..", "src", "cli.ts");
 const forwardedArgs = process.argv.slice(2);
 
+// Pre-flight: fail loud if the CLI entry was renamed/moved since last deploy.
+// Without this, a missing entry produces an opaque bun error buried in PM2
+// logs and crash-loops against `max_restarts` — the exact 04-17 failure mode.
+if (!fs.existsSync(CLI)) {
+  console.error("[maw-boot launcher] entry not found: " + CLI);
+  console.error("[maw-boot launcher] ecosystem drift — src/cli.ts was renamed or deleted.");
+  console.error("[maw-boot launcher] run: bash scripts/check-ecosystem.sh");
+  process.exit(2);
+}
+
 const child = spawn(BUN_BIN, ["run", CLI, ...forwardedArgs], {
   stdio: "inherit",
   // shell:true on Windows is required to execute .cmd files.

--- a/test/ecosystem-drift.test.ts
+++ b/test/ecosystem-drift.test.ts
@@ -64,7 +64,10 @@ describe("ecosystem.config.cjs — drift guard", () => {
       const src = readFileSync(launcherAbs, "utf8");
 
       // Look for `path.join(__dirname, "..", "src", "foo.ts")` style refs.
-      const joinRe = /path\.join\(\s*__dirname\s*,\s*((?:['"][^'"]+['"]\s*,?\s*)+)\)/g;
+      // Two-pass parse to avoid nested quantifiers (CodeQL ReDoS):
+      //   1. Capture the arg list with a single negated class ([^)]+).
+      //   2. Extract quoted strings from the arg list separately.
+      const joinRe = /path\.join\(\s*__dirname\s*,\s*([^)]+)\)/g;
       const matches = [...src.matchAll(joinRe)];
       for (const m of matches) {
         const parts = [...m[1].matchAll(/['"]([^'"]+)['"]/g)].map((x) => x[1]);

--- a/test/ecosystem-drift.test.ts
+++ b/test/ecosystem-drift.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Ecosystem drift guard — bun test counterpart to scripts/check-ecosystem.sh.
+ *
+ * Runs in the standard `bun run test` suite so local dev catches drift
+ * before CI. Complements the shell script + GH Actions workflow added in
+ * #576 by failing fast in the normal test loop.
+ *
+ * Incident this guards against (2026-04-17):
+ *   src/server.ts was renamed to src/core/server.ts but ecosystem.config.cjs
+ *   still referenced the old path → PM2 crash-loop.
+ *
+ *   Additionally, scripts/maw-boot.launcher.cjs hard-codes the CLI entry at
+ *   ../src/cli.ts — if that file is renamed, the launcher silently fails in
+ *   production. This test asserts that path too.
+ */
+import { describe, test, expect } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join, dirname, resolve as pathResolve } from "node:path";
+
+const REPO_ROOT = pathResolve(__dirname, "..");
+const ECOSYSTEM = join(REPO_ROOT, "ecosystem.config.cjs");
+
+describe("ecosystem.config.cjs — drift guard", () => {
+  test("config file is present at repo root", () => {
+    expect(existsSync(ECOSYSTEM)).toBe(true);
+  });
+
+  test("every apps[].script points to an existing file", () => {
+    const config = require(ECOSYSTEM) as { apps: Array<{ name: string; script: string }> };
+    expect(Array.isArray(config.apps)).toBe(true);
+    expect(config.apps.length).toBeGreaterThan(0);
+
+    const missing: Array<{ name: string; script: string }> = [];
+    for (const app of config.apps) {
+      const abs = join(REPO_ROOT, app.script);
+      if (!existsSync(abs)) missing.push({ name: app.name, script: app.script });
+    }
+
+    if (missing.length > 0) {
+      const msg = missing
+        .map((m) => `  • ${m.name}: ${m.script} (not found)`)
+        .join("\n");
+      throw new Error(
+        `ecosystem.config.cjs references missing scripts:\n${msg}\n\n` +
+          `Likely a refactor renamed the file without updating the PM2 config. ` +
+          `Run: bash scripts/check-ecosystem.sh for suggested paths.`,
+      );
+    }
+  });
+
+  test(".cjs launcher shims resolve their target entry", () => {
+    // Launcher shims (e.g. scripts/maw-boot.launcher.cjs) hard-code the
+    // real entry file they spawn. Static-parse their `path.join(..., "src", "cli.ts")`
+    // style references and assert each resolves. Catches the class of failure
+    // where a refactor moves the entry but the shim still points at the old one.
+    const config = require(ECOSYSTEM) as { apps: Array<{ name: string; script: string }> };
+    const launchers = config.apps
+      .map((a) => a.script)
+      .filter((s) => s.endsWith(".launcher.cjs") || s.endsWith(".cjs"));
+
+    for (const launcherRel of launchers) {
+      const launcherAbs = join(REPO_ROOT, launcherRel);
+      const launcherDir = dirname(launcherAbs);
+      const src = readFileSync(launcherAbs, "utf8");
+
+      // Look for `path.join(__dirname, "..", "src", "foo.ts")` style refs.
+      const joinRe = /path\.join\(\s*__dirname\s*,\s*((?:['"][^'"]+['"]\s*,?\s*)+)\)/g;
+      const matches = [...src.matchAll(joinRe)];
+      for (const m of matches) {
+        const parts = [...m[1].matchAll(/['"]([^'"]+)['"]/g)].map((x) => x[1]);
+        if (parts.length === 0) continue;
+        const target = pathResolve(launcherDir, ...parts);
+        // Only assert paths that look like source files (have an extension).
+        if (/\.(ts|js|cjs|mjs)$/.test(target)) {
+          if (!existsSync(target)) {
+            throw new Error(
+              `${launcherRel} references missing target: ${target}\n` +
+                `Launcher shims must be updated in lockstep with source refactors.`,
+            );
+          }
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Complements the shell drift-guard from #576 with two source-layer assertions that catch ecosystem drift **before** it reaches production — without changing anything #576 already does.

- **`test/ecosystem-drift.test.ts`** — new bun test (3 cases) runs in `bun run test`, validates every `apps[].script` in `ecosystem.config.cjs` resolves, and statically parses `.launcher.cjs` shims to verify their `path.join(__dirname, …, "*.ts")` targets exist.
- **`scripts/maw-boot.launcher.cjs`** pre-flight check — fails loud with exit code 2 and an "ecosystem drift" diagnostic instead of letting PM2 crash-loop silently against `max_restarts` when `src/cli.ts` is missing. Directly addresses the 04-17 silent-degradation failure mode.

## Context

The 2026-04-17 incident (`src/server.ts` renamed to `src/core/server.ts` without updating `ecosystem.config.cjs`) was caught after the fact by the #576 CI drift-guard. This PR adds two layers closer to the developer:

| Layer | Existing | This PR |
|-------|----------|---------|
| CI shell script (`scripts/check-ecosystem.sh`) | ✅ #576 | — |
| GH Actions workflow | ✅ #576 | — |
| `bun run test` (local + CI normal test loop) | — | ✅ new |
| Launcher pre-flight at PM2 spawn | — | ✅ new |

So drift is caught progressively earlier: during `bun run test` before push → if that misses, shell script in CI → if CI is skipped, the launcher fails fast at PM2 spawn instead of silent crash-loop.

## Verification

### Unit
```
$ bun test test/ecosystem-drift.test.ts
 3 pass / 0 fail / 3 expect() calls — 38ms
```

Full suite: 1304 pass / 7 skip / 4 fail — the 4 failures are pre-existing on `main` (2 × `buildCommand` uid=0 [#685], 2 × pair-handshake timeout), unrelated to this PR.

### Launcher pre-flight
Simulated the 04-17 incident by renaming `src/cli.ts` and invoking the launcher directly:
```
$ node scripts/maw-boot.launcher.cjs
[maw-boot launcher] entry not found: /…/src/cli.ts
[maw-boot launcher] ecosystem drift — src/cli.ts was renamed or deleted.
[maw-boot launcher] run: bash scripts/check-ecosystem.sh
exit: 2
```

Without this change, the same scenario produced an opaque bun error buried under repeated PM2 restarts up to `max_restarts: 5`.

## Test plan

- [ ] `bun run test` green on CI
- [ ] `scripts/check-ecosystem.sh` still passes (unchanged)
- [ ] `.github/workflows/ecosystem-drift.yml` still passes (unchanged)
- [ ] Manual: rename `src/cli.ts` briefly, confirm launcher exits 2 with diagnostic — then restore

## Related

- Upstream drift-guard: #576
- 04-17 incident RCA: posted to sibling Pulse Oracle, confirmed root cause = same class as #576
- #685 (separate issue I filed earlier today, independent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)