### PR TITLE
feat(hey): auto-wake fleet-known targets (Phase 1.2 of #736)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.28-alpha.20",
+  "version": "26.4.28-alpha.21",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -202,7 +202,38 @@ export async function cmdSend(query: string, message: string, force = false) {
     process.exit(1);
   }
 
-  const sessions = await listSessions();
+  let sessions = await listSessions();
+
+  // --- #736 Phase 1.2: auto-wake fleet-known targets (parity with maw view) ---
+  // Mirrors view/impl.ts:107 — if the user's hey target is fleet-known but
+  // no local session exists, silently wake it before sending. No y/N prompt:
+  // fleet membership is sufficient signal that this isn't a typo. Cross-node
+  // targets are skipped here — the remote peer's federation handler wakes its
+  // own fleet (sessions.ts:/api/wake already does cmdWake for inbound peers).
+  {
+    const colonIdx = query.indexOf(":");
+    const targetNode = colonIdx >= 0 ? query.slice(0, colonIdx) : null;
+    const bareAgent = colonIdx >= 0 ? query.slice(colonIdx + 1).split(":")[0] : query;
+    const isLocalScope = !targetNode || targetNode === config.node;
+    if (isLocalScope && bareAgent) {
+      const hasLocalSession = sessions.some(s =>
+        s.name === bareAgent ||
+        s.windows.some(w => w.name === `${bareAgent}-oracle` || w.name === bareAgent)
+      );
+      if (!hasLocalSession) {
+        try {
+          const { resolveFleetSession } = await import("./wake-resolve");
+          if (resolveFleetSession(bareAgent)) {
+            console.log(`\x1b[36m⚡\x1b[0m '${bareAgent}' is fleet-known — auto-wake`);
+            const { cmdWake } = await import("./wake-cmd");
+            await cmdWake(bareAgent, {});
+            // Refresh after wake — resolver needs the new tmux session visible.
+            sessions = await listSessions();
+          }
+        } catch { /* fleet/wake best-effort — fall through to existing error path */ }
+      }
+    }
+  }
 
   // --- Unified resolution via resolveTarget (#201) ---
   const result = resolveTarget(query, config, sessions);

--- a/test/isolated/hey-fleet-auto-wake.test.ts
+++ b/test/isolated/hey-fleet-auto-wake.test.ts
@@ -1,0 +1,219 @@
+/**
+ * hey-fleet-auto-wake.test.ts — #736 Phase 1.2.
+ *
+ * Verifies cmdSend silently auto-wakes fleet-known targets when no local
+ * session exists yet — parity with `maw view` / `maw a` (view/impl.ts:107).
+ *
+ * Mocked seams: src/sdk, src/config, src/core/routing,
+ *   src/core/runtime/hooks, src/commands/shared/comm-log-feed,
+ *   src/commands/shared/wake-resolve, src/commands/shared/wake-cmd.
+ *
+ * process.exit is stubbed to throw "__exit__:<code>" so the harness survives
+ * branches that would otherwise terminate the runner.
+ */
+import { describe, test, expect, mock, beforeEach, afterEach, afterAll } from "bun:test";
+import { join } from "path";
+
+// ─── Gate ────────────────────────────────────────────────────────────────────
+
+let mockActive = false;
+
+// ─── Capture real module refs BEFORE any mock.module installs ────────────────
+
+const _rSdk = await import("../../src/sdk");
+
+// ─── Mutable stubs ───────────────────────────────────────────────────────────
+
+let sendKeysCalls: Array<{ target: string; text: string }> = [];
+let listSessionsReturn: Array<{ name: string; windows: { index: number; name: string; active: boolean }[] }> = [];
+let resolveTargetReturn: { type: string; target: string; node?: string } = { type: "local", target: "test-session:oracle.0" };
+let fleetKnown: Set<string> = new Set();
+let cmdWakeCalls: Array<{ oracle: string; opts: unknown }> = [];
+let listSessionsCallCount = 0;
+let listSessionsAfterWake: Array<{ name: string; windows: { index: number; name: string; active: boolean }[] }> | null = null;
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
+  ..._rSdk,
+  capture: async () => "",
+  sendKeys: async (target: string, text: string) => {
+    if (!mockActive) return;
+    sendKeysCalls.push({ target, text });
+  },
+  getPaneCommand: async () => "claude",
+  listSessions: async () => {
+    if (!mockActive) return [];
+    listSessionsCallCount++;
+    if (listSessionsCallCount > 1 && listSessionsAfterWake) return listSessionsAfterWake;
+    return listSessionsReturn;
+  },
+  findPeerForTarget: async () => null,
+  curlFetch: async () => ({ ok: false, status: 500, data: {} }),
+  runHook: async () => {},
+  hostExec: async () => "",
+}));
+
+mock.module(join(import.meta.dir, "../../src/config"), () => {
+  const { mockConfigModule } = require("../helpers/mock-config");
+  return mockConfigModule(() => ({ node: "test-node", port: 3456 }));
+});
+
+mock.module(join(import.meta.dir, "../../src/core/routing"), () => ({
+  resolveTarget: () => resolveTargetReturn,
+}));
+
+mock.module(join(import.meta.dir, "../../src/core/runtime/hooks"), () => ({
+  runHook: async () => {},
+}));
+
+mock.module(join(import.meta.dir, "../../src/commands/shared/comm-log-feed"), () => ({
+  logMessage: () => {},
+  emitFeed: () => {},
+}));
+
+mock.module(join(import.meta.dir, "../../src/commands/shared/wake-resolve"), () => ({
+  resolveFleetSession: (oracle: string) => fleetKnown.has(oracle) ? `${oracle}-session` : null,
+}));
+
+mock.module(join(import.meta.dir, "../../src/commands/shared/wake-cmd"), () => ({
+  cmdWake: async (oracle: string, opts: unknown) => {
+    cmdWakeCalls.push({ oracle, opts });
+    return `${oracle}-session`;
+  },
+}));
+
+// Bun.sleep intercept — keep tests fast
+const origSleep = Bun.sleep.bind(Bun);
+(Bun as unknown as { sleep: (ms: number) => Promise<void> }).sleep = async () => {};
+
+// ─── Imports (after mocks) ────────────────────────────────────────────────────
+
+const { cmdSend } = await import("../../src/commands/shared/comm-send");
+
+// ─── Harness ─────────────────────────────────────────────────────────────────
+
+const origExit = process.exit;
+const origErr = console.error;
+const origLog = console.log;
+
+let exitCode: number | undefined;
+let errs: string[] = [];
+let logs: string[] = [];
+
+async function run(fn: () => Promise<unknown>): Promise<void> {
+  exitCode = undefined; errs = []; logs = [];
+  console.error = (...a: unknown[]) => { errs.push(a.map(String).join(" ")); };
+  console.log = (...a: unknown[]) => { logs.push(a.map(String).join(" ")); };
+  (process as unknown as { exit: (c?: number) => never }).exit =
+    (c?: number): never => { exitCode = c ?? 0; throw new Error("__exit__:" + exitCode); };
+  try { await fn(); }
+  catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (!msg.startsWith("__exit__")) throw e;
+  } finally {
+    console.error = origErr;
+    console.log = origLog;
+    (process as unknown as { exit: typeof origExit }).exit = origExit;
+  }
+}
+
+beforeEach(() => {
+  mockActive = true;
+  sendKeysCalls = [];
+  cmdWakeCalls = [];
+  listSessionsCallCount = 0;
+  listSessionsAfterWake = null;
+  fleetKnown = new Set();
+  listSessionsReturn = [];
+  resolveTargetReturn = { type: "local", target: "test-session:oracle.0" };
+  process.env.MAW_QUIET = "1";
+});
+
+afterEach(() => { mockActive = false; delete process.env.MAW_QUIET; });
+afterAll(() => {
+  mockActive = false;
+  (Bun as unknown as { sleep: typeof origSleep }).sleep = origSleep;
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("cmdSend — fleet auto-wake (#736 Phase 1.2)", () => {
+  test("auto-wakes when target is fleet-known and no local session exists", async () => {
+    fleetKnown.add("volt");
+    listSessionsReturn = []; // no session yet
+    listSessionsAfterWake = [{ name: "volt-session", windows: [{ index: 0, name: "volt-oracle", active: true }] }];
+    resolveTargetReturn = { type: "local", target: "volt-session:volt-oracle.0" };
+
+    await run(() => cmdSend("volt", "hello"));
+
+    expect(cmdWakeCalls.length).toBe(1);
+    expect(cmdWakeCalls[0].oracle).toBe("volt");
+    // Auto-wake message printed (no y/N prompt path)
+    expect(logs.some(l => l.includes("fleet-known") && l.includes("auto-wake"))).toBe(true);
+    expect(sendKeysCalls.length).toBe(1);
+    expect(sendKeysCalls[0].text).toBe("hello");
+    expect(exitCode).toBeUndefined();
+  });
+
+  test("does NOT wake when target is fleet-known but session already running", async () => {
+    fleetKnown.add("mawjs");
+    listSessionsReturn = [{ name: "mawjs", windows: [{ index: 0, name: "mawjs-oracle", active: true }] }];
+    resolveTargetReturn = { type: "local", target: "mawjs:mawjs-oracle.0" };
+
+    await run(() => cmdSend("mawjs", "hi"));
+
+    expect(cmdWakeCalls.length).toBe(0);
+    expect(sendKeysCalls.length).toBe(1);
+  });
+
+  test("does NOT wake when target is unknown (not in fleet)", async () => {
+    // fleetKnown empty
+    listSessionsReturn = [];
+    resolveTargetReturn = { type: "error", target: "typo", detail: "not found", hint: "" } as any;
+
+    await run(() => cmdSend("typo", "hi"));
+
+    expect(cmdWakeCalls.length).toBe(0);
+    // resolveTarget returned error → cmdSend exits 1 via the error branch
+    expect(exitCode).toBe(1);
+  });
+
+  test("does NOT wake on cross-node target (peer handles its own wake)", async () => {
+    fleetKnown.add("hojo"); // even if our local fleet knew about it
+    listSessionsReturn = [];
+    resolveTargetReturn = { type: "peer", target: "hojo", node: "phaith", peerUrl: "http://phaith:3456" } as any;
+
+    await run(() => cmdSend("phaith:hojo", "ping"));
+
+    expect(cmdWakeCalls.length).toBe(0);
+  });
+
+  test("auto-wakes on self-node prefixed target (test-node:volt)", async () => {
+    fleetKnown.add("volt");
+    listSessionsReturn = [];
+    listSessionsAfterWake = [{ name: "volt-session", windows: [{ index: 0, name: "volt-oracle", active: true }] }];
+    resolveTargetReturn = { type: "self-node", target: "volt-session:volt-oracle.0" };
+
+    await run(() => cmdSend("test-node:volt", "yo"));
+
+    expect(cmdWakeCalls.length).toBe(1);
+    expect(cmdWakeCalls[0].oracle).toBe("volt");
+    expect(sendKeysCalls.length).toBe(1);
+  });
+
+  test("does NOT prompt y/N — wake is silent on fleet-known", async () => {
+    fleetKnown.add("colab");
+    listSessionsReturn = [];
+    listSessionsAfterWake = [{ name: "colab-session", windows: [{ index: 0, name: "colab-oracle", active: true }] }];
+    resolveTargetReturn = { type: "local", target: "colab-session:colab-oracle.0" };
+
+    await run(() => cmdSend("colab", "msg"));
+
+    // No prompt-style strings should appear in stderr
+    const allErr = errs.join("\n");
+    expect(allErr).not.toContain("[y/N]");
+    expect(allErr).not.toContain("Wake it now?");
+    expect(cmdWakeCalls.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1.2 of #736 — close the asymmetry between `maw view` (auto-wakes fleet-known targets) and `maw hey` (was: errored with "no active Claude session").

`maw hey <agent>` now mirrors the behavior in `view/impl.ts:107`: when the target is fleet-known but no local tmux session exists, silently wake it before sending. **No y/N prompt** — fleet membership is sufficient signal that the name isn't a typo.

Cross-node targets (`<peer>:<agent>`) are skipped at this layer; the remote peer's federation handler (`sessions.ts:/api/wake`) wakes its own fleet.

## Changes

- `src/commands/shared/comm-send.ts` — auto-wake block inserted between `listSessions()` and `resolveTarget()` inside `cmdSend`. Uses `resolveFleetSession()` for fleet detection, calls `cmdWake(target, {})` (no attach), refreshes sessions list before resolution.
- `test/isolated/hey-fleet-auto-wake.test.ts` — 6 isolated cases:
  - auto-wakes when fleet-known + no session
  - skips wake when session already running
  - skips wake when unknown (not fleet-known)
  - skips local wake on cross-node target
  - auto-wakes on self-node prefix (`test-node:volt`)
  - no y/N prompt strings printed (silent)
- `package.json` — calver bump to `v26.4.28-alpha.0`.

## Test plan

- [x] `bun test test/isolated/hey-fleet-auto-wake.test.ts` — 6 pass / 0 fail
- [x] `bun test test/isolated/send-idle-guard.test.ts test/isolated/comm-send-resolve-pane.test.ts test/isolated/hey-fleet-auto-wake.test.ts` — 24 pass / 0 fail (no regression in adjacent comm-send tests)
- [x] `bun test test/isolated/wake-cmd.test.ts` alone — 39 pass / 0 fail (mock-cross-pollution failures observed in full-suite are pre-existing on `alpha` and unrelated to this diff)
- [ ] CI green on `alpha` base

## Refs

- Closes Phase 1.2 of #736
- Mirrors `src/commands/plugins/view/impl.ts:107-113` (`autoWake` via `resolveFleetSession`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)