### PR TITLE
fix(wake): simpler — pane shows plain claude command

### DIFF
--- a/src/config/command.ts
+++ b/src/config/command.ts
@@ -313,23 +313,16 @@ export function buildCommandInDir(agentName: string, cwd: string, optsOrEngine?:
 }
 
 /**
- * Build a shell function definition + call for the oracle.
- * The pane shows `odin-oracle` — clean, re-runnable, no .sh path.
- * Defines the function inline, then calls it immediately.
+ * Build the plain wake command for the pane.
+ * No per-oracle function, no inline fallback wrap — relies on the
+ * user's `claude()` shell wrapper (from `maw shellenv`) to handle
+ * `--continue` fallback transparently.
+ *
+ * Pane shows the actual command: `claude --dangerously-skip-permissions --continue`
+ * Re-runnable with up-arrow. Re-runnable by typing claude flags directly.
  */
 export function buildShellFunction(agentName: string, optsOrEngine?: string | BuildCommandOpts): string {
-  const cmd = buildCommand(agentName, optsOrEngine);
-  const fn = agentName.replace(/[^a-zA-Z0-9_-]/g, "-");
-  const body = [
-    `clear`,
-    `printf '\\033]2;${fn}\\033\\\\'`,
-    `date '+🕐 %H:%M %Z — ${fn}'`,
-    `echo`,
-    cmd,
-    `echo`,
-    `date '+⏹ %H:%M %Z — ${fn} exited'`,
-  ].join("; ");
-  return `${fn}() { ${body}; }; ${fn}`;
+  return buildCommand(agentName, optsOrEngine);
 }
 
 export function getEnvVars(): Record<string, string> {


### PR DESCRIPTION
## Summary

Removes the inline per-oracle function wrapper from `buildShellFunction`. The pane now shows the actual command being run, with the fallback chain visible:

```
❯ { claude --dangerously-skip-permissions --continue || claude --dangerously-skip-permissions; }; printf '\e[?1049l\e[0m'; stty sane 2>/dev/null; clear
```

Explicit. Re-runnable with up-arrow. No `.sh` file, no per-oracle function definition.

Users who want a cleaner display can add a `claude()` wrapper to their shell config — but maw-js doesn't generate per-oracle functions anymore.

## Test plan
- [ ] `maw wake <oracle>` shows the actual claude command in the pane
- [ ] `bash scripts/test-isolated.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)