### PR TITLE
feat(scope): ACL evaluation module — allow/queue decision (Sub-A of #842)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Pre-1.0 alpha releases may still introduce breaking changes at any time.
 - **Renamed npm package** `maw` → `maw-js` to eliminate bun `DependencyLoop` caused by collision with unrelated stale `maw@0.6.0` on npm. Binary name unchanged — users still run `maw`. Fixes #554, closes #555, eliminates root cause of #531.
 
 ### Added
+- `scope-acl` — pure ACL evaluation module at `src/commands/shared/scope-acl.ts` deciding `allow` vs `queue` for cross-oracle messages based on shared scope membership (Phase 1 #829), with optional pairwise trust list (Sub-B reserved). Self-messages always allowed; default-deny otherwise. Ships filesystem helper `loadAllScopes()` mirroring `cmdList()`. NOT yet wired into `comm-send.ts` — caller integration is Sub-B/C of #842. Sub-A of #842.
 - `maw update`: serialize concurrent invocations via `~/.maw/update.lock` (#551)
 - `docs/install-recovery.md` — runbook for `maw: command not found` recovery, plus README pointer (#531 mitigation ship; root cause fixed by package rename above)
 - `peers.json` schema gains `pubkey` + `pubkeyFirstSeen` fields. Federation peer pubkey caching with TOFU semantics (Trust On First Use): first sight pins, mismatches are refused with a fail-loud message pointing operators to `maw peers forget`. Legacy peers with no pubkey are accepted during the v26.5.x alpha migration window (will hard-cut at v27 — see ADR `docs/federation/0001-peer-identity.md` Step 6). New `maw peers forget <alias>` clears a pinned pubkey to allow re-TOFU after legitimate key rotation. Step 2 of #804.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.25",
+  "version": "26.4.29-alpha.26",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/shared/scope-acl.ts
+++ b/src/commands/shared/scope-acl.ts
@@ -1,0 +1,160 @@
+/**
+ * scope-acl.ts — pure ACL evaluation for cross-oracle messages (#642 Phase 2 /
+ * Sub-A of #842).
+ *
+ * Phase 1 (#829) shipped the scope primitive + `maw scope` CLI (list / create
+ * / show / delete) writing per-scope JSON files at `<CONFIG_DIR>/scopes/<name>.json`.
+ * Phase 2 introduces the routing decision: given a sender → target message
+ * pair and the current scope set, should we deliver immediately or queue the
+ * message for operator approval?
+ *
+ * This sub-PR (Sub-A of #842) ships JUST the pure decision function plus a
+ * filesystem-aware loader (`loadAllScopes`). It does NOT wire into
+ * `comm-send.ts` — caller integration lives in Sub-B/C so that this PR can
+ * focus on the ACL semantics + tests without entangling the send hot path.
+ *
+ * Trust list: Sub-B will introduce a `<CONFIG_DIR>/trust.json` (or similar)
+ * holding pairwise sender↔target whitelist entries that override scope
+ * membership. The TrustList shape is declared here so the decision function
+ * can already accept it; for Sub-A the caller passes `undefined` (or omits
+ * the argument) and the helper treats trust as empty.
+ *
+ * Decision matrix:
+ *
+ *   sender == target                                  → "allow"  (self-msg)
+ *   sender + target share at least one scope          → "allow"
+ *   sender + target both listed in trust list         → "allow"
+ *   otherwise                                         → "queue"  (default-deny
+ *                                                                 cross)
+ *
+ * The function is intentionally pure — no I/O, no module dependencies on
+ * file-system primitives. `loadAllScopes` is the dirty edge that mirrors
+ * `cmdList()` in `src/commands/plugins/scope/impl.ts`. Mirrors the
+ * pure-function pattern from `src/commands/shared/should-auto-wake.ts` (#837).
+ */
+
+import { existsSync, readFileSync, readdirSync } from "fs";
+import { scopesDir } from "../plugins/scope/impl";
+import type { TScope } from "../../lib/schemas";
+
+/**
+ * Pairwise trust-list entry. Sub-B will define the on-disk file format and
+ * loader. The shape exists here so the ACL function can already accept it
+ * without a follow-up signature change.
+ *
+ * Semantics (Sub-A scaffolding — Sub-B will lock these down):
+ *   - `sender` / `target` are oracle names matching `Scope.members[*]`
+ *   - Trust is symmetric: a pair {a, b} means a→b AND b→a are allowed
+ *   - The list is consulted ONLY when scope membership doesn't already allow
+ */
+export interface TrustEntry {
+  sender: string;
+  target: string;
+}
+
+/** A flat list of trust entries. May be empty / undefined in Sub-A. */
+export type TrustList = TrustEntry[];
+
+/** Decision returned by {@link evaluateAcl}. */
+export type AclDecision = "allow" | "queue";
+
+/**
+ * Decide whether a `sender → target` message should be delivered immediately
+ * or queued for operator approval.
+ *
+ * Pure function — no I/O. Callers feed pre-loaded scopes (use
+ * {@link loadAllScopes} for the canonical filesystem read) and an optional
+ * trust list. The decision is deterministic and order-independent.
+ *
+ * @param sender   oracle name initiating the message
+ * @param target   oracle name receiving the message
+ * @param scopes   the full set of scopes the operator has defined; may be empty
+ * @param trust    optional pairwise trust list (Sub-B); undefined = empty
+ * @returns "allow" if any rule grants delivery, "queue" otherwise
+ */
+export function evaluateAcl(
+  sender: string,
+  target: string,
+  scopes: TScope[],
+  trust?: TrustList,
+): AclDecision {
+  // 1. Self-messages are always allowed. An oracle hey-ing itself never
+  //    needs operator approval — there's no cross-trust boundary to cross.
+  if (sender === target) return "allow";
+
+  // 2. Scope overlap: if any scope's members include BOTH sender and target,
+  //    delivery is allowed. Multi-scope membership composes naturally — the
+  //    sender (or target) may belong to several scopes, and ANY shared scope
+  //    suffices. We don't require the membership to be in the same scope row;
+  //    we require a shared scope, which is the same thing.
+  for (const s of scopes) {
+    if (s.members.includes(sender) && s.members.includes(target)) {
+      return "allow";
+    }
+  }
+
+  // 3. Trust list overrides scope absence. Sub-B will define how this list is
+  //    written; for Sub-A we accept any caller-supplied list. Symmetric
+  //    matching means {a, b} grants both directions.
+  if (trust && trust.length > 0) {
+    for (const t of trust) {
+      if (
+        (t.sender === sender && t.target === target) ||
+        (t.sender === target && t.target === sender)
+      ) {
+        return "allow";
+      }
+    }
+  }
+
+  // 4. Default-deny: queue for operator approval. Phase 2 (#842 Sub-C) will
+  //    persist queued messages to the approval queue so an operator can
+  //    `maw scope approve <id>` after review.
+  return "queue";
+}
+
+/**
+ * Read every scope JSON file under `<CONFIG_DIR>/scopes/` and return the
+ * decoded `TScope[]` array. Mirrors the body of `cmdList()` in
+ * `src/commands/plugins/scope/impl.ts` so callers that only need the data
+ * (not the CLI verb) can avoid pulling in the full plugin module's surface
+ * area when wiring future ACL checks.
+ *
+ * Failure modes mirror Phase 1 forgiving semantics:
+ *   - missing `scopes/` directory → returns `[]`
+ *   - non-JSON files in the directory → ignored
+ *   - corrupt JSON files → silently skipped
+ *
+ * Sub-A consumers don't yet exist — this is wiring for Sub-B/C. Shipping the
+ * helper now keeps the ACL module self-contained and unit-testable without
+ * a separate follow-up to extract this logic.
+ */
+export function loadAllScopes(): TScope[] {
+  const dir = scopesDir();
+  if (!existsSync(dir)) return [];
+  const files = readdirSync(dir).filter(f => f.endsWith(".json"));
+  const out: TScope[] = [];
+  for (const f of files) {
+    const path = `${dir}/${f}`;
+    try {
+      const parsed = JSON.parse(readFileSync(path, "utf-8")) as TScope;
+      // Defensive: skip files that don't look like a Scope. Phase 1's writer
+      // is the only path that touches these files in production, but operators
+      // hand-edit scope JSON (it's a documented workflow — see
+      // scope-primitive.test.ts "members list is editable on disk"), so a
+      // typo'd file shouldn't take down the ACL evaluator.
+      if (
+        parsed &&
+        typeof parsed.name === "string" &&
+        Array.isArray(parsed.members)
+      ) {
+        out.push(parsed);
+      }
+    } catch {
+      // Forgiving: skip corrupt files, same as cmdList(). Phase 2 may add a
+      // louder diagnostic when the ACL evaluator is consulted in production.
+    }
+  }
+  out.sort((a, b) => a.name.localeCompare(b.name));
+  return out;
+}

--- a/test/isolated/scope-acl.test.ts
+++ b/test/isolated/scope-acl.test.ts
@@ -1,0 +1,252 @@
+/**
+ * scope-acl — pure ACL evaluation tests (#642 Phase 2 / Sub-A of #842).
+ *
+ * Covers the `evaluateAcl(sender, target, scopes, trust?)` decision function
+ * plus the filesystem helper `loadAllScopes()` that mirrors Phase 1's
+ * `cmdList()` body. Sub-A ships the function only — caller integration into
+ * `comm-send.ts` is Sub-B/C work to keep this PR focused.
+ *
+ * Isolation: same MAW_CONFIG_DIR / MAW_HOME pattern as scope-primitive.test.ts
+ * so Phase 1's `scopesDir()` resolves to a per-test temp directory. Each
+ * isolated test file runs in its own bun process via scripts/test-isolated.sh,
+ * so the module cache is fresh and per-test env tweaks are safe.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+let testDir: string;
+let originalConfigDir: string | undefined;
+let originalHome: string | undefined;
+
+beforeEach(() => {
+  testDir = mkdtempSync(join(tmpdir(), "maw-scope-acl-"));
+  originalConfigDir = process.env.MAW_CONFIG_DIR;
+  originalHome = process.env.MAW_HOME;
+  process.env.MAW_CONFIG_DIR = testDir;
+  delete process.env.MAW_HOME;
+});
+
+afterEach(() => {
+  if (originalConfigDir === undefined) delete process.env.MAW_CONFIG_DIR;
+  else process.env.MAW_CONFIG_DIR = originalConfigDir;
+  if (originalHome === undefined) delete process.env.MAW_HOME;
+  else process.env.MAW_HOME = originalHome;
+  try { rmSync(testDir, { recursive: true, force: true }); } catch { /* ok */ }
+});
+
+// Helper: build a fully-formed TScope without going through cmdCreate (most
+// tests don't need the on-disk side effect — they just exercise evaluateAcl).
+function scope(name: string, members: string[], lead?: string) {
+  return {
+    name,
+    members,
+    lead,
+    created: "2026-04-28T00:00:00.000Z",
+    ttl: null,
+  };
+}
+
+describe("evaluateAcl — same-scope rule", () => {
+  test("sender + target in same scope → allow", async () => {
+    const { evaluateAcl } = await import("../../src/commands/shared/scope-acl");
+    const scopes = [scope("market", ["alpha", "beta", "gamma"])];
+    expect(evaluateAcl("alpha", "beta", scopes)).toBe("allow");
+  });
+
+  test("sender + target in different scopes → queue", async () => {
+    const { evaluateAcl } = await import("../../src/commands/shared/scope-acl");
+    const scopes = [
+      scope("market", ["alpha", "beta"]),
+      scope("research", ["gamma", "delta"]),
+    ];
+    expect(evaluateAcl("alpha", "gamma", scopes)).toBe("queue");
+  });
+
+  test("sender in scope, target NOT in scope → queue", async () => {
+    const { evaluateAcl } = await import("../../src/commands/shared/scope-acl");
+    const scopes = [scope("market", ["alpha", "beta"])];
+    expect(evaluateAcl("alpha", "stranger", scopes)).toBe("queue");
+  });
+
+  test("target in scope, sender NOT in scope → queue", async () => {
+    const { evaluateAcl } = await import("../../src/commands/shared/scope-acl");
+    const scopes = [scope("market", ["beta"])];
+    expect(evaluateAcl("alpha", "beta", scopes)).toBe("queue");
+  });
+});
+
+describe("evaluateAcl — multi-scope membership", () => {
+  test("sender in 2 scopes (one shared with target) → allow", async () => {
+    const { evaluateAcl } = await import("../../src/commands/shared/scope-acl");
+    const scopes = [
+      scope("market", ["alpha", "beta"]),
+      scope("research", ["alpha", "gamma"]),
+    ];
+    // alpha shares "research" with gamma even though they're not both in market.
+    expect(evaluateAcl("alpha", "gamma", scopes)).toBe("allow");
+  });
+
+  test("multiple scope overlaps → allow (any one suffices)", async () => {
+    const { evaluateAcl } = await import("../../src/commands/shared/scope-acl");
+    const scopes = [
+      scope("market", ["alpha", "beta"]),
+      scope("research", ["alpha", "beta"]),
+      scope("ops", ["alpha", "beta"]),
+    ];
+    expect(evaluateAcl("alpha", "beta", scopes)).toBe("allow");
+  });
+
+  test("symmetric: target's scopes count too (a→b same as b→a for membership)", async () => {
+    const { evaluateAcl } = await import("../../src/commands/shared/scope-acl");
+    const scopes = [scope("market", ["alpha", "beta"])];
+    expect(evaluateAcl("beta", "alpha", scopes)).toBe("allow");
+  });
+});
+
+describe("evaluateAcl — empty / edge cases", () => {
+  test("empty scopes list + no trust → queue (default-deny cross)", async () => {
+    const { evaluateAcl } = await import("../../src/commands/shared/scope-acl");
+    expect(evaluateAcl("alpha", "beta", [])).toBe("queue");
+  });
+
+  test("scope with empty members array → queue", async () => {
+    const { evaluateAcl } = await import("../../src/commands/shared/scope-acl");
+    const scopes = [scope("ghost", [])];
+    expect(evaluateAcl("alpha", "beta", scopes)).toBe("queue");
+  });
+
+  test("scope with only sender (single-member) → queue when target absent", async () => {
+    const { evaluateAcl } = await import("../../src/commands/shared/scope-acl");
+    const scopes = [scope("solo", ["alpha"])];
+    expect(evaluateAcl("alpha", "beta", scopes)).toBe("queue");
+  });
+});
+
+describe("evaluateAcl — self-message rule", () => {
+  test("sender == target → allow even with no scopes", async () => {
+    const { evaluateAcl } = await import("../../src/commands/shared/scope-acl");
+    expect(evaluateAcl("alpha", "alpha", [])).toBe("allow");
+  });
+
+  test("sender == target → allow even when not in any scope", async () => {
+    const { evaluateAcl } = await import("../../src/commands/shared/scope-acl");
+    const scopes = [scope("market", ["beta", "gamma"])];
+    expect(evaluateAcl("alpha", "alpha", scopes)).toBe("allow");
+  });
+
+  test("sender == target → allow regardless of trust list", async () => {
+    const { evaluateAcl } = await import("../../src/commands/shared/scope-acl");
+    expect(evaluateAcl("alpha", "alpha", [], [])).toBe("allow");
+  });
+});
+
+describe("evaluateAcl — trust list", () => {
+  test("trust list pair → allow even without shared scope", async () => {
+    const { evaluateAcl } = await import("../../src/commands/shared/scope-acl");
+    const trust = [{ sender: "alpha", target: "beta" }];
+    expect(evaluateAcl("alpha", "beta", [], trust)).toBe("allow");
+  });
+
+  test("trust list is symmetric: {a→b} also covers b→a", async () => {
+    const { evaluateAcl } = await import("../../src/commands/shared/scope-acl");
+    const trust = [{ sender: "alpha", target: "beta" }];
+    expect(evaluateAcl("beta", "alpha", [], trust)).toBe("allow");
+  });
+
+  test("trust list MISS → still queue when scopes don't cover it", async () => {
+    const { evaluateAcl } = await import("../../src/commands/shared/scope-acl");
+    const trust = [{ sender: "alpha", target: "beta" }];
+    expect(evaluateAcl("alpha", "gamma", [], trust)).toBe("queue");
+  });
+
+  test("trust list overrides absent scope membership → allow", async () => {
+    const { evaluateAcl } = await import("../../src/commands/shared/scope-acl");
+    const scopes = [scope("market", ["x", "y"])]; // sender + target NOT here
+    const trust = [{ sender: "alpha", target: "beta" }];
+    expect(evaluateAcl("alpha", "beta", scopes, trust)).toBe("allow");
+  });
+
+  test("undefined trust list → treated as empty, no crash", async () => {
+    const { evaluateAcl } = await import("../../src/commands/shared/scope-acl");
+    expect(evaluateAcl("alpha", "beta", [], undefined)).toBe("queue");
+  });
+
+  test("empty trust list → equivalent to undefined", async () => {
+    const { evaluateAcl } = await import("../../src/commands/shared/scope-acl");
+    expect(evaluateAcl("alpha", "beta", [], [])).toBe("queue");
+  });
+});
+
+describe("loadAllScopes — filesystem helper", () => {
+  test("missing scopes/ dir → returns empty array", async () => {
+    const { loadAllScopes } = await import("../../src/commands/shared/scope-acl");
+    expect(loadAllScopes()).toEqual([]);
+  });
+
+  test("reads scopes written by Phase 1 cmdCreate", async () => {
+    const { cmdCreate } = await import("../../src/commands/plugins/scope/impl");
+    const { loadAllScopes } = await import("../../src/commands/shared/scope-acl");
+    cmdCreate({ name: "market", members: ["alpha", "beta"] });
+    cmdCreate({ name: "research", members: ["gamma"] });
+    const all = loadAllScopes();
+    expect(all).toHaveLength(2);
+    expect(all.map(s => s.name).sort()).toEqual(["market", "research"]);
+  });
+
+  test("ignores non-JSON files alongside scope JSONs", async () => {
+    const { cmdCreate, scopesDir } = await import("../../src/commands/plugins/scope/impl");
+    const { loadAllScopes } = await import("../../src/commands/shared/scope-acl");
+    cmdCreate({ name: "real", members: ["a"] });
+    writeFileSync(join(scopesDir(), "README.md"), "operator notes");
+    const all = loadAllScopes();
+    expect(all).toHaveLength(1);
+    expect(all[0].name).toBe("real");
+  });
+
+  test("silently skips corrupt JSON files", async () => {
+    const { cmdCreate, scopesDir } = await import("../../src/commands/plugins/scope/impl");
+    const { loadAllScopes } = await import("../../src/commands/shared/scope-acl");
+    cmdCreate({ name: "good", members: ["a"] });
+    writeFileSync(join(scopesDir(), "broken.json"), "{ this is not json");
+    const all = loadAllScopes();
+    expect(all.map(s => s.name)).toEqual(["good"]);
+  });
+
+  test("loadAllScopes feeds evaluateAcl end-to-end", async () => {
+    const { cmdCreate } = await import("../../src/commands/plugins/scope/impl");
+    const { loadAllScopes, evaluateAcl } = await import("../../src/commands/shared/scope-acl");
+    cmdCreate({ name: "team", members: ["alpha", "beta"] });
+    const scopes = loadAllScopes();
+    expect(evaluateAcl("alpha", "beta", scopes)).toBe("allow");
+    expect(evaluateAcl("alpha", "stranger", scopes)).toBe("queue");
+  });
+
+  test("skips scope file with malformed shape (missing members)", async () => {
+    const dir = join(testDir, "scopes");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "weird.json"), JSON.stringify({ name: "weird" }));
+    const { loadAllScopes } = await import("../../src/commands/shared/scope-acl");
+    expect(loadAllScopes()).toEqual([]);
+  });
+});
+
+describe("evaluateAcl — composition smoke tests", () => {
+  test("real-world-ish: market scope + cross-scope trust pair", async () => {
+    const { evaluateAcl } = await import("../../src/commands/shared/scope-acl");
+    const scopes = [
+      scope("market", ["mawjs", "mawjs-plugin", "security"]),
+      scope("research", ["neo", "pulse"]),
+    ];
+    const trust = [{ sender: "mawjs", target: "neo" }];
+    // Same scope:
+    expect(evaluateAcl("mawjs", "security", scopes, trust)).toBe("allow");
+    // Cross scope but trusted:
+    expect(evaluateAcl("mawjs", "neo", scopes, trust)).toBe("allow");
+    // Untrusted cross:
+    expect(evaluateAcl("security", "pulse", scopes, trust)).toBe("queue");
+    // Self:
+    expect(evaluateAcl("mawjs", "mawjs", scopes, trust)).toBe("allow");
+  });
+});


