### PR TITLE
feat(fleet doctor): warn + auto-fix agents↔namedPeers collision (#1323, #1326)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.14-alpha.2335",
+  "version": "26.5.15-alpha.740",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/shared/fleet-doctor-checks.ts
+++ b/src/commands/shared/fleet-doctor-checks.ts
@@ -181,7 +181,37 @@ export function checkSelfPeer(
 }
 
 /**
- * Check 6 — Casing duplicates in config.agents keys and fleet window names.
+ * Check 6 — agents entry shadows a namedPeer (#1323 / #1326).
+ *
+ * When config.agents has a key that matches a namedPeer name, bare-name
+ * routing (resolveTarget Step 3b) resolves locally and never reaches peer
+ * routing. E.g. agents["oracle-world"] = "m5" + namedPeers[{name:"oracle-world"}]
+ * → `maw hey oracle-world:pulse` resolves "oracle-world" to local agent "m5"
+ * instead of the remote peer URL.
+ */
+export function checkAgentPeerShadow(
+  agents: Record<string, string>,
+  peers: PeerConfig[],
+): DoctorFinding[] {
+  const findings: DoctorFinding[] = [];
+  const peerMap = new Map(peers.map(p => [p.name.toLowerCase(), p]));
+  for (const [agentName, agentNode] of Object.entries(agents)) {
+    const peer = peerMap.get(agentName.toLowerCase());
+    if (peer) {
+      findings.push({
+        level: "error",
+        check: "agent-peer-shadow",
+        fixable: true,
+        message: `agents['${agentName}'] = '${agentNode}' shadows namedPeer '${peer.name}' (${peer.url}) — bare-name routing will never reach the peer`,
+        detail: { agentName, agentNode, peerName: peer.name, peerUrl: peer.url },
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Check 7 — Casing duplicates in config.agents keys and fleet window names.
  *
  * Root cause of #1240: no normalization at write sites left thClaws and
  * thclaws as distinct keys, causing the wake resolver to present both.

--- a/src/commands/shared/fleet-doctor-fixer.ts
+++ b/src/commands/shared/fleet-doctor-fixer.ts
@@ -109,7 +109,18 @@ export function autoFix(
     return true;
   });
 
-  // 3. Auto-add missing agents
+  // 3. Remove agents that shadow namedPeers (#1323 / #1326)
+  for (const f of findings) {
+    if (f.check !== "agent-peer-shadow" || !f.fixable || !f.detail) continue;
+    const agentName = f.detail.agentName as string | undefined;
+    if (agentName && currentAgents[agentName]) {
+      delete currentAgents[agentName];
+      applied.push(`removed config.agents['${agentName}'] (was shadowing namedPeer '${f.detail.peerName}')`);
+      touched = true;
+    }
+  }
+
+  // 4. Auto-add missing agents
   for (const f of findings) {
     if (f.check !== "missing-agent" || !f.fixable || !f.detail) continue;
     const oracle = f.detail.oracle as string | undefined;

--- a/src/commands/shared/fleet-doctor.ts
+++ b/src/commands/shared/fleet-doctor.ts
@@ -26,6 +26,7 @@ export {
   checkOrphanRoutes,
   checkDuplicatePeers,
   checkSelfPeer,
+  checkAgentPeerShadow,
   checkCasingDuplicates,
 } from "./fleet-doctor-checks";
 export type { FleetEntryLike } from "./fleet-doctor-checks-repo";
@@ -43,6 +44,7 @@ import {
   checkOrphanRoutes,
   checkDuplicatePeers,
   checkSelfPeer,
+  checkAgentPeerShadow,
   checkMissingAgents,
   checkCasingDuplicates,
 } from "./fleet-doctor-checks";
@@ -85,6 +87,7 @@ export async function cmdFleetDoctor(opts: DoctorOptions = {}): Promise<void> {
   findings.push(...checkDuplicatePeers(peers));
   findings.push(...checkSelfPeer(peers, localNode, config.port));
   findings.push(...checkMissingRepos(entries, join(getGhqRoot(), "github.com")));
+  findings.push(...checkAgentPeerShadow(agents, peers));
   findings.push(...checkCasingDuplicates(agents, fleetWindowNames));
 
   const { findings: staleFindings, identities } = await checkStalePeers(peers);

--- a/test/fleet-doctor.test.ts
+++ b/test/fleet-doctor.test.ts
@@ -5,6 +5,7 @@ import {
   checkOrphanRoutes,
   checkDuplicatePeers,
   checkSelfPeer,
+  checkAgentPeerShadow,
   checkMissingRepos,
   autoFix,
   type DoctorFinding,
@@ -193,6 +194,45 @@ describe("checkSelfPeer — federation loop prevention", () => {
   });
 });
 
+describe("checkAgentPeerShadow — #1323 / #1326 agents↔namedPeers collision", () => {
+  test("flags agent entry that shadows a namedPeer", () => {
+    const agents = { "oracle-world": "m5", mawjs: "local" };
+    const peers = [{ name: "oracle-world", url: "http://10.20.0.16:3456" }];
+    const out = checkAgentPeerShadow(agents, peers);
+    expect(out.length).toBe(1);
+    expect(out[0].check).toBe("agent-peer-shadow");
+    expect(out[0].level).toBe("error");
+    expect(out[0].fixable).toBe(true);
+    expect(out[0].detail).toEqual({
+      agentName: "oracle-world",
+      agentNode: "m5",
+      peerName: "oracle-world",
+      peerUrl: "http://10.20.0.16:3456",
+    });
+  });
+
+  test("case-insensitive match", () => {
+    const out = checkAgentPeerShadow(
+      { "Oracle-World": "m5" },
+      [{ name: "oracle-world", url: "http://10.20.0.16:3456" }],
+    );
+    expect(out.length).toBe(1);
+  });
+
+  test("no collision when names are different", () => {
+    const out = checkAgentPeerShadow(
+      { mawjs: "local", homekeeper: "local" },
+      [{ name: "white", url: "http://10.20.0.7:3456" }],
+    );
+    expect(out).toEqual([]);
+  });
+
+  test("empty agents or peers produce no findings", () => {
+    expect(checkAgentPeerShadow({}, [{ name: "white", url: "http://x" }])).toEqual([]);
+    expect(checkAgentPeerShadow({ mawjs: "local" }, [])).toEqual([]);
+  });
+});
+
 describe("checkMissingRepos — #237 wake cold-start signal", () => {
   test("flags fleet entry whose repo is not in ghq", () => {
     const entries = [
@@ -275,6 +315,26 @@ describe("autoFix — only safe transforms", () => {
     ];
     const applied = safeAutoFix(findings, config);
     expect(applied.some((m) => m.includes("volt-colab-ml") && m.includes("white"))).toBe(true);
+  });
+
+  test("removes agent that shadows a namedPeer (#1323)", () => {
+    const config = {
+      node: "oracle-world",
+      port: 3456,
+      namedPeers: [{ name: "oracle-world", url: "http://10.20.0.16:3456" }],
+      agents: { "oracle-world": "m5", mawjs: "local" },
+    } as unknown as MawConfig;
+    const findings: DoctorFinding[] = [
+      {
+        level: "error",
+        check: "agent-peer-shadow",
+        message: "",
+        fixable: true,
+        detail: { agentName: "oracle-world", agentNode: "m5", peerName: "oracle-world", peerUrl: "http://10.20.0.16:3456" },
+      },
+    ];
+    const applied = safeAutoFix(findings, config);
+    expect(applied.some((m) => m.includes("oracle-world") && m.includes("shadowing"))).toBe(true);
   });
 
   test("no-op when config is clean", () => {


### PR DESCRIPTION
## Summary
- New Check 6 in fleet-doctor-checks.ts: `checkAgentPeerShadow` detects when `config.agents` has a key matching a `namedPeers` name
- When an agent entry shadows a peer, bare-name routing resolves locally (Step 3b) and never reaches federation peer routing
- Auto-fix in fleet-doctor-fixer.ts: removes shadowing agents entries on `maw fleet doctor --fix`
- Case-insensitive matching (both `Oracle-World` and `oracle-world` caught)
- 5 new tests: detection, case-insensitive, no-collision, empty inputs, auto-fix

## Test plan
- [x] 33/33 fleet-doctor tests pass locally (was 28)
- [ ] CI green

Closes #1323
Closes #1326

🤖 Generated with [Claude Code](https://claude.com/claude-code)