### PR TITLE
bump: v26.4.24-alpha.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.24-alpha.0",
+  "version": "26.4.24-alpha.1",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
## Summary
- CalVer bump to v26.4.24-alpha.1 (hour 1, includes #714 tmux fix)

## Test plan
- [x] No code changes, version-only bump
- [ ] CI confirms build still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)