### PR TITLE
feat(wake): add agent concurrency cap to cmdWake (#2)

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -8,6 +8,7 @@ import { resolveOracle, findWorktrees, getSessionMap, resolveFleetSession, detec
 import { attachToSession, ensureSessionRunning, createWorktree } from "./wake-session";
 import { maybeSplit } from "./wake-maybe-split";
 import { parseWakeTarget, ensureCloned } from "./wake-target";
+import { assertAgentCapacity } from "./wake-concurrency";
 
 export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; split?: boolean; repoPath?: string; urlRepoName?: string; allLocal?: boolean; engine?: string }): Promise<string> {
   // Canonicalize the bare name before any lookup — strips trailing `/`, `/.git`, `/.git/`
@@ -81,6 +82,10 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
   });
 
   if (!session && wakeDecision.wake) {
+    // #2 — refuse to spawn a brand-new session/agent once the fleet is at the
+    // configured concurrency cap (no-op when limits.maxConcurrentAgents is 0).
+    await assertAgentCapacity(oracle);
+
     // #769 — URL input names the new session after the full repo (e.g.
     // "m5-oracle") so it's distinct from any unrelated sub-token sessions
     // and immediately disambiguates future `maw wake` calls.
@@ -275,6 +280,10 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
       return target;
     }
   } catch { /* session might be fresh */ }
+
+  // #2 — a new task/worktree window is a net-new agent pane: cap-check before
+  // spawning it (no-op when limits.maxConcurrentAgents is 0).
+  await assertAgentCapacity(oracle);
 
   await tmux.newWindow(session, windowName, { cwd: targetPath });
   await new Promise(r => setTimeout(r, 300));

