### PR TITLE
feat(plugin-install): dispatch bare owner/repo registry source format (refs plugin-registry#4)

### DIFF
--- a/src/commands/plugins/plugin/registry-resolve.ts
+++ b/src/commands/plugins/plugin/registry-resolve.ts
@@ -8,8 +8,11 @@
  * Supported source forms:
  *   • npm:NAME                          → https://registry.npmjs.org/NAME/-/<basename>-<version>.tgz
  *   • github:OWNER/REPO#REF             → https://github.com/OWNER/REPO/archive/refs/tags/REF.tar.gz
+ *   • owner/repo[/subpath][@ref]        → pass-through; `detectMode` routes to installFromGithub
+ *                                         (maw-plugin-registry#4 — Vercel-style bare github source;
+ *                                         the canonical replacement for `monorepo:`)
  *   • monorepo:plugins/<name>@<tag>     → pass-through; `detectMode` routes to installFromMonorepo
- *                                         (registry#2 — maw-plugin-registry monorepo subdirs)
+ *                                         (DEPRECATED — registry#2 legacy; see maw-plugin-registry#4)
  *   • https://URL.tgz (or .tar.gz)      → pass-through
  *
  * Returns null when the plugin isn't in the registry — callers should suggest
@@ -17,9 +20,12 @@
  */
 
 import type { RegistryManifest } from "./registry-fetch";
-import { parseMonorepoRef } from "./install-source-detect";
+import {
+  parseMonorepoRef,
+  parseGithubRef as parseBareGithubRef,
+} from "./install-source-detect";
 
-export type SourceKind = "npm" | "github" | "https" | "monorepo";
+export type SourceKind = "npm" | "github" | "github-bare" | "https" | "monorepo";
 
 export interface ResolvedSource {
   kind: SourceKind;
@@ -90,11 +96,26 @@ export function resolvePluginSource(
   // monorepo: passthrough — the install dispatcher (detectMode →
   // installFromMonorepo) handles URL construction and subpath walk.
   if (parseMonorepoRef(raw)) {
+    console.warn(
+      `WARN: monorepo: source format is deprecated, will be removed in v26.6.x. ` +
+      `Migration: maw-plugin-registry#4. (plugin '${name}', source: ${raw})`,
+    );
     return { kind: "monorepo", source: raw, ...common };
   }
 
   if (/^https?:\/\/.+\.(tgz|tar\.gz)(\?.*)?$/i.test(raw)) {
     return { kind: "https", source: raw, ...common };
+  }
+
+  // Vercel-style bare github source — `owner/repo[/subpath][@ref]` (maw-plugin-registry#4).
+  // Pass through verbatim: `detectMode` parses it via the same `parseGithubRef`
+  // and dispatches to `installFromGithub`, which honors subpath + ref.
+  //
+  // Run LAST so explicit `npm:` / `github:` / `monorepo:` / `https://` prefixes
+  // take precedence — `parseGithubRef` deliberately rejects those shapes, but
+  // ordering documents the contract.
+  if (parseBareGithubRef(raw)) {
+    return { kind: "github-bare", source: raw, ...common };
   }
 
   throw new Error(`registry entry '${name}' has unrecognized source: ${JSON.stringify(raw)}`);

--- a/test/registry-resolve.test.ts
+++ b/test/registry-resolve.test.ts
@@ -104,4 +104,42 @@ describe("resolvePluginSource", () => {
     expect(() => resolvePluginSource("foo", manifestWith("git+ssh://weird")))
       .toThrow(/unrecognized source/);
   });
+
+  // ─── bare owner/repo[/subpath][@ref] (maw-plugin-registry#4) ─────────────
+  it("resolves bare owner/repo/subpath@ref (canonical new format)", () => {
+    const r = resolvePluginSource(
+      "foo",
+      manifestWith("soul-brews-studio/maw-plugin-registry/bg@v0.1.2-bg"),
+    )!;
+    expect(r.kind).toBe("github-bare");
+    // Passthrough — detectMode parses it via parseGithubRef and dispatches to
+    // installFromGithub, which honors the subpath + ref.
+    expect(r.source).toBe("soul-brews-studio/maw-plugin-registry/bg@v0.1.2-bg");
+    expect(r.version).toBe("1.2.3");
+  });
+
+  it("resolves bare owner/repo@ref (own-repo, no subpath)", () => {
+    const r = resolvePluginSource("foo", manifestWith("some-org/their-plugin@v1.0.0"))!;
+    expect(r.kind).toBe("github-bare");
+    expect(r.source).toBe("some-org/their-plugin@v1.0.0");
+  });
+
+  it("legacy monorepo: still resolves (with deprecation warning)", () => {
+    const origWarn = console.warn;
+    const warnings: string[] = [];
+    console.warn = (...a: unknown[]) => { warnings.push(a.map(String).join(" ")); };
+    try {
+      const r = resolvePluginSource(
+        "foo",
+        manifestWith("monorepo:plugins/shellenv@v0.1.2-shellenv"),
+      )!;
+      expect(r.kind).toBe("monorepo");
+      expect(r.source).toBe("monorepo:plugins/shellenv@v0.1.2-shellenv");
+      expect(warnings.length).toBe(1);
+      expect(warnings[0]).toMatch(/deprecated/);
+      expect(warnings[0]).toMatch(/maw-plugin-registry#4/);
+    } finally {
+      console.warn = origWarn;
+    }
+  });
 });


### PR DESCRIPTION
## Summary

The maw-plugin-registry is migrating registry entries from
`monorepo:plugins/<name>@<tag>` to the Vercel-style bare
`owner/repo[/subpath][@ref]` source format ([maw-plugin-registry#4](https://github.com/Soul-Brews-Studio/maw-plugin-registry/issues/4)). **70 of 72 entries** are already in the new format, but the maw-js resolver (`registry-resolve.ts`) only dispatched `npm:` / `github:OWNER/REPO#REF` / `monorepo:` / `https://` source prefixes — new registry entries fell through to the "unrecognized source" throw and would fail to install.

## Changes

- `resolvePluginSource()` now recognizes bare `owner/repo[/subpath][@ref]` via `parseGithubRef` (the Vercel-style parser already shipped in #939 at `install-source-detect.ts:55-107` — reused, not re-implemented). Source is passed through verbatim; `detectMode` re-parses downstream and dispatches to `installFromGithub`, which honors subpath + ref. Returned as new `kind: "github-bare"` to disambiguate from legacy `kind: "github"` (which translates to a tarball URL).
- `monorepo:` branch now emits a deprecation `console.warn` pointing to maw-plugin-registry#4. Format still works — to be removed in v26.6.x.
- Tests cover both new-format shapes (with subpath: `soul-brews-studio/maw-plugin-registry/bg@v0.1.2-bg`; without: `some-org/their-plugin@v1.0.0`) and verify the legacy `monorepo:` path still resolves with a deprecation warning.

## Test plan

- [x] `bun test test/registry-resolve.test.ts` — 17 pass, 0 fail (3 new tests)
- [x] `bun test src/commands/plugins/plugin/install-source-detect.test.ts test/registry-resolve.test.ts test/registry-fetch.test.ts test/plugin-install-url-validation.test.ts test/plugin-registry.test.ts` — 138 pass, 0 fail (no regressions)
- [ ] Smoke-test against a real registry entry in new format (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)