### PR TITLE
refactor(shared): #834 Tier 3 — privatize 7 internal-only symbols

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.20",
+  "version": "26.4.29-alpha.21",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/shared/fleet-doctor.ts
+++ b/src/commands/shared/fleet-doctor.ts
@@ -49,7 +49,7 @@ import { checkStalePeers } from "./fleet-doctor-stale-peers";
 import { autoFix, C, colorFor, iconFor } from "./fleet-doctor-fixer";
 import type { DoctorFinding, Level } from "./fleet-doctor-checks";
 
-export interface DoctorOptions {
+interface DoctorOptions {
   fix?: boolean;
   json?: boolean;
 }

--- a/src/commands/shared/pulse-thread.ts
+++ b/src/commands/shared/pulse-thread.ts
@@ -22,7 +22,7 @@ export function timePeriod(): string {
   return "midnight";
 }
 
-export const PERIODS = [
+const PERIODS = [
   { key: "morning", label: "🌅 Morning (06:00-12:00)", hours: [6, 12] },
   { key: "afternoon", label: "☀️ Afternoon (12:00-18:00)", hours: [12, 18] },
   { key: "evening", label: "🌆 Evening (18:00-24:00)", hours: [18, 24] },
@@ -54,7 +54,7 @@ export async function findOrCreateDailyThread(repo: string): Promise<{ url: stri
   return { url, num, isNew: true };
 }
 
-export async function ensurePeriodComments(repo: string, threadNum: number): Promise<Record<string, { id: string; body: string }>> {
+async function ensurePeriodComments(repo: string, threadNum: number): Promise<Record<string, { id: string; body: string }>> {
   // Fetch existing comments
   const commentsJson = (await hostExec(
     `gh api repos/${repo}/issues/${threadNum}/comments --jq '[.[] | {id: .id, body: .body}]'`

--- a/src/commands/shared/scan-signals.ts
+++ b/src/commands/shared/scan-signals.ts
@@ -2,7 +2,7 @@ import { join } from "path";
 import { existsSync, readdirSync, readFileSync } from "fs";
 import type { Signal } from "../../core/fleet/leaf";
 
-export interface ScanOptions {
+interface ScanOptions {
   days?: number;
 }
 

--- a/src/commands/shared/wake-resolve-scan-suggest.ts
+++ b/src/commands/shared/wake-resolve-scan-suggest.ts
@@ -9,7 +9,7 @@ export interface OrgEntry {
   source: string;
 }
 
-export interface ScanSuggestDeps {
+interface ScanSuggestDeps {
   /** Synchronous exec — used for ghq list, gh repo view, gh --version */
   execFn?: (cmd: string) => string;
   /**
@@ -33,7 +33,7 @@ export interface ScanSuggestDeps {
  * actually own a repo in. `ok: false` triggers a graceful fallback to the
  * unfiltered (all-local) scan with a warning.
  */
-export type AllowedOrgs =
+type AllowedOrgs =
   | { ok: true; user: string; orgs: Set<string> }
   | { ok: false; reason: string };
 

--- a/src/commands/shared/wake-target.ts
+++ b/src/commands/shared/wake-target.ts
@@ -31,7 +31,7 @@ function stripOracleSuffix(repoName: string): string {
   return repoName.replace(/-oracle$/, "");
 }
 
-export interface ParsedWakeTarget {
+interface ParsedWakeTarget {
   /** Oracle name derived from repo (e.g. "mawjs" from "mawjs-oracle") */
   oracle: string;
   /** org/repo slug for ghq clone (e.g. "Soul-Brews-Studio/mawjs-oracle") */


### PR DESCRIPTION
Per audit-v2 (#834): 9 PRIVATE-CANDIDATE symbols. Two (`defaultPromptFn`, `checkGhRepo`) were already privatized in #851 (Tier 2), leaving 7 in this PR.

## Privatized (export removed)

| Symbol | File | Kind |
|---|---|---|
| `ScanSuggestDeps` | `wake-resolve-scan-suggest.ts` | interface |
| `AllowedOrgs` | `wake-resolve-scan-suggest.ts` | type alias |
| `DoctorOptions` | `fleet-doctor.ts` | interface |
| `PERIODS` | `pulse-thread.ts` | const |
| `ensurePeriodComments` | `pulse-thread.ts` | function |
| `ScanOptions` | `scan-signals.ts` | interface |
| `ParsedWakeTarget` | `wake-target.ts` | interface |

## Verification
- ✅ `bun build src/cli.ts --target=bun` — clean (635 modules, 1.67 MB).
- ✅ Targeted tests: 108/110 pass across 4 related test files (the 2 fails are the pre-existing `checkStalePeers` baseline from #851 era — unchanged).
- ✅ All 7 symbols verified internal-only via repo-wide grep: zero cross-module imports, zero test imports.

## Net delta
0 LOC reclaim — pure public-surface reduction. 6 files changed, +8 / −8 (the 8/8 is the 7 export drops + package.json bump line).

Bump: v26.4.29-alpha.21. Closes part of #834.