### PR TITLE
fix(api): warn + skip plugin auto-mount on route collision

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -68,24 +68,36 @@ export const api = new Elysia({ prefix: "/api" })
   .use(pairApi)
   .use(consentApi);
 
+// Snapshot direct-handler routes before plugin auto-mount (#705)
+const directRoutes = new Set(
+  api.routes.map(r => `${r.method}|${r.path}`),
+);
+
 // Auto-mount plugin API surfaces from manifests
 const bundledPlugins = discoverPackages();
 for (const p of bundledPlugins) {
   if (!p.manifest.api) continue;
-  // Strip /api prefix from manifest path — Elysia already has prefix: "/api"
   const rawPath = p.manifest.api.path;
   const apiPath = rawPath.startsWith("/api") ? rawPath.slice(4) : rawPath;
   const { methods } = p.manifest.api;
-  if (methods.includes("GET")) {
-    api.get(apiPath, async ({ query }) => {
-      const result = await invokePlugin(p, { source: "api", args: query ?? {} });
-      return result;
-    });
-  }
-  if (methods.includes("POST")) {
-    api.post(apiPath, async ({ body }) => {
-      const result = await invokePlugin(p, { source: "api", args: body ?? {} });
-      return result;
-    });
+  for (const method of methods) {
+    if (directRoutes.has(`${method}|${apiPath}`)) {
+      process.stderr.write(
+        `[maw] ⚠ plugin '${p.manifest.name}' declares ${method} ${rawPath} — ` +
+        `collides with direct handler, skipping auto-mount\n`,
+      );
+      continue;
+    }
+    if (method === "GET") {
+      api.get(apiPath, async ({ query }) => {
+        const result = await invokePlugin(p, { source: "api", args: query ?? {} });
+        return result;
+      });
+    } else if (method === "POST") {
+      api.post(apiPath, async ({ body }) => {
+        const result = await invokePlugin(p, { source: "api", args: body ?? {} });
+        return result;
+      });
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Snapshot direct-handler routes before plugin auto-mount loop
- If plugin `api.path` collides with existing direct handler → warn once + skip
- Prevents silent override that caused the self-fetch loop in #704

## Implementation
- `api.routes` introspection to build `Set<"METHOD |path">` after all `.use()` calls
- Per-method collision check in auto-mount loop
- Warning to stderr (one per collision, not per request)

Fixes #705

## Test plan
- [x] Build passes (626 modules bundled)
- [x] `api-plugins.test.ts` — 7/7 pass
- [ ] CI confirms full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)