### PR TITLE
fix(workflow): drop stale HOUR>23 check in calver-check.yml (#787)

### DIFF
--- a/.github/workflows/calver-check.yml
+++ b/.github/workflows/calver-check.yml
@@ -47,11 +47,15 @@ jobs:
             exit 1
           fi
 
-          if [[ "$VERSION" == *-alpha.* ]]; then
-            HOUR_RAW="${VERSION##*-alpha.}"
-            HOUR="${HOUR_RAW%%[a-z]*}"
-            if (( HOUR < 0 || HOUR > 23 )); then
-              echo "::error::Hour must be 0-23, got $HOUR"
+          # Post-#775: monotonic counter — N can be any non-negative integer.
+          # Pre-release suffix shape (-alpha.N / -beta.N) is validated by the
+          # regex in scripts/calver.ts; this workflow only sanity-checks it
+          # exists and is digit-shaped.
+          if [[ "$VERSION" =~ -(alpha|beta)\. ]]; then
+            CHANNEL_RAW="${VERSION##*-}"
+            N_RAW="${CHANNEL_RAW#*.}"
+            if [[ ! "$N_RAW" =~ ^[0-9]+$ ]]; then
+              echo "::error::Pre-release counter must be a non-negative integer, got $N_RAW"
               exit 1
             fi
           fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.28-alpha.27",
+  "version": "26.4.28-alpha.28",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
## Fixes #787

Pre-#766 hour-bucket validation in \`.github/workflows/calver-check.yml\` is stale post-#775 monotonic counter.

### Before
\`\`\`yaml
HOUR_RAW="\${VERSION##*-alpha.}"
HOUR="\${HOUR_RAW%%[a-z]*}"
if (( HOUR < 0 || HOUR > 23 )); then
  echo "::error::Hour must be 0-23, got \$HOUR"; exit 1
fi
\`\`\`

### After
\`\`\`yaml
if [[ "\$VERSION" =~ -(alpha|beta)\. ]]; then
  CHANNEL_RAW="\${VERSION##*-}"
  N_RAW="\${CHANNEL_RAW#*.}"
  if [[ ! "\$N_RAW" =~ ^[0-9]+\$ ]]; then
    echo "::error::Pre-release counter must be a non-negative integer, got \$N_RAW"
    exit 1
  fi
fi
\`\`\`

### Why
- Monotonic counter (#775) means N can be 0..∞
- Pre-release shape regex in \`scripts/calver.ts\` already validates structure
- Workflow now also accepts \`-beta.N\` shape (#783 channel)

### Bump
v26.4.28-alpha.28 (calver script auto-picked correctly via #786 fix)

### Cross-ref
- Filed by mawjs-oracle@m5 during #786 work
- Closes #787

🤖 Generated with [Claude Code](https://claude.com/claude-code)