### PR TITLE
release: v26.5.13-alpha.1253

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.13-alpha.1225",
+  "version": "26.5.13-alpha.1253",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Bundles 1 PR merged to alpha since v26.5.13-alpha.1225:
- #1300 fix(wake): case-insensitive resolvedOracle update (closes #1299)

Pairs with attach Phase 1 + delegate-to-wake. After this lands + local rebuild, `maw a phd` creates session matching fleet config, appears in `maw ls` Fleet section.

Cuts v26.5.13-alpha.1253 on merge via calver-release.yml.