### PR TITLE
fix(comm): restore federation peek and local self-node targets

### DIFF
--- a/src/cli/route-comm.ts
+++ b/src/cli/route-comm.ts
@@ -1,7 +1,14 @@
-import { cmdSend } from "../commands/shared/comm";
+import { cmdPeek, cmdSend } from "../commands/shared/comm";
 import { UserError } from "../core/util/user-error";
 
 export async function routeComm(cmd: string, args: string[]): Promise<boolean> {
+  // `peek` is a federation-aware comm verb. Keep `maw tmux peek` as the raw
+  // tmux pane reader; top-level `maw peek <node>:<agent>` must reach cmdPeek.
+  if (cmd === "peek") {
+    await cmdPeek(args[1]);
+    return true;
+  }
+
   // `hey` and `send` stay core — they are message-delivery verbs.
   // #1388: restore `maw send` to the same submitted delivery path as `maw hey`.
   // The raw-text compositor plugin remains available through lower-level tmux

--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -35,7 +35,6 @@ export type AliasResolution =
 export const ALIAS_DESCRIPTIONS: Record<string, string> = {
   a: "Attach to a tmux session",
   kill: "Kill a tmux pane or session",
-  peek: "Read content of a tmux pane",
   split: "Split pane and attach to a session",
   open: "Bring back hidden panes (join-pane)",
   close: "Hide panes without killing (break-pane)",
@@ -55,7 +54,6 @@ export const TOP_ALIASES: Record<string, string[] | DirectHandler> = {
   // Argv-rewrite form — canonical handler lives in a core plugin
   a: ["tmux", "attach"],
   kill: ["tmux", "kill"],
-  peek: ["tmux", "peek"],
   split: ["split"],
   open: ["tmux", "open"],
   close: ["tmux", "close"],

--- a/src/commands/shared/comm-peek.ts
+++ b/src/commands/shared/comm-peek.ts
@@ -46,7 +46,7 @@ export async function cmdPeek(query?: string) {
   if (query && query.includes(":") && !query.includes("/")) {
     const [nodeName, agentName] = query.split(":", 2);
     const localNode = config.node || "local";
-    if (nodeName === localNode) {
+    if (nodeName === localNode || nodeName === "local") {
       // #362 — local node prefix: strip and fall through to local peek
       query = agentName;
     } else {

--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -248,7 +248,7 @@ export async function cmdSend(
     const targetNode = parts.length >= 2 ? parts[0] : null;
     const bareAgent = parts.length >= 2 ? parts[1] : query;
     const isCanonical = parts.length >= 3;
-    const isLocalScope = !targetNode || targetNode === config.node;
+    const isLocalScope = !targetNode || targetNode === config.node || targetNode === "local";
     if (isLocalScope && bareAgent && !isCanonical) {
       const hasLocalSession = sessions.some(s =>
         s.name === bareAgent ||

--- a/src/core/routing.ts
+++ b/src/core/routing.ts
@@ -93,8 +93,9 @@ export function resolveTarget(
     const agentName = query.slice(colonIdx + 1);
     if (!nodeName || !agentName) return { type: "error", reason: "empty_node_or_agent", detail: `invalid format: '${query}'`, hint: "use node:agent format (e.g. mba:homekeeper)" };
 
-    // Self-node check: "white:mawjs" from white → resolve locally
-    if (nodeName === selfNode) {
+    // Self-node check: "white:mawjs" from white, or advertised
+    // "local:mawjs" alias from any configured node → resolve locally.
+    if (nodeName === selfNode || nodeName === "local") {
       const selfTarget = findWindow(writable, agentName);
       if (selfTarget) return { type: "self-node", target: selfTarget };
       // Try fleet config resolution (#281)

--- a/test/cli/dispatch-match.test.ts
+++ b/test/cli/dispatch-match.test.ts
@@ -194,6 +194,11 @@ describe("resolveTopAlias — RFC #954 verb aliases", () => {
     if (out!.kind === "argv") expect(out!.argv).toEqual(["tmux", "attach", "neo"]);
   });
 
+  test("`peek` is not a tmux top-alias; top-level peek is handled by routeComm", () => {
+    const out = resolveTopAlias(["peek", "m5:mawjs"]);
+    expect(out).toBeNull();
+  });
+
   test("`attach` is not a registered alias (removed — use `a`)", () => {
     const out = resolveTopAlias(["attach", "neo"]);
     expect(out).toBeNull();

--- a/test/isolated/comm-peek.test.ts
+++ b/test/isolated/comm-peek.test.ts
@@ -337,6 +337,22 @@ describe("cmdPeek — federation (node:agent)", () => {
     expect(outs.some((o) => o.includes("local pane body"))).toBe(true);
   });
 
+  test("local: prefix is treated as an alias for this node", async () => {
+    configOverride = { node: "white", sessions: {} };
+    listSessionsReturn = [
+      { name: "08-mawjs", windows: [{ index: 0, name: "mawjs-oracle", active: true }] },
+    ];
+    findWindowReturn = "08-mawjs:0";
+    captureResponses = [{ match: /08-mawjs:0/, result: "local alias body" }];
+
+    await run(() => cmdPeek("local:mawjs"));
+
+    expect(curlFetchCalls).toHaveLength(0);
+    expect(findWindowCalls).toHaveLength(1);
+    expect(findWindowCalls[0].query).toBe("mawjs");
+    expect(outs.some((o) => o.includes("local alias body"))).toBe(true);
+  });
+
   test("namedPeers hit → curlFetch(peerUrl + /api/capture?target=) + prints content", async () => {
     configOverride = {
       node: "mba",

--- a/test/isolated/hey-fleet-auto-wake.test.ts
+++ b/test/isolated/hey-fleet-auto-wake.test.ts
@@ -225,6 +225,19 @@ describe("cmdSend — fleet auto-wake (#736 Phase 1.2)", () => {
     expect(sendKeysCalls.length).toBe(1);
   });
 
+  test("auto-wakes on local: prefixed target", async () => {
+    fleetKnown.add("volt");
+    listSessionsReturn = [];
+    listSessionsAfterWake = [{ name: "volt-session", windows: [{ index: 0, name: "volt-oracle", active: true }] }];
+    resolveTargetReturn = { type: "self-node", target: "volt-session:volt-oracle.0" };
+
+    await run(() => cmdSend("local:volt", "yo"));
+
+    expect(cmdWakeCalls.length).toBe(1);
+    expect(cmdWakeCalls[0].oracle).toBe("volt");
+    expect(sendKeysCalls.length).toBe(1);
+  });
+
   test("does NOT prompt y/N — wake is silent on fleet-known", async () => {
     fleetKnown.add("colab");
     listSessionsReturn = [];

--- a/test/isolated/route-comm-send.test.ts
+++ b/test/isolated/route-comm-send.test.ts
@@ -9,15 +9,18 @@
 import { describe, test, expect, mock, beforeEach } from "bun:test";
 
 const calls: unknown[][] = [];
+const peekCalls: unknown[][] = [];
 
 mock.module("../../src/commands/shared/comm", () => ({
   cmdSend: async (...args: unknown[]) => { calls.push(args); },
+  cmdPeek: async (...args: unknown[]) => { peekCalls.push(args); },
 }));
 
 const { routeComm } = await import("../../src/cli/route-comm");
 
 beforeEach(() => {
   calls.length = 0;
+  peekCalls.length = 0;
 });
 
 describe("routeComm — top-level send uses core delivery (#1388)", () => {
@@ -46,5 +49,13 @@ describe("routeComm — top-level send uses core delivery (#1388)", () => {
     expect(calls).toEqual([
       ["local:mawjs", "ping", false, { approve: false, trust: false }],
     ]);
+  });
+
+  test("maw peek routes through federation-aware cmdPeek, not tmux alias", async () => {
+    const handled = await routeComm("peek", ["peek", "m5:mawjs"]);
+
+    expect(handled).toBe(true);
+    expect(peekCalls).toEqual([["m5:mawjs"]]);
+    expect(calls).toEqual([]);
   });
 });

--- a/test/isolated/routing-manifest.test.ts
+++ b/test/isolated/routing-manifest.test.ts
@@ -216,6 +216,23 @@ describe("resolveTarget — manifest as primary lookup (Sub-PR 3 of #841)", () =
     });
   });
 
+  test("local:agent form is a self-node alias and resolves local sessions", () => {
+    manifestEntries = [];
+    const r = resolveTarget("local:mawjs", BASE_CONFIG, SESSIONS);
+    expect(r).toEqual({ type: "self-node", target: "08-mawjs:1" });
+  });
+
+  test("local:agent miss reports self-node local miss, not unknown peer", () => {
+    manifestEntries = [];
+    const r = resolveTarget("local:ghost", BASE_CONFIG, SESSIONS);
+    expect(r).toMatchObject({
+      type: "error",
+      reason: "self_not_running",
+      detail: "'ghost' not found in local sessions on white",
+      hint: "maw wake ghost",
+    });
+  });
+
   // 9. Manifest loader throws → resolveTarget recovers, falls through.
   test("manifest load error swallowed → falls through to agents map", () => {
     loadManifestThrows = true;

--- a/test/routing.test.ts
+++ b/test/routing.test.ts
@@ -71,6 +71,16 @@ describe("resolveTarget", () => {
     expect(r).toMatchObject({ type: "error", reason: "self_not_running" });
   });
 
+  test("local: prefix is a self-node alias and resolves locally", () => {
+    const r = resolveTarget("local:mawjs", BASE_CONFIG, SESSIONS);
+    expect(r).toEqual({ type: "self-node", target: "08-mawjs:1" });
+  });
+
+  test("local: prefix miss is local/self miss, not unknown peer", () => {
+    const r = resolveTarget("local:ghost", BASE_CONFIG, SESSIONS);
+    expect(r).toMatchObject({ type: "error", reason: "self_not_running" });
+  });
+
   // #6: NODE:AGENT → UNKNOWN NODE
   test("unknown node returns error", () => {
     const r = resolveTarget("mars:neo", BASE_CONFIG, SESSIONS);


### PR DESCRIPTION
## Summary
- route top-level `maw peek` through federation-aware `cmdPeek` again; keep raw pane capture under `maw tmux peek`
- treat `local:<agent>` as a self-node alias in peek, send auto-wake scope, and shared routing
- add regressions for top-level peek routing plus `local:` self-node hit/miss behavior

Fixes #1389.
Fixes #1381.

## Test
- `MAW_TEST_MODE=1 rtk bun test test/cli/dispatch-match.test.ts test/routing.test.ts`
- `MAW_TEST_MODE=1 rtk bun test test/isolated/route-comm-send.test.ts`
- `MAW_TEST_MODE=1 rtk bun test test/isolated/comm-peek.test.ts`
- `MAW_TEST_MODE=1 rtk bun test test/isolated/routing-manifest.test.ts`
- `MAW_TEST_MODE=1 rtk bun test test/isolated/hey-fleet-auto-wake.test.ts`
- `MAW_TEST_MODE=1 rtk bun test test/isolated/resolve-local-first.test.ts`
- `rtk bun build src/cli.ts --outfile /tmp/maw-comm-routing-check --target=bun --external @eclipse-zenoh/zenoh-ts`

Note: isolated tests are intentionally run one file per process via `scripts/test-isolated.sh`; running multiple isolated files in one `bun test` command can leak mocks and is not the CI contract.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.