### PR TITLE
refactor(shared): delete dead writeInboxMessage per #834 Tier 1 (partial)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.17",
+  "version": "26.4.29-alpha.18",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -1,5 +1,5 @@
 /**
- * comm-send.ts — cmdSend + resolveOraclePane + resolveMyName + writeInboxMessage.
+ * comm-send.ts — cmdSend + resolveOraclePane + resolveMyName.
  */
 
 import {
@@ -9,18 +9,6 @@ import {
 import { Tmux } from "../../core/transport/tmux";
 import { loadConfig, cfgLimit } from "../../config";
 import { logMessage, emitFeed } from "./comm-log-feed";
-import { writeInboxFile } from "../plugins/inbox/impl";
-
-/**
- * Write a message to an oracle's ψ/inbox/ directory.
- * peerRoot is the oracle's repo root (contains ψ/ dir).
- * Called from route-comm.ts when --inbox is passed to `maw hey`.
- */
-export function writeInboxMessage(peerRoot: string, from: string, to: string, body: string): string {
-  const { join } = require("path");
-  const inboxDir = join(peerRoot, "ψ", "inbox");
-  return writeInboxFile(inboxDir, from, to, body);
-}
 
 /**
  * Resolve a `session:window` target to a specific pane running an agent


### PR DESCRIPTION
Closes part of #834 — only the genuinely-dead `writeInboxMessage` helper.

## Audit correction

Tier 1 audit had a grep-scope flaw that misclassified 3 of 4 listed deletions as dead. Full reverification + recommended fix to the audit pipeline posted as comment on #834: https://github.com/Soul-Brews-Studio/maw-js/issues/834#issuecomment-4337614072

Summary of misclassifications (reframed as Tier 2 privatize candidates — symbols stay, drop `export`):
- `wake-resolve-scan-suggest.ts` (9 helpers, 108 LOC) — all used internally by `scanSuggestOracle`
- `agents.ts` (`buildAgentRows` + `AgentRow`, 33 LOC) — used by `cmdAgents` + `printTable`
- `wake-maybe-split.ts` (`probeTmuxServer`, 7 LOC) — used by `maybeSplit`

## Changes
- Delete `writeInboxMessage` (5 LOC fn + 1 LOC import line + module-doc mention).
- Net **−12 LOC** from `comm-send.ts`.
- 0 behavior change — function had zero callers in src/ or test/, doc-comment's claim that `route-comm.ts` uses it is stale.

## Acceptance
- ✅ `bun build src/cli.ts` clean
- ✅ Targeted comm-send tests: 12 pass
- ✅ Full `bun run test`: 1383 pass / 14 fail — all 14 are pre-existing baseline (curl-fetch, build-command-cwd) unrelated to this change. 0 new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)