### PR TITLE
fix(tmux): add 1500ms paste-render delay before Enter (Claude Code auto-submit)

### DIFF
--- a/src/core/transport/tmux-class.ts
+++ b/src/core/transport/tmux-class.ts
@@ -262,25 +262,22 @@ export class Tmux {
       // Buffer method — reliable for multiline/long content
       await this.loadBuffer(text);
       await this.pasteBuffer(target);
-      // Flush-wait: let TUI finish rendering the paste before Enter hits.
-      // Without this, Enter races the paste-buffer commit in Claude Code.
-      await new Promise(r => setTimeout(r, 250));
-      // Staggered Enter — submit immediately + 2 fallbacks
+      await new Promise(r => setTimeout(r, 1500));
+      // Staggered Enter — submit + 2 fallbacks
       await this.sendKeys(target, "Enter");
-      await new Promise(r => setTimeout(r, 500));
+      await new Promise(r => setTimeout(r, 700));
       await this.sendKeys(target, "Enter");
-      await new Promise(r => setTimeout(r, 1000));
+      await new Promise(r => setTimeout(r, 1200));
       await this.sendKeys(target, "Enter");
     } else {
       // Literal send — -l prevents tmux from interpreting special chars like |
       await this.sendKeysLiteral(target, text);
-      // Flush-wait: same reason as above — avoid paste/submit race.
-      await new Promise(r => setTimeout(r, 250));
-      // Staggered Enter — submit immediately + 2 fallbacks
+      await new Promise(r => setTimeout(r, 1500));
+      // Staggered Enter — submit + 2 fallbacks
       await this.sendKeys(target, "Enter");
-      await new Promise(r => setTimeout(r, 500));
+      await new Promise(r => setTimeout(r, 700));
       await this.sendKeys(target, "Enter");
-      await new Promise(r => setTimeout(r, 1000));
+      await new Promise(r => setTimeout(r, 1200));
       await this.sendKeys(target, "Enter");
     }
   }


### PR DESCRIPTION
## Summary
- Rebased version of #707 (by @tordash) — resolved merge conflicts with main after #712 landed
- Adds 1500ms paste-render delay before Enter in `sendText()` — fixes Claude Code auto-submit race
- Both buffer path (multiline) and literal path (short) get the delay

## Original author
@tordash — full credit and context in #707

## Test plan
- [x] Verified by tordash: bidirectional HMAC relay between two Oracle agents (2026-04-20)
- [x] Rebase conflict resolved cleanly (1 file: `src/core/transport/tmux-class.ts`)
- [x] Auto-deployed to white via PM2 post-commit hook

Closes #707

Co-Authored-By: Tor Supakit <torsupakit@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)