### PR TITLE
fix(wake): show org/repo slug in wake output

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -44,7 +44,11 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
   }
 
   const { repoPath, repoName, parentDir } = resolved;
-  console.log(`\x1b[36m→\x1b[0m found ${repoPath}`);
+  // #673 — extract org/repo slug from ghq path (…/github.com/<org>/<repo>)
+  const ghSlug = repoPath.includes("github.com/")
+    ? repoPath.slice(repoPath.indexOf("github.com/") + "github.com/".length)
+    : repoName;
+  console.log(`\x1b[36m→\x1b[0m found \x1b[1m${ghSlug}\x1b[0m (${repoPath})`);
   let session = await detectSession(oracle);
   if (session) console.log(`\x1b[36m→\x1b[0m session exists: ${session}`);
   else console.log(`\x1b[36m→\x1b[0m no session found, creating...`);


### PR DESCRIPTION
## Summary
- Extract `org/repo` slug from the resolved ghq path and display it in the `→ found` line during `maw wake`
- Before: `→ found /home/nat/Code/github.com/Soul-Brews-Studio/timekeeper-oracle`
- After: `→ found **Soul-Brews-Studio/timekeeper-oracle** (/home/nat/Code/github.com/Soul-Brews-Studio/timekeeper-oracle)`
- Falls back to `repoName` for non-github.com paths

Closes #673

## Test plan
- [ ] `maw wake <oracle>` shows org/repo slug in bold before the full path
- [ ] Non-github.com repo paths fall back to repo name only

🤖 Generated with [Claude Code](https://claude.com/claude-code)