### PR TITLE
feat(calver): add --beta channel — parallel monotonic counter (#754)

### DIFF
--- a/.github/workflows/calver-release.yml
+++ b/.github/workflows/calver-release.yml
@@ -54,14 +54,15 @@ jobs:
 
           # Only act on CalVer-shaped versions. Legacy semver (2.0.0-alpha.*)
           # bumps are skipped as no-op during the transition period.
-          REGEX='^[0-9]{2}\.[0-9]{1,2}\.[0-9]{1,2}(-alpha\.[0-9]{1,2}[a-z]?)?$'
+          # Accepts alpha and beta channels (#754); both are prereleases.
+          REGEX='^[0-9]{2}\.[0-9]{1,2}\.[0-9]{1,2}(-(alpha|beta)\.[0-9]{1,2}[a-z]?)?$'
           if [[ ! "$VERSION" =~ $REGEX ]]; then
             echo "::notice title=Skipped::Version '$VERSION' is not CalVer — no release cut. Legacy ship-alpha.sh / auto-tag.yml handles this case."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Range validation — regex alone passes alpha.99.
+          # Range validation — regex alone passes channel.99.
           BASE="${VERSION%%-*}"
           IFS='.' read -r YY M D <<< "$BASE"
           if (( M < 1 || M > 12 )); then
@@ -71,16 +72,17 @@ jobs:
             echo "::error::Day must be 1-31, got $D"; exit 1
           fi
           PRERELEASE="false"
+          CHANNEL="stable"
           if [[ "$VERSION" == *-alpha.* ]]; then
-            HOUR_RAW="${VERSION##*-alpha.}"
-            HOUR="${HOUR_RAW%%[a-z]*}"
-            if (( HOUR < 0 || HOUR > 23 )); then
-              echo "::error::Hour must be 0-23, got $HOUR"; exit 1
-            fi
             PRERELEASE="true"
+            CHANNEL="alpha"
+          elif [[ "$VERSION" == *-beta.* ]]; then
+            PRERELEASE="true"
+            CHANNEL="beta"
           fi
           echo "prerelease=$PRERELEASE" >> "$GITHUB_OUTPUT"
-          echo "✅ valid CalVer: $TAG (prerelease=$PRERELEASE)"
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+          echo "✅ valid CalVer: $TAG (channel=$CHANNEL prerelease=$PRERELEASE)"
 
       - name: Fail loud on tag collision
         if: steps.ver.outputs.skip != 'true'
@@ -121,6 +123,6 @@ jobs:
         run: |
           TAG="${{ steps.ver.outputs.tag }}"
           echo "### 🎉 Released $TAG" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Channel:** ${{ steps.ver.outputs.prerelease == 'true' && 'alpha' || 'stable' }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Channel:** ${{ steps.ver.outputs.channel }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Release:** https://github.com/${{ github.repository }}/releases/tag/$TAG" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Install:** \`bun add -g github:${{ github.repository }}#$TAG\`" >> "$GITHUB_STEP_SUMMARY"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.28-alpha.25",
+  "version": "26.4.28-alpha.27",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/scripts/calver.ts
+++ b/scripts/calver.ts
@@ -1,17 +1,20 @@
 #!/usr/bin/env bun
 // CalVer bump for maw-js
 //
-// Scheme: v{yy}.{m}.{d}[-alpha.{N}]
+// Scheme: v{yy}.{m}.{d}[-(alpha|beta).{N}]
 // Spec:   https://github.com/Soul-Brews-Studio/mawjs-oracle/blob/main/%CF%88/inbox/2026-04-18_proposal-calver-skills-cli.md
 // Ported from: Soul-Brews-Studio/arra-oracle-skills-cli (PR #262)
 // Umbrella: #526
 // Option A (#766): monotonic running counter — N starts at 0 each day,
-// counts up per release. Walk existing tags for today's date and pick max+1.
-// No timestamp encoded in the alpha number; pure ordering.
+// counts up per release. Walk existing tags AND package.json (#784) for
+// today's date and pick max+1.
+// Beta channel (#754): parallel hourly channel, independent counter.
+// No timestamp encoded in the alpha/beta number; pure ordering.
 // Timezone comes from the shell — set TZ=Asia/Bangkok in CI if needed.
 //
 // Usage:
 //   bun scripts/calver.ts                  → 26.4.18-alpha.{next-N}
+//   bun scripts/calver.ts --beta           → 26.4.18-beta.{next-N}
 //   bun scripts/calver.ts --stable         → 26.4.18
 //   bun scripts/calver.ts --check          → dry-run (no writes)
 
@@ -19,13 +22,15 @@ import { $ } from "bun";
 import { readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 
-type Args = { stable: boolean; check: boolean; now?: Date };
+export type Channel = "alpha" | "beta";
+type Args = { stable: boolean; channel?: Channel; check: boolean; now?: Date };
 
 function parseArgs(argv: string[]): Args {
-  const args: Args = { stable: false, check: false };
+  const args: Args = { stable: false, channel: "alpha", check: false };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--stable") args.stable = true;
+    else if (a === "--beta") args.channel = "beta";
     else if (a === "--check" || a === "--dry-run") args.check = true;
     else if (a === "--hour") {
       console.error("--hour deprecated as of #766; CalVer now uses tag-walk monotonic counter");
@@ -40,6 +45,10 @@ function parseArgs(argv: string[]): Args {
       process.exit(2);
     }
   }
+  if (args.stable && args.channel === "beta") {
+    console.error("--stable and --beta are mutually exclusive");
+    process.exit(2);
+  }
   return args;
 }
 
@@ -47,16 +56,19 @@ const HELP = `Usage: bun scripts/calver.ts [options]
 
 Compute next CalVer version and bump package.json.
 
-Scheme: v{yy}.{m}.{d}[-alpha.{N}] — N is a monotonic running counter that
-starts at 0 each day and counts up per release (Option A from #766).
+Scheme: v{yy}.{m}.{d}[-(alpha|beta).{N}] — N is a monotonic running counter
+that starts at 0 each day and counts up per release (Option A from #766).
+Alpha and beta are independent channels with their own counters (#754).
 
 Options:
-  --stable         Cut stable (no alpha suffix)
+  --stable         Cut stable (no alpha/beta suffix)
+  --beta           Cut beta instead of alpha (separate counter)
   --check          Dry-run: print target, don't modify files
   -h, --help       Show help
 
 Examples:
   bun scripts/calver.ts                  next alpha → 26.4.18-alpha.{next-N}
+  bun scripts/calver.ts --beta           next beta  → 26.4.18-beta.{next-N}
   bun scripts/calver.ts --stable         stable cut → 26.4.18
   bun scripts/calver.ts --check          print only, no write`;
 
@@ -70,8 +82,10 @@ export function dateBase(now: Date): string {
 /**
  * Walk git tags matching `v{base}-{channel}.*` and return the max N found,
  * or -1 if no matching tags exist for this date+channel yet.
+ *
+ * Backwards-compatible alias `maxAlphaFromTags(base, tags)` defaults to alpha.
  */
-export function maxNFromTags(base: string, channel: "alpha" | "beta", tags: string[]): number {
+export function maxNFromTags(base: string, channel: Channel, tags: string[]): number {
   const prefix = `v${base}-${channel}.`;
   let max = -1;
   for (const tag of tags) {
@@ -105,7 +119,7 @@ export function maxAlphaFromTags(base: string, tags: string[]): number {
  */
 export function maxNFromPackageJson(
   base: string,
-  channel: "alpha" | "beta",
+  channel: Channel,
   packageVersion: string,
 ): number {
   if (!packageVersion) return -1;
@@ -119,8 +133,8 @@ export function maxNFromPackageJson(
   return Number.isInteger(n) ? n : -1;
 }
 
-async function listAlphaTags(base: string): Promise<string[]> {
-  const res = await $`git tag --list ${`v${base}-alpha.*`}`.nothrow().quiet();
+async function listChannelTags(base: string, channel: Channel): Promise<string[]> {
+  const res = await $`git tag --list ${`v${base}-${channel}.*`}`.nothrow().quiet();
   if (res.exitCode !== 0) return [];
   return res.stdout.toString().split("\n").map(s => s.trim()).filter(Boolean);
 }
@@ -129,12 +143,13 @@ export function computeVersion(args: Args, tags: string[] = [], packageVersion: 
   const now = args.now ?? new Date();
   const base = dateBase(now);
   if (args.stable) return base;
-  // #784: take max of (tag-walk N, package.json N) — see maxNFromPackageJson.
-  const tagMax = maxNFromTags(base, "alpha", tags);
-  const pkgMax = maxNFromPackageJson(base, "alpha", packageVersion);
+  const channel = args.channel ?? "alpha";
+  // Take max of (tag-walk N, package.json N) — see maxNFromPackageJson (#784).
+  const tagMax = maxNFromTags(base, channel, tags);
+  const pkgMax = maxNFromPackageJson(base, channel, packageVersion);
   const max = Math.max(tagMax, pkgMax);
   const next = max + 1; // -1 → 0 if none yet today
-  return `${base}-alpha.${next}`;
+  return `${base}-${channel}.${next}`;
 }
 
 async function tagExists(version: string): Promise<boolean> {
@@ -152,9 +167,10 @@ async function main() {
   const pkgPath = join(process.cwd(), "package.json");
   const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
 
-  const tags = args.stable ? [] : await listAlphaTags(base);
+  const channelForTags: Channel = args.channel ?? "alpha";
+  const tags = args.stable ? [] : await listChannelTags(base, channelForTags);
   const version = computeVersion(args, tags, pkg.version ?? "");
-  const channel = args.stable ? "stable" : "alpha";
+  const channel = args.stable ? "stable" : channelForTags;
 
   console.log(`Target: v${version}  [${channel}]`);
 

--- a/test/calver.test.ts
+++ b/test/calver.test.ts
@@ -4,6 +4,7 @@ import {
   dateBase,
   maxAlphaFromTags,
   maxNFromPackageJson,
+  maxNFromTags,
 } from "../scripts/calver";
 
 describe("calver dateBase", () => {
@@ -71,7 +72,53 @@ describe("calver computeVersion", () => {
 
   it("--stable ignores tags entirely", () => {
     const tags = ["v26.4.27-alpha.99"];
-    expect(computeVersion({ stable: true, check: false, now: apr27_1200 }, tags)).toBe("26.4.27");
+    expect(computeVersion({ stable: true, channel: "alpha", check: false, now: apr27_1200 }, tags)).toBe("26.4.27");
+  });
+});
+
+describe("calver beta channel (#754)", () => {
+  const apr28 = new Date(2026, 3, 28, 12, 0);
+
+  it("maxNFromTags isolates alpha and beta counters", () => {
+    const tags = [
+      "v26.4.28-alpha.0",
+      "v26.4.28-alpha.1",
+      "v26.4.28-beta.0",
+    ];
+    expect(maxNFromTags("26.4.28", "alpha", tags)).toBe(1);
+    expect(maxNFromTags("26.4.28", "beta", tags)).toBe(0);
+  });
+
+  it("maxAlphaFromTags is a back-compat alias for alpha channel", () => {
+    const tags = ["v26.4.28-alpha.5", "v26.4.28-beta.99"];
+    expect(maxAlphaFromTags("26.4.28", tags)).toBe(5);
+  });
+
+  it("--beta computes next beta version with independent counter", () => {
+    const tags = ["v26.4.28-alpha.21", "v26.4.28-beta.2"];
+    expect(
+      computeVersion({ stable: false, channel: "beta", check: false, now: apr28 }, tags)
+    ).toBe("26.4.28-beta.3");
+  });
+
+  it("--beta starts at 0 when no beta tags exist for today", () => {
+    const tags = ["v26.4.28-alpha.50"];
+    expect(
+      computeVersion({ stable: false, channel: "beta", check: false, now: apr28 }, tags)
+    ).toBe("26.4.28-beta.0");
+  });
+
+  it("alpha and beta on the same day do not collide", () => {
+    const tags = ["v26.4.28-alpha.5"];
+    const alpha = computeVersion({ stable: false, channel: "alpha", check: false, now: apr28 }, tags);
+    const beta = computeVersion({ stable: false, channel: "beta", check: false, now: apr28 }, tags);
+    expect(alpha).toBe("26.4.28-alpha.6");
+    expect(beta).toBe("26.4.28-beta.0");
+  });
+
+  it("beta tag walk rejects two-tier suffixes (e.g. beta.12.0)", () => {
+    const tags = ["v26.4.28-beta.5", "v26.4.28-beta.12.0"];
+    expect(maxNFromTags("26.4.28", "beta", tags)).toBe(5);
   });
 });
 


### PR DESCRIPTION
## Summary

Add \`--beta\` flag to \`scripts/calver.ts\`, mirroring \`--alpha\` (the default) with an independent monotonic counter. Per #754.

| Channel | Pattern | Counter |
|---|---|---|
| alpha (default) | \`vYY.M.D-alpha.{N}\` | independent |
| **beta (NEW)** | \`vYY.M.D-beta.{N}\` | independent |
| stable | \`vYY.M.D\` | n/a |

\`--stable --beta\` is rejected (mutex, exit 2).

## Changes

- \`scripts/calver.ts\` — new \`Channel\` type, \`maxNFromTags(base, channel, tags)\` (with \`maxAlphaFromTags\` as back-compat alias), \`listChannelTags\`, \`Args.channel?: Channel\`
- \`test/calver.test.ts\` — 6 new tests (channel isolation, beta computeVersion, alpha/beta non-collision, two-tier rejection)
- \`.github/workflows/calver-release.yml\` — regex extended to \`(-alpha|-beta).N\`, channel exposed as workflow output, summary uses real channel
- \`package.json\` — alpha.24 (manually chosen — see Side-Find below)

## Tests

\`\`\`
$ bun test test/calver.test.ts
17 pass
0 fail
\`\`\`

Manual sanity:

\`\`\`
$ TZ=Asia/Bangkok bun scripts/calver.ts --beta --check
Target: v26.4.28-beta.0  [beta]

$ TZ=Asia/Bangkok bun scripts/calver.ts --stable --beta --check
--stable and --beta are mutually exclusive  (exit 2)
\`\`\`

## Side-Find (separate issue to file)

\`/calver\` tag-walk returns \`alpha.0\` for today (\`v26.4.28-*\`) even though \`package.json\` is at \`alpha.22+\`. Cause: post-#767 alphas merge to alpha branch, but \`calver-release.yml\` only fires on push to \`main\` (creating tags only at stable cut). The script's tag-walk works for yesterday's pre-#767 pattern (\`v26.4.27-alpha.11/12/13\` are tagged) but not today's. Manually chose \`alpha.24\` for this bump (white claimed \`alpha.23\` for #759 in flight). Will file as a follow-up.

## Skill update

The \`/calver\` skill in \`mawjs-oracle\` is also stale (still references \`--hour\`). Will be updated separately with this PR's reference, in the same vault commit cycle.

Closes #754.