### PR TITLE
release: v26.4.53-alpha.914

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.53-alpha.830",
+  "version": "26.4.53-alpha.913",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts v26.4.53-alpha.914. Ships #972 (fix: maw a TTY detection in bundled binary). 🤖 /release-alpha