### PR TITLE
release: v26.5.5-alpha.758

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.5-alpha.708",
+  "version": "26.5.5-alpha.758",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts \`v26.5.5-alpha.758\` on merge via \`calver-release.yml\`.

## What's in this release

- **#1143** — refactor(lib): extract \`fetchAllowedOrgs\` to \`src/lib/gh-user-orgs.ts\`. Sets up the FTS+vector retrieval pattern for bud's smart-default org work. Used by wake-suggest today; consumed by future Phase 3 of bud (issue #1144).

The companion change in maw-plugin-registry (Soul-Brews-Studio/maw-plugin-registry#11 — fleet-as-truth smart-default for \`maw bud\`) lands separately on plugin-registry main.

## Notes

- Branch named \`release/v26.5.5-alpha-757\` because calver --check ticked one minute before \`apply\` — the actual version in package.json is \`alpha.758\`. \`calver-release.yml\` reads package.json so the tag will be 758.
- \`test-isolated\` is currently red on alpha (pre-existing — unrelated \`loadConfig\` / \`isAgentCommand\` mock pollution from a different surface). This release inherits the state and does not regress it.
- Auto-generated by \`/release-alpha\`.