### PR TITLE
fix(exports): add ./commands/shared/should-auto-wake subpath (#1176)

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "./commands/shared/fleet-load": "./src/commands/shared/fleet-load.ts",
     "./commands/shared/queue-store": "./src/commands/shared/queue-store.ts",
     "./commands/shared/scan-signals": "./src/commands/shared/scan-signals.ts",
+    "./commands/shared/should-auto-wake": "./src/commands/shared/should-auto-wake.ts",
     "./commands/shared/wake": "./src/commands/shared/wake.ts",
     "./commands/shared/wake-resolve": "./src/commands/shared/wake-resolve.ts",
     "./commands/shared/wake-target": "./src/commands/shared/wake-target.ts",


### PR DESCRIPTION
Closes #1176.

## Summary

`bud-wake.ts:83` imports `maw-js/commands/shared/should-auto-wake` (added in #835), but the subpath was never added to `package.json` `exports`. Bun resolves strictly → `Cannot find module` → `maw bud` (and the new `maw awaken` plugin) cannot complete the wake step.

The file already exists on disk (`src/commands/shared/should-auto-wake.ts`). Only the 1-line allow-list entry was missing.

## Diff

```diff
   "./commands/shared/scan-signals": "./src/commands/shared/scan-signals.ts",
+  "./commands/shared/should-auto-wake": "./src/commands/shared/should-auto-wake.ts",
   "./commands/shared/wake": "./src/commands/shared/wake.ts",
```

## Test plan

- [x] Verified by re-running `maw awaken awaken-smoke-pilot --root` end-to-end on this branch:
  - bud → wake → `/awaken` → identity ritual → PR #1 → MERGED (sha `01dc653c`)
- [ ] Existing `bun test test/build-command-*.test.ts` should be unaffected (exports change only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)