### PR TITLE
release: v26.4.53-alpha.1053

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.53-alpha.1041",
+  "version": "26.4.53-alpha.1053",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts v26.4.53-alpha.1053 on merge via calver-release.yml.

Ships #988 — maw ls roster view (sleeping oracles from ghq).

Auto-generated by /release-alpha.