### PR TITLE
fix(command): engine-aware --continue auto-inject for claude wakes (#1174)

### DIFF
--- a/src/config/command.ts
+++ b/src/config/command.ts
@@ -86,12 +86,29 @@ export function buildCommand(agentName: string, optsOrEngine?: string | BuildCom
     if (opts.permissionMode !== "relay" && !cmd.includes("--dangerously-skip-permissions")) {
       cmd += " --dangerously-skip-permissions";
     }
-    if (!cmd.includes("--continue") && !cmd.includes("--resume")) {
-      cmd += " --continue";
-    }
   }
   if (opts.devChannels) {
     cmd += " --dangerously-load-development-channels";
+  }
+
+  // #1174 — `--continue` is the default for ALL claude wakes (not just
+  // channel-enabled bots), so `maw wake <oracle>` resumes the prior
+  // conversation in that oracle's cwd instead of starting fresh.
+  //
+  // Engine-aware guard: only inject for `claude` commands. `codex` (and any
+  // other non-claude engine in `commands.<engine>`) doesn't recognize
+  // `--continue`, and the `||` fallback below only fires on non-zero exit —
+  // codex may silently ignore unknown flags, never tripping the fallback.
+  // The simplest safe rule: cmd must start with `claude` (after optional env-
+  // var prefix from `channelEnv`).
+  const cmdPart = cmd.replace(/^(?:[A-Z_][A-Z0-9_]*=(?:'[^']*'|\S*)\s+)+/, "");
+  const isClaudeEngine = cmdPart.startsWith("claude");
+  if (
+    isClaudeEngine &&
+    !cmd.includes("--continue") &&
+    !cmd.includes("--resume")
+  ) {
+    cmd += " --continue";
   }
 
   // Strip --dangerously-skip-permissions when running as root (#181)

--- a/test/build-command-contract.test.ts
+++ b/test/build-command-contract.test.ts
@@ -60,9 +60,15 @@ const wrap = (cmd: string) => cmd + RESET;
 const wrapFallback = (primary: string, fallback: string) => `{ ${primary} || ${fallback}; }${RESET}`;
 
 describe("buildCommand — post-#541 contract", () => {
-  test("returns bare default when no --continue (#1091 reset suffix)", () => {
+  test("auto-injects --continue + fallback when default is bare 'claude' (#1174)", () => {
+    // #1174 — `--continue` is the default for ALL claude wakes (engine-aware).
+    // Bare "claude" config now produces the wrapped fallback form so a fresh
+    // wake resumes the prior conversation in that oracle's cwd, falling back
+    // to bare claude when no prior session exists.
     fakeConfig.commands = { default: "claude" };
-    expect(buildCommand("any-agent")).toBe(wrap("claude"));
+    expect(buildCommand("any-agent")).toBe(
+      wrapFallback("claude --continue", "claude"),
+    );
   });
 
   test("emits || fallback when default has --continue (#1091 reset suffix)", () => {
@@ -122,9 +128,12 @@ describe("buildCommand — post-#541 contract", () => {
     expect(buildCommand("any-agent", "codex")).toBe(wrap("codex --search"));
   });
 
-  test("engine param falls back to default when engine not in config", () => {
+  test("engine param falls back to default when engine not in config (#1174 fallback for claude)", () => {
     fakeConfig.commands = { default: "claude" };
-    expect(buildCommand("any-agent", "gemini")).toBe(wrap("claude"));
+    // Falls back to default "claude" → #1174 auto-injects --continue.
+    expect(buildCommand("any-agent", "gemini")).toBe(
+      wrapFallback("claude --continue", "claude"),
+    );
   });
 
   test("engine param skips pattern matching", () => {
@@ -135,6 +144,44 @@ describe("buildCommand — post-#541 contract", () => {
   test("buildCommandInDir passes engine through", () => {
     fakeConfig.commands = { default: "claude", codex: "codex --search" };
     expect(buildCommandInDir("foo", "/tmp", "codex")).toBe(wrap("codex --search"));
+  });
+
+  // #1174 — engine-aware --continue auto-inject for claude wakes.
+
+  test("#1174: non-channel claude wake auto-injects --continue (positive case)", () => {
+    fakeConfig.commands = { default: "claude --dangerously-skip-permissions" };
+    const out = buildCommand("any-agent");
+    expect(out).toContain("--continue");
+    expect(out).toContain("||"); // wrapped with fallback
+    expect(out).toBe(
+      wrapFallback(
+        "claude --dangerously-skip-permissions --continue",
+        "claude --dangerously-skip-permissions",
+      ),
+    );
+  });
+
+  test("#1174: codex (non-claude) engine does NOT get --continue (engine-aware guard)", () => {
+    // codex doesn't recognize --continue, and its silent-ignore behavior
+    // would defeat the || fallback. Guard ensures only `claude` cmds get it.
+    fakeConfig.commands = { default: "claude", codex: "codex --search" };
+    expect(buildCommand("any-agent", "codex")).toBe(wrap("codex --search"));
+    expect(buildCommand("any-agent", "codex")).not.toContain("--continue");
+  });
+
+  test("#1174: pattern-matched non-claude command does NOT get --continue", () => {
+    // Pattern `foo-*` resolves to `echo hi` — not claude, no --continue.
+    fakeConfig.commands = { default: "claude", "foo-*": "echo hi" };
+    expect(buildCommand("foo-bar")).toBe(wrap("echo hi"));
+    expect(buildCommand("foo-bar")).not.toContain("--continue");
+  });
+
+  test("#1174: claude command with channelEnv prefix still gets --continue", () => {
+    // Env-var prefix shouldn't fool the engine detector (e.g. via channelEnv).
+    fakeConfig.commands = { default: "claude" };
+    const out = buildCommand("any-agent", { channelEnv: { DISCORD_STATE_DIR: "~/.claude/channels/foo" } });
+    expect(out).toContain("DISCORD_STATE_DIR=");
+    expect(out).toContain("--continue");
   });
 
   test("no direnv / CLAUDECODE / cd preamble anywhere in output", () => {


### PR DESCRIPTION
Closes #1174 (Phase 2 — code fix).

## Summary

`maw wake <claude-oracle>` previously did NOT auto-inject `--continue` for non-channel oracles, causing fresh Claude sessions instead of resuming prior conversation. The `--continue` injection (#1108) was gated to `if (opts.channels?.length)` only.

Fix: lift the injection out of the channels block + add an **engine-aware guard** (`cmd.startsWith("claude")` after stripping `channelEnv` prefix). Codex and other engines do NOT receive `--continue`.

## Diff

```diff
   if (opts.channels?.length) {
     cmd += " --channels " + opts.channels.join(" ");
     ...
-    if (!cmd.includes("--continue") && !cmd.includes("--resume")) {
-      cmd += " --continue";
-    }
   }

+  // #1174 — engine-aware --continue default for ALL claude wakes
+  const cmdPart = cmd.replace(/^(?:[A-Z_][A-Z0-9_]*=(?:'[^']*'|\S*)\s+)+/, "");
+  const isClaudeEngine = cmdPart.startsWith("claude");
+  if (isClaudeEngine && !cmd.includes("--continue") && !cmd.includes("--resume")) {
+    cmd += " --continue";
+  }
```

## Why engine-aware

Naive lift would break `commands.codex = "codex --search"` → `codex --search --continue` (codex doesn't know that flag and may silently ignore, defeating the `||` fallback at line 119-123). Engine-aware guard ensures only `claude` commands get `--continue`.

## Safety

The existing `||` fallback (line 119-123) already retries without `--continue` when it fails (fresh worktree, expired session). So even if a brand-new oracle has no prior Claude session in its cwd, the wake gracefully degrades to a fresh session.

## Tests

`test/build-command-contract.test.ts`: **35/35 green** (was 31, +4 #1174):
- ✅ non-channel claude wake auto-injects --continue (positive case)
- ✅ codex engine does NOT get --continue (engine-aware guard)
- ✅ pattern-matched non-claude command does NOT get --continue
- ✅ claude command with channelEnv prefix still gets --continue

Updated 2 existing tests:
- L63 "returns bare default when no --continue" → "auto-injects --continue + fallback when default is bare 'claude' (#1174)"
- L127 "engine param falls back to default" → reflects new wrapped-fallback form

Permission-mode + channel-env + cwd test files: **unaffected** (channels-with-permissionMode tests still pass since `--continue` is now added universally for claude, and they assert `--continue` presence).

## Verification

End-to-end via `maw awaken awaken-smoke-pilot --root` (maw-plugin-registry#13 smoke test):
- bud → wake → /awaken → identity → PR #1 → **MERGED** (sha `01dc653c`)
- Without this fix: would start fresh Claude session
- With this fix: prior history resumes when present (test repos had no prior history, fallback fired correctly)

## Test plan

- [x] `bun test test/build-command-*.test.ts` → 35/35 green
- [x] Wake regression test pass (30/30 in wake/build-command scope)
- [ ] Real wake on machine where the oracle has prior Claude history → resumes correctly
- [ ] Codex wake unaffected (verified via test, want operator confirmation)

## Out of scope

- Phase 1 white.local config patch already shipped via mawjs-oracle#6
- Bug B (`should-auto-wake` export) shipped via #1177

🤖 Generated with [Claude Code](https://claude.com/claude-code)