### PR TITLE
fix(resolve): exact oracle names beat fuzzy wake fallback

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -124,6 +124,18 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
 
   // #358 — reject -view suffix at the user-input boundary (before any session work).
   assertValidOracleName(oracle);
+  let preResolvedSession: string | null = null;
+  const numericFleetTarget = oracle.match(/^\d+-(.+)$/);
+  if (numericFleetTarget) {
+    // #1469 — a user may pass the exact live tmux session (`48-foo`) to
+    // bring/split. Prefer that exact session before resolving a repo; then
+    // strip the fleet prefix only for repo/oracle lookup (`foo-oracle`).
+    const sessions = await tmux.listSessions().catch(() => [] as { name: string }[]);
+    if (sessions.some(s => s.name === oracle)) {
+      preResolvedSession = oracle;
+      oracle = numericFleetTarget[1]!;
+    }
+  }
   console.log(`\x1b[36m⚡\x1b[0m resolving ${oracle}...`);
   let resolved: { repoPath: string; repoName: string; parentDir: string };
 
@@ -167,7 +179,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
     ? repoPath.slice(repoPath.indexOf("github.com/") + "github.com/".length)
     : repoName;
   console.log(`\x1b[36m→\x1b[0m found \x1b[1m${ghSlug}\x1b[0m (${repoPath})`);
-  let session = await detectSession(oracle, opts.urlRepoName);
+  let session = preResolvedSession ?? await detectSession(oracle, opts.urlRepoName);
   if (session) console.log(`\x1b[36m→\x1b[0m session exists: ${session}`);
   else console.log(`\x1b[36m→\x1b[0m no session found, creating...`);
 

--- a/src/commands/shared/wake-resolve-impl.test.ts
+++ b/src/commands/shared/wake-resolve-impl.test.ts
@@ -30,7 +30,7 @@ mock.module(join(root, "config"), () => mockConfigModule(() => ({
   peers: [],
 })));
 
