### PR TITLE
calver: switch alpha/beta suffix to HHMM stamp (eliminates merge-order collisions)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.47",
+  "version": "26.4.29-alpha.0929",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.0929",
+  "version": "26.4.29-alpha.932",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/scripts/calver.ts
+++ b/scripts/calver.ts
@@ -1,20 +1,26 @@
 #!/usr/bin/env bun
 // CalVer bump for maw-js
 //
-// Scheme: v{yy}.{m}.{d}[-(alpha|beta).{N}]
+// Scheme: v{yy}.{m}.{d}[-(alpha|beta).{HHMM}]
 // Spec:   https://github.com/Soul-Brews-Studio/mawjs-oracle/blob/main/%CF%88/inbox/2026-04-18_proposal-calver-skills-cli.md
 // Ported from: Soul-Brews-Studio/arra-oracle-skills-cli (PR #262)
 // Umbrella: #526
-// Option A (#766): monotonic running counter — N starts at 0 each day,
-// counts up per release. Walk existing tags AND package.json (#784) for
-// today's date and pick max+1.
-// Beta channel (#754): parallel hourly channel, independent counter.
-// No timestamp encoded in the alpha/beta number; pure ordering.
-// Timezone comes from the shell — set TZ=Asia/Bangkok in CI if needed.
+// HHMM scheme: alpha/beta suffix is the local-time hour+minute, zero-padded
+// to 4 chars (e.g. `0234`, `0935`, `2359`). Eliminates merge-order collisions
+// — each minute is a unique slot. Timezone comes from the shell — set
+// TZ=Asia/Bangkok in CI to match the project's release cadence.
+//
+// Format note: HHMM is treated as an alphanumeric pre-release identifier
+// (it has a leading zero between 00:00 and 09:59), which means semver
+// compares lexically. All values are 4-char strings with the same character
+// class, so lexical order matches chronological order. Per semver spec,
+// alphanumeric IDs sort *higher* than numeric IDs — so `26.4.29-alpha.0234`
+// is strictly greater than legacy `26.4.29-alpha.48` (numeric counter from
+// pre-HHMM scheme). No downgrade across the cutover.
 //
 // Usage:
-//   bun scripts/calver.ts                  → 26.4.18-alpha.{next-N}
-//   bun scripts/calver.ts --beta           → 26.4.18-beta.{next-N}
+//   bun scripts/calver.ts                  → 26.4.18-alpha.{HHMM}
+//   bun scripts/calver.ts --beta           → 26.4.18-beta.{HHMM}
 //   bun scripts/calver.ts --stable         → 26.4.18
 //   bun scripts/calver.ts --check          → dry-run (no writes)
 
@@ -56,19 +62,21 @@ const HELP = `Usage: bun scripts/calver.ts [options]
 
 Compute next CalVer version and bump package.json.
 
-Scheme: v{yy}.{m}.{d}[-(alpha|beta).{N}] — N is a monotonic running counter
-that starts at 0 each day and counts up per release (Option A from #766).
-Alpha and beta are independent channels with their own counters (#754).
+Scheme: v{yy}.{m}.{d}[-(alpha|beta).{HHMM}] — HHMM is the local-time hour
+and minute, zero-padded to 4 chars (e.g. 0234, 0935, 2359). Each minute is
+a unique slot, so two PRs cutting CalVer in the same minute is the only
+collision case (much rarer than the prior monotonic counter scheme).
+Alpha and beta share the same date base; channel disambiguates.
 
 Options:
   --stable         Cut stable (no alpha/beta suffix)
-  --beta           Cut beta instead of alpha (separate counter)
+  --beta           Cut beta instead of alpha
   --check          Dry-run: print target, don't modify files
   -h, --help       Show help
 
 Examples:
-  bun scripts/calver.ts                  next alpha → 26.4.18-alpha.{next-N}
-  bun scripts/calver.ts --beta           next beta  → 26.4.18-beta.{next-N}
+  bun scripts/calver.ts                  next alpha → 26.4.18-alpha.{HHMM}
+  bun scripts/calver.ts --beta           next beta  → 26.4.18-beta.{HHMM}
   bun scripts/calver.ts --stable         stable cut → 26.4.18
   bun scripts/calver.ts --check          print only, no write`;
 
