### PR TITLE
refactor(lib): extract fetchAllowedOrgs to src/lib/gh-user-orgs.ts

### DIFF
--- a/src/commands/shared/wake-resolve-scan-suggest.ts
+++ b/src/commands/shared/wake-resolve-scan-suggest.ts
@@ -3,6 +3,16 @@ import { openSync, readSync, closeSync } from "fs";
 import { hostExec } from "../../sdk";
 import { loadConfig } from "../../config";
 import { tlink } from "../../core/util/terminal";
+import {
+  type AllowedOrgs,
+  fetchAllowedOrgs,
+  _resetAllowedOrgsCache,
+} from "../../lib/gh-user-orgs";
+
+// Re-export to preserve existing import paths (wake-resolve-impl + tests
+// import these from this file). The implementation moved to src/lib/gh-user-orgs.ts
+// so the bud plugin (Phase 2 of the smart-default-org work) can share it.
+export { type AllowedOrgs, fetchAllowedOrgs, _resetAllowedOrgsCache };
 
 export interface OrgEntry {
   name: string;
@@ -29,15 +39,6 @@ interface ScanSuggestDeps {
 }
 
 /**
- * #770 — Result of probing GitHub for the orgs the authenticated user can
- * actually own a repo in. `ok: false` triggers a graceful fallback to the
- * unfiltered (all-local) scan with a warning.
- */
-type AllowedOrgs =
-  | { ok: true; user: string; orgs: Set<string> }
-  | { ok: false; reason: string };
-
-/**
  * Extract unique org names from `ghq list` output (github.com/<org>/<repo> format).
  * @internal — exported for tests only.
  */
@@ -49,50 +50,6 @@ export function extractGhqOrgs(ghqOutput: string): string[] {
     if (parts.length >= 3 && parts[1]) orgs.add(parts[1]);
   }
   return [...orgs].sort();
-}
-
-/**
- * Process-lifetime cache for the user's owned + member orgs. Single `gh api
- * user/orgs` per maw invocation; reset between tests via `_resetAllowedOrgsCache`.
- */
-let _allowedOrgsCache: AllowedOrgs | null = null;
-
-/** @internal — exported only so tests can isolate cases. */
-export function _resetAllowedOrgsCache(): void { _allowedOrgsCache = null; }
-
-/**
- * Probe `gh api user` and `gh api user/orgs` to derive the orgs the user can
- * actually host a repo in. Cached on first call. On any failure (no auth,
- * offline, gh missing) returns `ok: false` so the caller can fall back to the
- * legacy all-local scan with a warning rather than silently empty out.
- *
- * @internal — exported for tests only.
- */
-export function fetchAllowedOrgs(execFn: (cmd: string) => string): AllowedOrgs {
-  if (_allowedOrgsCache) return _allowedOrgsCache;
-
-  let user: string;
-  try {
-    user = execFn("gh api user --jq .login 2>/dev/null").trim();
-    if (!user) throw new Error("empty login");
-  } catch (e: any) {
-    const reason = `gh api user failed: ${String(e?.message || e).split("\n")[0]}`;
-    return (_allowedOrgsCache = { ok: false, reason });
-  }
-
-  const orgs = new Set<string>([user]);
-  try {
-    const raw = execFn("gh api user/orgs --jq '.[].login' 2>/dev/null");
-    for (const line of raw.split("\n")) {
-      const t = line.trim();
-      if (t) orgs.add(t);
-    }
-  } catch {
-    // user lookup worked but org listing failed (e.g. token without `read:org`).
-    // Falling through with just the user is still better than scanning all-local.
-  }
-
-  return (_allowedOrgsCache = { ok: true, user, orgs });
 }
 
 /**

--- a/src/lib/gh-user-orgs.ts
+++ b/src/lib/gh-user-orgs.ts
@@ -1,0 +1,73 @@
+/**
+ * gh-user-orgs.ts — shared helper for resolving the orgs the current `gh`
+ * authenticated user can host repos in.
+ *
+ * Two callers today:
+ *   - `wake-resolve-scan-suggest.ts` (#770) — filter the ghq org list to
+ *     orgs the user actually owns/is a member of, before suggesting which
+ *     repo to clone for an unknown oracle.
+ *   - bud plugin (Phase 2) — cold-start fallback for `smartDefaultOrg`
+ *     when the local fleet is empty (first oracle on a fresh machine).
+ *
+ * Process-lifetime cache: a single `gh api user/orgs` per maw invocation.
+ * Test isolation via `_resetAllowedOrgsCache`.
+ *
+ * Failure mode: any `gh` failure (no auth, offline, gh missing, scope
+ * mismatch) returns `ok: false` so callers can fall back gracefully —
+ * never silently empty out.
+ *
+ * Multi-host (`github.com` + GHE) is a known unsolved limitation; the
+ * function defaults to whichever `gh` host is active. Tracked as a
+ * pre-existing maw-js issue, not introduced by this extraction.
+ */
+
+/**
+ * Result of probing GitHub for the orgs the authenticated user can
+ * actually own a repo in. `ok: false` triggers a graceful fallback to
+ * the unfiltered scan with a warning.
+ */
+export type AllowedOrgs =
+  | { ok: true; user: string; orgs: Set<string> }
+  | { ok: false; reason: string };
+
+let _allowedOrgsCache: AllowedOrgs | null = null;
+
+/** @internal — exported only so tests can isolate cases. */
+export function _resetAllowedOrgsCache(): void {
+  _allowedOrgsCache = null;
+}
+
+/**
+ * Probe `gh api user` and `gh api user/orgs` to derive the orgs the user
+ * can actually host a repo in. Cached on first call. On any failure
+ * returns `ok: false` so the caller can fall back.
+ *
+ * Caller injects `execFn` (synchronous shell exec) so tests can mock
+ * the gh boundary without touching the real network.
+ */
+export function fetchAllowedOrgs(execFn: (cmd: string) => string): AllowedOrgs {
+  if (_allowedOrgsCache) return _allowedOrgsCache;
+
+  let user: string;
+  try {
+    user = execFn("gh api user --jq .login 2>/dev/null").trim();
+    if (!user) throw new Error("empty login");
+  } catch (e: any) {
+    const reason = `gh api user failed: ${String(e?.message || e).split("\n")[0]}`;
+    return (_allowedOrgsCache = { ok: false, reason });
+  }
+
+  const orgs = new Set<string>([user]);
+  try {
+    const raw = execFn("gh api user/orgs --jq '.[].login' 2>/dev/null");
+    for (const line of raw.split("\n")) {
+      const t = line.trim();
+      if (t) orgs.add(t);
+    }
+  } catch {
+    // user lookup worked but org listing failed (e.g. token without `read:org`).
+    // Falling through with just the user is still better than scanning all-local.
+  }
+
+  return (_allowedOrgsCache = { ok: true, user, orgs });
+}

