### PR TITLE
feat: restore team plugin to core + kill/t aliases

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -34,6 +34,8 @@ export type AliasResolution =
 export const TOP_ALIASES: Record<string, string[] | DirectHandler> = {
   // Argv-rewrite form — canonical handler lives in a core plugin
   a: ["tmux", "attach"],
+  kill: ["tmux", "kill"],
+  t: ["team"],
 
   // Direct-handler form — `ls` flags differ from tmux ls:
   //   maw ls      → compact, live sessions only

--- a/src/commands/plugins/team/impl.ts
+++ b/src/commands/plugins/team/impl.ts
@@ -1,0 +1,108 @@
+import { readdirSync, existsSync, readFileSync } from "fs";
+import { join } from "path";
+import { tmux } from "../../../sdk";
+import { TEAMS_DIR, loadTeam, resolvePsi } from "./team-helpers";
+import { findZombiePanes } from "./team-cleanup-zombies";
+
+// Re-export everything so index.ts and tests continue to import from "./impl"
+export { _setDirs, loadTeam, writeShutdownRequest, writeMessage } from "./team-helpers";
+export { cmdTeamShutdown, cmdTeamCreate, cmdTeamSpawn, mergeTeamKnowledge } from "./team-lifecycle";
+export { cmdTeamSend } from "./team-comms";
+export { cmdTeamResume, cmdTeamLives } from "./team-reincarnation";
+export { cmdCleanupZombies } from "./team-cleanup-zombies";
+
+/**
+ * Scan vault for CLI-created team manifests (#393 Bug B).
+ * Returns list of {name, members[]} that are NOT also present in the tool store.
+ */
+function listVaultOnlyTeams(toolTeamNames: Set<string>): Array<{ name: string; members: string[] }> {
+  const vaultTeamsDir = join(resolvePsi(), "memory", "mailbox", "teams");
+  if (!existsSync(vaultTeamsDir)) return [];
+  const out: Array<{ name: string; members: string[] }> = [];
+  try {
+    for (const name of readdirSync(vaultTeamsDir)) {
+      if (toolTeamNames.has(name)) continue; // also in tool store — listed via main loop
+      const manifestPath = join(vaultTeamsDir, name, "manifest.json");
+      if (!existsSync(manifestPath)) continue;
+      try {
+        const raw = JSON.parse(readFileSync(manifestPath, "utf-8"));
+        const members = Array.isArray(raw?.members)
+          ? raw.members.map((m: any) => typeof m === "string" ? m : m?.name).filter(Boolean)
+          : [];
+        out.push({ name, members });
+      } catch { /* skip malformed manifest */ }
+    }
+  } catch { /* no vault teams dir */ }
+  return out;
+}
+
+// ─── maw team list ───
+
+export async function cmdTeamList() {
+  let teamDirs: string[] = [];
+  try {
+    teamDirs = readdirSync(TEAMS_DIR).filter(d =>
+      existsSync(join(TEAMS_DIR, d, "config.json"))
+    );
+  } catch { /* expected: teams dir may not exist */ }
+
+  // #393 Bug B: also surface vault-only teams (created via maw team create
+  // but never wired through the tool-layer Agent()). They don't have pane
+  // IDs, but they exist and can be resumed.
+  const vaultOnly = listVaultOnlyTeams(new Set(teamDirs));
+
+  if (!teamDirs.length && !vaultOnly.length) {
+    console.log("\x1b[90mNo teams found.\x1b[0m");
+    console.log("\x1b[90m  looked in: ~/.claude/teams/ (tool) + ψ/memory/mailbox/teams/ (vault)\x1b[0m");
+    return;
+  }
+
+  const panes = await tmux.listPaneIds();
+
+  console.log();
+  console.log(`  \x1b[36;1mTEAM${" ".repeat(26)}STORE  MEMBERS  STATUS          ZOMBIES\x1b[0m`);
+
+  for (const dir of teamDirs) {
+    const team = loadTeam(dir);
+    if (!team) continue;
+
+    const teammates = team.members.filter(m => m.agentType !== "team-lead");
+    const aliveMembers = team.members.filter(m =>
+      m.tmuxPaneId && m.tmuxPaneId !== "in-process" && m.tmuxPaneId !== "" && panes.has(m.tmuxPaneId)
+    );
+    const deadPanes = teammates.filter(m =>
+      m.tmuxPaneId && m.tmuxPaneId !== "in-process" && m.tmuxPaneId !== "" && !panes.has(m.tmuxPaneId)
+    );
+
+    const name = dir.padEnd(30);
+    const store = "tool".padEnd(7);
+    const memberCount = String(teammates.length).padEnd(9);
+    const idle = aliveMembers.filter(m => m.agentType !== "team-lead").length;
+    const status = aliveMembers.length > 0
+      ? `\x1b[32m${idle} alive\x1b[0m`.padEnd(26)
+      : `\x1b[90mno live panes\x1b[0m`.padEnd(26);
+
+    console.log(`  ${name}${store}${memberCount}${status}${deadPanes.length > 0 ? `\x1b[90m${deadPanes.length} exited\x1b[0m` : "0"}`);
+  }
+
+  for (const v of vaultOnly) {
+    const name = v.name.padEnd(30);
+    const store = "vault".padEnd(7);
+    const memberCount = String(v.members.length).padEnd(9);
+    const status = `\x1b[90mprep-only\x1b[0m`.padEnd(26);
+    console.log(`  ${name}${store}${memberCount}${status}\x1b[90m—\x1b[0m`);
+  }
+
+  if (vaultOnly.length > 0) {
+    console.log(`\n  \x1b[90m${vaultOnly.length} vault-only team(s) — resume via \x1b[36mmaw team resume <name>\x1b[90m or remove via \x1b[36mrm -rf ψ/memory/mailbox/teams/<name>/\x1b[0m`);
+  }
+
+  // Check for orphan zombie panes (panes running claude with no matching team)
+  const allPanes = await tmux.listPanes();
+  const zombies = findZombiePanes(allPanes);
+  if (zombies.length > 0) {
+    console.log(`\n  \x1b[33m⚠ ${zombies.length} orphan zombie pane(s) detected\x1b[0m — run \x1b[36mmaw cleanup --zombie-agents\x1b[0m`);
+  }
+
+  console.log();
+}

--- a/src/commands/plugins/team/index.ts
+++ b/src/commands/plugins/team/index.ts
@@ -1,0 +1,234 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { readdirSync, existsSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import {
+  cmdTeamShutdown, cmdTeamList, cmdTeamCreate, cmdTeamSpawn,
+  cmdTeamSend, cmdTeamResume, cmdTeamLives,
+} from "./impl";
+import { parseFlags } from "../../../cli/parse-args";
+
+export const command = {
+  name: "team",
+  description: "Agent reincarnation engine — create, spawn, send, shutdown, resume, lives.",
+};
+
+/**
+ * Best-effort team detection for task verbs (#393 Bug E).
+ *
+ * 1. If $MAW_TEAM env var is set, use it (explicit override — highest priority).
+ * 2. If exactly ONE team exists in ~/.claude/teams/ with a config.json,
+ *    that's unambiguous — use it.
+ * 3. Otherwise fall back to "default" (preserves legacy behavior).
+ *
+ * Users who want a specific team should pass --team <name> explicitly.
+ */
+function resolveTeamFromContext(): string {
+  const envTeam = process.env.MAW_TEAM;
+  if (envTeam) return envTeam;
+  const teamsDir = join(homedir(), ".claude/teams");
+  try {
+    const live = readdirSync(teamsDir).filter(d =>
+      existsSync(join(teamsDir, d, "config.json"))
+    );
+    if (live.length === 1) return live[0]!;
+  } catch { /* no teams dir */ }
+  return "default";
+}
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  try {
+    const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+    const sub = args[0]?.toLowerCase();
+
+    if (sub === "create" || sub === "new") {
+      if (!args[1]) {
+        logs.push("usage: maw team create <name> [--description <text>]");
+        return { ok: false, error: "name required", output: logs.join("\n") };
+      }
+      const descIdx = args.indexOf("--description");
+      const description = descIdx !== -1 ? args.slice(descIdx + 1).join(" ") : undefined;
+      cmdTeamCreate(args[1], { description });
+    } else if (sub === "spawn") {
+      if (!args[1] || !args[2]) {
+        logs.push("usage: maw team spawn <team> <role> [--model <model>] [--prompt <text>] [--exec]");
+        return { ok: false, error: "team and role required", output: logs.join("\n") };
+      }
+      const modelIdx = args.indexOf("--model");
+      const model = modelIdx !== -1 ? args[modelIdx + 1] : undefined;
+      const promptIdx = args.indexOf("--prompt");
+      const exec = args.includes("--exec");
+      // --prompt is greedy to end-of-argv; strip --exec if it appears in the tail
+      let prompt: string | undefined;
+      if (promptIdx !== -1) {
+        const tail = args.slice(promptIdx + 1).filter(a => a !== "--exec");
+        prompt = tail.join(" ") || undefined;
+      }
+      await cmdTeamSpawn(args[1], args[2], { model, prompt, exec });
+    } else if (sub === "send" || sub === "msg") {
+      if (!args[1] || !args[2] || !args[3]) {
+        logs.push("usage: maw team send <team> <agent> <message>");
+        return { ok: false, error: "team, agent, and message required", output: logs.join("\n") };
+      }
+      cmdTeamSend(args[1], args[2], args.slice(3).join(" "));
+    } else if (sub === "resume") {
+      if (!args[1]) {
+        logs.push("usage: maw team resume <name> [--model <model>]");
+        return { ok: false, error: "name required", output: logs.join("\n") };
+      }
+      const modelIdx = args.indexOf("--model");
+      const model = modelIdx !== -1 ? args[modelIdx + 1] : undefined;
+      cmdTeamResume(args[1], { model });
+    } else if (sub === "lives" || sub === "history") {
+      if (!args[1]) {
+        logs.push("usage: maw team lives <agent>");
+        return { ok: false, error: "agent name required", output: logs.join("\n") };
+      }
+      cmdTeamLives(args[1]);
+    } else if (sub === "shutdown" || sub === "down") {
+      if (!args[1]) {
+        logs.push("usage: maw team shutdown <name> [--force] [--merge]");
+        return { ok: false, error: "name required", output: logs.join("\n") };
+      }
+      await cmdTeamShutdown(args[1], {
+        force: args.includes("--force"),
+        merge: args.includes("--merge"),
+      });
+    } else if (sub === "list" || sub === "ls" || !sub) {
+      await cmdTeamList();
+    } else if (sub === "add" || sub === "task") {
+      // maw team add "subject" [--team <name>] [--assign agent] [--description text]
+      const { cmdTeamTaskAdd } = await import("./task-ops");
+      const flags = parseFlags(args, {
+        "--team": String,
+        "--assign": String,
+        "--description": String,
+      }, 1);
+      const subject = flags._.join(" ");
+      if (!subject) { logs.push("usage: maw team add <subject> [--team <name>]"); return { ok: false, error: "subject required" }; }
+      const team = (flags["--team"] as string | undefined) || resolveTeamFromContext();
+      cmdTeamTaskAdd(team, subject, {
+        assign: flags["--assign"] as string | undefined,
+        description: flags["--description"] as string | undefined,
+      });
+
+    } else if (sub === "tasks") {
+      // maw team tasks [team-name] [--team <name>]
+      const { cmdTeamTaskList } = await import("./task-ops");
+      const flags = parseFlags(args, { "--team": String }, 1);
+      // Priority: --team flag > positional arg > context detection
+      const team = (flags["--team"] as string | undefined)
+        || flags._[0]
+        || resolveTeamFromContext();
+      cmdTeamTaskList(team);
+
+    } else if (sub === "done") {
+      // maw team done <id> [--team <name>]
+      const { cmdTeamTaskDone } = await import("./task-ops");
+      const flags = parseFlags(args, { "--team": String }, 1);
+      const id = parseInt(flags._[0] || "");
+      if (!id) { return { ok: false, error: "usage: maw team done <task-id> [--team <name>]" }; }
+      const team = (flags["--team"] as string | undefined) || resolveTeamFromContext();
+      cmdTeamTaskDone(team, id);
+
+    } else if (sub === "assign") {
+      // maw team assign <id> <agent> [--team <name>]
+      const { cmdTeamTaskAssign } = await import("./task-ops");
+      const flags = parseFlags(args, { "--team": String }, 1);
+      const id = parseInt(flags._[0] || "");
+      const agent = flags._[1];
+      if (!id || !agent) { return { ok: false, error: "usage: maw team assign <task-id> <agent> [--team <name>]" }; }
+      const team = (flags["--team"] as string | undefined) || resolveTeamFromContext();
+      cmdTeamTaskAssign(team, id, agent);
+
+    } else if (sub === "status") {
+      // maw team status [team-name]
+      const { cmdTeamStatus } = await import("./team-status");
+      await cmdTeamStatus(args[1]);
+
+    } else if (sub === "delete" || sub === "rm") {
+      // maw team delete <team-name>
+      const { cmdTeamDelete } = await import("./team-cleanup");
+      if (!args[1]) { return { ok: false, error: "usage: maw team delete <team-name>" }; }
+      await cmdTeamDelete(args[1]);
+
+    } else if (sub === "invite") {
+      // maw team invite <team> <peer> [--scope <scope>] [--lead <lead>]
+      const { cmdTeamInvite } = await import("./team-invite");
+      const flags = parseFlags(args, {
+        "--scope": String,
+        "--lead": String,
+      }, 1);
+      const team = flags._[0];
+      const peer = flags._[1];
+      if (!team || !peer) {
+        logs.push("usage: maw team invite <team> <peer> [--scope <scope>] [--lead <lead>]");
+        return { ok: false, error: "team and peer required", output: logs.join("\n") };
+      }
+      await cmdTeamInvite(team, peer, {
+        scope: flags["--scope"] as string | undefined,
+        lead: flags["--lead"] as string | undefined,
+      });
+
+    } else if (sub === "oracle-invite") {
+      // maw team oracle-invite <oracle-name> [--team <team>] [--role <role>]
+      const { cmdOracleInvite } = await import("./oracle-members");
+      const flags = parseFlags(args, {
+        "--team": String,
+        "--role": String,
+      }, 1);
+      const oracleName = flags._[0];
+      if (!oracleName) {
+        logs.push("usage: maw team oracle-invite <oracle-name> [--team <team>] [--role <role>]");
+        return { ok: false, error: "oracle name required", output: logs.join("\n") };
+      }
+      const team = (flags["--team"] as string | undefined) || resolveTeamFromContext();
+      const role = flags["--role"] as string | undefined;
+      cmdOracleInvite(team, oracleName, { role });
+
+    } else if (sub === "oracle-remove") {
+      // maw team oracle-remove <oracle-name> [--team <team>]
+      const { cmdOracleRemove } = await import("./oracle-members");
+      const flags = parseFlags(args, { "--team": String }, 1);
+      const oracleName = flags._[0];
+      if (!oracleName) {
+        logs.push("usage: maw team oracle-remove <oracle-name> [--team <team>]");
+        return { ok: false, error: "oracle name required", output: logs.join("\n") };
+      }
+      const team = (flags["--team"] as string | undefined) || resolveTeamFromContext();
+      cmdOracleRemove(team, oracleName);
+
+    } else if (sub === "members") {
+      // maw team members [--team <team>]
+      const { cmdOracleMembers } = await import("./oracle-members");
+      const flags = parseFlags(args, { "--team": String }, 1);
+      const team = (flags["--team"] as string | undefined)
+        || flags._[0]
+        || resolveTeamFromContext();
+      cmdOracleMembers(team);
+
+    } else {
+      logs.push(`unknown team subcommand: ${sub}`);
+      logs.push("usage: maw team <create|spawn|send|shutdown|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members>");
+      return { ok: false, error: `unknown subcommand: ${sub}`, output: logs.join("\n") };
+    }
+
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/src/commands/plugins/team/oracle-members.ts
+++ b/src/commands/plugins/team/oracle-members.ts
@@ -1,0 +1,196 @@
+/**
+ * oracle-members.ts — persistent oracle member registry for teams (#627 Phase 1).
+ *
+ * Stores team membership in ~/.config/maw/teams/<team-name>/oracle-members.json.
+ * Each member is a named oracle (budded from maw bud, or any oracle with a
+ * CLAUDE.md + ψ/ vault) that persists across sessions. This is the "oracle-team"
+ * paradigm: team members are not ephemeral agents — they have identity, memory,
+ * and accumulated domain knowledge.
+ *
+ * Phase 1 scope:
+ *   - maw team oracle-invite <oracle-name> [--team <team>] [--role <role>]
+ *   - maw team members [--team <team>]
+ *   - team:<team-name> fan-out routing via maw hey
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+import { CONFIG_DIR } from "../../../core/paths";
+
+// ─── Types ───
+
+export interface OracleMember {
+  /** Oracle name (e.g. "mawjs-plugin-oracle", "security-oracle") */
+  oracle: string;
+  /** Role within the team (e.g. "researcher", "builder", "reviewer") */
+  role: string;
+  /** ISO timestamp when the oracle was added */
+  addedAt: string;
+}
+
+export interface OracleTeamRegistry {
+  /** Team name */
+  name: string;
+  /** Persistent oracle members */
+  members: OracleMember[];
+  /** ISO timestamp when registry was created */
+  createdAt: string;
+  /**
+   * When true (default), `maw hey team:<name>` fan-out skips the sending
+   * oracle so a broadcast does not re-inject into the sender's own pane.
+   * Set to false to opt back into self-inclusive fan-out.
+   */
+  excludeSelf?: boolean;
+}
+
+// ─── Paths ───
+
+function teamRegistryDir(teamName: string): string {
+  return join(CONFIG_DIR, "teams", teamName);
+}
+
+function teamRegistryPath(teamName: string): string {
+  return join(teamRegistryDir(teamName), "oracle-members.json");
+}
+
+// ─── Registry CRUD ───
+
+export function loadOracleRegistry(teamName: string): OracleTeamRegistry | null {
+  const path = teamRegistryPath(teamName);
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+function ensureRegistry(teamName: string): OracleTeamRegistry {
+  const existing = loadOracleRegistry(teamName);
+  if (existing) return existing;
+  const registry: OracleTeamRegistry = {
+    name: teamName,
+    members: [],
+    createdAt: new Date().toISOString(),
+  };
+  const dir = teamRegistryDir(teamName);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(teamRegistryPath(teamName), JSON.stringify(registry, null, 2));
+  return registry;
+}
+
+function saveRegistry(teamName: string, registry: OracleTeamRegistry): void {
+  const dir = teamRegistryDir(teamName);
+  mkdirSync(dir, { recursive: true });
+  // lgtm[js/file-system-race] — PRIVATE-PATH: registry under ~/.config/maw/teams/, see docs/security/file-system-race-stance.md
+  writeFileSync(teamRegistryPath(teamName), JSON.stringify(registry, null, 2));
+}
+
+// ─── Commands ───
+
+/**
+ * Add an oracle as a persistent member of a team.
+ * Idempotent — re-inviting updates the role.
+ */
+export function cmdOracleInvite(
+  teamName: string,
+  oracleName: string,
+  opts: { role?: string } = {},
+): void {
+  const registry = ensureRegistry(teamName);
+  const role = opts.role || "member";
+  const existing = registry.members.findIndex(m => m.oracle === oracleName);
+
+  const entry: OracleMember = {
+    oracle: oracleName,
+    role,
+    addedAt: new Date().toISOString(),
+  };
+
+  if (existing >= 0) {
+    registry.members[existing] = entry;
+    console.log(`\x1b[32m✓\x1b[0m updated '${oracleName}' in team '${teamName}' (role: ${role})`);
+  } else {
+    registry.members.push(entry);
+    console.log(`\x1b[32m✓\x1b[0m added '${oracleName}' to team '${teamName}' (role: ${role})`);
+  }
+
+  saveRegistry(teamName, registry);
+  console.log(`  \x1b[90m${teamRegistryPath(teamName)}\x1b[0m`);
+}
+
+/**
+ * Remove an oracle from a team.
+ */
+export function cmdOracleRemove(teamName: string, oracleName: string): void {
+  const registry = loadOracleRegistry(teamName);
+  if (!registry) {
+    console.log(`\x1b[33m⚠\x1b[0m team '${teamName}' has no oracle member registry`);
+    return;
+  }
+
+  const idx = registry.members.findIndex(m => m.oracle === oracleName);
+  if (idx < 0) {
+    console.log(`\x1b[33m⚠\x1b[0m '${oracleName}' is not a member of team '${teamName}'`);
+    return;
+  }
+
+  registry.members.splice(idx, 1);
+  saveRegistry(teamName, registry);
+  console.log(`\x1b[32m✓\x1b[0m removed '${oracleName}' from team '${teamName}'`);
+}
+
+/**
+ * List persistent oracle members of a team.
+ */
+export function cmdOracleMembers(teamName: string): OracleMember[] {
+  const registry = loadOracleRegistry(teamName);
+  if (!registry || registry.members.length === 0) {
+    console.log(`\x1b[90mNo oracle members in team '${teamName}'.\x1b[0m`);
+    console.log(`\x1b[90m  add one: maw team oracle-invite <oracle-name> --team ${teamName}\x1b[0m`);
+    return [];
+  }
+
+  console.log();
+  console.log(`  \x1b[36;1mOracle members of '${teamName}'\x1b[0m (${registry.members.length})`);
+  console.log();
+
+  for (const m of registry.members) {
+    const added = new Date(m.addedAt).toLocaleDateString();
+    console.log(`  \x1b[32m●\x1b[0m ${m.oracle.padEnd(30)} \x1b[90mrole:\x1b[0m ${m.role.padEnd(15)} \x1b[90madded:\x1b[0m ${added}`);
+  }
+  console.log();
+
+  return registry.members;
+}
+
+/**
+ * Pure helper: filter member oracle names against the sender, honoring the
+ * registry's `excludeSelf` flag (default true).
+ *
+ * Extracted for unit-testing without going through CONFIG_DIR module caching.
+ */
+export function filterMembers(
+  members: OracleMember[],
+  excludeSelf: boolean | undefined,
+  currentOracle?: string,
+): string[] {
+  const all = members.map(m => m.oracle);
+  // Default true — filter only when explicitly false.
+  if (excludeSelf !== false && currentOracle) {
+    return all.filter(o => o !== currentOracle);
+  }
+  return all;
+}
+
+/**
+ * Get oracle member names for a team (for routing fan-out).
+ *
+ * When `currentOracle` is provided and the registry's `excludeSelf` flag is
+ * not explicitly false, the sending oracle is filtered out so a team
+ * broadcast does not re-inject into its own pane (#742 follow-up).
+ */
+export function getOracleMembers(teamName: string, currentOracle?: string): string[] {
+  const registry = loadOracleRegistry(teamName);
+  if (!registry) return [];
+  return filterMembers(registry.members, registry.excludeSelf, currentOracle);
+}

--- a/src/commands/plugins/team/plugin.json
+++ b/src/commands/plugins/team/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "team",
+  "version": "2.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Agent reincarnation engine — create, spawn, send, shutdown, resume, lives.",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "team",
+    "aliases": ["t"],
+    "help": "maw team <create|spawn|send|shutdown|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members>"
+  },
+  "weight": 50
+}

--- a/src/commands/plugins/team/task-ops.ts
+++ b/src/commands/plugins/team/task-ops.ts
@@ -1,0 +1,157 @@
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+function configBase(): string {
+  return process.env.MAW_CONFIG_DIR ?? join(homedir(), ".config/maw");
+}
+
+function tasksDir(team: string): string {
+  return join(configBase(), "teams", team, "tasks");
+}
+
+function ensureTasksDir(team: string): string {
+  const dir = tasksDir(team);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function counterPath(team: string): string {
+  return join(tasksDir(team), "_counter.json");
+}
+
+function taskPath(team: string, id: number): string {
+  return join(tasksDir(team), `${id}.json`);
+}
+
+function nextId(team: string): number {
+  const p = counterPath(team);
+  let counter = { next: 1 };
+  if (existsSync(p)) {
+    try { counter = JSON.parse(readFileSync(p, "utf-8")); } catch { /**/ }
+  }
+  const id = counter.next;
+  // lgtm[js/file-system-race] — PRIVATE-PATH: counter under ~/.maw/teams/, see docs/security/file-system-race-stance.md
+  writeFileSync(p, JSON.stringify({ next: id + 1 }));
+  return id;
+}
+
+function readTask(team: string, id: number): MawTask | null {
+  const p = taskPath(team, id);
+  if (!existsSync(p)) return null;
+  try { return JSON.parse(readFileSync(p, "utf-8")); } catch { return null; }
+}
+
+function writeTask(team: string, task: MawTask): void {
+  writeFileSync(taskPath(team, task.id), JSON.stringify(task, null, 2));
+}
+
+export interface MawTask {
+  id: number;
+  subject: string;
+  description?: string;
+  status: "pending" | "in_progress" | "completed";
+  assignee?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export function cmdTeamTaskAdd(
+  team: string,
+  subject: string,
+  opts?: { description?: string; assign?: string },
+): MawTask {
+  ensureTasksDir(team);
+  const now = new Date().toISOString();
+  const task: MawTask = {
+    id: nextId(team),
+    subject,
+    ...(opts?.description ? { description: opts.description } : {}),
+    status: "pending",
+    ...(opts?.assign ? { assignee: opts.assign } : {}),
+    createdAt: now,
+    updatedAt: now,
+  };
+  writeTask(team, task);
+  console.log(`\x1b[32m✓\x1b[0m task #${task.id} created: ${subject}`);
+  return task;
+}
+
+export function cmdTeamTaskList(team: string): MawTask[] {
+  const dir = tasksDir(team);
+  if (!existsSync(dir)) {
+    console.log(`\x1b[36mℹ\x1b[0m no tasks for team "${team}"`);
+    return [];
+  }
+  const tasks: MawTask[] = readdirSync(dir)
+    .filter(f => f.endsWith(".json") && f !== "_counter.json")
+    .map(f => {
+      try { return JSON.parse(readFileSync(join(dir, f), "utf-8")) as MawTask; } catch { return null; }
+    })
+    .filter(Boolean) as MawTask[];
+
+  tasks.sort((a, b) => a.id - b.id);
+
+  if (tasks.length === 0) {
+    console.log(`\x1b[36mℹ\x1b[0m no tasks for team "${team}"`);
+    return tasks;
+  }
+
+  const statusColor = (s: string) =>
+    s === "completed" ? `\x1b[32m${s}\x1b[0m`
+    : s === "in_progress" ? `\x1b[36m${s}\x1b[0m`
+    : `\x1b[33m${s}\x1b[0m`;
+
+  console.log(`\x1b[36mℹ\x1b[0m tasks for team "${team}" (${tasks.length}):`);
+  for (const t of tasks) {
+    const assignee = t.assignee ? ` → ${t.assignee}` : "";
+    console.log(`  #${t.id}  [${statusColor(t.status)}]  ${t.subject}${assignee}`);
+  }
+  return tasks;
+}
+
+export function cmdTeamTaskDone(team: string, id: number): MawTask | null {
+  ensureTasksDir(team);
+  const task = readTask(team, id);
+  if (!task) {
+    console.log(`\x1b[33m⚠\x1b[0m task #${id} not found in team "${team}"`);
+    return null;
+  }
+  task.status = "completed";
+  task.updatedAt = new Date().toISOString();
+  writeTask(team, task);
+  console.log(`\x1b[32m✓\x1b[0m task #${id} marked completed`);
+  return task;
+}
+
+export function cmdTeamTaskAssign(team: string, id: number, agent: string): MawTask | null {
+  ensureTasksDir(team);
+  const task = readTask(team, id);
+  if (!task) {
+    console.log(`\x1b[33m⚠\x1b[0m task #${id} not found in team "${team}"`);
+    return null;
+  }
+  task.assignee = agent;
+  task.status = "in_progress";
+  task.updatedAt = new Date().toISOString();
+  writeTask(team, task);
+  console.log(`\x1b[32m✓\x1b[0m task #${id} assigned to ${agent}`);
+  return task;
+}
+
+export function cmdTeamTaskDelete(team: string, id: number): boolean {
+  const p = taskPath(team, id);
+  if (!existsSync(p)) {
+    console.log(`\x1b[33m⚠\x1b[0m task #${id} not found in team "${team}"`);
+    return false;
+  }
+  rmSync(p);
+  console.log(`\x1b[32m✓\x1b[0m task #${id} deleted`);
+  return true;
+}
+
+export function cmdTeamTaskDeleteAll(team: string): void {
+  const dir = tasksDir(team);
+  if (!existsSync(dir)) return;
+  rmSync(dir, { recursive: true, force: true });
+}

--- a/src/commands/plugins/team/team-cleanup-zombies.ts
+++ b/src/commands/plugins/team/team-cleanup-zombies.ts
@@ -1,0 +1,116 @@
+import { readdirSync, existsSync } from "fs";
+import { join } from "path";
+import { tmux } from "../../../sdk";
+import type { TmuxPane } from "../../../sdk";
+import { loadFleetEntries } from "../../shared/fleet-load";
+import { TEAMS_DIR, loadTeam } from "./team-helpers";
+
+// ─── maw cleanup --zombie-agents ───
+
+export async function cmdCleanupZombies(opts: { yes?: boolean } = {}) {
+  console.log("\x1b[36mScanning tmux panes...\x1b[0m");
+
+  const allPanes = await tmux.listPanes();
+  const zombies = findZombiePanes(allPanes);
+
+  if (!zombies.length) {
+    console.log("\x1b[32m✓\x1b[0m No zombie agent panes found.");
+    return;
+  }
+
+  console.log(`\nFound \x1b[33m${zombies.length}\x1b[0m orphan claude pane(s):\n`);
+  for (const z of zombies) {
+    console.log(`  \x1b[33m${z.paneId}\x1b[0m  ${z.info}  \x1b[90m(team: ${z.teamName} — DELETED)\x1b[0m`);
+  }
+
+  if (!opts.yes) {
+    console.log(`\nRun with \x1b[36m--yes\x1b[0m to kill them.`);
+    return;
+  }
+
+  for (const z of zombies) {
+    await tmux.killPane(z.paneId);
+    console.log(`\x1b[32m✓\x1b[0m killed ${z.paneId}`);
+  }
+}
+
+interface ZombiePane {
+  paneId: string;
+  info: string;
+  teamName: string;
+}
+
+/**
+ * Find zombie panes: tmux panes running `claude` that are NOT part of any
+ * live team config AND NOT part of the fleet. Fleet-exclusion is critical
+ * — without it, every live fleet oracle would be flagged as a zombie.
+ */
+export function findZombiePanes(allPanes: TmuxPane[]): ZombiePane[] {
+  // Get all known team pane IDs from existing team configs
+  const knownTeamPaneIds = new Set<string>();
+  let teamDirs: string[] = [];
+  try {
+    teamDirs = readdirSync(TEAMS_DIR).filter(d =>
+      existsSync(join(TEAMS_DIR, d, "config.json"))
+    );
+  } catch { /* no teams dir */ }
+
+  for (const dir of teamDirs) {
+    const team = loadTeam(dir);
+    if (!team) continue;
+    for (const m of team.members) {
+      if (m.tmuxPaneId && m.tmuxPaneId !== "in-process" && m.tmuxPaneId !== "") {
+        knownTeamPaneIds.add(m.tmuxPaneId);
+      }
+    }
+  }
+
+  // Compute the set of fleet session names (e.g. "01-pulse", "08-mawjs").
+  // Any pane whose target starts with "<fleet-session>:" is a live fleet
+  // oracle and must NEVER be flagged as a zombie.
+  const fleetSessions = new Set<string>();
+  try {
+    for (const entry of loadFleetEntries()) {
+      fleetSessions.add(entry.file.replace(/\.json$/, ""));
+    }
+  } catch { /* no fleet dir */ }
+
+  // Also allow meta-view sessions (maw-view + any *-view) which mirror fleet
+  // panes. Each oracle creates its meta-view as `<stem>-view` (e.g.
+  // mawjs-view, mawui-view). #393 Bug F — zombie-auditor iter3 caught this:
+  // hardcoding only "maw-view" left every oracle's live pane one keystroke
+  // away from being killed by `maw cleanup --zombie-agents --yes`.
+  const isViewSession = (s: string) => s === "maw-view" || /-view$/.test(s);
+
+  // Defense-in-depth: also compute the set of pane ids that have ANY fleet
+  // (or view) listing. If the same pane id appears across multiple sessions
+  // (tmux-linked windows), a single safe target is enough to mark it safe.
+  // This protects against tmux reporting the non-fleet session as canonical.
+  const safePaneIds = new Set<string>();
+  for (const p of allPanes) {
+    const session = p.target.split(":")[0];
+    if (fleetSessions.has(session) || isViewSession(session)) {
+      safePaneIds.add(p.id);
+    }
+  }
+
+  const isFleetPane = (target: string): boolean => {
+    const session = target.split(":")[0];
+    return fleetSessions.has(session) || isViewSession(session);
+  };
+
+  // Find claude panes that are (a) not in any team config AND
+  // (b) not in the fleet/view (by either target OR any other listing of the same pane)
+  return allPanes
+    .filter(p =>
+      p.command?.includes("claude") &&
+      !knownTeamPaneIds.has(p.id) &&
+      !isFleetPane(p.target) &&
+      !safePaneIds.has(p.id)
+    )
+    .map(p => ({
+      paneId: p.id,
+      info: `${p.target}  "${(p.title || "").slice(0, 50)}"`,
+      teamName: "unknown",
+    }));
+}

--- a/src/commands/plugins/team/team-cleanup.ts
+++ b/src/commands/plugins/team/team-cleanup.ts
@@ -1,0 +1,23 @@
+import { existsSync, rmSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import { cmdTeamTaskDeleteAll } from "./task-ops";
+
+const TEAMS_DIR = join(homedir(), ".claude/teams");
+
+export async function cmdTeamDelete(teamName: string): Promise<void> {
+  // 1. Delete task files
+  cmdTeamTaskDeleteAll(teamName);
+  console.log(`  \x1b[32m✓\x1b[0m tasks cleared`);
+
+  // 2. Remove team directory
+  const teamDir = join(TEAMS_DIR, teamName);
+  if (existsSync(teamDir)) {
+    rmSync(teamDir, { recursive: true, force: true });
+    console.log(`  \x1b[32m✓\x1b[0m team dir removed: ${teamDir}`);
+  } else {
+    console.log(`  \x1b[90mℹ team dir not found (already clean)\x1b[0m`);
+  }
+
+  console.log(`\x1b[32m✓\x1b[0m team "${teamName}" deleted`);
+}

--- a/src/commands/plugins/team/team-comms.ts
+++ b/src/commands/plugins/team/team-comms.ts
@@ -1,0 +1,32 @@
+import { writeFileSync, existsSync, mkdirSync } from "fs";
+import { join } from "path";
+import { loadTeam, writeMessage, resolvePsi } from "./team-helpers";
+
+// ─── maw team send <team> <agent> <message> ───
+
+export function cmdTeamSend(teamName: string, agent: string, message: string) {
+  if (!message) {
+    throw new Error("usage: maw team send <team> <agent> <message>");
+  }
+
+  // Try CC team inbox first (live team), fallback to vault mailbox
+  const team = loadTeam(teamName);
+  if (team) {
+    writeMessage(teamName, agent, "maw-team-send", message);
+    console.log(`\x1b[32m✓\x1b[0m message sent to ${agent} in live team '${teamName}'`);
+    return;
+  }
+
+  // Fallback: write to ψ mailbox for async delivery
+  const PSI = resolvePsi();
+  const mailboxDir = join(PSI, "memory", "mailbox", agent);
+  mkdirSync(mailboxDir, { recursive: true });
+  const msgFile = join(mailboxDir, `msg-${Date.now()}.json`);
+  writeFileSync(msgFile, JSON.stringify({
+    from: "maw-team-send",
+    team: teamName,
+    text: message,
+    timestamp: new Date().toISOString(),
+  }, null, 2));
+  console.log(`\x1b[32m✓\x1b[0m message written to ψ/memory/mailbox/${agent}/ (team not live)`);
+}

--- a/src/commands/plugins/team/team-helpers.ts
+++ b/src/commands/plugins/team/team-helpers.ts
@@ -1,0 +1,108 @@
+import { readFileSync, writeFileSync, existsSync, rmSync, mkdirSync } from "fs";
+import { join, dirname } from "path";
+import { homedir } from "os";
+
+// Exported for testing — override with _setDirs
+export let TEAMS_DIR = join(homedir(), ".claude/teams");
+export let TASKS_DIR = join(homedir(), ".claude/tasks");
+
+/** @internal — for tests only */
+export function _setDirs(teams: string, tasks: string) {
+  TEAMS_DIR = teams;
+  TASKS_DIR = tasks;
+}
+
+export interface TeamMember {
+  name: string;
+  agentId?: string;
+  agentType?: string;
+  tmuxPaneId?: string;
+  color?: string;
+  model?: string;
+  backendType?: string;
+}
+
+export interface TeamConfig {
+  name: string;
+  description?: string;
+  members: TeamMember[];
+  createdAt?: number;
+}
+
+export function loadTeam(name: string): TeamConfig | null {
+  const configPath = join(TEAMS_DIR, name, "config.json");
+  if (!existsSync(configPath)) return null;
+  try { return JSON.parse(readFileSync(configPath, "utf-8")); }
+  catch { return null; }
+}
+
+/**
+ * Resolve ψ/ directory by walking UP from cwd looking for an oracle root
+ * (marked by CLAUDE.md + ψ/). Falls back to cwd/ψ for backward compat when
+ * no marker is found. Prevents rogue nested vaults when the CLI is run from
+ * a sub-directory (#393 — Bug A).
+ */
+export function resolvePsi(): string {
+  let dir = process.cwd();
+  // Walk up looking for an oracle root (CLAUDE.md + ψ/ both present)
+  while (true) {
+    const psi = join(dir, "ψ");
+    if (existsSync(psi) && existsSync(join(dir, "CLAUDE.md"))) return psi;
+    const parent = dirname(dir);
+    if (parent === dir) break; // reached filesystem root
+    dir = parent;
+  }
+  // Fallback: legacy behavior — cwd/ψ, callers mkdir as needed
+  return join(process.cwd(), "ψ");
+}
+
+/**
+ * Write a shutdown_request message to a teammate's inbox file.
+ * This is the same protocol Claude Code uses internally via SendMessage.
+ */
+export function writeShutdownRequest(teamName: string, memberName: string, reason: string): void {
+  const inboxPath = join(TEAMS_DIR, teamName, "inboxes", `${memberName}.json`);
+  let messages: any[] = [];
+  if (existsSync(inboxPath)) {
+    try { messages = JSON.parse(readFileSync(inboxPath, "utf-8")); } catch { messages = []; }
+  }
+  const requestId = `shutdown-${Date.now()}@${memberName}`;
+  messages.push({
+    from: "maw-team-shutdown",
+    text: JSON.stringify({ type: "shutdown_request", reason, request_id: requestId }),
+    summary: `Shutdown request: ${reason}`,
+    timestamp: new Date().toISOString(),
+    read: false,
+  });
+  // lgtm[js/file-system-race] — PRIVATE-PATH: inbox under ~/.maw/teams/<team>/inboxes/, see docs/security/file-system-race-stance.md
+  writeFileSync(inboxPath, JSON.stringify(messages, null, 2));
+}
+
+/**
+ * Write a generic message to a teammate's inbox file.
+ * Same protocol as writeShutdownRequest but with type: "message".
+ */
+export function writeMessage(teamName: string, memberName: string, from: string, text: string): void {
+  const inboxPath = join(TEAMS_DIR, teamName, "inboxes", `${memberName}.json`);
+  let messages: any[] = [];
+  if (existsSync(inboxPath)) {
+    try { messages = JSON.parse(readFileSync(inboxPath, "utf-8")); } catch { messages = []; }
+  }
+  messages.push({
+    from,
+    text: JSON.stringify({ type: "message", content: text }),
+    summary: text.slice(0, 80),
+    timestamp: new Date().toISOString(),
+    read: false,
+  });
+  mkdirSync(join(TEAMS_DIR, teamName, "inboxes"), { recursive: true });
+  // lgtm[js/file-system-race] — PRIVATE-PATH: inbox under ~/.maw/teams/<team>/inboxes/, see docs/security/file-system-race-stance.md
+  writeFileSync(inboxPath, JSON.stringify(messages, null, 2));
+}
+
+export function cleanupTeamDir(name: string) {
+  const teamDir = join(TEAMS_DIR, name);
+  const tasksDir = join(TASKS_DIR, name);
+  if (existsSync(teamDir)) { try { rmSync(teamDir, { recursive: true }); } catch {} }
+  if (existsSync(tasksDir)) { try { rmSync(tasksDir, { recursive: true }); } catch {} }
+}

--- a/src/commands/plugins/team/team-invite.ts
+++ b/src/commands/plugins/team/team-invite.ts
@@ -1,0 +1,214 @@
+/**
+ * maw team invite — invite a remote oracle to a local team (#644 Phase 2).
+ *
+ * Completes the 3-layer consent story (Phase 1: hey, Phase 3: plugin-install).
+ * Adding a remote oracle to a team is a privileged action — the invitee will
+ * receive team messages, tasks, and eventually share knowledge at shutdown
+ * via --merge. Phase 2 gates this with the same PIN-consent primitive.
+ *
+ * Default OFF. Opt in via MAW_CONSENT=1 (same convention as Phase 1 + 3).
+ *
+ * When consent IS required and not yet trusted, we:
+ *   1. Resolve the peer in namedPeers → peerUrl (the "hard ID").
+ *   2. requestConsent(action="team-invite") with a summary containing
+ *      team + lead + invitee + scope so the approver has full context.
+ *   3. Print the PIN + "on <peer>: maw consent approve ..." + exit 2.
+ *
+ * Once the peer has approved (or an existing trust entry matches), we add
+ * the peer to the team manifest under `invitees` and return. The caller
+ * re-runs `maw team invite` after OOB PIN relay.
+ *
+ * Trust-key scope note: trust is bound to (myNode, peerNode, "team-invite").
+ * A `hey` or `plugin-install` trust entry does NOT allow a team invite — the
+ * scopes are intentionally distinct (see gate-plugin-install.ts §2).
+ */
+import { readFileSync, writeFileSync, existsSync } from "fs";
+import { join } from "path";
+import { loadConfig } from "../../../config";
+import { isTrusted, requestConsent } from "../../../core/consent";
+import { resolvePsi } from "./team-helpers";
+
+export interface TeamInviteOptions {
+  /** Scope string surfaced in the consent summary (default: "member"). */
+  scope?: string;
+  /** Team lead name surfaced in the consent summary. Defaults to config.node. */
+  lead?: string;
+  /** Test injection — override peer lookup. Defaults to config.namedPeers. */
+  peerLookup?: (peerName: string) => NamedPeer | null;
+  /** Test injection — override local node. Defaults to config.node. */
+  myNode?: string;
+}
+
+export interface TeamInviteDecision {
+  ok: boolean;
+  exitCode?: number;
+  /** Message to print to stderr when ok=false. */
+  message?: string;
+}
+
+const SCOPE_DEFAULT = "member";
+
+export interface NamedPeer {
+  name: string;
+  url: string;
+  node?: string;
+}
+
+function defaultPeerLookup(peerName: string): NamedPeer | null {
+  const cfg = loadConfig() as { namedPeers?: NamedPeer[] };
+  const named = cfg.namedPeers ?? [];
+  return named.find(p => p.name === peerName) ?? null;
+}
+
+function manifestPath(teamName: string): string {
+  return join(resolvePsi(), "memory", "mailbox", "teams", teamName, "manifest.json");
+}
+
+/**
+ * Record the invitee in the team manifest. Idempotent — repeat invites
+ * are no-ops so post-consent re-runs don't duplicate entries.
+ *
+ * No `existsSync` precheck: catch ENOENT on the read instead. CodeQL's
+ * `js/file-system-race` flags check-then-use patterns regardless of path
+ * ownership, and inline `// lgtm` markers don't suppress alerts under the
+ * current GHAS scanner (see .github/codeql/codeql-config.yml). The
+ * read-then-write pattern matches team-lifecycle.ts (#393) which ships
+ * without an alert.
+ */
+export function recordInvitee(teamName: string, peer: NamedPeer, scope: string): void {
+  const path = manifestPath(teamName);
+  let manifest: any;
+  try {
+    manifest = JSON.parse(readFileSync(path, "utf-8"));
+  } catch (e: any) {
+    if (e?.code === "ENOENT") {
+      throw new Error(`team '${teamName}' not found — run: maw team create ${teamName}`);
+    }
+    throw e;
+  }
+  manifest.invitees = Array.isArray(manifest.invitees) ? manifest.invitees : [];
+  const existing = manifest.invitees.findIndex((i: any) => i?.name === peer.name);
+  const entry = {
+    name: peer.name,
+    url: peer.url,
+    node: peer.node,
+    scope,
+    invitedAt: new Date().toISOString(),
+  };
+  if (existing >= 0) {
+    manifest.invitees[existing] = entry;
+  } else {
+    manifest.invitees.push(entry);
+  }
+  // lgtm[js/file-system-race] — PRIVATE-PATH: manifest under ψ/memory/mailbox/teams/<team>/, see docs/security/file-system-race-stance.md
+  writeFileSync(path, JSON.stringify(manifest, null, 2));
+}
+
+/**
+ * Pure decision function — easier to unit-test than the CLI wrapper.
+ * Returns ok=true iff the invite was recorded; ok=false carries the
+ * stderr message + exit code the CLI should print.
+ */
+export async function runTeamInvite(
+  teamName: string,
+  peerName: string,
+  opts: TeamInviteOptions = {},
+): Promise<TeamInviteDecision> {
+  if (!existsSync(manifestPath(teamName))) {
+    return {
+      ok: false,
+      exitCode: 1,
+      message: `\x1b[31m✗\x1b[0m team '${teamName}' not found — run: maw team create ${teamName}`,
+    };
+  }
+
+  const lookup = opts.peerLookup ?? defaultPeerLookup;
+  const peer = lookup(peerName);
+  if (!peer) {
+    return {
+      ok: false,
+      exitCode: 1,
+      message:
+        `\x1b[31m✗\x1b[0m unknown peer '${peerName}' — not in namedPeers.\n` +
+        `  hint: add ${peerName} to maw.config.json namedPeers`,
+    };
+  }
+
+  const scope = opts.scope || SCOPE_DEFAULT;
+
+  // Default OFF — opt in via MAW_CONSENT=1. When off, skip the PIN round-trip
+  // entirely and record the invite directly (legacy path).
+  if (process.env.MAW_CONSENT !== "1") {
+    recordInvitee(teamName, peer, scope);
+    return { ok: true };
+  }
+
+  const myNode = opts.myNode ?? (loadConfig().node ?? "local");
+  const lead = opts.lead || myNode;
+
+  // Trust key falls back to peerName when peer didn't advertise a node.
+  // Same convention as gate-plugin-install.ts — keeps trust decisions
+  // expressible even for legacy peers.
+  const peerIdForTrust = peer.node || peer.name;
+  if (isTrusted(myNode, peerIdForTrust, "team-invite")) {
+    recordInvitee(teamName, peer, scope);
+    return { ok: true };
+  }
+
+  const summary =
+    `team-invite: team='${teamName}' lead='${lead}' ` +
+    `invitee='${peer.name}'${peer.node ? ` (${peer.node})` : ""} ` +
+    `url='${peer.url}' scope='${scope}'`;
+
+  const r = await requestConsent({
+    from: myNode,
+    to: peerIdForTrust,
+    action: "team-invite",
+    summary,
+    peerUrl: peer.url,
+  });
+
+  if (!r.ok) {
+    return {
+      ok: false,
+      exitCode: 1,
+      message: [
+        `\x1b[31m✗ consent request failed\x1b[0m: ${r.error}`,
+        r.requestId ? `  request id (local mirror): ${r.requestId}` : "",
+        `  hint: peer may be down, or /api/consent/request not yet deployed`,
+      ].filter(Boolean).join("\n"),
+    };
+  }
+
+  return {
+    ok: false,
+    exitCode: 2,
+    message: [
+      `\x1b[33m⏸  consent required\x1b[0m → team-invite`,
+      `   team:   ${teamName}  (lead: ${lead})`,
+      `   peer:   ${peer.name}${peer.node ? ` (${peer.node})` : ""}  [${peer.url}]`,
+      `   scope:  ${scope}`,
+      `   request id: ${r.requestId}`,
+      `   PIN (relay OOB to ${peerIdForTrust} operator): \x1b[1m${r.pin}\x1b[0m`,
+      `   expires: ${r.expiresAt}`,
+      ``,
+      `   on ${peerIdForTrust}: \x1b[36mmaw consent approve ${r.requestId} ${r.pin}\x1b[0m`,
+      `   then re-run: \x1b[36mmaw team invite ${teamName} ${peer.name}\x1b[0m`,
+    ].join("\n"),
+  };
+}
+
+/** CLI entry — prints outcome, returns void. Throws only on programmer error. */
+export async function cmdTeamInvite(
+  teamName: string,
+  peerName: string,
+  opts: TeamInviteOptions = {},
+): Promise<void> {
+  const decision = await runTeamInvite(teamName, peerName, opts);
+  if (decision.ok) {
+    console.log(`\x1b[32m✓\x1b[0m invited '${peerName}' to team '${teamName}' (scope: ${opts.scope || SCOPE_DEFAULT})`);
+    return;
+  }
+  if (decision.message) console.error(decision.message);
+  process.exit(decision.exitCode ?? 1);
+}

--- a/src/commands/plugins/team/team-lifecycle.ts
+++ b/src/commands/plugins/team/team-lifecycle.ts
@@ -1,0 +1,271 @@
+import { readdirSync, readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync } from "fs";
+import { join } from "path";
+import { tmux } from "../../../sdk";
+import { assertValidOracleName } from "../../../core/fleet/validate";
+import { TEAMS_DIR, loadTeam, resolvePsi, writeShutdownRequest, cleanupTeamDir, type TeamConfig, type TeamMember } from "./team-helpers";
+
+const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
+
+/**
+ * Copy per-member inbox + findings to the vault mailbox, then archive the
+ * manifest. Extracted from cmdTeamShutdown so it can be called from both
+ * the alive=0 and alive>0 paths (#393 Bug G — --merge was unreachable
+ * when all members had already exited).
+ *
+ * Iterates `teammates` (not `alive`) so dead members' accumulated state
+ * still gets captured — the whole point of --merge is to preserve state
+ * at shutdown time, regardless of whether members are still live.
+ */
+export function mergeTeamKnowledge(name: string, teammates: Array<{ name: string }>) {
+  const PSI = resolvePsi();
+  const teamInboxDir = join(TEAMS_DIR, name, "inboxes");
+  for (const m of teammates) {
+    const dest = join(PSI, "memory", "mailbox", m.name);
+    mkdirSync(dest, { recursive: true });
+    // Copy inbox messages
+    const src = join(teamInboxDir, `${m.name}.json`);
+    if (existsSync(src)) {
+      copyFileSync(src, join(dest, `team-${name}-inbox.json`));
+    }
+    // Copy any findings from team dir
+    const memberDir = join(TEAMS_DIR, name, m.name);
+    if (existsSync(memberDir)) {
+      try {
+        for (const f of readdirSync(memberDir).filter(f => f.endsWith("_findings.md"))) {
+          copyFileSync(join(memberDir, f), join(dest, f));
+        }
+      } catch { /* best effort */ }
+    }
+    console.log(`  \x1b[36m↪\x1b[0m merged ${m.name} → ψ/memory/mailbox/${m.name}/`);
+  }
+  // Archive manifest instead of deleting
+  const manifestSrc = join(TEAMS_DIR, name, "config.json");
+  if (existsSync(manifestSrc)) {
+    const archiveDest = join(PSI, "memory", "mailbox", "teams", name);
+    mkdirSync(archiveDest, { recursive: true });
+    copyFileSync(manifestSrc, join(archiveDest, "manifest.json"));
+  }
+}
+
+// ─── maw team shutdown <name> ───
+
+export async function cmdTeamShutdown(name: string, opts: { force?: boolean; merge?: boolean } = {}) {
+  const team = loadTeam(name);
+  if (!team) {
+    throw new Error(`team not found: ${name} — check ~/.claude/teams/ for available teams`);
+  }
+
+  const teammates = team.members.filter(m => m.agentType !== "team-lead");
+  if (!teammates.length) {
+    console.log(`\x1b[90mNo teammates to shut down in '${name}'.\x1b[0m`);
+    return;
+  }
+
+  const panes = await tmux.listPaneIds();
+  const alive = teammates.filter(m =>
+    m.tmuxPaneId && m.tmuxPaneId !== "in-process" && m.tmuxPaneId !== "" && panes.has(m.tmuxPaneId)
+  );
+
+  if (!alive.length) {
+    console.log(`\x1b[90mAll teammates in '${name}' already exited. Cleaning up config...\x1b[0m`);
+    // #393 Bug G: --merge must still run when alive=0. Knowledge preservation
+    // is the whole point; gating it on alive count caused silent data loss.
+    if (opts.merge) {
+      mergeTeamKnowledge(name, teammates);
+    }
+    cleanupTeamDir(name);
+    if (opts.merge) console.log(`\x1b[32m✓\x1b[0m team '${name}' cleaned up (knowledge merged)`);
+    return;
+  }
+
+  console.log(`\x1b[36m⏳\x1b[0m shutting down ${alive.length} teammate(s) in '${name}'...`);
+
+  // Step 1: Send shutdown_request via inbox files
+  for (const m of alive) {
+    try {
+      writeShutdownRequest(name, m.name, "team teardown via maw team shutdown");
+      console.log(`  \x1b[90m↪ shutdown_request → ${m.name} (${m.tmuxPaneId})\x1b[0m`);
+    } catch (e) {
+      console.error(`  \x1b[31m✗\x1b[0m failed to send shutdown to ${m.name}: ${e}`);
+    }
+  }
+
+  // Step 2: Wait for panes to die (up to 30s)
+  const deadline = Date.now() + 30_000;
+  let remaining = alive.length;
+  while (Date.now() < deadline && remaining > 0) {
+    await sleep(1000);
+    const current = await tmux.listPaneIds();
+    remaining = alive.filter(m => current.has(m.tmuxPaneId!)).length;
+    if (remaining > 0 && Date.now() + 5000 > deadline) break;
+  }
+  // Step 3: Force-kill stragglers
+  const finalPanes = await tmux.listPaneIds();
+  for (const m of alive) {
+    if (!finalPanes.has(m.tmuxPaneId!)) {
+      console.log(`  \x1b[32m✓\x1b[0m ${m.name} shut down gracefully`);
+      continue;
+    }
+    if (opts.force) {
+      await tmux.killPane(m.tmuxPaneId!);
+      console.log(`  \x1b[33m⚠\x1b[0m force-killed ${m.name} (${m.tmuxPaneId})`);
+    } else {
+      console.error(`  \x1b[31m✗\x1b[0m ${m.name} did not respond to shutdown_request (use --force to kill)`);
+    }
+  }
+
+  // FUSION: merge team knowledge into individual oracle mailboxes
+  if (opts.merge) {
+    mergeTeamKnowledge(name, teammates);
+  }
+
+  cleanupTeamDir(name);
+  console.log(`\x1b[32m✓\x1b[0m team '${name}' shut down${opts.merge ? " (knowledge merged)" : ""}`);
+}
+
+// ─── maw team create <name> ───
+export function cmdTeamCreate(name: string, opts: { description?: string } = {}) {
+  assertValidOracleName(name);
+
+  const PSI = resolvePsi();
+  const teamDir = join(PSI, "memory", "mailbox", "teams", name);
+
+  if (existsSync(join(teamDir, "manifest.json"))) {
+    throw new Error(`team '${name}' already exists at ${teamDir}`);
+  }
+
+  mkdirSync(teamDir, { recursive: true });
+
+  const manifest = {
+    name,
+    createdAt: Date.now(),
+    members: [] as string[],
+    description: opts.description || "",
+  };
+  writeFileSync(join(teamDir, "manifest.json"), JSON.stringify(manifest, null, 2));
+
+  // Bridge: write stub to tool store so list/status/shutdown can see this team (#393)
+  const toolTeamDir = join(TEAMS_DIR, name);
+  if (!existsSync(toolTeamDir)) {
+    mkdirSync(toolTeamDir, { recursive: true });
+    const stubConfig: TeamConfig = {
+      name,
+      description: opts.description || "",
+      members: [],
+      createdAt: Date.now(),
+    };
+    writeFileSync(join(toolTeamDir, "config.json"), JSON.stringify(stubConfig, null, 2));
+  }
+
+  console.log(`\x1b[32m✓\x1b[0m team '${name}' created`);
+  console.log(`  \x1b[90m${teamDir}/manifest.json\x1b[0m`);
+}
+
+// ─── maw team spawn <team> <role> ───
+export async function cmdTeamSpawn(
+  teamName: string,
+  role: string,
+  opts: { model?: string; prompt?: string; exec?: boolean } = {},
+) {
+  const PSI = resolvePsi();
+  const teamDir = join(PSI, "memory", "mailbox", "teams", teamName);
+  const manifestPath = join(teamDir, "manifest.json");
+
+  if (!existsSync(manifestPath)) {
+    throw new Error(`team '${teamName}' not found — run: maw team create ${teamName}`);
+  }
+
+  // Check for past life
+  const agentMailbox = join(PSI, "memory", "mailbox", role);
+  let pastLife = false;
+  let standingOrders = "";
+  let latestFindings = "";
+
+  if (existsSync(agentMailbox)) {
+    pastLife = true;
+    const soPath = join(agentMailbox, "standing-orders.md");
+    if (existsSync(soPath)) {
+      standingOrders = readFileSync(soPath, "utf-8");
+    }
+    // Find latest *_findings.md
+    try {
+      const findings = readdirSync(agentMailbox)
+        .filter(f => f.endsWith("_findings.md"))
+        .sort()
+        .pop();
+      if (findings) {
+        const lines = readFileSync(join(agentMailbox, findings), "utf-8").split("\n");
+        latestFindings = lines.slice(-30).join("\n");
+      }
+    } catch { /* no findings */ }
+  }
+
+  // Build spawn prompt
+  const model = opts.model || "sonnet";
+  const parts: string[] = [];
+  parts.push(`You are '${role}' on team '${teamName}'.`);
+  if (opts.prompt) parts.push(opts.prompt);
+  if (standingOrders) parts.push(`## Standing Orders (from past life)\n${standingOrders}`);
+  if (latestFindings) parts.push(`## Last Known Findings\n${latestFindings}`);
+
+  const spawnPrompt = parts.join("\n\n");
+
+  // Write prompt file for the user to use
+  const promptPath = join(teamDir, `${role}-spawn-prompt.md`);
+  writeFileSync(promptPath, spawnPrompt);
+
+  // Update manifest with new member
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+  if (!manifest.members.includes(role)) {
+    manifest.members.push(role);
+    // lgtm[js/file-system-race] — PRIVATE-PATH: manifest under ~/.maw/teams/<team>/, see docs/security/file-system-race-stance.md
+    writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+  }
+
+  // Bridge: sync member to tool store config (#393)
+  const toolConfigPath = join(TEAMS_DIR, teamName, "config.json");
+  if (existsSync(toolConfigPath)) {
+    try {
+      const toolConfig = JSON.parse(readFileSync(toolConfigPath, "utf-8"));
+      const member: TeamMember = { name: role, model };
+      if (!toolConfig.members.some((m: any) => m.name === role)) {
+        toolConfig.members.push(member);
+        // lgtm[js/file-system-race] — PRIVATE-PATH: tool config under ~/.maw/teams/<team>/ (#393), see docs/security/file-system-race-stance.md
+        writeFileSync(toolConfigPath, JSON.stringify(toolConfig, null, 2));
+      }
+    } catch { /* best effort */ }
+  }
+
+  console.log(`\x1b[32m✓\x1b[0m spawn prompt written for '${role}'`);
+  console.log(`  \x1b[90mpast life: ${pastLife ? "yes" : "no"}\x1b[0m`);
+  console.log(`  \x1b[90mmodel: ${model}\x1b[0m`);
+  console.log(`  \x1b[90mprompt: ${promptPath}\x1b[0m`);
+
+  // #393 Bug C — opt-in auto-spawn via splitWindowLocked. Default behavior
+  // (print-only) is unchanged. With --exec, we split the current pane and
+  // run the printed claude command inside it. Requires $TMUX (must be
+  // inside an active tmux session).
+  if (opts.exec) {
+    if (!process.env.TMUX) {
+      console.log();
+      console.log(`  \x1b[33m⚠\x1b[0m --exec requires an active tmux session ($TMUX not set).`);
+      console.log(`  \x1b[36mRun manually:\x1b[0m claude --model ${model} --prompt-file "${promptPath}"`);
+      return;
+    }
+    try {
+      const { hostExec } = await import("../../../sdk");
+      const claudeCmd = `claude --model ${model} --prompt-file '${promptPath.replace(/'/g, "'\\''")}'`;
+      await hostExec(`tmux split-window -h -l 50% '${claudeCmd.replace(/'/g, "'\\''")}'`);
+      console.log();
+      console.log(`  \x1b[32m✓ --exec\x1b[0m spawned ${role} in a new tmux pane (right, 50%)`);
+    } catch (e: any) {
+      console.log();
+      console.log(`  \x1b[33m⚠\x1b[0m --exec split failed: ${e?.message || e}`);
+      console.log(`  \x1b[36mRun manually:\x1b[0m claude --model ${model} --prompt-file "${promptPath}"`);
+    }
+    return;
+  }
+
+  console.log();
+  console.log(`  \x1b[36mRun:\x1b[0m claude --model ${model} --prompt-file "${promptPath}"`);
+}

--- a/src/commands/plugins/team/team-reincarnation.ts
+++ b/src/commands/plugins/team/team-reincarnation.ts
@@ -1,0 +1,73 @@
+import { readFileSync, existsSync, readdirSync } from "fs";
+import { join } from "path";
+import { resolvePsi } from "./team-helpers";
+import { cmdTeamSpawn } from "./team-lifecycle";
+
+// ─── maw team resume <name> ───
+
+export function cmdTeamResume(name: string, opts: { model?: string } = {}) {
+  const PSI = resolvePsi();
+  const manifestPath = join(PSI, "memory", "mailbox", "teams", name, "manifest.json");
+
+  if (!existsSync(manifestPath)) {
+    throw new Error(`no archived team '${name}' found — looked in: ${manifestPath}`);
+  }
+
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+  const members: string[] = manifest.members || [];
+
+  if (!members.length) {
+    console.log(`\x1b[90mTeam '${name}' has no members to resume.\x1b[0m`);
+    return;
+  }
+
+  console.log(`\x1b[36m⏳\x1b[0m resuming team '${name}' — ${members.length} agent(s)...\n`);
+
+  for (const member of members) {
+    cmdTeamSpawn(name, member, { model: opts.model });
+    console.log();
+  }
+
+  console.log(`\x1b[32m✓\x1b[0m team '${name}' resumed — ${members.length} agent(s) reincarnated`);
+}
+
+// ─── maw team lives <agent> ───
+
+export function cmdTeamLives(agent: string) {
+  const PSI = resolvePsi();
+  const mailboxDir = join(PSI, "memory", "mailbox", agent);
+
+  if (!existsSync(mailboxDir)) {
+    console.log(`\x1b[90mNo past lives found for '${agent}'\x1b[0m`);
+    console.log(`  \x1b[90mlooked in: ${mailboxDir}\x1b[0m`);
+    return;
+  }
+
+  const files = readdirSync(mailboxDir).sort();
+
+  console.log(`\n  \x1b[36;1m${agent} — past lives\x1b[0m\n`);
+
+  // Standing orders
+  const hasOrders = files.includes("standing-orders.md");
+  console.log(`  standing orders: ${hasOrders ? "\x1b[32myes\x1b[0m" : "\x1b[90mno\x1b[0m"}`);
+
+  // Findings
+  const findings = files.filter(f => f.endsWith("_findings.md"));
+  if (findings.length) {
+    console.log(`  findings: \x1b[32m${findings.length}\x1b[0m`);
+    for (const f of findings) {
+      const lines = readFileSync(join(mailboxDir, f), "utf-8").split("\n").length;
+      console.log(`    \x1b[90m${f} (${lines} lines)\x1b[0m`);
+    }
+  } else {
+    console.log(`  findings: \x1b[90mnone\x1b[0m`);
+  }
+
+  // Other files (messages, team archives)
+  const other = files.filter(f => f !== "standing-orders.md" && !f.endsWith("_findings.md"));
+  if (other.length) {
+    console.log(`  other: \x1b[90m${other.join(", ")}\x1b[0m`);
+  }
+
+  console.log();
+}

--- a/src/commands/plugins/team/team-status.ts
+++ b/src/commands/plugins/team/team-status.ts
@@ -1,0 +1,101 @@
+import { existsSync, readdirSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import { hostExec } from "../../../sdk";
+import { cmdTeamTaskList, type MawTask } from "./task-ops";
+import { loadTeam } from "./impl";
+
+const TEAMS_DIR = join(homedir(), ".claude/teams");
+
+function pad(s: string, n: number): string {
+  return s.length >= n ? s.slice(0, n) : s + " ".repeat(n - s.length);
+}
+
+function listTeams(): string[] {
+  if (!existsSync(TEAMS_DIR)) return [];
+  return readdirSync(TEAMS_DIR, { withFileTypes: true })
+    .filter(e => e.isDirectory())
+    .map(e => e.name);
+}
+
+async function getPanes(): Promise<Map<string, string>> {
+  const paneMap = new Map<string, string>();
+  try {
+    const out = await hostExec(
+      "tmux list-panes -a -F '#{pane_id} #{session_name}:#{window_index} #{pane_current_command}'"
+    );
+    for (const line of out.split("\n").filter(Boolean)) {
+      const [paneId, session, cmd] = line.split(" ");
+      if (paneId) paneMap.set(paneId, `${session ?? ""} ${cmd ?? ""}`.trim());
+    }
+  } catch { /* tmux may not be running */ }
+  return paneMap;
+}
+
+export async function cmdTeamStatus(teamName?: string): Promise<void> {
+  const teams = teamName ? [teamName] : listTeams();
+
+  if (teams.length === 0) {
+    console.log(`\x1b[36mℹ\x1b[0m no active teams`);
+    return;
+  }
+
+  const panes = await getPanes();
+
+  for (const name of teams) {
+    const config = loadTeam(name);
+    if (!config) {
+      console.log(`\x1b[33m⚠\x1b[0m team not found: ${name}`);
+      continue;
+    }
+
+    const tasks = cmdTeamTaskList(name);
+    const taskByAssignee = new Map<string, MawTask[]>();
+    for (const t of tasks) {
+      if (t.assignee) {
+        const arr = taskByAssignee.get(t.assignee) ?? [];
+        arr.push(t);
+        taskByAssignee.set(t.assignee, arr);
+      }
+    }
+
+    const members = config.members.filter(m => m.agentType !== "team-lead");
+    console.log(`\n\x1b[36;1mTeam: ${name}\x1b[0m (${members.length} agents)\n`);
+    console.log(
+      `  ${pad("Agent", 15)} ${pad("Status", 9)} ${pad("Task", 29)} Pane`
+    );
+    console.log(
+      `  ${"─".repeat(15)} ${"─".repeat(9)} ${"─".repeat(29)} ${"─".repeat(8)}`
+    );
+
+    let working = 0;
+    let idle = 0;
+
+    for (const m of members) {
+      const memberTasks = taskByAssignee.get(m.name) ?? [];
+      const activeTask = memberTasks.find(t => t.status === "in_progress") ?? memberTasks.at(-1);
+      const taskLabel = activeTask
+        ? `#${activeTask.id} ${activeTask.subject.slice(0, 20)} [${activeTask.status === "completed" ? "done" : activeTask.status}]`
+        : "-";
+
+      const paneId = m.tmuxPaneId ?? "";
+      const paneLabel = paneId && panes.has(paneId) ? paneId : (paneId || "-");
+      const isWorking = activeTask?.status === "in_progress";
+      isWorking ? working++ : idle++;
+
+      const statusTxt = isWorking
+        ? `\x1b[36mworking\x1b[0m  `
+        : `\x1b[90midle\x1b[0m     `;
+
+      console.log(
+        `  ${pad(m.name, 15)} ${statusTxt} ${pad(taskLabel, 29)} ${paneLabel}`
+      );
+    }
+
+    const done = tasks.filter(t => t.status === "completed").length;
+    console.log(
+      `\n  \x1b[90mTasks: ${done}/${tasks.length} done | Agents: ${working} working, ${idle} idle\x1b[0m`
+    );
+  }
+  console.log("");
+}


### PR DESCRIPTION
## Summary
- Restore `src/commands/plugins/team/` (13 files, 1647 LOC) from pre-lean-core
- Team is core infrastructure — engine already in core, commands should be too
- Add `maw t` alias → `maw team` (shorthand)
- Add `maw kill` alias → `maw tmux kill` (direct)

12 team subcommands restored: create, spawn, shutdown, delete, send, resume, lives, list, status, tasks, done, assign.

## Test plan
- [x] Build: `bun build src/cli.ts` — 629 modules, clean
- [x] `bun test test/cli/dispatch-match.test.ts` — 18 pass
- [ ] Manual: `maw team list` shows vault teams
- [ ] Manual: `maw t list` works (alias)
- [ ] Manual: `maw kill <target>` kills pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)