### PR TITLE
release: v26.4.48 stable cut (calver regex widened for HHMM)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.47",
+  "version": "26.4.48",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Calver workflow regex updated for HHMM stamp scheme.