### PR TITLE
fix(bring): restore v1 split default

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -44,7 +44,7 @@ export const ALIAS_DESCRIPTIONS: Record<string, string> = {
   panes: "List all panes across sessions",
   cleanup: "Kill zombie agent panes",
   tile: "Tile current window or spawn N panes tiled",
-  bring: "Bring an oracle HERE — symmetric with `a` (go there)",
+  bring: "Bring an oracle HERE — split current pane and attach",
   b: "Bring an oracle HERE (short form of `bring`)",
   ls: "List sessions (compact, -a roster, -v detail)",
   wake: "Wake an oracle session (fuzzy match, auto-clone)",
@@ -108,9 +108,9 @@ export function parseBringArgs(argv: string[]): {
   oracle: string;
   opts: { bring?: true; split?: boolean; tab?: boolean; engine?: string };
 } {
-  // `maw bring <oracle>` replaces the top-right pane when possible. `--split`
-  // remains available as the opt-in layout-mutating form, while `--tab`
-  // preserves the old background-tab behavior explicitly.
+  // v1 default (#1398, locked by #1430): `maw bring <oracle>` splits the
+  // current pane and attaches there. `--split` is kept as a no-op alias for
+  // muscle memory, while `--tab` opts into the later top-right/bg-tab path.
   const flags = parseFlags(argv, {
     "--engine": String, "-e": "--engine",
     "--split": Boolean,
@@ -119,15 +119,15 @@ export function parseBringArgs(argv: string[]): {
   const oracle = (flags._ as string[])[0];
   if (!oracle) {
     console.error("usage: maw bring <oracle> [--split|--tab] [-e|--engine <name>]");
-    console.error("  Replaces the top-right pane by default when one exists.");
-    console.error("  Use --split to split the current pane instead.");
-    console.error("  Use --tab to force a background tmux tab.");
+    console.error("  Default: split the current pane and attach (v1).");
+    console.error("  --split is accepted as an explicit alias of the default.");
+    console.error("  Use --tab for the top-right tile/bg-tab form.");
     console.error("  Symmetric with `maw a` (attach goes there, bring comes here).");
     throw new UserError("bring: missing oracle name");
   }
-  const opts: { bring?: true; split?: boolean; tab?: boolean; engine?: string } = flags["--split"]
-    ? { split: true }
-    : { bring: true, ...(flags["--tab"] ? { tab: true } : {}) };
+  const opts: { bring?: true; split?: boolean; tab?: boolean; engine?: string } = flags["--tab"]
+    ? { bring: true }
+    : { split: true };
   if (flags["--engine"]) opts.engine = flags["--engine"];
   return { oracle, opts };
 }
@@ -230,8 +230,8 @@ export async function invokeDirectHandler(
   }
 
   if (exportName === "cmdBring") {
-    // `maw bring <oracle>` — show oracle here in a new tab by default.
-    // `--split` opts into current-pane splitting.
+    // `maw bring <oracle>` defaults to the v1 current-pane split path.
+    // `--tab` opts into the later top-right/bg-tab path.
     const { oracle, opts } = parseBringArgs(argv);
     await cmdWake(oracle, opts);
     return;

--- a/test/cli/dispatch-match.test.ts
+++ b/test/cli/dispatch-match.test.ts
@@ -243,9 +243,9 @@ describe("resolveTopAlias — RFC #954 verb aliases", () => {
     }
   });
 
-  test("`bring neo` defaults to bring-pane mode, not split", () => {
+  test("`bring neo` defaults to v1 split-and-attach mode", () => {
     const parsed = parseBringArgs(["neo"]);
-    expect(parsed).toEqual({ oracle: "neo", opts: { bring: true } });
+    expect(parsed).toEqual({ oracle: "neo", opts: { split: true } });
   });
 
   test("`b neo` is a direct shorthand for bring", () => {
@@ -260,14 +260,14 @@ describe("resolveTopAlias — RFC #954 verb aliases", () => {
     expect(ALIAS_DESCRIPTIONS.b).toContain("short form of `bring`");
   });
 
-  test("`bring neo --split` opts into split mode", () => {
+  test("`bring neo --split` remains an explicit alias of split mode", () => {
     const parsed = parseBringArgs(["neo", "--split", "-e", "codex"]);
     expect(parsed).toEqual({ oracle: "neo", opts: { split: true, engine: "codex" } });
   });
 
-  test("`bring neo --tab` forces the old background tab mode", () => {
+  test("`bring neo --tab` opts into the top-right/bg-tab mode", () => {
     const parsed = parseBringArgs(["neo", "--tab"]);
-    expect(parsed).toEqual({ oracle: "neo", opts: { bring: true, tab: true } });
+    expect(parsed).toEqual({ oracle: "neo", opts: { bring: true } });
   });
 
   test("`audit` → null (does NOT shadow CORE_ROUTES)", () => {

--- a/test/isolated/wake-maybe-split.test.ts
+++ b/test/isolated/wake-maybe-split.test.ts
@@ -91,7 +91,7 @@ describe("wake maybeSplit", () => {
     expect(pane).toBe("%43");
   });
 
-  test("replaces the top-right pane for bring default mode", async () => {
+  test("replaces the top-right pane for explicit bring mode", async () => {
     await maybeOpenWindow("20-homekeeper:homekeeper-oracle", { bring: true });
 
     expect(hostExecCalls).toHaveLength(2);
@@ -101,7 +101,7 @@ describe("wake maybeSplit", () => {
     expect(hostExecCalls[1]).toContain("20-homekeeper:homekeeper-oracle");
   });
 
-  test("falls back to a background tab when no replacement pane exists", async () => {
+  test("falls back to a background tab when explicit bring mode has no replacement pane", async () => {
     paneGeometryResponse = "%42|0|0|\n";
 
     await maybeOpenWindow("20-homekeeper:homekeeper-oracle", { bring: true });


### PR DESCRIPTION
## Summary
- restore `maw bring <oracle>` / `maw b <oracle>` to v1 split-and-attach default
- keep `--split` as an explicit alias of the default
- move the later top-right/bg-tab flow behind `--tab`
- refresh help text and parser/behavior test names for the locked v1 default

## Tests
- `MAW_TEST_MODE=1 rtk bun test test/cli/dispatch-match.test.ts test/wake-bring.test.ts test/isolated/wake-maybe-split.test.ts`
- `rtk bun run build`
- `MAW_TEST_MODE=1 rtk bun src/cli.ts --help | rtk rg 'maw bring\\s+Bring an oracle HERE|maw b\\s+Bring an oracle HERE'`

Closes #1430.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
