### PR TITLE
feat(transport): shared SSH-attach helper for cross-node (#1236 Tier 3 prep)

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,8 @@
     "./core/matcher/resolve-target": "./src/core/matcher/resolve-target.ts",
     "./core/paths": "./src/core/paths.ts",
     "./core/transport/ssh": "./src/core/transport/ssh.ts",
+    "./core/transport/ssh-attach": "./src/core/transport/ssh-attach.ts",
+    "./core/transport/peers": "./src/core/transport/peers.ts",
     "./core/transport/tmux": "./src/core/transport/tmux.ts",
     "./worktrees": "./src/core/fleet/worktrees.ts",
     "./core/util/terminal": "./src/core/util/terminal.ts",

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -10,10 +10,23 @@ export interface TriggerConfig {
   once?: boolean;       // fire once then self-destruct (#149)
 }
 
-/** Named peer with URL */
+/** Named peer with URL + optional SSH alias. */
 export interface PeerConfig {
   name: string;
   url: string;
+  /**
+   * SSH host/alias used for cross-node tmux attach (#1236 Tier 3).
+   *
+   * Resolution order in `attach.resolveSshAlias`:
+   *   1. `namedPeers[n].ssh`        (explicit override — preferred)
+   *   2. URL hostname stripped      (`http://mba.wg:9090` → `mba.wg`)
+   *   3. literal node name from /api/identity
+   *
+   * Set this when the peer's wireguard hostname is different from its SSH
+   * alias, or when you've configured `Host <alias>` in `~/.ssh/config`.
+   * No new secret storage — SSH keys stay where they are (~/.ssh).
+   */
+  ssh?: string;
 }
 
 export interface MawIntervals {

--- a/src/config/validate-ext.ts
+++ b/src/config/validate-ext.ts
@@ -107,13 +107,17 @@ function validateExtFields(
     }
   }
 
-  // namedPeers: array of {name, url} objects
+  // namedPeers: array of {name, url, ssh?} objects
+  // `ssh` is the optional SSH alias for cross-node attach (#1236). When
+  // present it MUST be a string; non-string ssh values cause the whole entry
+  // to be dropped (rather than silently leaking a bad type into hostExec).
   if ("namedPeers" in raw) {
     if (Array.isArray(raw.namedPeers)) {
       const valid = raw.namedPeers.filter((p: unknown) => {
         if (!p || typeof p !== "object") return false;
         const obj = p as Record<string, unknown>;
         if (typeof obj.name !== "string" || typeof obj.url !== "string") return false;
+        if ("ssh" in obj && typeof obj.ssh !== "string") return false;
         try { new URL(obj.url); return true; } catch { return false; }
       });
       if (valid.length !== raw.namedPeers.length) {
@@ -121,7 +125,7 @@ function validateExtFields(
       }
       result.namedPeers = valid;
     } else {
-      warn("namedPeers", "must be an array of {name, url}");
+      warn("namedPeers", "must be an array of {name, url, ssh?}");
     }
   }
 

--- a/src/core/transport/peers.ts
+++ b/src/core/transport/peers.ts
@@ -20,8 +20,17 @@ function isValidPeerSession(item: unknown): item is Session {
   );
 }
 
+/**
+ * Aggregated session row — local sessions + peer sessions tagged with origin.
+ *   - `source`: peer URL (or "local" for local sessions)
+ *   - `node`:   peer's logical node identity (from /api/identity), when known.
+ *               Surfaced for cross-node attach (#1236 Tier 3) so callers can
+ *               render "homekeeper is on mba" instead of leaking the raw URL.
+ */
+export type AggregatedSession = Session & { source?: string; node?: string };
+
 /** Simple TTL cache for aggregated sessions (#145) */
-let aggregatedCache: { peers: (Session & { source?: string })[]; ts: number } | null = null;
+let aggregatedCache: { peers: AggregatedSession[]; ts: number } | null = null;
 const CACHE_TTL = 30_000;
 
 export interface PeerStatus {
@@ -114,14 +123,27 @@ export function getPeers(): string[] {
 }
 
 /**
- * Fetch sessions from a peer
+ * Fetch sessions from a peer, alongside its node identity.
+ *
+ * Two parallel calls — /api/sessions for the data, /api/identity for the
+ * `node` tag. Identity is best-effort: a peer that answers /api/sessions but
+ * not /api/identity still yields sessions tagged with `source=url, node=undefined`.
+ * The node tag is consumed by cross-node attach (#1236 Tier 3) for friendlier
+ * "on <node>" messaging — never load-bearing for routing.
  */
-async function fetchPeerSessions(url: string): Promise<Session[]> {
+async function fetchPeerSessions(url: string): Promise<{ sessions: Session[]; node?: string }> {
   try {
-    const res = await curlFetch(`${url}/api/sessions?local=true`, { timeout: cfgTimeout("http") });
-    if (!res.ok) return [];
-    const raw = res.data;
-    if (!Array.isArray(raw)) return [];
+    const [sessionsRes, idRes] = await Promise.all([
+      curlFetch(`${url}/api/sessions?local=true`, { timeout: cfgTimeout("http") }),
+      curlFetch(`${url}/api/identity`, { timeout: cfgTimeout("http") }).catch(() => null),
+    ]);
+    const node: string | undefined =
+      idRes && idRes.ok && idRes.data && typeof (idRes.data as any).node === "string"
+        ? (idRes.data as any).node
+        : undefined;
+    if (!sessionsRes.ok) return { sessions: [], node };
+    const raw = sessionsRes.data;
+    if (!Array.isArray(raw)) return { sessions: [], node };
     // Validate at federation boundary — drop sessions with malformed names
     const valid: Session[] = [];
     for (const item of raw) {
@@ -134,32 +156,35 @@ async function fetchPeerSessions(url: string): Promise<Session[]> {
         );
       }
     }
-    return valid;
+    return { sessions: valid, node };
   } catch {
-    return [];
+    return { sessions: [] };
   }
 }
 
 /**
- * Merge local sessions with peer sessions, tagging each with source
+ * Merge local sessions with peer sessions, tagging each with `source` (URL or
+ * "local") and `node` (peer's logical identity, when known). The `node` tag
+ * powers cross-node attach (#1236 Tier 3) without leaking peer URLs to the
+ * operator.
  */
-export async function getAggregatedSessions(localSessions: Session[]): Promise<(Session & { source?: string })[]> {
+export async function getAggregatedSessions(localSessions: Session[]): Promise<AggregatedSession[]> {
   const peers = getPeers();
   if (peers.length === 0) {
     return localSessions;
   }
 
-  const local: (Session & { source?: string })[] = localSessions.map(s => ({ ...s, source: "local" }));
+  const local: AggregatedSession[] = localSessions.map(s => ({ ...s, source: "local" }));
 
   // Return cached peer sessions if fresh (#145)
   if (aggregatedCache && Date.now() - aggregatedCache.ts < CACHE_TTL) {
     return [...local, ...aggregatedCache.peers];
   }
 
-  // Fetch sessions from all peers in parallel
+  // Fetch sessions + identity from all peers in parallel
   const peerResults = await Promise.all(peers.map(async (url) => {
-    const sessions = await fetchPeerSessions(url);
-    return sessions.map(s => ({ ...s, source: url }));
+    const { sessions, node } = await fetchPeerSessions(url);
+    return sessions.map(s => ({ ...s, source: url, node }));
   }));
 
   // Dedup sessions by source + name (#175)

--- a/src/core/transport/ssh-attach.ts
+++ b/src/core/transport/ssh-attach.ts
@@ -1,0 +1,191 @@
+/**
+ * Shared SSH-attach helper for cross-node tmux session takeover.
+ *
+ * Used by:
+ *   - plugins/attach (Tier 3 — cross-node attach via aggregated peer sessions)
+ *   - plugins/view  (existing host-config-based view attach)
+ *
+ * Pattern proven in view's `attachViaTmux` (impl.ts:357): `ssh -tt <host>
+ * "tmux attach-session -t '<safe>'"`. The remote tmux owns the session;
+ * operator's terminal becomes a remote tmux client. Detach (prefix+d) returns
+ * cleanly to the local shell. Sizing, copy-mode, and scrollback all work
+ * because the remote tmux owns the session — no state-mirroring needed.
+ *
+ * Failure handling — per cross-node-attach-design §5: this helper NEVER
+ * `process.exit`s. Transport failures throw `SshAttachError` so callers can
+ * format a one-line UserError and let the CLI catch it. SSH stderr is
+ * captured to `err.stderr` for diagnosis.
+ */
+import { execFileSync } from "child_process";
+import { tmuxCmd } from "./tmux";
+
+/** Distinguishes transport failure modes for user-facing error UX. */
+export type SshAttachErrorKind =
+  | "unreachable"     // ssh exit 255: connection refused / no route / timeout
+  | "auth-failed"     // ssh exit 255: permission denied (publickey)
+  | "tmux-missing"    // remote: tmux: command not found
+  | "session-missing" // remote: tmux can't find session
+  | "unsafe-name"     // session name fails safety regex (defensive)
+  | "unknown";        // other non-zero exit
+
+export class SshAttachError extends Error {
+  readonly node: string;
+  readonly sshAlias: string;
+  readonly sessionName: string;
+  readonly kind: SshAttachErrorKind;
+  readonly exitCode?: number;
+  readonly stderr?: string;
+
+  constructor(opts: {
+    node: string;
+    sshAlias: string;
+    sessionName: string;
+    kind: SshAttachErrorKind;
+    message: string;
+    exitCode?: number;
+    stderr?: string;
+  }) {
+    super(opts.message);
+    this.name = "SshAttachError";
+    this.node = opts.node;
+    this.sshAlias = opts.sshAlias;
+    this.sessionName = opts.sessionName;
+    this.kind = opts.kind;
+    this.exitCode = opts.exitCode;
+    this.stderr = opts.stderr;
+  }
+}
+
+/**
+ * Defense-in-depth — the remote command is shell-interpreted via `ssh`, so
+ * we reject anything outside the tmux-safe character set (matches the same
+ * guard in view/impl.ts and peers' isValidPeerSession boundary).
+ */
+const SAFE_SESSION_NAME = /^[A-Za-z0-9._-]+$/;
+
+/** Test seam — accepts a real `execFileSync` or a stub of the same shape. */
+export type ExecFileSyncFn = (
+  file: string,
+  args: readonly string[],
+  options?: { stdio?: unknown },
+) => unknown;
+
+export interface AttachRemoteSessionOpts {
+  /** Logical node identity (used for error messages, e.g. "mba"). */
+  node: string;
+  /** SSH host/alias from ~/.ssh/config or wireguard hostname. */
+  sshAlias: string;
+  /** Remote tmux session name to attach to. */
+  sessionName: string;
+  /** Optional injection seam for tests. Defaults to child_process execFileSync. */
+  exec?: ExecFileSyncFn;
+}
+
+/**
+ * Hand the TTY over to a remote tmux session via SSH.
+ *
+ * Blocks (synchronously, via execFileSync) until the user detaches with
+ * prefix+d or the remote session ends. Throws `SshAttachError` on transport
+ * failures — callers should format and bubble as UserError; do NOT
+ * `process.exit` (would take the SSH session with it on nested invocations).
+ */
+export function attachRemoteSession(opts: AttachRemoteSessionOpts): void {
+  const { node, sshAlias, sessionName } = opts;
+  const exec = opts.exec ?? (execFileSync as unknown as ExecFileSyncFn);
+
+  if (!SAFE_SESSION_NAME.test(sessionName)) {
+    throw new SshAttachError({
+      node,
+      sshAlias,
+      sessionName,
+      kind: "unsafe-name",
+      message: `refusing ssh attach: unsafe session name '${sessionName}'`,
+    });
+  }
+
+  const remoteCmd = `${tmuxCmd()} attach-session -t '${sessionName}'`;
+  try {
+    exec("ssh", ["-tt", sshAlias, remoteCmd], { stdio: "inherit" });
+    return;
+  } catch (err: unknown) {
+    const e = err as { status?: number; message?: string; stderr?: unknown };
+    const status = typeof e.status === "number" ? e.status : undefined;
+    const stderr = decodeStderr(e.stderr);
+    const blob = `${e.message ?? ""}\n${stderr ?? ""}`.toLowerCase();
+    const kind = classifyFailure(status, blob);
+    throw new SshAttachError({
+      node,
+      sshAlias,
+      sessionName,
+      kind,
+      exitCode: status,
+      stderr,
+      message: formatMessage({ node, sshAlias, sessionName, kind }),
+    });
+  }
+}
+
+function decodeStderr(s: unknown): string | undefined {
+  if (s == null) return undefined;
+  try {
+    if (typeof s === "string") return s;
+    if (s instanceof Uint8Array) return Buffer.from(s).toString("utf-8");
+    return String(s);
+  } catch {
+    return undefined;
+  }
+}
+
+function classifyFailure(status: number | undefined, blob: string): SshAttachErrorKind {
+  // Auth ordering matters: ssh returns 255 for both unreachable AND
+  // permission-denied, so we discriminate on the stderr blob first.
+  if (blob.includes("permission denied") || blob.includes("publickey")) return "auth-failed";
+  if (
+    blob.includes("connection refused") ||
+    blob.includes("could not resolve") ||
+    blob.includes("name or service not known") ||
+    blob.includes("no route to host") ||
+    blob.includes("connection timed out") ||
+    blob.includes("operation timed out") ||
+    blob.includes("network is unreachable") ||
+    blob.includes("host is down") ||
+    blob.includes("connection closed by remote host")
+  ) {
+    return "unreachable";
+  }
+  if (blob.includes("command not found") || blob.includes("tmux: not found")) return "tmux-missing";
+  if (
+    blob.includes("can't find session") ||
+    blob.includes("no server running") ||
+    blob.includes("no sessions") ||
+    blob.includes("session not found")
+  ) {
+    return "session-missing";
+  }
+  // ssh's "unable to reach" generic — fall back to unreachable at exit 255.
+  if (status === 255) return "unreachable";
+  return "unknown";
+}
+
+function formatMessage(opts: {
+  node: string;
+  sshAlias: string;
+  sessionName: string;
+  kind: SshAttachErrorKind;
+}): string {
+  const { node, sshAlias, sessionName, kind } = opts;
+  switch (kind) {
+    case "auth-failed":
+      return `✗ no SSH key for ${node} — try: ssh-add ~/.ssh/<your-key> (or check 'ssh ${sshAlias}')`;
+    case "unreachable":
+      return `✗ can't reach ${node} via ssh — try: ssh ${sshAlias}`;
+    case "tmux-missing":
+      return `✗ tmux not installed on ${node}`;
+    case "session-missing":
+      return `✗ session '${sessionName}' is gone on ${node}`;
+    case "unsafe-name":
+      return `✗ refusing ssh attach: unsafe session name '${sessionName}'`;
+    default:
+      return `✗ ssh attach to ${node} failed (exit ${"unknown"})`;
+  }
+}

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -45,8 +45,15 @@ export {
 export type { Session as SshSession, HostExecTransport } from "../core/transport/ssh";
 export { curlFetch } from "../core/transport/curl-fetch";
 export {
-  getPeers, getFederationStatus, findPeerForTarget,
+  getPeers, getFederationStatus, findPeerForTarget, getAggregatedSessions,
 } from "../core/transport/peers";
+export type { AggregatedSession } from "../core/transport/peers";
+export {
+  attachRemoteSession, SshAttachError,
+} from "../core/transport/ssh-attach";
+export type {
+  AttachRemoteSessionOpts, SshAttachErrorKind, ExecFileSyncFn,
+} from "../core/transport/ssh-attach";
 export { resolveTarget } from "../core/routing";
 export type { ResolveResult } from "../core/routing";
 export { findWindow } from "../core/runtime/find-window";

--- a/test/ssh-attach.test.ts
+++ b/test/ssh-attach.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Unit tests for the shared cross-node SSH-attach helper (#1236 Tier 3 prep).
+ *
+ * We inject a fake `exec` to avoid actually shelling out to ssh, and assert:
+ *   - the helper builds the right ssh argv
+ *   - failure classification maps stderr/exit to the right SshAttachErrorKind
+ *   - the formatted message matches the design-doc §5 error UX
+ *   - unsafe session names are rejected before any exec
+ */
+import { describe, test, expect } from "bun:test";
+import {
+  attachRemoteSession,
+  SshAttachError,
+  type ExecFileSyncFn,
+} from "../src/core/transport/ssh-attach";
+
+function makeFakeExec(thrown?: { status?: number; message?: string; stderr?: string }): {
+  exec: ExecFileSyncFn;
+  calls: Array<{ file: string; args: readonly string[] }>;
+} {
+  const calls: Array<{ file: string; args: readonly string[] }> = [];
+  const exec: ExecFileSyncFn = (file, args) => {
+    calls.push({ file, args });
+    if (thrown) {
+      const e: any = new Error(thrown.message ?? "exec failed");
+      if (thrown.status != null) e.status = thrown.status;
+      if (thrown.stderr != null) e.stderr = thrown.stderr;
+      throw e;
+    }
+    return Buffer.alloc(0);
+  };
+  return { exec, calls };
+}
+
+describe("attachRemoteSession", () => {
+  test("happy path — builds `ssh -tt <alias> 'tmux attach-session -t <name>'`", () => {
+    const { exec, calls } = makeFakeExec();
+    attachRemoteSession({
+      node: "mba",
+      sshAlias: "mba.wg",
+      sessionName: "24-homekeeper",
+      exec,
+    });
+    expect(calls.length).toBe(1);
+    expect(calls[0].file).toBe("ssh");
+    expect(calls[0].args[0]).toBe("-tt");
+    expect(calls[0].args[1]).toBe("mba.wg");
+    expect(String(calls[0].args[2])).toContain("attach-session -t '24-homekeeper'");
+  });
+
+  test("ssh exit 255 + Connection refused → kind=unreachable, friendly message", () => {
+    const { exec } = makeFakeExec({
+      status: 255,
+      message: "Command failed: ssh -tt mba.wg",
+      stderr: "ssh: connect to host mba.wg port 22: Connection refused\r\n",
+    });
+    try {
+      attachRemoteSession({ node: "mba", sshAlias: "mba.wg", sessionName: "homekeeper", exec });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(SshAttachError);
+      const e = err as SshAttachError;
+      expect(e.kind).toBe("unreachable");
+      expect(e.exitCode).toBe(255);
+      expect(e.message).toContain("can't reach mba");
+      expect(e.message).toContain("ssh mba.wg");
+    }
+  });
+
+  test("ssh exit 255 + Permission denied (publickey) → kind=auth-failed", () => {
+    const { exec } = makeFakeExec({
+      status: 255,
+      message: "Command failed",
+      stderr: "mba.wg: Permission denied (publickey).\r\n",
+    });
+    try {
+      attachRemoteSession({ node: "mba", sshAlias: "mba.wg", sessionName: "homekeeper", exec });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(SshAttachError);
+      const e = err as SshAttachError;
+      expect(e.kind).toBe("auth-failed");
+      expect(e.message).toContain("no SSH key for mba");
+    }
+  });
+
+  test("remote tmux missing → kind=tmux-missing", () => {
+    const { exec } = makeFakeExec({
+      status: 127,
+      message: "Command failed",
+      stderr: "bash: tmux: command not found\r\n",
+    });
+    try {
+      attachRemoteSession({ node: "mba", sshAlias: "mba.wg", sessionName: "homekeeper", exec });
+      throw new Error("expected throw");
+    } catch (err) {
+      const e = err as SshAttachError;
+      expect(e.kind).toBe("tmux-missing");
+      expect(e.message).toContain("tmux not installed on mba");
+    }
+  });
+
+  test("remote session missing → kind=session-missing", () => {
+    const { exec } = makeFakeExec({
+      status: 1,
+      message: "Command failed",
+      stderr: "can't find session: homekeeper\r\n",
+    });
+    try {
+      attachRemoteSession({ node: "mba", sshAlias: "mba.wg", sessionName: "homekeeper", exec });
+      throw new Error("expected throw");
+    } catch (err) {
+      const e = err as SshAttachError;
+      expect(e.kind).toBe("session-missing");
+      expect(e.message).toContain("session 'homekeeper'");
+    }
+  });
+
+  test("unsafe session name is rejected BEFORE exec", () => {
+    const { exec, calls } = makeFakeExec();
+    try {
+      attachRemoteSession({
+        node: "mba",
+        sshAlias: "mba.wg",
+        // Shell-meaningful chars; must be refused at the helper boundary.
+        sessionName: "bad;rm -rf /",
+        exec,
+      });
+      throw new Error("expected throw");
+    } catch (err) {
+      const e = err as SshAttachError;
+      expect(e.kind).toBe("unsafe-name");
+      expect(calls.length).toBe(0);
+    }
+  });
+
+  test("Buffer stderr is decoded for classification", () => {
+    const calls: Array<{ file: string; args: readonly string[] }> = [];
+    const exec: ExecFileSyncFn = (file, args) => {
+      calls.push({ file, args });
+      const e: any = new Error("Command failed");
+      e.status = 255;
+      e.stderr = Buffer.from("Permission denied (publickey).\n", "utf-8");
+      throw e;
+    };
+    try {
+      attachRemoteSession({ node: "mba", sshAlias: "mba.wg", sessionName: "ok-name", exec });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect((err as SshAttachError).kind).toBe("auth-failed");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Extracts the proven `attachViaTmux` pattern from `plugins/view/impl.ts:357` into a reusable helper that powers cross-node `maw a <remote-oracle>` (#1236 Tier 3). Companion PR in maw-plugin-registry wires the attach plugin to it.

- New `src/core/transport/ssh-attach.ts` — `attachRemoteSession({ node, sshAlias, sessionName })` with execFileSync ssh -tt. Classifies failures (unreachable / auth-failed / tmux-missing / session-missing) per cross-node-attach-design §5; never process.exits.
- `core/transport/peers.ts` — `getAggregatedSessions()` now surfaces peer `node` identity alongside `source`. Exported as `AggregatedSession`. Identity fetch is best-effort + parallel with sessions fetch.
- `config/types.ts` — `PeerConfig` gets optional `ssh?: string` for cross-node SSH alias (preferred over URL-hostname / literal node).
- SDK + package.json subpath exports so plugins can `import { attachRemoteSession } from "maw-js/sdk"`.

Tier 4 (remote wake) deferred per the phasing recommendation in the design doc.

## Test plan

- [x] `bun test test/ssh-attach.test.ts` — 7 new tests pass (happy path, 4 failure-classification kinds, unsafe-name guard, Buffer stderr decode)
- [x] `bun test test/peers-session-validation.test.ts test/federation-sync.test.ts test/federation-symmetric.test.ts` — 45 pass, 0 fail; no regressions in the surface I touched
- [x] Full suite baseline matches alpha (326 pre-existing failures on a clean tree, same number with my changes; +7 new passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)