### PR TITLE
release: v26.5.5-alpha.134

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.5-alpha.14",
+  "version": "26.5.5-alpha.134",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Docker chain end-to-end + cross-platform memory + plugin loader fixes + oracle rename + richHelp.