### PR TITLE
release: v26.5.5-alpha.708

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.5-alpha.444",
+  "version": "26.5.5-alpha.708",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts `v26.5.5-alpha.708` on merge via `calver-release.yml`.

## What's in this release

Two channel/hey fixes from the 2026-05-05 cross-oracle debug session:

- **#1135 / #1137** — fix(channel): expand tilde in DISCORD_STATE_DIR. Bun/Node don't expand `~` in JSON env values, so the auto-injected env-prefix sent the plugin a literal tilde — it silently fell back to a default state dir.
- **#1136 / #1138** — feat(hey): bare-name local fallback for unambiguous matches. Restores `maw hey discord-oracle "msg"` (no node prefix) when local resolution finds an exact match. Federation safety preserved via the existing `kind: "ambiguous"` resolver path.

Both discovered during a federated debug round-trip with discord-oracle (`maw hey m5:discord-oracle`). Trace: `mawjs-oracle/ψ/memory/traces/2026-05-05/0647_bare-name-target-removed.md`.

## Notes

- `test-isolated` is currently red on alpha (pre-existing — unrelated `loadConfig` / `isAgentCommand` mock pollution). Tracked separately; this release inherits the state and does not regress it.
- Auto-generated by `/release-alpha`.