### PR TITLE
fix(update): evict cache + fallback to release binary on bun dep-loop (#697 part 2/2)

### DIFF
--- a/src/cli/cmd-update.ts
+++ b/src/cli/cmd-update.ts
@@ -2,7 +2,7 @@ import { execSync } from "child_process";
 import {
   existsSync, writeFileSync, mkdirSync, readdirSync,
   lstatSync, unlinkSync, symlinkSync, openSync, readSync, closeSync, realpathSync,
-  renameSync,
+  renameSync, rmSync,
 } from "fs";
 import { join, dirname } from "path";
 import { homedir } from "os";
@@ -170,7 +170,55 @@ export async function runUpdate(args: string[]): Promise<void> {
       } catch { /* stash best-effort */ }
 
       try { execSync(`bun remove -g maw`, { stdio: "pipe" }); } catch {}
+
+      // #697 — evict bun's global lockfiles + any cached maw-js tarballs.
+      // `bun remove` clears the node_modules entry but bun.lock/bun.lockb pin
+      // the *previous* ref's commit SHA, and `~/.bun/install/cache/` may hold
+      // a stale tarball. When an annotated tag's ref points to the tag object
+      // SHA rather than the commit SHA (tag-object polymorphism), bun's
+      // resolver can get stuck re-resolving to the cached/pinned SHA — the
+      // dep-loop. Nuke these so the retry resolves from scratch.
+      try {
+        const bunGlobal = join(homedir(), ".bun", "install", "global");
+        for (const f of ["bun.lock", "bun.lockb"]) {
+          const p = join(bunGlobal, f);
+          try { if (existsSync(p)) unlinkSync(p); } catch {}
+        }
+      } catch {}
+      try {
+        const cacheDir = join(homedir(), ".bun", "install", "cache");
+        if (existsSync(cacheDir)) {
+          for (const entry of readdirSync(cacheDir)) {
+            if (entry.includes("maw-js")) {
+              try { rmSync(join(cacheDir, entry), { recursive: true, force: true }); } catch {}
+            }
+          }
+        }
+      } catch {}
+
       installCode = await spawnInstall().exited;
+
+      if (installCode !== 0) {
+        // #697 — Fallback: download pre-built binary from GitHub release
+        // (bypasses bun's resolver entirely). calver-release.yml attaches `maw`
+        // as a release asset. Works around bun's annotated-tag-SHA dep-loop
+        // bug and any future resolver regressions. Only meaningful when `ref`
+        // is a release tag — for branches/SHAs the curl 404s and we fall
+        // through to the existing error path.
+        console.warn(`\x1b[33m↺\x1b[0m bun add failed — trying release-binary fallback`);
+        const releaseUrl = `https://github.com/${repository}/releases/download/${ref}/maw`;
+        const dl = Bun.spawn(["curl", "-fsSL", "-o", BIN, releaseUrl], { stdout: "inherit", stderr: "inherit" });
+        const dlCode = await dl.exited;
+        if (dlCode === 0) {
+          await Bun.spawn(["chmod", "+x", BIN]).exited;
+          const v = Bun.spawn(["maw", "--version"], { stdout: "pipe" });
+          const versionOk = (await v.exited) === 0;
+          if (versionOk) {
+            console.log(`\x1b[32m✓\x1b[0m installed via release binary (bun resolver bypassed)`);
+            installCode = 0;
+          }
+        }
+      }
 
       if (installCode !== 0 && stashed && existsSync(STASH)) {
         // Retry failed — restore the previous binary so the user isn't stranded.


### PR DESCRIPTION
## Summary

Two defensive fixes to `src/cli/cmd-update.ts` retry path — both target the bun dep-loop where a failed install loops forever on the same pinned SHA (the annotated-tag-SHA polymorphism behind #697).

### 1. Cache + lockfile eviction on retry
After `bun remove -g maw`, also delete:
- `~/.bun/install/global/bun.lock` (pins prior ref's SHA)
- `~/.bun/install/global/bun.lockb` (binary lock)
- `~/.bun/install/cache/*maw-js*` (stale tarballs)

Without this, bun's resolver re-resolves to the cached SHA even after the node_modules entry is gone. All fs ops are best-effort — cleanup failures cannot brick the retry.

### 2. Release-binary fallback
If both `bun add` attempts fail, curl the pre-built `maw` asset from the GitHub release for `${ref}` into `~/.bun/bin/maw`. Bypasses bun's resolver entirely — immune to any resolver regression.

- Sanity-checks with `maw --version`
- On success marks `installCode = 0` so existing stash-cleanup runs (not restore)
- On failure (e.g. branch/SHA ref with no release asset), curl 404s and we fall through to the existing error+exit

Composes with the #551 stash/restore logic already in place.

## Test plan
- [x] `bun run test` — 1308 pass, 7 skip, 0 fail
- [ ] Manual: trigger retry path on a real alpha tag; confirm cache eviction runs
- [ ] Manual: simulate both bun add failures; confirm release-binary fallback downloads and runs

Part 2/2 of the #697 dep-loop mitigation (workflow fix is the sibling PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)