### PR TITLE
fix(wake): ghq clone fallthrough + parseWakeTarget wiring

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -7,11 +7,20 @@ import { assertValidOracleName } from "../../core/fleet/validate";
 import { resolveOracle, findWorktrees, getSessionMap, resolveFleetSession, detectSession, setSessionEnv, sanitizeBranchName } from "./wake-resolve";
 import { attachToSession, ensureSessionRunning, createWorktree } from "./wake-session";
 import { maybeSplit } from "./wake-maybe-split";
+import { parseWakeTarget, ensureCloned } from "./wake-target";
 
 export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; split?: boolean; repoPath?: string; urlRepoName?: string; allLocal?: boolean }): Promise<string> {
   // Canonicalize the bare name before any lookup — strips trailing `/`, `/.git`, `/.git/`
   // so `maw wake token-oracle/` (tab-completion artifact) resolves the same as `token-oracle`.
   oracle = normalizeTarget(oracle);
+
+  const parsed = parseWakeTarget(oracle);
+  if (parsed) {
+    await ensureCloned(parsed.slug);
+    oracle = parsed.oracle;
+    if (!opts.urlRepoName) opts.urlRepoName = parsed.slug.split("/").pop();
+  }
+
   // #358 — reject -view suffix at the user-input boundary (before any session work).
   assertValidOracleName(oracle);
   console.log(`\x1b[36m⚡\x1b[0m resolving ${oracle}...`);

--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -117,16 +117,15 @@ export async function resolveOracle(
       await hostExec(`ghq get -u 'github.com/${fleetRepo}'`);
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
-      console.error(`\x1b[31merror\x1b[0m: fleet-pinned ${fleetRepo} but clone failed: ${msg.split("\n")[0]}`);
-      console.error(`\x1b[90m  manually: ghq get -u 'github.com/${fleetRepo}' && maw wake ${oracle}\x1b[0m`);
-      process.exit(1);
+      console.error(`\x1b[33m⚠\x1b[0m fleet-pinned ${fleetRepo} clone/update failed: ${msg.split("\n")[0]}`);
     }
     const cloned = await ghqFind(`/${fleetRepoStem}`);
     if (cloned) {
-      console.log(`\x1b[32m✓\x1b[0m cloned to ${cloned}`);
+      console.log(`\x1b[32m✓\x1b[0m found at ${cloned}`);
       return { repoPath: cloned, repoName: cloned.split("/").pop()!, parentDir: cloned.replace(/\/[^/]+$/, "") };
     }
-    console.error(`\x1b[31merror\x1b[0m: clone of ${fleetRepo} reported success but path not found in ghq list`);
+    console.error(`\x1b[31merror\x1b[0m: fleet-pinned ${fleetRepo} — clone failed and not found locally`);
+    console.error(`\x1b[90m  manually: ghq get -u 'github.com/${fleetRepo}' && maw wake ${oracle}\x1b[0m`);
     process.exit(1);
   }
 
@@ -144,7 +143,6 @@ export async function resolveOracle(
       catch (e: unknown) {
         const msg = e instanceof Error ? e.message : String(e);
         console.error(`\x1b[33m⚠\x1b[0m  clone failed for ${slug}: ${msg.split("\n")[0]}`);
-        continue;
       }
       const cloned = await ghqFind(`/${slug.split("/").pop()}`);
       if (cloned) {

--- a/src/commands/shared/wake-resolve-scan-suggest.ts
+++ b/src/commands/shared/wake-resolve-scan-suggest.ts
@@ -306,7 +306,6 @@ export async function scanSuggestOracle(
     await hostExecFn(`ghq get -u '${cloneUrl}'`);
   } catch (e: any) {
     console.error(`\x1b[33m⚠\x1b[0m clone failed: ${String(e?.message || e).split("\n")[0]}`);
-    return null;
   }
 
   const cloned = await hostExecFn(`ghq list --full-path | grep -i '/${stem}$' | head -1`);


### PR DESCRIPTION
## Summary
- Wire `parseWakeTarget` into `cmdWake` — URL and `org/repo-oracle` slug inputs now parsed before `resolveOracle`
- Remove premature bail-out on `ghq get -u` failure in 3 locations — fall through to `ghqFind`/`ghq list` to find existing local repos
- Fixes `maw wake arra-oracle-v3-oracle` failing with "oracle repo not found" when repo exists locally but has SSH remote (ghq tries HTTPS, gets `[local:local]` error)

Closes #982

## Test plan
- [x] `bun test test/wake-target-parser.test.ts` — 13 pass
- [x] `bun test test/wake-resolve.test.ts` — 3 pass
- [x] `bun test test/wake-resolve-scan-suggest.test.ts` — 43 pass
- [ ] Manual: `maw wake arra-oracle-v3-oracle -a` on m5 (SSH remote, ghq get -u fails → should still resolve)
- [ ] Manual: `maw wake Soul-Brews-Studio/arra-oracle-v3-oracle -a` (slug input)
- [ ] Manual: `maw wake nonexistent-oracle` (scan-suggest "Scan now? [y/N]" still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)