### PR TITLE
release: v26.5.13-alpha.114

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.12-alpha.1650",
+  "version": "26.5.13-alpha.114",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts v26.5.13-alpha.114 on merge via calver-release.yml.

Bundles fixes from already-merged PRs #1253 + #1254:
- #1253 — `./commands/shared/wake-cmd` subpath export (closes #1250)
- #1254 — 5 missing subpath exports surfaced by debt-survey scout (worktrees, triggers, pulse, federation, federation-sync)

Both PRs landed without their own version bump (code-only); this PR carries the bump to tag the bundled release.