### PR TITLE
fix(bring): default to tmux tab and make split opt-in

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -102,6 +102,31 @@ export function resolveTopAlias(args: string[]): AliasResolution | null {
   return { kind: "direct", handler: entry.handler, argv: args.slice(1) };
 }
 
+export function parseBringArgs(argv: string[]): {
+  oracle: string;
+  opts: { bring?: true; split?: boolean; engine?: string };
+} {
+  // `maw bring <oracle>` opens a new tmux window/tab by default. `--split`
+  // remains available as the opt-in layout-mutating form.
+  const flags = parseFlags(argv, {
+    "--engine": String, "-e": "--engine",
+    "--split": Boolean,
+  }, 0);
+  const oracle = (flags._ as string[])[0];
+  if (!oracle) {
+    console.error("usage: maw bring <oracle> [--split] [-e|--engine <name>]");
+    console.error("  Opens oracle in a new tmux window/tab by default.");
+    console.error("  Use --split to split the current pane instead.");
+    console.error("  Symmetric with `maw a` (attach goes there, bring comes here).");
+    throw new UserError("bring: missing oracle name");
+  }
+  const opts: { bring?: true; split?: boolean; engine?: string } = flags["--split"]
+    ? { split: true }
+    : { bring: true };
+  if (flags["--engine"]) opts.engine = flags["--engine"];
+  return { oracle, opts };
+}
+
 /**
  * Invoke a direct-handler alias. Used by `wake` and `ls`.
  *
@@ -200,19 +225,9 @@ export async function invokeDirectHandler(
   }
 
   if (exportName === "cmdBring") {
-    // `maw bring <oracle> [-e <engine>]` — split current pane and wake oracle there.
-    const flags = parseFlags(argv, {
-      "--engine": String, "-e": "--engine",
-    }, 0);
-    const oracle = (flags._ as string[])[0];
-    if (!oracle) {
-      console.error("usage: maw bring <oracle> [-e|--engine <name>]");
-      console.error("  Splits current pane and wakes oracle there (non-destructive).");
-      console.error("  Symmetric with `maw a` (attach goes there, bring comes here).");
-      throw new UserError("bring: missing oracle name");
-    }
-    const opts: { split: true; engine?: string } = { split: true };
-    if (flags["--engine"]) opts.engine = flags["--engine"];
+    // `maw bring <oracle>` — show oracle here in a new tab by default.
+    // `--split` opts into current-pane splitting.
+    const { oracle, opts } = parseBringArgs(argv);
     await cmdWake(oracle, opts);
     return;
   }

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -6,18 +6,18 @@ import { normalizeTarget } from "../../core/matcher/normalize-target";
 import { assertValidOracleName } from "../../core/fleet/validate";
 import { resolveOracle, findWorktrees, getSessionMap, resolveFleetSession, detectSession, setSessionEnv, sanitizeBranchName } from "./wake-resolve";
 import { attachToSession, ensureSessionRunning, createWorktree } from "./wake-session";
-import { maybeSplit } from "./wake-maybe-split";
+import { maybeOpenWindow, maybeSplit } from "./wake-maybe-split";
 import { parseWakeTarget, ensureCloned } from "./wake-target";
 import { assertAgentCapacity } from "./wake-concurrency";
 
 export function shouldOfferExistingSessionAttach(
-  opts: { attach?: boolean; split?: boolean },
+  opts: { attach?: boolean; split?: boolean; bring?: boolean },
   isTTY = process.stdin.isTTY,
 ): boolean {
-  return !opts.attach && !opts.split && Boolean(isTTY);
+  return !opts.attach && !opts.split && !opts.bring && Boolean(isTTY);
 }
 
-export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; split?: boolean; repoPath?: string; urlRepoName?: string; allLocal?: boolean; engine?: string }): Promise<string> {
+export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; split?: boolean; bring?: boolean; repoPath?: string; urlRepoName?: string; allLocal?: boolean; engine?: string }): Promise<string> {
   // Canonicalize the bare name before any lookup — strips trailing `/`, `/.git`, `/.git/`
   // so `maw wake token-oracle/` (tab-completion artifact) resolves the same as `token-oracle`.
   oracle = normalizeTarget(oracle);
@@ -247,6 +247,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
         await tmux.sendText(`${session}:${existingWindow}`, `${buildCommandInDir(existingWindow, targetPath, opts.engine)} -p '${escaped}'`);
         if (opts.attach) await attachToSession(session);
         await maybeSplit(`${session}:${existingWindow}`, opts);
+        await maybeOpenWindow(`${session}:${existingWindow}`, opts);
         return `${session}:${existingWindow}`;
       }
       // Check if agent is actually alive in the pane
@@ -263,6 +264,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
           await attachToSession(session);
         }
         await maybeSplit(target, opts);
+        await maybeOpenWindow(target, opts);
         return target;
       }
 
@@ -284,6 +286,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
         await attachToSession(session);
       }
       await maybeSplit(target, opts);
+      await maybeOpenWindow(target, opts);
       return target;
     }
   } catch { /* session might be fresh */ }
