### PR TITLE
feat(plugin): explicit tier field in plugin.json (#675)

### DIFF
--- a/src/api/plugin-list-manifest.ts
+++ b/src/api/plugin-list-manifest.ts
@@ -13,8 +13,7 @@
  * See docs/plugins/search-peers-impl.md for the full spec.
  */
 import { Elysia } from "elysia";
-import type { PluginTier } from "../plugin/types";
-import { weightToTier } from "../plugin/types";
+import { type PluginTier, weightToTier } from "../plugin/types";
 import { discoverPackages } from "../plugin/registry";
 import { loadConfig } from "../config";
 

--- a/src/api/plugin-list-manifest.ts
+++ b/src/api/plugin-list-manifest.ts
@@ -13,6 +13,8 @@
  * See docs/plugins/search-peers-impl.md for the full spec.
  */
 import { Elysia } from "elysia";
+import type { PluginTier } from "../plugin/types";
+import { weightToTier } from "../plugin/types";
 import { discoverPackages } from "../plugin/registry";
 import { loadConfig } from "../config";
 
@@ -22,6 +24,8 @@ export interface PeerPluginEntry {
   summary?: string;
   author?: string;
   sha256?: string | null;
+  /** Plugin tier — explicit or inferred from weight (#675). */
+  tier?: PluginTier;
   /**
    * Relative URL to fetch this plugin's tarball from the peer (Task #1).
    * Additive; clients ignore unknown keys, so no schemaVersion bump needed.
@@ -46,6 +50,7 @@ export const pluginListManifestApi = new Elysia().get(
       const entry: PeerPluginEntry = {
         name: m.name,
         version: m.version,
+        tier: m.tier ?? weightToTier(m.weight ?? 50),
         downloadUrl: `/api/plugin/download/${encodeURIComponent(m.name)}`,
       };
       if (m.description) entry.summary = m.description;

--- a/src/commands/shared/plugins-ls-info.ts
+++ b/src/commands/shared/plugins-ls-info.ts
@@ -2,8 +2,7 @@
  * plugins seam: doLs + doInfo implementations.
  */
 
-import type { LoadedPlugin, PluginTier } from "../../plugin/types";
-import { weightToTier } from "../../plugin/types";
+import { type LoadedPlugin, type PluginTier, weightToTier } from "../../plugin/types";
 import { existsSync } from "fs";
 import { surfaces, shortenHome, printTable } from "./plugins-ui";
 

--- a/src/commands/shared/plugins-ls-info.ts
+++ b/src/commands/shared/plugins-ls-info.ts
@@ -2,9 +2,25 @@
  * plugins seam: doLs + doInfo implementations.
  */
 
-import type { LoadedPlugin } from "../../plugin/types";
+import type { LoadedPlugin, PluginTier } from "../../plugin/types";
+import { weightToTier } from "../../plugin/types";
 import { existsSync } from "fs";
 import { surfaces, shortenHome, printTable } from "./plugins-ui";
+
+/** Resolve effective tier: explicit tier field first, then inferred from weight (#675). */
+function effectiveTier(p: LoadedPlugin): PluginTier {
+  return p.manifest.tier ?? weightToTier(p.manifest.weight ?? 50);
+}
+
+/** Tier color for terminal output. */
+function tierIcon(tier: PluginTier, disabled: boolean): string {
+  if (disabled) return "\x1b[90m○\x1b[0m";
+  switch (tier) {
+    case "core": return "\x1b[32m●\x1b[0m";
+    case "standard": return "\x1b[36m●\x1b[0m";
+    case "extra": return "\x1b[33m●\x1b[0m";
+  }
+}
 
 export function doLs(json: boolean, showAll: boolean, discover: () => LoadedPlugin[]): void {
   const allPlugins = discover();
@@ -15,6 +31,7 @@ export function doLs(json: boolean, showAll: boolean, discover: () => LoadedPlug
         allPlugins.map(p => ({
           name: p.manifest.name,
           version: p.manifest.version,
+          tier: effectiveTier(p),
           surfaces: surfaces(p),
           dir: p.dir,
         })),
@@ -42,17 +59,17 @@ export function doLs(json: boolean, showAll: boolean, discover: () => LoadedPlug
     return;
   }
 
-  // Group by weight tier
-  const tiers: { label: string; plugins: LoadedPlugin[] }[] = [
+  // Group by effective tier (#675 — explicit tier field, fallback to weight-inferred)
+  const tiers: { label: PluginTier; plugins: LoadedPlugin[] }[] = [
     { label: "core", plugins: [] },
     { label: "standard", plugins: [] },
     { label: "extra", plugins: [] },
   ];
 
   for (const p of plugins) {
-    const w = p.manifest.weight ?? 50;
-    if (w < 10) tiers[0].plugins.push(p);
-    else if (w < 50) tiers[1].plugins.push(p);
+    const t = effectiveTier(p);
+    if (t === "core") tiers[0].plugins.push(p);
+    else if (t === "standard") tiers[1].plugins.push(p);
     else tiers[2].plugins.push(p);
   }
 
@@ -60,10 +77,10 @@ export function doLs(json: boolean, showAll: boolean, discover: () => LoadedPlug
     if (tier.plugins.length === 0) continue;
     console.log(`\n\x1b[1m${tier.label}\x1b[0m (${tier.plugins.length})`);
     const rows = tier.plugins.map(p => {
-      const w = p.manifest.weight ?? 50;
+      const t = effectiveTier(p);
       const isDisabled = disabledSet.has(p.manifest.name);
-      const icon = isDisabled ? "\x1b[90m○\x1b[0m" : (w < 10 ? "\x1b[32m●\x1b[0m" : w < 50 ? "\x1b[36m●\x1b[0m" : "\x1b[33m●\x1b[0m");
-      const source = `${icon} ${isDisabled ? "disabled" : (w < 10 ? "core" : w < 50 ? "standard" : "extra")}`;
+      const icon = tierIcon(t, isDisabled);
+      const source = `${icon} ${isDisabled ? "disabled" : t}`;
       return [
         p.manifest.name,
         p.manifest.version,
@@ -72,7 +89,7 @@ export function doLs(json: boolean, showAll: boolean, discover: () => LoadedPlug
         shortenHome(p.dir),
       ];
     });
-    printTable(["name", "version", "source", "surfaces", "dir"], rows);
+    printTable(["name", "version", "tier", "surfaces", "dir"], rows);
   }
 
   if (showAll) {
@@ -93,10 +110,12 @@ export function doInfo(name: string, discover: () => LoadedPlugin[]): void {
   }
 
   const m = p.manifest;
+  const t = effectiveTier(p);
   console.log(`\x1b[1m${m.name}\x1b[0m  ${m.version}`);
   if (m.description) console.log(`  desc:    ${m.description}`);
   if (m.author)      console.log(`  author:  ${m.author}`);
   console.log(`  sdk:     ${m.sdk}`);
+  console.log(`  tier:    ${t}${m.tier ? "" : " (inferred from weight)"}`);
   if (m.cli) {
     const help = m.cli.help ? `  — ${m.cli.help}` : "";
     console.log(`  cli:     ${m.cli.command}${help}`);

--- a/src/plugin/manifest-parse.ts
+++ b/src/plugin/manifest-parse.ts
@@ -16,6 +16,7 @@ import {
   parseTarget,
   parseCapabilities,
   parseArtifact,
+  parseTier,
 } from "./manifest-validate";
 
 /**
@@ -93,11 +94,13 @@ export function parseManifest(jsonText: string, dir: string): PluginManifest {
   const target = parseTarget(r);
   const capabilities = parseCapabilities(r);
   const artifact = parseArtifact(r);
+  const tier = parseTier(r);
 
   return {
     name: r.name,
     version: r.version,
     ...(typeof r.weight === "number" ? { weight: r.weight } : {}),
+    ...(tier ? { tier } : {}),
     ...(hasWasm ? { wasm: r.wasm as string } : {}),
     ...(hasEntry ? { entry: r.entry as string } : {}),
     sdk: r.sdk,

--- a/src/plugin/manifest-validate.ts
+++ b/src/plugin/manifest-validate.ts
@@ -3,8 +3,10 @@
  * Each function validates and shapes one optional manifest section.
  */
 
-import type { PluginManifest } from "./types";
+import type { PluginManifest, PluginTier } from "./types";
 import { KNOWN_CAPABILITY_NAMESPACES } from "./manifest-constants";
+
+const VALID_TIERS = new Set<PluginTier>(["core", "standard", "extra"]);
 
 export function parseCli(r: Record<string, unknown>): PluginManifest["cli"] {
   if (r.cli === undefined) return undefined;
@@ -178,4 +180,19 @@ export function parseArtifact(r: Record<string, unknown>): PluginManifest["artif
     throw new Error("plugin.json: artifact.sha256 must be a string or null");
   }
   return { path: a.path, sha256: (a.sha256 as string | null) ?? null };
+}
+
+/**
+ * Parse optional `tier` field (#675).
+ * Must be one of "core" | "standard" | "extra".
+ * Missing → undefined (caller falls back to weightToTier).
+ */
+export function parseTier(r: Record<string, unknown>): PluginManifest["tier"] {
+  if (r.tier === undefined) return undefined;
+  if (typeof r.tier !== "string" || !VALID_TIERS.has(r.tier as PluginTier)) {
+    throw new Error(
+      `plugin.json: tier must be "core", "standard", or "extra" (got ${JSON.stringify(r.tier)})`,
+    );
+  }
+  return r.tier as PluginTier;
 }

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -19,6 +19,32 @@
 export type PluginTarget = "js" | "wasm";
 
 /**
+ * Plugin tier — explicit membership contract (#675).
+ *
+ * `tier` is the migration/governance contract. `weight` stays as a
+ * load-order hint only. Missing `tier` falls back to `weightToTier(weight)`
+ * for backward compatibility (one release).
+ *
+ *   "core"     — boot-path / contract / substrate / cant-profile
+ *   "standard" — normal plugins
+ *   "extra"    — optional / experimental
+ */
+export type PluginTier = "core" | "standard" | "extra";
+
+/**
+ * Infer tier from weight (backward-compat fallback).
+ *
+ *   weight 0-9   → "core"
+ *   weight 10-49 → "standard"
+ *   weight 50+   → "extra"
+ */
+export function weightToTier(weight: number): PluginTier {
+  if (weight < 10) return "core";
+  if (weight < 50) return "standard";
+  return "extra";
+}
+
+/**
  * Built-plugin artifact descriptor. Present on compiled plugins written
  * by `maw plugin build`. `sha256: null` means "unbuilt" — the loader
  * refuses such plugins with a "run `maw plugin build`" message.
@@ -32,6 +58,7 @@ export interface PluginManifest {
   name: string;           // unique id, slug-safe /^[a-z0-9-]+$/
   version: string;        // semver e.g. "1.0.0"
   weight?: number;        // execution order: lower = first (default 50, like Drupal)
+  tier?: PluginTier;      // membership contract: "core" | "standard" | "extra" (#675)
   wasm?: string;          // relative path to .wasm (WASM plugin)
   entry?: string;         // relative path to .ts/.js (TS plugin)
   sdk: string;            // semver range e.g. "^1.0.0"


### PR DESCRIPTION
## Summary

- Adds `PluginTier` type (`"core" | "standard" | "extra"`) and optional `tier` field to `plugin.json` schema
- `tier` is the membership/governance contract for #640 migration waves; `weight` stays as load-order hint only
- Missing `tier` falls back to `weightToTier(weight)` for backward compatibility (one release)
- `maw plugin ls` groups and labels by effective tier; `maw plugin info` shows tier with "(inferred from weight)" annotation when not explicit
- Peer manifest API (`/api/plugin/list-manifest`) includes `tier` in response for federated discovery

## Files changed

| File | Change |
|------|--------|
| `src/plugin/types.ts` | `PluginTier` type, `weightToTier()` helper, `tier` on `PluginManifest` |
| `src/plugin/manifest-validate.ts` | `parseTier()` validator |
| `src/plugin/manifest-parse.ts` | Wire `parseTier` into `parseManifest` |
| `src/commands/shared/plugins-ls-info.ts` | Group/display by effective tier, show in `doInfo` |
| `src/api/plugin-list-manifest.ts` | Include `tier` in peer manifest response |

## Test plan

- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] Existing plugins without `tier` field still load correctly (backward compat via `weightToTier`)
- [ ] Plugin with explicit `"tier": "core"` in plugin.json is parsed and displayed correctly
- [ ] Invalid tier value (e.g. `"tier": "premium"`) throws validation error
- [ ] `maw plugin ls --json` includes `tier` field in output
- [ ] `maw plugin info <name>` shows tier line

Closes #675

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>