### PR TITLE
fix(cli): `cleanup` alias routes to top-level cleanup plugin (#1244)

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -65,7 +65,12 @@ export const TOP_ALIASES: Record<string, string[] | DirectHandler> = {
   layout: ["team", "layout"],
   zoom: ["tmux", "zoom"],
   panes: ["tmux", "ls", "--all", "--verbose"],
-  cleanup: ["team", "cleanup", "--zombie-agents"],
+  // `maw cleanup` → `maw cleanup --zombie-agents` (auto-inject flag for the
+  // top-level cleanup plugin in maw-plugin-registry). The previous rewrite
+  // `["team", "cleanup", ...]` was wrong — the `team` plugin has no `cleanup`
+  // subcommand; the cleanup plugin sits at the top level. Resolver runs once
+  // (dispatch.ts:36), so the self-reference doesn't loop. (#1244)
+  cleanup: ["cleanup", "--zombie-agents"],
   stall: ["tmux", "detect-stalls"],
 
   // `maw new <name>` — the friendly door for creating an oracle.


### PR DESCRIPTION
## Summary
- Closes #1244
- `cleanup` alias was rewriting to `["team", "cleanup", "--zombie-agents"]` — but \`team\` has no \`cleanup\` subcommand
- Replace with `["cleanup", "--zombie-agents"]` — routes directly to the top-level cleanup plugin in maw-plugin-registry
- Resolver runs once (dispatch.ts:36), then continues to plugin dispatch — no infinite loop on the self-reference

## Before
\`\`\`
\$ maw cleanup --zombie-agents
loaded ...
unknown subcommand: cleanup
\`\`\`

## After
\`\`\`
\$ maw cleanup --zombie-agents
Scanning tmux panes...
✓ No zombie agent panes found.
\`\`\`

## Test plan
- [x] 1258/1258 tests pass (\`bun test test/\`)
- [x] \`resolveTopAlias([\"cleanup\"])\` returns \`{kind:\"argv\", argv:[\"cleanup\",\"--zombie-agents\"]}\`
- [x] Live verification: \`maw cleanup --zombie-agents\` now reaches the plugin handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)