### PR TITLE
release: v26.5.15-alpha.1252

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.15-alpha.815",
+  "version": "26.5.15-alpha.1252",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/test/helpers/mock-config.ts
+++ b/test/helpers/mock-config.ts
@@ -7,10 +7,7 @@
  * @target-module src/config.ts
  * (Checked by scripts/check-mock-export-sync.sh — #435)
  */
-import type { MawConfig, MawIntervals, MawTimeouts, MawLimits } from "../../src/config";
-// #1126 — Use real buildCommand. The stub returning "echo test" was clobbering
-// command-simplified.test.ts when it ran after any test mocking '../src/config'.
-import { buildCommand as realBuildCommand, buildCommandInDir as realBuildCommandInDir } from "../../src/config/command";
+import type { MawConfig, MawIntervals, MawTimeouts, MawLimits } from "../../src/config/types";
 
 const INTERVALS: Record<keyof MawIntervals, number> = {
   capture: 50, sessions: 5000, status: 3000, teams: 3000,
@@ -29,6 +26,11 @@ const LIMITS: Record<keyof MawLimits, number> = {
   maxConcurrentAgents: 0,
 };
 
+function commandFrom(loadConfig: () => Partial<MawConfig>, agentName: string, engine?: string): string {
+  const commands = loadConfig().commands || {};
+  return (engine && commands[engine]) || commands[agentName] || commands.default || "claude";
+}
+
 export const TEST_D = {
   intervals: INTERVALS,
   timeouts: TIMEOUTS,
@@ -44,8 +46,10 @@ export function mockConfigModule(loadConfig: () => Partial<MawConfig>) {
     saveConfig: () => {},
     validateConfigShape: (c: any) => c,
     configForDisplay: () => ({}),
-    buildCommand: realBuildCommand,
-    buildCommandInDir: realBuildCommandInDir,
+    buildCommand: (agentName: string, engine?: string) => commandFrom(loadConfig, agentName, engine),
+    buildCommandInDir: (agentName: string, _cwd: string, engine?: string) => commandFrom(loadConfig, agentName, engine),
+    buildShellFunction: (agentName: string, engine?: string) => commandFrom(loadConfig, agentName, engine),
+    writeSessionScript: (agentName: string) => `/tmp/maw-${agentName}.sh`,
     getEnvVars: () => ({}),
     D: TEST_D,
     cfgInterval: (k: keyof MawIntervals) => INTERVALS[k],


### PR DESCRIPTION
Cuts v26.5.15-alpha.1252 on merge via calver-release.yml.\n\nIncludes main fixes: #1382, #1387, #1391.\n\nWritten by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.