### PR TITLE
feat(manifest): loadManifestAsync with worktree scan (Sub-PR 5 of #841)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.22",
+  "version": "26.4.29-alpha.23",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/lib/oracle-manifest.ts
+++ b/src/lib/oracle-manifest.ts
@@ -32,11 +32,20 @@
  * `maw oracle ls`. Each contributing source is exercised independently by
  * the test suite (test/isolated/oracle-manifest.test.ts).
  *
+ * Async variant
+ * ─────────────
+ * `loadManifestAsync()` (Sub-PR 5 of #841) extends `loadManifest()` with the
+ * 6th source — `scanWorktrees()` from `core/fleet/worktrees-scan.ts`. It is
+ * factored as a separate function (not a flag on the sync loader) because the
+ * worktree scan is genuinely async (SSH-y `hostExec` + tmux walks). Existing
+ * sync callers stay sync; opt-in consumers pick the async variant.
+ *
+ * The async variant has its own TTL cache (`loadManifestCachedAsync`) — kept
+ * separate from the sync cache because the return shape is async (Promise)
+ * and most consumers prefer to not pay the worktree-scan cost on hot paths.
+ * `invalidateManifest()` resets BOTH caches.
+ *
  * NOT in scope here:
- *   - Worktree scan integration: `scanWorktrees()` is async + does SSH-y
- *     `hostExec` walks. Pulling that into the synchronous loader path would
- *     change every caller's signature. The fallback hook is wired via
- *     `loadManifestWithWorktrees()` for callers that explicitly opt in.
  *   - Federation peers (~/.maw/peers/...) — those describe peer NODES, not
  *     oracles. A future sub-issue will fold peer pubkeys here.
  *
@@ -44,6 +53,7 @@
  *   - src/commands/shared/should-auto-wake.ts — Sub-issue 1 (#835).
  *   - src/config/fleet-merge.ts                — load-time fleet→agents merge (#736 Phase 1.1).
  *   - src/core/fleet/oracle-registry.ts        — registry cache producer.
+ *   - src/core/fleet/worktrees-scan.ts         — async worktree scanner.
  */
 
 import { existsSync, readdirSync, readFileSync } from "fs";
@@ -325,7 +335,150 @@ export function loadManifestCached(ttlMs: number = DEFAULT_TTL_MS): OracleManife
 }
 
 /** Manual cache reset — for tests and post-mutation callers (e.g., after
- *  a fresh `maw oracle scan` rewrites oracles.json). */
+ *  a fresh `maw oracle scan` rewrites oracles.json). Resets BOTH the sync
+ *  and async caches. */
 export function invalidateManifest(): void {
   cacheState = null;
+  asyncCacheState = null;
+}
+
+// ─── Async variant — adds worktree scan as 6th source ────────────────────────
+
+/**
+ * Lite shape of `WorktreeInfo` — the fields we actually consume. We avoid
+ * importing the `WorktreeInfo` type from `core/fleet/worktrees-scan` directly
+ * here so the test suite can fabricate fixtures without pulling in the SSH
+ * transport layer that real `scanWorktrees` depends on.
+ */
+export interface WorktreeLite {
+  /** Local checkout path of the worktree on this machine. */
+  path?: string;
+  /** Bound tmux window, e.g. `"neo-oracle"` when active. */
+  tmuxWindow?: string;
+  /** Main repo (org/repo), e.g. `"Soul-Brews-Studio/neo-oracle"`. */
+  mainRepo?: string;
+}
+
+/** A scan function with the same external contract as `scanWorktrees()`. */
+export type ScanWorktreesFn = () => Promise<WorktreeLite[]>;
+
+/**
+ * Derive the oracle short-name from a worktree, or return `null` if the
+ * worktree is not bindable to an oracle (e.g. its main repo doesn't follow
+ * the `<name>-oracle` convention and there's no tmux window to read from).
+ *
+ * Precedence:
+ *   1. tmuxWindow ending in `-oracle` (most reliable — explicit binding)
+ *   2. mainRepo basename ending in `-oracle` (filesystem fallback)
+ */
+export function oracleNameFromWorktree(wt: WorktreeLite): string | null {
+  // 1. Bound tmux window — `neo-oracle` → `neo`.
+  const fromWindow = nameFromWindow(wt?.tmuxWindow);
+  if (fromWindow) return fromWindow;
+
+  // 2. Main repo basename — `Soul-Brews-Studio/neo-oracle` → `neo`.
+  if (wt?.mainRepo) {
+    const basename = wt.mainRepo.split("/").pop() || "";
+    if (basename.endsWith("-oracle")) return basename.replace(/-oracle$/, "");
+  }
+  return null;
+}
+
+/**
+ * Async variant of `loadManifest()` — same return type, with the 6th source
+ * (worktree scan) folded in.
+ *
+ * Behavior for worktree contributions:
+ *   - **New oracle** (not in any other source) → added with `source: "worktree"`,
+ *     `localPath = wt.path` if available.
+ *   - **Existing oracle** (already surfaced by fleet/session/agent/oracles-json)
+ *     → merge `localPath` if not already set; do NOT create a duplicate entry.
+ *     The `worktree` source is appended so consumers can see it contributed.
+ *
+ * Failure isolation matches the sync loader: if `scanWorktrees()` rejects, the
+ * async loader still returns the sync result — a flaky tmux/SSH must NOT brick
+ * a `maw oracle ls --with-worktrees` command. Errors are swallowed silently;
+ * callers wanting visibility into scan failures should call `scanWorktrees()`
+ * themselves.
+ *
+ * @param scanFn Optional scan function injection — defaults to the real
+ *               `scanWorktrees()`. Tests pass a synchronous mock here.
+ */
+export async function loadManifestAsync(
+  scanFn?: ScanWorktreesFn,
+): Promise<OracleManifestEntry[]> {
+  // Start from the synchronous merge — we never want to duplicate that work.
+  const base = loadManifest();
+  const byName = new Map(base.map((e) => [e.name, e]));
+
+  // Resolve the scan function lazily so importing this module doesn't pay the
+  // SSH-transport cost up front, and so the default path is fully optional.
+  let scan: ScanWorktreesFn;
+  if (scanFn) {
+    scan = scanFn;
+  } else {
+    try {
+      const mod = await import("../core/fleet/worktrees-scan");
+      scan = mod.scanWorktrees as ScanWorktreesFn;
+    } catch {
+      // Worktree scanner unavailable — return the sync manifest unchanged.
+      return base;
+    }
+  }
+
+  let worktrees: WorktreeLite[];
+  try {
+    worktrees = await scan();
+  } catch {
+    // scanWorktrees() can throw on ssh/tmux failure — fall through to base.
+    return base;
+  }
+
+  for (const wt of worktrees) {
+    const name = oracleNameFromWorktree(wt);
+    if (!name) continue;
+
+    let e = byName.get(name);
+    if (!e) {
+      // Worktree-only oracle — not surfaced by any other registry.
+      e = { name, sources: [], isLive: false };
+      byName.set(name, e);
+    }
+    if (!e.sources.includes("worktree")) e.sources.push("worktree");
+    // localPath: oracles-json had first dibs; only fill if absent.
+    if (e.localPath === undefined && wt?.path) e.localPath = wt.path;
+  }
+
+  return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+// ─── Async TTL cache ─────────────────────────────────────────────────────────
+
+interface AsyncCacheState {
+  manifest: OracleManifestEntry[];
+  loadedAt: number;
+}
+
+let asyncCacheState: AsyncCacheState | null = null;
+
+/**
+ * Cached `loadManifestAsync()` — re-uses the in-process result for `ttlMs` ms.
+ *
+ * Separate from `loadManifestCached` because the return shape is async and
+ * including the worktree scan is opt-in. Most consumers don't need it.
+ *
+ * @param ttlMs  Cache lifetime in ms (default 30s).
+ * @param scanFn Optional scan injection — primarily for tests.
+ */
+export async function loadManifestCachedAsync(
+  ttlMs: number = DEFAULT_TTL_MS,
+  scanFn?: ScanWorktreesFn,
+): Promise<OracleManifestEntry[]> {
+  const now = Date.now();
+  if (asyncCacheState && now - asyncCacheState.loadedAt < ttlMs) {
+    return asyncCacheState.manifest;
+  }
+  const manifest = await loadManifestAsync(scanFn);
+  asyncCacheState = { manifest, loadedAt: now };
+  return manifest;
 }

--- a/test/isolated/oracle-manifest-async.test.ts
+++ b/test/isolated/oracle-manifest-async.test.ts
@@ -1,0 +1,329 @@
+/**
+ * oracle-manifest-async.test.ts — Sub-PR 5 of #841.
+ *
+ * Verifies the async variant `loadManifestAsync()` which adds the 6th source
+ * (worktree scan via `scanWorktrees()`) on top of the sync `loadManifest()`.
+ *
+ * Coverage:
+ *   - Worktree-only oracle (not in any other source) appears with source="worktree".
+ *   - Worktree that DUPLICATES a fleet/oracles-json entry merges `localPath`
+ *     and adds `worktree` to the entry's `sources` list — does NOT create a
+ *     second entry.
+ *   - Sync vs async diff — worktree-only entries appear ONLY in the async result.
+ *   - TTL caching for `loadManifestCachedAsync` works (and is separate from
+ *     the sync cache).
+ *   - `invalidateManifest()` clears BOTH sync + async caches.
+ *
+ * Isolated (per-file subprocess) for the same reason as oracle-manifest.test.ts —
+ * we mutate process.env.MAW_CONFIG_DIR before importing the target module.
+ *
+ * The mock for `scanWorktrees()` is passed by dependency injection via the
+ * `scanFn` parameter on `loadManifestAsync` / `loadManifestCachedAsync`. This
+ * avoids `mock.module()` pollution — the real `core/fleet/worktrees-scan`
+ * module is never loaded in this test, so its SSH transport never fires.
+ */
+import { describe, test, expect, afterAll, beforeEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+// ─── Pin CONFIG_DIR + FLEET_DIR before imports ───────────────────────────────
+const TEST_CONFIG_DIR = mkdtempSync(join(tmpdir(), "maw-manifest-async-841-"));
+const TEST_FLEET_DIR = join(TEST_CONFIG_DIR, "fleet");
+mkdirSync(TEST_FLEET_DIR, { recursive: true });
+
+process.env.MAW_CONFIG_DIR = TEST_CONFIG_DIR;
+delete process.env.MAW_HOME;
+process.env.MAW_TEST_MODE = "1";
+
+const manifest = await import("../../src/lib/oracle-manifest");
+const config = await import("../../src/config");
+const {
+  loadManifest,
+  loadManifestAsync,
+  loadManifestCachedAsync,
+  invalidateManifest,
+  oracleNameFromWorktree,
+  DEFAULT_TTL_MS,
+} = manifest;
+
+const CONFIG_FILE = join(TEST_CONFIG_DIR, "maw.config.json");
+const ORACLES_JSON = join(TEST_CONFIG_DIR, "oracles.json");
+
+afterAll(() => {
+  rmSync(TEST_CONFIG_DIR, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  for (const f of [CONFIG_FILE, ORACLES_JSON]) {
+    try { rmSync(f, { force: true }); } catch { /* missing is fine */ }
+  }
+  try {
+    rmSync(TEST_FLEET_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_FLEET_DIR, { recursive: true });
+  } catch { /* best-effort */ }
+  config.resetConfig();
+  invalidateManifest();
+});
+
+// ─── Fixture builders ────────────────────────────────────────────────────────
+
+function writeFleetWindow(file: string, sessionName: string, windows: Array<{ name: string; repo?: string }>) {
+  writeFileSync(
+    join(TEST_FLEET_DIR, file),
+    JSON.stringify({ name: sessionName, windows }, null, 2) + "\n",
+    "utf-8",
+  );
+}
+
+function writeOraclesJson(oracles: any[]) {
+  writeFileSync(
+    ORACLES_JSON,
+    JSON.stringify(
+      {
+        schema: 1,
+        local_scanned_at: new Date().toISOString(),
+        ghq_root: "/tmp/ghq-fixture",
+        oracles,
+      },
+      null,
+      2,
+    ) + "\n",
+    "utf-8",
+  );
+}
+
+function makeOraclesEntry(o: Partial<any> & { name: string }) {
+  return {
+    org: "Soul-Brews-Studio",
+    repo: `${o.name}-oracle`,
+    name: o.name,
+    local_path: `/home/nat/Code/github.com/Soul-Brews-Studio/${o.name}-oracle`,
+    has_psi: true,
+    has_fleet_config: false,
+    budded_from: null,
+    budded_at: null,
+    federation_node: null,
+    detected_at: new Date().toISOString(),
+    ...o,
+  };
+}
+
+/** Build a mock `scanWorktrees` that returns the given array. */
+function mockScan(worktrees: any[]) {
+  return async () => worktrees;
+}
+
+// ─── oracleNameFromWorktree — name derivation ────────────────────────────────
+
+describe("oracleNameFromWorktree — name derivation", () => {
+  test("derives from tmuxWindow ending in -oracle", () => {
+    expect(oracleNameFromWorktree({ tmuxWindow: "neo-oracle" })).toBe("neo");
+  });
+
+  test("derives from mainRepo basename when tmuxWindow is missing", () => {
+    expect(
+      oracleNameFromWorktree({ mainRepo: "Soul-Brews-Studio/freshbud-oracle" }),
+    ).toBe("freshbud");
+  });
+
+  test("tmuxWindow wins over mainRepo basename", () => {
+    expect(
+      oracleNameFromWorktree({
+        tmuxWindow: "actual-oracle",
+        mainRepo: "Soul-Brews-Studio/different-oracle",
+      }),
+    ).toBe("actual");
+  });
+
+  test("returns null when neither tmuxWindow nor -oracle suffix matches", () => {
+    expect(oracleNameFromWorktree({ mainRepo: "user/random-repo" })).toBeNull();
+    expect(oracleNameFromWorktree({})).toBeNull();
+  });
+});
+
+// ─── Async aggregation — worktree as 6th source ──────────────────────────────
+
+describe("loadManifestAsync — worktree-only oracle surfaces", () => {
+  test("worktree-only oracle (no other source) → entry with source='worktree'", async () => {
+    const m = await loadManifestAsync(mockScan([
+      {
+        path: "/tmp/ghq/Soul-Brews-Studio/loner-oracle",
+        tmuxWindow: "loner-oracle",
+        mainRepo: "Soul-Brews-Studio/loner-oracle",
+      },
+    ]));
+
+    expect(m).toHaveLength(1);
+    const e = m[0];
+    expect(e.name).toBe("loner");
+    expect(e.sources).toEqual(["worktree"]);
+    expect(e.localPath).toBe("/tmp/ghq/Soul-Brews-Studio/loner-oracle");
+  });
+
+  test("worktree-only oracle derived from mainRepo when tmuxWindow absent", async () => {
+    const m = await loadManifestAsync(mockScan([
+      {
+        path: "/tmp/ghq/Soul-Brews-Studio/quiet-oracle",
+        mainRepo: "Soul-Brews-Studio/quiet-oracle",
+      },
+    ]));
+    expect(m).toHaveLength(1);
+    expect(m[0].name).toBe("quiet");
+    expect(m[0].sources).toContain("worktree");
+  });
+
+  test("unbindable worktrees (no -oracle suffix anywhere) are skipped", async () => {
+    const m = await loadManifestAsync(mockScan([
+      {
+        path: "/tmp/some/random-repo",
+        mainRepo: "user/random-repo",
+      },
+    ]));
+    expect(m).toEqual([]);
+  });
+});
+
+describe("loadManifestAsync — duplicate worktrees merge into existing entries", () => {
+  test("worktree duplicates a fleet entry → merges localPath, no second entry", async () => {
+    writeFleetWindow("200-omni.json", "omni-session", [
+      { name: "omni-oracle", repo: "Soul-Brews-Studio/omni-oracle" },
+    ]);
+
+    const m = await loadManifestAsync(mockScan([
+      {
+        path: "/tmp/ghq/Soul-Brews-Studio/omni-oracle",
+        tmuxWindow: "omni-oracle",
+        mainRepo: "Soul-Brews-Studio/omni-oracle",
+      },
+    ]));
+
+    // Single merged entry — not two.
+    expect(m).toHaveLength(1);
+    const e = m[0];
+    expect(e.name).toBe("omni");
+    // Fleet preserved.
+    expect(e.session).toBe("omni-session");
+    expect(e.window).toBe("omni-oracle");
+    expect(e.sources).toContain("fleet");
+    // Worktree contributed too.
+    expect(e.sources).toContain("worktree");
+    // localPath came from worktree (oracles-json wasn't present).
+    expect(e.localPath).toBe("/tmp/ghq/Soul-Brews-Studio/omni-oracle");
+  });
+
+  test("worktree does NOT clobber an oracles-json localPath", async () => {
+    writeOraclesJson([
+      makeOraclesEntry({
+        name: "owned",
+        local_path: "/canonical/path/owned-oracle",
+      }),
+    ]);
+
+    const m = await loadManifestAsync(mockScan([
+      {
+        path: "/different/worktree/path",
+        tmuxWindow: "owned-oracle",
+        mainRepo: "Soul-Brews-Studio/owned-oracle",
+      },
+    ]));
+
+    expect(m).toHaveLength(1);
+    const e = m[0];
+    expect(e.localPath).toBe("/canonical/path/owned-oracle");
+    expect(e.sources).toContain("oracles-json");
+    expect(e.sources).toContain("worktree");
+  });
+});
+
+describe("loadManifestAsync — sync vs async diff", () => {
+  test("worktree-only entries appear ONLY in async result", async () => {
+    writeFleetWindow("210-known.json", "known", [{ name: "known-oracle" }]);
+
+    const sync = loadManifest();
+    const async_ = await loadManifestAsync(mockScan([
+      {
+        path: "/tmp/ghq/Soul-Brews-Studio/extra-oracle",
+        tmuxWindow: "extra-oracle",
+        mainRepo: "Soul-Brews-Studio/extra-oracle",
+      },
+    ]));
+
+    expect(sync.map((e) => e.name)).toEqual(["known"]);
+    expect(async_.map((e) => e.name).sort()).toEqual(["extra", "known"]);
+
+    // The sync entry for `known` is unchanged; the async result also includes
+    // it (the worktree didn't claim it, so no merge mutated it either).
+    const knownAsync = async_.find((e) => e.name === "known")!;
+    expect(knownAsync.sources).not.toContain("worktree");
+  });
+
+  test("when scanWorktrees returns empty, async equals sync (by content)", async () => {
+    writeFleetWindow("220-empty.json", "e", [{ name: "e-oracle" }]);
+    const sync = loadManifest();
+    const async_ = await loadManifestAsync(mockScan([]));
+    expect(async_.map((e) => e.name)).toEqual(sync.map((e) => e.name));
+    expect(async_[0].sources).not.toContain("worktree");
+  });
+});
+
+// ─── Resilience ──────────────────────────────────────────────────────────────
+
+describe("loadManifestAsync — resilience to scan failure", () => {
+  test("scanWorktrees throwing → returns sync manifest, never rejects", async () => {
+    writeFleetWindow("230-resil.json", "r", [{ name: "r-oracle" }]);
+    const failingScan = async () => {
+      throw new Error("ssh: kaboom");
+    };
+    const m = await loadManifestAsync(failingScan);
+    expect(m).toHaveLength(1);
+    expect(m[0].name).toBe("r");
+    expect(m[0].sources).not.toContain("worktree");
+  });
+});
+
+// ─── Async TTL cache ─────────────────────────────────────────────────────────
+
+describe("loadManifestCachedAsync — TTL cache", () => {
+  test("two calls within TTL → second is cached (does not see new fleet entry)", async () => {
+    writeFleetWindow("240-cache-a.json", "first", [{ name: "first-oracle" }]);
+    const first = await loadManifestCachedAsync(60_000, mockScan([]));
+    expect(first.map((e) => e.name)).toEqual(["first"]);
+
+    writeFleetWindow("241-cache-b.json", "second", [{ name: "second-oracle" }]);
+    config.resetConfig();
+
+    const second = await loadManifestCachedAsync(60_000, mockScan([]));
+    expect(second).toBe(first);
+    expect(second.map((e) => e.name)).toEqual(["first"]);
+  });
+
+  test("ttlMs=0 → effectively disables cache (always reload)", async () => {
+    writeFleetWindow("242-ttl0-a.json", "a", [{ name: "a-oracle" }]);
+    const first = await loadManifestCachedAsync(0, mockScan([]));
+    writeFleetWindow("243-ttl0-b.json", "b", [{ name: "b-oracle" }]);
+    config.resetConfig();
+    const second = await loadManifestCachedAsync(0, mockScan([]));
+    expect(first).not.toBe(second);
+    expect(second.map((e) => e.name).sort()).toEqual(["a", "b"]);
+  });
+
+  test("invalidateManifest() clears BOTH sync and async caches", async () => {
+    writeFleetWindow("250-inv-a.json", "x", [{ name: "x-oracle" }]);
+    const first = await loadManifestCachedAsync(60_000, mockScan([]));
+    expect(first.map((e) => e.name)).toEqual(["x"]);
+
+    writeFleetWindow("251-inv-b.json", "y", [{ name: "y-oracle" }]);
+    config.resetConfig();
+    invalidateManifest();
+
+    const second = await loadManifestCachedAsync(60_000, mockScan([]));
+    expect(second).not.toBe(first);
+    expect(second.map((e) => e.name).sort()).toEqual(["x", "y"]);
+  });
+
+  test("DEFAULT_TTL_MS is shared with the sync cache (sane default)", () => {
+    expect(typeof DEFAULT_TTL_MS).toBe("number");
+    expect(DEFAULT_TTL_MS).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Final sub-PR of #841 (OracleManifest follow-ups). Adds the 6th source — `scanWorktrees()` — as an opt-in async loader so existing sync callers stay sync. Only consumers that need worktree visibility pay the SSH/tmux cost.

This closes the OracleManifest follow-up series except Sub-PR 3 (federation routing), which remains the single open item on #841.

## What ships

**`loadManifestAsync(scanFn?)`** — same return shape as `loadManifest()`, with worktree scan folded in.
- Worktree-only oracles surface with `source: "worktree"` and `localPath = wt.path`.
- Worktrees that duplicate fleet/oracles-json entries merge `localPath` (only if absent) and append `worktree` to the entry's sources — no second entry is created.
- `oracles-json` retains first-dibs on `localPath` (canonical filesystem path).

**`oracleNameFromWorktree()`** — derives the oracle short-name from a worktree:
1. `tmuxWindow` ending in `-oracle` (preferred — explicit binding).
2. `mainRepo` basename ending in `-oracle` (filesystem fallback).
3. Returns `null` when neither matches the convention.

**`loadManifestCachedAsync(ttlMs, scanFn?)`** — async TTL cache, separate from the sync cache because the return shape differs and most consumers don't need worktree visibility on hot paths.

**`invalidateManifest()`** — now resets BOTH sync and async caches. Existing callers continue to work; the contract is now strictly stronger.

**`ScanWorktreesFn` / `WorktreeLite`** — exported types so callers (and tests) can inject a scan function. Tests use this for fast deterministic fixtures with zero SSH.

## Failure isolation

- `scanWorktrees()` rejection → silently fall back to the sync manifest. A flaky tmux/SSH must not brick `maw oracle ls --with-worktrees` once consumers migrate.
- The `core/fleet/worktrees-scan` module is imported lazily inside `loadManifestAsync` — importing `oracle-manifest.ts` itself stays free of SSH transport deps.

## Why a separate function (not a flag)

Pulling the async work into the sync loader would change every existing caller's signature. Sub-PRs 1, 2, 4 deliberately reused the sync loader; this PR preserves that. Async opt-in is a per-consumer migration that follows in separate PRs.

## Out of scope

No caller migrated. Consumers that want worktree visibility opt in via their own PRs (the same incremental pattern the rest of #841 used).

## Test plan

- [x] New `test/isolated/oracle-manifest-async.test.ts` — 16 cases, 42 assertions:
  - worktree-only oracle surfaces with `source="worktree"`
  - mainRepo-derived name when no tmuxWindow
  - unbindable worktrees skipped
  - fleet+worktree dedupe merges localPath, no duplicate entry
  - oracles-json localPath preserved when worktree path differs
  - sync vs async diff — worktree-only entries appear ONLY in async result
  - async with empty scan equals sync by content
  - scan throwing → falls back to sync manifest, never rejects
  - TTL cache returns same reference within window
  - `ttlMs=0` disables cache
  - `invalidateManifest()` clears both sync and async caches
  - `oracleNameFromWorktree` precedence (tmuxWindow > mainRepo)
- [x] Existing `test/isolated/oracle-manifest.test.ts` (22 cases) green and unchanged.
- [x] `tsc --noEmit` clean.
- [x] CalVer bumped → `26.4.29-alpha.23`.
- [ ] CalVer Release on alpha after merge.

## Sub-PR ladder for #841

- [x] 1. `maw oracle ls` (#845)
- [x] 2. `maw doctor` (#856)
- [ ] 3. federation routing — remaining
- [x] 4. `shouldAutoWake()` (#860)
- [x] 5. worktree scan async loader — this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)