### PR TITLE
refactor(fleet): expose adoptByPath helper for external consumers (#1147)

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "./lib/schemas": "./src/lib/schemas.ts",
     "./lib/sleep": "./src/lib/sleep.ts",
     "./lib/sparkline": "./src/lib/sparkline.ts",
+    "./commands/plugins/fleet/fleet-adopt": "./src/commands/plugins/fleet/fleet-adopt.ts",
     "./commands/shared/comm": "./src/commands/shared/comm.ts",
     "./commands/shared/comm-send": "./src/commands/shared/comm-send.ts",
     "./commands/shared/done": "./src/commands/shared/done.ts",

--- a/src/commands/plugins/fleet/fleet-adopt.test.ts
+++ b/src/commands/plugins/fleet/fleet-adopt.test.ts
@@ -1,0 +1,130 @@
+/**
+ * fleet-adopt — adoptByPath() helper exposed for #1147 (bud lifecycle).
+ *
+ * The helper writes a `<NN>-<stem>.json` into FLEET_DIR. FLEET_DIR is captured
+ * at module-load time from MAW_CONFIG_DIR (src/core/paths.ts), so we set the
+ * env var BEFORE the dynamic import so the module sees the temp dir.
+ *
+ * org/repo derivation falls back to `git remote get-url origin` when the path
+ * isn't under `ghq root` — that's the seam we exercise here (real `git init`
+ * + remote add in a tmpdir).
+ */
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { execSync } from "child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "maw-fleet-adopt-"));
+const tmpConfigDir = join(tmpRoot, "config");
+const fleetDir = join(tmpConfigDir, "fleet");
+mkdirSync(fleetDir, { recursive: true });
+process.env.MAW_CONFIG_DIR = tmpConfigDir;
+
+// Import AFTER env override so FLEET_DIR resolves to our tmpdir.
+const adoptMod = await import("./fleet-adopt");
+const { adoptByPath } = adoptMod;
+
+function makeRepo(name: string, claudeMdLine1: string): string {
+  const repoPath = join(tmpRoot, "repos", name);
+  mkdirSync(repoPath, { recursive: true });
+  writeFileSync(join(repoPath, "CLAUDE.md"), `${claudeMdLine1}\n\nbody.\n`);
+  // Real git repo with a fake origin remote so deriveOrgRepo's fallback works.
+  execSync("git init -q", { cwd: repoPath });
+  execSync(`git remote add origin git@github.com:Soul-Brews-Studio/${name}.git`, { cwd: repoPath });
+  return repoPath;
+}
+
+function clearFleet(): void {
+  for (const f of readdirSync(fleetDir)) rmSync(join(fleetDir, f), { force: true });
+}
+
+beforeEach(() => clearFleet());
+
+afterAll(() => {
+  try { rmSync(tmpRoot, { recursive: true, force: true }); } catch {}
+});
+
+describe("adoptByPath — exposed helper for #1147", () => {
+  test("import resolves through the package exports map shape", () => {
+    // The helper must be a callable async function (the public contract).
+    expect(typeof adoptByPath).toBe("function");
+  });
+
+  test("happy path: writes <NN>-<stem>.json with derived org/repo", async () => {
+    const repo = makeRepo("foo-oracle", "# foo Oracle");
+
+    const result = await adoptByPath(repo);
+
+    expect(result.slot).toBe(1);
+    expect(result.groupName).toBe("foo");
+    expect(result.written).toBe(true);
+    expect(result.configPath).toBe(join(fleetDir, "01-foo.json"));
+    expect(existsSync(result.configPath)).toBe(true);
+
+    const written = JSON.parse(readFileSync(result.configPath, "utf8"));
+    expect(written).toMatchObject({
+      name: "01-foo",
+      windows: [{ name: "foo-oracle", repo: "Soul-Brews-Studio/foo-oracle" }],
+      adopted_from: "ghq:Soul-Brews-Studio/foo-oracle",
+    });
+    expect(typeof written.adopted_at).toBe("string");
+  });
+
+  test("dry-run: returns config but writes nothing", async () => {
+    const repo = makeRepo("bar-oracle", "# bar Oracle");
+
+    const result = await adoptByPath(repo, { dryRun: true });
+
+    expect(result.written).toBe(false);
+    expect(result.slot).toBe(1);
+    expect(existsSync(result.configPath)).toBe(false);
+    expect(result.config.windows[0].repo).toBe("Soul-Brews-Studio/bar-oracle");
+  });
+
+  test("slot increments based on existing fleet entries", async () => {
+    writeFileSync(join(fleetDir, "07-existing.json"), JSON.stringify({
+      name: "07-existing",
+      windows: [{ name: "existing-oracle", repo: "x/existing" }],
+    }));
+    const repo = makeRepo("baz-oracle", "# baz Oracle");
+
+    const result = await adoptByPath(repo);
+
+    expect(result.slot).toBe(8);
+    expect(result.configPath).toBe(join(fleetDir, "08-baz.json"));
+  });
+
+  test("opts.as overrides the extracted stem", async () => {
+    const repo = makeRepo("qux-oracle", "# qux Oracle");
+
+    const result = await adoptByPath(repo, { as: "custom" });
+
+    expect(result.groupName).toBe("custom");
+    expect(result.configPath).toBe(join(fleetDir, "01-custom.json"));
+  });
+
+  test("missing CLAUDE.md → throws", async () => {
+    const repoPath = join(tmpRoot, "repos", "no-claude");
+    mkdirSync(repoPath, { recursive: true });
+
+    let err: Error | undefined;
+    try { await adoptByPath(repoPath); }
+    catch (e) { err = e as Error; }
+    expect(err).toBeDefined();
+    expect(err!.message).toMatch(/CLAUDE\.md not found/);
+  });
+
+  test("duplicate stem already in fleet → throws", async () => {
+    const repo = makeRepo("dupe-oracle", "# dupe Oracle");
+    await adoptByPath(repo);
+    // Second adoption of same stem must fail.
+    const repo2 = makeRepo("dupe-oracle-2", "# dupe Oracle");
+
+    let err: Error | undefined;
+    try { await adoptByPath(repo2); }
+    catch (e) { err = e as Error; }
+    expect(err).toBeDefined();
+    expect(err!.message).toMatch(/already exists in fleet/);
+  });
+});

--- a/src/commands/plugins/fleet/fleet-adopt.ts
+++ b/src/commands/plugins/fleet/fleet-adopt.ts
@@ -4,7 +4,7 @@ import { execSync } from "child_process";
 import { FLEET_DIR } from "../../../core/paths";
 import { loadFleetEntries } from "../../shared/fleet-load";
 
-function extractOracleStem(claudeMdPath: string): string | null {
+export function extractOracleStem(claudeMdPath: string): string | null {
   const line1 = readFileSync(claudeMdPath, "utf8")
     .split("\n")[0]
     .replace(/^#\s*/, "");
@@ -62,6 +62,120 @@ function scanOrphans(): Orphan[] {
   return orphans;
 }
 
+/**
+ * Derive `{ org, repo }` from a local repo path.
+ *
+ * Tries ghq layout first (path inside `ghq root` → host/org/repo), then falls
+ * back to `git remote get-url origin`. The bud lifecycle (#1147) creates repos
+ * via `gh repo create` + `ghq get`, so both paths are reliable in practice.
+ */
+function deriveOrgRepo(repoPath: string): { org: string; repo: string } {
+  // 1. ghq layout: <root>/<host>/<org>/<repo>
+  try {
+    const ghqRoot = execSync("ghq root", { encoding: "utf8" }).trim();
+    const normalized = repoPath.replace(/\/+$/, "");
+    if (ghqRoot && normalized.startsWith(ghqRoot + "/")) {
+      const rel = normalized.slice(ghqRoot.length + 1);
+      const parts = rel.split("/");
+      if (parts.length >= 3 && parts[1] && parts[2]) {
+        return { org: parts[1], repo: parts[2] };
+      }
+    }
+  } catch { /* fall through */ }
+
+  // 2. Fallback: git remote get-url origin
+  try {
+    const remote = execSync(
+      `git -C ${JSON.stringify(repoPath)} remote get-url origin`,
+      { encoding: "utf8" },
+    ).trim();
+    const m = remote.match(/[:/]([^/:]+)\/([^/]+?)(?:\.git)?$/);
+    if (m && m[1] && m[2]) return { org: m[1], repo: m[2] };
+  } catch { /* fall through */ }
+
+  throw new Error(`adoptByPath: cannot derive org/repo for ${repoPath} (not under ghq root, no origin remote)`);
+}
+
+export interface AdoptByPathOpts {
+  /** Don't write the fleet config file; still compute and return what would be written. */
+  dryRun?: boolean;
+  /** Override the stem (defaults to the one extracted from CLAUDE.md line 1). */
+  as?: string;
+}
+
+export interface AdoptByPathResult {
+  /** Numeric slot (e.g. 27 → `27-foo.json`). */
+  slot: number;
+  /** Absolute path of the fleet config file (written, or would-be written when dry-run). */
+  configPath: string;
+  /** The fleet stem (after override, lowercased, slug-form). */
+  groupName: string;
+  /** The full session config that was (or would be) written. */
+  config: {
+    name: string;
+    windows: Array<{ name: string; repo: string }>;
+    adopted_at: string;
+    adopted_from: string;
+  };
+  /** True iff the file was actually written (false in dry-run). */
+  written: boolean;
+}
+
+/**
+ * Adopt a local oracle repo into the fleet — register a `<NN>-<stem>.json`
+ * config under `FLEET_DIR` so `maw wake <stem>` can resolve it deterministically.
+ *
+ * Importable helper for the maw-js side of #1147 (bud lifecycle completion).
+ * The CLI (`maw fleet adopt <name>`) calls this internally.
+ *
+ * Throws if:
+ * - `repoPath/CLAUDE.md` is missing or its first line yields no stem
+ * - the stem already exists in the fleet (pass `opts.as` to override)
+ * - the org/repo can't be derived (not under ghq root, no `origin` remote)
+ */
+export async function adoptByPath(
+  repoPath: string,
+  opts: AdoptByPathOpts = {},
+): Promise<AdoptByPathResult> {
+  const { dryRun = false, as: nameOverride } = opts;
+
+  const claudeMd = join(repoPath, "CLAUDE.md");
+  if (!existsSync(claudeMd)) {
+    throw new Error(`adoptByPath: CLAUDE.md not found at ${repoPath}`);
+  }
+
+  const stem = nameOverride ?? extractOracleStem(claudeMd);
+  if (!stem) {
+    throw new Error(`adoptByPath: could not extract oracle stem from ${claudeMd}`);
+  }
+
+  const { org, repo } = deriveOrgRepo(repoPath);
+
+  const entries = loadFleetEntries();
+  if (entries.some(e => e.groupName === stem)) {
+    throw new Error(`adoptByPath: stem '${stem}' already exists in fleet — pass opts.as to override`);
+  }
+  if (entries.some(e => e.session.windows?.some(w => w.repo === `${org}/${repo}`))) {
+    throw new Error(`adoptByPath: ${org}/${repo} is already registered in fleet`);
+  }
+
+  const slot = entries.reduce((max, e) => Math.max(max, e.num), 0) + 1;
+  const fileName = `${String(slot).padStart(2, "0")}-${stem}.json`;
+  const configPath = join(FLEET_DIR, fileName);
+  const config = {
+    name: `${String(slot).padStart(2, "0")}-${stem}`,
+    windows: [{ name: `${stem}-oracle`, repo: `${org}/${repo}` }],
+    adopted_at: new Date().toISOString(),
+    adopted_from: `ghq:${org}/${repo}`,
+  };
+
+  if (!dryRun) {
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  }
+
+  return { slot, configPath, groupName: stem, config, written: !dryRun };
+}
+
 export async function cmdFleetAdopt(args: string[]) {
   const isScan = args.includes("--scan");
   const isDryRun = args.includes("--dry-run");
@@ -91,8 +205,6 @@ export async function cmdFleetAdopt(args: string[]) {
   }
 
   const orphans = scanOrphans();
-  const entries = loadFleetEntries();
-  let maxNum = entries.reduce((max, e) => Math.max(max, e.num), 0);
 
   for (const target of targets) {
     const match = orphans.find(o => o.repo === target || o.stem === target || o.repo.includes(target));
@@ -101,32 +213,24 @@ export async function cmdFleetAdopt(args: string[]) {
       continue;
     }
 
-    const stem = nameOverride || match.stem;
-    const existingStem = entries.find(e => e.groupName === stem);
-    if (existingStem) {
-      console.log(`  \x1b[31m✗\x1b[0m '${stem}' already exists in fleet — use --as <other-name>`);
-      continue;
+    try {
+      const result = await adoptByPath(match.path, {
+        dryRun: isDryRun,
+        as: nameOverride ?? match.stem,
+      });
+
+      if (!result.written) {
+        console.log(`  \x1b[90m[dry-run]\x1b[0m would create: ${basename(result.configPath)}`);
+        console.log(JSON.stringify(result.config, null, 2));
+        continue;
+      }
+
+      console.log(`  \x1b[32m✅\x1b[0m adopted: ${match.repo} → ${result.groupName} (${basename(result.configPath)})`);
+      console.log(`     repo: ${match.org}/${match.repo}`);
+      console.log(`     fleet: ~/.config/maw/fleet/${basename(result.configPath)}`);
+      console.log(`     next: \x1b[36mmaw wake ${result.groupName}\x1b[0m`);
+    } catch (e) {
+      console.log(`  \x1b[31m✗\x1b[0m ${(e as Error).message}`);
     }
-
-    maxNum++;
-    const fileName = `${String(maxNum).padStart(2, "0")}-${stem}.json`;
-    const config = {
-      name: `${String(maxNum).padStart(2, "0")}-${stem}`,
-      windows: [{ name: `${stem}-oracle`, repo: `${match.org}/${match.repo}` }],
-      adopted_at: new Date().toISOString(),
-      adopted_from: `ghq:${match.org}/${match.repo}`,
-    };
-
-    if (isDryRun) {
-      console.log(`  \x1b[90m[dry-run]\x1b[0m would create: ${fileName}`);
-      console.log(JSON.stringify(config, null, 2));
-      continue;
-    }
-
-    writeFileSync(join(FLEET_DIR, fileName), JSON.stringify(config, null, 2) + "\n");
-    console.log(`  \x1b[32m✅\x1b[0m adopted: ${match.repo} → ${stem} (${fileName})`);
-    console.log(`     repo: ${match.org}/${match.repo}`);
-    console.log(`     fleet: ~/.config/maw/fleet/${fileName}`);
-    console.log(`     next: \x1b[36mmaw wake ${stem}\x1b[0m`);
   }
 }


### PR DESCRIPTION
## Summary

- Extracts the core "adopt this path" logic from `cmdFleetAdopt` into a new exported async function `adoptByPath(repoPath, opts?)` so the bud lifecycle (maw-plugin-registry) can call it directly after `gh repo create` + `ghq get`, instead of shelling out to `maw fleet adopt`.
- Adds `./commands/plugins/fleet/fleet-adopt` to the package.json exports map.
- CLI wrapper (`maw fleet adopt`) now delegates to the helper — preserves existing output (success messages + `--dry-run` JSON preview verbatim).

## Scope

maw-js side of #1147 only. Registry-side wiring (calling this helper from `maw bud`) is a follow-up PR against [Soul-Brews-Studio/maw-plugin-registry](https://github.com/Soul-Brews-Studio/maw-plugin-registry).

## Helper signature

```ts
adoptByPath(repoPath: string, opts?: { dryRun?: boolean; as?: string })
  → Promise<{ slot, configPath, groupName, config, written }>
```

Derives `org/repo` from ghq layout, falls back to `git remote get-url origin`. Throws on missing CLAUDE.md, duplicate stem, or unresolvable origin.

## Test plan

- [x] `bun test src/commands/plugins/fleet/fleet-adopt.test.ts` — 7 pass / 0 fail / 20 expect() calls
  - import resolves through exports map shape
  - happy path writes `01-foo.json` with derived org/repo
  - dry-run returns config + writes nothing
  - slot increments past existing entries (`07-existing` → next is `08-…`)
  - `opts.as` overrides extracted stem
  - missing `CLAUDE.md` throws
  - duplicate stem already in fleet throws
- [x] `bun test src/commands/plugins/fleet/` — 19 pass / 0 fail (no regression in `fleet-compose`)
- [x] `bun run build` — 648 modules bundled, 0.90 MB, 26ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)