### PR TITLE
feat(doctor): cross-source consistency via OracleManifest (Sub-PR 2 of #841)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.17",
+  "version": "26.4.29-alpha.18",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/plugins/doctor/cross-source-detect.ts
+++ b/src/commands/plugins/doctor/cross-source-detect.ts
@@ -1,0 +1,200 @@
+/**
+ * doctor/cross-source-detect.ts — Sub-PR 2 of #841.
+ *
+ * Cross-source consistency analysis over `OracleManifest` (#838). Unlike
+ * `peers/duplicate-detect.ts` (#810) which scans the peer cache for
+ * `<oracle>:<node>` collisions, this layer asks a different question:
+ *
+ *   "For each oracle the manifest knows about, do the 5 registries AGREE
+ *    enough that runtime paths (federation routing, awake state, fleet
+ *    bring-up) will work?"
+ *
+ * Underlying fact: `loadConfig()` already auto-merges fleet windows into
+ * `config.agents` at load time (src/config/fleet-merge.ts). So a fleet
+ * window without an `agent` source label is rare on a healthy box — but
+ * an `agent` entry without a backing fleet window IS common when
+ * operators hand-edit `maw.config.json` ahead of registering the fleet,
+ * or after deleting a fleet json without cleaning the agent map.
+ *
+ * Pure: takes a manifest snapshot, returns a list of warnings. No fs, no
+ * network. The doctor surface adapts findings into the existing
+ * `DoctorResult["checks"]` shape; tests can drive `findGaps()` directly.
+ *
+ * Severity philosophy
+ * ───────────────────
+ * Every gap is a WARNING, not a hard failure — operators legitimately keep
+ * registries partly aligned during migrations (e.g. budding a new oracle
+ * into `config.sessions` before its filesystem checkout exists). The
+ * doctor entry returns `ok:true` in all cases; the message body counts
+ * the gaps. Gating on `ok:false` here would force operators into
+ * `--allow-drift` for normal mid-migration states, defeating the purpose.
+ */
+
+import type { OracleManifestEntry } from "../../../lib/oracle-manifest";
+
+/** One inconsistency flagged across the 5 registries for a single oracle. */
+export interface CrossSourceGap {
+  /** Oracle short name. */
+  oracle: string;
+  /** Stable category — drives test assertions and message templating. */
+  kind:
+    | "agent-without-fleet"
+    | "session-without-fleet"
+    | "fleet-without-oracles-json"
+    | "oracles-json-without-runtime"
+    | "agent-mismatch-fleet-local";
+  /** Human-readable hint (one sentence). */
+  detail: string;
+}
+
+/**
+ * Walk the manifest and surface each gap pattern. Pure — feed it the
+ * output of `loadManifestCached()` (or a hand-built fixture in tests).
+ *
+ * Patterns flagged:
+ *
+ *   1. agent-without-fleet
+ *      `agent` source present, `fleet` absent, AND node === "local".
+ *      An operator-added entry pointing to local with no fleet window
+ *      backing it; `maw hey <name>` will think it's local but find no
+ *      tmux session to wake.
+ *
+ *   2. session-without-fleet
+ *      `session` source present, `fleet` absent, no `agent` either —
+ *      a budded oracle whose Claude session UUID was recorded but no
+ *      fleet window was ever registered. This is the "just-budded but
+ *      not yet wired" state; usually transient but worth surfacing.
+ *
+ *   3. fleet-without-oracles-json
+ *      `fleet` source present, `oracles-json` absent, AND no
+ *      `localPath`. Indicates the registry cache (`oracles.json`) is
+ *      stale relative to fleet; `maw oracle scan` will reconcile.
+ *
+ *   4. oracles-json-without-runtime
+ *      Only `oracles-json` source. Filesystem-discovered oracle that
+ *      no fleet/session/agent registry references. Either an orphan
+ *      checkout (clone exists, never wired up) or a stale cache entry
+ *      pointing at a deleted directory.
+ *
+ *   5. agent-mismatch-fleet-local
+ *      `fleet` AND `agent` both present, but `agent` says a remote
+ *      node while fleet implies "local". Federation routing will
+ *      prefer the agent value (#736 precedence), so a `maw hey` will
+ *      go remote even though there's a local fleet window — almost
+ *      certainly a misconfigured agents map after a node migration.
+ */
+export function findGaps(manifest: OracleManifestEntry[]): CrossSourceGap[] {
+  const gaps: CrossSourceGap[] = [];
+  for (const e of manifest) {
+    const has = (s: string) => e.sources.includes(s as OracleManifestEntry["sources"][number]);
+    const hasFleet = has("fleet");
+    const hasSession = has("session");
+    const hasAgent = has("agent");
+    const hasOraclesJson = has("oracles-json");
+
+    // 1. agent-without-fleet — operator-added agent map entry pointing
+    //    "local" but no fleet window to back it. Pure agent entries that
+    //    point to a remote node are a normal federation routing setup
+    //    (no fleet expected on the local box), so we only flag the
+    //    `local`-typed ones to avoid false positives.
+    if (hasAgent && !hasFleet && e.node === "local") {
+      gaps.push({
+        oracle: e.name,
+        kind: "agent-without-fleet",
+        detail:
+          `config.agents has '${e.name}' → 'local' but no fleet window registered — ` +
+          `'maw hey ${e.name}' will fail to wake. Run 'maw fleet --init-agents' or remove the entry.`,
+      });
+    }
+
+    // 2. session-without-fleet — Claude session UUID without fleet/agent
+    //    registration. Budded-but-not-wired state.
+    if (hasSession && !hasFleet && !hasAgent) {
+      gaps.push({
+        oracle: e.name,
+        kind: "session-without-fleet",
+        detail:
+          `config.sessions has '${e.name}' but no fleet window or agent route — ` +
+          `oracle is unreachable. Register a fleet window or remove the session.`,
+      });
+    }
+
+    // 3. fleet-without-oracles-json — fleet registered but registry
+    //    cache hasn't seen it (no oracles-json source AND no localPath).
+    //    Pure-fleet entries with localPath happen via routed-only setups
+    //    where the operator legitimately has no checkout — only flag
+    //    when there's no cache record AND the manifest didn't surface
+    //    a path from anywhere.
+    if (hasFleet && !hasOraclesJson && !e.localPath) {
+      gaps.push({
+        oracle: e.name,
+        kind: "fleet-without-oracles-json",
+        detail:
+          `fleet has '${e.name}' but oracles.json has no record and no local checkout known — ` +
+          `run 'maw oracle scan' to refresh.`,
+      });
+    }
+
+    // 4. oracles-json-without-runtime — filesystem-only oracle, no
+    //    fleet/session/agent. Orphan checkout or stale cache.
+    if (hasOraclesJson && !hasFleet && !hasSession && !hasAgent) {
+      gaps.push({
+        oracle: e.name,
+        kind: "oracles-json-without-runtime",
+        detail:
+          `oracles.json lists '${e.name}' but no fleet window, session, or agent route — ` +
+          `orphan checkout or stale cache. Wake it once or remove the directory.`,
+      });
+    }
+
+    // 5. agent-mismatch-fleet-local — both fleet and agent contributed,
+    //    but the resolved node is NOT "local". Federation will route
+    //    away from the local fleet window. We detect this by looking
+    //    for entries that have fleet AND a non-local node — fleet's
+    //    own contribution would have left node === "local".
+    if (hasFleet && hasAgent && e.node && e.node !== "local") {
+      gaps.push({
+        oracle: e.name,
+        kind: "agent-mismatch-fleet-local",
+        detail:
+          `fleet window for '${e.name}' is local but config.agents points at '${e.node}' — ` +
+          `federation will route away from local. Reconcile with 'maw fleet --init-agents' or fix the agent map.`,
+      });
+    }
+  }
+  // Stable order: by oracle name, then kind — keeps test assertions
+  // and human-readable diff output deterministic.
+  gaps.sort((a, b) =>
+    a.oracle === b.oracle ? a.kind.localeCompare(b.kind) : a.oracle.localeCompare(b.oracle),
+  );
+  return gaps;
+}
+
+/**
+ * Format one gap as a single-line warning suitable for `maw doctor` output.
+ * Caller wraps with color codes per its own log surface.
+ */
+export function formatGap(g: CrossSourceGap): string {
+  return `[${g.kind}] ${g.detail}`;
+}
+
+/**
+ * Aggregate all gaps into a single doctor message body. Returns a tuple of
+ * `(headline, lines)` so the doctor renderer can do one-line-per-gap output
+ * while still surfacing a compact `message` field on the check result.
+ */
+export function summarizeGaps(gaps: CrossSourceGap[]): { headline: string; lines: string[] } {
+  if (gaps.length === 0) {
+    return { headline: "no cross-source inconsistencies", lines: [] };
+  }
+  const byKind = new Map<string, number>();
+  for (const g of gaps) byKind.set(g.kind, (byKind.get(g.kind) ?? 0) + 1);
+  const breakdown = [...byKind.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, n]) => `${k}×${n}`)
+    .join(", ");
+  return {
+    headline: `${gaps.length} cross-source ${gaps.length === 1 ? "gap" : "gaps"} (${breakdown})`,
+    lines: gaps.map(formatGap),
+  };
+}

