### PR TITLE
fix(tile): make tile cleanup branch-safe

### DIFF
--- a/src/commands/plugins/tile/impl.ts
+++ b/src/commands/plugins/tile/impl.ts
@@ -226,19 +226,37 @@ export async function cmdTileClean(): Promise<void> {
     const parentDir = dirname(repoPath);
     const repoName = basename(repoPath).replace(/\.wt-.*$/, "");
     const mainRepo = `${parentDir}/${repoName}`;
-    const wtRaw = await hostExec(`git -C '${mainRepo}' worktree list --porcelain 2>/dev/null`);
-    const tileWts = wtRaw.split("\n")
-      .filter(l => l.startsWith("worktree "))
-      .map(l => l.replace("worktree ", ""))
-      .filter(p => /\.wt-\d+-tile-\d+$/.test(p));
+    const wtRaw = await hostExec(`git -C ${shellArg(mainRepo)} worktree list --porcelain 2>/dev/null`);
+    const tileWts: { path: string; branch?: string }[] = [];
+    let current: { path: string; branch?: string } | null = null;
+    for (const line of wtRaw.split("\n")) {
+      if (line.startsWith("worktree ")) {
+        if (current) tileWts.push(current);
+        current = { path: line.replace("worktree ", "") };
+      } else if (line.startsWith("branch ") && current) {
+        current.branch = line.replace("branch refs/heads/", "").replace("branch ", "");
+      }
+    }
+    if (current) tileWts.push(current);
 
-    for (const wt of tileWts) {
+    for (const wtInfo of tileWts.filter(w => /\.wt-\d+-tile-\d+$/.test(w.path))) {
+      const wt = wtInfo.path;
       if (!existsSync(wt)) continue;
       try {
-        await hostExec(`git -C '${mainRepo}' worktree remove '${wt}' --force 2>/dev/null`);
+        await hostExec(`git -C ${shellArg(mainRepo)} worktree remove ${shellArg(wt)} --force 2>/dev/null`);
         console.log(`  \x1b[31m✗\x1b[0m worktree ${wt}`);
         killed++;
       } catch { /* ok */ }
+      const branch = wtInfo.branch;
+      if (branch && /^agents\/\d+-tile-\d+$/.test(branch)) {
+        try {
+          await hostExec(`git -C ${shellArg(mainRepo)} branch -d ${shellArg(branch)} 2>/dev/null`);
+          console.log(`  \x1b[31m✗\x1b[0m branch ${branch}`);
+          killed++;
+        } catch {
+          console.log(`  \x1b[33m⚠\x1b[0m kept branch ${branch} (not fully merged)`);
+        }
+      }
     }
   } catch { /* not in a git repo */ }
 

--- a/src/commands/shared/wake-session.ts
+++ b/src/commands/shared/wake-session.ts
@@ -70,15 +70,39 @@ export async function createWorktree(
   existingWorktrees: { name: string; path: string }[],
 ): Promise<{ wtPath: string; windowName: string }> {
   const nums = existingWorktrees.map(w => parseInt(w.name) || 0);
-  const nextNum = nums.length > 0 ? Math.max(...nums) + 1 : 1;
-  const wtName = `${nextNum}-${name}`;
-  const wtPath = `${parentDir}/${repoName}.wt-${wtName}`;
-  const branch = `agents/${wtName}`;
+  let nextNum = nums.length > 0 ? Math.max(...nums) + 1 : 1;
   const safe = (s: string) => s.replace(/'/g, "'\\''");
   try { await hostExec(`git -C '${safe(repoPath)}' rev-parse HEAD 2>/dev/null`); } catch {
     await hostExec(`git -C '${safe(repoPath)}' commit --allow-empty -m "init: bootstrap for worktree"`);
   }
-  try { await hostExec(`git -C '${safe(repoPath)}' branch -D '${safe(branch)}' 2>/dev/null`); } catch { /* ok */ }
+
+  let wtName = "";
+  let wtPath = "";
+  let branch = "";
+  let allocated = false;
+  for (let attempts = 0; attempts < 1000; attempts++) {
+    wtName = `${nextNum}-${name}`;
+    wtPath = `${parentDir}/${repoName}.wt-${wtName}`;
+    branch = `agents/${wtName}`;
+    const knownWorktree = existingWorktrees.some(w => w.name === wtName || w.path === wtPath);
+    if (knownWorktree) {
+      nextNum++;
+      continue;
+    }
+    try {
+      await hostExec(`git -C '${safe(repoPath)}' show-ref --verify --quiet 'refs/heads/${safe(branch)}'`);
+      nextNum++;
+      continue;
+    } catch {
+      allocated = true;
+      break;
+    }
+  }
+
+  if (!allocated || !wtName || !wtPath || !branch) {
+    throw new Error(`could not allocate worktree for ${name}`);
+  }
+
   await hostExec(`git -C '${safe(repoPath)}' worktree add '${safe(wtPath)}' -b '${safe(branch)}'`);
   console.log(`\x1b[32m+\x1b[0m worktree: ${wtPath} (${branch})`);
   return { wtPath, windowName: `${oracle}-${name}` };

--- a/test/isolated/tile.test.ts
+++ b/test/isolated/tile.test.ts
@@ -7,6 +7,7 @@
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { join } from "path";
+import { mkdirSync, rmSync } from "fs";
 
 let commands: string[] = [];
 let nextPane = 1;
@@ -58,6 +59,7 @@ beforeEach(() => {
   nextPane = 1;
   paneList = "";
   worktreeList = "";
+  rmSync("/tmp/maw-js.wt-1-tile-1", { recursive: true, force: true });
   process.env.TMUX_PANE = "%lead";
 });
 
@@ -153,6 +155,31 @@ describe("tile clean", () => {
     expect(commands).toContain("tmux kill-pane -t '%p3'");
     expect(commands).not.toContain("tmux kill-pane -t '%p2'");
     expect(commands).not.toContain("tmux kill-pane -t '%lead'");
+  });
+
+  test("removes tile worktrees and safely deletes matching tile branches", async () => {
+    mkdirSync("/tmp/maw-js.wt-1-tile-1", { recursive: true });
+    worktreeList = [
+      "worktree /tmp/maw-js",
+      "HEAD 1111111111111111111111111111111111111111",
+      "branch refs/heads/main",
+      "",
+      "worktree /tmp/maw-js.wt-1-tile-1",
+      "HEAD 2222222222222222222222222222222222222222",
+      "branch refs/heads/agents/1-tile-1",
+      "",
+      "worktree /tmp/maw-js.wt-2-task",
+      "HEAD 3333333333333333333333333333333333333333",
+      "branch refs/heads/agents/2-task",
+    ].join("\n");
+
+    await cmdTileClean();
+
+    expect(commands).toContain("git -C '/tmp/maw-js' worktree remove '/tmp/maw-js.wt-1-tile-1' --force 2>/dev/null");
+    expect(commands).toContain("git -C '/tmp/maw-js' branch -d 'agents/1-tile-1' 2>/dev/null");
+    expect(commands.some(cmd => cmd.includes("agents/2-task"))).toBe(false);
+
+    rmSync("/tmp/maw-js.wt-1-tile-1", { recursive: true, force: true });
   });
 });
 

--- a/test/isolated/wake-session-worktree.test.ts
+++ b/test/isolated/wake-session-worktree.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Worktree creation tests — ISOLATED SUITE.
+ *
+ * Why isolated: createWorktree shells through @maw-js/sdk/hostExec.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { join } from "path";
+
+let commands: string[] = [];
+let existingBranches = new Set<string>();
+
+mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
+  hostExec: async (cmd: string): Promise<string> => {
+    commands.push(cmd);
+    if (cmd.includes("rev-parse HEAD")) return "abc123\n";
+    const branchMatch = cmd.match(/show-ref --verify --quiet 'refs\/heads\/([^']+)'/);
+    if (branchMatch) {
+      if (existingBranches.has(branchMatch[1])) return "";
+      throw new Error("missing ref");
+    }
+    return "";
+  },
+  tmux: {},
+}));
+
+const { createWorktree } = await import("../../src/commands/shared/wake-session");
+
+beforeEach(() => {
+  commands = [];
+  existingBranches = new Set<string>();
+});
+
+describe("createWorktree", () => {
+  test("creates the next worktree branch without deleting existing branches", async () => {
+    await createWorktree("/repo", "/tmp", "repo", "oracle", "tile-1", []);
+
+    expect(commands.some(cmd => cmd.includes("branch -D"))).toBe(false);
+    expect(commands).toContain("git -C '/repo' worktree add '/tmp/repo.wt-1-tile-1' -b 'agents/1-tile-1'");
+  });
+
+  test("skips stale branch names instead of clobbering them", async () => {
+    existingBranches.add("agents/1-tile-1");
+
+    await createWorktree("/repo", "/tmp", "repo", "oracle", "tile-1", []);
+
+    expect(commands.some(cmd => cmd.includes("branch -D"))).toBe(false);
+    expect(commands).toContain("git -C '/repo' show-ref --verify --quiet 'refs/heads/agents/1-tile-1'");
+    expect(commands).toContain("git -C '/repo' worktree add '/tmp/repo.wt-2-tile-1' -b 'agents/2-tile-1'");
+  });
+});


### PR DESCRIPTION
## Summary
- stop `createWorktree` from deleting an existing `agents/<n>-tile-*` branch before creating a new tile worktree
- make `maw tile clean` parse `git worktree list --porcelain` and safely delete matching `agents/*-tile-*` branches after removing tile worktrees
- keep branch deletion safe (`git branch -d`), so unmerged branch history is preserved with a warning instead of silently clobbered

## Validation
- `bun test test/isolated/tile.test.ts test/isolated/wake-session-worktree.test.ts`
- `bun run build`

Part of #1380.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
