### PR TITLE
release: v26.5.12-alpha.444 — maw channel migrate --to-repo (#1195 Phase 3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.12-alpha.635",
+  "version": "26.5.12-alpha.641",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.12-alpha.407",
+  "version": "26.5.12-alpha.444",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.12-alpha.640",
-
+  "version": "26.5.12-alpha.645",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/plugins/channel/index.ts
+++ b/src/commands/plugins/channel/index.ts
@@ -35,6 +35,9 @@ subcommands:
   providers                list available channel providers
   setup <oracle>           interactive channel setup wizard
   test <oracle>            test channel configuration
+  migrate --to-repo [...]  copy global ~/.claude/channels/<oracle>/config.json
+                           into each oracle's <repo>/.claude/channel.json
+                           ([oracle...] empty = all; --dry-run / --remove-global)
 
 shorthand: discord → plugin:discord@claude-plugins-official
 github: prefix → delegates to setup wizard`,
@@ -261,16 +264,117 @@ github: prefix → delegates to setup wizard`,
         for (const c of checks) console.log(`    ${c}`);
       }
 
+    } else if (sub === "migrate") {
+      const rest = args.slice(1);
+      const toRepo = rest.includes("--to-repo");
+      const dryRun = rest.includes("--dry-run");
+      const removeGlobal = rest.includes("--remove-global");
+      const targets = rest.filter(a => !a.startsWith("--"));
+
+      if (!toRepo) {
+        console.log("usage: maw channel migrate --to-repo [oracle...] [--dry-run] [--remove-global]");
+        console.log("  copies global ~/.claude/channels/<oracle>/config.json into");
+        console.log("  <repo>/.claude/channel.json so config travels with the repo (#1195).");
+        console.log("");
+        console.log("  no [oracle...] args = migrate every oracle with global config.");
+        console.log("  --dry-run            = show what would happen, no writes.");
+        console.log("  --remove-global      = delete the global config after a successful copy.");
+        return { ok: false, error: "--to-repo required" };
+      }
+
+      const stems = targets.length > 0
+        ? targets
+        : listAllOracleChannels().map(o => o.oracle);
+
+      if (stems.length === 0) {
+        console.log("  no oracles with global channel config to migrate");
+        return { ok: true };
+      }
+
+      const { ghqFind } = await import("../../../core/ghq");
+      const { unlinkSync, rmdirSync } = await import("fs");
+      const { join: pathJoin } = await import("path");
+      const { homedir: hd } = await import("os");
+
+      // Channel dir names are heterogeneous: some include the `-oracle`
+      // suffix (e.g. `mawjs-oracle`), some don't (e.g. `mother`,
+      // `hermes-discord`). Try the literal name first, then the
+      // `-oracle`-suffixed form, then the stripped form. ghqFind returns
+      // the FIRST match (and warns on multiples) without calling
+      // process.exit — unlike resolveOracle.
+      const resolveRepo = async (stem: string): Promise<string | null> => {
+        const candidates = [
+          stem,
+          stem.endsWith("-oracle") ? stem.replace(/-oracle$/, "") : `${stem}-oracle`,
+        ];
+        for (const candidate of candidates) {
+          const hit = await ghqFind(`/${candidate}`);
+          if (hit) return hit;
+        }
+        return null;
+      };
+
+      let migrated = 0, skipped = 0, failed = 0;
+      for (const stem of stems) {
+        const global = loadOracleChannels(stem);
+        if (!global) {
+          console.log(`  \x1b[90m·\x1b[0m ${stem}: no global config — skip`);
+          skipped++;
+          continue;
+        }
+
+        const repoPath = await resolveRepo(stem);
+        if (!repoPath) {
+          console.log(`  \x1b[31m✗\x1b[0m ${stem}: no local repo (tried ghq for '${stem}' and '-oracle' variants) — skip`);
+          failed++;
+          continue;
+        }
+
+        if (loadRepoChannels(repoPath)) {
+          console.log(`  \x1b[33m⚠\x1b[0m ${stem}: ${repoPath}/.claude/channel.json already exists — skip (delete it first)`);
+          skipped++;
+          continue;
+        }
+
+        if (dryRun) {
+          console.log(`  \x1b[36m·\x1b[0m DRY-RUN ${stem}: would write ${repoPath}/.claude/channel.json (${global.plugins.length} plugin(s))`);
+          migrated++;
+          continue;
+        }
+
+        saveRepoChannels(repoPath, global);
+        console.log(`  \x1b[32m✓\x1b[0m ${stem}: → ${repoPath}/.claude/channel.json`);
+
+        if (removeGlobal) {
+          const globalConfig = pathJoin(hd(), ".claude", "channels", stem, "config.json");
+          const globalDir = pathJoin(hd(), ".claude", "channels", stem);
+          try {
+            unlinkSync(globalConfig);
+            try { rmdirSync(globalDir); } catch { /* dir not empty: state files survive */ }
+            console.log(`    \x1b[90m✓ removed global config\x1b[0m`);
+          } catch (e: any) {
+            console.log(`    \x1b[33m⚠ failed to remove global: ${e?.message || e}\x1b[0m`);
+          }
+        }
+        migrated++;
+      }
+
+      console.log(`\n  ${migrated} migrated, ${skipped} skipped, ${failed} failed`);
+      if (migrated > 0 && !removeGlobal && !dryRun) {
+        console.log(`  tip: re-run with --remove-global to delete the global config copies.`);
+      }
+
     } else {
-      console.log("usage: maw channel <add|rm|ls|providers|setup|test> [oracle] [plugin]\n");
-      console.log("  maw channel providers                        list available providers");
-      console.log("  maw channel setup hermes-discord discord      interactive wizard");
-      console.log("  maw channel setup myoracle github:org/repo   git channel wizard");
-      console.log("  maw channel add hermes-discord discord        quick register");
-      console.log("  maw channel add myoracle github:org/repo     git channel");
-      console.log("  maw channel rm hermes-discord discord         remove channel");
-      console.log("  maw channel ls                                list all");
-      console.log("  maw channel test hermes-discord               verify connectivity");
+      console.log("usage: maw channel <add|rm|ls|providers|setup|test|migrate> [oracle] [plugin]\n");
+      console.log("  maw channel providers                          list available providers");
+      console.log("  maw channel setup hermes-discord discord       interactive wizard");
+      console.log("  maw channel setup myoracle github:org/repo     git channel wizard");
+      console.log("  maw channel add hermes-discord discord         quick register");
+      console.log("  maw channel add myoracle github:org/repo       git channel");
+      console.log("  maw channel rm hermes-discord discord          remove channel");
+      console.log("  maw channel ls                                 list all");
+      console.log("  maw channel test hermes-discord                verify connectivity");
+      console.log("  maw channel migrate --to-repo [oracle...]      global → repo (#1195)");
       console.log("");
       console.log("  maw wake <oracle> auto-injects --channels when config exists");
     }

