### PR TITLE
fix(wake): hide session script path from pane display

### DIFF
--- a/src/config/command.ts
+++ b/src/config/command.ts
@@ -171,6 +171,8 @@ function formatScriptHeader(agentName: string, cwd: string, opts: BuildCommandOp
   if (opts.permissionMode) lines.push(`# Permission: ${opts.permissionMode}`);
   if (opts.engine) lines.push(`# Engine: ${opts.engine}`);
   lines.push("");
+  lines.push(`printf '\\033]2;${agentName}\\033\\\\'`);
+  lines.push("");
   return lines.join("\n");
 }
 
@@ -302,7 +304,7 @@ export function writeSessionScript(agentName: string, cwd: string, optsOrEngine?
 export function buildCommandInDir(agentName: string, cwd: string, optsOrEngine?: string | BuildCommandOpts): string {
   try {
     const scriptPath = writeSessionScript(agentName, cwd, optsOrEngine);
-    return `bash ${scriptPath}`;
+    return ` bash ${scriptPath}`;
   } catch {
     return buildCommand(agentName, optsOrEngine);
   }

--- a/test/build-command-contract.test.ts
+++ b/test/build-command-contract.test.ts
@@ -118,7 +118,7 @@ describe("buildCommand — post-#541 contract", () => {
   test("buildCommandInDir returns script path (#1188 — replaces inline blob with session script)", () => {
     fakeConfig.commands = { default: "claude --continue --dangerously-skip-permissions" };
     const inDir = buildCommandInDir("foo", "/tmp/some where/nested");
-    expect(inDir).toStartWith("bash ");
+    expect(inDir).toStartWith(" bash ");
     expect(inDir).toContain("sessions/foo.sh");
     expect(inDir).not.toContain("cd ");
   });
@@ -143,7 +143,7 @@ describe("buildCommand — post-#541 contract", () => {
   test("buildCommandInDir returns bash script path (#1188)", () => {
     fakeConfig.commands = { default: "claude", codex: "codex --search" };
     const result = buildCommandInDir("foo", "/tmp", "codex");
-    expect(result).toStartWith("bash ");
+    expect(result).toStartWith(" bash ");
     expect(result).toContain("sessions/foo.sh");
   });
 
@@ -199,7 +199,7 @@ describe("buildCommand — post-#541 contract", () => {
         expect(out).not.toContain("CLAUDECODE");
         expect(out.startsWith("cd ")).toBe(false);
         const inDir = buildCommandInDir(name, "/tmp/x");
-        expect(inDir).toStartWith("bash ");
+        expect(inDir).toStartWith(" bash ");
         expect(inDir).toContain("sessions/");
       }
     }


### PR DESCRIPTION
## Summary
- Leading space in `buildCommandInDir` suppresses bash history recording
- Session script sets terminal title to agent name via OSC escape sequence
- Pane shows `odin-oracle` instead of `bash /Users/nat/.maw/sessions/odin-oracle.sh`

## Test plan
- [ ] `bash scripts/test-isolated.sh` passes
- [ ] `maw wake <oracle>` — pane title shows oracle name, not script path

🤖 Generated with [Claude Code](https://claude.com/claude-code)