### PR TITLE
feat(plugin install): resolve package names (standard/federation/dev/extras)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.51",
+  "version": "26.4.52",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/plugins/plugin/index.ts
+++ b/src/commands/plugins/plugin/index.ts
@@ -12,7 +12,9 @@ const USAGE =
   "  build [dir] [--watch] [--types]     bundle + pack a plugin\n" +
   "                                        --types: emit dist/<name>.d.ts\n" +
   "  dev [dir] [--types]                 watch mode (alias for build --watch, DX verb)\n" +
-  "  install <name | dir | .tgz | URL>   install a plugin (plain name → registry lookup)\n" +
+  "  install <name | package | dir | .tgz | URL>\n" +
+  "                                      plain name → registry lookup (plugin or package)\n" +
+  "                                      e.g. 'maw plugin install standard' installs the standard bundle\n" +
   "                                        --pin: add to plugins.lock on first install\n" +
   "  install <owner/repo>[/<name>][@<ref>]   install from GitHub (Vercel-style)\n" +
   "    install owner/repo                  whole repo (single-plugin repo)\n" +
@@ -147,12 +149,32 @@ async function runInstallCmd(args: string[]): Promise<void> {
   const src = args.find(a => !a.startsWith("-"));
   if (src && isPlainName(src)) {
     const { getRegistry } = await import("./registry-fetch");
-    const { resolvePluginSource } = await import("./registry-resolve");
     const reg = await getRegistry();
+    const pkg = reg.packages?.[src];
+    if (pkg) {
+      console.log(`installing package '${src}': ${pkg.plugins.length} plugins — ${pkg.summary}`);
+      const failures: { name: string; err: unknown }[] = [];
+      for (const pluginName of pkg.plugins) {
+        const subArgs = args.map(a => (a === src ? pluginName : a));
+        try {
+          await runInstallCmd(subArgs);
+        } catch (err) {
+          failures.push({ name: pluginName, err });
+          console.error(`  ! ${pluginName}: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      }
+      const ok = pkg.plugins.length - failures.length;
+      console.log(`package '${src}': ${ok}/${pkg.plugins.length} installed${failures.length ? ` (${failures.length} failed)` : ""}`);
+      if (failures.length) throw new Error(`package install partial: ${failures.length} failed`);
+      return;
+    }
+    const { resolvePluginSource } = await import("./registry-resolve");
     const resolved = resolvePluginSource(src, reg);
     if (!resolved) {
+      const knownPackages = reg.packages ? Object.keys(reg.packages).join(", ") : "";
       throw new Error(
         `plugin '${src}' not in registry.\n` +
+        (knownPackages ? `  packages available: ${knownPackages}\n` : "") +
         `  if you have a direct URL or tarball, run: maw plugin install <url | .tgz>`,
       );
     }

--- a/src/commands/plugins/plugin/registry-fetch.ts
+++ b/src/commands/plugins/plugin/registry-fetch.ts
@@ -25,12 +25,19 @@ export interface RegistryEntry {
   license: string;
   homepage?: string;
   addedAt: string;
+  tier?: string;
+}
+
+export interface RegistryPackage {
+  summary: string;
+  plugins: string[];
 }
 
 export interface RegistryManifest {
   schemaVersion: 1;
   updated: string;
   plugins: Record<string, RegistryEntry>;
+  packages?: Record<string, RegistryPackage>;
 }
 
 export function registryUrl(override?: string): string {


### PR DESCRIPTION
## Summary

Wires `maw plugin install <package-name>` to expand into multiple plugin installs. Consumes the new `packages` map shipped in [maw-plugin-registry#7](https://github.com/Soul-Brews-Studio/maw-plugin-registry/pull/7).

This was the last piece needed for the end-state described in #939: **"all 70 plugins available + working via new github: source resolver"**.

## Usage after this lands

```bash
maw plugin install standard      # 14 daily-use plugins (init, ls, peek, stop, ...)
maw plugin install federation    # 10 multi-oracle (peers, trust, consent, ...)
maw plugin install dev           # 12 diagnostics (doctor, panes, ping, ...)
maw plugin install extras        # 34 optional community plugins
```

## What changed

| File | Change |
|------|--------|
| `registry-fetch.ts` | Add `RegistryPackage` interface + optional `packages` field on `RegistryManifest`. Also added optional `tier` on `RegistryEntry` (matches registry schema). |
| `index.ts` | `runInstallCmd` now checks packages first; expands to plugin list and installs each via the existing single-plugin path. |
| `index.ts` | Help text updated. |

## Behavior

- **Package vs plugin name**: package lookup runs first. If both exist with the same name, package wins. (No conflicts in current data.)
- **Partial failures**: each plugin install in a bundle is wrapped in try/catch. Bundle reports `N/M installed`; throws if any failed — so CI/scripts catch partial failures without losing visibility into the successes.
- **Backward compat**: zero impact on existing flows. `packages` is optional in the manifest. If absent, install behavior is unchanged.

## Verification

- 93/93 plugin install tests pass locally
- Type-safe TypeScript (registry-fetch interface extended, no breakage)
- Help text reflects new usage

## Out of scope

- Per-package install flags (e.g. dry-run for just one plugin in the bundle) — could be follow-up
- `maw plugin search standard` listing what's in a package — could be follow-up

## References

- maw-plugin-registry#7 — packages map shipped to registry
- maw-js#939 — the parent design issue
- maw-js#940 — github: source resolver