### PR TITLE
refactor(trust): extract trust store to src/lib (sub-PR 1 of #924)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.932",
+  "version": "26.4.29-alpha.939",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/plugins/trust/store.ts
+++ b/src/commands/plugins/trust/store.ts
@@ -1,143 +1,35 @@
 /**
- * maw trust — storage layer (#842 Sub-B).
+ * maw trust — storage layer (back-compat shim, #924 sub-PR 1).
  *
- * Atomic read/write of `<CONFIG_DIR>/trust.json`. Holds the pairwise
- * trust list consulted by `evaluateAcl()` (Sub-A, #872) when neither
- * sender nor target share a scope. Trust is symmetric: an entry
- * `{sender: a, target: b}` allows BOTH directions a→b and b→a.
+ * The actual storage primitives now live in `src/lib/trust-store.ts` so that
+ * core consumers (notably `src/commands/shared/scope-acl.ts`) can depend on
+ * them without reaching INTO the plugin directory. That decoupling is what
+ * unblocks community extraction of the trust plugin (deferred from #918's
+ * Phase 3 lean-core sweep — see #924 for the full extraction plan).
  *
- * Schema v1 — flat array of TrustEntry. We deliberately avoid the
- * peers-style `{version, peers: {alias: {...}}}` map because trust
- * entries are pair-keyed, not alias-keyed; a flat array with dedup on
- * write is simpler and matches the `TrustList` shape exposed by
- * `scope-acl.ts`.
+ * This file is preserved as a thin re-export so:
  *
- *   [
- *     { "sender": "alpha", "target": "beta", "addedAt": "2026-04-28T..." },
- *     ...
- *   ]
+ *   - existing plugin code (`impl.ts`) keeps importing `./store` as before
+ *   - existing tests under `test/isolated/trust-list.test.ts` and
+ *     `test/isolated/comm-send-acl.test.ts` keep working unchanged
+ *   - third-party plugin authors who copied the trust plugin pattern still
+ *     find a `store.ts` next to `impl.ts`
  *
- * Path resolution mirrors `scope/impl.ts::scopesDir()` — a function
- * (not a const) so tests setting `MAW_CONFIG_DIR` / `MAW_HOME` per-test
- * pick up a fresh path each call.
+ * Once #924 fully extracts the trust plugin to a community package, this
+ * shim disappears with the rest of the plugin directory. Until then:
+ * NEW core code should import from `src/lib/trust-store` directly. Plugin-
+ * internal code may use either path — both resolve to the same module.
  *
- * Atomic writes via tmp + rename(2) — same trick as
- * `src/commands/plugins/peers/store.ts::writeAtomic`. A crash mid-write
- * leaves either the old file intact or the new file fully in place,
- * never a truncated file. No file lock yet — Phase 1 is operator-driven
- * and `maw trust add` is rare enough that racing writers aren't a
- * realistic workload (mirrors scope's Phase 1 decision).
- *
- * Forgiving load semantics — missing file, corrupt JSON, or wrong
- * shape all fall back to `[]` rather than throwing. The ACL evaluator
- * treating "no trust file" the same as "empty trust list" means an
- * operator who's never run `maw trust add` still gets a working ACL.
+ * See also:
+ *   - src/lib/trust-store.ts — canonical storage primitives
+ *   - src/commands/shared/scope-acl.ts — uses `src/lib/trust-store` directly
+ *   - src/lib/profile-loader.ts (#889) — same pure-data-layer pattern
  */
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  renameSync,
-  writeFileSync,
-} from "fs";
-import { homedir } from "os";
-import { dirname, join } from "path";
-
-/**
- * On-disk trust entry. `sender` / `target` are oracle names matching
- * `Scope.members[*]`. `addedAt` is the ISO timestamp when the entry was
- * first written — useful for `maw trust list` to show recency, and for
- * future TTL semantics if/when trust entries gain expiry.
- *
- * Mirrors {@link import("../../shared/scope-acl").TrustEntry} on the
- * pair-key fields, with `addedAt` added on disk. `evaluateAcl()` only
- * reads `sender` / `target`, so the extra field doesn't break the ACL
- * type contract (TypeScript structural typing — extra fields are fine).
- */
-export interface TrustEntryOnDisk {
-  sender: string;
-  target: string;
-  addedAt: string;
-}
-
-/** A flat list of on-disk trust entries. May be empty. */
-export type TrustListOnDisk = TrustEntryOnDisk[];
-
-/**
- * Resolve the active config dir at call time (not import time) so tests
- * can point the directory at a temp path per-test by setting
- * `MAW_CONFIG_DIR` / `MAW_HOME` in beforeEach. Mirrors the precedence
- * logic in `src/core/paths.ts` and `scope/impl.ts::activeConfigDir`.
- *
- *   1. `MAW_HOME` → `<MAW_HOME>/config` (instance mode, see #566)
- *   2. `MAW_CONFIG_DIR` override (legacy)
- *   3. Default singleton `~/.config/maw/`
- */
-function activeConfigDir(): string {
-  if (process.env.MAW_HOME) return join(process.env.MAW_HOME, "config");
-  if (process.env.MAW_CONFIG_DIR) return process.env.MAW_CONFIG_DIR;
-  return join(homedir(), ".config", "maw");
-}
-
-export function trustPath(): string {
-  return join(activeConfigDir(), "trust.json");
-}
-
-/**
- * Read the trust list from disk. Returns `[]` if the file is missing,
- * unreadable, or malformed — forgiving semantics so an operator who's
- * never written a trust entry still gets a working empty list.
- */
-export function loadTrust(): TrustListOnDisk {
-  const path = trustPath();
-  if (!existsSync(path)) return [];
-  let raw: string;
-  try {
-    raw = readFileSync(path, "utf-8");
-  } catch {
-    return [];
-  }
-  try {
-    const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    // Defensive: skip entries that don't have the required string fields.
-    // Operators may hand-edit trust.json (parallel to scope JSON's
-    // documented hand-edit workflow), so a typo'd line shouldn't sink
-    // the whole list.
-    return parsed.filter(
-      (e: any): e is TrustEntryOnDisk =>
-        e &&
-        typeof e.sender === "string" &&
-        typeof e.target === "string" &&
-        typeof e.addedAt === "string",
-    );
-  } catch {
-    return [];
-  }
-}
-
-/**
- * Write the trust list atomically (tmp + rename). Creates the config
- * directory if missing. Mirrors `peers/store.ts::writeAtomic`.
- */
-export function saveTrust(list: TrustListOnDisk): void {
-  const path = trustPath();
-  mkdirSync(dirname(path), { recursive: true });
-  const tmp = `${path}.tmp`;
-  writeFileSync(tmp, JSON.stringify(list, null, 2) + "\n");
-  renameSync(tmp, path);
-}
-
-/**
- * Symmetric pair equality. `{a, b}` matches `{b, a}` — trust is
- * direction-agnostic, same as `evaluateAcl()`'s match semantics.
- */
-export function samePair(
-  a: { sender: string; target: string },
-  b: { sender: string; target: string },
-): boolean {
-  return (
-    (a.sender === b.sender && a.target === b.target) ||
-    (a.sender === b.target && a.target === b.sender)
-  );
-}
+export {
+  loadTrust,
+  saveTrust,
+  samePair,
+  trustPath,
+  type TrustEntryOnDisk,
+  type TrustListOnDisk,
+} from "../../../lib/trust-store";

