### PR TITLE
feat(wake): auto-assign NN- session prefix (#994)

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -76,7 +76,23 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
     // #769 — URL input names the new session after the full repo (e.g.
     // "m5-oracle") so it's distinct from any unrelated sub-token sessions
     // and immediately disambiguates future `maw wake` calls.
-    session = getSessionMap()[oracle] || resolveFleetSession(oracle) || opts.urlRepoName || oracle;
+    const baseName = getSessionMap()[oracle] || resolveFleetSession(oracle) || opts.urlRepoName || oracle;
+
+    // #994 — auto-assign NN- prefix to match fleet convention (01-maw-m5, 02-...).
+    // Scan existing sessions for numeric prefixes, pick max+1, zero-pad to 2 digits.
+    let session_: string;
+    if (/^\d+-/.test(baseName)) {
+      session_ = baseName;
+    } else {
+      const sessions = await tmux.listSessions().catch(() => [] as { name: string }[]);
+      let maxNum = 0;
+      for (const s of sessions) {
+        const m = s.name.match(/^(\d+)-/);
+        if (m) maxNum = Math.max(maxNum, parseInt(m[1], 10));
+      }
+      session_ = `${String(maxNum + 1).padStart(2, "0")}-${baseName}`;
+    }
+    session = session_;
     const mainWindowName = `${oracle}-oracle`;
     await tmux.newSession(session, { window: mainWindowName, cwd: repoPath });
     await setSessionEnv(session);


### PR DESCRIPTION
## Summary
`maw wake` now auto-assigns numbered prefixes to new sessions, matching fleet convention:
```
10-mawjs    ← auto (after existing 01-09)
11-token    ← auto
```
- Scans existing tmux sessions for `NN-` prefixes
- Picks max+1, zero-padded to 2 digits
- Skips if name already has a numeric prefix (fleet/session-map)

Closes #994

## Test plan
- [x] 47 tests pass (dispatch, wake-target, wake-resolve)
- [ ] Manual: `maw wake new-oracle` creates `NN-new-oracle` session

🤖 Generated with [Claude Code](https://claude.com/claude-code)