### PR TITLE
release: v26.5.12-alpha.425 — fix #1186 plugin bootstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.12-alpha.635",
+  "version": "26.5.12-alpha.640",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.12-alpha.407",
+  "version": "26.5.12-alpha.425",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/cli/plugin-bootstrap.test.ts
+++ b/src/cli/plugin-bootstrap.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
 import {
   mkdirSync,
   mkdtempSync,
@@ -13,6 +13,25 @@ import {
 import { join } from "path";
 import { tmpdir } from "os";
 import { runBootstrap } from "./plugin-bootstrap";
+
+/**
+ * #1186 — `runBootstrap` now dynamic-imports `../config` so the multi-source
+ * resolver can read `bundledPluginSource`. paths.ts caches CONFIG_FILE on
+ * first load, so MAW_HOME must be sandboxed before any test calls
+ * runBootstrap. MAW_TEST_MODE=1 makes `persistBundledPath` a no-op as a
+ * second line of defence against corrupting the developer's real config.
+ */
+let configSandbox: string;
+beforeAll(() => {
+  configSandbox = mkdtempSync(join(tmpdir(), "maw-bootstrap-config-"));
+  process.env.MAW_HOME = configSandbox;
+  process.env.MAW_TEST_MODE = "1";
+});
+afterAll(() => {
+  try { rmSync(configSandbox, { recursive: true, force: true }); } catch {}
+  delete process.env.MAW_HOME;
+  delete process.env.MAW_TEST_MODE;
+});
 
 /**
  * Tests for #817 — bootstrap-on-empty.
@@ -212,6 +231,106 @@ describe("runBootstrap — #817 idempotent bundled-plugin symlinks", () => {
       expect(existsSync(join(pluginDir, "shellenv"))).toBe(true);
       expect(lstatSync(join(pluginDir, "shellenv")).isSymbolicLink()).toBe(true);
     } finally {
+      console.log = originalLog;
+    }
+  });
+});
+
+/**
+ * Tests for #1186 — multi-source resolver.
+ *
+ * The bug: the compiled binary's `import.meta.dir` no longer resolves to the
+ * source tree, so `<srcDir>/commands/plugins` doesn't exist and bundled
+ * plugins never re-symlink after `~/.maw/plugins/` is wiped.
+ *
+ * The fix: `runBootstrap` checks $MAW_BUNDLED_PLUGINS env first, then
+ * `config.bundledPluginSource`, then falls back to the srcDir hint.
+ */
+describe("runBootstrap — #1186 multi-source resolver", () => {
+  let workDir: string;
+  let srcDir: string;
+  let altBundled: string;
+  let pluginDir: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "maw-bootstrap-1186-"));
+    srcDir = join(workDir, "src");
+    altBundled = join(workDir, "alt-bundled-plugins");
+    pluginDir = join(workDir, "plugins");
+    mkdirSync(join(srcDir, "commands", "plugins"), { recursive: true });
+    mkdirSync(altBundled, { recursive: true });
+  });
+
+  afterEach(() => {
+    try { rmSync(workDir, { recursive: true, force: true }); } catch {}
+    delete process.env.MAW_BUNDLED_PLUGINS;
+  });
+
+  /** Create a plugin directory under `parent` that runBootstrap will accept. */
+  function makePlugin(parent: string, name: string): void {
+    const dir = join(parent, name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "plugin.json"), JSON.stringify({ name }));
+  }
+
+  it("env MAW_BUNDLED_PLUGINS overrides srcDir hint (compiled-binary case)", async () => {
+    // Bundled plugins exist at both paths — env override wins.
+    makePlugin(join(srcDir, "commands", "plugins"), "src-only");
+    makePlugin(altBundled, "alt-only");
+    process.env.MAW_BUNDLED_PLUGINS = altBundled;
+
+    await runBootstrap(pluginDir, srcDir);
+
+    const linked = readdirSync(pluginDir).sort();
+    expect(linked).toEqual(["alt-only"]);
+    expect(readlinkSync(join(pluginDir, "alt-only"))).toBe(join(altBundled, "alt-only"));
+  });
+
+  it("env MAW_BUNDLED_PLUGINS expands leading ~/", async () => {
+    // Stash a real bundled dir somewhere under HOME so the ~/ expansion has
+    // a target — we use the sandbox's own .maw-bundled subdir.
+    const homeRel = ".maw-bundled-test";
+    const homeAbs = join(process.env.HOME ?? "", homeRel);
+    mkdirSync(homeAbs, { recursive: true });
+    try {
+      makePlugin(homeAbs, "tilde-resolved");
+      process.env.MAW_BUNDLED_PLUGINS = `~/${homeRel}`;
+
+      await runBootstrap(pluginDir, srcDir);
+
+      expect(readdirSync(pluginDir).sort()).toEqual(["tilde-resolved"]);
+    } finally {
+      try { rmSync(homeAbs, { recursive: true, force: true }); } catch {}
+    }
+  });
+
+  it("missing MAW_BUNDLED_PLUGINS target → falls through to srcDir hint", async () => {
+    makePlugin(join(srcDir, "commands", "plugins"), "from-src");
+    process.env.MAW_BUNDLED_PLUGINS = "/nonexistent/path/that/does/not/exist";
+
+    await runBootstrap(pluginDir, srcDir);
+
+    expect(readdirSync(pluginDir).sort()).toEqual(["from-src"]);
+  });
+
+  it("no env + no srcDir bundled + empty pluginDir → warns, doesn't throw", async () => {
+    // Remove the bundled dir so the resolver returns null.
+    rmSync(join(srcDir, "commands", "plugins"), { recursive: true });
+
+    const originalWarn = console.warn;
+    const warns: string[] = [];
+    console.warn = (...args: unknown[]) => { warns.push(args.map(String).join(" ")); };
+    const originalLog = console.log;
+    console.log = () => {};
+
+    try {
+      await runBootstrap(pluginDir, srcDir);
+      expect(warns.some(w => w.includes("bundled-plugin source not found"))).toBe(true);
+      expect(warns.some(w => w.includes("#1186"))).toBe(true);
+      expect(existsSync(pluginDir)).toBe(true);
+      expect(readdirSync(pluginDir)).toEqual([]);
+    } finally {
+      console.warn = originalWarn;
       console.log = originalLog;
     }
   });

