### PR TITLE
release: v26.5.12-alpha.714 — --engine flag for team spawn (#1201 + #1202)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.12-alpha.645",
+  "version": "26.5.12-alpha.712",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.12-alpha.712",
+  "version": "26.5.12-alpha.714",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/plugins/team/index.ts
+++ b/src/commands/plugins/team/index.ts
@@ -103,7 +103,7 @@ general flags: --description <text>, --members <list>`,
       cmdTeamCreate(args[1], { description });
     } else if (sub === "spawn") {
       if (!args[1] || !args[2]) {
-        logs.push("usage: maw team spawn <team> <role> [--model <m>] [--type <t>] [--color <c>] [--exec] [--prompt <p>]");
+        logs.push("usage: maw team spawn <team> <role> [--engine <e>] [--model <m>] [--type <t>] [--color <c>] [--exec] [--prompt <p>]");
         return { ok: false, error: "team and role required", output: logs.join("\n") };
       }
       const modelIdx = args.indexOf("--model");
@@ -114,13 +114,17 @@ general flags: --description <text>, --members <list>`,
       const color = colorIdx !== -1 ? args[colorIdx + 1] : undefined;
       const promptIdx = args.indexOf("--prompt");
       const exec = args.includes("--exec");
+      // --engine <name> or --codex shorthand (#1202)
+      const engineIdx = args.indexOf("--engine");
+      let engine = engineIdx !== -1 ? args[engineIdx + 1] : undefined;
+      if (args.includes("--codex")) engine = "codex";
       // --prompt is greedy to end-of-argv; strip known flags if they appear in the tail
       let prompt: string | undefined;
       if (promptIdx !== -1) {
-        const tail = args.slice(promptIdx + 1).filter(a => a !== "--exec");
+        const tail = args.slice(promptIdx + 1).filter(a => a !== "--exec" && a !== "--codex");
         prompt = tail.join(" ") || undefined;
       }
-      await cmdTeamSpawn(args[1], args[2], { model, prompt, exec, type, color });
+      await cmdTeamSpawn(args[1], args[2], { model, prompt, exec, engine, type, color });
     } else if (sub === "send" || sub === "msg") {
       if (!args[1] || !args[2] || !args[3]) {
         logs.push("usage: maw team send <team> <agent> <message>");

--- a/src/commands/plugins/team/team-lifecycle.ts
+++ b/src/commands/plugins/team/team-lifecycle.ts
@@ -180,7 +180,7 @@ export function cmdTeamCreate(name: string, opts: { description?: string } = {})
 export async function cmdTeamSpawn(
   teamName: string,
   role: string,
-  opts: { model?: string; prompt?: string; exec?: boolean; type?: string; color?: string } = {},
+  opts: { model?: string; prompt?: string; exec?: boolean; engine?: string; type?: string; color?: string } = {},
 ) {
   const PSI = resolvePsi();
   const teamDir = join(PSI, "memory", "mailbox", "teams", teamName);
@@ -215,8 +215,12 @@ export async function cmdTeamSpawn(
     } catch { /* no findings */ }
   }
 
-  // Build spawn prompt
-  const model = opts.model || "sonnet";
+  // Resolve engine (#1202) — defaults to claude, supports --engine codex etc.
+  const { resolveEngine, ENGINE_DEFS, buildEngineCommand } = await import("../../shared/engines");
+  const engineName = opts.engine ? resolveEngine(opts.engine) : "claude";
+  const engineConfig = ENGINE_DEFS[engineName];
+  const isClaudeEngine = engineName === "claude";
+  const model = opts.model || engineConfig.defaultModel;
   const parts: string[] = [];
   parts.push(`You are '${role}' on team '${teamName}'.`);
   if (opts.prompt) parts.push(opts.prompt);
@@ -242,7 +246,7 @@ export async function cmdTeamSpawn(
   if (existsSync(toolConfigPath)) {
     try {
       const toolConfig = JSON.parse(readFileSync(toolConfigPath, "utf-8"));
-      const member: TeamMember = { name: role, model };
+      const member: TeamMember = { name: role, model, backendType: engineName };
       if (!toolConfig.members.some((m: any) => m.name === role)) {
         toolConfig.members.push(member);
         // lgtm[js/file-system-race] — PRIVATE-PATH: tool config under ~/.maw/teams/<team>/ (#393), see docs/security/file-system-race-stance.md
@@ -253,6 +257,7 @@ export async function cmdTeamSpawn(
 
   console.log(`\x1b[32m✓\x1b[0m spawn prompt written for '${role}'`);
   console.log(`  \x1b[90mpast life: ${pastLife ? "yes" : "no"}\x1b[0m`);
+  console.log(`  \x1b[90mengine: ${engineName} (${engineConfig.binary})\x1b[0m`);
   console.log(`  \x1b[90mmodel: ${model}\x1b[0m`);
   console.log(`  \x1b[90mprompt: ${promptPath}\x1b[0m`);
 
@@ -279,17 +284,24 @@ export async function cmdTeamSpawn(
     `--system-prompt-file '${promptPath.replace(/'/g, "'\\''")}'`,
   ].filter(Boolean).join(" ");
 
+  // For non-claude engines, build the command from the registry (#1202).
+  // Claude keeps its agent-teams-aware command with --agent-id etc.
+  const escapedPromptPath = promptPath.replace(/'/g, "'\\''");
+  const agentCmd = isClaudeEngine
+    ? claudeCmd
+    : buildEngineCommand(engineName, { model, promptPath: escapedPromptPath });
+
   if (opts.exec) {
     if (!process.env.TMUX) {
       console.log();
       console.log(`  \x1b[33m⚠\x1b[0m --exec requires an active tmux session ($TMUX not set).`);
-      console.log(`  \x1b[36mRun manually:\x1b[0m ${claudeCmd}`);
+      console.log(`  \x1b[36mRun manually:\x1b[0m ${agentCmd}`);
       return;
     }
     try {
       const { spawnTeammatePane, colorAnsi } = await import("../tmux/layout-manager");
 
-      const result = await spawnTeammatePane(role, claudeCmd, { colorIndex: teammateCount });
+      const result = await spawnTeammatePane(role, agentCmd, { colorIndex: teammateCount });
 
       // Persist pane state to tool store config (~/.claude/teams/)
       const toolConfigPath = join(TEAMS_DIR, teamName, "config.json");

--- a/src/commands/shared/engines.test.ts
+++ b/src/commands/shared/engines.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import {
+  ENGINE_DEFS,
+  ENGINE_NAMES,
+  resolveEngine,
+  isEngineInstalled,
+  buildEngineCommand,
+  resolveDefaultEngine,
+} from "./engines";
+
+describe("engines — as-const registry (#1201)", () => {
+  it("ENGINE_NAMES matches ENGINE_DEFS keys", () => {
+    expect([...ENGINE_NAMES].sort()).toEqual(Object.keys(ENGINE_DEFS).sort());
+  });
+
+  it("every engine has required fields", () => {
+    for (const name of ENGINE_NAMES) {
+      const e = ENGINE_DEFS[name];
+      expect(typeof e.binary).toBe("string");
+      expect(typeof e.defaultModel).toBe("string");
+      expect(typeof e.permissionFlag).toBe("string");
+      expect(["file", "stdin"]).toContain(e.promptMode);
+    }
+  });
+
+  it("resolveEngine accepts valid names", () => {
+    expect(resolveEngine("claude")).toBe("claude");
+    expect(resolveEngine("codex")).toBe("codex");
+    expect(resolveEngine("gemini")).toBe("gemini");
+  });
+
+  it("resolveEngine throws on unknown name", () => {
+    expect(() => resolveEngine("gpt4all")).toThrow("Unknown engine 'gpt4all'");
+  });
+
+  it("resolveEngine error message lists available engines", () => {
+    try {
+      resolveEngine("nope");
+    } catch (e: any) {
+      expect(e.message).toContain("claude");
+      expect(e.message).toContain("codex");
+    }
+  });
+
+  it("buildEngineCommand uses default model when none specified", () => {
+    const cmd = buildEngineCommand("claude", { promptPath: "/tmp/p.md" });
+    expect(cmd).toContain("sonnet");
+    expect(cmd).toContain("--prompt-file");
+  });
+
+  it("buildEngineCommand accepts custom model override", () => {
+    const cmd = buildEngineCommand("claude", { promptPath: "/tmp/p.md", model: "opus" });
+    expect(cmd).toContain("opus");
+    expect(cmd).not.toContain("sonnet");
+  });
+
+  it("buildEngineCommand uses stdin redirect for stdin-mode engines", () => {
+    const cmd = buildEngineCommand("codex", { promptPath: "/tmp/p.md" });
+    expect(cmd).toContain("< '/tmp/p.md'");
+    expect(cmd).not.toContain("--prompt-file");
+  });
+
+  it("buildEngineCommand uses --prompt-file for file-mode engines", () => {
+    const cmd = buildEngineCommand("aider", { promptPath: "/tmp/p.md" });
+    expect(cmd).toContain("--prompt-file '/tmp/p.md'");
+  });
+
+  it("buildEngineCommand escapes single quotes in path", () => {
+    const cmd = buildEngineCommand("claude", { promptPath: "/tmp/nat's file.md" });
+    expect(cmd).toContain("nat'\\''s file.md");
+  });
+
+  it("buildEngineCommand includes permission flag", () => {
+    const cmd = buildEngineCommand("codex", { promptPath: "/tmp/p.md" });
+    expect(cmd).toContain("-c approval_policy=never");
+  });
+
+  it("buildEngineCommand omits empty permission flag", () => {
+    const cmd = buildEngineCommand("opencode", { promptPath: "/tmp/p.md" });
+    expect(cmd).not.toContain("  "); // no double-space from empty flag
+    expect(cmd).toStartWith("opencode --model");
+  });
+
+  it("isEngineInstalled returns boolean for claude", () => {
+    const result = isEngineInstalled("claude");
+    expect(typeof result).toBe("boolean");
+  });
+});
+
+describe("resolveDefaultEngine — override chain (#1205)", () => {
+  const savedEnv = process.env.MAW_ENGINE;
+
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env.MAW_ENGINE;
+    else process.env.MAW_ENGINE = savedEnv;
+  });
+
+  it("returns claude when no overrides set", () => {
+    delete process.env.MAW_ENGINE;
+    expect(resolveDefaultEngine()).toBe("claude");
+  });
+
+  it("MAW_ENGINE env var wins over everything", () => {
+    process.env.MAW_ENGINE = "codex";
+    expect(resolveDefaultEngine()).toBe("codex");
+  });
+
+  it("ignores invalid MAW_ENGINE values", () => {
+    process.env.MAW_ENGINE = "invalid-engine";
+    expect(resolveDefaultEngine()).toBe("claude");
+  });
+});

--- a/src/commands/shared/engines.ts
+++ b/src/commands/shared/engines.ts
@@ -1,0 +1,123 @@
+/**
+ * Type-safe AI engine registry (#1201).
+ *
+ * Uses `as const` (viem/abitype pattern) so TypeScript derives EngineName
+ * union, default models, and binary names from the data — adding an engine
+ * is one line, zero type definitions to update.
+ */
+
+/** Engine definitions — the single source of truth. */
+export const ENGINE_DEFS = {
+  claude: {
+    binary: "claude",
+    defaultModel: "sonnet",
+    permissionFlag: "--dangerously-skip-permissions",
+    promptMode: "file" as const,
+  },
+  codex: {
+    binary: "codex",
+    defaultModel: "gpt-5.5",
+    permissionFlag: "-c approval_policy=never",
+    promptMode: "stdin" as const,
+  },
+  gemini: {
+    binary: "gemini",
+    defaultModel: "gemini-2.5-pro",
+    permissionFlag: "--sandbox",
+    promptMode: "stdin" as const,
+  },
+  opencode: {
+    binary: "opencode",
+    defaultModel: "sonnet",
+    permissionFlag: "",
+    promptMode: "stdin" as const,
+  },
+  aider: {
+    binary: "aider",
+    defaultModel: "sonnet",
+    permissionFlag: "--yes-always",
+    promptMode: "file" as const,
+  },
+} as const;
+
+/** Union of all registered engine names — auto-derived from ENGINE_DEFS. */
+export type EngineName = keyof typeof ENGINE_DEFS;
+
+/** Config shape for a specific engine. */
+export type EngineConfig<T extends EngineName = EngineName> = (typeof ENGINE_DEFS)[T];
+
+/** All registered engine names as a runtime array. */
+export const ENGINE_NAMES = Object.keys(ENGINE_DEFS) as EngineName[];
+
+/** Narrow a runtime string to EngineName or throw. */
+export function resolveEngine(name: string): EngineName {
+  if (name in ENGINE_DEFS) return name as EngineName;
+  throw new Error(
+    `Unknown engine '${name}'. Available: ${ENGINE_NAMES.join(", ")}`,
+  );
+}
+
+/** Check if an engine's binary is installed. */
+export function isEngineInstalled(engine: EngineName): boolean {
+  try {
+    const { execSync } = require("child_process");
+    execSync(`which ${ENGINE_DEFS[engine].binary}`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve the default engine via override chain (#1205):
+ *   1. $MAW_ENGINE env var (highest — CI, scripts)
+ *   2. <repoPath>/.claude/engine.json → { "engine": "codex" }
+ *   3. maw.config.json → { "defaultEngine": "codex" }
+ *   4. "claude" (lowest — the built-in default)
+ */
+export function resolveDefaultEngine(repoPath?: string): EngineName {
+  // 1. Env override
+  const envEngine = process.env.MAW_ENGINE;
+  if (envEngine && envEngine in ENGINE_DEFS) return envEngine as EngineName;
+
+  // 2. Per-repo config
+  if (repoPath) {
+    try {
+      const { existsSync, readFileSync } = require("fs");
+      const { join } = require("path");
+      const configPath = join(repoPath, ".claude", "engine.json");
+      if (existsSync(configPath)) {
+        const cfg = JSON.parse(readFileSync(configPath, "utf8"));
+        if (cfg.engine && cfg.engine in ENGINE_DEFS) return cfg.engine as EngineName;
+      }
+    } catch {}
+  }
+
+  // 3. Global config (lazy-import to avoid circular dep with config module)
+  try {
+    const { loadConfig } = require("../../config");
+    const globalEngine = loadConfig().defaultEngine;
+    if (globalEngine && globalEngine in ENGINE_DEFS) return globalEngine as EngineName;
+  } catch {}
+
+  // 4. Built-in default
+  return "claude";
+}
+
+/** Build a shell command to invoke an engine with a prompt file. */
+export function buildEngineCommand<T extends EngineName>(
+  engine: T,
+  opts: { model?: string; promptPath: string },
+): string {
+  const config = ENGINE_DEFS[engine];
+  const model = opts.model ?? config.defaultModel;
+  const escaped = opts.promptPath.replace(/'/g, "'\\''");
+  const perm = config.permissionFlag ? ` ${config.permissionFlag}` : "";
+
+  switch (config.promptMode) {
+    case "file":
+      return `${config.binary}${perm} --model ${model} --prompt-file '${escaped}'`;
+    case "stdin":
+      return `${config.binary}${perm} --model ${model} < '${escaped}'`;
+  }
+}


### PR DESCRIPTION
## Summary

Bundles #1201 (engine registry) + #1202 (--engine flag) since #1202 depends on #1201.

**#1201**: `src/commands/shared/engines.ts` — type-safe as-const engine registry (claude, codex, gemini, opencode, aider). 16 tests.

**#1202**: `--engine <name>` flag on `maw team spawn`. Replaces the proposed `--codex` boolean from PR #1185. `--codex` kept as shorthand. Shell injection fixed by design — each engine's `buildEngineCommand` handles its own quoting.

```bash
maw team spawn myteam coder --engine codex --exec
maw team spawn myteam reviewer --engine gemini --exec
maw team spawn myteam lead --exec  # default: claude
```

Also adds `resolveDefaultEngine(repoPath?)` — override chain: `$MAW_ENGINE` > `.claude/engine.json` > `maw.config.json` > `"claude"`.

Closes #1201, closes #1202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)