### PR TITLE
fix(wake): shell function — pane shows oracle name, not .sh path

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -1,6 +1,6 @@
 import { hostExec, tmux, restoreTabOrder, takeSnapshot, getPaneInfos, isAgentCommand } from "../../sdk";
 import { ghqFind } from "../../core/ghq";
-import { buildCommandInDir, buildRespawnCommand, cfgTimeout, loadConfig, saveConfig } from "../../config";
+import { buildCommandInDir, buildShellFunction, cfgTimeout, loadConfig, saveConfig } from "../../config";
 import { resolveWorktreeTarget } from "../../core/matcher/resolve-target";
 import { normalizeTarget } from "../../core/matcher/normalize-target";
 import { assertValidOracleName } from "../../core/fleet/validate";
@@ -149,7 +149,7 @@ export async function cmdWake(oracle: string, opts: WakeCmdOptions): Promise<str
       ? { engine: opts.engine, channels: channelIds, channelEnv, permissionMode }
       : opts.engine;
     const paneTarget = `${session}:${mainWindowName}`;
-    await tmux.respawnPane(paneTarget, buildRespawnCommand(mainWindowName, wakeOpts));
+    await tmux.sendText(paneTarget, buildShellFunction(mainWindowName, wakeOpts));
     console.log(`\x1b[32m+\x1b[0m created session '${session}' (main: ${mainWindowName})`);
 
     // Auto-register agent in config.agents so federation peers can route to it (#285)

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -204,7 +204,7 @@ export async function cmdWake(oracle: string, opts: WakeCmdOptions): Promise<str
           usedNames.add(wtWindowName);
           await tmux.newWindow(session, wtWindowName, { cwd: wt.path });
           await new Promise(r => setTimeout(r, 300));
-          await tmux.sendText(`${session}:${wtWindowName}`, buildShellFunction(wtWindowName, wakeOpts));
+          await tmux.sendText(`${session}:${wtWindowName}`, buildShellFunction(wtWindowName, opts.engine));
           console.log(`\x1b[32m↻\x1b[0m respawned: ${wtWindowName}`);
         }
       }

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -178,7 +178,7 @@ export async function cmdWake(oracle: string, opts: WakeCmdOptions): Promise<str
         usedNames.add(wtWindowName);
         await tmux.newWindow(session, wtWindowName, { cwd: wt.path });
         await new Promise(r => setTimeout(r, 300));
-        await tmux.sendText(`${session}:${wtWindowName}`, buildCommandInDir(wtWindowName, wt.path, wakeOpts));
+        await tmux.sendText(`${session}:${wtWindowName}`, buildShellFunction(wtWindowName, wakeOpts));
         console.log(`\x1b[32m+\x1b[0m window: ${wtWindowName}`);
       }
     }
@@ -204,7 +204,7 @@ export async function cmdWake(oracle: string, opts: WakeCmdOptions): Promise<str
           usedNames.add(wtWindowName);
           await tmux.newWindow(session, wtWindowName, { cwd: wt.path });
           await new Promise(r => setTimeout(r, 300));
-          await tmux.sendText(`${session}:${wtWindowName}`, buildCommandInDir(wtWindowName, wt.path, wakeOpts));
+          await tmux.sendText(`${session}:${wtWindowName}`, buildShellFunction(wtWindowName, wakeOpts));
           console.log(`\x1b[32m↻\x1b[0m respawned: ${wtWindowName}`);
         }
       }
