### PR TITLE
release: v26.5.13-alpha.356

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.13-alpha.318",
+  "version": "26.5.13-alpha.356",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts v26.5.13-alpha.356 on merge via calver-release.yml.

Bundles 1 commit since alpha.318:
- #1266 feat(plugin-install): dispatch bare owner/repo registry source format

Auto-generated by /release-alpha.