### PR TITLE
fix(calver): widen suffix regex 1→4 digits; sync docs to HMM (post-#923)

### DIFF
--- a/.github/workflows/calver-release.yml
+++ b/.github/workflows/calver-release.yml
@@ -64,21 +64,29 @@ jobs:
           # Only act on CalVer-shaped versions. Legacy semver (2.0.0-alpha.*)
           # bumps are skipped as no-op during the transition period.
           # Accepts alpha and beta channels (#754); both are prereleases.
-          REGEX='^[0-9]{2}\.[0-9]{1,2}\.[0-9]{1,2}(-(alpha|beta)\.[0-9]{1,2}[a-z]?)?$'
+          # Suffix is HMM (#923): integer H*100+M, 1-4 digits, no leading zero
+          # (e.g. 5, 30, 929, 1200, 2359). Optional trailing lowercase letter
+          # remains the same-minute collision suffix.
+          REGEX='^[0-9]{2}\.[0-9]{1,2}\.[0-9]{1,3}(-(alpha|beta)\.[0-9]{1,4}[a-z]?)?$'
           if [[ ! "$VERSION" =~ $REGEX ]]; then
             echo "::notice title=Skipped::Version '$VERSION' is not CalVer — no release cut. Legacy ship-alpha.sh / auto-tag.yml handles this case."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Range validation — regex alone passes channel.99.
+          # Range validation — regex alone passes month.99.
           BASE="${VERSION%%-*}"
           IFS='.' read -r YY M D <<< "$BASE"
           if (( M < 1 || M > 12 )); then
             echo "::error::Month must be 1-12, got $M"; exit 1
           fi
-          if (( D < 1 || D > 31 )); then
-            echo "::error::Day must be 1-31, got $D"; exit 1
+          # The third number is a monotonic counter that floors at the
+          # day-of-month and increments on every cut, so values can legitimately
+          # exceed 31 after a day-rollover streak (yesterday cut .31, today
+          # cuts continue .32, .33, …). Floor-only validation; the calver
+          # script (scripts/calver.ts) is the source of truth for ordering.
+          if (( D < 1 )); then
+            echo "::error::Day/counter must be ≥1, got $D"; exit 1
           fi
           PRERELEASE="false"
           CHANNEL="stable"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ PRs to `main` come from one source: `alpha` itself, on a stable cut.
 
 **maw-js uses CalVer as of 2026-04-18.**
 
-Scheme: `v{yy}.{m}.{d}[-alpha.{N}]` — e.g. `v26.4.18` (stable) or `v26.4.18-alpha.19` (alpha cut). Spec lives in [umbrella #526](https://github.com/Soul-Brews-Studio/maw-js/issues/526) and the [CHANGELOG](./CHANGELOG.md#versioning--calver-since-2026-04-18). The alpha-counter scheme (hour-bucket vs monotonic) is tracked in [#766](https://github.com/Soul-Brews-Studio/maw-js/issues/766).
+Scheme: `v{yy}.{m}.{d}[-alpha.{HMM}]` — e.g. `v26.4.18` (stable) or `v26.4.18-alpha.937` (alpha cut at 09:37). The HMM suffix is the integer `H*100 + M` rendered with no leading zeros (09:37 → 937, 10:01 → 1001, 23:59 → 2359). Each minute is a unique slot. Spec lives in [umbrella #526](https://github.com/Soul-Brews-Studio/maw-js/issues/526) and the [CHANGELOG](./CHANGELOG.md#versioning--calver-since-2026-04-18). HMM replaced the prior monotonic counter in [#923](https://github.com/Soul-Brews-Studio/maw-js/pull/923); see [#766](https://github.com/Soul-Brews-Studio/maw-js/issues/766) for the original counter design.
 
 ## Releasing
 


### PR DESCRIPTION
## Summary
PR #923 switched the alpha/beta suffix from monotonic counter (`alpha.0–.99`) to **HMM** (`H*100+M`, range `0–2359`). The release workflow's validation regex was not updated — it still allowed only `[0-9]{1,2}` (max 99). Any cut after 01:00 produces HMM ≥ 100, which silently fails the regex → workflow exits 0 with `Skipped: not CalVer` notice → **no tag, no release**.

That's why no alpha tags exist past `v26.4.29-alpha.46` despite dozens of alpha bumps landing today.

## What changed
1. `.github/workflows/calver-release.yml`:
   - Suffix regex: `[0-9]{1,2}` → `[0-9]{1,4}` (HMM range)
   - Third base segment: `[0-9]{1,2}` → `[0-9]{1,3}` (day-counter can exceed 99 on long stable streaks)
   - Day-counter floor-only check (incorporates #930 for alpha parity)
   - Comment block updated to document HMM
2. `CONTRIBUTING.md:101`: `[-alpha.{N}]` → `[-alpha.{HMM}]` with examples + link to #923.

## Verify
After merge, push to alpha (any package.json bump) → workflow should tag the alpha release for the first time since v26.4.29-alpha.46.

## Related
- #923 (HMM scheme), #930 (day-counter fix on main), #766 (original counter)