### PR TITLE
fix(wake): maw show pipe in pane instead of raw script path

### DIFF
--- a/src/config/command.ts
+++ b/src/config/command.ts
@@ -303,8 +303,8 @@ export function writeSessionScript(agentName: string, cwd: string, optsOrEngine?
  */
 export function buildCommandInDir(agentName: string, cwd: string, optsOrEngine?: string | BuildCommandOpts): string {
   try {
-    const scriptPath = writeSessionScript(agentName, cwd, optsOrEngine);
-    return ` bash ${scriptPath}`;
+    writeSessionScript(agentName, cwd, optsOrEngine);
+    return ` maw show ${agentName} | bash`;
   } catch {
     return buildCommand(agentName, optsOrEngine);
   }

--- a/src/config/command.ts
+++ b/src/config/command.ts
@@ -171,6 +171,7 @@ function formatScriptHeader(agentName: string, cwd: string, opts: BuildCommandOp
   if (opts.permissionMode) lines.push(`# Permission: ${opts.permissionMode}`);
   if (opts.engine) lines.push(`# Engine: ${opts.engine}`);
   lines.push("");
+  lines.push(`clear`);
   lines.push(`printf '\\033]2;${agentName}\\033\\\\'`);
   lines.push("");
   return lines.join("\n");

--- a/src/config/command.ts
+++ b/src/config/command.ts
@@ -286,31 +286,24 @@ export function writeSessionScript(agentName: string, cwd: string, optsOrEngine?
     ? { engine: optsOrEngine }
     : (optsOrEngine || {});
 
-  const content = formatScriptHeader(agentName, cwd, opts) + formatScriptBody(agentName, opts) + "\n";
-
   mkdirSync(SESSIONS_DIR, { recursive: true });
-  const globalPath = join(SESSIONS_DIR, `${agentName}.sh`);
-  writeFileSync(globalPath, content, { mode: 0o755 });
+  const scriptPath = join(SESSIONS_DIR, `${agentName}.sh`);
+  const content = formatScriptHeader(agentName, cwd, opts) + formatScriptBody(agentName, opts) + "\n";
+  writeFileSync(scriptPath, content, { mode: 0o755 });
 
-  if (cwd) {
-    const localPath = join(cwd, ".start.sh");
-    try { writeFileSync(localPath, content, { mode: 0o755 }); } catch {}
-  }
-
-  return globalPath;
+  return scriptPath;
 }
 
 /**
- * Build the command string for a wake pane. Writes session script to both
- * ~/.maw/sessions/<agent>.sh (global) and <cwd>/.start.sh (local).
- * Returns `bash .start.sh` for clean pane display (#1188).
+ * Build the command string for a wake pane. Writes a session script to
+ * ~/.maw/sessions/<agent>.sh and returns the command to run it (#1188).
  *
- * Falls back to global path, then inline buildCommand().
+ * Falls back to inline buildCommand() if script write fails.
  */
 export function buildCommandInDir(agentName: string, cwd: string, optsOrEngine?: string | BuildCommandOpts): string {
   try {
-    writeSessionScript(agentName, cwd, optsOrEngine);
-    return ` bash .start.sh`;
+    const scriptPath = writeSessionScript(agentName, cwd, optsOrEngine);
+    return ` bash ${scriptPath}`;
   } catch {
     return buildCommand(agentName, optsOrEngine);
   }

--- a/src/config/command.ts
+++ b/src/config/command.ts
@@ -286,25 +286,31 @@ export function writeSessionScript(agentName: string, cwd: string, optsOrEngine?
     ? { engine: optsOrEngine }
     : (optsOrEngine || {});
 
-  mkdirSync(SESSIONS_DIR, { recursive: true });
-  const scriptPath = join(SESSIONS_DIR, `${agentName}.sh`);
   const content = formatScriptHeader(agentName, cwd, opts) + formatScriptBody(agentName, opts) + "\n";
-  writeFileSync(scriptPath, content, { mode: 0o755 });
 
-  return scriptPath;
+  mkdirSync(SESSIONS_DIR, { recursive: true });
+  const globalPath = join(SESSIONS_DIR, `${agentName}.sh`);
+  writeFileSync(globalPath, content, { mode: 0o755 });
+
+  if (cwd) {
+    const localPath = join(cwd, ".start.sh");
+    try { writeFileSync(localPath, content, { mode: 0o755 }); } catch {}
+  }
+
+  return globalPath;
 }
 
 /**
- * Build the command string for a wake pane. Writes a session script to
- * ~/.maw/sessions/<agent>.sh and returns `bash <path>` so the tmux pane
- * shows a clean one-liner instead of a 200-char inline blob (#1188).
+ * Build the command string for a wake pane. Writes session script to both
+ * ~/.maw/sessions/<agent>.sh (global) and <cwd>/.start.sh (local).
+ * Returns `bash .start.sh` for clean pane display (#1188).
  *
- * Falls back to inline buildCommand() if script write fails.
+ * Falls back to global path, then inline buildCommand().
  */
 export function buildCommandInDir(agentName: string, cwd: string, optsOrEngine?: string | BuildCommandOpts): string {
   try {
     writeSessionScript(agentName, cwd, optsOrEngine);
-    return ` maw show ${agentName} | bash`;
+    return ` bash .start.sh`;
   } catch {
     return buildCommand(agentName, optsOrEngine);
   }

--- a/test/build-command-contract.test.ts
+++ b/test/build-command-contract.test.ts
@@ -115,11 +115,10 @@ describe("buildCommand — post-#541 contract", () => {
     expect(fallback).not.toContain("--resume");
   });
 
-  test("buildCommandInDir returns script path (#1188 — replaces inline blob with session script)", () => {
+  test("buildCommandInDir returns maw show pipe (#1188 — clean pane display)", () => {
     fakeConfig.commands = { default: "claude --continue --dangerously-skip-permissions" };
     const inDir = buildCommandInDir("foo", "/tmp/some where/nested");
-    expect(inDir).toStartWith(" bash ");
-    expect(inDir).toContain("sessions/foo.sh");
+    expect(inDir).toBe(" maw show foo | bash");
     expect(inDir).not.toContain("cd ");
   });
 
@@ -140,11 +139,10 @@ describe("buildCommand — post-#541 contract", () => {
     expect(buildCommand("foo-bar", "codex")).toBe(wrap("codex --auto"));
   });
 
-  test("buildCommandInDir returns bash script path (#1188)", () => {
+  test("buildCommandInDir returns maw show pipe with engine (#1188)", () => {
     fakeConfig.commands = { default: "claude", codex: "codex --search" };
     const result = buildCommandInDir("foo", "/tmp", "codex");
-    expect(result).toStartWith(" bash ");
-    expect(result).toContain("sessions/foo.sh");
+    expect(result).toBe(" maw show foo | bash");
   });
 
   // #1174 — engine-aware --continue auto-inject for claude wakes.
@@ -199,8 +197,8 @@ describe("buildCommand — post-#541 contract", () => {
         expect(out).not.toContain("CLAUDECODE");
         expect(out.startsWith("cd ")).toBe(false);
         const inDir = buildCommandInDir(name, "/tmp/x");
-        expect(inDir).toStartWith(" bash ");
-        expect(inDir).toContain("sessions/");
+        expect(inDir).toStartWith(" maw show ");
+        expect(inDir).toContain("| bash");
       }
     }
   });

--- a/test/build-command-contract.test.ts
+++ b/test/build-command-contract.test.ts
@@ -115,10 +115,10 @@ describe("buildCommand — post-#541 contract", () => {
     expect(fallback).not.toContain("--resume");
   });
 
-  test("buildCommandInDir returns maw show pipe (#1188 — clean pane display)", () => {
+  test("buildCommandInDir returns bash .start.sh (#1188 — clean pane display)", () => {
     fakeConfig.commands = { default: "claude --continue --dangerously-skip-permissions" };
     const inDir = buildCommandInDir("foo", "/tmp/some where/nested");
-    expect(inDir).toBe(" maw show foo | bash");
+    expect(inDir).toBe(" bash .start.sh");
     expect(inDir).not.toContain("cd ");
   });
 
@@ -139,10 +139,10 @@ describe("buildCommand — post-#541 contract", () => {
     expect(buildCommand("foo-bar", "codex")).toBe(wrap("codex --auto"));
   });
 
-  test("buildCommandInDir returns maw show pipe with engine (#1188)", () => {
+  test("buildCommandInDir returns bash .start.sh with engine (#1188)", () => {
     fakeConfig.commands = { default: "claude", codex: "codex --search" };
     const result = buildCommandInDir("foo", "/tmp", "codex");
-    expect(result).toBe(" maw show foo | bash");
+    expect(result).toBe(" bash .start.sh");
   });
 
   // #1174 — engine-aware --continue auto-inject for claude wakes.
@@ -197,8 +197,7 @@ describe("buildCommand — post-#541 contract", () => {
         expect(out).not.toContain("CLAUDECODE");
         expect(out.startsWith("cd ")).toBe(false);
         const inDir = buildCommandInDir(name, "/tmp/x");
-        expect(inDir).toStartWith(" maw show ");
-        expect(inDir).toContain("| bash");
+        expect(inDir).toBe(" bash .start.sh");
       }
     }
   });

--- a/test/build-command-contract.test.ts
+++ b/test/build-command-contract.test.ts
@@ -115,10 +115,11 @@ describe("buildCommand — post-#541 contract", () => {
     expect(fallback).not.toContain("--resume");
   });
 
-  test("buildCommandInDir returns bash .start.sh (#1188 — clean pane display)", () => {
+  test("buildCommandInDir returns session script path (#1188)", () => {
     fakeConfig.commands = { default: "claude --continue --dangerously-skip-permissions" };
     const inDir = buildCommandInDir("foo", "/tmp/some where/nested");
-    expect(inDir).toBe(" bash .start.sh");
+    expect(inDir).toStartWith(" bash ");
+    expect(inDir).toContain("sessions/foo.sh");
     expect(inDir).not.toContain("cd ");
   });
 
@@ -139,10 +140,11 @@ describe("buildCommand — post-#541 contract", () => {
     expect(buildCommand("foo-bar", "codex")).toBe(wrap("codex --auto"));
   });
 
-  test("buildCommandInDir returns bash .start.sh with engine (#1188)", () => {
+  test("buildCommandInDir returns session script path with engine (#1188)", () => {
     fakeConfig.commands = { default: "claude", codex: "codex --search" };
     const result = buildCommandInDir("foo", "/tmp", "codex");
-    expect(result).toBe(" bash .start.sh");
+    expect(result).toStartWith(" bash ");
+    expect(result).toContain("sessions/foo.sh");
   });
 
   // #1174 — engine-aware --continue auto-inject for claude wakes.
@@ -197,7 +199,8 @@ describe("buildCommand — post-#541 contract", () => {
         expect(out).not.toContain("CLAUDECODE");
         expect(out.startsWith("cd ")).toBe(false);
         const inDir = buildCommandInDir(name, "/tmp/x");
-        expect(inDir).toBe(" bash .start.sh");
+        expect(inDir).toStartWith(" bash ");
+        expect(inDir).toContain("sessions/");
       }
     }
   });


### PR DESCRIPTION
## Summary
Changes the pane command from:
```
❯ bash /Users/nat/.maw/sessions/odin-oracle.sh
```
to:
```
❯ maw show odin-oracle | bash
```

A clean UNIX pipe the user understands, not an implementation detail.

## Changes
- `buildCommandInDir` returns ` maw show <agent> | bash` (leading space = no history)
- Session script still written (maw show reads it)
- OSC title escape in script header sets pane title to agent name

Follows up on #1222 (which added the leading space + OSC title).

## Test plan
- [ ] `bash scripts/test-isolated.sh` passes
- [ ] `maw wake <oracle>` shows `maw show <name> | bash` in pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)