### PR TITLE
fix(wake): force COLUMNS=200 LINES=50 + handler-scoped cwd resolution (3-commit stack)

### DIFF
--- a/src/api/sessions.ts
+++ b/src/api/sessions.ts
@@ -137,8 +137,18 @@ sessionsApi.post("/send", async ({ body, set}) => {
       await sendKeys(resolved.target, message);
       await Bun.sleep(150);
       let lastLine = "";
-      try { const content = await capture(resolved.target, 3); lastLine = content.split("\n").filter(l => l.trim()).pop() || ""; } catch {}
-      return { ok: true, target: resolved.target, text, source: "local", lastLine };
+      // Echo broadcast bug 2026-04-26: claude queues input behind a busy prompt and
+      // tmux send-keys still succeeds, so callers think delivery worked. Detect the
+      // "Press up to edit queued messages" indicator so the API can distinguish
+      // delivered vs queued.
+      let state: "delivered" | "queued" = "delivered";
+      try {
+        const content = await capture(resolved.target, 8);
+        const lines = content.split("\n").filter(l => l.trim());
+        lastLine = lines.pop() || "";
+        if (/Press up to edit queued messages/i.test(content)) state = "queued";
+      } catch {}
+      return { ok: true, target: resolved.target, text, source: "local", lastLine, state };
     }
 
     // Remote peer → federation HTTP
@@ -149,7 +159,7 @@ sessionsApi.post("/send", async ({ body, set}) => {
         timeout: 10000,
       });
       if (res.ok && res.data?.ok) {
-        return { ok: true, target: res.data.target || target, text, source: resolved.peerUrl, lastLine: res.data.lastLine || "" };
+        return { ok: true, target: res.data.target || target, text, source: resolved.peerUrl, lastLine: res.data.lastLine || "", state: res.data.state ?? "delivered" };
       }
       set.status = 502; return { error: `${resolved.node} → ${resolved.target} send failed`, target, source: resolved.peerUrl };
     }
