### PR TITLE
release: v26.5.4-alpha.1906

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.4-alpha.651",
+  "version": "26.5.4-alpha.1906",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts v26.5.4-alpha.1906 on merge via calver-release.yml.

Auto-generated by /release-alpha — branch had commits ahead of origin/alpha at cut time.

Changes since last release:
- fix(wake): fleet pin wins over ghq scan (#1104)
- fix(wake): refuse spawn into missing cwd (#1090)
- 9 issues closed (#1087, #1091, #1095-#1098, #1100, #1102, #1104)