### PR TITLE
fix(plugin): restore PluginTier + weightToTier (lost in #722 squash)

### DIFF
--- a/src/plugin/tier.ts
+++ b/src/plugin/tier.ts
@@ -1,0 +1,7 @@
+import type { PluginTier } from "./types";
+
+export function weightToTier(weight: number): PluginTier {
+  if (weight < 10) return "core";
+  if (weight < 50) return "standard";
+  return "extra";
+}

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -18,6 +18,8 @@
  */
 export type PluginTarget = "js" | "wasm";
 
+export type PluginTier = "core" | "standard" | "extra";
+
 /**
  * Built-plugin artifact descriptor. Present on compiled plugins written
  * by `maw plugin build`. `sha256: null` means "unbuilt" — the loader
@@ -64,6 +66,7 @@ export interface PluginManifest {
   transport?: {
     peer?: boolean;     // enable maw hey plugin:<name>
   };
+  tier?: PluginTier;
 }
 
 export interface LoadedPlugin {


### PR DESCRIPTION
## Summary
- #722 squash merge lost the tier extraction commits that came after merge
- Re-adds `PluginTier` type + `tier?` field on `PluginManifest`
- Creates `src/plugin/tier.ts` with `weightToTier()` (separate module to avoid bun CI resolution bug)

## Test plan
- [x] Build passes (0.85 MB)
- [x] `plugins-cli.test.ts` — 8/8 pass
- [ ] CI confirms

🤖 Generated with [Claude Code](https://claude.com/claude-code)