### PR TITLE
feat(federation): maw federation agents — list agents across all nodes (#1232)

### DIFF
--- a/src/commands/plugins/federation/federation.test.ts
+++ b/src/commands/plugins/federation/federation.test.ts
@@ -13,7 +13,9 @@ describe("federation plugin — smoke", () => {
     const result = await handler(ctx);
     expect(result.ok).toBe(false);
     expect(result.error ?? "").toContain("usage");
-    expect(result.error ?? "").toContain("status|sync");
+    expect(result.error ?? "").toContain("status");
+    expect(result.error ?? "").toContain("sync");
+    expect(result.error ?? "").toContain("agents");
   });
 
   it("CLI — --help treated as unknown sub, returns usage", async () => {

--- a/src/commands/plugins/federation/index.ts
+++ b/src/commands/plugins/federation/index.ts
@@ -42,10 +42,21 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         force: args.includes("--force"),
         json: args.includes("--json"),
       });
+    } else if (sub === "agents") {
+      const { cmdFederationAgents } = await import("../../shared/federation-agents");
+      const nodeFlag = args.find(a => a.startsWith("--node="))?.split("=")[1]
+        ?? (args.includes("--node") ? args[args.indexOf("--node") + 1] : undefined);
+      const oracleFlag = args.find(a => a.startsWith("--oracle="))?.split("=")[1]
+        ?? (args.includes("--oracle") ? args[args.indexOf("--oracle") + 1] : undefined);
+      await cmdFederationAgents({
+        json: args.includes("--json"),
+        node: nodeFlag,
+        oracle: oracleFlag,
+      });
     } else {
       return {
         ok: false,
-        error: "usage: maw federation <status|sync> [--verify|--dry-run|--check|--prune|--force|--json]",
+        error: "usage: maw federation <status|agents|sync> [--verify|--json|--node <name>|--oracle <glob>|--dry-run|--check|--prune|--force]",
       };
     }
 

