### PR TITLE
test(manifest): #902 — guard tmux/shell in seeded-namespace test (regression guard)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.39",
+  "version": "26.4.29-alpha.40",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/test/plugin-manifest-v1.test.ts
+++ b/test/plugin-manifest-v1.test.ts
@@ -254,6 +254,8 @@ describe("manifest v1 — capabilities", () => {
             "sdk:identity",
             "proc:spawn",
             "ffi:load",
+            "tmux",
+            "shell",
           ],
         }),
         dir,


### PR DESCRIPTION
## Summary

Adds `tmux` and `shell` to the seeded-namespace acceptance test in `test/plugin-manifest-v1.test.ts`. #880 introduced these namespaces into `KNOWN_CAPABILITY_NAMESPACES` but missed updating this test — without the guard, a future cleanup could silently drop them.

## Why this is a test-only PR

#902 turned out NOT to be a source bug. The runtime capability validator at `src/plugin/manifest-validate.ts` already uses `KNOWN_CAPABILITY_NAMESPACES` from `manifest-constants.ts` (single source of truth, with `tmux`+`shell` since #880).

The warnings the user observed came from their locally-installed binary at `/Users/nat/.local/bin/maw` being **alpha.24** (pre-#880), where the bundled namespace list is frozen at the old `["net","fs","peer","sdk","proc","ffi"]`. After binary reinstall, warnings disappear (verified against `/tmp/maw-alpha41` — no warnings printed).

## What this PR adds

- 2-line test addition adding `tmux`/`shell` to the seeded-namespace acceptance assertion
- Regression guard so #880's expanded namespace set stays covered

## Test plan

- [x] `bun test test/plugin-manifest-v1.test.ts` — 15/15 pass
- [ ] CI: test-unit, test-plugin, ecosystem-paths SUCCESS (test-isolated baseline failure expected per #811/#813)

Closes #902.

🤖 Generated with [Claude Code](https://claude.com/claude-code)