### PR TITLE
feat(plugin): maw plugin sync — reconcile broken symlinks (#1277)

### DIFF
--- a/src/commands/plugins/plugin/index.ts
+++ b/src/commands/plugins/plugin/index.ts
@@ -7,7 +7,7 @@ export const command = {
 };
 
 const USAGE =
-  "usage: maw plugin <init|build|dev|install|pin|unpin|registry|search|info> [args]\n" +
+  "usage: maw plugin <init|build|dev|install|sync|pin|unpin|registry|search|info> [args]\n" +
   "  init <name> --ts                    scaffold a TS plugin\n" +
   "  build [dir] [--watch] [--types]     bundle + pack a plugin\n" +
   "                                        --types: emit dist/<name>.d.ts\n" +
@@ -16,11 +16,15 @@ const USAGE =
   "                                      plain name → registry lookup (plugin or package)\n" +
   "                                      e.g. 'maw plugin install standard' installs the standard bundle\n" +
   "                                        --pin: add to plugins.lock on first install\n" +
+  "                                        --all: reinstall every entry in plugins.lock (#1277)\n" +
+  "                                        --dry-run: with --all, list without installing\n" +
   "  install <owner/repo>[/<name>][@<ref>]   install from GitHub (Vercel-style)\n" +
   "    install owner/repo                  whole repo (single-plugin repo)\n" +
   "    install owner/repo/bg               subdir from monorepo (auto plugins/ prefix)\n" +
   "    install owner/repo/sub/dir          literal subpath\n" +
   "    install owner/repo@v1.2.3           pinned tag (or branch / sha)\n" +
+  "  sync [--dry-run]                    reconcile ~/.maw/plugins/ from plugins.lock (#1277)\n" +
+  "                                        non-destructive: recreates missing symlinks only\n" +
   "  pin <name> <tarball> [--version V]  add/update plugins.lock entry (#487)\n" +
   "  unpin <name>                        remove a plugins.lock entry\n" +
   "  registry                            show registry URL + entry count\n" +
@@ -229,7 +233,22 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       await runSearchCmd(args.slice(1));
     } else if (sub === "info") {
       await runInfoCmd(args.slice(1));
+    } else if (sub === "sync") {
+      const { cmdPluginSync } = await import("./sync-impl");
+      const dryRun = args.includes("--dry-run");
+      await cmdPluginSync({ dryRun });
     } else if (sub === "install") {
+      // #1277 — `install --all` is a batch-reinstall shortcut that loops
+      // over plugins.lock and dispatches the existing install flow per
+      // entry. Lives here (not sync-impl) because the underlying network
+      // gesture IS install — sync stays purely local + non-destructive.
+      if (args.includes("--all")) {
+        const { cmdPluginInstallAll } = await import("./install-all-impl");
+        const dryRun = args.includes("--dry-run");
+        const force = args.includes("--force");
+        await cmdPluginInstallAll({ dryRun, force });
+        return { ok: true, output: logs.join("\n") || undefined };
+      }
       try {
         await runInstallCmd(args.slice(1));
       } catch (e: unknown) {

--- a/src/commands/plugins/plugin/install-all-impl.ts
+++ b/src/commands/plugins/plugin/install-all-impl.ts
@@ -1,0 +1,114 @@
+/**
+ * maw plugin install --all (#1277 companion)
+ *
+ * Batch-reinstall every plugin in plugins.lock by re-dispatching the
+ * existing install flow for each entry's `source`. Useful after a source
+ * dir rename or fresh clone.
+ *
+ * Why a separate file? Keeps install-impl.ts focused on single-source
+ * dispatch (already 130 LoC). The batch loop is a thin shell that just
+ * calls back into cmdPluginInstall — no duplicated logic.
+ *
+ * Behavior per source type:
+ *   • link:<abs-path>  → re-link (cmdPluginInstall handles the directory)
+ *   • <url>            → download + extract + verify
+ *   • <github-ref>     → tarball download
+ *   • <local-tarball>  → extract + verify  (only if path still exists)
+ *   • bare name        → registry resolve  (rare in lock — sources are
+ *                                            usually concrete by the time
+ *                                            we record them)
+ *
+ * --dry-run prints what would happen without touching the network or FS.
+ * --force is propagated to each install (so existing dirs are replaced).
+ *
+ * Failures are isolated: one bad plugin doesn't stop the rest. We collect
+ * + report at the end and exit non-zero iff anything failed.
+ */
+
+import { readLock } from "./lock";
+
+export interface InstallAllOptions {
+  dryRun?: boolean;
+  force?: boolean;
+}
+
+export interface InstallAllResult {
+  total: number;
+  installed: number;
+  skipped: number;
+  failed: { name: string; reason: string }[];
+}
+
+export async function cmdPluginInstallAll(opts: InstallAllOptions = {}): Promise<InstallAllResult> {
+  const lock = readLock();
+  const entries = Object.entries(lock.plugins);
+  const dryRun = !!opts.dryRun;
+  const force = !!opts.force;
+
+  if (entries.length === 0) {
+    console.log("plugins.lock is empty — nothing to install.");
+    return { total: 0, installed: 0, skipped: 0, failed: [] };
+  }
+
+  console.log(`install --all: ${entries.length} entries in plugins.lock${dryRun ? " (dry-run)" : ""}`);
+
+  const failed: { name: string; reason: string }[] = [];
+  let installed = 0;
+  let skipped = 0;
+
+  for (const [name, entry] of entries) {
+    const source = entry.source ?? "";
+
+    // For `link:` sources, the install argument is the absolute path
+    // (the directory). detectMode() in install-source-detect.ts treats
+    // dir paths as `--link` installs implicitly when you pass a dir.
+    let installArg: string;
+    if (source.startsWith("link:")) {
+      installArg = source.slice("link:".length);
+    } else {
+      installArg = source;
+    }
+
+    if (!installArg) {
+      console.log(`  - ${name}: no source recorded — skipping`);
+      skipped++;
+      continue;
+    }
+
+    if (dryRun) {
+      console.log(`  would install: ${name} ← ${source}`);
+      installed++;
+      continue;
+    }
+
+    console.log(`  → ${name} ← ${source}`);
+    try {
+      const { cmdPluginInstall } = await import("./install-impl");
+      const args: string[] = [installArg];
+      if (force) args.push("--force");
+      // For link: sources, mirror the original --link flag so the install
+      // path takes the symlink branch (not a real copy).
+      if (source.startsWith("link:")) args.push("--link");
+      await cmdPluginInstall(args);
+      installed++;
+    } catch (e: unknown) {
+      const reason = e instanceof Error ? e.message : String(e);
+      console.log(`  ✗ ${name}: ${reason.split("\n")[0]}`);
+      failed.push({ name, reason });
+    }
+  }
+
+  const verb = dryRun ? "install --all (dry-run)" : "install --all";
+  console.log(
+    `${verb}: ${installed}/${entries.length} ${dryRun ? "would install" : "installed"}` +
+    (skipped ? `, ${skipped} skipped` : "") +
+    (failed.length ? `, ${failed.length} failed` : ""),
+  );
+
+  if (failed.length > 0 && !dryRun) {
+    // Non-fatal exit signal — bubble up so the dispatcher can mark ok:false.
+    throw new Error(`install --all: ${failed.length} of ${entries.length} failed`);
+  }
+
+  return { total: entries.length, installed, skipped, failed };
+}

--- a/src/commands/plugins/plugin/plugin.json
+++ b/src/commands/plugins/plugin/plugin.json
@@ -3,11 +3,11 @@
   "version": "1.0.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "Plugin lifecycle — init, build, dev, install.",
+  "description": "Plugin lifecycle — init, build, dev, install, sync.",
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "plugin",
-    "help": "maw plugin <init|build|dev|install> [args]"
+    "help": "maw plugin <init|build|dev|install|sync> [args]"
   },
   "weight": 10
 }

