### PR TITLE
fix(plugin): add attach to known capability namespaces

### DIFF
--- a/src/plugin/manifest-constants.ts
+++ b/src/plugin/manifest-constants.ts
@@ -28,6 +28,7 @@ export const KNOWN_CAPABILITY_NAMESPACES = new Set([
   "ffi",    // native FFI (bun:ffi)
   "tmux",   // tmux socket interaction (spawnSync("tmux", …) + SDK tmux helpers)
   "shell",  // shell-eval / stdout-writing plugins (shellenv-style)
+  "attach", // attach-strategy plugins (attach:strategy capability — extracted from built-in attach plugin)
 ]);
 
 /**

--- a/test/isolated/plugin-load-capability-902.test.ts
+++ b/test/isolated/plugin-load-capability-902.test.ts
@@ -74,9 +74,9 @@ function makePluginDir(opts: {
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe("#902 — load-time capability validator (single source of truth)", () => {
-  test("KNOWN_CAPABILITY_NAMESPACES is the canonical set (#874 baseline)", () => {
+  test("KNOWN_CAPABILITY_NAMESPACES is the canonical set", () => {
     expect([...KNOWN_CAPABILITY_NAMESPACES].sort()).toEqual(
-      ["ffi", "fs", "net", "peer", "proc", "sdk", "shell", "tmux"],
+      ["attach", "ffi", "fs", "net", "peer", "proc", "sdk", "shell", "tmux"],
     );
   });
 


### PR DESCRIPTION
## Summary

Adds `attach` to `KNOWN_CAPABILITY_NAMESPACES` so plugins extracted from the built-in `attach` plugin (attach-ssh, future attach-clone, attach-sync) don't trigger an "unknown capability namespace" warning on install.

## Why

`maw-plugin-registry#58` (attach-ssh) extracts the Tier 3 SSH+tmux dispatch into a plugin declaring `capabilities: ["attach:strategy"]`. Without this fix every `maw plugins install attach-ssh` prints:

> `plugin.json: unknown capability namespace "attach" in "attach:strategy" (known: net, fs, peer, sdk, proc, ffi, tmux, shell)`

Install proceeds anyway (the warning is advisory in Phase A), but the noise is unhelpful.

## Changes

- `src/plugin/manifest-constants.ts` — +1 line: add `"attach"` to the set
- `test/isolated/plugin-load-capability-902.test.ts` — update baseline assertion to include `attach`

No version bump — `/release-alpha` cuts the next alpha separately (per maw-js convention).

## Test plan

- [x] `bun test test/isolated/plugin-load-capability-902.test.ts` — 7 pass
- [x] Verified `maw plugins install attach-ssh` no longer warns (after `bun link`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)