### PR TITLE
feat(plugin install): github: source format owner/repo[/name][@ref] (#939)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.1423",
+  "version": "26.4.29-alpha.1430",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/plugins/plugin/install-handlers.ts
+++ b/src/commands/plugins/plugin/install-handlers.ts
@@ -366,6 +366,95 @@ export function monorepoTarballUrl(tag: string, repo?: string): string {
 }
 
 /**
+ * Default GitHub host for `github:` source resolution (#939). Override via
+ * `MAW_GITHUB_BASE_URL` for tests / mirrors / local fixture servers (parallel
+ * to MAW_MONOREPO_BASE_URL).
+ */
+const DEFAULT_GITHUB_BASE_URL = "https://github.com";
+
+export function githubBaseUrl(): string {
+  return process.env.MAW_GITHUB_BASE_URL || DEFAULT_GITHUB_BASE_URL;
+}
+
+/**
+ * Build the GitHub archive tarball URL for a given owner/repo[@ref] (#939).
+ *
+ * - `<base>/<owner>/<repo>/archive/refs/tags/<ref>.tar.gz` when ref is a
+ *   tag-shaped string (starts with `v` followed by a digit, e.g. `v0.1.2`)
+ *   — matches how monorepoTarballUrl already shapes URLs and lets users
+ *   pin to a release.
+ * - `<base>/<owner>/<repo>/archive/<ref>.tar.gz` for any other ref (branch
+ *   names, commit shas, channel placeholders) — GitHub serves both `refs/
+ *   heads/<branch>` AND bare-name forms from the same archive endpoint.
+ * - `<base>/<owner>/<repo>/archive/HEAD.tar.gz` when no ref is given —
+ *   default branch, latest commit.
+ */
+export function githubTarballUrl(owner: string, repo: string, ref?: string): string {
+  const base = githubBaseUrl();
+  if (!ref) return `${base}/${owner}/${repo}/archive/HEAD.tar.gz`;
+  if (/^v\d/.test(ref)) {
+    return `${base}/${owner}/${repo}/archive/refs/tags/${ref}.tar.gz`;
+  }
+  return `${base}/${owner}/${repo}/archive/${ref}.tar.gz`;
+}
+
+/**
+ * Install a plugin from a GitHub `owner/repo[/name][@ref]` source (#939).
+ *
+ * Resolves to a github archive tarball, then reuses the existing tarball
+ * install path. When `name` is supplied it is interpreted as a subpath
+ * inside the repo:
+ *   • single segment (no `/`)  → auto-prefix `plugins/<name>/` for monorepo
+ *     convenience (matches the `maw-plugin-registry` layout)
+ *   • multi-segment            → treated as literal path
+ *
+ * `ref` is optional — without it, we fetch the default branch's HEAD.
+ *
+ * Reuses the installFromTarball flow (sdk gate, sha256 verify, plugins.lock,
+ * --pin/--force semantics) — the only delta is the URL builder + optional
+ * subpath walk performed by findMonorepoPluginRoot.
+ */
+export async function installFromGithub(
+  owner: string,
+  repo: string,
+  opts: { name?: string; ref?: string; force?: boolean; weight?: number; pin?: boolean } = {},
+): Promise<void> {
+  const url = githubTarballUrl(owner, repo, opts.ref);
+  const dl = await downloadTarball(url);
+  if (!dl.ok) {
+    throw new Error(dl.error);
+  }
+  // Build the canonical source string for plugins.lock — round-trippable
+  // through parseGithubRef. owner/repo are already lowercased by the parser.
+  const sourceParts = [`${owner}/${repo}`];
+  if (opts.name) sourceParts[0] += `/${opts.name}`;
+  if (opts.ref) sourceParts[0] += `@${opts.ref}`;
+  const source = sourceParts[0]!;
+
+  // Resolve the in-tarball subpath: single-name → `plugins/<name>/`, else literal.
+  let subpath: string | undefined;
+  if (opts.name) {
+    subpath = opts.name.includes("/") ? opts.name : `plugins/${opts.name}`;
+  }
+
+  try {
+    await installFromTarball(dl.path, {
+      source,
+      subpath,
+      force: opts.force,
+      weight: opts.weight,
+      pin: opts.pin,
+    });
+  } finally {
+    try {
+      rmSync(join(dl.path, ".."), { recursive: true, force: true });
+    } catch {
+      // Non-fatal.
+    }
+  }
+}
+
+/**
  * Install a plugin from the maw-plugin-registry monorepo (registry#2).
  *
  * Source format: `monorepo:plugins/<name>@<tag>` — the subpath identifies

--- a/src/commands/plugins/plugin/install-impl.ts
+++ b/src/commands/plugins/plugin/install-impl.ts
@@ -23,14 +23,14 @@
 
 import { parseFlags } from "../../../cli/parse-args";
 import { detectMode, ensureInstallRoot } from "./install-source-detect";
-import { installFromDir, installFromTarball, installFromUrl, installFromMonorepo } from "./install-handlers";
+import { installFromDir, installFromTarball, installFromUrl, installFromMonorepo, installFromGithub } from "./install-handlers";
 import { resolvePeerInstall } from "./install-peer-resolver";
 import { basename } from "path";
 
-export { installRoot, detectMode, parsePeerSpec, parseMonorepoRef, ensureInstallRoot, removeExisting } from "./install-source-detect";
+export { installRoot, detectMode, parsePeerSpec, parseMonorepoRef, parseGithubRef, ensureInstallRoot, removeExisting } from "./install-source-detect";
 export { extractTarball, downloadTarball, verifyArtifactHash } from "./install-extraction";
 export { readManifest, shortHash, printInstallSuccess, findMonorepoPluginRoot } from "./install-manifest-helpers";
-export { installFromDir, installFromTarball, installFromUrl, installFromMonorepo, ensurePluginMawJsLink, monorepoTarballUrl, monorepoRepoSlug } from "./install-handlers";
+export { installFromDir, installFromTarball, installFromUrl, installFromMonorepo, installFromGithub, ensurePluginMawJsLink, monorepoTarballUrl, monorepoRepoSlug, githubTarballUrl, githubBaseUrl } from "./install-handlers";
 export { resolvePeerInstall } from "./install-peer-resolver";
 export type { ResolvedPeerSource } from "./install-peer-resolver";
 
@@ -56,7 +56,7 @@ export async function cmdPluginInstall(args: string[]): Promise<void> {
   const src = flags._[0];
 
   if (!src || src === "--help" || src === "-h") {
-    throw new Error("usage: maw plugin install <dir | .tgz | URL | name@peer | monorepo:plugins/<name>@<tag>> [--link] [--force] [--pin] [--category core|standard|extra]");
+    throw new Error("usage: maw plugin install <dir | .tgz | URL | name@peer | monorepo:plugins/<name>@<tag> | owner/repo[/name][@ref]> [--link] [--force] [--pin] [--category core|standard|extra]");
   }
 
   ensureInstallRoot();
@@ -77,6 +77,16 @@ export async function cmdPluginInstall(args: string[]): Promise<void> {
     await installFromTarball(mode.src, { source: `./${basename(mode.src)}`, force, weight, pin });
   } else if (mode.kind === "monorepo") {
     await installFromMonorepo(mode.subpath, mode.tag, { force, weight, pin });
+  } else if (mode.kind === "github") {
+    // #939 — GitHub source format. Reuses tarball install path; auto-prefixes
+    // single-name subpath to plugins/<name>/ for monorepo convenience.
+    await installFromGithub(mode.owner, mode.repo, {
+      name: mode.name,
+      ref: mode.ref,
+      force,
+      weight,
+      pin,
+    });
   } else if (mode.kind === "peer") {
     const resolved = await resolvePeerInstall(mode.name, mode.peer);
     console.log(

--- a/src/commands/plugins/plugin/install-source-detect.ts
+++ b/src/commands/plugins/plugin/install-source-detect.ts
@@ -21,10 +21,91 @@ export type Mode =
   | { kind: "tarball"; src: string }
   | { kind: "url"; src: string }
   | { kind: "peer"; src: string; name: string; peer: string }
-  | { kind: "monorepo"; src: string; subpath: string; tag: string };
+  | { kind: "monorepo"; src: string; subpath: string; tag: string }
+  | { kind: "github"; src: string; owner: string; repo: string; name?: string; ref?: string };
 
 const PEER_NAME_RE = /^[a-z][a-z0-9-]*$/;
 const PEER_HOST_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+/**
+ * GitHub source format (#939) — `owner/repo[/name][@ref]`.
+ *
+ * Mirrors Vercel's `npx skills add owner/repo` pattern. Lets users install
+ * plugins by GitHub coordinates without the `monorepo:` prefix or a registry
+ * entry. The resolver fetches `https://github.com/<owner>/<repo>/archive/
+ * <ref-or-HEAD>.tar.gz` and reuses the existing tarball install path
+ * (#866 wrapper-dir + #880 source plugins handle the rest).
+ *
+ * Examples:
+ *   • `nazt/my-plugin`                            → owner=nazt, repo=my-plugin
+ *   • `Soul-Brews-Studio/maw-plugins/bg`          → owner, repo, name=bg
+ *   • `nazt/my-plugin@v1.2.3`                     → owner, repo, ref=v1.2.3
+ *   • `Soul-Brews-Studio/maw-plugins/bg@v0.1.2`   → owner, repo, name, ref
+ *
+ * Owner + repo are GitHub identifiers (alphanumerics, hyphens, dots,
+ * underscores). Owner/repo are normalized to lowercase (GitHub treats them
+ * case-insensitively for lookup). Name (subpath) and ref are preserved
+ * verbatim — filesystem paths and git refs are case-sensitive.
+ */
+const GH_SEG_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const GH_REF_RE = /^[A-Za-z0-9][A-Za-z0-9._/-]*$/;
+
+export interface GithubRef {
+  owner: string;
+  repo: string;
+  name?: string;
+  ref?: string;
+}
+
+export function parseGithubRef(raw: string): GithubRef | null {
+  if (!raw) return null;
+  // Hard filters — must not look like another mode.
+  if (/^https?:\/\//i.test(raw)) return null;
+  if (raw.startsWith("/") || raw.startsWith("./") || raw.startsWith("../")) return null;
+  if (raw.endsWith(".tgz") || raw.endsWith(".tar.gz")) return null;
+  if (raw.startsWith("monorepo:") || raw.startsWith("github:")) return null;
+  // Must contain at least one `/` to be github-shaped (distinguishes from
+  // bare `name` (dir) and `name@peer`).
+  if (!raw.includes("/")) return null;
+
+  // Split off optional `@ref` from the right (last `@` wins so refs may
+  // contain `@`-free chars; subpath segments cannot contain `@`).
+  let body = raw;
+  let ref: string | undefined;
+  const at = raw.lastIndexOf("@");
+  if (at >= 0) {
+    body = raw.slice(0, at);
+    ref = raw.slice(at + 1);
+    if (!ref || !GH_REF_RE.test(ref)) return null;
+  }
+
+  const segments = body.split("/");
+  if (segments.length < 2) return null;
+  const owner = segments[0]!;
+  const repo = segments[1]!;
+  if (!GH_SEG_RE.test(owner) || !GH_SEG_RE.test(repo)) return null;
+
+  let name: string | undefined;
+  if (segments.length >= 3) {
+    const rest = segments.slice(2).filter((s) => s.length > 0);
+    if (rest.length === 0) return null;
+    if (rest.includes("..")) return null;
+    // Per #939: when subpath is a single segment (no `/`), it's the plugin
+    // name — the resolver auto-prefixes `plugins/<name>/` for monorepo
+    // convenience. Multi-segment subpaths are treated as literal paths.
+    name = rest.join("/");
+    for (const seg of rest) {
+      if (!GH_SEG_RE.test(seg)) return null;
+    }
+  }
+
+  return {
+    owner: owner.toLowerCase(),
+    repo: repo.toLowerCase(),
+    ...(name !== undefined ? { name } : {}),
+    ...(ref !== undefined ? { ref } : {}),
+  };
+}
 
 /**
  * `monorepo:<subpath>@<tag>` source format (maw-plugin-registry#2).
@@ -86,6 +167,21 @@ export function detectMode(src: string): Mode {
   if (monoRef) return { kind: "monorepo", src, subpath: monoRef.subpath, tag: monoRef.tag };
   const peerSpec = parsePeerSpec(src);
   if (peerSpec) return { kind: "peer", src, name: peerSpec.name, peer: peerSpec.peer };
+  // #939 — github: source format. Mode last among the structured kinds so
+  // existing url/tarball/monorepo/peer detection wins for any string that
+  // matches them. parseGithubRef requires `/` and refuses url/path/tarball
+  // shapes defensively, so this is non-shadowing.
+  const ghRef = parseGithubRef(src);
+  if (ghRef) {
+    return {
+      kind: "github",
+      src,
+      owner: ghRef.owner,
+      repo: ghRef.repo,
+      ...(ghRef.name !== undefined ? { name: ghRef.name } : {}),
+      ...(ghRef.ref !== undefined ? { ref: ghRef.ref } : {}),
+    };
+  }
   return { kind: "dir", src: resolve(src) };
 }
 

--- a/test/isolated/install-github-source-939.test.ts
+++ b/test/isolated/install-github-source-939.test.ts
@@ -1,0 +1,395 @@
+/**
+ * github: source resolver — #939 Vercel-style `owner/repo[/name][@ref]`.
+ *
+ * Adds a github source kind to the install resolver:
+ *
+ *   maw plugin install nazt/my-plugin
+ *   maw plugin install Soul-Brews-Studio/maw-plugins/bg
+ *   maw plugin install nazt/my-plugin@v1.2.3
+ *   maw plugin install Soul-Brews-Studio/maw-plugins/bg@v0.1.2
+ *
+ * Mirrors Vercel's `npx skills add owner/repo` pattern (registry becomes a
+ * discovery layer over GitHub, not a custom packaging format).
+ *
+ * Coverage:
+ *   • parseGithubRef happy paths (4 shapes)
+ *   • parseGithubRef rejects: bare name, url, tarball, peer-shape, leading
+ *     `./` `../` `/`, `monorepo:` prefix, double-slash, invalid segment chars
+ *   • detectMode precedence: url, tarball, peer, monorepo, dir each win when
+ *     applicable
+ *   • githubTarballUrl shapes (HEAD, tag-shaped ref, branch ref, env override)
+ *   • End-to-end installFromTarball with the github subpath layout produces
+ *     a working install.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { createHash } from "crypto";
+import { spawnSync } from "child_process";
+import {
+  parseGithubRef,
+  detectMode,
+  installFromTarball,
+  githubTarballUrl,
+  githubBaseUrl,
+  ensureInstallRoot,
+} from "../../src/commands/plugins/plugin/install-impl";
+import {
+  __resetDiscoverStateForTests,
+  resetDiscoverCache,
+} from "../../src/plugin/registry";
+
+// ─── Harness ─────────────────────────────────────────────────────────────────
+
+const created: string[] = [];
+let origPluginsDir: string | undefined;
+let origPluginsLock: string | undefined;
+let origGithubBase: string | undefined;
+
+function tmpDir(prefix = "maw-gh-"): string {
+  const d = mkdtempSync(join(tmpdir(), prefix));
+  created.push(d);
+  return d;
+}
+function pluginsDir(): string { return process.env.MAW_PLUGINS_DIR!; }
+
+beforeEach(() => {
+  origPluginsDir = process.env.MAW_PLUGINS_DIR;
+  origPluginsLock = process.env.MAW_PLUGINS_LOCK;
+  origGithubBase = process.env.MAW_GITHUB_BASE_URL;
+  const home = tmpDir("maw-gh-home-");
+  process.env.MAW_PLUGINS_DIR = join(home, "plugins");
+  process.env.MAW_PLUGINS_LOCK = join(home, "plugins.lock");
+  ensureInstallRoot();
+  __resetDiscoverStateForTests();
+  resetDiscoverCache();
+});
+
+afterEach(() => {
+  if (origPluginsDir !== undefined) process.env.MAW_PLUGINS_DIR = origPluginsDir;
+  else delete process.env.MAW_PLUGINS_DIR;
+  if (origPluginsLock !== undefined) process.env.MAW_PLUGINS_LOCK = origPluginsLock;
+  else delete process.env.MAW_PLUGINS_LOCK;
+  if (origGithubBase !== undefined) process.env.MAW_GITHUB_BASE_URL = origGithubBase;
+  else delete process.env.MAW_GITHUB_BASE_URL;
+  for (const d of created.splice(0)) {
+    if (existsSync(d)) rmSync(d, { recursive: true, force: true });
+  }
+});
+
+// ─── parseGithubRef — positive cases ─────────────────────────────────────────
+
+describe("parseGithubRef — positive cases", () => {
+  test("owner/repo parses to owner + repo", () => {
+    expect(parseGithubRef("nazt/my-plugin")).toEqual({
+      owner: "nazt",
+      repo: "my-plugin",
+    });
+  });
+
+  test("owner/repo/name extracts the trailing name segment", () => {
+    expect(parseGithubRef("Soul-Brews-Studio/maw-plugins/bg")).toEqual({
+      owner: "soul-brews-studio",
+      repo: "maw-plugins",
+      name: "bg",
+    });
+  });
+
+  test("owner/repo@ref extracts ref without name", () => {
+    expect(parseGithubRef("nazt/my-plugin@v1.2.3")).toEqual({
+      owner: "nazt",
+      repo: "my-plugin",
+      ref: "v1.2.3",
+    });
+  });
+
+  test("owner/repo/name@ref extracts all four fields", () => {
+    expect(parseGithubRef("Soul-Brews-Studio/maw-plugins/bg@v0.1.2")).toEqual({
+      owner: "soul-brews-studio",
+      repo: "maw-plugins",
+      name: "bg",
+      ref: "v0.1.2",
+    });
+  });
+
+  test("owner + repo are normalized to lowercase (GitHub is case-insensitive)", () => {
+    const r = parseGithubRef("NAZT/My-Plugin@v1.0.0")!;
+    expect(r.owner).toBe("nazt");
+    expect(r.repo).toBe("my-plugin");
+    // ref preserved verbatim (git refs are case-sensitive).
+    expect(r.ref).toBe("v1.0.0");
+  });
+
+  test("name (subpath) preserved verbatim — filesystem paths are case-sensitive", () => {
+    const r = parseGithubRef("owner/repo/MixedCase-Name")!;
+    expect(r.name).toBe("MixedCase-Name");
+  });
+
+  test("multi-segment subpath kept as literal slash-joined path", () => {
+    expect(parseGithubRef("owner/repo/plugins/deep/nested")).toEqual({
+      owner: "owner",
+      repo: "repo",
+      name: "plugins/deep/nested",
+    });
+  });
+
+  test("ref may contain dots and hyphens (semver pre-release shapes)", () => {
+    expect(parseGithubRef("owner/repo@v1.2.3-rc.4")).toEqual({
+      owner: "owner",
+      repo: "repo",
+      ref: "v1.2.3-rc.4",
+    });
+  });
+});
+
+// ─── parseGithubRef — negative cases ─────────────────────────────────────────
+
+describe("parseGithubRef — negative cases (other modes win)", () => {
+  test("bare name (no slash) returns null — would be dir mode", () => {
+    expect(parseGithubRef("my-plugin")).toBeNull();
+  });
+
+  test("http/https URLs return null", () => {
+    expect(parseGithubRef("https://github.com/owner/repo")).toBeNull();
+    expect(parseGithubRef("http://example.com/a/b")).toBeNull();
+  });
+
+  test(".tgz / .tar.gz tarball paths return null", () => {
+    expect(parseGithubRef("./pkg/foo.tgz")).toBeNull();
+    expect(parseGithubRef("owner/repo.tar.gz")).toBeNull();
+  });
+
+  test("explicit relative paths return null (./ and ../)", () => {
+    expect(parseGithubRef("./owner/repo")).toBeNull();
+    expect(parseGithubRef("../owner/repo")).toBeNull();
+  });
+
+  test("absolute paths return null", () => {
+    expect(parseGithubRef("/var/plugins/owner/repo")).toBeNull();
+  });
+
+  test("monorepo: prefix returns null (existing mode wins)", () => {
+    expect(parseGithubRef("monorepo:plugins/bg@v0.1.2")).toBeNull();
+  });
+
+  test("github: prefix returns null (avoid double-claim)", () => {
+    expect(parseGithubRef("github:owner/repo")).toBeNull();
+  });
+
+  test("empty owner or repo returns null", () => {
+    expect(parseGithubRef("/repo")).toBeNull();
+    expect(parseGithubRef("owner/")).toBeNull();
+    expect(parseGithubRef("//repo")).toBeNull();
+  });
+
+  test("invalid characters in owner/repo return null", () => {
+    expect(parseGithubRef("own er/repo")).toBeNull();
+    expect(parseGithubRef("owner/re po")).toBeNull();
+  });
+
+  test("empty ref returns null", () => {
+    expect(parseGithubRef("owner/repo@")).toBeNull();
+  });
+
+  test("subpath containing .. segment returns null", () => {
+    expect(parseGithubRef("owner/repo/..")).toBeNull();
+    expect(parseGithubRef("owner/repo/foo/../etc")).toBeNull();
+  });
+
+  test("empty input returns null", () => {
+    expect(parseGithubRef("")).toBeNull();
+  });
+});
+
+// ─── detectMode — precedence guarantees ──────────────────────────────────────
+
+describe("detectMode — github branch + precedence", () => {
+  test("returns kind:github for a bare owner/repo", () => {
+    const m = detectMode("nazt/my-plugin");
+    expect(m.kind).toBe("github");
+    if (m.kind === "github") {
+      expect(m.owner).toBe("nazt");
+      expect(m.repo).toBe("my-plugin");
+      expect(m.src).toBe("nazt/my-plugin");
+    }
+  });
+
+  test("returns kind:github with name + ref for owner/repo/name@ref", () => {
+    const m = detectMode("Soul-Brews-Studio/maw-plugins/bg@v0.1.2");
+    expect(m.kind).toBe("github");
+    if (m.kind === "github") {
+      expect(m.owner).toBe("soul-brews-studio");
+      expect(m.repo).toBe("maw-plugins");
+      expect(m.name).toBe("bg");
+      expect(m.ref).toBe("v0.1.2");
+    }
+  });
+
+  test("URL still wins over github (https://… stays kind:url)", () => {
+    expect(detectMode("https://github.com/owner/repo/archive/HEAD.tar.gz").kind).toBe("url");
+  });
+
+  test("tarball extension wins over github (foo/bar.tgz stays kind:tarball)", () => {
+    // Note: ./ is added so resolve() doesn't escape cwd; this still exercises
+    // the .tgz branch winning over github-shape detection.
+    expect(detectMode("./owner/repo.tgz").kind).toBe("tarball");
+  });
+
+  test("monorepo: prefix wins over github (existing kind:monorepo preserved)", () => {
+    const m = detectMode("monorepo:plugins/bg@v0.1.2-bg");
+    expect(m.kind).toBe("monorepo");
+  });
+
+  test("peer name@host (no slash) stays kind:peer", () => {
+    expect(detectMode("ping@white").kind).toBe("peer");
+  });
+
+  test("explicit relative path stays kind:dir even when shaped like owner/repo", () => {
+    expect(detectMode("./owner/repo").kind).toBe("dir");
+  });
+
+  test("bare name with no slash stays kind:dir (legacy behavior)", () => {
+    expect(detectMode("my-plugin").kind).toBe("dir");
+  });
+});
+
+// ─── githubTarballUrl — URL construction ────────────────────────────────────
+
+describe("githubTarballUrl — URL shapes", () => {
+  test("no ref → archive/HEAD.tar.gz", () => {
+    delete process.env.MAW_GITHUB_BASE_URL;
+    expect(githubTarballUrl("nazt", "my-plugin")).toBe(
+      "https://github.com/nazt/my-plugin/archive/HEAD.tar.gz",
+    );
+  });
+
+  test("tag-shaped ref (v…) → archive/refs/tags/<ref>.tar.gz", () => {
+    delete process.env.MAW_GITHUB_BASE_URL;
+    expect(githubTarballUrl("owner", "repo", "v1.2.3")).toBe(
+      "https://github.com/owner/repo/archive/refs/tags/v1.2.3.tar.gz",
+    );
+  });
+
+  test("branch ref (non-v) → archive/<ref>.tar.gz (bare)", () => {
+    delete process.env.MAW_GITHUB_BASE_URL;
+    expect(githubTarballUrl("owner", "repo", "main")).toBe(
+      "https://github.com/owner/repo/archive/main.tar.gz",
+    );
+  });
+
+  test("MAW_GITHUB_BASE_URL overrides host", () => {
+    process.env.MAW_GITHUB_BASE_URL = "http://localhost:9999";
+    expect(githubTarballUrl("owner", "repo", "v1.0.0")).toBe(
+      "http://localhost:9999/owner/repo/archive/refs/tags/v1.0.0.tar.gz",
+    );
+    expect(githubBaseUrl()).toBe("http://localhost:9999");
+  });
+});
+
+// ─── End-to-end install via installFromTarball + github layout ──────────────
+//
+// We reuse the same monorepo-style fixture as the registry tests: github
+// archives wrap contents in `<repo>-<ref>/`, and when a `name` is supplied
+// the resolver descends into `plugins/<name>/`. Hitting installFromTarball
+// directly with the synthesized subpath keeps the test offline.
+
+function buildGithubFixture(opts: {
+  owner: string;
+  repo: string;
+  name: string;
+  ref: string;
+  version: string;
+}): { tarball: string; entrySha256: string } {
+  const wrapper = `${opts.repo}-${opts.ref}`;
+  const dir = tmpDir("maw-gh-fx-");
+  const wrapperDir = join(dir, wrapper);
+  const pluginDir = join(wrapperDir, "plugins", opts.name);
+  const srcDir = join(pluginDir, "src");
+  mkdirSync(srcDir, { recursive: true });
+
+  writeFileSync(join(wrapperDir, "README.md"), `# ${opts.repo}\n`);
+  const src = `export default () => ({ ok: "${opts.name}" });\n`;
+  writeFileSync(join(srcDir, "index.ts"), src);
+  const sha = "sha256:" + createHash("sha256").update(src).digest("hex");
+
+  const manifest = {
+    $schema: "https://maw.soulbrews.studio/schema/plugin.json",
+    name: opts.name,
+    version: opts.version,
+    sdk: "^1.0.0-alpha",
+    target: "js",
+    capabilities: [],
+    schemaVersion: 1,
+    entry: "./src/index.ts",
+  };
+  writeFileSync(join(pluginDir, "plugin.json"), JSON.stringify(manifest, null, 2));
+
+  const tarball = join(dir, `${wrapper}.tar.gz`);
+  const tar = spawnSync("tar", ["-czf", tarball, "-C", dir, wrapper]);
+  if (tar.status !== 0) throw new Error(`tar failed: ${tar.stderr}`);
+  return { tarball, entrySha256: sha };
+}
+
+describe("installFromTarball — github source layout (offline)", () => {
+  test("installs plugin via owner/repo/name layout", async () => {
+    const fx = buildGithubFixture({
+      owner: "soul-brews-studio",
+      repo: "maw-plugins",
+      name: "bg",
+      ref: "v0.1.2",
+      version: "0.1.2",
+    });
+    await installFromTarball(fx.tarball, {
+      source: "soul-brews-studio/maw-plugins/bg@v0.1.2",
+      subpath: "plugins/bg",
+      pin: true,
+    });
+    expect(existsSync(join(pluginsDir(), "bg"))).toBe(true);
+    expect(existsSync(join(pluginsDir(), "bg", "plugin.json"))).toBe(true);
+    expect(existsSync(join(pluginsDir(), "bg", "src", "index.ts"))).toBe(true);
+  });
+
+  test("records github source string into plugins.lock", async () => {
+    const fx = buildGithubFixture({
+      owner: "nazt",
+      repo: "maw-plugins",
+      name: "rename",
+      ref: "v0.2.0",
+      version: "0.2.0",
+    });
+    await installFromTarball(fx.tarball, {
+      source: "nazt/maw-plugins/rename@v0.2.0",
+      subpath: "plugins/rename",
+      pin: true,
+    });
+    const lock = JSON.parse(readFileSync(process.env.MAW_PLUGINS_LOCK!, "utf8"));
+    expect(lock.plugins["rename"]).toBeDefined();
+    expect(lock.plugins["rename"].source).toBe("nazt/maw-plugins/rename@v0.2.0");
+    expect(lock.plugins["rename"].sha256).toBe(fx.entrySha256);
+  });
+});
+
+// ─── detectMode round-trip with parseGithubRef ───────────────────────────────
+
+describe("detectMode round-trip with parseGithubRef", () => {
+  test("kind:github carries through owner/repo/name/ref verbatim from parser", () => {
+    const m = detectMode("Soul-Brews-Studio/maw-plugins/bg@v0.1.2");
+    expect(m.kind).toBe("github");
+    if (m.kind === "github") {
+      const parsed = parseGithubRef(m.src)!;
+      expect(parsed.owner).toBe(m.owner);
+      expect(parsed.repo).toBe(m.repo);
+      expect(parsed.name).toBe(m.name);
+      expect(parsed.ref).toBe(m.ref);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `github` Mode kind to the plugin install resolver, letting users install plugins directly by GitHub coordinates — no `monorepo:` prefix, no registry entry required. Mirrors Vercel's [`npx skills add owner/repo`](https://vercel.com/docs/agent-resources/skills) pattern. The maw-plugin-registry becomes a discovery layer over GitHub, not a custom packaging format.

```bash
maw plugin install nazt/my-plugin
maw plugin install Soul-Brews-Studio/maw-plugins/bg
maw plugin install nazt/my-plugin@v1.2.3
maw plugin install Soul-Brews-Studio/maw-plugins/bg@v0.1.2
```

Closes part of #939 (parser + resolver + tests; registry-side migration in maw-plugin-registry is a follow-up).

## What changed

**`install-source-detect.ts`**
- New `Mode` arm: `{ kind: "github"; owner; repo; name?; ref? }`
- `parseGithubRef(raw)` — splits `owner/repo[/name][@ref]`, lowercases owner+repo (GitHub is case-insensitive on lookup), preserves name and ref verbatim (filesystem paths and git refs are case-sensitive).
- `detectMode` dispatch: url → tarball → monorepo → peer → **github** → dir. The github branch is added last among the structured kinds, and `parseGithubRef` defensively rejects `http(s)://`, `.tgz`/`.tar.gz`, leading `./` `../` `/`, and `monorepo:`/`github:` prefixes — existing modes always win when they apply. Bare names (no slash) keep `kind:dir`.

**`install-handlers.ts`**
- `installFromGithub(owner, repo, { name?, ref?, force?, weight?, pin? })` — fetches the GitHub archive tarball and reuses `installFromTarball` (so #866 wrapper-dir walk + #880 source plugins + sdk gate + sha256 verify + `plugins.lock` + `--pin`/`--force` semantics all apply unchanged).
- `githubTarballUrl(owner, repo, ref?)` — three URL shapes:
  - no ref → `…/archive/HEAD.tar.gz` (default branch)
  - tag-shaped ref (`v…`) → `…/archive/refs/tags/<ref>.tar.gz`
  - any other ref → `…/archive/<ref>.tar.gz` (branches, shas)
- `MAW_GITHUB_BASE_URL` env override (parallel to `MAW_MONOREPO_BASE_URL`) for tests / mirrors / local fixture servers.
- Subpath rule: single-segment `name` auto-prefixes `plugins/<name>/` for monorepo convenience (matches the maw-plugin-registry layout); multi-segment paths are treated as literals.

**`install-impl.ts`**
- Dispatcher routes `mode.kind === "github"` to `installFromGithub`.
- Re-exports `parseGithubRef`, `installFromGithub`, `githubTarballUrl`, `githubBaseUrl`.
- Help text updated to list the new `owner/repo[/name][@ref]` form.

## Tests — `test/isolated/install-github-source-939.test.ts` (35 cases)

- `parseGithubRef` positives: 4 canonical shapes, lowercase normalization, multi-segment subpath, semver pre-release refs.
- `parseGithubRef` negatives: bare name, http/https URLs, `.tgz`/`.tar.gz`, `./`, `../`, `/`, `monorepo:`, `github:`, empty owner/repo, invalid chars, empty ref, `..` in subpath.
- `detectMode` precedence: every existing kind (url, tarball, monorepo, peer, dir) still wins when applicable. Bare `owner/repo` becomes `kind:github`; `./owner/repo` stays `kind:dir`.
- `githubTarballUrl`: HEAD (no ref), tag form, branch form, env override.
- End-to-end install via `installFromTarball` with a synthesized github-archive fixture (`<repo>-<ref>/plugins/<name>/`) — confirms the wrapper-dir walk + subpath descent path works for github layouts and that the github source string round-trips through `plugins.lock`.

## Non-goals (deferred)

- Channel resolution (`@alpha`, `@stable`) — needs tag-naming convention; tracked as a follow-up.
- `registry.json` schema migration in maw-plugin-registry — separate PR.
- `gh release list` integration for "latest stable" — out of scope.

## Test plan

- [x] `bun test src/commands/plugins/plugin/install-source-detect.test.ts` — existing 33 unit tests still green.
- [x] `bun test test/isolated/install-github-source-939.test.ts` — 35 new tests pass.
- [x] `bun test test/isolated/install-monorepo-source.test.ts` + `install-source-regression-896.test.ts` + `install-source-plugin.test.ts` — no regression in adjacent install paths.
- [x] `tsc --noEmit` clean.
- [ ] Live smoke once merged: `maw plugin install Soul-Brews-Studio/maw-plugin-registry/bg@v0.1.2-bg` against the real registry repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)