### PR TITLE
ci(#1278): shard test-unit 8-way with bun --shard + --isolate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Run unit tests (shard ${{ matrix.shard }}/8)
         env:
           MAW_SKIP_FLAKY: "1"
-        run: bun test -- --shard=${{ matrix.shard }}/8 --isolate
+        run: bun test --shard=${{ matrix.shard }}/8 --isolate
 
   # test-isolated is the slowest CI job — 79 test files × bun startup, all
   # sequential because Bun's mock.module is process-global. Each subprocess

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,14 +8,14 @@ on:
 
 jobs:
   test:
-    # Fast suites — single runner each. test-isolated is split out below
-    # into a sharded matrix because it's the slowest (79 per-file subprocesses).
+    # Fast suites — single runner each. test-unit and test-isolated are split
+    # out below into sharded matrices (test-unit because mock.module is
+    # process-global and benefits from --isolate; test-isolated because it's
+    # the slowest at 79 per-file subprocesses).
     runs-on: ubuntu-latest
     strategy:
       matrix:
         suite:
-          - name: unit
-            script: test
           - name: plugin
             script: test:plugin
           - name: mock-smoke
@@ -45,6 +45,41 @@ jobs:
         env:
           MAW_SKIP_FLAKY: "1"
         run: bun run ${{ matrix.suite.script }}
+
+  # test-unit shards the 102-file unit suite 8-way using Bun 1.3.13's native
+  # --shard=N/M + --isolate flags. --isolate is essential — 31 of the 102
+  # files use mock.module() which is process-global, so without per-file
+  # isolation a shard's tests can leak mocks into siblings. (#1278)
+  test-unit:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
+
+      - name: Cache bun deps
+        uses: actions/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Setup ghq
+        uses: ./.github/actions/setup-ghq
+
+      - name: Run unit tests (shard ${{ matrix.shard }}/8)
+        env:
+          MAW_SKIP_FLAKY: "1"
+        run: bun test -- --shard=${{ matrix.shard }}/8 --isolate
 
   # test-isolated is the slowest CI job — 79 test files × bun startup, all
   # sequential because Bun's mock.module is process-global. Each subprocess
@@ -95,7 +130,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: [test, test-isolated]
+    needs: [test, test-unit, test-isolated]
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
- Splits the 102-file unit suite into a fail-fast=false 8-way matrix using Bun 1.3.13's native `--shard=N/M` flag.
- Uses `--isolate` to prevent mock.module() leaks (31 of 102 files mock globally — without isolation a shard can poison its siblings).
- No custom runner script — pure workflow change.
- `test` matrix retains `plugin` + `mock-smoke` (both fast single-runner). `build` now needs `test`, `test-unit`, `test-isolated`.

Closes #1278.

## Test plan
- [ ] CI green: `test-unit (1)` … `test-unit (8)` all pass
- [ ] `test (plugin)` and `test (mock-smoke)` still pass
- [ ] `test-isolated (1..8)` unaffected
- [ ] `build` waits on all three before running
- [ ] Wall-clock for unit suite drops ~8x vs single-runner baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)