### PR TITLE
fix(auth): mark federation auth hooks global + restore fail-closed (#1, #3)

### DIFF
--- a/src/lib/elysia-auth.ts
+++ b/src/lib/elysia-auth.ts
@@ -161,7 +161,13 @@ export const fromSigningAuth = new Elysia({ name: "from-signing-auth" })
       console.warn(`[from-auth] accepted signed request from unknown peer ${decision.from} (no cached pubkey to verify against — alpha behavior; will harden at v27)`);
     }
     // accept-verified is the steady-state happy path; no log spam.
-  });
+  })
+  // SECURITY (#1): `.as('global')` propagates this onBeforeHandle to every
+  // sibling route module mounted alongside this plugin in src/api/index.ts.
+  // Without it, a named Elysia plugin's lifecycle hook is `local`-scoped — it
+  // guards only routes defined on THIS instance (which defines zero), so the
+  // hook would run for nothing and every protected route would be unguarded.
+  .as("global");
 
 /** Federation auth — Elysia plugin with onBeforeHandle HMAC verification */
 export const federationAuth = new Elysia({ name: "federation-auth" })
@@ -169,8 +175,13 @@ export const federationAuth = new Elysia({ name: "federation-auth" })
     const config = loadConfig();
     const token = config.federationToken;
 
-    // No token configured → auth disabled (backwards compat)
-    if (!token) return;
+    // Peers-require-token invariant (#3) — mirrors the Hono federation-auth.ts.
+    // A node with peers configured binds 0.0.0.0 (see core/server.ts) and is
+    // network-reachable, so "no token" in that posture is default-insecure-open,
+    // NOT single-node mode. We must reach the fail-closed check below before
+    // returning on `!token`, so the token short-circuit no longer happens here.
+    const hasPeers = (config.peers?.length ?? 0) > 0 || (config.namedPeers?.length ?? 0) > 0;
+    const allowPeersWithoutToken = config.allowPeersWithoutToken === true;
 
     const url = new URL(request.url);
     // Strip /api prefix to match against PROTECTED set
@@ -195,6 +206,22 @@ export const federationAuth = new Elysia({ name: "federation-auth" })
     const clientIp = _bunServer?.requestIP?.(request)?.address;
 
     if (isLoopback(clientIp)) return;
+
+    // Fail-closed (#3): peers configured but no federationToken → the node is
+    // network-reachable with auth fully off. Refuse protected writes from
+    // non-loopback callers unless the operator explicitly opted into the
+    // legacy posture with `allowPeersWithoutToken: true`. Restores the
+    // invariant the Hono federation-auth.ts has always enforced.
+    if (!token && hasPeers && !allowPeersWithoutToken) {
+      console.warn(`[auth] rejected ${request.method} ${url.pathname} from ${clientIp ?? "?"}: federation_token_required (peers configured, no federationToken)`);
+      set.status = 401;
+      return { error: "federation auth required", reason: "federation_token_required" };
+    }
+
+    // No token configured AND no peers → local-only single-node mode.
+    // The server binds to 127.0.0.1 in this posture; preserve legacy
+    // pass-through so fresh single-node installs work unchanged.
+    if (!token) return;
 
     // #804 Step 4: when the request carries `x-maw-from`, the from-signing
     // layer owns the `x-maw-signature` slot and is verified by
@@ -229,4 +256,11 @@ export const federationAuth = new Elysia({ name: "federation-auth" })
     }
 
     // Auth passed — continue to handler
-  });
+  })
+  // SECURITY (#1): `.as('global')` propagates this onBeforeHandle to every
+  // sibling route module mounted alongside this plugin in src/api/index.ts
+  // (.use(sessionsApi), .use(feedApi), .use(transportApi), …). Without it the
+  // hook is `local`-scoped to this instance — which defines zero routes — so
+  // it guards NOTHING and every protected write endpoint accepts unsigned
+  // non-loopback requests. Empirically confirmed in maw-stress revalidation.
+  .as("global");

