### PR TITLE
release: v26.4.53-alpha.1030

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.53-alpha.913",
+  "version": "26.4.53-alpha.1030",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts v26.4.53-alpha.1030 on merge via calver-release.yml.

## Ships 4 PRs since alpha.914
- #983 — fix(wake): ghq clone fallthrough + parseWakeTarget wiring
- #979 — feat(tmux): status dots + age column (Heartbeat #975)
- #978 — feat(tmux): cooldown + quota gating (Heartbeat #974)
- #981 — chore(ci): remove ecosystem-drift + CodeQL

Auto-generated by /release-alpha — branch had 1 commit ahead of origin/alpha at cut time.