### PR TITLE
fix(plugin): make capability warnings self-diagnose stale runtimes

### DIFF
--- a/src/cli/cmd-version.ts
+++ b/src/cli/cmd-version.ts
@@ -1,15 +1,5 @@
-import { execSync } from "child_process";
+import { getRuntimeVersionString } from "../core/runtime/build-info";
 
 export function getVersionString(): string {
-  const pkg = require("../../package.json");
-  let hash = "";
-  try { hash = execSync("git rev-parse --short HEAD", { cwd: import.meta.dir, stdio: "pipe" }).toString().trim(); } catch {}
-  let buildDate = "";
-  try {
-    const raw = execSync("git log -1 --format=%ci", { cwd: import.meta.dir, stdio: "pipe" }).toString().trim();
-    const d = new Date(raw);
-    const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-    buildDate = `${raw.slice(0, 10)} ${days[d.getDay()]} ${raw.slice(11, 16)}`;
-  } catch {}
-  return `maw v${pkg.version}${hash ? ` (${hash})` : ""}${buildDate ? ` built ${buildDate}` : ""}`;
+  return getRuntimeVersionString();
 }

--- a/src/core/runtime/build-info.ts
+++ b/src/core/runtime/build-info.ts
@@ -1,0 +1,30 @@
+import { execSync } from "child_process";
+
+let cachedVersionString: string | undefined;
+
+export function getRuntimeVersionString(): string {
+  if (cachedVersionString !== undefined) return cachedVersionString;
+
+  const pkg = require("../../../package.json");
+  let hash = "";
+  try {
+    hash = execSync("git rev-parse --short HEAD", {
+      cwd: import.meta.dir,
+      stdio: "pipe",
+    }).toString().trim();
+  } catch {}
+
+  let buildDate = "";
+  try {
+    const raw = execSync("git log -1 --format=%ci", {
+      cwd: import.meta.dir,
+      stdio: "pipe",
+    }).toString().trim();
+    const d = new Date(raw);
+    const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+    buildDate = `${raw.slice(0, 10)} ${days[d.getDay()]} ${raw.slice(11, 16)}`;
+  } catch {}
+
+  cachedVersionString = `maw v${pkg.version}${hash ? ` (${hash})` : ""}${buildDate ? ` built ${buildDate}` : ""}`;
+  return cachedVersionString;
+}

--- a/src/plugin/manifest-constants.ts
+++ b/src/plugin/manifest-constants.ts
@@ -18,7 +18,12 @@
  * load-time path appeared to lag the install-time path — in fact both
  * paths now share this constant via parseCapabilities(). The
  * test/isolated/plugin-load-capability-902.test.ts regression suite locks
