### PR TITLE
fix(wake): respawn-pane for clean pane display — no .sh, no history, no flash

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -1,6 +1,6 @@
 import { hostExec, tmux, restoreTabOrder, takeSnapshot, getPaneInfos, isAgentCommand } from "../../sdk";
 import { ghqFind } from "../../core/ghq";
-import { buildCommandInDir, cfgTimeout, loadConfig, saveConfig } from "../../config";
+import { buildCommandInDir, buildRespawnCommand, cfgTimeout, loadConfig, saveConfig } from "../../config";
 import { resolveWorktreeTarget } from "../../core/matcher/resolve-target";
 import { normalizeTarget } from "../../core/matcher/normalize-target";
 import { assertValidOracleName } from "../../core/fleet/validate";
@@ -148,7 +148,8 @@ export async function cmdWake(oracle: string, opts: WakeCmdOptions): Promise<str
     const wakeOpts = channelIds.length
       ? { engine: opts.engine, channels: channelIds, channelEnv, permissionMode }
       : opts.engine;
-    await tmux.sendText(`${session}:${mainWindowName}`, buildCommandInDir(mainWindowName, repoPath, wakeOpts));
+    const paneTarget = `${session}:${mainWindowName}`;
+    await tmux.respawnPane(paneTarget, buildRespawnCommand(mainWindowName, wakeOpts));
     console.log(`\x1b[32m+\x1b[0m created session '${session}' (main: ${mainWindowName})`);
 
     // Auto-register agent in config.agents so federation peers can route to it (#285)

--- a/src/commands/shared/wake-session.ts
+++ b/src/commands/shared/wake-session.ts
@@ -1,5 +1,5 @@
 import { hostExec, tmux } from "../../sdk";
-import { buildCommand, buildCommandInDir, cfgTimeout } from "../../config";
+import { buildCommand, buildRespawnCommand, cfgTimeout } from "../../config";
 import { execSync } from "child_process";
 
 /** Attach to tmux session — switch-client if inside tmux, attach if fresh shell */
@@ -47,9 +47,7 @@ export async function ensureSessionRunning(session: string, excludeNames?: Set<s
       if (await paneRanSessionScript(target)) continue;
       try {
         await new Promise(r => setTimeout(r, cfgTimeout("wakeRetry")));
-        const cwd = cwdMap?.[win.name];
-        const cmd = cwd ? buildCommandInDir(win.name, cwd) : buildCommand(win.name);
-        await tmux.sendText(target, cmd);
+        await tmux.respawnPane(target, buildRespawnCommand(win.name));
         console.log(`\x1b[33m↻\x1b[0m retry: ${win.name} (was ${paneCmd || "empty"})`);
         retried++;
       } catch { /* window may have been killed */ }

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,4 +3,4 @@ export type { TriggerEvent, TriggerConfig, PeerConfig, MawIntervals, MawTimeouts
 export { D } from "./config/types";
 export { validateConfigShape } from "./config/validate";
 export { loadConfig, resetConfig, saveConfig, configForDisplay, cfgInterval, cfgTimeout, cfgLimit, cfg } from "./config/load";
-export { buildCommand, buildCommandInDir, writeSessionScript, getEnvVars } from "./config/command";
+export { buildCommand, buildCommandInDir, buildRespawnCommand, writeSessionScript, getEnvVars } from "./config/command";

--- a/src/config/command.ts
+++ b/src/config/command.ts
@@ -312,6 +312,27 @@ export function buildCommandInDir(agentName: string, cwd: string, optsOrEngine?:
   }
 }
 
+/**
+ * Build a respawn-pane command — replaces the pane process entirely.
+ * No shell history, no typed command visible. Shows date + oracle name
+ * before Claude starts, exit timestamp after Claude exits, then drops
+ * to user's $SHELL.
+ */
+export function buildRespawnCommand(agentName: string, optsOrEngine?: string | BuildCommandOpts): string {
+  const cmd = buildCommand(agentName, optsOrEngine);
+  const safe = agentName.replace(/'/g, "'\\''");
+  return [
+    `clear`,
+    `printf '\\033]2;${safe}\\033\\\\'`,
+    `date '+🕐 %H:%M %Z — ${safe}'`,
+    `echo`,
+    cmd,
+    `echo`,
+    `date '+⏹ %H:%M %Z — ${safe} exited'`,
+    `exec \${SHELL:-zsh} -li`,
+  ].join("; ");
+}
+
 export function getEnvVars(): Record<string, string> {
   return loadConfig().env || {};
 }

--- a/src/core/transport/tmux-class.ts
+++ b/src/core/transport/tmux-class.ts
@@ -288,6 +288,10 @@ export class Tmux {
     }
   }
 
+  async respawnPane(target: string, command: string): Promise<void> {
+    await this.run("respawn-pane", "-k", "-t", target, command);
+  }
+
   // --- Environment ---
 
   async setEnvironment(session: string, key: string, value: string): Promise<void> {


### PR DESCRIPTION
## Summary
Replaces `tmux.sendText()` with `tmux.respawnPane()` for oracle wake. The command is the pane's process — never typed into a shell.

### Before
```
❯ bash /Users/nat/.maw/sessions/mother-oracle.sh   ← visible in history, in pane
```

### After
```
🕐 11:34 +07 — mother-oracle                       ← date + name, then Claude starts
⏹ 12:15 +07 — mother-oracle exited                 ← on exit, shows when it ended
```

## Changes
- `tmux.respawnPane(target, command)` — new method in tmux-class.ts
- `buildRespawnCommand(name, opts)` — inline command chain (clear → title → date → claude → exit info → $SHELL)
- `wake-cmd.ts` — main wake uses `respawnPane` instead of `sendText`
- `wake-session.ts` — retry also uses `respawnPane`

## Why respawn-pane
- No shell history (command is pane's process, not typed into shell)
- No flash (pane process starts clean)
- No `.sh` filename visible
- Works with any shell ($SHELL, not hardcoded bash)
- Same pattern swarm + arena already use

## Test plan
- [ ] `bash scripts/test-isolated.sh` passes
- [ ] `maw wake <oracle>` shows clean date + name, no .sh path

🤖 Generated with [Claude Code](https://claude.com/claude-code)