### PR TITLE
release: v26.4.53-alpha.1041

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.53-alpha.1030",
+  "version": "26.4.53-alpha.1041",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts v26.4.53-alpha.1041 on merge via calver-release.yml.

Ships #985 — maw ls compact view + -v for full detail, dedupe attach alias.

Auto-generated by /release-alpha.