### PR TITLE
release: v26.5.16-alpha.2123

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.16",
+  "version": "26.5.16-alpha.2123",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/scripts/hooks/maw-hooks.env.example
+++ b/scripts/hooks/maw-hooks.env.example
@@ -1,0 +1,15 @@
+# maw-js local git hook config.
+# Copy to .git/maw-hooks.env or run scripts/install-git-hooks.sh.
+
+# Run `bun run build` before deploy. Set to 0 for docs-only commit bursts.
+MAW_HOOK_BUILD=1
+
+# Copy dist/maw here after a successful build. Empty string disables copying.
+MAW_HOOK_DEPLOY="$HOME/.local/bin/maw"
+
+# Optional pm2 service name to restart after deploy. Empty skips restart.
+MAW_HOOK_PM2=""
+
+# Optional second clone to fast-forward after commit.
+MAW_HOOK_MIRROR=""
+MAW_HOOK_MIRROR_BRANCH="alpha"

--- a/scripts/hooks/post-commit
+++ b/scripts/hooks/post-commit
@@ -1,0 +1,68 @@
+#!/bin/bash
+# maw-js post-commit auto-deploy hook.
+#
+# Installed by: scripts/install-git-hooks.sh
+# Local config: .git/maw-hooks.env (copy of scripts/hooks/maw-hooks.env.example)
+#
+# Keep the build command delegated to `bun run build` so local hooks inherit
+# package.json/CI build flags such as `--external @eclipse-zenoh/zenoh-ts`.
+set -e
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# Load user config if present.
+[ -f "$REPO_ROOT/.git/maw-hooks.env" ] && . "$REPO_ROOT/.git/maw-hooks.env"
+
+# Defaults — override any of these in .git/maw-hooks.env.
+: "${MAW_HOOK_BUILD:=1}"
+: "${MAW_HOOK_DEPLOY:=$HOME/.local/bin/maw}"
+: "${MAW_HOOK_PM2:=}"                  # pm2 service name; empty = skip
+: "${MAW_HOOK_MIRROR:=}"               # mirror clone path; empty = skip
+: "${MAW_HOOK_MIRROR_BRANCH:=alpha}"
+
+echo "🚀 Auto-deploying..."
+
+if [ "$MAW_HOOK_BUILD" = "1" ]; then
+  BUILD_LOG=$(mktemp -t maw-build.XXXXXX)
+  if ! bun run build >"$BUILD_LOG" 2>&1; then
+    echo "❌ BUILD FAILED — dist/maw NOT updated"
+    echo ""
+    cat "$BUILD_LOG"
+    echo ""
+    echo "  fix the build, then run:  bash .git/hooks/post-commit"
+    mv "$BUILD_LOG" /tmp/maw-build-FAILED-$(date +%H%M%S).log
+    exit 1
+  fi
+  tail -1 "$BUILD_LOG"
+  mv "$BUILD_LOG" /tmp/maw-build-last.log
+
+  [ -f dist/maw ] || { echo "❌ build claimed success but dist/maw does not exist"; exit 1; }
+fi
+
+if [ -n "$MAW_HOOK_DEPLOY" ] && [ -f dist/maw ]; then
+  cp dist/maw "$MAW_HOOK_DEPLOY" 2>/dev/null \
+    || echo "⚠️  cp dist/maw → $MAW_HOOK_DEPLOY failed (non-fatal)"
+fi
+
+if [ -n "$MAW_HOOK_PM2" ]; then
+  pm2 restart "$MAW_HOOK_PM2" 2>/dev/null || true
+fi
+
+# Fleet-user mirror sync. The mirror is a SECOND clone owned by another
+# user account (e.g. /opt/Code/.../maw-js read by a mawjs system user while
+# Nat edits a linked/dev clone). The hook runs AFTER commit but BEFORE push,
+# so this only catches up on the NEXT commit — eventually consistent within
+# one commit cycle, which is good enough in practice.
+if [ -n "$MAW_HOOK_MIRROR" ] \
+   && [ -d "$MAW_HOOK_MIRROR/.git" ] \
+   && [ "$MAW_HOOK_MIRROR" != "$REPO_ROOT" ]; then
+  if git -C "$MAW_HOOK_MIRROR" fetch origin "$MAW_HOOK_MIRROR_BRANCH" >/dev/null 2>&1 \
+     && git -C "$MAW_HOOK_MIRROR" merge --ff-only "origin/$MAW_HOOK_MIRROR_BRANCH" >/dev/null 2>&1; then
+    echo "  ✓ mirror $MAW_HOOK_MIRROR synced to $(git -C "$MAW_HOOK_MIRROR" log --oneline -1 | cut -c1-12)"
+  else
+    echo "  ⚠ mirror sync failed — run: git -C $MAW_HOOK_MIRROR fetch + merge manually"
+  fi
+fi
+
+echo "✅ Deployed $(git log --oneline -1)"

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Install maw-js local development git hooks.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR/.." rev-parse --show-toplevel)"
+HOOK_SRC="$REPO_ROOT/scripts/hooks/post-commit"
+ENV_SRC="$REPO_ROOT/scripts/hooks/maw-hooks.env.example"
+HOOK_DST="$REPO_ROOT/.git/hooks/post-commit"
+ENV_DST="$REPO_ROOT/.git/maw-hooks.env"
+
+[ -f "$HOOK_SRC" ] || { echo "missing $HOOK_SRC" >&2; exit 1; }
+mkdir -p "$(dirname "$HOOK_DST")"
+
+if [ -f "$HOOK_DST" ] && ! cmp -s "$HOOK_SRC" "$HOOK_DST"; then
+  backup="$HOOK_DST.backup-$(date +%Y%m%d-%H%M%S)"
+  cp "$HOOK_DST" "$backup"
+  echo "  ↺ backed up existing hook → $backup"
+fi
+
+cp "$HOOK_SRC" "$HOOK_DST"
+chmod +x "$HOOK_DST"
+echo "  ✓ installed .git/hooks/post-commit"
+
+if [ ! -f "$ENV_DST" ] && [ -f "$ENV_SRC" ]; then
+  cp "$ENV_SRC" "$ENV_DST"
+  echo "  ✓ created .git/maw-hooks.env"
+else
+  echo "  • leaving existing .git/maw-hooks.env unchanged"
+fi

