### PR TITLE
fix(test): #942 — checkStalePeers timeout forwarding + #411 message routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.29-alpha.1426",
+  "version": "26.4.29-alpha.1439",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",
@@ -28,7 +28,7 @@
     "check:redos": "bun scripts/check-redos.ts",
     "preflight": "bash scripts/preflight.sh"
   },
-  "description": "maw.js \u2014 Multi-Agent Workflow in Bun/TS. Remote tmux orchestra control. CLI + Web UI.",
+  "description": "maw.js — Multi-Agent Workflow in Bun/TS. Remote tmux orchestra control. CLI + Web UI.",
   "dependencies": {
     "@elysiajs/cors": "^1.4.1",
     "@elysiajs/swagger": "^1.3.1",

--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -310,7 +310,9 @@ export async function cmdSend(
           });
           if (!wakeRes.ok || !wakeRes.data?.ok) {
             const underlying = wakeRes.data?.error || (wakeRes.status ? `HTTP ${wakeRes.status}` : "connection failed");
-            console.error(`\x1b[31merror\x1b[0m: cross-node wake failed for ${targetNode}:${bareAgent}: ${underlying}`);
+            // #942 — surface as "Remote fetch failed for peer" so callers see a
+            // consistent network-failure shape across wake + send (#411 contract).
+            console.error(`\x1b[31merror\x1b[0m: Remote fetch failed for peer ${peer.url} (${targetNode}): cross-node wake failed for ${bareAgent}: ${underlying}`);
             console.error(`\x1b[33mhint\x1b[0m:  check peer connectivity: maw health`);
             process.exit(1);
           }

--- a/test/isolated/fleet-doctor.test.ts
+++ b/test/isolated/fleet-doctor.test.ts
@@ -233,8 +233,11 @@ describe("checkStalePeers — reachable happy path", () => {
     expect(out.identities).toEqual({ fresh: { node: "fresh", agents: [] } });
   });
 
-  // Pre-existing failure — see #942
-  test.skip("explicit timeout forwarded to curlFetch", async () => {
+  // #942 — overspecified assertion fixed: checkStalePeers also passes
+  // `from: "auto"` for #804 Step 4 v3-sign. The contract here is "timeout
+  // is forwarded" — use objectContaining so future opts (sign tags, etc.)
+  // don't regress this test.
+  test("explicit timeout forwarded to curlFetch", async () => {
     curlFetchResponses = [{
       match: /identity/,
       response: { ok: true, status: 200, data: { node: "x", agents: [] } },
@@ -242,11 +245,11 @@ describe("checkStalePeers — reachable happy path", () => {
 
     await checkStalePeers([{ name: "x", url: "https://x.example" }], 7777);
 
-    expect(curlFetchCalls[0].opts).toEqual({ timeout: 7777 });
+    expect(curlFetchCalls[0].opts).toEqual(expect.objectContaining({ timeout: 7777 }));
   });
 
-  // Pre-existing failure — see #942
-  test.skip("default timeout=3000 when omitted", async () => {
+  // #942 — see note above.
+  test("default timeout=3000 when omitted", async () => {
     curlFetchResponses = [{
       match: /identity/,
       response: { ok: true, status: 200, data: { node: "x", agents: [] } },
@@ -254,7 +257,7 @@ describe("checkStalePeers — reachable happy path", () => {
 
     await checkStalePeers([{ name: "x", url: "https://x.example" }]);
 
-    expect(curlFetchCalls[0].opts).toEqual({ timeout: 3000 });
+    expect(curlFetchCalls[0].opts).toEqual(expect.objectContaining({ timeout: 3000 }));
   });
 });
 

--- a/test/isolated/resolve-local-first.test.ts
+++ b/test/isolated/resolve-local-first.test.ts
@@ -173,8 +173,7 @@ describe("local-first routing (#411)", () => {
 
   // ── Case 3: local miss + remote peer unreachable ───────────────────────────
 
-  // Pre-existing failure — see #942 (#411 fix may have regressed)
-  test.skip("(3) local miss + remote peer unreachable — surfaces remote failure, not local-miss", async () => {
+  test("(3) local miss + remote peer unreachable — surfaces remote failure, not local-miss", async () => {
     fakeSessions = [];
     // curlFetch returns failure (peer unreachable)
     fakeCurlResponse = { ok: false, status: 0, data: null };


### PR DESCRIPTION
## Summary

Fixes the 3 pre-existing isolated test failures tracked in #942 (surfaced after #941 deleted the stranded tests masking them). All 3 tests now run and pass — no new `.skip()` introduced.

Closes #942.

## Changes

### 1. `test/isolated/fleet-doctor.test.ts` — overspecified, test fixed (FIX)
Two tests asserted `expect(curlFetchCalls[0].opts).toEqual({ timeout: N })` against `checkStalePeers`. The real call site in `src/commands/shared/fleet-doctor-stale-peers.ts` passes `{ timeout, from: "auto" }` — the second key was added for #804 Step 4 v3-sign to authenticate cross-node `/api/identity` checks.

The behaviour the test guards (timeout IS forwarded) is correct in production; the assertion shape was just too strict. Switched to `expect.objectContaining({ timeout: N })` so future opts (sign tags, headers, etc.) don't regress this contract.

Resolution: **test fix**. Production code was already correct.

### 2. `test/isolated/resolve-local-first.test.ts` — production fix (FIX)
Test (3) asserts that `cmdSend("mba:homekeeper", ...)` against an unreachable peer surfaces "Remote fetch failed for peer" (and NOT "not in local sessions or agents map"). #411's original fix lives in the SEND failure branch of `comm-send.ts:482, 506`.

Root cause: when the cross-node auto-wake step (#791 Option B, lines 305–316) is reached BEFORE the send, a `wakeRes.ok=false` path emitted `"cross-node wake failed for ..."` and exited — never reaching the send. The first-failing-network-call therefore showed a different message shape than #411 promised.

Fix: prefix the wake-failure message with the same `"Remote fetch failed for peer <url> (<node>): cross-node wake failed for <agent>: <underlying>"` shape so the network-failure contract is consistent across wake + send. The wake context is preserved as a tail clause for operators.

Resolution: **production fix** in `src/commands/shared/comm-send.ts`.

## Fix vs skip per test

| Test | File | Action | Why |
|---|---|---|---|
| `explicit timeout forwarded to curlFetch` | `fleet-doctor.test.ts:236` | **fix test** | Behaviour correct; assertion overspecified vs `from:"auto"` (#804) |
| `default timeout=3000 when omitted` | `fleet-doctor.test.ts:247` | **fix test** | Same as above |
| `(3) local miss + remote peer unreachable` | `resolve-local-first.test.ts:176` | **fix prod** | wake-failure message didn't honour #411 contract |

## Verification

```
$ bun test test/isolated/fleet-doctor.test.ts test/isolated/resolve-local-first.test.ts
 33 pass
 0 fail
 93 expect() calls
```

Full `test/isolated/` suite fail count unchanged from baseline (149 → 149) — no regressions; remaining failures are pre-existing and orthogonal to this PR.

## Calver

Bumped to `v26.4.29-alpha.1439` per HHMM scheme (cut at 14:39 local).

## Commit

`fix(test): #942 — checkStalePeers timeout forwarding + #411 message routing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)