### PR TITLE
fix(ci): align Build CLI step with package.json (--external zenoh)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build CLI
-        run: bun build --target=bun src/cli.ts
+        run: bun build src/cli.ts --outfile dist/maw --target=bun --minify --external @eclipse-zenoh/zenoh-ts
 
       - name: Validate plugin manifests
         run: |


### PR DESCRIPTION
## Summary
Build was failing on CI with \`cannot write multiple output files without an output directory\`. The fix needs ALL the flags from package.json's \`build\` script, especially \`--external @eclipse-zenoh/zenoh-ts\`.

\`\`\`diff
- run: bun build --target=bun src/cli.ts
+ run: bun build src/cli.ts --outfile dist/maw --target=bun --minify --external @eclipse-zenoh/zenoh-ts
\`\`\`

Supersedes #1390 (fresh branch from current main).