### PR TITLE
release: v26.5.12-alpha.437 — channels: repo > global (#1195 Phase 2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.12-alpha.635",
+  "version": "26.5.12-alpha.640",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.12-alpha.407",
+  "version": "26.5.12-alpha.437",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/shared/channel-loader.test.ts
+++ b/src/commands/shared/channel-loader.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+/**
+ * Sandbox HOME before importing the SUT — channel-loader resolves
+ * `~/.claude/channels/<stem>/config.json` via `homedir()` at module load
+ * time. Without this, tests would read whatever the developer has
+ * configured globally.
+ */
+let homeSandbox: string;
+beforeAll(() => {
+  homeSandbox = mkdtempSync(join(tmpdir(), "maw-channel-loader-home-"));
+  process.env.HOME = homeSandbox;
+});
+afterAll(() => {
+  try { rmSync(homeSandbox, { recursive: true, force: true }); } catch {}
+});
+
+import {
+  loadEffectiveChannels,
+  getChannelPluginIds,
+  getChannelPermissionMode,
+  saveOracleChannels,
+  saveRepoChannels,
+  type OracleChannelConfig,
+} from "./channel-loader";
+
+describe("loadEffectiveChannels — #1195 Phase 2 repo > global precedence", () => {
+  let repoDir: string;
+  const stem = "test-oracle";
+
+  beforeEach(() => {
+    repoDir = mkdtempSync(join(tmpdir(), "maw-channel-loader-repo-"));
+    // Clear any prior global config for this stem so tests don't pollute each other.
+    try { rmSync(join(homeSandbox, ".claude", "channels", stem), { recursive: true, force: true }); } catch {}
+  });
+
+  afterEach(() => {
+    try { rmSync(repoDir, { recursive: true, force: true }); } catch {}
+  });
+
+  function globalConfig(): OracleChannelConfig {
+    return { plugins: [{ id: "plugin:global-discord@1" }], permissionMode: "skip" };
+  }
+  function repoConfig(): OracleChannelConfig {
+    return { plugins: [{ id: "plugin:repo-discord@1" }, { id: "plugin:repo-telegram@1" }], permissionMode: "relay" };
+  }
+
+  it("returns null when neither global nor repo config exists", () => {
+    expect(loadEffectiveChannels(stem, repoDir)).toBeNull();
+    expect(loadEffectiveChannels(stem)).toBeNull();
+  });
+
+  it("returns global when only global config exists", () => {
+    saveOracleChannels(stem, globalConfig());
+    const got = loadEffectiveChannels(stem, repoDir);
+    expect(got?.plugins[0].id).toBe("plugin:global-discord@1");
+  });
+
+  it("returns repo when only repo config exists (no fallback needed)", () => {
+    saveRepoChannels(repoDir, repoConfig());
+    const got = loadEffectiveChannels(stem, repoDir);
+    expect(got?.plugins.map(p => p.id)).toEqual(["plugin:repo-discord@1", "plugin:repo-telegram@1"]);
+  });
+
+  it("repo wins over global when both exist", () => {
+    saveOracleChannels(stem, globalConfig());
+    saveRepoChannels(repoDir, repoConfig());
+    const got = loadEffectiveChannels(stem, repoDir);
+    expect(got?.plugins[0].id).toBe("plugin:repo-discord@1");
+    expect(got?.permissionMode).toBe("relay");
+  });
+
+  it("falls back to global when repoPath is omitted", () => {
+    saveOracleChannels(stem, globalConfig());
+    saveRepoChannels(repoDir, repoConfig());
+    const got = loadEffectiveChannels(stem); // no repoPath
+    expect(got?.plugins[0].id).toBe("plugin:global-discord@1");
+  });
+
+  it("getChannelPluginIds propagates the repo precedence", () => {
+    saveOracleChannels(stem, globalConfig());
+    saveRepoChannels(repoDir, repoConfig());
+    expect(getChannelPluginIds(stem, undefined, repoDir)).toEqual(["plugin:repo-discord@1", "plugin:repo-telegram@1"]);
+    expect(getChannelPluginIds(stem)).toEqual(["plugin:global-discord@1"]);
+  });
+
+  it("getChannelPermissionMode propagates the repo precedence", () => {
+    saveOracleChannels(stem, globalConfig()); // skip
+    saveRepoChannels(repoDir, repoConfig());  // relay
+    expect(getChannelPermissionMode(stem, repoDir)).toBe("relay");
+    expect(getChannelPermissionMode(stem)).toBe("skip");
+  });
+
+  it("fleetOverride still trumps both repo and global", () => {
+    saveOracleChannels(stem, globalConfig());
+    saveRepoChannels(repoDir, repoConfig());
+    expect(getChannelPluginIds(stem, ["plugin:fleet@1"], repoDir)).toEqual(["plugin:fleet@1"]);
+  });
+});

--- a/src/commands/shared/channel-loader.ts
+++ b/src/commands/shared/channel-loader.ts
@@ -77,25 +77,55 @@ export function saveOracleChannels(oracleStem: string, config: OracleChannelConf
   writeFileSync(configPath(oracleStem), JSON.stringify(config, null, 2) + "\n");
 }
 
-export function getChannelPluginIds(oracleStem: string, fleetOverride?: string[]): string[] {
+/**
+ * Resolve the effective channel config for an oracle.
+ *
+ * Phase 2 of #1195 — repo-local `.claude/channel.json` (if present at
+ * `repoPath`) wins over the global `~/.claude/channels/<stem>/config.json`,
+ * so config travels with the repo across machines and users. The global
+ * path remains the fallback for un-migrated oracles.
+ */
+export function loadEffectiveChannels(
+  oracleStem: string,
+  repoPath?: string,
+): OracleChannelConfig | null {
+  if (repoPath) {
+    const repo = loadRepoChannels(repoPath);
+    if (repo) return repo;
+  }
+  return loadOracleChannels(oracleStem);
+}
+
+export function getChannelPluginIds(
+  oracleStem: string,
+  fleetOverride?: string[],
+  repoPath?: string,
+): string[] {
   if (fleetOverride?.length) return fleetOverride;
-  const config = loadOracleChannels(oracleStem);
-  return config?.plugins.map(p => p.id) ?? [];
+  return loadEffectiveChannels(oracleStem, repoPath)?.plugins.map(p => p.id) ?? [];
 }
 
 /**
  * #1146 — read the permissionMode from the channel config.
  * Returns "skip" when unset or the file is missing so callers can pass the
  * value straight through to buildCommand without an extra null-check.
+ * `repoPath` is honored per #1195 Phase 2.
  */
-export function getChannelPermissionMode(oracleStem: string): "skip" | "relay" {
-  const config = loadOracleChannels(oracleStem);
+export function getChannelPermissionMode(
+  oracleStem: string,
+  repoPath?: string,
+): "skip" | "relay" {
+  const config = loadEffectiveChannels(oracleStem, repoPath);
   return config?.permissionMode === "relay" ? "relay" : "skip";
 }
 
-export function getChannelEnv(oracleStem: string, fleetEnvOverride?: Record<string, string>): Record<string, string> {
+export function getChannelEnv(
+  oracleStem: string,
+  fleetEnvOverride?: Record<string, string>,
+  repoPath?: string,
+): Record<string, string> {
   const env: Record<string, string> = {};
-  const config = loadOracleChannels(oracleStem);
+  const config = loadEffectiveChannels(oracleStem, repoPath);
   if (config?.plugins) {
     for (const p of config.plugins) {
       if (p.env) Object.assign(env, p.env);

--- a/src/commands/shared/fleet-wake.ts
+++ b/src/commands/shared/fleet-wake.ts
@@ -85,10 +85,11 @@ export async function cmdWakeAll(opts: { kill?: boolean; all?: boolean; resume?:
       if (!sess.skip_command) {
         await new Promise(r => setTimeout(r, 300));
         // #1096 — auto-inject channels for fleet sessions
+        // #1195 Phase 2 — prefer <firstPath>/.claude/channel.json over global config
         const { getChannelPluginIds, getChannelEnv } = await import("./channel-loader");
         const oracleStem = first.name.replace(/-oracle$/, "");
-        const chIds = getChannelPluginIds(oracleStem);
-        const chEnv = getChannelEnv(oracleStem);
+        const chIds = getChannelPluginIds(oracleStem, undefined, firstPath);
+        const chEnv = getChannelEnv(oracleStem, undefined, firstPath);
         for (const [k, v] of Object.entries(chEnv)) {
           await tmux.setEnvironment(sess.name, k, v);
         }
@@ -106,8 +107,9 @@ export async function cmdWakeAll(opts: { kill?: boolean; all?: boolean; resume?:
           if (!sess.skip_command) {
             await new Promise(r => setTimeout(r, 300));
             const winStem = win.name.replace(/-oracle$/, "");
+            // #1195 Phase 2 — prefer <winPath>/.claude/channel.json over global config
             const { getChannelPluginIds: gcp } = await import("./channel-loader");
-            const winChIds = gcp(winStem);
+            const winChIds = gcp(winStem, undefined, winPath);
             const winOpts = winChIds.length ? { channels: winChIds } : undefined;
             await tmux.sendText(`${sess.name}:${win.name}`, buildCommand(win.name, winOpts));
           }

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -123,11 +123,12 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
     // Channel env vars are prepended to the command (not tmux set-environment)
     // because tmux set-environment only affects NEW shells, not the existing one
     const { getChannelPluginIds, getChannelEnv, getChannelPermissionMode } = await import("./channel-loader");
-    const channelIds = getChannelPluginIds(oracle);
-    const channelEnv = getChannelEnv(oracle);
+    // #1195 Phase 2 — prefer <repo>/.claude/channel.json over the global config
+    const channelIds = getChannelPluginIds(oracle, undefined, repoPath);
+    const channelEnv = getChannelEnv(oracle, undefined, repoPath);
     // #1146 — read permissionMode so channel-enabled bots can opt into "relay"
     // (channel-routed prompts) instead of the default "skip" (autonomous).
-    const permissionMode = getChannelPermissionMode(oracle);
+    const permissionMode = getChannelPermissionMode(oracle, repoPath);
     const wakeOpts = channelIds.length
       ? { engine: opts.engine, channels: channelIds, channelEnv, permissionMode }
       : opts.engine;

--- a/src/commands/shared/wake-show.ts
+++ b/src/commands/shared/wake-show.ts
@@ -15,9 +15,10 @@ export async function cmdShow(oracle: string): Promise<void> {
   const windowName = `${oracle}-oracle`;
 
   const { getChannelPluginIds, getChannelEnv, getChannelPermissionMode } = await import("./channel-loader");
-  const channelIds = getChannelPluginIds(oracle);
-  const channelEnv = getChannelEnv(oracle);
-  const permissionMode = getChannelPermissionMode(oracle);
+  // #1195 Phase 2 — prefer <repo>/.claude/channel.json over the global config
+  const channelIds = getChannelPluginIds(oracle, undefined, repoPath);
+  const channelEnv = getChannelEnv(oracle, undefined, repoPath);
+  const permissionMode = getChannelPermissionMode(oracle, repoPath);
 
   const opts = channelIds.length
     ? { channels: channelIds, channelEnv, permissionMode }


### PR DESCRIPTION
## Summary

Closes #1195 Phase 2 — wake/show/fleet code paths now read `<repo>/.claude/channel.json` before falling back to `~/.claude/channels/<oracle>/config.json`.

## What changed

- `loadEffectiveChannels(stem, repoPath?)` helper in `channel-loader.ts` — repo wins when present, global is the fallback
- `getChannelPluginIds`, `getChannelEnv`, `getChannelPermissionMode` gain an optional `repoPath` arg
- `wake-cmd.ts`, `wake-show.ts`, `fleet-wake.ts` (both first and additional windows) pass the resolved repo path through

`maw channel test` keeps the existing global-only behavior (it works off an oracle stem with no repo context).

## Tests

`bun test src/commands/shared/channel-loader.test.ts` — 8/8 pass: null, global-only, repo-only, both (repo wins), no-path (fallback to global), getters propagate, fleetOverride trumps both.

Smoke: `maw show mawjs` still produces a valid `{ claude --continue || claude; }` script when no repo or global channel config exists.

## Pending

- Phase 3 — `maw channel migrate --to-repo` bulk move
- Phases 4-5 — listed in #1195

🤖 Generated with [Claude Code](https://claude.com/claude-code)