### PR TITLE
feat(ci): self-hosted runner workflow for federation + flake cross-check (#763)

### DIFF
--- a/.github/workflows/federation-self-hosted.yml
+++ b/.github/workflows/federation-self-hosted.yml
@@ -1,0 +1,115 @@
+name: Federation (self-hosted) integration
+
+# Self-hosted runner workflow for federation tests + curlFetch + buildCommand
+# cross-check. Implements #763.
+#
+# WHY THIS EXISTS
+# ---------------
+# 1. Federation tests need a real second peer — multi-node behavior is hard
+#    to fake inside a single GH-hosted VM. A persistent self-hosted runner
+#    can keep a peer warm or talk to the fleet directly.
+# 2. The 14 known-flaky tests in curlFetch (6) + buildCommand (8) — see
+#    #786 for the calver fix that exposed them — may be GH-Actions
+#    sandbox quirks (Bun fetch / /usr/bin/curl path / sandboxed exec).
+#    Re-running them on a real Linux host tells us if they are universal
+#    or environment-specific.
+# 3. Real-peer round-trip for #832 (federation 2-port flake) — the local
+#    ephemeral-port race vanishes when one peer is on a different host.
+#
+# SECURITY — TRIGGER RESTRICTION (DO NOT RELAX)
+# ---------------------------------------------
+# `Soul-Brews-Studio/maw-js` is a PUBLIC repository. GitHub explicitly
+# warns against self-hosted runners on public repos because any forked
+# pull request can run arbitrary code on the runner host
+# (https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#self-hosted-runner-security).
+#
+# This workflow MUST therefore only fire on `push` to protected branches
+# we control — never on `pull_request`. Forked PRs continue to run via
+# `ci.yml` on GH-hosted runners (sandboxed, ephemeral, safe by default).
+#
+# If you ever add a `pull_request:` trigger here, add an explicit
+# `if: github.event.pull_request.head.repo.full_name == github.repository`
+# guard or you will hand attackers a shell on the runner host.
+#
+# OPERATOR PREREQUISITES
+# ----------------------
+# A runner host with the labels `self-hosted` AND `federation` must be
+# registered against the repo before this workflow can fire. Until then
+# pushes to `main` will queue and time out. See `docs/ci/self-hosted-runner.md`
+# for setup steps.
+
+on:
+  push:
+    branches:
+      # Protected branches only. Adding `alpha` here would expose the
+      # runner to anything merged to alpha; keep alpha on GH-hosted CI
+      # until we have approval gates wired.
+      - main
+
+# Run one job at a time on the self-hosted runner. Federation tests
+# bind ports and stand up peers; concurrent runs would race each other.
+concurrency:
+  group: federation-self-hosted
+  cancel-in-progress: false
+
+jobs:
+  federation:
+    name: federation + flake cross-check (self-hosted)
+    # Both labels required. The runner host must be registered with both.
+    runs-on: [self-hosted, federation]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Show runner identity
+        run: |
+          echo "host: $(hostname)"
+          echo "user: $(id -un)"
+          echo "bun:  $(command -v bun || echo 'MISSING')"
+          echo "curl: $(command -v curl || echo 'MISSING')"
+          bun --version || true
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # Federation tests that benefit from a real peer / real network stack.
+      # These are the existing files under test/ that exercise the federation
+      # transports + auth + sync + 2-port round-trip (#832). Listed
+      # explicitly so the set is auditable and we don't silently pick up
+      # unrelated tests when new files land.
+      #
+      # NOTE: MAW_SKIP_FLAKY is intentionally NOT set for this job — the
+      # whole point of the self-hosted runner is to exercise the real
+      # path that ci.yml has to skip.
+      - name: Federation tests (real peer / real network)
+        env:
+          MAW_TEST_MODE: "1"
+        run: |
+          bun test \
+            test/federation-auth.test.ts \
+            test/federation-symmetric.test.ts \
+            test/federation-sync.test.ts \
+            test/integration/federation-local.test.ts \
+            test/integration/search-peers-2port.test.ts
+
+      # Cross-check the 14 GH-Actions flakes — curlFetch (6) + buildCommand
+      # (8). If these pass here but fail on ubuntu-latest, the failures
+      # are environment-specific (Bun fetch behavior / sandboxed exec /
+      # /usr/bin/curl path). See #786.
+      - name: Flake cross-check (curlFetch + buildCommand)
+        env:
+          MAW_TEST_MODE: "1"
+        run: |
+          bun test \
+            test/curl-fetch.test.ts \
+            test/build-command-cwd.test.ts
+
+      - name: Federation log dump on failure
+        if: failure()
+        run: |
+          echo "::group::recent maw logs"
+          ls -lah ~/.maw/logs 2>/dev/null | tail -40 || echo "no ~/.maw/logs"
+          echo "::endgroup::"
+          echo "::group::open ports"
+          ss -tlnp 2>/dev/null | head -40 || true
+          echo "::endgroup::"

--- a/docs/ci/self-hosted-runner.md
+++ b/docs/ci/self-hosted-runner.md
@@ -1,0 +1,141 @@
+# Self-hosted runner — federation + flake cross-check
+
+Operator guide for the runner host that powers
+`.github/workflows/federation-self-hosted.yml` (issue #763).
+
+## What this runner does
+
+It exercises two things that GitHub-hosted runners cannot do well:
+
+1. **Federation tests** that need a real peer / real network stack
+   (`test/federation-*.test.ts`, `test/integration/federation-local.test.ts`,
+   `test/integration/search-peers-2port.test.ts`).
+2. **Cross-check** the 14 known-flaky tests in `test/curl-fetch.test.ts`
+   (6) and `test/build-command-cwd.test.ts` (8) that were marked
+   environment-specific in #786 — if they pass on a real Linux host,
+   we know the failure is a GH-Actions sandbox quirk.
+
+Existing GH-hosted CI (`.github/workflows/ci.yml`) keeps running on every
+PR and push; this workflow is purely additive.
+
+## SECURITY WARNING — read first
+
+`Soul-Brews-Studio/maw-js` is a **public repository**. GitHub explicitly
+warns against attaching self-hosted runners to public repos:
+
+> We recommend that you only use self-hosted runners with private
+> repositories. This is because forks of your public repository can
+> potentially run dangerous code on your self-hosted runner machine
+> by creating a pull request that executes the code in a workflow.
+
+The workflow is therefore restricted to `push` to `main` only. **Do
+not** add `pull_request` triggers without an explicit guard like:
+
+```yaml
+if: github.event.pull_request.head.repo.full_name == github.repository
+```
+
+Additionally, in repo Settings → Actions → General, enable:
+
+- **Fork pull request workflows from outside collaborators** →
+  *Require approval for all outside collaborators* (or stricter).
+- **Allow GitHub Actions to create and approve pull requests** → off.
+
+## Required runner labels
+
+The workflow targets `runs-on: [self-hosted, federation]`. The runner
+must be registered with **both** labels — `self-hosted` is added by
+the runner installer, `federation` must be added explicitly (see below).
+
+## Operator setup
+
+### 1. Pick a host
+
+Candidates from the fleet (#763 reporter notes):
+
+- `m5` — already runs maw federation, has spare cycles.
+- `white` — primary maw-js code partner, more agents.
+
+Either works. Pick whichever has best uptime + spare CPU/RAM. The host
+needs:
+
+- Linux (Ubuntu 22.04+ or similar) or macOS.
+- `bun` on PATH (1.3.13+ to match `ci.yml`).
+- `/usr/bin/curl` present (the `curl-fetch` tests probe this exact path).
+- `git` on PATH.
+- Outbound HTTPS to `github.com` and `objects.githubusercontent.com`.
+- If federation tests are extended to real fleet peers: SSH keys for
+  the peer hosts (`mba.wg`, `oracle-world`, etc.) configured for the
+  runner user.
+
+### 2. Register the runner
+
+#### Option A — manual `actions-runner` binary (recommended for one host)
+
+```bash
+# On the runner host:
+mkdir -p ~/actions-runner && cd ~/actions-runner
+# Get the latest from
+# https://github.com/actions/runner/releases
+curl -O -L https://github.com/actions/runner/releases/download/v2.319.1/actions-runner-linux-x64-2.319.1.tar.gz
+tar xzf actions-runner-linux-x64-2.319.1.tar.gz
+
+# Generate a registration token from the repo:
+#   gh api -X POST repos/Soul-Brews-Studio/maw-js/actions/runners/registration-token
+# or via the UI: Settings → Actions → Runners → New self-hosted runner
+
+./config.sh \
+  --url https://github.com/Soul-Brews-Studio/maw-js \
+  --token <REG_TOKEN> \
+  --labels self-hosted,federation \
+  --name fed-runner-$(hostname -s) \
+  --unattended
+
+# Run as a service (Linux):
+sudo ./svc.sh install
+sudo ./svc.sh start
+```
+
+Verify the runner appears in
+`https://github.com/Soul-Brews-Studio/maw-js/settings/actions/runners`
+with **both** `self-hosted` and `federation` labels.
+
+#### Option B — `actions-runner-controller` (Kubernetes)
+
+Use [actions-runner-controller](https://github.com/actions/actions-runner-controller)
+if the fleet already runs k8s. Define a `RunnerDeployment` (or
+`AutoscalingRunnerSet` with the newer `gha-runner-scale-set` chart)
+with `labels: [self-hosted, federation]` and the same Bun + curl
+prerequisites baked into the runner image.
+
+### 3. Sanity check
+
+Push any no-op commit to `main` and watch the workflow at
+`https://github.com/Soul-Brews-Studio/maw-js/actions/workflows/federation-self-hosted.yml`.
+The first step (`Show runner identity`) prints `bun:` and `curl:` paths
+— if either is `MISSING`, fix the host before debugging anything else.
+
+## Operating notes
+
+- **One job at a time.** `concurrency.group: federation-self-hosted`
+  serializes runs so port-binding tests don't race each other.
+- **`MAW_SKIP_FLAKY` is intentionally unset.** This runner is the one
+  place in CI that exercises the real path; setting it would defeat
+  the purpose.
+- **Failure logs.** The `Federation log dump on failure` step prints
+  recent `~/.maw/logs` and open ports for triage.
+- **Runner host is not ephemeral.** Unlike GH-hosted runners, state
+  persists between jobs. If a federation test leaks a process or port
+  it may affect the next run — check `ps`, `ss -tlnp`, and clean up
+  in the test's `afterAll`.
+
+## Decommissioning
+
+```bash
+cd ~/actions-runner
+sudo ./svc.sh stop
+sudo ./svc.sh uninstall
+./config.sh remove --token <REMOVAL_TOKEN>
+```
+
+Removal token: `gh api -X POST repos/Soul-Brews-Studio/maw-js/actions/runners/remove-token`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.34",
+  "version": "26.4.29-alpha.35",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
## Summary

Adds `.github/workflows/federation-self-hosted.yml` plus operator docs at `docs/ci/self-hosted-runner.md` to set up a self-hosted GitHub Actions runner for federation tests and the curlFetch / buildCommand flake cross-check called for in #763.

The workflow is **additive**: existing `.github/workflows/ci.yml` keeps running on every PR and push to `alpha`/`main` against GH-hosted ubuntu-latest. This new workflow only fires on push to `main` and only on a runner registered with `[self-hosted, federation]` labels.

## What it runs

1. **Federation tests that benefit from a real peer / real network stack:**
   - `test/federation-auth.test.ts`
   - `test/federation-symmetric.test.ts`
   - `test/federation-sync.test.ts`
   - `test/integration/federation-local.test.ts` (the 2-port flake — see #832)
   - `test/integration/search-peers-2port.test.ts`
2. **Flake cross-check** for the 14 GH-Actions-environment-specific failures from #786:
   - `test/curl-fetch.test.ts` (6)
   - `test/build-command-cwd.test.ts` (8)

`MAW_SKIP_FLAKY` is intentionally **not** set on this runner — the whole point is to exercise the real path that `ci.yml` has to skip. If these pass on the self-hosted host but fail on `ubuntu-latest`, we know the failures are sandbox quirks (Bun fetch / `/usr/bin/curl` path / sandboxed exec) and can write a targeted fix or platform skip.

## Security — trigger restriction (do not relax)

`Soul-Brews-Studio/maw-js` is a **public repository**. GitHub explicitly warns against attaching self-hosted runners to public repos because any forked PR can run arbitrary code on the runner host. The workflow therefore:

- Triggers on `push` to `main` only — never `pull_request`.
- Does not include `alpha` in the trigger branches yet (would require approval gates first).
- Uses `concurrency.group: federation-self-hosted` to serialize runs so port-binding tests don't race each other on a long-lived host.

The workflow file's leading comment block reiterates this constraint inline so anyone editing it sees the warning before adding new triggers. The operator doc at `docs/ci/self-hosted-runner.md` repeats the warning prominently and recommends additionally enabling "Require approval for all outside collaborators" under repo Settings → Actions → General.

## Operator action required before this PR helps anyone

This PR is **yaml + docs only**. The workflow will queue and time out on `main` until an operator registers a runner host with both `self-hosted` and `federation` labels. The doc covers two registration paths:

- Manual `actions-runner` binary (recommended for one host — `m5` or `white` per #763 reporter notes).
- `actions-runner-controller` / `gha-runner-scale-set` for k8s deployments.

Prerequisites baked into the doc: `bun` 1.3.13+, `/usr/bin/curl` present, `git`, outbound HTTPS, optional SSH keys for fleet peers if the federation test corpus is later extended to talk to real fleet hosts.

## Out of scope (per #763)

- Dogfooding maw-js itself as the runner orchestrator.
- Designing the federation test corpus for real peers (this PR runs the existing federation tests; it does not write new ones).
- Fixing the 14 pre-existing curlFetch / buildCommand failures — that work happens after we have signal from this runner.

## CalVer

Bumped to `26.4.29-alpha.35`.

## Test plan

- [ ] PR CI (`ci.yml`) stays green — this change should not affect GH-hosted CI.
- [ ] Workflow YAML lints cleanly in GitHub Actions UI after merge.
- [ ] After an operator registers a runner host (separate task, tracked in #763), a no-op push to `main` triggers the workflow and the `Show runner identity` step prints non-empty `bun:` and `curl:` paths.
- [ ] Confirm federation + flake jobs surface real failures rather than silently skipping.

Refs: #763, #786, #832