### PR TITLE
feat(wake): permissive matchOracleWindow() for fleet windows like dustboy-phd-oracle (closes #1302)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.14-alpha.219",
+  "version": "26.5.14-alpha.226",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -65,15 +65,23 @@ export async function resolveFromWorktrees(
  * silently fell through to fleet-clone. Strip the numeric prefix before
  * comparing; keep the raw form for backward compat with un-prefixed callers.
  *
+ * #1302 — Add a permissive suffix check so a bare query like `phd` matches a
+ * fleet window named `dustboy-phd-oracle` (ends with `-phd-oracle`). This
+ * intentionally allows a 2nd path beyond exact equality; if 2+ windows match
+ * the same bare query, callers' ambiguity handling bails. Case-insensitive
+ * so `phd` matches `DustBoy-PHD-Oracle` too.
+ *
  * @internal — exported for tests.
  */
 export function matchOracleWindow(oracle: string, windowName: string): boolean {
   const bare = oracle.replace(/^\d+-/, "");
+  const bareLower = bare.toLowerCase();
   return (
     windowName === `${bare}-oracle` ||
     windowName === bare ||
     windowName === `${oracle}-oracle` ||
-    windowName === oracle
+    windowName === oracle ||
+    windowName.toLowerCase().endsWith(`-${bareLower}-oracle`)
   );
 }
 

--- a/test/wake-resolve.test.ts
+++ b/test/wake-resolve.test.ts
@@ -179,3 +179,45 @@ describe("matchOracleWindow — #1282 numeric prefix strip", () => {
     expect(matchOracleWindow("homekeeper", "")).toBe(false);
   });
 });
+
+/**
+ * Tests for matchOracleWindow — #1302 permissive suffix match.
+ *
+ * A bare query like `phd` should match a fleet window named `dustboy-phd-oracle`
+ * (ends with `-phd-oracle`). Over-match risk is handled by callers' ambiguity
+ * detection — if 2+ windows match, they bail loudly.
+ */
+describe("matchOracleWindow — #1302 permissive suffix match", () => {
+  test("bare query 'phd' matches fleet window 'dustboy-phd-oracle'", () => {
+    expect(matchOracleWindow("phd", "dustboy-phd-oracle")).toBe(true);
+  });
+
+  test("bare query 'bar' matches 'foo-bar-oracle'", () => {
+    expect(matchOracleWindow("bar", "foo-bar-oracle")).toBe(true);
+  });
+
+  test("bare query 'bar' does NOT match 'other-oracle' (no -bar- segment)", () => {
+    expect(matchOracleWindow("bar", "other-oracle")).toBe(false);
+  });
+
+  test("case-insensitive: query 'phd' matches 'DustBoy-PHD-Oracle'", () => {
+    expect(matchOracleWindow("phd", "DustBoy-PHD-Oracle")).toBe(true);
+  });
+
+  test("does not over-match a bare substring without -oracle suffix: 'phd' vs 'dustboy-phd-dev'", () => {
+    expect(matchOracleWindow("phd", "dustboy-phd-dev")).toBe(false);
+  });
+
+  test("does not match when bare appears without dash boundary: 'phd' vs 'superphd-oracle'", () => {
+    expect(matchOracleWindow("phd", "superphd-oracle")).toBe(false);
+  });
+
+  test("backward compat: whole-name match still works (existing check #1) — 'phd' matches 'phd-oracle'", () => {
+    expect(matchOracleWindow("phd", "phd-oracle")).toBe(true);
+  });
+
+  test("numeric-prefix + permissive suffix combine: '20-phd' matches 'dustboy-phd-oracle'", () => {
+    // After ^\d+- strip, bare='phd' → suffix '-phd-oracle' matches.
+    expect(matchOracleWindow("20-phd", "dustboy-phd-oracle")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
`maw wake phd` failed to match fleet windows like `dustboy-phd-oracle`. This adds a permissive suffix arm to `matchOracleWindow()` — case-insensitive `-<bare>-oracle` tail match — so a bare query resolves to namespaced fleet windows. Purely additive; exact-match arms unchanged.

## Changes
- `src/commands/shared/wake-resolve-impl.ts:70-88` — add 5th arm `windowName.toLowerCase().endsWith(\`-${bareLower}-oracle\`)` plus header comment explaining intent + ambiguity behavior.
- `test/wake-resolve.test.ts` (EOF) — new describe block, +42 lines, covers fleet-window suffix, case-insensitivity, `\d+-` prefix interaction, and non-match negative.

## Test plan
- [x] `bun test test/wake-resolve.test.ts` → 25 pass
- [x] shards 1-8 (`MAW_SKIP_FLAKY=1 bun test --shard=N/8 --isolate test/ …`) → 1223 pass / 0 fail / 12 skip
- [x] `bun run test:plugin` → 234 pass
- [x] `bun run test:mock-smoke` → 6 pass
- [x] `bash scripts/test-isolated.sh` → 5 pass (83/83 files)
- [ ] live smoke deferred — covered by unit tests; ambiguity guard is existing behavior

## Out of scope
Pre-existing TS error at `wake-resolve-impl.ts:245` (federation fallback `data?.sessions` on `{}`) — NOT introduced here. Will file separately if not already tracked.

Closes #1302.

🤖 Generated with [Claude Code](https://claude.com/claude-code)