### PR TITLE
release: v26.5.12-alpha.712 — engine registry (#1201)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.12-alpha.645",
+  "version": "26.5.12-alpha.712",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/shared/engines.test.ts
+++ b/src/commands/shared/engines.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import {
+  ENGINE_DEFS,
+  ENGINE_NAMES,
+  resolveEngine,
+  isEngineInstalled,
+  buildEngineCommand,
+  resolveDefaultEngine,
+} from "./engines";
+
+describe("engines — as-const registry (#1201)", () => {
+  it("ENGINE_NAMES matches ENGINE_DEFS keys", () => {
+    expect([...ENGINE_NAMES].sort()).toEqual(Object.keys(ENGINE_DEFS).sort());
+  });
+
+  it("every engine has required fields", () => {
+    for (const name of ENGINE_NAMES) {
+      const e = ENGINE_DEFS[name];
+      expect(typeof e.binary).toBe("string");
+      expect(typeof e.defaultModel).toBe("string");
+      expect(typeof e.permissionFlag).toBe("string");
+      expect(["file", "stdin"]).toContain(e.promptMode);
+    }
+  });
+
+  it("resolveEngine accepts valid names", () => {
+    expect(resolveEngine("claude")).toBe("claude");
+    expect(resolveEngine("codex")).toBe("codex");
+    expect(resolveEngine("gemini")).toBe("gemini");
+  });
+
+  it("resolveEngine throws on unknown name", () => {
+    expect(() => resolveEngine("gpt4all")).toThrow("Unknown engine 'gpt4all'");
+  });
+
+  it("resolveEngine error message lists available engines", () => {
+    try {
+      resolveEngine("nope");
+    } catch (e: any) {
+      expect(e.message).toContain("claude");
+      expect(e.message).toContain("codex");
+    }
+  });
+
+  it("buildEngineCommand uses default model when none specified", () => {
+    const cmd = buildEngineCommand("claude", { promptPath: "/tmp/p.md" });
+    expect(cmd).toContain("sonnet");
+    expect(cmd).toContain("--prompt-file");
+  });
+
+  it("buildEngineCommand accepts custom model override", () => {
+    const cmd = buildEngineCommand("claude", { promptPath: "/tmp/p.md", model: "opus" });
+    expect(cmd).toContain("opus");
+    expect(cmd).not.toContain("sonnet");
+  });
+
+  it("buildEngineCommand uses stdin redirect for stdin-mode engines", () => {
+    const cmd = buildEngineCommand("codex", { promptPath: "/tmp/p.md" });
+    expect(cmd).toContain("< '/tmp/p.md'");
+    expect(cmd).not.toContain("--prompt-file");
+  });
+
+  it("buildEngineCommand uses --prompt-file for file-mode engines", () => {
+    const cmd = buildEngineCommand("aider", { promptPath: "/tmp/p.md" });
+    expect(cmd).toContain("--prompt-file '/tmp/p.md'");
+  });
+
+  it("buildEngineCommand escapes single quotes in path", () => {
+    const cmd = buildEngineCommand("claude", { promptPath: "/tmp/nat's file.md" });
+    expect(cmd).toContain("nat'\\''s file.md");
+  });
+
+  it("buildEngineCommand includes permission flag", () => {
+    const cmd = buildEngineCommand("codex", { promptPath: "/tmp/p.md" });
+    expect(cmd).toContain("-c approval_policy=never");
+  });
+
+  it("buildEngineCommand omits empty permission flag", () => {
+    const cmd = buildEngineCommand("opencode", { promptPath: "/tmp/p.md" });
+    expect(cmd).not.toContain("  "); // no double-space from empty flag
+    expect(cmd).toStartWith("opencode --model");
+  });
+
+  it("isEngineInstalled returns boolean for claude", () => {
+    const result = isEngineInstalled("claude");
+    expect(typeof result).toBe("boolean");
+  });
+});
+
+describe("resolveDefaultEngine — override chain (#1205)", () => {
+  const savedEnv = process.env.MAW_ENGINE;
+
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env.MAW_ENGINE;
+    else process.env.MAW_ENGINE = savedEnv;
+  });
+
+  it("returns claude when no overrides set", () => {
+    delete process.env.MAW_ENGINE;
+    expect(resolveDefaultEngine()).toBe("claude");
+  });
+
+  it("MAW_ENGINE env var wins over everything", () => {
+    process.env.MAW_ENGINE = "codex";
+    expect(resolveDefaultEngine()).toBe("codex");
+  });
+
+  it("ignores invalid MAW_ENGINE values", () => {
+    process.env.MAW_ENGINE = "invalid-engine";
+    expect(resolveDefaultEngine()).toBe("claude");
+  });
+});

