### PR TITLE
fix(tmux): real exec for maw a/attach instead of print-only

### DIFF
--- a/src/commands/plugins/tmux/impl.ts
+++ b/src/commands/plugins/tmux/impl.ts
@@ -362,25 +362,52 @@ export async function cmdTmuxLayout(target: string, preset: string): Promise<voi
   console.log(`\x1b[32m✓\x1b[0m layout ${preset} applied to ${target} → ${window} \x1b[90m[${source}]\x1b[0m`);
 }
 
+export interface TmuxAttachOpts {
+  /** Force print-only mode (no exec) regardless of TTY/$TMUX state. */
+  print?: boolean;
+}
+
 /**
- * Print the tmux attach command for the user to exec themselves.
+ * Attach to a tmux session.
  *
- * We can't `exec tmux attach` from a Bun subprocess because attach is
- * TTY-interactive and our process is the wrong process to attach. Instead
- * we resolve the target and print the exact command — the user runs it.
+ * Branch behavior (issue #962, fix for #395 print-only regression):
+ *   - Inside tmux ($TMUX set) + TTY → `tmux switch-client -t <session>`
+ *   - Outside tmux + TTY            → `tmux attach -t <session>`
+ *   - No TTY (script/pipe/CI)       → fall back to 3-line print (don't break automation)
+ *   - Explicit --print              → force print mode regardless of TTY
  *
- * This matches `maw team spawn`'s pattern (Bug C philosophy): prepare,
- * print, let the operator run the interactive part.
+ * Pre-#962 this was print-only (since #395, 2026-04-17). RFC #954's `a`
+ * alias surfaced the regression — operators expected `maw a foo` to attach,
+ * not just print instructions.
  */
