### PR TITLE
fix(test): add isAgentCommand to mock-ssh helper

### DIFF
--- a/test/helpers/mock-ssh.ts
+++ b/test/helpers/mock-ssh.ts
@@ -40,6 +40,7 @@ export interface SshMockOverrides {
   getPaneCommand?: (...args: any[]) => any;
   getPaneCommands?: (...args: any[]) => any;
   getPaneInfos?: (...args: any[]) => any;
+  isAgentCommand?: (...args: any[]) => any;
   HostExecError?: any;
 }
 
@@ -75,6 +76,11 @@ export function mockSshModule(overrides: SshMockOverrides = {}) {
     getPaneCommand: async () => "",
     getPaneCommands: async () => ({}),
     getPaneInfos: async () => ({}),
+    isAgentCommand: (cmd: string | null | undefined) => {
+      const c = (cmd ?? "").trim();
+      if (!c) return false;
+      return /claude|codex|node/i.test(c) || /^\d+\.\d+\.\d+$/.test(c);
+    },
     HostExecError: MockHostExecError,
     ...overrides,
   };

--- a/test/isolated/comm-send-resolve-pane.test.ts
+++ b/test/isolated/comm-send-resolve-pane.test.ts
@@ -52,6 +52,10 @@ mock.module(join(srcRoot, "src/sdk"), () => ({
   capture: async () => "",
   sendKeys: async () => {},
   getPaneCommand: async () => "claude",
+  isAgentCommand: (cmd: string | null | undefined) => {
+    const c = (cmd ?? "").trim();
+    return !!c && (/claude|codex|node/i.test(c) || /^\d+\.\d+\.\d+$/.test(c));
+  },
   findPeerForTarget: async () => null,
   resolveTarget: () => null,
   curlFetch: async () => ({ ok: false, status: 0, data: null }),

--- a/test/isolated/pulse-label-injection.test.ts
+++ b/test/isolated/pulse-label-injection.test.ts
@@ -16,6 +16,7 @@
 
 import { describe, test, expect, beforeAll, mock, spyOn } from "bun:test";
 import { Elysia } from "elysia";
+import { mockSshModule } from "../helpers/mock-ssh";
 
 // ---- Capture calls to Bun.spawn -------------------------------------------
 
@@ -47,7 +48,7 @@ Bun.spawn = (cmd: string[], _opts?: unknown) => {
 
 // ---- Stub dependencies so pulse.ts can be imported -----------------------
 
-mock.module("../../src/core/transport/ssh", () => ({
+mock.module("../../src/core/transport/ssh", () => mockSshModule({
   hostExec: async (_cmd: string) => "[]",
 }));
 

--- a/test/isolated/resolve-local-first.test.ts
+++ b/test/isolated/resolve-local-first.test.ts
@@ -25,6 +25,7 @@ let curlFetchUrl = "";
 // ─── Module mocks (must be before any imports of the modules under test) ─────
 
 import { mockConfigModule } from "../helpers/mock-config";
+import { mockSshModule } from "../helpers/mock-ssh";
 
 mock.module("../../src/config", () => mockConfigModule(() => ({
   node: "white",
@@ -34,7 +35,7 @@ mock.module("../../src/config", () => mockConfigModule(() => ({
   sessions: {},
 })));
 
-mock.module("../../src/core/transport/ssh", () => ({
+mock.module("../../src/core/transport/ssh", () => mockSshModule({
   listSessions: async () => fakeSessions,
   sendKeys: async () => { sendKeysCalled = true; },
   capture: async () => "",
@@ -42,7 +43,6 @@ mock.module("../../src/core/transport/ssh", () => ({
   getPaneCommands: async () => [],
   getPaneInfos: async () => ({}),
   hostExec: async () => { throw new Error("tmux unavailable in test"); },
-  HostExecError: class HostExecError extends Error {},
 }));
 
 mock.module("../../src/core/transport/curl-fetch", () => ({

--- a/test/isolated/worktree-scope-match-935.test.ts
+++ b/test/isolated/worktree-scope-match-935.test.ts
@@ -27,6 +27,7 @@
  */
 import { describe, it, expect, mock, beforeEach } from "bun:test";
 import { join } from "path";
+import { mockSshModule } from "../helpers/mock-ssh";
 
 const root = join(import.meta.dir, "../../src");
 
@@ -34,7 +35,7 @@ const root = join(import.meta.dir, "../../src");
 let stubFindOutput: string = "";
 let stubSessions: Array<{ name: string; windows: Array<{ name: string; index: number; active: boolean }> }> = [];
 
-mock.module(join(root, "core/transport/ssh"), () => ({
+mock.module(join(root, "core/transport/ssh"), () => mockSshModule({
   hostExec: async (cmd: string) => {
     if (cmd.includes("find ") && cmd.includes(".wt-")) {
       return stubFindOutput;
@@ -42,7 +43,6 @@ mock.module(join(root, "core/transport/ssh"), () => ({
     if (cmd.includes("rev-parse --abbrev-ref")) {
       return "agents/935-test";
     }
-    // Suppress prunable-worktree probe — return empty so no orphans appear
     return "";
   },
   listSessions: async () => stubSessions,


### PR DESCRIPTION
## Summary
- `isAgentCommand` was added to `ssh.ts` but never to `mockSshModule` helper — any test mocking ssh.ts poisoned the process-global module registry, breaking `sdk/index.ts` re-exports
- Adds `isAgentCommand` stub to `mockSshModule` with real pattern matching (claude/codex/node)
- Converts 3 raw-mock tests to use the helper (`resolve-local-first`, `worktree-scope-match-935`, `pulse-label-injection`)
- Patches direct SDK mock in `comm-send-resolve-pane.test.ts`

## Results
- test-isolated: 70/79 → 74/79 passing (fixes 4 files broken by missing mock export)
- Remaining 5 failures are pre-existing unrelated issues

## Test plan
- [x] `bun test test/isolated/resolve-local-first.test.ts` — 3/3 pass
- [x] `bun test test/isolated/comm-send-resolve-pane.test.ts` — 6/6 pass (was 33 fail)
- [x] `bun test test/isolated/pulse-label-injection.test.ts` — pass
- [x] `bun test test/isolated/worktree-scope-match-935.test.ts` — 5/5 pass
- [x] `bun run test:mock-smoke` — 6/6 pass
- [x] `bash scripts/test-isolated.sh` — 74/79 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)