### PR TITLE
fix(bring): keep --tab non-destructive

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -110,7 +110,9 @@ export function parseBringArgs(argv: string[]): {
 } {
   // v1 default (#1398, locked by #1430): `maw bring <oracle>` splits the
   // current pane and attaches there. `--split` is kept as a no-op alias for
-  // muscle memory, while `--tab` opts into the later top-right/bg-tab path.
+  // muscle memory, while `--tab` preserves the background tmux-window path.
+  // The top-right respawn experiment (#1422) is deliberately not wired to
+  // `--tab`: tab must be non-destructive.
   const flags = parseFlags(argv, {
     "--engine": String, "-e": "--engine",
     "--split": Boolean,
@@ -121,12 +123,12 @@ export function parseBringArgs(argv: string[]): {
     console.error("usage: maw bring <oracle> [--split|--tab] [-e|--engine <name>]");
     console.error("  Default: split the current pane and attach (v1).");
     console.error("  --split is accepted as an explicit alias of the default.");
-    console.error("  Use --tab for the top-right tile/bg-tab form.");
+    console.error("  Use --tab for a non-destructive background tmux window.");
     console.error("  Symmetric with `maw a` (attach goes there, bring comes here).");
     throw new UserError("bring: missing oracle name");
   }
   const opts: { bring?: true; split?: boolean; tab?: boolean; engine?: string } = flags["--tab"]
-    ? { bring: true }
+    ? { bring: true, tab: true }
     : { split: true };
   if (flags["--engine"]) opts.engine = flags["--engine"];
   return { oracle, opts };
@@ -231,7 +233,7 @@ export async function invokeDirectHandler(
 
   if (exportName === "cmdBring") {
     // `maw bring <oracle>` defaults to the v1 current-pane split path.
-    // `--tab` opts into the later top-right/bg-tab path.
+    // `--tab` opts into the non-destructive background tmux-window path.
     const { oracle, opts } = parseBringArgs(argv);
     await cmdWake(oracle, opts);
     return;

--- a/test/cli/dispatch-match.test.ts
+++ b/test/cli/dispatch-match.test.ts
@@ -265,9 +265,9 @@ describe("resolveTopAlias — RFC #954 verb aliases", () => {
     expect(parsed).toEqual({ oracle: "neo", opts: { split: true, engine: "codex" } });
   });
 
-  test("`bring neo --tab` opts into the top-right/bg-tab mode", () => {
+  test("`bring neo --tab` opts into non-destructive background-tab mode", () => {
     const parsed = parseBringArgs(["neo", "--tab"]);
-    expect(parsed).toEqual({ oracle: "neo", opts: { bring: true } });
+    expect(parsed).toEqual({ oracle: "neo", opts: { bring: true, tab: true } });
   });
 
   test("`audit` → null (does NOT shadow CORE_ROUTES)", () => {


### PR DESCRIPTION
## Summary
- make `maw bring <oracle> --tab` pass `tab: true` through direct-handler dispatch
- keep `--tab` on the non-destructive background tmux-window path
- clarify help/comments so `--tab` is not confused with the top-right respawn experiment
- update the dispatch regression to prove `--tab` maps to `{ bring: true, tab: true }`

Fixes #1472.

## Tests
- `MAW_TEST_MODE=1 rtk bun test test/cli/dispatch-match.test.ts test/isolated/wake-maybe-split.test.ts test/wake-bring.test.ts`
- `rtk bun run build`

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.