### PR TITLE
fix(api): dedupe /api/sessions windows by name within session (#732)

### DIFF
--- a/src/api/sessions.ts
+++ b/src/api/sessions.ts
@@ -12,6 +12,35 @@ import { WakeBody, SleepBody, SendBody } from "../lib/schemas";
 
 export const sessionsApi = new Elysia();
 
+/**
+ * Dedupe windows within each session by window name (#732).
+ *
+ * When `config.agents` lists the same repo across multiple tmux windows,
+ * `session.windows` can contain repeated entries with the same name. UI
+ * consumers (mawui federation viz) iterate `session.windows` to render
+ * one row per oracle — duplicates cause React key collisions.
+ *
+ * We keep the first occurrence per name, preferring the active window
+ * when present so the "live" one wins. Shape is unchanged.
+ */
+export function dedupeSessionWindows<T extends { windows: { name: string; active?: boolean }[] }>(
+  sessions: T[],
+): T[] {
+  return sessions.map(s => {
+    const seen = new Map<string, typeof s.windows[number]>();
+    for (const w of s.windows) {
+      const existing = seen.get(w.name);
+      if (!existing) {
+        seen.set(w.name, w);
+      } else if (!existing.active && w.active) {
+        // Prefer the active window over an earlier non-active one
+        seen.set(w.name, w);
+      }
+    }
+    return { ...s, windows: [...seen.values()] };
+  });
+}
+
 /** Resolve oracle name → tmux target, same logic as local peek (#273). */
 function resolveCapture(query: string, sessions: { name: string }[]): string {
   const config = loadConfig();
@@ -31,10 +60,10 @@ function resolveCapture(query: string, sessions: { name: string }[]): string {
 sessionsApi.get("/sessions", async ({ query }) => {
   const local = await listSessions();
   if (query.local === "true") {
-    return local.map(s => ({ ...s, source: "local" }));
+    return dedupeSessionWindows(local.map(s => ({ ...s, source: "local" })));
   }
   const aggregated = await getAggregatedSessions(local);
-  return aggregated;
+  return dedupeSessionWindows(aggregated);
 }, {
   query: t.Object({
     local: t.Optional(t.String()),

--- a/test/api-sessions-dedup.test.ts
+++ b/test/api-sessions-dedup.test.ts
@@ -1,0 +1,107 @@
+/**
+ * #732 — /api/sessions dedupes windows with the same name within a session.
+ *
+ * When config.agents lists the same repo across multiple tmux windows,
+ * session.windows contains repeated entries with the same name. UI
+ * consumers iterate windows to render one row per oracle — duplicates
+ * cause React key collisions.
+ *
+ * dedupeSessionWindows() keeps one window per name, preferring the
+ * active one when present.
+ */
+import { describe, it, expect } from "bun:test";
+import { dedupeSessionWindows } from "../src/api/sessions";
+
+describe("#732 — dedupeSessionWindows", () => {
+  it("keeps the only window when there are no duplicates", () => {
+    const sessions = [
+      {
+        name: "fleet",
+        windows: [
+          { index: 0, name: "mawjs-oracle", active: true },
+          { index: 1, name: "pulse-oracle", active: false },
+        ],
+      },
+    ];
+    const out = dedupeSessionWindows(sessions);
+    expect(out[0].windows.length).toBe(2);
+    expect(out[0].windows.map(w => w.name)).toEqual(["mawjs-oracle", "pulse-oracle"]);
+  });
+
+  it("dedupes windows with the same name within a session", () => {
+    const sessions = [
+      {
+        name: "fleet",
+        windows: [
+          { index: 0, name: "pulse-oracle", active: false },
+          { index: 1, name: "mawjs-oracle", active: false },
+          { index: 5, name: "pulse-oracle", active: false },
+        ],
+      },
+    ];
+    const out = dedupeSessionWindows(sessions);
+    expect(out[0].windows.length).toBe(2);
+    expect(out[0].windows.map(w => w.name).sort()).toEqual(["mawjs-oracle", "pulse-oracle"]);
+  });
+
+  it("prefers the active window over an earlier non-active one", () => {
+    const sessions = [
+      {
+        name: "fleet",
+        windows: [
+          { index: 0, name: "pulse-oracle", active: false },
+          { index: 3, name: "pulse-oracle", active: true },
+          { index: 7, name: "pulse-oracle", active: false },
+        ],
+      },
+    ];
+    const out = dedupeSessionWindows(sessions);
+    expect(out[0].windows.length).toBe(1);
+    expect(out[0].windows[0].active).toBe(true);
+    expect(out[0].windows[0].index).toBe(3);
+  });
+
+  it("dedupes independently per session", () => {
+    const sessions = [
+      {
+        name: "a",
+        windows: [
+          { index: 0, name: "pulse-oracle", active: true },
+          { index: 1, name: "pulse-oracle", active: false },
+        ],
+      },
+      {
+        name: "b",
+        windows: [
+          { index: 0, name: "pulse-oracle", active: false },
+        ],
+      },
+    ];
+    const out = dedupeSessionWindows(sessions);
+    expect(out[0].windows.length).toBe(1);
+    expect(out[1].windows.length).toBe(1);
+  });
+
+  it("preserves extra fields on the session and on the window", () => {
+    const sessions = [
+      {
+        name: "fleet",
+        source: "local",
+        windows: [
+          { index: 0, name: "pulse-oracle", active: false, cwd: "/a" },
+          { index: 1, name: "pulse-oracle", active: true, cwd: "/b" },
+        ],
+      },
+    ];
+    const out = dedupeSessionWindows(sessions as any);
+    expect((out[0] as any).source).toBe("local");
+    expect(out[0].windows.length).toBe(1);
+    expect((out[0].windows[0] as any).cwd).toBe("/b");
+  });
+
+  it("handles empty windows array", () => {
+    const sessions = [{ name: "empty", windows: [] }];
+    const out = dedupeSessionWindows(sessions);
+    expect(out[0].windows).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- `/api/sessions` was returning the same oracle N times when `config.agents` listed the same repo across multiple tmux windows
- UI consumers (mawui federation viz) had to dedupe client-side to avoid React key collisions
- Now `/api/sessions` keeps one window per name per session, preferring the `active: true` entry when present

Shape is unchanged — still `Session[]` with `windows[]` — only duplicates within each session's windows array are collapsed.

Fixes #732

## Test plan

- [x] New unit test `test/api-sessions-dedup.test.ts` — 6 cases covering:
  - No-op when no duplicates
  - Basic dedupe by window name within a session
  - Preference for `active: true` window
  - Independent dedupe per session
  - Preservation of extra fields (source, cwd)
  - Empty windows array
- [x] `bun run build` succeeds
- [x] Nearby tests (`peers-session-validation`, `api-plugins`) still pass
- [ ] mawui can drop the repo-tiebreaker React-key workaround (commit `bf5eacf`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)