### PR TITLE
lib: vendor 7 helpers from plugin dirs (unblocks 6 plugins for prune)

### DIFF
--- a/src/api/pair.ts
+++ b/src/api/pair.ts
@@ -11,7 +11,7 @@ import { Elysia } from "elysia";
 import { randomBytes } from "crypto";
 import { loadConfig } from "../config";
 import { register, lookup, consume, isValidShape, normalize, pretty, generateCode } from "../commands/plugins/pair/codes";
-import { cmdAdd } from "../commands/plugins/peers/impl";
+import { cmdAdd } from "../lib/peers/impl";
 
 export const pairApi = new Elysia();
 

--- a/src/api/sessions.ts
+++ b/src/api/sessions.ts
@@ -374,7 +374,7 @@ sessionsApi.post("/wake", async ({ body, set}) => {
 sessionsApi.post("/sleep", async ({ body, set}) => {
   try {
     const { target } = body;
-    const { cmdSleepOne } = await import("../commands/plugins/sleep/impl");
+    const { cmdSleepOne } = await import("../lib/sleep");
     await cmdSleepOne(target);
     return { ok: true, target };
   } catch (err) {

--- a/src/commands/plugins/bud/bud-wake.ts
+++ b/src/commands/plugins/bud/bud-wake.ts
@@ -130,7 +130,7 @@ export async function finalizeBud(ctx: BudFinalizeCtx): Promise<void> {
   if (opts.repo) {
     const localPsi = join(reposRoot, opts.repo, "ψ", "memory");
     if (existsSync(localPsi)) {
-      const { syncDir } = await import("../soul-sync/impl");
+      const { syncDir } = await import("../../../lib/sync-dir");
       for (const sub of ["learnings", "retrospectives", "traces"]) {
         const src = join(localPsi, sub);
         const dst = join(psiDir, "memory", sub);

--- a/src/commands/plugins/bud/from-repo-seed.ts
+++ b/src/commands/plugins/bud/from-repo-seed.ts
@@ -15,7 +15,7 @@ import { cpSync, copyFileSync, existsSync, mkdirSync, statSync } from "fs";
 import { join } from "path";
 import { loadConfig } from "../../../config";
 import { getGhqRoot } from "../../../config/ghq-root";
-import { peersPath } from "../peers/store";
+import { peersPath } from "../../../lib/peers/store";
 
 type Log = (msg: string) => void;
 

--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -170,7 +170,7 @@ export async function cmdSend(
       console.error("usage: maw hey team:<team-name> <message>");
       process.exit(1);
     }
-    const { getOracleMembers, loadOracleRegistry } = await import("../plugins/team/oracle-members");
+    const { getOracleMembers, loadOracleRegistry } = await import("../../lib/oracle-members");
     const senderOracle = resolveMyName(config);
     const members = getOracleMembers(teamName, senderOracle);
     if (members.length === 0) {
@@ -392,7 +392,7 @@ export async function cmdSend(
   // skips the gate immediately. Idempotent in `cmdAdd`.
   if (opts.approve && opts.trust && result?.type === "peer") {
     try {
-      const { cmdAdd } = await import("../plugins/trust/impl");
+      const { cmdAdd } = await import("../../lib/trust-store");
       const senderOracle = config.oracle ?? "mawjs";
       const targetOracle = result.target;
       cmdAdd(senderOracle, targetOracle);

--- a/src/commands/shared/scope-acl.ts
+++ b/src/commands/shared/scope-acl.ts
@@ -34,8 +34,8 @@
  */
 
 import { existsSync, readFileSync, readdirSync } from "fs";
-import { scopesDir } from "../plugins/scope/impl";
-import { loadTrust as loadTrustStore } from "../plugins/trust/store";
+import { scopesDir } from "../../lib/scope-paths";
+import { loadTrust as loadTrustStore } from "../../lib/trust-store";
 import type { TScope } from "../../lib/schemas";
 
 /**

--- a/src/core/bind-host.ts
+++ b/src/core/bind-host.ts
@@ -42,7 +42,7 @@ export function resolveBindHost(
   const reader = readPeers ?? (() => {
     try {
       // Lazy-require to keep this heuristic importable without the plugin bundle.
-      return require("../commands/plugins/peers/store").loadPeers();
+      return require("../lib/peers/store").loadPeers();
     } catch { return { peers: {} }; }
   });
   try {

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -204,8 +204,8 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
   // the ADR, "Crypto solves can't-fake; doctor + boot-time check solves
   // operator confusion" — so we just warn loudly and let serve continue.
   try {
-    const { loadPeers } = require("../commands/plugins/peers/store");
-    const { warnDuplicatesAtBoot } = require("../commands/plugins/peers/duplicate-detect");
+    const { loadPeers } = require("../lib/peers/store");
+    const { warnDuplicatesAtBoot } = require("../lib/peers/duplicate-detect");
     const peers = loadPeers().peers;
     const local = config.node ? { oracle: config.oracle ?? "mawjs", node: config.node } : undefined;
     warnDuplicatesAtBoot({ peers, local });

--- a/src/lib/elysia-auth.ts
+++ b/src/lib/elysia-auth.ts
@@ -14,7 +14,7 @@
 import { Elysia } from "elysia";
 import { loadConfig, D } from "../config";
 import { verify, isLoopback, verifyRequest, isRefuseDecision, type FromVerifyDecision } from "./federation-auth";
-import { loadPeers } from "../commands/plugins/peers/store";
+import { loadPeers } from "./peers/store";
 import type { Server } from "bun";
 
 const WINDOW_SEC = D.hmacWindowSeconds;

--- a/src/lib/oracle-members.ts
+++ b/src/lib/oracle-members.ts
@@ -1,0 +1,85 @@
+/**
+ * oracle-members.ts — vendored team registry helpers (Phase 2 vendor, #918 follow-up).
+ *
+ * Mirrors `src/commands/plugins/team/oracle-members.ts` so that
+ * `src/commands/shared/comm-send.ts` (and any other src/core / src/api /
+ * src/lib consumer) can resolve `team:<name>` fan-out without reaching across
+ * the plugin boundary into the team plugin.
+ *
+ * After the follow-up "prune" PR removes the team plugin's source, this
+ * vendored copy is the canonical location for the registry-read logic.
+ *
+ * Stores team membership at `<CONFIG_DIR>/teams/<team-name>/oracle-members.json`.
+ * Forgiving load semantics — missing file or corrupt JSON returns `null`,
+ * never throws. The ACL and routing layers treat "no registry" as "no members".
+ */
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+import { CONFIG_DIR } from "../core/paths";
+
+export interface OracleMember {
+  /** Oracle name (e.g. "mawjs-plugin-oracle", "security-oracle") */
+  oracle: string;
+  /** Role within the team (e.g. "researcher", "builder", "reviewer") */
+  role: string;
+  /** ISO timestamp when the oracle was added */
+  addedAt: string;
+}
+
+export interface OracleTeamRegistry {
+  name: string;
+  members: OracleMember[];
+  createdAt: string;
+  /**
+   * When true (default), `maw hey team:<name>` fan-out skips the sending
+   * oracle so a broadcast does not re-inject into the sender's own pane.
+   */
+  excludeSelf?: boolean;
+}
+
+function teamRegistryDir(teamName: string): string {
+  return join(CONFIG_DIR, "teams", teamName);
+}
+
+function teamRegistryPath(teamName: string): string {
+  return join(teamRegistryDir(teamName), "oracle-members.json");
+}
+
+export function loadOracleRegistry(teamName: string): OracleTeamRegistry | null {
+  const path = teamRegistryPath(teamName);
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Pure helper: filter member oracle names against the sender, honoring the
+ * registry's `excludeSelf` flag (default true).
+ */
+export function filterMembers(
+  members: OracleMember[],
+  excludeSelf: boolean | undefined,
+  currentOracle?: string,
+): string[] {
+  const all = members.map(m => m.oracle);
+  if (excludeSelf !== false && currentOracle) {
+    return all.filter(o => o !== currentOracle);
+  }
+  return all;
+}
+
+/**
+ * Get oracle member names for a team (for routing fan-out).
+ *
+ * When `currentOracle` is provided and the registry's `excludeSelf` flag is
+ * not explicitly false, the sending oracle is filtered out so a team
+ * broadcast does not re-inject into its own pane.
+ */
+export function getOracleMembers(teamName: string, currentOracle?: string): string[] {
+  const registry = loadOracleRegistry(teamName);
+  if (!registry) return [];
+  return filterMembers(registry.members, registry.excludeSelf, currentOracle);
+}

--- a/src/lib/peers/duplicate-detect.ts
+++ b/src/lib/peers/duplicate-detect.ts
@@ -1,0 +1,104 @@
+/**
+ * peers/duplicate-detect.ts — #804 Step 3.
+ *
+ * Pure logic that scans the peer cache for duplicate `<oracle>:<node>` claims.
+ * Two peers in `peers.json` advertising the same `(oracle, node)` pair is
+ * almost certainly operator confusion — typically a copy-pasted alias setup,
+ * a forgotten `maw peers remove` after a node migration, or a fleet split-
+ * brain where the same identity got TOFU'd from two different URLs.
+ *
+ * Per ADR docs/federation/0001-peer-identity.md ("Crypto solves can't-fake;
+ * doctor + boot-time check solves operator confusion") — this layer does NOT
+ * refuse anything. It surfaces collisions; the operator decides whether to
+ * `maw peers remove` the loser, rename a node, or accept (multi-oracle on a
+ * single node, where the *oracle* names differ even though the *node* is one
+ * physical machine, is fine and won't trigger this — the key is the full
+ * `<oracle>:<node>` pair).
+ *
+ * Pure: no fs, no network. Caller passes in the peer set + optional local
+ * identity. That makes the module trivial to test and lets both the doctor
+ * subsystem and the `maw serve` startup hook reuse the same code path.
+ */
+import type { Peer } from "./store";
+
+/** A single collision: two-or-more peers (or local + peers) sharing one key. */
+export interface DuplicateClaim {
+  /** Canonical `<oracle>:<node>` key the peers collide on. */
+  key: string;
+  /** All claimants — alias `"<local>"` is the running maw process itself. */
+  claimants: Array<{ alias: string; url?: string }>;
+}
+
+/**
+ * Build the map of `<oracle>:<node>` → claimants.
+ *
+ * Peers without an `identity` field are skipped (legacy peers; their oracle
+ * may differ from "mawjs" silently — surfacing them as collisions would be
+ * a false-positive against pre-Step-1 nodes that simply haven't been probed
+ * since the upgrade).
+ *
+ * The local identity is included as alias `"<local>"` so the boot-time check
+ * can spot "this maw IS something I'm also calling a peer" (often happens
+ * when an operator copy-pastes a federation snippet on the wrong machine).
+ */
+export function findDuplicateIdentities(
+  peers: Record<string, Peer>,
+  local?: { oracle: string; node: string },
+): DuplicateClaim[] {
+  const groups = new Map<string, Array<{ alias: string; url?: string }>>();
+
+  if (local) {
+    const localKey = `${local.oracle}:${local.node}`;
+    groups.set(localKey, [{ alias: "<local>" }]);
+  }
+
+  for (const [alias, peer] of Object.entries(peers)) {
+    if (!peer?.identity) continue;
+    const { oracle, node } = peer.identity;
+    if (!oracle || !node) continue;
+    const key = `${oracle}:${node}`;
+    const arr = groups.get(key) ?? [];
+    arr.push({ alias, url: peer.url });
+    groups.set(key, arr);
+  }
+
+  const dups: DuplicateClaim[] = [];
+  for (const [key, claimants] of groups) {
+    if (claimants.length >= 2) dups.push({ key, claimants });
+  }
+  // Stable order: by key, alphabetically.
+  dups.sort((a, b) => a.key.localeCompare(b.key));
+  return dups;
+}
+
+/**
+ * Format a one-line warning suitable for `maw doctor` output OR a `maw serve`
+ * startup log. Caller wraps in colors per its own log surface.
+ */
+export function formatDuplicate(d: DuplicateClaim): string {
+  const tail = d.claimants
+    .map(c => (c.url ? `${c.alias} (${c.url})` : c.alias))
+    .join(", ");
+  return `duplicate <oracle>:<node> claim "${d.key}" — ${tail}`;
+}
+
+/**
+ * Boot-time hook used by `startServer()`. Loads the peer cache + the
+ * caller-supplied local identity, then writes a YELLOW warning per
+ * collision via `console.warn`. Never throws — boot must continue per ADR.
+ *
+ * Returns the duplicates list so tests / callers can assert on it.
+ */
+export function warnDuplicatesAtBoot(args: {
+  peers: Record<string, Peer>;
+  local?: { oracle: string; node: string };
+  log?: (msg: string) => void;
+}): DuplicateClaim[] {
+  const log = args.log ?? ((m: string) => console.warn(m));
+  const dups = findDuplicateIdentities(args.peers, args.local);
+  for (const d of dups) {
+    log(`\x1b[33m⚠ ${formatDuplicate(d)}\x1b[0m`);
+    log(`\x1b[33m  investigate with \`maw peers list\` and \`maw peers remove <alias>\` if stale.\x1b[0m`);
+  }
+  return dups;
+}

--- a/src/lib/peers/impl.ts
+++ b/src/lib/peers/impl.ts
@@ -1,0 +1,270 @@
+/**
+ * maw peers — subcommand implementations (#568).
+ *
+ * Pure(-ish) functions for CRUD over `~/.maw/peers.json`. No CLI
+ * parsing here — the dispatcher in index.ts peels off `args[0]` and
+ * hands typed positional + flag data to these functions.
+ *
+ * Node resolution (when `--node` is not given) is intentionally
+ * best-effort: we try `<url>/info`, and on any error (missing endpoint,
+ * DNS, timeout) we store `node: null`. An alias without a node is still
+ * valid — it just means `alias:<agent>` routing needs the URL-to-node
+ * map from another source. That's a follow-up concern.
+ */
+import { loadPeers, mutatePeers, type Peer, type LastError } from "./store";
+import { probePeer } from "./probe";
+import { evaluatePeerIdentity, applyTofuDecision, PeerPubkeyMismatchError } from "./tofu";
+
+const ALIAS_RE = /^[a-z0-9][a-z0-9_-]{0,31}$/;
+
+export function validateAlias(alias: string): string | null {
+  if (!ALIAS_RE.test(alias)) {
+    return `invalid alias "${alias}" (must match ^[a-z0-9][a-z0-9_-]{0,31}$)`;
+  }
+  return null;
+}
+
+export function validateUrl(raw: string): string | null {
+  let parsed: URL;
+  try { parsed = new URL(raw); } catch { return `invalid URL "${raw}"`; }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return `invalid URL "${raw}" (must be http:// or https://)`;
+  }
+  return null;
+}
+
+/**
+ * Thin back-compat wrapper returning `string | null`. New callers should
+ * use probePeer() directly to get structured errors — but pre-#565 code
+ * paths that only want the node name keep working unchanged.
+ */
+export async function resolveNode(url: string): Promise<string | null> {
+  const res = await probePeer(url);
+  return res.node;
+}
+
+export interface AddOptions {
+  alias: string;
+  url: string;
+  node?: string;
+}
+
+export interface AddResult {
+  alias: string;
+  overwrote: boolean;
+  peer: Peer;
+  /** Probe error, if the /info handshake failed. Caller prints a loud warning. */
+  probeError?: LastError;
+  /** Set when the cached pubkey did not match the peer's advertised pubkey (#804 Step 2). */
+  pubkeyMismatch?: PeerPubkeyMismatchError;
+}
+
+export async function cmdAdd(opts: AddOptions): Promise<AddResult> {
+  const aliasErr = validateAlias(opts.alias);
+  if (aliasErr) throw new Error(aliasErr);
+  const urlErr = validateUrl(opts.url);
+  if (urlErr) throw new Error(urlErr);
+
+  // Probe OUTSIDE the lock — it does network I/O. If --node was supplied
+  // we still probe to surface errors, but the user-supplied node wins.
+  const probe = await probePeer(opts.url);
+  const resolvedNode = opts.node ?? probe.node ?? null;
+
+  // TOFU evaluation against any pre-existing cache entry for this alias.
+  // Decided BEFORE we overwrite so a re-`add` of the same alias against a
+  // peer whose key changed is refused at the cache layer (operator must
+  // `maw peers forget` first). Bootstrap path stamps the pubkey on the
+  // freshly-written entry, so we evaluate now but apply after the write.
+  const existingForTofu = loadPeers().peers[opts.alias];
+  const tofuDecision = evaluatePeerIdentity(opts.alias, existingForTofu, probe.pubkey);
+  if (tofuDecision.kind === "mismatch") {
+    return {
+      alias: opts.alias,
+      overwrote: Boolean(existingForTofu),
+      peer: existingForTofu!, // unchanged on disk — we refuse the write
+      probeError: probe.error,
+      pubkeyMismatch: new PeerPubkeyMismatchError(
+        opts.alias,
+        tofuDecision.cached!,
+        tofuDecision.observed!,
+      ),
+    };
+  }
+
+  const peer: Peer = {
+    url: opts.url,
+    node: resolvedNode,
+    addedAt: new Date().toISOString(),
+    lastSeen: probe.error ? null : new Date().toISOString(),
+  };
+  if (probe.error) peer.lastError = probe.error;
+  if (probe.nickname) peer.nickname = probe.nickname;
+  // Preserve cached pubkey across re-adds — TOFU has already certified it
+  // matches (or is absent). On bootstrap, stamp the new pubkey now so the
+  // returned AddResult.peer reflects on-disk state in one go.
+  if (existingForTofu?.pubkey) {
+    peer.pubkey = existingForTofu.pubkey;
+    peer.pubkeyFirstSeen = existingForTofu.pubkeyFirstSeen;
+  } else if (tofuDecision.kind === "tofu-bootstrap") {
+    peer.pubkey = tofuDecision.observed!;
+    peer.pubkeyFirstSeen = new Date().toISOString();
+  }
+  // Identity (#804 Step 3): capture from probe when available; fall back to
+  // any previously-cached identity so a transient /api/identity blip on
+  // re-add doesn't lose what we already know about this peer.
+  if (probe.identity) {
+    peer.identity = probe.identity;
+  } else if (existingForTofu?.identity) {
+    peer.identity = existingForTofu.identity;
+  }
+
+  let existed = false;
+  mutatePeers((data) => {
+    existed = Boolean(data.peers[opts.alias]);
+    data.peers[opts.alias] = peer;
+  });
+
+  // applyTofuDecision is a no-op for match / legacy-*; for tofu-bootstrap
+  // we already stamped the pubkey above, so the call is defensive (it
+  // checks `if (p.pubkey) return` and bails). Keeping the call documents
+  // the contract: every probePeer response goes through TOFU exactly once.
+  applyTofuDecision(tofuDecision);
+
+  return { alias: opts.alias, overwrote: existed, peer, probeError: probe.error };
+}
+
+/**
+ * Re-run the /info handshake for an existing alias. On success clears
+ * lastError and sets lastSeen; on failure records lastError.
+ *
+ * Throws if the alias does not exist.
+ */
+export interface ProbeResult {
+  alias: string;
+  url: string;
+  node: string | null;
+  ok: boolean;
+  error?: LastError;
+  /** Set when the peer's advertised pubkey did not match the cached one (#804 Step 2). */
+  pubkeyMismatch?: PeerPubkeyMismatchError;
+}
+
+export async function cmdProbe(alias: string): Promise<ProbeResult> {
+  const data = loadPeers();
+  const existing = data.peers[alias];
+  if (!existing) throw new Error(`peer "${alias}" not found`);
+
+  const probe = await probePeer(existing.url);
+  const now = new Date().toISOString();
+
+  // TOFU first — if the peer rotated its key without operator approval, the
+  // probe's "ok" status is misleading: their /info answered, but their
+  // identity changed. Surface as `pubkeyMismatch` and *do not* update
+  // lastSeen — operator must run `maw peers forget` to re-TOFU.
+  const tofuDecision = evaluatePeerIdentity(alias, existing, probe.pubkey);
+  if (tofuDecision.kind === "mismatch") {
+    return {
+      alias,
+      url: existing.url,
+      node: probe.node ?? existing.node,
+      ok: false,
+      error: probe.error,
+      pubkeyMismatch: new PeerPubkeyMismatchError(
+        alias,
+        tofuDecision.cached!,
+        tofuDecision.observed!,
+      ),
+    };
+  }
+
+  mutatePeers((d) => {
+    const p = d.peers[alias];
+    if (!p) return; // removed between load and mutate — race-safe no-op
+    if (probe.error) {
+      p.lastError = probe.error;
+    } else {
+      delete p.lastError;
+      p.lastSeen = now;
+      if (probe.node) p.node = probe.node;
+      // Refresh nickname on success: string updates, null clears.
+      if (probe.nickname) p.nickname = probe.nickname;
+      else if (probe.nickname === null) delete p.nickname;
+      // Refresh identity on success (#804 Step 3) — only updates, never clears,
+      // so a transient /api/identity blip won't drop a known-good pin.
+      if (probe.identity) p.identity = probe.identity;
+    }
+  });
+
+  // Persist the bootstrap (only on first sight, after the peer entry exists).
+  applyTofuDecision(tofuDecision);
+
+  return {
+    alias,
+    url: existing.url,
+    node: probe.node ?? existing.node,
+    ok: !probe.error,
+    error: probe.error,
+  };
+}
+
+export function cmdList(): Array<{ alias: string } & Peer> {
+  const data = loadPeers();
+  return Object.entries(data.peers)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([alias, p]) => ({ alias, ...p }));
+}
+
+export function cmdInfo(alias: string): ({ alias: string } & Peer) | null {
+  const data = loadPeers();
+  const p = data.peers[alias];
+  return p ? { alias, ...p } : null;
+}
+
+export function cmdRemove(alias: string): boolean {
+  let existed = false;
+  mutatePeers((data) => {
+    if (data.peers[alias]) {
+      existed = true;
+      delete data.peers[alias];
+    }
+  });
+  return existed;
+}
+
+/**
+ * Clear the TOFU-cached pubkey for an alias so the next /api/identity
+ * contact re-TOFUs (#804 Step 2).
+ *
+ * Use cases:
+ *   - Legitimate operator-initiated key rotation on the peer side.
+ *   - Factory reset / key loss recovery.
+ *   - Resolving a `peer pubkey changed` refusal after the operator has
+ *     verified out-of-band that the change is intentional.
+ *
+ * Does NOT remove the alias itself — `maw peers remove` is the destructive
+ * one. Forget is a re-TOFU primitive, not a delete.
+ */
+export type ForgetOutcome = "cleared" | "no-pubkey" | "not-found";
+
+export async function cmdForget(alias: string): Promise<ForgetOutcome> {
+  const aliasErr = validateAlias(alias);
+  if (aliasErr) throw new Error(aliasErr);
+  const { forgetPeerPubkey } = await import("./tofu");
+  return forgetPeerPubkey(alias);
+}
+
+export function formatList(rows: Array<{ alias: string } & Peer>): string {
+  if (!rows.length) return "no peers";
+  const header = ["alias", "url", "node", "nickname", "lastSeen"];
+  const lines = rows.map(r => [
+    r.alias,
+    r.url,
+    r.node ?? "-",
+    r.nickname ?? "-",
+    r.lastSeen ?? "-",
+  ]);
+  const widths = header.map((h, i) =>
+    Math.max(h.length, ...lines.map(l => l[i].length)));
+  const fmt = (cols: string[]) => cols.map((c, i) => c.padEnd(widths[i])).join("  ");
+  return [fmt(header), fmt(widths.map(w => "-".repeat(w))), ...lines.map(fmt)].join("\n");
+}

--- a/src/lib/peers/lock.ts
+++ b/src/lib/peers/lock.ts
@@ -1,0 +1,78 @@
+/**
+ * maw peers — file lock for concurrent writers (#572 nit 3).
+ *
+ * Mirrors the pattern in src/cli/update-lock.ts: O_EXCL create on a
+ * sibling `.lock` file, write our pid, retry on EEXIST. If the holder
+ * pid is gone (kill -0 → ESRCH) we steal the lock immediately rather
+ * than waiting out the timeout. Synchronous (no await) so it composes
+ * with the existing sync savePeers signature without a contract change.
+ *
+ * Sized for CLI use: 5s deadline, 50ms poll. peers.json writes are
+ * sub-millisecond, so racing CLIs almost always succeed on first try.
+ */
+import { openSync, closeSync, unlinkSync, writeSync, readSync, existsSync } from "fs";
+
+const DEADLINE_MS = 5_000;
+const POLL_MS = 50;
+
+function isAlive(pid: number): boolean {
+  if (!Number.isFinite(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e: any) {
+    return e.code === "EPERM";
+  }
+}
+
+function sleepSync(ms: number): void {
+  const end = Date.now() + ms;
+  while (Date.now() < end) { /* spin — short waits only */ }
+}
+
+/** Run fn() while holding an exclusive lock on `<path>.lock`. Synchronous. */
+export function withPeersLock<T>(path: string, fn: () => T): T {
+  const lockPath = `${path}.lock`;
+  const deadline = Date.now() + DEADLINE_MS;
+  let fd: number | null = null;
+
+  while (true) {
+    try {
+      fd = openSync(lockPath, "wx"); // O_CREAT | O_EXCL
+      // fd-based write — prevents path-TOCTOU symlink swap between open and write.
+      // See #562 / #581 (exemplar fix in src/cli/update-lock.ts).
+      const pidBytes = Buffer.from(String(process.pid));
+      writeSync(fd, pidBytes, 0, pidBytes.length, 0);
+      break;
+    } catch (e: any) {
+      if (e.code !== "EEXIST") throw e;
+      // fd-based read for the same TOCTOU reason as the write above.
+      // Fixed 64-byte buffer — PIDs are ≤20 digits on every supported OS, so
+      // no fstatSync needed (also avoids the CodeQL "stat-then-read" pattern).
+      let holderPid = NaN;
+      let readFd: number | null = null;
+      try {
+        readFd = openSync(lockPath, "r");
+        const buf = Buffer.alloc(64);
+        const n = readSync(readFd, buf, 0, buf.length, 0);
+        holderPid = parseInt(buf.subarray(0, n).toString("utf-8").trim(), 10);
+      } catch { /* empty/racy — treat as stale */ }
+      finally { if (readFd !== null) { try { closeSync(readFd); } catch {} } }
+      if (!isAlive(holderPid)) {
+        try { unlinkSync(lockPath); } catch { /* race with another stealer is fine */ }
+        continue;
+      }
+      if (Date.now() > deadline) {
+        throw new Error(`peers lock timeout: pid ${holderPid} still holds ${lockPath}`);
+      }
+      sleepSync(POLL_MS);
+    }
+  }
+
+  try {
+    return fn();
+  } finally {
+    try { if (fd !== null) closeSync(fd); } catch { /* ignore */ }
+    try { if (existsSync(lockPath)) unlinkSync(lockPath); } catch { /* ignore */ }
+  }
+}

--- a/src/lib/peers/probe.ts
+++ b/src/lib/peers/probe.ts
@@ -1,0 +1,329 @@
+/**
+ * maw peers — handshake probe + error classifier (#565).
+ *
+ * Replaces the silent try/catch→null in resolveNode(). probePeer()
+ * fetches <url>/info, classifies failures into a small enum, and
+ * returns both resolved node (if any) and structured error (if any).
+ * The old resolveNode() wrapper in impl.ts is kept as a thin
+ * `string | null` fallback for pre-#565 call sites.
+ */
+import type { LastError } from "./store";
+import { lookup } from "dns/promises";
+
+export type ProbeErrorCode = LastError["code"];
+
+export interface ProbeResult {
+  node: string | null;
+  /** Peer's self-reported nickname from /info (#643 Phase 2). Null means peer did not advertise one. */
+  nickname?: string | null;
+  /**
+   * Peer's pubkey from /api/identity (#804 Step 2). Undefined when:
+   *   - the /info handshake itself failed (no second fetch attempted), OR
+   *   - the peer is pre-Step-1 and does not expose /api/identity, OR
+   *   - /api/identity responded but did not advertise a pubkey field.
+   *
+   * Caller passes this through `tofuRecordPeerIdentity` to pin / validate.
+   */
+  pubkey?: string;
+  /**
+   * Peer's self-reported `<oracle>:<node>` from /api/identity (#804 Step 3).
+   *
+   * Captured opportunistically alongside `pubkey` so the local cache can
+   * detect duplicate-claim collisions across peers (e.g. two peers both
+   * declaring themselves `mawjs:m5`). Undefined when /api/identity did not
+   * respond or omitted both `oracle` and `node` fields.
+   *
+   * `oracle` defaults to `"mawjs"` when the response only carries `node` —
+   * this is the family default per ADR docs/federation/0001-peer-identity.md
+   * and lets pre-Step-3 peers still participate in the collision check.
+   */
+  identity?: { oracle: string; node: string };
+  error?: LastError;
+}
+
+/**
+ * Exit code per probe error family — fail-loud for scripts.
+ *
+ * Scripts that chain `maw peers add` with subsequent commands need a
+ * non-zero exit to branch on. The old `ok:true + ⚠ block on stderr`
+ * behavior was easy to miss in CI logs.
+ *
+ *   2 — generic/structural (UNKNOWN, BAD_BODY, TLS)
+ *   3 — DNS (host does not resolve)
+ *   4 — REFUSED (resolved but port closed)
+ *   5 — TIMEOUT (no response in 2s)
+ *   6 — HTTP_4XX / HTTP_5XX (peer responded but /info failed)
+ */
+export const PROBE_EXIT_CODES: Record<ProbeErrorCode, number> = {
+  DNS: 3,
+  REFUSED: 4,
+  TIMEOUT: 5,
+  HTTP_4XX: 6,
+  HTTP_5XX: 6,
+  TLS: 2,
+  BAD_BODY: 2,
+  UNKNOWN: 2,
+};
+
+/** Actionable hint per error code — shown in CLI output. */
+export const PROBE_HINTS: Record<ProbeErrorCode, string> = {
+  DNS: "Host does not resolve. Check /etc/hosts, DNS, or VPN.",
+  REFUSED: "Host resolves but port is closed. Is the peer process running?",
+  TIMEOUT: "Peer did not respond within 2s. Network path may be blocked.",
+  TLS: "TLS handshake failed. Check cert validity / chain.",
+  HTTP_4XX: "Peer responded with a client error. /info endpoint may be missing OR peer is running an old maw version — if you control the peer, try restarting it.",
+  HTTP_5XX: "Peer returned a server error. Server-side fault.",
+  BAD_BODY: "/info responded but body shape was unexpected.",
+  UNKNOWN: "Probe failed for an unclassified reason.",
+};
+
+/**
+ * Classify a thrown fetch error OR a failed Response into a ProbeErrorCode.
+ * Node/undici → err.cause.code; AbortError → 2s timeout; TLS → CERT_*;
+ * HTTP → non-ok Response. Bun collapses DNS+refused → "ConnectionRefused";
+ * run prefetchDnsCheck() first to recover the DNS distinction.
+ */
+export function classifyProbeError(input: unknown): ProbeErrorCode {
+  // HTTP: non-ok Response
+  if (typeof input === "object" && input !== null && "status" in input && "ok" in input) {
+    const res = input as { status: number; ok: boolean };
+    if (!res.ok) {
+      if (res.status >= 400 && res.status < 500) return "HTTP_4XX";
+      if (res.status >= 500) return "HTTP_5XX";
+    }
+  }
+
+  // Thrown error: inspect cause.code, code, name
+  const err = input as { name?: string; code?: string; cause?: { code?: string } } | null;
+  if (!err || typeof err !== "object") return "UNKNOWN";
+
+  const code = err.cause?.code ?? err.code;
+  // ENOTIMP = resolver method unimplemented (e.g. mDNS/.local without Avahi); EAI_FAIL = unrecoverable DNS (#593).
+  if (code === "ENOTFOUND" || code === "ENOTIMP" || code === "EAI_FAIL" || code === "EAI_AGAIN" || code === "EAI_NODATA") return "DNS";
+  // Bun conflates DNS + refused into "ConnectionRefused" — we run a DNS
+  // precheck upstream, so any code that reaches here means connect failed.
+  if (code === "ECONNREFUSED" || code === "ConnectionRefused") return "REFUSED";
+  if (code === "ETIMEDOUT" || code === "UND_ERR_CONNECT_TIMEOUT") return "TIMEOUT";
+  if (err.name === "AbortError" || err.name === "TimeoutError") return "TIMEOUT";
+  if (typeof code === "string" && (code.startsWith("CERT_") || code.startsWith("SELF_SIGNED") || code.startsWith("DEPTH_ZERO_") || code === "UNABLE_TO_VERIFY_LEAF_SIGNATURE")) {
+    return "TLS";
+  }
+
+  return "UNKNOWN";
+}
+
+/**
+ * DNS precheck — resolves host-doesn't-resolve vs connection-refused before
+ * fetch (Bun conflates them). Returns DNS LastError on failure, null on ok.
+ */
+async function prefetchDnsCheck(url: string): Promise<LastError | null> {
+  let hostname: string;
+  try { hostname = new URL(url).hostname; } catch { return null; }
+  if (/^\d+\.\d+\.\d+\.\d+$/.test(hostname) || hostname.startsWith("[")) return null;
+  try {
+    await lookup(hostname);
+    return null;
+  } catch (e: any) {
+    return {
+      code: classifyProbeError(e),
+      message: typeof e?.message === "string" ? e.message : `DNS lookup failed for ${hostname}`,
+      at: new Date().toISOString(),
+    };
+  }
+}
+
+/** Build a LastError record from a thrown error + url context. */
+function errToLast(err: unknown, fallbackMsg: string): LastError {
+  const code = classifyProbeError(err);
+  const message = (err && typeof err === "object" && "message" in err && typeof (err as any).message === "string")
+    ? (err as any).message
+    : fallbackMsg;
+  return { code, message, at: new Date().toISOString() };
+}
+
+/**
+ * Probe <url>/info with a 2s timeout. Success → { node } (body.node or
+ * body.name). Failure → { node: null, error } — caller persists + warns.
+ */
+export async function probePeer(url: string, timeoutMs = 2000): Promise<ProbeResult> {
+  // DNS precheck first — cheaper than fetch and gives us clean ENOTFOUND
+  // classification on Bun (whose fetch conflates DNS/refused into one code).
+  const dnsErr = await prefetchDnsCheck(url);
+  if (dnsErr) return { node: null, error: dnsErr };
+
+  let res: Response;
+  try {
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), timeoutMs);
+    try {
+      res = await fetch(new URL("/info", url), { signal: ctrl.signal });
+    } finally {
+      clearTimeout(t);
+    }
+  } catch (e) {
+    return { node: null, error: errToLast(e, `fetch ${url}/info failed`) };
+  }
+
+  if (!res.ok) {
+    return {
+      node: null,
+      error: {
+        code: classifyProbeError(res),
+        message: `HTTP ${res.status} from ${url}/info`,
+        at: new Date().toISOString(),
+      },
+    };
+  }
+
+  let body: { node?: unknown; name?: unknown; nickname?: unknown; maw?: unknown };
+  try {
+    body = await res.json() as { node?: unknown; name?: unknown; nickname?: unknown; maw?: unknown };
+  } catch (e) {
+    return {
+      node: null,
+      error: {
+        code: "BAD_BODY",
+        message: `/info body was not valid JSON`,
+        at: new Date().toISOString(),
+      },
+    };
+  }
+
+  // Accept both the old handshake (#596 — `maw: true`) and the new
+  // self-describing shape (#628 — `maw: { schema: "1", ... }`). Any
+  // truthy `maw` value passes; missing/falsy fails as BAD_BODY so we
+  // don't paint random HTTP 200 endpoints as maw peers.
+  if (!isValidMawHandshake(body.maw)) {
+    return {
+      node: null,
+      error: {
+        code: "BAD_BODY",
+        message: `/info response missing valid "maw" handshake field`,
+        at: new Date().toISOString(),
+      },
+    };
+  }
+
+  const node = (typeof body.node === "string" && body.node)
+    || (typeof body.name === "string" && body.name)
+    || null;
+
+  if (!node) {
+    return {
+      node: null,
+      error: {
+        code: "BAD_BODY",
+        message: `/info response had neither "node" nor "name" string`,
+        at: new Date().toISOString(),
+      },
+    };
+  }
+
+  // Nickname is optional and strictly cosmetic — only accept non-empty strings.
+  const nickname = typeof body.nickname === "string" && body.nickname.length > 0
+    ? body.nickname
+    : null;
+
+  // Best-effort pubkey + identity fetch (#804 Steps 2 + 3). Pre-Step-1 peers
+  // don't expose /api/identity at all; we tolerate that and return without
+  // either field — TOFU layer treats the result as a legacy peer, and the
+  // duplicate-detection layer skips peers without identity (no false positive).
+  const ident = await fetchPeerIdentityFields(url, timeoutMs);
+
+  const result: ProbeResult = { node, nickname };
+  if (ident?.pubkey) result.pubkey = ident.pubkey;
+  if (ident?.identity) result.identity = ident.identity;
+  return result;
+}
+
+/**
+ * Best-effort second fetch — `/api/identity` (#804 Steps 2 + 3).
+ *
+ * Keep this *separate* from the /info handshake so a missing/older endpoint
+ * does not poison the primary probe. We swallow every failure here: TOFU
+ * only acts on a confirmed pubkey value, and the caller already classified
+ * /info errors elsewhere.
+ *
+ * Returns whatever subset of `{ pubkey, identity }` the response advertised,
+ * or `undefined` if the endpoint is missing / unreachable / malformed.
+ *
+ * `identity` is synthesised from the response's `oracle` (defaulting to
+ * `"mawjs"` per ADR family-default) + `node` fields. Both fields must be
+ * non-empty strings for `identity` to be returned — a peer that reports
+ * neither is treated as legacy and skipped by the dedup check upstream.
+ */
+async function fetchPeerIdentityFields(
+  url: string,
+  timeoutMs: number,
+): Promise<{ pubkey?: string; identity?: { oracle: string; node: string } } | undefined> {
+  try {
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), timeoutMs);
+    let res: Response;
+    try {
+      res = await fetch(new URL("/api/identity", url), { signal: ctrl.signal });
+    } finally {
+      clearTimeout(t);
+    }
+    if (!res.ok) return undefined;
+    const body = (await res.json()) as { pubkey?: unknown; oracle?: unknown; node?: unknown };
+    const out: { pubkey?: string; identity?: { oracle: string; node: string } } = {};
+    if (typeof body.pubkey === "string" && body.pubkey.length > 0) out.pubkey = body.pubkey;
+    const node = typeof body.node === "string" && body.node.length > 0 ? body.node : undefined;
+    const oracle = typeof body.oracle === "string" && body.oracle.length > 0 ? body.oracle : "mawjs";
+    if (node) out.identity = { oracle, node };
+    return out;
+  } catch {
+    // Pre-Step-1 peers: no /api/identity yet. Step 4 will reject this — for
+    // now (alpha migration window) we silently accept.
+  }
+  return undefined;
+}
+
+/**
+ * Handshake gate — accepts the pre-#628 `maw: true` form AND the new
+ * `maw: { schema: "1", ... }` form. Objects must carry at least a
+ * `schema` string to count as a valid new-shape handshake (bare `{}`
+ * is rejected so a typo doesn't silently pass). Anything truthy but
+ * not one of these shapes (e.g. `maw: "yes"`, `maw: 1`) is rejected —
+ * future shapes should bump the schema field rather than changing the
+ * outer type.
+ */
+export function isValidMawHandshake(maw: unknown): boolean {
+  if (maw === true) return true;
+  if (maw && typeof maw === "object") {
+    const m = maw as { schema?: unknown };
+    return typeof m.schema === "string" && m.schema.length > 0;
+  }
+  return false;
+}
+
+/** Hint chooser — DNS bucket sub-types for ENOTIMP get a distinct hint (#593). */
+export function pickHint(err: LastError): string {
+  if (err.code === "DNS" && /ENOTIMP/i.test(err.message)) {
+    return "install avahi-daemon (Linux) for mDNS, or add white.local to /etc/hosts";
+  }
+  return PROBE_HINTS[err.code] ?? PROBE_HINTS.UNKNOWN;
+}
+
+/** Colored, multi-line stderr block with actionable hint. */
+export function formatProbeError(err: LastError, url: string, alias: string): string {
+  const hint = pickHint(err);
+  const host = safeHost(url);
+  return [
+    `\x1b[33m⚠\x1b[0m peer handshake failed: \x1b[1m${err.code}\x1b[0m`,
+    `   host: ${host}`,
+    `   error: ${err.message}`,
+    `   hint: ${hint}`,
+    `   retry: maw peers probe ${alias}`,
+  ].join("\n");
+}
+
+function safeHost(url: string): string {
+  try {
+    const u = new URL(url);
+    return u.port ? `${u.hostname}:${u.port}` : u.hostname;
+  } catch {
+    return url;
+  }
+}

--- a/src/lib/peers/store.ts
+++ b/src/lib/peers/store.ts
@@ -1,0 +1,190 @@
+/**
+ * maw peers — storage layer (#568, #572).
+ *
+ * Atomic read/write of `~/.maw/peers.json`. Writes go via a temp file
+ * and rename(2) so a crash mid-write leaves either the old file intact
+ * or the new file fully in place — never a truncated file. A stale tmp
+ * file from a crashed previous write is cleaned on load (the live file
+ * is still valid; the tmp is leftover from a crashed writer).
+ *
+ * Schema v1:
+ *   { version: 1, peers: { <alias>: { url, node, addedAt, lastSeen,
+ *                                     [lastError, nickname, pubkey, pubkeyFirstSeen,
+ *                                      identity] } } }
+ *   — fields in brackets are optional. `pubkey` / `pubkeyFirstSeen` were
+ *   added in #804 Step 2 for TOFU peer-identity pinning. `identity` was
+ *   added in #804 Step 3 to capture the peer's self-reported `<oracle>:<node>`
+ *   pair for duplicate-detection (doctor + boot-time warn).
+ *
+ * Path resolution is a function (not a const) so tests can override
+ * `HOME` / the path via `PEERS_FILE` and get a fresh value each call.
+ *
+ * Concurrency: savePeers takes a short-lived file lock around the
+ * read-modify-write critical section so concurrent `maw peers add`
+ * calls don't lose each other's updates (#572 nit 3). See ./lock.ts.
+ *
+ * Corruption: if the live file fails to parse, OR if it parses but
+ * the shape is wrong (e.g. `{"peers":[]}` — array instead of object),
+ * we rename it aside to `peers.json.corrupt-<ISO>` and start fresh —
+ * non-destructive, with an audit trail (#572 nit 1, follow-up to #579).
+ */
+import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync, unlinkSync } from "fs";
+import { join, dirname } from "path";
+import { homedir } from "os";
+import { withPeersLock } from "./lock";
+
+/**
+ * Structured last-probe failure — opt-in field on Peer (#565).
+ *
+ * Absent (undefined) means either the peer has never been probed, or
+ * the most recent probe succeeded. Readers that don't know about this
+ * field continue to work — schema v1 is unchanged.
+ */
+export interface LastError {
+  /** Classified code — see probe.ts classifyProbeError(). */
+  code: "DNS" | "REFUSED" | "TIMEOUT" | "TLS" | "HTTP_4XX" | "HTTP_5XX" | "BAD_BODY" | "UNKNOWN";
+  /** Raw error message (from err.message or synthesized for HTTP cases). */
+  message: string;
+  /** ISO timestamp when the failure was recorded. */
+  at: string;
+}
+
+export interface Peer {
+  url: string;
+  node: string | null;
+  addedAt: string;
+  lastSeen: string | null;
+  /** Optional — set by probePeer() when handshake fails; cleared on success. */
+  lastError?: LastError;
+  /** Optional human-friendly nickname, propagated from peer's /info (#643 Phase 2). */
+  nickname?: string | null;
+  /**
+   * TOFU-cached pubkey from the peer's /api/identity response (#804 Step 2).
+   *
+   * Absent until the first successful identity fetch that returned a `pubkey`
+   * field. Once cached, every subsequent identity check validates the response
+   * against this value — mismatch is treated as either rotation or
+   * impersonation and is refused (see ADR docs/federation/0001-peer-identity.md
+   * O6 table). Operator clears via `maw peers forget <alias>` to re-TOFU.
+   */
+  pubkey?: string;
+  /** ISO timestamp when the pubkey was first cached (TOFU). */
+  pubkeyFirstSeen?: string;
+  /**
+   * Peer's self-reported `<oracle>:<node>` pair from /api/identity (#804 Step 3).
+   *
+   * Captured opportunistically alongside `pubkey` during TOFU bootstrap and on
+   * every subsequent successful probe. Drives the duplicate-detection check
+   * in `maw doctor` and the boot-time warning in `maw serve` — two peers
+   * claiming the same `<oracle>:<node>` is operator confusion that crypto
+   * (Step 2) cannot solve, and operator must investigate.
+   *
+   * Absent for legacy peers (pre-Step-1 nodes that don't expose /api/identity)
+   * and for peers whose /api/identity response omitted both `node` and `oracle`.
+   * Doctor + boot-warn skip undefined identity (no false-positive collision).
+   */
+  identity?: { oracle: string; node: string };
+}
+
+export interface PeersFile {
+  version: 1;
+  peers: Record<string, Peer>;
+}
+
+export function peersPath(): string {
+  return process.env.PEERS_FILE || join(homedir(), ".maw", "peers.json");
+}
+
+export function emptyStore(): PeersFile {
+  return { version: 1, peers: {} };
+}
+
+export function loadPeers(): PeersFile {
+  clearStaleTmp();
+  const path = peersPath();
+  if (!existsSync(path)) return emptyStore();
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch {
+    return emptyStore();
+  }
+  try {
+    const parsed = JSON.parse(raw) as Partial<PeersFile>;
+    if (!isValidStoreShape(parsed)) throw new Error("invalid store shape (expected { peers: { ... } } object)");
+    return {
+      version: 1,
+      peers: (parsed.peers ?? {}) as Record<string, Peer>,
+    };
+  } catch (e: any) {
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const aside = `${path}.corrupt-${stamp}`;
+    try { renameSync(path, aside); } catch { /* ignore — caller still gets empty store */ }
+    console.error(`\x1b[33m⚠\x1b[0m peers store at ${path} failed to parse (${e?.message || e}); moved aside to ${aside}`);
+    return emptyStore();
+  }
+}
+
+/**
+ * Validate the parsed JSON matches the expected store shape:
+ * a non-null object whose `peers` field is itself a non-null,
+ * non-array object. Guards against `{"peers":[]}` (array) and
+ * other junk that would silently no-op every write (follow-up
+ * to #579).
+ */
+function isValidStoreShape(parsed: unknown): parsed is PeersFile {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return false;
+  const peers = (parsed as { peers?: unknown }).peers;
+  if (peers === undefined) return true; // missing peers is ok — we default to {}
+  return typeof peers === "object" && peers !== null && !Array.isArray(peers);
+}
+
+export function savePeers(data: PeersFile): void {
+  const path = peersPath();
+  mkdirSync(dirname(path), { recursive: true });
+  withPeersLock(path, () => writeAtomic(path, data));
+}
+
+/**
+ * Atomic read-modify-write under the peers lock. Use this whenever a
+ * mutation depends on current contents (add/remove) — it re-reads
+ * inside the lock so concurrent writers don't lose each other's
+ * updates. The mutator runs synchronously inside the critical section.
+ */
+export function mutatePeers(mutate: (data: PeersFile) => void): PeersFile {
+  const path = peersPath();
+  mkdirSync(dirname(path), { recursive: true });
+  return withPeersLock(path, () => {
+    const fresh = readUnlocked(path);
+    mutate(fresh);
+    writeAtomic(path, fresh);
+    return fresh;
+  });
+}
+
+/** Read + parse without taking the lock or doing corruption-handling rename. */
+function readUnlocked(path: string): PeersFile {
+  if (!existsSync(path)) return emptyStore();
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8")) as Partial<PeersFile>;
+    if (!isValidStoreShape(parsed)) return emptyStore();
+    return {
+      version: 1,
+      peers: (parsed.peers ?? {}) as Record<string, Peer>,
+    };
+  } catch {
+    return emptyStore();
+  }
+}
+
+function writeAtomic(path: string, data: PeersFile): void {
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, JSON.stringify(data, null, 2) + "\n");
+  renameSync(tmp, path);
+}
+
+/** Best-effort cleanup of a stale tmp file (ignore errors). */
+export function clearStaleTmp(): void {
+  const tmp = `${peersPath()}.tmp`;
+  try { if (existsSync(tmp)) unlinkSync(tmp); } catch { /* ignore */ }
+}

--- a/src/lib/peers/tofu.ts
+++ b/src/lib/peers/tofu.ts
@@ -1,0 +1,219 @@
+/**
+ * peers/tofu.ts — Trust On First Use cache for peer pubkeys (#804 Step 2).
+ *
+ * Pure, no-network logic that gets called by every code path which has just
+ * fetched a peer's `/api/identity` response. The peer's reply may carry a
+ * `pubkey` (Step 1 advertised it; pre-Step-1 peers omit it). We cache the
+ * pubkey on first sight and refuse mismatches thereafter.
+ *
+ * O6 table from ADR docs/federation/0001-peer-identity.md drives the four
+ * outcomes here — see `evaluatePeerIdentity` for the truth-table mapping.
+ *
+ * Design rules (deliberately not in store.ts):
+ *   - This module owns the *policy* (when to accept / refuse / warn).
+ *   - store.ts owns the *persistence* (how to read/write peers.json safely).
+ *   - This module never throws on absent-from-cache — it returns a tagged
+ *     decision the caller acts on. Throwing here would couple network code
+ *     paths to TOFU state shape.
+ *
+ * The receive-side (Step 4 signature verification) will reuse the same cache
+ * shape; this module is the only writer of `pubkey` / `pubkeyFirstSeen` so
+ * there's exactly one place that decides "this pubkey is now pinned".
+ */
+import type { Peer } from "./store";
+import { mutatePeers } from "./store";
+
+export type TofuDecisionKind =
+  /** First time we ever see a pubkey for this peer. Cache it. */
+  | "tofu-bootstrap"
+  /** Cached pubkey matches incoming pubkey. No-op write needed. */
+  | "match"
+  /** Cached pubkey, peer responded with a different pubkey. Refuse. */
+  | "mismatch"
+  /**
+   * Peer is a legacy node with no `pubkey` field at all. First contact —
+   * cache the entry without a pubkey; future Step-1+ contacts will TOFU.
+   */
+  | "legacy-first-contact"
+  /**
+   * Peer previously advertised a pubkey but this response omits it.
+   * During the v26.5.x migration window we accept-with-warning (rollback
+   * scenario). v27 will hard-cut this — see ADR Step 6.
+   */
+  | "legacy-after-pinned";
+
+export interface TofuDecision {
+  kind: TofuDecisionKind;
+  alias: string;
+  /** The cached pubkey (if any) BEFORE this call. */
+  cached?: string;
+  /** The pubkey the peer just advertised (if any). */
+  observed?: string;
+  /** Human-readable description for logs / errors. */
+  message: string;
+}
+
+export class PeerPubkeyMismatchError extends Error {
+  alias: string;
+  cached: string;
+  observed: string;
+  constructor(alias: string, cached: string, observed: string) {
+    super(
+      `peer pubkey changed for ${alias}: ${cached.slice(0, 16)}… → ${observed.slice(0, 16)}…; ` +
+        `manually \`maw peers forget ${alias}\` to re-TOFU`,
+    );
+    this.name = "PeerPubkeyMismatchError";
+    this.alias = alias;
+    this.cached = cached;
+    this.observed = observed;
+  }
+}
+
+/**
+ * Pure decision function — given the current cache entry and the peer's
+ * advertised pubkey (or `undefined` for legacy peers), return what should
+ * happen. Persistence is the caller's job (`applyTofuDecision`).
+ *
+ * The four decisions map directly onto the O6 table cells that are
+ * relevant to the *receive an identity response* event (the other O6
+ * cells about signed messages are Step 4's concern).
+ */
+export function evaluatePeerIdentity(
+  alias: string,
+  peer: Peer | undefined,
+  observed: string | undefined,
+): TofuDecision {
+  const cached = peer?.pubkey;
+
+  // Case 1: peer is brand-new to us OR we've never cached a pubkey.
+  if (!cached) {
+    if (observed) {
+      return {
+        kind: "tofu-bootstrap",
+        alias,
+        observed,
+        message: `[tofu] caching pubkey for ${alias} (first sight)`,
+      };
+    }
+    return {
+      kind: "legacy-first-contact",
+      alias,
+      message: `[tofu] ${alias} did not advertise a pubkey (legacy peer; no pin established)`,
+    };
+  }
+
+  // Case 2: cached pubkey present — must validate.
+  if (!observed) {
+    return {
+      kind: "legacy-after-pinned",
+      alias,
+      cached,
+      message:
+        `[tofu] ${alias} previously advertised pubkey ${cached.slice(0, 16)}… but this response omits it; ` +
+        `accepting during alpha migration, will hard-fail at v27`,
+    };
+  }
+
+  if (cached === observed) {
+    return {
+      kind: "match",
+      alias,
+      cached,
+      observed,
+      message: `[tofu] ${alias} pubkey verified`,
+    };
+  }
+
+  return {
+    kind: "mismatch",
+    alias,
+    cached,
+    observed,
+    message:
+      `peer pubkey changed for ${alias}: ${cached.slice(0, 16)}… → ${observed.slice(0, 16)}…; ` +
+      `manually \`maw peers forget ${alias}\` to re-TOFU`,
+  };
+}
+
+/**
+ * Persist the side-effect of `evaluatePeerIdentity`. Bootstrap writes the
+ * pubkey + timestamp; mismatch throws; match / legacy-* are no-ops on disk.
+ *
+ * Throws `PeerPubkeyMismatchError` on `kind === "mismatch"` — caller decides
+ * whether to surface to user or swallow (e.g. background sweepers may log
+ * and skip; interactive `maw peers add` may fail loud).
+ */
+export function applyTofuDecision(decision: TofuDecision): void {
+  switch (decision.kind) {
+    case "tofu-bootstrap": {
+      const now = new Date().toISOString();
+      mutatePeers((data) => {
+        const p = data.peers[decision.alias];
+        if (!p) return; // race-safe: peer was forgotten between fetch+apply
+        // Defensive: if someone else cached a pubkey between evaluate and
+        // apply, treat that as authoritative — re-evaluate would mismatch
+        // or match; we don't silently overwrite.
+        if (p.pubkey) return;
+        p.pubkey = decision.observed!;
+        p.pubkeyFirstSeen = now;
+      });
+      return;
+    }
+    case "mismatch":
+      throw new PeerPubkeyMismatchError(
+        decision.alias,
+        decision.cached!,
+        decision.observed!,
+      );
+    case "match":
+    case "legacy-first-contact":
+    case "legacy-after-pinned":
+      return;
+  }
+}
+
+/**
+ * One-shot helper: evaluate + apply. Returns the decision so callers can log.
+ *
+ * Throws `PeerPubkeyMismatchError` on mismatch (caller chooses recovery).
+ */
+export function tofuRecordPeerIdentity(
+  alias: string,
+  peer: Peer | undefined,
+  observed: string | undefined,
+): TofuDecision {
+  const decision = evaluatePeerIdentity(alias, peer, observed);
+  applyTofuDecision(decision);
+  return decision;
+}
+
+/**
+ * Operator-driven re-TOFU: clears the pinned pubkey for an alias. Used by
+ * `maw peers forget <alias>`. Idempotent — clearing a peer that has no
+ * pubkey is fine and reports nothing-changed via the return value.
+ *
+ * Returns:
+ *   - "cleared" — pubkey was present and is now removed
+ *   - "no-pubkey" — alias exists but had no pubkey (legacy peer)
+ *   - "not-found" — alias does not exist
+ */
+export function forgetPeerPubkey(
+  alias: string,
+): "cleared" | "no-pubkey" | "not-found" {
+  let outcome: "cleared" | "no-pubkey" | "not-found" = "not-found";
+  mutatePeers((data) => {
+    const p = data.peers[alias];
+    if (!p) {
+      outcome = "not-found";
+      return;
+    }
+    if (p.pubkey === undefined) {
+      outcome = "no-pubkey";
+      return;
+    }
+    delete p.pubkey;
+    delete p.pubkeyFirstSeen;
+    outcome = "cleared";
+  });
+  return outcome;
+}

--- a/src/lib/scope-paths.ts
+++ b/src/lib/scope-paths.ts
@@ -1,0 +1,31 @@
+/**
+ * scope-paths.ts — vendored scope-config-dir helpers (Phase 2 vendor, #918 follow-up).
+ *
+ * Mirrors the path helpers in `src/commands/plugins/scope/impl.ts` so that
+ * `src/commands/shared/scope-acl.ts` (and any other src/core / src/api / src/lib
+ * consumer) can resolve `<CONFIG_DIR>/scopes/` without reaching across the
+ * plugin boundary into `src/commands/plugins/scope/`.
+ *
+ * After the follow-up "prune" PR removes the scope plugin's source, this
+ * vendored copy is the canonical location for the path resolution logic.
+ *
+ * Path resolution mirrors `scope/impl.ts::activeConfigDir` exactly — same
+ * precedence: MAW_HOME → MAW_CONFIG_DIR → ~/.config/maw. Function (not const)
+ * so tests overriding env per-test see fresh values each call.
+ */
+import { join } from "path";
+import { homedir } from "os";
+
+function activeConfigDir(): string {
+  if (process.env.MAW_HOME) return join(process.env.MAW_HOME, "config");
+  if (process.env.MAW_CONFIG_DIR) return process.env.MAW_CONFIG_DIR;
+  return join(homedir(), ".config", "maw");
+}
+
+export function scopesDir(): string {
+  return join(activeConfigDir(), "scopes");
+}
+
+export function scopePath(name: string): string {
+  return join(scopesDir(), `${name}.json`);
+}

--- a/src/lib/sleep.ts
+++ b/src/lib/sleep.ts
@@ -1,0 +1,108 @@
+/**
+ * sleep.ts — vendored `cmdSleepOne` (Phase 2 vendor, #918 follow-up).
+ *
+ * Mirrors `src/commands/plugins/sleep/impl.ts::cmdSleepOne` so that
+ * `src/api/sessions.ts` (and any other src/core / src/api / src/lib consumer)
+ * can gracefully stop an oracle's tmux window without reaching across the
+ * plugin boundary into the sleep plugin.
+ *
+ * After the follow-up "prune" PR removes the sleep plugin's source, this
+ * vendored copy is the canonical location for the per-oracle sleep flow.
+ *
+ * Behavior — gracefully stop a single Oracle agent's tmux window:
+ *   1. Send /exit to the Claude session
+ *   2. Wait 3 seconds
+ *   3. If window still exists, kill it
+ *   4. Append a `sleep` event to ~/.oracle/maw-log.jsonl
+ */
+import { tmux, saveTabOrder, takeSnapshot } from "../sdk";
+import { detectSession } from "../commands/shared/wake";
+import { appendFile, mkdir } from "fs/promises";
+import { homedir } from "os";
+import { join } from "path";
+
+export async function cmdSleepOne(oracle: string, window?: string) {
+  const session = await detectSession(oracle);
+  if (!session) {
+    throw new Error(`no running session found for '${oracle}'`);
+  }
+
+  const windowName = window ? `${oracle}-${window}` : `${oracle}-oracle`;
+
+  // Save tab order before sleeping (so wake can restore positions)
+  await saveTabOrder(session);
+
+  let windows;
+  try {
+    windows = await tmux.listWindows(session);
+  } catch {
+    throw new Error(`could not list windows for session '${session}'`);
+  }
+
+  // Normalize trailing dashes — tmux window names like "fireman-1w-test-"
+  // cause exact-match failures and strand maw sleep (#206)
+  const stripDash = (s: string) => s.replace(/-+$/, "");
+
+  const target = windows.find(w => w.name === windowName || stripDash(w.name) === stripDash(windowName));
+  if (!target) {
+    const nameSuffix = window || "oracle";
+    const fuzzy = windows.find(w =>
+      stripDash(w.name) === stripDash(windowName) ||
+      new RegExp(`^${oracle}-\\d+-${nameSuffix}-?$`).test(w.name)
+    );
+    if (!fuzzy) {
+      console.error(`\x1b[90mavailable:\x1b[0m ${windows.map(w => w.name).join(", ")}`);
+      throw new Error(`window '${windowName}' not found in session '${session}'`);
+    }
+    return await doSleep(session, fuzzy.name, oracle);
+  }
+
+  await doSleep(session, windowName, oracle);
+}
+
+async function doSleep(session: string, windowName: string, oracle: string) {
+  const target = `${session}:${windowName}`;
+
+  console.log(`\x1b[90m...\x1b[0m sending /exit to ${target}`);
+  try {
+    for (const ch of "/exit") {
+      await tmux.sendKeysLiteral(target, ch);
+    }
+    await tmux.sendKeys(target, "Enter");
+  } catch {
+    // Window might already be gone
+  }
+
+  await new Promise(r => setTimeout(r, 3000));
+
+  try {
+    const windows = await tmux.listWindows(session);
+    const stripDash = (s: string) => s.replace(/-+$/, "");
+    const stillExists = windows.some(w => w.name === windowName || stripDash(w.name) === stripDash(windowName));
+    if (stillExists) {
+      await tmux.killWindow(target);
+      console.log(`  \x1b[33m!\x1b[0m force-killed ${windowName} (did not exit gracefully)`);
+    } else {
+      console.log(`  \x1b[32m✓\x1b[0m ${windowName} exited gracefully`);
+    }
+  } catch {
+    console.log(`  \x1b[32m✓\x1b[0m ${windowName} stopped`);
+  }
+
+  const logDir = join(homedir(), ".oracle");
+  const logFile = join(logDir, "maw-log.jsonl");
+  const line = JSON.stringify({
+    ts: new Date().toISOString(),
+    type: "sleep",
+    oracle,
+    window: windowName,
+  }) + "\n";
+  try {
+    await mkdir(logDir, { recursive: true });
+    await appendFile(logFile, line);
+  } catch (e) { console.error(`\x1b[33m⚠\x1b[0m sleep log write failed: ${e}`); }
+
+  console.log(`\x1b[32msleep\x1b[0m ${oracle} (${windowName})`);
+
+  takeSnapshot("sleep").catch(() => {});
+}

--- a/src/lib/sync-dir.ts
+++ b/src/lib/sync-dir.ts
@@ -1,0 +1,52 @@
+/**
+ * sync-dir.ts — vendored "copy new files only" helper (Phase 2 vendor, #918 follow-up).
+ *
+ * Mirrors the `syncDir` function in
+ * `src/commands/plugins/soul-sync/sync-helpers.ts` so that
+ * `src/commands/plugins/bud/bud-wake.ts` (and any other src/core / src/api /
+ * src/lib consumer) can copy ψ subtrees without reaching across the plugin
+ * boundary into the soul-sync plugin.
+ *
+ * After the follow-up "prune" PR removes the soul-sync plugin's source, this
+ * vendored copy is the canonical location for the dest-biased copy primitive.
+ *
+ * Semantics: dest-biased ("Nothing is Deleted") — pre-existing target files
+ * are preserved, missing source returns 0, unreadable entries are skipped
+ * silently. Returns the number of files copied.
+ */
+import { existsSync, readdirSync, copyFileSync, mkdirSync } from "fs";
+import { join } from "path";
+
+/**
+ * Copy new files from src dir to dst dir (skip existing). Returns count copied.
+ * Recursive walk; missing dst dirs are created on-demand. Errors during
+ * directory listing or per-file copy are swallowed — same forgiving stance
+ * as the soul-sync plugin's original.
+ */
+export function syncDir(srcDir: string, dstDir: string): number {
+  if (!existsSync(srcDir)) return 0;
+  let count = 0;
+
+  function walk(src: string, dst: string) {
+    let entries: any[];
+    try { entries = readdirSync(src, { withFileTypes: true } as any) as any; }
+    catch { return; }
+
+    for (const entry of entries) {
+      const srcPath = join(src, entry.name);
+      const dstPath = join(dst, entry.name);
+      if (entry.isDirectory()) {
+        walk(srcPath, dstPath);
+      } else if (!existsSync(dstPath)) {
+        try {
+          mkdirSync(dst, { recursive: true });
+          copyFileSync(srcPath, dstPath);
+          count++;
+        } catch { /* skip unreadable files */ }
+      }
+    }
+  }
+
+  walk(srcDir, dstDir);
+  return count;
+}

--- a/src/lib/trust-store.ts
+++ b/src/lib/trust-store.ts
@@ -1,0 +1,129 @@
+/**
+ * trust-store.ts — vendored trust list helpers (Phase 2 vendor, #918 follow-up).
+ *
+ * Mirrors `src/commands/plugins/trust/{store,impl}.ts` so that
+ * `src/commands/shared/{scope-acl,comm-send}.ts` (and any other src/core /
+ * src/api / src/lib consumer) can read + append to `<CONFIG_DIR>/trust.json`
+ * without reaching across the plugin boundary into the trust plugin.
+ *
+ * After the follow-up "prune" PR removes the trust plugin's source, this
+ * vendored copy is the canonical location for the helper logic; the plugin
+ * (if it survives at all) becomes a thin CLI dispatcher.
+ *
+ * Forgiving load semantics — missing file, corrupt JSON, or wrong shape
+ * all fall back to `[]` rather than throwing. Atomic writes via tmp +
+ * rename(2). No file lock — Phase 1 / Phase 2 trust adds are operator-driven
+ * and racing writers aren't a realistic workload.
+ */
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "fs";
+import { homedir } from "os";
+import { dirname, join } from "path";
+
+export interface TrustEntryOnDisk {
+  sender: string;
+  target: string;
+  addedAt: string;
+}
+
+export type TrustListOnDisk = TrustEntryOnDisk[];
+
+function activeConfigDir(): string {
+  if (process.env.MAW_HOME) return join(process.env.MAW_HOME, "config");
+  if (process.env.MAW_CONFIG_DIR) return process.env.MAW_CONFIG_DIR;
+  return join(homedir(), ".config", "maw");
+}
+
+export function trustPath(): string {
+  return join(activeConfigDir(), "trust.json");
+}
+
+export function loadTrust(): TrustListOnDisk {
+  const path = trustPath();
+  if (!existsSync(path)) return [];
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (e: any): e is TrustEntryOnDisk =>
+        e &&
+        typeof e.sender === "string" &&
+        typeof e.target === "string" &&
+        typeof e.addedAt === "string",
+    );
+  } catch {
+    return [];
+  }
+}
+
+export function saveTrust(list: TrustListOnDisk): void {
+  const path = trustPath();
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, JSON.stringify(list, null, 2) + "\n");
+  renameSync(tmp, path);
+}
+
+/** Symmetric pair equality. `{a, b}` matches `{b, a}` — trust is direction-agnostic. */
+export function samePair(
+  a: { sender: string; target: string },
+  b: { sender: string; target: string },
+): boolean {
+  return (
+    (a.sender === b.sender && a.target === b.target) ||
+    (a.sender === b.target && a.target === b.sender)
+  );
+}
+
+export interface AddResult {
+  added: boolean;
+  entry: TrustEntryOnDisk;
+}
+
+/**
+ * Add a sender↔target trust pair. Idempotent in both directions:
+ * `add(a, b)` after `add(a, b)` or `add(b, a)` is a no-op. Throws on
+ * empty / equal sender+target — self-trust is meaningless because
+ * `evaluateAcl()` already allows self-messages unconditionally.
+ */
+export function cmdAdd(sender: string, target: string): AddResult {
+  if (!sender || typeof sender !== "string") {
+    throw new Error("trust add: sender must be a non-empty string");
+  }
+  if (!target || typeof target !== "string") {
+    throw new Error("trust add: target must be a non-empty string");
+  }
+  if (sender === target) {
+    throw new Error(
+      `trust add: refusing self-trust pair "${sender}↔${sender}" — self-messages are always allowed`,
+    );
+  }
+
+  const list = loadTrust();
+  const candidate = { sender, target };
+  for (const existing of list) {
+    if (samePair(existing, candidate)) {
+      return { added: false, entry: existing };
+    }
+  }
+
+  const entry: TrustEntryOnDisk = {
+    sender,
+    target,
+    addedAt: new Date().toISOString(),
+  };
+  list.push(entry);
+  saveTrust(list);
+  return { added: true, entry };
+}

--- a/test/isolated/bud-wake.test.ts
+++ b/test/isolated/bud-wake.test.ts
@@ -198,6 +198,19 @@ mock.module(
   }),
 );
 
+// `bud-wake.ts` imports `syncDir` from the vendored `src/lib/sync-dir` (#918
+// follow-up Phase 2) — same surface area as the soul-sync plugin export above,
+// just relocated. Mirror the mock here so finalizeBud step 8.5 records calls.
+mock.module(
+  join(import.meta.dir, "../../src/lib/sync-dir"),
+  () => ({
+    syncDir: (src: string, dst: string) => {
+      if (!mockActive) return realSyncDir(src, dst);
+      syncDirCalls.push({ src, dst });
+    },
+  }),
+);
+
 let cmdSplitCalls: string[] = [];
 let cmdSplitThrow: Error | null = null;
 mock.module(


### PR DESCRIPTION
## Summary

Phase 2 follow-up to #918. The previous PR kept 6 plugins bundled
because `src/core`, `src/api`, `src/lib` (and `src/commands/plugins/bud/`)
reach into their internals. This vendors those reach-points to `src/lib/`
so the plugins become fully prunable in a follow-up.

| Vendored to | From plugin source | Used by |
|---|---|---|
| `src/lib/scope-paths.ts` | `scope/impl::scopesDir, scopePath` | `commands/shared/scope-acl.ts` |
| `src/lib/trust-store.ts` | `trust/{store,impl}::loadTrust + cmdAdd` | `commands/shared/{scope-acl,comm-send}.ts` |
| `src/lib/oracle-members.ts` | `team/oracle-members::getOracleMembers + loadOracleRegistry` | `commands/shared/comm-send.ts` (dynamic) |
| `src/lib/sync-dir.ts` | `soul-sync/sync-helpers::syncDir` | `commands/plugins/bud/bud-wake.ts` (dynamic) |
| `src/lib/sleep.ts` | `sleep/impl::cmdSleepOne` | `api/sessions.ts` (dynamic) |
| `src/lib/peers/` (6 files) | `peers/{store,lock,duplicate-detect,probe,tofu,impl}.ts` | `core/{bind-host,server}.ts`, `lib/elysia-auth.ts`, `api/pair.ts`, `commands/plugins/bud/from-repo-seed.ts` |

`peers` is vendored as a directory because `cmdAdd` (used by `pair.ts`)
drags TOFU + probe + lock through the whole module graph — extracting a
single function would have shipped most of the plugin anyway.

After this PR, `grep` for `from .../plugins/{peers,scope,sleep,soul-sync,team,trust}`
inside `src/core`, `src/api`, `src/lib`, `src/commands/plugins/bud` returns
**zero** matches. The 6 plugins can be deleted in a follow-up PR without
breaking the daemon or any non-plugin caller.

Plugin source is kept verbatim — pruning is the follow-up PR.

## Verification

- `bun run build` green between each helper (one-at-a-time vendoring discipline).
- `bun test:isolated` — baseline preserved: 4 known-failing files
  (`fleet-doctor`, `resolve-local-first`, `oracle-manifest`, `resolve-psi`).
  No new regressions; `bud-wake.test.ts` updated to mirror the existing
  `soul-sync/impl` mock onto the vendored `src/lib/sync-dir` so step-8.5
  call-count assertions still fire.

## Test plan
- [ ] CI passes on alpha base
- [ ] Manual smoke: `maw peers list`, `maw scope list`, `maw trust list` still work (plugin source untouched)
- [ ] Manual smoke: `maw serve` still warns on duplicate `<oracle>:<node>` (uses `src/lib/peers/duplicate-detect`)
- [ ] Follow-up: delete `src/commands/plugins/{peers,scope,sleep,soul-sync,team,trust}/` once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)