### PR TITLE
chore: extract inline types — SessionInfo, TransportHandlers, ValidationResult, WakeCmdOptions

### DIFF
--- a/src/commands/plugins/channel/setup.ts
+++ b/src/commands/plugins/channel/setup.ts
@@ -35,18 +35,23 @@ function extractClientId(token: string): string | null {
   } catch { return null; }
 }
 
+interface DiscordGuild {
+  id: string;
+  name: string;
+}
+
 // #1170 — use native fetch instead of execSync curl: shell-spawned curl puts
 // the token in process argv (visible to `ps`, EDR, crash logs). fetch keeps
 // the token in-memory in this process only. AbortSignal.timeout matches the
 // 10s subprocess timeout this replaced.
-async function fetchGuilds(token: string): Promise<Array<{ id: string; name: string }>> {
+async function fetchGuilds(token: string): Promise<DiscordGuild[]> {
   try {
     const r = await fetch("https://discord.com/api/v10/users/@me/guilds", {
       headers: { Authorization: `Bot ${token}` },
       signal: AbortSignal.timeout(10_000),
     });
     if (!r.ok) return [];
-    const data = await r.json() as Array<{ id: string; name: string }>;
+    const data = await r.json() as DiscordGuild[];
     return data.map((g) => ({ id: g.id, name: g.name }));
   } catch { return []; }
 }

--- a/src/commands/plugins/plugin/install-extraction.ts
+++ b/src/commands/plugins/plugin/install-extraction.ts
@@ -2,7 +2,7 @@
  * install-impl seam: tarball extraction, URL download, artifact hash verify.
  */
 
-import type { PluginManifest } from "../../../plugin/types";
+import type { PluginManifest, ValidationResult } from "../../../plugin/types";
 import { spawnSync } from "child_process";
 import { existsSync, mkdtempSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
@@ -16,7 +16,7 @@ const MAX_DOWNLOAD_BYTES = 50 * 1024 * 1024; // 50 MB
  * We shell out to GNU tar rather than adding a `tar` npm dep — Bun ships without
  * streaming tar, and adding a dep for a single call is not worth it.
  */
-export function extractTarball(tarballPath: string, destDir: string): { ok: true } | { ok: false; error: string } {
+export function extractTarball(tarballPath: string, destDir: string): ValidationResult {
   // Path-traversal guard: list entries first, reject any that escape the staging dir.
   // GNU tar does not strip "../" by default; -C alone does not prevent traversal.
   const list = spawnSync("tar", ["-tzf", tarballPath], { encoding: "utf8" });
@@ -144,7 +144,7 @@ export function verifyArtifactHashAgainst(
   dir: string,
   manifest: PluginManifest,
   expected: string,
-): { ok: true } | { ok: false; error: string } {
+): ValidationResult {
   let relPath: string;
   // #896: entry-first when source-shaped — covers no-artifact AND
   // half-built (sha256:null) shapes uniformly.
@@ -189,7 +189,7 @@ export function verifyArtifactHashAgainst(
  * half-built (artifact.sha256===null) shapes when entry is present. Both
  * fall through to entry-only existence verification.
  */
-export function verifyArtifactHash(dir: string, manifest: PluginManifest): { ok: true } | { ok: false; error: string } {
+export function verifyArtifactHash(dir: string, manifest: PluginManifest): ValidationResult {
   if (isSourcePluginManifest(manifest)) {
     // Source plugins have no embedded sha256 to fencepost against. Verify the
     // entry file at least exists; the real adversarial check is plugins.lock.

--- a/src/commands/plugins/plugin/lock.ts
+++ b/src/commands/plugins/plugin/lock.ts
@@ -10,14 +10,13 @@
  * See ψ/writing/2026-04-18/plugin-hash-supply-chain-spec.md for the spec.
  */
 
-import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from "fs";
-import { homedir } from "os";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "fs";
+import { homedir, tmpdir } from "os";
 import { dirname, join } from "path";
 import { hashFile } from "../../../plugin/registry";
+import type { ValidationResult } from "../../../plugin/types";
 import { readManifest } from "./install-manifest-helpers";
 import { extractTarball } from "./install-extraction";
-import { mkdtempSync, rmSync } from "fs";
-import { tmpdir } from "os";
 
 export const LOCK_SCHEMA = 1;
 
@@ -48,7 +47,7 @@ export function lockPath(): string {
 }
 
 /** Validate sha256 is a canonical "sha256:" + 64 lowercase hex, or bare 64-hex. */
-export function validateSha256(value: string): { ok: true } | { ok: false; error: string } {
+export function validateSha256(value: string): ValidationResult {
   const s = typeof value === "string" ? value : "";
   const hex = s.startsWith("sha256:") ? s.slice("sha256:".length) : s;
   if (!/^[0-9a-f]{64}$/.test(hex)) {
@@ -58,7 +57,7 @@ export function validateSha256(value: string): { ok: true } | { ok: false; error
 }
 
 /** Plugin names: segmented by '/', lowercase alnum + . _ - within segments. */
-export function validateName(name: string): { ok: true } | { ok: false; error: string } {
+export function validateName(name: string): ValidationResult {
   if (typeof name !== "string" || name.length === 0) {
     return { ok: false, error: "plugin name required" };
   }

--- a/src/commands/shared/plugins-ls-info.ts
+++ b/src/commands/shared/plugins-ls-info.ts
@@ -59,8 +59,13 @@ export function doLs(json: boolean, showAll: boolean, discover: () => LoadedPlug
     return;
   }
 
+  interface PluginTierGroup {
+    label: PluginTier;
+    plugins: LoadedPlugin[];
+  }
+
   // Group by effective tier (#675 — explicit tier field, fallback to weight-inferred)
-  const tiers: { label: PluginTier; plugins: LoadedPlugin[] }[] = [
+  const tiers: PluginTierGroup[] = [
     { label: "core", plugins: [] },
     { label: "standard", plugins: [] },
     { label: "extra", plugins: [] },

--- a/src/commands/shared/pulse-cmd.ts
+++ b/src/commands/shared/pulse-cmd.ts
@@ -52,6 +52,12 @@ export async function cmdPulseAdd(title: string, opts: { oracle?: string; priori
   }
 }
 
+interface PulseIssue {
+  number: number;
+  title: string;
+  labels: { name: string }[];
+}
+
 export async function cmdPulseLs(opts: { sync?: boolean }) {
   const repo = "laris-co/pulse-oracle";
 
@@ -59,7 +65,7 @@ export async function cmdPulseLs(opts: { sync?: boolean }) {
   const issuesJson = (await hostExec(
     `gh issue list --repo ${repo} --state open --json number,title,labels --limit 50`
   )).trim();
-  const issues: { number: number; title: string; labels: { name: string }[] }[] = JSON.parse(issuesJson || "[]");
+  const issues: PulseIssue[] = JSON.parse(issuesJson || "[]");
 
   // Categorize
   const projects: typeof issues = [];

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -10,7 +10,23 @@ import { attachToSession, ensureSessionRunning, createWorktree } from "./wake-se
 import { maybeSplit } from "./wake-maybe-split";
 import { parseWakeTarget, ensureCloned } from "./wake-target";
 
-export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; noAttach?: boolean; listWt?: boolean; split?: boolean; repoPath?: string; urlRepoName?: string; allLocal?: boolean; engine?: string }): Promise<string> {
+export interface WakeCmdOptions {
+  task?: string;
+  wt?: string;
+  prompt?: string;
+  incubate?: string;
+  fresh?: boolean;
+  attach?: boolean;
+  noAttach?: boolean;
+  listWt?: boolean;
+  split?: boolean;
+  repoPath?: string;
+  urlRepoName?: string;
+  allLocal?: boolean;
+  engine?: string;
+}
+
+export async function cmdWake(oracle: string, opts: WakeCmdOptions): Promise<string> {
   // #1151 — reject flag-shaped names. parseFlags lands unrecognized flags
   // (e.g. --help) in positional `_`, so they reach here as oracle="--help"
   // and (without this guard) get sanitized into session names like `26---help`.

--- a/src/core/fleet/snapshot.ts
+++ b/src/core/fleet/snapshot.ts
@@ -77,8 +77,16 @@ export async function takeSnapshot(trigger: string): Promise<string> {
   return filepath;
 }
 
+export interface SnapshotListEntry {
+  file: string;
+  timestamp: string;
+  trigger: string;
+  sessionCount: number;
+  windowCount: number;
+}
+
 /** List all snapshots, newest first */
-export function listSnapshots(): { file: string; timestamp: string; trigger: string; sessionCount: number; windowCount: number }[] {
+export function listSnapshots(): SnapshotListEntry[] {
   const files = readdirSync(SNAPSHOT_DIR)
     .filter(f => f.endsWith(".json"))
     .sort()

--- a/src/core/runtime/handlers.ts
+++ b/src/core/runtime/handlers.ts
@@ -15,6 +15,11 @@ async function runAction(ws: MawWS, action: string, target: string, fn: () => Pr
   }
 }
 
+export interface HandlerTarget { target: string }
+export interface HandlerScopedTarget { scope?: string; target: string }
+export interface HandlerSendData { force?: boolean; target: string; text: string }
+export interface SpawnCommandData { target?: string; command?: string; cwd?: string }
+
 // --- Handlers ---
 
 const subscribe: Handler = (ws, data, engine) => {
@@ -22,7 +27,7 @@ const subscribe: Handler = (ws, data, engine) => {
   // scope "preview" adds to previewTargets — used by FleetGrid pinned cards,
   //   VSAgentPanel, useMissionControl pin so they don't clobber the active
   //   TerminalView target on the same singleton WS (echo 2026-04-29).
-  const d = data as { scope?: string; target: string };
+  const d = data as HandlerScopedTarget;
   const scope = d.scope === "preview" ? "preview" : "main";
   if (scope === "main") {
     ws.data.target = d.target;
@@ -41,13 +46,13 @@ const subscribePreviews: Handler = (ws, data, engine) => {
 };
 
 const select: Handler = (_ws, data) => {
-  const d = data as { target: string };
+  const d = data as HandlerTarget;
   selectWindow(d.target).catch(() => { /* expected: window may not exist */ });
 };
 
 const send: Handler = async (ws, data, engine) => {
   // Check for active Claude session before sending (#17)
-  const d = data as { force?: boolean; target: string; text: string };
+  const d = data as HandlerSendData;
   if (!d.force) {
     try {
       const cmd = await getPaneCommand(d.target);
@@ -69,12 +74,12 @@ const send: Handler = async (ws, data, engine) => {
 };
 
 const sleep: Handler = (ws, data) => {
-  const d = data as { target: string };
+  const d = data as HandlerTarget;
   runAction(ws, "sleep", d.target, () => sendKeys(d.target, "\x03"));
 };
 
 const stop: Handler = (ws, data) => {
-  const d = data as { target: string };
+  const d = data as HandlerTarget;
   runAction(ws, "stop", d.target, () => tmux.killWindow(d.target));
 };
 
@@ -93,7 +98,7 @@ const stop: Handler = (ws, data) => {
  *   • Resolve the canonical cwd from fleet config and prepend `cd '<cwd>' && `
  *     when known. Non-fleet targets fall back to the bare cmd (pre-fix behavior).
  */
-function buildSpawnCmd(data: { target?: string; command?: string; cwd?: string }): string {
+function buildSpawnCmd(data: SpawnCommandData): string {
   const target = data.target || "";
   const oracle = extractOracleName(target);
   const baseCmd = data.command || buildCommand(oracle);
@@ -102,13 +107,13 @@ function buildSpawnCmd(data: { target?: string; command?: string; cwd?: string }
 }
 
 const wake: Handler = (ws, data) => {
-  const d = data as { target?: string; command?: string; cwd?: string };
+  const d = data as SpawnCommandData;
   const cmd = buildSpawnCmd(d);
   runAction(ws, "wake", d.target, () => sendKeys(d.target, cmd + "\r"));
 };
 
 const restart: Handler = (ws, data) => {
-  const d = data as { target?: string; command?: string; cwd?: string };
+  const d = data as SpawnCommandData;
   const cmd = buildSpawnCmd(d);
   runAction(ws, "restart", d.target, async () => {
     await sendKeys(d.target, "\x03"); // Ctrl+C

--- a/src/core/transport/transport.ts
+++ b/src/core/transport/transport.ts
@@ -67,6 +67,10 @@ export interface TransportPresence {
   timestamp: number;
 }
 
+export type MessageHandler = (msg: TransportMessage) => void;
+export type PresenceHandler = (p: TransportPresence) => void;
+export type FeedHandler = (e: FeedEvent) => void;
+
 /** Abstract transport — implementations handle different channels */
 export interface Transport {
   readonly name: string;

--- a/src/engine/capture.ts
+++ b/src/engine/capture.ts
@@ -1,8 +1,7 @@
 import { capture, isAgentCommand } from "../core/transport/ssh";
 import { tmux } from "../core/transport/tmux";
 import type { MawWS } from "../core/types";
-
-type SessionInfo = { name: string; windows: { index: number; name: string; active: boolean }[] };
+import type { SessionInfo } from "./types";
 
 /** Push terminal capture to a subscribed WebSocket client. */
 export async function pushCapture(

--- a/src/engine/engine-crash.ts
+++ b/src/engine/engine-crash.ts
@@ -3,8 +3,7 @@ import { loadConfig, buildCommand } from "../config";
 import type { FeedEvent } from "../lib/feed";
 import type { MawWS } from "../core/types";
 import type { StatusDetector } from "./status";
-
-type SessionInfo = { name: string; windows: { index: number; name: string; active: boolean }[] };
+import type { SessionInfo } from "./types";
 
 /** Auto-restart crashed agents if config.autoRestart is enabled. */
 export async function handleCrashedAgents(

--- a/src/engine/engine-intervals.ts
+++ b/src/engine/engine-intervals.ts
@@ -8,8 +8,7 @@ import type { Session } from "../core/transport/ssh";
 import type { TransportRouter } from "../core/transport/transport";
 import type { StatusDetector } from "./status";
 import { tmux } from "../core/transport/tmux";
-
-type SessionInfo = { name: string; windows: { index: number; name: string; active: boolean }[] };
+import type { SessionInfo } from "./types";
 
 export interface EngineIntervalState {
   clients: Set<MawWS>;

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -10,8 +10,7 @@ import type { Session } from "../core/transport/ssh";
 import type { TransportRouter } from "../core/transport/transport";
 import { startIntervals, stopIntervals, sendInitialSessions, type EngineIntervalState } from "./engine-intervals";
 import { handleCrashedAgents } from "./engine-crash";
-
-type SessionInfo = { name: string; windows: { index: number; name: string; active: boolean }[] };
+import type { SessionInfo } from "./types";
 
 export class MawEngine {
   private clients = new Set<MawWS>();

--- a/src/engine/status.ts
+++ b/src/engine/status.ts
@@ -2,6 +2,7 @@ import { capture, isAgentCommand } from "../core/transport/ssh";
 import { tmux } from "../core/transport/tmux";
 import type { FeedEvent } from "../lib/feed";
 import type { MawWS } from "../core/types";
+import type { SessionInfo } from "./types";
 
 interface AgentState {
   hash: string;
@@ -25,11 +26,6 @@ export interface CrashedAgent {
   target: string;
   name: string;
   session: string;
-}
-
-interface SessionInfo {
-  name: string;
-  windows: { index: number; name: string; active: boolean }[];
 }
 
 /** Strip Claude Code status bar lines before hashing (they change constantly even when idle) */

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -1,0 +1,10 @@
+export interface SessionWindow {
+  index: number;
+  name: string;
+  active: boolean;
+}
+
+export interface SessionInfo {
+  name: string;
+  windows: SessionWindow[];
+}

--- a/src/lib/artifacts.ts
+++ b/src/lib/artifacts.ts
@@ -131,14 +131,16 @@ export function listArtifacts(teamFilter?: string): ArtifactSummary[] {
   return results;
 }
 
-/** Get full artifact contents (spec + result + attachment list) */
-export function getArtifact(team: string, taskId: string): {
+interface ArtifactDetail {
   meta: ArtifactMeta;
   spec: string;
   result: string | null;
   attachments: string[];
   dir: string;
-} | null {
+}
+
+/** Get full artifact contents (spec + result + attachment list) */
+export function getArtifact(team: string, taskId: string): ArtifactDetail | null {
   const dir = join(ARTIFACTS_ROOT, team, taskId);
   const metaPath = join(dir, "meta.json");
   if (!existsSync(metaPath)) return null;

--- a/src/lib/peers/impl.ts
+++ b/src/lib/peers/impl.ts
@@ -139,7 +139,7 @@ export async function cmdAdd(opts: AddOptions): Promise<AddResult> {
  *
  * Throws if the alias does not exist.
  */
-export interface ProbeResult {
+export interface CmdProbeResult {
   alias: string;
   url: string;
   node: string | null;
@@ -149,7 +149,7 @@ export interface ProbeResult {
   pubkeyMismatch?: PeerPubkeyMismatchError;
 }
 
-export async function cmdProbe(alias: string): Promise<ProbeResult> {
+export async function cmdProbe(alias: string): Promise<CmdProbeResult> {
   const data = loadPeers();
   const existing = data.peers[alias];
   if (!existing) throw new Error(`peer "${alias}" not found`);

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -11,6 +11,9 @@
  *   entry: string → TS plugin (full maw-js internals access)
  */
 
+/** Discriminated ok/error result used by validation helpers throughout the plugin subsystem. */
+export type ValidationResult = { ok: true } | { ok: false; error: string };
+
 /**
  * Plugin compile target. Phase A ships `"js"` only. `"wasm"` is a reserved
  * slot for Phase C — parser validates+rejects today so the enum shape can

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -10,7 +10,7 @@ import { cfgTimeout } from "../config";
 import { listSessions } from "../core/transport/ssh";
 import { findWindow } from "../core/runtime/find-window";
 import { curlFetch } from "../core/transport/curl-fetch";
-import type { Transport, TransportTarget, TransportMessage, TransportPresence } from "../core/transport/transport";
+import type { Transport, TransportTarget, TransportPresence, MessageHandler, PresenceHandler, FeedHandler } from "../core/transport/transport";
 import type { FeedEvent } from "../lib/feed";
 
 export interface HttpTransportConfig {
@@ -23,9 +23,9 @@ export class HttpTransport implements Transport {
   readonly name = "http-federation";
   private _connected = false;
   private config: HttpTransportConfig;
-  private msgHandlers = new Set<(msg: TransportMessage) => void>();
-  private presenceHandlers = new Set<(p: TransportPresence) => void>();
-  private feedHandlers = new Set<(e: FeedEvent) => void>();
+  private msgHandlers = new Set<MessageHandler>();
+  private presenceHandlers = new Set<PresenceHandler>();
+  private feedHandlers = new Set<FeedHandler>();
 
   constructor(config: HttpTransportConfig) {
     this.config = config;
@@ -89,15 +89,15 @@ export class HttpTransport implements Transport {
     }
   }
 
-  onMessage(handler: (msg: TransportMessage) => void) {
+  onMessage(handler: MessageHandler) {
     this.msgHandlers.add(handler);
   }
 
-  onPresence(handler: (p: TransportPresence) => void) {
+  onPresence(handler: PresenceHandler) {
     this.presenceHandlers.add(handler);
   }
 
-  onFeed(handler: (e: FeedEvent) => void) {
+  onFeed(handler: FeedHandler) {
     this.feedHandlers.add(handler);
   }
 

--- a/src/transports/hub-transport.ts
+++ b/src/transports/hub-transport.ts
@@ -3,7 +3,7 @@
  * See hub.ts for full protocol documentation.
  */
 
-import type { Transport, TransportTarget, TransportMessage, TransportPresence } from "../core/transport/transport";
+import type { Transport, TransportTarget, TransportPresence, MessageHandler, PresenceHandler, FeedHandler } from "../core/transport/transport";
 import type { FeedEvent } from "../lib/feed";
 import { loadConfig } from "../config";
 import { trySilent } from "../core/util/try-silent";
@@ -19,9 +19,9 @@ export class HubTransport implements Transport {
   private connections: Map<string, HubConnection> = new Map();
   private nodeId: string;
   private federationToken: string | undefined;
-  private msgHandlers = new Set<(msg: TransportMessage) => void>();
-  private presenceHandlers = new Set<(p: TransportPresence) => void>();
-  private feedHandlers = new Set<(e: FeedEvent) => void>();
+  private msgHandlers = new Set<MessageHandler>();
+  private presenceHandlers = new Set<PresenceHandler>();
+  private feedHandlers = new Set<FeedHandler>();
 
   constructor(nodeId?: string) {
     const config = loadConfig();
@@ -114,15 +114,15 @@ export class HubTransport implements Transport {
     }
   }
 
-  onMessage(handler: (msg: TransportMessage) => void) {
+  onMessage(handler: MessageHandler) {
     this.msgHandlers.add(handler);
   }
 
-  onPresence(handler: (p: TransportPresence) => void) {
+  onPresence(handler: PresenceHandler) {
     this.presenceHandlers.add(handler);
   }
 
-  onFeed(handler: (e: FeedEvent) => void) {
+  onFeed(handler: FeedHandler) {
     this.feedHandlers.add(handler);
   }
 

--- a/src/transports/lora.ts
+++ b/src/transports/lora.ts
@@ -6,15 +6,15 @@
  * Reserved via `maw radio`.
  */
 
-import type { Transport, TransportTarget, TransportMessage, TransportPresence } from "../core/transport/transport";
+import type { Transport, TransportTarget, TransportPresence, MessageHandler, PresenceHandler, FeedHandler } from "../core/transport/transport";
 import type { FeedEvent } from "../lib/feed";
 
 export class LoRaTransport implements Transport {
   readonly name = "lora";
   private _connected = false;
-  private msgHandlers = new Set<(msg: TransportMessage) => void>();
-  private presenceHandlers = new Set<(p: TransportPresence) => void>();
-  private feedHandlers = new Set<(e: FeedEvent) => void>();
+  private msgHandlers = new Set<MessageHandler>();
+  private presenceHandlers = new Set<PresenceHandler>();
+  private feedHandlers = new Set<FeedHandler>();
 
   get connected() { return this._connected; }
 
@@ -34,9 +34,9 @@ export class LoRaTransport implements Transport {
   async publishPresence(_presence: TransportPresence): Promise<void> {}
   async publishFeed(_event: FeedEvent): Promise<void> {}
 
-  onMessage(handler: (msg: TransportMessage) => void) { this.msgHandlers.add(handler); }
-  onPresence(handler: (p: TransportPresence) => void) { this.presenceHandlers.add(handler); }
-  onFeed(handler: (e: FeedEvent) => void) { this.feedHandlers.add(handler); }
+  onMessage(handler: MessageHandler) { this.msgHandlers.add(handler); }
+  onPresence(handler: PresenceHandler) { this.presenceHandlers.add(handler); }
+  onFeed(handler: FeedHandler) { this.feedHandlers.add(handler); }
 
   /** LoRa transport cannot reach anything until hardware is connected */
   canReach(_target: TransportTarget): boolean {

--- a/src/transports/mdns.ts
+++ b/src/transports/mdns.ts
@@ -21,6 +21,9 @@ import type {
   TransportTarget,
   TransportMessage,
   TransportPresence,
+  MessageHandler,
+  PresenceHandler,
+  FeedHandler,
 } from "../core/transport/transport";
 import type { FeedEvent } from "../lib/feed";
 
@@ -49,9 +52,9 @@ export class MdnsTransport implements Transport {
   private socket: Socket | null = null;
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private peers = new Map<string, DiscoveredPeer>();
-  private msgHandlers = new Set<(msg: TransportMessage) => void>();
-  private presenceHandlers = new Set<(p: TransportPresence) => void>();
-  private feedHandlers = new Set<(e: FeedEvent) => void>();
+  private msgHandlers = new Set<MessageHandler>();
+  private presenceHandlers = new Set<PresenceHandler>();
+  private feedHandlers = new Set<FeedHandler>();
 
   constructor(config: MdnsTransportConfig) {
     this.config = config;
@@ -198,15 +201,15 @@ export class MdnsTransport implements Transport {
     }
   }
 
-  onMessage(handler: (msg: TransportMessage) => void) {
+  onMessage(handler: MessageHandler) {
     this.msgHandlers.add(handler);
   }
 
-  onPresence(handler: (p: TransportPresence) => void) {
+  onPresence(handler: PresenceHandler) {
     this.presenceHandlers.add(handler);
   }
 
-  onFeed(handler: (e: FeedEvent) => void) {
+  onFeed(handler: FeedHandler) {
     this.feedHandlers.add(handler);
   }
 

--- a/src/transports/nanoclaw.ts
+++ b/src/transports/nanoclaw.ts
@@ -8,16 +8,16 @@
  * send() POSTs { jid, text } to nanoclaw's /send endpoint for delivery.
  */
 
-import type { Transport, TransportTarget, TransportMessage, TransportPresence } from "../core/transport/transport";
+import type { Transport, TransportTarget, TransportPresence, MessageHandler, PresenceHandler, FeedHandler } from "../core/transport/transport";
 import type { FeedEvent } from "../lib/feed";
 import { resolveNanoclawJid, sendViaNanoclaw } from "../bridges/nanoclaw";
 
 export class NanoclawTransport implements Transport {
   readonly name = "nanoclaw";
   private _connected = true; // Stateless HTTP — always "connected"
-  private msgHandlers = new Set<(msg: TransportMessage) => void>();
-  private presenceHandlers = new Set<(p: TransportPresence) => void>();
-  private feedHandlers = new Set<(e: FeedEvent) => void>();
+  private msgHandlers = new Set<MessageHandler>();
+  private presenceHandlers = new Set<PresenceHandler>();
+  private feedHandlers = new Set<FeedHandler>();
 
   get connected() { return this._connected; }
 
@@ -33,9 +33,9 @@ export class NanoclawTransport implements Transport {
   async publishPresence(_presence: TransportPresence): Promise<void> {}
   async publishFeed(_event: FeedEvent): Promise<void> {}
 
-  onMessage(handler: (msg: TransportMessage) => void) { this.msgHandlers.add(handler); }
-  onPresence(handler: (p: TransportPresence) => void) { this.presenceHandlers.add(handler); }
-  onFeed(handler: (e: FeedEvent) => void) { this.feedHandlers.add(handler); }
+  onMessage(handler: MessageHandler) { this.msgHandlers.add(handler); }
+  onPresence(handler: PresenceHandler) { this.presenceHandlers.add(handler); }
+  onFeed(handler: FeedHandler) { this.feedHandlers.add(handler); }
 
   /** Can reach targets that resolve to a nanoclaw channel JID */
   canReach(target: TransportTarget): boolean {

--- a/src/transports/scout-pair.ts
+++ b/src/transports/scout-pair.ts
@@ -24,12 +24,17 @@ export interface AutoPairResponse {
   error?: string;
 }
 
+export interface OperationResult {
+  ok: boolean;
+  error?: string;
+}
+
 export async function initiatePair(
   peer: DiscoveredPeer,
   localNode: string,
   localOracle: string,
   localPort: number,
-): Promise<{ ok: boolean; error?: string }> {
+): Promise<OperationResult> {
   const locator = peer.locators[0];
   if (!locator) return { ok: false, error: "no_locator" };
 

--- a/src/transports/scout.ts
+++ b/src/transports/scout.ts
@@ -15,6 +15,9 @@ import type {
   TransportTarget,
   TransportMessage,
   TransportPresence,
+  MessageHandler,
+  PresenceHandler,
+  FeedHandler,
 } from "../core/transport/transport";
 import type { FeedEvent } from "../lib/feed";
 import { loadPeers } from "../lib/peers/store";
@@ -47,9 +50,9 @@ export class ScoutTransport implements Transport {
   private scoutTimer: ReturnType<typeof setTimeout> | null = null;
   private pruneTimer: ReturnType<typeof setInterval> | null = null;
   private state: ScoutState;
-  private msgHandlers = new Set<(msg: TransportMessage) => void>();
-  private presenceHandlers = new Set<(p: TransportPresence) => void>();
-  private feedHandlers = new Set<(e: FeedEvent) => void>();
+  private msgHandlers = new Set<MessageHandler>();
+  private presenceHandlers = new Set<PresenceHandler>();
+  private feedHandlers = new Set<FeedHandler>();
 
   constructor(config: ScoutTransportConfig) {
     this.config = config;
@@ -182,15 +185,15 @@ export class ScoutTransport implements Transport {
     }
   }
 
-  onMessage(handler: (msg: TransportMessage) => void) {
+  onMessage(handler: MessageHandler) {
     this.msgHandlers.add(handler);
   }
 
-  onPresence(handler: (p: TransportPresence) => void) {
+  onPresence(handler: PresenceHandler) {
     this.presenceHandlers.add(handler);
   }
 
-  onFeed(handler: (e: FeedEvent) => void) {
+  onFeed(handler: FeedHandler) {
     this.feedHandlers.add(handler);
   }
 

--- a/src/transports/tmux.ts
+++ b/src/transports/tmux.ts
@@ -7,15 +7,15 @@
 
 import { sendKeys, listSessions } from "../core/transport/ssh";
 import { findWindow } from "../core/runtime/find-window";
-import type { Transport, TransportTarget, TransportMessage, TransportPresence } from "../core/transport/transport";
+import type { Transport, TransportTarget, TransportPresence, MessageHandler, PresenceHandler, FeedHandler } from "../core/transport/transport";
 import type { FeedEvent } from "../lib/feed";
 
 export class TmuxTransport implements Transport {
   readonly name = "tmux";
   private _connected = false;
-  private msgHandlers = new Set<(msg: TransportMessage) => void>();
-  private presenceHandlers = new Set<(p: TransportPresence) => void>();
-  private feedHandlers = new Set<(e: FeedEvent) => void>();
+  private msgHandlers = new Set<MessageHandler>();
+  private presenceHandlers = new Set<PresenceHandler>();
+  private feedHandlers = new Set<FeedHandler>();
 
   get connected() { return this._connected; }
 
@@ -56,15 +56,15 @@ export class TmuxTransport implements Transport {
   /** Feed events are handled by the MawEngine — no-op here */
   async publishFeed(_event: FeedEvent): Promise<void> {}
 
-  onMessage(handler: (msg: TransportMessage) => void) {
+  onMessage(handler: MessageHandler) {
     this.msgHandlers.add(handler);
   }
 
-  onPresence(handler: (p: TransportPresence) => void) {
+  onPresence(handler: PresenceHandler) {
     this.presenceHandlers.add(handler);
   }
 
-  onFeed(handler: (e: FeedEvent) => void) {
+  onFeed(handler: FeedHandler) {
     this.feedHandlers.add(handler);
   }
 


### PR DESCRIPTION
## Summary
- Extracts ~20 inline type patterns to named, reusable types across 26 files
- New shared types: `SessionInfo`, `SessionWindow`, `MessageHandler`, `PresenceHandler`, `FeedHandler`, `ValidationResult`, `WakeCmdOptions`, `HandlerTarget`, `SpawnCommandData`, `SnapshotListEntry`, `PulseIssue`, `DiscordGuild`, `PluginTierGroup`, `ArtifactDetail`, `OperationResult`, `CmdProbeResult`
- Fixes ProbeResult name collision between peers/probe.ts and peers/impl.ts
- No runtime behavior changes — pure type refactor

Supersedes #1217 (rebased cleanly, no force push)
Closes #1216

## Test plan
- [ ] `bash scripts/test-isolated.sh` passes
- [ ] No runtime behavior changes (type-only refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)