--- a/src/commands/shared/federation-agents.ts
+++ b/src/commands/shared/federation-agents.ts
@@ -1,0 +1,173 @@
+import { getPeers, curlFetch } from "../../sdk";
+import { tmux } from "../../sdk";
+import { loadConfig } from "../../config";
+import { buildAgentRows, type AgentRow } from "./agents";
+
+export interface FederationAgent {
+  node: string;
+  oracle: string;
+  session: string;
+  window: string;
+  state: string;
+  pid?: number;
+}
+
+export interface SkippedNode {
+  label: string;
+  url: string;
+  error: string;
+}
+
+type FetchFn = (url: string, opts?: { timeout?: number }) => Promise<{ ok: boolean; status: number; data: unknown }>;
+
+export interface FederationAgentDeps {
+  fetch: FetchFn;
+  getLocalAgents: (nodeName: string) => Promise<FederationAgent[]>;
+  peers: () => string[];
+  namedPeers: () => { name: string; url: string }[];
+  nodeName: () => string;
+}
+
+function labelForPeer(url: string, named: { name: string; url: string }[]): string {
+  const match = named.find(p => p.url === url);
+  if (match) return match.name;
+  try {
+    const u = new URL(url);
+    return u.hostname === "localhost" || u.hostname === "127.0.0.1"
+      ? `localhost:${u.port}` : u.host;
+  } catch { return url; }
+}
+
+async function defaultGetLocalAgents(nodeName: string): Promise<FederationAgent[]> {
+  const [sessions, panes] = await Promise.all([tmux.listAll(), tmux.listPanes()]);
+  const windowNames = new Map<string, string>();
+  for (const s of sessions) {
+    for (const w of s.windows) {
+      windowNames.set(`${s.name}:${w.index}`, w.name);
+    }
+  }
+  const rows: AgentRow[] = buildAgentRows(panes, windowNames, nodeName);
+  return rows.map(r => ({
+    node: r.node,
+    oracle: r.oracle,
+    session: r.session,
+    window: r.window,
+    state: r.state,
+    pid: r.pid ?? undefined,
+  }));
+}
+
+function matchGlob(pattern: string, str: string): boolean {
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
+  return new RegExp("^" + escaped + "$").test(str);
+}
+
+function pad(s: string, n: number): string {
+  return s.padEnd(n);
+}
+
+export async function cmdFederationAgents(
+  opts: { json?: boolean; node?: string; oracle?: string },
+  _deps?: Partial<FederationAgentDeps>,
+): Promise<void> {
+  const config = loadConfig();
+  const rawNodeName = config.node || "local";
+  const named = config.namedPeers ?? [];
+
+  const deps: FederationAgentDeps = {
+    fetch: curlFetch as FetchFn,
+    getLocalAgents: defaultGetLocalAgents,
+    peers: getPeers,
+    namedPeers: () => named,
+    nodeName: () => rawNodeName,
+    ..._deps,
+  };
+
+  const nodeName = deps.nodeName();
+  const agents: FederationAgent[] = [];
+  const skipped: SkippedNode[] = [];
+
+  // Local agents
+  try {
+    const local = await deps.getLocalAgents(nodeName);
+    agents.push(...local);
+  } catch {
+    // non-fatal
+  }
+
+  // Peer agents — parallel, isolated failures
+  const peers = deps.peers();
+  if (peers.length > 0) {
+    const results = await Promise.allSettled(
+      peers.map(url =>
+        deps.fetch(`${url}/api/agents`, { timeout: 3000 }).then(res => {
+          if (!res.ok) throw new Error(`HTTP ${res.status || "error"}`);
+          return { url, data: res.data };
+        })
+      )
+    );
+
+    for (let i = 0; i < results.length; i++) {
+      const r = results[i];
+      const url = peers[i];
+      if (r.status === "fulfilled") {
+        const raw = r.value.data as { agents?: FederationAgent[] } | null;
+        if (Array.isArray(raw?.agents)) {
+          agents.push(...raw.agents);
+        }
+      } else {
+        const label = labelForPeer(url, deps.namedPeers());
+        const error = r.reason instanceof Error ? r.reason.message : String(r.reason);
+        skipped.push({ label, url, error });
+      }
+    }
+  }
+
+  // Apply filters
+  let filtered = agents;
+  if (opts.node) {
+    filtered = filtered.filter(a => a.node === opts.node);
+  }
+  if (opts.oracle) {
+    const pattern = opts.oracle;
+    filtered = filtered.filter(a => matchGlob(pattern, a.oracle));
+  }
+
+  if (opts.json) {
+    console.log(JSON.stringify({ agents: filtered, skipped }, null, 2));
+    return;
+  }
+
+  // Render table
+  const COL = { node: 16, oracle: 18, session: 24, state: 8 };
+  const header =
+    pad("node", COL.node) +
+    pad("oracle", COL.oracle) +
+    pad("session", COL.session) +
+    "state";
+  console.log(header);
+  console.log("─".repeat(header.length));
+
+  if (filtered.length === 0) {
+    console.log("\x1b[90mno agents found\x1b[0m");
+  } else {
+    for (const a of filtered) {
+      const nodeLabel = a.node === nodeName ? `${a.node} (local)` : a.node;
+      const dot = a.state === "active" ? "\x1b[32m●\x1b[0m" : "\x1b[90m●\x1b[0m";
+      const stateColor = a.state === "active" ? "\x1b[32m" : "\x1b[90m";
+      console.log(
+        pad(nodeLabel, COL.node) +
+        pad(a.oracle, COL.oracle) +
+        pad(a.session, COL.session) +
+        `${dot} ${stateColor}${a.state}\x1b[0m`
+      );
+    }
+  }
+
+  if (skipped.length > 0) {
+    console.log("");
+    for (const s of skipped) {
+      console.log(`\x1b[33m! ${s.label}\x1b[0m  unreachable (${s.error})`);
+    }
+  }
+}

