### PR TITLE
release: v26.4.53-alpha.734

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.53-alpha.706",
+  "version": "26.4.53-alpha.734",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts `v26.4.53-alpha.734` on merge via `calver-release.yml`.

## What ships

Bumps over `v26.4.53-alpha.706`:

| # | Title |
|---|---|
| #962 | fix(tmux): real exec for `maw a/attach` instead of print-only — TTY/$TMUX-aware (switch-client inside, attach outside, print fallback no-TTY/--print) |
| #963 | fix(cli): `maw ls --fix` wired (prunes orphans) + suppress preamble noise on top-alias verbs (ls/a/attach/wake) |

## Test plan

- [x] CI green on both source PRs (#962 + #963)
- [x] No `package.json` bump on the source PRs (release is the deliberate gesture)
- [x] Branched off `origin/alpha` tip (`979949d7`)
- [ ] CI green on this release PR
- [ ] After merge: `calver-release.yml` cuts the tag + builds `dist/maw`
- [ ] Cross-machine: `maw update alpha` on mba/m5 pulls v26.4.53-alpha.734
- [ ] Verify on m5: `maw a mawjs` actually attaches (not just prints) + `maw ls` has no preamble noise

🤖 Cut via /release-alpha
