### PR TITLE
feat(api): /send returns state field — delivered | queued

### DIFF
--- a/src/api/sessions.ts
+++ b/src/api/sessions.ts
@@ -137,8 +137,18 @@ sessionsApi.post("/send", async ({ body, set}) => {
       await sendKeys(resolved.target, message);
       await Bun.sleep(150);
       let lastLine = "";
-      try { const content = await capture(resolved.target, 3); lastLine = content.split("\n").filter(l => l.trim()).pop() || ""; } catch {}
-      return { ok: true, target: resolved.target, text, source: "local", lastLine };
+      // Echo broadcast bug 2026-04-26: claude queues input behind a busy prompt and
+      // tmux send-keys still succeeds, so callers think delivery worked. Detect the
+      // "Press up to edit queued messages" indicator so the API can distinguish
+      // delivered vs queued.
+      let state: "delivered" | "queued" = "delivered";
+      try {
+        const content = await capture(resolved.target, 8);
+        const lines = content.split("\n").filter(l => l.trim());
+        lastLine = lines.pop() || "";
+        if (/Press up to edit queued messages/i.test(content)) state = "queued";
+      } catch {}
+      return { ok: true, target: resolved.target, text, source: "local", lastLine, state };
     }
 
     // Remote peer → federation HTTP
@@ -149,7 +159,7 @@ sessionsApi.post("/send", async ({ body, set}) => {
         timeout: 10000,
       });
       if (res.ok && res.data?.ok) {
-        return { ok: true, target: res.data.target || target, text, source: resolved.peerUrl, lastLine: res.data.lastLine || "" };
+        return { ok: true, target: res.data.target || target, text, source: resolved.peerUrl, lastLine: res.data.lastLine || "", state: res.data.state ?? "delivered" };
       }
       set.status = 502; return { error: `${resolved.node} → ${resolved.target} send failed`, target, source: resolved.peerUrl };
     }
@@ -158,7 +168,7 @@ sessionsApi.post("/send", async ({ body, set}) => {
     const peerUrl = await findPeerForTarget(target, local);
     if (peerUrl) {
       const ok = await sendKeysToPeer(peerUrl, target, message);
-      if (ok) return { ok: true, target, text, source: peerUrl };
+      if (ok) return { ok: true, target, text, source: peerUrl, state: "delivered" as const };
       set.status = 502; return { error: "Failed to send to peer", target, source: peerUrl };
     }
 


### PR DESCRIPTION
## Summary
- `POST /api/send` now returns `state: "delivered" | "queued"` so callers can distinguish a send that landed at an idle prompt from one that was queued behind a busy claude turn.
- Detection: capture 8 lines after the existing `sleep(150)` and regex-match `Press up to edit queued messages` in the visible buffer.
- Peer branch propagates `res.data.state` with `"delivered"` fallback for older peers (graceful degradation). Async-fallback peer path defaults to `"delivered"` (no buffer to inspect).

## Why
Echo broadcast bug 2026-04-26 — Boss broadcast → 0/5 Oracles received. Three layers; this is the API signal layer. tmux send-keys succeeds silently when claude is mid-turn, so the API previously returned `ok:true` whether or not delivery actually reached the prompt. Echo's UI fix needs the field to render `✓ delivered / ⏳ queued` per-agent.

## Backwards compat
Additive — existing callers (`maw hey`, federation peers in `comm-send.ts`, `sdk.ts`) read `ok` only and ignore the new field. Older remote peers without the field degrade to `"delivered"` (current behavior).

## Test plan
- [x] `bun test` — 1316 pass / 7 skip / 0 fail (1323 across 103 files, 16.24s)
- [x] `bun build src/api/sessions.ts` — bundles 443 modules, no errors
- [x] `tsc --noEmit src/api/sessions.ts` filtered to this file — no new errors (4 pre-existing on lines 50/55/57/197 unrelated to this change)
- [ ] Live probe against busy/idle claude pane (manual, post-merge)

Refs: Labubu inbox `2026-04-26_1027_from-labubu_api-send-state-field-needed.md`. Echo UI fix is chain-merge dependent on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)