### PR TITLE
bump: v26.4.20-alpha.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.19-alpha.15",
+  "version": "26.4.20-alpha.6",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
First release of Apr 20.

## Since v26.4.19-alpha.15
- #694 **fix(pty)**: macOS `expect`-based PTY wrapper. BSD `script` calls `tcgetattr` on stdin; Bun's `stdin:"pipe"` is a socket → ioctl fails → silent `[session detached]` on every click. Live-verified on Darwin 25.3.0.
- #695 fix(test): RFC 6761 `.invalid` TLD replaces `nonexistent.example` (DNS-flake-free).

## Ship
- calver-release.yml auto-tags `v26.4.20-alpha.6` + publishes release + uploads dist/maw tarball

🤖 Generated with [Claude Code](https://claude.com/claude-code)