### PR TITLE
fix(kill): validate --pane index and fail loud when out of range

### DIFF
--- a/src/vendor/mpr-plugins/kill/impl.ts
+++ b/src/vendor/mpr-plugins/kill/impl.ts
@@ -62,6 +62,26 @@ export async function cmdKill(target: string, opts: KillOpts = {}) {
   if (opts.pane !== undefined) {
     // Default to window 0 if no window given
     const win = rawWindow || String(r.match.windows[0]?.index ?? 0);
+    const winTarget = `${session}:${win}`;
+    const paneIndexesRaw = await hostExec(
+      `${tmux} list-panes -t '${winTarget}' -F '#{pane_index}'`,
+    ).catch((e: any) => {
+      throw new Error(`list-panes failed for ${winTarget}: ${e?.message || e}`);
+    });
+    const validPaneIndexes = paneIndexesRaw
+      .split("\n")
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map((s) => Number.parseInt(s, 10))
+      .filter((n) => Number.isInteger(n));
+
+    if (!validPaneIndexes.includes(opts.pane)) {
+      const valid = validPaneIndexes.length
+        ? validPaneIndexes.join(", ")
+        : "(none)";
+      throw new Error(`pane ${opts.pane} does not exist in window ${winTarget} (valid: ${valid})`);
+    }
+
     const pane = `${session}:${win}.${opts.pane}`;
     try {
       await hostExec(`${tmux} kill-pane -t '${pane}'`);

--- a/test/isolated/kill-pane-range.test.ts
+++ b/test/isolated/kill-pane-range.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let hostExecCalls: string[] = [];
+
+mock.module("maw-js/sdk", () => ({
+  listSessions: async () => [
+    {
+      name: "47-mawjs",
+      windows: [{ index: 0 }, { index: 1 }],
+    },
+  ],
+  tmuxCmd: () => "tmux",
+  hostExec: async (cmd: string) => {
+    hostExecCalls.push(cmd);
+    if (cmd.includes("list-panes -t '47-mawjs:0'")) return "0\n1\n2\n";
+    if (cmd.includes("kill-pane -t '47-mawjs:0.2'")) return "";
+    throw new Error(`unexpected command: ${cmd}`);
+  },
+}));
+
+const { cmdKill } = await import("../../src/vendor/mpr-plugins/kill/impl");
+
+describe("kill --pane range validation (#1441)", () => {
+  beforeEach(() => {
+    hostExecCalls = [];
+  });
+
+  test("errors when pane index is out of range instead of silently falling back", async () => {
+    await expect(cmdKill("mawjs", { pane: 99 })).rejects.toThrow(
+      "pane 99 does not exist in window 47-mawjs:0 (valid: 0, 1, 2)",
+    );
+
+    expect(hostExecCalls.some((c) => c.includes("kill-pane"))).toBeFalse();
+    expect(hostExecCalls[0]).toContain("list-panes -t '47-mawjs:0'");
+  });
+
+  test("kills the requested pane when index is valid", async () => {
+    await expect(cmdKill("mawjs", { pane: 2 })).resolves.toBeUndefined();
+
+    expect(hostExecCalls[0]).toContain("list-panes -t '47-mawjs:0'");
+    expect(hostExecCalls[1]).toContain("kill-pane -t '47-mawjs:0.2'");
+  });
+});


### PR DESCRIPTION
Closes #1441

## What changed
- Added preflight pane-index validation for `maw kill --pane N` using `tmux list-panes -F #{pane_index}` on the resolved target window.
- Out-of-range now errors clearly and exits non-zero instead of attempting `kill-pane`.
- Added isolated regression tests for out-of-range and valid-index paths.

## Why
Destructive commands must fail loud on index mistakes so wrappers/scripts do not accidentally kill the wrong pane.

## Verification
- `MAW_TEST_MODE=1 bun test test/isolated/kill-pane-range.test.ts`
- `MAW_TEST_MODE=1 bun run test:isolated` (88/88 files passed)

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.