### PR TITLE
fix(wake): fleet pin wins over ghq scan (#1104)

### DIFF
--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -58,6 +58,22 @@ export async function resolveOracle(
   oracle: string,
   opts?: { allLocal?: boolean },
 ): Promise<{ repoPath: string; repoName: string; parentDir: string }> {
+  // #1104 — fleet pin wins over ghq scan. When fleet config specifies a full
+  // org/repo slug, use it for an org-qualified ghq lookup so duplicate repo
+  // names across orgs resolve correctly.
+  try {
+    for (const file of readdirSync(FLEET_DIR).filter(f => f.endsWith(".json"))) {
+      const config = JSON.parse(readFileSync(join(FLEET_DIR, file), "utf-8")) as FleetSession;
+      const win = (config.windows || []).find((w: FleetWindow) => w.name === `${oracle}-oracle` || w.name === oracle);
+      if (win?.repo && win.repo.includes("/")) {
+        const fleetHit = await ghqFind(`/${win.repo}`);
+        if (fleetHit) {
+          return { repoPath: fleetHit, repoName: fleetHit.split("/").pop()!, parentDir: fleetHit.replace(/\/[^/]+$/, "") };
+        }
+      }
+    }
+  } catch { /* fleet dir may not exist */ }
+
   const ghqHit = await ghqFind(`/${oracle}-oracle`);
   if (ghqHit) {
     const repoPath = ghqHit;

--- a/src/core/repo-discovery/ghq-discovery.ts
+++ b/src/core/repo-discovery/ghq-discovery.ts
@@ -48,7 +48,14 @@ export const GhqDiscovery: RepoDiscovery = {
 
   async findBySuffix(suffix: string): Promise<string | null> {
     const lower = literalize(suffix).toLowerCase();
-    return (await this.list()).find((p) => p.toLowerCase().endsWith(lower)) ?? null;
+    const all = (await this.list()).filter((p) => p.toLowerCase().endsWith(lower));
+    if (all.length > 1) {
+      // #1104 — multiple orgs have the same repo name; caller should use
+      // an org-qualified suffix to disambiguate.
+      console.error(`\x1b[33m⚠\x1b[0m ghq: ${all.length} repos match '${suffix}':`);
+      for (const p of all) console.error(`\x1b[90m    • ${p}\x1b[0m`);
+    }
+    return all[0] ?? null;
   },
 
   findBySuffixSync(suffix: string): string | null {


### PR DESCRIPTION
## Summary
- Fleet config checked as Tier 0 before ghq scan — when fleet specifies full org/repo, uses org-qualified ghq lookup
- Fixes duplicate repo names across orgs (e.g. laris-co/metis-oracle vs Soul-Brews-Studio/metis-oracle)
- Adds ambiguity warning in findBySuffix when multiple repos match same suffix

## Test plan
- [x] `maw wake metis` resolves to Soul-Brews-Studio/metis-oracle (verified locally)
- [x] Both files compile clean
- [ ] CI passes

Closes #1104

🤖 Generated with [Claude Code](https://claude.com/claude-code)