### PR TITLE
fix(calver): lightweight tags — unblock bun upgrade loop (#697 part 1/2)

### DIFF
--- a/.github/workflows/calver-release.yml
+++ b/.github/workflows/calver-release.yml
@@ -107,7 +107,7 @@ jobs:
           TAG="${{ steps.ver.outputs.tag }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "$TAG" -m "Release $TAG"
+          git tag "$TAG"
           git push origin "$TAG"
 
           FLAGS="--generate-notes --title $TAG"


### PR DESCRIPTION
## Summary

One-line fix in `.github/workflows/calver-release.yml`: replace annotated `git tag -a "$TAG" -m "Release $TAG"` with lightweight `git tag "$TAG"`.

## Why

Per #697, `maw update` fails with a dependency-loop error on every alpha release. Root cause:

- Annotated tags create a **tag object** with its own SHA, distinct from the commit SHA it points at.
- Bun's `github:` URL resolver uses the tag-object SHA as package identity.
- Every `maw-js` alpha gets a different identity in bun's graph → bun's dep-loop detector trips.

Lightweight tags point directly at the commit. Same commit = same SHA, bun stays happy.

## Tradeoff

We lose the "Release X" message on the tag object itself. GitHub release notes (generated separately later in this same workflow via `gh release create --generate-notes`) cover the human-visible annotation, so nothing user-facing is lost.

## Scope

Part 1/2 of the dep-loop fix. A companion PR (update-fixer) handles `cmd-update.ts` mitigations.

Refs #697.

🤖 Generated with [Claude Code](https://claude.com/claude-code)