### PR TITLE
refactor(cli): merge aliases into core command list

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -31,6 +31,19 @@ export type AliasResolution =
   | { kind: "argv"; argv: string[] }
   | { kind: "direct"; handler: string; argv: string[] };
 
+export const ALIAS_DESCRIPTIONS: Record<string, string> = {
+  a: "Attach to a tmux session",
+  kill: "Kill a tmux pane or session",
+  peek: "Read content of a tmux pane",
+  split: "Split pane and attach to a session",
+  open: "Bring back hidden panes (join-pane)",
+  close: "Hide panes without killing (break-pane)",
+  t: "Team — create, spawn, send, shutdown",
+  cleanup: "Kill zombie agent panes",
+  ls: "List sessions (compact, -a roster, -v detail)",
+  wake: "Wake an oracle session (fuzzy match, auto-clone)",
+};
+
 export const TOP_ALIASES: Record<string, string[] | DirectHandler> = {
   // Argv-rewrite form — canonical handler lives in a core plugin
   a: ["tmux", "attach"],

--- a/src/cli/usage.ts
+++ b/src/cli/usage.ts
@@ -1,5 +1,5 @@
 import { discoverPackages } from "../plugin/registry";
-import { TOP_ALIASES } from "./top-aliases";
+import { TOP_ALIASES, ALIAS_DESCRIPTIONS } from "./top-aliases";
 
 export function usage() {
   const title = `\x1b[36mmaw\x1b[0m — Multi-Agent Workflow`;
@@ -9,7 +9,6 @@ export function usage() {
     const active = all.filter(p => !p.disabled && p.manifest.cli?.command);
     const hasDisabled = all.some(p => p.disabled);
 
-    // Group by weight tier: core < 10, standard 10-49, extra 50+
     const tiers = [
       { name: "core",     plugins: active.filter(p => (p.manifest.weight ?? 50) < 10) },
       { name: "standard", plugins: active.filter(p => { const w = p.manifest.weight ?? 50; return w >= 10 && w < 50; }) },
@@ -19,28 +18,10 @@ export function usage() {
     const multiTier = tiers.length > 1;
     const lines: string[] = [title, ""];
 
-    // RFC #954 — top-level aliases between core and standard tiers.
-    // Render once after the core tier (or first tier) so users see
-    // the verb-prominence surface alongside the canonical plugins.
     const aliasEntries = Object.entries(TOP_ALIASES);
-    const renderAliases = () => {
-      lines.push(`\x1b[33maliases (${aliasEntries.length}):\x1b[0m`);
-      for (const [verb, target] of aliasEntries) {
-        const cmd = `maw ${verb}`.padEnd(28);
-        let arrow: string;
-        if (Array.isArray(target)) {
-          arrow = `→ maw ${target.join(" ")}`;
-        } else {
-          // Direct-handler form: extract just the export name for readability.
-          const exportName = target.handler.split(":").pop() ?? target.handler;
-          arrow = `→ direct handler: ${exportName}`;
-        }
-        lines.push(`  ${cmd} ${arrow}`);
-      }
-      lines.push("");
-    };
+    const pluginNames = new Set(active.map(p => p.manifest.cli!.command));
 
-    let aliasesRendered = false;
+    let aliasesInserted = false;
     for (const tier of tiers) {
       const label = multiTier
         ? `\x1b[33m${tier.name} (${tier.plugins.length}):\x1b[0m`
@@ -51,25 +32,37 @@ export function usage() {
         const desc = p.manifest.description ?? "";
         lines.push(`  ${cmd} ${desc}`);
       }
-      lines.push("");
-      // Insert aliases section immediately after the core tier (RFC §Q3).
-      if (!aliasesRendered && tier.name === "core" && aliasEntries.length > 0) {
-        renderAliases();
-        aliasesRendered = true;
-      }
-    }
-    // Fallback: if no `core` tier was rendered (e.g. minimal profile), still
-    // surface the aliases block at the end so users don't lose access.
-    if (!aliasesRendered && aliasEntries.length > 0) renderAliases();
 
+      if (!aliasesInserted && tier.name === "core" && aliasEntries.length > 0) {
+        for (const [verb] of aliasEntries) {
+          if (pluginNames.has(verb)) continue;
+          const cmd = `maw ${verb}`.padEnd(28);
+          const desc = ALIAS_DESCRIPTIONS[verb] ?? "";
+          lines.push(`  ${cmd} ${desc}`);
+        }
+        aliasesInserted = true;
+      }
+      lines.push("");
+    }
+
+    if (!aliasesInserted && aliasEntries.length > 0) {
+      for (const [verb] of aliasEntries) {
+        if (pluginNames.has(verb)) continue;
+        const cmd = `maw ${verb}`.padEnd(28);
+        const desc = ALIAS_DESCRIPTIONS[verb] ?? "";
+        lines.push(`  ${cmd} ${desc}`);
+      }
+      lines.push("");
+    }
+
+    const total = active.length + aliasEntries.filter(([v]) => !pluginNames.has(v)).length;
     const countLine = hasDisabled
-      ? `\x1b[90m${active.length} commands active. Run 'maw plugin enable <name>' for more.\x1b[0m`
-      : `\x1b[90m${active.length} commands active.\x1b[0m`;
+      ? `\x1b[90m${total} commands active. Run 'maw plugin enable <name>' for more.\x1b[0m`
+      : `\x1b[90m${total} commands active.\x1b[0m`;
     lines.push(countLine);
 
     console.log(lines.join("\n"));
   } catch {
-    // Registry not loaded yet — minimal fallback
     console.log(`${title}\n\nRun \x1b[33mmaw plugin ls\x1b[0m to see available commands.`);
   }
 }


### PR DESCRIPTION
## Summary

- Aliases now appear inline with core commands instead of a separate "aliases (10):" section
- Each alias has a human-readable description (e.g. `maw ls → List sessions (compact, -a roster, -v detail)`)
- Removes arrow notation (`→ maw tmux attach`, `→ direct handler: cmdLs`)
- Total command count includes aliases
- Skip aliases that duplicate a plugin name

Closes #1024

🤖 Generated with [Claude Code](https://claude.com/claude-code)