### PR TITLE
release: v26.5.3-alpha.852 — fix tmux pane stty init (#1091)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.3-alpha.852",
+  "version": "26.5.4-alpha.651",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.3-alpha.820",
+  "version": "26.5.3-alpha.852",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/plugins/fleet/fleet-adopt.ts
+++ b/src/commands/plugins/fleet/fleet-adopt.ts
@@ -1,0 +1,132 @@
+import { readFileSync, writeFileSync, existsSync } from "fs";
+import { join, basename } from "path";
+import { execSync } from "child_process";
+import { FLEET_DIR } from "../../../core/paths";
+import { loadFleetEntries } from "../../shared/fleet-load";
+
+function extractOracleStem(claudeMdPath: string): string | null {
+  const line1 = readFileSync(claudeMdPath, "utf8")
+    .split("\n")[0]
+    .replace(/^#\s*/, "");
+  if (!line1 || /project instructions|generic ai|quick reference/i.test(line1)) return null;
+  return line1
+    .replace(/[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}\u{FE00}-\u{FE0F}\u{200D}]/gu, "")
+    .replace(/\s*[Oo]racle\s*$/i, "")
+    .replace(/\s*—.*$/, "")
+    .replace(/\s*\(.*\)\s*$/, "")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9-]/g, "")
+    .replace(/^-+|-+$/g, "") || null;
+}
+
+interface Orphan {
+  repo: string;
+  org: string;
+  stem: string;
+  path: string;
+  identity: string;
+}
+
+function scanOrphans(): Orphan[] {
+  let ghqRoot: string;
+  try {
+    ghqRoot = execSync("ghq root", { encoding: "utf8" }).trim();
+  } catch { return []; }
+  const repos = execSync("ghq list", { encoding: "utf8" }).trim().split("\n");
+  const entries = loadFleetEntries();
+  const registered = new Set(
+    entries.flatMap(e => e.session.windows?.map(w => w.repo) ?? []),
+  );
+
+  const orphans: Orphan[] = [];
+  for (const rel of repos) {
+    if (rel.includes(".wt-")) continue;
+    const full = join(ghqRoot, rel);
+    const claudeMd = join(full, "CLAUDE.md");
+    const psi = join(full, "ψ");
+    if (!existsSync(claudeMd) || (!existsSync(psi) && !existsSync(join(full, "ψ")))) continue;
+
+    const parts = rel.split("/");
+    const org = parts[1] || "";
+    const repo = parts[2] || basename(full);
+    if (registered.has(`${org}/${repo}`)) continue;
+
+    const identity = readFileSync(claudeMd, "utf8").split("\n")[0].replace(/^#\s*/, "");
+    const stem = extractOracleStem(claudeMd);
+    if (!stem) continue;
+
+    orphans.push({ repo, org, stem, path: full, identity });
+  }
+  return orphans;
+}
+
+export async function cmdFleetAdopt(args: string[]) {
+  const isScan = args.includes("--scan");
+  const isDryRun = args.includes("--dry-run");
+  const asIdx = args.indexOf("--as");
+  const nameOverride = asIdx !== -1 ? args[asIdx + 1] : undefined;
+  const targets = args.filter(a => !a.startsWith("--") && a !== nameOverride);
+
+  if (isScan) {
+    const orphans = scanOrphans();
+    if (orphans.length === 0) {
+      console.log("  \x1b[32m✓\x1b[0m No orphan oracles — fleet is complete.");
+      return;
+    }
+    console.log(`  Orphan oracles (\x1b[33m${orphans.length}\x1b[0m not in fleet):\n`);
+    for (let i = 0; i < orphans.length; i++) {
+      const o = orphans[i];
+      console.log(`  ${String(i + 1).padStart(3)}  ${o.repo.padEnd(35)} → ${o.identity.substring(0, 30).padEnd(30)} (${o.org})`);
+    }
+    console.log(`\n  Adopt: \x1b[36mmaw fleet adopt <repo-name>\x1b[0m`);
+    return;
+  }
+
+  if (targets.length === 0) {
+    console.log("  usage: maw fleet adopt <repo-name> [--as <stem>] [--dry-run]");
+    console.log("         maw fleet adopt --scan");
+    return;
+  }
+
+  const orphans = scanOrphans();
+  const entries = loadFleetEntries();
+  let maxNum = entries.reduce((max, e) => Math.max(max, e.num), 0);
+
+  for (const target of targets) {
+    const match = orphans.find(o => o.repo === target || o.stem === target || o.repo.includes(target));
+    if (!match) {
+      console.log(`  \x1b[31m✗\x1b[0m '${target}' not found or already in fleet`);
+      continue;
+    }
+
+    const stem = nameOverride || match.stem;
+    const existingStem = entries.find(e => e.groupName === stem);
+    if (existingStem) {
+      console.log(`  \x1b[31m✗\x1b[0m '${stem}' already exists in fleet — use --as <other-name>`);
+      continue;
+    }
+
+    maxNum++;
+    const fileName = `${String(maxNum).padStart(2, "0")}-${stem}.json`;
+    const config = {
+      name: `${String(maxNum).padStart(2, "0")}-${stem}`,
+      windows: [{ name: `${stem}-oracle`, repo: `${match.org}/${match.repo}` }],
+      adopted_at: new Date().toISOString(),
+      adopted_from: `ghq:${match.org}/${match.repo}`,
+    };
+
+    if (isDryRun) {
+      console.log(`  \x1b[90m[dry-run]\x1b[0m would create: ${fileName}`);
+      console.log(JSON.stringify(config, null, 2));
+      continue;
+    }
+
+    writeFileSync(join(FLEET_DIR, fileName), JSON.stringify(config, null, 2) + "\n");
+    console.log(`  \x1b[32m✅\x1b[0m adopted: ${match.repo} → ${stem} (${fileName})`);
+    console.log(`     repo: ${match.org}/${match.repo}`);
+    console.log(`     fleet: ~/.config/maw/fleet/${fileName}`);
+    console.log(`     next: \x1b[36mmaw wake ${stem}\x1b[0m`);
+  }
+}

--- a/src/commands/plugins/fleet/index.ts
+++ b/src/commands/plugins/fleet/index.ts
@@ -96,6 +96,9 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
           }
         }
       }
