### PR TITLE
feat(wait): add maw wait <name> + fix #1304 dispatch (closes #1306)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.14-alpha.130",
+  "version": "26.5.14-alpha.219",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/plugins/bg/index.ts
+++ b/src/commands/plugins/bg/index.ts
@@ -47,11 +47,17 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
 
   try {
     const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+    // skip=0: ctx.args from the dispatcher is already stripped of the command
+    // name (src/cli/dispatch.ts ~L82: `args.slice(matchedWords)`). Pre-#1306
+    // this was skip=1 which silently ate the first positional, making
+    // `maw bg <name> "<cmd>"` always error with "session name required". The
+    // shipped tests passed a leading command name so they didn't catch it —
+    // tests updated alongside this fix.
     const flags = parseFlags(args, {
       "--attach":    Boolean,
       "--no-attach": Boolean,
       "--help":      Boolean, "-h": "--help",
-    }, 1);
+    }, 0);
 
     if (flags["--help"]) {
       printUsage();

--- a/src/commands/plugins/shell/index.ts
+++ b/src/commands/plugins/shell/index.ts
@@ -44,11 +44,17 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
 
   try {
     const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+    // skip=0: ctx.args from the dispatcher is already stripped of the command
+    // name (src/cli/dispatch.ts ~L82: `args.slice(matchedWords)`). Pre-#1306
+    // this was skip=1 which silently ate the first positional, making
+    // `maw shell <name>` always error with "session name required". The
+    // shipped tests passed a leading command name so they didn't catch it —
+    // tests updated alongside this fix.
     const flags = parseFlags(args, {
       "--no-attach": Boolean,
       "--attach":    Boolean,
       "--help":      Boolean, "-h": "--help",
-    }, 1);
+    }, 0);
 
     if (flags["--help"]) {
       printUsage();

--- a/src/commands/plugins/wait/SKILL.md
+++ b/src/commands/plugins/wait/SKILL.md
@@ -1,0 +1,49 @@
+# maw wait
+
+Block until a tmux session named `<name>` no longer exists (#1306). Returns immediately if the session never existed.
+
+## Usage
+
+```
+maw wait <name>                        # poll every 5s, no timeout
+maw wait <name> --interval 1           # poll every 1s
+maw wait <name> --timeout 600          # bail after 10 min
+maw wait <name> --interval 1 --timeout 600
+```
+
+## When to use
+
+After `maw bg <name> "<cmd>"` (#1304), when you want to block the current shell until that background command finishes — e.g. to chain a builder, a fetcher, or a one-shot task.
+
+```bash
+maw bg builder "bun run build"
+maw wait builder
+echo "build done — running tests"
+maw bg tests "bun test"
+maw wait tests
+```
+
+Mirrors POSIX shell `wait %1`. Same shape as `until ! tmux has-session -t … ; do sleep 5; done`, made first-class.
+
+## When NOT to use
+
+- For interactive sessions you started with `maw shell` — they exit when the human types `exit`, not on a schedule. `maw wait` works, but the semantics are different (you're waiting for a human, not a job).
+- When you need the spawned process's exit code — `maw wait` only sees "is the session alive?", not the command's exit status. Use `maw bg` log capture (separate issue) or read `tmux capture-pane` once it ends.
+
+## Behavior
+
+- Polls `tmux has-session -t <name>` every `--interval` seconds.
+- Returns immediately if the session never existed.
+- With `--timeout`, throws (ok=false) after the deadline; the error message is prefixed `timeout: …` so callers can distinguish from arg errors.
+
+## Out of scope (v1)
+
+- Exit-code propagation from the wrapped command. Tracked separately.
+- Waiting on multiple names (`maw wait foo bar baz`). Punt to v2 unless needed.
+- Waiting on remote / `maw a` peer sessions.
+
+## Related
+
+- `maw bg <name> "<cmd>"` — sibling verb that spawns the session (#1304).
+- `maw shell <name>` — sibling verb for interactive shells (#1304).
+- `maw kill <name>` — force-end a session (causes `maw wait` to return).

--- a/src/commands/plugins/wait/impl.ts
+++ b/src/commands/plugins/wait/impl.ts
@@ -1,0 +1,68 @@
+/**
+ * `maw wait <name>` — block until a tmux session named `<name>` no longer
+ * exists (#1306). Completes the POSIX-style job-control trio with
+ * `maw bg` and `maw shell` (#1304).
+ *
+ * Returns immediately if the session never existed — "wait for nothing"
+ * is satisfied without polling. Mirrors POSIX `wait %1` on a job that has
+ * already finished.
+ *
+ * Polls `tmux.hasSession(name)` every `intervalSec` seconds (default 5).
+ * Optional `timeoutSec` makes the wait bounded; on expiry, throws so the
+ * outer handler can surface exit code 1.
+ *
+ * Out of scope (v1, per #1306 body):
+ *   - process exit-code propagation (needs `maw bg` log capture; separate issue)
+ *   - waiting on multiple names at once
+ *   - waiting on `maw a` peer / remote sessions
+ */
+import { tmux } from "../../../core/transport/tmux-class";
+
+export interface WaitOpts {
+  /** Poll interval in seconds. Default 5. Fractional values allowed. */
+  intervalSec?: number;
+  /** Hard timeout in seconds. Throws on expiry. Omit for no timeout. */
+  timeoutSec?: number;
+}
+
+/** Thrown when --timeout is exceeded. Caller maps to exit code 1. */
+export class WaitTimeoutError extends Error {
+  constructor(name: string, timeoutSec: number) {
+    super(`timeout: session '${name}' still running after ${timeoutSec}s`);
+    this.name = "WaitTimeoutError";
+  }
+}
+
+export async function cmdWait(name: string, opts: WaitOpts = {}): Promise<void> {
+  if (!name) throw new Error("session name required (usage: maw wait <name>)");
+
+  const intervalSec = opts.intervalSec ?? 5;
+  if (!(intervalSec > 0)) {
+    throw new Error(`--interval must be positive (got ${opts.intervalSec})`);
+  }
+  if (opts.timeoutSec !== undefined && !(opts.timeoutSec > 0)) {
+    throw new Error(`--timeout must be positive (got ${opts.timeoutSec})`);
+  }
+
+  // Fast path: session never existed → nothing to wait for. This matches
+  // POSIX `wait` on a finished job: no error, no spin.
+  if (!(await tmux.hasSession(name))) {
+    console.log(`✓ session '${name}' not running — nothing to wait for`);
+    return;
+  }
+
+  const intervalMs = intervalSec * 1000;
+  const deadline = opts.timeoutSec ? Date.now() + opts.timeoutSec * 1000 : Infinity;
+
+  // Loop body uses ts-ignore-style infinite condition; exits via return or throw.
+  while (true) {
+    if (Date.now() > deadline) {
+      throw new WaitTimeoutError(name, opts.timeoutSec!);
+    }
+    await new Promise<void>((r) => setTimeout(r, intervalMs));
+    if (!(await tmux.hasSession(name))) {
+      console.log(`✓ session '${name}' ended`);
+      return;
+    }
+  }
+}

--- a/src/commands/plugins/wait/index.ts
+++ b/src/commands/plugins/wait/index.ts
@@ -1,0 +1,93 @@
+/**
+ * `maw wait` — block until a tmux session ends (#1306).
+ *
+ * Usage:
+ *   maw wait <name>                        # poll every 5s, no timeout
+ *   maw wait <name> --interval 1           # poll every 1s
+ *   maw wait <name> --timeout 600          # bail after 10 min (exit 1)
+ *
+ * Pairs with `maw bg` and `maw shell` (#1304) — the missing third of the
+ * POSIX-style job-control trio.
+ */
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { parseFlags } from "../../../cli/parse-args";
+import { cmdWait, WaitTimeoutError } from "./impl";
+
+export const command = {
+  name: "wait",
+  description: "Block until a tmux session ends (#1306).",
+};
+
+function printUsage(): void {
+  console.log("usage: maw wait <name> [--interval N] [--timeout N]");
+  console.log("  <name>        tmux session name");
+  console.log("  --interval N  poll interval in seconds (default: 5)");
+  console.log("  --timeout N   bail after N seconds (default: no timeout, exit 1 on bail)");
+  console.log("");
+  console.log("examples:");
+  console.log("  maw wait builder                          # block until 'builder' ends");
+  console.log("  maw wait builder --interval 1             # check every second");
+  console.log("  maw wait builder --timeout 600            # bail after 10 min");
+  console.log("  maw bg t \"sleep 2\" && maw wait t          # spawn + wait pattern");
+}
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: unknown[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: unknown[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+
+  try {
+    const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+    // skip=0: ctx.args from the dispatcher is already stripped of the command
+    // name (see src/cli/dispatch.ts ≈L82: `args.slice(matchedWords)`). The
+    // sibling shell + bg index files used skip=1 which silently ate the first
+    // positional — fixed in this PR alongside the new sibling.
+    const flags = parseFlags(args, {
+      "--interval": Number,
+      "--timeout":  Number,
+      "--help":     Boolean, "-h": "--help",
+    }, 0);
+
+    if (flags["--help"]) {
+      printUsage();
+      return { ok: true, output: logs.join("\n") || undefined };
+    }
+
+    const positional = flags._ as string[];
+    const name = positional[0];
+
+    if (!name) {
+      printUsage();
+      return { ok: false, error: "session name required", output: logs.join("\n") };
+    }
+
+    await cmdWait(name, {
+      intervalSec: flags["--interval"],
+      timeoutSec:  flags["--timeout"],
+    });
+
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    // WaitTimeoutError → exit code 1 (timeout); other Errors → exit code 2 (args/runtime).
+    // The plugin contract is { ok, error }; the CLI host maps ok=false to a
+    // non-zero exit. We don't have a way to differentiate 1 vs 2 from here
+    // (handler can only signal ok/!ok), so the cleanest discriminator is to
+    // include the error class name in the message: `timeout: ...` for timeouts,
+    // anything else for arg/usage errors. The shell pattern (grep / case) can
+    // act on the message; ergonomic exit codes are a v2 concern once the CLI
+    // host gains a richer return contract (#1311 tracker if/when filed).
+    return { ok: false, error: msg, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/src/commands/plugins/wait/plugin.json
+++ b/src/commands/plugins/wait/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "wait",
+  "version": "0.1.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Block until a tmux session named <name> no longer exists (#1306). Completes the bg/shell/wait POSIX-style trio.",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "wait",
+    "help": "maw wait <name> [--interval N] [--timeout N] — block until tmux session ends"
+  },
+  "weight": 10
+}

--- a/test/plugins/shell-bg-verbs.test.ts
+++ b/test/plugins/shell-bg-verbs.test.ts
@@ -22,6 +22,13 @@ import * as tmuxImpl from "../../src/commands/plugins/tmux/impl";
  * the live `tmux` singleton is patched per-test only — avoids `mock.module`
  * global pollution that breaks sibling oracle/fleet tests via the `Tmux`
  * class export.
+ *
+ * Arg-shape note (#1306): ctx.args from the real CLI dispatcher does NOT
+ * include the command name (the dispatcher strips it via
+ * `args.slice(matchedWords)`). The original #1304 tests passed
+ * `["shell", "scratch"]` which masked a parseFlags(…, skip=1) bug that made
+ * `maw shell foo` always fail at the real CLI. Tests below pass the real
+ * shape `["scratch"]` so they would catch the regression next time.
  */
 
 const calls: {
@@ -76,7 +83,7 @@ describe("maw shell plugin", () => {
   });
 
   it("default: creates session + attaches", async () => {
-    const result = await handler({ source: "cli", args: ["shell", "scratch"] });
+    const result = await handler({ source: "cli", args: ["scratch"] });
     expect(result.ok).toBe(true);
     expect(calls.newSession).toHaveLength(1);
     expect(calls.newSession[0].name).toBe("scratch");
@@ -85,7 +92,7 @@ describe("maw shell plugin", () => {
   });
 
   it("--no-attach: creates session, does NOT attach", async () => {
-    const result = await handler({ source: "cli", args: ["shell", "svc", "--no-attach"] });
+    const result = await handler({ source: "cli", args: ["svc", "--no-attach"] });
     expect(result.ok).toBe(true);
     expect(calls.newSession).toHaveLength(1);
     expect(calls.newSession[0].name).toBe("svc");
@@ -94,7 +101,7 @@ describe("maw shell plugin", () => {
   });
 
   it("missing name: prints usage and errors", async () => {
-    const result = await handler({ source: "cli", args: ["shell"] });
+    const result = await handler({ source: "cli", args: [] });
     expect(result.ok).toBe(false);
     expect(result.error).toContain("required");
     expect(calls.newSession).toHaveLength(0);
@@ -102,7 +109,7 @@ describe("maw shell plugin", () => {
 
   it("existing session: fails loudly", async () => {
     existingSessions.add("scratch");
-    const result = await handler({ source: "cli", args: ["shell", "scratch"] });
+    const result = await handler({ source: "cli", args: ["scratch"] });
     expect(result.ok).toBe(false);
     expect(result.error).toContain("already exists");
     expect(calls.newSession).toHaveLength(0);
@@ -110,7 +117,7 @@ describe("maw shell plugin", () => {
   });
 
   it("--help: prints usage", async () => {
-    const result = await handler({ source: "cli", args: ["shell", "--help"] });
+    const result = await handler({ source: "cli", args: ["--help"] });
     expect(result.ok).toBe(true);
     expect(result.output).toContain("usage: maw shell");
     expect(calls.newSession).toHaveLength(0);
@@ -140,7 +147,7 @@ describe("maw bg plugin", () => {
   });
 
   it("default: spawns detached, does NOT attach", async () => {
-    const result = await handler({ source: "cli", args: ["bg", "dev", "bun run dev"] });
+    const result = await handler({ source: "cli", args: ["dev", "bun run dev"] });
     expect(result.ok).toBe(true);
     expect(calls.newSession).toHaveLength(1);
     expect(calls.newSession[0].name).toBe("dev");
@@ -151,7 +158,7 @@ describe("maw bg plugin", () => {
   });
 
   it("--attach: spawns AND attaches", async () => {
-    const result = await handler({ source: "cli", args: ["bg", "srv", "bun run dev", "--attach"] });
+    const result = await handler({ source: "cli", args: ["srv", "bun run dev", "--attach"] });
     expect(result.ok).toBe(true);
     expect(calls.newSession).toHaveLength(1);
     expect(calls.newSession[0].opts.command).toBe("bun run dev");
@@ -159,14 +166,14 @@ describe("maw bg plugin", () => {
   });
 
   it("missing name: prints usage and errors", async () => {
-    const result = await handler({ source: "cli", args: ["bg"] });
+    const result = await handler({ source: "cli", args: [] });
     expect(result.ok).toBe(false);
     expect(result.error).toContain("name required");
     expect(calls.newSession).toHaveLength(0);
   });
 
   it("missing command: prints usage and errors", async () => {
-    const result = await handler({ source: "cli", args: ["bg", "lonely"] });
+    const result = await handler({ source: "cli", args: ["lonely"] });
     expect(result.ok).toBe(false);
     expect(result.error).toContain("command required");
     expect(calls.newSession).toHaveLength(0);
@@ -174,7 +181,7 @@ describe("maw bg plugin", () => {
 
   it("existing session: fails loudly", async () => {
     existingSessions.add("dev");
-    const result = await handler({ source: "cli", args: ["bg", "dev", "bun run dev"] });
+    const result = await handler({ source: "cli", args: ["dev", "bun run dev"] });
     expect(result.ok).toBe(false);
     expect(result.error).toContain("already exists");
     expect(calls.newSession).toHaveLength(0);
@@ -182,7 +189,7 @@ describe("maw bg plugin", () => {
   });
 
   it("--help: prints usage", async () => {
-    const result = await handler({ source: "cli", args: ["bg", "--help"] });
+    const result = await handler({ source: "cli", args: ["--help"] });
     expect(result.ok).toBe(true);
     expect(result.output).toContain("usage: maw bg");
     expect(calls.newSession).toHaveLength(0);

--- a/test/plugins/wait-verb.test.ts
+++ b/test/plugins/wait-verb.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, spyOn, beforeEach, afterEach, mock } from "bun:test";
+import type { InvokeContext } from "../../src/plugin/types";
+import { tmux } from "../../src/core/transport/tmux-class";
+
+/**
+ * Tests for `maw wait` — the third verb of the POSIX-style job-control trio
+ * (#1306). Companion to `maw bg` + `maw shell` (#1304).
+ *
+ * Placed at `test/plugins/` (alongside `shell-bg-verbs.test.ts`) — NOT at
+ * `src/commands/plugins/wait/wait.test.ts` — for the same shard-stability
+ * reason documented in shell-bg-verbs.test.ts header. See PR #1307 retro
+ * and #1308 for the underlying EEXIST shard-flake.
+ *
+ * Mocking strategy: `spyOn(tmux, "hasSession")` + `mockRestore` in afterEach
+ * so the live `tmux` singleton is patched per-test only. Avoids
+ * `mock.module` global pollution.
+ */
+
+let aliveQueue: boolean[] = [];
+const calls: { hasSession: string[] } = { hasSession: [] };
+
+function resetCalls(): void {
+  calls.hasSession.length = 0;
+  aliveQueue = [];
+}
+
+/** Push a sequence of has-session results. Each call to `tmux.hasSession`
+ *  consumes one. If the queue empties, returns `false` (i.e. ended). */
+function queueAlive(...values: boolean[]): void {
+  aliveQueue.push(...values);
+}
+
+function installSpies(): { has: any } {
+  const has = spyOn(tmux, "hasSession").mockImplementation(async (name: string) => {
+    calls.hasSession.push(name);
+    return aliveQueue.shift() ?? false;
+  });
+  return { has };
+}
+
+describe("maw wait plugin", () => {
+  let handler: (ctx: InvokeContext) => Promise<any>;
+  let spies: { has: any };
+
+  beforeEach(async () => {
+    resetCalls();
+    spies = installSpies();
+    const mod = await import("../../src/commands/plugins/wait/index");
+    handler = mod.default;
+  });
+
+  afterEach(() => {
+    spies.has.mockRestore();
+    mock.restore();
+  });
+
+  // Arg-shape note: ctx.args from the real CLI dispatcher does NOT include
+  // the command name (dispatcher strips it via `args.slice(matchedWords)`).
+  // Tests pass the real shape `[<name>, ...flags]` so they catch regressions
+  // in the skip=0 parseFlags wiring.
+
+  it("session never existed: returns immediately", async () => {
+    queueAlive(false);
+    const result = await handler({ source: "cli", args: ["ghost"] });
+    expect(result.ok).toBe(true);
+    expect(calls.hasSession).toEqual(["ghost"]);
+    expect(result.output).toContain("not running");
+  });
+
+  it("session ends mid-wait: blocks then returns", async () => {
+    // alive once (fast path), then ends on next poll
+    queueAlive(true, false);
+    const result = await handler({
+      source: "cli",
+      // 1ms interval keeps test instant
+      args: ["builder", "--interval", "0.001"],
+    });
+    expect(result.ok).toBe(true);
+    expect(calls.hasSession.length).toBeGreaterThanOrEqual(2);
+    expect(result.output).toContain("ended");
+  });
+
+  it("--timeout exceeded: returns ok=false with timeout: prefix", async () => {
+    // Keep returning true forever — timeout must kick in.
+    spies.has.mockImplementation(async (name: string) => {
+      calls.hasSession.push(name);
+      return true;
+    });
+    const result = await handler({
+      source: "cli",
+      args: ["stuck", "--interval", "0.05", "--timeout", "0.01"],
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/^timeout:/);
+    expect(result.error).toContain("stuck");
+  });
+
+  it("missing name: prints usage and errors", async () => {
+    const result = await handler({ source: "cli", args: [] });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("required");
+    expect(calls.hasSession).toHaveLength(0);
+  });
+
+  it("--help: prints usage, does not poll", async () => {
+    const result = await handler({ source: "cli", args: ["--help"] });
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("usage: maw wait");
+    expect(calls.hasSession).toHaveLength(0);
+  });
+
+  it("--interval 0: rejects with validation error", async () => {
+    queueAlive(true);
+    const result = await handler({
+      source: "cli",
+      args: ["x", "--interval", "0"],
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("--interval");
+    // hasSession may still have been called by the fast-path check — that's fine.
+  });
+
+  it("--timeout 0: rejects with validation error", async () => {
+    queueAlive(true);
+    const result = await handler({
+      source: "cli",
+      args: ["x", "--timeout", "0"],
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("--timeout");
+  });
+
+  it("custom --interval is plumbed through", async () => {
+    queueAlive(true, true, false);
+    const start = Date.now();
+    const result = await handler({
+      source: "cli",
+      args: ["x", "--interval", "0.05"],
+    });
+    const elapsed = Date.now() - start;
+    expect(result.ok).toBe(true);
+    // Two intervals of 50ms after the fast-path check.
+    expect(elapsed).toBeGreaterThanOrEqual(50);
+    expect(calls.hasSession.length).toBeGreaterThanOrEqual(3);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1306 — adds `maw wait <name>`, completing the POSIX-style job-control trio with `maw bg` and `maw shell` from #1304.

```bash
maw bg builder \"bun run build\"
maw wait builder
echo \"build done — running tests\"
```

While writing the sibling test, caught a real bug in shipped #1304: `maw shell <name>` and `maw bg <name> \"<cmd>\"` were both broken at the CLI layer — `parseFlags(args, spec, /*skip=*/ 1)` silently consumed the first positional. The dispatcher (`src/cli/dispatch.ts`) already strips the command name via `args.slice(matchedWords)`, so `skip=1` dropped `<name>`. The original tests passed the wrong arg shape (`[\"shell\", \"scratch\"]`) so the gap stayed invisible.

This PR ships the new verb **and** the dispatch fix together because the bug was caught by the new sibling and the fix touches the same family.

## Changes

**New: `maw wait`** (~150 LOC + 8 tests)
- `src/commands/plugins/wait/{plugin.json,index.ts,impl.ts,SKILL.md}`
- Polls `tmux.hasSession()` every `--interval` seconds (default 5)
- `--timeout N` bails after N seconds; error message prefixed `timeout: …` so callers can discriminate
- Fast-path: session never existed → returns immediately (no error, no spin)
- Validation: `--interval` and `--timeout` must be `> 0`

**Drive-by fix: `maw shell` + `maw bg` dispatch arg shape**
- `skip=1` → `skip=0` in `shell/index.ts`, `bg/index.ts`
- Same in new `wait/index.ts` (would otherwise have inherited the bug)
- `test/plugins/shell-bg-verbs.test.ts` updated to use the **real** CLI arg shape — `[\"scratch\"]`, not `[\"shell\", \"scratch\"]` — so a regression would now be caught

## CalVer

`v26.5.14-alpha.219`

## Test plan

- [x] `test/plugins/wait-verb.test.ts` — 8 cases (fast-path, block-then-end, timeout, missing-name, --help, --interval-0, --timeout-0, --interval plumbing)
- [x] `test/plugins/shell-bg-verbs.test.ts` — 11 cases updated to real arg shape, still 11/11 pass
- [x] Full matrix green locally: 1375 unit (8 shards, isolated) + 83/83 isolated + 232 plugin + 6 mock-smoke
- [x] Live smoke against real tmux:
  - `bg \"\$N\" \"sleep 3\" && wait \"\$N\" --interval 1` → exit 0 in ~3s
  - `bg \"\$N\" \"sleep 10\" && wait \"\$N\" --timeout 1` → exit 1 with `timeout: …` prefix
  - `maw shell <name> --no-attach` — works (was broken on alpha.130)
  - `maw bg <name> \"<cmd>\"` — works (was broken on alpha.130)

## Out of scope (separate issues if needed)

- Exit-code propagation from the wrapped process (needs `maw bg` log capture)
- Multi-name waits (`maw wait foo bar baz`) — punt to v2
- Remote / peer-session waits

🤖 Generated with [Claude Code](https://claude.com/claude-code)