### PR TITLE
release: v26.5.13-alpha.1120

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.13-alpha.1102",
+  "version": "26.5.13-alpha.1120",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Bundles 1 PR merged to alpha since v26.5.13-alpha.1102:
- #1295 fix(wake): SSH+tmux wake for federation peers (not HTTP /api/send) — restores original 4cc891ed pattern

Cuts v26.5.13-alpha.1120 on merge via calver-release.yml.