### PR TITLE
fix(plugins): #864 — walk into wrapper dir on tarball extract

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.23",
+  "version": "26.4.29-alpha.24",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/plugins/plugin/install-handlers.ts
+++ b/src/commands/plugins/plugin/install-handlers.ts
@@ -10,7 +10,7 @@ import { basename, join, resolve } from "path";
 import { formatSdkMismatchError, runtimeSdkVersion, satisfies } from "../../../plugin/registry";
 import { installRoot, removeExisting } from "./install-source-detect";
 import { extractTarball, downloadTarball, verifyArtifactHash, verifyArtifactHashAgainst } from "./install-extraction";
-import { readManifest, printInstallSuccess } from "./install-manifest-helpers";
+import { findPluginRoot, readManifest, printInstallSuccess } from "./install-manifest-helpers";
 import { readLock, recordInstall } from "./lock";
 import { createHash } from "crypto";
 
@@ -180,7 +180,15 @@ export async function installFromTarball(
     throw new Error(extractResult.error);
   }
 
-  const manifest = readManifest(staging);
+  // #864 — github-archive and npm tarballs wrap contents in a single top-level
+  // directory (`<repo>-<ref>/` or `package/`). Walk one level if needed.
+  const pluginRoot = findPluginRoot(staging);
+  if (!pluginRoot) {
+    rmSync(staging, { recursive: true, force: true });
+    throw new Error(`failed to read plugin manifest: no plugin.json at ${staging} or in single top-level subdir`);
+  }
+
+  const manifest = readManifest(pluginRoot);
   if (!manifest) {
     rmSync(staging, { recursive: true, force: true });
     throw new Error("failed to read plugin manifest");
@@ -195,7 +203,7 @@ export async function installFromTarball(
   // Defense-in-depth fencepost (#487 §8 Phase 1): manifest-embedded hash still
   // catches transport corruption and hand-edited tarballs before we touch
   // ~/.maw/plugins. It is NOT the adversarial check — plugins.lock is.
-  const selfHashResult = verifyArtifactHash(staging, manifest!);
+  const selfHashResult = verifyArtifactHash(pluginRoot, manifest!);
   if (!selfHashResult.ok) {
     rmSync(staging, { recursive: true, force: true });
     throw new Error(selfHashResult.error);
@@ -228,7 +236,7 @@ export async function installFromTarball(
         `plugin '${manifest!.name}' version mismatch: plugins.lock=${pinned.version} tarball=${manifest!.version}`,
       );
     }
-    const pinnedResult = verifyArtifactHashAgainst(staging, manifest!, pinned.sha256);
+    const pinnedResult = verifyArtifactHashAgainst(pluginRoot, manifest!, pinned.sha256);
     if (!pinnedResult.ok) {
       if (!opts.force && !opts.pin) {
         rmSync(staging, { recursive: true, force: true });
@@ -260,14 +268,19 @@ export async function installFromTarball(
 
   removeExisting(dest);
   // Use rename when the staging dir is on the same fs; otherwise copy-then-rm.
+  // #864 — rename pluginRoot (not staging): when github/npm wrapped in a
+  // single subdir, pluginRoot points at the subdir and staging is its parent.
   try {
     const { renameSync } = require("fs");
-    renameSync(staging, dest);
+    renameSync(pluginRoot, dest);
   } catch {
     // Cross-device fallback (rare). Fall back to cp -a then rm -rf.
-    spawnSync("cp", ["-a", staging + "/.", dest], { encoding: "utf8" });
-    rmSync(staging, { recursive: true, force: true });
+    spawnSync("cp", ["-a", pluginRoot + "/.", dest], { encoding: "utf8" });
   }
+  // Clean up the staging tmpdir. When pluginRoot === staging this no-ops
+  // (already moved); when pluginRoot was a subdir, staging is now empty
+  // (or has the cp leftovers in the cross-device case).
+  rmSync(staging, { recursive: true, force: true });
 
   // #680 — persist lock entry on every successful tarball install. TOFU on
   // first install; overwrites on --force/--pin re-trust.

--- a/src/commands/plugins/plugin/install-manifest-helpers.test.ts
+++ b/src/commands/plugins/plugin/install-manifest-helpers.test.ts
@@ -1,0 +1,85 @@
+/**
+ * findPluginRoot — wrapper-dir resolution unit tests (#864).
+ *
+ * Covers the three real-world tarball layouts:
+ *   • flat    — `maw plugin build` output, plugin.json at root
+ *   • github  — github-archive `<repo>-<ref>/` wrapping dir
+ *   • npm     — npm `package/` wrapping dir
+ *
+ * Plus negative cases that must return null (multi-entry, no manifest, etc.).
+ */
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { findPluginRoot } from "./install-manifest-helpers";
+
+let suiteRoot: string;
+let staging: string;
+
+beforeEach(() => {
+  suiteRoot = mkdtempSync(join(tmpdir(), "find-plugin-root-"));
+  staging = join(suiteRoot, "staging");
+  mkdirSync(staging, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(suiteRoot, { recursive: true, force: true });
+});
+
+describe("findPluginRoot — positive cases", () => {
+  it("flat tarball: plugin.json at root → returns staging", () => {
+    writeFileSync(join(staging, "plugin.json"), "{}");
+    writeFileSync(join(staging, "index.js"), "");
+    expect(findPluginRoot(staging)).toBe(staging);
+  });
+
+  it("github-archive wrapper: plugin.json one level down → returns subdir", () => {
+    const inner = join(staging, "maw-shellenv-v0.1.0");
+    mkdirSync(inner);
+    writeFileSync(join(inner, "plugin.json"), "{}");
+    writeFileSync(join(inner, "index.js"), "");
+    expect(findPluginRoot(staging)).toBe(inner);
+  });
+
+  it("npm-style 'package/' wrapper → returns subdir", () => {
+    const inner = join(staging, "package");
+    mkdirSync(inner);
+    writeFileSync(join(inner, "plugin.json"), "{}");
+    expect(findPluginRoot(staging)).toBe(inner);
+  });
+
+  it("flat with sibling files takes precedence over walking → returns staging", () => {
+    writeFileSync(join(staging, "plugin.json"), "{}");
+    mkdirSync(join(staging, "tests"));
+    expect(findPluginRoot(staging)).toBe(staging);
+  });
+});
+
+describe("findPluginRoot — negative cases", () => {
+  it("empty staging → null", () => {
+    expect(findPluginRoot(staging)).toBeNull();
+  });
+
+  it("multiple top-level entries with no plugin.json at root → null (ambiguous)", () => {
+    mkdirSync(join(staging, "alpha"));
+    mkdirSync(join(staging, "beta"));
+    writeFileSync(join(staging, "alpha", "plugin.json"), "{}");
+    expect(findPluginRoot(staging)).toBeNull();
+  });
+
+  it("single subdir without plugin.json → null", () => {
+    mkdirSync(join(staging, "lonely"));
+    writeFileSync(join(staging, "lonely", "README.md"), "");
+    expect(findPluginRoot(staging)).toBeNull();
+  });
+
+  it("single top-level file (not a directory) → null", () => {
+    writeFileSync(join(staging, "stray.txt"), "");
+    expect(findPluginRoot(staging)).toBeNull();
+  });
+
+  it("nonexistent staging dir → null", () => {
+    expect(findPluginRoot(join(suiteRoot, "does-not-exist"))).toBeNull();
+  });
+});

--- a/src/commands/plugins/plugin/install-manifest-helpers.ts
+++ b/src/commands/plugins/plugin/install-manifest-helpers.ts
@@ -3,10 +3,36 @@
  */
 
 import type { PluginManifest } from "../../../plugin/types";
-import { existsSync, readFileSync } from "fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "fs";
 import { join } from "path";
 import { parseManifest } from "../../../plugin/manifest";
 import { runtimeSdkVersion } from "../../../plugin/registry";
+
+/**
+ * #864 — Resolve the plugin root inside an extracted staging dir.
+ *
+ * `maw plugin build` produces flat tarballs (plugin.json at root). But
+ * GitHub-archive tarballs (`github:OWNER/REPO#REF` registry sources, used by
+ * shellenv/bg/rename/park) extract with a wrapping `<repo>-<ref>/` directory,
+ * and npm tarballs likewise wrap in `package/`. Both leave plugin.json one
+ * level down, breaking root-only manifest discovery.
+ *
+ * Walks at most one level: if plugin.json exists at root, returns root; else
+ * if root contains exactly one entry — a directory — with plugin.json inside,
+ * returns that subdir; else returns null. The extractTarball() path-traversal
+ * guard ensures every entry lives under the staging dir, so walking one level
+ * is safe.
+ */
+export function findPluginRoot(stagingDir: string): string | null {
+  if (existsSync(join(stagingDir, "plugin.json"))) return stagingDir;
+  let entries: string[];
+  try { entries = readdirSync(stagingDir); } catch { return null; }
+  if (entries.length !== 1) return null;
+  const inner = join(stagingDir, entries[0]!);
+  try { if (!statSync(inner).isDirectory()) return null; } catch { return null; }
+  if (existsSync(join(inner, "plugin.json"))) return inner;
+  return null;
+}
 
 /**
  * Read + parse plugin.json from an unpacked dir. Returns null + logs if missing.


### PR DESCRIPTION
## Summary

Closes #864. `maw plugin install <name>` was failing for any registry plugin sourced from a GitHub archive (every plugin extracted via Path A.* — shellenv, bg, rename, park) because `installFromTarball` looked for `plugin.json` only at the staging-dir root, but github-archive tarballs wrap contents in a `<repo>-<ref>/` directory.

```
✗ no plugin.json at /var/folders/.../maw-install-XXXXXX
failed to read plugin manifest
```

## Fix

Add `findPluginRoot(stagingDir)` in `install-manifest-helpers.ts`:

```ts
export function findPluginRoot(stagingDir: string): string | null {
  if (existsSync(join(stagingDir, "plugin.json"))) return stagingDir;
  let entries: string[];
  try { entries = readdirSync(stagingDir); } catch { return null; }
  if (entries.length !== 1) return null;
  const inner = join(stagingDir, entries[0]!);
  try { if (!statSync(inner).isDirectory()) return null; } catch { return null; }
  if (existsSync(join(inner, "plugin.json"))) return inner;
  return null;
}
```

`installFromTarball` uses the resolved root for manifest read, hash verify, and rename. Path-traversal guard already in `extractTarball` keeps walking one level safe.

Handles three real-world layouts uniformly:
- `maw plugin build` → flat (plugin.json at root)
- github archive → `<repo>-<ref>/` wrapper
- npm tarball → `package/` wrapper

## Verification

Built `/tmp/maw-js-864-fix` worktree, wired the fix, then:

**Unit tests** (new file `install-manifest-helpers.test.ts`, 9 cases):
```
9 pass / 0 fail — flat / github / npm / multi-entry / single-no-manifest / lone-file / nonexistent-dir
```

**End-to-end integration** (purpose-built script, wraps a fake plugin in `maw-fake-v0.1.0/`):
```
--- tarball contents ---
maw-fake-v0.1.0/
maw-fake-v0.1.0/dist/
maw-fake-v0.1.0/plugin.json
maw-fake-v0.1.0/dist/index.js
--- begin install ---
✓ fake-wrap@0.1.0 installed
  mode: installed (sha256:94cd2eb…)
  dir: /var/folders/.../plugins/fake-wrap
✓ install succeeded; plugin.json present
✓ sha256 verification fired and recorded
```

**Regression** (existing flat-tarball tests):
```
test/integration/plugins-lock-trust.test.ts: 6 pass / 0 fail
test/isolated/plugin-install-url.test.ts:    4 pass / 0 fail
```

## Test plan

- [x] Unit: `findPluginRoot` covers flat, github wrapper, npm wrapper, and negative cases.
- [x] E2E (local): wrapped fake tarball installs cleanly + lock entry written.
- [x] Regression: existing flat-tarball install tests pass.
- [ ] Post-merge alpha tag: `bun add 'github:Soul-Brews-Studio/maw-js#v26.4.29-alpha.<N>' -g && maw plugin install shellenv` succeeds end-to-end against the live registry.

## Why now

After #857 (plugin install dispatch — alpha.23) and #861 (CalVer Release unblock — alpha.23), this is the LAST blocker on the marketplace install path. Once this lands, the registry → install loop is functional end-to-end for every Path A plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)