### PR TITLE
fix(ci): use --isolate in CalVer Release to match PR CI (#1336)

### DIFF
--- a/.github/workflows/calver-release.yml
+++ b/.github/workflows/calver-release.yml
@@ -120,11 +120,23 @@ jobs:
         # leaving the proximate user-facing fix #857 unreachable to users.
         # Same override pattern as test-unit shard (#811/#813 precedent).
         # Root-cause port-race fix is tracked separately in #830.
+        #
+        # #1336 — mirror ci.yml test-unit's --isolate. 31 of 102 test files
+        # use process-global mock.module() which leaks across files in a
+        # shared process. PR CI uses --isolate (per #1278); CalVer Release
+        # did not, so curlFetch + peers/accept tests would flake on the
+        # release runner even when sharded CI was 20/20 green, silently
+        # blocking the alpha tag (e.g. v26.5.14-alpha.1944 from #1331/#1335).
+        # path-ignores mirror package.json:test exactly.
         env:
           MAW_SKIP_FLAKY: "1"
+          MAW_TEST_MODE: "1"
         run: |
           bun install --frozen-lockfile
-          bun run test
+          bun test test/ --isolate \
+            --path-ignore-patterns '**/test/isolated/**' \
+            --path-ignore-patterns '**/zz-mock-tmux-smoke*' \
+            --path-ignore-patterns '**/agents/**'
           bun run build
 
       - name: Tag + GitHub release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.14-alpha.1944",
+  "version": "26.5.14-alpha.2036",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
## Summary

CalVer Release workflow now uses `--isolate` to match PR CI's test-unit step. Closes #1336.

## The bug

PR #1335 (maw worktree v1) merged with 20/20 green sharded CI, but `CalVer Release` failed (run [25862066079](https://github.com/Soul-Brews-Studio/maw-js/actions/runs/25862066079)) with 11 unrelated curlFetch + peers/accept test failures, blocking the `v26.5.14-alpha.1944` tag silently.

Diagnosis (issue #1336):
- PR CI test-unit uses `bun test --shard=N/8 --isolate` (per #1278 — 31 of 102 files use process-global `mock.module()`).
- CalVer Release used plain `bun run test` (no `--isolate`) → mocks leak across files → cascade fails in curlFetch/peers tests.
- Verified locally: failing tests pass clean in isolation, only fail when full suite runs in one process.

## The fix

`.github/workflows/calver-release.yml` test step now runs:

```yaml
env:
  MAW_SKIP_FLAKY: "1"
  MAW_TEST_MODE: "1"
run: |
  bun install --frozen-lockfile
  bun test test/ --isolate \
    --path-ignore-patterns '**/test/isolated/**' \
    --path-ignore-patterns '**/zz-mock-tmux-smoke*' \
    --path-ignore-patterns '**/agents/**'
  bun run build
```

Path-ignores mirror `package.json:test` exactly. `MAW_TEST_MODE` inlined since we're not going through the npm script anymore.

## Test plan

- [x] Locally verified `bun test test/curl-fetch.test.ts` is clean in isolation (2 pass / 12 skip / 0 fail)
- [x] Confirmed PR #1335 didn't touch curlFetch/peers/accept files — bug is purely load-order
- [ ] This PR's own CI must pass (proves the workflow doesn't break itself)
- [ ] Merge → CalVer Release run should succeed and cut v26.5.14-alpha.2036 tag

## What this fixes retroactively

- v26.5.14-alpha.1944 (PR #1335) — code merged, tag missing. Next alpha cut (this PR's bump = .2036) will roll forward and include PR #1331's worktree code automatically since alpha branch already has it.

## What's next after merge

- Retroactively backfill alpha.1944 tag? Could re-run workflow 25862066079 manually via `gh run rerun --failed` if desired. Or skip — alpha.2036 supersedes.

Closes #1336