### PR TITLE
feat(scope): scope primitive + maw scope list/create/show/delete (Phase 1 of #642)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.12",
+  "version": "26.4.29-alpha.13",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/plugins/scope/impl.ts
+++ b/src/commands/plugins/scope/impl.ts
@@ -1,0 +1,181 @@
+/**
+ * maw scope — subcommand implementations (#642 Phase 1, primitive only).
+ *
+ * Pure(-ish) functions that read and write per-scope JSON files under
+ * `<CONFIG_DIR>/scopes/<name>.json`. Phase 1 ships ONLY the data primitive
+ * + CLI verbs (list / create / show / delete). ACL evaluation, the trust
+ * list, and the cross-scope approval queue are deferred to follow-up
+ * issues — see #642 for the full picture.
+ *
+ * Design decisions:
+ *   - One JSON file per scope (vs. a single index file) so a future
+ *     `maw scope edit` can be a plain text edit; concurrent writes touch
+ *     disjoint files; and corruption blasts at most one scope.
+ *   - Path resolution is a function (not a const) so tests can override
+ *     `MAW_CONFIG_DIR` per-test and get a fresh path each call. Mirrors
+ *     the pattern in src/commands/plugins/team/oracle-members.ts.
+ *   - No file lock (yet) — Phase 1 is operator-driven; concurrent
+ *     multi-writer edits are not a real workload here. Phase 2 routing
+ *     enforcement reads scopes; if writes ever race, we'll add a lock
+ *     mirroring src/commands/plugins/peers/lock.ts.
+ */
+import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, unlinkSync, writeFileSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import type { TScope } from "../../../lib/schemas";
+
+// Scope name validation — same alphabet as peers aliases. Slug-safe so the
+// name can double as a filename without escaping.
+const SCOPE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/;
+
+export function validateScopeName(name: string): string | null {
+  if (!SCOPE_NAME_RE.test(name)) {
+    return `invalid scope name "${name}" (must match ^[a-z0-9][a-z0-9_-]{0,63}$)`;
+  }
+  return null;
+}
+
+// ─── Paths ───
+
+/**
+ * Resolve the active config dir at call time (not import time) so tests can
+ * point the directory at a temp path per-test by setting MAW_CONFIG_DIR /
+ * MAW_HOME in beforeEach. Mirrors the precedence logic in src/core/paths.ts
+ * — but as a function instead of a module-level const, so successive calls
+ * see env mutations made between them.
+ *
+ *   1. MAW_HOME → <MAW_HOME>/config (instance mode, see #566)
+ *   2. MAW_CONFIG_DIR override (legacy)
+ *   3. Default singleton ~/.config/maw/
+ *
+ * In production the env doesn't change between CLI startup and command
+ * dispatch, so the live read returns the same path the cached CONFIG_DIR
+ * would have. In tests, the live read is what makes per-test isolation work.
+ */
+function activeConfigDir(): string {
+  if (process.env.MAW_HOME) return join(process.env.MAW_HOME, "config");
+  if (process.env.MAW_CONFIG_DIR) return process.env.MAW_CONFIG_DIR;
+  return join(homedir(), ".config", "maw");
+}
+
+export function scopesDir(): string {
+  return join(activeConfigDir(), "scopes");
+}
+
+export function scopePath(name: string): string {
+  return join(scopesDir(), `${name}.json`);
+}
+
+function ensureScopesDir(): void {
+  mkdirSync(scopesDir(), { recursive: true });
+}
+
+// ─── Read ───
+
+export function loadScope(name: string): TScope | null {
+  const path = scopePath(name);
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as TScope;
+  } catch {
+    return null;
+  }
+}
+
+export function cmdList(): TScope[] {
+  ensureScopesDir();
+  const dir = scopesDir();
+  const files = readdirSync(dir).filter(f => f.endsWith(".json"));
+  const out: TScope[] = [];
+  for (const f of files) {
+    const name = f.replace(/\.json$/, "");
+    const s = loadScope(name);
+    if (s) out.push(s);
+  }
+  out.sort((a, b) => a.name.localeCompare(b.name));
+  return out;
+}
+
+export function cmdShow(name: string): TScope | null {
+  const nameErr = validateScopeName(name);
+  if (nameErr) throw new Error(nameErr);
+  return loadScope(name);
+}
+
+// ─── Write ───
+
+export interface CreateOptions {
+  name: string;
+  members: string[];
+  lead?: string;
+  ttl?: string | null;
+}
+
+/**
+ * Create a new scope. Refuses to overwrite — operators must `delete`
+ * first. This is intentional: Phase 2 routing will key on scope identity,
+ * and silently swapping members under a name would be surprising.
+ */
+export function cmdCreate(opts: CreateOptions): TScope {
+  const nameErr = validateScopeName(opts.name);
+  if (nameErr) throw new Error(nameErr);
+  if (!opts.members || opts.members.length === 0) {
+    throw new Error(`scope "${opts.name}" must have at least one member`);
+  }
+  for (const m of opts.members) {
+    if (typeof m !== "string" || m.length === 0) {
+      throw new Error(`scope "${opts.name}" has an empty/invalid member entry`);
+    }
+  }
+  if (opts.lead && !opts.members.includes(opts.lead)) {
+    throw new Error(`scope "${opts.name}" lead "${opts.lead}" is not in members`);
+  }
+
+  ensureScopesDir();
+  const path = scopePath(opts.name);
+  if (existsSync(path)) {
+    throw new Error(`scope "${opts.name}" already exists at ${path} — delete it first to recreate`);
+  }
+
+  const scope: TScope = {
+    name: opts.name,
+    members: [...opts.members],
+    created: new Date().toISOString(),
+    ttl: opts.ttl ?? null,
+  };
+  if (opts.lead) scope.lead = opts.lead;
+
+  // Atomic-ish write via tmp + rename. Cheap insurance against a partial
+  // file on crash; same trick as src/commands/plugins/peers/store.ts.
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, JSON.stringify(scope, null, 2) + "\n");
+  renameSync(tmp, path);
+  return scope;
+}
+
+export function cmdDelete(name: string): boolean {
+  const nameErr = validateScopeName(name);
+  if (nameErr) throw new Error(nameErr);
+  const path = scopePath(name);
+  if (!existsSync(path)) return false;
+  unlinkSync(path);
+  return true;
+}
+
+// ─── Format ───
+
+export function formatList(rows: TScope[]): string {
+  if (!rows.length) return "no scopes";
+  const header = ["name", "members", "lead", "ttl", "created"];
+  const lines = rows.map(r => [
+    r.name,
+    r.members.join(","),
+    r.lead ?? "-",
+    r.ttl ?? "-",
+    r.created,
+  ]);
+  const widths = header.map((h, i) =>
+    Math.max(h.length, ...lines.map(l => l[i].length)));
+  const fmt = (cols: string[]) => cols.map((c, i) => c.padEnd(widths[i])).join("  ");
+  return [fmt(header), fmt(widths.map(w => "-".repeat(w))), ...lines.map(fmt)].join("\n");
+}

