### PR TITLE
fix(routing): keep local tmux pane targets local

### DIFF
--- a/src/core/routing.ts
+++ b/src/core/routing.ts
@@ -105,9 +105,11 @@ export function resolveTarget(
     const agentName = query.slice(colonIdx + 1);
     if (!nodeName || !agentName) return { type: "error", reason: "empty_node_or_agent", detail: `invalid format: '${query}'`, hint: "use node:agent format (e.g. mba:homekeeper)" };
 
-    // Self-node check: "m5:discord" from m5 → resolve locally
+    // Self-node check: "m5:discord" from m5 → resolve locally.
+    // "local:" is an advertised same-host alias and must not fall through
+    // to peer lookup (e.g. #1450: host config uses "local" but node is "m5").
     // #1107: fleet config first to prevent substring collision
-    if (nodeName === selfNode) {
+    if (nodeName === selfNode || nodeName === "local") {
       const selfFleet = resolveFleetSession(agentName) || resolveFleetSession(agentName.replace(/-oracle$/, ""));
       if (selfFleet) {
         const fleetTarget = findWindow(writable.filter(s => s.name === selfFleet), agentName)

--- a/src/core/runtime/find-window.ts
+++ b/src/core/runtime/find-window.ts
@@ -135,7 +135,8 @@ export function findWindow(sessions: Session[], query: string): string | null {
   if (sub.size > 1) throw new AmbiguousMatchError(query, [...sub]);
   // If query has ":" and the SESSION part matched a real session but the
   // WINDOW part didn't → only return raw query when winPart is empty
-  // (first window) or numeric (literal tmux index like "08-mawjs:1").
+  // (first window), numeric (literal tmux window index like "08-mawjs:1"),
+  // or pane-specific (literal tmux pane address like "47-mawjs:1.0").
   // Otherwise return null so resolveTarget Step 2 can try peer routing
   // (e.g. "oracle-world:100-pulse" → peer namedPeer, not local tmux).
   if (query.includes(":")) {
@@ -143,7 +144,7 @@ export function findWindow(sessions: Session[], query: string): string | null {
     const sessExists = matchSession(sessions, sessPart, true);
     if (!sessExists) return null;
     if (!winPart) return query;
-    if (/^\d+$/.test(winPart)) return query;
+    if (/^\d+(?:\.\d+)?$/.test(winPart)) return query;
     return null;
   }
   return null;

--- a/test/isolated/plugin-dts-gen.test.ts
+++ b/test/isolated/plugin-dts-gen.test.ts
@@ -23,6 +23,9 @@ import { cmdPluginBuild } from "../../src/commands/plugins/plugin/build-impl";
 // ─── Harness ─────────────────────────────────────────────────────────────────
 
 const created: string[] = [];
+// CI shard load can push the external `bun x tsc` subprocess just past Bun's
+// default 5s test timeout. Keep the test deterministic while still bounding it.
+const DTS_TEST_TIMEOUT_MS = 15_000;
 
 function tmpDir(prefix = "maw-dts-test-"): string {
   const d = mkdtempSync(join(tmpdir(), prefix));
@@ -133,7 +136,7 @@ describe("generatePluginDts", () => {
     expect(content).toContain("greeting: string");
     // Must contain the default export signature
     expect(content).toContain("export default function handler");
-  });
+  }, DTS_TEST_TIMEOUT_MS);
 
   test("emitted .d.ts contains exported types from plugin source", () => {
     const dir = scaffoldPlugin({
@@ -159,7 +162,7 @@ export interface TypedOptions {
     expect(content).toContain('"read" | "write"');
     expect(content).toContain("TypedOptions");
     expect(content).toContain("timeout: number");
-  });
+  }, DTS_TEST_TIMEOUT_MS);
 
   test("throws when entry file does not exist", () => {
     const dir = tmpDir();
@@ -212,7 +215,7 @@ describe("cmdPluginBuild --types flag", () => {
     // Summary line includes types mention
     expect(stdout).toContain("types:");
     expect(stdout).toContain("greet.d.ts");
-  });
+  }, DTS_TEST_TIMEOUT_MS);
 
   test("does NOT emit .d.ts when --types is absent", async () => {
     const dir = scaffoldPlugin({ name: "notypes" });

--- a/test/routing.test.ts
+++ b/test/routing.test.ts
@@ -53,6 +53,15 @@ describe("resolveTarget", () => {
     expect(r).toEqual({ type: "local", target: "13-mother:1" });
   });
 
+  test("session:window.pane tmux address stays local before node:agent routing (#1450)", () => {
+    const sessions: Session[] = [
+      ...SESSIONS,
+      { name: "47-mawjs", windows: [{ index: 1, name: "mawjs-oracle", active: true }] },
+    ];
+    const r = resolveTarget("47-mawjs:1.0", BASE_CONFIG, sessions);
+    expect(r).toEqual({ type: "local", target: "47-mawjs:1.0" });
+  });
+
   // #3: NODE:AGENT → REMOTE PEER
   test("node:agent resolves to remote peer", () => {
     const r = resolveTarget("mba:homekeeper", BASE_CONFIG, SESSIONS);
@@ -69,6 +78,11 @@ describe("resolveTarget", () => {
   test("self-node prefix with no local match returns error", () => {
     const r = resolveTarget("white:ghost", BASE_CONFIG, SESSIONS);
     expect(r).toMatchObject({ type: "error", reason: "self_not_running" });
+  });
+
+  test("local: prefix is a self-node alias and resolves locally (#1450)", () => {
+    const r = resolveTarget("local:mawjs", BASE_CONFIG, SESSIONS);
+    expect(r).toEqual({ type: "self-node", target: "08-mawjs:1" });
   });
 
   // #6: NODE:AGENT → UNKNOWN NODE


### PR DESCRIPTION
## Summary
- Fix #1450 for alpha by treating literal tmux `session:window.pane` addresses as local targets before peer node parsing.
- Restore advertised `local:` same-host alias even when `config.node` is a real node name such as `m5`.
- Add resolver regressions for `47-mawjs:1.0` and `local:mawjs`.
- Fix #1457 by giving only the declaration-generator tests enough timeout budget for their external `bun x tsc` subprocess under CI shard load.

## Verification
- `MAW_SKIP_FLAKY=1 MAW_TEST_MODE=1 bun test test/routing.test.ts`
- `MAW_SKIP_FLAKY=1 MAW_TEST_MODE=1 bun test test/isolated/resolve-local-first.test.ts`
- `MAW_SKIP_FLAKY=1 MAW_TEST_MODE=1 bun test test/isolated/plugin-dts-gen.test.ts`
- `MAW_SKIP_FLAKY=1 MAW_TEST_MODE=1 bun run build`

Closes #1450 for the alpha lane.
Closes #1457 for the alpha lane.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
