### PR TITLE
fix(plugin): read tier from registry.meta.json (#1341)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.15-alpha.800",
+  "version": "26.5.15-alpha.815",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/plugin/registry.ts
+++ b/src/plugin/registry.ts
@@ -113,6 +113,18 @@ export function discoverPackages(): LoadedPlugin[] {
 
       const m = loaded.manifest;
 
+      // #1341 — merge tier from registry.meta.json (mpr's canonical source).
+      // plugin.json doesn't declare tier; registry.meta.json does.
+      if (!m.tier) {
+        const metaPath = join(pkgDir, "registry.meta.json");
+        try {
+          if (existsSync(metaPath)) {
+            const meta = JSON.parse(readFileSync(metaPath, "utf-8"));
+            if (meta.tier) m.tier = meta.tier;
+          }
+        } catch { /* malformed meta — skip silently */ }
+      }
+
       // Gate 1: SDK semver. Mismatch → refuse with actionable error.
       if (!satisfies(runtimeVer, m.sdk)) {
         console.warn(formatSdkMismatchError(m.name, m.sdk, runtimeVer));


### PR DESCRIPTION
## Summary
- Reads `registry.meta.json` in the plugin dir when `plugin.json` omits `tier`
- mpr-hosted plugins declare tier in registry.meta.json (registry-side metadata), not plugin.json (runtime manifest)
- Previously every mpr plugin showed as "core" regardless of actual tier

## Test plan
- [ ] CI green
- [ ] `maw plugin ls` shows correct tiers for mpr plugins

Closes #1341

🤖 Generated with [Claude Code](https://claude.com/claude-code)