### PR TITLE
feat(alias): add maw b shorthand for bring

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -44,7 +44,8 @@ export const ALIAS_DESCRIPTIONS: Record<string, string> = {
   panes: "List all panes across sessions",
   cleanup: "Kill zombie agent panes",
   tile: "Tile current window or spawn N panes tiled",
-  bring: "Bring an oracle HERE (split pane) — symmetric with `a` (go there)",
+  bring: "Bring an oracle HERE — symmetric with `a` (go there)",
+  b: "Bring an oracle HERE (short form of `bring`)",
   ls: "List sessions (compact, -a roster, -v detail)",
   wake: "Wake an oracle session (fuzzy match, auto-clone)",
   preflight: "Pre-flight check — version, plugins, dead agents, config",
@@ -64,6 +65,7 @@ export const TOP_ALIASES: Record<string, string[] | DirectHandler> = {
   cleanup: ["team", "cleanup", "--zombie-agents"],
   tile: ["tile"],
   bring: { kind: "direct", handler: "../commands/shared/wake-cmd:cmdBring" },
+  b: { kind: "direct", handler: "../commands/shared/wake-cmd:cmdBring" },
 
   // Direct-handler form — `ls` flags differ from tmux ls:
   //   maw ls      → compact, live sessions only

--- a/test/cli/dispatch-match.test.ts
+++ b/test/cli/dispatch-match.test.ts
@@ -10,7 +10,7 @@
  */
 import { describe, test, expect } from "bun:test";
 import { resolvePluginMatch } from "../../src/cli/dispatch-match";
-import { parseBringArgs, resolveTopAlias } from "../../src/cli/top-aliases";
+import { ALIAS_DESCRIPTIONS, parseBringArgs, resolveTopAlias } from "../../src/cli/top-aliases";
 import type { LoadedPlugin } from "../../src/plugin/types";
 
 function plugin(name: string, command: string, aliases: string[] = []): LoadedPlugin {
@@ -219,6 +219,18 @@ describe("resolveTopAlias — RFC #954 verb aliases", () => {
   test("`bring neo` defaults to tab/window mode, not split", () => {
     const parsed = parseBringArgs(["neo"]);
     expect(parsed).toEqual({ oracle: "neo", opts: { bring: true } });
+  });
+
+  test("`b neo` is a direct shorthand for bring", () => {
+    const out = resolveTopAlias(["b", "neo"]);
+    expect(out).not.toBeNull();
+    expect(out!.kind).toBe("direct");
+    if (out!.kind === "direct") {
+      expect(out!.handler).toContain("wake-cmd");
+      expect(out!.handler).toContain("cmdBring");
+      expect(out!.argv).toEqual(["neo"]);
+    }
+    expect(ALIAS_DESCRIPTIONS.b).toContain("short form of `bring`");
   });
 
   test("`bring neo --split` opts into split mode", () => {


### PR DESCRIPTION
## Summary

- add `maw b` as a top-level direct-handler alias for `maw bring`
- list `maw b` in help text alongside existing short aliases
- add a dispatch regression for the shorthand preserving argv for `cmdBring`

Refs #1415.

## Test

- `bun test test/cli/dispatch-match.test.ts`
- `bun run build`
- `MAW_TEST_MODE=1 bun src/cli.ts --help 2>/dev/null | rg 'maw b\\s+Bring an oracle HERE'`

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
