### PR TITLE
fix(plugins): inline whoami logic into session/ to fix dangling import (closes #953)

### DIFF
--- a/src/commands/plugins/session/index.ts
+++ b/src/commands/plugins/session/index.ts
@@ -1,5 +1,46 @@
-import whoamiHandler from "../whoami/index";
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { hostExec } from "../../../sdk";
+import { UserError } from "../../../core/util/user-error";
 
-export const command = { name: "session", description: "Alias for `maw whoami` — print the current tmux session name." };
+export const command = {
+  name: "session",
+  description: "Print the current tmux session name (alias of former `maw whoami`).",
+};
 
-export default whoamiHandler;
+/**
+ * Inlined from the former `whoami/` plugin (extracted to registry in #936).
+ * `session/` and `whoami/` were always 1:1 aliases — fix #953 inlines the
+ * five-line impl here so `session/` no longer dangles on the deleted module.
+ *
+ * Behavior preserved:
+ *   - Requires an active tmux ($TMUX). Otherwise throws UserError.
+ *   - Runs `tmux display-message -p '#S'` via hostExec, prints trimmed.
+ *   - Output is captured via ctx.writer (CLI stream) or logs[] (api/peer).
+ */
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log, origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  try {
+    if (!process.env.TMUX) {
+      throw new UserError(
+        "maw session requires an active tmux session — run 'maw wake <oracle>' or attach to tmux first",
+      );
+    }
+    const raw = await hostExec(`tmux display-message -p '#S'`);
+    console.log(raw.trim());
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/test/isolated/session-whoami-inline.test.ts
+++ b/test/isolated/session-whoami-inline.test.ts
@@ -1,0 +1,85 @@
+/**
+ * test/isolated/session-whoami-inline.test.ts
+ *
+ * Regression test for #953: `maw session` errored with
+ *   ResolveMessage: Cannot find module '../whoami/index'
+ * because session/index.ts re-exported the deleted whoami/ plugin
+ * (extracted to registry in #936).
+ *
+ * After the fix, session/index.ts inlines the ~5-line whoami impl.
+ * This test pins:
+ *   1. The module imports without throwing (catches future dangling imports).
+ *   2. The handler returns ok with non-empty output when TMUX is set.
+ *   3. The handler returns a UserError-shaped failure when TMUX is unset.
+ *
+ * Isolated because mock.module on src/core/transport/ssh is process-global.
+ */
+import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
+import { mockSshModule } from "../helpers/mock-ssh";
+
+// Stub hostExec so the test never shells out to a real tmux.
+let lastCmd = "";
+const fakeSession = "oracle-session-953";
+mock.module("../../src/core/transport/ssh", () =>
+  mockSshModule({
+    hostExec: async (cmd: string) => {
+      lastCmd = cmd;
+      // tmux display-message -p '#S' returns the session name with a trailing newline.
+      return `${fakeSession}\n`;
+    },
+  }),
+);
+
+describe("session/ inlined whoami (fix #953)", () => {
+  let savedTmux: string | undefined;
+  let savedTmuxPane: string | undefined;
+
+  beforeEach(() => {
+    savedTmux = process.env.TMUX;
+    savedTmuxPane = process.env.TMUX_PANE;
+    lastCmd = "";
+  });
+
+  afterEach(() => {
+    if (savedTmux === undefined) delete process.env.TMUX;
+    else process.env.TMUX = savedTmux;
+    if (savedTmuxPane === undefined) delete process.env.TMUX_PANE;
+    else process.env.TMUX_PANE = savedTmuxPane;
+  });
+
+  test("module imports without throwing (no dangling whoami import)", async () => {
+    const mod = await import("../../src/commands/plugins/session/index");
+    expect(mod.command).toBeDefined();
+    expect(mod.command.name).toBe("session");
+    expect(typeof mod.default).toBe("function");
+  });
+
+  test("handler returns non-empty session name when TMUX is set", async () => {
+    process.env.TMUX = "/tmp/tmux-1000/default,1234,5";
+    process.env.TMUX_PANE = "%42";
+
+    const { default: handler } = await import("../../src/commands/plugins/session/index");
+    const result = await handler({ source: "api", args: [] });
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toBeDefined();
+    expect((result.output ?? "").length).toBeGreaterThan(0);
+    expect(result.output).toContain(fakeSession);
+    // It should have shelled out via tmux display-message — proving we're
+    // running the inlined impl, not a stub.
+    expect(lastCmd).toContain("tmux display-message");
+    expect(lastCmd).toContain("#S");
+  });
+
+  test("handler fails cleanly when TMUX is unset (UserError path)", async () => {
+    delete process.env.TMUX;
+    delete process.env.TMUX_PANE;
+
+    const { default: handler } = await import("../../src/commands/plugins/session/index");
+    const result = await handler({ source: "api", args: [] });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error).toContain("tmux");
+  });
+});


### PR DESCRIPTION
## Bug

`maw session` errored with:

```
ResolveMessage: Cannot find module '../whoami/index'
```

`src/commands/plugins/session/index.ts` re-exported `whoamiHandler` from
`../whoami/index`, but the `whoami/` plugin was extracted to the registry
in #936 (commit 32bd1604, Phase-2 lean-core prune). The dangling import
was silent at startup — only `maw session` invocations triggered the
resolve and crashed.

## Fix (Option 2: inline)

Inlined the ~5-line `whoami` impl directly into `session/index.ts`,
preserving the original behavior:

- Requires an active tmux (`process.env.TMUX`) — otherwise throws
  `UserError` with the canonical "run `maw wake <oracle>` or attach to
  tmux first" hint.
- Runs `tmux display-message -p '#S'` via `hostExec` from the SDK
  (no manual shell-out, no new dependencies).
- Output captured via `ctx.writer` (CLI stream) or `logs[]` fallback
  (api/peer source) — same shape as the original handler.
- Export contract preserved: `command` named export + default handler.

`session/` is now standalone — no `import.*whoami` anywhere. The
extracted `whoami/` plugin in the registry is untouched and unaffected.

## Test plan

Added `test/isolated/session-whoami-inline.test.ts` with three checks:

- [x] Module imports without throwing (catches future dangling imports).
- [x] Handler returns `ok: true` with non-empty session name when `TMUX`
  is set — verifies the inlined impl actually runs `tmux display-message`
  via `hostExec` (mocked).
- [x] Handler returns `ok: false` with a tmux-shaped error when `TMUX`
  is unset — pins the `UserError` path.

Test placed under `test/isolated/` because `mock.module` on
`src/core/transport/ssh` is process-global (consistent with sibling
isolated tests).

### Suite results

```
bun test test/isolated/session-whoami-inline.test.ts
 3 pass / 0 fail / 12 expect() calls
```

Full suite delta vs `origin/alpha` baseline:
- Pass: 2159 → 2164 (+5)
- Fail: 375 → 372 (-3)
- No new failures introduced; remaining failures are pre-existing on
  alpha and unrelated to this fix.

## Constraints respected

- No `package.json` bump (code-fix only — release cut is a separate
  gesture).
- No re-introduction of an in-tree `whoami/` plugin (it lives in the
  registry now).
- No coupling re-introduced: zero `import.*whoami` in tree.

Closes #953
