### PR TITLE
feat(team): zoom + structured inbox (Phase 3)

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -40,6 +40,7 @@ export const ALIAS_DESCRIPTIONS: Record<string, string> = {
   close: "Hide panes without killing (break-pane)",
   t: "Team — create, spawn, send, shutdown",
   layout: "Apply team layout (main-vertical or tiled)",
+  zoom: "Toggle zoom on a pane",
   panes: "List all panes across sessions",
   cleanup: "Kill zombie agent panes",
   ls: "List sessions (compact, -a roster, -v detail)",
@@ -56,6 +57,7 @@ export const TOP_ALIASES: Record<string, string[] | DirectHandler> = {
   close: ["tmux", "close"],
   t: ["team"],
   layout: ["team", "layout"],
+  zoom: ["tmux", "zoom"],
   panes: ["tmux", "ls", "--all", "--verbose"],
   cleanup: ["team", "cleanup", "--zombie-agents"],
 

--- a/src/commands/plugins/team/inbox.ts
+++ b/src/commands/plugins/team/inbox.ts
@@ -1,0 +1,83 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync, renameSync } from "fs";
+import { join } from "path";
+import { TEAMS_DIR } from "./team-helpers";
+
+export type MessageType = "shutdown" | "progress" | "done" | "stuck" | "status";
+
+export interface InboxMessage {
+  type: MessageType;
+  from: string;
+  to: string;
+  timestamp: number;
+  payload: Record<string, unknown>;
+  read?: boolean;
+}
+
+function inboxDir(teamName: string, agent: string): string {
+  const dir = join(TEAMS_DIR, teamName, "inboxes", agent);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+export function writeInboxMessage(teamName: string, to: string, msg: Omit<InboxMessage, "timestamp">): string {
+  const dir = inboxDir(teamName, to);
+  const ts = Date.now();
+  const full: InboxMessage = { ...msg, timestamp: ts };
+  const filename = `${ts}-${msg.type}.json`;
+  const tmpPath = join(dir, `.${filename}.tmp`);
+  const finalPath = join(dir, filename);
+  writeFileSync(tmpPath, JSON.stringify(full, null, 2));
+  renameSync(tmpPath, finalPath);
+  return finalPath;
+}
+
+export function readInbox(teamName: string, agent: string): InboxMessage[] {
+  const dir = inboxDir(teamName, agent);
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter(f => f.endsWith(".json") && !f.startsWith("."))
+    .sort()
+    .map(f => {
+      try { return JSON.parse(readFileSync(join(dir, f), "utf-8")) as InboxMessage; }
+      catch { return null; }
+    })
+    .filter((m): m is InboxMessage => m !== null);
+}
+
+export function readUnread(teamName: string, agent: string): InboxMessage[] {
+  return readInbox(teamName, agent).filter(m => !m.read);
+}
+
+export function markRead(teamName: string, agent: string): number {
+  const dir = inboxDir(teamName, agent);
+  if (!existsSync(dir)) return 0;
+  let count = 0;
+  for (const f of readdirSync(dir).filter(f => f.endsWith(".json") && !f.startsWith("."))) {
+    try {
+      const path = join(dir, f);
+      const msg: InboxMessage = JSON.parse(readFileSync(path, "utf-8"));
+      if (!msg.read) {
+        msg.read = true;
+        writeFileSync(path, JSON.stringify(msg, null, 2));
+        count++;
+      }
+    } catch { /* skip corrupt */ }
+  }
+  return count;
+}
+
+export function sendProgress(teamName: string, from: string, status: string): string {
+  return writeInboxMessage(teamName, "leader", { type: "progress", from, to: "leader", payload: { status } });
+}
+
+export function sendDone(teamName: string, from: string, summary: string): string {
+  return writeInboxMessage(teamName, "leader", { type: "done", from, to: "leader", payload: { summary } });
+}
+
+export function sendStuck(teamName: string, from: string, reason: string): string {
+  return writeInboxMessage(teamName, "leader", { type: "stuck", from, to: "leader", payload: { reason } });
+}
+
+export function sendShutdown(teamName: string, to: string, reason: string): string {
+  return writeInboxMessage(teamName, to, { type: "shutdown", from: "leader", to, payload: { reason } });
+}

--- a/src/commands/plugins/team/index.ts
+++ b/src/commands/plugins/team/index.ts
@@ -392,9 +392,34 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         console.log(`\x1b[32m✓\x1b[0m applied main-vertical layout (leader ${pct}%)`);
       }
 
+    } else if (sub === "inbox") {
+      // maw team inbox [agent] [--mark-read]
+      const { readInbox, readUnread, markRead } = await import("./inbox");
+      const teamName = resolveTeamFromContext();
+      const agent = args[1] || "leader";
+      const doMark = args.includes("--mark-read");
+
+      const messages = doMark ? readInbox(teamName, agent) : readUnread(teamName, agent);
+      if (messages.length === 0) {
+        console.log(`\x1b[90mno ${doMark ? "" : "unread "}messages for ${agent}@${teamName}\x1b[0m`);
+      } else {
+        const { colorAnsi } = await import("../tmux/layout-manager");
+        for (const m of messages) {
+          const ts = new Date(m.timestamp).toLocaleTimeString("en", { hour12: false, hour: "2-digit", minute: "2-digit" });
+          const typeColor = m.type === "done" ? "32" : m.type === "stuck" ? "31" : m.type === "progress" ? "36" : "33";
+          const payload = Object.values(m.payload).join(" ").slice(0, 60);
+          console.log(`  \x1b[${typeColor}m${m.type.padEnd(10)}\x1b[0m \x1b[90m${ts}\x1b[0m ${m.from} → ${payload}`);
+        }
+        console.log(`\x1b[90m  ${messages.length} message${messages.length !== 1 ? "s" : ""}\x1b[0m`);
+      }
+      if (doMark) {
+        const marked = markRead(teamName, agent);
+        if (marked > 0) console.log(`\x1b[32m✓\x1b[0m marked ${marked} message${marked !== 1 ? "s" : ""} read`);
+      }
+
     } else {
       logs.push(`unknown team subcommand: ${sub}`);
-      logs.push("usage: maw team <create|spawn|send|shutdown|split|peek|layout|resume|lives|list|status|add|tasks|done|assign|delete>");
+      logs.push("usage: maw team <create|spawn|send|shutdown|split|peek|hey|inbox|layout|prep|resume|lives|list|status|add|tasks|done|assign|delete>");
       return { ok: false, error: `unknown subcommand: ${sub}`, output: logs.join("\n") };
     }
 

