### PR TITLE
fix(config): pass zenoh field through validator

### DIFF
--- a/src/config/validate-ext.ts
+++ b/src/config/validate-ext.ts
@@ -70,6 +70,14 @@ function validateExtFields(
     }
   }
 
+  // zenoh: { locator: string }
+  if ("zenoh" in raw && raw.zenoh && typeof raw.zenoh === "object") {
+    const z = raw.zenoh as Record<string, unknown>;
+    if (typeof z.locator === "string") {
+      result.zenoh = { locator: z.locator };
+    }
+  }
+
   // pluginSources: string[] of URLs
   if ("pluginSources" in raw) {
     if (Array.isArray(raw.pluginSources)) {


### PR DESCRIPTION
Zenoh.locator was stripped by config validator. Now passes through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)