### PR TITLE
fix(tmux): stop recursive core-route output

### DIFF
--- a/src/cli/route-tools.ts
+++ b/src/cli/route-tools.ts
@@ -130,7 +130,13 @@ export async function routeTools(cmd: string, args: string[]): Promise<boolean> 
     const result = await tmuxHandler({
       source: "cli",
       args: args.slice(1),
-      writer: (...a: unknown[]) => console.log(...a),
+      // Do not pass `console.log` here. The core tmux handler temporarily
+      // wraps console.log so command implementations can keep using it; a
+      // writer that calls console.log re-enters that wrapper and recurses
+      // until "Maximum call stack size exceeded" (#1459).
+      writer: (...a: unknown[]) => {
+        process.stdout.write(`${a.map(String).join(" ")}\n`);
+      },
     });
     if (!result.ok) {
       if (result.error) console.error(result.error);

--- a/test/isolated/tmux-route-tools.test.ts
+++ b/test/isolated/tmux-route-tools.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { mockConfigModule } from "../helpers/mock-config";
+import { mockSshModule } from "../helpers/mock-ssh";
+
+let hostCommands: string[] = [];
+
+mock.module("../../src/config", () => mockConfigModule(() => ({
+  host: "local",
+  node: "m5",
+  port: 3456,
+  sessions: {},
+})));
+
+mock.module("../../src/core/transport/ssh", () => mockSshModule({
+  hostExec: async (cmd: string) => {
+    hostCommands.push(cmd);
+    if (cmd.includes("capture-pane")) return "PEEKED";
+    return "";
+  },
+  ssh: async (cmd: string) => {
+    hostCommands.push(cmd);
+    return "";
+  },
+}));
+
+describe("routeTools tmux core route", () => {
+  let originalWrite: typeof process.stdout.write;
+  let stdout: string[];
+
+  beforeEach(() => {
+    hostCommands = [];
+    stdout = [];
+    originalWrite = process.stdout.write;
+    process.stdout.write = ((chunk: unknown) => {
+      stdout.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+  });
+
+  afterEach(() => {
+    process.stdout.write = originalWrite;
+  });
+
+  test("maw tmux peek streams output without recursive console writer (#1459)", async () => {
+    const { routeTools } = await import("../../src/cli/route-tools");
+
+    const handled = await routeTools("tmux", ["tmux", "peek", "47-mawjs:2.0", "--lines", "1"]);
+
+    expect(handled).toBe(true);
+    expect(stdout.join("")).toContain("PEEKED");
+    expect(hostCommands.some((cmd) => cmd.includes("tmux capture-pane"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Fix #1459 by changing the core `tmux` route writer to write directly to stdout instead of recursively calling `console.log` while the tmux handler has `console.log` wrapped.
- Add an isolated regression for `routeTools("tmux", ["tmux", "peek", ...])` so the recursive-writer path stays covered.

## Verification
- `MAW_SKIP_FLAKY=1 MAW_TEST_MODE=1 bun test test/isolated/tmux-route-tools.test.ts`
- `MAW_SKIP_FLAKY=1 MAW_TEST_MODE=1 bun test test/isolated/tmux.test.ts`
- `bun src/cli.ts tmux peek 47-mawjs:2.0 --lines 1`
- `MAW_SKIP_FLAKY=1 MAW_TEST_MODE=1 bun run build`

Closes #1459 for the alpha lane.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
