### PR TITLE
feat(wake): --engine flag to select AI backend

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -143,12 +143,13 @@ export async function invokeDirectHandler(
       "--list": Boolean,
       "--split": Boolean,
       "--all-local": Boolean,
+      "--engine": String, "-e": "--engine",
     }, 0);
 
     const positional = flags._;
     const oracle = positional[0];
     if (!oracle) {
-      console.error("usage: maw wake <oracle> [--task <s>] [--wt <s>] [-p|--prompt <s>] [--incubate <slug>] [--fresh] [-a|--attach] [--list] [--split] [--all-local]");
+      console.error("usage: maw wake <oracle> [--task <s>] [--wt <s>] [-p|--prompt <s>] [--incubate <slug>] [--fresh] [-a|--attach] [--list] [--split] [--all-local] [-e|--engine <name>]");
       throw new UserError("wake: missing oracle name");
     }
 
@@ -162,6 +163,7 @@ export async function invokeDirectHandler(
       listWt?: boolean;
       split?: boolean;
       allLocal?: boolean;
+      engine?: string;
     } = {};
     if (flags["--task"]) opts.task = flags["--task"];
     if (flags["--wt"]) opts.wt = flags["--wt"];
@@ -172,6 +174,7 @@ export async function invokeDirectHandler(
     if (flags["--list"]) opts.listWt = true;
     if (flags["--split"]) opts.split = true;
     if (flags["--all-local"]) opts.allLocal = true;
+    if (flags["--engine"]) opts.engine = flags["--engine"];
 
     await cmdWake(oracle, opts);
     return;

--- a/src/commands/plugins/swarm/index.ts
+++ b/src/commands/plugins/swarm/index.ts
@@ -86,10 +86,14 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       config = { name: teamName, description: "Multi-AI swarm", members: [], createdAt: Date.now() };
     }
 
+    const { loadConfig } = await import("../../../config");
+    const configCommands = loadConfig().commands || {};
+
     for (let i = 0; i < agentList.length; i++) {
       const agentType = agentList[i];
       const known = KNOWN_AGENTS[agentType];
-      const agentCmd = known ? known.cmd : agentType;
+      const fromConfig = configCommands[agentType];
+      const agentCmd = fromConfig || (known ? known.cmd : agentType);
       const label = known ? known.label : agentType;
       const name = `${agentType}-${i + 1}`;
       const color = nextAgentColor(i);

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -9,7 +9,7 @@ import { attachToSession, ensureSessionRunning, createWorktree } from "./wake-se
 import { maybeSplit } from "./wake-maybe-split";
 import { parseWakeTarget, ensureCloned } from "./wake-target";
 
-export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; split?: boolean; repoPath?: string; urlRepoName?: string; allLocal?: boolean }): Promise<string> {
+export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; split?: boolean; repoPath?: string; urlRepoName?: string; allLocal?: boolean; engine?: string }): Promise<string> {
   // Canonicalize the bare name before any lookup — strips trailing `/`, `/.git`, `/.git/`
   // so `maw wake token-oracle/` (tab-completion artifact) resolves the same as `token-oracle`.
   oracle = normalizeTarget(oracle);
@@ -105,7 +105,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
     await tmux.newSession(session, { window: mainWindowName, cwd: repoPath });
     await setSessionEnv(session);
     await new Promise(r => setTimeout(r, 300));
-    await tmux.sendText(`${session}:${mainWindowName}`, buildCommandInDir(mainWindowName, repoPath));
+    await tmux.sendText(`${session}:${mainWindowName}`, buildCommandInDir(mainWindowName, repoPath, opts.engine));
     console.log(`\x1b[32m+\x1b[0m created session '${session}' (main: ${mainWindowName})`);
 
     // Auto-register agent in config.agents so federation peers can route to it (#285)
@@ -134,7 +134,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
         usedNames.add(wtWindowName);
         await tmux.newWindow(session, wtWindowName, { cwd: wt.path });
         await new Promise(r => setTimeout(r, 300));
-        await tmux.sendText(`${session}:${wtWindowName}`, buildCommandInDir(wtWindowName, wt.path));
+        await tmux.sendText(`${session}:${wtWindowName}`, buildCommandInDir(wtWindowName, wt.path, opts.engine));
         console.log(`\x1b[32m+\x1b[0m window: ${wtWindowName}`);
       }
     }
@@ -160,7 +160,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
           usedNames.add(wtWindowName);
           await tmux.newWindow(session, wtWindowName, { cwd: wt.path });
           await new Promise(r => setTimeout(r, 300));
-          await tmux.sendText(`${session}:${wtWindowName}`, buildCommandInDir(wtWindowName, wt.path));
+          await tmux.sendText(`${session}:${wtWindowName}`, buildCommandInDir(wtWindowName, wt.path, opts.engine));
           console.log(`\x1b[32m↻\x1b[0m respawned: ${wtWindowName}`);
         }
       }
