### PR TITLE
refactor(routing): manifest as primary lookup (Sub-PR 3 of #841 — hot path migration)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.23",
+  "version": "26.4.29-alpha.24",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/core/routing.ts
+++ b/src/core/routing.ts
@@ -7,12 +7,37 @@
  *   3. Agents map → peer URL → { type: 'peer' } (skip if self-node)
  *   4. null (caller handles peer discovery fallback separately — it's async/network)
  *
- * See: Soul-Brews-Studio/maw-js#201
+ * Sub-PR 3 of #841 — manifest as primary lookup
+ * ─────────────────────────────────────────────
+ * Before falling through to the legacy agents-map step (Step 3), we now consult
+ * the unified `OracleManifest` (#838 + #863) via `loadManifestCached()` (30s TTL,
+ * fully synchronous). If the manifest carries a node mapping for the bare name
+ * AND the passed `config` exposes a peer URL for that node, we route to the peer
+ * directly — letting the manifest cover the cross-source cases the agents map
+ * alone misses (fleet-only, oracles-json-only, session-only registrations).
+ *
+ * Critical contract — additive, not replacement:
+ *   - Local resolution (Step 1) and node:prefix syntax (Step 2) ALWAYS run first.
+ *     The manifest never overrides a local hit or an explicit node:agent route.
+ *   - When the manifest misses, has no `node`, points at `selfNode`, or names a
+ *     node with no peer URL in the passed config → we fall through to Step 3
+ *     (agents map) unchanged. Existing routing tests remain green.
+ *   - Manifest read failures are swallowed (try/catch) — the loader can throw
+ *     on filesystem races; the hot path must not brick.
+ *
+ * Performance — manifest is cached at 30s, so steady-state hot-path cost is a
+ * single in-memory Map lookup. Cold-start cost is ~one config read + one fleet
+ * dir scan + one oracles.json read, all sync. We deliberately do NOT use the
+ * async `loadManifestCachedAsync()` variant here — `resolveTarget` is on every
+ * `maw hey` / `/api/send` path and must stay sync to avoid promise-chain churn.
+ *
+ * See: Soul-Brews-Studio/maw-js#201, #841 (sub-PR 3 of 5).
  */
 
 import { findWindow, type Session } from "./runtime/find-window";
 import type { MawConfig } from "../config";
 import { resolveFleetSession } from "../commands/shared/wake";
+import { loadManifestCached, type OracleManifestEntry } from "../lib/oracle-manifest";
 
 export type { Session };
 
@@ -91,7 +116,21 @@ export function resolveTarget(
     return { type: "error", reason: "unknown_node", detail: `node '${nodeName}' not in namedPeers or peers`, hint: "add to maw.config.json namedPeers" };
   }
 
-  // --- Step 3: Agents map (bare name, e.g. "homekeeper") ---
+  // --- Step 3a (NEW, Sub-PR 3 of #841): OracleManifest as primary lookup ---
+  // The manifest unifies the 5 oracle registries (fleet/session/agent/oracles-json/worktree)
+  // — when the agents map alone would miss (fleet-only or oracles-json-only entries),
+  // the manifest still resolves the routing. We only short-circuit when the manifest
+  // produces a REMOTE node AND the passed config exposes a peer URL for it: every
+  // other case (no entry, self-node, no peer URL) falls through to Step 3b unchanged.
+  const manifestEntry = lookupManifestEntry(query);
+  if (manifestEntry?.node && manifestEntry.node !== selfNode && manifestEntry.node !== "local") {
+    const peerUrl = findPeerUrl(manifestEntry.node, config);
+    if (peerUrl) {
+      return { type: "peer", peerUrl, target: query, node: manifestEntry.node };
+    }
+  }
+
+  // --- Step 3b: Agents map (bare name, e.g. "homekeeper") ---
   const agentNode =
     config.agents?.[query] ||
     config.agents?.[query.replace(/-oracle$/, "")];
@@ -119,4 +158,27 @@ function findPeerUrl(nodeName: string, config: MawConfig): string | undefined {
   const peer = config.namedPeers?.find((p) => p.name === nodeName);
   if (peer) return peer.url;
   return config.peers?.find((p) => p.includes(nodeName));
+}
+
+/**
+ * Look up an oracle short-name in the cached `OracleManifest` (Sub-PR 3 of #841).
+ *
+ * Tries the raw query first, then the `-oracle`-stripped variant — mirrors the
+ * normalization the agents-map step uses. Failures swallowed: a filesystem race
+ * on the manifest loader must NOT brick `resolveTarget`. The 30s TTL keeps the
+ * hot path on a single in-memory Map lookup in steady state.
+ */
+function lookupManifestEntry(query: string): OracleManifestEntry | undefined {
+  if (query.includes(":") || query.includes("/")) return undefined;
+  let manifest: OracleManifestEntry[];
+  try {
+    manifest = loadManifestCached();
+  } catch {
+    return undefined;
+  }
+  const stripped = query.replace(/-oracle$/, "");
+  return (
+    manifest.find((e) => e.name === query) ||
+    (stripped !== query ? manifest.find((e) => e.name === stripped) : undefined)
+  );
 }

--- a/test/isolated/routing-manifest.test.ts
+++ b/test/isolated/routing-manifest.test.ts
@@ -1,0 +1,254 @@
+/**
+ * routing-manifest.test.ts — Sub-PR 3 of #841 (final).
+ *
+ * Verifies that `resolveTarget()` consults the unified `OracleManifest` (#838 +
+ * #863) as the PRIMARY lookup before falling back to `config.agents`. The new
+ * step 3a sits between node:prefix routing (Step 2) and the legacy agents-map
+ * step (Step 3b) — see `src/core/routing.ts`.
+ *
+ * Coverage:
+ *   1. Manifest hit (remote node + peer URL in config)            → returns peer
+ *   2. Manifest miss                                              → falls through to agents map
+ *   3. Manifest hit but node === selfNode                         → falls through (local takes priority)
+ *   4. Manifest hit but node has NO peer URL in passed config     → falls through to agents map
+ *   5. Manifest hit AND agents map hit (different nodes)          → manifest wins
+ *   6. Manifest hit via `-oracle`-stripped variant                → returns peer
+ *   7. Manifest hit but local session exists                      → local STILL wins (Step 1 first)
+ *   8. Manifest hit but query is `node:agent` form                → manifest skipped (Step 2 path)
+ *   9. Manifest read failure (loader throws)                      → falls through gracefully
+ *
+ * Isolated subprocess because we install a `mock.module()` for
+ * `src/lib/oracle-manifest` BEFORE importing the routing module. Mirrors the
+ * pattern used by `hey-fleet-auto-wake.test.ts` (the Sub-PR 4 callsite).
+ */
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+import { join } from "path";
+import type { OracleManifestEntry } from "../../src/lib/oracle-manifest";
+import type { Session } from "../../src/core/runtime/find-window";
+import type { MawConfig } from "../../src/config";
+
+// ─── Manifest mock ───────────────────────────────────────────────────────────
+//
+// Holds the manifest the loader will surface to `resolveTarget`. Each test
+// rewrites it in `beforeEach` (or inline) and the mocked `loadManifestCached`
+// returns whatever's in the slot. `loadManifestThrows` flips error-path tests.
+
+let manifestEntries: OracleManifestEntry[] = [];
+let loadManifestThrows = false;
+
+mock.module(join(import.meta.dir, "../../src/lib/oracle-manifest"), () => ({
+  loadManifestCached: () => {
+    if (loadManifestThrows) throw new Error("manifest load failure (test)");
+    return manifestEntries;
+  },
+  loadManifest: () => {
+    if (loadManifestThrows) throw new Error("manifest load failure (test)");
+    return manifestEntries;
+  },
+  // findOracle is unused by routing, but exported so other modules pulling
+  // this barrel during the test run don't break.
+  findOracle: (name: string) => manifestEntries.find((e) => e.name === name),
+  invalidateManifest: () => { manifestEntries = []; },
+  loadManifestAsync: async () => manifestEntries,
+  loadManifestCachedAsync: async () => manifestEntries,
+  readFleetWindows: () => [],
+  mergeOraclesJsonEntry: () => {},
+  oracleNameFromWorktree: () => null,
+  DEFAULT_TTL_MS: 30_000,
+}));
+
+// Late import — must happen AFTER the mock above.
+const { resolveTarget } = await import("../../src/core/routing");
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const SESSIONS: Session[] = [
+  { name: "08-mawjs", windows: [{ index: 1, name: "mawjs-oracle", active: true }] },
+  { name: "13-mother", windows: [{ index: 1, name: "mother-oracle", active: true }] },
+];
+
+const BASE_CONFIG: MawConfig = {
+  host: "local",
+  port: 3456,
+  ghqRoot: "/home/nat/Code/github.com",
+  oracleUrl: "http://localhost:47779",
+  env: {},
+  commands: { default: "claude" },
+  sessions: {},
+  node: "white",
+  namedPeers: [
+    { name: "mba", url: "http://10.20.0.3:3457" },
+    { name: "oracle-world", url: "http://100.120.242.120:3456" },
+  ],
+  agents: {
+    homekeeper: "mba",
+  },
+  peers: ["http://10.20.0.3:3457"],
+};
+
+function entry(o: Partial<OracleManifestEntry> & { name: string }): OracleManifestEntry {
+  return {
+    sources: ["fleet"],
+    isLive: false,
+    ...o,
+  } as OracleManifestEntry;
+}
+
+beforeEach(() => {
+  manifestEntries = [];
+  loadManifestThrows = false;
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("resolveTarget — manifest as primary lookup (Sub-PR 3 of #841)", () => {
+  // 1. Manifest hit on a remote node with a known peer URL → peer route.
+  test("manifest hit with remote node + peer URL → returns peer entry", () => {
+    manifestEntries = [
+      entry({ name: "boonkeeper", sources: ["fleet", "agent"], node: "oracle-world" }),
+    ];
+    const r = resolveTarget("boonkeeper", BASE_CONFIG, SESSIONS);
+    expect(r).toEqual({
+      type: "peer",
+      peerUrl: "http://100.120.242.120:3456",
+      target: "boonkeeper",
+      node: "oracle-world",
+    });
+  });
+
+  // 2. Manifest miss → falls through to agents map.
+  test("manifest miss → falls through to agents map", () => {
+    manifestEntries = []; // empty manifest
+    const r = resolveTarget("homekeeper", BASE_CONFIG, SESSIONS);
+    expect(r).toEqual({
+      type: "peer",
+      peerUrl: "http://10.20.0.3:3457",
+      target: "homekeeper",
+      node: "mba",
+    });
+  });
+
+  // 3. Manifest entry with self-node → does not short-circuit (local wins).
+  test("manifest entry with node === selfNode → falls through to existing logic", () => {
+    manifestEntries = [
+      entry({ name: "ghost", sources: ["session"], node: "white" }),
+    ];
+    // No local match for "ghost", no agents map entry → not_found.
+    const r = resolveTarget("ghost", BASE_CONFIG, SESSIONS);
+    expect(r).toMatchObject({ type: "error", reason: "not_found" });
+  });
+
+  // 3b. Manifest entry with node === "local" → also treated as self-node-ish.
+  test("manifest entry with node === 'local' → falls through (treated as self)", () => {
+    manifestEntries = [
+      entry({ name: "fleet-only", sources: ["fleet"], node: "local" }),
+    ];
+    const r = resolveTarget("fleet-only", BASE_CONFIG, SESSIONS);
+    // No local session, no agents entry → not_found, NOT a peer route.
+    expect(r).toMatchObject({ type: "error", reason: "not_found" });
+  });
+
+  // 4. Manifest hit but no peer URL for that node → falls through.
+  test("manifest hit, remote node, but no peer URL → falls through", () => {
+    manifestEntries = [
+      entry({ name: "farboon", sources: ["oracles-json"], node: "mars" }),
+    ];
+    const r = resolveTarget("farboon", BASE_CONFIG, SESSIONS);
+    // Falls through; not in agents map either → not_found.
+    expect(r).toMatchObject({ type: "error", reason: "not_found" });
+  });
+
+  // 5. Manifest hit AND agents map hit (different nodes) → manifest wins.
+  //    This is the "primary lookup" property — the manifest is the unified view.
+  test("manifest and agents map disagree → manifest wins", () => {
+    manifestEntries = [
+      entry({ name: "homekeeper", sources: ["fleet", "agent"], node: "oracle-world" }),
+    ];
+    // BASE_CONFIG.agents.homekeeper === "mba", but manifest says "oracle-world".
+    const r = resolveTarget("homekeeper", BASE_CONFIG, SESSIONS);
+    expect(r).toEqual({
+      type: "peer",
+      peerUrl: "http://100.120.242.120:3456",
+      target: "homekeeper",
+      node: "oracle-world",
+    });
+  });
+
+  // 6. Manifest entry matched via `-oracle` suffix strip.
+  test("manifest hit via -oracle suffix strip → returns peer", () => {
+    manifestEntries = [
+      entry({ name: "boonkeeper", sources: ["fleet"], node: "oracle-world" }),
+    ];
+    const r = resolveTarget("boonkeeper-oracle", BASE_CONFIG, SESSIONS);
+    expect(r).toEqual({
+      type: "peer",
+      peerUrl: "http://100.120.242.120:3456",
+      target: "boonkeeper-oracle",
+      node: "oracle-world",
+    });
+  });
+
+  // 7. Local session match (Step 1) ALWAYS wins, even with manifest hit.
+  test("local session match wins over manifest entry", () => {
+    manifestEntries = [
+      // Manifest claims mother-oracle is on a remote node, but Step 1 should
+      // route to the local session before manifest is consulted.
+      entry({ name: "mother", sources: ["agent"], node: "oracle-world" }),
+      entry({ name: "mother-oracle", sources: ["agent"], node: "oracle-world" }),
+    ];
+    const r = resolveTarget("mother-oracle", BASE_CONFIG, SESSIONS);
+    expect(r).toEqual({ type: "local", target: "13-mother:1" });
+  });
+
+  // 8. node:agent form skips manifest (Step 2 path is authoritative).
+  test("node:agent form bypasses manifest lookup → uses Step 2", () => {
+    manifestEntries = [
+      // Manifest claims homekeeper is on oracle-world, but the explicit
+      // "mba:homekeeper" syntax MUST honor the user's node specifier.
+      entry({ name: "homekeeper", sources: ["agent"], node: "oracle-world" }),
+    ];
+    const r = resolveTarget("mba:homekeeper", BASE_CONFIG, SESSIONS);
+    expect(r).toEqual({
+      type: "peer",
+      peerUrl: "http://10.20.0.3:3457",
+      target: "homekeeper",
+      node: "mba",
+    });
+  });
+
+  // 9. Manifest loader throws → resolveTarget recovers, falls through.
+  test("manifest load error swallowed → falls through to agents map", () => {
+    loadManifestThrows = true;
+    const r = resolveTarget("homekeeper", BASE_CONFIG, SESSIONS);
+    // Should still resolve via agents map (BASE_CONFIG.agents.homekeeper = "mba").
+    expect(r).toEqual({
+      type: "peer",
+      peerUrl: "http://10.20.0.3:3457",
+      target: "homekeeper",
+      node: "mba",
+    });
+  });
+
+  // Empty manifest (no entries) is a baseline guarantee — equivalent to
+  // pre-#841 routing behavior across the entire suite.
+  test("empty manifest is a no-op — agents map continues to drive routing", () => {
+    manifestEntries = [];
+    const r = resolveTarget("homekeeper", BASE_CONFIG, SESSIONS);
+    expect(r).toEqual({
+      type: "peer",
+      peerUrl: "http://10.20.0.3:3457",
+      target: "homekeeper",
+      node: "mba",
+    });
+  });
+
+  // Manifest entry with no `node` field → can't drive routing, falls through.
+  test("manifest entry with no node field → falls through", () => {
+    manifestEntries = [
+      // session-only entry — has sessionId but no federation node.
+      entry({ name: "ghost", sources: ["session"], sessionId: "uuid-ghost" }),
+    ];
+    const r = resolveTarget("ghost", BASE_CONFIG, SESSIONS);
+    expect(r).toMatchObject({ type: "error", reason: "not_found" });
+  });
+});


### PR DESCRIPTION
## Summary

Sub-PR 3 of #841 — and the **final** sub-PR of the OracleManifest consumer migration suite. Wires the unified `OracleManifest` (#838 + #863) into `resolveTarget()` as the primary lookup ahead of the legacy `config.agents` step. This is the hot path — every `maw hey`, every `/api/send`, every `talk-to` route walks through this function — so the migration is deliberately conservative and additive.

This completes the OracleManifest consumer migration suite (#841). All 5 sub-PRs landed. #841 ready to close.

## What changed

**`src/core/routing.ts`** (+manifest lookup, +helper)
- New Step 3a between node:prefix (Step 2) and the legacy agents-map (Step 3b). Calls `loadManifestCached()` (sync, 30s TTL) and short-circuits to a peer route ONLY when the manifest carries a remote `node` AND the passed `config` exposes a peer URL for that node.
- Added `lookupManifestEntry(query)` — tries the raw query first, then the `-oracle`-stripped variant (mirrors agents-map normalization). Wraps the loader in try/catch so a filesystem race on the manifest cannot brick the hot path.
- Imports `loadManifestCached` and the `OracleManifestEntry` type from `src/lib/oracle-manifest`.

**Critical contract — additive, not replacement.** Local hits (Step 1) and explicit `node:agent` syntax (Step 2) ALWAYS run first; the manifest never overrides them. When the manifest misses, has no `node`, points at `selfNode`/`"local"`, or names a node with no peer URL in the passed config, we fall through to the existing agents-map step exactly as before. All 23 existing tests in `test/routing.test.ts` stay green without modification.

**`test/isolated/routing-manifest.test.ts`** (new — 12 tests)
- Manifest hit (remote node + peer URL) → returns peer entry
- Manifest miss → falls through to agents map
- Manifest entry with `node === selfNode` or `"local"` → falls through (local takes priority)
- Manifest hit, remote node, no peer URL in config → falls through
- Manifest and agents map disagree on node → manifest wins (primary-lookup property)
- Manifest hit via `-oracle` suffix strip → returns peer
- Local session match (Step 1) wins over manifest entry
- `node:agent` form bypasses manifest (Step 2 is authoritative)
- Manifest loader throws → swallowed, falls through gracefully
- Empty manifest is a no-op
- Manifest entry with no `node` field → falls through
- Pattern mirrors `test/isolated/should-auto-wake-manifest.test.ts` (Sub-PR 4) — `mock.module()` for `src/lib/oracle-manifest` installed before importing `routing`.

**`package.json`** — calver bump to `26.4.29-alpha.24`.

## Performance — hot path note

`resolveTarget` is on every `maw hey` and `/api/send`. We deliberately use the SYNC `loadManifestCached()` (not the async variant from #863). Steady-state cost is one in-memory `Map` lookup; the 30s TTL absorbs CLI bursts. Cold-start cost is one config read + one fleet dir scan + one `oracles.json` read — all sync, all wrapped in try/catch. No tmux walks, no SSH, no network. Formal microbenchmarks not added — the indirection is identical in shape to `findOracle()` in `comm-send.ts` (Sub-PR 4) which has been on the local-scope auto-wake path since alpha.22.

## Test plan

- [x] `bun test test/routing.test.ts` — 23/23 pass (existing suite untouched)
- [x] `bun test test/isolated/routing-manifest.test.ts` — 12/12 pass (new suite)
- [x] `bun test test/routing.test.ts test/isolated/routing-manifest.test.ts` — 35/35 pass together
- [x] `bash scripts/test-isolated.sh` — 97/100 files pass (3 pre-existing failures: `doctor-cross-source`, `fleet-doctor`, `resolve-local-first` — all confirmed unrelated by stash-baseline diff and matching the failure set called out in #860's test plan)
- [x] Main suite (`bun test test/ --path-ignore-patterns '**/agents/**' --path-ignore-patterns '**/isolated/**'`) — 1408 pass / 1 pre-existing fail (`curl-fetch.test.ts` HMAC headers, also confirmed by stash-baseline diff and matching #860)
- [x] Manual review: existing test/routing.test.ts cases verified against new flow — bare-name agents-map hits (#7, #11, BONUS) still resolve via Step 3b when manifest is empty; local hits (#1, #2) untouched; node:prefix (#3-#6, #13, #16-#18) untouched

Closes checkbox 3 of #841 (final box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)