### PR TITLE
bump: v26.4.20-alpha.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.20-alpha.6",
+  "version": "26.4.20-alpha.10",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts the first alpha with the #697 fix chain.

## Since v26.4.20-alpha.6
- #698 fix(calver): lightweight tags — unblock bun upgrade loop (part 1/2)
- #699 fix(update): evict cache + fallback to release binary on bun dep-loop (part 2/2)

## What this means for the next \`maw update alpha\`
1. Existing alpha.6 installs try bun add as usual
2. On the inevitable dep-loop (this release still lives alongside annotated tags from prior alphas in bun's cache): retry evicts `~/.bun/install/global/bun.lock` + cache
3. If bun still can't resolve: curl the `maw` binary attached to this release → `~/.bun/bin/maw` → success

First release going forward will only have lightweight tags. The update cascade becomes self-healing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)