### PR TITLE
release(stable): v26.5.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.15-beta.1736",
+  "version": "26.5.15",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
## Summary
- Package-only stable cut: `v26.5.15`.
- No code changes; follows beta `v26.5.15-beta.1736` and the #1437 release workflow fix.

## Verification
- `TZ=Asia/Bangkok bun scripts/calver.ts --stable --check`
- Verified target tag `v26.5.15` is free.
- Verified diff is `package.json` only.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
