### PR TITLE
fix(wake): skip worktree respawn when matching tile pane role is already live

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -35,6 +35,24 @@ function isFreshSessionLookupRace(error: unknown, session: string): boolean {
   return message.includes(session) && /can't find (session|window|pane)/i.test(message);
 }
 
+export async function getLiveTileRoles(
+  session: string,
+  deps: { hostExecFn?: typeof hostExec } = {},
+): Promise<Set<string>> {
+  const run = deps.hostExecFn ?? hostExec;
+  try {
+    const raw = await run(`tmux list-panes -t '${session}' -F '#{@maw_tile_role}'`);
+    return new Set(
+      raw
+        .split("\n")
+        .map((s) => s.trim())
+        .filter(Boolean),
+    );
+  } catch {
+    return new Set<string>();
+  }
+}
+
 export async function waitForTmuxSessionReady(
   session: string,
   deps: {
@@ -238,8 +256,12 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
       if (allWt.length > 0) {
         const existingWindows = [...preExistingWindows];
         const usedNames = new Set(existingWindows);
+        const liveTileRoles = await getLiveTileRoles(session);
         for (const wt of allWt) {
           const taskPart = wt.name.replace(/^\d+-/, "");
+          // #1445 — tile panes are split panes (role metadata), not windows.
+          // If the role is already alive in-session, skip respawn.
+          if (liveTileRoles.has(taskPart)) continue;
           let wtWindowName = `${oracle}-${taskPart}`;
           if (usedNames.has(wtWindowName)) {
             if (existingWindows.includes(wtWindowName)) continue;

--- a/test/isolated/wake-live-tile-roles.test.ts
+++ b/test/isolated/wake-live-tile-roles.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { getLiveTileRoles } from "../../src/commands/shared/wake-cmd";
+
+describe("getLiveTileRoles (#1445)", () => {
+  test("returns non-empty @maw_tile_role values from list-panes output", async () => {
+    const roles = await getLiveTileRoles("47-mawjs", {
+      hostExecFn: async () => "tile-1\n\n tile-2 \n\n",
+    });
+
+    expect(Array.from(roles).sort()).toEqual(["tile-1", "tile-2"]);
+  });
+
+  test("returns empty set when tmux list-panes fails", async () => {
+    const roles = await getLiveTileRoles("47-mawjs", {
+      hostExecFn: async () => {
+        throw new Error("can't find session");
+      },
+    });
+
+    expect(roles.size).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #1445

## What changed
- Added `getLiveTileRoles(session)` helper to read `@maw_tile_role` values from live panes.
- In existing-session wake worktree respawn path, skip respawn when worktree task role is already live as a tile pane role.

## Why
`maw wake <oracle>` should be idempotent for active tile panes; tile roles are pane metadata, not window names.

## Verification
- `MAW_TEST_MODE=1 bun test test/isolated/wake-live-tile-roles.test.ts`
- `MAW_TEST_MODE=1 bun run test:isolated` (89/89 files passed)

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.