### PR TITLE
refactor(oracle-ls): use OracleManifest for cross-source visibility (Sub-PR 1 of #841)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.16",
+  "version": "26.4.29-alpha.17",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/plugins/oracle/impl-list.ts
+++ b/src/commands/plugins/oracle/impl-list.ts
@@ -2,9 +2,17 @@
  * maw oracle ls — cached grouped inventory enriched with source-lineage
  * and runtime awake state. Replaces the old awake-only list + fleet view.
  *
- * Reads the oracle registry cache (~/.config/maw/oracles.json) so it shows
- * ALL oracles the user has, not just the ones currently running in tmux.
- * Auto-bootstraps the cache on first use.
+ * Source of truth: `OracleManifest` (#838) — a unified read-only view that
+ * aggregates the 5 oracle registries (fleet windows, config.sessions,
+ * config.agents, oracles.json, worktree). Sub-PR 1 of #841.
+ *
+ * Why manifest > raw oracles.json: an oracle that lives only in `config.sessions`
+ * (e.g. just-budded, not yet filesystem-scanned) or only in fleet config (no
+ * local checkout) used to be invisible to `maw oracle ls`. Now they all show up.
+ *
+ * `oracles.json` cache is still read — it's the only source for `local_path`,
+ * `org`, `repo` (split form), and lineage timestamps. We auto-refresh the cache
+ * on stale/missing as before so first-run UX stays unchanged.
  *
  * Flags:
  *   --awake   filter to running tmux sessions only
@@ -23,6 +31,11 @@ import {
   loadConfig,
   type OracleEntry,
 } from "../../../sdk";
+import {
+  loadManifestCached,
+  invalidateManifest,
+  type OracleManifestEntry,
+} from "../../../lib/oracle-manifest";
 import { lineageOf, timeSince, type OracleLineage } from "./impl-helpers";
 import { resolveNickname } from "../../../core/fleet/nicknames";
 
@@ -40,6 +53,58 @@ interface EnrichedEntry {
   awake: boolean;
   session: string | null;
   lineage: OracleLineage;
+  /** Manifest-source labels — useful for future debugging / future flag. */
+  sources: string[];
+}
+
+/**
+ * Build a renderer-compatible `OracleEntry` from a manifest entry, layering
+ * any oracles.json metadata we already have on top. Manifest covers the
+ * "this oracle exists" fact; `cache.oracles` covers the org/repo/local_path
+ * detail (only registry that knows the filesystem path).
+ */
+function buildEntryFromManifest(
+  m: OracleManifestEntry,
+  cacheByName: Map<string, OracleEntry>,
+  fallbackNode: string | null,
+  detectedAt: string,
+): OracleEntry {
+  const cached = cacheByName.get(m.name);
+  if (cached) {
+    // oracles.json had this — preserve full metadata, but let manifest
+    // contribute a federation_node when oracles.json didn't carry one.
+    if (!cached.federation_node && m.node) {
+      return { ...cached, federation_node: m.node };
+    }
+    return cached;
+  }
+
+  // Manifest-only oracle (lives in fleet/sessions/agents but not oracles.json).
+  // Synthesize a minimal OracleEntry the renderer can format. Repo from
+  // manifest may be `org/repo` (fleet) or just `name-oracle` — handle both.
+  let org = "(unregistered)";
+  let repo = `${m.name}-oracle`;
+  if (m.repo) {
+    const slash = m.repo.indexOf("/");
+    if (slash > 0) {
+      org = m.repo.slice(0, slash);
+      repo = m.repo.slice(slash + 1);
+    } else {
+      repo = m.repo;
+    }
+  }
+  return {
+    org,
+    repo,
+    name: m.name,
+    local_path: m.localPath ?? "",
+    has_psi: m.hasPsi ?? false,
+    has_fleet_config: m.hasFleetConfig ?? false,
+    budded_from: m.buddedFrom ?? null,
+    budded_at: m.buddedAt ?? null,
+    federation_node: m.node ?? fallbackNode,
+    detected_at: detectedAt,
+  };
 }
 
 export async function cmdOracleList(opts: OracleListOpts = {}) {
@@ -59,10 +124,13 @@ export async function cmdOracleList(opts: OracleListOpts = {}) {
       );
     }
     cache = scanAndCache("local");
+    // The cache changed under us — drop any stale manifest TTL view so we
+    // reflect the freshly-scanned oracles.json contribution.
+    invalidateManifest();
   }
 
   // 2. Live tmux snapshot — used for awake state + surfacing just-budded
-  //    oracles that haven't landed in the cache yet.
+  //    oracles that haven't landed in the manifest's filesystem sources.
   const sessions = await listSessions().catch(() => []);
   const awakeByName = new Map<string, string>(); // name → session
   for (const s of sessions) {
@@ -74,12 +142,32 @@ export async function cmdOracleList(opts: OracleListOpts = {}) {
     }
   }
 
-  // 3. Merge in tmux-only oracles (just budded, not yet in cache)
-  const entries: OracleEntry[] = [...cache!.oracles];
-  const entryNames = new Set(entries.map((e) => e.name));
+  // 3. Aggregate via OracleManifest — single source of "what oracles exist"
+  //    spanning fleet/sessions/agents/oracles-json. Replaces the old direct
+  //    `cache.oracles` enumeration (which missed sessions/agents-only entries).
+  const manifest = loadManifestCached();
+  const cacheByName = new Map<string, OracleEntry>(
+    (cache?.oracles ?? []).map((e) => [e.name, e]),
+  );
   const now = new Date().toISOString();
+
+  // Build entries from manifest (cross-source visibility).
+  const manifestNames = new Set<string>();
+  const entries: OracleEntry[] = [];
+  const sourcesByName = new Map<string, string[]>();
+  for (const m of manifest) {
+    manifestNames.add(m.name);
+    sourcesByName.set(m.name, [...m.sources]);
+    entries.push(
+      buildEntryFromManifest(m, cacheByName, config.node || null, now),
+    );
+  }
+
+  // Edge case: tmux has an oracle window the manifest doesn't know about
+  // (e.g., a stray window with no fleet/session/agent/oracles-json record).
+  // Surface it so the operator can see it. Tag source as "tmux" for clarity.
   for (const [name] of awakeByName) {
-    if (!entryNames.has(name)) {
+    if (!manifestNames.has(name)) {
       entries.push({
         org: "(unregistered)",
         repo: `${name}-oracle`,
@@ -92,6 +180,7 @@ export async function cmdOracleList(opts: OracleListOpts = {}) {
         federation_node: config.node || null,
         detected_at: now,
       });
+      sourcesByName.set(name, ["tmux"]);
     }
   }
 
@@ -108,6 +197,7 @@ export async function cmdOracleList(opts: OracleListOpts = {}) {
       awake,
       session,
       lineage: lineageOf(entry, awake, agents),
+      sources: sourcesByName.get(entry.name) ?? [],
     };
   });
 
@@ -135,6 +225,9 @@ export async function cmdOracleList(opts: OracleListOpts = {}) {
         awake: x.awake,
         session: x.session,
         lineage: x.lineage,
+        // Manifest source labels — helps consumers see why this oracle
+        // shows up (fleet/session/agent/oracles-json/tmux).
+        sources: x.sources,
       })),
     };
     console.log(JSON.stringify(out, null, 2));

