### PR TITLE
release: v26.5.13-alpha.318

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.13-alpha.208",
+  "version": "26.5.13-alpha.318",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts v26.5.13-alpha.318 on merge via calver-release.yml.

Bundles 2 commits since alpha.208:
- #1263 fix(#1252): install maw-plugin-registry in docker image
- #1264 ci: simplify test-isolated job name (drop /8 suffix)

Auto-generated by /release-alpha.