### PR TITLE
release(alpha): carry wake tile-role respawn fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.15-alpha.1252",
+  "version": "26.5.15-alpha.1857",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -57,6 +57,24 @@ async function findExistingOracleWindow(
   return null;
 }
 
+export async function getLiveTileRoles(
+  session: string,
+  deps: { hostExecFn?: typeof hostExec } = {},
+): Promise<Set<string>> {
+  const run = deps.hostExecFn ?? hostExec;
+  try {
+    const raw = await run(`tmux list-panes -t '${session}' -F '#{@maw_tile_role}'`);
+    return new Set(
+      raw
+        .split("\n")
+        .map((s) => s.trim())
+        .filter(Boolean),
+    );
+  } catch {
+    return new Set<string>();
+  }
+}
+
 export async function cmdWake(oracle: string, opts: WakeCmdOptions): Promise<string> {
   // #1151 — reject flag-shaped names. parseFlags lands unrecognized flags
   // (e.g. --help) in positional `_`, so they reach here as oracle="--help"
@@ -238,8 +256,12 @@ export async function cmdWake(oracle: string, opts: WakeCmdOptions): Promise<str
       if (allWt.length > 0) {
         const existingWindows = [...preExistingWindows];
         const usedNames = new Set(existingWindows);
+        const liveTileRoles = await getLiveTileRoles(session);
         for (const wt of allWt) {
           const taskPart = wt.name.replace(/^\d+-/, "");
+          // #1445 — tile panes are split panes (role metadata), not windows.
+          // If the role is already alive in-session, skip respawn.
+          if (liveTileRoles.has(taskPart)) continue;
           let wtWindowName = `${oracle}-${taskPart}`;
           if (usedNames.has(wtWindowName)) {
             if (existingWindows.includes(wtWindowName)) continue;
@@ -400,4 +422,3 @@ export async function cmdWake(oracle: string, opts: WakeCmdOptions): Promise<str
   takeSnapshot("wake").catch(() => {});
   return `${session}:${windowName}`;
 }
-

--- a/test/isolated/wake-live-tile-roles.test.ts
+++ b/test/isolated/wake-live-tile-roles.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { getLiveTileRoles } from "../../src/commands/shared/wake-cmd";
+
+describe("getLiveTileRoles (#1445)", () => {
+  test("returns non-empty @maw_tile_role values from list-panes output", async () => {
+    const roles = await getLiveTileRoles("47-mawjs", {
+      hostExecFn: async () => "tile-1\n\n tile-2 \n\n",
+    });
+
+    expect(Array.from(roles).sort()).toEqual(["tile-1", "tile-2"]);
+  });
+
+  test("returns empty set when tmux list-panes fails", async () => {
+    const roles = await getLiveTileRoles("47-mawjs", {
+      hostExecFn: async () => {
+        throw new Error("can't find session");
+      },
+    });
+
+    expect(roles.size).toBe(0);
+  });
+});


### PR DESCRIPTION
Carries #1445 fix (`df2d90cf`) onto alpha and bumps CalVer alpha for publish.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.