### PR TITLE
fix(release): skip legacy auto-tag for current CalVer cuts

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -24,10 +24,12 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "tag=v$VERSION" >> $GITHUB_OUTPUT
 
-          # CalVer versions (v{yy}.{m}.{d}[-alpha.{hour}]) are handled by
-          # calver-release.yml — skip here to avoid double-fire.
-          # See: #526 (CalVer adoption umbrella)
-          if [[ "$VERSION" =~ ^[0-9]{2}\.[0-9]{1,2}\.[0-9]{1,2}(-alpha\.[0-9]{1,2}[a-z]?)?$ ]]; then
+          # CalVer versions are handled by calver-release.yml — skip
+          # here to avoid racing a second tag/release creator. Mirrors the
+          # current CalVer validator: YY.M.D with D as a 1-3 digit stable
+          # counter, plus optional alpha/beta HMM suffix (#923/#930).
+          # See: #526 (CalVer adoption umbrella), #1437 (Auto Tag race).
+          if [[ "$VERSION" =~ ^[0-9]{2}\.[0-9]{1,2}\.[0-9]{1,3}(-(alpha|beta)\.[0-9]{1,4}[a-z]?)?$ ]]; then
             echo "::notice::CalVer version '$VERSION' — handled by calver-release.yml. Skipping legacy auto-tag."
             echo "skip=true" >> $GITHUB_OUTPUT
           fi
@@ -55,7 +57,9 @@ jobs:
 
       - name: Summary
         run: |
-          if [ "${{ steps.check.outputs.exists }}" == "true" ]; then
+          if [ "${{ steps.version.outputs.skip }}" == "true" ]; then
+            echo "Skipped CalVer v${{ steps.version.outputs.version }}; calver-release.yml owns this release." >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ steps.check.outputs.exists }}" == "true" ]; then
             echo "Tag v${{ steps.version.outputs.version }} already exists" >> $GITHUB_STEP_SUMMARY
           else
             echo "Created tag v${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Update legacy `auto-tag.yml` CalVer skip regex to match current stable/alpha/beta shapes.
- Include beta HMM suffixes and stable day/counter values up to 3 digits.
- Make the workflow summary explicit when Auto Tag skips because `calver-release.yml` owns the release.

Closes #1437.

## Verification
- Local bash regex smoke for:
  - `26.5.15`
  - `26.5.50`
  - `26.5.15-alpha.1724`
  - `26.5.15-beta.1736`
  - legacy/non-CalVer negative cases
- `git diff --check`

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
