### PR TITLE
bump: v26.4.24-alpha.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.24-alpha.2",
+  "version": "26.4.24-alpha.7",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
CalVer bump to v26.4.24-alpha.7 (hour 7). Includes #729 send-enter plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)