### PR TITLE
feat(help): conceptual grouping + alias markers in maw --help (#1154)

### DIFF
--- a/src/cli/usage.ts
+++ b/src/cli/usage.ts
@@ -1,6 +1,39 @@
 import { discoverPackages } from "../plugin/registry";
 import { TOP_ALIASES, ALIAS_DESCRIPTIONS } from "./top-aliases";
 
+/**
+ * Conceptual grouping for --help output (#1154).
+ *
+ * Each verb (plugin command or top-level alias) is assigned a category.
+ * Groups are rendered in CATEGORY_ORDER. Verbs not in VERB_CATEGORY
+ * fall through to "Other" (forward-compat for new plugins).
+ */
+const CATEGORY_ORDER = ["Sessions", "Look", "Talk", "Window", "Teams", "Oracles", "System"];
+
+const VERB_CATEGORY: Record<string, string> = {
+  wake: "Sessions", a: "Sessions", sleep: "Sessions", stop: "Sessions", kill: "Sessions",
+  ls: "Look", panes: "Look", peek: "Look", health: "Look",
+  run: "Talk", send: "Talk", "send-enter": "Talk",
+  split: "Window", open: "Window", close: "Window", layout: "Window", zoom: "Window", take: "Window", done: "Window",
+  t: "Teams", swarm: "Teams", cleanup: "Teams",
+  oracle: "Oracles", bud: "Oracles", contacts: "Oracles", ping: "Oracles",
+  init: "System", preflight: "System",
+};
+
+interface VerbEntry {
+  verb: string;
+  desc: string;
+  isAlias: boolean;
+  canonical?: string;
+}
+
+function getCanonical(verb: string): string | undefined {
+  const entry = TOP_ALIASES[verb];
+  if (!entry) return undefined;
+  if (Array.isArray(entry)) return entry.join(" ");
+  return undefined;
+}
+
 export function usage() {
   const title = `\x1b[36mmaw\x1b[0m — Multi-Agent Workflow`;
 
@@ -9,57 +42,65 @@ export function usage() {
     const active = all.filter(p => !p.disabled && p.manifest.cli?.command);
     const hasDisabled = all.some(p => p.disabled);
 
-    const tiers = [
-      { name: "core",     plugins: active.filter(p => (p.manifest.weight ?? 50) < 10) },
-      { name: "standard", plugins: active.filter(p => { const w = p.manifest.weight ?? 50; return w >= 10 && w < 50; }) },
-      { name: "extra",    plugins: active.filter(p => (p.manifest.weight ?? 50) >= 50) },
-    ].filter(t => t.plugins.length > 0);
-
-    const multiTier = tiers.length > 1;
-    const lines: string[] = [title, ""];
-
-    const aliasEntries = Object.entries(TOP_ALIASES);
     const pluginNames = new Set(active.map(p => p.manifest.cli!.command));
+    const aliasEntries = Object.entries(TOP_ALIASES);
 
-    let aliasesInserted = false;
-    for (const tier of tiers) {
-      const label = multiTier
-        ? `\x1b[33m${tier.name} (${tier.plugins.length}):\x1b[0m`
-        : `\x1b[33m${tier.name}:\x1b[0m`;
-      lines.push(label);
-      for (const p of tier.plugins) {
-        const cmd = `maw ${p.manifest.cli!.command}`.padEnd(28);
-        const desc = p.manifest.description ?? "";
-        lines.push(`  ${cmd} ${desc}`);
-      }
+    // Build unified verb list
+    const verbs: VerbEntry[] = [];
 
-      if (!aliasesInserted && tier.name === "core" && aliasEntries.length > 0) {
-        for (const [verb] of aliasEntries) {
-          if (pluginNames.has(verb)) continue;
-          const cmd = `maw ${verb}`.padEnd(28);
-          const desc = ALIAS_DESCRIPTIONS[verb] ?? "";
-          lines.push(`  ${cmd} ${desc}`);
-        }
-        aliasesInserted = true;
+    // Plugins first
+    for (const p of active) {
+      const verb = p.manifest.cli!.command;
+      verbs.push({ verb, desc: p.manifest.description ?? "", isAlias: false });
+    }
+
+    // Aliases that aren't already a plugin
+    for (const [verb] of aliasEntries) {
+      if (pluginNames.has(verb)) continue;
+      verbs.push({
+        verb,
+        desc: ALIAS_DESCRIPTIONS[verb] ?? "",
+        isAlias: true,
+        canonical: getCanonical(verb),
+      });
+    }
+
+    // Group by category
+    const groups = new Map<string, VerbEntry[]>();
+    for (const cat of [...CATEGORY_ORDER, "Other"]) groups.set(cat, []);
+
+    for (const v of verbs) {
+      const cat = VERB_CATEGORY[v.verb] || "Other";
+      groups.get(cat)!.push(v);
+    }
+
+    // Render
+    const lines: string[] = [title, ""];
+    let verbCount = 0;
+    let aliasCount = 0;
+
+    for (const cat of [...CATEGORY_ORDER, "Other"]) {
+      const entries = groups.get(cat)!;
+      if (entries.length === 0) continue;
+
+      const preview = entries.map(e => e.verb).join(", ");
+      lines.push(`  \x1b[33m${cat}\x1b[0m  \x1b[90m${preview}\x1b[0m`);
+
+      for (const e of entries) {
+        if (e.isAlias) aliasCount++; else verbCount++;
+        const marker = e.isAlias ? "↳" : " ";
+        const label = `${marker} ${e.verb}`.padEnd(22);
+        const suffix = e.isAlias && e.canonical ? `\x1b[90m→ ${e.canonical}\x1b[0m` : "";
+        lines.push(`    ${label} ${e.desc}${suffix ? `  ${suffix}` : ""}`);
       }
       lines.push("");
     }
 
-    if (!aliasesInserted && aliasEntries.length > 0) {
-      for (const [verb] of aliasEntries) {
-        if (pluginNames.has(verb)) continue;
-        const cmd = `maw ${verb}`.padEnd(28);
-        const desc = ALIAS_DESCRIPTIONS[verb] ?? "";
-        lines.push(`  ${cmd} ${desc}`);
-      }
-      lines.push("");
-    }
-
-    const total = active.length + aliasEntries.filter(([v]) => !pluginNames.has(v)).length;
-    const countLine = hasDisabled
-      ? `\x1b[90m${total} commands active. Run 'maw plugin enable <name>' for more.\x1b[0m`
-      : `\x1b[90m${total} commands active.\x1b[0m`;
-    lines.push(countLine);
+    const hiddenCount = hasDisabled ? all.filter(p => p.disabled).length : 0;
+    const footer = hiddenCount > 0
+      ? `\x1b[90m${verbCount} commands · ${aliasCount} aliases · ${hiddenCount} hidden (maw plugin enable <name>)\x1b[0m`
+      : `\x1b[90m${verbCount} commands · ${aliasCount} aliases\x1b[0m`;
+    lines.push(footer);
 
     console.log(lines.join("\n"));
   } catch {


### PR DESCRIPTION
## Summary

- Rewrites `src/cli/usage.ts` from flat tier dump → 7 conceptual groups
- Aliases marked with `↳` + showing `→ canonical` route
- Groups: Sessions, Look, Talk, Window, Teams, Oracles, System
- Unknown verbs fall to "Other" (forward-compat)

## Before

```
core:
  maw send-enter             Send Enter key...
  maw ping                   Ping peer nodes...
  maw sleep                  ...
  maw a                      Attach to a tmux session
  ... (28 items, flat, blended)
```

## After

```
Sessions  sleep, stop, wake, a, kill
    sleep                Gracefully stop...
    stop                 Stop ALL fleet sessions
    wake                 Spawn or attach to an oracle session
  ↳ a                    Attach to a tmux session  → tmux attach
  ↳ kill                 Kill a pane or session    → tmux kill

Look  health, ls, peek, panes
    health               System health check
    ...
```

## Test plan

- [x] `bun build` clean (0.90 MB)
- [x] `maw --help` renders grouped output
- [x] Full test suite: 1199 pass, 3 pre-existing flakes
- [x] Forward-compat: new plugins without category map entry → "Other" group

Fixes #1154

🤖 Generated with [Claude Code](https://claude.com/claude-code)