+    } else if (sub === "adopt") {
+      const { cmdFleetAdopt } = await import("./fleet-adopt");
+      await cmdFleetAdopt(args.slice(1));
     } else if (sub === "snapshot") {
       const { takeSnapshot } = await import("../../../core/fleet/snapshot");
       const trigger = args[1] || "manual";
@@ -107,7 +110,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     } else {
       return {
         ok: false,
-        error: `unknown fleet subcommand: ${sub}\nusage: maw fleet <init|ls|renumber|validate|health|doctor|consolidate|sync|sync-windows|snapshots|restore|snapshot>`,
+        error: `unknown fleet subcommand: ${sub}\nusage: maw fleet <init|ls|renumber|validate|health|doctor|consolidate|sync|sync-windows|snapshots|restore|snapshot|adopt>`,
       };
     }
 

--- a/src/commands/plugins/split/impl.ts
+++ b/src/commands/plugins/split/impl.ts
@@ -1,0 +1,133 @@
+import { listSessions, hostExec, withPaneLock } from "../../../sdk";
+import { resolveSessionTarget } from "../../../core/matcher/resolve-target";
+import { normalizeTarget } from "../../../core/matcher/normalize-target";
+
+export interface SplitOpts {
+  /** Split percentage (1-99). Default: 50. */
+  pct?: number;
+  /** Split vertical (top/bottom) instead of horizontal (side-by-side). */
+  vertical?: boolean;
+  /** Split without attaching — leaves a plain shell in the new pane. */
+  noAttach?: boolean;
+  /** Serialize via the pane-creation lock + settle. Opt-in — only matters
+   *  when another in-process caller may be spawning concurrently. */
+  lock?: boolean;
+  /** Settle delay after split when lock=true. Default: 200ms. */
+  settleMs?: number;
+  /** Pane-id / selector to split beside instead of $TMUX_PANE. Break the
+   *  implicit active-pane-drift that caused fractal-split cascade (#545).
+   *  Accepts: "%N" (pane id), "session:window.pane", or "session:window". */
+  anchorPane?: string;
+}
+
+/**
+ * maw split <target> [--pct N] [--vertical] [--no-attach]
+ *
+ * Split the current tmux pane and attach to a target session in the new pane.
+ *
+ * Target resolution:
+ *   - "session:window"  → used as-is
+ *   - "session"         → resolved to session:window[0]
+ *   - bare oracle name  → finds session ending with "-<name>" or name === <name>
+ *
+ * Why this exists: `/bud --split` inlined this pattern, but (a) the nested
+ * `tmux attach-session` silently fails when $TMUX is set, and (b) the logic
+ * is useful beyond bud (worktree, pair-ops, debugging). Extracted here as
+ * one canonical helper — future skills call `maw split` instead of duplicating
+ * the tmux shell-out.
+ */
+export async function cmdSplit(target: string, opts: SplitOpts = {}) {
+  // Canonicalize first — drop trailing `/`, `/.git`, `/.git/` tab-completion artifacts.
+  // Safe for "session:window" form: nothing to strip unless the user adds a literal slash.
+  target = normalizeTarget(target);
+  if (!process.env.TMUX) {
+    throw new Error("maw split requires an active tmux session");
+  }
+
+  if (!target) {
+    console.error("usage: maw split <target> [--pct N] [--vertical] [--no-attach]");
+    console.error("  e.g. maw split yeast");
+    console.error("       maw split mawjs-view --pct 30 --vertical");
+    throw new Error("usage: maw split <target> [--pct N] [--vertical] [--no-attach]");
+  }
+
+  // Validate pct early so bad input never reaches tmux
+  const pct = opts.pct ?? 50;
+  if (!Number.isFinite(pct) || pct < 1 || pct > 99) {
+    throw new Error(`--pct must be 1-99 (got ${pct})`);
+  }
+
+  // Resolve target to session:window if bare name given. Resolution rules
+  // (exact > suffix/prefix fuzzy > ambiguous > none) live in the canonical
+  // matcher — silent wrong-answer is worse than a loud failure.
+  let resolved = target;
+  if (!target.includes(":")) {
+    const sessions = await listSessions();
+    const r = resolveSessionTarget(target, sessions);
+
+    if (r.kind === "ambiguous") {
+      console.error(`  \x1b[31m✗\x1b[0m '${target}' is ambiguous — matches ${r.candidates.length} sessions:`);
+      for (const s of r.candidates) {
+        console.error(`  \x1b[90m    • ${s.name}\x1b[0m`);
+      }
+      console.error(`  \x1b[90m  use the full name: maw split <exact-session>\x1b[0m`);
+      throw new Error(`'${target}' is ambiguous`);
+    }
+    if (r.kind === "none") {
+      console.error(`  \x1b[31m✗\x1b[0m session '${target}' not found in fleet`);
+      if (r.hints?.length) {
+        console.error(`  \x1b[90mdid you mean:\x1b[0m`);
+        for (const h of r.hints) {
+          console.error(`  \x1b[90m    • ${h.name}\x1b[0m`);
+        }
+      }
+      console.error(`  \x1b[90m  try: maw ls\x1b[0m`);
+      throw new Error(`session '${target}' not found in fleet`);
+    }
+
+    resolved = `${r.match.name}:${r.match.windows[0]?.index ?? 0}`;
+  }
+
+  // Build tmux split-window command.
+  //
+  // Critical: unset $TMUX in the spawned shell so the inner attach-session
+  // can nest into the target. Without `TMUX=`, tmux refuses nested attach
+  // and the new pane dies immediately (this is the #bud --split silent-fail bug).
+  //
+  // Target the caller's pane (#365 cascade fix): without -t, tmux splits
+  // the currently-active pane — which shifts after the first split, causing
+  // the second `maw bud <name> --split` from the same parent to silently
+  // split the wrong pane (or noop visually). Explicit -t $TMUX_PANE anchors
+  // every split to the caller's origin pane, so buds cascade instead of drifting.
+  // Fallback: if TMUX_PANE isn't set (shouldn't happen — we checked $TMUX above,
+  // and any pane inside tmux has TMUX_PANE set — but defend anyway), omit -t
+  // and accept the pre-fix behavior.
+  // Precedence: opts.anchorPane (explicit, from cmdView) > $TMUX_PANE (caller's
+  // pane) > none. Explicit anchor breaks the active-pane-drift that caused
+  // fractal-split cascade in #545/#546.
+  const direction = opts.vertical ? "-v" : "-h";
+  const innerCmd = opts.noAttach ? "bash" : `TMUX= tmux attach-session -t ${resolved}`;
+  const anchor = opts.anchorPane ?? process.env.TMUX_PANE;
+  const targetFlag = anchor ? `-t '${anchor.replace(/'/g, "'\\''")}' ` : "";
+  const cmd = `tmux split-window ${targetFlag}${direction} -l ${pct}% "${innerCmd}"`;
+
+  try {
+    if (opts.lock) {
+      // Serialize against other in-process pane spawns; settle before release
+      // so tmux has a tick to register the new pane index.
+      const settleMs = opts.settleMs ?? 200;
+      await withPaneLock(async () => {
+        await hostExec(cmd);
+        if (settleMs > 0) await new Promise((r) => setTimeout(r, settleMs));
+      });
+    } else {
+      await hostExec(cmd);
+    }
+    const side = opts.vertical ? "below" : "beside";
+    const action = opts.noAttach ? "empty pane" : resolved;
+    const anchorLabel = opts.anchorPane ? ` (anchored at ${opts.anchorPane})` : "";
+    console.log(`  \x1b[32m✓\x1b[0m split ${side} — ${action} (${pct}%)${anchorLabel}`);
+  } catch (e: any) {
+    throw new Error(`split failed: ${e.message || e}`);
+  }
+}

