### PR TITLE
feat(tmux): stall-detect notify-only (Phase A of #976)

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -47,6 +47,7 @@ export const ALIAS_DESCRIPTIONS: Record<string, string> = {
   ls: "List sessions (compact, -a roster, -v detail)",
   wake: "Wake an oracle session (fuzzy match, auto-clone)",
   preflight: "Pre-flight check — version, plugins, dead agents, config",
+  stall: "Detect stalled panes — notify-only (#976A)",
 };
 
 export const TOP_ALIASES: Record<string, string[] | DirectHandler> = {
@@ -62,6 +63,7 @@ export const TOP_ALIASES: Record<string, string[] | DirectHandler> = {
   zoom: ["tmux", "zoom"],
   panes: ["tmux", "ls", "--all", "--verbose"],
   cleanup: ["team", "cleanup", "--zombie-agents"],
+  stall: ["tmux", "detect-stalls"],
 
   // Direct-handler form — `ls` flags differ from tmux ls:
   //   maw ls      → compact, live sessions only

--- a/src/commands/plugins/tmux/index.ts
+++ b/src/commands/plugins/tmux/index.ts
@@ -1,6 +1,7 @@
 import type { InvokeContext, InvokeResult } from "../../../plugin/types";
 import { parseFlags } from "../../../cli/parse-args";
 import { cmdTmuxPeek, cmdTmuxLs, cmdTmuxSend, cmdTmuxSplit, cmdTmuxKill, cmdTmuxLayout, cmdTmuxAttach, resolveTmuxTarget } from "./impl";
+import { cmdStallDetect } from "./stall-detect";
 import { hostExec } from "../../../sdk";
 
 export const command = {
@@ -224,6 +225,37 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         const { cmdSplit } = await import("../split/impl");
         await cmdSplit(target, { lock: true });
       }
+    } else if (sub === "detect-stalls" || sub === "stall") {
+      const flags = parseFlags(args, {
+        "--watch": Boolean,
+        "--threshold": Number,
+        "--interval": Number,
+        "--lines": Number,
+        "--help": Boolean,
+        "-h": "--help",
+      }, 1);
+      if (flags["--help"]) {
+        console.log("usage: maw tmux detect-stalls <target> [<target>...] [--watch] [--threshold N] [--interval MS] [--lines N]");
+        console.log("  Phase A — notify-only. Reports panes whose capture-pane content");
+        console.log("  hash hasn't changed for `threshold` consecutive samples.");
+        console.log("  --watch       keep watching (default: one-shot single sample)");
+        console.log("  --threshold N consecutive unchanged samples before notify (default 3)");
+        console.log("  --interval MS milliseconds between samples (default 30000)");
+        console.log("  --lines N     lines from bottom of pane to hash (default 30)");
+        console.log("  NOTE: no auto-nudge in Phase A. See #976B for opt-in injection.");
+        return { ok: true, output: logs.join("\n") || undefined };
+      }
+      const targets = (flags._ as string[]).filter(Boolean);
+      if (targets.length === 0) {
+        console.log("usage: maw tmux detect-stalls <target> [<target>...] [--watch] [--threshold N] [--interval MS]");
+        return { ok: false, error: "at least one target required", output: logs.join("\n") };
+      }
+      await cmdStallDetect(targets, {
+        watch: !!flags["--watch"],
+        threshold: flags["--threshold"] as number | undefined,
+        intervalMs: flags["--interval"] as number | undefined,
+        lines: flags["--lines"] as number | undefined,
+      });
     } else if (sub === "zoom") {
       const target = args[1];
       if (!target) {
@@ -235,7 +267,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       console.log(`\x1b[32m✓\x1b[0m toggled zoom on ${resolved}`);
 
     } else if (!sub || sub === "--help" || sub === "-h") {
-      console.log("usage: maw tmux <ls|peek|send|split|kill|open|close|layout|attach> [args]");
+      console.log("usage: maw tmux <ls|peek|send|split|kill|open|close|layout|attach|detect-stalls> [args]");
       console.log("  ls [--all]              list panes with fleet + team annotations");
       console.log("  peek <target>           read content of a tmux pane");
       console.log("  send <target> <cmd>     send keys to a pane (with safety gates)");
@@ -243,6 +275,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       console.log("  kill <target>           kill a pane or --session (fleet-safe)");
       console.log("  layout <target> <preset> apply a tmux layout preset");
       console.log("  attach <target> [--print] attach to a tmux session (--print to skip exec)");
+      console.log("  detect-stalls <target>... [--watch]  notify when pane content stops changing");
       return { ok: true, output: logs.join("\n") || undefined };
     } else {
       console.log(`unknown tmux subcommand: ${sub}`);

--- a/src/commands/plugins/tmux/stall-detect.ts
+++ b/src/commands/plugins/tmux/stall-detect.ts
@@ -1,0 +1,132 @@
+/**
+ * Stall detection for tmux panes — Phase A (notify-only) of #976.
+ *
+ * Watches one or more panes by hashing the tail of `tmux capture-pane`
+ * output every `intervalMs`. When N consecutive samples produce the
+ * same hash (no visible change), the pane is reported as stalled.
+ *
+ * Phase A is NOTIFY-ONLY: we log a warning, never inject keys.
+ * Phase B (issue #976B) adds gated auto-nudge with 4 safety gates.
+ *
+ * The core logic (`updateStallState`) is a pure function over a state
+ * map, so unit tests don't need to mock tmux. The async runner
+ * (`cmdStallDetect`) wires it to `cmdTmuxPeek` + a setInterval loop.
+ */
+
+import { createHash } from "node:crypto";
+import { hostExec } from "../../../sdk";
+import { resolveTmuxTarget } from "./impl";
+
+export interface StallDetectOpts {
+  /** Keep watching forever. Default: false (one-shot single sample). */
+  watch?: boolean;
+  /** Consecutive unchanged samples before reporting stall. Default: 3. */
+  threshold?: number;
+  /** Interval between samples in ms. Default: 30_000. */
+  intervalMs?: number;
+  /** Lines from bottom of pane to hash. Default: 30. */
+  lines?: number;
+}
+
+export interface PaneSample {
+  hash: string;
+  unchanged: number;  // consecutive unchanged sample count
+  notified: boolean;  // already notified for this stall window
+}
+
+export type StallState = Map<string, PaneSample>;
+
+export interface StallEvent {
+  paneId: string;
+  hash: string;
+  unchanged: number;
+  /** First time we've crossed the threshold for this stall window. */
+  firstReport: boolean;
+}
+
+/**
+ * Pure state-update step. Given the previous state, a pane id, and
+ * the new captured content, return the next state plus an optional
+ * event when the pane is stalled.
+ *
+ * Caller decides what to do with the event (log, audit, nudge — Phase B).
+ *
+ * Reset rule: if the hash differs from the prior sample, `unchanged`
+ * goes back to 1 and `notified` clears (next stall counts again).
+ */
+export function updateStallState(
+  state: StallState,
+  paneId: string,
+  content: string,
+  threshold: number,
+): { state: StallState; event: StallEvent | null } {
+  const hash = createHash("sha1").update(content).digest("hex");
+  const prev = state.get(paneId);
+  const next: StallState = new Map(state);
+
+  if (!prev || prev.hash !== hash) {
+    next.set(paneId, { hash, unchanged: 1, notified: false });
+    return { state: next, event: null };
+  }
+
+  const unchanged = prev.unchanged + 1;
+  const stalled = unchanged >= threshold;
+  const firstReport = stalled && !prev.notified;
+  next.set(paneId, { hash, unchanged, notified: prev.notified || stalled });
+
+  if (!stalled) return { state: next, event: null };
+  return { state: next, event: { paneId, hash, unchanged, firstReport } };
+}
+
+/** Format a stall notification for the console. Phase A: notify only. */
+export function formatStallNotice(event: StallEvent, intervalMs: number): string {
+  const seconds = Math.round((event.unchanged * intervalMs) / 1000);
+  const tag = event.firstReport ? "STALL" : "still stalled";
+  return `\x1b[33m⚠ ${tag}\x1b[0m ${event.paneId} — ${event.unchanged} unchanged samples (~${seconds}s) · hash ${event.hash.slice(0, 8)}`;
+}
+
+/**
+ * CLI entry point. Captures one (or `--watch` many) sample per target
+ * and prints stall notices. Phase A — never injects keys.
+ */
+export async function cmdStallDetect(
+  targets: string[],
+  opts: StallDetectOpts = {},
+): Promise<void> {
+  const threshold = opts.threshold ?? 3;
+  const intervalMs = opts.intervalMs ?? 30_000;
+  const lines = opts.lines ?? 30;
+
+  const resolved = targets.map(t => {
+    const hit = resolveTmuxTarget(t);
+    if (!hit) throw new Error(`cannot resolve target '${t}'`);
+    return { user: t, id: hit.resolved };
+  });
+
+  let state: StallState = new Map();
+
+  const sampleOnce = async (): Promise<void> => {
+    for (const { user, id } of resolved) {
+      let out: string;
+      try {
+        out = await hostExec(`tmux capture-pane -pt '${id}' -S -${lines} -J`);
+      } catch (e: any) {
+        console.log(`\x1b[31m✗\x1b[0m ${user} (${id}): capture failed — ${e?.message || e}`);
+        continue;
+      }
+      const result = updateStallState(state, id, out, threshold);
+      state = result.state;
+      if (result.event) {
+        console.log(formatStallNotice(result.event, intervalMs));
+      }
+    }
+  };
+
+  await sampleOnce();
+  if (!opts.watch) return;
+
+  console.log(`\x1b[90m▸ watching ${resolved.length} pane(s) every ${intervalMs}ms (threshold=${threshold}) — notify-only\x1b[0m`);
+  await new Promise<void>(() => {
+    setInterval(() => { void sampleOnce(); }, intervalMs);
+  });
+}

--- a/test/stall-detect.test.ts
+++ b/test/stall-detect.test.ts
@@ -1,0 +1,131 @@
+import { describe, test, expect } from "bun:test";
+import {
+  updateStallState,
+  formatStallNotice,
+  type StallState,
+} from "../src/commands/plugins/tmux/stall-detect";
+
+// Pure logic tests for #976 Phase A stall detection.
+// No tmux, no setInterval — `updateStallState` is a pure state-machine
+// step, so we feed it captured strings and assert state transitions.
+
+describe("updateStallState — content hash transitions", () => {
+  test("first sample initializes state, never reports stall", () => {
+    const { state, event } = updateStallState(new Map(), "%1", "hello", 3);
+    expect(event).toBeNull();
+    expect(state.get("%1")?.unchanged).toBe(1);
+    expect(state.get("%1")?.notified).toBe(false);
+  });
+
+  test("changed content resets unchanged counter to 1", () => {
+    let state: StallState = new Map();
+    state = updateStallState(state, "%1", "a", 3).state;
+    state = updateStallState(state, "%1", "a", 3).state;
+    expect(state.get("%1")?.unchanged).toBe(2);
+    const r = updateStallState(state, "%1", "b", 3);
+    expect(r.event).toBeNull();
+    expect(r.state.get("%1")?.unchanged).toBe(1);
+  });
+
+  test("threshold=3 fires stall on third unchanged sample", () => {
+    let state: StallState = new Map();
+    let last = updateStallState(state, "%1", "x", 3);
+    expect(last.event).toBeNull();
+    state = last.state;
+
+    last = updateStallState(state, "%1", "x", 3);
+    expect(last.event).toBeNull();
+    state = last.state;
+
+    last = updateStallState(state, "%1", "x", 3);
+    expect(last.event).not.toBeNull();
+    expect(last.event?.paneId).toBe("%1");
+    expect(last.event?.unchanged).toBe(3);
+    expect(last.event?.firstReport).toBe(true);
+  });
+
+  test("subsequent unchanged samples set firstReport=false", () => {
+    let state: StallState = new Map();
+    for (let i = 0; i < 3; i++) {
+      state = updateStallState(state, "%1", "x", 3).state;
+    }
+    // 4th sample — still stalled but already notified
+    const r = updateStallState(state, "%1", "x", 3);
+    expect(r.event).not.toBeNull();
+    expect(r.event?.firstReport).toBe(false);
+    expect(r.event?.unchanged).toBe(4);
+  });
+
+  test("changed content after stall clears notified flag", () => {
+    let state: StallState = new Map();
+    for (let i = 0; i < 3; i++) {
+      state = updateStallState(state, "%1", "x", 3).state;
+    }
+    expect(state.get("%1")?.notified).toBe(true);
+
+    // Change → reset
+    state = updateStallState(state, "%1", "y", 3).state;
+    expect(state.get("%1")?.unchanged).toBe(1);
+    expect(state.get("%1")?.notified).toBe(false);
+
+    // Stall again → firstReport=true again
+    state = updateStallState(state, "%1", "y", 3).state;
+    const final = updateStallState(state, "%1", "y", 3);
+    expect(final.event?.firstReport).toBe(true);
+  });
+
+  test("multiple panes tracked independently", () => {
+    let state: StallState = new Map();
+    state = updateStallState(state, "%1", "a", 3).state;
+    state = updateStallState(state, "%2", "b", 3).state;
+    state = updateStallState(state, "%1", "a", 3).state;
+    state = updateStallState(state, "%2", "c", 3).state;  // changed
+
+    expect(state.get("%1")?.unchanged).toBe(2);
+    expect(state.get("%2")?.unchanged).toBe(1);
+  });
+
+  test("threshold=1 fires on first repeat", () => {
+    let state: StallState = new Map();
+    state = updateStallState(state, "%1", "x", 1).state;
+    const r = updateStallState(state, "%1", "x", 1);
+    // unchanged=2 ≥ threshold=1 → stall
+    expect(r.event).not.toBeNull();
+    expect(r.event?.firstReport).toBe(true);
+  });
+
+  test("hash is stable for identical content", () => {
+    const r1 = updateStallState(new Map(), "%1", "same content here\nline 2", 3);
+    const r2 = updateStallState(new Map(), "%2", "same content here\nline 2", 3);
+    expect(r1.state.get("%1")?.hash).toBe(r2.state.get("%2")?.hash);
+  });
+
+  test("hash differs for different content", () => {
+    const r1 = updateStallState(new Map(), "%1", "alpha", 3);
+    const r2 = updateStallState(new Map(), "%1", "beta", 3);
+    expect(r1.state.get("%1")?.hash).not.toBe(r2.state.get("%1")?.hash);
+  });
+});
+
+describe("formatStallNotice — output", () => {
+  test("first report uses STALL tag", () => {
+    const msg = formatStallNotice(
+      { paneId: "%42", hash: "abc123def456", unchanged: 3, firstReport: true },
+      30_000,
+    );
+    expect(msg).toContain("STALL");
+    expect(msg).toContain("%42");
+    expect(msg).toContain("3 unchanged");
+    expect(msg).toContain("abc123de");  // 8-char prefix
+    expect(msg).toContain("~90s");      // 3 * 30000 / 1000
+  });
+
+  test("subsequent report uses 'still stalled' tag", () => {
+    const msg = formatStallNotice(
+      { paneId: "%1", hash: "deadbeef00", unchanged: 5, firstReport: false },
+      1000,
+    );
+    expect(msg).toContain("still stalled");
+    expect(msg).toContain("~5s");
+  });
+});


### PR DESCRIPTION
## Summary
- Phase A of #976: detect stalled tmux panes via SHA-1 hash of `capture-pane` content; notify when N consecutive samples are unchanged
- New CLI: `maw tmux detect-stalls <target>...` (alias `maw stall`) with `--watch`, `--threshold`, `--interval`, `--lines`
- **Notify-only** — no key injection. Phase B (#976B) will add gated auto-nudge with the 4 safety gates

## Files
- **NEW** `src/commands/plugins/tmux/stall-detect.ts` — pure `updateStallState` state-machine + `cmdStallDetect` runner
- **NEW** `test/stall-detect.test.ts` — 11 unit tests (transitions, threshold, multi-pane independence, hash stability, format)
- **MOD** `src/commands/plugins/tmux/index.ts` — wired `detect-stalls`/`stall` subcommand
- **MOD** `src/cli/top-aliases.ts` — top-level `stall` → `tmux detect-stalls`

Defaults: threshold=3, interval=30s, lines=30.

## Test plan
- [x] `bun test test/stall-detect.test.ts` — 11/11 pass
- [x] `bun test test/isolated/tmux-safety.test.ts` — 37/37 pass (regression)
- [x] `bun run build` — clean (0.90 MB)
- [x] CLI dispatch verified (`maw tmux detect-stalls` reaches handler)
- [ ] Manual smoke: run `maw stall <pane>` against a known-idle pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)