### PR TITLE
fix(wake): --no-attach corrupts worktree name → cascading errors (#823)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.12",
+  "version": "26.4.29-alpha.13",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/plugins/wake/index.ts
+++ b/src/commands/plugins/wake/index.ts
@@ -50,7 +50,9 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         "--wt": String, "--new": "--wt",
         "--incubate": String, "--issue": Number,
         "--pr": Number, "--repo": String, "--task": String,
-        "--fresh": Boolean, "--attach": Boolean, "-a": "--attach", "--list": Boolean, "--ls": "--list",
+        "--fresh": Boolean, "--attach": Boolean, "-a": "--attach",
+        "--no-attach": Boolean, // #823 Bug B — register so it doesn't fall through to positional → wakeOpts.task
+        "--list": Boolean, "--ls": "--list",
         "--split": Boolean,
         "--all-local": Boolean,
       }, 1);
@@ -77,6 +79,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       if (flags["--incubate"]) wakeOpts.incubate = flags["--incubate"];
       if (flags["--fresh"]) wakeOpts.fresh = true;
       if (flags["--attach"]) wakeOpts.attach = true;
+      if (flags["--no-attach"]) wakeOpts.attach = false; // #823 Bug B — explicit opt-out; preserves default when neither flag is set
       if (flags["--list"]) wakeOpts.listWt = true;
       if (flags["--split"]) wakeOpts.split = true;
       if (flags["--all-local"]) wakeOpts.allLocal = true;

--- a/src/commands/plugins/wake/wake.test.ts
+++ b/src/commands/plugins/wake/wake.test.ts
@@ -138,4 +138,21 @@ describe("wake plugin", () => {
     expect(lastWakeCall?.opts.wt).toBe(wtValue);
     expect(lastWakeCall?.opts.wt).toBe("foo");
   });
+
+  // #823 Bug B — --no-attach must be a registered Boolean flag, not fall
+  // through to flags._ where it would be consumed as wakeOpts.task and then
+  // sanitized into a corrupted worktree name (see sanitizeBranchName tests
+  // and worktrees-scan dedupe test for the rest of the cascade).
+  it("CLI --no-attach: populates wakeOpts.attach=false, NOT wakeOpts.task", async () => {
+    const result = await handler({ source: "cli", args: ["neo", "--no-attach"] });
+    expect(result.ok).toBe(true);
+    expect(lastWakeCall?.opts.attach).toBe(false);
+    expect(lastWakeCall?.opts.task).toBeUndefined();
+  });
+
+  it("CLI no flag: wakeOpts.attach stays undefined (preserves default behavior)", async () => {
+    const result = await handler({ source: "cli", args: ["neo"] });
+    expect(result.ok).toBe(true);
+    expect(lastWakeCall?.opts.attach).toBeUndefined();
+  });
 });

--- a/src/commands/shared/wake-resolve-impl.test.ts
+++ b/src/commands/shared/wake-resolve-impl.test.ts
@@ -30,7 +30,36 @@ mock.module(join(root, "config"), () => mockConfigModule(() => ({
   peers: [],
 })));
 
