### PR TITLE
fix(channel): expand tilde in DISCORD_STATE_DIR (#1135)

### DIFF
--- a/src/commands/plugins/channel/index.ts
+++ b/src/commands/plugins/channel/index.ts
@@ -66,9 +66,12 @@ github: prefix → delegates to setup wizard`,
 
       const newPlugin: ChannelPlugin = { id: pluginId };
 
-      // Auto-set DISCORD_STATE_DIR for discord plugins
+      // Auto-set DISCORD_STATE_DIR for discord plugins. Use absolute path —
+      // Bun/Node don't expand `~` in JSON values; storing a literal tilde
+      // here would fail at exec time (#1135).
       if (pluginId.includes("discord")) {
-        newPlugin.env = { DISCORD_STATE_DIR: `~/.claude/channels/${oracle}` };
+        const home = require("os").homedir();
+        newPlugin.env = { DISCORD_STATE_DIR: `${home}/.claude/channels/${oracle}` };
       }
 
       // --env KEY=VAL

--- a/src/config/command.ts
+++ b/src/config/command.ts
@@ -1,4 +1,23 @@
 import { loadConfig } from "./load";
+import { homedir } from "os";
+
+/**
+ * Expand a leading `~` to the user's home directory.
+ *
+ * Channel config (`~/.claude/channels/<oracle>/config.json`) accepts paths
+ * like `"~/.claude/channels/foo"` in env values. JSON has no shell, so the
+ * tilde reaches `buildCommand` as a literal `~`. The env-prepend block
+ * single-quotes values, which suppresses tilde expansion at exec time too,
+ * so the plugin sees `DISCORD_STATE_DIR=~/.claude/...` literally and either
+ * fails to find the dir or silently falls back to a default.
+ *
+ * Expand here, before quoting. Only triggers when `~` is the first character
+ * and followed by `/` or end-of-string — won't touch usernames embedded
+ * elsewhere in the value. (#1135)
+ */
+function expandTilde(value: string): string {
+  return value.replace(/^~(?=\/|$)/, homedir());
+}
 
 function matchGlob(pattern: string, name: string): boolean {
   if (pattern === name) return true;
@@ -35,7 +54,7 @@ export function buildCommand(agentName: string, optsOrEngine?: string | BuildCom
   // because tmux set-environment only affects NEW shells, not the existing one
   if (opts.channelEnv && Object.keys(opts.channelEnv).length > 0) {
     const envPrefix = Object.entries(opts.channelEnv)
-      .map(([k, v]) => `${k}='${v.replace(/'/g, "'\\''")}'`)
+      .map(([k, v]) => `${k}='${expandTilde(v).replace(/'/g, "'\\''")}'`)
       .join(" ");
     cmd = `${envPrefix} ${cmd}`;
   }

--- a/test/command-simplified.test.ts
+++ b/test/command-simplified.test.ts
@@ -162,3 +162,57 @@ describe("buildCommand — post-#541 contract", () => {
     }
   });
 });
+
+describe("buildCommand — channelEnv tilde expansion (#1135)", () => {
+  test("leading tilde in env value expands to homedir before single-quoting", () => {
+    fakeConfig.commands = { default: "claude" };
+    const out = buildCommand("bot", {
+      channelEnv: { DISCORD_STATE_DIR: "~/.claude/channels/mybot" },
+      channels: ["plugin:discord@claude-plugins-official"],
+    });
+    const home = require("os").homedir();
+    expect(out).toContain(`DISCORD_STATE_DIR='${home}/.claude/channels/mybot'`);
+    // Critically: the literal tilde must NOT survive into the quoted value.
+    expect(out).not.toContain("'~/.claude/channels/mybot'");
+  });
+
+  test("tilde in middle of value is left alone (only leading ~ expands)", () => {
+    fakeConfig.commands = { default: "claude" };
+    const out = buildCommand("bot", {
+      channelEnv: { WEIRD: "/path/with/~/inside" },
+      channels: ["plugin:discord@claude-plugins-official"],
+    });
+    expect(out).toContain("WEIRD='/path/with/~/inside'");
+  });
+
+  test("absolute path env value is preserved verbatim (already-fixed configs)", () => {
+    fakeConfig.commands = { default: "claude" };
+    const home = require("os").homedir();
+    const out = buildCommand("bot", {
+      channelEnv: { DISCORD_STATE_DIR: `${home}/.claude/channels/mybot` },
+      channels: ["plugin:discord@claude-plugins-official"],
+    });
+    expect(out).toContain(`DISCORD_STATE_DIR='${home}/.claude/channels/mybot'`);
+  });
+
+  test("single quotes inside env value are still escaped after tilde expansion", () => {
+    fakeConfig.commands = { default: "claude" };
+    const out = buildCommand("bot", {
+      channelEnv: { TRICKY: "~/path with 'quotes'" },
+      channels: ["plugin:discord@claude-plugins-official"],
+    });
+    const home = require("os").homedir();
+    // Single quote inside the value gets the canonical "'\\''" escape sequence.
+    expect(out).toContain(`TRICKY='${home}/path with '\\''quotes'\\'''`);
+  });
+
+  test("bare tilde (~ alone, no slash) also expands", () => {
+    fakeConfig.commands = { default: "claude" };
+    const home = require("os").homedir();
+    const out = buildCommand("bot", {
+      channelEnv: { JUST_TILDE: "~" },
+      channels: ["plugin:discord@claude-plugins-official"],
+    });
+    expect(out).toContain(`JUST_TILDE='${home}'`);
+  });
+});


### PR DESCRIPTION
## Closes

#1135

## Problem

Bun/Node don't expand `~` in JSON env values. `~/.claude/channels/<oracle>/config.json` accepts paths like `"~/.claude/channels/foo"` as `DISCORD_STATE_DIR`. The auto-injected env-prefix in `buildCommand` single-quotes values verbatim, so the plugin sees a literal `~` — directory lookup fails, falls back to a default state dir, "Failed to reconnect" in `/mcp`.

## Fix

Two-layer:

1. **`src/config/command.ts`** — `expandTilde()` runs *before* single-quoting in the env-prepend block. Heals existing configs in the wild (mawjs-oracle, mother-oracle, anyone who hand-edited).
2. **`src/commands/plugins/channel/index.ts`** — `maw channel add` writes the absolute path via `os.homedir()`. Prevents new tilde paths from being written.

`expandTilde` only triggers when `~` is the first character followed by `/` or end-of-string — won't touch `~user` or tildes elsewhere in the path.

## Tests

5 new cases in `test/command-simplified.test.ts`:
- Leading tilde expands and gets correctly single-quoted
- Tilde in the middle of a value is preserved
- Already-absolute paths stay verbatim
- Quote-escape still works after tilde expansion
- Bare `~` (no slash) also expands

All pass. Existing 12 cases in the file still pass.

## Discovery

Cross-oracle debug session on 2026-05-05. mawjs-oracle's `/mcp` failed; I anchored on token collision. discord-oracle pinged back via `maw hey m5:discord-oracle` with the actual diagnosis: literal tilde + wrong target dir. Trace: `mawjs-oracle/ψ/memory/traces/2026-05-05/0647_bare-name-target-removed.md`.

## Sibling PR

#1136 (bare-name local fallback for `maw hey`) coming next — independent change, will be filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)