### PR TITLE
fix(wake): wait for fresh tmux session before attach handoff

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -17,6 +17,81 @@ export function shouldOfferExistingSessionAttach(
   return !opts.attach && !opts.split && !opts.bring && Boolean(isTTY);
 }
 
+const FRESH_SESSION_READY_ATTEMPTS = 8;
+const FRESH_SESSION_READY_DELAY_MS = 150;
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    const cause = (error as { cause?: unknown }).cause;
+    return cause ? `${error.message}\n${errorMessage(cause)}` : error.message;
+  }
+  return String(error);
+}
+
+function isFreshSessionLookupRace(error: unknown, session: string): boolean {
+  const message = errorMessage(error);
+  return message.includes(session) && /can't find (session|window|pane)/i.test(message);
+}
+
+export async function waitForTmuxSessionReady(
+  session: string,
+  deps: {
+    hasSession?: (session: string) => Promise<boolean>;
+    sleep?: (ms: number) => Promise<void>;
+    attempts?: number;
+    delayMs?: number;
+  } = {},
+): Promise<void> {
+  const hasSession = deps.hasSession ?? tmux.hasSession.bind(tmux);
+  const wait = deps.sleep ?? sleep;
+  const attempts = deps.attempts ?? FRESH_SESSION_READY_ATTEMPTS;
+  const delayMs = deps.delayMs ?? FRESH_SESSION_READY_DELAY_MS;
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    if (await hasSession(session)) return;
+    if (attempt < attempts) await wait(delayMs);
+  }
+
+  throw new Error(`tmux did not report fresh session '${session}' ready after ${attempts} checks`);
+}
+
+export async function retryFreshSessionTmuxStep<T>(
+  session: string,
+  label: string,
+  step: () => Promise<T>,
+  deps: {
+    sleep?: (ms: number) => Promise<void>;
+    attempts?: number;
+    delayMs?: number;
+    hasSession?: (session: string) => Promise<boolean>;
+  } = {},
+): Promise<T> {
+  const wait = deps.sleep ?? sleep;
+  const attempts = deps.attempts ?? FRESH_SESSION_READY_ATTEMPTS;
+  const delayMs = deps.delayMs ?? FRESH_SESSION_READY_DELAY_MS;
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await step();
+    } catch (error) {
+      if (!isFreshSessionLookupRace(error, session) || attempt === attempts) {
+        throw error;
+      }
+      await wait(delayMs);
+      await waitForTmuxSessionReady(session, {
+        hasSession: deps.hasSession,
+        sleep: wait,
+        attempts: 2,
+        delayMs,
+      });
+    }
+  }
+
+  throw new Error(`unreachable: fresh tmux session setup step '${label}' exhausted without throwing`);
+}
+
 export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; split?: boolean; bring?: boolean; tab?: boolean; repoPath?: string; urlRepoName?: string; allLocal?: boolean; engine?: string }): Promise<string> {
   // Canonicalize the bare name before any lookup — strips trailing `/`, `/.git`, `/.git/`
   // so `maw wake token-oracle/` (tab-completion artifact) resolves the same as `token-oracle`.
@@ -115,9 +190,12 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
     session = session_;
     const mainWindowName = `${oracle}-oracle`;
     await tmux.newSession(session, { window: mainWindowName, cwd: repoPath });
-    await setSessionEnv(session);
+    await waitForTmuxSessionReady(session);
+    await retryFreshSessionTmuxStep(session, "set session environment", () => setSessionEnv(session));
     await new Promise(r => setTimeout(r, 300));
-    await tmux.sendText(`${session}:${mainWindowName}`, buildCommandInDir(mainWindowName, repoPath, opts.engine));
+    await retryFreshSessionTmuxStep(session, "launch main window", () =>
+      tmux.sendText(`${session}:${mainWindowName}`, buildCommandInDir(mainWindowName, repoPath, opts.engine))
+    );
     console.log(`\x1b[32m+\x1b[0m created session '${session}' (main: ${mainWindowName})`);
 
     // Auto-register agent in config.agents so federation peers can route to it (#285)

--- a/test/isolated/wake-session-ready.test.ts
+++ b/test/isolated/wake-session-ready.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import {
+  retryFreshSessionTmuxStep,
+  waitForTmuxSessionReady,
+} from "../../src/commands/shared/wake-cmd";
+
+describe("fresh wake tmux session readiness (#1440)", () => {
+  test("waitForTmuxSessionReady waits until tmux can see the new session", async () => {
+    let checks = 0;
+    const sleeps: number[] = [];
+
+    await waitForTmuxSessionReady("47-mawjs", {
+      attempts: 4,
+      delayMs: 5,
+      sleep: async ms => { sleeps.push(ms); },
+      hasSession: async session => {
+        expect(session).toBe("47-mawjs");
+        checks++;
+        return checks === 3;
+      },
+    });
+
+    expect(checks).toBe(3);
+    expect(sleeps).toEqual([5, 5]);
+  });
+
+  test("retryFreshSessionTmuxStep retries transient can't-find-session startup races", async () => {
+    let attempts = 0;
+    let visibilityChecks = 0;
+
+    const result = await retryFreshSessionTmuxStep("47-mawjs", "launch main window", async () => {
+      attempts++;
+      if (attempts === 1) {
+        throw new Error("[local:local] can't find session: 47-mawjs");
+      }
+      return "launched";
+    }, {
+      attempts: 3,
+      delayMs: 5,
+      sleep: async () => {},
+      hasSession: async session => {
+        expect(session).toBe("47-mawjs");
+        visibilityChecks++;
+        return true;
+      },
+    });
+
+    expect(result).toBe("launched");
+    expect(attempts).toBe(2);
+    expect(visibilityChecks).toBe(1);
+  });
+
+  test("retryFreshSessionTmuxStep does not hide unrelated setup failures", async () => {
+    let attempts = 0;
+
+    await expect(retryFreshSessionTmuxStep("47-mawjs", "set session environment", async () => {
+      attempts++;
+      throw new Error("pass show 'secret' failed (exit 1)");
+    }, {
+      attempts: 3,
+      sleep: async () => {},
+      hasSession: async () => true,
+    })).rejects.toThrow(/pass show/);
+
+    expect(attempts).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes the `maw a <sleeping-oracle>` recovery path that shells out to `maw wake <oracle> -a` and can hit a raw `HostExecError: can't find session` while a fresh tmux session is still becoming visible.
- Adds a bounded wait for the newly-created session before setup.
- Retries only fresh-session tmux lookup races during env setup / first launch; unrelated setup failures still throw.

Closes #1440.

## Verification
- `MAW_TEST_MODE=1 bun test test/isolated/wake-session-ready.test.ts test/isolated/tmux-action-verbs.test.ts`
- `MAW_TEST_MODE=1 bun run build`
- `MAW_TEST_MODE=1 bun run test:isolated` → 87/87 files passed
- `MAW_TEST_MODE=1 bun run test:mock-smoke`
- `MAW_TEST_MODE=1 bun run test:plugin`
- Temp `cmdWake(..., { attach: true })` smoke with isolated `MAW_CONFIG_DIR` and `true` engine

## Known unrelated local gap
- Full default `bun test test/ ...` on this Darwin machine still fails existing `test/curl-fetch.test.ts` Linux/live-peer expectations; not touched by this PR.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
