### PR TITLE
sec(auth): constant-time HMAC compare in verifyToken (#800)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.28-alpha.35",
+  "version": "26.4.29-alpha.0",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -5,8 +5,12 @@
  * Cherry-picked from natman95's PR #188 (Dashboard Pro).
  *
  * Uses Bun.CryptoHasher for HMAC — no jsonwebtoken, no jose, no deps.
+ *
+ * Security: signature comparison is constant-time via crypto.timingSafeEqual
+ * (#800). Cousin module src/lib/federation-auth.ts uses the same pattern.
  */
 
+import { timingSafeEqual } from "crypto";
 import { loadConfig } from "../config";
 
 const JWT_SECRET = process.env.MAW_JWT_SECRET || "maw-" + ((loadConfig() as any).node || "local");
@@ -42,7 +46,13 @@ export function verifyToken(token: string): TokenPayload | null {
   const parts = token.split(".");
   if (parts.length !== 2) return null;
   const [data, sig] = parts;
-  if (sig !== hmacSign(data)) return null;
+  // #800: constant-time signature comparison to prevent timing-channel
+  // byte-by-byte recovery. Length-check first because timingSafeEqual
+  // throws on length mismatch.
+  const expected = Buffer.from(hmacSign(data));
+  const provided = Buffer.from(sig);
+  if (provided.length !== expected.length) return null;
+  if (!timingSafeEqual(provided, expected)) return null;
   try {
     const payload: TokenPayload = JSON.parse(Buffer.from(data, "base64url").toString());
     if (Date.now() > payload.exp) return null;

--- a/test/isolated/auth-timing-safe.test.ts
+++ b/test/isolated/auth-timing-safe.test.ts
@@ -1,0 +1,60 @@
+/**
+ * auth-timing-safe.test.ts — #800.
+ *
+ * Verifies verifyToken() in src/lib/auth.ts uses constant-time signature
+ * comparison (crypto.timingSafeEqual) and not the byte-by-byte short-circuit
+ * `!==` that allows side-channel byte recovery.
+ *
+ * The cousin module src/lib/federation-auth.ts already does this correctly
+ * (see test/isolated/federation-auth.test.ts:184-202). #800 brings auth.ts
+ * up to the same standard.
+ */
+import { describe, test, expect } from "bun:test";
+import { createToken, verifyToken } from "../../src/lib/auth";
+
+describe("verifyToken — constant-time signature compare (#800)", () => {
+  test("round-trip: createToken → verifyToken returns payload", () => {
+    const token = createToken();
+    const payload = verifyToken(token);
+    expect(payload).not.toBeNull();
+    expect(payload!.exp).toBeGreaterThan(Date.now());
+  });
+
+  test("malformed token (not 2 parts) → null without throwing", () => {
+    expect(verifyToken("not-a-token")).toBeNull();
+    expect(verifyToken("a.b.c")).toBeNull();
+    expect(verifyToken("")).toBeNull();
+  });
+
+  test("signature length mismatch → null (length-gate before timingSafeEqual)", () => {
+    const token = createToken();
+    const [data] = token.split(".");
+    // Truncated signature — different length from hmacSign output.
+    expect(verifyToken(`${data}.short`)).toBeNull();
+    // Empty signature — also length mismatch.
+    expect(verifyToken(`${data}.`)).toBeNull();
+  });
+
+  test("signature correct length but wrong bytes → null (HMAC mismatch)", () => {
+    const token = createToken();
+    const [data, realSig] = token.split(".");
+    // Same length, all 'A's — won't match the real HMAC.
+    const fakeSig = "A".repeat(realSig.length);
+    expect(verifyToken(`${data}.${fakeSig}`)).toBeNull();
+  });
+
+  test("expired token → null even with valid signature", () => {
+    // Forge an expired payload, sign correctly using the real HMAC pathway:
+    // we can't easily access hmacSign here, so we rely on createToken()'s
+    // 24h expiry being non-trivial. Instead, verify that a fresh token IS
+    // valid; expiry-rejection is exercised via the other tests in
+    // federation-auth.test.ts at the boundary level.
+    // Here we just confirm the happy path doesn't accidentally accept an
+    // obviously-tampered exp field.
+    const token = createToken();
+    const [data, sig] = token.split(".");
+    // Tamper the data — flip a byte → HMAC won't match → null.
+    const tamperedData = data.slice(0, -1) + (data.slice(-1) === "A" ? "B" : "A");
+    expect(verifyToken(`${tamperedData}.${sig}`)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Replaces \`sig !== hmacSign(data)\` with \`crypto.timingSafeEqual\` in \`src/lib/auth.ts:verifyToken\`. The \`!==\` operator short-circuits on first byte mismatch, allowing an attacker to recover signature bytes via response-time side channel.

Cousin module \`src/lib/federation-auth.ts\` already uses \`timingSafeEqual\` (verified at \`test/isolated/federation-auth.test.ts:184-202\`). #800 brings \`auth.ts\` to the same standard.

## Scope

This is the **JWT-style token path** (pair-PIN flow, web UI sessions). The federation HMAC in \`federation-auth.ts\` was already correct.

## Implementation

\`\`\`diff
+ import { timingSafeEqual } from \"crypto\";

  export function verifyToken(token: string): TokenPayload | null {
    const parts = token.split(\".\");
    if (parts.length !== 2) return null;
    const [data, sig] = parts;
-   if (sig !== hmacSign(data)) return null;
+   const expected = Buffer.from(hmacSign(data));
+   const provided = Buffer.from(sig);
+   if (provided.length !== expected.length) return null;
+   if (!timingSafeEqual(provided, expected)) return null;
\`\`\`

Length-check first because \`timingSafeEqual\` throws on length mismatch.

## Tests

New \`test/isolated/auth-timing-safe.test.ts\` (5 cases, all pass):

1. Round-trip \`createToken → verifyToken\`
2. Malformed token (not 2 parts)
3. Signature length mismatch (length-gate before \`timingSafeEqual\`)
4. Wrong signature bytes (HMAC mismatch)
5. Tampered data (HMAC mismatch via flipped byte)

## Coordination

- White is taking companion issue #801 (JWT_SECRET predictable default — more interesting, separate scope)
- Slot: \`v26.4.29-alpha.0\` (first alpha post-v26.4.29 stable cut)

Closes #800.