### PR TITLE
fix(plugin-bootstrap): symlink new bundled plugins on existing installs (#817)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.11",
+  "version": "26.4.29-alpha.12",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/cli/plugin-bootstrap.test.ts
+++ b/src/cli/plugin-bootstrap.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import {
   mkdirSync,
+  mkdtempSync,
   writeFileSync,
   readdirSync,
   existsSync,
@@ -31,7 +32,10 @@ describe("runBootstrap — #817 idempotent bundled-plugin symlinks", () => {
   let bundledDir: string;
 
   beforeEach(() => {
-    workDir = join(tmpdir(), `maw-bootstrap-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    // mkdtempSync is atomic — appends 6 random chars + creates the dir in one
+    // syscall. Avoids js/insecure-temporary-file (CodeQL) which flags the
+    // mkdirSync(join(tmpdir(), userControlledName)) pattern as race-prone.
+    workDir = mkdtempSync(join(tmpdir(), "maw-bootstrap-test-"));
     srcDir = join(workDir, "src");
     pluginDir = join(workDir, "plugins");
     bundledDir = join(srcDir, "commands", "plugins");

--- a/src/cli/plugin-bootstrap.test.ts
+++ b/src/cli/plugin-bootstrap.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import {
+  mkdirSync,
+  writeFileSync,
+  readdirSync,
+  existsSync,
+  lstatSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+} from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { runBootstrap } from "./plugin-bootstrap";
+
+/**
+ * Tests for #817 — bootstrap-on-empty.
+ *
+ * The bug: the entire bootstrap body (including bundled-plugin symlinks)
+ * was gated on `pluginDir` being empty. New bundled plugins added in an
+ * update were silently invisible on every existing host.
+ *
+ * The fix: bundled-plugin symlinks are idempotent (run every boot, skip
+ * existing dests). The `pluginSources` URL-fetch path stays first-install
+ * only.
+ */
+describe("runBootstrap — #817 idempotent bundled-plugin symlinks", () => {
+  let workDir: string;
+  let srcDir: string;
+  let pluginDir: string;
+  let bundledDir: string;
+
+  beforeEach(() => {
+    workDir = join(tmpdir(), `maw-bootstrap-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    srcDir = join(workDir, "src");
+    pluginDir = join(workDir, "plugins");
+    bundledDir = join(srcDir, "commands", "plugins");
+    mkdirSync(bundledDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    try { rmSync(workDir, { recursive: true, force: true }); } catch {}
+  });
+
+  /** Helper: create a bundled plugin dir that runBootstrap will recognize. */
+  function makeBundledPlugin(name: string, kind: "manifest" | "index" = "manifest") {
+    const dir = join(bundledDir, name);
+    mkdirSync(dir, { recursive: true });
+    if (kind === "manifest") {
+      writeFileSync(join(dir, "plugin.json"), JSON.stringify({ name }));
+    } else {
+      writeFileSync(join(dir, "index.ts"), `export default async () => ({ ok: true });\n`);
+    }
+    return dir;
+  }
+
+  it("empty pluginDir → all bundled plugins symlinked (first install)", async () => {
+    makeBundledPlugin("alpha");
+    makeBundledPlugin("beta", "index");
+    makeBundledPlugin("gamma");
+
+    await runBootstrap(pluginDir, srcDir);
+
+    const linked = readdirSync(pluginDir).sort();
+    expect(linked).toEqual(["alpha", "beta", "gamma"]);
+    for (const name of linked) {
+      const dest = join(pluginDir, name);
+      expect(lstatSync(dest).isSymbolicLink()).toBe(true);
+      expect(readlinkSync(dest)).toBe(join(bundledDir, name));
+    }
+  });
+
+  it("non-empty pluginDir with N-1 of N plugins → 1 new symlink, others untouched", async () => {
+    makeBundledPlugin("alpha");
+    makeBundledPlugin("beta");
+    makeBundledPlugin("shellenv"); // the new plugin from #816
+
+    // Pre-existing install: alpha + beta symlinked, shellenv missing.
+    mkdirSync(pluginDir, { recursive: true });
+    symlinkSync(join(bundledDir, "alpha"), join(pluginDir, "alpha"));
+    symlinkSync(join(bundledDir, "beta"), join(pluginDir, "beta"));
+
+    // Capture inode/mtime for the existing alpha symlink so we can verify
+    // it wasn't recreated.
+    const alphaBefore = lstatSync(join(pluginDir, "alpha")).ino;
+
+    await runBootstrap(pluginDir, srcDir);
+
+    const linked = readdirSync(pluginDir).sort();
+    expect(linked).toEqual(["alpha", "beta", "shellenv"]);
+    expect(lstatSync(join(pluginDir, "shellenv")).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(join(pluginDir, "shellenv"))).toBe(join(bundledDir, "shellenv"));
+
+    // Pre-existing symlink not recreated (same inode).
+    expect(lstatSync(join(pluginDir, "alpha")).ino).toBe(alphaBefore);
+  });
+
+  it("all N plugins already present → no-op (no new symlinks)", async () => {
+    makeBundledPlugin("alpha");
+    makeBundledPlugin("beta");
+
+    mkdirSync(pluginDir, { recursive: true });
+    symlinkSync(join(bundledDir, "alpha"), join(pluginDir, "alpha"));
+    symlinkSync(join(bundledDir, "beta"), join(pluginDir, "beta"));
+
+    await runBootstrap(pluginDir, srcDir);
+
+    expect(readdirSync(pluginDir).sort()).toEqual(["alpha", "beta"]);
+  });
+
+  it("existing dest dir (user-owned, not a symlink) → skipped, not overwritten", async () => {
+    makeBundledPlugin("alpha");
+
+    mkdirSync(pluginDir, { recursive: true });
+    // User has a real dir at the bundled-plugin name (e.g. fork, override).
+    const userDir = join(pluginDir, "alpha");
+    mkdirSync(userDir, { recursive: true });
+    writeFileSync(join(userDir, "marker.txt"), "user-owned");
+
+    await runBootstrap(pluginDir, srcDir);
+
+    // Still a directory, not a symlink — bootstrap left it alone.
+    expect(lstatSync(userDir).isDirectory()).toBe(true);
+    expect(lstatSync(userDir).isSymbolicLink()).toBe(false);
+    expect(existsSync(join(userDir, "marker.txt"))).toBe(true);
+  });
+
+  it("non-plugin dirs (no plugin.json, no index.ts) are skipped", async () => {
+    makeBundledPlugin("alpha");
+    // garbage dir under bundled — not a plugin
+    mkdirSync(join(bundledDir, "_shared"), { recursive: true });
+    writeFileSync(join(bundledDir, "_shared", "util.ts"), "// helper\n");
+
+    await runBootstrap(pluginDir, srcDir);
+
+    expect(readdirSync(pluginDir).sort()).toEqual(["alpha"]);
+  });
+
+  it("missing bundled dir entirely → no error, pluginDir created", async () => {
+    rmSync(bundledDir, { recursive: true, force: true });
+    rmSync(srcDir, { recursive: true, force: true });
+
+    await runBootstrap(pluginDir, srcDir);
+
+    expect(existsSync(pluginDir)).toBe(true);
+    expect(readdirSync(pluginDir)).toEqual([]);
+  });
+
+  it("pluginSources URL-fetch path is gated behind wasEmpty (only logs on first install)", async () => {
+    // The `[maw] bootstrapped N plugins` console.log is inside the `wasEmpty`
+    // branch alongside the URL-fetch logic — its presence/absence is a
+    // proxy for whether the URL-fetch path executed.
+    makeBundledPlugin("alpha");
+
+    const originalLog = console.log;
+    const logs: string[] = [];
+    console.log = (...args: unknown[]) => { logs.push(args.map(String).join(" ")); };
+
+    try {
+      // First install: pluginDir empty → wasEmpty branch should run.
+      await runBootstrap(pluginDir, srcDir);
+      const firstRunLogs = logs.filter((l) => l.includes("bootstrapped"));
+      expect(firstRunLogs.length).toBe(1);
+
+      // Second invocation with new bundled plugin added: pluginDir is NOT
+      // empty → URL-fetch path must NOT re-run, but new symlink IS added.
+      makeBundledPlugin("shellenv");
+      logs.length = 0;
+      await runBootstrap(pluginDir, srcDir);
+
+      // No "bootstrapped" log → wasEmpty branch was correctly skipped.
+      expect(logs.filter((l) => l.includes("bootstrapped")).length).toBe(0);
+      // But the new bundled plugin WAS linked (the bug fix).
+      expect(existsSync(join(pluginDir, "shellenv"))).toBe(true);
+      expect(lstatSync(join(pluginDir, "shellenv")).isSymbolicLink()).toBe(true);
+    } finally {
+      console.log = originalLog;
+    }
+  });
+});

--- a/src/cli/plugin-bootstrap.ts
+++ b/src/cli/plugin-bootstrap.ts
@@ -1,30 +1,49 @@
-import { mkdirSync, existsSync, readdirSync, symlinkSync, cpSync, writeFileSync, readFileSync } from "fs";
+import { mkdirSync, existsSync, readdirSync, symlinkSync, cpSync, readFileSync } from "fs";
 import { join } from "path";
 
 /** Allowlist: only http/https URLs may be used as plugin sources */
 const URL_SCHEME_RE = /^https?:\/\//;
 
 /**
- * Auto-bootstrap plugins into pluginDir if empty.
- * Symlinks bundled plugins and installs from pluginSources config URLs.
+ * Auto-bootstrap plugins into pluginDir.
+ *
+ * Bundled-plugin symlinks are idempotent — walked on every boot so newly
+ * added bundled plugins (e.g. introduced by an update) get linked into
+ * existing installs. Existing destinations (symlinks or user dirs) are
+ * never overwritten.
+ *
+ * The pluginSources URL fetch path is preserved as first-install only:
+ * it makes network calls and has a different cost profile, so it still
+ * runs only when pluginDir is empty.
+ *
+ * Bug: #817 — bootstrap-on-empty caused new bundled plugins to be
+ * silently invisible on every existing host until a manual symlink.
  *
  * @param pluginDir  resolved ~/.maw/plugins/ path
  * @param srcDir     resolved src/ directory (pass import.meta.dir from cli.ts)
  */
 export async function runBootstrap(pluginDir: string, srcDir: string): Promise<void> {
   mkdirSync(pluginDir, { recursive: true });
-  if (readdirSync(pluginDir).length === 0) {
-    // 1. Symlink bundled plugins (symlinks preserve relative imports)
-    const bundled = join(srcDir, "commands", "plugins");
-    if (existsSync(bundled)) {
-      for (const d of readdirSync(bundled)) {
-        if (existsSync(join(bundled, d, "plugin.json")) || existsSync(join(bundled, d, "index.ts"))) {
-          symlinkSync(join(bundled, d), join(pluginDir, d));
-        }
-      }
-    }
+  const wasEmpty = readdirSync(pluginDir).length === 0;
 
-    // 2. Install from pluginSources URLs in config
+  // 1. Symlink any bundled plugin missing from pluginDir — IDEMPOTENT,
+  //    runs every boot. Cheap (fs stat + symlink), no network.
+  const bundled = join(srcDir, "commands", "plugins");
+  if (existsSync(bundled)) {
+    for (const d of readdirSync(bundled)) {
+      const src = join(bundled, d);
+      const dest = join(pluginDir, d);
+      const isPlugin =
+        existsSync(join(src, "plugin.json")) || existsSync(join(src, "index.ts"));
+      if (!isPlugin) continue;
+      if (existsSync(dest)) continue; // already linked / user dir / valid symlink
+      symlinkSync(src, dest);
+    }
+  }
+
+  // 2. Install from pluginSources URLs — first-install only (network calls,
+  //    should not retry every boot).
+  if (wasEmpty) {
     try {
       const { loadConfig } = await import("../config");
       const config = loadConfig();


### PR DESCRIPTION
## Summary

Fixes #817 — `plugin-bootstrap` only seeded plugins when the user's `~/.maw/plugins/` directory was empty (first install). Existing installs that upgraded to a maw-js version with newly-bundled plugins never got the new symlinks, so the new plugins effectively didn't exist.

The rewrite changes the policy from "skip if any plugin present" to "symlink each missing bundled plugin". Existing user-customized plugins (different target, real file, etc.) are left untouched.

## Files changed

- `src/cli/plugin-bootstrap.ts` — rewrite (67 → 84 LOC). Per-plugin idempotent symlink reconciliation.
- `src/cli/plugin-bootstrap.test.ts` — NEW (7 tests, 22 expects).
- `package.json` — calver bump (v26.4.29-alpha.11 → v26.4.29-alpha.12)

## Test results

- **Focused suite green**: `bun test src/cli/plugin-bootstrap.test.ts` → 7 pass / 0 fail / 22 expects.
- **Full `bun test` has TWO PRE-EXISTING baseline failures unrelated to this fix** (verified by impl-817 via `git stash` + re-run on baseline):
  1. `test/command-simplified.test.ts` buildCommand suite — fails on baseline
  2. `test/soul-sync.test.ts` — Bun v1.3.13 panic/segfault, reproduces on baseline
  These will be filed as a separate issue (test-isolation pollution + Bun runtime crash on full-suite mode). They are not caused by, and cannot be fixed by, this PR.
- **CI test-isolated overridable flakes** (per #811/#813 precedent):
  - `checkStalePeers — reachable happy path` (timeout-forwarded x2, default-timeout x2)
  - `local-first routing (#411) > (3) local miss + remote peer unreachable`

## Verification

- New install path (empty plugins dir) — still works (test 1).
- Upgrade path (existing plugins dir, missing one bundled plugin) — new symlink created (tests 2-3, the bug scenario).
- User-customized plugin paths — preserved (tests 4-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
