### PR TITLE
feat(sdk): export UserError + parseFlags from @maw-js/sdk/plugin (#844)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.29",
+  "version": "26.4.29-alpha.30",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/packages/sdk/plugin.d.ts
+++ b/packages/sdk/plugin.d.ts
@@ -1,9 +1,17 @@
 /**
- * @maw-js/sdk/plugin — plugin-authoring types.
+ * @maw-js/sdk/plugin — plugin-authoring surface.
  *
- * Self-contained declarations. Mirrors src/plugin/types.ts InvokeContext +
- * InvokeResult so plugin authors can import without a path dependency.
+ * Self-contained declarations — no parent-relative imports, no peer-dep
+ * type references. Mirrors src/plugin/types.ts (InvokeContext / InvokeResult),
+ * src/core/util/user-error.ts (UserError + isUserError), and
+ * src/cli/parse-args.ts (parseFlags) so plugin authors can import without
+ * a path or peer-dep dance.
+ *
+ * See #844 / #848 — shellenv inlined UserError + parseFlags as TEMP for its
+ * v0.1.0 tag; once this declaration ships those inlines drop in v0.2.0.
  */
+
+// ─── Plugin invocation types ─────────────────────────────────────────────────
 
 export interface InvokeContext {
   /** Where the plugin is being called from. */
@@ -20,3 +28,62 @@ export interface InvokeResult {
   /** Optional error message when `ok` is false. */
   error?: string;
 }
+
+// ─── UserError — user-facing failure with ESM-safe brand ─────────────────────
+
+/**
+ * UserError signals a user-facing failure — bad input, missing target,
+ * unknown command. The throw site is responsible for printing the
+ * user-facing output BEFORE throwing; the top-level catch exits 1
+ * cleanly without printing a stack trace.
+ *
+ * The `isUserError` brand survives ESM module-boundary crossings where
+ * `instanceof UserError` would not.
+ */
+export declare class UserError extends Error {
+  readonly isUserError: true;
+  constructor(message: string);
+}
+
+/** Type guard — true for any error (cross-realm) carrying the UserError brand. */
+export declare function isUserError(e: unknown): e is UserError;
+
+// ─── parseFlags — permissive `arg` wrapper ───────────────────────────────────
+
+/**
+ * Minimal arg-spec shape — keeps plugin.d.ts self-contained without forcing
+ * plugin authors to depend on `arg`'s type package. Plugins that want richer
+ * typing can import `arg` directly and pass-through.
+ */
+export type ParseFlagsHandler<T = unknown> = (
+  value: string,
+  name: string,
+  previousValue?: T,
+) => T;
+
+export interface ParseFlagsSpec {
+  [key: string]: string | ParseFlagsHandler | [ParseFlagsHandler];
+}
+
+export type ParseFlagsResult<T extends ParseFlagsSpec> = { _: string[] } & {
+  [K in keyof T]?: T[K] extends ParseFlagsHandler<infer R>
+    ? R
+    : T[K] extends [ParseFlagsHandler<infer R>]
+    ? R[]
+    : unknown;
+};
+
+/**
+ * Parse flags from an args array. Permissive — unknown flags fall through
+ * to `result._` rather than throwing. Wraps the `arg` package.
+ *
+ * @param args  raw process.argv.slice(2) array
+ * @param spec  arg spec (e.g. `{ "--verbose": Boolean, "--from": String }`)
+ * @param skip  number of leading positional args to skip (default 0) —
+ *              e.g. `skip=1` for `bud <name> --from neo` skips `bud`
+ */
+export declare function parseFlags<T extends ParseFlagsSpec>(
+  args: string[],
+  spec: T,
+  skip?: number,
+): ParseFlagsResult<T>;

--- a/packages/sdk/plugin.ts
+++ b/packages/sdk/plugin.ts
@@ -1,11 +1,29 @@
 /**
- * @maw-js/sdk/plugin — plugin-authoring types.
+ * @maw-js/sdk/plugin — plugin-authoring surface.
  *
- *   import type { InvokeContext, InvokeResult } from "@maw-js/sdk/plugin";
+ * Single import line for plugin authors:
+ *
+ *   import {
+ *     type InvokeContext,
+ *     type InvokeResult,
+ *     UserError,
+ *     isUserError,
+ *     parseFlags,
+ *   } from "@maw-js/sdk/plugin";
  *
  *   export default async function (ctx: InvokeContext): Promise<InvokeResult> {
+ *     if (!ctx.args) throw new UserError("missing args");
  *     return { ok: true, output: "hello" };
  *   }
+ *
+ * Pure re-exports — semantics match the originals in src/. See #844 / #848:
+ * shellenv inlined UserError + parseFlags as TEMP at v0.1.0; once this lands
+ * those inlines disappear in v0.2.0. Same shape unblocks `maw-bg` and any
+ * future plugin that needs user-facing exits or permissive flag parsing.
  */
 
 export type { InvokeContext, InvokeResult } from "../../src/plugin/types";
+
+export { UserError, isUserError } from "../../src/core/util/user-error";
+
+export { parseFlags } from "../../src/cli/parse-args";

--- a/test/isolated/sdk-plugin-exports.test.ts
+++ b/test/isolated/sdk-plugin-exports.test.ts
@@ -1,0 +1,105 @@
+/**
+ * sdk-plugin-exports.test.ts — #844
+ *
+ * Verifies @maw-js/sdk/plugin exposes the plugin-author surface:
+ *   - InvokeContext, InvokeResult (types — already present pre-#844)
+ *   - UserError (class) + isUserError() (type guard) — added in #844
+ *   - parseFlags (function)                          — added in #844
+ *
+ * Strategy:
+ *   1. Direct import from packages/sdk/plugin.ts to assert runtime exports
+ *      and behavior (the .ts file is what the workspace `@maw-js/sdk`
+ *      package resolves to — same path plugin authors hit at install time).
+ *   2. .d.ts shape check — no parent-relative imports, declares the new
+ *      symbols. Mirrors the existing test/sdk-package.test.ts contract.
+ *
+ * Why isolated: runs in its own bun process so mock pollution from other
+ * test files (which monkey-patch tmux/ssh transports) cannot leak. Same
+ * convention as the rest of test/isolated/.
+ *
+ * shellenv (v0.1.0) inlines UserError + parseFlags as TEMP today; once #844
+ * lands those inlines drop in v0.2.0. Same pattern unblocks `maw-bg` and
+ * any future plugin needing user-facing exits or permissive flag parsing.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import {
+  UserError,
+  isUserError,
+  parseFlags,
+} from "../../packages/sdk/plugin";
+
+const PLUGIN_DTS = resolve(__dirname, "..", "..", "packages", "sdk", "plugin.d.ts");
+
+describe("@maw-js/sdk/plugin runtime exports (#844)", () => {
+  test("UserError is a constructable class with the expected name", () => {
+    const err = new UserError("missing target");
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("UserError");
+    expect(err.message).toBe("missing target");
+  });
+
+  test("UserError carries the ESM-safe `isUserError` brand", () => {
+    const err = new UserError("bad input");
+    // The brand is what survives across ESM realm boundaries — `instanceof`
+    // does not. Plugin authors rely on this contract.
+    expect((err as { isUserError?: boolean }).isUserError).toBe(true);
+  });
+
+  test("isUserError() narrows for thrown UserError instances", () => {
+    const err: unknown = new UserError("nope");
+    expect(isUserError(err)).toBe(true);
+  });
+
+  test("isUserError() returns false for plain Errors and non-errors", () => {
+    expect(isUserError(new Error("regular"))).toBe(false);
+    expect(isUserError("string")).toBe(false);
+    expect(isUserError(null)).toBe(false);
+    expect(isUserError(undefined)).toBe(false);
+    expect(isUserError({ isUserError: true })).toBe(false); // not an Error
+  });
+
+  test("parseFlags is a function exported from the plugin entry", () => {
+    expect(typeof parseFlags).toBe("function");
+  });
+
+  test("parseFlags parses known flags and routes positionals to `_`", () => {
+    const result = parseFlags(
+      ["sub", "--verbose", "pos1", "pos2"],
+      { "--verbose": Boolean, "-v": "--verbose" },
+      1, // skip leading "sub"
+    );
+    expect(result["--verbose"]).toBe(true);
+    expect(result._).toEqual(["pos1", "pos2"]);
+  });
+
+  test("parseFlags is permissive — unknown flags do not throw", () => {
+    // Permissive mode: --unknown should fall through to `_`, not error.
+    expect(() =>
+      parseFlags(["--unknown", "value"], { "--known": String }, 0),
+    ).not.toThrow();
+  });
+});
+
+describe("@maw-js/sdk/plugin .d.ts surface (#844)", () => {
+  const dts = readFileSync(PLUGIN_DTS, "utf8");
+
+  test(".d.ts is self-contained — no parent-relative imports", () => {
+    // Same contract as test/sdk-package.test.ts: must survive file:/tarball
+    // installs from outside the repo.
+    expect(dts).not.toMatch(/from ["']\.\.\//);
+  });
+
+  test(".d.ts declares the new #844 surface", () => {
+    expect(dts).toMatch(/export declare class UserError/);
+    expect(dts).toMatch(/export declare function isUserError/);
+    expect(dts).toMatch(/export declare function parseFlags/);
+  });
+
+  test(".d.ts retains the pre-existing InvokeContext / InvokeResult", () => {
+    expect(dts).toMatch(/export interface InvokeContext/);
+    expect(dts).toMatch(/export interface InvokeResult/);
+  });
+});


### PR DESCRIPTION
## Summary

Plugin authors can now import `UserError`, `isUserError()`, and `parseFlags` from the existing `@maw-js/sdk/plugin` entry — alongside the `InvokeContext` / `InvokeResult` types they already get there. Closes #844 (Option A — fold into `./plugin`).

```ts
import {
  type InvokeContext,
  type InvokeResult,
  UserError,
  isUserError,
  parseFlags,
} from "@maw-js/sdk/plugin";

export default async function (ctx: InvokeContext): Promise<InvokeResult> {
  const flags = parseFlags(ctx.args as string[], { "--help": Boolean }, 0);
  if (flags["--help"]) return { ok: true, output: "usage: ..." };
  if (!ctx.args) throw new UserError("missing args");
  return { ok: true, output: "hello" };
}
```

## Why

shellenv (#848) hit a pre-flight blocker: two plugin-author surfaces are NOT exposed by `@maw-js/sdk`. The plugin shipped v0.1.0 with both inlined as `TEMP` so it could tag and unblock the lean-core epic (#640, Path A.2). Same gap will repeat for `maw-bg` and any future plugin.

This PR folds the two surfaces into the SDK so:

- **shellenv v0.2.0** can delete its `TEMP` inlines and import directly from `@maw-js/sdk/plugin` — single import line, zero duplication
- Future plugins skip the inline-then-fold dance entirely
- The brand pattern (`isUserError = true`) — the documented ESM-realm-safe convention — becomes the contract plugin authors compose against, not a copy-pasted constant

## What changed

- `packages/sdk/plugin.ts` — adds re-exports of `UserError` + `isUserError` (from `src/core/util/user-error.ts`) and `parseFlags` (from `src/cli/parse-args.ts`). Pure re-exports; nothing in `src/` moved or changed semantics.
- `packages/sdk/plugin.d.ts` — adds self-contained declarations for the new symbols. No parent-relative imports, no peer-dep type references — the existing `test/sdk-package.test.ts` self-containment contract is preserved so `file:` / tarball / npm installs from outside the repo keep resolving cleanly.
- `test/isolated/sdk-plugin-exports.test.ts` — new isolated test, 10 assertions across 9 cases:
  - `UserError` construction + `name === "UserError"` + extends `Error`
  - ESM-safe `isUserError = true` brand
  - `isUserError()` narrowing for genuine `UserError` instances
  - `isUserError()` returning false for plain `Error`s, strings, null/undefined, plain branded objects
  - `parseFlags` is a function
  - `parseFlags` parses known flags + routes positionals to `_` + honors `skip`
  - `parseFlags` permissive — unknown flags do not throw
  - `.d.ts` contract: no `from "../"`, declares `UserError` / `isUserError` / `parseFlags`, retains `InvokeContext` / `InvokeResult`
- `package.json` — calver bump to `v26.4.29-alpha.30`

## Compatibility

- `src/cli.ts` and `src/core/fleet/validate.ts` keep importing `UserError` from the local path — unchanged.
- `parseFlags` was already exported from the umbrella `@maw-js/sdk` index; this PR adds it under `/plugin` too. Both paths resolve to the same source.
- Pre-existing `@maw-js/sdk/plugin` consumers (init template, `test/plugin-build.test.ts`, `test/sdk-package.test.ts`) still pass — verified locally.
- No breaking changes to existing CLI runtime or third-party plugin imports.

## Follow-ups

- Once this lands, file the shellenv v0.2.0 PR that deletes the `TEMP` inlines and imports from `@maw-js/sdk/plugin` (referenced in #848). Same path opens for `maw-bg` and future plugins.

## Test plan

- [x] `bun test test/isolated/sdk-plugin-exports.test.ts` — 10/10 pass locally
- [x] `bun test test/sdk-package.test.ts` — 3/3 pass (self-containment + workspace install untouched)
- [x] `bun test test/plugin-build.test.ts` — 32/32 pass (init template + build pipeline untouched)
- [ ] CI on `alpha` runs the full suite

Refs: #844, #848, #640