-const { detectSession } = await import("./wake-resolve-impl");
+const { detectSession, sanitizeBranchName } = await import("./wake-resolve-impl");
+
+describe("sanitizeBranchName (#823 Bug A) — greedy strip", () => {
+  it("strips ALL leading dashes (--no-attach → no-attach)", () => {
+    // Pre-#823: `/^[-.]|[-.]$/g` only stripped one leading dash, leaving
+    // "-no-attach" which then became corrupted worktree name "1--no-attach".
+    expect(sanitizeBranchName("--no-attach")).toBe("no-attach");
+  });
+
+  it("strips ALL trailing dashes/dots", () => {
+    expect(sanitizeBranchName("foo--")).toBe("foo");
+    expect(sanitizeBranchName("foo..")).toBe("foo");
+    expect(sanitizeBranchName("--foo--")).toBe("foo");
+  });
+
+  it("collapses pure-junk input (`--`) to empty string", () => {
+    // Edge case — caller responsible for treating empty as malformed input.
+    expect(sanitizeBranchName("--")).toBe("");
+    expect(sanitizeBranchName("...")).toBe("");
+  });
+
+  it("preserves valid branch names unchanged", () => {
+    expect(sanitizeBranchName("feature-x")).toBe("feature-x");
+    expect(sanitizeBranchName("issue-823")).toBe("issue-823");
+  });
+
+  it("lowercases and replaces whitespace with dashes (existing behavior)", () => {
+    expect(sanitizeBranchName("My Task Name")).toBe("my-task-name");
+  });
+});
 
 describe("detectSession (#769) — URL-aware resolution", () => {
   it("URL with `<name>-oracle` repo resolves to exact full-name session", async () => {

--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -262,8 +262,12 @@ export async function setSessionEnv(session: string): Promise<void> {
 }
 
 export function sanitizeBranchName(name: string): string {
+  // #823 Bug A — greedy strip of leading/trailing dashes/dots so unknown CLI
+  // flags that leak into the positional slot (e.g. "--no-attach") sanitize to
+  // "no-attach" rather than the half-stripped "-no-attach", which then
+  // becomes a corrupted worktree name "1--no-attach" downstream.
   return name.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9._\-]/g, "")
-    .replace(/\.{2,}/g, ".").replace(/^[-.]|[-.]$/g, "").slice(0, 50);
+    .replace(/\.{2,}/g, ".").replace(/^[-.]+|[-.]+$/g, "").slice(0, 50);
 }
 
 // Wake target parsing (parseWakeTarget, ensureCloned) is in wake-target.ts

--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -267,12 +267,14 @@ export function sanitizeBranchName(name: string): string {
   // "no-attach" rather than the half-stripped "-no-attach", which then
   // becomes a corrupted worktree name "1--no-attach" downstream.
   //
-  // Two separate anchored replace() calls instead of `/^[-.]+|[-.]+$/g` —
-  // CodeQL's js/polynomial-redos flagged the alternation form as
-  // backtrack-prone on long all-dash input. Anchored single-pass strips
-  // are linear (no alternation, no backtracking).
+  // Strip pattern split into two anchored passes:
+  //   - `^[-.]+`        — `^` anchor pins the start, no backtracking possible.
+  //   - `(?<![-.])[-.]+$` — negative look-behind pins the trailing run to its
+  //     leftmost start, preventing the n² backtrack CodeQL's js/polynomial-redos
+  //     flags on the bare `[-.]+$` form (it can begin matching anywhere within
+  //     the run, then backtrack on long all-dash input).
   return name.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9._\-]/g, "")
-    .replace(/\.{2,}/g, ".").replace(/^[-.]+/, "").replace(/[-.]+$/, "").slice(0, 50);
+    .replace(/\.{2,}/g, ".").replace(/^[-.]+/, "").replace(/(?<![-.])[-.]+$/, "").slice(0, 50);
 }
 
 // Wake target parsing (parseWakeTarget, ensureCloned) is in wake-target.ts

--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -266,8 +266,13 @@ export function sanitizeBranchName(name: string): string {
   // flags that leak into the positional slot (e.g. "--no-attach") sanitize to
   // "no-attach" rather than the half-stripped "-no-attach", which then
   // becomes a corrupted worktree name "1--no-attach" downstream.
+  //
+  // Two separate anchored replace() calls instead of `/^[-.]+|[-.]+$/g` —
+  // CodeQL's js/polynomial-redos flagged the alternation form as
+  // backtrack-prone on long all-dash input. Anchored single-pass strips
+  // are linear (no alternation, no backtracking).
   return name.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9._\-]/g, "")
-    .replace(/\.{2,}/g, ".").replace(/^[-.]+|[-.]+$/g, "").slice(0, 50);
+    .replace(/\.{2,}/g, ".").replace(/^[-.]+/, "").replace(/[-.]+$/, "").slice(0, 50);
 }
 
 // Wake target parsing (parseWakeTarget, ensureCloned) is in wake-target.ts

