### PR TITLE
release: v26.4.28 stable cut

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,24 +49,60 @@ Exempt: type-definition files, specs/docs, generated/scaffolded boilerplate.
 - **Features**: open a short issue describing the problem first. If we align on the shape, a PR is welcome.
 - **Proposals / design docs**: use GitHub Discussions, not issues. Issues are for work; discussions are for thought.
 
+## Branch model
+
+- **`main`** — stable releases only. No alpha tags, no in-progress work. Every commit is a cut version that someone could install today.
+- **`alpha`** — active development. All feature/bugfix PRs target this branch. Alpha versions accumulate here.
+
+PRs to `main` come from one source: `alpha` itself, on a stable cut.
+
 ## Versioning
 
 **maw-js uses CalVer as of 2026-04-18.**
 
-Scheme: `v{yy}.{m}.{d}[-alpha.{hour}]` — e.g. `v26.4.18` (stable) or `v26.4.18-alpha.19` (alpha cut at 19:xx ICT). Up to 24 alpha cuts per day (one per hour). Spec lives in [umbrella #526](https://github.com/Soul-Brews-Studio/maw-js/issues/526) and the [CHANGELOG](./CHANGELOG.md#versioning--calver-since-2026-04-18).
+Scheme: `v{yy}.{m}.{d}[-alpha.{N}]` — e.g. `v26.4.18` (stable) or `v26.4.18-alpha.19` (alpha cut). Spec lives in [umbrella #526](https://github.com/Soul-Brews-Studio/maw-js/issues/526) and the [CHANGELOG](./CHANGELOG.md#versioning--calver-since-2026-04-18). The alpha-counter scheme (hour-bucket vs monotonic) is tracked in [#766](https://github.com/Soul-Brews-Studio/maw-js/issues/766).
 
-### Cut a release
+## Releasing
+
+The day-to-day flow — alphas accumulate on `alpha`, stable cuts roll up to `main`:
+
+1. **Branch from `alpha`.** Name the branch `fix/<issue>-<slug>` or `feat/<issue>-<slug>`.
+   ```bash
+   git fetch origin
+   git checkout -B alpha origin/alpha
+   git checkout -b fix/123-my-bugfix
+   ```
+2. **Open the PR with base `alpha`** (NOT `main`).
+   ```bash
+   gh pr create --base alpha --title "fix: ..."
+   ```
+3. **`/calver --apply` runs on `alpha` only.** Alpha versions accumulate on `alpha`; `main` never receives an alpha bump directly. If you find yourself bumping CalVer on `main`, stop — you're on the wrong branch.
+4. **Cut stable when ready** by opening a PR from `alpha` into `main`:
+   ```bash
+   gh pr create --base main --head alpha --title "release: vYY.M.D"
+   ```
+5. **Merge the stable PR.** Squash-merge or fast-forward, depending on the cut's history. The `.github/workflows/calver-release.yml` workflow auto-tags `v<version>`, cuts a GitHub Release, and attaches the `dist/maw` artifact.
+
+### When to cut stable
+
+Cutting stable is a **discrete decision, not automatic**. Common triggers:
+
+- A coherent batch of fixes/features has settled on `alpha` and tests are green.
+- A user-visible milestone wants a clean version pointer.
+- Time has passed and `alpha` is materially ahead of `main`.
+
+There is no fixed cadence. If `alpha` is quiet, don't cut. If `alpha` has shipped real value, cut.
+
+### Cut commands
 
 ```bash
-TZ=Asia/Bangkok bun scripts/calver.ts            # alpha at current hour, e.g. v26.4.18-alpha.19
-TZ=Asia/Bangkok bun scripts/calver.ts --stable   # stable cut, e.g. v26.4.18
-TZ=Asia/Bangkok bun scripts/calver.ts --hour 14  # alpha at 14:xx
+TZ=Asia/Bangkok bun scripts/calver.ts            # alpha bump (run on `alpha` branch)
+TZ=Asia/Bangkok bun scripts/calver.ts --stable   # stable bump (run on `alpha`, then PR to `main`)
+TZ=Asia/Bangkok bun scripts/calver.ts --hour 14  # alpha pinned to a specific hour bucket
 TZ=Asia/Bangkok bun scripts/calver.ts --check    # dry-run, no writes
 ```
 
-Or via the npm script alias: `bun run calver [--stable|--hour N|--check]` (TZ still recommended).
-
-Then commit + open a PR + merge into `main`. The `.github/workflows/calver-release.yml` workflow auto-tags `v<version>`, cuts a GitHub Release, and attaches the `dist/maw` build artifact. Single job — no cascade gaps.
+Or via the npm-script alias: `bun run calver [--stable|--hour N|--check]` (TZ still recommended).
 
 ### Do NOT manually bump semver
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.28-alpha.18",
+  "version": "26.4.28",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.27-alpha.13",
+  "version": "26.4.28-alpha.9",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.28-alpha.10",
+  "version": "26.4.28-alpha.16",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.28-alpha.17",
+  "version": "26.4.28-alpha.18",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.28-alpha.9",
+  "version": "26.4.28-alpha.10",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.28-alpha.16",
+  "version": "26.4.28-alpha.17",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/scripts/calver.ts
+++ b/scripts/calver.ts
@@ -1,25 +1,25 @@
 #!/usr/bin/env bun
 // CalVer bump for maw-js
 //
-// Scheme: v{yy}.{m}.{d}[-alpha.{hour}]
+// Scheme: v{yy}.{m}.{d}[-alpha.{N}]
 // Spec:   https://github.com/Soul-Brews-Studio/mawjs-oracle/blob/main/%CF%88/inbox/2026-04-18_proposal-calver-skills-cli.md
 // Ported from: Soul-Brews-Studio/arra-oracle-skills-cli (PR #262)
 // Umbrella: #526
-//
-// Max 24 alphas per day (one per hour). Stable = no alpha suffix.
+// Option A (#766): monotonic running counter — N starts at 0 each day,
+// counts up per release. Walk existing tags for today's date and pick max+1.
+// No timestamp encoded in the alpha number; pure ordering.
 // Timezone comes from the shell — set TZ=Asia/Bangkok in CI if needed.
 //
 // Usage:
-//   bun scripts/calver.ts                  → 26.4.18-alpha.10
+//   bun scripts/calver.ts                  → 26.4.18-alpha.{next-N}
 //   bun scripts/calver.ts --stable         → 26.4.18
-//   bun scripts/calver.ts --hour 14        → 26.4.18-alpha.14
 //   bun scripts/calver.ts --check          → dry-run (no writes)
 
 import { $ } from "bun";
 import { readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 
-type Args = { stable: boolean; hour?: number; check: boolean; now?: Date };
+type Args = { stable: boolean; check: boolean; now?: Date };
 
 function parseArgs(argv: string[]): Args {
   const args: Args = { stable: false, check: false };
@@ -27,7 +27,10 @@ function parseArgs(argv: string[]): Args {
     const a = argv[i];
     if (a === "--stable") args.stable = true;
     else if (a === "--check" || a === "--dry-run") args.check = true;
-    else if (a === "--hour") args.hour = parseInt(argv[++i], 10);
+    else if (a === "--hour") {
+      console.error("--hour deprecated as of #766; CalVer now uses tag-walk monotonic counter");
+      process.exit(2);
+    }
     else if (a === "-h" || a === "--help") {
       console.log(HELP);
       process.exit(0);
@@ -44,40 +47,71 @@ const HELP = `Usage: bun scripts/calver.ts [options]
 
 Compute next CalVer version and bump package.json.
 
+Scheme: v{yy}.{m}.{d}[-alpha.{N}] — N is a monotonic running counter that
+starts at 0 each day and counts up per release (Option A from #766).
+
 Options:
   --stable         Cut stable (no alpha suffix)
-  --hour N         Override hour 0-23 (default: current hour)
   --check          Dry-run: print target, don't modify files
   -h, --help       Show help
 
 Examples:
-  bun scripts/calver.ts                  alpha at current hour → 26.4.18-alpha.10
-  bun scripts/calver.ts --stable         stable cut            → 26.4.18
-  bun scripts/calver.ts --hour 14        alpha at 14:xx        → 26.4.18-alpha.14
+  bun scripts/calver.ts                  next alpha → 26.4.18-alpha.{next-N}
+  bun scripts/calver.ts --stable         stable cut → 26.4.18
   bun scripts/calver.ts --check          print only, no write`;
 
-export function computeVersion(args: Args): string {
-  const now = args.now ?? new Date();
+export function dateBase(now: Date): string {
   const yy = now.getFullYear() % 100;
   const m = now.getMonth() + 1;
   const d = now.getDate();
-  const base = `${yy}.${m}.${d}`;
-  if (args.stable) return base;
-  const hour = args.hour ?? now.getHours();
-  if (!Number.isInteger(hour) || hour < 0 || hour > 23) {
-    throw new Error(`invalid hour: ${hour} (must be 0-23)`);
+  return `${yy}.${m}.${d}`;
+}
+
+/**
+ * Walk git tags matching `v{base}-alpha.*` and return the max N found,
+ * or -1 if no alpha tags exist for this date yet.
+ */
+export function maxAlphaFromTags(base: string, tags: string[]): number {
+  const prefix = `v${base}-alpha.`;
+  let max = -1;
+  for (const tag of tags) {
+    if (!tag.startsWith(prefix)) continue;
+    const rest = tag.slice(prefix.length);
+    // Option A: pure integer N (no further dots). Reject e.g. "12.0".
+    if (!/^\d+$/.test(rest)) continue;
+    const n = parseInt(rest, 10);
+    if (Number.isInteger(n) && n > max) max = n;
   }
-  return `${base}-alpha.${hour}`;
+  return max;
+}
+
+async function listAlphaTags(base: string): Promise<string[]> {
+  const res = await $`git tag --list ${`v${base}-alpha.*`}`.nothrow().quiet();
+  if (res.exitCode !== 0) return [];
+  return res.stdout.toString().split("\n").map(s => s.trim()).filter(Boolean);
+}
+
+export function computeVersion(args: Args, tags: string[] = []): string {
+  const now = args.now ?? new Date();
+  const base = dateBase(now);
+  if (args.stable) return base;
+  const max = maxAlphaFromTags(base, tags);
+  const next = max + 1; // -1 → 0 if none yet today
+  return `${base}-alpha.${next}`;
 }
 
 async function tagExists(version: string): Promise<boolean> {
-  const res = await $`git rev-parse --verify --quiet v${version}`.nothrow().quiet();
+  const res = await $`git rev-parse --verify --quiet ${`v${version}`}`.nothrow().quiet();
   return res.exitCode === 0;
 }
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
-  const version = computeVersion(args);
+  const now = args.now ?? new Date();
+  const base = dateBase(now);
+
+  const tags = args.stable ? [] : await listAlphaTags(base);
+  const version = computeVersion(args, tags);
   const channel = args.stable ? "stable" : "alpha";
 
   console.log(`Target: v${version}  [${channel}]`);
@@ -88,8 +122,13 @@ async function main() {
   }
 
   if (await tagExists(version)) {
+    // Should never happen for alpha (we picked max+1) but stable can collide.
     console.error(`\n❌ tag v${version} already exists`);
-    console.error(`   → wait for next hour, or use --hour N, or cut --stable`);
+    if (args.stable) {
+      console.error(`   → stable for today already cut; nothing to do`);
+    } else {
+      console.error(`   → race detected: another tag was created between scan and bump`);
+    }
     process.exit(1);
   }
 

--- a/src/commands/plugins/wake/index.ts
+++ b/src/commands/plugins/wake/index.ts
@@ -57,7 +57,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       const wakeOpts: {
         task?: string; wt?: string; prompt?: string;
         incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean;
-        split?: boolean;
+        split?: boolean; urlRepoName?: string;
       } = {};
       let issueNum: number | null = flags["--issue"] ?? null;
       let repo: string | undefined = flags["--repo"];
@@ -67,6 +67,9 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       if (parsed) {
         await ensureCloned(parsed.slug);
         if (parsed.issueNum) { issueNum = parsed.issueNum; repo = parsed.slug; }
+        // #769 — pass the FULL repo name through so detectSession resolves on
+        // the explicit URL intent rather than the stripped sub-token.
+        wakeOpts.urlRepoName = parsed.slug.split("/").pop();
       }
 
       if (flags["--wt"]) wakeOpts.wt = flags["--wt"];

--- a/src/commands/plugins/wake/index.ts
+++ b/src/commands/plugins/wake/index.ts
@@ -32,7 +32,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       if (!args[0]) {
         return {
           ok: false,
-          error: "usage: maw wake <oracle|org/repo|URL> [task] [--task \"<prompt>\"] [--wt <name>] [--fresh] [--attach] [--issue N] [--pr N] [--repo org/name] [--list]\n       maw wake all [--kill]\n       (--new is a deprecated alias for --wt, removed in alpha.114)",
+          error: "usage: maw wake <oracle|org/repo|URL> [task] [--task \"<prompt>\"] [--wt <name>] [--fresh] [--attach] [--issue N] [--pr N] [--repo org/name] [--list] [--all-local]\n       maw wake all [--kill]\n       (--new is a deprecated alias for --wt, removed in alpha.114)",
         };
       }
 
@@ -52,12 +52,13 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         "--pr": Number, "--repo": String, "--task": String,
         "--fresh": Boolean, "--attach": Boolean, "-a": "--attach", "--list": Boolean, "--ls": "--list",
         "--split": Boolean,
+        "--all-local": Boolean,
       }, 1);
 
       const wakeOpts: {
         task?: string; wt?: string; prompt?: string;
         incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean;
-        split?: boolean; urlRepoName?: string;
+        split?: boolean; urlRepoName?: string; allLocal?: boolean;
       } = {};
       let issueNum: number | null = flags["--issue"] ?? null;
       let repo: string | undefined = flags["--repo"];
@@ -78,6 +79,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       if (flags["--attach"]) wakeOpts.attach = true;
       if (flags["--list"]) wakeOpts.listWt = true;
       if (flags["--split"]) wakeOpts.split = true;
+      if (flags["--all-local"]) wakeOpts.allLocal = true;
 
       const positionals = flags._;
       if (positionals.length > 0) wakeOpts.task = positionals[0];

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -8,7 +8,7 @@ import { resolveOracle, findWorktrees, getSessionMap, resolveFleetSession, detec
 import { attachToSession, ensureSessionRunning, createWorktree } from "./wake-session";
 import { maybeSplit } from "./wake-maybe-split";
 
-export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; split?: boolean; repoPath?: string }): Promise<string> {
+export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; split?: boolean; repoPath?: string; urlRepoName?: string }): Promise<string> {
   // Canonicalize the bare name before any lookup — strips trailing `/`, `/.git`, `/.git/`
   // so `maw wake token-oracle/` (tab-completion artifact) resolves the same as `token-oracle`.
   oracle = normalizeTarget(oracle);
@@ -49,12 +49,15 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
     ? repoPath.slice(repoPath.indexOf("github.com/") + "github.com/".length)
     : repoName;
   console.log(`\x1b[36m→\x1b[0m found \x1b[1m${ghSlug}\x1b[0m (${repoPath})`);
-  let session = await detectSession(oracle);
+  let session = await detectSession(oracle, opts.urlRepoName);
   if (session) console.log(`\x1b[36m→\x1b[0m session exists: ${session}`);
   else console.log(`\x1b[36m→\x1b[0m no session found, creating...`);
 
   if (!session) {
-    session = getSessionMap()[oracle] || resolveFleetSession(oracle) || oracle;
+    // #769 — URL input names the new session after the full repo (e.g.
+    // "m5-oracle") so it's distinct from any unrelated sub-token sessions
+    // and immediately disambiguates future `maw wake` calls.
+    session = getSessionMap()[oracle] || resolveFleetSession(oracle) || opts.urlRepoName || oracle;
     const mainWindowName = `${oracle}-oracle`;
     await tmux.newSession(session, { window: mainWindowName, cwd: repoPath });
     await setSessionEnv(session);

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -8,7 +8,7 @@ import { resolveOracle, findWorktrees, getSessionMap, resolveFleetSession, detec
 import { attachToSession, ensureSessionRunning, createWorktree } from "./wake-session";
 import { maybeSplit } from "./wake-maybe-split";
 
-export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; split?: boolean; repoPath?: string; urlRepoName?: string }): Promise<string> {
+export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; split?: boolean; repoPath?: string; urlRepoName?: string; allLocal?: boolean }): Promise<string> {
   // Canonicalize the bare name before any lookup — strips trailing `/`, `/.git`, `/.git/`
   // so `maw wake token-oracle/` (tab-completion artifact) resolves the same as `token-oracle`.
   oracle = normalizeTarget(oracle);
@@ -40,7 +40,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
     resolved = { repoPath, repoName: repoPath.split("/").pop()!, parentDir: repoPath.replace(/\/[^/]+$/, "") };
     if (!opts.task && !opts.wt) opts.wt = resolved.repoName.replace(/-/g, "");
   } else {
-    resolved = await resolveOracle(oracle);
+    resolved = await resolveOracle(oracle, { allLocal: opts.allLocal });
   }
 
   const { repoPath, repoName, parentDir } = resolved;

--- a/src/commands/shared/wake-resolve-impl.test.ts
+++ b/src/commands/shared/wake-resolve-impl.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Regression tests for #769 — wake URL-resolver greedy substring match.
+ *
+ * detectSession(oracle, urlRepoName) must NOT fall back to substring
+ * matching against the stripped sub-token when the wake target was a URL
+ * (the user expressed full repo intent). It should only match on the
+ * full repo name, the stripped form (exact), or a `NN-<full>` numbered
+ * session — and return null otherwise so the caller can auto-create.
+ */
+import { describe, it, expect, mock } from "bun:test";
+import { join } from "path";
+
+const root = join(import.meta.dir, "../..");
+const { mockConfigModule } = await import("../../../test/helpers/mock-config");
+
+let tmuxSessions: Array<{ name: string }> = [];
+
+mock.module(join(root, "sdk"), () => ({
+  tmux: {
+    listSessions: async () => tmuxSessions,
+  },
+  hostExec: async () => "",
+  curlFetch: async () => ({ ok: false }),
+  FLEET_DIR: "/tmp/maw-test-nonexistent-fleet",
+}));
+
+mock.module(join(root, "config"), () => mockConfigModule(() => ({
+  sessions: {},
+  agents: {},
+  peers: [],
+})));
+
+const { detectSession } = await import("./wake-resolve-impl");
+
+describe("detectSession (#769) — URL-aware resolution", () => {
+  it("URL with `<name>-oracle` repo resolves to exact full-name session", async () => {
+    tmuxSessions = [
+      { name: "01-maw-m5" },
+      { name: "04-ollama-m5" },
+      { name: "m5-oracle" },
+    ];
+    const result = await detectSession("m5", "m5-oracle");
+    expect(result).toBe("m5-oracle");
+  });
+
+  it("URL with no existing session returns null (caller auto-creates)", async () => {
+    // The pre-#769 bug: oracle="m5" + sessions like "01-maw-m5" / "04-ollama-m5"
+    // would be picked up by the generic `endsWith("-${oracle}")` rule and
+    // surface as AmbiguousMatchError. With urlRepoName="m5-oracle", neither
+    // of those sessions matches and we return null cleanly.
+    tmuxSessions = [
+      { name: "01-maw-m5" },
+      { name: "04-ollama-m5" },
+    ];
+    const result = await detectSession("m5", "m5-oracle");
+    expect(result).toBeNull();
+  });
+
+  it("URL with NN-<full-name> numbered prefix resolves to that session", async () => {
+    tmuxSessions = [
+      { name: "01-maw-m5" },
+      { name: "99-m5-oracle" },
+    ];
+    const result = await detectSession("m5", "m5-oracle");
+    expect(result).toBe("99-m5-oracle");
+  });
+
+  it("URL with stripped-form exact match also resolves", async () => {
+    // `name === <repo-name without -oracle>` per issue #769 fix sketch.
+    tmuxSessions = [
+      { name: "m5" },
+    ];
+    const result = await detectSession("m5", "m5-oracle");
+    expect(result).toBe("m5");
+  });
+
+  it("genuine multi-exact-match on full name still errors", async () => {
+    tmuxSessions = [
+      { name: "10-m5-oracle" },
+      { name: "20-m5-oracle" },
+    ];
+    // detectSession calls process.exit(1) on ambiguous numeric matches.
+    // Stub it to throw so we can assert the path was hit.
+    const origExit = process.exit;
+    let exited = false;
+    // @ts-expect-error — test stub
+    process.exit = (code?: number) => { exited = true; throw new Error(`process.exit(${code})`); };
+    try {
+      await expect(detectSession("m5", "m5-oracle")).rejects.toThrow("process.exit(1)");
+      expect(exited).toBe(true);
+    } finally {
+      process.exit = origExit;
+    }
+  });
+});

--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -186,10 +186,29 @@ export function resolveFleetSession(oracle: string): string | null {
   return null;
 }
 
-export async function detectSession(oracle: string): Promise<string | null> {
+export async function detectSession(oracle: string, urlRepoName?: string): Promise<string | null> {
   const sessions = await tmux.listSessions();
   const mapped = getSessionMap()[oracle];
   if (mapped && sessions.find(s => s.name === mapped)) return mapped;
+
+  // #769 — URL/slug input expresses the FULL repo intent (e.g. "m5-oracle").
+  // The bare `oracle` is the stripped form ("m5"), and falling through to the
+  // generic suffix match would greedily hit unrelated `*-m5` sessions
+  // (`01-maw-m5`, `04-ollama-m5`). Match strictly on the full repo name; if
+  // none, return null so the caller auto-creates a session named after it.
+  if (urlRepoName) {
+    const exact = sessions.find(s => s.name === urlRepoName || s.name === oracle);
+    if (exact) return exact.name;
+    const numbered = sessions.filter(s => /^\d+-/.test(s.name) && s.name.endsWith(`-${urlRepoName}`));
+    if (numbered.length === 1) return numbered[0]!.name;
+    if (numbered.length > 1) {
+      console.error(`\x1b[31merror\x1b[0m: '${urlRepoName}' is ambiguous — matches ${numbered.length} fleet sessions:`);
+      for (const s of numbered) console.error(`\x1b[90m    • ${s.name}\x1b[0m`);
+      console.error(`\x1b[90m  use the full name: maw wake <exact-session>\x1b[0m`);
+      process.exit(1);
+    }
+    return null;
+  }
 
   // Numeric-prefixed fleet sessions get first dibs — "110-yeast" beats a bare
   // "yeast" or an ephemeral "yeast-view" when the user types "yeast". If two

--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -64,7 +64,7 @@ export async function resolveOracle(
   try {
     for (const file of readdirSync(FLEET_DIR).filter(f => f.endsWith(".json"))) {
       const config = JSON.parse(readFileSync(join(FLEET_DIR, file), "utf-8")) as FleetSession;
-      const win = (config.windows || []).find((w: FleetWindow) => w.name === `${oracle}-oracle`);
+      const win = (config.windows || []).find((w: FleetWindow) => w.name === `${oracle}-oracle` || w.name === oracle);
       if (win?.repo) {
         const fullPath = await ghqFind(`/${win.repo.replace(/^[^/]+\//, "")}`);
         if (fullPath) {

--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -49,7 +49,10 @@ export async function resolveFromWorktrees(
   };
 }
 
-export async function resolveOracle(oracle: string): Promise<{ repoPath: string; repoName: string; parentDir: string }> {
+export async function resolveOracle(
+  oracle: string,
+  opts?: { allLocal?: boolean },
+): Promise<{ repoPath: string; repoName: string; parentDir: string }> {
   const ghqHit = await ghqFind(`/${oracle}-oracle`);
   if (ghqHit) {
     const repoPath = ghqHit;
@@ -159,7 +162,7 @@ export async function resolveOracle(oracle: string): Promise<{ repoPath: string;
 
   // Scan suggest: offer interactive org scan when all silent resolution paths fail
   try {
-    const scanned = await scanSuggestOracle(oracle);
+    const scanned = await scanSuggestOracle(oracle, { allLocal: opts?.allLocal });
     if (scanned) return scanned;
   } catch { /* scan suggest failed — fall through to original error */ }
 

--- a/src/commands/shared/wake-resolve-scan-suggest.ts
+++ b/src/commands/shared/wake-resolve-scan-suggest.ts
@@ -21,7 +21,21 @@ export interface ScanSuggestDeps {
   hostExecFn?: (cmd: string) => Promise<string>;
   /** Load maw config (injectable for tests) */
   configFn?: () => any;
+  /**
+   * #770 — bypass owned/member-org filter and scan every locally-cloned org.
+   * Rare third-party-org case (oracle spawned into someone else's org).
+   */
+  allLocal?: boolean;
 }
+
+/**
+ * #770 — Result of probing GitHub for the orgs the authenticated user can
+ * actually own a repo in. `ok: false` triggers a graceful fallback to the
+ * unfiltered (all-local) scan with a warning.
+ */
+export type AllowedOrgs =
+  | { ok: true; user: string; orgs: Set<string> }
+  | { ok: false; reason: string };
 
 /** Extract unique org names from `ghq list` output (github.com/<org>/<repo> format). */
 export function extractGhqOrgs(ghqOutput: string): string[] {
@@ -32,6 +46,54 @@ export function extractGhqOrgs(ghqOutput: string): string[] {
     if (parts.length >= 3 && parts[1]) orgs.add(parts[1]);
   }
   return [...orgs].sort();
+}
+
+/**
+ * Process-lifetime cache for the user's owned + member orgs. Single `gh api
+ * user/orgs` per maw invocation; reset between tests via `_resetAllowedOrgsCache`.
+ */
+let _allowedOrgsCache: AllowedOrgs | null = null;
+
+/** @internal — exported only so tests can isolate cases. */
+export function _resetAllowedOrgsCache(): void { _allowedOrgsCache = null; }
+
+/**
+ * Probe `gh api user` and `gh api user/orgs` to derive the orgs the user can
+ * actually host a repo in. Cached on first call. On any failure (no auth,
+ * offline, gh missing) returns `ok: false` so the caller can fall back to the
+ * legacy all-local scan with a warning rather than silently empty out.
+ */
+export function fetchAllowedOrgs(execFn: (cmd: string) => string): AllowedOrgs {
+  if (_allowedOrgsCache) return _allowedOrgsCache;
+
+  let user: string;
+  try {
+    user = execFn("gh api user --jq .login 2>/dev/null").trim();
+    if (!user) throw new Error("empty login");
+  } catch (e: any) {
+    const reason = `gh api user failed: ${String(e?.message || e).split("\n")[0]}`;
+    return (_allowedOrgsCache = { ok: false, reason });
+  }
+
+  const orgs = new Set<string>([user]);
+  try {
+    const raw = execFn("gh api user/orgs --jq '.[].login' 2>/dev/null");
+    for (const line of raw.split("\n")) {
+      const t = line.trim();
+      if (t) orgs.add(t);
+    }
+  } catch {
+    // user lookup worked but org listing failed (e.g. token without `read:org`).
+    // Falling through with just the user is still better than scanning all-local.
+  }
+
+  return (_allowedOrgsCache = { ok: true, user, orgs });
+}
+
+/** Keep only orgs that match `allowed.orgs` (case-sensitive — GitHub org slugs). */
+export function filterOrgsByAllowed(orgs: OrgEntry[], allowed: AllowedOrgs): OrgEntry[] {
+  if (!allowed.ok) return orgs;
+  return orgs.filter(o => allowed.orgs.has(o.name));
 }
 
 /** Combine orgs from ghq list + config, deduped, sorted case-insensitively. */
@@ -159,11 +221,31 @@ export async function scanSuggestOracle(
   let ghqOutput = "";
   try { ghqOutput = execFn("ghq list"); } catch { /* no ghq or empty */ }
 
-  const orgs = buildOrgList(ghqOutput, cfg);
+  const allOrgs = buildOrgList(ghqOutput, cfg);
 
-  if (orgs.length === 0) {
+  if (allOrgs.length === 0) {
     console.error(`\x1b[90mno orgs configured; set githubOrg in config or: ghq get <url>  then re-run\x1b[0m`);
     return null;
+  }
+
+  // #770 — filter to owned/member orgs unless --all-local was passed.
+  // Read-only clones of upstream code (anthropics, NousResearch, etc.) can never
+  // host the user's oracle, so probing them wastes API budget and clutters the prompt.
+  let orgs = allOrgs;
+  let scopeNote = "scope: --all-local (no filter)";
+  if (!deps?.allLocal) {
+    const allowed = fetchAllowedOrgs(execFn);
+    if (allowed.ok) {
+      orgs = filterOrgsByAllowed(allOrgs, allowed);
+      scopeNote = "scope: owned + member orgs only";
+      if (orgs.length === 0) {
+        console.error(`\x1b[33m⚠\x1b[0m no locally-cloned orgs are owned by or shared with @${allowed.user}; pass --all-local to override`);
+        return null;
+      }
+    } else {
+      console.error(`\x1b[33m⚠\x1b[0m org-scope filter unavailable (${allowed.reason}); falling back to all local`);
+      scopeNote = "scope: all local (org-fetch failed)";
+    }
   }
 
   // Strip -oracle suffix if caller passed it (we always append exactly once)
@@ -176,7 +258,7 @@ export async function scanSuggestOracle(
     return `  ${tlink(ghUrl, o.name.padEnd(24))} (${o.source})`;
   }).join("\n");
   console.log(`\n\x1b[36m🔍 Scan for ${stem}?\x1b[0m\n`);
-  console.log(`Provider: github.com`);
+  console.log(`Provider: github.com (${scopeNote})`);
   console.log(`Orgs (${orgs.length}, sorted):\n${orgLines}\n`);
   console.log(`Will check: gh repo view <org>/${stem}  (${orgs.length} request${orgs.length !== 1 ? "s" : ""})\n`);
 

--- a/test/calver.test.ts
+++ b/test/calver.test.ts
@@ -1,40 +1,71 @@
 import { describe, it, expect } from "bun:test";
-import { computeVersion } from "../scripts/calver";
+import { computeVersion, dateBase, maxAlphaFromTags } from "../scripts/calver";
+
+describe("calver dateBase", () => {
+  it("yy.m.d with no zero-pad (semver safety)", () => {
+    expect(dateBase(new Date(2026, 3, 18, 9, 37))).toBe("26.4.18");
+    expect(dateBase(new Date(2026, 1, 5, 9, 5))).toBe("26.2.5");
+    expect(dateBase(new Date(2027, 0, 1, 0, 5))).toBe("27.1.1");
+  });
+});
+
+describe("calver maxAlphaFromTags", () => {
+  it("returns -1 when no matching tags", () => {
+    expect(maxAlphaFromTags("26.4.18", [])).toBe(-1);
+    expect(maxAlphaFromTags("26.4.18", ["v26.4.17-alpha.5", "v26.4.19-alpha.0"])).toBe(-1);
+  });
+
+  it("returns max N across matching alpha tags", () => {
+    expect(
+      maxAlphaFromTags("26.4.27", ["v26.4.27-alpha.11", "v26.4.27-alpha.12", "v26.4.27-alpha.13"])
+    ).toBe(13);
+  });
+
+  it("handles non-monotonic tag order", () => {
+    expect(
+      maxAlphaFromTags("26.4.27", ["v26.4.27-alpha.13", "v26.4.27-alpha.0", "v26.4.27-alpha.7"])
+    ).toBe(13);
+  });
+
+  it("ignores tags with non-integer suffixes (e.g. two-tier alpha.12.0)", () => {
+    expect(
+      maxAlphaFromTags("26.4.27", ["v26.4.27-alpha.5", "v26.4.27-alpha.12.0"])
+    ).toBe(5);
+  });
+
+  it("handles single-digit and multi-digit N", () => {
+    expect(maxAlphaFromTags("26.4.18", ["v26.4.18-alpha.0"])).toBe(0);
+    expect(maxAlphaFromTags("26.4.18", ["v26.4.18-alpha.99"])).toBe(99);
+  });
+});
 
 describe("calver computeVersion", () => {
   const apr18_0937 = new Date(2026, 3, 18, 9, 37);
-  const apr18_2255 = new Date(2026, 3, 18, 22, 55);
+  const apr27_1200 = new Date(2026, 3, 27, 12, 0);
   const jan1_0005  = new Date(2027, 0, 1, 0, 5);
 
-  it("stable: yy.m.d", () => {
-    expect(computeVersion({ stable: true,  check: false, now: apr18_0937 })).toBe("26.4.18");
-    expect(computeVersion({ stable: true,  check: false, now: jan1_0005  })).toBe("27.1.1");
+  it("stable: yy.m.d (ignores tags)", () => {
+    expect(computeVersion({ stable: true, check: false, now: apr18_0937 })).toBe("26.4.18");
+    expect(computeVersion({ stable: true, check: false, now: jan1_0005 })).toBe("27.1.1");
   });
 
-  it("alpha: yy.m.d-alpha.{hour}", () => {
-    expect(computeVersion({ stable: false, check: false, now: apr18_0937 })).toBe("26.4.18-alpha.9");
-    expect(computeVersion({ stable: false, check: false, now: apr18_2255 })).toBe("26.4.18-alpha.22");
-    expect(computeVersion({ stable: false, check: false, now: jan1_0005  })).toBe("27.1.1-alpha.0");
+  it("alpha: starts at 0 when no tags exist for today", () => {
+    expect(computeVersion({ stable: false, check: false, now: apr18_0937 }, [])).toBe("26.4.18-alpha.0");
+    expect(computeVersion({ stable: false, check: false, now: jan1_0005 }, [])).toBe("27.1.1-alpha.0");
   });
 
-  it("explicit --hour overrides current hour", () => {
-    expect(computeVersion({ stable: false, check: false, hour: 14, now: apr18_0937 })).toBe("26.4.18-alpha.14");
-    expect(computeVersion({ stable: false, check: false, hour: 0,  now: apr18_0937 })).toBe("26.4.18-alpha.0");
+  it("alpha: bumps to max+1 from existing today's tags", () => {
+    const tags = ["v26.4.27-alpha.11", "v26.4.27-alpha.12"];
+    expect(computeVersion({ stable: false, check: false, now: apr27_1200 }, tags)).toBe("26.4.27-alpha.13");
   });
 
-  it("--stable ignores --hour", () => {
-    expect(computeVersion({ stable: true,  check: false, hour: 14, now: apr18_0937 })).toBe("26.4.18");
+  it("alpha: ignores tags from other dates", () => {
+    const tags = ["v26.4.26-alpha.99", "v26.4.28-alpha.50"];
+    expect(computeVersion({ stable: false, check: false, now: apr27_1200 }, tags)).toBe("26.4.27-alpha.0");
   });
 
-  it("rejects invalid hour", () => {
-    expect(() => computeVersion({ stable: false, check: false, hour: -1, now: apr18_0937 })).toThrow();
-    expect(() => computeVersion({ stable: false, check: false, hour: 24, now: apr18_0937 })).toThrow();
-    expect(() => computeVersion({ stable: false, check: false, hour: 1.5, now: apr18_0937 })).toThrow();
-  });
-
-  it("no zero-pad (semver safety)", () => {
-    const feb5_0905 = new Date(2026, 1, 5, 9, 5);
-    expect(computeVersion({ stable: true,  check: false, now: feb5_0905 })).toBe("26.2.5");
-    expect(computeVersion({ stable: false, check: false, now: feb5_0905 })).toBe("26.2.5-alpha.9");
+  it("--stable ignores tags entirely", () => {
+    const tags = ["v26.4.27-alpha.99"];
+    expect(computeVersion({ stable: true, check: false, now: apr27_1200 }, tags)).toBe("26.4.27");
   });
 });

--- a/test/wake-resolve-scan-suggest.test.ts
+++ b/test/wake-resolve-scan-suggest.test.ts
@@ -4,16 +4,23 @@
  *
  * All tests use injected deps — no real gh/ghq calls, no /dev/tty access.
  */
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, beforeEach } from "bun:test";
 import {
   extractGhqOrgs,
   buildOrgList,
   scanOrgs,
   scanSuggestOracle,
   readTtyAnswer,
+  fetchAllowedOrgs,
+  filterOrgsByAllowed,
+  _resetAllowedOrgsCache,
   type OrgEntry,
   type TtyReader,
 } from "../src/commands/shared/wake-resolve-scan-suggest";
+
+// #770 — every test that exercises the org-scope filter must start from a
+// clean cache; otherwise a prior test's mocked execFn leaks across cases.
+beforeEach(() => { _resetAllowedOrgsCache(); });
 
 // ---------------------------------------------------------------------------
 // extractGhqOrgs — unit tests
@@ -219,5 +226,236 @@ describe("scanSuggestOracle — non-TTY fallback", () => {
     });
 
     expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #770 — owned/member org scope filter
+// ---------------------------------------------------------------------------
+
+describe("fetchAllowedOrgs (#770)", () => {
+  test("returns user + orgs when both api calls succeed", () => {
+    const execFn = (cmd: string): string => {
+      if (cmd.startsWith("gh api user --jq .login")) return "nazt\n";
+      if (cmd.startsWith("gh api user/orgs")) return "Soul-Brews-Studio\nlaris-co\n";
+      throw new Error(`unexpected: ${cmd}`);
+    };
+    const result = fetchAllowedOrgs(execFn);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.user).toBe("nazt");
+    expect([...result.orgs].sort()).toEqual(["Soul-Brews-Studio", "laris-co", "nazt"].sort());
+  });
+
+  test("falls back to ok:false when gh api user fails (unauthenticated)", () => {
+    const execFn = (cmd: string): string => {
+      if (cmd.startsWith("gh api user --jq")) throw new Error("401 Bad credentials");
+      return "";
+    };
+    const result = fetchAllowedOrgs(execFn);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toContain("gh api user failed");
+  });
+
+  test("returns just the user when user/orgs fails (e.g. token lacks read:org)", () => {
+    const execFn = (cmd: string): string => {
+      if (cmd.startsWith("gh api user --jq")) return "nazt\n";
+      if (cmd.startsWith("gh api user/orgs")) throw new Error("403 Resource not accessible");
+      throw new Error(`unexpected: ${cmd}`);
+    };
+    const result = fetchAllowedOrgs(execFn);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect([...result.orgs]).toEqual(["nazt"]);
+  });
+
+  test("caches across calls — second invocation does not hit execFn", () => {
+    let calls = 0;
+    const execFn = (cmd: string): string => {
+      calls++;
+      if (cmd.startsWith("gh api user --jq")) return "nazt\n";
+      if (cmd.startsWith("gh api user/orgs")) return "Soul-Brews-Studio\n";
+      throw new Error(`unexpected: ${cmd}`);
+    };
+    fetchAllowedOrgs(execFn);
+    const callsAfterFirst = calls;
+    fetchAllowedOrgs(execFn);
+    expect(calls).toBe(callsAfterFirst);
+  });
+});
+
+describe("filterOrgsByAllowed (#770)", () => {
+  const ghqOrgs: OrgEntry[] = [
+    { name: "anthropics", source: "local" },        // read-only upstream — out
+    { name: "NousResearch", source: "local" },      // read-only upstream — out
+    { name: "Soul-Brews-Studio", source: "local" }, // owned — in
+    { name: "nazt", source: "local" },              // user — in
+    { name: "laris-co", source: "local" },          // member — in
+    { name: "arthur-oracle.wt", source: "local" },  // worktree artifact — out
+  ];
+
+  test("(a) read-only upstream orgs are filtered out", () => {
+    const allowed = { ok: true as const, user: "nazt", orgs: new Set(["nazt", "Soul-Brews-Studio", "laris-co"]) };
+    const filtered = filterOrgsByAllowed(ghqOrgs, allowed);
+    const names = filtered.map(o => o.name);
+    expect(names).not.toContain("anthropics");
+    expect(names).not.toContain("NousResearch");
+    expect(names).not.toContain("arthur-oracle.wt");
+  });
+
+  test("(b) owned org is included", () => {
+    const allowed = { ok: true as const, user: "nazt", orgs: new Set(["nazt", "Soul-Brews-Studio"]) };
+    const names = filterOrgsByAllowed(ghqOrgs, allowed).map(o => o.name);
+    expect(names).toContain("Soul-Brews-Studio");
+  });
+
+  test("(c) member org is included", () => {
+    const allowed = { ok: true as const, user: "nazt", orgs: new Set(["nazt", "laris-co"]) };
+    const names = filterOrgsByAllowed(ghqOrgs, allowed).map(o => o.name);
+    expect(names).toContain("laris-co");
+  });
+
+  test("(e) when allowed.ok is false, filter is a passthrough (graceful fallback)", () => {
+    const allowed = { ok: false as const, reason: "gh api user failed: 401" };
+    const result = filterOrgsByAllowed(ghqOrgs, allowed);
+    expect(result).toEqual(ghqOrgs);
+  });
+});
+
+describe("scanSuggestOracle scope filter (#770)", () => {
+  test("(a-c) filters scan to owned + member orgs by default", async () => {
+    const probed: string[] = [];
+    const result = await scanSuggestOracle("liquid", {
+      execFn: (cmd) => {
+        if (cmd.includes("gh --version")) return "gh version 2.0.0";
+        if (cmd.startsWith("ghq list") && !cmd.includes("--full-path")) {
+          return [
+            "github.com/anthropics/claude-code",       // upstream
+            "github.com/NousResearch/some-tool",       // upstream
+            "github.com/Soul-Brews-Studio/maw-js",     // owned
+            "github.com/nazt/dotfiles",                // user
+            "github.com/laris-co/neo-oracle",          // member
+          ].join("\n");
+        }
+        if (cmd.startsWith("gh api user --jq")) return "nazt\n";
+        if (cmd.startsWith("gh api user/orgs")) return "Soul-Brews-Studio\nlaris-co\n";
+        if (cmd.startsWith("gh repo view ")) {
+          const m = cmd.match(/gh repo view '([^']+)'/);
+          if (m) probed.push(m[1]!);
+          throw new Error("not found");
+        }
+        throw new Error(`unexpected: ${cmd}`);
+      },
+      promptFn: () => true,
+      configFn: () => ({}),
+      hostExecFn: async () => "",
+    });
+
+    expect(result).toBeNull();
+    // Read-only upstream orgs must NOT be probed
+    expect(probed).not.toContain("anthropics/liquid-oracle");
+    expect(probed).not.toContain("NousResearch/liquid-oracle");
+    // Allowed orgs MUST be probed
+    expect(probed).toContain("Soul-Brews-Studio/liquid-oracle");
+    expect(probed).toContain("nazt/liquid-oracle");
+    expect(probed).toContain("laris-co/liquid-oracle");
+    expect(probed.length).toBe(3);
+  });
+
+  test("(d) --all-local bypasses filter and scans every org", async () => {
+    const probed: string[] = [];
+    const result = await scanSuggestOracle("liquid", {
+      execFn: (cmd) => {
+        if (cmd.includes("gh --version")) return "gh version 2.0.0";
+        if (cmd.startsWith("ghq list") && !cmd.includes("--full-path")) {
+          return [
+            "github.com/anthropics/claude-code",
+            "github.com/Soul-Brews-Studio/maw-js",
+          ].join("\n");
+        }
+        if (cmd.startsWith("gh api")) {
+          throw new Error("gh api MUST NOT be called when --all-local is set");
+        }
+        if (cmd.startsWith("gh repo view ")) {
+          const m = cmd.match(/gh repo view '([^']+)'/);
+          if (m) probed.push(m[1]!);
+          throw new Error("not found");
+        }
+        throw new Error(`unexpected: ${cmd}`);
+      },
+      promptFn: () => true,
+      configFn: () => ({}),
+      hostExecFn: async () => "",
+      allLocal: true,
+    });
+
+    expect(result).toBeNull();
+    expect(probed).toContain("anthropics/liquid-oracle");
+    expect(probed).toContain("Soul-Brews-Studio/liquid-oracle");
+  });
+
+  test("(e) gh api user failure falls back to all-local with warning (does not abort)", async () => {
+    const probed: string[] = [];
+    const warnings: string[] = [];
+    const origErr = console.error;
+    console.error = (...a: any[]) => { warnings.push(a.map(String).join(" ")); };
+    try {
+      const result = await scanSuggestOracle("liquid", {
+        execFn: (cmd) => {
+          if (cmd.includes("gh --version")) return "gh version 2.0.0";
+          if (cmd.startsWith("ghq list") && !cmd.includes("--full-path")) {
+            return [
+              "github.com/anthropics/claude-code",
+              "github.com/Soul-Brews-Studio/maw-js",
+            ].join("\n");
+          }
+          if (cmd.startsWith("gh api user --jq")) throw new Error("401 Bad credentials");
+          if (cmd.startsWith("gh repo view ")) {
+            const m = cmd.match(/gh repo view '([^']+)'/);
+            if (m) probed.push(m[1]!);
+            throw new Error("not found");
+          }
+          throw new Error(`unexpected: ${cmd}`);
+        },
+        promptFn: () => true,
+        configFn: () => ({}),
+        hostExecFn: async () => "",
+      });
+      expect(result).toBeNull();
+      // Both orgs probed — fallback retains legacy behavior on api failure
+      expect(probed).toContain("anthropics/liquid-oracle");
+      expect(probed).toContain("Soul-Brews-Studio/liquid-oracle");
+      // Warning surfaced so the user understands why the scope wasn't narrowed
+      expect(warnings.some(w => w.includes("org-scope filter unavailable"))).toBe(true);
+    } finally {
+      console.error = origErr;
+    }
+  });
+
+  test("returns null with a hint when filter empties the org list", async () => {
+    const errors: string[] = [];
+    const origErr = console.error;
+    console.error = (...a: any[]) => { errors.push(a.map(String).join(" ")); };
+    try {
+      const result = await scanSuggestOracle("liquid", {
+        execFn: (cmd) => {
+          if (cmd.includes("gh --version")) return "gh version 2.0.0";
+          if (cmd.startsWith("ghq list") && !cmd.includes("--full-path")) {
+            return "github.com/anthropics/claude-code\ngithub.com/NousResearch/some-tool\n";
+          }
+          if (cmd.startsWith("gh api user --jq")) return "nazt\n";
+          if (cmd.startsWith("gh api user/orgs")) return "";
+          throw new Error(`unexpected: ${cmd}`);
+        },
+        promptFn: () => true,
+        configFn: () => ({}),
+        hostExecFn: async () => "",
+      });
+      expect(result).toBeNull();
+      expect(errors.some(e => e.includes("--all-local"))).toBe(true);
+    } finally {
+      console.error = origErr;
+    }
   });
 });


### PR DESCRIPTION
## Stable Cut: v26.4.28

Per CONTRIBUTING.md (#774): alpha → main, strip `-alpha.N` suffix.

### Includes
- #769 — fix(wake): match repo-name not sub-token (#771)
- #770 — feat(wake): scope scan to owned/member orgs (#772)
- #768 — fix(wake): match fleet window names with or without -oracle suffix (#773)
- #767 — docs: CONTRIBUTING.md alpha-branch workflow (#774)
- #766 — feat(calver): monotonic alpha counter (#775)

### Not included (still in flight)
- #747 — PR #776 (regression test, awaiting CI), targets next stable cut

### Post-merge
- Tag `v26.4.28` on main HEAD
- Bump alpha to next iter (e.g. `v26.4.29-alpha.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)