### PR TITLE
fix(hooks): track post-commit deploy hook

### DIFF
--- a/scripts/hooks/maw-hooks.env.example
+++ b/scripts/hooks/maw-hooks.env.example
@@ -1,0 +1,15 @@
+# maw-js local git hook config.
+# Copy to .git/maw-hooks.env or run scripts/install-git-hooks.sh.
+
+# Run `bun run build` before deploy. Set to 0 for docs-only commit bursts.
+MAW_HOOK_BUILD=1
+
+# Copy dist/maw here after a successful build. Empty string disables copying.
+MAW_HOOK_DEPLOY="$HOME/.local/bin/maw"
+
+# Optional pm2 service name to restart after deploy. Empty skips restart.
+MAW_HOOK_PM2=""
+
+# Optional second clone to fast-forward after commit.
+MAW_HOOK_MIRROR=""
+MAW_HOOK_MIRROR_BRANCH="alpha"

--- a/scripts/hooks/post-commit
+++ b/scripts/hooks/post-commit
@@ -1,0 +1,68 @@
+#!/bin/bash
+# maw-js post-commit auto-deploy hook.
+#
+# Installed by: scripts/install-git-hooks.sh
+# Local config: .git/maw-hooks.env (copy of scripts/hooks/maw-hooks.env.example)
+#
+# Keep the build command delegated to `bun run build` so local hooks inherit
+# package.json/CI build flags such as `--external @eclipse-zenoh/zenoh-ts`.
+set -e
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# Load user config if present.
+[ -f "$REPO_ROOT/.git/maw-hooks.env" ] && . "$REPO_ROOT/.git/maw-hooks.env"
+
+# Defaults — override any of these in .git/maw-hooks.env.
+: "${MAW_HOOK_BUILD:=1}"
+: "${MAW_HOOK_DEPLOY:=$HOME/.local/bin/maw}"
+: "${MAW_HOOK_PM2:=}"                  # pm2 service name; empty = skip
+: "${MAW_HOOK_MIRROR:=}"               # mirror clone path; empty = skip
+: "${MAW_HOOK_MIRROR_BRANCH:=alpha}"
+
+echo "🚀 Auto-deploying..."
+
+if [ "$MAW_HOOK_BUILD" = "1" ]; then
+  BUILD_LOG=$(mktemp -t maw-build.XXXXXX)
+  if ! bun run build >"$BUILD_LOG" 2>&1; then
+    echo "❌ BUILD FAILED — dist/maw NOT updated"
+    echo ""
+    cat "$BUILD_LOG"
+    echo ""
+    echo "  fix the build, then run:  bash .git/hooks/post-commit"
+    mv "$BUILD_LOG" /tmp/maw-build-FAILED-$(date +%H%M%S).log
+    exit 1
+  fi
+  tail -1 "$BUILD_LOG"
+  mv "$BUILD_LOG" /tmp/maw-build-last.log
+
+  [ -f dist/maw ] || { echo "❌ build claimed success but dist/maw does not exist"; exit 1; }
+fi
+
+if [ -n "$MAW_HOOK_DEPLOY" ] && [ -f dist/maw ]; then
+  cp dist/maw "$MAW_HOOK_DEPLOY" 2>/dev/null \
+    || echo "⚠️  cp dist/maw → $MAW_HOOK_DEPLOY failed (non-fatal)"
+fi
+
+if [ -n "$MAW_HOOK_PM2" ]; then
+  pm2 restart "$MAW_HOOK_PM2" 2>/dev/null || true
+fi
+
+# Fleet-user mirror sync. The mirror is a SECOND clone owned by another
+# user account (e.g. /opt/Code/.../maw-js read by a mawjs system user while
+# Nat edits a linked/dev clone). The hook runs AFTER commit but BEFORE push,
+# so this only catches up on the NEXT commit — eventually consistent within
+# one commit cycle, which is good enough in practice.
+if [ -n "$MAW_HOOK_MIRROR" ] \
+   && [ -d "$MAW_HOOK_MIRROR/.git" ] \
+   && [ "$MAW_HOOK_MIRROR" != "$REPO_ROOT" ]; then
+  if git -C "$MAW_HOOK_MIRROR" fetch origin "$MAW_HOOK_MIRROR_BRANCH" >/dev/null 2>&1 \
+     && git -C "$MAW_HOOK_MIRROR" merge --ff-only "origin/$MAW_HOOK_MIRROR_BRANCH" >/dev/null 2>&1; then
+    echo "  ✓ mirror $MAW_HOOK_MIRROR synced to $(git -C "$MAW_HOOK_MIRROR" log --oneline -1 | cut -c1-12)"
+  else
+    echo "  ⚠ mirror sync failed — run: git -C $MAW_HOOK_MIRROR fetch + merge manually"
+  fi
+fi
+
+echo "✅ Deployed $(git log --oneline -1)"

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Install maw-js local development git hooks.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR/.." rev-parse --show-toplevel)"
+HOOK_SRC="$REPO_ROOT/scripts/hooks/post-commit"
+ENV_SRC="$REPO_ROOT/scripts/hooks/maw-hooks.env.example"
+HOOK_DST="$REPO_ROOT/.git/hooks/post-commit"
+ENV_DST="$REPO_ROOT/.git/maw-hooks.env"
+
+[ -f "$HOOK_SRC" ] || { echo "missing $HOOK_SRC" >&2; exit 1; }
+mkdir -p "$(dirname "$HOOK_DST")"
+
+if [ -f "$HOOK_DST" ] && ! cmp -s "$HOOK_SRC" "$HOOK_DST"; then
+  backup="$HOOK_DST.backup-$(date +%Y%m%d-%H%M%S)"
+  cp "$HOOK_DST" "$backup"
+  echo "  ↺ backed up existing hook → $backup"
+fi
+
+cp "$HOOK_SRC" "$HOOK_DST"
+chmod +x "$HOOK_DST"
+echo "  ✓ installed .git/hooks/post-commit"
+
+if [ ! -f "$ENV_DST" ] && [ -f "$ENV_SRC" ]; then
+  cp "$ENV_SRC" "$ENV_DST"
+  echo "  ✓ created .git/maw-hooks.env"
+else
+  echo "  • leaving existing .git/maw-hooks.env unchanged"
+fi

