### PR TITLE
feat: stall detection + session recovery (#976, #977)

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -51,7 +51,6 @@ export const ALIAS_DESCRIPTIONS: Record<string, string> = {
   stall: "Detect stalled panes — notify-only (#976A)",
   show: "Print session launch script to stdout (pipe-able)",
   new: "Create a new oracle (alias for awaken — friendly door)",
-  arena: "Engine arena — compare AI engines side by side",
 };
 
 export const TOP_ALIASES: Record<string, string[] | DirectHandler> = {
@@ -74,7 +73,6 @@ export const TOP_ALIASES: Record<string, string[] | DirectHandler> = {
   // all awaken flags pass through. New users learn `new`; the `bud`/`awaken`
   // metaphors stay for those who want them.
   new: ["awaken"],
-  arena: ["arena"],
 
   // Direct-handler form — `ls` flags differ from tmux ls:
   //   maw ls      → compact, live sessions only

--- a/src/commands/plugins/team/index.ts
+++ b/src/commands/plugins/team/index.ts
@@ -77,9 +77,10 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
 subcommands:
   create <name>            create a new team (alias: new)
   spawn <team> <role>      spawn agent into team
+  save <name>              save current session state to JSONL
+  resume <name>            restore dead panes (JSONL snapshot) or reincarnate from vault
   delete <name>            delete a team
   status                   show team status
-  doctor [--fix]           detect ghost/orphan panes; --fix auto-repairs
   invite <oracle>          invite oracle to team
   members <name>           list team members
   send <name> <message>    send message to team
@@ -133,6 +134,14 @@ general flags: --description <text>, --members <list>`,
         return { ok: false, error: "team, agent, and message required", output: logs.join("\n") };
       }
       cmdTeamSend(args[1], args[2], args.slice(3).join(" "));
+    } else if (sub === "save") {
+      if (!args[1]) {
+        logs.push("usage: maw team save <name>");
+        return { ok: false, error: "name required", output: logs.join("\n") };
+      }
+      const { cmdTeamSave } = await import("./team-recovery");
+      await cmdTeamSave(args[1]);
+
     } else if (sub === "resume") {
       if (!args[1]) {
         logs.push("usage: maw team resume <name> [--model <model>]");
@@ -140,7 +149,13 @@ general flags: --description <text>, --members <list>`,
       }
       const modelIdx = args.indexOf("--model");
       const model = modelIdx !== -1 ? args[modelIdx + 1] : undefined;
-      cmdTeamResume(args[1], { model });
+      // Prefer JSONL-based session recovery when a snapshot exists; fall back to vault reincarnation.
+      const { hasSavedSession, cmdTeamSessionResume } = await import("./team-recovery");
+      if (hasSavedSession(args[1])) {
+        await cmdTeamSessionResume(args[1], { model });
+      } else {
+        cmdTeamResume(args[1], { model });
+      }
     } else if (sub === "lives" || sub === "history") {
       if (!args[1]) {
         logs.push("usage: maw team lives <agent>");
@@ -202,11 +217,6 @@ general flags: --description <text>, --members <list>`,
       if (!id || !agent) { return { ok: false, error: "usage: maw team assign <task-id> <agent> [--team <name>]" }; }
       const team = (flags["--team"] as string | undefined) || resolveTeamFromContext();
       cmdTeamTaskAssign(team, id, agent);
-
-    } else if (sub === "doctor") {
-      // maw team doctor [--fix]
-      const { cmdTeamDoctor } = await import("./team-doctor");
-      await cmdTeamDoctor({ fix: args.includes("--fix") });
 
     } else if (sub === "status") {
       // maw team status [team-name]
@@ -532,7 +542,7 @@ general flags: --description <text>, --members <list>`,
 
     } else {
       logs.push(`unknown team subcommand: ${sub}`);
-      logs.push("usage: maw team <create|spawn|send|shutdown|split|peek|hey|inbox|layout|prep|recover|resume|lives|list|status|doctor|add|tasks|done|assign|delete>");
+      logs.push("usage: maw team <create|spawn|save|resume|send|shutdown|split|peek|hey|inbox|layout|prep|recover|lives|list|status|add|tasks|done|assign|delete>");
       return { ok: false, error: `unknown subcommand: ${sub}`, output: logs.join("\n") };
     }
 

--- a/src/commands/plugins/team/team-recovery.ts
+++ b/src/commands/plugins/team/team-recovery.ts
@@ -1,0 +1,183 @@
+import { appendFileSync, readFileSync, existsSync, mkdirSync, writeFileSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import { hostExec } from "../../../sdk";
+import { TEAMS_DIR, loadTeam, resolvePsi } from "./team-helpers";
+import type { AgentColor } from "../tmux/layout-manager";
+
+const MAW_TEAMS_DIR = join(homedir(), ".maw/teams");
+
+interface SavedMember {
+  name: string;
+  tmuxPaneId: string;
+  cwd: string;
+  agentType: string;
+  backendType: string;
+  color: string;
+  model: string;
+  agentId: string;
+}
+
+interface TeamSaveEntry {
+  ts: string;
+  type: "team_save";
+  team: string;
+  members: SavedMember[];
+}
+
+interface TeamResumeEntry {
+  ts: string;
+  type: "team_resume";
+  team: string;
+  recovered: number;
+  result: "success" | "partial" | "failed";
+}
+
+function jsonlPath(teamName: string): string {
+  return join(MAW_TEAMS_DIR, `${teamName}.jsonl`);
+}
+
+export function hasSavedSession(teamName: string): boolean {
+  const path = jsonlPath(teamName);
+  if (!existsSync(path)) return false;
+  const lines = readFileSync(path, "utf-8").trim().split("\n").filter(Boolean);
+  for (let i = lines.length - 1; i >= 0; i--) {
+    try {
+      const entry = JSON.parse(lines[i]!);
+      if (entry.type === "team_save") return true;
+    } catch { /* skip malformed */ }
+  }
+  return false;
+}
+
+function readLastSave(teamName: string): TeamSaveEntry | null {
+  const path = jsonlPath(teamName);
+  if (!existsSync(path)) return null;
+  const lines = readFileSync(path, "utf-8").trim().split("\n").filter(Boolean);
+  for (let i = lines.length - 1; i >= 0; i--) {
+    try {
+      const entry = JSON.parse(lines[i]!);
+      if (entry.type === "team_save") return entry as TeamSaveEntry;
+    } catch { /* skip malformed */ }
+  }
+  return null;
+}
+
+export async function cmdTeamSave(teamName: string): Promise<void> {
+  const team = loadTeam(teamName);
+  if (!team) throw new Error(`team not found: ${teamName}`);
+
+  mkdirSync(MAW_TEAMS_DIR, { recursive: true });
+
+  const members: SavedMember[] = [];
+  for (const m of team.members) {
+    let cwd = "";
+    if (m.tmuxPaneId && m.tmuxPaneId !== "in-process") {
+      try {
+        cwd = (await hostExec(`tmux display -p -t '${m.tmuxPaneId}' '#{pane_current_path}'`)).trim();
+      } catch { /* pane may be dead */ }
+    }
+    members.push({
+      name: m.name,
+      tmuxPaneId: m.tmuxPaneId || "",
+      cwd,
+      agentType: m.agentType || "general-purpose",
+      backendType: m.backendType || "claude",
+      color: m.color || "blue",
+      model: m.model || "sonnet",
+      agentId: m.agentId || `${m.name}@${teamName}`,
+    });
+  }
+
+  const entry: TeamSaveEntry = {
+    ts: new Date().toISOString(),
+    type: "team_save",
+    team: teamName,
+    members,
+  };
+  appendFileSync(jsonlPath(teamName), JSON.stringify(entry) + "\n");
+
+  console.log(`\x1b[32m✓\x1b[0m saved session for team '${teamName}' — ${members.length} member(s)`);
+  console.log(`  \x1b[90m${jsonlPath(teamName)}\x1b[0m`);
+}
+
+export async function cmdTeamSessionResume(teamName: string, opts: { model?: string } = {}): Promise<void> {
+  const save = readLastSave(teamName);
+  if (!save) {
+    throw new Error(`no saved session for '${teamName}' — run: maw team save ${teamName}`);
+  }
+
+  const alivePanes = new Set(
+    (await hostExec("tmux list-panes -a -F '#{pane_id}'")).split("\n").filter(Boolean),
+  );
+
+  const { spawnTeammatePane, colorAnsi } = await import("../tmux/layout-manager");
+  const PSI = resolvePsi();
+
+  let recovered = 0;
+  let colorIndex = 0;
+
+  for (const m of save.members) {
+    if (m.agentType === "team-lead") { colorIndex++; continue; }
+
+    if (alivePanes.has(m.tmuxPaneId)) {
+      console.log(`  \x1b[${colorAnsi(m.color as AgentColor)}m●\x1b[0m ${m.agentId} alive (${m.tmuxPaneId})`);
+      colorIndex++;
+      continue;
+    }
+
+    const model = opts.model || m.model || "sonnet";
+    const promptPath = join(PSI, "memory", "mailbox", "teams", teamName, `${m.name}-spawn-prompt.md`);
+    const envPrefix = "CLAUDECODE=1 CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1";
+    const claudeCmd = [
+      envPrefix,
+      "claude",
+      `--agent-id '${m.agentId}'`,
+      `--agent-name '${m.name}'`,
+      `--team-name '${teamName}'`,
+      `--agent-color ${m.color}`,
+      `--agent-type ${m.agentType}`,
+      "--dangerously-skip-permissions",
+      `--model ${model}`,
+      existsSync(promptPath) ? `--system-prompt-file '${promptPath.replace(/'/g, "'\\''")}'` : "",
+    ].filter(Boolean).join(" ");
+
+    const fullCmd = m.cwd ? `cd '${m.cwd.replace(/'/g, "'\\''")}' && ${claudeCmd}` : claudeCmd;
+
+    try {
+      const result = await spawnTeammatePane(m.name, fullCmd, { colorIndex });
+
+      // Update tool store with new pane ID
+      const toolConfigPath = join(TEAMS_DIR, teamName, "config.json");
+      if (existsSync(toolConfigPath)) {
+        try {
+          const toolConfig = JSON.parse(readFileSync(toolConfigPath, "utf-8"));
+          const member = toolConfig.members?.find((tm: { name: string }) => tm.name === m.name);
+          if (member) {
+            member.tmuxPaneId = result.paneId;
+            writeFileSync(toolConfigPath, JSON.stringify(toolConfig, null, 2));
+          }
+        } catch { /* best effort */ }
+      }
+
+      await hostExec(`tmux send-keys -t '${result.paneId}' '/recap --deep' Enter`);
+
+      console.log(`  \x1b[${colorAnsi(result.color)}m↻\x1b[0m ${m.agentId} restored → ${result.paneId}`);
+      recovered++;
+    } catch (e) {
+      console.error(`  \x1b[31m✗\x1b[0m failed to restore ${m.agentId}: ${e instanceof Error ? e.message : String(e)}`);
+    }
+    colorIndex++;
+  }
+
+  const resumeEntry: TeamResumeEntry = {
+    ts: new Date().toISOString(),
+    type: "team_resume",
+    team: teamName,
+    recovered,
+    result: recovered > 0 ? "success" : "failed",
+  };
+  appendFileSync(jsonlPath(teamName), JSON.stringify(resumeEntry) + "\n");
+
+  console.log(`\x1b[32m✓\x1b[0m resumed team '${teamName}' — ${recovered} pane(s) restored`);
+}

--- a/src/commands/plugins/tmux/index.ts
+++ b/src/commands/plugins/tmux/index.ts
@@ -1,7 +1,7 @@
 import type { InvokeContext, InvokeResult } from "../../../plugin/types";
 import { parseFlags } from "../../../cli/parse-args";
 import { cmdTmuxPeek, cmdTmuxLs, cmdTmuxSend, cmdTmuxSplit, cmdTmuxKill, cmdTmuxLayout, cmdTmuxAttach, resolveTmuxTarget } from "./impl";
-import { cmdStallDetect } from "./stall-detect";
+import { cmdStallDetect, cmdDetectStalls } from "./stall-detect";
 import { hostExec } from "../../../sdk";
 
 export const command = {
@@ -203,6 +203,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       const target = args[1];
       if (!target) {
         // No target: bring back hidden panes from other windows in this session
+        const myPane = process.env.TMUX_PANE;
         const myWindow = (await hostExec("tmux display-message -p '#{window_index}'")).trim();
         const windowList = (await hostExec("tmux list-windows -F '#{window_index}:#{window_panes}'")).split("\n").filter(Boolean);
         const hiddenWindows = windowList
@@ -227,6 +228,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       }
     } else if (sub === "detect-stalls" || sub === "stall") {
       const flags = parseFlags(args, {
+        "--auto-nudge": Boolean,
         "--watch": Boolean,
         "--threshold": Number,
         "--interval": Number,
@@ -235,27 +237,33 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         "-h": "--help",
       }, 1);
       if (flags["--help"]) {
-        console.log("usage: maw tmux detect-stalls <target> [<target>...] [--watch] [--threshold N] [--interval MS] [--lines N]");
-        console.log("  Phase A — notify-only. Reports panes whose capture-pane content");
-        console.log("  hash hasn't changed for `threshold` consecutive samples.");
-        console.log("  --watch       keep watching (default: one-shot single sample)");
-        console.log("  --threshold N consecutive unchanged samples before notify (default 3)");
-        console.log("  --interval MS milliseconds between samples (default 30000)");
-        console.log("  --lines N     lines from bottom of pane to hash (default 30)");
-        console.log("  NOTE: no auto-nudge in Phase A. See #976B for opt-in injection.");
+        console.log("usage: maw tmux detect-stalls [<target>...] [--auto-nudge] [--watch] [--threshold N] [--interval MS] [--lines N]");
+        console.log("  No targets → inspect all panes in current tmux session.");
+        console.log("  --auto-nudge  send Enter to stalled panes (gated by 4 safety checks)");
+        console.log("  --watch       keep watching (legacy Phase A loop mode)");
+        console.log("  --threshold N consecutive unchanged samples before notify (watch mode, default 3)");
+        console.log("  --interval MS milliseconds between samples (watch mode, default 30000)");
+        console.log("  --lines N     lines from bottom of pane to hash (watch mode, default 30)");
         return { ok: true, output: logs.join("\n") || undefined };
       }
       const targets = (flags._ as string[]).filter(Boolean);
-      if (targets.length === 0) {
-        console.log("usage: maw tmux detect-stalls <target> [<target>...] [--watch] [--threshold N] [--interval MS]");
-        return { ok: false, error: "at least one target required", output: logs.join("\n") };
+      if (flags["--watch"]) {
+        // Legacy Phase A: watch loop mode requires explicit targets
+        if (targets.length === 0) {
+          console.log("usage: maw tmux detect-stalls <target>... --watch [--threshold N] [--interval MS]");
+          return { ok: false, error: "at least one target required for --watch mode", output: logs.join("\n") };
+        }
+        await cmdStallDetect(targets, {
+          watch: true,
+          threshold: flags["--threshold"] as number | undefined,
+          intervalMs: flags["--interval"] as number | undefined,
+          lines: flags["--lines"] as number | undefined,
+        });
+      } else {
+        await cmdDetectStalls(targets.length > 0 ? targets : undefined, {
+          autoNudge: !!flags["--auto-nudge"],
+        });
       }
-      await cmdStallDetect(targets, {
-        watch: !!flags["--watch"],
-        threshold: flags["--threshold"] as number | undefined,
-        intervalMs: flags["--interval"] as number | undefined,
-        lines: flags["--lines"] as number | undefined,
-      });
     } else if (sub === "zoom") {
       const target = args[1];
       if (!target) {

--- a/src/commands/plugins/tmux/stall-detect.ts
+++ b/src/commands/plugins/tmux/stall-detect.ts
@@ -17,6 +17,170 @@ import { createHash } from "node:crypto";
 import { hostExec } from "../../../sdk";
 import { resolveTmuxTarget } from "./impl";
 
+// ─── Phase B: one-shot stall detection with gated auto-nudge (#976) ──────────
+
+const EDITOR_REPL_CMDS = new Set(["vim", "nano", "emacs", "node", "python", "python3", "psql", "irb"]);
+
+interface NudgeGateResult {
+  safe: boolean;
+  reason?: string;
+}
+
+function checkNudgeGates(lastLine: string, paneCmd: string): NudgeGateResult {
+  // Gate 1: password prompt
+  if (/password:|passphrase:|\[sudo\]|pin:/i.test(lastLine))
+    return { safe: false, reason: "gate 1: password prompt" };
+  // Gate 2: editor or REPL running
+  const bare = paneCmd.trim().toLowerCase().split(/\s+/)[0] ?? "";
+  if (EDITOR_REPL_CMDS.has(bare))
+    return { safe: false, reason: "gate 2: editor/REPL" };
+  // Gate 3: claude mid-turn (braille spinner, "Thinking", ⏺ marker)
+  if (/[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]|thinking|⏺/i.test(lastLine))
+    return { safe: false, reason: "gate 3: claude mid-turn" };
+  // Gate 4: interactive prompt (trailing ? or numbered options 1), 2) …)
+  if (/\?\s*$|\b[1-9]\)/.test(lastLine))
+    return { safe: false, reason: "gate 4: interactive prompt" };
+  return { safe: true };
+}
+
+interface PaneStallResult {
+  display: string;
+  id: string;
+  stalled: boolean;
+  nudgeBlocked?: string;
+  nudged?: boolean;
+}
+
+/**
+ * One-shot stall detection with optional gated auto-nudge.
+ *
+ * Algorithm:
+ *   1. Capture last 5 lines from each target pane.
+ *   2. Wait 3 seconds.
+ *   3. Capture again — unchanged content → stall detected.
+ *   4. If --auto-nudge and all safety gates pass → send Enter.
+ *
+ * No targets → inspect every pane in the current tmux session.
+ */
+export async function cmdDetectStalls(targets?: string[], opts?: { autoNudge?: boolean }): Promise<void> {
+  const autoNudge = opts?.autoNudge ?? false;
+
+  // Resolve targets. No targets → all panes in current session.
+  type Resolved = { display: string; id: string };
+  let resolved: Resolved[];
+
+  if (!targets || targets.length === 0) {
+    let raw: string;
+    try {
+      raw = await hostExec("tmux list-panes -a -F '#{session_name}:#{window_index}.#{pane_index} #{pane_id}'");
+    } catch {
+      console.log("\x1b[33m⚠\x1b[0m  not in a tmux session or tmux unavailable");
+      return;
+    }
+    resolved = raw.trim().split("\n").filter(Boolean).map(line => {
+      const [display, id] = line.trim().split(" ");
+      return { display: display ?? line, id: id ?? display ?? line };
+    });
+  } else {
+    resolved = targets.map(t => {
+      const hit = resolveTmuxTarget(t);
+      if (!hit) throw new Error(`cannot resolve target '${t}'`);
+      return { display: t, id: hit.resolved };
+    });
+  }
+
+  if (resolved.length === 0) {
+    console.log("\x1b[90mno panes to inspect\x1b[0m");
+    return;
+  }
+
+  // First capture
+  const snap1 = new Map<string, string>();
+  for (const { id } of resolved) {
+    try {
+      snap1.set(id, await hostExec(`tmux capture-pane -pt '${id}' -S -5 -J`));
+    } catch {
+      snap1.set(id, "");
+    }
+  }
+
+  // Wait 3 seconds
+  await new Promise<void>(r => setTimeout(r, 3000));
+
+  // Second capture + evaluate
+  const results: PaneStallResult[] = [];
+  for (const { display, id } of resolved) {
+    let snap2 = "";
+    try {
+      snap2 = await hostExec(`tmux capture-pane -pt '${id}' -S -5 -J`);
+    } catch { /* pane gone */ }
+
+    const before = snap1.get(id) ?? "";
+    const stalled = before === snap2;
+
+    if (!stalled) {
+      results.push({ display, id, stalled: false });
+      continue;
+    }
+
+    if (!autoNudge) {
+      results.push({ display, id, stalled: true });
+      continue;
+    }
+
+    // Get pane's current command for gate 2
+    let paneCmd = "";
+    try {
+      paneCmd = (await hostExec(`tmux display-message -p -t '${id}' '#{pane_current_command}'`)).trim();
+    } catch { /* ignore */ }
+
+    const lastLine = snap2.trimEnd().split("\n").pop() ?? "";
+    const gate = checkNudgeGates(lastLine, paneCmd);
+
+    if (!gate.safe) {
+      results.push({ display, id, stalled: true, nudgeBlocked: gate.reason });
+      continue;
+    }
+
+    try {
+      await hostExec(`tmux send-keys -t '${id}' '' Enter`);
+      results.push({ display, id, stalled: true, nudged: true });
+    } catch {
+      results.push({ display, id, stalled: true, nudgeBlocked: "send-keys failed" });
+    }
+  }
+
+  // Output
+  console.log("\n\x1b[1m🔍 Stall Detection\x1b[0m\n");
+  for (const r of results) {
+    const label = r.display.padEnd(20);
+    if (!r.stalled) {
+      console.log(`  \x1b[32m●\x1b[0m ${label} active (output changing)`);
+    } else {
+      console.log(`  \x1b[33m⚠\x1b[0m ${label} STALLED (no output for 3s)`);
+      if (autoNudge) {
+        if (r.nudged) {
+          console.log(`    \x1b[90m→ auto-nudge: sent Enter\x1b[0m`);
+        } else if (r.nudgeBlocked) {
+          console.log(`    \x1b[90m→ auto-nudge: blocked (${r.nudgeBlocked})\x1b[0m`);
+        }
+      }
+    }
+  }
+
+  const active = results.filter(r => !r.stalled).length;
+  const stalled = results.filter(r => r.stalled).length;
+  const nudged = results.filter(r => r.nudged).length;
+  const blocked = results.filter(r => r.stalled && !r.nudged).length;
+
+  console.log();
+  if (autoNudge && stalled > 0) {
+    console.log(`\x1b[90mSummary: ${active} active, ${stalled} stalled (${nudged} nudged, ${blocked} blocked)\x1b[0m\n`);
+  } else {
+    console.log(`\x1b[90mSummary: ${active} active, ${stalled} stalled\x1b[0m\n`);
+  }
+}
+
 export interface StallDetectOpts {
   /** Keep watching forever. Default: false (one-shot single sample). */
   watch?: boolean;


### PR DESCRIPTION
## Summary

Two final backlog features:

### Stall Detection (#976)
- `maw stall` detects panes with no output change over 3s
- 4 safety gates for `--auto-nudge`: password prompts, editors/REPLs, Claude mid-turn, interactive prompts
- No targets → inspect all panes in current session
- `--watch` mode preserved for legacy Phase A loop

### Session Recovery (#977)
- `maw team save <name>` captures layout + pane cwds to JSONL (`~/.maw/teams/<name>.jsonl`)
- `maw team resume <name>` reads last snapshot, respawns dead panes, sends `/recap --deep`
- Falls back to vault reincarnation when no JSONL snapshot exists
- Append-only JSONL for crash safety

Closes #976, closes #977

## Test plan
- [ ] `bash scripts/test-isolated.sh` passes
- [ ] `maw stall` runs without error in tmux
- [ ] `maw team save <name>` writes JSONL
- [ ] `maw team resume <name>` restores layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)