### PR TITLE
fix(hey): cross-node auto-wake via sender-side /api/wake + /api/send sequence (#791)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.28-alpha.31",
+  "version": "26.4.28-alpha.33",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -216,18 +216,23 @@ export async function cmdSend(query: string, message: string, force = false) {
 
   let sessions = await listSessions();
 
-  // --- #736 Phase 1.2: auto-wake fleet-known targets (parity with maw view) ---
+  // --- #736 Phase 1.2 + #791: auto-wake fleet-known targets (parity with maw view) ---
   // Mirrors view/impl.ts:107 — if the user's hey target is fleet-known but
-  // no local session exists, silently wake it before sending. No y/N prompt:
-  // fleet membership is sufficient signal that this isn't a typo. Cross-node
-  // targets are skipped here — the remote peer's federation handler wakes its
-  // own fleet (sessions.ts:/api/wake already does cmdWake for inbound peers).
+  // no live session exists, silently wake it before sending. No y/N prompt:
+  // fleet membership is sufficient signal that this isn't a typo.
+  //
+  // Local scope (no node prefix or matches config.node): wake locally via cmdWake.
+  // Cross-node short form (<peer>:<agent>, no third colon): wake remotely via
+  // peer's /api/wake (#791 — Option B from the design RFC). Canonical form
+  // (<peer>:<session>:<window>) skips wake because the session is explicitly
+  // named — wake on a session id would no-op or misroute.
   {
-    const colonIdx = query.indexOf(":");
-    const targetNode = colonIdx >= 0 ? query.slice(0, colonIdx) : null;
-    const bareAgent = colonIdx >= 0 ? query.slice(colonIdx + 1).split(":")[0] : query;
+    const parts = query.split(":");
+    const targetNode = parts.length >= 2 ? parts[0] : null;
+    const bareAgent = parts.length >= 2 ? parts[1] : query;
+    const isCanonical = parts.length >= 3;
     const isLocalScope = !targetNode || targetNode === config.node;
-    if (isLocalScope && bareAgent) {
+    if (isLocalScope && bareAgent && !isCanonical) {
       const hasLocalSession = sessions.some(s =>
         s.name === bareAgent ||
         s.windows.some(w => w.name === `${bareAgent}-oracle` || w.name === bareAgent)
@@ -244,6 +249,26 @@ export async function cmdSend(query: string, message: string, force = false) {
           }
         } catch { /* fleet/wake best-effort — fall through to existing error path */ }
       }
+    } else if (targetNode && bareAgent && !isCanonical) {
+      // #791: cross-node auto-wake. Sender does explicit /api/wake before
+      // /api/send (Option B). Wake is idempotent on the receiver — if the
+      // session already exists, cmdWake returns quickly. If wake errors,
+      // surface and exit (do NOT silently fall through to send — design
+      // call requires wake errors to be visible).
+      const peer = (config.namedPeers || []).find(p => p.name === targetNode);
+      if (peer) {
+        const wakeRes = await curlFetch(`${peer.url}/api/wake`, {
+          method: "POST",
+          body: JSON.stringify({ target: bareAgent }),
+        });
+        if (!wakeRes.ok || !wakeRes.data?.ok) {
+          const underlying = wakeRes.data?.error || (wakeRes.status ? `HTTP ${wakeRes.status}` : "connection failed");
+          console.error(`\x1b[31merror\x1b[0m: cross-node wake failed for ${targetNode}:${bareAgent}: ${underlying}`);
+          console.error(`\x1b[33mhint\x1b[0m:  check peer connectivity: maw health`);
+          process.exit(1);
+        }
+      }
+      // peer not in namedPeers → fall through; resolveTarget will surface the routing error.
     }
   }
 

--- a/test/isolated/hey-cross-node-auto-wake.test.ts
+++ b/test/isolated/hey-cross-node-auto-wake.test.ts
@@ -1,0 +1,177 @@
+/**
+ * hey-cross-node-auto-wake.test.ts — #791 Option B.
+ *
+ * Verifies cmdSend does cross-node auto-wake by calling the peer's
+ * /api/wake before /api/send when the target is short cross-node form
+ * (<peer>:<agent>). Sender-side wake+send sequence per the design RFC
+ * on issue #791.
+ *
+ * - Short form (peer:agent) on a peer in namedPeers → wake then send.
+ * - Canonical form (peer:session:window) → no wake, just send.
+ * - Peer not in namedPeers → no wake call, fall through to resolveTarget.
+ * - Wake error → process.exit(1) with wake error message; do NOT proceed to send.
+ */
+import { describe, test, expect, mock, beforeEach, afterEach, afterAll } from "bun:test";
+import { join } from "path";
+
+let mockActive = false;
+const _rSdk = await import("../../src/sdk");
+
+let curlFetchCalls: Array<{ url: string }> = [];
+let curlFetchHandler: (url: string) => { ok: boolean; status?: number; data: unknown } =
+  () => ({ ok: false, status: 500, data: {} });
+let listSessionsReturn: Array<{ name: string; windows: { index: number; name: string; active: boolean }[] }> = [];
+let resolveTargetReturn: unknown = { type: "peer", target: "hojo", node: "phaith", peerUrl: "http://phaith:3456" };
+let mockNamedPeers: Array<{ name: string; url: string }> = [];
+
+mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
+  ..._rSdk,
+  capture: async () => "",
+  sendKeys: async () => {},
+  getPaneCommand: async () => "claude",
+  listSessions: async () => mockActive ? listSessionsReturn : [],
+  findPeerForTarget: async () => null,
+  curlFetch: async (url: string) => {
+    if (!mockActive) return { ok: false, status: 0, data: {} };
+    curlFetchCalls.push({ url });
+    return curlFetchHandler(url);
+  },
+  runHook: async () => {},
+  hostExec: async () => "",
+}));
+
+mock.module(join(import.meta.dir, "../../src/config"), () => {
+  const { mockConfigModule } = require("../helpers/mock-config");
+  return mockConfigModule(() => ({
+    node: "test-node",
+    port: 3456,
+    namedPeers: mockNamedPeers,
+  }));
+});
+
+mock.module(join(import.meta.dir, "../../src/core/routing"), () => ({
+  resolveTarget: () => resolveTargetReturn,
+}));
+
+mock.module(join(import.meta.dir, "../../src/core/runtime/hooks"), () => ({
+  runHook: async () => {},
+}));
+
+mock.module(join(import.meta.dir, "../../src/commands/shared/comm-log-feed"), () => ({
+  logMessage: () => {},
+  emitFeed: () => {},
+}));
+
+mock.module(join(import.meta.dir, "../../src/commands/shared/wake-resolve"), () => ({
+  resolveFleetSession: () => null,
+}));
+
+mock.module(join(import.meta.dir, "../../src/commands/shared/wake-cmd"), () => ({
+  cmdWake: async () => "should-not-be-called-for-cross-node",
+}));
+
+const origSleep = Bun.sleep.bind(Bun);
+(Bun as unknown as { sleep: (ms: number) => Promise<void> }).sleep = async () => {};
+
+const { cmdSend } = await import("../../src/commands/shared/comm-send");
+
+const origExit = process.exit;
+const origErr = console.error;
+const origLog = console.log;
+let exitCode: number | undefined;
+let errs: string[] = [];
+
+async function run(fn: () => Promise<unknown>): Promise<void> {
+  exitCode = undefined; errs = [];
+  console.error = (...a: unknown[]) => { errs.push(a.map(String).join(" ")); };
+  console.log = () => {};
+  (process as unknown as { exit: (c?: number) => never }).exit =
+    (c?: number): never => { exitCode = c ?? 0; throw new Error("__exit__:" + exitCode); };
+  try { await fn(); }
+  catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (!msg.startsWith("__exit__")) throw e;
+  } finally {
+    console.error = origErr;
+    console.log = origLog;
+    (process as unknown as { exit: typeof origExit }).exit = origExit;
+  }
+}
+
+beforeEach(() => {
+  mockActive = true;
+  curlFetchCalls = [];
+  listSessionsReturn = [];
+  mockNamedPeers = [];
+  curlFetchHandler = () => ({ ok: false, status: 500, data: {} });
+  resolveTargetReturn = { type: "peer", target: "hojo", node: "phaith", peerUrl: "http://phaith:3456" };
+  process.env.MAW_QUIET = "1";
+});
+
+afterEach(() => { mockActive = false; delete process.env.MAW_QUIET; });
+afterAll(() => {
+  mockActive = false;
+  (Bun as unknown as { sleep: typeof origSleep }).sleep = origSleep;
+});
+
+describe("cmdSend — cross-node auto-wake (#791)", () => {
+  test("short cross-node form calls /api/wake then /api/send (#791 Option B)", async () => {
+    mockNamedPeers = [{ name: "phaith", url: "http://phaith:3456" }];
+    curlFetchHandler = (url: string) => {
+      if (url.includes("/api/wake")) return { ok: true, status: 200, data: { ok: true, target: "hojo" } };
+      if (url.includes("/api/send")) return { ok: true, status: 200, data: { ok: true, target: "hojo:1" } };
+      return { ok: false, status: 500, data: {} };
+    };
+
+    await run(() => cmdSend("phaith:hojo", "ping"));
+
+    expect(curlFetchCalls.length).toBe(2);
+    expect(curlFetchCalls[0].url).toContain("/api/wake");
+    expect(curlFetchCalls[1].url).toContain("/api/send");
+    expect(exitCode).toBeUndefined();
+  });
+
+  test("canonical cross-node form (peer:session:window) does NOT call /api/wake", async () => {
+    mockNamedPeers = [{ name: "phaith", url: "http://phaith:3456" }];
+    resolveTargetReturn = { type: "peer", target: "01-hojo:3", node: "phaith", peerUrl: "http://phaith:3456" };
+    curlFetchHandler = (url: string) => {
+      if (url.includes("/api/send")) return { ok: true, status: 200, data: { ok: true, target: "01-hojo:3" } };
+      return { ok: false, status: 500, data: {} };
+    };
+
+    await run(() => cmdSend("phaith:01-hojo:3", "ping"));
+
+    const wakeCalls = curlFetchCalls.filter(c => c.url.includes("/api/wake"));
+    const sendCalls = curlFetchCalls.filter(c => c.url.includes("/api/send"));
+    expect(wakeCalls.length).toBe(0);
+    expect(sendCalls.length).toBe(1);
+  });
+
+  test("peer not in namedPeers → no wake call, fall through to resolveTarget error path", async () => {
+    mockNamedPeers = []; // no peers configured
+    resolveTargetReturn = { type: "error", target: "phaith:hojo", detail: "no peer URL", hint: "" };
+
+    await run(() => cmdSend("phaith:hojo", "ping"));
+
+    const wakeCalls = curlFetchCalls.filter(c => c.url.includes("/api/wake"));
+    expect(wakeCalls.length).toBe(0);
+  });
+
+  test("wake error surfaces and exits — does NOT proceed to /api/send", async () => {
+    mockNamedPeers = [{ name: "phaith", url: "http://phaith:3456" }];
+    curlFetchHandler = (url: string) => {
+      if (url.includes("/api/wake")) return { ok: false, status: 503, data: { error: "peer unreachable" } };
+      // /api/send mock would succeed, but should not be reached
+      if (url.includes("/api/send")) return { ok: true, status: 200, data: { ok: true } };
+      return { ok: false, status: 500, data: {} };
+    };
+
+    await run(() => cmdSend("phaith:hojo", "ping"));
+
+    expect(exitCode).toBe(1);
+    const sendCalls = curlFetchCalls.filter(c => c.url.includes("/api/send"));
+    expect(sendCalls.length).toBe(0);
+    const allErr = errs.join("\n");
+    expect(allErr).toMatch(/cross-node wake failed/);
+  });
+});


