### PR TITLE
fix(hey+wake): fleet-first routing + auto-skip-permissions (#1107, #1108)

### DIFF
--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -250,10 +250,16 @@ export async function cmdSend(
     const isCanonical = parts.length >= 3;
     const isLocalScope = !targetNode || targetNode === config.node;
     if (isLocalScope && bareAgent && !isCanonical) {
-      const hasLocalSession = sessions.some(s =>
-        s.name === bareAgent ||
-        s.windows.some(w => w.name === `${bareAgent}-oracle` || w.name === bareAgent)
-      );
+      // #1107: check fleet config first — if fleet maps this oracle to a
+      // running session, it's live (don't fall through to substring matching)
+      const { resolveFleetSession } = await import("./wake");
+      const fleetSess = resolveFleetSession(bareAgent);
+      const hasLocalSession = (fleetSess && sessions.some(s => s.name === fleetSess)) ||
+        sessions.some(s =>
+          s.name === bareAgent ||
+          s.name.replace(/^\d+-/, "") === bareAgent ||
+          s.windows.some(w => w.name === `${bareAgent}-oracle` || w.name === bareAgent)
+        );
       try {
         // Sub-PR 4 of #841: use the unified OracleManifest as the source of
         // truth for `isFleetKnown`. We still derive `isLive` from the freshly

--- a/src/config/command.ts
+++ b/src/config/command.ts
@@ -42,6 +42,14 @@ export function buildCommand(agentName: string, optsOrEngine?: string | BuildCom
 
   if (opts.channels?.length) {
     cmd += " --channels " + opts.channels.join(" ");
+    // #1108: channel-enabled oracles (Discord/Telegram bots) run autonomous —
+    // permission prompts block unattended sessions (Mother stuck 20+ min).
+    if (!cmd.includes("--dangerously-skip-permissions")) {
+      cmd += " --dangerously-skip-permissions";
+    }
+    if (!cmd.includes("--continue") && !cmd.includes("--resume")) {
+      cmd += " --continue";
+    }
   }
   if (opts.devChannels) {
     cmd += " --dangerously-load-development-channels";

--- a/src/core/routing.ts
+++ b/src/core/routing.ts
@@ -70,20 +70,22 @@ export function resolveTarget(
 
   const selfNode = config.node ?? "local";
 
-  // --- Step 1: Local findWindow + fleet config ---
-  const localTarget = findWindow(writable, query);
-  if (localTarget) {
-    return { type: "local", target: localTarget };
-  }
-  // Fleet config: oracle name → session name → findWindow (#281)
+  // --- Step 1: Fleet config first, then local findWindow (#1107) ---
+  // Fleet config is authoritative — check it BEFORE substring matching
+  // to prevent "discord" matching "hermes-discord" when fleet says
+  // discord → 24-discord-oracle.
   const fleetSession = resolveFleetSession(query) || resolveFleetSession(query.replace(/-oracle$/, ""));
   if (fleetSession) {
     const fleetTarget = findWindow(writable.filter(s => s.name === fleetSession), query)
       || findWindow(writable.filter(s => s.name === fleetSession), query.replace(/-oracle$/, ""));
     if (fleetTarget) return { type: "local", target: fleetTarget };
-    // Fleet config matched but session not running — try first window of fleet session
     const fleetSess = writable.find(s => s.name === fleetSession);
     if (fleetSess?.windows.length) return { type: "local", target: `${fleetSession}:${fleetSess.windows[0].index}` };
+  }
+  // Fallback to general findWindow (catches non-fleet sessions)
+  const localTarget = findWindow(writable, query);
+  if (localTarget) {
+    return { type: "local", target: localTarget };
   }
 
   // --- Step 2: Node:prefix syntax (e.g. "mba:homekeeper") ---
@@ -93,16 +95,19 @@ export function resolveTarget(
     const agentName = query.slice(colonIdx + 1);
     if (!nodeName || !agentName) return { type: "error", reason: "empty_node_or_agent", detail: `invalid format: '${query}'`, hint: "use node:agent format (e.g. mba:homekeeper)" };
 
-    // Self-node check: "white:mawjs" from white → resolve locally
+    // Self-node check: "m5:discord" from m5 → resolve locally
+    // #1107: fleet config first to prevent substring collision
     if (nodeName === selfNode) {
-      const selfTarget = findWindow(writable, agentName);
-      if (selfTarget) return { type: "self-node", target: selfTarget };
-      // Try fleet config resolution (#281)
       const selfFleet = resolveFleetSession(agentName) || resolveFleetSession(agentName.replace(/-oracle$/, ""));
       if (selfFleet) {
+        const fleetTarget = findWindow(writable.filter(s => s.name === selfFleet), agentName)
+          || findWindow(writable.filter(s => s.name === selfFleet), agentName.replace(/-oracle$/, ""));
+        if (fleetTarget) return { type: "self-node", target: fleetTarget };
         const fleetSess = writable.find(s => s.name === selfFleet);
         if (fleetSess?.windows.length) return { type: "self-node", target: `${selfFleet}:${fleetSess.windows[0].index}` };
       }
+      const selfTarget = findWindow(writable, agentName);
+      if (selfTarget) return { type: "self-node", target: selfTarget };
       return { type: "error", reason: "self_not_running", detail: `'${agentName}' not found in local sessions on ${selfNode}`, hint: `maw wake ${agentName}` };
     }
 

--- a/src/core/runtime/find-window.ts
+++ b/src/core/runtime/find-window.ts
@@ -98,6 +98,21 @@ export function findWindow(sessions: Session[], query: string): string | null {
   if (exact.size === 1) return [...exact][0];
   if (exact.size > 1) throw new AmbiguousMatchError(query, [...exact]);
 
+  // Pass 1.5: suffix-segment match — window named `<query>-oracle` or session
+  // stem ending with `-<query>`. Resolves "discord" → window "discord-oracle"
+  // without falling to substring that also catches "hermes-discord" (#1107).
+  const suffixSeg = new Set<string>();
+  for (const s of sessions) {
+    for (const w of s.windows) {
+      const wn = w.name.toLowerCase();
+      if (wn === `${q}-oracle` || wn.replace(/-oracle$/, "") === q) {
+        suffixSeg.add(`${s.name}:${w.index}`);
+      }
+    }
+  }
+  if (suffixSeg.size === 1) return [...suffixSeg][0];
+  if (suffixSeg.size > 1) throw new AmbiguousMatchError(query, [...suffixSeg]);
+
   const sub = new Set<string>();
   for (const s of sessions) {
     for (const w of s.windows) {


### PR DESCRIPTION
## Summary
- Fleet config checked before findWindow in routing.ts — prevents substring collision
- find-window.ts Pass 1.5: suffix-segment match for window names
- command.ts: auto --dangerously-skip-permissions + --continue for channel bots
- comm-send.ts: fleet-aware hasLocalSession prevents orphan window recreation

## Test
- `maw hey m5:discord` → `24-discord-oracle:1` (was: `18-hermes-discord:3`)
- Verified fleet pin resolution, no orphan windows created

Closes #1107, closes #1108

🤖 Generated with [Claude Code](https://claude.com/claude-code)