--- a/src/commands/shared/wake-concurrency.ts
+++ b/src/commands/shared/wake-concurrency.ts
@@ -1,0 +1,58 @@
+/**
+ * wake-concurrency.ts — agent concurrency cap for `maw wake` (#2).
+ *
+ * `cmdWake` had no count, queue, or cap: nothing stopped a script (or a
+ * runaway orchestrator) from spawning agents until the box fell over.
+ * `D.limits` governed feed/logs/pty/message sizes but nothing about agent
+ * count.
+ *
+ * This module adds an opt-in cap. When `limits.maxConcurrentAgents` is a
+ * positive number, `maw wake` counts the agent panes already live across the
+ * fleet and refuses ("fails loud") to spawn one more once the fleet is at or
+ * over the cap. `0` / unset disables the cap — no behavior change for anyone
+ * who has not configured it.
+ *
+ * Pure decision logic (`checkCapacity`) is split from the tmux I/O
+ * (`countLiveAgents`) so the over-cap path is unit-testable without a tmux
+ * server.
+ */
+
+import { cfgLimit } from "../../config";
+import { tmux } from "../../core/transport/tmux";
+import { isAgentCommand } from "../../core/transport/ssh";
+
+/**
+ * Pure cap decision — throws a loud, actionable error when `liveAgents` is at
+ * or over `cap`. A `cap` of `0` or less means "disabled" and is always a
+ * no-op. Kept free of I/O so tests can exercise every branch directly.
+ */
+export function checkCapacity(liveAgents: number, cap: number, spawning: string): void {
+  if (!cap || cap <= 0) return; // cap disabled — opt-in only
+  if (liveAgents >= cap) {
+    throw new Error(
+      `agent concurrency cap reached: ${liveAgents}/${cap} agents already live — ` +
+      `refusing to spawn '${spawning}'. Raise limits.maxConcurrentAgents in maw.config.json ` +
+      `or sleep an idle agent first (maw sleep <agent>).`,
+    );
+  }
+}
+
+/** Count tmux panes currently running an agent process across all sessions. */
+export async function countLiveAgents(): Promise<number> {
+  const panes = await tmux.listPanes();
+  return panes.filter(p => isAgentCommand(p.command)).length;
+}
+
+/**
+ * Guard a spawn against the configured agent concurrency cap (#2). No-op when
+ * `limits.maxConcurrentAgents` is `0` / unset — and in that case we skip the
+ * tmux `list-panes` call entirely so the disabled path stays free.
+ *
+ * @param spawning  the oracle/agent name about to be spawned — surfaced in the
+ *                  error so the operator knows what was refused.
+ */
+export async function assertAgentCapacity(spawning: string): Promise<void> {
+  const cap = cfgLimit("maxConcurrentAgents");
+  if (!cap || cap <= 0) return; // disabled — don't even query tmux
+  checkCapacity(await countLiveAgents(), cap, spawning);
+}

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -47,6 +47,12 @@ export interface MawLimits {
   messageTruncate?: number;
   ptyCols?: number;
   ptyRows?: number;
+  /**
+   * Max concurrent agent panes across the fleet before `maw wake` refuses to
+   * spawn a new one (#2). `0` (the default) disables the cap entirely —
+   * operators opt in by setting a positive number.
+   */
+  maxConcurrentAgents?: number;
 }
 
 export interface MawConfig {
@@ -159,6 +165,6 @@ export interface MawConfig {
 export const D = {
   intervals: { capture: 50, sessions: 5000, status: 3000, teams: 3000, preview: 2000, peerFetch: 10000, crashCheck: 30000 } as const,
   timeouts: { http: 5000, health: 3000, ping: 5000, pty: 5000, workspace: 5000, shellInit: 3000, wakeRetry: 500, wakeVerify: 3000 } as const,
-  limits: { feedMax: 500, feedDefault: 50, feedHistory: 50, logsMax: 500, logsDefault: 50, logsTruncate: 500, messageTruncate: 100, ptyCols: 500, ptyRows: 200 } as const,
+  limits: { feedMax: 500, feedDefault: 50, feedHistory: 50, logsMax: 500, logsDefault: 50, logsTruncate: 500, messageTruncate: 100, ptyCols: 500, ptyRows: 200, maxConcurrentAgents: 0 } as const,
   hmacWindowSeconds: 300,
 } as const;

--- a/test/helpers/mock-config.ts
+++ b/test/helpers/mock-config.ts
@@ -23,6 +23,7 @@ const LIMITS: Record<keyof MawLimits, number> = {
   feedMax: 500, feedDefault: 50, feedHistory: 50,
   logsMax: 500, logsDefault: 50, logsTruncate: 500,
   messageTruncate: 100, ptyCols: 500, ptyRows: 200,
+  maxConcurrentAgents: 0,
 };
 
 export const TEST_D = {

--- a/test/helpers/mock-tmux.ts
+++ b/test/helpers/mock-tmux.ts
@@ -69,12 +69,24 @@ export interface MockPeer {
   sessions: MockSession[];
 }
 
+/** Shape returned by the mocked `tmux.listPanes()` — mirrors TmuxPane. */
+export interface MockPane {
+  id: string;
+  command: string;
+  target: string;
+  title?: string;
+  pid?: number;
+  cwd?: string;
+  lastActivity?: number;
+}
+
 // --- Internal state (cleared by resetMocks) ---
 
 let tmuxConfig: { sessions: MockSession[] } | null = null;
 let peersConfig: { peers: MockPeer[] } | null = null;
 let paneCommands: Record<string, string> = {};
 let capturedCommands: string[] = [];
+let panes: MockPane[] = [];
 
 // --- Shim install latches (shim stays live; config is what changes) ---
 
@@ -152,7 +164,7 @@ export function installTmuxMock(config: { sessions: MockSession[] }): void {
       },
       async listPanes() {
         capturedCommands.push("tmux list-panes -a");
-        return [];
+        return panes.map(p => ({ ...p }));
       },
       async killPane(target: string) {
         capturedCommands.push(`tmux kill-pane -t ${target}`);
@@ -328,6 +340,23 @@ export function setPaneCommands(cmds: Record<string, string>): void {
   paneCommands = { ...cmds };
 }
 
+/**
+ * Configure what `tmux.listPanes()` returns. Accepts partial panes — only
+ * `command` is required (the field most callers filter on); the rest are
+ * filled with deterministic placeholders. Replaces the previous list.
+ */
+export function setPanes(p: Array<Partial<MockPane> & { command: string }>): void {
+  panes = p.map((pane, i) => ({
+    id: pane.id ?? `%${i}`,
+    command: pane.command,
+    target: pane.target ?? `mock:${i}`,
+    title: pane.title,
+    pid: pane.pid,
+    cwd: pane.cwd,
+    lastActivity: pane.lastActivity,
+  }));
+}
+
 /** Captured tmux commands issued through the mock (for assertions). */
 export function getCapturedCommands(): string[] {
   return [...capturedCommands];
@@ -345,4 +374,5 @@ export function resetMocks(): void {
   peersConfig = null;
   paneCommands = {};
   capturedCommands = [];
+  panes = [];
 }

--- a/test/isolated/wake-concurrency.test.ts
+++ b/test/isolated/wake-concurrency.test.ts
@@ -1,0 +1,122 @@
+/**
+ * wake-concurrency.test.ts — regression for maw-stress finding #2.
+ *
+ * `cmdWake` had no count / queue / cap — nothing stopped a script or a
+ * runaway orchestrator from spawning agents until the box fell over.
+ * `src/commands/shared/wake-concurrency.ts` adds an opt-in cap
+ * (`limits.maxConcurrentAgents`); `cmdWake` calls `assertAgentCapacity`
+ * before every net-new spawn.
+ *
+ * Isolated: installs the tmux mock + a config mock (both mock.module, which
+ * is process-global). Pure decision logic (`checkCapacity`) is also pinned
+ * here — it needs no mocks but lives with its siblings.
+ */
+import { describe, test, expect, beforeAll, afterEach, mock } from "bun:test";
+import { join } from "path";
+import { installTmuxMock, setPanes, getCapturedCommands, resetMocks } from "../helpers/mock-tmux";
+
+const root = join(import.meta.dir, "../..");
+
+// Controllable cap value — assertAgentCapacity reads it via cfgLimit().
+let capValue = 0;
+
+// tmux mock first, then config mock — both mock.module, registered before the
+// dynamic import in beforeAll so wake-concurrency.ts resolves to the shims.
+installTmuxMock({ sessions: [] });
+
+mock.module(join(root, "src/config"), () => {
+  const { mockConfigModule } = require("../helpers/mock-config");
+  const base = mockConfigModule(() => ({ node: "test-node", commands: {} }));
+  return {
+    ...base,
+    cfgLimit: (k: string) =>
+      k === "maxConcurrentAgents" ? capValue : base.cfgLimit(k),
+  };
+});
+
+let checkCapacity: typeof import("../../src/commands/shared/wake-concurrency").checkCapacity;
+let countLiveAgents: typeof import("../../src/commands/shared/wake-concurrency").countLiveAgents;
+let assertAgentCapacity: typeof import("../../src/commands/shared/wake-concurrency").assertAgentCapacity;
+
+beforeAll(async () => {
+  const mod = await import("../../src/commands/shared/wake-concurrency");
+  checkCapacity = mod.checkCapacity;
+  countLiveAgents = mod.countLiveAgents;
+  assertAgentCapacity = mod.assertAgentCapacity;
+});
+
+afterEach(() => {
+  resetMocks();
+  capValue = 0;
+});
+
+describe("checkCapacity — pure cap decision (#2)", () => {
+  test("cap 0 / negative → disabled, never throws", () => {
+    expect(() => checkCapacity(999, 0, "x")).not.toThrow();
+    expect(() => checkCapacity(999, -1, "x")).not.toThrow();
+  });
+
+  test("under cap → no throw", () => {
+    expect(() => checkCapacity(3, 5, "neo")).not.toThrow();
+  });
+
+  test("at cap → throws (over-cap path)", () => {
+    expect(() => checkCapacity(5, 5, "neo")).toThrow(/5\/5/);
+    expect(() => checkCapacity(5, 5, "neo")).toThrow(/refusing to spawn 'neo'/);
+  });
+
+  test("over cap → throws", () => {
+    expect(() => checkCapacity(8, 5, "pulse")).toThrow(/8\/5/);
+  });
+
+  test("error message is actionable — names the config knob", () => {
+    expect(() => checkCapacity(5, 5, "neo")).toThrow(/maxConcurrentAgents/);
+  });
+});
+
+describe("countLiveAgents — counts agent panes across the fleet", () => {
+  test("counts only agent-process panes (claude / node), ignores shells", async () => {
+    setPanes([
+      { command: "claude" },
+      { command: "node" },
+      { command: "zsh" },
+      { command: "bash" },
+      { command: "claude" },
+    ]);
+    expect(await countLiveAgents()).toBe(3);
+  });
+
+  test("no panes → 0", async () => {
+    setPanes([]);
+    expect(await countLiveAgents()).toBe(0);
+  });
+});
+
+describe("assertAgentCapacity — the guard cmdWake calls before spawning", () => {
+  test("disabled (cap 0) → no throw, and does NOT even query tmux", async () => {
+    capValue = 0;
+    setPanes([{ command: "claude" }, { command: "claude" }, { command: "claude" }]);
+    await assertAgentCapacity("neo");
+    // fast-path: disabled cap must skip the list-panes call entirely
+    expect(getCapturedCommands().some(c => c.includes("list-panes"))).toBe(false);
+  });
+
+  test("under cap → resolves", async () => {
+    capValue = 5;
+    setPanes([{ command: "claude" }, { command: "node" }]);
+    await assertAgentCapacity("neo");
+    expect(getCapturedCommands().some(c => c.includes("list-panes"))).toBe(true);
+  });
+
+  test("at/over cap → rejects loudly", async () => {
+    capValue = 2;
+    setPanes([{ command: "claude" }, { command: "claude" }, { command: "node" }]);
+    await expect(assertAgentCapacity("neo")).rejects.toThrow(/concurrency cap reached: 3\/2/);
+  });
+
+  test("exactly at cap → rejects (cap is inclusive)", async () => {
+    capValue = 2;
+    setPanes([{ command: "claude" }, { command: "claude" }]);
+    await expect(assertAgentCapacity("pulse")).rejects.toThrow(/2\/2/);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes maw-stress finding #2 — `cmdWake` had **no count, queue, or cap**. Nothing stopped a script or a runaway orchestrator from spawning agents until the box fell over. `D.limits` governed feed/logs/pty/message sizes but nothing about agent count.

## Change — opt-in concurrency cap

- **New config key** `limits.maxConcurrentAgents` (`MawLimits` + `D.limits` default `0`). `0` / unset **disables the cap entirely** — zero behavior change for anyone who hasn't configured it.
- **New module** `src/commands/shared/wake-concurrency.ts`:
  - `checkCapacity()` — pure cap decision; throws a loud, actionable error at/over cap (**fail-loud** per the issue). I/O-free so the over-cap path is unit-testable directly.
  - `countLiveAgents()` — counts tmux panes running an agent process (`isAgentCommand`) across all sessions.
  - `assertAgentCapacity()` — the guard: no-op when the cap is `0`/unset (and skips the `list-panes` call entirely in that case), otherwise counts live agents and refuses once at/over cap.
- `cmdWake` calls `assertAgentCapacity(oracle)` before **both net-new spawn sites**: new-session creation and new task/worktree window creation. Idempotent reuse / dead-agent respawn paths are *not* gated — they don't grow the fleet.

## Test infra

- `mock-tmux.ts` gains `setPanes()` + `MockPane` so `tmux.listPanes()` is scriptable (was hardcoded to `[]`).
- `mock-config.ts` `LIMITS` gains the new key so `Record<keyof MawLimits>` stays exhaustive.

## Tests

`test/isolated/wake-concurrency.test.ts` pins `checkCapacity` (all branches incl. at/over cap), `countLiveAgents` (filters shells, counts agents), and `assertAgentCapacity` (disabled fast-path skips tmux, under-cap resolves, at/over-cap rejects loudly).

## Deploy note

**NOT deployed** — fix + test + PR only. Awaiting brain/Nat review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)