### PR TITLE
fix(wake): reject flag-shaped names like --help (#1151)

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -4,12 +4,20 @@ import { buildCommandInDir, cfgTimeout, loadConfig, saveConfig } from "../../con
 import { resolveWorktreeTarget } from "../../core/matcher/resolve-target";
 import { normalizeTarget } from "../../core/matcher/normalize-target";
 import { assertValidOracleName } from "../../core/fleet/validate";
+import { UserError } from "../../core/util/user-error";
 import { resolveOracle, findWorktrees, getSessionMap, resolveFleetSession, detectSession, setSessionEnv, sanitizeBranchName } from "./wake-resolve";
 import { attachToSession, ensureSessionRunning, createWorktree } from "./wake-session";
 import { maybeSplit } from "./wake-maybe-split";
 import { parseWakeTarget, ensureCloned } from "./wake-target";
 
 export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; split?: boolean; repoPath?: string; urlRepoName?: string; allLocal?: boolean; engine?: string }): Promise<string> {
+  // #1151 — reject flag-shaped names. parseFlags lands unrecognized flags
+  // (e.g. --help) in positional `_`, so they reach here as oracle="--help"
+  // and (without this guard) get sanitized into session names like `26---help`.
+  if (oracle.startsWith("-")) {
+    throw new UserError(`invalid oracle name: "${oracle}" — did you mean 'maw --help'?`);
+  }
+
   // Canonicalize the bare name before any lookup — strips trailing `/`, `/.git`, `/.git/`
   // so `maw wake token-oracle/` (tab-completion artifact) resolves the same as `token-oracle`.
   oracle = normalizeTarget(oracle);

--- a/test/wake-flag-name-guard.test.ts
+++ b/test/wake-flag-name-guard.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Regression test for #1151 — `maw wake --help` should NOT create a session.
+ *
+ * Background: parseFlags drops unrecognized flags (like --help) into the
+ * positional `_` array. Without a guard, `--help` reaches cmdWake as the
+ * oracle name and gets sanitized into a session named `26---help`.
+ */
+import { describe, test, expect } from "bun:test";
+import { cmdWake } from "../src/commands/shared/wake-cmd";
+import { UserError } from "../src/core/util/user-error";
+
+describe("cmdWake — flag-shaped name guard (#1151)", () => {
+  test("rejects --help", async () => {
+    await expect(cmdWake("--help", {})).rejects.toThrow(UserError);
+  });
+
+  test("rejects --dry-run", async () => {
+    await expect(cmdWake("--dry-run", {})).rejects.toThrow(UserError);
+  });
+
+  test("rejects short flag -e", async () => {
+    await expect(cmdWake("-e", {})).rejects.toThrow(UserError);
+  });
+
+  test("error message suggests 'maw --help'", async () => {
+    await expect(cmdWake("--help", {})).rejects.toThrow(/maw --help/);
+  });
+});


### PR DESCRIPTION
## Summary

- Guard at start of `cmdWake` rejects oracle names beginning with `-` (catches `--help`, `--dry-run`, `-e`, etc.)
- Throws `UserError` with hint pointing to `maw --help`
- Adds `test/wake-flag-name-guard.test.ts` (4 cases) as regression coverage

## Why

`parseFlags` drops unrecognized flags into the positional `_` array. Without this guard, `maw wake --help` reaches `cmdWake` as `oracle="--help"` and gets sanitized into a tmux session named `26---help` (with an actual `claude.exe` running inside). Per #1151's audit, this happened 3 times in one day before being spotted.

## Behavior

```
$ maw wake --help
✗ invalid oracle name: "--help" — did you mean 'maw --help'?
```

## Test plan

- [x] `bun test test/wake-flag-name-guard.test.ts` (4 new cases pass)
- [x] `bun test test/wake` (114 pre-existing wake tests still pass)
- [x] `bun build src/cli.ts` clean (647 modules, 29ms)
- [ ] Manual: `maw wake --help` errors instead of creating session

Fixes #1151

🤖 Generated with [Claude Code](https://claude.com/claude-code)