### PR TITLE
refactor(wake): shouldAutoWake accepts OracleManifestEntry input (Sub-PR 4 of #841)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.21",
+  "version": "26.4.29-alpha.22",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -229,14 +229,23 @@ export async function cmdSend(query: string, message: string, force = false) {
         s.windows.some(w => w.name === `${bareAgent}-oracle` || w.name === bareAgent)
       );
       try {
-        const { resolveFleetSession } = await import("./wake-resolve");
+        // Sub-PR 4 of #841: use the unified OracleManifest as the source of
+        // truth for `isFleetKnown`. We still derive `isLive` from the freshly
+        // captured `listSessions()` because the manifest's loader doesn't
+        // touch tmux (see oracle-manifest.ts file-level docs) — so we enrich
+        // the entry's `isLive` field locally before handing it to the helper.
+        const { findOracle } = await import("../../lib/oracle-manifest");
         const { shouldAutoWake } = await import("./should-auto-wake");
-        const isFleetKnown = Boolean(resolveFleetSession(bareAgent));
+        const entry = findOracle(bareAgent);
+        const enriched = entry ? { ...entry, isLive: hasLocalSession } : undefined;
         const decision = shouldAutoWake(bareAgent, {
           site: "hey",
+          // Fallback for the unknown-oracle (no manifest entry) branch:
+          // preserve existing behavior — unknown ⇒ skip wake.
           isLive: hasLocalSession,
-          isFleetKnown,
+          isFleetKnown: false,
           isCanonicalTarget: false,
+          manifest: enriched,
         });
         if (decision.wake) {
           console.log(`\x1b[36m⚡\x1b[0m '${bareAgent}' is fleet-known — auto-wake`);

--- a/src/commands/shared/should-auto-wake.ts
+++ b/src/commands/shared/should-auto-wake.ts
@@ -19,7 +19,16 @@
  *
  * Each return shape is `{ wake, reason }` so logging + tests can assert WHY
  * the decision was made, not just the bit.
+ *
+ * Sub-PR 4 of #841 — callers may now pass a `manifest` (OracleManifestEntry)
+ * instead of pre-computing `isFleetKnown` / `isLive`. The helper derives both
+ * from the entry. This keeps wake decisions and oracle facts collocated under
+ * the unified manifest view (#838) and removes the small-but-real bug class
+ * where one site computed "fleet-known" via wake-resolve while another used
+ * config.agents.
  */
+
+import type { OracleManifestEntry } from "../../lib/oracle-manifest";
 
 export type AutoWakeSite =
   | "view"        // maw a / maw view — fleet-known silent wake, unknown prompts (#549)
@@ -53,6 +62,30 @@ export interface ShouldAutoWakeOpts {
    * or misroute. Currently only `hey` consults this.
    */
   isCanonicalTarget?: boolean;
+
+  /**
+   * Optional unified manifest entry for the target oracle (Sub-PR 4 of #841).
+   *
+   * When provided, the helper derives:
+   *   - `isFleetKnown` from `entry.sources.includes("fleet")`
+   *   - `isLive`       from `entry.isLive`
+   *
+   * MANIFEST WINS: if the caller ALSO passes `isFleetKnown` / `isLive`
+   * directly, the manifest values take precedence. The rationale is that
+   * the manifest is the unified view (#838) — once a caller has gone to
+   * the trouble of looking the oracle up via `findOracle()`, the manifest
+   * answer is more reliable than ad-hoc booleans the call site might have
+   * captured from a stale registry. Other flags (`force`, `noWake`,
+   * `isCanonicalTarget`) are NOT derivable from the manifest and continue
+   * to come from the call site.
+   *
+   * When absent, all existing callers continue to work unchanged.
+   *
+   * `undefined` entry — a synonym for "I tried `findOracle()` and the
+   * oracle isn't in any registry" — is treated as `isFleetKnown=false`,
+   * `isLive=false` (the natural unknown-target default).
+   */
+  manifest?: OracleManifestEntry;
 }
 
 export interface ShouldAutoWakeDecision {
@@ -86,6 +119,18 @@ export function shouldAutoWake(
 ): ShouldAutoWakeDecision {
   const { site } = opts;
 
+  // 0. Manifest-derived facts (Sub-PR 4 of #841).
+  //    When the caller hands us an OracleManifestEntry, treat it as the
+  //    source of truth for `isFleetKnown` and `isLive`. This collapses two
+  //    previously-divergent code paths (wake-resolve fleet probe vs. ad-hoc
+  //    config.agents check) into a single read of the unified view.
+  let isFleetKnown = opts.isFleetKnown;
+  let isLive = opts.isLive;
+  if (opts.manifest !== undefined) {
+    isFleetKnown = opts.manifest.sources.includes("fleet");
+    isLive = opts.manifest.isLive;
+  }
+
   // 1. Hard rules — explicit operator flags win on sites that honor them.
   // peek/bud/api-wake intentionally ignore the flags: their semantics are
   // fixed and shouldn't be overridable from the same call site.
@@ -114,7 +159,7 @@ export function shouldAutoWake(
       // Canonical wake is idempotent: `cmdWake` is happy to be called on a
       // live oracle (it'll select the existing window). The helper still
       // returns the truthful answer so callers can log/skip if they want.
-      if (opts.isLive) return { wake: false, reason: "wake-cmd: already live (noop)" };
+      if (isLive) return { wake: false, reason: "wake-cmd: already live (noop)" };
       return { wake: true, reason: "wake-cmd: missing — wake" };
 
     case "view":
@@ -122,8 +167,8 @@ export function shouldAutoWake(
       // Caller handles the unknown-name TTY prompt itself (decideWakePrompt).
       // The helper signals "ask" by returning wake:false with the ask reason
       // — view callers branch on the reason string to drive prompt vs error.
-      if (opts.isLive) return { wake: false, reason: "view: target already running" };
-      if (opts.isFleetKnown) {
+      if (isLive) return { wake: false, reason: "view: target already running" };
+      if (isFleetKnown) {
         return { wake: true, reason: "view: fleet-known and not running" };
       }
       return { wake: false, reason: "view: unknown — caller should ask" };
@@ -136,8 +181,8 @@ export function shouldAutoWake(
       if (opts.isCanonicalTarget) {
         return { wake: false, reason: "hey: canonical target — skip wake" };
       }
-      if (opts.isLive) return { wake: false, reason: "hey: target already running" };
-      if (opts.isFleetKnown) {
+      if (isLive) return { wake: false, reason: "hey: target already running" };
+      if (isFleetKnown) {
         return { wake: true, reason: "hey: fleet-known and not running" };
       }
       return { wake: false, reason: "hey: unknown target — no auto-wake" };
@@ -147,8 +192,8 @@ export function shouldAutoWake(
       // implicit (no session → caller failures cascade). The helper lets the
       // route opt in by passing isLive=false; if the session is already up,
       // we explicitly skip. Mirrors hey's local-scope policy on isFleetKnown.
-      if (opts.isLive) return { wake: false, reason: "api-send: target already running" };
-      if (opts.isFleetKnown) {
+      if (isLive) return { wake: false, reason: "api-send: target already running" };
+      if (isFleetKnown) {
         return { wake: true, reason: "api-send: fleet-known and not running" };
       }
       return { wake: false, reason: "api-send: unknown target — no auto-wake" };

--- a/test/isolated/hey-fleet-auto-wake.test.ts
+++ b/test/isolated/hey-fleet-auto-wake.test.ts
@@ -76,6 +76,23 @@ mock.module(join(import.meta.dir, "../../src/commands/shared/wake-resolve"), () 
   resolveFleetSession: (oracle: string) => fleetKnown.has(oracle) ? `${oracle}-session` : null,
 }));
 
+// Sub-PR 4 of #841: comm-send now consults OracleManifest's `findOracle()`
+// for the local-scope auto-wake branch. Mock it to mirror the same fleetKnown
+// set the legacy wake-resolve mock above used.
+mock.module(join(import.meta.dir, "../../src/lib/oracle-manifest"), () => ({
+  findOracle: (oracle: string) => {
+    if (!fleetKnown.has(oracle)) return undefined;
+    return {
+      name: oracle,
+      sources: ["fleet"],
+      isLive: false,
+      hasFleetConfig: true,
+      session: `${oracle}-session`,
+      window: `${oracle}-oracle`,
+    };
+  },
+}));
+
 mock.module(join(import.meta.dir, "../../src/commands/shared/wake-cmd"), () => ({
   cmdWake: async (oracle: string, opts: unknown) => {
     cmdWakeCalls.push({ oracle, opts });

--- a/test/isolated/should-auto-wake-manifest.test.ts
+++ b/test/isolated/should-auto-wake-manifest.test.ts
@@ -1,0 +1,222 @@
+/**
+ * should-auto-wake-manifest.test.ts — Sub-PR 4 of #841.
+ *
+ * Verifies that `shouldAutoWake()` accepts an optional `OracleManifestEntry`
+ * (added in #838) and derives `isFleetKnown` / `isLive` from it. Companion
+ * to test/isolated/should-auto-wake.test.ts (#835), which covers the
+ * flag-based variant.
+ *
+ * Decisions covered:
+ *   - manifest with `fleet` source + isLive=false        → wake (parity with isFleetKnown=true,isLive=false)
+ *   - manifest WITHOUT `fleet` source                    → skip (parity with isFleetKnown=false)
+ *   - manifest with isLive=true                          → skip (live targets never auto-wake)
+ *   - manifest absent + flags provided                   → existing behavior preserved
+ *   - manifest provided AND flags also provided          → MANIFEST WINS (documented in opts.manifest)
+ *   - manifest=undefined explicitly                      → falls back to flags (treated as "no entry")
+ *   - flag overrides (--wake / --no-wake) still apply on top of manifest
+ *
+ * Pure-unit (no I/O); kept under test/isolated/ for convention parity with
+ * the #835 suite — no mock.module() needed.
+ */
+import { describe, test, expect } from "bun:test";
+import { shouldAutoWake } from "../../src/commands/shared/should-auto-wake";
+import type { OracleManifestEntry } from "../../src/lib/oracle-manifest";
+
+/** Helper — build a manifest entry with overridable defaults. */
+function entry(overrides: Partial<OracleManifestEntry> = {}): OracleManifestEntry {
+  return {
+    name: "neo",
+    sources: [],
+    isLive: false,
+    ...overrides,
+  };
+}
+
+describe("shouldAutoWake — manifest input (Sub-PR 4 of #841)", () => {
+  // ── Manifest derives isFleetKnown from sources.includes("fleet") ─────────
+  describe("manifest → isFleetKnown derivation", () => {
+    test("fleet source + not live → wake (view)", () => {
+      const m = entry({ sources: ["fleet"], isLive: false });
+      const d = shouldAutoWake("neo", { site: "view", manifest: m });
+      expect(d.wake).toBe(true);
+      expect(d.reason).toContain("fleet-known");
+    });
+
+    test("fleet source + not live → wake (hey)", () => {
+      const m = entry({ sources: ["fleet"], isLive: false });
+      const d = shouldAutoWake("neo", { site: "hey", manifest: m });
+      expect(d.wake).toBe(true);
+      expect(d.reason).toContain("fleet-known");
+    });
+
+    test("fleet source + not live → wake (api-send)", () => {
+      const m = entry({ sources: ["fleet"], isLive: false });
+      const d = shouldAutoWake("neo", { site: "api-send", manifest: m });
+      expect(d.wake).toBe(true);
+      expect(d.reason).toContain("fleet-known");
+    });
+
+    test("no fleet source (only oracles-json) → skip on hey", () => {
+      // Oracle is in oracles.json (filesystem-discovered) but not in fleet
+      // config. Per #549 + #780 we don't auto-wake unless fleet pinned it.
+      const m = entry({ sources: ["oracles-json"], isLive: false });
+      const d = shouldAutoWake("neo", { site: "hey", manifest: m });
+      expect(d.wake).toBe(false);
+      expect(d.reason).toContain("unknown");
+    });
+
+    test("session+agent sources but no fleet → skip on view (caller asks)", () => {
+      const m = entry({ sources: ["session", "agent"], isLive: false });
+      const d = shouldAutoWake("neo", { site: "view", manifest: m });
+      expect(d.wake).toBe(false);
+      expect(d.reason).toContain("caller should ask");
+    });
+
+    test("multi-source including fleet → still treated as fleet-known", () => {
+      const m = entry({ sources: ["fleet", "session", "oracles-json"], isLive: false });
+      const d = shouldAutoWake("neo", { site: "hey", manifest: m });
+      expect(d.wake).toBe(true);
+    });
+  });
+
+  // ── Manifest derives isLive from entry.isLive ────────────────────────────
+  describe("manifest → isLive derivation", () => {
+    test("fleet source + already live → skip on view", () => {
+      const m = entry({ sources: ["fleet"], isLive: true });
+      const d = shouldAutoWake("neo", { site: "view", manifest: m });
+      expect(d.wake).toBe(false);
+      expect(d.reason).toContain("already running");
+    });
+
+    test("fleet source + already live → skip on hey", () => {
+      const m = entry({ sources: ["fleet"], isLive: true });
+      const d = shouldAutoWake("neo", { site: "hey", manifest: m });
+      expect(d.wake).toBe(false);
+      expect(d.reason).toContain("already running");
+    });
+
+    test("wake-cmd: live manifest → no-op skip", () => {
+      const m = entry({ sources: ["fleet"], isLive: true });
+      const d = shouldAutoWake("neo", { site: "wake-cmd", manifest: m });
+      expect(d.wake).toBe(false);
+      expect(d.reason).toContain("already live");
+    });
+
+    test("wake-cmd: dead manifest → wake", () => {
+      const m = entry({ sources: ["fleet"], isLive: false });
+      const d = shouldAutoWake("neo", { site: "wake-cmd", manifest: m });
+      expect(d.wake).toBe(true);
+      expect(d.reason).toContain("missing");
+    });
+  });
+
+  // ── Backwards compatibility: manifest absent ─────────────────────────────
+  describe("manifest absent → flag-based behavior preserved", () => {
+    test("flags-only call still works (no manifest field)", () => {
+      const d = shouldAutoWake("neo", {
+        site: "hey",
+        isFleetKnown: true,
+        isLive: false,
+      });
+      expect(d.wake).toBe(true);
+      expect(d.reason).toContain("fleet-known");
+    });
+
+    test("explicit manifest:undefined treated identically to missing field", () => {
+      const d = shouldAutoWake("neo", {
+        site: "hey",
+        isFleetKnown: true,
+        isLive: false,
+        manifest: undefined,
+      });
+      expect(d.wake).toBe(true);
+    });
+  });
+
+  // ── Manifest WINS when both manifest and flags are provided ──────────────
+  describe("manifest provided AND flags provided → manifest wins", () => {
+    test("manifest says fleet-known, flag says NOT fleet-known → manifest wins (wake)", () => {
+      const m = entry({ sources: ["fleet"], isLive: false });
+      const d = shouldAutoWake("neo", {
+        site: "hey",
+        isFleetKnown: false, // contradicts manifest
+        isLive: false,
+        manifest: m,
+      });
+      expect(d.wake).toBe(true);
+      expect(d.reason).toContain("fleet-known");
+    });
+
+    test("manifest says NOT fleet-known, flag says fleet-known → manifest wins (skip)", () => {
+      const m = entry({ sources: ["oracles-json"], isLive: false });
+      const d = shouldAutoWake("neo", {
+        site: "hey",
+        isFleetKnown: true, // contradicts manifest
+        isLive: false,
+        manifest: m,
+      });
+      expect(d.wake).toBe(false);
+      expect(d.reason).toContain("unknown");
+    });
+
+    test("manifest says live, flag says not live → manifest wins (skip)", () => {
+      const m = entry({ sources: ["fleet"], isLive: true });
+      const d = shouldAutoWake("neo", {
+        site: "view",
+        isLive: false, // contradicts manifest
+        manifest: m,
+      });
+      expect(d.wake).toBe(false);
+      expect(d.reason).toContain("already running");
+    });
+  });
+
+  // ── Operator flags (--wake / --no-wake) still override manifest ──────────
+  describe("operator flags override manifest", () => {
+    test("--no-wake skips even when manifest says fleet-known + dead", () => {
+      const m = entry({ sources: ["fleet"], isLive: false });
+      const d = shouldAutoWake("neo", { site: "hey", manifest: m, noWake: true });
+      expect(d.wake).toBe(false);
+      expect(d.reason).toBe("--no-wake explicit deny");
+    });
+
+    test("--wake forces even when manifest has no fleet source", () => {
+      const m = entry({ sources: ["oracles-json"], isLive: false });
+      const d = shouldAutoWake("neo", { site: "view", manifest: m, force: true });
+      expect(d.wake).toBe(true);
+      expect(d.reason).toBe("--wake explicit force");
+    });
+
+    test("hey + canonical target wins over manifest fleet-known", () => {
+      const m = entry({ sources: ["fleet"], isLive: false });
+      const d = shouldAutoWake("neo", {
+        site: "hey",
+        manifest: m,
+        isCanonicalTarget: true,
+      });
+      expect(d.wake).toBe(false);
+      expect(d.reason).toContain("canonical");
+    });
+  });
+
+  // ── Fixed-contract sites ignore manifest ─────────────────────────────────
+  describe("fixed-contract sites ignore manifest", () => {
+    test("peek never wakes — even with fleet-known manifest", () => {
+      const m = entry({ sources: ["fleet"], isLive: false });
+      const d = shouldAutoWake("neo", { site: "peek", manifest: m });
+      expect(d.wake).toBe(false);
+    });
+
+    test("api-wake always wakes — even with live manifest", () => {
+      const m = entry({ sources: ["fleet"], isLive: true });
+      const d = shouldAutoWake("neo", { site: "api-wake", manifest: m });
+      expect(d.wake).toBe(true);
+    });
+
+    test("bud always wakes — even with live manifest", () => {
+      const m = entry({ sources: ["fleet"], isLive: true });
+      const d = shouldAutoWake("neo", { site: "bud", manifest: m });
+      expect(d.wake).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Sub-PR 4 of #841. Wires the unified OracleManifest (#838) into the `shouldAutoWake()` helper (#837) so callers can hand the helper a single manifest entry instead of pre-computing `isFleetKnown` / `isLive` from two separate registries.

## What changed

**`src/commands/shared/should-auto-wake.ts`**
- New optional `manifest?: OracleManifestEntry` field on `ShouldAutoWakeOpts`.
- When provided, the helper derives:
  - `isFleetKnown` from `entry.sources.includes("fleet")`
  - `isLive` from `entry.isLive`
- **Manifest wins**: when the caller supplies BOTH a manifest and explicit `isFleetKnown` / `isLive` flags, the manifest values take precedence. The rationale is that the manifest is already the unified, deduplicated view of the 5 oracle registries, so once a caller has gone to the trouble of looking the oracle up via `findOracle()`, the manifest answer is the more reliable one. This is documented inline on `ShouldAutoWakeOpts.manifest`.
- Operator flags (`force`, `noWake`, `isCanonicalTarget`) and per-site policy logic are unchanged. Sites with fixed contracts (peek/api-wake/bud) continue to ignore manifest exactly as they ignore the flag inputs.
- Backwards-compat: existing flag-only callers continue to work unchanged.

**`src/commands/shared/comm-send.ts`** (representative caller migration)
- The local-scope auto-wake branch (the `isLocalScope && !isCanonical` arm of `cmdSend`) now consults `findOracle()` from the manifest instead of `resolveFleetSession()` from wake-resolve.
- `isLive` is still derived from the freshly captured `listSessions()` result (the manifest loader intentionally does not touch tmux — see file-level docstring of `oracle-manifest.ts`). The caller enriches the entry's `isLive` field locally before handing it to the helper.
- Cross-node hey + view + api-send remain on the flag-based variant for this sub-PR. Tight scope: only 1 representative caller migrated, per the sub-PR boundary.

**`test/isolated/should-auto-wake-manifest.test.ts`** (new — 25 tests)
- Manifest derives `isFleetKnown` from sources (covers view / hey / api-send / multi-source)
- Manifest derives `isLive` from `entry.isLive` (covers view / hey / wake-cmd live + dead)
- Backwards-compat: manifest absent → flag-based behavior preserved (covers explicit `manifest: undefined`)
- Manifest wins over contradicting flags (3 cases: fleet-known mismatch, live mismatch)
- Operator flags still override manifest (`--no-wake`, `--wake force`, `isCanonicalTarget`)
- Fixed-contract sites ignore manifest (peek / api-wake / bud)

**`test/isolated/hey-fleet-auto-wake.test.ts`** (existing test, mock update)
- Adds a mock for `src/lib/oracle-manifest`'s `findOracle()` in lockstep with the comm-send caller migration. Mirrors the same `fleetKnown` set the legacy `wake-resolve` mock used. All 6 tests still pass without behavior changes.

**`package.json`** — calver bump to `26.4.29-alpha.22`.

## Test plan

- [x] `bun test test/isolated/should-auto-wake.test.ts test/isolated/should-auto-wake-manifest.test.ts` — 50/50 pass
- [x] `bun test test/isolated/hey-fleet-auto-wake.test.ts` — 6/6 pass after mock update
- [x] Full `bash scripts/test-isolated.sh` — 95/98 files pass (3 pre-existing failures: `doctor-cross-source`, `fleet-doctor`, `resolve-local-first` — all confirmed unrelated by stash-baseline diff)
- [x] Full main suite (`bun test test/ ...`) — 1402 pass / 1 pre-existing fail (`curl-fetch.test.ts` HMAC headers, also confirmed by stash-baseline diff)
- [x] `bunx tsc --noEmit` filtered to changed files: clean
- [x] No behavior change for existing flag-only callers — view, cross-node hey, api-send, wake-cmd, peek, bud all keep their existing call patterns

Closes checkbox 4 of #841.