### PR TITLE
release: v26.5.5-alpha.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.4-alpha.2155",
+  "version": "26.5.5-alpha.14",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
## Loop session deliverables (10 iterations)

### Features
- `maw fleet compose` — generate single-service docker-compose.yml for maw serve
- `Dockerfile.oracle` + `Dockerfile.serve`
- `cli.richHelp` opt-out — bypass thin plugin help interception (#1116)
- Rich --help handlers in fleet/channel/team/oracle
- `--json` flag on fleet ls + channel ls (#1118 partial)
- `maw wake --dry-run` actually previews without side effects (#1113)
- `maw hey` usage documents --approve --trust (#1119)

### Issues Filed
- #1111 — maw oracle rename (full identity)
- #1113 — wake --dry-run side-effect (FIXED)
- #1114 — CLI error format inconsistency
- #1115 — fleet --to-compose (FIXED)
- #1116 — --help thin output (FIXED via richHelp)
- #1117 — subcommand verb inconsistency
- #1118 — ls flag variance (PARTIAL FIX: fleet+channel)
- #1119 — undocumented hey flags (FIXED)

Auto-generated by /release-alpha