### PR TITLE
feat(team): add --codex flag for Codex backend support

### DIFF
--- a/src/commands/plugins/team/index.ts
+++ b/src/commands/plugins/team/index.ts
@@ -114,13 +114,14 @@ general flags: --description <text>, --members <list>`,
       const color = colorIdx !== -1 ? args[colorIdx + 1] : undefined;
       const promptIdx = args.indexOf("--prompt");
       const exec = args.includes("--exec");
+      const codex = args.includes("--codex");
       // --prompt is greedy to end-of-argv; strip known flags if they appear in the tail
       let prompt: string | undefined;
       if (promptIdx !== -1) {
-        const tail = args.slice(promptIdx + 1).filter(a => a !== "--exec");
+        const tail = args.slice(promptIdx + 1).filter(a => a !== "--exec" && a !== "--codex");
         prompt = tail.join(" ") || undefined;
       }
-      await cmdTeamSpawn(args[1], args[2], { model, prompt, exec, type, color });
+      await cmdTeamSpawn(args[1], args[2], { model, prompt, exec, codex, type, color });
     } else if (sub === "send" || sub === "msg") {
       if (!args[1] || !args[2] || !args[3]) {
         logs.push("usage: maw team send <team> <agent> <message>");

--- a/src/commands/plugins/team/team-lifecycle.ts
+++ b/src/commands/plugins/team/team-lifecycle.ts
@@ -180,7 +180,7 @@ export function cmdTeamCreate(name: string, opts: { description?: string } = {})
 export async function cmdTeamSpawn(
   teamName: string,
   role: string,
-  opts: { model?: string; prompt?: string; exec?: boolean; type?: string; color?: string } = {},
+  opts: { model?: string; prompt?: string; exec?: boolean; codex?: boolean; type?: string; color?: string } = {},
 ) {
   const PSI = resolvePsi();
   const teamDir = join(PSI, "memory", "mailbox", "teams", teamName);
@@ -216,7 +216,8 @@ export async function cmdTeamSpawn(
   }
 
   // Build spawn prompt
-  const model = opts.model || "sonnet";
+  const isCodex = opts.codex === true;
+  const model = opts.model || (isCodex ? "gpt-5.5" : "sonnet");
   const parts: string[] = [];
   parts.push(`You are '${role}' on team '${teamName}'.`);
   if (opts.prompt) parts.push(opts.prompt);
@@ -242,7 +243,7 @@ export async function cmdTeamSpawn(
   if (existsSync(toolConfigPath)) {
     try {
       const toolConfig = JSON.parse(readFileSync(toolConfigPath, "utf-8"));
-      const member: TeamMember = { name: role, model };
+      const member: TeamMember = { name: role, model, backendType: isCodex ? "codex" : "claude" };
       if (!toolConfig.members.some((m: any) => m.name === role)) {
         toolConfig.members.push(member);
         // lgtm[js/file-system-race] — PRIVATE-PATH: tool config under ~/.maw/teams/<team>/ (#393), see docs/security/file-system-race-stance.md
@@ -289,7 +290,11 @@ export async function cmdTeamSpawn(
     try {
       const { spawnTeammatePane, colorAnsi } = await import("../tmux/layout-manager");
 
-      const result = await spawnTeammatePane(role, claudeCmd, { colorIndex: teammateCount });
+      const escapedPath = promptPath.replace(/'/g, "'\\''");
+      const agentCmd = isCodex
+        ? `codex exec --model ${model} -c approval_policy=never "$(cat '${escapedPath}')"`
+        : claudeCmd;
+      const result = await spawnTeammatePane(role, agentCmd, { colorIndex: teammateCount });
 
       // Persist pane state to tool store config (~/.claude/teams/)
       const toolConfigPath = join(TEAMS_DIR, teamName, "config.json");


### PR DESCRIPTION
## Summary

Add `--codex` flag to `maw team spawn` so teams can mix Claude and Codex (OpenAI) workers. When `--codex` is passed, spawns via `codex exec` CLI instead of `claude`, with `gpt-5.5` as default model. Activates the existing `TeamMember.backendType` field.

## Changes (2 files, +12 -6 lines)

### `src/commands/plugins/team/index.ts`
- Parse `--codex` CLI flag
- Pass `codex` to `cmdTeamSpawn` opts
- Strip `--codex` from greedy `--prompt` tail

### `src/commands/plugins/team/team-lifecycle.ts`
- Add `codex?: boolean` to opts type
- Model selection: `gpt-5.5` when codex, `sonnet` default
- Track `backendType: "codex" | "claude"` in TeamMember config
- Exec path branches: `codex exec --model ... -c approval_policy=never` vs `claudeCmd`

## Usage

```bash
# Claude (default)
maw team spawn myteam w1 --exec --prompt "implement feature X"

# Codex
maw team spawn myteam w2 --codex --exec --prompt "implement feature Y"

# Mixed team
maw team spawn myteam orchestrator --exec --prompt "coordinate"
maw team spawn myteam coder1 --codex --exec --prompt "module A"
maw team spawn myteam coder2 --codex --exec --prompt "module B"
```

## Test plan

- [x] `maw team spawn t w --exec` → spawns claude, model: sonnet
- [x] `maw team spawn t w --codex --exec` → spawns codex, model: gpt-5.5
- [x] `maw team shutdown t --force` → kills both backend types
- [x] TeamMember config persists `backendType: "codex"` in config.json

## Notes

- `TeamMember.backendType` already exists in `team-helpers.ts` — this PR wires it up
- Codex workers use `approval_policy=never` (autonomous, no interactive prompts)
- No changes to `team-helpers.ts` needed

⚡ Generated by Gale