### PR TITLE
feat(cli): maw bring — alias for wake --split (#1395)

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -45,6 +45,7 @@ export const ALIAS_DESCRIPTIONS: Record<string, string> = {
   panes: "List all panes across sessions",
   cleanup: "Kill zombie agent panes",
   tile: "Tile current window or spawn N panes tiled",
+  bring: "Bring an oracle HERE (split pane) — symmetric with `a` (go there)",
   ls: "List sessions (compact, -a roster, -v detail)",
   wake: "Wake an oracle session (fuzzy match, auto-clone)",
   preflight: "Pre-flight check — version, plugins, dead agents, config",
@@ -64,6 +65,7 @@ export const TOP_ALIASES: Record<string, string[] | DirectHandler> = {
   panes: ["tmux", "ls", "--all", "--verbose"],
   cleanup: ["team", "cleanup", "--zombie-agents"],
   tile: ["tile"],
+  bring: ["wake", "--split"],
 
   // Direct-handler form — `ls` flags differ from tmux ls:
   //   maw ls      → compact, live sessions only


### PR DESCRIPTION
## Summary

Adds \`maw bring <oracle>\` as a top-level alias for \`maw wake <oracle> --split\`.

\`\`\`diff
+ bring: "Bring an oracle HERE (split pane) — symmetric with \`a\` (go there)",
+ bring: ["wake", "--split"],
\`\`\`

## Mental model

- \`maw a <oracle>\`     → "**go there**" (switches client to oracle's session — destructive to current layout)
- \`maw bring <oracle>\` → "**come here**" (splits current pane, wakes oracle in the split — non-destructive)

## Implementation

Pure argv-rewrite alias. Zero new code paths. \`wake --split\` already does the work.

## Use case

\`\`\`bash
# You're in a tiled workspace with 3 panes already
# Want homekeeper alongside without losing layout:
maw bring homekeeper
# → new pane appears, homekeeper wakes in it, original panes untouched
\`\`\`

Closes #1395.

🤖 Generated with [Claude Code](https://claude.com/claude-code)