### PR TITLE
fix(cli): maw ls — wire --fix flag + suppress preamble noise on read-only verbs

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -81,15 +81,20 @@ export async function invokeDirectHandler(
   }
 
   if (exportName === "cmdList") {
-    // Original `maw ls` (pre-#918) was a thin shim that called cmdList()
-    // with no args. Preserve that signature exactly — extra argv is dropped
-    // until/unless we add filtering.
+    // Thread known flags through to cmdList. Currently:
+    //   --fix   prune orphaned worktrees after listing (#4 / FIX-A).
+    // Other argv is still dropped — cmdList has no positional filtering yet.
+    const { parseFlags } = await import("./parse-args");
+    const flags = parseFlags(argv, { "--fix": Boolean }, 0);
+    const opts: { fix?: boolean } = {};
+    if (flags["--fix"]) opts.fix = true;
+
     const mod = await import(modulePath);
-    const fn = mod[exportName] as () => Promise<unknown>;
+    const fn = mod[exportName] as (opts?: { fix?: boolean }) => Promise<unknown>;
     if (typeof fn !== "function") {
       throw new Error(`top-alias: '${exportName}' not found in '${modulePath}'`);
     }
-    await fn();
+    await fn(opts);
     return;
   }
 

--- a/src/cli/verbosity.ts
+++ b/src/cli/verbosity.ts
@@ -35,6 +35,18 @@ export function isSilent(): boolean {
   return process.env.MAW_SILENT === "1";
 }
 
