### PR TITLE
feat(team): exclude sender from team:<> fan-out by default

### DIFF
--- a/src/commands/plugins/team/oracle-members.ts
+++ b/src/commands/plugins/team/oracle-members.ts
@@ -34,6 +34,12 @@ export interface OracleTeamRegistry {
   members: OracleMember[];
   /** ISO timestamp when registry was created */
   createdAt: string;
+  /**
+   * When true (default), `maw hey team:<name>` fan-out skips the sending
+   * oracle so a broadcast does not re-inject into the sender's own pane.
+   * Set to false to opt back into self-inclusive fan-out.
+   */
+  excludeSelf?: boolean;
 }
 
 // ─── Paths ───
@@ -158,10 +164,33 @@ export function cmdOracleMembers(teamName: string): OracleMember[] {
 }
 
 /**
- * Get all oracle member names for a team (for routing fan-out).
+ * Pure helper: filter member oracle names against the sender, honoring the
+ * registry's `excludeSelf` flag (default true).
+ *
+ * Extracted for unit-testing without going through CONFIG_DIR module caching.
  */
-export function getOracleMembers(teamName: string): string[] {
+export function filterMembers(
+  members: OracleMember[],
+  excludeSelf: boolean | undefined,
+  currentOracle?: string,
+): string[] {
+  const all = members.map(m => m.oracle);
+  // Default true — filter only when explicitly false.
+  if (excludeSelf !== false && currentOracle) {
+    return all.filter(o => o !== currentOracle);
+  }
+  return all;
+}
+
+/**
+ * Get oracle member names for a team (for routing fan-out).
+ *
+ * When `currentOracle` is provided and the registry's `excludeSelf` flag is
+ * not explicitly false, the sending oracle is filtered out so a team
+ * broadcast does not re-inject into its own pane (#742 follow-up).
+ */
+export function getOracleMembers(teamName: string, currentOracle?: string): string[] {
   const registry = loadOracleRegistry(teamName);
   if (!registry) return [];
-  return registry.members.map(m => m.oracle);
+  return filterMembers(registry.members, registry.excludeSelf, currentOracle);
 }

--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -124,14 +124,26 @@ export async function cmdSend(query: string, message: string, force = false) {
       console.error("usage: maw hey team:<team-name> <message>");
       process.exit(1);
     }
-    const { getOracleMembers } = await import("../plugins/team/oracle-members");
-    const members = getOracleMembers(teamName);
+    const { getOracleMembers, loadOracleRegistry } = await import("../plugins/team/oracle-members");
+    const senderOracle = resolveMyName(config);
+    const members = getOracleMembers(teamName, senderOracle);
     if (members.length === 0) {
-      console.error(`\x1b[31m✗\x1b[0m no oracle members in team '${teamName}'`);
-      console.error(`\x1b[33mhint\x1b[0m: add members with: maw team oracle-invite <oracle-name> --team ${teamName}`);
+      const registry = loadOracleRegistry(teamName);
+      if (registry && registry.members.length > 0) {
+        console.error(`\x1b[31m✗\x1b[0m team '${teamName}' has only the sender ('${senderOracle}') as a member`);
+        console.error(`\x1b[33mhint\x1b[0m: invite more members or set excludeSelf:false in the registry`);
+      } else {
+        console.error(`\x1b[31m✗\x1b[0m no oracle members in team '${teamName}'`);
+        console.error(`\x1b[33mhint\x1b[0m: add members with: maw team oracle-invite <oracle-name> --team ${teamName}`);
+      }
       process.exit(1);
     }
-    console.log(`\x1b[36m⚡\x1b[0m fan-out to ${members.length} oracle(s) in team '${teamName}':`);
+    const totalMembers = (loadOracleRegistry(teamName)?.members.length ?? members.length);
+    if (totalMembers > members.length) {
+      console.log(`\x1b[36m⚡\x1b[0m fan-out to ${members.length} oracle(s) in team '${teamName}' \x1b[90m(self '${senderOracle}' excluded)\x1b[0m:`);
+    } else {
+      console.log(`\x1b[36m⚡\x1b[0m fan-out to ${members.length} oracle(s) in team '${teamName}':`);
+    }
     let delivered = 0;
     let failed = 0;
 

--- a/test/isolated/oracle-members.test.ts
+++ b/test/isolated/oracle-members.test.ts
@@ -136,6 +136,62 @@ describe("oracle-members registry", () => {
     expect(existsSync(registryPath)).toBe(false);
   });
 
+  test("filterMembers excludes sender by default (#742 follow-up)", async () => {
+    const { filterMembers } = await import("../../src/commands/plugins/team/oracle-members");
+    const members = [
+      { oracle: "echo", role: "knowledge", addedAt: "2026-04-25T00:00:00.000Z" },
+      { oracle: "labubu", role: "pm", addedAt: "2026-04-25T00:00:00.000Z" },
+      { oracle: "neo", role: "backend", addedAt: "2026-04-25T00:00:00.000Z" },
+      { oracle: "nari", role: "hr", addedAt: "2026-04-25T00:00:00.000Z" },
+      { oracle: "pulse", role: "ops", addedAt: "2026-04-25T00:00:00.000Z" },
+    ];
+
+    // Default (excludeSelf undefined) + sender 'echo' → echo filtered out
+    const filtered = filterMembers(members, undefined, "echo");
+    expect(filtered).not.toContain("echo");
+    expect(filtered).toHaveLength(4);
+    expect(filtered).toEqual(expect.arrayContaining(["labubu", "neo", "nari", "pulse"]));
+
+    // No sender provided → all 5 members returned (back-compat)
+    const all = filterMembers(members, undefined);
+    expect(all).toHaveLength(5);
+    expect(all).toContain("echo");
+  });
+
+  test("filterMembers includes sender when excludeSelf:false (opt-in)", async () => {
+    const { filterMembers } = await import("../../src/commands/plugins/team/oracle-members");
+    const members = [
+      { oracle: "alpha", role: "lead", addedAt: "2026-04-25T00:00:00.000Z" },
+      { oracle: "beta", role: "member", addedAt: "2026-04-25T00:00:00.000Z" },
+    ];
+
+    // excludeSelf: false → sender stays in the list
+    const all = filterMembers(members, false, "alpha");
+    expect(all).toHaveLength(2);
+    expect(all).toContain("alpha");
+
+    // excludeSelf: true (explicit) → sender filtered
+    const filtered = filterMembers(members, true, "alpha");
+    expect(filtered).toHaveLength(1);
+    expect(filtered).not.toContain("alpha");
+  });
+
+  test("registry serializes excludeSelf flag round-trip", () => {
+    const teamsDir = join(testDir, "teams", "with-flag");
+    mkdirSync(teamsDir, { recursive: true });
+    const registryPath = join(teamsDir, "oracle-members.json");
+    const { writeFileSync } = require("fs");
+    writeFileSync(registryPath, JSON.stringify({
+      name: "with-flag",
+      members: [{ oracle: "x", role: "lead", addedAt: "2026-04-25T00:00:00.000Z" }],
+      createdAt: "2026-04-25T00:00:00.000Z",
+      excludeSelf: false,
+    }, null, 2));
+
+    const data = JSON.parse(readFileSync(registryPath, "utf-8"));
+    expect(data.excludeSelf).toBe(false);
+  });
+
   test("registry stores correct shape", () => {
     const teamsDir = join(testDir, "teams", "my-team");
     mkdirSync(teamsDir, { recursive: true });


### PR DESCRIPTION
## Summary

When `maw hey team:<name>` is invoked, the sending oracle is now filtered out of the fan-out so a team broadcast does not re-inject into its own pane.

## Why

Echo's Phase 1 ship-report on 2026-04-25 (maw-js #742) confirmed that when a `maw hey team:labubu-family ...` fan-out includes the sender, the message lands in the sender's own prompt buffer as next user input — Echo wasted one turn responding to her own standup. Codified in the Oracle family doctrine as Decision C.

## Changes

- Add `excludeSelf?: boolean` field to `OracleTeamRegistry` (default `true`).
- Extract pure helper `filterMembers(members, excludeSelf, currentOracle)` so the filter logic can be unit-tested without going through `CONFIG_DIR` module caching.
- `getOracleMembers(teamName, currentOracle?)` now applies the filter via the helper.
- `cmdSend` resolves the sender via `resolveMyName(config)` and passes it to `getOracleMembers`. The UI surfaces `(self '<name>' excluded)` when filtering kicks in.
- Friendly hint when the team has only the sender as a member.

## Backwards compatibility

Existing registries without the new flag get the safer default (exclude self). Teams that want self-inclusive fan-out can opt back in by setting `excludeSelf: false` in the registry JSON.

## Test plan

- [x] `bun test test/isolated/oracle-members.test.ts` — 8/8 pass (3 new tests: default exclude, opt-in inclusion, schema round-trip).
- [x] `bun test test/**team*.test.ts` — 63/63 pass (no regressions in team-* suite).
- [x] `bun build src/cli.ts --target=bun` — builds clean (1.64 MB, 630 modules).

## Out of scope

The new flag is registry-level, not per-message. If a future use case needs per-message override, add a `--include-self` CLI flag in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)