### PR TITLE
fix(federation): cross-node auto-wake sends oracle field, not target (#1343)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.14-alpha.2124",
+  "version": "26.5.14-alpha.2142",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -333,7 +333,12 @@ export async function cmdSend(
         if (decision.wake) {
           const wakeRes = await curlFetch(`${peer.url}/api/wake`, {
             method: "POST",
-            body: JSON.stringify({ target: bareAgent }),
+            // #1343 — receiver (mpr/plugins/wake/index.ts:117) reads body.oracle.
+            // Previously sent {target: ...} which silently failed every cross-node
+            // auto-wake. Cross-node hey short-form (peer:agent) has been broken
+            // since wake was extracted to mpr. Canonical (peer:session:window)
+            // skips wake entirely so masked the bug.
+            body: JSON.stringify({ oracle: bareAgent }),
             from: "auto", // #804 Step 4 SIGN — sign cross-node /api/wake
           });
           if (!wakeRes.ok || !wakeRes.data?.ok) {


### PR DESCRIPTION
## Summary

1-line fix to comm-send.ts: cross-node auto-wake now sends `{oracle: bareAgent}` instead of `{target: bareAgent}`, matching the receiver's contract.

Closes #1343.

## The bug

Sender (`src/commands/shared/comm-send.ts:336`) sent:
```ts
body: JSON.stringify({ target: bareAgent }),
```

Receiver (`maw-plugin-registry/plugins/wake/index.ts:117`) reads:
```ts
const oracle = body.oracle as string | undefined;
if (!oracle) return { ok: false, error: "missing oracle name" };
```

`{target: ...}` arrived; receiver's `body.oracle` was always undefined; every cross-node short-form auto-wake silently failed.

## What this fixes

```bash
# Before:
maw hey oracle-world-sila:01-Somwind "ping"
# → "Remote fetch failed for peer ...: cross-node wake failed for 01-Somwind: missing oracle name"

# After (expected):
maw hey oracle-world-sila:01-Somwind "ping"
# → wake (no-op if session exists) + send delivers "ping" to 01-Somwind:1
```

## Surfaced

By sila@oracle-world setup 2026-05-14 — cross-node hey from sila to peers consistently failed. Verified via source trace at both ends. Canonical form (peer:session:window) skips wake entirely so masked the bug.

## Test plan

- [x] Local build clean (1.83 MB)
- [x] Diff scoped to one line (comm-send.ts:336) + comment
- [ ] CI sharded matrix passes
- [ ] CI CalVer Release passes (the --isolate fix from #1336 should keep this clean)
- [ ] Post-merge: cross-node hey from sila works (manual verify)

## Pre-existing TS diagnostics

Build flagged 10 unrelated `wakeRes.data?.X` type issues at lines 344-345, 509-536 — these predate this PR (curlFetch return type isn't typed). Runtime is fine; not in scope. Worth a separate cleanup PR.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>