### PR TITLE
release(beta): v26.5.15-beta.1736

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.2",
+  "version": "26.5.15-beta.1736",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
## Summary
- Package-only beta cut: `v26.5.15-beta.1736`.
- No code changes; this follows validated alpha `v26.5.15-alpha.1724`.

## Verification
- `TZ=Asia/Bangkok bun scripts/calver.ts --beta --check`
- Verified diff is `package.json` only.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