--- a/test/lib-gh-user-orgs.test.ts
+++ b/test/lib-gh-user-orgs.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Direct import path test for src/lib/gh-user-orgs.ts.
+ *
+ * The behavioral coverage lives in test/wake-resolve-scan-suggest.test.ts,
+ * which exercises fetchAllowedOrgs through the wake-suggest call path. This
+ * file verifies the new shared module location can be consumed directly
+ * (the bud plugin will import from here in Phase 2).
+ */
+import { describe, test, expect, beforeEach } from "bun:test";
+import {
+  type AllowedOrgs,
+  fetchAllowedOrgs,
+  _resetAllowedOrgsCache,
+} from "../src/lib/gh-user-orgs";
+
+beforeEach(() => { _resetAllowedOrgsCache(); });
+
+describe("src/lib/gh-user-orgs — direct import path", () => {
+  test("fetchAllowedOrgs is callable via the new shared module", () => {
+    const exec = (cmd: string) => {
+      if (cmd.startsWith("gh api user --jq .login")) return "shared-user\n";
+      if (cmd.startsWith("gh api user/orgs")) return "org-a\norg-b\n";
+      throw new Error("unexpected cmd: " + cmd);
+    };
+    const result = fetchAllowedOrgs(exec);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.user).toBe("shared-user");
+      expect(result.orgs.has("shared-user")).toBe(true);
+      expect(result.orgs.has("org-a")).toBe(true);
+      expect(result.orgs.has("org-b")).toBe(true);
+    }
+  });
+
+  test("AllowedOrgs failure shape is preserved through the new module", () => {
+    const exec = (_cmd: string) => { throw new Error("not authed"); };
+    const result: AllowedOrgs = fetchAllowedOrgs(exec);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("gh api user failed");
+    }
+  });
+
+  test("re-export path through wake-resolve-scan-suggest still works", async () => {
+    // Existing consumers (wake-resolve-impl, the wake-suggest test file)
+    // import from wake-resolve-scan-suggest. Verify the re-export bridge.
+    const reexported = await import("../src/commands/shared/wake-resolve-scan-suggest");
+    expect(typeof reexported.fetchAllowedOrgs).toBe("function");
+    expect(typeof reexported._resetAllowedOrgsCache).toBe("function");
+  });
+});


