### PR TITLE
release: v26.5.4-alpha.2155

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.4-alpha.1906",
+  "version": "26.5.4-alpha.2155",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts v26.5.4-alpha.2155 — fleet-first resolution marathon.

- fix(hey+wake): fleet-first routing + auto-skip-permissions (#1107, #1108)
- fix(wake): fleet-first detectSession — prevents wrong-session match
- fix(wake): fleet-known oracle returns null when session dead
- fix(attach): fleet-first in resolveTmuxTarget
- fix(wake): worktree windows inherit channel opts from main oracle

Auto-generated by /release-alpha