### PR TITLE
fix(transport): confirm tmux sendText submission instead of blind Enter (#6)

### DIFF
--- a/src/commands/shared/fleet-wake.ts
+++ b/src/commands/shared/fleet-wake.ts
@@ -1,4 +1,4 @@
-import { readdirSync } from "fs";
+import { existsSync, readdirSync } from "fs";
 import { join } from "path";
 import { tmux, FLEET_DIR, saveTabOrder, restoreTabOrder } from "../../sdk";
 import { buildCommand, getEnvVars } from "../../config";
@@ -76,6 +76,16 @@ export async function cmdWakeAll(opts: { kill?: boolean; all?: boolean; resume?:
       // not under github.com/<org>/<repo>. Falling back to /root via missing-cwd was making
       // every Oracle session inherit Labubu's CLAUDE.md identity.
       const firstPath = join(getGhqRoot(), first.repo);
+      // #748 follow-up — tmux silently falls back to $HOME when -c <missing-path>,
+      // which re-surfaces the wrong-CLAUDE.md bug if ghqRoot resolves to a stale value
+      // (e.g. test fixture leak setting "/tmp/nope"). Refuse to spawn into a missing
+      // path; raise a clear error instead of silently inheriting the wrong identity.
+      if (!existsSync(firstPath)) {
+        throw new Error(
+          `wake: refusing to spawn ${sess.name} — cwd "${firstPath}" does not exist. ` +
+          `Check ghqRoot resolution (config.ghqRoot, $GHQ_ROOT, \`ghq root\`) and fleet config repo "${first.repo}".`,
+        );
+      }
       await tmux.newSession(sess.name, { window: first.name, cwd: firstPath });
       await pinSessionWide(sess.name);
       for (const [key, val] of Object.entries(getEnvVars())) {
@@ -101,6 +111,15 @@ export async function cmdWakeAll(opts: { kill?: boolean; all?: boolean; resume?:
       for (let i = 1; i < sess.windows.length; i++) {
         const win = sess.windows[i];
         const winPath = join(getGhqRoot(), win.repo);
+        if (!existsSync(winPath)) {
+          // Skip rather than throw — first-window throw already surfaced the
+          // root cause; per-window failures should fail-soft so other windows
+          // in the same session still wake.
+          process.stderr.write(
+            `[maw] wake: skipping ${sess.name}:${win.name} — cwd "${winPath}" does not exist.\n`,
+          );
+          continue;
+        }
         try {
           await tmux.newWindow(sess.name, win.name, { cwd: winPath });
           await pinWindowWide(`${sess.name}:${win.name}`);

--- a/src/core/transport/tmux-class.ts
+++ b/src/core/transport/tmux-class.ts
@@ -8,6 +8,22 @@ import {
   type TmuxWindow,
 } from "./tmux-types";
 
+// --- sendText submit-confirmation tuning (#6) ---
+// The old sendText fired 3 blind `Enter` keys on a fixed ~1.9s schedule with
+// zero feedback. If the pane wasn't ready when they landed (agent still
+// rendering the paste, brief stall), every Enter missed and the command sat
+// in the input box unexecuted — this forced manual re-launch of dispatches
+// on 2026-05-14. We now send Enter, re-check the pane, and retry only while
+// input is still pending.
+/** Wait after paste/literal-send before the first Enter — lets the input settle. */
+const SEND_SETTLE_MS = 1500;
+/** Wait after each Enter before re-checking whether the input line cleared. */
+const SUBMIT_CONFIRM_MS = 700;
+/** Max Enter attempts before giving up and warning (was 3 blind, unconditional sends). */
+const MAX_SUBMIT_ATTEMPTS = 4;
+/** ANSI escape stripper — matches checkPaneIdle in comm-send.ts (#405). */
+const ANSI_RE = /\x1b\[[0-9;]*[mGKHFJA-Z]/g;
+
 /**
  * Typed wrapper around tmux CLI.
  * All methods build arg arrays and delegate to `run()`.
@@ -265,31 +281,65 @@ export class Tmux {
 
   /**
    * Smart text sending — uses load-buffer for multiline/long messages,
-   * send-keys for short single-line. Always appends Enter.
+   * send-keys for short single-line. Always submits with Enter.
    * Ported from old bash maw hey (Dec 2025).
+   *
+   * #6 — submit is now confirmed, not fire-and-forget. After placing the
+   * text we send Enter, re-inspect the pane, and retry the Enter only while
+   * the input line still holds un-submitted content (up to
+   * MAX_SUBMIT_ATTEMPTS). This closes the trailing-Enter race where blind
+   * staggered Enter keys landed before the pane was ready and the command
+   * was silently left unexecuted.
    */
   async sendText(target: string, text: string): Promise<void> {
     if (text.includes("\n") || text.length > 500) {
       // Buffer method — reliable for multiline/long content
       await this.loadBuffer(text);
       await this.pasteBuffer(target);
-      await new Promise(r => setTimeout(r, 1500));
-      // Staggered Enter — submit + 2 fallbacks
-      await this.sendKeys(target, "Enter");
-      await new Promise(r => setTimeout(r, 700));
-      await this.sendKeys(target, "Enter");
-      await new Promise(r => setTimeout(r, 1200));
-      await this.sendKeys(target, "Enter");
     } else {
       // Literal send — -l prevents tmux from interpreting special chars like |
       await this.sendKeysLiteral(target, text);
-      await new Promise(r => setTimeout(r, 1500));
-      // Staggered Enter — submit + 2 fallbacks
+    }
+    await new Promise(r => setTimeout(r, SEND_SETTLE_MS));
+    await this.submitWithConfirm(target);
+  }
+
+  /**
+   * Send Enter, then confirm the input line cleared before returning. Retries
+   * the Enter while input is still pending — see sendText for the #6 race.
+   * @internal — exported behavior is exercised via sendText in tests.
+   */
+  private async submitWithConfirm(target: string): Promise<void> {
+    for (let attempt = 1; attempt <= MAX_SUBMIT_ATTEMPTS; attempt++) {
       await this.sendKeys(target, "Enter");
-      await new Promise(r => setTimeout(r, 700));
-      await this.sendKeys(target, "Enter");
-      await new Promise(r => setTimeout(r, 1200));
-      await this.sendKeys(target, "Enter");
+      await new Promise(r => setTimeout(r, SUBMIT_CONFIRM_MS));
+      if (!(await this.paneInputPending(target))) return; // submitted — done
+    }
+    // Exhausted every retry and the input line still looks non-empty. The
+    // caller has no visibility into tmux pane state, so warn loudly — a
+    // silently-dropped dispatch is the exact failure mode #6 is about.
+    console.warn(
+      `[tmux] sendText: ${target} still shows pending input after ${MAX_SUBMIT_ATTEMPTS} Enter attempts — command may not have submitted`,
+    );
+  }
+
+  /**
+   * True when the pane's prompt line still holds un-submitted input.
+   * Mirrors checkPaneIdle (comm-send.ts #405) but inlined here to avoid a
+   * circular import — comm-send.ts already imports Tmux. A read failure
+   * returns false (assume submitted) so a flaky capture can't spin the retry
+   * loop.
+   */
+  private async paneInputPending(target: string): Promise<boolean> {
+    try {
+      const content = await this.capture(target, 5);
+      const lines = content.split("\n").filter(l => l.trim());
+      const last = (lines.at(-1) ?? "").replace(ANSI_RE, "").replace(/\r/g, "");
+      // Prompt marker followed by non-whitespace → user/command text still
+      // sitting on the input line, i.e. Enter has not submitted it yet.
+      return /[#$%>❯»]\s+\S/.test(last);
+    } catch {
+      return false;
     }
   }
 

--- a/src/engine/engine-intervals.ts
+++ b/src/engine/engine-intervals.ts
@@ -91,9 +91,10 @@ export function startIntervals(
   state.feedUnsub = () => state.feedListeners.delete(listener);
 }
 
-/** Stop all polling intervals when last WS client disconnects. No-op if clients remain. */
+/** Stop all polling intervals when last WS client disconnects. No-op if clients remain or triggers are configured. */
 export function stopIntervals(state: EngineIntervalState): void {
   if (state.clients.size > 0) return;
+  if (loadConfig().triggers?.length > 0) return;
   if (state.captureInterval) { clearInterval(state.captureInterval); state.captureInterval = null; }
   if (state.sessionInterval) { clearInterval(state.sessionInterval); state.sessionInterval = null; }
   if (state.previewInterval) { clearInterval(state.previewInterval); state.previewInterval = null; }

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -51,6 +51,8 @@ export class MawEngine {
     } catch {
       console.warn("[engine] session cache init failed — will retry on first WS connect");
     }
+    // Start intervals headlessly so triggers fire without a browser connected (#headless-triggers)
+    this.startIntervals();
   }
 
   on(type: string, handler: Handler) { this.handlers.set(type, handler); }

--- a/src/engine/status.ts
+++ b/src/engine/status.ts
@@ -60,7 +60,7 @@ export class StatusDetector {
     clients: Set<MawWS>,
     feedListeners: Set<(event: FeedEvent) => void>,
   ) {
-    if (clients.size === 0 || sessions.length === 0) return;
+    if (sessions.length === 0) return;
 
     const agents = sessions.flatMap(s =>
       s.windows.map(w => ({ target: `${s.name}:${w.index}`, name: w.name, session: s.name }))

--- a/test/tmux-sendtext-submit.test.ts
+++ b/test/tmux-sendtext-submit.test.ts
@@ -1,0 +1,132 @@
+/**
+ * tmux-sendtext-submit.test.ts — regression for maw-stress finding #6.
+ *
+ * Tmux.sendText used to fire 3 blind `Enter` keys on a fixed ~1.9s schedule
+ * with zero feedback. When the pane wasn't ready as they landed, every Enter
+ * missed and the command sat in the input box unexecuted — this forced
+ * brain to manually re-launch dispatches on 2026-05-14.
+ *
+ * The fix: send Enter, re-inspect the pane, retry only while the input line
+ * still holds un-submitted content (capped at MAX_SUBMIT_ATTEMPTS).
+ *
+ * Strategy: subclass Tmux and override the low-level primitives so we can
+ * script the pane's capture output and assert the exact key sequence — no
+ * tmux process, no module mock (safe for the main suite).
+ */
+import { describe, test, expect } from "bun:test";
+import { Tmux } from "../src/core/transport/tmux-class";
+
+/** Tmux with the tmux-touching primitives stubbed + a scripted capture feed. */
+class FakeTmux extends Tmux {
+  calls: string[] = [];
+  /** Successive return values for capture(); last value repeats once exhausted. */
+  captureScript: string[] = [];
+  private captureIdx = 0;
+
+  constructor() {
+    super(undefined, ""); // no socket — overridden methods never hit hostExec
+  }
+
+  async capture(_target: string, _lines = 80): Promise<string> {
+    this.calls.push("capture");
+    const v = this.captureScript[this.captureIdx] ?? this.captureScript.at(-1) ?? "";
+    this.captureIdx++;
+    return v;
+  }
+  async sendKeys(_target: string, ...keys: string[]): Promise<void> {
+    this.calls.push(`sendKeys:${keys.join(",")}`);
+  }
+  async sendKeysLiteral(_target: string, text: string): Promise<void> {
+    this.calls.push(`sendKeysLiteral:${text}`);
+  }
+  async loadBuffer(text: string): Promise<void> {
+    this.calls.push(`loadBuffer:${text.length}`);
+  }
+  async pasteBuffer(_target: string): Promise<void> {
+    this.calls.push("pasteBuffer");
+  }
+}
+
+const PROMPT_IDLE = "agent@host:~$ "; // prompt marker + trailing space → submitted
+const PROMPT_PENDING = "agent@host:~$ unsent command text"; // input still on the line
+const enterCount = (calls: string[]) => calls.filter(c => c === "sendKeys:Enter").length;
+
+describe("Tmux.sendText — confirmed submit (#6)", () => {
+  test(
+    "single Enter when the pane clears on the first check — no blind trailing Enters",
+    async () => {
+      const t = new FakeTmux();
+      t.captureScript = [PROMPT_IDLE];
+      await t.sendText("sess:win", "hello");
+
+      expect(t.calls).toEqual(["sendKeysLiteral:hello", "sendKeys:Enter", "capture"]);
+      expect(enterCount(t.calls)).toBe(1);
+    },
+    10_000,
+  );
+
+  test(
+    "retries Enter while input is still pending, stops as soon as it clears",
+    async () => {
+      const t = new FakeTmux();
+      // pending after Enter #1 and #2, cleared after #3
+      t.captureScript = [PROMPT_PENDING, PROMPT_PENDING, PROMPT_IDLE];
+      await t.sendText("sess:win", "deploy task");
+
+      expect(enterCount(t.calls)).toBe(3);
+      // last action is the confirming capture, not another blind Enter
+      expect(t.calls.at(-1)).toBe("capture");
+    },
+    15_000,
+  );
+
+  test(
+    "stops after MAX_SUBMIT_ATTEMPTS and warns when the pane never clears",
+    async () => {
+      const t = new FakeTmux();
+      t.captureScript = [PROMPT_PENDING]; // repeats → never clears
+
+      const warnings: string[] = [];
+      const origWarn = console.warn;
+      console.warn = (...args: unknown[]) => { warnings.push(args.join(" ")); };
+      try {
+        await t.sendText("sess:win", "stuck task");
+      } finally {
+        console.warn = origWarn;
+      }
+
+      // capped — not an unbounded spin
+      expect(enterCount(t.calls)).toBe(4);
+      expect(warnings.some(w => w.includes("pending input") && w.includes("sess:win"))).toBe(true);
+    },
+    15_000,
+  );
+
+  test(
+    "multiline content routes through loadBuffer + pasteBuffer, then confirmed submit",
+    async () => {
+      const t = new FakeTmux();
+      t.captureScript = [PROMPT_IDLE];
+      await t.sendText("sess:win", "line one\nline two");
+
+      expect(t.calls[0]).toBe(`loadBuffer:${"line one\nline two".length}`);
+      expect(t.calls[1]).toBe("pasteBuffer");
+      expect(t.calls).not.toContain("sendKeysLiteral:line one\nline two");
+      expect(enterCount(t.calls)).toBe(1);
+    },
+    10_000,
+  );
+
+  test(
+    "a capture failure is treated as submitted — the retry loop cannot spin",
+    async () => {
+      const t = new FakeTmux();
+      // capture throws → paneInputPending swallows → false (assume submitted)
+      t.capture = async () => { throw new Error("tmux gone"); };
+      await t.sendText("sess:win", "hi");
+
+      expect(enterCount(t.calls)).toBe(1);
+    },
+    10_000,
+  );
+});


### PR DESCRIPTION
Rebased from natkingsize2's PR #1366 onto latest alpha (includes oracle test mock fix from #1371).

Original: https://github.com/Soul-Brews-Studio/maw-js/pull/1366

🤖 Generated with [Claude Code](https://claude.com/claude-code)