### PR TITLE
fix(wake): strip numeric prefix before fleet window match (#1282)

### DIFF
--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -54,6 +54,28 @@ export async function resolveFromWorktrees(
   };
 }
 
+/**
+ * Match an oracle alias to a fleet window name.
+ *
+ * #1282 — When `maw a <oracle>` (or any caller running inside a numbered tmux
+ * session like "20-homekeeper") forwards the session name as the oracle alias,
+ * the bare name carries a `^\d+-` prefix while fleet window names do not. So
+ * `"20-homekeeper-oracle" !== "homekeeper-oracle"` always missed and waking
+ * silently fell through to fleet-clone. Strip the numeric prefix before
+ * comparing; keep the raw form for backward compat with un-prefixed callers.
+ *
+ * @internal — exported for tests.
+ */
+export function matchOracleWindow(oracle: string, windowName: string): boolean {
+  const bare = oracle.replace(/^\d+-/, "");
+  return (
+    windowName === `${bare}-oracle` ||
+    windowName === bare ||
+    windowName === `${oracle}-oracle` ||
+    windowName === oracle
+  );
+}
+
 export async function resolveOracle(
   oracle: string,
   opts?: { allLocal?: boolean },
@@ -64,7 +86,7 @@ export async function resolveOracle(
   try {
     for (const file of readdirSync(FLEET_DIR).filter(f => f.endsWith(".json"))) {
       const config = JSON.parse(readFileSync(join(FLEET_DIR, file), "utf-8")) as FleetSession;
-      const win = (config.windows || []).find((w: FleetWindow) => w.name === `${oracle}-oracle` || w.name === oracle);
+      const win = (config.windows || []).find((w: FleetWindow) => matchOracleWindow(oracle, w.name));
       if (win?.repo && win.repo.includes("/")) {
         const fleetHit = await ghqFind(`/${win.repo}`);
         if (fleetHit) {
@@ -112,7 +134,7 @@ export async function resolveOracle(
   try {
     for (const file of readdirSync(FLEET_DIR).filter(f => f.endsWith(".json"))) {
       const config = JSON.parse(readFileSync(join(FLEET_DIR, file), "utf-8")) as FleetSession;
-      const win = (config.windows || []).find((w: FleetWindow) => w.name === `${oracle}-oracle` || w.name === oracle);
+      const win = (config.windows || []).find((w: FleetWindow) => matchOracleWindow(oracle, w.name));
       if (win?.repo) {
         const fullPath = await ghqFind(`/${win.repo.replace(/^[^/]+\//, "")}`);
         if (fullPath) {
@@ -246,7 +268,7 @@ export function resolveFleetSession(oracle: string): string | null {
   try {
     for (const file of readdirSync(FLEET_DIR).filter(f => f.endsWith(".json") && !f.endsWith(".disabled"))) {
       const config = JSON.parse(readFileSync(join(FLEET_DIR, file), "utf-8")) as FleetSession;
-      if ((config.windows || []).some((w: FleetWindow) => w.name === `${oracle}-oracle` || w.name === oracle)) return config.name;
+      if ((config.windows || []).some((w: FleetWindow) => matchOracleWindow(oracle, w.name))) return config.name;
     }
   } catch { /* fleet dir may not exist */ }
   return null;

--- a/test/wake-resolve.test.ts
+++ b/test/wake-resolve.test.ts
@@ -10,7 +10,7 @@
  * following the same pattern as wake.test.ts.
  */
 import { describe, test, expect } from "bun:test";
-import { resolveFromWorktrees } from "../src/commands/shared/wake-resolve-impl";
+import { resolveFromWorktrees, matchOracleWindow } from "../src/commands/shared/wake-resolve-impl";
 import type { WorktreeInfo } from "../src/core/fleet/worktrees-scan";
 
 const MAIN_PATH = "/home/user/ghq/github.com/Soul-Brews-Studio/wireboy-oracle";
@@ -126,5 +126,56 @@ describe("resolveFromWorktrees — worktree fallback", () => {
       () => true,
     );
     expect(result).toBeNull();
+  });
+});
+
+/**
+ * Tests for matchOracleWindow — fleet window name comparator that tolerates
+ * the `^\d+-` tmux session prefix that callers like `maw a <oracle>` carry in.
+ *
+ * #1282 — oracle="20-homekeeper" must match window.name="homekeeper-oracle".
+ * Without the strip, every `maw a` invocation from a numbered fleet session
+ * silently fell through fleet-pin lookup into fleet-clone.
+ */
+describe("matchOracleWindow — #1282 numeric prefix strip", () => {
+  test("strips numeric prefix: oracle='20-homekeeper' matches 'homekeeper-oracle'", () => {
+    expect(matchOracleWindow("20-homekeeper", "homekeeper-oracle")).toBe(true);
+  });
+
+  test("strips numeric prefix: oracle='20-homekeeper' matches bare 'homekeeper'", () => {
+    expect(matchOracleWindow("20-homekeeper", "homekeeper")).toBe(true);
+  });
+
+  test("backward compat: oracle='homekeeper' still matches 'homekeeper-oracle'", () => {
+    expect(matchOracleWindow("homekeeper", "homekeeper-oracle")).toBe(true);
+  });
+
+  test("backward compat: oracle='mawjs' matches 'mawjs-oracle'", () => {
+    expect(matchOracleWindow("mawjs", "mawjs-oracle")).toBe(true);
+  });
+
+  test("backward compat: oracle='mawjs' matches bare 'mawjs'", () => {
+    expect(matchOracleWindow("mawjs", "mawjs")).toBe(true);
+  });
+
+  test("preserves prefixed form too: oracle='20-homekeeper' matches '20-homekeeper-oracle'", () => {
+    // Some configs may genuinely name a window with the numeric prefix — don't lose that path.
+    expect(matchOracleWindow("20-homekeeper", "20-homekeeper-oracle")).toBe(true);
+  });
+
+  test("multi-digit prefix: oracle='110-yeast' matches 'yeast-oracle'", () => {
+    expect(matchOracleWindow("110-yeast", "yeast-oracle")).toBe(true);
+  });
+
+  test("non-numeric prefix is NOT stripped: oracle='dev-homekeeper' does not match 'homekeeper-oracle'", () => {
+    expect(matchOracleWindow("dev-homekeeper", "homekeeper-oracle")).toBe(false);
+  });
+
+  test("mismatched name returns false: oracle='20-homekeeper' does not match 'wireboy-oracle'", () => {
+    expect(matchOracleWindow("20-homekeeper", "wireboy-oracle")).toBe(false);
+  });
+
+  test("empty window name returns false", () => {
+    expect(matchOracleWindow("homekeeper", "")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Fixes #1282 — wake silently fell through fleet-pin lookup when oracle alias carried a `^\d+-` tmux session prefix (e.g. `maw a homekeeper` from inside `20-homekeeper` session passed `"20-homekeeper"` as the alias, never matched fleet window `"homekeeper-oracle"`).
- Extracted `matchOracleWindow(oracle, windowName)` that strips the numeric prefix before comparing, with full backward compat for un-prefixed callers.
- Applied at all three fleet-window match sites in `wake-resolve-impl.ts` (two in `resolveOracle`, one in `resolveFleetSession`).

## Test plan
- [x] `bun test test/wake-resolve.test.ts` — 17/17 pass (7 existing + 10 new)
- [x] `bun test test/wake-resolve*.test.ts test/wake-target-parser.test.ts test/wake.test.ts` — 75/75 pass
- [x] Backward compat verified: un-prefixed `oracle="homekeeper"` still matches `"homekeeper-oracle"` and `"homekeeper"`
- [x] Multi-digit prefix verified: `oracle="110-yeast"` matches `"yeast-oracle"`
- [x] Non-numeric prefix NOT stripped: `oracle="dev-homekeeper"` does NOT match `"homekeeper-oracle"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)