### PR TITLE
feat(done): add current-session done --all

### DIFF
--- a/src/vendor/mpr-plugins/done/impl.ts
+++ b/src/vendor/mpr-plugins/done/impl.ts
@@ -11,6 +11,38 @@ import { removeWorktreeViaConfig, removeWorktreeByGhqScan, removeFromFleetConfig
 export interface DoneOpts {
   force?: boolean;
   dryRun?: boolean;
+  /** Restrict window-name lookup to a specific tmux session. Used by done --all. */
+  sessionName?: string;
+}
+
+type DoneWindow = { index: number; name: string; active: boolean };
+type DoneSession = { name: string; windows: DoneWindow[] };
+
+export interface DoneAllSummary {
+  sessionName: string | null;
+  processed: string[];
+  skipped: string[];
+}
+
+async function currentSessionName(sessions: DoneSession[]): Promise<string | null> {
+  try {
+    const current = (await tmux.run("display-message", "-p", "#{session_name}")).trim();
+    if (current && sessions.some(s => s.name === current)) return current;
+  } catch { /* outside tmux or tmux unavailable */ }
+
+  // `done --all` is destructive. If tmux cannot tell us the current session
+  // and multiple sessions exist, refuse to guess from per-session "active"
+  // windows because every session may have one.
+  return sessions.length === 1 ? sessions[0].name : null;
+}
+
+function nonLeadWindows(session: DoneSession): DoneWindow[] {
+  const windows = [...session.windows];
+  if (windows.length === 0) return [];
+  const leadIndex = Math.min(...windows.map(w => w.index));
+  return windows
+    .filter(w => w.index !== leadIndex)
+    .sort((a, b) => a.index - b.index);
 }
 
 /**
@@ -30,13 +62,16 @@ export async function cmdDone(windowName_: string, opts: DoneOpts = {}) {
   const windowNameLower = windowName.toLowerCase();
   let sessionName: string | null = null;
   let windowIndex: number | null = null;
-  for (const s of sessions) {
+  const searchSessions = opts.sessionName
+    ? sessions.filter(s => s.name === opts.sessionName)
+    : sessions;
+  for (const s of searchSessions) {
     const w = s.windows.find(w => w.name.toLowerCase() === windowNameLower);
     if (w) { sessionName = s.name; windowIndex = w.index; windowName = w.name; break; }
   }
 
   // 0. Signal parent inbox (#81) — write before kill so parent knows
-  if (sessionName) {
+  if (sessionName && !opts.dryRun) {
     await signalParentInbox(windowName, sessionName, sessions as any);
   }
 
@@ -80,4 +115,55 @@ export async function cmdDone(windowName_: string, opts: DoneOpts = {}) {
   takeSnapshot("done").catch(() => {});
 
   console.log();
+}
+
+/**
+ * maw done --all [--force] [--dry-run]
+ *
+ * Batch-clean all non-lead windows in the current tmux session. Reuses the
+ * single-window lifecycle so /rrr, auto-save, worktree cleanup, fleet cleanup,
+ * and snapshots stay consistent with `maw done <window>`.
+ */
+export async function cmdDoneAll(opts: DoneOpts = {}): Promise<DoneAllSummary> {
+  const sessions = await listSessions() as DoneSession[];
+  const sessionName = await currentSessionName(sessions);
+  if (!sessionName) {
+    const reason = sessions.length === 0
+      ? "no tmux sessions to clean"
+      : "could not identify current tmux session; run inside tmux";
+    console.log(`  \x1b[90m○\x1b[0m ${reason}`);
+    return { sessionName: null, processed: [], skipped: [] };
+  }
+
+  const session = sessions.find(s => s.name === sessionName);
+  if (!session) {
+    console.log(`  \x1b[90m○\x1b[0m current tmux session '${sessionName}' not found`);
+    return { sessionName, processed: [], skipped: [] };
+  }
+
+  const targets = nonLeadWindows(session);
+  if (targets.length === 0) {
+    console.log(`  \x1b[90m○\x1b[0m no non-lead windows in ${sessionName}`);
+    return { sessionName, processed: [], skipped: [] };
+  }
+
+  const mode = opts.dryRun ? "would process" : "processing";
+  console.log(`  \x1b[36m⬡\x1b[0m ${mode} ${targets.length} non-lead window(s) in ${sessionName}`);
+
+  const processed: string[] = [];
+  const skipped: string[] = [];
+  for (const target of targets) {
+    console.log(`\n\x1b[36m→\x1b[0m done ${sessionName}:${target.name}`);
+    try {
+      await cmdDone(target.name, { ...opts, sessionName });
+      processed.push(target.name);
+    } catch (e: any) {
+      skipped.push(target.name);
+      console.log(`  \x1b[33m⚠\x1b[0m skipped ${target.name}: ${e?.message || e}`);
+    }
+  }
+
+  const verb = opts.dryRun ? "would process" : "processed";
+  console.log(`  \x1b[32m✓\x1b[0m done --all ${verb} ${processed.length} window(s)${skipped.length ? `, skipped ${skipped.length}` : ""}`);
+  return { sessionName, processed, skipped };
 }

--- a/src/vendor/mpr-plugins/done/index.ts
+++ b/src/vendor/mpr-plugins/done/index.ts
@@ -1,5 +1,5 @@
 import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
-import { cmdDone } from "./impl";
+import { cmdDone, cmdDoneAll } from "./impl";
 
 export const command = {
   name: ["done", "finish"],
@@ -19,28 +19,34 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     else logs.push(a.map(String).join(" "));
   };
   try {
-    let name: string;
+    let name: string | undefined;
     let force: boolean | undefined;
     let dryRun: boolean | undefined;
+    let all: boolean | undefined;
 
     if (ctx.source === "cli") {
       const args = ctx.args as string[];
       // Find first non-flag arg
       const positional = args.filter(a => !a.startsWith("--"));
-      if (!positional[0]) {
-        return { ok: false, error: "usage: maw done <window-name> [--force] [--dry-run]" };
-      }
-      name = positional[0];
       force = args.includes("--force");
       dryRun = args.includes("--dry-run");
+      all = args.includes("--all");
+      name = positional[0];
     } else {
       const args = ctx.args as Record<string, unknown>;
-      if (!args.name) {
-        return { ok: false, error: "name is required" };
-      }
-      name = args.name as string;
+      name = args.name as string | undefined;
       force = args.force as boolean | undefined;
       dryRun = args.dryRun as boolean | undefined;
+      all = args.all as boolean | undefined;
+    }
+
+    if (all) {
+      await cmdDoneAll({ force, dryRun });
+      return { ok: true, output: logs.join("\n") || undefined };
+    }
+
+    if (!name) {
+      return { ok: false, error: "usage: maw done <window-name> [--force] [--dry-run] or maw done --all [--force] [--dry-run]" };
     }
 
     await cmdDone(name, { force, dryRun });

--- a/src/vendor/mpr-plugins/done/plugin.json
+++ b/src/vendor/mpr-plugins/done/plugin.json
@@ -10,7 +10,7 @@
     "aliases": [
       "finish"
     ],
-    "help": "maw done <window-name> [--force] [--dry-run] — clean up a finished worktree"
+    "help": "maw done <window-name> [--force] [--dry-run] | maw done --all [--force] [--dry-run] — clean up finished worktrees"
   },
   "api": {
     "path": "/api/done",

--- a/test/isolated/done-all.test.ts
+++ b/test/isolated/done-all.test.ts
@@ -1,0 +1,167 @@
+/**
+ * done-all.test.ts — #1380 regression guard.
+ *
+ * `maw done --all` batches the existing single-window done lifecycle across
+ * the current tmux session, but it must never target the lead window or a
+ * same-named window from another session.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { join } from "path";
+
+type Window = { index: number; name: string; active: boolean };
+type Session = { name: string; windows: Window[] };
+
+let sessions: Session[] = [];
+let tmuxCommands: string[] = [];
+let autoSaveCalls: Array<{ windowName: string; sessionName: string; dryRun?: boolean }> = [];
+let inboxSignals: Array<{ windowName: string; sessionName: string }> = [];
+let worktreeLookups: string[] = [];
+let removedFleetEntries: string[] = [];
+let snapshots: string[] = [];
+let currentSession = "work";
+let tmuxRunFails = false;
+
+mock.module("maw-js/sdk", () => ({
+  listSessions: async () => sessions,
+  get FLEET_DIR() { return "/tmp/maw-test-fleet"; },
+  takeSnapshot: async (trigger: string) => { snapshots.push(trigger); return "/tmp/snapshot.json"; },
+  tmux: {
+    run: async (subcommand: string, ...args: string[]) => {
+      tmuxCommands.push(["run", subcommand, ...args].join(" "));
+      if (tmuxRunFails) throw new Error("no current tmux session");
+      if (subcommand === "display-message") return `${currentSession}\n`;
+      return "";
+    },
+    killWindow: async (target: string) => {
+      tmuxCommands.push(`kill ${target}`);
+    },
+  },
+}));
+
+mock.module("maw-js/config/ghq-root", () => ({
+  getGhqRoot: () => "/ghq",
+}));
+
+mock.module("maw-js/core/matcher/normalize-target", () => ({
+  normalizeTarget: (target: string) => target,
+}));
+
+mock.module(join(import.meta.dir, "../../src/vendor/mpr-plugins/done/done-autosave"), () => ({
+  signalParentInbox: async (windowName: string, sessionName: string) => {
+    inboxSignals.push({ windowName, sessionName });
+  },
+  autoSave: async (windowName: string, sessionName: string, opts: { dryRun?: boolean }) => {
+    autoSaveCalls.push({ windowName, sessionName, dryRun: opts.dryRun });
+  },
+}));
+
+mock.module(join(import.meta.dir, "../../src/vendor/mpr-plugins/done/done-worktree"), () => ({
+  removeWorktreeViaConfig: async (windowNameLower: string) => {
+    worktreeLookups.push(`config:${windowNameLower}`);
+    return false;
+  },
+  removeWorktreeByGhqScan: async (windowName: string) => {
+    worktreeLookups.push(`ghq:${windowName}`);
+    return false;
+  },
+  removeFromFleetConfig: (windowNameLower: string) => {
+    removedFleetEntries.push(windowNameLower);
+    return false;
+  },
+}));
+
+const { cmdDoneAll } = await import("../../src/vendor/mpr-plugins/done/impl");
+const donePlugin = await import("../../src/vendor/mpr-plugins/done/index");
+
+beforeEach(() => {
+  sessions = [
+    {
+      name: "work",
+      windows: [
+        { index: 0, name: "lead", active: true },
+        { index: 1, name: "alpha", active: false },
+        { index: 2, name: "duplicate", active: false },
+      ],
+    },
+    {
+      name: "other",
+      windows: [
+        { index: 0, name: "other-lead", active: true },
+        { index: 1, name: "duplicate", active: false },
+      ],
+    },
+  ];
+  currentSession = "work";
+  tmuxCommands = [];
+  autoSaveCalls = [];
+  inboxSignals = [];
+  worktreeLookups = [];
+  removedFleetEntries = [];
+  snapshots = [];
+  tmuxRunFails = false;
+});
+
+describe("cmdDoneAll", () => {
+  test("dry-run processes only non-lead windows in the current session", async () => {
+    const summary = await cmdDoneAll({ dryRun: true });
+
+    expect(summary).toEqual({
+      sessionName: "work",
+      processed: ["alpha", "duplicate"],
+      skipped: [],
+    });
+    expect(autoSaveCalls).toEqual([
+      { windowName: "alpha", sessionName: "work", dryRun: true },
+      { windowName: "duplicate", sessionName: "work", dryRun: true },
+    ]);
+    expect(inboxSignals).toEqual([]);
+    expect(tmuxCommands).not.toContain("kill work:lead");
+    expect(tmuxCommands).not.toContain("kill other:duplicate");
+    expect(worktreeLookups).toEqual([]);
+    expect(removedFleetEntries).toEqual([]);
+  });
+
+  test("--force skips auto-save and kills only current-session non-lead windows", async () => {
+    const summary = await cmdDoneAll({ force: true });
+
+    expect(summary.processed).toEqual(["alpha", "duplicate"]);
+    expect(autoSaveCalls).toEqual([]);
+    expect(tmuxCommands).toContain("kill work:alpha");
+    expect(tmuxCommands).toContain("kill work:duplicate");
+    expect(tmuxCommands).not.toContain("kill work:lead");
+    expect(tmuxCommands).not.toContain("kill other:duplicate");
+    expect(worktreeLookups).toEqual([
+      "config:alpha",
+      "ghq:alpha",
+      "config:duplicate",
+      "ghq:duplicate",
+    ]);
+    expect(removedFleetEntries).toEqual(["alpha", "duplicate"]);
+    expect(snapshots).toEqual(["done", "done"]);
+  });
+
+  test("refuses to guess a current session when tmux cannot identify one", async () => {
+    tmuxRunFails = true;
+
+    const summary = await cmdDoneAll({ force: true });
+
+    expect(summary).toEqual({ sessionName: null, processed: [], skipped: [] });
+    expect(tmuxCommands).toEqual(["run display-message -p #{session_name}"]);
+    expect(autoSaveCalls).toEqual([]);
+    expect(inboxSignals).toEqual([]);
+    expect(worktreeLookups).toEqual([]);
+  });
+
+  test("plugin CLI parses --all without a positional window name", async () => {
+    const output: string[] = [];
+    const result = await donePlugin.default({
+      source: "cli",
+      args: ["--all", "--dry-run"],
+      writer: (...args: unknown[]) => output.push(args.map(String).join(" ")),
+    } as any);
+
+    expect(result.ok).toBe(true);
+    expect(autoSaveCalls.map(c => c.windowName)).toEqual(["alpha", "duplicate"]);
+    expect(output.join("\n")).toContain("would process 2 non-lead window(s) in work");
+  });
+});


### PR DESCRIPTION
## Summary
- add `maw done --all [--force] [--dry-run]` to the vendored done plugin
- scope batch cleanup to the current tmux session and skip the lead window
- reuse the existing single-window `cmdDone` lifecycle for /rrr, save, kill, worktree cleanup, fleet cleanup, and snapshots
- keep dry-run side-effect free and refuse to guess across multiple sessions when tmux cannot identify the current one

## Tests
- `bun test test/isolated/done-all.test.ts`
- `bun run build`
- `MAW_PLUGINS_DIR=$(mktemp -d) bun src/cli.ts done --all --dry-run`

Closes #1380 for the `done --all` slice; `tile clean`/worktree safety were already landed in #1424.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