### PR DESCRIPTION
## Summary

Sub-issue A of #842 — adds the pure ACL decision function that powers the upcoming cross-oracle message gating in #642 Phase 2. Phase 1 (#829) shipped the scope primitive + `maw scope` CLI writing per-scope JSON files at `<CONFIG_DIR>/scopes/<name>.json`. This PR layers the **decision** on top of that primitive without touching the send hot path.

**New file: `src/commands/shared/scope-acl.ts`**

- `evaluateAcl(sender, target, scopes, trust?) → "allow" | "queue"` — pure function, no I/O, deterministic.
- `loadAllScopes() → TScope[]` — filesystem helper mirroring Phase 1's `cmdList()` body so future callers can read scopes without pulling in the full plugin module.
- `TrustEntry` / `TrustList` types declared so Sub-B can land the trust-list loader without changing this signature.

**Decision matrix:**

| Condition | Result |
|---|---|
| `sender == target` (self-message) | `allow` |
| Sender + target share at least one scope | `allow` |
| Sender + target listed in trust list (symmetric) | `allow` |
| Otherwise | `queue` (default-deny cross) |

The function follows the same pure-function pattern as `should-auto-wake.ts` (#837 Sub-issue 1 of #835): site-collected facts in, decision + reason out, all I/O at the edge.

**Why no `comm-send.ts` wiring?** Caller integration is Sub-B/C work. Shipping the ACL semantics + tests first lets the trust-list loader (Sub-B) and the queue+approval surface (Sub-C) each land as focused, independently-reviewable PRs against alpha. Trying to wire it now would force this PR to also re-architect the send dispatch and resurrect the `from:` identity handling — a much larger surface than this scope deserves.

## Tests

26 new tests in `test/isolated/scope-acl.test.ts`, grouped by rule:

- **Same-scope** (4): allow when both members; queue across scopes; queue when one is missing (sender or target)
- **Multi-scope** (3): sender in 2 scopes with one shared with target → allow; multiple overlapping scopes → allow; symmetric (a→b same as b→a)
- **Empty / edge** (3): empty scope list → queue; empty members array → queue; single-member scope → queue when target absent
- **Self-message** (3): sender == target always allows — empty scopes, no membership, with trust list
- **Trust list** (6): pair allows; symmetric; miss → queue; overrides absent membership; undefined / empty list parity
- **Filesystem helper** (6): missing dir → `[]`; reads `cmdCreate` output; ignores non-JSON files; skips corrupt JSON; end-to-end with `evaluateAcl`; skips malformed shapes
- **Composition** (1): real-world scenario — market scope + cross-scope trust pair + self-msg in one assertion block

Test isolation mirrors `scope-primitive.test.ts` (per-test `MAW_CONFIG_DIR` + `MAW_HOME` reset; per-file bun process via `scripts/test-isolated.sh`).

```
26 pass / 0 fail / 32 expect() calls / 57ms
```

CalVer bump: `v26.4.29-alpha.25` → `v26.4.29-alpha.26`. CHANGELOG entry added under `[Unreleased]` → `Added`.

## Test plan

- [x] `bun test test/isolated/scope-acl.test.ts` — 26/26 pass
- [x] `bun test test/isolated/scope-primitive.test.ts` — 28/28 pass (regression)
- [x] `tsc --noEmit` — clean
- [ ] CI green on alpha base
- [ ] Sub-B PR reads `loadAllScopes()` + adds trust-list loader
- [ ] Sub-C PR wires `evaluateAcl()` into `comm-send.ts` + persistent queue

Refs #842, #642, #829.