### PR TITLE
fix(routing): unblock peer routing when local session prefix-matches

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.14-alpha.1004",
+  "version": "26.5.14-alpha.1643",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/core/runtime/find-window.ts
+++ b/src/core/runtime/find-window.ts
@@ -125,13 +125,17 @@ export function findWindow(sessions: Session[], query: string): string | null {
   if (sub.size === 1) return [...sub][0];
   if (sub.size > 1) throw new AmbiguousMatchError(query, [...sub]);
   // If query has ":" and the SESSION part matched a real session but the
-  // WINDOW part didn't → return raw query (user may mean index, e.g. "08-mawjs:1").
-  // If the SESSION part didn't match anything local → return null so cmdSend
-  // falls through to federation routing (node:agent like "oracle-world:mawjs").
+  // WINDOW part didn't → only return raw query when winPart is empty
+  // (first window) or numeric (literal tmux index like "08-mawjs:1").
+  // Otherwise return null so resolveTarget Step 2 can try peer routing
+  // (e.g. "oracle-world:100-pulse" → peer namedPeer, not local tmux).
   if (query.includes(":")) {
-    const [sessPart] = query.toLowerCase().split(":", 2);
+    const [sessPart, winPart] = query.toLowerCase().split(":", 2);
     const sessExists = matchSession(sessions, sessPart, true);
-    return sessExists ? query : null;
+    if (!sessExists) return null;
+    if (!winPart) return query;
+    if (/^\d+$/.test(winPart)) return query;
+    return null;
   }
   return null;
 }

--- a/test/00-ssh.test.ts
+++ b/test/00-ssh.test.ts
@@ -181,12 +181,14 @@ describe("findWindow", () => {
         .toBeNull();
     });
 
-    test("falls through when session matches but window part doesn't", () => {
-      // 'mawjs:nowindow' → matches 08-mawjs but no window matches.
-      // Falls through to legacy substring match (which won't find it),
-      // ending at the colon-fallback.
+    test("returns null when session matches but window part is non-numeric and unmatched", () => {
+      // 'mawjs:nowindow' → matches 08-mawjs (oracle-name strip) but no window
+      // named 'nowindow'. Returning the raw query here was the shadow bug:
+      // routing then treated it as local tmux and skipped peer routing.
+      // New contract: non-numeric winPart with no window match → null so
+      // resolveTarget Step 2 can route to a peer (e.g. oracle-world:100-pulse).
       expect(findWindow(MAW_SESSIONS, "mawjs:nowindow"))
-        .toBe("mawjs:nowindow");
+        .toBeNull();
     });
   });
 });

--- a/test/find-window.test.ts
+++ b/test/find-window.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Tests for findWindow fallback at "session-matched, window-didn't" boundary.
+ *
+ * Guards the shadow regression where `oracle-world:100-pulse` (a remote
+ * namedPeer + remote agent) silently matched local session `30-oracle-world`
+ * via oracle-name strip and returned the raw query as a tmux target — causing
+ * routing to skip peer Step 2 entirely. See: ship-routing-fix team task #1.
+ */
+import { describe, test, expect } from "bun:test";
+import { findWindow, type Session } from "../src/core/runtime/find-window";
+
+describe("findWindow — session-matched, window-not-matched fallback", () => {
+  test("shadow case: oracle-world:100-pulse with local 30-oracle-world returns null (lets peer routing take over)", () => {
+    const sessions: Session[] = [
+      { name: "30-oracle-world", windows: [{ index: 1, name: "oracle-world-oracle", active: true }] },
+    ];
+    expect(findWindow(sessions, "oracle-world:100-pulse")).toBeNull();
+  });
+
+  test("numeric tmux index still resolves: mawjs:1 with local 01-mawjs returns raw query", () => {
+    const sessions: Session[] = [
+      { name: "01-mawjs", windows: [{ index: 1, name: "mawjs-oracle", active: true }] },
+    ];
+    expect(findWindow(sessions, "mawjs:1")).toBe("mawjs:1");
+  });
+});


### PR DESCRIPTION
## Summary
- Fix `find-window.ts:122-128` over-eager fallback that shadowed peer routing
- When local session matched via strip-prefix but window name didn't, raw query was returned → routing treated as local → send-keys to non-existent tmux target
- Now: return null for unmatched named windows so Step 2 (peer routing) can take over
- Empty winPart (first window) and numeric winPart (tmux index) still return raw query

## Root cause
`oracle-world:100-pulse` from m5:
1. Step 1 calls findWindow(writable, query)
2. matchSession(strict=true) matches `30-oracle-world` via strip-prefix
3. winPart `100-pulse` substring search fails
4. Fallback at line 122-128 returns raw `oracle-world:100-pulse` (assumes user meant tmux index)
5. routing.ts:88 treats as type=local, send-keys to non-existent target → silent fail
6. Step 2 (peer routing → namedPeer `oracle-world` at 10.20.0.16:3456) never runs

## Test plan
- [x] New unit tests in find-window.test.ts cover both cases
- [x] Full `bun test` — 0 new failures vs alpha baseline
- [ ] Manual: `maw hey oracle-world:agent` from m5 routes to peer

## Credit
Bug discovered + traced cross-node by oracle-worlds-machine via maw hey.
Verified by mawjs-oracle find-root-cause team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)