### PR TITLE
bump: v26.4.20-alpha.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.20-alpha.10",
+  "version": "26.4.20-alpha.11",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Bakes in the complete #697 fix chain.

Since v26.4.20-alpha.10:
- #701 fix(update): bun remove by package name — kills the persistent dep-loop at source

Once users on alpha.10 or earlier update to this, the first thing their update tool does is call \`bun remove -g maw-js\` (correct name) → evicts the stale \`maw-js: github:...#v26.4.19-alpha.15\` pin from \`~/.bun/install/global/package.json\` → next \`bun add\` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)