### PR TITLE
fix(wake): case-insensitive fuzzy match for *-oracle repos

### DIFF
--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -109,11 +109,13 @@ export async function resolveOracle(
     const { ghqList } = await import("../../core/ghq");
     const repos = await ghqList();
     const oracleLower = oracle.toLowerCase();
+    // #997 — case-insensitive endsWith so DustBoy-Phd-Oracle matches
+    // alongside foo-oracle. Also strip -oracle case-insensitively.
     const candidates = repos
-      .filter(p => p.endsWith("-oracle"))
+      .filter(p => p.toLowerCase().endsWith("-oracle"))
       .map(p => p.split("/").pop()!)
       .filter(name => {
-        const bare = name.replace(/-oracle$/, "");
+        const bare = name.toLowerCase().replace(/-oracle$/, "");
         return bare.includes(oracleLower) || oracleLower.includes(bare);
       });
     if (candidates.length === 1) {


### PR DESCRIPTION
## Summary

`maw wake phd` (and by extension `maw a phd`) was missing local `DustBoy-Phd-Oracle`-style repos because `p.endsWith("-oracle")` is case-sensitive. Paths like `laris-co/DustBoy-Phd-Oracle` end with `-Oracle` (capital O) and never matched.

## Change

`src/commands/shared/wake-resolve-impl.ts:117`:
- `p.endsWith("-oracle")` → `p.toLowerCase().endsWith("-oracle")`
- bare-stem strip also lowercased before comparison

## Test plan

- [x] `bun test test/wake-*.test.ts` — 51 pass
- [x] Live: `bun -e 'resolveOracle("phd", {})'` now returns `/opt/Code/github.com/laris-co/DustBoy-Phd-Oracle`
- [x] Case variants tested: `phd`, `PHD`, `dustboy-phd`, `DustBoy-Phd` — all resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)