### PR TITLE
feat(bring): replace top-right pane by default

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -106,25 +106,28 @@ export function resolveTopAlias(args: string[]): AliasResolution | null {
 
 export function parseBringArgs(argv: string[]): {
   oracle: string;
-  opts: { bring?: true; split?: boolean; engine?: string };
+  opts: { bring?: true; split?: boolean; tab?: boolean; engine?: string };
 } {
-  // `maw bring <oracle>` opens a new tmux window/tab by default. `--split`
-  // remains available as the opt-in layout-mutating form.
+  // `maw bring <oracle>` replaces the top-right pane when possible. `--split`
+  // remains available as the opt-in layout-mutating form, while `--tab`
+  // preserves the old background-tab behavior explicitly.
   const flags = parseFlags(argv, {
     "--engine": String, "-e": "--engine",
     "--split": Boolean,
+    "--tab": Boolean,
   }, 0);
   const oracle = (flags._ as string[])[0];
   if (!oracle) {
-    console.error("usage: maw bring <oracle> [--split] [-e|--engine <name>]");
-    console.error("  Opens oracle in a new tmux window/tab by default.");
+    console.error("usage: maw bring <oracle> [--split|--tab] [-e|--engine <name>]");
+    console.error("  Replaces the top-right pane by default when one exists.");
     console.error("  Use --split to split the current pane instead.");
+    console.error("  Use --tab to force a background tmux tab.");
     console.error("  Symmetric with `maw a` (attach goes there, bring comes here).");
     throw new UserError("bring: missing oracle name");
   }
-  const opts: { bring?: true; split?: boolean; engine?: string } = flags["--split"]
+  const opts: { bring?: true; split?: boolean; tab?: boolean; engine?: string } = flags["--split"]
     ? { split: true }
-    : { bring: true };
+    : { bring: true, ...(flags["--tab"] ? { tab: true } : {}) };
   if (flags["--engine"]) opts.engine = flags["--engine"];
   return { oracle, opts };
 }

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -17,7 +17,7 @@ export function shouldOfferExistingSessionAttach(
   return !opts.attach && !opts.split && !opts.bring && Boolean(isTTY);
 }
 
-export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; split?: boolean; bring?: boolean; repoPath?: string; urlRepoName?: string; allLocal?: boolean; engine?: string }): Promise<string> {
+export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; split?: boolean; bring?: boolean; tab?: boolean; repoPath?: string; urlRepoName?: string; allLocal?: boolean; engine?: string }): Promise<string> {
   // Canonicalize the bare name before any lookup — strips trailing `/`, `/.git`, `/.git/`
   // so `maw wake token-oracle/` (tab-completion artifact) resolves the same as `token-oracle`.
   oracle = normalizeTarget(oracle);

--- a/src/commands/shared/wake-maybe-split.ts
+++ b/src/commands/shared/wake-maybe-split.ts
@@ -39,6 +39,44 @@ async function isMawTilePane(anchor?: string): Promise<boolean> {
   }
 }
 
+type PaneGeometry = {
+  id: string;
+  top: number;
+  left: number;
+  isTile: boolean;
+};
+
+function parsePaneGeometry(raw: string): PaneGeometry[] {
+  return raw
+    .split("\n")
+    .map(line => line.trim())
+    .filter(Boolean)
+    .map(line => {
+      const [id, top, left, tile] = line.split("|");
+      return {
+        id: id || "",
+        top: Number.parseInt(top || "", 10),
+        left: Number.parseInt(left || "", 10),
+        isTile: tile === "1",
+      };
+    })
+    .filter(p => p.id && Number.isFinite(p.top) && Number.isFinite(p.left));
+}
+
+/** @internal — exported for tests only. */
+export async function findTopRightPane(anchor?: string): Promise<string | null> {
+  if (!anchor) return null;
+  const targetFlag = `-t ${shellArg(anchor)} `;
+  const raw = await hostExec(`tmux list-panes ${targetFlag}-F '#{pane_id}|#{pane_top}|#{pane_left}|#{@maw_tile}'`);
+  const panes = parsePaneGeometry(String(raw)).filter(p => p.id !== anchor);
+  if (panes.length === 0) return null;
+
+  const tilePanes = panes.filter(p => p.isTile);
+  const candidates = tilePanes.length > 0 ? tilePanes : panes;
+  candidates.sort((a, b) => a.top - b.top || b.left - a.left || a.id.localeCompare(b.id));
+  return candidates[0]?.id ?? null;
+}
+
 export async function maybeSplit(target: string, opts: { split?: boolean }): Promise<void> {
   if (!opts.split) return;
   if (process.env.TMUX) {
@@ -72,16 +110,28 @@ export async function maybeSplit(target: string, opts: { split?: boolean }): Pro
   }
 }
 
