### PR TITLE
refactor(calver): revert to hour-bucket scheme with collision letter suffix (#858)

### DIFF
--- a/scripts/calver.ts
+++ b/scripts/calver.ts
@@ -1,21 +1,37 @@
 #!/usr/bin/env bun
 // CalVer bump for maw-js
 //
-// Scheme: v{yy}.{m}.{d}[-(alpha|beta).{N}]
-// Spec:   https://github.com/Soul-Brews-Studio/mawjs-oracle/blob/main/%CF%88/inbox/2026-04-18_proposal-calver-skills-cli.md
-// Ported from: Soul-Brews-Studio/arra-oracle-skills-cli (PR #262)
-// Umbrella: #526
-// Option A (#766): monotonic running counter — N starts at 0 each day,
-// counts up per release. Walk existing tags AND package.json (#784) for
-// today's date and pick max+1.
-// Beta channel (#754): parallel hourly channel, independent counter.
-// No timestamp encoded in the alpha/beta number; pure ordering.
+// Scheme: v{yy}.{m}.{d}[-(alpha|beta).{hh}{letter?}]
+//
+// Per #858: alpha numbers encode the wall-clock hour (0–23). Multiple releases
+// in the same hour add a collision letter suffix starting at `b`:
+//   first  release in 18:00 → 26.4.29-alpha.18
+//   second release in 18:00 → 26.4.29-alpha.18b
+//   third  release in 18:00 → 26.4.29-alpha.18c
+//   ...
+//   26th   release in 18:00 → 26.4.29-alpha.18z   (cap — error if exceeded)
+//
+// Self-describing: the alpha number tells you when it shipped. Trade-off vs
+// the post-#766 monotonic counter: hour-bucketing caps releases per hour at
+// 26 (one plain + b–z), and busy hours show as `.18b/.18c/...` rather than a
+// dense run of integers.
+//
+// Backward compatibility: existing tags from the monotonic-counter era (e.g.
+// `v26.4.29-alpha.21`) are NOT misread by the new collision detector — only
+// tags whose suffix matches the *current hour* (with an optional letter) are
+// counted as collisions. Pre-existing higher-numbered tags from earlier in
+// the day stay valid in git history.
+//
+// Beta channel (#754) follows the same hour-bucket + letter rule with its
+// own independent space.
+//
 // Timezone comes from the shell — set TZ=Asia/Bangkok in CI if needed.
 //
 // Usage:
-//   bun scripts/calver.ts                  → 26.4.18-alpha.{next-N}
-//   bun scripts/calver.ts --beta           → 26.4.18-beta.{next-N}
+//   bun scripts/calver.ts                  → 26.4.18-alpha.{hh}[letter?]
+//   bun scripts/calver.ts --beta           → 26.4.18-beta.{hh}[letter?]
 //   bun scripts/calver.ts --stable         → 26.4.18
+//   bun scripts/calver.ts --hour 14        → 26.4.18-alpha.14[letter?]
 //   bun scripts/calver.ts --check          → dry-run (no writes)
 
 import { $ } from "bun";
@@ -23,7 +39,7 @@ import { readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 
 export type Channel = "alpha" | "beta";
-type Args = { stable: boolean; channel?: Channel; check: boolean; now?: Date };
+type Args = { stable: boolean; channel?: Channel; hour?: number; check: boolean; now?: Date };
 
 function parseArgs(argv: string[]): Args {
   const args: Args = { stable: false, channel: "alpha", check: false };
@@ -33,10 +49,14 @@ function parseArgs(argv: string[]): Args {
     else if (a === "--beta") args.channel = "beta";
     else if (a === "--check" || a === "--dry-run") args.check = true;
     else if (a === "--hour") {
-      console.error("--hour deprecated as of #766; CalVer now uses tag-walk monotonic counter");
-      process.exit(2);
-    }
-    else if (a === "-h" || a === "--help") {
+      const v = argv[++i];
+      const n = parseInt(v, 10);
+      if (!Number.isInteger(n) || n < 0 || n > 23) {
+        console.error(`--hour expects integer 0-23, got: ${v}`);
+        process.exit(2);
+      }
+      args.hour = n;
+    } else if (a === "-h" || a === "--help") {
       console.log(HELP);
       process.exit(0);
     } else {
@@ -56,20 +76,22 @@ const HELP = `Usage: bun scripts/calver.ts [options]
 
 Compute next CalVer version and bump package.json.
 
-Scheme: v{yy}.{m}.{d}[-(alpha|beta).{N}] — N is a monotonic running counter
-that starts at 0 each day and counts up per release (Option A from #766).
-Alpha and beta are independent channels with their own counters (#754).
+Scheme: v{yy}.{m}.{d}[-(alpha|beta).{hh}{letter?}] — hh is the wall-clock
+hour 0-23; collisions within the same hour add a letter suffix b, c, …, z
+(per #858). Cap is 26 releases/hour.
 
 Options:
   --stable         Cut stable (no alpha/beta suffix)
-  --beta           Cut beta instead of alpha (separate counter)
+  --beta           Cut beta instead of alpha (separate space)
+  --hour N         Override hour (0-23) — useful for backfill or testing
   --check          Dry-run: print target, don't modify files
   -h, --help       Show help
 
 Examples:
-  bun scripts/calver.ts                  next alpha → 26.4.18-alpha.{next-N}
-  bun scripts/calver.ts --beta           next beta  → 26.4.18-beta.{next-N}
-  bun scripts/calver.ts --stable         stable cut → 26.4.18
+  bun scripts/calver.ts                  next alpha at current hour → 26.4.18-alpha.10[b…]
+  bun scripts/calver.ts --beta           next beta  at current hour → 26.4.18-beta.10[b…]
+  bun scripts/calver.ts --stable         stable cut                 → 26.4.18
+  bun scripts/calver.ts --hour 14        alpha at 14:xx             → 26.4.18-alpha.14[b…]
   bun scripts/calver.ts --check          print only, no write`;
 
 export function dateBase(now: Date): string {
@@ -81,16 +103,12 @@ export function dateBase(now: Date): string {
 
 /**
  * #819: extract the CalVer base (YY.M.D) from a version string. Accepts
- * `v26.4.29`, `26.4.29`, `v26.4.29-alpha.5`, `26.4.29-alpha.5`, etc.
- * Returns null if the string does not look like a CalVer base — caller can
- * then fall back to today's date. Mirrors maxNFromPackageJson's tolerant
- * accept-with-or-without-leading-v parsing.
+ * `v26.4.29`, `26.4.29`, `v26.4.29-alpha.5`, `26.4.29-alpha.5b`, etc.
+ * Returns null if the string does not look like a CalVer base.
  */
 export function extractBaseFromVersion(version: string): string | null {
   if (!version) return null;
   const stripped = version.startsWith("v") ? version.slice(1) : version;
-  // Match leading YY.M.D — terminated by `-`, `+`, end of string, or a dot
-  // that is NOT part of the base (i.e. caller passed a 4-segment thing).
   const m = stripped.match(/^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/);
   if (!m) return null;
   const [, yy, mo, da] = m;
@@ -99,8 +117,7 @@ export function extractBaseFromVersion(version: string): string | null {
 
 /**
  * #819: lexicographic-safe compare of two CalVer bases by integer segment.
- * Returns negative if a < b, 0 if equal, positive if a > b. Accepts only
- * `YY.M.D` triples — anything else throws (caller validates upstream).
+ * Returns negative if a < b, 0 if equal, positive if a > b.
  */
 export function compareBases(a: string, b: string): number {
   const pa = a.split(".").map((x) => parseInt(x, 10));
@@ -116,11 +133,8 @@ export function compareBases(a: string, b: string): number {
 
 /**
  * #819: pick the effective base for the next bump — the later of today's
- * clock-derived base and the package.json-derived base. This prevents the
- * post-stable-cut downgrade where package.json carries `YY.M.(D+1)` but the
- * clock still reads `YY.M.D` (tomorrow's stable already cut, today's clock
- * still ticking). Without this, the script targets `YY.M.D-alpha.0` — a
- * downgrade against `YY.M.(D+1)-alpha.N`.
+ * clock-derived base and the package.json-derived base. Prevents the
+ * post-stable-cut downgrade described in #819.
  */
 export function effectiveBase(todayBase: string, packageVersion: string): string {
   const pkgBase = extractBaseFromVersion(packageVersion);
@@ -129,80 +143,121 @@ export function effectiveBase(todayBase: string, packageVersion: string): string
 }
 
 /**
- * Walk git tags matching `v{base}-{channel}.*` and return the max N found,
- * or -1 if no matching tags exist for this date+channel yet.
+ * Parse a tag/version suffix into {hour, letterIndex} where letterIndex is
+ * 0 for plain `{hh}`, 1 for `{hh}b`, 2 for `{hh}c`, …, 25 for `{hh}z`.
  *
- * Backwards-compatible alias `maxAlphaFromTags(base, tags)` defaults to alpha.
+ * Returns null on:
+ *   - hour out of range (must be 0-23) — rejects legacy monotonic ints ≥ 24
+ *   - letter not in [b-z] — rejects "16a" (reserved for plain), multi-letter
+ *     ("16ab"), uppercase, and any non-letter ("16-rc", "16.0", etc.)
+ *
+ * Exported for tests.
  */
-export function maxNFromTags(base: string, channel: Channel, tags: string[]): number {
+export function parseSuffix(suffix: string): { hour: number; letterIndex: number } | null {
+  // Match "{digits}" or "{digits}{single-lowercase-letter}".
+  const m = suffix.match(/^(\d+)([b-z])?$/);
+  if (!m) return null;
+  const hour = parseInt(m[1], 10);
+  if (!Number.isInteger(hour) || hour < 0 || hour > 23) return null;
+  const letter = m[2];
+  // letter "b" → index 1, "c" → 2, …, "z" → 25
+  const letterIndex = letter ? letter.charCodeAt(0) - "a".charCodeAt(0) : 0;
+  return { hour, letterIndex };
+}
+
+/**
+ * Render a bucket index back to a suffix. 0 → "{hh}" (plain), 1 → "{hh}b",
+ * …, 25 → "{hh}z". Throws on overflow (one-day-one-hour cap is 26 releases).
+ */
+export function renderSuffix(hour: number, letterIndex: number): string {
+  if (letterIndex < 0 || letterIndex > 25) {
+    throw new Error(`hour-bucket collision overflow: letterIndex=${letterIndex} (max 25 = 'z')`);
+  }
+  if (letterIndex === 0) return `${hour}`;
+  const letter = String.fromCharCode("a".charCodeAt(0) + letterIndex);
+  return `${hour}${letter}`;
+}
+
+/**
+ * Walk tags for {base}-{channel}.* and return the highest letterIndex *for the
+ * given hour bucket*. Returns -1 if no tag in that bucket exists yet.
+ *
+ * Legacy monotonic tags (e.g. v26.4.29-alpha.21 from the pre-#858 counter)
+ * coexist: numerically `21` parses as hour 21 with letterIndex 0, so it
+ * counts as a collision IF the user is bumping during hour 21. Other-hour
+ * legacy tags are correctly ignored.
+ *
+ * Suffixes ≥ 24 (legacy ints like alpha.24, alpha.25) are rejected by
+ * parseSuffix and don't poison the collision space.
+ */
+export function maxLetterInHour(
+  base: string,
+  channel: Channel,
+  hour: number,
+  tags: string[],
+): number {
   const prefix = `v${base}-${channel}.`;
   let max = -1;
   for (const tag of tags) {
     if (!tag.startsWith(prefix)) continue;
     const rest = tag.slice(prefix.length);
-    // Option A: pure integer N (no further dots). Reject e.g. "12.0".
-    if (!/^\d+$/.test(rest)) continue;
-    const n = parseInt(rest, 10);
-    if (Number.isInteger(n) && n > max) max = n;
+    const parsed = parseSuffix(rest);
+    if (!parsed) continue;
+    if (parsed.hour !== hour) continue;
+    if (parsed.letterIndex > max) max = parsed.letterIndex;
   }
   return max;
 }
 
 /**
- * Back-compat alias: alpha-only tag walk.
+ * Same scan applied to package.json's version string. Returns -1 if the
+ * version doesn't match base+channel+hour, or if it's not parseable.
  */
-export function maxAlphaFromTags(base: string, tags: string[]): number {
-  return maxNFromTags(base, "alpha", tags);
-}
-
-/**
- * #784: walk package.json.version as an additional source-of-truth for the
- * monotonic counter. Post-#767, alpha releases merge to the `alpha` branch,
- * but `calver-release.yml` only fires on push to `main` — so no git tags get
- * created for in-flight alphas. Without this, tag-walk returns -1 and we
- * regress to alpha.0 on every alpha-branch run.
- *
- * Parses `vYY.M.D-{channel}.{N}` (with or without leading "v") and returns N
- * only if base+channel match today's. Rejects non-integer suffixes and
- * empty/missing strings (returns -1).
- */
-export function maxNFromPackageJson(
+export function maxLetterInHourFromPackageJson(
   base: string,
   channel: Channel,
+  hour: number,
   packageVersion: string,
 ): number {
   if (!packageVersion) return -1;
-  // Accept either `vYY.M.D-channel.N` or `YY.M.D-channel.N`.
   const stripped = packageVersion.startsWith("v") ? packageVersion.slice(1) : packageVersion;
   const prefix = `${base}-${channel}.`;
   if (!stripped.startsWith(prefix)) return -1;
   const rest = stripped.slice(prefix.length);
-  if (!/^\d+$/.test(rest)) return -1;
-  const n = parseInt(rest, 10);
-  return Number.isInteger(n) ? n : -1;
+  const parsed = parseSuffix(rest);
+  if (!parsed) return -1;
+  if (parsed.hour !== hour) return -1;
+  return parsed.letterIndex;
 }
 
 async function listChannelTags(base: string, channel: Channel): Promise<string[]> {
   const res = await $`git tag --list ${`v${base}-${channel}.*`}`.nothrow().quiet();
   if (res.exitCode !== 0) return [];
-  return res.stdout.toString().split("\n").map(s => s.trim()).filter(Boolean);
+  return res.stdout.toString().split("\n").map((s) => s.trim()).filter(Boolean);
 }
 
-export function computeVersion(args: Args, tags: string[] = [], packageVersion: string = ""): string {
+export function computeVersion(
+  args: Args,
+  tags: string[] = [],
+  packageVersion: string = "",
+): string {
   const now = args.now ?? new Date();
   const todayBase = dateBase(now);
-  // #819: if package.json is future-dated (e.g. tomorrow's stable just cut),
-  // bump against that base — never downgrade to today's date.
   const base = args.stable ? todayBase : effectiveBase(todayBase, packageVersion);
   if (args.stable) return base;
+
   const channel = args.channel ?? "alpha";
-  // Take max of (tag-walk N, package.json N) against the effective base —
-  // see maxNFromPackageJson (#784) and effectiveBase (#819).
-  const tagMax = maxNFromTags(base, channel, tags);
-  const pkgMax = maxNFromPackageJson(base, channel, packageVersion);
+  const hour = args.hour ?? now.getHours();
+  if (!Number.isInteger(hour) || hour < 0 || hour > 23) {
+    throw new Error(`invalid hour: ${hour} (must be 0-23)`);
+  }
+
+  const tagMax = maxLetterInHour(base, channel, hour, tags);
+  const pkgMax = maxLetterInHourFromPackageJson(base, channel, hour, packageVersion);
   const max = Math.max(tagMax, pkgMax);
-  const next = max + 1; // -1 → 0 if none yet today
-  return `${base}-${channel}.${next}`;
+  // -1 → no collision yet, plain `{hh}`. Otherwise next letter.
+  const next = max + 1;
+  return `${base}-${channel}.${renderSuffix(hour, next)}`;
 }
 
 async function tagExists(version: string): Promise<boolean> {
@@ -215,13 +270,9 @@ async function main() {
   const now = args.now ?? new Date();
   const todayBase = dateBase(now);
 
-  // #784: read package.json once up front so its version participates in the
-  // source-of-truth set for the monotonic counter (see computeVersion).
   const pkgPath = join(process.cwd(), "package.json");
   const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
 
-  // #819: choose the effective base before fetching tags so we list tags for
-  // the correct date when package.json is future-dated.
   const base = args.stable ? todayBase : effectiveBase(todayBase, pkg.version ?? "");
 
   const channelForTags: Channel = args.channel ?? "alpha";
@@ -237,7 +288,7 @@ async function main() {
   }
 
   if (await tagExists(version)) {
-    // Should never happen for alpha (we picked max+1) but stable can collide.
+    // Should never happen — we picked the next free letter — but guard the race.
     console.error(`\n❌ tag v${version} already exists`);
     if (args.stable) {
       console.error(`   → stable for today already cut; nothing to do`);

--- a/test/calver.test.ts
+++ b/test/calver.test.ts
@@ -5,9 +5,10 @@ import {
   dateBase,
   effectiveBase,
   extractBaseFromVersion,
-  maxAlphaFromTags,
-  maxNFromPackageJson,
-  maxNFromTags,
+  maxLetterInHour,
+  maxLetterInHourFromPackageJson,
+  parseSuffix,
+  renderSuffix,
 } from "../scripts/calver";
 
 describe("calver dateBase", () => {
@@ -18,339 +19,352 @@ describe("calver dateBase", () => {
   });
 });
 
-describe("calver maxAlphaFromTags", () => {
-  it("returns -1 when no matching tags", () => {
-    expect(maxAlphaFromTags("26.4.18", [])).toBe(-1);
-    expect(maxAlphaFromTags("26.4.18", ["v26.4.17-alpha.5", "v26.4.19-alpha.0"])).toBe(-1);
+describe("calver parseSuffix (#858 hour-bucket + collision letter)", () => {
+  it("plain hour with no letter → letterIndex 0", () => {
+    expect(parseSuffix("0")).toEqual({ hour: 0, letterIndex: 0 });
+    expect(parseSuffix("12")).toEqual({ hour: 12, letterIndex: 0 });
+    expect(parseSuffix("23")).toEqual({ hour: 23, letterIndex: 0 });
   });
 
-  it("returns max N across matching alpha tags", () => {
-    expect(
-      maxAlphaFromTags("26.4.27", ["v26.4.27-alpha.11", "v26.4.27-alpha.12", "v26.4.27-alpha.13"])
-    ).toBe(13);
+  it("letter b → letterIndex 1, ..., z → 25", () => {
+    expect(parseSuffix("16b")).toEqual({ hour: 16, letterIndex: 1 });
+    expect(parseSuffix("16c")).toEqual({ hour: 16, letterIndex: 2 });
+    expect(parseSuffix("16z")).toEqual({ hour: 16, letterIndex: 25 });
   });
 
-  it("handles non-monotonic tag order", () => {
-    expect(
-      maxAlphaFromTags("26.4.27", ["v26.4.27-alpha.13", "v26.4.27-alpha.0", "v26.4.27-alpha.7"])
-    ).toBe(13);
+  it("rejects letter 'a' (reserved for plain hour)", () => {
+    expect(parseSuffix("16a")).toBeNull();
   });
 
-  it("ignores tags with non-integer suffixes (e.g. two-tier alpha.12.0)", () => {
-    expect(
-      maxAlphaFromTags("26.4.27", ["v26.4.27-alpha.5", "v26.4.27-alpha.12.0"])
-    ).toBe(5);
+  it("rejects out-of-range hour (legacy monotonic ≥ 24 must NOT poison)", () => {
+    expect(parseSuffix("24")).toBeNull();
+    expect(parseSuffix("25")).toBeNull();
+    expect(parseSuffix("99")).toBeNull();
   });
 
-  it("handles single-digit and multi-digit N", () => {
-    expect(maxAlphaFromTags("26.4.18", ["v26.4.18-alpha.0"])).toBe(0);
-    expect(maxAlphaFromTags("26.4.18", ["v26.4.18-alpha.99"])).toBe(99);
-  });
-});
-
-describe("calver computeVersion", () => {
-  const apr18_0937 = new Date(2026, 3, 18, 9, 37);
-  const apr27_1200 = new Date(2026, 3, 27, 12, 0);
-  const jan1_0005  = new Date(2027, 0, 1, 0, 5);
-
-  it("stable: yy.m.d (ignores tags)", () => {
-    expect(computeVersion({ stable: true, check: false, now: apr18_0937 })).toBe("26.4.18");
-    expect(computeVersion({ stable: true, check: false, now: jan1_0005 })).toBe("27.1.1");
-  });
-
-  it("alpha: starts at 0 when no tags exist for today", () => {
-    expect(computeVersion({ stable: false, check: false, now: apr18_0937 }, [])).toBe("26.4.18-alpha.0");
-    expect(computeVersion({ stable: false, check: false, now: jan1_0005 }, [])).toBe("27.1.1-alpha.0");
-  });
-
-  it("alpha: bumps to max+1 from existing today's tags", () => {
-    const tags = ["v26.4.27-alpha.11", "v26.4.27-alpha.12"];
-    expect(computeVersion({ stable: false, check: false, now: apr27_1200 }, tags)).toBe("26.4.27-alpha.13");
-  });
-
-  it("alpha: ignores tags from other dates", () => {
-    const tags = ["v26.4.26-alpha.99", "v26.4.28-alpha.50"];
-    expect(computeVersion({ stable: false, check: false, now: apr27_1200 }, tags)).toBe("26.4.27-alpha.0");
-  });
-
-  it("--stable ignores tags entirely", () => {
-    const tags = ["v26.4.27-alpha.99"];
-    expect(computeVersion({ stable: true, channel: "alpha", check: false, now: apr27_1200 }, tags)).toBe("26.4.27");
+  it("rejects multi-letter / non [b-z] / non-letter suffixes", () => {
+    expect(parseSuffix("16ab")).toBeNull();
+    expect(parseSuffix("16BB")).toBeNull(); // case-sensitive
+    expect(parseSuffix("16-rc")).toBeNull();
+    expect(parseSuffix("16.0")).toBeNull();
+    expect(parseSuffix("16.b")).toBeNull();
+    expect(parseSuffix("foo")).toBeNull();
+    expect(parseSuffix("")).toBeNull();
   });
 });
 
-describe("calver beta channel (#754)", () => {
-  const apr28 = new Date(2026, 3, 28, 12, 0);
-
-  it("maxNFromTags isolates alpha and beta counters", () => {
-    const tags = [
-      "v26.4.28-alpha.0",
-      "v26.4.28-alpha.1",
-      "v26.4.28-beta.0",
-    ];
-    expect(maxNFromTags("26.4.28", "alpha", tags)).toBe(1);
-    expect(maxNFromTags("26.4.28", "beta", tags)).toBe(0);
+describe("calver renderSuffix", () => {
+  it("letterIndex 0 → plain hour", () => {
+    expect(renderSuffix(0, 0)).toBe("0");
+    expect(renderSuffix(16, 0)).toBe("16");
   });
 
-  it("maxAlphaFromTags is a back-compat alias for alpha channel", () => {
-    const tags = ["v26.4.28-alpha.5", "v26.4.28-beta.99"];
-    expect(maxAlphaFromTags("26.4.28", tags)).toBe(5);
+  it("letterIndex 1 → 'b', 2 → 'c', ..., 25 → 'z'", () => {
+    expect(renderSuffix(16, 1)).toBe("16b");
+    expect(renderSuffix(16, 2)).toBe("16c");
+    expect(renderSuffix(16, 25)).toBe("16z");
   });
 
-  it("--beta computes next beta version with independent counter", () => {
-    const tags = ["v26.4.28-alpha.21", "v26.4.28-beta.2"];
-    expect(
-      computeVersion({ stable: false, channel: "beta", check: false, now: apr28 }, tags)
-    ).toBe("26.4.28-beta.3");
+  it("throws on overflow (cap is letterIndex 25)", () => {
+    expect(() => renderSuffix(16, 26)).toThrow(/overflow/i);
+    expect(() => renderSuffix(16, -1)).toThrow(/overflow/i);
   });
 
-  it("--beta starts at 0 when no beta tags exist for today", () => {
-    const tags = ["v26.4.28-alpha.50"];
-    expect(
-      computeVersion({ stable: false, channel: "beta", check: false, now: apr28 }, tags)
-    ).toBe("26.4.28-beta.0");
-  });
-
-  it("alpha and beta on the same day do not collide", () => {
-    const tags = ["v26.4.28-alpha.5"];
-    const alpha = computeVersion({ stable: false, channel: "alpha", check: false, now: apr28 }, tags);
-    const beta = computeVersion({ stable: false, channel: "beta", check: false, now: apr28 }, tags);
-    expect(alpha).toBe("26.4.28-alpha.6");
-    expect(beta).toBe("26.4.28-beta.0");
-  });
-
-  it("beta tag walk rejects two-tier suffixes (e.g. beta.12.0)", () => {
-    const tags = ["v26.4.28-beta.5", "v26.4.28-beta.12.0"];
-    expect(maxNFromTags("26.4.28", "beta", tags)).toBe(5);
+  it("round-trip: parseSuffix(renderSuffix(h, n)) === { h, n }", () => {
+    for (const h of [0, 5, 16, 23]) {
+      for (const n of [0, 1, 12, 25]) {
+        expect(parseSuffix(renderSuffix(h, n))).toEqual({ hour: h, letterIndex: n });
+      }
+    }
   });
 });
 
-describe("calver maxNFromPackageJson (#784)", () => {
-  it("returns N for matching alpha base+channel", () => {
-    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-alpha.24")).toBe(24);
-    expect(maxNFromPackageJson("26.4.28", "alpha", "v26.4.28-alpha.7")).toBe(7);
+describe("calver maxLetterInHour", () => {
+  it("returns -1 when no matching tags for the hour", () => {
+    expect(maxLetterInHour("26.4.29", "alpha", 16, [])).toBe(-1);
+    expect(
+      maxLetterInHour("26.4.29", "alpha", 16, ["v26.4.29-alpha.10", "v26.4.28-alpha.16"]),
+    ).toBe(-1);
   });
 
-  it("returns N for matching beta base+channel", () => {
-    expect(maxNFromPackageJson("26.4.28", "beta", "26.4.28-beta.3")).toBe(3);
+  it("plain hour bucket → letterIndex 0", () => {
+    expect(maxLetterInHour("26.4.29", "alpha", 16, ["v26.4.29-alpha.16"])).toBe(0);
   });
 
-  it("returns -1 when date base does not match", () => {
-    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.27-alpha.99")).toBe(-1);
-    expect(maxNFromPackageJson("26.4.28", "alpha", "26.5.1-alpha.0")).toBe(-1);
+  it("walks letter sequence and returns max", () => {
+    const tags = ["v26.4.29-alpha.16", "v26.4.29-alpha.16b", "v26.4.29-alpha.16c"];
+    expect(maxLetterInHour("26.4.29", "alpha", 16, tags)).toBe(2);
+  });
+
+  it("non-monotonic tag order doesn't matter", () => {
+    const tags = ["v26.4.29-alpha.16c", "v26.4.29-alpha.16", "v26.4.29-alpha.16b"];
+    expect(maxLetterInHour("26.4.29", "alpha", 16, tags)).toBe(2);
+  });
+
+  it("isolates by hour — other-hour tags don't count", () => {
+    const tags = ["v26.4.29-alpha.16", "v26.4.29-alpha.17", "v26.4.29-alpha.17b"];
+    expect(maxLetterInHour("26.4.29", "alpha", 16, tags)).toBe(0);
+    expect(maxLetterInHour("26.4.29", "alpha", 17, tags)).toBe(1);
+  });
+
+  it("isolates alpha and beta", () => {
+    const tags = ["v26.4.29-alpha.16b", "v26.4.29-beta.16"];
+    expect(maxLetterInHour("26.4.29", "alpha", 16, tags)).toBe(1);
+    expect(maxLetterInHour("26.4.29", "beta", 16, tags)).toBe(0);
+  });
+
+  it("legacy monotonic tags ≥ 24 are rejected (don't poison)", () => {
+    // From the pre-#858 monotonic counter: v26.4.29-alpha.24 etc. could exist.
+    // parseSuffix rejects hour=24+, so these don't claim any bucket.
+    const tags = ["v26.4.29-alpha.24", "v26.4.29-alpha.99"];
+    for (let h = 0; h < 24; h++) {
+      expect(maxLetterInHour("26.4.29", "alpha", h, tags)).toBe(-1);
+    }
+  });
+
+  it("legacy monotonic tag ≤ 23 coexists as a same-hour collision", () => {
+    // A tag like v26.4.29-alpha.21 from monotonic-era IS legitimately the
+    // 21:xx hour bucket today. Treat it as a collision when bumping in 21.
+    const tags = ["v26.4.29-alpha.21"];
+    expect(maxLetterInHour("26.4.29", "alpha", 21, tags)).toBe(0); // claim plain
+    expect(maxLetterInHour("26.4.29", "alpha", 18, tags)).toBe(-1); // hour 18 free
+  });
+
+  it("rejects two-tier or malformed suffixes", () => {
+    const tags = ["v26.4.29-alpha.16.0", "v26.4.29-alpha.16-rc", "v26.4.29-alpha.16ab"];
+    expect(maxLetterInHour("26.4.29", "alpha", 16, tags)).toBe(-1);
+  });
+
+  it("ignores tags from other dates", () => {
+    const tags = ["v26.4.28-alpha.16z"];
+    expect(maxLetterInHour("26.4.29", "alpha", 16, tags)).toBe(-1);
+  });
+});
+
+describe("calver maxLetterInHourFromPackageJson", () => {
+  it("returns letterIndex for matching base/channel/hour", () => {
+    expect(maxLetterInHourFromPackageJson("26.4.29", "alpha", 16, "26.4.29-alpha.16")).toBe(0);
+    expect(maxLetterInHourFromPackageJson("26.4.29", "alpha", 16, "26.4.29-alpha.16b")).toBe(1);
+    expect(maxLetterInHourFromPackageJson("26.4.29", "alpha", 16, "v26.4.29-alpha.16c")).toBe(2);
+  });
+
+  it("returns -1 when hour does not match", () => {
+    expect(maxLetterInHourFromPackageJson("26.4.29", "alpha", 17, "26.4.29-alpha.16")).toBe(-1);
+    expect(maxLetterInHourFromPackageJson("26.4.29", "alpha", 16, "26.4.29-alpha.17b")).toBe(-1);
   });
 
   it("returns -1 when channel does not match", () => {
-    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-beta.5")).toBe(-1);
-    expect(maxNFromPackageJson("26.4.28", "beta", "26.4.28-alpha.5")).toBe(-1);
+    expect(maxLetterInHourFromPackageJson("26.4.29", "alpha", 16, "26.4.29-beta.16")).toBe(-1);
+    expect(maxLetterInHourFromPackageJson("26.4.29", "beta", 16, "26.4.29-alpha.16")).toBe(-1);
   });
 
-  it("rejects non-integer suffix (e.g. two-tier alpha.12.0 or alpha.12-rc)", () => {
-    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-alpha.12.0")).toBe(-1);
-    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-alpha.12-rc")).toBe(-1);
-    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-alpha.abc")).toBe(-1);
+  it("returns -1 when base does not match", () => {
+    expect(maxLetterInHourFromPackageJson("26.4.29", "alpha", 16, "26.4.28-alpha.16")).toBe(-1);
   });
 
-  it("returns -1 for empty or stable-only version strings", () => {
-    expect(maxNFromPackageJson("26.4.28", "alpha", "")).toBe(-1);
-    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28")).toBe(-1);
+  it("returns -1 for empty / stable / malformed", () => {
+    expect(maxLetterInHourFromPackageJson("26.4.29", "alpha", 16, "")).toBe(-1);
+    expect(maxLetterInHourFromPackageJson("26.4.29", "alpha", 16, "26.4.29")).toBe(-1);
+    expect(maxLetterInHourFromPackageJson("26.4.29", "alpha", 16, "26.4.29-alpha.")).toBe(-1);
+    expect(maxLetterInHourFromPackageJson("26.4.29", "alpha", 16, "26.4.29-alpha.bogus")).toBe(-1);
+  });
+
+  it("rejects legacy monotonic ≥ 24 (for hour-mismatch reason)", () => {
+    // alpha.99 cannot match any hour bucket — parseSuffix returns null.
+    for (let h = 0; h < 24; h++) {
+      expect(maxLetterInHourFromPackageJson("26.4.29", "alpha", h, "26.4.29-alpha.99")).toBe(-1);
+    }
   });
 });
 
-describe("calver computeVersion package.json walk (#784)", () => {
+describe("calver computeVersion (hour-bucket)", () => {
+  // Date constructor uses 0-indexed months. (2026, 3, 29, 16, 0) = April 29, 16:00.
+  const apr29_1600 = new Date(2026, 3, 29, 16, 0);
+  const apr29_0900 = new Date(2026, 3, 29, 9, 0);
+  const jan1_0005 = new Date(2027, 0, 1, 0, 5);
+
+  it("stable: yy.m.d (ignores tags + hour)", () => {
+    expect(computeVersion({ stable: true, check: false, now: apr29_1600 })).toBe("26.4.29");
+    expect(computeVersion({ stable: true, check: false, now: jan1_0005 })).toBe("27.1.1");
+  });
+
+  it("alpha: plain hour when no tags exist for current hour", () => {
+    expect(computeVersion({ stable: false, check: false, now: apr29_1600 }, [])).toBe(
+      "26.4.29-alpha.16",
+    );
+    expect(computeVersion({ stable: false, check: false, now: apr29_0900 }, [])).toBe(
+      "26.4.29-alpha.9",
+    );
+  });
+
+  it("alpha: collision adds 'b'", () => {
+    const tags = ["v26.4.29-alpha.16"];
+    expect(computeVersion({ stable: false, check: false, now: apr29_1600 }, tags)).toBe(
+      "26.4.29-alpha.16b",
+    );
+  });
+
+  it("alpha: 'b' + 'c' + ... up to 'z'", () => {
+    const baseTag = "v26.4.29-alpha.";
+    const tags = [
+      baseTag + "16",
+      baseTag + "16b",
+      baseTag + "16c",
+      baseTag + "16d",
+    ];
+    expect(computeVersion({ stable: false, check: false, now: apr29_1600 }, tags)).toBe(
+      "26.4.29-alpha.16e",
+    );
+  });
+
+  it("alpha: 26-release-per-hour cap throws", () => {
+    const tags: string[] = ["v26.4.29-alpha.16"];
+    for (let i = 1; i <= 25; i++) {
+      const letter = String.fromCharCode("a".charCodeAt(0) + i); // b..z
+      tags.push("v26.4.29-alpha.16" + letter);
+    }
+    expect(() => computeVersion({ stable: false, check: false, now: apr29_1600 }, tags)).toThrow(
+      /overflow/i,
+    );
+  });
+
+  it("alpha: other-hour tags don't affect current hour", () => {
+    const tags = ["v26.4.29-alpha.0", "v26.4.29-alpha.0b", "v26.4.29-alpha.17"];
+    expect(computeVersion({ stable: false, check: false, now: apr29_1600 }, tags)).toBe(
+      "26.4.29-alpha.16",
+    );
+  });
+
+  it("alpha: ignores tags from other dates", () => {
+    const tags = ["v26.4.28-alpha.16z", "v26.4.30-alpha.16"];
+    expect(computeVersion({ stable: false, check: false, now: apr29_1600 }, tags)).toBe(
+      "26.4.29-alpha.16",
+    );
+  });
+
+  it("--hour override picks bucket explicitly", () => {
+    expect(
+      computeVersion({ stable: false, hour: 14, check: false, now: apr29_1600 }, []),
+    ).toBe("26.4.29-alpha.14");
+    expect(
+      computeVersion(
+        { stable: false, hour: 14, check: false, now: apr29_1600 },
+        ["v26.4.29-alpha.14"],
+      ),
+    ).toBe("26.4.29-alpha.14b");
+  });
+
+  it("--stable ignores tags + hour entirely", () => {
+    const tags = ["v26.4.29-alpha.16z"];
+    expect(
+      computeVersion({ stable: true, channel: "alpha", check: false, now: apr29_1600 }, tags),
+    ).toBe("26.4.29");
+  });
+});
+
+describe("calver beta channel (#754) under hour-bucket", () => {
+  const apr29_1600 = new Date(2026, 3, 29, 16, 0);
+
+  it("alpha and beta hour-buckets are independent", () => {
+    const tags = ["v26.4.29-alpha.16", "v26.4.29-alpha.16b"];
+    const alpha = computeVersion(
+      { stable: false, channel: "alpha", check: false, now: apr29_1600 },
+      tags,
+    );
+    const beta = computeVersion(
+      { stable: false, channel: "beta", check: false, now: apr29_1600 },
+      tags,
+    );
+    expect(alpha).toBe("26.4.29-alpha.16c");
+    expect(beta).toBe("26.4.29-beta.16"); // beta space is empty
+  });
+
+  it("--beta with prior beta tags collides correctly", () => {
+    const tags = ["v26.4.29-alpha.16z", "v26.4.29-beta.16", "v26.4.29-beta.16b"];
+    expect(
+      computeVersion({ stable: false, channel: "beta", check: false, now: apr29_1600 }, tags),
+    ).toBe("26.4.29-beta.16c");
+  });
+});
+
+describe("calver computeVersion package.json walk (hour-bucket)", () => {
+  const apr29_1600 = new Date(2026, 3, 29, 16, 0);
+  const apr30_0500 = new Date(2026, 3, 30, 5, 0);
+
+  it("package.json sets the only collision in this hour", () => {
+    expect(
+      computeVersion({ stable: false, check: false, now: apr29_1600 }, [], "26.4.29-alpha.16"),
+    ).toBe("26.4.29-alpha.16b");
+  });
+
+  it("tags + package.json: take the max collision", () => {
+    const tags = ["v26.4.29-alpha.16b"];
+    expect(
+      computeVersion({ stable: false, check: false, now: apr29_1600 }, tags, "26.4.29-alpha.16"),
+    ).toBe("26.4.29-alpha.16c");
+  });
+
+  it("date roll: clock advances → fresh hour-bucket starts at plain hh", () => {
+    expect(
+      computeVersion({ stable: false, check: false, now: apr30_0500 }, [], "26.4.29-alpha.18z"),
+    ).toBe("26.4.30-alpha.5");
+  });
+
+  it("post-stable bare YY.M.D in package.json: fresh bucket on that date", () => {
+    expect(
+      computeVersion({ stable: false, check: false, now: apr29_1600 }, [], "26.4.29"),
+    ).toBe("26.4.29-alpha.16");
+  });
+
+  it("legacy monotonic in package.json (alpha.23 from #766 era) does not poison", () => {
+    // hour=23 → that legacy tag IS a hour-23 plain-bucket claim, so a 23:xx
+    // bump becomes 23b. But for any non-23 hour the legacy tag is irrelevant.
+    expect(
+      computeVersion({ stable: false, check: false, now: apr29_1600 }, [], "26.4.29-alpha.23"),
+    ).toBe("26.4.29-alpha.16");
+    // And during the 23:00 hour:
+    const apr29_2300 = new Date(2026, 3, 29, 23, 0);
+    expect(
+      computeVersion({ stable: false, check: false, now: apr29_2300 }, [], "26.4.29-alpha.23"),
+    ).toBe("26.4.29-alpha.23b");
+  });
+});
+
+describe("calver future-dated package.json (#819 still applies)", () => {
   const apr28_1200 = new Date(2026, 3, 28, 12, 0);
 
-  it("package.json ahead of tags wins (alpha-branch case from #784)", () => {
-    // Simulates current bug: no tags exist yet for today (alpha branch),
-    // but package.json carries 26.4.28-alpha.24 from prior in-flight alphas.
-    expect(
-      computeVersion({ stable: false, check: false, now: apr28_1200 }, [], "26.4.28-alpha.24"),
-    ).toBe("26.4.28-alpha.25");
-  });
-
-  it("tags ahead of package.json wins", () => {
-    const tags = ["v26.4.28-alpha.30"];
-    expect(
-      computeVersion({ stable: false, check: false, now: apr28_1200 }, tags, "26.4.28-alpha.10"),
-    ).toBe("26.4.28-alpha.31");
-  });
-
-  it("tags and package.json at same value still increments by 1", () => {
-    const tags = ["v26.4.28-alpha.5"];
-    expect(
-      computeVersion({ stable: false, check: false, now: apr28_1200 }, tags, "26.4.28-alpha.5"),
-    ).toBe("26.4.28-alpha.6");
-  });
-
-  it("daily rollover: yesterday's package.json + no today-tags → .0", () => {
-    // Critical: without date-gating, every day would start at yesterday's N+1
-    // instead of resetting to 0. Verifies date-mismatch returns -1 from pkg-walk.
-    expect(
-      computeVersion({ stable: false, check: false, now: apr28_1200 }, [], "26.4.27-alpha.50"),
-    ).toBe("26.4.28-alpha.0");
-  });
-
-  it("yesterday's stable in package.json + today's no-tags → .0", () => {
-    // After a stable cut, package.json holds bare YY.M.D. Next-day alpha
-    // starts at .0, not at the stable's "version".
-    expect(
-      computeVersion({ stable: false, check: false, now: apr28_1200 }, [], "26.4.27"),
-    ).toBe("26.4.28-alpha.0");
-  });
-});
-
-describe("calver maxNFromPackageJson — robustness (#784 explorer findings)", () => {
-  it("rejects non-CalVer legacy version (e.g. 2.0.0-alpha.134)", () => {
-    // Pre-CalVer migration shape — the trailing 134 must NOT match.
-    expect(maxNFromPackageJson("26.4.28", "alpha", "2.0.0-alpha.134")).toBe(-1);
-  });
-
-  it("substring trap: base 26.4.2 must not match 26.4.28-alpha.N", () => {
-    // The dash boundary in `${base}-${channel}.` should anchor the match
-    // so a shorter base doesn't fall through into a longer date.
-    expect(maxNFromPackageJson("26.4.2", "alpha", "26.4.28-alpha.5")).toBe(-1);
-    expect(maxNFromPackageJson("26.4.2", "alpha", "26.4.20-alpha.5")).toBe(-1);
-    // Genuine match still works for the actual base 26.4.2:
-    expect(maxNFromPackageJson("26.4.2", "alpha", "26.4.2-alpha.5")).toBe(5);
-  });
-
-  it("rejects malformed alpha suffix in package.json", () => {
-    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-alpha.")).toBe(-1);
-    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-alpha")).toBe(-1);
-    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-alpha.bogus")).toBe(-1);
-    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-alpha.12b")).toBe(-1);
-  });
-
-  it("zero-padded N parses as decimal (parity with parseInt)", () => {
-    // Mirrors maxNFromTags's parseInt behavior — `05` → 5, not octal.
-    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-alpha.05")).toBe(5);
-  });
-
-  it("rejects rc/other channels even if structurally similar", () => {
-    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-rc.5")).toBe(-1);
-  });
-});
-
-describe("calver extractBaseFromVersion (#819)", () => {
-  it("strips alpha/beta suffix, returns YY.M.D", () => {
-    expect(extractBaseFromVersion("26.4.29-alpha.5")).toBe("26.4.29");
-    expect(extractBaseFromVersion("26.4.29-beta.0")).toBe("26.4.29");
-  });
-
-  it("accepts bare YY.M.D (post-stable-cut shape)", () => {
-    expect(extractBaseFromVersion("26.4.29")).toBe("26.4.29");
-    expect(extractBaseFromVersion("v26.4.29")).toBe("26.4.29");
-  });
-
-  it("accepts leading v prefix", () => {
-    expect(extractBaseFromVersion("v26.4.29-alpha.5")).toBe("26.4.29");
-  });
-
-  it("returns null for empty/missing", () => {
-    expect(extractBaseFromVersion("")).toBeNull();
-  });
-
-  it("returns null for non-CalVer legacy versions", () => {
-    expect(extractBaseFromVersion("2.0.0-alpha.134")).toBe("2.0.0"); // shape-OK
-    expect(extractBaseFromVersion("not-a-version")).toBeNull();
-    expect(extractBaseFromVersion("26.4")).toBeNull();
-    expect(extractBaseFromVersion("26.4.29.1")).toBeNull();
-  });
-});
-
-describe("calver compareBases (#819)", () => {
-  it("compares by integer segment, not lexicographic", () => {
-    // Lexicographic would say "26.4.30" < "26.4.4" — must compare ints.
-    expect(compareBases("26.4.30", "26.4.4")).toBeGreaterThan(0);
-    expect(compareBases("26.4.4", "26.4.30")).toBeLessThan(0);
-  });
-
-  it("equal bases return 0", () => {
-    expect(compareBases("26.4.28", "26.4.28")).toBe(0);
-  });
-
-  it("year and month dominate", () => {
-    expect(compareBases("27.1.1", "26.12.31")).toBeGreaterThan(0);
-    expect(compareBases("26.5.1", "26.4.99")).toBeGreaterThan(0);
-  });
-
-  it("throws on malformed input", () => {
-    expect(() => compareBases("26.4", "26.4.28")).toThrow();
-    expect(() => compareBases("26.4.28.1", "26.4.28")).toThrow();
-  });
-});
-
-describe("calver effectiveBase (#819)", () => {
-  it("picks package.json base when ahead of today", () => {
-    expect(effectiveBase("26.4.28", "26.4.29-alpha.5")).toBe("26.4.29");
-  });
-
-  it("picks today when package.json is behind", () => {
-    expect(effectiveBase("26.4.28", "26.4.27-alpha.99")).toBe("26.4.28");
-  });
-
-  it("picks today when bases are equal", () => {
-    expect(effectiveBase("26.4.28", "26.4.28-alpha.18")).toBe("26.4.28");
-  });
-
-  it("picks today when package.json is empty/unparseable", () => {
-    expect(effectiveBase("26.4.28", "")).toBe("26.4.28");
-    expect(effectiveBase("26.4.28", "not-a-version")).toBe("26.4.28");
-  });
-
-  it("handles bare future stable (post-cut shape, no suffix)", () => {
-    // Just-cut tomorrow's stable: package.json holds bare 26.4.30 with no suffix.
-    expect(effectiveBase("26.4.28", "26.4.30")).toBe("26.4.30");
-  });
-});
-
-describe("calver computeVersion future-dated package.json (#819)", () => {
-  const apr28_1200 = new Date(2026, 3, 28, 12, 0);
-  const apr29_0500 = new Date(2026, 3, 29, 5, 0);
-
-  it("future-dated alpha: continues counter on package.json's date (NOT downgrade)", () => {
-    // The exact bug from #819: package.json at 26.4.29-alpha.5, clock at
-    // 2026-04-28. Pre-fix this returned 26.4.28-alpha.0 (a downgrade).
+  it("future-dated alpha continues on package.json's date", () => {
+    // package.json at 26.4.29-alpha.5, clock at 2026-04-28 12:00.
+    // effectiveBase picks 26.4.29; bump should claim hour=12 on that date.
     expect(
       computeVersion({ stable: false, check: false, now: apr28_1200 }, [], "26.4.29-alpha.5"),
-    ).toBe("26.4.29-alpha.6");
+    ).toBe("26.4.29-alpha.12");
   });
 
-  it("today-dated alpha: existing tag-walk behavior preserved", () => {
-    expect(
-      computeVersion({ stable: false, check: false, now: apr28_1200 }, [], "26.4.28-alpha.18"),
-    ).toBe("26.4.28-alpha.19");
-  });
-
-  it("date roll: clock advances past package.json → resets to .0", () => {
-    // Clock is 26.4.29, package.json still at 26.4.28-alpha.18 → .0 fresh day.
-    expect(
-      computeVersion({ stable: false, check: false, now: apr29_0500 }, [], "26.4.28-alpha.18"),
-    ).toBe("26.4.29-alpha.0");
-  });
-
-  it("just-cut stable in package.json: bare YY.M.D → alpha.0 on that date", () => {
-    // After --stable cut, package.json holds bare 26.4.30. Today's clock still
-    // 26.4.28 — must NOT regress to 26.4.28-alpha.0; bumps the future date.
-    expect(
-      computeVersion({ stable: false, check: false, now: apr28_1200 }, [], "26.4.30"),
-    ).toBe("26.4.30-alpha.0");
-  });
-
-  it("future-dated + tags for that future date: tags also count", () => {
-    // If the stable-cut day already saw alphas before the cut tagged some,
-    // and package.json holds 26.4.29-alpha.3 plus tags up to alpha.7 exist
-    // for 26.4.29 — bump to alpha.8.
-    const tags = ["v26.4.29-alpha.7"];
-    expect(
-      computeVersion({ stable: false, check: false, now: apr28_1200 }, tags, "26.4.29-alpha.3"),
-    ).toBe("26.4.29-alpha.8");
-  });
-
-  it("--stable always uses today's clock, never package.json's future date", () => {
-    // Defensive: if package.json is somehow ahead, --stable still cuts today.
+  it("--stable always uses today's clock", () => {
     expect(
       computeVersion({ stable: true, check: false, now: apr28_1200 }, [], "26.4.29-alpha.5"),
     ).toBe("26.4.28");
+  });
+});
+
+describe("calver extractBaseFromVersion + compareBases + effectiveBase (#819 unchanged)", () => {
+  it("strips hour-bucket suffix variants too", () => {
+    expect(extractBaseFromVersion("26.4.29-alpha.16")).toBe("26.4.29");
+    expect(extractBaseFromVersion("26.4.29-alpha.16b")).toBe("26.4.29");
+    expect(extractBaseFromVersion("26.4.29-alpha.16z")).toBe("26.4.29");
+    expect(extractBaseFromVersion("v26.4.29")).toBe("26.4.29");
+  });
+
+  it("compareBases by integer segment (regression coverage)", () => {
+    expect(compareBases("26.4.30", "26.4.4")).toBeGreaterThan(0);
+    expect(compareBases("26.4.4", "26.4.30")).toBeLessThan(0);
+    expect(compareBases("27.1.1", "26.12.31")).toBeGreaterThan(0);
+  });
+
+  it("effectiveBase picks future package.json over today's clock", () => {
+    expect(effectiveBase("26.4.28", "26.4.29-alpha.16b")).toBe("26.4.29");
+    expect(effectiveBase("26.4.30", "26.4.28-alpha.16b")).toBe("26.4.30");
+    expect(effectiveBase("26.4.28", "")).toBe("26.4.28");
   });
 });


### PR DESCRIPTION
**DRAFT** — Do not merge. Posted for explicit Nat approval per task #24 / issue #858.

## Summary

Per #858 user preference (reaffirmed 3x in tonight's /loop directives), revert CalVer from monotonic counter (Option A from #766) to hour-bucket self-describing scheme:

| First in 18:00 | `26.4.29-alpha.18` |
|---|---|
| Second in 18:00 | `26.4.29-alpha.18b` |
| Third  in 18:00 | `26.4.29-alpha.18c` |
| 26th in 18:00 | `26.4.29-alpha.18z` (cap — overflow throws) |

Beta channel (#754) follows the same rule with its own space.

## Why hour-bucket

- **Self-describing**: alpha number tells you when it shipped (16 = 4-5pm)
- **24-bucket forcing function** for batching
- Collision letter handles bursty hours up to 26 releases. Tonight's busiest hour (17:00 UTC, the marketplace-migration session) had 6 releases — well within 26-release ceiling.

## Trade-offs vs monotonic

| Aspect | Hour-bucket (#858) | Monotonic (#766) |
|---|---|---|
| Self-describing time | ✅ alpha.16 = 4-5pm | ❌ alpha.16 = 16th release of day |
| Collision handling | ✅ letter suffix (b–z) | ✅ next slot |
| Max releases/day | 26 × 24 = 624 | unbounded |
| Visual density busy hour | `16b/16c/16d` | `16/17/18` |

## Backward compatibility

Critical: existing tags from the monotonic-counter era coexist:
- `parseSuffix()` rejects suffixes ≥ 24 → legacy `v26.4.29-alpha.24/.25/.99` NOT misread as hour buckets.
- Legacy tags ≤ 23 (e.g. `v26.4.29-alpha.21`) coincidentally claim the hour-21 plain bucket — correct since those tags WERE generated during hour 21 anyway.
- All `effectiveBase`/`extractBaseFromVersion`/`compareBases` semantics from #819 unchanged.

## ⚠️ Transition note (NEEDS REVIEW)

`package.json` currently reads `26.4.29-alpha.23` (the last monotonic bump from A.4 park-extract merge). The first bump under this PR's script will be the hour-bucket of the bump moment, e.g. `alpha.18` if bumping during 18:00 — semver-wise LOWER than `alpha.23`. This is a one-time apparent downgrade across the scheme transition; subsequent bumps are linear.

**Options for landing**:
1. Land as-is, accept the one-time downgrade. Future-package.json users see `26.4.29-alpha.18` after `26.4.29-alpha.23` ever (only humans/git log notice).
2. Land + cut a bare `26.4.29` stable first, then start fresh with hour-bucket alpha on the next day.
3. Wait until midnight local rollover; date-base advance to `26.4.30` makes the issue moot.

(I'd lean (3) — zero ceremony.)

## API changes

**Removed**:
- `maxAlphaFromTags` (back-compat alias, no longer needed)
- `maxNFromTags` / `maxNFromPackageJson` (numeric-only walks)
- `--hour` deprecation gate from #766

**Added**:
- `parseSuffix(suffix)` — `{hh}` or `{hh}{letter}` → `{hour, letterIndex}`; null on malformed/out-of-range
- `renderSuffix(hour, letterIndex)` — inverse; throws on overflow > 25
- `maxLetterInHour(base, channel, hour, tags)` — hour-scoped collision walk
- `maxLetterInHourFromPackageJson(...)` — same against package.json
- `--hour N` flag returned (was deprecated in #766)

## Tests

47/47 green locally. New cases:
- parseSuffix valid/invalid (hour range, letter `a` reserved, multi-letter rejection, malformed)
- renderSuffix round-trip property
- maxLetterInHour: hour isolation, channel isolation, legacy-monotonic coexistence, malformed tag rejection
- computeVersion: plain hour, b/c/... cascade, 26-release-per-hour overflow throws, --hour override
- Beta channel hour-bucket with own space
- package.json walk: hour-bucket variants, legacy alpha.23 doesn't poison non-23 hours
- Future-dated package.json (#819) still works
- All `effectiveBase`/`extractBaseFromVersion`/`compareBases` regression-covered

## Diff

- `scripts/calver.ts`: -211/+225 (rewrite of computeVersion + helpers)
- `test/calver.test.ts`: -316/+486 (full rewrite for hour-bucket cases)

## Sequencing

Per task #24 spec: opens AFTER #862 park merge (✅ landed at `b1603ee6`). Sequenced before merge of PR B (wrapper-dir, task #23, still pending) — but as DRAFT so no merge race.

## Closes (when approved)

- Closes #858

Refs: #766 (the scheme this reverts), #754 (beta channel), #819 (future-dated package.json).