### PR TITLE
fix(cli): maw bring — direct handler (supersedes #1400)

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -65,7 +65,7 @@ export const TOP_ALIASES: Record<string, string[] | DirectHandler> = {
   panes: ["tmux", "ls", "--all", "--verbose"],
   cleanup: ["team", "cleanup", "--zombie-agents"],
   tile: ["tile"],
-  bring: ["wake", "--split"],
+  bring: { kind: "direct", handler: "../commands/shared/wake-cmd:cmdBring" },
 
   // Direct-handler form — `ls` flags differ from tmux ls:
   //   maw ls      → compact, live sessions only
@@ -197,6 +197,24 @@ export async function invokeDirectHandler(
       }
     }
 
+    await cmdWake(oracle, opts);
+    return;
+  }
+
+  if (exportName === "cmdBring") {
+    // `maw bring <oracle> [-e <engine>]` — split current pane and wake oracle there.
+    const flags = parseFlags(argv, {
+      "--engine": String, "-e": "--engine",
+    }, 0);
+    const oracle = (flags._ as string[])[0];
+    if (!oracle) {
+      console.error("usage: maw bring <oracle> [-e|--engine <name>]");
+      console.error("  Splits current pane and wakes oracle there (non-destructive).");
+      console.error("  Symmetric with `maw a` (attach goes there, bring comes here).");
+      throw new UserError("bring: missing oracle name");
+    }
+    const opts: { split: true; engine?: string } = { split: true };
+    if (flags["--engine"]) opts.engine = flags["--engine"];
     await cmdWake(oracle, opts);
     return;
   }


### PR DESCRIPTION
Direct-handler fix for bring. Supersedes #1400 which had history-rewrite issues. Closes #1395 properly. Also surfaced #1402 (separate split-import bug).