### PR TITLE
release(stable): v26.5.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.15",
+  "version": "26.5.16",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
## Summary
- Cut stable hotfix `v26.5.16` so the merged #1440 wake/attach fix ships after `v26.5.15` was already released.
- Metadata-only `package.json` bump; code fix is #1442 (`4c0ac510`).

## Verification
- Release workflow will run install, tests, build, tag, and attach `dist/maw` on merge.
- Pre-check: `v26.5.16` tag/release is free.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.