### PR TITLE
fix(wake): no bogus host injection on fleet clone (#906)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.42",
+  "version": "26.4.29-alpha.43",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/plugins/init/write-config.ts
+++ b/src/commands/plugins/init/write-config.ts
@@ -44,8 +44,19 @@ export function buildConfig(input: BuildConfigInput): Partial<MawConfig> {
 
   // #680 — ghqRoot is resolved on demand; only persist when caller explicitly
   // passes it (legacy override path; logs deprecation in cmdInit).
+  //
+  // #906 — `host` is the SSH connection target for hostExec, NOT the node
+  // identity. Pre-#906 we wrote `host: input.node`, which made hostExec try
+  // to `ssh <node-name> <cmd>` for every fleet-pinned clone. Concrete blast
+  // radius: any user who ran `maw init --node mba` (or the prompt's default
+  // os.hostname()) had `config.host = "mba"` → wake-resolve-impl's
+  // `hostExec("ghq get …")` failed with `[ssh:mba] ssh: Could not resolve
+  // hostname mba`. The fix is small + surgical: `host` defaults to "local"
+  // (the same fallback DEFAULT_HOST uses when the field is absent), and
+  // `node` keeps the identity. Existing broken configs are healed at load
+  // time — see config/load.ts (#906 migration sibling).
   const cfg: Partial<MawConfig> = {
-    host: input.node,
+    host: "local",
     node: input.node,
     port: DEFAULT_PORT,
     oracleUrl: DEFAULT_ORACLE_URL,

--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -95,6 +95,23 @@ export async function resolveOracle(
   // that exact slug loudly. Do NOT fall through to scan-suggest (which would
   // re-ask for a 24-org scan we already know the answer to).
   if (fleetRepo) {
+    // #906 — re-check ghq for the fleet-pinned repo BEFORE shelling out to
+    // `ghq get`. The earlier `ghqFind(\`/${oracle}-oracle\`)` only matches
+    // by oracle name; a fleet pin can name a repo whose slug differs from
+    // `${oracle}-oracle` (e.g. `mawjs-2 → mawjs-2-oracle` clones fine, but
+    // also any custom repo name). When the manual workaround in #906 ran
+    // `ghq get` outside `maw`, the repo IS on disk but the first ghqFind
+    // miss left us re-cloning every wake. Re-check by the fleet slug's
+    // last segment so the second `maw wake` short-circuits cleanly.
+    const fleetRepoStem = fleetRepo.split("/").pop()!;
+    const existing = await ghqFind(`/${fleetRepoStem}`);
+    if (existing) {
+      return {
+        repoPath: existing,
+        repoName: existing.split("/").pop()!,
+        parentDir: existing.replace(/\/[^/]+$/, ""),
+      };
+    }
     console.log(`\x1b[36m🌱\x1b[0m ${oracle} pinned in fleet → github.com/${fleetRepo} — cloning to ghq...`);
     try {
       await hostExec(`ghq get -u 'github.com/${fleetRepo}'`);
@@ -104,7 +121,7 @@ export async function resolveOracle(
       console.error(`\x1b[90m  manually: ghq get -u 'github.com/${fleetRepo}' && maw wake ${oracle}\x1b[0m`);
       process.exit(1);
     }
-    const cloned = await ghqFind(`/${fleetRepo.split("/").pop()}`);
+    const cloned = await ghqFind(`/${fleetRepoStem}`);
     if (cloned) {
       console.log(`\x1b[32m✓\x1b[0m cloned to ${cloned}`);
       return { repoPath: cloned, repoName: cloned.split("/").pop()!, parentDir: cloned.replace(/\/[^/]+$/, "") };

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -24,6 +24,7 @@ const DEFAULTS: MawConfig = {
 
 let warnedGhqRoot = false;
 let warnedHostMigrated = false;
+let warnedHostNodeConflated = false;
 
 let cached: MawConfig | null = null;
 
@@ -52,6 +53,35 @@ export function loadConfig(): MawConfig {
         `[maw] config.host "${cached.host}" is a bind address, not a connection target. ` +
         `Migrated to config.bind; host reset to "local". ` +
         `(#713 — set "bind" in maw.config.json to silence this warning.)\n`,
+      );
+    }
+    cached.host = "local";
+  }
+  // #906 — heal the host=node conflation bug shipped by `maw init` pre-fix.
+  // Pre-#906 buildConfig wrote `host: input.node`, conflating the SSH
+  // connection target with the node identity. Anyone who ran `maw init`
+  // ended up with `host: "<their-machine-name>"`, which made `hostExec`
+  // attempt `ssh <node-name> <cmd>` on every fleet-pinned clone (the
+  // `lock-trust-node` cryptic error in the wild). The fix in
+  // commands/plugins/init/write-config.ts now writes `host: "local"` for
+  // fresh installs; this migration heals existing broken configs at load
+  // time without operator action: when host === node and host is NOT
+  // already a known-good target ("local"/"localhost"), reset to "local".
+  // We deliberately do NOT touch configs where the operator hand-set
+  // `host` to something other than node — that's a real SSH target.
+  if (
+    typeof cached.host === "string" &&
+    typeof cached.node === "string" &&
+    cached.host === cached.node &&
+    cached.host !== "local" &&
+    cached.host !== "localhost"
+  ) {
+    if (!warnedHostNodeConflated) {
+      warnedHostNodeConflated = true;
+      process.stderr.write(
+        `[maw] config.host "${cached.host}" matches config.node — legacy init bug (#906). ` +
+        `host is the SSH target, not the node identity. Resetting host to "local". ` +
+        `Edit maw.config.json to silence this warning.\n`,
       );
     }
     cached.host = "local";
@@ -91,6 +121,7 @@ export function resetConfig() {
   cached = null;
   warnedGhqRoot = false;
   warnedHostMigrated = false;
+  warnedHostNodeConflated = false;
 }
 
 /**

--- a/test/init-wizard-subprocess.test.ts
+++ b/test/init-wizard-subprocess.test.ts
@@ -77,7 +77,8 @@ describe("maw init --non-interactive — happy path", () => {
     expect(existsSync(r.configPath)).toBe(true);
 
     const cfg = readConfig(r.configPath);
-    expect(cfg.host).toBe("alpha");
+    // #906 — host = SSH connection target (defaults to "local"); node = identity.
+    expect(cfg.host).toBe("local");
     expect(cfg.node).toBe("alpha");
     expect(cfg.ghqRoot).toBe(ghq);
   });
@@ -130,7 +131,8 @@ describe("maw init — node name validation (Q1)", () => {
     const name = "a".repeat(63);
     const r = runInit(["--non-interactive", "--node", name, "--ghq-root", ghq]);
     expect(r.code).toBe(0);
-    expect(readConfig(r.configPath).host).toBe(name);
+    // #906 — assert against `node`, not `host`. host stays "local".
+    expect(readConfig(r.configPath).node).toBe(name);
   });
 
   test("node name starting with hyphen → reject", () => {
@@ -143,7 +145,8 @@ describe("maw init — node name validation (Q1)", () => {
     const ghq = mkdtempSync(join(tmpdir(), "maw-init-ghq-"));
     const r = runInit(["--non-interactive", "--node", "1", "--ghq-root", ghq]);
     expect(r.code).toBe(0);
-    expect(readConfig(r.configPath).host).toBe("1");
+    // #906 — assert against `node`, not `host`. host stays "local".
+    expect(readConfig(r.configPath).node).toBe("1");
   });
 
   test("node name with underscore → reject (hostname-safe regex excludes _)", () => {
@@ -363,7 +366,8 @@ describe("maw init — existing config handling (§ 4a)", () => {
     expect(second.status ?? -1).toBe(0);
 
     const cfg = readConfig(first.configPath);
-    expect(cfg.host).toBe("second");
+    // #906 — assert against `node`. host stays "local" by design.
+    expect(cfg.node).toBe("second");
   });
 
   // #510: --backup flag supported in --non-interactive (spec § 4a).
@@ -387,7 +391,8 @@ describe("maw init — existing config handling (§ 4a)", () => {
     expect(second.status ?? -1).toBe(0);
 
     // New config reflects second run
-    expect(readConfig(first.configPath).host).toBe("second");
+    // #906 — assert against `node`. host stays "local" by design.
+    expect(readConfig(first.configPath).node).toBe("second");
 
     // Some file in the config dir should match the backup pattern
     const entries = readdirSync(first.configDir);

--- a/test/isolated/init-wizard.test.ts
+++ b/test/isolated/init-wizard.test.ts
@@ -78,7 +78,11 @@ describe("cmdInit non-interactive", () => {
     expect(result.ok).toBe(true);
     expect(existsSync(CONFIG_FILE)).toBe(true);
     const cfg = JSON.parse(readFileSync(CONFIG_FILE, "utf-8"));
-    expect(cfg.host).toBe("ci-node");
+    // #906 — host is the SSH connection target ("local" by default), NOT
+    // the node identity. Pre-#906 this asserted `cfg.host === "ci-node"`
+    // which is exactly the bug — `hostExec` would then `ssh ci-node …` on
+    // every fleet-pinned clone.
+    expect(cfg.host).toBe("local");
     expect(cfg.node).toBe("ci-node");
     expect(cfg.ghqRoot).toBe("/tmp/code");
     expect(cfg.port).toBe(3456);
@@ -186,7 +190,9 @@ describe("cmdInit interactive (scripted ask)", () => {
     const result = await cmdInit({ args: [], ask, writer: () => {} });
     expect(result.ok).toBe(true);
     const cfg = JSON.parse(readFileSync(CONFIG_FILE, "utf-8"));
-    expect(cfg.host).toBe("white");
+    // #906 — host is the SSH target ("local"); node is the identity ("white").
+    expect(cfg.host).toBe("local");
+    expect(cfg.node).toBe("white");
     // #680 — ghqRoot is no longer prompted/persisted; resolved on demand via getGhqRoot().
     expect(cfg.ghqRoot).toBeUndefined();
     expect(cfg.env).toEqual({});
@@ -246,7 +252,9 @@ describe("cmdInit interactive (scripted ask)", () => {
     const result = await cmdInit({ args: [], ask, writer: () => {} });
     expect(result.ok).toBe(true);
     const cfg = JSON.parse(readFileSync(CONFIG_FILE, "utf-8"));
-    expect(cfg.host).toBe("fresh");
+    // #906 — host=local; node=fresh.
+    expect(cfg.host).toBe("local");
+    expect(cfg.node).toBe("fresh");
   });
 
   test("backup option writes maw.config.json.bak.<ts> before overwrite", async () => {
@@ -286,7 +294,9 @@ describe("cmdInit interactive (scripted ask)", () => {
     const result = await cmdInit({ args: [], ask, writer: (m) => out.push(m) });
     expect(result.ok).toBe(true);
     const cfg = JSON.parse(readFileSync(CONFIG_FILE, "utf-8"));
-    expect(cfg.host).toBe("myoracle");
+    // #906 — host=local; node=myoracle.
+    expect(cfg.host).toBe("local");
+    expect(cfg.node).toBe("myoracle");
     expect(out.some((l) => l.includes("Node name must be"))).toBe(true);
   });
 });

--- a/test/isolated/wake-clone-host-906.test.ts
+++ b/test/isolated/wake-clone-host-906.test.ts
@@ -1,0 +1,285 @@
+/**
+ * #906 — wake-clone host injection regression suite.
+ *
+ * Symptom (in the wild): `maw a mawjs-2` (auto-wake) on a fleet-pinned
+ * oracle failed with the cryptic
+ *   `[ssh:lock-trust-node] ssh: Could not resolve hostname lock-trust-node`
+ * error. Running `ghq get -u 'github.com/<slug>'` directly from the same
+ * shell succeeded.
+ *
+ * ROOT CAUSE: `buildConfig()` in src/commands/plugins/init/write-config.ts
+ * shipped `host: input.node` for every `maw init` invocation — conflating
+ * the SSH connection target (`config.host`) with the node identity
+ * (`config.node`). `hostExec(cmd)` defaults to `config.host` when no
+ * explicit target is passed; for any user whose init wrote a non-loopback
+ * value (anything other than "local"/"localhost"), the resulting hostExec
+ * call became `ssh <node-name> <cmd>`, which only works if `<node-name>`
+ * happens to be SSH-resolvable.
+ *
+ * The wake call site is wake-resolve-impl.ts:100 —
+ *   `await hostExec(\`ghq get -u 'github.com/${fleetRepo}'\`)`
+ * — so EVERY fleet-pinned auto-clone was at risk. The user's reported
+ * value `lock-trust-node` came from an integration test fixture
+ * (test/integration/plugins-lock-trust.test.ts:148) but the bug applies
+ * universally: `--node mba` → tries `ssh mba ghq get …`, etc.
+ *
+ * This suite locks the fix into source so a future refactor can't regress:
+ *
+ *   1. `buildConfig()` must write `host: "local"` (not the node name).
+ *   2. `loadConfig()` must heal an existing `host === node` config in
+ *      memory by resetting `host` to "local" — silent migration so
+ *      operators with broken disk state recover on next process boot.
+ *   3. `hostExec(cmd, "local")` must spawn `bash -c <cmd>`, NOT
+ *      `ssh local <cmd>` (so the `host: "local"` fallback is genuinely
+ *      no-SSH).
+ *   4. `hostExec(cmd)` with no explicit host must use the local
+ *      transport when `loadConfig().host === "local"`.
+ *   5. The string `lock-trust-node` must NEVER appear in the spawn
+ *      argv for any hostExec call when host=="local".
+ *   6. Migration is idempotent + only triggers when host === node (an
+ *      operator-set explicit SSH target like `host: "mba.wg"` is left
+ *      alone — that's a real connection target, not a conflation).
+ */
+
+import { describe, test, expect, beforeEach, afterAll } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { spawnSync } from "child_process";
+
+import { buildConfig } from "../../src/commands/plugins/init/write-config";
+
+// ─── (1) buildConfig — host must default to "local", not node name ───────────
+
+describe("#906 — buildConfig host/node split", () => {
+  test("host defaults to \"local\" regardless of node name", () => {
+    const cfg = buildConfig({ node: "white" });
+    expect(cfg.host).toBe("local");
+    expect(cfg.node).toBe("white");
+  });
+
+  test("the canary `lock-trust-node` value never bleeds into host", () => {
+    // The string in the wild error came from a test fixture that ran with
+    // --node lock-trust-node. Pre-fix, host would also be "lock-trust-node".
+    // Post-fix, only `node` carries it; `host` stays "local".
+    const cfg = buildConfig({ node: "lock-trust-node" });
+    expect(cfg.host).toBe("local");
+    expect(cfg.host).not.toBe("lock-trust-node");
+    expect(cfg.node).toBe("lock-trust-node");
+  });
+
+  test("federate flag does not change host/node split", () => {
+    const cfg = buildConfig({
+      node: "alpha",
+      federate: true,
+      peers: [{ name: "mba", url: "http://10.0.0.1:3456" }],
+      federationToken: "deadbeef".repeat(8),
+    });
+    expect(cfg.host).toBe("local");
+    expect(cfg.node).toBe("alpha");
+    expect(cfg.namedPeers).toEqual([{ name: "mba", url: "http://10.0.0.1:3456" }]);
+  });
+});
+
+// ─── (2) loadConfig migration — heal existing broken configs in memory ───────
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+
+function runConfigScript(
+  script: string,
+  env: Record<string, string>,
+): { code: number; stdout: string; stderr: string } {
+  const r = spawnSync("bun", ["-e", script], {
+    env: { ...process.env, ...env, MAW_TEST_MODE: "1" },
+    encoding: "utf-8",
+    timeout: 10_000,
+  });
+  return { code: r.status ?? -1, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+}
+
+describe("#906 — loadConfig host=node migration", () => {
+  let tempHomes: string[] = [];
+
+  function newTempHome(diskConfig: Record<string, unknown>): string {
+    const home = mkdtempSync(join(tmpdir(), "maw-906-"));
+    const cfgDir = join(home, "config");
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(join(cfgDir, "maw.config.json"), JSON.stringify(diskConfig, null, 2));
+    tempHomes.push(home);
+    return home;
+  }
+
+  afterAll(() => {
+    for (const h of tempHomes) {
+      try { rmSync(h, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+  });
+
+  test("legacy host=node disk config heals to host=\"local\" in memory", () => {
+    const home = newTempHome({
+      host: "lock-trust-node",
+      node: "lock-trust-node",
+      port: 3456,
+      oracleUrl: "http://localhost:47779",
+      env: {},
+      commands: { default: "claude" },
+      sessions: {},
+    });
+    const script = `
+      const { loadConfig } = await import("${REPO_ROOT}/src/config/load.ts");
+      const cfg = loadConfig();
+      console.log("HOST:" + cfg.host);
+      console.log("NODE:" + cfg.node);
+    `;
+    const { stdout } = runConfigScript(script, { MAW_HOME: home });
+    expect(stdout).toContain("HOST:local");
+    expect(stdout).toContain("NODE:lock-trust-node");
+  });
+
+  test("operator-set explicit SSH target is preserved (host !== node)", () => {
+    const home = newTempHome({
+      host: "mba.wg",
+      node: "white",
+      port: 3456,
+      oracleUrl: "http://localhost:47779",
+      env: {},
+      commands: { default: "claude" },
+      sessions: {},
+    });
+    const script = `
+      const { loadConfig } = await import("${REPO_ROOT}/src/config/load.ts");
+      const cfg = loadConfig();
+      console.log("HOST:" + cfg.host);
+      console.log("NODE:" + cfg.node);
+    `;
+    const { stdout } = runConfigScript(script, { MAW_HOME: home });
+    // host !== node → not a conflation, leave alone.
+    expect(stdout).toContain("HOST:mba.wg");
+    expect(stdout).toContain("NODE:white");
+  });
+
+  test("disk written by post-fix init survives load unchanged", () => {
+    // Simulates a fresh `maw init --node mba`: host=local, node=mba.
+    const home = newTempHome({
+      host: "local",
+      node: "mba",
+      port: 3456,
+      oracleUrl: "http://localhost:47779",
+      env: {},
+      commands: { default: "claude" },
+      sessions: {},
+    });
+    const script = `
+      const { loadConfig } = await import("${REPO_ROOT}/src/config/load.ts");
+      const cfg = loadConfig();
+      console.log("HOST:" + cfg.host);
+      console.log("NODE:" + cfg.node);
+    `;
+    const { stdout } = runConfigScript(script, { MAW_HOME: home });
+    expect(stdout).toContain("HOST:local");
+    expect(stdout).toContain("NODE:mba");
+  });
+});
+
+// ─── (3) hostExec semantics — host="local" must NOT spawn ssh ────────────────
+
+describe("#906 — hostExec local transport never spawns ssh", () => {
+  test("explicit host=\"local\" → bash transport, exit 0", async () => {
+    const { hostExec } = await import("../../src/core/transport/ssh");
+    const out = await hostExec("echo from-bash", "local");
+    expect(out).toBe("from-bash");
+  });
+
+  test("explicit host=\"local\" → error reports local transport, never ssh", async () => {
+    const { hostExec, HostExecError } = await import("../../src/core/transport/ssh");
+    try {
+      await hostExec("exit 7", "local");
+      throw new Error("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(HostExecError);
+      const err = e as InstanceType<typeof HostExecError>;
+      expect(err.transport).toBe("local");
+      // Critical guard: target field MUST NOT be the canary value, since
+      // a passing host="local" call has nothing to do with that string.
+      expect(err.target).not.toBe("lock-trust-node");
+      expect(err.target).toBe("local");
+    }
+  });
+});
+
+// ─── (4) Fleet-pinned wake — clone target never carries a bogus host ─────────
+
+describe("#906 — fleet clone never gets `lock-trust-node` as ssh target", () => {
+  // Pure-source assertion: the wake-resolve-impl.ts call site must use the
+  // unparameterized `hostExec(cmd)` signature, and the DEFAULT_HOST it falls
+  // back to is `process.env.MAW_HOST || loadConfig().host || "local"`. With
+  // the buildConfig + loadConfig fixes, that resolves to "local" for every
+  // post-fix install. We freeze that contract here at the source level
+  // (cheap, deterministic) so a future refactor can't quietly regress to
+  // hard-coding a hostname.
+  test("wake-resolve-impl.ts:100 — `ghq get` is invoked with the default (local) host", () => {
+    const src = readFileSync(
+      join(REPO_ROOT, "src/commands/shared/wake-resolve-impl.ts"),
+      "utf-8",
+    );
+    // The exact failing line in the issue body:
+    expect(src).toContain("await hostExec(`ghq get -u 'github.com/${fleetRepo}'`);");
+    // No second positional argument is being snuck in — that would be
+    // `await hostExec(..., "<bogus>")`. The pattern we forbid:
+    expect(src).not.toMatch(/hostExec\(`ghq get -u[^`]+`,\s*['"]/);
+  });
+
+  test("buildConfig output never lets `host` shadow the node identity", () => {
+    // Walk a representative set of node names — every one must give
+    // host="local". This is the contract that the migration in load.ts
+    // depends on.
+    const cases = ["white", "mba", "lock-trust-node", "alpha", "ci-node", "1"];
+    for (const node of cases) {
+      const cfg = buildConfig({ node });
+      expect({ node, host: cfg.host }).toEqual({ node, host: "local" });
+    }
+  });
+});
+
+// ─── (5) Re-clone short-circuit — second wake after manual ghq get works ─────
+
+describe("#906 — re-cloning short-circuits when fleet repo is on disk", () => {
+  // We can't exercise the full wake path in a unit test (it spawns tmux
+  // and touches the real ghq). But we CAN lock the source-level guard
+  // that issue (B) demands: wake-resolve-impl.ts must call ghqFind on the
+  // fleet repo's stem BEFORE shelling out to `ghq get`. Without this,
+  // running the suggested `manually:` workaround leaves `maw wake` in an
+  // infinite re-clone loop hitting the same error.
+  test("wake-resolve-impl.ts checks ghq for the fleet stem before cloning", () => {
+    const src = readFileSync(
+      join(REPO_ROOT, "src/commands/shared/wake-resolve-impl.ts"),
+      "utf-8",
+    );
+    // Look for the early ghq probe that bypasses the clone when the
+    // fleet-pinned repo is already on disk under its OWN slug (not just
+    // the `${oracle}-oracle` slug that the top-level resolveOracle
+    // already covered).
+    expect(src).toMatch(/fleetRepo\.split\("\/"\)\.pop\(\)!/);
+    // The early-return guard: if existing path is found, return without
+    // calling hostExec (which would re-clone and re-hit the bug).
+    const earlyReturnRegion = src.slice(
+      src.indexOf("if (fleetRepo) {"),
+      src.indexOf("await hostExec(`ghq get -u 'github.com/"),
+    );
+    expect(earlyReturnRegion).toContain("ghqFind");
+    expect(earlyReturnRegion).toContain("return");
+  });
+});
+
+// Sanity: this test file itself never spawns ssh.
+test("#906 — this test file never invokes the ssh binary", () => {
+  // Source-level grep so a future refactor can't sneak ssh in.
+  const self = readFileSync(__filename, "utf-8");
+  // The literal token must not appear as a spawn argv element. The file
+  // does mention "ssh" in prose / type names, so we look for the spawn
+  // shape specifically.
+  expect(self).not.toMatch(/spawn(?:Sync)?\(\s*["']ssh["']/);
+  expect(self).not.toMatch(/Bun\.spawn\(\s*\[\s*["']ssh["']/);
+  // Reaffirm: existsSync is imported (used in the migration test setup).
+  expect(typeof existsSync).toBe("function");
+});


### PR DESCRIPTION
## Summary

Fixes #906 — `maw a <oracle>` (auto-wake) on a fleet-pinned oracle failed with a cryptic `[ssh:lock-trust-node] ssh: Could not resolve hostname lock-trust-node` error. Running `ghq get` directly in the same shell succeeded, so the bug had to be in how maw spawned the subprocess.

## Root cause

`buildConfig()` in `src/commands/plugins/init/write-config.ts:48` shipped `host: input.node` — conflating the SSH connection target (`config.host`) with the node identity (`config.node`). They are different concerns:

- `config.host` is read by `hostExec(cmd)` as the default SSH target. When it equals `"local"` / `"localhost"`, hostExec spawns `bash -c <cmd>`. Otherwise it spawns `ssh <host> <cmd>`.
- `config.node` is the federation identity (e.g. `"white"`, `"mba"`) — what other peers route to.

The conflation meant **every user who ever ran `maw init`** got a config like `{ host: "<machine>", node: "<machine>" }`. Then `wake-resolve-impl.ts:100`'s `await hostExec(\`ghq get -u 'github.com/${fleetRepo}'\`)` became `ssh <machine> ghq get …`, which fails unless the machine name happens to be SSH-resolvable. The reported `lock-trust-node` came from `test/integration/plugins-lock-trust.test.ts:148` (a fixture passing `--node lock-trust-node`), but the same bug bites any node name.

The greps in the issue body looked clean because the fix was a missing field, not a stray string — there was no literal `"lock-trust-node"` in source/dist; the value flowed in from disk config.

## Fix

Three surgical changes:

1. **`src/commands/plugins/init/write-config.ts`** — `buildConfig()` now writes `host: "local"`. The `node` field continues to carry identity. Fresh installs are unbreakable.

2. **`src/config/load.ts`** — in-memory migration: when a loaded config has `host === node` AND host isn't `"local"`/`"localhost"`, reset `host` to `"local"` with a one-shot warning. This silently heals every existing broken disk config on next process boot. Operator-set explicit SSH targets (`host !== node`, e.g. `host: "mba.wg"`) are left alone.

3. **`src/commands/shared/wake-resolve-impl.ts`** — added the issue's suggested early ghqFind on the fleet repo's slug stem before shelling out. Without this, the `manually:` workaround in the original error message looped: `ghq get` succeeded but the next `maw wake` re-cloned and re-hit the bug. The early check covers fleet-pinned slugs that don't match `${oracle}-oracle` (the only stem the top-level resolveOracle already checked).

## Tests

- **New**: `test/isolated/wake-clone-host-906.test.ts` — 12 assertions across:
  - buildConfig output contract (`host: "local"` for every node name, including the canary `"lock-trust-node"`).
  - loadConfig migration (subprocess-driven so `core/paths.ts` re-evaluates under fresh `MAW_HOME`).
  - hostExec local transport never spawning `ssh`.
  - Source-level guard on `wake-resolve-impl.ts:100` that the call site stays unparameterized.
  - Source-level guard that the early ghqFind probe lives between `if (fleetRepo) {` and the `ghq get` shellout.
- **Updated**: `test/isolated/init-wizard.test.ts` (5 cases) + `test/init-wizard-subprocess.test.ts` (5 cases) to assert against `cfg.node` for identity and `cfg.host === "local"` for the SSH target.

All 62 targeted tests pass (5 files, 181 assertions).

## Calver

`v26.4.29-alpha.42` → `v26.4.29-alpha.43` (handled by `bun scripts/calver.ts`).

## Test plan

- [ ] CI green on alpha-targeted PR
- [ ] On a host with the broken config (`host === node`, e.g. `host: "white"`): run `maw a <fleet-pinned-oracle>` — should print the migration warning + clone via local bash, no SSH attempt
- [ ] Fresh `maw init --node <anything>`: inspect `~/.config/maw/maw.config.json`, confirm `host: "local"` + `node: "<anything>"`
- [ ] Issue (B) workaround: `ghq get -u 'github.com/<slug>' && maw wake <oracle>` — second wake short-circuits via ghqFind, no re-clone

🤖 Generated with [Claude Code](https://claude.com/claude-code)