### PR TITLE
fix(ci): unblock CalVer Release on alpha — set MAW_SKIP_FLAKY=1 (#830 mitigation)

### DIFF
--- a/.github/workflows/calver-release.yml
+++ b/.github/workflows/calver-release.yml
@@ -105,6 +105,15 @@ jobs:
 
       - name: Install + test + build
         if: steps.ver.outputs.skip != 'true'
+        # #830 — skip the federation 2-port localhost integration test on this
+        # runner. It hits a kernel port-race between getEphemeralPort()→close
+        # and Bun.spawn()→listen that's been flaking nightly on alpha cuts:
+        # 10 alpha bumps (.12 → .21) failed to publish here on 2026-04-28,
+        # leaving the proximate user-facing fix #857 unreachable to users.
+        # Same override pattern as test-unit shard (#811/#813 precedent).
+        # Root-cause port-race fix is tracked separately in #830.
+        env:
+          MAW_SKIP_FLAKY: "1"
         run: |
           bun install --frozen-lockfile
           bun run test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.21",
+  "version": "26.4.29-alpha.22",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
## Summary

10 alpha bumps tonight (`.12` → `.21`) **failed to publish** as GitHub releases. The latest published alpha tag is **alpha.11 from 14:55 UTC** while alpha tip is at `99fc24e7` with package.json `26.4.29-alpha.21`.

Root cause: every CalVer Release workflow run since alpha.11 has failed at the same test:

```
1 tests failed:
(fail) federation — 2-port localhost /info + probe round-trip > (unnamed) [107.00ms]
```

This is the kernel port-race tracked in #830. Test-isolated and PR-level admin merges sidestep it for PR merging — but `bun run test` post-merge in CalVer Release has no override, so every alpha bump silently fails to ship.

## Fix

Set `MAW_SKIP_FLAKY=1` for the workflow's "Install + test + build" step. The test already has a self-skip gate (`test/integration/federation-local.test.ts:37-40`) that honors this env var. Same override pattern already in use for the `test-unit` shard (#811/#813 precedent).

```yaml
- name: Install + test + build
  if: steps.ver.outputs.skip != 'true'
  # #830 — skip the federation 2-port localhost integration test on this
  # runner. It hits a kernel port-race between getEphemeralPort()→close
  # and Bun.spawn()→listen that's been flaking nightly on alpha cuts:
  # 10 alpha bumps (.12 → .21) failed to publish here on 2026-04-28,
  # leaving the proximate user-facing fix #857 unreachable to users.
  # Same override pattern as test-unit shard (#811/#813 precedent).
  # Root-cause port-race fix is tracked separately in #830.
  env:
    MAW_SKIP_FLAKY: "1"
  run: |
    bun install --frozen-lockfile
    bun run test
    bun run build
```

Out of scope (intentional): the actual port-race fix. That's #830.

## Self-validating

This PR is itself a CalVer bump (alpha.21 → alpha.22). Once merged, the post-merge CalVer Release run uses the new env var → publishes `v26.4.29-alpha.22` → recovers the alpha channel.

## Why now

Without this, #857 (plugin install path resolution — landed earlier tonight at `99fc24e7`) is unreachable to users: `maw update alpha` on m5 still pulls alpha.11 where `maw plugin install <name>` falls through to `usage: maw plugin create`. This PR is the unblocker for the marketplace-loop migration.

## Test plan

- [x] PR-level CI: `bun run test` skips the flaky test → green.
- [ ] Post-merge: CalVer Release succeeds, publishes `v26.4.29-alpha.22`.
- [ ] m5 reinstalls latest alpha and `maw plugin install shellenv` reaches registry-fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)