### PR TITLE
fix(team): support worktree cwd and enter for team panes

### DIFF
--- a/ISSUE-maw-team-send-not-hey.md
+++ b/ISSUE-maw-team-send-not-hey.md
@@ -1,0 +1,87 @@
+# Issue: Use `maw team send` for team agents, not `maw hey`
+
+Date: 2026-05-14 22:06 +07
+Trace target: `/opt/sila/Code/github.com/Soul-Brews-Studio/maw-js`
+
+## Problem
+
+During a live Somwind team simulation, I used `maw hey` to talk to individual
+panes that belonged to a `maw team`.
+
+That is the wrong operator surface for team members.
+
+`maw hey` is for oracle/session messaging. For agents that are members of a
+`maw team`, the correct channel is:
+
+```bash
+maw team send <team> <agent> <message>
+```
+
+Using `maw hey` against pane targets can bypass the team inbox, make ACK/status
+tracking ambiguous, and encourage operators to think in panes instead of team
+agents.
+
+## Observed Team
+
+Team:
+
+```text
+gale-codex-215257
+```
+
+Members:
+
+```text
+scout
+implementer
+```
+
+Correct commands sent:
+
+```bash
+maw team send gale-codex-215257 scout "SCOUT: ACK กลับมา สรุปสิ่งที่กำลังทำ และบอกไฟล์หรือ WT ที่รับผิดชอบ"
+maw team send gale-codex-215257 implementer "IMPLEMENTER: ACK กลับมา สรุปสิ่งที่กำลังทำ และบอกไฟล์หรือ WT ที่รับผิดชอบ"
+```
+
+Verification commands:
+
+```bash
+maw team status gale-codex-215257
+ls -la ~/.claude/teams/gale-codex-215257/inboxes
+maw pane list
+```
+
+Verification observed:
+
+- `scout` engine `codex`, status `running`, pane `%20`.
+- `implementer` engine `codex`, status `running`, pane `%21`.
+- Team inbox files existed: `scout.json`, `implementer.json`.
+- `maw pane list` showed lead, implementer, and scout panes.
+
+## Fix / Product Direction
+
+1. Document that `maw team send` is the canonical way to message team members.
+2. Consider adding a guard or warning when `maw hey` targets a pane annotated as
+   `team: <agent> @ <team>`.
+3. Keep `maw hey` for oracle/session messaging, including team fan-out where
+   explicitly supported by `team:<name>`, but do not present it as the normal
+   command for live `maw team` member coordination.
+
+## Permanent Code-Team Rule
+
+For code teams, create worktrees first:
+
+```bash
+maw workon Somwind-oracle scout
+maw workon Somwind-oracle implementer
+maw workon Somwind-oracle verifier
+```
+
+Then send prompts with an absolute worktree path:
+
+```text
+REPO=/absolute/path/to/Somwind-oracle-<role-worktree>
+You own only REPO. Do not edit outside that worktree.
+Report changed files and verification.
+```
+

--- a/ISSUE-team-worktree-cwd-enter.md
+++ b/ISSUE-team-worktree-cwd-enter.md
@@ -1,0 +1,53 @@
+# Issue: Team panes need real worktree cwd and explicit enter
+
+Date: 2026-05-14
+
+## Problem
+
+Live team testing with Somwind showed two related gaps in `maw team`:
+
+1. `maw workon <repo> <role>` creates role-specific worktree windows, but
+   `maw team spawn --exec` still splits from the leader pane and starts the
+   agent in the leader cwd. Passing `REPO=/abs/worktree` in the prompt is only
+   an instruction; it does not make the pane actually run in that worktree.
+
+2. `maw team hey <agent> <message>` can leave long text staged in a Codex TUI
+   prompt without submitting it. Operators need a team-scoped way to send an
+   Enter key without dropping down to raw tmux.
+
+## Repro
+
+```bash
+maw workon Somwind-oracle scout
+maw workon Somwind-oracle implementer
+maw workon Somwind-oracle verifier
+
+maw team create somwind-wt-horizontal --description "Horizontal team panes with real worktree cwd"
+maw team spawn somwind-wt-horizontal implementer --exec \
+  --worktree /opt/sila/Code/github.com/sila-build-with-oracle/Somwind-oracle.wt-1-implementer \
+  --prompt "REPO=/opt/sila/Code/github.com/sila-build-with-oracle/Somwind-oracle.wt-1-implementer"
+```
+
+Expected: the spawned pane's agent starts with the worktree as cwd.
+
+Observed before the fix: team panes could appear in the main repo even though
+the prompt named a worktree path.
+
+For prompt submission:
+
+```bash
+maw team hey implementer "TASK ..."
+```
+
+Observed: text can be visible in the Codex prompt but not executed until a
+separate Enter is sent.
+
+## Proposed Fix
+
+- Add `--cwd <path>` and `--worktree <path>` to `maw team spawn`.
+- Wrap the spawned agent command with `cd '<path>' && ...` when cwd is present.
+- Add `maw team enter <agent|all>` as a team-scoped Enter key surface.
+
+This keeps operators on `maw team` instead of raw `tmux` while preserving the
+existing `--exec` split-pane flow.
+

