### PR TITLE
release: v26.5.15-alpha.2004

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.15-alpha.1928",
+  "version": "26.5.15-alpha.2004",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump alpha package version from `26.5.15-alpha.1928` to `26.5.15-alpha.2004`.
- Publishes the merged #1456 fixes for #1450 same-host tmux pane routing and #1457 plugin-dts-gen CI timeout guard.

## Verification
- #1456 was merged after all GitHub checks passed.
- This PR only changes `package.json` version.

On merge, `calver-release.yml` should create tag/release `v26.5.15-alpha.2004`.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
