### PR TITLE
fix(talk-to): resolveOraclePane for multi-pane oracles (#764)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.28-alpha.21",
+  "version": "26.4.28-alpha.22",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/plugins/talk-to/impl.ts
+++ b/src/commands/plugins/talk-to/impl.ts
@@ -1,6 +1,7 @@
 import { loadConfig } from "../../../config";
 import { listSessions, sendKeys, getPaneCommand, resolveTarget } from "../../../sdk";
 import { runHook } from "../../../sdk";
+import { resolveOraclePane } from "../../shared/comm-send";
 import { appendFile, mkdir } from "fs/promises";
 import { homedir, hostname } from "os";
 import { join } from "path";
@@ -140,9 +141,13 @@ export async function cmdTalkTo(target: string, message: string, force = false) 
   const config = loadConfig();
   const sessions = await listSessions();
   const resolved = resolveTarget(target, config, sessions);
+  // Resolve to a specific pane: when the oracle window has multiple panes
+  // (team-agents spawned beside it), `send-keys -t session:window` would
+  // otherwise land in whichever pane is currently active, not the oracle's
+  // claude pane. Mirrors comm-send (#764).
   const tmuxTarget =
     resolved?.type === "local" || resolved?.type === "self-node"
-      ? resolved.target
+      ? await resolveOraclePane(resolved.target)
       : null;
   if (!tmuxTarget) {
     // Thread was posted but target window not found — still useful

--- a/test/isolated/talk-to-resolve-pane.test.ts
+++ b/test/isolated/talk-to-resolve-pane.test.ts
@@ -1,0 +1,170 @@
+/**
+ * test/isolated/talk-to-resolve-pane.test.ts
+ *
+ * #764: `maw talk-to` must call resolveOraclePane on the resolved local
+ * target so multi-pane oracle windows (team-agents spawned beside the
+ * oracle) deliver to the oracle's claude pane, not whichever pane is
+ * currently active.
+ *
+ * Mirrors the comm-send-resolve-pane.test.ts pattern: stub the tmux
+ * transport's list-panes return value, then assert sendKeys was called
+ * with the pane-suffixed target (e.g. "08-mawjs:1.0") rather than the
+ * bare window target ("08-mawjs:1").
+ *
+ * Isolated because mock.module is process-global.
+ */
+import { describe, test, expect, mock, beforeEach, afterEach, afterAll } from "bun:test";
+import { join } from "path";
+import { mockConfigModule } from "../helpers/mock-config";
+
+const srcRoot = join(import.meta.dir, "../..");
+
+// Capture the real tmux transport types BEFORE mock.module replaces it.
+const _rTmux = await import("../../src/core/transport/tmux");
+
+// --- Mutable tmux stub state ---
+let listPanesReturn = "";
+let lastListPanesArgs: (string | number)[] = [];
+
+// --- Mock tmux transport (resolveOraclePane uses `new Tmux().run("list-panes", ...)`) ---
+mock.module(join(srcRoot, "src/core/transport/tmux"), () => {
+  class MockTmux {
+    constructor(public host?: string, public socket?: string) {}
+    async run(subcommand: string, ...args: (string | number)[]): Promise<string> {
+      if (subcommand === "list-panes") {
+        lastListPanesArgs = args;
+        return listPanesReturn;
+      }
+      return "";
+    }
+    async tryRun(subcommand: string, ...args: (string | number)[]): Promise<string> {
+      return this.run(subcommand, ...args);
+    }
+  }
+  return {
+    ..._rTmux,
+    Tmux: MockTmux,
+    tmux: new MockTmux(),
+  };
+});
+
+// --- Mutable sdk stub state ---
+type SessionRow = { name: string; windows: { index: number; name: string; active: boolean }[]; source?: string };
+let sessionsToReturn: SessionRow[] = [];
+let sendKeysCalls: { target: string; message: string }[] = [];
+
+// Use the real resolveTarget so the local resolution path is exercised end-to-end.
+const realRouting = await import("../../src/core/routing");
+
+mock.module(join(srcRoot, "src/sdk"), () => ({
+  listSessions: async () => sessionsToReturn,
+  sendKeys: async (target: string, message: string) => {
+    sendKeysCalls.push({ target, message });
+  },
+  getPaneCommand: async () => "claude",
+  resolveTarget: realRouting.resolveTarget,
+  runHook: async () => {},
+}));
+
+mock.module(join(srcRoot, "src/config"), () =>
+  mockConfigModule(() => ({
+    node: "white",
+    namedPeers: [],
+    agents: {},
+    peers: [],
+    oracleUrl: "http://oracle.invalid:1",
+  })),
+);
+
+// --- Stub fetch (Oracle thread API) ---
+const origFetch = globalThis.fetch;
+const origLog = console.log;
+const origErr = console.error;
+
+// --- Import module under test AFTER all mocks installed ---
+const { cmdTalkTo } = await import("../../src/commands/plugins/talk-to/impl");
+
+beforeEach(() => {
+  sessionsToReturn = [];
+  sendKeysCalls = [];
+  listPanesReturn = "";
+  lastListPanesArgs = [];
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.endsWith("/api/threads?limit=50")) {
+      return new Response(JSON.stringify({ threads: [] }), { status: 200 });
+    }
+    if (url.endsWith("/api/thread")) {
+      return new Response(JSON.stringify({ thread_id: 42, message_id: 1, status: "ok" }), { status: 200 });
+    }
+    if (url.includes("/api/thread/")) {
+      return new Response(
+        JSON.stringify({ thread: { id: 42, title: "x", status: "open", created_at: "" }, messages: [] }),
+        { status: 200 },
+      );
+    }
+    return new Response("not found", { status: 404 });
+  }) as typeof fetch;
+  console.log = () => {};
+  console.error = () => {};
+});
+
+afterEach(() => {
+  globalThis.fetch = origFetch;
+  console.log = origLog;
+  console.error = origErr;
+});
+
+afterAll(() => {
+  globalThis.fetch = origFetch;
+  console.log = origLog;
+  console.error = origErr;
+});
+
+describe("cmdTalkTo — #764 multi-pane oracle resolution", () => {
+  test("multi-pane window: sendKeys targets the lowest-index agent pane, not the bare window", async () => {
+    // Oracle window has two panes: pane 0 = claude (oracle), pane 1 = node (team-agent split).
+    // Without resolveOraclePane, sendKeys would land on whichever pane is active —
+    // typically the just-spawned teammate at pane 1.
+    sessionsToReturn = [
+      { name: "08-mawjs", windows: [{ index: 1, name: "mawjs-oracle", active: true }] },
+    ];
+    listPanesReturn = "0 claude\n1 node\n";
+
+    await cmdTalkTo("mawjs-oracle", "hi");
+
+    // resolveOraclePane was called with the window-level target.
+    expect(lastListPanesArgs).toEqual(["-t", "08-mawjs:1", "-F", "#{pane_index} #{pane_current_command}"]);
+    // sendKeys received the pane-suffixed target.
+    expect(sendKeysCalls).toHaveLength(1);
+    expect(sendKeysCalls[0].target).toBe("08-mawjs:1.0");
+  });
+
+  test("single-pane window: sendKeys uses the unmodified window target", async () => {
+    sessionsToReturn = [
+      { name: "08-mawjs", windows: [{ index: 1, name: "mawjs-oracle", active: true }] },
+    ];
+    listPanesReturn = "0 claude\n";
+
+    await cmdTalkTo("mawjs-oracle", "hi");
+
+    expect(sendKeysCalls).toHaveLength(1);
+    // Single-pane short-circuit: target unchanged.
+    expect(sendKeysCalls[0].target).toBe("08-mawjs:1");
+  });
+
+  test("multi-pane window with split positions reordered: still picks the lowest agent pane", async () => {
+    // Even if claude got assigned a higher pane index due to splits, the pane
+    // running an agent process with the smallest index wins.
+    sessionsToReturn = [
+      { name: "08-mawjs", windows: [{ index: 1, name: "mawjs-oracle", active: true }] },
+    ];
+    // pane 0 = zsh (a leftover shell), pane 1 = claude, pane 2 = node
+    listPanesReturn = "0 zsh\n1 claude\n2 node\n";
+
+    await cmdTalkTo("mawjs-oracle", "hi");
+
+    expect(sendKeysCalls).toHaveLength(1);
+    expect(sendKeysCalls[0].target).toBe("08-mawjs:1.1");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #764. `maw talk-to` was missing the pane-resolution step that `maw hey` (cmdSend) gained in the original multi-pane fix. On oracles where team-agents have spawned beside the oracle (multi-pane window), tmux's `send-keys -t session:window` lands on whichever pane is currently active — typically the just-spawned teammate at pane 1, not the oracle's claude pane at pane 0.

This PR mirrors the cmdSend treatment in talk-to: after `resolveTarget` resolves a local/self-node target, pass through `resolveOraclePane(...)` to pick the lowest-index agent pane in the window.

## Changes

- `src/commands/plugins/talk-to/impl.ts` — call `resolveOraclePane` on resolved local target. Six lines plus a comment.
- `test/isolated/talk-to-resolve-pane.test.ts` — three isolated test cases mirroring `comm-send-resolve-pane.test.ts`:
  1. multi-pane window: pane-suffixed target wins
  2. single-pane window: target unchanged (short-circuit)
  3. shell-on-pane-0 + claude-on-pane-1: lowest-index agent pane wins
- `package.json` — bump to `v26.4.28-alpha.22`

## Audit of related write paths

Per the issue, audited `broadcast/` and `peek/` for the same gap:

- **`src/commands/plugins/broadcast/impl.ts`** — same pattern (uses `${session}:${windowIndex}` window-level target, calls `tmux.sendText`). Suggest a follow-up issue: broadcast affects every window in the fan-out, scope is broader, and it pre-checks `pane_current_command` which already hides the bug for many cases. Keeping #764 narrow per the bug report's scope.
- **`src/commands/plugins/peek/`** — read-only (uses `capture`, not `send-keys`). Different concern: wrong-pane reads return wrong content but don't deliver bad input. Worth its own issue if/when peek is reported as showing the wrong pane on multi-pane oracles.

## Test plan

- [x] `bun test test/isolated/talk-to-resolve-pane.test.ts` — 3 pass, 7 expect calls
- [x] `bun test test/isolated/talk-to-resolve.test.ts` — 3 pass (existing #762 tests unaffected; the resolveOraclePane error path swallows missing-tmux gracefully)
- [x] `bun test test/isolated/comm-send-resolve-pane.test.ts` — 6 pass (no regression in the source pattern)
- [ ] manual: `maw talk-to <oracle> "..."` against a window with team-agents split beside it should hit pane 0 (claude), not pane 1 (node)

🤖 Generated with [Claude Code](https://claude.com/claude-code)