### PR TITLE
fix(bring): open default tabs in the background

### DIFF
--- a/src/commands/shared/wake-maybe-split.ts
+++ b/src/commands/shared/wake-maybe-split.ts
@@ -52,8 +52,8 @@ export async function maybeOpenWindow(target: string, opts: { bring?: boolean })
       const targetWindow = target.split(":").slice(1).join(":") || session;
       const windowName = `bring-${targetWindow}`.replace(/[^A-Za-z0-9_.-]/g, "-").slice(0, 80) || "bring";
       const innerCmd = `TMUX= tmux attach-session -t ${shellArg(target)}`;
-      await hostExec(`tmux new-window -n ${shellArg(windowName)} ${shellArg(innerCmd)}`);
-      console.log(`  \x1b[32m✓\x1b[0m opened tab — ${target}`);
+      await hostExec(`tmux new-window -d -n ${shellArg(windowName)} ${shellArg(innerCmd)}`);
+      console.log(`  \x1b[32m✓\x1b[0m opened background tab — ${target}`);
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);
       console.log(`  \x1b[33m⚠\x1b[0m bring failed: ${message}`);

--- a/test/isolated/wake-maybe-split.test.ts
+++ b/test/isolated/wake-maybe-split.test.ts
@@ -52,7 +52,7 @@ describe("wake maybeSplit", () => {
     await maybeOpenWindow("20-homekeeper:homekeeper-oracle", { bring: true });
 
     expect(hostExecCalls).toHaveLength(1);
-    expect(hostExecCalls[0]).toContain("tmux new-window");
+    expect(hostExecCalls[0]).toContain("tmux new-window -d");
     expect(hostExecCalls[0]).toContain("-n 'bring-homekeeper-oracle'");
     expect(hostExecCalls[0]).toContain("TMUX= tmux attach-session -t");
     expect(hostExecCalls[0]).toContain("20-homekeeper:homekeeper-oracle");


### PR DESCRIPTION
## Summary
- create default `maw bring` tmux tabs with `new-window -d` so the current client stays put
- update the bring tab regression test to lock the detached-window command
- keep `--split` as the explicit current-layout mutation path

Fixes #1412.

## Tests
- `MAW_TEST_MODE=1 rtk bun test test/isolated/wake-maybe-split.test.ts test/wake-bring.test.ts`
- `rtk bun build src/cli.ts --outfile /tmp/maw-bring-background-check --target=bun --external @eclipse-zenoh/zenoh-ts`

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
