### PR TITLE
fix(test): resolve mock.module path + SDK barrel import for oracle tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.15-alpha.740",
+  "version": "26.5.15-alpha.800",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/plugins/oracle/oracle.test.ts
+++ b/src/commands/plugins/oracle/oracle.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { join } from "path";
 import type { InvokeContext } from "../../../plugin/types";
 
 // Import real implementations that other test files depend on — mock.module
@@ -7,8 +8,13 @@ import type { InvokeContext } from "../../../plugin/types";
 // "export not found" SyntaxErrors AND preserves behavior for those tests.
 const realPrune = await import("./impl-prune");
 const realRegister = await import("./impl-register");
+const realHelpers = await import("./impl-helpers");
 
-mock.module("./impl", () => ({
+// Use absolute paths so Bun's mock.module resolves the same physical file
+// regardless of the import path used by other modules (e.g. src/sdk/index.ts
+// imports "../commands/plugins/oracle/impl" which is a different module key
+// than "./impl" from this test file's perspective).
+mock.module(join(import.meta.dir, "./impl"), () => ({
   cmdOracleList: async () => {
     console.log("Oracle Fleet  (1/2 awake)");
   },
@@ -26,9 +32,12 @@ mock.module("./impl", () => ({
   },
   cmdOraclePrune: realPrune.cmdOraclePrune,
   cmdOracleRegister: realRegister.cmdOracleRegister,
+  resolveOracleSafe: realHelpers.resolveOracleSafe,
+  discoverOracles: realHelpers.discoverOracles,
+  timeSince: realHelpers.timeSince,
 }));
 
-mock.module("./impl-nickname", () => ({
+mock.module(join(import.meta.dir, "./impl-nickname"), () => ({
   cmdOracleSetNickname: (name: string, nickname: string) => {
     console.log(`set-nickname ${name}=${nickname}`);
   },

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -131,9 +131,9 @@ export {
   cmdOracleScan,
   cmdOracleFleet,
   cmdOracleScanStale,
-  cmdOraclePrune,
-  cmdOracleRegister,
 } from "../commands/plugins/oracle/impl";
+export { cmdOraclePrune } from "../commands/plugins/oracle/impl-prune";
+export { cmdOracleRegister } from "../commands/plugins/oracle/impl-register";
 
 // ─── definePlugin — the plugin contract ──────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- `oracle.test.ts`: use `join(import.meta.dir, "./impl")` for `mock.module` — absolute path resolution
- `sdk/index.ts`: import `cmdOraclePrune` and `cmdOracleRegister` directly from impl files, breaking the circular dependency `impl-register → sdk → impl → impl-register`
- Adds missing helper exports (`resolveOracleSafe`, `discoverOracles`, `timeSince`) to the mock

## Root Cause
Circular dependency: `impl-register.ts` imports from `sdk/index.ts`, which re-exports from `impl.ts`, which re-exports from `impl-register.ts`. When `mock.module("./impl")` uses a relative path, Bun doesn't always match it to the `"../commands/plugins/oracle/impl"` path used by `sdk/index.ts`.

## Test plan
- [x] 232/232 test:plugin pass locally (was 13 failures)
- [ ] CI green

Unblocks PRs #1365, #1366, #1368

🤖 Generated with [Claude Code](https://claude.com/claude-code)