### PR TITLE
feat(profile): profile loader + maw profile CLI (Phase 1 of #640)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.36",
+  "version": "26.4.29-alpha.37",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/plugins/profile/impl.ts
+++ b/src/commands/plugins/profile/impl.ts
@@ -1,0 +1,70 @@
+/**
+ * maw profile — subcommand implementations (#888 / Phase 1 of #640).
+ *
+ * Thin shell around `src/lib/profile-loader.ts`. Phase 1 ships READ + active-
+ * pointer-write only; profile authoring (`maw profile create`) is intentionally
+ * NOT here yet — operators write the JSON themselves in Phase 1, and a follow-up
+ * sub-issue will add a scaffolding verb once Phase 2 wires the loader into the
+ * registry.
+ *
+ * Verb shape mirrors `src/commands/plugins/scope/impl.ts` (#642 Phase 1 — same
+ * primitive-with-CLI pattern).
+ */
+
+import {
+  getActiveProfile,
+  loadAllProfiles,
+  loadProfile,
+  setActiveProfile,
+} from "../../../lib/profile-loader";
+import type { TProfile } from "../../../lib/schemas";
+
+export function cmdList(): TProfile[] {
+  return loadAllProfiles();
+}
+
+export function cmdShow(name: string): TProfile | null {
+  return loadProfile(name);
+}
+
+export function cmdCurrent(): string {
+  return getActiveProfile();
+}
+
+/**
+ * Switch the active profile. Refuses to point at a profile file that doesn't
+ * exist — Phase 1 has no scaffolder, so a typo would silently brick plugin
+ * activation in Phase 2 if we let unknown names through.
+ */
+export function cmdUse(name: string): TProfile {
+  const profile = loadProfile(name);
+  if (!profile) {
+    throw new Error(`profile "${name}" not found — see "maw profile list"`);
+  }
+  setActiveProfile(name);
+  return profile;
+}
+
+// ─── Format ──────────────────────────────────────────────────────────────────
+
+export function formatList(rows: TProfile[], active: string): string {
+  if (!rows.length) return "no profiles";
+  const header = ["", "name", "plugins", "tiers", "description"];
+  const lines = rows.map((r) => [
+    r.name === active ? "*" : " ",
+    r.name,
+    r.plugins ? String(r.plugins.length) : "-",
+    r.tiers && r.tiers.length ? r.tiers.join(",") : "-",
+    r.description ?? "",
+  ]);
+  const widths = header.map((h, i) =>
+    Math.max(h.length, ...lines.map((l) => l[i].length))
+  );
+  const fmt = (cols: string[]) =>
+    cols.map((c, i) => c.padEnd(widths[i])).join("  ");
+  return [
+    fmt(header),
+    fmt(widths.map((w) => "-".repeat(w))),
+    ...lines.map(fmt),
+  ].join("\n");
+}

--- a/src/commands/plugins/profile/index.ts
+++ b/src/commands/plugins/profile/index.ts
@@ -1,0 +1,122 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+
+export const command = {
+  name: "profile",
+  description: "Profile primitive — named plugin bundles (Phase 1 of #640 / #888).",
+};
+
+/**
+ * maw profile — primitive plugin (#888, Phase 1 of #640 lean-core epic).
+ *
+ * Phase 1 ships READ verbs + the active-profile pointer write. Profile JSON
+ * authoring is operator-driven (write the file by hand at
+ * `<CONFIG_DIR>/profiles/<name>.json`); a Phase 1.5 follow-up will add a
+ * scaffolder. Phase 2 (separate sub-issue) wires `getActiveProfile()` into the
+ * plugin registry so the chosen profile actually narrows the loader. Until
+ * then this module is purely additive.
+ *
+ * Subcommand dispatcher mirrors the `scope` plugin (#642 Phase 1).
+ */
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const impl = await import("./impl");
+
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+
+  const out = () => logs.join("\n");
+  const help = () =>
+    [
+      "usage: maw profile <list|use|show|current>",
+      "  list                 — list all profiles (active is marked with *)",
+      "  use     <name>       — set active profile (refuses unknown names)",
+      "  show    <name>       — print one profile's JSON",
+      "  current              — print active profile name",
+      "",
+      "storage:",
+      "  <CONFIG_DIR>/profiles/<name>.json   — one file per profile",
+      "  <CONFIG_DIR>/profile-active         — active profile pointer (text)",
+      "",
+      "note: Phase 1 of #640 — additive read + active-pointer only. Profile",
+      "      authoring is operator-driven (hand-edit JSON). Phase 2 wires this",
+      "      into the plugin loader.",
+    ].join("\n");
+
+  try {
+    const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+    const positional = args.filter((a) => !a.startsWith("--"));
+    const sub = positional[0];
+
+    if (!sub) {
+      console.log(help());
+      return { ok: true, output: out() || help() };
+    }
+
+    switch (sub) {
+      case "list":
+      case "ls": {
+        const rows = impl.cmdList();
+        const active = impl.cmdCurrent();
+        console.log(impl.formatList(rows, active));
+        return { ok: true, output: out() };
+      }
+      case "use":
+      case "set": {
+        const name = positional[1];
+        if (!name) return { ok: false, error: "usage: maw profile use <name>" };
+        try {
+          const used = impl.cmdUse(name);
+          console.log(`active profile: "${used.name}"`);
+          return { ok: true, output: out() };
+        } catch (e: any) {
+          return { ok: false, error: e?.message || String(e), output: out() };
+        }
+      }
+      case "show":
+      case "info": {
+        const name = positional[1];
+        if (!name) return { ok: false, error: "usage: maw profile show <name>" };
+        try {
+          const found = impl.cmdShow(name);
+          if (!found) {
+            return {
+              ok: false,
+              error: `profile "${name}" not found`,
+              output: out(),
+            };
+          }
+          console.log(JSON.stringify(found, null, 2));
+          return { ok: true, output: out() };
+        } catch (e: any) {
+          return { ok: false, error: e?.message || String(e), output: out() };
+        }
+      }
+      case "current":
+      case "active": {
+        console.log(impl.cmdCurrent());
+        return { ok: true, output: out() };
+      }
+      default: {
+        console.log(help());
+        return {
+          ok: false,
+          error: `maw profile: unknown subcommand "${sub}" (expected list|use|show|current)`,
+          output: out() || help(),
+        };
+      }
+    }
+  } catch (e: any) {
+    return { ok: false, error: out() || e.message, output: out() || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/src/commands/plugins/profile/plugin.json
+++ b/src/commands/plugins/profile/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "profile",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Profile primitive — named plugin bundles (Phase 1 of #640 / #888).",
+  "author": "Soul-Brews-Studio",
+  "tier": "core",
+  "cli": {
+    "command": "profile",
+    "aliases": ["profiles"],
+    "help": "maw profile <list|use|show|current> [...] — manage plugin profiles (Phase 1 of #640)"
+  },
+  "weight": 50
+}

--- a/src/lib/profile-loader.ts
+++ b/src/lib/profile-loader.ts
@@ -1,0 +1,295 @@
+/**
+ * profile-loader.ts — read/write profile JSON files + active-profile pointer.
+ *
+ * Phase 1 of #640 (lean-core epic) / closes #888.
+ *
+ * Background
+ * ──────────
+ * The lean-core epic wants operators to install a slim binary by default and
+ * opt INTO heavier plugin sets via named profiles. Phase 0 (#886) classified
+ * every plugin into core/standard/extra tiers. This module is Phase 1: the
+ * read/write primitive plus a CLI plugin (`maw profile`) that lets operators
+ * see what's available and pick one.
+ *
+ * **ADDITIVE ONLY.** This module does NOT touch the existing plugin loader.
+ * Phase 2 (a separate sub-issue of #640) wires `getActiveProfile()` into
+ * `discoverPackages()` so the lean profile actually narrows the registry. Until
+ * then, all plugins continue to load as today — this layer just writes JSON.
+ *
+ * Storage layout
+ * ──────────────
+ *   <CONFIG_DIR>/profiles/<name>.json     # one file per profile
+ *   <CONFIG_DIR>/profile-active           # single-line text file (just the name)
+ *
+ * Default profile
+ * ───────────────
+ * `getActiveProfile()` returns `"all"` when no pointer file exists. The "all"
+ * profile is special: it has neither `plugins` nor `tiers` set, so
+ * `resolveProfilePlugins()` returns the FULL plugin list. This keeps the
+ * Phase 1 default behavior identical to today (no plugins filtered).
+ *
+ * On first use the loader auto-writes `~/.config/maw/profiles/all.json` if it
+ * doesn't exist. This is a convenience — operators can immediately
+ * `maw profile show all` without digging up sample JSON.
+ *
+ * Atomic writes
+ * ─────────────
+ * All writes go through `tmp + rename` to avoid partial files on crash. Same
+ * pattern as `src/commands/plugins/peers/store.ts` and the scope plugin's
+ * write path (#642 Phase 1).
+ *
+ * Path resolution
+ * ───────────────
+ * Like the scope primitive, paths are resolved at call-time (not import-time)
+ * so tests can mutate `MAW_CONFIG_DIR` per-test. Mirrors the resolver in
+ * src/commands/plugins/scope/impl.ts.
+ *
+ * See also:
+ *   - docs/lean-core/plugin-audit.md (#887) — tier reference for untiered plugins
+ *   - src/lib/schemas.ts — `Profile` TypeBox schema
+ *   - src/commands/plugins/profile/ — CLI plugin (`maw profile`)
+ */
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, writeFileSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import type { TProfile } from "./schemas";
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+const PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/;
+
+export function validateProfileName(name: string): string | null {
+  if (typeof name !== "string" || !PROFILE_NAME_RE.test(name)) {
+    return `invalid profile name "${name}" (must match ^[a-z0-9][a-z0-9_-]{0,63}$)`;
+  }
+  return null;
+}
+
+// ─── Paths (live-resolved, like the scope primitive) ─────────────────────────
+
+function activeConfigDir(): string {
+  if (process.env.MAW_HOME) return join(process.env.MAW_HOME, "config");
+  if (process.env.MAW_CONFIG_DIR) return process.env.MAW_CONFIG_DIR;
+  return join(homedir(), ".config", "maw");
+}
+
+export function profilesDir(): string {
+  return join(activeConfigDir(), "profiles");
+}
+
+export function profilePath(name: string): string {
+  return join(profilesDir(), `${name}.json`);
+}
+
+export function activeProfilePath(): string {
+  return join(activeConfigDir(), "profile-active");
+}
+
+function ensureProfilesDir(): void {
+  mkdirSync(profilesDir(), { recursive: true });
+}
+
+// ─── Default "all" profile (auto-seeded on first read) ───────────────────────
+
+/**
+ * The "all" profile is the Phase-1 default. It deliberately has neither
+ * `plugins` nor `tiers` set, so `resolveProfilePlugins` returns the FULL
+ * plugin list — i.e. behavior identical to today.
+ */
+const DEFAULT_ALL_PROFILE: TProfile = {
+  name: "all",
+  description: "All plugins (Phase 1 default — equivalent to no profile filter).",
+};
+
+/**
+ * Embedded fallback for the "minimal" profile referenced in the Phase 1 spec.
+ * NOT auto-written to disk; operators opt-in by `maw profile use minimal` (which
+ * fails fast if the file isn't there yet) or by writing the JSON themselves.
+ *
+ * Keeping this constant in source means the schema example in the issue body
+ * stays grep-able after extraction. If/when a follow-up wires up a profile
+ * `init` verb that scaffolds known profiles, this is the seed it uses.
+ */
+export const KNOWN_PROFILE_SEEDS: ReadonlyArray<TProfile> = [
+  DEFAULT_ALL_PROFILE,
+  {
+    name: "minimal",
+    plugins: ["scope", "trust", "inbox", "ls", "hey", "help"],
+    tiers: ["core"],
+    description: "Lean-core minimal profile — daily-driver primitives only.",
+  },
+];
+
+/**
+ * Ensure the default `all.json` profile exists on disk. Called lazily by
+ * `loadProfile("all")` and `loadAllProfiles()`. Idempotent: if the file
+ * exists, leaves it alone (operators may have edited it).
+ */
+function ensureDefaultProfile(): void {
+  ensureProfilesDir();
+  const path = profilePath("all");
+  if (!existsSync(path)) {
+    atomicWriteJSON(path, DEFAULT_ALL_PROFILE);
+  }
+}
+
+// ─── Atomic write helper ─────────────────────────────────────────────────────
+
+function atomicWriteJSON(path: string, data: unknown): void {
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, JSON.stringify(data, null, 2) + "\n", "utf-8");
+  renameSync(tmp, path);
+}
+
+// ─── Read ────────────────────────────────────────────────────────────────────
+
+/**
+ * Load a profile by name. Returns `null` when the file doesn't exist or fails
+ * to parse — callers translate null into a CLI-level "profile not found".
+ *
+ * Side effect: when called with "all" and the default file is missing, this
+ * auto-writes `<CONFIG_DIR>/profiles/all.json` with the embedded default. Any
+ * other name is read-only.
+ */
+export function loadProfile(name: string): TProfile | null {
+  const nameErr = validateProfileName(name);
+  if (nameErr) return null;
+  if (name === "all") ensureDefaultProfile();
+
+  const path = profilePath(name);
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8")) as TProfile;
+    // Defensive normalization — operator hand-edits may drop the name field.
+    if (typeof parsed.name !== "string") parsed.name = name;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Load every profile under `<CONFIG_DIR>/profiles/`. Returns sorted by name.
+ *
+ * Same failure isolation as `loadManifest()` (#838): a single corrupt JSON file
+ * is silently skipped — must NOT brick `maw profile list`.
+ */
+export function loadAllProfiles(): TProfile[] {
+  ensureDefaultProfile();
+  const dir = profilesDir();
+  let files: string[];
+  try {
+    files = readdirSync(dir).filter((f) => f.endsWith(".json"));
+  } catch {
+    return [];
+  }
+  const out: TProfile[] = [];
+  for (const f of files) {
+    const name = f.replace(/\.json$/, "");
+    const p = loadProfile(name);
+    if (p) out.push(p);
+  }
+  out.sort((a, b) => a.name.localeCompare(b.name));
+  return out;
+}
+
+// ─── Resolve ─────────────────────────────────────────────────────────────────
+
+/**
+ * Lite shape of a plugin entry — just enough for tier resolution. We accept
+ * `unknown`-shaped plugin records so this module doesn't drag in the heavy
+ * `LoadedPlugin` type from `src/plugin/types`. Callers (Phase 2) will pass the
+ * already-discovered plugins.
+ */
+export interface PluginNameAndTier {
+  name: string;
+  tier?: "core" | "standard" | "extra";
+}
+
+/**
+ * Resolve a profile to the concrete list of plugin names that should activate.
+ *
+ * Rules (additive — both fields contribute, no shadowing):
+ *   - Profile has `plugins` only → return that list (filtered to known names).
+ *   - Profile has `tiers` only   → return all plugins whose tier is in the
+ *                                  filter. Plugins WITHOUT a tier field are
+ *                                  not implicitly included (they fall through
+ *                                  to the audit doc's classification at the
+ *                                  caller layer).
+ *   - Profile has BOTH           → UNION of the two sets, deduplicated.
+ *   - Profile has NEITHER        → return all plugin names (the "all" case).
+ *
+ * Returns plugin names in the same order they appear in `allPlugins`, with
+ * duplicates removed. Unknown names from `profile.plugins` are silently
+ * dropped — Phase 1 prefers a permissive resolver so a missing plugin doesn't
+ * block the whole CLI.
+ */
+export function resolveProfilePlugins(
+  profile: TProfile,
+  allPlugins: PluginNameAndTier[],
+): string[] {
+  const knownNames = new Set(allPlugins.map((p) => p.name));
+  const tierMap = new Map(allPlugins.map((p) => [p.name, p.tier]));
+
+  const hasPlugins = Array.isArray(profile.plugins) && profile.plugins.length > 0;
+  const hasTiers = Array.isArray(profile.tiers) && profile.tiers.length > 0;
+
+  // Empty profile → "all" semantics.
+  if (!hasPlugins && !hasTiers) {
+    return allPlugins.map((p) => p.name);
+  }
+
+  const accept = new Set<string>();
+
+  if (hasPlugins) {
+    for (const n of profile.plugins!) {
+      if (knownNames.has(n)) accept.add(n);
+    }
+  }
+
+  if (hasTiers) {
+    const tierFilter = new Set(profile.tiers!);
+    for (const p of allPlugins) {
+      if (p.tier && tierFilter.has(p.tier)) accept.add(p.name);
+    }
+  }
+
+  // Preserve input order so caller-side weight ordering survives.
+  return allPlugins.map((p) => p.name).filter((n) => accept.has(n));
+}
+
+// ─── Active profile pointer ──────────────────────────────────────────────────
+
+/**
+ * Read the active profile name from `<CONFIG_DIR>/profile-active`.
+ * Returns `"all"` when the file is missing, empty, or unreadable.
+ */
+export function getActiveProfile(): string {
+  const path = activeProfilePath();
+  if (!existsSync(path)) return "all";
+  try {
+    const raw = readFileSync(path, "utf-8").trim();
+    if (!raw) return "all";
+    const err = validateProfileName(raw);
+    if (err) return "all";
+    return raw;
+  } catch {
+    return "all";
+  }
+}
+
+/**
+ * Write the active profile name. Validates the name before touching disk;
+ * callers receive a thrown error on bad input. The pointer file is a
+ * single-line text file (no JSON) so operators can `cat` or hand-edit it.
+ */
+export function setActiveProfile(name: string): void {
+  const nameErr = validateProfileName(name);
+  if (nameErr) throw new Error(nameErr);
+  mkdirSync(activeConfigDir(), { recursive: true });
+  const path = activeProfilePath();
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, name + "\n", "utf-8");
+  renameSync(tmp, path);
+}

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -117,6 +117,47 @@ export const Scope = Type.Object({
 });
 export type TScope = Static<typeof Scope>;
 
+/**
+ * Profile — a named bundle of plugins (#640 lean-core / Phase 1 of #888).
+ *
+ * Profiles let an operator pick which plugins activate without editing
+ * config-level disable lists. Phase 1 is ADDITIVE only: this schema and the
+ * accompanying loader exist alongside the current plugin loader without
+ * changing it. Phase 2 (#640 follow-up) wires the profile into the registry.
+ *
+ * A profile file lives at:
+ *   <CONFIG_DIR>/profiles/<name>.json
+ *
+ * The active profile name lives at:
+ *   <CONFIG_DIR>/profile-active   (single-line text file; "all" by default)
+ *
+ * Resolution rules (see `resolveProfilePlugins` in src/lib/profile-loader.ts):
+ *   - If `plugins` is set → use that explicit allowlist verbatim.
+ *   - If `tiers` is set → include any plugin whose `plugin.json#tier` is in
+ *     the list. Plugins without a `tier` field map to the audit doc
+ *     (docs/lean-core/plugin-audit.md) — Phase 1 falls back to "all" for
+ *     untiered plugins so the loader is conservative.
+ *   - If both fields are set → UNION (allowlist ∪ tier-filter).
+ *   - If neither field is set → empty resolution (caller should treat as "all").
+ *
+ * Fields:
+ *   - `name`     slug-safe identifier; mirrors the file name
+ *   - `plugins`  optional explicit plugin-name allowlist
+ *   - `tiers`    optional tier filter ("core" | "standard" | "extra")
+ *   - `description` optional human-readable note (Phase 1 ignores it)
+ */
+export const Profile = Type.Object({
+  name: Type.String(),
+  plugins: Type.Optional(Type.Array(Type.String())),
+  tiers: Type.Optional(Type.Array(Type.Union([
+    Type.Literal("core"),
+    Type.Literal("standard"),
+    Type.Literal("extra"),
+  ]))),
+  description: Type.Optional(Type.String()),
+});
+export type TProfile = Static<typeof Profile>;
+
 // ---------------------------------------------------------------------------
 // Request body schemas (POST endpoints)
 // ---------------------------------------------------------------------------

--- a/test/isolated/profile-loader.test.ts
+++ b/test/isolated/profile-loader.test.ts
@@ -1,0 +1,378 @@
+/**
+ * profile-loader — unit tests (#888 / Phase 1 of #640 lean-core).
+ *
+ * Covers `src/lib/profile-loader.ts` plus the impl layer of the
+ * `maw profile` plugin. Verbs under test:
+ *   - loadProfile / loadAllProfiles
+ *   - getActiveProfile / setActiveProfile (round-trip)
+ *   - resolveProfilePlugins (plugins-only, tiers-only, union, neither)
+ *   - default "all" auto-seed on first read
+ *   - validateProfileName
+ *
+ * Isolation: we redirect MAW_CONFIG_DIR to a per-test mkdtempSync dir BEFORE
+ * any dynamic import. The loader resolves paths at call-time (not import-time)
+ * so a fresh env per beforeEach is enough. Mirrors scope-primitive.test.ts
+ * (#642 Phase 1) which uses the same scaffold.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+let testDir: string;
+let originalConfigDir: string | undefined;
+let originalHome: string | undefined;
+
+beforeEach(() => {
+  testDir = mkdtempSync(join(tmpdir(), "maw-profile-888-"));
+  originalConfigDir = process.env.MAW_CONFIG_DIR;
+  originalHome = process.env.MAW_HOME;
+  process.env.MAW_CONFIG_DIR = testDir;
+  delete process.env.MAW_HOME;
+});
+
+afterEach(() => {
+  if (originalConfigDir === undefined) delete process.env.MAW_CONFIG_DIR;
+  else process.env.MAW_CONFIG_DIR = originalConfigDir;
+  if (originalHome === undefined) delete process.env.MAW_HOME;
+  else process.env.MAW_HOME = originalHome;
+  try { rmSync(testDir, { recursive: true, force: true }); } catch { /* ok */ }
+});
+
+// ─── Fixture helpers ─────────────────────────────────────────────────────────
+
+function writeProfile(name: string, body: Record<string, unknown>): void {
+  const dir = join(testDir, "profiles");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, `${name}.json`),
+    JSON.stringify(body, null, 2) + "\n",
+    "utf-8",
+  );
+}
+
+// Re-import the loader on every test so MAW_CONFIG_DIR mutations land. The
+// loader itself doesn't cache, but bun:test caches modules across tests in a
+// file → we still want a fresh import in case future refactors add module
+// state.
+async function importLoader() {
+  return await import("../../src/lib/profile-loader");
+}
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+describe("validateProfileName", () => {
+  test("accepts slug-safe names", async () => {
+    const { validateProfileName } = await importLoader();
+    expect(validateProfileName("minimal")).toBeNull();
+    expect(validateProfileName("a")).toBeNull();
+    expect(validateProfileName("dev_2")).toBeNull();
+    expect(validateProfileName("federation-set")).toBeNull();
+  });
+
+  test("rejects empty / leading-hyphen / uppercase / overlong", async () => {
+    const { validateProfileName } = await importLoader();
+    expect(validateProfileName("")).not.toBeNull();
+    expect(validateProfileName("-bad")).not.toBeNull();
+    expect(validateProfileName("BAD")).not.toBeNull();
+    expect(validateProfileName("a".repeat(65))).not.toBeNull();
+  });
+});
+
+// ─── loadProfile ─────────────────────────────────────────────────────────────
+
+describe("loadProfile", () => {
+  test("returns null for missing file (non-default name)", async () => {
+    const { loadProfile } = await importLoader();
+    expect(loadProfile("does-not-exist")).toBeNull();
+  });
+
+  test("returns null for invalid name", async () => {
+    const { loadProfile } = await importLoader();
+    expect(loadProfile("BAD!")).toBeNull();
+  });
+
+  test("loads a hand-written profile by name", async () => {
+    writeProfile("dev", {
+      name: "dev",
+      plugins: ["scope", "ls"],
+      tiers: ["core"],
+      description: "developer profile",
+    });
+    const { loadProfile } = await importLoader();
+    const p = loadProfile("dev");
+    expect(p).not.toBeNull();
+    expect(p?.name).toBe("dev");
+    expect(p?.plugins).toEqual(["scope", "ls"]);
+    expect(p?.tiers).toEqual(["core"]);
+    expect(p?.description).toBe("developer profile");
+  });
+
+  test("auto-seeds the default 'all' profile on first load", async () => {
+    const { loadProfile, profilePath } = await importLoader();
+    const path = profilePath("all");
+    expect(existsSync(path)).toBe(false);
+    const all = loadProfile("all");
+    expect(all).not.toBeNull();
+    expect(all?.name).toBe("all");
+    expect(all?.plugins).toBeUndefined();
+    expect(all?.tiers).toBeUndefined();
+    expect(existsSync(path)).toBe(true);
+  });
+
+  test("does not overwrite an existing 'all' profile", async () => {
+    writeProfile("all", {
+      name: "all",
+      plugins: ["custom"],
+      description: "operator-edited",
+    });
+    const { loadProfile } = await importLoader();
+    const all = loadProfile("all");
+    expect(all?.plugins).toEqual(["custom"]);
+    expect(all?.description).toBe("operator-edited");
+  });
+
+  test("tolerates malformed JSON (returns null, no crash)", async () => {
+    const dir = join(testDir, "profiles");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "broken.json"), "{not json", "utf-8");
+    const { loadProfile } = await importLoader();
+    expect(loadProfile("broken")).toBeNull();
+  });
+});
+
+// ─── loadAllProfiles ─────────────────────────────────────────────────────────
+
+describe("loadAllProfiles", () => {
+  test("returns just the auto-seeded 'all' on a fresh CONFIG_DIR", async () => {
+    const { loadAllProfiles } = await importLoader();
+    const all = loadAllProfiles();
+    expect(all.length).toBe(1);
+    expect(all[0].name).toBe("all");
+  });
+
+  test("includes hand-written profiles, sorted by name", async () => {
+    writeProfile("zeta", { name: "zeta" });
+    writeProfile("alpha", { name: "alpha", plugins: ["scope"] });
+    const { loadAllProfiles } = await importLoader();
+    const names = loadAllProfiles().map((p) => p.name);
+    expect(names).toEqual(["all", "alpha", "zeta"]);
+  });
+
+  test("skips a single corrupt file without poisoning the list", async () => {
+    writeProfile("good", { name: "good" });
+    const dir = join(testDir, "profiles");
+    writeFileSync(join(dir, "broken.json"), "{not json", "utf-8");
+    const { loadAllProfiles } = await importLoader();
+    const names = loadAllProfiles().map((p) => p.name);
+    expect(names).toContain("good");
+    expect(names).toContain("all");
+    expect(names).not.toContain("broken");
+  });
+});
+
+// ─── Active profile pointer ──────────────────────────────────────────────────
+
+describe("getActiveProfile / setActiveProfile", () => {
+  test("defaults to 'all' when no pointer file exists", async () => {
+    const { getActiveProfile } = await importLoader();
+    expect(getActiveProfile()).toBe("all");
+  });
+
+  test("setActiveProfile then getActiveProfile round-trips", async () => {
+    const { setActiveProfile, getActiveProfile, activeProfilePath } =
+      await importLoader();
+    setActiveProfile("minimal");
+    expect(getActiveProfile()).toBe("minimal");
+    // pointer file is plain text, not JSON.
+    expect(readFileSync(activeProfilePath(), "utf-8").trim()).toBe("minimal");
+  });
+
+  test("setActiveProfile rejects invalid names", async () => {
+    const { setActiveProfile } = await importLoader();
+    expect(() => setActiveProfile("BAD!")).toThrow(/invalid profile name/);
+  });
+
+  test("getActiveProfile falls back to 'all' on garbage pointer content", async () => {
+    const { getActiveProfile, activeProfilePath } = await importLoader();
+    mkdirSync(testDir, { recursive: true });
+    writeFileSync(activeProfilePath(), "BAD!\n", "utf-8");
+    expect(getActiveProfile()).toBe("all");
+  });
+
+  test("getActiveProfile falls back to 'all' on empty pointer file", async () => {
+    const { getActiveProfile, activeProfilePath } = await importLoader();
+    writeFileSync(activeProfilePath(), "", "utf-8");
+    expect(getActiveProfile()).toBe("all");
+  });
+});
+
+// ─── resolveProfilePlugins ───────────────────────────────────────────────────
+
+describe("resolveProfilePlugins", () => {
+  const plugins = [
+    { name: "scope",   tier: "core" as const },
+    { name: "trust",   tier: "core" as const },
+    { name: "inbox",   tier: "core" as const },
+    { name: "ls",      tier: "core" as const },
+    { name: "send",    tier: "standard" as const },
+    { name: "wake",    tier: "standard" as const },
+    { name: "bud",     tier: "extra" as const },
+    { name: "untiered" }, // intentionally tier-less
+  ];
+
+  test("empty profile (no plugins/tiers) → all plugins", async () => {
+    const { resolveProfilePlugins } = await importLoader();
+    const got = resolveProfilePlugins({ name: "all" }, plugins);
+    expect(got).toEqual(plugins.map((p) => p.name));
+  });
+
+  test("explicit `plugins` allowlist", async () => {
+    const { resolveProfilePlugins } = await importLoader();
+    const got = resolveProfilePlugins(
+      { name: "minimal", plugins: ["scope", "inbox", "ls"] },
+      plugins,
+    );
+    expect(got).toEqual(["scope", "inbox", "ls"]);
+  });
+
+  test("explicit `plugins` drops unknown entries silently", async () => {
+    const { resolveProfilePlugins } = await importLoader();
+    const got = resolveProfilePlugins(
+      { name: "typo", plugins: ["scope", "ghost", "xxx"] },
+      plugins,
+    );
+    expect(got).toEqual(["scope"]);
+  });
+
+  test("`tiers` filter — core only", async () => {
+    const { resolveProfilePlugins } = await importLoader();
+    const got = resolveProfilePlugins(
+      { name: "lean", tiers: ["core"] },
+      plugins,
+    );
+    expect(got).toEqual(["scope", "trust", "inbox", "ls"]);
+  });
+
+  test("`tiers` filter — multiple tiers", async () => {
+    const { resolveProfilePlugins } = await importLoader();
+    const got = resolveProfilePlugins(
+      { name: "dev", tiers: ["core", "standard"] },
+      plugins,
+    );
+    expect(got).toEqual(["scope", "trust", "inbox", "ls", "send", "wake"]);
+  });
+
+  test("`tiers` filter excludes plugins without a tier field", async () => {
+    const { resolveProfilePlugins } = await importLoader();
+    const got = resolveProfilePlugins(
+      { name: "lean", tiers: ["core"] },
+      plugins,
+    );
+    expect(got).not.toContain("untiered");
+  });
+
+  test("union: `plugins` ∪ `tiers` — both contribute, no duplicates", async () => {
+    const { resolveProfilePlugins } = await importLoader();
+    const got = resolveProfilePlugins(
+      {
+        name: "hybrid",
+        plugins: ["bud", "scope"], // scope is also in core tier
+        tiers: ["core"],
+      },
+      plugins,
+    );
+    // expected: union of {bud, scope} ∪ {scope, trust, inbox, ls},
+    // returned in input order → scope, trust, inbox, ls, bud
+    expect(got).toEqual(["scope", "trust", "inbox", "ls", "bud"]);
+    // dedup check
+    expect(new Set(got).size).toBe(got.length);
+  });
+
+  test("preserves input order (caller-side weight ordering survives)", async () => {
+    const { resolveProfilePlugins } = await importLoader();
+    const reordered = [
+      { name: "wake", tier: "standard" as const },
+      { name: "scope", tier: "core" as const },
+      { name: "send", tier: "standard" as const },
+    ];
+    const got = resolveProfilePlugins(
+      { name: "set", tiers: ["core", "standard"] },
+      reordered,
+    );
+    expect(got).toEqual(["wake", "scope", "send"]);
+  });
+});
+
+// ─── KNOWN_PROFILE_SEEDS sanity ──────────────────────────────────────────────
+
+describe("KNOWN_PROFILE_SEEDS", () => {
+  test("includes 'all' (no filters) and 'minimal' (with plugins+tiers)", async () => {
+    const { KNOWN_PROFILE_SEEDS } = await importLoader();
+    const all = KNOWN_PROFILE_SEEDS.find((p) => p.name === "all");
+    const minimal = KNOWN_PROFILE_SEEDS.find((p) => p.name === "minimal");
+    expect(all).toBeTruthy();
+    expect(all?.plugins).toBeUndefined();
+    expect(all?.tiers).toBeUndefined();
+    expect(minimal).toBeTruthy();
+    expect(Array.isArray(minimal?.plugins)).toBe(true);
+    expect(Array.isArray(minimal?.tiers)).toBe(true);
+  });
+});
+
+// ─── Integration with the impl layer (cmd*) ─────────────────────────────────
+
+describe("profile plugin impl", () => {
+  test("cmdCurrent returns 'all' before any setActiveProfile", async () => {
+    const impl = await import("../../src/commands/plugins/profile/impl");
+    expect(impl.cmdCurrent()).toBe("all");
+  });
+
+  test("cmdUse switches the active profile when the file exists", async () => {
+    writeProfile("minimal", {
+      name: "minimal",
+      plugins: ["scope", "ls"],
+      tiers: ["core"],
+    });
+    const impl = await import("../../src/commands/plugins/profile/impl");
+    impl.cmdUse("minimal");
+    expect(impl.cmdCurrent()).toBe("minimal");
+  });
+
+  test("cmdUse refuses unknown profile name", async () => {
+    const impl = await import("../../src/commands/plugins/profile/impl");
+    expect(() => impl.cmdUse("ghost")).toThrow(/not found/);
+  });
+
+  test("cmdShow returns null for unknown name; full object for known", async () => {
+    writeProfile("dev", { name: "dev", plugins: ["scope"] });
+    const impl = await import("../../src/commands/plugins/profile/impl");
+    expect(impl.cmdShow("ghost")).toBeNull();
+    const found = impl.cmdShow("dev");
+    expect(found?.name).toBe("dev");
+    expect(found?.plugins).toEqual(["scope"]);
+  });
+
+  test("cmdList includes the auto-seeded 'all' even with zero hand-written profiles", async () => {
+    const impl = await import("../../src/commands/plugins/profile/impl");
+    const rows = impl.cmdList();
+    expect(rows.find((r) => r.name === "all")).toBeTruthy();
+  });
+
+  test("formatList marks the active profile with *", async () => {
+    writeProfile("dev", { name: "dev", plugins: ["scope"] });
+    const impl = await import("../../src/commands/plugins/profile/impl");
+    impl.cmdUse("dev");
+    const rendered = impl.formatList(impl.cmdList(), impl.cmdCurrent());
+    const devLine = rendered.split("\n").find((l) => l.includes("dev"));
+    expect(devLine).toBeTruthy();
+    expect(devLine!.startsWith("*")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of the #640 lean-core epic — closes #888.

This PR adds a profile system as **ADDITIVE-only** scaffolding. The
existing plugin loader is untouched. Phase 2 (separate sub-issue) will
wire `getActiveProfile()` into `discoverPackages()` so the chosen
profile narrows the plugin registry; today it's a pure read/write
primitive plus a CLI surface.

Builds on #886/#887 (Phase 0 audit) and follows the same primitive +
CLI shape as the scope plugin (#642 Phase 1).

## What's new

- **`src/lib/profile-loader.ts`** — `loadProfile`, `loadAllProfiles`,
  `resolveProfilePlugins`, `getActiveProfile`, `setActiveProfile`,
  `validateProfileName`. Path resolution is live (call-time) so tests
  can mutate `MAW_CONFIG_DIR` per-test, mirroring the scope primitive.
- **`src/lib/schemas.ts`** — TypeBox `Profile` schema with optional
  `plugins`, `tiers`, and `description` fields.
- **`src/commands/plugins/profile/`** — new plugin shape mirroring
  `src/commands/plugins/scope/`. Subcommands: `list`, `use <name>`,
  `show <name>`, `current`. Marked `tier: "core"` in `plugin.json`.
- **`test/isolated/profile-loader.test.ts`** — 31 test cases covering
  validation, missing-file null, `all` auto-seed, set/get round-trip,
  plugins-only, tiers-only, plugins ∪ tiers union, input-order
  preservation, corrupt-JSON tolerance, plus impl-layer coverage.

## Storage layout

```
<CONFIG_DIR>/profiles/<name>.json     # one file per profile
<CONFIG_DIR>/profile-active           # single-line text pointer
```

Profile JSON shape:

```json
{
  "name": "minimal",
  "plugins": ["scope", "trust", "inbox", "ls", "hey", "help"],
  "tiers": ["core"],
  "description": "Lean-core minimal profile"
}
```

`plugins` and `tiers` are both optional. Resolution rule:

- Neither set → return all plugin names ("all" semantics).
- `plugins` only → that allowlist (unknown names dropped silently).
- `tiers` only → all plugins whose `plugin.json#tier` is in the filter.
- Both → **UNION**, deduped, in input order.

The default `all` profile is auto-seeded on first read so operators
can immediately `maw profile show all` without seeding sample JSON.
Active profile defaults to `"all"` when no pointer file exists.

## Why a separate Phase 1

The lean-core epic (#640) is going to touch the registry, the loader,
and the install path. Landing the data primitive + CLI first means:

1. Phase 0 (#886/#887) defined the tier vocabulary on paper.
2. Phase 1 (this PR) makes that vocabulary writable + queryable.
3. Phase 2 adds a single integration point — `discoverPackages()` reads
   `getActiveProfile()` and filters via `resolveProfilePlugins()`.

Each phase ships independently and is independently reversible.

## Test plan

- [x] `bun test test/isolated/profile-loader.test.ts` — 31 pass
- [x] `bun test test/isolated/scope-primitive.test.ts` — schemas import
      still clean (28 pass)
- [x] Plugin `index.ts` smoke imports cleanly
- [ ] Phase 2 integration arrives in a follow-up sub-issue

## References

- Closes #888
- Part of #640 (lean-core epic)
- Builds on #886 / #887 (Phase 0 audit)
- Pattern source: #642 (scope primitive)

Bumps calver to `26.4.29-alpha.37`.

Generated with [Claude Code](https://claude.com/claude-code).