### PR TITLE
fix(cli): restore marketplace plugin subcommand routing

### DIFF
--- a/src/cli/route-tools.ts
+++ b/src/cli/route-tools.ts
@@ -32,9 +32,10 @@ export async function routeTools(cmd: string, args: string[]): Promise<boolean> 
   }
   if (cmd === "plugin") {
     const sub = args[1]?.toLowerCase();
-    // "maw plugin init|build|install" → forward to the plugin-lifecycle
-    // plugin (tasks #2 + #3 both landed).
-    if (sub === "init" || sub === "build" || sub === "install") {
+    // "maw plugin init|build|install|search|registry|pin|unpin|dev" →
+    // forward to the plugin-lifecycle plugin (marketplace pipeline).
+    const lifecycleSubs = new Set(["init", "build", "install", "search", "registry", "pin", "unpin", "dev"]);
+    if (sub && lifecycleSubs.has(sub)) {
       const { loadManifestFromDir } = await import("../plugin/manifest");
       const { invokePlugin } = await import("../plugin/registry");
       const { resolve, join } = await import("path");


### PR DESCRIPTION
## Summary

- During lean-core refactoring, `route-tools.ts` only forwarded `init|build|install` to the plugin-lifecycle handler
- Marketplace commands (`search`, `registry`, `pin`, `unpin`, `dev`) fell through to the `create` usage message — silently unreachable
- Handler code in `src/commands/plugins/plugin/index.ts` was intact — only the routing was missing
- Fix: Set-based routing for all 8 lifecycle subcommands

## Changed

- `src/cli/route-tools.ts` — 4 lines changed

## Verified (117 tests)

- `maw plugin registry` → reaches handler
- `maw plugin search oracle --peers-only` → shows peer results
- 5 test suites: 117/117 pass (search-peers, install-*, lock)
- Regression: existing commands unaffected
- Build: clean 1.65 MB

## Test plan

- [x] `maw plugin registry` — reaches handler (not "usage: create")
- [x] `maw plugin search` — reaches handler
- [x] `maw plugin search --peers-only` — peer results
- [x] `maw plugin info` — works (regression)
- [x] `bun build` — clean
- [x] `bun test src/commands/plugins/plugin/` — 117/117 pass

⚡ Generated by Gale