### PR TITLE
fix(workspace): defer mkdirSync to first use, not module load

### DIFF
--- a/src/commands/shared/workspace-store.ts
+++ b/src/commands/shared/workspace-store.ts
@@ -8,7 +8,10 @@ export const WORKSPACES_DIR = join(
   process.env.MAW_CONFIG_DIR || join(homedir(), ".config", "maw"),
   "workspaces"
 );
-mkdirSync(WORKSPACES_DIR, { recursive: true });
+
+function ensureDir(): void {
+  mkdirSync(WORKSPACES_DIR, { recursive: true });
+}
 
 // ── Types ───────────────────────────────────────────────────────────
 export interface WorkspaceConfig {
@@ -85,11 +88,13 @@ export function loadWorkspace(id: string): WorkspaceConfig | null {
 }
 
 export function saveWorkspace(ws: WorkspaceConfig): void {
+  ensureDir();
   writeFileSync(configPath(ws.id), JSON.stringify(ws, null, 2) + "\n", "utf-8");
 }
 
 export function loadAllWorkspaces(): WorkspaceConfig[] {
   try {
+    ensureDir();
     const files = readdirSync(WORKSPACES_DIR).filter(f => f.endsWith(".json"));
     return files
       .map(f => {


### PR DESCRIPTION
## Summary
- Move `mkdirSync(WORKSPACES_DIR)` from module-level (fires on import) to lazy `ensureDir()` (fires on first write/read)
- Prevents workspace dir creation in sandbox/worktree contexts where the module is imported but workspaces aren't used
- Stops seed workspace files from leaking into real `~/.config/maw/workspaces/` during `bun install`

Fixes #703

## Test plan
- [x] `workspace.test.ts` — 49/49 pass (test uses `MAW_CONFIG_DIR` tmpdir)
- [x] Build passes (0.85 MB)
- [ ] CI confirms full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)