### PR TITLE
fix(security): close 3 ReDoS alerts (normalize-target/soul-sync/triggers-engine)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.16",
+  "version": "26.4.29-alpha.17",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/plugins/soul-sync/impl.ts
+++ b/src/commands/plugins/soul-sync/impl.ts
@@ -28,7 +28,10 @@ export async function cmdSoulSync(target?: string, opts?: { from?: boolean; cwd?
 
   const cwdParts = cwd.split("/");
   const repoName = cwdParts.pop() || "";
-  const oracleName = repoName.replace(/-oracle$/, "").replace(/\.wt-.*$/, "");
+  // Strip `.wt-…` worktree suffix via indexOf — non-regex to avoid CodeQL polynomial-redos flag.
+  const wtIdx = repoName.indexOf(".wt-");
+  const baseRepo = wtIdx >= 0 ? repoName.slice(0, wtIdx) : repoName;
+  const oracleName = baseRepo.replace(/-oracle$/, "");
 
   let oraclePath = cwd;
   try {

--- a/src/core/matcher/normalize-target.ts
+++ b/src/core/matcher/normalize-target.ts
@@ -43,8 +43,8 @@ export function normalizeTarget(raw: string): string {
   let prev: string;
   do {
     prev = s;
-    // trailing slashes (one or many)
-    s = s.replace(/\/+$/, "");
+    // trailing slashes (one or many) — non-regex to avoid CodeQL polynomial-redos flag
+    while (s.endsWith("/")) s = s.slice(0, -1);
     // trailing `.git` once the slashes are gone
     if (s.endsWith("/.git")) s = s.slice(0, -"/.git".length);
   } while (s !== prev);

--- a/src/core/runtime/triggers-engine.ts
+++ b/src/core/runtime/triggers-engine.ts
@@ -43,7 +43,8 @@ function expandAction(action: string, event: TriggerEvent, ctx: TriggerContext):
   result = result.replace(/\{event\}/g, event);
   for (const [key, value] of Object.entries(ctx)) {
     if (value !== undefined) {
-      result = result.replace(new RegExp(`\\{${key}\\}`, "g"), value);
+      // Use split/join — no dynamic RegExp, so no ReDoS surface from arbitrary ctx keys.
+      result = result.split(`{${key}}`).join(value);
     }
   }
   return result;


### PR DESCRIPTION
## Summary

Close 3 pre-existing CodeQL `js/polynomial-redos` alerts (~30+ days old). All three replace polynomial regex with non-regex string operations — pattern proven on #823 last night.

| Alert | File | Severity | Fix |
|---|---|---|---|
| A | `src/core/matcher/normalize-target.ts:47` | HIGH | `/\/+$/` → `while (s.endsWith("/")) s = s.slice(0, -1)` |
| B | `src/commands/plugins/soul-sync/impl.ts:31` | HIGH | `/\.wt-.*$/` → `indexOf(".wt-")` + slice |
| C | `src/core/runtime/triggers-engine.ts:46` | MEDIUM | dynamic `new RegExp(...)` → `result.split('{key}').join(value)` |

## Behavior preservation

- **A**: All 6 `normalize-target` tests pass (single trailing slash, multiple, `/.git`, `/.git/`, plain, empty).
- **B**: Same suffix-strip semantics — `repo.wt-foo` → `repo`. The original regex matched `.wt-` to end-of-string (`.*$`); `indexOf` + slice does the same.
- **C**: Template-variable expansion `{key}` is a literal substring, not a pattern — `split/join` is the natural primitive and removes any ReDoS surface from arbitrary `ctx` keys.

## Test plan

- [x] `bun build src/cli.ts` — clean
- [x] `bun test test/core/matcher/normalize-target.test.ts` — 6/6 pass
- [ ] CodeQL must re-scan and clear all 3 alerts
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)