### PR TITLE
feat(wake): add --no-attach flag + remove [y/N] prompt

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -146,6 +146,7 @@ export async function invokeDirectHandler(
       "--incubate": String,
       "--fresh": Boolean,
       "--attach": Boolean, "-a": "--attach",
+      "--no-attach": Boolean,
       "--list": Boolean,
       "--split": Boolean,
       "--all-local": Boolean,
@@ -156,7 +157,7 @@ export async function invokeDirectHandler(
     const positional = flags._;
     const oracle = positional[0];
     if (!oracle) {
-      console.error("usage: maw wake <oracle> [--task <s>] [--wt <s>] [-p|--prompt <s>] [--incubate <slug>] [--fresh] [-a|--attach] [--list] [--split] [--all-local] [-e|--engine <name>] [--dry-run]");
+      console.error("usage: maw wake <oracle> [--task <s>] [--wt <s>] [-p|--prompt <s>] [--incubate <slug>] [--fresh] [-a|--attach] [--no-attach] [--list] [--split] [--all-local] [-e|--engine <name>] [--dry-run]");
       throw new UserError("wake: missing oracle name");
     }
 
@@ -185,6 +186,7 @@ export async function invokeDirectHandler(
       incubate?: string;
       fresh?: boolean;
       attach?: boolean;
+      noAttach?: boolean;
       listWt?: boolean;
       split?: boolean;
       allLocal?: boolean;
@@ -196,6 +198,7 @@ export async function invokeDirectHandler(
     if (flags["--incubate"]) opts.incubate = flags["--incubate"];
     if (flags["--fresh"]) opts.fresh = true;
     if (flags["--attach"]) opts.attach = true;
+    if (flags["--no-attach"]) opts.noAttach = true;
     if (flags["--list"]) opts.listWt = true;
     if (flags["--split"]) opts.split = true;
     if (flags["--all-local"]) opts.allLocal = true;

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -10,7 +10,7 @@ import { attachToSession, ensureSessionRunning, createWorktree } from "./wake-se
 import { maybeSplit } from "./wake-maybe-split";
 import { parseWakeTarget, ensureCloned } from "./wake-target";
 
-export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; split?: boolean; repoPath?: string; urlRepoName?: string; allLocal?: boolean; engine?: string }): Promise<string> {
+export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; noAttach?: boolean; listWt?: boolean; split?: boolean; repoPath?: string; urlRepoName?: string; allLocal?: boolean; engine?: string }): Promise<string> {
   // #1151 — reject flag-shaped names. parseFlags lands unrecognized flags
   // (e.g. --help) in positional `_`, so they reach here as oracle="--help"
   // and (without this guard) get sanitized into session names like `26---help`.
@@ -18,6 +18,11 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
     console.error(`\x1b[31m✗\x1b[0m invalid oracle name: "${oracle}" — did you mean 'maw --help'?`);
     throw new UserError(`invalid oracle name: "${oracle}"`);
   }
+
+  // --no-attach wins over --attach; normalize early so all downstream
+  // `opts.attach` checks honor caller intent. Lets api/sessions.ts and
+  // friends pass `noAttach: true` cleanly without needing `attach: false`.
+  if (opts.noAttach) opts.attach = false;
 
   // Canonicalize the bare name before any lookup — strips trailing `/`, `/.git`, `/.git/`
   // so `maw wake token-oracle/` (tab-completion artifact) resolves the same as `token-oracle`.
@@ -276,18 +281,6 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
       }
 
       console.log(`\x1b[32m⚡\x1b[0m '${existingWindow}' running in ${session}`);
-      if (!opts.attach && process.stdin.isTTY) {
-        process.stdout.write(`  attach? [y/N] `);
-        const { openSync, readSync, closeSync } = await import("fs");
-        try {
-          const fd = openSync("/dev/tty", "r");
-          const buf = Buffer.alloc(8);
-          const n = readSync(fd, buf, 0, buf.length, null);
-          closeSync(fd);
-          const answer = buf.slice(0, n).toString().trim().toLowerCase();
-          if (answer === "y" || answer === "yes") opts.attach = true;
-        } catch {}
-      }
       if (opts.attach) {
         await tmux.selectWindow(target);
         await attachToSession(session);


### PR DESCRIPTION
## Summary

- Adds explicit `--no-attach` CLI flag for symmetry with `-a`/`--attach`
- Removes the [y/N] interactive prompt added 5 days ago in `6c187f5d` — it interrupted scripted callers (`comm-send`, `pulse-cmd`) and re-introduced an interactive default after the 2026-04-14 flip (`aab2a233`) deliberately removed auto-attach
- Honors `noAttach: true` already passed by `src/api/sessions.ts:191,375` — silently dropped pre-this-change because the field wasn't on the opts type
- **Default behavior unchanged**: still no attach. Use `-a`/`--attach` to attach.

## Why now

- Yesterday's wake-attach archaeology + design rounds converged on this as the lowest-risk improvement — closes the 5-caller drift bug for free, removes the last interactive surprise, doesn't lock in any architectural decision (PATH C in the plan-room).
- The [y/N] prompt was the only remaining interactive default after the aab2a233 flip; removing it restores the full no-attach intent.
- 5 callers across the codebase (`api/sessions×2`, `auto-restore`, `fleet`, `comm-send`, `pulse-cmd`) all benefit silently.

## Test plan

- [x] `MAW_TEST_MODE=1 bun test test/wake-flags.test.ts` — 11/11 pass (existing `--no-attach` cases now exercise real production wiring instead of the test-local builder)
- [x] `bash scripts/test-isolated.sh` — 79/79 pass
- [x] Main suite delta: 0 regressions (9 pre-existing failures in tmux transport + curlFetch HMAC are unrelated to wake)
- [x] Local install + smoke: `maw wake --no-attach <oracle>` parses cleanly, usage shows the flag

## Diff scope

- `src/commands/shared/wake-cmd.ts`: +6 / -13 (add `noAttach?: boolean` to opts type, add normalization line, delete 12-line [y/N] block)
- `src/cli/top-aliases.ts`: +4 / -1 (add `--no-attach` to parseFlags, opts type, wiring, usage string)
- **Net: +10 / -14 = -4 LOC**

🤖 Generated with [Claude Code](https://claude.com/claude-code)