### PR TITLE
feat(wake): --codex shorthand + attach prompt

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -176,6 +176,19 @@ export async function invokeDirectHandler(
     if (flags["--all-local"]) opts.allLocal = true;
     if (flags["--engine"]) opts.engine = flags["--engine"];
 
+    // Shorthand: --codex, --gemini etc. → engine from config.commands
+    // Unknown flags land in flags._ (permissive mode), so scan for --<engine>
+    if (!opts.engine) {
+      const { loadConfig } = await import("../config");
+      const commands = loadConfig().commands || {};
+      for (const arg of (flags._ as string[])) {
+        if (arg.startsWith("--") && commands[arg.slice(2)]) {
+          opts.engine = arg.slice(2);
+          break;
+        }
+      }
+    }
+
     await cmdWake(oracle, opts);
     return;
   }

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -238,6 +238,18 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
         return `${session}:${existingWindow}`;
       }
       console.log(`\x1b[33m⚡\x1b[0m '${existingWindow}' already running in ${session}`);
+      if (!opts.attach && process.stdin.isTTY) {
+        process.stdout.write(`  attach? [y/N] `);
+        const { openSync, readSync, closeSync } = await import("fs");
+        try {
+          const fd = openSync("/dev/tty", "r");
+          const buf = Buffer.alloc(8);
+          const n = readSync(fd, buf, 0, buf.length, null);
+          closeSync(fd);
+          const answer = buf.slice(0, n).toString().trim().toLowerCase();
+          if (answer === "y" || answer === "yes") opts.attach = true;
+        } catch {}
+      }
       if (opts.attach) {
         await tmux.selectWindow(`${session}:${existingWindow}`);
         await attachToSession(session);


### PR DESCRIPTION
## Summary

- `maw wake esp32 --codex` works (reads from config.commands)
- Any engine in config.commands works as `--<name>` shorthand
- When session already exists: prompts "attach? [y/N]" instead of silent return

## Test plan
- [x] Build succeeds
- [x] 12 tests pass
- [ ] `maw wake esp32 --codex` → prompts to attach existing session

🤖 Generated with [Claude Code](https://claude.com/claude-code)