### PR TITLE
fix(attach): @clack/prompts for interactive oracle select

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "maw",
       "dependencies": {
+        "@clack/prompts": "^1.3.0",
         "@elysiajs/cors": "^1.4.1",
         "@elysiajs/swagger": "^1.3.1",
         "@monaco-editor/react": "^4.7.0",
@@ -80,6 +81,10 @@
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
+
+    "@clack/core": ["@clack/core@1.3.0", "", { "dependencies": { "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-xJPHpAmEQUBrXSLx0gF+q5K/IyihXpsHZcha+jB+tyahsKRK3Dxo4D0coZDewHo12NhiuzC3dTtMPbm53GEAAA=="],
+
+    "@clack/prompts": ["@clack/prompts@1.3.0", "", { "dependencies": { "@clack/core": "1.3.0", "fast-string-width": "^3.0.2", "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-GgcWwRCs/xPtaqlMy8qRhPnZf9vlWcWZNHAitnVQ3yk7JmSralSiq5q07yaffYE8SogtDm7zFeKccx1QNVARpw=="],
 
     "@dimforge/rapier3d-compat": ["@dimforge/rapier3d-compat@0.12.0", "", {}, "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow=="],
 
@@ -371,7 +376,13 @@
 
     "fast-decode-uri-component": ["fast-decode-uri-component@1.0.1", "", {}, "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="],
 
+    "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
+
+    "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
+
     "fast-unique-numbers": ["fast-unique-numbers@9.0.27", "", { "dependencies": { "@babel/runtime": "^7.29.2", "tslib": "^2.8.1" } }, "sha512-nDA9ADeINN8SA2u2wCtU+siWFTTDqQR37XvgPIDDmboWQeExz7X0mImxuaN+kJddliIqy2FpVRmnvRZ+j8i1/A=="],
+
+    "fast-wrap-ansi": ["fast-wrap-ansi@0.2.0", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
@@ -488,6 +499,8 @@
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
     "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "description": "maw.js — Multi-Agent Workflow in Bun/TS. Remote tmux orchestra control. CLI + Web UI.",
   "dependencies": {
+    "@clack/prompts": "^1.3.0",
     "@elysiajs/cors": "^1.4.1",
     "@elysiajs/swagger": "^1.3.1",
     "@monaco-editor/react": "^4.7.0",

--- a/src/commands/plugins/tmux/impl.ts
+++ b/src/commands/plugins/tmux/impl.ts
@@ -579,7 +579,7 @@ export function cmdTmuxAttach(target: string, opts: TmuxAttachOpts = {}): void {
   }
 }
 
-function suggestRecovery(target: string, session: string, source: string): never {
+function suggestRecovery(target: string, session: string, source: string): void {
   const candidates: Array<{ oracle: string; label: string }> = [];
 
   if (source.startsWith("fleet-stem") || source.startsWith("live-session")) {
@@ -618,77 +618,31 @@ function suggestRecovery(target: string, session: string, source: string): never
     process.exit(1);
   }
 
-  const selected = interactiveSelect(candidates);
-  if (selected) {
-    console.log(`\x1b[36m→\x1b[0m maw wake ${selected.oracle}`);
-    const result = Bun.spawnSync(["maw", "wake", selected.oracle], {
-      stdio: ["inherit", "inherit", "inherit"],
-    });
-    process.exit(result.exitCode ?? 0);
-  }
-  process.exit(0);
+  selectAndWake(candidates);
 }
 
-function interactiveSelect(items: Array<{ oracle: string; label: string }>): { oracle: string; label: string } | null {
-  const { openSync, readSync, closeSync } = require("fs") as typeof import("fs");
-  let cursor = 0;
-  const fd = openSync("/dev/tty", "r");
+async function selectAndWake(candidates: Array<{ oracle: string; label: string }>): Promise<never> {
+  const { select, isCancel } = await import("@clack/prompts");
 
-  const render = () => {
-    // Move up to clear previous render (skip on first render)
-    process.stdout.write(`\x1b[?25l`); // hide cursor
-    console.log("");
-    console.log("  Wake which oracle? \x1b[90m(↑↓ select, Enter confirm, q quit)\x1b[0m");
-    for (let i = 0; i < items.length; i++) {
-      const prefix = i === cursor ? "\x1b[36m❯\x1b[0m" : " ";
-      const highlight = i === cursor ? `\x1b[1m${items[i].label}\x1b[0m` : `\x1b[90m${items[i].label}\x1b[0m`;
-      console.log(`  ${prefix} ${highlight}`);
-    }
-  };
+  const selected = await select({
+    message: "Wake which oracle?",
+    options: candidates.map(c => ({
+      value: c.oracle,
+      label: c.label,
+      hint: `maw wake ${c.oracle}`,
+    })),
+  });
 
-  const clear = () => {
-    // Move up and clear the menu lines
-    const totalLines = items.length + 2; // header + items + blank
-    for (let i = 0; i < totalLines; i++) {
-      process.stdout.write(`\x1b[A\x1b[2K`);
-    }
-  };
-
-  render();
-
-  const buf = Buffer.alloc(8);
-  while (true) {
-    const n = readSync(fd, buf, 0, buf.length, null);
-    if (n === 0) break;
-    const input = buf.slice(0, n).toString();
-
-    if (input === "q" || input === "\x03") { // q or Ctrl-C
-      clear();
-      closeSync(fd);
-      process.stdout.write(`\x1b[?25h`); // show cursor
-      console.log("  \x1b[90maborted\x1b[0m");
-      return null;
-    }
-    if (input === "\r" || input === "\n") { // Enter
-      clear();
-      closeSync(fd);
-      process.stdout.write(`\x1b[?25h`);
-      return items[cursor];
-    }
-    if (input === "\x1b[A" || input === "k") { // Up
-      clear();
-      cursor = (cursor - 1 + items.length) % items.length;
-      render();
-    }
-    if (input === "\x1b[B" || input === "j") { // Down
-      clear();
-      cursor = (cursor + 1) % items.length;
-      render();
-    }
+  if (isCancel(selected)) {
+    console.log("\x1b[90m  aborted\x1b[0m");
+    process.exit(0);
   }
-  closeSync(fd);
-  process.stdout.write(`\x1b[?25h`);
-  return null;
+
+  console.log(`\x1b[36m→\x1b[0m maw wake ${selected}`);
+  const result = Bun.spawnSync(["maw", "wake", selected as string], {
+    stdio: ["inherit", "inherit", "inherit"],
+  });
+  process.exit(result.exitCode ?? 0);
 }
 
 function ghqFindOracleSync(slug: string): string | null {


### PR DESCRIPTION
## Summary

Replace broken hand-rolled TTY select (raw `^[[B` escape codes leaked) with `@clack/prompts` select.

**Before** (broken):
```
^[[B^[[B^[[B^[[B^[[B^[[B
```

**After** (works):
```
◆ Wake which oracle?
│ ● m5-keeper-oracle (cloned)  — maw wake m5-keeper
│ ○ timekeeper-oracle          — maw wake timekeeper  
│ ○ petkeeper-oracle           — maw wake petkeeper
└
```

Select + Enter → auto-runs `maw wake`. Non-TTY prints plain text list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)