### PR TITLE
fix(ci): tag pre-releases on alpha pushes (#818)

### DIFF
--- a/.github/workflows/calver-release.yml
+++ b/.github/workflows/calver-release.yml
@@ -5,10 +5,19 @@ name: CalVer Release
 # Ported from: Soul-Brews-Studio/arra-oracle-skills-cli (PR #264)
 # Umbrella: #526 · Design review: mother-roots (white)
 #
-# Triggered when package.json is modified on main. All steps run in ONE
-# job so there is no workflow-cascade gap (GITHUB_TOKEN-created tags/
-# releases deliberately don't trigger downstream workflows; doing it
+# Triggered when package.json is modified on main or alpha. All steps run
+# in ONE job so there is no workflow-cascade gap (GITHUB_TOKEN-created
+# tags/releases deliberately don't trigger downstream workflows; doing it
 # inline sidesteps that rule entirely).
+#
+# Branch ↔ channel mapping (#818):
+#   - main  → stable cut       → tag vX.Y.Z          (marked latest)
+#   - alpha → pre-release cut  → tag vX.Y.Z-alpha.N  (prerelease=true,
+#                                                     NOT marked latest)
+# The prerelease flag is derived from the version string (-alpha./-beta.
+# suffix) — branch is just the trigger; version is the source of truth.
+# Concurrency group `calver-release` serializes simultaneous main+alpha
+# pushes so two runs cannot race on tag creation.
 #
 # Note: maw-js is NOT published to npm for the main package. Install flow
 # is `bun add github:Soul-Brews-Studio/maw-js#vX.Y.Z`. This workflow only
@@ -19,7 +28,7 @@ name: CalVer Release
 
 on:
   push:
-    branches: [main]
+    branches: [main, alpha]
     paths:
       - package.json
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.10",
+  "version": "26.4.29-alpha.11",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
## Summary

Fixes #818 — `calver-release.yml` only triggered on `main`, so pre-releases pushed to `alpha` never got tags or GitHub releases. Adds `alpha` to the workflow's branch trigger; the existing prerelease-from-version-string logic handles the rest.

## Files changed

- `.github/workflows/calver-release.yml` — `branches: [main]` → `branches: [main, alpha]` (+ doc comment for branch ↔ channel mapping). +13/-4, 1 functional line.
- `package.json` — calver bump (v26.4.29-alpha.10 → v26.4.29-alpha.11)

## Verification plan

This PR's own merge commit will exercise the new path: when it lands on `alpha`, the package.json bump triggers `calver-release.yml`, which now matches `branches: [main, alpha]` and publishes `v26.4.29-alpha.11` as a prerelease (NOT marked latest, per the version-string-derived prerelease flag).

No separate verification commit needed — first prerelease tag will fire on this PR's merge.

## Test results

- Local `bun test`: pre-existing Bun runtime panic + state pollution failures unrelated to this YAML-only change. CI doesn't run `bun test`.
- CI on origin/alpha (run 25059762703, sha 8e6e3fad) currently RED with documented overridable flakes:
  - `checkStalePeers — reachable happy path > explicit timeout forwarded to curlFetch` (x2)
  - `checkStalePeers — reachable happy path > default timeout=3000 when omitted` (x2)
  - `local-first routing (#411) > (3) local miss + remote peer unreachable`
- Override per #811/#813 precedent. All flakes pre-date this PR; YAML-only change is file-disjoint from any test code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