--- a/test/federation-agents.test.ts
+++ b/test/federation-agents.test.ts
@@ -1,0 +1,219 @@
+/**
+ * federation-agents — cmdFederationAgents DI-testable unit tests.
+ *
+ * Uses FederationAgentDeps injection so no mock.module calls are needed.
+ * Pattern mirrors federation-symmetric.test.ts to avoid cross-file wrapper layering.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { cmdFederationAgents, type FederationAgent, type FederationAgentDeps } from "../src/commands/shared/federation-agents";
+
+type FetchFn = FederationAgentDeps["fetch"];
+
+function makeFetch(responses: Record<string, { ok: boolean; status: number; data: unknown }>): FetchFn {
+  return async (url) => responses[url] ?? { ok: false, status: 0, data: null };
+}
+
+function makeLocalAgents(node: string, agents: Omit<FederationAgent, "node">[]): FederationAgentDeps["getLocalAgents"] {
+  return async () => agents.map(a => ({ ...a, node }));
+}
+
+const localAgent: Omit<FederationAgent, "node"> = {
+  oracle: "volt",
+  session: "36-volt",
+  window: "volt-oracle",
+  state: "active",
+};
+
+// Capture console output
+let output: string[] = [];
+const origLog = console.log;
+
+beforeEach(() => {
+  output = [];
+  console.log = (...args: unknown[]) => output.push(args.map(String).join(" "));
+});
+
+afterEach(() => {
+  console.log = origLog;
+});
+
+describe("cmdFederationAgents", () => {
+  test("happy path: local + 2 peers, merged table", async () => {
+    const peers = ["http://white:3456", "http://mba:3456"];
+    await cmdFederationAgents({ json: false }, {
+      getLocalAgents: makeLocalAgents("m5", [localAgent]),
+      peers: () => peers,
+      namedPeers: () => [
+        { name: "white", url: "http://white:3456" },
+        { name: "mba", url: "http://mba:3456" },
+      ],
+      nodeName: () => "m5",
+      fetch: makeFetch({
+        "http://white:3456/api/agents": {
+          ok: true, status: 200,
+          data: { agents: [{ node: "white", oracle: "mother", session: "14-mother", window: "mother-oracle", state: "idle" }] },
+        },
+        "http://mba:3456/api/agents": {
+          ok: true, status: 200,
+          data: { agents: [{ node: "mba", oracle: "pigment", session: "04-pigment", window: "pigment-oracle", state: "idle" }] },
+        },
+      }),
+    });
+
+    const all = output.join("\n");
+    expect(all).toContain("volt");
+    expect(all).toContain("mother");
+    expect(all).toContain("pigment");
+    expect(all).toContain("m5 (local)");
+    expect(all).toContain("white");
+    expect(all).toContain("mba");
+    // no skipped warning
+    expect(all).not.toContain("unreachable");
+  });
+
+  test("single peer timeout: warning shown, table still renders", async () => {
+    const peers = ["http://white:3456", "http://clinic-nat:3456"];
+    await cmdFederationAgents({ json: false }, {
+      getLocalAgents: makeLocalAgents("m5", [localAgent]),
+      peers: () => peers,
+      namedPeers: () => [
+        { name: "white", url: "http://white:3456" },
+        { name: "clinic-nat", url: "http://clinic-nat:3456" },
+      ],
+      nodeName: () => "m5",
+      fetch: async (url) => {
+        if (url.startsWith("http://clinic-nat")) throw new Error("timeout");
+        return { ok: true, status: 200, data: { agents: [{ node: "white", oracle: "neo", session: "02-neo", window: "neo-oracle", state: "active" }] } };
+      },
+    });
+
+    const all = output.join("\n");
+    expect(all).toContain("volt");
+    expect(all).toContain("neo");
+    expect(all).toContain("clinic-nat");
+    expect(all).toContain("unreachable");
+    expect(all).toContain("timeout");
+  });
+
+  test("--node white filter: only white agents shown", async () => {
+    const peers = ["http://white:3456"];
+    await cmdFederationAgents({ node: "white" }, {
+      getLocalAgents: makeLocalAgents("m5", [localAgent]),
+      peers: () => peers,
+      namedPeers: () => [{ name: "white", url: "http://white:3456" }],
+      nodeName: () => "m5",
+      fetch: makeFetch({
+        "http://white:3456/api/agents": {
+          ok: true, status: 200,
+          data: { agents: [{ node: "white", oracle: "mother", session: "14-mother", window: "mother-oracle", state: "idle" }] },
+        },
+      }),
+    });
+
+    const all = output.join("\n");
+    expect(all).toContain("mother");
+    expect(all).not.toContain("volt"); // local agent filtered out (node = "m5")
+    expect(all).not.toContain("m5 (local)");
+  });
+
+  test("--oracle '*volt*' glob filter", async () => {
+    const peers = ["http://white:3456"];
+    await cmdFederationAgents({ oracle: "*volt*" }, {
+      getLocalAgents: makeLocalAgents("m5", [
+        localAgent,
+        { oracle: "volt-oracle", session: "37-volt-oracle", window: "volt-oracle-oracle", state: "idle" },
+        { oracle: "pigment", session: "04-pigment", window: "pigment-oracle", state: "active" },
+      ]),
+      peers: () => peers,
+      namedPeers: () => [],
+      nodeName: () => "m5",
+      fetch: makeFetch({
+        "http://white:3456/api/agents": {
+          ok: true, status: 200,
+          data: { agents: [{ node: "white", oracle: "volt-prod", session: "99-volt", window: "volt-prod-oracle", state: "active" }] },
+        },
+      }),
+    });
+
+    const all = output.join("\n");
+    expect(all).toContain("volt");
+    expect(all).toContain("volt-oracle");
+    expect(all).toContain("volt-prod");
+    expect(all).not.toContain("pigment");
+  });
+
+  test("--json shape contract", async () => {
+    const peers = ["http://white:3456"];
+    await cmdFederationAgents({ json: true }, {
+      getLocalAgents: makeLocalAgents("m5", [localAgent]),
+      peers: () => peers,
+      namedPeers: () => [{ name: "white", url: "http://white:3456" }],
+      nodeName: () => "m5",
+      fetch: makeFetch({
+        "http://white:3456/api/agents": {
+          ok: true, status: 200,
+          data: { agents: [{ node: "white", oracle: "mother", session: "14-mother", window: "mother-oracle", state: "idle" }] },
+        },
+      }),
+    });
+
+    const raw = output.join("\n");
+    const parsed = JSON.parse(raw);
+    expect(parsed).toHaveProperty("agents");
+    expect(parsed).toHaveProperty("skipped");
+    expect(Array.isArray(parsed.agents)).toBe(true);
+    expect(Array.isArray(parsed.skipped)).toBe(true);
+    expect(parsed.agents.length).toBe(2);
+    expect(parsed.skipped.length).toBe(0);
+
+    const volt = parsed.agents.find((a: FederationAgent) => a.oracle === "volt");
+    expect(volt).toBeDefined();
+    expect(volt.node).toBe("m5");
+    expect(volt.session).toBe("36-volt");
+    expect(volt.state).toBe("active");
+  });
+
+  test("empty fleet: no agents anywhere", async () => {
+    await cmdFederationAgents({ json: false }, {
+      getLocalAgents: makeLocalAgents("m5", []),
+      peers: () => [],
+      namedPeers: () => [],
+      nodeName: () => "m5",
+      fetch: makeFetch({}),
+    });
+
+    const all = output.join("\n");
+    expect(all).toContain("no agents found");
+  });
+
+  test("all peers fail: skipped list shows all, no crash", async () => {
+    const peers = ["http://alpha:3456", "http://bravo:3456"];
+    await cmdFederationAgents({ json: false }, {
+      getLocalAgents: makeLocalAgents("m5", [localAgent]),
+      peers: () => peers,
+      namedPeers: () => [],
+      nodeName: () => "m5",
+      fetch: async () => { throw new Error("connection refused"); },
+    });
+
+    const all = output.join("\n");
+    expect(all).toContain("volt"); // local still renders
+    expect(output.filter(l => l.includes("unreachable")).length).toBe(2);
+  });
+
+  test("peer returns non-ok status: recorded as skipped", async () => {
+    const peers = ["http://white:3456"];
+    await cmdFederationAgents({ json: false }, {
+      getLocalAgents: makeLocalAgents("m5", [localAgent]),
+      peers: () => peers,
+      namedPeers: () => [{ name: "white", url: "http://white:3456" }],
+      nodeName: () => "m5",
+      fetch: makeFetch({ "http://white:3456/api/agents": { ok: false, status: 503, data: null } }),
+    });
+
+    const all = output.join("\n");
+    expect(all).toContain("white");
+    expect(all).toContain("unreachable");
+    expect(all).toContain("HTTP 503");
+  });
+});


### PR DESCRIPTION
## Summary

`maw federation agents` lists every agent across the federation. Closes the gap between `maw federation status` (counts) and `maw ls` (local only).

```bash
maw federation agents                    # full table
maw federation agents --node white       # filter
maw federation agents --oracle '*volt*'  # glob
maw federation agents --json             # machine-readable
```

### Output
```
node            oracle      session     state
─────────────────────────────────────────────
m5 (local)      volt        36-volt     ● active
white           volt        05-volt     ● active

! oracle-world  unreachable (timeout)
```

## Implementation

- **New**: `src/commands/shared/federation-agents.ts` (~180 LOC)
  - `Promise.allSettled` for peer fetches (3s timeout per peer)
  - DI-testable via optional `_deps` parameter (no mock.module)
  - Mirrors `/api/agents` payload shape exactly
- **Edited**: `src/commands/plugins/federation/index.ts` — added `agents` subcommand dispatcher with `--json`, `--node`, `--oracle` flags
- **Tests**: `test/federation-agents.test.ts` — 8 tests, all pass (39ms)

## Test plan
- [x] `bun test test/federation-agents.test.ts` — 8/8 pass
- [x] `bun build` — clean (654 modules, 24ms)
- [x] Live test: `maw federation agents --oracle volt` finds volt on both m5 and white
- [x] Unreachable peers degrade gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)