### PR TITLE
release: v26.5.15-alpha.1538

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build CLI
-        run: bun build --target=bun src/cli.ts
+        run: bun build src/cli.ts --outfile dist/maw --target=bun --minify --external @eclipse-zenoh/zenoh-ts
 
       - name: Validate plugin manifests
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ ui/office/assets/
 
 # psi/ — ASCII alias of ψ/ vault runtime data (#451)
 psi/
+
+# Local Codex/OMX runtime state
+.omx/

--- a/ISSUE-maw-team-send-not-hey.md
+++ b/ISSUE-maw-team-send-not-hey.md
@@ -1,0 +1,87 @@
+# Issue: Use `maw team send` for team agents, not `maw hey`
+
+Date: 2026-05-14 22:06 +07
+Trace target: `/opt/sila/Code/github.com/Soul-Brews-Studio/maw-js`
+
+## Problem
+
+During a live Somwind team simulation, I used `maw hey` to talk to individual
+panes that belonged to a `maw team`.
+
+That is the wrong operator surface for team members.
+
+`maw hey` is for oracle/session messaging. For agents that are members of a
+`maw team`, the correct channel is:
+
+```bash
+maw team send <team> <agent> <message>
+```
+
+Using `maw hey` against pane targets can bypass the team inbox, make ACK/status
+tracking ambiguous, and encourage operators to think in panes instead of team
+agents.
+
+## Observed Team
+
+Team:
+
+```text
+gale-codex-215257
+```
+
+Members:
+
+```text
+scout
+implementer
+```
+
+Correct commands sent:
+
+```bash
+maw team send gale-codex-215257 scout "SCOUT: ACK กลับมา สรุปสิ่งที่กำลังทำ และบอกไฟล์หรือ WT ที่รับผิดชอบ"
+maw team send gale-codex-215257 implementer "IMPLEMENTER: ACK กลับมา สรุปสิ่งที่กำลังทำ และบอกไฟล์หรือ WT ที่รับผิดชอบ"
+```
+
+Verification commands:
+
+```bash
+maw team status gale-codex-215257
+ls -la ~/.claude/teams/gale-codex-215257/inboxes
+maw pane list
+```
+
+Verification observed:
+
+- `scout` engine `codex`, status `running`, pane `%20`.
+- `implementer` engine `codex`, status `running`, pane `%21`.
+- Team inbox files existed: `scout.json`, `implementer.json`.
+- `maw pane list` showed lead, implementer, and scout panes.
+
+## Fix / Product Direction
+
+1. Document that `maw team send` is the canonical way to message team members.
+2. Consider adding a guard or warning when `maw hey` targets a pane annotated as
+   `team: <agent> @ <team>`.
+3. Keep `maw hey` for oracle/session messaging, including team fan-out where
+   explicitly supported by `team:<name>`, but do not present it as the normal
+   command for live `maw team` member coordination.
+
+## Permanent Code-Team Rule
+
+For code teams, create worktrees first:
+
+```bash
+maw workon Somwind-oracle scout
+maw workon Somwind-oracle implementer
+maw workon Somwind-oracle verifier
+```
+
+Then send prompts with an absolute worktree path:
+
+```text
+REPO=/absolute/path/to/Somwind-oracle-<role-worktree>
+You own only REPO. Do not edit outside that worktree.
+Report changed files and verification.
+```
+

--- a/ISSUE-team-worktree-cwd-enter.md
+++ b/ISSUE-team-worktree-cwd-enter.md
@@ -1,0 +1,53 @@
+# Issue: Team panes need real worktree cwd and explicit enter
+
+Date: 2026-05-14
+
+## Problem
+
+Live team testing with Somwind showed two related gaps in `maw team`:
+
+1. `maw workon <repo> <role>` creates role-specific worktree windows, but
+   `maw team spawn --exec` still splits from the leader pane and starts the
+   agent in the leader cwd. Passing `REPO=/abs/worktree` in the prompt is only
+   an instruction; it does not make the pane actually run in that worktree.
+
+2. `maw team hey <agent> <message>` can leave long text staged in a Codex TUI
+   prompt without submitting it. Operators need a team-scoped way to send an
+   Enter key without dropping down to raw tmux.
+
+## Repro
+
+```bash
+maw workon Somwind-oracle scout
+maw workon Somwind-oracle implementer
+maw workon Somwind-oracle verifier
+
+maw team create somwind-wt-horizontal --description "Horizontal team panes with real worktree cwd"
+maw team spawn somwind-wt-horizontal implementer --exec \
+  --worktree /opt/sila/Code/github.com/sila-build-with-oracle/Somwind-oracle.wt-1-implementer \
+  --prompt "REPO=/opt/sila/Code/github.com/sila-build-with-oracle/Somwind-oracle.wt-1-implementer"
+```
+
+Expected: the spawned pane's agent starts with the worktree as cwd.
+
+Observed before the fix: team panes could appear in the main repo even though
+the prompt named a worktree path.
+
+For prompt submission:
+
+```bash
+maw team hey implementer "TASK ..."
+```
+
+Observed: text can be visible in the Codex prompt but not executed until a
+separate Enter is sent.
+
+## Proposed Fix
+
+- Add `--cwd <path>` and `--worktree <path>` to `maw team spawn`.
+- Wrap the spawned agent command with `cd '<path>' && ...` when cwd is present.
+- Add `maw team enter <agent|all>` as a team-scoped Enter key surface.
+
+This keeps operators on `maw team` instead of raw `tmux` while preserving the
+existing `--exec` split-pane flow.
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.2",
+  "version": "26.5.15-alpha.1538",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/api/pair.ts
+++ b/src/api/pair.ts
@@ -62,3 +62,48 @@ pairApi.get("/pair/:code/status", ({ params, set }) => {
 });
 
 export function _resetResults(): void { results.clear(); }
+
+// ─── Auto-pair (scout discovery) ─────────────────────────────────────
+
+const recentHellos = new Map<string, number>();
+const HELLO_WINDOW_MS = 60_000;
+
+/** Called by ScoutTransport when a Hello is received, to track zid for anti-replay */
+export function recordHelloZid(zid: string): void {
+  recentHellos.set(zid, Date.now());
+  // prune old entries
+  const cutoff = Date.now() - HELLO_WINDOW_MS;
+  for (const [k, v] of recentHellos) {
+    if (v < cutoff) recentHellos.delete(k);
+  }
+}
+
+pairApi.post("/pair/auto", async ({ body, set }) => {
+  const b = (body ?? {}) as { node?: string; oracle?: string; url?: string; zid?: string; capabilities?: string[] };
+
+  if (!b.node || !b.url || !b.zid) {
+    set.status = 400;
+    return { ok: false, error: "missing_fields" };
+  }
+
+  // anti-replay: must have seen a Hello from this zid recently
+  const helloTs = recentHellos.get(b.zid);
+  if (!helloTs || Date.now() - helloTs > HELLO_WINDOW_MS) {
+    set.status = 403;
+    return { ok: false, error: "no_recent_hello" };
+  }
+
+  const id = me();
+  try {
+    await cmdAdd({ alias: b.node, url: b.url, node: b.node });
+  } catch {}
+
+  recentHellos.delete(b.zid);
+
+  return {
+    ok: true,
+    node: id.node,
+    oracle: "mawjs",
+    url: `http://localhost:${id.port}`,
+  };
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,19 +6,16 @@ process.env.MAW_CLI = "1";
 import { applyInstancePreset } from "./cli/instance-preset";
 applyInstancePreset();
 
-import { cmdPeek, cmdSend } from "./commands/shared/comm";
 import { logAudit } from "./core/fleet/audit";
 import { usage } from "./cli/usage";
-import { routeComm } from "./cli/route-comm";
-import { routeTools } from "./cli/route-tools";
-import { scanCommands, matchCommand, executeCommand } from "./cli/command-registry";
+import { scanCommands } from "./cli/command-registry";
 import { setVerbosityFlags } from "./cli/verbosity";
 import { getVersionString } from "./cli/cmd-version";
 import { runUpdate } from "./cli/cmd-update";
 import { runBootstrap } from "./cli/plugin-bootstrap";
-import { UserError, isUserError } from "./core/util/user-error";
-import { AmbiguousMatchError } from "./core/runtime/find-window";
-import { renderAmbiguousMatch } from "./core/util/render-ambiguous";
+import { maybeAutoRestore } from "./cli/auto-restore";
+import { dispatchCommand } from "./cli/dispatch";
+import { handleTopLevelError } from "./cli/error-handler";
 import { join } from "path";
 import { homedir } from "os";
 
@@ -38,228 +35,29 @@ logAudit(cmd || "", args);
 async function main(): Promise<void> {
   if (cmd === "--version" || cmd === "-v" || cmd === "version") {
     console.log(getVersionString());
-  } else if (cmd === "update" || cmd === "upgrade") {
-    await runUpdate(args);
-  } else {
-    // Auto-bootstrap: if ~/.maw/plugins/ is empty, symlink bundled + install from pluginSources
-    const pluginDir = join(homedir(), ".maw", "plugins");
-    await runBootstrap(pluginDir, import.meta.dir);
-
-    // Load plugins from ~/.maw/plugins/ — the single source of truth
-    await scanCommands(pluginDir, "user");
-
-    // Auto-restore: if no tmux sessions and a recent snapshot exists, offer to restore.
-    if (cmd && cmd !== "--help" && cmd !== "-h") {
-      try {
-        const { listSessions } = await import("./sdk");
-        const live = await listSessions().catch(() => [] as any[]);
-        if (live.length === 0) {
-          const { latestSnapshot } = await import("./core/fleet/snapshot");
-          const snap = latestSnapshot();
-          if (snap) {
-            const ageMs = Date.now() - new Date(snap.timestamp).getTime();
-            if (ageMs < 24 * 60 * 60 * 1000) {
-              const mins = Math.round(ageMs / 60000);
-              const ageStr = mins >= 60 ? `${Math.round(mins / 60)}h ago` : `${mins}m ago`;
-              console.log(`\x1b[36m📸\x1b[0m Last snapshot: ${snap.sessions.length} sessions (${ageStr})`);
-              for (const s of snap.sessions) console.log(`   ${s.name}`);
-              process.stdout.write(`\nRestore all? [y/N] `);
-              const buf = new Uint8Array(64);
-              const fd = require("fs").openSync("/dev/tty", "r");
-              const n = require("fs").readSync(fd, buf);
-              require("fs").closeSync(fd);
-              const answer = new TextDecoder().decode(buf.subarray(0, n)).trim().toLowerCase();
-              if (answer === "y" || answer === "yes") {
-                const { cmdWake } = await import("./commands/shared/wake-cmd");
-                for (const s of snap.sessions) {
-                  const oracle = s.name.replace(/^\d+-/, "");
-                  try {
-                    await cmdWake(oracle, { attach: false });
-                    console.log(`  \x1b[32m✓\x1b[0m ${s.name}`);
-                  } catch (e: any) {
-                    console.log(`  \x1b[31m✗\x1b[0m ${s.name}: ${e?.message || String(e)}`);
-                  }
-                }
-                console.log("");
-              }
-            }
-          }
-        }
-      } catch {}
-    }
-
-    if (!cmd || cmd === "--help" || cmd === "-h") {
-      usage();
-    } else {
-
-    // Core routes: hey (transport) + plugin management + serve
-    const handled =
-      await routeComm(cmd, args) ||
-      await routeTools(cmd, args);
-
-    if (!handled) {
-      // RFC #954 — top-level verb aliases. Sits between routeTools and
-      // matchCommand. Either rewrites argv in place (continue dispatch flow)
-      // or dispatches a direct-handler and exits the pipeline.
-      const { resolveTopAlias, invokeDirectHandler } = await import("./cli/top-aliases");
-      const aliasResult = resolveTopAlias(args);
-      if (aliasResult) {
-        if (aliasResult.kind === "direct") {
-          await invokeDirectHandler(aliasResult.handler, aliasResult.argv);
-          return;
-        }
-        // Argv-rewrite: splice in place, then fall through to matchCommand
-        // (which will pick up the canonical plugin verb).
-        args.splice(0, args.length, ...aliasResult.argv);
-      }
-      // Try plugin commands (beta) — after core routes, before fallback
-      const pluginMatch = matchCommand(args);
-      if (pluginMatch) {
-        await executeCommand(pluginMatch.desc, pluginMatch.remaining);
-      } else {
-        // Fallback: check plugin registry for bundled commands
-        // #349/#351/#354 — prefix match MUST require word boundary. Loose
-        // `startsWith(n)` lets alias "rest" of stop plugin match "restart --help"
-        // and invoke destructive cmdSleep. Fix: require exact OR `n + " "` prefix.
-        // Also: slice by the MATCHED name (alias or command), not always command,
-        // so remaining args are computed correctly when an alias fires.
-        const { discoverPackages, invokePlugin } = await import("./plugin/registry");
-        const { resolvePluginMatch, pluginCliNames } = await import("./cli/dispatch-match");
-        const plugins = discoverPackages();
-        // #393 Bug H: use lowercased cmdName ONLY for plugin-name matching.
-        // Pass the ORIGINAL-case args to the plugin. Previously remaining was
-        // sliced off the lowercased cmdName, which silently lowercased team
-        // names, subjects, paths, and any case-sensitive arg.
-        const cmdName = args.join(" ").toLowerCase();
-        const dispatch = resolvePluginMatch(plugins, cmdName);
-        if (dispatch.kind === "ambiguous") {
-          console.error(`\x1b[31m✗\x1b[0m ambiguous command: ${args[0]}`);
-          console.error(`  candidates: ${dispatch.candidates.map(c => `${c.plugin} (${c.name})`).join(", ")}`);
-          throw new UserError(`ambiguous command: ${args[0]}`);
-        }
-        if (dispatch.kind === "match") {
-          const matchedWords = dispatch.matchedName.split(/\s+/).filter(Boolean).length;
-          const remaining = args.slice(matchedWords);
-          const result = await invokePlugin(dispatch.plugin, { source: "cli", args: remaining });
-          if (result.ok && result.output) console.log(result.output);
-          else if (!result.ok) { console.error(result.error); process.exit(result.exitCode ?? 1); }
-          process.exit(0);
-        }
-        // #388.2 — unknown command: fuzzy-suggest against the plugin registry.
-        // Only intercepts when cmd is NOT a known route/plugin/alias AND does
-        // NOT strictly match an oracle session name. Preserves `maw mawjs`
-        // shorthand while catching `maw hek` / `maw oracl` / typos.
-        const CORE_ROUTES = [
-          "hey",
-          "plugins", "plugin", "artifacts", "artifact",
-          "agents", "agent", "audit", "serve",
-          "update", "upgrade", "version",
-        ];
-        const knownCommands: string[] = [...CORE_ROUTES];
-        for (const p of plugins) {
-          // #899 — mirror dispatch-match's default-name behavior: plugins
-          // without `cli` but with a dispatchable entry surface as
-          // `manifest.name`. Keeps the unknown-command guard in sync with
-          // the dispatcher so source-installed community plugins don't
-          // trigger "did you mean" suggestions for their own command.
-          const cliNames = pluginCliNames(p);
-          if (!cliNames) continue;
-          knownCommands.push(cliNames.command);
-          for (const a of cliNames.aliases) knownCommands.push(a);
-        }
-        const { listCommands } = await import("./cli/command-registry");
-        for (const c of listCommands()) {
-          const names = Array.isArray(c.name) ? c.name : [c.name];
-          for (const n of names) knownCommands.push(n);
-        }
-        const isKnownCommand = knownCommands.some(n => n.toLowerCase() === cmd);
-        if (!isKnownCommand) {
-          // Prefix auto-resolve: if input uniquely prefixes one known command, run it.
-          // e.g. "v" → "version", "up" → "update", "cl" → "cleanup"
-          const prefixMatches = knownCommands.filter(n => n.toLowerCase().startsWith(cmd) && n.toLowerCase() !== cmd);
-          const uniquePrefixes = [...new Set(prefixMatches.map(n => n.toLowerCase()))];
-          if (uniquePrefixes.length === 1) {
-            const resolved = prefixMatches[0];
-            args.splice(0, 1, resolved);
-            const retryMatch = matchCommand(args);
-            if (retryMatch) {
-              await executeCommand(retryMatch.desc, retryMatch.remaining);
-              process.exit(0);
-            }
-            const retryPlugin = resolvePluginMatch(plugins, args.join(" ").toLowerCase());
-            if (retryPlugin.kind === "match") {
-              const matchedWords = retryPlugin.matchedName.split(/\s+/).filter(Boolean).length;
-              const result = await invokePlugin(retryPlugin.plugin, { source: "cli", args: args.slice(matchedWords) });
-              if (result.ok && result.output) console.log(result.output);
-              else if (!result.ok) { console.error(result.error); process.exit(result.exitCode ?? 1); }
-              process.exit(0);
-            }
-            // Special case: core routes handled before plugin dispatch
-            if (resolved === "version") { console.log(getVersionString()); process.exit(0); }
-            if (resolved === "update" || resolved === "upgrade") { await runUpdate(args.slice(1)); process.exit(0); }
-          }
-
-          // #394 — fuzzy FIRST, tmux listSessions second.
-          const { fuzzyMatch } = await import("./core/util/fuzzy");
-          // Include prefix matches in suggestions when multiple candidates exist
-          const closeCandidates = uniquePrefixes.length > 1
-            ? uniquePrefixes
-            : fuzzyMatch(args[0], knownCommands, 3, 2);
-          let isOracle = false;
-          if (closeCandidates.length === 0) {
-            // No close typo-match. Only spend the tmux query if the arg
-            // shape is plausibly an oracle session name.
-            const ORACLE_NAME_SHAPE = /^[a-z0-9][a-z0-9:_-]*$/i;
-            if (ORACLE_NAME_SHAPE.test(args[0])) {
-              const { listSessions } = await import("./sdk");
-              const sessions = await listSessions().catch(() => [] as Awaited<ReturnType<typeof listSessions>>);
-              const target = args[0].toLowerCase();
-              isOracle = sessions.some(s => {
-                const name = s.name.toLowerCase();
-                return name === target || name.replace(/^\d+-/, "") === target;
-              });
-            }
-          }
-          if (!isOracle) {
-            console.error(`\x1b[31m✗\x1b[0m unknown command: ${args[0]}`);
-            if (closeCandidates.length > 0) {
-              console.error(`  did you mean: ${closeCandidates.join(", ")}?`);
-            } else {
-              console.error(`  run 'maw --help' to see available commands`);
-            }
-            // UserError: output already printed above; top-level catch just
-            // exits 1 without bun's default stack trace (alpha.66 polish).
-            throw new UserError(`unknown command: ${args[0]}`);
-          }
-        }
-        // Default: agent name shorthand (maw <agent> <msg> or maw <agent>)
-        if (args.length >= 2) {
-          const f = args.includes("--force");
-          const m = args.slice(1).filter(a => a !== "--force");
-          await cmdSend(args[0], m.join(" "), f);
-        } else {
-          await cmdPeek(args[0]);
-        }
-      }
-    }
-    }
+    return;
   }
+  if (cmd === "update" || cmd === "upgrade") {
+    await runUpdate(args);
+    return;
+  }
+
+  // Auto-bootstrap: if ~/.maw/plugins/ is empty, symlink bundled + install from pluginSources.
+  // import.meta.dir must resolve to src/ — keep the call here, not in a child module.
+  const pluginDir = join(homedir(), ".maw", "plugins");
+  await runBootstrap(pluginDir, import.meta.dir);
+
+  // Load plugins from ~/.maw/plugins/ — the single source of truth
+  await scanCommands(pluginDir, "user");
+
+  await maybeAutoRestore(cmd);
+
+  if (!cmd || cmd === "--help" || cmd === "-h") {
+    usage();
+    return;
+  }
+
+  await dispatchCommand(cmd, args);
 }
 
-// Top-level error handler (#388 polish): suppress bun's default stack trace
-// for UserError — the throw site already printed user-facing output. Real
-// bugs still surface their full stack so we can debug them.
-main().catch((e: unknown) => {
-  if (isUserError(e)) {
-    process.exit(1);
-  }
-  // #567 — AmbiguousMatchError escapes from findWindow via resolver chains
-  // (cmdSend, cmdPeek, talk-to, view, etc.). Render it as actionable CLI
-  // output instead of a minified stack trace. Exit 1 preserved.
-  if (e instanceof AmbiguousMatchError) {
-    console.error(renderAmbiguousMatch(e, args));
-    process.exit(1);
-  }
-  console.error(e);
-  process.exit(1);
-});
+main().catch((e: unknown) => handleTopLevelError(e, args));

--- a/src/cli/auto-restore.ts
+++ b/src/cli/auto-restore.ts
@@ -1,0 +1,49 @@
+/**
+ * Auto-restore: if no live tmux sessions exist and a recent (<24h) snapshot
+ * is on disk, prompt the user to revive every session in the snapshot.
+ *
+ * Skipped for help-style invocations (--help / -h) so `maw --help` never
+ * stalls waiting for tty input.
+ *
+ * Exceptions are intentionally swallowed — auto-restore is best-effort
+ * UX sugar, never load-bearing for the actual command the user typed.
+ */
+export async function maybeAutoRestore(cmd: string | undefined): Promise<void> {
+  if (!cmd || cmd === "--help" || cmd === "-h") return;
+  try {
+    const { listSessions } = await import("../sdk");
+    const live = await listSessions().catch(() => [] as any[]);
+    if (live.length !== 0) return;
+
+    const { latestSnapshot } = await import("../core/fleet/snapshot");
+    const snap = latestSnapshot();
+    if (!snap) return;
+
+    const ageMs = Date.now() - new Date(snap.timestamp).getTime();
+    if (ageMs >= 24 * 60 * 60 * 1000) return;
+
+    const mins = Math.round(ageMs / 60000);
+    const ageStr = mins >= 60 ? `${Math.round(mins / 60)}h ago` : `${mins}m ago`;
+    console.log(`\x1b[36m📸\x1b[0m Last snapshot: ${snap.sessions.length} sessions (${ageStr})`);
+    for (const s of snap.sessions) console.log(`   ${s.name}`);
+    process.stdout.write(`\nRestore all? [y/N] `);
+    const buf = new Uint8Array(64);
+    const fd = require("fs").openSync("/dev/tty", "r");
+    const n = require("fs").readSync(fd, buf);
+    require("fs").closeSync(fd);
+    const answer = new TextDecoder().decode(buf.subarray(0, n)).trim().toLowerCase();
+    if (answer !== "y" && answer !== "yes") return;
+
+    const { cmdWake } = await import("../commands/shared/wake-cmd");
+    for (const s of snap.sessions) {
+      const oracle = s.name.replace(/^\d+-/, "");
+      try {
+        await cmdWake(oracle, { attach: false });
+        console.log(`  \x1b[32m✓\x1b[0m ${s.name}`);
+      } catch (e: any) {
+        console.log(`  \x1b[31m✗\x1b[0m ${s.name}: ${e?.message || String(e)}`);
+      }
+    }
+    console.log("");
+  } catch {}
+}

--- a/src/cli/cmd-update.ts
+++ b/src/cli/cmd-update.ts
@@ -135,6 +135,19 @@ export async function runUpdate(args: string[]): Promise<void> {
   // Order matters: validation (above) → try add → on fail, remove + retry →
   // on still-fail, print recovery command. User always has a working maw
   // unless BOTH adds fail.
+  // Test-mode guard — runUpdate mutates the *real* `~/.bun/bin/maw`,
+  // `~/.bun/install/global/`, and bun's global lockfiles; it has no sandbox
+  // seam. The test suite (MAW_TEST_MODE=1) spawns `maw update <ref> --yes` to
+  // exercise the ref-allowlist gate — that previously fell straight through
+  // into the destructive install ops below and wiped the developer's maw
+  // install on every `bun test` run (observed 2026-05-14/15). Stop here:
+  // everything above (help short-circuit, REF_RE allowlist, channel resolve,
+  // confirmation gate) is non-destructive and still fully exercised.
+  if (process.env.MAW_TEST_MODE) {
+    console.log(`  \x1b[90m[test-mode] ref "${ref}" accepted — skipping destructive install\x1b[0m`);
+    return;
+  }
+
   // #551 — serialize concurrent `maw update` invocations via filesystem lock.
   // Channel-resolve + validation above runs unlocked; destructive install ops
   // below (stash, bun remove, bun add, link refresh) are serialized.
@@ -152,6 +165,16 @@ export async function runUpdate(args: string[]): Promise<void> {
       const BIN = join(homedir(), ".bun", "bin", "maw");
       const STASH = `${BIN}.prev`;
       let stashed = false;
+      // The global maw-js package dir. A `bun add -g` install makes
+      // `~/.bun/bin/maw` a symlink INTO this dir, so `rmSync`-ing it orphans
+      // the stashed bin symlink — `existsSync(STASH)` then reports false and
+      // the restore below silently no-ops, leaving NO working maw (observed:
+      // full install wipe on a failed `maw update`). Stash this dir by RENAME
+      // (not rm) so a failed retry can restore a *working* install — both the
+      // bin symlink AND the package it resolves to.
+      const NM = join(homedir(), ".bun", "install", "global", "node_modules");
+      const PKG_STASH = join(NM, "maw-js.update-stash");
+      let pkgStashed = false;
       // #968 — if .prev already exists, it's a leftover from a prior crashed
       // update. The original (#551) behavior refused at this point so the
       // user wouldn't lose their last-known-good binary. But that left the
@@ -201,9 +224,18 @@ export async function runUpdate(args: string[]): Promise<void> {
         if (dirty) writeFileSync(globalPkg, JSON.stringify(data, null, 2) + "\n");
       } catch { /* best effort — file missing or unreadable; bun remove still runs below */ }
       try {
-        const nm = join(homedir(), ".bun", "install", "global", "node_modules");
-        for (const name of ["maw-js", "maw", "@maw-js"]) {
-          try { rmSync(join(nm, name), { recursive: true, force: true }); } catch {}
+        // Clear any leftover pkg stash from a prior crashed update, then move
+        // the maw-js package OUT of node_modules by rename. bun's resolver
+        // sees a clean node_modules (same effect as rm for the dep-loop fix,
+        // #950) but the package stays recoverable for the restore path below.
+        try { rmSync(PKG_STASH, { recursive: true, force: true }); } catch {}
+        if (existsSync(join(NM, "maw-js"))) {
+          try { renameSync(join(NM, "maw-js"), PKG_STASH); pkgStashed = true; } catch {}
+        }
+        // `maw` (bin shim) and `@maw-js` (scope dir) are not what the bin
+        // symlink resolves through — safe to drop outright.
+        for (const name of ["maw", "@maw-js"]) {
+          try { rmSync(join(NM, name), { recursive: true, force: true }); } catch {}
         }
       } catch {}
 
@@ -264,17 +296,57 @@ export async function runUpdate(args: string[]): Promise<void> {
         }
       }
 
-      if (installCode !== 0 && stashed && existsSync(STASH)) {
-        // Retry failed — restore the previous binary so the user isn't stranded.
+      // Restore the maw-js package dir from the rename-stash. Used by both the
+      // failure path (put the old install back) and the rollback path (a
+      // "successful" install whose binary doesn't actually run).
+      const restorePkgStash = () => {
+        if (!pkgStashed || !existsSync(PKG_STASH)) return;
         try {
-          renameSync(STASH, BIN);
-          console.warn(`\x1b[33m↺\x1b[0m restored previous maw binary from stash`);
+          rmSync(join(NM, "maw-js"), { recursive: true, force: true });
+          renameSync(PKG_STASH, join(NM, "maw-js"));
         } catch (e: any) {
-          console.error(`failed to restore stash: ${e.message || e}`);
+          console.error(`failed to restore maw-js package from stash: ${e.message || e}`);
         }
-      } else if (installCode === 0 && stashed && existsSync(STASH)) {
-        // Retry succeeded — clean up the stash.
-        try { unlinkSync(STASH); } catch {}
+      };
+
+      if (installCode !== 0) {
+        // Retry failed — restore the previous WORKING maw so the user isn't
+        // stranded. Order matters: restore the package dir FIRST so the
+        // stashed bin symlink resolves again, THEN move the bin back.
+        restorePkgStash();
+        if (stashed && existsSync(STASH)) {
+          try {
+            renameSync(STASH, BIN);
+            console.warn(`\x1b[33m↺\x1b[0m restored previous maw binary from stash`);
+          } catch (e: any) {
+            console.error(`failed to restore stash: ${e.message || e}`);
+          }
+        }
+      } else {
+        // Retry reported success — but verify the fresh binary actually RUNS
+        // before discarding the stash (the invariant: never rotate away the
+        // old one until the new one is confirmed working). If it doesn't,
+        // roll back to the stashed install and fall into the error path.
+        const verify = Bun.spawn(["maw", "--version"], { stdout: "pipe", stderr: "pipe" });
+        const freshOk = (await verify.exited) === 0;
+        if (!freshOk) {
+          console.warn(`\x1b[33m↺\x1b[0m fresh install did not run — rolling back to previous maw`);
+          restorePkgStash();
+          if (stashed && existsSync(STASH)) {
+            try {
+              renameSync(STASH, BIN);
+            } catch (e: any) {
+              console.error(`failed to restore stash: ${e.message || e}`);
+            }
+          }
+          installCode = 1; // fall into the error path below
+        } else {
+          // Fresh install confirmed working — discard the stashes.
+          if (stashed && existsSync(STASH)) { try { unlinkSync(STASH); } catch {} }
+          if (pkgStashed && existsSync(PKG_STASH)) {
+            try { rmSync(PKG_STASH, { recursive: true, force: true }); } catch {}
+          }
+        }
       }
     }
     if (installCode !== 0) {

--- a/src/cli/cmd-version.ts
+++ b/src/cli/cmd-version.ts
@@ -1,15 +1,5 @@
-import { execSync } from "child_process";
+import { getRuntimeVersionString } from "../core/runtime/build-info";
 
 export function getVersionString(): string {
-  const pkg = require("../../package.json");
-  let hash = "";
-  try { hash = execSync("git rev-parse --short HEAD", { cwd: import.meta.dir, stdio: "pipe" }).toString().trim(); } catch {}
-  let buildDate = "";
-  try {
-    const raw = execSync("git log -1 --format=%ci", { cwd: import.meta.dir, stdio: "pipe" }).toString().trim();
-    const d = new Date(raw);
-    const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-    buildDate = `${raw.slice(0, 10)} ${days[d.getDay()]} ${raw.slice(11, 16)}`;
-  } catch {}
-  return `maw v${pkg.version}${hash ? ` (${hash})` : ""}${buildDate ? ` built ${buildDate}` : ""}`;
+  return getRuntimeVersionString();
 }

--- a/src/cli/command-registry-execute.ts
+++ b/src/cli/command-registry-execute.ts
@@ -6,6 +6,8 @@
  */
 
 import { parseFlags } from "./parse-args";
+import { realpathSync } from "fs";
+import { pathToFileURL } from "url";
 import {
   preCacheBridge, readString,
   textEncoder, textDecoder,
@@ -91,7 +93,10 @@ export async function executeCommand(desc: CommandDescriptor, remaining: string[
     }
     return;
   }
-  const mod = await import(desc.path!);
+  // Bun canary on macOS can lose later dynamic imports that come through the
+  // /var → /private/var symlink. Import the canonical file URL so temporary
+  // JS command modules load deterministically across runners.
+  const mod = await import(pathToFileURL(realpathSync(desc.path!)).href);
   const handler = mod.default || mod.handler;
   if (!handler) { console.error(`[commands] ${desc.name}: no default export or handler`); return; }
   const flags = desc.flags ? parseFlags(["_", ...remaining], desc.flags, 1) : { _: remaining };

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -1,0 +1,174 @@
+import { cmdPeek, cmdSend } from "../commands/shared/comm";
+import { routeComm } from "./route-comm";
+import { routeTools } from "./route-tools";
+import { matchCommand, executeCommand } from "./command-registry";
+import { getVersionString } from "./cmd-version";
+import { runUpdate } from "./cmd-update";
+import { UserError } from "../core/util/user-error";
+
+/** Core route names that are not plugins but are still "known commands". */
+const CORE_ROUTES = [
+  "hey",
+  "plugins", "plugin", "artifacts", "artifact",
+  "agents", "agent", "audit", "serve",
+  "update", "upgrade", "version",
+];
+
+/**
+ * Run a command after plugins have been scanned. Walks the dispatch ladder:
+ *   routeComm → routeTools → top-aliases → plugin registry (beta) →
+ *   bundled plugin registry → agent-name shorthand.
+ *
+ * Throws UserError for ambiguous/unknown commands. Exits the process on
+ * successful plugin invocation (preserves prior behavior).
+ */
+export async function dispatchCommand(cmd: string, args: string[]): Promise<void> {
+  const handled =
+    (await routeComm(cmd, args)) ||
+    (await routeTools(cmd, args));
+  if (handled) return;
+
+  // RFC #954 — top-level verb aliases. Sits between routeTools and
+  // matchCommand. Either rewrites argv in place (continue dispatch flow)
+  // or dispatches a direct-handler and exits the pipeline.
+  const { resolveTopAlias, invokeDirectHandler } = await import("./top-aliases");
+  const aliasResult = resolveTopAlias(args);
+  if (aliasResult) {
+    if (aliasResult.kind === "direct") {
+      await invokeDirectHandler(aliasResult.handler, aliasResult.argv);
+      return;
+    }
+    args.splice(0, args.length, ...aliasResult.argv);
+  }
+
+  // Try plugin commands (beta) — after core routes, before fallback
+  const pluginMatch = matchCommand(args);
+  if (pluginMatch) {
+    await executeCommand(pluginMatch.desc, pluginMatch.remaining);
+    return;
+  }
+
+  // Fallback: check plugin registry for bundled commands
+  await dispatchPluginRegistry(cmd, args);
+}
+
+/**
+ * Bundled plugin registry dispatch + unknown-command handling.
+ *
+ * #349/#351/#354 — prefix match MUST require word boundary. Loose
+ * `startsWith(n)` lets alias "rest" of stop plugin match "restart --help"
+ * and invoke destructive cmdSleep. Fix: require exact OR `n + " "` prefix.
+ *
+ * #393 Bug H: lowercase ONLY for plugin-name matching. Pass ORIGINAL-case
+ * args to the plugin so team names, subjects, paths stay case-correct.
+ */
+async function dispatchPluginRegistry(cmd: string, args: string[]): Promise<void> {
+  const { discoverPackages, invokePlugin } = await import("../plugin/registry");
+  const { resolvePluginMatch, pluginCliNames } = await import("./dispatch-match");
+  const plugins = discoverPackages();
+  const cmdName = args.join(" ").toLowerCase();
+  const dispatch = resolvePluginMatch(plugins, cmdName);
+
+  if (dispatch.kind === "ambiguous") {
+    console.error(`\x1b[31m✗\x1b[0m ambiguous command: ${args[0]}`);
+    console.error(`  candidates: ${dispatch.candidates.map(c => `${c.plugin} (${c.name})`).join(", ")}`);
+    throw new UserError(`ambiguous command: ${args[0]}`);
+  }
+  if (dispatch.kind === "match") {
+    const matchedWords = dispatch.matchedName.split(/\s+/).filter(Boolean).length;
+    const remaining = args.slice(matchedWords);
+    const result = await invokePlugin(dispatch.plugin, { source: "cli", args: remaining });
+    if (result.ok && result.output) console.log(result.output);
+    else if (!result.ok) { console.error(result.error); process.exit(result.exitCode ?? 1); }
+    process.exit(0);
+  }
+
+  // #388.2 — unknown command: fuzzy-suggest against the plugin registry.
+  // Only intercepts when cmd is NOT a known route/plugin/alias AND does
+  // NOT strictly match an oracle session name. Preserves `maw mawjs`
+  // shorthand while catching `maw hek` / `maw oracl` / typos.
+  const knownCommands: string[] = [...CORE_ROUTES];
+  for (const p of plugins) {
+    // #899 — mirror dispatch-match's default-name behavior: plugins
+    // without `cli` but with a dispatchable entry surface as
+    // `manifest.name`. Keeps the unknown-command guard in sync with
+    // the dispatcher so source-installed community plugins don't
+    // trigger "did you mean" suggestions for their own command.
+    const cliNames = pluginCliNames(p);
+    if (!cliNames) continue;
+    knownCommands.push(cliNames.command);
+    for (const a of cliNames.aliases) knownCommands.push(a);
+  }
+  const { listCommands } = await import("./command-registry");
+  for (const c of listCommands()) {
+    const names = Array.isArray(c.name) ? c.name : [c.name];
+    for (const n of names) knownCommands.push(n);
+  }
+  const isKnownCommand = knownCommands.some(n => n.toLowerCase() === cmd);
+  if (!isKnownCommand) {
+    // Prefix auto-resolve: if input uniquely prefixes one known command, run it.
+    // e.g. "v" → "version", "up" → "update", "cl" → "cleanup"
+    const prefixMatches = knownCommands.filter(n => n.toLowerCase().startsWith(cmd) && n.toLowerCase() !== cmd);
+    const uniquePrefixes = [...new Set(prefixMatches.map(n => n.toLowerCase()))];
+    if (uniquePrefixes.length === 1) {
+      const resolved = prefixMatches[0];
+      args.splice(0, 1, resolved);
+      const retryMatch = matchCommand(args);
+      if (retryMatch) {
+        await executeCommand(retryMatch.desc, retryMatch.remaining);
+        process.exit(0);
+      }
+      const retryPlugin = resolvePluginMatch(plugins, args.join(" ").toLowerCase());
+      if (retryPlugin.kind === "match") {
+        const matchedWords = retryPlugin.matchedName.split(/\s+/).filter(Boolean).length;
+        const result = await invokePlugin(retryPlugin.plugin, { source: "cli", args: args.slice(matchedWords) });
+        if (result.ok && result.output) console.log(result.output);
+        else if (!result.ok) { console.error(result.error); process.exit(result.exitCode ?? 1); }
+        process.exit(0);
+      }
+      // Special case: core routes handled before plugin dispatch
+      if (resolved === "version") { console.log(getVersionString()); process.exit(0); }
+      if (resolved === "update" || resolved === "upgrade") { await runUpdate(args.slice(1)); process.exit(0); }
+    }
+
+    // #394 — fuzzy FIRST, tmux listSessions second.
+    const { fuzzyMatch } = await import("../core/util/fuzzy");
+    const closeCandidates = uniquePrefixes.length > 1
+      ? uniquePrefixes
+      : fuzzyMatch(args[0], knownCommands, 3, 2);
+    let isOracle = false;
+    if (closeCandidates.length === 0) {
+      // No close typo-match. Only spend the tmux query if the arg
+      // shape is plausibly an oracle session name.
+      const ORACLE_NAME_SHAPE = /^[a-z0-9][a-z0-9:_-]*$/i;
+      if (ORACLE_NAME_SHAPE.test(args[0])) {
+        const { listSessions } = await import("../sdk");
+        const sessions = await listSessions().catch(() => [] as Awaited<ReturnType<typeof listSessions>>);
+        const target = args[0].toLowerCase();
+        isOracle = sessions.some(s => {
+          const name = s.name.toLowerCase();
+          return name === target || name.replace(/^\d+-/, "") === target;
+        });
+      }
+    }
+    if (!isOracle) {
+      console.error(`\x1b[31m✗\x1b[0m unknown command: ${args[0]}`);
+      if (closeCandidates.length > 0) {
+        console.error(`  did you mean: ${closeCandidates.join(", ")}?`);
+      } else {
+        console.error(`  run 'maw --help' to see available commands`);
+      }
+      // UserError: output already printed above; top-level catch just
+      // exits 1 without bun's default stack trace (alpha.66 polish).
+      throw new UserError(`unknown command: ${args[0]}`);
+    }
+  }
+  // Default: agent name shorthand (maw <agent> <msg> or maw <agent>)
+  if (args.length >= 2) {
+    const f = args.includes("--force");
+    const m = args.slice(1).filter(a => a !== "--force");
+    await cmdSend(args[0], m.join(" "), f);
+  } else {
+    await cmdPeek(args[0]);
+  }
+}

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -8,7 +8,7 @@ import { UserError } from "../core/util/user-error";
 
 /** Core route names that are not plugins but are still "known commands". */
 const CORE_ROUTES = [
-  "hey",
+  "hey", "send",
   "plugins", "plugin", "artifacts", "artifact",
   "agents", "agent", "audit", "serve",
   "update", "upgrade", "version",

--- a/src/cli/error-handler.ts
+++ b/src/cli/error-handler.ts
@@ -1,0 +1,25 @@
+import { isUserError } from "../core/util/user-error";
+import { AmbiguousMatchError } from "../core/runtime/find-window";
+import { renderAmbiguousMatch } from "../core/util/render-ambiguous";
+
+/**
+ * Top-level error handler for `main()`. Always exits — never returns.
+ *
+ * - UserError: output already printed at throw site, exit 1 silently
+ *   (no bun stack trace).
+ * - AmbiguousMatchError: escapes from findWindow via resolver chains
+ *   (cmdSend, cmdPeek, talk-to, view, etc.). Render as actionable CLI
+ *   output instead of a minified stack trace.
+ * - Anything else: print the error normally and exit 1.
+ */
+export function handleTopLevelError(e: unknown, args: string[]): never {
+  if (isUserError(e)) {
+    process.exit(1);
+  }
+  if (e instanceof AmbiguousMatchError) {
+    console.error(renderAmbiguousMatch(e, args));
+    process.exit(1);
+  }
+  console.error(e);
+  process.exit(1);
+}

--- a/src/cli/route-comm.ts
+++ b/src/cli/route-comm.ts
@@ -1,7 +1,14 @@
-import { cmdSend } from "../commands/shared/comm";
+import { cmdPeek, cmdSend } from "../commands/shared/comm";
 import { UserError } from "../core/util/user-error";
 
 export async function routeComm(cmd: string, args: string[]): Promise<boolean> {
+  // `peek` is a federation-aware comm verb. Keep `maw tmux peek` as the raw
+  // tmux pane reader; top-level `maw peek <node>:<agent>` must reach cmdPeek.
+  if (cmd === "peek") {
+    await cmdPeek(args[1]);
+    return true;
+  }
+
   // `hey` and `send` stay core — they are message-delivery verbs.
   // #1388: restore `maw send` to the same submitted delivery path as `maw hey`.
   // The raw-text compositor plugin remains available through lower-level tmux

--- a/src/cli/route-comm.ts
+++ b/src/cli/route-comm.ts
@@ -2,11 +2,11 @@ import { cmdSend } from "../commands/shared/comm";
 import { UserError } from "../core/util/user-error";
 
 export async function routeComm(cmd: string, args: string[]): Promise<boolean> {
-  // hey stays core — it's the transport layer.
-  // Note: `send` and `tell` were previously aliases here; `send` is now the
-  // raw-text plugin (#757), and `tell` was undocumented. Use `maw hey` for
-  // agent messaging.
-  if (cmd === "hey") {
+  // `hey` and `send` stay core — they are message-delivery verbs.
+  // #1388: restore `maw send` to the same submitted delivery path as `maw hey`.
+  // The raw-text compositor plugin remains available through lower-level tmux
+  // verbs; top-level `send` must not leave text buffered without Enter.
+  if (cmd === "hey" || cmd === "send") {
     const force = args.includes("--force");
     // #842 Sub-C — `--approve` bypasses the cross-scope ACL queue gate.
     // Operator-explicit opt-in for THIS message; mirrors the consent
@@ -26,19 +26,19 @@ export async function routeComm(cmd: string, args: string[]): Promise<boolean> {
     // same "usage:" error. Now the missing-message case names the target
     // so the user sees their input got through.
     if (!target) {
-      console.error("usage: maw hey <target> <message> [--force]");
+      console.error(`usage: maw ${cmd} <target> <message> [--force]`);
       console.error("  target forms (#759 Phase 2 — bare names removed):");
       console.error("    local:<agent>                this node");
       console.error("    <node>:<session>             canonical cross-node form (window 1)");
       console.error("    <node>:<session>:<window>    target a specific tmux window (#410)");
-      console.error("  e.g. maw hey local:mawjs \"hello from neo\"");
-      console.error("       maw hey phaith:01-hojo:3 \"hello hojo-hermes\"");
+      console.error(`  e.g. maw ${cmd} local:mawjs "hello from neo"`);
+      console.error(`       maw ${cmd} phaith:01-hojo:3 "hello hojo-hermes"`);
       console.error("       run `maw locate <agent>` to enumerate across federation");
       throw new UserError("missing target and message");
     }
     if (!msgArgs.length) {
       console.error(`✗ missing message for target '${target}'`);
-      console.error(`  maw hey ${target} <message>`);
+      console.error(`  maw ${cmd} ${target} <message>`);
       console.error(`  (if '${target}' isn't a valid target, run 'maw ls' to see available ones)`);
       throw new UserError(`missing message for '${target}'`);
     }

--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -45,6 +45,7 @@ export const ALIAS_DESCRIPTIONS: Record<string, string> = {
   panes: "List all panes across sessions",
   cleanup: "Kill zombie agent panes",
   tile: "Tile current window or spawn N panes tiled",
+  bring: "Bring an oracle HERE (split pane) — symmetric with `a` (go there)",
   ls: "List sessions (compact, -a roster, -v detail)",
   wake: "Wake an oracle session (fuzzy match, auto-clone)",
   preflight: "Pre-flight check — version, plugins, dead agents, config",
@@ -64,6 +65,7 @@ export const TOP_ALIASES: Record<string, string[] | DirectHandler> = {
   panes: ["tmux", "ls", "--all", "--verbose"],
   cleanup: ["team", "cleanup", "--zombie-agents"],
   tile: ["tile"],
+  bring: ["wake", "--split"],
 
   // Direct-handler form — `ls` flags differ from tmux ls:
   //   maw ls      → compact, live sessions only

--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -35,7 +35,6 @@ export type AliasResolution =
 export const ALIAS_DESCRIPTIONS: Record<string, string> = {
   a: "Attach to a tmux session",
   kill: "Kill a tmux pane or session",
-  peek: "Read content of a tmux pane",
   split: "Split pane and attach to a session",
   open: "Bring back hidden panes (join-pane)",
   close: "Hide panes without killing (break-pane)",
@@ -55,7 +54,6 @@ export const TOP_ALIASES: Record<string, string[] | DirectHandler> = {
   // Argv-rewrite form — canonical handler lives in a core plugin
   a: ["tmux", "attach"],
   kill: ["tmux", "kill"],
-  peek: ["tmux", "peek"],
   split: ["split"],
   open: ["tmux", "open"],
   close: ["tmux", "close"],

--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -102,6 +102,31 @@ export function resolveTopAlias(args: string[]): AliasResolution | null {
   return { kind: "direct", handler: entry.handler, argv: args.slice(1) };
 }
 
+export function parseBringArgs(argv: string[]): {
+  oracle: string;
+  opts: { bring?: true; split?: boolean; engine?: string };
+} {
+  // `maw bring <oracle>` opens a new tmux window/tab by default. `--split`
+  // remains available as the opt-in layout-mutating form.
+  const flags = parseFlags(argv, {
+    "--engine": String, "-e": "--engine",
+    "--split": Boolean,
+  }, 0);
+  const oracle = (flags._ as string[])[0];
+  if (!oracle) {
+    console.error("usage: maw bring <oracle> [--split] [-e|--engine <name>]");
+    console.error("  Opens oracle in a new tmux window/tab by default.");
+    console.error("  Use --split to split the current pane instead.");
+    console.error("  Symmetric with `maw a` (attach goes there, bring comes here).");
+    throw new UserError("bring: missing oracle name");
+  }
+  const opts: { bring?: true; split?: boolean; engine?: string } = flags["--split"]
+    ? { split: true }
+    : { bring: true };
+  if (flags["--engine"]) opts.engine = flags["--engine"];
+  return { oracle, opts };
+}
+
 /**
  * Invoke a direct-handler alias. Used by `wake` and `ls`.
  *
@@ -200,19 +225,9 @@ export async function invokeDirectHandler(
   }
 
   if (exportName === "cmdBring") {
-    // `maw bring <oracle> [-e <engine>]` — split current pane and wake oracle there.
-    const flags = parseFlags(argv, {
-      "--engine": String, "-e": "--engine",
-    }, 0);
-    const oracle = (flags._ as string[])[0];
-    if (!oracle) {
-      console.error("usage: maw bring <oracle> [-e|--engine <name>]");
-      console.error("  Splits current pane and wakes oracle there (non-destructive).");
-      console.error("  Symmetric with `maw a` (attach goes there, bring comes here).");
-      throw new UserError("bring: missing oracle name");
-    }
-    const opts: { split: true; engine?: string } = { split: true };
-    if (flags["--engine"]) opts.engine = flags["--engine"];
+    // `maw bring <oracle>` — show oracle here in a new tab by default.
+    // `--split` opts into current-pane splitting.
+    const { oracle, opts } = parseBringArgs(argv);
     await cmdWake(oracle, opts);
     return;
   }

--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -44,7 +44,8 @@ export const ALIAS_DESCRIPTIONS: Record<string, string> = {
   panes: "List all panes across sessions",
   cleanup: "Kill zombie agent panes",
   tile: "Tile current window or spawn N panes tiled",
-  bring: "Bring an oracle HERE (split pane) — symmetric with `a` (go there)",
+  bring: "Bring an oracle HERE — symmetric with `a` (go there)",
+  b: "Bring an oracle HERE (short form of `bring`)",
   ls: "List sessions (compact, -a roster, -v detail)",
   wake: "Wake an oracle session (fuzzy match, auto-clone)",
   preflight: "Pre-flight check — version, plugins, dead agents, config",
@@ -64,6 +65,7 @@ export const TOP_ALIASES: Record<string, string[] | DirectHandler> = {
   cleanup: ["team", "cleanup", "--zombie-agents"],
   tile: ["tile"],
   bring: { kind: "direct", handler: "../commands/shared/wake-cmd:cmdBring" },
+  b: { kind: "direct", handler: "../commands/shared/wake-cmd:cmdBring" },
 
   // Direct-handler form — `ls` flags differ from tmux ls:
   //   maw ls      → compact, live sessions only

--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -44,6 +44,7 @@ export const ALIAS_DESCRIPTIONS: Record<string, string> = {
   zoom: "Toggle zoom on a pane",
   panes: "List all panes across sessions",
   cleanup: "Kill zombie agent panes",
+  tile: "Tile current window or spawn N panes tiled",
   ls: "List sessions (compact, -a roster, -v detail)",
   wake: "Wake an oracle session (fuzzy match, auto-clone)",
   preflight: "Pre-flight check — version, plugins, dead agents, config",
@@ -62,6 +63,7 @@ export const TOP_ALIASES: Record<string, string[] | DirectHandler> = {
   zoom: ["tmux", "zoom"],
   panes: ["tmux", "ls", "--all", "--verbose"],
   cleanup: ["team", "cleanup", "--zombie-agents"],
+  tile: ["tile"],
 
   // Direct-handler form — `ls` flags differ from tmux ls:
   //   maw ls      → compact, live sessions only

--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -65,7 +65,7 @@ export const TOP_ALIASES: Record<string, string[] | DirectHandler> = {
   panes: ["tmux", "ls", "--all", "--verbose"],
   cleanup: ["team", "cleanup", "--zombie-agents"],
   tile: ["tile"],
-  bring: ["wake", "--split"],
+  bring: { kind: "direct", handler: "../commands/shared/wake-cmd:cmdBring" },
 
   // Direct-handler form — `ls` flags differ from tmux ls:
   //   maw ls      → compact, live sessions only
@@ -197,6 +197,24 @@ export async function invokeDirectHandler(
       }
     }
 
+    await cmdWake(oracle, opts);
+    return;
+  }
+
+  if (exportName === "cmdBring") {
+    // `maw bring <oracle> [-e <engine>]` — split current pane and wake oracle there.
+    const flags = parseFlags(argv, {
+      "--engine": String, "-e": "--engine",
+    }, 0);
+    const oracle = (flags._ as string[])[0];
+    if (!oracle) {
+      console.error("usage: maw bring <oracle> [-e|--engine <name>]");
+      console.error("  Splits current pane and wakes oracle there (non-destructive).");
+      console.error("  Symmetric with `maw a` (attach goes there, bring comes here).");
+      throw new UserError("bring: missing oracle name");
+    }
+    const opts: { split: true; engine?: string } = { split: true };
+    if (flags["--engine"]) opts.engine = flags["--engine"];
     await cmdWake(oracle, opts);
     return;
   }

--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -106,25 +106,28 @@ export function resolveTopAlias(args: string[]): AliasResolution | null {
 
 export function parseBringArgs(argv: string[]): {
   oracle: string;
-  opts: { bring?: true; split?: boolean; engine?: string };
+  opts: { bring?: true; split?: boolean; tab?: boolean; engine?: string };
 } {
-  // `maw bring <oracle>` opens a new tmux window/tab by default. `--split`
-  // remains available as the opt-in layout-mutating form.
+  // `maw bring <oracle>` replaces the top-right pane when possible. `--split`
+  // remains available as the opt-in layout-mutating form, while `--tab`
+  // preserves the old background-tab behavior explicitly.
   const flags = parseFlags(argv, {
     "--engine": String, "-e": "--engine",
     "--split": Boolean,
+    "--tab": Boolean,
   }, 0);
   const oracle = (flags._ as string[])[0];
   if (!oracle) {
-    console.error("usage: maw bring <oracle> [--split] [-e|--engine <name>]");
-    console.error("  Opens oracle in a new tmux window/tab by default.");
+    console.error("usage: maw bring <oracle> [--split|--tab] [-e|--engine <name>]");
+    console.error("  Replaces the top-right pane by default when one exists.");
     console.error("  Use --split to split the current pane instead.");
+    console.error("  Use --tab to force a background tmux tab.");
     console.error("  Symmetric with `maw a` (attach goes there, bring comes here).");
     throw new UserError("bring: missing oracle name");
   }
-  const opts: { bring?: true; split?: boolean; engine?: string } = flags["--split"]
+  const opts: { bring?: true; split?: boolean; tab?: boolean; engine?: string } = flags["--split"]
     ? { split: true }
-    : { bring: true };
+    : { bring: true, ...(flags["--tab"] ? { tab: true } : {}) };
   if (flags["--engine"]) opts.engine = flags["--engine"];
   return { oracle, opts };
 }

--- a/src/commands/plugins/oracle/index.ts
+++ b/src/commands/plugins/oracle/index.ts
@@ -1,10 +1,42 @@
 import type { InvokeContext, InvokeResult } from "../../../plugin/types";
-import { cmdOracleList, cmdOracleAbout, cmdOracleScan, cmdOracleScanStale } from "./impl";
-import { cmdOraclePrune } from "./impl-prune";
-import { cmdOracleRegister } from "./impl-register";
-import { cmdOracleSetNickname, cmdOracleGetNickname } from "./impl-nickname";
-import { cmdOracleSearch } from "./impl-search";
+import {
+  cmdOracleList as realCmdOracleList,
+  cmdOracleAbout as realCmdOracleAbout,
+  cmdOracleScan as realCmdOracleScan,
+  cmdOracleScanStale as realCmdOracleScanStale,
+} from "./impl";
+import { cmdOraclePrune as realCmdOraclePrune } from "./impl-prune";
+import { cmdOracleRegister as realCmdOracleRegister } from "./impl-register";
+import {
+  cmdOracleSetNickname as realCmdOracleSetNickname,
+  cmdOracleGetNickname as realCmdOracleGetNickname,
+} from "./impl-nickname";
+import { cmdOracleSearch as realCmdOracleSearch } from "./impl-search";
 import { parseFlags } from "../../../cli/parse-args";
+
+type OracleCommandDeps = {
+  cmdOracleList: typeof realCmdOracleList;
+  cmdOracleAbout: typeof realCmdOracleAbout;
+  cmdOracleScan: typeof realCmdOracleScan;
+  cmdOracleScanStale: typeof realCmdOracleScanStale;
+  cmdOraclePrune: typeof realCmdOraclePrune;
+  cmdOracleRegister: typeof realCmdOracleRegister;
+  cmdOracleSetNickname: typeof realCmdOracleSetNickname;
+  cmdOracleGetNickname: typeof realCmdOracleGetNickname;
+  cmdOracleSearch: typeof realCmdOracleSearch;
+};
+
+const defaultOracleCommandDeps: OracleCommandDeps = {
+  cmdOracleList: realCmdOracleList,
+  cmdOracleAbout: realCmdOracleAbout,
+  cmdOracleScan: realCmdOracleScan,
+  cmdOracleScanStale: realCmdOracleScanStale,
+  cmdOraclePrune: realCmdOraclePrune,
+  cmdOracleRegister: realCmdOracleRegister,
+  cmdOracleSetNickname: realCmdOracleSetNickname,
+  cmdOracleGetNickname: realCmdOracleGetNickname,
+  cmdOracleSearch: realCmdOracleSearch,
+};
 
 export const command = {
   name: ["oracle", "oracles"],
@@ -22,7 +54,10 @@ const LS_FLAGS = {
   "-p": "--path",
 } as const;
 
-export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+export function createOracleHandler(overrides: Partial<OracleCommandDeps> = {}) {
+  const commands: OracleCommandDeps = { ...defaultOracleCommandDeps, ...overrides };
+
+  return async function handler(ctx: InvokeContext): Promise<InvokeResult> {
   const logs: string[] = [];
   const origLog = console.log;
   const origError = console.error;
@@ -40,7 +75,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       const subcmd = args[0]?.toLowerCase();
       if (!subcmd || subcmd === "ls" || subcmd === "list") {
         const flags = parseFlags(args, LS_FLAGS, 1);
-        await cmdOracleList({
+        await commands.cmdOracleList({
           awake: flags["--awake"],
           org: flags["--org"],
           json: flags["--json"],
@@ -62,12 +97,12 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
           "-q": "--quiet",
         }, 1);
         if (flags["--stale"]) {
-          await cmdOracleScanStale({
+          await commands.cmdOracleScanStale({
             json: flags["--json"],
             all: flags["--all"],
           });
         } else {
-          await cmdOracleScan({
+          await commands.cmdOracleScan({
             json: flags["--json"],
             force: flags["--force"],
             local: flags["--local"],
@@ -83,7 +118,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
           `\x1b[33m⚠  maw oracle fleet is deprecated — use \x1b[36mmaw oracle ls\x1b[0m\x1b[33m instead\x1b[0m`,
         );
         const flags = parseFlags(args, LS_FLAGS, 1);
-        await cmdOracleList({
+        await commands.cmdOracleList({
           awake: flags["--awake"],
           org: flags["--org"],
           json: flags["--json"],
@@ -97,7 +132,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
           "--force": Boolean,
           "--json": Boolean,
         }, 1);
-        await cmdOraclePrune({
+        await commands.cmdOraclePrune({
           stale: flags["--stale"],
           force: flags["--force"],
           json: flags["--json"],
@@ -106,7 +141,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         const name = args[1];
         if (!name) return { ok: false, error: "usage: maw oracle register <name>" };
         const flags = parseFlags(args, { "--json": Boolean }, 2);
-        await cmdOracleRegister(name, { json: flags["--json"] });
+        await commands.cmdOracleRegister(name, { json: flags["--json"] });
       } else if (subcmd === "set-nickname") {
         const name = args[1];
         const nickname = args[2];
@@ -114,19 +149,19 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
           return { ok: false, error: "usage: maw oracle set-nickname <oracle> \"<nickname>\"" };
         }
         const flags = parseFlags(args, { "--json": Boolean }, 3);
-        cmdOracleSetNickname(name, nickname, { json: flags["--json"] });
+        commands.cmdOracleSetNickname(name, nickname, { json: flags["--json"] });
       } else if (subcmd === "get-nickname") {
         const name = args[1];
         if (!name) return { ok: false, error: "usage: maw oracle get-nickname <oracle>" };
         const flags = parseFlags(args, { "--json": Boolean }, 2);
-        cmdOracleGetNickname(name, { json: flags["--json"] });
+        commands.cmdOracleGetNickname(name, { json: flags["--json"] });
       } else if (subcmd === "search" || subcmd === "find") {
         const query = args[1];
         if (!query) return { ok: false, error: "usage: maw oracle search <query>" };
         const flags = parseFlags(args, { "--json": Boolean, "--awake": Boolean, "--org": String }, 2);
-        await cmdOracleSearch(query, { json: flags["--json"], awake: flags["--awake"], org: flags["--org"] });
+        await commands.cmdOracleSearch(query, { json: flags["--json"], awake: flags["--awake"], org: flags["--org"] });
       } else if (subcmd === "about" && args[1]) {
-        await cmdOracleAbout(args[1]);
+        await commands.cmdOracleAbout(args[1]);
       } else {
         return { ok: false, error: "usage: maw oracle [ls|scan|search <query>|prune|register <name>|set-nickname <name> <nickname>|get-nickname <name>|about <name>]" };
       }
@@ -134,7 +169,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       const query = ctx.args as Record<string, unknown>;
       const sub = (query.sub as string | undefined)?.toLowerCase();
       if (!sub || sub === "ls" || sub === "list") {
-        await cmdOracleList({
+        await commands.cmdOracleList({
           awake: query.awake as boolean | undefined,
           org: query.org as string | undefined,
           json: query.json as boolean | undefined,
@@ -144,12 +179,12 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         });
       } else if (sub === "scan") {
         if (query.stale) {
-          await cmdOracleScanStale({
+          await commands.cmdOracleScanStale({
             json: query.json as boolean | undefined,
             all: query.all as boolean | undefined,
           });
         } else {
-          await cmdOracleScan({
+          await commands.cmdOracleScan({
             json: query.json as boolean | undefined,
             force: query.force as boolean | undefined,
             local: query.local as boolean | undefined,
@@ -162,7 +197,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         console.error(
           `\x1b[33m⚠  oracle.fleet is deprecated — use oracle.ls\x1b[0m`,
         );
-        await cmdOracleList({
+        await commands.cmdOracleList({
           awake: query.awake as boolean | undefined,
           org: query.org as string | undefined,
           json: query.json as boolean | undefined,
@@ -171,14 +206,14 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
           path: query.path as boolean | undefined,
         });
       } else if (sub === "prune") {
-        await cmdOraclePrune({
+        await commands.cmdOraclePrune({
           stale: query.stale as boolean | undefined,
           force: query.force as boolean | undefined,
           json: query.json as boolean | undefined,
         });
       } else if (sub === "register") {
         if (!query.name) return { ok: false, error: "usage: query.sub=register + query.name" };
-        await cmdOracleRegister(query.name as string, {
+        await commands.cmdOracleRegister(query.name as string, {
           json: query.json as boolean | undefined,
         });
       } else if (sub === "set-nickname") {
@@ -187,19 +222,19 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         if (!name || nickname === undefined) {
           return { ok: false, error: "usage: query.sub=set-nickname + query.name + query.nickname" };
         }
-        cmdOracleSetNickname(name, nickname, { json: query.json as boolean | undefined });
+        commands.cmdOracleSetNickname(name, nickname, { json: query.json as boolean | undefined });
       } else if (sub === "get-nickname") {
         if (!query.name) return { ok: false, error: "usage: query.sub=get-nickname + query.name" };
-        cmdOracleGetNickname(query.name as string, { json: query.json as boolean | undefined });
+        commands.cmdOracleGetNickname(query.name as string, { json: query.json as boolean | undefined });
       } else if (sub === "search" || sub === "find") {
         if (!query.query) return { ok: false, error: "usage: query.sub=search + query.query" };
-        await cmdOracleSearch(query.query as string, {
+        await commands.cmdOracleSearch(query.query as string, {
           json: query.json as boolean | undefined,
           awake: query.awake as boolean | undefined,
           org: query.org as string | undefined,
         });
       } else if (sub === "about" && query.name) {
-        await cmdOracleAbout(query.name as string);
+        await commands.cmdOracleAbout(query.name as string);
       } else {
         return { ok: false, error: "usage: query.sub=[ls|scan|search|prune|register|set-nickname|get-nickname|about] + query.name" };
       }
@@ -212,4 +247,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     console.log = origLog;
     console.error = origError;
   }
+  };
 }
+
+export default createOracleHandler();

--- a/src/commands/plugins/oracle/oracle.test.ts
+++ b/src/commands/plugins/oracle/oracle.test.ts
@@ -1,39 +1,40 @@
-import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { describe, it, expect, beforeEach } from "bun:test";
 import type { InvokeContext } from "../../../plugin/types";
-
-mock.module("./impl", () => ({
-  cmdOracleList: async () => {
-    console.log("Oracle Fleet  (1/2 awake)");
-  },
-  cmdOracleScan: async (_opts: any) => {
-    console.log("Scanned 5 oracles locally");
-  },
-  cmdOracleScanStale: async (_opts: any) => {
-    console.log("Stale oracle scan  (DEAD 1  STALE 2)");
-  },
-  cmdOracleFleet: async (_opts: any) => {
-    console.log("Oracle Fleet  (5 oracles)");
-  },
-  cmdOracleAbout: async (name: string) => {
-    console.log(`Oracle — ${name}`);
-  },
-}));
-
-mock.module("./impl-nickname", () => ({
-  cmdOracleSetNickname: (name: string, nickname: string) => {
-    console.log(`set-nickname ${name}=${nickname}`);
-  },
-  cmdOracleGetNickname: (name: string) => {
-    console.log(`get-nickname ${name}`);
-  },
-}));
+import { createOracleHandler } from "./index";
 
 describe("oracle plugin", () => {
   let handler: (ctx: InvokeContext) => Promise<any>;
 
-  beforeEach(async () => {
-    const mod = await import("./index");
-    handler = mod.default;
+  beforeEach(() => {
+    handler = createOracleHandler({
+      cmdOracleList: async () => {
+        console.log("Oracle Fleet  (1/2 awake)");
+      },
+      cmdOracleScan: async (_opts: any) => {
+        console.log("Scanned 5 oracles locally");
+      },
+      cmdOracleScanStale: async (_opts: any) => {
+        console.log("Stale oracle scan  (DEAD 1  STALE 2)");
+      },
+      cmdOracleFleet: async (_opts: any) => {
+        console.log("Oracle Fleet  (5 oracles)");
+      },
+      cmdOracleAbout: async (name: string) => {
+        console.log(`Oracle — ${name}`);
+      },
+      cmdOraclePrune: async () => {
+        console.log("pruned");
+      },
+      cmdOracleRegister: async (name: string) => {
+        console.log(`registered ${name}`);
+      },
+      cmdOracleSetNickname: (name: string, nickname: string) => {
+        console.log(`set-nickname ${name}=${nickname}`);
+      },
+      cmdOracleGetNickname: (name: string) => {
+        console.log(`get-nickname ${name}`);
+      },
+    });
   });
 
   it("cli: ls lists oracles", async () => {

--- a/src/commands/plugins/pane/index.ts
+++ b/src/commands/plugins/pane/index.ts
@@ -1,0 +1,52 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+
+export const command = {
+  name: "pane",
+  description: "Pane workflow helpers such as swapping panes in the current tmux window.",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+
+  try {
+    if (!process.env.TMUX) {
+      console.log("\x1b[33m⚠\x1b[0m pane requires tmux");
+      return { ok: false, error: "not in tmux" };
+    }
+
+    const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+    const sub = args[0]?.toLowerCase();
+
+    if (!sub || sub === "--help" || sub === "-h") {
+      console.log("usage: maw pane swap <pane-a> <pane-b>");
+      console.log("  pane targets: index (1), pane id (%1), title prefix (tile-1), top, bottom");
+      return { ok: true, output: logs.join("\n") || undefined };
+    }
+
+    if (sub !== "swap") {
+      console.log(`unknown pane subcommand: ${sub}`);
+      console.log("usage: maw pane swap <pane-a> <pane-b>");
+      return { ok: false, error: `unknown subcommand: ${sub}`, output: logs.join("\n") };
+    }
+
+    const a = args[1];
+    const b = args[2];
+    if (!a || !b) {
+      console.log("usage: maw pane swap <pane-a> <pane-b>");
+      return { ok: false, error: "two pane targets required", output: logs.join("\n") };
+    }
+
+    const { cmdTileSwap } = await import("../tile/impl");
+    await cmdTileSwap(a, b);
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: e?.message || String(e), output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+  }
+}

--- a/src/commands/plugins/pane/plugin.json
+++ b/src/commands/plugins/pane/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "pane",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Pane workflow helpers such as swapping panes in the current tmux window.",
+  "cli": {
+    "command": "pane",
+    "help": "maw pane swap <a> <b> — swap panes in the current tmux window"
+  },
+  "weight": 5
+}

--- a/src/commands/plugins/swarm/index.ts
+++ b/src/commands/plugins/swarm/index.ts
@@ -1,4 +1,5 @@
 import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { AgentColor } from "../tmux/layout-manager";
 import { parseFlags } from "../../../cli/parse-args";
 
 export const command = {
@@ -89,6 +90,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     const { loadConfig } = await import("../../../config");
     const configCommands = loadConfig().commands || {};
 
+    const paneIds: { name: string; agentId: string; agentCmd: string; label: string; color: AgentColor }[] = [];
     for (let i = 0; i < agentList.length; i++) {
       const agentType = agentList[i];
       const known = KNOWN_AGENTS[agentType];
@@ -98,34 +100,50 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       const name = `${agentType}-${i + 1}`;
       const color = nextAgentColor(i);
       const agentId = `${name}@${teamName}`;
+
+      paneIds.push({ name, agentId, agentCmd, label, color });
+    }
+
+    // Phase 1: Split all panes (empty shells) — no agents yet
+    const spawned: { name: string; agentId: string; agentCmd: string; label: string; color: AgentColor; paneId: string }[] = [];
+    for (const agent of paneIds) {
       const targetFlag = anchor ? `-t '${anchor}' ` : "";
-
-      const shellCmd = `${agentCmd}; exec zsh`;
-
       let paneId = "";
       await withPaneLock(async () => {
         paneId = (await hostExec(
-          `tmux split-window ${targetFlag}-h -P -F '#{pane_id}' '${shellCmd.replace(/'/g, "'\\''")}'`,
+          `tmux split-window ${targetFlag}-h -P -F '#{pane_id}' 'exec zsh -li'`,
         )).trim();
-        await new Promise(r => setTimeout(r, 300));
+        await new Promise(r => setTimeout(r, 100));
       });
+      spawned.push({ ...agent, paneId });
+    }
 
-      await stylePaneBorder(paneId, `${name} (${label})`, color);
+    // Phase 2: Apply layout ONCE — all panes get their final sizes
+    const window = await getWindowTarget();
+    if (tiled) {
+      await applyTiledLayout(window);
+    } else if (anchor) {
+      await applyTeamLayout(window, anchor);
+    }
+    await enableBorderStatus(window);
+    await new Promise(r => setTimeout(r, 200));
 
-      const existing = config.members.findIndex((m: any) => m.name === name);
-      const entry = { name, agentId, tmuxPaneId: paneId, color, model: agentType };
+    // Phase 3: Start agents in correctly-sized panes
+    for (const agent of spawned) {
+      await stylePaneBorder(agent.paneId, `${agent.name} (${agent.label})`, agent.color);
+
+      const escaped = agent.agentCmd.replace(/'/g, "'\\''");
+      await hostExec(
+        `tmux send-keys -t '${agent.paneId}' '${escaped}; printf "\\e[?1049l"; clear; exec zsh -li' Enter`,
+      );
+      await new Promise(r => setTimeout(r, 200));
+
+      const existing = config.members.findIndex((m: any) => m.name === agent.name);
+      const entry = { name: agent.name, agentId: agent.agentId, tmuxPaneId: agent.paneId, color: agent.color, model: agent.agentCmd };
       if (existing >= 0) config.members[existing] = entry;
       else config.members.push(entry);
 
-      const window = await getWindowTarget();
-      if (tiled) {
-        await applyTiledLayout(window);
-      } else if (anchor) {
-        await applyTeamLayout(window, anchor);
-      }
-      await enableBorderStatus(window);
-
-      console.log(`  \x1b[${colorAnsi(color)}m●\x1b[0m ${name} (${label}) → ${paneId}`);
+      console.log(`  \x1b[${colorAnsi(agent.color)}m●\x1b[0m ${agent.name} (${agent.label}) → ${agent.paneId}`);
     }
 
     writeFileSync(configPath, JSON.stringify(config, null, 2));

--- a/src/commands/plugins/team/index.ts
+++ b/src/commands/plugins/team/index.ts
@@ -77,20 +77,33 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       cmdTeamCreate(args[1], { description });
     } else if (sub === "spawn") {
       if (!args[1] || !args[2]) {
-        logs.push("usage: maw team spawn <team> <role> [--model <model>] [--prompt <text>] [--exec]");
+        logs.push("usage: maw team spawn <team> <role> [--model <model>] [--cwd <path>] [--worktree <path>] [--prompt <text>] [--exec]");
         return { ok: false, error: "team and role required", output: logs.join("\n") };
       }
       const modelIdx = args.indexOf("--model");
       const model = modelIdx !== -1 ? args[modelIdx + 1] : undefined;
+      const cwdIdx = args.indexOf("--cwd");
+      const worktreeIdx = args.indexOf("--worktree");
+      const cwd = cwdIdx !== -1 ? args[cwdIdx + 1] : (worktreeIdx !== -1 ? args[worktreeIdx + 1] : undefined);
       const promptIdx = args.indexOf("--prompt");
       const exec = args.includes("--exec");
       // --prompt is greedy to end-of-argv; strip --exec if it appears in the tail
       let prompt: string | undefined;
       if (promptIdx !== -1) {
-        const tail = args.slice(promptIdx + 1).filter(a => a !== "--exec");
+        const rawTail = args.slice(promptIdx + 1);
+        const tail: string[] = [];
+        for (let i = 0; i < rawTail.length; i++) {
+          const a = rawTail[i];
+          if (a === "--exec") continue;
+          if (a === "--model" || a === "--cwd" || a === "--worktree") {
+            i++;
+            continue;
+          }
+          tail.push(a);
+        }
         prompt = tail.join(" ") || undefined;
       }
-      await cmdTeamSpawn(args[1], args[2], { model, prompt, exec });
+      await cmdTeamSpawn(args[1], args[2], { model, prompt, exec, cwd });
     } else if (sub === "send" || sub === "msg") {
       if (!args[1] || !args[2] || !args[3]) {
         logs.push("usage: maw team send <team> <agent> <message>");
@@ -371,6 +384,37 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       }
       console.log(`\x1b[32m✓\x1b[0m broadcast to ${sent}/${withPanes.length} agents: ${message}`);
 
+    } else if (sub === "enter" || sub === "send-enter") {
+      // maw team enter <agent|all> — submit pending input in agent pane(s)
+      const agent = args[1];
+      if (!agent) {
+        logs.push("usage: maw team enter <agent|all>");
+        return { ok: false, error: "agent required", output: logs.join("\n") };
+      }
+      const teamName = resolveTeamFromContext();
+      const { loadTeam } = await import("./team-helpers");
+      const team = loadTeam(teamName);
+      if (!team) {
+        logs.push(`\x1b[33m⚠\x1b[0m team '${teamName}' not found`);
+        return { ok: false, error: "team not found" };
+      }
+      const members = team.members.filter(m =>
+        m.tmuxPaneId && m.agentType !== "team-lead" &&
+        (agent === "all" || m.name === agent || m.agentId === agent || m.agentId === `${agent}@${teamName}`)
+      );
+      if (!members.length) {
+        logs.push(`\x1b[33m⚠\x1b[0m agent '${agent}' not found or no pane ID`);
+        logs.push(`Available: ${team.members.filter(m => m.tmuxPaneId).map(m => m.name).join(", ") || "none"}`);
+        return { ok: false, error: "agent not found" };
+      }
+      const { hostExec: exec } = await import("../../../sdk");
+      const { colorAnsi } = await import("../tmux/layout-manager");
+      for (const m of members) {
+        await exec(`tmux send-keys -t '${m.tmuxPaneId}' Enter`);
+        const color = (m.color || "white") as any;
+        console.log(`\x1b[${colorAnsi(color)}m↵\x1b[0m enter sent to ${m.agentId || m.name}`);
+      }
+
     } else if (sub === "hey") {
       // maw team hey <agent> <message> — send keystrokes to agent's tmux pane
       const agent = args[1];
@@ -491,7 +535,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
 
     } else {
       logs.push(`unknown team subcommand: ${sub}`);
-      logs.push("usage: maw team <create|spawn|send|shutdown|split|peek|hey|inbox|layout|prep|recover|resume|lives|list|status|add|tasks|done|assign|delete>");
+      logs.push("usage: maw team <create|spawn|send|shutdown|split|peek|hey|enter|inbox|layout|prep|recover|resume|lives|list|status|add|tasks|done|assign|delete>");
       return { ok: false, error: `unknown subcommand: ${sub}`, output: logs.join("\n") };
     }
 

--- a/src/commands/plugins/team/team-lifecycle.ts
+++ b/src/commands/plugins/team/team-lifecycle.ts
@@ -176,7 +176,7 @@ export function cmdTeamCreate(name: string, opts: { description?: string } = {})
 export async function cmdTeamSpawn(
   teamName: string,
   role: string,
-  opts: { model?: string; prompt?: string; exec?: boolean } = {},
+  opts: { model?: string; prompt?: string; exec?: boolean; cwd?: string } = {},
 ) {
   const PSI = resolvePsi();
   const teamDir = join(PSI, "memory", "mailbox", "teams", teamName);
@@ -213,6 +213,8 @@ export async function cmdTeamSpawn(
 
   // Build spawn prompt
   const model = opts.model || "sonnet";
+  const shellQuote = (s: string) => `'${s.replace(/'/g, "'\\''")}'`;
+  const cwdPrefix = opts.cwd ? `cd ${shellQuote(opts.cwd)} && ` : "";
   const parts: string[] = [];
   parts.push(`You are '${role}' on team '${teamName}'.`);
   if (opts.prompt) parts.push(opts.prompt);
@@ -260,12 +262,12 @@ export async function cmdTeamSpawn(
     if (!process.env.TMUX) {
       console.log();
       console.log(`  \x1b[33m⚠\x1b[0m --exec requires an active tmux session ($TMUX not set).`);
-      console.log(`  \x1b[36mRun manually:\x1b[0m claude --model ${model} --system-prompt-file "${promptPath}"`);
+      console.log(`  \x1b[36mRun manually:\x1b[0m ${cwdPrefix}claude --model ${model} --system-prompt-file "${promptPath}"`);
       return;
     }
     try {
       const { spawnTeammatePane, colorAnsi } = await import("../tmux/layout-manager");
-      const claudeCmd = `claude --model ${model} --system-prompt-file '${promptPath.replace(/'/g, "'\\''")}'`;
+      const claudeCmd = `${cwdPrefix}claude --model ${model} --system-prompt-file '${promptPath.replace(/'/g, "'\\''")}'`;
       const teammateCount = manifest.members.filter((m: any) => m.name !== role).length;
       const agentId = `${role}@${teamName}`;
 
@@ -295,11 +297,11 @@ export async function cmdTeamSpawn(
     } catch (e: any) {
       console.log();
       console.log(`  \x1b[33m⚠\x1b[0m --exec split failed: ${e?.message || e}`);
-      console.log(`  \x1b[36mRun manually:\x1b[0m claude --model ${model} --system-prompt-file "${promptPath}"`);
+      console.log(`  \x1b[36mRun manually:\x1b[0m ${cwdPrefix}claude --model ${model} --system-prompt-file "${promptPath}"`);
     }
     return;
   }
 
   console.log();
-  console.log(`  \x1b[36mRun:\x1b[0m claude --model ${model} --system-prompt-file "${promptPath}"`);
+  console.log(`  \x1b[36mRun:\x1b[0m ${cwdPrefix}claude --model ${model} --system-prompt-file "${promptPath}"`);
 }

--- a/src/commands/plugins/tile/impl.ts
+++ b/src/commands/plugins/tile/impl.ts
@@ -110,9 +110,12 @@ export async function cmdTile(count: number, opts: TileOpts = {}): Promise<void>
     console.log(`  \x1b[${colorAnsi(color)}m●\x1b[0m ${label} → ${paneId}${extras ? "  " + extras : ""}`);
   }
 
-  // Apply layout: even-horizontal for 1 tile (left|right), tiled for 2+ (grid)
+  // Layout: 1 tile = left|right, 2-3 tiles = lead full-left + tiles stacked right,
+  // 4+ = even grid
   if (count === 1) {
     await hostExec(`tmux select-layout -t '${window}' even-horizontal`);
+  } else if (count <= 3) {
+    await hostExec(`tmux select-layout -t '${window}' main-vertical`);
   } else {
     await applyTiledLayout(window);
   }
@@ -140,7 +143,6 @@ export async function cmdTileClean(): Promise<void> {
     const [paneId, ...titleParts] = line.split(" ");
     const title = titleParts.join(" ");
     if (paneId === myPane) continue;
-    if (!title.startsWith("tile-")) continue;
 
     try {
       await hostExec(`tmux kill-pane -t '${paneId}'`);

--- a/src/commands/plugins/tile/impl.ts
+++ b/src/commands/plugins/tile/impl.ts
@@ -110,11 +110,14 @@ export async function cmdTile(count: number, opts: TileOpts = {}): Promise<void>
     console.log(`  \x1b[${colorAnsi(color)}m●\x1b[0m ${label} → ${paneId}${extras ? "  " + extras : ""}`);
   }
 
-  // Layout: 1 tile = left|right, 2-3 tiles = lead full-left + tiles stacked right,
-  // 4+ = even grid
-  if (count === 1) {
+  // Layout decision uses TOTAL pane count (lead + all tiles), not just new spawns.
+  // 2 panes = lead | tile (even split), 3-4 = main-vertical (lead-left, tiles-right),
+  // 5+ = tiled grid. (#1394)
+  const paneCountRaw = (await hostExec(`tmux list-panes -t '${window}' | wc -l`)).trim();
+  const totalPanes = parseInt(paneCountRaw, 10) || (count + 1);
+  if (totalPanes === 2) {
     await hostExec(`tmux select-layout -t '${window}' even-horizontal`);
-  } else if (count <= 3) {
+  } else if (totalPanes <= 4) {
     await hostExec(`tmux select-layout -t '${window}' main-vertical`);
   } else {
     await applyTiledLayout(window);

--- a/src/commands/plugins/tile/impl.ts
+++ b/src/commands/plugins/tile/impl.ts
@@ -226,19 +226,37 @@ export async function cmdTileClean(): Promise<void> {
     const parentDir = dirname(repoPath);
     const repoName = basename(repoPath).replace(/\.wt-.*$/, "");
     const mainRepo = `${parentDir}/${repoName}`;
-    const wtRaw = await hostExec(`git -C '${mainRepo}' worktree list --porcelain 2>/dev/null`);
-    const tileWts = wtRaw.split("\n")
-      .filter(l => l.startsWith("worktree "))
-      .map(l => l.replace("worktree ", ""))
-      .filter(p => /\.wt-\d+-tile-\d+$/.test(p));
+    const wtRaw = await hostExec(`git -C ${shellArg(mainRepo)} worktree list --porcelain 2>/dev/null`);
+    const tileWts: { path: string; branch?: string }[] = [];
+    let current: { path: string; branch?: string } | null = null;
+    for (const line of wtRaw.split("\n")) {
+      if (line.startsWith("worktree ")) {
+        if (current) tileWts.push(current);
+        current = { path: line.replace("worktree ", "") };
+      } else if (line.startsWith("branch ") && current) {
+        current.branch = line.replace("branch refs/heads/", "").replace("branch ", "");
+      }
+    }
+    if (current) tileWts.push(current);
 
-    for (const wt of tileWts) {
+    for (const wtInfo of tileWts.filter(w => /\.wt-\d+-tile-\d+$/.test(w.path))) {
+      const wt = wtInfo.path;
       if (!existsSync(wt)) continue;
       try {
-        await hostExec(`git -C '${mainRepo}' worktree remove '${wt}' --force 2>/dev/null`);
+        await hostExec(`git -C ${shellArg(mainRepo)} worktree remove ${shellArg(wt)} --force 2>/dev/null`);
         console.log(`  \x1b[31m✗\x1b[0m worktree ${wt}`);
         killed++;
       } catch { /* ok */ }
+      const branch = wtInfo.branch;
+      if (branch && /^agents\/\d+-tile-\d+$/.test(branch)) {
+        try {
+          await hostExec(`git -C ${shellArg(mainRepo)} branch -d ${shellArg(branch)} 2>/dev/null`);
+          console.log(`  \x1b[31m✗\x1b[0m branch ${branch}`);
+          killed++;
+        } catch {
+          console.log(`  \x1b[33m⚠\x1b[0m kept branch ${branch} (not fully merged)`);
+        }
+      }
     }
   } catch { /* not in a git repo */ }
 

--- a/src/commands/plugins/tile/impl.ts
+++ b/src/commands/plugins/tile/impl.ts
@@ -9,6 +9,51 @@ function shellArg(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
+function envExport(assignments: Record<string, string>): string {
+  return Object.entries(assignments)
+    .map(([key, value]) => `${key}=${shellArg(value)}`)
+    .join(" ");
+}
+
+async function getParentAddress(anchor: string): Promise<string> {
+  if (!anchor) return "";
+  try {
+    return (await hostExec(
+      `tmux display-message -t '${anchor}' -p '#{session_name}:#{window_index}.#{pane_index}'`,
+    )).trim();
+  } catch {
+    return anchor;
+  }
+}
+
+async function getWindowAddress(anchor: string, window: string): Promise<string> {
+  if (!anchor) return window;
+  try {
+    return (await hostExec(
+      `tmux display-message -t '${anchor}' -p '#{session_name}:#{window_index}'`,
+    )).trim();
+  } catch {
+    return window;
+  }
+}
+
+async function listPanes(window: string, format = "#{pane_id}"): Promise<string[]> {
+  const raw = await hostExec(`tmux list-panes -t '${window}' -F '${format}'`);
+  return raw.split("\n").filter(Boolean);
+}
+
+async function countExistingTilePanes(window: string): Promise<number> {
+  try {
+    const panes = await listPanes(window, "#{pane_id}|||#{pane_title}|||#{@maw_tile}");
+    return panes.filter(line => {
+      const [, title = "", marker = ""] = line.split("|||");
+      return marker === "1" || /^tile-\d+(?: 🌳)?$/.test(title);
+    }).length;
+  } catch {
+    return 0;
+  }
+}
+
 async function getWindow(): Promise<string> {
   const pane = process.env.TMUX_PANE;
   if (pane) {
@@ -39,6 +84,10 @@ export async function cmdTile(count: number, opts: TileOpts = {}): Promise<void>
   }
 
   const anchor = process.env.TMUX_PANE ?? "";
+  const parentAddress = await getParentAddress(anchor);
+  const windowAddress = await getWindowAddress(anchor, window);
+  const existingTileCount = await countExistingTilePanes(window);
+  const finalTileTotal = existingTileCount + count;
 
   let engineCmd = "";
   if (opts.engine) {
@@ -70,7 +119,8 @@ export async function cmdTile(count: number, opts: TileOpts = {}): Promise<void>
   const paneIds: string[] = [];
 
   for (let i = 0; i < count; i++) {
-    const name = `tile-${i + 1}`;
+    const tileIndex = existingTileCount + i + 1;
+    const name = `tile-${tileIndex}`;
 
     let cwd = "";
     if (opts.wt) {
@@ -81,12 +131,20 @@ export async function cmdTile(count: number, opts: TileOpts = {}): Promise<void>
       existingWorktrees.push({ name, path: cwd });
     }
 
-    let shellCmd = "exec zsh";
+    const tileEnv = envExport({
+      MAW_TILE_PARENT: parentAddress,
+      MAW_TILE_ROLE: name,
+      MAW_TILE_INDEX: String(tileIndex),
+      MAW_TILE_TOTAL: String(finalTileTotal),
+      MAW_TILE_WINDOW: windowAddress,
+    });
+
+    let shellCmd = `export ${tileEnv}; exec zsh`;
     if (engineCmd) {
-      shellCmd = `${engineCmd.replace(/'/g, "'\\''")}; exec zsh`;
+      shellCmd = `export ${tileEnv}; ${engineCmd}; exec zsh`;
     }
     if (cwd) {
-      shellCmd = `cd '${cwd.replace(/'/g, "'\\''")}' && ${shellCmd}`;
+      shellCmd = `cd ${shellArg(cwd)} && ${shellCmd}`;
     }
 
     // Chain: split from last pane so idx order = spawn order
@@ -95,7 +153,7 @@ export async function cmdTile(count: number, opts: TileOpts = {}): Promise<void>
     let paneId = "";
     await withPaneLock(async () => {
       paneId = (await hostExec(
-        `tmux split-window ${targetFlag}-h -P -F '#{pane_id}' '${shellCmd}'`,
+        `tmux split-window ${targetFlag}-h -P -F '#{pane_id}' ${shellArg(shellCmd)}`,
       )).trim();
       await new Promise(r => setTimeout(r, 200));
     });
@@ -105,6 +163,9 @@ export async function cmdTile(count: number, opts: TileOpts = {}): Promise<void>
     const color = nextAgentColor(i);
     const label = opts.wt ? `${name} 🌳` : name;
     await stylePaneBorder(paneId, label, color);
+    await hostExec(`tmux set-option -p -t '${paneId}' @maw_tile '1'`);
+    await hostExec(`tmux set-option -p -t '${paneId}' @maw_tile_parent ${shellArg(parentAddress)}`);
+    await hostExec(`tmux set-option -p -t '${paneId}' @maw_tile_role ${shellArg(name)}`);
 
     const extras = [
       opts.wt ? `\x1b[90m${cwd}\x1b[0m` : "",
@@ -114,11 +175,10 @@ export async function cmdTile(count: number, opts: TileOpts = {}): Promise<void>
     console.log(`  \x1b[${colorAnsi(color)}m●\x1b[0m ${label} → ${paneId}${extras ? "  " + extras : ""}`);
   }
 
-  // Layout decision uses TOTAL pane count (lead + all tiles), not just new spawns.
-  // 2 panes = lead | tile (even split), 3-4 = main-vertical (lead-left, tiles-right),
-  // 5+ = tiled grid. (#1394)
-  const paneCountRaw = (await hostExec(`tmux list-panes -t '${window}' | wc -l`)).trim();
-  const totalPanes = parseInt(paneCountRaw, 10) || (count + 1);
+  const totalPanes = (await listPanes(window)).length;
+
+  // Layout by total panes after spawn: lead+1 = side-by-side, lead+2-3 =
+  // lead full-left with tiles stacked right, 5+ panes = even grid.
   if (totalPanes === 2) {
     await hostExec(`tmux select-layout -t '${window}' even-horizontal`);
   } else if (totalPanes <= 4) {
@@ -141,15 +201,15 @@ export async function cmdTileClean(): Promise<void> {
   const myPane = process.env.TMUX_PANE ?? "";
 
   const raw = await hostExec(
-    `tmux list-panes -t '${window}' -F '#{pane_id} #{pane_title}'`,
+    `tmux list-panes -t '${window}' -F '#{pane_id}|||#{pane_title}|||#{@maw_tile}'`,
   );
   const lines = raw.split("\n").filter(Boolean);
   let killed = 0;
 
   for (const line of lines) {
-    const [paneId, ...titleParts] = line.split(" ");
-    const title = titleParts.join(" ");
+    const [paneId, title = "", marker = ""] = line.split("|||");
     if (paneId === myPane) continue;
+    if (marker !== "1" && !/^tile-\d+(?: 🌳)?$/.test(title)) continue;
 
     try {
       await hostExec(`tmux kill-pane -t '${paneId}'`);

--- a/src/commands/plugins/tile/impl.ts
+++ b/src/commands/plugins/tile/impl.ts
@@ -1,0 +1,181 @@
+import {
+  nextAgentColor, colorAnsi, stylePaneBorder, enableBorderStatus,
+  applyTiledLayout,
+} from "../tmux/layout-manager";
+import { hostExec } from "../../../sdk";
+import { withPaneLock } from "../../../core/transport/tmux-pane-lock";
+
+async function getWindow(): Promise<string> {
+  const pane = process.env.TMUX_PANE;
+  if (pane) {
+    return (await hostExec(`tmux display-message -t '${pane}' -p '#{window_id}'`)).trim();
+  }
+  return (await hostExec("tmux display-message -p '#{window_id}'")).trim();
+}
+
+export interface TileOpts {
+  wt?: boolean;
+  engine?: string;
+}
+
+export async function cmdTile(count: number, opts: TileOpts = {}): Promise<void> {
+  if (count < 0 || !Number.isFinite(count)) {
+    throw new Error("tile: count must be a non-negative integer");
+  }
+  if (count > 10) {
+    throw new Error("tile: max 10 panes (got " + count + ")");
+  }
+
+  const window = await getWindow();
+
+  if (count === 0) {
+    await applyTiledLayout(window);
+    console.log("\x1b[32m✓\x1b[0m tiled");
+    return;
+  }
+
+  const anchor = process.env.TMUX_PANE ?? "";
+
+  let engineCmd = "";
+  if (opts.engine) {
+    const { loadConfig } = await import("../../../config");
+    const commands = loadConfig().commands || {};
+    engineCmd = commands[opts.engine] || opts.engine;
+  }
+
+  let repoPath = "";
+  let parentDir = "";
+  let repoName = "";
+  let existingWorktrees: { name: string; path: string }[] = [];
+
+  if (opts.wt) {
+    const { findWorktrees } = await import("../../shared/wake-resolve-impl");
+    repoPath = (await hostExec("git rev-parse --show-toplevel")).trim();
+    const { dirname, basename } = await import("path");
+    parentDir = dirname(repoPath);
+    repoName = basename(repoPath).replace(/\.wt-.*$/, "");
+    const mainRepo = `${parentDir}/${repoName}`;
+    try {
+      await hostExec(`git -C '${mainRepo}' rev-parse --git-dir 2>/dev/null`);
+      repoPath = mainRepo;
+    } catch { /* already main */ }
+    existingWorktrees = await findWorktrees(parentDir, repoName);
+  }
+
+  // Spawn all panes chained from previous (preserves index order for grid)
+  const paneIds: string[] = [];
+
+  for (let i = 0; i < count; i++) {
+    const name = `tile-${i + 1}`;
+
+    let cwd = "";
+    if (opts.wt) {
+      const { createWorktree } = await import("../../shared/wake-session");
+      const oracle = repoName.replace(/-oracle$/, "");
+      const result = await createWorktree(repoPath, parentDir, repoName, oracle, name, existingWorktrees);
+      cwd = result.wtPath;
+      existingWorktrees.push({ name, path: cwd });
+    }
+
+    let shellCmd = "exec zsh";
+    if (engineCmd) {
+      shellCmd = `${engineCmd.replace(/'/g, "'\\''")}; exec zsh`;
+    }
+    if (cwd) {
+      shellCmd = `cd '${cwd.replace(/'/g, "'\\''")}' && ${shellCmd}`;
+    }
+
+    // Chain: split from last pane so idx order = spawn order
+    const splitFrom = paneIds.length > 0 ? paneIds[paneIds.length - 1] : anchor;
+    const targetFlag = splitFrom ? `-t '${splitFrom}' ` : "";
+    let paneId = "";
+    await withPaneLock(async () => {
+      paneId = (await hostExec(
+        `tmux split-window ${targetFlag}-h -P -F '#{pane_id}' '${shellCmd}'`,
+      )).trim();
+      await new Promise(r => setTimeout(r, 200));
+    });
+
+    paneIds.push(paneId);
+
+    const color = nextAgentColor(i);
+    const label = opts.wt ? `${name} 🌳` : name;
+    await stylePaneBorder(paneId, label, color);
+
+    const extras = [
+      opts.wt ? `\x1b[90m${cwd}\x1b[0m` : "",
+      opts.engine ? `\x1b[90m${opts.engine}\x1b[0m` : "",
+    ].filter(Boolean).join(" ");
+
+    console.log(`  \x1b[${colorAnsi(color)}m●\x1b[0m ${label} → ${paneId}${extras ? "  " + extras : ""}`);
+  }
+
+  // Apply layout: even-horizontal for 1 tile (left|right), tiled for 2+ (grid)
+  if (count === 1) {
+    await hostExec(`tmux select-layout -t '${window}' even-horizontal`);
+  } else {
+    await applyTiledLayout(window);
+  }
+  await enableBorderStatus(window);
+
+  const flags = [
+    opts.wt ? "worktree" : "",
+    opts.engine || "",
+  ].filter(Boolean).join(", ");
+
+  console.log(`\x1b[32m✓\x1b[0m ${count} panes tiled${flags ? " (" + flags + ")" : ""}`);
+}
+
+export async function cmdTileClean(): Promise<void> {
+  const window = await getWindow();
+  const myPane = process.env.TMUX_PANE ?? "";
+
+  const raw = await hostExec(
+    `tmux list-panes -t '${window}' -F '#{pane_id} #{pane_title}'`,
+  );
+  const lines = raw.split("\n").filter(Boolean);
+  let killed = 0;
+
+  for (const line of lines) {
+    const [paneId, ...titleParts] = line.split(" ");
+    const title = titleParts.join(" ");
+    if (paneId === myPane) continue;
+    if (!title.startsWith("tile-")) continue;
+
+    try {
+      await hostExec(`tmux kill-pane -t '${paneId}'`);
+      console.log(`  \x1b[31m✗\x1b[0m ${title} (${paneId})`);
+      killed++;
+    } catch { /* already gone */ }
+  }
+
+  // Clean up orphaned tile worktrees
+  const { existsSync } = await import("fs");
+  try {
+    const repoPath = (await hostExec("git rev-parse --show-toplevel")).trim();
+    const { dirname, basename } = await import("path");
+    const parentDir = dirname(repoPath);
+    const repoName = basename(repoPath).replace(/\.wt-.*$/, "");
+    const mainRepo = `${parentDir}/${repoName}`;
+    const wtRaw = await hostExec(`git -C '${mainRepo}' worktree list --porcelain 2>/dev/null`);
+    const tileWts = wtRaw.split("\n")
+      .filter(l => l.startsWith("worktree "))
+      .map(l => l.replace("worktree ", ""))
+      .filter(p => /\.wt-\d+-tile-\d+$/.test(p));
+
+    for (const wt of tileWts) {
+      if (!existsSync(wt)) continue;
+      try {
+        await hostExec(`git -C '${mainRepo}' worktree remove '${wt}' --force 2>/dev/null`);
+        console.log(`  \x1b[31m✗\x1b[0m worktree ${wt}`);
+        killed++;
+      } catch { /* ok */ }
+    }
+  } catch { /* not in a git repo */ }
+
+  if (killed === 0) {
+    console.log("\x1b[90mno tile panes or worktrees to clean\x1b[0m");
+  } else {
+    console.log(`\x1b[32m✓\x1b[0m cleaned ${killed} tiles`);
+  }
+}

--- a/src/commands/plugins/tile/impl.ts
+++ b/src/commands/plugins/tile/impl.ts
@@ -5,6 +5,10 @@ import {
 import { hostExec } from "../../../sdk";
 import { withPaneLock } from "../../../core/transport/tmux-pane-lock";
 
+function shellArg(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
 async function getWindow(): Promise<string> {
   const pane = process.env.TMUX_PANE;
   if (pane) {
@@ -183,4 +187,54 @@ export async function cmdTileClean(): Promise<void> {
   } else {
     console.log(`\x1b[32m✓\x1b[0m cleaned ${killed} tiles`);
   }
+}
+
+type PaneRow = {
+  index: string;
+  paneId: string;
+  title: string;
+  top: number;
+};
+
+async function listPaneRows(window: string): Promise<PaneRow[]> {
+  const raw = await hostExec(
+    `tmux list-panes -t '${window}' -F '#{pane_index}|||#{pane_id}|||#{pane_title}|||#{pane_top}'`,
+  );
+  return raw.split("\n").filter(Boolean).map((line) => {
+    const [index = "", paneId = "", title = "", topRaw = "0"] = line.split("|||");
+    return { index, paneId, title, top: parseInt(topRaw, 10) || 0 };
+  }).filter(row => row.paneId);
+}
+
+function resolveSwapPane(spec: string, rows: PaneRow[]): PaneRow | null {
+  const normalized = spec.trim();
+  if (!normalized) return null;
+
+  if (normalized === "top") {
+    return [...rows].sort((a, b) => a.top - b.top || parseInt(a.index, 10) - parseInt(b.index, 10))[0] ?? null;
+  }
+  if (normalized === "bottom") {
+    return [...rows].sort((a, b) => b.top - a.top || parseInt(b.index, 10) - parseInt(a.index, 10))[0] ?? null;
+  }
+  if (normalized.startsWith("%")) {
+    return rows.find(row => row.paneId === normalized) ?? { index: "", paneId: normalized, title: normalized, top: 0 };
+  }
+  if (/^\d+$/.test(normalized)) {
+    return rows.find(row => row.index === normalized) ?? null;
+  }
+  return rows.find(row => row.title === normalized || row.title.startsWith(normalized)) ?? null;
+}
+
+export async function cmdTileSwap(a: string, b: string): Promise<void> {
+  const window = await getWindow();
+  const rows = await listPaneRows(window);
+  const source = resolveSwapPane(a, rows);
+  const target = resolveSwapPane(b, rows);
+
+  if (!source) throw new Error(`tile swap: could not resolve pane '${a}'`);
+  if (!target) throw new Error(`tile swap: could not resolve pane '${b}'`);
+  if (source.paneId === target.paneId) throw new Error("tile swap: source and target are the same pane");
+
+  await hostExec(`tmux swap-pane -s ${shellArg(source.paneId)} -t ${shellArg(target.paneId)}`);
+  console.log(`\x1b[32m✓\x1b[0m swapped ${source.title || source.paneId} ↔ ${target.title || target.paneId}`);
 }

--- a/src/commands/plugins/tile/index.ts
+++ b/src/commands/plugins/tile/index.ts
@@ -30,12 +30,15 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     if (flags["--help"]) {
       console.log("usage: maw tile [N] [--wt] [--engine <name>]");
       console.log("       maw tile clean");
+      console.log("       maw tile swap <a> <b>");
       console.log("");
       console.log("  maw tile              apply tiled layout to current window");
       console.log("  maw tile 3            spawn 3 empty panes and tile them");
       console.log("  maw tile 3 --wt       spawn 3 worktree-backed panes, each with own branch");
       console.log("  maw tile 3 -e claude  spawn 3 panes running claude, tiled");
       console.log("  maw tile clean        kill tile panes + remove tile worktrees");
+      console.log("  maw tile swap 1 2     swap pane indices in the current window");
+      console.log("  maw tile swap top bottom | tile-1 tile-2 | %1 %2");
       return { ok: true, output: logs.join("\n") };
     }
 
@@ -44,6 +47,18 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     if (positional[0] === "clean") {
       const { cmdTileClean } = await import("./impl");
       await cmdTileClean();
+      return { ok: true, output: logs.join("\n") || undefined };
+    }
+
+    if (positional[0] === "swap") {
+      const a = positional[1];
+      const b = positional[2];
+      if (!a || !b) {
+        console.log("usage: maw tile swap <pane-a> <pane-b>");
+        return { ok: false, error: "two pane targets required", output: logs.join("\n") };
+      }
+      const { cmdTileSwap } = await import("./impl");
+      await cmdTileSwap(a, b);
       return { ok: true, output: logs.join("\n") || undefined };
     }
 

--- a/src/commands/plugins/tile/index.ts
+++ b/src/commands/plugins/tile/index.ts
@@ -1,0 +1,68 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { parseFlags } from "../../../cli/parse-args";
+
+export const command = {
+  name: "tile",
+  description: "Tile current window or spawn N colored panes in a tiled grid.",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+
+  try {
+    if (!process.env.TMUX) {
+      console.log("\x1b[33m⚠\x1b[0m tile requires tmux");
+      return { ok: false, error: "not in tmux" };
+    }
+
+    const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+    const flags = parseFlags(args, {
+      "--help": Boolean, "-h": "--help",
+      "--wt": Boolean,
+      "--engine": String, "-e": "--engine",
+    }, 0);
+
+    if (flags["--help"]) {
+      console.log("usage: maw tile [N] [--wt] [--engine <name>]");
+      console.log("       maw tile clean");
+      console.log("");
+      console.log("  maw tile              apply tiled layout to current window");
+      console.log("  maw tile 3            spawn 3 empty panes and tile them");
+      console.log("  maw tile 3 --wt       spawn 3 worktree-backed panes, each with own branch");
+      console.log("  maw tile 3 -e claude  spawn 3 panes running claude, tiled");
+      console.log("  maw tile clean        kill tile panes + remove tile worktrees");
+      return { ok: true, output: logs.join("\n") };
+    }
+
+    const positional = flags._ as string[];
+
+    if (positional[0] === "clean") {
+      const { cmdTileClean } = await import("./impl");
+      await cmdTileClean();
+      return { ok: true, output: logs.join("\n") || undefined };
+    }
+
+    const { cmdTile } = await import("./impl");
+    const count = positional[0] ? parseInt(positional[0], 10) : 0;
+
+    if (isNaN(count)) {
+      console.log("\x1b[33m⚠\x1b[0m tile: expected a number, got '" + positional[0] + "'");
+      return { ok: false, error: "invalid count" };
+    }
+
+    await cmdTile(count, {
+      wt: !!flags["--wt"],
+      engine: flags["--engine"] as string | undefined,
+    });
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: e?.message || String(e), output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+  }
+}

--- a/src/commands/plugins/tile/plugin.json
+++ b/src/commands/plugins/tile/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "tile",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Tile current window or spawn N colored panes in a tiled grid.",
+  "cli": {
+    "command": "tile",
+    "help": "maw tile [N] — tile window, or spawn N panes tiled"
+  },
+  "weight": 5
+}

--- a/src/commands/plugins/tmux/impl.ts
+++ b/src/commands/plugins/tmux/impl.ts
@@ -612,6 +612,16 @@ function suggestRecovery(target: string, session: string, source: string): void 
     process.exit(1);
   }
 
+  if (candidates.length === 1) {
+    const picked = candidates[0];
+    console.log(`\n  \x1b[36m→\x1b[0m auto-selecting: ${picked.label}`);
+    console.log(`  \x1b[36m→\x1b[0m maw wake ${picked.oracle} -a\n`);
+    const result = Bun.spawnSync(["maw", "wake", picked.oracle, "-a"], {
+      stdio: ["inherit", "inherit", "inherit"],
+    });
+    process.exit(result.exitCode ?? 0);
+  }
+
   if (!_tty.isStdoutTTY()) {
     console.log("");
     for (const c of candidates) {

--- a/src/commands/plugins/tmux/layout-manager.ts
+++ b/src/commands/plugins/tmux/layout-manager.ts
@@ -125,8 +125,8 @@ export async function spawnTeammatePane(
   const targetFlag = anchor ? `-t '${anchor}' ` : "";
   const color = nextAgentColor(opts.colorIndex);
 
-  // Wrap in zsh so the pane stays alive after the command exits
-  const wrapped = `${command.replace(/'/g, "'\\''")}; exec zsh`;
+  // Wrap: reset terminal after agent TUI exits, then login shell with full profile
+  const wrapped = `${command.replace(/'/g, "'\\''")}; printf "\\e[?1049l"; clear; exec zsh -li`;
 
   let paneId = "";
   await withPaneLock(async () => {

--- a/src/commands/shared/comm-peek.ts
+++ b/src/commands/shared/comm-peek.ts
@@ -46,7 +46,7 @@ export async function cmdPeek(query?: string) {
   if (query && query.includes(":") && !query.includes("/")) {
     const [nodeName, agentName] = query.split(":", 2);
     const localNode = config.node || "local";
-    if (nodeName === localNode) {
+    if (nodeName === localNode || nodeName === "local") {
       // #362 — local node prefix: strip and fall through to local peek
       query = agentName;
     } else {

--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -248,7 +248,7 @@ export async function cmdSend(
     const targetNode = parts.length >= 2 ? parts[0] : null;
     const bareAgent = parts.length >= 2 ? parts[1] : query;
     const isCanonical = parts.length >= 3;
-    const isLocalScope = !targetNode || targetNode === config.node;
+    const isLocalScope = !targetNode || targetNode === config.node || targetNode === "local";
     if (isLocalScope && bareAgent && !isCanonical) {
       const hasLocalSession = sessions.some(s =>
         s.name === bareAgent ||

--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -68,6 +68,33 @@ export function resolveMyName(config: ReturnType<typeof loadConfig>): string {
 }
 
 /**
+ * Visible internal federation attribution.
+ *
+ * Transport-level signing (`curlFetch(..., { from: "auto" })`) authenticates
+ * cross-node HTTP calls, but same-node tmux delivery has no protocol envelope.
+ * Internal Oracle convention is a body-level `[node:oracle]` prefix for human
+ * chat. Preserve executable slash/$ commands and already-signed messages so
+ * `maw hey target /skill` keeps invoking the command instead of turning into
+ * prose.
+ *
+ * @internal exported for regression tests.
+ */
+export function formatSignedMessage(
+  message: string,
+  config: Pick<ReturnType<typeof loadConfig>, "node">,
+  senderName: string,
+): string {
+  const leading = message.match(/^\s*/)?.[0] ?? "";
+  const body = message.slice(leading.length);
+  if (!body) return message;
+  if (body.startsWith("/") || body.startsWith("$")) return message;
+  if (/^\[[^\]\s:]+:[^\]]+\](?:\s|$)/.test(body)) return message;
+
+  const node = config.node || "local";
+  return `${leading}[${node}:${senderName}] ${body}`;
+}
+
+/**
  * Check if a pane is idle — i.e., no user input is in progress on the prompt line.
  * Uses capture-pane to inspect the last visible line. If a shell prompt marker
  * ($, %, >, ❯, #) is followed by non-whitespace text, the user is mid-input.
@@ -423,6 +450,9 @@ export async function cmdSend(
     }
   }
 
+  const senderName = resolveMyName(config);
+  const outboundMessage = formatSignedMessage(message, config, senderName);
+
   // Local target (or self-node) → send via tmux.
   // Resolve to a specific pane first: when the oracle window has multiple
   // panes (team-agents spawned beside it), `send-keys -t session:window`
@@ -450,16 +480,15 @@ export async function cmdSend(
         }
       }
     }
-    await sendKeys(target, message);
-    await runHook("after_send", { to: query, message });
+    await sendKeys(target, outboundMessage);
+    await runHook("after_send", { to: query, message: outboundMessage });
     if (!config.node) throw new Error("config.node is required — set 'node' in maw.config.json");
-    const senderName = resolveMyName(config);
-    logMessage(senderName, query, message, "local");
-    emitFeed("MessageSend", senderName, config.node, `${query}: ${message.slice(0, 200)}`, config.port || 3456);
+    logMessage(senderName, query, outboundMessage, "local");
+    emitFeed("MessageSend", senderName, config.node, `${query}: ${outboundMessage.slice(0, 200)}`, config.port || 3456);
     await Bun.sleep(150);
     let lastLine = "";
     try { const content = await capture(target, 3); lastLine = content.split("\n").filter(l => l.trim()).pop() || ""; } catch {}
-    console.log(`\x1b[32mdelivered\x1b[0m → ${target}: ${message}`);
+    console.log(`\x1b[32mdelivered\x1b[0m → ${target}: ${outboundMessage}`);
     if (lastLine) console.log(`\x1b[90m  ⤷ ${lastLine.slice(0, cfgLimit("messageTruncate"))}\x1b[0m`);
     return;
   }
@@ -468,16 +497,15 @@ export async function cmdSend(
   if (result?.type === "peer") {
     const res = await curlFetch(`${result.peerUrl}/api/send`, {
       method: "POST",
-      body: JSON.stringify({ target: result.target, text: message }),
+      body: JSON.stringify({ target: result.target, text: outboundMessage }),
       from: "auto", // #804 Step 4 SIGN — sign cross-node /api/send
     });
     if (res.ok && res.data?.ok) {
-      const agentName = resolveMyName(config);
-      logMessage(agentName, query, message, `peer:${result.node}`);
-      emitFeed("MessageSend", agentName, config.node!, `${result.node}:${query}: ${message.slice(0, 200)}`, config.port || 3456);
-      console.log(`\x1b[32mdelivered\x1b[0m ⚡ ${result.node} → ${res.data.target || result.target}: ${message}`);
+      logMessage(senderName, query, outboundMessage, `peer:${result.node}`);
+      emitFeed("MessageSend", senderName, config.node!, `${result.node}:${query}: ${outboundMessage.slice(0, 200)}`, config.port || 3456);
+      console.log(`\x1b[32mdelivered\x1b[0m ⚡ ${result.node} → ${res.data.target || result.target}: ${outboundMessage}`);
       if (res.data.lastLine) console.log(`\x1b[90m  ⤷ ${res.data.lastLine.slice(0, cfgLimit("messageTruncate"))}\x1b[0m`);
-      await runHook("after_send", { to: query, message });
+      await runHook("after_send", { to: query, message: outboundMessage });
       return;
     }
     const underlying = res.data?.error || (res.status ? `HTTP ${res.status}` : "connection failed");
@@ -493,13 +521,13 @@ export async function cmdSend(
   if (peerUrl) {
     const res = await curlFetch(`${peerUrl}/api/send`, {
       method: "POST",
-      body: JSON.stringify({ target: query, text: message }),
+      body: JSON.stringify({ target: query, text: outboundMessage }),
       from: "auto", // #804 Step 4 SIGN — sign discovery-fallback /api/send
     });
     if (res.ok && res.data?.ok) {
-      console.log(`\x1b[32mdelivered\x1b[0m ⚡ ${peerUrl} → ${res.data.target || query}: ${message}`);
+      console.log(`\x1b[32mdelivered\x1b[0m ⚡ ${peerUrl} → ${res.data.target || query}: ${outboundMessage}`);
       if (res.data.lastLine) console.log(`\x1b[90m  ⤷ ${res.data.lastLine.slice(0, cfgLimit("messageTruncate"))}\x1b[0m`);
-      await runHook("after_send", { to: query, message });
+      await runHook("after_send", { to: query, message: outboundMessage });
       return;
     }
     // Remote fetch was attempted but failed — surface the remote failure explicitly (#411).

--- a/src/commands/shared/fleet-wake.ts
+++ b/src/commands/shared/fleet-wake.ts
@@ -1,4 +1,4 @@
-import { readdirSync } from "fs";
+import { existsSync, readdirSync } from "fs";
 import { join } from "path";
 import { tmux, FLEET_DIR, saveTabOrder, restoreTabOrder } from "../../sdk";
 import { buildCommand, getEnvVars } from "../../config";
@@ -76,6 +76,16 @@ export async function cmdWakeAll(opts: { kill?: boolean; all?: boolean; resume?:
       // not under github.com/<org>/<repo>. Falling back to /root via missing-cwd was making
       // every Oracle session inherit Labubu's CLAUDE.md identity.
       const firstPath = join(getGhqRoot(), first.repo);
+      // #748 follow-up — tmux silently falls back to $HOME when -c <missing-path>,
+      // which re-surfaces the wrong-CLAUDE.md bug if ghqRoot resolves to a stale value
+      // (e.g. test fixture leak setting "/tmp/nope"). Refuse to spawn into a missing
+      // path; raise a clear error instead of silently inheriting the wrong identity.
+      if (!existsSync(firstPath)) {
+        throw new Error(
+          `wake: refusing to spawn ${sess.name} — cwd "${firstPath}" does not exist. ` +
+          `Check ghqRoot resolution (config.ghqRoot, $GHQ_ROOT, \`ghq root\`) and fleet config repo "${first.repo}".`,
+        );
+      }
       await tmux.newSession(sess.name, { window: first.name, cwd: firstPath });
       await pinSessionWide(sess.name);
       for (const [key, val] of Object.entries(getEnvVars())) {
@@ -91,6 +101,15 @@ export async function cmdWakeAll(opts: { kill?: boolean; all?: boolean; resume?:
       for (let i = 1; i < sess.windows.length; i++) {
         const win = sess.windows[i];
         const winPath = join(getGhqRoot(), win.repo);
+        if (!existsSync(winPath)) {
+          // Skip rather than throw — first-window throw already surfaced the
+          // root cause; per-window failures should fail-soft so other windows
+          // in the same session still wake.
+          process.stderr.write(
+            `[maw] wake: skipping ${sess.name}:${win.name} — cwd "${winPath}" does not exist.\n`,
+          );
+          continue;
+        }
         try {
           await tmux.newWindow(sess.name, win.name, { cwd: winPath });
           await pinWindowWide(`${sess.name}:${win.name}`);

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -6,18 +6,18 @@ import { normalizeTarget } from "../../core/matcher/normalize-target";
 import { assertValidOracleName } from "../../core/fleet/validate";
 import { resolveOracle, findWorktrees, getSessionMap, resolveFleetSession, detectSession, setSessionEnv, sanitizeBranchName } from "./wake-resolve";
 import { attachToSession, ensureSessionRunning, createWorktree } from "./wake-session";
-import { maybeSplit } from "./wake-maybe-split";
+import { maybeOpenWindow, maybeSplit } from "./wake-maybe-split";
 import { parseWakeTarget, ensureCloned } from "./wake-target";
 import { assertAgentCapacity } from "./wake-concurrency";
 
 export function shouldOfferExistingSessionAttach(
-  opts: { attach?: boolean; split?: boolean },
+  opts: { attach?: boolean; split?: boolean; bring?: boolean },
   isTTY = process.stdin.isTTY,
 ): boolean {
-  return !opts.attach && !opts.split && Boolean(isTTY);
+  return !opts.attach && !opts.split && !opts.bring && Boolean(isTTY);
 }
 
-export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; split?: boolean; repoPath?: string; urlRepoName?: string; allLocal?: boolean; engine?: string }): Promise<string> {
+export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; split?: boolean; bring?: boolean; repoPath?: string; urlRepoName?: string; allLocal?: boolean; engine?: string }): Promise<string> {
   // Canonicalize the bare name before any lookup — strips trailing `/`, `/.git`, `/.git/`
   // so `maw wake token-oracle/` (tab-completion artifact) resolves the same as `token-oracle`.
   oracle = normalizeTarget(oracle);
@@ -247,6 +247,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
         await tmux.sendText(`${session}:${existingWindow}`, `${buildCommandInDir(existingWindow, targetPath, opts.engine)} -p '${escaped}'`);
         if (opts.attach) await attachToSession(session);
         await maybeSplit(`${session}:${existingWindow}`, opts);
+        await maybeOpenWindow(`${session}:${existingWindow}`, opts);
         return `${session}:${existingWindow}`;
       }
       // Check if agent is actually alive in the pane
@@ -263,6 +264,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
           await attachToSession(session);
         }
         await maybeSplit(target, opts);
+        await maybeOpenWindow(target, opts);
         return target;
       }
 
@@ -284,6 +286,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
         await attachToSession(session);
       }
       await maybeSplit(target, opts);
+      await maybeOpenWindow(target, opts);
       return target;
     }
   } catch { /* session might be fresh */ }
@@ -306,6 +309,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
   if (opts.attach) await attachToSession(session);
 
   await maybeSplit(`${session}:${windowName}`, opts);
+  await maybeOpenWindow(`${session}:${windowName}`, opts);
 
   takeSnapshot("wake").catch(() => {});
   return `${session}:${windowName}`;

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -8,6 +8,7 @@ import { resolveOracle, findWorktrees, getSessionMap, resolveFleetSession, detec
 import { attachToSession, ensureSessionRunning, createWorktree } from "./wake-session";
 import { maybeSplit } from "./wake-maybe-split";
 import { parseWakeTarget, ensureCloned } from "./wake-target";
+import { assertAgentCapacity } from "./wake-concurrency";
 
 export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; split?: boolean; repoPath?: string; urlRepoName?: string; allLocal?: boolean; engine?: string }): Promise<string> {
   // Canonicalize the bare name before any lookup — strips trailing `/`, `/.git`, `/.git/`
@@ -81,6 +82,10 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
   });
 
   if (!session && wakeDecision.wake) {
+    // #2 — refuse to spawn a brand-new session/agent once the fleet is at the
+    // configured concurrency cap (no-op when limits.maxConcurrentAgents is 0).
+    await assertAgentCapacity(oracle);
+
     // #769 — URL input names the new session after the full repo (e.g.
     // "m5-oracle") so it's distinct from any unrelated sub-token sessions
     // and immediately disambiguates future `maw wake` calls.
@@ -275,6 +280,10 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
       return target;
     }
   } catch { /* session might be fresh */ }
+
+  // #2 — a new task/worktree window is a net-new agent pane: cap-check before
+  // spawning it (no-op when limits.maxConcurrentAgents is 0).
+  await assertAgentCapacity(oracle);
 
   await tmux.newWindow(session, windowName, { cwd: targetPath });
   await new Promise(r => setTimeout(r, 300));

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -17,7 +17,7 @@ export function shouldOfferExistingSessionAttach(
   return !opts.attach && !opts.split && !opts.bring && Boolean(isTTY);
 }
 
-export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; split?: boolean; bring?: boolean; repoPath?: string; urlRepoName?: string; allLocal?: boolean; engine?: string }): Promise<string> {
+export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; split?: boolean; bring?: boolean; tab?: boolean; repoPath?: string; urlRepoName?: string; allLocal?: boolean; engine?: string }): Promise<string> {
   // Canonicalize the bare name before any lookup — strips trailing `/`, `/.git`, `/.git/`
   // so `maw wake token-oracle/` (tab-completion artifact) resolves the same as `token-oracle`.
   oracle = normalizeTarget(oracle);

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -10,6 +10,13 @@ import { maybeSplit } from "./wake-maybe-split";
 import { parseWakeTarget, ensureCloned } from "./wake-target";
 import { assertAgentCapacity } from "./wake-concurrency";
 
+export function shouldOfferExistingSessionAttach(
+  opts: { attach?: boolean; split?: boolean },
+  isTTY = process.stdin.isTTY,
+): boolean {
+  return !opts.attach && !opts.split && Boolean(isTTY);
+}
+
 export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; split?: boolean; repoPath?: string; urlRepoName?: string; allLocal?: boolean; engine?: string }): Promise<string> {
   // Canonicalize the bare name before any lookup — strips trailing `/`, `/.git`, `/.git/`
   // so `maw wake token-oracle/` (tab-completion artifact) resolves the same as `token-oracle`.
@@ -260,7 +267,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
       }
 
       console.log(`\x1b[32m⚡\x1b[0m '${existingWindow}' running in ${session}`);
-      if (!opts.attach && process.stdin.isTTY) {
+      if (shouldOfferExistingSessionAttach(opts)) {
         process.stdout.write(`  attach? [y/N] `);
         const { openSync, readSync, closeSync } = await import("fs");
         try {
@@ -303,4 +310,3 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
   takeSnapshot("wake").catch(() => {});
   return `${session}:${windowName}`;
 }
-

--- a/src/commands/shared/wake-concurrency.ts
+++ b/src/commands/shared/wake-concurrency.ts
@@ -1,0 +1,58 @@
+/**
+ * wake-concurrency.ts — agent concurrency cap for `maw wake` (#2).
+ *
+ * `cmdWake` had no count, queue, or cap: nothing stopped a script (or a
+ * runaway orchestrator) from spawning agents until the box fell over.
+ * `D.limits` governed feed/logs/pty/message sizes but nothing about agent
+ * count.
+ *
+ * This module adds an opt-in cap. When `limits.maxConcurrentAgents` is a
+ * positive number, `maw wake` counts the agent panes already live across the
+ * fleet and refuses ("fails loud") to spawn one more once the fleet is at or
+ * over the cap. `0` / unset disables the cap — no behavior change for anyone
+ * who has not configured it.
+ *
+ * Pure decision logic (`checkCapacity`) is split from the tmux I/O
+ * (`countLiveAgents`) so the over-cap path is unit-testable without a tmux
+ * server.
+ */
+
+import { cfgLimit } from "../../config";
+import { tmux } from "../../core/transport/tmux";
+import { isAgentCommand } from "../../core/transport/ssh";
+
+/**
+ * Pure cap decision — throws a loud, actionable error when `liveAgents` is at
+ * or over `cap`. A `cap` of `0` or less means "disabled" and is always a
+ * no-op. Kept free of I/O so tests can exercise every branch directly.
+ */
+export function checkCapacity(liveAgents: number, cap: number, spawning: string): void {
+  if (!cap || cap <= 0) return; // cap disabled — opt-in only
+  if (liveAgents >= cap) {
+    throw new Error(
+      `agent concurrency cap reached: ${liveAgents}/${cap} agents already live — ` +
+      `refusing to spawn '${spawning}'. Raise limits.maxConcurrentAgents in maw.config.json ` +
+      `or sleep an idle agent first (maw sleep <agent>).`,
+    );
+  }
+}
+
+/** Count tmux panes currently running an agent process across all sessions. */
+export async function countLiveAgents(): Promise<number> {
+  const panes = await tmux.listPanes();
+  return panes.filter(p => isAgentCommand(p.command)).length;
+}
+
+/**
+ * Guard a spawn against the configured agent concurrency cap (#2). No-op when
+ * `limits.maxConcurrentAgents` is `0` / unset — and in that case we skip the
+ * tmux `list-panes` call entirely so the disabled path stays free.
+ *
+ * @param spawning  the oracle/agent name about to be spawned — surfaced in the
+ *                  error so the operator knows what was refused.
+ */
+export async function assertAgentCapacity(spawning: string): Promise<void> {
+  const cap = cfgLimit("maxConcurrentAgents");
+  if (!cap || cap <= 0) return; // disabled — don't even query tmux
+  checkCapacity(await countLiveAgents(), cap, spawning);
+}

--- a/src/commands/shared/wake-maybe-split.ts
+++ b/src/commands/shared/wake-maybe-split.ts
@@ -43,3 +43,33 @@ export async function maybeSplit(target: string, opts: { split?: boolean }): Pro
     console.log(`      \x1b[90mto silence:       drop --split when running headless\x1b[0m`);
   }
 }
+
+export async function maybeOpenWindow(target: string, opts: { bring?: boolean }): Promise<void> {
+  if (!opts.bring) return;
+  const session = target.split(":")[0] || target;
+  if (process.env.TMUX) {
+    try {
+      const targetWindow = target.split(":").slice(1).join(":") || session;
+      const windowName = `bring-${targetWindow}`.replace(/[^A-Za-z0-9_.-]/g, "-").slice(0, 80) || "bring";
+      const innerCmd = `TMUX= tmux attach-session -t ${shellArg(target)}`;
+      await hostExec(`tmux new-window -n ${shellArg(windowName)} ${shellArg(innerCmd)}`);
+      console.log(`  \x1b[32m✓\x1b[0m opened tab — ${target}`);
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+      console.log(`  \x1b[33m⚠\x1b[0m bring failed: ${message}`);
+    }
+    return;
+  }
+  const serverUp = await probeTmuxServer();
+  if (serverUp) {
+    console.log(`  \x1b[33m⚠\x1b[0m bring skipped — shell is not attached to a tmux pane.`);
+    console.log(`      \x1b[90mstate created:    ${target}\x1b[0m`);
+    console.log(`      \x1b[90mto view:          tmux attach -t ${session}\x1b[0m`);
+    console.log(`      \x1b[90mto silence:       use maw wake instead of maw bring when running headless\x1b[0m`);
+  } else {
+    console.log(`  \x1b[33m⚠\x1b[0m bring skipped — tmux server not running.`);
+    console.log(`      \x1b[90mstate created:    ${target}\x1b[0m`);
+    console.log(`      \x1b[90mto start tmux:    tmux new -s work\x1b[0m`);
+    console.log(`      \x1b[90mto silence:       use maw wake instead of maw bring when running headless\x1b[0m`);
+  }
+}

--- a/src/commands/shared/wake-maybe-split.ts
+++ b/src/commands/shared/wake-maybe-split.ts
@@ -1,5 +1,9 @@
 import { hostExec } from "../../sdk";
 
+function shellArg(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
 /** @internal — exported for tests only. */
 export async function probeTmuxServer(): Promise<boolean> {
   try {
@@ -14,10 +18,14 @@ export async function maybeSplit(target: string, opts: { split?: boolean }): Pro
   if (!opts.split) return;
   if (process.env.TMUX) {
     try {
-      const { cmdSplit } = await import("../plugins/split/impl");
-      await cmdSplit(target);
-    } catch (e: any) {
-      console.log(`  \x1b[33m⚠\x1b[0m split failed: ${e.message || e}`);
+      const anchor = process.env.TMUX_PANE;
+      const targetFlag = anchor ? `-t ${shellArg(anchor)} ` : "";
+      const innerCmd = `TMUX= tmux attach-session -t ${shellArg(target)}`;
+      await hostExec(`tmux split-window ${targetFlag}-h -l 50% ${shellArg(innerCmd)}`);
+      console.log(`  \x1b[32m✓\x1b[0m split beside — ${target} (50%)`);
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+      console.log(`  \x1b[33m⚠\x1b[0m split failed: ${message}`);
     }
     return;
   }

--- a/src/commands/shared/wake-maybe-split.ts
+++ b/src/commands/shared/wake-maybe-split.ts
@@ -52,8 +52,8 @@ export async function maybeOpenWindow(target: string, opts: { bring?: boolean })
       const targetWindow = target.split(":").slice(1).join(":") || session;
       const windowName = `bring-${targetWindow}`.replace(/[^A-Za-z0-9_.-]/g, "-").slice(0, 80) || "bring";
       const innerCmd = `TMUX= tmux attach-session -t ${shellArg(target)}`;
-      await hostExec(`tmux new-window -n ${shellArg(windowName)} ${shellArg(innerCmd)}`);
-      console.log(`  \x1b[32m✓\x1b[0m opened tab — ${target}`);
+      await hostExec(`tmux new-window -d -n ${shellArg(windowName)} ${shellArg(innerCmd)}`);
+      console.log(`  \x1b[32m✓\x1b[0m opened background tab — ${target}`);
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);
       console.log(`  \x1b[33m⚠\x1b[0m bring failed: ${message}`);

--- a/src/commands/shared/wake-maybe-split.ts
+++ b/src/commands/shared/wake-maybe-split.ts
@@ -39,6 +39,44 @@ async function isMawTilePane(anchor?: string): Promise<boolean> {
   }
 }
 
+type PaneGeometry = {
+  id: string;
+  top: number;
+  left: number;
+  isTile: boolean;
+};
+
+function parsePaneGeometry(raw: string): PaneGeometry[] {
+  return raw
+    .split("\n")
+    .map(line => line.trim())
+    .filter(Boolean)
+    .map(line => {
+      const [id, top, left, tile] = line.split("|");
+      return {
+        id: id || "",
+        top: Number.parseInt(top || "", 10),
+        left: Number.parseInt(left || "", 10),
+        isTile: tile === "1",
+      };
+    })
+    .filter(p => p.id && Number.isFinite(p.top) && Number.isFinite(p.left));
+}
+
+/** @internal — exported for tests only. */
+export async function findTopRightPane(anchor?: string): Promise<string | null> {
+  if (!anchor) return null;
+  const targetFlag = `-t ${shellArg(anchor)} `;
+  const raw = await hostExec(`tmux list-panes ${targetFlag}-F '#{pane_id}|#{pane_top}|#{pane_left}|#{@maw_tile}'`);
+  const panes = parsePaneGeometry(String(raw)).filter(p => p.id !== anchor);
+  if (panes.length === 0) return null;
+
+  const tilePanes = panes.filter(p => p.isTile);
+  const candidates = tilePanes.length > 0 ? tilePanes : panes;
+  candidates.sort((a, b) => a.top - b.top || b.left - a.left || a.id.localeCompare(b.id));
+  return candidates[0]?.id ?? null;
+}
+
 export async function maybeSplit(target: string, opts: { split?: boolean }): Promise<void> {
   if (!opts.split) return;
   if (process.env.TMUX) {
@@ -72,16 +110,28 @@ export async function maybeSplit(target: string, opts: { split?: boolean }): Pro
   }
 }
 
-export async function maybeOpenWindow(target: string, opts: { bring?: boolean }): Promise<void> {
+async function openBackgroundTab(target: string): Promise<void> {
+  const session = target.split(":")[0] || target;
+  const targetWindow = target.split(":").slice(1).join(":") || session;
+  const windowName = `bring-${targetWindow}`.replace(/[^A-Za-z0-9_.-]/g, "-").slice(0, 80) || "bring";
+  const innerCmd = `TMUX= tmux attach-session -t ${shellArg(target)}`;
+  await hostExec(`tmux new-window -d -n ${shellArg(windowName)} ${shellArg(innerCmd)}`);
+  console.log(`  \x1b[32m✓\x1b[0m opened background tab — ${target}`);
+}
+
+export async function maybeOpenWindow(target: string, opts: { bring?: boolean; tab?: boolean }): Promise<void> {
   if (!opts.bring) return;
   const session = target.split(":")[0] || target;
   if (process.env.TMUX) {
     try {
-      const targetWindow = target.split(":").slice(1).join(":") || session;
-      const windowName = `bring-${targetWindow}`.replace(/[^A-Za-z0-9_.-]/g, "-").slice(0, 80) || "bring";
       const innerCmd = `TMUX= tmux attach-session -t ${shellArg(target)}`;
-      await hostExec(`tmux new-window -d -n ${shellArg(windowName)} ${shellArg(innerCmd)}`);
-      console.log(`  \x1b[32m✓\x1b[0m opened background tab — ${target}`);
+      const replacementPane = opts.tab ? null : await findTopRightPane(process.env.TMUX_PANE);
+      if (replacementPane) {
+        await hostExec(`tmux respawn-pane -k -t ${shellArg(replacementPane)} ${shellArg(innerCmd)}`);
+        console.log(`  \x1b[32m✓\x1b[0m replaced top-right pane — ${target}`);
+      } else {
+        await openBackgroundTab(target);
+      }
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);
       console.log(`  \x1b[33m⚠\x1b[0m bring failed: ${message}`);

--- a/src/commands/shared/wake-maybe-split.ts
+++ b/src/commands/shared/wake-maybe-split.ts
@@ -14,6 +14,21 @@ export async function probeTmuxServer(): Promise<boolean> {
   }
 }
 
+
+async function restoreSplitLayout(anchor?: string): Promise<void> {
+  try {
+    const windowTarget = anchor || process.env.TMUX_PANE;
+    const targetFlag = windowTarget ? `-t ${shellArg(windowTarget)} ` : "";
+    const raw = await hostExec(`tmux list-panes ${targetFlag}| wc -l`);
+    const total = Number.parseInt(String(raw).trim(), 10);
+    const layout = Number.isFinite(total) && total > 4 ? "tiled" : "main-vertical";
+    await hostExec(`tmux select-layout ${targetFlag}${layout}`);
+  } catch {
+    // Best-effort polish only: split succeeded, so never fail delivery because
+    // the caller's tmux cannot reflow the current window.
+  }
+}
+
 export async function maybeSplit(target: string, opts: { split?: boolean }): Promise<void> {
   if (!opts.split) return;
   if (process.env.TMUX) {
@@ -22,6 +37,7 @@ export async function maybeSplit(target: string, opts: { split?: boolean }): Pro
       const targetFlag = anchor ? `-t ${shellArg(anchor)} ` : "";
       const innerCmd = `TMUX= tmux attach-session -t ${shellArg(target)}`;
       await hostExec(`tmux split-window ${targetFlag}-h -l 50% ${shellArg(innerCmd)}`);
+      await restoreSplitLayout(anchor);
       console.log(`  \x1b[32m✓\x1b[0m split beside — ${target} (50%)`);
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);

--- a/src/commands/shared/wake-maybe-split.ts
+++ b/src/commands/shared/wake-maybe-split.ts
@@ -29,6 +29,16 @@ async function restoreSplitLayout(anchor?: string): Promise<void> {
   }
 }
 
+async function isMawTilePane(anchor?: string): Promise<boolean> {
+  if (!anchor) return false;
+  try {
+    const raw = await hostExec(`tmux show-options -p -t ${shellArg(anchor)} -v @maw_tile 2>/dev/null || true`);
+    return String(raw).trim() === "1";
+  } catch {
+    return false;
+  }
+}
+
 export async function maybeSplit(target: string, opts: { split?: boolean }): Promise<void> {
   if (!opts.split) return;
   if (process.env.TMUX) {
@@ -37,7 +47,9 @@ export async function maybeSplit(target: string, opts: { split?: boolean }): Pro
       const targetFlag = anchor ? `-t ${shellArg(anchor)} ` : "";
       const innerCmd = `TMUX= tmux attach-session -t ${shellArg(target)}`;
       await hostExec(`tmux split-window ${targetFlag}-h -l 50% ${shellArg(innerCmd)}`);
-      await restoreSplitLayout(anchor);
+      if (!(await isMawTilePane(anchor))) {
+        await restoreSplitLayout(anchor);
+      }
       console.log(`  \x1b[32m✓\x1b[0m split beside — ${target} (50%)`);
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);

--- a/src/commands/shared/wake-session.ts
+++ b/src/commands/shared/wake-session.ts
@@ -70,15 +70,39 @@ export async function createWorktree(
   existingWorktrees: { name: string; path: string }[],
 ): Promise<{ wtPath: string; windowName: string }> {
   const nums = existingWorktrees.map(w => parseInt(w.name) || 0);
-  const nextNum = nums.length > 0 ? Math.max(...nums) + 1 : 1;
-  const wtName = `${nextNum}-${name}`;
-  const wtPath = `${parentDir}/${repoName}.wt-${wtName}`;
-  const branch = `agents/${wtName}`;
+  let nextNum = nums.length > 0 ? Math.max(...nums) + 1 : 1;
   const safe = (s: string) => s.replace(/'/g, "'\\''");
   try { await hostExec(`git -C '${safe(repoPath)}' rev-parse HEAD 2>/dev/null`); } catch {
     await hostExec(`git -C '${safe(repoPath)}' commit --allow-empty -m "init: bootstrap for worktree"`);
   }
-  try { await hostExec(`git -C '${safe(repoPath)}' branch -D '${safe(branch)}' 2>/dev/null`); } catch { /* ok */ }
+
+  let wtName = "";
+  let wtPath = "";
+  let branch = "";
+  let allocated = false;
+  for (let attempts = 0; attempts < 1000; attempts++) {
+    wtName = `${nextNum}-${name}`;
+    wtPath = `${parentDir}/${repoName}.wt-${wtName}`;
+    branch = `agents/${wtName}`;
+    const knownWorktree = existingWorktrees.some(w => w.name === wtName || w.path === wtPath);
+    if (knownWorktree) {
+      nextNum++;
+      continue;
+    }
+    try {
+      await hostExec(`git -C '${safe(repoPath)}' show-ref --verify --quiet 'refs/heads/${safe(branch)}'`);
+      nextNum++;
+      continue;
+    } catch {
+      allocated = true;
+      break;
+    }
+  }
+
+  if (!allocated || !wtName || !wtPath || !branch) {
+    throw new Error(`could not allocate worktree for ${name}`);
+  }
+
   await hostExec(`git -C '${safe(repoPath)}' worktree add '${safe(wtPath)}' -b '${safe(branch)}'`);
   console.log(`\x1b[32m+\x1b[0m worktree: ${wtPath} (${branch})`);
   return { wtPath, windowName: `${oracle}-${name}` };

--- a/src/config/command-logic.ts
+++ b/src/config/command-logic.ts
@@ -1,0 +1,67 @@
+import type { MawConfig } from "./types";
+
+function matchGlob(pattern: string, name: string): boolean {
+  if (pattern === name) return true;
+  if (pattern.startsWith("*") && name.endsWith(pattern.slice(1))) return true;
+  if (pattern.endsWith("*") && name.startsWith(pattern.slice(0, -1))) return true;
+  return false;
+}
+
+export function buildCommandFromConfig(
+  config: Partial<MawConfig> & { sessionIds?: Record<string, string> },
+  agentName: string,
+  engine?: string,
+): string {
+  const commands = config.commands || { default: "claude" };
+  let cmd: string;
+
+  if (engine && commands[engine]) {
+    cmd = commands[engine];
+  } else {
+    cmd = commands.default || "claude";
+    for (const [pattern, command] of Object.entries(commands)) {
+      if (pattern === "default") continue;
+      if (matchGlob(pattern, agentName)) { cmd = command; break; }
+    }
+  }
+
+  // Strip --dangerously-skip-permissions when running as root (#181)
+  if (process.getuid?.() === 0) {
+    cmd = cmd.replace(/\s*--dangerously-skip-permissions\b/, "");
+  }
+
+  // Inject --session-id if configured for this agent
+  const sessionIds: Record<string, string> = config.sessionIds || {};
+  const sessionId = sessionIds[agentName]
+    || Object.entries(sessionIds).find(([p]) => p !== "default" && matchGlob(p, agentName))?.[1];
+  if (sessionId) {
+    if (cmd.includes("--continue")) {
+      cmd = cmd.replace(/\s*--continue\b/, ` --resume "${sessionId}"`);
+    } else {
+      cmd += ` --resume "${sessionId}"`;
+    }
+  }
+
+  // Fallback for --continue/--resume: retry without it (fresh worktree / expired session).
+  // Keep --session-id (if set) so the first run creates the session with that ID.
+  if (cmd.includes("--continue") || cmd.includes("--resume")) {
+    let fallback = cmd.replace(/\s*--continue\b/, "").replace(/\s*--resume\s+"[^"]*"/, "");
+    if (sessionId) fallback += ` --session-id "${sessionId}"`;
+    return `${cmd} || ${fallback}`;
+  }
+
+  return cmd;
+}
+
+/**
+ * `cwd` param kept for API compatibility + future use. The command itself is
+ * cwd-independent because tmux newWindow(cwd:) sets the initial pane cwd.
+ */
+export function buildCommandInDirFromConfig(
+  config: Partial<MawConfig> & { sessionIds?: Record<string, string> },
+  agentName: string,
+  _cwd: string,
+  engine?: string,
+): string {
+  return buildCommandFromConfig(config, agentName, engine);
+}

--- a/src/config/command.ts
+++ b/src/config/command.ts
@@ -1,52 +1,10 @@
 import { loadConfig } from "./load";
+import { buildCommandFromConfig, buildCommandInDirFromConfig } from "./command-logic";
 
-function matchGlob(pattern: string, name: string): boolean {
-  if (pattern === name) return true;
-  if (pattern.startsWith("*") && name.endsWith(pattern.slice(1))) return true;
-  if (pattern.endsWith("*") && name.startsWith(pattern.slice(0, -1))) return true;
-  return false;
-}
+export { buildCommandFromConfig, buildCommandInDirFromConfig } from "./command-logic";
 
 export function buildCommand(agentName: string, engine?: string): string {
-  const config = loadConfig();
-  let cmd: string;
-
-  if (engine && config.commands[engine]) {
-    cmd = config.commands[engine];
-  } else {
-    cmd = config.commands.default || "claude";
-    for (const [pattern, command] of Object.entries(config.commands)) {
-      if (pattern === "default") continue;
-      if (matchGlob(pattern, agentName)) { cmd = command; break; }
-    }
-  }
-
-  // Strip --dangerously-skip-permissions when running as root (#181)
-  if (process.getuid?.() === 0) {
-    cmd = cmd.replace(/\s*--dangerously-skip-permissions\b/, "");
-  }
-
-  // Inject --session-id if configured for this agent
-  const sessionIds: Record<string, string> = (config as any).sessionIds || {};
-  const sessionId = sessionIds[agentName]
-    || Object.entries(sessionIds).find(([p]) => p !== "default" && matchGlob(p, agentName))?.[1];
-  if (sessionId) {
-    if (cmd.includes("--continue")) {
-      cmd = cmd.replace(/\s*--continue\b/, ` --resume "${sessionId}"`);
-    } else {
-      cmd += ` --resume "${sessionId}"`;
-    }
-  }
-
-  // Fallback for --continue/--resume: retry without it (fresh worktree / expired session).
-  // Keep --session-id (if set) so the first run creates the session with that ID.
-  if (cmd.includes("--continue") || cmd.includes("--resume")) {
-    let fallback = cmd.replace(/\s*--continue\b/, "").replace(/\s*--resume\s+"[^"]*"/, "");
-    if (sessionId) fallback += ` --session-id "${sessionId}"`;
-    return `${cmd} || ${fallback}`;
-  }
-
-  return cmd;
+  return buildCommandFromConfig(loadConfig(), agentName, engine);
 }
 
 /**
@@ -55,8 +13,8 @@ export function buildCommand(agentName: string, engine?: string): string {
  * already sets the initial pane cwd, and the scrollback noise wasn't worth
  * the reboot-recovery edge case. `cwd` param kept for API compat + future use.
  */
-export function buildCommandInDir(agentName: string, _cwd: string, engine?: string): string {
-  return buildCommand(agentName, engine);
+export function buildCommandInDir(agentName: string, cwd: string, engine?: string): string {
+  return buildCommandInDirFromConfig(loadConfig(), agentName, cwd, engine);
 }
 
 export function getEnvVars(): Record<string, string> {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -47,6 +47,12 @@ export interface MawLimits {
   messageTruncate?: number;
   ptyCols?: number;
   ptyRows?: number;
+  /**
+   * Max concurrent agent panes across the fleet before `maw wake` refuses to
+   * spawn a new one (#2). `0` (the default) disables the cap entirely —
+   * operators opt in by setting a positive number.
+   */
+  maxConcurrentAgents?: number;
 }
 
 export interface MawConfig {
@@ -159,6 +165,6 @@ export interface MawConfig {
 export const D = {
   intervals: { capture: 50, sessions: 5000, status: 3000, teams: 3000, preview: 2000, peerFetch: 10000, crashCheck: 30000 } as const,
   timeouts: { http: 5000, health: 3000, ping: 5000, pty: 5000, workspace: 5000, shellInit: 3000, wakeRetry: 500, wakeVerify: 3000 } as const,
-  limits: { feedMax: 500, feedDefault: 50, feedHistory: 50, logsMax: 500, logsDefault: 50, logsTruncate: 500, messageTruncate: 100, ptyCols: 500, ptyRows: 200 } as const,
+  limits: { feedMax: 500, feedDefault: 50, feedHistory: 50, logsMax: 500, logsDefault: 50, logsTruncate: 500, messageTruncate: 100, ptyCols: 500, ptyRows: 200, maxConcurrentAgents: 0 } as const,
   hmacWindowSeconds: 300,
 } as const;

--- a/src/core/routing.ts
+++ b/src/core/routing.ts
@@ -93,8 +93,9 @@ export function resolveTarget(
     const agentName = query.slice(colonIdx + 1);
     if (!nodeName || !agentName) return { type: "error", reason: "empty_node_or_agent", detail: `invalid format: '${query}'`, hint: "use node:agent format (e.g. mba:homekeeper)" };
 
-    // Self-node check: "white:mawjs" from white → resolve locally
-    if (nodeName === selfNode) {
+    // Self-node check: "white:mawjs" from white, or advertised
+    // "local:mawjs" alias from any configured node → resolve locally.
+    if (nodeName === selfNode || nodeName === "local") {
       const selfTarget = findWindow(writable, agentName);
       if (selfTarget) return { type: "self-node", target: selfTarget };
       // Try fleet config resolution (#281)

--- a/src/core/runtime/build-info.ts
+++ b/src/core/runtime/build-info.ts
@@ -1,0 +1,30 @@
+import { execSync } from "child_process";
+
+let cachedVersionString: string | undefined;
+
+export function getRuntimeVersionString(): string {
+  if (cachedVersionString !== undefined) return cachedVersionString;
+
+  const pkg = require("../../../package.json");
+  let hash = "";
+  try {
+    hash = execSync("git rev-parse --short HEAD", {
+      cwd: import.meta.dir,
+      stdio: "pipe",
+    }).toString().trim();
+  } catch {}
+
+  let buildDate = "";
+  try {
+    const raw = execSync("git log -1 --format=%ci", {
+      cwd: import.meta.dir,
+      stdio: "pipe",
+    }).toString().trim();
+    const d = new Date(raw);
+    const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+    buildDate = `${raw.slice(0, 10)} ${days[d.getDay()]} ${raw.slice(11, 16)}`;
+  } catch {}
+
+  cachedVersionString = `maw v${pkg.version}${hash ? ` (${hash})` : ""}${buildDate ? ` built ${buildDate}` : ""}`;
+  return cachedVersionString;
+}

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -164,8 +164,24 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
     },
   };
 
+  const corsHeaders = (req: Request) => {
+    const origin = req.headers.get("origin") ?? "*";
+    return {
+      "Access-Control-Allow-Origin": origin,
+      "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Federation-Token, X-From-Signature",
+      "Access-Control-Allow-Private-Network": "true",
+    };
+  };
+
   const fetchHandler = (req: Request, server: any) => {
     const url = new URL(req.url);
+
+    // CORS preflight for all routes
+    if (req.method === "OPTIONS") {
+      return new Response(null, { status: 204, headers: corsHeaders(req) });
+    }
+
     if (url.pathname === "/ws/pty") {
       if (server.upgrade(req, { data: { target: null, previewTargets: new Set(), mode: "pty" } as WSData })) return;
       return new Response("WebSocket upgrade failed", { status: 400 });
@@ -174,12 +190,22 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
       if (server.upgrade(req, { data: { target: null, previewTargets: new Set() } as WSData })) return;
       return new Response("WebSocket upgrade failed", { status: 400 });
     }
-    // Elysia handles all /api/* routes
+    // Elysia handles all /api/* routes (has its own CORS)
     if (url.pathname.startsWith("/api")) {
       return api.handle(req);
     }
-    // Hono handles views + static
-    return views.fetch(req, { server });
+    // Hono handles views + static — clone response with CORS headers
+    const addCors = (r: Response) => {
+      const h = corsHeaders(req);
+      return new Response(r.body, {
+        status: r.status,
+        statusText: r.statusText,
+        headers: { ...Object.fromEntries(r.headers.entries()), ...h },
+      });
+    };
+    const res = views.fetch(req, { server });
+    if (res instanceof Promise) return res.then(addCors);
+    return addCors(res as Response);
   };
 
   // HTTP server (always)

--- a/src/core/transport/ssh.ts
+++ b/src/core/transport/ssh.ts
@@ -81,18 +81,30 @@ export async function getPaneCommand(target: string, host?: string): Promise<str
 
 /** Pane command looks like an AI agent — name match (claude/codex/node),
  *  Claude Code 2.1+ versioned-binary signature (e.g. "2.1.121"), or any
- *  binary from config.commands entries. */
+ *  binary from config.commands entries.
+ *
+ *  #10: `cmd` is a tmux `#{pane_current_command}` — a bare command basename,
+ *  not a command line. `claude` / `codex` are distinctive enough that a
+ *  substring match is safe (no benign command contains them), but `node` is
+ *  a substring of `nodemon`, the `node` REPL, `node-red`, and any number of
+ *  non-agent tools. So `node` (and configured binaries) are matched as the
+ *  WHOLE command name — not loose substrings — so non-agent node processes
+ *  don't pass. */
 export function isAgentCommand(cmd: string | null | undefined): boolean {
   const c = (cmd ?? "").trim();
   if (!c) return false;
-  if (/claude|codex|node/i.test(c)) return true;
+  if (/claude|codex/i.test(c)) return true;
+  if (/^node$/i.test(c)) return true;
   if (/^\d+\.\d+\.\d+$/.test(c)) return true;
   try {
     const { loadConfig } = require("../../config");
     const commands: Record<string, string> = loadConfig().commands || {};
+    const lc = c.toLowerCase();
     for (const v of Object.values(commands)) {
       const bin = v.split(/\s/)[0];
-      if (bin && bin !== "default" && c.toLowerCase().includes(bin.toLowerCase())) return true;
+      // Exact name match, not substring — a configured `node`-launched agent
+      // must not make every `nodemon`/`node-*` pane look like an agent.
+      if (bin && bin !== "default" && lc === bin.toLowerCase()) return true;
     }
   } catch {}
   return false;

--- a/src/core/transport/tmux-class.ts
+++ b/src/core/transport/tmux-class.ts
@@ -8,6 +8,22 @@ import {
   type TmuxWindow,
 } from "./tmux-types";
 
+// --- sendText submit-confirmation tuning (#6) ---
+// The old sendText fired 3 blind `Enter` keys on a fixed ~1.9s schedule with
+// zero feedback. If the pane wasn't ready when they landed (agent still
+// rendering the paste, brief stall), every Enter missed and the command sat
+// in the input box unexecuted — this forced manual re-launch of dispatches
+// on 2026-05-14. We now send Enter, re-check the pane, and retry only while
+// input is still pending.
+/** Wait after paste/literal-send before the first Enter — lets the input settle. */
+const SEND_SETTLE_MS = 1500;
+/** Wait after each Enter before re-checking whether the input line cleared. */
+const SUBMIT_CONFIRM_MS = 700;
+/** Max Enter attempts before giving up and warning (was 3 blind, unconditional sends). */
+const MAX_SUBMIT_ATTEMPTS = 4;
+/** ANSI escape stripper — matches checkPaneIdle in comm-send.ts (#405). */
+const ANSI_RE = /\x1b\[[0-9;]*[mGKHFJA-Z]/g;
+
 /**
  * Typed wrapper around tmux CLI.
  * All methods build arg arrays and delegate to `run()`.
@@ -260,31 +276,65 @@ export class Tmux {
 
   /**
    * Smart text sending — uses load-buffer for multiline/long messages,
-   * send-keys for short single-line. Always appends Enter.
+   * send-keys for short single-line. Always submits with Enter.
    * Ported from old bash maw hey (Dec 2025).
+   *
+   * #6 — submit is now confirmed, not fire-and-forget. After placing the
+   * text we send Enter, re-inspect the pane, and retry the Enter only while
+   * the input line still holds un-submitted content (up to
+   * MAX_SUBMIT_ATTEMPTS). This closes the trailing-Enter race where blind
+   * staggered Enter keys landed before the pane was ready and the command
+   * was silently left unexecuted.
    */
   async sendText(target: string, text: string): Promise<void> {
     if (text.includes("\n") || text.length > 500) {
       // Buffer method — reliable for multiline/long content
       await this.loadBuffer(text);
       await this.pasteBuffer(target);
-      await new Promise(r => setTimeout(r, 1500));
-      // Staggered Enter — submit + 2 fallbacks
-      await this.sendKeys(target, "Enter");
-      await new Promise(r => setTimeout(r, 700));
-      await this.sendKeys(target, "Enter");
-      await new Promise(r => setTimeout(r, 1200));
-      await this.sendKeys(target, "Enter");
     } else {
       // Literal send — -l prevents tmux from interpreting special chars like |
       await this.sendKeysLiteral(target, text);
-      await new Promise(r => setTimeout(r, 1500));
-      // Staggered Enter — submit + 2 fallbacks
+    }
+    await new Promise(r => setTimeout(r, SEND_SETTLE_MS));
+    await this.submitWithConfirm(target);
+  }
+
+  /**
+   * Send Enter, then confirm the input line cleared before returning. Retries
+   * the Enter while input is still pending — see sendText for the #6 race.
+   * @internal — exported behavior is exercised via sendText in tests.
+   */
+  private async submitWithConfirm(target: string): Promise<void> {
+    for (let attempt = 1; attempt <= MAX_SUBMIT_ATTEMPTS; attempt++) {
       await this.sendKeys(target, "Enter");
-      await new Promise(r => setTimeout(r, 700));
-      await this.sendKeys(target, "Enter");
-      await new Promise(r => setTimeout(r, 1200));
-      await this.sendKeys(target, "Enter");
+      await new Promise(r => setTimeout(r, SUBMIT_CONFIRM_MS));
+      if (!(await this.paneInputPending(target))) return; // submitted — done
+    }
+    // Exhausted every retry and the input line still looks non-empty. The
+    // caller has no visibility into tmux pane state, so warn loudly — a
+    // silently-dropped dispatch is the exact failure mode #6 is about.
+    console.warn(
+      `[tmux] sendText: ${target} still shows pending input after ${MAX_SUBMIT_ATTEMPTS} Enter attempts — command may not have submitted`,
+    );
+  }
+
+  /**
+   * True when the pane's prompt line still holds un-submitted input.
+   * Mirrors checkPaneIdle (comm-send.ts #405) but inlined here to avoid a
+   * circular import — comm-send.ts already imports Tmux. A read failure
+   * returns false (assume submitted) so a flaky capture can't spin the retry
+   * loop.
+   */
+  private async paneInputPending(target: string): Promise<boolean> {
+    try {
+      const content = await this.capture(target, 5);
+      const lines = content.split("\n").filter(l => l.trim());
+      const last = (lines.at(-1) ?? "").replace(ANSI_RE, "").replace(/\r/g, "");
+      // Prompt marker followed by non-whitespace → user/command text still
+      // sitting on the input line, i.e. Enter has not submitted it yet.
+      return /[#$%>❯»]\s+\S/.test(last);
+    } catch {
+      return false;
     }
   }
 

--- a/src/core/transport/transport.ts
+++ b/src/core/transport/transport.ts
@@ -56,7 +56,7 @@ export interface TransportMessage {
   to: string;            // recipient oracle name
   body: string;          // the actual message text
   timestamp: number;     // epoch ms
-  transport: "tmux" | "mqtt" | "http" | "hub";  // which channel carried it
+  transport: "tmux" | "mqtt" | "http" | "hub" | "scout";  // which channel carried it
 }
 
 /** Presence info broadcast by each host */

--- a/src/engine/engine-intervals.ts
+++ b/src/engine/engine-intervals.ts
@@ -92,9 +92,10 @@ export function startIntervals(
   state.feedUnsub = () => state.feedListeners.delete(listener);
 }
 
-/** Stop all polling intervals when last WS client disconnects. No-op if clients remain. */
+/** Stop all polling intervals when last WS client disconnects. No-op if clients remain or triggers are configured. */
 export function stopIntervals(state: EngineIntervalState): void {
   if (state.clients.size > 0) return;
+  if (loadConfig().triggers?.length > 0) return;
   if (state.captureInterval) { clearInterval(state.captureInterval); state.captureInterval = null; }
   if (state.sessionInterval) { clearInterval(state.sessionInterval); state.sessionInterval = null; }
   if (state.previewInterval) { clearInterval(state.previewInterval); state.previewInterval = null; }

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -52,6 +52,8 @@ export class MawEngine {
     } catch {
       console.warn("[engine] session cache init failed — will retry on first WS connect");
     }
+    // Start intervals headlessly so triggers fire without a browser connected (#headless-triggers)
+    this.startIntervals();
   }
 
   on(type: string, handler: Handler) { this.handlers.set(type, handler); }

--- a/src/engine/status.ts
+++ b/src/engine/status.ts
@@ -64,7 +64,7 @@ export class StatusDetector {
     clients: Set<MawWS>,
     feedListeners: Set<(event: FeedEvent) => void>,
   ) {
-    if (clients.size === 0 || sessions.length === 0) return;
+    if (sessions.length === 0) return;
 
     const agents = sessions.flatMap(s =>
       s.windows.map(w => ({ target: `${s.name}:${w.index}`, name: w.name, session: s.name }))

--- a/src/lib/elysia-auth.ts
+++ b/src/lib/elysia-auth.ts
@@ -161,7 +161,13 @@ export const fromSigningAuth = new Elysia({ name: "from-signing-auth" })
       console.warn(`[from-auth] accepted signed request from unknown peer ${decision.from} (no cached pubkey to verify against — alpha behavior; will harden at v27)`);
     }
     // accept-verified is the steady-state happy path; no log spam.
-  });
+  })
+  // SECURITY (#1): `.as('global')` propagates this onBeforeHandle to every
+  // sibling route module mounted alongside this plugin in src/api/index.ts.
+  // Without it, a named Elysia plugin's lifecycle hook is `local`-scoped — it
+  // guards only routes defined on THIS instance (which defines zero), so the
+  // hook would run for nothing and every protected route would be unguarded.
+  .as("global");
 
 /** Federation auth — Elysia plugin with onBeforeHandle HMAC verification */
 export const federationAuth = new Elysia({ name: "federation-auth" })
@@ -169,8 +175,13 @@ export const federationAuth = new Elysia({ name: "federation-auth" })
     const config = loadConfig();
     const token = config.federationToken;
 
-    // No token configured → auth disabled (backwards compat)
-    if (!token) return;
+    // Peers-require-token invariant (#3) — mirrors the Hono federation-auth.ts.
+    // A node with peers configured binds 0.0.0.0 (see core/server.ts) and is
+    // network-reachable, so "no token" in that posture is default-insecure-open,
+    // NOT single-node mode. We must reach the fail-closed check below before
+    // returning on `!token`, so the token short-circuit no longer happens here.
+    const hasPeers = (config.peers?.length ?? 0) > 0 || (config.namedPeers?.length ?? 0) > 0;
+    const allowPeersWithoutToken = config.allowPeersWithoutToken === true;
 
     const url = new URL(request.url);
     // Strip /api prefix to match against PROTECTED set
@@ -195,6 +206,22 @@ export const federationAuth = new Elysia({ name: "federation-auth" })
     const clientIp = _bunServer?.requestIP?.(request)?.address;
 
     if (isLoopback(clientIp)) return;
+
+    // Fail-closed (#3): peers configured but no federationToken → the node is
+    // network-reachable with auth fully off. Refuse protected writes from
+    // non-loopback callers unless the operator explicitly opted into the
+    // legacy posture with `allowPeersWithoutToken: true`. Restores the
+    // invariant the Hono federation-auth.ts has always enforced.
+    if (!token && hasPeers && !allowPeersWithoutToken) {
+      console.warn(`[auth] rejected ${request.method} ${url.pathname} from ${clientIp ?? "?"}: federation_token_required (peers configured, no federationToken)`);
+      set.status = 401;
+      return { error: "federation auth required", reason: "federation_token_required" };
+    }
+
+    // No token configured AND no peers → local-only single-node mode.
+    // The server binds to 127.0.0.1 in this posture; preserve legacy
+    // pass-through so fresh single-node installs work unchanged.
+    if (!token) return;
 
     // #804 Step 4: when the request carries `x-maw-from`, the from-signing
     // layer owns the `x-maw-signature` slot and is verified by
@@ -229,4 +256,11 @@ export const federationAuth = new Elysia({ name: "federation-auth" })
     }
 
     // Auth passed — continue to handler
-  });
+  })
+  // SECURITY (#1): `.as('global')` propagates this onBeforeHandle to every
+  // sibling route module mounted alongside this plugin in src/api/index.ts
+  // (.use(sessionsApi), .use(feedApi), .use(transportApi), …). Without it the
+  // hook is `local`-scoped to this instance — which defines zero routes — so
+  // it guards NOTHING and every protected write endpoint accepts unsigned
+  // non-loopback requests. Empirically confirmed in maw-stress revalidation.
+  .as("global");

--- a/src/lib/oracle-manifest.ts
+++ b/src/lib/oracle-manifest.ts
@@ -145,7 +145,7 @@ export function readFleetWindows(dir: string = FLEET_DIR): FleetSessionLite[] {
   try {
     files = readdirSync(dir).filter(
       (f) => f.endsWith(".json") && !f.endsWith(".disabled"),
-    );
+    ).sort();
   } catch {
     return [];
   }

--- a/src/plugin/manifest-constants.ts
+++ b/src/plugin/manifest-constants.ts
@@ -18,7 +18,12 @@
  * load-time path appeared to lag the install-time path — in fact both
  * paths now share this constant via parseCapabilities(). The
  * test/isolated/plugin-load-capability-902.test.ts regression suite locks
- * the load-path against this set so any future drift fails CI. */
+ * the load-path against this set so any future drift fails CI.
+ *
+ * #1418 — add `attach` to mainline too. Alpha already accepted
+ * attach:strategy via #1291, but main diverged and released alphas from main
+ * regressed to warning on every CLI load when mpr's attach-ssh plugin is
+ * installed. */
 export const KNOWN_CAPABILITY_NAMESPACES = new Set([
   "net",    // network (fetch, sockets)
   "fs",     // filesystem
@@ -28,6 +33,7 @@ export const KNOWN_CAPABILITY_NAMESPACES = new Set([
   "ffi",    // native FFI (bun:ffi)
   "tmux",   // tmux socket interaction (spawnSync("tmux", …) + SDK tmux helpers)
   "shell",  // shell-eval / stdout-writing plugins (shellenv-style)
+  "attach", // attach strategies (mpr attach-ssh declares attach:strategy)
 ]);
 
 /**

--- a/src/plugin/manifest-validate.ts
+++ b/src/plugin/manifest-validate.ts
@@ -5,6 +5,7 @@
 
 import type { PluginManifest, PluginTier } from "./types";
 import { KNOWN_CAPABILITY_NAMESPACES } from "./manifest-constants";
+import { getRuntimeVersionString } from "../core/runtime/build-info";
 
 const VALID_TIERS = new Set<PluginTier>(["core", "standard", "extra"]);
 
@@ -169,7 +170,9 @@ export function parseCapabilities(r: Record<string, unknown>): PluginManifest["c
     if (!KNOWN_CAPABILITY_NAMESPACES.has(ns)) {
       console.warn(
         `plugin.json: unknown capability namespace "${ns}" in "${cap}" ` +
-          `(known: ${[...KNOWN_CAPABILITY_NAMESPACES].join(", ")})`,
+          `(known: ${[...KNOWN_CAPABILITY_NAMESPACES].join(", ")})\n` +
+          `  ↳ runtime: ${getRuntimeVersionString()} — if this namespace is expected, update maw: ` +
+          `bun add -g github:Soul-Brews-Studio/maw-js#alpha`,
       );
     }
   }

--- a/src/plugin/registry-invoke.ts
+++ b/src/plugin/registry-invoke.ts
@@ -4,7 +4,8 @@
  * WASM plugins with a hard 5-second timeout.
  */
 
-import { readFileSync } from "fs";
+import { readFileSync, realpathSync } from "fs";
+import { pathToFileURL } from "url";
 import {
   buildImportObject,
   preCacheBridge,
@@ -93,7 +94,10 @@ export async function invokePlugin(
   // honest behavior for Phase A (no sandbox).
   if (plugin.kind === "ts" && plugin.entryPath) {
     try {
-      const mod = await import(plugin.entryPath);
+      // Bun canary on macOS can lose later dynamic imports that pass through
+      // the /var → /private/var symlink. Canonicalize to a file URL so
+      // temporary TS plugin modules load deterministically across runners.
+      const mod = await import(pathToFileURL(realpathSync(plugin.entryPath)).href);
       const handler = mod.default || mod.handler;
       if (!handler) return { ok: false, error: "TS plugin has no default export or handler" };
 

--- a/src/transports/index.ts
+++ b/src/transports/index.ts
@@ -10,6 +10,7 @@ import { HubTransport, loadWorkspaceConfigs } from "./hub";
 import { LoRaTransport } from "./lora";
 import { NanoclawTransport } from "./nanoclaw";
 import { MdnsTransport } from "./mdns";
+import { ScoutTransport } from "./scout";
 // ZenohTransport loaded dynamically — zenoh-ts bundles WASM that conflicts with single-file build
 
 /** Singleton router instance */
@@ -33,15 +34,17 @@ export function createTransportRouter(): TransportRouter {
     router.register(new HubTransport(config.node));
   }
 
-  // 2.5. mDNS P2P — auto-discovery + direct messaging (no config needed)
+  // 2.5. Scout P2P — zenoh-inspired zero-config LAN discovery + auto-pairing
   const oracles = Object.keys(config.agents || {}).filter(k => k.endsWith("-oracle"));
-  const mdns = new MdnsTransport({
+  const scout = new ScoutTransport({
     node: config.node ?? "local",
+    oracle: config.oracle ?? "mawjs",
     port: config.port ?? 3456,
     oracles,
+    autoPair: true,
   });
-  mdns.connect().catch(() => {});
-  router.register(mdns);
+  scout.connect().catch(() => {});
+  router.register(scout);
 
   // 2.6. Zenoh transport — pub/sub + auto-discovery (dynamic import — WASM)
   if (config.zenoh?.locator) {
@@ -93,4 +96,5 @@ export { HttpTransport } from "./http";
 export { NanoclawTransport } from "./nanoclaw";
 export { LoRaTransport } from "./lora";
 export { MdnsTransport } from "./mdns";
+export { ScoutTransport } from "./scout";
 // ZenohTransport exported via dynamic import only (WASM dependency)

--- a/src/transports/scout-integration.test.ts
+++ b/src/transports/scout-integration.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { createSocket } from "dgram";
+import {
+  MULTICAST_ADDR,
+  MULTICAST_PORT,
+  makeScout,
+  makeHello,
+  generateZid,
+  parseMessage,
+} from "./scout-protocol";
+
+describe("scout integration — real UDP", () => {
+  const sockets: ReturnType<typeof createSocket>[] = [];
+
+  afterEach(() => {
+    for (const s of sockets) {
+      try { s.dropMembership(MULTICAST_ADDR); } catch {}
+      s.close();
+    }
+    sockets.length = 0;
+  });
+
+  it("scout message round-trips through multicast", async () => {
+    const zid = generateZid();
+    const received: any[] = [];
+
+    const listener = createSocket({ type: "udp4", reuseAddr: true });
+    sockets.push(listener);
+
+    await new Promise<void>((resolve, reject) => {
+      listener.bind(MULTICAST_PORT, () => {
+        try {
+          listener.addMembership(MULTICAST_ADDR);
+          resolve();
+        } catch (e) { reject(e); }
+      });
+      listener.on("error", reject);
+    });
+
+    listener.on("message", (buf) => {
+      const msg = parseMessage(buf);
+      if (msg && msg.type === "maw-scout") received.push(msg);
+    });
+
+    const sender = createSocket({ type: "udp4", reuseAddr: true });
+    sockets.push(sender);
+    const scout = makeScout(zid);
+    const buf = Buffer.from(JSON.stringify(scout));
+    sender.send(buf, MULTICAST_PORT, MULTICAST_ADDR);
+
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(received.length).toBeGreaterThanOrEqual(1);
+    expect(received[0].type).toBe("maw-scout");
+    expect(received[0].zid).toBe(zid);
+  });
+
+  it("hello unicast reply reaches scout sender", async () => {
+    const scoutZid = generateZid();
+    const helloZid = generateZid();
+    const received: any[] = [];
+
+    // Responder: listens on multicast, replies with Hello via unicast
+    const responder = createSocket({ type: "udp4", reuseAddr: true });
+    sockets.push(responder);
+
+    await new Promise<void>((resolve, reject) => {
+      responder.bind(MULTICAST_PORT, () => {
+        try {
+          responder.addMembership(MULTICAST_ADDR);
+          resolve();
+        } catch (e) { reject(e); }
+      });
+      responder.on("error", reject);
+    });
+
+    responder.on("message", (buf, rinfo) => {
+      const msg = parseMessage(buf);
+      if (msg && msg.type === "maw-scout" && msg.zid !== helloZid) {
+        const hello = makeHello({
+          zid: helloZid,
+          node: "responder",
+          oracle: "test",
+          locators: ["http://responder:3456"],
+          oracles: ["test-oracle"],
+        });
+        responder.send(
+          Buffer.from(JSON.stringify(hello)),
+          rinfo.port,
+          rinfo.address,
+        );
+      }
+    });
+
+    // Sender: sends scout, collects hello responses
+    const sender = createSocket({ type: "udp4", reuseAddr: true });
+    sockets.push(sender);
+
+    await new Promise<void>((resolve) => sender.bind(0, resolve));
+
+    sender.on("message", (buf) => {
+      const msg = parseMessage(buf);
+      if (msg && msg.type === "maw-hello") received.push(msg);
+    });
+
+    const scout = makeScout(scoutZid);
+    sender.send(Buffer.from(JSON.stringify(scout)), MULTICAST_PORT, MULTICAST_ADDR);
+
+    await new Promise((r) => setTimeout(r, 500));
+
+    expect(received.length).toBeGreaterThanOrEqual(1);
+    const hello = received[0];
+    expect(hello.type).toBe("maw-hello");
+    expect(hello.zid).toBe(helloZid);
+    expect(hello.node).toBe("responder");
+    expect(hello.locators).toEqual(["http://responder:3456"]);
+  });
+
+  it("legacy maw-announce is parseable alongside scout messages", () => {
+    const announce = { type: "maw-announce", node: "legacy-node", port: 3456, oracles: ["old-oracle"], ts: Date.now() };
+    const scout = makeScout(generateZid());
+    const hello = makeHello({ zid: generateZid(), node: "n", oracle: "o", locators: ["http://x:3456"] });
+
+    const msgs = [announce, scout, hello].map((m) =>
+      parseMessage(Buffer.from(JSON.stringify(m)))
+    );
+
+    expect(msgs[0]!.type).toBe("maw-announce");
+    expect(msgs[1]!.type).toBe("maw-scout");
+    expect(msgs[2]!.type).toBe("maw-hello");
+  });
+
+  it("GreaterZid ensures exactly one initiator in simulated 2-node handshake", () => {
+    const zidA = generateZid();
+    const zidB = generateZid();
+
+    // Simulate both sides receiving each other's Hello
+    const { ScoutState } = require("./scout-state");
+    const stateA = new ScoutState(zidA);
+    const stateB = new ScoutState(zidB);
+
+    const helloA = makeHello({ zid: zidA, node: "nodeA", oracle: "a", locators: ["http://a:3456"], capabilities: ["pair"] });
+    const helloB = makeHello({ zid: zidB, node: "nodeB", oracle: "b", locators: ["http://b:3456"], capabilities: ["pair"] });
+
+    const resultA = stateA.handleHello(helloB, "10.0.0.2");
+    const resultB = stateB.handleHello(helloA, "10.0.0.1");
+
+    // Exactly one should pair
+    const pairCount = [resultA.shouldPair, resultB.shouldPair].filter(Boolean).length;
+    expect(pairCount).toBe(1);
+
+    // The one with greater ZID is the initiator
+    if (zidA > zidB) {
+      expect(resultA.shouldPair).toBe(true);
+      expect(resultB.shouldPair).toBe(false);
+    } else {
+      expect(resultA.shouldPair).toBe(false);
+      expect(resultB.shouldPair).toBe(true);
+    }
+  });
+});

--- a/src/transports/scout-pair.ts
+++ b/src/transports/scout-pair.ts
@@ -1,0 +1,70 @@
+/**
+ * Scout auto-pairing — HTTP handshake after Scout/Hello discovery.
+ *
+ * After GreaterZid selects the initiator, it POSTs to the peer's
+ * /api/pair/auto endpoint. Both sides persist via cmdAdd().
+ */
+
+import { cmdAdd } from "../lib/peers/impl";
+import type { DiscoveredPeer } from "./scout-state";
+
+export interface AutoPairRequest {
+  node: string;
+  oracle: string;
+  url: string;
+  zid: string;
+  capabilities: string[];
+}
+
+export interface AutoPairResponse {
+  ok: boolean;
+  node?: string;
+  oracle?: string;
+  url?: string;
+  error?: string;
+}
+
+export async function initiatePair(
+  peer: DiscoveredPeer,
+  localNode: string,
+  localOracle: string,
+  localPort: number,
+): Promise<{ ok: boolean; error?: string }> {
+  const locator = peer.locators[0];
+  if (!locator) return { ok: false, error: "no_locator" };
+
+  const body: AutoPairRequest = {
+    node: localNode,
+    oracle: localOracle,
+    url: `http://${localNode}:${localPort}`,
+    zid: peer.zid,
+    capabilities: ["pair", "feed", "send"],
+  };
+
+  try {
+    const res = await fetch(`${locator}/api/pair/auto`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(5000),
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      return { ok: false, error: `http_${res.status}: ${text}` };
+    }
+
+    const data = (await res.json()) as AutoPairResponse;
+    if (!data.ok) return { ok: false, error: data.error ?? "rejected" };
+
+    await cmdAdd({
+      alias: peer.node,
+      url: locator,
+      node: peer.node,
+    });
+
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/src/transports/scout-protocol.test.ts
+++ b/src/transports/scout-protocol.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "bun:test";
+import {
+  generateZid,
+  greaterZid,
+  makeScout,
+  makeHello,
+  parseMessage,
+  SCOUT_VERSION,
+  MULTICAST_ADDR,
+  MULTICAST_PORT,
+} from "./scout-protocol";
+
+describe("scout-protocol", () => {
+  describe("generateZid", () => {
+    it("returns 32-char hex string (16 bytes)", () => {
+      const zid = generateZid();
+      expect(zid).toHaveLength(32);
+      expect(zid).toMatch(/^[0-9a-f]{32}$/);
+    });
+
+    it("generates unique IDs", () => {
+      const ids = new Set(Array.from({ length: 100 }, () => generateZid()));
+      expect(ids.size).toBe(100);
+    });
+  });
+
+  describe("greaterZid", () => {
+    it("returns true when a > b", () => {
+      expect(greaterZid("ff", "00")).toBe(true);
+      expect(greaterZid("b", "a")).toBe(true);
+    });
+
+    it("returns false when a < b", () => {
+      expect(greaterZid("00", "ff")).toBe(false);
+      expect(greaterZid("a", "b")).toBe(false);
+    });
+
+    it("returns false when equal", () => {
+      expect(greaterZid("abc", "abc")).toBe(false);
+    });
+
+    it("exactly one side initiates for any pair", () => {
+      const a = generateZid();
+      const b = generateZid();
+      // exactly one of these is true (unless equal, which is astronomically unlikely)
+      const aInitiates = greaterZid(a, b);
+      const bInitiates = greaterZid(b, a);
+      expect(aInitiates !== bInitiates).toBe(true);
+    });
+  });
+
+  describe("makeScout", () => {
+    it("creates valid scout message", () => {
+      const zid = generateZid();
+      const msg = makeScout(zid);
+      expect(msg.type).toBe("maw-scout");
+      expect(msg.version).toBe(SCOUT_VERSION);
+      expect(msg.zid).toBe(zid);
+      expect(msg.whatAmI).toBe("oracle");
+      expect(msg.ts).toBeGreaterThan(0);
+    });
+
+    it("accepts custom whatAmI", () => {
+      const msg = makeScout(generateZid(), "hub");
+      expect(msg.whatAmI).toBe("hub");
+    });
+  });
+
+  describe("makeHello", () => {
+    it("creates valid hello message", () => {
+      const zid = generateZid();
+      const msg = makeHello({
+        zid,
+        node: "white",
+        oracle: "neo",
+        locators: ["http://192.168.1.10:3456"],
+        oracles: ["neo-oracle", "mawjs-oracle"],
+      });
+      expect(msg.type).toBe("maw-hello");
+      expect(msg.version).toBe(SCOUT_VERSION);
+      expect(msg.zid).toBe(zid);
+      expect(msg.node).toBe("white");
+      expect(msg.oracle).toBe("neo");
+      expect(msg.locators).toEqual(["http://192.168.1.10:3456"]);
+      expect(msg.capabilities).toEqual(["pair", "feed", "send"]);
+      expect(msg.oracles).toEqual(["neo-oracle", "mawjs-oracle"]);
+    });
+
+    it("uses defaults for optional fields", () => {
+      const msg = makeHello({
+        zid: generateZid(),
+        node: "mba",
+        oracle: "mawjs",
+        locators: ["http://mba:3456"],
+      });
+      expect(msg.capabilities).toEqual(["pair", "feed", "send"]);
+      expect(msg.oracles).toEqual([]);
+      expect(msg.whatAmI).toBe("oracle");
+    });
+  });
+
+  describe("parseMessage", () => {
+    it("parses scout message", () => {
+      const scout = makeScout(generateZid());
+      const buf = Buffer.from(JSON.stringify(scout));
+      const parsed = parseMessage(buf);
+      expect(parsed).not.toBeNull();
+      expect(parsed!.type).toBe("maw-scout");
+    });
+
+    it("parses hello message", () => {
+      const hello = makeHello({
+        zid: generateZid(),
+        node: "test",
+        oracle: "test",
+        locators: ["http://test:3456"],
+      });
+      const buf = Buffer.from(JSON.stringify(hello));
+      const parsed = parseMessage(buf);
+      expect(parsed).not.toBeNull();
+      expect(parsed!.type).toBe("maw-hello");
+    });
+
+    it("parses legacy announce message", () => {
+      const announce = { type: "maw-announce", node: "old", port: 3456, oracles: [], ts: Date.now() };
+      const buf = Buffer.from(JSON.stringify(announce));
+      const parsed = parseMessage(buf);
+      expect(parsed).not.toBeNull();
+      expect(parsed!.type).toBe("maw-announce");
+    });
+
+    it("returns null for unknown message types", () => {
+      const buf = Buffer.from(JSON.stringify({ type: "unknown" }));
+      expect(parseMessage(buf)).toBeNull();
+    });
+
+    it("returns null for invalid JSON", () => {
+      expect(parseMessage(Buffer.from("not json"))).toBeNull();
+    });
+
+    it("returns null for empty buffer", () => {
+      expect(parseMessage(Buffer.from(""))).toBeNull();
+    });
+  });
+
+  describe("constants", () => {
+    it("multicast address matches zenoh default", () => {
+      expect(MULTICAST_ADDR).toBe("224.0.0.224");
+    });
+
+    it("port is 31746", () => {
+      expect(MULTICAST_PORT).toBe(31746);
+    });
+  });
+});

--- a/src/transports/scout-protocol.ts
+++ b/src/transports/scout-protocol.ts
@@ -1,0 +1,94 @@
+/**
+ * Scout/Hello discovery protocol — message types and utilities.
+ *
+ * Inspired by Eclipse Zenoh's scouting protocol:
+ *   Scout (multicast) → Hello (unicast) → Pair (HTTP)
+ *
+ * JSON over UDP for simplicity. Same multicast group as mdns transport.
+ */
+
+import { randomBytes } from "crypto";
+
+export const SCOUT_VERSION = 1;
+export const MULTICAST_ADDR = "224.0.0.224";
+export const MULTICAST_PORT = 31746;
+
+export type WhatAmI = "oracle" | "hub" | "bridge";
+
+export interface ScoutMessage {
+  type: "maw-scout";
+  version: number;
+  zid: string;
+  whatAmI: WhatAmI;
+  ts: number;
+}
+
+export interface HelloMessage {
+  type: "maw-hello";
+  version: number;
+  zid: string;
+  whatAmI: WhatAmI;
+  node: string;
+  oracle: string;
+  locators: string[];
+  capabilities: string[];
+  oracles: string[];
+  ts: number;
+}
+
+export interface AnnounceMessage {
+  type: "maw-announce";
+  node: string;
+  port: number;
+  oracles: string[];
+  ts: number;
+}
+
+export type ScoutProtocolMessage = ScoutMessage | HelloMessage | AnnounceMessage;
+
+export function generateZid(): string {
+  return randomBytes(16).toString("hex");
+}
+
+export function greaterZid(a: string, b: string): boolean {
+  return a > b;
+}
+
+export function makeScout(zid: string, whatAmI: WhatAmI = "oracle"): ScoutMessage {
+  return { type: "maw-scout", version: SCOUT_VERSION, zid, whatAmI, ts: Date.now() };
+}
+
+export function makeHello(opts: {
+  zid: string;
+  node: string;
+  oracle: string;
+  locators: string[];
+  capabilities?: string[];
+  oracles?: string[];
+  whatAmI?: WhatAmI;
+}): HelloMessage {
+  return {
+    type: "maw-hello",
+    version: SCOUT_VERSION,
+    zid: opts.zid,
+    whatAmI: opts.whatAmI ?? "oracle",
+    node: opts.node,
+    oracle: opts.oracle,
+    locators: opts.locators,
+    capabilities: opts.capabilities ?? ["pair", "feed", "send"],
+    oracles: opts.oracles ?? [],
+    ts: Date.now(),
+  };
+}
+
+export function parseMessage(buf: Buffer): ScoutProtocolMessage | null {
+  try {
+    const msg = JSON.parse(buf.toString());
+    if (msg.type === "maw-scout" || msg.type === "maw-hello" || msg.type === "maw-announce") {
+      return msg as ScoutProtocolMessage;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/src/transports/scout-state.test.ts
+++ b/src/transports/scout-state.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { ScoutState, SCOUT_INITIAL_MS, SCOUT_MAX_MS, PEER_STALE_MS } from "./scout-state";
+import { generateZid, makeHello } from "./scout-protocol";
+
+describe("scout-state", () => {
+  let state: ScoutState;
+  const localZid = "ff" + "0".repeat(30); // high zid — will always be initiator
+
+  beforeEach(() => {
+    state = new ScoutState(localZid);
+  });
+
+  describe("backoff", () => {
+    it("starts at SCOUT_INITIAL_MS", () => {
+      expect(state.backoffMs).toBe(SCOUT_INITIAL_MS);
+    });
+
+    it("doubles on each advance", () => {
+      expect(state.advanceBackoff()).toBe(1000);
+      expect(state.backoffMs).toBe(2000);
+      expect(state.advanceBackoff()).toBe(2000);
+      expect(state.backoffMs).toBe(4000);
+      expect(state.advanceBackoff()).toBe(4000);
+      expect(state.backoffMs).toBe(8000);
+    });
+
+    it("caps at SCOUT_MAX_MS", () => {
+      for (let i = 0; i < 10; i++) state.advanceBackoff();
+      expect(state.backoffMs).toBe(SCOUT_MAX_MS);
+    });
+
+    it("resets to initial on resetBackoff()", () => {
+      state.advanceBackoff();
+      state.advanceBackoff();
+      state.resetBackoff();
+      expect(state.backoffMs).toBe(SCOUT_INITIAL_MS);
+    });
+  });
+
+  describe("handleHello", () => {
+    it("detects new peer", () => {
+      const hello = makeHello({
+        zid: "00" + "0".repeat(30),
+        node: "mba",
+        oracle: "neo",
+        locators: ["http://192.168.1.10:3456"],
+      });
+      const result = state.handleHello(hello, "192.168.1.10");
+      expect(result.isNew).toBe(true);
+      expect(state.discoveredPeers.size).toBe(1);
+    });
+
+    it("returns isNew=false for known peer", () => {
+      const zid = "00" + "0".repeat(30);
+      const hello = makeHello({ zid, node: "mba", oracle: "neo", locators: ["http://x:3456"] });
+      state.handleHello(hello, "192.168.1.10");
+      const result = state.handleHello(hello, "192.168.1.10");
+      expect(result.isNew).toBe(false);
+    });
+
+    it("ignores self", () => {
+      const hello = makeHello({ zid: localZid, node: "self", oracle: "self", locators: [] });
+      const result = state.handleHello(hello, "127.0.0.1");
+      expect(result.isNew).toBe(false);
+      expect(result.shouldPair).toBe(false);
+      expect(state.discoveredPeers.size).toBe(0);
+    });
+
+    it("resets backoff on new peer", () => {
+      state.advanceBackoff();
+      state.advanceBackoff();
+      expect(state.backoffMs).toBe(4000);
+
+      const hello = makeHello({
+        zid: generateZid(),
+        node: "new",
+        oracle: "new",
+        locators: ["http://x:3456"],
+      });
+      state.handleHello(hello, "10.0.0.1");
+      expect(state.backoffMs).toBe(SCOUT_INITIAL_MS);
+    });
+
+    it("updates lastSeen on repeated hello", () => {
+      const zid = "00" + "0".repeat(30);
+      const hello = makeHello({ zid, node: "mba", oracle: "neo", locators: ["http://x:3456"] });
+
+      state.handleHello(hello, "192.168.1.10");
+      const firstSeen = state.discoveredPeers.get(zid)!.lastSeen;
+
+      // tiny delay to ensure timestamp differs
+      const later = makeHello({ zid, node: "mba", oracle: "neo", locators: ["http://x:3456"] });
+      state.handleHello(later, "192.168.1.10");
+      expect(state.discoveredPeers.get(zid)!.lastSeen).toBeGreaterThanOrEqual(firstSeen);
+    });
+  });
+
+  describe("GreaterZid pairing", () => {
+    it("shouldPair=true when local zid > remote zid and peer has pair capability", () => {
+      const remoteZid = "00" + "0".repeat(30);
+      const hello = makeHello({
+        zid: remoteZid,
+        node: "mba",
+        oracle: "neo",
+        locators: ["http://x:3456"],
+        capabilities: ["pair", "feed", "send"],
+      });
+      const result = state.handleHello(hello, "10.0.0.1");
+      expect(result.shouldPair).toBe(true);
+    });
+
+    it("shouldPair=false when local zid < remote zid", () => {
+      const lowState = new ScoutState("00" + "0".repeat(30));
+      const hello = makeHello({
+        zid: "ff" + "0".repeat(30),
+        node: "mba",
+        oracle: "neo",
+        locators: ["http://x:3456"],
+        capabilities: ["pair"],
+      });
+      const result = lowState.handleHello(hello, "10.0.0.1");
+      expect(result.shouldPair).toBe(false);
+    });
+
+    it("shouldPair=false when peer lacks pair capability", () => {
+      const hello = makeHello({
+        zid: "00" + "0".repeat(30),
+        node: "mba",
+        oracle: "neo",
+        locators: ["http://x:3456"],
+        capabilities: ["feed", "send"],
+      });
+      const result = state.handleHello(hello, "10.0.0.1");
+      expect(result.shouldPair).toBe(false);
+    });
+
+    it("shouldPair=false when already paired", () => {
+      const zid = "00" + "0".repeat(30);
+      const hello = makeHello({
+        zid,
+        node: "mba",
+        oracle: "neo",
+        locators: ["http://x:3456"],
+        capabilities: ["pair"],
+      });
+      state.handleHello(hello, "10.0.0.1");
+      state.markPaired(zid);
+
+      // second hello from same peer
+      const hello2 = makeHello({ zid, node: "mba", oracle: "neo", locators: ["http://x:3456"], capabilities: ["pair"] });
+      const result = state.handleHello(hello2, "10.0.0.1");
+      expect(result.shouldPair).toBe(false);
+    });
+
+    it("shouldPair=false when connection is pending", () => {
+      const zid = "00" + "0".repeat(30);
+      state.markPending(zid);
+      const hello = makeHello({ zid, node: "mba", oracle: "neo", locators: ["http://x:3456"], capabilities: ["pair"] });
+      const result = state.handleHello(hello, "10.0.0.1");
+      expect(result.shouldPair).toBe(false);
+    });
+
+    it("exactly one side initiates for any pair of zids", () => {
+      const zidA = generateZid();
+      const zidB = generateZid();
+      const stateA = new ScoutState(zidA);
+      const stateB = new ScoutState(zidB);
+
+      const helloFromB = makeHello({ zid: zidB, node: "b", oracle: "b", locators: ["http://b:3456"], capabilities: ["pair"] });
+      const helloFromA = makeHello({ zid: zidA, node: "a", oracle: "a", locators: ["http://a:3456"], capabilities: ["pair"] });
+
+      const aResult = stateA.handleHello(helloFromB, "10.0.0.2");
+      const bResult = stateB.handleHello(helloFromA, "10.0.0.1");
+
+      // exactly one should pair
+      expect(aResult.shouldPair !== bResult.shouldPair).toBe(true);
+    });
+  });
+
+  describe("peer management", () => {
+    it("markPaired sets paired flag and clears pending", () => {
+      const zid = "00" + "0".repeat(30);
+      const hello = makeHello({ zid, node: "mba", oracle: "neo", locators: ["http://x:3456"] });
+      state.handleHello(hello, "10.0.0.1");
+      state.markPending(zid);
+      state.markPaired(zid);
+
+      expect(state.discoveredPeers.get(zid)!.paired).toBe(true);
+      expect(state.pendingConnections.has(zid)).toBe(false);
+    });
+
+    it("findPeerByNode returns correct peer", () => {
+      const hello = makeHello({ zid: generateZid(), node: "white", oracle: "mawjs", locators: ["http://x:3456"], oracles: ["mawjs-oracle"] });
+      state.handleHello(hello, "10.0.0.1");
+      expect(state.findPeerByNode("white")).toBeDefined();
+      expect(state.findPeerByNode("nonexistent")).toBeUndefined();
+    });
+
+    it("findPeerByOracle matches partial oracle name", () => {
+      const hello = makeHello({ zid: generateZid(), node: "white", oracle: "mawjs", locators: ["http://x:3456"], oracles: ["mawjs-oracle", "neo-oracle"] });
+      state.handleHello(hello, "10.0.0.1");
+      expect(state.findPeerByOracle("mawjs")).toBeDefined();
+      expect(state.findPeerByOracle("neo")).toBeDefined();
+      expect(state.findPeerByOracle("unknown")).toBeUndefined();
+    });
+
+    it("markExistingPeerPaired marks by node name", () => {
+      const hello = makeHello({ zid: generateZid(), node: "mba", oracle: "neo", locators: ["http://x:3456"] });
+      state.handleHello(hello, "10.0.0.1");
+      state.markExistingPeerPaired("mba");
+      const peer = state.findPeerByNode("mba");
+      expect(peer!.paired).toBe(true);
+    });
+  });
+
+  describe("pruneStale", () => {
+    it("removes peers older than PEER_STALE_MS", () => {
+      const zid = generateZid();
+      const hello = makeHello({ zid, node: "old", oracle: "old", locators: ["http://x:3456"] });
+      state.handleHello(hello, "10.0.0.1");
+
+      // manually set lastSeen to past
+      state.discoveredPeers.get(zid)!.lastSeen = Date.now() - PEER_STALE_MS - 1;
+
+      const removed = state.pruneStale();
+      expect(removed).toEqual(["old"]);
+      expect(state.discoveredPeers.size).toBe(0);
+    });
+
+    it("keeps fresh peers", () => {
+      const hello = makeHello({ zid: generateZid(), node: "fresh", oracle: "fresh", locators: ["http://x:3456"] });
+      state.handleHello(hello, "10.0.0.1");
+
+      const removed = state.pruneStale();
+      expect(removed).toEqual([]);
+      expect(state.discoveredPeers.size).toBe(1);
+    });
+
+    it("clears pending connections for pruned peers", () => {
+      const zid = generateZid();
+      const hello = makeHello({ zid, node: "stale", oracle: "stale", locators: ["http://x:3456"] });
+      state.handleHello(hello, "10.0.0.1");
+      state.markPending(zid);
+      state.discoveredPeers.get(zid)!.lastSeen = Date.now() - PEER_STALE_MS - 1;
+
+      state.pruneStale();
+      expect(state.pendingConnections.has(zid)).toBe(false);
+    });
+  });
+});

--- a/src/transports/scout-state.ts
+++ b/src/transports/scout-state.ts
@@ -1,0 +1,129 @@
+/**
+ * Scout state machine — backoff, peer tracking, GreaterZid dedup.
+ */
+
+import { greaterZid, type HelloMessage } from "./scout-protocol";
+
+export const SCOUT_INITIAL_MS = 1_000;
+export const SCOUT_MAX_MS = 8_000;
+export const PEER_STALE_MS = 30_000;
+
+export interface DiscoveredPeer {
+  zid: string;
+  node: string;
+  host: string;
+  oracle: string;
+  locators: string[];
+  capabilities: string[];
+  oracles: string[];
+  lastSeen: number;
+  paired: boolean;
+}
+
+export class ScoutState {
+  readonly localZid: string;
+  private _backoffMs = SCOUT_INITIAL_MS;
+  readonly discoveredPeers = new Map<string, DiscoveredPeer>();
+  readonly pendingConnections = new Set<string>();
+
+  constructor(localZid: string) {
+    this.localZid = localZid;
+  }
+
+  get backoffMs(): number {
+    return this._backoffMs;
+  }
+
+  advanceBackoff(): number {
+    const current = this._backoffMs;
+    this._backoffMs = Math.min(this._backoffMs * 2, SCOUT_MAX_MS);
+    return current;
+  }
+
+  resetBackoff(): void {
+    this._backoffMs = SCOUT_INITIAL_MS;
+  }
+
+  handleHello(hello: HelloMessage, host: string): { isNew: boolean; shouldPair: boolean } {
+    if (hello.zid === this.localZid) return { isNew: false, shouldPair: false };
+
+    const existing = this.discoveredPeers.get(hello.zid);
+    const isNew = !existing;
+
+    this.discoveredPeers.set(hello.zid, {
+      zid: hello.zid,
+      node: hello.node,
+      host,
+      oracle: hello.oracle,
+      locators: hello.locators,
+      capabilities: hello.capabilities,
+      oracles: hello.oracles,
+      lastSeen: Date.now(),
+      paired: existing?.paired ?? false,
+    });
+
+    if (isNew) this.resetBackoff();
+
+    const alreadyPaired = existing?.paired ?? false;
+    const isPending = this.pendingConnections.has(hello.zid);
+    const shouldPair =
+      isNew &&
+      !alreadyPaired &&
+      !isPending &&
+      hello.capabilities.includes("pair") &&
+      greaterZid(this.localZid, hello.zid);
+
+    return { isNew, shouldPair };
+  }
+
+  markPaired(zid: string): void {
+    const peer = this.discoveredPeers.get(zid);
+    if (peer) peer.paired = true;
+    this.pendingConnections.delete(zid);
+  }
+
+  markPending(zid: string): void {
+    this.pendingConnections.add(zid);
+  }
+
+  clearPending(zid: string): void {
+    this.pendingConnections.delete(zid);
+  }
+
+  markExistingPeerPaired(node: string): void {
+    for (const peer of this.discoveredPeers.values()) {
+      if (peer.node === node) peer.paired = true;
+    }
+  }
+
+  pruneStale(): string[] {
+    const cutoff = Date.now() - PEER_STALE_MS;
+    const removed: string[] = [];
+    for (const [zid, peer] of this.discoveredPeers) {
+      if (peer.lastSeen < cutoff) {
+        this.discoveredPeers.delete(zid);
+        this.pendingConnections.delete(zid);
+        removed.push(peer.node);
+      }
+    }
+    return removed;
+  }
+
+  findPeerByNode(node: string): DiscoveredPeer | undefined {
+    for (const peer of this.discoveredPeers.values()) {
+      if (peer.node === node) return peer;
+    }
+    return undefined;
+  }
+
+  findPeerByOracle(oracle: string): DiscoveredPeer | undefined {
+    for (const peer of this.discoveredPeers.values()) {
+      if (peer.oracles.some((o) => o.includes(oracle))) return peer;
+    }
+    return undefined;
+  }
+
+  findPeerByZid(zid: string): DiscoveredPeer | undefined {
+    return this.discoveredPeers.get(zid);
+  }
+}

--- a/src/transports/scout.ts
+++ b/src/transports/scout.ts
@@ -1,0 +1,353 @@
+/**
+ * Scout transport — zenoh-inspired zero-config LAN discovery + auto-pairing.
+ *
+ * Replaces MdnsTransport with a proper Scout→Hello→Pair handshake:
+ *   1. Scout (multicast) — "who's out there?"
+ *   2. Hello (unicast)   — "I'm here, these are my capabilities"
+ *   3. Pair  (HTTP)      — "let's establish a persistent peer relationship"
+ *
+ * Backward-compatible: accepts maw-announce from legacy MdnsTransport nodes.
+ */
+
+import { createSocket, type Socket } from "dgram";
+import type {
+  Transport,
+  TransportTarget,
+  TransportMessage,
+  TransportPresence,
+} from "../core/transport/transport";
+import type { FeedEvent } from "../lib/feed";
+import { loadPeers } from "../lib/peers/store";
+import {
+  MULTICAST_ADDR,
+  MULTICAST_PORT,
+  generateZid,
+  makeScout,
+  makeHello,
+  parseMessage,
+  type HelloMessage,
+} from "./scout-protocol";
+import { ScoutState } from "./scout-state";
+import { initiatePair } from "./scout-pair";
+import { recordHelloZid } from "../api/pair";
+
+export interface ScoutTransportConfig {
+  node: string;
+  oracle?: string;
+  port: number;
+  oracles?: string[];
+  autoPair?: boolean;
+}
+
+export class ScoutTransport implements Transport {
+  readonly name = "scout-p2p";
+  private _connected = false;
+  private config: ScoutTransportConfig;
+  private socket: Socket | null = null;
+  private scoutTimer: ReturnType<typeof setTimeout> | null = null;
+  private pruneTimer: ReturnType<typeof setInterval> | null = null;
+  private state: ScoutState;
+  private msgHandlers = new Set<(msg: TransportMessage) => void>();
+  private presenceHandlers = new Set<(p: TransportPresence) => void>();
+  private feedHandlers = new Set<(e: FeedEvent) => void>();
+
+  constructor(config: ScoutTransportConfig) {
+    this.config = config;
+    this.state = new ScoutState(generateZid());
+  }
+
+  get connected() {
+    return this._connected;
+  }
+
+  async connect(): Promise<void> {
+    try {
+      this.loadExistingPeers();
+
+      this.socket = createSocket({ type: "udp4", reuseAddr: true });
+
+      this.socket.on("message", (buf, rinfo) => {
+        const msg = parseMessage(buf);
+        if (!msg) return;
+
+        switch (msg.type) {
+          case "maw-scout":
+            this.handleScout(msg, rinfo.address, rinfo.port);
+            break;
+          case "maw-hello":
+            this.handleHello(msg, rinfo.address);
+            break;
+          case "maw-announce":
+            this.handleLegacyAnnounce(msg, rinfo.address);
+            break;
+        }
+      });
+
+      await new Promise<void>((resolve, reject) => {
+        this.socket!.bind(MULTICAST_PORT, () => {
+          try {
+            this.socket!.addMembership(MULTICAST_ADDR);
+            this.socket!.setMulticastTTL(2);
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        });
+        this.socket!.on("error", reject);
+      });
+
+      this._connected = true;
+      this.scheduleScout();
+      this.pruneTimer = setInterval(() => this.pruneStale(), 10_000);
+
+      console.log(
+        `[scout] listening on ${MULTICAST_ADDR}:${MULTICAST_PORT} as ${this.config.node} (zid: ${this.state.localZid.slice(0, 8)}…)`,
+      );
+    } catch (err) {
+      console.warn(
+        `[scout] connect failed: ${err instanceof Error ? err.message : err}`,
+      );
+      this._connected = false;
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.scoutTimer) {
+      clearTimeout(this.scoutTimer);
+      this.scoutTimer = null;
+    }
+    if (this.pruneTimer) {
+      clearInterval(this.pruneTimer);
+      this.pruneTimer = null;
+    }
+    if (this.socket) {
+      try {
+        this.socket.dropMembership(MULTICAST_ADDR);
+      } catch {}
+      this.socket.close();
+      this.socket = null;
+    }
+    this._connected = false;
+  }
+
+  async send(target: TransportTarget, message: string): Promise<boolean> {
+    const peer = this.findPeer(target);
+    if (!peer) return false;
+
+    const url = peer.locators[0];
+    if (!url) return false;
+
+    try {
+      const res = await fetch(`${url}/api/send`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ target: target.oracle, text: message }),
+        signal: AbortSignal.timeout(5000),
+      });
+
+      if (res.ok) {
+        const data = (await res.json()) as any;
+        if (data.ok) {
+          const msg: TransportMessage = {
+            from: this.config.node,
+            to: target.oracle,
+            body: message,
+            timestamp: Date.now(),
+            transport: "scout" as any,
+          };
+          for (const h of this.msgHandlers) h(msg);
+          return true;
+        }
+      }
+      return false;
+    } catch {
+      return false;
+    }
+  }
+
+  async publishPresence(_presence: TransportPresence): Promise<void> {
+    this.sendScout();
+  }
+
+  async publishFeed(event: FeedEvent): Promise<void> {
+    for (const peer of this.state.discoveredPeers.values()) {
+      const url = peer.locators[0];
+      if (!url) continue;
+      fetch(`${url}/api/feed`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(event),
+        signal: AbortSignal.timeout(3000),
+      }).catch(() => {});
+    }
+  }
+
+  onMessage(handler: (msg: TransportMessage) => void) {
+    this.msgHandlers.add(handler);
+  }
+
+  onPresence(handler: (p: TransportPresence) => void) {
+    this.presenceHandlers.add(handler);
+  }
+
+  onFeed(handler: (e: FeedEvent) => void) {
+    this.feedHandlers.add(handler);
+  }
+
+  canReach(target: TransportTarget): boolean {
+    if (!target.host || target.host === "local" || target.host === "localhost")
+      return false;
+    return this.findPeer(target) !== null;
+  }
+
+  listPeers() {
+    return [...this.state.discoveredPeers.values()];
+  }
+
+  // ─── Protocol Handlers ─────────────────────────────────────────────
+
+  private handleScout(
+    msg: { zid: string; whatAmI: string },
+    fromHost: string,
+    fromPort: number,
+  ): void {
+    if (msg.zid === this.state.localZid) return;
+
+    const hello = makeHello({
+      zid: this.state.localZid,
+      node: this.config.node,
+      oracle: this.config.oracle ?? this.config.node,
+      locators: [`http://${this.config.node}:${this.config.port}`],
+      oracles: this.config.oracles,
+    });
+
+    const buf = Buffer.from(JSON.stringify(hello));
+    this.socket?.send(buf, fromPort, fromHost);
+  }
+
+  private handleHello(hello: HelloMessage, fromHost: string): void {
+    recordHelloZid(hello.zid);
+    const { isNew, shouldPair } = this.state.handleHello(hello, fromHost);
+
+    if (isNew) {
+      console.log(
+        `[scout] discovered: ${hello.node} at ${fromHost} (zid: ${hello.zid.slice(0, 8)}…, oracles: ${hello.oracles.length})`,
+      );
+    }
+
+    this.emitPresence(hello.node, fromHost, "ready");
+
+    if (shouldPair && this.config.autoPair !== false) {
+      this.state.markPending(hello.zid);
+      this.doPair(hello.zid);
+    }
+  }
+
+  private handleLegacyAnnounce(
+    msg: { node: string; port: number; oracles: string[] },
+    fromHost: string,
+  ): void {
+    if (msg.node === this.config.node) return;
+
+    const legacyHello: HelloMessage = {
+      type: "maw-hello",
+      version: 1,
+      zid: `legacy-${msg.node}`,
+      whatAmI: "oracle",
+      node: msg.node,
+      oracle: msg.node,
+      locators: [`http://${fromHost}:${msg.port || 3456}`],
+      capabilities: [],
+      oracles: msg.oracles || [],
+      ts: Date.now(),
+    };
+
+    const existing = this.state.findPeerByNode(msg.node);
+    if (!existing) {
+      console.log(
+        `[scout] legacy peer: ${msg.node} at ${fromHost}:${msg.port}`,
+      );
+    }
+
+    this.state.handleHello(legacyHello, fromHost);
+    this.emitPresence(msg.node, fromHost, "ready");
+  }
+
+  // ─── Scout Loop ────────────────────────────────────────────────────
+
+  private scheduleScout(): void {
+    if (!this._connected) return;
+    const delay = this.state.advanceBackoff();
+    this.scoutTimer = setTimeout(() => {
+      this.sendScout();
+      this.scheduleScout();
+    }, delay);
+  }
+
+  private sendScout(): void {
+    if (!this.socket || !this._connected) return;
+    const msg = makeScout(this.state.localZid);
+    const buf = Buffer.from(JSON.stringify(msg));
+    this.socket.send(buf, MULTICAST_PORT, MULTICAST_ADDR);
+  }
+
+  // ─── Pairing ───────────────────────────────────────────────────────
+
+  private async doPair(zid: string): Promise<void> {
+    const peer = this.state.findPeerByZid(zid);
+    if (!peer) {
+      this.state.clearPending(zid);
+      return;
+    }
+
+    console.log(`[scout] pairing with ${peer.node} (zid: ${zid.slice(0, 8)}…)…`);
+
+    const result = await initiatePair(
+      peer,
+      this.config.node,
+      this.config.oracle ?? this.config.node,
+      this.config.port,
+    );
+
+    if (result.ok) {
+      this.state.markPaired(zid);
+      console.log(`[scout] ✓ paired with ${peer.node}`);
+    } else {
+      this.state.clearPending(zid);
+      console.warn(`[scout] pair failed with ${peer.node}: ${result.error}`);
+    }
+  }
+
+  // ─── Helpers ───────────────────────────────────────────────────────
+
+  private findPeer(target: TransportTarget) {
+    if (target.host) {
+      const p = this.state.findPeerByNode(target.host);
+      if (p) return p;
+    }
+    return this.state.findPeerByOracle(target.oracle);
+  }
+
+  private emitPresence(oracle: string, host: string, status: TransportPresence["status"]): void {
+    for (const h of this.presenceHandlers) {
+      h({ oracle, host, status, timestamp: Date.now() });
+    }
+  }
+
+  private pruneStale(): void {
+    const removed = this.state.pruneStale();
+    for (const node of removed) {
+      console.log(`[scout] peer gone: ${node}`);
+      this.emitPresence(node, "", "offline");
+    }
+  }
+
+  private loadExistingPeers(): void {
+    try {
+      const { peers } = loadPeers();
+      for (const [alias] of Object.entries(peers)) {
+        this.state.markExistingPeerPaired(alias);
+      }
+    } catch {}
+  }
+}

--- a/test/cli/dispatch-match.test.ts
+++ b/test/cli/dispatch-match.test.ts
@@ -194,6 +194,11 @@ describe("resolveTopAlias — RFC #954 verb aliases", () => {
     if (out!.kind === "argv") expect(out!.argv).toEqual(["tmux", "attach", "neo"]);
   });
 
+  test("`peek` is not a tmux top-alias; top-level peek is handled by routeComm", () => {
+    const out = resolveTopAlias(["peek", "m5:mawjs"]);
+    expect(out).toBeNull();
+  });
+
   test("`attach` is not a registered alias (removed — use `a`)", () => {
     const out = resolveTopAlias(["attach", "neo"]);
     expect(out).toBeNull();

--- a/test/cli/dispatch-match.test.ts
+++ b/test/cli/dispatch-match.test.ts
@@ -10,7 +10,7 @@
  */
 import { describe, test, expect } from "bun:test";
 import { resolvePluginMatch } from "../../src/cli/dispatch-match";
-import { resolveTopAlias } from "../../src/cli/top-aliases";
+import { parseBringArgs, resolveTopAlias } from "../../src/cli/top-aliases";
 import type { LoadedPlugin } from "../../src/plugin/types";
 
 function plugin(name: string, command: string, aliases: string[] = []): LoadedPlugin {
@@ -214,6 +214,16 @@ describe("resolveTopAlias — RFC #954 verb aliases", () => {
       // argv passed to handler is everything AFTER the verb
       expect(out!.argv).toEqual(["neo", "--task", "X"]);
     }
+  });
+
+  test("`bring neo` defaults to tab/window mode, not split", () => {
+    const parsed = parseBringArgs(["neo"]);
+    expect(parsed).toEqual({ oracle: "neo", opts: { bring: true } });
+  });
+
+  test("`bring neo --split` opts into split mode", () => {
+    const parsed = parseBringArgs(["neo", "--split", "-e", "codex"]);
+    expect(parsed).toEqual({ oracle: "neo", opts: { split: true, engine: "codex" } });
   });
 
   test("`audit` → null (does NOT shadow CORE_ROUTES)", () => {

--- a/test/cli/dispatch-match.test.ts
+++ b/test/cli/dispatch-match.test.ts
@@ -216,7 +216,7 @@ describe("resolveTopAlias — RFC #954 verb aliases", () => {
     }
   });
 
-  test("`bring neo` defaults to tab/window mode, not split", () => {
+  test("`bring neo` defaults to bring-pane mode, not split", () => {
     const parsed = parseBringArgs(["neo"]);
     expect(parsed).toEqual({ oracle: "neo", opts: { bring: true } });
   });
@@ -236,6 +236,11 @@ describe("resolveTopAlias — RFC #954 verb aliases", () => {
   test("`bring neo --split` opts into split mode", () => {
     const parsed = parseBringArgs(["neo", "--split", "-e", "codex"]);
     expect(parsed).toEqual({ oracle: "neo", opts: { split: true, engine: "codex" } });
+  });
+
+  test("`bring neo --tab` forces the old background tab mode", () => {
+    const parsed = parseBringArgs(["neo", "--tab"]);
+    expect(parsed).toEqual({ oracle: "neo", opts: { bring: true, tab: true } });
   });
 
   test("`audit` → null (does NOT shadow CORE_ROUTES)", () => {

--- a/test/cli/dispatch-match.test.ts
+++ b/test/cli/dispatch-match.test.ts
@@ -10,7 +10,7 @@
  */
 import { describe, test, expect } from "bun:test";
 import { resolvePluginMatch } from "../../src/cli/dispatch-match";
-import { parseBringArgs, resolveTopAlias } from "../../src/cli/top-aliases";
+import { ALIAS_DESCRIPTIONS, parseBringArgs, resolveTopAlias } from "../../src/cli/top-aliases";
 import type { LoadedPlugin } from "../../src/plugin/types";
 
 function plugin(name: string, command: string, aliases: string[] = []): LoadedPlugin {
@@ -219,6 +219,18 @@ describe("resolveTopAlias — RFC #954 verb aliases", () => {
   test("`bring neo` defaults to tab/window mode, not split", () => {
     const parsed = parseBringArgs(["neo"]);
     expect(parsed).toEqual({ oracle: "neo", opts: { bring: true } });
+  });
+
+  test("`b neo` is a direct shorthand for bring", () => {
+    const out = resolveTopAlias(["b", "neo"]);
+    expect(out).not.toBeNull();
+    expect(out!.kind).toBe("direct");
+    if (out!.kind === "direct") {
+      expect(out!.handler).toContain("wake-cmd");
+      expect(out!.handler).toContain("cmdBring");
+      expect(out!.argv).toEqual(["neo"]);
+    }
+    expect(ALIAS_DESCRIPTIONS.b).toContain("short form of `bring`");
   });
 
   test("`bring neo --split` opts into split mode", () => {

--- a/test/cmd-update-ref-validation.test.ts
+++ b/test/cmd-update-ref-validation.test.ts
@@ -18,7 +18,13 @@ async function runCli(
   const proc = Bun.spawn(["bun", cliPath, ...args], {
     stdout: "pipe",
     stderr: "pipe",
-    env: { ...process.env, MAW_CLI: "1", ...opts.env },
+    // MAW_TEST_MODE=1 is mandatory here: runUpdate mutates the *real*
+    // ~/.bun/bin/maw and ~/.bun/install/global/ (no sandbox seam). Without
+    // this guard a valid ref falls through into the destructive install path
+    // and wipes the developer's maw install on every `bun test` run. Set it
+    // explicitly so the test is safe even when run standalone (not just
+    // inheriting it from the suite-level env).
+    env: { ...process.env, MAW_CLI: "1", MAW_TEST_MODE: "1", ...opts.env },
   });
   const [stdout, stderr, code] = await Promise.all([
     new Response(proc.stdout).text(),
@@ -89,16 +95,19 @@ describe("H3 — cmd-update ref allowlist (CLI subprocess)", () => {
     expect(stderr).toContain("invalid ref");
   }, 10_000);
 
-  it("valid ref 'main' passes the allowlist gate (reaches install, not ref guard)", async () => {
-    // We can't complete a real install in test, but the error must NOT be about
-    // "invalid ref" — it should be about network or bun, meaning REF_RE passed.
-    const { stderr } = await runCli(["update", "main", "--yes"]);
-    // The ref guard must NOT fire for "main"
+  it("valid ref 'main' passes the allowlist gate (reaches test-mode gate, not ref guard)", async () => {
+    // A valid ref must pass REF_RE and reach the destructive-op boundary.
+    // Under MAW_TEST_MODE that boundary is the test-mode guard, which prints
+    // "accepted" and stops — so we assert REF_RE did NOT reject AND the ref
+    // actually reached the gate (proof it traversed the whole allowlist path).
+    const { stdout, stderr } = await runCli(["update", "main", "--yes"]);
     expect(stderr).not.toContain("invalid ref");
+    expect(stdout).toContain('ref "main" accepted');
   }, 15_000);
 
   it("valid branch name 'feat/my-feature' passes the allowlist gate", async () => {
-    const { stderr } = await runCli(["update", "feat/my-feature", "--yes"]);
+    const { stdout, stderr } = await runCli(["update", "feat/my-feature", "--yes"]);
     expect(stderr).not.toContain("invalid ref");
+    expect(stdout).toContain('ref "feat/my-feature" accepted');
   }, 15_000);
 });

--- a/test/comm-send-signing.test.ts
+++ b/test/comm-send-signing.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { formatSignedMessage } from "../src/commands/shared/comm-send";
+
+describe("formatSignedMessage — visible Oracle attribution (#1388)", () => {
+  const config = { node: "m5" };
+
+  test("prefixes ordinary federation chat with node and sender", () => {
+    expect(formatSignedMessage("hello", config, "mawjs-codex")).toBe("[m5:mawjs-codex] hello");
+  });
+
+  test("does not double-prefix already signed messages", () => {
+    expect(formatSignedMessage("[m5:mawjs-codex] hello", config, "mawjs-codex"))
+      .toBe("[m5:mawjs-codex] hello");
+  });
+
+  test("does not prefix slash commands", () => {
+    expect(formatSignedMessage("/recap --now", config, "mawjs-codex")).toBe("/recap --now");
+  });
+
+  test("does not prefix dollar skill commands", () => {
+    expect(formatSignedMessage("$go update", config, "mawjs-codex")).toBe("$go update");
+  });
+
+  test("preserves leading whitespace when signing prose", () => {
+    expect(formatSignedMessage("  hello", config, "mawjs-codex")).toBe("  [m5:mawjs-codex] hello");
+  });
+});

--- a/test/command-simplified.test.ts
+++ b/test/command-simplified.test.ts
@@ -1,8 +1,8 @@
-import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 
-// Drives loadConfig() via a per-test mutable fixture so we can exercise the
-// post-#541 buildCommand branches (bare cmd, --continue fallback, pattern
-// match, --resume injection, no-cd/no-direnv invariant).
+// Drives the pure command builder with a per-test mutable fixture so we can
+// exercise the post-#541 branches without being affected by Bun's process-global
+// module mocks from other test files.
 let fakeConfig: any = {
   host: "local",
   port: 3456,
@@ -16,18 +16,19 @@ let fakeConfig: any = {
 };
 let fakeSessionIds: Record<string, string> = {};
 
-mock.module("../src/config/load", () => ({
-  loadConfig: () => ({ ...fakeConfig, sessionIds: fakeSessionIds }),
-  resetConfig: () => {},
-  saveConfig: () => fakeConfig,
-  configForDisplay: () => ({ ...fakeConfig, envMasked: {} }),
-  cfgInterval: () => 1000,
-  cfgTimeout: () => 1000,
-  cfgLimit: () => 100,
-  cfg: (k: string) => (fakeConfig as any)[k],
-}));
+const { buildCommandFromConfig, buildCommandInDirFromConfig } = await import("../src/config/command-logic");
 
-const { buildCommand, buildCommandInDir } = await import("../src/config/command");
+function testConfig() {
+  return { ...fakeConfig, sessionIds: fakeSessionIds };
+}
+
+function buildCommand(agentName: string, engine?: string): string {
+  return buildCommandFromConfig(testConfig(), agentName, engine);
+}
+
+function buildCommandInDir(agentName: string, cwd: string, engine?: string): string {
+  return buildCommandInDirFromConfig(testConfig(), agentName, cwd, engine);
+}
 
 // buildCommand strips --dangerously-skip-permissions when process.getuid() === 0
 // (root-stripping from #181). Tests below assert the flag is preserved in the

--- a/test/helpers/mock-config.ts
+++ b/test/helpers/mock-config.ts
@@ -23,6 +23,7 @@ const LIMITS: Record<keyof MawLimits, number> = {
   feedMax: 500, feedDefault: 50, feedHistory: 50,
   logsMax: 500, logsDefault: 50, logsTruncate: 500,
   messageTruncate: 100, ptyCols: 500, ptyRows: 200,
+  maxConcurrentAgents: 0,
 };
 
 export const TEST_D = {

--- a/test/helpers/mock-ssh.ts
+++ b/test/helpers/mock-ssh.ts
@@ -40,6 +40,7 @@ export interface SshMockOverrides {
   getPaneCommand?: (...args: any[]) => any;
   getPaneCommands?: (...args: any[]) => any;
   getPaneInfos?: (...args: any[]) => any;
+  isAgentCommand?: (...args: any[]) => any;
   HostExecError?: any;
 }
 
@@ -75,6 +76,11 @@ export function mockSshModule(overrides: SshMockOverrides = {}) {
     getPaneCommand: async () => "",
     getPaneCommands: async () => ({}),
     getPaneInfos: async () => ({}),
+    isAgentCommand: (cmd: string | null | undefined) => {
+      const c = (cmd ?? "").trim();
+      if (!c) return false;
+      return /claude|codex|node/i.test(c) || /^\d+\.\d+\.\d+$/.test(c);
+    },
     HostExecError: MockHostExecError,
     ...overrides,
   };

--- a/test/helpers/mock-ssh.ts
+++ b/test/helpers/mock-ssh.ts
@@ -44,6 +44,15 @@ export interface SshMockOverrides {
   HostExecError?: any;
 }
 
+/** Faithful lightweight default for isAgentCommand — name-match only (no
+ *  config.commands lookup, which the real one does). Mirrors the tightened
+ *  #10 logic so tests that don't override it still get sane answers. */
+function defaultIsAgentCommand(cmd?: string | null): boolean {
+  const c = (cmd ?? "").trim();
+  if (!c) return false;
+  return /claude|codex/i.test(c) || /^node$/i.test(c) || /^\d+\.\d+\.\d+$/.test(c);
+}
+
 // #431 added HostExecError — mocks must re-export the class shape or
 // imports of the real module leak the pollution pattern above.
 class MockHostExecError extends Error {
@@ -76,11 +85,7 @@ export function mockSshModule(overrides: SshMockOverrides = {}) {
     getPaneCommand: async () => "",
     getPaneCommands: async () => ({}),
     getPaneInfos: async () => ({}),
-    isAgentCommand: (cmd: string | null | undefined) => {
-      const c = (cmd ?? "").trim();
-      if (!c) return false;
-      return /claude|codex|node/i.test(c) || /^\d+\.\d+\.\d+$/.test(c);
-    },
+    isAgentCommand: defaultIsAgentCommand,
     HostExecError: MockHostExecError,
     ...overrides,
   };

--- a/test/helpers/mock-tmux.ts
+++ b/test/helpers/mock-tmux.ts
@@ -69,12 +69,24 @@ export interface MockPeer {
   sessions: MockSession[];
 }
 
+/** Shape returned by the mocked `tmux.listPanes()` — mirrors TmuxPane. */
+export interface MockPane {
+  id: string;
+  command: string;
+  target: string;
+  title?: string;
+  pid?: number;
+  cwd?: string;
+  lastActivity?: number;
+}
+
 // --- Internal state (cleared by resetMocks) ---
 
 let tmuxConfig: { sessions: MockSession[] } | null = null;
 let peersConfig: { peers: MockPeer[] } | null = null;
 let paneCommands: Record<string, string> = {};
 let capturedCommands: string[] = [];
+let panes: MockPane[] = [];
 
 // --- Shim install latches (shim stays live; config is what changes) ---
 
@@ -152,7 +164,7 @@ export function installTmuxMock(config: { sessions: MockSession[] }): void {
       },
       async listPanes() {
         capturedCommands.push("tmux list-panes -a");
-        return [];
+        return panes.map(p => ({ ...p }));
       },
       async killPane(target: string) {
         capturedCommands.push(`tmux kill-pane -t ${target}`);
@@ -328,6 +340,23 @@ export function setPaneCommands(cmds: Record<string, string>): void {
   paneCommands = { ...cmds };
 }
 
+/**
+ * Configure what `tmux.listPanes()` returns. Accepts partial panes — only
+ * `command` is required (the field most callers filter on); the rest are
+ * filled with deterministic placeholders. Replaces the previous list.
+ */
+export function setPanes(p: Array<Partial<MockPane> & { command: string }>): void {
+  panes = p.map((pane, i) => ({
+    id: pane.id ?? `%${i}`,
+    command: pane.command,
+    target: pane.target ?? `mock:${i}`,
+    title: pane.title,
+    pid: pane.pid,
+    cwd: pane.cwd,
+    lastActivity: pane.lastActivity,
+  }));
+}
+
 /** Captured tmux commands issued through the mock (for assertions). */
 export function getCapturedCommands(): string[] {
   return [...capturedCommands];
@@ -345,4 +374,5 @@ export function resetMocks(): void {
   peersConfig = null;
   paneCommands = {};
   capturedCommands = [];
+  panes = [];
 }

--- a/test/is-agent-command.test.ts
+++ b/test/is-agent-command.test.ts
@@ -39,4 +39,28 @@ describe("isAgentCommand", () => {
     expect(isAgentCommand("  claude  ")).toBe(true);
     expect(isAgentCommand("\t2.1.121\n")).toBe(true);
   });
+
+  // #10 — the guard regex used a loose substring match on `node`, so any
+  // command containing "node" passed. tmux #{pane_current_command} is a bare
+  // command basename, so `node` is now matched as the WHOLE name only.
+  test("rejects non-agent commands that merely contain 'node' (#10)", () => {
+    expect(isAgentCommand("nodemon")).toBe(false);
+    expect(isAgentCommand("node-red")).toBe(false);
+    expect(isAgentCommand("node-gyp")).toBe(false);
+    expect(isAgentCommand("nodejs")).toBe(false);
+    expect(isAgentCommand("anode")).toBe(false);
+  });
+
+  test("still matches bare 'node' regardless of case (#10)", () => {
+    expect(isAgentCommand("node")).toBe(true);
+    expect(isAgentCommand("Node")).toBe(true);
+    expect(isAgentCommand("NODE")).toBe(true);
+    expect(isAgentCommand("  node  ")).toBe(true);
+  });
+
+  test("claude / codex stay substring-matched (distinctive — no false positives)", () => {
+    expect(isAgentCommand("claude")).toBe(true);
+    expect(isAgentCommand("claude-code")).toBe(true);
+    expect(isAgentCommand("codex")).toBe(true);
+  });
 });

--- a/test/isolated/cmd-update-order.test.ts
+++ b/test/isolated/cmd-update-order.test.ts
@@ -93,7 +93,12 @@ describe("cmd-update source-order invariants", () => {
     expect(src).toMatch(/for \(const key of \["maw-js", "maw"\]\)/);
   });
 
-  it("#950: direct-rm covers maw-js, maw, and @maw-js node_modules", () => {
-    expect(src).toMatch(/for \(const name of \["maw-js", "maw", "@maw-js"\]\)/);
+  it("#950: node_modules eviction covers maw-js, maw, and @maw-js", () => {
+    // maw-js is the package the `~/.bun/bin/maw` symlink resolves through, so
+    // it is moved aside by RENAME (recoverable for the restore path) rather
+    // than rm'd — see the stash-restore invariant test. `maw` and `@maw-js`
+    // carry nothing the bin symlink needs, so they are still rm'd outright.
+    expect(src).toMatch(/renameSync\(join\(NM, "maw-js"\), PKG_STASH\)/);
+    expect(src).toMatch(/for \(const name of \["maw", "@maw-js"\]\)/);
   });
 });

--- a/test/isolated/comm-list.test.ts
+++ b/test/isolated/comm-list.test.ts
@@ -849,17 +849,17 @@ describe("cmdSend — local target (happy path + error branches)", () => {
 
     await run(() => cmdSend("white:mawjs", "ping"));
 
-    expect(sendKeysCalls).toEqual([{ target: "08-mawjs:0", text: "ping" }]);
+    expect(sendKeysCalls).toEqual([{ target: "08-mawjs:0", text: "[white:test-oracle] ping" }]);
     expect(runHookCalls.some((h) => h.event === "after_send")).toBe(true);
     expect(logMessageCalls).toHaveLength(1);
     expect(logMessageCalls[0]).toMatchObject({
-      from: "test-oracle", to: "white:mawjs", msg: "ping", route: "local",
+      from: "test-oracle", to: "white:mawjs", msg: "[white:test-oracle] ping", route: "local",
     });
     expect(emitFeedCalls).toHaveLength(1);
     expect(emitFeedCalls[0]).toMatchObject({
       event: "MessageSend", oracle: "test-oracle", node: "white", port: 4000,
     });
-    expect(outs.some((o) => o.includes("delivered") && o.includes("08-mawjs:0: ping"))).toBe(true);
+    expect(outs.some((o) => o.includes("delivered") && o.includes("08-mawjs:0: [white:test-oracle] ping"))).toBe(true);
     expect(outs.some((o) => o.includes("⤷ hello back"))).toBe(true);
   });
 
@@ -886,7 +886,7 @@ describe("cmdSend — local target (happy path + error branches)", () => {
 
     await run(() => cmdSend("white:mawjs", "ping", true));
 
-    expect(sendKeysCalls).toEqual([{ target: "08-mawjs:0", text: "ping" }]);
+    expect(sendKeysCalls).toEqual([{ target: "08-mawjs:0", text: "[white:test-oracle] ping" }]);
     expect(exitCode).toBeUndefined();
   });
 
@@ -921,7 +921,7 @@ describe("cmdSend — local target (happy path + error branches)", () => {
 
     await run(() => cmdSend("white:mawjs", "ping"));
 
-    expect(sendKeysCalls).toEqual([{ target: "08-mawjs:0", text: "ping" }]);
+    expect(sendKeysCalls).toEqual([{ target: "08-mawjs:0", text: "[white:test-oracle] ping" }]);
     expect(logMessageCalls[0].route).toBe("local");
   });
 
@@ -951,7 +951,7 @@ describe("cmdSend — local target (happy path + error branches)", () => {
 
     await run(() => cmdSend("white:mawjs", "ping"));
 
-    expect(sendKeysCalls).toEqual([{ target: "08-mawjs:0.1", text: "ping" }]);
+    expect(sendKeysCalls).toEqual([{ target: "08-mawjs:0.1", text: "[white:test-oracle] ping" }]);
   });
 });
 
@@ -974,7 +974,7 @@ describe("cmdSend — peer target (federation)", () => {
     expect(runHookCalls.some((h) => h.event === "after_send")).toBe(true);
     expect(logMessageCalls[0]).toMatchObject({ from: "test-oracle", to: "mba:mawjs", route: "peer:mba" });
     expect(emitFeedCalls[0]).toMatchObject({ event: "MessageSend", node: "white", port: 5000 });
-    expect(outs.some((o) => o.includes("delivered") && o.includes("mba") && o.includes("mawjs: ping"))).toBe(true);
+    expect(outs.some((o) => o.includes("delivered") && o.includes("mba") && o.includes("mawjs: [white:test-oracle] ping"))).toBe(true);
     expect(outs.some((o) => o.includes("⤷ peer saw it"))).toBe(true);
   });
 

--- a/test/isolated/comm-peek.test.ts
+++ b/test/isolated/comm-peek.test.ts
@@ -337,6 +337,22 @@ describe("cmdPeek — federation (node:agent)", () => {
     expect(outs.some((o) => o.includes("local pane body"))).toBe(true);
   });
 
+  test("local: prefix is treated as an alias for this node", async () => {
+    configOverride = { node: "white", sessions: {} };
+    listSessionsReturn = [
+      { name: "08-mawjs", windows: [{ index: 0, name: "mawjs-oracle", active: true }] },
+    ];
+    findWindowReturn = "08-mawjs:0";
+    captureResponses = [{ match: /08-mawjs:0/, result: "local alias body" }];
+
+    await run(() => cmdPeek("local:mawjs"));
+
+    expect(curlFetchCalls).toHaveLength(0);
+    expect(findWindowCalls).toHaveLength(1);
+    expect(findWindowCalls[0].query).toBe("mawjs");
+    expect(outs.some((o) => o.includes("local alias body"))).toBe(true);
+  });
+
   test("namedPeers hit → curlFetch(peerUrl + /api/capture?target=) + prints content", async () => {
     configOverride = {
       node: "mba",

--- a/test/isolated/comm-send-resolve-pane.test.ts
+++ b/test/isolated/comm-send-resolve-pane.test.ts
@@ -52,6 +52,10 @@ mock.module(join(srcRoot, "src/sdk"), () => ({
   capture: async () => "",
   sendKeys: async () => {},
   getPaneCommand: async () => "claude",
+  isAgentCommand: (cmd: string | null | undefined) => {
+    const c = (cmd ?? "").trim();
+    return !!c && (/claude|codex|node/i.test(c) || /^\d+\.\d+\.\d+$/.test(c));
+  },
   findPeerForTarget: async () => null,
   resolveTarget: () => null,
   curlFetch: async () => ({ ok: false, status: 0, data: null }),

--- a/test/isolated/elysia-auth-global-scope.test.ts
+++ b/test/isolated/elysia-auth-global-scope.test.ts
@@ -1,0 +1,189 @@
+/**
+ * elysia-auth-global-scope.test.ts — regression for maw-stress findings #1 + #3.
+ *
+ * #1 (CRITICAL) — `federationAuth` was a bare `new Elysia(...).onBeforeHandle(...)`
+ *   with no `.as('global')`. In Elysia 1.4 a named plugin's lifecycle hook is
+ *   `local`-scoped: it guards only routes defined on that same instance.
+ *   `federationAuth` defines ZERO routes, so the hook guarded nothing — every
+ *   protected write endpoint (`/api/send`, …) accepted unsigned non-loopback
+ *   requests. maw-stress revalidation confirmed this empirically.
+ *   Fix: `.as('global')` so the hook propagates to sibling route modules.
+ *
+ * #3 (HIGH) — `federationAuth` did `if (!token) return;` at the top — fail-OPEN.
+ *   A node with peers configured binds 0.0.0.0 and is network-reachable, so
+ *   "no token" there is default-insecure-open. Fix: fail-closed — no token +
+ *   peers configured + !allowPeersWithoutToken ⇒ 401.
+ *
+ * Isolated: mocks `src/config` (mock.module is process-global) and mutates
+ * the bun-server reference via setBunServer.
+ */
+import { describe, test, expect, mock, beforeAll, afterEach } from "bun:test";
+import { join } from "path";
+import { Elysia } from "elysia";
+import type { MawConfig } from "../../src/config";
+
+const root = join(import.meta.dir, "../..");
+
+// Mutable config state — the auth hook calls loadConfig() fresh per request,
+// so each test can dial in the federation posture it needs.
+const TOKEN = "test-federation-token-min-16-chars";
+let configState: Partial<MawConfig> = { node: "test-node", federationToken: TOKEN };
+
+mock.module(join(root, "src/config"), () => {
+  const { mockConfigModule } = require("../helpers/mock-config");
+  return mockConfigModule(() => configState);
+});
+
+let federationAuth: typeof import("../../src/lib/elysia-auth").federationAuth;
+let setBunServer: typeof import("../../src/lib/elysia-auth").setBunServer;
+let sign: typeof import("../../src/lib/federation-auth").sign;
+
+const NON_LOOPBACK_IP = "168.144.97.69";
+
+/** Mount federationAuth + a protected route as SEPARATE plugin instances —
+ *  this mirrors src/api/index.ts (`.use(federationAuth).use(sessionsApi)`)
+ *  and is exactly the topology the `.as('global')` fix has to cover. */
+function buildApp(): Elysia {
+  const protectedRoutes = new Elysia()
+    .post("/send", () => ({ ok: true }))
+    .get("/sessions", () => ({ ok: true }));
+  return new Elysia({ prefix: "/api" }).use(federationAuth).use(protectedRoutes);
+}
+
+/** Point setBunServer at a fake server reporting the given client IP. */
+function setClientIp(address: string): void {
+  setBunServer({ requestIP: () => ({ address }) } as unknown as import("bun").Server);
+}
+
+beforeAll(async () => {
+  const mod = await import("../../src/lib/elysia-auth");
+  federationAuth = mod.federationAuth;
+  setBunServer = mod.setBunServer;
+  sign = (await import("../../src/lib/federation-auth")).sign;
+});
+
+afterEach(() => {
+  configState = { node: "test-node", federationToken: TOKEN };
+});
+
+describe("federationAuth — global scope (#1)", () => {
+  test("REGRESSION: unsigned non-loopback POST /api/send → 401 (hook must guard sibling routes)", async () => {
+    setClientIp(NON_LOOPBACK_IP);
+    const res = await buildApp().handle(
+      new Request("http://localhost/api/send", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ target: "x", text: "y" }),
+      }),
+    );
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.reason).toBe("missing_signature");
+  });
+
+  test("signed non-loopback POST /api/send → reaches handler (200)", async () => {
+    setClientIp(NON_LOOPBACK_IP);
+    const ts = Math.floor(Date.now() / 1000);
+    const sig = sign(TOKEN, "POST", "/api/send", ts);
+    const res = await buildApp().handle(
+      new Request("http://localhost/api/send", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-maw-signature": sig,
+          "x-maw-timestamp": String(ts),
+        },
+        body: JSON.stringify({ target: "x", text: "y" }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json()).ok).toBe(true);
+  });
+
+  test("loopback unsigned POST /api/send → bypass (local CLI exemption preserved)", async () => {
+    setClientIp("127.0.0.1");
+    const res = await buildApp().handle(
+      new Request("http://localhost/api/send", { method: "POST", body: "{}" }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  test("non-protected GET /api/sessions → public even unsigned from non-loopback", async () => {
+    setClientIp(NON_LOOPBACK_IP);
+    const res = await buildApp().handle(
+      new Request("http://localhost/api/sessions", { method: "GET" }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  test("bad signature non-loopback → 401 (hook actually inspects the sig)", async () => {
+    setClientIp(NON_LOOPBACK_IP);
+    const res = await buildApp().handle(
+      new Request("http://localhost/api/send", {
+        method: "POST",
+        headers: {
+          "x-maw-signature": "deadbeef".repeat(8),
+          "x-maw-timestamp": String(Math.floor(Date.now() / 1000)),
+        },
+        body: "{}",
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("federationAuth — fail-closed when peers configured but no token (#3)", () => {
+  test("REGRESSION: no token + peers configured + non-loopback → 401 (was fail-open)", async () => {
+    configState = { node: "test-node", peers: ["http://peer-a.example"] };
+    setClientIp(NON_LOOPBACK_IP);
+    const res = await buildApp().handle(
+      new Request("http://localhost/api/send", { method: "POST", body: "{}" }),
+    );
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.reason).toBe("federation_token_required");
+  });
+
+  test("no token + namedPeers configured + non-loopback → 401", async () => {
+    configState = {
+      node: "test-node",
+      namedPeers: [{ name: "peer-a", url: "http://peer-a.example" }],
+    };
+    setClientIp(NON_LOOPBACK_IP);
+    const res = await buildApp().handle(
+      new Request("http://localhost/api/send", { method: "POST", body: "{}" }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("no token + peers + allowPeersWithoutToken:true → explicit opt-in bypass", async () => {
+    configState = {
+      node: "test-node",
+      peers: ["http://peer-a.example"],
+      allowPeersWithoutToken: true,
+    };
+    setClientIp(NON_LOOPBACK_IP);
+    const res = await buildApp().handle(
+      new Request("http://localhost/api/send", { method: "POST", body: "{}" }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  test("no token + NO peers + non-loopback → pass (single-node backwards compat)", async () => {
+    configState = { node: "test-node" };
+    setClientIp(NON_LOOPBACK_IP);
+    const res = await buildApp().handle(
+      new Request("http://localhost/api/send", { method: "POST", body: "{}" }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  test("no token + peers + loopback → pass (fail-closed only gates non-loopback)", async () => {
+    configState = { node: "test-node", peers: ["http://peer-a.example"] };
+    setClientIp("127.0.0.1");
+    const res = await buildApp().handle(
+      new Request("http://localhost/api/send", { method: "POST", body: "{}" }),
+    );
+    expect(res.status).toBe(200);
+  });
+});

--- a/test/isolated/hey-fleet-auto-wake.test.ts
+++ b/test/isolated/hey-fleet-auto-wake.test.ts
@@ -31,6 +31,7 @@ let fleetKnown: Set<string> = new Set();
 let cmdWakeCalls: Array<{ oracle: string; opts: unknown }> = [];
 let listSessionsCallCount = 0;
 let listSessionsAfterWake: Array<{ name: string; windows: { index: number; name: string; active: boolean }[] }> | null = null;
+let previousAgentName: string | undefined;
 
 // ─── Mocks ───────────────────────────────────────────────────────────────────
 
@@ -136,6 +137,8 @@ async function run(fn: () => Promise<unknown>): Promise<void> {
 }
 
 beforeEach(() => {
+  previousAgentName = process.env.CLAUDE_AGENT_NAME;
+  process.env.CLAUDE_AGENT_NAME = "test-node";
   mockActive = true;
   sendKeysCalls = [];
   cmdWakeCalls = [];
@@ -147,7 +150,12 @@ beforeEach(() => {
   process.env.MAW_QUIET = "1";
 });
 
-afterEach(() => { mockActive = false; delete process.env.MAW_QUIET; });
+afterEach(() => {
+  mockActive = false;
+  delete process.env.MAW_QUIET;
+  if (previousAgentName === undefined) delete process.env.CLAUDE_AGENT_NAME;
+  else process.env.CLAUDE_AGENT_NAME = previousAgentName;
+});
 afterAll(() => {
   mockActive = false;
   (Bun as unknown as { sleep: typeof origSleep }).sleep = origSleep;
@@ -171,7 +179,7 @@ describe("cmdSend — fleet auto-wake (#736 Phase 1.2)", () => {
     // Auto-wake message printed (no y/N prompt path)
     expect(logs.some(l => l.includes("fleet-known") && l.includes("auto-wake"))).toBe(true);
     expect(sendKeysCalls.length).toBe(1);
-    expect(sendKeysCalls[0].text).toBe("hello");
+    expect(sendKeysCalls[0].text).toBe("[test-node:test-node] hello");
     expect(exitCode).toBeUndefined();
   });
 

--- a/test/isolated/hey-fleet-auto-wake.test.ts
+++ b/test/isolated/hey-fleet-auto-wake.test.ts
@@ -225,6 +225,19 @@ describe("cmdSend — fleet auto-wake (#736 Phase 1.2)", () => {
     expect(sendKeysCalls.length).toBe(1);
   });
 
+  test("auto-wakes on local: prefixed target", async () => {
+    fleetKnown.add("volt");
+    listSessionsReturn = [];
+    listSessionsAfterWake = [{ name: "volt-session", windows: [{ index: 0, name: "volt-oracle", active: true }] }];
+    resolveTargetReturn = { type: "self-node", target: "volt-session:volt-oracle.0" };
+
+    await run(() => cmdSend("local:volt", "yo"));
+
+    expect(cmdWakeCalls.length).toBe(1);
+    expect(cmdWakeCalls[0].oracle).toBe("volt");
+    expect(sendKeysCalls.length).toBe(1);
+  });
+
   test("does NOT prompt y/N — wake is silent on fleet-known", async () => {
     fleetKnown.add("colab");
     listSessionsReturn = [];

--- a/test/isolated/is-agent-command-config.test.ts
+++ b/test/isolated/is-agent-command-config.test.ts
@@ -1,0 +1,59 @@
+/**
+ * is-agent-command-config.test.ts — #10, config.commands branch.
+ *
+ * isAgentCommand also matches panes whose command equals a binary from
+ * `config.commands`. That match used a loose `.includes()` substring, so a
+ * configured `node`-launched agent made every `nodemon` / `node-*` pane look
+ * like an agent. #10 tightens it to an exact (whole-name) comparison.
+ *
+ * Isolated: mocks src/config (mock.module is process-global) so the
+ * config.commands map is controllable. The plain-name regex branch is
+ * covered without mocks in test/is-agent-command.test.ts.
+ */
+import { describe, test, expect, beforeAll, mock } from "bun:test";
+import { join } from "path";
+
+const root = join(import.meta.dir, "../..");
+
+mock.module(join(root, "src/config"), () => {
+  const { mockConfigModule } = require("../helpers/mock-config");
+  return mockConfigModule(() => ({
+    node: "test-node",
+    commands: {
+      // bin tokens: "myagent", "node", "default" (the "default" key's value
+      // is intentionally the literal string the loop skips on)
+      primary: "myagent --run --flag",
+      secondary: "node /opt/agent/index.js",
+      default: "default",
+    },
+  }));
+});
+
+let isAgentCommand: typeof import("../../src/core/transport/ssh").isAgentCommand;
+
+beforeAll(async () => {
+  isAgentCommand = (await import("../../src/core/transport/ssh")).isAgentCommand;
+});
+
+describe("isAgentCommand — config.commands exact match (#10)", () => {
+  test("matches a configured binary by exact command name", () => {
+    expect(isAgentCommand("myagent")).toBe(true);
+  });
+
+  test("does NOT match commands that merely contain a configured binary name", () => {
+    expect(isAgentCommand("myagentx")).toBe(false);
+    expect(isAgentCommand("xmyagent")).toBe(false);
+    expect(isAgentCommand("my-myagent-wrapper")).toBe(false);
+  });
+
+  test("a configured `node`-launched agent does not make nodemon look like an agent", () => {
+    // "node" is a configured bin (secondary) AND a name-regex match — bare
+    // `node` is an agent, but `nodemon` must not inherit that.
+    expect(isAgentCommand("node")).toBe(true);
+    expect(isAgentCommand("nodemon")).toBe(false);
+  });
+
+  test("the literal 'default' key value is still skipped", () => {
+    expect(isAgentCommand("default")).toBe(false);
+  });
+});

--- a/test/isolated/plugin-load-capability-902.test.ts
+++ b/test/isolated/plugin-load-capability-902.test.ts
@@ -74,9 +74,9 @@ function makePluginDir(opts: {
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe("#902 — load-time capability validator (single source of truth)", () => {
-  test("KNOWN_CAPABILITY_NAMESPACES is the canonical set (#874 baseline)", () => {
+  test("KNOWN_CAPABILITY_NAMESPACES is the canonical set (#874/#1418 baseline)", () => {
     expect([...KNOWN_CAPABILITY_NAMESPACES].sort()).toEqual(
-      ["ffi", "fs", "net", "peer", "proc", "sdk", "shell", "tmux"],
+      ["attach", "ffi", "fs", "net", "peer", "proc", "sdk", "shell", "tmux"],
     );
   });
 
@@ -102,6 +102,17 @@ describe("#902 — load-time capability validator (single source of truth)", () 
     expect(shellWarns).toEqual([]);
   });
 
+  test("load-time: plugin with `attach:strategy` capability does NOT warn", () => {
+    const dir = makePluginDir({ name: "attach-ssh", capabilities: ["attach:strategy"] });
+    const loaded = loadManifestFromDir(dir);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.manifest.capabilities).toEqual(["attach:strategy"]);
+    const attachWarns = warnings.filter((w) =>
+      w.includes('unknown capability namespace "attach"'),
+    );
+    expect(attachWarns).toEqual([]);
+  });
+
   test("load-time: plugin with bogus namespace `foo` DOES warn", () => {
     const dir = makePluginDir({ name: "bogus-cap", capabilities: ["foo:bar"] });
     const loaded = loadManifestFromDir(dir);
@@ -125,9 +136,13 @@ describe("#902 — load-time capability validator (single source of truth)", () 
     for (const ns of KNOWN_CAPABILITY_NAMESPACES) {
       expect(fooWarn!).toContain(ns);
     }
+    expect(fooWarn!).toContain("runtime: maw v");
+    expect(fooWarn!).toContain("bun add -g github:Soul-Brews-Studio/maw-js#alpha");
     // Specifically tmux + shell — the two #874 added — must appear.
     expect(fooWarn!).toContain("tmux");
     expect(fooWarn!).toContain("shell");
+    // Specifically attach — the #1418 regression namespace — must appear.
+    expect(fooWarn!).toContain("attach");
   });
 
   test("load-time: every canonical namespace passes silently (no warning per known ns)", () => {

--- a/test/isolated/pulse-label-injection.test.ts
+++ b/test/isolated/pulse-label-injection.test.ts
@@ -16,6 +16,7 @@
 
 import { describe, test, expect, beforeAll, mock, spyOn } from "bun:test";
 import { Elysia } from "elysia";
+import { mockSshModule } from "../helpers/mock-ssh";
 
 // ---- Capture calls to Bun.spawn -------------------------------------------
 
@@ -47,7 +48,7 @@ Bun.spawn = (cmd: string[], _opts?: unknown) => {
 
 // ---- Stub dependencies so pulse.ts can be imported -----------------------
 
-mock.module("../../src/core/transport/ssh", () => ({
+mock.module("../../src/core/transport/ssh", () => mockSshModule({
   hostExec: async (_cmd: string) => "[]",
 }));
 

--- a/test/isolated/resolve-local-first.test.ts
+++ b/test/isolated/resolve-local-first.test.ts
@@ -25,6 +25,7 @@ let curlFetchUrl = "";
 // ─── Module mocks (must be before any imports of the modules under test) ─────
 
 import { mockConfigModule } from "../helpers/mock-config";
+import { mockSshModule } from "../helpers/mock-ssh";
 
 mock.module("../../src/config", () => mockConfigModule(() => ({
   node: "white",
@@ -34,7 +35,7 @@ mock.module("../../src/config", () => mockConfigModule(() => ({
   sessions: {},
 })));
 
-mock.module("../../src/core/transport/ssh", () => ({
+mock.module("../../src/core/transport/ssh", () => mockSshModule({
   listSessions: async () => fakeSessions,
   sendKeys: async () => { sendKeysCalled = true; },
   capture: async () => "",
@@ -42,7 +43,6 @@ mock.module("../../src/core/transport/ssh", () => ({
   getPaneCommands: async () => [],
   getPaneInfos: async () => ({}),
   hostExec: async () => { throw new Error("tmux unavailable in test"); },
-  HostExecError: class HostExecError extends Error {},
 }));
 
 mock.module("../../src/core/transport/curl-fetch", () => ({

--- a/test/isolated/route-comm-send.test.ts
+++ b/test/isolated/route-comm-send.test.ts
@@ -9,15 +9,18 @@
 import { describe, test, expect, mock, beforeEach } from "bun:test";
 
 const calls: unknown[][] = [];
+const peekCalls: unknown[][] = [];
 
 mock.module("../../src/commands/shared/comm", () => ({
   cmdSend: async (...args: unknown[]) => { calls.push(args); },
+  cmdPeek: async (...args: unknown[]) => { peekCalls.push(args); },
 }));
 
 const { routeComm } = await import("../../src/cli/route-comm");
 
 beforeEach(() => {
   calls.length = 0;
+  peekCalls.length = 0;
 });
 
 describe("routeComm — top-level send uses core delivery (#1388)", () => {
@@ -46,5 +49,13 @@ describe("routeComm — top-level send uses core delivery (#1388)", () => {
     expect(calls).toEqual([
       ["local:mawjs", "ping", false, { approve: false, trust: false }],
     ]);
+  });
+
+  test("maw peek routes through federation-aware cmdPeek, not tmux alias", async () => {
+    const handled = await routeComm("peek", ["peek", "m5:mawjs"]);
+
+    expect(handled).toBe(true);
+    expect(peekCalls).toEqual([["m5:mawjs"]]);
+    expect(calls).toEqual([]);
   });
 });

--- a/test/isolated/route-comm-send.test.ts
+++ b/test/isolated/route-comm-send.test.ts
@@ -1,0 +1,50 @@
+/**
+ * route-comm-send.test.ts — #1388 regression guard.
+ *
+ * Top-level `maw send` is message delivery, not raw pane typing. It must
+ * route through the same core cmdSend path as `maw hey`, which appends Enter
+ * through the transport and reports `delivered` instead of leaving text in the
+ * target prompt buffer.
+ */
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+
+const calls: unknown[][] = [];
+
+mock.module("../../src/commands/shared/comm", () => ({
+  cmdSend: async (...args: unknown[]) => { calls.push(args); },
+}));
+
+const { routeComm } = await import("../../src/cli/route-comm");
+
+beforeEach(() => {
+  calls.length = 0;
+});
+
+describe("routeComm — top-level send uses core delivery (#1388)", () => {
+  test("maw send <target> <message> routes through cmdSend like maw hey", async () => {
+    const handled = await routeComm("send", ["send", "local:mawjs", "hello", "world"]);
+
+    expect(handled).toBe(true);
+    expect(calls).toEqual([
+      ["local:mawjs", "hello world", false, { approve: false, trust: false }],
+    ]);
+  });
+
+  test("--force is preserved and stripped from the delivered message", async () => {
+    const handled = await routeComm("send", ["send", "local:mawjs", "hello", "--force"]);
+
+    expect(handled).toBe(true);
+    expect(calls).toEqual([
+      ["local:mawjs", "hello", true, { approve: false, trust: false }],
+    ]);
+  });
+
+  test("maw hey remains on the same core path", async () => {
+    const handled = await routeComm("hey", ["hey", "local:mawjs", "ping"]);
+
+    expect(handled).toBe(true);
+    expect(calls).toEqual([
+      ["local:mawjs", "ping", false, { approve: false, trust: false }],
+    ]);
+  });
+});

--- a/test/isolated/routing-manifest.test.ts
+++ b/test/isolated/routing-manifest.test.ts
@@ -216,6 +216,23 @@ describe("resolveTarget — manifest as primary lookup (Sub-PR 3 of #841)", () =
     });
   });
 
+  test("local:agent form is a self-node alias and resolves local sessions", () => {
+    manifestEntries = [];
+    const r = resolveTarget("local:mawjs", BASE_CONFIG, SESSIONS);
+    expect(r).toEqual({ type: "self-node", target: "08-mawjs:1" });
+  });
+
+  test("local:agent miss reports self-node local miss, not unknown peer", () => {
+    manifestEntries = [];
+    const r = resolveTarget("local:ghost", BASE_CONFIG, SESSIONS);
+    expect(r).toMatchObject({
+      type: "error",
+      reason: "self_not_running",
+      detail: "'ghost' not found in local sessions on white",
+      hint: "maw wake ghost",
+    });
+  });
+
   // 9. Manifest loader throws → resolveTarget recovers, falls through.
   test("manifest load error swallowed → falls through to agents map", () => {
     loadManifestThrows = true;

--- a/test/isolated/send-idle-guard.test.ts
+++ b/test/isolated/send-idle-guard.test.ts
@@ -78,6 +78,7 @@ mock.module(join(import.meta.dir, "../../src/commands/shared/comm-log-feed"), ()
 
 // Bun.sleep intercept — replace globally so checkPaneIdle retry doesn't stall
 const origSleep = Bun.sleep.bind(Bun);
+const origClaudeAgentName = process.env.CLAUDE_AGENT_NAME;
 (Bun as unknown as { sleep: (ms: number) => Promise<void> }).sleep = async (ms: number) => {
   sleepCalls.push(ms);
 };
@@ -120,12 +121,15 @@ beforeEach(() => {
   resolveTargetReturn = { type: "local", target: "test-session:oracle.0" };
   delete process.env.MAW_QUIET;
   process.env.MAW_QUIET = "1"; // suppress tip output
+  process.env.CLAUDE_AGENT_NAME = "test-node";
 });
 
 afterEach(() => { mockActive = false; delete process.env.MAW_QUIET; });
 afterAll(() => {
   mockActive = false;
   (Bun as unknown as { sleep: typeof origSleep }).sleep = origSleep;
+  if (origClaudeAgentName === undefined) delete process.env.CLAUDE_AGENT_NAME;
+  else process.env.CLAUDE_AGENT_NAME = origClaudeAgentName;
 });
 
 // ─── checkPaneIdle tests ─────────────────────────────────────────────────────
@@ -202,7 +206,7 @@ describe("cmdSend — idle guard integration (#405)", () => {
     ];
     await run(() => cmdSend("test-node:oracle", "hello world"));
     expect(sendKeysCalls.length).toBe(1);
-    expect(sendKeysCalls[0].text).toBe("hello world");
+    expect(sendKeysCalls[0].text).toBe("[test-node:test-node] hello world");
     expect(exitCode).toBeUndefined();
   });
 
@@ -215,6 +219,7 @@ describe("cmdSend — idle guard integration (#405)", () => {
     await run(() => cmdSend("test-node:oracle", "hello after retry"));
     expect(sleepCalls).toContain(500);
     expect(sendKeysCalls.length).toBe(1);
+    expect(sendKeysCalls[0].text).toBe("[test-node:test-node] hello after retry");
     expect(exitCode).toBeUndefined();
   });
 
@@ -238,7 +243,7 @@ describe("cmdSend — idle guard integration (#405)", () => {
     ];
     await run(() => cmdSend("test-node:oracle", "forced message", /* force */ true));
     expect(sendKeysCalls.length).toBe(1);
-    expect(sendKeysCalls[0].text).toBe("forced message");
+    expect(sendKeysCalls[0].text).toBe("[test-node:test-node] forced message");
     expect(exitCode).toBeUndefined();
     // No 500ms sleep should have been triggered by idle check
     expect(sleepCalls.filter(ms => ms === 500).length).toBe(0);

--- a/test/isolated/tile.test.ts
+++ b/test/isolated/tile.test.ts
@@ -7,6 +7,7 @@
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { join } from "path";
+import { mkdirSync, rmSync } from "fs";
 
 let commands: string[] = [];
 let nextPane = 1;
@@ -58,6 +59,7 @@ beforeEach(() => {
   nextPane = 1;
   paneList = "";
   worktreeList = "";
+  rmSync("/tmp/maw-js.wt-1-tile-1", { recursive: true, force: true });
   process.env.TMUX_PANE = "%lead";
 });
 
@@ -153,6 +155,31 @@ describe("tile clean", () => {
     expect(commands).toContain("tmux kill-pane -t '%p3'");
     expect(commands).not.toContain("tmux kill-pane -t '%p2'");
     expect(commands).not.toContain("tmux kill-pane -t '%lead'");
+  });
+
+  test("removes tile worktrees and safely deletes matching tile branches", async () => {
+    mkdirSync("/tmp/maw-js.wt-1-tile-1", { recursive: true });
+    worktreeList = [
+      "worktree /tmp/maw-js",
+      "HEAD 1111111111111111111111111111111111111111",
+      "branch refs/heads/main",
+      "",
+      "worktree /tmp/maw-js.wt-1-tile-1",
+      "HEAD 2222222222222222222222222222222222222222",
+      "branch refs/heads/agents/1-tile-1",
+      "",
+      "worktree /tmp/maw-js.wt-2-task",
+      "HEAD 3333333333333333333333333333333333333333",
+      "branch refs/heads/agents/2-task",
+    ].join("\n");
+
+    await cmdTileClean();
+
+    expect(commands).toContain("git -C '/tmp/maw-js' worktree remove '/tmp/maw-js.wt-1-tile-1' --force 2>/dev/null");
+    expect(commands).toContain("git -C '/tmp/maw-js' branch -d 'agents/1-tile-1' 2>/dev/null");
+    expect(commands.some(cmd => cmd.includes("agents/2-task"))).toBe(false);
+
+    rmSync("/tmp/maw-js.wt-1-tile-1", { recursive: true, force: true });
   });
 });
 

--- a/test/isolated/tile.test.ts
+++ b/test/isolated/tile.test.ts
@@ -27,7 +27,7 @@ mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
   },
 }));
 
-const { cmdTile, cmdTileClean } = await import("../../src/commands/plugins/tile/impl");
+const { cmdTile, cmdTileClean, cmdTileSwap } = await import("../../src/commands/plugins/tile/impl");
 
 beforeEach(() => {
   commands = [];
@@ -95,5 +95,37 @@ describe("tile clean", () => {
     expect(commands).toContain("tmux kill-pane -t '%p1'");
     expect(commands).toContain("tmux kill-pane -t '%p2'");
     expect(commands).not.toContain("tmux kill-pane -t '%lead'");
+  });
+});
+
+describe("tile swap", () => {
+  beforeEach(() => {
+    paneList = [
+      "0|||%lead|||lead|||0",
+      "1|||%p1|||tile-1|||4",
+      "2|||%p2|||tile-2 🌳|||14",
+    ].join("\n");
+  });
+
+  test("swaps panes by current-window pane index", async () => {
+    await cmdTileSwap("1", "2");
+
+    expect(commands).toContain("tmux swap-pane -s '%p1' -t '%p2'");
+  });
+
+  test("swaps panes by tile title prefix", async () => {
+    await cmdTileSwap("tile-1", "tile-2");
+
+    expect(commands).toContain("tmux swap-pane -s '%p1' -t '%p2'");
+  });
+
+  test("swaps top and bottom panes by pane_top", async () => {
+    await cmdTileSwap("top", "bottom");
+
+    expect(commands).toContain("tmux swap-pane -s '%lead' -t '%p2'");
+  });
+
+  test("rejects unresolved pane targets", async () => {
+    await expect(cmdTileSwap("missing", "tile-2")).rejects.toThrow(/could not resolve pane 'missing'/);
   });
 });

--- a/test/isolated/tile.test.ts
+++ b/test/isolated/tile.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tile plugin tests — ISOLATED SUITE.
+ *
+ * Why isolated: tile shells through @maw-js/sdk/hostExec for tmux and git.
+ * Bun's mock.module is process-global, so this belongs under test/isolated
+ * rather than the main suite.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { join } from "path";
+
+let commands: string[] = [];
+let nextPane = 1;
+let paneList = "";
+let worktreeList = "";
+
+mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
+  hostExec: async (cmd: string): Promise<string> => {
+    commands.push(cmd);
+
+    if (cmd.includes("tmux display-message")) return "@win\n";
+    if (cmd.includes("tmux split-window")) return `%p${nextPane++}\n`;
+    if (cmd.includes("tmux list-panes")) return paneList;
+    if (cmd.includes("git rev-parse --show-toplevel")) return "/tmp/maw-js\n";
+    if (cmd.includes("git -C '/tmp/maw-js' worktree list")) return worktreeList;
+
+    return "";
+  },
+}));
+
+const { cmdTile, cmdTileClean } = await import("../../src/commands/plugins/tile/impl");
+
+beforeEach(() => {
+  commands = [];
+  nextPane = 1;
+  paneList = "";
+  worktreeList = "";
+  process.env.TMUX_PANE = "%lead";
+});
+
+describe("tile plugin layout", () => {
+  test("2-3 spawned tiles use main-vertical, leaving lead pane full-height on the left", async () => {
+    await cmdTile(2);
+
+    expect(commands).toContain("tmux split-window -t '%lead' -h -P -F '#{pane_id}' 'exec zsh'");
+    expect(commands).toContain("tmux split-window -t '%p1' -h -P -F '#{pane_id}' 'exec zsh'");
+    expect(commands).toContain("tmux select-layout -t '@win' main-vertical");
+    expect(commands).not.toContain("tmux select-layout -t '@win' tiled");
+  });
+
+  test("one spawned tile keeps the simple side-by-side split", async () => {
+    await cmdTile(1);
+
+    expect(commands).toContain("tmux select-layout -t '@win' even-horizontal");
+    expect(commands).not.toContain("tmux select-layout -t '@win' main-vertical");
+  });
+
+  test("four or more spawned tiles use the tiled grid", async () => {
+    await cmdTile(4);
+
+    expect(commands).toContain("tmux select-layout -t '@win' tiled");
+    expect(commands).not.toContain("tmux select-layout -t '@win' main-vertical");
+  });
+});
+
+describe("tile clean", () => {
+  test("kills every non-lead pane in the current window without trusting pane titles", async () => {
+    paneList = [
+      "%lead leader-title",
+      "%p1 overwritten-by-agent",
+      "%p2 zsh",
+    ].join("\n");
+
+    await cmdTileClean();
+
+    expect(commands).toContain("tmux kill-pane -t '%p1'");
+    expect(commands).toContain("tmux kill-pane -t '%p2'");
+    expect(commands).not.toContain("tmux kill-pane -t '%lead'");
+  });
+});

--- a/test/isolated/tile.test.ts
+++ b/test/isolated/tile.test.ts
@@ -13,13 +13,37 @@ let nextPane = 1;
 let paneList = "";
 let worktreeList = "";
 
+function generatedPaneIds(): string[] {
+  return Array.from({ length: nextPane - 1 }, (_, i) => `%p${i + 1}`);
+}
+
+function paneIdsFromPaneList(): string[] {
+  return paneList.split("\n")
+    .filter(Boolean)
+    .map(line => {
+      const parts = line.split("|||");
+      if (parts[0]?.startsWith("%")) return parts[0];
+      if (parts[1]?.startsWith("%")) return parts[1];
+      return line.split(" ")[0];
+    })
+    .filter(Boolean);
+}
+
 mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
   hostExec: async (cmd: string): Promise<string> => {
     commands.push(cmd);
 
+    if (cmd.includes("#{session_name}:#{window_index}.#{pane_index}")) return "sess:1.0\n";
+    if (cmd.includes("#{session_name}:#{window_index}")) return "sess:1\n";
     if (cmd.includes("tmux display-message")) return "@win\n";
     if (cmd.includes("tmux split-window")) return `%p${nextPane++}\n`;
-    if (cmd.includes("tmux list-panes")) return paneList;
+    if (cmd.includes("tmux list-panes") && cmd.includes("|||")) {
+      return paneList || "%lead|||lead|||\n";
+    }
+    if (cmd.includes("tmux list-panes") && cmd.includes("#{pane_id}")) {
+      const ids = paneIdsFromPaneList();
+      return [...(ids.length ? ids : ["%lead"]), ...generatedPaneIds()].join("\n") + "\n";
+    }
     if (cmd.includes("git rev-parse --show-toplevel")) return "/tmp/maw-js\n";
     if (cmd.includes("git -C '/tmp/maw-js' worktree list")) return worktreeList;
 
@@ -38,33 +62,43 @@ beforeEach(() => {
 });
 
 describe("tile plugin layout", () => {
-  test("2-3 spawned tiles use main-vertical, leaving lead pane full-height on the left", async () => {
+  test("2-3 total spawned tiles use main-vertical, leaving lead pane full-height on the left", async () => {
     await cmdTile(2);
 
-    expect(commands).toContain("tmux split-window -t '%lead' -h -P -F '#{pane_id}' 'exec zsh'");
-    expect(commands).toContain("tmux split-window -t '%p1' -h -P -F '#{pane_id}' 'exec zsh'");
+    const splitCommands = commands.filter(cmd => cmd.includes("tmux split-window"));
+    expect(splitCommands[0]).toContain("MAW_TILE_PARENT='");
+    expect(splitCommands[0]).toContain("MAW_TILE_ROLE='\\''tile-1'\\''");
+    expect(splitCommands[0]).toContain("MAW_TILE_TOTAL='\\''2'\\''");
+    expect(splitCommands[1]).toContain("MAW_TILE_ROLE='\\''tile-2'\\''");
     expect(commands).toContain("tmux select-layout -t '@win' main-vertical");
     expect(commands).not.toContain("tmux select-layout -t '@win' tiled");
   });
 
-  test("one spawned tile keeps the simple side-by-side split", async () => {
+  test("one spawned tile keeps the simple side-by-side split when it creates two total panes", async () => {
     await cmdTile(1);
 
     expect(commands).toContain("tmux select-layout -t '@win' even-horizontal");
     expect(commands).not.toContain("tmux select-layout -t '@win' main-vertical");
   });
 
-  test("incremental tile spawn chooses layout from total panes, not new spawn count", async () => {
-    paneList = "4\n";
+  test("incremental spawn selects layout from total panes after spawn, not the requested spawn count", async () => {
+    paneList = [
+      "%lead|||lead|||",
+      "%p-existing-1|||tile-1|||1",
+      "%p-existing-2|||tile-2|||1",
+    ].join("\n");
 
     await cmdTile(1);
 
-    expect(commands).toContain("tmux list-panes -t '@win' | wc -l");
+    const splitCommand = commands.find(cmd => cmd.includes("tmux split-window"));
+    expect(splitCommand).toContain("MAW_TILE_ROLE='\\''tile-3'\\''");
+    expect(splitCommand).toContain("MAW_TILE_INDEX='\\''3'\\''");
+    expect(splitCommand).toContain("MAW_TILE_TOTAL='\\''3'\\''");
     expect(commands).toContain("tmux select-layout -t '@win' main-vertical");
     expect(commands).not.toContain("tmux select-layout -t '@win' even-horizontal");
   });
 
-  test("four or more spawned tiles use the tiled grid", async () => {
+  test("five or more total panes use the tiled grid", async () => {
     await cmdTile(4);
 
     expect(commands).toContain("tmux select-layout -t '@win' tiled");
@@ -72,7 +106,12 @@ describe("tile plugin layout", () => {
   });
 
   test("incremental tile spawn switches to tiled grid once total pane count exceeds four", async () => {
-    paneList = "5\n";
+    paneList = [
+      "%lead|||lead|||",
+      "%p-existing-1|||tile-1|||1",
+      "%p-existing-2|||tile-2|||1",
+      "%p-existing-3|||tile-3|||1",
+    ].join("\n");
 
     await cmdTile(1);
 
@@ -82,18 +121,37 @@ describe("tile plugin layout", () => {
   });
 });
 
+describe("tile plugin spawn metadata", () => {
+  test("passes parent/window identity and tile role env to engine commands", async () => {
+    await cmdTile(1, { engine: "claude" });
+
+    const splitCommand = commands.find(cmd => cmd.includes("tmux split-window"));
+    expect(splitCommand).toContain("MAW_TILE_PARENT='\\''sess:1.0'\\''");
+    expect(splitCommand).toContain("MAW_TILE_ROLE='\\''tile-1'\\''");
+    expect(splitCommand).toContain("MAW_TILE_INDEX='\\''1'\\''");
+    expect(splitCommand).toContain("MAW_TILE_TOTAL='\\''1'\\''");
+    expect(splitCommand).toContain("MAW_TILE_WINDOW='\\''sess:1'\\''");
+    expect(splitCommand).toContain("; claude; exec zsh");
+    expect(commands).toContain("tmux set-option -p -t '%p1' @maw_tile '1'");
+    expect(commands).toContain("tmux set-option -p -t '%p1' @maw_tile_parent 'sess:1.0'");
+    expect(commands).toContain("tmux set-option -p -t '%p1' @maw_tile_role 'tile-1'");
+  });
+});
+
 describe("tile clean", () => {
-  test("kills every non-lead pane in the current window without trusting pane titles", async () => {
+  test("kills only panes marked or titled as tile panes in the current window", async () => {
     paneList = [
-      "%lead leader-title",
-      "%p1 overwritten-by-agent",
-      "%p2 zsh",
+      "%lead|||leader-title|||",
+      "%p1|||tile-1|||1",
+      "%p2|||zsh|||",
+      "%p3|||tile-3 🌳|||",
     ].join("\n");
 
     await cmdTileClean();
 
     expect(commands).toContain("tmux kill-pane -t '%p1'");
-    expect(commands).toContain("tmux kill-pane -t '%p2'");
+    expect(commands).toContain("tmux kill-pane -t '%p3'");
+    expect(commands).not.toContain("tmux kill-pane -t '%p2'");
     expect(commands).not.toContain("tmux kill-pane -t '%lead'");
   });
 });

--- a/test/isolated/tile.test.ts
+++ b/test/isolated/tile.test.ts
@@ -54,10 +54,30 @@ describe("tile plugin layout", () => {
     expect(commands).not.toContain("tmux select-layout -t '@win' main-vertical");
   });
 
+  test("incremental tile spawn chooses layout from total panes, not new spawn count", async () => {
+    paneList = "4\n";
+
+    await cmdTile(1);
+
+    expect(commands).toContain("tmux list-panes -t '@win' | wc -l");
+    expect(commands).toContain("tmux select-layout -t '@win' main-vertical");
+    expect(commands).not.toContain("tmux select-layout -t '@win' even-horizontal");
+  });
+
   test("four or more spawned tiles use the tiled grid", async () => {
     await cmdTile(4);
 
     expect(commands).toContain("tmux select-layout -t '@win' tiled");
+    expect(commands).not.toContain("tmux select-layout -t '@win' main-vertical");
+  });
+
+  test("incremental tile spawn switches to tiled grid once total pane count exceeds four", async () => {
+    paneList = "5\n";
+
+    await cmdTile(1);
+
+    expect(commands).toContain("tmux select-layout -t '@win' tiled");
+    expect(commands).not.toContain("tmux select-layout -t '@win' even-horizontal");
     expect(commands).not.toContain("tmux select-layout -t '@win' main-vertical");
   });
 });

--- a/test/isolated/tmux-action-verbs.test.ts
+++ b/test/isolated/tmux-action-verbs.test.ts
@@ -6,6 +6,27 @@ import { join } from "path";
 
 const implSrc = readFileSync(join(import.meta.dir, "../../src/commands/plugins/tmux/impl.ts"), "utf-8");
 
+const encode = (text: string) => new TextEncoder().encode(text);
+const spawnOk = (stdout = "") => ({
+  exitCode: 0,
+  stdout: encode(stdout),
+  stderr: new Uint8Array(),
+  success: true,
+});
+
+function mockTmuxSessions(aliveSessions: string[], calls: any[] = [], fallback = () => spawnOk()) {
+  const origSpawnSync = Bun.spawnSync;
+  (Bun as any).spawnSync = ((args: any, opts: any) => {
+    if (Array.isArray(args) && args[0] === "tmux" && args[1] === "list-sessions") {
+      return spawnOk(aliveSessions.length ? `${aliveSessions.join("\n")}\n` : "");
+    }
+    calls.push({ args, opts });
+    return fallback();
+  }) as any;
+  return () => { (Bun as any).spawnSync = origSpawnSync; };
+}
+
+
 // Pure-validation tests for split, kill, layout, attach. These verbs call
 // hostExec under the hood — we test the input-validation paths that throw
 // BEFORE any tmux interaction. Live behavior was smoke-tested in iter 9.
@@ -51,18 +72,14 @@ describe("cmdTmuxAttach — print fallback (no TTY / --print)", () => {
     const origLog = console.log;
     console.log = (...a: any[]) => logs.push(a.map(String).join(" "));
     const calls: any[] = [];
-    const origSpawnSync = Bun.spawnSync;
-    (Bun as any).spawnSync = ((args: any, opts: any) => {
-      calls.push({ args, opts });
-      return { exitCode: 0, stdout: new Uint8Array(), stderr: new Uint8Array(), success: true };
-    });
+    const restoreSpawn = mockTmuxSessions(["%999"], calls);
     try {
       cmdTmuxAttach("%999", { print: true });
     } finally {
       console.log = origLog;
-      (Bun as any).spawnSync = origSpawnSync;
+      restoreSpawn();
     }
-    expect(calls).toHaveLength(0); // --print → never spawns
+    expect(calls).toHaveLength(0); // --print → never spawns attach/switch
     const joined = logs.join("\n");
     expect(joined).toContain("tmux attach -t");
     expect(joined).toContain("Ctrl-b d");
@@ -72,10 +89,12 @@ describe("cmdTmuxAttach — print fallback (no TTY / --print)", () => {
     const logs: string[] = [];
     const origLog = console.log;
     console.log = (...a: any[]) => logs.push(a.map(String).join(" "));
+    const restoreSpawn = mockTmuxSessions(["some-session"]);
     try {
       cmdTmuxAttach("some-session:0.1", { print: true });
     } finally {
       console.log = origLog;
+      restoreSpawn();
     }
     expect(logs.join("\n")).toContain("tmux attach -t some-session");
   });
@@ -89,11 +108,7 @@ describe("cmdTmuxAttach — print fallback (no TTY / --print)", () => {
     delete process.env.TMUX;
 
     const calls: any[] = [];
-    const origSpawnSync = Bun.spawnSync;
-    (Bun as any).spawnSync = ((args: any, opts: any) => {
-      calls.push({ args, opts });
-      return { exitCode: 0, stdout: new Uint8Array(), stderr: new Uint8Array(), success: true };
-    });
+    const restoreSpawn = mockTmuxSessions(["%999"], calls);
 
     const logs: string[] = [];
     const origLog = console.log;
@@ -102,12 +117,12 @@ describe("cmdTmuxAttach — print fallback (no TTY / --print)", () => {
       cmdTmuxAttach("%999"); // no opts → relies on TTY/$TMUX detection
     } finally {
       console.log = origLog;
-      (Bun as any).spawnSync = origSpawnSync;
+      restoreSpawn();
       Object.defineProperty(process.stdout, "isTTY", { value: origIsTty, configurable: true });
       if (origTmux !== undefined) process.env.TMUX = origTmux;
     }
 
-    expect(calls).toHaveLength(0); // no TTY → never spawns
+    expect(calls).toHaveLength(0); // no TTY → never spawns attach/switch
     const joined = logs.join("\n");
     expect(joined).toContain("tmux attach -t");
     expect(joined).toContain("Ctrl-b d");
@@ -122,11 +137,7 @@ describe("cmdTmuxAttach — TTY exec branches", () => {
     process.env.TMUX = "/tmp/tmux-1000/default,1234,0";
 
     const calls: any[] = [];
-    const origSpawnSync = Bun.spawnSync;
-    (Bun as any).spawnSync = ((args: any, opts: any) => {
-      calls.push({ args, opts });
-      return { exitCode: 0, stdout: new Uint8Array(), stderr: new Uint8Array(), success: true };
-    });
+    const restoreSpawn = mockTmuxSessions(["some-session"], calls);
 
     const logs: string[] = [];
     const origLog = console.log;
@@ -135,7 +146,7 @@ describe("cmdTmuxAttach — TTY exec branches", () => {
       cmdTmuxAttach("some-session:0.1");
     } finally {
       console.log = origLog;
-      (Bun as any).spawnSync = origSpawnSync;
+      restoreSpawn();
       impl._tty.isStdoutTTY = origTTY;
       if (origTmux !== undefined) process.env.TMUX = origTmux;
       else delete process.env.TMUX;
@@ -153,16 +164,12 @@ describe("cmdTmuxAttach — TTY exec branches", () => {
     delete process.env.TMUX;
 
     const calls: any[] = [];
-    const origSpawnSync = Bun.spawnSync;
-    (Bun as any).spawnSync = ((args: any, opts: any) => {
-      calls.push({ args, opts });
-      return { exitCode: 0, stdout: new Uint8Array(), stderr: new Uint8Array(), success: true };
-    });
+    const restoreSpawn = mockTmuxSessions(["some-session"], calls);
 
     try {
       cmdTmuxAttach("some-session:0.1");
     } finally {
-      (Bun as any).spawnSync = origSpawnSync;
+      restoreSpawn();
       impl._tty.isStdoutTTY = origTTY;
       if (origTmux !== undefined) process.env.TMUX = origTmux;
     }
@@ -171,24 +178,28 @@ describe("cmdTmuxAttach — TTY exec branches", () => {
     expect(calls[0].args).toEqual(["tmux", "attach", "-t", "some-session"]);
   });
 
-  test("non-zero exit → throws with exit code + verb", () => {
+  test("dead resolved session → prints recovery and exits non-zero", () => {
     const origTTY = impl._tty.isStdoutTTY;
     impl._tty.isStdoutTTY = () => true;
     const origTmux = process.env.TMUX;
     delete process.env.TMUX;
 
-    const origSpawnSync = Bun.spawnSync;
-    (Bun as any).spawnSync = (() => ({
-      exitCode: 1,
-      stdout: new Uint8Array(),
-      stderr: new Uint8Array(),
-      success: false,
-    }));
+    const restoreSpawn = mockTmuxSessions([]);
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...a: any[]) => logs.push(a.map(String).join(" "));
+    const origExit = process.exit;
+    (process as any).exit = ((code?: number) => {
+      throw new Error(`process.exit:${code ?? 0}`);
+    }) as any;
 
     try {
-      expect(() => cmdTmuxAttach("ghost-session")).toThrow(/tmux attach failed.*exit 1/);
+      expect(() => cmdTmuxAttach("ghost-session")).toThrow(/process\.exit:1/);
+      expect(logs.join("\n")).toContain("No session matches 'ghost-session'");
     } finally {
-      (Bun as any).spawnSync = origSpawnSync;
+      console.log = origLog;
+      (process as any).exit = origExit;
+      restoreSpawn();
       impl._tty.isStdoutTTY = origTTY;
       if (origTmux !== undefined) process.env.TMUX = origTmux;
     }
@@ -201,11 +212,7 @@ describe("cmdTmuxAttach — TTY exec branches", () => {
     delete process.env.TMUX;
 
     const calls: any[] = [];
-    const origSpawnSync = Bun.spawnSync;
-    (Bun as any).spawnSync = ((args: any, opts: any) => {
-      calls.push({ args, opts });
-      return { exitCode: 0, stdout: new Uint8Array(), stderr: new Uint8Array(), success: true };
-    });
+    const restoreSpawn = mockTmuxSessions(["%999"], calls);
 
     const logs: string[] = [];
     const origLog = console.log;
@@ -214,7 +221,7 @@ describe("cmdTmuxAttach — TTY exec branches", () => {
       cmdTmuxAttach("%999", { print: true });
     } finally {
       console.log = origLog;
-      (Bun as any).spawnSync = origSpawnSync;
+      restoreSpawn();
       impl._tty.isStdoutTTY = origTTY;
       if (origTmux !== undefined) process.env.TMUX = origTmux;
     }

--- a/test/isolated/tmux-peek.test.ts
+++ b/test/isolated/tmux-peek.test.ts
@@ -56,20 +56,21 @@ describe("resolveTmuxTarget — target resolution", () => {
   test("team-agent with empty tmuxPaneId falls through to session-name fallback", async () => {
     const { resolveTmuxTarget } = await import("../../src/commands/plugins/tmux/impl");
     const hit = resolveTmuxTarget("orphan-agent");
-    // orphan-agent has tmuxPaneId="" — skipped as not-live, falls to session fallback
-    expect(hit?.resolved).toBe("orphan-agent:0");
+    // orphan-agent has tmuxPaneId="" — skipped as not-live, falls to session fallback.
+    // Since #1012 the resolver lets tmux choose the pane for a bare session target
+    // instead of hardcoding :0.
+    expect(hit?.resolved).toBe("orphan-agent");
     expect(hit?.source).toContain("session-name");
   });
 
-  test("bare session name → session:0 (via fleet-stem OR session-name fallback)", async () => {
+  test("bare session name resolves without hardcoded :0 (fleet/live/session fallback)", async () => {
     const { resolveTmuxTarget } = await import("../../src/commands/plugins/tmux/impl");
     const hit = resolveTmuxTarget("112-fusion");
-    expect(hit?.resolved).toBe("112-fusion:0");
-    // After #394 Bug I fix: this now resolves via the fleet-stem tier first
-    // (since 112-fusion IS a fleet session). Falls back to session-name only
-    // for non-fleet stems. Either tier is acceptable — both produce correct
-    // pane-0 resolution.
-    expect(["fleet-stem", "session-name"].some(tag => hit!.source.includes(tag))).toBe(true);
+    expect(hit?.resolved).toBe("112-fusion");
+    // After #394 Bug I / #1058 fixes, this may resolve via fleet, live-session,
+    // or final session-name fallback depending on the runner environment. All
+    // tiers intentionally preserve the bare session target.
+    expect(["fleet-stem", "live-session", "session-name"].some(tag => hit!.source.includes(tag))).toBe(true);
   });
 
   test("target resolution is deterministic — same input, same output", async () => {
@@ -81,12 +82,12 @@ describe("resolveTmuxTarget — target resolution", () => {
 
   test("unknown name that looks like session produces fallback (no false-positive match)", async () => {
     const { resolveTmuxTarget } = await import("../../src/commands/plugins/tmux/impl");
-    // Not a team-agent name (not in any config), not a pane-id pattern — fallback to session.
-    // Note: may still hit fleet-stem tier if "zzz-nonexistent" word-matches a fleet name.
-    // This test isn't isolated from the real fleet dir; just verify we get SOME resolution.
+    // Not a team-agent name (not in any config), not a pane-id pattern — fallback to
+    // a bare session target. #1012 intentionally stopped hardcoding :0 here.
     const hit = resolveTmuxTarget("zzz-nonexistent-xyzzy");
     expect(hit).not.toBeNull();
-    expect(hit?.resolved).toContain(":");
+    expect(hit?.resolved).toBe("zzz-nonexistent-xyzzy");
+    expect(hit?.source).toContain("session-name");
   });
 });
 
@@ -101,10 +102,10 @@ describe("resolveTmuxTarget — fleet stem tier (#394 Bug I)", () => {
     // This name won't match any fleet session but WILL match the final fallback.
     const hit = resolveTmuxTarget("definitely-not-a-real-fleet-oracle-xyzzy");
     expect(hit).not.toBeNull();
-    // Either fleet-stem (if fuzzy-matched) or session-name — both valid,
-    // both include a :N suffix meaning "pane 0 of that session".
-    expect(hit!.resolved).toMatch(/:\d+$/);
-    expect(["fleet-stem", "session-name"].some(tag => hit!.source.includes(tag))).toBe(true);
+    // Since #1012 the fallback preserves the bare session target and lets tmux
+    // choose the pane rather than forcing :0.
+    expect(hit!.resolved).toBe("definitely-not-a-real-fleet-oracle-xyzzy");
+    expect(["fleet-stem", "live-session", "session-name"].some(tag => hit!.source.includes(tag))).toBe(true);
   });
 
   test("source label for bare-name resolution mentions the tier used", async () => {

--- a/test/isolated/update-stash-restore.test.ts
+++ b/test/isolated/update-stash-restore.test.ts
@@ -109,17 +109,23 @@ describe("cmd-update stash+restore — source invariants (#551)", () => {
     );
   });
 
-  // ── Case 5: retry success → stash cleaned up ──────────────────────────
-  it("case 5 — retry success (installCode === 0) unlinks STASH", () => {
+  // ── Case 5: retry success → stash cleaned up only AFTER verify ────────
+  it("case 5 — retry success unlinks STASH only after the fresh binary verifies", () => {
+    // Restructured (crash-loop fix): the success branch is now `else { ... }`,
+    // and the stash is discarded only inside the `freshOk` (verified-working)
+    // sub-branch — never rotate away the old binary until the new one runs.
     expect(cmdUpdateSrc).toMatch(
-      /else if\s*\(\s*installCode\s*===\s*0\s*&&\s*stashed\s*&&\s*existsSync\(STASH\)\s*\)\s*\{[\s\S]*?unlinkSync\(STASH\)/,
+      /const\s+freshOk\s*=\s*\(await\s+verify\.exited\)\s*===\s*0\s*;[\s\S]*?else\s*\{[\s\S]*?unlinkSync\(STASH\)/,
     );
   });
 
-  // ── Case 6: retry fails → restore + warn ──────────────────────────────
-  it("case 6 — retry failure restores STASH → BIN and warns", () => {
+  // ── Case 6: retry fails → restore pkg dir + bin, warn ─────────────────
+  it("case 6 — retry failure restores the package dir then STASH → BIN and warns", () => {
+    // Restructured (crash-loop fix): guard is now plain `if (installCode !== 0)`;
+    // restorePkgStash() runs FIRST so the stashed bin symlink resolves again,
+    // THEN the bin is moved back.
     expect(cmdUpdateSrc).toMatch(
-      /if\s*\(\s*installCode\s*!==\s*0\s*&&\s*stashed\s*&&\s*existsSync\(STASH\)\s*\)\s*\{[\s\S]*?renameSync\(STASH\s*,\s*BIN\)/,
+      /if\s*\(\s*installCode\s*!==\s*0\s*\)\s*\{[\s\S]*?restorePkgStash\(\)\s*;[\s\S]*?renameSync\(STASH\s*,\s*BIN\)/,
     );
     expect(cmdUpdateSrc).toContain("restored previous maw binary from stash");
   });
@@ -128,6 +134,29 @@ describe("cmd-update stash+restore — source invariants (#551)", () => {
     // If the restore rename itself throws, we still surface the error so the user
     // knows manual recovery is needed.
     expect(cmdUpdateSrc).toMatch(/failed to restore stash/);
+  });
+
+  // ── Case 8: maw-js package dir is stashed by RENAME, not rm ───────────
+  it("case 8 — maw-js node_modules dir is stashed by rename (recoverable), not rm'd", () => {
+    // The crash-loop root cause: rm'ing node_modules/maw-js orphaned the
+    // stashed bin symlink, so existsSync(STASH) reported false and the
+    // restore silently no-op'd — leaving NO working maw. Now the dir is
+    // moved aside by rename so the restore path can put a *working* install
+    // back (bin symlink + the package it resolves through).
+    expect(cmdUpdateSrc).toMatch(
+      /renameSync\(join\(NM,\s*"maw-js"\),\s*PKG_STASH\)\s*;\s*pkgStashed\s*=\s*true/,
+    );
+    // maw-js must NOT be in the outright-rm loop anymore
+    expect(cmdUpdateSrc).not.toMatch(/for \(const name of \["maw-js",/);
+  });
+
+  // ── Case 9: verify-before-discard — rollback on broken "success" ──────
+  it("case 9 — a 'successful' install whose binary does not run is rolled back", () => {
+    // installCode === 0 is necessary but not sufficient: if `maw --version`
+    // does not exit 0, restore the stash and fall into the error path.
+    expect(cmdUpdateSrc).toMatch(
+      /if\s*\(\s*!freshOk\s*\)\s*\{[\s\S]*?restorePkgStash\(\)[\s\S]*?installCode\s*=\s*1\s*;/,
+    );
   });
 
   // ── Case 7: rename throws → best-effort, doesn't block retry ──────────

--- a/test/isolated/wake-concurrency.test.ts
+++ b/test/isolated/wake-concurrency.test.ts
@@ -1,0 +1,122 @@
+/**
+ * wake-concurrency.test.ts — regression for maw-stress finding #2.
+ *
+ * `cmdWake` had no count / queue / cap — nothing stopped a script or a
+ * runaway orchestrator from spawning agents until the box fell over.
+ * `src/commands/shared/wake-concurrency.ts` adds an opt-in cap
+ * (`limits.maxConcurrentAgents`); `cmdWake` calls `assertAgentCapacity`
+ * before every net-new spawn.
+ *
+ * Isolated: installs the tmux mock + a config mock (both mock.module, which
+ * is process-global). Pure decision logic (`checkCapacity`) is also pinned
+ * here — it needs no mocks but lives with its siblings.
+ */
+import { describe, test, expect, beforeAll, afterEach, mock } from "bun:test";
+import { join } from "path";
+import { installTmuxMock, setPanes, getCapturedCommands, resetMocks } from "../helpers/mock-tmux";
+
+const root = join(import.meta.dir, "../..");
+
+// Controllable cap value — assertAgentCapacity reads it via cfgLimit().
+let capValue = 0;
+
+// tmux mock first, then config mock — both mock.module, registered before the
+// dynamic import in beforeAll so wake-concurrency.ts resolves to the shims.
+installTmuxMock({ sessions: [] });
+
+mock.module(join(root, "src/config"), () => {
+  const { mockConfigModule } = require("../helpers/mock-config");
+  const base = mockConfigModule(() => ({ node: "test-node", commands: {} }));
+  return {
+    ...base,
+    cfgLimit: (k: string) =>
+      k === "maxConcurrentAgents" ? capValue : base.cfgLimit(k),
+  };
+});
+
+let checkCapacity: typeof import("../../src/commands/shared/wake-concurrency").checkCapacity;
+let countLiveAgents: typeof import("../../src/commands/shared/wake-concurrency").countLiveAgents;
+let assertAgentCapacity: typeof import("../../src/commands/shared/wake-concurrency").assertAgentCapacity;
+
+beforeAll(async () => {
+  const mod = await import("../../src/commands/shared/wake-concurrency");
+  checkCapacity = mod.checkCapacity;
+  countLiveAgents = mod.countLiveAgents;
+  assertAgentCapacity = mod.assertAgentCapacity;
+});
+
+afterEach(() => {
+  resetMocks();
+  capValue = 0;
+});
+
+describe("checkCapacity — pure cap decision (#2)", () => {
+  test("cap 0 / negative → disabled, never throws", () => {
+    expect(() => checkCapacity(999, 0, "x")).not.toThrow();
+    expect(() => checkCapacity(999, -1, "x")).not.toThrow();
+  });
+
+  test("under cap → no throw", () => {
+    expect(() => checkCapacity(3, 5, "neo")).not.toThrow();
+  });
+
+  test("at cap → throws (over-cap path)", () => {
+    expect(() => checkCapacity(5, 5, "neo")).toThrow(/5\/5/);
+    expect(() => checkCapacity(5, 5, "neo")).toThrow(/refusing to spawn 'neo'/);
+  });
+
+  test("over cap → throws", () => {
+    expect(() => checkCapacity(8, 5, "pulse")).toThrow(/8\/5/);
+  });
+
+  test("error message is actionable — names the config knob", () => {
+    expect(() => checkCapacity(5, 5, "neo")).toThrow(/maxConcurrentAgents/);
+  });
+});
+
+describe("countLiveAgents — counts agent panes across the fleet", () => {
+  test("counts only agent-process panes (claude / node), ignores shells", async () => {
+    setPanes([
+      { command: "claude" },
+      { command: "node" },
+      { command: "zsh" },
+      { command: "bash" },
+      { command: "claude" },
+    ]);
+    expect(await countLiveAgents()).toBe(3);
+  });
+
+  test("no panes → 0", async () => {
+    setPanes([]);
+    expect(await countLiveAgents()).toBe(0);
+  });
+});
+
+describe("assertAgentCapacity — the guard cmdWake calls before spawning", () => {
+  test("disabled (cap 0) → no throw, and does NOT even query tmux", async () => {
+    capValue = 0;
+    setPanes([{ command: "claude" }, { command: "claude" }, { command: "claude" }]);
+    await assertAgentCapacity("neo");
+    // fast-path: disabled cap must skip the list-panes call entirely
+    expect(getCapturedCommands().some(c => c.includes("list-panes"))).toBe(false);
+  });
+
+  test("under cap → resolves", async () => {
+    capValue = 5;
+    setPanes([{ command: "claude" }, { command: "node" }]);
+    await assertAgentCapacity("neo");
+    expect(getCapturedCommands().some(c => c.includes("list-panes"))).toBe(true);
+  });
+
+  test("at/over cap → rejects loudly", async () => {
+    capValue = 2;
+    setPanes([{ command: "claude" }, { command: "claude" }, { command: "node" }]);
+    await expect(assertAgentCapacity("neo")).rejects.toThrow(/concurrency cap reached: 3\/2/);
+  });
+
+  test("exactly at cap → rejects (cap is inclusive)", async () => {
+    capValue = 2;
+    setPanes([{ command: "claude" }, { command: "claude" }]);
+    await expect(assertAgentCapacity("pulse")).rejects.toThrow(/2\/2/);
+  });
+});

--- a/test/isolated/wake-maybe-split.test.ts
+++ b/test/isolated/wake-maybe-split.test.ts
@@ -1,0 +1,57 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { join } from "path";
+
+let hostExecCalls: string[] = [];
+
+mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
+  hostExec: async (cmd: string) => {
+    hostExecCalls.push(cmd);
+    return "";
+  },
+}));
+
+const { maybeSplit } = await import("../../src/commands/shared/wake-maybe-split");
+
+describe("wake maybeSplit", () => {
+  const originalTmux = process.env.TMUX;
+  const originalPane = process.env.TMUX_PANE;
+
+  beforeEach(() => {
+    hostExecCalls = [];
+    process.env.TMUX = "/tmp/tmux-501/default,123,0";
+    process.env.TMUX_PANE = "%42";
+  });
+
+  test("does nothing when split is not requested", async () => {
+    await maybeSplit("20-homekeeper:homekeeper-oracle", {});
+    expect(hostExecCalls).toEqual([]);
+  });
+
+  test("splits current pane and attaches target without importing removed split plugin", async () => {
+    await maybeSplit("20-homekeeper:homekeeper-oracle", { split: true });
+
+    expect(hostExecCalls).toHaveLength(1);
+    expect(hostExecCalls[0]).toContain("tmux split-window");
+    expect(hostExecCalls[0]).toContain("-t '%42'");
+    expect(hostExecCalls[0]).toContain("-h -l 50%");
+    expect(hostExecCalls[0]).toContain("TMUX= tmux attach-session -t");
+    expect(hostExecCalls[0]).toContain("20-homekeeper:homekeeper-oracle");
+  });
+
+  test("can split without TMUX_PANE by omitting anchor", async () => {
+    delete process.env.TMUX_PANE;
+
+    await maybeSplit("20-homekeeper:homekeeper-oracle", { split: true });
+
+    expect(hostExecCalls).toHaveLength(1);
+    expect(hostExecCalls[0]).not.toContain("-t '%");
+    expect(hostExecCalls[0]).toContain("tmux split-window -h -l 50%");
+  });
+
+  afterAll(() => {
+    if (originalTmux === undefined) delete process.env.TMUX;
+    else process.env.TMUX = originalTmux;
+    if (originalPane === undefined) delete process.env.TMUX_PANE;
+    else process.env.TMUX_PANE = originalPane;
+  });
+});

--- a/test/isolated/wake-maybe-split.test.ts
+++ b/test/isolated/wake-maybe-split.test.ts
@@ -3,10 +3,12 @@ import { join } from "path";
 
 let hostExecCalls: string[] = [];
 let listPanesResponse = "3\n";
+let tileMarkerResponse = "";
 
 mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
   hostExec: async (cmd: string) => {
     hostExecCalls.push(cmd);
+    if (cmd.includes("show-options") && cmd.includes("@maw_tile")) return tileMarkerResponse;
     if (cmd.includes("list-panes")) return listPanesResponse;
     return "";
   },
@@ -21,6 +23,7 @@ describe("wake maybeSplit", () => {
   beforeEach(() => {
     hostExecCalls = [];
     listPanesResponse = "3\n";
+    tileMarkerResponse = "";
     process.env.TMUX = "/tmp/tmux-501/default,123,0";
     process.env.TMUX_PANE = "%42";
   });
@@ -33,14 +36,28 @@ describe("wake maybeSplit", () => {
   test("splits current pane and attaches target without importing removed split plugin", async () => {
     await maybeSplit("20-homekeeper:homekeeper-oracle", { split: true });
 
-    expect(hostExecCalls).toHaveLength(3);
+    expect(hostExecCalls).toHaveLength(4);
     expect(hostExecCalls[0]).toContain("tmux split-window");
     expect(hostExecCalls[0]).toContain("-t '%42'");
     expect(hostExecCalls[0]).toContain("-h -l 50%");
     expect(hostExecCalls[0]).toContain("TMUX= tmux attach-session -t");
     expect(hostExecCalls[0]).toContain("20-homekeeper:homekeeper-oracle");
-    expect(hostExecCalls[1]).toContain("tmux list-panes -t '%42'");
-    expect(hostExecCalls[2]).toContain("tmux select-layout -t '%42' main-vertical");
+    expect(hostExecCalls[1]).toContain("tmux show-options -p -t '%42' -v @maw_tile");
+    expect(hostExecCalls[2]).toContain("tmux list-panes -t '%42'");
+    expect(hostExecCalls[3]).toContain("tmux select-layout -t '%42' main-vertical");
+  });
+
+  test("preserves horizontal split when splitting from a maw tile pane", async () => {
+    tileMarkerResponse = "1\n";
+
+    await maybeSplit("20-homekeeper:homekeeper-oracle", { split: true });
+
+    expect(hostExecCalls).toHaveLength(2);
+    expect(hostExecCalls[0]).toContain("tmux split-window");
+    expect(hostExecCalls[0]).toContain("-t '%42'");
+    expect(hostExecCalls[0]).toContain("-h -l 50%");
+    expect(hostExecCalls[1]).toContain("tmux show-options -p -t '%42' -v @maw_tile");
+    expect(hostExecCalls.some(cmd => cmd.includes("tmux select-layout"))).toBe(false);
   });
 
   test("can split without TMUX_PANE by omitting anchor", async () => {
@@ -60,7 +77,7 @@ describe("wake maybeSplit", () => {
 
     await maybeSplit("20-homekeeper:homekeeper-oracle", { split: true });
 
-    expect(hostExecCalls[2]).toContain("tmux select-layout -t '%42' tiled");
+    expect(hostExecCalls[3]).toContain("tmux select-layout -t '%42' tiled");
   });
 
   test("opens a new tmux window/tab for bring default mode", async () => {

--- a/test/isolated/wake-maybe-split.test.ts
+++ b/test/isolated/wake-maybe-split.test.ts
@@ -2,10 +2,12 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { join } from "path";
 
 let hostExecCalls: string[] = [];
+let listPanesResponse = "3\n";
 
 mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
   hostExec: async (cmd: string) => {
     hostExecCalls.push(cmd);
+    if (cmd.includes("list-panes")) return listPanesResponse;
     return "";
   },
 }));
@@ -18,6 +20,7 @@ describe("wake maybeSplit", () => {
 
   beforeEach(() => {
     hostExecCalls = [];
+    listPanesResponse = "3\n";
     process.env.TMUX = "/tmp/tmux-501/default,123,0";
     process.env.TMUX_PANE = "%42";
   });
@@ -30,12 +33,14 @@ describe("wake maybeSplit", () => {
   test("splits current pane and attaches target without importing removed split plugin", async () => {
     await maybeSplit("20-homekeeper:homekeeper-oracle", { split: true });
 
-    expect(hostExecCalls).toHaveLength(1);
+    expect(hostExecCalls).toHaveLength(3);
     expect(hostExecCalls[0]).toContain("tmux split-window");
     expect(hostExecCalls[0]).toContain("-t '%42'");
     expect(hostExecCalls[0]).toContain("-h -l 50%");
     expect(hostExecCalls[0]).toContain("TMUX= tmux attach-session -t");
     expect(hostExecCalls[0]).toContain("20-homekeeper:homekeeper-oracle");
+    expect(hostExecCalls[1]).toContain("tmux list-panes -t '%42'");
+    expect(hostExecCalls[2]).toContain("tmux select-layout -t '%42' main-vertical");
   });
 
   test("can split without TMUX_PANE by omitting anchor", async () => {
@@ -43,9 +48,19 @@ describe("wake maybeSplit", () => {
 
     await maybeSplit("20-homekeeper:homekeeper-oracle", { split: true });
 
-    expect(hostExecCalls).toHaveLength(1);
+    expect(hostExecCalls).toHaveLength(3);
     expect(hostExecCalls[0]).not.toContain("-t '%");
     expect(hostExecCalls[0]).toContain("tmux split-window -h -l 50%");
+    expect(hostExecCalls[1]).toContain("tmux list-panes ");
+    expect(hostExecCalls[2]).toContain("tmux select-layout main-vertical");
+  });
+
+  test("uses tiled layout after split when pane count is high", async () => {
+    listPanesResponse = "5\n";
+
+    await maybeSplit("20-homekeeper:homekeeper-oracle", { split: true });
+
+    expect(hostExecCalls[2]).toContain("tmux select-layout -t '%42' tiled");
   });
 
   test("opens a new tmux window/tab for bring default mode", async () => {

--- a/test/isolated/wake-maybe-split.test.ts
+++ b/test/isolated/wake-maybe-split.test.ts
@@ -52,7 +52,7 @@ describe("wake maybeSplit", () => {
     await maybeOpenWindow("20-homekeeper:homekeeper-oracle", { bring: true });
 
     expect(hostExecCalls).toHaveLength(1);
-    expect(hostExecCalls[0]).toContain("tmux new-window");
+    expect(hostExecCalls[0]).toContain("tmux new-window -d");
     expect(hostExecCalls[0]).toContain("-n 'bring-homekeeper-oracle'");
     expect(hostExecCalls[0]).toContain("TMUX= tmux attach-session -t");
     expect(hostExecCalls[0]).toContain("20-homekeeper:homekeeper-oracle");

--- a/test/isolated/wake-maybe-split.test.ts
+++ b/test/isolated/wake-maybe-split.test.ts
@@ -10,7 +10,7 @@ mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
   },
 }));
 
-const { maybeSplit } = await import("../../src/commands/shared/wake-maybe-split");
+const { maybeOpenWindow, maybeSplit } = await import("../../src/commands/shared/wake-maybe-split");
 
 describe("wake maybeSplit", () => {
   const originalTmux = process.env.TMUX;
@@ -46,6 +46,21 @@ describe("wake maybeSplit", () => {
     expect(hostExecCalls).toHaveLength(1);
     expect(hostExecCalls[0]).not.toContain("-t '%");
     expect(hostExecCalls[0]).toContain("tmux split-window -h -l 50%");
+  });
+
+  test("opens a new tmux window/tab for bring default mode", async () => {
+    await maybeOpenWindow("20-homekeeper:homekeeper-oracle", { bring: true });
+
+    expect(hostExecCalls).toHaveLength(1);
+    expect(hostExecCalls[0]).toContain("tmux new-window");
+    expect(hostExecCalls[0]).toContain("-n 'bring-homekeeper-oracle'");
+    expect(hostExecCalls[0]).toContain("TMUX= tmux attach-session -t");
+    expect(hostExecCalls[0]).toContain("20-homekeeper:homekeeper-oracle");
+  });
+
+  test("does not open a window when bring is not requested", async () => {
+    await maybeOpenWindow("20-homekeeper:homekeeper-oracle", {});
+    expect(hostExecCalls).toEqual([]);
   });
 
   afterAll(() => {

--- a/test/isolated/wake-maybe-split.test.ts
+++ b/test/isolated/wake-maybe-split.test.ts
@@ -4,17 +4,21 @@ import { join } from "path";
 let hostExecCalls: string[] = [];
 let listPanesResponse = "3\n";
 let tileMarkerResponse = "";
+let paneGeometryResponse = "%42|0|0|\n%43|0|81|1\n%44|26|81|1\n";
 
 mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
   hostExec: async (cmd: string) => {
     hostExecCalls.push(cmd);
     if (cmd.includes("show-options") && cmd.includes("@maw_tile")) return tileMarkerResponse;
+    if (cmd.includes("list-panes") && cmd.includes("#{pane_id}|#{pane_top}|#{pane_left}|#{@maw_tile}")) {
+      return paneGeometryResponse;
+    }
     if (cmd.includes("list-panes")) return listPanesResponse;
     return "";
   },
 }));
 
-const { maybeOpenWindow, maybeSplit } = await import("../../src/commands/shared/wake-maybe-split");
+const { findTopRightPane, maybeOpenWindow, maybeSplit } = await import("../../src/commands/shared/wake-maybe-split");
 
 describe("wake maybeSplit", () => {
   const originalTmux = process.env.TMUX;
@@ -24,6 +28,7 @@ describe("wake maybeSplit", () => {
     hostExecCalls = [];
     listPanesResponse = "3\n";
     tileMarkerResponse = "";
+    paneGeometryResponse = "%42|0|0|\n%43|0|81|1\n%44|26|81|1\n";
     process.env.TMUX = "/tmp/tmux-501/default,123,0";
     process.env.TMUX_PANE = "%42";
   });
@@ -80,14 +85,38 @@ describe("wake maybeSplit", () => {
     expect(hostExecCalls[3]).toContain("tmux select-layout -t '%42' tiled");
   });
 
-  test("opens a new tmux window/tab for bring default mode", async () => {
+  test("finds the top-right tile pane, excluding the caller", async () => {
+    const pane = await findTopRightPane("%42");
+
+    expect(pane).toBe("%43");
+  });
+
+  test("replaces the top-right pane for bring default mode", async () => {
     await maybeOpenWindow("20-homekeeper:homekeeper-oracle", { bring: true });
+
+    expect(hostExecCalls).toHaveLength(2);
+    expect(hostExecCalls[0]).toContain("tmux list-panes -t '%42' -F");
+    expect(hostExecCalls[1]).toContain("tmux respawn-pane -k -t '%43'");
+    expect(hostExecCalls[1]).toContain("TMUX= tmux attach-session -t");
+    expect(hostExecCalls[1]).toContain("20-homekeeper:homekeeper-oracle");
+  });
+
+  test("falls back to a background tab when no replacement pane exists", async () => {
+    paneGeometryResponse = "%42|0|0|\n";
+
+    await maybeOpenWindow("20-homekeeper:homekeeper-oracle", { bring: true });
+
+    expect(hostExecCalls).toHaveLength(2);
+    expect(hostExecCalls[0]).toContain("tmux list-panes -t '%42' -F");
+    expect(hostExecCalls[1]).toContain("tmux new-window -d");
+    expect(hostExecCalls[1]).toContain("-n 'bring-homekeeper-oracle'");
+  });
+
+  test("can force the old background-tab behavior", async () => {
+    await maybeOpenWindow("20-homekeeper:homekeeper-oracle", { bring: true, tab: true });
 
     expect(hostExecCalls).toHaveLength(1);
     expect(hostExecCalls[0]).toContain("tmux new-window -d");
-    expect(hostExecCalls[0]).toContain("-n 'bring-homekeeper-oracle'");
-    expect(hostExecCalls[0]).toContain("TMUX= tmux attach-session -t");
-    expect(hostExecCalls[0]).toContain("20-homekeeper:homekeeper-oracle");
   });
 
   test("does not open a window when bring is not requested", async () => {

--- a/test/isolated/wake-session-worktree.test.ts
+++ b/test/isolated/wake-session-worktree.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Worktree creation tests — ISOLATED SUITE.
+ *
+ * Why isolated: createWorktree shells through @maw-js/sdk/hostExec.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { join } from "path";
+
+let commands: string[] = [];
+let existingBranches = new Set<string>();
+
+mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
+  hostExec: async (cmd: string): Promise<string> => {
+    commands.push(cmd);
+    if (cmd.includes("rev-parse HEAD")) return "abc123\n";
+    const branchMatch = cmd.match(/show-ref --verify --quiet 'refs\/heads\/([^']+)'/);
+    if (branchMatch) {
+      if (existingBranches.has(branchMatch[1])) return "";
+      throw new Error("missing ref");
+    }
+    return "";
+  },
+  tmux: {},
+}));
+
+const { createWorktree } = await import("../../src/commands/shared/wake-session");
+
+beforeEach(() => {
+  commands = [];
+  existingBranches = new Set<string>();
+});
+
+describe("createWorktree", () => {
+  test("creates the next worktree branch without deleting existing branches", async () => {
+    await createWorktree("/repo", "/tmp", "repo", "oracle", "tile-1", []);
+
+    expect(commands.some(cmd => cmd.includes("branch -D"))).toBe(false);
+    expect(commands).toContain("git -C '/repo' worktree add '/tmp/repo.wt-1-tile-1' -b 'agents/1-tile-1'");
+  });
+
+  test("skips stale branch names instead of clobbering them", async () => {
+    existingBranches.add("agents/1-tile-1");
+
+    await createWorktree("/repo", "/tmp", "repo", "oracle", "tile-1", []);
+
+    expect(commands.some(cmd => cmd.includes("branch -D"))).toBe(false);
+    expect(commands).toContain("git -C '/repo' show-ref --verify --quiet 'refs/heads/agents/1-tile-1'");
+    expect(commands).toContain("git -C '/repo' worktree add '/tmp/repo.wt-2-tile-1' -b 'agents/2-tile-1'");
+  });
+});

--- a/test/isolated/worktree-scope-match-935.test.ts
+++ b/test/isolated/worktree-scope-match-935.test.ts
@@ -27,6 +27,7 @@
  */
 import { describe, it, expect, mock, beforeEach } from "bun:test";
 import { join } from "path";
+import { mockSshModule } from "../helpers/mock-ssh";
 
 const root = join(import.meta.dir, "../../src");
 
@@ -34,7 +35,7 @@ const root = join(import.meta.dir, "../../src");
 let stubFindOutput: string = "";
 let stubSessions: Array<{ name: string; windows: Array<{ name: string; index: number; active: boolean }> }> = [];
 
-mock.module(join(root, "core/transport/ssh"), () => ({
+mock.module(join(root, "core/transport/ssh"), () => mockSshModule({
   hostExec: async (cmd: string) => {
     if (cmd.includes("find ") && cmd.includes(".wt-")) {
       return stubFindOutput;
@@ -42,7 +43,6 @@ mock.module(join(root, "core/transport/ssh"), () => ({
     if (cmd.includes("rev-parse --abbrev-ref")) {
       return "agents/935-test";
     }
-    // Suppress prunable-worktree probe — return empty so no orphans appear
     return "";
   },
   listSessions: async () => stubSessions,

--- a/test/plugin-manifest-v1.test.ts
+++ b/test/plugin-manifest-v1.test.ts
@@ -88,7 +88,7 @@ describe("manifest v1 — new fields", () => {
     // #874 — `tmux` and `shell` joined the namespace list to support community
     // plugins (bg, rename, park, shellenv) that spawn tmux or shell-eval.
     expect([...KNOWN_CAPABILITY_NAMESPACES].sort()).toEqual(
-      ["net", "fs", "peer", "sdk", "proc", "ffi", "tmux", "shell"].sort(),
+      ["net", "fs", "peer", "sdk", "proc", "ffi", "tmux", "shell", "attach"].sort(),
     );
   });
 });
@@ -230,6 +230,8 @@ describe("manifest v1 — capabilities", () => {
       expect(warn).toHaveBeenCalled();
       const msg = warn.mock.calls[0]?.[0] as string;
       expect(msg).toMatch(/blockchain/);
+      expect(msg).toContain("runtime: maw v");
+      expect(msg).toContain("bun add -g github:Soul-Brews-Studio/maw-js#alpha");
     } finally {
       warn.mockRestore();
       rmSync(dir, { recursive: true });

--- a/test/routing.test.ts
+++ b/test/routing.test.ts
@@ -71,6 +71,16 @@ describe("resolveTarget", () => {
     expect(r).toMatchObject({ type: "error", reason: "self_not_running" });
   });
 
+  test("local: prefix is a self-node alias and resolves locally", () => {
+    const r = resolveTarget("local:mawjs", BASE_CONFIG, SESSIONS);
+    expect(r).toEqual({ type: "self-node", target: "08-mawjs:1" });
+  });
+
+  test("local: prefix miss is local/self miss, not unknown peer", () => {
+    const r = resolveTarget("local:ghost", BASE_CONFIG, SESSIONS);
+    expect(r).toMatchObject({ type: "error", reason: "self_not_running" });
+  });
+
   // #6: NODE:AGENT → UNKNOWN NODE
   test("unknown node returns error", () => {
     const r = resolveTarget("mars:neo", BASE_CONFIG, SESSIONS);

--- a/test/tmux-sendtext-submit.test.ts
+++ b/test/tmux-sendtext-submit.test.ts
@@ -1,0 +1,132 @@
+/**
+ * tmux-sendtext-submit.test.ts — regression for maw-stress finding #6.
+ *
+ * Tmux.sendText used to fire 3 blind `Enter` keys on a fixed ~1.9s schedule
+ * with zero feedback. When the pane wasn't ready as they landed, every Enter
+ * missed and the command sat in the input box unexecuted — this forced
+ * brain to manually re-launch dispatches on 2026-05-14.
+ *
+ * The fix: send Enter, re-inspect the pane, retry only while the input line
+ * still holds un-submitted content (capped at MAX_SUBMIT_ATTEMPTS).
+ *
+ * Strategy: subclass Tmux and override the low-level primitives so we can
+ * script the pane's capture output and assert the exact key sequence — no
+ * tmux process, no module mock (safe for the main suite).
+ */
+import { describe, test, expect } from "bun:test";
+import { Tmux } from "../src/core/transport/tmux-class";
+
+/** Tmux with the tmux-touching primitives stubbed + a scripted capture feed. */
+class FakeTmux extends Tmux {
+  calls: string[] = [];
+  /** Successive return values for capture(); last value repeats once exhausted. */
+  captureScript: string[] = [];
+  private captureIdx = 0;
+
+  constructor() {
+    super(undefined, ""); // no socket — overridden methods never hit hostExec
+  }
+
+  async capture(_target: string, _lines = 80): Promise<string> {
+    this.calls.push("capture");
+    const v = this.captureScript[this.captureIdx] ?? this.captureScript.at(-1) ?? "";
+    this.captureIdx++;
+    return v;
+  }
+  async sendKeys(_target: string, ...keys: string[]): Promise<void> {
+    this.calls.push(`sendKeys:${keys.join(",")}`);
+  }
+  async sendKeysLiteral(_target: string, text: string): Promise<void> {
+    this.calls.push(`sendKeysLiteral:${text}`);
+  }
+  async loadBuffer(text: string): Promise<void> {
+    this.calls.push(`loadBuffer:${text.length}`);
+  }
+  async pasteBuffer(_target: string): Promise<void> {
+    this.calls.push("pasteBuffer");
+  }
+}
+
+const PROMPT_IDLE = "agent@host:~$ "; // prompt marker + trailing space → submitted
+const PROMPT_PENDING = "agent@host:~$ unsent command text"; // input still on the line
+const enterCount = (calls: string[]) => calls.filter(c => c === "sendKeys:Enter").length;
+
+describe("Tmux.sendText — confirmed submit (#6)", () => {
+  test(
+    "single Enter when the pane clears on the first check — no blind trailing Enters",
+    async () => {
+      const t = new FakeTmux();
+      t.captureScript = [PROMPT_IDLE];
+      await t.sendText("sess:win", "hello");
+
+      expect(t.calls).toEqual(["sendKeysLiteral:hello", "sendKeys:Enter", "capture"]);
+      expect(enterCount(t.calls)).toBe(1);
+    },
+    10_000,
+  );
+
+  test(
+    "retries Enter while input is still pending, stops as soon as it clears",
+    async () => {
+      const t = new FakeTmux();
+      // pending after Enter #1 and #2, cleared after #3
+      t.captureScript = [PROMPT_PENDING, PROMPT_PENDING, PROMPT_IDLE];
+      await t.sendText("sess:win", "deploy task");
+
+      expect(enterCount(t.calls)).toBe(3);
+      // last action is the confirming capture, not another blind Enter
+      expect(t.calls.at(-1)).toBe("capture");
+    },
+    15_000,
+  );
+
+  test(
+    "stops after MAX_SUBMIT_ATTEMPTS and warns when the pane never clears",
+    async () => {
+      const t = new FakeTmux();
+      t.captureScript = [PROMPT_PENDING]; // repeats → never clears
+
+      const warnings: string[] = [];
+      const origWarn = console.warn;
+      console.warn = (...args: unknown[]) => { warnings.push(args.join(" ")); };
+      try {
+        await t.sendText("sess:win", "stuck task");
+      } finally {
+        console.warn = origWarn;
+      }
+
+      // capped — not an unbounded spin
+      expect(enterCount(t.calls)).toBe(4);
+      expect(warnings.some(w => w.includes("pending input") && w.includes("sess:win"))).toBe(true);
+    },
+    15_000,
+  );
+
+  test(
+    "multiline content routes through loadBuffer + pasteBuffer, then confirmed submit",
+    async () => {
+      const t = new FakeTmux();
+      t.captureScript = [PROMPT_IDLE];
+      await t.sendText("sess:win", "line one\nline two");
+
+      expect(t.calls[0]).toBe(`loadBuffer:${"line one\nline two".length}`);
+      expect(t.calls[1]).toBe("pasteBuffer");
+      expect(t.calls).not.toContain("sendKeysLiteral:line one\nline two");
+      expect(enterCount(t.calls)).toBe(1);
+    },
+    10_000,
+  );
+
+  test(
+    "a capture failure is treated as submitted — the retry loop cannot spin",
+    async () => {
+      const t = new FakeTmux();
+      // capture throws → paneInputPending swallows → false (assume submitted)
+      t.capture = async () => { throw new Error("tmux gone"); };
+      await t.sendText("sess:win", "hi");
+
+      expect(enterCount(t.calls)).toBe(1);
+    },
+    10_000,
+  );
+});

--- a/test/wake-bring.test.ts
+++ b/test/wake-bring.test.ts
@@ -10,7 +10,7 @@ describe("maw bring existing-session behavior", () => {
     expect(shouldOfferExistingSessionAttach({ split: true }, true)).toBe(false);
   });
 
-  test("bring default tab mode never offers the destructive attach prompt", () => {
+  test("bring default mode never offers the destructive attach prompt", () => {
     expect(shouldOfferExistingSessionAttach({ bring: true }, true)).toBe(false);
   });
 

--- a/test/wake-bring.test.ts
+++ b/test/wake-bring.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { shouldOfferExistingSessionAttach } from "../src/commands/shared/wake-cmd";
+
+describe("maw bring existing-session behavior", () => {
+  test("wake may offer attach for an existing session in an interactive terminal", () => {
+    expect(shouldOfferExistingSessionAttach({}, true)).toBe(true);
+  });
+
+  test("bring/wake --split never offers the destructive attach prompt", () => {
+    expect(shouldOfferExistingSessionAttach({ split: true }, true)).toBe(false);
+  });
+
+  test("explicit attach skips the prompt because attach was already requested", () => {
+    expect(shouldOfferExistingSessionAttach({ attach: true }, true)).toBe(false);
+  });
+
+  test("headless wake does not prompt", () => {
+    expect(shouldOfferExistingSessionAttach({}, false)).toBe(false);
+  });
+});

--- a/test/wake-bring.test.ts
+++ b/test/wake-bring.test.ts
@@ -10,6 +10,10 @@ describe("maw bring existing-session behavior", () => {
     expect(shouldOfferExistingSessionAttach({ split: true }, true)).toBe(false);
   });
 
+  test("bring default tab mode never offers the destructive attach prompt", () => {
+    expect(shouldOfferExistingSessionAttach({ bring: true }, true)).toBe(false);
+  });
+
   test("explicit attach skips the prompt because attach was already requested", () => {
     expect(shouldOfferExistingSessionAttach({ attach: true }, true)).toBe(false);
   });


### PR DESCRIPTION
Cuts v26.5.15-alpha.1538 on merge via calver-release.yml.

Includes:
- #1424 tile cleanup branch-safety for #1380
- #1423 stale-runtime/capability diagnostic fix

Validation before release branch:
- `bun test test/isolated/tile.test.ts test/isolated/wake-session-worktree.test.ts`
- `bun run build`

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