--- a/src/commands/plugins/tmux/index.ts
+++ b/src/commands/plugins/tmux/index.ts
@@ -1,6 +1,6 @@
 import type { InvokeContext, InvokeResult } from "../../../plugin/types";
 import { parseFlags } from "../../../cli/parse-args";
-import { cmdTmuxPeek, cmdTmuxLs, cmdTmuxSend, cmdTmuxSplit, cmdTmuxKill, cmdTmuxLayout, cmdTmuxAttach } from "./impl";
+import { cmdTmuxPeek, cmdTmuxLs, cmdTmuxSend, cmdTmuxSplit, cmdTmuxKill, cmdTmuxLayout, cmdTmuxAttach, resolveTmuxTarget } from "./impl";
 import { hostExec } from "../../../sdk";
 
 export const command = {
@@ -224,6 +224,16 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         const { cmdSplit } = await import("../split/impl");
         await cmdSplit(target, { lock: true });
       }
+    } else if (sub === "zoom") {
+      const target = args[1];
+      if (!target) {
+        console.log("usage: maw tmux zoom <target>");
+        return { ok: false, error: "target required", output: logs.join("\n") };
+      }
+      const { resolved } = resolveTmuxTarget(target) ?? { resolved: target };
+      await hostExec(`tmux resize-pane -Z -t '${resolved}'`);
+      console.log(`\x1b[32m✓\x1b[0m toggled zoom on ${resolved}`);
+
     } else if (!sub || sub === "--help" || sub === "-h") {
       console.log("usage: maw tmux <ls|peek|send|split|kill|open|close|layout|attach> [args]");
       console.log("  ls [--all]              list panes with fleet + team annotations");


### PR DESCRIPTION
## Summary

- `maw zoom <target>` — toggle zoom on any pane (5-way target resolution)
- New `inbox.ts` (83 LOC) — 5 typed messages (shutdown/progress/done/stuck/status), atomic writes
- `maw team inbox [agent] [--mark-read]` — read messages with colored labels

## Usage

```bash
maw zoom %301           # toggle zoom on pane
maw zoom agent-1        # by team agent name
maw team inbox          # read leader inbox
maw team inbox agent-1  # read agent's inbox
```

Closes #1034

🤖 Generated with [Claude Code](https://claude.com/claude-code)