### PR TITLE
feat(sdk): export tmux from @maw-js/sdk top-level (#855)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.30",
+  "version": "26.4.29-alpha.31",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/packages/sdk/index.d.ts
+++ b/packages/sdk/index.d.ts
@@ -116,3 +116,59 @@ export interface MawSdk {
 
 export declare const maw: MawSdk;
 export default maw;
+
+// --- tmux SDK surface (#855) ---
+// Self-contained mirror of src/core/transport/tmux-class.ts. Hand-authored
+// so file:/tarball installs from outside the repo type-check cleanly. Only
+// the most-used methods are surfaced — the runtime class has more, but
+// this is the stable contract plugin authors can rely on.
+
+export interface TmuxPane {
+  id: string;
+  command: string;
+  target: string;
+  title: string;
+  pid?: number;
+  cwd?: string;
+}
+
+export interface TmuxWindow {
+  index: number;
+  name: string;
+  active: boolean;
+  cwd?: string;
+}
+
+export interface TmuxSession {
+  name: string;
+  windows: TmuxWindow[];
+}
+
+export declare class Tmux {
+  constructor(host?: string, socket?: string);
+  run(subcommand: string, ...args: (string | number)[]): Promise<string>;
+  tryRun(subcommand: string, ...args: (string | number)[]): Promise<string>;
+  listSessions(): Promise<TmuxSession[]>;
+  listAll(): Promise<TmuxSession[]>;
+  hasSession(name: string): Promise<boolean>;
+  killSession(name: string): Promise<void>;
+  listWindows(session: string): Promise<TmuxWindow[]>;
+  newWindow(
+    session: string,
+    name: string,
+    opts?: { cwd?: string },
+  ): Promise<void>;
+  selectWindow(target: string): Promise<void>;
+  switchClient(session: string): Promise<void>;
+  killWindow(target: string): Promise<void>;
+  listPanes(): Promise<TmuxPane[]>;
+  killPane(target: string): Promise<void>;
+  getPaneCommand(target: string): Promise<string>;
+  capture(target: string, lines?: number): Promise<string>;
+  sendKeys(target: string, ...keys: string[]): Promise<void>;
+  sendKeysLiteral(target: string, text: string): Promise<void>;
+  sendText(target: string, text: string): Promise<void>;
+}
+
+/** Default tmux instance — use this for the local socket. */
+export declare const tmux: Tmux;

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -5,8 +5,9 @@
  * get bundled with `maw plugin build`, the bundler inlines this module.
  * Phase B: swaps to a host-injected shim for runtime capability gating.
  *
- *   import { maw } from "@maw-js/sdk";
+ *   import { maw, tmux } from "@maw-js/sdk";
  *   const id = await maw.identity();
+ *   const sessions = await tmux.listSessions();
  */
 
 export {
@@ -22,3 +23,14 @@ export type {
   FeedEvent,
   PluginInfo,
 } from "../../src/core/runtime/sdk";
+
+// ─── tmux — top-level transport surface (#855) ───────────────────────────────
+// Plugins use `import { tmux } from "@maw-js/sdk"` for tmux ops (list, send,
+// capture). The `Tmux` class is also exported for consumers that need to
+// construct their own instances (custom socket / remote host).
+export { tmux, Tmux } from "../../src/core/transport/tmux";
+export type {
+  TmuxPane,
+  TmuxWindow,
+  TmuxSession,
+} from "../../src/core/transport/tmux";

--- a/src/core/runtime/sdk.ts
+++ b/src/core/runtime/sdk.ts
@@ -7,7 +7,7 @@
  *
  * Three layers:
  *   maw.*        — API calls to maw serve (typed responses)
- *   maw.tmux.*   — tmux operations (list, send, capture)
+ *   tmux.*       — tmux operations (list, send, capture) [@maw-js/sdk top-level]
  *   maw.print.*  — colored terminal output helpers
  */
 

--- a/test/isolated/sdk-tmux-export.test.ts
+++ b/test/isolated/sdk-tmux-export.test.ts
@@ -1,0 +1,105 @@
+/**
+ * sdk-tmux-export.test.ts — #855
+ *
+ * Verifies @maw-js/sdk re-exports `tmux` at the top level so plugins can
+ *
+ *   import { tmux } from "@maw-js/sdk";
+ *   const sessions = await tmux.listSessions();
+ *
+ * Background: the doc comment at src/core/runtime/sdk.ts:10 originally
+ * advertised `maw.tmux.*` but the runtime `maw` const at line 153 never
+ * wired tmux. The internal SDK barrel (src/sdk/index.ts) exposed tmux but
+ * the public package barrel (packages/sdk/index.ts) didn't. Option 2
+ * (chosen): re-export `tmux` from packages/sdk/index.ts as a top-level
+ * symbol — cleanest abstraction, no `maw.tmux` aliasing.
+ *
+ * Strategy:
+ *   1. Direct import from packages/sdk/index.ts to assert runtime exports
+ *      and shape (the .ts file is what the workspace `@maw-js/sdk`
+ *      package resolves to — same path plugin authors hit at install time).
+ *   2. .d.ts shape check — no parent-relative imports, declares the new
+ *      `tmux` const + `Tmux` class + Tmux* types. Mirrors the existing
+ *      test/sdk-package.test.ts contract.
+ *
+ * Why isolated: runs in its own bun process so mock pollution from other
+ * test files (which monkey-patch tmux/ssh transports) cannot leak into
+ * the assertions on the real Tmux class. Same convention as the rest of
+ * test/isolated/.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { tmux, Tmux } from "../../packages/sdk";
+
+const INDEX_DTS = resolve(__dirname, "..", "..", "packages", "sdk", "index.d.ts");
+
+describe("@maw-js/sdk top-level tmux export (#855)", () => {
+  test("tmux is importable from @maw-js/sdk", () => {
+    expect(tmux).toBeDefined();
+    expect(tmux).not.toBeNull();
+  });
+
+  test("tmux is an instance of Tmux", () => {
+    expect(tmux).toBeInstanceOf(Tmux);
+  });
+
+  test("Tmux is a constructable class", () => {
+    const inst = new Tmux();
+    expect(inst).toBeInstanceOf(Tmux);
+  });
+
+  test("tmux exposes the documented operation methods", () => {
+    // Spec from src/core/runtime/sdk.ts:10 — "tmux.* — tmux operations
+    // (list, send, capture)". These are the contract surface plugin
+    // authors rely on; the rest of the Tmux class is implementation
+    // detail we don't lock into the public typing.
+    expect(typeof tmux.listSessions).toBe("function");
+    expect(typeof tmux.listWindows).toBe("function");
+    expect(typeof tmux.listPanes).toBe("function");
+    expect(typeof tmux.sendKeys).toBe("function");
+    expect(typeof tmux.sendText).toBe("function");
+    expect(typeof tmux.capture).toBe("function");
+  });
+
+  test("tmux exposes lifecycle helpers (hasSession, kill*, newWindow)", () => {
+    expect(typeof tmux.hasSession).toBe("function");
+    expect(typeof tmux.killSession).toBe("function");
+    expect(typeof tmux.killWindow).toBe("function");
+    expect(typeof tmux.killPane).toBe("function");
+    expect(typeof tmux.newWindow).toBe("function");
+  });
+
+  test("Tmux constructor accepts optional host + socket", () => {
+    // Sanity-check the class shape — a custom socket should not throw at
+    // construction time. The actual tmux call only happens on method use.
+    expect(() => new Tmux(undefined, "/tmp/maw-test.sock")).not.toThrow();
+    expect(() => new Tmux("user@host", "/tmp/maw-test.sock")).not.toThrow();
+  });
+});
+
+describe("@maw-js/sdk index.d.ts surface (#855)", () => {
+  const dts = readFileSync(INDEX_DTS, "utf8");
+
+  test(".d.ts is self-contained — no parent-relative imports", () => {
+    // Same contract as test/sdk-package.test.ts: must survive file:/tarball
+    // installs from outside the repo.
+    expect(dts).not.toMatch(/from ["']\.\.\//);
+  });
+
+  test(".d.ts declares the new #855 surface (tmux const + Tmux class)", () => {
+    expect(dts).toMatch(/export declare const tmux/);
+    expect(dts).toMatch(/export declare class Tmux/);
+  });
+
+  test(".d.ts declares the Tmux* types plugins need", () => {
+    expect(dts).toMatch(/export interface TmuxPane/);
+    expect(dts).toMatch(/export interface TmuxWindow/);
+    expect(dts).toMatch(/export interface TmuxSession/);
+  });
+
+  test(".d.ts retains the pre-existing maw + Identity surface", () => {
+    expect(dts).toMatch(/export declare const maw/);
+    expect(dts).toMatch(/export interface Identity/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes drift on #855: the doc comment at `src/core/runtime/sdk.ts:10` advertised three SDK layers — `maw.*`, `maw.tmux.*`, `maw.print.*` — but the actual `maw` const at line 153 never wired tmux. Internally `src/sdk/index.ts` (the umbrella SDK barrel) exposed `tmux`, but the public package barrel `packages/sdk/index.ts` never re-exported it. Plugin authors who followed the doc and tried `maw.tmux.listSessions()` got a `TypeError: undefined is not a function`.

This PR picks **Option 2** of three considered: re-export `tmux` as a top-level symbol from `@maw-js/sdk`. Plugins now write:

```ts
import { maw, tmux } from "@maw-js/sdk";

const id = await maw.identity();
const sessions = await tmux.listSessions();
```

Cleaner than retrofitting `maw.tmux` (which would have re-routed an already-shipped object) and consistent with how `print` is exposed at the top level. Pure re-export — zero semantic change to the underlying `Tmux` class.

## Changes

- `packages/sdk/index.ts` — re-export `tmux`, `Tmux`, and `TmuxPane` / `TmuxWindow` / `TmuxSession` types from `src/core/transport/tmux`.
- `packages/sdk/index.d.ts` — hand-authored, self-contained declarations for `tmux` const, `Tmux` class, and the three type aliases. No parent-relative imports (same contract as `test/sdk-package.test.ts`).
- `src/core/runtime/sdk.ts:10` — doc comment updated: `maw.tmux.*` → `tmux.*  — tmux operations (list, send, capture) [@maw-js/sdk top-level]`. Reflects the actual public surface plugin authors should reach for.
- `test/isolated/sdk-tmux-export.test.ts` — new isolated test, 10 cases / 25 assertions covering: `tmux` is importable, is a `Tmux` instance, `Tmux` is constructable, six documented operation methods are functions, five lifecycle helpers are functions, custom-host/socket constructor doesn't throw, `.d.ts` is self-contained (no `..` imports), `.d.ts` declares the new surface, `.d.ts` retains the pre-existing `maw` + `Identity` contract.
- `package.json` — CalVer bump `v26.4.29-alpha.30` → `v26.4.29-alpha.31` via `bun scripts/calver.ts`.

## Why isolated test

Other test files monkey-patch the tmux/ssh transports for fixture work; running this test in `test/isolated/` keeps mock pollution out of the assertions on the real `Tmux` class. Same convention as `sdk-plugin-exports.test.ts` from #844 (#878).

## Compatibility

- No breaking change. The internal `src/sdk/index.ts` barrel already exported `tmux`, so anything importing from `maw-js/sdk` (the workspace path, used by `bun build` plugin bundling) was already getting it. This PR only widens the published `@maw-js/sdk` package's public surface to match.
- The `.d.ts` is intentionally narrower than the runtime class — it locks in the methods plugin authors are documented to use (list / send / capture / lifecycle) and leaves the rest of `Tmux`'s internals (e.g. `loadBuffer`, `pasteBuffer`, `selectLayout`) as implementation detail not yet promoted to the contract. That can grow later without breaking existing consumers.

## Test plan

- [x] `bun test test/isolated/sdk-tmux-export.test.ts` — 10/10 pass, 25 assertions.
- [x] `bun test test/sdk-package.test.ts test/isolated/sdk-plugin-exports.test.ts` — 13/13 pass, 37 assertions (no regressions on the existing SDK contract).
- [ ] CI: `test:all` + isolated suite + mock-smoke + plugin tests on alpha branch.

## Refs

- Issue: #855
- Doc source of drift: `src/core/runtime/sdk.ts:10`
- Sibling pattern: #844 / #878 (UserError + parseFlags re-export from `@maw-js/sdk/plugin`)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>