### PR TITLE
feat(loader): wire profile + tier into plugin discovery (Phase 2 of #640 / closes #890)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.37",
+  "version": "26.4.29-alpha.38",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/lib/profile-loader.ts
+++ b/src/lib/profile-loader.ts
@@ -259,6 +259,77 @@ export function resolveProfilePlugins(
   return allPlugins.map((p) => p.name).filter((n) => accept.has(n));
 }
 
+// ─── Per-process profile resolution cache (Phase 2 / #890) ──────────────────
+
+/**
+ * In-process cache of the active profile's resolved plugin set. The plugin
+ * registry calls `resolveActiveProfileFilter()` once on first
+ * `discoverPackages()`; subsequent calls in the same `maw` invocation reuse
+ * the result. Mirrors `_discoverCache` in src/plugin/registry.ts.
+ *
+ * The cache key is the (active profile name + plugin-name fingerprint) so
+ * adding/removing plugins between calls in the same process forces a refresh
+ * (rare path — install flows already call resetDiscoverCache()).
+ */
+let _filterCache: { key: string; allowed: Set<string> | null } | null = null;
+
+/** Reset the profile-resolution cache. Use after `setActiveProfile()` and
+ *  in tests that mutate MAW_CONFIG_DIR mid-process. */
+export function resetProfileFilterCache(): void {
+  _filterCache = null;
+}
+
+/**
+ * Resolve the active profile to a plugin-name allowlist, or `null` when the
+ * profile is "all" / empty (== load everything, identical to pre-Phase-2
+ * behavior).
+ *
+ * Hot path — every `maw` invocation hits this exactly once. Designed to be
+ * cheap on the "all" branch (single file stat, no JSON parse).
+ *
+ * @returns `null` to mean "no filter, load all plugins". A `Set<string>` of
+ *          allowed plugin names otherwise. Callers MUST treat `null` as the
+ *          identity filter, not as "load nothing".
+ */
+export function resolveActiveProfileFilter(
+  allPlugins: PluginNameAndTier[],
+): Set<string> | null {
+  const activeName = getActiveProfile();
+  // "all" is the documented passthrough — short-circuit before any disk read
+  // so the default install pays nothing for Phase 2.
+  if (activeName === "all") return null;
+
+  // Cache key folds in the plugin-name set so adding a plugin between two
+  // calls in the same process still produces the right answer.
+  const fingerprint = allPlugins
+    .map((p) => `${p.name}:${p.tier ?? "core"}`)
+    .sort()
+    .join("|");
+  const key = `${activeName}::${fingerprint}`;
+  if (_filterCache && _filterCache.key === key) return _filterCache.allowed;
+
+  const profile = loadProfile(activeName);
+  if (!profile) {
+    // Active profile points at a missing/corrupt file — fail open (load all)
+    // and let `maw profile` surface the error. Bricking the CLI on a stray
+    // active-profile pointer would be far worse than a permissive fallback.
+    _filterCache = { key, allowed: null };
+    return null;
+  }
+
+  const hasPlugins = Array.isArray(profile.plugins) && profile.plugins.length > 0;
+  const hasTiers = Array.isArray(profile.tiers) && profile.tiers.length > 0;
+  if (!hasPlugins && !hasTiers) {
+    // Empty profile → "all" semantics, same as the "all" pointer above.
+    _filterCache = { key, allowed: null };
+    return null;
+  }
+
+  const allowed = new Set(resolveProfilePlugins(profile, allPlugins));
+  _filterCache = { key, allowed };
+  return allowed;
+}
+
 // ─── Active profile pointer ──────────────────────────────────────────────────
 
 /**
@@ -292,4 +363,8 @@ export function setActiveProfile(name: string): void {
   const tmp = `${path}.tmp`;
   writeFileSync(tmp, name + "\n", "utf-8");
   renameSync(tmp, path);
+  // Phase 2 (#890): pointer change must invalidate the resolved-filter cache
+  // so the next discoverPackages() call re-reads. Same pattern as
+  // resetDiscoverCache() in src/plugin/registry.ts.
+  resetProfileFilterCache();
 }

--- a/src/plugin/manifest-constants.ts
+++ b/src/plugin/manifest-constants.ts
@@ -22,6 +22,27 @@ export const KNOWN_CAPABILITY_NAMESPACES = new Set([
   "shell",  // shell-eval / stdout-writing plugins (shellenv-style)
 ]);
 
+/**
+ * Plugin membership tiers (#675 / #890). Same shape as KNOWN_CAPABILITY_NAMESPACES
+ * — a single source of truth for the validator and the profile resolver. Tier is
+ * an OPTIONAL field on plugin.json: missing → treated as "core" by the loader's
+ * profile filter (Phase 2 of #640). The TypeBox schema in src/lib/schemas.ts
+ * mirrors this list.
+ *
+ *   - core      essential primitives (scope, trust, inbox, ls, hey, help, …)
+ *   - standard  daily drivers that aren't strictly required
+ *   - extra     opt-in / experimental plugins
+ *
+ * See docs/lean-core/plugin-audit.md (#887) for the per-plugin classification.
+ */
+export const KNOWN_TIERS = ["core", "standard", "extra"] as const;
+export type KnownTier = typeof KNOWN_TIERS[number];
+
+/** Default tier when plugin.json omits the field. Used by the profile loader's
+ *  tier filter so untiered plugins ride along with the most conservative
+ *  profile (matches the audit doc — missing tier → assumed core / always-on). */
+export const DEFAULT_TIER: KnownTier = "core";
+
 export const NAME_RE = /^[a-z0-9-]+$/;
 
 // Semver: N.N.N with optional pre-release (-alpha.1) and build metadata (+001)

--- a/src/plugin/registry.ts
+++ b/src/plugin/registry.ts
@@ -33,6 +33,7 @@ import {
   isDevModeInstall,
   warnLegacyOnce,
 } from "./registry-helpers";
+import { resolveActiveProfileFilter, resetProfileFilterCache } from "../lib/profile-loader";
 
 // Re-export everything that external callers import from this module
 export { satisfies, formatSdkMismatchError } from "./registry-semver";
@@ -59,9 +60,12 @@ export { invokePlugin } from "./registry-invoke";
  */
 let _discoverCache: LoadedPlugin[] | null = null;
 
-/** Clear the discovery cache. For install-flow + tests. */
+/** Clear the discovery cache. For install-flow + tests. Also flushes the
+ *  profile-resolver cache so a re-scan picks up new plugins under the
+ *  active profile filter (#890). */
 export function resetDiscoverCache(): void {
   _discoverCache = null;
+  resetProfileFilterCache();
 }
 
 /**
@@ -194,6 +198,29 @@ export function discoverPackages(): LoadedPlugin[] {
   // Sort by weight (lower = first, default 50) — like Drupal module weight
   plugins.sort((a, b) => (a.manifest.weight ?? 50) - (b.manifest.weight ?? 50));
 
-  _discoverCache = plugins;
-  return plugins;
+  // Phase 2 (#890) — apply active-profile filter. Resolution happens at most
+  // once per process via the cache in profile-loader.ts. The "all" profile
+  // (default for fresh installs) returns null = passthrough, so the hot path
+  // pays only one stat() call. Non-"all" profiles narrow the registry to the
+  // resolved name set; everything outside is dropped silently here so it
+  // never reaches the command surface.
+  //
+  // Tier defaulting (#890 spec): plugins missing the `tier` field are
+  // treated as "core" at the loader layer so untiered legacy plugins stay
+  // visible under conservative tier filters (e.g. profile.tiers === ["core"]).
+  // The pure resolver in profile-loader.ts keeps its Phase-1 contract
+  // (untiered = excluded); the default lives here in the wiring layer where
+  // the audit doc's "missing → core" convention applies.
+  const filter = resolveActiveProfileFilter(
+    plugins.map((p) => ({
+      name: p.manifest.name,
+      tier: p.manifest.tier ?? "core",
+    })),
+  );
+  const filtered = filter === null
+    ? plugins
+    : plugins.filter((p) => filter.has(p.manifest.name));
+
+  _discoverCache = filtered;
+  return filtered;
 }

--- a/test/isolated/plugin-loader-profile.test.ts
+++ b/test/isolated/plugin-loader-profile.test.ts
@@ -1,0 +1,324 @@
+/**
+ * plugin-loader-profile — Phase 2 of #640 lean-core / closes #890.
+ *
+ * Tests the wiring between `getActiveProfile()` (#889) and `discoverPackages()`
+ * (the hot path every `maw` invocation walks). The shape mirrors
+ * profile-loader.test.ts (#888 sibling) — per-test mkdtempSync for
+ * MAW_CONFIG_DIR + a fake plugin tree under MAW_HOME so the registry's
+ * scanDirs() helper finds our fixtures.
+ *
+ * Coverage matrix:
+ *   - default "all" profile → loads everything (Phase 1 invariant must hold)
+ *   - "minimal" profile with `plugins: [...]` → explicit allowlist
+ *   - "minimal" profile with `tiers: ["core"]` → tier filter
+ *   - profile with BOTH plugins+tiers → union
+ *   - missing plugin.json tier → defaults to "core" under tier filter
+ *   - missing active-profile pointer → fallback to "all" / no filter
+ *   - active profile points at unknown name → fail-open (load all)
+ *   - profile cache reuses one resolution per process
+ *   - resolution is fast (<5ms) on a realistic plugin set
+ *   - resolveActiveProfileFilter null shape on "all" branch
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+let testDir: string;
+let mawHome: string;
+let pluginsDir: string;
+let originalConfigDir: string | undefined;
+let originalHome: string | undefined;
+let originalPluginsDir: string | undefined;
+
+beforeEach(async () => {
+  testDir = mkdtempSync(join(tmpdir(), "maw-loader-890-"));
+  mawHome = mkdtempSync(join(tmpdir(), "maw-home-890-"));
+  pluginsDir = join(mawHome, "plugins");
+  mkdirSync(pluginsDir, { recursive: true });
+  originalConfigDir = process.env.MAW_CONFIG_DIR;
+  originalHome = process.env.MAW_HOME;
+  originalPluginsDir = process.env.MAW_PLUGINS_DIR;
+  // MAW_HOME so the profile loader resolves <MAW_HOME>/config/profile-active
+  // and <MAW_HOME>/config/profiles/. MAW_PLUGINS_DIR redirects scanDirs() so
+  // the registry only sees our fixtures (not the developer's real ~/.maw).
+  process.env.MAW_HOME = mawHome;
+  process.env.MAW_PLUGINS_DIR = pluginsDir;
+  delete process.env.MAW_CONFIG_DIR;
+  // Ensure both caches are clean before each test.
+  const { resetProfileFilterCache } = await import("../../src/lib/profile-loader");
+  const { resetDiscoverCache } = await import("../../src/plugin/registry");
+  resetProfileFilterCache();
+  resetDiscoverCache();
+});
+
+afterEach(() => {
+  if (originalConfigDir === undefined) delete process.env.MAW_CONFIG_DIR;
+  else process.env.MAW_CONFIG_DIR = originalConfigDir;
+  if (originalHome === undefined) delete process.env.MAW_HOME;
+  else process.env.MAW_HOME = originalHome;
+  if (originalPluginsDir === undefined) delete process.env.MAW_PLUGINS_DIR;
+  else process.env.MAW_PLUGINS_DIR = originalPluginsDir;
+  try { rmSync(testDir, { recursive: true, force: true }); } catch { /* ok */ }
+  try { rmSync(mawHome, { recursive: true, force: true }); } catch { /* ok */ }
+});
+
+// ─── Fixture helpers ─────────────────────────────────────────────────────────
+
+interface Fixture {
+  name: string;
+  tier?: "core" | "standard" | "extra";
+  weight?: number;
+}
+
+/** Drop a plugin tree under MAW_PLUGINS_DIR/<name>/ with a minimal manifest
+ *  + an entry stub so loadManifestFromDir resolves a valid LoadedPlugin. */
+function writePluginTree(plugins: Fixture[]): void {
+  for (const p of plugins) {
+    const dir = join(pluginsDir, p.name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "index.ts"),
+      `// fixture entry for ${p.name}\nexport default async function() {}\n`,
+      "utf-8",
+    );
+    const manifest: Record<string, unknown> = {
+      name: p.name,
+      version: "1.0.0",
+      // sdk * = match any runtime version, sidesteps semver gate noise
+      sdk: "*",
+      entry: "./index.ts",
+    };
+    if (p.tier) manifest.tier = p.tier;
+    if (p.weight !== undefined) manifest.weight = p.weight;
+    writeFileSync(join(dir, "plugin.json"), JSON.stringify(manifest, null, 2), "utf-8");
+  }
+}
+
+function writeProfile(name: string, body: Record<string, unknown>): void {
+  const dir = join(mawHome, "config", "profiles");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${name}.json`), JSON.stringify(body, null, 2), "utf-8");
+}
+
+function setActive(name: string): void {
+  const dir = join(mawHome, "config");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "profile-active"), name + "\n", "utf-8");
+}
+
+async function freshDiscover(): Promise<string[]> {
+  const { discoverPackages, resetDiscoverCache } = await import("../../src/plugin/registry");
+  const { resetProfileFilterCache } = await import("../../src/lib/profile-loader");
+  resetDiscoverCache();
+  resetProfileFilterCache();
+  return discoverPackages().map((p) => p.manifest.name).sort();
+}
+
+// ─── Default behavior: "all" profile loads everything ────────────────────────
+
+describe("active profile = all (default)", () => {
+  test("no profile-active pointer → loads everything (passthrough)", async () => {
+    writePluginTree([
+      { name: "alpha", tier: "core" },
+      { name: "beta", tier: "standard" },
+      { name: "gamma", tier: "extra" },
+    ]);
+    const names = await freshDiscover();
+    expect(names).toEqual(["alpha", "beta", "gamma"]);
+  });
+
+  test("profile-active explicitly = 'all' → loads everything", async () => {
+    writePluginTree([
+      { name: "alpha", tier: "core" },
+      { name: "beta", tier: "standard" },
+    ]);
+    setActive("all");
+    const names = await freshDiscover();
+    expect(names).toEqual(["alpha", "beta"]);
+  });
+
+  test("untiered plugins still load under the default profile", async () => {
+    writePluginTree([
+      { name: "alpha" },           // no tier field
+      { name: "beta", tier: "core" },
+    ]);
+    const names = await freshDiscover();
+    expect(names).toEqual(["alpha", "beta"]);
+  });
+});
+
+// ─── Profile with explicit `plugins: [...]` allowlist ────────────────────────
+
+describe("profile with explicit plugins[]", () => {
+  test("only listed plugins load", async () => {
+    writePluginTree([
+      { name: "alpha", tier: "core" },
+      { name: "beta", tier: "standard" },
+      { name: "gamma", tier: "extra" },
+    ]);
+    writeProfile("minimal", {
+      name: "minimal",
+      plugins: ["alpha", "gamma"],
+    });
+    setActive("minimal");
+    const names = await freshDiscover();
+    expect(names).toEqual(["alpha", "gamma"]);
+  });
+
+  test("unknown names in plugins[] are silently dropped", async () => {
+    writePluginTree([
+      { name: "alpha", tier: "core" },
+    ]);
+    writeProfile("minimal", {
+      name: "minimal",
+      plugins: ["alpha", "does-not-exist"],
+    });
+    setActive("minimal");
+    const names = await freshDiscover();
+    expect(names).toEqual(["alpha"]);
+  });
+});
+
+// ─── Profile with `tiers: [...]` filter ──────────────────────────────────────
+
+describe("profile with tiers[] filter", () => {
+  test("tiers: ['core'] loads only core-tier plugins", async () => {
+    writePluginTree([
+      { name: "alpha", tier: "core" },
+      { name: "beta", tier: "standard" },
+      { name: "gamma", tier: "extra" },
+    ]);
+    writeProfile("lean", {
+      name: "lean",
+      tiers: ["core"],
+    });
+    setActive("lean");
+    const names = await freshDiscover();
+    expect(names).toEqual(["alpha"]);
+  });
+
+  test("tiers: ['core', 'standard'] loads both", async () => {
+    writePluginTree([
+      { name: "alpha", tier: "core" },
+      { name: "beta", tier: "standard" },
+      { name: "gamma", tier: "extra" },
+    ]);
+    writeProfile("daily", {
+      name: "daily",
+      tiers: ["core", "standard"],
+    });
+    setActive("daily");
+    const names = await freshDiscover();
+    expect(names).toEqual(["alpha", "beta"]);
+  });
+
+  test("plugin without tier defaults to 'core' under tier filter", async () => {
+    writePluginTree([
+      { name: "alpha" },                    // missing tier → default core
+      { name: "beta", tier: "extra" },
+    ]);
+    writeProfile("lean", {
+      name: "lean",
+      tiers: ["core"],
+    });
+    setActive("lean");
+    const names = await freshDiscover();
+    expect(names).toEqual(["alpha"]);
+  });
+});
+
+// ─── Both plugins[] and tiers[] → union ──────────────────────────────────────
+
+describe("profile with both plugins[] and tiers[]", () => {
+  test("union of allowlist and tier filter", async () => {
+    writePluginTree([
+      { name: "alpha", tier: "core" },      // matches tiers
+      { name: "beta", tier: "extra" },      // matches plugins
+      { name: "gamma", tier: "standard" },  // matches neither
+    ]);
+    writeProfile("custom", {
+      name: "custom",
+      plugins: ["beta"],
+      tiers: ["core"],
+    });
+    setActive("custom");
+    const names = await freshDiscover();
+    expect(names).toEqual(["alpha", "beta"]);
+  });
+});
+
+// ─── Pointer edge cases ──────────────────────────────────────────────────────
+
+describe("active profile pointer edge cases", () => {
+  test("active profile points at unknown name → fail-open (load all)", async () => {
+    writePluginTree([
+      { name: "alpha", tier: "core" },
+      { name: "beta", tier: "extra" },
+    ]);
+    setActive("does-not-exist");
+    const names = await freshDiscover();
+    // permissive fallback — better than bricking the CLI on a stale pointer
+    expect(names).toEqual(["alpha", "beta"]);
+  });
+
+  test("empty profile body (no plugins, no tiers) → all", async () => {
+    writePluginTree([
+      { name: "alpha", tier: "core" },
+      { name: "beta", tier: "extra" },
+    ]);
+    writeProfile("blank", { name: "blank" });
+    setActive("blank");
+    const names = await freshDiscover();
+    expect(names).toEqual(["alpha", "beta"]);
+  });
+});
+
+// ─── Cache + performance ─────────────────────────────────────────────────────
+
+describe("resolution caching", () => {
+  test("resolveActiveProfileFilter is cached per-process", async () => {
+    writePluginTree([{ name: "alpha", tier: "core" }]);
+    writeProfile("lean", { name: "lean", tiers: ["core"] });
+    setActive("lean");
+
+    const { resolveActiveProfileFilter, resetProfileFilterCache } = await import(
+      "../../src/lib/profile-loader"
+    );
+    resetProfileFilterCache();
+    const inputs = [{ name: "alpha", tier: "core" as const }];
+    const a = resolveActiveProfileFilter(inputs);
+    const b = resolveActiveProfileFilter(inputs);
+    // Same Set instance returned on cache hit.
+    expect(a).toBe(b);
+  });
+
+  test("returns null on the 'all' profile (passthrough fast-path)", async () => {
+    setActive("all");
+    const { resolveActiveProfileFilter, resetProfileFilterCache } = await import(
+      "../../src/lib/profile-loader"
+    );
+    resetProfileFilterCache();
+    expect(resolveActiveProfileFilter([{ name: "alpha", tier: "core" }])).toBeNull();
+  });
+
+  test("resolution finishes under 5ms on a realistic 50-plugin set", async () => {
+    writeProfile("lean", { name: "lean", tiers: ["core"] });
+    setActive("lean");
+    const inputs = Array.from({ length: 50 }, (_, i) => ({
+      name: `plugin-${i}`,
+      tier: (i % 3 === 0 ? "core" : i % 3 === 1 ? "standard" : "extra") as
+        | "core"
+        | "standard"
+        | "extra",
+    }));
+    const { resolveActiveProfileFilter, resetProfileFilterCache } = await import(
+      "../../src/lib/profile-loader"
+    );
+    resetProfileFilterCache();
+    const t0 = performance.now();
+    resolveActiveProfileFilter(inputs);
+    const elapsed = performance.now() - t0;
+    expect(elapsed).toBeLessThan(5);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 of the lean-core epic (#640). Phase 1 (#889) shipped the profile loader and `maw profile` CLI as additive state; the registry didn't read it. This PR wires `getActiveProfile()` into `discoverPackages()` so the active profile actually narrows the runtime plugin surface.

Default behavior is unchanged: fresh installs have no `profile-active` pointer, `getActiveProfile()` returns `"all"`, the resolver short-circuits to `null` (passthrough), and `discoverPackages()` returns the same set as before. The hot path adds exactly one `existsSync()` for the pointer file on the default branch.

Closes #890. Builds on #889 (Phase 1), #886/#887 (Phase 0 audit + tier doc), #675 (tier field origin).

## What changed

- **`src/plugin/manifest-constants.ts`** — add `KNOWN_TIERS` + `DEFAULT_TIER` alongside `KNOWN_CAPABILITY_NAMESPACES`. Single source of truth for the tier vocabulary; mirrors the TypeBox schema in `src/lib/schemas.ts`. The `tier` field on `plugin.json` was already parsed by `parseTier()` (#675), already in the schema, and already on `PluginManifest`. The constants module now exposes the same vocabulary so the validator and the loader stay in sync.

- **`src/lib/profile-loader.ts`** — new `resolveActiveProfileFilter()` helper. Reads the active profile pointer once per process, resolves it against the discovered plugin list, caches the result behind a fingerprint key (`activeName + sorted plugin names`). Returns `null` on `"all"` / missing-pointer / empty-profile / corrupt-profile so the wiring layer can treat `null` as the identity filter. Pure `resolveProfilePlugins()` keeps its Phase-1 contract (untiered → excluded from tier filter); the "missing tier → core" default is applied at the wiring boundary, not in the resolver. `setActiveProfile()` now flushes the filter cache.

- **`src/plugin/registry.ts`** — `discoverPackages()` runs the resolved filter after the existing weight-sort, before caching `_discoverCache`. Manifests are mapped to `{name, tier: tier ?? "core"}` so legacy plugins stay visible under `profile.tiers === ["core"]`. `resetDiscoverCache()` also flushes the profile-resolver cache, keeping install-flow callers correct.

- **`test/isolated/plugin-loader-profile.test.ts`** — 14 cases covering: default-all loads everything (×3 variants), explicit `plugins[]` allowlist (×2), `tiers[]` filter for one and multiple tiers, missing-tier defaults to "core" under tier filter, BOTH `plugins[]` and `tiers[]` → union, unknown active-profile name fails open, empty profile body resolves to "all", per-process resolver cache returns the same Set, "all" branch returns null fast-path, and a <5ms budget for resolution on a 50-plugin set.

## Why the default-tier rule lives at the registry, not the resolver

The Phase-1 unit tests (`test/isolated/profile-loader.test.ts`) explicitly assert `tiers` filter excludes untiered plugins — that's the documented pure-resolver contract. Phase 2's spec says missing tier should default to `"core"`. The reconciliation: keep the pure resolver's contract (no breaking change to #889 tests), apply the conservative default at the loader boundary. The registry maps `tier ?? "core"` before passing the list into `resolveProfilePlugins`. Single-line change, surface-area minimal, both contracts honored.

## Hot-path cost

Default install (no profile-active pointer):
1. `getActiveProfile()` — one `existsSync()` for `<CONFIG_DIR>/profile-active`. Returns `"all"`.
2. `resolveActiveProfileFilter()` — short-circuits to `null` before any disk read or JSON parse.
3. `discoverPackages()` — passes through. Cached after first call.

Non-default profile: one extra `loadProfile()` call (single `readFileSync` + `JSON.parse`) on first invocation, then cached for the rest of the process. Filter application is `Array.filter` over the already-discovered plugins — O(n) on a set typically <100.

## Test plan

- [x] `bun test test/isolated/plugin-loader-profile.test.ts` — 14/14 pass
- [x] `bun test test/isolated/profile-loader.test.ts` — 31/31 pass (Phase 1 invariants intact)
- [x] `bun test test/plugin-registry.test.ts test/plugin-manifest.test.ts test/hooks-registry.test.ts test/api-plugins.test.ts` — 61/61 pass
- [x] `bun scripts/calver.ts` — bumped to 26.4.29-alpha.38
- [ ] CI green on alpha base
- [ ] Smoke: `maw profile use minimal && maw <any-cmd>` excludes non-listed plugins

🤖 Generated with [Claude Code](https://claude.com/claude-code)