### PR TITLE
fix: defer workspace dir creation to first use (#703)

### DIFF
--- a/src/api/workspace-storage.ts
+++ b/src/api/workspace-storage.ts
@@ -6,7 +6,15 @@ import { CONFIG_DIR } from "../core/paths";
 import type { Workspace } from "./workspace-types";
 
 export const WORKSPACE_DIR = join(CONFIG_DIR, "workspaces");
-mkdirSync(WORKSPACE_DIR, { recursive: true });
+
+// #703: Defer directory creation to first use — module-level mkdirSync
+// wrote to real $XDG_CONFIG_HOME even during `bun install` in a worktree.
+let _wsDirReady = false;
+function ensureWorkspaceDir(): void {
+  if (_wsDirReady) return;
+  mkdirSync(WORKSPACE_DIR, { recursive: true });
+  _wsDirReady = true;
+}
 
 /** In-memory cache, persisted to disk on mutation */
 export const workspaces = new Map<string, Workspace>();
@@ -14,6 +22,7 @@ export const workspaces = new Map<string, Workspace>();
 /** Load all workspaces from disk into memory */
 export function loadAll() {
   if (workspaces.size > 0) return; // already loaded
+  ensureWorkspaceDir();
   try {
     for (const file of readdirSync(WORKSPACE_DIR)) {
       if (!file.endsWith(".json")) continue;
@@ -26,6 +35,7 @@ export function loadAll() {
 }
 
 export function persist(ws: Workspace) {
+  ensureWorkspaceDir();
   writeFileSync(join(WORKSPACE_DIR, `${ws.id}.json`), JSON.stringify(ws, null, 2) + "\n", "utf-8");
 }
 

--- a/src/commands/shared/workspace-store.ts
+++ b/src/commands/shared/workspace-store.ts
@@ -4,11 +4,19 @@ import { homedir } from "os";
 import { loadConfig } from "../../config";
 
 // ── Workspace config directory ──────────────────────────────────────
+// #703: Resolved lazily — module-level mkdirSync wrote to the real
+// $XDG_CONFIG_HOME even during `bun install` inside a /tmp worktree.
 export const WORKSPACES_DIR = join(
   process.env.MAW_CONFIG_DIR || join(homedir(), ".config", "maw"),
   "workspaces"
 );
-mkdirSync(WORKSPACES_DIR, { recursive: true });
+
+let _wsDirReady = false;
+function ensureWorkspacesDir(): void {
+  if (_wsDirReady) return;
+  mkdirSync(WORKSPACES_DIR, { recursive: true });
+  _wsDirReady = true;
+}
 
 // ── Types ───────────────────────────────────────────────────────────
 export interface WorkspaceConfig {
@@ -75,6 +83,7 @@ export function normalizeWorkspace(raw: unknown): WorkspaceConfig | null {
 }
 
 export function loadWorkspace(id: string): WorkspaceConfig | null {
+  ensureWorkspacesDir();
   const p = configPath(id);
   if (!existsSync(p)) return null;
   try {
@@ -85,10 +94,12 @@ export function loadWorkspace(id: string): WorkspaceConfig | null {
 }
 
 export function saveWorkspace(ws: WorkspaceConfig): void {
+  ensureWorkspacesDir();
   writeFileSync(configPath(ws.id), JSON.stringify(ws, null, 2) + "\n", "utf-8");
 }
 
 export function loadAllWorkspaces(): WorkspaceConfig[] {
+  ensureWorkspacesDir();
   try {
     const files = readdirSync(WORKSPACES_DIR).filter(f => f.endsWith(".json"));
     return files
@@ -109,12 +120,12 @@ export function loadAllWorkspaces(): WorkspaceConfig[] {
 export function reportNoWorkspaceId(): void {
   const all = loadAllWorkspaces();
   if (all.length === 0) {
-    console.error("\x1b[31m\u274c\x1b[0m no workspaces joined");
+    console.error("\x1b[31m❌\x1b[0m no workspaces joined");
     console.error("\x1b[90m  maw workspace create <name>   Create a new workspace\x1b[0m");
     console.error("\x1b[90m  maw workspace join <code>     Join with invite code\x1b[0m");
     return;
   }
-  console.error(`\x1b[31m\u274c\x1b[0m multiple workspaces joined (${all.length}) — pass one with --workspace <id>:`);
+  console.error(`\x1b[31m❌\x1b[0m multiple workspaces joined (${all.length}) — pass one with --workspace <id>:`);
   for (const ws of all) {
     console.error(`  \x1b[90m${ws.id}\x1b[0m  ${ws.name}`);
   }

--- a/test/isolated/workspace.test.ts
+++ b/test/isolated/workspace.test.ts
@@ -21,7 +21,7 @@ import {
   describe, test, expect, mock, beforeEach, afterEach, afterAll,
 } from "bun:test";
 import { join } from "path";
-import { mkdtempSync, rmSync, readdirSync, writeFileSync, existsSync, readFileSync } from "fs";
+import { mkdtempSync, mkdirSync, rmSync, readdirSync, writeFileSync, existsSync, readFileSync } from "fs";
 import { tmpdir } from "os";
 
 // ─── Gate ───────────────────────────────────────────────────────────────────
@@ -35,6 +35,9 @@ process.env.MAW_CONFIG_DIR = tmpConfigDir;
 const WS_DIR = join(tmpConfigDir, "workspaces");
 
 function clearWorkspacesDir(): void {
+  // #703: workspace-store no longer creates the dir at import time,
+  // so ensure it exists for tests that use writeWsFile() directly.
+  mkdirSync(WS_DIR, { recursive: true });
   try {
     for (const f of readdirSync(WS_DIR)) {
       try { rmSync(join(WS_DIR, f), { force: true }); } catch {}


### PR DESCRIPTION
## Summary

- Replace module-level `mkdirSync` with lazy `ensureWorkspacesDir()` / `ensureWorkspaceDir()` in both `workspace-store.ts` and `workspace-storage.ts`
- Directory is created on first actual filesystem operation (`loadWorkspace`, `saveWorkspace`, `loadAll`, `persist`, `loadAllWorkspaces`), not at import time
- Prevents `bun install` in a `/tmp` worktree from writing placeholder workspace configs to the real `~/.config/maw/workspaces/`

Fixes #703

## Test plan

- [x] `test/workspace.test.ts` -- 17 tests pass (normalizeWorkspace pure function, unaffected)
- [x] `test/isolated/workspace.test.ts` -- 49 tests pass (added `mkdirSync` to test setup since dir is no longer auto-created at import)
- [x] Full suite -- 1314 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)