### PR TITLE
fix(test): use RFC 6761 `.invalid` TLD to avoid DNS-timeout flake (#692)

### DIFF
--- a/test/pair-handshake.test.ts
+++ b/test/pair-handshake.test.ts
@@ -84,7 +84,7 @@ describe("pair API — handshake + consume", () => {
     const { status, json } = await call(`/pair/${code}`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ node: "mba", url: "http://mba.local:3456" }),
+      body: JSON.stringify({ node: "mba", url: "http://fake.invalid:3456" }),
     });
     expect(status).toBe(200);
     expect(json.ok).toBe(true);
@@ -94,7 +94,7 @@ describe("pair API — handshake + consume", () => {
 
   it("replay: second POST /pair/:code returns 410 consumed", async () => {
     const code = await newCode();
-    const body = JSON.stringify({ node: "mba", url: "http://mba.local:3456" });
+    const body = JSON.stringify({ node: "mba", url: "http://fake.invalid:3456" });
     const first = await call(`/pair/${code}`, { method: "POST", headers: { "content-type": "application/json" }, body });
     expect(first.status).toBe(200);
     const second = await call(`/pair/${code}`, { method: "POST", headers: { "content-type": "application/json" }, body });
@@ -117,7 +117,7 @@ describe("pair API — handshake + consume", () => {
     const { status, json } = await call(`/pair/XXX`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ node: "mba", url: "http://mba.local:3456" }),
+      body: JSON.stringify({ node: "mba", url: "http://fake.invalid:3456" }),
     });
     expect(status).toBe(400);
     expect(json.error).toBe("invalid_shape");
@@ -130,7 +130,7 @@ describe("pair API — handshake + consume", () => {
     await call(`/pair/${code}`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ node: "mba", url: "http://mba.local:3456" }),
+      body: JSON.stringify({ node: "mba", url: "http://fake.invalid:3456" }),
     });
     const after = await call(`/pair/${code}/status`);
     expect(after.json.consumed).toBe(true);
@@ -142,11 +142,11 @@ describe("pair API — handshake + consume", () => {
     await call(`/pair/${code}`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ node: "mba", url: "http://mba.local:3456" }),
+      body: JSON.stringify({ node: "mba", url: "http://fake.invalid:3456" }),
     });
     const { loadPeers } = await import("../src/commands/plugins/peers/store");
     const peers = loadPeers();
-    expect(peers.peers["mba"]?.url).toBe("http://mba.local:3456");
+    expect(peers.peers["mba"]?.url).toBe("http://fake.invalid:3456");
     expect(peers.peers["mba"]?.node).toBe("mba");
   });
 });


### PR DESCRIPTION
## Summary

Closes #692 — pair-handshake tests timeout at 5000ms on hosts without `mba.local` mDNS resolution.

Replace `http://mba.local:3456` with `http://fake.invalid:3456` in 6 test bodies. The `.invalid` TLD is RFC 6761-reserved and must return NXDOMAIN instantly, so the `fetch()` inside `cmdAdd` → `probePeer` fails in ~19ms instead of racing bun's default 5000ms test budget.

## Why this fix (option 2 from the issue)

- Smallest diff: 6 insertions, 6 deletions.
- No mock plumbing; tests still exercise the real `cmdAdd` error path.
- The test's intent — API shape, consumption, peer persistence — is unchanged. The host was never meant to be reachable.

## Verification

```
Before: 1301 pass, 4 fail (2 × #692 + 2 × #685)
After:  1308 pass, 7 skip, 0 fail — full suite 10.51s
```

Local: Linux 6.8.0-106-generic, bun 1.3.11, no avahi/mDNS responder.

```bash
$ time bun -e 'try { await fetch("http://fake.invalid:3456/info"); } catch(e) { console.log(e.code) }'
ConnectionRefused
real    0m0.019s
```

## Test plan

- [x] `bun run test test/pair-handshake.test.ts` — 8/8 pass, <100ms each (previously 2 × ~5000ms timeout)
- [x] Full suite: 1308 pass, 0 fail
- [ ] CI green on GH Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)