### PR TITLE
fix(update): bun remove by package name (maw-js) not bin name (maw) — kills dep-loop at source

### DIFF
--- a/src/cli/cmd-update.ts
+++ b/src/cli/cmd-update.ts
@@ -169,10 +169,19 @@ export async function runUpdate(args: string[]): Promise<void> {
         }
       } catch { /* stash best-effort */ }
 
+      // #697 — use the PACKAGE name (`maw-js`), not the bin name (`maw`).
+      // `bun remove -g maw` is a silent no-op because bun looks up by package
+      // name in ~/.bun/install/global/package.json, and the package registered
+      // there is `maw-js`. Leaving the old ref in that manifest (e.g. pinning
+      // `maw-js: github:.../#v26.4.19-alpha.15`) was the actual persistent
+      // source of the dep-loop across every retry — bun kept merging the
+      // stale pin into its graph alongside the new resolution. Removing by
+      // package name evicts the pin from global package.json cleanly.
+      try { execSync(`bun remove -g maw-js`, { stdio: "pipe" }); } catch {}
       try { execSync(`bun remove -g maw`, { stdio: "pipe" }); } catch {}
 
-      // #697 — evict bun's global lockfiles + any cached maw-js tarballs.
-      // `bun remove` clears the node_modules entry but bun.lock/bun.lockb pin
+      // #697 — also evict bun's global lockfiles + any cached maw-js tarballs.
+      // `bun remove` clears the package entry but bun.lock/bun.lockb pin
       // the *previous* ref's commit SHA, and `~/.bun/install/cache/` may hold
       // a stale tarball. When an annotated tag's ref points to the tag object
       // SHA rather than the commit SHA (tag-object polymorphism), bun's


### PR DESCRIPTION
## Definitive fix for the dep-loop chain

Prior diagnosis (#697, #698, #699) identified annotated tags + stale cache as contributors — but the **root, reliably-reproducible cause** was only found by inspecting \`~/.bun/install/global/package.json\`:

\`\`\`json
{
  "dependencies": {
    "maw-js": "github:Soul-Brews-Studio/maw-js#v26.4.19-alpha.15"
  }
}
\`\`\`

This pin survives every cache wipe, every bun.lock delete, every node_modules remove. On each \`bun add -g github:.../#<new-ref>\`, bun merges this stale pin into its graph alongside the new resolution → two SHAs for one package name → "dependency loop" error.

\`bun remove -g maw\` (what #699 did) is a no-op on this manifest because bun looks up by **package** name. \`maw\` is the bin (per package.json's \`bin\` field); the package is \`maw-js\`.

## Fix

\`\`\`diff
+ try { execSync(\`bun remove -g maw-js\`, { stdio: "pipe" }); } catch {}
  try { execSync(\`bun remove -g maw\`, { stdio: "pipe" }); } catch {}
\`\`\`

Kept the \`maw\` line too for belt-and-braces.

## Live verification

On MBA (Darwin 25.3.0), I ran \`bun remove -g maw-js\` manually before the next \`maw update alpha\`. Result:

\`\`\`
installed maw-js@github:Soul-Brews-Studio/maw-js#0b7b405
3 packages installed [4.76s]
✅ v26.4.20-alpha.10 (re-sync'd)
\`\`\`

No dep-loop. No retry. No release-binary fallback. First-attempt success in 4.76s. That's the behavior users should see going forward.

## Relation to #698 (lightweight tags)
Still correct — prevents NEW annotated-tag-SHAs from entering bun's resolution. Belt-and-braces with this fix.

## Relation to #699 (cache eviction + release fallback)
Still correct — the release-binary fallback makes updates resilient when bun's resolver has ANY issue, not just this one. This new fix means the fallback rarely fires under normal conditions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)