--- a/test/isolated/oracle-ls-manifest.test.ts
+++ b/test/isolated/oracle-ls-manifest.test.ts
@@ -1,0 +1,261 @@
+/**
+ * oracle-ls-manifest.test.ts — sub-PR 1 of #841.
+ *
+ * Verifies that `maw oracle ls` (cmdOracleList) now sources its entries from
+ * `OracleManifest` (#838) and therefore surfaces oracles that exist only in
+ * non-`oracles.json` registries: fleet windows, config.sessions, config.agents.
+ *
+ * Pre-#841 behavior: ls iterated `cache.oracles` (oracles.json) only and
+ * augmented with tmux-awake names. Anything that existed only in
+ * `config.sessions` (just-budded, not yet filesystem-scanned) or only in fleet
+ * windows (registered for routing but no local checkout) was invisible.
+ *
+ * Isolated subprocess because we mutate `process.env.MAW_CONFIG_DIR` BEFORE
+ * importing the target module — `core/paths.ts` captures CONFIG_DIR at
+ * module-load time. Mirrors the pattern from oracle-manifest.test.ts (#836).
+ */
+import { describe, test, expect, beforeEach, afterAll, mock } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+// ─── Pin CONFIG_DIR + FLEET_DIR to a sandboxed tmp dir BEFORE imports ───────
+const TEST_CONFIG_DIR = mkdtempSync(join(tmpdir(), "maw-oracle-ls-841-"));
+const TEST_FLEET_DIR = join(TEST_CONFIG_DIR, "fleet");
+mkdirSync(TEST_FLEET_DIR, { recursive: true });
+
+process.env.MAW_CONFIG_DIR = TEST_CONFIG_DIR;
+delete process.env.MAW_HOME;
+process.env.MAW_TEST_MODE = "1";
+
+// Mock tmux barrel BEFORE importing the impl — so any code path that hits
+// `listSessions()` returns our controlled value rather than spawning real tmux.
+let tmuxSessions: Array<{ name: string; windows: Array<{ index: number; name: string; active: boolean }> }> = [];
+mock.module("../../src/core/transport/tmux", () => {
+  const impl = {
+    async listAll() { return tmuxSessions; },
+    async listSessions() { return tmuxSessions; },
+    async hasSession(name: string) { return tmuxSessions.some(s => s.name === name); },
+  };
+  return {
+    tmux: impl,
+    Tmux: class { async listAll() { return tmuxSessions; } async listSessions() { return tmuxSessions; } async hasSession(n: string) { return tmuxSessions.some(s => s.name === n); } },
+    tmuxCmd: async () => ({ stdout: "", stderr: "", exitCode: 0 }),
+    resolveSocket: () => undefined,
+    withPaneLock: async (_id: string, fn: () => any) => fn(),
+    splitWindowLocked: async () => "",
+    tagPane: async () => {},
+    readPaneTags: async () => ({}),
+  };
+});
+
+// Skip the oracles.json auto-rescan path — the impl calls scanAndCache("local")
+// when the cache is missing/stale, which walks ghq root. We pre-write a fresh
+// oracles.json in each test (so isCacheStale → false) AND pass `stale: true`
+// to runLs so a stale read can't trigger a real filesystem walk either.
+
+// Late import after env + mocks are set.
+const impl = await import("../../src/commands/plugins/oracle/impl-list");
+const config = await import("../../src/config");
+const manifest = await import("../../src/lib/oracle-manifest");
+
+const CONFIG_FILE = join(TEST_CONFIG_DIR, "maw.config.json");
+const ORACLES_JSON = join(TEST_CONFIG_DIR, "oracles.json");
+
+afterAll(() => {
+  rmSync(TEST_CONFIG_DIR, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  for (const f of [CONFIG_FILE, ORACLES_JSON]) {
+    try { rmSync(f, { force: true }); } catch { /* ok */ }
+  }
+  try {
+    rmSync(TEST_FLEET_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_FLEET_DIR, { recursive: true });
+  } catch { /* best-effort */ }
+  config.resetConfig();
+  manifest.invalidateManifest();
+  tmuxSessions = [];
+});
+
+// ─── Fixture builders ────────────────────────────────────────────────────────
+
+function writeFleetWindow(file: string, sessionName: string, windows: Array<{ name: string; repo?: string }>) {
+  writeFileSync(
+    join(TEST_FLEET_DIR, file),
+    JSON.stringify({ name: sessionName, windows }, null, 2) + "\n",
+    "utf-8",
+  );
+}
+
+function writeConfig(patch: Record<string, unknown>) {
+  writeFileSync(CONFIG_FILE, JSON.stringify(patch, null, 2) + "\n", "utf-8");
+  config.resetConfig();
+}
+
+function writeOraclesJson(oracles: any[]) {
+  writeFileSync(
+    ORACLES_JSON,
+    JSON.stringify(
+      {
+        schema: 1,
+        // Fresh timestamp so isCacheStale → false, no auto-rescan.
+        local_scanned_at: new Date().toISOString(),
+        ghq_root: "/tmp/ghq-fixture",
+        oracles,
+      },
+      null,
+      2,
+    ) + "\n",
+    "utf-8",
+  );
+}
+
+// ─── stdout capture ──────────────────────────────────────────────────────────
+
+async function runLs(opts: Parameters<typeof impl.cmdOracleList>[0] = {}): Promise<string> {
+  const lines: string[] = [];
+  const orig = console.log;
+  console.log = (...a: any[]) => { lines.push(a.map(String).join(" ")); };
+  try {
+    await impl.cmdOracleList(opts);
+  } finally {
+    console.log = orig;
+  }
+  return lines.join("\n");
+}
+
+async function runLsJson(opts: Parameters<typeof impl.cmdOracleList>[0] = {}): Promise<any> {
+  const out = await runLs({ ...opts, json: true, stale: true });
+  return JSON.parse(out);
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("cmdOracleList — manifest-backed cross-source visibility (#841)", () => {
+  test("oracles.json-only entry still appears (regression guard)", async () => {
+    writeOraclesJson([
+      {
+        org: "Soul-Brews-Studio",
+        repo: "alpha-fs-oracle",
+        name: "alpha-fs",
+        local_path: "/tmp/alpha-fs-oracle",
+        has_psi: true,
+        has_fleet_config: false,
+        budded_from: null,
+        budded_at: null,
+        federation_node: null,
+        detected_at: new Date().toISOString(),
+      },
+    ]);
+    const result = await runLsJson();
+    const names = result.oracles.map((o: any) => o.name);
+    expect(names).toContain("alpha-fs");
+  });
+
+  test("fleet-only oracle (NOT in oracles.json) appears via manifest", async () => {
+    // Empty oracles.json — fleet is the only registry that knows about
+    // `fleet-only`. Pre-#841 this oracle was invisible to ls.
+    writeOraclesJson([]);
+    writeFleetWindow("100-fleet-only.json", "fleet-only-session", [
+      { name: "fleet-only-oracle", repo: "Soul-Brews-Studio/fleet-only-oracle" },
+    ]);
+
+    const result = await runLsJson();
+    const names = result.oracles.map((o: any) => o.name);
+    expect(names).toContain("fleet-only");
+
+    const entry = result.oracles.find((o: any) => o.name === "fleet-only");
+    expect(entry).toBeDefined();
+    expect(entry.org).toBe("Soul-Brews-Studio");
+    expect(entry.repo).toBe("fleet-only-oracle");
+    // Manifest sources should reflect fleet contribution.
+    expect(entry.sources).toContain("fleet");
+  });
+
+  test("config.sessions-only oracle (just-budded) appears via manifest", async () => {
+    // Empty oracles.json + no fleet — sessions is the only signal.
+    writeOraclesJson([]);
+    writeConfig({ sessions: { "just-budded": "uuid-jb-1" } });
+
+    const result = await runLsJson();
+    const names = result.oracles.map((o: any) => o.name);
+    expect(names).toContain("just-budded");
+
+    const entry = result.oracles.find((o: any) => o.name === "just-budded");
+    expect(entry.sources).toContain("session");
+  });
+
+  test("config.agents-only oracle (federation-known, no local) appears via manifest", async () => {
+    writeOraclesJson([]);
+    writeConfig({ agents: { "remote-pal": "mba" } });
+
+    const result = await runLsJson();
+    const names = result.oracles.map((o: any) => o.name);
+    expect(names).toContain("remote-pal");
+
+    const entry = result.oracles.find((o: any) => o.name === "remote-pal");
+    // federation_node should be derived from the agent map via manifest.
+    expect(entry.federation_node).toBe("mba");
+    expect(entry.sources).toContain("agent");
+  });
+
+  test("oracles.json + fleet entry merges into ONE row (no dupes)", async () => {
+    writeOraclesJson([
+      {
+        org: "Soul-Brews-Studio",
+        repo: "merged-oracle",
+        name: "merged",
+        local_path: "/tmp/merged-oracle",
+        has_psi: true,
+        has_fleet_config: true,
+        budded_from: "neo",
+        budded_at: "2026-04-01T00:00:00Z",
+        federation_node: null,
+        detected_at: new Date().toISOString(),
+      },
+    ]);
+    writeFleetWindow("110-merged.json", "merged-session", [
+      { name: "merged-oracle", repo: "Soul-Brews-Studio/merged-oracle" },
+    ]);
+
+    const result = await runLsJson();
+    const matches = result.oracles.filter((o: any) => o.name === "merged");
+    expect(matches).toHaveLength(1);
+    const entry = matches[0];
+    // local_path should still come from oracles.json (only registry with paths).
+    expect(entry.local_path).toBe("/tmp/merged-oracle");
+    // Source labels reflect both contributors.
+    expect(entry.sources).toContain("fleet");
+    expect(entry.sources).toContain("oracles-json");
+  });
+
+  test("totals reflect manifest union, not just oracles.json", async () => {
+    writeOraclesJson([
+      {
+        org: "Soul-Brews-Studio",
+        repo: "alpha-oracle",
+        name: "alpha",
+        local_path: "/tmp/alpha",
+        has_psi: true,
+        has_fleet_config: false,
+        budded_from: null,
+        budded_at: null,
+        federation_node: null,
+        detected_at: new Date().toISOString(),
+      },
+    ]);
+    // Plus a fleet-only oracle the cache doesn't know about.
+    writeFleetWindow("120-bravo.json", "bravo-session", [
+      { name: "bravo-oracle", repo: "Soul-Brews-Studio/bravo-oracle" },
+    ]);
+    // Plus a sessions-only oracle.
+    writeConfig({ sessions: { charlie: "uuid-c-1" } });
+
+    const result = await runLsJson();
+    expect(result.total).toBe(3);
+    const names = result.oracles.map((o: any) => o.name).sort();
+    expect(names).toEqual(["alpha", "bravo", "charlie"]);
+  });
+});


### PR DESCRIPTION
## Summary

First of 5 sub-PRs migrating consumers to `OracleManifest` (#838). This one
switches `maw oracle ls` to drive its listing from the manifest instead of
iterating `oracles.json` directly.

## Why

`OracleManifest` (shipped in #838) already aggregates the 5 oracle registries
into one read-only view: fleet windows, `config.sessions`, `config.agents`,
`oracles.json`, and (deferred) worktree scan. But every consumer still reads
from individual sources, so an oracle that exists in only one registry can
remain invisible to `ls`. Concretely:

- A just-budded oracle present in `config.sessions` but not yet
  filesystem-scanned was missing from `ls`.
- A federation peer present only in `config.agents` (no local checkout) was
  missing from `ls`.
- A fleet-registered oracle without a checkout (e.g. routed-only) was
  missing until `oracles.json` caught up.

Manifest-backed enumeration fixes all three with no operator action.

## What changed

`src/commands/plugins/oracle/impl-list.ts`:

- Source of "what oracles exist" is now `loadManifestCached()` — the union
  across fleet/sessions/agents/oracles.json.
- For each manifest entry we synthesise a renderer-compatible `OracleEntry`,
  preferring `oracles.json` metadata when present (it's the only registry
  that knows `local_path`/`org`/`repo` split) and falling back to manifest
  fields (`m.repo`, `m.localPath`, `m.node`, lineage) when the cache is
  cold for that name.
- `oracles.json` is still auto-refreshed on missing/stale (unless `--stale`).
  After a refresh we call `invalidateManifest()` so the manifest TTL view
  picks up the freshly-scanned cache contribution on the same call.
- Stray tmux windows whose oracle name appears in NO registry still surface
  with a synthetic `(unregistered)` row, tagged `sources: ["tmux"]`.
- JSON output gains an additive `sources: string[]` field per entry. No
  existing fields removed.

## Behavior preserved

- Renderer (icon mapping, lineage note, group-by-org sort) is identical.
- `--awake`, `--org`, `--scan`, `--stale`, `--path`, `--json` flags behave
  the same as before.
- Cache-stale messaging unchanged.

## Tests

- `test/isolated/oracle-ls-manifest.test.ts` (new, 6 tests, all passing):
  verifies regression guard for `oracles.json`-only entries; confirms
  fleet-only, sessions-only, and agents-only oracles now appear in `ls`;
  asserts merging into a single row when multiple registries name the same
  oracle; asserts `total` reflects manifest union.
- `test/isolated/oracle-manifest.test.ts` (#838) — still passes (untouched).

## Out of scope (later sub-PRs)

- `maw doctor` cross-source consistency (sub-PR 2)
- federation routing manifest lookup (sub-PR 3)
- `shouldAutoWake` manifest input (sub-PR 4)
- async worktree-scan loader (sub-PR 5)

## Refs

Closes-checkbox #841 (item 1).
Builds on #838 (manifest), #835 (shouldAutoWake), #736 Phase 2.

## Checklist (#841)

- [x] **`maw oracle ls`** — read from manifest instead of `oracles.json`
  directly (cross-source visibility) ← this PR
- [ ] federation routing
- [ ] `maw doctor`
- [ ] `shouldAutoWake()` manifest integration
- [ ] worktree scan async loader

## Test plan

- [x] `bun test test/isolated/oracle-ls-manifest.test.ts` — 6/6 pass
- [x] `bun test test/isolated/oracle-manifest.test.ts` — 22/22 pass (unchanged)
- [x] `bun tsc --noEmit` — no new errors on touched files
- [ ] manual smoke: `maw oracle ls` on a fleet with a sessions-only oracle