### PR TITLE
fix(ci): calver-check.yml — sync to HMM scheme + past-31 day allowed

### DIFF
--- a/.github/workflows/calver-check.yml
+++ b/.github/workflows/calver-check.yml
@@ -3,7 +3,12 @@ name: CalVer Tag Check
 # Validates any tag pushed to the repo against the CalVer scheme proposed in
 # Soul-Brews-Studio/mawjs-oracle PR #3.
 #
-# Scheme: v{yy}.{m}.{d}[-alpha.{hour}[a-z]?]
+# Scheme: v{yy}.{m}.{d}[-(alpha|beta).{HMM}[a-z]?]
+#
+# HMM = H*100+M decimal, no leading zero (e.g. 09:37 → 937, 23:59 → 2359).
+# Replaced monotonic counter (#766/#775) in #923.
+# D may exceed 31 — used as a stable counter once the natural date is
+# exhausted (#930 fix in calver-release.yml; mirrored here in #948).
 #
 # This workflow is a pure validator — no side effects. Belt-and-suspenders
 # for calver-release.yml which also validates before tagging.
@@ -28,9 +33,11 @@ jobs:
           VERSION="${TAG#v}"
           echo "Validating: $TAG ($VERSION)"
 
-          REGEX='^[0-9]{2}\.[0-9]{1,2}\.[0-9]{1,2}(-(alpha|beta)\.[0-9]+)?$'
+          # D allows 1-3 digits (past-31 stable counter per #930).
+          # Pre-release suffix is HMM (H*100+M), 1-4 digits per #923/#933.
+          REGEX='^[0-9]{2}\.[0-9]{1,2}\.[0-9]{1,3}(-(alpha|beta)\.[0-9]{1,4}[a-z]?)?$'
           if [[ ! "$VERSION" =~ $REGEX ]]; then
-            echo "::error title=CalVer violation::Tag '$TAG' does not match v{yy}.{m}.{d}[-(alpha|beta).{N}]"
+            echo "::error title=CalVer violation::Tag '$TAG' does not match v{yy}.{m}.{d}[-(alpha|beta).{HMM}]"
             echo "::error::Spec: https://github.com/Soul-Brews-Studio/mawjs-oracle/blob/main/%CF%88/inbox/2026-04-18_proposal-calver-skills-cli.md"
             exit 1
           fi
@@ -42,12 +49,14 @@ jobs:
             echo "::error::Month must be 1-12, got $M"
             exit 1
           fi
-          if (( D < 1 || D > 31 )); then
-            echo "::error::Day must be 1-31, got $D"
+          if (( D < 1 )); then
+            echo "::error::Day must be ≥1, got $D"
             exit 1
           fi
 
-          # Post-#775: monotonic counter — N can be any non-negative integer.
+          # Post-#923: HMM scheme (H*100+M decimal, no leading zero).
+          # Pre-release counter is digit-shaped; range 0-2359 expected but not
+          # strict-validated here — the regex above covers the upper bound.
           # Pre-release suffix shape (-alpha.N / -beta.N) is validated by the
           # regex in scripts/calver.ts; this workflow only sanity-checks it
           # exists and is digit-shaped.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,11 +136,12 @@ There is no fixed cadence. If `alpha` is quiet, don't cut. If `alpha` has shippe
 ```bash
 TZ=Asia/Bangkok bun scripts/calver.ts            # alpha bump (run on `alpha` branch)
 TZ=Asia/Bangkok bun scripts/calver.ts --stable   # stable bump (run on `alpha`, then PR to `main`)
-TZ=Asia/Bangkok bun scripts/calver.ts --hour 14  # alpha pinned to a specific hour bucket
 TZ=Asia/Bangkok bun scripts/calver.ts --check    # dry-run, no writes
 ```
 
-Or via the npm-script alias: `bun run calver [--stable|--hour N|--check]` (TZ still recommended).
+Or via the npm-script alias: `bun run calver [--stable|--check]` (TZ still recommended).
+
+`--hour` was removed in #923 — HMM is now computed from wall-clock automatically.
 
 ### Do NOT manually bump semver
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.52",
+  "version": "26.4.53",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
## Summary

`calver-check.yml` has been failing on every release tag since 2026-04-19 (alpha.24 onwards) — 11+ days of red runs. Same staleness that #787 fixed in `calver-release.yml` was never mirrored here.

## What's failing

- Day regex `[0-9]{1,2}` rejected v26.4.32+ stable counters
- `D > 31` validation rejected past-31 counter (per #930 in calver-release.yml)
- Pre-release suffix regex didn't account for HMM (post-#923 — values up to 4 digits)
- Comments said "monotonic counter" — pre-#923 staleness

## Fix

```diff
- REGEX='^[0-9]{2}\.[0-9]{1,2}\.[0-9]{1,2}(-(alpha|beta)\.[0-9]+)?$'
+ REGEX='^[0-9]{2}\.[0-9]{1,2}\.[0-9]{1,3}(-(alpha|beta)\.[0-9]{1,4}[a-z]?)?$'

- if (( D < 1 || D > 31 )); then
-   echo "::error::Day must be 1-31, got $D"
+ if (( D < 1 )); then
+   echo "::error::Day must be ≥1, got $D"
```

Plus:
- Header comment scheme updated: `v{yy}.{m}.{d}[-(alpha|beta).{HMM}[a-z]?]`
- Body comment updated: monotonic counter → HMM scheme
- `CONTRIBUTING.md`: drop `--hour 14` example line (flag was removed in #923)

## Verification

After merge, `calver-check.yml` will pass on:
- `v26.4.53` (this PR's tag — past-31 stable counter)
- `v26.4.30-alpha.428` (today + HMM 4-digit example)
- `v26.4.18` (legacy in-range stable, still valid)

Existing `calver-release.yml` already validates correctly post-#930/#923/#933 — this PR just mirrors that to the standalone validator.

## References

- #787 — same fix on calver-release.yml (closed)
- #923 — HMM scheme replaces monotonic counter
- #930 — stable counter past 31
- #933 — alpha suffix regex 1→4 digits