### PR TITLE
fix(transport): tighten isAgentCommand — match node/configured bins exactly (#10)

### DIFF
--- a/src/core/transport/ssh.ts
+++ b/src/core/transport/ssh.ts
@@ -81,18 +81,30 @@ export async function getPaneCommand(target: string, host?: string): Promise<str
 
 /** Pane command looks like an AI agent — name match (claude/codex/node),
  *  Claude Code 2.1+ versioned-binary signature (e.g. "2.1.121"), or any
- *  binary from config.commands entries. */
+ *  binary from config.commands entries.
+ *
+ *  #10: `cmd` is a tmux `#{pane_current_command}` — a bare command basename,
+ *  not a command line. `claude` / `codex` are distinctive enough that a
+ *  substring match is safe (no benign command contains them), but `node` is
+ *  a substring of `nodemon`, the `node` REPL, `node-red`, and any number of
+ *  non-agent tools. So `node` (and configured binaries) are matched as the
+ *  WHOLE command name — not loose substrings — so non-agent node processes
+ *  don't pass. */
 export function isAgentCommand(cmd: string | null | undefined): boolean {
   const c = (cmd ?? "").trim();
   if (!c) return false;
-  if (/claude|codex|node/i.test(c)) return true;
+  if (/claude|codex/i.test(c)) return true;
+  if (/^node$/i.test(c)) return true;
   if (/^\d+\.\d+\.\d+$/.test(c)) return true;
   try {
     const { loadConfig } = require("../../config");
     const commands: Record<string, string> = loadConfig().commands || {};
+    const lc = c.toLowerCase();
     for (const v of Object.values(commands)) {
       const bin = v.split(/\s/)[0];
-      if (bin && bin !== "default" && c.toLowerCase().includes(bin.toLowerCase())) return true;
+      // Exact name match, not substring — a configured `node`-launched agent
+      // must not make every `nodemon`/`node-*` pane look like an agent.
+      if (bin && bin !== "default" && lc === bin.toLowerCase()) return true;
     }
   } catch {}
   return false;

--- a/test/helpers/mock-ssh.ts
+++ b/test/helpers/mock-ssh.ts
@@ -40,7 +40,17 @@ export interface SshMockOverrides {
   getPaneCommand?: (...args: any[]) => any;
   getPaneCommands?: (...args: any[]) => any;
   getPaneInfos?: (...args: any[]) => any;
+  isAgentCommand?: (...args: any[]) => any;
   HostExecError?: any;
+}
+
+/** Faithful lightweight default for isAgentCommand — name-match only (no
+ *  config.commands lookup, which the real one does). Mirrors the tightened
+ *  #10 logic so tests that don't override it still get sane answers. */
+function defaultIsAgentCommand(cmd?: string | null): boolean {
+  const c = (cmd ?? "").trim();
+  if (!c) return false;
+  return /claude|codex/i.test(c) || /^node$/i.test(c) || /^\d+\.\d+\.\d+$/.test(c);
 }
 
 // #431 added HostExecError — mocks must re-export the class shape or
@@ -75,6 +85,7 @@ export function mockSshModule(overrides: SshMockOverrides = {}) {
     getPaneCommand: async () => "",
     getPaneCommands: async () => ({}),
     getPaneInfos: async () => ({}),
+    isAgentCommand: defaultIsAgentCommand,
     HostExecError: MockHostExecError,
     ...overrides,
   };

--- a/test/is-agent-command.test.ts
+++ b/test/is-agent-command.test.ts
@@ -39,4 +39,28 @@ describe("isAgentCommand", () => {
     expect(isAgentCommand("  claude  ")).toBe(true);
     expect(isAgentCommand("\t2.1.121\n")).toBe(true);
   });
+
+  // #10 — the guard regex used a loose substring match on `node`, so any
+  // command containing "node" passed. tmux #{pane_current_command} is a bare
+  // command basename, so `node` is now matched as the WHOLE name only.
+  test("rejects non-agent commands that merely contain 'node' (#10)", () => {
+    expect(isAgentCommand("nodemon")).toBe(false);
+    expect(isAgentCommand("node-red")).toBe(false);
+    expect(isAgentCommand("node-gyp")).toBe(false);
+    expect(isAgentCommand("nodejs")).toBe(false);
+    expect(isAgentCommand("anode")).toBe(false);
+  });
+
+  test("still matches bare 'node' regardless of case (#10)", () => {
+    expect(isAgentCommand("node")).toBe(true);
+    expect(isAgentCommand("Node")).toBe(true);
+    expect(isAgentCommand("NODE")).toBe(true);
+    expect(isAgentCommand("  node  ")).toBe(true);
+  });
+
+  test("claude / codex stay substring-matched (distinctive — no false positives)", () => {
+    expect(isAgentCommand("claude")).toBe(true);
+    expect(isAgentCommand("claude-code")).toBe(true);
+    expect(isAgentCommand("codex")).toBe(true);
+  });
 });

