### PR TITLE
fix(bring): preserve tile-pane split orientation

### DIFF
--- a/src/commands/shared/wake-maybe-split.ts
+++ b/src/commands/shared/wake-maybe-split.ts
@@ -29,6 +29,16 @@ async function restoreSplitLayout(anchor?: string): Promise<void> {
   }
 }
 
+async function isMawTilePane(anchor?: string): Promise<boolean> {
+  if (!anchor) return false;
+  try {
+    const raw = await hostExec(`tmux show-options -p -t ${shellArg(anchor)} -v @maw_tile 2>/dev/null || true`);
+    return String(raw).trim() === "1";
+  } catch {
+    return false;
+  }
+}
+
 export async function maybeSplit(target: string, opts: { split?: boolean }): Promise<void> {
   if (!opts.split) return;
   if (process.env.TMUX) {
@@ -37,7 +47,9 @@ export async function maybeSplit(target: string, opts: { split?: boolean }): Pro
       const targetFlag = anchor ? `-t ${shellArg(anchor)} ` : "";
       const innerCmd = `TMUX= tmux attach-session -t ${shellArg(target)}`;
       await hostExec(`tmux split-window ${targetFlag}-h -l 50% ${shellArg(innerCmd)}`);
-      await restoreSplitLayout(anchor);
+      if (!(await isMawTilePane(anchor))) {
+        await restoreSplitLayout(anchor);
+      }
       console.log(`  \x1b[32m✓\x1b[0m split beside — ${target} (50%)`);
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);

--- a/test/isolated/wake-maybe-split.test.ts
+++ b/test/isolated/wake-maybe-split.test.ts
@@ -3,10 +3,12 @@ import { join } from "path";
 
 let hostExecCalls: string[] = [];
 let listPanesResponse = "3\n";
+let tileMarkerResponse = "";
 
 mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
   hostExec: async (cmd: string) => {
     hostExecCalls.push(cmd);
+    if (cmd.includes("show-options") && cmd.includes("@maw_tile")) return tileMarkerResponse;
     if (cmd.includes("list-panes")) return listPanesResponse;
     return "";
   },
@@ -21,6 +23,7 @@ describe("wake maybeSplit", () => {
   beforeEach(() => {
     hostExecCalls = [];
     listPanesResponse = "3\n";
+    tileMarkerResponse = "";
     process.env.TMUX = "/tmp/tmux-501/default,123,0";
     process.env.TMUX_PANE = "%42";
   });
@@ -33,14 +36,28 @@ describe("wake maybeSplit", () => {
   test("splits current pane and attaches target without importing removed split plugin", async () => {
     await maybeSplit("20-homekeeper:homekeeper-oracle", { split: true });
 
-    expect(hostExecCalls).toHaveLength(3);
+    expect(hostExecCalls).toHaveLength(4);
     expect(hostExecCalls[0]).toContain("tmux split-window");
     expect(hostExecCalls[0]).toContain("-t '%42'");
     expect(hostExecCalls[0]).toContain("-h -l 50%");
     expect(hostExecCalls[0]).toContain("TMUX= tmux attach-session -t");
     expect(hostExecCalls[0]).toContain("20-homekeeper:homekeeper-oracle");
-    expect(hostExecCalls[1]).toContain("tmux list-panes -t '%42'");
-    expect(hostExecCalls[2]).toContain("tmux select-layout -t '%42' main-vertical");
+    expect(hostExecCalls[1]).toContain("tmux show-options -p -t '%42' -v @maw_tile");
+    expect(hostExecCalls[2]).toContain("tmux list-panes -t '%42'");
+    expect(hostExecCalls[3]).toContain("tmux select-layout -t '%42' main-vertical");
+  });
+
+  test("preserves horizontal split when splitting from a maw tile pane", async () => {
+    tileMarkerResponse = "1\n";
+
+    await maybeSplit("20-homekeeper:homekeeper-oracle", { split: true });
+
+    expect(hostExecCalls).toHaveLength(2);
+    expect(hostExecCalls[0]).toContain("tmux split-window");
+    expect(hostExecCalls[0]).toContain("-t '%42'");
+    expect(hostExecCalls[0]).toContain("-h -l 50%");
+    expect(hostExecCalls[1]).toContain("tmux show-options -p -t '%42' -v @maw_tile");
+    expect(hostExecCalls.some(cmd => cmd.includes("tmux select-layout"))).toBe(false);
   });
 
   test("can split without TMUX_PANE by omitting anchor", async () => {
@@ -60,7 +77,7 @@ describe("wake maybeSplit", () => {
 
     await maybeSplit("20-homekeeper:homekeeper-oracle", { split: true });
 
-    expect(hostExecCalls[2]).toContain("tmux select-layout -t '%42' tiled");
+    expect(hostExecCalls[3]).toContain("tmux select-layout -t '%42' tiled");
   });
 
   test("opens a new tmux window/tab for bring default mode", async () => {


### PR DESCRIPTION
## Summary

- skip `restoreSplitLayout()` when `maw bring --split` / `maw b --split` is invoked from a pane marked `@maw_tile=1`
- keep #1414's reflow path for non-tile/lead-pane splits so #1408 remains covered
- add an isolated regression that ensures tile-pane splits do not call `tmux select-layout`

Closes #1419.

## Test

- `bun test test/isolated/wake-maybe-split.test.ts`
- `bun test test/cli/dispatch-match.test.ts`
- `bun run build`

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
