### PR TITLE
release: v26.4.53-alpha.811

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.53-alpha.734",
+  "version": "26.4.53-alpha.811",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts `v26.4.53-alpha.811` on merge via `calver-release.yml`.

## What ships

Bumps over `v26.4.53-alpha.734`:

| # | Title |
|---|---|
| #966 | fix(cli): static imports in top-aliases — fix `maw ls` bundling regression |

Single-PR cut — this is the urgent fix for the `Cannot find module '../commands/shared/comm-list'` error users hit on alpha.734.

## Test plan

- [x] CI green on #966 before merge to alpha
- [x] Local bundle smoke: `bun build src/cli.ts && bun cli-bundled.js ls` works
- [x] `maw wake` usage error correct
- [x] `maw ls --fix` flag still threads
- [ ] CI green on this release PR
- [ ] After merge: `calver-release.yml` cuts v26.4.53-alpha.811 + builds `dist/maw`
- [ ] Cross-machine: `maw update alpha` on mba/m5 pulls v26.4.53-alpha.811 — `maw ls` works clean

## Refs

- Closes the regression introduced in #955 (added direct-handler dispatch with dynamic imports)
- Surfaced today on user's mba/m5 after `maw update alpha` to alpha.734

🤖 Cut via /release-alpha
