### PR TITLE
fix(bring): reflow split layout after attach

### DIFF
--- a/src/commands/shared/wake-maybe-split.ts
+++ b/src/commands/shared/wake-maybe-split.ts
@@ -14,6 +14,21 @@ export async function probeTmuxServer(): Promise<boolean> {
   }
 }
 
+
+async function restoreSplitLayout(anchor?: string): Promise<void> {
+  try {
+    const windowTarget = anchor || process.env.TMUX_PANE;
+    const targetFlag = windowTarget ? `-t ${shellArg(windowTarget)} ` : "";
+    const raw = await hostExec(`tmux list-panes ${targetFlag}| wc -l`);
+    const total = Number.parseInt(String(raw).trim(), 10);
+    const layout = Number.isFinite(total) && total > 4 ? "tiled" : "main-vertical";
+    await hostExec(`tmux select-layout ${targetFlag}${layout}`);
+  } catch {
+    // Best-effort polish only: split succeeded, so never fail delivery because
+    // the caller's tmux cannot reflow the current window.
+  }
+}
+
 export async function maybeSplit(target: string, opts: { split?: boolean }): Promise<void> {
   if (!opts.split) return;
   if (process.env.TMUX) {
@@ -22,6 +37,7 @@ export async function maybeSplit(target: string, opts: { split?: boolean }): Pro
       const targetFlag = anchor ? `-t ${shellArg(anchor)} ` : "";
       const innerCmd = `TMUX= tmux attach-session -t ${shellArg(target)}`;
       await hostExec(`tmux split-window ${targetFlag}-h -l 50% ${shellArg(innerCmd)}`);
+      await restoreSplitLayout(anchor);
       console.log(`  \x1b[32m✓\x1b[0m split beside — ${target} (50%)`);
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);

--- a/test/isolated/wake-maybe-split.test.ts
+++ b/test/isolated/wake-maybe-split.test.ts
@@ -2,10 +2,12 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { join } from "path";
 
 let hostExecCalls: string[] = [];
+let listPanesResponse = "3\n";
 
 mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
   hostExec: async (cmd: string) => {
     hostExecCalls.push(cmd);
+    if (cmd.includes("list-panes")) return listPanesResponse;
     return "";
   },
 }));
@@ -18,6 +20,7 @@ describe("wake maybeSplit", () => {
 
   beforeEach(() => {
     hostExecCalls = [];
+    listPanesResponse = "3\n";
     process.env.TMUX = "/tmp/tmux-501/default,123,0";
     process.env.TMUX_PANE = "%42";
   });
@@ -30,12 +33,14 @@ describe("wake maybeSplit", () => {
   test("splits current pane and attaches target without importing removed split plugin", async () => {
     await maybeSplit("20-homekeeper:homekeeper-oracle", { split: true });
 
-    expect(hostExecCalls).toHaveLength(1);
+    expect(hostExecCalls).toHaveLength(3);
     expect(hostExecCalls[0]).toContain("tmux split-window");
     expect(hostExecCalls[0]).toContain("-t '%42'");
     expect(hostExecCalls[0]).toContain("-h -l 50%");
     expect(hostExecCalls[0]).toContain("TMUX= tmux attach-session -t");
     expect(hostExecCalls[0]).toContain("20-homekeeper:homekeeper-oracle");
+    expect(hostExecCalls[1]).toContain("tmux list-panes -t '%42'");
+    expect(hostExecCalls[2]).toContain("tmux select-layout -t '%42' main-vertical");
   });
 
   test("can split without TMUX_PANE by omitting anchor", async () => {
@@ -43,9 +48,19 @@ describe("wake maybeSplit", () => {
 
     await maybeSplit("20-homekeeper:homekeeper-oracle", { split: true });
 
-    expect(hostExecCalls).toHaveLength(1);
+    expect(hostExecCalls).toHaveLength(3);
     expect(hostExecCalls[0]).not.toContain("-t '%");
     expect(hostExecCalls[0]).toContain("tmux split-window -h -l 50%");
+    expect(hostExecCalls[1]).toContain("tmux list-panes ");
+    expect(hostExecCalls[2]).toContain("tmux select-layout main-vertical");
+  });
+
+  test("uses tiled layout after split when pane count is high", async () => {
+    listPanesResponse = "5\n";
+
+    await maybeSplit("20-homekeeper:homekeeper-oracle", { split: true });
+
+    expect(hostExecCalls[2]).toContain("tmux select-layout -t '%42' tiled");
   });
 
   test("opens a new tmux window/tab for bring default mode", async () => {


### PR DESCRIPTION
## Summary
- reflow explicit `maw bring --split` windows after the tmux split
- use `main-vertical` for up to four panes and `tiled` above that
- keep reflow best-effort so a successful split is not failed by layout polish

Fixes #1408.

## Tests
- `MAW_TEST_MODE=1 rtk bun test test/isolated/wake-maybe-split.test.ts test/wake-bring.test.ts`
- `rtk bun build src/cli.ts --outfile /tmp/maw-bring-split-layout-check --target=bun --external @eclipse-zenoh/zenoh-ts`

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
