### PR TITLE
feat(team): CC-style layout manager — main-vertical + colored borders

### DIFF
--- a/src/commands/plugins/team/team-lifecycle.ts
+++ b/src/commands/plugins/team/team-lifecycle.ts
@@ -254,15 +254,32 @@ export async function cmdTeamSpawn(
     }
     try {
       const { hostExec, withPaneLock } = await import("../../../sdk");
+      const {
+        rebalanceAfterSpawn, stylePaneBorder, enableBorderStatus,
+        nextAgentColor, getWindowTarget, colorAnsi,
+      } = await import("../tmux/layout-manager");
       const claudeCmd = `claude --model ${model} --prompt-file '${promptPath.replace(/'/g, "'\\''")}'`;
       const anchor = process.env.TMUX_PANE;
       const targetFlag = anchor ? `-t '${anchor}' ` : "";
+
+      let newPaneId = "";
       await withPaneLock(async () => {
-        await hostExec(`tmux split-window ${targetFlag}-h -l 50% '${claudeCmd.replace(/'/g, "'\\''")}'`);
+        newPaneId = (await hostExec(
+          `tmux split-window ${targetFlag}-h -P -F '#{pane_id}' '${claudeCmd.replace(/'/g, "'\\''")}'`,
+        )).trim();
         await sleep(200);
       });
+
+      const teammateCount = manifest.members.length - 1;
+      const color = nextAgentColor(teammateCount);
+      const window = await getWindowTarget();
+
+      if (anchor) await rebalanceAfterSpawn(window, anchor);
+      if (newPaneId) await stylePaneBorder(newPaneId, role, color);
+      await enableBorderStatus(window);
+
       console.log();
-      console.log(`  \x1b[32m✓ --exec\x1b[0m spawned ${role} in a new tmux pane (right, 50%)`);
+      console.log(`  \x1b[32m✓ --exec\x1b[0m spawned ${role} in a new tmux pane [\x1b[${colorAnsi(color)}m${color}\x1b[0m]`);
     } catch (e: any) {
       console.log();
       console.log(`  \x1b[33m⚠\x1b[0m --exec split failed: ${e?.message || e}`);

--- a/src/commands/plugins/tmux/layout-manager.ts
+++ b/src/commands/plugins/tmux/layout-manager.ts
@@ -1,0 +1,94 @@
+import { hostExec } from "../../../sdk";
+
+// CC palette — 8 distinct colors, same order as claude-code AgentColorName
+const AGENT_COLORS = [
+  "blue", "green", "yellow", "cyan", "magenta", "red", "white", "orange",
+] as const;
+export type AgentColor = (typeof AGENT_COLORS)[number];
+
+// tmux color names (256-color for orange which has no named equivalent)
+const TMUX_COLOR: Record<AgentColor, string> = {
+  blue: "blue", green: "green", yellow: "yellow", cyan: "cyan",
+  magenta: "magenta", red: "red", white: "white", orange: "colour208",
+};
+
+// ANSI codes for terminal output
+const ANSI_FG: Record<AgentColor, string> = {
+  blue: "34", green: "32", yellow: "33", cyan: "36",
+  magenta: "35", red: "31", white: "37", orange: "38;5;208",
+};
+
+export function nextAgentColor(index: number): AgentColor {
+  return AGENT_COLORS[index % AGENT_COLORS.length];
+}
+
+export function colorAnsi(color: AgentColor): string {
+  return ANSI_FG[color];
+}
+
+// ─── Layout ──────────────────────────────────────────────
+
+export async function applyTeamLayout(
+  windowTarget: string,
+  leaderPane: string,
+  leaderPct = 30,
+): Promise<void> {
+  await hostExec(`tmux select-layout -t '${windowTarget}' main-vertical`);
+  await hostExec(`tmux resize-pane -t '${leaderPane}' -x ${leaderPct}%`);
+}
+
+export async function rebalanceAfterSpawn(
+  windowTarget: string,
+  leaderPane: string,
+): Promise<void> {
+  await applyTeamLayout(windowTarget, leaderPane);
+}
+
+// ─── Pane Borders ────────────────────────────────────────
+
+export async function stylePaneBorder(
+  paneId: string,
+  agentName: string,
+  color: AgentColor,
+): Promise<void> {
+  const tc = TMUX_COLOR[color];
+  await hostExec(`tmux select-pane -t '${paneId}' -T '${agentName}'`);
+  await hostExec(
+    `tmux set-option -p -t '${paneId}' pane-border-format '#[fg=${tc},bold] #{pane_title}'`,
+  );
+  await hostExec(
+    `tmux set-option -p -t '${paneId}' pane-active-border-style 'fg=${tc}'`,
+  );
+}
+
+export async function enableBorderStatus(windowTarget: string): Promise<void> {
+  await hostExec(`tmux set-option -w -t '${windowTarget}' pane-border-status top`);
+}
+
+// ─── Hide / Show (CC-style break-pane / join-pane) ───────
+
+export async function hidePane(paneId: string): Promise<boolean> {
+  try {
+    await hostExec(`tmux break-pane -d -t '${paneId}'`);
+    return true;
+  } catch { return false; }
+}
+
+export async function showPane(paneId: string, targetPane: string): Promise<boolean> {
+  try {
+    await hostExec(`tmux join-pane -h -s '${paneId}' -t '${targetPane}'`);
+    return true;
+  } catch { return false; }
+}
+
+// ─── Helpers ─────────────────────────────────────────────
+
+export async function getWindowTarget(): Promise<string> {
+  return (await hostExec("tmux display-message -p '#{window_id}'")).trim();
+}
+
+export async function listPaneIds(windowTarget?: string): Promise<string[]> {
+  const flag = windowTarget ? `-t '${windowTarget}'` : "";
+  const raw = await hostExec(`tmux list-panes ${flag} -F '#{pane_id}'`);
+  return raw.split("\n").filter(Boolean);
+}


### PR DESCRIPTION
## Summary

- New `src/commands/plugins/tmux/layout-manager.ts` (94 LOC) — CC-pattern pane management
- `applyTeamLayout()` → `select-layout main-vertical` + `resize-pane -x 30%`
- `rebalanceAfterSpawn()` → re-apply after each teammate split
- `stylePaneBorder()` → pane title + colored border per agent
- `enableBorderStatus()` → show titles in border bar
- `hidePane()` / `showPane()` → break-pane / join-pane wrappers
- 8-color palette matching CC `AgentColorName` (blue, green, yellow, cyan, magenta, red, white, orange)
- Wired into `team-lifecycle.ts` spawn `--exec` path

## Layout

```
┌────────────┬──────────────────────┐
│            │  agent-1 (blue)      │
│  leader    ├──────────────────────┤
│  (30%)     │  agent-2 (green)     │
│            ├──────────────────────┤
│            │  agent-3 (yellow)    │
└────────────┴──────────────────────┘
```

## Test plan

- [ ] `bun build src/cli.ts` — builds clean
- [ ] `maw team create test && maw team spawn test agent-1 --exec` → split + colored border
- [ ] Spawn 3 agents → leader 30% left, agents stacked right with distinct colors
- [ ] `maw close` → panes hidden (break-pane), `maw open` → panes restored (join-pane)

Closes #1019

🤖 Generated with [Claude Code](https://claude.com/claude-code)