### PR TITLE
release: v26.5.2-alpha.225

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.30-alpha.1426",
+  "version": "26.5.2-alpha.225",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts v26.5.2-alpha.225 on merge via calver-release.yml.

## What's in this alpha

- **feat(plugin): maw swarm** — spawn claude/codex/opencode side by side (#1054)
- **fix(attach): fuzzy-match live tmux sessions** — `maw a mawjs` → `01-mawjs` (#1058)
- **fix(team): prep upserts** — re-prep updates paneId instead of skipping (#1051)

Auto-generated by /release-alpha.