### PR TITLE
fix(wake): refuse spawn into missing cwd (#748 follow-up to bc660788)

### DIFF
--- a/src/commands/shared/fleet-wake.ts
+++ b/src/commands/shared/fleet-wake.ts
@@ -1,4 +1,4 @@
-import { readdirSync } from "fs";
+import { existsSync, readdirSync } from "fs";
 import { join } from "path";
 import { tmux, FLEET_DIR, saveTabOrder, restoreTabOrder } from "../../sdk";
 import { buildCommand, getEnvVars } from "../../config";
@@ -76,6 +76,16 @@ export async function cmdWakeAll(opts: { kill?: boolean; all?: boolean; resume?:
       // not under github.com/<org>/<repo>. Falling back to /root via missing-cwd was making
       // every Oracle session inherit Labubu's CLAUDE.md identity.
       const firstPath = join(getGhqRoot(), first.repo);
+      // #748 follow-up — tmux silently falls back to $HOME when -c <missing-path>,
+      // which re-surfaces the wrong-CLAUDE.md bug if ghqRoot resolves to a stale value
+      // (e.g. test fixture leak setting "/tmp/nope"). Refuse to spawn into a missing
+      // path; raise a clear error instead of silently inheriting the wrong identity.
+      if (!existsSync(firstPath)) {
+        throw new Error(
+          `wake: refusing to spawn ${sess.name} — cwd "${firstPath}" does not exist. ` +
+          `Check ghqRoot resolution (config.ghqRoot, $GHQ_ROOT, \`ghq root\`) and fleet config repo "${first.repo}".`,
+        );
+      }
       await tmux.newSession(sess.name, { window: first.name, cwd: firstPath });
       await pinSessionWide(sess.name);
       for (const [key, val] of Object.entries(getEnvVars())) {
@@ -91,6 +101,15 @@ export async function cmdWakeAll(opts: { kill?: boolean; all?: boolean; resume?:
       for (let i = 1; i < sess.windows.length; i++) {
         const win = sess.windows[i];
         const winPath = join(getGhqRoot(), win.repo);
+        if (!existsSync(winPath)) {
+          // Skip rather than throw — first-window throw already surfaced the
+          // root cause; per-window failures should fail-soft so other windows
+          // in the same session still wake.
+          process.stderr.write(
+            `[maw] wake: skipping ${sess.name}:${win.name} — cwd "${winPath}" does not exist.\n`,
+          );
+          continue;
+        }
         try {
           await tmux.newWindow(sess.name, win.name, { cwd: winPath });
           await pinWindowWide(`${sess.name}:${win.name}`);


### PR DESCRIPTION
## Summary

bc660788 (PR #1052, merged 2026-05-02 08:12 BKK) fixed one form of missing-cwd in `cmdWakeAll`: dropped the spurious `"github.com"` segment from `firstPath`. A second, structurally-distinct missing-cwd survived and re-surfaced the same #748 symptom this morning at 06:07 BKK.

**Failure chain (Bug #2)**:
1. `~/.config/maw/maw.config.json` had `"ghqRoot": "/tmp/nope"` (test fixture leak from `fleet-doctor.test.ts`'s autoFix suite, written before #820's `MAW_TEST_MODE` guard landed)
2. `getGhqRoot()` honors the legacy override → returns `/tmp/nope`
3. `firstPath = join("/tmp/nope", "neo-oracle")` → doesn't exist
4. `tmux new-session -c <missing-path>` silently falls back to `$HOME = /root` (Labubu's repo)
5. Every Oracle pane spawns claude at `/root` → loads Labubu's CLAUDE.md → all 4 sibling Oracles show wrong identity

bc660788's fix didn't catch this because its verification ran with a different ghqRoot value at the time. The path-construction layer was correct; the upstream resolver returned junk.

## Fix

`existsSync(firstPath)` before `tmux.newSession`. If missing, throw clear error with diagnostic hint instead of letting tmux silently fall back to `$HOME`. Same check on per-window `winPath` with fail-soft skip (first-window throw already surfaced root cause).

## Verified live

Test fixture re-poisoned config mid-session during my own test run today — perfect dogfood. Guard fired:

\`\`\`
wake: refusing to spawn 88-guard-test — cwd "/tmp/nope/neo-oracle" does not exist.
Check ghqRoot resolution (config.ghqRoot, \$GHQ_ROOT, \`ghq root\`) and fleet config repo "neo-oracle".
\`\`\`

## Test plan

- [x] `bash scripts/test-isolated.sh` → 74/74 pass
- [x] Targeted wake suites (wake.test, wake-resolve, wake-flags, wake-handler-cwd, fleet-wake-ssh-failsoft, fleet-doctor) → 83/83 pass
- [x] Live dogfood with poisoned config → guard fires clean error

## Why a separate PR (not #1052 reopen)

#1052 was a clean 3-commit stack with focused scope (path-construction + COLUMNS=200 + handler-scoped cwd). This is a defense-in-depth follow-up at a different layer (validation guard at tmux-call site). Keeping scope-isolated makes it easier to revert if the strict-error-on-missing-path behavior surprises any downstream tests.

## Related

- Closes class of recurrence for #748
- Companion structural recommendation: add `existsSync` validation to `getGhqRoot()` legacy-override path itself. Not in this PR scope (would touch test mock surface — see `bud.test.ts:42` and `fleet-doctor.test.ts` × 14 sites that mock `getGhqRoot` via `loadConfig`); flagged for separate consideration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)