### PR TITLE
fix(ci): add 5-minute timeout to test shards (#1348)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,14 @@ jobs:
   # --shard=N/M + --isolate flags. --isolate is essential — 31 of the 102
   # files use mock.module() which is process-global, so without per-file
   # isolation a shard's tests can leak mocks into siblings. (#1278)
+  #
+  # #1348 — timeout-minutes guards against Bun --isolate crashes that hang
+  # the runner indefinitely (panic: Option::unwrap() on None). Normal shard
+  # completes in <30s; 5 min is generous enough to catch real slowdowns
+  # while failing fast on hung shards. Rerun --failed usually passes.
   test-unit:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:
@@ -87,6 +93,7 @@ jobs:
   # (#1257)
   test-isolated:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.14-alpha.2235",
+  "version": "26.5.14-alpha.2325",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
## Summary
- Adds `timeout-minutes: 5` to both `test-unit` and `test-isolated` CI jobs
- Prevents Bun 1.3.x `--isolate` crashes from hanging the runner for 6 hours (GitHub's default timeout)
- Normal shard completes in <30s; 5 min is generous for real slowdowns

## Root Cause
Bun has an intermittent `panic: called Option::unwrap() on a None value` when running `--shard + --isolate`. This is a Bun runtime bug, not test code. The crash leaves the process hung rather than exiting, so CI appears to hang indefinitely.

## Test plan
- [ ] CI itself validates this — if a shard hangs, it'll timeout at 5min instead of 6hr
- [ ] `gh run rerun --failed` is the workaround when this triggers

Closes #1348

🤖 Generated with [Claude Code](https://claude.com/claude-code)