--- a/src/commands/plugins/doctor/impl.ts
+++ b/src/commands/plugins/doctor/impl.ts
@@ -5,6 +5,8 @@ import { join, dirname, resolve } from "path";
 import { loadPeers } from "../peers/store";
 import { findDuplicateIdentities, formatDuplicate } from "../peers/duplicate-detect";
 import { loadConfig } from "../../../config";
+import { loadManifestCached, invalidateManifest } from "../../../lib/oracle-manifest";
+import { findGaps, summarizeGaps } from "./cross-source-detect";
 
 const GREEN = "\x1b[32m";
 const RED = "\x1b[31m";
@@ -33,6 +35,9 @@ export async function cmdDoctor(args: string[] = []): Promise<DoctorResult> {
   }
   if (!only || only === "peers" || only === "all") {
     checks.push(checkPeerDuplicates());
+  }
+  if (!only || only === "manifest" || only === "all") {
+    checks.push(checkCrossSourceConsistency());
   }
 
   const hardOk = checks.every(c => c.ok);
@@ -215,6 +220,48 @@ function checkPeerDuplicates(): DoctorResult["checks"][number] {
     name: "peers:duplicates",
     ok: false,
     message: dups.map(formatDuplicate).join("; "),
+  };
+}
+
+/**
+ * Cross-source consistency via OracleManifest (Sub-PR 2 of #841).
+ *
+ * Loads the unified manifest (#838 — fleet, sessions, agents, oracles.json)
+ * and runs `findGaps()` over it to surface inconsistencies between the
+ * registries. All gaps are warnings, never hard failures: operators
+ * legitimately keep registries partly aligned during migrations, so
+ * gating exit codes on these would force `--allow-drift` for normal
+ * mid-flight states. Surface as `ok:true` with a message body that
+ * counts the gaps and breaks them down by kind; the per-gap detail
+ * lines are written to console for human inspection.
+ *
+ * Uses `loadManifestCached()` so this check shares the in-process
+ * manifest with any other consumer running in the same `maw doctor`
+ * invocation. We invalidate first to avoid serving a stale view if
+ * `loadConfig`-touching work happened earlier in the same process.
+ */
+function checkCrossSourceConsistency(): DoctorResult["checks"][number] {
+  let gaps: ReturnType<typeof findGaps>;
+  try {
+    invalidateManifest();
+    const manifest = loadManifestCached();
+    gaps = findGaps(manifest);
+  } catch (e: any) {
+    return {
+      name: "manifest:cross-source",
+      ok: true,
+      message: `manifest unreadable (${e?.message || e}) — skipping cross-source check`,
+    };
+  }
+
+  const { headline, lines } = summarizeGaps(gaps);
+  for (const line of lines) {
+    console.log(`    ${YELLOW}⚠${RESET} ${line}`);
+  }
+  return {
+    name: "manifest:cross-source",
+    ok: true,
+    message: headline,
   };
 }
 

