### PR TITLE
refactor: vendor cross-plugin helpers in 10 DEFER plugins (unblocks Phase 2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.935",
+  "version": "26.4.29-alpha.937",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/plugins/about/index.ts
+++ b/src/commands/plugins/about/index.ts
@@ -1,5 +1,5 @@
 import type { InvokeContext, InvokeResult } from "../../../plugin/types";
-import { cmdOracleAbout } from "../oracle/impl";
+import { cmdOracleAbout } from "./internal/impl-about";
 
 export const command = {
   name: ["about", "info"],

--- a/src/commands/plugins/about/internal/impl-about.ts
+++ b/src/commands/plugins/about/internal/impl-about.ts
@@ -1,0 +1,98 @@
+import { listSessions, capture, FLEET_DIR } from "../../../../sdk";
+import { findWorktrees, detectSession } from "../../../shared/wake";
+import { readdirSync, readFileSync } from "fs";
+import { join } from "path";
+import { resolveOracleSafe } from "./impl-helpers";
+import { UserError } from "../../../../core/util/user-error";
+
+export async function cmdOracleAbout(oracle: string) {
+  const name = oracle.toLowerCase();
+  const sessions = await listSessions();
+
+  // Gather all signals first so we can distinguish "real oracle, sparse data"
+  // from "no such oracle" — the latter must error rather than print an
+  // empty-but-valid-looking record (#390.2).
+  const { repoPath, repoName, parentDir } = await resolveOracleSafe(name);
+  const session = await detectSession(name);
+
+  const fleetDir = FLEET_DIR;
+  let fleetFile: string | null = null;
+  let fleetWindowCount = 0;
+  try {
+    for (const file of readdirSync(fleetDir).filter(f => f.endsWith(".json"))) {
+      const config = JSON.parse(readFileSync(join(fleetDir, file), "utf-8"));
+      const hasOracle = (config.windows || []).some(
+        (w: any) => w.name.toLowerCase() === `${name}-oracle` || w.name.toLowerCase() === name
+      );
+      if (hasOracle) {
+        fleetFile = file;
+        fleetWindowCount = config.windows.length;
+        break;
+      }
+    }
+  } catch { /* expected: fleet dir may not exist */ }
+
+  if (!repoPath && !session && !fleetFile) {
+    throw new UserError(`no oracle named '${oracle}' — try: maw oracle ls`);
+  }
+
+  // Heading — preserve user input casing. Auto-capitalizing turned 'mawjs'
+  // into 'Mawjs', which is wrong (oracle names are lowercase by convention).
+  console.log(`\n  \x1b[36mOracle — ${oracle}\x1b[0m\n`);
+
+  // Repo
+  console.log(`  Repo:      ${repoPath || "(not found)"}`);
+
+  // Session + windows
+  if (session) {
+    const s = sessions.find(s => s.name === session);
+    const windows = s?.windows || [];
+    console.log(`  Session:   ${session} (${windows.length} windows)`);
+    for (const w of windows) {
+      let status = "\x1b[90m○\x1b[0m";
+      try {
+        const content = await capture(`${session}:${w.index}`, 3);
+        status = content.trim() ? "\x1b[32m●\x1b[0m" : "\x1b[33m●\x1b[0m";
+      } catch { /* expected: capture may fail for inactive pane */ }
+      console.log(`    ${status} ${w.name}`);
+    }
+  } else {
+    console.log(`  Session:   (none)`);
+  }
+
+  // Worktrees
+  if (parentDir) {
+    const wts = await findWorktrees(parentDir, repoName);
+    console.log(`  Worktrees: ${wts.length}`);
+    for (const wt of wts) {
+      console.log(`    ${wt.name} → ${wt.path}`);
+    }
+  }
+
+  // Fleet config
+  if (fleetFile) {
+    const actualWindows = session
+      ? (sessions.find(s => s.name === session)?.windows.length || 0)
+      : 0;
+    console.log(`  Fleet:     ${fleetFile} (${fleetWindowCount} registered, ${actualWindows} running)`);
+    if (actualWindows > fleetWindowCount) {
+      // Find which windows are unregistered
+      const fleetConfig = JSON.parse(readFileSync(join(fleetDir, fleetFile), "utf-8"));
+      const registeredNames = new Set((fleetConfig.windows || []).map((w: any) => w.name));
+      const runningWindows = sessions.find(s => s.name === session)?.windows || [];
+      const unregistered = runningWindows.filter(w => !registeredNames.has(w.name));
+
+      console.log(`  \x1b[33m⚠\x1b[0m  ${unregistered.length} window(s) not in fleet config — won't survive reboot`);
+      for (const w of unregistered) {
+        console.log(`    \x1b[33m→\x1b[0m ${w.name}`);
+      }
+      console.log(`\n  \x1b[90mFix: add to fleet/${fleetFile}\x1b[0m`);
+      console.log(`  \x1b[90m  maw fleet init          # regenerate all configs\x1b[0m`);
+      console.log(`  \x1b[90m  maw fleet validate      # check for problems\x1b[0m`);
+    }
+  } else {
+    console.log(`  Fleet:     (no config)`);
+  }
+
+  console.log();
+}

--- a/src/commands/plugins/about/internal/impl-helpers.ts
+++ b/src/commands/plugins/about/internal/impl-helpers.ts
@@ -1,0 +1,87 @@
+import { listSessions, FLEET_DIR, type OracleEntry } from "../../../../sdk";
+import { ghqFind } from "../../../../core/ghq";
+import { readdirSync, readFileSync } from "fs";
+import { join } from "path";
+
+/** Like resolveOracle but returns null instead of throwing on miss */
+export async function resolveOracleSafe(oracle: string): Promise<{ repoPath: string; repoName: string; parentDir: string } | { parentDir: ""; repoName: ""; repoPath: "" }> {
+  // Try oracle-oracle pattern first, then direct name (e.g., homekeeper → homelab)
+  const repoPath = (await ghqFind(`/${oracle}-oracle$`)) ?? (await ghqFind(`/${oracle}$`));
+  if (!repoPath) return { parentDir: "", repoName: "", repoPath: "" };
+  const repoName = repoPath.split("/").pop()!;
+  const parentDir = repoPath.replace(/\/[^/]+$/, "");
+  return { repoPath, repoName, parentDir };
+}
+
+/** Discover oracles: union of fleet configs + running tmux sessions */
+export async function discoverOracles(): Promise<string[]> {
+  const names = new Set<string>();
+
+  // 1. Fleet configs (registered — includes sleeping)
+  const fleetDir = FLEET_DIR;
+  try {
+    for (const file of readdirSync(fleetDir).filter(f => f.endsWith(".json") && !f.endsWith(".disabled"))) {
+      const config = JSON.parse(readFileSync(join(fleetDir, file), "utf-8"));
+      for (const w of config.windows || []) {
+        if (w.name.endsWith("-oracle")) names.add(w.name.replace(/-oracle$/, ""));
+      }
+    }
+  } catch { /* fleet dir may not exist */ }
+
+  // 2. Running tmux (actual state — catches unregistered oracles)
+  try {
+    const sessions = await listSessions();
+    for (const s of sessions) {
+      for (const w of s.windows) {
+        if (w.name.endsWith("-oracle")) names.add(w.name.replace(/-oracle$/, ""));
+      }
+    }
+  } catch { /* tmux not running */ }
+
+  return [...names].sort();
+}
+
+export interface OracleStatus {
+  name: string;
+  session: string | null;
+  windows: string[];
+  worktrees: number;
+  status: "awake" | "sleeping";
+}
+
+/**
+ * Source-lineage for an oracle entry — "why is this in the list?"
+ * Drives the icon column in the grouped `ls` view.
+ */
+export interface OracleLineage {
+  hasFleetConfig: boolean;   // ~/.config/maw/fleet/<name>.json exists
+  hasPsi: boolean;           // <repo>/ψ exists
+  isAwake: boolean;          // tmux session running
+  inAgents: boolean;         // appears in config.agents
+  federationNode?: string;   // from config.agents (or entry's federation_node)
+}
+
+export function lineageOf(
+  entry: OracleEntry,
+  awake: boolean,
+  agents: Record<string, string>,
+): OracleLineage {
+  return {
+    hasFleetConfig: entry.has_fleet_config,
+    hasPsi: entry.has_psi,
+    isAwake: awake,
+    inAgents: entry.name in agents,
+    federationNode: agents[entry.name] ?? entry.federation_node ?? undefined,
+  };
+}
+
+export function timeSince(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h`;
+  return `${Math.floor(h / 24)}d`;
+}

--- a/src/commands/plugins/archive/impl.ts
+++ b/src/commands/plugins/archive/impl.ts
@@ -1,7 +1,7 @@
 import { hostExec } from "../../../sdk";
 import { getGhqRoot } from "../../../config/ghq-root";
 import { loadFleetEntries } from "../../shared/fleet-load";
-import { cmdSoulSync } from "../soul-sync/impl";
+import { cmdSoulSync } from "./internal/soul-sync-impl";
 import { FLEET_DIR } from "../../../sdk";
 import { join } from "path";
 import { existsSync, renameSync } from "fs";

--- a/src/commands/plugins/archive/internal/resolve.ts
+++ b/src/commands/plugins/archive/internal/resolve.ts
@@ -1,0 +1,81 @@
+import { existsSync } from "fs";
+import { join } from "path";
+import { ghqFind } from "../../../../core/ghq";
+import { getGhqRoot } from "../../../../config/ghq-root";
+import { loadFleet } from "../../../shared/fleet-load";
+
+/**
+ * Resolve ghq path for an oracle name.
+ * Tries: ghqFind(`/<stem>-oracle$`) — case-insensitive ghq lookup.
+ *
+ * Defensive — accepts both bare oracle name ("neo") and full repo name
+ * ("neo-oracle"). Strips trailing "-oracle" before re-appending so callers
+ * passing either form land on the same lookup. (#372)
+ */
+export async function resolveOraclePath(name: string): Promise<string | null> {
+  // Strip trailing -oracle so "neo" and "neo-oracle" both resolve identically.
+  const stem = name.replace(/-oracle$/, "");
+  const out = await ghqFind(`/${stem}-oracle$`);
+  if (out) return out;
+
+  // Fallback: check fleet config for repo path
+  const reposRoot = join(getGhqRoot(), "github.com");
+  const fleet = loadFleet();
+  for (const sess of fleet) {
+    const oracleName = sess.name.replace(/^\d+-/, "");
+    if (oracleName === stem && sess.windows.length > 0) {
+      const repoPath = join(reposRoot, sess.windows[0].repo);
+      if (existsSync(repoPath)) return repoPath;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Resolve a git repo path to its canonical "org/repo" slug for `project_repos`
+ * lookup. Handles both shapes of `ghqRoot`:
+ *
+ *   A. github.com-rooted: `/home/neo/Code/github.com`
+ *      repoRoot = `/home/neo/Code/github.com/Soul-Brews-Studio/maw-js`
+ *      → rel = `Soul-Brews-Studio/maw-js` → slug = `Soul-Brews-Studio/maw-js`
+ *
+ *   B. bare ghq root:     `/home/neo/Code`
+ *      repoRoot = `/home/neo/Code/github.com/Soul-Brews-Studio/maw-js`
+ *      → rel = `github.com/Soul-Brews-Studio/maw-js` → (strip host) →
+ *        `Soul-Brews-Studio/maw-js` → slug = `Soul-Brews-Studio/maw-js`
+ *
+ * Before this normalization, shape B produced the org-only slug
+ * `github.com/Soul-Brews-Studio` because `.split("/").slice(0, 2)` grabbed
+ * the host + org instead of org + repo. See #193.
+ *
+ * Worktree suffix (`.wt-*`) is stripped from the repo segment so worktrees
+ * match their parent repo's `project_repos` entry.
+ *
+ * Returns null if `repoRoot` is not under `ghqRoot` or doesn't have the
+ * expected depth (e.g. sitting directly under ghqRoot with no org segment).
+ */
+export function resolveProjectSlug(repoRoot: string, ghqRoot: string): string | null {
+  if (!repoRoot.startsWith(ghqRoot)) return null;
+  let rel = repoRoot.slice(ghqRoot.length).replace(/^\/+/, "");
+  // If ghqRoot is the bare ghq root (not github.com-rooted), rel starts with
+  // a host segment — strip known forges so we always land at "<org>/<repo>".
+  rel = rel.replace(/^(github\.com|gitlab\.com|bitbucket\.org)\//, "");
+  const parts = rel.split("/").slice(0, 2);
+  if (parts.length !== 2 || !parts[0] || !parts[1]) return null;
+  parts[1] = parts[1].replace(/\.wt-.*$/, "");
+  return parts.join("/");
+}
+
+/**
+ * Find the oracle that owns a given project repo (org/repo slug).
+ */
+export function findOracleForProject(projectRepo: string): string | null {
+  const fleet = loadFleet();
+  for (const sess of fleet) {
+    if (sess.project_repos?.includes(projectRepo)) {
+      return sess.name.replace(/^\d+-/, "");
+    }
+  }
+  return null;
+}

--- a/src/commands/plugins/archive/internal/soul-sync-impl.ts
+++ b/src/commands/plugins/archive/internal/soul-sync-impl.ts
@@ -1,0 +1,166 @@
+import { existsSync } from "fs";
+import { join, basename } from "path";
+import { hostExec } from "../../../../sdk";
+import { getGhqRoot } from "../../../../config/ghq-root";
+import { findPeers, findProjectsForOracle, syncOracleVaults, syncProjectVault, reportProjectResult, type SoulSyncResult, type ProjectSyncResult } from "./sync-helpers";
+import { resolveOraclePath, resolveProjectSlug, findOracleForProject } from "./resolve";
+
+export { syncDir, findPeers, findProjectsForOracle, syncProjectVault } from "./sync-helpers";
+export type { SoulSyncResult, ProjectSyncResult } from "./sync-helpers";
+export { resolveOraclePath, resolveProjectSlug, findOracleForProject } from "./resolve";
+
+/**
+ * maw soul-sync [peer] [--from <peer>] — push ψ/ to peers; --from reverses direction.
+ * maw ss <peer>       push to specific peer
+ * maw ss --from <p>   pull from specific peer
+ */
+export async function cmdSoulSync(target?: string, opts?: { from?: boolean; cwd?: string }): Promise<SoulSyncResult[]> {
+  const results: SoulSyncResult[] = [];
+
+  let cwd = opts?.cwd || "";
+  if (!cwd) {
+    try {
+      cwd = (await hostExec("tmux display-message -p '#{pane_current_path}'")).trim();
+    } catch {
+      cwd = process.cwd();
+    }
+  }
+
+  const cwdParts = cwd.split("/");
+  const repoName = cwdParts.pop() || "";
+  // Strip `.wt-…` worktree suffix via indexOf — non-regex to avoid CodeQL polynomial-redos flag.
+  const wtIdx = repoName.indexOf(".wt-");
+  const baseRepo = wtIdx >= 0 ? repoName.slice(0, wtIdx) : repoName;
+  const oracleName = baseRepo.replace(/-oracle$/, "");
+
+  let oraclePath = cwd;
+  try {
+    const commonDir = (await hostExec(`git -C '${cwd}' rev-parse --git-common-dir`)).trim();
+    if (commonDir && commonDir !== ".git") {
+      const mainGit = commonDir.startsWith("/") ? commonDir : join(cwd, commonDir);
+      oraclePath = join(mainGit, "..");
+    }
+  } catch { /* use cwd */ }
+
+  const peers = target ? [target] : findPeers(oracleName);
+  if (peers.length === 0) {
+    console.log(`  \x1b[33m⚠\x1b[0m soul-sync: no sync_peers configured for '${oracleName}'`);
+    console.log(`  \x1b[90mAdd "sync_peers": ["name"] to fleet config, or run: maw ss <peer>\x1b[0m`);
+    return results;
+  }
+
+  const direction = opts?.from ? "pull" : "push";
+  const label = direction === "pull"
+    ? `pulling ${peers[0]} → ${oracleName}`
+    : `pushing ${oracleName} → ${peers.join(", ")}`;
+  console.log(`\n  \x1b[36m⚡ Soul Sync\x1b[0m — ${label}\n`);
+
+  for (const peer of peers) {
+    const peerPath = await resolveOraclePath(peer);
+    if (!peerPath) {
+      console.log(`  \x1b[33m⚠\x1b[0m ${peer}: repo not found, skipping`);
+      continue;
+    }
+
+    const [from, to, fromName, toName] = direction === "pull"
+      ? [peerPath, oraclePath, peer, oracleName]
+      : [oraclePath, peerPath, oracleName, peer];
+
+    const result = syncOracleVaults(from, to, fromName, toName);
+    results.push(result);
+
+    if (result.total === 0) {
+      console.log(`  \x1b[90m○\x1b[0m ${fromName} → ${toName}: nothing new`);
+    } else {
+      const parts = Object.entries(result.synced).map(([dir, n]) => `${n} ${dir.split("/").pop()}`);
+      console.log(`  \x1b[32m✓\x1b[0m ${fromName} → ${toName}: ${parts.join(", ")}`);
+    }
+  }
+
+  const totalAll = results.reduce((a, r) => a + r.total, 0);
+  if (totalAll > 0) {
+    console.log(`\n  \x1b[32m${totalAll} file(s) synced.\x1b[0m\n`);
+  } else {
+    console.log();
+  }
+
+  return results;
+}
+
+/**
+ * maw soul-sync --project — absorb project ψ/ into oracle ψ/ (inward only).
+ * Oracle cwd: absorbs from each project_repos entry.
+ * Project cwd: pushes ψ/ to the oracle that owns this repo.
+ */
+export async function cmdSoulSyncProject(opts?: { cwd?: string }): Promise<ProjectSyncResult[]> {
+  const results: ProjectSyncResult[] = [];
+  const reposRoot = join(getGhqRoot(), "github.com");
+
+  let cwd = opts?.cwd || "";
+  if (!cwd) {
+    try {
+      cwd = (await hostExec("tmux display-message -p '#{pane_current_path}'")).trim();
+    } catch {
+      cwd = process.cwd();
+    }
+  }
+
+  let repoRoot = cwd;
+  try {
+    const top = (await hostExec(`git -C '${cwd}' rev-parse --show-toplevel`)).trim();
+    if (top) repoRoot = top;
+  } catch { /* not a git repo */ }
+
+  const repoSlug = resolveProjectSlug(repoRoot, reposRoot);
+  const repoBase = basename(repoRoot).replace(/\.wt-.*$/, "");
+  const isOracle = repoBase.endsWith("-oracle");
+
+  console.log(`\n  \x1b[36m⚡ Soul Sync (project)\x1b[0m — ${isOracle ? "absorbing into" : "exporting from"} ${repoBase}\n`);
+
+  if (isOracle) {
+    const oracleName = repoBase.replace(/-oracle$/, "");
+    const projects = findProjectsForOracle(oracleName);
+    if (projects.length === 0) {
+      console.log(`  \x1b[33m⚠\x1b[0m no project_repos configured for '${oracleName}'`);
+      console.log(`  \x1b[90mAdd "project_repos": ["org/repo"] to fleet config for ${oracleName}.\x1b[0m\n`);
+      return results;
+    }
+    for (const projectRepo of projects) {
+      const projectPath = join(reposRoot, projectRepo);
+      if (!existsSync(projectPath)) {
+        console.log(`  \x1b[33m⚠\x1b[0m ${projectRepo}: not found at ${projectPath}, skipping`);
+        continue;
+      }
+      const result = syncProjectVault(projectPath, repoRoot, projectRepo, oracleName);
+      results.push(result);
+      reportProjectResult(result);
+    }
+  } else {
+    if (!repoSlug) {
+      console.log(`  \x1b[33m⚠\x1b[0m cannot resolve project slug from ${repoRoot} (not under repos root ${reposRoot})\n`);
+      return results;
+    }
+    const oracleName = findOracleForProject(repoSlug);
+    if (!oracleName) {
+      console.log(`  \x1b[33m⚠\x1b[0m no oracle owns project '${repoSlug}'`);
+      console.log(`  \x1b[90mAdd "project_repos": ["${repoSlug}"] to an oracle's fleet config.\x1b[0m\n`);
+      return results;
+    }
+    const oraclePath = await resolveOraclePath(oracleName);
+    if (!oraclePath) {
+      console.log(`  \x1b[33m⚠\x1b[0m oracle '${oracleName}' repo not found locally\n`);
+      return results;
+    }
+    const result = syncProjectVault(repoRoot, oraclePath, repoSlug, oracleName);
+    results.push(result);
+    reportProjectResult(result);
+  }
+
+  const totalAll = results.reduce((a, r) => a + r.total, 0);
+  if (totalAll > 0) {
+    console.log(`\n  \x1b[32m${totalAll} file(s) absorbed.\x1b[0m\n`);
+  } else {
+    console.log();
+  }
+  return results;
+}

--- a/src/commands/plugins/archive/internal/sync-helpers.ts
+++ b/src/commands/plugins/archive/internal/sync-helpers.ts
@@ -1,0 +1,150 @@
+import { existsSync, readdirSync, copyFileSync, mkdirSync, appendFileSync } from "fs";
+import { join } from "path";
+import { loadFleet } from "../../../shared/fleet-load";
+
+const SYNC_DIRS = ["memory/learnings", "memory/retrospectives", "memory/traces", "memory/collaborations"];
+
+/**
+ * Sync new files from src dir to dst dir (skip existing).
+ * Returns count of files copied.
+ */
+export function syncDir(srcDir: string, dstDir: string): number {
+  if (!existsSync(srcDir)) return 0;
+  let count = 0;
+
+  function walk(src: string, dst: string) {
+    let entries: string[];
+    try { entries = readdirSync(src, { withFileTypes: true } as any) as any; }
+    catch { return; }
+
+    for (const entry of entries as any[]) {
+      const srcPath = join(src, entry.name);
+      const dstPath = join(dst, entry.name);
+      if (entry.isDirectory()) {
+        walk(srcPath, dstPath);
+      } else if (!existsSync(dstPath)) {
+        try {
+          mkdirSync(dst, { recursive: true });
+          copyFileSync(srcPath, dstPath);
+          count++;
+        } catch { /* skip unreadable files */ }
+      }
+    }
+  }
+
+  walk(srcDir, dstDir);
+  return count;
+}
+
+/**
+ * Find peer oracle names for a given oracle from fleet config.
+ * Flat lookup — each oracle declares its own sync_peers.
+ */
+export function findPeers(oracleName: string): string[] {
+  const fleet = loadFleet();
+  for (const sess of fleet) {
+    const name = sess.name.replace(/^\d+-/, "");
+    if (name === oracleName && sess.sync_peers) return sess.sync_peers;
+  }
+  return [];
+}
+
+/**
+ * Find project repos this oracle absorbs from.
+ */
+export function findProjectsForOracle(oracleName: string): string[] {
+  const fleet = loadFleet();
+  for (const sess of fleet) {
+    const name = sess.name.replace(/^\d+-/, "");
+    if (name === oracleName) return sess.project_repos || [];
+  }
+  return [];
+}
+
+export interface SoulSyncResult {
+  from: string;
+  to: string;
+  synced: Record<string, number>;
+  total: number;
+}
+
+/**
+ * Sync ψ/memory/ from one oracle repo to another (new files only).
+ */
+export function syncOracleVaults(fromPath: string, toPath: string, fromName: string, toName: string): SoulSyncResult {
+  const fromVault = join(fromPath, "ψ");
+  const toVault = join(toPath, "ψ");
+
+  const synced: Record<string, number> = {};
+  for (const subdir of SYNC_DIRS) {
+    const src = join(fromVault, subdir);
+    const dst = join(toVault, subdir);
+    const count = syncDir(src, dst);
+    if (count > 0) synced[subdir] = count;
+  }
+
+  const total = Object.values(synced).reduce((a, b) => a + b, 0);
+
+  if (total > 0) {
+    const logDir = join(toVault, ".soul-sync");
+    try {
+      mkdirSync(logDir, { recursive: true });
+      const ts = new Date().toISOString();
+      const logLine = `${ts} | ${fromName} → ${toName} | ${total} files | ${Object.entries(synced).map(([k, v]) => `${v} ${k.split("/").pop()}`).join(", ")}\n`;
+      appendFileSync(join(logDir, "sync.log"), logLine);
+    } catch { /* non-critical */ }
+  }
+
+  return { from: fromName, to: toName, synced, total };
+}
+
+export interface ProjectSyncResult {
+  project: string;
+  oracle: string;
+  synced: Record<string, number>;
+  total: number;
+}
+
+/**
+ * Sync ψ/memory/ from a project repo into an oracle repo.
+ * Knowledge flows inward through the membrane — project → oracle, new files only.
+ */
+export function syncProjectVault(
+  projectPath: string,
+  oraclePath: string,
+  projectRepo: string,
+  oracleName: string,
+): ProjectSyncResult {
+  const projectVault = join(projectPath, "ψ");
+  const oracleVault = join(oraclePath, "ψ");
+
+  const synced: Record<string, number> = {};
+  for (const subdir of SYNC_DIRS) {
+    const src = join(projectVault, subdir);
+    const dst = join(oracleVault, subdir);
+    const count = syncDir(src, dst);
+    if (count > 0) synced[subdir] = count;
+  }
+  const total = Object.values(synced).reduce((a, b) => a + b, 0);
+
+  if (total > 0) {
+    const logDir = join(oracleVault, ".soul-sync");
+    try {
+      mkdirSync(logDir, { recursive: true });
+      const ts = new Date().toISOString();
+      const logLine = `${ts} | project:${projectRepo} → ${oracleName} | ${total} files | ${Object.entries(synced).map(([k, v]) => `${v} ${k.split("/").pop()}`).join(", ")}\n`;
+      appendFileSync(join(logDir, "sync.log"), logLine);
+    } catch { /* non-critical */ }
+  }
+
+  return { project: projectRepo, oracle: oracleName, synced, total };
+}
+
+export function reportProjectResult(r: ProjectSyncResult) {
+  if (r.total === 0) {
+    console.log(`  \x1b[90m○\x1b[0m project:${r.project} → ${r.oracle}: nothing new`);
+  } else {
+    const parts = Object.entries(r.synced).map(([dir, n]) => `${n} ${dir.split("/").pop()}`);
+    console.log(`  \x1b[32m✓\x1b[0m project:${r.project} → ${r.oracle}: ${parts.join(", ")}`);
+  }
+}

--- a/src/commands/plugins/bud/internal/resolve.ts
+++ b/src/commands/plugins/bud/internal/resolve.ts
@@ -1,0 +1,81 @@
+import { existsSync } from "fs";
+import { join } from "path";
+import { ghqFind } from "../../../../core/ghq";
+import { getGhqRoot } from "../../../../config/ghq-root";
+import { loadFleet } from "../../../shared/fleet-load";
+
+/**
+ * Resolve ghq path for an oracle name.
+ * Tries: ghqFind(`/<stem>-oracle$`) — case-insensitive ghq lookup.
+ *
+ * Defensive — accepts both bare oracle name ("neo") and full repo name
+ * ("neo-oracle"). Strips trailing "-oracle" before re-appending so callers
+ * passing either form land on the same lookup. (#372)
+ */
+export async function resolveOraclePath(name: string): Promise<string | null> {
+  // Strip trailing -oracle so "neo" and "neo-oracle" both resolve identically.
+  const stem = name.replace(/-oracle$/, "");
+  const out = await ghqFind(`/${stem}-oracle$`);
+  if (out) return out;
+
+  // Fallback: check fleet config for repo path
+  const reposRoot = join(getGhqRoot(), "github.com");
+  const fleet = loadFleet();
+  for (const sess of fleet) {
+    const oracleName = sess.name.replace(/^\d+-/, "");
+    if (oracleName === stem && sess.windows.length > 0) {
+      const repoPath = join(reposRoot, sess.windows[0].repo);
+      if (existsSync(repoPath)) return repoPath;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Resolve a git repo path to its canonical "org/repo" slug for `project_repos`
+ * lookup. Handles both shapes of `ghqRoot`:
+ *
+ *   A. github.com-rooted: `/home/neo/Code/github.com`
+ *      repoRoot = `/home/neo/Code/github.com/Soul-Brews-Studio/maw-js`
+ *      → rel = `Soul-Brews-Studio/maw-js` → slug = `Soul-Brews-Studio/maw-js`
+ *
+ *   B. bare ghq root:     `/home/neo/Code`
+ *      repoRoot = `/home/neo/Code/github.com/Soul-Brews-Studio/maw-js`
+ *      → rel = `github.com/Soul-Brews-Studio/maw-js` → (strip host) →
+ *        `Soul-Brews-Studio/maw-js` → slug = `Soul-Brews-Studio/maw-js`
+ *
+ * Before this normalization, shape B produced the org-only slug
+ * `github.com/Soul-Brews-Studio` because `.split("/").slice(0, 2)` grabbed
+ * the host + org instead of org + repo. See #193.
+ *
+ * Worktree suffix (`.wt-*`) is stripped from the repo segment so worktrees
+ * match their parent repo's `project_repos` entry.
+ *
+ * Returns null if `repoRoot` is not under `ghqRoot` or doesn't have the
+ * expected depth (e.g. sitting directly under ghqRoot with no org segment).
+ */
+export function resolveProjectSlug(repoRoot: string, ghqRoot: string): string | null {
+  if (!repoRoot.startsWith(ghqRoot)) return null;
+  let rel = repoRoot.slice(ghqRoot.length).replace(/^\/+/, "");
+  // If ghqRoot is the bare ghq root (not github.com-rooted), rel starts with
+  // a host segment — strip known forges so we always land at "<org>/<repo>".
+  rel = rel.replace(/^(github\.com|gitlab\.com|bitbucket\.org)\//, "");
+  const parts = rel.split("/").slice(0, 2);
+  if (parts.length !== 2 || !parts[0] || !parts[1]) return null;
+  parts[1] = parts[1].replace(/\.wt-.*$/, "");
+  return parts.join("/");
+}
+
+/**
+ * Find the oracle that owns a given project repo (org/repo slug).
+ */
+export function findOracleForProject(projectRepo: string): string | null {
+  const fleet = loadFleet();
+  for (const sess of fleet) {
+    if (sess.project_repos?.includes(projectRepo)) {
+      return sess.name.replace(/^\d+-/, "");
+    }
+  }
+  return null;
+}

--- a/src/commands/plugins/bud/internal/split-impl.ts
+++ b/src/commands/plugins/bud/internal/split-impl.ts
@@ -1,0 +1,133 @@
+import { listSessions, hostExec, withPaneLock } from "../../../../sdk";
+import { resolveSessionTarget } from "../../../../core/matcher/resolve-target";
+import { normalizeTarget } from "../../../../core/matcher/normalize-target";
+
+export interface SplitOpts {
+  /** Split percentage (1-99). Default: 50. */
+  pct?: number;
+  /** Split vertical (top/bottom) instead of horizontal (side-by-side). */
+  vertical?: boolean;
+  /** Split without attaching — leaves a plain shell in the new pane. */
+  noAttach?: boolean;
+  /** Serialize via the pane-creation lock + settle. Opt-in — only matters
+   *  when another in-process caller may be spawning concurrently. */
+  lock?: boolean;
+  /** Settle delay after split when lock=true. Default: 200ms. */
+  settleMs?: number;
+  /** Pane-id / selector to split beside instead of $TMUX_PANE. Break the
+   *  implicit active-pane-drift that caused fractal-split cascade (#545).
+   *  Accepts: "%N" (pane id), "session:window.pane", or "session:window". */
+  anchorPane?: string;
+}
+
+/**
+ * maw split <target> [--pct N] [--vertical] [--no-attach]
+ *
+ * Split the current tmux pane and attach to a target session in the new pane.
+ *
+ * Target resolution:
+ *   - "session:window"  → used as-is
+ *   - "session"         → resolved to session:window[0]
+ *   - bare oracle name  → finds session ending with "-<name>" or name === <name>
+ *
+ * Why this exists: `/bud --split` inlined this pattern, but (a) the nested
+ * `tmux attach-session` silently fails when $TMUX is set, and (b) the logic
+ * is useful beyond bud (worktree, pair-ops, debugging). Extracted here as
+ * one canonical helper — future skills call `maw split` instead of duplicating
+ * the tmux shell-out.
+ */
+export async function cmdSplit(target: string, opts: SplitOpts = {}) {
+  // Canonicalize first — drop trailing `/`, `/.git`, `/.git/` tab-completion artifacts.
+  // Safe for "session:window" form: nothing to strip unless the user adds a literal slash.
+  target = normalizeTarget(target);
+  if (!process.env.TMUX) {
+    throw new Error("maw split requires an active tmux session");
+  }
+
+  if (!target) {
+    console.error("usage: maw split <target> [--pct N] [--vertical] [--no-attach]");
+    console.error("  e.g. maw split yeast");
+    console.error("       maw split mawjs-view --pct 30 --vertical");
+    throw new Error("usage: maw split <target> [--pct N] [--vertical] [--no-attach]");
+  }
+
+  // Validate pct early so bad input never reaches tmux
+  const pct = opts.pct ?? 50;
+  if (!Number.isFinite(pct) || pct < 1 || pct > 99) {
+    throw new Error(`--pct must be 1-99 (got ${pct})`);
+  }
+
+  // Resolve target to session:window if bare name given. Resolution rules
+  // (exact > suffix/prefix fuzzy > ambiguous > none) live in the canonical
+  // matcher — silent wrong-answer is worse than a loud failure.
+  let resolved = target;
+  if (!target.includes(":")) {
+    const sessions = await listSessions();
+    const r = resolveSessionTarget(target, sessions);
+
+    if (r.kind === "ambiguous") {
+      console.error(`  \x1b[31m✗\x1b[0m '${target}' is ambiguous — matches ${r.candidates.length} sessions:`);
+      for (const s of r.candidates) {
+        console.error(`  \x1b[90m    • ${s.name}\x1b[0m`);
+      }
+      console.error(`  \x1b[90m  use the full name: maw split <exact-session>\x1b[0m`);
+      throw new Error(`'${target}' is ambiguous`);
+    }
+    if (r.kind === "none") {
+      console.error(`  \x1b[31m✗\x1b[0m session '${target}' not found in fleet`);
+      if (r.hints?.length) {
+        console.error(`  \x1b[90mdid you mean:\x1b[0m`);
+        for (const h of r.hints) {
+          console.error(`  \x1b[90m    • ${h.name}\x1b[0m`);
+        }
+      }
+      console.error(`  \x1b[90m  try: maw ls\x1b[0m`);
+      throw new Error(`session '${target}' not found in fleet`);
+    }
+
+    resolved = `${r.match.name}:${r.match.windows[0]?.index ?? 0}`;
+  }
+
+  // Build tmux split-window command.
+  //
+  // Critical: unset $TMUX in the spawned shell so the inner attach-session
+  // can nest into the target. Without `TMUX=`, tmux refuses nested attach
+  // and the new pane dies immediately (this is the #bud --split silent-fail bug).
+  //
+  // Target the caller's pane (#365 cascade fix): without -t, tmux splits
+  // the currently-active pane — which shifts after the first split, causing
+  // the second `maw bud <name> --split` from the same parent to silently
+  // split the wrong pane (or noop visually). Explicit -t $TMUX_PANE anchors
+  // every split to the caller's origin pane, so buds cascade instead of drifting.
+  // Fallback: if TMUX_PANE isn't set (shouldn't happen — we checked $TMUX above,
+  // and any pane inside tmux has TMUX_PANE set — but defend anyway), omit -t
+  // and accept the pre-fix behavior.
+  // Precedence: opts.anchorPane (explicit, from cmdView) > $TMUX_PANE (caller's
+  // pane) > none. Explicit anchor breaks the active-pane-drift that caused
+  // fractal-split cascade in #545/#546.
+  const direction = opts.vertical ? "-v" : "-h";
+  const innerCmd = opts.noAttach ? "bash" : `TMUX= tmux attach-session -t ${resolved}`;
+  const anchor = opts.anchorPane ?? process.env.TMUX_PANE;
+  const targetFlag = anchor ? `-t '${anchor.replace(/'/g, "'\\''")}' ` : "";
+  const cmd = `tmux split-window ${targetFlag}${direction} -l ${pct}% "${innerCmd}"`;
+
+  try {
+    if (opts.lock) {
+      // Serialize against other in-process pane spawns; settle before release
+      // so tmux has a tick to register the new pane index.
+      const settleMs = opts.settleMs ?? 200;
+      await withPaneLock(async () => {
+        await hostExec(cmd);
+        if (settleMs > 0) await new Promise((r) => setTimeout(r, settleMs));
+      });
+    } else {
+      await hostExec(cmd);
+    }
+    const side = opts.vertical ? "below" : "beside";
+    const action = opts.noAttach ? "empty pane" : resolved;
+    const anchorLabel = opts.anchorPane ? ` (anchored at ${opts.anchorPane})` : "";
+    console.log(`  \x1b[32m✓\x1b[0m split ${side} — ${action} (${pct}%)${anchorLabel}`);
+  } catch (e: any) {
+    throw new Error(`split failed: ${e.message || e}`);
+  }
+}

--- a/src/commands/plugins/cleanup/index.ts
+++ b/src/commands/plugins/cleanup/index.ts
@@ -1,5 +1,5 @@
 import type { InvokeContext, InvokeResult } from "../../../plugin/types";
-import { cmdCleanupZombies } from "../team/impl";
+import { cmdCleanupZombies } from "./internal/team-cleanup-zombies";
 
 export const command = {
   name: "cleanup",

--- a/src/commands/plugins/cleanup/internal/team-cleanup-zombies.ts
+++ b/src/commands/plugins/cleanup/internal/team-cleanup-zombies.ts
@@ -1,0 +1,116 @@
+import { readdirSync, existsSync } from "fs";
+import { join } from "path";
+import { tmux } from "../../../../sdk";
+import type { TmuxPane } from "../../../../sdk";
+import { loadFleetEntries } from "../../../shared/fleet-load";
+import { TEAMS_DIR, loadTeam } from "./team-helpers";
+
+// ─── maw cleanup --zombie-agents ───
+
+export async function cmdCleanupZombies(opts: { yes?: boolean } = {}) {
+  console.log("\x1b[36mScanning tmux panes...\x1b[0m");
+
+  const allPanes = await tmux.listPanes();
+  const zombies = findZombiePanes(allPanes);
+
+  if (!zombies.length) {
+    console.log("\x1b[32m✓\x1b[0m No zombie agent panes found.");
+    return;
+  }
+
+  console.log(`\nFound \x1b[33m${zombies.length}\x1b[0m orphan claude pane(s):\n`);
+  for (const z of zombies) {
+    console.log(`  \x1b[33m${z.paneId}\x1b[0m  ${z.info}  \x1b[90m(team: ${z.teamName} — DELETED)\x1b[0m`);
+  }
+
+  if (!opts.yes) {
+    console.log(`\nRun with \x1b[36m--yes\x1b[0m to kill them.`);
+    return;
+  }
+
+  for (const z of zombies) {
+    await tmux.killPane(z.paneId);
+    console.log(`\x1b[32m✓\x1b[0m killed ${z.paneId}`);
+  }
+}
+
+interface ZombiePane {
+  paneId: string;
+  info: string;
+  teamName: string;
+}
+
+/**
+ * Find zombie panes: tmux panes running `claude` that are NOT part of any
+ * live team config AND NOT part of the fleet. Fleet-exclusion is critical
+ * — without it, every live fleet oracle would be flagged as a zombie.
+ */
+export function findZombiePanes(allPanes: TmuxPane[]): ZombiePane[] {
+  // Get all known team pane IDs from existing team configs
+  const knownTeamPaneIds = new Set<string>();
+  let teamDirs: string[] = [];
+  try {
+    teamDirs = readdirSync(TEAMS_DIR).filter(d =>
+      existsSync(join(TEAMS_DIR, d, "config.json"))
+    );
+  } catch { /* no teams dir */ }
+
+  for (const dir of teamDirs) {
+    const team = loadTeam(dir);
+    if (!team) continue;
+    for (const m of team.members) {
+      if (m.tmuxPaneId && m.tmuxPaneId !== "in-process" && m.tmuxPaneId !== "") {
+        knownTeamPaneIds.add(m.tmuxPaneId);
+      }
+    }
+  }
+
+  // Compute the set of fleet session names (e.g. "01-pulse", "08-mawjs").
+  // Any pane whose target starts with "<fleet-session>:" is a live fleet
+  // oracle and must NEVER be flagged as a zombie.
+  const fleetSessions = new Set<string>();
+  try {
+    for (const entry of loadFleetEntries()) {
+      fleetSessions.add(entry.file.replace(/\.json$/, ""));
+    }
+  } catch { /* no fleet dir */ }
+
+  // Also allow meta-view sessions (maw-view + any *-view) which mirror fleet
+  // panes. Each oracle creates its meta-view as `<stem>-view` (e.g.
+  // mawjs-view, mawui-view). #393 Bug F — zombie-auditor iter3 caught this:
+  // hardcoding only "maw-view" left every oracle's live pane one keystroke
+  // away from being killed by `maw cleanup --zombie-agents --yes`.
+  const isViewSession = (s: string) => s === "maw-view" || /-view$/.test(s);
+
+  // Defense-in-depth: also compute the set of pane ids that have ANY fleet
+  // (or view) listing. If the same pane id appears across multiple sessions
+  // (tmux-linked windows), a single safe target is enough to mark it safe.
+  // This protects against tmux reporting the non-fleet session as canonical.
+  const safePaneIds = new Set<string>();
+  for (const p of allPanes) {
+    const session = p.target.split(":")[0];
+    if (fleetSessions.has(session) || isViewSession(session)) {
+      safePaneIds.add(p.id);
+    }
+  }
+
+  const isFleetPane = (target: string): boolean => {
+    const session = target.split(":")[0];
+    return fleetSessions.has(session) || isViewSession(session);
+  };
+
+  // Find claude panes that are (a) not in any team config AND
+  // (b) not in the fleet/view (by either target OR any other listing of the same pane)
+  return allPanes
+    .filter(p =>
+      p.command?.includes("claude") &&
+      !knownTeamPaneIds.has(p.id) &&
+      !isFleetPane(p.target) &&
+      !safePaneIds.has(p.id)
+    )
+    .map(p => ({
+      paneId: p.id,
+      info: `${p.target}  "${(p.title || "").slice(0, 50)}"`,
+      teamName: "unknown",
+    }));
+}

--- a/src/commands/plugins/cleanup/internal/team-helpers.ts
+++ b/src/commands/plugins/cleanup/internal/team-helpers.ts
@@ -1,0 +1,108 @@
+import { readFileSync, writeFileSync, existsSync, rmSync, mkdirSync } from "fs";
+import { join, dirname } from "path";
+import { homedir } from "os";
+
+// Exported for testing — override with _setDirs
+export let TEAMS_DIR = join(homedir(), ".claude/teams");
+export let TASKS_DIR = join(homedir(), ".claude/tasks");
+
+/** @internal — for tests only */
+export function _setDirs(teams: string, tasks: string) {
+  TEAMS_DIR = teams;
+  TASKS_DIR = tasks;
+}
+
+export interface TeamMember {
+  name: string;
+  agentId?: string;
+  agentType?: string;
+  tmuxPaneId?: string;
+  color?: string;
+  model?: string;
+  backendType?: string;
+}
+
+export interface TeamConfig {
+  name: string;
+  description?: string;
+  members: TeamMember[];
+  createdAt?: number;
+}
+
+export function loadTeam(name: string): TeamConfig | null {
+  const configPath = join(TEAMS_DIR, name, "config.json");
+  if (!existsSync(configPath)) return null;
+  try { return JSON.parse(readFileSync(configPath, "utf-8")); }
+  catch { return null; }
+}
+
+/**
+ * Resolve ψ/ directory by walking UP from cwd looking for an oracle root
+ * (marked by CLAUDE.md + ψ/). Falls back to cwd/ψ for backward compat when
+ * no marker is found. Prevents rogue nested vaults when the CLI is run from
+ * a sub-directory (#393 — Bug A).
+ */
+export function resolvePsi(): string {
+  let dir = process.cwd();
+  // Walk up looking for an oracle root (CLAUDE.md + ψ/ both present)
+  while (true) {
+    const psi = join(dir, "ψ");
+    if (existsSync(psi) && existsSync(join(dir, "CLAUDE.md"))) return psi;
+    const parent = dirname(dir);
+    if (parent === dir) break; // reached filesystem root
+    dir = parent;
+  }
+  // Fallback: legacy behavior — cwd/ψ, callers mkdir as needed
+  return join(process.cwd(), "ψ");
+}
+
+/**
+ * Write a shutdown_request message to a teammate's inbox file.
+ * This is the same protocol Claude Code uses internally via SendMessage.
+ */
+export function writeShutdownRequest(teamName: string, memberName: string, reason: string): void {
+  const inboxPath = join(TEAMS_DIR, teamName, "inboxes", `${memberName}.json`);
+  let messages: any[] = [];
+  if (existsSync(inboxPath)) {
+    try { messages = JSON.parse(readFileSync(inboxPath, "utf-8")); } catch { messages = []; }
+  }
+  const requestId = `shutdown-${Date.now()}@${memberName}`;
+  messages.push({
+    from: "maw-team-shutdown",
+    text: JSON.stringify({ type: "shutdown_request", reason, request_id: requestId }),
+    summary: `Shutdown request: ${reason}`,
+    timestamp: new Date().toISOString(),
+    read: false,
+  });
+  // lgtm[js/file-system-race] — PRIVATE-PATH: inbox under ~/.maw/teams/<team>/inboxes/, see docs/security/file-system-race-stance.md
+  writeFileSync(inboxPath, JSON.stringify(messages, null, 2));
+}
+
+/**
+ * Write a generic message to a teammate's inbox file.
+ * Same protocol as writeShutdownRequest but with type: "message".
+ */
+export function writeMessage(teamName: string, memberName: string, from: string, text: string): void {
+  const inboxPath = join(TEAMS_DIR, teamName, "inboxes", `${memberName}.json`);
+  let messages: any[] = [];
+  if (existsSync(inboxPath)) {
+    try { messages = JSON.parse(readFileSync(inboxPath, "utf-8")); } catch { messages = []; }
+  }
+  messages.push({
+    from,
+    text: JSON.stringify({ type: "message", content: text }),
+    summary: text.slice(0, 80),
+    timestamp: new Date().toISOString(),
+    read: false,
+  });
+  mkdirSync(join(TEAMS_DIR, teamName, "inboxes"), { recursive: true });
+  // lgtm[js/file-system-race] — PRIVATE-PATH: inbox under ~/.maw/teams/<team>/inboxes/, see docs/security/file-system-race-stance.md
+  writeFileSync(inboxPath, JSON.stringify(messages, null, 2));
+}
+
+export function cleanupTeamDir(name: string) {
+  const teamDir = join(TEAMS_DIR, name);
+  const tasksDir = join(TASKS_DIR, name);
+  if (existsSync(teamDir)) { try { rmSync(teamDir, { recursive: true }); } catch {} }
+  if (existsSync(tasksDir)) { try { rmSync(tasksDir, { recursive: true }); } catch {} }
+}

--- a/src/commands/plugins/doctor/impl.ts
+++ b/src/commands/plugins/doctor/impl.ts
@@ -2,8 +2,8 @@ import { existsSync, readFileSync, readlinkSync } from "fs";
 import { execSync } from "child_process";
 import { homedir } from "os";
 import { join, dirname, resolve } from "path";
-import { loadPeers } from "../peers/store";
-import { findDuplicateIdentities, formatDuplicate } from "../peers/duplicate-detect";
+import { loadPeers } from "./internal/peers-store";
+import { findDuplicateIdentities, formatDuplicate } from "./internal/duplicate-detect";
 import { loadConfig } from "../../../config";
 import { C } from "../../shared/fleet-doctor-fixer";
 import { loadManifestCached, invalidateManifest } from "../../../lib/oracle-manifest";
@@ -178,7 +178,7 @@ function listPm2MawProcs(): Pm2Proc[] | null {
  * will populate identity and bring them under the dedup umbrella).
  */
 function checkPeerDuplicates(): DoctorResult["checks"][number] {
-  let peers: Record<string, import("../peers/store").Peer> = {};
+  let peers: Record<string, import("./internal/peers-store").Peer> = {};
   try {
     peers = loadPeers().peers;
   } catch (e: any) {

--- a/src/commands/plugins/doctor/internal/duplicate-detect.ts
+++ b/src/commands/plugins/doctor/internal/duplicate-detect.ts
@@ -1,0 +1,104 @@
+/**
+ * peers/duplicate-detect.ts — #804 Step 3.
+ *
+ * Pure logic that scans the peer cache for duplicate `<oracle>:<node>` claims.
+ * Two peers in `peers.json` advertising the same `(oracle, node)` pair is
+ * almost certainly operator confusion — typically a copy-pasted alias setup,
+ * a forgotten `maw peers remove` after a node migration, or a fleet split-
+ * brain where the same identity got TOFU'd from two different URLs.
+ *
+ * Per ADR docs/federation/0001-peer-identity.md ("Crypto solves can't-fake;
+ * doctor + boot-time check solves operator confusion") — this layer does NOT
+ * refuse anything. It surfaces collisions; the operator decides whether to
+ * `maw peers remove` the loser, rename a node, or accept (multi-oracle on a
+ * single node, where the *oracle* names differ even though the *node* is one
+ * physical machine, is fine and won't trigger this — the key is the full
+ * `<oracle>:<node>` pair).
+ *
+ * Pure: no fs, no network. Caller passes in the peer set + optional local
+ * identity. That makes the module trivial to test and lets both the doctor
+ * subsystem and the `maw serve` startup hook reuse the same code path.
+ */
+import type { Peer } from "./peers-store";
+
+/** A single collision: two-or-more peers (or local + peers) sharing one key. */
+export interface DuplicateClaim {
+  /** Canonical `<oracle>:<node>` key the peers collide on. */
+  key: string;
+  /** All claimants — alias `"<local>"` is the running maw process itself. */
+  claimants: Array<{ alias: string; url?: string }>;
+}
+
+/**
+ * Build the map of `<oracle>:<node>` → claimants.
+ *
+ * Peers without an `identity` field are skipped (legacy peers; their oracle
+ * may differ from "mawjs" silently — surfacing them as collisions would be
+ * a false-positive against pre-Step-1 nodes that simply haven't been probed
+ * since the upgrade).
+ *
+ * The local identity is included as alias `"<local>"` so the boot-time check
+ * can spot "this maw IS something I'm also calling a peer" (often happens
+ * when an operator copy-pastes a federation snippet on the wrong machine).
+ */
+export function findDuplicateIdentities(
+  peers: Record<string, Peer>,
+  local?: { oracle: string; node: string },
+): DuplicateClaim[] {
+  const groups = new Map<string, Array<{ alias: string; url?: string }>>();
+
+  if (local) {
+    const localKey = `${local.oracle}:${local.node}`;
+    groups.set(localKey, [{ alias: "<local>" }]);
+  }
+
+  for (const [alias, peer] of Object.entries(peers)) {
+    if (!peer?.identity) continue;
+    const { oracle, node } = peer.identity;
+    if (!oracle || !node) continue;
+    const key = `${oracle}:${node}`;
+    const arr = groups.get(key) ?? [];
+    arr.push({ alias, url: peer.url });
+    groups.set(key, arr);
+  }
+
+  const dups: DuplicateClaim[] = [];
+  for (const [key, claimants] of groups) {
+    if (claimants.length >= 2) dups.push({ key, claimants });
+  }
+  // Stable order: by key, alphabetically.
+  dups.sort((a, b) => a.key.localeCompare(b.key));
+  return dups;
+}
+
+/**
+ * Format a one-line warning suitable for `maw doctor` output OR a `maw serve`
+ * startup log. Caller wraps in colors per its own log surface.
+ */
+export function formatDuplicate(d: DuplicateClaim): string {
+  const tail = d.claimants
+    .map(c => (c.url ? `${c.alias} (${c.url})` : c.alias))
+    .join(", ");
+  return `duplicate <oracle>:<node> claim "${d.key}" — ${tail}`;
+}
+
+/**
+ * Boot-time hook used by `startServer()`. Loads the peer cache + the
+ * caller-supplied local identity, then writes a YELLOW warning per
+ * collision via `console.warn`. Never throws — boot must continue per ADR.
+ *
+ * Returns the duplicates list so tests / callers can assert on it.
+ */
+export function warnDuplicatesAtBoot(args: {
+  peers: Record<string, Peer>;
+  local?: { oracle: string; node: string };
+  log?: (msg: string) => void;
+}): DuplicateClaim[] {
+  const log = args.log ?? ((m: string) => console.warn(m));
+  const dups = findDuplicateIdentities(args.peers, args.local);
+  for (const d of dups) {
+    log(`\x1b[33m⚠ ${formatDuplicate(d)}\x1b[0m`);
+    log(`\x1b[33m  investigate with \`maw peers list\` and \`maw peers remove <alias>\` if stale.\x1b[0m`);
+  }
+  return dups;
+}

--- a/src/commands/plugins/done/done-autosave.ts
+++ b/src/commands/plugins/done/done-autosave.ts
@@ -3,8 +3,8 @@ import { tmux } from "../../../sdk";
 import { appendFileSync, mkdirSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
-import { cmdReunion } from "../reunion/impl";
-import { cmdSoulSync } from "../soul-sync/impl";
+import { cmdReunion } from "./internal/reunion-impl";
+import { cmdSoulSync } from "./internal/soul-sync-impl";
 import type { DoneOpts } from "./impl";
 
 type SessionInfo = { name: string; windows: { index: number; name: string; active: boolean }[] };

--- a/src/commands/plugins/done/internal/resolve.ts
+++ b/src/commands/plugins/done/internal/resolve.ts
@@ -1,0 +1,81 @@
+import { existsSync } from "fs";
+import { join } from "path";
+import { ghqFind } from "../../../../core/ghq";
+import { getGhqRoot } from "../../../../config/ghq-root";
+import { loadFleet } from "../../../shared/fleet-load";
+
+/**
+ * Resolve ghq path for an oracle name.
+ * Tries: ghqFind(`/<stem>-oracle$`) — case-insensitive ghq lookup.
+ *
+ * Defensive — accepts both bare oracle name ("neo") and full repo name
+ * ("neo-oracle"). Strips trailing "-oracle" before re-appending so callers
+ * passing either form land on the same lookup. (#372)
+ */
+export async function resolveOraclePath(name: string): Promise<string | null> {
+  // Strip trailing -oracle so "neo" and "neo-oracle" both resolve identically.
+  const stem = name.replace(/-oracle$/, "");
+  const out = await ghqFind(`/${stem}-oracle$`);
+  if (out) return out;
+
+  // Fallback: check fleet config for repo path
+  const reposRoot = join(getGhqRoot(), "github.com");
+  const fleet = loadFleet();
+  for (const sess of fleet) {
+    const oracleName = sess.name.replace(/^\d+-/, "");
+    if (oracleName === stem && sess.windows.length > 0) {
+      const repoPath = join(reposRoot, sess.windows[0].repo);
+      if (existsSync(repoPath)) return repoPath;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Resolve a git repo path to its canonical "org/repo" slug for `project_repos`
+ * lookup. Handles both shapes of `ghqRoot`:
+ *
+ *   A. github.com-rooted: `/home/neo/Code/github.com`
+ *      repoRoot = `/home/neo/Code/github.com/Soul-Brews-Studio/maw-js`
+ *      → rel = `Soul-Brews-Studio/maw-js` → slug = `Soul-Brews-Studio/maw-js`
+ *
+ *   B. bare ghq root:     `/home/neo/Code`
+ *      repoRoot = `/home/neo/Code/github.com/Soul-Brews-Studio/maw-js`
+ *      → rel = `github.com/Soul-Brews-Studio/maw-js` → (strip host) →
+ *        `Soul-Brews-Studio/maw-js` → slug = `Soul-Brews-Studio/maw-js`
+ *
+ * Before this normalization, shape B produced the org-only slug
+ * `github.com/Soul-Brews-Studio` because `.split("/").slice(0, 2)` grabbed
+ * the host + org instead of org + repo. See #193.
+ *
+ * Worktree suffix (`.wt-*`) is stripped from the repo segment so worktrees
+ * match their parent repo's `project_repos` entry.
+ *
+ * Returns null if `repoRoot` is not under `ghqRoot` or doesn't have the
+ * expected depth (e.g. sitting directly under ghqRoot with no org segment).
+ */
+export function resolveProjectSlug(repoRoot: string, ghqRoot: string): string | null {
+  if (!repoRoot.startsWith(ghqRoot)) return null;
+  let rel = repoRoot.slice(ghqRoot.length).replace(/^\/+/, "");
+  // If ghqRoot is the bare ghq root (not github.com-rooted), rel starts with
+  // a host segment — strip known forges so we always land at "<org>/<repo>".
+  rel = rel.replace(/^(github\.com|gitlab\.com|bitbucket\.org)\//, "");
+  const parts = rel.split("/").slice(0, 2);
+  if (parts.length !== 2 || !parts[0] || !parts[1]) return null;
+  parts[1] = parts[1].replace(/\.wt-.*$/, "");
+  return parts.join("/");
+}
+
+/**
+ * Find the oracle that owns a given project repo (org/repo slug).
+ */
+export function findOracleForProject(projectRepo: string): string | null {
+  const fleet = loadFleet();
+  for (const sess of fleet) {
+    if (sess.project_repos?.includes(projectRepo)) {
+      return sess.name.replace(/^\d+-/, "");
+    }
+  }
+  return null;
+}

--- a/src/commands/plugins/done/internal/reunion-impl.ts
+++ b/src/commands/plugins/done/internal/reunion-impl.ts
@@ -1,0 +1,141 @@
+import { listSessions, hostExec } from "../../../../sdk";
+import { existsSync, readdirSync, copyFileSync, mkdirSync } from "fs";
+import { join, dirname } from "path";
+
+const SYNC_DIRS = ["memory/learnings", "memory/retrospectives", "memory/traces", "memory/collaborations"];
+
+/**
+ * Resolve the main oracle repo root from a worktree cwd.
+ * Uses git --git-common-dir which points to the shared .git in the main repo.
+ */
+async function resolveMainRepoRoot(cwd: string): Promise<string | null> {
+  try {
+    // git rev-parse --git-common-dir returns path to shared .git
+    const commonDir = (await hostExec(`git -C '${cwd}' rev-parse --git-common-dir`)).trim();
+    if (!commonDir || commonDir === ".git") return null; // already main repo
+
+    // commonDir is something like /path/to/main-repo/.git
+    // strip trailing /.git to get main repo root
+    const mainGit = commonDir.startsWith("/") ? commonDir : join(cwd, commonDir);
+    return dirname(mainGit);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Sync new files from src dir to dst dir (skip existing).
+ * Returns count of files copied.
+ */
+function syncDir(srcDir: string, dstDir: string): number {
+  if (!existsSync(srcDir)) return 0;
+  let count = 0;
+
+  function walk(src: string, dst: string) {
+    let entries: string[];
+    try { entries = readdirSync(src, { withFileTypes: true } as any) as any; }
+    catch { return; }
+
+    for (const entry of entries as any[]) {
+      const srcPath = join(src, entry.name);
+      const dstPath = join(dst, entry.name);
+      if (entry.isDirectory()) {
+        walk(srcPath, dstPath);
+      } else if (!existsSync(dstPath)) {
+        try {
+          mkdirSync(dst, { recursive: true });
+          copyFileSync(srcPath, dstPath);
+          count++;
+        } catch { /* skip unreadable files */ }
+      }
+    }
+  }
+
+  walk(srcDir, dstDir);
+  return count;
+}
+
+export interface ReunionResult {
+  mainRoot: string;
+  synced: Record<string, number>;
+  total: number;
+}
+
+/**
+ * maw reunion [window]
+ *
+ * Sync ψ/memory/ from a worktree back to the main oracle repo.
+ * Subdirs synced: memory/learnings, memory/retrospectives, memory/traces
+ * Skip existing files (never overwrite main).
+ */
+export async function cmdReunion(windowName?: string): Promise<ReunionResult | null> {
+  // 1. Resolve cwd
+  let cwd = "";
+  if (windowName) {
+    const sessions = await listSessions();
+    const wl = windowName.toLowerCase();
+    let target = "";
+    for (const s of sessions) {
+      const w = s.windows.find(w => w.name.toLowerCase() === wl);
+      if (w) { target = `${s.name}:${w.name}`; break; }
+    }
+    if (!target) {
+      console.log(`  \x1b[33m⚠\x1b[0m reunion: window '${windowName}' not found, skipping`);
+      return null;
+    }
+    try {
+      cwd = (await hostExec(`tmux display-message -t '${target}' -p '#{pane_current_path}'`)).trim();
+    } catch {
+      console.log(`  \x1b[33m⚠\x1b[0m reunion: could not get cwd for ${target}`);
+      return null;
+    }
+  } else {
+    // Use current pane's cwd
+    try {
+      cwd = (await hostExec("tmux display-message -p '#{pane_current_path}'")).trim();
+    } catch {
+      console.log(`  \x1b[33m⚠\x1b[0m reunion: not in tmux, cannot determine cwd`);
+      return null;
+    }
+  }
+
+  // 2. Find ψ/ in cwd
+  const wtVault = join(cwd, "ψ");
+  if (!existsSync(wtVault)) {
+    console.log(`  \x1b[90m○\x1b[0m reunion: no ψ/ in ${cwd}, skipping`);
+    return null;
+  }
+
+  // 3. Find main oracle repo
+  const mainRoot = await resolveMainRepoRoot(cwd);
+  if (!mainRoot) {
+    console.log(`  \x1b[90m○\x1b[0m reunion: not a worktree (already main), skipping`);
+    return null;
+  }
+
+  const mainVault = join(mainRoot, "ψ");
+
+  // 4. Sync subdirs
+  const synced: Record<string, number> = {};
+  for (const subdir of SYNC_DIRS) {
+    const src = join(wtVault, subdir);
+    const dst = join(mainVault, subdir);
+    const count = syncDir(src, dst);
+    if (count > 0) synced[subdir] = count;
+  }
+
+  const total = Object.values(synced).reduce((a, b) => a + b, 0);
+
+  // 5. Report
+  if (total === 0) {
+    console.log(`  \x1b[90m○\x1b[0m reunion: nothing new to sync to main (${mainRoot.split("/").pop()})`);
+  } else {
+    const parts = Object.entries(synced).map(([dir, n]) => {
+      const label = dir.split("/").pop()!;
+      return `${n} ${label}`;
+    });
+    console.log(`  \x1b[32m✓\x1b[0m reunion: synced ${parts.join(", ")} → ${mainRoot.split("/").pop()}/ψ/`);
+  }
+
+  return { mainRoot, synced, total };
+}

--- a/src/commands/plugins/done/internal/soul-sync-impl.ts
+++ b/src/commands/plugins/done/internal/soul-sync-impl.ts
@@ -1,0 +1,166 @@
+import { existsSync } from "fs";
+import { join, basename } from "path";
+import { hostExec } from "../../../../sdk";
+import { getGhqRoot } from "../../../../config/ghq-root";
+import { findPeers, findProjectsForOracle, syncOracleVaults, syncProjectVault, reportProjectResult, type SoulSyncResult, type ProjectSyncResult } from "./sync-helpers";
+import { resolveOraclePath, resolveProjectSlug, findOracleForProject } from "./resolve";
+
+export { syncDir, findPeers, findProjectsForOracle, syncProjectVault } from "./sync-helpers";
+export type { SoulSyncResult, ProjectSyncResult } from "./sync-helpers";
+export { resolveOraclePath, resolveProjectSlug, findOracleForProject } from "./resolve";
+
+/**
+ * maw soul-sync [peer] [--from <peer>] — push ψ/ to peers; --from reverses direction.
+ * maw ss <peer>       push to specific peer
+ * maw ss --from <p>   pull from specific peer
+ */
+export async function cmdSoulSync(target?: string, opts?: { from?: boolean; cwd?: string }): Promise<SoulSyncResult[]> {
+  const results: SoulSyncResult[] = [];
+
+  let cwd = opts?.cwd || "";
+  if (!cwd) {
+    try {
+      cwd = (await hostExec("tmux display-message -p '#{pane_current_path}'")).trim();
+    } catch {
+      cwd = process.cwd();
+    }
+  }
+
+  const cwdParts = cwd.split("/");
+  const repoName = cwdParts.pop() || "";
+  // Strip `.wt-…` worktree suffix via indexOf — non-regex to avoid CodeQL polynomial-redos flag.
+  const wtIdx = repoName.indexOf(".wt-");
+  const baseRepo = wtIdx >= 0 ? repoName.slice(0, wtIdx) : repoName;
+  const oracleName = baseRepo.replace(/-oracle$/, "");
+
+  let oraclePath = cwd;
+  try {
+    const commonDir = (await hostExec(`git -C '${cwd}' rev-parse --git-common-dir`)).trim();
+    if (commonDir && commonDir !== ".git") {
+      const mainGit = commonDir.startsWith("/") ? commonDir : join(cwd, commonDir);
+      oraclePath = join(mainGit, "..");
+    }
+  } catch { /* use cwd */ }
+
+  const peers = target ? [target] : findPeers(oracleName);
+  if (peers.length === 0) {
+    console.log(`  \x1b[33m⚠\x1b[0m soul-sync: no sync_peers configured for '${oracleName}'`);
+    console.log(`  \x1b[90mAdd "sync_peers": ["name"] to fleet config, or run: maw ss <peer>\x1b[0m`);
+    return results;
+  }
+
+  const direction = opts?.from ? "pull" : "push";
+  const label = direction === "pull"
+    ? `pulling ${peers[0]} → ${oracleName}`
+    : `pushing ${oracleName} → ${peers.join(", ")}`;
+  console.log(`\n  \x1b[36m⚡ Soul Sync\x1b[0m — ${label}\n`);
+
+  for (const peer of peers) {
+    const peerPath = await resolveOraclePath(peer);
+    if (!peerPath) {
+      console.log(`  \x1b[33m⚠\x1b[0m ${peer}: repo not found, skipping`);
+      continue;
+    }
+
+    const [from, to, fromName, toName] = direction === "pull"
+      ? [peerPath, oraclePath, peer, oracleName]
+      : [oraclePath, peerPath, oracleName, peer];
+
+    const result = syncOracleVaults(from, to, fromName, toName);
+    results.push(result);
+
+    if (result.total === 0) {
+      console.log(`  \x1b[90m○\x1b[0m ${fromName} → ${toName}: nothing new`);
+    } else {
+      const parts = Object.entries(result.synced).map(([dir, n]) => `${n} ${dir.split("/").pop()}`);
+      console.log(`  \x1b[32m✓\x1b[0m ${fromName} → ${toName}: ${parts.join(", ")}`);
+    }
+  }
+
+  const totalAll = results.reduce((a, r) => a + r.total, 0);
+  if (totalAll > 0) {
+    console.log(`\n  \x1b[32m${totalAll} file(s) synced.\x1b[0m\n`);
+  } else {
+    console.log();
+  }
+
+  return results;
+}
+
+/**
+ * maw soul-sync --project — absorb project ψ/ into oracle ψ/ (inward only).
+ * Oracle cwd: absorbs from each project_repos entry.
+ * Project cwd: pushes ψ/ to the oracle that owns this repo.
+ */
+export async function cmdSoulSyncProject(opts?: { cwd?: string }): Promise<ProjectSyncResult[]> {
+  const results: ProjectSyncResult[] = [];
+  const reposRoot = join(getGhqRoot(), "github.com");
+
+  let cwd = opts?.cwd || "";
+  if (!cwd) {
+    try {
+      cwd = (await hostExec("tmux display-message -p '#{pane_current_path}'")).trim();
+    } catch {
+      cwd = process.cwd();
+    }
+  }
+
+  let repoRoot = cwd;
+  try {
+    const top = (await hostExec(`git -C '${cwd}' rev-parse --show-toplevel`)).trim();
+    if (top) repoRoot = top;
+  } catch { /* not a git repo */ }
+
+  const repoSlug = resolveProjectSlug(repoRoot, reposRoot);
+  const repoBase = basename(repoRoot).replace(/\.wt-.*$/, "");
+  const isOracle = repoBase.endsWith("-oracle");
+
+  console.log(`\n  \x1b[36m⚡ Soul Sync (project)\x1b[0m — ${isOracle ? "absorbing into" : "exporting from"} ${repoBase}\n`);
+
+  if (isOracle) {
+    const oracleName = repoBase.replace(/-oracle$/, "");
+    const projects = findProjectsForOracle(oracleName);
+    if (projects.length === 0) {
+      console.log(`  \x1b[33m⚠\x1b[0m no project_repos configured for '${oracleName}'`);
+      console.log(`  \x1b[90mAdd "project_repos": ["org/repo"] to fleet config for ${oracleName}.\x1b[0m\n`);
+      return results;
+    }
+    for (const projectRepo of projects) {
+      const projectPath = join(reposRoot, projectRepo);
+      if (!existsSync(projectPath)) {
+        console.log(`  \x1b[33m⚠\x1b[0m ${projectRepo}: not found at ${projectPath}, skipping`);
+        continue;
+      }
+      const result = syncProjectVault(projectPath, repoRoot, projectRepo, oracleName);
+      results.push(result);
+      reportProjectResult(result);
+    }
+  } else {
+    if (!repoSlug) {
+      console.log(`  \x1b[33m⚠\x1b[0m cannot resolve project slug from ${repoRoot} (not under repos root ${reposRoot})\n`);
+      return results;
+    }
+    const oracleName = findOracleForProject(repoSlug);
+    if (!oracleName) {
+      console.log(`  \x1b[33m⚠\x1b[0m no oracle owns project '${repoSlug}'`);
+      console.log(`  \x1b[90mAdd "project_repos": ["${repoSlug}"] to an oracle's fleet config.\x1b[0m\n`);
+      return results;
+    }
+    const oraclePath = await resolveOraclePath(oracleName);
+    if (!oraclePath) {
+      console.log(`  \x1b[33m⚠\x1b[0m oracle '${oracleName}' repo not found locally\n`);
+      return results;
+    }
+    const result = syncProjectVault(repoRoot, oraclePath, repoSlug, oracleName);
+    results.push(result);
+    reportProjectResult(result);
+  }
+
+  const totalAll = results.reduce((a, r) => a + r.total, 0);
+  if (totalAll > 0) {
+    console.log(`\n  \x1b[32m${totalAll} file(s) absorbed.\x1b[0m\n`);
+  } else {
+    console.log();
+  }
+  return results;
+}

--- a/src/commands/plugins/done/internal/sync-helpers.ts
+++ b/src/commands/plugins/done/internal/sync-helpers.ts
@@ -1,0 +1,150 @@
+import { existsSync, readdirSync, copyFileSync, mkdirSync, appendFileSync } from "fs";
+import { join } from "path";
+import { loadFleet } from "../../../shared/fleet-load";
+
+const SYNC_DIRS = ["memory/learnings", "memory/retrospectives", "memory/traces", "memory/collaborations"];
+
+/**
+ * Sync new files from src dir to dst dir (skip existing).
+ * Returns count of files copied.
+ */
+export function syncDir(srcDir: string, dstDir: string): number {
+  if (!existsSync(srcDir)) return 0;
+  let count = 0;
+
+  function walk(src: string, dst: string) {
+    let entries: string[];
+    try { entries = readdirSync(src, { withFileTypes: true } as any) as any; }
+    catch { return; }
+
+    for (const entry of entries as any[]) {
+      const srcPath = join(src, entry.name);
+      const dstPath = join(dst, entry.name);
+      if (entry.isDirectory()) {
+        walk(srcPath, dstPath);
+      } else if (!existsSync(dstPath)) {
+        try {
+          mkdirSync(dst, { recursive: true });
+          copyFileSync(srcPath, dstPath);
+          count++;
+        } catch { /* skip unreadable files */ }
+      }
+    }
+  }
+
+  walk(srcDir, dstDir);
+  return count;
+}
+
+/**
+ * Find peer oracle names for a given oracle from fleet config.
+ * Flat lookup — each oracle declares its own sync_peers.
+ */
+export function findPeers(oracleName: string): string[] {
+  const fleet = loadFleet();
+  for (const sess of fleet) {
+    const name = sess.name.replace(/^\d+-/, "");
+    if (name === oracleName && sess.sync_peers) return sess.sync_peers;
+  }
+  return [];
+}
+
+/**
+ * Find project repos this oracle absorbs from.
+ */
+export function findProjectsForOracle(oracleName: string): string[] {
+  const fleet = loadFleet();
+  for (const sess of fleet) {
+    const name = sess.name.replace(/^\d+-/, "");
+    if (name === oracleName) return sess.project_repos || [];
+  }
+  return [];
+}
+
+export interface SoulSyncResult {
+  from: string;
+  to: string;
+  synced: Record<string, number>;
+  total: number;
+}
+
+/**
+ * Sync ψ/memory/ from one oracle repo to another (new files only).
+ */
+export function syncOracleVaults(fromPath: string, toPath: string, fromName: string, toName: string): SoulSyncResult {
+  const fromVault = join(fromPath, "ψ");
+  const toVault = join(toPath, "ψ");
+
+  const synced: Record<string, number> = {};
+  for (const subdir of SYNC_DIRS) {
+    const src = join(fromVault, subdir);
+    const dst = join(toVault, subdir);
+    const count = syncDir(src, dst);
+    if (count > 0) synced[subdir] = count;
+  }
+
+  const total = Object.values(synced).reduce((a, b) => a + b, 0);
+
+  if (total > 0) {
+    const logDir = join(toVault, ".soul-sync");
+    try {
+      mkdirSync(logDir, { recursive: true });
+      const ts = new Date().toISOString();
+      const logLine = `${ts} | ${fromName} → ${toName} | ${total} files | ${Object.entries(synced).map(([k, v]) => `${v} ${k.split("/").pop()}`).join(", ")}\n`;
+      appendFileSync(join(logDir, "sync.log"), logLine);
+    } catch { /* non-critical */ }
+  }
+
+  return { from: fromName, to: toName, synced, total };
+}
+
+export interface ProjectSyncResult {
+  project: string;
+  oracle: string;
+  synced: Record<string, number>;
+  total: number;
+}
+
+/**
+ * Sync ψ/memory/ from a project repo into an oracle repo.
+ * Knowledge flows inward through the membrane — project → oracle, new files only.
+ */
+export function syncProjectVault(
+  projectPath: string,
+  oraclePath: string,
+  projectRepo: string,
+  oracleName: string,
+): ProjectSyncResult {
+  const projectVault = join(projectPath, "ψ");
+  const oracleVault = join(oraclePath, "ψ");
+
+  const synced: Record<string, number> = {};
+  for (const subdir of SYNC_DIRS) {
+    const src = join(projectVault, subdir);
+    const dst = join(oracleVault, subdir);
+    const count = syncDir(src, dst);
+    if (count > 0) synced[subdir] = count;
+  }
+  const total = Object.values(synced).reduce((a, b) => a + b, 0);
+
+  if (total > 0) {
+    const logDir = join(oracleVault, ".soul-sync");
+    try {
+      mkdirSync(logDir, { recursive: true });
+      const ts = new Date().toISOString();
+      const logLine = `${ts} | project:${projectRepo} → ${oracleName} | ${total} files | ${Object.entries(synced).map(([k, v]) => `${v} ${k.split("/").pop()}`).join(", ")}\n`;
+      appendFileSync(join(logDir, "sync.log"), logLine);
+    } catch { /* non-critical */ }
+  }
+
+  return { project: projectRepo, oracle: oracleName, synced, total };
+}
+
+export function reportProjectResult(r: ProjectSyncResult) {
+  if (r.total === 0) {
+    console.log(`  \x1b[90m○\x1b[0m project:${r.project} → ${r.oracle}: nothing new`);
+  } else {
+    const parts = Object.entries(r.synced).map(([dir, n]) => `${n} ${dir.split("/").pop()}`);
+    console.log(`  \x1b[32m✓\x1b[0m project:${r.project} → ${r.oracle}: ${parts.join(", ")}`);
+  }
+}

--- a/src/commands/plugins/init/bootstrap-plugins-lock.ts
+++ b/src/commands/plugins/init/bootstrap-plugins-lock.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync } from "fs";
 import { dirname } from "path";
-import { LOCK_SCHEMA, lockPath, writeLock } from "../plugin/lock";
+import { LOCK_SCHEMA, lockPath, writeLock } from "./internal/plugin-lock";
 
 export interface BootstrapPluginsLockResult {
   created: boolean;

--- a/src/commands/plugins/init/internal/install-extraction.ts
+++ b/src/commands/plugins/init/internal/install-extraction.ts
@@ -1,0 +1,210 @@
+/**
+ * install-impl seam: tarball extraction, URL download, artifact hash verify.
+ */
+
+import type { PluginManifest } from "../../../../plugin/types";
+import { spawnSync } from "child_process";
+import { existsSync, mkdtempSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { basename, join } from "path";
+import { hashFile } from "../../../../plugin/registry";
+
+const MAX_DOWNLOAD_BYTES = 50 * 1024 * 1024; // 50 MB
+
+/**
+ * Run `tar -xzf <tarball> -C <destDir>` synchronously. Returns true on success.
+ * We shell out to GNU tar rather than adding a `tar` npm dep — Bun ships without
+ * streaming tar, and adding a dep for a single call is not worth it.
+ */
+export function extractTarball(tarballPath: string, destDir: string): { ok: true } | { ok: false; error: string } {
+  // Path-traversal guard: list entries first, reject any that escape the staging dir.
+  // GNU tar does not strip "../" by default; -C alone does not prevent traversal.
+  const list = spawnSync("tar", ["-tzf", tarballPath], { encoding: "utf8" });
+  if (list.status !== 0) {
+    return { ok: false, error: `tar list failed: ${list.stderr || list.stdout || `exit ${list.status}`}` };
+  }
+  for (const entry of list.stdout.split("\n").filter(Boolean)) {
+    if (entry.startsWith("/") || entry.split("/").includes("..")) {
+      return { ok: false, error: `tarball rejected: path traversal in entry "${entry}"` };
+    }
+  }
+
+  const r = spawnSync("tar", ["-xzf", tarballPath, "-C", destDir], {
+    encoding: "utf8",
+  });
+  if (r.status !== 0) {
+    return { ok: false, error: `tar extract failed: ${r.stderr || r.stdout || `exit ${r.status}`}` };
+  }
+  return { ok: true };
+}
+
+/**
+ * Download a URL to a temp file. Verifies the content type looks like gzip/tar
+ * before writing (per brief: "verify content-type is gzip/tar").
+ */
+export async function downloadTarball(url: string): Promise<{ ok: true; path: string } | { ok: false; error: string }> {
+  // Scheme gate — defense in depth; detectMode already filters callers from cmdPluginInstall
+  // but direct callers of this function would bypass that upstream check.
+  if (!/^https?:\/\//i.test(url)) {
+    return { ok: false, error: `download refused: only http/https URLs are allowed (got ${JSON.stringify(url.slice(0, 32))})` };
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(url);
+  } catch (e: any) {
+    return { ok: false, error: `download failed: ${e.message}` };
+  }
+  if (!res.ok) {
+    return { ok: false, error: `download failed: HTTP ${res.status} ${res.statusText}` };
+  }
+
+  // Size cap: reject before buffering if Content-Length already exceeds limit.
+  const declared = Number(res.headers.get("content-length") ?? 0);
+  if (declared > MAX_DOWNLOAD_BYTES) {
+    return { ok: false, error: `download refused: Content-Length ${declared} exceeds ${MAX_DOWNLOAD_BYTES} byte limit` };
+  }
+
+  const ct = (res.headers.get("content-type") ?? "").toLowerCase();
+  const ctOk =
+    ct.includes("gzip") ||
+    ct.includes("x-gzip") ||
+    ct.includes("x-tar") ||
+    ct.includes("tar+gzip") ||
+    ct.includes("octet-stream"); // many CDNs return generic binary
+  if (!ctOk) {
+    return { ok: false, error: `unexpected content-type ${JSON.stringify(ct)} — expected gzip/tar` };
+  }
+
+  const buf = new Uint8Array(await res.arrayBuffer());
+  // Cap actual bytes too — Content-Length can be absent or spoofed.
+  if (buf.byteLength > MAX_DOWNLOAD_BYTES) {
+    return { ok: false, error: `download refused: response body (${buf.byteLength} bytes) exceeds ${MAX_DOWNLOAD_BYTES} byte limit` };
+  }
+
+  const tmp = mkdtempSync(join(tmpdir(), "maw-dl-"));
+  const filename = basename(new URL(url).pathname) || "plugin.tgz";
+  const outPath = join(tmp, filename);
+  writeFileSync(outPath, buf);
+  return { ok: true, path: outPath };
+}
+
+/**
+ * Source-plugin detector (#874 path A.3, hardened in #896).
+ *
+ * A "source plugin" is one that ships executable source rather than a
+ * pre-built bundle — typical of community repos with `src/index.ts` +
+ * `plugin.json` and no `dist/`. Bun runs `.ts`/`.js` source transparently,
+ * so the install path can accept them without an ahead-of-time build. We
+ * still hash the entry file's bytes for plugins.lock parity so
+ * `recordInstall` / `--pin` / hash-mismatch all work uniformly.
+ *
+ * #896 — hardened to accept EITHER of:
+ *   • no `artifact` + has `entry`         (canonical source shape, #874 A.3)
+ *   • has `artifact.sha256 === null` + has `entry`  (half-built — entry is
+ *     authoritative because the artifact has no committed bytes to verify)
+ *
+ * The second branch matters because parseManifest accepts `artifact.sha256
+ * = null` as valid (a manifest mid-build). Pre-#896 those tarballs hit the
+ * `manifest.artifact` truthy branch, fell through `verifyArtifactHash`'s
+ * sha256-null fencepost, and never tried the perfectly valid `entry`. The
+ * symptom looked like a stale-binary regression (#896): the user filed
+ * `tarball manifest has no 'artifact' field` even on tarballs whose
+ * plugin.json clearly had `entry: "./src/index.ts"` — the artifact branch
+ * was rejecting them before the entry branch could rescue.
+ */
+export function isSourcePluginManifest(manifest: PluginManifest): boolean {
+  const hasEntry = typeof manifest.entry === "string" && manifest.entry.length > 0;
+  if (!hasEntry) return false;
+  // Canonical source shape: no artifact at all.
+  if (!manifest.artifact) return true;
+  // Half-built: artifact declared but sha256 not yet computed. Entry is the
+  // authoritative byte source.
+  if (manifest.artifact.sha256 === null) return true;
+  return false;
+}
+
+/**
+ * Verify sha256 of `manifest.artifact.path` (relative to `dir`) matches
+ * `expected`. If `expected` is null/undefined, the manifest's embedded hash is
+ * used as the expected value — this is the legacy (circular) check kept as a
+ * defense-in-depth fencepost for transport corruption. See #487 / plugins.lock
+ * for the real adversarial check (registry-pinned hashes).
+ *
+ * #874 path A.3 — for source plugins (no `artifact`, has `entry`), the entry
+ * file's bytes ARE the artifact. Hash that instead.
+ *
+ * #896 — when `manifest.artifact.path` doesn't exist on disk but the
+ * manifest also declares `entry`, fall back to entry. Defensive against
+ * tarballs whose artifact path got out of sync with their actual contents
+ * (e.g. registry source republished with a stale dist reference).
+ */
+export function verifyArtifactHashAgainst(
+  dir: string,
+  manifest: PluginManifest,
+  expected: string,
+): { ok: true } | { ok: false; error: string } {
+  let relPath: string;
+  // #896: entry-first when source-shaped — covers no-artifact AND
+  // half-built (sha256:null) shapes uniformly.
+  if (isSourcePluginManifest(manifest)) {
+    relPath = manifest.entry!;
+  } else if (manifest.artifact) {
+    relPath = manifest.artifact.path;
+    // #896: artifact declared but missing on disk — try entry rescue.
+    if (!existsSync(join(dir, relPath)) && typeof manifest.entry === "string" && manifest.entry.length > 0) {
+      relPath = manifest.entry;
+    }
+  } else {
+    return { ok: false, error: "tarball manifest has no 'artifact' or 'entry' field — rebuild with `maw plugin build` or declare an entry path" };
+  }
+  const artifactPath = join(dir, relPath);
+  if (!existsSync(artifactPath)) {
+    return { ok: false, error: `artifact missing at ${relPath}` };
+  }
+  const observed = hashFile(artifactPath);
+  if (observed !== expected) {
+    return {
+      ok: false,
+      error:
+        `artifact hash mismatch — refusing to install.\n` +
+        `  expected: ${expected}\n` +
+        `  actual:   ${observed}`,
+    };
+  }
+  return { ok: true };
+}
+
+/**
+ * Legacy manifest-only hash check. Kept as defense-in-depth fencepost per
+ * #487 §8 Phase 1.
+ *
+ * #874 path A.3 — source plugins (no `artifact`, has `entry`) skip this
+ * fencepost: there is no embedded hash to check against, so the registry-
+ * pinned hash in plugins.lock is the only authoritative source. Tampering
+ * is still detected at the pinned-hash check in `installFromTarball`.
+ *
+ * #896 — `isSourcePluginManifest` now accepts both no-artifact and
+ * half-built (artifact.sha256===null) shapes when entry is present. Both
+ * fall through to entry-only existence verification.
+ */
+export function verifyArtifactHash(dir: string, manifest: PluginManifest): { ok: true } | { ok: false; error: string } {
+  if (isSourcePluginManifest(manifest)) {
+    // Source plugins have no embedded sha256 to fencepost against. Verify the
+    // entry file at least exists; the real adversarial check is plugins.lock.
+    const entryPath = join(dir, manifest.entry!);
+    if (!existsSync(entryPath)) {
+      return { ok: false, error: `source entry missing at ${manifest.entry}` };
+    }
+    return { ok: true };
+  }
+  if (!manifest.artifact) {
+    return { ok: false, error: "tarball manifest has no 'artifact' or 'entry' field — rebuild with `maw plugin build` or declare an entry path" };
+  }
+  if (manifest.artifact.sha256 === null) {
+    // Should be unreachable thanks to #896 isSourcePluginManifest covering
+    // half-built + entry. Kept as a fencepost for the no-entry case.
+    return { ok: false, error: "tarball manifest has artifact.sha256=null (unbuilt) and no entry fallback — rebuild with `maw plugin build`" };
+  }
+  return verifyArtifactHashAgainst(dir, manifest, manifest.artifact.sha256);
+}

--- a/src/commands/plugins/init/internal/install-manifest-helpers.ts
+++ b/src/commands/plugins/init/internal/install-manifest-helpers.ts
@@ -1,0 +1,122 @@
+/**
+ * install-impl seam: manifest reading + success printing helpers.
+ */
+
+import type { PluginManifest } from "../../../../plugin/types";
+import { existsSync, readFileSync, readdirSync, statSync } from "fs";
+import { join } from "path";
+import { parseManifest } from "../../../../plugin/manifest";
+import { runtimeSdkVersion } from "../../../../plugin/registry";
+
+/**
+ * #864 — Resolve the plugin root inside an extracted staging dir.
+ *
+ * `maw plugin build` produces flat tarballs (plugin.json at root). But
+ * GitHub-archive tarballs (`github:OWNER/REPO#REF` registry sources, used by
+ * shellenv/bg/rename/park) extract with a wrapping `<repo>-<ref>/` directory,
+ * and npm tarballs likewise wrap in `package/`. Both leave plugin.json one
+ * level down, breaking root-only manifest discovery.
+ *
+ * Walks at most one level: if plugin.json exists at root, returns root; else
+ * if root contains exactly one entry — a directory — with plugin.json inside,
+ * returns that subdir; else returns null. The extractTarball() path-traversal
+ * guard ensures every entry lives under the staging dir, so walking one level
+ * is safe.
+ */
+export function findPluginRoot(stagingDir: string): string | null {
+  if (existsSync(join(stagingDir, "plugin.json"))) return stagingDir;
+  let entries: string[];
+  try { entries = readdirSync(stagingDir); } catch { return null; }
+  if (entries.length !== 1) return null;
+  const inner = join(stagingDir, entries[0]!);
+  try { if (!statSync(inner).isDirectory()) return null; } catch { return null; }
+  if (existsSync(join(inner, "plugin.json"))) return inner;
+  return null;
+}
+
+/**
+ * Resolve the plugin root inside an extracted monorepo staging dir
+ * (maw-plugin-registry#2). The registry repo's tarball, fetched via the
+ * `monorepo:plugins/<name>@<tag>` source format, is wrapped by github in
+ * `<repo>-<tag>/` and contains the FULL repo at that tag — so the plugin
+ * doesn't live at the root, it lives under a known subpath
+ * (typically `plugins/<name>/`).
+ *
+ * Walk: optional wrapper-dir descent (matching findPluginRoot's one-level
+ * walk), then descend into `subpath`. Returns null if no `plugin.json` is
+ * found at the resolved location.
+ *
+ * Path-traversal is gated upstream by `extractTarball`'s entry list check;
+ * we still refuse `..` segments in the parsed subpath (parseMonorepoRef).
+ */
+export function findMonorepoPluginRoot(stagingDir: string, subpath: string): string | null {
+  // First try: subpath relative to the staging dir directly. Local-tarball
+  // fixtures and any tarball whose entries weren't wrapped in a top-level
+  // dir hit this path.
+  const direct = join(stagingDir, subpath);
+  if (existsSync(join(direct, "plugin.json"))) return direct;
+
+  // Then: github-archive wrap style — `<repo>-<tag>/<subpath>/`. Walk one
+  // level into the lone top-level dir and retry. We don't gate on plugin.json
+  // at the staging root because the monorepo root NEVER has plugin.json — the
+  // root is the repo, plugins live under <subpath>.
+  let entries: string[];
+  try { entries = readdirSync(stagingDir); } catch { return null; }
+  if (entries.length !== 1) return null;
+  const inner = join(stagingDir, entries[0]!);
+  try {
+    if (!statSync(inner).isDirectory()) return null;
+  } catch { return null; }
+  const wrapped = join(inner, subpath);
+  if (existsSync(join(wrapped, "plugin.json"))) return wrapped;
+  return null;
+}
+
+/**
+ * Read + parse plugin.json from an unpacked dir. Returns null + logs if missing.
+ */
+export function readManifest(dir: string): PluginManifest | null {
+  const manifestPath = join(dir, "plugin.json");
+  if (!existsSync(manifestPath)) {
+    console.error(`\x1b[31m✗\x1b[0m no plugin.json at ${dir}`);
+    return null;
+  }
+  try {
+    return parseManifest(readFileSync(manifestPath, "utf8"), dir);
+  } catch (e: any) {
+    console.error(`\x1b[31m✗\x1b[0m invalid plugin.json: ${e.message}`);
+    return null;
+  }
+}
+
+/** Short sha256 prefix for the label, e.g. "abc1234" from "sha256:abc1234def…". */
+export function shortHash(sha256: string): string {
+  const idx = sha256.indexOf(":");
+  const hex = idx === -1 ? sha256 : sha256.slice(idx + 1);
+  return hex.slice(0, 7);
+}
+
+/** Print the Phase A success label block. */
+export function printInstallSuccess(
+  manifest: PluginManifest,
+  dest: string,
+  mode: "linked (dev)" | { sha256: string },
+  sourceNote?: string,
+): void {
+  const runtime = runtimeSdkVersion();
+  const caps =
+    manifest.capabilities && manifest.capabilities.length
+      ? manifest.capabilities.join(", ")
+      : "(none)";
+  const modeLabel =
+    typeof mode === "string" ? mode : `installed (sha256:${shortHash(mode.sha256)}…)`;
+  const lines = [
+    `\x1b[32m✓\x1b[0m ${manifest.name}@${manifest.version} installed${sourceNote ? " " + sourceNote : ""}`,
+    `  sdk: ${manifest.sdk} ✓ (maw ${runtime})`,
+    `  capabilities: ${caps}`,
+    `  mode: ${modeLabel}`,
+    `  dir: ${dest}`,
+    `try: maw ${manifest.cli?.command ?? manifest.name}`,
+  ];
+  console.log(lines.join("\n"));
+}

--- a/src/commands/plugins/init/internal/plugin-lock.ts
+++ b/src/commands/plugins/init/internal/plugin-lock.ts
@@ -1,0 +1,341 @@
+/**
+ * plugins.lock — registry-pinned plugin hashes (#487, Option A).
+ *
+ * A node-local JSON file (~/.maw/plugins.lock) that maps plugin names to
+ * approved {version, sha256, source} entries. `maw plugin install` derives
+ * the expected hash from here instead of from the tarball's own manifest,
+ * closing the circular-trust bug where an attacker who controls the tarball
+ * controls both the artifact AND its declared hash.
+ *
+ * See ψ/writing/2026-04-18/plugin-hash-supply-chain-spec.md for the spec.
+ */
+
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from "fs";
+import { homedir } from "os";
+import { dirname, join } from "path";
+import { hashFile } from "../../../../plugin/registry";
+import { readManifest } from "./install-manifest-helpers";
+import { extractTarball } from "./install-extraction";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+
+export const LOCK_SCHEMA = 1;
+
+export interface LockEntry {
+  version: string;
+  sha256: string;
+  source: string;
+  added: string;
+  signers?: string[];
+  /** True iff entry was written by a `--link` (dev-clone) install. */
+  linked?: boolean;
+}
+
+export interface Lock {
+  schema: number;
+  updated: string;
+  plugins: Record<string, LockEntry>;
+}
+
+/** Default lock when none exists on disk. */
+function emptyLock(): Lock {
+  return { schema: LOCK_SCHEMA, updated: new Date().toISOString(), plugins: {} };
+}
+
+/** Resolve lock path. Honors MAW_PLUGINS_LOCK for tests. */
+export function lockPath(): string {
+  return process.env.MAW_PLUGINS_LOCK || join(homedir(), ".maw", "plugins.lock");
+}
+
+/** Validate sha256 is a canonical "sha256:" + 64 lowercase hex, or bare 64-hex. */
+export function validateSha256(value: string): { ok: true } | { ok: false; error: string } {
+  const s = typeof value === "string" ? value : "";
+  const hex = s.startsWith("sha256:") ? s.slice("sha256:".length) : s;
+  if (!/^[0-9a-f]{64}$/.test(hex)) {
+    return { ok: false, error: `invalid sha256 (want 64 lowercase hex chars, got ${JSON.stringify(s)})` };
+  }
+  return { ok: true };
+}
+
+/** Plugin names: segmented by '/', lowercase alnum + . _ - within segments. */
+export function validateName(name: string): { ok: true } | { ok: false; error: string } {
+  if (typeof name !== "string" || name.length === 0) {
+    return { ok: false, error: "plugin name required" };
+  }
+  if (!/^[a-z0-9][a-z0-9._\-\/]{0,127}$/.test(name)) {
+    return { ok: false, error: `invalid plugin name ${JSON.stringify(name)}` };
+  }
+  return { ok: true };
+}
+
+/** Schema check — refuse unknown schema versions with migration hint. */
+export function validateSchema(parsed: unknown): { ok: true; lock: Lock } | { ok: false; error: string } {
+  if (!parsed || typeof parsed !== "object") {
+    return { ok: false, error: "plugins.lock: not a JSON object" };
+  }
+  const obj = parsed as Record<string, unknown>;
+  const schema = obj.schema ?? obj["$schema"];
+  if (typeof schema !== "number") {
+    return { ok: false, error: "plugins.lock: missing numeric 'schema' field" };
+  }
+  if (schema !== LOCK_SCHEMA) {
+    return {
+      ok: false,
+      error:
+        `plugins.lock: unknown schema ${schema} (this build supports ${LOCK_SCHEMA}).\n` +
+        `  migration: upgrade maw-js or regenerate the lockfile with 'maw plugin pin' on each entry.`,
+    };
+  }
+  const plugins = obj.plugins;
+  if (plugins === undefined || typeof plugins !== "object" || plugins === null || Array.isArray(plugins)) {
+    return { ok: false, error: "plugins.lock: 'plugins' must be an object" };
+  }
+  const updated = typeof obj.updated === "string" ? obj.updated : new Date().toISOString();
+  // Per-entry validation.
+  const out: Record<string, LockEntry> = {};
+  for (const [name, entry] of Object.entries(plugins as Record<string, unknown>)) {
+    const nv = validateName(name);
+    if (!nv.ok) return { ok: false, error: `plugins.lock: ${nv.error}` };
+    if (!entry || typeof entry !== "object") {
+      return { ok: false, error: `plugins.lock: entry '${name}' is not an object` };
+    }
+    const e = entry as Record<string, unknown>;
+    if (typeof e.version !== "string" || !e.version) {
+      return { ok: false, error: `plugins.lock: entry '${name}' missing 'version'` };
+    }
+    if (typeof e.sha256 !== "string") {
+      return { ok: false, error: `plugins.lock: entry '${name}' missing 'sha256'` };
+    }
+    const hv = validateSha256(e.sha256);
+    if (!hv.ok) return { ok: false, error: `plugins.lock: entry '${name}': ${hv.error}` };
+    if (typeof e.source !== "string") {
+      return { ok: false, error: `plugins.lock: entry '${name}' missing 'source'` };
+    }
+    out[name] = {
+      version: e.version,
+      sha256: e.sha256,
+      source: e.source,
+      added: typeof e.added === "string" ? e.added : updated,
+      signers: Array.isArray(e.signers) ? (e.signers as string[]).filter(s => typeof s === "string") : undefined,
+      ...(e.linked === true ? { linked: true } : {}),
+    };
+  }
+  return { ok: true, lock: { schema: LOCK_SCHEMA, updated, plugins: out } };
+}
+
+/** Warn to stderr if lockfile is world-writable. Per spec §8: warn but proceed. */
+function checkLockPermissions(path: string): void {
+  try {
+    const mode = statSync(path).mode & 0o777;
+    if ((mode & 0o022) !== 0) {
+      process.stderr.write(
+        `\x1b[33m!\x1b[0m plugins.lock is group/world-writable (mode ${mode.toString(8)}) — ` +
+        `recommend 'chmod 0644 ${path}'\n`
+      );
+    }
+  } catch { /* stat can fail on exotic filesystems — non-fatal */ }
+}
+
+/**
+ * Read + validate the lockfile. Returns an empty lock if the file does not
+ * exist (first-time use). Throws on malformed JSON or unknown schema so the
+ * caller never silently treats a broken lock as "no plugins pinned".
+ */
+export function readLock(): Lock {
+  const path = lockPath();
+  if (!existsSync(path)) return emptyLock();
+  checkLockPermissions(path);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf8"));
+  } catch (e: any) {
+    throw new Error(`plugins.lock: invalid JSON at ${path}: ${e.message}`);
+  }
+  const v = validateSchema(parsed);
+  if (!v.ok) throw new Error(v.error);
+  return v.lock;
+}
+
+/**
+ * Atomically write the lockfile. Writes to <path>.tmp then renames into place
+ * so a crashed write never leaves a half-written lock on disk.
+ */
+export function writeLock(lock: Lock): void {
+  const path = lockPath();
+  const tmp = `${path}.tmp`;
+  const content = JSON.stringify({ ...lock, updated: new Date().toISOString() }, null, 2) + "\n";
+  // Parent dir may not exist yet on fresh installs that haven't run `maw init`.
+  mkdirSync(dirname(path), { recursive: true });
+  // Exclusive create on the tmp path — if a prior write crashed and left
+  // <path>.tmp behind, we refuse to clobber without surfacing it.
+  try {
+    writeFileSync(tmp, content, { encoding: "utf8", flag: "w" });
+  } catch (e: any) {
+    throw new Error(`plugins.lock: failed to stage ${tmp}: ${e.message}`);
+  }
+  try {
+    chmodSync(tmp, 0o644);
+  } catch { /* not all filesystems support chmod — continue */ }
+  renameSync(tmp, path);
+}
+
+/**
+ * Compute sha256 of a tarball's declared artifact (matches manifest.artifact.path).
+ *
+ * #874 path A.3 — for source plugins (no `artifact`, has `entry`), the entry
+ * file's bytes ARE the artifact. Hash that instead so `maw plugin pin` works
+ * uniformly across source and built tarballs.
+ */
+function hashTarballArtifact(tarballPath: string): { ok: true; hash: string; version: string } | { ok: false; error: string } {
+  if (!existsSync(tarballPath)) {
+    return { ok: false, error: `source not found: ${tarballPath}` };
+  }
+  const staging = mkdtempSync(join(tmpdir(), "maw-pin-"));
+  try {
+    const ex = extractTarball(tarballPath, staging);
+    if (!ex.ok) return { ok: false, error: ex.error };
+    // findPluginRoot reused via the manifest helper if needed — but
+    // pinPlugin's tarballs are produced by `maw plugin build` (flat layout)
+    // OR community-source tarballs (also flat after extraction). Either way
+    // plugin.json sits at the staging root.
+    const manifest = readManifest(staging);
+    if (!manifest) return { ok: false, error: "failed to read plugin.json from tarball" };
+    // #896 — entry-first when source-shaped (covers no-artifact AND half-built
+    // artifact.sha256=null shapes). Mirrors `verifyArtifactHashAgainst` so
+    // `maw plugin pin` and `maw plugin install` both accept the same set of
+    // tarballs uniformly.
+    const hasEntry = typeof manifest.entry === "string" && manifest.entry.length > 0;
+    const isSourceShaped = hasEntry && (!manifest.artifact || manifest.artifact.sha256 === null);
+    let relPath: string;
+    if (isSourceShaped) {
+      relPath = manifest.entry!;
+    } else if (manifest.artifact) {
+      relPath = manifest.artifact.path;
+    } else if (hasEntry) {
+      relPath = manifest.entry!;
+    } else {
+      return { ok: false, error: "tarball manifest has no 'artifact' or 'entry' field — rebuild with 'maw plugin build' or declare an entry path" };
+    }
+    const artifactPath = join(staging, relPath);
+    if (!existsSync(artifactPath)) {
+      return { ok: false, error: `artifact missing at ${relPath}` };
+    }
+    const hash = hashFile(artifactPath);
+    return { ok: true, hash, version: manifest.version };
+  } finally {
+    rmSync(staging, { recursive: true, force: true });
+  }
+}
+
+export interface PinOptions {
+  version?: string;
+  signers?: string[];
+}
+
+export interface PinResult {
+  name: string;
+  entry: LockEntry;
+  previous?: LockEntry;
+}
+
+/**
+ * Pin a plugin: hash the tarball at `source`, stage a lockfile entry, write.
+ * Source must be a local tarball path for v1 (URL pinning needs download +
+ * cache; deferred to follow-up — document in pin command help).
+ */
+export function pinPlugin(name: string, source: string, opts: PinOptions = {}): PinResult {
+  const nv = validateName(name);
+  if (!nv.ok) throw new Error(nv.error);
+
+  const h = hashTarballArtifact(source);
+  if (!h.ok) throw new Error(h.error);
+
+  if (opts.version !== undefined && opts.version !== h.version) {
+    throw new Error(
+      `version mismatch: --version=${opts.version} but tarball manifest.version=${h.version}`,
+    );
+  }
+
+  const lock = readLock();
+  const previous = lock.plugins[name];
+  const now = new Date().toISOString();
+  const entry: LockEntry = {
+    version: h.version,
+    sha256: h.hash,
+    source,
+    added: previous?.added ?? now,
+    ...(opts.signers && opts.signers.length ? { signers: opts.signers } : {}),
+  };
+  lock.plugins[name] = entry;
+  writeLock(lock);
+  return { name, entry, previous };
+}
+
+/**
+ * #680 ask #1 — happy-path install writer.
+ *
+ * Called after a successful `maw plugin install`. Persists the artifact's
+ * sha256 into plugins.lock so subsequent installs have local truth to verify
+ * against. Idempotent: re-installing `<name>` updates the entry but preserves
+ * the original `added` timestamp.
+ *
+ * Separate from `pinPlugin` (which hashes a tarball on disk): this one trusts
+ * the caller's already-verified sha256 so we don't double-hash the artifact
+ * in the common install flow.
+ */
+export interface RecordInstallInput {
+  name: string;
+  version: string;
+  /** Canonical 64-hex sha256. For --link installs, hash of plugin.json content. */
+  sha256: string;
+  /** Tarball path, URL, or `link:<abs-path>` for --link. */
+  source: string;
+  /** True iff this was a --link (dev-clone) install. */
+  linked?: boolean;
+  signers?: string[];
+}
+
+export function recordInstall(input: RecordInstallInput): LockEntry {
+  const nv = validateName(input.name);
+  if (!nv.ok) throw new Error(nv.error);
+  const hv = validateSha256(input.sha256);
+  if (!hv.ok) throw new Error(`recordInstall(${input.name}): ${hv.error}`);
+  if (typeof input.version !== "string" || !input.version) {
+    throw new Error(`recordInstall(${input.name}): version required`);
+  }
+  if (typeof input.source !== "string" || !input.source) {
+    throw new Error(`recordInstall(${input.name}): source required`);
+  }
+  const lock = readLock();
+  const previous = lock.plugins[input.name];
+  const now = new Date().toISOString();
+  const entry: LockEntry = {
+    version: input.version,
+    sha256: input.sha256,
+    source: input.source,
+    added: previous?.added ?? now,
+    ...(input.linked === true ? { linked: true } : {}),
+    ...(input.signers && input.signers.length ? { signers: input.signers } : {}),
+  };
+  lock.plugins[input.name] = entry;
+  writeLock(lock);
+  return entry;
+}
+
+export interface UnpinResult {
+  name: string;
+  removed: LockEntry | null;
+}
+
+/** Remove a plugin from the lockfile. No-op if not present. */
+export function unpinPlugin(name: string): UnpinResult {
+  const nv = validateName(name);
+  if (!nv.ok) throw new Error(nv.error);
+  const lock = readLock();
+  const removed = lock.plugins[name] ?? null;
+  if (removed) {
+    delete lock.plugins[name];
+    writeLock(lock);
+  }
+  return { name, removed };
+}

--- a/src/commands/plugins/pair/impl.ts
+++ b/src/commands/plugins/pair/impl.ts
@@ -5,7 +5,7 @@
  */
 
 import { loadConfig } from "../../../config";
-import { cmdAdd } from "../peers/impl";
+import { cmdAdd } from "./internal/peers-impl";
 import { postHandshake, warnIfPlainHttp } from "./handshake";
 import { normalize, isValidShape, redact } from "./codes";
 

--- a/src/commands/plugins/pair/internal/peers-impl.ts
+++ b/src/commands/plugins/pair/internal/peers-impl.ts
@@ -1,0 +1,270 @@
+/**
+ * maw peers — subcommand implementations (#568).
+ *
+ * Pure(-ish) functions for CRUD over `~/.maw/peers.json`. No CLI
+ * parsing here — the dispatcher in index.ts peels off `args[0]` and
+ * hands typed positional + flag data to these functions.
+ *
+ * Node resolution (when `--node` is not given) is intentionally
+ * best-effort: we try `<url>/info`, and on any error (missing endpoint,
+ * DNS, timeout) we store `node: null`. An alias without a node is still
+ * valid — it just means `alias:<agent>` routing needs the URL-to-node
+ * map from another source. That's a follow-up concern.
+ */
+import { loadPeers, mutatePeers, type Peer, type LastError } from "./store";
+import { probePeer } from "./probe";
+import { evaluatePeerIdentity, applyTofuDecision, PeerPubkeyMismatchError } from "./tofu";
+
+const ALIAS_RE = /^[a-z0-9][a-z0-9_-]{0,31}$/;
+
+export function validateAlias(alias: string): string | null {
+  if (!ALIAS_RE.test(alias)) {
+    return `invalid alias "${alias}" (must match ^[a-z0-9][a-z0-9_-]{0,31}$)`;
+  }
+  return null;
+}
+
+export function validateUrl(raw: string): string | null {
+  let parsed: URL;
+  try { parsed = new URL(raw); } catch { return `invalid URL "${raw}"`; }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return `invalid URL "${raw}" (must be http:// or https://)`;
+  }
+  return null;
+}
+
+/**
+ * Thin back-compat wrapper returning `string | null`. New callers should
+ * use probePeer() directly to get structured errors — but pre-#565 code
+ * paths that only want the node name keep working unchanged.
+ */
+export async function resolveNode(url: string): Promise<string | null> {
+  const res = await probePeer(url);
+  return res.node;
+}
+
+export interface AddOptions {
+  alias: string;
+  url: string;
+  node?: string;
+}
+
+export interface AddResult {
+  alias: string;
+  overwrote: boolean;
+  peer: Peer;
+  /** Probe error, if the /info handshake failed. Caller prints a loud warning. */
+  probeError?: LastError;
+  /** Set when the cached pubkey did not match the peer's advertised pubkey (#804 Step 2). */
+  pubkeyMismatch?: PeerPubkeyMismatchError;
+}
+
+export async function cmdAdd(opts: AddOptions): Promise<AddResult> {
+  const aliasErr = validateAlias(opts.alias);
+  if (aliasErr) throw new Error(aliasErr);
+  const urlErr = validateUrl(opts.url);
+  if (urlErr) throw new Error(urlErr);
+
+  // Probe OUTSIDE the lock — it does network I/O. If --node was supplied
+  // we still probe to surface errors, but the user-supplied node wins.
+  const probe = await probePeer(opts.url);
+  const resolvedNode = opts.node ?? probe.node ?? null;
+
+  // TOFU evaluation against any pre-existing cache entry for this alias.
+  // Decided BEFORE we overwrite so a re-`add` of the same alias against a
+  // peer whose key changed is refused at the cache layer (operator must
+  // `maw peers forget` first). Bootstrap path stamps the pubkey on the
+  // freshly-written entry, so we evaluate now but apply after the write.
+  const existingForTofu = loadPeers().peers[opts.alias];
+  const tofuDecision = evaluatePeerIdentity(opts.alias, existingForTofu, probe.pubkey);
+  if (tofuDecision.kind === "mismatch") {
+    return {
+      alias: opts.alias,
+      overwrote: Boolean(existingForTofu),
+      peer: existingForTofu!, // unchanged on disk — we refuse the write
+      probeError: probe.error,
+      pubkeyMismatch: new PeerPubkeyMismatchError(
+        opts.alias,
+        tofuDecision.cached!,
+        tofuDecision.observed!,
+      ),
+    };
+  }
+
+  const peer: Peer = {
+    url: opts.url,
+    node: resolvedNode,
+    addedAt: new Date().toISOString(),
+    lastSeen: probe.error ? null : new Date().toISOString(),
+  };
+  if (probe.error) peer.lastError = probe.error;
+  if (probe.nickname) peer.nickname = probe.nickname;
+  // Preserve cached pubkey across re-adds — TOFU has already certified it
+  // matches (or is absent). On bootstrap, stamp the new pubkey now so the
+  // returned AddResult.peer reflects on-disk state in one go.
+  if (existingForTofu?.pubkey) {
+    peer.pubkey = existingForTofu.pubkey;
+    peer.pubkeyFirstSeen = existingForTofu.pubkeyFirstSeen;
+  } else if (tofuDecision.kind === "tofu-bootstrap") {
+    peer.pubkey = tofuDecision.observed!;
+    peer.pubkeyFirstSeen = new Date().toISOString();
+  }
+  // Identity (#804 Step 3): capture from probe when available; fall back to
+  // any previously-cached identity so a transient /api/identity blip on
+  // re-add doesn't lose what we already know about this peer.
+  if (probe.identity) {
+    peer.identity = probe.identity;
+  } else if (existingForTofu?.identity) {
+    peer.identity = existingForTofu.identity;
+  }
+
+  let existed = false;
+  mutatePeers((data) => {
+    existed = Boolean(data.peers[opts.alias]);
+    data.peers[opts.alias] = peer;
+  });
+
+  // applyTofuDecision is a no-op for match / legacy-*; for tofu-bootstrap
+  // we already stamped the pubkey above, so the call is defensive (it
+  // checks `if (p.pubkey) return` and bails). Keeping the call documents
+  // the contract: every probePeer response goes through TOFU exactly once.
+  applyTofuDecision(tofuDecision);
+
+  return { alias: opts.alias, overwrote: existed, peer, probeError: probe.error };
+}
+
+/**
+ * Re-run the /info handshake for an existing alias. On success clears
+ * lastError and sets lastSeen; on failure records lastError.
+ *
+ * Throws if the alias does not exist.
+ */
+export interface ProbeResult {
+  alias: string;
+  url: string;
+  node: string | null;
+  ok: boolean;
+  error?: LastError;
+  /** Set when the peer's advertised pubkey did not match the cached one (#804 Step 2). */
+  pubkeyMismatch?: PeerPubkeyMismatchError;
+}
+
+export async function cmdProbe(alias: string): Promise<ProbeResult> {
+  const data = loadPeers();
+  const existing = data.peers[alias];
+  if (!existing) throw new Error(`peer "${alias}" not found`);
+
+  const probe = await probePeer(existing.url);
+  const now = new Date().toISOString();
+
+  // TOFU first — if the peer rotated its key without operator approval, the
+  // probe's "ok" status is misleading: their /info answered, but their
+  // identity changed. Surface as `pubkeyMismatch` and *do not* update
+  // lastSeen — operator must run `maw peers forget` to re-TOFU.
+  const tofuDecision = evaluatePeerIdentity(alias, existing, probe.pubkey);
+  if (tofuDecision.kind === "mismatch") {
+    return {
+      alias,
+      url: existing.url,
+      node: probe.node ?? existing.node,
+      ok: false,
+      error: probe.error,
+      pubkeyMismatch: new PeerPubkeyMismatchError(
+        alias,
+        tofuDecision.cached!,
+        tofuDecision.observed!,
+      ),
+    };
+  }
+
+  mutatePeers((d) => {
+    const p = d.peers[alias];
+    if (!p) return; // removed between load and mutate — race-safe no-op
+    if (probe.error) {
+      p.lastError = probe.error;
+    } else {
+      delete p.lastError;
+      p.lastSeen = now;
+      if (probe.node) p.node = probe.node;
+      // Refresh nickname on success: string updates, null clears.
+      if (probe.nickname) p.nickname = probe.nickname;
+      else if (probe.nickname === null) delete p.nickname;
+      // Refresh identity on success (#804 Step 3) — only updates, never clears,
+      // so a transient /api/identity blip won't drop a known-good pin.
+      if (probe.identity) p.identity = probe.identity;
+    }
+  });
+
+  // Persist the bootstrap (only on first sight, after the peer entry exists).
+  applyTofuDecision(tofuDecision);
+
+  return {
+    alias,
+    url: existing.url,
+    node: probe.node ?? existing.node,
+    ok: !probe.error,
+    error: probe.error,
+  };
+}
+
+export function cmdList(): Array<{ alias: string } & Peer> {
+  const data = loadPeers();
+  return Object.entries(data.peers)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([alias, p]) => ({ alias, ...p }));
+}
+
+export function cmdInfo(alias: string): ({ alias: string } & Peer) | null {
+  const data = loadPeers();
+  const p = data.peers[alias];
+  return p ? { alias, ...p } : null;
+}
+
+export function cmdRemove(alias: string): boolean {
+  let existed = false;
+  mutatePeers((data) => {
+    if (data.peers[alias]) {
+      existed = true;
+      delete data.peers[alias];
+    }
+  });
+  return existed;
+}
+
+/**
+ * Clear the TOFU-cached pubkey for an alias so the next /api/identity
+ * contact re-TOFUs (#804 Step 2).
+ *
+ * Use cases:
+ *   - Legitimate operator-initiated key rotation on the peer side.
+ *   - Factory reset / key loss recovery.
+ *   - Resolving a `peer pubkey changed` refusal after the operator has
+ *     verified out-of-band that the change is intentional.
+ *
+ * Does NOT remove the alias itself — `maw peers remove` is the destructive
+ * one. Forget is a re-TOFU primitive, not a delete.
+ */
+export type ForgetOutcome = "cleared" | "no-pubkey" | "not-found";
+
+export async function cmdForget(alias: string): Promise<ForgetOutcome> {
+  const aliasErr = validateAlias(alias);
+  if (aliasErr) throw new Error(aliasErr);
+  const { forgetPeerPubkey } = await import("./tofu");
+  return forgetPeerPubkey(alias);
+}
+
+export function formatList(rows: Array<{ alias: string } & Peer>): string {
+  if (!rows.length) return "no peers";
+  const header = ["alias", "url", "node", "nickname", "lastSeen"];
+  const lines = rows.map(r => [
+    r.alias,
+    r.url,
+    r.node ?? "-",
+    r.nickname ?? "-",
+    r.lastSeen ?? "-",
+  ]);
+  const widths = header.map((h, i) =>
+    Math.max(h.length, ...lines.map(l => l[i].length)));
+  const fmt = (cols: string[]) => cols.map((c, i) => c.padEnd(widths[i])).join("  ");
+  return [fmt(header), fmt(widths.map(w => "-".repeat(w))), ...lines.map(fmt)].join("\n");
+}

--- a/src/commands/plugins/pair/internal/probe.ts
+++ b/src/commands/plugins/pair/internal/probe.ts
@@ -1,0 +1,329 @@
+/**
+ * maw peers — handshake probe + error classifier (#565).
+ *
+ * Replaces the silent try/catch→null in resolveNode(). probePeer()
+ * fetches <url>/info, classifies failures into a small enum, and
+ * returns both resolved node (if any) and structured error (if any).
+ * The old resolveNode() wrapper in impl.ts is kept as a thin
+ * `string | null` fallback for pre-#565 call sites.
+ */
+import type { LastError } from "./store";
+import { lookup } from "dns/promises";
+
+export type ProbeErrorCode = LastError["code"];
+
+export interface ProbeResult {
+  node: string | null;
+  /** Peer's self-reported nickname from /info (#643 Phase 2). Null means peer did not advertise one. */
+  nickname?: string | null;
+  /**
+   * Peer's pubkey from /api/identity (#804 Step 2). Undefined when:
+   *   - the /info handshake itself failed (no second fetch attempted), OR
+   *   - the peer is pre-Step-1 and does not expose /api/identity, OR
+   *   - /api/identity responded but did not advertise a pubkey field.
+   *
+   * Caller passes this through `tofuRecordPeerIdentity` to pin / validate.
+   */
+  pubkey?: string;
+  /**
+   * Peer's self-reported `<oracle>:<node>` from /api/identity (#804 Step 3).
+   *
+   * Captured opportunistically alongside `pubkey` so the local cache can
+   * detect duplicate-claim collisions across peers (e.g. two peers both
+   * declaring themselves `mawjs:m5`). Undefined when /api/identity did not
+   * respond or omitted both `oracle` and `node` fields.
+   *
+   * `oracle` defaults to `"mawjs"` when the response only carries `node` —
+   * this is the family default per ADR docs/federation/0001-peer-identity.md
+   * and lets pre-Step-3 peers still participate in the collision check.
+   */
+  identity?: { oracle: string; node: string };
+  error?: LastError;
+}
+
+/**
+ * Exit code per probe error family — fail-loud for scripts.
+ *
+ * Scripts that chain `maw peers add` with subsequent commands need a
+ * non-zero exit to branch on. The old `ok:true + ⚠ block on stderr`
+ * behavior was easy to miss in CI logs.
+ *
+ *   2 — generic/structural (UNKNOWN, BAD_BODY, TLS)
+ *   3 — DNS (host does not resolve)
+ *   4 — REFUSED (resolved but port closed)
+ *   5 — TIMEOUT (no response in 2s)
+ *   6 — HTTP_4XX / HTTP_5XX (peer responded but /info failed)
+ */
+export const PROBE_EXIT_CODES: Record<ProbeErrorCode, number> = {
+  DNS: 3,
+  REFUSED: 4,
+  TIMEOUT: 5,
+  HTTP_4XX: 6,
+  HTTP_5XX: 6,
+  TLS: 2,
+  BAD_BODY: 2,
+  UNKNOWN: 2,
+};
+
+/** Actionable hint per error code — shown in CLI output. */
+export const PROBE_HINTS: Record<ProbeErrorCode, string> = {
+  DNS: "Host does not resolve. Check /etc/hosts, DNS, or VPN.",
+  REFUSED: "Host resolves but port is closed. Is the peer process running?",
+  TIMEOUT: "Peer did not respond within 2s. Network path may be blocked.",
+  TLS: "TLS handshake failed. Check cert validity / chain.",
+  HTTP_4XX: "Peer responded with a client error. /info endpoint may be missing OR peer is running an old maw version — if you control the peer, try restarting it.",
+  HTTP_5XX: "Peer returned a server error. Server-side fault.",
+  BAD_BODY: "/info responded but body shape was unexpected.",
+  UNKNOWN: "Probe failed for an unclassified reason.",
+};
+
+/**
+ * Classify a thrown fetch error OR a failed Response into a ProbeErrorCode.
+ * Node/undici → err.cause.code; AbortError → 2s timeout; TLS → CERT_*;
+ * HTTP → non-ok Response. Bun collapses DNS+refused → "ConnectionRefused";
+ * run prefetchDnsCheck() first to recover the DNS distinction.
+ */
+export function classifyProbeError(input: unknown): ProbeErrorCode {
+  // HTTP: non-ok Response
+  if (typeof input === "object" && input !== null && "status" in input && "ok" in input) {
+    const res = input as { status: number; ok: boolean };
+    if (!res.ok) {
+      if (res.status >= 400 && res.status < 500) return "HTTP_4XX";
+      if (res.status >= 500) return "HTTP_5XX";
+    }
+  }
+
+  // Thrown error: inspect cause.code, code, name
+  const err = input as { name?: string; code?: string; cause?: { code?: string } } | null;
+  if (!err || typeof err !== "object") return "UNKNOWN";
+
+  const code = err.cause?.code ?? err.code;
+  // ENOTIMP = resolver method unimplemented (e.g. mDNS/.local without Avahi); EAI_FAIL = unrecoverable DNS (#593).
+  if (code === "ENOTFOUND" || code === "ENOTIMP" || code === "EAI_FAIL" || code === "EAI_AGAIN" || code === "EAI_NODATA") return "DNS";
+  // Bun conflates DNS + refused into "ConnectionRefused" — we run a DNS
+  // precheck upstream, so any code that reaches here means connect failed.
+  if (code === "ECONNREFUSED" || code === "ConnectionRefused") return "REFUSED";
+  if (code === "ETIMEDOUT" || code === "UND_ERR_CONNECT_TIMEOUT") return "TIMEOUT";
+  if (err.name === "AbortError" || err.name === "TimeoutError") return "TIMEOUT";
+  if (typeof code === "string" && (code.startsWith("CERT_") || code.startsWith("SELF_SIGNED") || code.startsWith("DEPTH_ZERO_") || code === "UNABLE_TO_VERIFY_LEAF_SIGNATURE")) {
+    return "TLS";
+  }
+
+  return "UNKNOWN";
+}
+
+/**
+ * DNS precheck — resolves host-doesn't-resolve vs connection-refused before
+ * fetch (Bun conflates them). Returns DNS LastError on failure, null on ok.
+ */
+async function prefetchDnsCheck(url: string): Promise<LastError | null> {
+  let hostname: string;
+  try { hostname = new URL(url).hostname; } catch { return null; }
+  if (/^\d+\.\d+\.\d+\.\d+$/.test(hostname) || hostname.startsWith("[")) return null;
+  try {
+    await lookup(hostname);
+    return null;
+  } catch (e: any) {
+    return {
+      code: classifyProbeError(e),
+      message: typeof e?.message === "string" ? e.message : `DNS lookup failed for ${hostname}`,
+      at: new Date().toISOString(),
+    };
+  }
+}
+
+/** Build a LastError record from a thrown error + url context. */
+function errToLast(err: unknown, fallbackMsg: string): LastError {
+  const code = classifyProbeError(err);
+  const message = (err && typeof err === "object" && "message" in err && typeof (err as any).message === "string")
+    ? (err as any).message
+    : fallbackMsg;
+  return { code, message, at: new Date().toISOString() };
+}
+
+/**
+ * Probe <url>/info with a 2s timeout. Success → { node } (body.node or
+ * body.name). Failure → { node: null, error } — caller persists + warns.
+ */
+export async function probePeer(url: string, timeoutMs = 2000): Promise<ProbeResult> {
+  // DNS precheck first — cheaper than fetch and gives us clean ENOTFOUND
+  // classification on Bun (whose fetch conflates DNS/refused into one code).
+  const dnsErr = await prefetchDnsCheck(url);
+  if (dnsErr) return { node: null, error: dnsErr };
+
+  let res: Response;
+  try {
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), timeoutMs);
+    try {
+      res = await fetch(new URL("/info", url), { signal: ctrl.signal });
+    } finally {
+      clearTimeout(t);
+    }
+  } catch (e) {
+    return { node: null, error: errToLast(e, `fetch ${url}/info failed`) };
+  }
+
+  if (!res.ok) {
+    return {
+      node: null,
+      error: {
+        code: classifyProbeError(res),
+        message: `HTTP ${res.status} from ${url}/info`,
+        at: new Date().toISOString(),
+      },
+    };
+  }
+
+  let body: { node?: unknown; name?: unknown; nickname?: unknown; maw?: unknown };
+  try {
+    body = await res.json() as { node?: unknown; name?: unknown; nickname?: unknown; maw?: unknown };
+  } catch (e) {
+    return {
+      node: null,
+      error: {
+        code: "BAD_BODY",
+        message: `/info body was not valid JSON`,
+        at: new Date().toISOString(),
+      },
+    };
+  }
+
+  // Accept both the old handshake (#596 — `maw: true`) and the new
+  // self-describing shape (#628 — `maw: { schema: "1", ... }`). Any
+  // truthy `maw` value passes; missing/falsy fails as BAD_BODY so we
+  // don't paint random HTTP 200 endpoints as maw peers.
+  if (!isValidMawHandshake(body.maw)) {
+    return {
+      node: null,
+      error: {
+        code: "BAD_BODY",
+        message: `/info response missing valid "maw" handshake field`,
+        at: new Date().toISOString(),
+      },
+    };
+  }
+
+  const node = (typeof body.node === "string" && body.node)
+    || (typeof body.name === "string" && body.name)
+    || null;
+
+  if (!node) {
+    return {
+      node: null,
+      error: {
+        code: "BAD_BODY",
+        message: `/info response had neither "node" nor "name" string`,
+        at: new Date().toISOString(),
+      },
+    };
+  }
+
+  // Nickname is optional and strictly cosmetic — only accept non-empty strings.
+  const nickname = typeof body.nickname === "string" && body.nickname.length > 0
+    ? body.nickname
+    : null;
+
+  // Best-effort pubkey + identity fetch (#804 Steps 2 + 3). Pre-Step-1 peers
+  // don't expose /api/identity at all; we tolerate that and return without
+  // either field — TOFU layer treats the result as a legacy peer, and the
+  // duplicate-detection layer skips peers without identity (no false positive).
+  const ident = await fetchPeerIdentityFields(url, timeoutMs);
+
+  const result: ProbeResult = { node, nickname };
+  if (ident?.pubkey) result.pubkey = ident.pubkey;
+  if (ident?.identity) result.identity = ident.identity;
+  return result;
+}
+
+/**
+ * Best-effort second fetch — `/api/identity` (#804 Steps 2 + 3).
+ *
+ * Keep this *separate* from the /info handshake so a missing/older endpoint
+ * does not poison the primary probe. We swallow every failure here: TOFU
+ * only acts on a confirmed pubkey value, and the caller already classified
+ * /info errors elsewhere.
+ *
+ * Returns whatever subset of `{ pubkey, identity }` the response advertised,
+ * or `undefined` if the endpoint is missing / unreachable / malformed.
+ *
+ * `identity` is synthesised from the response's `oracle` (defaulting to
+ * `"mawjs"` per ADR family-default) + `node` fields. Both fields must be
+ * non-empty strings for `identity` to be returned — a peer that reports
+ * neither is treated as legacy and skipped by the dedup check upstream.
+ */
+async function fetchPeerIdentityFields(
+  url: string,
+  timeoutMs: number,
+): Promise<{ pubkey?: string; identity?: { oracle: string; node: string } } | undefined> {
+  try {
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), timeoutMs);
+    let res: Response;
+    try {
+      res = await fetch(new URL("/api/identity", url), { signal: ctrl.signal });
+    } finally {
+      clearTimeout(t);
+    }
+    if (!res.ok) return undefined;
+    const body = (await res.json()) as { pubkey?: unknown; oracle?: unknown; node?: unknown };
+    const out: { pubkey?: string; identity?: { oracle: string; node: string } } = {};
+    if (typeof body.pubkey === "string" && body.pubkey.length > 0) out.pubkey = body.pubkey;
+    const node = typeof body.node === "string" && body.node.length > 0 ? body.node : undefined;
+    const oracle = typeof body.oracle === "string" && body.oracle.length > 0 ? body.oracle : "mawjs";
+    if (node) out.identity = { oracle, node };
+    return out;
+  } catch {
+    // Pre-Step-1 peers: no /api/identity yet. Step 4 will reject this — for
+    // now (alpha migration window) we silently accept.
+  }
+  return undefined;
+}
+
+/**
+ * Handshake gate — accepts the pre-#628 `maw: true` form AND the new
+ * `maw: { schema: "1", ... }` form. Objects must carry at least a
+ * `schema` string to count as a valid new-shape handshake (bare `{}`
+ * is rejected so a typo doesn't silently pass). Anything truthy but
+ * not one of these shapes (e.g. `maw: "yes"`, `maw: 1`) is rejected —
+ * future shapes should bump the schema field rather than changing the
+ * outer type.
+ */
+export function isValidMawHandshake(maw: unknown): boolean {
+  if (maw === true) return true;
+  if (maw && typeof maw === "object") {
+    const m = maw as { schema?: unknown };
+    return typeof m.schema === "string" && m.schema.length > 0;
+  }
+  return false;
+}
+
+/** Hint chooser — DNS bucket sub-types for ENOTIMP get a distinct hint (#593). */
+export function pickHint(err: LastError): string {
+  if (err.code === "DNS" && /ENOTIMP/i.test(err.message)) {
+    return "install avahi-daemon (Linux) for mDNS, or add white.local to /etc/hosts";
+  }
+  return PROBE_HINTS[err.code] ?? PROBE_HINTS.UNKNOWN;
+}
+
+/** Colored, multi-line stderr block with actionable hint. */
+export function formatProbeError(err: LastError, url: string, alias: string): string {
+  const hint = pickHint(err);
+  const host = safeHost(url);
+  return [
+    `\x1b[33m⚠\x1b[0m peer handshake failed: \x1b[1m${err.code}\x1b[0m`,
+    `   host: ${host}`,
+    `   error: ${err.message}`,
+    `   hint: ${hint}`,
+    `   retry: maw peers probe ${alias}`,
+  ].join("\n");
+}
+
+function safeHost(url: string): string {
+  try {
+    const u = new URL(url);
+    return u.port ? `${u.hostname}:${u.port}` : u.hostname;
+  } catch {
+    return url;
+  }
+}

--- a/src/commands/plugins/pair/internal/tofu.ts
+++ b/src/commands/plugins/pair/internal/tofu.ts
@@ -1,0 +1,219 @@
+/**
+ * peers/tofu.ts — Trust On First Use cache for peer pubkeys (#804 Step 2).
+ *
+ * Pure, no-network logic that gets called by every code path which has just
+ * fetched a peer's `/api/identity` response. The peer's reply may carry a
+ * `pubkey` (Step 1 advertised it; pre-Step-1 peers omit it). We cache the
+ * pubkey on first sight and refuse mismatches thereafter.
+ *
+ * O6 table from ADR docs/federation/0001-peer-identity.md drives the four
+ * outcomes here — see `evaluatePeerIdentity` for the truth-table mapping.
+ *
+ * Design rules (deliberately not in store.ts):
+ *   - This module owns the *policy* (when to accept / refuse / warn).
+ *   - store.ts owns the *persistence* (how to read/write peers.json safely).
+ *   - This module never throws on absent-from-cache — it returns a tagged
+ *     decision the caller acts on. Throwing here would couple network code
+ *     paths to TOFU state shape.
+ *
+ * The receive-side (Step 4 signature verification) will reuse the same cache
+ * shape; this module is the only writer of `pubkey` / `pubkeyFirstSeen` so
+ * there's exactly one place that decides "this pubkey is now pinned".
+ */
+import type { Peer } from "./store";
+import { mutatePeers } from "./store";
+
+export type TofuDecisionKind =
+  /** First time we ever see a pubkey for this peer. Cache it. */
+  | "tofu-bootstrap"
+  /** Cached pubkey matches incoming pubkey. No-op write needed. */
+  | "match"
+  /** Cached pubkey, peer responded with a different pubkey. Refuse. */
+  | "mismatch"
+  /**
+   * Peer is a legacy node with no `pubkey` field at all. First contact —
+   * cache the entry without a pubkey; future Step-1+ contacts will TOFU.
+   */
+  | "legacy-first-contact"
+  /**
+   * Peer previously advertised a pubkey but this response omits it.
+   * During the v26.5.x migration window we accept-with-warning (rollback
+   * scenario). v27 will hard-cut this — see ADR Step 6.
+   */
+  | "legacy-after-pinned";
+
+export interface TofuDecision {
+  kind: TofuDecisionKind;
+  alias: string;
+  /** The cached pubkey (if any) BEFORE this call. */
+  cached?: string;
+  /** The pubkey the peer just advertised (if any). */
+  observed?: string;
+  /** Human-readable description for logs / errors. */
+  message: string;
+}
+
+export class PeerPubkeyMismatchError extends Error {
+  alias: string;
+  cached: string;
+  observed: string;
+  constructor(alias: string, cached: string, observed: string) {
+    super(
+      `peer pubkey changed for ${alias}: ${cached.slice(0, 16)}… → ${observed.slice(0, 16)}…; ` +
+        `manually \`maw peers forget ${alias}\` to re-TOFU`,
+    );
+    this.name = "PeerPubkeyMismatchError";
+    this.alias = alias;
+    this.cached = cached;
+    this.observed = observed;
+  }
+}
+
+/**
+ * Pure decision function — given the current cache entry and the peer's
+ * advertised pubkey (or `undefined` for legacy peers), return what should
+ * happen. Persistence is the caller's job (`applyTofuDecision`).
+ *
+ * The four decisions map directly onto the O6 table cells that are
+ * relevant to the *receive an identity response* event (the other O6
+ * cells about signed messages are Step 4's concern).
+ */
+export function evaluatePeerIdentity(
+  alias: string,
+  peer: Peer | undefined,
+  observed: string | undefined,
+): TofuDecision {
+  const cached = peer?.pubkey;
+
+  // Case 1: peer is brand-new to us OR we've never cached a pubkey.
+  if (!cached) {
+    if (observed) {
+      return {
+        kind: "tofu-bootstrap",
+        alias,
+        observed,
+        message: `[tofu] caching pubkey for ${alias} (first sight)`,
+      };
+    }
+    return {
+      kind: "legacy-first-contact",
+      alias,
+      message: `[tofu] ${alias} did not advertise a pubkey (legacy peer; no pin established)`,
+    };
+  }
+
+  // Case 2: cached pubkey present — must validate.
+  if (!observed) {
+    return {
+      kind: "legacy-after-pinned",
+      alias,
+      cached,
+      message:
+        `[tofu] ${alias} previously advertised pubkey ${cached.slice(0, 16)}… but this response omits it; ` +
+        `accepting during alpha migration, will hard-fail at v27`,
+    };
+  }
+
+  if (cached === observed) {
+    return {
+      kind: "match",
+      alias,
+      cached,
+      observed,
+      message: `[tofu] ${alias} pubkey verified`,
+    };
+  }
+
+  return {
+    kind: "mismatch",
+    alias,
+    cached,
+    observed,
+    message:
+      `peer pubkey changed for ${alias}: ${cached.slice(0, 16)}… → ${observed.slice(0, 16)}…; ` +
+      `manually \`maw peers forget ${alias}\` to re-TOFU`,
+  };
+}
+
+/**
+ * Persist the side-effect of `evaluatePeerIdentity`. Bootstrap writes the
+ * pubkey + timestamp; mismatch throws; match / legacy-* are no-ops on disk.
+ *
+ * Throws `PeerPubkeyMismatchError` on `kind === "mismatch"` — caller decides
+ * whether to surface to user or swallow (e.g. background sweepers may log
+ * and skip; interactive `maw peers add` may fail loud).
+ */
+export function applyTofuDecision(decision: TofuDecision): void {
+  switch (decision.kind) {
+    case "tofu-bootstrap": {
+      const now = new Date().toISOString();
+      mutatePeers((data) => {
+        const p = data.peers[decision.alias];
+        if (!p) return; // race-safe: peer was forgotten between fetch+apply
+        // Defensive: if someone else cached a pubkey between evaluate and
+        // apply, treat that as authoritative — re-evaluate would mismatch
+        // or match; we don't silently overwrite.
+        if (p.pubkey) return;
+        p.pubkey = decision.observed!;
+        p.pubkeyFirstSeen = now;
+      });
+      return;
+    }
+    case "mismatch":
+      throw new PeerPubkeyMismatchError(
+        decision.alias,
+        decision.cached!,
+        decision.observed!,
+      );
+    case "match":
+    case "legacy-first-contact":
+    case "legacy-after-pinned":
+      return;
+  }
+}
+
+/**
+ * One-shot helper: evaluate + apply. Returns the decision so callers can log.
+ *
+ * Throws `PeerPubkeyMismatchError` on mismatch (caller chooses recovery).
+ */
+export function tofuRecordPeerIdentity(
+  alias: string,
+  peer: Peer | undefined,
+  observed: string | undefined,
+): TofuDecision {
+  const decision = evaluatePeerIdentity(alias, peer, observed);
+  applyTofuDecision(decision);
+  return decision;
+}
+
+/**
+ * Operator-driven re-TOFU: clears the pinned pubkey for an alias. Used by
+ * `maw peers forget <alias>`. Idempotent — clearing a peer that has no
+ * pubkey is fine and reports nothing-changed via the return value.
+ *
+ * Returns:
+ *   - "cleared" — pubkey was present and is now removed
+ *   - "no-pubkey" — alias exists but had no pubkey (legacy peer)
+ *   - "not-found" — alias does not exist
+ */
+export function forgetPeerPubkey(
+  alias: string,
+): "cleared" | "no-pubkey" | "not-found" {
+  let outcome: "cleared" | "no-pubkey" | "not-found" = "not-found";
+  mutatePeers((data) => {
+    const p = data.peers[alias];
+    if (!p) {
+      outcome = "not-found";
+      return;
+    }
+    if (p.pubkey === undefined) {
+      outcome = "no-pubkey";
+      return;
+    }
+    delete p.pubkey;
+    delete p.pubkeyFirstSeen;
+    outcome = "cleared";
+  });
+  return outcome;
+}

--- a/src/commands/plugins/tab/impl.ts
+++ b/src/commands/plugins/tab/impl.ts
@@ -1,7 +1,7 @@
 import { hostExec } from "../../../sdk";
 import { tmux, tmuxCmd } from "../../../sdk";
 import { cmdPeek, cmdSend } from "../../shared/comm";
-import { cmdTalkTo } from "../talk-to/impl";
+import { cmdTalkTo } from "./internal/talk-to-impl";
 
 /**
  * Get current tmux session name (whoami).

--- a/src/commands/plugins/tab/internal/talk-to-impl.ts
+++ b/src/commands/plugins/tab/internal/talk-to-impl.ts
@@ -1,0 +1,202 @@
+import { loadConfig } from "../../../../config";
+import { listSessions, sendKeys, getPaneCommand, resolveTarget } from "../../../../sdk";
+import { runHook } from "../../../../sdk";
+import { resolveOraclePane } from "../../../shared/comm-send";
+import { appendFile, mkdir } from "fs/promises";
+import { homedir, hostname } from "os";
+import { join } from "path";
+
+const ORACLE_URL = () => process.env.ORACLE_URL || loadConfig().oracleUrl;
+
+interface ThreadResponse {
+  thread_id: number;
+  message_id: number;
+  status: string;
+  oracle_response?: {
+    content: string;
+    principles_found: number;
+    patterns_found: number;
+  } | null;
+}
+
+interface ThreadInfo {
+  thread: {
+    id: number;
+    title: string;
+    status: string;
+    created_at: string;
+  };
+  messages: {
+    id: number;
+    role: string;
+    content: string;
+    created_at: string;
+  }[];
+}
+
+/**
+ * Find or create a channel thread for a target.
+ * Convention: thread title = "channel:<target>"
+ */
+async function findChannelThread(target: string): Promise<number | null> {
+  try {
+    const res = await fetch(`${ORACLE_URL()}/api/threads?limit=50`);
+    if (!res.ok) return null;
+    const data = await res.json() as { threads: { id: number; title: string; status: string }[] };
+    const channel = data.threads.find(t => t.title === `channel:${target}` && t.status !== "closed");
+    return channel?.id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Post message to oracle_thread (MCP persistence layer).
+ */
+async function postToThread(target: string, message: string): Promise<ThreadResponse | null> {
+  const threadId = await findChannelThread(target);
+  const body: Record<string, unknown> = {
+    message,
+    role: "claude",
+  };
+  if (threadId) {
+    body.thread_id = threadId;
+  } else {
+    body.title = `channel:${target}`;
+  }
+
+  try {
+    const res = await fetch(`${ORACLE_URL()}/api/thread`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      console.error(`\x1b[31merror\x1b[0m: Oracle API returned ${res.status}`);
+      return null;
+    }
+    return await res.json() as ThreadResponse;
+  } catch (e: any) {
+    console.error(`\x1b[31merror\x1b[0m: Oracle unreachable — ${e.message}`);
+    return null;
+  }
+}
+
+/**
+ * Get thread message count.
+ */
+async function getThreadInfo(threadId: number): Promise<{ messageCount: number } | null> {
+  try {
+    const res = await fetch(`${ORACLE_URL()}/api/thread/${threadId}`);
+    if (!res.ok) return null;
+    const data = await res.json() as ThreadInfo;
+    return { messageCount: data.messages.length };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * maw talk-to <target> "message"
+ *
+ * 1. Post to oracle_thread (MCP) → persistent
+ * 2. Send maw hey to target → notification with context
+ *
+ * MCP first, hey after. Order matters.
+ */
+export async function cmdTalkTo(target: string, message: string, force = false) {
+  // Step 1: Post to oracle_thread
+  console.log(`\x1b[36m💬\x1b[0m posting to thread channel:${target}...`);
+  const threadResult = await postToThread(target, message);
+
+  if (!threadResult) {
+    console.error(`\x1b[33mwarn\x1b[0m: thread post failed — falling back to maw hey only`);
+  }
+
+  // Step 2: Build notification with context
+  const from = process.env.CLAUDE_AGENT_NAME || "cli";
+  const preview = message.length > 80 ? message.slice(0, 77) + "..." : message;
+
+  let notification: string;
+  if (threadResult) {
+    const info = await getThreadInfo(threadResult.thread_id);
+    const msgCount = info?.messageCount ?? "?";
+    notification = [
+      `💬 channel:${target} (#${threadResult.thread_id}) — ${msgCount} msgs`,
+      `From: ${from}`,
+      `Preview: "${preview}"`,
+      `→ อ่านเต็มที่ thread #${threadResult.thread_id} หรือพิมพ์ /talk-to #${threadResult.thread_id}`,
+    ].join("\n");
+  } else {
+    notification = [
+      `💬 from ${from}`,
+      `"${preview}"`,
+    ].join("\n");
+  }
+
+  // Step 3: Send hey with context
+  // Route through resolveTarget so the #758 writable filter (drop -view mirrors
+  // and federated peer records before the ambiguity check) applies to talk-to too.
+  // talk-to is local-only delivery: only "local" / "self-node" results map to a tmux pane.
+  const config = loadConfig();
+  const sessions = await listSessions();
+  const resolved = resolveTarget(target, config, sessions);
+  // Resolve to a specific pane: when the oracle window has multiple panes
+  // (team-agents spawned beside it), `send-keys -t session:window` would
+  // otherwise land in whichever pane is currently active, not the oracle's
+  // claude pane. Mirrors comm-send (#764).
+  const tmuxTarget =
+    resolved?.type === "local" || resolved?.type === "self-node"
+      ? await resolveOraclePane(resolved.target)
+      : null;
+  if (!tmuxTarget) {
+    // Thread was posted but target window not found — still useful
+    if (threadResult) {
+      console.log(`\x1b[32m✓\x1b[0m thread #${threadResult.thread_id} updated`);
+      const reason = resolved?.type === "error" ? resolved.detail : `window "${target}" not found`;
+      console.log(`\x1b[33mwarn\x1b[0m: ${reason} — message saved to thread only`);
+    } else {
+      const reason = resolved?.type === "error" ? resolved.detail : `window "${target}" not found`;
+      throw new Error(reason);
+    }
+    return;
+  }
+
+  // Check if agent is running
+  if (!force) {
+    const cmd = await getPaneCommand(tmuxTarget);
+    const isAgent = /claude|codex|node/i.test(cmd);
+    if (!isAgent) {
+      if (threadResult) {
+        console.log(`\x1b[32m✓\x1b[0m thread #${threadResult.thread_id} updated`);
+        console.log(`\x1b[33mwarn\x1b[0m: no active Claude in ${tmuxTarget} — message saved to thread only`);
+      } else {
+        throw new Error(`no active Claude session in ${tmuxTarget} (use --force)`);
+      }
+      return;
+    }
+  }
+
+  await sendKeys(tmuxTarget, notification);
+  await runHook("after_send", { to: target, message: notification });
+
+  // Log to maw-log.jsonl
+  const logDir = join(homedir(), ".oracle");
+  const logFile = join(logDir, "maw-log.jsonl");
+  const host = hostname();
+  const sid = process.env.CLAUDE_SESSION_ID || null;
+  const ch = threadResult ? `thread:${threadResult.thread_id}` : undefined;
+  const line = JSON.stringify({
+    ts: new Date().toISOString(),
+    from,
+    to: target,
+    target: tmuxTarget,
+    msg: message,
+    host,
+    sid,
+    ch,
+  }) + "\n";
+  try { await mkdir(logDir, { recursive: true }); await appendFile(logFile, line); } catch (e) { console.error(`\x1b[33m⚠\x1b[0m talk-to log write failed: ${e}`); }
+
+  console.log(`\x1b[32m✓\x1b[0m thread #${threadResult?.thread_id ?? "?"} + sent → ${tmuxTarget}`);
+}

--- a/src/commands/plugins/view/impl.ts
+++ b/src/commands/plugins/view/impl.ts
@@ -4,7 +4,7 @@ import { loadConfig } from "../../../config";
 import { resolveSessionTarget } from "../../../core/matcher/resolve-target";
 import { logAnomaly } from "../../../core/fleet/audit";
 import { execFileSync } from "child_process";
-import { ttyAsk } from "../init/prompts";
+import { ttyAsk } from "./internal/prompts";
 
 /**
  * Decide whether to offer a wake prompt on missing target. Extracted for
@@ -207,7 +207,7 @@ export async function cmdView(
       await t.set(sessionName, "status", "off");
     }
     if (splitAnchor !== undefined) {
-      const { cmdSplit } = await import("../split/impl");
+      const { cmdSplit } = await import("./internal/split-impl");
       const anchorPane = typeof splitAnchor === "string"
         ? await resolveAnchorPane(splitAnchor)
         : undefined;
@@ -274,7 +274,7 @@ export async function cmdView(
   // detaching+attaching the whole client. Explicit anchor breaks the
   // active-pane-drift that caused the fractal-split cascade (#545/#546).
   if (splitAnchor !== undefined) {
-    const { cmdSplit } = await import("../split/impl");
+    const { cmdSplit } = await import("./internal/split-impl");
     const anchorPane = typeof splitAnchor === "string"
       ? await resolveAnchorPane(splitAnchor)
       : undefined;

--- a/src/commands/plugins/view/internal/prompts.ts
+++ b/src/commands/plugins/view/internal/prompts.ts
@@ -1,0 +1,146 @@
+import { createInterface } from "readline";
+import { createReadStream, openSync } from "fs";
+
+export type AskFn = (question: string, defaultVal?: string) => Promise<string>;
+
+export async function ttyAsk(question: string, defaultVal = ""): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const prompt = defaultVal ? `${question} [${defaultVal}]: ` : `${question}: `;
+    let fd: number;
+    try {
+      fd = openSync("/dev/tty", "r+");
+    } catch (e) {
+      reject(new Error("/dev/tty unavailable — use --non-interactive"));
+      return;
+    }
+    const rl = createInterface({
+      input: createReadStream("/dev/tty", { fd }),
+      output: process.stdout,
+      terminal: true,
+    });
+    rl.question(prompt, (answer) => {
+      rl.close();
+      resolve(answer.trim() || defaultVal);
+    });
+  });
+}
+
+const NODE_NAME_RE = /^[a-z0-9][a-z0-9-]{0,62}$/i;
+const PEER_NAME_RE = /^[a-z0-9][a-z0-9-]{0,30}$/i;
+
+export function validateNodeName(name: string): string | null {
+  if (!NODE_NAME_RE.test(name)) {
+    return "Node name must be 1-63 chars, letters/digits/hyphens only";
+  }
+  return null;
+}
+
+/**
+ * @deprecated (#680) — `ghqRoot` is no longer asked at init. Retained only so
+ * third-party callers that imported this validator keep compiling. The init
+ * flow resolves ghq root on demand via `getGhqRoot()`.
+ */
+export function validateGhqRoot(input: string, homedir: string): { ok: true; path: string } | { ok: false; err: string } {
+  if (!input) return { ok: false, err: "Path must be absolute" };
+  if (!input.startsWith("/") && !input.startsWith("~")) {
+    return { ok: false, err: "Path must be absolute (start with / or ~)" };
+  }
+  const expanded = input.startsWith("~") ? input.replace(/^~/, homedir) : input;
+  return { ok: true, path: expanded };
+}
+
+export function validatePeerUrl(url: string): string | null {
+  if (!url) return "URL required";
+  if (!/^https?:\/\//.test(url)) return "URL must start with http:// or https://";
+  try {
+    new URL(url);
+    return null;
+  } catch {
+    return `Invalid URL: ${url}`;
+  }
+}
+
+export function validatePeerName(name: string): string | null {
+  if (!PEER_NAME_RE.test(name)) {
+    return "Name must be 1-31 chars, letters/digits/hyphens only";
+  }
+  return null;
+}
+
+export interface PromptAnswers {
+  node: string;
+  token: string;
+  federate: boolean;
+  peers: { name: string; url: string }[];
+}
+
+const MAX_ATTEMPTS = 3;
+
+async function askUntilValid(
+  ask: AskFn,
+  question: string,
+  defaultVal: string,
+  validate: (v: string) => string | null,
+  writer: (msg: string) => void,
+): Promise<string> {
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const answer = await ask(question, defaultVal);
+    const err = validate(answer);
+    if (!err) return answer;
+    writer(`  \x1b[31m✗\x1b[0m ${err}`);
+    if (attempt === MAX_ATTEMPTS) {
+      throw new Error(`Aborted after ${MAX_ATTEMPTS} invalid attempts: ${question}`);
+    }
+  }
+  throw new Error("unreachable");
+}
+
+export async function runPromptLoop(
+  ask: AskFn,
+  defaults: { node: string },
+  homedir: string,
+  writer: (msg: string) => void,
+): Promise<PromptAnswers> {
+  // #680 — ghq root is no longer prompted; it's resolved on demand via `ghq root`.
+  void homedir; // kept in signature for backward-compat (callers still pass it)
+  const node = await askUntilValid(
+    ask,
+    "Node name (this machine's identity in the federation)",
+    defaults.node,
+    validateNodeName,
+    writer,
+  );
+
+  const token = await ask("Claude token (blank = use $CLAUDE_CODE_OAUTH_TOKEN or ~/.claude/credentials)", "");
+  if (!token && !process.env.CLAUDE_CODE_OAUTH_TOKEN) {
+    writer(`  \x1b[33m!\x1b[0m no token provided and $CLAUDE_CODE_OAUTH_TOKEN not set — set it before running 'maw wake'`);
+  }
+
+  const federateAnswer = (await ask("Federate with other machines? (y/N)", "N")).toLowerCase();
+  const federate = federateAnswer === "y" || federateAnswer === "yes";
+
+  const peers: { name: string; url: string }[] = [];
+  if (federate) {
+    let idx = 1;
+    while (true) {
+      const url = await ask(`Peer ${idx} URL`, "done");
+      if (!url || url === "done") break;
+      const urlErr = validatePeerUrl(url);
+      if (urlErr) {
+        writer(`  \x1b[31m✗\x1b[0m ${urlErr}`);
+        continue;
+      }
+      const name = await askUntilValid(
+        ask,
+        `Peer ${idx} name (short label)`,
+        `peer-${idx}`,
+        validatePeerName,
+        writer,
+      );
+      peers.push({ name, url });
+      idx++;
+    }
+  }
+
+  return { node, token, federate, peers };
+}

--- a/src/commands/plugins/view/internal/split-impl.ts
+++ b/src/commands/plugins/view/internal/split-impl.ts
@@ -1,0 +1,133 @@
+import { listSessions, hostExec, withPaneLock } from "../../../../sdk";
+import { resolveSessionTarget } from "../../../../core/matcher/resolve-target";
+import { normalizeTarget } from "../../../../core/matcher/normalize-target";
+
+export interface SplitOpts {
+  /** Split percentage (1-99). Default: 50. */
+  pct?: number;
+  /** Split vertical (top/bottom) instead of horizontal (side-by-side). */
+  vertical?: boolean;
+  /** Split without attaching — leaves a plain shell in the new pane. */
+  noAttach?: boolean;
+  /** Serialize via the pane-creation lock + settle. Opt-in — only matters
+   *  when another in-process caller may be spawning concurrently. */
+  lock?: boolean;
+  /** Settle delay after split when lock=true. Default: 200ms. */
+  settleMs?: number;
+  /** Pane-id / selector to split beside instead of $TMUX_PANE. Break the
+   *  implicit active-pane-drift that caused fractal-split cascade (#545).
+   *  Accepts: "%N" (pane id), "session:window.pane", or "session:window". */
+  anchorPane?: string;
+}
+
+/**
+ * maw split <target> [--pct N] [--vertical] [--no-attach]
+ *
+ * Split the current tmux pane and attach to a target session in the new pane.
+ *
+ * Target resolution:
+ *   - "session:window"  → used as-is
+ *   - "session"         → resolved to session:window[0]
+ *   - bare oracle name  → finds session ending with "-<name>" or name === <name>
+ *
+ * Why this exists: `/bud --split` inlined this pattern, but (a) the nested
+ * `tmux attach-session` silently fails when $TMUX is set, and (b) the logic
+ * is useful beyond bud (worktree, pair-ops, debugging). Extracted here as
+ * one canonical helper — future skills call `maw split` instead of duplicating
+ * the tmux shell-out.
+ */
+export async function cmdSplit(target: string, opts: SplitOpts = {}) {
+  // Canonicalize first — drop trailing `/`, `/.git`, `/.git/` tab-completion artifacts.
+  // Safe for "session:window" form: nothing to strip unless the user adds a literal slash.
+  target = normalizeTarget(target);
+  if (!process.env.TMUX) {
+    throw new Error("maw split requires an active tmux session");
+  }
+
+  if (!target) {
+    console.error("usage: maw split <target> [--pct N] [--vertical] [--no-attach]");
+    console.error("  e.g. maw split yeast");
+    console.error("       maw split mawjs-view --pct 30 --vertical");
+    throw new Error("usage: maw split <target> [--pct N] [--vertical] [--no-attach]");
+  }
+
+  // Validate pct early so bad input never reaches tmux
+  const pct = opts.pct ?? 50;
+  if (!Number.isFinite(pct) || pct < 1 || pct > 99) {
+    throw new Error(`--pct must be 1-99 (got ${pct})`);
+  }
+
+  // Resolve target to session:window if bare name given. Resolution rules
+  // (exact > suffix/prefix fuzzy > ambiguous > none) live in the canonical
+  // matcher — silent wrong-answer is worse than a loud failure.
+  let resolved = target;
+  if (!target.includes(":")) {
+    const sessions = await listSessions();
+    const r = resolveSessionTarget(target, sessions);
+
+    if (r.kind === "ambiguous") {
+      console.error(`  \x1b[31m✗\x1b[0m '${target}' is ambiguous — matches ${r.candidates.length} sessions:`);
+      for (const s of r.candidates) {
+        console.error(`  \x1b[90m    • ${s.name}\x1b[0m`);
+      }
+      console.error(`  \x1b[90m  use the full name: maw split <exact-session>\x1b[0m`);
+      throw new Error(`'${target}' is ambiguous`);
+    }
+    if (r.kind === "none") {
+      console.error(`  \x1b[31m✗\x1b[0m session '${target}' not found in fleet`);
+      if (r.hints?.length) {
+        console.error(`  \x1b[90mdid you mean:\x1b[0m`);
+        for (const h of r.hints) {
+          console.error(`  \x1b[90m    • ${h.name}\x1b[0m`);
+        }
+      }
+      console.error(`  \x1b[90m  try: maw ls\x1b[0m`);
+      throw new Error(`session '${target}' not found in fleet`);
+    }
+
+    resolved = `${r.match.name}:${r.match.windows[0]?.index ?? 0}`;
+  }
+
+  // Build tmux split-window command.
+  //
+  // Critical: unset $TMUX in the spawned shell so the inner attach-session
+  // can nest into the target. Without `TMUX=`, tmux refuses nested attach
+  // and the new pane dies immediately (this is the #bud --split silent-fail bug).
+  //
+  // Target the caller's pane (#365 cascade fix): without -t, tmux splits
+  // the currently-active pane — which shifts after the first split, causing
+  // the second `maw bud <name> --split` from the same parent to silently
+  // split the wrong pane (or noop visually). Explicit -t $TMUX_PANE anchors
+  // every split to the caller's origin pane, so buds cascade instead of drifting.
+  // Fallback: if TMUX_PANE isn't set (shouldn't happen — we checked $TMUX above,
+  // and any pane inside tmux has TMUX_PANE set — but defend anyway), omit -t
+  // and accept the pre-fix behavior.
+  // Precedence: opts.anchorPane (explicit, from cmdView) > $TMUX_PANE (caller's
+  // pane) > none. Explicit anchor breaks the active-pane-drift that caused
+  // fractal-split cascade in #545/#546.
+  const direction = opts.vertical ? "-v" : "-h";
+  const innerCmd = opts.noAttach ? "bash" : `TMUX= tmux attach-session -t ${resolved}`;
+  const anchor = opts.anchorPane ?? process.env.TMUX_PANE;
+  const targetFlag = anchor ? `-t '${anchor.replace(/'/g, "'\\''")}' ` : "";
+  const cmd = `tmux split-window ${targetFlag}${direction} -l ${pct}% "${innerCmd}"`;
+
+  try {
+    if (opts.lock) {
+      // Serialize against other in-process pane spawns; settle before release
+      // so tmux has a tick to register the new pane index.
+      const settleMs = opts.settleMs ?? 200;
+      await withPaneLock(async () => {
+        await hostExec(cmd);
+        if (settleMs > 0) await new Promise((r) => setTimeout(r, settleMs));
+      });
+    } else {
+      await hostExec(cmd);
+    }
+    const side = opts.vertical ? "below" : "beside";
+    const action = opts.noAttach ? "empty pane" : resolved;
+    const anchorLabel = opts.anchorPane ? ` (anchored at ${opts.anchorPane})` : "";
+    console.log(`  \x1b[32m✓\x1b[0m split ${side} — ${action} (${pct}%)${anchorLabel}`);
+  } catch (e: any) {
+    throw new Error(`split failed: ${e.message || e}`);
+  }
+}

--- a/test/isolated/bud-wake.test.ts
+++ b/test/isolated/bud-wake.test.ts
@@ -175,27 +175,33 @@ mock.module(
 let cmdSoulSyncCalls: Array<{ target: string; opts: Record<string, unknown> }> = [];
 let cmdSoulSyncThrow: Error | null = null;
 let syncDirCalls: Array<{ src: string; dst: string }> = [];
+const soulSyncMockFactory = () => ({
+  resolveOraclePath: realResolveOraclePath,
+  resolveProjectSlug: realResolveProjectSlug,
+  findOracleForProject: realFindOracleForProject,
+  findPeers: realFindPeers,
+  findProjectsForOracle: realFindProjectsForOracle,
+  syncProjectVault: realSyncProjectVault,
+  cmdSoulSyncProject: realCmdSoulSyncProject,
+  cmdSoulSync: async (target?: string, opts?: Record<string, unknown>) => {
+    if (!mockActive) return realCmdSoulSync(target, opts as any);
+    cmdSoulSyncCalls.push({ target: target ?? "", opts: opts ?? {} });
+    if (cmdSoulSyncThrow) throw cmdSoulSyncThrow;
+    return [];
+  },
+  syncDir: (src: string, dst: string) => {
+    if (!mockActive) return realSyncDir(src, dst);
+    syncDirCalls.push({ src, dst });
+  },
+});
 mock.module(
   join(import.meta.dir, "../../src/commands/plugins/soul-sync/impl"),
-  () => ({
-    resolveOraclePath: realResolveOraclePath,
-    resolveProjectSlug: realResolveProjectSlug,
-    findOracleForProject: realFindOracleForProject,
-    findPeers: realFindPeers,
-    findProjectsForOracle: realFindProjectsForOracle,
-    syncProjectVault: realSyncProjectVault,
-    cmdSoulSyncProject: realCmdSoulSyncProject,
-    cmdSoulSync: async (target?: string, opts?: Record<string, unknown>) => {
-      if (!mockActive) return realCmdSoulSync(target, opts as any);
-      cmdSoulSyncCalls.push({ target: target ?? "", opts: opts ?? {} });
-      if (cmdSoulSyncThrow) throw cmdSoulSyncThrow;
-      return [];
-    },
-    syncDir: (src: string, dst: string) => {
-      if (!mockActive) return realSyncDir(src, dst);
-      syncDirCalls.push({ src, dst });
-    },
-  }),
+  soulSyncMockFactory,
+);
+// Phase 2 vendor: bud now imports cmdSoulSync from its own vendored copy.
+mock.module(
+  join(import.meta.dir, "../../src/commands/plugins/bud/internal/soul-sync-impl"),
+  soulSyncMockFactory,
 );
 
 // `bud-wake.ts` imports `syncDir` from the vendored `src/lib/sync-dir` (#918
@@ -213,16 +219,22 @@ mock.module(
 
 let cmdSplitCalls: string[] = [];
 let cmdSplitThrow: Error | null = null;
+const splitMockFactory = () => ({
+  ..._rSplitImpl,
+  cmdSplit: async (name: string, opts?: Record<string, unknown>) => {
+    if (!mockActive) return realCmdSplit(name, opts as any);
+    cmdSplitCalls.push(name);
+    if (cmdSplitThrow) throw cmdSplitThrow;
+  },
+});
 mock.module(
   join(import.meta.dir, "../../src/commands/plugins/split/impl"),
-  () => ({
-    ..._rSplitImpl,
-    cmdSplit: async (name: string, opts?: Record<string, unknown>) => {
-      if (!mockActive) return realCmdSplit(name, opts as any);
-      cmdSplitCalls.push(name);
-      if (cmdSplitThrow) throw cmdSplitThrow;
-    },
-  }),
+  splitMockFactory,
+);
+// Phase 2 vendor: bud now imports cmdSplit from its own vendored copy.
+mock.module(
+  join(import.meta.dir, "../../src/commands/plugins/bud/internal/split-impl"),
+  splitMockFactory,
 );
 
 // #680 — getGhqRoot moved to leaf module config/ghq-root. finalizeBud calls

--- a/test/isolated/view-split-anchor.test.ts
+++ b/test/isolated/view-split-anchor.test.ts
@@ -62,11 +62,14 @@ mock.module(join(import.meta.dir, "../../src/core/fleet/audit"), () => ({
   logAnomaly: () => {},
 }));
 
-mock.module(join(import.meta.dir, "../../src/commands/plugins/split/impl"), () => ({
+const splitMockFactory = () => ({
   cmdSplit: async (target: string, opts: { anchorPane?: string } = {}) => {
     cmdSplitCalls.push({ target, opts });
   },
-}));
+});
+mock.module(join(import.meta.dir, "../../src/commands/plugins/split/impl"), splitMockFactory);
+// Phase 2 vendor: view now imports cmdSplit from its own vendored copy.
+mock.module(join(import.meta.dir, "../../src/commands/plugins/view/internal/split-impl"), splitMockFactory);
 
 const { cmdView } = await import("../../src/commands/plugins/view/impl");
 


### PR DESCRIPTION
## Summary

Phase 2 prep — make 10 plugins (about, archive, bud, cleanup, doctor, done, init, pair, tab, view) **self-contained** by vendoring sibling-plugin imports into each plugin's `internal/` directory.

After this PR, all 10 plugins pass `migrate-plugin.sh` preflight C (no cross-plugin coupling) and can be extracted to `maw-plugin-registry`.

## What changed

Per importer: copy referenced sibling source into `<plugin>/internal/` and rewrite the import. Source plugins (oracle, soul-sync, peers, team, talk-to, init/prompts, plugin/lock, split) are **NOT deleted** — pruning is a separate concern.

| Importer | Vendored from |
|----------|---------------|
| about    | oracle: `impl-about`, `impl-helpers` |
| archive  | soul-sync: `impl`, `sync-helpers`, `resolve` |
| bud      | soul-sync (3) + peers: `store`, `lock` + split: `impl` |
| cleanup  | team: `team-cleanup-zombies`, `team-helpers` |
| doctor   | peers: `store`, `lock`, `duplicate-detect` |
| done     | reunion: `impl` (from registry — pruned in b5aaf040) + soul-sync (3) |
| init     | plugin: `lock`, `install-manifest-helpers`, `install-extraction` |
| pair     | peers: `impl`, `store`, `lock`, `probe`, `tofu` |
| tab      | talk-to: `impl` |
| view     | init: `prompts` + split: `impl` |

~30 vendored files across 10 importers. Cross-plugin imports → **0** (verified via preflight C + manual grep).

## Notes

- `done/done-autosave.ts` had a **dangling import** to `../reunion/impl` (reunion was pruned to registry in b5aaf040, so the runtime call to `cmdReunion` would have failed had the function been hit). Vendored from `maw-plugin-registry/plugins/reunion/impl.ts` to restore the call.
- Test mocks updated: `bud-wake.test.ts` and `view-split-anchor.test.ts` now mock both the original and vendored module paths so process-global `mock.module` covers vendored callers.
- Two dynamic imports updated (`await import("../split/impl")` in bud-wake & view) and one type-only inline import in doctor.

## Test plan

- [x] `bun install && bun run build` — green (646 modules, 0.89 MB)
- [x] `bun run test:isolated` — 107/111 files passed (same 4 pre-existing path-symlink flakes as baseline: fleet-doctor, oracle-manifest, resolve-local-first, resolve-psi)
- [x] `migrate-plugin.sh` preflight C passes for all 10 plugins (manual grep verified: no cross-plugin sibling imports remain in any of the 10)
- [ ] Phase 2 extraction can now proceed plugin-by-plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)