### PR TITLE
release: v26.5.12-alpha.736 — maw wake/show --engine (#1205)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.12-alpha.728",
+  "version": "26.5.12-alpha.736",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -241,10 +241,12 @@ export async function invokeDirectHandler(
   if (exportName === "cmdShow") {
     const oracle = argv[0];
     if (!oracle) {
-      console.error("usage: maw show <oracle>");
+      console.error("usage: maw show <oracle> [--engine <name>]");
       process.exit(1);
     }
-    await cmdShow(oracle);
+    const engineIdx = argv.indexOf("--engine");
+    const engine = engineIdx !== -1 ? argv[engineIdx + 1] : undefined;
+    await cmdShow(oracle, { engine });
     return;
   }
 

--- a/src/commands/shared/wake-show.ts
+++ b/src/commands/shared/wake-show.ts
@@ -4,9 +4,9 @@ import { normalizeTarget } from "../../core/matcher/normalize-target";
 import { UserError } from "../../core/util/user-error";
 import { readFileSync } from "fs";
 
-export async function cmdShow(oracle: string): Promise<void> {
+export async function cmdShow(oracle: string, showOpts?: { engine?: string }): Promise<void> {
   if (!oracle) {
-    console.error("usage: maw show <oracle>");
+    console.error("usage: maw show <oracle> [--engine <name>]");
     throw new UserError("missing oracle name");
   }
 
@@ -21,8 +21,8 @@ export async function cmdShow(oracle: string): Promise<void> {
   const permissionMode = getChannelPermissionMode(oracle, repoPath);
 
   const opts = channelIds.length
-    ? { channels: channelIds, channelEnv, permissionMode }
-    : undefined;
+    ? { engine: showOpts?.engine, channels: channelIds, channelEnv, permissionMode }
+    : showOpts?.engine ? { engine: showOpts.engine } : undefined;
 
   const scriptPath = writeSessionScript(windowName, repoPath, opts);
   process.stdout.write(readFileSync(scriptPath, "utf-8"));

--- a/src/config/command.ts
+++ b/src/config/command.ts
@@ -49,6 +49,21 @@ export function buildCommand(agentName: string, optsOrEngine?: string | BuildCom
   const opts: BuildCommandOpts = typeof optsOrEngine === "string"
     ? { engine: optsOrEngine }
     : (optsOrEngine || {});
+
+  // #1205 — non-claude engines: use the engine registry for interactive mode.
+  // Team-spawn uses buildEngineCommand (with prompt file); wake just starts
+  // the engine's interactive CLI with permission flags.
+  if (opts.engine) {
+    try {
+      const { ENGINE_DEFS } = require("../commands/shared/engines");
+      const engineDef = ENGINE_DEFS[opts.engine as keyof typeof ENGINE_DEFS];
+      if (engineDef && engineDef.binary !== "claude") {
+        const perm = engineDef.permissionFlag ? ` ${engineDef.permissionFlag}` : "";
+        return `${engineDef.binary}${perm}`;
+      }
+    } catch {}
+  }
+
   const config = loadConfig();
   let cmd: string;
 
@@ -174,6 +189,24 @@ function formatScriptBody(agentName: string, opts: BuildCommandOpts): string {
       }
       lines.push("");
     }
+  }
+
+  // #1205 — non-claude engines: simple interactive command from registry.
+  if (opts.engine) {
+    try {
+      const { ENGINE_DEFS } = require("../commands/shared/engines");
+      const e = ENGINE_DEFS[opts.engine as keyof typeof ENGINE_DEFS];
+      if (e && e.binary !== "claude") {
+        const perm = e.permissionFlag ? ` ${e.permissionFlag}` : "";
+        lines.push(`${e.binary}${perm}`);
+        lines.push("");
+        lines.push("# Terminal reset");
+        lines.push('printf "\\e[?1049l\\e[0m"');
+        lines.push("stty sane 2>/dev/null");
+        lines.push("clear");
+        return lines.join("\n");
+      }
+    } catch {}
   }
 
   let cmd: string;


### PR DESCRIPTION
Closes #1205. `maw wake neo --engine codex` + `maw show neo --engine codex` work. Registry-typed (no hardcoded claude strings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)