### PR TITLE
fix(fleet): allowlist intentional non-fleet sessions in validate (#1134)

### DIFF
--- a/src/commands/shared/fleet-validate.ts
+++ b/src/commands/shared/fleet-validate.ts
@@ -2,6 +2,7 @@ import { join } from "path";
 import { existsSync } from "fs";
 import { tmux } from "../../sdk";
 import { getGhqRoot } from "../../config/ghq-root";
+import { loadConfig } from "../../config/load";
 import { loadFleetEntries, getSessionNames } from "./fleet-load";
 
 export async function cmdFleetValidate() {
@@ -48,12 +49,17 @@ export async function cmdFleetValidate() {
   }
 
   // 4. Running sessions without config
+  // #1134 — allowlist skips intentional non-fleet sessions (dev oracles like
+  // mawjs/mawui that run from source repos). Match exact name OR stem after
+  // stripping NN- slot prefix, so `"mawjs"` covers `08-mawjs` and `25-mawjs`.
   const runningSessions = await getSessionNames();
   const configNames = new Set(entries.map(e => e.session.name));
+  const allowlist = new Set(loadConfig().fleetValidateAllowlist || []);
   for (const s of runningSessions) {
-    if (!configNames.has(s)) {
-      issues.push(`\x1b[90mOrphan session\x1b[0m: tmux '${s}' has no fleet config`);
-    }
+    if (configNames.has(s)) continue;
+    const stem = s.replace(/^\d+-/, "");
+    if (allowlist.has(s) || allowlist.has(stem)) continue;
+    issues.push(`\x1b[90mOrphan session\x1b[0m: tmux '${s}' has no fleet config`);
   }
 
   // 5. Running windows not in fleet config (won't survive reboot)

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -153,6 +153,15 @@ export interface MawConfig {
   pluginSources?: string[];
   /** Plugin names to disable (skip during scanning and execution) */
   disabledPlugins?: string[];
+  /**
+   * Tmux session names treated as intentional non-fleet — `maw fleet validate`
+   * skips its "Orphan session" warning for these. Useful for dev oracles that
+   * run from source repos directly (incubator pattern) without fleet configs.
+   * Match is exact OR after stripping the `NN-` slot prefix, so listing
+   * `"mawjs"` allowlists both `08-mawjs` and `25-mawjs` even as slots shift.
+   * (#1134)
+   */
+  fleetValidateAllowlist?: string[];
 }
 
 /** Typed defaults for intervals, timeouts, limits (#172) */

--- a/test/fleet-validate-allowlist.test.ts
+++ b/test/fleet-validate-allowlist.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Tests for #1134 — `maw fleet validate` orphan-allowlist match logic.
+ *
+ * Replicates the matching rule from src/commands/shared/fleet-validate.ts
+ * inline (same pattern as wake.test.ts) so we don't pull in tmux/fs/config
+ * module chains. The rule is small enough to keep in sync.
+ */
+import { describe, test, expect } from "bun:test";
+
+// Replicates the match logic from fleet-validate.ts:
+//   const stem = s.replace(/^\d+-/, "");
+//   if (allowlist.has(s) || allowlist.has(stem)) continue;
+function isAllowlisted(session: string, allowlist: string[]): boolean {
+  const set = new Set(allowlist);
+  if (set.has(session)) return true;
+  const stem = session.replace(/^\d+-/, "");
+  return set.has(stem);
+}
+
+describe("fleetValidateAllowlist match (#1134)", () => {
+  test("exact session-name match", () => {
+    expect(isAllowlisted("08-mawjs", ["08-mawjs"])).toBe(true);
+  });
+
+  test("matches stem after NN- slot prefix strip", () => {
+    // The whole point: slot prefixes shift between renumberings, so listing
+    // 'mawjs' should cover the oracle no matter what slot it's in.
+    expect(isAllowlisted("08-mawjs", ["mawjs"])).toBe(true);
+    expect(isAllowlisted("25-mawjs", ["mawjs"])).toBe(true);
+  });
+
+  test("does NOT match unrelated session", () => {
+    expect(isAllowlisted("12-pulse", ["mawjs"])).toBe(false);
+  });
+
+  test("stem-match is exact, not prefix — `mawjs` does not allow `mawjs-2`", () => {
+    // Session "09-mawjs-2" has stem "mawjs-2" (not "mawjs"). The allowlist
+    // entry "mawjs" must NOT inadvertently cover the related-but-distinct
+    // session — operator must list it explicitly.
+    expect(isAllowlisted("09-mawjs-2", ["mawjs"])).toBe(false);
+    expect(isAllowlisted("09-mawjs-2", ["mawjs-2"])).toBe(true);
+  });
+
+  test("session without NN- prefix matches only exactly", () => {
+    expect(isAllowlisted("custom-session", ["custom-session"])).toBe(true);
+    expect(isAllowlisted("custom-session", ["custom-other"])).toBe(false);
+  });
+
+  test("empty allowlist matches nothing", () => {
+    expect(isAllowlisted("08-mawjs", [])).toBe(false);
+  });
+
+  test("multi-entry allowlist", () => {
+    const allow = ["mawjs", "mawui", "pulse"];
+    expect(isAllowlisted("08-mawjs", allow)).toBe(true);
+    expect(isAllowlisted("25-mawui", allow)).toBe(true);
+    expect(isAllowlisted("12-pulse", allow)).toBe(true);
+    expect(isAllowlisted("31-odin", allow)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `fleetValidateAllowlist?: string[]` to `MawConfig`
- `maw fleet validate` skips Orphan-session warnings for allowlisted names
- Match is **exact OR by stem** (after stripping `NN-` slot prefix)
- 7 new tests covering match semantics

## Why

Today's output for dev oracles is noise:
```
⚠ Orphan session: tmux '08-mawjs' has no fleet config
⚠ Orphan session: tmux '25-mawui' has no fleet config
```

`mawjs` and `mawui` are dev oracles running from source repos directly (incubator pattern) — they intentionally have no fleet config. Per the issue, the false positives erode trust in `validate` after the legitimate issues from #1133 were fixed.

## Configuration

```jsonc
// ~/.config/maw/maw.config.json
{
  "fleetValidateAllowlist": ["mawjs", "mawui"]
}
```

Match rule: a session is allowlisted if its name OR its stem (after stripping `^\d+-`) is in the list. So `"mawjs"` covers `08-mawjs`, `25-mawjs`, etc. — but NOT `09-mawjs-2` (different stem). Operator must list `"mawjs-2"` explicitly to cover the variant.

## Test plan

- [x] `bun test test/fleet-validate-allowlist.test.ts` (7 cases pass)
- [x] `bun build src/cli.ts` clean
- [ ] Manual: add allowlist, run `maw fleet validate`, confirm no orphan-session warnings

Fixes #1134

🤖 Generated with [Claude Code](https://claude.com/claude-code)