### PR TITLE
feat(config): pre-populate agents from fleet at load (Phase 1.1 of #736)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.28-alpha.19",
+  "version": "26.4.28-alpha.20",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/config/fleet-merge.ts
+++ b/src/config/fleet-merge.ts
@@ -1,0 +1,101 @@
+import { readdirSync, readFileSync, existsSync } from "fs";
+import { join } from "path";
+import { FLEET_DIR } from "../core/paths";
+
+/**
+ * Phase 1.1 of #736 — pre-populate `config.agents` from fleet at loadConfig time.
+ *
+ * Background:
+ *   Before this, `config.agents[name] = node` only got registered AFTER the first
+ *   `maw wake <oracle>` call (src/commands/shared/wake-cmd.ts). That meant any
+ *   fleet-known oracle was invisible to federation routing until a human had
+ *   manually woken it once. `maw hey volt-colab-ml` would fail because
+ *   `config.agents.volt-colab-ml` was unset, even though `fleet/101-volt-colab-ml.json`
+ *   already declared the window. Same gap motivated `maw fleet --init-agents`
+ *   (#215) — but that's a manual one-shot, and drift kept reopening.
+ *
+ * Fix:
+ *   On every `loadConfig()` call, scan FLEET_DIR and inject `<window-name> → "local"`
+ *   for every fleet window that isn't already in `config.agents`. Additive only —
+ *   never overwrites a hand-tuned mapping. Pure in-memory: does NOT write to
+ *   maw.config.json. Persistence stays the responsibility of `maw fleet
+ *   --init-agents` and `maw wake`.
+ *
+ * Failure mode:
+ *   If FLEET_DIR doesn't exist or any file is malformed, we swallow and return
+ *   the input agents map unchanged. loadConfig() is too foundational to throw on
+ *   a fleet glitch.
+ */
+
+interface FleetWindowLite {
+  name?: string;
+  repo?: string;
+}
+
+interface FleetSessionLite {
+  name?: string;
+  windows?: FleetWindowLite[];
+}
+
+/**
+ * Merge fleet window names into the agents map.
+ *
+ * Pure function — no I/O, fully testable. Mirrors the local-fleet branch of
+ * `cmdFleetInitAgents` so behaviour stays consistent between load-time auto-merge
+ * and the explicit `maw fleet --init-agents` reconcile.
+ */
+export function mergeFleetIntoAgents(
+  existing: Record<string, string>,
+  fleet: FleetSessionLite[],
+  localNode: string = "local",
+): Record<string, string> {
+  const proposed: Record<string, string> = { ...existing };
+  for (const sess of fleet) {
+    for (const w of sess?.windows || []) {
+      if (!w?.name) continue;
+      if (!(w.name in proposed)) proposed[w.name] = localNode;
+    }
+  }
+  return proposed;
+}
+
+/**
+ * Read every `*.json` (skipping `*.disabled`) from `dir` as a `FleetSessionLite`.
+ * Returns `[]` when the directory is missing or unreadable, and silently skips
+ * any file that fails to parse — a single corrupt fleet file shouldn't brick
+ * config loading.
+ */
+export function readFleetDir(dir: string): FleetSessionLite[] {
+  if (!existsSync(dir)) return [];
+  let files: string[];
+  try {
+    files = readdirSync(dir).filter(f => f.endsWith(".json") && !f.endsWith(".disabled"));
+  } catch {
+    return [];
+  }
+  const out: FleetSessionLite[] = [];
+  for (const f of files) {
+    try {
+      const raw = readFileSync(join(dir, f), "utf-8");
+      out.push(JSON.parse(raw) as FleetSessionLite);
+    } catch {
+      // Skip malformed file — don't break config load over one bad fleet entry.
+    }
+  }
+  return out;
+}
+
+/**
+ * Convenience wrapper: read FLEET_DIR and merge into the supplied agents map.
+ * `localNode` defaults to `"local"` (the convention used by `cmdFleetInitAgents`
+ * and `wake-cmd.ts`'s auto-register path). Callers that know the canonical node
+ * identity (e.g. `config.node`) can pass it through, but `"local"` keeps the
+ * map self-referential which is what the rest of the codebase expects.
+ */
+export function loadFleetAgents(
+  existing: Record<string, string> = {},
+  localNode: string = "local",
+  dir: string = FLEET_DIR,
+): Record<string, string> {
+  return mergeFleetIntoAgents(existing, readFleetDir(dir), localNode);
+}

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -5,6 +5,7 @@ import { verbose, info } from "../cli/verbosity";
 import type { MawConfig } from "./types";
 import { D } from "./types";
 import { validateConfig } from "./validate-ext";
+import { loadFleetAgents } from "./fleet-merge";
 
 // #680 — ghqRoot is no longer resolved at config-load time. Callers that need
 // a filesystem path go through `getGhqRoot()` (src/config/ghq-root.ts), which
@@ -52,6 +53,18 @@ export function loadConfig(): MawConfig {
       );
     }
     cached.host = "local";
