### PR TITLE
fix(channel): defer to shell env over channel config.json (#1148)

### DIFF
--- a/src/config/command.ts
+++ b/src/config/command.ts
@@ -51,12 +51,18 @@ export function buildCommand(agentName: string, optsOrEngine?: string | BuildCom
   }
 
   // Prepend channel env vars directly to command (not tmux set-environment)
-  // because tmux set-environment only affects NEW shells, not the existing one
+  // because tmux set-environment only affects NEW shells, not the existing one.
+  //
+  // #1148 — defer to shell env when set. Precedence: shell env (non-empty)
+  // wins over channel config.json. Empty-string env is treated as unset
+  // (otherwise stale `export DISCORD_STATE_DIR=` would silently disable
+  // the config value — same #1135 trap shape through a different door).
   if (opts.channelEnv && Object.keys(opts.channelEnv).length > 0) {
     const envPrefix = Object.entries(opts.channelEnv)
+      .filter(([k]) => process.env[k] === undefined || process.env[k] === "")
       .map(([k, v]) => `${k}='${expandTilde(v).replace(/'/g, "'\\''")}'`)
       .join(" ");
-    cmd = `${envPrefix} ${cmd}`;
+    if (envPrefix) cmd = `${envPrefix} ${cmd}`;
   }
 
   if (opts.channels?.length) {

--- a/test/command-simplified.test.ts
+++ b/test/command-simplified.test.ts
@@ -216,3 +216,56 @@ describe("buildCommand — channelEnv tilde expansion (#1135)", () => {
     expect(out).toContain(`JUST_TILDE='${home}'`);
   });
 });
+
+describe("buildCommand — channelEnv shell-vs-config precedence (#1148)", () => {
+  const KEY = "MAWJS_TEST_PRECEDENCE_KEY";
+  const KEY1 = "MAWJS_TEST_K1";
+  const KEY2 = "MAWJS_TEST_K2";
+
+  afterEach(() => {
+    delete process.env[KEY];
+    delete process.env[KEY1];
+    delete process.env[KEY2];
+  });
+
+  test("shell env unset → config value prepended", () => {
+    fakeConfig.commands = { default: "claude" };
+    delete process.env[KEY];
+    const out = buildCommand("bot", { channelEnv: { [KEY]: "from-config" } });
+    expect(out).toContain(`${KEY}='from-config'`);
+  });
+
+  test("shell env set non-empty → config value NOT prepended (defer to shell)", () => {
+    fakeConfig.commands = { default: "claude" };
+    process.env[KEY] = "from-shell";
+    const out = buildCommand("bot", { channelEnv: { [KEY]: "from-config" } });
+    // Config value must NOT win over the operator's shell-set value.
+    expect(out).not.toContain(`${KEY}='from-config'`);
+  });
+
+  test("shell env empty string → config value still prepended (treats empty as unset)", () => {
+    fakeConfig.commands = { default: "claude" };
+    process.env[KEY] = "";
+    const out = buildCommand("bot", { channelEnv: { [KEY]: "from-config" } });
+    // Empty-string env was the #1135 trap reborn — must NOT silently disable config.
+    expect(out).toContain(`${KEY}='from-config'`);
+  });
+
+  test("multi-key: shell wins for one, config wins for the other", () => {
+    fakeConfig.commands = { default: "claude" };
+    process.env[KEY1] = "shell-1";
+    delete process.env[KEY2];
+    const out = buildCommand("bot", {
+      channelEnv: { [KEY1]: "config-1", [KEY2]: "config-2" },
+    });
+    expect(out).not.toContain(`${KEY1}='config-1'`); // shell wins for KEY1
+    expect(out).toContain(`${KEY2}='config-2'`);     // config used for KEY2
+  });
+
+  test("all keys covered by shell → no envPrefix added at all", () => {
+    fakeConfig.commands = { default: "claude" };
+    process.env[KEY] = "from-shell";
+    const out = buildCommand("bot", { channelEnv: { [KEY]: "from-config" } });
+    expect(out).not.toMatch(new RegExp(`\\b${KEY}=`));
+  });
+});


### PR DESCRIPTION
## Summary

- `buildCommand` now filters `opts.channelEnv` keys where `process.env[k]` is set non-empty
- Empty-string shell env treated as unset (avoids the #1135 trap reborn)
- 5 new precedence tests in `test/command-simplified.test.ts`

## Why

`maw wake <bot>` auto-prepends env vars from `~/.claude/channels/<bot>/config.json`. Without precedence rules, when the operator has e.g. `DISCORD_STATE_DIR=/tmp/test` exported from a debug session, it's undefined which value reaches the spawned claude. Today the config-prepend wins silently — operator's intent ignored, debug state masked.

Worse, an empty `export DISCORD_STATE_DIR=` would (without the empty-check) skip prepending and let the plugin fall back to its default state dir → wrong bot token loaded → identical failure mode to #1135.

## Precedence rule (new)

| Shell env | Behavior |
|---|---|
| Unset | Config value prepended |
| Empty string | Config value prepended (treated as unset) |
| Non-empty | Config value NOT prepended (defer to shell) |

Sets up the precedence chain that #1146 (permissionMode work) will inherit.

## Test plan

- [x] `bun test test/command-simplified.test.ts` (22 pass — 17 pre-existing + 5 new)
- [x] `bun build src/cli.ts` clean
- [ ] Manual: `export DISCORD_STATE_DIR=/tmp/x; maw wake mybot` — verify config value not in spawned cmd

Fixes #1148

🤖 Generated with [Claude Code](https://claude.com/claude-code)