### PR TITLE
release: v26.5.7-alpha.752

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.5-alpha.758",
+  "version": "26.5.7-alpha.752",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts v26.5.7-alpha.752 on merge via calver-release.yml.

## Included since v26.5.5-alpha.758

- #1151 fix(wake): reject flag-shaped names like --help
- #1148 fix(channel): defer to shell env over channel config.json
- #1134 fix(fleet): allowlist intentional non-fleet sessions in validate
- #1132 feat(api): add /api/agents and /api/agent endpoints
- #1152 feat(fleet): add maw fleet wake + refactor to map-based router
- #1154 feat(help): conceptual grouping + alias markers in maw --help
- #1153 feat(ls): grouped compact output with summary header
- #1142 fix(inbox): parse date: frontmatter (plugin-registry)
- #1126 fix(test): skip nativeFetch-only tests on macOS
- #1151 follow-up: print error before UserError throw

Auto-generated by /release-alpha