### PR TITLE
feat(inbox): approval queue + maw inbox + ACL in comm-send (Sub-C of #842, closes #842 + #642)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.27",
+  "version": "26.4.29-alpha.28",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/cli/route-comm.ts
+++ b/src/cli/route-comm.ts
@@ -8,8 +8,17 @@ export async function routeComm(cmd: string, args: string[]): Promise<boolean> {
   // agent messaging.
   if (cmd === "hey") {
     const force = args.includes("--force");
+    // #842 Sub-C — `--approve` bypasses the cross-scope ACL queue gate.
+    // Operator-explicit opt-in for THIS message; mirrors the consent
+    // `--pin` escape hatch already wired in #644. Optional `--trust`
+    // pairs with `--approve` to also persist the sender↔target trust
+    // entry so the same pair stops queuing on subsequent sends.
+    const approve = args.includes("--approve");
+    const trust = args.includes("--trust");
     const target = args[1];
-    const msgArgs = args.slice(2).filter(a => a !== "--force");
+    const msgArgs = args
+      .slice(2)
+      .filter(a => a !== "--force" && a !== "--approve" && a !== "--trust");
 
     // Distinguish: zero-args usage error vs missing-message error (#388.3)
     // A user who typed `maw hey mawjs` (just the target, no message) was
@@ -33,7 +42,7 @@ export async function routeComm(cmd: string, args: string[]): Promise<boolean> {
       console.error(`  (if '${target}' isn't a valid target, run 'maw ls' to see available ones)`);
       throw new UserError(`missing message for '${target}'`);
     }
-    await cmdSend(target, msgArgs.join(" "), force);
+    await cmdSend(target, msgArgs.join(" "), force, { approve, trust });
     return true;
   }
   return false;

--- a/src/commands/plugins/inbox/impl.ts
+++ b/src/commands/plugins/inbox/impl.ts
@@ -1,6 +1,27 @@
 import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "fs";
 import { join } from "path";
 import { loadConfig } from "../../../config";
+import {
+  deletePending,
+  loadPending,
+  loadPendingById,
+  updatePending,
+  type PendingMessage,
+} from "../../shared/queue-store";
+
+// Re-export queue-store helpers so callers can import from one place.
+export {
+  loadPending,
+  loadPendingById,
+  savePending,
+  updatePending,
+  deletePending,
+  pendingDir,
+  pendingPath,
+  isExpired,
+  TTL_MS,
+} from "../../shared/queue-store";
+export type { PendingMessage } from "../../shared/queue-store";
 
 // File naming: YYYY-MM-DD_HH-MM_<from>_<slug>.md
 // Frontmatter: from / to / timestamp / read
@@ -148,4 +169,142 @@ export async function cmdInboxWrite(note: string) {
   const config = loadConfig();
   const filename = writeInboxFile(inboxDir, config.node ?? "cli", config.node ?? "local", note);
   console.log(`\x1b[32m✓\x1b[0m wrote \x1b[33m${filename}\x1b[0m`);
+}
+
+// ─── Approval queue (#842 Sub-C) ────────────────────────────────────────────
+//
+// `cmdList` / `cmdApprove` / `cmdReject` / `cmdShow` operate on the
+// per-message JSON files under `<CONFIG_DIR>/pending/` written by
+// `comm-send.ts` when `evaluateAclFromDisk(...) === "queue"`. The plugin
+// dispatcher in `index.ts` peels the verb off and routes here.
+//
+// Approve flow: flip status → re-issue the send via `cmdSend(query, message)`
+// (the same code path operators take with `maw hey`). On a successful send
+// we delete the file (the approval was the gate; the file no longer needs
+// to exist). Reject flow: flip status briefly so observers can see the
+// terminal state, then delete the file unconditionally.
+
+/**
+ * Resolve a partial id (e.g. user types the timestamp prefix) to a full
+ * pending file. Returns the loaded {@link PendingMessage} or `null`. If
+ * multiple pending files match the prefix, the oldest is returned —
+ * mirrors the "oldest first" semantics of `cmdQueueList()`.
+ */
+export function resolvePendingId(idOrPrefix: string): PendingMessage | null {
+  if (!idOrPrefix) return null;
+  // Exact match first — common case after `maw inbox pending` prints the id.
+  const exact = loadPendingById(idOrPrefix);
+  if (exact) return exact;
+  // Fallback: prefix match. List loads + reaps in one pass; the user is
+  // never given a stale id by the list output, so prefix is safe.
+  const list = loadPending();
+  const matches = list.filter(m => m.id.startsWith(idOrPrefix));
+  if (matches.length === 0) return null;
+  return matches[0]; // oldest first
+}
+
+/** List pending messages, oldest first. Pure read — no mutation. */
+export function cmdQueueList(): PendingMessage[] {
+  return loadPending().filter(m => m.status === "pending");
+}
+
+/**
+ * Format the pending list for human consumption. Mirrors `formatList` in
+ * `scope/impl.ts` and `trust/impl.ts` — padded columns, header + divider.
+ */
+export function formatQueueList(rows: PendingMessage[]): string {
+  if (!rows.length) return "no pending messages";
+  const header = ["id", "sender", "target", "sentAt", "preview"];
+  const lines = rows.map(r => [
+    r.id,
+    r.sender,
+    r.target,
+    r.sentAt,
+    r.message.replace(/\s+/g, " ").slice(0, 50),
+  ]);
+  const widths = header.map((h, i) =>
+    Math.max(h.length, ...lines.map(l => l[i].length)),
+  );
+  const fmt = (cols: string[]) =>
+    cols.map((c, i) => c.padEnd(widths[i])).join("  ");
+  return [
+    fmt(header),
+    fmt(widths.map(w => "-".repeat(w))),
+    ...lines.map(fmt),
+  ].join("\n");
+}
+
+/** Show a single pending message in human-readable detail. */
+export function formatQueueDetail(msg: PendingMessage): string {
+  return [
+    `id:      ${msg.id}`,
+    `sender:  ${msg.sender}`,
+    `target:  ${msg.target}`,
+    `query:   ${msg.query ?? "-"}`,
+    `sentAt:  ${msg.sentAt}`,
+    `status:  ${msg.status}`,
+    `message:`,
+    msg.message,
+  ].join("\n");
+}
+
+/**
+ * Approve a queued message → mark status "approved" + execute the send via
+ * `cmdSend(query, message)` (lazy import to avoid a circular module load:
+ * comm-send imports this plugin's loader chain). On successful send we
+ * delete the file. Returns the record that was just approved (status
+ * pre-delete) for caller logging.
+ *
+ * Throws if the id is unknown or the underlying send rejects (the file is
+ * left intact in that case so the operator can retry).
+ */
+export async function cmdApprove(idOrPrefix: string): Promise<PendingMessage> {
+  const found = resolvePendingId(idOrPrefix);
+  if (!found) throw new Error(`pending message not found: ${idOrPrefix}`);
+  if (found.status !== "pending") {
+    throw new Error(`message ${found.id} is already ${found.status}`);
+  }
+  const updated = updatePending(found.id, { status: "approved" });
+  // Re-issue the send. Use the original query string when present (preserves
+  // node prefix routing); fall back to target name otherwise.
+  const query = updated.query ?? updated.target;
+  const { cmdSend } = await import("../../shared/comm-send");
+  // Pass `force=true` plus a sentinel to bypass ACL on the second pass:
+  // the human approval IS the gate — re-checking here would loop forever.
+  process.env.MAW_ACL_BYPASS = "1";
+  try {
+    await cmdSend(query, updated.message);
+  } finally {
+    delete process.env.MAW_ACL_BYPASS;
+  }
+  // Successful send → file's job is done. Delete it.
+  deletePending(updated.id);
+  return updated;
+}
+
+/**
+ * Reject a queued message → mark status "rejected" + delete the file.
+ * Returns the record (with status flipped) so the caller can log the
+ * rejection. Throws on unknown id.
+ */
+export function cmdReject(idOrPrefix: string): PendingMessage {
+  const found = resolvePendingId(idOrPrefix);
+  if (!found) throw new Error(`pending message not found: ${idOrPrefix}`);
+  if (found.status === "rejected") {
+    // Idempotent — already rejected. Still delete in case the file was left
+    // behind by a partial earlier reject.
+    deletePending(found.id);
+    return found;
+  }
+  const updated = updatePending(found.id, { status: "rejected" });
+  deletePending(updated.id);
+  return updated;
+}
+
+/**
+ * Show a single pending message by id. Returns `null` if not found —
+ * the dispatcher converts that to a CLI error. Pure read.
+ */
+export function cmdShow(idOrPrefix: string): PendingMessage | null {
+  return resolvePendingId(idOrPrefix);
 }

--- a/src/commands/plugins/inbox/index.ts
+++ b/src/commands/plugins/inbox/index.ts
@@ -1,9 +1,20 @@
 import type { InvokeContext, InvokeResult } from "../../../plugin/types";
-import { cmdInboxLs, cmdInboxMarkRead, cmdInboxRead, cmdInboxWrite } from "./impl";
+import {
+  cmdInboxLs,
+  cmdInboxMarkRead,
+  cmdInboxRead,
+  cmdInboxWrite,
+  cmdQueueList,
+  cmdApprove,
+  cmdReject,
+  cmdShow,
+  formatQueueList,
+  formatQueueDetail,
+} from "./impl";
 
 export const command = {
   name: "inbox",
-  description: "List and manage agent inbox messages (ψ/inbox/ thread-backed).",
+  description: "Inbox messages + cross-scope approval queue (#842 Sub-C).",
 };
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
@@ -18,10 +29,58 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     if (ctx.writer) ctx.writer(...a);
     else logs.push(a.map(String).join(" "));
   };
+  const out = () => logs.join("\n");
   try {
     const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
     const sub = args[0]?.toLowerCase();
 
+    // ─── Approval queue subcommands (#842 Sub-C) ───
+    if (sub === "pending" || sub === "queue") {
+      // maw inbox pending — list pending approval-queue messages.
+      const rows = cmdQueueList();
+      console.log(formatQueueList(rows));
+      return { ok: true, output: out() };
+    }
+    if (sub === "approve") {
+      const id = args[1];
+      if (!id) {
+        return { ok: false, error: "usage: maw inbox approve <id>", output: out() };
+      }
+      try {
+        const approved = await cmdApprove(id);
+        console.log(`approved: ${approved.id} (${approved.sender} → ${approved.target})`);
+        return { ok: true, output: out() };
+      } catch (e: any) {
+        return { ok: false, error: e?.message || String(e), output: out() };
+      }
+    }
+    if (sub === "reject") {
+      const id = args[1];
+      if (!id) {
+        return { ok: false, error: "usage: maw inbox reject <id>", output: out() };
+      }
+      try {
+        const rejected = cmdReject(id);
+        console.log(`rejected: ${rejected.id} (${rejected.sender} → ${rejected.target})`);
+        return { ok: true, output: out() };
+      } catch (e: any) {
+        return { ok: false, error: e?.message || String(e), output: out() };
+      }
+    }
+    if (sub === "show-pending" || sub === "pending-show") {
+      const id = args[1];
+      if (!id) {
+        return { ok: false, error: "usage: maw inbox show-pending <id>", output: out() };
+      }
+      const msg = cmdShow(id);
+      if (!msg) {
+        return { ok: false, error: `pending message not found: ${id}`, output: out() };
+      }
+      console.log(formatQueueDetail(msg));
+      return { ok: true, output: out() };
+    }
+
+    // ─── Legacy ψ/inbox/ subcommands ───
     if (sub === "read") {
       // maw inbox read <id>  — mark as read
       await cmdInboxMarkRead(args[1] ?? "");

--- a/src/commands/plugins/inbox/plugin.json
+++ b/src/commands/plugins/inbox/plugin.json
@@ -3,11 +3,11 @@
   "version": "2.0.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "List and manage agent inbox messages (ψ/inbox/ thread-backed).",
+  "description": "Inbox messages + cross-scope approval queue (#842 Sub-C).",
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "inbox",
-    "help": "maw inbox [--unread] [--from <peer>] [--last N] | read <id> | show [N] | write <msg>"
+    "help": "maw inbox [--unread] [--from <peer>] [--last N] | read <id> | show [N] | write <msg> | pending | approve <id> | reject <id> | show-pending <id>"
   },
   "weight": 50
 }

--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -123,7 +123,29 @@ export function formatBareNameError(query: string): string {
   ].join("\n");
 }
 
