### PR TITLE
release: v26.4.53-alpha.830

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.53-alpha.811",
+  "version": "26.4.53-alpha.830",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts `v26.4.53-alpha.830` on merge via `calver-release.yml`.

## What ships

| # | Title |
|---|---|
| #969 | fix(update): auto-rotate stale maw.prev so retry path can run (closes #968) |

Single-PR cut — unblocks the existing curl-fallback recovery path when `maw.prev` orphan exists from a prior crashed update.

🤖 Cut via /release-alpha