### PR TITLE
fix(plugin): deduplicate PluginTier + move weightToTier to tier.ts

### DIFF
--- a/src/api/plugin-list-manifest.ts
+++ b/src/api/plugin-list-manifest.ts
@@ -13,7 +13,8 @@
  * See docs/plugins/search-peers-impl.md for the full spec.
  */
 import { Elysia } from "elysia";
-import { type PluginTier, weightToTier } from "../plugin/types";
+import type { PluginTier } from "../plugin/types";
+import { weightToTier } from "../plugin/tier";
 import { discoverPackages } from "../plugin/registry";
 import { loadConfig } from "../config";
 

--- a/src/commands/shared/plugins-ls-info.ts
+++ b/src/commands/shared/plugins-ls-info.ts
@@ -2,7 +2,8 @@
  * plugins seam: doLs + doInfo implementations.
  */
 
-import { type LoadedPlugin, type PluginTier, weightToTier } from "../../plugin/types";
+import type { LoadedPlugin, PluginTier } from "../../plugin/types";
+import { weightToTier } from "../../plugin/tier";
 import { existsSync } from "fs";
 import { surfaces, shortenHome, printTable } from "./plugins-ui";
 

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -21,32 +21,6 @@ export type PluginTarget = "js" | "wasm";
 export type PluginTier = "core" | "standard" | "extra";
 
 /**
- * Plugin tier — explicit membership contract (#675).
- *
- * `tier` is the migration/governance contract. `weight` stays as a
- * load-order hint only. Missing `tier` falls back to `weightToTier(weight)`
- * for backward compatibility (one release).
- *
- *   "core"     — boot-path / contract / substrate / cant-profile
- *   "standard" — normal plugins
- *   "extra"    — optional / experimental
- */
-export type PluginTier = "core" | "standard" | "extra";
-
-/**
- * Infer tier from weight (backward-compat fallback).
- *
- *   weight 0-9   → "core"
- *   weight 10-49 → "standard"
- *   weight 50+   → "extra"
- */
-export function weightToTier(weight: number): PluginTier {
-  if (weight < 10) return "core";
-  if (weight < 50) return "standard";
-  return "extra";
-}
-
-/**
  * Built-plugin artifact descriptor. Present on compiled plugins written
  * by `maw plugin build`. `sha256: null` means "unbuilt" — the loader
  * refuses such plugins with a "run `maw plugin build`" message.


### PR DESCRIPTION
## Summary
- Remove duplicate PluginTier type + weightToTier function from types.ts
- Keep canonical weightToTier in src/plugin/tier.ts (separate module avoids bun CI bug)
- Update 2 consumers to import from tier.ts instead of types.ts
- Fixes CI failures from #722/#724 squash merge inconsistency

## Test plan
- [x] Build passes
- [x] `plugins-cli.test.ts` — 8/8 pass
- [ ] CI confirms

🤖 Generated with [Claude Code](https://claude.com/claude-code)