### PR TITLE
fix(api): /api/fleet returns JSON not TypeScript types (#747)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.28-alpha.18",
+  "version": "26.4.28-alpha.19",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/test/isolated/api-fleet-json.test.ts
+++ b/test/isolated/api-fleet-json.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Regression test for #747 — `/api/fleet` MUST return JSON, never TypeScript
+ * type definitions.
+ *
+ * The bug shape from #747:
+ *   curl http://localhost:3456/api/fleet
+ *   →  { fleet: [{ file: string, name: string, ... }] }   ❌ types
+ *
+ * Expected:
+ *   →  {"fleet":[{"file":"...","name":"...", ...}]}        ✓ JSON
+ *
+ * Root-cause class: an Elysia route declared with a schema as the second
+ * argument and no handler body causes the validator schema to be serialized
+ * into the response. e.g.
+ *   api.get("/fleet", { response: t.Object({...}) })   // BAD — no handler
+ * vs.
+ *   api.get("/fleet", () => ({ fleet: scanFleet() }))   // GOOD — handler
+ *
+ * This test pins down the contract via in-process `app.handle(req)` so any
+ * future regression that returns a non-JSON body, or a body whose values are
+ * type strings instead of real data, fails the suite.
+ */
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { Elysia } from "elysia";
+
+// FLEET_DIR is captured at module import time from MAW_HOME — set it before
+// the dynamic import of federation.ts (which transitively pulls paths.ts).
+const TEST_HOME = mkdtempSync(join(tmpdir(), "maw-api-fleet-test-"));
+process.env.MAW_HOME = TEST_HOME;
+
+const FLEET_DIR = join(TEST_HOME, "config", "fleet");
+mkdirSync(FLEET_DIR, { recursive: true });
+
+// Two sample fleet entries with predictable shape.
+const sampleA = {
+  name: "alpha-oracle",
+  windows: [{ name: "alpha-oracle", repo: "Soul-Brews-Studio/alpha-oracle" }],
+  budded_from: "neo-oracle",
+};
+const sampleB = {
+  name: "beta-oracle",
+  windows: [{ name: "beta-oracle", repo: "Soul-Brews-Studio/beta-oracle" }],
+  budded_from: "alpha-oracle",
+};
+writeFileSync(join(FLEET_DIR, "alpha-oracle.json"), JSON.stringify(sampleA, null, 2));
+writeFileSync(join(FLEET_DIR, "beta-oracle.json"), JSON.stringify(sampleB, null, 2));
+// A `.disabled` file should be filtered out by the handler.
+writeFileSync(join(FLEET_DIR, "ignored.json.disabled"), JSON.stringify({ name: "ignored" }));
+
+let app: Elysia;
+
+beforeAll(async () => {
+  const { federationApi } = await import("../../src/api/federation");
+  app = new Elysia().use(federationApi);
+});
+
+afterAll(() => {
+  rmSync(TEST_HOME, { recursive: true, force: true });
+  delete process.env.MAW_HOME;
+});
+
+describe("GET /api/fleet — #747 regression", () => {
+  test("returns 200 with application/json content-type", async () => {
+    const res = await app.handle(new Request("http://localhost/fleet"));
+    expect(res.status).toBe(200);
+    const ct = res.headers.get("content-type") || "";
+    expect(ct.toLowerCase()).toContain("application/json");
+  });
+
+  test("body is valid JSON (parses without throwing)", async () => {
+    const res = await app.handle(new Request("http://localhost/fleet"));
+    const text = await res.text();
+    // The bug shape — `{ fleet: [{ file: string, ... }] }` — is NOT valid JSON
+    // because keys are unquoted and values are bare type identifiers.
+    expect(() => JSON.parse(text)).not.toThrow();
+  });
+
+  test("body shape: { fleet: Array<object> } with real config data, not type strings", async () => {
+    const res = await app.handle(new Request("http://localhost/fleet"));
+    const body = (await res.json()) as { fleet: unknown };
+    expect(Array.isArray(body.fleet)).toBe(true);
+
+    const fleet = body.fleet as Array<Record<string, unknown>>;
+    // Two non-disabled fixture files were written → exactly two entries.
+    expect(fleet.length).toBe(2);
+
+    for (const entry of fleet) {
+      // `file` and `name` must be real strings from the JSON, NOT the literal
+      // type identifier "string". The bug's signature is values like
+      // `"file": "string"` instead of `"file": "alpha-oracle.json"`.
+      expect(typeof entry.file).toBe("string");
+      expect(typeof entry.name).toBe("string");
+      expect(entry.file).not.toBe("string");
+      expect(entry.name).not.toBe("string");
+      expect(entry.file).toMatch(/\.json$/);
+    }
+
+    // Verify the actual fixture data is present, not a schema sketch.
+    const names = fleet.map(e => e.name).sort();
+    expect(names).toEqual(["alpha-oracle", "beta-oracle"]);
+  });
+
+  test("filters out *.json.disabled fleet files", async () => {
+    const res = await app.handle(new Request("http://localhost/fleet"));
+    const body = (await res.json()) as { fleet: Array<{ file: string }> };
+    const files = body.fleet.map(e => e.file);
+    expect(files).not.toContain("ignored.json.disabled");
+    expect(files).not.toContain("ignored.json");
+  });
+
+  test("returned text does not contain bare TypeScript type identifiers as values", async () => {
+    // Last-line defense: if Elysia or the handler ever serializes a TypeBox
+    // schema, the response text will contain unquoted `: string` / `: number`
+    // pairs (the type-name leak from #747).
+    const res = await app.handle(new Request("http://localhost/fleet"));
+    const text = await res.text();
+    // JSON always quotes string values: `"file":"alpha-oracle.json"`. The bug
+    // produced `file: string` — which is matched by these patterns.
+    expect(text).not.toMatch(/:\s*string\b/);
+    expect(text).not.toMatch(/:\s*number\b/);
+    expect(text).not.toMatch(/:\s*boolean\b/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #747.

The `/api/fleet` Elysia handler in `src/api/federation.ts` (lines 76-86) is already correctly written — it returns `{ fleet: configs }` where `configs` is the parsed JSON from `~/.config/maw/fleet/*.json`. The bug as described in #747 does not reproduce against `alpha` (`v26.4.28-alpha.18`) or against the `v26.4.24-alpha.12` tag the reporter was running:

```
$ curl -s http://localhost:3456/api/fleet | head -c 120
{"fleet":[{"file":"108-arra-oracle-v3.json","name":"108-arra-oracle-v3","windows":[{"name":"arra-oracle-v3-oracle"...
```

The reporter's quoted output (`{ fleet: [{ file: string, name: string, ... }] }`) is a bug-class signature where an Elysia route is declared with a TypeBox schema as the second argument and no handler body — but no such pattern exists anywhere under `src/api/`.

Most likely cause for the symptom on @jodunk's box: stale `maw` binary, a different bun process bound to `:3456`, or a reverse-proxy returning a docs page. `maw doctor`'s "unreachable" diagnosis comes from probing `/info` (not `/api/fleet`), so the JSON output of `/api/fleet` is unrelated to the doctor failure anyway — that's a separate issue worth filing if it persists after a clean reinstall.

## What this PR adds

A regression test in `test/isolated/api-fleet-json.test.ts` that pins the `/api/fleet` contract via in-process `app.handle()`. Five assertions:

- 200 + `application/json` content-type
- body parses as valid JSON
- shape `{ fleet: Array<object> }` with **real config data** (rejects values like `"file": "string"` — the bug signature)
- `*.json.disabled` files are filtered out
- response text contains no bare TypeScript type identifiers as values (`: string`, `: number`, `: boolean`)

The test lives under `test/isolated/` so the per-file `bun test` runner (`scripts/test-isolated.sh`) gives it a fresh process with `MAW_HOME` set before `federation.ts` captures `FLEET_DIR` at import.

No production code changed.

## Test plan

- [x] `bun test test/isolated/api-fleet-json.test.ts` — 5 pass, 21 expect() calls
- [x] `bun test test/isolated/api-fleet-json.test.ts --randomize` — green
- [x] `tsc --noEmit` — no errors
- [x] Live `curl http://localhost:3456/api/fleet` against running `maw serve` returns valid JSON
- [ ] @jodunk: please re-verify on a fresh `bun add -g github:Soul-Brews-Studio/maw-js` install — if the symptom returns, capture `curl -v` output and we'll dig further

🤖 Generated with [Claude Code](https://claude.com/claude-code)