+/**
+ * Top-alias verbs (RFC #954) that are read-only and don't shell out to a
+ * plugin. Suppress the bootstrap preamble (`loaded config: …`,
+ * `loaded N plugins (…)`) for these — chatter pollutes their output and
+ * users perceive the verbosity as breakage. See FIX-A / task #4.
+ *
+ * Kept here (not in top-aliases.ts) because isQuiet() runs from import-time
+ * side-effects in load.ts / registry.ts, well before cli.ts can call
+ * setVerbosityFlags(). Mirroring the help/version guard's structure.
+ */
+const QUIET_TOP_ALIASES = new Set(["ls", "a", "attach", "wake"]);
+
 export function isQuiet(): boolean {
   // --silent implies --quiet
   if (isSilent()) return true;
@@ -45,9 +57,19 @@ export function isQuiet(): boolean {
   // lines fire from import-time side-effects (e.g. ssh.ts top-level
   // loadConfig()) before cli.ts can call setVerbosityFlags(). Covers nested
   // forms too — `maw oracle scan --help` etc.
-  return process.argv.some(
-    a => a === "--help" || a === "-h" || a === "--version" || a === "-v",
-  );
+  if (
+    process.argv.some(
+      a => a === "--help" || a === "-h" || a === "--version" || a === "-v",
+    )
+  ) return true;
+  // FIX-A — top-alias verbs (ls, a, attach, wake) are read-only and don't
+  // need plugin-loading narration. cli.ts builds args via
+  // `process.argv.slice(2)` then takes args[0] as the verb, so mirror that
+  // shape here. We deliberately check ONLY argv[2] (not `.some()`) so flag
+  // values like `--as ls` don't false-positive.
+  const verb = process.argv[2]?.toLowerCase();
+  if (verb && QUIET_TOP_ALIASES.has(verb)) return true;
+  return false;
 }
 
 export function verbose(fn: () => void): void {

--- a/src/commands/shared/comm-list.ts
+++ b/src/commands/shared/comm-list.ts
@@ -9,7 +9,7 @@
  * Regression test: test/isolated/cmd-list-no-new-session-957.test.ts.
  */
 
-import { listSessions, getPaneInfos, scanWorktrees } from "../../sdk";
+import { listSessions, getPaneInfos, scanWorktrees, cleanupWorktree } from "../../sdk";
 
 /**
  * #359 — render a session header line for `maw ls`.
@@ -36,7 +36,15 @@ function isViewDiag(name: string): boolean {
   return /-view-diag$/.test(name);
 }
 
-export async function cmdList() {
+/**
+ * `maw ls` — list active oracle sessions and orphaned worktrees.
+ *
+ * @param opts.fix  When true, after listing, prune any orphaned/stale
+ *                  worktrees via cleanupWorktree() and print a summary.
+ *                  Threaded from the alias-dispatch path
+ *                  (src/cli/top-aliases.ts → invokeDirectHandler).
+ */
+export async function cmdList(opts: { fix?: boolean } = {}) {
   const rawSessions = await listSessions();
   const sessions = rawSessions.filter(s => !isViewDiag(s.name));
 
@@ -85,7 +93,9 @@ export async function cmdList() {
         console.log(`  \x1b[33m⚠ orphaned:\x1b[0m ${dirName} \x1b[90m(${label})\x1b[0m`);
       }
       console.log("");
-      console.log(`\x1b[90m  → maw ls --fix       to prune orphans\x1b[0m`);
+      if (!opts.fix) {
+        console.log(`\x1b[90m  → maw ls --fix       to prune orphans\x1b[0m`);
+      }
     }
   } catch (e: any) {
     // Don't crash maw ls on scan failure (non-critical) — but surface the error in debug mode
@@ -99,5 +109,31 @@ export async function cmdList() {
     console.log("\x1b[90mNo active sessions.\x1b[0m");
     console.log("\x1b[90m  → maw bud <name>     create new oracle\x1b[0m");
     console.log("\x1b[90m  → maw wake <name>    attach existing\x1b[0m");
+  }
+
+  // --fix — prune orphans we just listed. Calls cleanupWorktree() per
+  // entry; same surface that `maw fleet` flows already use, so behavior
+  // matches user expectations from existing maintenance commands.
+  // Read-only contract above is preserved when --fix is absent (default).
+  if (opts.fix && orphans.length > 0) {
+    console.log("");
+    console.log(`\x1b[36m→ pruning ${orphans.length} orphan${orphans.length === 1 ? "" : "s"}…\x1b[0m`);
+    let pruned = 0;
+    for (const wt of orphans) {
+      const dirName = wt.path.split("/").pop() || wt.name;
+      try {
+        const log = await cleanupWorktree(wt.path);
+        console.log(`  \x1b[32m✓\x1b[0m ${dirName}`);
+        for (const line of log) console.log(`    \x1b[90m${line}\x1b[0m`);
+        pruned++;
+      } catch (e: any) {
+        console.log(`  \x1b[31m✗\x1b[0m ${dirName} \x1b[90m(${e?.message || e})\x1b[0m`);
+      }
+    }
+    console.log("");
+    console.log(`\x1b[90m  pruned ${pruned}/${orphans.length}\x1b[0m`);
+  } else if (opts.fix && orphans.length === 0) {
+    console.log("");
+    console.log(`\x1b[90m  → nothing to prune\x1b[0m`);
   }
 }

--- a/test/cli/dispatch-match.test.ts
+++ b/test/cli/dispatch-match.test.ts
@@ -185,6 +185,20 @@ describe("resolveTopAlias — RFC #954 verb aliases", () => {
     }
   });
 
