### PR TITLE
release: v26.4.30-alpha.1320

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.30-alpha.1254",
+  "version": "26.4.30-alpha.1320",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts v26.4.30-alpha.1320 on merge via calver-release.yml.

Includes:
- #1025 refactor(cli): aliases inline with core commands
- #1026 feat(team): CC-style layout manager (main-vertical + colored borders)
- #1027 feat(wake): session = team (auto-register team on wake)
- #1028 feat(team): tiled layout + layout command + shutdown cleanup

Auto-generated by /release-alpha.