### PR TITLE
release: v26.5.13-alpha.208

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.13-alpha.114",
+  "version": "26.5.13-alpha.208",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Bundles 4 PRs merged to alpha since v26.5.13-alpha.114:
- #1258 ci(test-isolated) — shard 8-way for ~8x speedup
- #1259 docker test fix (#1255)
- #1260 ssh-attach helper for cross-node (#1236 Tier 3 prep)
- #1261 peers list --discovered + accept API (#1237, slice 1)

Cuts v26.5.13-alpha.208 on merge via calver-release.yml.