--- a/src/cli/plugin-bootstrap.ts
+++ b/src/cli/plugin-bootstrap.ts
@@ -1,8 +1,66 @@
 import { mkdirSync, existsSync, readdirSync, symlinkSync, cpSync, readFileSync, lstatSync, unlinkSync } from "fs";
 import { join } from "path";
+import { homedir } from "os";
 
 /** Allowlist: only http/https URLs may be used as plugin sources */
 const URL_SCHEME_RE = /^https?:\/\//;
+
+/** Expand a leading "~/" to the current user's home directory. */
+function expandHome(p: string): string {
+  return p.startsWith("~/") ? join(homedir(), p.slice(2)) : p;
+}
+
+/**
+ * Resolve the absolute path to the bundled-plugins directory.
+ *
+ * Priority (#1186):
+ *   1. `$MAW_BUNDLED_PLUGINS` — env override; escape hatch for tests and
+ *      distributed binaries that ship plugins alongside the executable.
+ *   2. `config.bundledPluginSource` — persisted by a prior source-mode boot
+ *      so the compiled binary keeps finding plugins after the binary has
+ *      replaced the bun-linked source path.
+ *   3. `<srcDirHint>/commands/plugins` — works in source / `bun link` mode
+ *      where `import.meta.dir` still resolves to the source tree.
+ *
+ * Returns the resolved path or null if none exist. Callers warn rather than
+ * throw so an already-populated `pluginDir` continues to work.
+ */
+async function resolveBundledPath(srcDirHint: string): Promise<string | null> {
+  const envPath = process.env.MAW_BUNDLED_PLUGINS;
+  if (envPath) {
+    const expanded = expandHome(envPath);
+    if (existsSync(expanded)) return expanded;
+  }
+
+  try {
+    const { loadConfig } = await import("../config");
+    const configured = loadConfig().bundledPluginSource;
+    if (configured) {
+      const expanded = expandHome(configured);
+      if (existsSync(expanded)) return expanded;
+    }
+  } catch {}
+
+  const fromSrc = join(srcDirHint, "commands", "plugins");
+  if (existsSync(fromSrc)) return fromSrc;
+
+  return null;
+}
+
+/**
+ * Persist the resolved bundled-plugins path to config when it came from the
+ * srcDir hint — that's the source / `bun link` boot recording its location
+ * for the later compiled-binary boot. Skipped under `MAW_TEST_MODE=1` to
+ * keep test runs from writing into the real config file.
+ */
+async function persistBundledPath(resolvedPath: string): Promise<void> {
+  if (process.env.MAW_TEST_MODE === "1") return;
+  try {
+    const { loadConfig, saveConfig } = await import("../config");
+    if (loadConfig().bundledPluginSource === resolvedPath) return;
+    saveConfig({ bundledPluginSource: resolvedPath });
+  } catch {}
+}
 
 /**
  * Auto-bootstrap plugins into pluginDir.
@@ -18,6 +76,10 @@ const URL_SCHEME_RE = /^https?:\/\//;
  *
  * Bug: #817 — bootstrap-on-empty caused new bundled plugins to be
  * silently invisible on every existing host until a manual symlink.
+ *
+ * Bug: #1186 — compiled binary lost the bundled-plugin path because
+ * `import.meta.dir` no longer pointed at the source tree. Multi-source
+ * resolver (`resolveBundledPath`) and source-mode auto-persist fix it.
  *
  * @param pluginDir  resolved ~/.maw/plugins/ path
  * @param srcDir     resolved src/ directory (pass import.meta.dir from cli.ts)
@@ -48,8 +110,8 @@ export async function runBootstrap(pluginDir: string, srcDir: string): Promise<v
 
   // 1. Symlink any bundled plugin missing from pluginDir — IDEMPOTENT,
   //    runs every boot. Cheap (fs stat + symlink), no network.
-  const bundled = join(srcDir, "commands", "plugins");
-  if (existsSync(bundled)) {
+  const bundled = await resolveBundledPath(srcDir);
+  if (bundled) {
     for (const d of readdirSync(bundled)) {
       const src = join(bundled, d);
       const dest = join(pluginDir, d);
@@ -59,6 +121,20 @@ export async function runBootstrap(pluginDir: string, srcDir: string): Promise<v
       if (existsSync(dest)) continue; // already linked / user dir / valid symlink
       symlinkSync(src, dest);
     }
+    // Source-mode boot? Persist the path so a later compiled-binary boot
+    // can find the bundled plugins even after `import.meta.dir` stops
+    // pointing at the source tree. Skip when the path came from env so
+    // a transient `MAW_BUNDLED_PLUGINS` doesn't overwrite stored config.
+    const fromSrc = join(srcDir, "commands", "plugins");
+    if (bundled === fromSrc && !process.env.MAW_BUNDLED_PLUGINS) {
+      await persistBundledPath(bundled);
+    }
+  } else if (wasEmpty) {
+    console.warn(
+      `[maw] bundled-plugin source not found — set MAW_BUNDLED_PLUGINS or ` +
+      `'bundledPluginSource' in maw.config.json to the absolute path of ` +
+      `src/commands/plugins in your maw-js checkout. (#1186)`,
+    );
   }
 
   // 2. Install from pluginSources URLs — first-install only (network calls,

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -149,6 +149,19 @@ export interface MawConfig {
   pin?: string;
   /** Plugin source URLs — auto-installed on bootstrap (nuke → first run) */
   pluginSources?: string[];
