### PR TITLE
fix(team): TMUX_PANE anchoring + pane lock for spawn --exec

### DIFF
--- a/src/commands/plugins/team/team-lifecycle.ts
+++ b/src/commands/plugins/team/team-lifecycle.ts
@@ -253,9 +253,14 @@ export async function cmdTeamSpawn(
       return;
     }
     try {
-      const { hostExec } = await import("../../../sdk");
+      const { hostExec, withPaneLock } = await import("../../../sdk");
       const claudeCmd = `claude --model ${model} --prompt-file '${promptPath.replace(/'/g, "'\\''")}'`;
-      await hostExec(`tmux split-window -h -l 50% '${claudeCmd.replace(/'/g, "'\\''")}'`);
+      const anchor = process.env.TMUX_PANE;
+      const targetFlag = anchor ? `-t '${anchor}' ` : "";
+      await withPaneLock(async () => {
+        await hostExec(`tmux split-window ${targetFlag}-h -l 50% '${claudeCmd.replace(/'/g, "'\\''")}'`);
+        await sleep(200);
+      });
       console.log();
       console.log(`  \x1b[32m✓ --exec\x1b[0m spawned ${role} in a new tmux pane (right, 50%)`);
     } catch (e: any) {


### PR DESCRIPTION
## Summary
`maw team spawn <team> <role> --exec` now uses:
- `$TMUX_PANE` anchoring — splits beside the caller, not the active pane
- `withPaneLock` mutex — safe concurrent multi-agent spawns
- 200ms settle — tmux registers pane before next spawn

Prevents drift bug where second spawn splits the wrong pane.

## Usage
```bash
maw team create myteam
maw team spawn myteam scout --exec     # splits right, runs claude
maw team spawn myteam builder --exec   # splits again, anchored correctly
```

## Test plan
- [x] Build clean
- [ ] Manual: spawn 2 agents with --exec, both anchor to caller's pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)