### PR TITLE
fix(calver): pick max(today, package.json) base — no downgrade post-stable-cut (#819)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.28-alpha.20",
+  "version": "26.4.29-alpha.9",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/scripts/calver.ts
+++ b/scripts/calver.ts
@@ -80,6 +80,55 @@ export function dateBase(now: Date): string {
 }
 
 /**
+ * #819: extract the CalVer base (YY.M.D) from a version string. Accepts
+ * `v26.4.29`, `26.4.29`, `v26.4.29-alpha.5`, `26.4.29-alpha.5`, etc.
+ * Returns null if the string does not look like a CalVer base — caller can
+ * then fall back to today's date. Mirrors maxNFromPackageJson's tolerant
+ * accept-with-or-without-leading-v parsing.
+ */
+export function extractBaseFromVersion(version: string): string | null {
+  if (!version) return null;
+  const stripped = version.startsWith("v") ? version.slice(1) : version;
+  // Match leading YY.M.D — terminated by `-`, `+`, end of string, or a dot
+  // that is NOT part of the base (i.e. caller passed a 4-segment thing).
+  const m = stripped.match(/^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/);
+  if (!m) return null;
+  const [, yy, mo, da] = m;
+  return `${yy}.${mo}.${da}`;
+}
+
+/**
+ * #819: lexicographic-safe compare of two CalVer bases by integer segment.
+ * Returns negative if a < b, 0 if equal, positive if a > b. Accepts only
+ * `YY.M.D` triples — anything else throws (caller validates upstream).
+ */
+export function compareBases(a: string, b: string): number {
+  const pa = a.split(".").map((x) => parseInt(x, 10));
+  const pb = b.split(".").map((x) => parseInt(x, 10));
+  if (pa.length !== 3 || pb.length !== 3) {
+    throw new Error(`compareBases expects YY.M.D, got "${a}" vs "${b}"`);
+  }
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) return pa[i] - pb[i];
+  }
+  return 0;
+}
+
+/**
+ * #819: pick the effective base for the next bump — the later of today's
+ * clock-derived base and the package.json-derived base. This prevents the
+ * post-stable-cut downgrade where package.json carries `YY.M.(D+1)` but the
+ * clock still reads `YY.M.D` (tomorrow's stable already cut, today's clock
+ * still ticking). Without this, the script targets `YY.M.D-alpha.0` — a
+ * downgrade against `YY.M.(D+1)-alpha.N`.
+ */
+export function effectiveBase(todayBase: string, packageVersion: string): string {
+  const pkgBase = extractBaseFromVersion(packageVersion);
+  if (!pkgBase) return todayBase;
+  return compareBases(pkgBase, todayBase) > 0 ? pkgBase : todayBase;
+}
+
+/**
  * Walk git tags matching `v{base}-{channel}.*` and return the max N found,
  * or -1 if no matching tags exist for this date+channel yet.
  *
@@ -141,10 +190,14 @@ async function listChannelTags(base: string, channel: Channel): Promise<string[]
 
 export function computeVersion(args: Args, tags: string[] = [], packageVersion: string = ""): string {
   const now = args.now ?? new Date();
-  const base = dateBase(now);
+  const todayBase = dateBase(now);
+  // #819: if package.json is future-dated (e.g. tomorrow's stable just cut),
+  // bump against that base — never downgrade to today's date.
+  const base = args.stable ? todayBase : effectiveBase(todayBase, packageVersion);
   if (args.stable) return base;
   const channel = args.channel ?? "alpha";
-  // Take max of (tag-walk N, package.json N) — see maxNFromPackageJson (#784).
+  // Take max of (tag-walk N, package.json N) against the effective base —
+  // see maxNFromPackageJson (#784) and effectiveBase (#819).
   const tagMax = maxNFromTags(base, channel, tags);
   const pkgMax = maxNFromPackageJson(base, channel, packageVersion);
   const max = Math.max(tagMax, pkgMax);
@@ -160,12 +213,16 @@ async function tagExists(version: string): Promise<boolean> {
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const now = args.now ?? new Date();
-  const base = dateBase(now);
+  const todayBase = dateBase(now);
 
   // #784: read package.json once up front so its version participates in the
   // source-of-truth set for the monotonic counter (see computeVersion).
   const pkgPath = join(process.cwd(), "package.json");
   const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+
+  // #819: choose the effective base before fetching tags so we list tags for
+  // the correct date when package.json is future-dated.
+  const base = args.stable ? todayBase : effectiveBase(todayBase, pkg.version ?? "");
 
   const channelForTags: Channel = args.channel ?? "alpha";
   const tags = args.stable ? [] : await listChannelTags(base, channelForTags);

--- a/test/calver.test.ts
+++ b/test/calver.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from "bun:test";
 import {
+  compareBases,
   computeVersion,
   dateBase,
+  effectiveBase,
+  extractBaseFromVersion,
   maxAlphaFromTags,
   maxNFromPackageJson,
   maxNFromTags,
@@ -225,5 +228,129 @@ describe("calver maxNFromPackageJson — robustness (#784 explorer findings)", (
 
   it("rejects rc/other channels even if structurally similar", () => {
     expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-rc.5")).toBe(-1);
+  });
+});
+
+describe("calver extractBaseFromVersion (#819)", () => {
+  it("strips alpha/beta suffix, returns YY.M.D", () => {
+    expect(extractBaseFromVersion("26.4.29-alpha.5")).toBe("26.4.29");
+    expect(extractBaseFromVersion("26.4.29-beta.0")).toBe("26.4.29");
+  });
+
+  it("accepts bare YY.M.D (post-stable-cut shape)", () => {
+    expect(extractBaseFromVersion("26.4.29")).toBe("26.4.29");
+    expect(extractBaseFromVersion("v26.4.29")).toBe("26.4.29");
+  });
+
+  it("accepts leading v prefix", () => {
+    expect(extractBaseFromVersion("v26.4.29-alpha.5")).toBe("26.4.29");
+  });
+
+  it("returns null for empty/missing", () => {
+    expect(extractBaseFromVersion("")).toBeNull();
+  });
+
+  it("returns null for non-CalVer legacy versions", () => {
+    expect(extractBaseFromVersion("2.0.0-alpha.134")).toBe("2.0.0"); // shape-OK
+    expect(extractBaseFromVersion("not-a-version")).toBeNull();
+    expect(extractBaseFromVersion("26.4")).toBeNull();
+    expect(extractBaseFromVersion("26.4.29.1")).toBeNull();
+  });
+});
+
+describe("calver compareBases (#819)", () => {
+  it("compares by integer segment, not lexicographic", () => {
+    // Lexicographic would say "26.4.30" < "26.4.4" — must compare ints.
+    expect(compareBases("26.4.30", "26.4.4")).toBeGreaterThan(0);
+    expect(compareBases("26.4.4", "26.4.30")).toBeLessThan(0);
+  });
+
+  it("equal bases return 0", () => {
+    expect(compareBases("26.4.28", "26.4.28")).toBe(0);
+  });
+
+  it("year and month dominate", () => {
+    expect(compareBases("27.1.1", "26.12.31")).toBeGreaterThan(0);
+    expect(compareBases("26.5.1", "26.4.99")).toBeGreaterThan(0);
+  });
+
+  it("throws on malformed input", () => {
+    expect(() => compareBases("26.4", "26.4.28")).toThrow();
+    expect(() => compareBases("26.4.28.1", "26.4.28")).toThrow();
+  });
+});
+
+describe("calver effectiveBase (#819)", () => {
+  it("picks package.json base when ahead of today", () => {
+    expect(effectiveBase("26.4.28", "26.4.29-alpha.5")).toBe("26.4.29");
+  });
+
+  it("picks today when package.json is behind", () => {
+    expect(effectiveBase("26.4.28", "26.4.27-alpha.99")).toBe("26.4.28");
+  });
+
+  it("picks today when bases are equal", () => {
+    expect(effectiveBase("26.4.28", "26.4.28-alpha.18")).toBe("26.4.28");
+  });
+
+  it("picks today when package.json is empty/unparseable", () => {
+    expect(effectiveBase("26.4.28", "")).toBe("26.4.28");
+    expect(effectiveBase("26.4.28", "not-a-version")).toBe("26.4.28");
+  });
+
+  it("handles bare future stable (post-cut shape, no suffix)", () => {
+    // Just-cut tomorrow's stable: package.json holds bare 26.4.30 with no suffix.
+    expect(effectiveBase("26.4.28", "26.4.30")).toBe("26.4.30");
+  });
+});
+
+describe("calver computeVersion future-dated package.json (#819)", () => {
+  const apr28_1200 = new Date(2026, 3, 28, 12, 0);
+  const apr29_0500 = new Date(2026, 3, 29, 5, 0);
+
+  it("future-dated alpha: continues counter on package.json's date (NOT downgrade)", () => {
+    // The exact bug from #819: package.json at 26.4.29-alpha.5, clock at
+    // 2026-04-28. Pre-fix this returned 26.4.28-alpha.0 (a downgrade).
+    expect(
+      computeVersion({ stable: false, check: false, now: apr28_1200 }, [], "26.4.29-alpha.5"),
+    ).toBe("26.4.29-alpha.6");
+  });
+
+  it("today-dated alpha: existing tag-walk behavior preserved", () => {
+    expect(
+      computeVersion({ stable: false, check: false, now: apr28_1200 }, [], "26.4.28-alpha.18"),
+    ).toBe("26.4.28-alpha.19");
+  });
+
+  it("date roll: clock advances past package.json → resets to .0", () => {
+    // Clock is 26.4.29, package.json still at 26.4.28-alpha.18 → .0 fresh day.
+    expect(
+      computeVersion({ stable: false, check: false, now: apr29_0500 }, [], "26.4.28-alpha.18"),
+    ).toBe("26.4.29-alpha.0");
+  });
+
+  it("just-cut stable in package.json: bare YY.M.D → alpha.0 on that date", () => {
+    // After --stable cut, package.json holds bare 26.4.30. Today's clock still
+    // 26.4.28 — must NOT regress to 26.4.28-alpha.0; bumps the future date.
+    expect(
+      computeVersion({ stable: false, check: false, now: apr28_1200 }, [], "26.4.30"),
+    ).toBe("26.4.30-alpha.0");
+  });
+
+  it("future-dated + tags for that future date: tags also count", () => {
+    // If the stable-cut day already saw alphas before the cut tagged some,
+    // and package.json holds 26.4.29-alpha.3 plus tags up to alpha.7 exist
+    // for 26.4.29 — bump to alpha.8.
+    const tags = ["v26.4.29-alpha.7"];
+    expect(
+      computeVersion({ stable: false, check: false, now: apr28_1200 }, tags, "26.4.29-alpha.3"),
+    ).toBe("26.4.29-alpha.8");
+  });
+
+  it("--stable always uses today's clock, never package.json's future date", () => {
+    // Defensive: if package.json is somehow ahead, --stable still cuts today.
+    expect(
+      computeVersion({ stable: true, check: false, now: apr28_1200 }, [], "26.4.29-alpha.5"),
+    ).toBe("26.4.28");
   });
 });


### PR DESCRIPTION
## Closes #819

After cutting stable v26.4.29 / v26.4.30, package.json on alpha carries a future-dated base (e.g. \`26.4.29-alpha.5\`). Today is 2026-04-28. Script's tag/package walk only matched today's date, so it would target \`v26.4.28-alpha.0\` — a downgrade.

### Fix

Compute both \`packageBase\` and \`todayBase\`, pick max. When package.json is ahead (post-stable-cut), continue the counter from there. When today is ahead (date roll), reset counter to 0 — existing behavior preserved.

### Cases (test/calver.test.ts +127 lines)

| package.json | today | target | Why |
|---|---|---|---|
| \`26.4.29-alpha.5\` | 2026-04-28 | \`26.4.29-alpha.6\` | Package ahead → continue |
| \`26.4.28-alpha.18\` | 2026-04-28 | \`26.4.28-alpha.19\` | Same date → continue |
| \`26.4.28-alpha.18\` | 2026-04-29 | \`26.4.29-alpha.0\` | Date roll → reset |
| \`26.4.30\` | 2026-04-28 | \`26.4.30-alpha.0\` | Just-cut stable |

### Bump

v26.4.29-alpha.9

### Impact

8 PRs today (#796 #803 #806 #808 #810 #811 #813 #815) hit this and required manual \`jq\` to land at the correct slot. Going forward: \`bun run calver\` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)