--- a/src/commands/plugins/plugin/sync-impl.ts
+++ b/src/commands/plugins/plugin/sync-impl.ts
@@ -1,0 +1,130 @@
+/**
+ * maw plugin sync (#1277)
+ *
+ * Reconcile ~/.maw/plugins/ against plugins.lock. Non-destructive by default —
+ * only recreates missing/broken symlinks for `link:` sources. For tarball /
+ * URL / GitHub sources, prints an actionable hint pointing at `maw plugin
+ * install <name>` (the safe, network-aware path).
+ *
+ * Why a separate command? Auto-cleanup at plugin-bootstrap.ts:99 and
+ * cmd-update.ts:337 silently removes broken symlinks without recovery. If
+ * the source dir holding maw-js is renamed (e.g. `~/Code` → `/opt/Code`)
+ * every linked plugin evaporates. plugins.lock retains enough metadata
+ * (source: "link:/abs/path") to recreate the link iff the target still
+ * exists somewhere on disk.
+ *
+ * Design constraints:
+ *   • NEVER delete anything. Only `symlinkSync(target, dest)` for missing.
+ *   • `--dry-run` prints the would-be repairs without touching the FS.
+ *   • Registry/tarball sources don't auto-reinstall here — that's a
+ *     network operation; surface as a hint instead. (`install --all` is
+ *     the batch reinstall path; see install-impl.ts.)
+ */
+
+import { existsSync, lstatSync, realpathSync, symlinkSync } from "fs";
+import { join } from "path";
+import { readLock } from "./lock";
+import { installRoot } from "./install-source-detect";
+
+export interface SyncOptions {
+  dryRun?: boolean;
+}
+
+export interface SyncResult {
+  ok: number;
+  fixed: number;
+  broken: number;
+  missing: number;
+}
+
+/**
+ * Read plugins.lock, walk every entry, recreate broken symlinks for
+ * `link:`-sourced plugins. Returns counts so callers / tests can assert.
+ */
+export async function cmdPluginSync(opts: SyncOptions = {}): Promise<SyncResult> {
+  const lock = readLock();
+  const pluginDir = installRoot();
+  const dryRun = !!opts.dryRun;
+
+  let ok = 0, fixed = 0, broken = 0, missing = 0;
+  const entries = Object.entries(lock.plugins);
+
+  if (entries.length === 0) {
+    console.log("plugins.lock is empty — nothing to sync.");
+    console.log("Sync: 0 ok, 0 fixed, 0 broken, 0 missing");
+    return { ok: 0, fixed: 0, broken: 0, missing: 0 };
+  }
+
+  for (const [name, entry] of entries) {
+    const symlink = join(pluginDir, name);
+
+    // Distinguish three states:
+    //   1. link present + target reachable          → ok
+    //   2. link absent OR present-but-target-gone   → try to repair
+    //
+    // We use lstat (not stat) so we don't follow the symlink — a dangling
+    // symlink reports as a symlink, not as ENOENT.
+    let linkPresent = false;
+    let targetReachable = false;
+    try {
+      lstatSync(symlink);
+      linkPresent = true;
+      try {
+        const real = realpathSync(symlink);
+        targetReachable = existsSync(real);
+      } catch {
+        // realpath can throw on dangling symlinks → target unreachable.
+        targetReachable = false;
+      }
+    } catch {
+      linkPresent = false;
+    }
+
+    if (linkPresent && targetReachable) {
+      ok++;
+      continue;
+    }
+
+    // Need repair. Behavior depends on source type.
+    const source = entry.source ?? "";
+
+    if (source.startsWith("link:")) {
+      const target = source.slice("link:".length);
+      if (!existsSync(target)) {
+        console.log(`  ✗ ${name}: link target missing — ${target}`);
+        broken++;
+        continue;
+      }
+      if (dryRun) {
+        console.log(`  would fix: ${name} → ${target}`);
+      } else {
+        // Non-destructive: only create when the link is absent. If a
+        // dangling link is in the way, surface it instead of silently
+        // unlinking — preserves the "nothing is deleted" principle.
+        if (linkPresent) {
+          console.log(`  ✗ ${name}: link present but dangling (target ${target} ok) — re-run 'maw plugin install --link ${target}' to refresh`);
+          broken++;
+          continue;
+        }
+        symlinkSync(target, symlink);
+        console.log(`  ✓ fixed: ${name} → ${target}`);
+      }
+      fixed++;
+    } else {
+      // Registry tarball / URL / GitHub source. We can't safely re-fetch
+      // here — that's a network gesture and the user may want to choose.
+      // Surface the actionable hint.
+      const sourceLabel = source || "(no source recorded)";
+      console.log(`  ! ${name}: missing/broken — source=${sourceLabel}`);
+      console.log(`      run: maw plugin install ${name}`);
+      missing++;
+    }
+  }
+
+  const verb = dryRun ? "Sync (dry-run)" : "Sync";
+  console.log(`${verb}: ${ok} ok, ${fixed} fixed, ${broken} broken, ${missing} missing`);
+  if (missing > 0 && !dryRun) {
+    console.log(`Tip: 'maw plugin install --all' will reinstall every entry in plugins.lock.`);
+  }
+  return { ok, fixed, broken, missing };
+}