--- a/test/isolated/doctor-cross-source.test.ts
+++ b/test/isolated/doctor-cross-source.test.ts
@@ -1,0 +1,335 @@
+/**
+ * doctor-cross-source.test.ts — Sub-PR 2 of #841.
+ *
+ * Verifies `findGaps()` (cross-source consistency analyzer over
+ * `OracleManifest`) plus the `manifest:cross-source` doctor check:
+ *
+ *   1. Each gap pattern fires once for the matching fixture
+ *   2. Empty manifest produces no warnings (no false positives)
+ *   3. All-sources-aligned manifest produces no warnings
+ *   4. Doctor surface integrates the result as a non-failing warning
+ *      check (ok:true, message body summarizes gaps)
+ *
+ * `findGaps()` is pure — most tests drive it with hand-built
+ * `OracleManifestEntry[]` fixtures, sidestepping the filesystem entirely.
+ * The doctor-integration test uses the same isolated-tmpdir pattern as
+ * `oracle-manifest.test.ts` because `cmdDoctor` reads CONFIG_DIR /
+ * FLEET_DIR through the manifest.
+ */
+import { describe, test, expect, beforeEach, afterAll } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+// ─── Pure tests for findGaps() — no env mutation needed ──────────────────────
+
+import {
+  findGaps,
+  summarizeGaps,
+  formatGap,
+  type CrossSourceGap,
+} from "../../src/commands/plugins/doctor/cross-source-detect";
+import type { OracleManifestEntry } from "../../src/lib/oracle-manifest";
+
+function entry(o: Partial<OracleManifestEntry> & { name: string; sources: OracleManifestEntry["sources"] }): OracleManifestEntry {
+  return {
+    isLive: false,
+    ...o,
+  } as OracleManifestEntry;
+}
+
+describe("findGaps — empty / aligned manifests produce no warnings", () => {
+  test("empty manifest → no gaps", () => {
+    expect(findGaps([])).toEqual([]);
+  });
+
+  test("fully aligned oracle (fleet+session+agent+oracles-json, node=local) → no gaps", () => {
+    const m = [
+      entry({
+        name: "neo",
+        sources: ["fleet", "session", "agent", "oracles-json"],
+        node: "local",
+        session: "neo",
+        window: "neo-oracle",
+        sessionId: "uuid-1",
+        repo: "Soul-Brews-Studio/neo-oracle",
+        localPath: "/tmp/neo-oracle",
+        hasFleetConfig: true,
+        hasPsi: true,
+      }),
+    ];
+    expect(findGaps(m)).toEqual([]);
+  });
+
+  test("aligned remote oracle (agent only, remote node) → no gaps (federation routing target)", () => {
+    // Pure agent → remote node is a normal federation routing setup;
+    // we don't expect a fleet window for an oracle that lives on another box.
+    const m = [
+      entry({ name: "homekeeper", sources: ["agent"], node: "mba" }),
+    ];
+    expect(findGaps(m)).toEqual([]);
+  });
+});
+
+describe("findGaps — each gap pattern fires for its matching fixture", () => {
+  test("agent-without-fleet: agent→local with no fleet source", () => {
+    const gaps = findGaps([
+      entry({ name: "stray", sources: ["agent"], node: "local" }),
+    ]);
+    expect(gaps).toHaveLength(1);
+    expect(gaps[0].kind).toBe("agent-without-fleet");
+    expect(gaps[0].oracle).toBe("stray");
+    expect(gaps[0].detail).toContain("config.agents");
+    expect(gaps[0].detail).toContain("'maw hey stray'");
+  });
+
+  test("session-without-fleet: only session source, no fleet/agent", () => {
+    const gaps = findGaps([
+      entry({ name: "just-budded", sources: ["session"], sessionId: "uuid-jb" }),
+    ]);
+    expect(gaps).toHaveLength(1);
+    expect(gaps[0].kind).toBe("session-without-fleet");
+    expect(gaps[0].oracle).toBe("just-budded");
+  });
+
+  test("fleet-without-oracles-json: fleet source, no oracles-json, no localPath", () => {
+    const gaps = findGaps([
+      entry({
+        name: "fleet-only",
+        sources: ["fleet", "agent"], // fleet pre-populates agent at loadConfig time
+        node: "local",
+        session: "fleet-only",
+        window: "fleet-only-oracle",
+        hasFleetConfig: true,
+      }),
+    ]);
+    // Should produce exactly the fleet-without-oracles-json gap
+    const kinds = gaps.map((g) => g.kind);
+    expect(kinds).toContain("fleet-without-oracles-json");
+    // It should NOT also produce agent-without-fleet (fleet IS present)
+    expect(kinds).not.toContain("agent-without-fleet");
+  });
+
+  test("oracles-json-without-runtime: only oracles-json, no fleet/session/agent", () => {
+    const gaps = findGaps([
+      entry({
+        name: "orphan",
+        sources: ["oracles-json"],
+        repo: "Soul-Brews-Studio/orphan-oracle",
+        localPath: "/tmp/orphan",
+        hasPsi: true,
+      }),
+    ]);
+    expect(gaps).toHaveLength(1);
+    expect(gaps[0].kind).toBe("oracles-json-without-runtime");
+    expect(gaps[0].oracle).toBe("orphan");
+    expect(gaps[0].detail).toContain("orphan");
+  });
+
+  test("agent-mismatch-fleet-local: fleet+agent both, but resolved node is remote", () => {
+    const gaps = findGaps([
+      entry({
+        name: "mismatched",
+        sources: ["fleet", "agent"],
+        node: "mba", // agent overrode fleet's "local" — operator drift
+        session: "mismatched",
+        window: "mismatched-oracle",
+        hasFleetConfig: true,
+      }),
+    ]);
+    const kinds = gaps.map((g) => g.kind);
+    expect(kinds).toContain("agent-mismatch-fleet-local");
+  });
+});
+
+describe("findGaps — combinations and ordering", () => {
+  test("multiple gaps for different oracles all surface", () => {
+    const gaps = findGaps([
+      entry({ name: "stray", sources: ["agent"], node: "local" }),
+      entry({ name: "just-budded", sources: ["session"], sessionId: "u" }),
+      entry({ name: "orphan", sources: ["oracles-json"], localPath: "/p", hasPsi: true }),
+    ]);
+    expect(gaps).toHaveLength(3);
+    const oracles = gaps.map((g) => g.oracle);
+    expect(oracles).toEqual(["just-budded", "orphan", "stray"]); // alphabetical
+  });
+
+  test("does not flag agent-without-fleet when node is remote (federation peer)", () => {
+    const gaps = findGaps([
+      entry({ name: "remote-pal", sources: ["agent"], node: "mba" }),
+    ]);
+    expect(gaps).toEqual([]);
+  });
+
+  test("does not flag fleet-without-oracles-json when localPath is known", () => {
+    // Routed-only setup: fleet has the window AND localPath got surfaced
+    // from the manifest (e.g. via worktree fallback in a future sub-PR).
+    const gaps = findGaps([
+      entry({
+        name: "routed",
+        sources: ["fleet", "agent"],
+        node: "local",
+        localPath: "/tmp/routed",
+        hasFleetConfig: true,
+      }),
+    ]);
+    expect(gaps).toEqual([]);
+  });
+
+  test("ordering: same oracle multiple gaps → kind alphabetical", () => {
+    // We can't trivially get two gaps for one oracle through the live
+    // patterns (they're mostly mutually exclusive), but the sort
+    // contract holds — verify with a constructed pair via two oracles
+    // sharing a name pattern.
+    const gaps = findGaps([
+      entry({ name: "z-last", sources: ["session"], sessionId: "u" }),
+      entry({ name: "a-first", sources: ["agent"], node: "local" }),
+    ]);
+    expect(gaps[0].oracle).toBe("a-first");
+    expect(gaps[1].oracle).toBe("z-last");
+  });
+});
+
+describe("summarizeGaps + formatGap", () => {
+  test("empty gaps → headline 'no cross-source inconsistencies'", () => {
+    const s = summarizeGaps([]);
+    expect(s.headline).toBe("no cross-source inconsistencies");
+    expect(s.lines).toEqual([]);
+  });
+
+  test("single gap → headline counts 1, breakdown shows kind", () => {
+    const gaps: CrossSourceGap[] = [
+      { oracle: "x", kind: "agent-without-fleet", detail: "..." },
+    ];
+    const s = summarizeGaps(gaps);
+    expect(s.headline).toContain("1 cross-source gap");
+    expect(s.headline).toContain("agent-without-fleet×1");
+    expect(s.lines).toHaveLength(1);
+  });
+
+  test("multiple gaps of mixed kinds → breakdown groups by kind", () => {
+    const gaps: CrossSourceGap[] = [
+      { oracle: "a", kind: "agent-without-fleet", detail: "..." },
+      { oracle: "b", kind: "agent-without-fleet", detail: "..." },
+      { oracle: "c", kind: "session-without-fleet", detail: "..." },
+    ];
+    const s = summarizeGaps(gaps);
+    expect(s.headline).toContain("3 cross-source gaps");
+    expect(s.headline).toContain("agent-without-fleet×2");
+    expect(s.headline).toContain("session-without-fleet×1");
+  });
+
+  test("formatGap → '[kind] detail'", () => {
+    const out = formatGap({ oracle: "x", kind: "agent-without-fleet", detail: "hello" });
+    expect(out).toBe("[agent-without-fleet] hello");
+  });
+});
+
+// ─── Doctor integration — uses an isolated CONFIG_DIR/FLEET_DIR ──────────────
+
+const TEST_CONFIG_DIR = mkdtempSync(join(tmpdir(), "maw-doctor-cross-841-"));
+const TEST_FLEET_DIR = join(TEST_CONFIG_DIR, "fleet");
+mkdirSync(TEST_FLEET_DIR, { recursive: true });
+
+process.env.MAW_CONFIG_DIR = TEST_CONFIG_DIR;
+delete process.env.MAW_HOME;
+process.env.MAW_TEST_MODE = "1";
+
+const manifestModule = await import("../../src/lib/oracle-manifest");
+const configModule = await import("../../src/config");
+const { cmdDoctor } = await import("../../src/commands/plugins/doctor/impl");
+
+const CONFIG_FILE = join(TEST_CONFIG_DIR, "maw.config.json");
+const ORACLES_JSON = join(TEST_CONFIG_DIR, "oracles.json");
+
+afterAll(() => {
+  rmSync(TEST_CONFIG_DIR, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  for (const f of [CONFIG_FILE, ORACLES_JSON]) {
+    try { rmSync(f, { force: true }); } catch { /* ok */ }
+  }
+  try {
+    rmSync(TEST_FLEET_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_FLEET_DIR, { recursive: true });
+  } catch { /* best-effort */ }
+  configModule.resetConfig();
+  manifestModule.invalidateManifest();
+});
+
+function writeFleetWindow(file: string, sessionName: string, windows: Array<{ name: string; repo?: string }>) {
+  writeFileSync(
+    join(TEST_FLEET_DIR, file),
+    JSON.stringify({ name: sessionName, windows }, null, 2) + "\n",
+    "utf-8",
+  );
+}
+
+function writeConfig(patch: Record<string, unknown>) {
+  writeFileSync(CONFIG_FILE, JSON.stringify(patch, null, 2) + "\n", "utf-8");
+  configModule.resetConfig();
+}
+
+const origLog = console.log;
+async function runOnly<T>(fn: () => Promise<T>): Promise<T> {
+  console.log = () => {};
+  try { return await fn(); }
+  finally { console.log = origLog; }
+}
+
+describe("cmdDoctor 'manifest' check — integration", () => {
+  test("empty manifest → ok:true, message 'no cross-source inconsistencies'", async () => {
+    const out = await runOnly(() => cmdDoctor(["manifest"]));
+    const c = out.checks.find((x) => x.name === "manifest:cross-source")!;
+    expect(c).toBeDefined();
+    expect(c.ok).toBe(true);
+    expect(c.message).toBe("no cross-source inconsistencies");
+  });
+
+  test("session-only oracle → ok:true with session-without-fleet headline", async () => {
+    writeConfig({ sessions: { "just-budded": "uuid-jb-1" } });
+    const out = await runOnly(() => cmdDoctor(["manifest"]));
+    const c = out.checks.find((x) => x.name === "manifest:cross-source")!;
+    // Always ok:true — gaps are warnings, not failures.
+    expect(c.ok).toBe(true);
+    expect(c.message).toContain("1 cross-source gap");
+    expect(c.message).toContain("session-without-fleet");
+  });
+
+  test("agent-only with node=local → flags agent-without-fleet", async () => {
+    writeConfig({ agents: { stray: "local" } });
+    const out = await runOnly(() => cmdDoctor(["manifest"]));
+    const c = out.checks.find((x) => x.name === "manifest:cross-source")!;
+    expect(c.ok).toBe(true);
+    expect(c.message).toContain("agent-without-fleet");
+  });
+
+  test("fleet window present + no oracles.json → flags fleet-without-oracles-json", async () => {
+    writeFleetWindow("100-fleet.json", "fleet-only", [
+      { name: "fleet-only-oracle", repo: "Soul-Brews-Studio/fleet-only-oracle" },
+    ]);
+    const out = await runOnly(() => cmdDoctor(["manifest"]));
+    const c = out.checks.find((x) => x.name === "manifest:cross-source")!;
+    expect(c.ok).toBe(true);
+    expect(c.message).toContain("fleet-without-oracles-json");
+  });
+
+  test("doctor 'all' includes manifest:cross-source check", async () => {
+    const out = await runOnly(() => cmdDoctor(["all"]));
+    expect(out.checks.map((c) => c.name)).toContain("manifest:cross-source");
+  });
+
+  test("default args (no positional) include manifest:cross-source check", async () => {
+    const out = await runOnly(() => cmdDoctor([]));
+    expect(out.checks.map((c) => c.name)).toContain("manifest:cross-source");
+  });
+
+  test("manifest gap does NOT flip overall doctor result to failed", async () => {
+    // session-only oracle is a warning (not blocking) — overall doctor
+    // ok flag should still reflect only HARD failures from other checks.
+    writeConfig({ sessions: { ghost: "uuid-ghost" } });
+    const out = await runOnly(() => cmdDoctor(["manifest"]));
+    expect(out.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Second of 5 sub-PRs migrating consumers to `OracleManifest` (#838). This
one adds a new `manifest:cross-source` check to `maw doctor` that walks
the unified manifest and surfaces inconsistencies between the 5 oracle
registries — beyond just the `<oracle>:<node>` peer duplicate detection
shipped in #810.

## Why

The 5 registries (fleet windows, `config.sessions`, `config.agents`,
`oracles.json`, worktree scan) each carry a different facet of "what
oracles do I know?". Sub-PR 1 (#845) made `maw oracle ls` see the union.
This PR makes `maw doctor` flag the **disagreements** — operator drift
that quietly breaks federation routing or wake.

Concretely flagged:

- **agent-without-fleet** — `config.agents` has `<name>` → `local` but
  no fleet window. `maw hey <name>` will think it's local but find no
  tmux session to wake.
- **session-without-fleet** — `config.sessions` has a Claude UUID but
  no fleet/agent route. Budded-but-not-wired oracle is unreachable.
- **fleet-without-oracles-json** — fleet window exists but registry
  cache (`oracles.json`) hasn't seen it; no local checkout known.
- **oracles-json-without-runtime** — filesystem-only oracle nothing
  references. Orphan checkout or stale cache pointing at a deleted dir.
- **agent-mismatch-fleet-local** — both fleet and agent contributed,
  but resolved node is a remote one. Federation routes away from the
  local fleet window — almost certainly a misconfigured agents map.

## Severity

Every gap is a **warning**, not a hard failure. `manifest:cross-source`
returns `ok:true` always; the message body counts gaps and breaks them
down by kind, with one detail line per gap printed to console. Gating on
`ok:false` here would force operators into `--allow-drift` for normal
mid-migration states.

## What changed

- `src/commands/plugins/doctor/cross-source-detect.ts` (new) — pure
  analyzer: takes a manifest snapshot, returns `CrossSourceGap[]`.
  No fs, no network. Exposes `findGaps()`, `formatGap()`,
  `summarizeGaps()`.
- `src/commands/plugins/doctor/impl.ts` — wires `checkCrossSourceConsistency()`
  into `cmdDoctor`. Runs on default args, `all`, and the new positional
  `manifest`. Uses `loadManifestCached()` so the manifest is shared
  across any other consumer in the same `maw doctor` invocation;
  `invalidateManifest()` first to avoid serving a stale view if
  earlier checks touched config.
- `test/isolated/doctor-cross-source.test.ts` (new) — 23 tests.

## Tests

Pure-analyzer tests cover each gap pattern with hand-built
`OracleManifestEntry[]` fixtures (no fs needed):

- empty manifest → no gaps
- fully aligned oracle (4 sources, node=local) → no gaps
- aligned remote agent-only (federation peer) → no gaps
- each of the 5 gap kinds fires for its matching fixture
- multi-oracle ordering (alphabetical by name, then by kind)
- routed-only setup (`fleet+agent` with `localPath`) → no false positive
- agent→remote without fleet → no false positive (normal federation)

Doctor-integration tests use the same `MAW_CONFIG_DIR` sandbox pattern
as `oracle-manifest.test.ts`/`oracle-ls-manifest.test.ts`:

- empty manifest → check exists, message `"no cross-source inconsistencies"`
- session-only / agent-only / fleet-only fixtures each surface the
  expected gap kind in the headline
- `cmdDoctor(["all"])` and `cmdDoctor([])` include the check
- a flagged gap does NOT flip overall `out.ok` to false

## Behavior preserved

- All existing doctor checks (`install`, `version:*`, `peers:duplicates`)
  unchanged. Existing tests (`doctor-install-check`, `doctor-version-drift`,
  `peer-duplicate-detect`) still pass.
- Manifest TTL semantics unchanged.

## Out of scope (later sub-PRs)

- federation routing manifest lookup (sub-PR 3)
- `shouldAutoWake` manifest input (sub-PR 4)
- async worktree-scan loader (sub-PR 5)

## Refs

Closes-checkbox #841 (item 2). Builds on #838 (manifest), #810 (peer
duplicate-detect — pattern reference), #845 (sub-PR 1).

## Checklist (#841)

- [x] `maw oracle ls` — manifest-backed (sub-PR 1, #845)
- [ ] federation routing
- [x] **`maw doctor` — cross-source consistency check** ← this PR
- [ ] `shouldAutoWake()` manifest integration
- [ ] worktree scan async loader

## Test plan

- [x] `bun test test/isolated/doctor-cross-source.test.ts` — 23/23 pass
- [x] `bun test test/isolated/doctor-install-check.test.ts` — 11/11 pass
- [x] `bun test test/isolated/doctor-version-drift.test.ts` — 11/11 pass
- [x] `bun test test/isolated/oracle-manifest.test.ts` — 22/22 pass
- [x] `bun test test/isolated/oracle-ls-manifest.test.ts` — 6/6 pass
- [x] `bun test test/isolated/peer-duplicate-detect.test.ts` — 18/18 pass