### PR TITLE
fix(update): avoid dep-loop noise before alpha installs

### DIFF
--- a/src/cli/cmd-update.ts
+++ b/src/cli/cmd-update.ts
@@ -10,6 +10,91 @@ import { getVersionString } from "./cmd-version";
 import { ghqFindSync } from "../core/ghq";
 import { withUpdateLock } from "./update-lock";
 
+function clearBunGlobalResolverState(): () => void {
+  // #1449 — Bun can reject `bun add -g github:...#newRef` before it mutates
+  // anything when the global package.json/lock still pins maw-js to a
+  // different GitHub ref. Remove only resolver metadata before the *first*
+  // install attempt; keep the current bin + node_modules in place so a
+  // network/auth failure still leaves the running maw usable.
+  const bunGlobal = join(homedir(), ".bun", "install", "global");
+  const globalPkg = join(bunGlobal, "package.json");
+  let pkgBackup: string | null = null;
+  try {
+    pkgBackup = readFileSync(globalPkg, "utf-8");
+    const data = JSON.parse(pkgBackup);
+    let dirty = false;
+    for (const key of ["maw-js", "maw"]) {
+      if (data.dependencies?.[key]) { delete data.dependencies[key]; dirty = true; }
+    }
+    if (dirty) writeFileSync(globalPkg, JSON.stringify(data, null, 2) + "\n");
+  } catch { /* best effort — fallback path still handles resolver wedges */ }
+
+  try {
+    for (const f of ["bun.lock", "bun.lockb"]) {
+      const p = join(bunGlobal, f);
+      try { if (existsSync(p)) unlinkSync(p); } catch {}
+    }
+  } catch {}
+  try {
+    const cacheDir = join(homedir(), ".bun", "install", "cache");
+    if (existsSync(cacheDir)) {
+      for (const entry of readdirSync(cacheDir)) {
+        if (entry.includes("maw-js")) {
+          try { rmSync(join(cacheDir, entry), { recursive: true, force: true }); } catch {}
+        }
+      }
+    }
+  } catch {}
+
+  return () => {
+    if (pkgBackup === null) return;
+    try { writeFileSync(globalPkg, pkgBackup); } catch {}
+  };
+}
+
+function isPluginSourceDir(dir: string): boolean {
+  return existsSync(join(dir, "plugin.json")) || existsSync(join(dir, "index.ts"));
+}
+
+function linkBundledPluginRoots(pluginDir: string, roots: string[]): number {
+  let refreshed = 0;
+  for (const root of roots) {
+    if (!existsSync(root)) continue;
+    for (const d of readdirSync(root)) {
+      const src = join(root, d);
+      if (!isPluginSourceDir(src)) continue;
+      const dest = join(pluginDir, d);
+      try {
+        if (lstatSync(dest).isSymbolicLink() && !existsSync(dest)) unlinkSync(dest);
+      } catch {}
+      if (!existsSync(dest)) { symlinkSync(src, dest); refreshed++; }
+    }
+  }
+  return refreshed;
+}
+
+function healBrokenPluginSymlinks(pluginDir: string, roots: string[]): { healed: number; pruned: number } {
+  let healed = 0;
+  let pruned = 0;
+  for (const entry of readdirSync(pluginDir)) {
+    const p = join(pluginDir, entry);
+    try {
+      if (!lstatSync(p).isSymbolicLink() || existsSync(p)) continue;
+      const replacement = roots
+        .map((root) => join(root, entry))
+        .find((candidate) => existsSync(candidate) && isPluginSourceDir(candidate));
+      unlinkSync(p);
+      if (replacement) {
+        symlinkSync(replacement, p);
+        healed++;
+      } else {
+        pruned++;
+      }
+    } catch {}
+  }
+  return { healed, pruned };
+}
+
 export async function runUpdate(args: string[]): Promise<void> {
   const { repository } = require("../../package.json");
   // args[0] is "update"; first non-flag positional is the ref.
@@ -156,6 +241,7 @@ export async function runUpdate(args: string[]): Promise<void> {
       stdio: ["inherit", "inherit", "inherit"],
     });
 
