### PR TITLE
fix(ci): bun build needs --outfile to fix 'multiple output files' error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build CLI
-        run: bun build --target=bun src/cli.ts --outfile dist/maw
+        run: bun build src/cli.ts --outfile dist/maw --target=bun --minify --external @eclipse-zenoh/zenoh-ts
 
       - name: Validate plugin manifests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build CLI
-        run: bun build --target=bun src/cli.ts
+        run: bun build --target=bun src/cli.ts --outfile dist/maw
 
       - name: Validate plugin manifests
         run: |


### PR DESCRIPTION
## Summary
Build job in CI fails with:
\`\`\`
error: cannot write multiple output files without an output directory
\`\`\`

bun build now generates multiple chunks for the CLI entry, so \`--outfile dist/maw\` is required.

## Test plan
- [x] CI build job passes with this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)