### PR TITLE
fix(split): refuse to carve caller pane when --no-attach + no --from from Claude pane (closes #1303)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.13-alpha.1253",
+  "version": "26.5.14-alpha.126",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/plugins/pane/split.ts
+++ b/src/commands/plugins/pane/split.ts
@@ -14,6 +14,8 @@
  * pane-ref resolution or pct validation.
  */
 import { cmdTmuxSplit } from "../tmux/impl";
+import { isClaudeLikePane, callerPaneCarveRefusal } from "../tmux/safety";
+import { hostExec } from "../../../sdk";
 
 export interface PaneSplitOpts {
   /** Horizontal split (side-by-side). Mutually exclusive with vertical. */
@@ -56,6 +58,25 @@ export async function cmdPaneSplit(command: string, opts: PaneSplitOpts = {}): P
   const target = opts.target ?? process.env.TMUX_PANE ?? "";
   if (!target) {
     throw new Error("no target — pass -t SESSION:WINDOW or run inside a tmux pane");
+  }
+
+  // Foot-gun refusal (#1303): when no explicit `-t` target is supplied, the
+  // caller's pane ($TMUX_PANE) gets carved. If the caller is running a
+  // claude-like process (Claude Code session), refuse outright. Mirror of
+  // the gate in `maw split` — see split/impl.ts for full rationale.
+  if (!opts.target && process.env.TMUX_PANE) {
+    let callerCmd: string | undefined;
+    try {
+      const out = await hostExec(
+        `tmux display-message -p -t '${process.env.TMUX_PANE.replace(/'/g, "'\\''")}' '#{pane_current_command}'`,
+      );
+      callerCmd = out.trim();
+    } catch {
+      // Lookup failure is rare; don't block legitimate splits on it.
+    }
+    if (isClaudeLikePane(callerCmd)) {
+      throw new Error(callerPaneCarveRefusal(process.env.TMUX_PANE, callerCmd));
+    }
   }
 
   // Default vertical=false (= horizontal). `-h` is the default tmux orientation

--- a/src/commands/plugins/split/SKILL.md
+++ b/src/commands/plugins/split/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: split
+description: Carve the caller's tmux pane and attach to (or open a shell in) a fleet session.
+---
+
+# `maw split <target>`
+
+Split the current tmux pane and, by default, attach to `<target>` in the new pane.
+
+> **The pane it carves is YOUR pane.** Without `--from`, every split slices
+> the caller's pane in half — the new pane is created beside (or below) the
+> one you typed the command from. This is by design (matches the implicit
+> behavior of raw `tmux split-window`) but is the source of the #1303 foot-gun
+> when run from inside a Claude Code session.
+
+## Synopsis
+
+```
+maw split <target> [--pct N] [--vertical] [--no-attach] [--from <pane>]
+```
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--pct N` | `50` | Width (or height, with `--vertical`) of the new pane, 1–99. |
+| `--vertical` | off | Split top/bottom instead of side-by-side. |
+| `--no-attach` | off | Open a plain shell in the new pane — don't `attach-session` to `<target>`. |
+| `--from <pane>` | `$TMUX_PANE` | Anchor pane to carve. Pass a `%N` pane id or another oracle's session to slice a peer's pane instead of your own. |
+
+## Target resolution
+
+- `session:window` → used verbatim
+- `session` → resolves to `session:window[0]`
+- bare oracle name → finds the fleet session matching `*-<name>` or exact `<name>`
+
+Resolution rules live in `src/core/matcher/resolve-target.ts` — same rules as
+the rest of maw (exact > suffix/prefix fuzzy > ambiguous → loud error).
+
+## Carve semantics
+
+`maw split` is a **carving** verb: it always splits an existing pane, and the
+default anchor is `$TMUX_PANE` (the pane you're typing in).
+
+```
+┌──────────────┐         ┌──────┬───────┐
+│              │   →     │      │       │
+│  your pane   │         │ your │ new   │
+│              │         │ pane │ pane  │
+└──────────────┘         └──────┴───────┘
+```
+
+To carve a peer's pane instead of your own, use `--from %N` (or `--from session:window`).
+This is how `maw view` lays out fleet panes side-by-side without touching the
+caller's session.
+
+## When NOT to use `maw split`
+
+If you want to launch a process **without** carving your current pane, use
+the non-carve verbs from #1304:
+
+| Goal | Use |
+|---|---|
+| open an interactive shell on a peer oracle without slicing yours | `maw shell <name>` |
+| run a background command on a peer oracle without slicing yours | `maw bg <name> "<cmd>"` |
+| carve a peer's pane intentionally (debugging layout) | `maw split <name> --from <pane>` |
+| carve your own pane to attach to a peer (classic flow) | `maw split <name>` |
+
+## The Claude foot-gun (#1303)
+
+Running `maw split <name> --no-attach` from inside a Claude Code session
+without `--from` would silently carve the Claude pane — three back-to-back
+calls would carve it three times, leaving the AI session in a 1/8th-width
+sliver.
+
+Since alpha v26.5.13, this exact combination refuses with:
+
+```
+refusing to carve caller's pane: would slice the claude-like pane '%42' (running 'claude').
+  use `maw shell <name>` for a non-carve interactive shell (#1304)
+  use `maw bg <name> "<cmd>"` for a non-carve background command (#1304)
+  use `--from <oracle>` (or `-t <pane>` for `maw pane split`) to carve a different pane intentionally
+```
+
+Heuristic: caller pane's `pane_current_command` is checked via
+`isClaudeLikePane()` (substring `claude` or `N.N.N` version pattern) at the
+top of `cmdSplit`. The same gate is mirrored in `maw pane split` — both
+verbs share `callerPaneCarveRefusal()` from `tmux/safety.ts` so the error
+string is byte-identical.
+
+Escape hatches:
+- explicit `--from <pane>` (any non-Claude anchor disables the gate)
+- `--no-attach` is not the gating condition alone — only `--no-attach` *and*
+  no `--from` *and* a Claude-like caller all together trigger refusal.
+
+## See also
+
+- `maw shell` / `maw bg` — non-carve peer-launch verbs (#1304)
+- `maw pane split` — lower-level primitive (no fleet target resolution)
+- `maw view` — multi-pane fleet dashboard (uses `--from` internally)

--- a/src/commands/plugins/split/impl.ts
+++ b/src/commands/plugins/split/impl.ts
@@ -2,6 +2,7 @@ import { listSessions, hostExec, withPaneLock } from "../../../sdk";
 import { resolveSessionTarget } from "../../../core/matcher/resolve-target";
 import { normalizeTarget } from "../../../core/matcher/normalize-target";
 import { formatError } from "../../../lib/format-error";
+import { isClaudeLikePane, callerPaneCarveRefusal } from "../tmux/safety";
 
 export interface SplitOpts {
   /** Split percentage (1-99). Default: 50. */
@@ -56,6 +57,34 @@ export async function cmdSplit(target: string, opts: SplitOpts = {}) {
   const pct = opts.pct ?? 50;
   if (!Number.isFinite(pct) || pct < 1 || pct > 99) {
     throw new Error(`--pct must be 1-99 (got ${pct})`);
+  }
+
+  // Foot-gun refusal (#1303): when `--no-attach` is used and no `--from`
+  // anchor is supplied, the caller's own pane ($TMUX_PANE) is the implicit
+  // anchor — meaning the caller's pane gets carved. If the caller is running
+  // a claude-like process (Claude Code session), refuse outright. Carving
+  // a live AI pane is almost never what the user wants; the user almost
+  // certainly meant to spawn a peer shell, not slice their own session.
+  //
+  // Three escape hatches, all mentioned in the error message:
+  //   - `maw shell <name>` — non-carve interactive shell (#1304)
+  //   - `maw bg <name> "<cmd>"` — non-carve background command (#1304)
+  //   - `--from <oracle>` — carve a different peer's pane intentionally
+  if (opts.noAttach && !opts.anchorPane && process.env.TMUX_PANE) {
+    let callerCmd: string | undefined;
+    try {
+      const out = await hostExec(
+        `tmux display-message -p -t '${process.env.TMUX_PANE.replace(/'/g, "'\\''")}' '#{pane_current_command}'`,
+      );
+      callerCmd = out.trim();
+    } catch {
+      // If the lookup fails (rare — pane gone, tmux unreachable), skip the
+      // gate rather than block legitimate splits. The bug we're guarding
+      // against is the silent carve, not the rare lookup failure.
+    }
+    if (isClaudeLikePane(callerCmd)) {
+      throw new Error(callerPaneCarveRefusal(process.env.TMUX_PANE, callerCmd));
+    }
   }
 
   // Resolve target to session:window if bare name given. Resolution rules

