### PR TITLE
release: maw hardening 2026-05-15 (auth #1/#3, enter-race #6, wake-cap #2, isAgentCommand #10, update crash-loop)

### DIFF
--- a/src/cli/cmd-update.ts
+++ b/src/cli/cmd-update.ts
@@ -135,6 +135,19 @@ export async function runUpdate(args: string[]): Promise<void> {
   // Order matters: validation (above) → try add → on fail, remove + retry →
   // on still-fail, print recovery command. User always has a working maw
   // unless BOTH adds fail.
+  // Test-mode guard — runUpdate mutates the *real* `~/.bun/bin/maw`,
+  // `~/.bun/install/global/`, and bun's global lockfiles; it has no sandbox
+  // seam. The test suite (MAW_TEST_MODE=1) spawns `maw update <ref> --yes` to
+  // exercise the ref-allowlist gate — that previously fell straight through
+  // into the destructive install ops below and wiped the developer's maw
+  // install on every `bun test` run (observed 2026-05-14/15). Stop here:
+  // everything above (help short-circuit, REF_RE allowlist, channel resolve,
+  // confirmation gate) is non-destructive and still fully exercised.
+  if (process.env.MAW_TEST_MODE) {
+    console.log(`  \x1b[90m[test-mode] ref "${ref}" accepted — skipping destructive install\x1b[0m`);
+    return;
+  }
+
   // #551 — serialize concurrent `maw update` invocations via filesystem lock.
   // Channel-resolve + validation above runs unlocked; destructive install ops
   // below (stash, bun remove, bun add, link refresh) are serialized.
@@ -152,6 +165,16 @@ export async function runUpdate(args: string[]): Promise<void> {
       const BIN = join(homedir(), ".bun", "bin", "maw");
       const STASH = `${BIN}.prev`;
       let stashed = false;
+      // The global maw-js package dir. A `bun add -g` install makes
+      // `~/.bun/bin/maw` a symlink INTO this dir, so `rmSync`-ing it orphans
+      // the stashed bin symlink — `existsSync(STASH)` then reports false and
+      // the restore below silently no-ops, leaving NO working maw (observed:
+      // full install wipe on a failed `maw update`). Stash this dir by RENAME
+      // (not rm) so a failed retry can restore a *working* install — both the
+      // bin symlink AND the package it resolves to.
+      const NM = join(homedir(), ".bun", "install", "global", "node_modules");
+      const PKG_STASH = join(NM, "maw-js.update-stash");
+      let pkgStashed = false;
       // #968 — if .prev already exists, it's a leftover from a prior crashed
       // update. The original (#551) behavior refused at this point so the
       // user wouldn't lose their last-known-good binary. But that left the
@@ -201,9 +224,18 @@ export async function runUpdate(args: string[]): Promise<void> {
         if (dirty) writeFileSync(globalPkg, JSON.stringify(data, null, 2) + "\n");
       } catch { /* best effort — file missing or unreadable; bun remove still runs below */ }
       try {
-        const nm = join(homedir(), ".bun", "install", "global", "node_modules");
-        for (const name of ["maw-js", "maw", "@maw-js"]) {
-          try { rmSync(join(nm, name), { recursive: true, force: true }); } catch {}
+        // Clear any leftover pkg stash from a prior crashed update, then move
+        // the maw-js package OUT of node_modules by rename. bun's resolver
+        // sees a clean node_modules (same effect as rm for the dep-loop fix,
+        // #950) but the package stays recoverable for the restore path below.
+        try { rmSync(PKG_STASH, { recursive: true, force: true }); } catch {}
+        if (existsSync(join(NM, "maw-js"))) {
+          try { renameSync(join(NM, "maw-js"), PKG_STASH); pkgStashed = true; } catch {}
+        }
+        // `maw` (bin shim) and `@maw-js` (scope dir) are not what the bin
+        // symlink resolves through — safe to drop outright.
+        for (const name of ["maw", "@maw-js"]) {
+          try { rmSync(join(NM, name), { recursive: true, force: true }); } catch {}
         }
       } catch {}
 
@@ -264,17 +296,57 @@ export async function runUpdate(args: string[]): Promise<void> {
         }
       }
 
-      if (installCode !== 0 && stashed && existsSync(STASH)) {
-        // Retry failed — restore the previous binary so the user isn't stranded.
+      // Restore the maw-js package dir from the rename-stash. Used by both the
+      // failure path (put the old install back) and the rollback path (a
+      // "successful" install whose binary doesn't actually run).
+      const restorePkgStash = () => {
+        if (!pkgStashed || !existsSync(PKG_STASH)) return;
         try {
-          renameSync(STASH, BIN);
-          console.warn(`\x1b[33m↺\x1b[0m restored previous maw binary from stash`);
+          rmSync(join(NM, "maw-js"), { recursive: true, force: true });
+          renameSync(PKG_STASH, join(NM, "maw-js"));
         } catch (e: any) {
-          console.error(`failed to restore stash: ${e.message || e}`);
+          console.error(`failed to restore maw-js package from stash: ${e.message || e}`);
         }
-      } else if (installCode === 0 && stashed && existsSync(STASH)) {
-        // Retry succeeded — clean up the stash.
-        try { unlinkSync(STASH); } catch {}
+      };
+
+      if (installCode !== 0) {
+        // Retry failed — restore the previous WORKING maw so the user isn't
+        // stranded. Order matters: restore the package dir FIRST so the
+        // stashed bin symlink resolves again, THEN move the bin back.
+        restorePkgStash();
+        if (stashed && existsSync(STASH)) {
+          try {
+            renameSync(STASH, BIN);
+            console.warn(`\x1b[33m↺\x1b[0m restored previous maw binary from stash`);
+          } catch (e: any) {
+            console.error(`failed to restore stash: ${e.message || e}`);
+          }
+        }
+      } else {
+        // Retry reported success — but verify the fresh binary actually RUNS
+        // before discarding the stash (the invariant: never rotate away the
+        // old one until the new one is confirmed working). If it doesn't,
+        // roll back to the stashed install and fall into the error path.
+        const verify = Bun.spawn(["maw", "--version"], { stdout: "pipe", stderr: "pipe" });
+        const freshOk = (await verify.exited) === 0;
+        if (!freshOk) {
+          console.warn(`\x1b[33m↺\x1b[0m fresh install did not run — rolling back to previous maw`);
+          restorePkgStash();
+          if (stashed && existsSync(STASH)) {
+            try {
+              renameSync(STASH, BIN);
+            } catch (e: any) {
+              console.error(`failed to restore stash: ${e.message || e}`);
+            }
+          }
+          installCode = 1; // fall into the error path below
+        } else {
+          // Fresh install confirmed working — discard the stashes.
+          if (stashed && existsSync(STASH)) { try { unlinkSync(STASH); } catch {} }
+          if (pkgStashed && existsSync(PKG_STASH)) {
+            try { rmSync(PKG_STASH, { recursive: true, force: true }); } catch {}
+          }
+        }
       }
     }
     if (installCode !== 0) {

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -8,6 +8,7 @@ import { resolveOracle, findWorktrees, getSessionMap, resolveFleetSession, detec
 import { attachToSession, ensureSessionRunning, createWorktree } from "./wake-session";
 import { maybeSplit } from "./wake-maybe-split";
 import { parseWakeTarget, ensureCloned } from "./wake-target";
+import { assertAgentCapacity } from "./wake-concurrency";
 
 export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; split?: boolean; repoPath?: string; urlRepoName?: string; allLocal?: boolean; engine?: string }): Promise<string> {
   // Canonicalize the bare name before any lookup — strips trailing `/`, `/.git`, `/.git/`
@@ -81,6 +82,10 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
   });
 
   if (!session && wakeDecision.wake) {
+    // #2 — refuse to spawn a brand-new session/agent once the fleet is at the
+    // configured concurrency cap (no-op when limits.maxConcurrentAgents is 0).
+    await assertAgentCapacity(oracle);
+
     // #769 — URL input names the new session after the full repo (e.g.
     // "m5-oracle") so it's distinct from any unrelated sub-token sessions
     // and immediately disambiguates future `maw wake` calls.
@@ -275,6 +280,10 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
       return target;
     }
   } catch { /* session might be fresh */ }
+
+  // #2 — a new task/worktree window is a net-new agent pane: cap-check before
+  // spawning it (no-op when limits.maxConcurrentAgents is 0).
+  await assertAgentCapacity(oracle);
 
   await tmux.newWindow(session, windowName, { cwd: targetPath });
   await new Promise(r => setTimeout(r, 300));

--- a/src/commands/shared/wake-concurrency.ts
+++ b/src/commands/shared/wake-concurrency.ts
@@ -1,0 +1,58 @@
+/**
+ * wake-concurrency.ts — agent concurrency cap for `maw wake` (#2).
+ *
+ * `cmdWake` had no count, queue, or cap: nothing stopped a script (or a
+ * runaway orchestrator) from spawning agents until the box fell over.
+ * `D.limits` governed feed/logs/pty/message sizes but nothing about agent
+ * count.
+ *
+ * This module adds an opt-in cap. When `limits.maxConcurrentAgents` is a
+ * positive number, `maw wake` counts the agent panes already live across the
+ * fleet and refuses ("fails loud") to spawn one more once the fleet is at or
+ * over the cap. `0` / unset disables the cap — no behavior change for anyone
+ * who has not configured it.
+ *
+ * Pure decision logic (`checkCapacity`) is split from the tmux I/O
+ * (`countLiveAgents`) so the over-cap path is unit-testable without a tmux
+ * server.
+ */
+
+import { cfgLimit } from "../../config";
+import { tmux } from "../../core/transport/tmux";
+import { isAgentCommand } from "../../core/transport/ssh";
+
+/**
+ * Pure cap decision — throws a loud, actionable error when `liveAgents` is at
+ * or over `cap`. A `cap` of `0` or less means "disabled" and is always a
+ * no-op. Kept free of I/O so tests can exercise every branch directly.
+ */
+export function checkCapacity(liveAgents: number, cap: number, spawning: string): void {
+  if (!cap || cap <= 0) return; // cap disabled — opt-in only
+  if (liveAgents >= cap) {
+    throw new Error(
+      `agent concurrency cap reached: ${liveAgents}/${cap} agents already live — ` +
+      `refusing to spawn '${spawning}'. Raise limits.maxConcurrentAgents in maw.config.json ` +
+      `or sleep an idle agent first (maw sleep <agent>).`,
+    );
+  }
+}
+
+/** Count tmux panes currently running an agent process across all sessions. */
+export async function countLiveAgents(): Promise<number> {
+  const panes = await tmux.listPanes();
+  return panes.filter(p => isAgentCommand(p.command)).length;
+}
+
+/**
+ * Guard a spawn against the configured agent concurrency cap (#2). No-op when
+ * `limits.maxConcurrentAgents` is `0` / unset — and in that case we skip the
+ * tmux `list-panes` call entirely so the disabled path stays free.
+ *
+ * @param spawning  the oracle/agent name about to be spawned — surfaced in the
+ *                  error so the operator knows what was refused.
+ */
+export async function assertAgentCapacity(spawning: string): Promise<void> {
+  const cap = cfgLimit("maxConcurrentAgents");
+  if (!cap || cap <= 0) return; // disabled — don't even query tmux
+  checkCapacity(await countLiveAgents(), cap, spawning);
+}

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -47,6 +47,12 @@ export interface MawLimits {
   messageTruncate?: number;
   ptyCols?: number;
   ptyRows?: number;
+  /**
+   * Max concurrent agent panes across the fleet before `maw wake` refuses to
+   * spawn a new one (#2). `0` (the default) disables the cap entirely —
+   * operators opt in by setting a positive number.
+   */
+  maxConcurrentAgents?: number;
 }
 
 export interface MawConfig {
@@ -159,6 +165,6 @@ export interface MawConfig {
 export const D = {
   intervals: { capture: 50, sessions: 5000, status: 3000, teams: 3000, preview: 2000, peerFetch: 10000, crashCheck: 30000 } as const,
   timeouts: { http: 5000, health: 3000, ping: 5000, pty: 5000, workspace: 5000, shellInit: 3000, wakeRetry: 500, wakeVerify: 3000 } as const,
-  limits: { feedMax: 500, feedDefault: 50, feedHistory: 50, logsMax: 500, logsDefault: 50, logsTruncate: 500, messageTruncate: 100, ptyCols: 500, ptyRows: 200 } as const,
+  limits: { feedMax: 500, feedDefault: 50, feedHistory: 50, logsMax: 500, logsDefault: 50, logsTruncate: 500, messageTruncate: 100, ptyCols: 500, ptyRows: 200, maxConcurrentAgents: 0 } as const,
   hmacWindowSeconds: 300,
 } as const;

--- a/src/core/transport/ssh.ts
+++ b/src/core/transport/ssh.ts
@@ -81,18 +81,30 @@ export async function getPaneCommand(target: string, host?: string): Promise<str
 
 /** Pane command looks like an AI agent — name match (claude/codex/node),
  *  Claude Code 2.1+ versioned-binary signature (e.g. "2.1.121"), or any
- *  binary from config.commands entries. */
+ *  binary from config.commands entries.
+ *
+ *  #10: `cmd` is a tmux `#{pane_current_command}` — a bare command basename,
+ *  not a command line. `claude` / `codex` are distinctive enough that a
+ *  substring match is safe (no benign command contains them), but `node` is
+ *  a substring of `nodemon`, the `node` REPL, `node-red`, and any number of
+ *  non-agent tools. So `node` (and configured binaries) are matched as the
+ *  WHOLE command name — not loose substrings — so non-agent node processes
+ *  don't pass. */
 export function isAgentCommand(cmd: string | null | undefined): boolean {
   const c = (cmd ?? "").trim();
   if (!c) return false;
-  if (/claude|codex|node/i.test(c)) return true;
+  if (/claude|codex/i.test(c)) return true;
+  if (/^node$/i.test(c)) return true;
   if (/^\d+\.\d+\.\d+$/.test(c)) return true;
   try {
     const { loadConfig } = require("../../config");
     const commands: Record<string, string> = loadConfig().commands || {};
+    const lc = c.toLowerCase();
     for (const v of Object.values(commands)) {
       const bin = v.split(/\s/)[0];
-      if (bin && bin !== "default" && c.toLowerCase().includes(bin.toLowerCase())) return true;
+      // Exact name match, not substring — a configured `node`-launched agent
+      // must not make every `nodemon`/`node-*` pane look like an agent.
+      if (bin && bin !== "default" && lc === bin.toLowerCase()) return true;
     }
   } catch {}
   return false;

--- a/src/core/transport/tmux-class.ts
+++ b/src/core/transport/tmux-class.ts
@@ -8,6 +8,22 @@ import {
   type TmuxWindow,
 } from "./tmux-types";
 
+// --- sendText submit-confirmation tuning (#6) ---
+// The old sendText fired 3 blind `Enter` keys on a fixed ~1.9s schedule with
+// zero feedback. If the pane wasn't ready when they landed (agent still
+// rendering the paste, brief stall), every Enter missed and the command sat
+// in the input box unexecuted — this forced manual re-launch of dispatches
+// on 2026-05-14. We now send Enter, re-check the pane, and retry only while
+// input is still pending.
+/** Wait after paste/literal-send before the first Enter — lets the input settle. */
+const SEND_SETTLE_MS = 1500;
+/** Wait after each Enter before re-checking whether the input line cleared. */
+const SUBMIT_CONFIRM_MS = 700;
+/** Max Enter attempts before giving up and warning (was 3 blind, unconditional sends). */
+const MAX_SUBMIT_ATTEMPTS = 4;
+/** ANSI escape stripper — matches checkPaneIdle in comm-send.ts (#405). */
+const ANSI_RE = /\x1b\[[0-9;]*[mGKHFJA-Z]/g;
+
 /**
  * Typed wrapper around tmux CLI.
  * All methods build arg arrays and delegate to `run()`.
@@ -260,31 +276,65 @@ export class Tmux {
 
   /**
    * Smart text sending — uses load-buffer for multiline/long messages,
-   * send-keys for short single-line. Always appends Enter.
+   * send-keys for short single-line. Always submits with Enter.
    * Ported from old bash maw hey (Dec 2025).
+   *
+   * #6 — submit is now confirmed, not fire-and-forget. After placing the
+   * text we send Enter, re-inspect the pane, and retry the Enter only while
+   * the input line still holds un-submitted content (up to
+   * MAX_SUBMIT_ATTEMPTS). This closes the trailing-Enter race where blind
+   * staggered Enter keys landed before the pane was ready and the command
+   * was silently left unexecuted.
    */
   async sendText(target: string, text: string): Promise<void> {
     if (text.includes("\n") || text.length > 500) {
       // Buffer method — reliable for multiline/long content
       await this.loadBuffer(text);
       await this.pasteBuffer(target);
-      await new Promise(r => setTimeout(r, 1500));
-      // Staggered Enter — submit + 2 fallbacks
-      await this.sendKeys(target, "Enter");
-      await new Promise(r => setTimeout(r, 700));
-      await this.sendKeys(target, "Enter");
-      await new Promise(r => setTimeout(r, 1200));
-      await this.sendKeys(target, "Enter");
     } else {
       // Literal send — -l prevents tmux from interpreting special chars like |
       await this.sendKeysLiteral(target, text);
-      await new Promise(r => setTimeout(r, 1500));
-      // Staggered Enter — submit + 2 fallbacks
+    }
+    await new Promise(r => setTimeout(r, SEND_SETTLE_MS));
+    await this.submitWithConfirm(target);
+  }
+
+  /**
+   * Send Enter, then confirm the input line cleared before returning. Retries
+   * the Enter while input is still pending — see sendText for the #6 race.
+   * @internal — exported behavior is exercised via sendText in tests.
+   */
+  private async submitWithConfirm(target: string): Promise<void> {
+    for (let attempt = 1; attempt <= MAX_SUBMIT_ATTEMPTS; attempt++) {
       await this.sendKeys(target, "Enter");
-      await new Promise(r => setTimeout(r, 700));
-      await this.sendKeys(target, "Enter");
-      await new Promise(r => setTimeout(r, 1200));
-      await this.sendKeys(target, "Enter");
+      await new Promise(r => setTimeout(r, SUBMIT_CONFIRM_MS));
+      if (!(await this.paneInputPending(target))) return; // submitted — done
+    }
+    // Exhausted every retry and the input line still looks non-empty. The
+    // caller has no visibility into tmux pane state, so warn loudly — a
+    // silently-dropped dispatch is the exact failure mode #6 is about.
+    console.warn(
+      `[tmux] sendText: ${target} still shows pending input after ${MAX_SUBMIT_ATTEMPTS} Enter attempts — command may not have submitted`,
+    );
+  }
+
+  /**
+   * True when the pane's prompt line still holds un-submitted input.
+   * Mirrors checkPaneIdle (comm-send.ts #405) but inlined here to avoid a
+   * circular import — comm-send.ts already imports Tmux. A read failure
+   * returns false (assume submitted) so a flaky capture can't spin the retry
+   * loop.
+   */
+  private async paneInputPending(target: string): Promise<boolean> {
+    try {
+      const content = await this.capture(target, 5);
+      const lines = content.split("\n").filter(l => l.trim());
+      const last = (lines.at(-1) ?? "").replace(ANSI_RE, "").replace(/\r/g, "");
+      // Prompt marker followed by non-whitespace → user/command text still
+      // sitting on the input line, i.e. Enter has not submitted it yet.
+      return /[#$%>❯»]\s+\S/.test(last);
+    } catch {
+      return false;
     }
   }
 

--- a/src/lib/elysia-auth.ts
+++ b/src/lib/elysia-auth.ts
@@ -161,7 +161,13 @@ export const fromSigningAuth = new Elysia({ name: "from-signing-auth" })
       console.warn(`[from-auth] accepted signed request from unknown peer ${decision.from} (no cached pubkey to verify against — alpha behavior; will harden at v27)`);
     }
     // accept-verified is the steady-state happy path; no log spam.
-  });
+  })
+  // SECURITY (#1): `.as('global')` propagates this onBeforeHandle to every
+  // sibling route module mounted alongside this plugin in src/api/index.ts.
+  // Without it, a named Elysia plugin's lifecycle hook is `local`-scoped — it
+  // guards only routes defined on THIS instance (which defines zero), so the
+  // hook would run for nothing and every protected route would be unguarded.
+  .as("global");
 
 /** Federation auth — Elysia plugin with onBeforeHandle HMAC verification */
 export const federationAuth = new Elysia({ name: "federation-auth" })
@@ -169,8 +175,13 @@ export const federationAuth = new Elysia({ name: "federation-auth" })
     const config = loadConfig();
     const token = config.federationToken;
 
-    // No token configured → auth disabled (backwards compat)
-    if (!token) return;
+    // Peers-require-token invariant (#3) — mirrors the Hono federation-auth.ts.
+    // A node with peers configured binds 0.0.0.0 (see core/server.ts) and is
+    // network-reachable, so "no token" in that posture is default-insecure-open,
+    // NOT single-node mode. We must reach the fail-closed check below before
+    // returning on `!token`, so the token short-circuit no longer happens here.
+    const hasPeers = (config.peers?.length ?? 0) > 0 || (config.namedPeers?.length ?? 0) > 0;
+    const allowPeersWithoutToken = config.allowPeersWithoutToken === true;
 
     const url = new URL(request.url);
     // Strip /api prefix to match against PROTECTED set
@@ -195,6 +206,22 @@ export const federationAuth = new Elysia({ name: "federation-auth" })
     const clientIp = _bunServer?.requestIP?.(request)?.address;
 
     if (isLoopback(clientIp)) return;
+
+    // Fail-closed (#3): peers configured but no federationToken → the node is
+    // network-reachable with auth fully off. Refuse protected writes from
+    // non-loopback callers unless the operator explicitly opted into the
+    // legacy posture with `allowPeersWithoutToken: true`. Restores the
+    // invariant the Hono federation-auth.ts has always enforced.
+    if (!token && hasPeers && !allowPeersWithoutToken) {
+      console.warn(`[auth] rejected ${request.method} ${url.pathname} from ${clientIp ?? "?"}: federation_token_required (peers configured, no federationToken)`);
+      set.status = 401;
+      return { error: "federation auth required", reason: "federation_token_required" };
+    }
+
+    // No token configured AND no peers → local-only single-node mode.
+    // The server binds to 127.0.0.1 in this posture; preserve legacy
+    // pass-through so fresh single-node installs work unchanged.
+    if (!token) return;
 
     // #804 Step 4: when the request carries `x-maw-from`, the from-signing
     // layer owns the `x-maw-signature` slot and is verified by
@@ -229,4 +256,11 @@ export const federationAuth = new Elysia({ name: "federation-auth" })
     }
 
     // Auth passed — continue to handler
