### PR TITLE
fix(wake): case-insensitive session detection + lowercase creation (#1340)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.14-alpha.2235",
+  "version": "26.5.14-alpha.2319",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -149,7 +149,8 @@ export async function cmdWake(oracle: string, opts: WakeCmdOptions): Promise<str
     // #769 — URL input names the new session after the full repo (e.g.
     // "m5-oracle") so it's distinct from any unrelated sub-token sessions
     // and immediately disambiguates future `maw wake` calls.
-    const baseName = getSessionMap()[oracle] || resolveFleetSession(oracle) || opts.urlRepoName || oracle;
+    // #1340 — lowercase baseName so maw always creates canonical lowercase sessions.
+    const baseName = (getSessionMap()[oracle] || resolveFleetSession(oracle) || opts.urlRepoName || oracle).toLowerCase();
 
     // #994 — auto-assign NN- prefix to match fleet convention (01-maw-m5, 02-...).
     // Scan existing sessions for numeric prefixes, pick max+1, zero-pad to 2 digits.

--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -302,15 +302,16 @@ export async function detectSession(oracle: string, urlRepoName?: string): Promi
   const mapped = getSessionMap()[oracle];
   if (mapped && sessions.find(s => s.name === mapped)) return mapped;
 
-  // #769 — URL/slug input expresses the FULL repo intent (e.g. "m5-oracle").
-  // The bare `oracle` is the stripped form ("m5"), and falling through to the
-  // generic suffix match would greedily hit unrelated `*-m5` sessions
-  // (`01-maw-m5`, `04-ollama-m5`). Match strictly on the full repo name; if
-  // none, return null so the caller auto-creates a session named after it.
+  // #1340 — all comparisons below are case-insensitive. tmux session names are
+  // case-sensitive (01-Somwind ≠ 01-somwind) but users aren't. Manually-created
+  // mixed-case sessions must be discoverable by maw's lowercase oracle names.
+  const oracleLc = oracle.toLowerCase();
+
   if (urlRepoName) {
-    const exact = sessions.find(s => s.name === urlRepoName || s.name === oracle);
+    const urlLc = urlRepoName.toLowerCase();
+    const exact = sessions.find(s => s.name.toLowerCase() === urlLc || s.name.toLowerCase() === oracleLc);
     if (exact) return exact.name;
-    const numbered = sessions.filter(s => /^\d+-/.test(s.name) && s.name.endsWith(`-${urlRepoName}`));
+    const numbered = sessions.filter(s => /^\d+-/.test(s.name) && s.name.toLowerCase().endsWith(`-${urlLc}`));
     if (numbered.length === 1) return numbered[0]!.name;
     if (numbered.length > 1) {
       console.error(`\x1b[31merror\x1b[0m: '${urlRepoName}' is ambiguous — matches ${numbered.length} fleet sessions:`);
@@ -321,21 +322,15 @@ export async function detectSession(oracle: string, urlRepoName?: string): Promi
     return null;
   }
 
-  // #1107: fleet config is authoritative — check FIRST before substring matching.
-  // "discord" → fleet says "24-discord-oracle", use that. Don't let substring
-  // matching grab "18-hermes-discord" first.
   const fleetSession = resolveFleetSession(oracle);
   if (fleetSession) {
-    if (sessions.find(s => s.name === fleetSession)) return fleetSession;
-    // Fleet knows this oracle but session is dead → return null so cmdWake
-    // creates a NEW session instead of substring-matching into the wrong one.
+    const fleetLc = fleetSession.toLowerCase();
+    if (sessions.find(s => s.name.toLowerCase() === fleetLc)) return fleetSession;
     return null;
   }
 
-  // Numeric-prefixed fleet sessions get first dibs — "110-yeast" beats a bare
-  // "yeast" or an ephemeral "yeast-view" when the user types "yeast". If two
-  // fleet sessions suffix-match, surface loudly rather than silently picking one.
-  const numeric = sessions.filter(s => /^\d+-/.test(s.name) && s.name.endsWith(`-${oracle}`));
+  // #1340 — case-insensitive suffix match for numeric-prefixed fleet sessions.
+  const numeric = sessions.filter(s => /^\d+-/.test(s.name) && s.name.toLowerCase().endsWith(`-${oracleLc}`));
   if (numeric.length === 1) return numeric[0]!.name;
   if (numeric.length > 1) {
     console.error(`\x1b[31merror\x1b[0m: '${oracle}' is ambiguous — matches ${numeric.length} fleet sessions:`);


### PR DESCRIPTION
## Summary
- `detectSession` now uses case-insensitive matching for session suffix/exact lookups
- New session names are forced to lowercase at creation time via `.toLowerCase()` on baseName
- Prevents case-collision where `01-Somwind` (manual) and `02-somwind` (maw) coexist

## Test plan
- [ ] Existing wake-resolve tests pass (35/35 green locally)
- [ ] `maw wake Somwind` attaches to `01-Somwind` instead of creating `02-somwind`
- [ ] CI green

Closes #1340

🤖 Generated with [Claude Code](https://claude.com/claude-code)