### PR TITLE
fix(engine): run trigger intervals headlessly without a browser

### DIFF
--- a/src/engine/engine-intervals.ts
+++ b/src/engine/engine-intervals.ts
@@ -92,9 +92,10 @@ export function startIntervals(
   state.feedUnsub = () => state.feedListeners.delete(listener);
 }
 
-/** Stop all polling intervals when last WS client disconnects. No-op if clients remain. */
+/** Stop all polling intervals when last WS client disconnects. No-op if clients remain or triggers are configured. */
 export function stopIntervals(state: EngineIntervalState): void {
   if (state.clients.size > 0) return;
+  if (loadConfig().triggers?.length > 0) return;
   if (state.captureInterval) { clearInterval(state.captureInterval); state.captureInterval = null; }
   if (state.sessionInterval) { clearInterval(state.sessionInterval); state.sessionInterval = null; }
   if (state.previewInterval) { clearInterval(state.previewInterval); state.previewInterval = null; }

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -52,6 +52,8 @@ export class MawEngine {
     } catch {
       console.warn("[engine] session cache init failed — will retry on first WS connect");
     }
+    // Start intervals headlessly so triggers fire without a browser connected (#headless-triggers)
+    this.startIntervals();
   }
 
   on(type: string, handler: Handler) { this.handlers.set(type, handler); }

--- a/src/engine/status.ts
+++ b/src/engine/status.ts
@@ -64,7 +64,7 @@ export class StatusDetector {
     clients: Set<MawWS>,
     feedListeners: Set<(event: FeedEvent) => void>,
   ) {
-    if (clients.size === 0 || sessions.length === 0) return;
+    if (sessions.length === 0) return;
 
     const agents = sessions.flatMap(s =>
       s.windows.map(w => ({ target: `${s.name}:${w.index}`, name: w.name, session: s.name }))


### PR DESCRIPTION
## Problem

`maw on` triggers were silently no-ops unless a browser had the maw UI open at `localhost:3456`. In a headless server environment (VPS, CI, no GUI), triggers never fire.

## Root cause

Three interconnected guards all required `clients.size > 0`:

**1. `status.ts`** — `detect()` bailed when no WS clients, so no feed events flowed:
```ts
if (clients.size === 0 || sessions.length === 0) return; // ← blocked here
```
No feed events → `markAgentActive()` never called → idle timers never populated → idle triggers never fire.

**2. `engine-intervals.ts`** — `stopIntervals()` destroyed all intervals on last disconnect, including the idle-check `setInterval`.

**3. `engine/index.ts`** — `startIntervals()` was only called from `handleOpen` (WS connect), never at server boot. Engine never starts headlessly.

## Fix

**`status.ts`** — remove `clients.size === 0` guard. Detection always runs; broadcasting to WS clients still skips when none present:
```ts
- if (clients.size === 0 || sessions.length === 0) return;
+ if (sessions.length === 0) return;
```

**`engine-intervals.ts`** — preserve intervals when triggers are configured:
```ts
  if (state.clients.size > 0) return;
+ if (loadConfig().triggers?.length > 0) return;
```

**`engine/index.ts`** — start intervals at server boot, not first WS connect:
```ts
  private async initSessionCache() {
    // ... existing cache init ...
+   this.startIntervals(); // headless trigger support
  }
```

## Verified

```bash
# No browser, no WS clients
maw on micky idle --once --timeout 10 "tg-send 'fired headlessly'"
maw wake micky --wt test --task 'sleep 8'
# → server log: [trigger] one-time trigger fired and removed: on-micky-idle
# → TG notification received ✅
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)