### PR TITLE
fix(wake): plain claude command + claude() wrapper in shellenv

### DIFF
--- a/src/config/command.ts
+++ b/src/config/command.ts
@@ -144,18 +144,10 @@ export function buildCommand(agentName: string, optsOrEngine?: string | BuildCom
     }
   }
 
-  // Fallback for --continue/--resume: retry without it (fresh worktree / expired session).
-  // Keep --session-id (if set) so the first run creates the session with that ID.
-  // Reset terminal after Claude TUI exits — prevents frozen prompt (#1091)
-  const reset = 'printf "\\e[?1049l\\e[0m"; stty sane 2>/dev/null; clear';
-
-  if (cmd.includes("--continue") || cmd.includes("--resume")) {
-    let fallback = cmd.replace(/\s*--continue\b/, "").replace(/\s*--resume\s+"[^"]*"/, "");
-    if (sessionId) fallback += ` --session-id "${sessionId}"`;
-    return `{ ${cmd} || ${fallback}; }; ${reset}`;
-  }
-
-  return `${cmd}; ${reset}`;
+  // Plain command — no fallback wrap. The `claude()` shell wrapper from
+  // `maw shellenv` handles `--continue` fallback transparently. Users without
+  // the wrapper get a single attempt at --continue (sufficient for normal use).
+  return cmd;
 }
 
 const SESSIONS_DIR = join(resolveHome(), "sessions");

--- a/test/build-command-contract.test.ts
+++ b/test/build-command-contract.test.ts
@@ -55,64 +55,44 @@ afterEach(() => {
   (process as any).getuid = origGetuid;
 });
 
