### PR TITLE
fix(fleet-load): skip malformed configs in loadFleetEntries (#1175)

### DIFF
--- a/src/commands/shared/fleet-load.ts
+++ b/src/commands/shared/fleet-load.ts
@@ -40,15 +40,20 @@ export function loadFleetEntries(): FleetEntry[] {
   const files = readdirSync(FLEET_DIR)
     .filter(f => f.endsWith(".json") && !f.endsWith(".disabled"))
     .sort();
-  return files.map(f => {
+  // #1175 — parity with loadFleet's #1133 filter: skip malformed configs
+  // (missing `name`) so downstream `entry.session.name.replace(...)` doesn't
+  // crash. Test fixtures from #484 (`{"writer":0}`, `{"a":1}`) were the
+  // re-trigger surfaced via maw bud → bud-init.ts:87 + bud-wake.ts:64.
+  return files.flatMap(f => {
     const raw = require(join(FLEET_DIR, f));
+    if (!raw || typeof raw.name !== "string") return [];
     const match = f.match(/^(\d+)-(.+)\.json$/);
-    return {
+    return [{
       file: f,
       num: match ? parseInt(match[1], 10) : 0,
       groupName: match ? match[2] : f.replace(".json", ""),
       session: raw as FleetSession,
-    };
+    }];
   });
 }
 


### PR DESCRIPTION
Closes #1175.

## Summary

`loadFleet()` filters malformed entries (PR #1133), but its sibling `loadFleetEntries()` doesn't. A single stray `fleet/*.json` without a top-level \`name\` field crashes every caller with `undefined is not an object (evaluating 'e.session.name.replace')`.

Surfaced live during smoke test of the new \`maw awaken\` plugin ([maw-plugin-registry#13](https://github.com/Soul-Brews-Studio/maw-plugin-registry/pull/13)) when two stale fixtures from #484 (\`{"writer":0}\` and \`{"a":1}\`) crashed bud's fleet config step.

## Diff

```diff
 export function loadFleetEntries(): FleetEntry[] {
   const files = readdirSync(FLEET_DIR)
     .filter(f => f.endsWith(".json") && !f.endsWith(".disabled"))
     .sort();
-  return files.map(f => {
+  // #1175 — parity with loadFleet's #1133 filter: skip malformed configs
+  // (missing \`name\`) so downstream \`entry.session.name.replace(...)\` doesn't
+  // crash. Test fixtures from #484 (\`{"writer":0}\`, \`{"a":1}\`) were the
+  // re-trigger surfaced via maw bud → bud-init.ts:87 + bud-wake.ts:64.
+  return files.flatMap(f => {
     const raw = require(join(FLEET_DIR, f));
+    if (!raw || typeof raw.name !== "string") return [];
     const match = f.match(/^(\d+)-(.+)\.json$/);
-    return {
+    return [{
       file: f,
       num: match ? parseInt(match[1], 10) : 0,
       groupName: match ? match[2] : f.replace(".json", ""),
       session: raw as FleetSession,
-    };
+    }];
   });
 }
```

## Why \`flatMap\` instead of \`filter\` + \`map\`

`flatMap + return []` skips malformed entries while still computing the per-file `file/num/groupName` derivation that `loadFleet`'s shape doesn't need. Functionally identical to `filter + map` but reads cleaner — single pass, no temp array.

## Affected callers (all now safe)

In \`maw-js\`:

| File | Sites | Pattern |
|------|-------|---------|
| \`commands/plugins/team/team-cleanup-zombies.ts\` | L73 | iterates entries |
| \`commands/plugins/tmux/impl.ts\` | L102, L182, L527, L645 | 4 iter sites |
| \`commands/plugins/fleet/fleet-adopt.ts\` | L38, L154 | 2 iter sites |
| \`commands/plugins/fleet/fleet-health.ts\` | L23 | `entry.session.name.replace(...)` |

In \`maw-plugin-registry\`:

| File | Sites |
|------|-------|
| \`archive/impl.ts:22\` | \`entries.find(e => e.session.name.replace(...))\` |
| \`bud/bud-init.ts:87\` | (same pattern) |
| \`bud/bud-wake.ts:64\` | \`entry.session.name.replace(/^\\d+-/, "")\` |
| \`cleanup/internal/team-cleanup-zombies.ts:73\` | iter |
| \`team/team-cleanup-zombies.ts:73\` | iter |

## Test plan

- [x] Empirical: \`maw awaken awaken-smoke-pilot --root\` end-to-end passed on this code path (smoke-test artifact: Soul-Brews-Studio/awaken-smoke-pilot-oracle PR #1, merged sha \`01dc653c\`)
- [x] Build/typecheck clean
- [ ] Unit test deferred — would need either child-process or pre-import \`MAW_HOME\` setup since \`FLEET_DIR\` is resolved at module load. Happy to add via child-process pattern in a follow-up if reviewers want it. Smoke-test E2E run is the strongest existing proof.
- [ ] Optional manual verify: \`echo '{"a":1}' > ~/.config/maw/fleet/garbage.json && maw bud test-stem --root --dry-run\` should now succeed (after this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)