@@ -306,6 +309,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
   if (opts.attach) await attachToSession(session);
 
   await maybeSplit(`${session}:${windowName}`, opts);
+  await maybeOpenWindow(`${session}:${windowName}`, opts);
 
   takeSnapshot("wake").catch(() => {});
   return `${session}:${windowName}`;

--- a/src/commands/shared/wake-maybe-split.ts
+++ b/src/commands/shared/wake-maybe-split.ts
@@ -43,3 +43,33 @@ export async function maybeSplit(target: string, opts: { split?: boolean }): Pro
     console.log(`      \x1b[90mto silence:       drop --split when running headless\x1b[0m`);
   }
 }
+
+export async function maybeOpenWindow(target: string, opts: { bring?: boolean }): Promise<void> {
+  if (!opts.bring) return;
+  const session = target.split(":")[0] || target;
+  if (process.env.TMUX) {
+    try {
+      const targetWindow = target.split(":").slice(1).join(":") || session;
+      const windowName = `bring-${targetWindow}`.replace(/[^A-Za-z0-9_.-]/g, "-").slice(0, 80) || "bring";
+      const innerCmd = `TMUX= tmux attach-session -t ${shellArg(target)}`;
+      await hostExec(`tmux new-window -n ${shellArg(windowName)} ${shellArg(innerCmd)}`);
+      console.log(`  \x1b[32m✓\x1b[0m opened tab — ${target}`);
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+      console.log(`  \x1b[33m⚠\x1b[0m bring failed: ${message}`);
+    }
+    return;
+  }
+  const serverUp = await probeTmuxServer();
+  if (serverUp) {
+    console.log(`  \x1b[33m⚠\x1b[0m bring skipped — shell is not attached to a tmux pane.`);
+    console.log(`      \x1b[90mstate created:    ${target}\x1b[0m`);
+    console.log(`      \x1b[90mto view:          tmux attach -t ${session}\x1b[0m`);
+    console.log(`      \x1b[90mto silence:       use maw wake instead of maw bring when running headless\x1b[0m`);
+  } else {
+    console.log(`  \x1b[33m⚠\x1b[0m bring skipped — tmux server not running.`);
+    console.log(`      \x1b[90mstate created:    ${target}\x1b[0m`);
+    console.log(`      \x1b[90mto start tmux:    tmux new -s work\x1b[0m`);
+    console.log(`      \x1b[90mto silence:       use maw wake instead of maw bring when running headless\x1b[0m`);
+  }
+}

--- a/test/cli/dispatch-match.test.ts
+++ b/test/cli/dispatch-match.test.ts
@@ -10,7 +10,7 @@
  */
 import { describe, test, expect } from "bun:test";
 import { resolvePluginMatch } from "../../src/cli/dispatch-match";
