### PR TITLE
feat(api): mobile attach — upload UUID/url + send attachments[]

### DIFF
--- a/src/api/sessions.ts
+++ b/src/api/sessions.ts
@@ -103,7 +103,10 @@ sessionsApi.get("/mirror", async ({ query, set}) => {
 
 sessionsApi.post("/send", async ({ body, set}) => {
   try {
-    const { target, text, force } = body;
+    const { target, text, force, attachments } = body;
+    const message = attachments?.length
+      ? attachments.join("\n") + "\n" + text
+      : text;
 
     const config = loadConfig();
     const local = await listSessions();
@@ -131,7 +134,7 @@ sessionsApi.post("/send", async ({ body, set}) => {
           }
         }
       }
-      await sendKeys(resolved.target, text);
+      await sendKeys(resolved.target, message);
       await Bun.sleep(150);
       let lastLine = "";
       try { const content = await capture(resolved.target, 3); lastLine = content.split("\n").filter(l => l.trim()).pop() || ""; } catch {}
@@ -142,7 +145,7 @@ sessionsApi.post("/send", async ({ body, set}) => {
     if (resolved?.type === "peer") {
       const res = await curlFetch(`${resolved.peerUrl}/api/send`, {
         method: "POST",
-        body: JSON.stringify({ target: resolved.target, text }),
+        body: JSON.stringify({ target: resolved.target, text: message }),
         timeout: 10000,
       });
       if (res.ok && res.data?.ok) {
@@ -154,7 +157,7 @@ sessionsApi.post("/send", async ({ body, set}) => {
     // Fallback: async peer discovery
     const peerUrl = await findPeerForTarget(target, local);
     if (peerUrl) {
-      const ok = await sendKeysToPeer(peerUrl, target, text);
+      const ok = await sendKeysToPeer(peerUrl, target, message);
       if (ok) return { ok: true, target, text, source: peerUrl };
       set.status = 502; return { error: "Failed to send to peer", target, source: peerUrl };
     }

--- a/src/api/upload.ts
+++ b/src/api/upload.ts
@@ -1,14 +1,39 @@
 import { Elysia } from "elysia";
 import { mkdirSync, existsSync, readdirSync, statSync, unlinkSync } from "fs";
-import { join, basename } from "path";
+import { join, basename, extname } from "path";
 import { homedir } from "os";
+import { randomUUID } from "crypto";
 
 const INBOX_DIR = join(homedir(), ".maw", "inbox");
+const WEB_DIR = process.env.MAW_UPLOAD_WEB_DIR || "/var/www/maw-uploads";
+const MAX_BYTES = 10 * 1024 * 1024;
+const ALLOWED_MIME = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+  "image/heic",
+  "image/heif",
+]);
+const EXT_BY_MIME: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/webp": "webp",
+  "image/heic": "heic",
+  "image/heif": "heif",
+};
 
 /** Ensure inbox dir exists on first use */
 function ensureInbox() {
   if (!existsSync(INBOX_DIR)) mkdirSync(INBOX_DIR, { recursive: true });
   return INBOX_DIR;
+}
+
+/** Ensure dated web-served dir exists; returns { dir, dateSlug } */
+function ensureWebDated() {
+  const dateSlug = new Date().toISOString().slice(0, 10);
+  const dir = join(WEB_DIR, dateSlug);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  return { dir, dateSlug };
 }
 
 export const uploadApi = new Elysia();
@@ -21,17 +46,36 @@ uploadApi.post("/upload", async ({ body, set }) => {
       set.status = 400;
       return { error: "missing 'file' field — use: curl -F 'file=@image.png' /api/upload" };
     }
-    const dir = ensureInbox();
-    const name = (file as any).name || `upload-${Date.now()}`;
-    const safeName = basename(name).replace(/[^a-zA-Z0-9._-]/g, "_");
-    const dest = join(dir, safeName);
 
-    // Write file to disk
+    const mime = (file as any).type || "";
+    if (!ALLOWED_MIME.has(mime)) {
+      set.status = 415;
+      return { error: `unsupported mime: ${mime || "unknown"} — allowed: png, jpeg, webp, heic, heif` };
+    }
+    if (file.size > MAX_BYTES) {
+      set.status = 413;
+      return { error: `file too large: ${(file.size / 1024 / 1024).toFixed(1)}MB (max 10MB)` };
+    }
+
+    const id = randomUUID();
+    const origName = (file as any).name || `upload-${Date.now()}`;
+    const safeName = basename(origName).replace(/[^a-zA-Z0-9._-]/g, "_");
+    const ext = (EXT_BY_MIME[mime] || extname(safeName).replace(/^\./, "") || "bin").toLowerCase();
+    const filename = `${id}.${ext}`;
+
+    // Primary: web-served path (nginx /maw-uploads/<date>/<id>.<ext>)
+    const { dir: webDir, dateSlug } = ensureWebDated();
+    const dest = join(webDir, filename);
     const buf = Buffer.from(await file.arrayBuffer());
     await Bun.write(dest, buf);
 
+    // Mirror to ~/.maw/inbox for back-compat with /files listing
+    const mirror = join(ensureInbox(), filename);
+    await Bun.write(mirror, buf);
+
+    const url = `/maw-uploads/${dateSlug}/${filename}`;
     const kb = (buf.length / 1024).toFixed(1);
-    return { ok: true, path: dest, name: safeName, size: `${kb}KB` };
+    return { ok: true, id, url, path: dest, name: safeName, size: `${kb}KB`, mime };
   } catch (e: any) {
     set.status = 500;
     return { error: e.message };

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -106,6 +106,7 @@ export const SendBody = Type.Object({
   target: Type.String(),
   text: Type.String(),
   force: Type.Optional(Type.Boolean()),
+  attachments: Type.Optional(Type.Array(Type.String())),
 });
 export type TSendBody = Static<typeof SendBody>;
 

--- a/test/upload.test.ts
+++ b/test/upload.test.ts
@@ -16,6 +16,8 @@ import { Elysia } from "elysia";
 // --- Temp home dir (evaluated before the mock factory, captured by closure) ---
 const TEST_HOME = mkdtempSync(join(tmpdir(), "maw-upload-test-"));
 const INBOX = join(TEST_HOME, ".maw", "inbox");
+const WEB = mkdtempSync(join(tmpdir(), "maw-upload-web-"));
+process.env.MAW_UPLOAD_WEB_DIR = WEB;
 
 // Override os.homedir so INBOX_DIR in upload.ts resolves to our temp dir.
 // mock.module is hoisted by Bun, so it runs before any dynamic imports below.
@@ -34,16 +36,17 @@ beforeAll(async () => {
 
 afterAll(() => {
   rmSync(TEST_HOME, { recursive: true, force: true });
+  rmSync(WEB, { recursive: true, force: true });
 });
 
 // --- POST /upload ---
 
 describe("POST /upload", () => {
-  test("valid file → 200 + {ok, path, name, size}", async () => {
+  test("valid image → 200 + {ok, id, url, path, name, size, mime}", async () => {
     const form = new FormData();
     form.append(
       "file",
-      new File(["hello upload content"], "hello.txt", { type: "text/plain" }),
+      new File(["fake png bytes"], "shot.png", { type: "image/png" }),
     );
     const res = await app.handle(
       new Request("http://localhost/upload", { method: "POST", body: form }),
@@ -51,9 +54,38 @@ describe("POST /upload", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.ok).toBe(true);
-    expect(body.name).toBe("hello.txt");
-    expect(body.path).toInclude(INBOX);
+    expect(body.id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(body.url).toMatch(/^\/maw-uploads\/\d{4}-\d{2}-\d{2}\/[0-9a-f-]{36}\.png$/);
+    expect(body.path).toInclude(WEB);
+    expect(body.name).toBe("shot.png");
+    expect(body.mime).toBe("image/png");
     expect(body.size).toBeDefined();
+  });
+
+  test("disallowed mime → 415", async () => {
+    const form = new FormData();
+    form.append(
+      "file",
+      new File(["plain text"], "hello.txt", { type: "text/plain" }),
+    );
+    const res = await app.handle(
+      new Request("http://localhost/upload", { method: "POST", body: form }),
+    );
+    expect(res.status).toBe(415);
+    const body = await res.json();
+    expect(body.error).toInclude("unsupported mime");
+  });
+
+  test("oversized file → 413", async () => {
+    const big = new Uint8Array(11 * 1024 * 1024);
+    const form = new FormData();
+    form.append("file", new File([big], "big.png", { type: "image/png" }));
+    const res = await app.handle(
+      new Request("http://localhost/upload", { method: "POST", body: form }),
+    );
+    expect(res.status).toBe(413);
+    const body = await res.json();
+    expect(body.error).toInclude("too large");
   });
 
   test("no file field → 400", async () => {


### PR DESCRIPTION
## Summary

Backend extensions for Echo's mobile TerminalView Phase 2 (image attach flow).
Dispatched by Pulse 🫀 → Neo ⚡ on 2026-04-26 02:11 GMT+7.

- `POST /api/upload` returns `{id, url, path, mime, ...}`; validates MIME (png/jpeg/webp/heic/heif) and size (max 10MB); stores at `/var/www/maw-uploads/YYYY-MM-DD/<uuid>.<ext>` with a mirror to `~/.maw/inbox` for `/api/files` back-compat.
- `POST /api/send` accepts optional `attachments: string[]`; each path is prepended on its own line before `text` (local + peer + fallback paths all updated).
- Storage path overridable via `MAW_UPLOAD_WEB_DIR` env (used by tests).

## Test plan

- [x] `bun test test/upload.test.ts` — 9/9 pass (valid image, MIME reject 415, size reject 413, missing field 400, files list/get/delete)
- [x] `bun test test/isolated/send-idle-guard.test.ts` — 12/12 pass (existing send paths unaffected)
- [x] `SendBody` schema accepts/rejects `attachments` correctly via Value.Check
- [x] `bun build src/cli.ts` clean
- [ ] Live mobile flow end-to-end (Echo will validate after merge + nginx wiring)

## Coordination

- Pulse owns nginx `/maw-uploads/` location wiring (Option A per dispatch). Pinging via outbox + `/talk-to`.
- Echo's mobile Phase 2 ship target: Sun 2026-04-26 14:00 BKK (soft).

🤖 Generated with [Claude Code](https://claude.com/claude-code)