### PR TITLE
fix(talk-to): route through resolveTarget — apply writable filter (#762)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.27-alpha.12",
+  "version": "26.4.27-alpha.13",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/plugins/talk-to/impl.ts
+++ b/src/commands/plugins/talk-to/impl.ts
@@ -1,6 +1,5 @@
 import { loadConfig } from "../../../config";
-import { listSessions, sendKeys, getPaneCommand } from "../../../sdk";
-import { findWindow } from "../../../sdk";
+import { listSessions, sendKeys, getPaneCommand, resolveTarget } from "../../../sdk";
 import { runHook } from "../../../sdk";
 import { appendFile, mkdir } from "fs/promises";
 import { homedir, hostname } from "os";
@@ -135,15 +134,25 @@ export async function cmdTalkTo(target: string, message: string, force = false) 
   }
 
   // Step 3: Send hey with context
+  // Route through resolveTarget so the #758 writable filter (drop -view mirrors
+  // and federated peer records before the ambiguity check) applies to talk-to too.
+  // talk-to is local-only delivery: only "local" / "self-node" results map to a tmux pane.
+  const config = loadConfig();
   const sessions = await listSessions();
-  const tmuxTarget = findWindow(sessions, target);
+  const resolved = resolveTarget(target, config, sessions);
+  const tmuxTarget =
+    resolved?.type === "local" || resolved?.type === "self-node"
+      ? resolved.target
+      : null;
   if (!tmuxTarget) {
     // Thread was posted but target window not found — still useful
     if (threadResult) {
       console.log(`\x1b[32m✓\x1b[0m thread #${threadResult.thread_id} updated`);
-      console.log(`\x1b[33mwarn\x1b[0m: window "${target}" not found — message saved to thread only`);
+      const reason = resolved?.type === "error" ? resolved.detail : `window "${target}" not found`;
+      console.log(`\x1b[33mwarn\x1b[0m: ${reason} — message saved to thread only`);
     } else {
-      throw new Error(`window "${target}" not found`);
+      const reason = resolved?.type === "error" ? resolved.detail : `window "${target}" not found`;
+      throw new Error(reason);
     }
     return;
   }

