### PR TITLE
fix(api): WakeBody accepts target OR oracle field (#795)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.28-alpha.33",
+  "version": "26.4.28-alpha.34",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/api/sessions.ts
+++ b/src/api/sessions.ts
@@ -213,9 +213,10 @@ sessionsApi.post("/select", async ({ body, set}) => {
 
 sessionsApi.post("/wake", async ({ body, set}) => {
   try {
-    const { target, task } = body;
+    const target = body.target ?? body.oracle;
+    if (!target) { set.status = 400; return { error: "target required (or 'oracle' for legacy peers)" }; }
     const { cmdWake } = await import("../commands/shared/wake");
-    await cmdWake(target, { noAttach: true, task });
+    await cmdWake(target, { noAttach: true, task: body.task });
     return { ok: true, target };
   } catch (err) {
     set.status = 500; return { error: String(err) };

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -88,9 +88,10 @@ export type TPluginInfo = Static<typeof PluginInfo>;
 // Request body schemas (POST endpoints)
 // ---------------------------------------------------------------------------
 
-/** POST /api/wake */
+/** POST /api/wake — accepts `target` (current) or `oracle` (legacy pre-rename) */
 export const WakeBody = Type.Object({
-  target: Type.String(),
+  target: Type.Optional(Type.String()),
+  oracle: Type.Optional(Type.String()),
   task: Type.Optional(Type.String()),
 });
 export type TWakeBody = Static<typeof WakeBody>;


### PR DESCRIPTION
## Fixes #795

Schema drift between deployed peers: older builds sent \`{ oracle: ... }\`, current alpha schema only accepted \`{ target: ... }\`. Surfaced by m5 during PR #794 runtime test (\`maw hey white:mawjs\` → \`missing oracle name\`).

### Fix
\`WakeBody\` now accepts BOTH:
\`\`\`ts
export const WakeBody = Type.Object({
  target: Type.Optional(Type.String()),
  oracle: Type.Optional(Type.String()),
  task: Type.Optional(Type.String()),
});
\`\`\`

Handler resolves \`body.target ?? body.oracle\` with explicit \"target required\" 400 if neither present.

### Forward-compat
Once both peers run alpha.34+, either field name works. The graceful fix means a current-alpha peer can both send \`target\` (preferred) and accept \`oracle\` (legacy).

### Long-term
Federation versioning + capability handshake is #565 (out of scope).

### Bump
v26.4.28-alpha.34

🤖 Generated with [Claude Code](https://claude.com/claude-code)