### PR TITLE
fix(wake): case-insensitive resolvedOracle update (closes #1299)

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -86,9 +86,10 @@ export async function cmdWake(oracle: string, opts: WakeCmdOptions): Promise<str
 
   // #997 — when fuzzy match resolved a different repo (e.g. "v3" → "arra-oracle-v3-oracle"),
   // update oracle to the resolved name so session/window names are correct.
-  const resolvedOracle = repoName.replace(/-oracle$/, "");
-  if (resolvedOracle !== oracle && repoName.endsWith("-oracle")) {
-    oracle = resolvedOracle;
+  // #1299 — case-insensitive match: e.g. "DustBoy-Phd-Oracle" should resolve too.
+  const resolvedOracle = repoName.replace(/-oracle$/i, "");
+  if (resolvedOracle !== oracle && repoName.toLowerCase().endsWith("-oracle")) {
+    oracle = resolvedOracle.toLowerCase();
   }
 
   // #673 — extract org/repo slug from ghq path (…/github.com/<org>/<repo>)


### PR DESCRIPTION
## Summary

Closes #1299. Same case-sensitivity bug class as #1297 — different location.

`maw a phd` (or `maw wake phd`) resolved correctly to `laris-co/DustBoy-Phd-Oracle` via the fuzzy matcher (fixed in #1297), but then created session `32-phd` / window `phd-oracle` instead of `NN-dustboy-phd` / window `dustboy-phd-oracle`. Downstream: `maw ls` classifies the session as "Other" instead of "Fleet".

Root cause: `wake-cmd.ts:89-90` used case-sensitive `repoName.endsWith("-oracle")` — false for `DustBoy-Phd-Oracle` (capital O) — so the resolved-name update never fired and `oracle` stayed as the bare typed query.

## Diff

`src/commands/shared/wake-cmd.ts:87-93`:
- `replace(/-oracle$/, "")` → `replace(/-oracle$/i, "")` (regex case-insensitive flag)
- `repoName.endsWith("-oracle")` → `repoName.toLowerCase().endsWith("-oracle")`
- `oracle = resolvedOracle` → `oracle = resolvedOracle.toLowerCase()` (canonical maw lowercase form)

## Test plan

- [x] `MAW_TEST_MODE=1 bun test test/wake-*.test.ts` — 118 pass, 0 fail
- [ ] Live: `maw a phd` (after merge + alpha cut) creates session `NN-dustboy-phd` matching fleet config, appears in `maw ls` Fleet section

🤖 Generated with [Claude Code](https://claude.com/claude-code)