@@ -232,7 +232,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
       if (opts.prompt) {
         await tmux.selectWindow(`${session}:${existingWindow}`);
         const escaped = opts.prompt.replace(/'/g, "'\\''");
-        await tmux.sendText(`${session}:${existingWindow}`, `${buildCommandInDir(existingWindow, targetPath)} -p '${escaped}'`);
+        await tmux.sendText(`${session}:${existingWindow}`, `${buildCommandInDir(existingWindow, targetPath, opts.engine)} -p '${escaped}'`);
         if (opts.attach) await attachToSession(session);
         await maybeSplit(`${session}:${existingWindow}`, opts);
         return `${session}:${existingWindow}`;
@@ -249,7 +249,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
 
   await tmux.newWindow(session, windowName, { cwd: targetPath });
   await new Promise(r => setTimeout(r, 300));
-  const cmd = buildCommandInDir(windowName, targetPath);
+  const cmd = buildCommandInDir(windowName, targetPath, opts.engine);
   if (opts.prompt) {
     const escaped = opts.prompt.replace(/'/g, "'\\''");
     await tmux.sendText(`${session}:${windowName}`, `${cmd} -p '${escaped}'`);

--- a/src/config/command.ts
+++ b/src/config/command.ts
@@ -7,19 +7,23 @@ function matchGlob(pattern: string, name: string): boolean {
   return false;
 }
 
-export function buildCommand(agentName: string): string {
+export function buildCommand(agentName: string, engine?: string): string {
   const config = loadConfig();
-  let cmd = config.commands.default || "claude";
+  let cmd: string;
+
+  if (engine && config.commands[engine]) {
+    cmd = config.commands[engine];
+  } else {
+    cmd = config.commands.default || "claude";
+    for (const [pattern, command] of Object.entries(config.commands)) {
+      if (pattern === "default") continue;
+      if (matchGlob(pattern, agentName)) { cmd = command; break; }
+    }
+  }
 
   // Strip --dangerously-skip-permissions when running as root (#181)
   if (process.getuid?.() === 0) {
     cmd = cmd.replace(/\s*--dangerously-skip-permissions\b/, "");
-  }
-
-  // Match specific patterns first (skip "default")
-  for (const [pattern, command] of Object.entries(config.commands)) {
-    if (pattern === "default") continue;
-    if (matchGlob(pattern, agentName)) { cmd = command; break; }
   }
 
   // Inject --session-id if configured for this agent
@@ -51,8 +55,8 @@ export function buildCommand(agentName: string): string {
  * already sets the initial pane cwd, and the scrollback noise wasn't worth
  * the reboot-recovery edge case. `cwd` param kept for API compat + future use.
  */
-export function buildCommandInDir(agentName: string, _cwd: string): string {
-  return buildCommand(agentName);
+export function buildCommandInDir(agentName: string, _cwd: string, engine?: string): string {
+  return buildCommand(agentName, engine);
 }
 
 export function getEnvVars(): Record<string, string> {

--- a/src/core/transport/ssh.ts
+++ b/src/core/transport/ssh.ts
@@ -79,13 +79,22 @@ export async function getPaneCommand(target: string, host?: string): Promise<str
   return t.getPaneCommand(target);
 }
 
-/** Pane command looks like an AI agent — name match (claude/codex/node) or
- *  Claude Code 2.1+ versioned-binary signature (e.g. "2.1.121"). */
+/** Pane command looks like an AI agent — name match (claude/codex/node),
+ *  Claude Code 2.1+ versioned-binary signature (e.g. "2.1.121"), or any
+ *  binary from config.commands entries. */
 export function isAgentCommand(cmd: string | null | undefined): boolean {
   const c = (cmd ?? "").trim();
   if (!c) return false;
   if (/claude|codex|node/i.test(c)) return true;
   if (/^\d+\.\d+\.\d+$/.test(c)) return true;
+  try {
+    const { loadConfig } = require("../../config");
+    const commands: Record<string, string> = loadConfig().commands || {};
+    for (const v of Object.values(commands)) {
+      const bin = v.split(/\s/)[0];
+      if (bin && bin !== "default" && c.toLowerCase().includes(bin.toLowerCase())) return true;
+    }
+  } catch {}
   return false;
 }
 

--- a/test/command-simplified.test.ts
+++ b/test/command-simplified.test.ts
@@ -112,6 +112,26 @@ describe("buildCommand — post-#541 contract", () => {
     expect(inDir).not.toContain("{ ");
   });
 
+  test("engine param selects named command from config", () => {
+    fakeConfig.commands = { default: "claude", codex: "codex --search" };
+    expect(buildCommand("any-agent", "codex")).toBe("codex --search");
+  });
+
+  test("engine param falls back to default when engine not in config", () => {
+    fakeConfig.commands = { default: "claude" };
+    expect(buildCommand("any-agent", "gemini")).toBe("claude");
+  });
+
+  test("engine param skips pattern matching", () => {
+    fakeConfig.commands = { default: "claude", "foo-*": "echo pattern", codex: "codex --auto" };
+    expect(buildCommand("foo-bar", "codex")).toBe("codex --auto");
+  });
+
+  test("buildCommandInDir passes engine through", () => {
+    fakeConfig.commands = { default: "claude", codex: "codex --search" };
+    expect(buildCommandInDir("foo", "/tmp", "codex")).toBe("codex --search");
+  });
+
   test("no direnv / CLAUDECODE / cd preamble anywhere in output", () => {
     // Try a mix of configs and confirm the invariant holds for all.
     const configs: any[] = [


### PR DESCRIPTION
## Summary

Adds `--engine` / `-e` flag to `maw wake` for selecting AI backends from `config.commands`:

```bash
maw wake foo --engine codex    # uses commands.codex
maw wake foo -e codex          # short form
maw wake foo                   # unchanged (commands.default)
```

Config:
```json
{ "commands": { "default": "claude ...", "codex": "codex --search ..." } }
```

Changes:
- `buildCommand(agentName, engine?)` — engine param looks up named command directly
- `cmdWake` — passes engine through to all 5 buildCommandInDir call sites
- `top-aliases.ts` — parses `--engine` / `-e`
- `isAgentCommand()` — reads config.commands to detect any engine's binary

## Test plan
- [x] 18 tests pass (4 new engine tests + 14 existing)
- [x] `maw doctor --smoke` — 7/7 pass
- [ ] `maw wake <oracle> --engine codex` — spawns codex in tmux

🤖 Generated with [Claude Code](https://claude.com/claude-code)