### PR TITLE
release: v26.5.13-alpha.1102

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.13-alpha.1039",
+  "version": "26.5.13-alpha.1102",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Bundles 1 PR merged to alpha since v26.5.13-alpha.1039:
- #1293 fix(wake): read namedPeers in federation fallback (closes #1290)

Cuts v26.5.13-alpha.1102 on merge via calver-release.yml.