### PR TITLE
refactor(shared): trim dead exports + dedup color constants (#834)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.28",
+  "version": "26.4.29-alpha.29",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/plugins/doctor/impl.ts
+++ b/src/commands/plugins/doctor/impl.ts
@@ -251,7 +251,7 @@ function checkCrossSourceConsistency(): DoctorResult["checks"][number] {
 
   const { headline, lines } = summarizeGaps(gaps);
   for (const line of lines) {
-    console.log(`    ${YELLOW}⚠${RESET} ${line}`);
+    console.log(`    ${C.yellow}⚠${C.reset} ${line}`);
   }
   return {
     name: "manifest:cross-source",

--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -104,6 +104,10 @@ export async function checkPaneIdle(target: string, host?: string): Promise<{ id
  * as literal placeholders — the user is meant to run `maw locate <agent>`
  * to enumerate concrete candidates across the federation. Only `<agent>`
  * is substituted with the bare query the user actually typed.
+ *
+ * @internal — exported for tests only (test/comm-send-deprecation-759.test.ts).
+ *   The production caller is `cmdSend` in this same file. No other module
+ *   imports this symbol.
  */
 export function formatBareNameError(query: string): string {
   const RED = "\x1b[31m"; // error marker

--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -16,6 +16,11 @@ import type { Session } from "../../core/runtime/find-window";
  *
  * Returns the resolved repo info, or null if no matching worktree is found
  * or the main repo path cannot be determined.
+ *
+ * @internal — exported for tests only (test/wake-resolve.test.ts).
+ *   The production caller is `resolveOracle` in this same file. Tests use
+ *   injected deps to exercise the fallback in isolation; no other module
+ *   imports this symbol.
  */
 export async function resolveFromWorktrees(
   oracle: string,


### PR DESCRIPTION
## Summary

Final cleanup pass for #834. Per the audit's "if anything imports it, STOP" rule, the bulk of #834's flagged "dead" symbols turned out to have test coverage and were correctly handled in #851 (Tier 2) by keeping them exported with `@internal — exported for tests only` JSDoc tags. This PR closes the three remaining gaps that #851 didn't catch.

## Why so small?

#834's headline number was **~232 LOC reclaimable** (184 dead + 43 internal-only + 5 color dedup). Reality after re-running grep for every flagged symbol:

| Symbol | #834 says | Reality |
|---|---|---|
| `extractGhqOrgs` | dead | imported by `test/wake-resolve-scan-suggest.test.ts` — kept |
| `fetchAllowedOrgs` | dead | imported by tests — kept |
| `filterOrgsByAllowed` | dead | imported by tests — kept |
| `buildOrgList` | dead | imported by tests — kept |
| `readTtyAnswer` | dead | imported by tests — kept |
| `defaultPromptFn` | dead | already privatized in #851 |
| `checkGhRepo` | dead | already privatized in #851 |
| `scanOrgs` | dead | imported by tests — kept |
| `_resetAllowedOrgsCache` | dead | imported by tests — kept |
| `buildAgentRows` | dead | imported by `test/agents.test.ts` — kept |
| `AgentRow` | dead | imported by `test/agents.test.ts` — kept |
| `probeTmuxServer` | dead | imported by `test/wake-maybe-split.test.ts` — kept |
| `writeInboxMessage` | dead | already deleted prior to this branch — no longer in the file |
| `resolveFromWorktrees` | privatize | imported by `test/wake-resolve.test.ts` — annotate, keep export |
| `formatBareNameError` | privatize | imported by `test/comm-send-deprecation-759.test.ts` — annotate, keep export |
| Color block (doctor/impl) | dedup | already done in #851; subsequent #856 introduced a regression — fixed here |

The audit ran 2026-04-28 morning, before #851 + #856 shipped. By the time this branch was cut, there was almost nothing left to delete.

## What this PR actually does

1. **Bug fix — `src/commands/plugins/doctor/impl.ts:254`**
   - Bare `YELLOW` and `RESET` identifiers referenced after the local color block was removed by #851.
   - Regression slipped in via #856 (`feat(doctor): cross-source consistency via OracleManifest`) which added a `console.log` using stale identifier names.
   - Fix: `${YELLOW}…${RESET}` → `${C.yellow}…${C.reset}` (using the `C` import already in the file).
   - Would have ReferenceError'd at runtime any time `checkCrossSourceConsistency` produced ≥1 gap line.

2. **`@internal` annotation — `resolveFromWorktrees`** (`src/commands/shared/wake-resolve-impl.ts:20`)
   - Test imports: `test/wake-resolve.test.ts:13`
   - In-file caller: `resolveOracle` (line 85)
   - No other module references it.
   - Action: keep `export`, add `@internal — exported for tests only` JSDoc tag matching the convention #851 established for the wake-resolve-scan-suggest.ts symbols.

3. **`@internal` annotation — `formatBareNameError`** (`src/commands/shared/comm-send.ts:108`)
   - Test imports: `test/comm-send-deprecation-759.test.ts:14`
   - In-file caller: `cmdSend` (line ~158)
   - No other module references it.
   - Action: same as above — keep `export`, add JSDoc.

## Acceptance

- [x] `bun test` — 1402 pass / 1 skip / 1 fail. The single failure is `test/curl-fetch.test.ts > sends HMAC headers when token configured`, which is pre-existing on baseline (HEAD before this branch) and unrelated to anything touched here.
- [x] No production callers were broken (only doc + comment changes, plus one undefined-identifier bug fixed).
- [x] CalVer bumped: `26.4.29-alpha.28` → `26.4.29-alpha.29`.

## LOC scoreboard

| Category | LOC delta |
|---|---|
| Production code deleted | 0 |
| Production code restored from broken state | 1 (the YELLOW/RESET fix) |
| JSDoc annotations added | +9 lines of `@internal` documentation |
| Total diff | `+11 / -2` across 4 files |

Closes #834.

🤖 Generated with [Claude Code](https://claude.com/claude-code)