-  });
+  })
+  // SECURITY (#1): `.as('global')` propagates this onBeforeHandle to every
+  // sibling route module mounted alongside this plugin in src/api/index.ts
+  // (.use(sessionsApi), .use(feedApi), .use(transportApi), …). Without it the
+  // hook is `local`-scoped to this instance — which defines zero routes — so
+  // it guards NOTHING and every protected write endpoint accepts unsigned
+  // non-loopback requests. Empirically confirmed in maw-stress revalidation.
+  .as("global");

--- a/test/cmd-update-ref-validation.test.ts
+++ b/test/cmd-update-ref-validation.test.ts
@@ -18,7 +18,13 @@ async function runCli(
   const proc = Bun.spawn(["bun", cliPath, ...args], {
     stdout: "pipe",
     stderr: "pipe",
-    env: { ...process.env, MAW_CLI: "1", ...opts.env },
+    // MAW_TEST_MODE=1 is mandatory here: runUpdate mutates the *real*
+    // ~/.bun/bin/maw and ~/.bun/install/global/ (no sandbox seam). Without
+    // this guard a valid ref falls through into the destructive install path
+    // and wipes the developer's maw install on every `bun test` run. Set it
+    // explicitly so the test is safe even when run standalone (not just
+    // inheriting it from the suite-level env).
+    env: { ...process.env, MAW_CLI: "1", MAW_TEST_MODE: "1", ...opts.env },
   });
   const [stdout, stderr, code] = await Promise.all([
     new Response(proc.stdout).text(),
@@ -89,16 +95,19 @@ describe("H3 — cmd-update ref allowlist (CLI subprocess)", () => {
     expect(stderr).toContain("invalid ref");
   }, 10_000);
 
-  it("valid ref 'main' passes the allowlist gate (reaches install, not ref guard)", async () => {
-    // We can't complete a real install in test, but the error must NOT be about
-    // "invalid ref" — it should be about network or bun, meaning REF_RE passed.
-    const { stderr } = await runCli(["update", "main", "--yes"]);
-    // The ref guard must NOT fire for "main"
+  it("valid ref 'main' passes the allowlist gate (reaches test-mode gate, not ref guard)", async () => {
+    // A valid ref must pass REF_RE and reach the destructive-op boundary.
+    // Under MAW_TEST_MODE that boundary is the test-mode guard, which prints
+    // "accepted" and stops — so we assert REF_RE did NOT reject AND the ref
+    // actually reached the gate (proof it traversed the whole allowlist path).
+    const { stdout, stderr } = await runCli(["update", "main", "--yes"]);
     expect(stderr).not.toContain("invalid ref");
+    expect(stdout).toContain('ref "main" accepted');
   }, 15_000);
 
   it("valid branch name 'feat/my-feature' passes the allowlist gate", async () => {
-    const { stderr } = await runCli(["update", "feat/my-feature", "--yes"]);
+    const { stdout, stderr } = await runCli(["update", "feat/my-feature", "--yes"]);
     expect(stderr).not.toContain("invalid ref");
+    expect(stdout).toContain('ref "feat/my-feature" accepted');
   }, 15_000);
 });

--- a/test/helpers/mock-config.ts
+++ b/test/helpers/mock-config.ts
@@ -23,6 +23,7 @@ const LIMITS: Record<keyof MawLimits, number> = {
   feedMax: 500, feedDefault: 50, feedHistory: 50,
   logsMax: 500, logsDefault: 50, logsTruncate: 500,
   messageTruncate: 100, ptyCols: 500, ptyRows: 200,
+  maxConcurrentAgents: 0,
 };
 
 export const TEST_D = {

--- a/test/helpers/mock-ssh.ts
+++ b/test/helpers/mock-ssh.ts
@@ -40,7 +40,17 @@ export interface SshMockOverrides {
   getPaneCommand?: (...args: any[]) => any;
   getPaneCommands?: (...args: any[]) => any;
   getPaneInfos?: (...args: any[]) => any;
+  isAgentCommand?: (...args: any[]) => any;
   HostExecError?: any;
+}
+
+/** Faithful lightweight default for isAgentCommand — name-match only (no
+ *  config.commands lookup, which the real one does). Mirrors the tightened
+ *  #10 logic so tests that don't override it still get sane answers. */
+function defaultIsAgentCommand(cmd?: string | null): boolean {
+  const c = (cmd ?? "").trim();
+  if (!c) return false;
+  return /claude|codex/i.test(c) || /^node$/i.test(c) || /^\d+\.\d+\.\d+$/.test(c);
 }
 
 // #431 added HostExecError — mocks must re-export the class shape or
@@ -75,6 +85,7 @@ export function mockSshModule(overrides: SshMockOverrides = {}) {
     getPaneCommand: async () => "",
     getPaneCommands: async () => ({}),
     getPaneInfos: async () => ({}),
+    isAgentCommand: defaultIsAgentCommand,
     HostExecError: MockHostExecError,
     ...overrides,
   };

--- a/test/helpers/mock-tmux.ts
+++ b/test/helpers/mock-tmux.ts
@@ -69,12 +69,24 @@ export interface MockPeer {
   sessions: MockSession[];
 }
 
+/** Shape returned by the mocked `tmux.listPanes()` — mirrors TmuxPane. */
+export interface MockPane {
+  id: string;
+  command: string;
+  target: string;
+  title?: string;
+  pid?: number;
+  cwd?: string;
+  lastActivity?: number;
+}
+
 // --- Internal state (cleared by resetMocks) ---
 
 let tmuxConfig: { sessions: MockSession[] } | null = null;
 let peersConfig: { peers: MockPeer[] } | null = null;
 let paneCommands: Record<string, string> = {};
 let capturedCommands: string[] = [];
+let panes: MockPane[] = [];
 
 // --- Shim install latches (shim stays live; config is what changes) ---
 
@@ -152,7 +164,7 @@ export function installTmuxMock(config: { sessions: MockSession[] }): void {
       },
       async listPanes() {
         capturedCommands.push("tmux list-panes -a");
-        return [];
+        return panes.map(p => ({ ...p }));
       },
       async killPane(target: string) {
         capturedCommands.push(`tmux kill-pane -t ${target}`);
@@ -328,6 +340,23 @@ export function setPaneCommands(cmds: Record<string, string>): void {
   paneCommands = { ...cmds };
 }
 
+/**
+ * Configure what `tmux.listPanes()` returns. Accepts partial panes — only
+ * `command` is required (the field most callers filter on); the rest are
+ * filled with deterministic placeholders. Replaces the previous list.
+ */
+export function setPanes(p: Array<Partial<MockPane> & { command: string }>): void {
+  panes = p.map((pane, i) => ({
+    id: pane.id ?? `%${i}`,
+    command: pane.command,
+    target: pane.target ?? `mock:${i}`,
+    title: pane.title,
+    pid: pane.pid,
+    cwd: pane.cwd,
+    lastActivity: pane.lastActivity,
+  }));
+}
+
 /** Captured tmux commands issued through the mock (for assertions). */
 export function getCapturedCommands(): string[] {
   return [...capturedCommands];
@@ -345,4 +374,5 @@ export function resetMocks(): void {
   peersConfig = null;
   paneCommands = {};
   capturedCommands = [];
+  panes = [];
 }

--- a/test/is-agent-command.test.ts
+++ b/test/is-agent-command.test.ts
@@ -39,4 +39,28 @@ describe("isAgentCommand", () => {
     expect(isAgentCommand("  claude  ")).toBe(true);
     expect(isAgentCommand("\t2.1.121\n")).toBe(true);
   });
+
+  // #10 — the guard regex used a loose substring match on `node`, so any
+  // command containing "node" passed. tmux #{pane_current_command} is a bare
+  // command basename, so `node` is now matched as the WHOLE name only.
+  test("rejects non-agent commands that merely contain 'node' (#10)", () => {
+    expect(isAgentCommand("nodemon")).toBe(false);
+    expect(isAgentCommand("node-red")).toBe(false);
+    expect(isAgentCommand("node-gyp")).toBe(false);
+    expect(isAgentCommand("nodejs")).toBe(false);
+    expect(isAgentCommand("anode")).toBe(false);
+  });
+
+  test("still matches bare 'node' regardless of case (#10)", () => {
+    expect(isAgentCommand("node")).toBe(true);
+    expect(isAgentCommand("Node")).toBe(true);
+    expect(isAgentCommand("NODE")).toBe(true);
+    expect(isAgentCommand("  node  ")).toBe(true);
+  });
+
+  test("claude / codex stay substring-matched (distinctive — no false positives)", () => {
+    expect(isAgentCommand("claude")).toBe(true);
+    expect(isAgentCommand("claude-code")).toBe(true);
+    expect(isAgentCommand("codex")).toBe(true);
+  });
 });

--- a/test/isolated/cmd-update-order.test.ts
+++ b/test/isolated/cmd-update-order.test.ts
@@ -93,7 +93,12 @@ describe("cmd-update source-order invariants", () => {
     expect(src).toMatch(/for \(const key of \["maw-js", "maw"\]\)/);
   });
 
-  it("#950: direct-rm covers maw-js, maw, and @maw-js node_modules", () => {
-    expect(src).toMatch(/for \(const name of \["maw-js", "maw", "@maw-js"\]\)/);
+  it("#950: node_modules eviction covers maw-js, maw, and @maw-js", () => {
+    // maw-js is the package the `~/.bun/bin/maw` symlink resolves through, so
+    // it is moved aside by RENAME (recoverable for the restore path) rather
+    // than rm'd — see the stash-restore invariant test. `maw` and `@maw-js`
+    // carry nothing the bin symlink needs, so they are still rm'd outright.
+    expect(src).toMatch(/renameSync\(join\(NM, "maw-js"\), PKG_STASH\)/);
+    expect(src).toMatch(/for \(const name of \["maw", "@maw-js"\]\)/);
   });
 });

--- a/test/isolated/elysia-auth-global-scope.test.ts
+++ b/test/isolated/elysia-auth-global-scope.test.ts
@@ -1,0 +1,189 @@
+/**
+ * elysia-auth-global-scope.test.ts — regression for maw-stress findings #1 + #3.
+ *
+ * #1 (CRITICAL) — `federationAuth` was a bare `new Elysia(...).onBeforeHandle(...)`
+ *   with no `.as('global')`. In Elysia 1.4 a named plugin's lifecycle hook is
+ *   `local`-scoped: it guards only routes defined on that same instance.
+ *   `federationAuth` defines ZERO routes, so the hook guarded nothing — every
+ *   protected write endpoint (`/api/send`, …) accepted unsigned non-loopback
+ *   requests. maw-stress revalidation confirmed this empirically.
+ *   Fix: `.as('global')` so the hook propagates to sibling route modules.
+ *
+ * #3 (HIGH) — `federationAuth` did `if (!token) return;` at the top — fail-OPEN.
+ *   A node with peers configured binds 0.0.0.0 and is network-reachable, so
+ *   "no token" there is default-insecure-open. Fix: fail-closed — no token +
+ *   peers configured + !allowPeersWithoutToken ⇒ 401.
+ *
+ * Isolated: mocks `src/config` (mock.module is process-global) and mutates
+ * the bun-server reference via setBunServer.
+ */
+import { describe, test, expect, mock, beforeAll, afterEach } from "bun:test";
+import { join } from "path";
+import { Elysia } from "elysia";
+import type { MawConfig } from "../../src/config";
+
+const root = join(import.meta.dir, "../..");
+
+// Mutable config state — the auth hook calls loadConfig() fresh per request,
+// so each test can dial in the federation posture it needs.
+const TOKEN = "test-federation-token-min-16-chars";
+let configState: Partial<MawConfig> = { node: "test-node", federationToken: TOKEN };
+
+mock.module(join(root, "src/config"), () => {
+  const { mockConfigModule } = require("../helpers/mock-config");
+  return mockConfigModule(() => configState);
+});
+
+let federationAuth: typeof import("../../src/lib/elysia-auth").federationAuth;
+let setBunServer: typeof import("../../src/lib/elysia-auth").setBunServer;
+let sign: typeof import("../../src/lib/federation-auth").sign;
+
+const NON_LOOPBACK_IP = "168.144.97.69";
+
+/** Mount federationAuth + a protected route as SEPARATE plugin instances —
+ *  this mirrors src/api/index.ts (`.use(federationAuth).use(sessionsApi)`)
+ *  and is exactly the topology the `.as('global')` fix has to cover. */
+function buildApp(): Elysia {
+  const protectedRoutes = new Elysia()
+    .post("/send", () => ({ ok: true }))
+    .get("/sessions", () => ({ ok: true }));
+  return new Elysia({ prefix: "/api" }).use(federationAuth).use(protectedRoutes);
+}
+
+/** Point setBunServer at a fake server reporting the given client IP. */
+function setClientIp(address: string): void {
+  setBunServer({ requestIP: () => ({ address }) } as unknown as import("bun").Server);
+}
+
+beforeAll(async () => {
+  const mod = await import("../../src/lib/elysia-auth");
+  federationAuth = mod.federationAuth;
+  setBunServer = mod.setBunServer;
+  sign = (await import("../../src/lib/federation-auth")).sign;
+});
+
+afterEach(() => {
+  configState = { node: "test-node", federationToken: TOKEN };
+});
+
+describe("federationAuth — global scope (#1)", () => {
+  test("REGRESSION: unsigned non-loopback POST /api/send → 401 (hook must guard sibling routes)", async () => {
+    setClientIp(NON_LOOPBACK_IP);
+    const res = await buildApp().handle(
+      new Request("http://localhost/api/send", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ target: "x", text: "y" }),
+      }),
+    );
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.reason).toBe("missing_signature");
+  });
+
+  test("signed non-loopback POST /api/send → reaches handler (200)", async () => {
+    setClientIp(NON_LOOPBACK_IP);
+    const ts = Math.floor(Date.now() / 1000);
+    const sig = sign(TOKEN, "POST", "/api/send", ts);
+    const res = await buildApp().handle(
+      new Request("http://localhost/api/send", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-maw-signature": sig,
+          "x-maw-timestamp": String(ts),
+        },
+        body: JSON.stringify({ target: "x", text: "y" }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json()).ok).toBe(true);
+  });
+
+  test("loopback unsigned POST /api/send → bypass (local CLI exemption preserved)", async () => {
+    setClientIp("127.0.0.1");
+    const res = await buildApp().handle(
+      new Request("http://localhost/api/send", { method: "POST", body: "{}" }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  test("non-protected GET /api/sessions → public even unsigned from non-loopback", async () => {
+    setClientIp(NON_LOOPBACK_IP);
+    const res = await buildApp().handle(
+      new Request("http://localhost/api/sessions", { method: "GET" }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  test("bad signature non-loopback → 401 (hook actually inspects the sig)", async () => {
+    setClientIp(NON_LOOPBACK_IP);
+    const res = await buildApp().handle(
+      new Request("http://localhost/api/send", {
+        method: "POST",
+        headers: {
+          "x-maw-signature": "deadbeef".repeat(8),
+          "x-maw-timestamp": String(Math.floor(Date.now() / 1000)),
+        },
+        body: "{}",
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("federationAuth — fail-closed when peers configured but no token (#3)", () => {
+  test("REGRESSION: no token + peers configured + non-loopback → 401 (was fail-open)", async () => {
+    configState = { node: "test-node", peers: ["http://peer-a.example"] };
+    setClientIp(NON_LOOPBACK_IP);
+    const res = await buildApp().handle(
+      new Request("http://localhost/api/send", { method: "POST", body: "{}" }),
+    );
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.reason).toBe("federation_token_required");
+  });
+
+  test("no token + namedPeers configured + non-loopback → 401", async () => {
+    configState = {
+      node: "test-node",
+      namedPeers: [{ name: "peer-a", url: "http://peer-a.example" }],
+    };
+    setClientIp(NON_LOOPBACK_IP);
+    const res = await buildApp().handle(
+      new Request("http://localhost/api/send", { method: "POST", body: "{}" }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("no token + peers + allowPeersWithoutToken:true → explicit opt-in bypass", async () => {
+    configState = {
+      node: "test-node",
+      peers: ["http://peer-a.example"],
+      allowPeersWithoutToken: true,
+    };
+    setClientIp(NON_LOOPBACK_IP);
+    const res = await buildApp().handle(
+      new Request("http://localhost/api/send", { method: "POST", body: "{}" }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  test("no token + NO peers + non-loopback → pass (single-node backwards compat)", async () => {
+    configState = { node: "test-node" };
+    setClientIp(NON_LOOPBACK_IP);
+    const res = await buildApp().handle(
+      new Request("http://localhost/api/send", { method: "POST", body: "{}" }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  test("no token + peers + loopback → pass (fail-closed only gates non-loopback)", async () => {
+    configState = { node: "test-node", peers: ["http://peer-a.example"] };
+    setClientIp("127.0.0.1");
+    const res = await buildApp().handle(
+      new Request("http://localhost/api/send", { method: "POST", body: "{}" }),
+    );
+    expect(res.status).toBe(200);
+  });
+});

--- a/test/isolated/is-agent-command-config.test.ts
+++ b/test/isolated/is-agent-command-config.test.ts
@@ -1,0 +1,59 @@
+/**
+ * is-agent-command-config.test.ts — #10, config.commands branch.
+ *
+ * isAgentCommand also matches panes whose command equals a binary from
+ * `config.commands`. That match used a loose `.includes()` substring, so a
+ * configured `node`-launched agent made every `nodemon` / `node-*` pane look
+ * like an agent. #10 tightens it to an exact (whole-name) comparison.
+ *
+ * Isolated: mocks src/config (mock.module is process-global) so the
+ * config.commands map is controllable. The plain-name regex branch is
+ * covered without mocks in test/is-agent-command.test.ts.
+ */
+import { describe, test, expect, beforeAll, mock } from "bun:test";
+import { join } from "path";
+
+const root = join(import.meta.dir, "../..");
+
+mock.module(join(root, "src/config"), () => {
+  const { mockConfigModule } = require("../helpers/mock-config");
+  return mockConfigModule(() => ({
+    node: "test-node",
+    commands: {
+      // bin tokens: "myagent", "node", "default" (the "default" key's value
+      // is intentionally the literal string the loop skips on)
+      primary: "myagent --run --flag",
+      secondary: "node /opt/agent/index.js",
+      default: "default",
+    },
+  }));
+});
+
+let isAgentCommand: typeof import("../../src/core/transport/ssh").isAgentCommand;
+
+beforeAll(async () => {
+  isAgentCommand = (await import("../../src/core/transport/ssh")).isAgentCommand;
+});
+
+describe("isAgentCommand — config.commands exact match (#10)", () => {
+  test("matches a configured binary by exact command name", () => {
+    expect(isAgentCommand("myagent")).toBe(true);
+  });
+
+  test("does NOT match commands that merely contain a configured binary name", () => {
+    expect(isAgentCommand("myagentx")).toBe(false);
+    expect(isAgentCommand("xmyagent")).toBe(false);
+    expect(isAgentCommand("my-myagent-wrapper")).toBe(false);
+  });
+
+  test("a configured `node`-launched agent does not make nodemon look like an agent", () => {
+    // "node" is a configured bin (secondary) AND a name-regex match — bare
+    // `node` is an agent, but `nodemon` must not inherit that.
+    expect(isAgentCommand("node")).toBe(true);
+    expect(isAgentCommand("nodemon")).toBe(false);
+  });
+
+  test("the literal 'default' key value is still skipped", () => {
+    expect(isAgentCommand("default")).toBe(false);
+  });
+});

--- a/test/isolated/update-stash-restore.test.ts
+++ b/test/isolated/update-stash-restore.test.ts
@@ -109,17 +109,23 @@ describe("cmd-update stash+restore — source invariants (#551)", () => {
     );
   });
 
-  // ── Case 5: retry success → stash cleaned up ──────────────────────────
-  it("case 5 — retry success (installCode === 0) unlinks STASH", () => {
+  // ── Case 5: retry success → stash cleaned up only AFTER verify ────────
+  it("case 5 — retry success unlinks STASH only after the fresh binary verifies", () => {
+    // Restructured (crash-loop fix): the success branch is now `else { ... }`,
+    // and the stash is discarded only inside the `freshOk` (verified-working)
+    // sub-branch — never rotate away the old binary until the new one runs.
     expect(cmdUpdateSrc).toMatch(
-      /else if\s*\(\s*installCode\s*===\s*0\s*&&\s*stashed\s*&&\s*existsSync\(STASH\)\s*\)\s*\{[\s\S]*?unlinkSync\(STASH\)/,
+      /const\s+freshOk\s*=\s*\(await\s+verify\.exited\)\s*===\s*0\s*;[\s\S]*?else\s*\{[\s\S]*?unlinkSync\(STASH\)/,
     );
   });
 
-  // ── Case 6: retry fails → restore + warn ──────────────────────────────
-  it("case 6 — retry failure restores STASH → BIN and warns", () => {
+  // ── Case 6: retry fails → restore pkg dir + bin, warn ─────────────────
+  it("case 6 — retry failure restores the package dir then STASH → BIN and warns", () => {
+    // Restructured (crash-loop fix): guard is now plain `if (installCode !== 0)`;
+    // restorePkgStash() runs FIRST so the stashed bin symlink resolves again,
+    // THEN the bin is moved back.
     expect(cmdUpdateSrc).toMatch(
-      /if\s*\(\s*installCode\s*!==\s*0\s*&&\s*stashed\s*&&\s*existsSync\(STASH\)\s*\)\s*\{[\s\S]*?renameSync\(STASH\s*,\s*BIN\)/,
+      /if\s*\(\s*installCode\s*!==\s*0\s*\)\s*\{[\s\S]*?restorePkgStash\(\)\s*;[\s\S]*?renameSync\(STASH\s*,\s*BIN\)/,
     );
     expect(cmdUpdateSrc).toContain("restored previous maw binary from stash");
   });
@@ -128,6 +134,29 @@ describe("cmd-update stash+restore — source invariants (#551)", () => {
     // If the restore rename itself throws, we still surface the error so the user
     // knows manual recovery is needed.
     expect(cmdUpdateSrc).toMatch(/failed to restore stash/);
+  });
+
+  // ── Case 8: maw-js package dir is stashed by RENAME, not rm ───────────
+  it("case 8 — maw-js node_modules dir is stashed by rename (recoverable), not rm'd", () => {
+    // The crash-loop root cause: rm'ing node_modules/maw-js orphaned the
+    // stashed bin symlink, so existsSync(STASH) reported false and the
+    // restore silently no-op'd — leaving NO working maw. Now the dir is
+    // moved aside by rename so the restore path can put a *working* install
+    // back (bin symlink + the package it resolves through).
+    expect(cmdUpdateSrc).toMatch(
+      /renameSync\(join\(NM,\s*"maw-js"\),\s*PKG_STASH\)\s*;\s*pkgStashed\s*=\s*true/,
+    );
+    // maw-js must NOT be in the outright-rm loop anymore
+    expect(cmdUpdateSrc).not.toMatch(/for \(const name of \["maw-js",/);
+  });
+
+  // ── Case 9: verify-before-discard — rollback on broken "success" ──────
+  it("case 9 — a 'successful' install whose binary does not run is rolled back", () => {
+    // installCode === 0 is necessary but not sufficient: if `maw --version`
+    // does not exit 0, restore the stash and fall into the error path.
+    expect(cmdUpdateSrc).toMatch(
+      /if\s*\(\s*!freshOk\s*\)\s*\{[\s\S]*?restorePkgStash\(\)[\s\S]*?installCode\s*=\s*1\s*;/,
+    );
   });
 
   // ── Case 7: rename throws → best-effort, doesn't block retry ──────────

--- a/test/isolated/wake-concurrency.test.ts
+++ b/test/isolated/wake-concurrency.test.ts
@@ -1,0 +1,122 @@
+/**
+ * wake-concurrency.test.ts — regression for maw-stress finding #2.
+ *
+ * `cmdWake` had no count / queue / cap — nothing stopped a script or a
+ * runaway orchestrator from spawning agents until the box fell over.
+ * `src/commands/shared/wake-concurrency.ts` adds an opt-in cap
+ * (`limits.maxConcurrentAgents`); `cmdWake` calls `assertAgentCapacity`
+ * before every net-new spawn.
+ *
+ * Isolated: installs the tmux mock + a config mock (both mock.module, which
+ * is process-global). Pure decision logic (`checkCapacity`) is also pinned
+ * here — it needs no mocks but lives with its siblings.
+ */
+import { describe, test, expect, beforeAll, afterEach, mock } from "bun:test";
+import { join } from "path";
+import { installTmuxMock, setPanes, getCapturedCommands, resetMocks } from "../helpers/mock-tmux";
+
+const root = join(import.meta.dir, "../..");
+
+// Controllable cap value — assertAgentCapacity reads it via cfgLimit().
+let capValue = 0;
+
+// tmux mock first, then config mock — both mock.module, registered before the
+// dynamic import in beforeAll so wake-concurrency.ts resolves to the shims.
+installTmuxMock({ sessions: [] });
+
+mock.module(join(root, "src/config"), () => {
+  const { mockConfigModule } = require("../helpers/mock-config");
+  const base = mockConfigModule(() => ({ node: "test-node", commands: {} }));
+  return {
+    ...base,
+    cfgLimit: (k: string) =>
+      k === "maxConcurrentAgents" ? capValue : base.cfgLimit(k),
+  };
+});
+
+let checkCapacity: typeof import("../../src/commands/shared/wake-concurrency").checkCapacity;
+let countLiveAgents: typeof import("../../src/commands/shared/wake-concurrency").countLiveAgents;
+let assertAgentCapacity: typeof import("../../src/commands/shared/wake-concurrency").assertAgentCapacity;
+
+beforeAll(async () => {
+  const mod = await import("../../src/commands/shared/wake-concurrency");
+  checkCapacity = mod.checkCapacity;
+  countLiveAgents = mod.countLiveAgents;
+  assertAgentCapacity = mod.assertAgentCapacity;
+});
+
+afterEach(() => {
+  resetMocks();
+  capValue = 0;
+});
+
+describe("checkCapacity — pure cap decision (#2)", () => {
+  test("cap 0 / negative → disabled, never throws", () => {
+    expect(() => checkCapacity(999, 0, "x")).not.toThrow();
+    expect(() => checkCapacity(999, -1, "x")).not.toThrow();
+  });
+
+  test("under cap → no throw", () => {
+    expect(() => checkCapacity(3, 5, "neo")).not.toThrow();
+  });
+
+  test("at cap → throws (over-cap path)", () => {
+    expect(() => checkCapacity(5, 5, "neo")).toThrow(/5\/5/);
+    expect(() => checkCapacity(5, 5, "neo")).toThrow(/refusing to spawn 'neo'/);
+  });
+
+  test("over cap → throws", () => {
+    expect(() => checkCapacity(8, 5, "pulse")).toThrow(/8\/5/);
+  });
+
+  test("error message is actionable — names the config knob", () => {
+    expect(() => checkCapacity(5, 5, "neo")).toThrow(/maxConcurrentAgents/);
+  });
+});
+
+describe("countLiveAgents — counts agent panes across the fleet", () => {
+  test("counts only agent-process panes (claude / node), ignores shells", async () => {
+    setPanes([
+      { command: "claude" },
+      { command: "node" },
+      { command: "zsh" },
+      { command: "bash" },
+      { command: "claude" },
+    ]);
+    expect(await countLiveAgents()).toBe(3);
+  });
+
+  test("no panes → 0", async () => {
+    setPanes([]);
+    expect(await countLiveAgents()).toBe(0);
+  });
+});
+
+describe("assertAgentCapacity — the guard cmdWake calls before spawning", () => {
+  test("disabled (cap 0) → no throw, and does NOT even query tmux", async () => {
+    capValue = 0;
+    setPanes([{ command: "claude" }, { command: "claude" }, { command: "claude" }]);
+    await assertAgentCapacity("neo");
+    // fast-path: disabled cap must skip the list-panes call entirely
+    expect(getCapturedCommands().some(c => c.includes("list-panes"))).toBe(false);
+  });
+
+  test("under cap → resolves", async () => {
+    capValue = 5;
+    setPanes([{ command: "claude" }, { command: "node" }]);
+    await assertAgentCapacity("neo");
+    expect(getCapturedCommands().some(c => c.includes("list-panes"))).toBe(true);
+  });
+
+  test("at/over cap → rejects loudly", async () => {
+    capValue = 2;
+    setPanes([{ command: "claude" }, { command: "claude" }, { command: "node" }]);
+    await expect(assertAgentCapacity("neo")).rejects.toThrow(/concurrency cap reached: 3\/2/);
+  });
+
+  test("exactly at cap → rejects (cap is inclusive)", async () => {
+    capValue = 2;
+    setPanes([{ command: "claude" }, { command: "claude" }]);
+    await expect(assertAgentCapacity("pulse")).rejects.toThrow(/2\/2/);
+  });
+});

--- a/test/tmux-sendtext-submit.test.ts
+++ b/test/tmux-sendtext-submit.test.ts
@@ -1,0 +1,132 @@
+/**
+ * tmux-sendtext-submit.test.ts — regression for maw-stress finding #6.
+ *
+ * Tmux.sendText used to fire 3 blind `Enter` keys on a fixed ~1.9s schedule
+ * with zero feedback. When the pane wasn't ready as they landed, every Enter
+ * missed and the command sat in the input box unexecuted — this forced
+ * brain to manually re-launch dispatches on 2026-05-14.
+ *
+ * The fix: send Enter, re-inspect the pane, retry only while the input line
+ * still holds un-submitted content (capped at MAX_SUBMIT_ATTEMPTS).
+ *
+ * Strategy: subclass Tmux and override the low-level primitives so we can
+ * script the pane's capture output and assert the exact key sequence — no
+ * tmux process, no module mock (safe for the main suite).
+ */
+import { describe, test, expect } from "bun:test";
+import { Tmux } from "../src/core/transport/tmux-class";
+
+/** Tmux with the tmux-touching primitives stubbed + a scripted capture feed. */
+class FakeTmux extends Tmux {
+  calls: string[] = [];
+  /** Successive return values for capture(); last value repeats once exhausted. */
+  captureScript: string[] = [];
+  private captureIdx = 0;
+
+  constructor() {
+    super(undefined, ""); // no socket — overridden methods never hit hostExec
+  }
+
+  async capture(_target: string, _lines = 80): Promise<string> {
+    this.calls.push("capture");
+    const v = this.captureScript[this.captureIdx] ?? this.captureScript.at(-1) ?? "";
+    this.captureIdx++;
+    return v;
+  }
+  async sendKeys(_target: string, ...keys: string[]): Promise<void> {
+    this.calls.push(`sendKeys:${keys.join(",")}`);
+  }
+  async sendKeysLiteral(_target: string, text: string): Promise<void> {
+    this.calls.push(`sendKeysLiteral:${text}`);
+  }
+  async loadBuffer(text: string): Promise<void> {
+    this.calls.push(`loadBuffer:${text.length}`);
+  }
+  async pasteBuffer(_target: string): Promise<void> {
+    this.calls.push("pasteBuffer");
+  }
+}
+
+const PROMPT_IDLE = "agent@host:~$ "; // prompt marker + trailing space → submitted
+const PROMPT_PENDING = "agent@host:~$ unsent command text"; // input still on the line
+const enterCount = (calls: string[]) => calls.filter(c => c === "sendKeys:Enter").length;
+
+describe("Tmux.sendText — confirmed submit (#6)", () => {
+  test(
+    "single Enter when the pane clears on the first check — no blind trailing Enters",
+    async () => {
+      const t = new FakeTmux();
+      t.captureScript = [PROMPT_IDLE];
+      await t.sendText("sess:win", "hello");
+
+      expect(t.calls).toEqual(["sendKeysLiteral:hello", "sendKeys:Enter", "capture"]);
+      expect(enterCount(t.calls)).toBe(1);
+    },
+    10_000,
+  );
+
+  test(
+    "retries Enter while input is still pending, stops as soon as it clears",
+    async () => {
+      const t = new FakeTmux();
+      // pending after Enter #1 and #2, cleared after #3
+      t.captureScript = [PROMPT_PENDING, PROMPT_PENDING, PROMPT_IDLE];
+      await t.sendText("sess:win", "deploy task");
+
+      expect(enterCount(t.calls)).toBe(3);
+      // last action is the confirming capture, not another blind Enter
+      expect(t.calls.at(-1)).toBe("capture");
+    },
+    15_000,
+  );
+
+  test(
+    "stops after MAX_SUBMIT_ATTEMPTS and warns when the pane never clears",
+    async () => {
+      const t = new FakeTmux();
+      t.captureScript = [PROMPT_PENDING]; // repeats → never clears
+
+      const warnings: string[] = [];
+      const origWarn = console.warn;
+      console.warn = (...args: unknown[]) => { warnings.push(args.join(" ")); };
+      try {
+        await t.sendText("sess:win", "stuck task");
+      } finally {
+        console.warn = origWarn;
+      }
+
+      // capped — not an unbounded spin
+      expect(enterCount(t.calls)).toBe(4);
+      expect(warnings.some(w => w.includes("pending input") && w.includes("sess:win"))).toBe(true);
+    },
+    15_000,
+  );
+
+  test(
+    "multiline content routes through loadBuffer + pasteBuffer, then confirmed submit",
+    async () => {
+      const t = new FakeTmux();
+      t.captureScript = [PROMPT_IDLE];
+      await t.sendText("sess:win", "line one\nline two");
+
+      expect(t.calls[0]).toBe(`loadBuffer:${"line one\nline two".length}`);
+      expect(t.calls[1]).toBe("pasteBuffer");
+      expect(t.calls).not.toContain("sendKeysLiteral:line one\nline two");
+      expect(enterCount(t.calls)).toBe(1);
+    },
+    10_000,
+  );
+
+  test(
+    "a capture failure is treated as submitted — the retry loop cannot spin",
+    async () => {
+      const t = new FakeTmux();
+      // capture throws → paneInputPending swallows → false (assume submitted)
+      t.capture = async () => { throw new Error("tmux gone"); };
+      await t.sendText("sess:win", "hi");
+
+      expect(enterCount(t.calls)).toBe(1);
+    },
+    10_000,
+  );
+});


### PR DESCRIPTION
## maw-hardening release — 2026-05-15

Integration branch off `main` (caf038d9) bundling 5 hardening fixes. Deployed live on **sgp1** (CLI + server on this build) and verified end-to-end.

### Fixes included
| # | branch | commit | summary |
|---|--------|--------|---------|
| #1 + #3 | fix/maw-js-auth-hardening | cc14a6fa | mark federation auth hooks global + restore fail-closed |
| #6 | fix/maw-js-tmux-enter-race | eb4defb0 | confirm tmux sendText submission instead of blind Enter |
| #2 | fix/maw-js-wake-concurrency-cap | e6ea4165 | agent concurrency cap in cmdWake |
| #10 | fix/maw-js-isagentcommand-tighten | 6020b78b | tighten isAgentCommand — match node/configured bins exactly |
| — | (this branch) | 699e5732 | **fix(update): never leave the system without a working maw** |

### The crash-loop fix (699e5732)
Two root causes behind full maw-install wipes observed 2026-05-14/15:
1. **Test pollution** — `test/cmd-update-ref-validation.test.ts` spawned real `maw update <ref> --yes` against the real `~/.bun/bin/maw`; runUpdate has no sandbox seam, so every `bun test` run wiped the dev's install. Fixed with a `MAW_TEST_MODE` guard that stops runUpdate right before the destructive ops (help/REF_RE/channel/confirmation still exercised).
2. **Dangling-stash restore-skip** — on a failed `bun add -g`, the fallback stashed the bin symlink then `rm`'d `node_modules/maw-js`, orphaning the stash; `existsSync(.prev)` then reported false and the restore silently no-op'd. Fixed by stashing the package dir via rename (recoverable), restoring it before the bin, and verifying `maw --version` runs before discarding the stash.

### Verification
- `bun test`: 1172 pass / 0 fail (pre-existing plugin-manifest wasm-timeout flake did not recur); +8 net new passing tests vs `main`.
- `bun run build`: clean → `dist/maw` v26.5.2.
- Live test dispatch on sgp1 (`maw wake … -p …`): full command submitted cleanly, no Enter-race — #6 proving itself.
- Source-contract tests (`cmd-update-order`, `update-stash-restore`) updated + 2 new cases for the rename-stash / verify-before-discard invariants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)