### PR TITLE
feat(trust): trust list storage + maw trust CLI (Sub-B of #842)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.26",
+  "version": "26.4.29-alpha.27",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/plugins/trust/impl.ts
+++ b/src/commands/plugins/trust/impl.ts
@@ -1,0 +1,131 @@
+/**
+ * maw trust — subcommand implementations (#842 Sub-B).
+ *
+ * Pure(-ish) functions that read and write `<CONFIG_DIR>/trust.json`
+ * via {@link ./store}. Sub-B ships the data primitive + CLI verbs
+ * (list / add / remove). Caller integration into `comm-send.ts` lives
+ * in Sub-C — same staging discipline as Sub-A's scope-acl.
+ *
+ * Design decisions:
+ *   - Add is idempotent: re-adding the same pair (in either direction
+ *     — trust is symmetric) is a no-op, not an error. Operators
+ *     shouldn't have to remember whether they already trusted a pair.
+ *   - Remove is exact-match-or-error: removing a non-existent pair
+ *     surfaces a clear error rather than silently no-op. Mirrors the
+ *     "loud miss" convention from `scope delete`.
+ *   - Format mirrors `scope/impl.ts::formatList` — operator-friendly
+ *     padded columns, sorted by addedAt for chronological context.
+ */
+import { loadTrust, samePair, saveTrust, type TrustEntryOnDisk } from "./store";
+
+// Re-export storage helpers so callers can `import { loadTrust } from
+// "./impl"` without two import paths. Mirrors how scope/impl.ts exposes
+// `scopesDir` / `scopePath` from a single module.
+export { loadTrust, saveTrust, trustPath } from "./store";
+export type { TrustEntryOnDisk, TrustListOnDisk } from "./store";
+
+// ─── Read ───
+
+export function cmdList(): TrustEntryOnDisk[] {
+  const list = loadTrust();
+  // Stable sort — addedAt ISO is lexicographically sortable. Older
+  // entries first so the operator sees the chronological story of
+  // how the trust list grew.
+  return [...list].sort((a, b) => a.addedAt.localeCompare(b.addedAt));
+}
+
+// ─── Write ───
+
+export interface AddResult {
+  added: boolean;        // true if a new entry was written, false if duplicate
+  entry: TrustEntryOnDisk;
+}
+
+/**
+ * Add a sender↔target trust pair. Idempotent in both directions:
+ * `add(a, b)` after `add(a, b)` or `add(b, a)` is a no-op. Returns
+ * `added: false` plus the existing entry so the CLI can print
+ * "already trusted" instead of a fake success.
+ *
+ * Validates that sender / target are non-empty and not equal — a
+ * self-trust pair is meaningless because `evaluateAcl()` already
+ * allows self-messages unconditionally (rule 1 of the decision matrix
+ * in scope-acl.ts).
+ */
+export function cmdAdd(sender: string, target: string): AddResult {
+  if (!sender || typeof sender !== "string") {
+    throw new Error("trust add: sender must be a non-empty string");
+  }
+  if (!target || typeof target !== "string") {
+    throw new Error("trust add: target must be a non-empty string");
+  }
+  if (sender === target) {
+    throw new Error(
+      `trust add: refusing self-trust pair "${sender}↔${sender}" — self-messages are always allowed`,
+    );
+  }
+
+  const list = loadTrust();
+  const candidate = { sender, target };
+  for (const existing of list) {
+    if (samePair(existing, candidate)) {
+      return { added: false, entry: existing };
+    }
+  }
+
+  const entry: TrustEntryOnDisk = {
+    sender,
+    target,
+    addedAt: new Date().toISOString(),
+  };
+  list.push(entry);
+  saveTrust(list);
+  return { added: true, entry };
+}
+
+/**
+ * Remove a sender↔target trust pair. Symmetric match — removing
+ * `(b, a)` succeeds even if disk has `{sender: a, target: b}`.
+ *
+ * Returns the removed entry, or throws if no matching pair exists.
+ * The CLI dispatcher catches the throw and converts to a non-zero
+ * exit so scripts can detect "nothing to remove".
+ */
+export function cmdRemove(sender: string, target: string): TrustEntryOnDisk {
+  if (!sender || typeof sender !== "string") {
+    throw new Error("trust remove: sender must be a non-empty string");
+  }
+  if (!target || typeof target !== "string") {
+    throw new Error("trust remove: target must be a non-empty string");
+  }
+
+  const list = loadTrust();
+  const candidate = { sender, target };
+  const idx = list.findIndex(e => samePair(e, candidate));
+  if (idx < 0) {
+    throw new Error(
+      `trust remove: no entry found for "${sender}↔${target}"`,
+    );
+  }
+  const [removed] = list.splice(idx, 1);
+  saveTrust(list);
+  return removed;
+}
+
+// ─── Format ───
+
+export function formatList(rows: TrustEntryOnDisk[]): string {
+  if (!rows.length) return "no trust entries";
+  const header = ["sender", "target", "addedAt"];
+  const lines = rows.map(r => [r.sender, r.target, r.addedAt]);
+  const widths = header.map((h, i) =>
+    Math.max(h.length, ...lines.map(l => l[i].length)),
+  );
+  const fmt = (cols: string[]) =>
+    cols.map((c, i) => c.padEnd(widths[i])).join("  ");
+  return [
+    fmt(header),
+    fmt(widths.map(w => "-".repeat(w))),
+    ...lines.map(fmt),
+  ].join("\n");
+}

--- a/src/commands/plugins/trust/index.ts
+++ b/src/commands/plugins/trust/index.ts
@@ -1,0 +1,135 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+
+export const command = {
+  name: "trust",
+  description: "Pairwise trust list — list, add, remove (#842 Sub-B).",
+};
+
+/**
+ * maw trust — primitive plugin (#842 Sub-B).
+ *
+ * Sub-B ships the data primitive + CLI verbs. ACL evaluation already
+ * lives in Sub-A (#872) — `evaluateAcl(sender, target, scopes, trust?)`
+ * accepts a `TrustList`. Sub-C will wire the loader into `comm-send.ts`
+ * so that messages between non-shared-scope oracles get checked against
+ * this list before queuing.
+ *
+ * Subcommand dispatcher mirrors `scope` (#829) and `peers` (#568): peel
+ * positional[0] off as the verb, dispatch on a switch, print helpText()
+ * on missing/unknown.
+ */
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const impl = await import("./impl");
+
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+
+  const out = () => logs.join("\n");
+  const help = () => [
+    "usage: maw trust <list|add|remove> [...]",
+    "  list                            — list all trust entries (sorted by addedAt)",
+    "  add      <sender> <target>      — add a pair (idempotent, symmetric)",
+    "  remove   <sender> <target> [--yes]",
+    "                                  — remove a pair (confirms unless --yes; symmetric match)",
+    "",
+    "storage: <CONFIG_DIR>/trust.json (flat array of {sender, target, addedAt})",
+    "",
+    "note: Sub-B of #842 — primitive only. Caller integration (cross-scope",
+    "      message routing in comm-send) lands in Sub-C.",
+  ].join("\n");
+
+  try {
+    const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+    const positional = args.filter(a => !a.startsWith("--"));
+    const sub = positional[0];
+
+    if (!sub) {
+      console.log(help());
+      return { ok: true, output: out() || help() };
+    }
+
+    switch (sub) {
+      case "list":
+      case "ls": {
+        console.log(impl.formatList(impl.cmdList()));
+        return { ok: true, output: out() };
+      }
+      case "add": {
+        const sender = positional[1];
+        const target = positional[2];
+        if (!sender || !target) {
+          return { ok: false, error: "usage: maw trust add <sender> <target>" };
+        }
+        try {
+          const res = impl.cmdAdd(sender, target);
+          if (res.added) {
+            console.log(`trusted "${res.entry.sender}" ↔ "${res.entry.target}"`);
+            console.log(`  added at ${res.entry.addedAt}`);
+          } else {
+            console.log(
+              `already trusted: "${res.entry.sender}" ↔ "${res.entry.target}" (added ${res.entry.addedAt})`,
+            );
+          }
+          return { ok: true, output: out() };
+        } catch (e: any) {
+          return { ok: false, error: e?.message || String(e), output: out() };
+        }
+      }
+      case "remove":
+      case "rm":
+      case "delete": {
+        const sender = positional[1];
+        const target = positional[2];
+        if (!sender || !target) {
+          return {
+            ok: false,
+            error: "usage: maw trust remove <sender> <target> [--yes]",
+          };
+        }
+        const confirmed = args.includes("--yes") || args.includes("-y");
+        if (!confirmed) {
+          console.log(
+            `refusing to remove trust pair "${sender} ↔ ${target}" without --yes`,
+          );
+          console.log(
+            `  to confirm: maw trust remove ${sender} ${target} --yes`,
+          );
+          return {
+            ok: false,
+            error: `remove requires --yes`,
+            output: out(),
+          };
+        }
+        try {
+          const removed = impl.cmdRemove(sender, target);
+          console.log(`removed trust pair "${removed.sender}" ↔ "${removed.target}"`);
+          return { ok: true, output: out() };
+        } catch (e: any) {
+          return { ok: false, error: e?.message || String(e), output: out() };
+        }
+      }
+      default: {
+        console.log(help());
+        return {
+          ok: false,
+          error: `maw trust: unknown subcommand "${sub}" (expected list|add|remove)`,
+          output: out() || help(),
+        };
+      }
+    }
+  } catch (e: any) {
+    return { ok: false, error: out() || e.message, output: out() || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/src/commands/plugins/trust/plugin.json
+++ b/src/commands/plugins/trust/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "trust",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Pairwise trust list — sender↔target whitelist consulted by scope-acl (#842 Sub-B).",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "trust",
+    "aliases": ["trusts"],
+    "help": "maw trust <list|add|remove> [...] — manage cross-scope trust pairs (Sub-B of #842)"
+  },
+  "weight": 50
+}

--- a/src/commands/plugins/trust/store.ts
+++ b/src/commands/plugins/trust/store.ts
@@ -1,0 +1,143 @@
+/**
+ * maw trust — storage layer (#842 Sub-B).
+ *
+ * Atomic read/write of `<CONFIG_DIR>/trust.json`. Holds the pairwise
+ * trust list consulted by `evaluateAcl()` (Sub-A, #872) when neither
+ * sender nor target share a scope. Trust is symmetric: an entry
+ * `{sender: a, target: b}` allows BOTH directions a→b and b→a.
+ *
+ * Schema v1 — flat array of TrustEntry. We deliberately avoid the
+ * peers-style `{version, peers: {alias: {...}}}` map because trust
+ * entries are pair-keyed, not alias-keyed; a flat array with dedup on
+ * write is simpler and matches the `TrustList` shape exposed by
+ * `scope-acl.ts`.
+ *
+ *   [
+ *     { "sender": "alpha", "target": "beta", "addedAt": "2026-04-28T..." },
+ *     ...
+ *   ]
+ *
+ * Path resolution mirrors `scope/impl.ts::scopesDir()` — a function
+ * (not a const) so tests setting `MAW_CONFIG_DIR` / `MAW_HOME` per-test
+ * pick up a fresh path each call.
+ *
+ * Atomic writes via tmp + rename(2) — same trick as
+ * `src/commands/plugins/peers/store.ts::writeAtomic`. A crash mid-write
+ * leaves either the old file intact or the new file fully in place,
+ * never a truncated file. No file lock yet — Phase 1 is operator-driven
+ * and `maw trust add` is rare enough that racing writers aren't a
+ * realistic workload (mirrors scope's Phase 1 decision).
+ *
+ * Forgiving load semantics — missing file, corrupt JSON, or wrong
+ * shape all fall back to `[]` rather than throwing. The ACL evaluator
+ * treating "no trust file" the same as "empty trust list" means an
+ * operator who's never run `maw trust add` still gets a working ACL.
+ */
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "fs";
+import { homedir } from "os";
+import { dirname, join } from "path";
+
+/**
+ * On-disk trust entry. `sender` / `target` are oracle names matching
+ * `Scope.members[*]`. `addedAt` is the ISO timestamp when the entry was
+ * first written — useful for `maw trust list` to show recency, and for
+ * future TTL semantics if/when trust entries gain expiry.
+ *
+ * Mirrors {@link import("../../shared/scope-acl").TrustEntry} on the
+ * pair-key fields, with `addedAt` added on disk. `evaluateAcl()` only
+ * reads `sender` / `target`, so the extra field doesn't break the ACL
+ * type contract (TypeScript structural typing — extra fields are fine).
+ */
+export interface TrustEntryOnDisk {
+  sender: string;
+  target: string;
+  addedAt: string;
+}
+
+/** A flat list of on-disk trust entries. May be empty. */
+export type TrustListOnDisk = TrustEntryOnDisk[];
+
+/**
+ * Resolve the active config dir at call time (not import time) so tests
+ * can point the directory at a temp path per-test by setting
+ * `MAW_CONFIG_DIR` / `MAW_HOME` in beforeEach. Mirrors the precedence
+ * logic in `src/core/paths.ts` and `scope/impl.ts::activeConfigDir`.
+ *
+ *   1. `MAW_HOME` → `<MAW_HOME>/config` (instance mode, see #566)
+ *   2. `MAW_CONFIG_DIR` override (legacy)
+ *   3. Default singleton `~/.config/maw/`
+ */
+function activeConfigDir(): string {
+  if (process.env.MAW_HOME) return join(process.env.MAW_HOME, "config");
+  if (process.env.MAW_CONFIG_DIR) return process.env.MAW_CONFIG_DIR;
+  return join(homedir(), ".config", "maw");
+}
+
+export function trustPath(): string {
+  return join(activeConfigDir(), "trust.json");
+}
+
+/**
+ * Read the trust list from disk. Returns `[]` if the file is missing,
+ * unreadable, or malformed — forgiving semantics so an operator who's
+ * never written a trust entry still gets a working empty list.
+ */
+export function loadTrust(): TrustListOnDisk {
+  const path = trustPath();
+  if (!existsSync(path)) return [];
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    // Defensive: skip entries that don't have the required string fields.
+    // Operators may hand-edit trust.json (parallel to scope JSON's
+    // documented hand-edit workflow), so a typo'd line shouldn't sink
+    // the whole list.
+    return parsed.filter(
+      (e: any): e is TrustEntryOnDisk =>
+        e &&
+        typeof e.sender === "string" &&
+        typeof e.target === "string" &&
+        typeof e.addedAt === "string",
+    );
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Write the trust list atomically (tmp + rename). Creates the config
+ * directory if missing. Mirrors `peers/store.ts::writeAtomic`.
+ */
+export function saveTrust(list: TrustListOnDisk): void {
+  const path = trustPath();
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, JSON.stringify(list, null, 2) + "\n");
+  renameSync(tmp, path);
+}
+
+/**
+ * Symmetric pair equality. `{a, b}` matches `{b, a}` — trust is
+ * direction-agnostic, same as `evaluateAcl()`'s match semantics.
+ */
+export function samePair(
+  a: { sender: string; target: string },
+  b: { sender: string; target: string },
+): boolean {
+  return (
+    (a.sender === b.sender && a.target === b.target) ||
+    (a.sender === b.target && a.target === b.sender)
+  );
+}

--- a/src/commands/shared/scope-acl.ts
+++ b/src/commands/shared/scope-acl.ts
@@ -35,6 +35,7 @@
 
 import { existsSync, readFileSync, readdirSync } from "fs";
 import { scopesDir } from "../plugins/scope/impl";
+import { loadTrust as loadTrustStore } from "../plugins/trust/store";
 import type { TScope } from "../../lib/schemas";
 
 /**
@@ -157,4 +158,45 @@ export function loadAllScopes(): TScope[] {
   }
   out.sort((a, b) => a.name.localeCompare(b.name));
   return out;
+}
+
+/**
+ * Read the on-disk pairwise trust list from `<CONFIG_DIR>/trust.json`.
+ *
+ * Thin wrapper around `loadTrust()` in `plugins/trust/store.ts` so that
+ * callers wiring the ACL evaluator don't need to know which plugin owns
+ * the file. Mirrors the relationship between `loadAllScopes()` (this
+ * module) and `cmdList()` (the scope plugin).
+ *
+ * Returns `[]` when the file is missing, malformed, or unreadable —
+ * forgiving semantics so an operator who's never written a trust entry
+ * still gets a working ACL evaluator. The on-disk shape carries an
+ * `addedAt` field that this function strips before returning, so the
+ * result is assignable to `TrustList` (which only requires
+ * `sender` / `target`). TypeScript's structural typing accepts the
+ * extra field, but stripping keeps the in-memory shape minimal.
+ *
+ * Sub-B of #842 — Sub-C will replace `evaluateAcl(...)` callers in
+ * `comm-send.ts` with the convenience wrapper {@link evaluateAclFromDisk}
+ * below, which composes both loaders.
+ */
+export function loadTrustFromDisk(): TrustList {
+  return loadTrustStore().map(e => ({ sender: e.sender, target: e.target }));
+}
+
+/**
+ * Convenience wrapper: load scopes + trust from disk and evaluate ACL.
+ *
+ * Composition of {@link loadAllScopes}, {@link loadTrustFromDisk}, and
+ * {@link evaluateAcl}. Most production callers want this — the pure
+ * `evaluateAcl` is exposed separately so unit tests can inject inputs
+ * directly without a temp filesystem dance.
+ *
+ * Sub-B introduces this wrapper. Sub-C wires it into the send hot path.
+ */
+export function evaluateAclFromDisk(
+  sender: string,
+  target: string,
+): AclDecision {
+  return evaluateAcl(sender, target, loadAllScopes(), loadTrustFromDisk());
 }

--- a/test/isolated/trust-list.test.ts
+++ b/test/isolated/trust-list.test.ts
@@ -1,0 +1,256 @@
+/**
+ * trust-list — storage + CLI primitive tests (#842 Sub-B).
+ *
+ * Covers:
+ *   - `loadTrust()` / `saveTrust()` round-trip
+ *   - `cmdList` / `cmdAdd` / `cmdRemove` semantics (idempotent add,
+ *     symmetric match, error on missing remove, validation)
+ *   - `loadTrustFromDisk()` + `evaluateAclFromDisk()` integration with
+ *     the Sub-A ACL evaluator
+ *   - Forgiving load (missing / corrupt file → [])
+ *
+ * Isolation: same MAW_CONFIG_DIR / MAW_HOME pattern as
+ * scope-acl.test.ts so the trust file resolves to a per-test temp
+ * directory. Each isolated test file runs in its own bun process via
+ * scripts/test-isolated.sh, so the module cache is fresh and per-test
+ * env tweaks are safe.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+let testDir: string;
+let originalConfigDir: string | undefined;
+let originalHome: string | undefined;
+
+beforeEach(() => {
+  testDir = mkdtempSync(join(tmpdir(), "maw-trust-list-"));
+  originalConfigDir = process.env.MAW_CONFIG_DIR;
+  originalHome = process.env.MAW_HOME;
+  process.env.MAW_CONFIG_DIR = testDir;
+  delete process.env.MAW_HOME;
+});
+
+afterEach(() => {
+  if (originalConfigDir === undefined) delete process.env.MAW_CONFIG_DIR;
+  else process.env.MAW_CONFIG_DIR = originalConfigDir;
+  if (originalHome === undefined) delete process.env.MAW_HOME;
+  else process.env.MAW_HOME = originalHome;
+  try { rmSync(testDir, { recursive: true, force: true }); } catch { /* ok */ }
+});
+
+describe("trust store — load/save round-trip", () => {
+  test("missing trust.json → loadTrust returns empty array", async () => {
+    const { loadTrust } = await import("../../src/commands/plugins/trust/store");
+    expect(loadTrust()).toEqual([]);
+  });
+
+  test("saveTrust then loadTrust round-trips a single entry", async () => {
+    const { loadTrust, saveTrust } = await import("../../src/commands/plugins/trust/store");
+    const entry = { sender: "alpha", target: "beta", addedAt: "2026-04-28T00:00:00.000Z" };
+    saveTrust([entry]);
+    const loaded = loadTrust();
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]).toEqual(entry);
+  });
+
+  test("saveTrust writes atomically (no .tmp left after success)", async () => {
+    const { saveTrust, trustPath } = await import("../../src/commands/plugins/trust/store");
+    saveTrust([{ sender: "a", target: "b", addedAt: "2026-04-28T00:00:00.000Z" }]);
+    // File exists, .tmp does not
+    expect(() => readFileSync(trustPath(), "utf-8")).not.toThrow();
+    expect(() => readFileSync(`${trustPath()}.tmp`, "utf-8")).toThrow();
+  });
+
+  test("loadTrust on corrupt JSON → empty array (forgiving)", async () => {
+    const { loadTrust, trustPath } = await import("../../src/commands/plugins/trust/store");
+    mkdirSync(testDir, { recursive: true });
+    writeFileSync(trustPath(), "{ this is not valid json");
+    expect(loadTrust()).toEqual([]);
+  });
+
+  test("loadTrust on non-array root JSON → empty array (forgiving)", async () => {
+    const { loadTrust, trustPath } = await import("../../src/commands/plugins/trust/store");
+    mkdirSync(testDir, { recursive: true });
+    writeFileSync(trustPath(), JSON.stringify({ entries: [] }));
+    expect(loadTrust()).toEqual([]);
+  });
+
+  test("loadTrust skips malformed entries but keeps valid ones", async () => {
+    const { loadTrust, trustPath } = await import("../../src/commands/plugins/trust/store");
+    mkdirSync(testDir, { recursive: true });
+    writeFileSync(trustPath(), JSON.stringify([
+      { sender: "a", target: "b", addedAt: "2026-04-28T00:00:00.000Z" },
+      { sender: "c" },                                  // missing target + addedAt
+      { sender: 1, target: 2, addedAt: 3 },             // wrong types
+      { sender: "d", target: "e", addedAt: "2026-04-28T00:00:01.000Z" },
+    ]));
+    const loaded = loadTrust();
+    expect(loaded).toHaveLength(2);
+    expect(loaded.map(e => e.sender).sort()).toEqual(["a", "d"]);
+  });
+});
+
+describe("cmdAdd — idempotent + symmetric", () => {
+  test("add → list shows the new entry", async () => {
+    const { cmdAdd, cmdList } = await import("../../src/commands/plugins/trust/impl");
+    cmdAdd("alpha", "beta");
+    const list = cmdList();
+    expect(list).toHaveLength(1);
+    expect(list[0].sender).toBe("alpha");
+    expect(list[0].target).toBe("beta");
+    expect(typeof list[0].addedAt).toBe("string");
+  });
+
+  test("add duplicate → idempotent (no dupe on disk)", async () => {
+    const { cmdAdd, cmdList } = await import("../../src/commands/plugins/trust/impl");
+    const first = cmdAdd("alpha", "beta");
+    const second = cmdAdd("alpha", "beta");
+    expect(first.added).toBe(true);
+    expect(second.added).toBe(false);
+    expect(second.entry.addedAt).toBe(first.entry.addedAt); // same entry
+    expect(cmdList()).toHaveLength(1);
+  });
+
+  test("add reverse pair → idempotent (symmetric, no dupe)", async () => {
+    const { cmdAdd, cmdList } = await import("../../src/commands/plugins/trust/impl");
+    cmdAdd("alpha", "beta");
+    const second = cmdAdd("beta", "alpha");
+    expect(second.added).toBe(false);
+    expect(cmdList()).toHaveLength(1);
+  });
+
+  test("add multiple distinct pairs → all kept", async () => {
+    const { cmdAdd, cmdList } = await import("../../src/commands/plugins/trust/impl");
+    cmdAdd("alpha", "beta");
+    cmdAdd("gamma", "delta");
+    cmdAdd("alpha", "delta");
+    expect(cmdList()).toHaveLength(3);
+  });
+
+  test("add self-trust pair → throws", async () => {
+    const { cmdAdd } = await import("../../src/commands/plugins/trust/impl");
+    expect(() => cmdAdd("alpha", "alpha")).toThrow(/self-trust/);
+  });
+
+  test("add empty sender / target → throws", async () => {
+    const { cmdAdd } = await import("../../src/commands/plugins/trust/impl");
+    expect(() => cmdAdd("", "beta")).toThrow(/non-empty/);
+    expect(() => cmdAdd("alpha", "")).toThrow(/non-empty/);
+  });
+});
+
+describe("cmdRemove — exact-or-error, symmetric", () => {
+  test("remove existing entry → entry gone from list", async () => {
+    const { cmdAdd, cmdRemove, cmdList } = await import("../../src/commands/plugins/trust/impl");
+    cmdAdd("alpha", "beta");
+    expect(cmdList()).toHaveLength(1);
+    const removed = cmdRemove("alpha", "beta");
+    expect(removed.sender).toBe("alpha");
+    expect(removed.target).toBe("beta");
+    expect(cmdList()).toEqual([]);
+  });
+
+  test("remove with reversed args → matches symmetrically", async () => {
+    const { cmdAdd, cmdRemove, cmdList } = await import("../../src/commands/plugins/trust/impl");
+    cmdAdd("alpha", "beta");
+    cmdRemove("beta", "alpha");
+    expect(cmdList()).toEqual([]);
+  });
+
+  test("remove non-existent pair → throws", async () => {
+    const { cmdRemove } = await import("../../src/commands/plugins/trust/impl");
+    expect(() => cmdRemove("ghost", "phantom")).toThrow(/no entry found/);
+  });
+
+  test("remove only one of many → others preserved", async () => {
+    const { cmdAdd, cmdRemove, cmdList } = await import("../../src/commands/plugins/trust/impl");
+    cmdAdd("alpha", "beta");
+    cmdAdd("gamma", "delta");
+    cmdAdd("eps", "zeta");
+    cmdRemove("gamma", "delta");
+    const remaining = cmdList().map(e => `${e.sender}-${e.target}`).sort();
+    expect(remaining).toEqual(["alpha-beta", "eps-zeta"]);
+  });
+});
+
+describe("formatList — operator output", () => {
+  test("empty list → 'no trust entries'", async () => {
+    const { formatList } = await import("../../src/commands/plugins/trust/impl");
+    expect(formatList([])).toBe("no trust entries");
+  });
+
+  test("non-empty list → header + rows aligned", async () => {
+    const { cmdAdd, cmdList, formatList } = await import("../../src/commands/plugins/trust/impl");
+    cmdAdd("alpha", "beta");
+    cmdAdd("gamma", "delta");
+    const out = formatList(cmdList());
+    expect(out).toContain("sender");
+    expect(out).toContain("target");
+    expect(out).toContain("addedAt");
+    expect(out).toContain("alpha");
+    expect(out).toContain("delta");
+  });
+});
+
+describe("evaluateAcl integration via on-disk trust list", () => {
+  test("loadTrustFromDisk on missing file → empty list", async () => {
+    const { loadTrustFromDisk } = await import("../../src/commands/shared/scope-acl");
+    expect(loadTrustFromDisk()).toEqual([]);
+  });
+
+  test("loadTrustFromDisk reads entries written by cmdAdd", async () => {
+    const { cmdAdd } = await import("../../src/commands/plugins/trust/impl");
+    const { loadTrustFromDisk } = await import("../../src/commands/shared/scope-acl");
+    cmdAdd("alpha", "beta");
+    cmdAdd("gamma", "delta");
+    const list = loadTrustFromDisk();
+    expect(list).toHaveLength(2);
+    // Order: cmdAdd appends; loadTrustFromDisk preserves on-disk order.
+    expect(list.find(e => e.sender === "alpha" && e.target === "beta")).toBeTruthy();
+    expect(list.find(e => e.sender === "gamma" && e.target === "delta")).toBeTruthy();
+  });
+
+  test("evaluateAcl with loadTrustFromDisk → trust pair allowed across scopes", async () => {
+    const { cmdAdd } = await import("../../src/commands/plugins/trust/impl");
+    const { evaluateAcl, loadTrustFromDisk } = await import("../../src/commands/shared/scope-acl");
+    cmdAdd("alpha", "beta");
+    const trust = loadTrustFromDisk();
+    // No scopes — only trust list grants the allow.
+    expect(evaluateAcl("alpha", "beta", [], trust)).toBe("allow");
+    expect(evaluateAcl("beta", "alpha", [], trust)).toBe("allow"); // symmetric
+    expect(evaluateAcl("alpha", "stranger", [], trust)).toBe("queue");
+  });
+
+  test("evaluateAclFromDisk composes scopes + trust loaders", async () => {
+    const { cmdCreate } = await import("../../src/commands/plugins/scope/impl");
+    const { cmdAdd } = await import("../../src/commands/plugins/trust/impl");
+    const { evaluateAclFromDisk } = await import("../../src/commands/shared/scope-acl");
+
+    cmdCreate({ name: "market", members: ["alpha", "beta"] });
+    cmdAdd("alpha", "neo"); // cross-scope trust pair
+
+    expect(evaluateAclFromDisk("alpha", "beta")).toBe("allow");   // shared scope
+    expect(evaluateAclFromDisk("alpha", "neo")).toBe("allow");    // trust list
+    expect(evaluateAclFromDisk("neo", "alpha")).toBe("allow");    // symmetric
+    expect(evaluateAclFromDisk("alpha", "stranger")).toBe("queue"); // neither
+    expect(evaluateAclFromDisk("alpha", "alpha")).toBe("allow");  // self
+  });
+
+  test("evaluateAclFromDisk works with no scopes file and no trust file", async () => {
+    const { evaluateAclFromDisk } = await import("../../src/commands/shared/scope-acl");
+    // Default-deny: empty everything → queue across, allow self.
+    expect(evaluateAclFromDisk("alpha", "beta")).toBe("queue");
+    expect(evaluateAclFromDisk("alpha", "alpha")).toBe("allow");
+  });
+
+  test("removed trust pair no longer grants allow", async () => {
+    const { cmdAdd, cmdRemove } = await import("../../src/commands/plugins/trust/impl");
+    const { evaluateAclFromDisk } = await import("../../src/commands/shared/scope-acl");
+    cmdAdd("alpha", "beta");
+    expect(evaluateAclFromDisk("alpha", "beta")).toBe("allow");
+    cmdRemove("alpha", "beta");
+    expect(evaluateAclFromDisk("alpha", "beta")).toBe("queue");
+  });
+});


