### PR TITLE
ci: simplify test-isolated job name (drop /8 suffix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,9 @@ jobs:
       fail-fast: false
       matrix:
         shard: [1, 2, 3, 4, 5, 6, 7, 8]
-    name: test-isolated (${{ matrix.shard }}/8)
+    # No explicit `name:` — GitHub's default matrix naming is `test-isolated (N)`
+    # which renders cleanly in the PR checks list. The previous explicit
+    # `test-isolated (${{ matrix.shard }}/8)` form was noisier.
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Drop the explicit `name: test-isolated (${{ matrix.shard }}/8)` template — GitHub's default matrix naming is shorter and matches the rest of the repo's conventions.

PR checks list before: 8 rows of `test-isolated (1/8)`, `test-isolated (2/8)`, ...
After: 8 rows of `test-isolated (1)`, `test-isolated (2)`, ...

Follow-up to #1258 (the original 8-way shard PR).