### PR TITLE
feat(scripts): preflight script + local-build-first docs (#911)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,12 +14,15 @@ Bun v1.3+ is required. tmux is needed for multi-agent features. On Linux, `ssh` 
 
 ## Before opening a PR
 
-1. `bun run test:all` passes locally.
-2. New code has tests. If the code path is integration-only (spawns a subprocess, sets a timer, listens for a signal), document why in the test file.
-3. New `mock.module(...)` calls live in `test/isolated/` or `test/helpers/` (see `scripts/check-mock-boundary.sh`).
-4. If you added a new export to `src/core/transport/ssh.ts` or `src/config/*`, update the canonical mock in `test/helpers/mock-*.ts` (see `scripts/check-mock-export-sync.sh`).
-5. **Run `bun run check:redos`** — pre-flight ReDoS scan that catches the most common polynomial-backtracking shapes before CI's CodeQL job does. See [ReDoS pre-flight](#redos-pre-flight) below.
-6. Commits follow [Conventional Commits](https://www.conventionalcommits.org/) — `feat:`, `fix:`, `chore:`, `test:`, `docs:`.
+1. **Run `bun run preflight`** — local-build-first sanity check (~10s). Builds `dist/maw` and smoke-tests the actual binary. Catches the obvious failures before you pay the GitHub Actions tax. See [docs/process/local-build-first.md](./docs/process/local-build-first.md) — and read it once for the bundle-grep false-positive trap that birthed the script ([#911](https://github.com/Soul-Brews-Studio/maw-js/issues/911)).
+2. `bun run test:all` passes locally.
+3. New code has tests. If the code path is integration-only (spawns a subprocess, sets a timer, listens for a signal), document why in the test file.
+4. New `mock.module(...)` calls live in `test/isolated/` or `test/helpers/` (see `scripts/check-mock-boundary.sh`).
+5. If you added a new export to `src/core/transport/ssh.ts` or `src/config/*`, update the canonical mock in `test/helpers/mock-*.ts` (see `scripts/check-mock-export-sync.sh`).
+6. **Run `bun run check:redos`** — pre-flight ReDoS scan that catches the most common polynomial-backtracking shapes before CI's CodeQL job does. See [ReDoS pre-flight](#redos-pre-flight) below.
+7. Commits follow [Conventional Commits](https://www.conventionalcommits.org/) — `feat:`, `fix:`, `chore:`, `test:`, `docs:`.
+
+> **Don't trust grep on minified Bun bundles.** `bun build --minify` renames identifiers and dead-strips strings, so `strings dist/maw | grep <symbol>` is a false-negative trap. Run the binary instead — that's what `bun run preflight` does. See [docs/process/local-build-first.md](./docs/process/local-build-first.md).
 
 ## ReDoS pre-flight
 

--- a/docs/process/local-build-first.md
+++ b/docs/process/local-build-first.md
@@ -1,0 +1,154 @@
+# Local-build-first
+
+> **Run the binary, don't grep the bundle.**
+> Filed after the [#911](https://github.com/Soul-Brews-Studio/maw-js/issues/911) post-mortem.
+
+## TL;DR
+
+Before you push, before you open a PR, before you claim "fixed":
+
+```bash
+bun run preflight
+```
+
+That runs `bun run build` and smoke-tests `dist/maw` in ~10 seconds. If it
+passes, you have actual evidence the binary works. If it fails, you have a
+real failure to investigate — not a CI mystery 5 minutes later.
+
+CI still runs the authoritative `test:all` suite. Preflight is opt-in
+augmentation, not a replacement.
+
+## Why this exists
+
+On 2026-04-29, the registry-monorepo migration paid the GitHub Actions tax
+**7+ times** (alpha.41 → alpha.44 plus intermediate failures), each cycle
+~3-7 min. The whole detour was caused by one false-negative grep.
+
+The chain:
+
+1. A verifier ran `strings dist/maw | grep -c monorepo`. It returned 0.
+2. The verifier ABORTed reporting "alpha.43 binary missing #908 handler."
+3. Emergency PR #909 cut alpha.44 to "force fresh build."
+4. Turns out alpha.43 was fine all along. The grep was wrong.
+
+Total wasted: ~30 min on phantom panic + a redundant alpha cut + the noise
+in the version stream. The fix would have been instant if anyone had run
+`./dist/maw plugin install shellenv` locally before merging #908.
+
+## Why grep on a Bun bundle is a false-positive trap
+
+`bun build --minify` (which the project uses for `dist/maw`) does two
+things that defeat naive grep:
+
+1. **Identifier renaming.** Function names like `parseMonorepoRef` get
+   renamed to 1-char vars (`a`, `b`, `c`). The original symbol name is
+   gone from the bundle.
+2. **Dead-string elimination.** String literals only used inside dead-
+   stripped code paths get removed entirely. Comment-strings drop. Even
+   live strings can be inlined and concatenated past recognition.
+
+So when you run:
+
+```bash
+strings dist/maw | grep -c parseMonorepoRef    # → 0
+```
+
+That **0 is not evidence the symbol is missing**. The symbol is almost
+certainly present, just renamed. You proved nothing.
+
+The right test is:
+
+```bash
+./dist/maw plugin install monorepo-thing       # actually exercises the path
+```
+
+If the binary actually parses a monorepo ref, the handler is present —
+no matter what `strings` claims.
+
+> **Rule:** Never trust `strings dist/maw | grep <symbol>` as evidence the
+> symbol is or isn't in the bundle. Run the binary instead. Behavior is the
+> only oracle.
+
+This same trap caught us earlier on #902/#904 — same shape, different
+symbol. It's worth filing the rule once and pointing future-us back here.
+
+## When to run preflight
+
+| When | Why |
+|---|---|
+| **Before `git push`** | Catches build break + obvious smoke fail in 10s |
+| **Before opening a PR** | CI passes faster when the obvious things are already green |
+| **Before claiming "fixed"** | You ran the binary; you actually know |
+| **After a registry / install path change** | Run with `--install <name>` for the full round-trip |
+| **When CI says `binary missing X` and you're tempted to force-rebuild** | Run preflight first. It's faster than another 5-min CI cycle. |
+
+Skip preflight when:
+
+- Docs-only changes
+- CI config or YAML-only changes
+- Pure-text PRs where there's no binary surface to smoke
+
+Use judgment. The tax is ~10 sec; not running it is rarely worth ~5 min in
+CI.
+
+## What preflight actually does
+
+```bash
+bun run preflight
+# → bun run build         (silent unless fails)
+# → dist/maw --version    (smoke)
+# → dist/maw plugin --help (smoke)
+# → "Local-build OK; safe to push"
+```
+
+With `--install <plugin>` it adds a full install round-trip against the
+live registry:
+
+```bash
+bun run preflight -- --install shellenv
+# → bun run build
+# → dist/maw plugin install shellenv     (real network, real registry)
+# → dist/maw --version
+# → dist/maw plugin --help
+# → "Local-build OK; safe to push"
+```
+
+This is the test that would have caught #908 before #909 ever shipped.
+
+## CDN cache propagation gotcha
+
+The plugin registry is served from `raw.githubusercontent.com`, which
+caches aggressively (~5 min propagation). After you push a registry
+update:
+
+- The registry.json HEAD on GitHub is up-to-date instantly.
+- `raw.githubusercontent.com/.../registry.json` may serve the **previous**
+  version for ~5 min.
+- A verifier that hits raw immediately after the push gets stale data.
+
+Mitigations when running verification scripts (not preflight — preflight
+hits your local build, not the registry):
+
+- `MAW_REGISTRY_URL='https://raw.githubusercontent.com/.../registry.json?bust=$(date +%s)'`
+  — query-string busts the CDN entry per-call.
+- Fetch via `gh api` — bypasses the CDN entirely.
+- Sleep 5 min after a registry push before running install verifiers.
+
+This bit us on top of the bundle-grep issue: a stale registry response
+during the alpha.43 panic made the verifier doubly confused. Don't repeat
+the mistake.
+
+## See also
+
+- [#911](https://github.com/Soul-Brews-Studio/maw-js/issues/911) — the
+  post-mortem that birthed this script
+- [#909](https://github.com/Soul-Brews-Studio/maw-js/pull/909) — the
+  redundant force-rebuild PR (would not have shipped if preflight had
+  existed)
+- [#908](https://github.com/Soul-Brews-Studio/maw-js/pull/908) — the
+  monorepo source resolver that triggered the false-positive chase
+- [#902](https://github.com/Soul-Brews-Studio/maw-js/pull/902) /
+  [#904](https://github.com/Soul-Brews-Studio/maw-js/pull/904) — earlier
+  bundle-grep false positive of the same shape
+- `scripts/preflight.sh` — the script itself, with inline rationale
+- `CONTRIBUTING.md` → "Before opening a PR" — pushes you here

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.45",
+  "version": "26.4.29-alpha.46",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",
@@ -25,7 +25,8 @@
     "ship:alpha": "bash scripts/ship-alpha.sh",
     "ship:alpha:dry": "bash scripts/ship-alpha.sh --dry-run",
     "calver": "bun scripts/calver.ts",
-    "check:redos": "bun scripts/check-redos.ts"
+    "check:redos": "bun scripts/check-redos.ts",
+    "preflight": "bash scripts/preflight.sh"
   },
   "description": "maw.js — Multi-Agent Workflow in Bun/TS. Remote tmux orchestra control. CLI + Web UI.",
   "dependencies": {

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# preflight.sh — local-build-first sanity check before push (#911)
+#
+# Why this exists:
+#   m5's registry-monorepo migration paid the GitHub Actions tax 7+ times
+#   chasing a phantom "binary missing #908 handler" — the bug was a
+#   `strings dist/maw | grep monorepo` returning 0 and being mistaken for
+#   evidence the symbol was missing. It wasn't. `bun build --minify`
+#   renames identifiers to 1-char vars and dead-strips string literals.
+#   Grep on a minified Bun bundle is a false-negative trap.
+#
+#   The fix every time was the same: BUILD LOCALLY, RUN THE BINARY.
+#   This script does that in ~10 seconds.
+#
+# What it does:
+#   1. `bun run build`                — fresh local build (silent unless fail)
+#   2. (optional) `dist/maw plugin install <name>`  — full install round-trip
+#                                                     against live registry
+#   3. `dist/maw --version`           — smoke-test the built binary
+#   4. `dist/maw plugin --help`       — smoke-test plugin surface
+#   5. Print PASS / FAIL with reason
+#
+# Usage:
+#   bash scripts/preflight.sh                       # build + smoke (default)
+#   bash scripts/preflight.sh --install shellenv    # also install + verify a plugin
+#   bash scripts/preflight.sh --help                # show this header
+#
+#   bun run preflight                               # via npm script alias
+#
+# This is OPT-IN, not part of CI. Operators run it before `git push` /
+# before opening a PR / before claiming "fixed". It augments CI; it does
+# not replace it. CI still runs the authoritative test:all suite.
+#
+# See: docs/process/local-build-first.md  (#911 post-mortem)
+
+set -euo pipefail
+
+# ─── arg parse ──────────────────────────────────────────────────────────────
+INSTALL_PLUGIN=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --install)
+      INSTALL_PLUGIN="${2:-}"
+      if [[ -z "$INSTALL_PLUGIN" ]]; then
+        echo "FAIL: --install requires a plugin name" >&2
+        exit 2
+      fi
+      shift 2
+      ;;
+    -h|--help)
+      sed -n '2,38p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "FAIL: unknown arg: $1" >&2
+      echo "      try: bash scripts/preflight.sh --help" >&2
+      exit 2
+      ;;
+  esac
+done
+
+# ─── colors (auto-disable when not a tty) ──────────────────────────────────
+if [[ -t 1 ]]; then
+  CYAN=$'\033[36m'; GREEN=$'\033[32m'; RED=$'\033[31m'; DIM=$'\033[90m'; RESET=$'\033[0m'
+else
+  CYAN=""; GREEN=""; RED=""; DIM=""; RESET=""
+fi
+
+step()   { printf '%s==>%s %s\n' "$CYAN" "$RESET" "$*"; }
+ok()     { printf '%s✓%s   %s\n' "$GREEN" "$RESET" "$*"; }
+fail()   { printf '%sFAIL%s: %s\n' "$RED" "$RESET" "$*" >&2; }
+dim()    { printf '%s%s%s\n' "$DIM" "$*" "$RESET"; }
+
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+# ─── 1. build ──────────────────────────────────────────────────────────────
+step "bun run build"
+BUILD_LOG=$(mktemp -t maw-preflight-build-XXXXXX.log)
+trap 'rm -f "$BUILD_LOG"' EXIT
+if ! bun run build >"$BUILD_LOG" 2>&1; then
+  fail "bun run build failed"
+  cat "$BUILD_LOG" >&2
+  exit 1
+fi
+ok "build succeeded"
+
+if [[ ! -x "./dist/maw" ]]; then
+  fail "./dist/maw not found or not executable after build"
+  exit 1
+fi
+
+# ─── 2. (optional) install a plugin against the live registry ──────────────
+if [[ -n "$INSTALL_PLUGIN" ]]; then
+  step "dist/maw plugin install $INSTALL_PLUGIN"
+  if ! ./dist/maw plugin install "$INSTALL_PLUGIN"; then
+    fail "plugin install $INSTALL_PLUGIN failed against live registry"
+    exit 1
+  fi
+  ok "plugin install round-trip OK ($INSTALL_PLUGIN)"
+fi
+
+# ─── 3. smoke: --version ───────────────────────────────────────────────────
+step "dist/maw --version"
+if ! VERSION_OUT=$(./dist/maw --version 2>&1); then
+  fail "dist/maw --version failed: $VERSION_OUT"
+  exit 1
+fi
+dim "    $VERSION_OUT"
+ok "version smoke OK"
+
+# ─── 4. smoke: plugin --help ───────────────────────────────────────────────
+step "dist/maw plugin --help"
+if ! ./dist/maw plugin --help >/dev/null 2>&1; then
+  fail "dist/maw plugin --help failed"
+  exit 1
+fi
+ok "plugin surface smoke OK"
+
+# ─── done ──────────────────────────────────────────────────────────────────
+echo ""
+ok "Local-build OK; safe to push"
+dim "    (CI will still run the authoritative test:all suite — this is opt-in augmentation, not a replacement)"

--- a/test/scripts/preflight.test.ts
+++ b/test/scripts/preflight.test.ts
@@ -1,0 +1,242 @@
+/**
+ * preflight.test.ts — tests for scripts/preflight.sh (#911)
+ *
+ * Covers:
+ *   1. Script exists at the documented path
+ *   2. Script is executable (chmod +x)
+ *   3. --help flag works (doesn't require a build to be present)
+ *   4. Smoke check passes on a healthy build
+ *   5. Smoke check fails clearly when the build is broken
+ *   6. --install flag is wired (rejects missing arg, accepts a plugin name)
+ *   7. Unknown args fail with a clear message
+ *
+ * Strategy: spawn `bash scripts/preflight.sh` as a subprocess against a
+ *   *fake* repo root constructed in a tmpdir. The fake repo includes:
+ *     - package.json with a `build` script we control
+ *     - a stub `dist/maw` binary that we control
+ *   This lets us assert on the exact contract without paying a real Bun
+ *   build (~5s) per test.
+ */
+import { describe, test, expect, beforeAll } from "bun:test";
+import { spawnSync } from "child_process";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  chmodSync,
+  existsSync,
+  statSync,
+  readFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+const SCRIPT = join(REPO_ROOT, "scripts", "preflight.sh");
+
+// ─── fake-repo harness ───────────────────────────────────────────────────────
+
+interface FakeRepo {
+  root: string;
+  /** Set how the fake `bun run build` behaves. */
+  setBuild(behavior: "ok" | "fail"): void;
+  /** Set how the fake dist/maw binary behaves for --version / plugin --help. */
+  setBinary(behavior: "ok" | "fail-version" | "fail-plugin-help" | "missing"): void;
+  /** Run preflight with the given args inside the fake repo. */
+  run(args: string[]): { code: number; stdout: string; stderr: string };
+}
+
+function makeFakeRepo(): FakeRepo {
+  const root = mkdtempSync(join(tmpdir(), "maw-preflight-"));
+
+  // Make it look like a git repo so `git rev-parse --show-toplevel` works.
+  spawnSync("git", ["init", "-q"], { cwd: root });
+
+  // Mirror scripts/ from the real repo so preflight.sh can be invoked from here.
+  mkdirSync(join(root, "scripts"), { recursive: true });
+  mkdirSync(join(root, "dist"), { recursive: true });
+
+  // package.json — `build` script is overwritten per-test.
+  writeFileSync(
+    join(root, "package.json"),
+    JSON.stringify({ name: "fake", version: "0.0.0", scripts: { build: "true" } }, null, 2),
+  );
+
+  // Copy the real preflight.sh into the fake repo. We test the actual file.
+  const realScript = readFileSync(SCRIPT, "utf-8");
+  writeFileSync(join(root, "scripts", "preflight.sh"), realScript);
+  chmodSync(join(root, "scripts", "preflight.sh"), 0o755);
+
+  return {
+    root,
+
+    setBuild(behavior) {
+      // We hijack `bun run build` by writing a `build` script that either
+      // creates dist/maw and exits 0, or just exits 1. Since the script
+      // calls `bun run build`, we need bun to be available — but we don't
+      // need a real build. We replace the `build` npm script with a shell
+      // command that touches dist/maw or fails outright.
+      const pkg = {
+        name: "fake",
+        version: "0.0.0",
+        scripts: {
+          build:
+            behavior === "ok"
+              ? "bash -c 'cp dist/_stub_maw dist/maw && chmod +x dist/maw'"
+              : "bash -c 'echo build broke >&2; exit 1'",
+        },
+      };
+      writeFileSync(join(root, "package.json"), JSON.stringify(pkg, null, 2));
+    },
+
+    setBinary(behavior) {
+      const stub = join(root, "dist", "_stub_maw");
+      let body = "";
+      switch (behavior) {
+        case "ok":
+          body = `#!/usr/bin/env bash
+case "$1" in
+  --version) echo "v26.4.29-alpha.fake" ;;
+  plugin)
+    case "$2" in
+      --help) echo "usage: maw plugin ..." ;;
+      install) echo "installed: $3" ;;
+      *) echo "plugin subcommand: $2" ;;
+    esac
+    ;;
+  *) echo "unknown: $@" ; exit 2 ;;
+esac
+`;
+          break;
+        case "fail-version":
+          body = `#!/usr/bin/env bash
+case "$1" in
+  --version) echo "boom" >&2; exit 7 ;;
+  *) echo "ok" ;;
+esac
+`;
+          break;
+        case "fail-plugin-help":
+          body = `#!/usr/bin/env bash
+case "$1" in
+  --version) echo "v26.4.29-alpha.fake" ;;
+  plugin) exit 9 ;;
+  *) echo "ok" ;;
+esac
+`;
+          break;
+        case "missing":
+          // No stub written → build won't produce dist/maw.
+          return;
+      }
+      writeFileSync(stub, body);
+      chmodSync(stub, 0o755);
+    },
+
+    run(args) {
+      const r = spawnSync("bash", ["scripts/preflight.sh", ...args], {
+        cwd: root,
+        encoding: "utf-8",
+        timeout: 30_000,
+        env: { ...process.env, NO_COLOR: "1" },
+      });
+      return { code: r.status ?? -1, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+    },
+  };
+}
+
+// ─── tests ───────────────────────────────────────────────────────────────────
+
+describe("scripts/preflight.sh — file presence", () => {
+  test("script exists at documented path", () => {
+    expect(existsSync(SCRIPT)).toBe(true);
+  });
+
+  test("script is executable (chmod +x)", () => {
+    const mode = statSync(SCRIPT).mode;
+    // Owner-execute bit must be set.
+    expect(mode & 0o100).toBe(0o100);
+  });
+
+  test("npm script `preflight` is wired in package.json", () => {
+    const pkg = JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf-8"));
+    expect(pkg.scripts?.preflight).toBe("bash scripts/preflight.sh");
+  });
+});
+
+describe("scripts/preflight.sh — smoke", () => {
+  test("--help prints usage and exits 0", () => {
+    const repo = makeFakeRepo();
+    const r = repo.run(["--help"]);
+    expect(r.code).toBe(0);
+    expect(r.stdout.toLowerCase()).toContain("usage");
+  });
+
+  test("passes on a healthy build (build OK + binary OK)", () => {
+    const repo = makeFakeRepo();
+    repo.setBinary("ok");
+    repo.setBuild("ok");
+    const r = repo.run([]);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("Local-build OK; safe to push");
+  });
+
+  test("fails clearly when build is broken", () => {
+    const repo = makeFakeRepo();
+    repo.setBinary("ok");
+    repo.setBuild("fail");
+    const r = repo.run([]);
+    expect(r.code).not.toBe(0);
+    // The FAIL line goes to stderr.
+    expect(r.stderr).toContain("FAIL");
+    expect(r.stderr.toLowerCase()).toContain("build");
+  });
+
+  test("fails clearly when build produces no dist/maw", () => {
+    const repo = makeFakeRepo();
+    repo.setBinary("missing"); // no stub
+    repo.setBuild("ok"); // build "succeeds" but cp will fail since stub doesn't exist
+    const r = repo.run([]);
+    expect(r.code).not.toBe(0);
+    expect(r.stderr).toContain("FAIL");
+  });
+
+  test("fails clearly when --version smoke fails", () => {
+    const repo = makeFakeRepo();
+    repo.setBinary("fail-version");
+    repo.setBuild("ok");
+    const r = repo.run([]);
+    expect(r.code).not.toBe(0);
+    expect(r.stderr).toContain("FAIL");
+    expect(r.stderr).toContain("--version");
+  });
+});
+
+describe("scripts/preflight.sh — flags", () => {
+  test("--install requires a plugin name (rejects missing arg)", () => {
+    const repo = makeFakeRepo();
+    const r = repo.run(["--install"]);
+    expect(r.code).not.toBe(0);
+    expect(r.stderr).toContain("FAIL");
+    expect(r.stderr).toContain("--install");
+  });
+
+  test("--install <name> runs the install round-trip and passes when binary OK", () => {
+    const repo = makeFakeRepo();
+    repo.setBinary("ok"); // stub handles `plugin install shellenv` → exit 0
+    repo.setBuild("ok");
+    const r = repo.run(["--install", "shellenv"]);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("plugin install round-trip OK");
+    expect(r.stdout).toContain("shellenv");
+    expect(r.stdout).toContain("Local-build OK; safe to push");
+  });
+
+  test("unknown arg fails with a clear message", () => {
+    const repo = makeFakeRepo();
+    const r = repo.run(["--no-such-flag"]);
+    expect(r.code).not.toBe(0);
+    expect(r.stderr).toContain("FAIL");
+    expect(r.stderr).toContain("unknown");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #911. Adds an opt-in local-build-first sanity check so we stop paying the GitHub Actions tax on false-negative grep panics.

The motivating loop: m5's registry-monorepo migration cycled alpha.41 -> alpha.44 chasing a phantom "binary missing #908 handler" that turned out to be a `strings dist/maw | grep -c monorepo` returning 0. Bun's minifier renames identifiers to 1-char vars and dead-strips string literals, so grep on the bundle proves nothing. The fix every time was the same: build locally, run the binary. This script does that in ~10 seconds.

## What's in the change

- **`scripts/preflight.sh`** (executable, +x) — bash script that runs `bun run build` (silent unless fails), then smoke-tests `dist/maw --version` and `dist/maw plugin --help`. Optional `--install <name>` runs a full plugin install round-trip against the live registry. Prints "Local-build OK; safe to push" on success or `FAIL: <reason>` on any step.
- **`package.json`** — adds `"preflight": "bash scripts/preflight.sh"` so users run `bun run preflight`.
- **`docs/process/local-build-first.md`** — explains why grep on a minified Bun bundle is a false-negative trap, when to run preflight (before push, before PR, before claiming "fixed"), and the `raw.githubusercontent.com` CDN cache gotcha (~5 min propagation) that compounded the alpha.43 panic.
- **`CONTRIBUTING.md`** — "Before opening a PR" now starts with `bun run preflight`. Adds a callout warning against `strings dist/maw | grep` with a link to the new doc.
- **`test/scripts/preflight.test.ts`** — 11 test cases. Covers: script exists at the documented path, executable bit set, `preflight` npm script wired, `--help` works, healthy-build passes, broken-build fails clearly with FAIL message, missing-binary case, `--version` smoke failure, `--install` rejects missing plugin name, `--install <name>` runs install round-trip and passes, unknown arg rejected. Tests use a fake-repo harness in tmpdir with a stub `dist/maw` so we don't pay a real Bun build per test (~140ms total).
- **CalVer bump** — `26.4.29-alpha.45` -> `26.4.29-alpha.46` via `bun scripts/calver.ts`.

## Design notes

- **Opt-in, not CI-gated.** Preflight augments CI; it does not replace it. CI still runs the authoritative `test:all` suite. Operators choose to run preflight before push because 10s beats waiting 5 min for CI.
- **No git hook.** Issue proposed an optional pre-push hook (`git config maw.preflight true`); skipped from this PR to keep scope tight. Easy follow-up if there's appetite.
- **No hourly batched alpha cron.** Issue proposed an optional `.github/workflows/calver-batch.yml` for batched cuts; also skipped from this PR — independent change, separate PR if we want it.
- **Targets `alpha` per CONTRIBUTING.md branch model.** Stable cuts roll up to main from alpha later.

## Test plan

- [x] `bash scripts/preflight.sh --help` prints usage and exits 0
- [x] `bash scripts/preflight.sh --no-such-flag` fails with `FAIL: unknown arg`
- [x] `bash scripts/preflight.sh --install` (no name) fails with `FAIL: --install requires a plugin name`
- [x] `bun test test/scripts/preflight.test.ts` — 11 pass, 0 fail
- [ ] Reviewer runs `bun run preflight` against this branch's working tree end-to-end
- [ ] Reviewer reads `docs/process/local-build-first.md` for the post-mortem framing