### PR TITLE
feat: enforce lowercase oracle names + doctor casing-duplicates check (#1240)

### DIFF
--- a/src/commands/plugins/fleet/fleet-adopt.ts
+++ b/src/commands/plugins/fleet/fleet-adopt.ts
@@ -144,7 +144,7 @@ export async function adoptByPath(
     throw new Error(`adoptByPath: CLAUDE.md not found at ${repoPath}`);
   }
 
-  const stem = nameOverride ?? extractOracleStem(claudeMd);
+  const stem = (nameOverride?.toLowerCase()) ?? extractOracleStem(claudeMd);
   if (!stem) {
     throw new Error(`adoptByPath: could not extract oracle stem from ${claudeMd}`);
   }

--- a/src/commands/plugins/fleet/fleet-init-agents.ts
+++ b/src/commands/plugins/fleet/fleet-init-agents.ts
@@ -41,7 +41,8 @@ export async function cmdFleetInitAgents(
       for (const w of sess.windows || []) {
         if (!w?.name) continue;
         localScanned++;
-        if (!(w.name in proposed)) proposed[w.name] = "local";
+        const wn = w.name.toLowerCase();
+        if (!(wn in proposed)) proposed[wn] = "local";
       }
     }
   } catch (e: unknown) {
@@ -66,8 +67,9 @@ export async function cmdFleetInitAgents(
       for (const [name, host] of Object.entries(peerAgents)) {
         // Only adopt entries the peer owns (host === "local") — skip their
         // view of other peers, which may be stale on their side too.
-        if (host === "local" && !(name in proposed)) {
-          proposed[name] = peer.name;
+        const lname = name.toLowerCase();
+        if (host === "local" && !(lname in proposed)) {
+          proposed[lname] = peer.name;
         }
       }
     } catch (e: unknown) {

--- a/src/commands/plugins/oracle/impl-register.ts
+++ b/src/commands/plugins/oracle/impl-register.ts
@@ -171,6 +171,7 @@ export async function cmdOracleRegister(
   } = {},
 ): Promise<void> {
   if (!name) throw new Error("register requires a name: maw oracle register <name>");
+  name = name.toLowerCase();
 
   const readRawCache = deps.readRawCache ?? (() => readRaw(CACHE_FILE));
   const writeRawCache = deps.writeRawCache ?? ((data) => writeRaw(CACHE_FILE, data));

--- a/src/commands/shared/fleet-doctor-checks.ts
+++ b/src/commands/shared/fleet-doctor-checks.ts
@@ -179,3 +179,56 @@ export function checkSelfPeer(
   }
   return findings;
 }
+
+/**
+ * Check 6 — Casing duplicates in config.agents keys and fleet window names.
+ *
+ * Root cause of #1240: no normalization at write sites left thClaws and
+ * thclaws as distinct keys, causing the wake resolver to present both.
+ */
+export function checkCasingDuplicates(
+  agents: Record<string, string>,
+  fleetWindowNames: string[],
+): DoctorFinding[] {
+  const findings: DoctorFinding[] = [];
+
+  const agentsByLower = new Map<string, string[]>();
+  for (const key of Object.keys(agents)) {
+    const lower = key.toLowerCase();
+    const group = agentsByLower.get(lower) ?? [];
+    group.push(key);
+    agentsByLower.set(lower, group);
+  }
+  for (const [, keys] of agentsByLower) {
+    if (keys.length > 1) {
+      findings.push({
+        level: "warn",
+        check: "casing-duplicates",
+        fixable: false,
+        message: `${keys.map((k) => `'${k}'`).join(" and ")} map to same oracle — pick one`,
+        detail: { kind: "agents", keys },
+      });
+    }
+  }
+
+  const windowsByLower = new Map<string, string[]>();
+  for (const name of fleetWindowNames) {
+    const lower = name.toLowerCase();
+    const group = windowsByLower.get(lower) ?? [];
+    group.push(name);
+    windowsByLower.set(lower, group);
+  }
+  for (const [, names] of windowsByLower) {
+    if (names.length > 1) {
+      findings.push({
+        level: "warn",
+        check: "casing-duplicates",
+        fixable: false,
+        message: `${names.map((n) => `'${n}'`).join(" and ")} map to same oracle — pick one`,
+        detail: { kind: "fleet", names },
+      });
+    }
+  }
+
+  return findings;
+}

--- a/src/commands/shared/fleet-doctor.ts
+++ b/src/commands/shared/fleet-doctor.ts
@@ -26,6 +26,7 @@ export {
   checkOrphanRoutes,
   checkDuplicatePeers,
   checkSelfPeer,
+  checkCasingDuplicates,
 } from "./fleet-doctor-checks";
 export type { FleetEntryLike } from "./fleet-doctor-checks-repo";
 export { checkMissingRepos } from "./fleet-doctor-checks-repo";
@@ -43,6 +44,7 @@ import {
   checkDuplicatePeers,
   checkSelfPeer,
   checkMissingAgents,
+  checkCasingDuplicates,
 } from "./fleet-doctor-checks";
 import { checkMissingRepos } from "./fleet-doctor-checks-repo";
 import { checkStalePeers } from "./fleet-doctor-stale-peers";
@@ -60,7 +62,7 @@ export async function cmdFleetDoctor(opts: DoctorOptions = {}): Promise<void> {
   const peers = config.namedPeers || [];
   const agents = config.agents || {};
 
-  let entries: Array<{ session: { name: string; windows: Array<{ repo?: string }> } }> = [];
+  let entries: Array<{ session: { name: string; windows: Array<{ name?: string; repo?: string }> } }> = [];
   try {
     entries = loadFleetEntries().map((e) => ({
       session: { name: e.session.name, windows: e.session.windows },
@@ -73,12 +75,17 @@ export async function cmdFleetDoctor(opts: DoctorOptions = {}): Promise<void> {
     sessionNames = sessions.map((s) => s.name);
   } catch { /* no tmux server — checks that need sessions will simply find nothing */ }
 
+  const fleetWindowNames = entries.flatMap((e) =>
+    (e.session.windows ?? []).map((w) => w.name).filter((n): n is string => !!n),
+  );
+
   const findings: DoctorFinding[] = [];
   findings.push(...checkCollisions(sessionNames, peers.map((p) => p.name)));
   findings.push(...checkOrphanRoutes(agents, peers.map((p) => p.name), localNode));
   findings.push(...checkDuplicatePeers(peers));
   findings.push(...checkSelfPeer(peers, localNode, config.port));
   findings.push(...checkMissingRepos(entries, join(getGhqRoot(), "github.com")));
+  findings.push(...checkCasingDuplicates(agents, fleetWindowNames));
 
   const { findings: staleFindings, identities } = await checkStalePeers(peers);
   findings.push(...staleFindings);

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -155,10 +155,11 @@ export async function cmdWake(oracle: string, opts: WakeCmdOptions): Promise<str
     // Auto-register agent in config.agents so federation peers can route to it (#285)
     const config = loadConfig();
     const agents = config.agents || {};
-    if (!(oracle in agents)) {
+    const oracleKey = oracle.toLowerCase();
+    if (!(oracleKey in agents)) {
       const node = config.node || "local";
-      saveConfig({ agents: { ...agents, [oracle]: node } });
-      console.log(`\x1b[32m+\x1b[0m registered agent '${oracle}' → '${node}' in config.agents`);
+      saveConfig({ agents: { ...agents, [oracleKey]: node } });
+      console.log(`\x1b[32m+\x1b[0m registered agent '${oracleKey}' → '${node}' in config.agents`);
     }
 
     // #1020 — session = team: auto-create team config so `maw team spawn`

--- a/test/casing-normalization.test.ts
+++ b/test/casing-normalization.test.ts
@@ -1,0 +1,55 @@
+import { describe, test, expect } from "bun:test";
+import { checkCasingDuplicates } from "../src/commands/shared/fleet-doctor";
+import { extractOracleStem } from "../src/commands/plugins/fleet/fleet-adopt";
+
+describe("checkCasingDuplicates — #1240 doctor check", () => {
+  test("flags mixed-case keys in config.agents", () => {
+    const agents = { thClaws: "local", thclaws: "local", homekeeper: "local" };
+    const out = checkCasingDuplicates(agents, []);
+    expect(out.length).toBe(1);
+    expect(out[0].check).toBe("casing-duplicates");
+    expect(out[0].level).toBe("warn");
+    expect(out[0].message).toContain("thClaws");
+    expect(out[0].message).toContain("thclaws");
+    expect(out[0].detail).toMatchObject({ kind: "agents" });
+  });
+
+  test("flags mixed-case fleet window names", () => {
+    const out = checkCasingDuplicates({}, ["thClaws-oracle", "thclaws-oracle", "homekeeper-oracle"]);
+    expect(out.length).toBe(1);
+    expect(out[0].check).toBe("casing-duplicates");
+    expect(out[0].message).toContain("thClaws-oracle");
+    expect(out[0].message).toContain("thclaws-oracle");
+    expect(out[0].detail).toMatchObject({ kind: "fleet" });
+  });
+
+  test("returns empty for all-lowercase entries", () => {
+    const agents = { thclaws: "local", homekeeper: "m5", volt: "m5" };
+    const windows = ["thclaws-oracle", "homekeeper-oracle"];
+    expect(checkCasingDuplicates(agents, windows)).toEqual([]);
+  });
+
+  test("returns empty for empty inputs", () => {
+    expect(checkCasingDuplicates({}, [])).toEqual([]);
+  });
+
+  test("fixable is false (human must resolve)", () => {
+    const out = checkCasingDuplicates({ Foo: "local", foo: "local" }, []);
+    expect(out[0].fixable).toBe(false);
+  });
+});
+
+describe("fleet adopt stem normalization — #1240 write-site fix", () => {
+  test("extractOracleStem lowercases mixed-case CLAUDE.md title", () => {
+    // extractOracleStem already lowercases — verify the contract holds
+    // (nameOverride path is covered by adoptByPath which calls stem.toLowerCase())
+    const { writeFileSync, mkdirSync } = require("fs");
+    const { join } = require("path");
+    const { tmpdir } = require("os");
+    const dir = join(tmpdir(), `maw-test-${Date.now()}`);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "CLAUDE.md"), "# ThClaws Oracle\n\nsome content");
+    const stem = extractOracleStem(join(dir, "CLAUDE.md"));
+    expect(stem).toBe("thclaws");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1240. Three changes to prevent the wake-prompt duplicate-with-different-case bug discovered with \`thClaws\` vs \`thclaws\`:

### 1. Normalize on write (4 sites)
- \`fleet-adopt.ts:137\` — \`--as\` flag lowercased
- \`impl-register.ts:163\` — oracle register lowercases name
- \`wake-cmd.ts:159\` — config.agents key lowercased
- \`fleet-init-agents.ts:44,69\` — local + peer window names lowercased

### 2. New doctor check
\`checkCasingDuplicates\` in \`fleet-doctor-checks.ts\` — groups config.agents keys and fleet window names by \`.toLowerCase()\`, warns on collisions.

Live test: \`maw fleet doctor\` now flags my existing \`thClaws\` + \`thclaws\` duplicate.

### 3. Tests
\`test/casing-normalization.test.ts\` — 6 tests, all pass.

## Test plan
- [x] 6 unit tests pass
- [x] Live: \`maw fleet doctor\` detects existing casing dupes
- [x] Build clean (\`bun build src/cli.ts\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)