--- a/test/isolated/elysia-auth-global-scope.test.ts
+++ b/test/isolated/elysia-auth-global-scope.test.ts
@@ -1,0 +1,189 @@
+/**
+ * elysia-auth-global-scope.test.ts — regression for maw-stress findings #1 + #3.
+ *
+ * #1 (CRITICAL) — `federationAuth` was a bare `new Elysia(...).onBeforeHandle(...)`
+ *   with no `.as('global')`. In Elysia 1.4 a named plugin's lifecycle hook is
+ *   `local`-scoped: it guards only routes defined on that same instance.
+ *   `federationAuth` defines ZERO routes, so the hook guarded nothing — every
+ *   protected write endpoint (`/api/send`, …) accepted unsigned non-loopback
+ *   requests. maw-stress revalidation confirmed this empirically.
+ *   Fix: `.as('global')` so the hook propagates to sibling route modules.
+ *
+ * #3 (HIGH) — `federationAuth` did `if (!token) return;` at the top — fail-OPEN.
+ *   A node with peers configured binds 0.0.0.0 and is network-reachable, so
+ *   "no token" there is default-insecure-open. Fix: fail-closed — no token +
+ *   peers configured + !allowPeersWithoutToken ⇒ 401.
+ *
+ * Isolated: mocks `src/config` (mock.module is process-global) and mutates
+ * the bun-server reference via setBunServer.
+ */
+import { describe, test, expect, mock, beforeAll, afterEach } from "bun:test";
+import { join } from "path";
+import { Elysia } from "elysia";
+import type { MawConfig } from "../../src/config";
+
+const root = join(import.meta.dir, "../..");
+
+// Mutable config state — the auth hook calls loadConfig() fresh per request,
+// so each test can dial in the federation posture it needs.
+const TOKEN = "test-federation-token-min-16-chars";
+let configState: Partial<MawConfig> = { node: "test-node", federationToken: TOKEN };
+
+mock.module(join(root, "src/config"), () => {
+  const { mockConfigModule } = require("../helpers/mock-config");
+  return mockConfigModule(() => configState);
+});
+
+let federationAuth: typeof import("../../src/lib/elysia-auth").federationAuth;
+let setBunServer: typeof import("../../src/lib/elysia-auth").setBunServer;
+let sign: typeof import("../../src/lib/federation-auth").sign;
+
+const NON_LOOPBACK_IP = "168.144.97.69";
+
+/** Mount federationAuth + a protected route as SEPARATE plugin instances —
+ *  this mirrors src/api/index.ts (`.use(federationAuth).use(sessionsApi)`)
+ *  and is exactly the topology the `.as('global')` fix has to cover. */
+function buildApp(): Elysia {
+  const protectedRoutes = new Elysia()
+    .post("/send", () => ({ ok: true }))
+    .get("/sessions", () => ({ ok: true }));
+  return new Elysia({ prefix: "/api" }).use(federationAuth).use(protectedRoutes);
+}
+
+/** Point setBunServer at a fake server reporting the given client IP. */
+function setClientIp(address: string): void {
+  setBunServer({ requestIP: () => ({ address }) } as unknown as import("bun").Server);
+}
+
+beforeAll(async () => {
+  const mod = await import("../../src/lib/elysia-auth");
+  federationAuth = mod.federationAuth;
+  setBunServer = mod.setBunServer;
+  sign = (await import("../../src/lib/federation-auth")).sign;
+});
+
+afterEach(() => {
+  configState = { node: "test-node", federationToken: TOKEN };
+});
+
+describe("federationAuth — global scope (#1)", () => {
+  test("REGRESSION: unsigned non-loopback POST /api/send → 401 (hook must guard sibling routes)", async () => {
+    setClientIp(NON_LOOPBACK_IP);
+    const res = await buildApp().handle(
+      new Request("http://localhost/api/send", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ target: "x", text: "y" }),
+      }),
+    );
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.reason).toBe("missing_signature");
+  });
+
+  test("signed non-loopback POST /api/send → reaches handler (200)", async () => {
+    setClientIp(NON_LOOPBACK_IP);
+    const ts = Math.floor(Date.now() / 1000);
+    const sig = sign(TOKEN, "POST", "/api/send", ts);
+    const res = await buildApp().handle(
+      new Request("http://localhost/api/send", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-maw-signature": sig,
+          "x-maw-timestamp": String(ts),
+        },
+        body: JSON.stringify({ target: "x", text: "y" }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json()).ok).toBe(true);
+  });
+
+  test("loopback unsigned POST /api/send → bypass (local CLI exemption preserved)", async () => {
+    setClientIp("127.0.0.1");
+    const res = await buildApp().handle(
+      new Request("http://localhost/api/send", { method: "POST", body: "{}" }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  test("non-protected GET /api/sessions → public even unsigned from non-loopback", async () => {
+    setClientIp(NON_LOOPBACK_IP);
+    const res = await buildApp().handle(
+      new Request("http://localhost/api/sessions", { method: "GET" }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  test("bad signature non-loopback → 401 (hook actually inspects the sig)", async () => {
+    setClientIp(NON_LOOPBACK_IP);
+    const res = await buildApp().handle(
+      new Request("http://localhost/api/send", {
+        method: "POST",
+        headers: {
+          "x-maw-signature": "deadbeef".repeat(8),
+          "x-maw-timestamp": String(Math.floor(Date.now() / 1000)),
+        },
+        body: "{}",
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("federationAuth — fail-closed when peers configured but no token (#3)", () => {
+  test("REGRESSION: no token + peers configured + non-loopback → 401 (was fail-open)", async () => {
+    configState = { node: "test-node", peers: ["http://peer-a.example"] };
+    setClientIp(NON_LOOPBACK_IP);
+    const res = await buildApp().handle(
+      new Request("http://localhost/api/send", { method: "POST", body: "{}" }),
+    );
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.reason).toBe("federation_token_required");
+  });
+
+  test("no token + namedPeers configured + non-loopback → 401", async () => {
+    configState = {
+      node: "test-node",
+      namedPeers: [{ name: "peer-a", url: "http://peer-a.example" }],
+    };
+    setClientIp(NON_LOOPBACK_IP);
+    const res = await buildApp().handle(
+      new Request("http://localhost/api/send", { method: "POST", body: "{}" }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("no token + peers + allowPeersWithoutToken:true → explicit opt-in bypass", async () => {
+    configState = {
+      node: "test-node",
+      peers: ["http://peer-a.example"],
+      allowPeersWithoutToken: true,
+    };
+    setClientIp(NON_LOOPBACK_IP);
+    const res = await buildApp().handle(
+      new Request("http://localhost/api/send", { method: "POST", body: "{}" }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  test("no token + NO peers + non-loopback → pass (single-node backwards compat)", async () => {
+    configState = { node: "test-node" };
+    setClientIp(NON_LOOPBACK_IP);
+    const res = await buildApp().handle(
+      new Request("http://localhost/api/send", { method: "POST", body: "{}" }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  test("no token + peers + loopback → pass (fail-closed only gates non-loopback)", async () => {
+    configState = { node: "test-node", peers: ["http://peer-a.example"] };
+    setClientIp("127.0.0.1");
+    const res = await buildApp().handle(
+      new Request("http://localhost/api/send", { method: "POST", body: "{}" }),
+    );
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes two real defects in `src/lib/elysia-auth.ts` confirmed by maw-stress revalidation against HEAD 26.5.2.

### #1 (CRITICAL) — auth hooks guard 0 routes
`federationAuth` and `fromSigningAuth` are bare named Elysia plugins with `onBeforeHandle` hooks but **no `.as('global')`**. In Elysia 1.4 a named plugin's lifecycle hook is `local`-scoped — it guards only routes defined on that same instance. Both plugins define **zero routes**, so the hooks guarded nothing: every protected write endpoint (`/api/send`, `/api/feed`, `/api/transport/send`, `/api/wake`, …) accepted **unsigned non-loopback requests**. Empirically confirmed — unsigned non-loopback `POST /api/send` reached the handler instead of returning 401 → fleet-wide RCE for anyone who can reach `:3456` when the node binds 0.0.0.0.

**Fix:** `.as('global')` on both plugin instances so the hooks propagate to the sibling route modules mounted in `src/api/index.ts`.

### #3 (HIGH) — fail-open when peers configured but no token
`federationAuth` did `if (!token) return;` at the top — **fail-open**. A node with peers configured binds 0.0.0.0 and is network-reachable, so "no token" there is default-insecure-open, not single-node mode.

**Fix:** restored the fail-closed invariant the Hono `federation-auth.ts` has always enforced — no token + peers configured + `!allowPeersWithoutToken` ⇒ 401. Single-node (no peers) still passes for backwards compat; loopback still bypasses.

## Tests

New `test/isolated/elysia-auth-global-scope.test.ts` mounts `federationAuth` + a protected route as **separate plugin instances** (the exact `src/api/index.ts` topology) and asserts:
- unsigned non-loopback `POST /api/send` ⇒ **401** (the regression)
- signed ⇒ 200, loopback bypass preserved, non-protected GET public, bad sig ⇒ 401
- all four #3 fail-closed posture combinations (peers/namedPeers/allow-flag/no-peers)

`bun test` green; existing `federation-auth.test.ts` + `elysia-auth-protected.test.ts` unaffected.

## Deploy note

**NOT deployed** — fix + test + PR only. Awaiting brain/Nat review before any deploy to the live fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)