### PR TITLE
fix(wake): match fleet window names with or without -oracle suffix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.28-alpha.10",
+  "version": "26.4.28-alpha.16",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -64,7 +64,7 @@ export async function resolveOracle(
   try {
     for (const file of readdirSync(FLEET_DIR).filter(f => f.endsWith(".json"))) {
       const config = JSON.parse(readFileSync(join(FLEET_DIR, file), "utf-8")) as FleetSession;
-      const win = (config.windows || []).find((w: FleetWindow) => w.name === `${oracle}-oracle`);
+      const win = (config.windows || []).find((w: FleetWindow) => w.name === `${oracle}-oracle` || w.name === oracle);
       if (win?.repo) {
         const fullPath = await ghqFind(`/${win.repo.replace(/^[^/]+\//, "")}`);
         if (fullPath) {


### PR DESCRIPTION
Fixes #768.

One-line fix at `wake-resolve-impl.ts:67`. Windows[].name can be bare `mktexpert` (no -oracle suffix) — match either form.

Regression of #686/#687.

🤖 Generated with [Claude Code](https://claude.com/claude-code)