### PR TITLE
feat(send-enter): manual Enter sender for stuck panes (#728)

### DIFF
--- a/src/commands/plugins/send-enter/impl.ts
+++ b/src/commands/plugins/send-enter/impl.ts
@@ -1,0 +1,100 @@
+/**
+ * send-enter — manually submit pending input on a maw target.
+ *
+ * `maw hey` sometimes leaves text as pending input on the target pane
+ * (older targets / interactive UIs without the #714 1500ms paste-render
+ * delay). This is the manual escape hatch — sends Enter to any maw target
+ * without attaching.
+ *
+ * Phase 1 (#728): local-only. Federation can be a follow-up.
+ *
+ *   maw send-enter <target>          # send single Enter
+ *   maw send-enter <target> --N 3    # send N Enters
+ */
+
+import { listSessions, resolveTarget, tmux } from "../../../sdk";
+import { loadConfig } from "../../../config";
+import { resolveOraclePane } from "../../shared/comm-send";
+
+export interface SendEnterOpts {
+  target: string;
+  count?: number;
+}
+
+export async function cmdSendEnter(opts: SendEnterOpts): Promise<void> {
+  const { target: query } = opts;
+  const count = Math.max(1, opts.count ?? 1);
+
+  if (!query) throw new Error("usage: maw send-enter <target> [--N <count>]");
+
+  const config = loadConfig();
+  const sessions = await listSessions();
+  const result = resolveTarget(query, config, sessions);
+
+  if (!result) {
+    throw new Error(`could not resolve target: ${query}`);
+  }
+
+  if (result.type === "error") {
+    const hint = result.hint ? ` — ${result.hint}` : "";
+    throw new Error(`${result.detail}${hint}`);
+  }
+
+  if (result.type === "peer") {
+    // Phase 1: local-only. Federation deferred to follow-up (see #728).
+    throw new Error(
+      `send-enter: cross-node target '${query}' (node '${result.node}') not yet supported — Phase 1 is local-only. ` +
+        `Workaround: ssh ${result.node} && maw send-enter ${result.target}`,
+    );
+  }
+
+  // Local or self-node — resolve to specific pane (handles multi-pane oracle windows)
+  const target = await resolveOraclePane(result.target);
+
+  for (let i = 0; i < count; i++) {
+    await tmux.sendKeys(target, "Enter");
+  }
+
+  const plural = count === 1 ? "Enter" : `${count} Enters`;
+  console.log(`\x1b[32mdelivered\x1b[0m → ${target}: ${plural}`);
+}
+
+/**
+ * Parse args: positional target, optional `--N <count>`.
+ *   ["mba:sloworacle"]              → { target: "mba:sloworacle", count: 1 }
+ *   ["mba:sloworacle", "--N", "3"]  → { target: "mba:sloworacle", count: 3 }
+ *   ["--N", "3", "mba:sloworacle"]  → { target: "mba:sloworacle", count: 3 }
+ */
+export function parseSendEnterArgs(args: string[]): SendEnterOpts {
+  let target: string | undefined;
+  let count = 1;
+
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--N" || a === "-N" || a === "--n") {
+      const next = args[i + 1];
+      const n = parseInt(next ?? "", 10);
+      if (!Number.isFinite(n) || n < 1) {
+        throw new Error(`--N requires a positive integer (got: ${next ?? "nothing"})`);
+      }
+      count = n;
+      i++;
+      continue;
+    }
+    if (a.startsWith("--N=") || a.startsWith("--n=")) {
+      const n = parseInt(a.split("=")[1] ?? "", 10);
+      if (!Number.isFinite(n) || n < 1) {
+        throw new Error(`--N requires a positive integer (got: ${a})`);
+      }
+      count = n;
+      continue;
+    }
+    if (!target && !a.startsWith("-")) {
+      target = a;
+      continue;
+    }
+  }
+
+  if (!target) throw new Error("usage: maw send-enter <target> [--N <count>]");
+  return { target, count };
+}

