### PR TITLE
feat(team): tiled layout + layout command + shutdown cleanup

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -39,6 +39,7 @@ export const ALIAS_DESCRIPTIONS: Record<string, string> = {
   open: "Bring back hidden panes (join-pane)",
   close: "Hide panes without killing (break-pane)",
   t: "Team — create, spawn, send, shutdown",
+  layout: "Apply team layout (main-vertical or tiled)",
   cleanup: "Kill zombie agent panes",
   ls: "List sessions (compact, -a roster, -v detail)",
   wake: "Wake an oracle session (fuzzy match, auto-clone)",
@@ -53,6 +54,7 @@ export const TOP_ALIASES: Record<string, string[] | DirectHandler> = {
   open: ["tmux", "open"],
   close: ["tmux", "close"],
   t: ["team"],
+  layout: ["team", "layout"],
   cleanup: ["team", "cleanup", "--zombie-agents"],
 
   // Direct-handler form — `ls` flags differ from tmux ls:

--- a/src/commands/plugins/team/index.ts
+++ b/src/commands/plugins/team/index.ts
@@ -280,9 +280,29 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       }
       await cmdTmuxPeek(target);
 
+    } else if (sub === "layout") {
+      // maw team layout [main-vertical|tiled] [--pct N]
+      if (!process.env.TMUX) {
+        logs.push("\x1b[33m⚠\x1b[0m layout requires tmux");
+        return { ok: false, error: "not in tmux" };
+      }
+      const { applyTeamLayout, applyTiledLayout, getWindowTarget } = await import("../tmux/layout-manager");
+      const preset = args[1] || "main-vertical";
+      const window = await getWindowTarget();
+      const anchor = process.env.TMUX_PANE ?? "";
+      if (preset === "tiled") {
+        await applyTiledLayout(window);
+        console.log(`\x1b[32m✓\x1b[0m applied tiled layout`);
+      } else {
+        const pctIdx = args.indexOf("--pct");
+        const pct = pctIdx !== -1 ? parseInt(args[pctIdx + 1] || "30") : 30;
+        await applyTeamLayout(window, anchor, pct);
+        console.log(`\x1b[32m✓\x1b[0m applied main-vertical layout (leader ${pct}%)`);
+      }
+
     } else {
       logs.push(`unknown team subcommand: ${sub}`);
-      logs.push("usage: maw team <create|spawn|send|shutdown|split|peek|resume|lives|list|status|add|tasks|done|assign|delete>");
+      logs.push("usage: maw team <create|spawn|send|shutdown|split|peek|layout|resume|lives|list|status|add|tasks|done|assign|delete>");
       return { ok: false, error: `unknown subcommand: ${sub}`, output: logs.join("\n") };
     }
 

--- a/src/commands/plugins/tmux/layout-manager.ts
+++ b/src/commands/plugins/tmux/layout-manager.ts
@@ -44,6 +44,10 @@ export async function rebalanceAfterSpawn(
   await applyTeamLayout(windowTarget, leaderPane);
 }
 
+export async function applyTiledLayout(windowTarget: string): Promise<void> {
+  await hostExec(`tmux select-layout -t '${windowTarget}' tiled`);
+}
+
 // ─── Pane Borders ────────────────────────────────────────
 
 export async function stylePaneBorder(
@@ -79,6 +83,28 @@ export async function showPane(paneId: string, targetPane: string): Promise<bool
     await hostExec(`tmux join-pane -h -s '${paneId}' -t '${targetPane}'`);
     return true;
   } catch { return false; }
+}
+
+// ─── Shutdown Cleanup ────────────────────────────────────
+
+export async function cleanupTeamPanes(
+  leaderPane: string,
+  teammatePaneIds: string[],
+  opts: { hide?: boolean } = {},
+): Promise<number> {
+  let cleaned = 0;
+  for (const pane of teammatePaneIds) {
+    if (pane === leaderPane) continue;
+    try {
+      if (opts.hide) {
+        await hostExec(`tmux break-pane -d -t '${pane}'`);
+      } else {
+        await hostExec(`tmux kill-pane -t '${pane}'`);
+      }
+      cleaned++;
+    } catch { /* already gone */ }
+  }
+  return cleaned;
 }
 
 // ─── Helpers ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `applyTiledLayout()` — equal pane distribution (no leader), CC tiled mode
- `cleanupTeamPanes()` — kill or hide teammate panes on shutdown
- `maw team layout [main-vertical|tiled] [--pct N]` — switch layout on the fly
- `maw layout` alias → `maw team layout`

## Usage

```bash
maw layout                    # main-vertical (leader 30% left)
maw layout tiled              # equal distribution
maw layout main-vertical --pct 40   # leader 40% left
```

## Test plan

- [ ] Builds clean
- [ ] `maw layout` → applies main-vertical
- [ ] `maw layout tiled` → applies tiled
- [ ] `maw layout main-vertical --pct 50` → leader 50%

🤖 Generated with [Claude Code](https://claude.com/claude-code)