### PR TITLE
feat(fleet): auto-restore sessions from snapshot

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -48,6 +48,46 @@ async function main(): Promise<void> {
     // Load plugins from ~/.maw/plugins/ — the single source of truth
     await scanCommands(pluginDir, "user");
 
+    // Auto-restore: if no tmux sessions and a recent snapshot exists, offer to restore.
+    if (cmd && cmd !== "--help" && cmd !== "-h") {
+      try {
+        const { listSessions } = await import("./sdk");
+        const live = await listSessions().catch(() => [] as any[]);
+        if (live.length === 0) {
+          const { latestSnapshot } = await import("./core/fleet/snapshot");
+          const snap = latestSnapshot();
+          if (snap) {
+            const ageMs = Date.now() - new Date(snap.timestamp).getTime();
+            if (ageMs < 24 * 60 * 60 * 1000) {
+              const mins = Math.round(ageMs / 60000);
+              const ageStr = mins >= 60 ? `${Math.round(mins / 60)}h ago` : `${mins}m ago`;
+              console.log(`\x1b[36m📸\x1b[0m Last snapshot: ${snap.sessions.length} sessions (${ageStr})`);
+              for (const s of snap.sessions) console.log(`   ${s.name}`);
+              process.stdout.write(`\nRestore all? [y/N] `);
+              const buf = new Uint8Array(64);
+              const fd = require("fs").openSync("/dev/tty", "r");
+              const n = require("fs").readSync(fd, buf);
+              require("fs").closeSync(fd);
+              const answer = new TextDecoder().decode(buf.subarray(0, n)).trim().toLowerCase();
+              if (answer === "y" || answer === "yes") {
+                const { cmdWake } = await import("./commands/shared/wake-cmd");
+                for (const s of snap.sessions) {
+                  const oracle = s.name.replace(/^\d+-/, "");
+                  try {
+                    await cmdWake(oracle, { attach: false });
+                    console.log(`  \x1b[32m✓\x1b[0m ${s.name}`);
+                  } catch (e: any) {
+                    console.log(`  \x1b[31m✗\x1b[0m ${s.name}: ${e?.message || String(e)}`);
+                  }
+                }
+                console.log("");
+              }
+            }
+          }
+        }
+      } catch {}
+    }
+
     if (!cmd || cmd === "--help" || cmd === "-h") {
       usage();
     } else {

--- a/src/commands/plugins/fleet/index.ts
+++ b/src/commands/plugins/fleet/index.ts
@@ -82,6 +82,20 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
           console.log(`  ${w.name}`);
         }
       }
+
+      if (args.includes("--all")) {
+        const { cmdWake } = await import("../../shared/wake-cmd");
+        console.log("");
+        for (const s of snap.sessions) {
+          const oracle = s.name.replace(/^\d+-/, "");
+          try {
+            await cmdWake(oracle, { attach: false });
+            console.log(`  \x1b[32m✓\x1b[0m ${s.name}`);
+          } catch (e: any) {
+            console.log(`  \x1b[31m✗\x1b[0m ${s.name}: ${e?.message || String(e)}`);
+          }
+        }
+      }
     } else if (sub === "snapshot") {
       const { takeSnapshot } = await import("../../../core/fleet/snapshot");
       const trigger = args[1] || "manual";

--- a/src/commands/shared/comm-list.ts
+++ b/src/commands/shared/comm-list.ts
@@ -107,6 +107,22 @@ export async function cmdList(opts: { fix?: boolean } = {}) {
 
   if (sessions.length === 0 && orphans.length === 0) {
     console.log("\x1b[90mNo active sessions.\x1b[0m");
+
+    try {
+      const { latestSnapshot } = await import("../../core/fleet/snapshot");
+      const snap = latestSnapshot();
+      if (snap) {
+        const ageMs = Date.now() - new Date(snap.timestamp).getTime();
+        if (ageMs < 24 * 60 * 60 * 1000) {
+          const mins = Math.round(ageMs / 60000);
+          const ageStr = mins >= 60 ? `${Math.round(mins / 60)}h ago` : `${mins}m ago`;
+          console.log(`\n\x1b[36m📸\x1b[0m Last snapshot (${ageStr}):`);
+          for (const s of snap.sessions) console.log(`   \x1b[33m${s.name}\x1b[0m`);
+          console.log(`\n\x1b[90m  → maw fleet restore --all   wake all from snapshot\x1b[0m`);
+        }
+      }
+    } catch {}
+
     console.log("\x1b[90m  → maw bud <name>     create new oracle\x1b[0m");
     console.log("\x1b[90m  → maw wake <name>    attach existing\x1b[0m");
   }


### PR DESCRIPTION
## Summary

- **Auto-restore prompt on startup**: When any `maw` command runs with 0 tmux sessions and a snapshot <24h old exists, prompts "Restore all? [y/N]" — wakes all sessions from the snapshot
- **`maw ls` snapshot hint**: Shows last snapshot contents when no sessions are running, with `→ maw fleet restore --all` suggestion
- **`maw fleet restore --all`**: New flag — wakes all sessions from a snapshot in one command

## UX after reboot

```
$ maw ls
No active sessions.

📸 Last snapshot (2h ago):
   01-mawjs
   02-timekeeper
   03-thClaws
   06-m5-keeper

  → maw fleet restore --all   wake all from snapshot
```

Or auto-prompted:
```
$ maw wake mawjs
📸 Last snapshot: 5 sessions (2h ago)
   01-mawjs
   ...

Restore all? [y/N] y
  ✓ 01-mawjs
  ✓ 02-timekeeper
  ...
```

## Test plan

- [ ] Take snapshot: `maw fleet snapshot`
- [ ] Kill tmux: `tmux kill-server`
- [ ] Run `maw ls` — should show snapshot hint
- [ ] Run `maw wake mawjs` — should prompt to restore all
- [ ] Press `y` — all sessions restored
- [ ] `maw ls` — verify all sessions back

🤖 Generated with [Claude Code](https://claude.com/claude-code)