### PR TITLE
fix(install): source plugins (path A.3) + tmux/shell capabilities (#874)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.31",
+  "version": "26.4.29-alpha.32",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/plugins/plugin/install-extraction.ts
+++ b/src/commands/plugins/plugin/install-extraction.ts
@@ -90,23 +90,46 @@ export async function downloadTarball(url: string): Promise<{ ok: true; path: st
 }
 
 /**
+ * Source-plugin detector (#874 path A.3).
+ *
+ * A "source plugin" is a tarball that declares `entry` (e.g. `./src/index.ts`
+ * or `./index.js`) but no `artifact` — typical of community repos that ship
+ * source rather than a pre-built `dist/index.js`. Bun runs source entries
+ * transparently, so the install path can accept them directly without a build
+ * step. We still hash the entry file's bytes for plugins.lock parity — that
+ * way `recordInstall` / `--pin` / hash-mismatch checks all keep working
+ * uniformly across source and built tarballs.
+ */
+export function isSourcePluginManifest(manifest: PluginManifest): boolean {
+  return !manifest.artifact && typeof manifest.entry === "string" && manifest.entry.length > 0;
+}
+
+/**
  * Verify sha256 of `manifest.artifact.path` (relative to `dir`) matches
  * `expected`. If `expected` is null/undefined, the manifest's embedded hash is
  * used as the expected value — this is the legacy (circular) check kept as a
  * defense-in-depth fencepost for transport corruption. See #487 / plugins.lock
  * for the real adversarial check (registry-pinned hashes).
+ *
+ * #874 path A.3 — for source plugins (no `artifact`, has `entry`), the entry
+ * file's bytes ARE the artifact. Hash that instead.
  */
 export function verifyArtifactHashAgainst(
   dir: string,
   manifest: PluginManifest,
   expected: string,
 ): { ok: true } | { ok: false; error: string } {
-  if (!manifest.artifact) {
+  let relPath: string;
+  if (manifest.artifact) {
+    relPath = manifest.artifact.path;
+  } else if (isSourcePluginManifest(manifest)) {
+    relPath = manifest.entry!;
+  } else {
     return { ok: false, error: "tarball manifest has no 'artifact' field — rebuild with `maw plugin build`" };
   }
-  const artifactPath = join(dir, manifest.artifact.path);
+  const artifactPath = join(dir, relPath);
   if (!existsSync(artifactPath)) {
-    return { ok: false, error: `artifact missing at ${manifest.artifact.path}` };
+    return { ok: false, error: `artifact missing at ${relPath}` };
   }
   const observed = hashFile(artifactPath);
   if (observed !== expected) {
@@ -121,8 +144,25 @@ export function verifyArtifactHashAgainst(
   return { ok: true };
 }
 
-/** Legacy manifest-only hash check. Kept as defense-in-depth fencepost per #487 §8 Phase 1. */
+/**
+ * Legacy manifest-only hash check. Kept as defense-in-depth fencepost per
+ * #487 §8 Phase 1.
+ *
+ * #874 path A.3 — source plugins (no `artifact`, has `entry`) skip this
+ * fencepost: there is no embedded hash to check against, so the registry-
+ * pinned hash in plugins.lock is the only authoritative source. Tampering
+ * is still detected at the pinned-hash check in `installFromTarball`.
+ */
 export function verifyArtifactHash(dir: string, manifest: PluginManifest): { ok: true } | { ok: false; error: string } {
+  if (isSourcePluginManifest(manifest)) {
+    // Source plugins have no embedded sha256 to fencepost against. Verify the
+    // entry file at least exists; the real adversarial check is plugins.lock.
+    const entryPath = join(dir, manifest.entry!);
+    if (!existsSync(entryPath)) {
+      return { ok: false, error: `source entry missing at ${manifest.entry}` };
+    }
+    return { ok: true };
+  }
   if (!manifest.artifact) {
     return { ok: false, error: "tarball manifest has no 'artifact' field — rebuild with `maw plugin build`" };
   }

--- a/src/commands/plugins/plugin/install-handlers.ts
+++ b/src/commands/plugins/plugin/install-handlers.ts
@@ -7,9 +7,9 @@ import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readlinkSy
 import { spawnSync } from "child_process";
 import { tmpdir } from "os";
 import { basename, join, resolve } from "path";
-import { formatSdkMismatchError, runtimeSdkVersion, satisfies } from "../../../plugin/registry";
+import { formatSdkMismatchError, hashFile, runtimeSdkVersion, satisfies } from "../../../plugin/registry";
 import { installRoot, removeExisting } from "./install-source-detect";
-import { extractTarball, downloadTarball, verifyArtifactHash, verifyArtifactHashAgainst } from "./install-extraction";
+import { extractTarball, downloadTarball, verifyArtifactHash, verifyArtifactHashAgainst, isSourcePluginManifest } from "./install-extraction";
 import { findPluginRoot, readManifest, printInstallSuccess } from "./install-manifest-helpers";
 import { readLock, recordInstall } from "./lock";
 import { createHash } from "crypto";
@@ -284,10 +284,17 @@ export async function installFromTarball(
 
   // #680 — persist lock entry on every successful tarball install. TOFU on
   // first install; overwrites on --force/--pin re-trust.
+  //
+  // #874 path A.3 — source plugins have no `artifact.sha256` to record. Hash
+  // the entry file's bytes instead so plugins.lock has a stable identity to
+  // verify against on subsequent installs. The entry file IS the artifact for
+  // source plugins (Bun executes .ts/.js source directly).
+  const recordedSha = manifest!.artifact?.sha256
+    ?? hashFile(join(dest, manifest!.entry!));
   recordInstall({
     name: manifest!.name,
     version: manifest!.version,
-    sha256: manifest!.artifact!.sha256!,
+    sha256: recordedSha,
     source: opts.source,
   });
 
@@ -295,7 +302,7 @@ export async function installFromTarball(
   printInstallSuccess(
     manifest!,
     dest,
-    { sha256: manifest!.artifact!.sha256! },
+    { sha256: recordedSha },
     sourceNote || undefined,
   );
 }

--- a/src/commands/plugins/plugin/lock.ts
+++ b/src/commands/plugins/plugin/lock.ts
@@ -179,7 +179,13 @@ export function writeLock(lock: Lock): void {
   renameSync(tmp, path);
 }
 
-/** Compute sha256 of a tarball's declared artifact (matches manifest.artifact.path). */
+/**
+ * Compute sha256 of a tarball's declared artifact (matches manifest.artifact.path).
+ *
+ * #874 path A.3 — for source plugins (no `artifact`, has `entry`), the entry
+ * file's bytes ARE the artifact. Hash that instead so `maw plugin pin` works
+ * uniformly across source and built tarballs.
+ */
 function hashTarballArtifact(tarballPath: string): { ok: true; hash: string; version: string } | { ok: false; error: string } {
   if (!existsSync(tarballPath)) {
     return { ok: false, error: `source not found: ${tarballPath}` };
@@ -188,14 +194,23 @@ function hashTarballArtifact(tarballPath: string): { ok: true; hash: string; ver
   try {
     const ex = extractTarball(tarballPath, staging);
     if (!ex.ok) return { ok: false, error: ex.error };
+    // findPluginRoot reused via the manifest helper if needed — but
+    // pinPlugin's tarballs are produced by `maw plugin build` (flat layout)
+    // OR community-source tarballs (also flat after extraction). Either way
+    // plugin.json sits at the staging root.
     const manifest = readManifest(staging);
     if (!manifest) return { ok: false, error: "failed to read plugin.json from tarball" };
-    if (!manifest.artifact) {
-      return { ok: false, error: "tarball manifest has no 'artifact' field — rebuild with 'maw plugin build'" };
+    let relPath: string;
+    if (manifest.artifact) {
+      relPath = manifest.artifact.path;
+    } else if (typeof manifest.entry === "string" && manifest.entry.length > 0) {
+      relPath = manifest.entry;
+    } else {
+      return { ok: false, error: "tarball manifest has no 'artifact' or 'entry' field — rebuild with 'maw plugin build' or declare an entry path" };
     }
-    const artifactPath = join(staging, manifest.artifact.path);
+    const artifactPath = join(staging, relPath);
     if (!existsSync(artifactPath)) {
-      return { ok: false, error: `artifact missing at ${manifest.artifact.path}` };
+      return { ok: false, error: `artifact missing at ${relPath}` };
     }
     const hash = hashFile(artifactPath);
     return { ok: true, hash, version: manifest.version };

--- a/src/plugin/manifest-constants.ts
+++ b/src/plugin/manifest-constants.ts
@@ -3,7 +3,14 @@
  */
 
 /** Capability namespaces seeded in Phase A. Unknown namespaces emit a
- * validation warning (not a hard fail). New namespaces need an ADR. */
+ * validation warning (not a hard fail). New namespaces need an ADR.
+ *
+ * #874 — added `tmux` and `shell` after community plugins (bg, rename, park,
+ * shellenv) declared them. `tmux` covers tmux-socket spawning via the SDK's
+ * tmux/Tmux helpers (src/core/transport/tmux). `shell` covers shell-eval style
+ * stdout writes for shell-environment plugins. Both are advisory in Phase A —
+ * mirroring the rest of this list — and gate-able once the runtime grows real
+ * capability enforcement (#487 follow-up). */
 export const KNOWN_CAPABILITY_NAMESPACES = new Set([
   "net",    // network (fetch, sockets)
   "fs",     // filesystem
@@ -11,6 +18,8 @@ export const KNOWN_CAPABILITY_NAMESPACES = new Set([
   "sdk",    // maw SDK calls (identity, federation, …)
   "proc",   // child processes
   "ffi",    // native FFI (bun:ffi)
+  "tmux",   // tmux socket interaction (spawnSync("tmux", …) + SDK tmux helpers)
+  "shell",  // shell-eval / stdout-writing plugins (shellenv-style)
 ]);
 
 export const NAME_RE = /^[a-z0-9-]+$/;

--- a/test/isolated/install-source-plugin.test.ts
+++ b/test/isolated/install-source-plugin.test.ts
@@ -1,0 +1,334 @@
+/**
+ * #874 — install supports source plugins natively (path A.3) +
+ *        tmux / shell capability namespaces.
+ *
+ * Two architectural sub-issues from #874:
+ *
+ *   A. Source vs built tarball — community repos (cross-team-queue, shellenv,
+ *      bg, rename, park) ship `src/index.ts` + `plugin.json` with no `dist/`
+ *      and no `manifest.artifact`. Pre-#874 the install path required
+ *      `manifest.artifact` and rejected with
+ *      `tarball manifest has no 'artifact' field — rebuild with maw plugin build`.
+ *      Path A.3: install accepts `entry`-only manifests; the entry file IS
+ *      the artifact for source plugins (Bun executes .ts/.js source directly).
+ *
+ *   B. Capability namespaces — `tmux` and `shell` joined the seeded list so
+ *      bg/rename/park/shellenv plugin.json files no longer trigger
+ *      `unknown capability namespace "tmux"` warnings during validation.
+ *
+ * Tests cover both paths + backwards compat + invalid-namespace rejection.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  existsSync, lstatSync, mkdtempSync,
+  readFileSync, rmSync, writeFileSync,
+} from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { createHash } from "crypto";
+import { spawnSync } from "child_process";
+import { cmdPluginInstall } from "../../src/commands/plugins/plugin/install-impl";
+import {
+  __resetDiscoverStateForTests,
+  resetDiscoverCache,
+} from "../../src/plugin/registry";
+import {
+  KNOWN_CAPABILITY_NAMESPACES,
+  parseManifest,
+} from "../../src/plugin/manifest";
+
+// ─── Harness (mirrors plugin-install.test.ts) ────────────────────────────────
+
+const created: string[] = [];
+let origPluginsDir: string | undefined;
+let origPluginsLock: string | undefined;
+
+function tmpDir(prefix = "maw-source-install-"): string {
+  const d = mkdtempSync(join(tmpdir(), prefix));
+  created.push(d);
+  return d;
+}
+function pluginsDir(): string { return process.env.MAW_PLUGINS_DIR!; }
+
+beforeEach(() => {
+  origPluginsDir = process.env.MAW_PLUGINS_DIR;
+  origPluginsLock = process.env.MAW_PLUGINS_LOCK;
+  const home = tmpDir("maw-home-");
+  process.env.MAW_PLUGINS_DIR = join(home, "plugins");
+  process.env.MAW_PLUGINS_LOCK = join(home, "plugins.lock");
+  __resetDiscoverStateForTests();
+  resetDiscoverCache();
+});
+
+afterEach(() => {
+  if (origPluginsDir !== undefined) process.env.MAW_PLUGINS_DIR = origPluginsDir;
+  else delete process.env.MAW_PLUGINS_DIR;
+  if (origPluginsLock !== undefined) process.env.MAW_PLUGINS_LOCK = origPluginsLock;
+  else delete process.env.MAW_PLUGINS_LOCK;
+  for (const d of created.splice(0)) {
+    if (existsSync(d)) rmSync(d, { recursive: true, force: true });
+  }
+});
+
+/** Capture stdout/stderr/exit identically to the existing install tests. */
+async function capture(fn: () => Promise<unknown>): Promise<{
+  exitCode: number | undefined; stdout: string; stderr: string;
+}> {
+  const o = { exit: process.exit, log: console.log, err: console.error, warn: console.warn };
+  const origStderrWrite = process.stderr.write.bind(process.stderr);
+  const outs: string[] = [], errs: string[] = [];
+  let exitCode: number | undefined;
+  console.log = (...a: any[]) => outs.push(a.map(String).join(" "));
+  console.error = (...a: any[]) => errs.push(a.map(String).join(" "));
+  console.warn = (...a: any[]) => errs.push(a.map(String).join(" "));
+  (process.stderr as any).write = (chunk: any) => {
+    errs.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  };
+  (process as any).exit = (c?: number) => { exitCode = c ?? 0; throw new Error("__exit__:" + exitCode); };
+  try { await fn(); }
+  catch (e: any) {
+    const msg = String(e?.message ?? "");
+    if (!msg.startsWith("__exit__")) {
+      if (e instanceof Error && exitCode === undefined) {
+        exitCode = 1;
+        errs.push(msg);
+      } else {
+        throw e;
+      }
+    }
+  }
+  finally {
+    (process as any).exit = o.exit; console.log = o.log;
+    console.error = o.err; console.warn = o.warn;
+    (process.stderr as any).write = origStderrWrite;
+  }
+  return { exitCode, stdout: outs.join("\n"), stderr: errs.join("\n") };
+}
+
+/**
+ * Build a SOURCE-plugin tarball (path A.3): plugin.json declares `entry` but
+ * no `artifact`. Mirrors what community repos publish (src/index.ts +
+ * plugin.json, no dist/).
+ */
+function buildSourceFixture(opts: {
+  name?: string; version?: string; sdk?: string;
+  capabilities?: string[];
+  entry?: string;
+  source?: string;
+} = {}): { dir: string; entryPath: string; sha256: string; tarball: string; entryRel: string } {
+  const name = opts.name ?? "src-hello";
+  const version = opts.version ?? "0.1.0";
+  const sdk = opts.sdk ?? "^1.0.0";
+  const entryRel = opts.entry ?? "./index.ts";
+  const src = opts.source ?? "export default () => ({ ok: true });\n";
+  const dir = tmpDir("maw-source-fixture-");
+  const entryPath = join(dir, entryRel.replace(/^\.\//, ""));
+  // Support nested entries like ./src/index.ts
+  const parent = join(entryPath, "..");
+  if (!existsSync(parent)) {
+    spawnSync("mkdir", ["-p", parent]);
+  }
+  writeFileSync(entryPath, src);
+  const sha = "sha256:" + createHash("sha256").update(src).digest("hex");
+  const manifest: Record<string, unknown> = {
+    name, version, sdk, target: "js",
+    entry: entryRel,
+    ...(opts.capabilities !== undefined ? { capabilities: opts.capabilities } : {}),
+    // NB: no `artifact` field — this is what `path A.3` must accept.
+  };
+  writeFileSync(join(dir, "plugin.json"), JSON.stringify(manifest, null, 2) + "\n");
+  const tarball = join(dir, `${name}-${version}.tgz`);
+  // Pack plugin.json + entry file at the staged paths.
+  const entryRelInTar = entryRel.replace(/^\.\//, "");
+  const tar = spawnSync("tar", [
+    "-czf", tarball, "-C", dir, "plugin.json", entryRelInTar,
+  ]);
+  if (tar.status !== 0) throw new Error(`tar failed: ${tar.stderr}`);
+  return { dir, entryPath, sha256: sha, tarball, entryRel };
+}
+
+/** Build a BUILT-plugin tarball (legacy / backwards-compat shape). */
+function buildBuiltFixture(opts: {
+  name?: string; version?: string; sdk?: string;
+  capabilities?: string[];
+} = {}): { dir: string; bundle: string; sha256: string; tarball: string } {
+  const name = opts.name ?? "built-hello";
+  const version = opts.version ?? "0.1.0";
+  const sdk = opts.sdk ?? "^1.0.0";
+  const src = "export default () => ({ ok: true });\n";
+  const dir = tmpDir("maw-built-fixture-");
+  const bundle = join(dir, "index.js");
+  writeFileSync(bundle, src);
+  const sha = "sha256:" + createHash("sha256").update(src).digest("hex");
+  const manifest: Record<string, unknown> = {
+    name, version, sdk, target: "js",
+    ...(opts.capabilities !== undefined ? { capabilities: opts.capabilities } : { capabilities: [] }),
+    artifact: { path: "./index.js", sha256: sha },
+  };
+  writeFileSync(join(dir, "plugin.json"), JSON.stringify(manifest, null, 2) + "\n");
+  const tarball = join(dir, `${name}-${version}.tgz`);
+  const tar = spawnSync("tar", ["-czf", tarball, "-C", dir, "plugin.json", "index.js"]);
+  if (tar.status !== 0) throw new Error("tar failed");
+  return { dir, bundle, sha256: sha, tarball };
+}
+
+// ─── A. source-plugin install (path A.3) ─────────────────────────────────────
+
+describe("#874 path A.3 — source plugin install (no artifact, has entry)", () => {
+  test("source-only manifest installs successfully", async () => {
+    const fx = buildSourceFixture({ name: "src-only" });
+    const { exitCode, stdout, stderr } = await capture(() =>
+      cmdPluginInstall([fx.tarball, "--pin"]),
+    );
+    expect(exitCode).toBeUndefined();
+    expect(stderr).not.toContain("tarball manifest has no 'artifact' field");
+    expect(existsSync(join(pluginsDir(), "src-only"))).toBe(true);
+    expect(existsSync(join(pluginsDir(), "src-only", "index.ts"))).toBe(true);
+    expect(stdout).toContain("src-only@0.1.0 installed");
+  });
+
+  test("source-only manifest with nested entry (./src/index.ts) installs", async () => {
+    const fx = buildSourceFixture({
+      name: "src-nested",
+      entry: "./src/index.ts",
+    });
+    const { exitCode, stderr } = await capture(() =>
+      cmdPluginInstall([fx.tarball, "--pin"]),
+    );
+    expect(exitCode).toBeUndefined();
+    expect(stderr).not.toContain("tarball manifest has no 'artifact' field");
+    expect(existsSync(join(pluginsDir(), "src-nested", "src", "index.ts"))).toBe(true);
+  });
+
+  test("source plugin records entry-file sha256 into plugins.lock", async () => {
+    const fx = buildSourceFixture({ name: "src-lock" });
+    const { exitCode } = await capture(() =>
+      cmdPluginInstall([fx.tarball, "--pin"]),
+    );
+    expect(exitCode).toBeUndefined();
+    const lock = JSON.parse(readFileSync(process.env.MAW_PLUGINS_LOCK!, "utf8"));
+    expect(lock.plugins["src-lock"]).toBeDefined();
+    // Recorded hash matches the entry-file bytes (source IS the artifact).
+    expect(lock.plugins["src-lock"].sha256).toBe(fx.sha256);
+  });
+
+  test("built-tarball install path still works (backwards compat)", async () => {
+    const fx = buildBuiltFixture({ name: "still-built" });
+    const { exitCode, stdout, stderr } = await capture(() =>
+      cmdPluginInstall([fx.tarball, "--pin"]),
+    );
+    expect(exitCode).toBeUndefined();
+    expect(stderr).not.toContain("tarball manifest has no 'artifact' field");
+    expect(existsSync(join(pluginsDir(), "still-built", "index.js"))).toBe(true);
+    expect(stdout).toContain("still-built@0.1.0 installed");
+    expect(stdout).toContain("installed (sha256:");
+  });
+
+  test("manifest with neither artifact nor entry → still rejected (no plugin to run)", async () => {
+    // Build a tarball whose plugin.json has nothing executable.
+    const dir = tmpDir("maw-naked-");
+    const manifest = { name: "naked", version: "0.1.0", sdk: "^1.0.0" };
+    writeFileSync(join(dir, "plugin.json"), JSON.stringify(manifest, null, 2));
+    const tarball = join(dir, "naked-0.1.0.tgz");
+    const tar = spawnSync("tar", ["-czf", tarball, "-C", dir, "plugin.json"]);
+    expect(tar.status).toBe(0);
+    const { exitCode, stderr } = await capture(() =>
+      cmdPluginInstall([tarball, "--pin"]),
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("no 'artifact' field");
+  });
+
+  test("source plugin with tampered entry (lock-mismatch) → refused on re-install", async () => {
+    const fx = buildSourceFixture({ name: "src-tamper" });
+    // First install: TOFU pins fx.sha256.
+    await capture(() => cmdPluginInstall([fx.tarball, "--pin"]));
+
+    // Build a tampered tarball with the same name+version but different
+    // entry source. The pinned sha must catch it.
+    const tampered = buildSourceFixture({
+      name: "src-tamper",
+      version: "0.1.0",
+      source: "export default () => ({ tampered: true });\n",
+    });
+    const { exitCode, stderr } = await capture(() =>
+      cmdPluginInstall([tampered.tarball]),
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("sha256 mismatch");
+  });
+});
+
+// ─── B. capability namespaces (tmux + shell) ─────────────────────────────────
+
+describe("#874 — tmux + shell capability namespaces", () => {
+  test("'tmux' is a known namespace", () => {
+    expect(KNOWN_CAPABILITY_NAMESPACES.has("tmux")).toBe(true);
+  });
+
+  test("'shell' is a known namespace", () => {
+    expect(KNOWN_CAPABILITY_NAMESPACES.has("shell")).toBe(true);
+  });
+
+  test("source plugin declaring capabilities:['tmux'] installs without warning", async () => {
+    const fx = buildSourceFixture({
+      name: "src-tmux",
+      capabilities: ["tmux"],
+    });
+    const { exitCode, stderr } = await capture(() =>
+      cmdPluginInstall([fx.tarball, "--pin"]),
+    );
+    expect(exitCode).toBeUndefined();
+    expect(stderr).not.toContain('unknown capability namespace "tmux"');
+  });
+
+  test("source plugin declaring capabilities:['shell'] installs without warning", async () => {
+    const fx = buildSourceFixture({
+      name: "src-shell",
+      capabilities: ["shell"],
+    });
+    const { exitCode, stderr } = await capture(() =>
+      cmdPluginInstall([fx.tarball, "--pin"]),
+    );
+    expect(exitCode).toBeUndefined();
+    expect(stderr).not.toContain('unknown capability namespace "shell"');
+  });
+
+  test("plugin declaring capabilities:['bogus'] still warns (unknown namespace)", () => {
+    const dir = tmpDir("maw-bogus-cap-");
+    writeFileSync(join(dir, "index.ts"), "export default () => {};");
+    const origWarn = console.warn;
+    const warnings: string[] = [];
+    console.warn = (...a: any[]) => warnings.push(a.map(String).join(" "));
+    try {
+      // parseManifest itself emits the warning; the install path inherits it.
+      parseManifest(
+        JSON.stringify({
+          name: "bogus-plugin",
+          version: "0.1.0",
+          sdk: "^1.0.0",
+          entry: "./index.ts",
+          capabilities: ["bogus"],
+        }),
+        dir,
+      );
+    } finally {
+      console.warn = origWarn;
+    }
+    expect(warnings.join("\n")).toContain('unknown capability namespace "bogus"');
+  });
+
+  test("plugin declaring tmux+shell+sdk together installs cleanly", async () => {
+    const fx = buildSourceFixture({
+      name: "src-multi-cap",
+      capabilities: ["tmux", "shell", "sdk:identity"],
+    });
+    const { exitCode, stderr } = await capture(() =>
+      cmdPluginInstall([fx.tarball, "--pin"]),
+    );
+    expect(exitCode).toBeUndefined();
+    expect(stderr).not.toContain('unknown capability namespace');
+  });
+});

--- a/test/plugin-manifest-v1.test.ts
+++ b/test/plugin-manifest-v1.test.ts
@@ -85,8 +85,10 @@ describe("manifest v1 — new fields", () => {
   });
 
   test("seeded capability namespaces are frozen set", () => {
+    // #874 — `tmux` and `shell` joined the namespace list to support community
+    // plugins (bg, rename, park, shellenv) that spawn tmux or shell-eval.
     expect([...KNOWN_CAPABILITY_NAMESPACES].sort()).toEqual(
-      ["net", "fs", "peer", "sdk", "proc", "ffi"].sort(),
+      ["net", "fs", "peer", "sdk", "proc", "ffi", "tmux", "shell"].sort(),
     );
   });
 });


### PR DESCRIPTION
## Summary

Final blocker for the marketplace install pipeline. Two architectural fixes
per the #874 brief: chose path **A.3** for source-vs-built and chose **B.1**
(new namespaces) for capability gating.

### A. Source vs built tarball — install supports source plugins natively

Community repos (cross-team-queue, shellenv, bg, rename, park) ship
`src/index.ts` + `plugin.json` with no `dist/` and no `manifest.artifact`.
Pre-#874 the install path bailed with `tarball manifest has no 'artifact'
field — rebuild with maw plugin build`. Per the #874 brief's preferred
path A.3, install now treats `manifest.entry` as authoritative when
`manifest.artifact` is absent — Bun runs `.ts`/`.js` source transparently,
so no ahead-of-time build is required.

Touched files:

- `src/commands/plugins/plugin/install-extraction.ts` — new
  `isSourcePluginManifest` helper. `verifyArtifactHash` skips the embedded-
  hash fencepost for source plugins (no embedded hash to check; plugins.lock
  remains the adversarial check). `verifyArtifactHashAgainst` hashes
  `manifest.entry` when `manifest.artifact` is absent.
- `src/commands/plugins/plugin/install-handlers.ts` — `installFromTarball`
  derives the recorded sha256 from the entry file when `manifest.artifact`
  is missing. plugins.lock parity preserved; `--pin` and mismatch detection
  still work end-to-end.
- `src/commands/plugins/plugin/lock.ts` — `hashTarballArtifact` accepts
  entry-only manifests so `maw plugin pin <source-tarball>` works.
- Backwards compat: the built-tarball install path is unchanged. Manifests
  with neither artifact nor entry are still rejected with the same
  actionable message.

### B. Capability namespaces — tmux + shell

Runtime previously seeded only `{net, fs, peer, sdk, proc, ffi}`. Community
plugins declare `tmux` (bg, rename, park) and `shell` (shellenv-style),
which tripped `unknown capability namespace` warnings during validation.
Per option B.1 in the brief, both are now first-class entries in
`KNOWN_CAPABILITY_NAMESPACES` — they remain advisory in Phase A like the
rest of the list (the seeded set is doc + lint, not a runtime gate yet).
`tmux` covers SDK tmux helpers (`src/core/transport/tmux`); `shell` covers
shell-eval style plugins. Real capability enforcement gates ride on the
#487 follow-up.

### Tests

`test/isolated/install-source-plugin.test.ts` — 12 cases covering both
fixes. The relevant matrix:

- source-only manifest (no `artifact`, has `entry`) → installs (path A.3)
- source-only manifest with nested `./src/index.ts` entry → installs
- source plugin records entry-file sha256 into plugins.lock
- built-tarball install path unchanged (backwards compat)
- manifest with neither artifact nor entry → still rejected
- source plugin tampered between installs → caught by pinned-hash check
- `tmux` and `shell` present in `KNOWN_CAPABILITY_NAMESPACES`
- `capabilities: ["tmux"]` / `["shell"]` / `["tmux","shell","sdk:identity"]`
  install without warning
- unknown namespace (`"bogus"`) still emits the warning

`test/plugin-manifest-v1.test.ts` updated to assert the new 8-namespace seed
list.

### CalVer

`26.4.29-alpha.31` → `26.4.29-alpha.32` (next available alpha; chosen by
the calver script per #766 monotonic-running-counter).

## Test plan

- [x] `bun test test/isolated/install-source-plugin.test.ts` — 12/12 pass
- [x] `bun test test/plugin-manifest-v1.test.ts test/isolated/plugin-install*.test.ts test/isolated/plugin-lock.test.ts` — 79/79 pass (no regressions)
- [x] `bun build src/cli.ts` — bundles 640 modules cleanly
- [ ] End-to-end with the live registry: `MAW_REGISTRY_URL=… maw plugin install cross-team-queue` and `… maw plugin install bg` should both succeed (verifying the original #874 reproductions)
- [ ] Smoke-test `maw plugin pin <source-tarball>` against a community-source tarball to confirm the lock.ts path

Closes the install pipeline cascade thread (#857/#861/#866/#870/#871).

Refs #874

🤖 Generated with [Claude Code](https://claude.com/claude-code)