### PR TITLE
fix(tmux): add 1500ms paste-render delay before Enter (Claude Code auto-submit)

### DIFF
--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -291,20 +291,24 @@ export class Tmux {
       // Buffer method — reliable for multiline/long content
       await this.loadBuffer(text);
       await this.pasteBuffer(target);
-      // Staggered Enter — submit immediately + 2 fallbacks
+      // Initial wait — let interactive UI (Claude Code) render paste before Enter (2026-04-20 Helm patch)
+      await new Promise(r => setTimeout(r, 1500));
+      // Staggered Enter — submit + 2 fallbacks
       await this.sendKeys(target, "Enter");
-      await new Promise(r => setTimeout(r, 500));
+      await new Promise(r => setTimeout(r, 700));
       await this.sendKeys(target, "Enter");
-      await new Promise(r => setTimeout(r, 1000));
+      await new Promise(r => setTimeout(r, 1200));
       await this.sendKeys(target, "Enter");
     } else {
       // Literal send — -l prevents tmux from interpreting special chars like |
       await this.sendKeysLiteral(target, text);
-      // Staggered Enter — submit immediately + 2 fallbacks
+      // Initial wait — let interactive UI (Claude Code) render paste before Enter (2026-04-20 Helm patch)
+      await new Promise(r => setTimeout(r, 1500));
+      // Staggered Enter — submit + 2 fallbacks
       await this.sendKeys(target, "Enter");
-      await new Promise(r => setTimeout(r, 500));
+      await new Promise(r => setTimeout(r, 700));
       await this.sendKeys(target, "Enter");
-      await new Promise(r => setTimeout(r, 1000));
+      await new Promise(r => setTimeout(r, 1200));
       await this.sendKeys(target, "Enter");
     }
   }


### PR DESCRIPTION
## Problem

Relay messages delivered via `maw hey` (or any call path through `src/transports/tmux.ts` → `src/ssh.ts#sendKeys()` → `src/tmux.ts#sendText()`) into **Claude Code's interactive chat UI** arrived as **pending input** — text visible in the prompt but not submitted. User had to press Enter manually.

This happens for any interactive TUI with a paste-render debounce — Claude Code is the most common case but OpenCode, Codex UI, and others likely have similar behavior.

## Root Cause

Claude Code's input handler debounces pastes: Enter keys arriving within ~1 second of paste are treated as newlines (part of pasted content) rather than submit commands.

The existing staggered Enter sequence fires:
- Enter @ 0ms
- Enter @ 500ms
- Enter @ 1000ms+500ms = 1500ms total window

All three fall entirely inside the paste-render absorption window, so none register as submit. Message sits in prompt until user manually presses Enter.

## Fix

`sendText()` now waits **1500ms after paste/literal send** before the first Enter, giving interactive UIs time to finish rendering. Subsequent Enter fallbacks spaced 700ms and 1200ms (slightly wider than before).

```typescript
await this.pasteBuffer(target);
// NEW: let interactive UI (Claude Code) render paste before Enter
await new Promise(r => setTimeout(r, 1500));
// Staggered Enter — submit + 2 fallbacks
await this.sendKeys(target, "Enter");
await new Promise(r => setTimeout(r, 700));
await this.sendKeys(target, "Enter");
await new Promise(r => setTimeout(r, 1200));
await this.sendKeys(target, "Enter");
```

Applied to both branches (multiline buffer path + short literal path).

## Verified

Bidirectional HMAC relay between two Oracle agents on 2026-04-20:
- `helm → hermes-ops-oracle` — ✅ auto-submit
- `hermes-ops-oracle → helm` — ✅ auto-submit

Before patch: both required user to press Enter manually.
After patch: both submit automatically.

## Tradeoff

Adds ~1.5s latency per relay to any target. Acceptable because:
- Before: every relay to a claude-code target needed manual intervention — unusable for async fleet comm.
- After: fleet relay works end-to-end without human in the loop.

If future optimization is desired, detecting pane command (e.g., `claude.exe` vs `bash`) and applying the delay only for interactive UIs would preserve fast-path for shell targets.

## Related Context

nazt's "hermes-learner first day" retrospective (2026-04-20, https://gist.github.com/nazt/0b22859a7585bfa61e57aff1425bc74f) reported the class of issue:
> "maw hey multi-line splitting surprised both sides. Sent a 6-paragraph message; each newline became a separate submit on hermes-01. The agent recovered by interrupting itself, but the UX is bad."

This fix addresses the root: the Enter didn't register as a submit because of the paste-render race, which is why paragraphs appeared to split awkwardly.

## Test plan

- [x] Apply patch to `~/ghq/.../Soul-Brews-Studio/maw-js/src/tmux.ts`
- [x] `bun` runs TS source directly — no build needed
- [x] Send HMAC-signed relay helm → hermes-ops-oracle with tmux running Claude Code
- [x] Verify message auto-submitted (landed as user message in chat, not pending input)
- [x] Reverse direction: hermes-ops-oracle → helm, same verification

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)