### PR TITLE
bump: v26.4.24-alpha.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.24-alpha.2",
+  "version": "26.4.24-alpha.3",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
## Summary
- CalVer bump to v26.4.24-alpha.3 (hour 3)
- Includes: #721 workspace-storage lazy init, #722 plugin tier field

🤖 Generated with [Claude Code](https://claude.com/claude-code)