### PR TITLE
feat(tile): add safe pane swap verbs

### DIFF
--- a/src/commands/plugins/pane/index.ts
+++ b/src/commands/plugins/pane/index.ts
@@ -1,0 +1,52 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+
+export const command = {
+  name: "pane",
+  description: "Pane workflow helpers such as swapping panes in the current tmux window.",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+
+  try {
+    if (!process.env.TMUX) {
+      console.log("\x1b[33m⚠\x1b[0m pane requires tmux");
+      return { ok: false, error: "not in tmux" };
+    }
+
+    const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+    const sub = args[0]?.toLowerCase();
+
+    if (!sub || sub === "--help" || sub === "-h") {
+      console.log("usage: maw pane swap <pane-a> <pane-b>");
+      console.log("  pane targets: index (1), pane id (%1), title prefix (tile-1), top, bottom");
+      return { ok: true, output: logs.join("\n") || undefined };
+    }
+
+    if (sub !== "swap") {
+      console.log(`unknown pane subcommand: ${sub}`);
+      console.log("usage: maw pane swap <pane-a> <pane-b>");
+      return { ok: false, error: `unknown subcommand: ${sub}`, output: logs.join("\n") };
+    }
+
+    const a = args[1];
+    const b = args[2];
+    if (!a || !b) {
+      console.log("usage: maw pane swap <pane-a> <pane-b>");
+      return { ok: false, error: "two pane targets required", output: logs.join("\n") };
+    }
+
+    const { cmdTileSwap } = await import("../tile/impl");
+    await cmdTileSwap(a, b);
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: e?.message || String(e), output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+  }
+}

--- a/src/commands/plugins/pane/plugin.json
+++ b/src/commands/plugins/pane/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "pane",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Pane workflow helpers such as swapping panes in the current tmux window.",
+  "cli": {
+    "command": "pane",
+    "help": "maw pane swap <a> <b> — swap panes in the current tmux window"
+  },
+  "weight": 5
+}

--- a/src/commands/plugins/tile/impl.ts
+++ b/src/commands/plugins/tile/impl.ts
@@ -5,6 +5,10 @@ import {
 import { hostExec } from "../../../sdk";
 import { withPaneLock } from "../../../core/transport/tmux-pane-lock";
 
+function shellArg(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
 async function getWindow(): Promise<string> {
   const pane = process.env.TMUX_PANE;
   if (pane) {
@@ -183,4 +187,54 @@ export async function cmdTileClean(): Promise<void> {
   } else {
     console.log(`\x1b[32m✓\x1b[0m cleaned ${killed} tiles`);
   }
+}
+
+type PaneRow = {
+  index: string;
+  paneId: string;
+  title: string;
+  top: number;
+};
+
+async function listPaneRows(window: string): Promise<PaneRow[]> {
+  const raw = await hostExec(
+    `tmux list-panes -t '${window}' -F '#{pane_index}|||#{pane_id}|||#{pane_title}|||#{pane_top}'`,
+  );
+  return raw.split("\n").filter(Boolean).map((line) => {
+    const [index = "", paneId = "", title = "", topRaw = "0"] = line.split("|||");
+    return { index, paneId, title, top: parseInt(topRaw, 10) || 0 };
+  }).filter(row => row.paneId);
+}
+
+function resolveSwapPane(spec: string, rows: PaneRow[]): PaneRow | null {
+  const normalized = spec.trim();
+  if (!normalized) return null;
+
+  if (normalized === "top") {
+    return [...rows].sort((a, b) => a.top - b.top || parseInt(a.index, 10) - parseInt(b.index, 10))[0] ?? null;
+  }
+  if (normalized === "bottom") {
+    return [...rows].sort((a, b) => b.top - a.top || parseInt(b.index, 10) - parseInt(a.index, 10))[0] ?? null;
+  }
+  if (normalized.startsWith("%")) {
+    return rows.find(row => row.paneId === normalized) ?? { index: "", paneId: normalized, title: normalized, top: 0 };
+  }
+  if (/^\d+$/.test(normalized)) {
+    return rows.find(row => row.index === normalized) ?? null;
+  }
+  return rows.find(row => row.title === normalized || row.title.startsWith(normalized)) ?? null;
+}
+
+export async function cmdTileSwap(a: string, b: string): Promise<void> {
+  const window = await getWindow();
+  const rows = await listPaneRows(window);
+  const source = resolveSwapPane(a, rows);
+  const target = resolveSwapPane(b, rows);
+
+  if (!source) throw new Error(`tile swap: could not resolve pane '${a}'`);
+  if (!target) throw new Error(`tile swap: could not resolve pane '${b}'`);
+  if (source.paneId === target.paneId) throw new Error("tile swap: source and target are the same pane");
+
+  await hostExec(`tmux swap-pane -s ${shellArg(source.paneId)} -t ${shellArg(target.paneId)}`);
+  console.log(`\x1b[32m✓\x1b[0m swapped ${source.title || source.paneId} ↔ ${target.title || target.paneId}`);
 }

--- a/src/commands/plugins/tile/index.ts
+++ b/src/commands/plugins/tile/index.ts
@@ -30,12 +30,15 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     if (flags["--help"]) {
       console.log("usage: maw tile [N] [--wt] [--engine <name>]");
       console.log("       maw tile clean");
+      console.log("       maw tile swap <a> <b>");
       console.log("");
       console.log("  maw tile              apply tiled layout to current window");
       console.log("  maw tile 3            spawn 3 empty panes and tile them");
       console.log("  maw tile 3 --wt       spawn 3 worktree-backed panes, each with own branch");
       console.log("  maw tile 3 -e claude  spawn 3 panes running claude, tiled");
       console.log("  maw tile clean        kill tile panes + remove tile worktrees");
+      console.log("  maw tile swap 1 2     swap pane indices in the current window");
+      console.log("  maw tile swap top bottom | tile-1 tile-2 | %1 %2");
       return { ok: true, output: logs.join("\n") };
     }
 
@@ -44,6 +47,18 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     if (positional[0] === "clean") {
       const { cmdTileClean } = await import("./impl");
       await cmdTileClean();
+      return { ok: true, output: logs.join("\n") || undefined };
+    }
+
+    if (positional[0] === "swap") {
+      const a = positional[1];
+      const b = positional[2];
+      if (!a || !b) {
+        console.log("usage: maw tile swap <pane-a> <pane-b>");
+        return { ok: false, error: "two pane targets required", output: logs.join("\n") };
+      }
+      const { cmdTileSwap } = await import("./impl");
+      await cmdTileSwap(a, b);
       return { ok: true, output: logs.join("\n") || undefined };
     }
 

--- a/test/isolated/tile.test.ts
+++ b/test/isolated/tile.test.ts
@@ -27,7 +27,7 @@ mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
   },
 }));
 