+  }
+  // #736 Phase 1.1 — pre-populate config.agents from fleet at loadConfig time
+  // so federation routing (`maw hey <oracle>`) sees fleet-known targets even
+  // before their first wake. Additive only: hand-tuned config.agents entries
+  // are preserved. Failure swallowed: a fleet read glitch must not brick load.
+  try {
+    const merged = loadFleetAgents(cached.agents || {});
+    if (Object.keys(merged).length > 0) cached.agents = merged;
+  } catch {
+    // Defensive — loadFleetAgents already swallows IO/parse errors, but if
+    // anything unexpected escapes we'd rather load with the raw config than
+    // fail to start at all.
   }
   // #680 — warn once if the (deprecated) ghqRoot override is set in config.
   if (!warnedGhqRoot && typeof cached.ghqRoot === "string" && cached.ghqRoot.length > 0) {

--- a/test/config-fleet-merge.test.ts
+++ b/test/config-fleet-merge.test.ts
@@ -1,0 +1,160 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, chmodSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import {
+  mergeFleetIntoAgents,
+  readFleetDir,
+  loadFleetAgents,
+} from "../src/config/fleet-merge";
+
+// ---- Pure merge logic --------------------------------------------------
+
+describe("mergeFleetIntoAgents (#736 Phase 1.1)", () => {
+  test("adds every fleet window to agents as 'local' when map is empty", () => {
+    const result = mergeFleetIntoAgents({}, [
+      { name: "01-pulse", windows: [{ name: "pulse-oracle" }, { name: "neo-oracle" }] },
+      { name: "08-mawjs", windows: [{ name: "mawjs-oracle" }] },
+    ]);
+    expect(result).toEqual({
+      "pulse-oracle": "local",
+      "neo-oracle": "local",
+      "mawjs-oracle": "local",
+    });
+  });
+
+  test("never overwrites a hand-tuned agents entry", () => {
+    const existing = {
+      // user pinned volt-oracle to mba; load must NOT clobber it back to "local"
+      "volt-oracle": "mba",
+      // fleet says local, but user override stands
+      "pulse-oracle": "white",
+    };
+    const result = mergeFleetIntoAgents(existing, [
+      { windows: [{ name: "pulse-oracle" }, { name: "volt-oracle" }, { name: "neo-oracle" }] },
+    ]);
+    expect(result["volt-oracle"]).toBe("mba");
+    expect(result["pulse-oracle"]).toBe("white");
+    expect(result["neo-oracle"]).toBe("local");
+  });
+
+  test("honors localNode override (e.g. config.node identity)", () => {
+    const result = mergeFleetIntoAgents({}, [
+      { windows: [{ name: "homekeeper-oracle" }] },
+    ], "mba");
+    expect(result["homekeeper-oracle"]).toBe("mba");
+  });
+
+  test("skips windows with empty/missing name and malformed sessions", () => {
+    const result = mergeFleetIntoAgents({}, [
+      { windows: [{ name: "" }, { name: "pulse-oracle" }] },
+      // @ts-expect-error — exercise the runtime guard for malformed window
+      { windows: [{ name: null }] },
+      // session with no windows at all
+      {},
+    ]);
+    expect(result).toEqual({ "pulse-oracle": "local" });
+  });
+
+  test("no-op when fleet list is empty", () => {
+    const result = mergeFleetIntoAgents({ already: "here" }, []);
+    expect(result).toEqual({ already: "here" });
+  });
+});
+
+// ---- Filesystem reader --------------------------------------------------
+
+describe("readFleetDir (#736 Phase 1.1)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "maw-fleet-merge-"));
+  });
+
+  afterEach(() => {
+    try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  test("returns [] when directory does not exist", () => {
+    expect(readFleetDir(join(dir, "does-not-exist"))).toEqual([]);
+  });
+
+  test("loads every *.json file, skips *.disabled", () => {
+    writeFileSync(join(dir, "01-pulse.json"), JSON.stringify({
+      name: "01-pulse",
+      windows: [{ name: "pulse-oracle", repo: "Soul-Brews-Studio/pulse-oracle" }],
+    }));
+    writeFileSync(join(dir, "02-neo.json"), JSON.stringify({
+      name: "02-neo",
+      windows: [{ name: "neo-oracle" }],
+    }));
+    // Disabled fleet — ignored by loader
+    writeFileSync(join(dir, "03-old.json.disabled"), JSON.stringify({
+      name: "03-old",
+      windows: [{ name: "old-oracle" }],
+    }));
+
+    const sessions = readFleetDir(dir);
+    const names = sessions.flatMap(s => (s.windows || []).map(w => w.name));
+    expect(names.sort()).toEqual(["neo-oracle", "pulse-oracle"]);
+  });
+
+  test("skips a malformed file rather than throwing", () => {
+    writeFileSync(join(dir, "01-good.json"), JSON.stringify({
+      windows: [{ name: "good-oracle" }],
+    }));
+    writeFileSync(join(dir, "02-broken.json"), "{ this is not JSON");
+
+    const sessions = readFleetDir(dir);
+    const names = sessions.flatMap(s => (s.windows || []).map(w => w.name));
+    expect(names).toEqual(["good-oracle"]);
+  });
+});
+
+// ---- End-to-end loadFleetAgents (reader + merge) -----------------------
+
+describe("loadFleetAgents (#736 Phase 1.1)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "maw-fleet-load-"));
+  });
+
+  afterEach(() => {
+    try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  test("federation gap fix: fleet-known oracle without prior wake gets routed", () => {
+    // Reproduce the #736 scenario: 101-volt-colab-ml.json exists in fleet but
+    // config.agents is empty (no manual wake yet). After loadFleetAgents, the
+    // map MUST contain volt-colab-ml-oracle so `maw hey volt-colab-ml` can route.
+    writeFileSync(join(dir, "101-volt-colab-ml.json"), JSON.stringify({
+      name: "101-volt-colab-ml",
+      windows: [{ name: "volt-colab-ml-oracle", repo: "Soul-Brews-Studio/volt-colab-ml-oracle" }],
+    }));
+
+    const agents = loadFleetAgents({}, "local", dir);
+    expect(agents["volt-colab-ml-oracle"]).toBe("local");
+  });
+
+  test("missing fleet directory does not throw — returns existing agents unchanged", () => {
+    const existing = { someone: "remote-node" };
+    const result = loadFleetAgents(existing, "local", join(dir, "nope"));
+    expect(result).toEqual(existing);
+  });
+
+  test("preserves hand-tuned agents alongside fleet-derived entries", () => {
+    writeFileSync(join(dir, "01-pulse.json"), JSON.stringify({
+      windows: [{ name: "pulse-oracle" }, { name: "neo-oracle" }],
+    }));
+    const existing = {
+      "pulse-oracle": "white",   // user override — must survive
+      "extra-oracle": "mba",      // not in fleet — must survive
+    };
+    const result = loadFleetAgents(existing, "local", dir);
+    expect(result["pulse-oracle"]).toBe("white");
+    expect(result["extra-oracle"]).toBe("mba");
+    expect(result["neo-oracle"]).toBe("local");
+  });
+});


### PR DESCRIPTION
## Phase 1.1 of #736 wake-unify

Closes federation routing gap: \`config.agents\` only populates AFTER first wake (wake-cmd.ts:68). Fix: at \`loadConfig()\` scan \`/tmp/maw-fleet/*.json\` and merge fleet windows into \`config.agents\`.

### Changes
- \`src/config/fleet-merge.ts\` (new) — \`mergeFleetIntoAgents\`/\`readFleetDir\`/\`loadFleetAgents\`
- \`src/config/load.ts\` — wired after \`validateConfig\`
- \`test/config-fleet-merge.test.ts\` — 11 pass

### Bump
v26.4.28-alpha.20

### Related
Phase 1.2 in #780 (auto-wake on \`maw hey\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)