### PR TITLE
release: v26.5.13-alpha.1225

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.13-alpha.1120",
+  "version": "26.5.13-alpha.1225",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Bundles 1 PR merged to alpha since v26.5.13-alpha.1120:
- #1297 fix(wake): case-insensitive fuzzy match for *-oracle repos

Pairs with maw-plugin-registry#59 (built-in attach Phase 1 + delegate-to-wake).

Cuts v26.5.13-alpha.1225 on merge via calver-release.yml.