### PR TITLE
release: v26.5.12-alpha.432 — portable git hooks (#1194)

### DIFF
--- a/.rtk/filters.toml
+++ b/.rtk/filters.toml
@@ -1,0 +1,13 @@
+# Project-local RTK filters — commit this file with your repo.
+# Filters here override user-global and built-in filters.
+# Docs: https://github.com/rtk-ai/rtk#custom-filters
+schema_version = 1
+
+# Example: suppress build noise from a custom tool
+# [filters.my-tool]
+# description = "Compact my-tool output"
+# match_command = "^my-tool\\s+build"
+# strip_ansi = true
+# strip_lines_matching = ["^\\s*$", "^Downloading", "^Installing"]
+# max_lines = 30
+# on_empty = "my-tool: ok"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,138 @@
+<!-- rtk-instructions v2 -->
+# RTK (Rust Token Killer) - Token-Optimized Commands
+
+## Golden Rule
+
+**Always prefix commands with `rtk`**. If RTK has a dedicated filter, it uses it. If not, it passes through unchanged. This means RTK is always safe to use.
+
+**Important**: Even in command chains with `&&`, use `rtk`:
+```bash
+# ❌ Wrong
+git add . && git commit -m "msg" && git push
+
+# ✅ Correct
+rtk git add . && rtk git commit -m "msg" && rtk git push
+```
+
+## RTK Commands by Workflow
+
+### Build & Compile (80-90% savings)
+```bash
+rtk cargo build         # Cargo build output
+rtk cargo check         # Cargo check output
+rtk cargo clippy        # Clippy warnings grouped by file (80%)
+rtk tsc                 # TypeScript errors grouped by file/code (83%)
+rtk lint                # ESLint/Biome violations grouped (84%)
+rtk prettier --check    # Files needing format only (70%)
+rtk next build          # Next.js build with route metrics (87%)
+```
+
+### Test (60-99% savings)
+```bash
+rtk cargo test          # Cargo test failures only (90%)
+rtk go test             # Go test failures only (90%)
+rtk jest                # Jest failures only (99.5%)
+rtk vitest              # Vitest failures only (99.5%)
+rtk playwright test     # Playwright failures only (94%)
+rtk pytest              # Python test failures only (90%)
+rtk rake test           # Ruby test failures only (90%)
+rtk rspec               # RSpec test failures only (60%)
+rtk test <cmd>          # Generic test wrapper - failures only
+```
+
+### Git (59-80% savings)
+```bash
+rtk git status          # Compact status
+rtk git log             # Compact log (works with all git flags)
+rtk git diff            # Compact diff (80%)
+rtk git show            # Compact show (80%)
+rtk git add             # Ultra-compact confirmations (59%)
+rtk git commit          # Ultra-compact confirmations (59%)
+rtk git push            # Ultra-compact confirmations
+rtk git pull            # Ultra-compact confirmations
+rtk git branch          # Compact branch list
+rtk git fetch           # Compact fetch
+rtk git stash           # Compact stash
+rtk git worktree        # Compact worktree
+```
+
+Note: Git passthrough works for ALL subcommands, even those not explicitly listed.
+
+### GitHub (26-87% savings)
+```bash
+rtk gh pr view <num>    # Compact PR view (87%)
+rtk gh pr checks        # Compact PR checks (79%)
+rtk gh run list         # Compact workflow runs (82%)
+rtk gh issue list       # Compact issue list (80%)
+rtk gh api              # Compact API responses (26%)
+```
+
+### JavaScript/TypeScript Tooling (70-90% savings)
+```bash
+rtk pnpm list           # Compact dependency tree (70%)
+rtk pnpm outdated       # Compact outdated packages (80%)
+rtk pnpm install        # Compact install output (90%)
+rtk npm run <script>    # Compact npm script output
+rtk npx <cmd>           # Compact npx command output
+rtk prisma              # Prisma without ASCII art (88%)
+```
+
+### Files & Search (60-75% savings)
+```bash
+rtk ls <path>           # Tree format, compact (65%)
+rtk read <file>         # Code reading with filtering (60%)
+rtk grep <pattern>      # Search grouped by file (75%). Format flags (-c, -l, -L, -o, -Z) run raw.
+rtk find <pattern>      # Find grouped by directory (70%)
+```
+
+### Analysis & Debug (70-90% savings)
+```bash
+rtk err <cmd>           # Filter errors only from any command
+rtk log <file>          # Deduplicated logs with counts
+rtk json <file>         # JSON structure without values
+rtk deps                # Dependency overview
+rtk env                 # Environment variables compact
+rtk summary <cmd>       # Smart summary of command output
+rtk diff                # Ultra-compact diffs
+```
+
+### Infrastructure (85% savings)
+```bash
+rtk docker ps           # Compact container list
+rtk docker images       # Compact image list
+rtk docker logs <c>     # Deduplicated logs
+rtk kubectl get         # Compact resource list
+rtk kubectl logs        # Deduplicated pod logs
+```
+
+### Network (65-70% savings)
+```bash
+rtk curl <url>          # Compact HTTP responses (70%)
+rtk wget <url>          # Compact download output (65%)
+```
+
+### Meta Commands
+```bash
+rtk gain                # View token savings statistics
+rtk gain --history      # View command history with savings
+rtk discover            # Analyze Claude Code sessions for missed RTK usage
+rtk proxy <cmd>         # Run command without filtering (for debugging)
+rtk init                # Add RTK instructions to CLAUDE.md
+rtk init --global       # Add RTK to ~/.claude/CLAUDE.md
+```
+
+## Token Savings Overview
+
+| Category | Commands | Typical Savings |
+|----------|----------|-----------------|
+| Tests | vitest, playwright, cargo test | 90-99% |
+| Build | next, tsc, lint, prettier | 70-87% |
+| Git | status, log, diff, add, commit | 59-80% |
+| GitHub | gh pr, gh run, gh issue | 26-87% |
+| Package Managers | pnpm, npm, npx | 70-90% |
+| Files | ls, read, grep, find | 60-75% |
+| Infrastructure | docker, kubectl | 85% |
+| Network | curl, wget | 65-70% |
+
+Overall average: **60-90% token reduction** on common development operations.
+<!-- /rtk-instructions -->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.12-alpha.635",
+  "version": "26.5.12-alpha.640",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.12-alpha.407",
+  "version": "26.5.12-alpha.432",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/scripts/hooks/maw-hooks.env.example
+++ b/scripts/hooks/maw-hooks.env.example
@@ -1,0 +1,27 @@
+# maw-js git-hook configuration. (#1194)
+#
+# Copied to .git/maw-hooks.env on first run of:
+#   bash scripts/install-git-hooks.sh
+#
+# Edit .git/maw-hooks.env in place (gitignored). Re-running the installer
+# never clobbers your edited copy.
+
+# 1 = build dist/maw on every commit (default). 0 = skip the build step.
+MAW_HOOK_BUILD=1
+
+# Path to copy dist/maw to after a successful build. Empty = skip the copy.
+# Defaults to ~/.local/bin/maw so the CLI in $PATH stays fresh.
+MAW_HOOK_DEPLOY=$HOME/.local/bin/maw
+
+# pm2 service name to restart after deploy. Empty = skip.
+# Example: MAW_HOOK_PM2=maw
+MAW_HOOK_PM2=
+
+# Second clone owned by another user account that should fast-forward to
+# match this one (the fleet-user-mirror pattern — e.g. /opt/Code/.../maw-js
+# read by the `mawjs` system user while `nat` edits in ~/Code/.../maw-js).
+# Empty = skip. (#1194)
+MAW_HOOK_MIRROR=
+
+# Branch the mirror tracks. Default: alpha.
+MAW_HOOK_MIRROR_BRANCH=alpha

--- a/scripts/hooks/post-commit
+++ b/scripts/hooks/post-commit
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Auto-deploy after commit — build CLI, copy to local bin, restart pm2,
+# fast-forward a fleet-user mirror clone. (#1194)
+#
+# Customize via .git/maw-hooks.env (gitignored, copied from
+# scripts/hooks/maw-hooks.env.example by install-git-hooks.sh).
+#
+# Fails LOUDLY if the build breaks — silent failures shipped stale binaries
+# on the maw-js fleet between 2026-05-07 and 2026-05-11, which is the
+# whole reason this hook exists.
+set -e
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# Load user config if present.
+[ -f "$REPO_ROOT/.git/maw-hooks.env" ] && . "$REPO_ROOT/.git/maw-hooks.env"
+
+# Defaults — override any of these in .git/maw-hooks.env.
+: "${MAW_HOOK_BUILD:=1}"
+: "${MAW_HOOK_DEPLOY:=$HOME/.local/bin/maw}"
+: "${MAW_HOOK_PM2:=}"                  # pm2 service name; empty = skip
+: "${MAW_HOOK_MIRROR:=}"                # mirror clone path; empty = skip
+: "${MAW_HOOK_MIRROR_BRANCH:=alpha}"
+
+echo "🚀 Auto-deploying..."
+
+if [ "$MAW_HOOK_BUILD" = "1" ]; then
+  BUILD_LOG=$(mktemp -t maw-build.XXXXXX)
+  if ! bun build src/cli.ts --outfile dist/maw --target=bun --minify >"$BUILD_LOG" 2>&1; then
+    echo "❌ BUILD FAILED — dist/maw NOT updated"
+    echo ""
+    cat "$BUILD_LOG"
+    echo ""
+    echo "  fix the build, then run:  bash .git/hooks/post-commit"
+    mv "$BUILD_LOG" /tmp/maw-build-FAILED-$(date +%H%M%S).log
+    exit 1
+  fi
+  tail -1 "$BUILD_LOG"
+  mv "$BUILD_LOG" /tmp/maw-build-last.log
+
+  [ -f dist/maw ] || { echo "❌ build claimed success but dist/maw does not exist"; exit 1; }
+fi
+
+if [ -n "$MAW_HOOK_DEPLOY" ] && [ -f dist/maw ]; then
+  cp dist/maw "$MAW_HOOK_DEPLOY" 2>/dev/null \
+    || echo "⚠️  cp dist/maw → $MAW_HOOK_DEPLOY failed (non-fatal)"
+fi
+
+if [ -n "$MAW_HOOK_PM2" ]; then
+  pm2 restart "$MAW_HOOK_PM2" 2>/dev/null || true
+fi
+
+# Fleet-user mirror sync. The mirror is a SECOND clone owned by another
+# user account (e.g. /opt/Code/.../maw-js read by the mawjs system user
+# while nat edits in ~/Code/.../maw-js). The hook runs AFTER commit but
+# BEFORE push, so this only catches up on the NEXT commit — eventually
+# consistent within one commit cycle, which is good enough in practice.
+if [ -n "$MAW_HOOK_MIRROR" ] \
+   && [ -d "$MAW_HOOK_MIRROR/.git" ] \
+   && [ "$MAW_HOOK_MIRROR" != "$REPO_ROOT" ]; then
+  if git -C "$MAW_HOOK_MIRROR" fetch origin "$MAW_HOOK_MIRROR_BRANCH" >/dev/null 2>&1 \
+     && git -C "$MAW_HOOK_MIRROR" merge --ff-only "origin/$MAW_HOOK_MIRROR_BRANCH" >/dev/null 2>&1; then
+    echo "  ✓ mirror $MAW_HOOK_MIRROR synced to $(git -C "$MAW_HOOK_MIRROR" log --oneline -1 | cut -c1-12)"
+  else
+    echo "  ⚠ mirror sync failed — run: git -C $MAW_HOOK_MIRROR fetch + merge manually"
+  fi
+fi
+
+echo "✅ Deployed $(git log --oneline -1)"

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Install maw-js git hooks from scripts/hooks/ into .git/hooks/. (#1194)
+#
+# Usage: bash scripts/install-git-hooks.sh
+#
+# Idempotent — re-running replaces hooks with the latest tracked versions
+# after backing up any pre-existing copy as .backup-<timestamp>.
+# Skips the customization env file (.git/maw-hooks.env) so user edits
+# are never clobbered.
+set -e
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HOOKS_SRC="$REPO_ROOT/scripts/hooks"
+HOOKS_DST="$REPO_ROOT/.git/hooks"
+
+[ -d "$HOOKS_SRC" ] || { echo "❌ $HOOKS_SRC does not exist"; exit 1; }
+[ -d "$HOOKS_DST" ] || { echo "❌ $HOOKS_DST does not exist (is this a git repo?)"; exit 1; }
+
+installed=0
+for hook_src in "$HOOKS_SRC"/*; do
+  name="$(basename "$hook_src")"
+  # Examples + READMEs aren't hooks
+  case "$name" in
+    *.example|README*|*.md) continue ;;
+  esac
+
+  hook_dst="$HOOKS_DST/$name"
+  if [ -e "$hook_dst" ] && ! cmp -s "$hook_src" "$hook_dst"; then
+    cp "$hook_dst" "$hook_dst.backup-$(date +%Y%m%d-%H%M%S)"
+    echo "  ↻ backed up existing $name"
+  fi
+  cp "$hook_src" "$hook_dst"
+  chmod +x "$hook_dst"
+  echo "  ✓ installed $name"
+  installed=$((installed + 1))
+done
+
+# Seed the per-user config file from the example, but never overwrite it.
+ENV_EXAMPLE="$HOOKS_SRC/maw-hooks.env.example"
+ENV_TARGET="$REPO_ROOT/.git/maw-hooks.env"
+if [ -f "$ENV_EXAMPLE" ] && [ ! -f "$ENV_TARGET" ]; then
+  cp "$ENV_EXAMPLE" "$ENV_TARGET"
+  echo "  ✓ seeded $(basename "$ENV_TARGET") from example"
+fi
+
+if [ "$installed" -eq 0 ]; then
+  echo "ℹ️  no hooks found in $HOOKS_SRC"
+  exit 0
+fi
+
+echo "✅ Installed $installed hook(s). Edit .git/maw-hooks.env to customize."


### PR DESCRIPTION
## Summary

Closes #1194 — moves the post-commit auto-deploy hook from `.git/hooks/` (untracked) into the repo as a tracked installer + hook source.

- `scripts/install-git-hooks.sh` — idempotent installer
- `scripts/hooks/post-commit` — the hook itself
- `scripts/hooks/maw-hooks.env.example` — seeds `.git/maw-hooks.env` (gitignored, per-user) on first install

Hook reads `.git/maw-hooks.env` for customization:
- `MAW_HOOK_BUILD` (default 1)
- `MAW_HOOK_DEPLOY` (default `$HOME/.local/bin/maw`)
- `MAW_HOOK_PM2` (default empty — skip)
- `MAW_HOOK_MIRROR` (default empty — skip) ← fleet-user mirror fast-forward
- `MAW_HOOK_MIRROR_BRANCH` (default `alpha`)

Also bundles an `rtk init` setup (`.rtk/filters.toml` + `CLAUDE.md`) so Claude Code sessions in this repo pick up project-local RTK filters.

## Smoke test

Installer ran cleanly: backed up existing hook → installed new → seeded env. Subsequent commits fired the new hook, built dist/maw (649 modules / ~30ms), copied to `~/.local/bin/maw`, attempted /opt/Code mirror sync (lag-by-one-commit as documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)