### PR TITLE
feat(wake): session = team — auto-register team on wake

### DIFF
--- a/src/commands/plugins/team/ensure-config.ts
+++ b/src/commands/plugins/team/ensure-config.ts
@@ -1,0 +1,19 @@
+import { existsSync, mkdirSync, writeFileSync } from "fs";
+import { join } from "path";
+import { TEAMS_DIR, type TeamConfig } from "./team-helpers";
+
+export function ensureTeamConfig(name: string, description?: string): boolean {
+  const configDir = join(TEAMS_DIR, name);
+  const configPath = join(configDir, "config.json");
+  if (existsSync(configPath)) return false;
+
+  mkdirSync(configDir, { recursive: true });
+  const config: TeamConfig = {
+    name,
+    description: description ?? `Auto-created team for session ${name}`,
+    members: [],
+    createdAt: Date.now(),
+  };
+  writeFileSync(configPath, JSON.stringify(config, null, 2));
+  return true;
+}

--- a/src/commands/plugins/team/index.ts
+++ b/src/commands/plugins/team/index.ts
@@ -27,6 +27,20 @@ export const command = {
 function resolveTeamFromContext(): string {
   const envTeam = process.env.MAW_TEAM;
   if (envTeam) return envTeam;
+
+  // #1020 — detect team from tmux session name (strip NN- prefix)
+  if (process.env.TMUX) {
+    try {
+      const { execSync } = require("child_process");
+      const sessionName = execSync("tmux display-message -p '#{session_name}'", { encoding: "utf-8" }).trim();
+      const teamName = sessionName.replace(/^\d+-/, "");
+      const teamsDir = join(homedir(), ".claude/teams");
+      if (teamName && existsSync(join(teamsDir, teamName, "config.json"))) {
+        return teamName;
+      }
+    } catch { /* not in tmux or tmux failed */ }
+  }
+
   const teamsDir = join(homedir(), ".claude/teams");
   try {
     const live = readdirSync(teamsDir).filter(d =>

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -117,6 +117,13 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
       console.log(`\x1b[32m+\x1b[0m registered agent '${oracle}' → '${node}' in config.agents`);
     }
 
+    // #1020 — session = team: auto-create team config so `maw team spawn`
+    // works without explicit `maw team create`.
+    const { ensureTeamConfig } = await import("../plugins/team/ensure-config");
+    if (ensureTeamConfig(oracle)) {
+      console.log(`\x1b[32m+\x1b[0m team '${oracle}' auto-created`);
+    }
+
     if (!opts.task && !opts.wt) {
       const allWt = await findWorktrees(parentDir, repoName);
       const usedNames = new Set<string>();


### PR DESCRIPTION
## Summary

- New `ensure-config.ts` — idempotent team config writer (creates `~/.claude/teams/{oracle}/config.json`)
- `wake-cmd.ts` — auto-calls `ensureTeamConfig(oracle)` after session creation
- `resolveTeamFromContext()` — detects team from `$TMUX` session name (strips NN- prefix)

## Flow

```
# Before: 3 steps
maw wake mawjs
maw team create mawjs
maw team spawn mawjs researcher --exec

# After: 2 steps
maw wake mawjs          → auto-creates team "mawjs"
maw team spawn researcher --exec    → auto-detects team from $TMUX
```

## Resolution priority

```
$MAW_TEAM env → $TMUX session name (strip NN-) → single team → "default"
```

## Test plan

- [ ] `maw wake test-oracle` → creates session + auto-creates `~/.claude/teams/test-oracle/config.json`
- [ ] Inside that session: `maw team spawn researcher --exec` → detects team without `--team` flag
- [ ] `MAW_TEAM=override maw team tasks` → env var takes priority over $TMUX
- [ ] Non-tmux: falls back to single-team or "default"

Closes #1020

🤖 Generated with [Claude Code](https://claude.com/claude-code)