-export function cmdTmuxAttach(target: string): void {
+export function cmdTmuxAttach(target: string, opts: TmuxAttachOpts = {}): void {
   const hit = resolveTmuxTarget(target);
   if (!hit) throw new Error(`cannot resolve target '${target}'`);
   const { resolved, source } = hit;
   const session = resolved.split(":")[0] ?? "";
 
-  console.log(`\x1b[36mRun:\x1b[0m tmux attach -t ${session}`);
-  console.log(`\x1b[90m  resolved: ${target} → ${session} [${source}]`);
-  console.log(`  detach with: Ctrl-b d\x1b[0m`);
+  const isTty = !!process.stdout.isTTY;
+  const inTmux = !!process.env.TMUX;
+
+  if (opts.print || !isTty) {
+    console.log(`\x1b[36mRun:\x1b[0m tmux attach -t ${session}`);
+    console.log(`\x1b[90m  resolved: ${target} → ${session} [${source}]`);
+    console.log(`  detach with: Ctrl-b d\x1b[0m`);
+    return;
+  }
+
+  const tmuxArgs = inTmux
+    ? ["switch-client", "-t", session]
+    : ["attach", "-t", session];
+  const verb = inTmux ? "switch-client" : "attach";
+
+  const result = Bun.spawnSync(["tmux", ...tmuxArgs], {
+    stdio: ["inherit", "inherit", "inherit"],
+  });
+
+  if (result.exitCode !== 0) {
+    throw new Error(`tmux ${verb} failed (exit ${result.exitCode}) for session '${session}' [${source}]`);
+  }
 }
 
 /**

--- a/src/commands/plugins/tmux/index.ts
+++ b/src/commands/plugins/tmux/index.ts
@@ -147,18 +147,22 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       }
       await cmdTmuxLayout(target, preset);
     } else if (sub === "attach") {
-      const flags = parseFlags(args, { "--help": Boolean, "-h": "--help" }, 1);
+      const flags = parseFlags(args, {
+        "--print": Boolean,
+        "--help": Boolean, "-h": "--help",
+      }, 1);
       if (flags["--help"]) {
-        console.log("usage: maw tmux attach <target>");
-        console.log("  prints the tmux attach command for you to run (TTY required).");
+        console.log("usage: maw tmux attach <target> [--print]");
+        console.log("  default: exec `tmux attach` (or `switch-client` inside $TMUX) when on a TTY.");
+        console.log("  --print: print the tmux command instead of exec'ing (auto-on without a TTY).");
         return { ok: true, output: logs.join("\n") || undefined };
       }
       const target = flags._[0];
       if (!target) {
-        console.log("usage: maw tmux attach <target>");
+        console.log("usage: maw tmux attach <target> [--print]");
         return { ok: false, error: "target required", output: logs.join("\n") };
       }
-      cmdTmuxAttach(target);
+      cmdTmuxAttach(target, { print: !!flags["--print"] });
     } else if (!sub || sub === "--help" || sub === "-h") {
       console.log("usage: maw tmux <ls|peek|send|split|kill|layout|attach> [args]");
       console.log("  ls [--all]              list panes with fleet + team annotations");
@@ -167,7 +171,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       console.log("  split <target>          split a pane (--vertical, --pct, --cmd)");
       console.log("  kill <target>           kill a pane or --session (fleet-safe)");
       console.log("  layout <target> <preset> apply a tmux layout preset");
-      console.log("  attach <target>         print tmux attach command (TTY required)");
+      console.log("  attach <target> [--print] attach to a tmux session (--print to skip exec)");
       return { ok: true, output: logs.join("\n") || undefined };
     } else {
       console.log(`unknown tmux subcommand: ${sub}`);

--- a/test/isolated/tmux-action-verbs.test.ts
+++ b/test/isolated/tmux-action-verbs.test.ts
@@ -40,22 +40,89 @@ describe("cmdTmuxSplit — pct bounds", () => {
   });
 });
 
-describe("cmdTmuxAttach — pure resolution + print", () => {
-  test("resolves and prints attach command (no side effects)", () => {
+describe("cmdTmuxAttach — print fallback (no TTY / --print)", () => {
+  test("--print resolves and prints attach command (no exec)", () => {
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...a: any[]) => logs.push(a.map(String).join(" "));
+    const calls: any[] = [];
+    const origSpawnSync = Bun.spawnSync;
+    (Bun as any).spawnSync = ((args: any, opts: any) => {
+      calls.push({ args, opts });
+      return { exitCode: 0, stdout: new Uint8Array(), stderr: new Uint8Array(), success: true };
+    });
+    try {
+      cmdTmuxAttach("%999", { print: true });
+    } finally {
+      console.log = origLog;
+      (Bun as any).spawnSync = origSpawnSync;
+    }
+    expect(calls).toHaveLength(0); // --print → never spawns
+    const joined = logs.join("\n");
+    expect(joined).toContain("tmux attach -t");
+    expect(joined).toContain("Ctrl-b d");
+  });
+
+  test("session-name target with --print → extracts session", () => {
     const logs: string[] = [];
     const origLog = console.log;
     console.log = (...a: any[]) => logs.push(a.map(String).join(" "));
     try {
-      cmdTmuxAttach("%999"); // pane id form, no resolution dependency
+      cmdTmuxAttach("some-session:0.1", { print: true });
     } finally {
       console.log = origLog;
     }
-    const joined = logs.join("\n");
-    expect(joined).toContain("tmux attach -t");
-    expect(joined).toContain("Ctrl-b d"); // detach instructions
+    expect(logs.join("\n")).toContain("tmux attach -t some-session");
   });
 
-  test("session-name target → extracts session for attach", () => {
+  test("no TTY (and no --print) → falls back to 3-line print, no spawn", () => {
+    // Simulate non-TTY environment (script / pipe / CI). Bun's test runner
+    // typically already has isTTY=undefined, but force it to be safe.
+    const origIsTty = process.stdout.isTTY;
+    Object.defineProperty(process.stdout, "isTTY", { value: false, configurable: true });
+    const origTmux = process.env.TMUX;
+    delete process.env.TMUX;
+
+    const calls: any[] = [];
+    const origSpawnSync = Bun.spawnSync;
+    (Bun as any).spawnSync = ((args: any, opts: any) => {
+      calls.push({ args, opts });
+      return { exitCode: 0, stdout: new Uint8Array(), stderr: new Uint8Array(), success: true };
+    });
+
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...a: any[]) => logs.push(a.map(String).join(" "));
+    try {
+      cmdTmuxAttach("%999"); // no opts → relies on TTY/$TMUX detection
+    } finally {
+      console.log = origLog;
+      (Bun as any).spawnSync = origSpawnSync;
+      Object.defineProperty(process.stdout, "isTTY", { value: origIsTty, configurable: true });
+      if (origTmux !== undefined) process.env.TMUX = origTmux;
+    }
+
+    expect(calls).toHaveLength(0); // no TTY → never spawns
+    const joined = logs.join("\n");
+    expect(joined).toContain("tmux attach -t");
+    expect(joined).toContain("Ctrl-b d");
+  });
+});
+
+describe("cmdTmuxAttach — TTY exec branches", () => {
+  test("inside tmux + TTY → spawns `tmux switch-client -t <session>`", () => {
+    const origIsTty = process.stdout.isTTY;
+    Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+    const origTmux = process.env.TMUX;
+    process.env.TMUX = "/tmp/tmux-1000/default,1234,0";
+
+    const calls: any[] = [];
+    const origSpawnSync = Bun.spawnSync;
+    (Bun as any).spawnSync = ((args: any, opts: any) => {
+      calls.push({ args, opts });
+      return { exitCode: 0, stdout: new Uint8Array(), stderr: new Uint8Array(), success: true };
+    });
+
     const logs: string[] = [];
     const origLog = console.log;
     console.log = (...a: any[]) => logs.push(a.map(String).join(" "));
@@ -63,7 +130,92 @@ describe("cmdTmuxAttach — pure resolution + print", () => {
       cmdTmuxAttach("some-session:0.1");
     } finally {
       console.log = origLog;
+      (Bun as any).spawnSync = origSpawnSync;
+      Object.defineProperty(process.stdout, "isTTY", { value: origIsTty, configurable: true });
+      if (origTmux !== undefined) process.env.TMUX = origTmux;
+      else delete process.env.TMUX;
     }
-    expect(logs.join("\n")).toContain("tmux attach -t some-session");
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args).toEqual(["tmux", "switch-client", "-t", "some-session"]);
+    // No 3-line print under exec path — output is whatever tmux emits via stdio:inherit
+    expect(logs.join("\n")).not.toContain("Run: tmux attach -t");
+  });
+
+  test("outside tmux + TTY → spawns `tmux attach -t <session>`", () => {
+    const origIsTty = process.stdout.isTTY;
+    Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+    const origTmux = process.env.TMUX;
+    delete process.env.TMUX;
+
+    const calls: any[] = [];
+    const origSpawnSync = Bun.spawnSync;
+    (Bun as any).spawnSync = ((args: any, opts: any) => {
+      calls.push({ args, opts });
+      return { exitCode: 0, stdout: new Uint8Array(), stderr: new Uint8Array(), success: true };
+    });
+
+    try {
+      cmdTmuxAttach("some-session:0.1");
+    } finally {
+      (Bun as any).spawnSync = origSpawnSync;
+      Object.defineProperty(process.stdout, "isTTY", { value: origIsTty, configurable: true });
+      if (origTmux !== undefined) process.env.TMUX = origTmux;
+    }
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args).toEqual(["tmux", "attach", "-t", "some-session"]);
+  });
+
+  test("non-zero exit → throws with exit code + verb", () => {
+    const origIsTty = process.stdout.isTTY;
+    Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+    const origTmux = process.env.TMUX;
+    delete process.env.TMUX;
+
+    const origSpawnSync = Bun.spawnSync;
+    (Bun as any).spawnSync = (() => ({
+      exitCode: 1,
+      stdout: new Uint8Array(),
+      stderr: new Uint8Array(),
+      success: false,
+    }));
+
+    try {
+      expect(() => cmdTmuxAttach("ghost-session")).toThrow(/tmux attach failed.*exit 1/);
+    } finally {
+      (Bun as any).spawnSync = origSpawnSync;
+      Object.defineProperty(process.stdout, "isTTY", { value: origIsTty, configurable: true });
+      if (origTmux !== undefined) process.env.TMUX = origTmux;
+    }
+  });
+
+  test("--print overrides TTY detection — never spawns even in interactive shell", () => {
+    const origIsTty = process.stdout.isTTY;
+    Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+    const origTmux = process.env.TMUX;
+    delete process.env.TMUX;
+
+    const calls: any[] = [];
+    const origSpawnSync = Bun.spawnSync;
+    (Bun as any).spawnSync = ((args: any, opts: any) => {
+      calls.push({ args, opts });
+      return { exitCode: 0, stdout: new Uint8Array(), stderr: new Uint8Array(), success: true };
+    });
+
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...a: any[]) => logs.push(a.map(String).join(" "));
+    try {
+      cmdTmuxAttach("%999", { print: true });
+    } finally {
+      console.log = origLog;
+      (Bun as any).spawnSync = origSpawnSync;
+      Object.defineProperty(process.stdout, "isTTY", { value: origIsTty, configurable: true });
+      if (origTmux !== undefined) process.env.TMUX = origTmux;
+    }
+
+    expect(calls).toHaveLength(0);
+    expect(logs.join("\n")).toContain("tmux attach -t");
   });
 });


### PR DESCRIPTION
## Summary

Fix #962 — `maw a <name>`, `maw attach <name>`, and `maw tmux attach <name>` now actually attach to the tmux session instead of printing 3 lines and exiting.

## Bug

Since #395 (2026-04-17) `cmdTmuxAttach()` only `console.log`'d a "Run: tmux attach -t <session>" instruction. RFC #954's new `a` alias surfaced the regression — operators expected `maw a foo` to drop them into the session, not lecture them on what to type.

```
$ maw a mawjs
Run: tmux attach -t mawjs
  resolved: mawjs → mawjs [session-name (pane 0)]
  detach with: Ctrl-b d
$    # ← shell still here, never attached
```

## Root cause

`src/commands/plugins/tmux/impl.ts:375-384` `cmdTmuxAttach()` had three `console.log` calls and no exec — a deliberate "prepare, print, let the operator run" pattern from #395 that misjudged operator expectations.

## Fix

`cmdTmuxAttach()` now branches on TTY + `$TMUX`:

| Context                          | Action                                  |
| -------------------------------- | --------------------------------------- |
| Inside tmux (`$TMUX` set) + TTY  | `tmux switch-client -t <session>`       |
| Outside tmux + TTY               | `tmux attach -t <session>`              |
| No TTY (script / pipe / CI)      | Fall back to 3-line print (preserve automation contract) |
| Explicit `--print` flag          | Force print mode regardless of TTY      |

Implemented via `Bun.spawnSync(["tmux", ...args], { stdio: ["inherit", "inherit", "inherit"] })` so the parent process keeps a live TTY through to tmux. Non-zero exit propagates as a thrown error.

The dispatch entry in `src/commands/plugins/tmux/index.ts` now parses `--print` and forwards it as `{ print }` opts.

## Test plan

`test/isolated/tmux-action-verbs.test.ts` extended with 5 new cases (8 total in the attach describe blocks). Mocks `Bun.spawnSync`, `process.stdout.isTTY`, and `process.env.TMUX`:

- [x] `--print` set → `spawnSync` not called, 3 print lines emitted
- [x] `--print` set with session-name target → session extracted correctly
- [x] no TTY (no `--print`) → `spawnSync` not called, 3 print lines emitted
- [x] inside tmux + TTY → `spawnSync` called with `["tmux", "switch-client", "-t", <session>]`
- [x] outside tmux + TTY → `spawnSync` called with `["tmux", "attach", "-t", <session>]`
- [x] non-zero exit code → throws with verb + exit code in message
- [x] `--print` overrides TTY detection — never spawns even on interactive TTY

Run:
- `MAW_TEST_MODE=1 bun test test/isolated/tmux-action-verbs.test.ts` → 13 pass / 0 fail
- All isolated tmux suites (`tmux*.test.ts`) → 116 pass / 0 fail
- `bash scripts/test-isolated.sh` → 77/78 files pass; the 1 failure (`oracle-manifest.test.ts`) is pre-existing on `alpha` and unrelated.
