### PR TITLE
feat: export test/helpers/mock-config for extracted plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "./commands/shared/wake": "./src/commands/shared/wake.ts",
     "./commands/shared/wake-resolve": "./src/commands/shared/wake-resolve.ts",
     "./commands/shared/wake-target": "./src/commands/shared/wake-target.ts",
-    "./commands/shared/workspace": "./src/commands/shared/workspace.ts"
+    "./commands/shared/workspace": "./src/commands/shared/workspace.ts",
+    "./test/helpers/mock-config": "./test/helpers/mock-config.ts"
   }
 }


### PR DESCRIPTION
## Summary
Adds \`./test/helpers/mock-config\` to the exports map so extracted plugins (in \`maw-plugin-registry\`) can import the shared bun:test config helper via the module resolver instead of brittle relative paths.

## Why
4 test files in \`maw-plugin-registry\` (\`costs\`, \`ping\`, \`health\`, \`hey-test\`) currently do:
\`\`\`ts
await import(\"../../../../test/helpers/mock-config\")
\`\`\`
which walks: \`<plugin>/\` → \`plugins/\` → \`maw-plugin-registry/\` → \`Soul-Brews-Studio/\` — landing outside the registry. Same root-cause pattern as maw-plugin-registry#34 (doctor's \`pkg.json\` path-walk fix).

After this lands, those tests switch to:
\`\`\`ts
import { mockConfigModule } from \"maw-js/test/helpers/mock-config\";
\`\`\`

Sibling PR on maw-plugin-registry pending — agents are migrating the 4 test files now.

## Test plan
- [x] \`grep '\"./test/helpers/mock-config\"' package.json\` confirms the new entry
- [x] Verified locally: \`Bun.resolveSync(\"maw-js/test/helpers/mock-config\", \".\")\` resolves to \`./test/helpers/mock-config.ts\`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)