### PR TITLE
fix(tile): keep incremental layout based on total panes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ ui/office/assets/
 
 # psi/ — ASCII alias of ψ/ vault runtime data (#451)
 psi/
+
+# Local Codex/OMX runtime state
+.omx/

--- a/src/commands/plugins/tile/impl.ts
+++ b/src/commands/plugins/tile/impl.ts
@@ -110,11 +110,14 @@ export async function cmdTile(count: number, opts: TileOpts = {}): Promise<void>
     console.log(`  \x1b[${colorAnsi(color)}m●\x1b[0m ${label} → ${paneId}${extras ? "  " + extras : ""}`);
   }
 
-  // Layout: 1 tile = left|right, 2-3 tiles = lead full-left + tiles stacked right,
-  // 4+ = even grid
-  if (count === 1) {
+  // Layout decision uses TOTAL pane count (lead + all tiles), not just new spawns.
+  // 2 panes = lead | tile (even split), 3-4 = main-vertical (lead-left, tiles-right),
+  // 5+ = tiled grid. (#1394)
+  const paneCountRaw = (await hostExec(`tmux list-panes -t '${window}' | wc -l`)).trim();
+  const totalPanes = parseInt(paneCountRaw, 10) || (count + 1);
+  if (totalPanes === 2) {
     await hostExec(`tmux select-layout -t '${window}' even-horizontal`);
-  } else if (count <= 3) {
+  } else if (totalPanes <= 4) {
     await hostExec(`tmux select-layout -t '${window}' main-vertical`);
   } else {
     await applyTiledLayout(window);

--- a/test/isolated/tile.test.ts
+++ b/test/isolated/tile.test.ts
@@ -54,10 +54,30 @@ describe("tile plugin layout", () => {
     expect(commands).not.toContain("tmux select-layout -t '@win' main-vertical");
   });
 
+  test("incremental tile spawn chooses layout from total panes, not new spawn count", async () => {
+    paneList = "4\n";
+
+    await cmdTile(1);
+
+    expect(commands).toContain("tmux list-panes -t '@win' | wc -l");
+    expect(commands).toContain("tmux select-layout -t '@win' main-vertical");
+    expect(commands).not.toContain("tmux select-layout -t '@win' even-horizontal");
+  });
+
   test("four or more spawned tiles use the tiled grid", async () => {
     await cmdTile(4);
 
     expect(commands).toContain("tmux select-layout -t '@win' tiled");
+    expect(commands).not.toContain("tmux select-layout -t '@win' main-vertical");
+  });
+
+  test("incremental tile spawn switches to tiled grid once total pane count exceeds four", async () => {
+    paneList = "5\n";
+
+    await cmdTile(1);
+
+    expect(commands).toContain("tmux select-layout -t '@win' tiled");
+    expect(commands).not.toContain("tmux select-layout -t '@win' even-horizontal");
     expect(commands).not.toContain("tmux select-layout -t '@win' main-vertical");
   });
 });


### PR DESCRIPTION
## Summary
- fix tile layout selection to use total panes after spawn, not just current spawn count
- add isolated regressions for incremental `maw tile 1` with 4/5 total panes
- ignore local `.omx/` runtime state created during Codex/OMX sessions

Fixes #1394.

## Test
- `rtk bun test test/isolated/tile.test.ts`

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.