### PR TITLE
fix(update): replace useless 'bun add' recovery hint with curl + manual eviction → v26.4.53-alpha.619

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.53-alpha.618",
+  "version": "26.4.53-alpha.619",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/cli/cmd-update.ts
+++ b/src/cli/cmd-update.ts
@@ -265,7 +265,11 @@ export async function runUpdate(args: string[]): Promise<void> {
     }
     if (installCode !== 0) {
       console.error(`\x1b[31merror\x1b[0m: bun add failed with exit ${installCode} — previous maw restored from stash (if available)`);
-      console.error(`  manual recovery: bun add -g github:${repository}#alpha`);
+      console.error(``);
+      console.error(`  Manual recovery (bypass bun resolver — release tags only):`);
+      console.error(`    curl -fsSL https://github.com/${repository}/releases/download/${ref}/maw -o ~/.bun/bin/maw && chmod +x ~/.bun/bin/maw && maw --version`);
+      console.error(``);
+      console.error(`  If dep-loop persists: edit ~/.bun/install/global/package.json to drop maw-js, then re-run \`bun add -g github:${repository}#${ref}\`.`);
       process.exit(installCode);
     }
     // Link SDK so plugins can `import { maw } from "@maw/sdk"` (workspace package at packages/sdk/)

--- a/test/isolated/cmd-update-order.test.ts
+++ b/test/isolated/cmd-update-order.test.ts
@@ -55,8 +55,18 @@ describe("cmd-update source-order invariants", () => {
     expect(src).toContain("clearing stale global refs");
   });
 
-  it("failure path prints recovery command", () => {
-    expect(src).toMatch(/manual recovery: bun add -g github:/);
+  it("failure path prints curl release-binary recovery command", () => {
+    // Updated #952 follow-up: previous message advised the same `bun add` that
+    // just failed — useless. New message points at the curl URL that bypasses
+    // bun's resolver entirely (works for release tags only).
+    expect(src).toMatch(/curl -fsSL https:\/\/github\.com\/.*\/releases\/download\//);
+    expect(src).toMatch(/-o ~\/\.bun\/bin\/maw/);
+  });
+
+  it("failure path prints fallback dep-loop instructions", () => {
+    // If the curl URL 404s (e.g. branch ref, not a tag), the user gets a
+    // pointer at the manual file-level eviction.
+    expect(src).toMatch(/edit ~\/\.bun\/install\/global\/package\.json to drop maw-js/);
   });
 
   // #950 — direct-evict of global package.json + node_modules must run


### PR DESCRIPTION
## Summary

Replaces useless `bun add` recovery hint in `cmd-update.ts` failure path with the actual curl recovery + manual eviction recipe.

Cuts as `v26.4.53-alpha.619` on merge.

## Why

Previous failure message advised `manual recovery: bun add -g github:#alpha` — the same command that just failed, useless to a user already stuck in the dep-loop (#950 family).

New message:

1. Points at the curl URL for the release binary (bypasses bun's resolver entirely — only works for release tags, noted explicitly in the message).
2. Falls back to the manual file-level eviction recipe for users whose ref isn't a tag (branches, SHAs, or release without binary asset).

One-line copy-pasteable curl command — triple-click + paste, no `\` continuations to fight with.

## Changes

- `src/cli/cmd-update.ts` — error block at `process.exit(installCode)` rewritten with three lines: header, curl command, fallback hint. ~6 LOC net.
- `test/isolated/cmd-update-order.test.ts` — replaces 1 existing test (which asserted the old `bun add` hint) with 2 new tests covering the curl URL pattern + the fallback eviction message.
- `package.json` — bump to `v26.4.53-alpha.619`.

## Test plan

- [x] `bun test test/isolated/cmd-update-order.test.ts` → all pass (8/8 → 9/9 with new assertions)
- [x] `bun test test/cli/` → 24/24 pass (no regression)
- [x] No `*.tmp` leaks (today's lesson)
- [x] No version conflict — bumped to `26.4.53-alpha.619` from alpha's `26.4.53-alpha.618` (post-#955 merge)

## Refs

- Follow-up to #952 (the dep-loop fix that landed today)
- Same family as #950 (the original dep-loop bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
