### PR TITLE
fix(costs): drop plugin api surface to stop self-fetch loop

### DIFF
--- a/src/commands/plugins/costs/plugin.json
+++ b/src/commands/plugins/costs/plugin.json
@@ -9,11 +9,5 @@
     "command": "costs",
     "help": "maw costs — show token usage and cost breakdown per agent"
   },
-  "api": {
-    "path": "/api/costs",
-    "methods": [
-      "GET"
-    ]
-  },
   "weight": 50
 }


### PR DESCRIPTION
## Problem

`GET /api/costs` has been returning a false "cannot reach maw server" error (HTTP 200 body `{ok:false, error:"cannot reach maw server — is \`maw serve\` running?"}`), even though the server is healthy and the direct handler at `src/api/costs.ts:185` could answer cleanly.

## Root cause — 2-layer bug

1. **Auto-mount override (symptom)**. `src/api/index.ts:71-91` iterates discovered plugins and registers `api.get(path, ...)` / `api.post(path, ...)` AFTER `.use(costsApi)` is mounted. Because the costs plugin declares `api.path = /api/costs` in its `plugin.json`, Elysia's route table gets a second handler that wraps `invokePlugin(p, {source:"api", args})` — and this plugin handler silently overrides the direct `costsApi.get("/costs")` at `src/api/costs.ts:185`.

2. **Self-fetch loop (systemic)**. The plugin's invocation path ultimately calls `cmdCosts()` at `src/commands/plugins/costs/impl.ts:30`, which does `await fetch(${base}/api/costs)` — i.e. the API route re-enters itself. The request hangs/fails, the `catch` block throws `UserError("cannot reach maw server — is \`maw serve\` running?")`, the plugin handler wraps it into `{ok:false, error:...}` and returns 200.

Evidence:
- `/api/costs/daily` works fine (the plugin only declares the bare `/api/costs` path, so `/daily` isn't shadowed).
- The error string `"cannot reach maw server — is \`maw serve\` running?"` lives ONLY in `src/commands/plugins/costs/impl.ts:32,118` (CLI code). No grep hit in `src/api/`.
- Swagger confirms both `/api/costs` and `/api/costs/daily` GETs are registered.

## Fix

Remove the `api` block from `src/commands/plugins/costs/plugin.json`:

```diff
 {
   "name": "costs",
   ...
   "cli": {
     "command": "costs",
     "help": "maw costs — show token usage and cost breakdown per agent"
   },
-  "api": {
-    "path": "/api/costs",
-    "methods": ["GET"]
-  },
   "weight": 50
 }
```

Effects:
- Auto-mount loop skips costs → no collision with the direct handler.
- `costsApi.get("/costs")` at `src/api/costs.ts:185` cleanly serves `/api/costs`.
- `maw costs` CLI command unchanged (still works via `cmdCosts → fetch /api/costs → direct handler`).

## Side effects

- `costs` no longer appears in `GET /api/plugins` (the enumeration of API-surfaced plugins). This is the correct framing — it's a CLI tool that consumes `/api/costs`, not an API-surfaced plugin.
- `GET /api/plugins/costs` now returns 405. Verified that `maw-ui` does not use this path.

## Verification

- `bun test src/commands/plugins/costs test/isolated/costs-daily.test.ts test/isolated/costs-errors.test.ts` → 14/14 pass.
- `bun test test/isolated/registry-invoke.test.ts test/isolated/plugin-*.test.ts test/isolated/command-registry-execute.test.ts` → 91/91 pass.
- `pm2 restart maw && curl http://localhost:3456/api/costs` → returns real `{agents:[{name:"root",inputTokens:...}], ...}` payload.

## Context

FORGE deprecated `/api/tokens/rate` on 2026-04-18 pointing at `/api/costs` as the successor. The self-fetch loop meant the successor was also broken, leaving `maw-ui` with no working rate endpoint. This PR unblocks the UI migration.

## Systemic follow-up (not in this PR)

The underlying pattern — plugin auto-mount silently overriding a direct handler, and plugin CLI impls fetching their own API path — will recur. Possible follow-ups:

- **S1**: guard in the auto-mount loop that skips (with a warning) when a direct route for the same path is already registered.
- **S3**: convention/lint rule that plugins MUST NOT declare `api.path` when a direct handler exists for that path.

Recommend tracking those separately.

## Test plan

- [x] Costs-plugin unit tests pass.
- [x] Plugin/registry tests pass.
- [x] Runtime curl returns real data (not the false "cannot reach maw server" error).

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>