### PR TITLE
release(alpha): publish update dep-loop fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.15-alpha.1857",
+  "version": "26.5.15-alpha.1928",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/cli/cmd-update.ts
+++ b/src/cli/cmd-update.ts
@@ -10,6 +10,91 @@ import { getVersionString } from "./cmd-version";
 import { ghqFindSync } from "../core/ghq";
 import { withUpdateLock } from "./update-lock";
 
+function clearBunGlobalResolverState(): () => void {
+  // #1449 — Bun can reject `bun add -g github:...#newRef` before it mutates
+  // anything when the global package.json/lock still pins maw-js to a
+  // different GitHub ref. Remove only resolver metadata before the *first*
+  // install attempt; keep the current bin + node_modules in place so a
+  // network/auth failure still leaves the running maw usable.
+  const bunGlobal = join(homedir(), ".bun", "install", "global");
+  const globalPkg = join(bunGlobal, "package.json");
+  let pkgBackup: string | null = null;
+  try {
+    pkgBackup = readFileSync(globalPkg, "utf-8");
+    const data = JSON.parse(pkgBackup);
+    let dirty = false;
+    for (const key of ["maw-js", "maw"]) {
+      if (data.dependencies?.[key]) { delete data.dependencies[key]; dirty = true; }
+    }
+    if (dirty) writeFileSync(globalPkg, JSON.stringify(data, null, 2) + "\n");
+  } catch { /* best effort — fallback path still handles resolver wedges */ }
+
+  try {
+    for (const f of ["bun.lock", "bun.lockb"]) {
+      const p = join(bunGlobal, f);
+      try { if (existsSync(p)) unlinkSync(p); } catch {}
+    }
+  } catch {}
+  try {
+    const cacheDir = join(homedir(), ".bun", "install", "cache");
+    if (existsSync(cacheDir)) {
+      for (const entry of readdirSync(cacheDir)) {
+        if (entry.includes("maw-js")) {
+          try { rmSync(join(cacheDir, entry), { recursive: true, force: true }); } catch {}
+        }
+      }
+    }
+  } catch {}
+
+  return () => {
+    if (pkgBackup === null) return;
+    try { writeFileSync(globalPkg, pkgBackup); } catch {}
+  };
+}
+
+function isPluginSourceDir(dir: string): boolean {
+  return existsSync(join(dir, "plugin.json")) || existsSync(join(dir, "index.ts"));
+}
+
+function linkBundledPluginRoots(pluginDir: string, roots: string[]): number {
+  let refreshed = 0;
+  for (const root of roots) {
+    if (!existsSync(root)) continue;
+    for (const d of readdirSync(root)) {
+      const src = join(root, d);
+      if (!isPluginSourceDir(src)) continue;
+      const dest = join(pluginDir, d);
+      try {
+        if (lstatSync(dest).isSymbolicLink() && !existsSync(dest)) unlinkSync(dest);
+      } catch {}
+      if (!existsSync(dest)) { symlinkSync(src, dest); refreshed++; }
+    }
+  }
+  return refreshed;
+}
+
+function healBrokenPluginSymlinks(pluginDir: string, roots: string[]): { healed: number; pruned: number } {
+  let healed = 0;
+  let pruned = 0;
+  for (const entry of readdirSync(pluginDir)) {
+    const p = join(pluginDir, entry);
+    try {
+      if (!lstatSync(p).isSymbolicLink() || existsSync(p)) continue;
+      const replacement = roots
+        .map((root) => join(root, entry))
+        .find((candidate) => existsSync(candidate) && isPluginSourceDir(candidate));
+      unlinkSync(p);
+      if (replacement) {
+        symlinkSync(replacement, p);
+        healed++;
+      } else {
+        pruned++;
+      }
+    } catch {}
+  }
+  return { healed, pruned };
+}
+
 export async function runUpdate(args: string[]): Promise<void> {
   const { repository } = require("../../package.json");
   // args[0] is "update"; first non-flag positional is the ref.
@@ -144,6 +229,7 @@ export async function runUpdate(args: string[]): Promise<void> {
       stdio: ["inherit", "inherit", "inherit"],
     });
 
