### PR TITLE
release: v26.5.2-alpha.437

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.4.30-alpha.1426",
+  "version": "26.5.2-alpha.437",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/plugins/oracle/impl-list.ts
+++ b/src/commands/plugins/oracle/impl-list.ts
@@ -48,7 +48,7 @@ export interface OracleListOpts {
   path?: boolean;
 }
 
-interface EnrichedEntry {
+export interface EnrichedEntry {
   entry: OracleEntry;
   awake: boolean;
   session: string | null;
@@ -107,13 +107,10 @@ function buildEntryFromManifest(
   };
 }
 
-export async function cmdOracleList(opts: OracleListOpts = {}) {
+export async function buildEnrichedEntries(opts: { scan?: boolean; stale?: boolean; json?: boolean } = {}): Promise<EnrichedEntry[]> {
   const config = loadConfig();
   const agents = config.agents || {};
 
-  // 1. Cache: --scan forces refresh; empty cache auto-bootstraps; stale cache
-  //    refreshes unless --stale. Edge case: offline scanLocal still succeeds
-  //    (filesystem walk, no network). Only scan --remote hits GitHub.
   let cache = readCache();
   const shouldRefresh =
     !!opts.scan || !cache || (isCacheStale(cache) && !opts.stale);
@@ -124,15 +121,11 @@ export async function cmdOracleList(opts: OracleListOpts = {}) {
       );
     }
     cache = scanAndCache("local");
-    // The cache changed under us — drop any stale manifest TTL view so we
-    // reflect the freshly-scanned oracles.json contribution.
     invalidateManifest();
   }
 
-  // 2. Live tmux snapshot — used for awake state + surfacing just-budded
-  //    oracles that haven't landed in the manifest's filesystem sources.
   const sessions = await listSessions().catch(() => []);
-  const awakeByName = new Map<string, string>(); // name → session
+  const awakeByName = new Map<string, string>();
   for (const s of sessions) {
     for (const w of s.windows) {
       if (w.name.endsWith("-oracle")) {
@@ -142,16 +135,12 @@ export async function cmdOracleList(opts: OracleListOpts = {}) {
     }
   }
 
-  // 3. Aggregate via OracleManifest — single source of "what oracles exist"
-  //    spanning fleet/sessions/agents/oracles-json. Replaces the old direct
-  //    `cache.oracles` enumeration (which missed sessions/agents-only entries).
   const manifest = loadManifestCached();
   const cacheByName = new Map<string, OracleEntry>(
     (cache?.oracles ?? []).map((e) => [e.name, e]),
   );
   const now = new Date().toISOString();
 
-  // Build entries from manifest (cross-source visibility).
   const manifestNames = new Set<string>();
   const entries: OracleEntry[] = [];
   const sourcesByName = new Map<string, string[]>();
@@ -163,9 +152,6 @@ export async function cmdOracleList(opts: OracleListOpts = {}) {
     );
   }
 
-  // Edge case: tmux has an oracle window the manifest doesn't know about
-  // (e.g., a stray window with no fleet/session/agent/oracles-json record).
-  // Surface it so the operator can see it. Tag source as "tmux" for clarity.
   for (const [name] of awakeByName) {
     if (!manifestNames.has(name)) {
       entries.push({
@@ -184,8 +170,7 @@ export async function cmdOracleList(opts: OracleListOpts = {}) {
     }
   }
 
-  // 4. Enrich each entry with awake state + lineage + nickname (read-through)
-  const enriched: EnrichedEntry[] = entries.map((entry) => {
+  return entries.map((entry) => {
     const session = awakeByName.get(entry.name) ?? null;
     const awake = session !== null;
     const nickname = resolveNickname(entry.name, entry.local_path || null);
@@ -200,6 +185,10 @@ export async function cmdOracleList(opts: OracleListOpts = {}) {
       sources: sourcesByName.get(entry.name) ?? [],
     };
   });
+}
+
+export async function cmdOracleList(opts: OracleListOpts = {}) {
+  const enriched = await buildEnrichedEntries(opts);
 
   // 5. Apply filters
   let filtered = enriched;
@@ -215,9 +204,10 @@ export async function cmdOracleList(opts: OracleListOpts = {}) {
   });
 
   // 7. JSON output — preserve schema for machine consumers
+  const cache = readCache();
   if (opts.json) {
     const out = {
-      cache_scanned_at: cache!.local_scanned_at,
+      cache_scanned_at: cache?.local_scanned_at ?? null,
       total: filtered.length,
       awake: filtered.filter((x) => x.awake).length,
       oracles: filtered.map((x) => ({
@@ -225,8 +215,6 @@ export async function cmdOracleList(opts: OracleListOpts = {}) {
         awake: x.awake,
         session: x.session,
         lineage: x.lineage,
-        // Manifest source labels — helps consumers see why this oracle
-        // shows up (fleet/session/agent/oracles-json/tmux).
         sources: x.sources,
       })),
     };
@@ -237,8 +225,8 @@ export async function cmdOracleList(opts: OracleListOpts = {}) {
   // 8. Formatted grouped output
   const total = filtered.length;
   const awakeCount = filtered.filter((x) => x.awake).length;
-  const age = timeSince(cache!.local_scanned_at);
-  const fresh = !isCacheStale(cache!);
+  const age = cache ? timeSince(cache.local_scanned_at) : "?";
+  const fresh = cache ? !isCacheStale(cache) : false;
   const staleMark = fresh ? "\x1b[32m✓\x1b[0m" : "\x1b[33m⚠ stale\x1b[0m";
 
   console.log(
@@ -274,7 +262,7 @@ export async function cmdOracleList(opts: OracleListOpts = {}) {
 
 // ─── Formatting helpers ──────────────────────────────────────────────────────
 
-function formatRow(x: EnrichedEntry, fopts: { showPath: boolean }): string {
+export function formatRow(x: EnrichedEntry, fopts: { showPath: boolean }): string {
   const { entry: e, awake, lineage } = x;
 
   // Icon + tag mapping:

--- a/src/commands/plugins/oracle/impl-search.ts
+++ b/src/commands/plugins/oracle/impl-search.ts
@@ -1,0 +1,60 @@
+import { buildEnrichedEntries, formatRow, type EnrichedEntry } from "./impl-list";
+
+export interface OracleSearchOpts {
+  json?: boolean;
+  awake?: boolean;
+  org?: string;
+}
+
+export async function cmdOracleSearch(query: string, opts: OracleSearchOpts = {}) {
+  const all = await buildEnrichedEntries();
+  const q = query.toLowerCase();
+
+  let matched = all.filter((x) => {
+    const e = x.entry;
+    const haystack = [
+      e.name,
+      e.org,
+      e.repo,
+      e.budded_from ?? "",
+      (e as any).nickname ?? "",
+    ].join(" ").toLowerCase();
+    return haystack.includes(q);
+  });
+
+  if (opts.awake) matched = matched.filter((x) => x.awake);
+  if (opts.org) matched = matched.filter((x) => x.entry.org === opts.org);
+
+  matched.sort((a, b) => {
+    const aExact = a.entry.name.toLowerCase() === q ? 0 : 1;
+    const bExact = b.entry.name.toLowerCase() === q ? 0 : 1;
+    if (aExact !== bExact) return aExact - bExact;
+    if (a.awake !== b.awake) return a.awake ? -1 : 1;
+    return a.entry.name.localeCompare(b.entry.name);
+  });
+
+  if (opts.json) {
+    console.log(JSON.stringify({
+      query,
+      total: matched.length,
+      oracles: matched.map((x) => ({
+        ...x.entry,
+        awake: x.awake,
+        session: x.session,
+        lineage: x.lineage,
+      })),
+    }, null, 2));
+    return;
+  }
+
+  if (matched.length === 0) {
+    console.log(`\n  No oracles matching \x1b[36m${query}\x1b[0m\n`);
+    return;
+  }
+
+  console.log(`\n  \x1b[36m${matched.length} oracle${matched.length === 1 ? "" : "s"} matching "${query}"\x1b[0m\n`);
+  for (const x of matched) {
+    console.log(formatRow(x, { showPath: false }));
+  }
+  console.log();
+}

--- a/src/commands/plugins/oracle/index.ts
+++ b/src/commands/plugins/oracle/index.ts
@@ -3,6 +3,7 @@ import { cmdOracleList, cmdOracleAbout, cmdOracleScan, cmdOracleScanStale } from
 import { cmdOraclePrune } from "./impl-prune";
 import { cmdOracleRegister } from "./impl-register";
 import { cmdOracleSetNickname, cmdOracleGetNickname } from "./impl-nickname";
+import { cmdOracleSearch } from "./impl-search";
 import { parseFlags } from "../../../cli/parse-args";
 
 export const command = {
@@ -119,10 +120,15 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         if (!name) return { ok: false, error: "usage: maw oracle get-nickname <oracle>" };
         const flags = parseFlags(args, { "--json": Boolean }, 2);
         cmdOracleGetNickname(name, { json: flags["--json"] });
+      } else if (subcmd === "search" || subcmd === "find") {
+        const query = args[1];
+        if (!query) return { ok: false, error: "usage: maw oracle search <query>" };
+        const flags = parseFlags(args, { "--json": Boolean, "--awake": Boolean, "--org": String }, 2);
+        await cmdOracleSearch(query, { json: flags["--json"], awake: flags["--awake"], org: flags["--org"] });
       } else if (subcmd === "about" && args[1]) {
         await cmdOracleAbout(args[1]);
       } else {
-        return { ok: false, error: "usage: maw oracle [ls|scan|prune|register <name>|set-nickname <name> <nickname>|get-nickname <name>|about <name>]" };
+        return { ok: false, error: "usage: maw oracle [ls|scan|search <query>|prune|register <name>|set-nickname <name> <nickname>|get-nickname <name>|about <name>]" };
       }
     } else if (ctx.source === "api") {
       const query = ctx.args as Record<string, unknown>;
@@ -185,10 +191,17 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       } else if (sub === "get-nickname") {
         if (!query.name) return { ok: false, error: "usage: query.sub=get-nickname + query.name" };
         cmdOracleGetNickname(query.name as string, { json: query.json as boolean | undefined });
+      } else if (sub === "search" || sub === "find") {
+        if (!query.query) return { ok: false, error: "usage: query.sub=search + query.query" };
+        await cmdOracleSearch(query.query as string, {
+          json: query.json as boolean | undefined,
+          awake: query.awake as boolean | undefined,
+          org: query.org as string | undefined,
+        });
       } else if (sub === "about" && query.name) {
         await cmdOracleAbout(query.name as string);
       } else {
-        return { ok: false, error: "usage: query.sub=[ls|scan|prune|register|set-nickname|get-nickname|about] + query.name" };
+        return { ok: false, error: "usage: query.sub=[ls|scan|search|prune|register|set-nickname|get-nickname|about] + query.name" };
       }
     }
 


### PR DESCRIPTION
Cuts v26.5.2-alpha.437 on merge via calver-release.yml.

Includes:
- feat(fleet): auto-restore sessions from snapshot on fresh boot
- feat(oracle): maw oracle search <query> (#1066)
- Version bump: v26.5.2-alpha.437

Auto-generated by /release-alpha.