### PR TITLE
fix(wake): route `maw wake all` to cmdWakeAll (rebased #1189)

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -168,8 +168,27 @@ export async function invokeDirectHandler(
     const positional = flags._;
     const oracle = positional[0];
     if (!oracle) {
-      console.error("usage: maw wake <oracle> [--task <s>] [--wt <s>] [-p|--prompt <s>] [--incubate <slug>] [--fresh] [-a|--attach] [--no-attach] [--list] [--split] [--all-local] [-e|--engine <name>] [--dry-run]");
+      console.error("usage: maw wake <oracle> [--task <s>] [--wt <s>] [-p|--prompt <s>] [--incubate <slug>] [--fresh] [-a|--attach] [--no-attach] [--list] [--split] [--all-local] [-e|--engine <name>] [--dry-run]\n       maw wake all [--kill] [--all] [--resume]");
       throw new UserError("wake: missing oracle name");
+    }
+
+    // Pre-#918 the wake/ plugin handled `maw wake all` by routing to cmdWakeAll.
+    // When wake routing moved to top-aliases the early-route was lost, so "all"
+    // started resolving as a literal oracle name (#918 regression surfaced via
+    // pulse-oracle 2026-05-06 maw-boot incident). Restore the routing here.
+    if (oracle.toLowerCase() === "all") {
+      const allFlags = parseFlags(argv, {
+        "--kill": Boolean,
+        "--all": Boolean,
+        "--resume": Boolean,
+      }, 0);
+      const { cmdWakeAll } = await import("../commands/shared/fleet-wake");
+      await cmdWakeAll({
+        kill: !!allFlags["--kill"],
+        all: !!allFlags["--all"],
+        resume: !!allFlags["--resume"],
+      });
+      return;
     }
 
     if (flags["--dry-run"]) {

--- a/test/cli/wake-all-routing.test.ts
+++ b/test/cli/wake-all-routing.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Regression tests for `maw wake all` routing.
+ *
+ * Pre-#918 the wake/ plugin routed `maw wake all` to cmdWakeAll. When wake
+ * moved to top-aliases via the direct-handler path (#979949d7 follow-on),
+ * the early-route was lost — "all" started resolving as a literal oracle
+ * name. This surfaced in production as the maw-boot regression on
+ * 2026-05-06 (pulse-oracle inbox: 22:15 BKK ship report).
+ *
+ * Tests verify that invokeDirectHandler with positional "all" routes to
+ * cmdWakeAll (not cmdWake) and forwards the three supported flags.
+ */
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+
+// Capture cmdWakeAll + cmdWake invocations without spawning real tmux sessions.
+const wakeAllCalls: any[] = [];
+const wakeCalls: any[] = [];
+
+mock.module("../../src/commands/shared/fleet-wake", () => ({
+  cmdWakeAll: async (opts: any) => { wakeAllCalls.push(opts); },
+  cmdSleep: async () => {},
+}));
+
+mock.module("../../src/commands/shared/wake-cmd", () => ({
+  cmdWake: async (oracle: string, opts: any) => { wakeCalls.push({ oracle, opts }); return ""; },
+}));
+
+const { invokeDirectHandler } = await import("../../src/cli/top-aliases");
+
+const WAKE_HANDLER = "../commands/shared/wake-cmd:cmdWake";
+
+describe("`maw wake all` routing → cmdWakeAll", () => {
+  beforeEach(() => {
+    wakeAllCalls.length = 0;
+    wakeCalls.length = 0;
+  });
+
+  test("`wake all` routes to cmdWakeAll (not cmdWake)", async () => {
+    await invokeDirectHandler(WAKE_HANDLER, ["all"]);
+    expect(wakeAllCalls).toHaveLength(1);
+    expect(wakeAllCalls[0]).toEqual({ kill: false, all: false, resume: false });
+    expect(wakeCalls).toHaveLength(0);
+  });
+
+  test("`wake all --resume` forwards resume=true", async () => {
+    await invokeDirectHandler(WAKE_HANDLER, ["all", "--resume"]);
+    expect(wakeAllCalls).toHaveLength(1);
+    expect(wakeAllCalls[0]).toEqual({ kill: false, all: false, resume: true });
+    expect(wakeCalls).toHaveLength(0);
+  });
+
+  test("`wake all --kill` forwards kill=true", async () => {
+    await invokeDirectHandler(WAKE_HANDLER, ["all", "--kill"]);
+    expect(wakeAllCalls[0]).toEqual({ kill: true, all: false, resume: false });
+  });
+
+  test("`wake all --all` forwards all=true (include dormant 20+)", async () => {
+    await invokeDirectHandler(WAKE_HANDLER, ["all", "--all"]);
+    expect(wakeAllCalls[0]).toEqual({ kill: false, all: true, resume: false });
+  });
+
+  test("`wake all --kill --resume --all` forwards every flag", async () => {
+    await invokeDirectHandler(WAKE_HANDLER, ["all", "--kill", "--resume", "--all"]);
+    expect(wakeAllCalls[0]).toEqual({ kill: true, all: true, resume: true });
+  });
+
+  test("`wake ALL` (uppercase) still routes to cmdWakeAll", async () => {
+    await invokeDirectHandler(WAKE_HANDLER, ["ALL"]);
+    expect(wakeAllCalls).toHaveLength(1);
+    expect(wakeCalls).toHaveLength(0);
+  });
+
+  test("`wake neo` does NOT route to cmdWakeAll (single-oracle path)", async () => {
+    await invokeDirectHandler(WAKE_HANDLER, ["neo"]);
+    expect(wakeAllCalls).toHaveLength(0);
+    expect(wakeCalls).toHaveLength(1);
+    expect(wakeCalls[0].oracle).toBe("neo");
+  });
+});


### PR DESCRIPTION
## Summary

Rebase of #1189 onto current alpha. The original PR (@natman95) is correct but its CI was failing due to a pre-existing `fleet-adopt.test.ts` test isolation bug that was already fixed on alpha by #1190.

## What this fixes

`maw wake all` was broken after #918 extracted the wake plugin:
- Pre-#918: wake/ plugin routed `oracle === "all"` to `cmdWakeAll`
- #918 moved wake to top-aliases direct-handler dispatch — "all" route was lost
- Result: `maw wake all` treated "all" as a literal oracle name → fuzzy-matched against ghq → not found
- Production impact: pulse-oracle's systemd `ExecStart=maw wake all --resume` silently failed on boot

## Changes (from #1189, unchanged)

- `src/cli/top-aliases.ts` — restore `oracle === "all"` early-route in `invokeDirectHandler`
- `src/cli/top-aliases.ts` — re-parse argv against cmdWakeAll's flag set (`--kill`, `--all`, `--resume`)
- `test/cli/wake-all-routing.test.ts` — 7 tests covering routing decisions

## Credits

Original PR #1189 by @natman95. This branch just rebases onto current alpha to clear the unrelated CI failure.

## Test plan
- [ ] `bun test test/cli/wake-all-routing.test.ts` — 7 tests pass
- [ ] `bash scripts/test-isolated.sh` passes (with #1190 fix on alpha)
- [ ] After merge: pulse-oracle reverts `scripts/maw-boot-wake.sh` shim

Closes #1189 (supersedes via rebase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)