### PR TITLE
release: v26.5.12-alpha.721 — maw engine ls (#1203)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.12-alpha.714",
+  "version": "26.5.12-alpha.721",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/plugins/engine/index.ts
+++ b/src/commands/plugins/engine/index.ts
@@ -1,0 +1,90 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { ENGINE_DEFS, ENGINE_NAMES, isEngineInstalled, resolveDefaultEngine, type EngineName } from "../../shared/engines";
+
+export const command = {
+  name: "engine",
+  description: "Manage AI engine backends — list, check, set default.",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+
+  try {
+    const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+    const sub = args[0]?.toLowerCase();
+
+    if (sub === "ls" || sub === "list" || !sub) {
+      const current = resolveDefaultEngine();
+      const json = args.includes("--json");
+
+      if (json) {
+        const data = ENGINE_NAMES.map(name => ({
+          name,
+          binary: ENGINE_DEFS[name].binary,
+          defaultModel: ENGINE_DEFS[name].defaultModel,
+          promptMode: ENGINE_DEFS[name].promptMode,
+          installed: isEngineInstalled(name),
+          active: name === current,
+        }));
+        console.log(JSON.stringify(data, null, 2));
+      } else {
+        console.log(`  \x1b[36;1mEngine${" ".repeat(12)}Binary${" ".repeat(10)}Model${" ".repeat(12)}Mode${" ".repeat(4)}Status\x1b[0m`);
+        console.log(`  ${"─".repeat(18)}${"─".repeat(16)}${"─".repeat(17)}${"─".repeat(8)}${"─".repeat(16)}`);
+        for (const name of ENGINE_NAMES) {
+          const e = ENGINE_DEFS[name];
+          const installed = isEngineInstalled(name);
+          const status = installed ? "\x1b[32m✓ installed\x1b[0m" : "\x1b[90mnot found\x1b[0m";
+          const active = name === current ? " \x1b[33m←\x1b[0m" : "";
+          console.log(
+            `  ${name.padEnd(18)}${e.binary.padEnd(16)}${e.defaultModel.padEnd(17)}${e.promptMode.padEnd(8)}${status}${active}`,
+          );
+        }
+        console.log(`\n  default: \x1b[36m${current}\x1b[0m (override: --engine <name>, $MAW_ENGINE, .claude/engine.json)`);
+      }
+
+    } else if (sub === "check") {
+      const target = args[1];
+      if (target) {
+        const name = target as EngineName;
+        if (!(name in ENGINE_DEFS)) {
+          console.log(`  \x1b[31m✗\x1b[0m unknown engine: ${name}`);
+          console.log(`  available: ${ENGINE_NAMES.join(", ")}`);
+          return { ok: false, error: `unknown engine: ${name}` };
+        }
+        const installed = isEngineInstalled(name);
+        const e = ENGINE_DEFS[name];
+        console.log(`  ${installed ? "\x1b[32m✓\x1b[0m" : "\x1b[31m✗\x1b[0m"} ${name}: ${e.binary} ${installed ? "(installed)" : "(not found in PATH)"}`);
+        if (!installed) {
+          console.log(`  install: check ${e.binary} documentation`);
+        }
+      } else {
+        let installed = 0;
+        for (const name of ENGINE_NAMES) {
+          const ok = isEngineInstalled(name);
+          if (ok) installed++;
+          console.log(`  ${ok ? "\x1b[32m✓\x1b[0m" : "\x1b[31m✗\x1b[0m"} ${name} (${ENGINE_DEFS[name].binary})`);
+        }
+        console.log(`\n  ${installed}/${ENGINE_NAMES.length} engines installed`);
+      }
+
+    } else {
+      console.log("usage: maw engine <ls|check> [engine-name] [--json]");
+      console.log("");
+      console.log("  maw engine ls              list all engines + install status");
+      console.log("  maw engine ls --json       machine-readable output");
+      console.log("  maw engine check           check all engines installed");
+      console.log("  maw engine check codex     check specific engine");
+    }
+
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: e?.message || String(e), output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+  }
+}

--- a/src/commands/plugins/engine/plugin.json
+++ b/src/commands/plugins/engine/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "engine",
+  "version": "0.1.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Manage AI engine backends — list, check, set default.",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "engine",
+    "help": "maw engine <ls|check|set> — manage AI backends"
+  },
+  "weight": 0
+}


### PR DESCRIPTION
New plugin: `maw engine ls/check`. Lists all registered AI backends with install status. Closes #1203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)