--- a/test/scripts/install-git-hooks.test.ts
+++ b/test/scripts/install-git-hooks.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync, statSync } from "fs";
+import { join } from "path";
+
+const repo = join(import.meta.dir, "../..");
+const installer = readFileSync(join(repo, "scripts/install-git-hooks.sh"), "utf-8");
+const hook = readFileSync(join(repo, "scripts/hooks/post-commit"), "utf-8");
+const envExample = readFileSync(join(repo, "scripts/hooks/maw-hooks.env.example"), "utf-8");
+
+describe("local git hook installer (#1451)", () => {
+  test("installer and post-commit template are executable", () => {
+    expect(statSync(join(repo, "scripts/install-git-hooks.sh")).mode & 0o111).not.toBe(0);
+    expect(statSync(join(repo, "scripts/hooks/post-commit")).mode & 0o111).not.toBe(0);
+  });
+
+  test("post-commit delegates to package build script, not a duplicated bun build command", () => {
+    expect(hook).toContain("bun run build");
+    expect(hook).not.toContain("bun build src/cli.ts");
+    expect(hook).toContain("--external @eclipse-zenoh/zenoh-ts");
+  });
+
+  test("installer copies the tracked hook into .git/hooks/post-commit", () => {
+    expect(installer).toContain("scripts/hooks/post-commit");
+    expect(installer).toContain(".git/hooks/post-commit");
+    expect(installer).toContain("cmp -s");
+    expect(installer).toContain("backup-");
+  });
+
+  test("env example exposes deploy knobs used by the hook", () => {
+    for (const key of ["MAW_HOOK_BUILD", "MAW_HOOK_DEPLOY", "MAW_HOOK_PM2", "MAW_HOOK_MIRROR", "MAW_HOOK_MIRROR_BRANCH"]) {
+      expect(envExample).toContain(key);
+      expect(hook).toContain(key);
+    }
+  });
+});


### PR DESCRIPTION
## Summary\n- add tracked 🚀 Auto-deploying...

Use --update-env to update environment variables
✅ Deployed 04aa8243 Keep local deploy hooks on tracked build command template for the local auto-deploy hook\n- make the hook delegate to Bundled 647 modules in 29ms

  maw  0.90 MB  (entry point) instead of duplicating a raw bun build v1.3.14-canary.1 (19d8ade2c)
error: Missing entrypoints. What would you like to bundle?

Usage:
  $ bun build <entrypoint> [...<entrypoints>] [...flags]  

To see full documentation:
  $ bun build --help command\n- add   ✓ installed .git/hooks/post-commit
  • leaving existing .git/maw-hooks.env unchanged plus env example to install/update the local hook safely\n- add tests that lock the no-drift contract for #1451\n\nFixes #1451.\n\n## Verification\n- bun test v1.3.14-canary.1 (19d8ade2c)\n- \n- Bundled 647 modules in 29ms

  maw  0.90 MB  (entry point)\n- ==> bun run build
✓   build succeeded
==> dist/maw --version
    maw v26.5.16 (04aa8243) built 2026-05-15 Fri 20:51
✓   version smoke OK
==> dist/maw plugin --help
✓   plugin surface smoke OK

✓   Local-build OK; safe to push
    (CI will still run the authoritative test:all suite — this is opt-in augmentation, not a replacement)\n\nWritten by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.