### PR DESCRIPTION
## What

Pure refactor — extract `fetchAllowedOrgs` + `AllowedOrgs` + `_resetAllowedOrgsCache` from `src/commands/shared/wake-resolve-scan-suggest.ts` into a new shared module `src/lib/gh-user-orgs.ts`.

## Why

Phase 1 of a 2-phase ship for **bud smart-default org resolve** (v2 plan: `mawjs-oracle/ψ/plans/2026-05-05_0735_bud-smart-default-v2-fleet-as-truth.md`). Phase 2 lives in maw-plugin-registry and needs to consume this helper for the cold-start fallback when local fleet is empty.

Today the helper is consumed only by `wake-resolve-scan-suggest`. The Phase 2 PR will add the bud plugin as a second consumer.

## Architectural framing

This refactor sets up the FTS+vector retrieval pattern (grounded in arra-oracle-v3 via `/dig --deep`):

| Tier | Bud's smart-default | arra-oracle-v3 analog |
|---|---|---|
| **FTS** (fast, structural) | Local fleet (`~/.config/maw/fleet/*.json`) | SQLite FTS5 |
| **Vector** (slow, authoritative) | `gh api user/orgs` (this helper) | ChromaDB / vector proxy |

Phase 2 ships the FTS tier in bud. This PR makes the vector tier consumable from outside maw-js core.

## Behavior change

None. Same exec injection contract, same process-lifetime cache, same `AllowedOrgs` failure shape. `wake-resolve-scan-suggest.ts` re-exports the symbols so existing imports (`wake-resolve-impl.ts` + test file) keep working unchanged.

## Tests

- **New**: `test/lib-gh-user-orgs.test.ts` (3 cases) — direct-import happy path, failure shape, re-export bridge
- **Existing**: `test/wake-resolve-scan-suggest.test.ts` (30 cases) — all green

## Diff stat

```
src/commands/shared/wake-resolve-scan-suggest.ts | 63 +++-----------
src/lib/gh-user-orgs.ts                          | 73 +++++++++++++++++++ (new)
test/lib-gh-user-orgs.test.ts                    | 51 ++++++++++++ (new)
3 files changed, 134 insertions(+), 53 deletions(-)
```

## Sequence

1. **This PR** — extract helper (refactor only) ← we are here
2. Next PR (in maw-plugin-registry) — add `smartDefaultOrg()` reading fleet, update bud `impl.ts:90` precedence, add echo line
3. Future (deferred): full arra-pattern hybrid with parallel + confidence bonus + freshness-aware cache. Filed as separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)