### PR TITLE
feat(cli): runtime core-plugin guard (closes #1316)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.14-alpha.905",
+  "version": "26.5.14-alpha.907",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,10 +12,12 @@ import { scanCommands } from "./cli/command-registry";
 import { setVerbosityFlags } from "./cli/verbosity";
 import { getVersionString } from "./cli/cmd-version";
 import { runUpdate } from "./cli/cmd-update";
-import { runBootstrap } from "./cli/plugin-bootstrap";
+import { runBootstrap, resolveBundledPath } from "./cli/plugin-bootstrap";
 import { maybeAutoRestore } from "./cli/auto-restore";
 import { dispatchCommand } from "./cli/dispatch";
 import { handleTopLevelError } from "./cli/error-handler";
+import { DEFAULT_TIER } from "./plugin/manifest-constants";
+import { existsSync, readdirSync, readFileSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 
@@ -46,6 +48,30 @@ async function main(): Promise<void> {
   // import.meta.dir must resolve to src/ — keep the call here, not in a child module.
   const pluginDir = join(homedir(), ".maw", "plugins");
   await runBootstrap(pluginDir, import.meta.dir);
+
+  // #1316 — startup integrity check: warn loudly if any core-tier bundled
+  // plugin is missing from pluginDir after bootstrap. Catches the silent
+  // "unknown command" failure mode when symlinks have drifted or never
+  // landed (e.g. partially-healed install).
+  try {
+    const linked = new Set(readdirSync(pluginDir));
+    const bundledRoot = await resolveBundledPath(import.meta.dir);
+    const expectedCore = bundledRoot
+      ? readdirSync(bundledRoot).filter(d => {
+          const m = join(bundledRoot, d, "plugin.json");
+          if (!existsSync(m)) return false;
+          try {
+            const j = JSON.parse(readFileSync(m, "utf-8"));
+            return (j.tier ?? DEFAULT_TIER) === "core";
+          } catch { return false; }
+        })
+      : [];
+    const missing = expectedCore.filter(n => !linked.has(n));
+    if (missing.length) {
+      console.warn(`[maw] core plugins missing from ${pluginDir}: ${missing.join(", ")}`);
+      console.warn(`[maw] run 'maw plugins doctor --heal' to relink, or rm -rf ${pluginDir} && maw --version`);
+    }
+  } catch {}
 
   // Load plugins from ~/.maw/plugins/ — the single source of truth
   await scanCommands(pluginDir, "user");

--- a/src/cli/plugin-bootstrap.ts
+++ b/src/cli/plugin-bootstrap.ts
@@ -39,7 +39,7 @@ function isTransientPath(p: string): boolean {
  * Returns the resolved path or null if none exist. Callers warn rather than
  * throw so an already-populated `pluginDir` continues to work.
  */
-async function resolveBundledPath(srcDirHint: string): Promise<string | null> {
+export async function resolveBundledPath(srcDirHint: string): Promise<string | null> {
   const envPath = process.env.MAW_BUNDLED_PLUGINS;
   if (envPath) {
     const expanded = expandHome(envPath);


### PR DESCRIPTION
## Summary
- Added a runtime guard in CLI bootstrap that warns when core plugins are missing post-bootstrap.
- Tests: 49/49 pass, build clean.

Closes #1316

🤖 Generated with [Claude Code](https://claude.com/claude-code)