### PR TITLE
feat(plugin): auto-symlink node_modules/maw-js for plugin module resolution (#1339 Option E)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.14-alpha.2211",
+  "version": "26.5.14-alpha.2235",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/cli/plugin-bootstrap.ts
+++ b/src/cli/plugin-bootstrap.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, existsSync, readdirSync, symlinkSync, cpSync, readFileSync, lstatSync, unlinkSync, readlinkSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
+import { ensureMawJsResolvable } from "../plugin/ensure-maw-js-resolvable";
 
 /** Allowlist: only http/https URLs may be used as plugin sources */
 const URL_SCHEME_RE = /^https?:\/\//;
@@ -109,6 +110,17 @@ async function persistBundledPath(resolvedPath: string): Promise<void> {
  */
 export async function runBootstrap(pluginDir: string, srcDir: string): Promise<void> {
   mkdirSync(pluginDir, { recursive: true });
+
+  // #1339 Option E — ensure `<pluginDir>/node_modules/maw-js` exists so any
+  // installed plugin can resolve `import "maw-js/..."` via standard node
+  // module walk-up. Idempotent; silent on no-op. The verbose log path
+  // surfaces actual link creations / replacements only.
+  try {
+    const r = ensureMawJsResolvable();
+    if (r.changed) {
+      console.warn(`[maw] ${r.reason}`);
+    }
+  } catch { /* never fatal on bootstrap */ }
 
   // 0. #1015 — prune broken symlinks before anything else. After an update
   //    removes bundled plugins from src/commands/plugins/, their old symlinks

--- a/src/commands/plugins/plugin/install-impl.ts
+++ b/src/commands/plugins/plugin/install-impl.ts
@@ -25,6 +25,7 @@ import { parseFlags } from "../../../cli/parse-args";
 import { detectMode, ensureInstallRoot } from "./install-source-detect";
 import { installFromDir, installFromTarball, installFromUrl, installFromMonorepo, installFromGithub } from "./install-handlers";
 import { resolvePeerInstall } from "./install-peer-resolver";
+import { ensureMawJsResolvable } from "../../../plugin/ensure-maw-js-resolvable";
 import { basename } from "path";
 
 export { installRoot, detectMode, parsePeerSpec, parseMonorepoRef, parseGithubRef, ensureInstallRoot, removeExisting } from "./install-source-detect";
@@ -69,6 +70,17 @@ export async function cmdPluginInstall(args: string[]): Promise<void> {
     throw new Error(`--category must be one of: core, standard, extra (got ${JSON.stringify(cat)})`);
   }
   const weight = cat !== undefined ? CATEGORY_WEIGHT[cat] : undefined;
+
+  // #1339 Option E — every successful install path must end with the parent
+  // `node_modules/maw-js` shared link in place. Wired here at the dispatch
+  // level so all source kinds (dir/tarball/url/peer/monorepo/github) inherit
+  // the fix from a single call site. Idempotent; silent on no-op.
+  const runEnsureLink = (): void => {
+    try {
+      const r = ensureMawJsResolvable();
+      if (r.changed) console.warn(`[maw] ${r.reason}`);
+    } catch { /* never fatal */ }
+  };
 
   // Dispatch on source type. --pin only meaningful for tarball/URL installs
   // (dev `--link` is a symlink, not a supply-chain surface).
@@ -125,4 +137,7 @@ export async function cmdPluginInstall(args: string[]): Promise<void> {
   } else {
     await installFromUrl(mode.src, { force, weight, pin });
   }
+
+  // Post-install (every source kind): ensure the resolution layer is in place.
+  runEnsureLink();
 }

--- a/src/commands/plugins/plugin/install-tier-impl.ts
+++ b/src/commands/plugins/plugin/install-tier-impl.ts
@@ -40,6 +40,7 @@
 import { existsSync } from "fs";
 import { join } from "path";
 import { installRoot } from "./install-source-detect";
+import { ensureMawJsResolvable } from "../../../plugin/ensure-maw-js-resolvable";
 
 export const VALID_TIERS = ["core", "standard", "extra"] as const;
 export type Tier = (typeof VALID_TIERS)[number];
@@ -157,6 +158,16 @@ export async function cmdPluginInstallTier(opts: InstallTierOptions): Promise<In
       (skipped ? `, ${skipped} skipped` : "") +
       (failed.length ? `, ${failed.length} failed` : ""),
   );
+
+  // #1339 Option E — once at the end of the bulk loop (not per-iteration).
+  // cmdPluginInstall already calls ensureMawJsResolvable() per-install, so
+  // this is a belt-and-suspenders final reconcile that also covers the
+  // skip-existing path where nothing was installed but the link may still
+  // be missing from a prior partial run.
+  try {
+    const r = ensureMawJsResolvable();
+    if (r.changed) console.warn(`[maw] ${r.reason}`);
+  } catch { /* never fatal */ }
 
   if (failed.length > 0) {
     throw new Error(`install --tier ${opts.tier}: ${failed.length} of ${names.length} failed`);

--- a/src/plugin/ensure-maw-js-resolvable.ts
+++ b/src/plugin/ensure-maw-js-resolvable.ts
@@ -1,0 +1,158 @@
+/**
+ * #1339 Option E — make `maw-js` resolvable from any installed plugin.
+ *
+ * After `maw plugin install` (or on every boot), ensure
+ *   <installRoot>/node_modules/maw-js
+ * exists as a symlink to the running maw-js source root. Plugins under
+ * <installRoot>/<name>/ then resolve `import "maw-js/..."` via the standard
+ * node_modules walk-up.
+ *
+ * ── Why this is needed ──────────────────────────────────────────────────────
+ * Per the Layer 2 trace in #1339 (sila@oracle-world, 2026-05-14): plugins
+ * installed into ~/.maw/plugins/<name>/ import subpaths declared in
+ * maw-js's package.json#exports (e.g. `maw-js/cli/parse-args`). Bun resolves
+ * the subpath fine — but ONLY if it can first resolve `maw-js` itself, which
+ * requires `node_modules/maw-js` somewhere in the ancestor walk from the
+ * plugin file. A global `bun install -g maw-js` lands the package under
+ * `~/.bun/install/global/node_modules/maw-js/` — NOT in any ancestor of
+ * `~/.maw/plugins/<name>/`. Walk-up fails. Plugin import errors. UX dies.
+ *
+ * ── How this fix differs from #641's per-plugin link ────────────────────────
+ * `src/commands/plugins/plugin/install-handlers.ts:ensurePluginMawJsLink`
+ * writes `<srcDir>/node_modules/maw-js` INSIDE each linked plugin source — and
+ * runs only on `--link` installs (dev workflow). Tarball / URL / peer / monorepo
+ * / github installs never touch it, and `<srcDir>` is the operator's source
+ * tree, not `~/.maw/plugins/<name>/`. So #641 doesn't cover the Layer 2 case.
+ *
+ * This helper writes ONE shared link at the install-root parent
+ * (`~/.maw/plugins/node_modules/maw-js`) — covers every plugin under it,
+ * regardless of how it was installed.
+ *
+ * ── Resolution chain for the maw-js root ────────────────────────────────────
+ *   1. `$MAW_JS_PATH` env override — matches existing #641 convention so
+ *      tests and unusual layouts have a single env knob.
+ *   2. Walk up from this file (`src/plugin/`) two levels → the maw-js
+ *      repo root (the one with package.json `name: "maw-js"`).
+ *
+ * Bun.resolveSync("maw-js") is NOT used — the WHOLE POINT is that "maw-js"
+ * isn't resolvable from arbitrary contexts; the running CLI's own location
+ * is the only reliable anchor.
+ *
+ * ── Invariants ──────────────────────────────────────────────────────────────
+ *   • Idempotent (safe to call N times — returns `changed: false` on no-op).
+ *   • Silent on no-op (caller decides whether to log).
+ *   • Tolerates broken symlinks gracefully (removes + recreates dangling ones).
+ *   • Does NOT clobber a wrong-but-existing symlink pointing elsewhere
+ *     (returns `changed: false` with a `reason` so callers can surface).
+ *   • Never throws on permission / fs errors — returns a `reason` instead.
+ */
+
+import { existsSync, lstatSync, mkdirSync, readlinkSync, symlinkSync, unlinkSync } from "fs";
+import { join, resolve } from "path";
+import { installRoot } from "../commands/plugins/plugin/install-source-detect";
+
+/** Resolve the running maw-js source root. */
+function resolveMawJsRoot(): string {
+  if (process.env.MAW_JS_PATH) return process.env.MAW_JS_PATH;
+  // this file: <mawJsRoot>/src/plugin/ensure-maw-js-resolvable.ts
+  return resolve(import.meta.dir, "..", "..");
+}
+
+export interface EnsureResult {
+  changed: boolean;
+  /** Short human-readable reason — caller may log on verbose. */
+  reason: string;
+  /** Absolute path of the symlink (whether or not it was created). */
+  linkPath: string;
+  /** Absolute path of the maw-js root the link points (or would point) at. */
+  target: string;
+}
+
+/**
+ * Ensure `<installRoot>/node_modules/maw-js` is a symlink to the running
+ * maw-js source root. See module header for full rationale.
+ */
+export function ensureMawJsResolvable(): EnsureResult {
+  const mawJsRoot = resolveMawJsRoot();
+  const nodeModulesDir = join(installRoot(), "node_modules");
+  const linkPath = join(nodeModulesDir, "maw-js");
+
+  if (!existsSync(mawJsRoot)) {
+    return {
+      changed: false,
+      reason: `maw-js root not found at ${mawJsRoot}`,
+      linkPath,
+      target: mawJsRoot,
+    };
+  }
+
+  // Check the existing link via lstat (existsSync follows broken symlinks
+  // to false — we want to detect a dangling symlink and replace it).
+  let existing: import("fs").Stats | undefined;
+  try { existing = lstatSync(linkPath); } catch { /* absent */ }
+
+  if (existing) {
+    if (existing.isSymbolicLink()) {
+      let linkTarget: string;
+      try {
+        linkTarget = readlinkSync(linkPath);
+      } catch {
+        // unreadable symlink — replace.
+        try { unlinkSync(linkPath); } catch { /* leave alone */ }
+        return tryLink(nodeModulesDir, linkPath, mawJsRoot, "replaced unreadable symlink");
+      }
+      const resolvedTarget = resolve(nodeModulesDir, linkTarget);
+      if (resolvedTarget === mawJsRoot) {
+        return {
+          changed: false,
+          reason: "symlink already correct",
+          linkPath,
+          target: mawJsRoot,
+        };
+      }
+      // Dangling? (target absent on disk) → safe to replace.
+      if (!existsSync(linkPath)) {
+        try { unlinkSync(linkPath); } catch { /* leave alone */ }
+        return tryLink(nodeModulesDir, linkPath, mawJsRoot, `replaced dangling symlink (was → ${linkTarget})`);
+      }
+      // Live symlink to a DIFFERENT location — operator put it there or a
+      // prior maw-js install owns it. Do not clobber (#1339 spec invariant).
+      return {
+        changed: false,
+        reason: `symlink exists but points to ${resolvedTarget}; leave alone (manual fix needed)`,
+        linkPath,
+        target: mawJsRoot,
+      };
+    }
+    // Real file or directory at linkPath — operator intent, leave alone.
+    return {
+      changed: false,
+      reason: `${linkPath} is not a symlink; leave alone`,
+      linkPath,
+      target: mawJsRoot,
+    };
+  }
+
+  return tryLink(nodeModulesDir, linkPath, mawJsRoot, `linked ${linkPath} → ${mawJsRoot}`);
+}
+
+function tryLink(
+  nodeModulesDir: string,
+  linkPath: string,
+  mawJsRoot: string,
+  successReason: string,
+): EnsureResult {
+  try {
+    mkdirSync(nodeModulesDir, { recursive: true });
+    symlinkSync(mawJsRoot, linkPath, "dir");
+    return { changed: true, reason: successReason, linkPath, target: mawJsRoot };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return {
+      changed: false,
+      reason: `failed to create symlink: ${msg}`,
+      linkPath,
+      target: mawJsRoot,
+    };
+  }
+}

--- a/test/cli/plugin-node-modules-symlink.test.ts
+++ b/test/cli/plugin-node-modules-symlink.test.ts
@@ -1,0 +1,285 @@
+/**
+ * test/cli/plugin-node-modules-symlink.test.ts — #1339 Option E
+ * `ensureMawJsResolvable` from `src/plugin/ensure-maw-js-resolvable.ts`.
+ *
+ * Validates the helper that lays a single shared symlink
+ *   <installRoot>/node_modules/maw-js → <mawJsRoot>
+ * so plugins under `<installRoot>/<name>/` can resolve `import "maw-js/..."`
+ * via the standard node_modules walk-up. See the impl module header for
+ * full Layer 2 / sila trace context.
+ *
+ * ## Mocking strategy (per #1335 retro)
+ *
+ * - NO `mock.module()` / NO `mock.module(process.stderr.write, ...)` — those
+ *   are the test-pollution + Bun 1.3.13 epoll patterns the retro called out.
+ * - Two env knobs the impl already exposes give us a clean test seam:
+ *     1. `MAW_PLUGINS_DIR`  → overrides `installRoot()` (per-test tmpdir).
+ *     2. `MAW_JS_PATH`      → overrides the maw-js source root the link
+ *                              should point at (per-test tmpdir).
+ * - Every test calls `mkdtempSync` for both knobs, then `rmSync` in afterEach.
+ *   No global state leaks between tests.
+ *
+ * ## Placement
+ *
+ * test/cli/ subdir — sidesteps the test/*.test.ts shard re-partitioning bug
+ * (#1335 retro) and matches the precedent set by plugin-install-tier.test.ts.
+ *
+ * ## Timeout
+ *
+ * 5000ms per test — avoids the #1348 shard-3 hang (default 30s lets a
+ * deadlocked symlink call burn the whole shard before failing).
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+import { ensureMawJsResolvable } from "../../src/plugin/ensure-maw-js-resolvable";
+
+// ─── Harness ─────────────────────────────────────────────────────────────────
+
+const created: string[] = [];
+
+let origPluginsDir: string | undefined;
+let origMawJsPath: string | undefined;
+
+// #1308 — guard against a prior shard test leaving stderr.write monkey-patched
+// against a disposed closure. (The impl never touches stderr but other test
+// files in the shard do; we restore from a pristine pointer captured here.)
+const pristineStderrWrite = process.stderr.write.bind(process.stderr);
+
+function tmpDir(prefix: string): string {
+  const d = mkdtempSync(join(tmpdir(), prefix));
+  created.push(d);
+  return d;
+}
+
+/** Create a fake maw-js source root with a package.json (the impl checks
+ *  `existsSync(mawJsRoot)` only, but a real package.json keeps the fixture
+ *  honest and matches what plugins will actually see post-symlink). */
+function makeMawJsRoot(): string {
+  const root = tmpDir("maw-js-root-");
+  writeFileSync(
+    join(root, "package.json"),
+    JSON.stringify({ name: "maw-js", version: "0.0.0-test" }),
+  );
+  return root;
+}
+
+beforeEach(() => {
+  if (typeof process.stderr.write !== "function") {
+    (process.stderr as any).write = pristineStderrWrite;
+  }
+  origPluginsDir = process.env.MAW_PLUGINS_DIR;
+  origMawJsPath = process.env.MAW_JS_PATH;
+
+  // Per-test tmp install root + maw-js source root.
+  process.env.MAW_PLUGINS_DIR = tmpDir("maw-plugins-");
+  process.env.MAW_JS_PATH = makeMawJsRoot();
+});
+
+afterEach(() => {
+  if (origPluginsDir !== undefined) process.env.MAW_PLUGINS_DIR = origPluginsDir;
+  else delete process.env.MAW_PLUGINS_DIR;
+  if (origMawJsPath !== undefined) process.env.MAW_JS_PATH = origMawJsPath;
+  else delete process.env.MAW_JS_PATH;
+  for (const d of created.splice(0)) {
+    if (existsSync(d)) rmSync(d, { recursive: true, force: true });
+  }
+});
+
+// ─── Cases ───────────────────────────────────────────────────────────────────
+
+describe("ensureMawJsResolvable", () => {
+  test(
+    "creates node_modules dir + symlink when nothing exists",
+    () => {
+      const installRoot = process.env.MAW_PLUGINS_DIR!;
+      const mawJsRoot = process.env.MAW_JS_PATH!;
+      const linkPath = join(installRoot, "node_modules", "maw-js");
+
+      // Sanity preconditions.
+      expect(existsSync(join(installRoot, "node_modules"))).toBe(false);
+      expect(existsSync(linkPath)).toBe(false);
+
+      const r = ensureMawJsResolvable();
+
+      expect(r.changed).toBe(true);
+      expect(r.linkPath).toBe(linkPath);
+      expect(r.target).toBe(mawJsRoot);
+      expect(existsSync(join(installRoot, "node_modules"))).toBe(true);
+      expect(lstatSync(linkPath).isSymbolicLink()).toBe(true);
+      expect(readlinkSync(linkPath)).toBe(mawJsRoot);
+    },
+    5000,
+  );
+
+  test(
+    "no-op when correct symlink already exists",
+    () => {
+      const installRoot = process.env.MAW_PLUGINS_DIR!;
+      const mawJsRoot = process.env.MAW_JS_PATH!;
+      const nodeModules = join(installRoot, "node_modules");
+      const linkPath = join(nodeModules, "maw-js");
+
+      mkdirSync(nodeModules, { recursive: true });
+      symlinkSync(mawJsRoot, linkPath, "dir");
+
+      const r = ensureMawJsResolvable();
+
+      expect(r.changed).toBe(false);
+      expect(r.reason).toMatch(/already correct/i);
+      expect(readlinkSync(linkPath)).toBe(mawJsRoot);
+    },
+    5000,
+  );
+
+  test(
+    "safety: refuses to clobber live symlink pointing elsewhere",
+    () => {
+      const installRoot = process.env.MAW_PLUGINS_DIR!;
+      const nodeModules = join(installRoot, "node_modules");
+      const linkPath = join(nodeModules, "maw-js");
+
+      // Wrong target — but a live, existing dir (not dangling).
+      const wrongTarget = tmpDir("maw-js-wrong-");
+      writeFileSync(
+        join(wrongTarget, "package.json"),
+        JSON.stringify({ name: "maw-js", version: "9.9.9-impostor" }),
+      );
+
+      mkdirSync(nodeModules, { recursive: true });
+      symlinkSync(wrongTarget, linkPath, "dir");
+
+      const r = ensureMawJsResolvable();
+
+      expect(r.changed).toBe(false);
+      expect(r.reason).toMatch(/manual fix|points to/i);
+      // Symlink left untouched.
+      expect(readlinkSync(linkPath)).toBe(wrongTarget);
+    },
+    5000,
+  );
+
+  test(
+    "creates symlink when node_modules dir already exists but link is missing",
+    () => {
+      const installRoot = process.env.MAW_PLUGINS_DIR!;
+      const mawJsRoot = process.env.MAW_JS_PATH!;
+      const nodeModules = join(installRoot, "node_modules");
+      const linkPath = join(nodeModules, "maw-js");
+
+      // Pre-existing node_modules (e.g. from a prior unrelated install) but
+      // no maw-js entry yet.
+      mkdirSync(nodeModules, { recursive: true });
+      writeFileSync(join(nodeModules, ".keep"), "");
+      expect(existsSync(linkPath)).toBe(false);
+
+      const r = ensureMawJsResolvable();
+
+      expect(r.changed).toBe(true);
+      expect(lstatSync(linkPath).isSymbolicLink()).toBe(true);
+      expect(readlinkSync(linkPath)).toBe(mawJsRoot);
+      // Sibling content untouched.
+      expect(existsSync(join(nodeModules, ".keep"))).toBe(true);
+    },
+    5000,
+  );
+
+  test(
+    "replaces a dangling symlink (target deleted)",
+    () => {
+      const installRoot = process.env.MAW_PLUGINS_DIR!;
+      const mawJsRoot = process.env.MAW_JS_PATH!;
+      const nodeModules = join(installRoot, "node_modules");
+      const linkPath = join(nodeModules, "maw-js");
+
+      // Point at a directory we then delete → dangling symlink on disk.
+      const ghost = tmpDir("maw-js-ghost-");
+      mkdirSync(nodeModules, { recursive: true });
+      symlinkSync(ghost, linkPath, "dir");
+      rmSync(ghost, { recursive: true, force: true });
+
+      // Confirm dangling: lstat sees the link, existsSync (which follows) is false.
+      expect(lstatSync(linkPath).isSymbolicLink()).toBe(true);
+      expect(existsSync(linkPath)).toBe(false);
+
+      const r = ensureMawJsResolvable();
+
+      expect(r.changed).toBe(true);
+      expect(r.reason).toMatch(/dangling/i);
+      expect(readlinkSync(linkPath)).toBe(mawJsRoot);
+    },
+    5000,
+  );
+
+  test(
+    "leaves a real (non-symlink) file at maw-js path alone",
+    () => {
+      const installRoot = process.env.MAW_PLUGINS_DIR!;
+      const nodeModules = join(installRoot, "node_modules");
+      const linkPath = join(nodeModules, "maw-js");
+
+      // Operator (or another tool) wrote a real directory here. Don't touch it.
+      mkdirSync(linkPath, { recursive: true });
+      writeFileSync(join(linkPath, "package.json"), "{}");
+
+      const r = ensureMawJsResolvable();
+
+      expect(r.changed).toBe(false);
+      expect(r.reason).toMatch(/not a symlink/i);
+      // Not converted into a symlink.
+      expect(lstatSync(linkPath).isDirectory()).toBe(true);
+      expect(lstatSync(linkPath).isSymbolicLink()).toBe(false);
+    },
+    5000,
+  );
+
+  test(
+    "graceful no-op when maw-js root does not exist",
+    () => {
+      // Point MAW_JS_PATH at a path we never created.
+      const ghost = join(tmpdir(), "maw-js-never-existed-" + Date.now() + "-" + Math.random());
+      process.env.MAW_JS_PATH = ghost;
+      expect(existsSync(ghost)).toBe(false);
+
+      const r = ensureMawJsResolvable();
+
+      expect(r.changed).toBe(false);
+      expect(r.reason).toMatch(/not found/i);
+      // No symlink created.
+      const linkPath = join(process.env.MAW_PLUGINS_DIR!, "node_modules", "maw-js");
+      expect(existsSync(linkPath)).toBe(false);
+    },
+    5000,
+  );
+
+  test(
+    "idempotent end-to-end: first call creates, second call is a no-op",
+    () => {
+      const mawJsRoot = process.env.MAW_JS_PATH!;
+      const linkPath = join(process.env.MAW_PLUGINS_DIR!, "node_modules", "maw-js");
+
+      const first = ensureMawJsResolvable();
+      expect(first.changed).toBe(true);
+      expect(readlinkSync(linkPath)).toBe(mawJsRoot);
+
+      const second = ensureMawJsResolvable();
+      expect(second.changed).toBe(false);
+      expect(second.reason).toMatch(/already correct/i);
+      // Link unchanged.
+      expect(readlinkSync(linkPath)).toBe(mawJsRoot);
+    },
+    5000,
+  );
+});


### PR DESCRIPTION
## Summary
- Adds `ensureMawJsResolvable()` helper that creates `~/.maw/plugins/node_modules/maw-js` as a symlink to the active maw-js root
- Invoked from plugin bootstrap and both `install-impl` + `install-tier-impl` flows so plugins under `~/.maw/plugins/` resolve `import "maw-js/..."` via standard node_modules walk-up
- Closes Layer 2 of the global-install resolution pain (sila user issue): plugins couldn't find the maw-js runtime when installed under `~/.maw/plugins/`

Closes #1339 (Option E layer)

## Test plan
- [x] `bun test test/cli/plugin-node-modules-symlink.test.ts` — 8 pass / 0 fail / 37 expect()
- [ ] CI green on alpha base
- [ ] Manual: install a plugin under `~/.maw/plugins/` and confirm `import "maw-js/..."` resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)