### PR TITLE
feat(calver): monotonic alpha counter (Option A from #766)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.28-alpha.17",
+  "version": "26.4.28-alpha.18",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/scripts/calver.ts
+++ b/scripts/calver.ts
@@ -1,25 +1,25 @@
 #!/usr/bin/env bun
 // CalVer bump for maw-js
 //
-// Scheme: v{yy}.{m}.{d}[-alpha.{hour}]
+// Scheme: v{yy}.{m}.{d}[-alpha.{N}]
 // Spec:   https://github.com/Soul-Brews-Studio/mawjs-oracle/blob/main/%CF%88/inbox/2026-04-18_proposal-calver-skills-cli.md
 // Ported from: Soul-Brews-Studio/arra-oracle-skills-cli (PR #262)
 // Umbrella: #526
-//
-// Max 24 alphas per day (one per hour). Stable = no alpha suffix.
+// Option A (#766): monotonic running counter — N starts at 0 each day,
+// counts up per release. Walk existing tags for today's date and pick max+1.
+// No timestamp encoded in the alpha number; pure ordering.
 // Timezone comes from the shell — set TZ=Asia/Bangkok in CI if needed.
 //
 // Usage:
-//   bun scripts/calver.ts                  → 26.4.18-alpha.10
+//   bun scripts/calver.ts                  → 26.4.18-alpha.{next-N}
 //   bun scripts/calver.ts --stable         → 26.4.18
-//   bun scripts/calver.ts --hour 14        → 26.4.18-alpha.14
 //   bun scripts/calver.ts --check          → dry-run (no writes)
 
 import { $ } from "bun";
 import { readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 
-type Args = { stable: boolean; hour?: number; check: boolean; now?: Date };
+type Args = { stable: boolean; check: boolean; now?: Date };
 
 function parseArgs(argv: string[]): Args {
   const args: Args = { stable: false, check: false };
@@ -27,7 +27,10 @@ function parseArgs(argv: string[]): Args {
     const a = argv[i];
     if (a === "--stable") args.stable = true;
     else if (a === "--check" || a === "--dry-run") args.check = true;
-    else if (a === "--hour") args.hour = parseInt(argv[++i], 10);
+    else if (a === "--hour") {
+      console.error("--hour deprecated as of #766; CalVer now uses tag-walk monotonic counter");
+      process.exit(2);
+    }
     else if (a === "-h" || a === "--help") {
       console.log(HELP);
       process.exit(0);
@@ -44,40 +47,71 @@ const HELP = `Usage: bun scripts/calver.ts [options]
 
 Compute next CalVer version and bump package.json.
 
+Scheme: v{yy}.{m}.{d}[-alpha.{N}] — N is a monotonic running counter that
+starts at 0 each day and counts up per release (Option A from #766).
+
 Options:
   --stable         Cut stable (no alpha suffix)
-  --hour N         Override hour 0-23 (default: current hour)
   --check          Dry-run: print target, don't modify files
   -h, --help       Show help
 
 Examples:
-  bun scripts/calver.ts                  alpha at current hour → 26.4.18-alpha.10
-  bun scripts/calver.ts --stable         stable cut            → 26.4.18
-  bun scripts/calver.ts --hour 14        alpha at 14:xx        → 26.4.18-alpha.14
+  bun scripts/calver.ts                  next alpha → 26.4.18-alpha.{next-N}
+  bun scripts/calver.ts --stable         stable cut → 26.4.18
   bun scripts/calver.ts --check          print only, no write`;
 
-export function computeVersion(args: Args): string {
-  const now = args.now ?? new Date();
+export function dateBase(now: Date): string {
   const yy = now.getFullYear() % 100;
   const m = now.getMonth() + 1;
   const d = now.getDate();
-  const base = `${yy}.${m}.${d}`;
-  if (args.stable) return base;
-  const hour = args.hour ?? now.getHours();
-  if (!Number.isInteger(hour) || hour < 0 || hour > 23) {
-    throw new Error(`invalid hour: ${hour} (must be 0-23)`);
+  return `${yy}.${m}.${d}`;
+}
+
+/**
+ * Walk git tags matching `v{base}-alpha.*` and return the max N found,
+ * or -1 if no alpha tags exist for this date yet.
+ */
+export function maxAlphaFromTags(base: string, tags: string[]): number {
+  const prefix = `v${base}-alpha.`;
+  let max = -1;
+  for (const tag of tags) {
+    if (!tag.startsWith(prefix)) continue;
+    const rest = tag.slice(prefix.length);
+    // Option A: pure integer N (no further dots). Reject e.g. "12.0".
+    if (!/^\d+$/.test(rest)) continue;
+    const n = parseInt(rest, 10);
+    if (Number.isInteger(n) && n > max) max = n;
   }
-  return `${base}-alpha.${hour}`;
+  return max;
+}
+
+async function listAlphaTags(base: string): Promise<string[]> {
+  const res = await $`git tag --list ${`v${base}-alpha.*`}`.nothrow().quiet();
+  if (res.exitCode !== 0) return [];
+  return res.stdout.toString().split("\n").map(s => s.trim()).filter(Boolean);
+}
+
+export function computeVersion(args: Args, tags: string[] = []): string {
+  const now = args.now ?? new Date();
+  const base = dateBase(now);
+  if (args.stable) return base;
+  const max = maxAlphaFromTags(base, tags);
+  const next = max + 1; // -1 → 0 if none yet today
+  return `${base}-alpha.${next}`;
 }
 
 async function tagExists(version: string): Promise<boolean> {
-  const res = await $`git rev-parse --verify --quiet v${version}`.nothrow().quiet();
+  const res = await $`git rev-parse --verify --quiet ${`v${version}`}`.nothrow().quiet();
   return res.exitCode === 0;
 }
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
-  const version = computeVersion(args);
+  const now = args.now ?? new Date();
+  const base = dateBase(now);
+
+  const tags = args.stable ? [] : await listAlphaTags(base);
+  const version = computeVersion(args, tags);
   const channel = args.stable ? "stable" : "alpha";
 
   console.log(`Target: v${version}  [${channel}]`);
@@ -88,8 +122,13 @@ async function main() {
   }
 
   if (await tagExists(version)) {
+    // Should never happen for alpha (we picked max+1) but stable can collide.
     console.error(`\n❌ tag v${version} already exists`);
-    console.error(`   → wait for next hour, or use --hour N, or cut --stable`);
+    if (args.stable) {
+      console.error(`   → stable for today already cut; nothing to do`);
+    } else {
+      console.error(`   → race detected: another tag was created between scan and bump`);
+    }
     process.exit(1);
   }
 

--- a/test/calver.test.ts
+++ b/test/calver.test.ts
@@ -1,40 +1,71 @@
 import { describe, it, expect } from "bun:test";
-import { computeVersion } from "../scripts/calver";
+import { computeVersion, dateBase, maxAlphaFromTags } from "../scripts/calver";
+
+describe("calver dateBase", () => {
+  it("yy.m.d with no zero-pad (semver safety)", () => {
+    expect(dateBase(new Date(2026, 3, 18, 9, 37))).toBe("26.4.18");
+    expect(dateBase(new Date(2026, 1, 5, 9, 5))).toBe("26.2.5");
+    expect(dateBase(new Date(2027, 0, 1, 0, 5))).toBe("27.1.1");
+  });
+});
+
+describe("calver maxAlphaFromTags", () => {
+  it("returns -1 when no matching tags", () => {
+    expect(maxAlphaFromTags("26.4.18", [])).toBe(-1);
+    expect(maxAlphaFromTags("26.4.18", ["v26.4.17-alpha.5", "v26.4.19-alpha.0"])).toBe(-1);
+  });
+
+  it("returns max N across matching alpha tags", () => {
+    expect(
+      maxAlphaFromTags("26.4.27", ["v26.4.27-alpha.11", "v26.4.27-alpha.12", "v26.4.27-alpha.13"])
+    ).toBe(13);
+  });
+
+  it("handles non-monotonic tag order", () => {
+    expect(
+      maxAlphaFromTags("26.4.27", ["v26.4.27-alpha.13", "v26.4.27-alpha.0", "v26.4.27-alpha.7"])
+    ).toBe(13);
+  });
+
+  it("ignores tags with non-integer suffixes (e.g. two-tier alpha.12.0)", () => {
+    expect(
+      maxAlphaFromTags("26.4.27", ["v26.4.27-alpha.5", "v26.4.27-alpha.12.0"])
+    ).toBe(5);
+  });
+
+  it("handles single-digit and multi-digit N", () => {
+    expect(maxAlphaFromTags("26.4.18", ["v26.4.18-alpha.0"])).toBe(0);
+    expect(maxAlphaFromTags("26.4.18", ["v26.4.18-alpha.99"])).toBe(99);
+  });
+});
 
 describe("calver computeVersion", () => {
   const apr18_0937 = new Date(2026, 3, 18, 9, 37);
-  const apr18_2255 = new Date(2026, 3, 18, 22, 55);
+  const apr27_1200 = new Date(2026, 3, 27, 12, 0);
   const jan1_0005  = new Date(2027, 0, 1, 0, 5);
 
-  it("stable: yy.m.d", () => {
-    expect(computeVersion({ stable: true,  check: false, now: apr18_0937 })).toBe("26.4.18");
-    expect(computeVersion({ stable: true,  check: false, now: jan1_0005  })).toBe("27.1.1");
+  it("stable: yy.m.d (ignores tags)", () => {
+    expect(computeVersion({ stable: true, check: false, now: apr18_0937 })).toBe("26.4.18");
+    expect(computeVersion({ stable: true, check: false, now: jan1_0005 })).toBe("27.1.1");
   });
 
-  it("alpha: yy.m.d-alpha.{hour}", () => {
-    expect(computeVersion({ stable: false, check: false, now: apr18_0937 })).toBe("26.4.18-alpha.9");
-    expect(computeVersion({ stable: false, check: false, now: apr18_2255 })).toBe("26.4.18-alpha.22");
-    expect(computeVersion({ stable: false, check: false, now: jan1_0005  })).toBe("27.1.1-alpha.0");
+  it("alpha: starts at 0 when no tags exist for today", () => {
+    expect(computeVersion({ stable: false, check: false, now: apr18_0937 }, [])).toBe("26.4.18-alpha.0");
+    expect(computeVersion({ stable: false, check: false, now: jan1_0005 }, [])).toBe("27.1.1-alpha.0");
   });
 
-  it("explicit --hour overrides current hour", () => {
-    expect(computeVersion({ stable: false, check: false, hour: 14, now: apr18_0937 })).toBe("26.4.18-alpha.14");
-    expect(computeVersion({ stable: false, check: false, hour: 0,  now: apr18_0937 })).toBe("26.4.18-alpha.0");
+  it("alpha: bumps to max+1 from existing today's tags", () => {
+    const tags = ["v26.4.27-alpha.11", "v26.4.27-alpha.12"];
+    expect(computeVersion({ stable: false, check: false, now: apr27_1200 }, tags)).toBe("26.4.27-alpha.13");
   });
 
-  it("--stable ignores --hour", () => {
-    expect(computeVersion({ stable: true,  check: false, hour: 14, now: apr18_0937 })).toBe("26.4.18");
+  it("alpha: ignores tags from other dates", () => {
+    const tags = ["v26.4.26-alpha.99", "v26.4.28-alpha.50"];
+    expect(computeVersion({ stable: false, check: false, now: apr27_1200 }, tags)).toBe("26.4.27-alpha.0");
   });
 
-  it("rejects invalid hour", () => {
-    expect(() => computeVersion({ stable: false, check: false, hour: -1, now: apr18_0937 })).toThrow();
-    expect(() => computeVersion({ stable: false, check: false, hour: 24, now: apr18_0937 })).toThrow();
-    expect(() => computeVersion({ stable: false, check: false, hour: 1.5, now: apr18_0937 })).toThrow();
-  });
-
-  it("no zero-pad (semver safety)", () => {
-    const feb5_0905 = new Date(2026, 1, 5, 9, 5);
-    expect(computeVersion({ stable: true,  check: false, now: feb5_0905 })).toBe("26.2.5");
-    expect(computeVersion({ stable: false, check: false, now: feb5_0905 })).toBe("26.2.5-alpha.9");
+  it("--stable ignores tags entirely", () => {
+    const tags = ["v26.4.27-alpha.99"];
+    expect(computeVersion({ stable: true, check: false, now: apr27_1200 }, tags)).toBe("26.4.27");
   });
 });


### PR DESCRIPTION
## Summary

Switch CalVer alpha from hour-bucket to a monotonic running counter (Option A from #766).

- `v{yy}.{m}.{d}-alpha.{N}` — N starts at 0 each day, walks `v{yy}.{m}.{d}-alpha.*` tags and picks `max+1`
- Drop `--hour` flag entirely; pass `--hour N` and the script exits 2 with a one-line deprecation note (`--hour deprecated as of #766; CalVer now uses tag-walk monotonic counter`)
- `--stable`, `--check`, `--help` unchanged
- Reject non-integer suffixes in tag walk so a future two-tier `alpha.12.0` can't poison the max
- Existing `v26.4.27-alpha.11/.12/.13` tags untouched; next bump from this point lands at `alpha.14`

## Why

Per #766: on bursty PR-ship days (e.g. 2026-04-27) the existing workaround `--hour N+1` was used twice in 50min to dodge collisions, producing tags whose number lied about the wall-clock hour they were cut at. A pure counter never collides, and tag timestamps already encode wall-clock time perfectly.

## Test plan

- [x] `bun test test/calver.test.ts` — 11 pass
- [x] `bun scripts/calver.ts --check` → `Target: v26.4.28-alpha.0  [alpha]`
- [x] `bun scripts/calver.ts --stable --check` → `Target: v26.4.28  [stable]`
- [x] `bun scripts/calver.ts --hour 5` → exits 2 with deprecation note
- [x] Verified against real 04-27 tag set: `[alpha.11, alpha.12, alpha.13]` → next = `alpha.14`
- [ ] Reviewer confirms targeting `alpha` branch is correct (per #767 alpha-branch workflow)

Refs #766
Targets `alpha` branch per #767.