--- a/src/commands/shared/scope-acl.ts
+++ b/src/commands/shared/scope-acl.ts
@@ -35,7 +35,7 @@
 
 import { existsSync, readFileSync, readdirSync } from "fs";
 import { scopesDir } from "../plugins/scope/impl";
-import { loadTrust as loadTrustStore } from "../plugins/trust/store";
+import { loadTrust as loadTrustStore } from "../../lib/trust-store";
 import type { TScope } from "../../lib/schemas";
 
 /**
@@ -163,9 +163,11 @@ export function loadAllScopes(): TScope[] {
 /**
  * Read the on-disk pairwise trust list from `<CONFIG_DIR>/trust.json`.
  *
- * Thin wrapper around `loadTrust()` in `plugins/trust/store.ts` so that
+ * Thin wrapper around `loadTrust()` in `src/lib/trust-store.ts` so that
  * callers wiring the ACL evaluator don't need to know which plugin owns
- * the file. Mirrors the relationship between `loadAllScopes()` (this
+ * the file. The store lives in `src/lib/` (not `plugins/trust/`) since
+ * #924 sub-PR 1 extracted it to unblock community extraction of the
+ * trust plugin. Mirrors the relationship between `loadAllScopes()` (this
  * module) and `cmdList()` (the scope plugin).
  *
  * Returns `[]` when the file is missing, malformed, or unreadable —

--- a/src/lib/trust-store.ts
+++ b/src/lib/trust-store.ts
@@ -1,0 +1,153 @@
+/**
+ * trust-store.ts — pure data layer for the pairwise trust list (#924 sub-PR 1).
+ *
+ * Background
+ * ──────────
+ * #918 (Phase 3 of the lean-core epic, #640) extracted 19 plugins out of the
+ * core CLI into community-style modules. Six plugins were deferred because
+ * `src/` files still imported from inside their plugin directory; trust is one
+ * of them — `src/commands/shared/scope-acl.ts` consumes `loadTrust` from
+ * `commands/plugins/trust/store`, which means the trust plugin can't be
+ * physically moved without breaking the core ACL evaluator.
+ *
+ * This module is the unblock: it lifts the storage layer up into `src/lib/`
+ * (a directory that survives plugin extraction), exposing the same pure
+ * read/write/path/equality primitives the trust plugin already uses. The
+ * plugin's existing `store.ts` becomes a thin re-export shim so that all
+ * existing imports — both inside and outside the plugin — keep working.
+ *
+ * Mirrors the pattern set by `src/lib/profile-loader.ts` (#889): a pure data
+ * layer that any code in `src/` can depend on without coupling to a specific
+ * plugin's directory structure. Once #924 sub-PR 2+ lands, this module is the
+ * only thing core needs from the trust feature, and the plugin directory can
+ * be physically moved into a community package.
+ *
+ * Behavior is byte-for-byte identical to the previous `plugins/trust/store.ts`:
+ *
+ *   - Atomic write via tmp + rename(2)
+ *   - Forgiving load (missing / corrupt / wrong-shape → `[]`)
+ *   - Live path resolution (re-reads MAW_HOME / MAW_CONFIG_DIR per call)
+ *   - Symmetric `samePair` for direction-agnostic matching
+ *
+ * No new tests are required for the existing contracts — the plugin's existing
+ * trust-list test suite covers them via the re-export shim. A new test file
+ * (`test/isolated/trust-store-lib.test.ts`) confirms that this module's
+ * exports work when imported DIRECTLY (i.e. without traversing the plugin
+ * directory at all), which is the property #924 needs for community
+ * extraction.
+ *
+ * See also:
+ *   - src/lib/profile-loader.ts (#889) — pattern for pure data layer in src/lib/
+ *   - src/commands/plugins/trust/store.ts — back-compat shim that re-exports this
+ *   - src/commands/shared/scope-acl.ts — primary core consumer (#842 Sub-A/B)
+ */
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "fs";
+import { homedir } from "os";
+import { dirname, join } from "path";
+
+/**
+ * On-disk trust entry. `sender` / `target` are oracle names matching
+ * `Scope.members[*]`. `addedAt` is the ISO timestamp when the entry was
+ * first written — useful for `maw trust list` to show recency, and for
+ * future TTL semantics if/when trust entries gain expiry.
+ *
+ * Mirrors {@link import("../commands/shared/scope-acl").TrustEntry} on the
+ * pair-key fields, with `addedAt` added on disk. `evaluateAcl()` only
+ * reads `sender` / `target`, so the extra field doesn't break the ACL
+ * type contract (TypeScript structural typing — extra fields are fine).
+ */
+export interface TrustEntryOnDisk {
+  sender: string;
+  target: string;
+  addedAt: string;
+}
+
+/** A flat list of on-disk trust entries. May be empty. */
+export type TrustListOnDisk = TrustEntryOnDisk[];
+
+/**
+ * Resolve the active config dir at call time (not import time) so tests
+ * can point the directory at a temp path per-test by setting
+ * `MAW_CONFIG_DIR` / `MAW_HOME` in beforeEach. Mirrors the precedence
+ * logic in `src/core/paths.ts`, `scope/impl.ts::activeConfigDir`, and
+ * `profile-loader.ts::activeConfigDir`.
+ *
+ *   1. `MAW_HOME` → `<MAW_HOME>/config` (instance mode, see #566)
+ *   2. `MAW_CONFIG_DIR` override (legacy)
+ *   3. Default singleton `~/.config/maw/`
+ */
+function activeConfigDir(): string {
+  if (process.env.MAW_HOME) return join(process.env.MAW_HOME, "config");
+  if (process.env.MAW_CONFIG_DIR) return process.env.MAW_CONFIG_DIR;
+  return join(homedir(), ".config", "maw");
+}
+
+export function trustPath(): string {
+  return join(activeConfigDir(), "trust.json");
+}
+
+/**
+ * Read the trust list from disk. Returns `[]` if the file is missing,
+ * unreadable, or malformed — forgiving semantics so an operator who's
+ * never written a trust entry still gets a working empty list.
+ */
+export function loadTrust(): TrustListOnDisk {
+  const path = trustPath();
+  if (!existsSync(path)) return [];
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    // Defensive: skip entries that don't have the required string fields.
+    // Operators may hand-edit trust.json (parallel to scope JSON's
+    // documented hand-edit workflow), so a typo'd line shouldn't sink
+    // the whole list.
+    return parsed.filter(
+      (e: any): e is TrustEntryOnDisk =>
+        e &&
+        typeof e.sender === "string" &&
+        typeof e.target === "string" &&
+        typeof e.addedAt === "string",
+    );
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Write the trust list atomically (tmp + rename). Creates the config
+ * directory if missing. Mirrors `peers/store.ts::writeAtomic` and
+ * `profile-loader.ts::atomicWriteJSON`.
+ */
+export function saveTrust(list: TrustListOnDisk): void {
+  const path = trustPath();
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, JSON.stringify(list, null, 2) + "\n");
+  renameSync(tmp, path);
+}
+
+/**
+ * Symmetric pair equality. `{a, b}` matches `{b, a}` — trust is
+ * direction-agnostic, same as `evaluateAcl()`'s match semantics.
+ */
+export function samePair(
+  a: { sender: string; target: string },
+  b: { sender: string; target: string },
+): boolean {
+  return (
+    (a.sender === b.sender && a.target === b.target) ||
+    (a.sender === b.target && a.target === b.sender)
+  );
+}