+  test("`ls --fix` → direct-handler form with --fix in argv (FIX-A: dispatch must not drop flag)", () => {
+    // Regression for the bug where invokeDirectHandler called cmdList() with
+    // no args, silently dropping `--fix` even though comm-list.ts:88 advertised
+    // it. The resolver must surface the flag so invokeDirectHandler can
+    // parse and forward it to cmdList({ fix: true }).
+    const out = resolveTopAlias(["ls", "--fix"]);
+    expect(out).not.toBeNull();
+    expect(out!.kind).toBe("direct");
+    if (out!.kind === "direct") {
+      expect(out!.handler).toContain("cmdList");
+      expect(out!.argv).toEqual(["--fix"]);
+    }
+  });
+
   test("`a neo` → argv rewrite to ['tmux', 'attach', 'neo']", () => {
     const out = resolveTopAlias(["a", "neo"]);
     expect(out).not.toBeNull();

--- a/test/cli/verbosity.test.ts
+++ b/test/cli/verbosity.test.ts
@@ -16,10 +16,18 @@ import {
 } from "../../src/cli/verbosity";
 
 describe("verbosity", () => {
+  // process.argv is mutated by some tests below; snapshot + restore.
+  const origArgv = process.argv;
+
   beforeEach(() => {
     setVerbosityFlags({});
     delete process.env.MAW_QUIET;
     delete process.env.MAW_SILENT;
+    process.argv = [...origArgv];
+  });
+
+  afterEach(() => {
+    process.argv = origArgv;
   });
 
   test("default: no flag, no env → neither quiet nor silent", () => {
@@ -55,6 +63,55 @@ describe("verbosity", () => {
     setVerbosityFlags({ quiet: false, silent: true });
     expect(isSilent()).toBe(true);
     expect(isQuiet()).toBe(true);
+  });
+
+  // ---------------------------------------------------------------------------
+  // FIX-A — top-alias verbs (ls / a / attach / wake) suppress bootstrap chatter.
+  // These verbs are read-only and don't need plugin-loading narration.
+  // ---------------------------------------------------------------------------
+
+  describe("top-alias verb suppression (FIX-A)", () => {
+    test("`maw ls` → quiet (suppress 'loaded config:' / 'loaded N plugins')", () => {
+      process.argv = ["bun", "/path/to/cli.ts", "ls"];
+      expect(isQuiet()).toBe(true);
+    });
+
+    test("`maw ls --fix` → still quiet (verb position is what matters)", () => {
+      process.argv = ["bun", "/path/to/cli.ts", "ls", "--fix"];
+      expect(isQuiet()).toBe(true);
+    });
+
+    test("`maw a <name>` → quiet", () => {
+      process.argv = ["bun", "/path/to/cli.ts", "a", "neo"];
+      expect(isQuiet()).toBe(true);
+    });
+
+    test("`maw attach <name>` → quiet", () => {
+      process.argv = ["bun", "/path/to/cli.ts", "attach", "neo"];
+      expect(isQuiet()).toBe(true);
+    });
+
+    test("`maw wake <name>` → quiet (cmdWake is direct-handler, no plugin shell-out)", () => {
+      process.argv = ["bun", "/path/to/cli.ts", "wake", "neo"];
+      expect(isQuiet()).toBe(true);
+    });
+
+    test("`maw bud --as ls` → NOT quiet (positional check at argv[2], not .some)", () => {
+      // Regression guard: an `--as ls` value buried later in argv must not
+      // false-positive into the suppression path.
+      process.argv = ["bun", "/path/to/cli.ts", "bud", "--as", "ls"];
+      expect(isQuiet()).toBe(false);
+    });
+
+    test("`maw fleet status` → NOT quiet (non-alias verb)", () => {
+      process.argv = ["bun", "/path/to/cli.ts", "fleet", "status"];
+      expect(isQuiet()).toBe(false);
+    });
+
+    test("verb is case-insensitive (LS == ls)", () => {
+      process.argv = ["bun", "/path/to/cli.ts", "LS"];
+      expect(isQuiet()).toBe(true);
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/test/isolated/comm-list.test.ts
+++ b/test/isolated/comm-list.test.ts
@@ -62,6 +62,7 @@ const realResolveTarget = _rSdk.resolveTarget;
 // scanWorktrees is re-exported through src/sdk but typed loosely here
 // because the type only ships at compile time; any() the shape we need.
 const realScanWorktrees = (_rSdk as unknown as { scanWorktrees: (...a: unknown[]) => unknown }).scanWorktrees;
+const realCleanupWorktree = (_rSdk as unknown as { cleanupWorktree: (...a: unknown[]) => unknown }).cleanupWorktree;
 
 const _rConfig = await import("../../src/config");
 const realLoadConfig = _rConfig.loadConfig;
@@ -93,6 +94,9 @@ let findPeerForTargetReturn: string | null = null;
 let resolveTargetReturn: unknown = null;
 let scanWorktreesReturn: unknown[] = [];
 let scanWorktreesThrows: string | null = null;
+let cleanupWorktreeCalls: string[] = [];
+let cleanupWorktreeThrows: Record<string, string> = {};
+let cleanupWorktreeLog: Record<string, string[]> = {};
 
 let configOverride: Record<string, unknown> = {};
 let cfgLimitMap: Record<string, number> = {};
@@ -181,6 +185,13 @@ mock.module(
       if (!mockActive) return (realScanWorktrees as (...a: unknown[]) => Promise<unknown[]>)(...args);
       if (scanWorktreesThrows) throw new Error(scanWorktreesThrows);
       return scanWorktreesReturn;
+    },
+    cleanupWorktree: async (...args: unknown[]) => {
+      if (!mockActive) return (realCleanupWorktree as (...a: unknown[]) => Promise<unknown>)(...args);
+      const [path] = args as [string];
+      cleanupWorktreeCalls.push(path);
+      if (cleanupWorktreeThrows[path]) throw new Error(cleanupWorktreeThrows[path]);
+      return cleanupWorktreeLog[path] ?? [`removed ${path}`];
     },
   }),
 );
@@ -304,6 +315,9 @@ beforeEach(() => {
   resolveTargetReturn = null;
   scanWorktreesReturn = [];
   scanWorktreesThrows = null;
+  cleanupWorktreeCalls = [];
+  cleanupWorktreeThrows = {};
+  cleanupWorktreeLog = {};
   configOverride = {};
   cfgLimitMap = {};
   logMessageCalls = [];
@@ -581,6 +595,77 @@ describe("cmdList — orphan detection", () => {
 
     expect(outs.some((o) => o.includes("⚠ orphaned:"))).toBe(false);
     expect(outs.some((o) => o.includes("→ maw ls --fix"))).toBe(false);
+  });
+});
+
+describe("cmdList — --fix prune (FIX-A)", () => {
+  test("opts.fix=true with orphans → calls cleanupWorktree per orphan + prints summary", async () => {
+    listSessionsReturn = [];
+    scanWorktreesReturn = [
+      { path: "/ghq/org/repo.wt-1-stale", status: "stale", name: "1-stale" },
+      { path: "/ghq/org/repo.wt-2-orphan", status: "orphan", name: "2-orphan" },
+    ];
+
+    await run(() => cmdList({ fix: true }));
+
+    // Both orphan paths should have been pruned
+    expect(cleanupWorktreeCalls.sort()).toEqual([
+      "/ghq/org/repo.wt-1-stale",
+      "/ghq/org/repo.wt-2-orphan",
+    ]);
+    const joined = outs.join("\n");
+    expect(joined).toContain("pruning 2 orphans");
+    expect(joined).toContain("repo.wt-1-stale");
+    expect(joined).toContain("repo.wt-2-orphan");
+    expect(joined).toContain("pruned 2/2");
+    // The "→ maw ls --fix" hint must NOT print when --fix is already active
+    expect(joined).not.toContain("→ maw ls --fix");
+  });
+
+  test("opts.fix=true with no orphans → 'nothing to prune' and no cleanupWorktree call", async () => {
+    listSessionsReturn = [
+      { name: "08-mawjs", windows: [{ index: 0, name: "mawjs-oracle", active: true }] },
+    ];
+    getPaneInfosReturn = { "08-mawjs:0": { command: "claude", cwd: "/" } };
+    scanWorktreesReturn = [
+      { path: "/ghq/org/repo", status: "active", name: "main" },
+    ];
+
+    await run(() => cmdList({ fix: true }));
+
+    expect(cleanupWorktreeCalls).toHaveLength(0);
+    expect(outs.join("\n")).toContain("nothing to prune");
+  });
+
+  test("opts.fix=false (default) preserves read-only behavior — no prune, hint shown", async () => {
+    listSessionsReturn = [];
+    scanWorktreesReturn = [
+      { path: "/ghq/org/repo.wt-1-stale", status: "stale", name: "1-stale" },
+    ];
+
+    await run(() => cmdList());
+
+    expect(cleanupWorktreeCalls).toHaveLength(0);
+    const joined = outs.join("\n");
+    expect(joined).toContain("⚠ orphaned:");
+    expect(joined).toContain("→ maw ls --fix");
+  });
+
+  test("opts.fix=true: cleanupWorktree throws on one orphan → keeps going + reports failure", async () => {
+    listSessionsReturn = [];
+    scanWorktreesReturn = [
+      { path: "/ghq/org/repo.wt-1-good", status: "stale", name: "1-good" },
+      { path: "/ghq/org/repo.wt-2-bad",  status: "stale", name: "2-bad" },
+    ];
+    cleanupWorktreeThrows = { "/ghq/org/repo.wt-2-bad": "permission denied" };
+
+    await run(() => cmdList({ fix: true }));
+
+    expect(cleanupWorktreeCalls).toHaveLength(2);
+    const joined = outs.join("\n");
+    expect(joined).toContain("repo.wt-1-good");
+    expect(joined).toContain("permission denied");
+    expect(joined).toContain("pruned 1/2");
   });
 });
 


### PR DESCRIPTION
## Summary

Two narrow fixes for the perceived `maw ls` breakage. Source ran without crash, but UX issues made it feel broken.

### 1. `--fix` flag wiring (path **1a**, preferred)

`comm-list.ts:88` advertised `→ maw ls --fix` but the alias dispatch path (`src/cli/top-aliases.ts` `invokeDirectHandler`) called `cmdList()` with no args — `--fix` was silently dropped.

- `cmdList(opts: { fix?: boolean } = {})` now accepts the flag.
- `invokeDirectHandler` for `cmdList` parses `--fix` via `parseFlags` and forwards `{ fix }`.
- When `opts.fix` is true, after listing, each orphan is pruned via `cleanupWorktree()` (the same surface `maw fleet` flows already use). Per-orphan ✓/✗ output + final `pruned N/M` summary.
- The `→ maw ls --fix` hint is suppressed when `--fix` is already active (no echo when the user already asked).
- Read-only contract (#957) is preserved when `--fix` is absent (the default).

LOC for plumbing: ~10 in `top-aliases.ts` + ~25 in `comm-list.ts`. Comfortably under the ~30 LOC fallback threshold, so path 1a was used (not 1b).

### 2. Preamble suppression on read-only verbs

Every `maw ls` printed two lines to stderr before any real output:

```
loaded config: 0 triggers, 0 declared plugins, N peers
loaded N plugins (N symlink)
```

`verbosity.ts:48-50`'s `isQuiet()` only exempted `--help`/`-v`. `isQuiet()` now also returns true when `process.argv[2]` is one of `ls`, `a`, `attach`, `wake` (the top-alias verbs).

Implementation notes:
- Positional check at `argv[2]` (not `.some()`) so flag values like `bud --as ls` do **not** false-positive into suppression.
- `wake` is included: `cmdWake` is a direct handler — no plugin shell-out — so the plugin-loading narration is dead weight.
- Set lookup is case-insensitive (`LS` → quiet).

## Test plan

- [x] `bun test test/cli/dispatch-match.test.ts test/cli/verbosity.test.ts test/isolated/comm-list.test.ts` — 103 pass / 0 fail
- [x] Full `bun test` — no new failures (pre-existing 373 failures in `find-plugin-root`, `search-peers`, etc. are unchanged from `origin/alpha`)
- [x] Smoke test on built CLI: `bun src/cli.ts ls` → stderr is empty, only session listing on stdout
- [x] Negative smoke: `bun src/cli.ts fleet status` → preamble still printed (suppression correctly scoped)

### New tests added

- `test/cli/dispatch-match.test.ts` — `ls --fix` argv reaches the resolver
- `test/cli/verbosity.test.ts` — top-alias suppression for `ls`/`a`/`attach`/`wake`, plus regression guard that `bud --as ls` is NOT quiet
- `test/isolated/comm-list.test.ts` — 4 `--fix` scenarios:
  - happy path: orphans → `cleanupWorktree` called per orphan
  - no orphans → `nothing to prune`
  - `opts.fix=false` (default) → read-only behavior preserved
  - partial failure → keeps going + reports `pruned 1/2`

## Files

- `src/cli/top-aliases.ts` — thread `--fix` through `invokeDirectHandler`
- `src/cli/verbosity.ts` — extend `isQuiet()` for top-alias verbs
- `src/commands/shared/comm-list.ts` — accept `opts.fix`, prune via `cleanupWorktree`
- `test/cli/dispatch-match.test.ts` — +1 test
- `test/cli/verbosity.test.ts` — +7 tests (+ argv setup/teardown)
- `test/isolated/comm-list.test.ts` — +4 tests (+ `cleanupWorktree` mock)

Code-only — no `package.json` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
