### PR TITLE
release: v26.4.48 — first stable post-CI-fix (lean-core 7 INFRA, #640)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.47",
+  "version": "26.4.48",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
## Summary
First package.json bump after #930 fixed the day-counter validation. Triggers the CalVer Release workflow which has been failing since v26.4.32 — this is the first commit that should successfully tag + build + publish.

## End state shipped tonight
- **Plugins in maw-js**: 7 INFRA (federation, fleet, oracle, plugin, session, tmux, transport)
- **Plugins in registry**: 60+ in maw-plugin-registry
- **Binary**: 0.85 MB (was ~1+ MB pre-prune)
- **Lines removed**: ~30,000 across #918, #926, #928

## Related
- #930 (workflow fix), #918, #919, #921, #922, #923, #926, #928
- #640 lean-core epic — CLOSED post this release

## After merge
Workflow fires → tags v26.4.48 → builds binary → `maw update` users get the lean binary.