### PR DESCRIPTION
## Summary

Sub-B of the [#842](https://github.com/Soul-Brews-Studio/maw-js/issues/842) ACL milestone — the operator-facing primitive for managing cross-scope trust pairs. Sub-A ([#872](https://github.com/Soul-Brews-Studio/maw-js/pull/872)) shipped the pure `evaluateAcl(sender, target, scopes, trust?)` decision function and declared a `TrustList` shape; this PR ships the on-disk storage that satisfies that type plus a `maw trust` plugin so operators can manage entries from the CLI today. Caller integration into `comm-send.ts` is deferred to Sub-C to keep this PR focused on storage + CLI semantics.

## What changed

- **`src/commands/plugins/trust/store.ts`** — `loadTrust()` / `saveTrust()` over `<CONFIG_DIR>/trust.json`. Atomic writes via tmp + rename (mirrors `peers/store.ts::writeAtomic`). Path resolution is a function (not a const) so `MAW_HOME` / `MAW_CONFIG_DIR` per-test isolation works the same as scope's pattern. Forgiving load: missing file, corrupt JSON, non-array root, or per-entry shape errors all fall back to `[]` rather than throwing — an operator who's never run `maw trust add` still gets a working ACL.
- **`src/commands/plugins/trust/impl.ts`** — `cmdList` (sorted by `addedAt`), `cmdAdd` (idempotent + symmetric — re-adding `(a, b)` or adding the reverse `(b, a)` is a no-op), `cmdRemove` (symmetric exact-match-or-error). Refuses self-trust pairs because `evaluateAcl` already allows self-messages unconditionally.
- **`src/commands/plugins/trust/{index.ts, plugin.json}`** — dispatcher mirroring the `scope` plugin's shape (#829). Subcommands: `list` / `add` / `remove`. `remove` requires `--yes` to confirm, matching the `scope delete` UX. Aliases: `ls`, `rm`, `delete`.
- **`src/commands/shared/scope-acl.ts`** — add `loadTrustFromDisk()` (thin wrapper around `loadTrust()` that strips the `addedAt` field to yield a `TrustList`) and `evaluateAclFromDisk(sender, target)` (composes both loaders + the pure evaluator). The pure `evaluateAcl` signature is unchanged — Sub-A's `trust?` parameter is now satisfied by a real on-disk loader, and Sub-C can drop the convenience wrapper into `comm-send` without touching the ACL semantics.
- **Schema (v1)** — flat array of `{sender, target, addedAt}`. Pair-keyed entries, not alias-keyed, so a flat array with dedup-on-write is simpler than the peers-style `{version, peers: {...}}` map. The `addedAt` ISO field powers `maw trust list` chronological ordering and reserves space for future TTL semantics.

## Tests

`test/isolated/trust-list.test.ts` — 24 cases:

- Store round-trip (load/save), no .tmp leftover after success
- Forgiving load (missing file, corrupt JSON, non-array root, per-entry malformation)
- Add → list shows entry; addedAt is populated
- Add duplicate → idempotent (no dupe on disk, returns existing entry)
- Add reverse pair → symmetric idempotent
- Add multiple distinct pairs → all kept
- Add self-trust pair → throws
- Add empty sender / target → throws
- Remove existing → entry gone
- Remove with reversed args → symmetric match
- Remove non-existent → throws
- Remove one of many → others preserved
- formatList empty / non-empty
- `loadTrustFromDisk` reads entries written by `cmdAdd`
- `evaluateAcl` + on-disk trust → allow across scopes (both directions)
- `evaluateAclFromDisk` composes scopes + trust, queues unrelated, allows self
- `evaluateAclFromDisk` works with no scopes file and no trust file
- Removed pair no longer grants allow

All 24 trust-list tests + 26 scope-acl tests (Sub-A) pass on this branch.

## Test plan

- [x] `bun test test/isolated/trust-list.test.ts` — 24 pass
- [x] `bun test test/isolated/scope-acl.test.ts` — 26 pass (Sub-A regression check)
- [x] CLI smoke: `maw trust add alpha beta` → `maw trust add beta alpha` (idempotent) → `maw trust list` (shows row) → `maw trust remove alpha beta` (refuses) → `maw trust remove alpha beta --yes` (removes)
- [ ] CI on alpha base

## Calver

Bumps `26.4.29-alpha.26` → `26.4.29-alpha.27`.

## Followups

- Sub-C: wire `evaluateAclFromDisk` into `comm-send.ts` and persist queued messages to the approval queue.

Refs: #842, #872.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>