### PR TITLE
fix(workflow): calver-check regex accepts beta + unbounded N

### DIFF
--- a/.github/workflows/calver-check.yml
+++ b/.github/workflows/calver-check.yml
@@ -28,9 +28,9 @@ jobs:
           VERSION="${TAG#v}"
           echo "Validating: $TAG ($VERSION)"
 
-          REGEX='^[0-9]{2}\.[0-9]{1,2}\.[0-9]{1,2}(-alpha\.[0-9]{1,2}[a-z]?)?$'
+          REGEX='^[0-9]{2}\.[0-9]{1,2}\.[0-9]{1,2}(-(alpha|beta)\.[0-9]+)?$'
           if [[ ! "$VERSION" =~ $REGEX ]]; then
-            echo "::error title=CalVer violation::Tag '$TAG' does not match v{yy}.{m}.{d}[-alpha.{hour}]"
+            echo "::error title=CalVer violation::Tag '$TAG' does not match v{yy}.{m}.{d}[-(alpha|beta).{N}]"
             echo "::error::Spec: https://github.com/Soul-Brews-Studio/mawjs-oracle/blob/main/%CF%88/inbox/2026-04-18_proposal-calver-skills-cli.md"
             exit 1
           fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.28-alpha.29",
+  "version": "26.4.28-alpha.30",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
## Follow-up to #788

The outer regex on \`.github/workflows/calver-check.yml:31\` was still alpha-only with \`N\` limited to \`{1,2}\` digits. After #783 (\`beta\` channel) and #775 (monotonic counter), this would fail validation on:

- Any \`-beta.N\` push to main
- Any \`-alpha.N\` where \`N >= 100\`

### Fix

\`\`\`diff
- REGEX='^[0-9]{2}\.[0-9]{1,2}\.[0-9]{1,2}(-alpha\.[0-9]{1,2}[a-z]?)?\$'
+ REGEX='^[0-9]{2}\.[0-9]{1,2}\.[0-9]{1,2}(-(alpha|beta)\.[0-9]+)?\$'
\`\`\`

### Discovery

Caught by mawjs-oracle@m5 reviewer pass on PR #788. Latent today (no main pushes use \`-beta\`) but landmine.

### Bump
v26.4.28-alpha.29 (may collide with #789 in flight — first to merge wins, other rebases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)