--- a/src/commands/plugins/send-enter/index.ts
+++ b/src/commands/plugins/send-enter/index.ts
@@ -1,0 +1,42 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { cmdSendEnter, parseSendEnterArgs } from "./impl";
+
+export const command = {
+  name: "send-enter",
+  description: "Send Enter key to a maw target — manually submit pending input on stuck panes.",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+
+  try {
+    let opts;
+    if (ctx.source === "cli") {
+      const args = ctx.args as string[];
+      opts = parseSendEnterArgs(args);
+    } else {
+      const a = ctx.args as Record<string, unknown>;
+      const target = (a.target as string) ?? "";
+      const count = typeof a.N === "number" ? (a.N as number) : typeof a.count === "number" ? (a.count as number) : 1;
+      opts = { target, count };
+    }
+
+    await cmdSendEnter(opts);
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/src/commands/plugins/send-enter/plugin.json
+++ b/src/commands/plugins/send-enter/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "send-enter",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Send Enter key to a maw target — manually submit pending input on stuck panes (#728).",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "send-enter",
+    "help": "maw send-enter <target> [--N <count>] — send Enter key to a tmux pane"
+  },
+  "weight": 0
+}

--- a/src/commands/plugins/send-enter/send-enter.test.ts
+++ b/src/commands/plugins/send-enter/send-enter.test.ts
@@ -1,0 +1,51 @@
+/**
+ * send-enter — argument parser tests (#728).
+ */
+
+import { test, expect } from "bun:test";
+import { parseSendEnterArgs } from "./impl";
+
+test("parseSendEnterArgs: positional target only", () => {
+  const opts = parseSendEnterArgs(["mba:sloworacle"]);
+  expect(opts.target).toBe("mba:sloworacle");
+  expect(opts.count).toBe(1);
+});
+
+test("parseSendEnterArgs: target then --N", () => {
+  const opts = parseSendEnterArgs(["mba:sloworacle", "--N", "3"]);
+  expect(opts.target).toBe("mba:sloworacle");
+  expect(opts.count).toBe(3);
+});
+
+test("parseSendEnterArgs: --N then target", () => {
+  const opts = parseSendEnterArgs(["--N", "5", "mba:sloworacle"]);
+  expect(opts.target).toBe("mba:sloworacle");
+  expect(opts.count).toBe(5);
+});
+
+test("parseSendEnterArgs: --N=N inline form", () => {
+  const opts = parseSendEnterArgs(["mba:sloworacle", "--N=4"]);
+  expect(opts.target).toBe("mba:sloworacle");
+  expect(opts.count).toBe(4);
+});
+
+test("parseSendEnterArgs: lowercase --n", () => {
+  const opts = parseSendEnterArgs(["mba:sloworacle", "--n", "2"]);
+  expect(opts.target).toBe("mba:sloworacle");
+  expect(opts.count).toBe(2);
+});
+
+test("parseSendEnterArgs: missing target throws", () => {
+  expect(() => parseSendEnterArgs([])).toThrow(/usage/);
+  expect(() => parseSendEnterArgs(["--N", "3"])).toThrow(/usage/);
+});
+
+test("parseSendEnterArgs: invalid --N value throws", () => {
+  expect(() => parseSendEnterArgs(["target", "--N", "foo"])).toThrow(/positive integer/);
+  expect(() => parseSendEnterArgs(["target", "--N", "0"])).toThrow(/positive integer/);
+  expect(() => parseSendEnterArgs(["target", "--N", "-1"])).toThrow(/positive integer/);
+});
+
+test("parseSendEnterArgs: --N missing value throws", () => {
+  expect(() => parseSendEnterArgs(["target", "--N"])).toThrow();
+});


### PR DESCRIPTION
Closes #728

## Summary
- New `send-enter` plugin: `maw send-enter <target> [--N <count>]` sends Enter key(s) to a tmux pane to manually submit text that `maw hey` left as pending input.
- Phase 1 is local-only (uses `resolveTarget()` + `resolveOraclePane()` — same logic as `maw hey`, so multi-pane oracle windows correctly route to the agent pane).
- Cross-node federation is deferred to a follow-up; for now a peer target surfaces a clear error with an `ssh` workaround.

## Why
`maw hey` sometimes leaves text as pending input on older targets / interactive UIs that haven't received the #714 1500ms paste-render delay fix. Users had to attach + press Enter manually. This is the manual escape hatch.

## Files
- `src/commands/plugins/send-enter/plugin.json` — manifest (`cli.command: "send-enter"`)
- `src/commands/plugins/send-enter/index.ts` — plugin handler (CLI + API entry)
- `src/commands/plugins/send-enter/impl.ts` — `cmdSendEnter` + `parseSendEnterArgs`
- `src/commands/plugins/send-enter/send-enter.test.ts` — 8 arg-parser tests

## Test plan
- [x] `bun run build` passes (627 modules, 0.85 MB)
- [x] `bun test src/commands/plugins/send-enter/` — 8/8 pass
- [x] Manual: `maw send-enter <local-target>` → "delivered → session:window: Enter"
- [x] Manual: `maw send-enter <target> --N 2` → "delivered → ...: 2 Enters"
- [x] Manual: `maw send-enter --N 3 <target>` (flag-first) → "3 Enters"
- [x] Manual: `maw send-enter <target> --N=4` (= form) → "4 Enters"
- [x] Manual: `maw send-enter <target> --N foo` → friendly error
- [x] Manual: `maw send-enter` (no args) → usage error
- [x] Manual: `maw send-enter nonexistent` → resolver error with hint
- [ ] Cross-node target (deferred — Phase 2)

## Acceptance (from #728)
- [x] `maw send-enter <local-target>` sends Enter to local tmux pane
- [ ] `maw send-enter <node>:<target>` works via federation — deferred to Phase 2
- [x] `--N` flag for multi-enter
- [x] Plugin (per repo convention)

🤖 Generated with [Claude Code](https://claude.com/claude-code)