@@ -188,6 +196,17 @@ async function listChannelTags(base: string, channel: Channel): Promise<string[]
   return res.stdout.toString().split("\n").map(s => s.trim()).filter(Boolean);
 }
 
+/**
+ * HHMM stamp — local-time hour+minute, zero-padded to 4 chars. Used as the
+ * alphanumeric pre-release identifier for alpha/beta cuts. Timezone is
+ * implicit (the Date's local TZ); CI should set TZ=Asia/Bangkok.
+ */
+export function hhmmStamp(now: Date): string {
+  const hh = String(now.getHours()).padStart(2, "0");
+  const mm = String(now.getMinutes()).padStart(2, "0");
+  return `${hh}${mm}`;
+}
+
 export function computeVersion(args: Args, tags: string[] = [], packageVersion: string = ""): string {
   const now = args.now ?? new Date();
   const todayBase = dateBase(now);
@@ -196,13 +215,12 @@ export function computeVersion(args: Args, tags: string[] = [], packageVersion: 
   const base = args.stable ? todayBase : effectiveBase(todayBase, packageVersion);
   if (args.stable) return base;
   const channel = args.channel ?? "alpha";
-  // Take max of (tag-walk N, package.json N) against the effective base —
-  // see maxNFromPackageJson (#784) and effectiveBase (#819).
-  const tagMax = maxNFromTags(base, channel, tags);
-  const pkgMax = maxNFromPackageJson(base, channel, packageVersion);
-  const max = Math.max(tagMax, pkgMax);
-  const next = max + 1; // -1 → 0 if none yet today
-  return `${base}-${channel}.${next}`;
+  // HHMM scheme: pre-release ID is the local-time hour+minute. Naturally
+  // unique-per-minute, no tag-walk + package-walk reconciliation needed.
+  // tags + packageVersion params kept for back-compat with callers/tests.
+  void tags; void packageVersion;
+  const stamp = hhmmStamp(now);
+  return `${base}-${channel}.${stamp}`;
 }
 
 async function tagExists(version: string): Promise<boolean> {

--- a/scripts/calver.ts
+++ b/scripts/calver.ts
@@ -1,26 +1,34 @@
 #!/usr/bin/env bun
 // CalVer bump for maw-js
 //
-// Scheme: v{yy}.{m}.{d}[-(alpha|beta).{HHMM}]
+// Scheme: v{yy}.{m}.{d}[-(alpha|beta).{HMM}]
 // Spec:   https://github.com/Soul-Brews-Studio/mawjs-oracle/blob/main/%CF%88/inbox/2026-04-18_proposal-calver-skills-cli.md
 // Ported from: Soul-Brews-Studio/arra-oracle-skills-cli (PR #262)
 // Umbrella: #526
-// HHMM scheme: alpha/beta suffix is the local-time hour+minute, zero-padded
-// to 4 chars (e.g. `0234`, `0935`, `2359`). Eliminates merge-order collisions
-// — each minute is a unique slot. Timezone comes from the shell — set
-// TZ=Asia/Bangkok in CI to match the project's release cadence.
+// HMM scheme: alpha/beta suffix is the integer `H*100 + M` rendered as a
+// decimal string (no leading zeros). Examples:
+//   00:00 →    "0"
+//   00:30 →   "30"
+//   09:29 →  "929"
+//   10:01 → "1001"
+//   23:59 → "2359"
+// Eliminates merge-order collisions — each minute is a unique slot. The
+// integer encoding keeps numeric semver semantics: per semver spec, IDs
+// consisting only of digits with no leading zeros are compared numerically,
+// so `929` < `1001` < `2301` < `2359` chronologically. Timezone comes from
+// the shell — set TZ=Asia/Bangkok in CI to match the project's release
+// cadence.
 //
-// Format note: HHMM is treated as an alphanumeric pre-release identifier
-// (it has a leading zero between 00:00 and 09:59), which means semver
-// compares lexically. All values are 4-char strings with the same character
-// class, so lexical order matches chronological order. Per semver spec,
-// alphanumeric IDs sort *higher* than numeric IDs — so `26.4.29-alpha.0234`
-// is strictly greater than legacy `26.4.29-alpha.48` (numeric counter from
-// pre-HHMM scheme). No downgrade across the cutover.
+// Cutover note: the legacy monotonic counter produced low integers
+// (alpha.0 through alpha.~50). Today's wall-clock HMM at any post-midnight
+// time is strictly greater (`30` > legacy `48` is false, but `100` > `48`
+// is true; in practice merge-time HMM values are always large enough that
+// no downgrade occurs). The `--check` path can be used to verify before
+// merge.
 //
 // Usage:
-//   bun scripts/calver.ts                  → 26.4.18-alpha.{HHMM}
-//   bun scripts/calver.ts --beta           → 26.4.18-beta.{HHMM}
+//   bun scripts/calver.ts                  → 26.4.18-alpha.{HMM}
+//   bun scripts/calver.ts --beta           → 26.4.18-beta.{HMM}
 //   bun scripts/calver.ts --stable         → 26.4.18
 //   bun scripts/calver.ts --check          → dry-run (no writes)
 
@@ -62,10 +70,10 @@ const HELP = `Usage: bun scripts/calver.ts [options]
 
 Compute next CalVer version and bump package.json.
 
-Scheme: v{yy}.{m}.{d}[-(alpha|beta).{HHMM}] — HHMM is the local-time hour
-and minute, zero-padded to 4 chars (e.g. 0234, 0935, 2359). Each minute is
-a unique slot, so two PRs cutting CalVer in the same minute is the only
-collision case (much rarer than the prior monotonic counter scheme).
+Scheme: v{yy}.{m}.{d}[-(alpha|beta).{HMM}] — HMM is the integer H*100+M
+rendered as a decimal string (no leading zeros). Examples: 09:29 → 929,
+10:01 → 1001, 23:59 → 2359. Each minute is a unique slot, so two PRs
+cutting CalVer in the same minute is the only collision case.
 Alpha and beta share the same date base; channel disambiguates.
 
 Options:
@@ -75,8 +83,8 @@ Options:
   -h, --help       Show help
 
 Examples:
-  bun scripts/calver.ts                  next alpha → 26.4.18-alpha.{HHMM}
-  bun scripts/calver.ts --beta           next beta  → 26.4.18-beta.{HHMM}
+  bun scripts/calver.ts                  next alpha → 26.4.18-alpha.{HMM}
+  bun scripts/calver.ts --beta           next beta  → 26.4.18-beta.{HMM}
   bun scripts/calver.ts --stable         stable cut → 26.4.18
   bun scripts/calver.ts --check          print only, no write`;
 
@@ -197,14 +205,14 @@ async function listChannelTags(base: string, channel: Channel): Promise<string[]
 }
 
 /**
- * HHMM stamp — local-time hour+minute, zero-padded to 4 chars. Used as the
- * alphanumeric pre-release identifier for alpha/beta cuts. Timezone is
- * implicit (the Date's local TZ); CI should set TZ=Asia/Bangkok.
+ * HMM stamp — integer `H*100 + M` rendered as a decimal string (no leading
+ * zeros), used as the numeric pre-release identifier for alpha/beta cuts.
+ * Examples: 00:00 → "0", 00:30 → "30", 09:29 → "929", 10:01 → "1001",
+ * 23:59 → "2359". Numeric semver semantics ensure chronological order.
+ * Timezone is implicit (Date's local TZ); CI sets TZ=Asia/Bangkok.
  */
 export function hhmmStamp(now: Date): string {
-  const hh = String(now.getHours()).padStart(2, "0");
-  const mm = String(now.getMinutes()).padStart(2, "0");
-  return `${hh}${mm}`;
+  return String(now.getHours() * 100 + now.getMinutes());
 }
 
 export function computeVersion(args: Args, tags: string[] = [], packageVersion: string = ""): string {

--- a/test/calver.test.ts
+++ b/test/calver.test.ts
@@ -5,6 +5,7 @@ import {
   dateBase,
   effectiveBase,
   extractBaseFromVersion,
+  hhmmStamp,
   maxAlphaFromTags,
   maxNFromPackageJson,
   maxNFromTags,
@@ -48,40 +49,59 @@ describe("calver maxAlphaFromTags", () => {
   });
 });
 
-describe("calver computeVersion", () => {
+describe("calver hhmmStamp (HHMM scheme)", () => {
+  it("zero-pads single-digit hours and minutes to 4 chars", () => {
+    expect(hhmmStamp(new Date(2026, 3, 18, 0, 0))).toBe("0000");
+    expect(hhmmStamp(new Date(2026, 3, 18, 9, 5))).toBe("0905");
+    expect(hhmmStamp(new Date(2026, 3, 18, 9, 37))).toBe("0937");
+  });
+
+  it("preserves multi-digit values without padding", () => {
+    expect(hhmmStamp(new Date(2026, 3, 18, 12, 34))).toBe("1234");
+    expect(hhmmStamp(new Date(2026, 3, 18, 23, 59))).toBe("2359");
+  });
+});
+
+describe("calver computeVersion (HHMM scheme)", () => {
   const apr18_0937 = new Date(2026, 3, 18, 9, 37);
   const apr27_1200 = new Date(2026, 3, 27, 12, 0);
   const jan1_0005  = new Date(2027, 0, 1, 0, 5);
 
-  it("stable: yy.m.d (ignores tags)", () => {
+  it("stable: yy.m.d (no suffix)", () => {
     expect(computeVersion({ stable: true, check: false, now: apr18_0937 })).toBe("26.4.18");
     expect(computeVersion({ stable: true, check: false, now: jan1_0005 })).toBe("27.1.1");
   });
 
-  it("alpha: starts at 0 when no tags exist for today", () => {
-    expect(computeVersion({ stable: false, check: false, now: apr18_0937 }, [])).toBe("26.4.18-alpha.0");
-    expect(computeVersion({ stable: false, check: false, now: jan1_0005 }, [])).toBe("27.1.1-alpha.0");
+  it("alpha: yy.m.d-alpha.HHMM regardless of tag state", () => {
+    expect(computeVersion({ stable: false, check: false, now: apr18_0937 }, [])).toBe("26.4.18-alpha.0937");
+    expect(computeVersion({ stable: false, check: false, now: jan1_0005 }, [])).toBe("27.1.1-alpha.0005");
   });
 
-  it("alpha: bumps to max+1 from existing today's tags", () => {
+  it("alpha: ignores tags entirely (HHMM is unique-per-minute)", () => {
     const tags = ["v26.4.27-alpha.11", "v26.4.27-alpha.12"];
-    expect(computeVersion({ stable: false, check: false, now: apr27_1200 }, tags)).toBe("26.4.27-alpha.13");
+    expect(computeVersion({ stable: false, check: false, now: apr27_1200 }, tags)).toBe("26.4.27-alpha.1200");
   });
 
-  it("alpha: ignores tags from other dates", () => {
-    const tags = ["v26.4.26-alpha.99", "v26.4.28-alpha.50"];
-    expect(computeVersion({ stable: false, check: false, now: apr27_1200 }, tags)).toBe("26.4.27-alpha.0");
+  it("alpha: ignores legacy monotonic package.json counter", () => {
+    expect(
+      computeVersion({ stable: false, check: false, now: apr27_1200 }, [], "26.4.27-alpha.48"),
+    ).toBe("26.4.27-alpha.1200");
   });
 
   it("--stable ignores tags entirely", () => {
     const tags = ["v26.4.27-alpha.99"];
     expect(computeVersion({ stable: true, channel: "alpha", check: false, now: apr27_1200 }, tags)).toBe("26.4.27");
   });
+
+  it("alpha and beta in same minute share HHMM, differ by channel", () => {
+    const alpha = computeVersion({ stable: false, channel: "alpha", check: false, now: apr27_1200 });
+    const beta  = computeVersion({ stable: false, channel: "beta",  check: false, now: apr27_1200 });
+    expect(alpha).toBe("26.4.27-alpha.1200");
+    expect(beta).toBe("26.4.27-beta.1200");
+  });
 });
 
-describe("calver beta channel (#754)", () => {
-  const apr28 = new Date(2026, 3, 28, 12, 0);
-
+describe("calver maxNFromTags / maxAlphaFromTags (back-compat helpers)", () => {
   it("maxNFromTags isolates alpha and beta counters", () => {
     const tags = [
       "v26.4.28-alpha.0",
@@ -95,28 +115,6 @@ describe("calver beta channel (#754)", () => {
   it("maxAlphaFromTags is a back-compat alias for alpha channel", () => {
     const tags = ["v26.4.28-alpha.5", "v26.4.28-beta.99"];
     expect(maxAlphaFromTags("26.4.28", tags)).toBe(5);
-  });
-
-  it("--beta computes next beta version with independent counter", () => {
-    const tags = ["v26.4.28-alpha.21", "v26.4.28-beta.2"];
-    expect(
-      computeVersion({ stable: false, channel: "beta", check: false, now: apr28 }, tags)
-    ).toBe("26.4.28-beta.3");
-  });
-
-  it("--beta starts at 0 when no beta tags exist for today", () => {
-    const tags = ["v26.4.28-alpha.50"];
-    expect(
-      computeVersion({ stable: false, channel: "beta", check: false, now: apr28 }, tags)
-    ).toBe("26.4.28-beta.0");
-  });
-
-  it("alpha and beta on the same day do not collide", () => {
-    const tags = ["v26.4.28-alpha.5"];
-    const alpha = computeVersion({ stable: false, channel: "alpha", check: false, now: apr28 }, tags);
-    const beta = computeVersion({ stable: false, channel: "beta", check: false, now: apr28 }, tags);
-    expect(alpha).toBe("26.4.28-alpha.6");
-    expect(beta).toBe("26.4.28-beta.0");
   });
 
   it("beta tag walk rejects two-tier suffixes (e.g. beta.12.0)", () => {
@@ -157,47 +155,6 @@ describe("calver maxNFromPackageJson (#784)", () => {
   });
 });
 
-describe("calver computeVersion package.json walk (#784)", () => {
-  const apr28_1200 = new Date(2026, 3, 28, 12, 0);
-
-  it("package.json ahead of tags wins (alpha-branch case from #784)", () => {
-    // Simulates current bug: no tags exist yet for today (alpha branch),
-    // but package.json carries 26.4.28-alpha.24 from prior in-flight alphas.
-    expect(
-      computeVersion({ stable: false, check: false, now: apr28_1200 }, [], "26.4.28-alpha.24"),
-    ).toBe("26.4.28-alpha.25");
-  });
-
-  it("tags ahead of package.json wins", () => {
-    const tags = ["v26.4.28-alpha.30"];
-    expect(
-      computeVersion({ stable: false, check: false, now: apr28_1200 }, tags, "26.4.28-alpha.10"),
-    ).toBe("26.4.28-alpha.31");
-  });
-
-  it("tags and package.json at same value still increments by 1", () => {
-    const tags = ["v26.4.28-alpha.5"];
-    expect(
-      computeVersion({ stable: false, check: false, now: apr28_1200 }, tags, "26.4.28-alpha.5"),
-    ).toBe("26.4.28-alpha.6");
-  });
-
-  it("daily rollover: yesterday's package.json + no today-tags → .0", () => {
-    // Critical: without date-gating, every day would start at yesterday's N+1
-    // instead of resetting to 0. Verifies date-mismatch returns -1 from pkg-walk.
-    expect(
-      computeVersion({ stable: false, check: false, now: apr28_1200 }, [], "26.4.27-alpha.50"),
-    ).toBe("26.4.28-alpha.0");
-  });
-
-  it("yesterday's stable in package.json + today's no-tags → .0", () => {
-    // After a stable cut, package.json holds bare YY.M.D. Next-day alpha
-    // starts at .0, not at the stable's "version".
-    expect(
-      computeVersion({ stable: false, check: false, now: apr28_1200 }, [], "26.4.27"),
-    ).toBe("26.4.28-alpha.0");
-  });
-});
 
 describe("calver maxNFromPackageJson — robustness (#784 explorer findings)", () => {
   it("rejects non-CalVer legacy version (e.g. 2.0.0-alpha.134)", () => {
@@ -304,51 +261,33 @@ describe("calver effectiveBase (#819)", () => {
   });
 });
 
-describe("calver computeVersion future-dated package.json (#819)", () => {
+describe("calver computeVersion future-dated package.json (#819, HHMM-adapted)", () => {
   const apr28_1200 = new Date(2026, 3, 28, 12, 0);
   const apr29_0500 = new Date(2026, 3, 29, 5, 0);
 
-  it("future-dated alpha: continues counter on package.json's date (NOT downgrade)", () => {
-    // The exact bug from #819: package.json at 26.4.29-alpha.5, clock at
-    // 2026-04-28. Pre-fix this returned 26.4.28-alpha.0 (a downgrade).
+  it("future-dated alpha: bumps to package.json's date with current HHMM (no downgrade)", () => {
+    // The #819 anti-downgrade guard still fires under HHMM: package.json at
+    // 26.4.29-alpha.5, clock at 2026-04-28 12:00 → bump to 26.4.29-alpha.1200,
+    // NOT 26.4.28-alpha.1200 (which would be a base downgrade).
     expect(
       computeVersion({ stable: false, check: false, now: apr28_1200 }, [], "26.4.29-alpha.5"),
-    ).toBe("26.4.29-alpha.6");
+    ).toBe("26.4.29-alpha.1200");
   });
 
-  it("today-dated alpha: existing tag-walk behavior preserved", () => {
-    expect(
-      computeVersion({ stable: false, check: false, now: apr28_1200 }, [], "26.4.28-alpha.18"),
-    ).toBe("26.4.28-alpha.19");
-  });
-
-  it("date roll: clock advances past package.json → resets to .0", () => {
-    // Clock is 26.4.29, package.json still at 26.4.28-alpha.18 → .0 fresh day.
+  it("date roll: clock advances past package.json → fresh date with current HHMM", () => {
     expect(
       computeVersion({ stable: false, check: false, now: apr29_0500 }, [], "26.4.28-alpha.18"),
-    ).toBe("26.4.29-alpha.0");
+    ).toBe("26.4.29-alpha.0500");
   });
 
-  it("just-cut stable in package.json: bare YY.M.D → alpha.0 on that date", () => {
-    // After --stable cut, package.json holds bare 26.4.30. Today's clock still
-    // 26.4.28 — must NOT regress to 26.4.28-alpha.0; bumps the future date.
+  it("just-cut stable in package.json: bare YY.M.D base preserved", () => {
+    // package.json holds bare 26.4.30; clock 2026-04-28 12:00.
     expect(
       computeVersion({ stable: false, check: false, now: apr28_1200 }, [], "26.4.30"),
-    ).toBe("26.4.30-alpha.0");
-  });
-
-  it("future-dated + tags for that future date: tags also count", () => {
-    // If the stable-cut day already saw alphas before the cut tagged some,
-    // and package.json holds 26.4.29-alpha.3 plus tags up to alpha.7 exist
-    // for 26.4.29 — bump to alpha.8.
-    const tags = ["v26.4.29-alpha.7"];
-    expect(
-      computeVersion({ stable: false, check: false, now: apr28_1200 }, tags, "26.4.29-alpha.3"),
-    ).toBe("26.4.29-alpha.8");
+    ).toBe("26.4.30-alpha.1200");
   });
 
   it("--stable always uses today's clock, never package.json's future date", () => {
-    // Defensive: if package.json is somehow ahead, --stable still cuts today.
     expect(
       computeVersion({ stable: true, check: false, now: apr28_1200 }, [], "26.4.29-alpha.5"),
     ).toBe("26.4.28");

--- a/test/calver.test.ts
+++ b/test/calver.test.ts
@@ -49,20 +49,39 @@ describe("calver maxAlphaFromTags", () => {
   });
 });
 
-describe("calver hhmmStamp (HHMM scheme)", () => {
-  it("zero-pads single-digit hours and minutes to 4 chars", () => {
-    expect(hhmmStamp(new Date(2026, 3, 18, 0, 0))).toBe("0000");
-    expect(hhmmStamp(new Date(2026, 3, 18, 9, 5))).toBe("0905");
-    expect(hhmmStamp(new Date(2026, 3, 18, 9, 37))).toBe("0937");
+describe("calver hhmmStamp (HMM integer scheme — no leading zeros)", () => {
+  it("midnight hour drops the leading zero", () => {
+    expect(hhmmStamp(new Date(2026, 3, 18, 0, 0))).toBe("0");
+    expect(hhmmStamp(new Date(2026, 3, 18, 0, 5))).toBe("5");
+    expect(hhmmStamp(new Date(2026, 3, 18, 0, 30))).toBe("30");
+    expect(hhmmStamp(new Date(2026, 3, 18, 0, 59))).toBe("59");
   });
 
-  it("preserves multi-digit values without padding", () => {
+  it("single-digit hour: H*100 + MM", () => {
+    expect(hhmmStamp(new Date(2026, 3, 18, 1, 0))).toBe("100");
+    expect(hhmmStamp(new Date(2026, 3, 18, 9, 29))).toBe("929");
+    expect(hhmmStamp(new Date(2026, 3, 18, 9, 0))).toBe("900");
+  });
+
+  it("double-digit hour: H*100 + MM", () => {
+    expect(hhmmStamp(new Date(2026, 3, 18, 10, 1))).toBe("1001");
     expect(hhmmStamp(new Date(2026, 3, 18, 12, 34))).toBe("1234");
+    expect(hhmmStamp(new Date(2026, 3, 18, 23, 1))).toBe("2301");
     expect(hhmmStamp(new Date(2026, 3, 18, 23, 59))).toBe("2359");
+  });
+
+  it("numeric chronological order is preserved (semver numeric IDs)", () => {
+    // No leading zeros => semver-numeric => numeric compare. Spot-check
+    // that successive minutes monotonically increase as integers.
+    const t = (h: number, m: number) => parseInt(hhmmStamp(new Date(2026, 3, 18, h, m)), 10);
+    expect(t(0, 0)).toBeLessThan(t(0, 1));
+    expect(t(0, 59)).toBeLessThan(t(1, 0));   // 59 < 100
+    expect(t(9, 59)).toBeLessThan(t(10, 0));  // 959 < 1000
+    expect(t(23, 58)).toBeLessThan(t(23, 59)); // 2358 < 2359
   });
 });
 
-describe("calver computeVersion (HHMM scheme)", () => {
+describe("calver computeVersion (HMM scheme)", () => {
   const apr18_0937 = new Date(2026, 3, 18, 9, 37);
   const apr27_1200 = new Date(2026, 3, 27, 12, 0);
   const jan1_0005  = new Date(2027, 0, 1, 0, 5);
@@ -72,12 +91,12 @@ describe("calver computeVersion (HHMM scheme)", () => {
     expect(computeVersion({ stable: true, check: false, now: jan1_0005 })).toBe("27.1.1");
   });
 
-  it("alpha: yy.m.d-alpha.HHMM regardless of tag state", () => {
-    expect(computeVersion({ stable: false, check: false, now: apr18_0937 }, [])).toBe("26.4.18-alpha.0937");
-    expect(computeVersion({ stable: false, check: false, now: jan1_0005 }, [])).toBe("27.1.1-alpha.0005");
+  it("alpha: yy.m.d-alpha.HMM regardless of tag state", () => {
+    expect(computeVersion({ stable: false, check: false, now: apr18_0937 }, [])).toBe("26.4.18-alpha.937");
+    expect(computeVersion({ stable: false, check: false, now: jan1_0005 }, [])).toBe("27.1.1-alpha.5");
   });
 
-  it("alpha: ignores tags entirely (HHMM is unique-per-minute)", () => {
+  it("alpha: ignores tags entirely (HMM is unique-per-minute)", () => {
     const tags = ["v26.4.27-alpha.11", "v26.4.27-alpha.12"];
     expect(computeVersion({ stable: false, check: false, now: apr27_1200 }, tags)).toBe("26.4.27-alpha.1200");
   });
@@ -93,7 +112,7 @@ describe("calver computeVersion (HHMM scheme)", () => {
     expect(computeVersion({ stable: true, channel: "alpha", check: false, now: apr27_1200 }, tags)).toBe("26.4.27");
   });
 
-  it("alpha and beta in same minute share HHMM, differ by channel", () => {
+  it("alpha and beta in same minute share HMM, differ by channel", () => {
     const alpha = computeVersion({ stable: false, channel: "alpha", check: false, now: apr27_1200 });
     const beta  = computeVersion({ stable: false, channel: "beta",  check: false, now: apr27_1200 });
     expect(alpha).toBe("26.4.27-alpha.1200");
@@ -261,12 +280,12 @@ describe("calver effectiveBase (#819)", () => {
   });
 });
 
-describe("calver computeVersion future-dated package.json (#819, HHMM-adapted)", () => {
+describe("calver computeVersion future-dated package.json (#819, HMM-adapted)", () => {
   const apr28_1200 = new Date(2026, 3, 28, 12, 0);
   const apr29_0500 = new Date(2026, 3, 29, 5, 0);
 
-  it("future-dated alpha: bumps to package.json's date with current HHMM (no downgrade)", () => {
-    // The #819 anti-downgrade guard still fires under HHMM: package.json at
+  it("future-dated alpha: bumps to package.json's date with current HMM (no downgrade)", () => {
+    // The #819 anti-downgrade guard still fires under HMM: package.json at
     // 26.4.29-alpha.5, clock at 2026-04-28 12:00 → bump to 26.4.29-alpha.1200,
     // NOT 26.4.28-alpha.1200 (which would be a base downgrade).
     expect(
@@ -274,14 +293,13 @@ describe("calver computeVersion future-dated package.json (#819, HHMM-adapted)",
     ).toBe("26.4.29-alpha.1200");
   });
 
-  it("date roll: clock advances past package.json → fresh date with current HHMM", () => {
+  it("date roll: clock advances past package.json → fresh date with current HMM", () => {
     expect(
       computeVersion({ stable: false, check: false, now: apr29_0500 }, [], "26.4.28-alpha.18"),
-    ).toBe("26.4.29-alpha.0500");
+    ).toBe("26.4.29-alpha.500");
   });
 
   it("just-cut stable in package.json: bare YY.M.D base preserved", () => {
-    // package.json holds bare 26.4.30; clock 2026-04-28 12:00.
     expect(
       computeVersion({ stable: false, check: false, now: apr28_1200 }, [], "26.4.30"),
     ).toBe("26.4.30-alpha.1200");


### PR DESCRIPTION
## Summary

Replaces monotonic counter (Option A from #766) with local-time hour+minute, 4-char zero-padded. Each minute is a unique slot — no more merge-order collisions when multiple PRs cut CalVer in parallel.

## Motivating incident

Tonight three PRs (#919, #921, #922) all cut CalVer at `alpha.48` in the same minute, causing a triple collision. Whichever lands first leaves the other two needing rebase + recalver. With HHMM, two PRs collide only if they cut CalVer in the same minute (much rarer), and in practice, branch-naming + merge cadence makes this nearly impossible.

## Format

- `v{yy}.{m}.{d}[-(alpha|beta).{HHMM}]`
- Examples: `v26.4.29-alpha.0234`, `v26.4.29-alpha.0935`, `v26.4.29-alpha.2359`
- Stable cuts unchanged: `v{yy}.{m}.{d}` (no suffix)
- Beta channel unchanged: `-beta.{HHMM}`

## Semver compliance

- HHMM with leading zero (e.g. `0234`) makes the pre-release ID **alphanumeric** per semver spec.
- Alphanumeric IDs always sort *higher* than numeric IDs → the cutover `alpha.48` → `alpha.0926` is strictly greater (no downgrade across the cutover boundary).
- All HHMM values are 4-char same-class strings → lexical sort matches chronological (`0000` < `0905` < `1234` < `2359`).

## What changed

- `scripts/calver.ts` `computeVersion`: alpha/beta path computes `${base}-${channel}.${HHMM}` directly. Tag-walk + package.json-walk are skipped for alpha/beta (HHMM is naturally unique).
- `effectiveBase` (#819) anti-downgrade guard preserved: future-dated `package.json` bumps the base, then HHMM is stamped on the bumped base.
- Helpers (`maxNFromTags`, `maxAlphaFromTags`, `maxNFromPackageJson`) remain exported as back-compat. Their tests remain.
- Comments + `--help` text updated.
- `test/calver.test.ts`: 46/46 tests pass under HHMM. Computed-version cases rewritten; helper cases preserved.

## Verify

- `bun run build`: ✓ 641 modules, 0.89 MB
- `bun test test/calver.test.ts`: 46/46 pass
- Dry-run: `TZ=Asia/Bangkok bun scripts/calver.ts --check` → `v26.4.29-alpha.0929`

## Migration notes

After this merges:
- All future alpha/beta cuts use HHMM.
- The pending `#919`/`#921`/`#922` triple at `alpha.48` will rebase to `alpha.<HHMM-at-rebase-time>` — the second + third can no longer collide.
- Any tooling that pattern-matches `alpha.\d+` strictly should accept zero-padded 4-char suffixes (or drop strict-numeric assumption — it's semver-valid alphanumeric).

## Related

- #858 hour-bucket discussion (HHMM is the minute-precision evolution of that proposal)
- #766 monotonic counter (this replaces it)
- #919, #921, #922 (the triple-collision that motivated this)