### PR TITLE
release: v26.5.12-alpha.1650

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.12-alpha.1615",
+  "version": "26.5.12-alpha.1650",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -54,24 +54,30 @@ export const ALIAS_DESCRIPTIONS: Record<string, string> = {
 };
 
 export const TOP_ALIASES: Record<string, string[] | DirectHandler> = {
-  // Argv-rewrite form — canonical handler lives in a core plugin
-  a: ["tmux", "attach"],
-  kill: ["tmux", "kill"],
-  peek: ["tmux", "peek"],
+  // Argv-rewrite form — canonical handler lives in a top-level plugin in
+  // maw-plugin-registry. The previous `["tmux", X]` rewrites were stale —
+  // the `tmux` plugin was split into per-verb top-level plugins
+  // (attach/, kill/, peek/, zoom/, panes/) but the alias table was not
+  // updated. Result: `maw a flutter` rewrote to `maw tmux attach flutter`
+  // → "unknown command: tmux" → fell through to bare-name comm-send.
+  // Same shape as the #1244 cleanup alias bug. (#TBD)
+  a: ["attach"],
+  kill: ["kill"],
+  peek: ["peek"],
   split: ["split"],
-  open: ["tmux", "open"],
+  open: ["tmux", "open"],     // tmux open/close/detect-stalls not yet extracted as top-level plugins
   close: ["tmux", "close"],
   t: ["team"],
   layout: ["team", "layout"],
-  zoom: ["tmux", "zoom"],
-  panes: ["tmux", "ls", "--all", "--verbose"],
+  zoom: ["zoom"],
+  panes: ["panes"],
   // `maw cleanup` → `maw cleanup --zombie-agents` (auto-inject flag for the
   // top-level cleanup plugin in maw-plugin-registry). The previous rewrite
   // `["team", "cleanup", ...]` was wrong — the `team` plugin has no `cleanup`
   // subcommand; the cleanup plugin sits at the top level. Resolver runs once
   // (dispatch.ts:36), so the self-reference doesn't loop. (#1244)
   cleanup: ["cleanup", "--zombie-agents"],
-  stall: ["tmux", "detect-stalls"],
+  stall: ["tmux", "detect-stalls"],   // detect-stalls not yet extracted as top-level plugin
 
   // `maw new <name>` — the friendly door for creating an oracle.
   // Routes to the awaken plugin (bud + wake + fire /awaken). Plain alias —

--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -112,7 +112,12 @@ export async function checkPaneIdle(target: string, host?: string): Promise<{ id
  *   test/isolated/hey-bare-name-rejection.test.ts). The production caller is
  *   `cmdSend` in this same file. No other module imports this symbol.
  */
-export function formatBareNameError(query: string): string {
+export function formatBareNameError(query: string, localNode = "local"): string {
+  // `localNode` is the current node's name (config.node). When provided, the
+  // `this node:` hint uses it so the suggestion actually resolves — `local:`
+  // is not a built-in alias and errors with "node 'local' not in namedPeers".
+  // Defaults to `"local"` for backward compat with the pure-function tests.
+  // (#1246)
   const RED = "\x1b[31m"; // error marker
   const C = "\x1b[36m";   // cyan — for canonical suggestion lines
   const D = "\x1b[90m";   // dim — for explanatory tail
@@ -121,7 +126,7 @@ export function formatBareNameError(query: string): string {
     `${RED}error${R}: bare-name target removed — node prefix required`,
     ``,
     `  this node:`,
-    `    ${C}maw hey local:${query} "..."${R}`,
+    `    ${C}maw hey ${localNode}:${query} "..."${R}`,
     ``,
     `  cross-node candidates:`,
     `    ${C}maw hey <node>:<session>:${query} "..."${R}`,
@@ -541,7 +546,7 @@ export async function cmdSend(
   // message. Bare names already had a chance through `resolveTarget` and
   // auto-wake above; if we got here it's a true miss.
   if (isBareName) {
-    console.error(formatBareNameError(query));
+    console.error(formatBareNameError(query, config.node ?? "local"));
     process.exit(1);
   }
   if (result?.type === "error") {

--- a/test/cli/dispatch-match.test.ts
+++ b/test/cli/dispatch-match.test.ts
@@ -187,11 +187,15 @@ describe("resolveTopAlias — RFC #954 verb aliases", () => {
     }
   });
 
-  test("`a neo` → argv rewrite to ['tmux', 'attach', 'neo']", () => {
+  test("`a neo` → argv rewrite to ['attach', 'neo']", () => {
+    // The alias rewrites to the top-level `attach` plugin (in maw-plugin-registry).
+    // The previous `["tmux", "attach"]` form was stale — the tmux/attach
+    // subcommand was extracted to a top-level plugin, but the alias was not
+    // updated. Same shape as the #1244 cleanup alias bug.
     const out = resolveTopAlias(["a", "neo"]);
     expect(out).not.toBeNull();
     expect(out!.kind).toBe("argv");
-    if (out!.kind === "argv") expect(out!.argv).toEqual(["tmux", "attach", "neo"]);
+    if (out!.kind === "argv") expect(out!.argv).toEqual(["attach", "neo"]);
   });
 
   test("`attach` is not a registered alias (removed — use `a`)", () => {

--- a/test/comm-send-deprecation-759.test.ts
+++ b/test/comm-send-deprecation-759.test.ts
@@ -50,6 +50,24 @@ describe("#759 Phase 2 + #1136 — bare-name federation-friendly error", () => {
     expect(out).toContain("maw locate weird name with spaces");
   });
 
+  test("localNode parameter substitutes into the `this node:` hint (#1246)", () => {
+    // When the caller passes the current node name, the hint uses it instead
+    // of the literal "local" so the suggested command actually resolves.
+    const out = formatBareNameError("mother", "m5");
+    expect(out).toContain("maw hey m5:mother");
+    expect(out).not.toContain("maw hey local:mother");
+    // Cross-node placeholder stays the same — `<node>:<session>:` is still
+    // a literal users learn to expand via `maw locate`.
+    expect(out).toContain("maw hey <node>:<session>:mother");
+  });
+
+  test("localNode defaults to 'local' for backward compat (#1246)", () => {
+    // No second arg → falls back to the original "local:" form. Callers in
+    // the codebase always pass config.node; this is just defense.
+    const out = formatBareNameError("mother");
+    expect(out).toContain("maw hey local:mother");
+  });
+
   test("output shape (ANSI-stripped) matches the issue example", () => {
     const out = formatBareNameError("mawjs-oracle");
     const stripped = out.replace(/\x1b\[[0-9;]*m/g, "");

--- a/test/isolated/hey-bare-name-rejection.test.ts
+++ b/test/isolated/hey-bare-name-rejection.test.ts
@@ -163,9 +163,12 @@ describe("cmdSend — bare-name contract (#759 Phase 2 + #1136)", () => {
     expect(allErr).toContain("error");
     expect(allErr).toContain("bare-name target removed");
     expect(allErr).toContain("node prefix required");
-    // this-node form with substituted agent
+    // this-node form uses the ACTUAL local node name (config.node), not the
+    // literal "local" — `local:` is not a built-in alias and errors with
+    // "node 'local' not in namedPeers". (#1246)
     expect(allErr).toContain("this node:");
-    expect(allErr).toContain("maw hey local:mawjs-oracle");
+    expect(allErr).toContain("maw hey test-node:mawjs-oracle");
+    expect(allErr).not.toContain("maw hey local:mawjs-oracle");
     // cross-node placeholder form
     expect(allErr).toContain("cross-node candidates:");
     expect(allErr).toContain("maw hey <node>:<session>:mawjs-oracle");


### PR DESCRIPTION
Cuts v26.5.12-alpha.1650 on merge via calver-release.yml.

## Contains

**fix(#1246)**: bare-name error hint uses actual node, not dead `local:`
- `formatBareNameError` takes a `localNode` param; `cmdSend` passes `config.node`
- Hint now reads e.g. `maw hey m5:mother "..."` instead of unresolvable `local:mother`
- Hit twice in 5 min on 2026-05-12 (mawjs ↔ mother, both on m5)

**fix(top-aliases)**: rewrite a/kill/peek/zoom/panes to top-level plugins
- Same shape as #1244 cleanup alias — `tmux` plugin was split into per-verb top-level plugins in maw-plugin-registry, alias table was stale
- `maw a flutter` → `maw tmux attach flutter` → "unknown command: tmux" → spurious bare-name error
- Live verified: `maw a flutter` now creates flutter-view and attaches

## Test plan

- [x] `formatBareNameError` pure-function tests — 8/8 pass (added 2 for the new param + default)
- [x] `hey-bare-name-rejection.test.ts` isolated test — 8/8 pass (updated to expect `test-node:` from mock config)
- [x] `dispatch-match.test.ts` — 18/18 pass (updated `a neo` expectation)
- [x] Full non-isolated suite — 1258 pass, 8 fail (all pre-existing `view-grouped-session` mock pollution)
- [x] Live binary test — `maw a flutter` works

Auto-generated by /release-alpha — branch had 3 commits ahead of origin/alpha at cut time (2 fixes + 1 bump).