+  /**
+   * Absolute path to the bundled-plugins directory
+   * (`<maw-js-checkout>/src/commands/plugins`).
+   *
+   * Why: `runBootstrap` uses `import.meta.dir` from cli.ts to locate bundled
+   * plugins. That works in source / `bun link` mode, but the compiled binary's
+   * `import.meta.dir` points at the binary's filesystem location — which
+   * doesn't contain the `commands/plugins/` subtree. With this field set
+   * (auto-populated on the first source-mode boot, or set manually for
+   * distributed binaries), the compiled binary can still re-symlink the
+   * bundled plugins after `~/.maw/plugins/` is wiped. (#1186)
+   */
+  bundledPluginSource?: string;
   /** Plugin names to disable (skip during scanning and execution) */
   disabledPlugins?: string[];
   /**


### PR DESCRIPTION
## Summary

Fixes #1186 — multi-source resolver for bundled plugins so the compiled binary keeps re-symlinking the 11 core plugins after `~/.maw/plugins/` is wiped.

`resolveBundledPath` priority:
1. `$MAW_BUNDLED_PLUGINS` env override
2. `config.bundledPluginSource` (auto-persisted on source-mode boots)
3. `<srcDirHint>/commands/plugins` fallback (existing behavior)

## Smoke test (this branch, bun-linked)

Wiped channel/federation/fleet/oracle/plugin/session/split/swarm/team/tmux/transport from `~/.maw/plugins/`, ran `maw --help`, all 11 re-symlinked from `/Users/nat/Code/.../maw-js/src/commands/plugins/`.

## Tests

`bun test src/cli/plugin-bootstrap.test.ts` — 20 pass, 0 fail (was 16; +4 new for env override, ~/ expansion, env-target-missing fall-through, no-source-found warning).

Auto-generated by /release-alpha — bump cosmetic mismatch (.424 vs .425) because calver clock rolled a minute between `--check` and `--apply`; package.json is source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)