### PR TITLE
feat(federation): locate searches federation + clearer error msgs (#1234, #1235)

### DIFF
--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -11,7 +11,7 @@ import { formatError } from "../lib/format-error";
 const CORE_ROUTES = [
   "hey",
   "plugins", "plugin", "artifacts", "artifact",
-  "agents", "agent", "audit", "serve",
+  "agents", "agent", "locate", "audit", "serve",
   "update", "upgrade", "version",
 ];
 

--- a/src/cli/route-tools.ts
+++ b/src/cli/route-tools.ts
@@ -8,6 +8,7 @@ const CORE_HELP: Record<string, string> = {
   artifact: "usage: maw artifact [ls|get] [team] [task-id] [--json]",
   agents: "usage: maw agents [--json] [--all] [--node <node>]",
   agent: "usage: maw agent [--json] [--all] [--node <node>]",
+  locate: "usage: maw locate <oracle> [--json]",
   audit: "usage: maw audit [limit]",
   serve: "usage: maw serve [port] [--as <name>]",
 };
@@ -101,6 +102,18 @@ export async function routeTools(cmd: string, args: string[]): Promise<boolean> 
     const { parseFlags } = await import("./parse-args");
     const flags = parseFlags(args, { "--json": Boolean, "--all": Boolean, "--node": String }, 1);
     await cmdAgents({ json: flags["--json"], all: flags["--all"], node: flags["--node"] });
+    return true;
+  }
+  if (cmd === "locate") {
+    const { cmdLocate } = await import("../commands/shared/locate");
+    const { parseFlags } = await import("./parse-args");
+    const flags = parseFlags(args, { "--json": Boolean }, 1);
+    const query = flags._[0];
+    if (!query) {
+      console.error("usage: maw locate <oracle> [--json]");
+      process.exit(1);
+    }
+    await cmdLocate(query, { json: flags["--json"] });
     return true;
   }
   if (cmd === "audit") {

--- a/src/commands/shared/federation-agents.ts
+++ b/src/commands/shared/federation-agents.ts
@@ -28,7 +28,7 @@ export interface FederationAgentDeps {
   nodeName: () => string;
 }
 
-function labelForPeer(url: string, named: { name: string; url: string }[]): string {
+export function labelForPeer(url: string, named: { name: string; url: string }[]): string {
   const match = named.find(p => p.url === url);
   if (match) return match.name;
   try {
@@ -38,7 +38,7 @@ function labelForPeer(url: string, named: { name: string; url: string }[]): stri
   } catch { return url; }
 }
 
-async function defaultGetLocalAgents(nodeName: string): Promise<FederationAgent[]> {
+export async function defaultGetLocalAgents(nodeName: string): Promise<FederationAgent[]> {
   const [sessions, panes] = await Promise.all([tmux.listAll(), tmux.listPanes()]);
   const windowNames = new Map<string, string>();
   for (const s of sessions) {
@@ -64,6 +64,23 @@ function matchGlob(pattern: string, str: string): boolean {
 
 function pad(s: string, n: number): string {
   return s.padEnd(n);
+}
+
+const CURL_CODES: Record<number, string> = {
+  6: "DNS resolution failed",
+  7: "connection refused",
+  22: "HTTP 4xx/5xx",
+  28: "connection timeout",
+  35: "SSL/TLS error",
+};
+
+export function describeFetchError(res: { status: number; data: unknown }): string {
+  const errMsg = (res.data as { error?: string } | null)?.error;
+  if (errMsg) return errMsg;
+  const s = res.status;
+  if (s >= 100 && s <= 599) return `HTTP ${s}`;
+  if (s === 0) return "unreachable";
+  return CURL_CODES[s] ? `curl exit ${s} (${CURL_CODES[s]})` : `curl exit ${s}`;
 }
 
 export async function cmdFederationAgents(
@@ -101,7 +118,7 @@ export async function cmdFederationAgents(
     const results = await Promise.allSettled(
       peers.map(url =>
         deps.fetch(`${url}/api/agents`, { timeout: 3000 }).then(res => {
-          if (!res.ok) throw new Error(`HTTP ${res.status || "error"}`);
+          if (!res.ok) throw new Error(describeFetchError(res));
           return { url, data: res.data };
         })
       )
@@ -167,7 +184,7 @@ export async function cmdFederationAgents(
   if (skipped.length > 0) {
     console.log("");
     for (const s of skipped) {
-      console.log(`\x1b[33m! ${s.label}\x1b[0m  unreachable (${s.error})`);
+      console.log(`\x1b[33m! ${s.label}\x1b[0m  ${s.error}`);
     }
   }
 }

--- a/src/commands/shared/locate.ts
+++ b/src/commands/shared/locate.ts
@@ -1,0 +1,123 @@
+import { loadConfig } from "../../config";
+import { getPeers, curlFetch } from "../../sdk";
+import {
+  type FederationAgent,
+  type FederationAgentDeps,
+  type SkippedNode,
+  defaultGetLocalAgents,
+  describeFetchError,
+  labelForPeer,
+} from "./federation-agents";
+
+export interface LocateDeps extends FederationAgentDeps {
+  configAgentsMap: () => Record<string, string> | undefined;
+}
+
+export async function cmdLocate(
+  query: string,
+  opts: { json?: boolean },
+  _deps?: Partial<LocateDeps>,
+): Promise<void> {
+  const config = loadConfig();
+  const rawNodeName = config.node || "local";
+  const named = config.namedPeers ?? [];
+
+  const deps: LocateDeps = {
+    fetch: curlFetch as FederationAgentDeps["fetch"],
+    getLocalAgents: defaultGetLocalAgents,
+    peers: getPeers,
+    namedPeers: () => named,
+    nodeName: () => rawNodeName,
+    configAgentsMap: () => config.agents,
+    ..._deps,
+  };
+
+  const nodeName = deps.nodeName();
+  const agents: FederationAgent[] = [];
+  const skipped: SkippedNode[] = [];
+
+  try {
+    const local = await deps.getLocalAgents(nodeName);
+    agents.push(...local);
+  } catch {
+    // non-fatal
+  }
+
+  const peers = deps.peers();
+  if (peers.length > 0) {
+    const results = await Promise.allSettled(
+      peers.map(url =>
+        deps.fetch(`${url}/api/agents`, { timeout: 3000 }).then(res => {
+          if (!res.ok) throw new Error(describeFetchError(res));
+          return { url, data: res.data };
+        })
+      )
+    );
+
+    for (let i = 0; i < results.length; i++) {
+      const r = results[i];
+      const url = peers[i];
+      if (r.status === "fulfilled") {
+        const raw = r.value.data as { agents?: FederationAgent[] } | null;
+        if (Array.isArray(raw?.agents)) {
+          agents.push(...raw.agents);
+        }
+      } else {
+        const label = labelForPeer(url, deps.namedPeers());
+        const error = r.reason instanceof Error ? r.reason.message : String(r.reason);
+        skipped.push({ label, url, error });
+      }
+    }
+  }
+
+  const q = query.toLowerCase();
+  const matching = agents.filter(a => a.oracle.toLowerCase() === q);
+  const configNode = deps.configAgentsMap()?.[query];
+
+  if (opts.json) {
+    console.log(JSON.stringify({
+      query,
+      config: configNode ? { node: configNode } : null,
+      federation: matching,
+      skipped,
+    }, null, 2));
+    return;
+  }
+
+  console.log(`\n📍 ${query}`);
+
+  if (configNode) {
+    console.log(`   node:     ${configNode} (from config.agents)`);
+  } else {
+    console.log(`   node:     (not in config.agents)`);
+  }
+
+  if (matching.length > 0) {
+    console.log(`\n   Running on federation:`);
+    const byNode = new Map<string, FederationAgent[]>();
+    for (const a of matching) {
+      const list = byNode.get(a.node) ?? [];
+      list.push(a);
+      byNode.set(a.node, list);
+    }
+    const nodeWidth = Math.max(...[...byNode.keys()].map(n => n.length), 4) + 2;
+    for (const [node, nodeAgents] of byNode) {
+      for (const a of nodeAgents) {
+        const dot = a.state === "active" ? "\x1b[32m●\x1b[0m" : "\x1b[90m●\x1b[0m";
+        const stateColor = a.state === "active" ? "\x1b[32m" : "\x1b[90m";
+        console.log(`     ${node.padEnd(nodeWidth)}${a.session} ${dot} ${stateColor}${a.state}\x1b[0m`);
+      }
+    }
+  } else {
+    console.log(`\n   \x1b[90mnot running anywhere in federation\x1b[0m`);
+  }
+
+  if (skipped.length > 0) {
+    console.log("");
+    for (const s of skipped) {
+      console.log(`   \x1b[33m! ${s.label}\x1b[0m  ${s.error}`);
+    }
+  }
+
+  console.log();
+}

--- a/test/federation-agents.test.ts
+++ b/test/federation-agents.test.ts
@@ -91,7 +91,6 @@ describe("cmdFederationAgents", () => {
     expect(all).toContain("volt");
     expect(all).toContain("neo");
     expect(all).toContain("clinic-nat");
-    expect(all).toContain("unreachable");
     expect(all).toContain("timeout");
   });
 
@@ -198,7 +197,7 @@ describe("cmdFederationAgents", () => {
 
     const all = output.join("\n");
     expect(all).toContain("volt"); // local still renders
-    expect(output.filter(l => l.includes("unreachable")).length).toBe(2);
+    expect(output.filter(l => l.includes("connection refused")).length).toBe(2);
   });
 
   test("peer returns non-ok status: recorded as skipped", async () => {
@@ -213,7 +212,6 @@ describe("cmdFederationAgents", () => {
 
     const all = output.join("\n");
     expect(all).toContain("white");
-    expect(all).toContain("unreachable");
     expect(all).toContain("HTTP 503");
   });
 });

--- a/test/locate.test.ts
+++ b/test/locate.test.ts
@@ -1,0 +1,197 @@
+/**
+ * locate — cmdLocate DI-testable unit tests.
+ *
+ * Uses LocateDeps injection — no mock.module calls needed.
+ * Pattern mirrors federation-agents.test.ts.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { cmdLocate, type LocateDeps } from "../src/commands/shared/locate";
+import type { FederationAgent } from "../src/commands/shared/federation-agents";
+
+type FetchFn = LocateDeps["fetch"];
+
+function makeFetch(responses: Record<string, { ok: boolean; status: number; data: unknown }>): FetchFn {
+  return async (url) => responses[url] ?? { ok: false, status: 0, data: null };
+}
+
+function makeLocalAgents(node: string, agents: Omit<FederationAgent, "node">[]): LocateDeps["getLocalAgents"] {
+  return async () => agents.map(a => ({ ...a, node }));
+}
+
+const voltAgent: Omit<FederationAgent, "node"> = {
+  oracle: "volt",
+  session: "36-volt",
+  window: "volt-oracle",
+  state: "active",
+};
+
+let output: string[] = [];
+const origLog = console.log;
+
+beforeEach(() => {
+  output = [];
+  console.log = (...args: unknown[]) => output.push(args.map(String).join(" "));
+});
+
+afterEach(() => {
+  console.log = origLog;
+});
+
+function baseDeps(overrides: Partial<LocateDeps> = {}): Partial<LocateDeps> {
+  return {
+    getLocalAgents: makeLocalAgents("m5", [voltAgent]),
+    peers: () => [],
+    namedPeers: () => [],
+    nodeName: () => "m5",
+    fetch: makeFetch({}),
+    configAgentsMap: () => ({ volt: "m5" }),
+    ...overrides,
+  };
+}
+
+describe("cmdLocate", () => {
+  test("shows local agent + config node", async () => {
+    await cmdLocate("volt", {}, baseDeps());
+
+    const all = output.join("\n");
+    expect(all).toContain("📍 volt");
+    expect(all).toContain("m5 (from config.agents)");
+    expect(all).toContain("36-volt");
+    expect(all).toContain("active");
+  });
+
+  test("shows federation results from peer", async () => {
+    await cmdLocate("volt", {}, baseDeps({
+      getLocalAgents: makeLocalAgents("m5", []),
+      peers: () => ["http://white:3456"],
+      namedPeers: () => [{ name: "white", url: "http://white:3456" }],
+      fetch: makeFetch({
+        "http://white:3456/api/agents": {
+          ok: true, status: 200,
+          data: { agents: [{ node: "white", oracle: "volt", session: "05-volt", window: "volt-oracle", state: "active" }] },
+        },
+      }),
+    }));
+
+    const all = output.join("\n");
+    expect(all).toContain("📍 volt");
+    expect(all).toContain("white");
+    expect(all).toContain("05-volt");
+  });
+
+  test("local + peer both running: both shown", async () => {
+    await cmdLocate("volt", {}, baseDeps({
+      peers: () => ["http://white:3456"],
+      namedPeers: () => [{ name: "white", url: "http://white:3456" }],
+      fetch: makeFetch({
+        "http://white:3456/api/agents": {
+          ok: true, status: 200,
+          data: { agents: [{ node: "white", oracle: "volt", session: "05-volt", window: "volt-oracle", state: "active" }] },
+        },
+      }),
+    }));
+
+    const all = output.join("\n");
+    expect(all).toContain("36-volt");
+    expect(all).toContain("05-volt");
+    expect(all).toContain("m5");
+    expect(all).toContain("white");
+  });
+
+  test("oracle not in config.agents: shows fallback text", async () => {
+    await cmdLocate("unknown-oracle", {}, baseDeps({
+      getLocalAgents: makeLocalAgents("m5", []),
+      configAgentsMap: () => ({}),
+    }));
+
+    const all = output.join("\n");
+    expect(all).toContain("📍 unknown-oracle");
+    expect(all).toContain("not in config.agents");
+    expect(all).toContain("not running anywhere");
+  });
+
+  test("oracle not running anywhere: shows not running message", async () => {
+    await cmdLocate("volt", {}, baseDeps({
+      getLocalAgents: makeLocalAgents("m5", [
+        { oracle: "other", session: "01-other", window: "other-oracle", state: "active" },
+      ]),
+    }));
+
+    const all = output.join("\n");
+    expect(all).toContain("not running anywhere in federation");
+  });
+
+  test("peer unreachable: warning shown, local still renders", async () => {
+    await cmdLocate("volt", {}, baseDeps({
+      peers: () => ["http://clinic-nat:3456"],
+      namedPeers: () => [{ name: "clinic-nat", url: "http://clinic-nat:3456" }],
+      fetch: async () => { throw new Error("timeout"); },
+    }));
+
+    const all = output.join("\n");
+    expect(all).toContain("36-volt");
+    expect(all).toContain("clinic-nat");
+    expect(all).toContain("timeout");
+  });
+
+  test("--json shape contract", async () => {
+    await cmdLocate("volt", { json: true }, baseDeps({
+      peers: () => ["http://white:3456"],
+      namedPeers: () => [{ name: "white", url: "http://white:3456" }],
+      fetch: makeFetch({
+        "http://white:3456/api/agents": {
+          ok: true, status: 200,
+          data: { agents: [{ node: "white", oracle: "volt", session: "05-volt", window: "volt-oracle", state: "idle" }] },
+        },
+      }),
+    }));
+
+    const raw = output.join("\n");
+    const parsed = JSON.parse(raw);
+    expect(parsed.query).toBe("volt");
+    expect(parsed.config).toEqual({ node: "m5" });
+    expect(Array.isArray(parsed.federation)).toBe(true);
+    expect(Array.isArray(parsed.skipped)).toBe(true);
+    expect(parsed.federation.length).toBe(2);
+
+    const local = parsed.federation.find((a: FederationAgent) => a.node === "m5");
+    expect(local?.session).toBe("36-volt");
+
+    const remote = parsed.federation.find((a: FederationAgent) => a.node === "white");
+    expect(remote?.session).toBe("05-volt");
+  });
+
+  test("--json with missing config entry: config is null", async () => {
+    await cmdLocate("ghost", { json: true }, baseDeps({
+      getLocalAgents: makeLocalAgents("m5", []),
+      configAgentsMap: () => ({}),
+    }));
+
+    const parsed = JSON.parse(output.join("\n"));
+    expect(parsed.query).toBe("ghost");
+    expect(parsed.config).toBeNull();
+    expect(parsed.federation).toEqual([]);
+    expect(parsed.skipped).toEqual([]);
+  });
+
+  test("query is case-insensitive: 'Volt' matches 'volt' agents", async () => {
+    await cmdLocate("Volt", {}, baseDeps());
+
+    const all = output.join("\n");
+    expect(all).toContain("📍 Volt");
+    expect(all).toContain("36-volt");
+  });
+
+  test("non-matching agents not shown", async () => {
+    await cmdLocate("volt", {}, baseDeps({
+      getLocalAgents: makeLocalAgents("m5", [
+        voltAgent,
+        { oracle: "matrix", session: "10-matrix", window: "matrix-oracle", state: "active" },
+      ]),
+    }));
+
+    const all = output.join("\n");
+    expect(all).toContain("36-volt");
+    expect(all).not.toContain("matrix");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1234 + #1235.

### #1234 — Semantic curl/HTTP error messages
Before: `! oracle-world  unreachable (HTTP 22)`
After: `! oracle-world  curl exit 22 (HTTP 4xx/5xx)`

Maps common curl exit codes to descriptions (DNS, timeout, refused, SSL). Real HTTP statuses kept as `HTTP NN`. Prefers `res.data.error` when available.

### #1235 — `maw locate <oracle>` queries federation
Before: only shows local `config.agents` mapping.
After: shows where the oracle is actually RUNNING across the federation.

```
📍 volt
   node:     m5 (from config.agents)

   Running on federation:
     m5     36-volt ● active
     white  05-volt ● active
```

Reuses `cmdFederationAgents` peer-fetch pattern. `--json` for scripts. Graceful peer-failure isolation.

## Test plan
- [x] 18 tests pass (10 new locate + 8 federation-agents)
- [x] Live: `maw locate volt` finds both m5 and white instances
- [x] Live: error messages now semantic, not bare `HTTP 22`

🤖 Generated with [Claude Code](https://claude.com/claude-code)