### PR TITLE
fix(config): pass config.node to loadFleetAgents — fleet-merged entries were 'local' literal (#790)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.28-alpha.30",
+  "version": "26.4.28-alpha.31",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -59,7 +59,7 @@ export function loadConfig(): MawConfig {
   // before their first wake. Additive only: hand-tuned config.agents entries
   // are preserved. Failure swallowed: a fleet read glitch must not brick load.
   try {
-    const merged = loadFleetAgents(cached.agents || {});
+    const merged = loadFleetAgents(cached.agents || {}, cached.node);
     if (Object.keys(merged).length > 0) cached.agents = merged;
   } catch {
     // Defensive — loadFleetAgents already swallows IO/parse errors, but if

--- a/test/config-fleet-merge.test.ts
+++ b/test/config-fleet-merge.test.ts
@@ -157,4 +157,22 @@ describe("loadFleetAgents (#736 Phase 1.1)", () => {
     expect(result["extra-oracle"]).toBe("mba");
     expect(result["neo-oracle"]).toBe("local");
   });
+
+  test("fleet-merged entries use config.node, not literal 'local' (#790)", () => {
+    // Regression: load.ts:62 was calling loadFleetAgents(cached.agents || {})
+    // without passing cached.node — so on a node named "m5", fleet-merged
+    // entries got the literal string "local", which resolveTarget() then
+    // failed to recognize as self. This test pins the contract: when the
+    // caller passes config.node ("m5"), every fleet-merged window must map
+    // to "m5", never to "local".
+    writeFileSync(join(dir, "08-mawjs.json"), JSON.stringify({
+      name: "08-mawjs",
+      windows: [{ name: "mawjs-oracle" }, { name: "neo-oracle" }],
+    }));
+    const result = loadFleetAgents({}, "m5", dir);
+    expect(result["mawjs-oracle"]).toBe("m5");
+    expect(result["neo-oracle"]).toBe("m5");
+    // And specifically NOT the buggy literal:
+    expect(result["mawjs-oracle"]).not.toBe("local");
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #790. One-liner config bug: `src/config/load.ts:62` was calling `loadFleetAgents(cached.agents || {})` without passing the node name, so fleet-merged windows always landed as the literal string `"local"`. On any node whose `config.node` is not literally `"local"` (e.g. `"m5"`), `resolveTarget()` then failed to recognize self — federation routing missed every fleet-known oracle until a manual wake repaired the map.

## Before / After

```ts
// before — load.ts:62
const merged = loadFleetAgents(cached.agents || {});

// after
const merged = loadFleetAgents(cached.agents || {}, cached.node);
```

`loadFleetAgents` already accepts `localNode` as the second arg with `"local"` default. The default stays for back-compat (no in-repo callers rely on it), but the live call site now threads `cached.node` through.

## Test

Added one regression test in `test/config-fleet-merge.test.ts`:

```ts
test("fleet-merged entries use config.node, not literal 'local' (#790)", ...);
```

Pins the contract: when caller passes `config.node = "m5"`, every fleet-merged window must map to `"m5"`, never to `"local"`.

- `bun test test/config-fleet-merge.test.ts` → **12 pass / 0 fail**
- `bun run build` → **0.86 MB**, 631 modules, 29ms

## Version

Bumps to `26.4.28-alpha.31` (alpha.29 = #789, .30 = white #792 regex fix in flight).

## Constraints honored

- Only touched `src/config/load.ts`, `test/config-fleet-merge.test.ts`, `package.json`
- Did not modify `loadFleetAgents` itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)