### PR TITLE
feat(maw-hey): deprecation warning for bare-name targets (#759 Phase 1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.26-alpha.9",
+  "version": "26.4.27-alpha.12",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -105,16 +105,36 @@ export async function checkPaneIdle(target: string, host?: string): Promise<{ id
   }
 }
 
+/**
+ * Phase 1 of #759 — bare-name deprecation. The bare-name path still resolves,
+ * but every call prints the suggestion shape from #759 so scripts get pushed
+ * onto the canonical `<node>:<agent>` form before Phase 2 makes it a hard
+ * error. Output is on stderr so it does not contaminate piped stdout.
+ */
+export function formatBareNameDeprecation(node: string, query: string): string {
+  const Y = "\x1b[33m"; // yellow — louder than the old gray tip
+  const C = "\x1b[36m"; // cyan — for canonical suggestion lines
+  const D = "\x1b[90m"; // dim — for explanatory tail
+  const R = "\x1b[0m";
+  return [
+    `${Y}⚠ deprecation${R}: bare-name target '${query}' is deprecated and will be removed (#759)`,
+    ``,
+    `  this node:`,
+    `    ${C}maw hey ${node}:${query} "..."${R}`,
+    ``,
+    `  ${D}run \`maw locate ${query}\` to enumerate cross-node candidates${R}`,
+    ``,
+  ].join("\n");
+}
+
 export async function cmdSend(query: string, message: string, force = false) {
   const config = loadConfig();
 
-  // #362b — inform users when they omit the node prefix. Canonical form is
-  // `<node>:<oracle>` (add `:<window>` to target a specific tmux window when
-  // the session has more than one — see #410). Bare name works locally but
-  // scripts should use the prefixed form for fleet portability. Silent when
-  // MAW_QUIET=1.
+  // #759 Phase 1 — every-call deprecation warning when the user omits the
+  // node prefix. Phase 2 will turn this into a hard error. Honors MAW_QUIET=1
+  // as an explicit per-invocation opt-out (e.g. for hot fan-out loops).
   if (!query.includes(":") && !query.includes("/") && !process.env.MAW_QUIET && config.node) {
-    console.error(`\x1b[90mℹ tip: use canonical form 'maw hey ${config.node}:${query}' for cross-node scripts — append ':<window>' to target a specific window (bare name = exact match locally; errors on ambiguity)\x1b[0m`);
+    console.error(formatBareNameDeprecation(config.node, query));
   }
 
   // --- Team fan-out routing: maw hey team:<team-name> <msg> (#627) ---

--- a/test/comm-send-deprecation-759.test.ts
+++ b/test/comm-send-deprecation-759.test.ts
@@ -1,0 +1,43 @@
+/**
+ * #759 Phase 1 — bare-name deprecation warning emitted by `maw hey`.
+ *
+ * The formatter is tested directly (pure function). The behavior wiring
+ * inside cmdSend (gating on `!query.includes(":")`, MAW_QUIET, config.node)
+ * is verified by inspecting the cmdSend source, since the full async path
+ * pulls in tmux + sessions + sdk and is covered by isolated tests already.
+ */
+import { describe, test, expect } from "bun:test";
+import { formatBareNameDeprecation } from "../src/commands/shared/comm-send";
+
+describe("#759 — bare-name deprecation warning", () => {
+  test("warning marker, query, and canonical suggestion are all present", () => {
+    const out = formatBareNameDeprecation("white", "mawjs-oracle");
+    expect(out).toContain("deprecation");
+    expect(out).toContain("#759");
+    expect(out).toContain("'mawjs-oracle'");
+    // Canonical suggestion line uses the configured node, not "local"
+    expect(out).toContain("maw hey white:mawjs-oracle");
+  });
+
+  test("references `maw locate <agent>` for cross-node enumeration", () => {
+    const out = formatBareNameDeprecation("white", "mawjs-oracle");
+    expect(out).toContain("maw locate mawjs-oracle");
+  });
+
+  test("query is interpolated literally — no shell mangling", () => {
+    // Defense in depth: the formatter is purely string-building. If this ever
+    // gets wired through a shell, the test fails loudly so we know to escape.
+    const out = formatBareNameDeprecation("oracle-world", "weird name with spaces");
+    expect(out).toContain("'weird name with spaces'");
+    expect(out).toContain("maw hey oracle-world:weird name with spaces");
+  });
+
+  test("output is multi-line and matches the issue suggestion shape", () => {
+    const out = formatBareNameDeprecation("white", "mawjs-oracle");
+    // Strip ANSI for shape assertions — color codes don't matter here.
+    const stripped = out.replace(/\x1b\[[0-9;]*m/g, "");
+    const lines = stripped.split("\n");
+    expect(lines.some(l => l.includes("this node:"))).toBe(true);
+    expect(lines.some(l => l.trim().startsWith("maw hey white:mawjs-oracle"))).toBe(true);
+  });
+});

--- a/test/isolated/comm-list.test.ts
+++ b/test/isolated/comm-list.test.ts
@@ -698,44 +698,45 @@ describe("resolveOraclePane", () => {
 // comm-send.ts — cmdSend (bare-name tip, local, peer, plugin, error paths)
 // ════════════════════════════════════════════════════════════════════════════
 
-describe("cmdSend — bare-name tip (#362b)", () => {
-  test("bare name + config.node set → tip on stderr", async () => {
+describe("cmdSend — bare-name deprecation (#362b → #759 Phase 1)", () => {
+  test("bare name + config.node set → deprecation warning on stderr", async () => {
     configOverride = { node: "white" };
     resolveTargetReturn = { type: "error", reason: "not_found", detail: "…" };
 
     await run(() => cmdSend("mawjs", "hi"));
 
     const joined = errs.join("\n");
-    expect(joined).toContain("tip:");
+    expect(joined).toContain("deprecation");
+    expect(joined).toContain("#759");
     expect(joined).toContain("maw hey white:mawjs");
   });
 
-  test("MAW_QUIET=1 suppresses the tip", async () => {
+  test("MAW_QUIET=1 suppresses the deprecation warning", async () => {
     process.env.MAW_QUIET = "1";
     configOverride = { node: "white" };
     resolveTargetReturn = { type: "error", reason: "not_found", detail: "…" };
 
     await run(() => cmdSend("mawjs", "hi"));
 
-    expect(errs.some((e) => e.includes("tip:"))).toBe(false);
+    expect(errs.some((e) => e.includes("deprecation"))).toBe(false);
   });
 
-  test("query containing ':' → no tip (already canonical)", async () => {
+  test("query containing ':' → no warning (already canonical)", async () => {
     configOverride = { node: "white" };
     resolveTargetReturn = { type: "error", reason: "unknown_node", detail: "…" };
 
     await run(() => cmdSend("white:mawjs", "hi"));
 
-    expect(errs.some((e) => e.includes("tip:"))).toBe(false);
+    expect(errs.some((e) => e.includes("deprecation"))).toBe(false);
   });
 
-  test("no config.node → no tip", async () => {
+  test("no config.node → no warning", async () => {
     configOverride = {};
     resolveTargetReturn = { type: "error", reason: "not_found", detail: "…" };
 
     await run(() => cmdSend("mawjs", "hi"));
 
-    expect(errs.some((e) => e.includes("tip:"))).toBe(false);
+    expect(errs.some((e) => e.includes("deprecation"))).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Phase 1 of #759 — every-call deprecation warning when `maw hey` is invoked with a bare agent name (no `<node>:` prefix). The bare-name path still resolves; Phase 2 will turn this into a hard error after consumers migrate.

## Why louder

The previous gray "tip" line (`#362b`) was easy to miss in dense scrollback. Bare-name resolution is the source of #758-class ambiguity bugs (and others), so we want users on the canonical `<node>:<agent>` form before we drop bare-name support entirely.

## What changed

`src/commands/shared/comm-send.ts`:
- New exported pure formatter `formatBareNameDeprecation(node, query)` that returns the multi-line warning text. Yellow header, cyan canonical suggestion line, dim explanatory tail.
- `cmdSend`'s existing bare-name branch now calls the formatter instead of printing the old single-line gray tip.
- Honors `MAW_QUIET=1` (per-invocation opt-out for hot fan-out loops). Output stays on stderr.
- Pre-existing `!query.includes(":")` / `!query.includes("/")` / `config.node` gate is preserved — no new code paths get a warning that didn't already get one.

## Test plan

- [x] `bun test test/comm-send-deprecation-759.test.ts` — 4/4 pass
  - warning marker, query, and canonical suggestion are all present
  - references `maw locate <agent>` for cross-node enumeration
  - query is interpolated literally (no shell mangling)
  - output is multi-line and matches the issue suggestion shape
- [x] `bun run test` deltas vs main: zero regressions. (Pre-existing 14 macOS-only fails are unrelated and present on `main`; CI on Linux is green.)

## Relationship to #758

#758 (PR #760, merged) makes the strict-exact `<node>:<agent>` form safe by filtering `-view` mirrors + non-`local` source sessions out of the resolver. This PR is the user-facing on-ramp pushing scripts onto that canonical form. Phase 2 (#759 follow-up) drops bare-name support entirely once the deprecation has had time to land.

## CalVer

- `26.4.26-alpha.9` → `26.4.27-alpha.12` (hour 12 BKK; hour 11 was claimed by #760).

🤖 Generated with [Claude Code](https://claude.com/claude-code)