### PR TITLE
fix(api/send): filter -view + remote-source sessions from resolver candidates (#758)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.26-alpha.9",
+  "version": "26.4.27-alpha.11",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/core/routing.ts
+++ b/src/core/routing.ts
@@ -30,25 +30,34 @@ export type ResolveResult =
 export function resolveTarget(
   query: string,
   config: MawConfig,
-  sessions: Session[],
+  sessions: (Session & { source?: string })[],
 ): ResolveResult {
   if (!query) return { type: "error", reason: "empty_query", detail: "no target specified", hint: "usage: maw hey <agent> <message>" };
+
+  // #758: candidates that are never valid send targets must be dropped before
+  // findWindow's ambiguity guard fires (#406). `-view` sessions are read-only
+  // mirrors; non-"local" sources are federated records of other peers' agents
+  // that this node can't deliver to via tmux send-keys.
+  const writable = sessions.filter(s =>
+    !s.name.endsWith("-view") &&
+    (s.source === undefined || s.source === "local"),
+  );
 
   const selfNode = config.node ?? "local";
 
   // --- Step 1: Local findWindow + fleet config ---
-  const localTarget = findWindow(sessions, query);
+  const localTarget = findWindow(writable, query);
   if (localTarget) {
     return { type: "local", target: localTarget };
   }
   // Fleet config: oracle name → session name → findWindow (#281)
   const fleetSession = resolveFleetSession(query) || resolveFleetSession(query.replace(/-oracle$/, ""));
   if (fleetSession) {
-    const fleetTarget = findWindow(sessions.filter(s => s.name === fleetSession), query)
-      || findWindow(sessions.filter(s => s.name === fleetSession), query.replace(/-oracle$/, ""));
+    const fleetTarget = findWindow(writable.filter(s => s.name === fleetSession), query)
+      || findWindow(writable.filter(s => s.name === fleetSession), query.replace(/-oracle$/, ""));
     if (fleetTarget) return { type: "local", target: fleetTarget };
     // Fleet config matched but session not running — try first window of fleet session
-    const fleetSess = sessions.find(s => s.name === fleetSession);
+    const fleetSess = writable.find(s => s.name === fleetSession);
     if (fleetSess?.windows.length) return { type: "local", target: `${fleetSession}:${fleetSess.windows[0].index}` };
   }
 
@@ -61,12 +70,12 @@ export function resolveTarget(
 
     // Self-node check: "white:mawjs" from white → resolve locally
     if (nodeName === selfNode) {
-      const selfTarget = findWindow(sessions, agentName);
+      const selfTarget = findWindow(writable, agentName);
       if (selfTarget) return { type: "self-node", target: selfTarget };
       // Try fleet config resolution (#281)
       const selfFleet = resolveFleetSession(agentName) || resolveFleetSession(agentName.replace(/-oracle$/, ""));
       if (selfFleet) {
-        const fleetSess = sessions.find(s => s.name === selfFleet);
+        const fleetSess = writable.find(s => s.name === selfFleet);
         if (fleetSess?.windows.length) return { type: "self-node", target: `${selfFleet}:${fleetSess.windows[0].index}` };
       }
       return { type: "error", reason: "self_not_running", detail: `'${agentName}' not found in local sessions on ${selfNode}`, hint: `maw wake ${agentName}` };

--- a/test/routing.test.ts
+++ b/test/routing.test.ts
@@ -157,3 +157,53 @@ describe("resolveTarget", () => {
     expect(r).toEqual({ type: "peer", peerUrl: "http://100.120.242.120:3456", target: "boonkeeper", node: "oracle-world" });
   });
 });
+
+// --- #758: filter -view mirrors + non-local sources before ambiguity check ---
+
+describe("resolveTarget — #758 candidate filtering", () => {
+  test("`-view` mirror is dropped: bare name resolves to the writable session", () => {
+    // Repro of #758 on white: 08-mawjs (real) + mawjs-view (read-only mirror).
+    // Pre-fix: AmbiguousMatchError thrown with both candidates. Post-fix:
+    // mawjs-view filtered out → only 08-mawjs:1 remains → routes locally.
+    const sessions: Session[] = [
+      { name: "08-mawjs", windows: [{ index: 1, name: "mawjs-oracle", active: true }] },
+      { name: "mawjs-view", windows: [{ index: 1, name: "mawjs-oracle", active: false }] },
+    ];
+    const r = resolveTarget("mawjs-oracle", BASE_CONFIG, sessions);
+    expect(r).toEqual({ type: "local", target: "08-mawjs:1" });
+  });
+
+  test("non-local source is dropped: federated session does not become a candidate", () => {
+    // Aggregated /api/sessions includes peer records tagged with source URL.
+    // resolveTarget must drop those — this node can't deliver via send-keys
+    // to a remote peer's tmux.
+    const sessions = [
+      { name: "08-mawjs", windows: [{ index: 1, name: "mawjs-oracle", active: true }], source: "local" },
+      { name: "101-mawjs", windows: [{ index: 0, name: "mawjs-oracle", active: true }], source: "http://oracle-world.wg:3456" },
+    ];
+    const r = resolveTarget("mawjs-oracle", BASE_CONFIG, sessions);
+    expect(r).toEqual({ type: "local", target: "08-mawjs:1" });
+  });
+
+  test("both filters compose: -view + federated dropped, single local writable wins", () => {
+    // The full #758 scenario: real local + view mirror + federated peer.
+    const sessions = [
+      { name: "08-mawjs", windows: [{ index: 1, name: "mawjs-oracle", active: true }], source: "local" },
+      { name: "mawjs-view", windows: [{ index: 1, name: "mawjs-oracle", active: false }], source: "local" },
+      { name: "101-mawjs", windows: [{ index: 0, name: "mawjs-oracle", active: true }], source: "http://oracle-world.wg:3456" },
+    ];
+    const r = resolveTarget("mawjs-oracle", BASE_CONFIG, sessions);
+    expect(r).toEqual({ type: "local", target: "08-mawjs:1" });
+  });
+
+  test("genuine ambiguity between two writable local sessions still throws (#406 guard intact)", () => {
+    // Two real local sessions both expose the same window name — this is the
+    // case #406 added the guard for. Filter must NOT collapse this into a
+    // silent route; ambiguity error is the correct outcome.
+    const sessions: Session[] = [
+      { name: "08-mawjs", windows: [{ index: 1, name: "mawjs-oracle", active: true }] },
+      { name: "09-mawjs", windows: [{ index: 1, name: "mawjs-oracle", active: false }] },
+    ];
+    expect(() => resolveTarget("mawjs-oracle", BASE_CONFIG, sessions)).toThrow(/Ambiguous match/);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #758 — POST /api/send returned `AmbiguousMatchError` when a bare agent name matched (a) a real local session, (b) its `-view` mirror, AND (c) federated copies from peer nodes. The #406 ambiguity guard correctly fired, but two of those candidates were never deliverable from this node.

## What changed

`resolveTarget` (src/core/routing.ts) now filters the candidate `Session[]` before handing it to `findWindow`:

- Sessions whose name ends in `-view` are dropped (read-only pane mirrors).
- Sessions with a non-`"local"` source are dropped (federated records of other peers' agents — this node can't deliver via local tmux send-keys).

`findWindow` itself stays pure. The filter lives at the caller because that's the only place where the `source` field is available (it's added by the aggregated `/api/sessions` builder, not by tmux discovery).

## Why this place, not findWindow

Per the issue investigation: the `Session` interface in `find-window.ts` has only `{name, windows}` — no `source` field. Adding `source` plumbing through `findWindow` would couple the local-resolution helper to the federation aggregation layer. Filtering at the caller keeps the layering clean.

## Test plan

- [x] `bun test test/routing.test.ts` — 23/23 pass (4 new tests):
  - `-view` mirror dropped → bare name resolves to writable session
  - non-`"local"` source dropped → federated session is not a candidate
  - both filters compose: real local + view mirror + federated peer → unambiguous local route
  - genuine ambiguity between two writable local sessions still throws (#406 guard intact)
- [x] `bun run test` deltas vs main: zero. Pre-existing 14 macOS-only fails (curlFetch / buildCommand) are unrelated and present on `main`; CI on Linux is green.

## CalVer

- `26.4.26-alpha.9` → `26.4.27-alpha.11` (apply slot for hour 11 BKK).

## Coordination

- mawjs-oracle@white asked to be pinged on this — will comment on issue #758 with the PR link after creation.
- Phase 2 / deprecation work for the bare-name target form is tracked in #759 (separate PR landing right behind this one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)