--- a/src/commands/plugins/team/index.ts
+++ b/src/commands/plugins/team/index.ts
@@ -77,20 +77,33 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       cmdTeamCreate(args[1], { description });
     } else if (sub === "spawn") {
       if (!args[1] || !args[2]) {
-        logs.push("usage: maw team spawn <team> <role> [--model <model>] [--prompt <text>] [--exec]");
+        logs.push("usage: maw team spawn <team> <role> [--model <model>] [--cwd <path>] [--worktree <path>] [--prompt <text>] [--exec]");
         return { ok: false, error: "team and role required", output: logs.join("\n") };
       }
       const modelIdx = args.indexOf("--model");
       const model = modelIdx !== -1 ? args[modelIdx + 1] : undefined;
+      const cwdIdx = args.indexOf("--cwd");
+      const worktreeIdx = args.indexOf("--worktree");
+      const cwd = cwdIdx !== -1 ? args[cwdIdx + 1] : (worktreeIdx !== -1 ? args[worktreeIdx + 1] : undefined);
       const promptIdx = args.indexOf("--prompt");
       const exec = args.includes("--exec");
       // --prompt is greedy to end-of-argv; strip --exec if it appears in the tail
       let prompt: string | undefined;
       if (promptIdx !== -1) {
-        const tail = args.slice(promptIdx + 1).filter(a => a !== "--exec");
+        const rawTail = args.slice(promptIdx + 1);
+        const tail: string[] = [];
+        for (let i = 0; i < rawTail.length; i++) {
+          const a = rawTail[i];
+          if (a === "--exec") continue;
+          if (a === "--model" || a === "--cwd" || a === "--worktree") {
+            i++;
+            continue;
+          }
+          tail.push(a);
+        }
         prompt = tail.join(" ") || undefined;
       }
-      await cmdTeamSpawn(args[1], args[2], { model, prompt, exec });
+      await cmdTeamSpawn(args[1], args[2], { model, prompt, exec, cwd });
     } else if (sub === "send" || sub === "msg") {
       if (!args[1] || !args[2] || !args[3]) {
         logs.push("usage: maw team send <team> <agent> <message>");
@@ -371,6 +384,37 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       }
       console.log(`\x1b[32m✓\x1b[0m broadcast to ${sent}/${withPanes.length} agents: ${message}`);
 
+    } else if (sub === "enter" || sub === "send-enter") {
+      // maw team enter <agent|all> — submit pending input in agent pane(s)
+      const agent = args[1];
+      if (!agent) {
+        logs.push("usage: maw team enter <agent|all>");
+        return { ok: false, error: "agent required", output: logs.join("\n") };
+      }
+      const teamName = resolveTeamFromContext();
+      const { loadTeam } = await import("./team-helpers");
+      const team = loadTeam(teamName);
+      if (!team) {
+        logs.push(`\x1b[33m⚠\x1b[0m team '${teamName}' not found`);
+        return { ok: false, error: "team not found" };
+      }
+      const members = team.members.filter(m =>
+        m.tmuxPaneId && m.agentType !== "team-lead" &&
+        (agent === "all" || m.name === agent || m.agentId === agent || m.agentId === `${agent}@${teamName}`)
+      );
+      if (!members.length) {
+        logs.push(`\x1b[33m⚠\x1b[0m agent '${agent}' not found or no pane ID`);
+        logs.push(`Available: ${team.members.filter(m => m.tmuxPaneId).map(m => m.name).join(", ") || "none"}`);
+        return { ok: false, error: "agent not found" };
+      }
+      const { hostExec: exec } = await import("../../../sdk");
+      const { colorAnsi } = await import("../tmux/layout-manager");
+      for (const m of members) {
+        await exec(`tmux send-keys -t '${m.tmuxPaneId}' Enter`);
+        const color = (m.color || "white") as any;
+        console.log(`\x1b[${colorAnsi(color)}m↵\x1b[0m enter sent to ${m.agentId || m.name}`);
+      }
+
     } else if (sub === "hey") {
       // maw team hey <agent> <message> — send keystrokes to agent's tmux pane
       const agent = args[1];
@@ -491,7 +535,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
 
     } else {
       logs.push(`unknown team subcommand: ${sub}`);
-      logs.push("usage: maw team <create|spawn|send|shutdown|split|peek|hey|inbox|layout|prep|recover|resume|lives|list|status|add|tasks|done|assign|delete>");
+      logs.push("usage: maw team <create|spawn|send|shutdown|split|peek|hey|enter|inbox|layout|prep|recover|resume|lives|list|status|add|tasks|done|assign|delete>");
       return { ok: false, error: `unknown subcommand: ${sub}`, output: logs.join("\n") };
     }
 

