### PR TITLE
fix(wake): skip retry when pane already ran session script

### DIFF
--- a/src/commands/shared/wake-session.ts
+++ b/src/commands/shared/wake-session.ts
@@ -43,7 +43,8 @@ export async function ensureSessionRunning(session: string, excludeNames?: Set<s
     const target = `${session}:${win.name}`;
     const paneCmd = (cmds[target] || "").trim().toLowerCase();
     if (paneCmd === "zsh" || paneCmd === "bash" || paneCmd === "sh" || paneCmd === "") {
-      if (!(await isPaneIdle(target))) continue; // shell has children → mid-startup, skip
+      if (!(await isPaneIdle(target))) continue;
+      if (await paneRanSessionScript(target)) continue;
       try {
         await new Promise(r => setTimeout(r, cfgTimeout("wakeRetry")));
         const cwd = cwdMap?.[win.name];
@@ -55,6 +56,17 @@ export async function ensureSessionRunning(session: string, excludeNames?: Set<s
     }
   }
   return retried;
+}
+
+async function paneRanSessionScript(target: string): Promise<boolean> {
+  try {
+    const content = (await hostExec(
+      `tmux capture-pane -t '${target}' -p -S -10 2>/dev/null`
+    )).trim();
+    return content.includes("maw-session:") || content.includes("🕐") || content.includes("\\033]2;");
+  } catch {
+    return false;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- `ensureSessionRunning` now checks pane scrollback for session script markers before retrying
- Prevents duplicate `bash ~/.maw/sessions/...` sent to panes where Claude already ran
- Checks for `maw-session:` comment, date stamp, or OSC title escape in last 10 lines

## Root cause
When Claude exits, the shell prompt returns. `ensureSessionRunning` sees an idle shell and retries — but the session script already ran. The retry types the command into whatever is running next (possibly a new Claude session).

## Test plan
- [ ] `bash scripts/test-isolated.sh` passes
- [ ] `maw wake <oracle>` doesn't double-send to already-started panes

🤖 Generated with [Claude Code](https://claude.com/claude-code)