### PR TITLE
release: v26.5.13-alpha.1039

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.13-alpha.809",
+  "version": "26.5.13-alpha.1039",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/test/plugin-manifest-v1.test.ts
+++ b/test/plugin-manifest-v1.test.ts
@@ -87,8 +87,9 @@ describe("manifest v1 — new fields", () => {
   test("seeded capability namespaces are frozen set", () => {
     // #874 — `tmux` and `shell` joined the namespace list to support community
     // plugins (bg, rename, park, shellenv) that spawn tmux or shell-eval.
+    // #1291 — `attach` joined for attach-strategy plugins (attach-ssh).
     expect([...KNOWN_CAPABILITY_NAMESPACES].sort()).toEqual(
-      ["net", "fs", "peer", "sdk", "proc", "ffi", "tmux", "shell"].sort(),
+      ["attach", "net", "fs", "peer", "sdk", "proc", "ffi", "tmux", "shell"].sort(),
     );
   });
 });


### PR DESCRIPTION
Bundles 1 PR merged to alpha since v26.5.13-alpha.809:
- #1291 fix(plugin): add attach to known capability namespaces (enables `maw-plugin-registry/attach-ssh`)

Cuts v26.5.13-alpha.1039 on merge via calver-release.yml.