### PR TITLE
feat(api): add /api/agents and /api/agent endpoints (#1132)

### DIFF
--- a/src/api/agents.ts
+++ b/src/api/agents.ts
@@ -1,0 +1,38 @@
+import { Elysia, t } from "elysia";
+import { tmux } from "../sdk";
+import { loadConfig } from "../config";
+import { buildAgentRows } from "../commands/shared/agents";
+
+/**
+ * GET /api/agents (and alias /api/agent)
+ *
+ * Returns the same data as `maw agents --json` — one row per pane, oracle
+ * windows by default, all panes when `?all=1`.
+ *
+ * #1132 — surfaces the existing `cmdAgents` CLI through the HTTP API. The
+ * pure `buildAgentRows` from commands/shared/agents.ts is reused here so the
+ * CLI and API stay in lockstep.
+ */
+async function listAgents(query: { all?: string } | undefined) {
+  const all = query?.all === "1" || query?.all === "true";
+  const config = loadConfig();
+  const nodeName = config.node || "local";
+
+  const [sessions, panes] = await Promise.all([tmux.listAll(), tmux.listPanes()]);
+
+  const windowNames = new Map<string, string>();
+  for (const s of sessions) {
+    for (const w of s.windows) {
+      windowNames.set(`${s.name}:${w.index}`, w.name);
+    }
+  }
+
+  const rows = buildAgentRows(panes, windowNames, nodeName, { all });
+  return { agents: rows, count: rows.length, node: nodeName };
+}
+
+const querySchema = t.Object({ all: t.Optional(t.String()) });
+
+export const agentsApi = new Elysia()
+  .get("/agents", ({ query }) => listAgents(query), { query: querySchema })
+  .get("/agent", ({ query }) => listAgents(query), { query: querySchema });

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -2,6 +2,7 @@ import { Elysia } from "elysia";
 import { cors } from "@elysiajs/cors";
 import { swagger } from "@elysiajs/swagger";
 import { sessionsApi } from "./sessions";
+import { agentsApi } from "./agents";
 import { feedApi } from "./feed";
 import { teamsApi } from "./teams";
 import { configApi } from "./config";
@@ -47,6 +48,7 @@ export const api = new Elysia({ prefix: "/api" })
     },
   }))
   .use(sessionsApi)
+  .use(agentsApi)
   .use(feedApi)
   .use(teamsApi)
   .use(configApi)

--- a/test/api-agents.test.ts
+++ b/test/api-agents.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for #1132 — /api/agents and /api/agent endpoints.
+ *
+ * Verifies the new agents API surfaces the same data as `maw agents --json`,
+ * including the `?all=1` query param and the alias path /api/agent.
+ *
+ * Mocks tmux + config modules so the test is hermetic.
+ */
+import { describe, test, expect, mock } from "bun:test";
+import { Elysia } from "elysia";
+
+// Mock tmux SDK before importing the API module
+mock.module("../src/sdk", () => ({
+  tmux: {
+    listAll: async () => [
+      { name: "01-mawjs", windows: [{ index: "0", name: "mawjs-oracle" }] },
+      { name: "02-neo", windows: [{ index: "0", name: "neo-oracle" }, { index: "1", name: "shell" }] },
+    ],
+    listPanes: async () => [
+      { command: "claude", target: "01-mawjs:0.0", pid: 1001 },
+      { command: "claude", target: "02-neo:0.0", pid: 1002 },
+      { command: "zsh", target: "02-neo:1.0", pid: 1003 },
+    ],
+  },
+}));
+
+mock.module("../src/config", () => ({
+  loadConfig: () => ({ node: "test-node", commands: { default: "claude" } }),
+}));
+
+const { agentsApi } = await import("../src/api/agents");
+const app = new Elysia({ prefix: "/api" }).use(agentsApi);
+
+async function hit(path: string) {
+  return app.handle(new Request(`http://localhost${path}`));
+}
+
+describe("/api/agents (#1132)", () => {
+  test("returns oracle-only rows by default", async () => {
+    const res = await hit("/api/agents");
+    expect(res.status).toBe(200);
+    const body: any = await res.json();
+
+    expect(body.count).toBe(2);
+    expect(body.node).toBe("test-node");
+    expect(body.agents).toHaveLength(2);
+    expect(body.agents.map((a: any) => a.oracle).sort()).toEqual(["mawjs", "neo"]);
+    expect(body.agents.every((a: any) => a.window.endsWith("-oracle"))).toBe(true);
+  });
+
+  test("?all=1 includes non-oracle panes", async () => {
+    const res = await hit("/api/agents?all=1");
+    expect(res.status).toBe(200);
+    const body: any = await res.json();
+
+    expect(body.count).toBe(3);
+    expect(body.agents.find((a: any) => a.window === "shell")).toBeDefined();
+  });
+
+  test("?all=true also enables", async () => {
+    const res = await hit("/api/agents?all=true");
+    const body: any = await res.json();
+    expect(body.count).toBe(3);
+  });
+
+  test("/api/agent (singular alias) returns same data", async () => {
+    const res = await hit("/api/agent");
+    expect(res.status).toBe(200);
+    const body: any = await res.json();
+    expect(body.count).toBe(2);
+    expect(body.agents.map((a: any) => a.oracle).sort()).toEqual(["mawjs", "neo"]);
+  });
+
+  test("agent row shape matches CLI format", async () => {
+    const res = await hit("/api/agents");
+    const body: any = await res.json();
+    const row = body.agents[0];
+
+    expect(row).toHaveProperty("node");
+    expect(row).toHaveProperty("session");
+    expect(row).toHaveProperty("window");
+    expect(row).toHaveProperty("oracle");
+    expect(row).toHaveProperty("state");
+    expect(row).toHaveProperty("pid");
+  });
+});


### PR DESCRIPTION
## Summary

- New `src/api/agents.ts` exporting `agentsApi` Elysia handler
- Two routes: `GET /api/agents` (canonical) and `GET /api/agent` (alias)
- Reuses pure `buildAgentRows` from `src/commands/shared/agents.ts` so CLI + API stay in lockstep
- 5 new tests in `test/api-agents.test.ts` covering both routes + `?all` query

## Why

`maw agents` CLI exists but the HTTP API returned `NOT_FOUND` for both `/api/agents` and `/api/agent` per #1132. Every other major surface (sessions, fleet, oracle, feed, asks, teams, etc.) is exposed — agents was the obvious gap.

## Response shape

```json
GET /api/agents
{
  "agents": [
    { "node": "white", "session": "29-mawjs", "window": "mawjs-oracle", "oracle": "mawjs", "state": "active", "pid": 12345 }
  ],
  "count": 1,
  "node": "white"
}
```

`?all=1` (or `?all=true`) includes non-oracle panes — same semantics as `maw agents --json --all`.

## Test plan

- [x] `bun test test/api-agents.test.ts` (5 cases pass)
- [x] `bun test test/agents.test.ts test/api-agents.test.ts test/api-deprecated-410.test.ts` (16 pass — no neighbor pollution from mock.module)
- [x] `bun build src/cli.ts` clean
- [ ] Manual: `curl http://localhost:3456/api/agents` returns oracle rows

Fixes #1132

🤖 Generated with [Claude Code](https://claude.com/claude-code)