### PR TITLE
ci(#1257): shard test-isolated 8-way for ~8x wall-clock speedup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,14 +8,14 @@ on:
 
 jobs:
   test:
+    # Fast suites — single runner each. test-isolated is split out below
+    # into a sharded matrix because it's the slowest (79 per-file subprocesses).
     runs-on: ubuntu-latest
     strategy:
       matrix:
         suite:
           - name: unit
             script: test
-          - name: isolated
-            script: test:isolated
           - name: plugin
             script: test:plugin
           - name: mock-smoke
@@ -48,6 +48,44 @@ jobs:
           echo "$HOME/go/bin" >> "$GITHUB_PATH"
 
       - name: Run ${{ matrix.suite.name }} tests
+        env:
+          MAW_SKIP_FLAKY: "1"
+        run: bun run ${{ matrix.suite.script }}
+
+  # test-isolated is the slowest CI job — 79 test files × bun startup, all
+  # sequential because Bun's mock.module is process-global. Each subprocess
+  # is already independent, so we shard 8-way for ~8x wall-clock speedup.
+  # (#1257)
+  test-isolated:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
+    name: test-isolated (${{ matrix.shard }}/8)
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
+
+      - name: Cache bun deps
+        uses: actions/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install ghq
+        run: |
+          go install github.com/x-motemen/ghq@latest
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+
+      - name: Run isolated tests (shard ${{ matrix.shard }}/8)
         # MAW_SKIP_FLAKY=1 — override list (#811/#813 precedent).
         # Currently skips:
         #   - test/integration/federation-local.test.ts (#830 — port-binding
@@ -59,11 +97,11 @@ jobs:
         # is a belt-and-braces measure to keep CI green while we monitor.
         env:
           MAW_SKIP_FLAKY: "1"
-        run: bun run ${{ matrix.suite.script }}
+        run: bash scripts/test-isolated.sh --shard ${{ matrix.shard }}/8
 
   build:
     runs-on: ubuntu-latest
-    needs: test
+    needs: [test, test-isolated]
     steps:
       - uses: actions/checkout@v6
 

--- a/scripts/test-isolated.sh
+++ b/scripts/test-isolated.sh
@@ -11,8 +11,14 @@
 # changes required.
 #
 # Usage:
-#   bash scripts/test-isolated.sh                 # normal run
-#   bash scripts/test-isolated.sh --randomize     # passes --randomize to each file
+#   bash scripts/test-isolated.sh                    # normal run
+#   bash scripts/test-isolated.sh --randomize        # passes --randomize to each file
+#   bash scripts/test-isolated.sh --shard 3/8        # process modulo-shard: files 3, 11, 19, ...
+#   bash scripts/test-isolated.sh --shard=3/8        # same, = form (#1257)
+#
+# Sharding: --shard N/M splits the file list into M groups and runs group N
+# (1-indexed). Each subprocess is already independent (one bun process per
+# file), so sharded runs are fully parallelizable across CI runners.
 set -eo pipefail
 
 cd "$(dirname "$0")/.."
@@ -26,15 +32,62 @@ IGNORE_ARGS=(
   --path-ignore-patterns '**/agents/**'
 )
 
-EXTRA_ARGS=("$@")
+# Parse --shard N/M or --shard=N/M out of the arg list; everything else
+# passes through to `bun test` (e.g. --randomize). (#1257)
+SHARD_N=""
+SHARD_M=""
+EXTRA_ARGS=()
+i=0
+args=("$@")
+while [ $i -lt ${#args[@]} ]; do
+  arg="${args[$i]}"
+  case "$arg" in
+    --shard=*)
+      spec="${arg#--shard=}"
+      SHARD_N="${spec%/*}"
+      SHARD_M="${spec#*/}"
+      ;;
+    --shard)
+      i=$((i + 1))
+      spec="${args[$i]:-}"
+      SHARD_N="${spec%/*}"
+      SHARD_M="${spec#*/}"
+      ;;
+    *)
+      EXTRA_ARGS+=("$arg")
+      ;;
+  esac
+  i=$((i + 1))
+done
 
-FILES=(test/isolated/*.test.ts)
+if [ -n "$SHARD_N" ] && [ -n "$SHARD_M" ]; then
+  if ! [[ "$SHARD_N" =~ ^[0-9]+$ ]] || ! [[ "$SHARD_M" =~ ^[0-9]+$ ]]; then
+    echo "ERR: --shard wants N/M with integers (got '$SHARD_N/$SHARD_M')" >&2
+    exit 2
+  fi
+  if [ "$SHARD_N" -lt 1 ] || [ "$SHARD_N" -gt "$SHARD_M" ]; then
+    echo "ERR: --shard N must be in 1..M (got '$SHARD_N/$SHARD_M')" >&2
+    exit 2
+  fi
+fi
+
+ALL_FILES=(test/isolated/*.test.ts)
+if [ -n "$SHARD_N" ] && [ -n "$SHARD_M" ]; then
+  FILES=()
+  for ((i = SHARD_N - 1; i < ${#ALL_FILES[@]}; i += SHARD_M)); do
+    FILES+=("${ALL_FILES[$i]}")
+  done
+  SHARD_LABEL=" (shard $SHARD_N/$SHARD_M)"
+else
+  FILES=("${ALL_FILES[@]}")
+  SHARD_LABEL=""
+fi
 TOTAL=${#FILES[@]}
 PASSED=0
 FAILED=0
 FAILED_FILES=()
 
-echo "=== test-isolated.sh: $TOTAL files, one process each ==="
+echo "=== test-isolated.sh: $TOTAL files, one process each${SHARD_LABEL} ==="
 for f in "${FILES[@]}"; do
   printf -- "--- %s ---\n" "$f"
   if bun test "$f" "${IGNORE_ARGS[@]}" "${EXTRA_ARGS[@]}"; then


### PR DESCRIPTION
## Summary

Closes #1257.

\`scripts/test-isolated.sh\` runs 79 test files in sequence — one bun subprocess per file because Bun's \`mock.module\` is process-global. Each subprocess is already independent. They were sequential by convenience, not necessity.

## Changes

### \`scripts/test-isolated.sh\`
- Accepts \`--shard N/M\` or \`--shard=N/M\`
- Validates N is 1..M and both integers; clear error on malformed input
- Applies modulo distribution: shard N processes files at indices [N-1, N-1+M, N-1+2M, ...]
- Other flags (\`--randomize\`, etc.) still pass through to \`bun test\`

### \`.github/workflows/ci.yml\`
- New \`test-isolated\` job with \`strategy.matrix.shard: [1, 2, 3, 4, 5, 6, 7, 8]\`
- Main \`test\` job keeps the 3 fast suites (unit/plugin/mock-smoke) — they don't benefit from sharding
- \`build\` job now depends on both \`test\` and \`test-isolated\`

## Distribution

79 files → 8 shards: **10, 10, 10, 10, 10, 10, 10, 9**

## Test plan

- [x] \`bash -n scripts/test-isolated.sh\` — syntax OK
- [x] Shard arithmetic verified: 79 → 10/10/10/10/10/10/10/9
- [x] \`bash scripts/test-isolated.sh --shard 8/8\` ran locally → 9/9 files pass
- [x] \`bash scripts/test-isolated.sh --shard 4/8\` selects 10 files at expected indices (verified visually)
- [x] YAML parse OK; jobs: test, test-isolated, build
- [ ] First CI run on this PR will exercise all 8 shards in parallel — wall-clock target ~1/8 of previous time

## Billing impact

Today's CI gross: <\$0.01, billed \$0 (GitHub Pro included allotment). 8x parallel runners stay trivially affordable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)