### PR TITLE
fix(send): sign delivered federation chat bodies

### DIFF
--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -68,6 +68,33 @@ export function resolveMyName(config: ReturnType<typeof loadConfig>): string {
 }
 
 /**
+ * Visible internal federation attribution.
+ *
+ * Transport-level signing (`curlFetch(..., { from: "auto" })`) authenticates
+ * cross-node HTTP calls, but same-node tmux delivery has no protocol envelope.
+ * Internal Oracle convention is a body-level `[node:oracle]` prefix for human
+ * chat. Preserve executable slash/$ commands and already-signed messages so
+ * `maw hey target /skill` keeps invoking the command instead of turning into
+ * prose.
+ *
+ * @internal exported for regression tests.
+ */
+export function formatSignedMessage(
+  message: string,
+  config: Pick<ReturnType<typeof loadConfig>, "node">,
+  senderName: string,
+): string {
+  const leading = message.match(/^\s*/)?.[0] ?? "";
+  const body = message.slice(leading.length);
+  if (!body) return message;
+  if (body.startsWith("/") || body.startsWith("$")) return message;
+  if (/^\[[^\]\s:]+:[^\]]+\](?:\s|$)/.test(body)) return message;
+
+  const node = config.node || "local";
+  return `${leading}[${node}:${senderName}] ${body}`;
+}
+
+/**
  * Check if a pane is idle — i.e., no user input is in progress on the prompt line.
  * Uses capture-pane to inspect the last visible line. If a shell prompt marker
  * ($, %, >, ❯, #) is followed by non-whitespace text, the user is mid-input.
@@ -423,6 +450,9 @@ export async function cmdSend(
     }
   }
 
+  const senderName = resolveMyName(config);
+  const outboundMessage = formatSignedMessage(message, config, senderName);
+
   // Local target (or self-node) → send via tmux.
   // Resolve to a specific pane first: when the oracle window has multiple
   // panes (team-agents spawned beside it), `send-keys -t session:window`
@@ -450,16 +480,15 @@ export async function cmdSend(
         }
       }
     }
-    await sendKeys(target, message);
-    await runHook("after_send", { to: query, message });
+    await sendKeys(target, outboundMessage);
+    await runHook("after_send", { to: query, message: outboundMessage });
     if (!config.node) throw new Error("config.node is required — set 'node' in maw.config.json");
-    const senderName = resolveMyName(config);
-    logMessage(senderName, query, message, "local");
-    emitFeed("MessageSend", senderName, config.node, `${query}: ${message.slice(0, 200)}`, config.port || 3456);
+    logMessage(senderName, query, outboundMessage, "local");
+    emitFeed("MessageSend", senderName, config.node, `${query}: ${outboundMessage.slice(0, 200)}`, config.port || 3456);
     await Bun.sleep(150);
     let lastLine = "";
     try { const content = await capture(target, 3); lastLine = content.split("\n").filter(l => l.trim()).pop() || ""; } catch {}
-    console.log(`\x1b[32mdelivered\x1b[0m → ${target}: ${message}`);
+    console.log(`\x1b[32mdelivered\x1b[0m → ${target}: ${outboundMessage}`);
     if (lastLine) console.log(`\x1b[90m  ⤷ ${lastLine.slice(0, cfgLimit("messageTruncate"))}\x1b[0m`);
     return;
   }
@@ -468,16 +497,15 @@ export async function cmdSend(
   if (result?.type === "peer") {
     const res = await curlFetch(`${result.peerUrl}/api/send`, {
       method: "POST",
-      body: JSON.stringify({ target: result.target, text: message }),
+      body: JSON.stringify({ target: result.target, text: outboundMessage }),
       from: "auto", // #804 Step 4 SIGN — sign cross-node /api/send
     });
     if (res.ok && res.data?.ok) {
-      const agentName = resolveMyName(config);
-      logMessage(agentName, query, message, `peer:${result.node}`);
-      emitFeed("MessageSend", agentName, config.node!, `${result.node}:${query}: ${message.slice(0, 200)}`, config.port || 3456);
-      console.log(`\x1b[32mdelivered\x1b[0m ⚡ ${result.node} → ${res.data.target || result.target}: ${message}`);
+      logMessage(senderName, query, outboundMessage, `peer:${result.node}`);
+      emitFeed("MessageSend", senderName, config.node!, `${result.node}:${query}: ${outboundMessage.slice(0, 200)}`, config.port || 3456);
+      console.log(`\x1b[32mdelivered\x1b[0m ⚡ ${result.node} → ${res.data.target || result.target}: ${outboundMessage}`);
       if (res.data.lastLine) console.log(`\x1b[90m  ⤷ ${res.data.lastLine.slice(0, cfgLimit("messageTruncate"))}\x1b[0m`);
-      await runHook("after_send", { to: query, message });
+      await runHook("after_send", { to: query, message: outboundMessage });
       return;
     }
     const underlying = res.data?.error || (res.status ? `HTTP ${res.status}` : "connection failed");
@@ -493,13 +521,13 @@ export async function cmdSend(
   if (peerUrl) {
     const res = await curlFetch(`${peerUrl}/api/send`, {
       method: "POST",
-      body: JSON.stringify({ target: query, text: message }),
+      body: JSON.stringify({ target: query, text: outboundMessage }),
       from: "auto", // #804 Step 4 SIGN — sign discovery-fallback /api/send
     });
     if (res.ok && res.data?.ok) {
-      console.log(`\x1b[32mdelivered\x1b[0m ⚡ ${peerUrl} → ${res.data.target || query}: ${message}`);
+      console.log(`\x1b[32mdelivered\x1b[0m ⚡ ${peerUrl} → ${res.data.target || query}: ${outboundMessage}`);
       if (res.data.lastLine) console.log(`\x1b[90m  ⤷ ${res.data.lastLine.slice(0, cfgLimit("messageTruncate"))}\x1b[0m`);
-      await runHook("after_send", { to: query, message });
+      await runHook("after_send", { to: query, message: outboundMessage });
       return;
     }
     // Remote fetch was attempted but failed — surface the remote failure explicitly (#411).

--- a/test/comm-send-signing.test.ts
+++ b/test/comm-send-signing.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { formatSignedMessage } from "../src/commands/shared/comm-send";
+
+describe("formatSignedMessage — visible Oracle attribution (#1388)", () => {
+  const config = { node: "m5" };
+
+  test("prefixes ordinary federation chat with node and sender", () => {
+    expect(formatSignedMessage("hello", config, "mawjs-codex")).toBe("[m5:mawjs-codex] hello");
+  });
+
+  test("does not double-prefix already signed messages", () => {
+    expect(formatSignedMessage("[m5:mawjs-codex] hello", config, "mawjs-codex"))
+      .toBe("[m5:mawjs-codex] hello");
+  });
+
+  test("does not prefix slash commands", () => {
+    expect(formatSignedMessage("/recap --now", config, "mawjs-codex")).toBe("/recap --now");
+  });
+
+  test("does not prefix dollar skill commands", () => {
+    expect(formatSignedMessage("$go update", config, "mawjs-codex")).toBe("$go update");
+  });
+
+  test("preserves leading whitespace when signing prose", () => {
+    expect(formatSignedMessage("  hello", config, "mawjs-codex")).toBe("  [m5:mawjs-codex] hello");
+  });
+});

--- a/test/isolated/comm-list.test.ts
+++ b/test/isolated/comm-list.test.ts
@@ -849,17 +849,17 @@ describe("cmdSend — local target (happy path + error branches)", () => {
 
     await run(() => cmdSend("white:mawjs", "ping"));
 
-    expect(sendKeysCalls).toEqual([{ target: "08-mawjs:0", text: "ping" }]);
+    expect(sendKeysCalls).toEqual([{ target: "08-mawjs:0", text: "[white:test-oracle] ping" }]);
     expect(runHookCalls.some((h) => h.event === "after_send")).toBe(true);
     expect(logMessageCalls).toHaveLength(1);
     expect(logMessageCalls[0]).toMatchObject({
-      from: "test-oracle", to: "white:mawjs", msg: "ping", route: "local",
+      from: "test-oracle", to: "white:mawjs", msg: "[white:test-oracle] ping", route: "local",
     });
     expect(emitFeedCalls).toHaveLength(1);
     expect(emitFeedCalls[0]).toMatchObject({
       event: "MessageSend", oracle: "test-oracle", node: "white", port: 4000,
     });
-    expect(outs.some((o) => o.includes("delivered") && o.includes("08-mawjs:0: ping"))).toBe(true);
+    expect(outs.some((o) => o.includes("delivered") && o.includes("08-mawjs:0: [white:test-oracle] ping"))).toBe(true);
     expect(outs.some((o) => o.includes("⤷ hello back"))).toBe(true);
   });
 
@@ -886,7 +886,7 @@ describe("cmdSend — local target (happy path + error branches)", () => {
 
     await run(() => cmdSend("white:mawjs", "ping", true));
 
-    expect(sendKeysCalls).toEqual([{ target: "08-mawjs:0", text: "ping" }]);
+    expect(sendKeysCalls).toEqual([{ target: "08-mawjs:0", text: "[white:test-oracle] ping" }]);
     expect(exitCode).toBeUndefined();
   });
 
@@ -921,7 +921,7 @@ describe("cmdSend — local target (happy path + error branches)", () => {
 
     await run(() => cmdSend("white:mawjs", "ping"));
 
-    expect(sendKeysCalls).toEqual([{ target: "08-mawjs:0", text: "ping" }]);
+    expect(sendKeysCalls).toEqual([{ target: "08-mawjs:0", text: "[white:test-oracle] ping" }]);
     expect(logMessageCalls[0].route).toBe("local");
   });
 
@@ -951,7 +951,7 @@ describe("cmdSend — local target (happy path + error branches)", () => {
 
     await run(() => cmdSend("white:mawjs", "ping"));
 
-    expect(sendKeysCalls).toEqual([{ target: "08-mawjs:0.1", text: "ping" }]);
+    expect(sendKeysCalls).toEqual([{ target: "08-mawjs:0.1", text: "[white:test-oracle] ping" }]);
   });
 });
 
@@ -974,7 +974,7 @@ describe("cmdSend — peer target (federation)", () => {
     expect(runHookCalls.some((h) => h.event === "after_send")).toBe(true);
     expect(logMessageCalls[0]).toMatchObject({ from: "test-oracle", to: "mba:mawjs", route: "peer:mba" });
     expect(emitFeedCalls[0]).toMatchObject({ event: "MessageSend", node: "white", port: 5000 });
-    expect(outs.some((o) => o.includes("delivered") && o.includes("mba") && o.includes("mawjs: ping"))).toBe(true);
+    expect(outs.some((o) => o.includes("delivered") && o.includes("mba") && o.includes("mawjs: [white:test-oracle] ping"))).toBe(true);
     expect(outs.some((o) => o.includes("⤷ peer saw it"))).toBe(true);
   });
 

--- a/test/isolated/hey-fleet-auto-wake.test.ts
+++ b/test/isolated/hey-fleet-auto-wake.test.ts
@@ -31,6 +31,7 @@ let fleetKnown: Set<string> = new Set();
 let cmdWakeCalls: Array<{ oracle: string; opts: unknown }> = [];
 let listSessionsCallCount = 0;
 let listSessionsAfterWake: Array<{ name: string; windows: { index: number; name: string; active: boolean }[] }> | null = null;
+let previousAgentName: string | undefined;
 
 // ─── Mocks ───────────────────────────────────────────────────────────────────
 
@@ -136,6 +137,8 @@ async function run(fn: () => Promise<unknown>): Promise<void> {
 }
 
 beforeEach(() => {
+  previousAgentName = process.env.CLAUDE_AGENT_NAME;
+  process.env.CLAUDE_AGENT_NAME = "test-node";
   mockActive = true;
   sendKeysCalls = [];
   cmdWakeCalls = [];
@@ -147,7 +150,12 @@ beforeEach(() => {
   process.env.MAW_QUIET = "1";
 });
 
-afterEach(() => { mockActive = false; delete process.env.MAW_QUIET; });
+afterEach(() => {
+  mockActive = false;
+  delete process.env.MAW_QUIET;
+  if (previousAgentName === undefined) delete process.env.CLAUDE_AGENT_NAME;
+  else process.env.CLAUDE_AGENT_NAME = previousAgentName;
+});
 afterAll(() => {
   mockActive = false;
   (Bun as unknown as { sleep: typeof origSleep }).sleep = origSleep;
@@ -171,7 +179,7 @@ describe("cmdSend — fleet auto-wake (#736 Phase 1.2)", () => {
     // Auto-wake message printed (no y/N prompt path)
     expect(logs.some(l => l.includes("fleet-known") && l.includes("auto-wake"))).toBe(true);
     expect(sendKeysCalls.length).toBe(1);
-    expect(sendKeysCalls[0].text).toBe("hello");
+    expect(sendKeysCalls[0].text).toBe("[test-node:test-node] hello");
     expect(exitCode).toBeUndefined();
   });
 

--- a/test/isolated/send-idle-guard.test.ts
+++ b/test/isolated/send-idle-guard.test.ts
@@ -78,6 +78,7 @@ mock.module(join(import.meta.dir, "../../src/commands/shared/comm-log-feed"), ()
 
 // Bun.sleep intercept — replace globally so checkPaneIdle retry doesn't stall
 const origSleep = Bun.sleep.bind(Bun);
+const origClaudeAgentName = process.env.CLAUDE_AGENT_NAME;
 (Bun as unknown as { sleep: (ms: number) => Promise<void> }).sleep = async (ms: number) => {
   sleepCalls.push(ms);
 };
@@ -120,12 +121,15 @@ beforeEach(() => {
   resolveTargetReturn = { type: "local", target: "test-session:oracle.0" };
   delete process.env.MAW_QUIET;
   process.env.MAW_QUIET = "1"; // suppress tip output
+  process.env.CLAUDE_AGENT_NAME = "test-node";
 });
 
 afterEach(() => { mockActive = false; delete process.env.MAW_QUIET; });
 afterAll(() => {
   mockActive = false;
   (Bun as unknown as { sleep: typeof origSleep }).sleep = origSleep;
+  if (origClaudeAgentName === undefined) delete process.env.CLAUDE_AGENT_NAME;
+  else process.env.CLAUDE_AGENT_NAME = origClaudeAgentName;
 });
 
 // ─── checkPaneIdle tests ─────────────────────────────────────────────────────
@@ -202,7 +206,7 @@ describe("cmdSend — idle guard integration (#405)", () => {
     ];
     await run(() => cmdSend("test-node:oracle", "hello world"));
     expect(sendKeysCalls.length).toBe(1);
-    expect(sendKeysCalls[0].text).toBe("hello world");
+    expect(sendKeysCalls[0].text).toBe("[test-node:test-node] hello world");
     expect(exitCode).toBeUndefined();
   });
 
@@ -215,6 +219,7 @@ describe("cmdSend — idle guard integration (#405)", () => {
     await run(() => cmdSend("test-node:oracle", "hello after retry"));
     expect(sleepCalls).toContain(500);
     expect(sendKeysCalls.length).toBe(1);
+    expect(sendKeysCalls[0].text).toBe("[test-node:test-node] hello after retry");
     expect(exitCode).toBeUndefined();
   });
 
@@ -238,7 +243,7 @@ describe("cmdSend — idle guard integration (#405)", () => {
     ];
     await run(() => cmdSend("test-node:oracle", "forced message", /* force */ true));
     expect(sendKeysCalls.length).toBe(1);
-    expect(sendKeysCalls[0].text).toBe("forced message");
+    expect(sendKeysCalls[0].text).toBe("[test-node:test-node] forced message");
     expect(exitCode).toBeUndefined();
     // No 500ms sleep should have been triggered by idle check
     expect(sleepCalls.filter(ms => ms === 500).length).toBe(0);


### PR DESCRIPTION
## Summary
- add visible `[node:oracle]` attribution to delivered ordinary federation chat bodies
- preserve slash commands (`/...`) and dollar skill commands (`$...`) so remote automation still executes
- keep signing idempotent for messages that already start with `[node:oracle]`

Fixes #1388.

## Tests
- `MAW_TEST_MODE=1 rtk bun test test/comm-send-signing.test.ts test/isolated/send-idle-guard.test.ts test/isolated/route-comm-send.test.ts`
- `rtk bun build src/cli.ts --outfile /tmp/maw-send-signing-check --target=bun --external @eclipse-zenoh/zenoh-ts`

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
