### PR TITLE
feat(runtime): source-plugin execution dispatch (#899)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Pre-1.0 alpha releases may still introduce breaking changes at any time.
 ### Fixed
 - `maw update`: stash maw binary before bun-remove fallback so failed retries don't strand users with no binary (#551 — defensive belt-and-suspenders; package rename above is the root-cause fix)
 - `withUpdateLock`: fd-based read/write on lock file to prevent path TOCTOU from symlink substitution between openSync and the path-based follow-up
+- `runtime`: source-plugin execution dispatch — community plugins installed into `~/.maw/plugins/<name>/` without an explicit `cli` field in plugin.json now dispatch as `maw <name>` via a default-name fallback in `dispatch-match.ts` (`pluginCliNames`). The fallback only applies to plugins that are actually dispatchable (have an `entry` or `wasm` surface) so headless API/hooks/cron plugins still route to the unknown-command path. The unknown-command guard in `cli.ts` and the `--help` / `--version` / `plugin info` / `plugin ls` surfaces are all updated in lockstep, so the default name shows up consistently across the CLI. Closes the runtime gap that survived the install cascade (#857 + #861 + #866 + #870 + #880 + #897). Fixes #899.
 
 ## [v2.0.0-alpha.134] - 2026-04-18
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.40",
+  "version": "26.4.29-alpha.41",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -70,7 +70,7 @@ async function main(): Promise<void> {
         // Also: slice by the MATCHED name (alias or command), not always command,
         // so remaining args are computed correctly when an alias fires.
         const { discoverPackages, invokePlugin } = await import("./plugin/registry");
-        const { resolvePluginMatch } = await import("./cli/dispatch-match");
+        const { resolvePluginMatch, pluginCliNames } = await import("./cli/dispatch-match");
         const plugins = discoverPackages();
         // #393 Bug H: use lowercased cmdName ONLY for plugin-name matching.
         // Pass the ORIGINAL-case args to the plugin. Previously remaining was
@@ -103,9 +103,15 @@ async function main(): Promise<void> {
         ];
         const knownCommands: string[] = [...CORE_ROUTES];
         for (const p of plugins) {
-          if (!p.manifest.cli) continue;
-          knownCommands.push(p.manifest.cli.command);
-          for (const a of p.manifest.cli.aliases ?? []) knownCommands.push(a);
+          // #899 — mirror dispatch-match's default-name behavior: plugins
+          // without `cli` but with a dispatchable entry surface as
+          // `manifest.name`. Keeps the unknown-command guard in sync with
+          // the dispatcher so source-installed community plugins don't
+          // trigger "did you mean" suggestions for their own command.
+          const cliNames = pluginCliNames(p);
+          if (!cliNames) continue;
+          knownCommands.push(cliNames.command);
+          for (const a of cliNames.aliases) knownCommands.push(a);
         }
         const { listCommands } = await import("./cli/command-registry");
         for (const c of listCommands()) {

--- a/src/cli/dispatch-match.ts
+++ b/src/cli/dispatch-match.ts
@@ -10,6 +10,16 @@
  *   1. Collect all exact `cmdName === name` matches.
  *   2. If pass-1 empty, collect all `cmdName startsWith (name + " ")` matches.
  *   3. Single survivor → match. Multi survivors → ambiguous (caller reports).
+ *
+ * #899: source-plugin execution dispatch. Community plugins installed via
+ * `maw plugin install` may omit the `cli` field in plugin.json — every
+ * existing community plugin was extracted that way (shellenv, bg, rename,
+ * cross-team-queue, park). Per the issue's stated runtime contract, the
+ * dispatcher defaults the CLI command to `manifest.name` when the field is
+ * absent. The plugin still needs an entry/wasm to actually execute (gated
+ * by `isDispatchable` below), so headless plugins (api-only, hooks-only,
+ * cron-only) remain skipped — we only inject a default for plugins that
+ * could meaningfully respond to a CLI invocation.
  */
 import type { LoadedPlugin } from "../plugin/types";
 
@@ -17,6 +27,36 @@ export type DispatchMatch =
   | { kind: "match"; plugin: LoadedPlugin; matchedName: string }
   | { kind: "ambiguous"; candidates: Array<{ plugin: string; name: string }> }
   | { kind: "none" };
+
+/**
+ * #899: a plugin is CLI-dispatchable if it has either a JS/TS entry or a
+ * WASM module. Pure-API / pure-hooks / pure-cron plugins (no entry, no wasm,
+ * no artifact) are not dispatchable — the default-cli-name path skips them
+ * so unknown commands still error correctly instead of silently matching a
+ * headless plugin and crashing inside invokePlugin.
+ */
+function isDispatchable(p: LoadedPlugin): boolean {
+  if (p.kind === "ts" && p.entryPath) return true;
+  if (p.kind === "wasm" && p.wasmPath) return true;
+  return false;
+}
+
+/**
+ * #899: derive the CLI command names for a plugin. If `manifest.cli` is
+ * present, use it (canonical command + aliases). Otherwise default to
+ * `manifest.name` IFF the plugin is dispatchable. Returns `null` for
+ * plugins that should not participate in CLI dispatch.
+ */
+export function pluginCliNames(p: LoadedPlugin): { command: string; aliases: string[] } | null {
+  if (p.manifest.cli) {
+    return {
+      command: p.manifest.cli.command,
+      aliases: p.manifest.cli.aliases ?? [],
+    };
+  }
+  if (!isDispatchable(p)) return null;
+  return { command: p.manifest.name, aliases: [] };
+}
 
 export function resolvePluginMatch(
   plugins: LoadedPlugin[],
@@ -26,8 +66,9 @@ export function resolvePluginMatch(
   const exact: Hit[] = [];
   const prefix: Hit[] = [];
   for (const p of plugins) {
-    if (!p.manifest.cli) continue;
-    const names = [p.manifest.cli.command, ...(p.manifest.cli.aliases ?? [])];
+    const cliNames = pluginCliNames(p);
+    if (!cliNames) continue;
+    const names = [cliNames.command, ...cliNames.aliases];
     let exactHit: string | null = null;
     let prefixHit: string | null = null;
     for (const n of names) {

--- a/src/commands/shared/plugins-ls-info.ts
+++ b/src/commands/shared/plugins-ls-info.ts
@@ -119,16 +119,33 @@ export function doInfo(name: string, discover: () => LoadedPlugin[]): void {
   if (m.cli) {
     const help = m.cli.help ? `  — ${m.cli.help}` : "";
     console.log(`  cli:     ${m.cli.command}${help}`);
+  } else if (p.kind === "ts" && p.entryPath) {
+    // #899 — community plugins without an explicit `cli` field still
+    // dispatch as `maw <name>` via the default-name path in dispatch-match.
+    console.log(`  cli:     ${m.name}  (default — no explicit cli field)`);
   }
   if (m.api) {
     console.log(`  api:     ${m.api.path}  [${m.api.methods.join(", ")}]`);
   }
   console.log(`  dir:     ${p.dir}`);
 
-  const wasmExists = existsSync(p.wasmPath);
-  const wasmMark = wasmExists ? "\x1b[32m✓\x1b[0m" : "\x1b[31m✗ missing\x1b[0m";
-  console.log(`  wasm:    ${p.wasmPath}  ${wasmMark}`);
-  if (!wasmExists) {
-    console.warn(`\x1b[33mwarn:\x1b[0m wasm file missing — plugin will not execute`);
+  // #899 — TS plugins execute via Bun import of `entry`, not WASM. Showing a
+  // "wasm missing — will not execute" warning for a healthy `target:js` plugin
+  // produced false-alarm reports during the source-plugin install cascade.
+  // Only warn about wasm when the plugin is actually a WASM kind.
+  if (p.kind === "ts" && p.entryPath) {
+    const entryExists = existsSync(p.entryPath);
+    const mark = entryExists ? "\x1b[32m✓\x1b[0m" : "\x1b[31m✗ missing\x1b[0m";
+    console.log(`  entry:   ${p.entryPath}  ${mark}`);
+    if (!entryExists) {
+      console.warn(`\x1b[33mwarn:\x1b[0m entry file missing — plugin will not execute`);
+    }
+  } else {
+    const wasmExists = existsSync(p.wasmPath);
+    const wasmMark = wasmExists ? "\x1b[32m✓\x1b[0m" : "\x1b[31m✗ missing\x1b[0m";
+    console.log(`  wasm:    ${p.wasmPath}  ${wasmMark}`);
+    if (!wasmExists) {
+      console.warn(`\x1b[33mwarn:\x1b[0m wasm file missing — plugin will not execute`);
+    }
   }
 }

--- a/src/commands/shared/plugins-ui.ts
+++ b/src/commands/shared/plugins-ui.ts
@@ -14,6 +14,12 @@ export function archiveToTmp(name: string, dir: string): void {
 export function surfaces(p: LoadedPlugin): string {
   const parts: string[] = [];
   if (p.manifest.cli) parts.push(`cli:${p.manifest.cli.command}`);
+  // #899 — surfaces the default-cli-name for community plugins that omit
+  // the `cli` field but still dispatch as `maw <name>` via dispatch-match's
+  // pluginCliNames(). Listing was reporting "—" for these, masking the
+  // surface they actually expose at runtime.
+  else if (p.kind === "ts" && p.entryPath) parts.push(`cli:${p.manifest.name}`);
+  else if (p.kind === "wasm" && p.wasmPath) parts.push(`cli:${p.manifest.name}`);
   if (p.manifest.api) parts.push(`api:${p.manifest.api.path}`);
   return parts.join(", ") || "—";
 }

--- a/src/plugin/registry-invoke.ts
+++ b/src/plugin/registry-invoke.ts
@@ -33,8 +33,14 @@ export async function invokePlugin(
 
     // -v / --version — show plugin metadata
     if (flag === "-v" || flag === "--version" || flag === "-version") {
+      // #899 — derive the effective CLI surface so plugins without an
+      // explicit `cli` field still report their default-name dispatch
+      // (community-plugin shape: shellenv, bg, rename, cross-team-queue, park).
+      const effectiveCli = m.cli?.command
+        ?? (plugin.kind === "ts" && plugin.entryPath ? m.name : undefined)
+        ?? (plugin.kind === "wasm" && plugin.wasmPath ? m.name : undefined);
       const surfaces = [
-        m.cli ? `cli:${m.cli.command}` : null,
+        effectiveCli ? `cli:${effectiveCli}` : null,
         m.api ? `api:${m.api.path}` : null,
         m.hooks ? "hooks" : null,
         m.transport?.peer ? "peer" : null,
@@ -54,8 +60,14 @@ export async function invokePlugin(
       lines.push(`${m.name} v${m.version}`);
       if (m.description) lines.push(`  ${m.description}`);
       lines.push("");
+      // #899 — fall back to default-name dispatch when `cli` is omitted but
+      // the plugin is dispatchable. Mirrors pluginCliNames() in dispatch-match.
+      const defaultCli = (plugin.kind === "ts" && plugin.entryPath) || (plugin.kind === "wasm" && plugin.wasmPath)
+        ? m.name
+        : null;
+      const effectiveCmd = m.cli?.command ?? defaultCli;
       if (m.cli?.help) lines.push(`  usage: ${m.cli.help}`);
-      else if (m.cli) lines.push(`  usage: maw ${m.cli.command}`);
+      else if (effectiveCmd) lines.push(`  usage: maw ${effectiveCmd}`);
       if (m.cli?.aliases?.length) lines.push(`  aliases: ${m.cli.aliases.join(", ")}`);
       if (m.cli?.flags) {
         lines.push("  flags:");
@@ -63,7 +75,7 @@ export async function invokePlugin(
       }
       lines.push("");
       lines.push("  surfaces:");
-      if (m.cli) lines.push(`    cli: maw ${m.cli.command}`);
+      if (effectiveCmd) lines.push(`    cli: maw ${effectiveCmd}`);
       if (m.api) lines.push(`    api: ${m.api.methods.join("/")} ${m.api.path}`);
       if (m.transport?.peer) lines.push(`    peer: maw hey plugin:${m.name}`);
       if (m.hooks) lines.push(`    hooks: ${Object.keys(m.hooks).join(", ")}`);

--- a/test/cli/dispatch-match.test.ts
+++ b/test/cli/dispatch-match.test.ts
@@ -84,7 +84,10 @@ describe("resolvePluginMatch — two-pass dispatch", () => {
     expect(out.kind).toBe("none");
   });
 
-  test("plugins without cli field are skipped", () => {
+  test("non-dispatchable plugins (no cli, no entry, no wasm) are skipped", () => {
+    // #899 — pure-hooks/api/cron plugins still get filtered out: no `cli`
+    // field AND no entry/wasm to default to. The default-name fallback
+    // requires a dispatchable surface so unknown commands still error.
     const noCli: LoadedPlugin = {
       manifest: { name: "headless", version: "1.0.0", sdk: "^1.0.0" } as LoadedPlugin["manifest"],
       dir: "/tmp/headless",
@@ -95,6 +98,10 @@ describe("resolvePluginMatch — two-pass dispatch", () => {
     const out = resolvePluginMatch([noCli, art], "art");
     expect(out.kind).toBe("match");
     if (out.kind === "match") expect(out.plugin.manifest.name).toBe("artifact-manager");
+
+    // The headless plugin's name MUST NOT match — it has no executable surface.
+    const miss = resolvePluginMatch([noCli, art], "headless");
+    expect(miss.kind).toBe("none");
   });
 
   test("two plugins sharing same exact command → ambiguous", () => {

--- a/test/isolated/source-plugin-execution.test.ts
+++ b/test/isolated/source-plugin-execution.test.ts
@@ -1,0 +1,233 @@
+/**
+ * #899 — source-plugin execution dispatch.
+ *
+ * After the install cascade (#857 + #861 + #866 + #870 + #880 + #897), source
+ * plugins land cleanly in `~/.maw/plugins/<name>/`. But running `maw <name>`
+ * still returned `unknown command: <name>` because the dispatcher's gate
+ * (resolvePluginMatch + cli.ts knownCommands) skipped any plugin whose
+ * plugin.json omitted the `cli` field — and every community plugin extracted
+ * during the cascade was missing that field.
+ *
+ * Fix contract (mirrored across dispatch-match + cli.ts + registry-invoke):
+ *   - When manifest.cli is present → use cli.command + cli.aliases (existing).
+ *   - When manifest.cli is absent  → default the command to manifest.name IFF
+ *     the plugin is dispatchable (has entryPath or wasmPath). Headless plugins
+ *     (api-only / hooks-only / cron-only) remain skipped — their absence
+ *     should still surface as an unknown command, not silently route into a
+ *     plugin that has nothing to run.
+ *
+ * Tests pin both branches: explicit cli wins, default-name path resolves,
+ * non-dispatchable plugins stay unknown, and unknown commands still error
+ * with the same fuzzy-suggest UX as before.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { resolvePluginMatch, pluginCliNames } from "../../src/cli/dispatch-match";
+import type { LoadedPlugin } from "../../src/plugin/types";
+
+// ─── Fixture builders ────────────────────────────────────────────────────────
+
+function tsPlugin(opts: {
+  name: string;
+  cli?: { command: string; aliases?: string[] };
+  entry?: boolean;
+}): LoadedPlugin {
+  return {
+    manifest: {
+      name: opts.name,
+      version: "1.0.0",
+      sdk: "^1.0.0",
+      ...(opts.cli ? { cli: { command: opts.cli.command, aliases: opts.cli.aliases ?? [], help: "" } } : {}),
+    } as LoadedPlugin["manifest"],
+    dir: `/tmp/${opts.name}`,
+    wasmPath: "",
+    ...(opts.entry !== false ? { entryPath: `/tmp/${opts.name}/src/index.ts` } : {}),
+    kind: "ts",
+  };
+}
+
+function wasmPlugin(opts: {
+  name: string;
+  cli?: { command: string; aliases?: string[] };
+  wasm?: boolean;
+}): LoadedPlugin {
+  return {
+    manifest: {
+      name: opts.name,
+      version: "1.0.0",
+      sdk: "^1.0.0",
+      ...(opts.cli ? { cli: { command: opts.cli.command, aliases: opts.cli.aliases ?? [], help: "" } } : {}),
+    } as LoadedPlugin["manifest"],
+    dir: `/tmp/${opts.name}`,
+    wasmPath: opts.wasm !== false ? `/tmp/${opts.name}/${opts.name}.wasm` : "",
+    kind: "wasm",
+  };
+}
+
+// ─── pluginCliNames — unit contract ──────────────────────────────────────────
+
+describe("#899 — pluginCliNames default-name derivation", () => {
+  test("explicit cli field is used verbatim (canonical command + aliases)", () => {
+    const p = tsPlugin({ name: "shellenv", cli: { command: "shellenv", aliases: ["se"] } });
+    expect(pluginCliNames(p)).toEqual({ command: "shellenv", aliases: ["se"] });
+  });
+
+  test("missing cli field defaults to manifest.name for dispatchable TS plugins", () => {
+    // Canonical community-plugin shape: plugin.json without `cli`, entry → src/index.ts.
+    const p = tsPlugin({ name: "shellenv" });
+    expect(pluginCliNames(p)).toEqual({ command: "shellenv", aliases: [] });
+  });
+
+  test("missing cli field defaults to manifest.name for dispatchable WASM plugins", () => {
+    const p = wasmPlugin({ name: "wasmer" });
+    expect(pluginCliNames(p)).toEqual({ command: "wasmer", aliases: [] });
+  });
+
+  test("non-dispatchable plugin (no entry, no wasm) → null (skipped from CLI)", () => {
+    // Hooks-only / api-only plugin: no entry path on disk, no wasm. Should
+    // NOT register a default cli command — its name still needs to surface
+    // as an unknown command if a user types it.
+    const p: LoadedPlugin = {
+      manifest: { name: "hooks-only", version: "1.0.0", sdk: "^1.0.0" } as LoadedPlugin["manifest"],
+      dir: "/tmp/hooks-only",
+      wasmPath: "",
+      kind: "ts",
+      // no entryPath
+    };
+    expect(pluginCliNames(p)).toBeNull();
+  });
+
+  test("aliases default to empty array when cli omits them", () => {
+    const p = tsPlugin({ name: "rename", cli: { command: "rename" } });
+    expect(pluginCliNames(p)).toEqual({ command: "rename", aliases: [] });
+  });
+});
+
+// ─── resolvePluginMatch — dispatch through default-name path ─────────────────
+
+describe("#899 — resolvePluginMatch routes default-name plugins", () => {
+  test("source plugin in ~/.maw/plugins/shellenv/ dispatches as `maw shellenv`", () => {
+    const shellenv = tsPlugin({ name: "shellenv" }); // no cli field
+    const out = resolvePluginMatch([shellenv], "shellenv zsh");
+    expect(out.kind).toBe("match");
+    if (out.kind === "match") {
+      expect(out.plugin.manifest.name).toBe("shellenv");
+      expect(out.matchedName).toBe("shellenv");
+    }
+  });
+
+  test("explicit cli field wins over default-name when present", () => {
+    // Plugin name and cli command differ — ensure cli wins (existing contract).
+    const p = tsPlugin({ name: "internal-name", cli: { command: "public-cmd" } });
+    const out = resolvePluginMatch([p], "public-cmd");
+    expect(out.kind).toBe("match");
+    if (out.kind === "match") expect(out.matchedName).toBe("public-cmd");
+
+    // The internal plugin name should NOT match anymore — cli overrides it.
+    const miss = resolvePluginMatch([p], "internal-name");
+    expect(miss.kind).toBe("none");
+  });
+
+  test("default-name + explicit cli plugins coexist in registry without crosstalk", () => {
+    // Mixed registry: canonical built-in (with cli) + community (without).
+    const builtIn = tsPlugin({ name: "scope", cli: { command: "scope", aliases: ["scopes"] } });
+    const community = tsPlugin({ name: "shellenv" });
+    const a = resolvePluginMatch([builtIn, community], "scope list");
+    expect(a.kind).toBe("match");
+    if (a.kind === "match") expect(a.plugin.manifest.name).toBe("scope");
+    const b = resolvePluginMatch([builtIn, community], "shellenv");
+    expect(b.kind).toBe("match");
+    if (b.kind === "match") expect(b.plugin.manifest.name).toBe("shellenv");
+  });
+
+  test("default-name plugin matches with subcommand args (prefix path)", () => {
+    // `maw rename old new` — community plugin without cli, args follow the name.
+    const rename = tsPlugin({ name: "rename" });
+    const out = resolvePluginMatch([rename], "rename old new");
+    expect(out.kind).toBe("match");
+    if (out.kind === "match") {
+      expect(out.plugin.manifest.name).toBe("rename");
+      expect(out.matchedName).toBe("rename");
+    }
+  });
+
+  test("non-dispatchable plugin's manifest.name is NOT a CLI surface", () => {
+    // Headless plugin shape — should fall through to "unknown command" so the
+    // top-level cli.ts fuzzy-suggest path still runs.
+    const headless: LoadedPlugin = {
+      manifest: { name: "ghost", version: "1.0.0", sdk: "^1.0.0" } as LoadedPlugin["manifest"],
+      dir: "/tmp/ghost",
+      wasmPath: "",
+      kind: "ts",
+    };
+    const out = resolvePluginMatch([headless], "ghost");
+    expect(out.kind).toBe("none");
+  });
+
+  test("unknown command still returns kind:none with a default-name registry", () => {
+    const shellenv = tsPlugin({ name: "shellenv" });
+    const rename = tsPlugin({ name: "rename" });
+    const out = resolvePluginMatch([shellenv, rename], "definitely-not-a-plugin");
+    expect(out.kind).toBe("none");
+  });
+
+  test("two source plugins sharing the same name → ambiguous (still reports)", () => {
+    // Edge: two `~/.maw/plugins/foo/` dirs surfaced (e.g. dev-mode symlink +
+    // tarball install of same name). The default-name path must still flag
+    // ambiguity rather than picking the first silently.
+    const a = tsPlugin({ name: "twin" });
+    const b = tsPlugin({ name: "twin" });
+    const out = resolvePluginMatch([a, b], "twin");
+    expect(out.kind).toBe("ambiguous");
+    if (out.kind === "ambiguous") {
+      expect(out.candidates.map(c => c.name)).toEqual(["twin", "twin"]);
+    }
+  });
+
+  test("default-name plugin does NOT collide with a longer-prefixed default-name plugin", () => {
+    // `bg` and `bg-helper` both default-named — typing `bg-helper` must not
+    // route to `bg` (prefix word-boundary contract from #354).
+    const bg = tsPlugin({ name: "bg" });
+    const bgHelper = tsPlugin({ name: "bg-helper" });
+    const out = resolvePluginMatch([bg, bgHelper], "bg-helper status");
+    expect(out.kind).toBe("match");
+    if (out.kind === "match") {
+      expect(out.plugin.manifest.name).toBe("bg-helper");
+      expect(out.matchedName).toBe("bg-helper");
+    }
+  });
+
+  test("explicit cli command overrides plugin.name even when name is also typed", () => {
+    // Plugin renamed its CLI surface — `maw <plugin-name>` should NOT match;
+    // only the explicit `cli.command` does. Confirms default-name fallback
+    // doesn't leak into plugins that opted into a custom CLI surface.
+    const p = tsPlugin({ name: "ctq", cli: { command: "queue" } });
+    const a = resolvePluginMatch([p], "queue list");
+    expect(a.kind).toBe("match");
+    if (a.kind === "match") expect(a.matchedName).toBe("queue");
+    const b = resolvePluginMatch([p], "ctq");
+    expect(b.kind).toBe("none");
+  });
+
+  test("WASM plugin without cli still dispatches via manifest.name", () => {
+    // Phase A ships TS-first, but the contract must hold for wasm too — the
+    // bundled `done.wasm` style plugin (if community-published without cli)
+    // would otherwise be unreachable. Symmetric with TS path.
+    const w = wasmPlugin({ name: "wasmcmd" });
+    const out = resolvePluginMatch([w], "wasmcmd");
+    expect(out.kind).toBe("match");
+    if (out.kind === "match") expect(out.matchedName).toBe("wasmcmd");
+  });
+
+  test("backward-compat: built-in plugin with cli + aliases still dispatches via aliases", () => {
+    // Sanity check that the default-name change didn't break alias matching
+    // for canonical built-in plugins. Mirrors `maw finish <window>` → done.
+    const done = tsPlugin({ name: "done", cli: { command: "done", aliases: ["finish"] } });
+    const out = resolvePluginMatch([done], "finish my-window");
+    expect(out.kind).toBe("match");
+    if (out.kind === "match") {
+      expect(out.plugin.manifest.name).toBe("done");
+      expect(out.matchedName).toBe("finish");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes the runtime gap that survived the install cascade. After #857 + #861 + #866 + #870 + #880 + #897, `maw plugin install <name>` lands community plugins cleanly into `~/.maw/plugins/<name>/`. But running `maw <name>` still printed `unknown command: <name>` for every one of them, because the dispatcher's gate skipped any plugin whose `plugin.json` omitted the `cli` field — and every community plugin extracted during the cascade (shellenv, bg, rename, cross-team-queue, park) was missing that field.

The fix is small and surgical: in `src/cli/dispatch-match.ts`, default the CLI command to `manifest.name` when `manifest.cli` is absent, gated on the plugin being dispatchable (has `entry` or `wasm`). Headless plugins (api-only, hooks-only, cron-only) remain skipped so unknown commands still error correctly with fuzzy-suggest. Community plugins get their default dispatch surface for free.

The default-name fallback is mirrored across every surface that touches plugin CLI metadata so display and dispatch agree:

- `src/cli.ts` — `knownCommands` collection in the unknown-command guard
- `src/plugin/registry-invoke.ts` — `--help` / `--version` output
- `src/commands/shared/plugins-ls-info.ts` — `maw plugin info` output
- `src/commands/shared/plugins-ui.ts` — `maw plugin ls` `surfaces` column

A second small fix: `maw plugin info` no longer prints the false-alarm warning `wasm file missing — plugin will not execute` for `target:js` source plugins. The warning was firing for every healthy community plugin during the install cascade and showed up in #899's reproduction. TS plugins now print an `entry:` line instead, with a `✗ missing` mark only when the entry file actually doesn't exist on disk.

The dispatcher, the unknown-command guard, the help text, the version metadata, and the listing UI all agree on the same `pluginCliNames(p)` helper exported from `dispatch-match.ts`. There is one source of truth for "what does this plugin look like to the CLI?" — adding a future surface (e.g. `maw <name> --completions`) means consulting that one helper rather than re-deriving the rule.

## What changes for users

- `maw shellenv zsh` — now dispatches to the source plugin without needing v0.1.3 republish (the `cli` field becomes optional).
- `maw plugin info shellenv` — shows `entry: ~/.maw/plugins/shellenv/src/index.ts ✓` and `cli: shellenv (default — no explicit cli field)` instead of warning about missing wasm.
- `maw plugin ls` — community plugins surface as `cli:<name>` rather than `—`.
- Built-in plugins keep their existing dispatch path. The `cli` field still overrides `manifest.name` when both differ, so plugins that opted into a custom CLI surface (e.g. `cross-team-queue` → `queue`) only respond to the explicit alias, never to the package name.

## Test plan

- [x] `bun test test/isolated/source-plugin-execution.test.ts` — 13 new cases covering both branches, prefix word boundary, alias passthrough, ambiguity reporting, WASM symmetry, and explicit-cli-overrides-name
- [x] `bun test test/cli/dispatch-match.test.ts` — extended existing "no cli" test with non-dispatchable assertion
- [x] `bun test test/isolated/registry-invoke.test.ts` — version + help output regression unchanged
- [x] `bun test test/isolated/plugin-registry-legacy.test.ts test/isolated/plugin-loader-profile.test.ts test/plugin-registry.test.ts` — loader path unchanged
- [x] `bun test test/isolated/plugins-cli.test.ts test/isolated/plugins-toggle.test.ts test/isolated/plugin-dev-verb.test.ts test/isolated/command-registry-execute.test.ts` — wider plugin surface unaffected
- [ ] Manual smoke: `maw plugin install shellenv` → `maw shellenv zsh` after merge to alpha cuts the next release

Refs #899.