### PR TITLE
feat(ls): roster view — sleeping oracles from ghq (#987)

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -33,7 +33,7 @@ export type AliasResolution =
 export const TOP_ALIASES: Record<string, string[] | DirectHandler> = {
   // Argv-rewrite form — canonical handler lives in a core plugin
   a: ["tmux", "attach"],
-  ls: ["tmux", "ls", "--all", "--compact"],
+  ls: ["tmux", "ls", "--all", "--compact", "--roster"],
 
   // Direct-handler form — cmdWake is in core (src/commands/shared/wake-cmd.ts)
   // even though the wake/ plugin was extracted to the registry in #918.

--- a/src/commands/plugins/tmux/impl.ts
+++ b/src/commands/plugins/tmux/impl.ts
@@ -4,6 +4,7 @@ import { homedir } from "os";
 import { hostExec, tmux } from "../../../sdk";
 import { resolveSessionTarget } from "../../../core/matcher/resolve-target";
 import { loadFleetEntries } from "../../shared/fleet-load";
+import { ghqList } from "../../../core/ghq";
 import { checkDestructive, isClaudeLikePane, isFleetOrViewSession } from "./safety";
 
 const TEAMS_DIR = join(homedir(), ".claude/teams");
@@ -111,6 +112,8 @@ export interface TmuxLsOpts {
   compact?: boolean;
   /** Verbose: full per-pane detail. Overrides --compact. */
   verbose?: boolean;
+  /** Roster: include sleeping oracles from ghq (compact mode only). */
+  roster?: boolean;
 }
 
 export type PaneStatus = "active" | "idle" | "stale" | "unknown";
@@ -185,7 +188,7 @@ export async function cmdTmuxLs(opts: TmuxLsOpts = {}): Promise<void> {
     return;
   }
 
-  if (!scope.length) {
+  if (!scope.length && !(opts.compact && opts.roster)) {
     console.log(opts.all
       ? "\x1b[90mNo panes found.\x1b[0m"
       : `\x1b[90mNo panes in current session '${currentSession || "(none)"}'. Use --all for every session.\x1b[0m`);
@@ -220,13 +223,35 @@ export async function cmdTmuxLs(opts: TmuxLsOpts = {}): Promise<void> {
       return "unknown";
     };
     console.log();
+    const awakeNames = new Set<string>();
     for (const [sess, panes] of bySession) {
+      awakeNames.add(sess);
       const dot = STATUS_DOT[bestStatus(panes)];
       const count = `${panes.length} pane${panes.length !== 1 ? "s" : ""}`;
       const agents = panes.filter(p => /claude|node/i.test(p.command || "")).length;
       const agentTag = agents > 0 ? `  \x1b[34m${agents} agent${agents !== 1 ? "s" : ""}\x1b[0m` : "";
       console.log(`  ${dot} \x1b[36m${sess}\x1b[0m  \x1b[90m${count}\x1b[0m${agentTag}`);
     }
+
+    if (opts.roster) {
+      try {
+        const repos = await ghqList();
+        const sleeping = repos
+          .filter(p => p.endsWith("-oracle"))
+          .map(p => p.split("/").pop()!)
+          .filter(name => !awakeNames.has(name))
+          .sort();
+        for (const name of sleeping) {
+          console.log(`  \x1b[90m· ${name}  (sleeping)\x1b[0m`);
+        }
+        const total = awakeNames.size + sleeping.length;
+        if (sleeping.length > 0) {
+          console.log();
+          console.log(`\x1b[90m  ${total} oracles — ${awakeNames.size} awake, ${sleeping.length} sleeping\x1b[0m`);
+        }
+      } catch { /* ghq unavailable */ }
+    }
+
     console.log();
     console.log(`\x1b[90m  → maw ls -v     full detail\x1b[0m`);
     console.log();

--- a/src/commands/plugins/tmux/index.ts
+++ b/src/commands/plugins/tmux/index.ts
@@ -59,15 +59,17 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         "--compact": Boolean,
         "--verbose": Boolean,
         "-v": "--verbose",
+        "--roster": Boolean,
         "--help": Boolean,
         "-h": "--help",
       }, 1);
       if (flags["--help"]) {
-        console.log("usage: maw tmux ls [--all|-a] [--compact] [-v|--verbose] [--json]");
+        console.log("usage: maw tmux ls [--all|-a] [--compact] [-v|--verbose] [--roster] [--json]");
         console.log("  default:    panes in current session only");
         console.log("  --all:      panes across every session");
         console.log("  --compact:  one line per session (default for `maw ls`)");
         console.log("  -v:         full per-pane detail (overrides --compact)");
+        console.log("  --roster:   include sleeping oracles from ghq");
         return { ok: true, output: logs.join("\n") || undefined };
       }
       await cmdTmuxLs({
@@ -75,6 +77,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         json: !!flags["--json"],
         compact: !!flags["--compact"],
         verbose: !!flags["--verbose"],
+        roster: !!flags["--roster"],
       });
     } else if (sub === "peek") {
       const flags = parseFlags(args, {

--- a/test/cli/dispatch-match.test.ts
+++ b/test/cli/dispatch-match.test.ts
@@ -157,18 +157,18 @@ describe("resolvePluginMatch — two-pass dispatch", () => {
 });
 
 describe("resolveTopAlias — RFC #954 verb aliases", () => {
-  test("`ls` → argv rewrite to ['tmux', 'ls', '--all', '--compact']", () => {
+  test("`ls` → argv rewrite to ['tmux', 'ls', '--all', '--compact', '--roster']", () => {
     const out = resolveTopAlias(["ls"]);
     expect(out).not.toBeNull();
     expect(out!.kind).toBe("argv");
-    if (out!.kind === "argv") expect(out!.argv).toEqual(["tmux", "ls", "--all", "--compact"]);
+    if (out!.kind === "argv") expect(out!.argv).toEqual(["tmux", "ls", "--all", "--compact", "--roster"]);
   });
 
   test("`ls -v` → argv rewrite with -v appended (overrides compact)", () => {
     const out = resolveTopAlias(["ls", "-v"]);
     expect(out).not.toBeNull();
     expect(out!.kind).toBe("argv");
-    if (out!.kind === "argv") expect(out!.argv).toEqual(["tmux", "ls", "--all", "--compact", "-v"]);
+    if (out!.kind === "argv") expect(out!.argv).toEqual(["tmux", "ls", "--all", "--compact", "--roster", "-v"]);
   });
 
   test("`a neo` → argv rewrite to ['tmux', 'attach', 'neo']", () => {


### PR DESCRIPTION
## Summary
- `maw ls` now shows sleeping oracles (from `ghq list *-oracle`) alongside live sessions
- Compact view: live sessions with status dots + sleeping oracles with `·` dot
- `maw ls -v` still shows full per-pane detail (unchanged)
- Handles edge case: no live sessions but sleeping oracles still render

Closes #987

## Test plan
- [x] `bun test test/cli/dispatch-match.test.ts` — 17 pass
- [ ] Manual: `maw ls` shows live + sleeping oracles
- [ ] Manual: `maw ls -v` shows full detail (no sleeping)
- [ ] Manual: with no tmux sessions, sleeping oracles still show

🤖 Generated with [Claude Code](https://claude.com/claude-code)