### PR TITLE
release: v26.4.30-alpha.1254

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.53-alpha.1150",
+  "version": "26.4.30-alpha.1254",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts v26.4.30-alpha.1254 on merge via calver-release.yml.

First alpha with correct CalVer date after ghost-date fix (#1022). Includes 4 unreleased commits:
- #1016 feat(tmux): maw unsplit
- #1017 feat: maw open/close
- #1018 feat: open/close with break-pane/join-pane (CC-style)
- #1022 fix(calver): ghost-date guard

Auto-generated by /release-alpha — branch had 4 commit(s) ahead of origin/alpha at cut time.