--- a/src/commands/plugins/tmux/safety.ts
+++ b/src/commands/plugins/tmux/safety.ts
@@ -66,6 +66,25 @@ export function isClaudeLikePane(paneCurrentCommand: string | undefined): boolea
 }
 
 /**
+ * Foot-gun refusal message (#1303) — shared between `maw split` and
+ * `maw pane split` so a single grep finds every refusal site. Both verbs
+ * implicitly carve $TMUX_PANE when called without an explicit anchor;
+ * when the caller is Claude Code, that carves the live AI pane.
+ *
+ * Returns the full error body (caller throws). Includes the offending
+ * pane id and current-command so the user can verify the heuristic
+ * matched the pane they expected.
+ */
+export function callerPaneCarveRefusal(panePane: string, callerCmd: string | undefined): string {
+  return (
+    `refusing to carve caller's pane: would slice the claude-like pane '${panePane}' (running '${callerCmd ?? "?"}').\n` +
+    `  use \`maw shell <name>\` for a non-carve interactive shell (#1304)\n` +
+    `  use \`maw bg <name> "<cmd>"\` for a non-carve background command (#1304)\n` +
+    `  use \`--from <oracle>\` (or \`-t <pane>\` for \`maw pane split\`) to carve a different pane intentionally`
+  );
+}
+
+/**
  * Fleet session protection (shared with kill). A session whose name
  * matches a known fleet stem OR ends in `-view` must never be killed
  * without --force.

--- a/test/isolated/split-foot-gun.test.ts
+++ b/test/isolated/split-foot-gun.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Regression tests for #1303 — `maw split` foot-gun refusal.
+ *
+ * The bug: `maw split <target> --no-attach` (no `--from`) falls back to
+ * $TMUX_PANE as anchor, which means the CALLER's own pane gets carved.
+ * When the caller is a Claude Code session, that slices the live AI pane —
+ * almost never what the user intended.
+ *
+ * Fix: refuse outright when caller pane is claude-like and no explicit
+ * anchor (`--from` for split, `-t` for pane split) was supplied. The
+ * refusal message points at `maw shell` / `maw bg` (issue #1304) as
+ * non-carve alternatives.
+ *
+ * Mirror gate exists in `src/commands/plugins/pane/split.ts` — both verbs
+ * share the helper `callerPaneCarveRefusal` from tmux/safety.ts so the
+ * error string is byte-identical.
+ */
+import { describe, test, expect, beforeEach, mock } from "bun:test";
+import { mockSshModule } from "../helpers/mock-ssh";
+import { mockConfigModule } from "../helpers/mock-config";
+
+// Capture every tmux command + let each test stub the responder.
+let commands: string[] = [];
+let execResponder: (cmd: string) => string = () => "";
+
+mock.module("../../src/config", () => mockConfigModule(() => ({ host: "white.local" })));
+
+function installSshMock() {
+  mock.module("../../src/core/transport/ssh", () =>
+    mockSshModule({
+      hostExec: async (cmd: string) => {
+        commands.push(cmd);
+        return execResponder(cmd);
+      },
+      ssh: async (cmd: string) => {
+        commands.push(cmd);
+        return execResponder(cmd);
+      },
+      listSessions: async () => [
+        { name: "mawjs-yeast", windows: [{ index: 0 }] },
+      ],
+    }),
+  );
+}
+installSshMock();
+
+beforeEach(() => {
+  commands = [];
+  execResponder = () => "";
+  installSshMock();
+});
+
+// Helper — set env so the guard sees a Claude pane and the `if (!TMUX)`
+// preflight passes. Returns a cleanup fn that restores prior values.
+function withTmuxPaneEnv(opts: { tmux?: string; pane?: string } = {}) {
+  const prev = { TMUX: process.env.TMUX, TMUX_PANE: process.env.TMUX_PANE };
+  process.env.TMUX = opts.tmux ?? "/tmp/tmux-501/default,12345,0";
+  process.env.TMUX_PANE = opts.pane ?? "%42";
+  return () => {
+    if (prev.TMUX === undefined) delete process.env.TMUX;
+    else process.env.TMUX = prev.TMUX;
+    if (prev.TMUX_PANE === undefined) delete process.env.TMUX_PANE;
+    else process.env.TMUX_PANE = prev.TMUX_PANE;
+  };
+}
+
+// ── cmdSplit refusal (the canonical #1303 regression) ──────────────────────
+
+describe("cmdSplit — #1303 foot-gun refusal", () => {
+  test("--no-attach + no --from from a Claude pane → refuses with helpful error", async () => {
+    const restore = withTmuxPaneEnv({ pane: "%42" });
+    // tmux display-message returns "claude" for the caller pane.
+    execResponder = (cmd: string) => {
+      if (cmd.startsWith("tmux display-message") && cmd.includes("%42")) {
+        return "claude\n";
+      }
+      return "";
+    };
+
+    const { cmdSplit } = await import("../../src/commands/plugins/split/impl");
+    try {
+      await expect(cmdSplit("yeast", { noAttach: true })).rejects.toThrow(
+        /refusing to carve caller's pane/,
+      );
+      // Verify it didn't fall through to the actual split-window invocation.
+      expect(commands.some((c) => c.startsWith("tmux split-window"))).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+
+  test("refusal message mentions maw shell, maw bg, and --from", async () => {
+    const restore = withTmuxPaneEnv();
+    execResponder = (cmd: string) =>
+      cmd.startsWith("tmux display-message") ? "claude" : "";
+
+    const { cmdSplit } = await import("../../src/commands/plugins/split/impl");
+    try {
+      let err: Error | undefined;
+      await cmdSplit("yeast", { noAttach: true }).catch((e) => {
+        err = e instanceof Error ? e : new Error(String(e));
+      });
+      expect(err).toBeDefined();
+      expect(err!.message).toContain("maw shell");
+      expect(err!.message).toContain("maw bg");
+      expect(err!.message).toContain("--from");
+      expect(err!.message).toContain("#1304");
+    } finally {
+      restore();
+    }
+  });
+
+  test("--no-attach + --from <pane> → no refusal (explicit anchor)", async () => {
+    const restore = withTmuxPaneEnv();
+    // Even if the caller pane LOOKS claude-like, --from bypasses the gate.
+    execResponder = (cmd: string) => {
+      if (cmd.startsWith("tmux display-message")) return "claude";
+      return "";
+    };
+
+    const { cmdSplit } = await import("../../src/commands/plugins/split/impl");
+    try {
+      await cmdSplit("yeast", { noAttach: true, anchorPane: "%99" });
+      // Split actually happened — targeting %99, not %42.
+      const split = commands.find((c) => c.startsWith("tmux split-window"));
+      expect(split).toBeDefined();
+      expect(split).toContain("%99");
+    } finally {
+      restore();
+    }
+  });
+
+  test("non-Claude caller pane → no refusal", async () => {
+    const restore = withTmuxPaneEnv();
+    execResponder = (cmd: string) => {
+      if (cmd.startsWith("tmux display-message")) return "bash";
+      return "";
+    };
+
+    const { cmdSplit } = await import("../../src/commands/plugins/split/impl");
+    try {
+      await cmdSplit("yeast", { noAttach: true });
+      const split = commands.find((c) => c.startsWith("tmux split-window"));
+      expect(split).toBeDefined();
+    } finally {
+      restore();
+    }
+  });
+
+  test("attach path (no --no-attach) is NOT gated — pre-existing behavior preserved", async () => {
+    const restore = withTmuxPaneEnv();
+    execResponder = (cmd: string) =>
+      cmd.startsWith("tmux display-message") ? "claude" : "";
+
+    const { cmdSplit } = await import("../../src/commands/plugins/split/impl");
+    try {
+      // No noAttach flag — attaching to a session in the new pane is a
+      // separate use case (intentional carve to ferry a peer). Don't gate
+      // here; the foot-gun is specifically about `--no-attach`.
+      await cmdSplit("yeast", {});
+      const split = commands.find((c) => c.startsWith("tmux split-window"));
+      expect(split).toBeDefined();
+      expect(split).toContain("attach-session");
+    } finally {
+      restore();
+    }
+  });
+});
+
+// ── cmdPaneSplit mirror gate ────────────────────────────────────────────────
+
+describe("cmdPaneSplit — #1303 foot-gun refusal (mirror)", () => {
+  test("no -t target from a Claude pane → refuses", async () => {
+    const restore = withTmuxPaneEnv({ pane: "%42" });
+    execResponder = (cmd: string) => {
+      if (cmd.startsWith("tmux display-message") && cmd.includes("%42")) {
+        return "claude";
+      }
+      return "";
+    };
+
+    const { cmdPaneSplit } = await import("../../src/commands/plugins/pane/split");
+    try {
+      await expect(cmdPaneSplit("", {})).rejects.toThrow(
+        /refusing to carve caller's pane/,
+      );
+      expect(commands.some((c) => c.startsWith("tmux split-window"))).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+
+  test("explicit -t target bypasses the gate", async () => {
+    const restore = withTmuxPaneEnv();
+    execResponder = (cmd: string) =>
+      cmd.startsWith("tmux display-message") ? "claude" : "";
+
+    const { cmdPaneSplit } = await import("../../src/commands/plugins/pane/split");
+    try {
+      await cmdPaneSplit("echo hi", { target: "%999" });
+      const split = commands.find((c) => c.startsWith("tmux split-window"));
+      expect(split).toBeDefined();
+      expect(split).toContain("%999");
+    } finally {
+      restore();
+    }
+  });
+
+  test("non-Claude caller → no refusal, falls through to split", async () => {
+    const restore = withTmuxPaneEnv();
+    execResponder = (cmd: string) =>
+      cmd.startsWith("tmux display-message") ? "bash" : "";
+
+    const { cmdPaneSplit } = await import("../../src/commands/plugins/pane/split");
+    try {
+      await cmdPaneSplit("echo hi", {});
+      const split = commands.find((c) => c.startsWith("tmux split-window"));
+      expect(split).toBeDefined();
+    } finally {
+      restore();
+    }
+  });
+});
+
+// ── isClaudeLikePane + callerPaneCarveRefusal — unit-level sanity ──────────
+
+describe("safety helpers", () => {
+  test("isClaudeLikePane matches claude substring + version-y patterns", async () => {
+    const { isClaudeLikePane } = await import(
+      "../../src/commands/plugins/tmux/safety"
+    );
+    expect(isClaudeLikePane("claude")).toBe(true);
+    expect(isClaudeLikePane("bun claude --foo")).toBe(true);
+    expect(isClaudeLikePane("2.1.111")).toBe(true);
+    expect(isClaudeLikePane("bash")).toBe(false);
+    expect(isClaudeLikePane(undefined)).toBe(false);
+    expect(isClaudeLikePane("")).toBe(false);
+  });
+
+  test("callerPaneCarveRefusal includes pane id + all three escape hatches", async () => {
+    const { callerPaneCarveRefusal } = await import(
+      "../../src/commands/plugins/tmux/safety"
+    );
+    const msg = callerPaneCarveRefusal("%42", "claude");
+    expect(msg).toContain("%42");
+    expect(msg).toContain("claude");
+    expect(msg).toContain("maw shell");
+    expect(msg).toContain("maw bg");
+    expect(msg).toContain("--from");
+    expect(msg).toContain("-t <pane>");
+    expect(msg).toContain("#1304");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1303.

Fixes a foot-gun in `maw split` where running it with `--no-attach` and no `--from` from inside a Claude pane would carve the caller pane itself.

### Changes
- `src/commands/plugins/split/impl.ts` — refuse to split caller pane when `--no-attach` + no `--from` and caller is the Claude pane
- `src/commands/plugins/pane/split.ts` — mirror the same guard
- `src/commands/plugins/tmux/safety.ts` — shared helper extracted
- `src/commands/plugins/split/SKILL.md` — new skill doc
- `test/isolated/split-foot-gun.test.ts` — 10 regression tests

### Tests
- Full suite: 1344 pass / 0 fail / 12 skip
- Plugin tests: 232 pass / 0 fail
- Isolated tests: 83/83 files passed

CalVer bump: v26.5.13-alpha.1253 → v26.5.14-alpha.126