--- a/test/isolated/is-agent-command-config.test.ts
+++ b/test/isolated/is-agent-command-config.test.ts
@@ -1,0 +1,59 @@
+/**
+ * is-agent-command-config.test.ts — #10, config.commands branch.
+ *
+ * isAgentCommand also matches panes whose command equals a binary from
+ * `config.commands`. That match used a loose `.includes()` substring, so a
+ * configured `node`-launched agent made every `nodemon` / `node-*` pane look
+ * like an agent. #10 tightens it to an exact (whole-name) comparison.
+ *
+ * Isolated: mocks src/config (mock.module is process-global) so the
+ * config.commands map is controllable. The plain-name regex branch is
+ * covered without mocks in test/is-agent-command.test.ts.
+ */
+import { describe, test, expect, beforeAll, mock } from "bun:test";
+import { join } from "path";
+
+const root = join(import.meta.dir, "../..");
+
+mock.module(join(root, "src/config"), () => {
+  const { mockConfigModule } = require("../helpers/mock-config");
+  return mockConfigModule(() => ({
+    node: "test-node",
+    commands: {
+      // bin tokens: "myagent", "node", "default" (the "default" key's value
+      // is intentionally the literal string the loop skips on)
+      primary: "myagent --run --flag",
+      secondary: "node /opt/agent/index.js",
+      default: "default",
+    },
+  }));
+});
+
+let isAgentCommand: typeof import("../../src/core/transport/ssh").isAgentCommand;
+
+beforeAll(async () => {
+  isAgentCommand = (await import("../../src/core/transport/ssh")).isAgentCommand;
+});
+
+describe("isAgentCommand — config.commands exact match (#10)", () => {
+  test("matches a configured binary by exact command name", () => {
+    expect(isAgentCommand("myagent")).toBe(true);
+  });
+
+  test("does NOT match commands that merely contain a configured binary name", () => {
+    expect(isAgentCommand("myagentx")).toBe(false);
+    expect(isAgentCommand("xmyagent")).toBe(false);
+    expect(isAgentCommand("my-myagent-wrapper")).toBe(false);
+  });
+
+  test("a configured `node`-launched agent does not make nodemon look like an agent", () => {
+    // "node" is a configured bin (secondary) AND a name-regex match — bare
+    // `node` is an agent, but `nodemon` must not inherit that.
+    expect(isAgentCommand("node")).toBe(true);
+    expect(isAgentCommand("nodemon")).toBe(false);
+  });
+
+  test("the literal 'default' key value is still skipped", () => {
+    expect(isAgentCommand("default")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes maw-stress finding #10 — `isAgentCommand`'s guard was a **loose substring match**.

The regex was `/claude|codex|node/i.test(c)`. `cmd` is a tmux `#{pane_current_command}` — a bare command basename, not a command line. `claude` / `codex` are distinctive enough that a substring match is safe (no benign command contains them), but `node` is a substring of `nodemon`, the `node` REPL, `node-red`, `node-gyp`, etc. — all of which wrongly registered as live agents (which then skews `resolveOraclePane`, the `cmdSend` agent-alive check, and now the #2 concurrency count).

## Change — match the whole command name, not a substring

- **regex:** `node` is now `/^node$/i` (claude/codex stay substring — distinctive, no false positives).
- **config.commands:** the per-binary check was `c.includes(bin)` — so a configured `node`-launched agent made every `nodemon` / `node-*` pane look like an agent. Now an exact `===` comparison.

## Also: pre-existing mock-export-sync drift (#435)

The canonical `test/helpers/mock-ssh.ts` was missing `isAgentCommand` — any test that mocked `ssh.ts` while another module imported `isAgentCommand` would hit the "Export named X not found" pollution failure. `scripts/check-mock-export-sync.sh` flagged this on `main` already. Added it with a faithful name-match default; the check is now green.

## Tests

- `test/is-agent-command.test.ts` gains the node-substring rejection cases (`nodemon` / `node-red` / `node-gyp` / `nodejs` / `anode`) + bare-`node` case + claude/codex-still-substring coverage.
- New `test/isolated/is-agent-command-config.test.ts` pins the `config.commands` exact-match branch (configured bin matches by exact name only, not substring; a configured `node` bin does not leak `nodemon`).

## Deploy note

**NOT deployed** — fix + test + PR only. Awaiting brain/Nat review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)