--- a/src/core/fleet/worktrees-scan.test.ts
+++ b/src/core/fleet/worktrees-scan.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Regression test for #823 Bug C — `allWindows` dedupe.
+ *
+ * Pre-fix: `sessions.flatMap(s => s.windows)` collected windows across
+ * sessions without deduping by name. Two sessions each containing a window
+ * named "neo" produced 2 candidate entries — the resolver then surfaced a
+ * phantom "ambiguous" match even though it's the same window logically.
+ *
+ * Test strategy: stub `find` to return one worktree path, stub
+ * `git rev-parse` to return a branch, stub `listSessions` to return TWO
+ * sessions with same-named windows, and assert that the dedupe collapses
+ * them so the worktree resolves to "active" rather than logging an
+ * ambiguous-match error.
+ */
+import { describe, it, expect, mock } from "bun:test";
+import { join } from "path";
+
+const root = join(import.meta.dir, "../..");
+
+// Stub host execution: `find` returns one worktree path, `git rev-parse`
+// returns a branch name, anything else returns empty.
+mock.module(join(root, "core/transport/ssh"), () => ({
+  hostExec: async (cmd: string) => {
+    if (cmd.includes("find ") && cmd.includes(".wt-")) {
+      return "/ghq/github.com/Org/foo-oracle/foo-oracle.wt-1-neo";
+    }
+    if (cmd.includes("rev-parse --abbrev-ref")) {
+      return "agents/1-neo";
+    }
+    return "";
+  },
+  // Two sessions with identically-named "neo" windows — pre-fix this surfaces
+  // as an ambiguous match (2 candidates), post-fix it dedupes to 1.
+  listSessions: async () => [
+    { name: "session-a", windows: [{ name: "neo", index: "1" }] },
+    { name: "session-b", windows: [{ name: "neo", index: "1" }] },
+  ],
+}));
+
+mock.module(join(root, "config/ghq-root"), () => ({
+  getGhqRoot: () => "/ghq",
+}));
+
+// Avoid touching real fleet dir
+mock.module(join(root, "core/paths"), () => ({
+  FLEET_DIR: "/tmp/maw-test-nonexistent-fleet-823",
+}));
+
+const { scanWorktrees } = await import("./worktrees-scan");
+
+describe("scanWorktrees (#823 Bug C) — dedupe windows across sessions", () => {
+  it("same-named window in 2 sessions resolves cleanly (no phantom ambiguous)", async () => {
+    // Capture stderr — pre-fix path emits "is ambiguous — matches 2 windows"
+    const errLogs: string[] = [];
+    const origErr = console.error;
+    console.error = (...a: any[]) => { errLogs.push(a.map(String).join(" ")); };
+
+    try {
+      const results = await scanWorktrees();
+      // Find our worktree
+      const wt = results.find(r => r.name === "1-neo");
+      expect(wt).toBeDefined();
+      // Post-fix: dedupe collapses the 2 same-named windows to 1, resolver
+      // returns exact/fuzzy → tmuxWindow set → status = "active".
+      expect(wt!.status).toBe("active");
+      expect(wt!.tmuxWindow).toBe("neo");
+
+      // No ambiguous-match noise should have been printed.
+      const combined = errLogs.join("\n");
+      expect(combined).not.toContain("ambiguous");
+    } finally {
+      console.error = origErr;
+    }
+  });
+});

--- a/src/core/fleet/worktrees-scan.ts
+++ b/src/core/fleet/worktrees-scan.ts
@@ -91,7 +91,12 @@ export async function scanWorktrees(): Promise<WorktreeInfo[]> {
     // Try to find matching window by name pattern
     // Window names like "neo-freelance" match wt name "1-freelance"
     const taskPart = wtName.replace(/^\d+-/, "");
-    const allWindows = sessions.flatMap(s => s.windows);
+    // #823 Bug C — dedupe windows by name across sessions. Without this, a
+    // window named X that exists in 2 sessions surfaces as 2 candidates in
+    // the ambiguous-match list, manufacturing phantom duplicates.
+    const allWindows = [
+      ...new Map(sessions.flatMap(s => s.windows).map(w => [w.name, w])).values()
+    ];
     const resolved = resolveWorktreeTarget(taskPart, allWindows);
     switch (resolved.kind) {
       case "exact":


### PR DESCRIPTION
## Summary

Fixes #823 — `maw wake --no-attach <name>` corrupted the worktree name with regex/flag-handling bugs, which cascaded into "phantom" worktrees on every subsequent fleet scan. Three coupled fixes (A regex / B flag / C dedupe) close the loop.

## Files changed

- `src/commands/shared/wake-resolve-impl.ts` — fix A: regex correction in name resolution path
- `src/commands/plugins/wake/index.ts` — fix B: `--no-attach` flag now correctly threaded
- `src/core/fleet/worktrees-scan.ts` — fix C: dedupe phantom worktrees defensively
- `src/commands/shared/wake-resolve-impl.test.ts` — new tests for fix A
- `src/commands/plugins/wake/wake.test.ts` — new tests for fix B
- `src/core/fleet/worktrees-scan.test.ts` — NEW file, tests for fix C
- `package.json` — calver bump (v26.4.29-alpha.12 → v26.4.29-alpha.13)

## Test results

Focused suite: `bun test src/commands/shared/wake-resolve-impl.test.ts src/commands/plugins/wake/wake.test.ts src/core/fleet/worktrees-scan.test.ts` → **22 pass / 0 fail / 48 expects**.

Pre-existing baseline failures from this branch (verified by impl-823 via stash-pop on 115070bb): `curl-fetch.test.ts` and `build-command-cwd.test.ts` — unrelated, not caused by this fix.

## CI flake overrides

Per #811/#813 precedent + #826/#827 precedent:
- `test-isolated`: `checkStalePeers` x2 (timeout-forwarded + default-timeout) + `local-first routing #411` — environmental
- `test-unit`: `federation — 2-port localhost /info + probe round-trip` — port-binding race, filed as #830 (file-disjoint from this PR's wake/worktree changes)

## Coverage

3 files modified + 3 test files (1 new). Files file-disjoint from #817 (plugin-bootstrap) and #818 (workflow YAML), so this completes the parallel-ship cycle without conflicts beyond package.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
