### PR TITLE
feat(team): session recovery — layout snapshot + recover (Phase 4)

### DIFF
--- a/src/commands/plugins/team/index.ts
+++ b/src/commands/plugins/team/index.ts
@@ -417,9 +417,52 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         if (marked > 0) console.log(`\x1b[32m✓\x1b[0m marked ${marked} message${marked !== 1 ? "s" : ""} read`);
       }
 
+    } else if (sub === "recover") {
+      // maw team recover [team-name] — restore layout from snapshot
+      const { loadLayoutSnapshot } = await import("./layout-snapshot");
+      const {
+        stylePaneBorder, enableBorderStatus, applyTeamLayout, getWindowTarget, colorAnsi,
+      } = await import("../tmux/layout-manager");
+      const teamName = args[1] || resolveTeamFromContext();
+      const snapshot = loadLayoutSnapshot(teamName);
+      if (!snapshot) {
+        logs.push(`\x1b[33m⚠\x1b[0m no layout snapshot for team '${teamName}'`);
+        return { ok: false, error: "no snapshot" };
+      }
+
+      const alive = await (async () => {
+        try {
+          const out = await hostExec("tmux list-panes -a -F '#{pane_id}'");
+          return new Set(out.split("\n").filter(Boolean));
+        } catch { return new Set<string>(); }
+      })();
+
+      let recovered = 0;
+      let dead = 0;
+      for (const p of snapshot.panes) {
+        if (alive.has(p.tmuxPaneId)) {
+          await stylePaneBorder(p.tmuxPaneId, p.name, p.color);
+          recovered++;
+          console.log(`  \x1b[${colorAnsi(p.color)}m●\x1b[0m ${p.agentId} → ${p.tmuxPaneId} (alive)`);
+        } else {
+          dead++;
+          console.log(`  \x1b[90m·\x1b[0m ${p.agentId} → ${p.tmuxPaneId} (dead)`);
+        }
+      }
+
+      if (recovered > 0) {
+        const window = await getWindowTarget();
+        const anchor = process.env.TMUX_PANE ?? snapshot.leaderPane;
+        await applyTeamLayout(window, anchor);
+        await enableBorderStatus(window);
+      }
+
+      const age = Math.round((Date.now() - snapshot.savedAt) / 60000);
+      console.log(`\x1b[32m✓\x1b[0m recovered ${recovered} pane${recovered !== 1 ? "s" : ""}, ${dead} dead (snapshot ${age}m ago)`);
+
     } else {
       logs.push(`unknown team subcommand: ${sub}`);
-      logs.push("usage: maw team <create|spawn|send|shutdown|split|peek|hey|inbox|layout|prep|resume|lives|list|status|add|tasks|done|assign|delete>");
+      logs.push("usage: maw team <create|spawn|send|shutdown|split|peek|hey|inbox|layout|prep|recover|resume|lives|list|status|add|tasks|done|assign|delete>");
       return { ok: false, error: `unknown subcommand: ${sub}`, output: logs.join("\n") };
     }
 

--- a/src/commands/plugins/team/layout-snapshot.ts
+++ b/src/commands/plugins/team/layout-snapshot.ts
@@ -1,0 +1,57 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+import { TEAMS_DIR, loadTeam } from "./team-helpers";
+import type { AgentColor } from "../tmux/layout-manager";
+
+export interface PaneSnapshot {
+  name: string;
+  agentId: string;
+  tmuxPaneId: string;
+  color: AgentColor;
+  command?: string;
+}
+
+export interface LayoutSnapshot {
+  teamName: string;
+  leaderPane: string;
+  layout: string;
+  panes: PaneSnapshot[];
+  savedAt: number;
+}
+
+function snapshotPath(teamName: string): string {
+  return join(TEAMS_DIR, teamName, "layout.json");
+}
+
+export function saveLayoutSnapshot(teamName: string, leaderPane: string, layout = "main-vertical"): void {
+  const team = loadTeam(teamName);
+  if (!team) return;
+
+  const panes: PaneSnapshot[] = team.members
+    .filter(m => m.tmuxPaneId && m.agentType !== "team-lead")
+    .map(m => ({
+      name: m.name,
+      agentId: m.agentId || `${m.name}@${teamName}`,
+      tmuxPaneId: m.tmuxPaneId!,
+      color: (m.color as AgentColor) || "blue",
+    }));
+
+  const snapshot: LayoutSnapshot = {
+    teamName,
+    leaderPane,
+    layout,
+    panes,
+    savedAt: Date.now(),
+  };
+
+  const dir = join(TEAMS_DIR, teamName);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(snapshotPath(teamName), JSON.stringify(snapshot, null, 2));
+}
+
+export function loadLayoutSnapshot(teamName: string): LayoutSnapshot | null {
+  const path = snapshotPath(teamName);
+  if (!existsSync(path)) return null;
+  try { return JSON.parse(readFileSync(path, "utf-8")); }
+  catch { return null; }
+}

--- a/src/commands/plugins/team/team-lifecycle.ts
+++ b/src/commands/plugins/team/team-lifecycle.ts
@@ -285,6 +285,10 @@ export async function cmdTeamSpawn(
         } catch { /* best effort */ }
       }
 
+      // Save layout snapshot for session recovery (#1035)
+      const { saveLayoutSnapshot } = await import("./layout-snapshot");
+      saveLayoutSnapshot(teamName, process.env.TMUX_PANE ?? "");
+
       console.log();
       console.log(`  \x1b[32m✓ --exec\x1b[0m spawned \x1b[${colorAnsi(result.color)}m${agentId}\x1b[0m in pane ${result.paneId}`);
     } catch (e: any) {


### PR DESCRIPTION
Save layout on spawn, recover after crash. Closes #1035.