### PR TITLE
fix(cli): #853 — resolve plugin lifecycle dir from ~/.maw in bundled binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.20",
+  "version": "26.4.29-alpha.21",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/cli/route-tools.ts
+++ b/src/cli/route-tools.ts
@@ -37,15 +37,28 @@ export async function routeTools(cmd: string, args: string[]): Promise<boolean> 
     if (sub === "init" || sub === "build" || sub === "install") {
       const { loadManifestFromDir } = await import("../plugin/manifest");
       const { invokePlugin } = await import("../plugin/registry");
-      const { resolve } = await import("path");
-      const pluginDir = resolve(import.meta.dir, "..", "commands", "plugins", "plugin");
-      const loaded = loadManifestFromDir(pluginDir);
-      if (loaded) {
-        const result = await invokePlugin(loaded, { source: "cli", args: args.slice(1) });
-        if (result.ok && result.output) console.log(result.output);
-        if (!result.ok && result.error) console.error(result.error);
-        if (!result.ok) process.exit(1);
-        return true;
+      const { resolve, join } = await import("path");
+      const { existsSync } = await import("fs");
+      const { homedir } = await import("os");
+      // #853 — `import.meta.dir` resolves to the source tree in dev but to
+      // `~/.local/bin/` in the bundled binary, where there's no
+      // commands/plugins/ subtree. Try the dev path first, then fall back to
+      // the bootstrapped symlink at ~/.maw/plugins/plugin (populated by
+      // runBootstrap on every CLI start).
+      const candidates = [
+        resolve(import.meta.dir, "..", "commands", "plugins", "plugin"),
+        join(homedir(), ".maw", "plugins", "plugin"),
+      ];
+      const pluginDir = candidates.find(p => existsSync(join(p, "plugin.json")));
+      if (pluginDir) {
+        const loaded = loadManifestFromDir(pluginDir);
+        if (loaded) {
+          const result = await invokePlugin(loaded, { source: "cli", args: args.slice(1) });
+          if (result.ok && result.output) console.log(result.output);
+          if (!result.ok && result.error) console.error(result.error);
+          if (!result.ok) process.exit(1);
+          return true;
+        }
       }
     }
     // "maw plugin ls/info/remove" → forward to plugins (plural) legacy handler.


### PR DESCRIPTION
## Summary

Closes #853. `maw plugin install <name>` (and `init`/`build`) silently fell through to the `maw plugin create` usage line in the bundled binary at `~/.local/bin/maw`. Root cause: `route-tools.ts` resolved the plugin-lifecycle manifest dir from `import.meta.dir`, which points at `~/.local/bin/` in the bundle (no `commands/plugins/` subtree there), so `loadManifestFromDir` returned null and the new dispatcher was skipped.

## Fix

Try the dev-tree path first, fall back to `~/.maw/plugins/plugin` — the symlink already populated by `runBootstrap` on every CLI start. ~10 LOC, no behavior change in the source tree.

```ts
const candidates = [
  resolve(import.meta.dir, "..", "commands", "plugins", "plugin"),
  join(homedir(), ".maw", "plugins", "plugin"),
];
const pluginDir = candidates.find(p => existsSync(join(p, "plugin.json")));
```

If neither exists, falls through gracefully to existing behavior (no panic).

## Verification

Rebuilt the bundle from this branch (`bun build src/cli.ts --outfile /tmp/maw-853-fix-bundle --target=bun --minify`) and ran:

```
$ /tmp/maw-853-fix-bundle plugin install shellenv
loaded config: ...
registry fetch failed: Unable to connect ...   # ← reaches registry-fetch (was: usage fall-through)

$ MAW_REGISTRY_URL=https://soul-brews-studio.github.io/maw-plugin-registry/registry.json \
    /tmp/maw-853-fix-bundle plugin install shellenv
loaded config: ...
✗ no plugin.json at /var/folders/.../maw-install-NkEWPV
failed to read plugin manifest                 # ← reaches install-impl tarball extraction
```

`init` and `build` (same dispatch) also reach their handlers. `create` unaffected.

The downstream tarball-layout issue surfaced in the second run is separate from this dispatch fix — likely github archive's wrapper-dir vs. install-impl's flat-tarball expectation. Will follow up in a separate issue if confirmed.

## Test plan

- [x] Bundled binary: `plugin install <name>` reaches registry-fetch (verified)
- [x] Bundled binary: `plugin init` / `plugin build` reach handler (verified)
- [x] Bundled binary: `plugin create` unaffected (verified)
- [ ] Dev tree: `bun src/cli.ts plugin install shellenv` reaches handler (blocked locally on a pre-existing bootstrap symlink collision in the worktree, unrelated to this PR)
- [ ] Post-merge / new alpha tag: `~/.local/bin/maw plugin install shellenv` end-to-end on m5

🤖 Generated with [Claude Code](https://claude.com/claude-code)