### PR TITLE
feat(hey): bare-name local fallback for unambiguous matches (#1136)

### DIFF
--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -94,20 +94,23 @@ export async function checkPaneIdle(target: string, host?: string): Promise<{ id
 }
 
 /**
- * Phase 2 of #759 — bare-name hard rejection. The bare-name path is removed
- * outright: cmdSend prints this error to stderr and exits non-zero before
- * any resolution attempt. Replaces the Phase 1 `formatBareNameDeprecation`
- * warning. Shape is fixed per the issue and exercised by
- * test/isolated/hey-bare-name-rejection.test.ts.
+ * Federation-friendly error for bare-name targets that don't resolve locally.
+ * Originally introduced in #759 Phase 2 (#785) as a hard error before any
+ * resolution work — every bare name was rejected.
+ *
+ * After #1136 the contract is softer: bare names get a local-resolver probe
+ * first, and this error only fires when the local lookup truly misses (or
+ * is ambiguous). The shape and substitution rules are unchanged so existing
+ * downstream tools that match on the message keep working.
  *
  * The triple `<node>:<session>:<agent>` form keeps `<node>` and `<session>`
  * as literal placeholders — the user is meant to run `maw locate <agent>`
  * to enumerate concrete candidates across the federation. Only `<agent>`
  * is substituted with the bare query the user actually typed.
  *
- * @internal — exported for tests only (test/comm-send-deprecation-759.test.ts).
- *   The production caller is `cmdSend` in this same file. No other module
- *   imports this symbol.
+ * @internal — exported for tests only (test/comm-send-deprecation-759.test.ts,
+ *   test/isolated/hey-bare-name-rejection.test.ts). The production caller is
+ *   `cmdSend` in this same file. No other module imports this symbol.
  */
 export function formatBareNameError(query: string): string {
   const RED = "\x1b[31m"; // error marker
@@ -152,16 +155,19 @@ export async function cmdSend(
 ) {
   const config = loadConfig();
 
-  // #759 Phase 2 — bare-name targets are now a hard error. Reject before any
-  // resolution work so users get a fast, deterministic failure pushing them
-  // onto the canonical `<node>:<agent>` form. `team:` and `plugin:` prefixes
-  // are special-cased downstream and have their own colon, so they pass.
-  // `/` is reserved for path-style targets. MAW_QUIET no longer suppresses —
-  // Phase 1's quiet-opt-out was a deprecation-window concession only.
-  if (!query.includes(":") && !query.includes("/")) {
-    console.error(formatBareNameError(query));
-    process.exit(1);
-  }
+  // #1136 — bare names get a local-resolver probe before the federation-
+  // friendly error fires. Capture the flag here; the error path at the end
+  // of this function uses it. The original #759 Phase 2 hard reject
+  // unconditionally exited here; that was the right call when federation
+  // ambiguity (#758) was unaddressed, but `resolveTarget` now returns
+  // `kind: "ambiguous"` for the dangerous case, so the safety net moved
+  // from the entry guard to the resolver itself. The 95% local-only case
+  // (single-host setups) gets the happy path; cross-host ambiguity still
+  // surfaces the canonical 3-part guidance.
+  //
+  // `team:` and `plugin:` prefixes have their own colon and skip this
+  // probe. `/` is reserved for path-style targets and also skips.
+  const isBareName = !query.includes(":") && !query.includes("/");
 
   // --- Team fan-out routing: maw hey team:<team-name> <msg> (#627) ---
   if (query.startsWith("team:")) {
@@ -517,6 +523,14 @@ export async function cmdSend(
   }
 
   // Local-only miss — no network was attempted (#411). Show resolver's own detail.
+  // #1136: for bare names, prefer the federation-friendly guidance (canonical
+  // 3-part form + `maw locate` hint) over the generic "window not found"
+  // message. Bare names already had a chance through `resolveTarget` and
+  // auto-wake above; if we got here it's a true miss.
+  if (isBareName) {
+    console.error(formatBareNameError(query));
+    process.exit(1);
+  }
   if (result?.type === "error") {
     console.error(`\x1b[31merror\x1b[0m: ${result.detail}`);
     if (result.hint) console.error(`\x1b[33mhint\x1b[0m:  ${result.hint}`);

--- a/test/comm-send-deprecation-759.test.ts
+++ b/test/comm-send-deprecation-759.test.ts
@@ -1,19 +1,21 @@
 /**
- * #759 Phase 2 — bare-name hard rejection error formatter.
+ * Bare-name federation-friendly error formatter (#759 Phase 2 + #1136).
  *
- * The Phase 1 deprecation warning has been converted into a hard error. The
- * formatter is tested directly (pure function). The cmdSend wiring (early
- * exit, gating on `!query.includes(":")`) is covered by the isolated test
+ * The formatter is tested directly (pure function). The cmdSend wiring —
+ * how/when this error fires — is covered by the isolated test
  * `test/isolated/hey-bare-name-rejection.test.ts`.
  *
- * History: this file used to assert `formatBareNameDeprecation` — Phase 2
- * renamed the export to `formatBareNameError` and changed the shape from
- * yellow `⚠ deprecation` to red `error:`. See issue #759.
+ * History:
+ *   - Phase 1 (#759 / #761) — deprecation warning, fall-through to send
+ *   - Phase 2 (#785) — hard error, no resolution attempted
+ *   - #1136 — relaxation: bare names get a local-resolver probe; this error
+ *     fires only when the local lookup truly misses or is ambiguous. The
+ *     formatter shape and substitution rules are unchanged.
  */
 import { describe, test, expect } from "bun:test";
 import { formatBareNameError } from "../src/commands/shared/comm-send";
 
-describe("#759 Phase 2 — bare-name hard rejection", () => {
+describe("#759 Phase 2 + #1136 — bare-name federation-friendly error", () => {
   test("error marker, removal phrase, and node-prefix demand are all present", () => {
     const out = formatBareNameError("mawjs-oracle");
     expect(out).toContain("error");

--- a/test/isolated/hey-bare-name-rejection.test.ts
+++ b/test/isolated/hey-bare-name-rejection.test.ts
@@ -1,14 +1,25 @@
 /**
- * hey-bare-name-rejection.test.ts — #759 Phase 2.
+ * hey-bare-name-rejection.test.ts — #759 Phase 2 + #1136.
  *
- * Verifies that `maw hey <bare-name> "..."` is now a hard error: cmdSend
- * MUST print the Phase 2 error shape on stderr and exit non-zero BEFORE
- * any tmux / sdk / network resolution work happens. No fallthrough, no
- * MAW_QUIET escape hatch.
+ * Verifies the bare-name contract:
+ *
+ *   #759 Phase 2 (#785) — bare-name targets cannot fall through to the
+ *   generic "window not found" path. The Phase 2 error shape (with this-node
+ *   suggestion + cross-node placeholders + `maw locate` hint) is what the
+ *   user sees instead.
+ *
+ *   #1136 (relaxation) — when the local resolver finds an unambiguous local
+ *   match, the bare name resolves and delivery proceeds. Federation safety
+ *   is preserved: the bare-name error still fires when local resolution
+ *   misses (or is ambiguous).
  *
  * Mocked seams: src/sdk, src/config, src/core/routing,
  *   src/core/runtime/hooks, src/commands/shared/comm-log-feed,
  *   src/commands/shared/wake-resolve, src/commands/shared/wake-cmd.
+ *
+ * `resolveTargetMock` is per-test mutable: tests that exercise the local
+ * happy path swap it to a "local" result; the rest leave it at the default
+ * "error" shape so the bare-name error fires at the end of cmdSend.
  *
  * process.exit is stubbed to throw "__exit__:<code>" so the harness survives
  * branches that would otherwise terminate the runner.
@@ -30,6 +41,10 @@ let sendKeysCalls: Array<{ target: string; text: string }> = [];
 let resolveTargetCalls = 0;
 let listSessionsCalls = 0;
 let cmdWakeCalls = 0;
+// Per-test mutable: bare-name tests need this to default to a miss so the
+// federation-friendly error fires at the end of cmdSend. Local-fallback tests
+// (#1136) flip it to a "local" result before invoking cmdSend.
+let resolveTargetMock: any = { type: "error", detail: "no local session found", hint: undefined };
 
 // ─── Mocks ───────────────────────────────────────────────────────────────────
 
@@ -60,7 +75,7 @@ mock.module(join(import.meta.dir, "../../src/config"), () => {
 mock.module(join(import.meta.dir, "../../src/core/routing"), () => ({
   resolveTarget: () => {
     resolveTargetCalls++;
-    return { type: "local", target: "x:y.0" };
+    return resolveTargetMock;
   },
 }));
 
@@ -125,6 +140,7 @@ beforeEach(() => {
   resolveTargetCalls = 0;
   listSessionsCalls = 0;
   cmdWakeCalls = 0;
+  resolveTargetMock = { type: "error", detail: "no local session found", hint: undefined };
   delete process.env.MAW_QUIET;
 });
 
@@ -136,8 +152,9 @@ afterAll(() => {
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
-describe("cmdSend — bare-name hard rejection (#759 Phase 2)", () => {
-  test("bare name 'mawjs-oracle' → exits 1, prints Phase 2 error, no resolution work", async () => {
+describe("cmdSend — bare-name contract (#759 Phase 2 + #1136)", () => {
+  test("bare name with no local match → exits 1, prints federation-friendly error", async () => {
+    // resolveTargetMock defaults to error (no local match)
     await run(() => cmdSend("mawjs-oracle", "test"));
 
     expect(exitCode).toBe(1);
@@ -154,14 +171,26 @@ describe("cmdSend — bare-name hard rejection (#759 Phase 2)", () => {
     expect(allErr).toContain("maw hey <node>:<session>:mawjs-oracle");
     // locate hint
     expect(allErr).toContain("maw locate mawjs-oracle");
-    // No downstream work happened
-    expect(resolveTargetCalls).toBe(0);
-    expect(listSessionsCalls).toBe(0);
-    expect(cmdWakeCalls).toBe(0);
+    // Delivery did NOT happen
     expect(sendKeysCalls.length).toBe(0);
   });
 
-  test("MAW_QUIET=1 does NOT bypass the rejection — Phase 1 escape hatch is gone", async () => {
+  test("bare name with local match → resolves and delivers, no federation error (#1136)", async () => {
+    resolveTargetMock = { type: "local", target: "x:y.0" };
+    await run(() => cmdSend("discord-oracle", "hello"));
+
+    const allErr = errs.join("\n");
+    // No federation error — local match resolved
+    expect(allErr).not.toContain("bare-name target removed");
+    expect(allErr).not.toContain("node prefix required");
+    // Delivery happened — sendKeys was called once
+    expect(sendKeysCalls.length).toBe(1);
+    expect(sendKeysCalls[0]?.text).toBe("hello");
+    // Resolution was attempted
+    expect(resolveTargetCalls).toBeGreaterThanOrEqual(1);
+  });
+
+  test("MAW_QUIET=1 does NOT bypass federation error when local match misses", async () => {
     process.env.MAW_QUIET = "1";
     await run(() => cmdSend("mawjs-oracle", "test"));
     expect(exitCode).toBe(1);
@@ -169,31 +198,30 @@ describe("cmdSend — bare-name hard rejection (#759 Phase 2)", () => {
     expect(sendKeysCalls.length).toBe(0);
   });
 
-  test("node-prefixed target 'test-node:foo' passes — no rejection", async () => {
+  test("node-prefixed target 'test-node:foo' bypasses bare-name probe", async () => {
+    resolveTargetMock = { type: "local", target: "test-node:foo.0" };
     await run(() => cmdSend("test-node:foo", "hi"));
-    // Either resolved as local/self-node and sent, or hit a downstream branch —
-    // the key invariant is we did NOT exit on the bare-name guard.
     const allErr = errs.join("\n");
     expect(allErr).not.toContain("bare-name target removed");
-    // Resolution was attempted
     expect(resolveTargetCalls).toBeGreaterThanOrEqual(1);
   });
 
-  test("team:<name> prefix passes the bare-name guard", async () => {
+  test("team:<name> prefix bypasses bare-name probe", async () => {
     // team: routing has its own validation downstream; we only assert the
-    // bare-name guard didn't fire.
+    // bare-name path didn't fire.
     await run(() => cmdSend("team:nonexistent-team", "hi"));
     const allErr = errs.join("\n");
     expect(allErr).not.toContain("bare-name target removed");
   });
 
-  test("plugin:<name> prefix passes the bare-name guard", async () => {
+  test("plugin:<name> prefix bypasses bare-name probe", async () => {
     await run(() => cmdSend("plugin:nonexistent-plugin", "hi"));
     const allErr = errs.join("\n");
     expect(allErr).not.toContain("bare-name target removed");
   });
 
-  test("path-style target with '/' passes the bare-name guard", async () => {
+  test("path-style target with '/' bypasses bare-name probe", async () => {
+    resolveTargetMock = { type: "local", target: "some/path.0" };
     await run(() => cmdSend("some/path", "hi"));
     const allErr = errs.join("\n");
     expect(allErr).not.toContain("bare-name target removed");


### PR DESCRIPTION
## Closes

#1136

## Problem

#785 (Phase 2 of #759) made bare-name targets a hard error before any resolution work. Today:

```bash
$ maw hey discord-oracle "ping"
error: bare-name target removed — node prefix required
```

In single-host setups (the 95% case), every `maw hey` requires `<node>:` even when there's exactly one matching local oracle. The original federation safety justification (#758 — `peer:agent` ambiguity with `-view` mirrors or federated copies) is real — but `resolveTarget` now returns `kind: "ambiguous"` for the dangerous case (the `.filter()` fix shipped in the recent loop). **The safety net moved from the entry guard to the resolver itself.**

## Fix

Relax the contract: bare names get a local-resolver probe before the federation error fires.

In `src/commands/shared/comm-send.ts`:
1. Capture `isBareName` at entry (no early exit)
2. Let auto-wake + `resolveTarget` run as normal
3. If resolution succeeds (`local` / `self-node`) → proceed with delivery
4. If resolution genuinely misses → surface `formatBareNameError` at the end (replacing the generic "window not found" message)

## What this preserves

- Federation safety: cross-host targets still need explicit `<peer>:<agent>` or `<peer>:<session>:<agent>`
- Ambiguous local matches: `resolveTarget` returns `kind: "ambiguous"` and the existing error path fires
- All non-bare prefixes (`team:`, `plugin:`, paths with `/`) — unchanged

## Tests

`test/isolated/hey-bare-name-rejection.test.ts` rewired:
- `resolveTargetMock` is now per-test mutable. Default = `error` (no local match) — every existing test still asserts the federation error fires when local truly misses.
- **New test**: *bare name with local match → resolves and delivers, no federation error*. Asserts `sendKeysCalls.length === 1` and the federation error string is absent.
- 7/7 pass.

`test/comm-send-deprecation-759.test.ts` — formatter unchanged; header + describe block updated to reflect the new contract. 6/6 pass.

`test/command-simplified.test.ts` — unrelated, still passes.

## Discovery

Cross-oracle debug session 2026-05-05. While preparing #1135 (sibling PR for the tilde-not-expanded bug), `maw hey discord-oracle "..."` failed with the bare-name error. Trace: `mawjs-oracle/ψ/memory/traces/2026-05-05/0647_bare-name-target-removed.md`.

## Trail

- #758 — original federation `AmbiguousMatchError` (root cause)
- #759 — parent tracking issue
- #761 — Phase 1 (deprecation warning)
- #785 — Phase 2 (hard error) ← this PR partially walks back

## Sibling PR

#1137 (`fix(channel): expand tilde in DISCORD_STATE_DIR — #1135`) — independent, file-disjoint, lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)