### PR TITLE
fix(#1252): export commands/shared/wake-cmd subpath

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "./commands/shared/scan-signals": "./src/commands/shared/scan-signals.ts",
     "./commands/shared/should-auto-wake": "./src/commands/shared/should-auto-wake.ts",
     "./commands/shared/wake": "./src/commands/shared/wake.ts",
+    "./commands/shared/wake-cmd": "./src/commands/shared/wake-cmd.ts",
     "./commands/shared/wake-resolve": "./src/commands/shared/wake-resolve.ts",
     "./commands/shared/wake-target": "./src/commands/shared/wake-target.ts",
     "./commands/shared/workspace": "./src/commands/shared/workspace.ts",


### PR DESCRIPTION
## Summary

Closes #1252.

`plugins/view/impl.ts:153` in maw-plugin-registry does:
\`\`\`ts
const { cmdWake } = await import("maw-js/commands/shared/wake-cmd");
\`\`\`

But \`maw-js/package.json\` exports field didn't expose that path, so the import failed at runtime:

\`\`\`
Cannot find module 'maw-js/commands/shared/wake-cmd' from '/path/to/plugin-registry/plugins/view/impl.ts'
\`\`\`

## Fix

One-line addition to \`package.json\` exports:
\`\`\`json
"./commands/shared/wake-cmd": "./src/commands/shared/wake-cmd.ts"
\`\`\`

Adjacent siblings (\`./commands/shared/wake\`, \`./commands/shared/wake-resolve\`, \`./commands/shared/wake-target\`) were already there — wake-cmd was simply missed when the others were added.

Same shape as #1243 (mock-config subpath). Single-line additive change, no other surface affected.

## Test plan

- [x] \`bun -e 'await import("maw-js/commands/shared/wake-cmd")'\` resolves successfully (exports: cmdWake)
- [x] Rebuilt binary + \`bun link\`, \`maw a skills-cli\` no longer hits "Cannot find module" error
- [x] No other change in package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)