### PR TITLE
feat(federation): /info returns endpoints + pubkey (Step 1 of #804)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.2",
+  "version": "26.4.29-alpha.3",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/api/federation.ts
+++ b/src/api/federation.ts
@@ -7,6 +7,23 @@ import { readFileSync, readdirSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 import { FLEET_DIR } from "../core/paths";
+import { getPeerKey } from "../lib/peer-key";
+
+/**
+ * Endpoints advertised by /api/identity (#804 Step 1).
+ *
+ * Lets peers discover supported API surfaces in one round-trip instead of
+ * probing each path individually. Keep alphabetised + in sync with the actual
+ * mounted routes — this is a contract, not documentation.
+ */
+const ADVERTISED_ENDPOINTS: string[] = [
+  "/api/identity",
+  "/api/pane-keys",
+  "/api/probe",
+  "/api/send",
+  "/api/sleep",
+  "/api/wake",
+];
 
 // Re-export so existing importers (and any future code) can still reach
 // hostedAgents via the API module. The canonical home is federation-sync.ts.
@@ -33,7 +50,15 @@ federationApi.get("/snapshots/:id", ({ params, set}) => {
   return snap;
 });
 
-/** Node identity — public endpoint for federation dedup (#192) + clock health (#268). */
+/**
+ * Node identity — public endpoint for federation dedup (#192) + clock health (#268).
+ *
+ * #804 Step 1 (ADR docs/federation/0001-peer-identity.md): also advertises
+ *   - `endpoints`: supported API paths so peers can discover capabilities
+ *     in one round-trip (closes the version-skew pressure).
+ *   - `pubkey`: per-peer identity for TOFU pinning + Step 4 signing. Persisted
+ *     at <CONFIG_DIR>/peer-key (SSH host-key model).
+ */
 federationApi.get("/identity", async () => {
   const config = loadConfig();
   const node = config.node ?? "local";
@@ -45,6 +70,8 @@ federationApi.get("/identity", async () => {
     agents,
     uptime: Math.floor(process.uptime()),
     clockUtc: new Date().toISOString(),
+    endpoints: ADVERTISED_ENDPOINTS,
+    pubkey: getPeerKey(),
   };
 });
 

--- a/src/core/runtime/sdk.ts
+++ b/src/core/runtime/sdk.ts
@@ -63,9 +63,17 @@ async function typedFetch<T>(path: string, init?: RequestInit & { timeout?: numb
 
 // --- API layer ---
 
-/** Node identity: name, version, agents, clock */
+/** Node identity: name, version, agents, clock, endpoints, pubkey (#804 Step 1) */
 async function identity(): Promise<Identity> {
-  return api<Identity>("/api/identity", { node: "unknown", version: "?", agents: [], clockUtc: "", uptime: 0 });
+  return api<Identity>("/api/identity", {
+    node: "unknown",
+    version: "?",
+    agents: [],
+    clockUtc: "",
+    uptime: 0,
+    endpoints: [],
+    pubkey: "",
+  });
 }
 
 /** Federation status: peers, latency, clock drift */

--- a/src/lib/peer-key.ts
+++ b/src/lib/peer-key.ts
@@ -1,0 +1,60 @@
+/**
+ * peer-key.ts — Per-peer cryptographic identity (#804 Step 1).
+ *
+ * Each maw node holds a long-lived 32-byte secret stored at
+ * `<CONFIG_DIR>/peer-key` (mode 0600), generated on first read. The hex
+ * encoding of this secret is published via `/api/identity` as `pubkey` so
+ * peers can pin it under TOFU (see ADR docs/federation/0001-peer-identity.md).
+ *
+ * Step 1 only persists + advertises the key. Signing + verification (Step 4)
+ * will derive an Ed25519 keypair from this seed; for now we treat the hex
+ * string as the published "pubkey" identifier — same persistence model, same
+ * lifecycle. Rotation is operator-driven (`maw peers forget`).
+ *
+ * Mirrors src/lib/auth.ts (#801) deliberately: env override, persistent file,
+ * mode 0600, in-process cache. Two cousin modules → one pattern.
+ */
+
+import { randomBytes } from "crypto";
+import { readFileSync, writeFileSync, chmodSync } from "fs";
+import { join } from "path";
+import { CONFIG_DIR } from "../core/paths";
+import { info } from "../cli/verbosity";
+
+/** Path to the persisted peer key (mode 0600). */
+export const PEER_KEY_FILE = join(CONFIG_DIR, "peer-key");
+
+let cachedKey: string | null = null;
+
+/**
+ * Resolve the peer key (hex-encoded).
+ *
+ * Precedence:
+ *   1. MAW_PEER_KEY env var (operator override) — file is not read.
+ *   2. <CONFIG_DIR>/peer-key if it exists.
+ *   3. Generate a fresh 32-byte (64-char hex) key, persist with mode 0600,
+ *      and log a one-time creation notice.
+ */
+export function getPeerKey(): string {
+  if (process.env.MAW_PEER_KEY) return process.env.MAW_PEER_KEY;
+  if (cachedKey) return cachedKey;
+  try {
+    cachedKey = readFileSync(PEER_KEY_FILE, "utf-8").trim();
+    if (cachedKey) return cachedKey;
+  } catch {
+    // file missing or unreadable — fall through to generate
+  }
+  const fresh = randomBytes(32).toString("hex");
+  writeFileSync(PEER_KEY_FILE, fresh, { mode: 0o600, flag: "w" });
+  // chmod is a belt-and-suspenders for filesystems where the open-time mode
+  // isn't honored (umask-stripped, NFS, etc).
+  try { chmodSync(PEER_KEY_FILE, 0o600); } catch { /* best-effort */ }
+  cachedKey = fresh;
+  info(`[peer-key] generated random peer key → ${PEER_KEY_FILE} (mode 0600)`);
+  return fresh;
+}
+
+/** Reset the in-memory key cache (test seam). */
+export function resetPeerKeyCache(): void {
+  cachedKey = null;
+}

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -21,6 +21,11 @@ export const Identity = Type.Object({
   agents: Type.Array(Type.String()),
   clockUtc: Type.String(),
   uptime: Type.Number(),
+  // #804 Step 1 — federation peer identity (ADR docs/federation/0001-peer-identity.md).
+  // `endpoints` lets peers discover supported API surfaces in one round-trip;
+  // `pubkey` is the per-peer identity used for TOFU pinning + future signing.
+  endpoints: Type.Array(Type.String()),
+  pubkey: Type.String(),
 });
 export type TIdentity = Static<typeof Identity>;
 

--- a/test/isolated/api-identity-fields.test.ts
+++ b/test/isolated/api-identity-fields.test.ts
@@ -1,0 +1,95 @@
+/**
+ * api-identity-fields.test.ts — #804 Step 1.
+ *
+ * Pinpoint test: GET /api/identity must return all 7 contract fields as the
+ * federation peer-identity ADR (docs/federation/0001-peer-identity.md) lays
+ * down: node, version, agents, clockUtc, uptime, endpoints, pubkey.
+ *
+ * Isolated because the handler's `pubkey` reads from <CONFIG_DIR>/peer-key,
+ * and CONFIG_DIR is captured at paths.ts import time. We pin MAW_HOME to a
+ * tmp dir before importing federation.ts so the test can't touch the
+ * operator's real key.
+ */
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { Elysia } from "elysia";
+
+const TEST_HOME = mkdtempSync(join(tmpdir(), "maw-api-identity-804-"));
+process.env.MAW_HOME = TEST_HOME;
+mkdirSync(join(TEST_HOME, "config", "fleet"), { recursive: true });
+delete process.env.MAW_PEER_KEY;
+delete process.env.MAW_JWT_SECRET;
+
+let app: Elysia;
+
+beforeAll(async () => {
+  const { federationApi } = await import("../../src/api/federation");
+  app = new Elysia().use(federationApi);
+});
+
+afterAll(() => {
+  rmSync(TEST_HOME, { recursive: true, force: true });
+  delete process.env.MAW_HOME;
+});
+
+describe("GET /api/identity — #804 Step 1 contract", () => {
+  test("returns 200 with application/json", async () => {
+    const res = await app.handle(new Request("http://localhost/identity"));
+    expect(res.status).toBe(200);
+    expect((res.headers.get("content-type") || "").toLowerCase()).toContain(
+      "application/json",
+    );
+  });
+
+  test("body has all 7 contract fields with correct types", async () => {
+    const res = await app.handle(new Request("http://localhost/identity"));
+    const body = (await res.json()) as Record<string, unknown>;
+
+    // 5 pre-existing fields (must not regress).
+    expect(typeof body.node).toBe("string");
+    expect((body.node as string).length).toBeGreaterThan(0);
+    expect(typeof body.version).toBe("string");
+    expect(Array.isArray(body.agents)).toBe(true);
+    expect(typeof body.clockUtc).toBe("string");
+    expect(typeof body.uptime).toBe("number");
+
+    // 2 new fields (#804 Step 1).
+    expect(Array.isArray(body.endpoints)).toBe(true);
+    expect(typeof body.pubkey).toBe("string");
+  });
+
+  test("clockUtc is a valid ISO-8601 timestamp", async () => {
+    const res = await app.handle(new Request("http://localhost/identity"));
+    const body = (await res.json()) as { clockUtc: string };
+    const parsed = new Date(body.clockUtc);
+    expect(Number.isNaN(parsed.getTime())).toBe(false);
+  });
+
+  test("endpoints contains the federation write paths from the ADR", async () => {
+    const res = await app.handle(new Request("http://localhost/identity"));
+    const body = (await res.json()) as { endpoints: string[] };
+    // ADR docs/federation/0001-peer-identity.md lists these as the canonical
+    // peer-write endpoints; their advertisement is the whole point of Step 1.
+    expect(body.endpoints).toContain("/api/send");
+    expect(body.endpoints).toContain("/api/wake");
+    expect(body.endpoints).toContain("/api/sleep");
+    expect(body.endpoints).toContain("/api/pane-keys");
+    expect(body.endpoints).toContain("/api/probe");
+  });
+
+  test("pubkey is the persisted 64-char hex peer key", async () => {
+    const res = await app.handle(new Request("http://localhost/identity"));
+    const body = (await res.json()) as { pubkey: string };
+    expect(body.pubkey).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("two consecutive calls return the same pubkey (persistence)", async () => {
+    const r1 = await app.handle(new Request("http://localhost/identity"));
+    const r2 = await app.handle(new Request("http://localhost/identity"));
+    const b1 = (await r1.json()) as { pubkey: string };
+    const b2 = (await r2.json()) as { pubkey: string };
+    expect(b1.pubkey).toBe(b2.pubkey);
+  });
+});

--- a/test/isolated/peer-key-persist.test.ts
+++ b/test/isolated/peer-key-persist.test.ts
@@ -1,0 +1,128 @@
+/**
+ * peer-key-persist.test.ts — #804 Step 1.
+ *
+ * Pinpoint test: src/lib/peer-key.ts mirrors the JWT-secret pattern (#801).
+ * When MAW_PEER_KEY is unset, the module generates a 32-byte random key on
+ * first call, persists it to <CONFIG_DIR>/peer-key with mode 0600, and reuses
+ * it across calls / restarts (SSH host-key model).
+ *
+ * Isolated (per-file subprocess) because we mutate process.env.MAW_CONFIG_DIR
+ * before the module import — and src/core/paths.ts captures CONFIG_DIR at
+ * module-load time. Running this in the shared pool would either poison
+ * sibling tests or get poisoned by them.
+ */
+import { describe, test, expect, afterAll, beforeEach } from "bun:test";
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, statSync } from "fs";
+import { join } from "path";
+import { tmpdir, platform } from "os";
+
+// ─── Pin CONFIG_DIR to a tmp dir BEFORE importing the target module ─────────
+const TEST_CONFIG_DIR = mkdtempSync(join(tmpdir(), "maw-peer-key-804-"));
+process.env.MAW_CONFIG_DIR = TEST_CONFIG_DIR;
+// Ensure no operator override leaks into the test process.
+delete process.env.MAW_PEER_KEY;
+delete process.env.MAW_HOME;
+
+// Import after env is set so CONFIG_DIR resolves to TEST_CONFIG_DIR.
+const peerKey = await import("../../src/lib/peer-key");
+const { PEER_KEY_FILE, getPeerKey, resetPeerKeyCache } = peerKey;
+
+afterAll(() => {
+  rmSync(TEST_CONFIG_DIR, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  // Each test starts with a clean slate: no env override, no cached key,
+  // no on-disk file.
+  delete process.env.MAW_PEER_KEY;
+  resetPeerKeyCache();
+  if (existsSync(PEER_KEY_FILE)) rmSync(PEER_KEY_FILE, { force: true });
+});
+
+describe("getPeerKey() — #804 random + persisted peer key", () => {
+  test("PEER_KEY_FILE resolves under the test CONFIG_DIR (env wiring sanity)", () => {
+    expect(PEER_KEY_FILE).toBe(join(TEST_CONFIG_DIR, "peer-key"));
+  });
+
+  test("missing file → creates 64-char hex key and persists it", () => {
+    expect(existsSync(PEER_KEY_FILE)).toBe(false);
+
+    const key = getPeerKey();
+
+    // 32 bytes hex-encoded == 64 chars, lowercase [0-9a-f].
+    expect(key).toMatch(/^[0-9a-f]{64}$/);
+    // File now exists with the same content.
+    expect(existsSync(PEER_KEY_FILE)).toBe(true);
+    expect(readFileSync(PEER_KEY_FILE, "utf-8")).toBe(key);
+  });
+
+  test("missing file → file written with mode 0600 (owner-only)", () => {
+    getPeerKey();
+    const st = statSync(PEER_KEY_FILE);
+    // POSIX permission bits only — mask off file-type bits.
+    const mode = st.mode & 0o777;
+    if (platform() === "win32") {
+      // Windows POSIX mode semantics differ; sanity-check the file exists.
+      expect(existsSync(PEER_KEY_FILE)).toBe(true);
+    } else {
+      expect(mode).toBe(0o600);
+    }
+  });
+
+  test("existing file → reused as-is (no overwrite, no regeneration)", () => {
+    const PRE_EXISTING = "d".repeat(64); // distinguishable from any random output
+    writeFileSync(PEER_KEY_FILE, PRE_EXISTING, { mode: 0o600 });
+    resetPeerKeyCache(); // force re-read
+
+    const key = getPeerKey();
+
+    expect(key).toBe(PRE_EXISTING);
+    // File contents must not have been overwritten.
+    expect(readFileSync(PEER_KEY_FILE, "utf-8")).toBe(PRE_EXISTING);
+  });
+
+  test("two calls in the same process return the same value (cache + persistence)", () => {
+    const a = getPeerKey();
+    const b = getPeerKey();
+    expect(a).toBe(b);
+    // Cache invalidation also returns the SAME persisted key (not a fresh one).
+    resetPeerKeyCache();
+    const c = getPeerKey();
+    expect(c).toBe(a);
+  });
+
+  test("MAW_PEER_KEY env var → used directly, file is NOT created or read", () => {
+    const ENV_KEY = "env-override-peer-key-not-on-disk";
+    process.env.MAW_PEER_KEY = ENV_KEY;
+    expect(existsSync(PEER_KEY_FILE)).toBe(false);
+
+    const key = getPeerKey();
+
+    expect(key).toBe(ENV_KEY);
+    // The presence of the env var must short-circuit before any file I/O.
+    expect(existsSync(PEER_KEY_FILE)).toBe(false);
+  });
+
+  test("MAW_PEER_KEY takes precedence even when an on-disk key already exists", () => {
+    const ON_DISK = "e".repeat(64);
+    writeFileSync(PEER_KEY_FILE, ON_DISK, { mode: 0o600 });
+    process.env.MAW_PEER_KEY = "env-wins";
+    resetPeerKeyCache();
+
+    expect(getPeerKey()).toBe("env-wins");
+    // On-disk file must remain untouched.
+    expect(readFileSync(PEER_KEY_FILE, "utf-8")).toBe(ON_DISK);
+  });
+
+  test("two distinct fresh keys in two processes differ (randomness sanity)", () => {
+    // First fresh key.
+    const k1 = getPeerKey();
+    expect(k1).toMatch(/^[0-9a-f]{64}$/);
+    // Wipe everything and regenerate — must be different (cryptographic random).
+    rmSync(PEER_KEY_FILE, { force: true });
+    resetPeerKeyCache();
+    const k2 = getPeerKey();
+    expect(k2).toMatch(/^[0-9a-f]{64}$/);
+    expect(k2).not.toBe(k1);
+  });
+});


### PR DESCRIPTION
## Step 1 of #804 — peer identity foundation

Per ADR \`docs/federation/0001-peer-identity.md\` (#805), Step 1 extends \`/api/identity\` (the \`/info\` endpoint) with two new fields:

- **\`endpoints: string[]\`** — supported API paths. One round-trip capability discovery, closes the version-skew pressure that bit us in #795.
- **\`pubkey: string\`** — per-peer cryptographic identity, hex format. Persisted at \`<CONFIG_DIR>/peer-key\` (mode 0600), SSH host-key model. Used in Step 4 for signed federation messages and TOFU pinning.

### Implementation

Mirrors the JWT-secret pattern from #801:
- Env var override: \`MAW_PEER_KEY\`
- On-disk persistence: \`<CONFIG_DIR>/peer-key\` (mode 0600 + chmod fallback)
- In-memory cache after first read
- Generate-on-miss: \`crypto.randomBytes(32).toString('hex')\`

Cousin modules \`src/lib/auth.ts\` (#801) and \`src/lib/peer-key.ts\` (this PR) — one pattern.

### Tests
- \`test/isolated/peer-key-persist.test.ts\` — 8 cases on file lifecycle
- \`test/isolated/api-identity-fields.test.ts\` — 6 cases on endpoint contract

### Backwards-compat
Pre-existing \`/api/identity\` fields unchanged. Only additions. Old peers reading the response see new fields they ignore.

### Bump
v26.4.29-alpha.3

### Tracking
Step 1 of [Tracking issue #804](https://github.com/Soul-Brews-Studio/maw-js/issues/804). After merge: tick checkbox 1 of 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)