### PR TITLE
bump: v26.4.24-alpha.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.24-alpha.2",
+  "version": "26.4.24-alpha.4",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
CalVer bump to v26.4.24-alpha.4 (hour 4). Includes #724 tier fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)