--- a/test/isolated/talk-to-resolve.test.ts
+++ b/test/isolated/talk-to-resolve.test.ts
@@ -1,0 +1,144 @@
+/**
+ * test/isolated/talk-to-resolve.test.ts
+ *
+ * #762: `maw talk-to` must inherit the #758 writable filter (drop -view
+ * mirrors and federated source records) by routing through resolveTarget
+ * instead of calling findWindow directly. Without that, peers with view
+ * mirrors or federated copies of the same agent re-trigger the #406
+ * AmbiguousMatchError that #758 fixed for `maw hey`.
+ *
+ * Isolated because we mock.module(".../src/sdk", ".../src/config") —
+ * mock.module is process-global.
+ */
+import { describe, test, expect, mock, beforeEach, afterEach, afterAll } from "bun:test";
+import { join } from "path";
+import { mockConfigModule } from "../helpers/mock-config";
+
+const srcRoot = join(import.meta.dir, "../..");
+
+// --- Mutable stubs ---
+type SessionRow = { name: string; windows: { index: number; name: string; active: boolean }[]; source?: string };
+
+let sessionsToReturn: SessionRow[] = [];
+let sendKeysCalls: { target: string; message: string }[] = [];
+let runHookCalls: { hook: string; payload: unknown }[] = [];
+
+// Resolve real resolveTarget so the mocked sdk re-exports the real implementation —
+// the bug being tested is "talk-to must call this real function," so we must not
+// stub it.
+const realRouting = await import("../../src/core/routing");
+
+// --- Mock sdk ---
+mock.module(join(srcRoot, "src/sdk"), () => ({
+  listSessions: async () => sessionsToReturn,
+  sendKeys: async (target: string, message: string) => {
+    sendKeysCalls.push({ target, message });
+  },
+  getPaneCommand: async () => "claude",
+  resolveTarget: realRouting.resolveTarget,
+  runHook: async (hook: string, payload: unknown) => {
+    runHookCalls.push({ hook, payload });
+  },
+}));
+
+// --- Mock config ---
+mock.module(join(srcRoot, "src/config"), () =>
+  mockConfigModule(() => ({
+    node: "white",
+    namedPeers: [{ name: "mba", url: "http://10.20.0.3:3457" }],
+    agents: {},
+    peers: [],
+    oracleUrl: "http://oracle.invalid:1",
+  })),
+);
+
+// --- Stub fetch so postToThread + getThreadInfo behave deterministically ---
+// Returning an unreachable Oracle ⇒ threadResult is null ⇒ talk-to throws on
+// "window not found" instead of falling to "thread saved only," which makes
+// the error path observable. The success/local-deliver path exercises sendKeys.
+const origFetch = globalThis.fetch;
+
+// --- Suppress decorated logs ---
+const origLog = console.log;
+const origErr = console.error;
+
+// --- Import module-under-test AFTER mocks installed ---
+const { cmdTalkTo } = await import("../../src/commands/plugins/talk-to/impl");
+
+beforeEach(() => {
+  sessionsToReturn = [];
+  sendKeysCalls = [];
+  runHookCalls = [];
+  // Mock fetch to simulate Oracle reachable + thread created.
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.endsWith("/api/threads?limit=50")) {
+      return new Response(JSON.stringify({ threads: [] }), { status: 200 });
+    }
+    if (url.endsWith("/api/thread")) {
+      return new Response(JSON.stringify({ thread_id: 42, message_id: 1, status: "ok" }), { status: 200 });
+    }
+    if (url.includes("/api/thread/")) {
+      return new Response(JSON.stringify({ thread: { id: 42, title: "x", status: "open", created_at: "" }, messages: [] }), { status: 200 });
+    }
+    return new Response("not found", { status: 404 });
+  }) as typeof fetch;
+  console.log = () => {};
+  console.error = () => {};
+});
+
+afterEach(() => {
+  globalThis.fetch = origFetch;
+  console.log = origLog;
+  console.error = origErr;
+});
+
+afterAll(() => {
+  globalThis.fetch = origFetch;
+  console.log = origLog;
+  console.error = origErr;
+});
+
+describe("cmdTalkTo — #762 routes through resolveTarget", () => {
+  test("(a) -view mirror is dropped from talk-to candidates", async () => {
+    // Real local writable + read-only mirror with the same window name.
+    // Pre-fix this would have thrown AmbiguousMatchError. Post-fix the mirror
+    // is filtered out and talk-to delivers to the writable session.
+    sessionsToReturn = [
+      { name: "08-mawjs", windows: [{ index: 1, name: "mawjs-oracle", active: true }] },
+      { name: "mawjs-view", windows: [{ index: 1, name: "mawjs-oracle", active: false }] },
+    ];
+
+    await cmdTalkTo("mawjs-oracle", "hi");
+
+    expect(sendKeysCalls).toHaveLength(1);
+    expect(sendKeysCalls[0].target).toBe("08-mawjs:1");
+  });
+
+  test("(b) source !== \"local\" is dropped — federated peer record is not a candidate", async () => {
+    // Aggregated session list contains a federated record from another peer.
+    // resolveTarget's writable filter drops anything tagged with non-local
+    // source — this node can't deliver via tmux send-keys to a remote pane.
+    sessionsToReturn = [
+      { name: "08-mawjs", windows: [{ index: 1, name: "mawjs-oracle", active: true }], source: "local" },
+      { name: "101-mawjs", windows: [{ index: 0, name: "mawjs-oracle", active: true }], source: "http://oracle-world.wg:3456" },
+    ];
+
+    await cmdTalkTo("mawjs-oracle", "hi");
+
+    expect(sendKeysCalls).toHaveLength(1);
+    expect(sendKeysCalls[0].target).toBe("08-mawjs:1");
+  });
+
+  test("(c) genuine local-writable ambiguity still throws (#406 guard intact)", async () => {
+    // Two real local sessions both expose the same window name. Filter must
+    // NOT collapse this — ambiguity is the correct outcome.
+    sessionsToReturn = [
+      { name: "08-mawjs", windows: [{ index: 1, name: "mawjs-oracle", active: true }] },
+      { name: "09-mawjs", windows: [{ index: 1, name: "mawjs-oracle", active: false }] },
+    ];
+
+    await expect(cmdTalkTo("mawjs-oracle", "hi")).rejects.toThrow(/Ambiguous match/);
+    expect(sendKeysCalls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #762.

## Summary

`talk-to` was calling `findWindow()` directly, bypassing the same writable filter that **PR #760 (#758)** had applied to `/api/send`. This left a parallel hole: `-view` tmux windows and `source != local` sessions could be selected and sent text.

This PR closes that bypass by routing `talk-to` through the same resolver (`resolveTarget`) that `/api/send` now uses.

## Option chosen

**Option 2 — route through `resolveTarget` (single source of truth).**

The alternative was Option 1: copy the writable filter into `talk-to` directly. We picked Option 2 because future filter changes (e.g. a third "writable" condition) flow through automatically and don't need to be remembered in a second place. One resolver, one filter, one path.

## Changes

- `src/commands/plugins/talk-to/impl.ts` — drop direct `findWindow()` call; use `resolveTarget(target, config, sessions)`. Local/self-node result is routed to `tmuxTarget`; `peer` / `error` / `null` falls through to the existing "thread saved only / window not found" fallback.
- `test/isolated/talk-to-resolve.test.ts` — 3 new isolated tests:
  - `-view` windows are dropped from candidates
  - sessions with `source != local` are dropped
  - `#406` ambiguity guard remains intact

## Test plan

- [x] `bun test test/isolated/talk-to-resolve.test.ts` → **3 pass / 0 fail**
- [x] `bun run test` (full) → **1310 pass / 14 fail / 7 skip** — the 14 failures are the pre-existing unrelated `curlFetch` + `buildCommand` set; **zero new regressions** vs. baseline (1306 → 1310 reflects +4 unrelated tests landed since last session).
- [ ] CI green on this PR
- [ ] Manual smoke: `maw talk-to <name>` resolves through the writable filter

## Related

- **PR #760 (#758)** — parallel `/api/send` fix this PR brings `talk-to` in line with.
- **Follow-up (separate issue to file)** — `talk-to` does not call `resolveOraclePane` like `comm-send` does; multi-pane oracle mis-routing remains a risk. Out of scope here to keep this PR's diff minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)