-export async function maybeOpenWindow(target: string, opts: { bring?: boolean }): Promise<void> {
+async function openBackgroundTab(target: string): Promise<void> {
+  const session = target.split(":")[0] || target;
+  const targetWindow = target.split(":").slice(1).join(":") || session;
+  const windowName = `bring-${targetWindow}`.replace(/[^A-Za-z0-9_.-]/g, "-").slice(0, 80) || "bring";
+  const innerCmd = `TMUX= tmux attach-session -t ${shellArg(target)}`;
+  await hostExec(`tmux new-window -d -n ${shellArg(windowName)} ${shellArg(innerCmd)}`);
+  console.log(`  \x1b[32m✓\x1b[0m opened background tab — ${target}`);
+}
+
+export async function maybeOpenWindow(target: string, opts: { bring?: boolean; tab?: boolean }): Promise<void> {
   if (!opts.bring) return;
   const session = target.split(":")[0] || target;
   if (process.env.TMUX) {
     try {
-      const targetWindow = target.split(":").slice(1).join(":") || session;
-      const windowName = `bring-${targetWindow}`.replace(/[^A-Za-z0-9_.-]/g, "-").slice(0, 80) || "bring";
       const innerCmd = `TMUX= tmux attach-session -t ${shellArg(target)}`;
-      await hostExec(`tmux new-window -d -n ${shellArg(windowName)} ${shellArg(innerCmd)}`);
-      console.log(`  \x1b[32m✓\x1b[0m opened background tab — ${target}`);
+      const replacementPane = opts.tab ? null : await findTopRightPane(process.env.TMUX_PANE);
+      if (replacementPane) {
+        await hostExec(`tmux respawn-pane -k -t ${shellArg(replacementPane)} ${shellArg(innerCmd)}`);
+        console.log(`  \x1b[32m✓\x1b[0m replaced top-right pane — ${target}`);
+      } else {
+        await openBackgroundTab(target);
+      }
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);
       console.log(`  \x1b[33m⚠\x1b[0m bring failed: ${message}`);

--- a/test/cli/dispatch-match.test.ts
+++ b/test/cli/dispatch-match.test.ts
@@ -216,7 +216,7 @@ describe("resolveTopAlias — RFC #954 verb aliases", () => {
     }
   });
 
-  test("`bring neo` defaults to tab/window mode, not split", () => {
+  test("`bring neo` defaults to bring-pane mode, not split", () => {
     const parsed = parseBringArgs(["neo"]);
     expect(parsed).toEqual({ oracle: "neo", opts: { bring: true } });
   });
@@ -236,6 +236,11 @@ describe("resolveTopAlias — RFC #954 verb aliases", () => {
   test("`bring neo --split` opts into split mode", () => {
     const parsed = parseBringArgs(["neo", "--split", "-e", "codex"]);
     expect(parsed).toEqual({ oracle: "neo", opts: { split: true, engine: "codex" } });
+  });
+
+  test("`bring neo --tab` forces the old background tab mode", () => {
+    const parsed = parseBringArgs(["neo", "--tab"]);
+    expect(parsed).toEqual({ oracle: "neo", opts: { bring: true, tab: true } });
   });
 
   test("`audit` → null (does NOT shadow CORE_ROUTES)", () => {

--- a/test/isolated/wake-maybe-split.test.ts
+++ b/test/isolated/wake-maybe-split.test.ts
@@ -4,17 +4,21 @@ import { join } from "path";
 let hostExecCalls: string[] = [];
 let listPanesResponse = "3\n";
 let tileMarkerResponse = "";
+let paneGeometryResponse = "%42|0|0|\n%43|0|81|1\n%44|26|81|1\n";
 
 mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
   hostExec: async (cmd: string) => {
     hostExecCalls.push(cmd);
     if (cmd.includes("show-options") && cmd.includes("@maw_tile")) return tileMarkerResponse;
+    if (cmd.includes("list-panes") && cmd.includes("#{pane_id}|#{pane_top}|#{pane_left}|#{@maw_tile}")) {
+      return paneGeometryResponse;
+    }
     if (cmd.includes("list-panes")) return listPanesResponse;
     return "";
   },
 }));
 
-const { maybeOpenWindow, maybeSplit } = await import("../../src/commands/shared/wake-maybe-split");
+const { findTopRightPane, maybeOpenWindow, maybeSplit } = await import("../../src/commands/shared/wake-maybe-split");
 
 describe("wake maybeSplit", () => {
   const originalTmux = process.env.TMUX;
@@ -24,6 +28,7 @@ describe("wake maybeSplit", () => {
     hostExecCalls = [];
     listPanesResponse = "3\n";
     tileMarkerResponse = "";
+    paneGeometryResponse = "%42|0|0|\n%43|0|81|1\n%44|26|81|1\n";
     process.env.TMUX = "/tmp/tmux-501/default,123,0";
     process.env.TMUX_PANE = "%42";
   });
@@ -80,14 +85,38 @@ describe("wake maybeSplit", () => {
     expect(hostExecCalls[3]).toContain("tmux select-layout -t '%42' tiled");
   });
 
-  test("opens a new tmux window/tab for bring default mode", async () => {
+  test("finds the top-right tile pane, excluding the caller", async () => {
+    const pane = await findTopRightPane("%42");
+
+    expect(pane).toBe("%43");
+  });
+
+  test("replaces the top-right pane for bring default mode", async () => {
     await maybeOpenWindow("20-homekeeper:homekeeper-oracle", { bring: true });
+
+    expect(hostExecCalls).toHaveLength(2);
+    expect(hostExecCalls[0]).toContain("tmux list-panes -t '%42' -F");
+    expect(hostExecCalls[1]).toContain("tmux respawn-pane -k -t '%43'");
+    expect(hostExecCalls[1]).toContain("TMUX= tmux attach-session -t");
+    expect(hostExecCalls[1]).toContain("20-homekeeper:homekeeper-oracle");
+  });
+
+  test("falls back to a background tab when no replacement pane exists", async () => {
+    paneGeometryResponse = "%42|0|0|\n";
+
+    await maybeOpenWindow("20-homekeeper:homekeeper-oracle", { bring: true });
+
+    expect(hostExecCalls).toHaveLength(2);
+    expect(hostExecCalls[0]).toContain("tmux list-panes -t '%42' -F");
+    expect(hostExecCalls[1]).toContain("tmux new-window -d");
+    expect(hostExecCalls[1]).toContain("-n 'bring-homekeeper-oracle'");
+  });
+
+  test("can force the old background-tab behavior", async () => {
+    await maybeOpenWindow("20-homekeeper:homekeeper-oracle", { bring: true, tab: true });
 
     expect(hostExecCalls).toHaveLength(1);
     expect(hostExecCalls[0]).toContain("tmux new-window -d");
-    expect(hostExecCalls[0]).toContain("-n 'bring-homekeeper-oracle'");
-    expect(hostExecCalls[0]).toContain("TMUX= tmux attach-session -t");
-    expect(hostExecCalls[0]).toContain("20-homekeeper:homekeeper-oracle");
   });
 
   test("does not open a window when bring is not requested", async () => {

--- a/test/wake-bring.test.ts
+++ b/test/wake-bring.test.ts
@@ -10,7 +10,7 @@ describe("maw bring existing-session behavior", () => {
     expect(shouldOfferExistingSessionAttach({ split: true }, true)).toBe(false);
   });
 
-  test("bring default tab mode never offers the destructive attach prompt", () => {
+  test("bring default mode never offers the destructive attach prompt", () => {
     expect(shouldOfferExistingSessionAttach({ bring: true }, true)).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

- make default `maw bring <oracle>` / `maw b <oracle>` replace the top-right pane when the current tmux window has a replacement pane
- prefer panes marked `@maw_tile=1`, then pick top-most/right-most; never replace the caller pane
- preserve the old background-tab behavior as explicit `--tab`
- keep `--split` unchanged

Closes #1416.

## Test

- `bun test test/isolated/wake-maybe-split.test.ts`
- `bun test test/cli/dispatch-match.test.ts`
- `bun test test/wake-bring.test.ts`
- `bun run build`

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
