### PR TITLE
fix(wake): use resolved oracle name after fuzzy match

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -53,6 +53,14 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
   }
 
   const { repoPath, repoName, parentDir } = resolved;
+
+  // #997 — when fuzzy match resolved a different repo (e.g. "v3" → "arra-oracle-v3-oracle"),
+  // update oracle to the resolved name so session/window names are correct.
+  const resolvedOracle = repoName.replace(/-oracle$/, "");
+  if (resolvedOracle !== oracle && repoName.endsWith("-oracle")) {
+    oracle = resolvedOracle;
+  }
+
   // #673 — extract org/repo slug from ghq path (…/github.com/<org>/<repo>)
   const ghSlug = repoPath.includes("github.com/")
     ? repoPath.slice(repoPath.indexOf("github.com/") + "github.com/".length)


### PR DESCRIPTION
## Summary
When fuzzy match resolves `v3` → `arra-oracle-v3-oracle`, update oracle name so:
- Session: `10-arra-oracle-v3` (was `10-v3`)
- Window: `arra-oracle-v3-oracle` (was `v3-oracle`)
- Agent registration: `arra-oracle-v3` (was `v3`)

Followup to #997/#998.

## Test plan
- [x] 47 tests pass
- [ ] Manual: `maw wake v3` creates `10-arra-oracle-v3` session

🤖 Generated with [Claude Code](https://claude.com/claude-code)