### PR TITLE
feat(wake): add agent concurrency cap to cmdWake (#2)

### DIFF
--- a/src/commands/shared/fleet-wake.ts
+++ b/src/commands/shared/fleet-wake.ts
@@ -1,4 +1,4 @@
-import { readdirSync } from "fs";
+import { existsSync, readdirSync } from "fs";
 import { join } from "path";
 import { tmux, FLEET_DIR, saveTabOrder, restoreTabOrder } from "../../sdk";
 import { buildCommand, getEnvVars } from "../../config";
@@ -76,6 +76,16 @@ export async function cmdWakeAll(opts: { kill?: boolean; all?: boolean; resume?:
       // not under github.com/<org>/<repo>. Falling back to /root via missing-cwd was making
       // every Oracle session inherit Labubu's CLAUDE.md identity.
       const firstPath = join(getGhqRoot(), first.repo);
+      // #748 follow-up — tmux silently falls back to $HOME when -c <missing-path>,
+      // which re-surfaces the wrong-CLAUDE.md bug if ghqRoot resolves to a stale value
+      // (e.g. test fixture leak setting "/tmp/nope"). Refuse to spawn into a missing
+      // path; raise a clear error instead of silently inheriting the wrong identity.
+      if (!existsSync(firstPath)) {
+        throw new Error(
+          `wake: refusing to spawn ${sess.name} — cwd "${firstPath}" does not exist. ` +
+          `Check ghqRoot resolution (config.ghqRoot, $GHQ_ROOT, \`ghq root\`) and fleet config repo "${first.repo}".`,
+        );
+      }
       await tmux.newSession(sess.name, { window: first.name, cwd: firstPath });
       await pinSessionWide(sess.name);
       for (const [key, val] of Object.entries(getEnvVars())) {
@@ -101,6 +111,15 @@ export async function cmdWakeAll(opts: { kill?: boolean; all?: boolean; resume?:
       for (let i = 1; i < sess.windows.length; i++) {
         const win = sess.windows[i];
         const winPath = join(getGhqRoot(), win.repo);
+        if (!existsSync(winPath)) {
+          // Skip rather than throw — first-window throw already surfaced the
+          // root cause; per-window failures should fail-soft so other windows
+          // in the same session still wake.
+          process.stderr.write(
+            `[maw] wake: skipping ${sess.name}:${win.name} — cwd "${winPath}" does not exist.\n`,
+          );
+          continue;
+        }
         try {
           await tmux.newWindow(sess.name, win.name, { cwd: winPath });
           await pinWindowWide(`${sess.name}:${win.name}`);

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -9,6 +9,7 @@ import { resolveOracle, findWorktrees, getSessionMap, resolveFleetSession, detec
 import { attachToSession, ensureSessionRunning, createWorktree } from "./wake-session";
 import { maybeSplit } from "./wake-maybe-split";
 import { parseWakeTarget, ensureCloned } from "./wake-target";
+import { assertAgentCapacity } from "./wake-concurrency";
 
 export interface WakeCmdOptions {
   task?: string;
@@ -146,6 +147,10 @@ export async function cmdWake(oracle: string, opts: WakeCmdOptions): Promise<str
   });
 
   if (!session && wakeDecision.wake) {
+    // #2 — refuse to spawn a brand-new session/agent once the fleet is at the
+    // configured concurrency cap (no-op when limits.maxConcurrentAgents is 0).
+    await assertAgentCapacity(oracle);
+
     // #769 — URL input names the new session after the full repo (e.g.
     // "m5-oracle") so it's distinct from any unrelated sub-token sessions
     // and immediately disambiguates future `maw wake` calls.
@@ -372,6 +377,10 @@ export async function cmdWake(oracle: string, opts: WakeCmdOptions): Promise<str
       `  use \`maw wake ${oracle} --force\` to spawn anyway`
     );
   }
+
+  // #2 — a new task/worktree window is a net-new agent pane: cap-check before
+  // spawning it (no-op when limits.maxConcurrentAgents is 0).
+  await assertAgentCapacity(oracle);
 
   await tmux.newWindow(session, windowName, { cwd: targetPath });
   await new Promise(r => setTimeout(r, 300));

--- a/src/commands/shared/wake-concurrency.ts
+++ b/src/commands/shared/wake-concurrency.ts
@@ -1,0 +1,58 @@
+/**
+ * wake-concurrency.ts — agent concurrency cap for `maw wake` (#2).
+ *
+ * `cmdWake` had no count, queue, or cap: nothing stopped a script (or a
+ * runaway orchestrator) from spawning agents until the box fell over.
+ * `D.limits` governed feed/logs/pty/message sizes but nothing about agent
+ * count.
+ *
+ * This module adds an opt-in cap. When `limits.maxConcurrentAgents` is a
+ * positive number, `maw wake` counts the agent panes already live across the
+ * fleet and refuses ("fails loud") to spawn one more once the fleet is at or
+ * over the cap. `0` / unset disables the cap — no behavior change for anyone
+ * who has not configured it.
+ *
+ * Pure decision logic (`checkCapacity`) is split from the tmux I/O
+ * (`countLiveAgents`) so the over-cap path is unit-testable without a tmux
+ * server.
+ */
+
+import { cfgLimit } from "../../config";
+import { tmux } from "../../core/transport/tmux";
+import { isAgentCommand } from "../../core/transport/ssh";
+
+/**
+ * Pure cap decision — throws a loud, actionable error when `liveAgents` is at
+ * or over `cap`. A `cap` of `0` or less means "disabled" and is always a
+ * no-op. Kept free of I/O so tests can exercise every branch directly.
+ */
+export function checkCapacity(liveAgents: number, cap: number, spawning: string): void {
+  if (!cap || cap <= 0) return; // cap disabled — opt-in only
+  if (liveAgents >= cap) {
+    throw new Error(
+      `agent concurrency cap reached: ${liveAgents}/${cap} agents already live — ` +
+      `refusing to spawn '${spawning}'. Raise limits.maxConcurrentAgents in maw.config.json ` +
+      `or sleep an idle agent first (maw sleep <agent>).`,
+    );
+  }
+}
+
+/** Count tmux panes currently running an agent process across all sessions. */
+export async function countLiveAgents(): Promise<number> {
+  const panes = await tmux.listPanes();
+  return panes.filter(p => isAgentCommand(p.command)).length;
+}
+
+/**
+ * Guard a spawn against the configured agent concurrency cap (#2). No-op when
+ * `limits.maxConcurrentAgents` is `0` / unset — and in that case we skip the
+ * tmux `list-panes` call entirely so the disabled path stays free.
+ *
+ * @param spawning  the oracle/agent name about to be spawned — surfaced in the
+ *                  error so the operator knows what was refused.
+ */
+export async function assertAgentCapacity(spawning: string): Promise<void> {
+  const cap = cfgLimit("maxConcurrentAgents");
+  if (!cap || cap <= 0) return; // disabled — don't even query tmux
+  checkCapacity(await countLiveAgents(), cap, spawning);
+}

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -60,6 +60,12 @@ export interface MawLimits {
   messageTruncate?: number;
   ptyCols?: number;
   ptyRows?: number;
+  /**
+   * Max concurrent agent panes across the fleet before `maw wake` refuses to
+   * spawn a new one (#2). `0` (the default) disables the cap entirely —
+   * operators opt in by setting a positive number.
+   */
+  maxConcurrentAgents?: number;
 }
 
 export interface MawConfig {
@@ -192,6 +198,6 @@ export interface MawConfig {
 export const D = {
   intervals: { capture: 50, sessions: 5000, status: 3000, teams: 3000, preview: 2000, peerFetch: 10000, crashCheck: 30000 } as const,
   timeouts: { http: 5000, health: 3000, ping: 5000, pty: 5000, workspace: 5000, shellInit: 3000, wakeRetry: 500, wakeVerify: 3000 } as const,
-  limits: { feedMax: 500, feedDefault: 50, feedHistory: 50, logsMax: 500, logsDefault: 50, logsTruncate: 500, messageTruncate: 100, ptyCols: 500, ptyRows: 200 } as const,
+  limits: { feedMax: 500, feedDefault: 50, feedHistory: 50, logsMax: 500, logsDefault: 50, logsTruncate: 500, messageTruncate: 100, ptyCols: 500, ptyRows: 200, maxConcurrentAgents: 0 } as const,
   hmacWindowSeconds: 300,
 } as const;

--- a/src/engine/engine-intervals.ts
+++ b/src/engine/engine-intervals.ts
@@ -91,9 +91,10 @@ export function startIntervals(
   state.feedUnsub = () => state.feedListeners.delete(listener);
 }
 
-/** Stop all polling intervals when last WS client disconnects. No-op if clients remain. */
+/** Stop all polling intervals when last WS client disconnects. No-op if clients remain or triggers are configured. */
 export function stopIntervals(state: EngineIntervalState): void {
   if (state.clients.size > 0) return;
+  if (loadConfig().triggers?.length > 0) return;
   if (state.captureInterval) { clearInterval(state.captureInterval); state.captureInterval = null; }
   if (state.sessionInterval) { clearInterval(state.sessionInterval); state.sessionInterval = null; }
   if (state.previewInterval) { clearInterval(state.previewInterval); state.previewInterval = null; }

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -51,6 +51,8 @@ export class MawEngine {
     } catch {
       console.warn("[engine] session cache init failed — will retry on first WS connect");
     }
+    // Start intervals headlessly so triggers fire without a browser connected (#headless-triggers)
+    this.startIntervals();
   }
 
   on(type: string, handler: Handler) { this.handlers.set(type, handler); }

--- a/src/engine/status.ts
+++ b/src/engine/status.ts
@@ -60,7 +60,7 @@ export class StatusDetector {
     clients: Set<MawWS>,
     feedListeners: Set<(event: FeedEvent) => void>,
   ) {
-    if (clients.size === 0 || sessions.length === 0) return;
+    if (sessions.length === 0) return;
 
     const agents = sessions.flatMap(s =>
       s.windows.map(w => ({ target: `${s.name}:${w.index}`, name: w.name, session: s.name }))

--- a/test/helpers/mock-config.ts
+++ b/test/helpers/mock-config.ts
@@ -26,6 +26,7 @@ const LIMITS: Record<keyof MawLimits, number> = {
   feedMax: 500, feedDefault: 50, feedHistory: 50,
   logsMax: 500, logsDefault: 50, logsTruncate: 500,
   messageTruncate: 100, ptyCols: 500, ptyRows: 200,
+  maxConcurrentAgents: 0,
 };
 
 export const TEST_D = {

--- a/test/helpers/mock-tmux.ts
+++ b/test/helpers/mock-tmux.ts
@@ -69,12 +69,24 @@ export interface MockPeer {
   sessions: MockSession[];
 }
 
+/** Shape returned by the mocked `tmux.listPanes()` — mirrors TmuxPane. */
+export interface MockPane {
+  id: string;
+  command: string;
+  target: string;
+  title?: string;
+  pid?: number;
+  cwd?: string;
+  lastActivity?: number;
+}
+
 // --- Internal state (cleared by resetMocks) ---
 
 let tmuxConfig: { sessions: MockSession[] } | null = null;
 let peersConfig: { peers: MockPeer[] } | null = null;
 let paneCommands: Record<string, string> = {};
 let capturedCommands: string[] = [];
+let panes: MockPane[] = [];
 
 // --- Shim install latches (shim stays live; config is what changes) ---
 
@@ -152,7 +164,7 @@ export function installTmuxMock(config: { sessions: MockSession[] }): void {
       },
       async listPanes() {
         capturedCommands.push("tmux list-panes -a");
-        return [];
+        return panes.map(p => ({ ...p }));
       },
       async killPane(target: string) {
         capturedCommands.push(`tmux kill-pane -t ${target}`);
@@ -328,6 +340,23 @@ export function setPaneCommands(cmds: Record<string, string>): void {
   paneCommands = { ...cmds };
 }
 
+/**
+ * Configure what `tmux.listPanes()` returns. Accepts partial panes — only
+ * `command` is required (the field most callers filter on); the rest are
+ * filled with deterministic placeholders. Replaces the previous list.
+ */
+export function setPanes(p: Array<Partial<MockPane> & { command: string }>): void {
+  panes = p.map((pane, i) => ({
+    id: pane.id ?? `%${i}`,
+    command: pane.command,
+    target: pane.target ?? `mock:${i}`,
+    title: pane.title,
+    pid: pane.pid,
+    cwd: pane.cwd,
+    lastActivity: pane.lastActivity,
+  }));
+}
+
 /** Captured tmux commands issued through the mock (for assertions). */
 export function getCapturedCommands(): string[] {
   return [...capturedCommands];
@@ -345,4 +374,5 @@ export function resetMocks(): void {
   peersConfig = null;
   paneCommands = {};
   capturedCommands = [];
+  panes = [];
 }

--- a/test/isolated/wake-concurrency.test.ts
+++ b/test/isolated/wake-concurrency.test.ts
@@ -1,0 +1,122 @@
+/**
+ * wake-concurrency.test.ts — regression for maw-stress finding #2.
+ *
+ * `cmdWake` had no count / queue / cap — nothing stopped a script or a
+ * runaway orchestrator from spawning agents until the box fell over.
+ * `src/commands/shared/wake-concurrency.ts` adds an opt-in cap
+ * (`limits.maxConcurrentAgents`); `cmdWake` calls `assertAgentCapacity`
+ * before every net-new spawn.
+ *
+ * Isolated: installs the tmux mock + a config mock (both mock.module, which
+ * is process-global). Pure decision logic (`checkCapacity`) is also pinned
+ * here — it needs no mocks but lives with its siblings.
+ */
+import { describe, test, expect, beforeAll, afterEach, mock } from "bun:test";
+import { join } from "path";
+import { installTmuxMock, setPanes, getCapturedCommands, resetMocks } from "../helpers/mock-tmux";
+
+const root = join(import.meta.dir, "../..");
+
+// Controllable cap value — assertAgentCapacity reads it via cfgLimit().
+let capValue = 0;
+
+// tmux mock first, then config mock — both mock.module, registered before the
+// dynamic import in beforeAll so wake-concurrency.ts resolves to the shims.
+installTmuxMock({ sessions: [] });
+
+mock.module(join(root, "src/config"), () => {
+  const { mockConfigModule } = require("../helpers/mock-config");
+  const base = mockConfigModule(() => ({ node: "test-node", commands: {} }));
+  return {
+    ...base,
+    cfgLimit: (k: string) =>
+      k === "maxConcurrentAgents" ? capValue : base.cfgLimit(k),
+  };
+});
+
+let checkCapacity: typeof import("../../src/commands/shared/wake-concurrency").checkCapacity;
+let countLiveAgents: typeof import("../../src/commands/shared/wake-concurrency").countLiveAgents;
+let assertAgentCapacity: typeof import("../../src/commands/shared/wake-concurrency").assertAgentCapacity;
+
+beforeAll(async () => {
+  const mod = await import("../../src/commands/shared/wake-concurrency");
+  checkCapacity = mod.checkCapacity;
+  countLiveAgents = mod.countLiveAgents;
+  assertAgentCapacity = mod.assertAgentCapacity;
+});
+
+afterEach(() => {
+  resetMocks();
+  capValue = 0;
+});
+
+describe("checkCapacity — pure cap decision (#2)", () => {
+  test("cap 0 / negative → disabled, never throws", () => {
+    expect(() => checkCapacity(999, 0, "x")).not.toThrow();
+    expect(() => checkCapacity(999, -1, "x")).not.toThrow();
+  });
+
+  test("under cap → no throw", () => {
+    expect(() => checkCapacity(3, 5, "neo")).not.toThrow();
+  });
+
+  test("at cap → throws (over-cap path)", () => {
+    expect(() => checkCapacity(5, 5, "neo")).toThrow(/5\/5/);
+    expect(() => checkCapacity(5, 5, "neo")).toThrow(/refusing to spawn 'neo'/);
+  });
+
+  test("over cap → throws", () => {
+    expect(() => checkCapacity(8, 5, "pulse")).toThrow(/8\/5/);
+  });
+
+  test("error message is actionable — names the config knob", () => {
+    expect(() => checkCapacity(5, 5, "neo")).toThrow(/maxConcurrentAgents/);
+  });
+});
+
+describe("countLiveAgents — counts agent panes across the fleet", () => {
+  test("counts only agent-process panes (claude / node), ignores shells", async () => {
+    setPanes([
+      { command: "claude" },
+      { command: "node" },
+      { command: "zsh" },
+      { command: "bash" },
+      { command: "claude" },
+    ]);
+    expect(await countLiveAgents()).toBe(3);
+  });
+
+  test("no panes → 0", async () => {
+    setPanes([]);
+    expect(await countLiveAgents()).toBe(0);
+  });
+});
+
+describe("assertAgentCapacity — the guard cmdWake calls before spawning", () => {
+  test("disabled (cap 0) → no throw, and does NOT even query tmux", async () => {
+    capValue = 0;
+    setPanes([{ command: "claude" }, { command: "claude" }, { command: "claude" }]);
+    await assertAgentCapacity("neo");
+    // fast-path: disabled cap must skip the list-panes call entirely
+    expect(getCapturedCommands().some(c => c.includes("list-panes"))).toBe(false);
+  });
+
+  test("under cap → resolves", async () => {
+    capValue = 5;
+    setPanes([{ command: "claude" }, { command: "node" }]);
+    await assertAgentCapacity("neo");
+    expect(getCapturedCommands().some(c => c.includes("list-panes"))).toBe(true);
+  });
+
+  test("at/over cap → rejects loudly", async () => {
+    capValue = 2;
+    setPanes([{ command: "claude" }, { command: "claude" }, { command: "node" }]);
+    await expect(assertAgentCapacity("neo")).rejects.toThrow(/concurrency cap reached: 3\/2/);
+  });
+
+  test("exactly at cap → rejects (cap is inclusive)", async () => {
+    capValue = 2;
+    setPanes([{ command: "claude" }, { command: "claude" }]);
+    await expect(assertAgentCapacity("pulse")).rejects.toThrow(/2\/2/);
+  });
+});


### PR DESCRIPTION
Rebased from natkingsize2's PR #1367 onto latest alpha (includes oracle test mock fix from #1371).

Original: https://github.com/Soul-Brews-Studio/maw-js/pull/1367

🤖 Generated with [Claude Code](https://claude.com/claude-code)