### PR TITLE
fix(test): resolve mock.module path + SDK barrel import for oracle tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.14-alpha.2335",
+  "version": "26.5.15-alpha.755",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/plugins/oracle/oracle.test.ts
+++ b/src/commands/plugins/oracle/oracle.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { join } from "path";
 import type { InvokeContext } from "../../../plugin/types";
 
 // Import real implementations that other test files depend on — mock.module
@@ -7,8 +8,13 @@ import type { InvokeContext } from "../../../plugin/types";
 // "export not found" SyntaxErrors AND preserves behavior for those tests.
 const realPrune = await import("./impl-prune");
 const realRegister = await import("./impl-register");
+const realHelpers = await import("./impl-helpers");
 
-mock.module("./impl", () => ({
+// Use absolute paths so Bun's mock.module resolves the same physical file
+// regardless of the import path used by other modules (e.g. src/sdk/index.ts
+// imports "../commands/plugins/oracle/impl" which is a different module key
+// than "./impl" from this test file's perspective).
+mock.module(join(import.meta.dir, "./impl"), () => ({
   cmdOracleList: async () => {
     console.log("Oracle Fleet  (1/2 awake)");
   },
@@ -26,9 +32,12 @@ mock.module("./impl", () => ({
   },
   cmdOraclePrune: realPrune.cmdOraclePrune,
   cmdOracleRegister: realRegister.cmdOracleRegister,
+  resolveOracleSafe: realHelpers.resolveOracleSafe,
+  discoverOracles: realHelpers.discoverOracles,
+  timeSince: realHelpers.timeSince,
 }));
 
-mock.module("./impl-nickname", () => ({
+mock.module(join(import.meta.dir, "./impl-nickname"), () => ({
   cmdOracleSetNickname: (name: string, nickname: string) => {
     console.log(`set-nickname ${name}=${nickname}`);
   },

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -131,9 +131,9 @@ export {
   cmdOracleScan,
   cmdOracleFleet,
   cmdOracleScanStale,
-  cmdOraclePrune,
-  cmdOracleRegister,
 } from "../commands/plugins/oracle/impl";
+export { cmdOraclePrune } from "../commands/plugins/oracle/impl-prune";
+export { cmdOracleRegister } from "../commands/plugins/oracle/impl-register";
 
 // ─── definePlugin — the plugin contract ──────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- `oracle.test.ts`: use `join(import.meta.dir, "./impl")` for `mock.module` so Bun resolves the same physical file regardless of import path
- `sdk/index.ts`: import `cmdOraclePrune` and `cmdOracleRegister` directly from their impl files instead of through the `./impl` barrel
- Eliminates the nondeterministic `SyntaxError: export 'cmdOracleRegister' not found` that blocks PRs #1365, #1366, #1368

## Root Cause
`src/sdk/index.ts` imports `cmdOracleRegister` from `"../commands/plugins/oracle/impl"`. The test mock uses `mock.module("./impl", ...)` — a different module key that Bun doesn't always match to the same physical file. When the SDK module loads before the mock registers, the real barrel's re-export chain fails.

## Test plan
- [x] 232/232 test:plugin pass locally (was 13 failures)
- [ ] CI green

Unblocks PRs #1365, #1366, #1368

🤖 Generated with [Claude Code](https://claude.com/claude-code)