### PR TITLE
fix(bring): split existing sessions without attach prompt

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -10,6 +10,13 @@ import { maybeSplit } from "./wake-maybe-split";
 import { parseWakeTarget, ensureCloned } from "./wake-target";
 import { assertAgentCapacity } from "./wake-concurrency";
 
+export function shouldOfferExistingSessionAttach(
+  opts: { attach?: boolean; split?: boolean },
+  isTTY = process.stdin.isTTY,
+): boolean {
+  return !opts.attach && !opts.split && Boolean(isTTY);
+}
+
 export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; split?: boolean; repoPath?: string; urlRepoName?: string; allLocal?: boolean; engine?: string }): Promise<string> {
   // Canonicalize the bare name before any lookup — strips trailing `/`, `/.git`, `/.git/`
   // so `maw wake token-oracle/` (tab-completion artifact) resolves the same as `token-oracle`.
@@ -260,7 +267,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
       }
 
       console.log(`\x1b[32m⚡\x1b[0m '${existingWindow}' running in ${session}`);
-      if (!opts.attach && process.stdin.isTTY) {
+      if (shouldOfferExistingSessionAttach(opts)) {
         process.stdout.write(`  attach? [y/N] `);
         const { openSync, readSync, closeSync } = await import("fs");
         try {
@@ -303,4 +310,3 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
   takeSnapshot("wake").catch(() => {});
   return `${session}:${windowName}`;
 }
-

--- a/src/commands/shared/wake-maybe-split.ts
+++ b/src/commands/shared/wake-maybe-split.ts
@@ -1,5 +1,9 @@
 import { hostExec } from "../../sdk";
 
+function shellArg(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
 /** @internal — exported for tests only. */
 export async function probeTmuxServer(): Promise<boolean> {
   try {
@@ -14,10 +18,14 @@ export async function maybeSplit(target: string, opts: { split?: boolean }): Pro
   if (!opts.split) return;
   if (process.env.TMUX) {
     try {
-      const { cmdSplit } = await import("../plugins/split/impl");
-      await cmdSplit(target);
-    } catch (e: any) {
-      console.log(`  \x1b[33m⚠\x1b[0m split failed: ${e.message || e}`);
+      const anchor = process.env.TMUX_PANE;
+      const targetFlag = anchor ? `-t ${shellArg(anchor)} ` : "";
+      const innerCmd = `TMUX= tmux attach-session -t ${shellArg(target)}`;
+      await hostExec(`tmux split-window ${targetFlag}-h -l 50% ${shellArg(innerCmd)}`);
+      console.log(`  \x1b[32m✓\x1b[0m split beside — ${target} (50%)`);
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+      console.log(`  \x1b[33m⚠\x1b[0m split failed: ${message}`);
     }
     return;
   }

--- a/test/isolated/wake-maybe-split.test.ts
+++ b/test/isolated/wake-maybe-split.test.ts
@@ -1,0 +1,57 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { join } from "path";
+
+let hostExecCalls: string[] = [];
+
+mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
+  hostExec: async (cmd: string) => {
+    hostExecCalls.push(cmd);
+    return "";
+  },
+}));
+
+const { maybeSplit } = await import("../../src/commands/shared/wake-maybe-split");
+
+describe("wake maybeSplit", () => {
+  const originalTmux = process.env.TMUX;
+  const originalPane = process.env.TMUX_PANE;
+
+  beforeEach(() => {
+    hostExecCalls = [];
+    process.env.TMUX = "/tmp/tmux-501/default,123,0";
+    process.env.TMUX_PANE = "%42";
+  });
+
+  test("does nothing when split is not requested", async () => {
+    await maybeSplit("20-homekeeper:homekeeper-oracle", {});
+    expect(hostExecCalls).toEqual([]);
+  });
+
+  test("splits current pane and attaches target without importing removed split plugin", async () => {
+    await maybeSplit("20-homekeeper:homekeeper-oracle", { split: true });
+
+    expect(hostExecCalls).toHaveLength(1);
+    expect(hostExecCalls[0]).toContain("tmux split-window");
+    expect(hostExecCalls[0]).toContain("-t '%42'");
+    expect(hostExecCalls[0]).toContain("-h -l 50%");
+    expect(hostExecCalls[0]).toContain("TMUX= tmux attach-session -t");
+    expect(hostExecCalls[0]).toContain("20-homekeeper:homekeeper-oracle");
+  });
+
+  test("can split without TMUX_PANE by omitting anchor", async () => {
+    delete process.env.TMUX_PANE;
+
+    await maybeSplit("20-homekeeper:homekeeper-oracle", { split: true });
+
+    expect(hostExecCalls).toHaveLength(1);
+    expect(hostExecCalls[0]).not.toContain("-t '%");
+    expect(hostExecCalls[0]).toContain("tmux split-window -h -l 50%");
+  });
+
+  afterAll(() => {
+    if (originalTmux === undefined) delete process.env.TMUX;
+    else process.env.TMUX = originalTmux;
+    if (originalPane === undefined) delete process.env.TMUX_PANE;
+    else process.env.TMUX_PANE = originalPane;
+  });
+});

--- a/test/wake-bring.test.ts
+++ b/test/wake-bring.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { shouldOfferExistingSessionAttach } from "../src/commands/shared/wake-cmd";
+
+describe("maw bring existing-session behavior", () => {
+  test("wake may offer attach for an existing session in an interactive terminal", () => {
+    expect(shouldOfferExistingSessionAttach({}, true)).toBe(true);
+  });
+
+  test("bring/wake --split never offers the destructive attach prompt", () => {
+    expect(shouldOfferExistingSessionAttach({ split: true }, true)).toBe(false);
+  });
+
+  test("explicit attach skips the prompt because attach was already requested", () => {
+    expect(shouldOfferExistingSessionAttach({ attach: true }, true)).toBe(false);
+  });
+
+  test("headless wake does not prompt", () => {
+    expect(shouldOfferExistingSessionAttach({}, false)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- suppress the existing-session `attach? [y/N]` prompt when wake is running in split/bring mode
- replace `wake-maybe-split`'s stale dynamic import of the removed split plugin with a direct tmux `split-window` attach command
- add regressions for bring prompt gating and split command generation

Fixes #1405.
Fixes #1402.

## Tests
- `MAW_TEST_MODE=1 rtk bun test test/isolated/wake-maybe-split.test.ts test/wake-bring.test.ts`
- `MAW_TEST_MODE=1 rtk bun test test/cli/dispatch-match.test.ts test/wake-bring.test.ts test/isolated/wake-maybe-split.test.ts`
- `rtk bun build src/cli.ts --outfile /tmp/maw-bring-split-check --target=bun --external @eclipse-zenoh/zenoh-ts`

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