--- a/src/commands/shared/channel-loader.ts
+++ b/src/commands/shared/channel-loader.ts
@@ -2,7 +2,15 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync, appendFileSync } fr
 import { join } from "path";
 import { homedir } from "os";
 
-const CHANNELS_BASE = join(homedir(), ".claude", "channels");
+/**
+ * Defer HOME lookup to call-time. Evaluating this at module load froze the
+ * developer's actual `$HOME` into a const, which made `process.env.HOME =
+ * sandbox` in test `beforeAll` a no-op — tests then leaked
+ * `test-*-oracle` dirs into the real `~/.claude/channels/`. (#1195 Phase 3)
+ */
+function channelsBase(): string {
+  return join(homedir(), ".claude", "channels");
+}
 
 /**
  * Per-repo channel config path (#1195 Phase 1).
@@ -58,7 +66,7 @@ export interface OracleChannelConfig {
 }
 
 function stateDir(oracleStem: string): string {
-  return join(CHANNELS_BASE, oracleStem);
+  return join(channelsBase(), oracleStem);
 }
 
 function configPath(oracleStem: string): string {
@@ -130,9 +138,9 @@ export function getChannelEnv(oracleStem: string, fleetEnvOverride?: Record<stri
 }
 
 export function listAllOracleChannels(): Array<{ oracle: string; plugins: ChannelPlugin[] }> {
-  if (!existsSync(CHANNELS_BASE)) return [];
+  if (!existsSync(channelsBase())) return [];
   const { readdirSync } = require("fs");
-  const dirs = readdirSync(CHANNELS_BASE, { withFileTypes: true })
+  const dirs = readdirSync(channelsBase(), { withFileTypes: true })
     .filter((d: any) => d.isDirectory())
     .map((d: any) => d.name);
 


### PR DESCRIPTION
## Summary

Closes #1195 Phase 3 — bulk-migrate `~/.claude/channels/<oracle>/config.json` files into each oracle's `<repo>/.claude/channel.json` (the per-repo location landed in Phase 1, read-first behavior landed in Phase 2 #1198).

## Commands

```
maw channel migrate --to-repo                            # migrate all
maw channel migrate --to-repo mawjs-oracle discord       # migrate named
maw channel migrate --to-repo --dry-run                  # preview
maw channel migrate --to-repo --remove-global            # delete global after copy
```

## Design notes

- Uses `ghqFind` directly (not `resolveOracle`) — the latter calls `process.exit(1)` on ambiguous matches, which would kill the whole loop. ghqFind logs the conflict and returns the first match.
- Tries the literal stem AND `-oracle`-suffixed variants since channel dir names are heterogeneous (`mawjs-oracle`, `mother`, `hermes-discord`, `22-metis`).
- Skips when `<repo>/.claude/channel.json` already exists (forces explicit conflict resolution).

## Sandbox bug fix bundled

`channel-loader.ts` evaluated `CHANNELS_BASE = join(homedir(), ".claude", "channels")` at module load. Hoisted ES imports run before `beforeAll`, so Phase 2's test sandbox (`process.env.HOME = sandbox` in beforeAll) was a no-op — the tests leaked `test-*-oracle` dirs into the developer's real `~/.claude/channels/`. Fixed by deferring HOME lookup to a `channelsBase()` function.

## Smoke test (this fleet, dry-run)

```
8 migrated, 0 skipped, 1 failed
```

(1 failure: `22-metis`, a numbered fleet slot with no `-oracle` repo — expected.)

## Pending in #1195

- Phases 4-5 — listed in the issue (`maw channel test` repo-aware, doc/migration story).

🤖 Generated with [Claude Code](https://claude.com/claude-code)