--- a/test/isolated/plugin-sync.test.ts
+++ b/test/isolated/plugin-sync.test.ts
@@ -1,0 +1,238 @@
+/**
+ * maw plugin sync (#1277) — reconcile broken symlinks from plugins.lock.
+ *
+ * Coverage:
+ *   • All-ok lock → no changes, all entries reported as "ok".
+ *   • Linked plugin with valid target + missing symlink → recreates link.
+ *   • Linked plugin with target gone (source dir deleted) → reports broken.
+ *   • Registry / tarball plugin with broken symlink → suggests reinstall.
+ *   • --dry-run shows would-fix without touching filesystem.
+ *   • Linked plugin with dangling symlink → does NOT delete (non-destructive).
+ *   • Empty lock → no-op + clear message.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  existsSync, lstatSync, mkdirSync, mkdtempSync, rmSync, symlinkSync,
+} from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { writeLock, LOCK_SCHEMA, type Lock } from "../../src/commands/plugins/plugin/lock";
+import { cmdPluginSync } from "../../src/commands/plugins/plugin/sync-impl";
+
+// ─── Harness ─────────────────────────────────────────────────────────────────
+
+const created: string[] = [];
+let origPluginsDir: string | undefined;
+let origPluginsLock: string | undefined;
+
+function tmpDir(prefix = "maw-sync-test-"): string {
+  const d = mkdtempSync(join(tmpdir(), prefix));
+  created.push(d);
+  return d;
+}
+function pluginsDir(): string { return process.env.MAW_PLUGINS_DIR!; }
+
+beforeEach(() => {
+  origPluginsDir = process.env.MAW_PLUGINS_DIR;
+  origPluginsLock = process.env.MAW_PLUGINS_LOCK;
+  const home = tmpDir("maw-home-");
+  mkdirSync(home, { recursive: true });
+  process.env.MAW_PLUGINS_DIR = join(home, "plugins");
+  process.env.MAW_PLUGINS_LOCK = join(home, "plugins.lock");
+  mkdirSync(process.env.MAW_PLUGINS_DIR!, { recursive: true });
+});
+
+afterEach(() => {
+  if (origPluginsDir !== undefined) process.env.MAW_PLUGINS_DIR = origPluginsDir;
+  else delete process.env.MAW_PLUGINS_DIR;
+  if (origPluginsLock !== undefined) process.env.MAW_PLUGINS_LOCK = origPluginsLock;
+  else delete process.env.MAW_PLUGINS_LOCK;
+  for (const d of created.splice(0)) {
+    if (existsSync(d)) rmSync(d, { recursive: true, force: true });
+  }
+});
+
+/** Capture console output from one sync run. */
+async function capture<T>(fn: () => Promise<T>): Promise<{ result: T; stdout: string }> {
+  const origLog = console.log;
+  const lines: string[] = [];
+  console.log = (...a: unknown[]) => lines.push(a.map(String).join(" "));
+  try {
+    const result = await fn();
+    return { result, stdout: lines.join("\n") };
+  } finally {
+    console.log = origLog;
+  }
+}
+
+function makeLockEntry(opts: { source: string; version?: string }): Lock["plugins"][string] {
+  return {
+    version: opts.version ?? "0.1.0",
+    sha256: "sha256:" + "a".repeat(64),
+    source: opts.source,
+    added: new Date().toISOString(),
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("cmdPluginSync", () => {
+  test("empty lock → 0/0/0/0 + friendly message", async () => {
+    writeLock({ schema: LOCK_SCHEMA, updated: new Date().toISOString(), plugins: {} });
+    const { result, stdout } = await capture(() => cmdPluginSync());
+    expect(result).toEqual({ ok: 0, fixed: 0, broken: 0, missing: 0 });
+    expect(stdout).toContain("plugins.lock is empty");
+  });
+
+  test("all symlinks ok → reports ok, no repair", async () => {
+    const target = tmpDir("maw-plugin-src-");
+    mkdirSync(join(target, "hello"), { recursive: true });
+    const linkSource = join(target, "hello");
+    symlinkSync(linkSource, join(pluginsDir(), "hello"));
+
+    writeLock({
+      schema: LOCK_SCHEMA, updated: new Date().toISOString(),
+      plugins: { hello: makeLockEntry({ source: `link:${linkSource}` }) },
+    });
+
+    const { result } = await capture(() => cmdPluginSync());
+    expect(result.ok).toBe(1);
+    expect(result.fixed).toBe(0);
+    expect(result.broken).toBe(0);
+    expect(result.missing).toBe(0);
+  });
+
+  test("linked plugin missing symlink + valid target → recreates symlink", async () => {
+    const target = tmpDir("maw-plugin-src-");
+    const linkSource = join(target, "hello");
+    mkdirSync(linkSource, { recursive: true });
+    // No symlink in plugins dir — represents post-auto-cleanup state.
+
+    writeLock({
+      schema: LOCK_SCHEMA, updated: new Date().toISOString(),
+      plugins: { hello: makeLockEntry({ source: `link:${linkSource}` }) },
+    });
+
+    const { result, stdout } = await capture(() => cmdPluginSync());
+    expect(result.fixed).toBe(1);
+    expect(result.ok).toBe(0);
+    expect(result.broken).toBe(0);
+    expect(stdout).toContain("fixed");
+
+    // Symlink now exists and points where the lock said.
+    const linkPath = join(pluginsDir(), "hello");
+    expect(lstatSync(linkPath).isSymbolicLink()).toBe(true);
+    expect(existsSync(linkPath)).toBe(true);
+  });
+
+  test("linked plugin with target missing → reports broken (not fixed)", async () => {
+    const ghostTarget = "/nonexistent/abs/path/maw-plugin-ghost";
+
+    writeLock({
+      schema: LOCK_SCHEMA, updated: new Date().toISOString(),
+      plugins: { ghost: makeLockEntry({ source: `link:${ghostTarget}` }) },
+    });
+
+    const { result, stdout } = await capture(() => cmdPluginSync());
+    expect(result.broken).toBe(1);
+    expect(result.fixed).toBe(0);
+    expect(stdout).toContain("ghost");
+    expect(stdout).toContain("link target missing");
+    // No phantom symlink created.
+    expect(existsSync(join(pluginsDir(), "ghost"))).toBe(false);
+  });
+
+  test("registry/tarball plugin broken → suggests reinstall (does not auto-fetch)", async () => {
+    writeLock({
+      schema: LOCK_SCHEMA, updated: new Date().toISOString(),
+      plugins: {
+        registry_pkg: makeLockEntry({ source: "https://registry.maw.dev/foo-0.1.0.tgz" }),
+      },
+    });
+
+    const { result, stdout } = await capture(() => cmdPluginSync());
+    expect(result.missing).toBe(1);
+    expect(result.fixed).toBe(0);
+    expect(stdout).toContain("maw plugin install registry_pkg");
+    expect(stdout).toContain("install --all");
+  });
+
+  test("--dry-run reports would-fix without touching the filesystem", async () => {
+    const target = tmpDir("maw-plugin-src-");
+    const linkSource = join(target, "hello");
+    mkdirSync(linkSource, { recursive: true });
+
+    writeLock({
+      schema: LOCK_SCHEMA, updated: new Date().toISOString(),
+      plugins: { hello: makeLockEntry({ source: `link:${linkSource}` }) },
+    });
+
+    const { result, stdout } = await capture(() => cmdPluginSync({ dryRun: true }));
+    expect(result.fixed).toBe(1);
+    expect(stdout).toContain("would fix");
+    // Critically: dry-run did NOT create the symlink.
+    expect(existsSync(join(pluginsDir(), "hello"))).toBe(false);
+  });
+
+  test("dangling symlink (link present, target reachable) → does NOT delete (non-destructive)", async () => {
+    // First create a linked plugin pointing somewhere, then yank the
+    // somewhere — leaves a dangling symlink. Sync should report it
+    // without unlinking — the "Nothing is Deleted" principle.
+    const target1 = tmpDir("maw-plugin-src-old-");
+    const linkSourceOld = join(target1, "hello");
+    mkdirSync(linkSourceOld, { recursive: true });
+    symlinkSync(linkSourceOld, join(pluginsDir(), "hello"));
+
+    // Now delete the original target → symlink dangles.
+    rmSync(target1, { recursive: true, force: true });
+
+    // Lock points at a NEW (still-valid) target.
+    const target2 = tmpDir("maw-plugin-src-new-");
+    const linkSourceNew = join(target2, "hello");
+    mkdirSync(linkSourceNew, { recursive: true });
+
+    writeLock({
+      schema: LOCK_SCHEMA, updated: new Date().toISOString(),
+      plugins: { hello: makeLockEntry({ source: `link:${linkSourceNew}` }) },
+    });
+
+    const { result, stdout } = await capture(() => cmdPluginSync());
+    // Non-destructive: we don't unlink the dangling symlink. Report broken
+    // and ask the user to refresh explicitly.
+    expect(result.broken).toBe(1);
+    expect(result.fixed).toBe(0);
+    expect(stdout).toContain("dangling");
+    // The dangling symlink is still there (we did not delete it).
+    expect(lstatSync(join(pluginsDir(), "hello")).isSymbolicLink()).toBe(true);
+  });
+
+  test("mixed lock (ok + broken-link + tarball) → correct counts", async () => {
+    // OK entry
+    const okTarget = tmpDir("maw-plugin-src-ok-");
+    const okSource = join(okTarget, "alpha");
+    mkdirSync(okSource, { recursive: true });
+    symlinkSync(okSource, join(pluginsDir(), "alpha"));
+
+    // Fixable entry
+    const fixTarget = tmpDir("maw-plugin-src-fix-");
+    const fixSource = join(fixTarget, "beta");
+    mkdirSync(fixSource, { recursive: true });
+
+    writeLock({
+      schema: LOCK_SCHEMA, updated: new Date().toISOString(),
+      plugins: {
+        alpha: makeLockEntry({ source: `link:${okSource}` }),
+        beta: makeLockEntry({ source: `link:${fixSource}` }),
+        gamma: makeLockEntry({ source: "https://example.com/gamma-0.1.0.tgz" }),
+        delta: makeLockEntry({ source: "link:/no/such/path" }),
+      },
+    });
+
+    const { result } = await capture(() => cmdPluginSync());
+    expect(result.ok).toBe(1);       // alpha
+    expect(result.fixed).toBe(1);    // beta
+    expect(result.missing).toBe(1);  // gamma (registry)
+    expect(result.broken).toBe(1);   // delta (target missing)
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1277. Adds `maw plugin sync` + `maw plugin install --all` for recovering from source-dir renames that silently break installed plugin symlinks (the `~/Code` → `/opt/Code` migration that triggered #1277 dropped 64 of 78 plugins).

- **`maw plugin sync [--dry-run]`** — non-destructive. Walks `plugins.lock`, recreates missing symlinks for `link:` sources, surfaces actionable hints for broken registry/tarball entries (no auto-fetch). Never deletes — dangling links are reported, not removed (preserves "Nothing is Deleted").
- **`maw plugin install --all [--dry-run] [--force]`** — batch reinstall by re-dispatching the existing install flow per `plugins.lock` entry. The network gesture, kept separate from sync.

## Design notes

- `sync-impl.ts` reads `plugins.lock` via existing `readLock()` — no new manifest format
- `install-all-impl.ts` is a thin shell over `cmdPluginInstall` — no duplicated install logic
- Failures isolate per-entry; `install --all` exits non-zero iff anything failed
- All gestures honor `MAW_PLUGINS_DIR` / `MAW_PLUGINS_LOCK` env overrides for tests

## Test plan

- [x] `bun test test/isolated/plugin-sync.test.ts` — 8 new tests (empty lock, all-ok, recreates, broken-target, registry-suggests-reinstall, dry-run, dangling-non-destructive, mixed)
- [x] `bun test test/isolated/plugin-lock.test.ts test/plugin-install-url-validation.test.ts test/plugins-cli.test.ts` — 38 existing pass
- [x] Smoke: invoke handler with `sync` arg → recreates symlink, returns ok
- [ ] Manual reproduction of #1277: rename source dir, run `maw plugin sync` → expect symlinks restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)