### PR TITLE
feat(lib): formatError helper + 10-file sweep (#1114 Phase 1)

### DIFF
--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -5,6 +5,7 @@ import { matchCommand, executeCommand } from "./command-registry";
 import { getVersionString } from "./cmd-version";
 import { runUpdate } from "./cmd-update";
 import { UserError } from "../core/util/user-error";
+import { formatError } from "../lib/format-error";
 
 /** Core route names that are not plugins but are still "known commands". */
 const CORE_ROUTES = [
@@ -70,8 +71,10 @@ async function dispatchPluginRegistry(cmd: string, args: string[]): Promise<void
   const dispatch = resolvePluginMatch(plugins, cmdName);
 
   if (dispatch.kind === "ambiguous") {
-    console.error(`\x1b[31m✗\x1b[0m ambiguous command: ${args[0]}`);
-    console.error(`  candidates: ${dispatch.candidates.map(c => `${c.plugin} (${c.name})`).join(", ")}`);
+    console.error(formatError(
+      `ambiguous command: ${args[0]}`,
+      `candidates: ${dispatch.candidates.map(c => `${c.plugin} (${c.name})`).join(", ")}`,
+    ));
     throw new UserError(`ambiguous command: ${args[0]}`);
   }
   if (dispatch.kind === "match") {
@@ -152,12 +155,10 @@ async function dispatchPluginRegistry(cmd: string, args: string[]): Promise<void
       }
     }
     if (!isOracle) {
-      console.error(`\x1b[31m✗\x1b[0m unknown command: ${args[0]}`);
-      if (closeCandidates.length > 0) {
-        console.error(`  did you mean: ${closeCandidates.join(", ")}?`);
-      } else {
-        console.error(`  run 'maw --help' to see available commands`);
-      }
+      const hint = closeCandidates.length > 0
+        ? `did you mean: ${closeCandidates.join(", ")}?`
+        : `run 'maw --help' to see available commands`;
+      console.error(formatError(`unknown command: ${args[0]}`, hint));
       // UserError: output already printed above; top-level catch just
       // exits 1 without bun's default stack trace (alpha.66 polish).
       throw new UserError(`unknown command: ${args[0]}`);

--- a/src/cli/route-comm.ts
+++ b/src/cli/route-comm.ts
@@ -3,6 +3,7 @@ import { homedir } from "os";
 import { join } from "path";
 import { cmdSend } from "../commands/shared/comm";
 import { UserError } from "../core/util/user-error";
+import { formatError } from "../lib/format-error";
 
 // #1149 — `--inbox` mode writes directly to Claude Code's teammate inbox file
 // (`~/.claude/teams/<team>/inboxes/<agent>.json`) instead of injecting via
@@ -84,9 +85,10 @@ export async function routeComm(cmd: string, args: string[]): Promise<boolean> {
       throw new UserError("missing target and message");
     }
     if (!msgArgs.length) {
-      console.error(`✗ missing message for target '${target}'`);
-      console.error(`  maw hey ${target} <message>`);
-      console.error(`  (if '${target}' isn't a valid target, run 'maw ls' to see available ones)`);
+      console.error(formatError(
+        `missing message for target '${target}'`,
+        `maw hey ${target} <message>  (if '${target}' isn't a valid target, run 'maw ls' to see available ones)`,
+      ));
       throw new UserError(`missing message for '${target}'`);
     }
 
@@ -95,8 +97,10 @@ export async function routeComm(cmd: string, args: string[]): Promise<boolean> {
     //  semantics for inbox writes — single-host file IPC)
     if (inboxFlag) {
       if (!teamName) {
-        console.error(`✗ --inbox requires --team <name> or CLAUDE_CODE_TEAM_NAME env`);
-        console.error(`  maw hey <agent> <message> --inbox --team <team-name>`);
+        console.error(formatError(
+          `--inbox requires --team <name> or CLAUDE_CODE_TEAM_NAME env`,
+          `maw hey <agent> <message> --inbox --team <team-name>`,
+        ));
         throw new UserError("--inbox missing --team");
       }
       const path = writeInboxMessage(teamName, target, fromTag, msgArgs.join(" "));

--- a/src/cli/route-tools.ts
+++ b/src/cli/route-tools.ts
@@ -123,8 +123,11 @@ export async function routeTools(cmd: string, args: string[]): Promise<boolean> 
     const unknownFlag = filteredArgs.find(a => a.startsWith("-"));
     if (unknownFlag) {
       const { UserError } = await import("../core/util/user-error");
-      console.error(`\x1b[31m✗\x1b[0m unknown flag '${unknownFlag}' for 'maw serve'`);
-      console.error(`  usage: maw serve [port] [--as <name>]  (run 'maw serve --help' for more)`);
+      const { formatError } = await import("../lib/format-error");
+      console.error(formatError(
+        `unknown flag '${unknownFlag}' for 'maw serve'`,
+        `usage: maw serve [port] [--as <name>]  (run 'maw serve --help' for more)`,
+      ));
       throw new UserError(`unknown flag '${unknownFlag}'`);
     }
     const portArg = filteredArgs.find(a => /^\d+$/.test(a));

--- a/src/commands/plugins/oracle/impl-rename.ts
+++ b/src/commands/plugins/oracle/impl-rename.ts
@@ -21,6 +21,7 @@ import { existsSync, readFileSync, writeFileSync, renameSync, readdirSync, copyF
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { hostExec, FLEET_DIR } from "../../../sdk";
+import { formatError } from "../../../lib/format-error";
 
 interface RenameOpts {
   org?: string;
@@ -70,7 +71,7 @@ export async function cmdOracleRename(oldName: string, newName: string, opts: Re
   // 1. Validate names
   const validationError = validateRename(oldName, newName);
   if (validationError) {
-    console.error(`\x1b[31merror\x1b[0m: ${validationError}`);
+    console.error(formatError(validationError));
     process.exit(1);
   }
 
@@ -97,7 +98,7 @@ export async function cmdOracleRename(oldName: string, newName: string, opts: Re
       await hostExec(`ghq get -u ${org}/${newName}-oracle 2>&1`);
       console.log(`\x1b[32m  ✓\x1b[0m cloned to new path`);
     } catch (e: any) {
-      console.error(`\x1b[31m  ✗\x1b[0m ghq get failed: ${e?.message?.split("\n")[0] || e}`);
+      console.error(formatError(`ghq get failed: ${e?.message?.split("\n")[0] || e}`));
     }
   }
 

--- a/src/commands/plugins/plugin/build-impl.ts
+++ b/src/commands/plugins/plugin/build-impl.ts
@@ -25,6 +25,7 @@ import { join, resolve, basename } from "path";
 import { spawnSync } from "child_process";
 import { parseFlags } from "../../../cli/parse-args";
 import { inferCapabilitiesAst } from "../../../plugin/cap-infer-ast";
+import { formatError } from "../../../lib/format-error";
 
 // ─── Capability inference ────────────────────────────────────────────────────
 
@@ -132,7 +133,7 @@ async function runWatch(dir: string, emitTypes = false): Promise<void> {
     try {
       await runBuild(dir, emitTypes);
     } catch (e: any) {
-      console.error(`\x1b[31m✗\x1b[0m rebuild failed: ${e.message}`);
+      console.error(formatError(`rebuild failed: ${e.message}`));
     } finally {
       building = false;
     }

--- a/src/commands/plugins/plugin/install-manifest-helpers.ts
+++ b/src/commands/plugins/plugin/install-manifest-helpers.ts
@@ -7,6 +7,7 @@ import { existsSync, readFileSync, readdirSync, statSync } from "fs";
 import { join } from "path";
 import { parseManifest } from "../../../plugin/manifest";
 import { runtimeSdkVersion } from "../../../plugin/registry";
+import { formatError } from "../../../lib/format-error";
 
 /**
  * #864 — Resolve the plugin root inside an extracted staging dir.
@@ -78,13 +79,13 @@ export function findMonorepoPluginRoot(stagingDir: string, subpath: string): str
 export function readManifest(dir: string): PluginManifest | null {
   const manifestPath = join(dir, "plugin.json");
   if (!existsSync(manifestPath)) {
-    console.error(`\x1b[31m✗\x1b[0m no plugin.json at ${dir}`);
+    console.error(formatError(`no plugin.json at ${dir}`));
     return null;
   }
   try {
     return parseManifest(readFileSync(manifestPath, "utf8"), dir);
   } catch (e: any) {
-    console.error(`\x1b[31m✗\x1b[0m invalid plugin.json: ${e.message}`);
+    console.error(formatError(`invalid plugin.json: ${e.message}`));
     return null;
   }
 }

--- a/src/commands/plugins/split/impl.ts
+++ b/src/commands/plugins/split/impl.ts
@@ -1,6 +1,7 @@
 import { listSessions, hostExec, withPaneLock } from "../../../sdk";
 import { resolveSessionTarget } from "../../../core/matcher/resolve-target";
 import { normalizeTarget } from "../../../core/matcher/normalize-target";
+import { formatError } from "../../../lib/format-error";
 
 export interface SplitOpts {
   /** Split percentage (1-99). Default: 50. */
@@ -66,22 +67,20 @@ export async function cmdSplit(target: string, opts: SplitOpts = {}) {
     const r = resolveSessionTarget(target, sessions);
 
     if (r.kind === "ambiguous") {
-      console.error(`  \x1b[31m✗\x1b[0m '${target}' is ambiguous — matches ${r.candidates.length} sessions:`);
+      console.error(formatError(
+        `'${target}' is ambiguous — matches ${r.candidates.length} sessions`,
+        `use the full name: maw split <exact-session>`,
+      ));
       for (const s of r.candidates) {
         console.error(`  \x1b[90m    • ${s.name}\x1b[0m`);
       }
-      console.error(`  \x1b[90m  use the full name: maw split <exact-session>\x1b[0m`);
       throw new Error(`'${target}' is ambiguous`);
     }
     if (r.kind === "none") {
-      console.error(`  \x1b[31m✗\x1b[0m session '${target}' not found in fleet`);
-      if (r.hints?.length) {
-        console.error(`  \x1b[90mdid you mean:\x1b[0m`);
-        for (const h of r.hints) {
-          console.error(`  \x1b[90m    • ${h.name}\x1b[0m`);
-        }
-      }
-      console.error(`  \x1b[90m  try: maw ls\x1b[0m`);
+      console.error(formatError(
+        `session '${target}' not found in fleet`,
+        r.hints?.length ? `did you mean ${r.hints.map(h => h.name).join(", ")}? (try: maw ls)` : `try: maw ls`,
+      ));
       throw new Error(`session '${target}' not found in fleet`);
     }
 

--- a/src/commands/plugins/team/team-lifecycle.ts
+++ b/src/commands/plugins/team/team-lifecycle.ts
@@ -3,6 +3,7 @@ import { join } from "path";
 import { tmux } from "../../../sdk";
 import { assertValidOracleName } from "../../../core/fleet/validate";
 import { TEAMS_DIR, loadTeam, resolvePsi, writeShutdownRequest, cleanupTeamDir, type TeamConfig, type TeamMember } from "./team-helpers";
+import { formatError } from "../../../lib/format-error";
 
 const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
 
@@ -87,7 +88,7 @@ export async function cmdTeamShutdown(name: string, opts: { force?: boolean; mer
       sendShutdown(name, m.name, "team teardown via maw team shutdown");
       console.log(`  \x1b[90m↪ shutdown → ${m.name} (${m.tmuxPaneId})\x1b[0m`);
     } catch (e) {
-      console.error(`  \x1b[31m✗\x1b[0m failed to send shutdown to ${m.name}: ${e}`);
+      console.error(formatError(`failed to send shutdown to ${m.name}: ${e}`));
     }
   }
 
@@ -111,7 +112,10 @@ export async function cmdTeamShutdown(name: string, opts: { force?: boolean; mer
       await tmux.killPane(m.tmuxPaneId!);
       console.log(`  \x1b[33m⚠\x1b[0m force-killed ${m.name} (${m.tmuxPaneId})`);
     } else {
-      console.error(`  \x1b[31m✗\x1b[0m ${m.name} did not respond to shutdown_request (use --force to kill)`);
+      console.error(formatError(
+        `${m.name} did not respond to shutdown_request`,
+        `use --force to kill`,
+      ));
     }
   }
 

--- a/src/commands/shared/fleet-sync.ts
+++ b/src/commands/shared/fleet-sync.ts
@@ -3,6 +3,7 @@ import { existsSync, unlinkSync, symlinkSync, mkdirSync, readdirSync } from "fs"
 import { tmux, FLEET_DIR } from "../../sdk";
 import { getGhqRoot } from "../../config/ghq-root";
 import { loadFleetEntries, getSessionNames } from "./fleet-load";
+import { formatError } from "../../lib/format-error";
 
 export async function cmdFleetSync() {
   const entries = loadFleetEntries();
@@ -59,7 +60,7 @@ export async function cmdFleetSyncConfigs() {
   const repoFleetDir = join(import.meta.dir, "..", "..", "fleet");
 
   if (!existsSync(repoFleetDir)) {
-    console.error(`  \x1b[31m✗\x1b[0m No fleet/ directory found in repo`);
+    console.error(formatError(`No fleet/ directory found in repo`));
     process.exit(1);
   }
 

--- a/src/commands/shared/plugin-create-cmd.ts
+++ b/src/commands/shared/plugin-create-cmd.ts
@@ -4,6 +4,7 @@ import { homedir } from "os";
 import { validatePluginName } from "./plugin-create-scaffold";
 import { scaffoldRust } from "./plugin-create-rust";
 import { scaffoldAs } from "./plugin-create-as";
+import { formatError } from "../../lib/format-error";
 
 export async function cmdPluginCreate(
   name: string | undefined,
@@ -36,7 +37,7 @@ export async function cmdPluginCreate(
   }
   const nameErr = validatePluginName(name);
   if (nameErr) {
-    console.error(`\x1b[31m✗\x1b[0m Invalid plugin name: ${nameErr}`);
+    console.error(formatError(`Invalid plugin name: ${nameErr}`));
     process.exit(1);
   }
 
@@ -47,7 +48,7 @@ export async function cmdPluginCreate(
       : join(homedir(), ".oracle", "plugins", name));
 
   if (existsSync(dest)) {
-    console.error(`\x1b[31m✗\x1b[0m Destination already exists: ${dest}`);
+    console.error(formatError(`Destination already exists: ${dest}`));
     process.exit(1);
   }
 
@@ -62,7 +63,7 @@ export async function cmdPluginCreate(
       scaffoldAs(name, dest);
     }
   } catch (err: any) {
-    console.error(`\x1b[31m✗\x1b[0m ${err.message}`);
+    console.error(formatError(err.message));
     process.exit(1);
   }
 

--- a/src/lib/format-error.ts
+++ b/src/lib/format-error.ts
@@ -1,0 +1,28 @@
+// #1114 — Canonical CLI error format.
+//
+// RFC: maw-js CLI previously had three drifting error styles:
+//   1. red-✗  — `\x1b[31m✗\x1b[0m message`  (most common; no semantic prefix)
+//   2. bare-✗ — `✗ message`                  (uncolored; visually inconsistent)
+//   3. red "error:" prefix — already used by impl-rename.ts                       ← canonical
+//
+// Decision: standardize on the red `error:` prefix (Rust/cargo-style). It's
+// machine-greppable, screen-reader-friendly, and decouples the visual marker
+// from the word semantic. Optional dim hint on the next line for actionable
+// remediation. ✗ glyphs remain valid for non-error inline status (warnings,
+// progress markers).
+//
+// Format (canonical):
+//   error: <message>
+//     hint: <optional-hint>
+//
+// ANSI: red on `error`, default on message; dim on the hint line.
+// No trailing newline — the caller is responsible (matches console.error).
+
+const RED = "\x1b[31m";
+const DIM = "\x1b[90m";
+const RESET = "\x1b[0m";
+
+export function formatError(msg: string, hint?: string): string {
+  const main = `${RED}error${RESET}: ${msg}`;
+  return hint ? `${main}\n${DIM}  hint: ${hint}${RESET}` : main;
+}

--- a/test/format-error.test.ts
+++ b/test/format-error.test.ts
@@ -1,0 +1,37 @@
+// #1114 — formatError shape + hint formatting.
+import { describe, expect, test } from "bun:test";
+import { formatError } from "../src/lib/format-error";
+
+describe("formatError (#1114)", () => {
+  test("renders red 'error:' prefix without hint", () => {
+    const out = formatError("something broke");
+    expect(out).toBe("\x1b[31merror\x1b[0m: something broke");
+  });
+
+  test("appends dim hint line when provided", () => {
+    const out = formatError("session not found", "run 'maw ls'");
+    expect(out).toBe(
+      "\x1b[31merror\x1b[0m: session not found\n\x1b[90m  hint: run 'maw ls'\x1b[0m",
+    );
+  });
+
+  test("hint is omitted when undefined", () => {
+    const out = formatError("oops", undefined);
+    expect(out.includes("hint:")).toBe(false);
+    expect(out.includes("\n")).toBe(false);
+  });
+
+  test("preserves message verbatim (no trimming, no extra punctuation)", () => {
+    const msg = "  spaced  message  ";
+    const out = formatError(msg);
+    expect(out).toBe(`\x1b[31merror\x1b[0m: ${msg}`);
+  });
+
+  test("ANSI reset closes color spans for both lines", () => {
+    const out = formatError("a", "b");
+    // Each opener has a matching reset.
+    const opens = (out.match(/\x1b\[(31|90)m/g) || []).length;
+    const closes = (out.match(/\x1b\[0m/g) || []).length;
+    expect(opens).toBe(closes);
+  });
+});


### PR DESCRIPTION
First wave of error-format unification. Adds `src/lib/format-error.ts` with cargo-style `error: <msg>` + optional dim `hint:`. Sweeps 10 files. Remaining ~25 call-sites in follow-up PR.

Tests: 5/5 new in test/format-error.test.ts; build clean; full suite 1211 pass (4 unrelated pre-existing failures verified via stash).

Excluded files (other swarm agents own): command.ts, wake-cmd.ts, comm-send.ts, fleet-adopt.ts, stall-detect.ts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)