--- a/src/commands/shared/engines.ts
+++ b/src/commands/shared/engines.ts
@@ -1,0 +1,123 @@
+/**
+ * Type-safe AI engine registry (#1201).
+ *
+ * Uses `as const` (viem/abitype pattern) so TypeScript derives EngineName
+ * union, default models, and binary names from the data — adding an engine
+ * is one line, zero type definitions to update.
+ */
+
+/** Engine definitions — the single source of truth. */
+export const ENGINE_DEFS = {
+  claude: {
+    binary: "claude",
+    defaultModel: "sonnet",
+    permissionFlag: "--dangerously-skip-permissions",
+    promptMode: "file" as const,
+  },
+  codex: {
+    binary: "codex",
+    defaultModel: "gpt-5.5",
+    permissionFlag: "-c approval_policy=never",
+    promptMode: "stdin" as const,
+  },
+  gemini: {
+    binary: "gemini",
+    defaultModel: "gemini-2.5-pro",
+    permissionFlag: "--sandbox",
+    promptMode: "stdin" as const,
+  },
+  opencode: {
+    binary: "opencode",
+    defaultModel: "sonnet",
+    permissionFlag: "",
+    promptMode: "stdin" as const,
+  },
+  aider: {
+    binary: "aider",
+    defaultModel: "sonnet",
+    permissionFlag: "--yes-always",
+    promptMode: "file" as const,
+  },
+} as const;
+
+/** Union of all registered engine names — auto-derived from ENGINE_DEFS. */
+export type EngineName = keyof typeof ENGINE_DEFS;
+
+/** Config shape for a specific engine. */
+export type EngineConfig<T extends EngineName = EngineName> = (typeof ENGINE_DEFS)[T];
+
+/** All registered engine names as a runtime array. */
+export const ENGINE_NAMES = Object.keys(ENGINE_DEFS) as EngineName[];
+
+/** Narrow a runtime string to EngineName or throw. */
+export function resolveEngine(name: string): EngineName {
+  if (name in ENGINE_DEFS) return name as EngineName;
+  throw new Error(
+    `Unknown engine '${name}'. Available: ${ENGINE_NAMES.join(", ")}`,
+  );
+}
+
+/** Check if an engine's binary is installed. */
+export function isEngineInstalled(engine: EngineName): boolean {
+  try {
+    const { execSync } = require("child_process");
+    execSync(`which ${ENGINE_DEFS[engine].binary}`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve the default engine via override chain (#1205):
+ *   1. $MAW_ENGINE env var (highest — CI, scripts)
+ *   2. <repoPath>/.claude/engine.json → { "engine": "codex" }
+ *   3. maw.config.json → { "defaultEngine": "codex" }
+ *   4. "claude" (lowest — the built-in default)
+ */
+export function resolveDefaultEngine(repoPath?: string): EngineName {
+  // 1. Env override
+  const envEngine = process.env.MAW_ENGINE;
+  if (envEngine && envEngine in ENGINE_DEFS) return envEngine as EngineName;
+
+  // 2. Per-repo config
+  if (repoPath) {
+    try {
+      const { existsSync, readFileSync } = require("fs");
+      const { join } = require("path");
+      const configPath = join(repoPath, ".claude", "engine.json");
+      if (existsSync(configPath)) {
+        const cfg = JSON.parse(readFileSync(configPath, "utf8"));
+        if (cfg.engine && cfg.engine in ENGINE_DEFS) return cfg.engine as EngineName;
+      }
+    } catch {}
+  }
+
+  // 3. Global config (lazy-import to avoid circular dep with config module)
+  try {
+    const { loadConfig } = require("../../config");
+    const globalEngine = loadConfig().defaultEngine;
+    if (globalEngine && globalEngine in ENGINE_DEFS) return globalEngine as EngineName;
+  } catch {}
+
+  // 4. Built-in default
+  return "claude";
+}
+
+/** Build a shell command to invoke an engine with a prompt file. */
+export function buildEngineCommand<T extends EngineName>(
+  engine: T,
+  opts: { model?: string; promptPath: string },
+): string {
+  const config = ENGINE_DEFS[engine];
+  const model = opts.model ?? config.defaultModel;
+  const escaped = opts.promptPath.replace(/'/g, "'\\''");
+  const perm = config.permissionFlag ? ` ${config.permissionFlag}` : "";
+
+  switch (config.promptMode) {
+    case "file":
+      return `${config.binary}${perm} --model ${model} --prompt-file '${escaped}'`;
+    case "stdin":
+      return `${config.binary}${perm} --model ${model} < '${escaped}'`;
+  }
+}


### PR DESCRIPTION
## Summary

Type-safe AI engine registry using `as const` pattern. Foundation for #1202-#1206.

5 engines: claude, codex, gemini, opencode, aider. Adding a new engine = one line.

- `resolveEngine("codex")` → type-narrowed `EngineName`
- `buildEngineCommand("codex", { promptPath })` → shell-safe command
- `resolveDefaultEngine(repoPath?)` → override chain: $MAW_ENGINE > .claude/engine.json > config > "claude"
- `isEngineInstalled("codex")` → which check

Tests: 16/16 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)