### PR DESCRIPTION
## Summary

Implements **Option B** from the design RFC on issue #791. Closes the gap where local fleet auto-wake (#780) did not extend to cross-node short form: \`maw hey peer:fleet-name \"msg\"\` to a sleeping remote agent silently no-op'd because \`/api/send\` on the remote peer doesn't call wake.

## ⚠️ Convergence note (m5 + white)

Both peers independently took #791 in the same iter (white deployed an Agent at iter20; m5 wrote inline during iter17 → iter20 wrap). m5 yielded alpha.32 to white's lane, took **alpha.33** for this PR. Whichever merges first wins; the other can be closed or rebased. Treat this as redundant signal of correctness on the implementation shape.

## Behavior

For short cross-node form (\`<peer>:<agent>\`, exactly 2 parts), if the peer is in \`config.namedPeers\`, sender now POSTs to \`<peer>/api/wake\` before \`<peer>/api/send\`. Wake errors surface and exit 1 — do NOT silently fall through to send (per RFC).

Canonical form (\`<peer>:<session>:<window>\`) is intentionally skipped: the session is explicit and wake on a session id would no-op or misroute. Local + self-node paths unchanged.

## Tradeoffs (per RFC)

- Two round-trips on every cross-node send. Wake is idempotent on the receiver, so warm-target overhead is small.
- Future work (Option C in v27): combined \`/api/send-or-wake\` endpoint for single round-trip + better receiver-side fleet ownership.

## Tests

New \`test/isolated/hey-cross-node-auto-wake.test.ts\` — 4 cases (4/4 pass):

1. Short cross-node form calls \`/api/wake\` then \`/api/send\` in order
2. Canonical form (\`peer:session:window\`) does NOT call \`/api/wake\`
3. Peer not in \`namedPeers\` → no wake call (falls through to error path)
4. Wake error → \`process.exit(1)\` with wake error message; \`/api/send\` NOT called

Existing \`hey-fleet-auto-wake.test.ts\` test \"does NOT wake on cross-node target\" still passes — it asserts no LOCAL \`cmdWake\` on cross-node, which remains true (wake is via \`/api/wake\` HTTP, not local cmdWake).

Closes #791.