### PR TITLE
fix(wake): SSH+tmux wake for federation peers (not HTTP)

### DIFF
--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "child_process";
 import { hostExec, tmux, FLEET_DIR, curlFetch } from "../../sdk";
 import { loadConfig, getEnvVars } from "../../config";
 import { ghqFind } from "../../core/ghq";
@@ -239,9 +240,17 @@ export async function resolveOracle(
             w.name === `${oracle}-oracle` || w.name === oracle || w.name.toLowerCase().startsWith(oracleLower)
           ) || (sessionMatch ? (s.windows || [])[0] : null);
           if (found) {
-            console.log(`\x1b[36m⚡\x1b[0m ${oracle} found on peer ${peer} — waking remotely`);
-            await curlFetch(`${peer}/api/send`, { method: "POST", body: JSON.stringify({ target: `${s.name}:${found.index}`, text: "" }), from: "auto" /* #804 Step 4 SIGN — sign cross-node remote-wake /api/send */ });
-            console.log(`\x1b[32m✓\x1b[0m ${oracle} is running on ${peer} (session ${s.name}:${found.name})`);
+            // #1290-followup: SSH+tmux nudge (matches original wake.ts @ 4cc891ed
+            // + src/core/transport/ssh-attach.ts pattern). No HTTP /api/send.
+            const namedPeer = config.namedPeers?.find(p => p.url === peer);
+            const sshAlias = namedPeer?.ssh || namedPeer?.name || new URL(peer).hostname;
+            console.log(`\x1b[36m⚡\x1b[0m ${oracle} on ${sshAlias} — wake keystroke via tmux`);
+            execFileSync(
+              "ssh",
+              ["-tt", sshAlias, `tmux send-keys -t '${s.name}:${found.index}' '' Enter`],
+              { stdio: "inherit" },
+            );
+            console.log(`\x1b[32m✓\x1b[0m ${oracle} woken on ${sshAlias} (session ${s.name}:${found.index})`);
             process.exit(0);
           }
         }


### PR DESCRIPTION
## Summary

Follow-up to #1293. The federation wake path was using `curlFetch(peer/api/send)` — restores the original SSH+tmux pattern from `src/wake.ts` @ `4cc891ed` (2026-03-10, before the refactor regression).

Also recorded as the intended design in `ψ/learn/cross-node-attach-design.md`: *"Bias toward shell-out (matches transport, no new endpoint)."*

## Changes

`src/commands/shared/wake-resolve-impl.ts` (~14 LOC):
- Replace `curlFetch(peer/api/send)` with `execFileSync("ssh", ["-tt", sshAlias, \`tmux send-keys -t '${s.name}:${found.index}' '' Enter\`])`
- SSH alias resolution: `namedPeers[].ssh` → `namedPeers[].name` → URL hostname
- Bonus: prints peer name (e.g. `mba.wg`) instead of raw URL

## Why this is right

| | Before | After |
|---|---|---|
| Transport | HTTP POST to peer's web server | SSH alias (same as `maw a` Tier 3) |
| Output | `http://10.20.0.16:3456` | `mba.wg` |
| Endpoint | `/api/send` | none |
| Matches original wake.ts | ❌ | ✅ (commit 4cc891ed) |
| Matches design doc | ❌ | ✅ (`cross-node-attach-design.md`) |
| Matches `maw a` pattern | ❌ | ✅ (`src/core/transport/ssh-attach.ts`) |

## Test plan

- [x] `bun test test/wake-*.test.ts` — 51 pass
- [ ] Manual: `maw wake phd` against namedPeer with .ssh field set

🤖 Generated with [Claude Code](https://claude.com/claude-code)