--- a/src/commands/plugins/scope/index.ts
+++ b/src/commands/plugins/scope/index.ts
@@ -1,0 +1,141 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+
+export const command = {
+  name: "scope",
+  description: "Routing scope primitive — list, create, show, delete (#642 Phase 1).",
+};
+
+/**
+ * maw scope — primitive plugin (#642 Phase 1).
+ *
+ * Phase 1 ships ONLY the data primitive + CLI verbs. ACL evaluation,
+ * trust list, and approval queue all land in follow-up issues. This
+ * unblocks operators creating named scopes today; routing enforcement
+ * comes later.
+ *
+ * Subcommand dispatcher mirrors the `peers` plugin (#568): peel
+ * positional[0] off as the verb, dispatch on a switch, print helpText()
+ * on missing/unknown.
+ */
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const impl = await import("./impl");
+
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+
+  const out = () => logs.join("\n");
+  const help = () => [
+    "usage: maw scope <list|create|show|delete> [...]",
+    "  list                                                    — list all scopes",
+    "  create   <name> --members <a,b,c> [--lead <m>] [--ttl <iso>]",
+    "                                                          — create new scope (refuses overwrite)",
+    "  show     <name>                                         — print one scope's JSON",
+    "  delete   <name> [--yes]                                 — remove scope file (confirms unless --yes)",
+    "",
+    "storage: <CONFIG_DIR>/scopes/<name>.json (one file per scope)",
+    "",
+    "note: Phase 1 of #642 — primitive only. ACL evaluation, trust list, and",
+    "      cross-scope approval queue are deferred to follow-up issues.",
+  ].join("\n");
+
+  try {
+    const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+    const positional = args.filter(a => !a.startsWith("--"));
+    const sub = positional[0];
+
+    if (!sub) {
+      console.log(help());
+      return { ok: true, output: out() || help() };
+    }
+
+    const flagValue = (flag: string): string | undefined => {
+      const i = args.indexOf(flag);
+      return i >= 0 ? args[i + 1] : undefined;
+    };
+
+    switch (sub) {
+      case "list":
+      case "ls": {
+        console.log(impl.formatList(impl.cmdList()));
+        return { ok: true, output: out() };
+      }
+      case "create":
+      case "new": {
+        const name = positional[1];
+        if (!name) {
+          return { ok: false, error: "usage: maw scope create <name> --members <a,b,c> [--lead <m>] [--ttl <iso>]" };
+        }
+        const membersRaw = flagValue("--members");
+        if (!membersRaw) {
+          return { ok: false, error: `usage: maw scope create ${name} --members <a,b,c> [--lead <m>] [--ttl <iso>]` };
+        }
+        const members = membersRaw.split(",").map(s => s.trim()).filter(Boolean);
+        const lead = flagValue("--lead");
+        const ttlRaw = flagValue("--ttl");
+        const ttl = ttlRaw === undefined ? null : ttlRaw;
+        try {
+          const created = impl.cmdCreate({ name, members, lead, ttl });
+          console.log(`created scope "${created.name}" (${created.members.length} member${created.members.length === 1 ? "" : "s"})`);
+          console.log(`  ${impl.scopePath(created.name)}`);
+          return { ok: true, output: out() };
+        } catch (e: any) {
+          return { ok: false, error: e?.message || String(e), output: out() };
+        }
+      }
+      case "show":
+      case "info": {
+        const name = positional[1];
+        if (!name) return { ok: false, error: "usage: maw scope show <name>" };
+        try {
+          const found = impl.cmdShow(name);
+          if (!found) return { ok: false, error: `scope "${name}" not found`, output: out() };
+          console.log(JSON.stringify(found, null, 2));
+          return { ok: true, output: out() };
+        } catch (e: any) {
+          return { ok: false, error: e?.message || String(e), output: out() };
+        }
+      }
+      case "delete":
+      case "rm":
+      case "remove": {
+        const name = positional[1];
+        if (!name) return { ok: false, error: "usage: maw scope delete <name> [--yes]" };
+        const confirmed = args.includes("--yes") || args.includes("-y");
+        if (!confirmed) {
+          console.log(`refusing to delete scope "${name}" without --yes`);
+          console.log(`  to confirm: maw scope delete ${name} --yes`);
+          return { ok: false, error: `delete requires --yes`, output: out() };
+        }
+        try {
+          const removed = impl.cmdDelete(name);
+          console.log(removed ? `deleted scope "${name}"` : `no-op: scope "${name}" not present`);
+          return { ok: true, output: out() };
+        } catch (e: any) {
+          return { ok: false, error: e?.message || String(e), output: out() };
+        }
+      }
+      default: {
+        console.log(help());
+        return {
+          ok: false,
+          error: `maw scope: unknown subcommand "${sub}" (expected list|create|show|delete)`,
+          output: out() || help(),
+        };
+      }
+    }
+  } catch (e: any) {
+    return { ok: false, error: out() || e.message, output: out() || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/src/commands/plugins/scope/plugin.json
+++ b/src/commands/plugins/scope/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "scope",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Scope primitive — named routing namespaces (#642 Phase 1).",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "scope",
+    "aliases": ["scopes"],
+    "help": "maw scope <list|create|show|delete> [...] — manage routing scopes (Phase 1 of #642)"
+  },
+  "weight": 50
+}

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -89,6 +89,34 @@ export const PluginInfo = Type.Object({
 });
 export type TPluginInfo = Static<typeof PluginInfo>;
 
+/**
+ * Scope — a named routing namespace (#642 Phase 1, primitive only).
+ *
+ * Scopes group oracles that may message each other freely. Phase 1 ships
+ * just the data primitive + CLI to create / list / show / delete; ACL
+ * evaluation, the trust list, and the cross-scope approval queue are
+ * follow-up issues. A scope file lives at:
+ *   <CONFIG_DIR>/scopes/<name>.json
+ *
+ * Fields:
+ *   - `name`     slug-safe identifier; mirrors the file name
+ *   - `members`  oracle names allowed to route within the scope
+ *   - `lead`     optional designated owner (one of `members` by convention,
+ *                but not enforced at the schema layer — operators can
+ *                experiment with shapes before Phase 2 nails it down)
+ *   - `created`  ISO-8601 timestamp at first write
+ *   - `ttl`      optional ISO date for auto-expire; null means no expiry.
+ *                Phase 1 stores it; Phase 2 enforces it.
+ */
+export const Scope = Type.Object({
+  name: Type.String(),
+  members: Type.Array(Type.String()),
+  lead: Type.Optional(Type.String()),
+  created: Type.String(),
+  ttl: Type.Union([Type.String(), Type.Null()]),
+});
+export type TScope = Static<typeof Scope>;
+
 // ---------------------------------------------------------------------------
 // Request body schemas (POST endpoints)
 // ---------------------------------------------------------------------------

--- a/test/isolated/scope-primitive.test.ts
+++ b/test/isolated/scope-primitive.test.ts
@@ -1,0 +1,281 @@
+/**
+ * scope primitive — unit tests (#642 Phase 1).
+ *
+ * Tests the per-scope JSON file primitive plus the maw scope CLI dispatcher.
+ * Phase 1 covers ONLY the data primitive + CLI verbs (list/create/show/delete);
+ * ACL evaluation, trust list, and the cross-scope approval queue are deferred
+ * to follow-up issues.
+ *
+ * Isolation: we set MAW_CONFIG_DIR + MAW_HOME before any dynamic import so
+ * core/paths.ts evaluates against the temp dir. Each isolated test file runs
+ * in its own bun process via scripts/test-isolated.sh, so the module cache
+ * is fresh and per-test env tweaks are safe.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+let testDir: string;
+let originalConfigDir: string | undefined;
+let originalHome: string | undefined;
+
+beforeEach(() => {
+  testDir = mkdtempSync(join(tmpdir(), "maw-scope-"));
+  originalConfigDir = process.env.MAW_CONFIG_DIR;
+  originalHome = process.env.MAW_HOME;
+  process.env.MAW_CONFIG_DIR = testDir;
+  delete process.env.MAW_HOME;
+});
+
+afterEach(() => {
+  if (originalConfigDir === undefined) delete process.env.MAW_CONFIG_DIR;
+  else process.env.MAW_CONFIG_DIR = originalConfigDir;
+  if (originalHome === undefined) delete process.env.MAW_HOME;
+  else process.env.MAW_HOME = originalHome;
+  try { rmSync(testDir, { recursive: true, force: true }); } catch { /* ok */ }
+});
+
+describe("scope impl — name validation", () => {
+  test("validateScopeName accepts slugs and rejects junk", async () => {
+    const { validateScopeName } = await import("../../src/commands/plugins/scope/impl");
+    expect(validateScopeName("marketplace-work")).toBeNull();
+    expect(validateScopeName("a")).toBeNull();
+    expect(validateScopeName("scope_1")).toBeNull();
+    expect(validateScopeName("")).not.toBeNull();
+    expect(validateScopeName("-bad")).not.toBeNull();
+    expect(validateScopeName("BAD")).not.toBeNull();
+    expect(validateScopeName("a".repeat(65))).not.toBeNull();
+  });
+});
+
+describe("scope impl — create / list / show / delete", () => {
+  test("create then list shows the new scope", async () => {
+    const { cmdCreate, cmdList } = await import("../../src/commands/plugins/scope/impl");
+    cmdCreate({
+      name: "marketplace-work",
+      members: ["mawjs", "mawjs-plugin", "security"],
+      lead: "mawjs",
+    });
+    const all = cmdList();
+    expect(all).toHaveLength(1);
+    expect(all[0].name).toBe("marketplace-work");
+    expect(all[0].members).toEqual(["mawjs", "mawjs-plugin", "security"]);
+    expect(all[0].lead).toBe("mawjs");
+    expect(all[0].ttl).toBeNull();
+    expect(typeof all[0].created).toBe("string");
+  });
+
+  test("create persists JSON to <CONFIG_DIR>/scopes/<name>.json", async () => {
+    const { cmdCreate, scopePath } = await import("../../src/commands/plugins/scope/impl");
+    cmdCreate({ name: "bench", members: ["alpha", "beta"] });
+    const path = scopePath("bench");
+    expect(existsSync(path)).toBe(true);
+    const parsed = JSON.parse(readFileSync(path, "utf-8"));
+    expect(parsed.name).toBe("bench");
+    expect(parsed.members).toEqual(["alpha", "beta"]);
+    expect(parsed).not.toHaveProperty("lead");
+    expect(parsed.ttl).toBeNull();
+  });
+
+  test("create rejects duplicate names (no overwrite)", async () => {
+    const { cmdCreate } = await import("../../src/commands/plugins/scope/impl");
+    cmdCreate({ name: "dup", members: ["a"] });
+    expect(() => cmdCreate({ name: "dup", members: ["b"] })).toThrow(/already exists/);
+  });
+
+  test("create rejects invalid name", async () => {
+    const { cmdCreate } = await import("../../src/commands/plugins/scope/impl");
+    expect(() => cmdCreate({ name: "BAD!", members: ["a"] })).toThrow(/invalid scope name/);
+  });
+
+  test("create rejects empty member list", async () => {
+    const { cmdCreate } = await import("../../src/commands/plugins/scope/impl");
+    expect(() => cmdCreate({ name: "empty", members: [] })).toThrow(/at least one member/);
+  });
+
+  test("create rejects lead not in members", async () => {
+    const { cmdCreate } = await import("../../src/commands/plugins/scope/impl");
+    expect(() => cmdCreate({ name: "lead-bad", members: ["alpha"], lead: "ghost" }))
+      .toThrow(/lead "ghost" is not in members/);
+  });
+
+  test("show returns scope object for known name", async () => {
+    const { cmdCreate, cmdShow } = await import("../../src/commands/plugins/scope/impl");
+    cmdCreate({ name: "vis", members: ["a", "b"], lead: "a" });
+    const found = cmdShow("vis");
+    expect(found).not.toBeNull();
+    expect(found?.name).toBe("vis");
+    expect(found?.lead).toBe("a");
+  });
+
+  test("show returns null for non-existent name (CLI translates to error)", async () => {
+    const { cmdShow } = await import("../../src/commands/plugins/scope/impl");
+    expect(cmdShow("ghost")).toBeNull();
+  });
+
+  test("show rejects invalid name format", async () => {
+    const { cmdShow } = await import("../../src/commands/plugins/scope/impl");
+    expect(() => cmdShow("BAD!")).toThrow(/invalid scope name/);
+  });
+
+  test("delete removes the scope file", async () => {
+    const { cmdCreate, cmdDelete, cmdList, scopePath } = await import("../../src/commands/plugins/scope/impl");
+    cmdCreate({ name: "victim", members: ["a"] });
+    expect(existsSync(scopePath("victim"))).toBe(true);
+    expect(cmdDelete("victim")).toBe(true);
+    expect(existsSync(scopePath("victim"))).toBe(false);
+    expect(cmdList()).toHaveLength(0);
+  });
+
+  test("delete is idempotent (returns false on missing)", async () => {
+    const { cmdDelete } = await import("../../src/commands/plugins/scope/impl");
+    expect(cmdDelete("ghost")).toBe(false);
+  });
+
+  test("members list is editable on disk (operator workflow)", async () => {
+    const { cmdCreate, cmdShow, scopePath } = await import("../../src/commands/plugins/scope/impl");
+    cmdCreate({ name: "edit-me", members: ["alpha", "beta"] });
+    const path = scopePath("edit-me");
+
+    // Operator hand-edits the JSON to add a member.
+    const parsed = JSON.parse(readFileSync(path, "utf-8"));
+    parsed.members.push("gamma");
+    writeFileSync(path, JSON.stringify(parsed, null, 2) + "\n");
+
+    const reloaded = cmdShow("edit-me");
+    expect(reloaded?.members).toEqual(["alpha", "beta", "gamma"]);
+  });
+
+  test("list is empty on a fresh CONFIG_DIR", async () => {
+    const { cmdList } = await import("../../src/commands/plugins/scope/impl");
+    expect(cmdList()).toEqual([]);
+  });
+
+  test("list ignores non-JSON files in scopes dir", async () => {
+    const { cmdCreate, cmdList, scopesDir } = await import("../../src/commands/plugins/scope/impl");
+    cmdCreate({ name: "real", members: ["a"] });
+    // Drop a stray non-JSON file alongside.
+    writeFileSync(join(scopesDir(), "README.md"), "operator notes");
+    const all = cmdList();
+    expect(all).toHaveLength(1);
+    expect(all[0].name).toBe("real");
+  });
+
+  test("list silently skips a corrupt JSON file", async () => {
+    const { cmdCreate, cmdList, scopesDir } = await import("../../src/commands/plugins/scope/impl");
+    cmdCreate({ name: "good", members: ["a"] });
+    writeFileSync(join(scopesDir(), "broken.json"), "{ this is not json");
+    const all = cmdList();
+    // Phase 1 is forgiving — corrupt files don't blow up `list`. Operator can
+    // diff the file by hand. Phase 2 may add a louder diagnostic.
+    expect(all.map(s => s.name)).toEqual(["good"]);
+  });
+});
+
+describe("scope impl — formatList", () => {
+  test("renders header + rows when non-empty", async () => {
+    const { cmdCreate, cmdList, formatList } = await import("../../src/commands/plugins/scope/impl");
+    cmdCreate({ name: "bench", members: ["a", "b"], lead: "a" });
+    const out = formatList(cmdList());
+    expect(out).toContain("name");
+    expect(out).toContain("members");
+    expect(out).toContain("lead");
+    expect(out).toContain("bench");
+    expect(out).toContain("a,b");
+  });
+
+  test("renders placeholder when empty", async () => {
+    const { formatList } = await import("../../src/commands/plugins/scope/impl");
+    expect(formatList([])).toBe("no scopes");
+  });
+});
+
+describe("scope dispatcher (index.ts)", () => {
+  test("no args → prints help", async () => {
+    const { default: handler } = await import("../../src/commands/plugins/scope/index");
+    const res = await handler({ source: "cli", args: [] });
+    expect(res.ok).toBe(true);
+    expect(res.output).toContain("usage: maw scope");
+    expect(res.output).toContain("Phase 1 of #642");
+  });
+
+  test("unknown subcommand → error + help in output", async () => {
+    const { default: handler } = await import("../../src/commands/plugins/scope/index");
+    const res = await handler({ source: "cli", args: ["wat"] });
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain("unknown subcommand");
+  });
+
+  test("create then list through dispatcher", async () => {
+    const { default: handler } = await import("../../src/commands/plugins/scope/index");
+    const create = await handler({
+      source: "cli",
+      args: ["create", "marketplace-work", "--members", "mawjs,mawjs-plugin,security", "--lead", "mawjs"],
+    });
+    expect(create.ok).toBe(true);
+    expect(create.output).toContain('created scope "marketplace-work"');
+    const list = await handler({ source: "cli", args: ["list"] });
+    expect(list.ok).toBe(true);
+    expect(list.output).toContain("marketplace-work");
+    expect(list.output).toContain("mawjs,mawjs-plugin,security");
+  });
+
+  test("create without --members → error", async () => {
+    const { default: handler } = await import("../../src/commands/plugins/scope/index");
+    const res = await handler({ source: "cli", args: ["create", "lonely"] });
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain("--members");
+  });
+
+  test("create duplicate via dispatcher → error", async () => {
+    const { default: handler } = await import("../../src/commands/plugins/scope/index");
+    const first = await handler({ source: "cli", args: ["create", "dup", "--members", "a"] });
+    expect(first.ok).toBe(true);
+    const second = await handler({ source: "cli", args: ["create", "dup", "--members", "b"] });
+    expect(second.ok).toBe(false);
+    expect(second.error).toContain("already exists");
+  });
+
+  test("show non-existent → error", async () => {
+    const { default: handler } = await import("../../src/commands/plugins/scope/index");
+    const res = await handler({ source: "cli", args: ["show", "ghost"] });
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain("not found");
+  });
+
+  test("show known scope → JSON output", async () => {
+    const { default: handler } = await import("../../src/commands/plugins/scope/index");
+    await handler({ source: "cli", args: ["create", "viewme", "--members", "alpha"] });
+    const res = await handler({ source: "cli", args: ["show", "viewme"] });
+    expect(res.ok).toBe(true);
+    const parsed = JSON.parse(res.output!);
+    expect(parsed.name).toBe("viewme");
+    expect(parsed.members).toEqual(["alpha"]);
+  });
+
+  test("delete refuses without --yes", async () => {
+    const { default: handler } = await import("../../src/commands/plugins/scope/index");
+    await handler({ source: "cli", args: ["create", "kill", "--members", "a"] });
+    const res = await handler({ source: "cli", args: ["delete", "kill"] });
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain("--yes");
+  });
+
+  test("delete with --yes removes the file", async () => {
+    const { default: handler } = await import("../../src/commands/plugins/scope/index");
+    await handler({ source: "cli", args: ["create", "kill", "--members", "a"] });
+    const res = await handler({ source: "cli", args: ["delete", "kill", "--yes"] });
+    expect(res.ok).toBe(true);
+    expect(res.output).toContain('deleted scope "kill"');
+    const list = await handler({ source: "cli", args: ["list"] });
+    expect(list.output).toContain("no scopes");
+  });
+
+  test("delete missing scope with --yes is idempotent (no-op)", async () => {
+    const { default: handler } = await import("../../src/commands/plugins/scope/index");
+    const res = await handler({ source: "cli", args: ["delete", "ghost", "--yes"] });
+    expect(res.ok).toBe(true);
+    expect(res.output).toContain("no-op");
+  });
+});


### PR DESCRIPTION
## Phase 1 of #642 — primitive only

ACL evaluation, trust list, approval queue all deferred to follow-up issues. This unblocks operators creating named scopes; routing enforcement comes later.

Supersedes #828 (branch was force-pushed to resolve calver collision with #827; PR auto-closed).

### Implementation
- One JSON file per scope under \`<CONFIG_DIR>/scopes/<name>.json\`
- Plugin: \`src/commands/plugins/scope/\` — \`list\`/\`create\`/\`show\`/\`delete\` (+ aliases)
- TypeBox \`Scope\` schema in \`src/lib/schemas.ts\`
- Atomic writes via tmp + rename
- Lead must be in members; member list non-empty
- TTL stored but not enforced (Phase 2)

### Tests
\`test/isolated/scope-primitive.test.ts\` — 28 pass, 0 fail.

### Bump
v26.4.29-alpha.13 (collision with #827 forced bump from .12)

### Cross-ref
- #642 (parent issue)
- #828 (superseded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)