### PR TITLE
🚨 sec(api): add /wake and /sleep to PROTECTED auth set (#798)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.28-alpha.34",
+  "version": "26.4.28-alpha.35",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/lib/elysia-auth.ts
+++ b/src/lib/elysia-auth.ts
@@ -17,6 +17,8 @@ const WINDOW_SEC = D.hmacWindowSeconds;
 const PROTECTED = new Set([
   "/send",
   "/pane-keys",
+  "/wake",            // #798 — clones repos, spawns tmux + agent processes
+  "/sleep",           // #798 — kills tmux sessions
   "/talk",
   "/transport/send",
   "/triggers/fire",
@@ -32,7 +34,7 @@ const PROTECTED_POST = new Set([
 // are intentionally public — the Office UI on LAN needs them.
 // HMAC protects write operations from unauthenticated remote peers.
 
-function isProtected(path: string, method: string): boolean {
+export function isProtected(path: string, method: string): boolean {
   if (PROTECTED.has(path)) return true;
   if (PROTECTED_POST.has(path) && method === "POST") return true;
   // Protect plugin invocation — POST /plugins/:name is a control operation

--- a/test/isolated/elysia-auth-protected.test.ts
+++ b/test/isolated/elysia-auth-protected.test.ts
@@ -1,0 +1,41 @@
+/**
+ * elysia-auth-protected.test.ts — #798.
+ *
+ * Pinpoint test: verify that the PROTECTED set in elysia-auth.ts gates
+ * /wake and /sleep. Prior to #798, these write endpoints were unauthenticated
+ * for non-loopback clients with federationToken configured — anyone reachable
+ * on :3456 could trigger wake (clone/spawn/start agent) or sleep (kill agent).
+ *
+ * Cousin file `federation-auth.test.ts` covers the Hono-based middleware in
+ * `federation-auth.ts`; this file targets the Elysia-based variant in
+ * `elysia-auth.ts` which is what `src/api/index.ts` actually `.use()`s.
+ */
+import { describe, test, expect } from "bun:test";
+import { isProtected } from "../../src/lib/elysia-auth";
+
+describe("elysia-auth — isProtected (#798)", () => {
+  test("/wake POST is protected", () => {
+    expect(isProtected("/wake", "POST")).toBe(true);
+  });
+
+  test("/sleep POST is protected", () => {
+    expect(isProtected("/sleep", "POST")).toBe(true);
+  });
+
+  test("existing protected paths still gated", () => {
+    expect(isProtected("/send", "POST")).toBe(true);
+    expect(isProtected("/pane-keys", "POST")).toBe(true);
+    expect(isProtected("/talk", "POST")).toBe(true);
+  });
+
+  test("read endpoints remain public", () => {
+    expect(isProtected("/sessions", "GET")).toBe(false);
+    expect(isProtected("/capture", "GET")).toBe(false);
+    expect(isProtected("/mirror", "GET")).toBe(false);
+  });
+
+  test("/feed: GET public, POST protected (PROTECTED_POST set)", () => {
+    expect(isProtected("/feed", "GET")).toBe(false);
+    expect(isProtected("/feed", "POST")).toBe(true);
+  });
+});


### PR DESCRIPTION
## 🚨 Security fix — must land in v26.4.29

Prior to this fix, \`/api/wake\` and \`/api/sleep\` were **not** in the \`PROTECTED\` set in \`src/lib/elysia-auth.ts\`. With \`federationToken\` configured (the standard federation deployment), every other write endpoint required HMAC, but wake/sleep passed through without auth from non-loopback clients.

## Impact

Any peer reachable on :3456 could:

1. **Trigger wake** — clones repos (potentially massive bandwidth/disk), creates tmux sessions, spawns agent processes (claude/codex/node). DoS / resource-exhaustion vector.
2. **Trigger sleep** — kills tmux sessions of running agents. Disruption vector.

PR #794 (cross-node auto-wake, merged at alpha.33) makes \`/api/wake\` actively used cross-peer — so this attack surface is not theoretical.

## Fix

Two new entries in the \`PROTECTED\` set:

\`\`\`diff
 const PROTECTED = new Set([
   \"/send\",
   \"/pane-keys\",
+  \"/wake\",            // #798 — clones repos, spawns tmux + agent processes
+  \"/sleep\",           // #798 — kills tmux sessions
   \"/talk\",
   \"/transport/send\",
   \"/triggers/fire\",
   \"/worktrees/cleanup\",
 ]);
\`\`\`

## Why elysia-auth.ts (not federation-auth.ts)

The cousin file \`src/lib/federation-auth.ts\` is the Hono-based legacy middleware (well-tested in \`test/isolated/federation-auth.test.ts\`). The \`PROTECTED\` set in question lives in \`src/lib/elysia-auth.ts\`, which is the Elysia variant that \`src/api/index.ts\` actually \`.use()\`s. The Hono test file does NOT cover the Elysia path.

## Test

New \`test/isolated/elysia-auth-protected.test.ts\` (5 cases, all pass):

1. \`isProtected(\"/wake\", \"POST\") === true\`
2. \`isProtected(\"/sleep\", \"POST\") === true\`
3. Existing protected paths still gated (regression: /send, /pane-keys, /talk)
4. Read endpoints remain public (/sessions, /capture, /mirror GET)
5. /feed POST/GET asymmetry preserved

To make the test possible, exported \`isProtected\` from \`elysia-auth.ts\` (was previously unexported). No behavior change — just visibility.

## Other findings from same codex pass (filed separately, lower priority)

- Non-constant-time HMAC comparison in \`src/lib/auth.ts:44-45\` (timing-attack risk on JWT path)
- Predictable JWT_SECRET default \`\"maw-\" + node\` if env var unset (\`src/lib/auth.ts:12\`)

These are in a DIFFERENT module (\`auth.ts\` JWT-style tokens, not \`federation-auth.ts\` HMAC). Lower urgency, separate PRs.

## Coordination

- White holding release PR #797 until this fix lands
- Once #798 merges, white refreshes #797 from alpha so v26.4.29 stable includes the security patch (not v26.4.30)
- Bumped alpha.35 (alpha.34 = white's #796 schema-drift fix)

Closes #798.