--- a/test/isolated/trust-store-lib.test.ts
+++ b/test/isolated/trust-store-lib.test.ts
@@ -1,0 +1,107 @@
+/**
+ * trust-store-lib — direct-import smoke tests for #924 sub-PR 1.
+ *
+ * #918 (Phase 3 lean-core) extracted 19 plugins out of `src/commands/plugins/`.
+ * Six were deferred because core code still imported from inside their plugin
+ * directory. Trust was one — `src/commands/shared/scope-acl.ts` reached into
+ * `commands/plugins/trust/store` for `loadTrust`.
+ *
+ * Sub-PR 1 lifts the trust storage primitives up into `src/lib/trust-store.ts`
+ * so the plugin directory can be extracted without breaking core. The plugin's
+ * old `store.ts` stays as a re-export shim (covered by the existing
+ * `trust-list.test.ts` suite via `plugins/trust/store`).
+ *
+ * What THIS file tests is the property the extraction needs: that
+ * `src/lib/trust-store` works correctly when imported DIRECTLY, with no
+ * traversal through the plugin directory at all. If the trust plugin were
+ * physically moved to a community package tomorrow, these imports would still
+ * resolve, and these tests would still pass.
+ *
+ * Mirrors the per-test temp-dir pattern from `trust-list.test.ts` so the
+ * trust file resolves to a fresh `<MAW_CONFIG_DIR>/trust.json` per test.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+let testDir: string;
+let originalConfigDir: string | undefined;
+let originalHome: string | undefined;
+
+beforeEach(() => {
+  testDir = mkdtempSync(join(tmpdir(), "maw-trust-store-lib-"));
+  originalConfigDir = process.env.MAW_CONFIG_DIR;
+  originalHome = process.env.MAW_HOME;
+  process.env.MAW_CONFIG_DIR = testDir;
+  delete process.env.MAW_HOME;
+});
+
+afterEach(() => {
+  if (originalConfigDir === undefined) delete process.env.MAW_CONFIG_DIR;
+  else process.env.MAW_CONFIG_DIR = originalConfigDir;
+  if (originalHome === undefined) delete process.env.MAW_HOME;
+  else process.env.MAW_HOME = originalHome;
+  try { rmSync(testDir, { recursive: true, force: true }); } catch { /* ok */ }
+});
+
+describe("src/lib/trust-store — direct imports work without the plugin", () => {
+  test("trustPath() resolves under MAW_CONFIG_DIR (call-time, not import-time)", async () => {
+    const { trustPath } = await import("../../src/lib/trust-store");
+    // Path is resolved on each call, so it picks up the per-test env tweak
+    // that beforeEach() applies AFTER module load. This is the property that
+    // makes the per-test temp-dir pattern safe in `trust-list.test.ts`, and
+    // it must hold for the lifted module too.
+    expect(trustPath()).toBe(join(testDir, "trust.json"));
+  });
+
+  test("loadTrust() returns [] when trust.json is missing (forgiving)", async () => {
+    const { loadTrust } = await import("../../src/lib/trust-store");
+    expect(loadTrust()).toEqual([]);
+  });
+
+  test("saveTrust() then loadTrust() round-trips entries via the lib path", async () => {
+    const { loadTrust, saveTrust } = await import("../../src/lib/trust-store");
+    const a = { sender: "alpha", target: "beta", addedAt: "2026-04-29T00:00:00.000Z" };
+    const b = { sender: "gamma", target: "delta", addedAt: "2026-04-29T00:00:01.000Z" };
+    saveTrust([a, b]);
+    const loaded = loadTrust();
+    expect(loaded).toHaveLength(2);
+    expect(loaded.map(e => e.sender).sort()).toEqual(["alpha", "gamma"]);
+  });
+
+  test("saveTrust() writes atomically — no .tmp file remains after success", async () => {
+    const { saveTrust, trustPath } = await import("../../src/lib/trust-store");
+    saveTrust([{ sender: "a", target: "b", addedAt: "2026-04-29T00:00:00.000Z" }]);
+    // Final file readable, .tmp gone — proves rename(2) executed.
+    expect(() => readFileSync(trustPath(), "utf-8")).not.toThrow();
+    expect(() => readFileSync(`${trustPath()}.tmp`, "utf-8")).toThrow();
+  });
+
+  test("loadTrust() forgiving on corrupt JSON — returns []", async () => {
+    const { loadTrust, trustPath } = await import("../../src/lib/trust-store");
+    mkdirSync(testDir, { recursive: true });
+    writeFileSync(trustPath(), "not valid json {{{");
+    expect(loadTrust()).toEqual([]);
+  });
+
+  test("samePair() is symmetric — {a,b} equals {b,a}", async () => {
+    const { samePair } = await import("../../src/lib/trust-store");
+    expect(samePair({ sender: "a", target: "b" }, { sender: "b", target: "a" })).toBe(true);
+    expect(samePair({ sender: "a", target: "b" }, { sender: "a", target: "b" })).toBe(true);
+    expect(samePair({ sender: "a", target: "b" }, { sender: "a", target: "c" })).toBe(false);
+    expect(samePair({ sender: "a", target: "b" }, { sender: "x", target: "y" })).toBe(false);
+  });
+
+  test("plugin shim re-exports point at the same module identity", async () => {
+    // Both import paths must resolve to the SAME functions — otherwise we'd
+    // have two independent module instances reading/writing the same file,
+    // and the back-compat shim would drift over time.
+    const lib = await import("../../src/lib/trust-store");
+    const shim = await import("../../src/commands/plugins/trust/store");
+    expect(shim.loadTrust).toBe(lib.loadTrust);
+    expect(shim.saveTrust).toBe(lib.saveTrust);
+    expect(shim.trustPath).toBe(lib.trustPath);
+    expect(shim.samePair).toBe(lib.samePair);
+  });
+});