-const { detectSession, sanitizeBranchName } = await import("./wake-resolve-impl");
+const { detectSession, sanitizeBranchName, resolveLocalOracleRepoName } = await import("./wake-resolve-impl");
 
 describe("sanitizeBranchName (#823 Bug A) — greedy strip", () => {
   it("strips ALL leading dashes (--no-attach → no-attach)", () => {
@@ -103,6 +103,15 @@ describe("detectSession (#769) — URL-aware resolution", () => {
     expect(result).toBe("m5");
   });
 
+  it("exact numeric-prefixed session name resolves before suffix ambiguity", async () => {
+    tmuxSessions = [
+      { name: "47-mawjs" },
+      { name: "48-mawjs-codex" },
+    ];
+    const result = await detectSession("48-mawjs-codex");
+    expect(result).toBe("48-mawjs-codex");
+  });
+
   it("genuine multi-exact-match on full name still errors", async () => {
     tmuxSessions = [
       { name: "10-m5-oracle" },
@@ -120,5 +129,41 @@ describe("detectSession (#769) — URL-aware resolution", () => {
     } finally {
       process.exit = origExit;
     }
+  });
+});
+
+describe("resolveLocalOracleRepoName (#1469) — exact local oracle wins before fuzzy", () => {
+  const repos = [
+    "github.com/Soul-Brews-Studio/mawjs-oracle",
+    "github.com/Soul-Brews-Studio/mawjs-codex-oracle",
+    "github.com/Soul-Brews-Studio/arra-oracle-v3-oracle",
+  ];
+
+  it("prefers an exact full oracle repo name over a shorter fuzzy suffix", () => {
+    expect(resolveLocalOracleRepoName("mawjs-codex-oracle", repos)).toEqual({
+      kind: "exact",
+      match: "mawjs-codex-oracle",
+    });
+  });
+
+  it("prefers an exact bare oracle name over a shorter fuzzy suffix", () => {
+    expect(resolveLocalOracleRepoName("mawjs-codex", repos)).toEqual({
+      kind: "exact",
+      match: "mawjs-codex-oracle",
+    });
+  });
+
+  it("strips a numeric fleet session prefix before exact local oracle lookup", () => {
+    expect(resolveLocalOracleRepoName("48-mawjs-codex", repos)).toEqual({
+      kind: "exact",
+      match: "mawjs-codex-oracle",
+    });
+  });
+
+  it("keeps legacy fuzzy lookup for non-exact local oracle abbreviations", () => {
+    expect(resolveLocalOracleRepoName("v3", repos)).toEqual({
+      kind: "fuzzy",
+      match: "arra-oracle-v3-oracle",
+    });
   });
 });

--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -54,11 +54,80 @@ export async function resolveFromWorktrees(
   };
 }
 
+type LocalOracleResolution =
+  | { kind: "none" }
+  | { kind: "exact"; match: string }
+  | { kind: "fuzzy"; match: string }
+  | { kind: "ambiguous"; candidates: string[] };
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function stripOracleSuffix(name: string): string {
+  return name.replace(/-oracle$/i, "");
+}
+
+function stripNumericFleetPrefix(name: string): string {
+  return name.replace(/^\d+-/, "");
+}
+
+function localOracleIntentNames(oracle: string): string[] {
+  const raw = oracle.trim().toLowerCase();
+  const withoutNumeric = stripNumericFleetPrefix(raw);
+  return uniqueStrings([
+    raw,
+    stripOracleSuffix(raw),
+    withoutNumeric,
+    stripOracleSuffix(withoutNumeric),
+  ].filter(Boolean));
+}
+
+/**
+ * Pick a local ghq `*-oracle` repo for a user-typed oracle/session target.
+ *
+ * Exact intent wins before the #997 substring fuzzy fallback. This preserves
+ * "maw wake v3" style fuzzy lookup while preventing a full name like
+ * "mawjs-codex-oracle" (or fleet session "48-mawjs-codex") from being
+ * rejected as ambiguous just because "mawjs-oracle" is also local.
+ *
+ * @internal exported for targeted resolver regression tests.
+ */
+export function resolveLocalOracleRepoName(oracle: string, repos: string[]): LocalOracleResolution {
+  const oracleLower = oracle.trim().toLowerCase();
+  if (!oracleLower) return { kind: "none" };
+
+  const repoNames = repos
+    .filter(p => p.toLowerCase().endsWith("-oracle"))
+    .map(p => p.split("/").pop()!)
+    .filter(Boolean);
+
+  const intents = new Set(localOracleIntentNames(oracle));
+  const exact = uniqueStrings(repoNames.filter(name => {
+    const lower = name.toLowerCase();
+    const bare = stripOracleSuffix(lower);
+    return intents.has(lower) || intents.has(bare);
+  }));
+
+  if (exact.length === 1) return { kind: "exact", match: exact[0]! };
+  if (exact.length > 1) return { kind: "ambiguous", candidates: exact };
+
+  const candidates = uniqueStrings(repoNames.filter(name => {
+    const bare = stripOracleSuffix(name.toLowerCase());
+    return bare.includes(oracleLower) || oracleLower.includes(bare);
+  }));
+
+  if (candidates.length === 1) return { kind: "fuzzy", match: candidates[0]! };
+  if (candidates.length > 1) return { kind: "ambiguous", candidates };
+  return { kind: "none" };
+}
+
 export async function resolveOracle(
   oracle: string,
   opts?: { allLocal?: boolean },
 ): Promise<{ repoPath: string; repoName: string; parentDir: string }> {
-  const ghqHit = await ghqFind(`/${oracle}-oracle`);
+  const oracleRepoStem = oracle.toLowerCase().endsWith("-oracle") ? oracle : `${oracle}-oracle`;
+  const ghqHit = await ghqFind(`/${oracleRepoStem}`);
   if (ghqHit) {
     const repoPath = ghqHit;
     return { repoPath, repoName: repoPath.split("/").pop()!, parentDir: repoPath.replace(/\/[^/]+$/, "") };
@@ -69,23 +138,16 @@ export async function resolveOracle(
   try {
     const { ghqList } = await import("../../core/ghq");
     const repos = await ghqList();
-    const oracleLower = oracle.toLowerCase();
-    const candidates = repos
-      .filter(p => p.endsWith("-oracle"))
-      .map(p => p.split("/").pop()!)
-      .filter(name => {
-        const bare = name.replace(/-oracle$/, "");
-        return bare.includes(oracleLower) || oracleLower.includes(bare);
-      });
-    if (candidates.length === 1) {
-      const match = await ghqFind(`/${candidates[0]}`);
+    const resolvedLocal = resolveLocalOracleRepoName(oracle, repos);
+    if (resolvedLocal.kind === "exact" || resolvedLocal.kind === "fuzzy") {
+      const match = await ghqFind(`/${resolvedLocal.match}`);
       if (match) {
-        console.log(`\x1b[36m→\x1b[0m fuzzy match: ${candidates[0]}`);
+        if (resolvedLocal.kind === "fuzzy") console.log(`\x1b[36m→\x1b[0m fuzzy match: ${resolvedLocal.match}`);
         return { repoPath: match, repoName: match.split("/").pop()!, parentDir: match.replace(/\/[^/]+$/, "") };
       }
-    } else if (candidates.length > 1) {
-      console.error(`\x1b[33m⚠\x1b[0m '${oracle}' matches ${candidates.length} local oracles:`);
-      for (const c of candidates) console.error(`\x1b[90m    • ${c}\x1b[0m`);
+    } else if (resolvedLocal.kind === "ambiguous") {
+      console.error(`\x1b[33m⚠\x1b[0m '${oracle}' matches ${resolvedLocal.candidates.length} local oracles:`);
+      for (const c of resolvedLocal.candidates) console.error(`\x1b[90m    • ${c}\x1b[0m`);
       console.error(`\x1b[90m  use the full name: maw wake <exact-name>\x1b[0m`);
       process.exit(1);
     }


### PR DESCRIPTION
## Summary
- make exact local oracle identity win before the older #997 ghq fuzzy fallback
- treat full `*-oracle` input as a repo stem instead of probing `*-oracle-oracle`
- preserve exact numeric tmux session targets like `48-mawjs-codex` before repo lookup, then strip the fleet prefix for repo resolution
- add focused regressions for full oracle, bare oracle, numeric session, and legacy fuzzy abbreviation behavior

Fixes #1469.
Refs #1470.

## RCA
Trace log: `/opt/Code/github.com/Soul-Brews-Studio/mawjs-codex-oracle/ψ/memory/traces/2026-05-15/2112_maw-bring-exact-resolution-1469.md`

Root cause: `maw bring` was restored correctly, but `resolveOracle()` appended `-oracle` unconditionally, so `mawjs-codex-oracle` first looked for `mawjs-codex-oracle-oracle`. The miss fell through to broad substring fuzzy matching, where the shorter `mawjs-oracle` collided. Numeric session names had the same issue because `cmdWake()` resolved repos before trying the exact tmux session.

## Tests
- `MAW_TEST_MODE=1 rtk bun test src/commands/shared/wake-resolve-impl.test.ts test/wake-resolve.test.ts`
- `MAW_TEST_MODE=1 rtk bun test test/wake-bring.test.ts test/cli/dispatch-match.test.ts`
- `rtk bun run build`

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.