-import { resolveTopAlias } from "../../src/cli/top-aliases";
+import { parseBringArgs, resolveTopAlias } from "../../src/cli/top-aliases";
 import type { LoadedPlugin } from "../../src/plugin/types";
 
 function plugin(name: string, command: string, aliases: string[] = []): LoadedPlugin {
@@ -214,6 +214,16 @@ describe("resolveTopAlias — RFC #954 verb aliases", () => {
       // argv passed to handler is everything AFTER the verb
       expect(out!.argv).toEqual(["neo", "--task", "X"]);
     }
+  });
+
+  test("`bring neo` defaults to tab/window mode, not split", () => {
+    const parsed = parseBringArgs(["neo"]);
+    expect(parsed).toEqual({ oracle: "neo", opts: { bring: true } });
+  });
+
+  test("`bring neo --split` opts into split mode", () => {
+    const parsed = parseBringArgs(["neo", "--split", "-e", "codex"]);
+    expect(parsed).toEqual({ oracle: "neo", opts: { split: true, engine: "codex" } });
   });
 
   test("`audit` → null (does NOT shadow CORE_ROUTES)", () => {

--- a/test/isolated/wake-maybe-split.test.ts
+++ b/test/isolated/wake-maybe-split.test.ts
@@ -10,7 +10,7 @@ mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
   },
 }));
 
-const { maybeSplit } = await import("../../src/commands/shared/wake-maybe-split");
+const { maybeOpenWindow, maybeSplit } = await import("../../src/commands/shared/wake-maybe-split");
 
 describe("wake maybeSplit", () => {
   const originalTmux = process.env.TMUX;
@@ -46,6 +46,21 @@ describe("wake maybeSplit", () => {
     expect(hostExecCalls).toHaveLength(1);
     expect(hostExecCalls[0]).not.toContain("-t '%");
     expect(hostExecCalls[0]).toContain("tmux split-window -h -l 50%");
+  });
+
+  test("opens a new tmux window/tab for bring default mode", async () => {
+    await maybeOpenWindow("20-homekeeper:homekeeper-oracle", { bring: true });
+
+    expect(hostExecCalls).toHaveLength(1);
+    expect(hostExecCalls[0]).toContain("tmux new-window");
+    expect(hostExecCalls[0]).toContain("-n 'bring-homekeeper-oracle'");
+    expect(hostExecCalls[0]).toContain("TMUX= tmux attach-session -t");
+    expect(hostExecCalls[0]).toContain("20-homekeeper:homekeeper-oracle");
+  });
+
+  test("does not open a window when bring is not requested", async () => {
+    await maybeOpenWindow("20-homekeeper:homekeeper-oracle", {});
+    expect(hostExecCalls).toEqual([]);
   });
 
   afterAll(() => {

--- a/test/wake-bring.test.ts
+++ b/test/wake-bring.test.ts
@@ -10,6 +10,10 @@ describe("maw bring existing-session behavior", () => {
     expect(shouldOfferExistingSessionAttach({ split: true }, true)).toBe(false);
   });
 
+  test("bring default tab mode never offers the destructive attach prompt", () => {
+    expect(shouldOfferExistingSessionAttach({ bring: true }, true)).toBe(false);
+  });
+
   test("explicit attach skips the prompt because attach was already requested", () => {
     expect(shouldOfferExistingSessionAttach({ attach: true }, true)).toBe(false);
   });


### PR DESCRIPTION
## Summary
- make `maw bring <oracle>` open the target in a new tmux window/tab by default
- keep the current pane split behavior behind explicit `maw bring <oracle> --split`
- keep bring non-interactive by suppressing the existing-session attach prompt in default tab mode

Fixes #1409.

## Tests
- `MAW_TEST_MODE=1 rtk bun test test/cli/dispatch-match.test.ts test/wake-bring.test.ts test/isolated/wake-maybe-split.test.ts`
- `rtk bun build src/cli.ts --outfile /tmp/maw-bring-tab-check --target=bun --external @eclipse-zenoh/zenoh-ts`

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