@@ -289,7 +289,7 @@ export async function cmdWake(oracle: string, opts: WakeCmdOptions): Promise<str
 
       if (!agentAlive) {
         console.log(`\x1b[33m⚡\x1b[0m '${existingWindow}' in ${session} — agent dead, re-launching...`);
-        await tmux.sendText(target, buildCommandInDir(existingWindow, targetPath, opts.engine));
+        await tmux.sendText(target, buildShellFunction(existingWindow, opts.engine));
         if (opts.attach) {
           await tmux.selectWindow(target);
           await attachToSession(session);
@@ -310,12 +310,12 @@ export async function cmdWake(oracle: string, opts: WakeCmdOptions): Promise<str
 
   await tmux.newWindow(session, windowName, { cwd: targetPath });
   await new Promise(r => setTimeout(r, 300));
-  const cmd = buildCommandInDir(windowName, targetPath, opts.engine);
   if (opts.prompt) {
+    const cmd = buildCommandInDir(windowName, targetPath, opts.engine);
     const escaped = opts.prompt.replace(/'/g, "'\\''");
     await tmux.sendText(`${session}:${windowName}`, `${cmd} -p '${escaped}'`);
   } else {
-    await tmux.sendText(`${session}:${windowName}`, cmd);
+    await tmux.sendText(`${session}:${windowName}`, buildShellFunction(windowName, opts.engine));
   }
 
   console.log(`\x1b[32m✅\x1b[0m woke '${windowName}' in ${session} → ${targetPath}`);

--- a/src/commands/shared/wake-session.ts
+++ b/src/commands/shared/wake-session.ts
@@ -1,5 +1,5 @@
 import { hostExec, tmux } from "../../sdk";
-import { buildCommand, buildRespawnCommand, cfgTimeout } from "../../config";
+import { buildShellFunction, cfgTimeout } from "../../config";
 import { execSync } from "child_process";
 
 /** Attach to tmux session — switch-client if inside tmux, attach if fresh shell */
@@ -47,7 +47,7 @@ export async function ensureSessionRunning(session: string, excludeNames?: Set<s
       if (await paneRanSessionScript(target)) continue;
       try {
         await new Promise(r => setTimeout(r, cfgTimeout("wakeRetry")));
-        await tmux.respawnPane(target, buildRespawnCommand(win.name));
+        await tmux.sendText(target, buildShellFunction(win.name));
         console.log(`\x1b[33m↻\x1b[0m retry: ${win.name} (was ${paneCmd || "empty"})`);
         retried++;
       } catch { /* window may have been killed */ }

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,4 +3,4 @@ export type { TriggerEvent, TriggerConfig, PeerConfig, MawIntervals, MawTimeouts
 export { D } from "./config/types";
 export { validateConfigShape } from "./config/validate";
 export { loadConfig, resetConfig, saveConfig, configForDisplay, cfgInterval, cfgTimeout, cfgLimit, cfg } from "./config/load";
-export { buildCommand, buildCommandInDir, buildRespawnCommand, writeSessionScript, getEnvVars } from "./config/command";
+export { buildCommand, buildCommandInDir, buildShellFunction, writeSessionScript, getEnvVars } from "./config/command";

--- a/src/config/command.ts
+++ b/src/config/command.ts
@@ -313,24 +313,23 @@ export function buildCommandInDir(agentName: string, cwd: string, optsOrEngine?:
 }
 
 /**
- * Build a respawn-pane command — replaces the pane process entirely.
- * No shell history, no typed command visible. Shows date + oracle name
- * before Claude starts, exit timestamp after Claude exits, then drops
- * to user's $SHELL.
+ * Build a shell function definition + call for the oracle.
+ * The pane shows `odin-oracle` — clean, re-runnable, no .sh path.
+ * Defines the function inline, then calls it immediately.
  */
-export function buildRespawnCommand(agentName: string, optsOrEngine?: string | BuildCommandOpts): string {
+export function buildShellFunction(agentName: string, optsOrEngine?: string | BuildCommandOpts): string {
   const cmd = buildCommand(agentName, optsOrEngine);
-  const safe = agentName.replace(/'/g, "'\\''");
-  return [
+  const fn = agentName.replace(/[^a-zA-Z0-9_-]/g, "-");
+  const body = [
     `clear`,
-    `printf '\\033]2;${safe}\\033\\\\'`,
-    `date '+🕐 %H:%M %Z — ${safe}'`,
+    `printf '\\033]2;${fn}\\033\\\\'`,
+    `date '+🕐 %H:%M %Z — ${fn}'`,
     `echo`,
     cmd,
     `echo`,
-    `date '+⏹ %H:%M %Z — ${safe} exited'`,
-    `exec \${SHELL:-zsh} -li`,
+    `date '+⏹ %H:%M %Z — ${fn} exited'`,
   ].join("; ");
+  return `${fn}() { ${body}; }; ${fn}`;
 }
 
 export function getEnvVars(): Record<string, string> {


### PR DESCRIPTION
## Summary

Replaces `bash ~/.maw/sessions/agent.sh` with an inline shell function:

```
❯ odin-oracle
🕐 11:40 +07 — odin-oracle
[Claude starts]
⏹ 12:15 +07 — odin-oracle exited
❯ odin-oracle   ← re-run by typing the name
```

### How it works

`buildShellFunction(name, opts)` generates:
```zsh
odin-oracle() { clear; printf '\033]2;odin-oracle\033\\'; date '+🕐 ...'; echo; claude --continue ...; echo; date '+⏹ ...'; }; odin-oracle
```

Sent via `tmux.sendText()` to the pane's shell. The function is defined + called in one line.

### Benefits
- Pane shows `odin-oracle` not `bash /Users/nat/.maw/sessions/odin-oracle.sh`
- Re-runnable — just type `odin-oracle` again after exit
- Works in zsh and bash (shell agnostic)
- No file to manage
- Extends the `maw shellenv` pattern

### What changed
- `buildShellFunction()` in `src/config/command.ts` (new)
- `wake-cmd.ts` uses `sendText(buildShellFunction())` instead of `respawnPane`
- `wake-session.ts` retry uses same pattern

## Test plan
- [ ] `bash scripts/test-isolated.sh` passes
- [ ] `maw wake <oracle>` — pane shows oracle name as command

🤖 Generated with [Claude Code](https://claude.com/claude-code)