### PR TITLE
feat: backlog sweep — doctor warn, sleep resolver, hey --no-reply, ls --verbose (#1180, #1182, #1140, #1118)

### DIFF
--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -167,8 +167,9 @@ async function dispatchPluginRegistry(cmd: string, args: string[]): Promise<void
   // Default: agent name shorthand (maw <agent> <msg> or maw <agent>)
   if (args.length >= 2) {
     const f = args.includes("--force");
-    const m = args.slice(1).filter(a => a !== "--force");
-    await cmdSend(args[0], m.join(" "), f);
+    const noReply = args.includes("--no-reply");
+    const m = args.slice(1).filter(a => a !== "--force" && a !== "--no-reply");
+    await cmdSend(args[0], m.join(" "), f, { noReply });
   } else {
     await cmdPeek(args[0]);
   }

--- a/src/cli/route-comm.ts
+++ b/src/cli/route-comm.ts
@@ -49,6 +49,8 @@ export async function routeComm(cmd: string, args: string[]): Promise<boolean> {
     // entry so the same pair stops queuing on subsequent sends.
     const approve = args.includes("--approve");
     const trust = args.includes("--trust");
+    // #1140 — `--no-reply` signals no response expected (FYI-only message)
+    const noReply = args.includes("--no-reply");
 
     // #1149 — `--inbox` short-circuits to file-based teammate inbox write
     const inboxFlag = args.includes("--inbox");
@@ -61,7 +63,7 @@ export async function routeComm(cmd: string, args: string[]): Promise<boolean> {
     const msgArgs = args
       .slice(2)
       .filter((a, i, arr) => {
-        if (["--force", "--approve", "--trust", "--inbox"].includes(a)) return false;
+        if (["--force", "--approve", "--trust", "--inbox", "--no-reply"].includes(a)) return false;
         if (a === "--team" || a === "--from") return false;
         // skip the value following --team/--from
         if (i > 0 && (arr[i - 1] === "--team" || arr[i - 1] === "--from")) return false;
@@ -74,7 +76,7 @@ export async function routeComm(cmd: string, args: string[]): Promise<boolean> {
     // same "usage:" error. Now the missing-message case names the target
     // so the user sees their input got through.
     if (!target) {
-      console.error("usage: maw hey <target> <message> [--force] [--approve] [--trust]");
+      console.error("usage: maw hey <target> <message> [--force] [--approve] [--trust] [--no-reply]");
       console.error("  target forms (#759 Phase 2 — bare names removed):");
       console.error("    local:<agent>                this node");
       console.error("    <node>:<session>             canonical cross-node form (window 1)");
@@ -111,7 +113,7 @@ export async function routeComm(cmd: string, args: string[]): Promise<boolean> {
       return true;
     }
 
-    await cmdSend(target, msgArgs.join(" "), force, { approve, trust });
+    await cmdSend(target, msgArgs.join(" "), force, { approve, trust, noReply });
     return true;
   }
   return false;

--- a/src/commands/plugins/channel/index.ts
+++ b/src/commands/plugins/channel/index.ts
@@ -35,7 +35,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         output: `usage: maw channel <subcommand> [args]
 
 subcommands:
-  ls [oracle]              list channels (all or for specific oracle)
+  ls [oracle] [--json] [-v] list channels (all or for specific oracle)
   add <oracle> <plugin>    add channel plugin to oracle
   rm <oracle> <plugin>     remove channel plugin from oracle
   providers                list available channel providers
@@ -162,7 +162,8 @@ github: prefix → delegates to setup wizard`,
 
     } else if (sub === "ls" || sub === "list" || !sub) {
       const json = args.includes("--json");
-      const target = args.filter(a => !a.startsWith("--"))[1];
+      const verbose = args.includes("--verbose") || args.includes("-v");
+      const target = args.filter(a => !a.startsWith("-"))[1];
 
       if (json) {
         const data = target
@@ -189,6 +190,9 @@ github: prefix → delegates to setup wizard`,
           if (config.token_source) {
             console.log(`    \x1b[90mtoken: ${config.token_source}\x1b[0m`);
           }
+          if (verbose && config.permissionMode) {
+            console.log(`    \x1b[90mpermissionMode: ${config.permissionMode}\x1b[0m`);
+          }
         }
       } else {
         const all = listAllOracleChannels();
@@ -201,6 +205,20 @@ github: prefix → delegates to setup wizard`,
           for (const { oracle, plugins } of all) {
             for (const p of plugins) {
               console.log(`  ${oracle.padEnd(30)}  ${p.id}`);
+              if (verbose) {
+                if (p.env) {
+                  for (const [k, v] of Object.entries(p.env)) {
+                    console.log(`  ${" ".repeat(30)}  \x1b[90m${k}=${v}\x1b[0m`);
+                  }
+                }
+                const cfg = loadOracleChannels(oracle);
+                if (cfg?.permissionMode) {
+                  console.log(`  ${" ".repeat(30)}  \x1b[90mpermissionMode: ${cfg.permissionMode}\x1b[0m`);
+                }
+                if (cfg?.token_source) {
+                  console.log(`  ${" ".repeat(30)}  \x1b[90mtoken: ${cfg.token_source}\x1b[0m`);
+                }
+              }
             }
           }
           console.log(`\n  ${all.length} oracle(s) with channels`);

--- a/src/commands/plugins/fleet/index.ts
+++ b/src/commands/plugins/fleet/index.ts
@@ -10,10 +10,10 @@ interface SubcommandDef {
 const FLEET: Record<string, SubcommandDef> = {
   ls: {
     desc: "list fleet configs",
-    args: "[--json]",
+    args: "[--json] [--verbose|-v]",
     handler: async (args) => {
       const { cmdFleetLs } = await import("../../shared/fleet");
-      await cmdFleetLs({ json: args.includes("--json") });
+      await cmdFleetLs({ json: args.includes("--json"), verbose: args.includes("--verbose") || args.includes("-v") });
     },
   },
   init: {

--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -141,10 +141,14 @@ export function formatBareNameError(query: string): string {
  * - `trust` (#842 Sub-C): paired with `approve` — also append the
  *   sender↔target pair to the on-disk trust list so subsequent sends in
  *   either direction skip the gate without operator intervention.
+ * - `noReply` (#1140): signal that no response is expected. Prepends
+ *   `/fyi ` to the message body (human-readable convention) and appends
+ *   `<no-reply/>` (wire-level marker for automated routing).
  */
 export interface CmdSendOptions {
   approve?: boolean;
   trust?: boolean;
+  noReply?: boolean;
 }
 
 export async function cmdSend(
@@ -153,6 +157,12 @@ export async function cmdSend(
   force = false,
   opts: CmdSendOptions = {},
 ) {
+  // #1140 — --no-reply: prepend /fyi (human convention) + append <no-reply/> (wire marker)
+  if (opts.noReply) {
+    if (!message.startsWith("/fyi ")) message = `/fyi ${message}`;
+    if (!message.includes("<no-reply/>")) message = `${message} <no-reply/>`;
+  }
+
   const config = loadConfig();
 
   // #1136 — bare names get a local-resolver probe before the federation-

--- a/src/commands/shared/fleet-manage.ts
+++ b/src/commands/shared/fleet-manage.ts
@@ -3,7 +3,7 @@ import { existsSync, renameSync, unlinkSync, readdirSync } from "fs";
 import { tmux, FLEET_DIR } from "../../sdk";
 import { loadFleetEntries, getSessionNames } from "./fleet-load";
 
-export async function cmdFleetLs(opts: { json?: boolean } = {}) {
+export async function cmdFleetLs(opts: { json?: boolean; verbose?: boolean } = {}) {
   const entries = loadFleetEntries();
   const disabled = readdirSync(FLEET_DIR).filter(f => f.endsWith(".disabled")).length;
 
@@ -19,6 +19,7 @@ export async function cmdFleetLs(opts: { json?: boolean } = {}) {
         name: e.session.name,
         windows: e.session.windows.length,
         running: runningSessions.includes(e.session.name),
+        ...(opts.verbose && { windowDetails: e.session.windows, syncPeers: e.session.sync_peers }),
       })),
     }, null, 2));
     return;
@@ -35,20 +36,35 @@ export async function cmdFleetLs(opts: { json?: boolean } = {}) {
   const conflicts = [...numCount.entries()].filter(([, names]) => names.length > 1);
 
   console.log(`\n  \x1b[36mFleet Configs\x1b[0m (${entries.length} active, ${disabled} disabled)\n`);
-  console.log(`  ${"#".padEnd(4)} ${"Session".padEnd(20)} ${"Win".padEnd(5)} Status`);
-  console.log(`  ${"─".repeat(4)} ${"─".repeat(20)} ${"─".repeat(5)} ${"─".repeat(20)}`);
 
-  for (const e of entries) {
-    const numStr = String(e.num).padStart(2, "0");
-    const name = e.session.name.padEnd(20);
-    const wins = String(e.session.windows.length).padEnd(5);
-    const isRunning = runningSessions.includes(e.session.name);
-    const isConflict = (numCount.get(e.num)?.length ?? 0) > 1;
+  if (opts.verbose) {
+    for (const e of entries) {
+      const numStr = String(e.num).padStart(2, "0");
+      const isRunning = runningSessions.includes(e.session.name);
+      const isConflict = (numCount.get(e.num)?.length ?? 0) > 1;
+      let status = isRunning ? "\x1b[32mrunning\x1b[0m" : "\x1b[90mstopped\x1b[0m";
+      if (isConflict) status += "  \x1b[31mCONFLICT\x1b[0m";
+      console.log(`  ${numStr}  \x1b[33m${e.session.name}\x1b[0m  ${status}`);
+      for (const w of e.session.windows) {
+        console.log(`       \x1b[90m${w.name.padEnd(20)} ${w.repo}\x1b[0m`);
+      }
+    }
+  } else {
+    console.log(`  ${"#".padEnd(4)} ${"Session".padEnd(20)} ${"Win".padEnd(5)} Status`);
+    console.log(`  ${"─".repeat(4)} ${"─".repeat(20)} ${"─".repeat(5)} ${"─".repeat(20)}`);
 
-    let status = isRunning ? "\x1b[32mrunning\x1b[0m" : "\x1b[90mstopped\x1b[0m";
-    if (isConflict) status += "  \x1b[31mCONFLICT\x1b[0m";
+    for (const e of entries) {
+      const numStr = String(e.num).padStart(2, "0");
+      const name = e.session.name.padEnd(20);
+      const wins = String(e.session.windows.length).padEnd(5);
+      const isRunning = runningSessions.includes(e.session.name);
+      const isConflict = (numCount.get(e.num)?.length ?? 0) > 1;
 
-    console.log(`  ${numStr}  ${name} ${wins} ${status}`);
+      let status = isRunning ? "\x1b[32mrunning\x1b[0m" : "\x1b[90mstopped\x1b[0m";
+      if (isConflict) status += "  \x1b[31mCONFLICT\x1b[0m";
+
+      console.log(`  ${numStr}  ${name} ${wins} ${status}`);
+    }
   }
 
   if (conflicts.length > 0) {

--- a/src/commands/shared/preflight.ts
+++ b/src/commands/shared/preflight.ts
@@ -104,6 +104,38 @@ export async function cmdPreflight(opts: { fix?: boolean } = {}) {
   console.log(`  \x1b[32m✓\x1b[0m config: node=${config.node || "?"}, engines=[${engines.join(", ") || "default only"}]`);
   pass++;
 
+  // 5. Local branch vs alpha check
+  try {
+    const { execSync } = require("child_process");
+    const mawRoot = join(__dirname, "../../..");
+    const branch = execSync("git branch --show-current", { cwd: mawRoot, encoding: "utf-8" }).trim();
+    if (branch && branch !== "alpha") {
+      try {
+        execSync("git fetch origin alpha --quiet", { cwd: mawRoot, stdio: "ignore", timeout: 5000 });
+      } catch {} // network may be offline
+      const behind = execSync(`git rev-list HEAD..origin/alpha --count`, { cwd: mawRoot, encoding: "utf-8" }).trim();
+      const behindCount = parseInt(behind) || 0;
+      if (behindCount > 0) {
+        console.log(`  \x1b[33m⚠\x1b[0m branch: '${branch}' is ${behindCount} commit(s) behind alpha`);
+        const commits = execSync(`git log HEAD..origin/alpha --oneline -5`, { cwd: mawRoot, encoding: "utf-8" }).trim();
+        if (commits) {
+          for (const line of commits.split("\n")) {
+            console.log(`    \x1b[90m${line}\x1b[0m`);
+          }
+          if (behindCount > 5) console.log(`    \x1b[90m... and ${behindCount - 5} more\x1b[0m`);
+        }
+        console.log(`    \x1b[36mConsider: cd $(git rev-parse --show-toplevel) && git checkout alpha\x1b[0m`);
+        fail++;
+      } else {
+        console.log(`  \x1b[32m✓\x1b[0m branch: ${branch} (up to date with alpha)`);
+        pass++;
+      }
+    } else {
+      console.log(`  \x1b[32m✓\x1b[0m branch: alpha`);
+      pass++;
+    }
+  } catch {} // not a git repo or git not available — skip silently
+
   // Summary
   const elapsed = Date.now() - t0;
   const icon = fail === 0 ? "\x1b[32m✓\x1b[0m" : "\x1b[33m⚠\x1b[0m";

--- a/src/lib/sleep.ts
+++ b/src/lib/sleep.ts
@@ -15,49 +15,53 @@
  *   3. If window still exists, kill it
  *   4. Append a `sleep` event to ~/.oracle/maw-log.jsonl
  */
-import { tmux, saveTabOrder, takeSnapshot } from "../sdk";
+import { tmux, saveTabOrder, takeSnapshot, listSessions } from "../sdk";
 import { detectSession } from "../commands/shared/wake";
+import { loadFleetEntries } from "../commands/shared/fleet-load";
 import { appendFile, mkdir } from "fs/promises";
 import { homedir } from "os";
 import { join } from "path";
 
 export async function cmdSleepOne(oracle: string, window?: string) {
-  const session = await detectSession(oracle);
-  if (!session) {
-    throw new Error(`no running session found for '${oracle}'`);
+  // If caller provides an explicit window name, use it directly
+  if (window) {
+    const session = await detectSession(oracle);
+    if (!session) throw new Error(`no running session found for '${oracle}'`);
+    await saveTabOrder(session);
+    return doSleep(session, window, oracle);
   }
 
-  const windowName = window ? `${oracle}-${window}` : `${oracle}-oracle`;
+  const sessions = await listSessions();
+  const targetLower = oracle.toLowerCase();
 
-  // Save tab order before sleeping (so wake can restore positions)
-  await saveTabOrder(session);
-
-  let windows;
-  try {
-    windows = await tmux.listWindows(session);
-  } catch {
-    throw new Error(`could not list windows for session '${session}'`);
-  }
-
-  // Normalize trailing dashes — tmux window names like "fireman-1w-test-"
-  // cause exact-match failures and strand maw sleep (#206)
-  const stripDash = (s: string) => s.replace(/-+$/, "");
-
-  const target = windows.find(w => w.name === windowName || stripDash(w.name) === stripDash(windowName));
-  if (!target) {
-    const nameSuffix = window || "oracle";
-    const fuzzy = windows.find(w =>
-      stripDash(w.name) === stripDash(windowName) ||
-      new RegExp(`^${oracle}-\\d+-${nameSuffix}-?$`).test(w.name)
-    );
-    if (!fuzzy) {
-      console.error(`\x1b[90mavailable:\x1b[0m ${windows.map(w => w.name).join(", ")}`);
-      throw new Error(`window '${windowName}' not found in session '${session}'`);
+  // Tier 1: window-name match across ALL sessions
+  for (const s of sessions) {
+    const w = s.windows.find(w => w.name.toLowerCase() === targetLower);
+    if (w) {
+      await saveTabOrder(s.name);
+      return doSleep(s.name, w.name, oracle);
     }
-    return await doSleep(session, fuzzy.name, oracle);
   }
 
-  await doSleep(session, windowName, oracle);
+  // Tier 2: session-name match → use fleet's primary window
+  const sess = sessions.find(s => s.name === oracle || s.name.endsWith(`-${oracle}`));
+  if (sess) {
+    const entry = loadFleetEntries().find(e => e.session.name === sess.name);
+    const primary = entry?.session.windows[0]?.name ?? sess.windows[0]?.name;
+    if (primary) {
+      await saveTabOrder(sess.name);
+      return doSleep(sess.name, primary, oracle);
+    }
+  }
+
+  // Tier 3: detectSession (existing fleet-aware resolver)
+  const session = await detectSession(oracle);
+  if (!session) throw new Error(`no running session found for '${oracle}'`);
+  const entry = loadFleetEntries().find(e => e.session.name === session);
+  const primary = entry?.session.windows[0]?.name;
+  if (!primary) throw new Error(`could not resolve window for '${oracle}'`);
+  await saveTabOrder(session);
+  return doSleep(session, primary, oracle);
 }
 
 async function doSleep(session: string, windowName: string, oracle: string) {


### PR DESCRIPTION
## Summary

Four backlog issues resolved in parallel:

### 1. Doctor warn behind-alpha (#1180)
- `maw preflight` now checks if local branch is behind `origin/alpha`
- Shows up to 5 missing commits with checkout suggestion
- 5s fetch timeout for offline resilience

### 2. Sleep resolver rewrite (#1182)
- Tier 1-2-3 resolver replaces `${stem}-oracle` string concatenation
- Fixes Pattern B (stem already has `-oracle` suffix)
- Adds worktree window support (`maw sleep discord-awaken`)

### 3. Hey --no-reply (#1140)
- `maw hey <agent> --no-reply "msg"` for fire-and-forget messages
- Prepends `/fyi` prefix + appends `<no-reply/>` wire marker
- Both CLI dispatch paths updated

### 4. Ls --verbose (#1118)
- `maw fleet ls --verbose` shows window names + repo paths
- `maw channel ls --verbose` shows env vars, permissionMode, token source
- `--json` was already wired — no changes needed

Closes #1180, closes #1182, closes #1140, closes #1118

## Test plan
- [ ] `bash scripts/test-isolated.sh` passes
- [ ] `maw preflight` shows branch check
- [ ] `maw fleet ls -v` shows verbose output
- [ ] `maw channel ls -v` shows verbose output

🤖 Generated with [Claude Code](https://claude.com/claude-code)