### PR TITLE
fix(wake): read namedPeers in federation fallback (#1290)

### DIFF
--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -219,9 +219,13 @@ export async function resolveOracle(
   } catch { /* probe/clone best-effort — fall through to federation */ }
 
   // Federation fallback: check peers
+  // #1290: read namedPeers (modern fleet config) AND legacy peers — same shape as
+  // #1282, different field. `maw a` already does this via getAggregatedSessions.
   try {
     const config = loadConfig();
-    const peers = config.peers || [];
+    const namedPeerUrls = (config.namedPeers ?? []).map(p => p.url).filter(Boolean);
+    const legacyPeerUrls = config.peers ?? [];
+    const peers = [...new Set([...namedPeerUrls, ...legacyPeerUrls])];
     for (const peer of peers) {
       try {
         const res = await curlFetch(`${peer}/api/sessions`, { timeout: 10000 });


### PR DESCRIPTION
## Summary

Closes #1290.

`maw wake <oracle>` was reading only `config.peers` (legacy) and ignoring `config.namedPeers` (modern fleet config). Fleets that only declare `namedPeers` got '0 peers checked'.

Mirrors the pattern already used by `getAggregatedSessions` (attach plugin) and `src/core/routing.ts:163` — read both, dedupe.

## Test plan

- [x] `bun test test/wake-resolve.test.ts test/wake-flag-name-guard.test.ts test/wake-resolve-scan-suggest.test.ts` — 51 pass
- [x] Manual: `maw wake phd` with `namedPeers` populated now iterates them

🤖 Generated with [Claude Code](https://claude.com/claude-code)