### PR TITLE
fix(cli): delegate maw ls <peer> to mpr ls plugin (#1327)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.14-alpha.1643",
+  "version": "26.5.14-alpha.1807",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -184,6 +184,19 @@ export async function invokeDirectHandler(
       "--fix": Boolean,
       "--json": Boolean,
     }, 0);
+    // Cross-node delegation: when a positional is present it names a federation
+    // peer (e.g. `maw ls oracle-world`) — route to the mpr ls plugin which
+    // owns peer resolution + /api/sessions calls. Local `maw ls` (no positional)
+    // keeps the existing cmdTmuxLs behavior so flags/output stay identical.
+    if (flags._.length > 0) {
+      const { discoverPackages, invokePlugin } = await import("../plugin/registry");
+      const plugin = discoverPackages().find(p => p.manifest.name === "ls");
+      if (!plugin) throw new UserError("ls plugin not found in registry");
+      const result = await invokePlugin(plugin, { source: "cli", args: argv });
+      if (result.ok && result.output) console.log(result.output);
+      else if (!result.ok) { console.error(result.error); process.exit(result.exitCode ?? 1); }
+      return;
+    }
     await cmdTmuxLs({
       all: true,
       compact: !flags["--verbose"],


### PR DESCRIPTION
## Summary

When `maw ls` is invoked with a positional argument (peer alias), delegate to the mpr `ls` plugin (shipped in [maw-plugin-registry#68](https://github.com/Soul-Brews-Studio/maw-plugin-registry/pull/68)) which owns federation peer resolution and `/api/sessions` calls.

Before this fix the direct-handler in `top-aliases.ts:cmdLs` dropped all positionals and always called `cmdTmuxLs`, leaving the new mpr plugin unreachable from the CLI — exactly the "shadow" family as #1322/#1323/#1324/#1326.

## The change

`src/cli/top-aliases.ts:cmdLs` — when `flags._.length > 0`, delegate to the registered `ls` plugin via `invokePlugin`. Local `maw ls` (no positional) keeps the existing `cmdTmuxLs` behavior so flag semantics and output stay byte-for-byte identical.

+13 lines, 1 file.

## Smoke test (verified locally on m5)

```
$ maw --version
maw v26.5.14-alpha.1807 (e971bead) built 2026-05-14

$ maw ls              # local sessions (unchanged)
  ◌ 06-m5-keeper  …

$ maw ls white         # NEW — real peer sessions on white.local
  ● metis-oracle
  ● pulse-oracle
  ● timekeeper-oracle
  ● volt-oracle

$ maw ls badname       # NEW — clean error
  unknown peer alias: badname (see: maw peers list)
```

## Test plan

- [x] Smoke test passes locally for the 3 cases above
- [x] Tests: `bun test test/find-window.test.ts` — 2/2 pass
- [ ] CI: bun test full suite
- [ ] CI: deep validate PR
- [ ] CI: GitGuardian

## References

- Issue: Soul-Brews-Studio/maw-js#1327
- Companion: Soul-Brews-Studio/maw-plugin-registry#68 (merged) — the plugin this delegates to
- Proposal in vault: `ψ/inbox/2026-05-14_proposal-cross-node-ls.md`
- Pattern: same shadow family as #1322 (find-window) routing fix shipped earlier today

Closes #1327

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>