--- a/src/commands/plugins/team/team-lifecycle.ts
+++ b/src/commands/plugins/team/team-lifecycle.ts
@@ -176,7 +176,7 @@ export function cmdTeamCreate(name: string, opts: { description?: string } = {})
 export async function cmdTeamSpawn(
   teamName: string,
   role: string,
-  opts: { model?: string; prompt?: string; exec?: boolean } = {},
+  opts: { model?: string; prompt?: string; exec?: boolean; cwd?: string } = {},
 ) {
   const PSI = resolvePsi();
   const teamDir = join(PSI, "memory", "mailbox", "teams", teamName);
@@ -213,6 +213,8 @@ export async function cmdTeamSpawn(
 
   // Build spawn prompt
   const model = opts.model || "sonnet";
+  const shellQuote = (s: string) => `'${s.replace(/'/g, "'\\''")}'`;
+  const cwdPrefix = opts.cwd ? `cd ${shellQuote(opts.cwd)} && ` : "";
   const parts: string[] = [];
   parts.push(`You are '${role}' on team '${teamName}'.`);
   if (opts.prompt) parts.push(opts.prompt);
@@ -260,12 +262,12 @@ export async function cmdTeamSpawn(
     if (!process.env.TMUX) {
       console.log();
       console.log(`  \x1b[33m⚠\x1b[0m --exec requires an active tmux session ($TMUX not set).`);
-      console.log(`  \x1b[36mRun manually:\x1b[0m claude --model ${model} --system-prompt-file "${promptPath}"`);
+      console.log(`  \x1b[36mRun manually:\x1b[0m ${cwdPrefix}claude --model ${model} --system-prompt-file "${promptPath}"`);
       return;
     }
     try {
       const { spawnTeammatePane, colorAnsi } = await import("../tmux/layout-manager");
-      const claudeCmd = `claude --model ${model} --system-prompt-file '${promptPath.replace(/'/g, "'\\''")}'`;
+      const claudeCmd = `${cwdPrefix}claude --model ${model} --system-prompt-file '${promptPath.replace(/'/g, "'\\''")}'`;
       const teammateCount = manifest.members.filter((m: any) => m.name !== role).length;
       const agentId = `${role}@${teamName}`;
 
@@ -295,11 +297,11 @@ export async function cmdTeamSpawn(
     } catch (e: any) {
       console.log();
       console.log(`  \x1b[33m⚠\x1b[0m --exec split failed: ${e?.message || e}`);
-      console.log(`  \x1b[36mRun manually:\x1b[0m claude --model ${model} --system-prompt-file "${promptPath}"`);
+      console.log(`  \x1b[36mRun manually:\x1b[0m ${cwdPrefix}claude --model ${model} --system-prompt-file "${promptPath}"`);
     }
     return;
   }
 
   console.log();
-  console.log(`  \x1b[36mRun:\x1b[0m claude --model ${model} --system-prompt-file "${promptPath}"`);
+  console.log(`  \x1b[36mRun:\x1b[0m ${cwdPrefix}claude --model ${model} --system-prompt-file "${promptPath}"`);
 }


### PR DESCRIPTION
## Summary
- add `maw team spawn --cwd <path>` and `--worktree <path>` so `--exec` panes start in the real worktree cwd
- add `maw team enter <agent|all>` / `send-enter` to submit pending text in team panes without raw tmux
- record the related operator lessons as root issue notes

Closes #1351
Related #1349

## Verification
- `bun run build`
- `bun test test/build-command-cwd.test.ts`
- live local installed-plugin smoke: spawned `somwind-wt-horizontal` scout/implementer/verifier in horizontal panes, each with worktree cwd; `maw team enter all` submitted staged Codex prompts

## Known existing caveats
- `bun run test:plugin` still fails on pre-existing oracle plugin export mismatch: `cmdOracleRegister` missing from `../commands/plugins/oracle/impl`
- direct `bun -e import("./src/commands/plugins/team/index.ts")` currently fails because source imports missing `./impl`; `team-lifecycle.ts` imports successfully