-export async function cmdSend(query: string, message: string, force = false) {
+/**
+ * Caller-supplied options for `cmdSend`. Backward compatible — the field
+ * is optional and the legacy 3-arg signature still works (positional
+ * `force` second-to-last).
+ *
+ * - `approve` (#842 Sub-C): bypass the ACL queue gate for THIS send.
+ *   Operator opted in explicitly via `maw hey --approve`. Equivalent to
+ *   the human-approval path that drives `maw inbox approve <id>`.
+ * - `trust` (#842 Sub-C): paired with `approve` — also append the
+ *   sender↔target pair to the on-disk trust list so subsequent sends in
+ *   either direction skip the gate without operator intervention.
+ */
+export interface CmdSendOptions {
+  approve?: boolean;
+  trust?: boolean;
+}
+
+export async function cmdSend(
+  query: string,
+  message: string,
+  force = false,
+  opts: CmdSendOptions = {},
+) {
   const config = loadConfig();
 
   // #759 Phase 2 — bare-name targets are now a hard error. Reject before any
@@ -296,6 +318,89 @@ export async function cmdSend(query: string, message: string, force = false) {
 
   // --- Unified resolution via resolveTarget (#201) ---
   const result = resolveTarget(query, config, sessions);
+
+  // --- #842 Sub-C — cross-oracle ACL gate (Phase 2 of #642) ---
+  //
+  // When the resolved target is on a different oracle/node, consult the
+  // scope + trust lists via `evaluateAclFromDisk`. A "queue" verdict means
+  // the operator hasn't pre-approved this sender↔target pair and the
+  // message is persisted under `<CONFIG_DIR>/pending/` for later
+  // `maw inbox approve <id>`. Default-allow when no scopes are defined
+  // (loadAllScopes returns []) — otherwise this would silently break every
+  // existing setup that hasn't migrated to scopes yet.
+  //
+  // Bypass paths:
+  //   1. `--approve` flag on `maw hey` (operator-explicit opt-in for THIS
+  //      message; optionally `--trust` to also persist the pair)
+  //   2. `MAW_ACL_BYPASS=1` env (set by `maw inbox approve <id>` when it
+  //      re-issues the queued send — the human approval IS the gate)
+  //
+  // Queue conditions:
+  //   - `result.type === "peer"` (genuine cross-node)
+  //   - At least one scope defined on disk (default-allow when empty)
+  //   - `evaluateAclFromDisk(sender, target) === "queue"`
+  //
+  // NOTE: self-node and local results bypass the ACL gate. Same-node
+  // sends across oracle names are rare (most operators run one oracle
+  // per node) and Phase 2's threat model targets cross-NODE delivery —
+  // the federation HTTP boundary is where untrusted-by-default applies.
+  if (result?.type === "peer" && !opts.approve && process.env.MAW_ACL_BYPASS !== "1") {
+    try {
+      const { evaluateAclFromDisk, loadAllScopes } = await import("./scope-acl");
+      const scopes = loadAllScopes();
+      // Default-allow when no scopes are defined — keeps existing
+      // pre-#642 setups working unchanged. Operators opt in to the gate
+      // by creating their first scope via `maw scope create`.
+      if (scopes.length > 0) {
+        const senderOracle = config.oracle ?? "mawjs";
+        const targetOracle = result.target; // agent name from `<node>:<agent>`
+        const decision = evaluateAclFromDisk(senderOracle, targetOracle);
+        if (decision === "queue") {
+          const { savePending } = await import("./queue-store");
+          const record = savePending({
+            sender: senderOracle,
+            target: targetOracle,
+            message,
+            query,
+          });
+          console.log(
+            `\x1b[33mqueued for approval\x1b[0m ${record.id} ${senderOracle} → ${targetOracle}`,
+          );
+          console.log(
+            `\x1b[90m  review: maw inbox show-pending ${record.id}\x1b[0m`,
+          );
+          console.log(
+            `\x1b[90m  approve: maw inbox approve ${record.id}\x1b[0m`,
+          );
+          return;
+        }
+      }
+    } catch (e: any) {
+      // Forgiving: ACL eval errors must not break delivery. Phase 2 is
+      // additive — log + fall through to existing behavior.
+      console.error(`\x1b[90mwarn: ACL evaluation failed (${e?.message ?? e}); allowing send\x1b[0m`);
+    }
+  }
+
+  // --- `--approve --trust` side effect (#842 Sub-C) ---
+  // Operator explicitly trusts this pair from now on. Append BEFORE
+  // delivery so a subsequent same-pair send (even in a parallel process)
+  // skips the gate immediately. Idempotent in `cmdAdd`.
+  if (opts.approve && opts.trust && result?.type === "peer") {
+    try {
+      const { cmdAdd } = await import("../plugins/trust/impl");
+      const senderOracle = config.oracle ?? "mawjs";
+      const targetOracle = result.target;
+      cmdAdd(senderOracle, targetOracle);
+      console.log(
+        `\x1b[36m+\x1b[0m trusted ${senderOracle} ↔ ${targetOracle}`,
+      );
+    } catch (e: any) {
+      // Same forgiving stance — trust persistence failure shouldn't
+      // block the send the operator just approved.
+      console.error(`\x1b[90mwarn: trust persistence failed (${e?.message ?? e})\x1b[0m`);
+    }
+  }
 
   // --- Consent gate (#644 Phase 1, opt-in via MAW_CONSENT=1) ---
   // Local + self-node sends are never gated. Cross-node hey to a peer that

--- a/src/commands/shared/queue-store.ts
+++ b/src/commands/shared/queue-store.ts
@@ -1,0 +1,233 @@
+/**
+ * queue-store.ts — pending approval-queue storage (#842 Sub-C).
+ *
+ * Phase 2 of #642: when `evaluateAcl(sender, target, ...)` returns "queue",
+ * the message must be persisted on disk so a human operator can review and
+ * approve / reject it later via `maw inbox`.
+ *
+ * Storage layout — one JSON file per pending message:
+ *
+ *   <CONFIG_DIR>/pending/<timestamp>-<random>.json
+ *
+ * Each file holds a {@link PendingMessage} record. The file-per-message
+ * shape mirrors the scope plugin (#829) — disjoint files mean concurrent
+ * writes don't race, corruption blasts at most one entry, and a future
+ * `maw inbox edit` can be a plain text edit.
+ *
+ * TTL: messages are valid for {@link TTL_MS} ms (30 days). Expiry is
+ * lazy — we delete stale files at read time rather than running a cron.
+ * That keeps the data-plane simple (no daemon, no scheduler) at the cost
+ * of an O(n) walk on each `loadPending()`. n is small in practice (queue
+ * is human-paced), so the trade is fine.
+ *
+ * Atomic writes: tmp + rename(2), same trick as scope/peers/trust stores.
+ *
+ * Pure-ish: depends only on `fs` + `os`. No business logic — that lives
+ * in `inbox/impl.ts` which composes this store with the comm-send hot
+ * path. Sub-A/Sub-B kept their primitives equally surgical.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs";
+import { homedir } from "os";
+import { dirname, join } from "path";
+
+/**
+ * On-disk pending message. Status starts at "pending" — `cmdApprove` /
+ * `cmdReject` flip it. `id` is the filename (sans `.json`) so the CLI
+ * can take a short id and resolve it back to the file with a single
+ * `pendingPath(id)` call.
+ */
+export interface PendingMessage {
+  id: string;
+  sender: string;
+  target: string;
+  message: string;
+  sentAt: string;
+  status: "pending" | "approved" | "rejected";
+  /** Original raw query (e.g. "mba:hojo") used by `cmdApprove` to re-issue the send via comm-send. */
+  query?: string;
+}
+
+/** TTL for a pending message — 30 days. Messages older than this are
+ *  silently removed on the next `loadPending()` call. */
+export const TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * Resolve the active config dir at call time so tests can point the
+ * directory at a temp path per-test by setting `MAW_CONFIG_DIR` /
+ * `MAW_HOME` in beforeEach. Mirrors `scope/impl.ts::activeConfigDir`
+ * and `trust/store.ts::activeConfigDir`.
+ */
+function activeConfigDir(): string {
+  if (process.env.MAW_HOME) return join(process.env.MAW_HOME, "config");
+  if (process.env.MAW_CONFIG_DIR) return process.env.MAW_CONFIG_DIR;
+  return join(homedir(), ".config", "maw");
+}
+
+export function pendingDir(): string {
+  return join(activeConfigDir(), "pending");
+}
+
+export function pendingPath(id: string): string {
+  return join(pendingDir(), `${id}.json`);
+}
+
+function ensurePendingDir(): void {
+  mkdirSync(pendingDir(), { recursive: true });
+}
+
+/**
+ * Generate a fresh queue id. ISO timestamp (filesystem-safe) + 6 random
+ * hex chars. Two-tier so chronological sort is meaningful AND collisions
+ * are vanishingly unlikely even when two writers fire in the same
+ * millisecond.
+ */
+export function newPendingId(now: Date = new Date()): string {
+  const ts = now.toISOString().replace(/[:.]/g, "-");
+  const rand = Math.floor(Math.random() * 0xffffff)
+    .toString(16)
+    .padStart(6, "0");
+  return `${ts}-${rand}`;
+}
+
+/**
+ * Persist a new pending message. Returns the on-disk record (with id
+ * + sentAt populated). Atomic write via tmp + rename.
+ */
+export function savePending(input: {
+  sender: string;
+  target: string;
+  message: string;
+  query?: string;
+}): PendingMessage {
+  ensurePendingDir();
+  const now = new Date();
+  const id = newPendingId(now);
+  const record: PendingMessage = {
+    id,
+    sender: input.sender,
+    target: input.target,
+    message: input.message,
+    sentAt: now.toISOString(),
+    status: "pending",
+    query: input.query,
+  };
+  const path = pendingPath(id);
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, JSON.stringify(record, null, 2) + "\n");
+  renameSync(tmp, path);
+  return record;
+}
+
+/**
+ * Update an existing pending record in place — used by approve/reject
+ * to flip `status`. Atomic write. Returns the updated record. Throws
+ * if the id doesn't exist on disk.
+ */
+export function updatePending(id: string, patch: Partial<PendingMessage>): PendingMessage {
+  const path = pendingPath(id);
+  if (!existsSync(path)) {
+    throw new Error(`pending message not found: ${id}`);
+  }
+  const current = JSON.parse(readFileSync(path, "utf-8")) as PendingMessage;
+  const merged: PendingMessage = { ...current, ...patch, id: current.id };
+  const tmp = `${path}.tmp`;
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(tmp, JSON.stringify(merged, null, 2) + "\n");
+  renameSync(tmp, path);
+  return merged;
+}
+
+/**
+ * Load a single pending message by id. Returns `null` if missing,
+ * malformed, or expired (older than {@link TTL_MS}). Expired files are
+ * deleted as a side effect — lazy GC.
+ */
+export function loadPendingById(id: string): PendingMessage | null {
+  const path = pendingPath(id);
+  if (!existsSync(path)) return null;
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch {
+    return null;
+  }
+  let parsed: PendingMessage;
+  try {
+    parsed = JSON.parse(raw) as PendingMessage;
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed.id !== "string") return null;
+  if (isExpired(parsed)) {
+    try { unlinkSync(path); } catch { /* ignore */ }
+    return null;
+  }
+  return parsed;
+}
+
+/**
+ * Load all pending messages, oldest first. Side effect: deletes
+ * expired files (older than {@link TTL_MS}). Returns `[]` if the
+ * pending dir is missing or unreadable — same forgiving semantics as
+ * the trust + scope loaders.
+ */
+export function loadPending(): PendingMessage[] {
+  const dir = pendingDir();
+  if (!existsSync(dir)) return [];
+  let files: string[];
+  try {
+    files = readdirSync(dir).filter(f => f.endsWith(".json"));
+  } catch {
+    return [];
+  }
+  const out: PendingMessage[] = [];
+  for (const f of files) {
+    const path = join(dir, f);
+    try {
+      const parsed = JSON.parse(readFileSync(path, "utf-8")) as PendingMessage;
+      if (!parsed || typeof parsed.id !== "string") continue;
+      if (isExpired(parsed)) {
+        try { unlinkSync(path); } catch { /* ignore */ }
+        continue;
+      }
+      out.push(parsed);
+    } catch {
+      // Skip corrupt files — operator may hand-edit, don't sink the whole list.
+    }
+  }
+  // Oldest first — sort by sentAt, fall back to id (lexicographic).
+  out.sort((a, b) => {
+    const at = a.sentAt || a.id;
+    const bt = b.sentAt || b.id;
+    return at.localeCompare(bt);
+  });
+  return out;
+}
+
+/** Delete a pending message file. Returns `true` if the file existed. */
+export function deletePending(id: string): boolean {
+  const path = pendingPath(id);
+  if (!existsSync(path)) return false;
+  try {
+    unlinkSync(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** True if the message's `sentAt` is older than {@link TTL_MS} ago. */
+export function isExpired(msg: PendingMessage, now: Date = new Date()): boolean {
+  const sent = Date.parse(msg.sentAt || "");
+  if (!Number.isFinite(sent)) return false; // unparseable → don't reap
+  return now.getTime() - sent > TTL_MS;
+}

--- a/test/isolated/comm-send-acl.test.ts
+++ b/test/isolated/comm-send-acl.test.ts
@@ -1,0 +1,255 @@
+/**
+ * comm-send-acl — ACL gate integration tests (#842 Sub-C).
+ *
+ * Verifies that `cmdSend` consults `evaluateAclFromDisk` for cross-node
+ * (peer) targets and either:
+ *
+ *   - allows the send (no scopes / sender+target share scope / trusted)
+ *   - queues the send under <CONFIG_DIR>/pending/ ("queue" verdict)
+ *
+ * Default-allow when scopes are empty is critical — Sub-C must not break
+ * existing setups that haven't migrated to scopes yet.
+ *
+ * The federation HTTP layer is mocked at `sdk` so no real requests fire.
+ * We assert on the queue-store side effects + the curlFetch call count.
+ */
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { mockConfigModule } from "../helpers/mock-config";
+
+const srcRoot = join(import.meta.dir, "../..");
+
+let testDir: string;
+let originalConfigDir: string | undefined;
+let originalHome: string | undefined;
+let curlCalls: Array<{ url: string }> = [];
+let configReturn: () => any = () => ({ node: "white", oracle: "mawjs", port: 3456, namedPeers: [{ name: "phaith", url: "http://phaith:3456" }] });
+
+const _rSdk = await import("../../src/sdk");
+
+mock.module(join(srcRoot, "src/sdk"), () => ({
+  ..._rSdk,
+  capture: async () => "",
+  sendKeys: async () => {},
+  getPaneCommand: async () => "claude",
+  listSessions: async () => [],
+  findPeerForTarget: async () => null,
+  curlFetch: async (url: string) => {
+    curlCalls.push({ url });
+    return { ok: true, status: 200, data: { ok: true, target: "hojo" } };
+  },
+  runHook: async () => {},
+  hostExec: async () => "",
+}));
+
+mock.module(join(srcRoot, "src/config"), () =>
+  mockConfigModule(() => configReturn()),
+);
+
+mock.module(join(srcRoot, "src/core/routing"), () => ({
+  resolveTarget: () => ({
+    type: "peer",
+    target: "hojo",
+    node: "phaith",
+    peerUrl: "http://phaith:3456",
+  }),
+}));
+
+mock.module(join(srcRoot, "src/commands/shared/comm-log-feed"), () => ({
+  logMessage: () => {},
+  emitFeed: () => {},
+}));
+
+mock.module(join(srcRoot, "src/commands/shared/wake-cmd"), () => ({
+  cmdWake: async () => {},
+}));
+
+const origSleep = Bun.sleep.bind(Bun);
+(Bun as unknown as { sleep: (ms: number) => Promise<void> }).sleep = async () => {};
+
+const { cmdSend } = await import("../../src/commands/shared/comm-send");
+
+const origExit = process.exit;
+const origErr = console.error;
+const origLog = console.log;
+let exitCode: number | undefined;
+let outs: string[] = [];
+
+async function run(fn: () => Promise<unknown>): Promise<void> {
+  exitCode = undefined; outs = [];
+  console.error = (...a: unknown[]) => { outs.push(a.map(String).join(" ")); };
+  console.log = (...a: unknown[]) => { outs.push(a.map(String).join(" ")); };
+  (process as unknown as { exit: (c?: number) => never }).exit =
+    (c?: number): never => { exitCode = c ?? 0; throw new Error("__exit__:" + exitCode); };
+  try { await fn(); }
+  catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (!msg.startsWith("__exit__")) throw e;
+  } finally {
+    console.error = origErr;
+    console.log = origLog;
+    (process as unknown as { exit: typeof origExit }).exit = origExit;
+  }
+}
+
+beforeEach(() => {
+  testDir = mkdtempSync(join(tmpdir(), "maw-comm-acl-"));
+  originalConfigDir = process.env.MAW_CONFIG_DIR;
+  originalHome = process.env.MAW_HOME;
+  process.env.MAW_CONFIG_DIR = testDir;
+  delete process.env.MAW_HOME;
+  delete process.env.MAW_ACL_BYPASS;
+  process.env.MAW_QUIET = "1";
+  curlCalls = [];
+  configReturn = () => ({
+    node: "white",
+    oracle: "mawjs",
+    port: 3456,
+    namedPeers: [{ name: "phaith", url: "http://phaith:3456" }],
+  });
+});
+
+afterEach(() => {
+  if (originalConfigDir === undefined) delete process.env.MAW_CONFIG_DIR;
+  else process.env.MAW_CONFIG_DIR = originalConfigDir;
+  if (originalHome === undefined) delete process.env.MAW_HOME;
+  else process.env.MAW_HOME = originalHome;
+  delete process.env.MAW_ACL_BYPASS;
+  delete process.env.MAW_QUIET;
+  try { rmSync(testDir, { recursive: true, force: true }); } catch { /* ok */ }
+});
+
+function writeScope(name: string, members: string[]) {
+  const dir = join(testDir, "scopes");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, `${name}.json`),
+    JSON.stringify({ name, members, created: new Date().toISOString(), ttl: null }),
+  );
+}
+
+function writeTrust(entries: { sender: string; target: string }[]) {
+  writeFileSync(
+    join(testDir, "trust.json"),
+    JSON.stringify(entries.map(e => ({ ...e, addedAt: new Date().toISOString() }))),
+  );
+}
+
+describe("comm-send ACL gate — default-allow", () => {
+  test("no scopes defined → send proceeds (default-allow)", async () => {
+    await run(() => cmdSend("phaith:hojo", "hi"));
+    expect(curlCalls.some(c => c.url.includes("/api/send"))).toBe(true);
+    expect(exitCode).toBeUndefined();
+  });
+
+  test("no scopes defined → no pending file written", async () => {
+    const { loadPending } = await import("../../src/commands/shared/queue-store");
+    await run(() => cmdSend("phaith:hojo", "hi"));
+    expect(loadPending()).toEqual([]);
+  });
+});
+
+describe("comm-send ACL gate — allow paths", () => {
+  test("sender + target share a scope → send proceeds", async () => {
+    writeScope("market", ["mawjs", "hojo"]);
+    await run(() => cmdSend("phaith:hojo", "hi"));
+    expect(curlCalls.some(c => c.url.includes("/api/send"))).toBe(true);
+  });
+
+  test("trust entry covers the pair → send proceeds", async () => {
+    writeScope("market", ["other"]); // forces ACL evaluation (non-empty)
+    writeTrust([{ sender: "mawjs", target: "hojo" }]);
+    await run(() => cmdSend("phaith:hojo", "hi"));
+    expect(curlCalls.some(c => c.url.includes("/api/send"))).toBe(true);
+  });
+
+  test("symmetric trust — {hojo, mawjs} grants mawjs → hojo too", async () => {
+    writeScope("market", ["other"]);
+    writeTrust([{ sender: "hojo", target: "mawjs" }]);
+    await run(() => cmdSend("phaith:hojo", "hi"));
+    expect(curlCalls.some(c => c.url.includes("/api/send"))).toBe(true);
+  });
+});
+
+describe("comm-send ACL gate — queue paths", () => {
+  test("scopes defined but pair not allowed → queue + no /api/send", async () => {
+    writeScope("market", ["other"]);
+    const { loadPending } = await import("../../src/commands/shared/queue-store");
+    await run(() => cmdSend("phaith:hojo", "hi"));
+    const list = loadPending();
+    expect(list).toHaveLength(1);
+    expect(list[0].sender).toBe("mawjs");
+    expect(list[0].target).toBe("hojo");
+    expect(list[0].message).toBe("hi");
+    expect(list[0].query).toBe("phaith:hojo");
+    // No federation send should have happened.
+    expect(curlCalls.some(c => c.url.includes("/api/send"))).toBe(false);
+  });
+
+  test("queued message includes the original query for re-issue on approve", async () => {
+    writeScope("market", ["other"]);
+    const { loadPending } = await import("../../src/commands/shared/queue-store");
+    await run(() => cmdSend("phaith:hojo", "deferred"));
+    const [m] = loadPending();
+    expect(m.query).toBe("phaith:hojo");
+  });
+});
+
+describe("comm-send ACL gate — bypass paths", () => {
+  test("MAW_ACL_BYPASS=1 → send proceeds even with scope deny", async () => {
+    writeScope("market", ["other"]);
+    process.env.MAW_ACL_BYPASS = "1";
+    await run(() => cmdSend("phaith:hojo", "hi"));
+    expect(curlCalls.some(c => c.url.includes("/api/send"))).toBe(true);
+    delete process.env.MAW_ACL_BYPASS;
+  });
+
+  test("--approve opts (cmdSend opts.approve) → send proceeds even with scope deny", async () => {
+    writeScope("market", ["other"]);
+    const { loadPending } = await import("../../src/commands/shared/queue-store");
+    await run(() => cmdSend("phaith:hojo", "hi", false, { approve: true }));
+    expect(curlCalls.some(c => c.url.includes("/api/send"))).toBe(true);
+    expect(loadPending()).toEqual([]);
+  });
+
+  test("--approve --trust persists the pair to trust.json", async () => {
+    writeScope("market", ["other"]);
+    await run(() => cmdSend("phaith:hojo", "hi", false, { approve: true, trust: true }));
+    const { loadTrust } = await import("../../src/commands/plugins/trust/store");
+    const list = loadTrust();
+    expect(list).toHaveLength(1);
+    expect(list[0].sender).toBe("mawjs");
+    expect(list[0].target).toBe("hojo");
+  });
+});
+
+describe("comm-send ACL gate — oracle name resolution", () => {
+  test("uses config.oracle for sender (not config.node)", async () => {
+    configReturn = () => ({
+      node: "white",
+      oracle: "weave",
+      port: 3456,
+      namedPeers: [{ name: "phaith", url: "http://phaith:3456" }],
+    });
+    writeScope("dummy", ["other"]);
+    const { loadPending } = await import("../../src/commands/shared/queue-store");
+    await run(() => cmdSend("phaith:hojo", "hi"));
+    const [m] = loadPending();
+    expect(m.sender).toBe("weave");
+  });
+
+  test("falls back to 'mawjs' when config.oracle is unset", async () => {
+    configReturn = () => ({
+      node: "white",
+      port: 3456,
+      namedPeers: [{ name: "phaith", url: "http://phaith:3456" }],
+    });
+    writeScope("dummy", ["other"]);
+    const { loadPending } = await import("../../src/commands/shared/queue-store");
+    await run(() => cmdSend("phaith:hojo", "hi"));
+    const [m] = loadPending();
+    expect(m.sender).toBe("mawjs");
+  });
+});

--- a/test/isolated/inbox-cli.test.ts
+++ b/test/isolated/inbox-cli.test.ts
@@ -1,0 +1,208 @@
+/**
+ * inbox-cli — approval-queue CLI command tests (#842 Sub-C).
+ *
+ * Covers the queue-side commands added to the `inbox` plugin:
+ *   - cmdQueueList — pending only, oldest first
+ *   - cmdShow      — single message lookup (exact id + prefix match)
+ *   - cmdApprove   — flip status + execute send + delete file
+ *   - cmdReject    — flip status + delete file
+ *   - resolvePendingId — id resolution semantics
+ *
+ * The send execution inside `cmdApprove` is mocked at the comm-send module
+ * level so the test stays isolated from tmux + federation.
+ */
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+let testDir: string;
+let originalConfigDir: string | undefined;
+let originalHome: string | undefined;
+
+// Mocked `cmdSend` — captures invocations so cmdApprove's re-issue path is
+// observable without touching the real transport stack.
+let sendCalls: Array<{ query: string; message: string; bypass: string | undefined }> = [];
+
+mock.module(join(import.meta.dir, "../../src/commands/shared/comm-send"), () => ({
+  cmdSend: async (query: string, message: string) => {
+    sendCalls.push({ query, message, bypass: process.env.MAW_ACL_BYPASS });
+  },
+}));
+
+beforeEach(() => {
+  testDir = mkdtempSync(join(tmpdir(), "maw-inbox-cli-"));
+  originalConfigDir = process.env.MAW_CONFIG_DIR;
+  originalHome = process.env.MAW_HOME;
+  process.env.MAW_CONFIG_DIR = testDir;
+  delete process.env.MAW_HOME;
+  sendCalls = [];
+});
+
+afterEach(() => {
+  if (originalConfigDir === undefined) delete process.env.MAW_CONFIG_DIR;
+  else process.env.MAW_CONFIG_DIR = originalConfigDir;
+  if (originalHome === undefined) delete process.env.MAW_HOME;
+  else process.env.MAW_HOME = originalHome;
+  try { rmSync(testDir, { recursive: true, force: true }); } catch { /* ok */ }
+});
+
+describe("inbox-cli — cmdQueueList", () => {
+  test("returns [] when no pending messages", async () => {
+    const { cmdQueueList } = await import("../../src/commands/plugins/inbox/impl");
+    expect(cmdQueueList()).toEqual([]);
+  });
+
+  test("returns pending messages oldest first", async () => {
+    const { savePending } = await import("../../src/commands/shared/queue-store");
+    const { cmdQueueList } = await import("../../src/commands/plugins/inbox/impl");
+    const r1 = savePending({ sender: "a", target: "b", message: "first" });
+    await new Promise(res => setTimeout(res, 5));
+    const r2 = savePending({ sender: "a", target: "c", message: "second" });
+    const list = cmdQueueList();
+    expect(list).toHaveLength(2);
+    expect(list[0].id).toBe(r1.id);
+    expect(list[1].id).toBe(r2.id);
+  });
+
+  test("excludes already-approved messages", async () => {
+    const { savePending, updatePending } = await import("../../src/commands/shared/queue-store");
+    const { cmdQueueList } = await import("../../src/commands/plugins/inbox/impl");
+    const r1 = savePending({ sender: "a", target: "b", message: "m1" });
+    const r2 = savePending({ sender: "a", target: "c", message: "m2" });
+    updatePending(r1.id, { status: "approved" });
+    const list = cmdQueueList();
+    expect(list).toHaveLength(1);
+    expect(list[0].id).toBe(r2.id);
+  });
+});
+
+describe("inbox-cli — cmdShow / resolvePendingId", () => {
+  test("cmdShow returns the message by exact id", async () => {
+    const { savePending } = await import("../../src/commands/shared/queue-store");
+    const { cmdShow } = await import("../../src/commands/plugins/inbox/impl");
+    const rec = savePending({ sender: "a", target: "b", message: "hi" });
+    const got = cmdShow(rec.id);
+    expect(got?.id).toBe(rec.id);
+    expect(got?.message).toBe("hi");
+  });
+
+  test("cmdShow returns null for unknown id", async () => {
+    const { cmdShow } = await import("../../src/commands/plugins/inbox/impl");
+    expect(cmdShow("does-not-exist")).toBeNull();
+  });
+
+  test("resolvePendingId prefix-matches when no exact match", async () => {
+    const { savePending } = await import("../../src/commands/shared/queue-store");
+    const { resolvePendingId } = await import("../../src/commands/plugins/inbox/impl");
+    const rec = savePending({ sender: "a", target: "b", message: "m" });
+    const prefix = rec.id.slice(0, 10);
+    const got = resolvePendingId(prefix);
+    expect(got?.id).toBe(rec.id);
+  });
+
+  test("resolvePendingId returns null on empty input", async () => {
+    const { resolvePendingId } = await import("../../src/commands/plugins/inbox/impl");
+    expect(resolvePendingId("")).toBeNull();
+  });
+});
+
+describe("inbox-cli — cmdApprove", () => {
+  test("approve flips status, calls cmdSend, then deletes file", async () => {
+    const { savePending, loadPendingById } = await import("../../src/commands/shared/queue-store");
+    const { cmdApprove } = await import("../../src/commands/plugins/inbox/impl");
+    const rec = savePending({ sender: "a", target: "b", message: "hi", query: "node:b" });
+
+    const result = await cmdApprove(rec.id);
+    expect(result.status).toBe("approved");
+    expect(sendCalls).toHaveLength(1);
+    expect(sendCalls[0].query).toBe("node:b");
+    expect(sendCalls[0].message).toBe("hi");
+    // ACL bypass env was set DURING the cmdSend invocation.
+    expect(sendCalls[0].bypass).toBe("1");
+    // File removed after successful send.
+    expect(loadPendingById(rec.id)).toBeNull();
+  });
+
+  test("approve throws on unknown id", async () => {
+    const { cmdApprove } = await import("../../src/commands/plugins/inbox/impl");
+    await expect(cmdApprove("nope")).rejects.toThrow(/not found/);
+  });
+
+  test("approve uses target as fallback query when query field absent", async () => {
+    const { savePending } = await import("../../src/commands/shared/queue-store");
+    const { cmdApprove } = await import("../../src/commands/plugins/inbox/impl");
+    const rec = savePending({ sender: "a", target: "beta", message: "hi" });
+    await cmdApprove(rec.id);
+    expect(sendCalls[0].query).toBe("beta");
+  });
+
+  test("approve clears MAW_ACL_BYPASS after the send", async () => {
+    const { savePending } = await import("../../src/commands/shared/queue-store");
+    const { cmdApprove } = await import("../../src/commands/plugins/inbox/impl");
+    const rec = savePending({ sender: "a", target: "b", message: "m" });
+    await cmdApprove(rec.id);
+    // After cmdApprove returns, the env is restored.
+    expect(process.env.MAW_ACL_BYPASS).toBeUndefined();
+  });
+
+  test("approve refuses to re-approve an already-approved record", async () => {
+    const { savePending, updatePending } = await import("../../src/commands/shared/queue-store");
+    const { cmdApprove } = await import("../../src/commands/plugins/inbox/impl");
+    const rec = savePending({ sender: "a", target: "b", message: "m" });
+    updatePending(rec.id, { status: "approved" });
+    await expect(cmdApprove(rec.id)).rejects.toThrow(/already approved/);
+  });
+});
+
+describe("inbox-cli — cmdReject", () => {
+  test("reject flips status to rejected, then deletes the file", async () => {
+    const { savePending, loadPendingById } = await import("../../src/commands/shared/queue-store");
+    const { cmdReject } = await import("../../src/commands/plugins/inbox/impl");
+    const rec = savePending({ sender: "a", target: "b", message: "m" });
+    const result = cmdReject(rec.id);
+    expect(result.status).toBe("rejected");
+    expect(loadPendingById(rec.id)).toBeNull();
+  });
+
+  test("reject does NOT call cmdSend", async () => {
+    const { savePending } = await import("../../src/commands/shared/queue-store");
+    const { cmdReject } = await import("../../src/commands/plugins/inbox/impl");
+    const rec = savePending({ sender: "a", target: "b", message: "m" });
+    cmdReject(rec.id);
+    expect(sendCalls).toHaveLength(0);
+  });
+
+  test("reject throws on unknown id", async () => {
+    const { cmdReject } = await import("../../src/commands/plugins/inbox/impl");
+    expect(() => cmdReject("nope")).toThrow(/not found/);
+  });
+});
+
+describe("inbox-cli — formatters", () => {
+  test("formatQueueList shows the empty state", async () => {
+    const { formatQueueList } = await import("../../src/commands/plugins/inbox/impl");
+    expect(formatQueueList([])).toMatch(/no pending/);
+  });
+
+  test("formatQueueList includes id, sender, target, sentAt", async () => {
+    const { savePending } = await import("../../src/commands/shared/queue-store");
+    const { cmdQueueList, formatQueueList } = await import("../../src/commands/plugins/inbox/impl");
+    const rec = savePending({ sender: "alpha", target: "beta", message: "hi" });
+    const out = formatQueueList(cmdQueueList());
+    expect(out).toContain(rec.id);
+    expect(out).toContain("alpha");
+    expect(out).toContain("beta");
+  });
+
+  test("formatQueueDetail surfaces all fields including query", async () => {
+    const { savePending } = await import("../../src/commands/shared/queue-store");
+    const { cmdShow, formatQueueDetail } = await import("../../src/commands/plugins/inbox/impl");
+    const rec = savePending({ sender: "a", target: "b", message: "hello world", query: "node:b" });
+    const got = cmdShow(rec.id)!;
+    const out = formatQueueDetail(got);
+    expect(out).toContain("hello world");
+    expect(out).toContain("node:b");
+    expect(out).toContain("pending");
+  });
+});

--- a/test/isolated/inbox-queue.test.ts
+++ b/test/isolated/inbox-queue.test.ts
@@ -1,0 +1,181 @@
+/**
+ * inbox-queue — pending-message store + TTL tests (#842 Sub-C).
+ *
+ * Covers:
+ *   - savePending/loadPending round-trip
+ *   - oldest-first ordering
+ *   - 30-day TTL (expired files reaped on read)
+ *   - atomic write (no .tmp left behind on success)
+ *   - updatePending merges + preserves id
+ *   - loadPendingById vs prefix resolution semantics in queue-store
+ *
+ * Isolation pattern mirrors trust-list.test.ts / scope-acl.test.ts —
+ * MAW_CONFIG_DIR is pointed at a per-test temp dir so the on-disk
+ * `<CONFIG_DIR>/pending/` resolves cleanly.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+let testDir: string;
+let originalConfigDir: string | undefined;
+let originalHome: string | undefined;
+
+beforeEach(() => {
+  testDir = mkdtempSync(join(tmpdir(), "maw-inbox-queue-"));
+  originalConfigDir = process.env.MAW_CONFIG_DIR;
+  originalHome = process.env.MAW_HOME;
+  process.env.MAW_CONFIG_DIR = testDir;
+  delete process.env.MAW_HOME;
+});
+
+afterEach(() => {
+  if (originalConfigDir === undefined) delete process.env.MAW_CONFIG_DIR;
+  else process.env.MAW_CONFIG_DIR = originalConfigDir;
+  if (originalHome === undefined) delete process.env.MAW_HOME;
+  else process.env.MAW_HOME = originalHome;
+  try { rmSync(testDir, { recursive: true, force: true }); } catch { /* ok */ }
+});
+
+describe("queue-store — savePending/loadPending round-trip", () => {
+  test("savePending writes a single record and loadPending returns it", async () => {
+    const { savePending, loadPending } = await import("../../src/commands/shared/queue-store");
+    const rec = savePending({ sender: "alpha", target: "beta", message: "hi" });
+    expect(rec.id).toBeTruthy();
+    expect(rec.sender).toBe("alpha");
+    expect(rec.target).toBe("beta");
+    expect(rec.message).toBe("hi");
+    expect(rec.status).toBe("pending");
+    const list = loadPending();
+    expect(list).toHaveLength(1);
+    expect(list[0].id).toBe(rec.id);
+  });
+
+  test("loadPending returns [] when pending dir missing", async () => {
+    const { loadPending } = await import("../../src/commands/shared/queue-store");
+    expect(loadPending()).toEqual([]);
+  });
+
+  test("savePending creates the pending directory if missing", async () => {
+    const { savePending, pendingDir } = await import("../../src/commands/shared/queue-store");
+    expect(existsSync(pendingDir())).toBe(false);
+    savePending({ sender: "a", target: "b", message: "m" });
+    expect(existsSync(pendingDir())).toBe(true);
+  });
+
+  test("savePending stores all fields on disk in JSON", async () => {
+    const { savePending, pendingPath } = await import("../../src/commands/shared/queue-store");
+    const rec = savePending({ sender: "a", target: "b", message: "m", query: "node:b" });
+    const onDisk = JSON.parse(readFileSync(pendingPath(rec.id), "utf-8"));
+    expect(onDisk.sender).toBe("a");
+    expect(onDisk.target).toBe("b");
+    expect(onDisk.message).toBe("m");
+    expect(onDisk.query).toBe("node:b");
+    expect(onDisk.status).toBe("pending");
+    expect(onDisk.id).toBe(rec.id);
+  });
+
+  test("savePending writes atomically (no .tmp left behind)", async () => {
+    const { savePending, pendingDir } = await import("../../src/commands/shared/queue-store");
+    savePending({ sender: "a", target: "b", message: "m" });
+    const files = readdirSync(pendingDir());
+    expect(files.some(f => f.endsWith(".tmp"))).toBe(false);
+  });
+});
+
+describe("queue-store — ordering", () => {
+  test("loadPending returns oldest first", async () => {
+    const { savePending, loadPending } = await import("../../src/commands/shared/queue-store");
+    const r1 = savePending({ sender: "a", target: "b", message: "first" });
+    // Force a measurable timestamp gap.
+    await new Promise(res => setTimeout(res, 5));
+    const r2 = savePending({ sender: "a", target: "c", message: "second" });
+    const list = loadPending();
+    expect(list).toHaveLength(2);
+    expect(list[0].id).toBe(r1.id);
+    expect(list[1].id).toBe(r2.id);
+  });
+});
+
+describe("queue-store — TTL (30 days)", () => {
+  test("file older than TTL_MS is reaped on loadPending", async () => {
+    const { savePending, loadPending, pendingPath, TTL_MS } = await import("../../src/commands/shared/queue-store");
+    const rec = savePending({ sender: "a", target: "b", message: "old" });
+    // Rewrite sentAt to be older than TTL.
+    const path = pendingPath(rec.id);
+    const stale = JSON.parse(readFileSync(path, "utf-8"));
+    stale.sentAt = new Date(Date.now() - TTL_MS - 1000).toISOString();
+    writeFileSync(path, JSON.stringify(stale, null, 2));
+    const list = loadPending();
+    expect(list).toHaveLength(0);
+    expect(existsSync(path)).toBe(false); // reaped
+  });
+
+  test("file just under TTL is preserved", async () => {
+    const { savePending, loadPending, pendingPath, TTL_MS } = await import("../../src/commands/shared/queue-store");
+    const rec = savePending({ sender: "a", target: "b", message: "fresh" });
+    const path = pendingPath(rec.id);
+    const fresh = JSON.parse(readFileSync(path, "utf-8"));
+    fresh.sentAt = new Date(Date.now() - TTL_MS + 60_000).toISOString();
+    writeFileSync(path, JSON.stringify(fresh, null, 2));
+    const list = loadPending();
+    expect(list).toHaveLength(1);
+    expect(existsSync(path)).toBe(true);
+  });
+
+  test("loadPendingById returns null for an expired entry and reaps it", async () => {
+    const { savePending, loadPendingById, pendingPath, TTL_MS } = await import("../../src/commands/shared/queue-store");
+    const rec = savePending({ sender: "a", target: "b", message: "old" });
+    const path = pendingPath(rec.id);
+    const stale = JSON.parse(readFileSync(path, "utf-8"));
+    stale.sentAt = new Date(Date.now() - TTL_MS - 1000).toISOString();
+    writeFileSync(path, JSON.stringify(stale, null, 2));
+    expect(loadPendingById(rec.id)).toBeNull();
+    expect(existsSync(path)).toBe(false);
+  });
+});
+
+describe("queue-store — updatePending", () => {
+  test("updatePending flips status and preserves id", async () => {
+    const { savePending, updatePending, loadPendingById } = await import("../../src/commands/shared/queue-store");
+    const rec = savePending({ sender: "a", target: "b", message: "m" });
+    const updated = updatePending(rec.id, { status: "approved" });
+    expect(updated.id).toBe(rec.id);
+    expect(updated.status).toBe("approved");
+    const reload = loadPendingById(rec.id);
+    expect(reload?.status).toBe("approved");
+  });
+
+  test("updatePending throws on unknown id", async () => {
+    const { updatePending } = await import("../../src/commands/shared/queue-store");
+    expect(() => updatePending("does-not-exist", { status: "approved" })).toThrow(/not found/);
+  });
+});
+
+describe("queue-store — deletePending", () => {
+  test("deletePending removes the file and returns true", async () => {
+    const { savePending, deletePending, pendingPath } = await import("../../src/commands/shared/queue-store");
+    const rec = savePending({ sender: "a", target: "b", message: "m" });
+    expect(existsSync(pendingPath(rec.id))).toBe(true);
+    expect(deletePending(rec.id)).toBe(true);
+    expect(existsSync(pendingPath(rec.id))).toBe(false);
+  });
+
+  test("deletePending returns false when file is missing", async () => {
+    const { deletePending } = await import("../../src/commands/shared/queue-store");
+    expect(deletePending("nope")).toBe(false);
+  });
+});
+
+describe("queue-store — corrupt files", () => {
+  test("corrupt JSON file is skipped silently", async () => {
+    const { savePending, loadPending, pendingDir } = await import("../../src/commands/shared/queue-store");
+    const good = savePending({ sender: "a", target: "b", message: "good" });
+    // Write a junk JSON file alongside.
+    writeFileSync(join(pendingDir(), "junk.json"), "{not json");
+    const list = loadPending();
+    expect(list).toHaveLength(1);
+    expect(list[0].id).toBe(good.id);
+  });
+});


### PR DESCRIPTION
## Closes #842 + completes #642 Phase 2

KEYSTONE: ACL evaluation now blocks cross-scope cross-oracle messages for human approval per the original #642 vision.

### What landed
- **`src/commands/shared/queue-store.ts`** — atomic writes to `<CONFIG_DIR>/pending/<id>.json`, 30-day TTL on read
- **`src/commands/plugins/inbox/`** — `list`/`approve`/`reject`/`show` subcommands
- **`src/commands/shared/comm-send.ts`** — `evaluateAclFromDisk(sender, target)` called for cross-oracle sends; verdict "queue" writes to pending/, doesn't deliver

### Default behavior preserved
No scopes configured → default-allow (existing behavior). Operators opt in by creating scopes via `maw scope create`.

### Tests
- inbox-queue.test.ts: 14 pass (storage + TTL)
- inbox-cli.test.ts: 18 pass
- comm-send-acl.test.ts: 12 pass when run alone (mock pollution in batch run is pre-existing pattern across other comm-send isolated tests)

### Sub-issues closed
- [x] A: ACL evaluation (#872)
- [x] B: Trust list (#873)
- [x] C: Approval queue + inbox + comm-send wiring (THIS PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)