### PR TITLE
feat(peers): list --discovered + accept (#1237, slice 1)

### DIFF
--- a/src/api/pair.ts
+++ b/src/api/pair.ts
@@ -12,6 +12,8 @@ import { randomBytes } from "crypto";
 import { loadConfig } from "../config";
 import { register, lookup, consume, isValidShape, normalize, pretty, generateCode } from "../lib/pair-codes";
 import { cmdAdd } from "../lib/peers/impl";
+import { loadPeers } from "../lib/peers/store";
+import { getCurrentScout } from "../transports/scout";
 
 export const pairApi = new Elysia();
 
@@ -75,6 +77,211 @@ export function recordHelloZid(zid: string): void {
   const cutoff = Date.now() - HELLO_WINDOW_MS;
   for (const [k, v] of recentHellos) {
     if (v < cutoff) recentHellos.delete(k);
+  }
+}
+
+// ─── Discovery snapshot + accept (#1237) ─────────────────────────────────
+//
+// `GET /api/peers/discoveries` exposes the in-memory `ScoutState.discoveredPeers`
+// map so the CLI's `maw peers list --discovered` can render LAN candidates
+// without polling multicast itself.
+//
+// `POST /api/peers/accept` is the operator-facing primitive — given a zid
+// (full or prefix) or a node name, derive the locator URL from the snapshot
+// and call cmdAdd(). Decision #4 of the design (impersonation guard): refuse
+// when the candidate's cached pubkey already pins under a different alias.
+
+interface DiscoveriesQuery { all?: string; limit?: string }
+
+function relSeen(ms: number, now: number): string {
+  const dt = Math.max(0, now - ms);
+  if (dt < 1000) return "now";
+  if (dt < 60_000) return `${Math.floor(dt / 1000)}s ago`;
+  if (dt < 3_600_000) return `${Math.floor(dt / 60_000)}m ago`;
+  if (dt < 86_400_000) return `${Math.floor(dt / 3_600_000)}h ago`;
+  return `${Math.floor(dt / 86_400_000)}d ago`;
+}
+
+pairApi.get("/peers/discoveries", ({ query, set }) => {
+  const scout = getCurrentScout();
+  if (!scout) {
+    // Open question #1 in the design — daemon down OR scout transport not
+    // currently bound (e.g. multicast bind failed). Hard error, no stale
+    // fallback. CLI surfaces this as "discovery unavailable".
+    set.status = 503;
+    return { ok: false, error: "scout_unavailable", hint: "Scout transport not bound — restart `maw serve` or check multicast binding." };
+  }
+  const q = (query ?? {}) as DiscoveriesQuery;
+  const includeAll = q.all === "1" || q.all === "true";
+  const limit = Number.isFinite(Number(q.limit)) && Number(q.limit) > 0
+    ? Math.min(Number(q.limit), 500)
+    : 50;
+
+  const now = Date.now();
+  const all = scout.discoveriesSnapshot();
+  const filtered = includeAll ? all : all.filter(p => !p.paired);
+  const sliced = filtered.slice(0, limit);
+  return {
+    ok: true,
+    total: all.length,
+    shown: sliced.length,
+    filtered: !includeAll,
+    peers: sliced.map(p => ({
+      zid: p.zid,
+      node: p.node,
+      oracle: p.oracle,
+      host: p.host,
+      locators: p.locators,
+      capabilities: p.capabilities,
+      oracles: p.oracles,
+      firstSeen: new Date(p.firstSeen).toISOString(),
+      lastSeen: new Date(p.lastSeen).toISOString(),
+      seenRel: relSeen(p.lastSeen, now),
+      paired: p.paired,
+    })),
+  };
+});
+
+/**
+ * Resolve a candidate by zid (full or shortest unambiguous prefix) or node
+ * name. Mirrors decision #3 of the design — ambiguous prefix returns the
+ * full candidate list so the CLI can render them and abort.
+ */
+function resolveCandidate(id: string, snapshot: ReturnType<NonNullable<ReturnType<typeof getCurrentScout>>["discoveriesSnapshot"]>) {
+  const exactZid = snapshot.find(p => p.zid === id);
+  if (exactZid) return { kind: "match" as const, peer: exactZid };
+  const exactNode = snapshot.filter(p => p.node === id);
+  if (exactNode.length === 1) return { kind: "match" as const, peer: exactNode[0] };
+  if (exactNode.length > 1) return { kind: "ambiguous" as const, candidates: exactNode };
+  const prefixZid = snapshot.filter(p => p.zid.startsWith(id));
+  if (prefixZid.length === 1) return { kind: "match" as const, peer: prefixZid[0] };
+  if (prefixZid.length > 1) return { kind: "ambiguous" as const, candidates: prefixZid };
+  return { kind: "not_found" as const };
+}
+
+pairApi.post("/peers/accept", async ({ body, set }) => {
+  const scout = getCurrentScout();
+  if (!scout) {
+    set.status = 503;
+    return { ok: false, error: "scout_unavailable" };
+  }
+  const b = (body ?? {}) as { id?: string; alias?: string; all?: boolean };
+  const snapshot = scout.discoveriesSnapshot();
+
+  // ─── --all branch: accept every unpaired candidate ────────────────────
+  if (b.all) {
+    const targets = snapshot.filter(p => !p.paired);
+    if (targets.length === 0) return { ok: true, accepted: [], skipped: [], message: "no unpaired discoveries" };
+    const results: Array<{ id: string; ok: boolean; alias?: string; error?: string }> = [];
+    // Open question #3 — concurrency cap matches probe-all (8 parallel).
+    const CONCURRENCY = 8;
+    for (let i = 0; i < targets.length; i += CONCURRENCY) {
+      const batch = targets.slice(i, i + CONCURRENCY);
+      const batchResults = await Promise.all(batch.map(p => acceptOne(p, undefined)));
+      results.push(...batchResults);
+    }
+    return {
+      ok: true,
+      accepted: results.filter(r => r.ok),
+      skipped: results.filter(r => !r.ok),
+    };
+  }
+
+  // ─── Single-target branch ─────────────────────────────────────────────
+  if (!b.id) {
+    set.status = 400;
+    return { ok: false, error: "missing_id", hint: "Pass { id } (zid, zid prefix, or node name) or { all: true }." };
+  }
+  const resolved = resolveCandidate(b.id, snapshot);
+  if (resolved.kind === "not_found") {
+    set.status = 404;
+    return { ok: false, error: "not_found", hint: `No discovered peer matches "${b.id}".` };
+  }
+  if (resolved.kind === "ambiguous") {
+    set.status = 409;
+    return {
+      ok: false,
+      error: "ambiguous",
+      candidates: resolved.candidates.map(c => ({ zid: c.zid, node: c.node, host: c.host })),
+      hint: "Disambiguate with a longer zid prefix or unique node name.",
+    };
+  }
+
+  const result = await acceptOne(resolved.peer, b.alias);
+  if (!result.ok) {
+    set.status = result.status ?? 400;
+    return { ok: false, error: result.error, hint: result.hint };
+  }
+  return { ok: true, alias: result.alias, node: resolved.peer.node, url: result.url };
+});
+
+/**
+ * Inner accept worker — runs the impersonation guard then cmdAdd. Returns a
+ * uniform shape for both single and --all paths.
+ *
+ * Decision #4 (impersonation guard): we probe the candidate's `/api/identity`
+ * via cmdAdd's built-in probe. After the probe (which returns pubkey),
+ * cross-check against every other alias in peers.json: if any other alias
+ * pins this exact pubkey, refuse — the operator is about to give a duplicate
+ * key two different aliases, which is precisely the peer-with-same-name
+ * attack the guard exists to block.
+ */
+async function acceptOne(
+  peer: { zid: string; node: string; oracle: string; locators: string[] },
+  aliasOverride: string | undefined,
+): Promise<{ ok: true; alias: string; url: string } | { ok: false; error: string; hint?: string; status?: number; id: string }> {
+  const id = peer.zid;
+  const url = peer.locators[0];
+  if (!url) return { ok: false, error: "no_locator", hint: "Hello carried no locator URL.", status: 400, id };
+  const alias = aliasOverride ?? peer.node;
+  try {
+    const res = await cmdAdd({ alias, url, node: peer.node });
+    if (res.pubkeyMismatch) {
+      return {
+        ok: false,
+        error: "pubkey_mismatch",
+        hint: `${res.pubkeyMismatch.message} — re-pin via \`maw peers forget ${alias}\` if rotation was intentional.`,
+        status: 409,
+        id,
+      };
+    }
+    // Impersonation guard (decision #4) — same pubkey under different alias.
+    const observedPubkey = res.peer.pubkey;
+    if (observedPubkey) {
+      const allPeers = loadPeers().peers;
+      for (const [otherAlias, p] of Object.entries(allPeers)) {
+        if (otherAlias === alias) continue;
+        if (p.pubkey && p.pubkey === observedPubkey) {
+          // We already wrote `alias` in cmdAdd — back it out so the guard
+          // is genuinely refusal (not "accept-and-warn"). Use mutate to
+          // stay atomic with concurrent peer writes.
+          const { mutatePeers } = await import("../lib/peers/store");
+          mutatePeers((d) => { delete d.peers[alias]; });
+          return {
+            ok: false,
+            error: "impersonation_guard",
+            hint: `pubkey already pins under alias "${otherAlias}". Use --alias <new> if intentional, or \`maw peers forget ${otherAlias}\` if rotating.`,
+            status: 409,
+            id,
+          };
+        }
+      }
+    }
+    if (res.probeError) {
+      // Probe failed but cmdAdd wrote the alias anyway (well-known behavior).
+      // Surface the error but report ok — operator will see lastError on
+      // `peers info`.
+      return { ok: true, alias, url };
+    }
+    return { ok: true, alias, url };
+  } catch (e: unknown) {
+    return {
+      ok: false,
+      error: "add_failed",
+      hint: e instanceof Error ? e.message : String(e),
+      status: 400,
+      id,
+    };
   }
 }
 

--- a/src/transports/scout-state.ts
+++ b/src/transports/scout-state.ts
@@ -16,6 +16,8 @@ export interface DiscoveredPeer {
   locators: string[];
   capabilities: string[];
   oracles: string[];
+  /** Epoch-ms when this zid was first observed (set on insert, never updated). #1237 */
+  firstSeen: number;
   lastSeen: number;
   paired: boolean;
 }
@@ -49,6 +51,7 @@ export class ScoutState {
 
     const existing = this.discoveredPeers.get(hello.zid);
     const isNew = !existing;
+    const now = Date.now();
 
     this.discoveredPeers.set(hello.zid, {
       zid: hello.zid,
@@ -58,7 +61,8 @@ export class ScoutState {
       locators: hello.locators,
       capabilities: hello.capabilities,
       oracles: hello.oracles,
-      lastSeen: Date.now(),
+      firstSeen: existing?.firstSeen ?? now,
+      lastSeen: now,
       paired: existing?.paired ?? false,
     });
 

--- a/src/transports/scout.ts
+++ b/src/transports/scout.ts
@@ -42,6 +42,19 @@ export interface ScoutTransportConfig {
   autoPair?: boolean;
 }
 
+// ─── Module-level singleton for cross-module access (#1237) ────────────────
+// The API layer (src/api/pair.ts) needs to read live `discoveredPeers` for
+// `GET /api/peers/discoveries`. Rather than inject the router into Elysia we
+// expose the *last connected* ScoutTransport via a small accessor. Tests can
+// override with `_setCurrentScout(null)` to clear.
+let currentScout: ScoutTransport | null = null;
+export function getCurrentScout(): ScoutTransport | null {
+  return currentScout;
+}
+export function _setCurrentScout(s: ScoutTransport | null): void {
+  currentScout = s;
+}
+
 export class ScoutTransport implements Transport {
   readonly name = "scout-p2p";
   private _connected = false;
@@ -100,6 +113,7 @@ export class ScoutTransport implements Transport {
       });
 
       this._connected = true;
+      currentScout = this; // #1237 — make this instance reachable from the API layer
       this.scheduleScout();
       this.pruneTimer = setInterval(() => this.pruneStale(), 10_000);
 
@@ -131,6 +145,7 @@ export class ScoutTransport implements Transport {
       this.socket = null;
     }
     this._connected = false;
+    if (currentScout === this) currentScout = null;
   }
 
   async send(target: TransportTarget, message: string): Promise<boolean> {
@@ -205,6 +220,30 @@ export class ScoutTransport implements Transport {
 
   listPeers() {
     return [...this.state.discoveredPeers.values()];
+  }
+
+  /**
+   * Snapshot of discovered peers as plain objects — for HTTP exposure (#1237).
+   * Returned in `lastSeen` desc order. Re-syncs `paired` against the latest
+   * peers.json so a peer added via `peers accept` flips ✓ without waiting
+   * for the next Hello.
+   */
+  discoveriesSnapshot(): import("./scout-state").DiscoveredPeer[] {
+    // Refresh `paired` from on-disk peers.json — cheap (small JSON) and keeps
+    // the snapshot honest immediately after an accept.
+    try {
+      const { peers } = loadPeers();
+      const pairedNodes = new Set<string>();
+      for (const [, p] of Object.entries(peers)) {
+        if (p.node) pairedNodes.add(p.node);
+      }
+      for (const peer of this.state.discoveredPeers.values()) {
+        if (!peer.paired && pairedNodes.has(peer.node)) peer.paired = true;
+      }
+    } catch { /* ignore — best-effort refresh */ }
+
+    return [...this.state.discoveredPeers.values()]
+      .sort((a, b) => b.lastSeen - a.lastSeen);
   }
 
   // ─── Protocol Handlers ─────────────────────────────────────────────

--- a/test/api-peers-discoveries.test.ts
+++ b/test/api-peers-discoveries.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Tests for #1237 — /api/peers/discoveries + /api/peers/accept.
+ *
+ * Hermetic: stubs the scout singleton with an in-memory fake so we don't bind
+ * a real UDP socket, and points PEERS_FILE at a tmp file so cmdAdd writes
+ * land in an isolated store. The probe path is mocked to short-circuit the
+ * /info handshake.
+ */
+import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
+import { Elysia } from "elysia";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+// ─── Stub probe so cmdAdd does not hit the network ──────────────────────
+mock.module("../src/lib/peers/probe", () => ({
+  probePeer: async (url: string) => {
+    // Encode "pubkey collision" scenarios in the URL so individual tests
+    // can drive the impersonation guard. Default behaviour: derive a stable
+    // synthetic pubkey from the URL itself.
+    const u = new URL(url);
+    const pubkey = u.searchParams.get("pubkey") ?? `pk-${u.hostname}-${u.port || "0"}`;
+    return {
+      node: u.hostname,
+      nickname: null,
+      pubkey,
+      identity: { oracle: "mawjs", node: u.hostname },
+      // no error → success
+    };
+  },
+  PROBE_EXIT_CODES: { DNS: 3, REFUSED: 4, TIMEOUT: 5, HTTP_4XX: 6, HTTP_5XX: 6, TLS: 2, BAD_BODY: 2, UNKNOWN: 2 },
+}));
+
+// ─── Fake ScoutTransport singleton ──────────────────────────────────────
+function makeFakeScout(initial: Array<Partial<{
+  zid: string; node: string; host: string; oracle: string;
+  locators: string[]; capabilities: string[]; oracles: string[];
+  firstSeen: number; lastSeen: number; paired: boolean;
+}>>) {
+  const peers = initial.map((p, i) => ({
+    zid: p.zid ?? `zid-${i.toString().padStart(8, "0")}`,
+    node: p.node ?? `node-${i}`,
+    host: p.host ?? "192.168.1." + (10 + i),
+    oracle: p.oracle ?? "mawjs",
+    locators: p.locators ?? [`http://host-${i}:3456`],
+    capabilities: p.capabilities ?? ["pair"],
+    oracles: p.oracles ?? [],
+    firstSeen: p.firstSeen ?? Date.now() - 10000,
+    lastSeen: p.lastSeen ?? Date.now(),
+    paired: p.paired ?? false,
+  }));
+  return {
+    discoveriesSnapshot() {
+      return [...peers].sort((a, b) => b.lastSeen - a.lastSeen);
+    },
+    _peers: peers,
+  };
+}
+
+let scoutSingleton: any = null;
+mock.module("../src/transports/scout", () => ({
+  getCurrentScout: () => scoutSingleton,
+  _setCurrentScout: (s: any) => { scoutSingleton = s; },
+}));
+
+mock.module("../src/config", () => ({
+  loadConfig: () => ({ node: "test-node", port: 3456 }),
+}));
+
+const { pairApi } = await import("../src/api/pair");
+const app = new Elysia({ prefix: "/api" }).use(pairApi);
+
+async function get(path: string) {
+  return app.handle(new Request(`http://localhost${path}`));
+}
+async function post(path: string, body: any) {
+  return app.handle(new Request(`http://localhost${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  }));
+}
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "maw-peers-discov-"));
+  process.env.PEERS_FILE = join(dir, "peers.json");
+  scoutSingleton = null;
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+  delete process.env.PEERS_FILE;
+});
+
+describe("GET /api/peers/discoveries (#1237)", () => {
+  test("503 when scout transport is unbound (open question #1: hard error)", async () => {
+    const res = await get("/api/peers/discoveries");
+    expect(res.status).toBe(503);
+    const body: any = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("scout_unavailable");
+  });
+
+  test("returns sorted snapshot (lastSeen desc) with relative seen string", async () => {
+    scoutSingleton = makeFakeScout([
+      { zid: "aa".repeat(16), node: "old", lastSeen: Date.now() - 60_000 },
+      { zid: "bb".repeat(16), node: "fresh", lastSeen: Date.now() - 1000 },
+    ]);
+    const res = await get("/api/peers/discoveries");
+    expect(res.status).toBe(200);
+    const body: any = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.peers).toHaveLength(2);
+    expect(body.peers[0].node).toBe("fresh");
+    expect(body.peers[1].node).toBe("old");
+    expect(body.peers[0].seenRel).toBeTruthy();
+  });
+
+  test("hides paired by default; --all (?all=1) includes them", async () => {
+    scoutSingleton = makeFakeScout([
+      { zid: "11".repeat(16), node: "a", paired: false },
+      { zid: "22".repeat(16), node: "b", paired: true },
+    ]);
+    const def: any = await (await get("/api/peers/discoveries")).json();
+    expect(def.peers).toHaveLength(1);
+    expect(def.peers[0].node).toBe("a");
+    expect(def.filtered).toBe(true);
+
+    const all: any = await (await get("/api/peers/discoveries?all=1")).json();
+    expect(all.peers).toHaveLength(2);
+    expect(all.filtered).toBe(false);
+  });
+
+  test("--limit caps result count", async () => {
+    scoutSingleton = makeFakeScout(
+      Array.from({ length: 60 }, (_, i) => ({ zid: i.toString(16).padStart(32, "0"), node: `n${i}` })),
+    );
+    const r: any = await (await get("/api/peers/discoveries?limit=5")).json();
+    expect(r.peers).toHaveLength(5);
+    expect(r.total).toBe(60);
+  });
+});
+
+describe("POST /api/peers/accept (#1237)", () => {
+  test("400 when neither id nor all is provided", async () => {
+    scoutSingleton = makeFakeScout([{ zid: "aa".repeat(16), node: "a" }]);
+    const res = await post("/api/peers/accept", {});
+    expect(res.status).toBe(400);
+    const body: any = await res.json();
+    expect(body.error).toBe("missing_id");
+  });
+
+  test("503 when scout is unbound", async () => {
+    const res = await post("/api/peers/accept", { id: "anything" });
+    expect(res.status).toBe(503);
+  });
+
+  test("404 when no candidate matches the id", async () => {
+    scoutSingleton = makeFakeScout([{ zid: "aa".repeat(16), node: "a" }]);
+    const res = await post("/api/peers/accept", { id: "ghost" });
+    expect(res.status).toBe(404);
+  });
+
+  test("accepts by node name → writes peers.json entry", async () => {
+    scoutSingleton = makeFakeScout([{
+      zid: "ab".repeat(16),
+      node: "mba",
+      locators: ["http://10.0.0.5:3456"],
+    }]);
+    const res = await post("/api/peers/accept", { id: "mba" });
+    expect(res.status).toBe(200);
+    const body: any = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.alias).toBe("mba");
+
+    const { loadPeers } = await import("../src/lib/peers/store");
+    expect(loadPeers().peers.mba?.url).toBe("http://10.0.0.5:3456");
+  });
+
+  test("accepts by zid prefix when unambiguous", async () => {
+    scoutSingleton = makeFakeScout([
+      { zid: "ab" + "0".repeat(30), node: "alpha", locators: ["http://10.0.0.6:3456"] },
+      { zid: "cd" + "0".repeat(30), node: "bravo", locators: ["http://10.0.0.7:3456"] },
+    ]);
+    const res = await post("/api/peers/accept", { id: "ab" });
+    expect(res.status).toBe(200);
+    const body: any = await res.json();
+    expect(body.alias).toBe("alpha");
+  });
+
+  test("409 when zid prefix is ambiguous → returns candidate list", async () => {
+    scoutSingleton = makeFakeScout([
+      { zid: "ab" + "1".repeat(30), node: "a1" },
+      { zid: "ab" + "2".repeat(30), node: "a2" },
+    ]);
+    const res = await post("/api/peers/accept", { id: "ab" });
+    expect(res.status).toBe(409);
+    const body: any = await res.json();
+    expect(body.error).toBe("ambiguous");
+    expect(body.candidates).toHaveLength(2);
+  });
+
+  test("--alias override is honored", async () => {
+    scoutSingleton = makeFakeScout([{
+      zid: "ee".repeat(16),
+      node: "white",
+      locators: ["http://10.0.0.8:3456"],
+    }]);
+    const res = await post("/api/peers/accept", { id: "white", alias: "snow" });
+    const body: any = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.alias).toBe("snow");
+
+    const { loadPeers } = await import("../src/lib/peers/store");
+    expect(loadPeers().peers.snow).toBeDefined();
+    expect(loadPeers().peers.white).toBeUndefined();
+  });
+
+  test("impersonation guard (decision #4) — refuses when pubkey already pins under a different alias", async () => {
+    // Seed: alias "ghost" already pins pubkey pk-evil-3456.
+    const { savePeers } = await import("../src/lib/peers/store");
+    savePeers({
+      version: 1,
+      peers: {
+        ghost: {
+          url: "http://evil:3456",
+          node: "evil",
+          addedAt: new Date().toISOString(),
+          lastSeen: new Date().toISOString(),
+          pubkey: "pk-evil-3456",
+          pubkeyFirstSeen: new Date().toISOString(),
+        },
+      },
+    });
+
+    // Discovery announces a NEW peer that probes to the SAME pubkey.
+    scoutSingleton = makeFakeScout([{
+      zid: "ff".repeat(16),
+      node: "evil",
+      locators: ["http://evil:3456"], // probePeer stub keys off hostname:port → pk-evil-3456
+    }]);
+
+    const res = await post("/api/peers/accept", { id: "evil", alias: "twin" });
+    expect(res.status).toBe(409);
+    const body: any = await res.json();
+    expect(body.error).toBe("impersonation_guard");
+    expect(body.hint).toContain("ghost");
+
+    // Guard must be a true refusal — no `twin` left behind on disk.
+    const { loadPeers } = await import("../src/lib/peers/store");
+    expect(loadPeers().peers.twin).toBeUndefined();
+  });
+
+  test("--all accepts every unpaired candidate in parallel", async () => {
+    scoutSingleton = makeFakeScout([
+      { zid: "11".repeat(16), node: "n1", locators: ["http://1.2.3.1:3456"], paired: false },
+      { zid: "22".repeat(16), node: "n2", locators: ["http://1.2.3.2:3456"], paired: false },
+      { zid: "33".repeat(16), node: "n3", locators: ["http://1.2.3.3:3456"], paired: true }, // skipped
+    ]);
+    const res = await post("/api/peers/accept", { all: true });
+    expect(res.status).toBe(200);
+    const body: any = await res.json();
+    expect(body.accepted).toHaveLength(2);
+    expect(body.accepted.map((r: any) => r.alias).sort()).toEqual(["n1", "n2"]);
+
+    const { loadPeers } = await import("../src/lib/peers/store");
+    expect(Object.keys(loadPeers().peers).sort()).toEqual(["n1", "n2"]);
+  });
+});


### PR DESCRIPTION
## Summary
- `GET /api/peers/discoveries` and `POST /api/peers/accept` expose the in-memory Scout discovery map so operators can list LAN candidates and accept them without re-implementing multicast in the CLI.
- Applies the impersonation guard from decision #4 of the design (`ψ/learn/peers-discovered-design.md`): refuses + rolls back the write if the candidate's pubkey already pins under a different alias.
- Adds `firstSeen` to `DiscoveredPeer` and a small `getCurrentScout` singleton so the API layer can read the live scout state.

## Scope (slice 1)
Implements decisions 1, 2, 3, 4, 5 of the design. **Deferred** to a follow-up (per the design's "Recommendation" + team-lead constraints):
- Decision #6 — `peers.autoAccept` config field
- `maw peers auto-pair on/off/status` runtime toggle

## Test plan
- [x] `MAW_TEST_MODE=1 bun test test/api-peers-discoveries.test.ts` — 13 cases (decision tree, --all, impersonation guard refusal-with-rollback, prefix ambiguity, alias override, 503 unbound)
- [x] `MAW_TEST_MODE=1 bun test src/transports/` — 44 scout-* tests still green
- [x] Full suite (1620 tests): 15 pre-existing failures (tmux/fleet-adopt/bootstrap/nicknames — unrelated, pass in isolation, confirmed via `git stash`); 1597 pass, 0 new failures from this PR.

## Related
- Design: `ψ/learn/peers-discovered-design.md` (mawjs-oracle)
- Plugin-registry side (CLI surface): companion PR in maw-plugin-registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)