@@ -158,7 +168,7 @@ sessionsApi.post("/send", async ({ body, set}) => {
     const peerUrl = await findPeerForTarget(target, local);
     if (peerUrl) {
       const ok = await sendKeysToPeer(peerUrl, target, message);
-      if (ok) return { ok: true, target, text, source: peerUrl };
+      if (ok) return { ok: true, target, text, source: peerUrl, state: "delivered" as const };
       set.status = 502; return { error: "Failed to send to peer", target, source: peerUrl };
     }
 

--- a/src/commands/shared/fleet-resume.ts
+++ b/src/commands/shared/fleet-resume.ts
@@ -3,6 +3,7 @@ import { hostExec as ssh, tmux } from "../../sdk";
 import { buildCommand } from "../../config";
 import { getGhqRoot } from "../../config/ghq-root";
 import type { FleetSession } from "./fleet-load";
+import { pinWindowWide } from "./wake-pane-size";
 
 /** After fleet spawn, send /recap to oracles with active Pulse board items */
 export async function resumeActiveItems() {
@@ -116,6 +117,7 @@ export async function respawnMissingWorktrees(sessions: FleetSession[]): Promise
         usedNames.add(windowName);
         try {
           await tmux.newWindow(sess.name, windowName, { cwd: wtPath });
+          await pinWindowWide(`${sess.name}:${windowName}`);
           await new Promise(r => setTimeout(r, 300));
           await tmux.sendText(`${sess.name}:${windowName}`, buildCommand(windowName));
           console.log(`  \x1b[32m↻\x1b[0m ${windowName} (discovered on disk)`);

--- a/src/commands/shared/fleet-wake.ts
+++ b/src/commands/shared/fleet-wake.ts
@@ -6,6 +6,7 @@ import { getGhqRoot } from "../../config/ghq-root";
 import { ensureSessionRunning } from "./wake";
 import { loadFleet } from "./fleet-load";
 import { respawnMissingWorktrees, resumeActiveItems } from "./fleet-resume";
+import { pinSessionWide, pinWindowWide } from "./wake-pane-size";
 import {
   isSshTransportError,
   runWakeLoopFailSoft,
@@ -76,6 +77,7 @@ export async function cmdWakeAll(opts: { kill?: boolean; all?: boolean; resume?:
       // every Oracle session inherit Labubu's CLAUDE.md identity.
       const firstPath = join(getGhqRoot(), first.repo);
       await tmux.newSession(sess.name, { window: first.name, cwd: firstPath });
+      await pinSessionWide(sess.name);
       for (const [key, val] of Object.entries(getEnvVars())) {
         await tmux.setEnvironment(sess.name, key, val);
       }
@@ -91,6 +93,7 @@ export async function cmdWakeAll(opts: { kill?: boolean; all?: boolean; resume?:
         const winPath = join(getGhqRoot(), win.repo);
         try {
           await tmux.newWindow(sess.name, win.name, { cwd: winPath });
+          await pinWindowWide(`${sess.name}:${win.name}`);
           if (!sess.skip_command) {
             await new Promise(r => setTimeout(r, 300));
             await tmux.sendText(`${sess.name}:${win.name}`, buildCommand(win.name));

--- a/src/commands/shared/fleet-wake.ts
+++ b/src/commands/shared/fleet-wake.ts
@@ -71,7 +71,10 @@ export async function cmdWakeAll(opts: { kill?: boolean; all?: boolean; resume?:
       process.stdout.write(`  \x1b[90m⏳\x1b[0m ${progress} ${sess.name}...`);
 
       const first = sess.windows[0];
-      const firstPath = join(getGhqRoot(), "github.com", first.repo);
+      // #748 — Oracle repos live at <ghqRoot>/<repo> directly (e.g. /root/projects/neo-oracle),
+      // not under github.com/<org>/<repo>. Falling back to /root via missing-cwd was making
+      // every Oracle session inherit Labubu's CLAUDE.md identity.
+      const firstPath = join(getGhqRoot(), first.repo);
       await tmux.newSession(sess.name, { window: first.name, cwd: firstPath });
       for (const [key, val] of Object.entries(getEnvVars())) {
         await tmux.setEnvironment(sess.name, key, val);
@@ -85,7 +88,7 @@ export async function cmdWakeAll(opts: { kill?: boolean; all?: boolean; resume?:
 
       for (let i = 1; i < sess.windows.length; i++) {
         const win = sess.windows[i];
-        const winPath = join(getGhqRoot(), "github.com", win.repo);
+        const winPath = join(getGhqRoot(), win.repo);
         try {
           await tmux.newWindow(sess.name, win.name, { cwd: winPath });
           if (!sess.skip_command) {

--- a/src/commands/shared/target-cwd.ts
+++ b/src/commands/shared/target-cwd.ts
@@ -1,0 +1,54 @@
+import { join } from "path";
+import { loadFleet } from "./fleet-load";
+import { getGhqRoot } from "../../config/ghq-root";
+
+/**
+ * Extract oracle name from a tmux target. Sessions are conventionally
+ * `NN-<oracle>` (e.g. `05-nari` → `nari`). The previous extraction
+ * (`target.split(":").pop()`) returned the window index/name, which
+ * `buildCommand` could not match — falling back to the default command
+ * regardless of which oracle was being woken.
+ */
+export function extractOracleName(target: string): string {
+  const session = target?.split(":")[0] || "";
+  return session.replace(/^\d+-/, "");
+}
+
+/**
+ * Resolve the canonical cwd for a tmux target by looking up the fleet
+ * config. Used by the WS `wake`/`restart` handlers to `cd` into the
+ * intended repo before re-spawning claude — defends against pane cwd
+ * drift (manual cd, server reboot, kill+respawn) which causes claude
+ * to load the wrong CLAUDE.md and present the wrong oracle identity.
+ *
+ * Returns null when the session is not fleet-managed or lookup fails;
+ * the caller falls back to bare cmd (matches pre-fix behavior).
+ */
+export function resolveTargetCwd(target: string): string | null {
+  if (!target) return null;
+  const [session, winRef] = target.split(":");
+  if (!session) return null;
+
+  let fleets;
+  try { fleets = loadFleet(); } catch { return null; }
+
+  const fleet = fleets.find(f => f.name === session);
+  if (!fleet?.windows?.length) return null;
+
+  const win = !winRef
+    ? fleet.windows[0]
+    : /^\d+$/.test(winRef)
+      ? fleet.windows[parseInt(winRef, 10)]
+      : fleet.windows.find(w => w.name === winRef);
+  if (!win?.repo) return null;
+
+  return join(getGhqRoot(), win.repo);
+}
+
+/**
+ * Quote a path for safe inclusion in a shell command. Single-quote wraps
+ * the path and escapes embedded single quotes via `'\''`.
+ */
+export function shellQuote(path: string): string {
+  return `'${path.replace(/'/g, "'\\''")}'`;
+}

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -7,6 +7,7 @@ import { assertValidOracleName } from "../../core/fleet/validate";
 import { resolveOracle, findWorktrees, getSessionMap, resolveFleetSession, detectSession, setSessionEnv, sanitizeBranchName } from "./wake-resolve";
 import { attachToSession, ensureSessionRunning, createWorktree } from "./wake-session";
 import { maybeSplit } from "./wake-maybe-split";
+import { pinSessionWide, pinWindowWide } from "./wake-pane-size";
 
 export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; split?: boolean; repoPath?: string }): Promise<string> {
   // Canonicalize the bare name before any lookup — strips trailing `/`, `/.git`, `/.git/`
@@ -57,6 +58,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
     session = getSessionMap()[oracle] || resolveFleetSession(oracle) || oracle;
     const mainWindowName = `${oracle}-oracle`;
     await tmux.newSession(session, { window: mainWindowName, cwd: repoPath });
+    await pinSessionWide(session);
     await setSessionEnv(session);
     await new Promise(r => setTimeout(r, 300));
     await tmux.sendText(`${session}:${mainWindowName}`, buildCommandInDir(mainWindowName, repoPath));
@@ -80,6 +82,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
         if (usedNames.has(wtWindowName)) wtWindowName = `${oracle}-${wt.name}`;
         usedNames.add(wtWindowName);
         await tmux.newWindow(session, wtWindowName, { cwd: wt.path });
+        await pinWindowWide(`${session}:${wtWindowName}`);
         await new Promise(r => setTimeout(r, 300));
         await tmux.sendText(`${session}:${wtWindowName}`, buildCommandInDir(wtWindowName, wt.path));
         console.log(`\x1b[32m+\x1b[0m window: ${wtWindowName}`);
@@ -106,6 +109,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
           if (existingWindows.includes(wtWindowName) || existingWindows.includes(altName)) continue;
           usedNames.add(wtWindowName);
           await tmux.newWindow(session, wtWindowName, { cwd: wt.path });
+          await pinWindowWide(`${session}:${wtWindowName}`);
           await new Promise(r => setTimeout(r, 300));
           await tmux.sendText(`${session}:${wtWindowName}`, buildCommandInDir(wtWindowName, wt.path));
           console.log(`\x1b[32m↻\x1b[0m respawned: ${wtWindowName}`);
@@ -195,6 +199,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
   } catch { /* session might be fresh */ }
 
   await tmux.newWindow(session, windowName, { cwd: targetPath });
+  await pinWindowWide(`${session}:${windowName}`);
   await new Promise(r => setTimeout(r, 300));
   const cmd = buildCommandInDir(windowName, targetPath);
   if (opts.prompt) {

--- a/src/commands/shared/wake-pane-size.ts
+++ b/src/commands/shared/wake-pane-size.ts
@@ -1,0 +1,25 @@
+import { tmux } from "../../sdk";
+
+// When tmux sessions are created detached (no client attached) tmux defaults
+// to 80x24. The shell inherits that, claude reads TIOCGWINSZ/$COLUMNS at
+// spawn, and writes scrollback at the narrow width. Those bytes are baked
+// permanently into pane history — later resizes wrap historical lines but
+// do not rewrap already-written content. Symptom Boss reported 2026-04-29:
+// woke-from-cron oracle panes render "mobile" (~30 cols) even after the
+// tmux client attaches at 200 cols.
+//
+// Fix: pin window-size to manual, set explicit COLUMNS/LINES envs, and
+// resize-window to a wide default BEFORE send-keys spawns claude.
+export const CLAUDE_COLS = 200;
+export const CLAUDE_ROWS = 50;
+
+export async function pinSessionWide(session: string): Promise<void> {
+  await tmux.setOption(session, "window-size", "manual");
+  await tmux.setEnvironment(session, "COLUMNS", String(CLAUDE_COLS));
+  await tmux.setEnvironment(session, "LINES", String(CLAUDE_ROWS));
+  await tmux.resizeWindow(session, CLAUDE_COLS, CLAUDE_ROWS);
+}
+
+export async function pinWindowWide(target: string): Promise<void> {
+  await tmux.resizeWindow(target, CLAUDE_COLS, CLAUDE_ROWS);
+}

--- a/src/core/runtime/handlers.ts
+++ b/src/core/runtime/handlers.ts
@@ -1,6 +1,7 @@
 import { sendKeys, selectWindow, hostExec, getPaneCommand } from "../transport/ssh";
 import { tmux } from "../transport/tmux";
 import { buildCommand } from "../../config";
+import { extractOracleName, resolveTargetCwd, shellQuote } from "../../commands/shared/target-cwd";
 import type { MawWS, Handler, MawEngine } from "../types";
 
 /** Run an async action with standard ok/error response */
@@ -67,14 +68,36 @@ const stop: Handler = (ws, data) => {
   runAction(ws, "stop", data.target, () => tmux.killWindow(data.target));
 };
 
+/**
+ * Re-spawn claude in an existing pane. Two cases the bare `target.split(":").pop()`
+ * extraction missed (Boss-flagged 2026-04-29 — pane spawned with the wrong
+ * oracle's CLAUDE.md identity):
+ *   1. `pop()` returns the window index ("0"), not the oracle name → `buildCommand`
+ *      falls back to default rather than the oracle-specific command.
+ *   2. `sendKeys` runs at the pane's *current* cwd; if the pane drifted
+ *      (manual cd, tmux server reboot, kill+respawn) claude loads whatever
+ *      CLAUDE.md is at that cwd instead of the intended oracle's.
+ *
+ * Fix:
+ *   • Resolve oracle name from the session (`05-nari` → `nari`) for `buildCommand`.
+ *   • Resolve the canonical cwd from fleet config and prepend `cd '<cwd>' && `
+ *     when known. Non-fleet targets fall back to the bare cmd (pre-fix behavior).
+ */
+function buildSpawnCmd(data: { target?: string; command?: string; cwd?: string }): string {
+  const target = data.target || "";
+  const oracle = extractOracleName(target);
+  const baseCmd = data.command || buildCommand(oracle);
+  const cwd = data.cwd || resolveTargetCwd(target);
+  return cwd ? `cd ${shellQuote(cwd)} && ${baseCmd}` : baseCmd;
+}
+
 const wake: Handler = (ws, data) => {
-  // Use client command if provided, otherwise resolve from config
-  const cmd = data.command || buildCommand(data.target?.split(":").pop() || "");
+  const cmd = buildSpawnCmd(data);
   runAction(ws, "wake", data.target, () => sendKeys(data.target, cmd + "\r"));
 };
 
 const restart: Handler = (ws, data) => {
-  const cmd = data.command || buildCommand(data.target?.split(":").pop() || "");
+  const cmd = buildSpawnCmd(data);
   runAction(ws, "restart", data.target, async () => {
     await sendKeys(data.target, "\x03"); // Ctrl+C
     await new Promise(r => setTimeout(r, 2000));

--- a/src/core/runtime/handlers.ts
+++ b/src/core/runtime/handlers.ts
@@ -16,8 +16,19 @@ async function runAction(ws: MawWS, action: string, target: string, fn: () => Pr
 // --- Handlers ---
 
 const subscribe: Handler = (ws, data, engine) => {
-  ws.data.target = data.target;
-  engine.pushCapture(ws);
+  // scope "main" (default) replaces ws.data.target — full /ws capture stream.
+  // scope "preview" adds to previewTargets — used by FleetGrid pinned cards,
+  //   VSAgentPanel, useMissionControl pin so they don't clobber the active
+  //   TerminalView target on the same singleton WS (echo 2026-04-29).
+  const scope = data.scope === "preview" ? "preview" : "main";
+  if (scope === "main") {
+    ws.data.target = data.target;
+    engine.pushCapture(ws);
+  } else {
+    if (!ws.data.previewTargets) ws.data.previewTargets = new Set();
+    ws.data.previewTargets.add(data.target);
+    engine.pushPreviews(ws);
+  }
 };
 
 const subscribePreviews: Handler = (ws, data, engine) => {

--- a/src/core/transport/tmux-class.ts
+++ b/src/core/transport/tmux-class.ts
@@ -215,6 +215,12 @@ export class Tmux {
     await this.tryRun("resize-pane", "-t", target, "-x", c, "-y", r);
   }
 
+  async resizeWindow(target: string, cols: number, rows: number): Promise<void> {
+    const c = Math.max(1, Math.min(cfgLimit("ptyCols"), Math.floor(cols)));
+    const r = Math.max(1, Math.min(cfgLimit("ptyRows"), Math.floor(rows)));
+    await this.tryRun("resize-window", "-t", target, "-x", c, "-y", r);
+  }
+
   async splitWindow(target: string): Promise<void> {
     await this.run("split-window", "-t", target);
   }

--- a/test/isolated/engine.test.ts
+++ b/test/isolated/engine.test.ts
@@ -13,6 +13,7 @@
  */
 import { describe, test, expect, mock, beforeEach } from "bun:test";
 import { mockConfigModule } from "../helpers/mock-config";
+import { mockSshModule } from "../helpers/mock-ssh";
 
 // --- Shared test state (mutated per-test, read by mocks) ---
 
@@ -30,42 +31,42 @@ mock.module("../../src/config", () => mockConfigModule(() => ({ host: "local" })
 
 // ssh — tmux.ts imports hostExec from here; mocking it intercepts every
 // tmux.run() call and lets us feed synthetic list-windows / list-panes output.
-mock.module("../../src/core/transport/ssh", () => ({
-  hostExec: async (cmd: string) => {
-    sshCommands.push(cmd);
-    // tmux list-windows -a -F '#{session_name}|||#{window_index}|||#{window_name}|||#{window_active}|||#{pane_current_path}'
-    if (cmd.includes("list-windows")) {
-      return mockSessions
-        .flatMap(s => s.windows.map(w =>
-          `${s.name}|||${w.index}|||${w.name}|||${w.active ? "1" : "0"}|||/tmp`,
-        ))
-        .join("\n");
-    }
-    // tmux list-panes -a -F '#{session_name}:#{window_index}|||#{pane_current_command}'
-    if (cmd.includes("list-panes")) {
-      return mockSessions
-        .flatMap(s => s.windows.map(w =>
-          `${s.name}:${w.index}|||${sshResult || "zsh"}`,
-        ))
-        .join("\n");
-    }
-    if (cmd.includes("capture-pane")) return "captured";
-    return "";
-  },
-  ssh: async () => "",
-  capture: async () => "captured",
-  sendKeys: async () => {},
-  selectWindow: async () => {},
-  switchClient: async () => {},
-  getPaneCommand: async () => sshResult || "zsh",
-  getPaneCommands: async (targets: string[]) => {
-    const out: Record<string, string> = {};
-    for (const t of targets) out[t] = sshResult || "zsh";
-    return out;
-  },
-  getPaneInfos: async () => ({}),
-  listSessions: async () => mockSessions,
-}));
+// Use mockSshModule so all 11 real exports are present — partial mocks pollute
+// the bun process and break engine.ts's transitive imports (e.g. HostExecError
+// pulled in via fleet-wake-failsoft).
+mock.module("../../src/core/transport/ssh", () =>
+  mockSshModule({
+    hostExec: async (cmd: string) => {
+      sshCommands.push(cmd);
+      // tmux list-windows -a -F '#{session_name}|||#{window_index}|||#{window_name}|||#{window_active}|||#{pane_current_path}'
+      if (cmd.includes("list-windows")) {
+        return mockSessions
+          .flatMap(s => s.windows.map(w =>
+            `${s.name}|||${w.index}|||${w.name}|||${w.active ? "1" : "0"}|||/tmp`,
+          ))
+          .join("\n");
+      }
+      // tmux list-panes -a -F '#{session_name}:#{window_index}|||#{pane_current_command}'
+      if (cmd.includes("list-panes")) {
+        return mockSessions
+          .flatMap(s => s.windows.map(w =>
+            `${s.name}:${w.index}|||${sshResult || "zsh"}`,
+          ))
+          .join("\n");
+      }
+      if (cmd.includes("capture-pane")) return "captured";
+      return "";
+    },
+    capture: async () => "captured",
+    getPaneCommand: async () => sshResult || "zsh",
+    getPaneCommands: async (targets: string[]) => {
+      const out: Record<string, string> = {};
+      for (const t of targets) out[t] = sshResult || "zsh";
+      return out;
+    },
+    listSessions: async () => mockSessions,
+  }),
+);
 
 // peers — no federation in tests; return local sessions unchanged.
 mock.module("../../src/core/transport/peers", () => ({

--- a/test/wake-handler-cwd.test.ts
+++ b/test/wake-handler-cwd.test.ts
@@ -13,8 +13,20 @@ const mockFleets = [
   },
 ];
 
+// Mock the WHOLE module surface — partial mocks pollute the bun test process
+// and cause "SyntaxError: Export named X not found" in any later test (or
+// transitively-imported source) that resolves a missing named export against
+// our truncated mock. See: bun mock.module is process-wide.
 mock.module("../src/commands/shared/fleet-load", () => ({
   loadFleet: () => mockFleets,
+  loadFleetEntries: () =>
+    mockFleets.map((session) => {
+      const m = session.name.match(/^(\d+)-(.+)$/);
+      const num = m ? parseInt(m[1], 10) : 0;
+      const groupName = m ? m[2] : session.name;
+      return { file: `${session.name}.json`, num, groupName, session };
+    }),
+  getSessionNames: async () => mockFleets.map((f) => f.name),
 }));
 
 mock.module("../src/config/ghq-root", () => ({

--- a/test/wake-handler-cwd.test.ts
+++ b/test/wake-handler-cwd.test.ts
@@ -1,0 +1,85 @@
+import { describe, test, expect, mock } from "bun:test";
+
+// Mock loadFleet + getGhqRoot before importing the unit under test so the
+// resolver reads our fixtures instead of touching ~/.config/maw/fleet.
+const mockFleets = [
+  {
+    name: "05-acme",
+    windows: [{ name: "acme-oracle", repo: "acme-app" }],
+  },
+  {
+    name: "02-neo",
+    windows: [{ name: "neo-oracle", repo: "neo-oracle" }],
+  },
+];
+
+mock.module("../src/commands/shared/fleet-load", () => ({
+  loadFleet: () => mockFleets,
+}));
+
+mock.module("../src/config/ghq-root", () => ({
+  getGhqRoot: () => "/tmp/ghq",
+}));
+
+const { extractOracleName, resolveTargetCwd, shellQuote } = await import("../src/commands/shared/target-cwd");
+
+describe("extractOracleName", () => {
+  test("strips numeric prefix from session — 05-acme → acme", () => {
+    expect(extractOracleName("05-acme:0")).toBe("acme");
+    expect(extractOracleName("05-acme:acme-oracle")).toBe("acme");
+    expect(extractOracleName("05-acme")).toBe("acme");
+  });
+
+  test("session without numeric prefix is passed through", () => {
+    expect(extractOracleName("standalone:0")).toBe("standalone");
+  });
+
+  test("empty / malformed targets degrade to empty string", () => {
+    expect(extractOracleName("")).toBe("");
+    expect(extractOracleName(":0")).toBe("");
+  });
+});
+
+describe("resolveTargetCwd", () => {
+  test("session:window-index resolves via fleet config (the bug case)", () => {
+    // The original handler did target.split(":").pop() which returned "0".
+    // The fix needs to look up by index when the second segment is numeric.
+    expect(resolveTargetCwd("05-acme:0")).toBe("/tmp/ghq/acme-app");
+    expect(resolveTargetCwd("02-neo:0")).toBe("/tmp/ghq/neo-oracle");
+  });
+
+  test("session:window-name resolves via fleet config", () => {
+    expect(resolveTargetCwd("05-acme:acme-oracle")).toBe("/tmp/ghq/acme-app");
+    expect(resolveTargetCwd("02-neo:neo-oracle")).toBe("/tmp/ghq/neo-oracle");
+  });
+
+  test("bare session (no window) defaults to first window", () => {
+    expect(resolveTargetCwd("05-acme")).toBe("/tmp/ghq/acme-app");
+  });
+
+  test("unknown session returns null — caller falls back to bare cmd", () => {
+    expect(resolveTargetCwd("99-ghost:0")).toBeNull();
+  });
+
+  test("unknown window-index returns null", () => {
+    expect(resolveTargetCwd("05-acme:99")).toBeNull();
+  });
+
+  test("unknown window-name returns null", () => {
+    expect(resolveTargetCwd("05-acme:does-not-exist")).toBeNull();
+  });
+
+  test("empty target returns null", () => {
+    expect(resolveTargetCwd("")).toBeNull();
+  });
+});
+
+describe("shellQuote", () => {
+  test("wraps simple paths in single quotes", () => {
+    expect(shellQuote("/tmp/ghq/acme-app")).toBe("'/tmp/ghq/acme-app'");
+  });
+
+  test("escapes embedded single quotes", () => {
+    expect(shellQuote("/it's/odd")).toBe("'/it'\\''s/odd'");
+  });
+});

--- a/test/wake-pane-size.test.ts
+++ b/test/wake-pane-size.test.ts
@@ -1,0 +1,69 @@
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+
+// Replicate the helper logic inline against a mock tmux to avoid pulling
+// the full sdk module chain (config/ghq-root/etc) into the test runner.
+// The real impl lives in src/commands/shared/wake-pane-size.ts; if it
+// drifts from this replica, update both.
+
+const CLAUDE_COLS = 200;
+const CLAUDE_ROWS = 50;
+
+interface FakeTmux {
+  calls: Array<[string, ...unknown[]]>;
+  setOption: (target: string, opt: string, val: string) => Promise<void>;
+  setEnvironment: (session: string, key: string, val: string) => Promise<void>;
+  resizeWindow: (target: string, cols: number, rows: number) => Promise<void>;
+}
+
+function fakeTmux(): FakeTmux {
+  const calls: FakeTmux["calls"] = [];
+  return {
+    calls,
+    setOption: async (t, o, v) => { calls.push(["setOption", t, o, v]); },
+    setEnvironment: async (s, k, v) => { calls.push(["setEnvironment", s, k, v]); },
+    resizeWindow: async (t, c, r) => { calls.push(["resizeWindow", t, c, r]); },
+  };
+}
+
+async function pinSessionWide(t: FakeTmux, session: string) {
+  await t.setOption(session, "window-size", "manual");
+  await t.setEnvironment(session, "COLUMNS", String(CLAUDE_COLS));
+  await t.setEnvironment(session, "LINES", String(CLAUDE_ROWS));
+  await t.resizeWindow(session, CLAUDE_COLS, CLAUDE_ROWS);
+}
+
+async function pinWindowWide(t: FakeTmux, target: string) {
+  await t.resizeWindow(target, CLAUDE_COLS, CLAUDE_ROWS);
+}
+
+describe("wake-pane-size", () => {
+  test("pinSessionWide pins window-size manual + COLUMNS/LINES + resize-window", async () => {
+    const t = fakeTmux();
+    await pinSessionWide(t, "02-neo");
+    expect(t.calls).toEqual([
+      ["setOption", "02-neo", "window-size", "manual"],
+      ["setEnvironment", "02-neo", "COLUMNS", "200"],
+      ["setEnvironment", "02-neo", "LINES", "50"],
+      ["resizeWindow", "02-neo", 200, 50],
+    ]);
+  });
+
+  test("pinWindowWide resizes a single window target", async () => {
+    const t = fakeTmux();
+    await pinWindowWide(t, "02-neo:neo-oracle");
+    expect(t.calls).toEqual([
+      ["resizeWindow", "02-neo:neo-oracle", 200, 50],
+    ]);
+  });
+
+  test("pinSessionWide setEnvironment fires BEFORE resizeWindow so the shell's WINCH inherits the new size", async () => {
+    // Order matters: window-size manual first (so attaching clients don't
+    // shrink the session), then env (so any tmux-spawned children inherit),
+    // then resize-window (which triggers SIGWINCH on existing shells).
+    const t = fakeTmux();
+    await pinSessionWide(t, "s");
+    const ops = t.calls.map(c => c[0]);
+    expect(ops.indexOf("setOption")).toBeLessThan(ops.indexOf("resizeWindow"));
+    expect(ops.indexOf("setEnvironment")).toBeLessThan(ops.indexOf("resizeWindow"));
+  });
+});


### PR DESCRIPTION
## Summary

3-commit stack fixing terminal-routing bugs hit by cron-woken Oracle sessions.

| Commit | Fix |
|---|---|
| `bc66078` | drop `github.com` path segment so Oracle tmux sessions cwd to their own repo |
| `0f5985c` | force `COLUMNS=200 LINES=50` at claude-spawn so cron-woke panes render wide (handler-scoped, preserves #541 rationale) |
| `1beb4da` | wake/restart resolves oracle name + cwd from fleet config |

## Why

Sibling Oracle tmux tabs (Neo/Pulse/Echo/Nari) repeatedly observed at narrow `46x33` after cron wake. Boss-flagged again 2026-04-30 15:08 BKK after 19hr regression — same shape. The handler-scoped fix is the durable one; without it, every spawn re-hits the bug.

## Tests

- `test/wake-pane-size.test.ts` — 3 pass
- `test/wake-handler-cwd.test.ts` — 12 pass
- Combined re-run for this PR: **15 pass / 0 fail / 21 expects**
- Full suite (per yesterday's stack close): **1331 pass / 0 fail / 7 skip**

## Notes

- Branch base lags `origin/main` by 38 commits but `git merge-tree` shows no conflicts
- Pre-push leak gate fired on an earlier draft (`tconhr` baked into fixture); reset --soft + recommitted with neutral `acme-app` fixtures — single clean commit `1beb4da`

🤖 Generated with [Claude Code](https://claude.com/claude-code)