### PR TITLE
fix(agent-detect): match Claude Code 2.1+ versioned-binary signature

### DIFF
--- a/src/commands/plugins/talk-to/impl.ts
+++ b/src/commands/plugins/talk-to/impl.ts
@@ -1,5 +1,5 @@
 import { loadConfig } from "../../../config";
-import { listSessions, sendKeys, getPaneCommand, resolveTarget } from "../../../sdk";
+import { listSessions, sendKeys, getPaneCommand, isAgentCommand, resolveTarget } from "../../../sdk";
 import { runHook } from "../../../sdk";
 import { appendFile, mkdir } from "fs/promises";
 import { homedir, hostname } from "os";
@@ -160,7 +160,7 @@ export async function cmdTalkTo(target: string, message: string, force = false) 
   // Check if agent is running
   if (!force) {
     const cmd = await getPaneCommand(tmuxTarget);
-    const isAgent = /claude|codex|node/i.test(cmd);
+    const isAgent = isAgentCommand(cmd);
     if (!isAgent) {
       if (threadResult) {
         console.log(`\x1b[32m✓\x1b[0m thread #${threadResult.thread_id} updated`);

--- a/src/commands/shared/comm-list.ts
+++ b/src/commands/shared/comm-list.ts
@@ -2,7 +2,7 @@
  * comm-list.ts — cmdList + renderSessionName + orphan detection.
  */
 
-import { listSessions, getPaneInfos, scanWorktrees } from "../../sdk";
+import { listSessions, getPaneInfos, scanWorktrees, isAgentCommand } from "../../sdk";
 
 /**
  * #359 — render a session header line for `maw ls`.
@@ -32,7 +32,7 @@ export async function cmdList() {
     for (const w of s.windows) {
       const target = `${s.name}:${w.index}`;
       const info = infos[target] || { command: "", cwd: "" };
-      const isAgent = /claude|codex|node/i.test(info.command);
+      const isAgent = isAgentCommand(info.command);
       const cwdBroken = info.cwd.includes("(deleted)") || info.cwd.includes("(dead)");
 
       let dot: string;

--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -3,7 +3,7 @@
  */
 
 import {
-  listSessions, capture, sendKeys, getPaneCommand, findPeerForTarget, resolveTarget,
+  listSessions, capture, sendKeys, getPaneCommand, isAgentCommand, findPeerForTarget, resolveTarget,
   curlFetch, runHook,
 } from "../../sdk";
 import { Tmux } from "../../core/transport/tmux";
@@ -56,7 +56,7 @@ export async function resolveOraclePane(target: string): Promise<string> {
       if (spaceIdx < 0) continue;
       const idx = parseInt(line.slice(0, spaceIdx), 10);
       const cmd = line.slice(spaceIdx + 1);
-      if (Number.isFinite(idx) && /claude|codex|node/i.test(cmd)) {
+      if (Number.isFinite(idx) && isAgentCommand(cmd)) {
         agentIndexes.push(idx);
       }
     }
@@ -231,7 +231,7 @@ export async function cmdSend(query: string, message: string, force = false) {
     const target = await resolveOraclePane(result.target);
     if (!force) {
       const cmd = await getPaneCommand(target);
-      const isAgent = /claude|codex|node/i.test(cmd);
+      const isAgent = isAgentCommand(cmd);
       if (!isAgent) {
         console.error(`\x1b[31merror\x1b[0m: no active Claude session in ${target} (running: ${cmd})`);
         console.error(`\x1b[33mhint\x1b[0m:  run \x1b[36mmaw wake ${query}\x1b[0m first, or use \x1b[36m--force\x1b[0m to send anyway`);

--- a/src/core/runtime/handlers.ts
+++ b/src/core/runtime/handlers.ts
@@ -1,4 +1,4 @@
-import { sendKeys, selectWindow, hostExec, getPaneCommand } from "../transport/ssh";
+import { sendKeys, selectWindow, hostExec, getPaneCommand, isAgentCommand } from "../transport/ssh";
 import { tmux } from "../transport/tmux";
 import { buildCommand } from "../../config";
 import type { MawWS, Handler, MawEngine } from "../types";
@@ -34,7 +34,7 @@ const send: Handler = async (ws, data, engine) => {
   if (!data.force) {
     try {
       const cmd = await getPaneCommand(data.target);
-      if (!/claude|codex|node/i.test(cmd)) {
+      if (!isAgentCommand(cmd)) {
         ws.send(JSON.stringify({ type: "error", error: `no active Claude session in ${data.target} (running: ${cmd})` }));
         return;
       }

--- a/src/core/transport/ssh.ts
+++ b/src/core/transport/ssh.ts
@@ -79,6 +79,16 @@ export async function getPaneCommand(target: string, host?: string): Promise<str
   return t.getPaneCommand(target);
 }
 
+/** Pane command looks like an AI agent — name match (claude/codex/node) or
+ *  Claude Code 2.1+ versioned-binary signature (e.g. "2.1.121"). */
+export function isAgentCommand(cmd: string | null | undefined): boolean {
+  const c = (cmd ?? "").trim();
+  if (!c) return false;
+  if (/claude|codex|node/i.test(c)) return true;
+  if (/^\d+\.\d+\.\d+$/.test(c)) return true;
+  return false;
+}
+
 /** Batch-check which panes are running what command. */
 export async function getPaneCommands(targets: string[], host?: string): Promise<Record<string, string>> {
   const { Tmux } = await import("./tmux");

--- a/src/engine/capture.ts
+++ b/src/engine/capture.ts
@@ -1,4 +1,4 @@
-import { capture } from "../core/transport/ssh";
+import { capture, isAgentCommand } from "../core/transport/ssh";
 import { tmux } from "../core/transport/tmux";
 import type { MawWS } from "../core/types";
 
@@ -79,7 +79,7 @@ export async function sendBusyAgents(ws: MawWS, sessions: SessionInfo[]) {
   const allTargets = sessions.flatMap(s => s.windows.map(w => `${s.name}:${w.index}`));
   const cmds = await tmux.getPaneCommands(allTargets);
   const busy = allTargets
-    .filter(t => /claude|codex|node/i.test(cmds[t] || ""))
+    .filter(t => isAgentCommand(cmds[t]))
     .map(t => {
       const [session] = t.split(":");
       const s = sessions.find(x => x.name === session);

--- a/src/engine/status.ts
+++ b/src/engine/status.ts
@@ -1,4 +1,4 @@
-import { capture } from "../core/transport/ssh";
+import { capture, isAgentCommand } from "../core/transport/ssh";
 import { tmux } from "../core/transport/tmux";
 import type { FeedEvent } from "../lib/feed";
 import type { MawWS } from "../core/types";
@@ -76,7 +76,7 @@ export class StatusDetector {
     // Claude agents get status from real hooks — no capture needed.
     const needsCapture = agents.filter(a => {
       const cmd = (cmds[`${a.session}:${a.target.split(":")[1]}`] || cmds[a.target] || "").toLowerCase();
-      return !/claude|codex|node/i.test(cmd);
+      return !isAgentCommand(cmd);
     });
     const captures = await Promise.allSettled(
       needsCapture.map(async a => ({ target: a.target, content: await capture(a.target, 20) }))
@@ -89,7 +89,7 @@ export class StatusDetector {
     const now = Date.now();
     for (const { target, name, session } of agents) {
       const cmd = (cmds[target] || "").toLowerCase();
-      const isAgent = /claude|codex|node/i.test(cmd);
+      const isAgent = isAgentCommand(cmd);
       const isShell = /^(zsh|bash|sh|fish)$/.test(cmd.trim());
 
       // Skip ALL agents running Claude — real hooks handle their status.

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -39,6 +39,7 @@ export type {
 export {
   hostExec, listSessions, capture, sendKeys,
   getPaneCommand, getPaneCommands, getPaneInfos,
+  isAgentCommand,
   HostExecError,
 } from "../core/transport/ssh";
 export type { Session as SshSession, HostExecTransport } from "../core/transport/ssh";

--- a/test/is-agent-command.test.ts
+++ b/test/is-agent-command.test.ts
@@ -1,0 +1,42 @@
+import { describe, test, expect } from "bun:test";
+import { isAgentCommand } from "../src/core/transport/ssh";
+
+describe("isAgentCommand", () => {
+  test("matches classic agent binary names", () => {
+    expect(isAgentCommand("claude")).toBe(true);
+    expect(isAgentCommand("codex")).toBe(true);
+    expect(isAgentCommand("node")).toBe(true);
+    expect(isAgentCommand("Claude")).toBe(true);
+  });
+
+  test("matches Claude Code 2.1+ versioned binary signature", () => {
+    expect(isAgentCommand("2.1.121")).toBe(true);
+    expect(isAgentCommand("2.1.116")).toBe(true);
+    expect(isAgentCommand("10.0.0")).toBe(true);
+  });
+
+  test("rejects shell commands", () => {
+    expect(isAgentCommand("zsh")).toBe(false);
+    expect(isAgentCommand("bash")).toBe(false);
+    expect(isAgentCommand("sh")).toBe(false);
+    expect(isAgentCommand("fish")).toBe(false);
+  });
+
+  test("handles empty / nullish / whitespace", () => {
+    expect(isAgentCommand("")).toBe(false);
+    expect(isAgentCommand("   ")).toBe(false);
+    expect(isAgentCommand(null)).toBe(false);
+    expect(isAgentCommand(undefined)).toBe(false);
+  });
+
+  test("rejects partial-version strings", () => {
+    expect(isAgentCommand("2.1")).toBe(false);
+    expect(isAgentCommand("v2.1.121")).toBe(false);
+    expect(isAgentCommand("2.1.121-rc1")).toBe(false);
+  });
+
+  test("trims whitespace before matching", () => {
+    expect(isAgentCommand("  claude  ")).toBe(true);
+    expect(isAgentCommand("\t2.1.121\n")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Detect Claude Code 2.1+ where `pane_current_command` is a version string (e.g. `2.1.121`) instead of `claude`/`node`
- Consolidate 8 ad-hoc regex sites behind a single `isAgentCommand()` helper in `src/core/transport/ssh.ts`, re-exported via `src/sdk/index.ts`
- Backward compat preserved — classic binary names (`claude`, `codex`, `node`) still match

## Pattern
```ts
/claude|codex|node/i.test(c) || /^\d+\.\d+\.\d+$/.test(c)
```

## 8 sites consolidated
- `src/core/runtime/handlers.ts:37` (WebSocket send)
- `src/commands/plugins/talk-to/impl.ts:163` (`maw talk-to`)
- `src/commands/shared/comm-list.ts:35` (`maw ls` agent dot)
- `src/commands/shared/comm-send.ts:59` (`resolveOraclePane`)
- `src/commands/shared/comm-send.ts:234` (`maw hey` — original repro)
- `src/engine/capture.ts:82` (`sendBusyAgents`)
- `src/engine/status.ts:79` (capture filter)
- `src/engine/status.ts:92` (StatusDetector)

## Test plan
- [x] 6 unit tests in `test/is-agent-command.test.ts`
- [x] Full suite: `bun run test` — 1316 pass / 14 fail / 7 skip
- [x] Regression check: same 14 failures pre-exist on `main` (curlFetch × 6 + buildCommand contract × 8) — unrelated
- [x] e2e verified locally — `maw ls` shows Claude Code 2.1.116 pane as 🟢 active agent

## Why approach A (regex helper) over B (process-tree walk)
`src/engine/status.ts` polls `getPaneCommands` in a hot loop per pane per tick. Adding `pgrep -P` walks would add `O(panes × depth)` exec calls per tick and require parallel federation through `tmux.ts`/`ssh.ts` for remote nodes. A is one regex, no extra syscalls, contained to a single helper if it ever needs to evolve.

## Optional follow-up (not in this PR)
Switch to full semver `^\d+\.\d+\.\d+(?:[-+][\w.-]+)?$` if `2.1.121-rc1` style tags need matching later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)