-const RESET = `; printf "\\e[?1049l\\e[0m"; stty sane 2>/dev/null; clear`;
-const wrap = (cmd: string) => cmd + RESET;
-const wrapFallback = (primary: string, fallback: string) => `{ ${primary} || ${fallback}; }${RESET}`;
+// Plain command — no fallback wrap, no reset suffix.
+// The `claude()` shell wrapper from `maw shellenv` handles --continue fallback.
+const wrap = (cmd: string) => cmd;
 
 describe("buildCommand — post-#541 contract", () => {
-  test("auto-injects --continue + fallback when default is bare 'claude' (#1174)", () => {
-    // #1174 — `--continue` is the default for ALL claude wakes (engine-aware).
-    // Bare "claude" config now produces the wrapped fallback form so a fresh
-    // wake resumes the prior conversation in that oracle's cwd, falling back
-    // to bare claude when no prior session exists.
+  test("auto-injects --continue when default is bare 'claude' (#1174)", () => {
     fakeConfig.commands = { default: "claude" };
-    expect(buildCommand("any-agent")).toBe(
-      wrapFallback("claude --continue", "claude"),
-    );
+    expect(buildCommand("any-agent")).toBe("claude --continue");
   });
 
-  test("emits || fallback when default has --continue (#1091 reset suffix)", () => {
+  test("preserves --continue when default has it", () => {
     fakeConfig.commands = { default: "claude --continue --dangerously-skip-permissions" };
-    expect(buildCommand("any-agent")).toBe(
-      wrapFallback("claude --continue --dangerously-skip-permissions", "claude --dangerously-skip-permissions"),
-    );
+    expect(buildCommand("any-agent")).toBe("claude --continue --dangerously-skip-permissions");
   });
 
   test("pattern-match wins over default", () => {
     fakeConfig.commands = { default: "claude", "foo-*": "echo hi" };
-    expect(buildCommand("foo-bar")).toBe(wrap("echo hi"));
+    expect(buildCommand("foo-bar")).toBe("echo hi");
   });
 
   test('pattern-match ignores the literal "default" key', () => {
     fakeConfig.commands = { default: "claude --continue --dangerously-skip-permissions" };
-    const out = buildCommand("default");
-    expect(out).toContain("claude --continue --dangerously-skip-permissions");
-    expect(out).toContain("||");
-    expect(out).toContain("claude --dangerously-skip-permissions");
+    expect(buildCommand("default")).toBe("claude --continue --dangerously-skip-permissions");
   });
 
-  test("sessionId replaces --continue with --resume and fallback carries --session-id", () => {
+  test("sessionId replaces --continue with --resume", () => {
     fakeConfig.commands = { default: "claude --continue --dangerously-skip-permissions" };
     fakeSessionIds = { foo: "uuid-1" };
     const out = buildCommand("foo");
-    const inner = out.replace(/^\{ /, "").replace(/; \};.*$/, "");
-    const [primary, fallback] = inner.split(" || ");
-    expect(primary).toContain('--resume "uuid-1"');
-    expect(primary).not.toContain("--continue");
-    expect(fallback).toContain('--session-id "uuid-1"');
-    expect(fallback).not.toContain("--continue");
-    expect(fallback).not.toContain("--resume");
+    expect(out).toContain('--resume "uuid-1"');
+    expect(out).not.toContain("--continue");
   });
 
   test("sessionId appends --resume when cmd has no --continue", () => {
     fakeConfig.commands = { default: "claude" };
     fakeSessionIds = { foo: "uuid-2" };
     const out = buildCommand("foo");
-    const inner = out.replace(/^\{ /, "").replace(/; \};.*$/, "");
-    const [primary, fallback] = inner.split(" || ");
-    expect(primary).toContain('--resume "uuid-2"');
-    expect(fallback).toContain('--session-id "uuid-2"');
-    expect(fallback).not.toContain("--resume");
+    expect(out).toContain('--resume "uuid-2"');
   });
 
   test("buildCommandInDir returns session script path (#1188)", () => {
@@ -152,14 +132,7 @@ describe("buildCommand — post-#541 contract", () => {
   test("#1174: non-channel claude wake auto-injects --continue (positive case)", () => {
     fakeConfig.commands = { default: "claude --dangerously-skip-permissions" };
     const out = buildCommand("any-agent");
-    expect(out).toContain("--continue");
-    expect(out).toContain("||"); // wrapped with fallback
-    expect(out).toBe(
-      wrapFallback(
-        "claude --dangerously-skip-permissions --continue",
-        "claude --dangerously-skip-permissions",
-      ),
-    );
+    expect(out).toBe("claude --dangerously-skip-permissions --continue");
   });
 
   test("#1174: codex (non-claude) engine does NOT get --continue (engine-aware guard)", () => {

--- a/test/build-command-permission-mode.test.ts
+++ b/test/build-command-permission-mode.test.ts
@@ -107,7 +107,7 @@ describe("buildCommand — permissionMode (#1146)", () => {
     expect(relayOut).not.toContain("--dangerously-skip-permissions");
   });
 
-  test('permissionMode "relay" preserves --continue plumbing (|| fallback wrap from #1091)', () => {
+  test('permissionMode "relay" preserves --continue plumbing', () => {
     fakeConfig.commands = { default: "claude" };
     const out = buildCommand("bot", {
       channels: ["plugin:discord@claude-plugins-official"],
@@ -115,6 +115,7 @@ describe("buildCommand — permissionMode (#1146)", () => {
     });
     expect(out).toContain("--continue");
     expect(out).not.toContain("--dangerously-skip-permissions");
-    expect(out).toContain(" || ");
+    // Fallback is now in the `claude()` shell wrapper (maw shellenv),
+    // not inline `|| fallback`. See PR #1229.
   });
 });


### PR DESCRIPTION
## Summary

Pane now shows the actual claude command, not a `{ X || Y; }; reset` chain:

**Before:**
```
{ claude --dangerously-skip-permissions --continue || claude --dangerously-skip-permissions; }; printf "\e[?1049l\e[0m"; stty sane 2>/dev/null; clear
```

**After:**
```
claude --dangerously-skip-permissions --continue
```

Fallback is handled by a `claude()` shell wrapper in `maw shellenv` output. Users `eval "$(maw shellenv zsh)"` once and `--continue` auto-retries without it on failure.

## Changes

### maw-js (this PR)
- `src/config/command.ts` — `buildCommand` returns plain command, no `{ X || Y; }` wrap
- `test/build-command-contract.test.ts` — updated expectations, 32/32 pass

### shellenv plugin (separate publish)
- `~/.maw/plugins/shellenv/src/snippets/zsh.ts` — adds `claude()` wrapper
- `~/.maw/plugins/shellenv/src/snippets/bash.ts` — adds `claude()` wrapper

## How users get the wrapper

```bash
eval "$(maw shellenv zsh)"   # add to ~/.zshrc
```

Without the wrapper: single `--continue` attempt (works for the common case).

## Test plan
- [ ] `bun test test/build-command-contract.test.ts` — 32 pass
- [ ] `maw wake <oracle>` — pane shows clean command, claude starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)