### PR TITLE
feat(send,run): raw text into any pane (#757)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.28-alpha.28",
+  "version": "26.4.28-alpha.29",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/api/sessions.ts
+++ b/src/api/sessions.ts
@@ -8,7 +8,8 @@ import { curlFetch } from "../core/transport/curl-fetch";
 import { resolveTarget } from "../core/routing";
 import { processMirror } from "../commands/plugins/overview/impl";
 import { resolveFleetSession } from "../commands/shared/wake";
-import { WakeBody, SleepBody, SendBody } from "../lib/schemas";
+import { WakeBody, SleepBody, SendBody, PaneKeysBody } from "../lib/schemas";
+import { Tmux } from "../core/transport/tmux";
 
 export const sessionsApi = new Elysia();
 
@@ -169,6 +170,36 @@ sessionsApi.post("/send", async ({ body, set}) => {
   }
 }, {
   body: SendBody,
+});
+
+/**
+ * POST /api/pane-keys — raw send-keys to any tmux pane (#757).
+ *
+ * Body: { target, text, enter? }
+ *   - text is sent literally via `tmux send-keys -l` (no paste-mode, no
+ *     interpretation of special chars like |). Empty text is allowed.
+ *   - enter=true appends `tmux send-keys Enter` after the text.
+ *
+ * No readiness guard, no paste delay — this is the dual of `maw send-enter`.
+ * Used by `maw send` (enter=false) and `maw run` (enter=true) cross-node.
+ */
+sessionsApi.post("/pane-keys", async ({ body, set }) => {
+  try {
+    const { target, text, enter } = body;
+    if (!target) { set.status = 400; return { error: "target required" }; }
+    const t = new Tmux();
+    if (text && text.length > 0) {
+      await t.sendKeysLiteral(target, text);
+    }
+    if (enter) {
+      await t.sendKeys(target, "Enter");
+    }
+    return { ok: true, target, enter: !!enter };
+  } catch (err) {
+    set.status = 500; return { error: String(err) };
+  }
+}, {
+  body: PaneKeysBody,
 });
 
 sessionsApi.post("/select", async ({ body, set}) => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -96,7 +96,7 @@ async function main(): Promise<void> {
         // NOT strictly match an oracle session name. Preserves `maw mawjs`
         // shorthand while catching `maw hek` / `maw oracl` / typos.
         const CORE_ROUTES = [
-          "hey", "send", "tell",
+          "hey",
           "plugins", "plugin", "artifacts", "artifact",
           "agents", "agent", "audit", "serve",
           "update", "upgrade", "version",

--- a/src/cli/route-comm.ts
+++ b/src/cli/route-comm.ts
@@ -2,8 +2,11 @@ import { cmdSend } from "../commands/shared/comm";
 import { UserError } from "../core/util/user-error";
 
 export async function routeComm(cmd: string, args: string[]): Promise<boolean> {
-  // hey stays core — it's the transport layer
-  if (cmd === "hey" || cmd === "send" || cmd === "tell") {
+  // hey stays core — it's the transport layer.
+  // Note: `send` and `tell` were previously aliases here; `send` is now the
+  // raw-text plugin (#757), and `tell` was undocumented. Use `maw hey` for
+  // agent messaging.
+  if (cmd === "hey") {
     const force = args.includes("--force");
     const target = args[1];
     const msgArgs = args.slice(2).filter(a => a !== "--force");

--- a/src/commands/plugins/run/impl.ts
+++ b/src/commands/plugins/run/impl.ts
@@ -1,0 +1,87 @@
+/**
+ * run — type text into any tmux pane and submit with Enter.
+ *
+ * Idiomatic verb for shell panes: `maw run <target> "<cmd>"` is the same as
+ * `maw send <target> "<cmd>" && maw send-enter <target>`. See #757.
+ *
+ * Unlike `maw hey`, this verb:
+ *   - accepts ANY tmux pane (bash, claude, anything) — no readiness guard
+ *   - uses `tmux send-keys -l` (literal) — no paste-mode, no smart escaping
+ *   - always appends Enter — submits the line
+ *
+ *   maw run <target> "<cmd>"
+ */
+
+import { listSessions, resolveTarget, Tmux, curlFetch } from "../../../sdk";
+import { loadConfig } from "../../../config";
+import { resolveOraclePane } from "../../shared/comm-send";
+
+export interface RunOpts {
+  target: string;
+  text: string;
+}
+
+export async function cmdRun(opts: RunOpts): Promise<void> {
+  const { target: query, text } = opts;
+  if (!query) throw new Error('usage: maw run <target> "<cmd>"');
+
+  const config = loadConfig();
+  const sessions = await listSessions();
+  const result = resolveTarget(query, config, sessions);
+
+  if (!result) {
+    throw new Error(`could not resolve target: ${query}`);
+  }
+
+  if (result.type === "error") {
+    const hint = result.hint ? ` — ${result.hint}` : "";
+    throw new Error(`${result.detail}${hint}`);
+  }
+
+  if (result.type === "peer") {
+    // Cross-node — route via federation /api/pane-keys (#757).
+    const res = await curlFetch(`${result.peerUrl}/api/pane-keys`, {
+      method: "POST",
+      body: JSON.stringify({ target: result.target, text, enter: true }),
+    });
+    if (!res.ok || !res.data?.ok) {
+      const underlying = res.data?.error || (res.status ? `HTTP ${res.status}` : "connection failed");
+      throw new Error(`peer run failed (${result.node} ${result.peerUrl}): ${underlying}`);
+    }
+    console.log(`\x1b[32mran\x1b[0m ⚡ ${result.node} → ${res.data.target || result.target}: ${truncate(text)}`);
+    return;
+  }
+
+  // Local or self-node — resolve to specific pane (handles multi-pane oracle windows)
+  const target = await resolveOraclePane(result.target);
+
+  const t = new Tmux();
+  if (text.length > 0) {
+    await t.sendKeysLiteral(target, text);
+  }
+  await t.sendKeys(target, "Enter");
+
+  console.log(`\x1b[32mran\x1b[0m → ${target}: ${truncate(text)}`);
+}
+
+function truncate(s: string, n = 200): string {
+  if (s.length <= n) return s;
+  return s.slice(0, n) + "…";
+}
+
+/**
+ * Parse args: <target> <cmd...>. The first positional (non-flag) arg is the
+ * target; everything after is the cmd, joined with spaces. Dashes inside
+ * the cmd are preserved so `maw run pane "ls -la"` and unquoted
+ * `maw run pane ls -la` both work. Empty cmd is allowed (degenerates to a
+ * bare Enter, same as `maw send-enter`).
+ *   ["bash-pane", "ls", "-la"]  → { target: "bash-pane", text: "ls -la" }
+ *   ["bash-pane"]               → { target: "bash-pane", text: "" }
+ */
+export function parseRunArgs(args: string[]): RunOpts {
+  const targetIdx = args.findIndex(a => !a.startsWith("-"));
+  if (targetIdx < 0) throw new Error('usage: maw run <target> "<cmd>"');
+  const target = args[targetIdx];
+  const text = args.slice(targetIdx + 1).join(" ");
+  return { target, text };
+}

--- a/src/commands/plugins/run/index.ts
+++ b/src/commands/plugins/run/index.ts
@@ -1,0 +1,42 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { cmdRun, parseRunArgs } from "./impl";
+
+export const command = {
+  name: "run",
+  description: "Type text into a tmux pane and submit with Enter (idiomatic for shells).",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+
+  try {
+    let opts;
+    if (ctx.source === "cli") {
+      const args = ctx.args as string[];
+      opts = parseRunArgs(args);
+    } else {
+      const a = ctx.args as Record<string, unknown>;
+      const target = (a.target as string) ?? "";
+      const text = (a.text as string) ?? "";
+      opts = { target, text };
+    }
+
+    await cmdRun(opts);
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/src/commands/plugins/run/plugin.json
+++ b/src/commands/plugins/run/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "run",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Type text into a tmux pane and submit with Enter — idiomatic for shells (#757).",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "run",
+    "help": "maw run <target> \"<cmd>\" — type text into a tmux pane and press Enter"
+  },
+  "weight": 0
+}

--- a/src/commands/plugins/run/run.test.ts
+++ b/src/commands/plugins/run/run.test.ts
@@ -1,0 +1,45 @@
+/**
+ * run — argument parser tests (#757).
+ */
+
+import { test, expect } from "bun:test";
+import { parseRunArgs } from "./impl";
+
+test("parseRunArgs: target + single-word cmd", () => {
+  const opts = parseRunArgs(["bash-pane", "ls"]);
+  expect(opts.target).toBe("bash-pane");
+  expect(opts.text).toBe("ls");
+});
+
+test("parseRunArgs: target + multi-word cmd", () => {
+  const opts = parseRunArgs(["bash-pane", "ls", "-la", "/tmp"]);
+  expect(opts.target).toBe("bash-pane");
+  expect(opts.text).toBe("ls -la /tmp");
+});
+
+test("parseRunArgs: empty cmd allowed (bare Enter)", () => {
+  const opts = parseRunArgs(["bash-pane"]);
+  expect(opts.target).toBe("bash-pane");
+  expect(opts.text).toBe("");
+});
+
+test("parseRunArgs: shell metacharacters preserved", () => {
+  const opts = parseRunArgs(["local:bash-pane", "echo", "hi", "&&", "ls"]);
+  expect(opts.text).toBe("echo hi && ls");
+});
+
+test("parseRunArgs: missing target throws", () => {
+  expect(() => parseRunArgs([])).toThrow(/usage/);
+});
+
+test("parseRunArgs: cross-node target accepted", () => {
+  const opts = parseRunArgs(["clinic:01-mawjs", "make", "test"]);
+  expect(opts.target).toBe("clinic:01-mawjs");
+  expect(opts.text).toBe("make test");
+});
+
+test("parseRunArgs: pane-specific target accepted", () => {
+  const opts = parseRunArgs(["session:1.2", "exit"]);
+  expect(opts.target).toBe("session:1.2");
+  expect(opts.text).toBe("exit");
+});

--- a/src/commands/plugins/send/impl.ts
+++ b/src/commands/plugins/send/impl.ts
@@ -1,0 +1,88 @@
+/**
+ * send — type raw text into any tmux pane (no Enter, composable).
+ *
+ * Dual of `maw send-enter` (#728). `maw send` puts characters on the prompt
+ * line without submitting; pair with `maw send-enter` to submit, or use
+ * `maw run` for the text+Enter combo. See #757.
+ *
+ * Unlike `maw hey`, this verb:
+ *   - accepts ANY tmux pane (bash, claude, anything) — no readiness guard
+ *   - uses `tmux send-keys -l` (literal) — no paste-mode, no smart escaping
+ *   - never appends Enter — the caller composes
+ *
+ *   maw send <target> "<text>"
+ */
+
+import { listSessions, resolveTarget, Tmux, curlFetch } from "../../../sdk";
+import { loadConfig } from "../../../config";
+import { resolveOraclePane } from "../../shared/comm-send";
+
+export interface SendOpts {
+  target: string;
+  text: string;
+}
+
+export async function cmdSend(opts: SendOpts): Promise<void> {
+  const { target: query, text } = opts;
+  if (!query) throw new Error('usage: maw send <target> "<text>"');
+
+  const config = loadConfig();
+  const sessions = await listSessions();
+  const result = resolveTarget(query, config, sessions);
+
+  if (!result) {
+    throw new Error(`could not resolve target: ${query}`);
+  }
+
+  if (result.type === "error") {
+    const hint = result.hint ? ` — ${result.hint}` : "";
+    throw new Error(`${result.detail}${hint}`);
+  }
+
+  if (result.type === "peer") {
+    // Cross-node — route via federation /api/pane-keys (#757).
+    const res = await curlFetch(`${result.peerUrl}/api/pane-keys`, {
+      method: "POST",
+      body: JSON.stringify({ target: result.target, text, enter: false }),
+    });
+    if (!res.ok || !res.data?.ok) {
+      const underlying = res.data?.error || (res.status ? `HTTP ${res.status}` : "connection failed");
+      throw new Error(`peer send failed (${result.node} ${result.peerUrl}): ${underlying}`);
+    }
+    console.log(`\x1b[32mtyped\x1b[0m ⚡ ${result.node} → ${res.data.target || result.target}: ${truncate(text)}`);
+    return;
+  }
+
+  // Local or self-node — resolve to specific pane (handles multi-pane oracle windows)
+  const target = await resolveOraclePane(result.target);
+
+  const t = new Tmux();
+  await t.sendKeysLiteral(target, text);
+
+  console.log(`\x1b[32mtyped\x1b[0m → ${target}: ${truncate(text)}`);
+}
+
+function truncate(s: string, n = 200): string {
+  if (s.length <= n) return s;
+  return s.slice(0, n) + "…";
+}
+
+/**
+ * Parse args: <target> <text...>. The first positional (non-flag) arg is the
+ * target; everything after is the text, joined with spaces. Dashes inside
+ * the text are preserved so `maw send pane "ls -la"` and unquoted
+ * `maw send pane ls -la` both work.
+ *   ["mba:sloworacle", "echo hi"]              → { target, text: "echo hi" }
+ *   ["mba:sloworacle", "echo", "hi"]           → { target, text: "echo hi" }
+ *   ["mba:sloworacle", "ls", "-la", "/tmp"]    → { target, text: "ls -la /tmp" }
+ */
+export function parseSendArgs(args: string[]): SendOpts {
+  // Find the first non-flag arg — that's the target. Everything after
+  // (regardless of dashes) is text.
+  const targetIdx = args.findIndex(a => !a.startsWith("-"));
+  if (targetIdx < 0) throw new Error('usage: maw send <target> "<text>"');
+  const target = args[targetIdx];
+  const text = args.slice(targetIdx + 1).join(" ");
+  if (text.length === 0) throw new Error('usage: maw send <target> "<text>" — text is required');
+  return { target, text };
+}

--- a/src/commands/plugins/send/index.ts
+++ b/src/commands/plugins/send/index.ts
@@ -1,0 +1,42 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { cmdSend, parseSendArgs } from "./impl";
+
+export const command = {
+  name: "send",
+  description: "Type raw text into a tmux pane (no Enter, composable).",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+
+  try {
+    let opts;
+    if (ctx.source === "cli") {
+      const args = ctx.args as string[];
+      opts = parseSendArgs(args);
+    } else {
+      const a = ctx.args as Record<string, unknown>;
+      const target = (a.target as string) ?? "";
+      const text = (a.text as string) ?? "";
+      opts = { target, text };
+    }
+
+    await cmdSend(opts);
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/src/commands/plugins/send/plugin.json
+++ b/src/commands/plugins/send/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "send",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Type raw text into a tmux pane (no Enter, composable) — dual of send-enter (#757).",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "send",
+    "help": "maw send <target> \"<text>\" — type raw text into a tmux pane (no Enter)"
+  },
+  "weight": 0
+}

--- a/src/commands/plugins/send/send.test.ts
+++ b/src/commands/plugins/send/send.test.ts
@@ -1,0 +1,43 @@
+/**
+ * send — argument parser tests (#757).
+ */
+
+import { test, expect } from "bun:test";
+import { parseSendArgs } from "./impl";
+
+test("parseSendArgs: target + single-word text", () => {
+  const opts = parseSendArgs(["mba:sloworacle", "echo"]);
+  expect(opts.target).toBe("mba:sloworacle");
+  expect(opts.text).toBe("echo");
+});
+
+test("parseSendArgs: target + multi-word text joined with spaces", () => {
+  const opts = parseSendArgs(["mba:sloworacle", "echo", "hello", "world"]);
+  expect(opts.target).toBe("mba:sloworacle");
+  expect(opts.text).toBe("echo hello world");
+});
+
+test("parseSendArgs: text with shell metacharacters preserved", () => {
+  const opts = parseSendArgs(["local:bash-pane", "ls", "|", "grep", "foo"]);
+  expect(opts.text).toBe("ls | grep foo");
+});
+
+test("parseSendArgs: missing target throws", () => {
+  expect(() => parseSendArgs([])).toThrow(/usage/);
+});
+
+test("parseSendArgs: missing text throws", () => {
+  expect(() => parseSendArgs(["mba:sloworacle"])).toThrow(/text is required/);
+});
+
+test("parseSendArgs: cross-node target accepted", () => {
+  const opts = parseSendArgs(["clinic:01-mawjs", "make", "test"]);
+  expect(opts.target).toBe("clinic:01-mawjs");
+  expect(opts.text).toBe("make test");
+});
+
+test("parseSendArgs: pane-specific target accepted", () => {
+  const opts = parseSendArgs(["session:1.2", "exit"]);
+  expect(opts.target).toBe("session:1.2");
+  expect(opts.text).toBe("exit");
+});

--- a/src/lib/elysia-auth.ts
+++ b/src/lib/elysia-auth.ts
@@ -16,6 +16,7 @@ const WINDOW_SEC = D.hmacWindowSeconds;
 /** Protected paths — write/control operations, require auth from non-loopback clients */
 const PROTECTED = new Set([
   "/send",
+  "/pane-keys",
   "/talk",
   "/transport/send",
   "/triggers/fire",

--- a/src/lib/federation-auth.ts
+++ b/src/lib/federation-auth.ts
@@ -34,6 +34,7 @@ export function hashBody(body: string | Uint8Array | undefined | null): string {
 /** Protected paths — write/control operations, require auth from non-loopback clients */
 const PROTECTED = new Set([
   "/api/send",
+  "/api/pane-keys",
   "/api/talk",
   "/api/transport/send",
   "/api/triggers/fire",

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -110,6 +110,20 @@ export const SendBody = Type.Object({
 });
 export type TSendBody = Static<typeof SendBody>;
 
+/**
+ * POST /api/pane-keys (#757)
+ *
+ * Raw tmux send-keys to any pane (bash, claude, anything). No paste-mode,
+ * no readiness guard. Used by `maw send` (enter=false) and `maw run`
+ * (enter=true) for cross-node pane control.
+ */
+export const PaneKeysBody = Type.Object({
+  target: Type.String(),
+  text: Type.String(),
+  enter: Type.Optional(Type.Boolean()),
+});
+export type TPaneKeysBody = Static<typeof PaneKeysBody>;
+
 /** POST /api/config-file (save) */
 export const ConfigFileBody = Type.Object({
   content: Type.String(),


### PR DESCRIPTION
## Summary

Adds two new verbs as duals of `maw send-enter` (#728), per Option B in #757:

- `maw send <target> "<text>"` — types raw text into any tmux pane (no Enter, composable)
- `maw run <target> "<cmd>"` — types text and presses Enter (idiomatic for shells)

Both verbs:
- Accept any tmux pane (bash, claude, anything) — no readiness guard
- Use `tmux send-keys -l` (literal) — no paste-mode, no smart escaping, no `--force` semantic mismatch
- Route through `resolveTarget` for local / self-node / cross-node / fleet auto-wake parity with `maw hey` and `maw send-enter`
- Cross-node calls hit a new `/api/pane-keys` endpoint (HMAC-protected) on the peer node

Removes the undocumented `send` and `tell` aliases of `maw hey` to free the verb. `maw hey` remains the canonical agent-messaging path; `--force` still works there for the existing escape hatch.

## Files

- `src/commands/plugins/send/` — new plugin (impl + index + plugin.json + tests)
- `src/commands/plugins/run/` — new plugin (impl + index + plugin.json + tests)
- `src/api/sessions.ts` — adds `POST /api/pane-keys` (raw send-keys to any pane, with optional Enter)
- `src/lib/schemas.ts` — adds `PaneKeysBody`
- `src/lib/elysia-auth.ts` + `src/lib/federation-auth.ts` — adds `/pane-keys` to PROTECTED set
- `src/cli/route-comm.ts` — drops `send`/`tell` aliases (kept `hey`)
- `src/cli.ts` — drops `send`/`tell` from CORE_ROUTES typo allowlist
- `package.json` — bumps to v26.4.28-alpha.26 (alpha.24 reserved for #783, alpha.25 for #784)

## Test plan

- [x] `bun test src/commands/plugins/{send,run,send-enter}` — 22 pass, 0 fail
  - parser: target + single-word, multi-word, missing-target, empty-text (send only)
  - parser: pane-specific targets (`session:1.2`), cross-node targets (`clinic:01-mawjs`), shell metacharacters (`|`, `&&`)
  - parser: dashed args inside cmd preserved (`ls -la`)
- [x] `bun run test` — 1360 pass, 0 fail (standard suite)
- [ ] Manual: `maw send local:bash-pane "echo hi"` → text appears, no Enter
- [ ] Manual: `maw run local:bash-pane "ls"` → command runs
- [ ] Manual: `maw send mba:bash-pane "echo hi"` → cross-node delivery via `/api/pane-keys`

🤖 Generated with [Claude Code](https://claude.com/claude-code)