### PR DESCRIPTION
## Summary

Sub-PR 1 of #924. Lifts the trust storage primitives out of
`src/commands/plugins/trust/store.ts` into `src/lib/trust-store.ts` so the
trust plugin can be physically extracted without breaking core. Mirrors the
pattern set by `src/lib/profile-loader.ts` (#889).

## Why

#918 (Phase 3 lean-core) extracted 19 plugins out of `src/commands/plugins/`
into community-style modules. Six were deferred because `src/` files still
reached INTO their plugin directory. Trust was one — `scope-acl.ts:38`
imports `loadTrust` from `commands/plugins/trust/store`, so the plugin
directory cannot move while that import exists.

This PR breaks that coupling. After the refactor:

- `src/lib/trust-store.ts` is the canonical home for `loadTrust`,
  `saveTrust`, `samePair`, `trustPath`, plus the `TrustEntryOnDisk` /
  `TrustListOnDisk` types
- `src/commands/plugins/trust/store.ts` becomes a thin re-export shim so
  existing plugin code (`impl.ts`) and existing tests (`trust-list.test.ts`,
  `comm-send-acl.test.ts`) keep working unchanged
- `src/commands/shared/scope-acl.ts:38` now imports from the lib path
  directly — the last core-into-plugin trust import is gone

## What changes

| File | Change |
|------|--------|
| `src/lib/trust-store.ts` | NEW — canonical storage layer |
| `src/commands/plugins/trust/store.ts` | Replaced body with re-export shim |
| `src/commands/shared/scope-acl.ts` | Import path swap (no semantic change) |
| `test/isolated/trust-store-lib.test.ts` | NEW — direct-import smoke tests |
| `package.json` | Calver bump 26.4.29-alpha.932 → alpha.939 |

## Behavior

Byte-for-byte identical. The atomic write pattern, forgiving load semantics
(missing / corrupt / wrong-shape → `[]`), live path resolution
(`MAW_HOME` / `MAW_CONFIG_DIR` re-read per call), and symmetric `samePair`
are preserved verbatim. Only the file location changed.

## Tests

- `test/isolated/trust-list.test.ts` (existing, 10 cases) — passes unchanged
  via the re-export shim, proving back-compat
- `test/isolated/comm-send-acl.test.ts` (existing, 12 cases) — passes
  unchanged, proving the scope-acl rewire is semantically a no-op
- `test/isolated/trust-store-lib.test.ts` (NEW, 7 cases) — confirms the lib
  module works when imported DIRECTLY, including:
  - `trustPath()` resolves under MAW_CONFIG_DIR (call-time, not import-time)
  - `loadTrust()` returns `[]` on missing file
  - `saveTrust` → `loadTrust` round-trip
  - Atomic write (no `.tmp` left after success)
  - Forgiving load on corrupt JSON
  - `samePair` symmetry
  - Module identity check — the shim re-exports the SAME function
    references as the lib (so future drift is structurally impossible)

Combined: 31 trust-related test cases, all green.

## Test plan

- [x] `bun test test/isolated/trust-store-lib.test.ts` — 7 pass
- [x] `bun test test/isolated/trust-list.test.ts` — 10 pass
- [x] `bun test test/isolated/comm-send-acl.test.ts` — 12 pass
- [x] `bunx tsc --noEmit` — no new type errors related to trust
- [ ] CI green on the PR

## Follow-ups

Sub-PR 2+ of #924 will physically move `src/commands/plugins/trust/` into a
community package, deleting the shim. That move is now safe — core no
longer depends on the plugin directory.

Refs #924, #918 (deferred extraction list), #889 (profile-loader pattern).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>