--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -110,7 +110,9 @@ export function parseBringArgs(argv: string[]): {
 } {
   // v1 default (#1398, locked by #1430): `maw bring <oracle>` splits the
   // current pane and attaches there. `--split` is kept as a no-op alias for
-  // muscle memory, while `--tab` opts into the later top-right/bg-tab path.
+  // muscle memory, while `--tab` preserves the background tmux-window path.
+  // The top-right respawn experiment (#1422) is deliberately not wired to
+  // `--tab`: tab must be non-destructive.
   const flags = parseFlags(argv, {
     "--engine": String, "-e": "--engine",
     "--split": Boolean,
@@ -121,12 +123,12 @@ export function parseBringArgs(argv: string[]): {
     console.error("usage: maw bring <oracle> [--split|--tab] [-e|--engine <name>]");
     console.error("  Default: split the current pane and attach (v1).");
     console.error("  --split is accepted as an explicit alias of the default.");
-    console.error("  Use --tab for the top-right tile/bg-tab form.");
+    console.error("  Use --tab for a non-destructive background tmux window.");
     console.error("  Symmetric with `maw a` (attach goes there, bring comes here).");
     throw new UserError("bring: missing oracle name");
   }
   const opts: { bring?: true; split?: boolean; tab?: boolean; engine?: string } = flags["--tab"]
-    ? { bring: true }
+    ? { bring: true, tab: true }
     : { split: true };
   if (flags["--engine"]) opts.engine = flags["--engine"];
   return { oracle, opts };
@@ -231,7 +233,7 @@ export async function invokeDirectHandler(
 
   if (exportName === "cmdBring") {
     // `maw bring <oracle>` defaults to the v1 current-pane split path.
-    // `--tab` opts into the later top-right/bg-tab path.
+    // `--tab` opts into the non-destructive background tmux-window path.
     const { oracle, opts } = parseBringArgs(argv);
     await cmdWake(oracle, opts);
     return;

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -124,6 +124,18 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
 
   // #358 — reject -view suffix at the user-input boundary (before any session work).
   assertValidOracleName(oracle);
+  let preResolvedSession: string | null = null;
+  const numericFleetTarget = oracle.match(/^\d+-(.+)$/);
+  if (numericFleetTarget) {
+    // #1469 — a user may pass the exact live tmux session (`48-foo`) to
+    // bring/split. Prefer that exact session before resolving a repo; then
+    // strip the fleet prefix only for repo/oracle lookup (`foo-oracle`).
+    const sessions = await tmux.listSessions().catch(() => [] as { name: string }[]);
+    if (sessions.some(s => s.name === oracle)) {
+      preResolvedSession = oracle;
+      oracle = numericFleetTarget[1]!;
+    }
+  }
   console.log(`\x1b[36m⚡\x1b[0m resolving ${oracle}...`);
   let resolved: { repoPath: string; repoName: string; parentDir: string };
 
@@ -167,7 +179,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
     ? repoPath.slice(repoPath.indexOf("github.com/") + "github.com/".length)
     : repoName;
   console.log(`\x1b[36m→\x1b[0m found \x1b[1m${ghSlug}\x1b[0m (${repoPath})`);
-  let session = await detectSession(oracle, opts.urlRepoName);
+  let session = preResolvedSession ?? await detectSession(oracle, opts.urlRepoName);
   if (session) console.log(`\x1b[36m→\x1b[0m session exists: ${session}`);
   else console.log(`\x1b[36m→\x1b[0m no session found, creating...`);
 

--- a/src/commands/shared/wake-resolve-impl.test.ts
+++ b/src/commands/shared/wake-resolve-impl.test.ts
@@ -30,7 +30,7 @@ mock.module(join(root, "config"), () => mockConfigModule(() => ({
   peers: [],
 })));
 
-const { detectSession, sanitizeBranchName } = await import("./wake-resolve-impl");
+const { detectSession, sanitizeBranchName, resolveLocalOracleRepoName } = await import("./wake-resolve-impl");
 
 describe("sanitizeBranchName (#823 Bug A) — greedy strip", () => {
   it("strips ALL leading dashes (--no-attach → no-attach)", () => {
@@ -103,6 +103,15 @@ describe("detectSession (#769) — URL-aware resolution", () => {
     expect(result).toBe("m5");
   });
 
+  it("exact numeric-prefixed session name resolves before suffix ambiguity", async () => {
+    tmuxSessions = [
+      { name: "47-mawjs" },
+      { name: "48-mawjs-codex" },
+    ];
+    const result = await detectSession("48-mawjs-codex");
+    expect(result).toBe("48-mawjs-codex");
+  });
+
   it("genuine multi-exact-match on full name still errors", async () => {
     tmuxSessions = [
       { name: "10-m5-oracle" },
@@ -120,5 +129,41 @@ describe("detectSession (#769) — URL-aware resolution", () => {
     } finally {
       process.exit = origExit;
     }
+  });
+});
+
+describe("resolveLocalOracleRepoName (#1469) — exact local oracle wins before fuzzy", () => {
+  const repos = [
+    "github.com/Soul-Brews-Studio/mawjs-oracle",
+    "github.com/Soul-Brews-Studio/mawjs-codex-oracle",
+    "github.com/Soul-Brews-Studio/arra-oracle-v3-oracle",
+  ];
+
+  it("prefers an exact full oracle repo name over a shorter fuzzy suffix", () => {
+    expect(resolveLocalOracleRepoName("mawjs-codex-oracle", repos)).toEqual({
+      kind: "exact",
+      match: "mawjs-codex-oracle",
+    });
+  });
+
+  it("prefers an exact bare oracle name over a shorter fuzzy suffix", () => {
+    expect(resolveLocalOracleRepoName("mawjs-codex", repos)).toEqual({
+      kind: "exact",
+      match: "mawjs-codex-oracle",
+    });
+  });
+
+  it("strips a numeric fleet session prefix before exact local oracle lookup", () => {
+    expect(resolveLocalOracleRepoName("48-mawjs-codex", repos)).toEqual({
+      kind: "exact",
+      match: "mawjs-codex-oracle",
+    });
+  });
+
+  it("keeps legacy fuzzy lookup for non-exact local oracle abbreviations", () => {
+    expect(resolveLocalOracleRepoName("v3", repos)).toEqual({
+      kind: "fuzzy",
+      match: "arra-oracle-v3-oracle",
+    });
   });
 });

--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -54,11 +54,80 @@ export async function resolveFromWorktrees(
   };
 }
 
+type LocalOracleResolution =
+  | { kind: "none" }
+  | { kind: "exact"; match: string }
+  | { kind: "fuzzy"; match: string }
+  | { kind: "ambiguous"; candidates: string[] };
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function stripOracleSuffix(name: string): string {
+  return name.replace(/-oracle$/i, "");
+}
+
+function stripNumericFleetPrefix(name: string): string {
+  return name.replace(/^\d+-/, "");
+}
+
+function localOracleIntentNames(oracle: string): string[] {
+  const raw = oracle.trim().toLowerCase();
+  const withoutNumeric = stripNumericFleetPrefix(raw);
+  return uniqueStrings([
+    raw,
+    stripOracleSuffix(raw),
+    withoutNumeric,
+    stripOracleSuffix(withoutNumeric),
+  ].filter(Boolean));
+}
+
+/**
+ * Pick a local ghq `*-oracle` repo for a user-typed oracle/session target.
+ *
+ * Exact intent wins before the #997 substring fuzzy fallback. This preserves
+ * "maw wake v3" style fuzzy lookup while preventing a full name like
+ * "mawjs-codex-oracle" (or fleet session "48-mawjs-codex") from being
+ * rejected as ambiguous just because "mawjs-oracle" is also local.
+ *
+ * @internal exported for targeted resolver regression tests.
+ */
+export function resolveLocalOracleRepoName(oracle: string, repos: string[]): LocalOracleResolution {
+  const oracleLower = oracle.trim().toLowerCase();
+  if (!oracleLower) return { kind: "none" };
+
+  const repoNames = repos
+    .filter(p => p.toLowerCase().endsWith("-oracle"))
+    .map(p => p.split("/").pop()!)
+    .filter(Boolean);
+
+  const intents = new Set(localOracleIntentNames(oracle));
+  const exact = uniqueStrings(repoNames.filter(name => {
+    const lower = name.toLowerCase();
+    const bare = stripOracleSuffix(lower);
+    return intents.has(lower) || intents.has(bare);
+  }));
+
+  if (exact.length === 1) return { kind: "exact", match: exact[0]! };
+  if (exact.length > 1) return { kind: "ambiguous", candidates: exact };
+
+  const candidates = uniqueStrings(repoNames.filter(name => {
+    const bare = stripOracleSuffix(name.toLowerCase());
+    return bare.includes(oracleLower) || oracleLower.includes(bare);
+  }));
+
+  if (candidates.length === 1) return { kind: "fuzzy", match: candidates[0]! };
+  if (candidates.length > 1) return { kind: "ambiguous", candidates };
+  return { kind: "none" };
+}
+
 export async function resolveOracle(
   oracle: string,
   opts?: { allLocal?: boolean },
 ): Promise<{ repoPath: string; repoName: string; parentDir: string }> {
-  const ghqHit = await ghqFind(`/${oracle}-oracle`);
+  const oracleRepoStem = oracle.toLowerCase().endsWith("-oracle") ? oracle : `${oracle}-oracle`;
+  const ghqHit = await ghqFind(`/${oracleRepoStem}`);
   if (ghqHit) {
     const repoPath = ghqHit;
     return { repoPath, repoName: repoPath.split("/").pop()!, parentDir: repoPath.replace(/\/[^/]+$/, "") };
@@ -69,23 +138,16 @@ export async function resolveOracle(
   try {
     const { ghqList } = await import("../../core/ghq");
     const repos = await ghqList();
-    const oracleLower = oracle.toLowerCase();
-    const candidates = repos
-      .filter(p => p.endsWith("-oracle"))
-      .map(p => p.split("/").pop()!)
-      .filter(name => {
-        const bare = name.replace(/-oracle$/, "");
-        return bare.includes(oracleLower) || oracleLower.includes(bare);
-      });
-    if (candidates.length === 1) {
-      const match = await ghqFind(`/${candidates[0]}`);
+    const resolvedLocal = resolveLocalOracleRepoName(oracle, repos);
+    if (resolvedLocal.kind === "exact" || resolvedLocal.kind === "fuzzy") {
+      const match = await ghqFind(`/${resolvedLocal.match}`);
       if (match) {
-        console.log(`\x1b[36m→\x1b[0m fuzzy match: ${candidates[0]}`);
+        if (resolvedLocal.kind === "fuzzy") console.log(`\x1b[36m→\x1b[0m fuzzy match: ${resolvedLocal.match}`);
         return { repoPath: match, repoName: match.split("/").pop()!, parentDir: match.replace(/\/[^/]+$/, "") };
       }
-    } else if (candidates.length > 1) {
-      console.error(`\x1b[33m⚠\x1b[0m '${oracle}' matches ${candidates.length} local oracles:`);
-      for (const c of candidates) console.error(`\x1b[90m    • ${c}\x1b[0m`);
+    } else if (resolvedLocal.kind === "ambiguous") {
+      console.error(`\x1b[33m⚠\x1b[0m '${oracle}' matches ${resolvedLocal.candidates.length} local oracles:`);
+      for (const c of resolvedLocal.candidates) console.error(`\x1b[90m    • ${c}\x1b[0m`);
       console.error(`\x1b[90m  use the full name: maw wake <exact-name>\x1b[0m`);
       process.exit(1);
     }

--- a/test/cli/dispatch-match.test.ts
+++ b/test/cli/dispatch-match.test.ts
@@ -265,9 +265,9 @@ describe("resolveTopAlias — RFC #954 verb aliases", () => {
     expect(parsed).toEqual({ oracle: "neo", opts: { split: true, engine: "codex" } });
   });
 
-  test("`bring neo --tab` opts into the top-right/bg-tab mode", () => {
+  test("`bring neo --tab` opts into non-destructive background-tab mode", () => {
     const parsed = parseBringArgs(["neo", "--tab"]);
-    expect(parsed).toEqual({ oracle: "neo", opts: { bring: true } });
+    expect(parsed).toEqual({ oracle: "neo", opts: { bring: true, tab: true } });
   });
 
   test("`audit` → null (does NOT shadow CORE_ROUTES)", () => {

--- a/test/scripts/install-git-hooks.test.ts
+++ b/test/scripts/install-git-hooks.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync, statSync } from "fs";
+import { join } from "path";
+
+const repo = join(import.meta.dir, "../..");
+const installer = readFileSync(join(repo, "scripts/install-git-hooks.sh"), "utf-8");
+const hook = readFileSync(join(repo, "scripts/hooks/post-commit"), "utf-8");
+const envExample = readFileSync(join(repo, "scripts/hooks/maw-hooks.env.example"), "utf-8");
+
+describe("local git hook installer (#1451)", () => {
+  test("installer and post-commit template are executable", () => {
+    expect(statSync(join(repo, "scripts/install-git-hooks.sh")).mode & 0o111).not.toBe(0);
+    expect(statSync(join(repo, "scripts/hooks/post-commit")).mode & 0o111).not.toBe(0);
+  });
+
+  test("post-commit delegates to package build script, not a duplicated bun build command", () => {
+    expect(hook).toContain("bun run build");
+    expect(hook).not.toContain("bun build src/cli.ts");
+    expect(hook).toContain("--external @eclipse-zenoh/zenoh-ts");
+  });
+
+  test("installer copies the tracked hook into .git/hooks/post-commit", () => {
+    expect(installer).toContain("scripts/hooks/post-commit");
+    expect(installer).toContain(".git/hooks/post-commit");
+    expect(installer).toContain("cmp -s");
+    expect(installer).toContain("backup-");
+  });
+
+  test("env example exposes deploy knobs used by the hook", () => {
+    for (const key of ["MAW_HOOK_BUILD", "MAW_HOOK_DEPLOY", "MAW_HOOK_PM2", "MAW_HOOK_MIRROR", "MAW_HOOK_MIRROR_BRANCH"]) {
+      expect(envExample).toContain(key);
+      expect(hook).toContain(key);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- cuts v26.5.16-alpha.2123 from current main
- bundles #1471/#1469 exact oracle/session resolution for `maw bring mawjs-codex-oracle`
- bundles #1473/#1472 non-destructive `maw bring --tab` behavior

## Included fixes
- #1471: exact full oracle names and numeric tmux session names win before fuzzy local wake resolution
- #1473: `--tab` now carries `tab: true` so it opens a background tmux window instead of respawning top-right pane

## Tests
- PR #1471 CI green: test-unit, test-isolated, test-plugin, test-mock-smoke, build
- PR #1473 CI green: test-unit, test-isolated, test-plugin, test-mock-smoke, build

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.