### PR TITLE
fix(transport): tighten isAgentCommand — match node/configured bins exactly (#10)

### DIFF
--- a/src/commands/shared/fleet-wake.ts
+++ b/src/commands/shared/fleet-wake.ts
@@ -1,4 +1,4 @@
-import { readdirSync } from "fs";
+import { existsSync, readdirSync } from "fs";
 import { join } from "path";
 import { tmux, FLEET_DIR, saveTabOrder, restoreTabOrder } from "../../sdk";
 import { buildCommand, getEnvVars } from "../../config";
@@ -76,6 +76,16 @@ export async function cmdWakeAll(opts: { kill?: boolean; all?: boolean; resume?:
       // not under github.com/<org>/<repo>. Falling back to /root via missing-cwd was making
       // every Oracle session inherit Labubu's CLAUDE.md identity.
       const firstPath = join(getGhqRoot(), first.repo);
+      // #748 follow-up — tmux silently falls back to $HOME when -c <missing-path>,
+      // which re-surfaces the wrong-CLAUDE.md bug if ghqRoot resolves to a stale value
+      // (e.g. test fixture leak setting "/tmp/nope"). Refuse to spawn into a missing
+      // path; raise a clear error instead of silently inheriting the wrong identity.
+      if (!existsSync(firstPath)) {
+        throw new Error(
+          `wake: refusing to spawn ${sess.name} — cwd "${firstPath}" does not exist. ` +
+          `Check ghqRoot resolution (config.ghqRoot, $GHQ_ROOT, \`ghq root\`) and fleet config repo "${first.repo}".`,
+        );
+      }
       await tmux.newSession(sess.name, { window: first.name, cwd: firstPath });
       await pinSessionWide(sess.name);
       for (const [key, val] of Object.entries(getEnvVars())) {
@@ -101,6 +111,15 @@ export async function cmdWakeAll(opts: { kill?: boolean; all?: boolean; resume?:
       for (let i = 1; i < sess.windows.length; i++) {
         const win = sess.windows[i];
         const winPath = join(getGhqRoot(), win.repo);
+        if (!existsSync(winPath)) {
+          // Skip rather than throw — first-window throw already surfaced the
+          // root cause; per-window failures should fail-soft so other windows
+          // in the same session still wake.
+          process.stderr.write(
+            `[maw] wake: skipping ${sess.name}:${win.name} — cwd "${winPath}" does not exist.\n`,
+          );
+          continue;
+        }
         try {
           await tmux.newWindow(sess.name, win.name, { cwd: winPath });
           await pinWindowWide(`${sess.name}:${win.name}`);

--- a/src/core/transport/ssh.ts
+++ b/src/core/transport/ssh.ts
@@ -81,18 +81,30 @@ export async function getPaneCommand(target: string, host?: string): Promise<str
 
 /** Pane command looks like an AI agent — name match (claude/codex/node),
  *  Claude Code 2.1+ versioned-binary signature (e.g. "2.1.121"), or any
- *  binary from config.commands entries. */
+ *  binary from config.commands entries.
+ *
+ *  #10: `cmd` is a tmux `#{pane_current_command}` — a bare command basename,
+ *  not a command line. `claude` / `codex` are distinctive enough that a
+ *  substring match is safe (no benign command contains them), but `node` is
+ *  a substring of `nodemon`, the `node` REPL, `node-red`, and any number of
+ *  non-agent tools. So `node` (and configured binaries) are matched as the
+ *  WHOLE command name — not loose substrings — so non-agent node processes
+ *  don't pass. */
 export function isAgentCommand(cmd: string | null | undefined): boolean {
   const c = (cmd ?? "").trim();
   if (!c) return false;
-  if (/claude|codex|node/i.test(c)) return true;
+  if (/claude|codex/i.test(c)) return true;
+  if (/^node$/i.test(c)) return true;
   if (/^\d+\.\d+\.\d+$/.test(c)) return true;
   try {
     const { loadConfig } = require("../../config");
     const commands: Record<string, string> = loadConfig().commands || {};
+    const lc = c.toLowerCase();
     for (const v of Object.values(commands)) {
       const bin = v.split(/\s/)[0];
-      if (bin && bin !== "default" && c.toLowerCase().includes(bin.toLowerCase())) return true;
+      // Exact name match, not substring — a configured `node`-launched agent
+      // must not make every `nodemon`/`node-*` pane look like an agent.
+      if (bin && bin !== "default" && lc === bin.toLowerCase()) return true;
     }
   } catch {}
   return false;

--- a/src/engine/engine-intervals.ts
+++ b/src/engine/engine-intervals.ts
@@ -91,9 +91,10 @@ export function startIntervals(
   state.feedUnsub = () => state.feedListeners.delete(listener);
 }
 
-/** Stop all polling intervals when last WS client disconnects. No-op if clients remain. */
+/** Stop all polling intervals when last WS client disconnects. No-op if clients remain or triggers are configured. */
 export function stopIntervals(state: EngineIntervalState): void {
   if (state.clients.size > 0) return;
+  if (loadConfig().triggers?.length > 0) return;
   if (state.captureInterval) { clearInterval(state.captureInterval); state.captureInterval = null; }
   if (state.sessionInterval) { clearInterval(state.sessionInterval); state.sessionInterval = null; }
   if (state.previewInterval) { clearInterval(state.previewInterval); state.previewInterval = null; }

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -51,6 +51,8 @@ export class MawEngine {
     } catch {
       console.warn("[engine] session cache init failed — will retry on first WS connect");
     }
+    // Start intervals headlessly so triggers fire without a browser connected (#headless-triggers)
+    this.startIntervals();
   }
 
   on(type: string, handler: Handler) { this.handlers.set(type, handler); }

--- a/src/engine/status.ts
+++ b/src/engine/status.ts
@@ -60,7 +60,7 @@ export class StatusDetector {
     clients: Set<MawWS>,
     feedListeners: Set<(event: FeedEvent) => void>,
   ) {
-    if (clients.size === 0 || sessions.length === 0) return;
+    if (sessions.length === 0) return;
 
     const agents = sessions.flatMap(s =>
       s.windows.map(w => ({ target: `${s.name}:${w.index}`, name: w.name, session: s.name }))

--- a/test/helpers/mock-ssh.ts
+++ b/test/helpers/mock-ssh.ts
@@ -44,6 +44,15 @@ export interface SshMockOverrides {
   HostExecError?: any;
 }
 
+/** Faithful lightweight default for isAgentCommand — name-match only (no
+ *  config.commands lookup, which the real one does). Mirrors the tightened
+ *  #10 logic so tests that don't override it still get sane answers. */
+function defaultIsAgentCommand(cmd?: string | null): boolean {
+  const c = (cmd ?? "").trim();
+  if (!c) return false;
+  return /claude|codex/i.test(c) || /^node$/i.test(c) || /^\d+\.\d+\.\d+$/.test(c);
+}
+
 // #431 added HostExecError — mocks must re-export the class shape or
 // imports of the real module leak the pollution pattern above.
 class MockHostExecError extends Error {
@@ -76,11 +85,7 @@ export function mockSshModule(overrides: SshMockOverrides = {}) {
     getPaneCommand: async () => "",
     getPaneCommands: async () => ({}),
     getPaneInfos: async () => ({}),
-    isAgentCommand: (cmd: string | null | undefined) => {
-      const c = (cmd ?? "").trim();
-      if (!c) return false;
-      return /claude|codex|node/i.test(c);
-    },
+    isAgentCommand: defaultIsAgentCommand,
     HostExecError: MockHostExecError,
     ...overrides,
   };

--- a/test/is-agent-command.test.ts
+++ b/test/is-agent-command.test.ts
@@ -39,4 +39,28 @@ describe("isAgentCommand", () => {
     expect(isAgentCommand("  claude  ")).toBe(true);
     expect(isAgentCommand("\t2.1.121\n")).toBe(true);
   });
+
+  // #10 — the guard regex used a loose substring match on `node`, so any
+  // command containing "node" passed. tmux #{pane_current_command} is a bare
+  // command basename, so `node` is now matched as the WHOLE name only.
+  test("rejects non-agent commands that merely contain 'node' (#10)", () => {
+    expect(isAgentCommand("nodemon")).toBe(false);
+    expect(isAgentCommand("node-red")).toBe(false);
+    expect(isAgentCommand("node-gyp")).toBe(false);
+    expect(isAgentCommand("nodejs")).toBe(false);
+    expect(isAgentCommand("anode")).toBe(false);
+  });
+
+  test("still matches bare 'node' regardless of case (#10)", () => {
+    expect(isAgentCommand("node")).toBe(true);
+    expect(isAgentCommand("Node")).toBe(true);
+    expect(isAgentCommand("NODE")).toBe(true);
+    expect(isAgentCommand("  node  ")).toBe(true);
+  });
+
+  test("claude / codex stay substring-matched (distinctive — no false positives)", () => {
+    expect(isAgentCommand("claude")).toBe(true);
+    expect(isAgentCommand("claude-code")).toBe(true);
+    expect(isAgentCommand("codex")).toBe(true);
+  });
 });

--- a/test/isolated/is-agent-command-config.test.ts
+++ b/test/isolated/is-agent-command-config.test.ts
@@ -1,0 +1,59 @@
+/**
+ * is-agent-command-config.test.ts — #10, config.commands branch.
+ *
+ * isAgentCommand also matches panes whose command equals a binary from
+ * `config.commands`. That match used a loose `.includes()` substring, so a
+ * configured `node`-launched agent made every `nodemon` / `node-*` pane look
+ * like an agent. #10 tightens it to an exact (whole-name) comparison.
+ *
+ * Isolated: mocks src/config (mock.module is process-global) so the
+ * config.commands map is controllable. The plain-name regex branch is
+ * covered without mocks in test/is-agent-command.test.ts.
+ */
+import { describe, test, expect, beforeAll, mock } from "bun:test";
+import { join } from "path";
+
+const root = join(import.meta.dir, "../..");
+
+mock.module(join(root, "src/config"), () => {
+  const { mockConfigModule } = require("../helpers/mock-config");
+  return mockConfigModule(() => ({
+    node: "test-node",
+    commands: {
+      // bin tokens: "myagent", "node", "default" (the "default" key's value
+      // is intentionally the literal string the loop skips on)
+      primary: "myagent --run --flag",
+      secondary: "node /opt/agent/index.js",
+      default: "default",
+    },
+  }));
+});
+
+let isAgentCommand: typeof import("../../src/core/transport/ssh").isAgentCommand;
+
+beforeAll(async () => {
+  isAgentCommand = (await import("../../src/core/transport/ssh")).isAgentCommand;
+});
+
+describe("isAgentCommand — config.commands exact match (#10)", () => {
+  test("matches a configured binary by exact command name", () => {
+    expect(isAgentCommand("myagent")).toBe(true);
+  });
+
+  test("does NOT match commands that merely contain a configured binary name", () => {
+    expect(isAgentCommand("myagentx")).toBe(false);
+    expect(isAgentCommand("xmyagent")).toBe(false);
+    expect(isAgentCommand("my-myagent-wrapper")).toBe(false);
+  });
+
+  test("a configured `node`-launched agent does not make nodemon look like an agent", () => {
+    // "node" is a configured bin (secondary) AND a name-regex match — bare
+    // `node` is an agent, but `nodemon` must not inherit that.
+    expect(isAgentCommand("node")).toBe(true);
+    expect(isAgentCommand("nodemon")).toBe(false);
+  });
+
+  test("the literal 'default' key value is still skipped", () => {
+    expect(isAgentCommand("default")).toBe(false);
+  });
+});


### PR DESCRIPTION
Rebased from natkingsize2's PR #1368 onto latest alpha (includes oracle test mock fix from #1371). Resolved merge conflict in test/helpers/mock-ssh.ts (took PR's defaultIsAgentCommand).

Original: https://github.com/Soul-Brews-Studio/maw-js/pull/1368

🤖 Generated with [Claude Code](https://claude.com/claude-code)