--- a/src/commands/plugins/split/index.ts
+++ b/src/commands/plugins/split/index.ts
@@ -1,0 +1,68 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { cmdSplit } from "./impl";
+import { parseFlags } from "../../../cli/parse-args";
+
+export const command = {
+  name: "split",
+  description: "Split current tmux pane and attach to a session.",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  try {
+    let target: string;
+    let opts: { pct?: number; vertical?: boolean; noAttach?: boolean } = {};
+
+    if (ctx.source === "cli") {
+      const args = ctx.args as string[];
+      const flags = parseFlags(args, {
+        "--pct": Number,
+        "--vertical": Boolean,
+        "--no-attach": Boolean,
+      }, 0);
+
+      target = flags._[0];
+      if (!target || target === "--help" || target === "-h") {
+        return { ok: false, error: "usage: maw split <target> [--pct N] [--vertical] [--no-attach]" };
+      }
+      if (target.startsWith("-")) {
+        return { ok: false, error: `"${target}" looks like a flag, not a target.\n  usage: maw split <target>` };
+      }
+
+      opts = {
+        pct: flags["--pct"],
+        vertical: flags["--vertical"],
+        noAttach: flags["--no-attach"],
+      };
+    } else {
+      const body = ctx.args as Record<string, unknown>;
+      if (!body.target) {
+        return { ok: false, error: "target is required" };
+      }
+      target = body.target as string;
+      opts = {
+        pct: body.pct as number | undefined,
+        vertical: body.vertical as boolean | undefined,
+        noAttach: body.noAttach as boolean | undefined,
+      };
+    }
+
+    await cmdSplit(target, opts);
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/src/commands/plugins/split/index.ts
+++ b/src/commands/plugins/split/index.ts
@@ -21,7 +21,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
   };
   try {
     let target: string;
-    let opts: { pct?: number; vertical?: boolean; noAttach?: boolean } = {};
+    let opts: { pct?: number; vertical?: boolean; noAttach?: boolean; anchorPane?: string } = {};
 
     if (ctx.source === "cli") {
       const args = ctx.args as string[];
@@ -29,11 +29,12 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         "--pct": Number,
         "--vertical": Boolean,
         "--no-attach": Boolean,
+        "--from": String,
       }, 0);
 
       target = flags._[0];
       if (!target || target === "--help" || target === "-h") {
-        return { ok: false, error: "usage: maw split <target> [--pct N] [--vertical] [--no-attach]" };
+        return { ok: false, error: "usage: maw split <target> [--from <oracle>] [--pct N] [--vertical] [--no-attach]" };
       }
       if (target.startsWith("-")) {
         return { ok: false, error: `"${target}" looks like a flag, not a target.\n  usage: maw split <target>` };
@@ -43,6 +44,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         pct: flags["--pct"],
         vertical: flags["--vertical"],
         noAttach: flags["--no-attach"],
+        anchorPane: flags["--from"] as string | undefined,
       };
     } else {
       const body = ctx.args as Record<string, unknown>;

--- a/src/commands/plugins/split/plugin.json
+++ b/src/commands/plugins/split/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "split",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Split current tmux pane and attach to a session (vesicle beside).",
+  "cli": {
+    "command": "split",
+    "help": "maw split <target> [--pct N] [--vertical] [--no-attach]",
+    "flags": {
+      "--pct": "number",
+      "--vertical": "boolean",
+      "--no-attach": "boolean"
+    }
+  },
+  "api": {
+    "path": "/api/split",
+    "methods": [
+      "POST"
+    ]
+  },
+  "weight": 10
+}

