### PR TITLE
fix(transport): confirm tmux sendText submission instead of blind Enter (#6)

### DIFF
--- a/src/core/transport/tmux-class.ts
+++ b/src/core/transport/tmux-class.ts
@@ -8,6 +8,22 @@ import {
   type TmuxWindow,
 } from "./tmux-types";
 
+// --- sendText submit-confirmation tuning (#6) ---
+// The old sendText fired 3 blind `Enter` keys on a fixed ~1.9s schedule with
+// zero feedback. If the pane wasn't ready when they landed (agent still
+// rendering the paste, brief stall), every Enter missed and the command sat
+// in the input box unexecuted — this forced manual re-launch of dispatches
+// on 2026-05-14. We now send Enter, re-check the pane, and retry only while
+// input is still pending.
+/** Wait after paste/literal-send before the first Enter — lets the input settle. */
+const SEND_SETTLE_MS = 1500;
+/** Wait after each Enter before re-checking whether the input line cleared. */
+const SUBMIT_CONFIRM_MS = 700;
+/** Max Enter attempts before giving up and warning (was 3 blind, unconditional sends). */
+const MAX_SUBMIT_ATTEMPTS = 4;
+/** ANSI escape stripper — matches checkPaneIdle in comm-send.ts (#405). */
+const ANSI_RE = /\x1b\[[0-9;]*[mGKHFJA-Z]/g;
+
 /**
  * Typed wrapper around tmux CLI.
  * All methods build arg arrays and delegate to `run()`.
@@ -260,31 +276,65 @@ export class Tmux {
 
   /**
    * Smart text sending — uses load-buffer for multiline/long messages,
-   * send-keys for short single-line. Always appends Enter.
+   * send-keys for short single-line. Always submits with Enter.
    * Ported from old bash maw hey (Dec 2025).
+   *
+   * #6 — submit is now confirmed, not fire-and-forget. After placing the
+   * text we send Enter, re-inspect the pane, and retry the Enter only while
+   * the input line still holds un-submitted content (up to
+   * MAX_SUBMIT_ATTEMPTS). This closes the trailing-Enter race where blind
+   * staggered Enter keys landed before the pane was ready and the command
+   * was silently left unexecuted.
    */
   async sendText(target: string, text: string): Promise<void> {
     if (text.includes("\n") || text.length > 500) {
       // Buffer method — reliable for multiline/long content
       await this.loadBuffer(text);
       await this.pasteBuffer(target);
-      await new Promise(r => setTimeout(r, 1500));
-      // Staggered Enter — submit + 2 fallbacks
-      await this.sendKeys(target, "Enter");
-      await new Promise(r => setTimeout(r, 700));
-      await this.sendKeys(target, "Enter");
-      await new Promise(r => setTimeout(r, 1200));
-      await this.sendKeys(target, "Enter");
     } else {
       // Literal send — -l prevents tmux from interpreting special chars like |
       await this.sendKeysLiteral(target, text);
-      await new Promise(r => setTimeout(r, 1500));
-      // Staggered Enter — submit + 2 fallbacks
+    }
+    await new Promise(r => setTimeout(r, SEND_SETTLE_MS));
+    await this.submitWithConfirm(target);
+  }
+
+  /**
+   * Send Enter, then confirm the input line cleared before returning. Retries
+   * the Enter while input is still pending — see sendText for the #6 race.
+   * @internal — exported behavior is exercised via sendText in tests.
+   */
+  private async submitWithConfirm(target: string): Promise<void> {
+    for (let attempt = 1; attempt <= MAX_SUBMIT_ATTEMPTS; attempt++) {
       await this.sendKeys(target, "Enter");
-      await new Promise(r => setTimeout(r, 700));
-      await this.sendKeys(target, "Enter");
-      await new Promise(r => setTimeout(r, 1200));
-      await this.sendKeys(target, "Enter");
+      await new Promise(r => setTimeout(r, SUBMIT_CONFIRM_MS));
+      if (!(await this.paneInputPending(target))) return; // submitted — done
+    }
+    // Exhausted every retry and the input line still looks non-empty. The
+    // caller has no visibility into tmux pane state, so warn loudly — a
+    // silently-dropped dispatch is the exact failure mode #6 is about.
+    console.warn(
+      `[tmux] sendText: ${target} still shows pending input after ${MAX_SUBMIT_ATTEMPTS} Enter attempts — command may not have submitted`,
+    );
+  }
+
+  /**
+   * True when the pane's prompt line still holds un-submitted input.
+   * Mirrors checkPaneIdle (comm-send.ts #405) but inlined here to avoid a
+   * circular import — comm-send.ts already imports Tmux. A read failure
+   * returns false (assume submitted) so a flaky capture can't spin the retry
+   * loop.
+   */
+  private async paneInputPending(target: string): Promise<boolean> {
+    try {
+      const content = await this.capture(target, 5);
+      const lines = content.split("\n").filter(l => l.trim());
+      const last = (lines.at(-1) ?? "").replace(ANSI_RE, "").replace(/\r/g, "");
+      // Prompt marker followed by non-whitespace → user/command text still
+      // sitting on the input line, i.e. Enter has not submitted it yet.
+      return /[#$%>❯»]\s+\S/.test(last);
+    } catch {
+      return false;
     }
   }
 

--- a/test/tmux-sendtext-submit.test.ts
+++ b/test/tmux-sendtext-submit.test.ts
@@ -1,0 +1,132 @@
+/**
+ * tmux-sendtext-submit.test.ts — regression for maw-stress finding #6.
+ *
+ * Tmux.sendText used to fire 3 blind `Enter` keys on a fixed ~1.9s schedule
+ * with zero feedback. When the pane wasn't ready as they landed, every Enter
+ * missed and the command sat in the input box unexecuted — this forced
+ * brain to manually re-launch dispatches on 2026-05-14.
+ *
+ * The fix: send Enter, re-inspect the pane, retry only while the input line
+ * still holds un-submitted content (capped at MAX_SUBMIT_ATTEMPTS).
+ *
+ * Strategy: subclass Tmux and override the low-level primitives so we can
+ * script the pane's capture output and assert the exact key sequence — no
+ * tmux process, no module mock (safe for the main suite).
+ */
+import { describe, test, expect } from "bun:test";
+import { Tmux } from "../src/core/transport/tmux-class";
+
+/** Tmux with the tmux-touching primitives stubbed + a scripted capture feed. */
+class FakeTmux extends Tmux {
+  calls: string[] = [];
+  /** Successive return values for capture(); last value repeats once exhausted. */
+  captureScript: string[] = [];
+  private captureIdx = 0;
+
+  constructor() {
+    super(undefined, ""); // no socket — overridden methods never hit hostExec
+  }
+
+  async capture(_target: string, _lines = 80): Promise<string> {
+    this.calls.push("capture");
+    const v = this.captureScript[this.captureIdx] ?? this.captureScript.at(-1) ?? "";
+    this.captureIdx++;
+    return v;
+  }
+  async sendKeys(_target: string, ...keys: string[]): Promise<void> {
+    this.calls.push(`sendKeys:${keys.join(",")}`);
+  }
+  async sendKeysLiteral(_target: string, text: string): Promise<void> {
+    this.calls.push(`sendKeysLiteral:${text}`);
+  }
+  async loadBuffer(text: string): Promise<void> {
+    this.calls.push(`loadBuffer:${text.length}`);
+  }
+  async pasteBuffer(_target: string): Promise<void> {
+    this.calls.push("pasteBuffer");
+  }
+}
+
+const PROMPT_IDLE = "agent@host:~$ "; // prompt marker + trailing space → submitted
+const PROMPT_PENDING = "agent@host:~$ unsent command text"; // input still on the line
+const enterCount = (calls: string[]) => calls.filter(c => c === "sendKeys:Enter").length;
+
+describe("Tmux.sendText — confirmed submit (#6)", () => {
+  test(
+    "single Enter when the pane clears on the first check — no blind trailing Enters",
+    async () => {
+      const t = new FakeTmux();
+      t.captureScript = [PROMPT_IDLE];
+      await t.sendText("sess:win", "hello");
+
+      expect(t.calls).toEqual(["sendKeysLiteral:hello", "sendKeys:Enter", "capture"]);
+      expect(enterCount(t.calls)).toBe(1);
+    },
+    10_000,
+  );
+
+  test(
+    "retries Enter while input is still pending, stops as soon as it clears",
+    async () => {
+      const t = new FakeTmux();
+      // pending after Enter #1 and #2, cleared after #3
+      t.captureScript = [PROMPT_PENDING, PROMPT_PENDING, PROMPT_IDLE];
+      await t.sendText("sess:win", "deploy task");
+
+      expect(enterCount(t.calls)).toBe(3);
+      // last action is the confirming capture, not another blind Enter
+      expect(t.calls.at(-1)).toBe("capture");
+    },
+    15_000,
+  );
+
+  test(
+    "stops after MAX_SUBMIT_ATTEMPTS and warns when the pane never clears",
+    async () => {
+      const t = new FakeTmux();
+      t.captureScript = [PROMPT_PENDING]; // repeats → never clears
+
+      const warnings: string[] = [];
+      const origWarn = console.warn;
+      console.warn = (...args: unknown[]) => { warnings.push(args.join(" ")); };
+      try {
+        await t.sendText("sess:win", "stuck task");
+      } finally {
+        console.warn = origWarn;
+      }
+
+      // capped — not an unbounded spin
+      expect(enterCount(t.calls)).toBe(4);
+      expect(warnings.some(w => w.includes("pending input") && w.includes("sess:win"))).toBe(true);
+    },
+    15_000,
+  );
+
+  test(
+    "multiline content routes through loadBuffer + pasteBuffer, then confirmed submit",
+    async () => {
+      const t = new FakeTmux();
+      t.captureScript = [PROMPT_IDLE];
+      await t.sendText("sess:win", "line one\nline two");
+
+      expect(t.calls[0]).toBe(`loadBuffer:${"line one\nline two".length}`);
+      expect(t.calls[1]).toBe("pasteBuffer");
+      expect(t.calls).not.toContain("sendKeysLiteral:line one\nline two");
+      expect(enterCount(t.calls)).toBe(1);
+    },
+    10_000,
+  );
+
+  test(
+    "a capture failure is treated as submitted — the retry loop cannot spin",
+    async () => {
+      const t = new FakeTmux();
+      // capture throws → paneInputPending swallows → false (assume submitted)
+      t.capture = async () => { throw new Error("tmux gone"); };
+      await t.sendText("sess:win", "hi");
+
+      expect(enterCount(t.calls)).toBe(1);
+    },
+    10_000,
+  );
+});


### PR DESCRIPTION
## Summary

Fixes maw-stress finding #6 — `Tmux.sendText` trailing-Enter race.

`sendText` fired **3 blind `Enter` keys** on a fixed ~1.9s schedule with zero feedback:

```
sendKeys Enter → +700ms → sendKeys Enter → +1200ms → sendKeys Enter
```

When the pane wasn't ready as those keys landed (agent still rendering the paste, a brief stall), every Enter missed and the command sat in the input box **unexecuted**. The idle guard in `cmdSend` (`comm-send.ts` #405) is checked exactly once, *before* the send, so it does not cover this window. This forced brain to manually re-launch every dispatch on 2026-05-14.

## Fix

Submit is now **confirmed**, not fire-and-forget:

- `submitWithConfirm()` sends Enter, re-inspects the pane via `paneInputPending()`, and retries the Enter **only while the input line still holds un-submitted content** — capped at `MAX_SUBMIT_ATTEMPTS` (4).
- If every retry is exhausted with input still pending, it `console.warn`s loudly instead of returning as if the command went through.
- `paneInputPending()` mirrors `checkPaneIdle` (`comm-send.ts` #405) but is inlined in `tmux-class.ts` to avoid a circular import (`comm-send.ts` already imports `Tmux`). A capture failure returns `false` (assume submitted) so a flaky capture cannot spin the retry loop.

On a clean submit this sends **exactly one Enter** (vs. 3 blind before) and returns in ~`SEND_SETTLE_MS + SUBMIT_CONFIRM_MS`.

## Tests

`test/tmux-sendtext-submit.test.ts` subclasses `Tmux`, scripts the capture feed, and asserts the exact key sequence: single Enter on a clean submit (no blind trailing Enters), retry-until-cleared, the `MAX_SUBMIT_ATTEMPTS` cap + warning, multiline buffer routing, and the capture-failure path.

## Deploy note

**NOT deployed** — fix + test + PR only. Awaiting brain/Nat review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)