### PR TITLE
release: v26.5.15-alpha.2018

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.15-alpha.2004",
+  "version": "26.5.15-alpha.2018",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts the next alpha after #1460 so users can update to the `maw tmux peek` core-route recursion fix.

Summary:
- Publishes the #1459/#1460 fix through calver-release.yml.
- No code changes in this PR beyond `package.json` version bump.

Verification before this cut:
- PR #1460 checks all green.
- Local source smoke: `bun src/cli.ts tmux peek 47-mawjs:2.0 --lines 1` no longer stack-overflows.
- Local tests: `MAW_SKIP_FLAKY=1 MAW_TEST_MODE=1 bun test test/isolated/tmux-route-tools.test.ts`; `MAW_SKIP_FLAKY=1 MAW_TEST_MODE=1 bun test test/isolated/tmux.test.ts`; `MAW_SKIP_FLAKY=1 MAW_TEST_MODE=1 bun run build`.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
