### PR TITLE
fix(update): auto-rotate stale maw.prev so retry path can run (closes #968)

### DIFF
--- a/src/cli/cmd-update.ts
+++ b/src/cli/cmd-update.ts
@@ -152,15 +152,29 @@ export async function runUpdate(args: string[]): Promise<void> {
       const BIN = join(homedir(), ".bun", "bin", "maw");
       const STASH = `${BIN}.prev`;
       let stashed = false;
-      // Refuse if .prev already exists — that's a prior crashed update's
-      // last-known-good escape hatch; silently overwriting would destroy it
-      // (architect's gotcha on #551). User resolves explicitly.
+      // #968 — if .prev already exists, it's a leftover from a prior crashed
+      // update. The original (#551) behavior refused at this point so the
+      // user wouldn't lose their last-known-good binary. But that left the
+      // user STUCK after a single crash — the retry/curl-fallback path below
+      // never runs because we exit here. Auto-rotate to a timestamped name
+      // instead: the working binary they're running RIGHT NOW still gets
+      // stashed (BIN → STASH below); the rotated copy is preserved as
+      // `${STASH}.crash.<unix-timestamp>` for forensic recovery if needed.
       if (existsSync(STASH)) {
-        console.error(`\x1b[31merror\x1b[0m: ${STASH} already exists (prior update crashed — last-known-good binary).`);
-        console.error(`  restore manually:  mv ${STASH} ${BIN}`);
-        console.error(`  or discard it:     rm ${STASH}   \x1b[90m# only if you're sure\x1b[0m`);
-        console.error(`  then re-run:       maw update ${ref}`);
-        process.exit(1);
+        const archived = `${STASH}.crash.${Math.floor(Date.now() / 1000)}`;
+        try {
+          renameSync(STASH, archived);
+          console.warn(`\x1b[33m↺\x1b[0m rotated stale ${STASH} → ${archived} (prior crash leftover; in-flight stash will replace it)`);
+        } catch (e: any) {
+          // Belt-and-suspenders: if rotation fails (perms, disk full, etc.),
+          // fall back to the original refuse behavior so we never silently
+          // overwrite a working binary in the rename below.
+          console.error(`\x1b[31merror\x1b[0m: ${STASH} already exists and could not be rotated: ${e.message || e}`);
+          console.error(`  resolve manually:  mv ${STASH} ${BIN}     \x1b[90m# restore last-known-good\x1b[0m`);
+          console.error(`  or discard it:     rm ${STASH}             \x1b[90m# only if you're sure\x1b[0m`);
+          console.error(`  then re-run:       maw update ${ref}`);
+          process.exit(1);
+        }
       }
       try {
         if (existsSync(BIN)) {

--- a/test/isolated/update-stash-restore.test.ts
+++ b/test/isolated/update-stash-restore.test.ts
@@ -79,16 +79,33 @@ describe("cmd-update stash+restore — source invariants (#551)", () => {
     expect(retryIdx).toBeGreaterThan(stashBlockEnd);
   });
 
-  // ── Case 4: prior .prev REFUSE (architect's safety gotcha) ────────────
-  it("case 4 — existing .prev refuses with process.exit(1) (does NOT overwrite)", () => {
-    // If ~/.bun/bin/maw.prev already exists, it's a prior crash's last-known-good
-    // escape hatch. Silently overwriting would destroy that. Refuse + hint user.
+  // ── Case 4: prior .prev ROTATE (#968 — auto-recover, don't block) ─────
+  it("case 4 — existing .prev rotates to timestamped archive (does NOT overwrite, does NOT exit)", () => {
+    // #968 — the original (#551) behavior refused with process.exit(1) when
+    // STASH already existed. That left users stuck after a single crash:
+    // the retry/curl-fallback path below could never run. Now we rotate the
+    // stale STASH to `${STASH}.crash.<unix-timestamp>` instead, preserving
+    // it for forensic recovery while unblocking the in-flight update.
     expect(cmdUpdateSrc).toMatch(
-      /if\s*\(\s*existsSync\(STASH\)\s*\)\s*\{[\s\S]*?process\.exit\(1\)/,
+      /if\s*\(\s*existsSync\(STASH\)\s*\)\s*\{[\s\S]*?renameSync\(STASH\s*,\s*archived\)/,
     );
-    // Must NOT silently unlink old stash before rename
+    // Must NOT exit on the happy rotate path (only on rotation failure)
+    expect(cmdUpdateSrc).toMatch(
+      /\$\{STASH\}\.crash\.\$\{Math\.floor\(Date\.now\(\) \/ 1000\)\}/,
+    );
+    // Must still NOT silently unlink old stash before rename of BIN
     expect(cmdUpdateSrc).not.toMatch(
       /unlinkSync\(STASH\)[\s\S]*?renameSync\(BIN\s*,\s*STASH\)/,
+    );
+  });
+
+  // ── Case 4b: rotation failure preserves the original refuse behavior ───
+  it("case 4b — rotation failure falls back to refuse + process.exit(1)", () => {
+    // If renameSync(STASH, archived) throws (perms, disk full, etc.), we
+    // restore the original "refuse to overwrite" safety net rather than
+    // risk silently destroying the user's last-known-good binary.
+    expect(cmdUpdateSrc).toMatch(
+      /catch\s*\([^)]*\)\s*\{[\s\S]*?could not be rotated[\s\S]*?process\.exit\(1\)/,
     );
   });
 


### PR DESCRIPTION
## Summary

Fixes #968 — `maw update` was leaving users stuck after a single crashed update because the `~/.bun/bin/maw.prev` orphan triggered an early `process.exit(1)` before the retry path (with the existing curl fallback at line 238-250) could run.

## Root cause

`cmd-update.ts:155-164` refused with `process.exit(1)` whenever `maw.prev` already existed. The original (#551) reasoning was sound — don't silently destroy the user's last-known-good binary — but the response was wrong: refusing means the user has to manually `mv`/`rm` the prev file every time, AND the existing release-binary curl fallback (#697, line 238-250) never gets a chance to run.

The dep-loop bug is upstream (bun resolver) and not really fixable from our side, but the curl fallback DOES work around it. The fix here is to make sure the curl fallback is reachable.

## Changes

### src/cli/cmd-update.ts (+24/-7)

Replace the `existsSync(STASH) → process.exit(1)` block with auto-rotation:

```ts
if (existsSync(STASH)) {
  const archived = `${STASH}.crash.${Math.floor(Date.now() / 1000)}`;
  try {
    renameSync(STASH, archived);
    console.warn(`↺ rotated stale ${STASH} → ${archived} (prior crash leftover)`);
  } catch (e) {
    // Belt-and-suspenders: rotation failure → original refuse behavior
    console.error(`error: ${STASH} already exists and could not be rotated`);
    console.error(`  resolve manually:  mv ${STASH} ${BIN}  or  rm ${STASH}`);
    console.error(`  then re-run:       maw update ${ref}`);
    process.exit(1);
  }
}
```

Why this preserves safety:
- The in-flight stash (`BIN → STASH`) still happens immediately after, preserving the binary the user is running RIGHT NOW
- The rotated `.crash.<timestamp>` files preserve forensic copies of prior crashes (user can compare versions, restore manually if desired)
- Rotation failure (permissions, disk full) falls back to the original refuse behavior

### test/isolated/update-stash-restore.test.ts (+21/-7)

- Case 4: assertion updated from `process.exit(1)` to `renameSync(STASH, archived)` + `.crash.<unix-timestamp>` pattern
- Case 4b (NEW): rotation failure falls back to `process.exit(1)` (regression guard)

## End-to-end flow after this fix

The user's reported sequence:

1. `maw update alpha` → bun add fails with DependencyLoop (upstream bug, can't fix)
2. Retry path activates: rotates stale `maw.prev` → `maw.prev.crash.<ts>` ← **was: exit(1)**
3. Stashes current binary: `maw → maw.prev` (in-flight)
4. Direct-evicts global package.json + bun.lock + cache
5. Second `bun add` attempt → still fails (same upstream dep-loop)
6. **Curl fallback fires**: downloads `maw` binary from GitHub release directly, bypassing bun resolver
7. ✓ User unstuck

Step 2 was the blocker — fixing it makes everything below it reachable.

## Test plan

- [x] `bun test test/isolated/update-stash-restore.test.ts test/isolated/cmd-update-order.test.ts` → 23/23 pass
- [ ] CI green
- [ ] On merge + alpha cut: real-world `maw update alpha` flow on a system with stale `maw.prev` succeeds via the curl fallback

## Refs

- #968 — this issue (dep-loop + maw.prev orphan)
- #551 — original maw.prev refuse logic (architect's gotcha — was right concern, wrong response)
- #697 — curl fallback added (line 238-250, unreachable until this fix)
- #952 — direct-evict global package.json (still runs, still helps for the cases it covers)

🤖 Code-only, no `package.json` bump. Cut as new alpha via `/release-alpha` after merge.
