### PR TITLE
feat(pane): unified maw pane plugin — split/kill/peek/list (#1269)

### DIFF
--- a/src/commands/plugins/pane/index.ts
+++ b/src/commands/plugins/pane/index.ts
@@ -1,0 +1,181 @@
+/**
+ * `maw pane` — unified pane control plugin (#1269).
+ *
+ * Subcommands:
+ *   maw pane split [-h|-v] [-p PERCENT] [-t SESSION:WINDOW] [<command>]
+ *   maw pane kill <pane-ref> [--force]
+ *   maw pane peek <pane-ref> [--lines N] [--history]
+ *   maw pane list [SESSION] [--all] [--json] [--compact] [-v|--verbose]
+ *
+ * Pane-ref forms (canonical maw resolver — same as `maw tmux peek`):
+ *   - %N                  → tmux pane id
+ *   - session:window.pane → fully-qualified path
+ *   - team-agent name     → looked up via ~/.claude/teams/* /config.json
+ *   - bare session name   → pane 0 of that session
+ *
+ * This plugin is a THIN FACADE — every verb delegates to existing helpers
+ * in `tmux/impl.ts`. We never re-implement pane-ref resolution, pct
+ * validation, fleet-safety gating, or buffer capture.
+ */
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { parseFlags } from "../../../cli/parse-args";
+import { cmdPaneSplit } from "./split";
+import { cmdPaneKill } from "./kill";
+import { cmdPanePeek } from "./peek";
+import { cmdPaneList } from "./list";
+
+export const command = {
+  name: "pane",
+  description: "Unified pane control — split, kill, peek, list (#1269).",
+};
+
+function printUsage(): void {
+  console.log("usage: maw pane <split|kill|peek|list> [args]");
+  console.log("  split [-h|-v] [-p PCT] [-t SESSION:WINDOW] [<command>]");
+  console.log("  kill <pane-ref> [--force]");
+  console.log("  peek <pane-ref> [--lines N] [--history]");
+  console.log("  list [SESSION] [--all] [--json] [-v|--verbose]");
+  console.log("");
+  console.log("pane-ref: %N | session:w.p | team-agent name | session name");
+}
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: unknown[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: unknown[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+
+  try {
+    const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+    const sub = args[0]?.toLowerCase();
+
+    if (!sub || sub === "--help" || sub === "-h") {
+      printUsage();
+      return { ok: true, output: logs.join("\n") || undefined };
+    }
+
+    if (sub === "split") {
+      // Per #1269: -h is horizontal (side-by-side), -v is vertical (stacked).
+      // -p is percentage, -t is target session:window. Positional remainder
+      // is the command to run in the new pane.
+      const flags = parseFlags(args, {
+        "--horizontal": Boolean, "-h": "--horizontal",
+        "--vertical":   Boolean, "-v": "--vertical",
+        "--pct":        Number,  "-p": "--pct",
+        "--target":     String,  "-t": "--target",
+        "--help":       Boolean,
+      }, 1);
+
+      if (flags["--help"]) {
+        console.log("usage: maw pane split [-h|-v] [-p PCT] [-t SESSION:WINDOW] [<command>]");
+        console.log("  -h, --horizontal   side-by-side split (default)");
+        console.log("  -v, --vertical     stacked top/bottom split");
+        console.log("  -p, --pct N        new-pane size percent (1-99, default 50)");
+        console.log("  -t, --target REF   pane/window to split (default: $TMUX_PANE)");
+        console.log("");
+        console.log("examples:");
+        console.log("  maw pane split -h -p 30 \"tail -f log.txt\"");
+        console.log("  maw pane split -v -t mawjs-view \"bash -c 'CMD; read -n1'\"");
+        return { ok: true, output: logs.join("\n") || undefined };
+      }
+
+      const command = (flags._ as string[]).join(" ");
+      await cmdPaneSplit(command, {
+        horizontal: !!flags["--horizontal"],
+        vertical:   !!flags["--vertical"],
+        pct:        flags["--pct"] as number | undefined,
+        target:     flags["--target"] as string | undefined,
+      });
+
+    } else if (sub === "kill") {
+      const flags = parseFlags(args, {
+        "--force": Boolean,
+        "--help":  Boolean, "-h": "--help",
+      }, 1);
+
+      if (flags["--help"]) {
+        console.log("usage: maw pane kill <pane-ref> [--force]");
+        console.log("  --force   bypass fleet/view session refusal");
+        return { ok: true, output: logs.join("\n") || undefined };
+      }
+
+      const ref = (flags._ as string[])[0];
+      if (!ref) {
+        console.log("usage: maw pane kill <pane-ref> [--force]");
+        return { ok: false, error: "pane-ref required", output: logs.join("\n") };
+      }
+      await cmdPaneKill(ref, { force: !!flags["--force"] });
+
+    } else if (sub === "peek") {
+      const flags = parseFlags(args, {
+        "--lines":   Number,
+        "--history": Boolean,
+        "--help":    Boolean, "-h": "--help",
+      }, 1);
+
+      if (flags["--help"]) {
+        console.log("usage: maw pane peek <pane-ref> [--lines N] [--history]");
+        console.log("  --lines N    lines from bottom (default 30)");
+        console.log("  --history    full scrollback (overrides --lines)");
+        return { ok: true, output: logs.join("\n") || undefined };
+      }
+
+      const ref = (flags._ as string[])[0];
+      if (!ref) {
+        console.log("usage: maw pane peek <pane-ref> [--lines N] [--history]");
+        return { ok: false, error: "pane-ref required", output: logs.join("\n") };
+      }
+      await cmdPanePeek(ref, {
+        lines: flags["--lines"] as number | undefined,
+        history: !!flags["--history"],
+      });
+
+    } else if (sub === "list" || sub === "ls") {
+      const flags = parseFlags(args, {
+        "--all":     Boolean, "-a": "--all",
+        "--json":    Boolean,
+        "--compact": Boolean,
+        "--verbose": Boolean, "-v": "--verbose",
+        "--help":    Boolean, "-h": "--help",
+      }, 1);
+
+      if (flags["--help"]) {
+        console.log("usage: maw pane list [SESSION] [--all] [--json] [-v|--verbose]");
+        console.log("  SESSION       filter to one session (positional)");
+        console.log("  --all, -a     all sessions (default: current $TMUX session)");
+        console.log("  --json        JSON output");
+        console.log("  -v, --verbose full per-pane detail");
+        return { ok: true, output: logs.join("\n") || undefined };
+      }
+
+      const session = (flags._ as string[])[0];
+      await cmdPaneList({
+        session: session || undefined,
+        all: !!flags["--all"],
+        json: !!flags["--json"],
+        compact: !!flags["--compact"],
+        verbose: !!flags["--verbose"],
+      });
+
+    } else {
+      console.log(`unknown pane subcommand: ${sub}`);
+      printUsage();
+      return { ok: false, error: `unknown subcommand: ${sub}`, output: logs.join("\n") };
+    }
+
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, error: msg, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/src/commands/plugins/pane/kill.ts
+++ b/src/commands/plugins/pane/kill.ts
@@ -1,0 +1,21 @@
+/**
+ * `maw pane kill <pane-ref>` — kill a single pane (not session).
+ *
+ * Per #1269, this is the granular counterpart to `maw kill` (which targets
+ * whole sessions). Always pane-only — to kill a session, use `maw kill` or
+ * `maw tmux kill --session`.
+ *
+ * Delegates to `cmdTmuxKill` (without --session) so fleet/view safety still
+ * applies — the underlying helper refuses fleet/view targets unless --force.
+ */
+import { cmdTmuxKill } from "../tmux/impl";
+
+export interface PaneKillOpts {
+  /** Bypass fleet/view session refusal. */
+  force?: boolean;
+}
+
+export async function cmdPaneKill(ref: string, opts: PaneKillOpts = {}): Promise<void> {
+  if (!ref) throw new Error("pane-ref required (try: %N, session:w.p, or team-agent name)");
+  await cmdTmuxKill(ref, { force: !!opts.force, session: false });
+}

--- a/src/commands/plugins/pane/list.ts
+++ b/src/commands/plugins/pane/list.ts
@@ -1,0 +1,87 @@
+/**
+ * `maw pane list [SESSION]` — list panes (mirrors `maw panes` plural).
+ *
+ * Per #1269, this delegates to `cmdTmuxLs` — the canonical pane-listing
+ * implementation that powers `maw ls`, `maw panes`, and `maw tmux ls`.
+ *
+ * Behavior:
+ *   - no SESSION arg → current session only (matches `maw tmux ls` default)
+ *   - SESSION arg    → filter to that session (post-filtered after --all scan,
+ *                      since cmdTmuxLs's "current session" auto-detection
+ *                      uses $TMUX rather than an explicit session name)
+ *   - --all          → every session
+ *   - --json         → JSON output for scripting
+ *   - -v|--verbose   → full per-pane detail
+ *
+ * Open question (called out in PR body): `maw pane list` overlaps with
+ * `maw panes` (which itself is a top-level alias for the panes plugin in
+ * maw-plugin-registry). For now `maw pane list` re-uses cmdTmuxLs directly
+ * — same output shape, simpler subset.
+ */
+import { cmdTmuxLs, type TmuxLsOpts } from "../tmux/impl";
+
+export interface PaneListOpts {
+  /** Filter to a specific session name. When set, implies --all-scope scan + post-filter. */
+  session?: string;
+  /** All sessions, not just current. */
+  all?: boolean;
+  /** JSON output. */
+  json?: boolean;
+  /** Compact one-line-per-session output. */
+  compact?: boolean;
+  /** Full per-pane detail. Overrides --compact. */
+  verbose?: boolean;
+}
+
+export async function cmdPaneList(opts: PaneListOpts = {}): Promise<void> {
+  // If a session filter was requested, force an --all scan so we can see
+  // panes outside the current $TMUX session, then let cmdTmuxLs's natural
+  // filter via TARGET prefix handle it. Since cmdTmuxLs doesn't accept a
+  // session-filter option directly, we fake it by setting $TMUX-via-display
+  // semantics — but easier: when session is set, just force --all. Per-session
+  // filter granularity is the open question called out in the PR body.
+  const lsOpts: TmuxLsOpts = {
+    all: !!opts.all || !!opts.session,
+    json: !!opts.json,
+    compact: !!opts.compact,
+    verbose: !!opts.verbose,
+  };
+
+  if (!opts.session) {
+    await cmdTmuxLs(lsOpts);
+    return;
+  }
+
+  // Session filter: capture cmdTmuxLs JSON output and filter, then re-render.
+  // Simplest correct path: force JSON, parse, filter, print rows.
+  const captured: string[] = [];
+  const origLog = console.log;
+  console.log = (...a: unknown[]) => captured.push(a.map(String).join(" "));
+  try {
+    await cmdTmuxLs({ ...lsOpts, json: true });
+  } finally {
+    console.log = origLog;
+  }
+
+  let parsed: Array<{ target: string; [k: string]: unknown }>;
+  try {
+    parsed = JSON.parse(captured.join("\n"));
+  } catch {
+    // Fallback: print raw output if JSON parse fails (shouldn't happen).
+    console.log(captured.join("\n"));
+    return;
+  }
+
+  const filtered = parsed.filter(p => p.target.startsWith(`${opts.session}:`));
+  if (opts.json) {
+    console.log(JSON.stringify(filtered, null, 2));
+    return;
+  }
+  if (filtered.length === 0) {
+    console.log(`\x1b[90mNo panes in session '${opts.session}'.\x1b[0m`);
+    return;
+  }
+  for (const p of filtered) {
+    console.log(`  ${p.target}  ${p.command ?? ""}  ${p.annotation ?? ""}`);
+  }
+}

--- a/src/commands/plugins/pane/peek.ts
+++ b/src/commands/plugins/pane/peek.ts
@@ -1,0 +1,16 @@
+/**
+ * `maw pane peek <pane-ref>` — alias to `maw tmux peek`.
+ *
+ * Per #1269, this is a thin re-export so `maw pane peek` behaves identically
+ * to the existing `maw tmux peek` (which itself is the canonical pane-content
+ * reader). No reimplementation — same resolver, same buffer-capture, same
+ * `--lines`/`--history` semantics.
+ */
+import { cmdTmuxPeek, type TmuxPeekOpts } from "../tmux/impl";
+
+export type PanePeekOpts = TmuxPeekOpts;
+
+export async function cmdPanePeek(ref: string, opts: PanePeekOpts = {}): Promise<void> {
+  if (!ref) throw new Error("pane-ref required (try: %N, session:w.p, or team-agent name)");
+  await cmdTmuxPeek(ref, opts);
+}

--- a/src/commands/plugins/pane/plugin.json
+++ b/src/commands/plugins/pane/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "pane",
+  "version": "0.1.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Unified pane control — split, kill, peek, list. Thin facade over tmux helpers (#1269).",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "pane",
+    "help": "maw pane <split|kill|peek|list> — unified pane control"
+  },
+  "weight": 10
+}

--- a/src/commands/plugins/pane/split.ts
+++ b/src/commands/plugins/pane/split.ts
@@ -1,0 +1,68 @@
+/**
+ * `maw pane split` — split a tmux pane and run a command in the new one.
+ *
+ * Per #1269 proposal:
+ *   maw pane split [-h|-v] [-p PERCENT] [-t SESSION:WINDOW] <command>
+ *
+ * Differences from `maw tmux split` (which is the lower-level primitive):
+ *   - target is a `-t` FLAG (defaults to $TMUX_PANE), not a positional
+ *   - command is POSITIONAL (default: open a shell)
+ *   - `-h` is horizontal (side-by-side), `-v` is vertical (stacked) — same
+ *     as raw tmux's split-window orientation flags
+ *
+ * Delegates the actual tmux invocation to `cmdTmuxSplit` so we never re-implement
+ * pane-ref resolution or pct validation.
+ */
+import { cmdTmuxSplit } from "../tmux/impl";
+
+export interface PaneSplitOpts {
+  /** Horizontal split (side-by-side). Mutually exclusive with vertical. */
+  horizontal?: boolean;
+  /** Vertical split (stacked top/bottom). Mutually exclusive with horizontal. */
+  vertical?: boolean;
+  /** Size percent (1-99). Default 50. */
+  pct?: number;
+  /** Target pane/window to split. Default: $TMUX_PANE (current pane). */
+  target?: string;
+}
+
+/**
+ * Run `tmux split-window` on a target, optionally with a command in the new pane.
+ *
+ * Resolution rules — see `resolveTmuxTarget` in tmux/impl.ts:
+ *   - "%N" pane id        → as-is
+ *   - "session:window.pane" → as-is
+ *   - team-agent name     → resolved via team config
+ *   - bare session name   → first pane of session
+ *
+ * @param command   command to run in the new pane (empty → login shell)
+ * @param opts      orientation, pct, target
+ */
+export async function cmdPaneSplit(command: string, opts: PaneSplitOpts = {}): Promise<void> {
+  if (!process.env.TMUX && !opts.target) {
+    throw new Error("maw pane split requires either an active tmux session ($TMUX) or an explicit -t target");
+  }
+
+  if (opts.horizontal && opts.vertical) {
+    throw new Error("-h and -v are mutually exclusive");
+  }
+
+  // Default target = caller's pane (anchors split to where the user typed
+  // the command, matching the implicit behavior of raw `tmux split-window`
+  // — but explicit so concurrent splits don't drift).
+  const target = opts.target ?? process.env.TMUX_PANE ?? "";
+  if (!target) {
+    throw new Error("no target — pass -t SESSION:WINDOW or run inside a tmux pane");
+  }
+
+  // Default vertical=false (= horizontal). `-h` is the default tmux orientation
+  // semantically (left/right split-window without a flag is `-h`); we keep it.
+  // If the user passed `-v` we honor it.
+  const vertical = !!opts.vertical;
+
+  await cmdTmuxSplit(target, {
+    vertical,
+    pct: opts.pct,
+    cmd: command || undefined,
+  });
+}

--- a/test/plugins/pane.test.ts
+++ b/test/plugins/pane.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Tests for `maw pane` plugin (#1269).
+ *
+ * Strategy: thin facade — we test that
+ *   1. The handler routes subcommands correctly (split/kill/peek/list).
+ *   2. Each subcommand wrapper validates inputs before delegating.
+ *   3. Delegation reaches the underlying tmux helpers with the right args.
+ *
+ * For (3) we mock ssh.ts via the canonical helper so `hostExec` captures
+ * the exact tmux command string — same approach as `tmux.test.ts`.
+ */
+import { describe, test, expect, beforeEach, mock } from "bun:test";
+import { mockSshModule } from "../helpers/mock-ssh";
+import { mockConfigModule } from "../helpers/mock-config";
+
+// Capture all tmux commands shelled out
+let commands: string[] = [];
+let nextResult = "";
+
+mock.module("../../src/config", () => mockConfigModule(() => ({ host: "white.local" })));
+
+function installSshMock() {
+  mock.module("../../src/core/transport/ssh", () => mockSshModule({
+    hostExec: async (cmd: string) => {
+      commands.push(cmd);
+      return nextResult;
+    },
+    ssh: async (cmd: string) => {
+      commands.push(cmd);
+      return nextResult;
+    },
+  }));
+}
+installSshMock();
+
+beforeEach(() => {
+  commands = [];
+  nextResult = "";
+  installSshMock();
+});
+
+// ── Handler dispatch ────────────────────────────────────────────────────────
+
+describe("pane handler — dispatch", () => {
+  test("no args → prints usage, returns ok", async () => {
+    const handler = (await import("../../src/commands/plugins/pane/index")).default;
+    const res = await handler({ source: "cli", args: [] });
+    expect(res.ok).toBe(true);
+    expect(res.output).toContain("usage: maw pane");
+    expect(res.output).toContain("split");
+    expect(res.output).toContain("kill");
+    expect(res.output).toContain("peek");
+    expect(res.output).toContain("list");
+  });
+
+  test("--help → prints usage, returns ok", async () => {
+    const handler = (await import("../../src/commands/plugins/pane/index")).default;
+    const res = await handler({ source: "cli", args: ["--help"] });
+    expect(res.ok).toBe(true);
+    expect(res.output).toContain("usage: maw pane");
+  });
+
+  test("unknown subcommand → returns ok:false with error", async () => {
+    const handler = (await import("../../src/commands/plugins/pane/index")).default;
+    const res = await handler({ source: "cli", args: ["bogus"] });
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain("unknown subcommand");
+    expect(res.error).toContain("bogus");
+  });
+
+  test("split --help → prints split usage", async () => {
+    const handler = (await import("../../src/commands/plugins/pane/index")).default;
+    const res = await handler({ source: "cli", args: ["split", "--help"] });
+    expect(res.ok).toBe(true);
+    expect(res.output).toContain("maw pane split");
+    expect(res.output).toContain("-h, --horizontal");
+    expect(res.output).toContain("-v, --vertical");
+  });
+
+  test("kill --help → prints kill usage", async () => {
+    const handler = (await import("../../src/commands/plugins/pane/index")).default;
+    const res = await handler({ source: "cli", args: ["kill", "--help"] });
+    expect(res.ok).toBe(true);
+    expect(res.output).toContain("maw pane kill");
+    expect(res.output).toContain("--force");
+  });
+
+  test("peek --help → prints peek usage with --lines and --history", async () => {
+    const handler = (await import("../../src/commands/plugins/pane/index")).default;
+    const res = await handler({ source: "cli", args: ["peek", "--help"] });
+    expect(res.ok).toBe(true);
+    expect(res.output).toContain("maw pane peek");
+    expect(res.output).toContain("--lines");
+    expect(res.output).toContain("--history");
+  });
+
+  test("list --help → prints list usage", async () => {
+    const handler = (await import("../../src/commands/plugins/pane/index")).default;
+    const res = await handler({ source: "cli", args: ["list", "--help"] });
+    expect(res.ok).toBe(true);
+    expect(res.output).toContain("maw pane list");
+    expect(res.output).toContain("--all");
+  });
+
+  test("ls is an alias for list", async () => {
+    // ls without args should not error on dispatch — it should hit the list handler.
+    // We don't care about output content here, just that it routes (no "unknown").
+    const handler = (await import("../../src/commands/plugins/pane/index")).default;
+    const res = await handler({ source: "cli", args: ["ls", "--help"] });
+    expect(res.ok).toBe(true);
+    expect(res.output).toContain("maw pane list");
+  });
+});
+
+// ── pane split — validation ─────────────────────────────────────────────────
+
+describe("cmdPaneSplit — validation", () => {
+  test("-h and -v together → throws", async () => {
+    const { cmdPaneSplit } = await import("../../src/commands/plugins/pane/split");
+    await expect(cmdPaneSplit("echo hi", { horizontal: true, vertical: true }))
+      .rejects.toThrow(/mutually exclusive/);
+  });
+
+  test("no $TMUX and no target → throws", async () => {
+    const { cmdPaneSplit } = await import("../../src/commands/plugins/pane/split");
+    const orig = process.env.TMUX;
+    delete process.env.TMUX;
+    const origPane = process.env.TMUX_PANE;
+    delete process.env.TMUX_PANE;
+    try {
+      await expect(cmdPaneSplit("echo hi", {}))
+        .rejects.toThrow(/active tmux|explicit -t target/);
+    } finally {
+      if (orig !== undefined) process.env.TMUX = orig;
+      if (origPane !== undefined) process.env.TMUX_PANE = origPane;
+    }
+  });
+
+  test("invalid pct propagates from cmdTmuxSplit", async () => {
+    const { cmdPaneSplit } = await import("../../src/commands/plugins/pane/split");
+    await expect(cmdPaneSplit("", { target: "%999", pct: 0 }))
+      .rejects.toThrow(/pct must be 1-99/);
+    await expect(cmdPaneSplit("", { target: "%999", pct: 150 }))
+      .rejects.toThrow(/pct must be 1-99/);
+  });
+});
+
+// ── pane split — delegation ─────────────────────────────────────────────────
+
+describe("cmdPaneSplit — delegation to tmux split-window", () => {
+  test("explicit target + horizontal default → tmux split-window -h -l 50%", async () => {
+    const { cmdPaneSplit } = await import("../../src/commands/plugins/pane/split");
+    await cmdPaneSplit("echo hello", { target: "%999" });
+    expect(commands.length).toBeGreaterThan(0);
+    const splitCmd = commands.find(c => c.startsWith("tmux split-window"));
+    expect(splitCmd).toBeDefined();
+    expect(splitCmd).toContain("-h");
+    expect(splitCmd).toContain("-l 50%");
+    expect(splitCmd).toContain("-t '%999'");
+    expect(splitCmd).toContain("'echo hello'");
+  });
+
+  test("vertical + custom pct + custom command", async () => {
+    const { cmdPaneSplit } = await import("../../src/commands/plugins/pane/split");
+    await cmdPaneSplit("tail -f log.txt", { target: "mawjs-view", vertical: true, pct: 30 });
+    const splitCmd = commands.find(c => c.startsWith("tmux split-window"));
+    expect(splitCmd).toBeDefined();
+    expect(splitCmd).toContain("-v");
+    expect(splitCmd).toContain("-l 30%");
+    expect(splitCmd).toContain("'tail -f log.txt'");
+  });
+
+  test("no command → tmux split-window without trailing cmd arg", async () => {
+    const { cmdPaneSplit } = await import("../../src/commands/plugins/pane/split");
+    await cmdPaneSplit("", { target: "%999" });
+    const splitCmd = commands.find(c => c.startsWith("tmux split-window"));
+    expect(splitCmd).toBeDefined();
+    // Without a command, cmdTmuxSplit's cmdSuffix is empty — the command string
+    // ends right after the target flag (no trailing single-quoted arg).
+    expect(splitCmd!.trim()).toMatch(/-t '%999'\s*$/);
+  });
+});
+
+// ── pane kill — validation + delegation ─────────────────────────────────────
+
+describe("cmdPaneKill", () => {
+  test("missing ref → throws", async () => {
+    const { cmdPaneKill } = await import("../../src/commands/plugins/pane/kill");
+    await expect(cmdPaneKill("")).rejects.toThrow(/pane-ref required/);
+  });
+
+  test("kill %999 → tmux kill-pane (not kill-session)", async () => {
+    const { cmdPaneKill } = await import("../../src/commands/plugins/pane/kill");
+    await cmdPaneKill("%999");
+    const killCmd = commands.find(c => c.includes("kill-pane") || c.includes("kill-session"));
+    expect(killCmd).toBeDefined();
+    expect(killCmd).toContain("kill-pane");
+    expect(killCmd).not.toContain("kill-session");
+    expect(killCmd).toContain("%999");
+  });
+
+  test("handler routes 'kill' to cmdPaneKill", async () => {
+    const handler = (await import("../../src/commands/plugins/pane/index")).default;
+    const res = await handler({ source: "cli", args: ["kill"] });
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain("pane-ref required");
+  });
+});
+
+// ── pane peek — validation + delegation ─────────────────────────────────────
+
+describe("cmdPanePeek", () => {
+  test("missing ref → throws", async () => {
+    const { cmdPanePeek } = await import("../../src/commands/plugins/pane/peek");
+    await expect(cmdPanePeek("")).rejects.toThrow(/pane-ref required/);
+  });
+
+  test("peek %999 → tmux capture-pane", async () => {
+    const { cmdPanePeek } = await import("../../src/commands/plugins/pane/peek");
+    nextResult = "fake pane content";
+    await cmdPanePeek("%999");
+    const captureCmd = commands.find(c => c.startsWith("tmux capture-pane"));
+    expect(captureCmd).toBeDefined();
+    expect(captureCmd).toContain("%999");
+  });
+
+  test("--lines flag forwards to capture-pane scroll range", async () => {
+    const { cmdPanePeek } = await import("../../src/commands/plugins/pane/peek");
+    nextResult = "x";
+    await cmdPanePeek("%999", { lines: 100 });
+    const captureCmd = commands.find(c => c.startsWith("tmux capture-pane"));
+    expect(captureCmd).toContain("-S -100");
+  });
+
+  test("--history flag forwards to full scrollback", async () => {
+    const { cmdPanePeek } = await import("../../src/commands/plugins/pane/peek");
+    nextResult = "x";
+    await cmdPanePeek("%999", { history: true });
+    const captureCmd = commands.find(c => c.startsWith("tmux capture-pane"));
+    expect(captureCmd).toContain("-S -");
+    expect(captureCmd).not.toContain("-S -30");
+  });
+
+  test("handler routes 'peek' to cmdPanePeek", async () => {
+    const handler = (await import("../../src/commands/plugins/pane/index")).default;
+    const res = await handler({ source: "cli", args: ["peek"] });
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain("pane-ref required");
+  });
+});
+
+// ── pane list — delegation ──────────────────────────────────────────────────
+
+describe("cmdPaneList", () => {
+  test("calls tmux list-panes (via cmdTmuxLs)", async () => {
+    const { cmdPaneList } = await import("../../src/commands/plugins/pane/list");
+    nextResult = "";
+    await cmdPaneList({ all: true });
+    const listCmd = commands.find(c => c.includes("list-panes"));
+    expect(listCmd).toBeDefined();
+  });
+
+  test("handler 'list' routes through and produces output", async () => {
+    const handler = (await import("../../src/commands/plugins/pane/index")).default;
+    nextResult = "";
+    const res = await handler({ source: "cli", args: ["list", "--all"] });
+    expect(res.ok).toBe(true);
+    // No panes returned → "No panes found" message hits the captured output.
+    expect(res.output).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Implements the proposal in #1269 — adds `maw pane` as a unified facade for tmux pane control. All four verbs delegate to existing helpers in `tmux/impl.ts` so we don't re-implement pane-ref resolution, pct validation, fleet/view safety, or buffer capture.

## Subcommands

```
maw pane split [-h|-v] [-p PCT] [-t SESSION:WINDOW] [<command>]
maw pane kill <pane-ref> [--force]
maw pane peek <pane-ref> [--lines N] [--history]
maw pane list [SESSION] [--all] [--json] [-v|--verbose]
```

Pane-ref forms reuse the canonical resolver (same as `maw tmux peek`): `%N`, `session:w.p`, `team-agent name`, or bare `session` name.

## Implementation notes

- **`split.ts`** — wraps `cmdTmuxSplit`. Differs from `maw tmux split` in CLI shape: target is a `-t` flag (defaults to `$TMUX_PANE`), command is positional. `-h`/`-v` are mutually exclusive.
- **`kill.ts`** — wraps `cmdTmuxKill` with `session: false` (always pane-only). Inherits fleet/view safety — refuses fleet sessions unless `--force`.
- **`peek.ts`** — thin re-export of `cmdTmuxPeek`. Same `--lines`/`--history` semantics.
- **`list.ts`** — wraps `cmdTmuxLs`. When a `SESSION` positional is given, forces an `--all` scan and post-filters by session prefix (called out as an open question below).

## Open question

`maw pane list [SESSION]` overlaps with the existing top-level `maw panes` plugin (lives in maw-plugin-registry). For this PR I implemented the simpler subset: list reuses `cmdTmuxLs` directly with the same output shape. If we want to fully consolidate, a follow-up could either deprecate `maw panes` in favor of `maw pane list`, or have `maw panes` route through `maw pane list`.

## Test plan

24 new tests in `test/plugins/pane.test.ts` covering:
- Handler dispatch (no-args/--help → usage; unknown subcommand → error; per-subcommand --help)
- Validation: `-h` + `-v` mutex; missing `\$TMUX` + no `-t`; invalid pct propagation
- Delegation via mocked `hostExec` — asserts the exact `tmux split-window`, `tmux kill-pane`, `tmux capture-pane`, `tmux list-panes` command strings produced

```
$ bun test test/plugins/pane.test.ts
 24 pass
 0 fail
 61 expect() calls
```

Sanity: `bun test test/isolated/tmux*.test.ts` → 113 pass, 0 fail (no regression in shared helpers).

- [ ] Smoke test: `maw pane split -h -p 30 \"tail -f /tmp/log\"` from inside tmux
- [ ] Smoke test: `maw pane peek <some-team-agent>`
- [ ] Smoke test: `maw pane list --all`
- [ ] Smoke test: `maw pane kill <ref>` rejects fleet session without `--force`

🤖 Generated with [Claude Code](https://claude.com/claude-code)