### PR TITLE
fix(transport): treat 0.0.0.0 and 127.0.0.1 as local sentinels

### DIFF
--- a/src/core/transport/ssh.ts
+++ b/src/core/transport/ssh.ts
@@ -2,7 +2,7 @@ import { loadConfig } from "../../config";
 import { tmuxCmd, Tmux } from "./tmux";
 
 const DEFAULT_HOST = process.env.MAW_HOST || loadConfig().host || "local";
-const IS_LOCAL = DEFAULT_HOST === "local" || DEFAULT_HOST === "localhost";
+const IS_LOCAL = DEFAULT_HOST === "local" || DEFAULT_HOST === "localhost" || DEFAULT_HOST === "0.0.0.0" || DEFAULT_HOST === "127.0.0.1";
 
 export type HostExecTransport = "local" | "ssh";
 
@@ -25,7 +25,7 @@ export class HostExecError extends Error {
 
 /** Transport — run on oracle host. local → bash -c | remote → ssh */
 export async function hostExec(cmd: string, host = DEFAULT_HOST): Promise<string> {
-  const local = host === "local" || host === "localhost" || IS_LOCAL;
+  const local = host === "local" || host === "localhost" || host === "0.0.0.0" || host === "127.0.0.1" || IS_LOCAL;
   const transport: HostExecTransport = local ? "local" : "ssh";
   const args = local ? ["bash", "-c", cmd] : ["ssh", host, cmd];
   const proc = Bun.spawn(args, { stdout: "pipe", stderr: "pipe", windowsHide: true });


### PR DESCRIPTION
## Summary
- `config.host = "0.0.0.0"` caused `hostExec` to use SSH transport instead of local bash
- All tmux operations (`maw ls`, `/api/send`, `/api/sessions?local=true`) returned empty
- This broke duplex federation — peers could send TO the node but the node couldn't see its own sessions
- Fix: add `"0.0.0.0"` and `"127.0.0.1"` to `IS_LOCAL` check and `hostExec()` guard

## Root Cause
`host: "0.0.0.0"` is commonly used to bind the maw server to all interfaces for federation. But `IS_LOCAL` only checked for `"local"` and `"localhost"`, so `"0.0.0.0"` fell through to SSH transport — which tried `ssh 0.0.0.0 tmux list-sessions` and failed silently.

## Test plan
- [x] `bun test test/routing.test.ts` — 19/19 pass
- [x] Verified `maw ls` shows local sessions after fix
- [x] Verified `/api/send` delivers to local tmux panes
- [x] Verified duplex federation (boom-mac ↔ pimpims-imac)

🤖 Generated with [Claude Code](https://claude.com/claude-code)