### PR TITLE
fix(config): persist migration to disk after host=node detection (#913)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.44",
+  "version": "26.4.29-alpha.45",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -31,6 +31,13 @@ let cached: MawConfig | null = null;
 /** Bind-address values that should never appear as an outbound target (#713). */
 const BIND_ADDRESSES = new Set(["0.0.0.0", "::", "", "127.0.0.1", "localhost"]);
 
+/**
+ * #820 — sentinel: the real homedir config path. Both `saveConfig` and the
+ * #913 migration-persist path use this to refuse disk writes when the test
+ * harness forgot to set MAW_HOME / MAW_CONFIG_DIR.
+ */
+const REAL_HOME_CONFIG = join(homedir(), ".config", "maw", "maw.config.json");
+
 export function loadConfig(): MawConfig {
   if (cached) return cached;
   try {
@@ -69,6 +76,15 @@ export function loadConfig(): MawConfig {
   // already a known-good target ("local"/"localhost"), reset to "local".
   // We deliberately do NOT touch configs where the operator hand-set
   // `host` to something other than node — that's a real SSH target.
+  //
+  // #913 — persist the migration to disk. #912 only mutated the in-memory
+  // `cached` object, which left the broken value on disk for any future
+  // process to re-load. In production this manifested as the warning
+  // printing every wake AND the clone still failing in subtle module-load
+  // order paths (e.g. ssh.ts's module-level `DEFAULT_HOST` captured before
+  // migration in some import graphs). Persisting on detection makes the
+  // heal one-shot: first run prints the warning + writes "local" to disk;
+  // every subsequent run loads a clean config, no warning, no surprise.
   if (
     typeof cached.host === "string" &&
     typeof cached.node === "string" &&
@@ -85,6 +101,25 @@ export function loadConfig(): MawConfig {
       );
     }
     cached.host = "local";
+    // #913 — persist heal to disk so the next process / subprocess loads
+    // clean state. Skip when MAW_TEST_MODE=1 AND the config path resolves
+    // to the real homedir — that combination signals a test harness that
+    // forgot to sandbox MAW_HOME (mirrors the #820 saveConfig guard).
+    // Tests that DO sandbox via MAW_HOME=<tmpdir> still get the persist
+    // (which is exactly what we want — they verify the disk write).
+    if (!(process.env.MAW_TEST_MODE === "1" && CONFIG_FILE === REAL_HOME_CONFIG)) {
+      try {
+        writeFileSync(CONFIG_FILE, JSON.stringify(cached, null, 2) + "\n", "utf-8");
+      } catch (e) {
+        // Defensive — a persist failure (read-only FS, perms) must NOT
+        // break loadConfig. The in-memory heal still applies for this
+        // process; the warning will fire again next boot.
+        process.stderr.write(
+          `[maw] config.host migration: in-memory heal applied but disk persist failed: ` +
+          `${e instanceof Error ? e.message : String(e)}\n`,
+        );
+      }
+    }
   }
   // #736 Phase 1.1 — pre-populate config.agents from fleet at loadConfig time
   // so federation routing (`maw hey <oracle>`) sees fleet-known targets even
@@ -136,8 +171,10 @@ export function resetConfig() {
  * MUST refuse to write to the real homedir config path. The test harness is
  * expected to set `MAW_HOME` or `MAW_CONFIG_DIR` to a tmpdir; if that's not
  * done, throw loudly rather than silently corrupting state.
+ *
+ * The `REAL_HOME_CONFIG` sentinel is declared at module-top so the #913
+ * migration-persist path in `loadConfig` can share the same guard.
  */
-const REAL_HOME_CONFIG = join(homedir(), ".config", "maw", "maw.config.json");
 
 export function saveConfig(update: Partial<MawConfig>) {
   if (process.env.MAW_TEST_MODE === "1" && CONFIG_FILE === REAL_HOME_CONFIG) {

--- a/test/isolated/migration-persist-913.test.ts
+++ b/test/isolated/migration-persist-913.test.ts
@@ -1,0 +1,349 @@
+/**
+ * #913 — host=node migration MUST persist to disk.
+ *
+ * #912 added an in-memory heal in `loadConfig()` that detects the
+ * legacy `host === node` corruption (#906), prints a warning, and
+ * resets `cached.host = "local"`. But the broken value stayed on
+ * disk, so:
+ *
+ *   - every fresh process re-loaded the bad config,
+ *   - the warning fired again every wake,
+ *   - subtle module-load orderings (e.g. ssh.ts capturing
+ *     `DEFAULT_HOST` from `loadConfig().host` before the migration
+ *     mutation reached the import graph that needed it) could still
+ *     deliver the original `[ssh:lock-trust-node]` error.
+ *
+ * #913 fixes this by writing the healed config back to disk inside
+ * `loadConfig()`, with one exception: when MAW_TEST_MODE=1 AND the
+ * resolved CONFIG_FILE equals the real homedir path, the persist is
+ * skipped (mirrors the #820 saveConfig guard against test-fixture
+ * leaks into developer state).
+ *
+ * Each scenario runs in a fresh `bun -e` subprocess so paths.ts gets
+ * re-evaluated under the right env (the same pattern used by
+ * #906 / #820 isolated tests).
+ */
+
+import { describe, test, expect, afterAll } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync, existsSync } from "fs";
+import { tmpdir, homedir } from "os";
+import { join } from "path";
+import { spawnSync } from "child_process";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+
+function newTempHome(diskConfig: Record<string, unknown>, tracker: string[]): string {
+  const home = mkdtempSync(join(tmpdir(), "maw-913-"));
+  const cfgDir = join(home, "config");
+  mkdirSync(cfgDir, { recursive: true });
+  writeFileSync(join(cfgDir, "maw.config.json"), JSON.stringify(diskConfig, null, 2));
+  tracker.push(home);
+  return home;
+}
+
+function configPathFor(home: string): string {
+  return join(home, "config", "maw.config.json");
+}
+
+function runScript(
+  script: string,
+  env: Record<string, string>,
+  opts: { testMode?: boolean } = {},
+): { code: number; stdout: string; stderr: string } {
+  const baseEnv = { ...process.env, ...env };
+  if (opts.testMode === true) baseEnv.MAW_TEST_MODE = "1";
+  if (opts.testMode === false) delete baseEnv.MAW_TEST_MODE;
+  const r = spawnSync("bun", ["-e", script], {
+    env: baseEnv,
+    encoding: "utf-8",
+    timeout: 10_000,
+  });
+  return { code: r.status ?? -1, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+}
+
+const tempHomes: string[] = [];
+
+afterAll(() => {
+  for (const h of tempHomes) {
+    try { rmSync(h, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+});
+
+const BAD_CONFIG = {
+  host: "lock-trust-node",
+  node: "lock-trust-node",
+  port: 3456,
+  oracleUrl: "http://localhost:47779",
+  env: {},
+  commands: { default: "claude" },
+  sessions: {},
+};
+
+// ─── (1) Production path — migration writes back to disk ─────────────────────
+
+describe("#913 — migration persists to disk in production", () => {
+  test("bad config on disk → load → migration runs → disk is healed", () => {
+    const home = newTempHome(BAD_CONFIG, tempHomes);
+    const cfgPath = configPathFor(home);
+
+    // Sanity: precondition is the broken value.
+    const before = JSON.parse(readFileSync(cfgPath, "utf-8"));
+    expect(before.host).toBe("lock-trust-node");
+
+    const script = `
+      const { loadConfig } = await import("${REPO_ROOT}/src/config/load.ts");
+      const cfg = loadConfig();
+      console.log("HOST:" + cfg.host);
+    `;
+    const { stdout, stderr } = runScript(script, { MAW_HOME: home }, { testMode: false });
+
+    expect(stdout).toContain("HOST:local");
+    expect(stderr).toContain("legacy init bug (#906)");
+
+    // Disk MUST now reflect the heal.
+    const after = JSON.parse(readFileSync(cfgPath, "utf-8"));
+    expect(after.host).toBe("local");
+    expect(after.node).toBe("lock-trust-node"); // node identity preserved
+  });
+
+  test("subsequent load → no warning (already migrated on disk)", () => {
+    const home = newTempHome(BAD_CONFIG, tempHomes);
+
+    // First load — heals + warns + persists.
+    const first = runScript(
+      `await import("${REPO_ROOT}/src/config/load.ts").then(m => m.loadConfig());`,
+      { MAW_HOME: home },
+      { testMode: false },
+    );
+    expect(first.stderr).toContain("legacy init bug (#906)");
+
+    // Second load — fresh process, fresh module — disk is already healed.
+    const script = `
+      const { loadConfig } = await import("${REPO_ROOT}/src/config/load.ts");
+      const cfg = loadConfig();
+      console.log("HOST:" + cfg.host);
+    `;
+    const second = runScript(script, { MAW_HOME: home }, { testMode: false });
+
+    expect(second.stdout).toContain("HOST:local");
+    expect(second.stderr).not.toContain("legacy init bug (#906)");
+  });
+
+  test("preserves all other config fields when persisting", () => {
+    const home = newTempHome({
+      ...BAD_CONFIG,
+      port: 4242,
+      oracleUrl: "http://example.invalid:47779",
+      env: { FOO: "bar" },
+    }, tempHomes);
+    const cfgPath = configPathFor(home);
+
+    runScript(
+      `await import("${REPO_ROOT}/src/config/load.ts").then(m => m.loadConfig());`,
+      { MAW_HOME: home },
+      { testMode: false },
+    );
+
+    const after = JSON.parse(readFileSync(cfgPath, "utf-8"));
+    expect(after.host).toBe("local");
+    expect(after.port).toBe(4242);
+    expect(after.oracleUrl).toBe("http://example.invalid:47779");
+    expect(after.env).toEqual({ FOO: "bar" });
+    expect(after.node).toBe("lock-trust-node");
+  });
+});
+
+// ─── (2) #820 guard — refuse persist when test-mode points at real homedir ───
+
+describe("#913 — MAW_TEST_MODE guard mirrors #820 saveConfig contract", () => {
+  test("MAW_TEST_MODE=1 + sandboxed MAW_HOME → still persists (sandbox is safe)", () => {
+    const home = newTempHome(BAD_CONFIG, tempHomes);
+    const cfgPath = configPathFor(home);
+
+    const script = `
+      const { loadConfig } = await import("${REPO_ROOT}/src/config/load.ts");
+      const cfg = loadConfig();
+      console.log("HOST:" + cfg.host);
+    `;
+    const { stdout } = runScript(script, { MAW_HOME: home }, { testMode: true });
+
+    expect(stdout).toContain("HOST:local");
+    // Sandbox got the persist — that's what tests want to assert against.
+    const after = JSON.parse(readFileSync(cfgPath, "utf-8"));
+    expect(after.host).toBe("local");
+  });
+
+  test("MAW_TEST_MODE=1 + CONFIG_FILE at real homedir → in-memory heal only, no disk write", () => {
+    // We simulate the dangerous combo (test mode without sandbox) by
+    // unsetting MAW_HOME and MAW_CONFIG_DIR. Crucially we DO NOT write
+    // a bad config to the real homedir — instead we verify that the
+    // guard refuses to write at all in that combination.
+    const realPath = join(homedir(), ".config", "maw", "maw.config.json");
+    const before = existsSync(realPath) ? readFileSync(realPath, "utf-8") : null;
+
+    const script = `
+      delete process.env.MAW_HOME;
+      delete process.env.MAW_CONFIG_DIR;
+      const { CONFIG_FILE } = await import("${REPO_ROOT}/src/core/paths.ts");
+      // Print the resolved CONFIG_FILE so the test can sanity-check the
+      // env actually pointed at the real homedir.
+      console.log("CFG:" + CONFIG_FILE);
+      const { loadConfig } = await import("${REPO_ROOT}/src/config/load.ts");
+      try {
+        const cfg = loadConfig();
+        console.log("HOST:" + cfg.host);
+      } catch (e) {
+        // loadConfig must NOT throw — only saveConfig throws under #820.
+        console.log("UNEXPECTED_THROW:" + (e instanceof Error ? e.message : String(e)));
+      }
+    `;
+    const { stdout } = runScript(script, { MAW_HOME: "", MAW_CONFIG_DIR: "" }, { testMode: true });
+
+    // If the real homedir does not have a host=node corruption, the
+    // migration block never fires and there's no persist to skip — the
+    // test still passes (no UNEXPECTED_THROW). The critical invariant
+    // is defense-in-depth: even if the real config WAS corrupt, we
+    // would not have written to it under test mode.
+    expect(stdout).not.toContain("UNEXPECTED_THROW");
+    expect(stdout).toContain("CFG:" + realPath);
+
+    // Hard guarantee: real file must not have changed.
+    const after = existsSync(realPath) ? readFileSync(realPath, "utf-8") : null;
+    expect(after).toBe(before);
+  });
+});
+
+// ─── (3) Negative cases — non-conflated configs are not touched ──────────────
+
+describe("#913 — only host===node configs are persisted", () => {
+  test("operator-set explicit SSH target (host !== node) → no rewrite", () => {
+    const diskConfig = {
+      host: "mba.wg",
+      node: "white",
+      port: 3456,
+      oracleUrl: "http://localhost:47779",
+      env: {},
+      commands: { default: "claude" },
+      sessions: {},
+    };
+    const home = newTempHome(diskConfig, tempHomes);
+    const cfgPath = configPathFor(home);
+    const beforeRaw = readFileSync(cfgPath, "utf-8");
+
+    const script = `
+      const { loadConfig } = await import("${REPO_ROOT}/src/config/load.ts");
+      const cfg = loadConfig();
+      console.log("HOST:" + cfg.host);
+    `;
+    const { stdout, stderr } = runScript(script, { MAW_HOME: home }, { testMode: false });
+
+    expect(stdout).toContain("HOST:mba.wg");
+    expect(stderr).not.toContain("legacy init bug (#906)");
+
+    // Disk untouched — no migration ran, no rewrite.
+    const afterRaw = readFileSync(cfgPath, "utf-8");
+    expect(afterRaw).toBe(beforeRaw);
+  });
+
+  test("post-fix init disk (host=local, node=mba) → no rewrite", () => {
+    const diskConfig = {
+      host: "local",
+      node: "mba",
+      port: 3456,
+      oracleUrl: "http://localhost:47779",
+      env: {},
+      commands: { default: "claude" },
+      sessions: {},
+    };
+    const home = newTempHome(diskConfig, tempHomes);
+    const cfgPath = configPathFor(home);
+    const beforeRaw = readFileSync(cfgPath, "utf-8");
+
+    runScript(
+      `await import("${REPO_ROOT}/src/config/load.ts").then(m => m.loadConfig());`,
+      { MAW_HOME: home },
+      { testMode: false },
+    );
+
+    const afterRaw = readFileSync(cfgPath, "utf-8");
+    expect(afterRaw).toBe(beforeRaw);
+  });
+});
+
+// ─── (4) hostExec uses the freshly-persisted value, not stale state ──────────
+
+describe("#913 — hostExec sees migrated host on next process boot", () => {
+  test("after migration persists, ssh.ts DEFAULT_HOST resolves to \"local\"", () => {
+    const home = newTempHome(BAD_CONFIG, tempHomes);
+
+    // Step 1 — first boot heals + persists.
+    runScript(
+      `await import("${REPO_ROOT}/src/config/load.ts").then(m => m.loadConfig());`,
+      { MAW_HOME: home },
+      { testMode: false },
+    );
+
+    // Step 2 — fresh boot imports ssh.ts, which captures DEFAULT_HOST
+    // at module init from `process.env.MAW_HOST || loadConfig().host`.
+    // We unset MAW_HOST explicitly so the disk value is the only signal.
+    const script = `
+      delete process.env.MAW_HOST;
+      const { hostExec } = await import("${REPO_ROOT}/src/core/transport/ssh.ts");
+      // Run with no host argument — uses DEFAULT_HOST. If migration
+      // persisted, DEFAULT_HOST is "local" → bash transport → echo works.
+      // If migration did NOT persist, DEFAULT_HOST would still be
+      // "lock-trust-node" → ssh transport → resolve failure.
+      const out = await hostExec("echo from-bash");
+      console.log("OUT:" + out);
+    `;
+    const { stdout, stderr } = runScript(
+      script,
+      { MAW_HOME: home },
+      { testMode: false },
+    );
+
+    expect(stdout).toContain("OUT:from-bash");
+    // No ssh resolve error in stderr.
+    expect(stderr).not.toContain("Could not resolve hostname");
+    expect(stderr).not.toContain("lock-trust-node");
+  });
+
+  test("acceptance criterion: second `maw a <oracle>` would not re-warn", () => {
+    // Mirrors the issue-913 acceptance test: after one process boots
+    // and heals, the file on disk has host=local, and a second process
+    // boot prints no migration warning.
+    const home = newTempHome(BAD_CONFIG, tempHomes);
+    const cfgPath = configPathFor(home);
+
+    const first = runScript(
+      `await import("${REPO_ROOT}/src/config/load.ts").then(m => m.loadConfig());`,
+      { MAW_HOME: home },
+      { testMode: false },
+    );
+    expect(first.stderr).toContain("legacy init bug (#906)");
+
+    // Disk acceptance check from the issue body.
+    const persisted = JSON.parse(readFileSync(cfgPath, "utf-8"));
+    expect(persisted.host).toBe("local");
+
+    // Second boot is silent.
+    const second = runScript(
+      `await import("${REPO_ROOT}/src/config/load.ts").then(m => m.loadConfig());`,
+      { MAW_HOME: home },
+      { testMode: false },
+    );
+    expect(second.stderr).not.toContain("legacy init bug (#906)");
+  });
+});
+
+// ─── (5) Source-level guard — the persist branch lives inside loadConfig ─────
+
+test("#913 — load.ts contains a writeFileSync inside the host=node migration block", () => {
+  const src = readFileSync(join(REPO_ROOT, "src/config/load.ts"), "utf-8");
+  // The fix must call writeFileSync after setting cached.host = "local"
+  // in the host=node branch. We check the structural pattern rather
+  // than exact whitespace so a future refactor can rearrange comments.
+  expect(src).toMatch(/cached\.host = "local";[\s\S]*writeFileSync\(CONFIG_FILE/);
+  // The #820-style guard must wrap the persist.
+  expect(src).toMatch(/MAW_TEST_MODE.*REAL_HOME_CONFIG/);
+});


### PR DESCRIPTION
## Closes #913

#912 (alpha.44) shipped an in-memory heal for the #906 host=node corruption: when `loadConfig()` detects `config.host === config.node`, the cache is rewritten to `host: "local"` and a one-shot warning fires. But the broken value stayed on disk. m5 reported the warning printed correctly while the clone STILL failed with the original `[ssh:lock-trust-node]` resolve error.

## Root cause

`#912` mutated the cache, never the file.

Three hypotheses were on the table:

1. **Migration doesn't persist to disk** — confirmed.
2. `hostExec` subprocess captures `lock-trust-node` from env — not the case; `hostExec` shells `bash -c <cmd>` for `host=local`, no env leakage.
3. `ghq` reads its own config — irrelevant; the `[ssh:lock-trust-node]` prefix is from `HostExecError` in `src/core/transport/ssh.ts`, so the bad value was being passed by maw itself.

The mechanism that lets a bad in-memory heal still produce the SSH error is module-load order: `src/core/transport/ssh.ts:4` captures `DEFAULT_HOST = process.env.MAW_HOST || loadConfig().host || "local"` at import time. Within a single process, `loadConfig()` runs migration before returning, so `DEFAULT_HOST` should resolve to `"local"`. But across process boundaries — and in any path where the config gets re-parsed by another tool — the disk truth wins. Without disk persist, every wake had to redo the migration in memory and hope the import graph cooperated.

## Fix

`src/config/load.ts` — after the in-memory reset of `cached.host = "local"`, write the healed config back to disk:

```ts
if (!(process.env.MAW_TEST_MODE === "1" && CONFIG_FILE === REAL_HOME_CONFIG)) {
  try {
    writeFileSync(CONFIG_FILE, JSON.stringify(cached, null, 2) + "\n", "utf-8");
  } catch (e) { /* surface, don't break load */ }
}
```

The persist is wrapped in the same `#820`-style guard `saveConfig` already uses: it is skipped only when `MAW_TEST_MODE=1` AND the resolved `CONFIG_FILE` equals the real homedir path. That's the single combination `#820` defends against (test fixture leaks into developer state). Sandboxed tests (`MAW_HOME=<tmpdir>`) still get the persist — which is exactly what tests want to assert against.

Failures of `writeFileSync` (read-only FS, perms) are non-fatal: the in-memory heal still applies for the current process, and a second warning is surfaced so operators can fix permissions and let the next boot retry.

The `REAL_HOME_CONFIG` sentinel was lifted to module-top so both `saveConfig` and the `loadConfig` migration path share the same reference.

## Tests

`test/isolated/migration-persist-913.test.ts` — 10 cases across 5 suites:

1. **Production path** — bad config heals on disk; subsequent loads are silent; unrelated fields preserved.
2. **#820 guard parity** — sandboxed `MAW_TEST_MODE=1` still persists; unsandboxed test mode never touches the real homedir.
3. **Negative cases** — `host !== node` SSH targets and post-fix init disks are not rewritten.
4. **hostExec sees migrated value on next boot** — fresh subprocess loads healed disk → `DEFAULT_HOST = "local"` → bash transport works → no `Could not resolve hostname` error.
5. **Source-level guard** — `writeFileSync` lives inside the host=node branch and is wrapped by the `MAW_TEST_MODE` / `REAL_HOME_CONFIG` check.

All 10 pass. Existing #906 (10 tests) and #820 (2 tests) suites still green.

## Acceptance (from issue body)

- [x] After `maw a mawjs-2`, `maw.config.json` has `host: "local"` on disk.
- [x] Second run clones cleanly, no warning, no `lock-trust-node`.
- [x] `cat ~/.maw/maw.config.json` confirms persisted fix.

## Bump

`package.json`: `26.4.29-alpha.44 → 26.4.29-alpha.45` (alpha channel, monotonic per #766).

## Cross-refs

- #906 — original `host=node` bug
- #912 — partial fix (in-memory only) this PR completes
- #820 — `saveConfig` test-mode guard whose pattern this PR mirrors