### PR TITLE
feat: maw arena + maw team doctor (#1206, #1149)

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -51,6 +51,7 @@ export const ALIAS_DESCRIPTIONS: Record<string, string> = {
   stall: "Detect stalled panes — notify-only (#976A)",
   show: "Print session launch script to stdout (pipe-able)",
   new: "Create a new oracle (alias for awaken — friendly door)",
+  arena: "Engine arena — compare AI engines side by side",
 };
 
 export const TOP_ALIASES: Record<string, string[] | DirectHandler> = {
@@ -73,6 +74,7 @@ export const TOP_ALIASES: Record<string, string[] | DirectHandler> = {
   // all awaken flags pass through. New users learn `new`; the `bud`/`awaken`
   // metaphors stay for those who want them.
   new: ["awaken"],
+  arena: ["arena"],
 
   // Direct-handler form — `ls` flags differ from tmux ls:
   //   maw ls      → compact, live sessions only

--- a/src/commands/plugins/arena/index.ts
+++ b/src/commands/plugins/arena/index.ts
@@ -1,0 +1,190 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { AgentColor } from "../tmux/layout-manager";
+import type { TeamConfig, TeamMember } from "../team/team-helpers";
+import { parseFlags } from "../../../cli/parse-args";
+import { ENGINE_DEFS, ENGINE_NAMES, resolveEngine, buildEngineCommand } from "../../shared/engines";
+import type { EngineName } from "../../shared/engines";
+
+export const command = {
+  name: "arena",
+  description: "Engine arena — same prompt, multiple engines, compare side by side.",
+};
+
+const DEFAULT_ENGINES: EngineName[] = ["claude", "codex", "gemini"];
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  console.log = (...a: unknown[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+
+  try {
+    if (!process.env.TMUX) {
+      console.log("\x1b[33m⚠\x1b[0m arena requires tmux");
+      return { ok: false, error: "not in tmux" };
+    }
+
+    const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+    const flags = parseFlags(args, {
+      "--engines": String,
+      "--tiled": Boolean,
+      "--help": Boolean, "-h": "--help",
+    }, 0);
+
+    if (flags["--help"]) {
+      console.log('usage: maw arena "<prompt>" [--engines engine1,engine2,...] [--tiled]');
+      console.log("");
+      console.log('  maw arena "fix this bug"                        claude,codex,gemini (default)');
+      console.log('  maw arena "explain this" --engines claude,gemini  two engines');
+      console.log('  maw arena "refactor" --tiled                    equal layout');
+      console.log("");
+      console.log(`Supported engines: ${ENGINE_NAMES.join(", ")}`);
+      return { ok: true, output: logs.join("\n") };
+    }
+
+    const tiled = !!flags["--tiled"];
+    const positional = flags._ as string[];
+    const prompt = positional.join(" ").trim();
+
+    if (!prompt) {
+      console.log('\x1b[33m⚠\x1b[0m arena requires a prompt: maw arena "your prompt here"');
+      return { ok: false, error: "missing prompt" };
+    }
+
+    const enginesRaw = (flags["--engines"] as string) || DEFAULT_ENGINES.join(",");
+    let engineList: EngineName[];
+    try {
+      engineList = enginesRaw.split(",").map(e => resolveEngine(e.trim()));
+    } catch (e: unknown) {
+      console.log(`\x1b[31m✗\x1b[0m ${e instanceof Error ? e.message : String(e)}`);
+      return { ok: false, error: e instanceof Error ? e.message : String(e) };
+    }
+
+    if (engineList.length > 10) {
+      console.log("\x1b[33m⚠\x1b[0m max 10 engines");
+      return { ok: false, error: "max 10" };
+    }
+
+    const {
+      nextAgentColor, colorAnsi, stylePaneBorder, enableBorderStatus,
+      applyTeamLayout, applyTiledLayout, getWindowTarget,
+    } = await import("../tmux/layout-manager");
+    const { hostExec, withPaneLock } = await import("../../../sdk");
+    const { PANE_INIT_PRELUDE } = await import("../../shared/pane-prelude");
+    const { existsSync, readFileSync, writeFileSync, mkdirSync } = await import("fs");
+    const { join } = await import("path");
+    const { homedir } = await import("os");
+
+    // Write prompt files to ~/.maw/arena/<timestamp>/
+    const timestamp = Date.now();
+    const promptDir = join(homedir(), ".maw", "arena", String(timestamp));
+    mkdirSync(promptDir, { recursive: true });
+
+    const anchor = process.env.TMUX_PANE ?? "";
+    const teamName = "arena";
+    const teamsDir = join(homedir(), ".claude/teams");
+    const teamDir = join(teamsDir, teamName);
+    const configPath = join(teamDir, "config.json");
+
+    mkdirSync(teamDir, { recursive: true });
+    let config: TeamConfig;
+    if (existsSync(configPath)) {
+      config = JSON.parse(readFileSync(configPath, "utf-8"));
+    } else {
+      config = { name: teamName, description: "Engine arena — same prompt, multiple engines", members: [], createdAt: Date.now() };
+    }
+
+    const paneInfos: {
+      engine: EngineName;
+      name: string;
+      agentId: string;
+      label: string;
+      color: AgentColor;
+      cmd: string;
+    }[] = [];
+
+    for (let i = 0; i < engineList.length; i++) {
+      const engine = engineList[i];
+      const def = ENGINE_DEFS[engine];
+      const name = `${engine}-${i + 1}`;
+      const color = nextAgentColor(i);
+      const agentId = `${name}@${teamName}`;
+      const promptPath = join(promptDir, `${engine}.prompt.md`);
+
+      writeFileSync(promptPath, prompt, "utf-8");
+
+      let cmd: string;
+      if (engine === "claude") {
+        const escapedPath = promptPath.replace(/'/g, "'\\''");
+        cmd = `claude --dangerously-skip-permissions --model ${def.defaultModel} -p "$(cat '${escapedPath}')"`;
+      } else {
+        cmd = buildEngineCommand(engine, { promptPath });
+      }
+
+      paneInfos.push({ engine, name, agentId, label: engine, color, cmd });
+    }
+
+    // Phase 1: Split placeholder panes — sleep, no shell init, immune to SIGWINCH
+    const spawned: (typeof paneInfos[number] & { paneId: string })[] = [];
+    for (const info of paneInfos) {
+      const targetFlag = anchor ? `-t '${anchor}' ` : "";
+      let paneId = "";
+      await withPaneLock(async () => {
+        paneId = (await hostExec(
+          `tmux split-window ${targetFlag}-h -P -F '#{pane_id}' 'sleep infinity'`,
+        )).trim();
+        await new Promise(r => setTimeout(r, 100));
+      });
+      spawned.push({ ...info, paneId });
+    }
+
+    // Phase 2: Apply layout ONCE — all panes get their final sizes
+    const window = await getWindowTarget();
+    if (tiled) {
+      await applyTiledLayout(window);
+    } else if (anchor) {
+      await applyTeamLayout(window, anchor);
+    }
+    await enableBorderStatus(window);
+    await new Promise(r => setTimeout(r, 200));
+
+    // Phase 3: Respawn panes with real shell + engine command
+    for (const agent of spawned) {
+      await stylePaneBorder(agent.paneId, `${agent.name} (${agent.label})`, agent.color);
+
+      const escaped = agent.cmd.replace(/'/g, "'\\''");
+      await hostExec(
+        `tmux respawn-pane -k -t '${agent.paneId}' '${PANE_INIT_PRELUDE}; ${escaped}; stty sane 2>/dev/null; printf "\\e[?1049l\\e[0m"; clear; exec zsh -li'`,
+      );
+      await new Promise(r => setTimeout(r, 200));
+
+      const entry = {
+        name: agent.name,
+        agentId: agent.agentId,
+        tmuxPaneId: agent.paneId,
+        color: agent.color,
+        model: ENGINE_DEFS[agent.engine].binary,
+      };
+      const existing = config.members.findIndex((m: TeamMember) => m.name === agent.name);
+      if (existing >= 0) config.members[existing] = entry;
+      else config.members.push(entry);
+
+      console.log(`  \x1b[${colorAnsi(agent.color)}m●\x1b[0m ${agent.name} (${agent.label}) → ${agent.paneId}`);
+    }
+
+    writeFileSync(configPath, JSON.stringify(config, null, 2));
+
+    const { saveLayoutSnapshot } = await import("../team/layout-snapshot");
+    saveLayoutSnapshot(teamName, anchor);
+
+    console.log(`\x1b[32m✓\x1b[0m arena: ${engineList.length} engines (${tiled ? "tiled" : "main-vertical"})`);
+    console.log(`\x1b[90m  prompt → ${promptDir}\x1b[0m`);
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: unknown) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e), output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+  }
+}

--- a/src/commands/plugins/arena/plugin.json
+++ b/src/commands/plugins/arena/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "arena",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Engine arena — same prompt, multiple engines, compare side by side.",
+  "cli": {
+    "command": "arena",
+    "help": "maw arena \"<prompt>\" [--engines engine1,engine2,...] [--tiled]"
+  },
+  "weight": 5
+}

--- a/src/commands/plugins/team/index.ts
+++ b/src/commands/plugins/team/index.ts
@@ -79,6 +79,7 @@ subcommands:
   spawn <team> <role>      spawn agent into team
   delete <name>            delete a team
   status                   show team status
+  doctor [--fix]           detect ghost/orphan panes; --fix auto-repairs
   invite <oracle>          invite oracle to team
   members <name>           list team members
   send <name> <message>    send message to team
@@ -201,6 +202,11 @@ general flags: --description <text>, --members <list>`,
       if (!id || !agent) { return { ok: false, error: "usage: maw team assign <task-id> <agent> [--team <name>]" }; }
       const team = (flags["--team"] as string | undefined) || resolveTeamFromContext();
       cmdTeamTaskAssign(team, id, agent);
+
+    } else if (sub === "doctor") {
+      // maw team doctor [--fix]
+      const { cmdTeamDoctor } = await import("./team-doctor");
+      await cmdTeamDoctor({ fix: args.includes("--fix") });
 
     } else if (sub === "status") {
       // maw team status [team-name]
@@ -526,7 +532,7 @@ general flags: --description <text>, --members <list>`,
 
     } else {
       logs.push(`unknown team subcommand: ${sub}`);
-      logs.push("usage: maw team <create|spawn|send|shutdown|split|peek|hey|inbox|layout|prep|recover|resume|lives|list|status|add|tasks|done|assign|delete>");
+      logs.push("usage: maw team <create|spawn|send|shutdown|split|peek|hey|inbox|layout|prep|recover|resume|lives|list|status|doctor|add|tasks|done|assign|delete>");
       return { ok: false, error: `unknown subcommand: ${sub}`, output: logs.join("\n") };
     }
 

--- a/src/commands/plugins/team/team-doctor.ts
+++ b/src/commands/plugins/team/team-doctor.ts
@@ -1,0 +1,126 @@
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+import { hostExec } from "../../../sdk";
+import { TEAMS_DIR, loadTeam, type TeamMember } from "./team-helpers";
+
+function listTeams(): string[] {
+  if (!existsSync(TEAMS_DIR)) return [];
+  return readdirSync(TEAMS_DIR, { withFileTypes: true })
+    .filter(e => e.isDirectory())
+    .map(e => e.name);
+}
+
+async function getAlivePanes(): Promise<Set<string>> {
+  try {
+    const out = await hostExec("tmux list-panes -a -F '#{pane_id}'");
+    return new Set(out.split("\n").filter(Boolean));
+  } catch { return new Set(); }
+}
+
+async function getOrphanPanes(knownPaneIds: Set<string>): Promise<Set<string>> {
+  try {
+    const out = await hostExec("tmux list-panes -a -F '#{pane_id} #{pane_current_command}'");
+    const result = new Set<string>();
+    for (const line of out.split("\n").filter(Boolean)) {
+      const spaceIdx = line.indexOf(" ");
+      const paneId = line.slice(0, spaceIdx);
+      const cmd = line.slice(spaceIdx + 1).toLowerCase();
+      if (paneId && !knownPaneIds.has(paneId) && (cmd.includes("claude") || cmd.includes("node") || cmd.includes("bun"))) {
+        result.add(paneId);
+      }
+    }
+    return result;
+  } catch { return new Set(); }
+}
+
+export async function cmdTeamDoctor(opts: { fix?: boolean } = {}): Promise<void> {
+  const label = opts.fix ? "🔍 Team Doctor (--fix)" : "🔍 Team Doctor";
+  console.log(`\n${label}\n`);
+
+  const teams = listTeams();
+  if (teams.length === 0) {
+    console.log(`\x1b[90mno teams found\x1b[0m\n`);
+    return;
+  }
+
+  const alive = await getAlivePanes();
+
+  // Build full member list and collect all known pane IDs across all teams
+  const knownPaneIds = new Set<string>();
+  const teamConfigs: Array<{ name: string; members: TeamMember[] }> = [];
+
+  for (const name of teams) {
+    const config = loadTeam(name);
+    if (!config) continue;
+    const members = config.members.filter(m => m.agentType !== "team-lead");
+    teamConfigs.push({ name, members });
+    for (const m of members) {
+      if (m.tmuxPaneId) knownPaneIds.add(m.tmuxPaneId);
+    }
+  }
+
+  const orphanPanes = await getOrphanPanes(knownPaneIds);
+
+  let totalGhosts = 0;
+  let totalFixed = 0;
+
+  for (const { name, members } of teamConfigs) {
+    const ghosts = members.filter(m => m.tmuxPaneId && !alive.has(m.tmuxPaneId));
+
+    if (opts.fix) {
+      if (ghosts.length === 0) continue;
+      console.log(`${name}`);
+      const configPath = join(TEAMS_DIR, name, "config.json");
+      try {
+        const cfg = JSON.parse(readFileSync(configPath, "utf-8"));
+        const ghostNames = new Set(ghosts.map(g => g.name));
+        cfg.members = cfg.members.filter((m: TeamMember) => !ghostNames.has(m.name));
+        writeFileSync(configPath, JSON.stringify(cfg, null, 2));
+        for (const g of ghosts) {
+          console.log(`  \x1b[32m✓\x1b[0m removed ghost: ${g.agentId || g.name} (pane ${g.tmuxPaneId || "-"})`);
+          totalFixed++;
+        }
+      } catch {
+        console.log(`  \x1b[31m✗\x1b[0m failed to update config for team ${name}`);
+      }
+      totalGhosts += ghosts.length;
+    } else {
+      console.log(`${name} (${members.length} member${members.length !== 1 ? "s" : ""})`);
+      for (const m of members) {
+        const paneId = m.tmuxPaneId ?? "";
+        const isAlive = paneId ? alive.has(paneId) : false;
+        const isGhost = paneId && !isAlive;
+        const dot = isAlive ? `\x1b[32m●\x1b[0m` : `\x1b[90m·\x1b[0m`;
+        const nameLabel = isAlive
+          ? `\x1b[32m${m.agentId || m.name}\x1b[0m`
+          : `\x1b[90m${m.agentId || m.name}\x1b[0m`;
+        const status = isAlive
+          ? `\x1b[32mrunning\x1b[0m`
+          : isGhost
+            ? `\x1b[31mghost\x1b[0m — pane dead but still in config`
+            : `\x1b[90mno pane\x1b[0m`;
+        console.log(`  ${dot} ${nameLabel}  ${paneId || "-"}  ${status}`);
+        if (isGhost) totalGhosts++;
+      }
+      console.log("");
+    }
+  }
+
+  if (opts.fix) {
+    for (const paneId of orphanPanes) {
+      try {
+        await hostExec(`tmux kill-pane -t '${paneId}'`);
+        console.log(`  \x1b[32m✓\x1b[0m killed orphan pane: ${paneId}`);
+      } catch {
+        console.log(`  \x1b[31m✗\x1b[0m failed to kill orphan pane: ${paneId}`);
+      }
+    }
+    const orphanStr = orphanPanes.size > 0
+      ? `, ${orphanPanes.size} orphan${orphanPanes.size !== 1 ? "s" : ""} killed`
+      : "";
+    console.log(`\nFixed: ${totalFixed} ghost${totalFixed !== 1 ? "s" : ""} removed${orphanStr}`);
+  } else {
+    console.log(`Summary: ${totalGhosts} ghost${totalGhosts !== 1 ? "s" : ""}, ${orphanPanes.size} orphan${orphanPanes.size !== 1 ? "s" : ""}`);
+  }
+  console.log("");
+}


### PR DESCRIPTION
## Summary
- **maw arena** (#1206): `maw arena "prompt" --engines claude,codex,gemini` — spawns N panes side-by-side, same prompt to each engine, human picks the winner
- **maw team doctor** (#1149): `maw team doctor [--fix]` — detect ghost teammates + orphan panes, auto-cleanup with --fix

## Engine Arena
- New plugin `src/commands/plugins/arena/`
- Follows swarm's 3-phase spawn: sleep → layout → respawn
- Prompt files at `~/.maw/arena/<timestamp>/<engine>.prompt.md`
- Defaults to claude,codex,gemini, supports --tiled, max 10
- CLI alias: `maw arena`

## Team Doctor
- New `src/commands/plugins/team/team-doctor.ts`
- Ghosts: members with dead panes still in config
- Orphans: alive panes running claude/node/bun not in any team
- `--fix`: removes ghosts from config + kills orphans
- Completes the team CLI surface (25+ subcommands)

Closes #1206, closes #1149

## Test plan
- [ ] `bash scripts/test-isolated.sh` passes
- [ ] `maw arena "hello" --engines claude` spawns correctly in tmux
- [ ] `maw team doctor` shows correct ghost/orphan status

🤖 Generated with [Claude Code](https://claude.com/claude-code)