### PR TITLE
bump: v26.4.24-alpha.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.24-alpha.1",
+  "version": "26.4.24-alpha.2",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
## Summary
- CalVer bump to v26.4.24-alpha.2 (hour 2)
- Includes: #716 plugin collision guard, #717 wake repo display, #718 workspace isolation

## Test plan
- [x] Version-only bump, no code changes
- [ ] CI confirms

🤖 Generated with [Claude Code](https://claude.com/claude-code)