--- a/src/commands/plugins/split/plugin.json
+++ b/src/commands/plugins/split/plugin.json
@@ -6,8 +6,9 @@
   "description": "Split current tmux pane and attach to a session (vesicle beside).",
   "cli": {
     "command": "split",
-    "help": "maw split <target> [--pct N] [--vertical] [--no-attach]",
+    "help": "maw split <target> [--from <oracle>] [--pct N] [--vertical] [--no-attach]",
     "flags": {
+      "--from": "string",
       "--pct": "number",
       "--vertical": "boolean",
       "--no-attach": "boolean"

--- a/src/commands/plugins/swarm/index.ts
+++ b/src/commands/plugins/swarm/index.ts
@@ -105,21 +105,21 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       paneIds.push({ name, agentId, agentCmd, label, color });
     }
 
-    // Phase 1: Split all panes (empty shells) — no agents yet
+    // Phase 1: Split placeholder panes — sleep, no shell init, immune to SIGWINCH
     const spawned: { name: string; agentId: string; agentCmd: string; label: string; color: AgentColor; paneId: string }[] = [];
     for (const agent of paneIds) {
       const targetFlag = anchor ? `-t '${anchor}' ` : "";
       let paneId = "";
       await withPaneLock(async () => {
         paneId = (await hostExec(
-          `tmux split-window ${targetFlag}-h -P -F '#{pane_id}' '${PANE_INIT_PRELUDE}; exec zsh -li'`,
+          `tmux split-window ${targetFlag}-h -P -F '#{pane_id}' 'sleep infinity'`,
         )).trim();
         await new Promise(r => setTimeout(r, 100));
       });
       spawned.push({ ...agent, paneId });
     }
 
-    // Phase 2: Apply layout ONCE — all panes get their final sizes
+    // Phase 2: Apply layout ONCE — all panes get their final sizes (only sleep is running)
     const window = await getWindowTarget();
     if (tiled) {
       await applyTiledLayout(window);
@@ -129,13 +129,13 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     await enableBorderStatus(window);
     await new Promise(r => setTimeout(r, 200));
 
-    // Phase 3: Start agents in correctly-sized panes
+    // Phase 3: Respawn panes with real shell + agent — shell inits at final pane size
     for (const agent of spawned) {
       await stylePaneBorder(agent.paneId, `${agent.name} (${agent.label})`, agent.color);
 
       const escaped = agent.agentCmd.replace(/'/g, "'\\''");
       await hostExec(
-        `tmux send-keys -t '${agent.paneId}' '${PANE_INIT_PRELUDE}; ${escaped}; stty sane 2>/dev/null; printf "\\e[?1049l\\e[0m"; clear; exec zsh -li' Enter`,
+        `tmux respawn-pane -k -t '${agent.paneId}' '${PANE_INIT_PRELUDE}; ${escaped}; stty sane 2>/dev/null; printf "\\e[?1049l\\e[0m"; clear; exec zsh -li'`,
       );
       await new Promise(r => setTimeout(r, 200));
 

--- a/src/commands/plugins/swarm/index.ts
+++ b/src/commands/plugins/swarm/index.ts
@@ -69,6 +69,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       applyTeamLayout, applyTiledLayout, getWindowTarget,
     } = await import("../tmux/layout-manager");
     const { hostExec, withPaneLock } = await import("../../../sdk");
+    const { PANE_INIT_PRELUDE } = await import("../../shared/pane-prelude");
     const { existsSync, readFileSync, writeFileSync, mkdirSync } = await import("fs");
     const { join } = await import("path");
     const { homedir } = await import("os");
@@ -111,7 +112,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       let paneId = "";
       await withPaneLock(async () => {
         paneId = (await hostExec(
-          `tmux split-window ${targetFlag}-h -P -F '#{pane_id}' 'exec zsh -li'`,
+          `tmux split-window ${targetFlag}-h -P -F '#{pane_id}' '${PANE_INIT_PRELUDE}; exec zsh -li'`,
         )).trim();
         await new Promise(r => setTimeout(r, 100));
       });
@@ -134,7 +135,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
 
       const escaped = agent.agentCmd.replace(/'/g, "'\\''");
       await hostExec(
-        `tmux send-keys -t '${agent.paneId}' '${escaped}; stty sane 2>/dev/null; printf "\\e[?1049l\\e[0m"; clear; exec zsh -li' Enter`,
+        `tmux send-keys -t '${agent.paneId}' '${PANE_INIT_PRELUDE}; ${escaped}; stty sane 2>/dev/null; printf "\\e[?1049l\\e[0m"; clear; exec zsh -li' Enter`,
       );
       await new Promise(r => setTimeout(r, 200));
 

--- a/src/commands/plugins/team/impl.ts
+++ b/src/commands/plugins/team/impl.ts
@@ -1,0 +1,108 @@
+import { readdirSync, existsSync, readFileSync } from "fs";
+import { join } from "path";
+import { tmux } from "../../../sdk";
+import { TEAMS_DIR, loadTeam, resolvePsi } from "./team-helpers";
+import { findZombiePanes } from "./team-cleanup-zombies";
+
+// Re-export everything so index.ts and tests continue to import from "./impl"
+export { _setDirs, loadTeam, writeShutdownRequest, writeMessage } from "./team-helpers";
+export { cmdTeamShutdown, cmdTeamCreate, cmdTeamSpawn, mergeTeamKnowledge } from "./team-lifecycle";
+export { cmdTeamSend } from "./team-comms";
+export { cmdTeamResume, cmdTeamLives } from "./team-reincarnation";
+export { cmdCleanupZombies } from "./team-cleanup-zombies";
+
+/**
+ * Scan vault for CLI-created team manifests (#393 Bug B).
+ * Returns list of {name, members[]} that are NOT also present in the tool store.
+ */
+function listVaultOnlyTeams(toolTeamNames: Set<string>): Array<{ name: string; members: string[] }> {
+  const vaultTeamsDir = join(resolvePsi(), "memory", "mailbox", "teams");
+  if (!existsSync(vaultTeamsDir)) return [];
+  const out: Array<{ name: string; members: string[] }> = [];
+  try {
+    for (const name of readdirSync(vaultTeamsDir)) {
+      if (toolTeamNames.has(name)) continue; // also in tool store — listed via main loop
+      const manifestPath = join(vaultTeamsDir, name, "manifest.json");
+      if (!existsSync(manifestPath)) continue;
+      try {
+        const raw = JSON.parse(readFileSync(manifestPath, "utf-8"));
+        const members = Array.isArray(raw?.members)
+          ? raw.members.map((m: any) => typeof m === "string" ? m : m?.name).filter(Boolean)
+          : [];
+        out.push({ name, members });
+      } catch { /* skip malformed manifest */ }
+    }
+  } catch { /* no vault teams dir */ }
+  return out;
+}
+
+// ─── maw team list ───
+
+export async function cmdTeamList() {
+  let teamDirs: string[] = [];
+  try {
+    teamDirs = readdirSync(TEAMS_DIR).filter(d =>
+      existsSync(join(TEAMS_DIR, d, "config.json"))
+    );
+  } catch { /* expected: teams dir may not exist */ }
+
+  // #393 Bug B: also surface vault-only teams (created via maw team create
+  // but never wired through the tool-layer Agent()). They don't have pane
+  // IDs, but they exist and can be resumed.
+  const vaultOnly = listVaultOnlyTeams(new Set(teamDirs));
+
+  if (!teamDirs.length && !vaultOnly.length) {
+    console.log("\x1b[90mNo teams found.\x1b[0m");
+    console.log("\x1b[90m  looked in: ~/.claude/teams/ (tool) + ψ/memory/mailbox/teams/ (vault)\x1b[0m");
+    return;
+  }
+
+  const panes = await tmux.listPaneIds();
+
+  console.log();
+  console.log(`  \x1b[36;1mTEAM${" ".repeat(26)}STORE  MEMBERS  STATUS          ZOMBIES\x1b[0m`);
+
+  for (const dir of teamDirs) {
+    const team = loadTeam(dir);
+    if (!team) continue;
+
+    const teammates = team.members.filter(m => m.agentType !== "team-lead");
+    const aliveMembers = team.members.filter(m =>
+      m.tmuxPaneId && m.tmuxPaneId !== "in-process" && m.tmuxPaneId !== "" && panes.has(m.tmuxPaneId)
+    );
+    const deadPanes = teammates.filter(m =>
+      m.tmuxPaneId && m.tmuxPaneId !== "in-process" && m.tmuxPaneId !== "" && !panes.has(m.tmuxPaneId)
+    );
+
+    const name = dir.padEnd(30);
+    const store = "tool".padEnd(7);
+    const memberCount = String(teammates.length).padEnd(9);
+    const idle = aliveMembers.filter(m => m.agentType !== "team-lead").length;
+    const status = aliveMembers.length > 0
+      ? `\x1b[32m${idle} alive\x1b[0m`.padEnd(26)
+      : `\x1b[90mno live panes\x1b[0m`.padEnd(26);
+
+    console.log(`  ${name}${store}${memberCount}${status}${deadPanes.length > 0 ? `\x1b[90m${deadPanes.length} exited\x1b[0m` : "0"}`);
+  }
+
+  for (const v of vaultOnly) {
+    const name = v.name.padEnd(30);
+    const store = "vault".padEnd(7);
+    const memberCount = String(v.members.length).padEnd(9);
+    const status = `\x1b[90mprep-only\x1b[0m`.padEnd(26);
+    console.log(`  ${name}${store}${memberCount}${status}\x1b[90m—\x1b[0m`);
+  }
+
+  if (vaultOnly.length > 0) {
+    console.log(`\n  \x1b[90m${vaultOnly.length} vault-only team(s) — resume via \x1b[36mmaw team resume <name>\x1b[90m or remove via \x1b[36mrm -rf ψ/memory/mailbox/teams/<name>/\x1b[0m`);
+  }
+
+  // Check for orphan zombie panes (panes running claude with no matching team)
+  const allPanes = await tmux.listPanes();
+  const zombies = findZombiePanes(allPanes);
+  if (zombies.length > 0) {
+    console.log(`\n  \x1b[33m⚠ ${zombies.length} orphan zombie pane(s) detected\x1b[0m — run \x1b[36mmaw cleanup --zombie-agents\x1b[0m`);
+  }
+
+  console.log();
+}

--- a/src/commands/plugins/team/index.ts
+++ b/src/commands/plugins/team/index.ts
@@ -8,6 +8,7 @@ import {
 } from "./impl";
 import { parseFlags } from "../../../cli/parse-args";
 import { hostExec } from "../../../sdk";
+import { PANE_INIT_PRELUDE } from "../../shared/pane-prelude";
 
 export const command = {
   name: "team",
@@ -314,7 +315,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         let paneId = "";
         await withPaneLock(async () => {
           paneId = (await hostExec(
-            `tmux split-window ${targetFlag}-h -P -F '#{pane_id}' 'echo "\\x1b[${colorAnsi(color)}m${name} ready\\x1b[0m" && exec zsh'`,
+            `tmux split-window ${targetFlag}-h -P -F '#{pane_id}' '${PANE_INIT_PRELUDE}; echo "\\x1b[${colorAnsi(color)}m${name} ready\\x1b[0m" && exec zsh'`,
           )).trim();
           await new Promise(r => setTimeout(r, 200));
         });

--- a/src/commands/plugins/team/plugin.json
+++ b/src/commands/plugins/team/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "team",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Agent reincarnation engine \u2014 create, spawn, send, shutdown, resume, lives.",
+  "cli": {
+    "command": "team",
+    "help": "maw team <create|spawn|send|shutdown|list|status|tasks>",
+    "flags": {}
+  },
+  "api": {
+    "path": "/api/team",
+    "methods": [
+      "POST",
+      "GET"
+    ]
+  },
+  "weight": 10
+}

--- a/src/commands/plugins/team/task-ops.ts
+++ b/src/commands/plugins/team/task-ops.ts
@@ -1,0 +1,157 @@
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+function configBase(): string {
+  return process.env.MAW_CONFIG_DIR ?? join(homedir(), ".config/maw");
+}
+
+function tasksDir(team: string): string {
+  return join(configBase(), "teams", team, "tasks");
+}
+
+function ensureTasksDir(team: string): string {
+  const dir = tasksDir(team);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function counterPath(team: string): string {
+  return join(tasksDir(team), "_counter.json");
+}
+
+function taskPath(team: string, id: number): string {
+  return join(tasksDir(team), `${id}.json`);
+}
+
+function nextId(team: string): number {
+  const p = counterPath(team);
+  let counter = { next: 1 };
+  if (existsSync(p)) {
+    try { counter = JSON.parse(readFileSync(p, "utf-8")); } catch { /**/ }
+  }
+  const id = counter.next;
+  // lgtm[js/file-system-race] — PRIVATE-PATH: counter under ~/.maw/teams/, see docs/security/file-system-race-stance.md
+  writeFileSync(p, JSON.stringify({ next: id + 1 }));
+  return id;
+}
+
+function readTask(team: string, id: number): MawTask | null {
+  const p = taskPath(team, id);
+  if (!existsSync(p)) return null;
+  try { return JSON.parse(readFileSync(p, "utf-8")); } catch { return null; }
+}
+
+function writeTask(team: string, task: MawTask): void {
+  writeFileSync(taskPath(team, task.id), JSON.stringify(task, null, 2));
+}
+
+export interface MawTask {
+  id: number;
+  subject: string;
+  description?: string;
+  status: "pending" | "in_progress" | "completed";
+  assignee?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export function cmdTeamTaskAdd(
+  team: string,
+  subject: string,
+  opts?: { description?: string; assign?: string },
+): MawTask {
+  ensureTasksDir(team);
+  const now = new Date().toISOString();
+  const task: MawTask = {
+    id: nextId(team),
+    subject,
+    ...(opts?.description ? { description: opts.description } : {}),
+    status: "pending",
+    ...(opts?.assign ? { assignee: opts.assign } : {}),
+    createdAt: now,
+    updatedAt: now,
+  };
+  writeTask(team, task);
+  console.log(`\x1b[32m✓\x1b[0m task #${task.id} created: ${subject}`);
+  return task;
+}
+
+export function cmdTeamTaskList(team: string): MawTask[] {
+  const dir = tasksDir(team);
+  if (!existsSync(dir)) {
+    console.log(`\x1b[36mℹ\x1b[0m no tasks for team "${team}"`);
+    return [];
+  }
+  const tasks: MawTask[] = readdirSync(dir)
+    .filter(f => f.endsWith(".json") && f !== "_counter.json")
+    .map(f => {
+      try { return JSON.parse(readFileSync(join(dir, f), "utf-8")) as MawTask; } catch { return null; }
+    })
+    .filter(Boolean) as MawTask[];
+
+  tasks.sort((a, b) => a.id - b.id);
+
+  if (tasks.length === 0) {
+    console.log(`\x1b[36mℹ\x1b[0m no tasks for team "${team}"`);
+    return tasks;
+  }
+
+  const statusColor = (s: string) =>
+    s === "completed" ? `\x1b[32m${s}\x1b[0m`
+    : s === "in_progress" ? `\x1b[36m${s}\x1b[0m`
+    : `\x1b[33m${s}\x1b[0m`;
+
+  console.log(`\x1b[36mℹ\x1b[0m tasks for team "${team}" (${tasks.length}):`);
+  for (const t of tasks) {
+    const assignee = t.assignee ? ` → ${t.assignee}` : "";
+    console.log(`  #${t.id}  [${statusColor(t.status)}]  ${t.subject}${assignee}`);
+  }
+  return tasks;
+}
+
+export function cmdTeamTaskDone(team: string, id: number): MawTask | null {
+  ensureTasksDir(team);
+  const task = readTask(team, id);
+  if (!task) {
+    console.log(`\x1b[33m⚠\x1b[0m task #${id} not found in team "${team}"`);
+    return null;
+  }
+  task.status = "completed";
+  task.updatedAt = new Date().toISOString();
+  writeTask(team, task);
+  console.log(`\x1b[32m✓\x1b[0m task #${id} marked completed`);
+  return task;
+}
+
+export function cmdTeamTaskAssign(team: string, id: number, agent: string): MawTask | null {
+  ensureTasksDir(team);
+  const task = readTask(team, id);
+  if (!task) {
+    console.log(`\x1b[33m⚠\x1b[0m task #${id} not found in team "${team}"`);
+    return null;
+  }
+  task.assignee = agent;
+  task.status = "in_progress";
+  task.updatedAt = new Date().toISOString();
+  writeTask(team, task);
+  console.log(`\x1b[32m✓\x1b[0m task #${id} assigned to ${agent}`);
+  return task;
+}
+
+export function cmdTeamTaskDelete(team: string, id: number): boolean {
+  const p = taskPath(team, id);
+  if (!existsSync(p)) {
+    console.log(`\x1b[33m⚠\x1b[0m task #${id} not found in team "${team}"`);
+    return false;
+  }
+  rmSync(p);
+  console.log(`\x1b[32m✓\x1b[0m task #${id} deleted`);
+  return true;
+}
+
+export function cmdTeamTaskDeleteAll(team: string): void {
+  const dir = tasksDir(team);
+  if (!existsSync(dir)) return;
+  rmSync(dir, { recursive: true, force: true });
+}

--- a/src/commands/plugins/team/team-cleanup-zombies.ts
+++ b/src/commands/plugins/team/team-cleanup-zombies.ts
@@ -1,0 +1,116 @@
+import { readdirSync, existsSync } from "fs";
+import { join } from "path";
+import { tmux } from "../../../sdk";
+import type { TmuxPane } from "../../../sdk";
+import { loadFleetEntries } from "../../shared/fleet-load";
+import { TEAMS_DIR, loadTeam } from "./team-helpers";
+
+// ─── maw cleanup --zombie-agents ───
+
+export async function cmdCleanupZombies(opts: { yes?: boolean } = {}) {
+  console.log("\x1b[36mScanning tmux panes...\x1b[0m");
+
+  const allPanes = await tmux.listPanes();
+  const zombies = findZombiePanes(allPanes);
+
+  if (!zombies.length) {
+    console.log("\x1b[32m✓\x1b[0m No zombie agent panes found.");
+    return;
+  }
+
+  console.log(`\nFound \x1b[33m${zombies.length}\x1b[0m orphan claude pane(s):\n`);
+  for (const z of zombies) {
+    console.log(`  \x1b[33m${z.paneId}\x1b[0m  ${z.info}  \x1b[90m(team: ${z.teamName} — DELETED)\x1b[0m`);
+  }
+
+  if (!opts.yes) {
+    console.log(`\nRun with \x1b[36m--yes\x1b[0m to kill them.`);
+    return;
+  }
+
+  for (const z of zombies) {
+    await tmux.killPane(z.paneId);
+    console.log(`\x1b[32m✓\x1b[0m killed ${z.paneId}`);
+  }
+}
+
+interface ZombiePane {
+  paneId: string;
+  info: string;
+  teamName: string;
+}
+
+/**
+ * Find zombie panes: tmux panes running `claude` that are NOT part of any
+ * live team config AND NOT part of the fleet. Fleet-exclusion is critical
+ * — without it, every live fleet oracle would be flagged as a zombie.
+ */
+export function findZombiePanes(allPanes: TmuxPane[]): ZombiePane[] {
+  // Get all known team pane IDs from existing team configs
+  const knownTeamPaneIds = new Set<string>();
+  let teamDirs: string[] = [];
+  try {
+    teamDirs = readdirSync(TEAMS_DIR).filter(d =>
+      existsSync(join(TEAMS_DIR, d, "config.json"))
+    );
+  } catch { /* no teams dir */ }
+
+  for (const dir of teamDirs) {
+    const team = loadTeam(dir);
+    if (!team) continue;
+    for (const m of team.members) {
+      if (m.tmuxPaneId && m.tmuxPaneId !== "in-process" && m.tmuxPaneId !== "") {
+        knownTeamPaneIds.add(m.tmuxPaneId);
+      }
+    }
+  }
+
+  // Compute the set of fleet session names (e.g. "01-pulse", "08-mawjs").
+  // Any pane whose target starts with "<fleet-session>:" is a live fleet
+  // oracle and must NEVER be flagged as a zombie.
+  const fleetSessions = new Set<string>();
+  try {
+    for (const entry of loadFleetEntries()) {
+      fleetSessions.add(entry.file.replace(/\.json$/, ""));
+    }
+  } catch { /* no fleet dir */ }
+
+  // Also allow meta-view sessions (maw-view + any *-view) which mirror fleet
+  // panes. Each oracle creates its meta-view as `<stem>-view` (e.g.
+  // mawjs-view, mawui-view). #393 Bug F — zombie-auditor iter3 caught this:
+  // hardcoding only "maw-view" left every oracle's live pane one keystroke
+  // away from being killed by `maw cleanup --zombie-agents --yes`.
+  const isViewSession = (s: string) => s === "maw-view" || /-view$/.test(s);
+
+  // Defense-in-depth: also compute the set of pane ids that have ANY fleet
+  // (or view) listing. If the same pane id appears across multiple sessions
+  // (tmux-linked windows), a single safe target is enough to mark it safe.
+  // This protects against tmux reporting the non-fleet session as canonical.
+  const safePaneIds = new Set<string>();
+  for (const p of allPanes) {
+    const session = p.target.split(":")[0];
+    if (fleetSessions.has(session) || isViewSession(session)) {
+      safePaneIds.add(p.id);
+    }
+  }
+
+  const isFleetPane = (target: string): boolean => {
+    const session = target.split(":")[0];
+    return fleetSessions.has(session) || isViewSession(session);
+  };
+
+  // Find claude panes that are (a) not in any team config AND
+  // (b) not in the fleet/view (by either target OR any other listing of the same pane)
+  return allPanes
+    .filter(p =>
+      p.command?.includes("claude") &&
+      !knownTeamPaneIds.has(p.id) &&
+      !isFleetPane(p.target) &&
+      !safePaneIds.has(p.id)
+    )
+    .map(p => ({
+      paneId: p.id,
+      info: `${p.target}  "${(p.title || "").slice(0, 50)}"`,
+      teamName: "unknown",
+    }));
+}

--- a/src/commands/plugins/team/team-comms.ts
+++ b/src/commands/plugins/team/team-comms.ts
@@ -1,0 +1,32 @@
+import { writeFileSync, existsSync, mkdirSync } from "fs";
+import { join } from "path";
+import { loadTeam, writeMessage, resolvePsi } from "./team-helpers";
+
+// ─── maw team send <team> <agent> <message> ───
+
+export function cmdTeamSend(teamName: string, agent: string, message: string) {
+  if (!message) {
+    throw new Error("usage: maw team send <team> <agent> <message>");
+  }
+
+  // Try CC team inbox first (live team), fallback to vault mailbox
+  const team = loadTeam(teamName);
+  if (team) {
+    writeMessage(teamName, agent, "maw-team-send", message);
+    console.log(`\x1b[32m✓\x1b[0m message sent to ${agent} in live team '${teamName}'`);
+    return;
+  }
+
+  // Fallback: write to ψ mailbox for async delivery
+  const PSI = resolvePsi();
+  const mailboxDir = join(PSI, "memory", "mailbox", agent);
+  mkdirSync(mailboxDir, { recursive: true });
+  const msgFile = join(mailboxDir, `msg-${Date.now()}.json`);
+  writeFileSync(msgFile, JSON.stringify({
+    from: "maw-team-send",
+    team: teamName,
+    text: message,
+    timestamp: new Date().toISOString(),
+  }, null, 2));
+  console.log(`\x1b[32m✓\x1b[0m message written to ψ/memory/mailbox/${agent}/ (team not live)`);
+}

--- a/src/commands/plugins/team/team-reincarnation.ts
+++ b/src/commands/plugins/team/team-reincarnation.ts
@@ -1,0 +1,73 @@
+import { readFileSync, existsSync, readdirSync } from "fs";
+import { join } from "path";
+import { resolvePsi } from "./team-helpers";
+import { cmdTeamSpawn } from "./team-lifecycle";
+
+// ─── maw team resume <name> ───
+
+export function cmdTeamResume(name: string, opts: { model?: string } = {}) {
+  const PSI = resolvePsi();
+  const manifestPath = join(PSI, "memory", "mailbox", "teams", name, "manifest.json");
+
+  if (!existsSync(manifestPath)) {
+    throw new Error(`no archived team '${name}' found — looked in: ${manifestPath}`);
+  }
+
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+  const members: string[] = manifest.members || [];
+
+  if (!members.length) {
+    console.log(`\x1b[90mTeam '${name}' has no members to resume.\x1b[0m`);
+    return;
+  }
+
+  console.log(`\x1b[36m⏳\x1b[0m resuming team '${name}' — ${members.length} agent(s)...\n`);
+
+  for (const member of members) {
+    cmdTeamSpawn(name, member, { model: opts.model });
+    console.log();
+  }
+
+  console.log(`\x1b[32m✓\x1b[0m team '${name}' resumed — ${members.length} agent(s) reincarnated`);
+}
+
+// ─── maw team lives <agent> ───
+
+export function cmdTeamLives(agent: string) {
+  const PSI = resolvePsi();
+  const mailboxDir = join(PSI, "memory", "mailbox", agent);
+
+  if (!existsSync(mailboxDir)) {
+    console.log(`\x1b[90mNo past lives found for '${agent}'\x1b[0m`);
+    console.log(`  \x1b[90mlooked in: ${mailboxDir}\x1b[0m`);
+    return;
+  }
+
+  const files = readdirSync(mailboxDir).sort();
+
+  console.log(`\n  \x1b[36;1m${agent} — past lives\x1b[0m\n`);
+
+  // Standing orders
+  const hasOrders = files.includes("standing-orders.md");
+  console.log(`  standing orders: ${hasOrders ? "\x1b[32myes\x1b[0m" : "\x1b[90mno\x1b[0m"}`);
+
+  // Findings
+  const findings = files.filter(f => f.endsWith("_findings.md"));
+  if (findings.length) {
+    console.log(`  findings: \x1b[32m${findings.length}\x1b[0m`);
+    for (const f of findings) {
+      const lines = readFileSync(join(mailboxDir, f), "utf-8").split("\n").length;
+      console.log(`    \x1b[90m${f} (${lines} lines)\x1b[0m`);
+    }
+  } else {
+    console.log(`  findings: \x1b[90mnone\x1b[0m`);
+  }
+
+  // Other files (messages, team archives)
+  const other = files.filter(f => f !== "standing-orders.md" && !f.endsWith("_findings.md"));
+  if (other.length) {
+    console.log(`  other: \x1b[90m${other.join(", ")}\x1b[0m`);
+  }
+
+  console.log();
+}

--- a/src/commands/plugins/tmux/layout-manager.ts
+++ b/src/commands/plugins/tmux/layout-manager.ts
@@ -1,4 +1,5 @@
 import { hostExec } from "../../../sdk";
+import { PANE_INIT_PRELUDE } from "../../shared/pane-prelude";
 
 // CC palette — 8 distinct colors, same order as claude-code AgentColorName
 const AGENT_COLORS = [
@@ -125,8 +126,9 @@ export async function spawnTeammatePane(
   const targetFlag = anchor ? `-t '${anchor}' ` : "";
   const color = nextAgentColor(opts.colorIndex);
 
-  // Wrap: restore terminal discipline + screen after agent TUI exits
-  const wrapped = `${command.replace(/'/g, "'\\''")}; stty sane 2>/dev/null; printf "\\e[?1049l\\e[0m"; clear; exec zsh -li`;
+  // Init terminal discipline + size BEFORE agent so it doesn't inherit a bad
+  // stty (#1091); restore again AFTER so the recovery shell is sane.
+  const wrapped = `${PANE_INIT_PRELUDE}; ${command.replace(/'/g, "'\\''")}; stty sane 2>/dev/null; printf "\\e[?1049l\\e[0m"; clear; exec zsh -li`;
 
   let paneId = "";
   await withPaneLock(async () => {

--- a/src/commands/shared/pane-prelude.ts
+++ b/src/commands/shared/pane-prelude.ts
@@ -1,0 +1,9 @@
+import { CLAUDE_COLS, CLAUDE_ROWS } from "./wake-pane-size";
+
+// Initial terminal discipline + size for newly-spawned agent panes. Without
+// this, panes inherit whatever stty/size state the parent process left behind
+// — most visibly the 80x24 default when the session was created detached
+// (#1091). `stty sane` resets line discipline; the explicit rows/cols stop
+// claude/codex from baking narrow scrollback at spawn. Errors silenced so a
+// missing stty doesn't break the spawn.
+export const PANE_INIT_PRELUDE = `stty sane 2>/dev/null; stty rows ${CLAUDE_ROWS} cols ${CLAUDE_COLS} 2>/dev/null`;


### PR DESCRIPTION
## Summary

Continues #1091. Yesterday's fixes added `stty sane` AFTER agent exit; this adds it BEFORE the agent spawns.

## What changed

- New `src/commands/shared/pane-prelude.ts` exporting `PANE_INIT_PRELUDE` (`stty sane; stty rows 50 cols 200`)
- Prepended in 3 spawn callsites:
  - `swarm/index.ts:114` (Phase 1 split) and `:137` (Phase 3 send-keys)
  - `tmux/layout-manager.ts:129` (`spawnTeammatePane` wrapped string)
  - `team/index.ts:317` (team prep split)
- Bump to `v26.5.3-alpha.852`

## Why

Live evidence on m5 showed `pane %5 80x24 cmd=claude.exe` — Claude rendering at the detached default. `pinSessionWide` exists for `maw wake` but never ran for `maw swarm` / `maw team` / `spawnTeammatePane`. Agents inherited 80x24 stty, baked narrow scrollback at spawn.

## Test plan

- [ ] On merge: install via `bun add -g maw-js@alpha`
- [ ] `maw swarm claude codex opencode` — verify new panes report 200x50 in `maw panes`
- [ ] Confirm Claude TUI renders correctly in spawned panes (no frozen prompt, no invisible keystrokes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)