### PR TITLE
fix(cli): maw bring — direct handler so --split isn't parsed as oracle

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -45,6 +45,7 @@ export const ALIAS_DESCRIPTIONS: Record<string, string> = {
   panes: "List all panes across sessions",
   cleanup: "Kill zombie agent panes",
   tile: "Tile current window or spawn N panes tiled",
+  bring: "Bring an oracle HERE (split pane) — symmetric with `a` (go there)",
   ls: "List sessions (compact, -a roster, -v detail)",
   wake: "Wake an oracle session (fuzzy match, auto-clone)",
   preflight: "Pre-flight check — version, plugins, dead agents, config",
@@ -64,6 +65,7 @@ export const TOP_ALIASES: Record<string, string[] | DirectHandler> = {
   panes: ["tmux", "ls", "--all", "--verbose"],
   cleanup: ["team", "cleanup", "--zombie-agents"],
   tile: ["tile"],
+  bring: { kind: "direct", handler: "../commands/shared/wake-cmd:cmdBring" },
 
   // Direct-handler form — `ls` flags differ from tmux ls:
   //   maw ls      → compact, live sessions only
@@ -195,6 +197,24 @@ export async function invokeDirectHandler(
       }
     }
 
+    await cmdWake(oracle, opts);
+    return;
+  }
+
+  if (exportName === "cmdBring") {
+    // `maw bring <oracle> [-e <engine>]` — split current pane and wake oracle there.
+    const flags = parseFlags(argv, {
+      "--engine": String, "-e": "--engine",
+    }, 0);
+    const oracle = (flags._ as string[])[0];
+    if (!oracle) {
+      console.error("usage: maw bring <oracle> [-e|--engine <name>]");
+      console.error("  Splits current pane and wakes oracle there (non-destructive).");
+      console.error("  Symmetric with `maw a` (attach goes there, bring comes here).");
+      throw new UserError("bring: missing oracle name");
+    }
+    const opts: { split: true; engine?: string } = { split: true };
+    if (flags["--engine"]) opts.engine = flags["--engine"];
     await cmdWake(oracle, opts);
     return;
   }


### PR DESCRIPTION
## Problem

Previous \`bring → wake --split\` argv-rewrite alias was broken:

\`\`\`
maw bring homekeeper
→ rewrites to: [wake, --split, homekeeper]
→ wake plugin parses --split as oracle name → "Scan for --split-oracle?" ❌
\`\`\`

## Fix

Make \`bring\` a direct handler that calls \`cmdWake(oracle, { split: true })\` directly. No more argv-rewrite confusion.

\`\`\`
maw bring                        → "usage: maw bring <oracle> ..."
maw bring homekeeper             → cmdWake("homekeeper", { split: true })
maw bring homekeeper -e codex    → cmdWake("homekeeper", { split: true, engine: "codex" })
\`\`\`

## Test plan

- [x] \`maw bring\` (no args) → usage error
- [x] \`maw bring homekeeper\` → splits pane and wakes
- [x] \`maw bring homekeeper -e codex\` → splits with codex engine

Closes — follow-up to #1398 (the bug it introduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)