### PR TITLE
fix(install): #869 — relax parseManifest, allow plugins without wasm/entry/artifact

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.24",
+  "version": "26.4.29-alpha.25",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/plugin/manifest-parse.ts
+++ b/src/plugin/manifest-parse.ts
@@ -49,15 +49,13 @@ export function parseManifest(jsonText: string, dir: string): PluginManifest {
       `plugin.json: version must be semver N.N.N (got ${JSON.stringify(r.version)})`,
     );
   }
-  // Must have either wasm, entry, or a built artifact (at least one).
+  // #869 — wasm / entry / artifact are all optional. When none are declared,
+  // build-impl.ts:173 falls back to `./src/index.ts` — the shape every community
+  // plugin in the registry follows (cross-team-queue, shellenv, bg, rename,
+  // park). Strictness here gated a manifest the rest of the system handles fine.
+  // File-existence checks below still apply when these fields ARE declared.
   const hasWasm = typeof r.wasm === "string" && r.wasm.length > 0;
   const hasEntry = typeof r.entry === "string" && (r.entry as string).length > 0;
-  const hasArtifact = r.artifact !== undefined;
-  if (!hasWasm && !hasEntry && !hasArtifact) {
-    throw new Error(
-      "plugin.json: must have 'wasm' (WASM plugin), 'entry' (TS plugin), or 'artifact' (built plugin)",
-    );
-  }
 
   // Optional weight (execution order: 0=first, 50=default, 99=last)
   if (r.weight !== undefined && (typeof r.weight !== "number" || r.weight < 0 || r.weight > 99)) {

--- a/test/plugin-manifest-v1.test.ts
+++ b/test/plugin-manifest-v1.test.ts
@@ -119,15 +119,16 @@ describe("manifest v1 — legacy manifests still parse", () => {
     }
   });
 
-  test("still requires wasm, entry, or artifact (at least one)", () => {
+  test("#869 — wasm/entry/artifact all optional; build-impl falls back to ./src/index.ts", () => {
     const dir = makeTempDir();
     try {
-      expect(() =>
-        parseManifest(
-          JSON.stringify({ name: "bare", version: "1.0.0", sdk: "*" }),
-          dir,
-        ),
-      ).toThrow(/wasm.*entry.*artifact/);
+      const m = parseManifest(
+        JSON.stringify({ name: "bare", version: "1.0.0", sdk: "*" }),
+        dir,
+      );
+      expect(m.wasm).toBeUndefined();
+      expect(m.entry).toBeUndefined();
+      expect(m.artifact).toBeUndefined();
     } finally {
       rmSync(dir, { recursive: true });
     }


### PR DESCRIPTION
## Closes #869

Validator at `parseManifest` was strict-rejecting plugins that omit `wasm`, `entry`, AND `artifact`. But `build-impl.ts:173` already has a fallback: `const entry = manifest.entry || "./src/index.ts"`. The strict gate contradicted the loader's own forgiving default.

## Symptom

5/5 community plugins in the registry failed `maw plugin install <name>` after #857 + #861 + #866 unblocked the rest of the install path:

```
$ MAW_REGISTRY_URL=<live> maw-alpha24 plugin install shellenv
loaded config: ...
✗ invalid plugin.json: plugin.json: must have 'wasm' (WASM plugin), 'entry' (TS plugin), or 'artifact' (built plugin)
failed to read plugin manifest
```

Reproduces against `cross-team-queue`, `shellenv`, `bg`, `rename`, `park` — every plugin currently registered.

## Fix

Drop the strict three-of check at `manifest-parse.ts:52-60`. File-existence checks for `wasm` / `entry` still apply when those fields ARE declared. Loader (build-impl.ts:173) handles inference downstream when none are declared.

## Test

Rewrote `test/plugin-manifest-v1.test.ts:122-134` from "still requires wasm/entry/artifact" to "all optional; build-impl falls back to ./src/index.ts". 15/15 manifest tests pass locally under `TZ=Asia/Bangkok`.

## Tonight's full install pipeline cascade

| # | Blocker | Fix | Status |
|---|---|---|---|
| 1 | #853 dispatch resolution | #857 | ✅ alpha.23 |
| 2 | #830 CalVer Release blocked | #861 | ✅ alpha.23 |
| 3 | #864 tarball wrapper-dir | #866 | ✅ alpha.24 |
| 4 | (validating run) | #862 park triggered first valid CalVer | ✅ alpha.23 |
| 5 | **#869 (this PR)** parseManifest strictness | this | → alpha.25 |

After alpha.25 publishes, marketplace install path is functional end-to-end for all 5 community plugins.