- * the load-path against this set so any future drift fails CI. */
+ * the load-path against this set so any future drift fails CI.
+ *
+ * #1418 — add `attach` to mainline too. Alpha already accepted
+ * attach:strategy via #1291, but main diverged and released alphas from main
+ * regressed to warning on every CLI load when mpr's attach-ssh plugin is
+ * installed. */
 export const KNOWN_CAPABILITY_NAMESPACES = new Set([
   "net",    // network (fetch, sockets)
   "fs",     // filesystem
@@ -28,6 +33,7 @@ export const KNOWN_CAPABILITY_NAMESPACES = new Set([
   "ffi",    // native FFI (bun:ffi)
   "tmux",   // tmux socket interaction (spawnSync("tmux", …) + SDK tmux helpers)
   "shell",  // shell-eval / stdout-writing plugins (shellenv-style)
+  "attach", // attach strategies (mpr attach-ssh declares attach:strategy)
 ]);
 
 /**

--- a/src/plugin/manifest-validate.ts
+++ b/src/plugin/manifest-validate.ts
@@ -5,6 +5,7 @@
 
 import type { PluginManifest, PluginTier } from "./types";
 import { KNOWN_CAPABILITY_NAMESPACES } from "./manifest-constants";
+import { getRuntimeVersionString } from "../core/runtime/build-info";
 
 const VALID_TIERS = new Set<PluginTier>(["core", "standard", "extra"]);
 
@@ -169,7 +170,9 @@ export function parseCapabilities(r: Record<string, unknown>): PluginManifest["c
     if (!KNOWN_CAPABILITY_NAMESPACES.has(ns)) {
       console.warn(
         `plugin.json: unknown capability namespace "${ns}" in "${cap}" ` +
-          `(known: ${[...KNOWN_CAPABILITY_NAMESPACES].join(", ")})`,
+          `(known: ${[...KNOWN_CAPABILITY_NAMESPACES].join(", ")})\n` +
+          `  ↳ runtime: ${getRuntimeVersionString()} — if this namespace is expected, update maw: ` +
+          `bun add -g github:Soul-Brews-Studio/maw-js#alpha`,
       );
     }
   }

--- a/test/isolated/plugin-load-capability-902.test.ts
+++ b/test/isolated/plugin-load-capability-902.test.ts
@@ -74,9 +74,9 @@ function makePluginDir(opts: {
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe("#902 — load-time capability validator (single source of truth)", () => {
-  test("KNOWN_CAPABILITY_NAMESPACES is the canonical set (#874 baseline)", () => {
+  test("KNOWN_CAPABILITY_NAMESPACES is the canonical set (#874/#1418 baseline)", () => {
     expect([...KNOWN_CAPABILITY_NAMESPACES].sort()).toEqual(
-      ["ffi", "fs", "net", "peer", "proc", "sdk", "shell", "tmux"],
+      ["attach", "ffi", "fs", "net", "peer", "proc", "sdk", "shell", "tmux"],
     );
   });
 
@@ -102,6 +102,17 @@ describe("#902 — load-time capability validator (single source of truth)", () 
     expect(shellWarns).toEqual([]);
   });
 
+  test("load-time: plugin with `attach:strategy` capability does NOT warn", () => {
+    const dir = makePluginDir({ name: "attach-ssh", capabilities: ["attach:strategy"] });
+    const loaded = loadManifestFromDir(dir);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.manifest.capabilities).toEqual(["attach:strategy"]);
+    const attachWarns = warnings.filter((w) =>
+      w.includes('unknown capability namespace "attach"'),
+    );
+    expect(attachWarns).toEqual([]);
+  });
+
   test("load-time: plugin with bogus namespace `foo` DOES warn", () => {
     const dir = makePluginDir({ name: "bogus-cap", capabilities: ["foo:bar"] });
     const loaded = loadManifestFromDir(dir);
@@ -125,9 +136,13 @@ describe("#902 — load-time capability validator (single source of truth)", () 
     for (const ns of KNOWN_CAPABILITY_NAMESPACES) {
       expect(fooWarn!).toContain(ns);
     }
+    expect(fooWarn!).toContain("runtime: maw v");
+    expect(fooWarn!).toContain("bun add -g github:Soul-Brews-Studio/maw-js#alpha");
     // Specifically tmux + shell — the two #874 added — must appear.
     expect(fooWarn!).toContain("tmux");
     expect(fooWarn!).toContain("shell");
+    // Specifically attach — the #1418 regression namespace — must appear.
+    expect(fooWarn!).toContain("attach");
   });
 
   test("load-time: every canonical namespace passes silently (no warning per known ns)", () => {

--- a/test/plugin-manifest-v1.test.ts
+++ b/test/plugin-manifest-v1.test.ts
@@ -88,7 +88,7 @@ describe("manifest v1 — new fields", () => {
     // #874 — `tmux` and `shell` joined the namespace list to support community
     // plugins (bg, rename, park, shellenv) that spawn tmux or shell-eval.
     expect([...KNOWN_CAPABILITY_NAMESPACES].sort()).toEqual(
-      ["net", "fs", "peer", "sdk", "proc", "ffi", "tmux", "shell"].sort(),
+      ["net", "fs", "peer", "sdk", "proc", "ffi", "tmux", "shell", "attach"].sort(),
     );
   });
 });
@@ -230,6 +230,8 @@ describe("manifest v1 — capabilities", () => {
       expect(warn).toHaveBeenCalled();
       const msg = warn.mock.calls[0]?.[0] as string;
       expect(msg).toMatch(/blockchain/);
+      expect(msg).toContain("runtime: maw v");
+      expect(msg).toContain("bun add -g github:Soul-Brews-Studio/maw-js#alpha");
     } finally {
       warn.mockRestore();
       rmSync(dir, { recursive: true });


### PR DESCRIPTION
## Summary
- restore `attach` as a canonical capability namespace on main so mpr `attach:strategy` plugins do not warn
- include the current maw runtime/version in unknown capability warnings with an update hint
- share the version-string implementation between `maw --version` and validator diagnostics

Fixes #1418.

## Verification
- `bun test test/plugin-manifest-v1.test.ts test/isolated/plugin-load-capability-902.test.ts test/isolated/install-source-plugin.test.ts`
- `bun run build`
- `./dist/maw --version`
- dist smoke: `MAW_PLUGINS_DIR=<tmp attach:strategy plugin> ./dist/maw plugins` with no `unknown capability namespace "attach"` warning

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.