### PR TITLE
fix(tmux): use node:tty.isatty(1) for TTY detection in bundled binary (closes #971)

### DIFF
--- a/src/commands/plugins/tmux/impl.ts
+++ b/src/commands/plugins/tmux/impl.ts
@@ -8,6 +8,22 @@ import { checkDestructive, isClaudeLikePane, isFleetOrViewSession } from "./safe
 
 const TEAMS_DIR = join(homedir(), ".claude/teams");
 
+// #971 — process.stdout.isTTY is `undefined` (not false) in bun-bundled
+// binaries installed via curl. `!!undefined` → false, making attach always
+// fall to print-only. node:tty.isatty(1) checks the fd directly and works
+// in both source and bundled contexts. Wrapped in object for test mockability
+// (ES module namespace objects are frozen, bare `let` can't be reassigned).
+export const _tty = {
+  isStdoutTTY: (): boolean => {
+    try {
+      const { isatty } = require("node:tty") as typeof import("node:tty");
+      return isatty(1);
+    } catch {
+      return !!process.stdout.isTTY;
+    }
+  },
+};
+
 export interface TmuxPeekOpts {
   /** Number of lines from bottom of pane buffer. Default 30. */
   lines?: number;
@@ -386,7 +402,7 @@ export function cmdTmuxAttach(target: string, opts: TmuxAttachOpts = {}): void {
   const { resolved, source } = hit;
   const session = resolved.split(":")[0] ?? "";
 
-  const isTty = !!process.stdout.isTTY;
+  const isTty = _tty.isStdoutTTY();
   const inTmux = !!process.env.TMUX;
 
   if (opts.print || !isTty) {

--- a/test/isolated/tmux-action-verbs.test.ts
+++ b/test/isolated/tmux-action-verbs.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import { cmdTmuxLayout, cmdTmuxSplit, cmdTmuxAttach } from "../../src/commands/plugins/tmux/impl";
+import * as impl from "../../src/commands/plugins/tmux/impl";
 
 // Pure-validation tests for split, kill, layout, attach. These verbs call
 // hostExec under the hood — we test the input-validation paths that throw
@@ -111,8 +112,8 @@ describe("cmdTmuxAttach — print fallback (no TTY / --print)", () => {
 
 describe("cmdTmuxAttach — TTY exec branches", () => {
   test("inside tmux + TTY → spawns `tmux switch-client -t <session>`", () => {
-    const origIsTty = process.stdout.isTTY;
-    Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+    const origTTY = impl._tty.isStdoutTTY;
+    impl._tty.isStdoutTTY = () => true;
     const origTmux = process.env.TMUX;
     process.env.TMUX = "/tmp/tmux-1000/default,1234,0";
 
@@ -131,20 +132,19 @@ describe("cmdTmuxAttach — TTY exec branches", () => {
     } finally {
       console.log = origLog;
       (Bun as any).spawnSync = origSpawnSync;
-      Object.defineProperty(process.stdout, "isTTY", { value: origIsTty, configurable: true });
+      impl._tty.isStdoutTTY = origTTY;
       if (origTmux !== undefined) process.env.TMUX = origTmux;
       else delete process.env.TMUX;
     }
 
     expect(calls).toHaveLength(1);
     expect(calls[0].args).toEqual(["tmux", "switch-client", "-t", "some-session"]);
-    // No 3-line print under exec path — output is whatever tmux emits via stdio:inherit
     expect(logs.join("\n")).not.toContain("Run: tmux attach -t");
   });
 
   test("outside tmux + TTY → spawns `tmux attach -t <session>`", () => {
-    const origIsTty = process.stdout.isTTY;
-    Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+    const origTTY = impl._tty.isStdoutTTY;
+    impl._tty.isStdoutTTY = () => true;
     const origTmux = process.env.TMUX;
     delete process.env.TMUX;
 
@@ -159,7 +159,7 @@ describe("cmdTmuxAttach — TTY exec branches", () => {
       cmdTmuxAttach("some-session:0.1");
     } finally {
       (Bun as any).spawnSync = origSpawnSync;
-      Object.defineProperty(process.stdout, "isTTY", { value: origIsTty, configurable: true });
+      impl._tty.isStdoutTTY = origTTY;
       if (origTmux !== undefined) process.env.TMUX = origTmux;
     }
 
@@ -168,8 +168,8 @@ describe("cmdTmuxAttach — TTY exec branches", () => {
   });
 
   test("non-zero exit → throws with exit code + verb", () => {
-    const origIsTty = process.stdout.isTTY;
-    Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+    const origTTY = impl._tty.isStdoutTTY;
+    impl._tty.isStdoutTTY = () => true;
     const origTmux = process.env.TMUX;
     delete process.env.TMUX;
 
@@ -185,14 +185,14 @@ describe("cmdTmuxAttach — TTY exec branches", () => {
       expect(() => cmdTmuxAttach("ghost-session")).toThrow(/tmux attach failed.*exit 1/);
     } finally {
       (Bun as any).spawnSync = origSpawnSync;
-      Object.defineProperty(process.stdout, "isTTY", { value: origIsTty, configurable: true });
+      impl._tty.isStdoutTTY = origTTY;
       if (origTmux !== undefined) process.env.TMUX = origTmux;
     }
   });
 
   test("--print overrides TTY detection — never spawns even in interactive shell", () => {
-    const origIsTty = process.stdout.isTTY;
-    Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+    const origTTY = impl._tty.isStdoutTTY;
+    impl._tty.isStdoutTTY = () => true;
     const origTmux = process.env.TMUX;
     delete process.env.TMUX;
 
@@ -211,7 +211,7 @@ describe("cmdTmuxAttach — TTY exec branches", () => {
     } finally {
       console.log = origLog;
       (Bun as any).spawnSync = origSpawnSync;
-      Object.defineProperty(process.stdout, "isTTY", { value: origIsTty, configurable: true });
+      impl._tty.isStdoutTTY = origTTY;
       if (origTmux !== undefined) process.env.TMUX = origTmux;
     }
 


### PR DESCRIPTION
## Summary

- `maw a <session>` never actually attaches in the curl-installed binary — `process.stdout.isTTY` is `undefined` in bun bundles
- Replace with `require("node:tty").isatty(1)` which checks the fd directly
- Wrap in `_tty.isStdoutTTY()` for test mockability (ES module namespace objects are frozen)

## Test plan

- [x] 13/13 tmux-action-verbs tests pass
- [ ] CI green
- [ ] Cross-machine: curl-install new alpha, `maw a <session>` actually attaches

🤖 Generated with [Claude Code](https://claude.com/claude-code)