### PR TITLE
fix(cli): restore maw ls = cmdList not fleet ls (RFC #954 Q1 follow-up) → v26.4.53-alpha.628

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.53-alpha.619",
+  "version": "26.4.53-alpha.628",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -24,7 +24,13 @@ export const TOP_ALIASES: Record<string, string[] | DirectHandler> = {
   // Argv-rewrite form — canonical handler lives in a core plugin
   a: ["tmux", "attach"],
   attach: ["tmux", "attach"],
-  ls: ["fleet", "ls"],
+
+  // Direct-handler form — `ls` invokes the original cmdList in core
+  // (src/commands/shared/comm-list.ts). Pre-#918 the `ls` plugin was a
+  // thin shim around cmdList(); the plugin shell was extracted but cmdList
+  // itself remained in core, so we route directly to it. NOT `fleet ls`
+  // (which lists fleet configs — different concept). See PR #955.
+  ls: { kind: "direct", handler: "../commands/shared/comm-list:cmdList" },
 
   // Direct-handler form — cmdWake is in core (src/commands/shared/wake-cmd.ts)
   // even though the wake/ plugin was extracted to the registry in #918.
@@ -56,12 +62,14 @@ export function resolveTopAlias(args: string[]): AliasResolution | null {
 }
 
 /**
- * Invoke a direct-handler alias. Currently only `wake` uses this path.
+ * Invoke a direct-handler alias. Used by `wake` and `ls`.
  *
  * Handler spec format: "<relative-module-path>:<exportName>"
  *   e.g. "../commands/shared/wake-cmd:cmdWake"
  *
  * For `wake`, parses the 9 known flags and calls cmdWake(oracle, opts).
+ * For `ls`, calls cmdList() with no args (any extra argv is ignored —
+ * the original pre-#918 plugin took no args either).
  */
 export async function invokeDirectHandler(
   handler: string,
@@ -70,6 +78,19 @@ export async function invokeDirectHandler(
   const [modulePath, exportName] = handler.split(":");
   if (!modulePath || !exportName) {
     throw new Error(`top-alias: malformed handler spec '${handler}' — expected '<module>:<export>'`);
+  }
+
+  if (exportName === "cmdList") {
+    // Original `maw ls` (pre-#918) was a thin shim that called cmdList()
+    // with no args. Preserve that signature exactly — extra argv is dropped
+    // until/unless we add filtering.
+    const mod = await import(modulePath);
+    const fn = mod[exportName] as () => Promise<unknown>;
+    if (typeof fn !== "function") {
+      throw new Error(`top-alias: '${exportName}' not found in '${modulePath}'`);
+    }
+    await fn();
+    return;
   }
 
   if (exportName === "cmdWake") {

--- a/test/cli/dispatch-match.test.ts
+++ b/test/cli/dispatch-match.test.ts
@@ -157,11 +157,32 @@ describe("resolvePluginMatch — two-pass dispatch", () => {
 });
 
 describe("resolveTopAlias — RFC #954 verb aliases", () => {
-  test("`ls` → argv rewrite to ['fleet', 'ls']", () => {
+  test("`ls` → direct-handler form with cmdList handler (NOT fleet ls)", () => {
+    // PR #955 routed `ls` to `fleet ls`, but fleet ls lists fleet *configs*
+    // — a different concept than the original `maw ls` which listed live
+    // tmux sessions/oracles via cmdList(). Restore the original direct dispatch.
     const out = resolveTopAlias(["ls"]);
     expect(out).not.toBeNull();
-    expect(out!.kind).toBe("argv");
-    if (out!.kind === "argv") expect(out!.argv).toEqual(["fleet", "ls"]);
+    expect(out!.kind).toBe("direct");
+    if (out!.kind === "direct") {
+      expect(out!.handler).toContain("comm-list");
+      expect(out!.handler).toContain("cmdList");
+      // No positional args after the verb
+      expect(out!.argv).toEqual([]);
+    }
+  });
+
+  test("`ls foo` → direct-handler form, extra argv passed through (ignored by handler today)", () => {
+    // The handler currently drops argv (cmdList takes no args), but the
+    // resolver must still pass everything-after-the-verb so future filtering
+    // (e.g. `maw ls <name>` name search) can be added without re-routing.
+    const out = resolveTopAlias(["ls", "foo"]);
+    expect(out).not.toBeNull();
+    expect(out!.kind).toBe("direct");
+    if (out!.kind === "direct") {
+      expect(out!.handler).toContain("cmdList");
+      expect(out!.argv).toEqual(["foo"]);
+    }
   });
 
   test("`a neo` → argv rewrite to ['tmux', 'attach', 'neo']", () => {


### PR DESCRIPTION
## Summary

Restores the pre-#918 semantics of `maw ls`. PR #955 wired the alias as `argv-rewrite to fleet ls` — wrong surface entirely. This switches it to a direct handler calling `cmdList()` from `src/commands/shared/comm-list.ts` (the original implementation, vendored in core when the ls plugin was extracted in #918).

Cuts as `v26.4.53-alpha.628` on merge.

## Why the previous alias was wrong

| | Original `maw ls` (pre-#918) | PR #955's `maw ls` → `fleet ls` |
|---|---|---|
| Source | `cmdList()` in `src/commands/shared/comm-list.ts` | `cmdFleetLs()` in `src/commands/shared/fleet-manage.ts` |
| Surveys | Live tmux sessions + per-window agent indicators (green/blue/red dots) + orphan worktrees | Fleet config-file groupNames + running/stopped status |
| Use case | "scan running sessions to find an oracle by name" | "list configured fleet groups" |

User reported this regression: they were using `maw ls` to find oracles by name (scanning the live-session output), and the new `fleet ls` output doesn't show session names — just config groups. Two different surfaces.

## Changes

- `src/cli/top-aliases.ts` — `TOP_ALIASES.ls` switched from `["fleet","ls"]` to `{ kind: "direct", handler: "../commands/shared/comm-list:cmdList" }`. Added `cmdList` branch in `invokeDirectHandler` (mirrors the wake pattern). Argv passthrough wired (currently unused — cmdList takes no args; reserved for future name-filter support).
- `test/cli/dispatch-match.test.ts` — replaces the `["fleet","ls"]` argv-rewrite assertion with a direct-handler assertion. Added second test verifying argv preservation for future filtering.

## Test plan

- [x] `bun test test/cli/` → 25 pass / 0 fail
- [x] `bun test test/isolated/cmd-update-order.test.ts` → 9 pass / 0 fail (no regression)
- [x] No `*.tmp` leak
- [ ] Manual: `maw ls` shows live tmux sessions (post-merge / `maw update`)

## Refs

- #918 — extracted ls plugin
- #954 — RFC for top-level verb aliases (this is the Q1 follow-up)
- #955 — original RFC implementation that wired the wrong canonical

## Origin

Today's session — user pointed out post-#955 behavior didn't match pre-extraction. /team-agents archaeologist confirmed: cmdList still in core, registry plugin byte-identical to extracted code, name-search never existed (user's mental model is "scan for the name in the live-session output"). Inline restore was the right move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)