### PR TITLE
release: v26.4.53-alpha.706

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.53-alpha.628",
+  "version": "26.4.53-alpha.706",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts `v26.4.53-alpha.706` on merge via `calver-release.yml`.

## What ships

Bumps over `v26.4.53-alpha.628`:

| # | Title |
|---|---|
| #959 | fix(plugins): inline whoami logic into session/ to fix dangling import (closes #953) |
| #960 | fix(cli): maw ls no longer creates orphan tmux view sessions (closes #957) |

## Test plan

- [x] CI green on both source PRs (#959 + #960) before merge to alpha
- [x] No package.json bump on the source PRs (release-cut is the deliberate gesture)
- [x] Branched off origin/alpha tip (6b0b731f)
- [ ] CI green on this release PR
- [ ] After merge: `calver-release.yml` cuts the tag + builds dist/maw
- [ ] Cross-machine verify: `maw update alpha` on mba/m5 pulls v26.4.53-alpha.706
- [ ] Verify on m5: `maw session` no longer errors (#953 fixed) + `maw ls` doesn't show duplicate `*-view-diag` entries (#957 fixed)

🤖 Cut via /release-alpha