+    const restoreResolverState = clearBunGlobalResolverState();
     let installCode = await spawnInstall().exited;
     if (installCode !== 0) {
       console.warn(`\x1b[33m⚠\x1b[0m first install attempt failed — clearing stale global refs and retrying`);
@@ -350,6 +436,7 @@ export async function runUpdate(args: string[]): Promise<void> {
       }
     }
     if (installCode !== 0) {
+      restoreResolverState();
       console.error(`\x1b[31merror\x1b[0m: bun add failed with exit ${installCode} — previous maw restored from stash (if available)`);
       console.error(``);
       console.error(`  Manual recovery (bypass bun resolver — release tags only):`);
@@ -389,33 +476,19 @@ export async function runUpdate(args: string[]): Promise<void> {
       mkdirSync(pluginDir, { recursive: true });
       const mawBin = execSync("which maw", { encoding: "utf-8" }).trim();
       const mawSrc = dirname(realpathSync(mawBin));
-      const bundled = join(mawSrc, "commands", "plugins");
-      if (existsSync(bundled)) {
-        let refreshed = 0;
-        for (const d of readdirSync(bundled)) {
-          if (existsSync(join(bundled, d, "plugin.json")) || existsSync(join(bundled, d, "index.ts"))) {
-            const dest = join(pluginDir, d);
-            // Replace old symlink or missing entry
-            try { if (lstatSync(dest).isSymbolicLink()) unlinkSync(dest); } catch {}
-            if (!existsSync(dest)) { symlinkSync(join(bundled, d), dest); refreshed++; }
-          }
-        }
+      const bundledRoots = [
+        join(mawSrc, "commands", "plugins"),
+        join(mawSrc, "vendor", "mpr-plugins"),
+      ];
+      if (bundledRoots.some((root) => existsSync(root))) {
+        const healed = healBrokenPluginSymlinks(pluginDir, bundledRoots);
+        const refreshed = linkBundledPluginRoots(pluginDir, bundledRoots);
         if (refreshed > 0) console.log(`\n  🔗 ${refreshed} bundled plugins re-linked`);
 
-        // #1015 — prune symlinks that point to plugins no longer in the bundle.
-        let pruned = 0;
-        for (const entry of readdirSync(pluginDir)) {
-          const p = join(pluginDir, entry);
-          try {
-            if (lstatSync(p).isSymbolicLink() && !existsSync(p)) {
-              unlinkSync(p);
-              pruned++;
-            }
-          } catch {}
-        }
-        if (pruned > 0) {
-          console.log(`\n  \x1b[33m⚠\x1b[0m removed ${pruned} broken plugin symlink${pruned === 1 ? "" : "s"} (targets no longer exist)`);
-          console.log(`    run \x1b[90mmaw plugin install standard\x1b[0m to restore from registry`);
+        // #1449 — silently heal broken symlinks when the same plugin is now
+        // bundled under src/vendor/mpr-plugins. Warn only for genuine losses.
+        if (healed.pruned > 0) {
+          console.log(`\n  \x1b[33m⚠\x1b[0m removed ${healed.pruned} broken plugin symlink${healed.pruned === 1 ? "" : "s"} (targets no longer exist)`);
         }
       }
     } catch {}

--- a/src/cli/plugin-bootstrap.test.ts
+++ b/src/cli/plugin-bootstrap.test.ts
@@ -221,6 +221,29 @@ describe("runBootstrap — #817 idempotent bundled-plugin symlinks", () => {
     }
   });
 
+  it("#1449 — broken symlinks are silently healed when the plugin is now vendored", async () => {
+    makeVendoredPlugin("wake");
+
+    mkdirSync(pluginDir, { recursive: true });
+    symlinkSync("/nonexistent/old-maw-js/packages/wake", join(pluginDir, "wake"));
+    expect(lstatSync(join(pluginDir, "wake")).isSymbolicLink()).toBe(true);
+    expect(existsSync(join(pluginDir, "wake"))).toBe(false);
+
+    const originalWarn = console.warn;
+    const warns: string[] = [];
+    console.warn = (...args: unknown[]) => { warns.push(args.map(String).join(" ")); };
+
+    try {
+      await runBootstrap(pluginDir, srcDir);
+
+      expect(lstatSync(join(pluginDir, "wake")).isSymbolicLink()).toBe(true);
+      expect(readlinkSync(join(pluginDir, "wake"))).toBe(join(vendoredDir, "wake"));
+      expect(warns.some(w => w.includes("broken plugin symlink"))).toBe(false);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
   it("pluginSources URL-fetch path is gated behind wasEmpty (only logs on first install)", async () => {
     // The `[maw] bootstrapped N plugins` console.log is inside the `wasEmpty`
     // branch alongside the URL-fetch logic — its presence/absence is a

--- a/src/cli/plugin-bootstrap.ts
+++ b/src/cli/plugin-bootstrap.ts
@@ -4,20 +4,44 @@ import { join } from "path";
 /** Allowlist: only http/https URLs may be used as plugin sources */
 const URL_SCHEME_RE = /^https?:\/\//;
 
+function isPluginDir(dir: string): boolean {
+  return existsSync(join(dir, "plugin.json")) || existsSync(join(dir, "index.ts"));
+}
+
 function linkBundledPlugins(pluginDir: string, bundled: string): number {
   if (!existsSync(bundled)) return 0;
   let linked = 0;
   for (const d of readdirSync(bundled)) {
     const src = join(bundled, d);
     const dest = join(pluginDir, d);
-    const isPlugin =
-      existsSync(join(src, "plugin.json")) || existsSync(join(src, "index.ts"));
-    if (!isPlugin) continue;
+    if (!isPluginDir(src)) continue;
     if (existsSync(dest)) continue; // already linked / user dir / valid symlink
     symlinkSync(src, dest);
     linked++;
   }
   return linked;
+}
+
+function healOrPruneBrokenSymlinks(pluginDir: string, bundledRoots: string[]): { healed: number; pruned: number } {
+  let healed = 0;
+  let pruned = 0;
+  for (const entry of readdirSync(pluginDir)) {
+    const p = join(pluginDir, entry);
+    try {
+      if (!lstatSync(p).isSymbolicLink() || existsSync(p)) continue;
+      const replacement = bundledRoots
+        .map((root) => join(root, entry))
+        .find((candidate) => existsSync(candidate) && isPluginDir(candidate));
+      unlinkSync(p);
+      if (replacement) {
+        symlinkSync(replacement, p);
+        healed++;
+      } else {
+        pruned++;
+      }
+    } catch {}
+  }
+  return { healed, pruned };
 }
 
 /**
@@ -46,16 +70,11 @@ export async function runBootstrap(pluginDir: string, srcDir: string): Promise<v
   //    in ~/.maw/plugins/ become dangling. readdirSync still lists them, but
   //    existsSync returns false (target gone). The plugin loader silently
   //    skips them, so the user sees "unknown command" with no explanation.
-  let pruned = 0;
-  for (const entry of readdirSync(pluginDir)) {
-    const p = join(pluginDir, entry);
-    try {
-      if (lstatSync(p).isSymbolicLink() && !existsSync(p)) {
-        unlinkSync(p);
-        pruned++;
-      }
-    } catch {}
-  }
+  const bundledRoots = [
+    join(srcDir, "commands", "plugins"),
+    join(srcDir, "vendor", "mpr-plugins"),
+  ];
+  const { pruned } = healOrPruneBrokenSymlinks(pluginDir, bundledRoots);
   if (pruned > 0) {
     console.warn(`[maw] removed ${pruned} broken plugin symlink${pruned === 1 ? "" : "s"} from ${pluginDir}`);
   }
@@ -64,13 +83,13 @@ export async function runBootstrap(pluginDir: string, srcDir: string): Promise<v
 
   // 1. Symlink any bundled plugin missing from pluginDir — IDEMPOTENT,
   //    runs every boot. Cheap (fs stat + symlink), no network.
-  linkBundledPlugins(pluginDir, join(srcDir, "commands", "plugins"));
+  linkBundledPlugins(pluginDir, bundledRoots[0]);
 
   // #1339 — fresh installs must also get the maw-plugin-registry command
   // surface (`wake`, `attach`, `done`, `send-enter`, ...). The vendored copy is
   // source-only and intentionally uses the same pluginDir symlink mechanism as
   // in-tree plugins so user-installed plugins keep precedence.
-  linkBundledPlugins(pluginDir, join(srcDir, "vendor", "mpr-plugins"));
+  linkBundledPlugins(pluginDir, bundledRoots[1]);
 
   // 2. Install from pluginSources URLs — first-install only (network calls,
   //    should not retry every boot).

--- a/src/cli/update-lock.ts
+++ b/src/cli/update-lock.ts
@@ -61,7 +61,7 @@ export async function withUpdateLock<T>(fn: () => Promise<T>): Promise<T> {
       } catch { /* treat as stale — holderPid stays NaN */ }
       finally { if (readFd !== null) { try { closeSync(readFd); } catch {} } }
       if (!isAlive(holderPid)) {
-        console.warn(`\x1b[33m⚠\x1b[0m stale update lock (pid ${holderPid || "?"} gone) — taking over`);
+        console.log(`  \x1b[90m⋯ stale update lock (pid ${holderPid || "?"} gone) — taking over\x1b[0m`);
         try { unlinkSync(LOCK_PATH); } catch {}
         continue;
       }

--- a/test/isolated/cmd-update-order.test.ts
+++ b/test/isolated/cmd-update-order.test.ts
@@ -93,6 +93,18 @@ describe("cmd-update source-order invariants", () => {
     expect(src).toMatch(/for \(const key of \["maw-js", "maw"\]\)/);
   });
 
+  it("#1449: resolver metadata is cleared before the first `bun add`", () => {
+    const clearIdx = src.indexOf("const restoreResolverState = clearBunGlobalResolverState()");
+    const firstAddIdx = src.indexOf("let installCode = await spawnInstall().exited");
+    expect(clearIdx).toBeGreaterThan(-1);
+    expect(firstAddIdx).toBeGreaterThan(-1);
+    expect(clearIdx).toBeLessThan(firstAddIdx);
+  });
+
+  it("#1449: total install failure restores preflight resolver metadata", () => {
+    expect(src).toMatch(/if\s*\(\s*installCode\s*!==\s*0\s*\)\s*\{\s*restoreResolverState\(\)/);
+  });
+
   it("#950: node_modules eviction covers maw-js, maw, and @maw-js", () => {
     // maw-js is the package the `~/.bun/bin/maw` symlink resolves through, so
     // it is moved aside by RENAME (recoverable for the restore path) rather

--- a/test/isolated/update-lock.test.ts
+++ b/test/isolated/update-lock.test.ts
@@ -214,19 +214,16 @@ describe("withUpdateLock — acquisition + release (#551)", () => {
     stubDateNow([0, 500, 500]);
     const { withUpdateLock } = await import("../../src/cli/update-lock");
 
-    const origWarn = console.warn;
     const origLog = console.log;
-    const warns: string[] = [];
-    console.warn = (...a: unknown[]) => warns.push(a.map(String).join(" "));
-    console.log = () => {};
+    const logs: string[] = [];
+    console.log = (...a: unknown[]) => logs.push(a.map(String).join(" "));
     try {
       await withUpdateLock(async () => {});
     } finally {
-      console.warn = origWarn;
       console.log = origLog;
     }
 
-    expect(warns.some((w) => w.includes("stale update lock") && w.includes("taking over"))).toBe(true);
+    expect(logs.some((w) => w.includes("stale update lock") && w.includes("taking over"))).toBe(true);
     // Successful-open fd (5) eventually closed in finally.
     expect(calls.some((c) => c.fn === "closeSync" && c.args[0] === 5)).toBe(true);
   });


### PR DESCRIPTION
## Summary

Closes #1449.

- clear Bun global resolver metadata before the first `bun add -g github:...#ref` attempt, while keeping the current binary/package in place
- restore the preflight package metadata if every install path fails
- demote dead `~/.maw/update.lock` takeover from warning to info
- heal broken plugin symlinks silently when the replacement exists under bundled/vendored plugins; warn only for genuine losses

Also filed #1451 for the local post-commit hook template/source mismatch discovered while committing (hook omitted the Zenoh external flag that package/CI already use).

## Validation

- `MAW_TEST_MODE=1 bun test test/isolated/update-lock.test.ts test/isolated/cmd-update-order.test.ts src/cli/plugin-bootstrap.test.ts`
- `MAW_TEST_MODE=1 bun run test:isolated` — 89/89 files passed
- `MAW_TEST_MODE=1 bun run test:mock-smoke`
- `MAW_TEST_MODE=1 bun run test:plugin`
- `bun run build`
- `bash .git/hooks/post-commit` after local hook patch for #1451

Noted but not caused by this PR: `MAW_TEST_MODE=1 bun run test` still has existing macOS `test/curl-fetch.test.ts` failures that assert Linux/white.local behavior.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
