### PR TITLE
feat(team): unified spawn + agent IDs + colored status + shutdown cleanup

### DIFF
--- a/src/commands/plugins/team/team-lifecycle.ts
+++ b/src/commands/plugins/team/team-lifecycle.ts
@@ -114,7 +114,17 @@ export async function cmdTeamShutdown(name: string, opts: { force?: boolean; mer
     }
   }
 
-  // FUSION: merge team knowledge into individual oracle mailboxes
+  // Step 4: Clean up any remaining panes (hide or kill)
+  try {
+    const { cleanupTeamPanes } = await import("../tmux/layout-manager");
+    const leaderPane = process.env.TMUX_PANE ?? "";
+    const allPaneIds = teammates.map(m => m.tmuxPaneId).filter(Boolean) as string[];
+    const cleaned = await cleanupTeamPanes(leaderPane, allPaneIds, { hide: !opts.force });
+    if (cleaned > 0) {
+      console.log(`  \x1b[90m${opts.force ? "killed" : "hidden"} ${cleaned} leftover pane${cleaned !== 1 ? "s" : ""}\x1b[0m`);
+    }
+  } catch { /* layout-manager not available outside tmux */ }
+
   if (opts.merge) {
     mergeTeamKnowledge(name, teammates);
   }
@@ -253,33 +263,24 @@ export async function cmdTeamSpawn(
       return;
     }
     try {
-      const { hostExec, withPaneLock } = await import("../../../sdk");
-      const {
-        rebalanceAfterSpawn, stylePaneBorder, enableBorderStatus,
-        nextAgentColor, getWindowTarget, colorAnsi,
-      } = await import("../tmux/layout-manager");
+      const { spawnTeammatePane, colorAnsi } = await import("../tmux/layout-manager");
       const claudeCmd = `claude --model ${model} --prompt-file '${promptPath.replace(/'/g, "'\\''")}'`;
-      const anchor = process.env.TMUX_PANE;
-      const targetFlag = anchor ? `-t '${anchor}' ` : "";
+      const teammateCount = manifest.members.filter((m: any) => m.name !== role).length;
+      const agentId = `${role}@${teamName}`;
 
-      let newPaneId = "";
-      await withPaneLock(async () => {
-        newPaneId = (await hostExec(
-          `tmux split-window ${targetFlag}-h -P -F '#{pane_id}' '${claudeCmd.replace(/'/g, "'\\''")}'`,
-        )).trim();
-        await sleep(200);
-      });
+      const result = await spawnTeammatePane(role, claudeCmd, { colorIndex: teammateCount });
 
-      const teammateCount = manifest.members.length - 1;
-      const color = nextAgentColor(teammateCount);
-      const window = await getWindowTarget();
-
-      if (anchor) await rebalanceAfterSpawn(window, anchor);
-      if (newPaneId) await stylePaneBorder(newPaneId, role, color);
-      await enableBorderStatus(window);
+      // Persist pane state to team config
+      const member = manifest.members.find((m: any) => m.name === role);
+      if (member) {
+        member.tmuxPaneId = result.paneId;
+        member.color = result.color;
+        member.agentId = agentId;
+        writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+      }
 
       console.log();
-      console.log(`  \x1b[32m✓ --exec\x1b[0m spawned ${role} in a new tmux pane [\x1b[${colorAnsi(color)}m${color}\x1b[0m]`);
+      console.log(`  \x1b[32m✓ --exec\x1b[0m spawned \x1b[${colorAnsi(result.color)}m${agentId}\x1b[0m in pane ${result.paneId}`);
     } catch (e: any) {
       console.log();
       console.log(`  \x1b[33m⚠\x1b[0m --exec split failed: ${e?.message || e}`);

--- a/src/commands/plugins/team/team-status.ts
+++ b/src/commands/plugins/team/team-status.ts
@@ -4,6 +4,7 @@ import { homedir } from "os";
 import { hostExec } from "../../../sdk";
 import { cmdTeamTaskList, type MawTask } from "./task-ops";
 import { loadTeam } from "./impl";
+import { type AgentColor, colorAnsi } from "../tmux/layout-manager";
 
 const TEAMS_DIR = join(homedir(), ".claude/teams");
 
@@ -18,34 +19,27 @@ function listTeams(): string[] {
     .map(e => e.name);
 }
 
-async function getPanes(): Promise<Map<string, string>> {
-  const paneMap = new Map<string, string>();
+async function getAlivePanes(): Promise<Set<string>> {
   try {
-    const out = await hostExec(
-      "tmux list-panes -a -F '#{pane_id} #{session_name}:#{window_index} #{pane_current_command}'"
-    );
-    for (const line of out.split("\n").filter(Boolean)) {
-      const [paneId, session, cmd] = line.split(" ");
-      if (paneId) paneMap.set(paneId, `${session ?? ""} ${cmd ?? ""}`.trim());
-    }
-  } catch { /* tmux may not be running */ }
-  return paneMap;
+    const out = await hostExec("tmux list-panes -a -F '#{pane_id}'");
+    return new Set(out.split("\n").filter(Boolean));
+  } catch { return new Set(); }
 }
 
 export async function cmdTeamStatus(teamName?: string): Promise<void> {
   const teams = teamName ? [teamName] : listTeams();
 
   if (teams.length === 0) {
-    console.log(`\x1b[36mℹ\x1b[0m no active teams`);
+    console.log(`\x1b[36minfo\x1b[0m no active teams`);
     return;
   }
 
-  const panes = await getPanes();
+  const alive = await getAlivePanes();
 
   for (const name of teams) {
     const config = loadTeam(name);
     if (!config) {
-      console.log(`\x1b[33m⚠\x1b[0m team not found: ${name}`);
+      console.log(`\x1b[33m!\x1b[0m team not found: ${name}`);
       continue;
     }
 
@@ -60,41 +54,47 @@ export async function cmdTeamStatus(teamName?: string): Promise<void> {
     }
 
     const members = config.members.filter(m => m.agentType !== "team-lead");
-    console.log(`\n\x1b[36;1mTeam: ${name}\x1b[0m (${members.length} agents)\n`);
+    console.log(`\n\x1b[36;1m${name}\x1b[0m (${members.length} agents)\n`);
     console.log(
-      `  ${pad("Agent", 15)} ${pad("Status", 9)} ${pad("Task", 29)} Pane`
+      `  ${pad("Agent", 20)} ${pad("Status", 10)} ${pad("Task", 25)} Pane`
     );
     console.log(
-      `  ${"─".repeat(15)} ${"─".repeat(9)} ${"─".repeat(29)} ${"─".repeat(8)}`
+      `  ${"─".repeat(20)} ${"─".repeat(10)} ${"─".repeat(25)} ${"─".repeat(10)}`
     );
 
-    let working = 0;
-    let idle = 0;
+    let running = 0;
+    let dead = 0;
 
     for (const m of members) {
       const memberTasks = taskByAssignee.get(m.name) ?? [];
       const activeTask = memberTasks.find(t => t.status === "in_progress") ?? memberTasks.at(-1);
       const taskLabel = activeTask
-        ? `#${activeTask.id} ${activeTask.subject.slice(0, 20)} [${activeTask.status === "completed" ? "done" : activeTask.status}]`
-        : "-";
+        ? `#${activeTask.id} ${activeTask.subject.slice(0, 18)} [${activeTask.status === "completed" ? "done" : activeTask.status}]`
+        : "\x1b[90m-\x1b[0m";
 
       const paneId = m.tmuxPaneId ?? "";
-      const paneLabel = paneId && panes.has(paneId) ? paneId : (paneId || "-");
-      const isWorking = activeTask?.status === "in_progress";
-      isWorking ? working++ : idle++;
+      const isAlive = paneId ? alive.has(paneId) : false;
+      isAlive ? running++ : dead++;
 
-      const statusTxt = isWorking
-        ? `\x1b[36mworking\x1b[0m  `
-        : `\x1b[90midle\x1b[0m     `;
+      const color = (m.color as AgentColor) || "white";
+      const ansi = colorAnsi(color);
+      const agentId = m.agentId || m.name;
 
-      console.log(
-        `  ${pad(m.name, 15)} ${statusTxt} ${pad(taskLabel, 29)} ${paneLabel}`
-      );
+      const dot = isAlive ? `\x1b[${ansi}m●\x1b[0m` : `\x1b[90m·\x1b[0m`;
+      const nameCol = isAlive
+        ? `\x1b[${ansi}m${pad(agentId, 18)}\x1b[0m`
+        : `\x1b[90m${pad(agentId, 18)}\x1b[0m`;
+      const statusCol = isAlive
+        ? `\x1b[32mrunning\x1b[0m   `
+        : `\x1b[90mexited\x1b[0m    `;
+      const paneCol = isAlive ? paneId : `\x1b[90m${paneId || "-"}\x1b[0m`;
+
+      console.log(`  ${dot} ${nameCol} ${statusCol} ${pad(taskLabel, 25)} ${paneCol}`);
     }
 
     const done = tasks.filter(t => t.status === "completed").length;
     console.log(
-      `\n  \x1b[90mTasks: ${done}/${tasks.length} done | Agents: ${working} working, ${idle} idle\x1b[0m`
+      `\n  \x1b[90mTasks: ${done}/${tasks.length} done | ${running} running, ${dead} exited\x1b[0m`
     );
   }
   console.log("");

--- a/src/commands/plugins/tmux/layout-manager.ts
+++ b/src/commands/plugins/tmux/layout-manager.ts
@@ -107,6 +107,43 @@ export async function cleanupTeamPanes(
   return cleaned;
 }
 
+// ─── Unified Spawn ───────────────────────────────────────
+
+export interface SpawnResult {
+  paneId: string;
+  color: AgentColor;
+  isFirst: boolean;
+}
+
+export async function spawnTeammatePane(
+  agentName: string,
+  command: string,
+  opts: { colorIndex: number; leaderPane?: string } = { colorIndex: 0 },
+): Promise<SpawnResult> {
+  const { withPaneLock } = await import("../../../sdk");
+  const anchor = opts.leaderPane || process.env.TMUX_PANE || "";
+  const targetFlag = anchor ? `-t '${anchor}' ` : "";
+  const color = nextAgentColor(opts.colorIndex);
+
+  let paneId = "";
+  await withPaneLock(async () => {
+    paneId = (await hostExec(
+      `tmux split-window ${targetFlag}-h -P -F '#{pane_id}' '${command.replace(/'/g, "'\\''")}'`,
+    )).trim();
+    await new Promise(r => setTimeout(r, 200));
+  });
+
+  const window = await getWindowTarget();
+  const panes = await listPaneIds(window);
+  const isFirst = panes.length <= 2;
+
+  if (anchor) await rebalanceAfterSpawn(window, anchor);
+  if (paneId) await stylePaneBorder(paneId, agentName, color);
+  await enableBorderStatus(window);
+
+  return { paneId, color, isFirst };
+}
+
 // ─── Helpers ─────────────────────────────────────────────
 
 export async function getWindowTarget(): Promise<string> {


### PR DESCRIPTION
## Summary

Phase 1+2 of CC swarm parity plan (~96 LOC net):

- **Unified `spawnTeammatePane()`** — one call does split + lock + color + rebalance + border status
- **Agent IDs** — `role@teamName` format, persisted to team config with paneId and color
- **Colored `maw team status`** — colored dots (● running / · exited), agent IDs, alive detection
- **Shutdown cleanup** — `cleanupTeamPanes` hides or kills leftover panes after shutdown

## Before/After

```
# Before: spawn output
✓ --exec spawned researcher in a new tmux pane (right, 50%)

# After: spawn output  
✓ --exec spawned researcher@mawjs in pane %42
```

```
# Before: maw team status
  Agent           Status    Task                          Pane
  researcher      working   #1 research...                %42

# After: maw team status
  ● researcher@mawjs  running    #1 research...            %42
  · analyst@mawjs     exited     -                         %43
```

## Test plan

- [ ] Builds clean
- [ ] `maw team spawn test agent --exec` → shows agent@team, pane ID, color
- [ ] `maw team status` → colored dots, alive detection
- [ ] `maw team shutdown test --force` → cleans up leftover panes
- [ ] Team config has tmuxPaneId, color, agentId after spawn

🤖 Generated with [Claude Code](https://claude.com/claude-code)