### PR TITLE
fix(wake): route `maw wake all` to cmdWakeAll (regression from #918)

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -157,8 +157,27 @@ export async function invokeDirectHandler(
     const positional = flags._;
     const oracle = positional[0];
     if (!oracle) {
-      console.error("usage: maw wake <oracle> [--task <s>] [--wt <s>] [-p|--prompt <s>] [--incubate <slug>] [--fresh] [-a|--attach] [--no-attach] [--list] [--split] [--all-local] [-e|--engine <name>] [--dry-run]");
+      console.error("usage: maw wake <oracle> [--task <s>] [--wt <s>] [-p|--prompt <s>] [--incubate <slug>] [--fresh] [-a|--attach] [--no-attach] [--list] [--split] [--all-local] [-e|--engine <name>] [--dry-run]\n       maw wake all [--kill] [--all] [--resume]");
       throw new UserError("wake: missing oracle name");
+    }
+
+    // Pre-#918 the wake/ plugin handled `maw wake all` by routing to cmdWakeAll.
+    // When wake routing moved to top-aliases the early-route was lost, so "all"
+    // started resolving as a literal oracle name (#918 regression surfaced via
+    // pulse-oracle 2026-05-06 maw-boot incident). Restore the routing here.
+    if (oracle.toLowerCase() === "all") {
+      const allFlags = parseFlags(argv, {
+        "--kill": Boolean,
+        "--all": Boolean,
+        "--resume": Boolean,
+      }, 0);
+      const { cmdWakeAll } = await import("../commands/shared/fleet-wake");
+      await cmdWakeAll({
+        kill: !!allFlags["--kill"],
+        all: !!allFlags["--all"],
+        resume: !!allFlags["--resume"],
+      });
+      return;
     }
 
     if (flags["--dry-run"]) {

--- a/test/cli/wake-all-routing.test.ts
+++ b/test/cli/wake-all-routing.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Regression tests for `maw wake all` routing.
+ *
+ * Pre-#918 the wake/ plugin routed `maw wake all` to cmdWakeAll. When wake
+ * moved to top-aliases via the direct-handler path (#979949d7 follow-on),
+ * the early-route was lost — "all" started resolving as a literal oracle
+ * name. This surfaced in production as the maw-boot regression on
+ * 2026-05-06 (pulse-oracle inbox: 22:15 BKK ship report).
+ *
+ * Tests verify that invokeDirectHandler with positional "all" routes to
+ * cmdWakeAll (not cmdWake) and forwards the three supported flags.
+ */
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+
+// Capture cmdWakeAll + cmdWake invocations without spawning real tmux sessions.
+const wakeAllCalls: any[] = [];
+const wakeCalls: any[] = [];
+
+mock.module("../../src/commands/shared/fleet-wake", () => ({
+  cmdWakeAll: async (opts: any) => { wakeAllCalls.push(opts); },
+  cmdSleep: async () => {},
+}));
+
+mock.module("../../src/commands/shared/wake-cmd", () => ({
+  cmdWake: async (oracle: string, opts: any) => { wakeCalls.push({ oracle, opts }); return ""; },
+}));
+
+const { invokeDirectHandler } = await import("../../src/cli/top-aliases");
+
+const WAKE_HANDLER = "../commands/shared/wake-cmd:cmdWake";
+
+describe("`maw wake all` routing → cmdWakeAll", () => {
+  beforeEach(() => {
+    wakeAllCalls.length = 0;
+    wakeCalls.length = 0;
+  });
+
+  test("`wake all` routes to cmdWakeAll (not cmdWake)", async () => {
+    await invokeDirectHandler(WAKE_HANDLER, ["all"]);
+    expect(wakeAllCalls).toHaveLength(1);
+    expect(wakeAllCalls[0]).toEqual({ kill: false, all: false, resume: false });
+    expect(wakeCalls).toHaveLength(0);
+  });
+
+  test("`wake all --resume` forwards resume=true", async () => {
+    await invokeDirectHandler(WAKE_HANDLER, ["all", "--resume"]);
+    expect(wakeAllCalls).toHaveLength(1);
+    expect(wakeAllCalls[0]).toEqual({ kill: false, all: false, resume: true });
+    expect(wakeCalls).toHaveLength(0);
+  });
+
+  test("`wake all --kill` forwards kill=true", async () => {
+    await invokeDirectHandler(WAKE_HANDLER, ["all", "--kill"]);
+    expect(wakeAllCalls[0]).toEqual({ kill: true, all: false, resume: false });
+  });
+
+  test("`wake all --all` forwards all=true (include dormant 20+)", async () => {
+    await invokeDirectHandler(WAKE_HANDLER, ["all", "--all"]);
+    expect(wakeAllCalls[0]).toEqual({ kill: false, all: true, resume: false });
+  });
+
+  test("`wake all --kill --resume --all` forwards every flag", async () => {
+    await invokeDirectHandler(WAKE_HANDLER, ["all", "--kill", "--resume", "--all"]);
+    expect(wakeAllCalls[0]).toEqual({ kill: true, all: true, resume: true });
+  });
+
+  test("`wake ALL` (uppercase) still routes to cmdWakeAll", async () => {
+    await invokeDirectHandler(WAKE_HANDLER, ["ALL"]);
+    expect(wakeAllCalls).toHaveLength(1);
+    expect(wakeCalls).toHaveLength(0);
+  });
+
+  test("`wake neo` does NOT route to cmdWakeAll (single-oracle path)", async () => {
+    await invokeDirectHandler(WAKE_HANDLER, ["neo"]);
+    expect(wakeAllCalls).toHaveLength(0);
+    expect(wakeCalls).toHaveLength(1);
+    expect(wakeCalls[0].oracle).toBe("neo");
+  });
+});


### PR DESCRIPTION
## Summary

- Restore the `oracle === "all"` early-route to `cmdWakeAll` in `invokeDirectHandler` (regression introduced when the wake/ plugin was extracted in #918 and wake moved to top-aliases direct-handler dispatch).
- Re-parse argv against the cmdWakeAll flag set (`--kill`, `--all`, `--resume`) so fleet-wide flags reach `cmdWakeAll(opts)` instead of being permissively dropped onto `flags._`.
- Add `test/cli/wake-all-routing.test.ts` — mocks `cmdWake` + `cmdWakeAll`, asserts routing decisions for the regression case + each flag combination, plus the negation (`wake neo` must still hit `cmdWake`).

## The regression

Pre-#918 the wake/ plugin (`src/commands/plugins/wake/index.ts`) handled `maw wake all` with this early-route:

```ts
if (args[0].toLowerCase() === "all") {
  const flags = parseFlags(args, { "--kill": Boolean, "--all": Boolean, "--resume": Boolean }, 1);
  await cmdWakeAll({ kill: flags["--kill"], all: flags["--all"], resume: flags["--resume"] });
  return { ok: true, output: logs.join("\n") || undefined };
}
```

When wake routing moved to top-aliases via the direct-handler path (lean-core extract), the early-route was lost. `oracle = positional[0] = "all"` was passed as a literal oracle name to `cmdWake`, which then ran `resolveOracle("all", { allLocal: false })` against ghq — yielding either a "not found" error or, worse, a fuzzy-matched phantom repo.

## Production impact

Surfaced in production on 2026-05-06 as a maw-boot regression. The systemd unit's `ExecStart=bun run src/cli.ts wake all --resume` silently failed once the host upgraded past v26.5.1, leaving every Oracle session offline at boot. Pulse Oracle landed a workaround in [pulse-oracle#24](https://github.com/natman95/pulse-oracle/pull/24) — `scripts/maw-boot-wake.sh` shells `cmdWakeAll` directly via `bun -e` — and routed the upstream fix here.

## Test plan

- [x] `bun test test/cli/wake-all-routing.test.ts` — 7/7 pass
- [x] `bun test test/cli/` — 41/41 pass (no regression in `dispatch-match.test.ts` which also imports `top-aliases`)
- [x] `bun test test/fleet-wake-ssh-failsoft.test.ts test/fleet-plugin-wake.test.ts` — 21/21 pass (related plumbing)
- [x] Full `bun test` suite — 2299 pass / 452 fail vs. baseline 2292 / 459 (delta = +7 pass / -7 fail; matches the 7 new tests in this PR; no new failures)
- [ ] Smoke after merge: pulse-oracle reverts `scripts/maw-boot-wake.sh` shim and restores `ExecStart=bun run src/cli.ts wake all --resume`; `systemctl status maw-boot` should show `active (exited)`.

## Follow-up

Once this releases, pulse-oracle will:
1. Delete `scripts/maw-boot-wake.sh`
2. Revert `systemd/maw-boot.service` ExecStart to `bun run src/cli.ts wake all --resume`
3. Push closing PR + completion-report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)