### PR TITLE
fix: split api.bind from config.host

### DIFF
--- a/src/commands/plugins/view/impl.ts
+++ b/src/commands/plugins/view/impl.ts
@@ -160,8 +160,9 @@ export async function cmdView(
   }
 
   const t = new Tmux();
+  // #713: with bind/host split, config.host is never a bind address (0.0.0.0 etc.)
   const host = process.env.MAW_HOST || loadConfig().host || "local";
-  const isLocal = host === "local" || host === "localhost" || host === "0.0.0.0" || host === "127.0.0.1";
+  const isLocal = host === "local" || host === "localhost";
   const socket = resolveSocket();
 
   // If the resolved session is already a view, attach directly — skip the

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -20,27 +20,12 @@ const DEFAULTS: MawConfig = {
 };
 
 let warnedGhqRoot = false;
-let warnedHostNormalized = false;
+let warnedHostMigrated = false;
 
 let cached: MawConfig | null = null;
 
-/**
- * Normalize `host` away from bind-address / loopback variants to the canonical
- * local sentinel `"local"`. Downstream code only needs to recognize one form
- * for self-connection (see #712: `0.0.0.0` as a target caused slow ssh-to-self
- * instead of bare local tmux).
- *
- * This is a *normalization at read time* — the file on disk is left alone so
- * the (misnamed) `0.0.0.0` write from bind-host.ts still round-trips, but no
- * in-memory consumer ever sees it.
- */
-function normalizeHost(host: string): string {
-  if (host === "0.0.0.0" || host === "::" || host === "" ||
-      host === "127.0.0.1" || host === "localhost") {
-    return "local";
-  }
-  return host;
-}
+/** Bind-address values that should never appear as an outbound target (#713). */
+const BIND_ADDRESSES = new Set(["0.0.0.0", "::", "", "127.0.0.1", "localhost"]);
 
 export function loadConfig(): MawConfig {
   if (cached) return cached;
@@ -51,20 +36,22 @@ export function loadConfig(): MawConfig {
   } catch {
     cached = { ...DEFAULTS };
   }
-  // #712 — normalize bind-address sentinels to "local" for outbound-target use.
-  if (typeof cached.host === "string") {
-    const normalized = normalizeHost(cached.host);
-    if (normalized !== cached.host) {
-      if (!warnedHostNormalized) {
-        warnedHostNormalized = true;
-        process.stderr.write(
-          `[maw] config.host "${cached.host}" normalized to "local" at load time. ` +
-          `"${cached.host}" is a bind address, not a connection target. ` +
-          `(See #712 — split api.bind from host.)\n`,
-        );
-      }
-      cached.host = normalized;
+  // #713 — migrate bind-address values out of `host` into `bind`.
+  // If `host` is a bind address (0.0.0.0, ::, 127.0.0.1, localhost, ""),
+  // move it to `bind` (if not already set) and reset `host` to "local".
+  if (typeof cached.host === "string" && BIND_ADDRESSES.has(cached.host)) {
+    if (!cached.bind) {
+      cached.bind = cached.host;
     }
+    if (!warnedHostMigrated) {
+      warnedHostMigrated = true;
+      process.stderr.write(
+        `[maw] config.host "${cached.host}" is a bind address, not a connection target. ` +
+        `Migrated to config.bind; host reset to "local". ` +
+        `(#713 — set "bind" in maw.config.json to silence this warning.)\n`,
+      );
+    }
+    cached.host = "local";
   }
   // #680 — warn once if the (deprecated) ghqRoot override is set in config.
   if (!warnedGhqRoot && typeof cached.ghqRoot === "string" && cached.ghqRoot.length > 0) {
@@ -88,7 +75,7 @@ export function loadConfig(): MawConfig {
 export function resetConfig() {
   cached = null;
   warnedGhqRoot = false;
-  warnedHostNormalized = false;
+  warnedHostMigrated = false;
 }
 
 /** Write config to maw.config.json and reset cache */

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -53,6 +53,16 @@ export interface MawConfig {
   host: string;
   port: number;
   /**
+   * API server bind address (#713). When present, the HTTP/WS server binds to
+   * this address instead of deriving it from `host`. This separates the
+   * "listen on all interfaces for federation" concern from the "outbound
+   * connection target" concern that `host` represents.
+   *
+   * Typical value: `"0.0.0.0"` (federation) or `"127.0.0.1"` (local only).
+   * When absent, the server falls back to `resolveBindHost()` heuristic.
+   */
+  bind?: string;
+  /**
    * @deprecated (#680) — ghq root is resolved on demand via `ghq root`. If
    * present, this value is honored as a legacy override (normalized to the
    * BARE shape — trailing `/github.com` stripped). Prefer removing it from

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -15,6 +15,15 @@ export function validateBasicFields(
     }
   }
 
+  // bind: string (#713) — API server bind address, separate from outbound host
+  if ("bind" in raw) {
+    if (typeof raw.bind === "string" && raw.bind.trim().length > 0) {
+      result.bind = raw.bind.trim();
+    } else {
+      warn("bind", "must be a non-empty string");
+    }
+  }
+
   // port: number, 1-65535
   if ("port" in raw) {
     const p = Number(raw.port);
@@ -93,6 +102,7 @@ export function validateConfigShape(config: unknown): string[] {
   const c = config as Record<string, unknown>;
 
   if (c.host !== undefined && typeof c.host !== "string") errors.push("host must be a string");
+  if (c.bind !== undefined && typeof c.bind !== "string") errors.push("bind must be a string");
   if (c.port !== undefined) {
     if (typeof c.port !== "number" || !Number.isInteger(c.port) || c.port < 1 || c.port > 65535)
       errors.push("port must be an integer 1-65535");

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -184,9 +184,14 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
 
   // HTTP server (always)
   // Security: bind to localhost unless federation is active (see resolveBindHost).
+  // #713: config.bind takes precedence over the heuristic — it's the explicit
+  // "I want to listen on this address" knob, separate from config.host (the
+  // outbound connection target).
   const config = loadConfig();
-  const { hostname, reason } = resolveBindHost(config);
-  const hasPeers = reason !== null;
+  const heuristic = resolveBindHost(config);
+  const hostname = config.bind ?? heuristic.hostname;
+  const reason = config.bind ? "config.bind" as const : heuristic.reason;
+  const hasPeers = heuristic.reason !== null;
 
   if (hasPeers && !config.federationToken) {
     console.warn(`\x1b[31m⚠ WARNING: peers configured but no federationToken set!\x1b[0m`);

--- a/src/core/transport/pty.ts
+++ b/src/core/transport/pty.ts
@@ -16,8 +16,9 @@ const sessions = new Map<string, PtySession>();
 const attaching = new Set<string>();
 
 function isLocalHost(): boolean {
+  // #713: with bind/host split, config.host is never a bind address (0.0.0.0 etc.)
   const host = process.env.MAW_HOST || loadConfig().host || "local";
-  return host === "local" || host === "localhost" || host === "0.0.0.0" || host === "127.0.0.1";
+  return host === "local" || host === "localhost";
 }
 
 function findSession(ws: MawWS): PtySession | undefined {

--- a/src/core/transport/ssh.ts
+++ b/src/core/transport/ssh.ts
@@ -2,7 +2,8 @@ import { loadConfig } from "../../config";
 import { tmuxCmd, Tmux } from "./tmux";
 
 const DEFAULT_HOST = process.env.MAW_HOST || loadConfig().host || "local";
-const IS_LOCAL = DEFAULT_HOST === "local" || DEFAULT_HOST === "localhost" || DEFAULT_HOST === "0.0.0.0" || DEFAULT_HOST === "127.0.0.1";
+// #713: with bind/host split, config.host is never a bind address (0.0.0.0 etc.)
+const IS_LOCAL = DEFAULT_HOST === "local" || DEFAULT_HOST === "localhost";
 
 export type HostExecTransport = "local" | "ssh";
 
@@ -25,7 +26,8 @@ export class HostExecError extends Error {
 
 /** Transport — run on oracle host. local → bash -c | remote → ssh */
 export async function hostExec(cmd: string, host = DEFAULT_HOST): Promise<string> {
-  const local = host === "local" || host === "localhost" || host === "0.0.0.0" || host === "127.0.0.1" || IS_LOCAL;
+  // #713: with bind/host split, host is never a bind address (0.0.0.0 etc.)
+  const local = host === "local" || host === "localhost" || IS_LOCAL;
   const transport: HostExecTransport = local ? "local" : "ssh";
   const args = local ? ["bash", "-c", cmd] : ["ssh", host, cmd];
   const proc = Bun.spawn(args, { stdout: "pipe", stderr: "pipe", windowsHide: true });


### PR DESCRIPTION
## Summary
- Add `config.bind` field to `MawConfig` for explicit server bind address, separate from `config.host` (outbound connection target)
- Replace the `normalizeHost` band-aid from #712 with a proper migration: if `host` is a bind address (0.0.0.0, ::, etc.), move it to `bind` and reset `host` to "local"
- Update `startServer()` to use `config.bind ?? resolveBindHost().hostname` for the listen address
- Remove redundant `0.0.0.0`/`127.0.0.1` checks from `ssh.ts`, `pty.ts`, and `view/impl.ts` -- with the split, `config.host` is never a bind address

## Files changed
- `src/config/types.ts` -- add `bind?: string` to MawConfig
- `src/config/validate.ts` -- validate `bind` field in both validators
- `src/config/load.ts` -- replace normalizeHost with bind migration
- `src/core/server.ts` -- prefer `config.bind` over heuristic for listen address
- `src/core/transport/ssh.ts` -- remove 0.0.0.0/127.0.0.1 from isLocal checks
- `src/core/transport/pty.ts` -- remove 0.0.0.0/127.0.0.1 from isLocalHost
- `src/commands/plugins/view/impl.ts` -- remove 0.0.0.0/127.0.0.1 from isLocal check

## Test plan
- [x] `bun run build` passes
- [x] `bun test test/bind-heuristic.test.ts` -- 10/10 pass
- [ ] Manual: set `"bind": "0.0.0.0"` in maw.config.json, verify server binds to 0.0.0.0 while `host` stays "local"
- [ ] Manual: set `"host": "0.0.0.0"` (legacy), verify migration warning + host reset to "local" + bind set to "0.0.0.0"

Fixes #713

Generated with [Claude Code](https://claude.com/claude-code)