+    const restoreResolverState = clearBunGlobalResolverState();
     let installCode = await spawnInstall().exited;
     if (installCode !== 0) {
       console.warn(`\x1b[33m⚠\x1b[0m first install attempt failed — clearing stale global refs and retrying`);
@@ -281,6 +367,7 @@ export async function runUpdate(args: string[]): Promise<void> {
       }
     }
     if (installCode !== 0) {
+      restoreResolverState();
       console.error(`\x1b[31merror\x1b[0m: bun add failed with exit ${installCode} — previous maw restored from stash (if available)`);
       console.error(``);
       console.error(`  Manual recovery (bypass bun resolver — release tags only):`);
@@ -320,41 +407,27 @@ export async function runUpdate(args: string[]): Promise<void> {
       mkdirSync(pluginDir, { recursive: true });
       const mawBin = execSync("which maw", { encoding: "utf-8" }).trim();
       const mawSrc = dirname(realpathSync(mawBin));
-      const bundled = join(mawSrc, "commands", "plugins");
+      const bundledRoots = [
+        join(mawSrc, "commands", "plugins"),
+        join(mawSrc, "vendor", "mpr-plugins"),
+      ].filter((root) => existsSync(root));
       // #1314 — refuse to re-link into a transient/worktree path. `which maw`
       // resolving into /tmp/<worktree>/ via `bun link` would otherwise write
       // symlinks that go dangling when the worktree is removed, leaving the
       // user with "unknown command: <bundled-plugin>" until they re-link from
-      // a stable checkout. Mirrors plugin-bootstrap.ts isTransientPath guard.
-      if (/^(\/private)?\/tmp\//.test(bundled)) {
-        console.log(`\n  \x1b[33m⚠\x1b[0m bundled plugins resolve to transient path (${bundled}) — skipping re-link`);
+      // a stable checkout.
+      if (bundledRoots.some((root) => /^(\/private)?\/tmp\//.test(root))) {
+        console.log(`\n  \x1b[33m⚠\x1b[0m bundled plugins resolve to transient path (${bundledRoots.join(", ")}) — skipping re-link`);
         console.log(`    re-run \x1b[90mbun link maw-js\x1b[0m from your stable checkout when ready (#1314)`);
-      } else if (existsSync(bundled)) {
-        let refreshed = 0;
-        for (const d of readdirSync(bundled)) {
-          if (existsSync(join(bundled, d, "plugin.json")) || existsSync(join(bundled, d, "index.ts"))) {
-            const dest = join(pluginDir, d);
-            // Replace old symlink or missing entry
-            try { if (lstatSync(dest).isSymbolicLink()) unlinkSync(dest); } catch {}
-            if (!existsSync(dest)) { symlinkSync(join(bundled, d), dest); refreshed++; }
-          }
-        }
+      } else if (bundledRoots.length > 0) {
+        const healed = healBrokenPluginSymlinks(pluginDir, bundledRoots);
+        const refreshed = linkBundledPluginRoots(pluginDir, bundledRoots);
         if (refreshed > 0) console.log(`\n  🔗 ${refreshed} bundled plugins re-linked`);
 
-        // #1015 — prune symlinks that point to plugins no longer in the bundle.
-        let pruned = 0;
-        for (const entry of readdirSync(pluginDir)) {
-          const p = join(pluginDir, entry);
-          try {
-            if (lstatSync(p).isSymbolicLink() && !existsSync(p)) {
-              unlinkSync(p);
-              pruned++;
-            }
-          } catch {}
-        }
-        if (pruned > 0) {
-          console.log(`\n  \x1b[33m⚠\x1b[0m removed ${pruned} broken plugin symlink${pruned === 1 ? "" : "s"} (targets no longer exist)`);
-          console.log(`    run \x1b[90mmaw plugin install standard\x1b[0m to restore from registry`);
+        // #1449 — silently heal broken symlinks when the same plugin is now
+        // bundled under src/vendor/mpr-plugins. Warn only for genuine losses.
+        if (healed.pruned > 0) {
+          console.log(`\n  \x1b[33m⚠\x1b[0m removed ${healed.pruned} broken plugin symlink${healed.pruned === 1 ? "" : "s"} (targets no longer exist)`);
         }
       }
     } catch {}

--- a/src/cli/command-registry-execute.ts
+++ b/src/cli/command-registry-execute.ts
@@ -6,6 +6,8 @@
  */
 
 import { parseFlags } from "./parse-args";
+import { realpathSync } from "fs";
+import { pathToFileURL } from "url";
 import {
   preCacheBridge, readString,
   textEncoder, textDecoder,
@@ -91,7 +93,10 @@ export async function executeCommand(desc: CommandDescriptor, remaining: string[
     }
     return;
   }
-  const mod = await import(desc.path!);
+  // Bun canary on macOS can lose later dynamic imports that come through the
+  // /var → /private/var symlink. Import the canonical file URL so temporary
+  // JS command modules load deterministically across runners.
+  const mod = await import(pathToFileURL(realpathSync(desc.path!)).href);
   const handler = mod.default || mod.handler;
   if (!handler) { console.error(`[commands] ${desc.name}: no default export or handler`); return; }
   const flags = desc.flags ? parseFlags(["_", ...remaining], desc.flags, 1) : { _: remaining };

--- a/src/cli/plugin-bootstrap.test.ts
+++ b/src/cli/plugin-bootstrap.test.ts
@@ -215,7 +215,17 @@ describe("runBootstrap — #817 idempotent bundled-plugin symlinks", () => {
   });
 
   it("#1449 — broken symlinks are silently healed when the plugin is now vendored", async () => {
-    makeVendoredPlugin("wake");
+    // Use a repo-local stable source path for the vendored replacement.
+    // On Linux CI, `tmpdir()` is `/tmp`, and #1314 intentionally refuses to
+    // heal plugin symlinks *to* transient/worktree paths. The user-facing
+    // #1449 case is a real package checkout, not a temp worktree.
+    const stableRoot = mkdtempSync(join(process.cwd(), ".tmp-maw-bootstrap-heal-"));
+    const stableSrcDir = join(stableRoot, "src");
+    const stableVendoredDir = join(stableSrcDir, "vendor", "mpr-plugins");
+    const wakeDir = join(stableVendoredDir, "wake");
+    mkdirSync(wakeDir, { recursive: true });
+    writeFileSync(join(wakeDir, "plugin.json"), JSON.stringify({ name: "wake" }));
+    writeFileSync(join(wakeDir, "index.ts"), `export default async () => ({ ok: true });\n`);
 
     mkdirSync(pluginDir, { recursive: true });
     symlinkSync("/nonexistent/old-maw-js/packages/wake", join(pluginDir, "wake"));
@@ -227,13 +237,14 @@ describe("runBootstrap — #817 idempotent bundled-plugin symlinks", () => {
     console.warn = (...args: unknown[]) => { warns.push(args.map(String).join(" ")); };
 
     try {
-      await runBootstrap(pluginDir, srcDir);
+      await runBootstrap(pluginDir, stableSrcDir);
 
       expect(lstatSync(join(pluginDir, "wake")).isSymbolicLink()).toBe(true);
-      expect(readlinkSync(join(pluginDir, "wake"))).toBe(join(vendoredDir, "wake"));
+      expect(readlinkSync(join(pluginDir, "wake"))).toBe(join(stableVendoredDir, "wake"));
       expect(warns.some(w => w.includes("broken plugin symlink"))).toBe(false);
     } finally {
       console.warn = originalWarn;
+      rmSync(stableRoot, { recursive: true, force: true });
     }
   });
 

--- a/src/cli/plugin-bootstrap.test.ts
+++ b/src/cli/plugin-bootstrap.test.ts
@@ -49,6 +49,7 @@ describe("runBootstrap — #817 idempotent bundled-plugin symlinks", () => {
   let srcDir: string;
   let pluginDir: string;
   let bundledDir: string;
+  let vendoredDir: string;
 
   beforeEach(() => {
     // mkdtempSync is atomic — appends 6 random chars + creates the dir in one
@@ -58,6 +59,7 @@ describe("runBootstrap — #817 idempotent bundled-plugin symlinks", () => {
     srcDir = join(workDir, "src");
     pluginDir = join(workDir, "plugins");
     bundledDir = join(srcDir, "commands", "plugins");
+    vendoredDir = join(srcDir, "vendor", "mpr-plugins");
     mkdirSync(bundledDir, { recursive: true });
   });
 
@@ -74,6 +76,15 @@ describe("runBootstrap — #817 idempotent bundled-plugin symlinks", () => {
     } else {
       writeFileSync(join(dir, "index.ts"), `export default async () => ({ ok: true });\n`);
     }
+    return dir;
+  }
+
+  /** Helper: create a vendored plugin dir that runBootstrap can heal to. */
+  function makeVendoredPlugin(name: string) {
+    const dir = join(vendoredDir, name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "plugin.json"), JSON.stringify({ name }));
+    writeFileSync(join(dir, "index.ts"), `export default async () => ({ ok: true });\n`);
     return dir;
   }
 
@@ -198,6 +209,29 @@ describe("runBootstrap — #817 idempotent bundled-plugin symlinks", () => {
       expect(entries).toContain("alpha");
       // Warning was logged
       expect(warns.some(w => w.includes("2 broken plugin symlink"))).toBe(true);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  it("#1449 — broken symlinks are silently healed when the plugin is now vendored", async () => {
+    makeVendoredPlugin("wake");
+
+    mkdirSync(pluginDir, { recursive: true });
+    symlinkSync("/nonexistent/old-maw-js/packages/wake", join(pluginDir, "wake"));
+    expect(lstatSync(join(pluginDir, "wake")).isSymbolicLink()).toBe(true);
+    expect(existsSync(join(pluginDir, "wake"))).toBe(false);
+
+    const originalWarn = console.warn;
+    const warns: string[] = [];
+    console.warn = (...args: unknown[]) => { warns.push(args.map(String).join(" ")); };
+
+    try {
+      await runBootstrap(pluginDir, srcDir);
+
+      expect(lstatSync(join(pluginDir, "wake")).isSymbolicLink()).toBe(true);
+      expect(readlinkSync(join(pluginDir, "wake"))).toBe(join(vendoredDir, "wake"));
+      expect(warns.some(w => w.includes("broken plugin symlink"))).toBe(false);
     } finally {
       console.warn = originalWarn;
     }

--- a/src/cli/plugin-bootstrap.ts
+++ b/src/cli/plugin-bootstrap.ts
@@ -25,6 +25,10 @@ function isTransientPath(p: string): boolean {
   return /^(\/private)?\/tmp\//.test(p);
 }
 
+function isPluginDir(dir: string): boolean {
+  return existsSync(join(dir, "plugin.json")) || existsSync(join(dir, "index.ts"));
+}
+
 /**
  * Resolve the absolute path to the bundled-plugins directory.
  *
@@ -86,6 +90,28 @@ async function persistBundledPath(resolvedPath: string): Promise<void> {
   } catch {}
 }
 
+function healOrPruneBrokenSymlinks(pluginDir: string, bundledRoots: string[]): { healed: number; pruned: number } {
+  let healed = 0;
+  let pruned = 0;
+  for (const entry of readdirSync(pluginDir)) {
+    const p = join(pluginDir, entry);
+    try {
+      if (!lstatSync(p).isSymbolicLink() || existsSync(p)) continue;
+      const replacement = bundledRoots
+        .map((root) => join(root, entry))
+        .find((candidate) => existsSync(candidate) && isPluginDir(candidate) && !isTransientPath(candidate));
+      unlinkSync(p);
+      if (replacement) {
+        symlinkSync(replacement, p);
+        healed++;
+      } else {
+        pruned++;
+      }
+    } catch {}
+  }
+  return { healed, pruned };
+}
+
 /**
  * Auto-bootstrap plugins into pluginDir.
  *
@@ -122,21 +148,14 @@ export async function runBootstrap(pluginDir: string, srcDir: string): Promise<v
     }
   } catch { /* never fatal on bootstrap */ }
 
-  // 0. #1015 — prune broken symlinks before anything else. After an update
-  //    removes bundled plugins from src/commands/plugins/, their old symlinks
-  //    in ~/.maw/plugins/ become dangling. readdirSync still lists them, but
-  //    existsSync returns false (target gone). The plugin loader silently
-  //    skips them, so the user sees "unknown command" with no explanation.
-  let pruned = 0;
-  for (const entry of readdirSync(pluginDir)) {
-    const p = join(pluginDir, entry);
-    try {
-      if (lstatSync(p).isSymbolicLink() && !existsSync(p)) {
-        unlinkSync(p);
-        pruned++;
-      }
-    } catch {}
-  }
+  // 0. #1015/#1449 — heal broken symlinks before anything else. After an
+  //    update moves bundled plugins, old symlinks become dangling. If the
+  //    same plugin exists in the resolved bundled root, silently re-link it;
+  //    warn only for symlinks that cannot be healed.
+  const bundled = await resolveBundledPath(srcDir);
+  const vendored = join(srcDir, "vendor", "mpr-plugins");
+  const bundledRoots = [bundled, vendored].filter((p): p is string => !!p && existsSync(p));
+  const { pruned } = healOrPruneBrokenSymlinks(pluginDir, bundledRoots);
   if (pruned > 0) {
     console.warn(`[maw] removed ${pruned} broken plugin symlink${pruned === 1 ? "" : "s"} from ${pluginDir}`);
   }
@@ -149,15 +168,12 @@ export async function runBootstrap(pluginDir: string, srcDir: string): Promise<v
   // Auto-heal: if dest is a symlink pointing to a path that's NOT under the
   //   current bundled root (e.g., a deleted clone path), re-link it. Prevents
   //   silent "unknown command: tmux" after migrating between maw-js checkouts.
-  const bundled = await resolveBundledPath(srcDir);
   if (bundled) {
     let healed = 0;
     for (const d of readdirSync(bundled)) {
       const src = join(bundled, d);
       const dest = join(pluginDir, d);
-      const isPlugin =
-        existsSync(join(src, "plugin.json")) || existsSync(join(src, "index.ts"));
-      if (!isPlugin) continue;
+      if (!isPluginDir(src)) continue;
       if (existsSync(dest)) {
         // Heal: if dest is a symlink pointing to a stale bundled location,
         // re-link to the current bundled path. Plain dirs (user overrides)

--- a/src/cli/update-lock.ts
+++ b/src/cli/update-lock.ts
@@ -63,7 +63,7 @@ export async function withUpdateLock<T>(fn: () => Promise<T>): Promise<T> {
       } catch { /* treat as stale — holderPid stays NaN */ }
       finally { if (readFd !== null) { try { closeSync(readFd); } catch {} } }
       if (!isAlive(holderPid)) {
-        console.warn(`\x1b[33m⚠\x1b[0m stale update lock (pid ${holderPid || "?"} gone) — taking over`);
+        console.log(`  \x1b[90m⋯ stale update lock (pid ${holderPid || "?"} gone) — taking over\x1b[0m`);
         try { unlinkSync(LOCK_PATH); } catch {}
         continue;
       }

--- a/src/plugin/registry-invoke.ts
+++ b/src/plugin/registry-invoke.ts
@@ -4,7 +4,8 @@
  * WASM plugins with a hard 5-second timeout.
  */
 
-import { readFileSync } from "fs";
+import { readFileSync, realpathSync } from "fs";
+import { pathToFileURL } from "url";
 import {
   buildImportObject,
   preCacheBridge,
@@ -95,7 +96,7 @@ export async function invokePlugin(
   // honest behavior for Phase A (no sandbox).
   if (plugin.kind === "ts" && plugin.entryPath) {
     try {
-      const mod = await import(plugin.entryPath);
+      const mod = await import(pathToFileURL(realpathSync(plugin.entryPath)).href);
       const handler = mod.default || mod.handler;
       if (!handler) return { ok: false, error: "TS plugin has no default export or handler" };
 

--- a/test/isolated/cmd-update-order.test.ts
+++ b/test/isolated/cmd-update-order.test.ts
@@ -93,7 +93,20 @@ describe("cmd-update source-order invariants", () => {
     expect(src).toMatch(/for \(const key of \["maw-js", "maw"\]\)/);
   });
 
+  it("#1449: resolver metadata is cleared before the first `bun add`", () => {
+    const clearIdx = src.indexOf("const restoreResolverState = clearBunGlobalResolverState()");
+    const firstAddIdx = src.indexOf("let installCode = await spawnInstall().exited");
+    expect(clearIdx).toBeGreaterThan(-1);
+    expect(firstAddIdx).toBeGreaterThan(-1);
+    expect(clearIdx).toBeLessThan(firstAddIdx);
+  });
+
+  it("#1449: total install failure restores preflight resolver metadata", () => {
+    expect(src).toMatch(/if\s*\(\s*installCode\s*!==\s*0\s*\)\s*\{\s*restoreResolverState\(\)/);
+  });
+
   it("#950: direct-rm covers maw-js, maw, and @maw-js node_modules", () => {
     expect(src).toMatch(/for \(const name of \["maw-js", "maw", "@maw-js"\]\)/);
+
   });
 });

--- a/test/isolated/update-lock.test.ts
+++ b/test/isolated/update-lock.test.ts
@@ -214,19 +214,16 @@ describe("withUpdateLock — acquisition + release (#551)", () => {
     stubDateNow([0, 500, 500]);
     const { withUpdateLock } = await import("../../src/cli/update-lock");
 
-    const origWarn = console.warn;
     const origLog = console.log;
-    const warns: string[] = [];
-    console.warn = (...a: unknown[]) => warns.push(a.map(String).join(" "));
-    console.log = () => {};
+    const logs: string[] = [];
+    console.log = (...a: unknown[]) => logs.push(a.map(String).join(" "));
     try {
       await withUpdateLock(async () => {});
     } finally {
-      console.warn = origWarn;
       console.log = origLog;
     }
 
-    expect(warns.some((w) => w.includes("stale update lock") && w.includes("taking over"))).toBe(true);
+    expect(logs.some((w) => w.includes("stale update lock") && w.includes("taking over"))).toBe(true);
     // Successful-open fd (5) eventually closed in finally.
     expect(calls.some((c) => c.fn === "closeSync" && c.args[0] === 5)).toBe(true);
   });

--- a/test/wake-resolve-scan-suggest.test.ts
+++ b/test/wake-resolve-scan-suggest.test.ts
@@ -4,7 +4,7 @@
  *
  * All tests use injected deps — no real gh/ghq calls, no /dev/tty access.
  */
-import { describe, test, expect, beforeEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import {
   extractGhqOrgs,
   buildOrgList,
@@ -20,7 +20,31 @@ import {
 
 // #770 — every test that exercises the org-scope filter must start from a
 // clean cache; otherwise a prior test's mocked execFn leaks across cases.
-beforeEach(() => { _resetAllowedOrgsCache(); });
+const realConsoleLog = console.log;
+const realConsoleError = console.error;
+const realStdoutWrite = process.stdout.write;
+const quietStdoutWrite = ((chunk: unknown, encoding?: unknown, cb?: unknown) => {
+  void chunk;
+  if (typeof encoding === "function") encoding();
+  if (typeof cb === "function") cb();
+  return true;
+}) as typeof process.stdout.write;
+
+beforeEach(() => {
+  _resetAllowedOrgsCache();
+  // These tests exercise the interactive scan renderer with mock gh/ghq deps.
+  // Keep CI logs focused on failures; assertions below still override and
+  // inspect console output when output itself is the behavior under test.
+  console.log = () => {};
+  console.error = () => {};
+  process.stdout.write = quietStdoutWrite;
+});
+
+afterEach(() => {
+  console.log = realConsoleLog;
+  console.error = realConsoleError;
+  process.stdout.write = realStdoutWrite;
+});
 
 // ---------------------------------------------------------------------------
 // extractGhqOrgs — unit tests


### PR DESCRIPTION
## Summary

Publishes `v26.5.15-alpha.1928` so `maw update alpha` can install the #1449 update fixes.

Includes:
- #1452 carry: avoid first-attempt Bun dependency-loop noise during `maw update alpha`
- dead update-lock takeover demoted from warning to info
- broken plugin symlinks healed silently when a bundled/vendored replacement exists
- alpha catch-up for canonical file-URL TS plugin imports, matching main behavior and keeping alpha isolated tests green on macOS/Bun canary

## Validation

- `MAW_TEST_MODE=1 bun test test/isolated/update-lock.test.ts test/isolated/cmd-update-order.test.ts src/cli/plugin-bootstrap.test.ts`
- `MAW_TEST_MODE=1 bun test test/isolated/command-registry-execute.test.ts test/isolated/registry-invoke.test.ts`
- `MAW_TEST_MODE=1 bun run test:isolated` — 87/87 files passed
- `MAW_TEST_MODE=1 bun run test:mock-smoke`
- `MAW_TEST_MODE=1 bun run test:plugin`
- `bun run build`

On merge, calver-release.yml should publish `v26.5.15-alpha.1928` to GitHub/npm alpha.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
