### PR TITLE
fix(tile): pass parent context and clean only tile panes

### DIFF
--- a/src/commands/plugins/tile/impl.ts
+++ b/src/commands/plugins/tile/impl.ts
@@ -9,6 +9,51 @@ function shellArg(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
+function envExport(assignments: Record<string, string>): string {
+  return Object.entries(assignments)
+    .map(([key, value]) => `${key}=${shellArg(value)}`)
+    .join(" ");
+}
+
+async function getParentAddress(anchor: string): Promise<string> {
+  if (!anchor) return "";
+  try {
+    return (await hostExec(
+      `tmux display-message -t '${anchor}' -p '#{session_name}:#{window_index}.#{pane_index}'`,
+    )).trim();
+  } catch {
+    return anchor;
+  }
+}
+
+async function getWindowAddress(anchor: string, window: string): Promise<string> {
+  if (!anchor) return window;
+  try {
+    return (await hostExec(
+      `tmux display-message -t '${anchor}' -p '#{session_name}:#{window_index}'`,
+    )).trim();
+  } catch {
+    return window;
+  }
+}
+
+async function listPanes(window: string, format = "#{pane_id}"): Promise<string[]> {
+  const raw = await hostExec(`tmux list-panes -t '${window}' -F '${format}'`);
+  return raw.split("\n").filter(Boolean);
+}
+
+async function countExistingTilePanes(window: string): Promise<number> {
+  try {
+    const panes = await listPanes(window, "#{pane_id}|||#{pane_title}|||#{@maw_tile}");
+    return panes.filter(line => {
+      const [, title = "", marker = ""] = line.split("|||");
+      return marker === "1" || /^tile-\d+(?: 🌳)?$/.test(title);
+    }).length;
+  } catch {
+    return 0;
+  }
+}
+
 async function getWindow(): Promise<string> {
   const pane = process.env.TMUX_PANE;
   if (pane) {
@@ -39,6 +84,10 @@ export async function cmdTile(count: number, opts: TileOpts = {}): Promise<void>
   }
 
   const anchor = process.env.TMUX_PANE ?? "";
+  const parentAddress = await getParentAddress(anchor);
+  const windowAddress = await getWindowAddress(anchor, window);
+  const existingTileCount = await countExistingTilePanes(window);
+  const finalTileTotal = existingTileCount + count;
 
   let engineCmd = "";
   if (opts.engine) {
@@ -70,7 +119,8 @@ export async function cmdTile(count: number, opts: TileOpts = {}): Promise<void>
   const paneIds: string[] = [];
 
   for (let i = 0; i < count; i++) {
-    const name = `tile-${i + 1}`;
+    const tileIndex = existingTileCount + i + 1;
+    const name = `tile-${tileIndex}`;
 
     let cwd = "";
     if (opts.wt) {
@@ -81,12 +131,20 @@ export async function cmdTile(count: number, opts: TileOpts = {}): Promise<void>
       existingWorktrees.push({ name, path: cwd });
     }
 
-    let shellCmd = "exec zsh";
+    const tileEnv = envExport({
+      MAW_TILE_PARENT: parentAddress,
+      MAW_TILE_ROLE: name,
+      MAW_TILE_INDEX: String(tileIndex),
+      MAW_TILE_TOTAL: String(finalTileTotal),
+      MAW_TILE_WINDOW: windowAddress,
+    });
+
+    let shellCmd = `export ${tileEnv}; exec zsh`;
     if (engineCmd) {
-      shellCmd = `${engineCmd.replace(/'/g, "'\\''")}; exec zsh`;
+      shellCmd = `export ${tileEnv}; ${engineCmd}; exec zsh`;
     }
     if (cwd) {
-      shellCmd = `cd '${cwd.replace(/'/g, "'\\''")}' && ${shellCmd}`;
+      shellCmd = `cd ${shellArg(cwd)} && ${shellCmd}`;
     }
 
     // Chain: split from last pane so idx order = spawn order
@@ -95,7 +153,7 @@ export async function cmdTile(count: number, opts: TileOpts = {}): Promise<void>
     let paneId = "";
     await withPaneLock(async () => {
       paneId = (await hostExec(
-        `tmux split-window ${targetFlag}-h -P -F '#{pane_id}' '${shellCmd}'`,
+        `tmux split-window ${targetFlag}-h -P -F '#{pane_id}' ${shellArg(shellCmd)}`,
       )).trim();
       await new Promise(r => setTimeout(r, 200));
     });
@@ -105,6 +163,9 @@ export async function cmdTile(count: number, opts: TileOpts = {}): Promise<void>
     const color = nextAgentColor(i);
     const label = opts.wt ? `${name} 🌳` : name;
     await stylePaneBorder(paneId, label, color);
+    await hostExec(`tmux set-option -p -t '${paneId}' @maw_tile '1'`);
+    await hostExec(`tmux set-option -p -t '${paneId}' @maw_tile_parent ${shellArg(parentAddress)}`);
+    await hostExec(`tmux set-option -p -t '${paneId}' @maw_tile_role ${shellArg(name)}`);
 
     const extras = [
       opts.wt ? `\x1b[90m${cwd}\x1b[0m` : "",
@@ -114,11 +175,10 @@ export async function cmdTile(count: number, opts: TileOpts = {}): Promise<void>
     console.log(`  \x1b[${colorAnsi(color)}m●\x1b[0m ${label} → ${paneId}${extras ? "  " + extras : ""}`);
   }
 
-  // Layout decision uses TOTAL pane count (lead + all tiles), not just new spawns.
-  // 2 panes = lead | tile (even split), 3-4 = main-vertical (lead-left, tiles-right),
-  // 5+ = tiled grid. (#1394)
-  const paneCountRaw = (await hostExec(`tmux list-panes -t '${window}' | wc -l`)).trim();
-  const totalPanes = parseInt(paneCountRaw, 10) || (count + 1);
+  const totalPanes = (await listPanes(window)).length;
+
+  // Layout by total panes after spawn: lead+1 = side-by-side, lead+2-3 =
+  // lead full-left with tiles stacked right, 5+ panes = even grid.
   if (totalPanes === 2) {
     await hostExec(`tmux select-layout -t '${window}' even-horizontal`);
   } else if (totalPanes <= 4) {
@@ -141,15 +201,15 @@ export async function cmdTileClean(): Promise<void> {
   const myPane = process.env.TMUX_PANE ?? "";
 
   const raw = await hostExec(
-    `tmux list-panes -t '${window}' -F '#{pane_id} #{pane_title}'`,
+    `tmux list-panes -t '${window}' -F '#{pane_id}|||#{pane_title}|||#{@maw_tile}'`,
   );
   const lines = raw.split("\n").filter(Boolean);
   let killed = 0;
 
   for (const line of lines) {
-    const [paneId, ...titleParts] = line.split(" ");
-    const title = titleParts.join(" ");
+    const [paneId, title = "", marker = ""] = line.split("|||");
     if (paneId === myPane) continue;
+    if (marker !== "1" && !/^tile-\d+(?: 🌳)?$/.test(title)) continue;
 
     try {
       await hostExec(`tmux kill-pane -t '${paneId}'`);

--- a/test/isolated/tile.test.ts
+++ b/test/isolated/tile.test.ts
@@ -13,13 +13,37 @@ let nextPane = 1;
 let paneList = "";
 let worktreeList = "";
 
+function generatedPaneIds(): string[] {
+  return Array.from({ length: nextPane - 1 }, (_, i) => `%p${i + 1}`);
+}
+
+function paneIdsFromPaneList(): string[] {
+  return paneList.split("\n")
+    .filter(Boolean)
+    .map(line => {
+      const parts = line.split("|||");
+      if (parts[0]?.startsWith("%")) return parts[0];
+      if (parts[1]?.startsWith("%")) return parts[1];
+      return line.split(" ")[0];
+    })
+    .filter(Boolean);
+}
+
 mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
   hostExec: async (cmd: string): Promise<string> => {
     commands.push(cmd);
 
+    if (cmd.includes("#{session_name}:#{window_index}.#{pane_index}")) return "sess:1.0\n";
+    if (cmd.includes("#{session_name}:#{window_index}")) return "sess:1\n";
     if (cmd.includes("tmux display-message")) return "@win\n";
     if (cmd.includes("tmux split-window")) return `%p${nextPane++}\n`;
-    if (cmd.includes("tmux list-panes")) return paneList;
+    if (cmd.includes("tmux list-panes") && cmd.includes("|||")) {
+      return paneList || "%lead|||lead|||\n";
+    }
+    if (cmd.includes("tmux list-panes") && cmd.includes("#{pane_id}")) {
+      const ids = paneIdsFromPaneList();
+      return [...(ids.length ? ids : ["%lead"]), ...generatedPaneIds()].join("\n") + "\n";
+    }
     if (cmd.includes("git rev-parse --show-toplevel")) return "/tmp/maw-js\n";
     if (cmd.includes("git -C '/tmp/maw-js' worktree list")) return worktreeList;
 
@@ -38,33 +62,43 @@ beforeEach(() => {
 });
 
 describe("tile plugin layout", () => {
-  test("2-3 spawned tiles use main-vertical, leaving lead pane full-height on the left", async () => {
+  test("2-3 total spawned tiles use main-vertical, leaving lead pane full-height on the left", async () => {
     await cmdTile(2);
 
-    expect(commands).toContain("tmux split-window -t '%lead' -h -P -F '#{pane_id}' 'exec zsh'");
-    expect(commands).toContain("tmux split-window -t '%p1' -h -P -F '#{pane_id}' 'exec zsh'");
+    const splitCommands = commands.filter(cmd => cmd.includes("tmux split-window"));
+    expect(splitCommands[0]).toContain("MAW_TILE_PARENT='");
+    expect(splitCommands[0]).toContain("MAW_TILE_ROLE='\\''tile-1'\\''");
+    expect(splitCommands[0]).toContain("MAW_TILE_TOTAL='\\''2'\\''");
+    expect(splitCommands[1]).toContain("MAW_TILE_ROLE='\\''tile-2'\\''");
     expect(commands).toContain("tmux select-layout -t '@win' main-vertical");
     expect(commands).not.toContain("tmux select-layout -t '@win' tiled");
   });
 
-  test("one spawned tile keeps the simple side-by-side split", async () => {
+  test("one spawned tile keeps the simple side-by-side split when it creates two total panes", async () => {
     await cmdTile(1);
 
     expect(commands).toContain("tmux select-layout -t '@win' even-horizontal");
     expect(commands).not.toContain("tmux select-layout -t '@win' main-vertical");
   });
 
-  test("incremental tile spawn chooses layout from total panes, not new spawn count", async () => {
-    paneList = "4\n";
+  test("incremental spawn selects layout from total panes after spawn, not the requested spawn count", async () => {
+    paneList = [
+      "%lead|||lead|||",
+      "%p-existing-1|||tile-1|||1",
+      "%p-existing-2|||tile-2|||1",
+    ].join("\n");
 
     await cmdTile(1);
 
-    expect(commands).toContain("tmux list-panes -t '@win' | wc -l");
+    const splitCommand = commands.find(cmd => cmd.includes("tmux split-window"));
+    expect(splitCommand).toContain("MAW_TILE_ROLE='\\''tile-3'\\''");
+    expect(splitCommand).toContain("MAW_TILE_INDEX='\\''3'\\''");
+    expect(splitCommand).toContain("MAW_TILE_TOTAL='\\''3'\\''");
     expect(commands).toContain("tmux select-layout -t '@win' main-vertical");
     expect(commands).not.toContain("tmux select-layout -t '@win' even-horizontal");
   });
 
-  test("four or more spawned tiles use the tiled grid", async () => {
+  test("five or more total panes use the tiled grid", async () => {
     await cmdTile(4);
 
     expect(commands).toContain("tmux select-layout -t '@win' tiled");
@@ -72,7 +106,12 @@ describe("tile plugin layout", () => {
   });
 
   test("incremental tile spawn switches to tiled grid once total pane count exceeds four", async () => {
-    paneList = "5\n";
+    paneList = [
+      "%lead|||lead|||",
+      "%p-existing-1|||tile-1|||1",
+      "%p-existing-2|||tile-2|||1",
+      "%p-existing-3|||tile-3|||1",
+    ].join("\n");
 
     await cmdTile(1);
 
@@ -82,18 +121,37 @@ describe("tile plugin layout", () => {
   });
 });
 
+describe("tile plugin spawn metadata", () => {
+  test("passes parent/window identity and tile role env to engine commands", async () => {
+    await cmdTile(1, { engine: "claude" });
+
+    const splitCommand = commands.find(cmd => cmd.includes("tmux split-window"));
+    expect(splitCommand).toContain("MAW_TILE_PARENT='\\''sess:1.0'\\''");
+    expect(splitCommand).toContain("MAW_TILE_ROLE='\\''tile-1'\\''");
+    expect(splitCommand).toContain("MAW_TILE_INDEX='\\''1'\\''");
+    expect(splitCommand).toContain("MAW_TILE_TOTAL='\\''1'\\''");
+    expect(splitCommand).toContain("MAW_TILE_WINDOW='\\''sess:1'\\''");
+    expect(splitCommand).toContain("; claude; exec zsh");
+    expect(commands).toContain("tmux set-option -p -t '%p1' @maw_tile '1'");
+    expect(commands).toContain("tmux set-option -p -t '%p1' @maw_tile_parent 'sess:1.0'");
+    expect(commands).toContain("tmux set-option -p -t '%p1' @maw_tile_role 'tile-1'");
+  });
+});
+
 describe("tile clean", () => {
-  test("kills every non-lead pane in the current window without trusting pane titles", async () => {
+  test("kills only panes marked or titled as tile panes in the current window", async () => {
     paneList = [
-      "%lead leader-title",
-      "%p1 overwritten-by-agent",
-      "%p2 zsh",
+      "%lead|||leader-title|||",
+      "%p1|||tile-1|||1",
+      "%p2|||zsh|||",
+      "%p3|||tile-3 🌳|||",
     ].join("\n");
 
     await cmdTileClean();
 
     expect(commands).toContain("tmux kill-pane -t '%p1'");
-    expect(commands).toContain("tmux kill-pane -t '%p2'");
+    expect(commands).toContain("tmux kill-pane -t '%p3'");
+    expect(commands).not.toContain("tmux kill-pane -t '%p2'");
     expect(commands).not.toContain("tmux kill-pane -t '%lead'");
   });
 });


### PR DESCRIPTION
## Summary
- export lightweight tile context into spawned panes: `MAW_TILE_PARENT`, `MAW_TILE_ROLE`, `MAW_TILE_INDEX`, `MAW_TILE_TOTAL`, `MAW_TILE_WINDOW`
- tag spawned tile panes with tmux `@maw_tile` metadata for durable ownership
- make `maw tile clean` kill only panes marked/titled as tile panes instead of every non-lead pane
- preserve the already-merged tile layout and pane swap behavior

Fixes #1385.
Partially addresses #1380 (safe tile-pane cleanup guardrails; broader `done --all`, branch deletion, and full cleanup lifecycle remain out of scope).

## Test
- `rtk bun test test/isolated/tile.test.ts`
- `rtk bun build src/cli.ts --outfile /tmp/maw-tile-metadata-check --target=bun --external @eclipse-zenoh/zenoh-ts`

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.