### PR TITLE
test(command-simplified): mock process.getuid to stabilize under root (#685)

### DIFF
--- a/test/command-simplified.test.ts
+++ b/test/command-simplified.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock, beforeEach } from "bun:test";
+import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
 
 // Drives loadConfig() via a per-test mutable fixture so we can exercise the
 // post-#541 buildCommand branches (bare cmd, --continue fallback, pattern
@@ -29,6 +29,11 @@ mock.module("../src/config/load", () => ({
 
 const { buildCommand, buildCommandInDir } = await import("../src/config/command");
 
+// buildCommand strips --dangerously-skip-permissions when process.getuid() === 0
+// (root-stripping from #181). Tests below assert the flag is preserved in the
+// fallback, so pin the uid to a non-root value regardless of the host user.
+// Fixes #685.
+const origGetuid = process.getuid;
 beforeEach(() => {
   fakeConfig = {
     host: "local",
@@ -42,6 +47,10 @@ beforeEach(() => {
     node: "local",
   };
   fakeSessionIds = {};
+  (process as any).getuid = () => 1000;
+});
+afterEach(() => {
+  (process as any).getuid = origGetuid;
 });
 
 describe("buildCommand — post-#541 contract", () => {


### PR DESCRIPTION
## Summary

Closes #685.

`buildCommand()` at `src/config/command.ts:15-17` strips `--dangerously-skip-permissions` when `process.getuid() === 0` (root-stripping from #181). The tests in `command-simplified.test.ts` assert the `||` fallback preserves `--dangerously-skip-permissions`, but did not pin the uid — so when the suite runs as root, 2/8 tests fail deterministically.

Fix: pin `process.getuid` to `1000` in `beforeEach`, restore in `afterEach`. This is Option 1 from the issue's suggested fixes — least invasive, matches the spirit of the existing `mock.module("../src/config/load", …)` setup in the same file.

## Before / After (under uid=0)

```
Before:  6 pass, 2 fail   — 2 contract tests fail with stripped flag
After:   8 pass, 0 fail   — all tests deterministic regardless of host uid
```

Full suite on `main` before this PR: 1301 pass / 4 fail (2 command-simplified + 2 pair-handshake timeouts). With this PR: 1303 pass / 2 fail (only the pre-existing pair-handshake timeouts remain, unrelated).

## Why not just assert the stripped form?

That would make the tests non-portable in the other direction (fail under non-root). Mocking is the only approach that makes the tests deterministic for both host users.

## Why not split the root-stripping?

That's a bigger refactor to `src/config/command.ts` just to aid testability. The mock is a 3-line change with no source impact — smaller blast radius.

## Test plan

- [ ] `bun test test/command-simplified.test.ts` green under `uid=0`
- [ ] `bun test test/command-simplified.test.ts` green under regular user
- [ ] `bun run test` full suite — no new failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)