-const { cmdTile, cmdTileClean } = await import("../../src/commands/plugins/tile/impl");
+const { cmdTile, cmdTileClean, cmdTileSwap } = await import("../../src/commands/plugins/tile/impl");
 
 beforeEach(() => {
   commands = [];
@@ -95,5 +95,37 @@ describe("tile clean", () => {
     expect(commands).toContain("tmux kill-pane -t '%p1'");
     expect(commands).toContain("tmux kill-pane -t '%p2'");
     expect(commands).not.toContain("tmux kill-pane -t '%lead'");
+  });
+});
+
+describe("tile swap", () => {
+  beforeEach(() => {
+    paneList = [
+      "0|||%lead|||lead|||0",
+      "1|||%p1|||tile-1|||4",
+      "2|||%p2|||tile-2 🌳|||14",
+    ].join("\n");
+  });
+
+  test("swaps panes by current-window pane index", async () => {
+    await cmdTileSwap("1", "2");
+
+    expect(commands).toContain("tmux swap-pane -s '%p1' -t '%p2'");
+  });
+
+  test("swaps panes by tile title prefix", async () => {
+    await cmdTileSwap("tile-1", "tile-2");
+
+    expect(commands).toContain("tmux swap-pane -s '%p1' -t '%p2'");
+  });
+
+  test("swaps top and bottom panes by pane_top", async () => {
+    await cmdTileSwap("top", "bottom");
+
+    expect(commands).toContain("tmux swap-pane -s '%lead' -t '%p2'");
+  });
+
+  test("rejects unresolved pane targets", async () => {
+    await expect(cmdTileSwap("missing", "tile-2")).rejects.toThrow(/could not resolve pane 'missing'/);
   });
 });


### PR DESCRIPTION
## Summary
- add `maw tile swap <a> <b>` for tile-workflow pane reordering
- add `maw pane swap <a> <b>` as the same safe wrapper from the pane surface
- resolve current-window pane targets by index, pane id, title prefix, `top`, or `bottom`

Fixes #1396.

## Test
- `rtk bun test test/isolated/tile.test.ts`
- `rtk bun build src/cli.ts --outfile /tmp/maw-pane-swap-check --target=bun --external @eclipse-zenoh/zenoh-ts`

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.