### PR TITLE
fix(calver): walk package.json + tags for monotonic counter (#784)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.28-alpha.23",
+  "version": "26.4.28-alpha.25",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/scripts/calver.ts
+++ b/scripts/calver.ts
@@ -68,11 +68,11 @@ export function dateBase(now: Date): string {
 }
 
 /**
- * Walk git tags matching `v{base}-alpha.*` and return the max N found,
- * or -1 if no alpha tags exist for this date yet.
+ * Walk git tags matching `v{base}-{channel}.*` and return the max N found,
+ * or -1 if no matching tags exist for this date+channel yet.
  */
-export function maxAlphaFromTags(base: string, tags: string[]): number {
-  const prefix = `v${base}-alpha.`;
+export function maxNFromTags(base: string, channel: "alpha" | "beta", tags: string[]): number {
+  const prefix = `v${base}-${channel}.`;
   let max = -1;
   for (const tag of tags) {
     if (!tag.startsWith(prefix)) continue;
@@ -85,17 +85,54 @@ export function maxAlphaFromTags(base: string, tags: string[]): number {
   return max;
 }
 
+/**
+ * Back-compat alias: alpha-only tag walk.
+ */
+export function maxAlphaFromTags(base: string, tags: string[]): number {
+  return maxNFromTags(base, "alpha", tags);
+}
+
+/**
+ * #784: walk package.json.version as an additional source-of-truth for the
+ * monotonic counter. Post-#767, alpha releases merge to the `alpha` branch,
+ * but `calver-release.yml` only fires on push to `main` — so no git tags get
+ * created for in-flight alphas. Without this, tag-walk returns -1 and we
+ * regress to alpha.0 on every alpha-branch run.
+ *
+ * Parses `vYY.M.D-{channel}.{N}` (with or without leading "v") and returns N
+ * only if base+channel match today's. Rejects non-integer suffixes and
+ * empty/missing strings (returns -1).
+ */
+export function maxNFromPackageJson(
+  base: string,
+  channel: "alpha" | "beta",
+  packageVersion: string,
+): number {
+  if (!packageVersion) return -1;
+  // Accept either `vYY.M.D-channel.N` or `YY.M.D-channel.N`.
+  const stripped = packageVersion.startsWith("v") ? packageVersion.slice(1) : packageVersion;
+  const prefix = `${base}-${channel}.`;
+  if (!stripped.startsWith(prefix)) return -1;
+  const rest = stripped.slice(prefix.length);
+  if (!/^\d+$/.test(rest)) return -1;
+  const n = parseInt(rest, 10);
+  return Number.isInteger(n) ? n : -1;
+}
+
 async function listAlphaTags(base: string): Promise<string[]> {
   const res = await $`git tag --list ${`v${base}-alpha.*`}`.nothrow().quiet();
   if (res.exitCode !== 0) return [];
   return res.stdout.toString().split("\n").map(s => s.trim()).filter(Boolean);
 }
 
-export function computeVersion(args: Args, tags: string[] = []): string {
+export function computeVersion(args: Args, tags: string[] = [], packageVersion: string = ""): string {
   const now = args.now ?? new Date();
   const base = dateBase(now);
   if (args.stable) return base;
-  const max = maxAlphaFromTags(base, tags);
+  // #784: take max of (tag-walk N, package.json N) — see maxNFromPackageJson.
+  const tagMax = maxNFromTags(base, "alpha", tags);
+  const pkgMax = maxNFromPackageJson(base, "alpha", packageVersion);
+  const max = Math.max(tagMax, pkgMax);
   const next = max + 1; // -1 → 0 if none yet today
   return `${base}-alpha.${next}`;
 }
@@ -110,8 +147,13 @@ async function main() {
   const now = args.now ?? new Date();
   const base = dateBase(now);
 
+  // #784: read package.json once up front so its version participates in the
+  // source-of-truth set for the monotonic counter (see computeVersion).
+  const pkgPath = join(process.cwd(), "package.json");
+  const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+
   const tags = args.stable ? [] : await listAlphaTags(base);
-  const version = computeVersion(args, tags);
+  const version = computeVersion(args, tags, pkg.version ?? "");
   const channel = args.stable ? "stable" : "alpha";
 
   console.log(`Target: v${version}  [${channel}]`);
@@ -132,8 +174,6 @@ async function main() {
     process.exit(1);
   }
 
-  const pkgPath = join(process.cwd(), "package.json");
-  const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
   const old = pkg.version;
   pkg.version = version;
   writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");

--- a/test/calver.test.ts
+++ b/test/calver.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "bun:test";
-import { computeVersion, dateBase, maxAlphaFromTags } from "../scripts/calver";
+import {
+  computeVersion,
+  dateBase,
+  maxAlphaFromTags,
+  maxNFromPackageJson,
+} from "../scripts/calver";
 
 describe("calver dateBase", () => {
   it("yy.m.d with no zero-pad (semver safety)", () => {
@@ -67,5 +72,63 @@ describe("calver computeVersion", () => {
   it("--stable ignores tags entirely", () => {
     const tags = ["v26.4.27-alpha.99"];
     expect(computeVersion({ stable: true, check: false, now: apr27_1200 }, tags)).toBe("26.4.27");
+  });
+});
+
+describe("calver maxNFromPackageJson (#784)", () => {
+  it("returns N for matching alpha base+channel", () => {
+    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-alpha.24")).toBe(24);
+    expect(maxNFromPackageJson("26.4.28", "alpha", "v26.4.28-alpha.7")).toBe(7);
+  });
+
+  it("returns N for matching beta base+channel", () => {
+    expect(maxNFromPackageJson("26.4.28", "beta", "26.4.28-beta.3")).toBe(3);
+  });
+
+  it("returns -1 when date base does not match", () => {
+    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.27-alpha.99")).toBe(-1);
+    expect(maxNFromPackageJson("26.4.28", "alpha", "26.5.1-alpha.0")).toBe(-1);
+  });
+
+  it("returns -1 when channel does not match", () => {
+    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-beta.5")).toBe(-1);
+    expect(maxNFromPackageJson("26.4.28", "beta", "26.4.28-alpha.5")).toBe(-1);
+  });
+
+  it("rejects non-integer suffix (e.g. two-tier alpha.12.0 or alpha.12-rc)", () => {
+    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-alpha.12.0")).toBe(-1);
+    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-alpha.12-rc")).toBe(-1);
+    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-alpha.abc")).toBe(-1);
+  });
+
+  it("returns -1 for empty or stable-only version strings", () => {
+    expect(maxNFromPackageJson("26.4.28", "alpha", "")).toBe(-1);
+    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28")).toBe(-1);
+  });
+});
+
+describe("calver computeVersion package.json walk (#784)", () => {
+  const apr28_1200 = new Date(2026, 3, 28, 12, 0);
+
+  it("package.json ahead of tags wins (alpha-branch case from #784)", () => {
+    // Simulates current bug: no tags exist yet for today (alpha branch),
+    // but package.json carries 26.4.28-alpha.24 from prior in-flight alphas.
+    expect(
+      computeVersion({ stable: false, check: false, now: apr28_1200 }, [], "26.4.28-alpha.24"),
+    ).toBe("26.4.28-alpha.25");
+  });
+
+  it("tags ahead of package.json wins", () => {
+    const tags = ["v26.4.28-alpha.30"];
+    expect(
+      computeVersion({ stable: false, check: false, now: apr28_1200 }, tags, "26.4.28-alpha.10"),
+    ).toBe("26.4.28-alpha.31");
+  });
+
+  it("tags and package.json at same value still increments by 1", () => {
+    const tags = ["v26.4.28-alpha.5"];
+    expect(
+      computeVersion({ stable: false, check: false, now: apr28_1200 }, tags, "26.4.28-alpha.5"),
+    ).toBe("26.4.28-alpha.6");
   });
 });

--- a/test/calver.test.ts
+++ b/test/calver.test.ts
@@ -131,4 +131,52 @@ describe("calver computeVersion package.json walk (#784)", () => {
       computeVersion({ stable: false, check: false, now: apr28_1200 }, tags, "26.4.28-alpha.5"),
     ).toBe("26.4.28-alpha.6");
   });
+
+  it("daily rollover: yesterday's package.json + no today-tags → .0", () => {
+    // Critical: without date-gating, every day would start at yesterday's N+1
+    // instead of resetting to 0. Verifies date-mismatch returns -1 from pkg-walk.
+    expect(
+      computeVersion({ stable: false, check: false, now: apr28_1200 }, [], "26.4.27-alpha.50"),
+    ).toBe("26.4.28-alpha.0");
+  });
+
+  it("yesterday's stable in package.json + today's no-tags → .0", () => {
+    // After a stable cut, package.json holds bare YY.M.D. Next-day alpha
+    // starts at .0, not at the stable's "version".
+    expect(
+      computeVersion({ stable: false, check: false, now: apr28_1200 }, [], "26.4.27"),
+    ).toBe("26.4.28-alpha.0");
+  });
+});
+
+describe("calver maxNFromPackageJson — robustness (#784 explorer findings)", () => {
+  it("rejects non-CalVer legacy version (e.g. 2.0.0-alpha.134)", () => {
+    // Pre-CalVer migration shape — the trailing 134 must NOT match.
+    expect(maxNFromPackageJson("26.4.28", "alpha", "2.0.0-alpha.134")).toBe(-1);
+  });
+
+  it("substring trap: base 26.4.2 must not match 26.4.28-alpha.N", () => {
+    // The dash boundary in `${base}-${channel}.` should anchor the match
+    // so a shorter base doesn't fall through into a longer date.
+    expect(maxNFromPackageJson("26.4.2", "alpha", "26.4.28-alpha.5")).toBe(-1);
+    expect(maxNFromPackageJson("26.4.2", "alpha", "26.4.20-alpha.5")).toBe(-1);
+    // Genuine match still works for the actual base 26.4.2:
+    expect(maxNFromPackageJson("26.4.2", "alpha", "26.4.2-alpha.5")).toBe(5);
+  });
+
+  it("rejects malformed alpha suffix in package.json", () => {
+    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-alpha.")).toBe(-1);
+    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-alpha")).toBe(-1);
+    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-alpha.bogus")).toBe(-1);
+    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-alpha.12b")).toBe(-1);
+  });
+
+  it("zero-padded N parses as decimal (parity with parseInt)", () => {
+    // Mirrors maxNFromTags's parseInt behavior — `05` → 5, not octal.
+    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-alpha.05")).toBe(5);
+  });
+
+  it("rejects rc/other channels even if structurally similar", () => {
+    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-rc.5")).toBe(-1);
+  });
 });


### PR DESCRIPTION
## Summary

Option A from #784: tag-walk failed for post-#767 alpha branch because release workflow only fires on push to \`main\`. Walk \`package.json.version\` as additional source-of-truth. Take \`Math.max(tag-walk, package.json) + 1\`.

## Why

\`scripts/calver.ts\` walked git tags (\`v{base}-alpha.*\`) introduced #775. Post-#767 (CONTRIBUTING.md alpha-branch workflow), alphas merge to \`alpha\` branch — but \`calver-release.yml\` only fires on push to \`main\`. So no git tags get created for in-flight alphas, and tag-walk returns \`-1 → next: alpha.0\` regardless of how high \`package.json\` has climbed.

Reproduced today: \`package.json = 26.4.28-alpha.22\`, \`git tag --list 'v26.4.28-alpha.*'\` returns nothing, \`bun scripts/calver.ts --check\` returns \`alpha.0\`.

## Approach: Option A

Treat package.json as authoritative source-of-truth (it IS the version). Tags become a diagnostic/safety signal. The \`Math.max\` of both still increments correctly, so:

| Scenario | tag-walk | pkg-walk | result |
|---|---|---|---|
| Yesterday's pre-#767 day (tags exist, pkg lags) | 13 | 5 | 14 |
| Today's post-#767 day (tags don't exist, pkg ahead) | -1 | 22 | 23 |
| Both at same value | 5 | 5 | 6 |
| New day rollover (yesterday's pkg, no tags today) | -1 | -1 (date mismatch) | 0 |
| After stable cut, next-day alpha | -1 | -1 (no -alpha suffix) | 0 |

## Changes

- \`scripts/calver.ts\` — new \`maxNFromPackageJson(base, channel, version)\` parses \`vYY.M.D-{channel}.{N}\` (with or without v-prefix), returns N if base+channel match today, else -1. \`computeVersion\` integrates it via \`Math.max(tagMax, pkgMax) + 1\`. \`maxNFromTags(base, channel, tags)\` generalizes the alpha-only walk; \`maxAlphaFromTags\` kept as back-compat alias.
- \`test/calver.test.ts\` — 16 new tests (9 from implementer + 7 from explorer-driven robustness review):
  - matching alpha/beta channel
  - mismatched date / mismatched channel
  - non-integer suffix rejection (\`12.0\`, \`12-rc\`, \`abc\`)
  - empty / stable-only version strings
  - daily rollover (yesterday's pkg + today's no-tags → .0)
  - **substring trap** (base \`26.4.2\` must not match \`26.4.28-alpha.5\`)
  - non-CalVer legacy version (\`2.0.0-alpha.134\`)
  - malformed alpha suffix (\`alpha.\`, \`alpha\` without N, \`alpha.bogus\`, \`alpha.12b\`)
  - zero-padded N (\`alpha.05 → 5\`)
  - non-alpha/beta channels (\`rc.5\` rejected)
  - pkg-ahead-of-tags / tags-ahead-of-pkg / both-equal-still-increments
- \`package.json\` — bumped to \`26.4.28-alpha.25\` (m5 reserved; alpha.23=#759, alpha.24=#783)

## Tests

\`\`\`
$ bun test test/calver.test.ts
27 pass
0 fail
44 expect() calls
\`\`\`

Manual verification (with this branch's pkg at \`26.4.28-alpha.25\`):

\`\`\`
$ TZ=Asia/Bangkok bun scripts/calver.ts --check
Target: v26.4.28-alpha.26  [alpha]
\`\`\`

(Pre-fix this would return \`alpha.0\`, clobbering the in-flight alphas.)

## Methodology note

This PR was produced by m5:mawjs using a 2-agent parallel-explore pattern (the same shape as the gist series published earlier today). One sub-agent implemented Option A; a second explored edge cases independently and produced a 19-case findings report. The 7 cases the explorer surfaced that the implementer didn't cover (substring trap, daily rollover, legacy version, malformed suffix family) were added as additional tests; all pass against the existing implementation. No production-code change was needed from the explorer's findings — robustness was already there, but it's now locked in.

## Side-finds (filing separately, NOT scoping into this PR)

- **\`calver-release.yml\` HOUR>23 check is stale** (lines 75-81). Pre-#766 hour-bucket leftover. Will fail any push of \`alpha.24+\` to main. Today's pkg is \`alpha.22\` — safe for now but a landmine. **High urgency for filing.**
- **\`[0-9]{1,2}\` regex caps at alpha.99** in calver workflows. Latent bug for high-volume days.
- **\`auto-tag.yml\` exists alongside \`calver-release.yml\`** — possible double-tag race; needs audit.

Cross-ref: #775 (introduced monotonic counter), #783 (--beta channel work, hit this bug), #767 (alpha-branch workflow that exposed it).

Closes #784.