### PR TITLE
release: v26.5.16-alpha.2126

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.16-alpha.2054",
+  "version": "26.5.16-alpha.2126",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -110,7 +110,9 @@ export function parseBringArgs(argv: string[]): {
 } {
   // v1 default (#1398, locked by #1430): `maw bring <oracle>` splits the
   // current pane and attaches there. `--split` is kept as a no-op alias for
-  // muscle memory, while `--tab` opts into the later top-right/bg-tab path.
+  // muscle memory, while `--tab` preserves the background tmux-window path.
+  // The top-right respawn experiment (#1422) is deliberately not wired to
+  // `--tab`: tab must be non-destructive.
   const flags = parseFlags(argv, {
     "--engine": String, "-e": "--engine",
     "--split": Boolean,
@@ -122,7 +124,7 @@ export function parseBringArgs(argv: string[]): {
     throw new UserError("bring: missing oracle name");
   }
   const opts: { bring?: true; split?: boolean; tab?: boolean; engine?: string } = flags["--tab"]
-    ? { bring: true }
+    ? { bring: true, tab: true }
     : { split: true };
   if (flags["--engine"]) opts.engine = flags["--engine"];
   return { oracle, opts };
@@ -133,7 +135,7 @@ function printBringUsage(write: (line: string) => void = console.log): void {
   write("       maw b <oracle> [--split|--tab] [-e|--engine <name>]");
   write("  Default: split the current pane and attach (v1).");
   write("  --split is accepted as an explicit alias of the default.");
-  write("  Use --tab for the top-right tile/bg-tab form.");
+  write("  Use --tab for a non-destructive background tmux window.");
   write("  Symmetric with `maw a` (attach goes there, bring comes here).");
 }
 
@@ -236,7 +238,7 @@ export async function invokeDirectHandler(
 
   if (exportName === "cmdBring") {
     // `maw bring <oracle>` defaults to the v1 current-pane split path.
-    // `--tab` opts into the later top-right/bg-tab path.
+    // `--tab` opts into the non-destructive background tmux-window path.
     if (argv.some(a => a === "-h" || a === "--help" || a === "-help")) {
       printBringUsage();
       return;

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -124,6 +124,18 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
 
   // #358 — reject -view suffix at the user-input boundary (before any session work).
   assertValidOracleName(oracle);
+  let preResolvedSession: string | null = null;
+  const numericFleetTarget = oracle.match(/^\d+-(.+)$/);
+  if (numericFleetTarget) {
+    // #1469 — a user may pass the exact live tmux session (`48-foo`) to
+    // bring/split. Prefer that exact session before resolving a repo; then
+    // strip the fleet prefix only for repo/oracle lookup (`foo-oracle`).
+    const sessions = await tmux.listSessions().catch(() => [] as { name: string }[]);
+    if (sessions.some(s => s.name === oracle)) {
+      preResolvedSession = oracle;
+      oracle = numericFleetTarget[1]!;
+    }
+  }
   console.log(`\x1b[36m⚡\x1b[0m resolving ${oracle}...`);
   let resolved: { repoPath: string; repoName: string; parentDir: string };
 
@@ -167,7 +179,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
     ? repoPath.slice(repoPath.indexOf("github.com/") + "github.com/".length)
     : repoName;
   console.log(`\x1b[36m→\x1b[0m found \x1b[1m${ghSlug}\x1b[0m (${repoPath})`);
-  let session = await detectSession(oracle, opts.urlRepoName);
+  let session = preResolvedSession ?? await detectSession(oracle, opts.urlRepoName);
   if (session) console.log(`\x1b[36m→\x1b[0m session exists: ${session}`);
   else console.log(`\x1b[36m→\x1b[0m no session found, creating...`);
 

--- a/src/commands/shared/wake-resolve-impl.test.ts
+++ b/src/commands/shared/wake-resolve-impl.test.ts
@@ -30,7 +30,7 @@ mock.module(join(root, "config"), () => mockConfigModule(() => ({
   peers: [],
 })));
 
-const { detectSession, sanitizeBranchName } = await import("./wake-resolve-impl");
+const { detectSession, sanitizeBranchName, resolveLocalOracleRepoName } = await import("./wake-resolve-impl");
 
 describe("sanitizeBranchName (#823 Bug A) — greedy strip", () => {
   it("strips ALL leading dashes (--no-attach → no-attach)", () => {
@@ -103,6 +103,15 @@ describe("detectSession (#769) — URL-aware resolution", () => {
     expect(result).toBe("m5");
   });
 
+  it("exact numeric-prefixed session name resolves before suffix ambiguity", async () => {
+    tmuxSessions = [
+      { name: "47-mawjs" },
+      { name: "48-mawjs-codex" },
+    ];
+    const result = await detectSession("48-mawjs-codex");
+    expect(result).toBe("48-mawjs-codex");
+  });
+
   it("genuine multi-exact-match on full name still errors", async () => {
     tmuxSessions = [
       { name: "10-m5-oracle" },
@@ -120,5 +129,41 @@ describe("detectSession (#769) — URL-aware resolution", () => {
     } finally {
       process.exit = origExit;
     }
+  });
+});
+
+describe("resolveLocalOracleRepoName (#1469) — exact local oracle wins before fuzzy", () => {
+  const repos = [
+    "github.com/Soul-Brews-Studio/mawjs-oracle",
+    "github.com/Soul-Brews-Studio/mawjs-codex-oracle",
+    "github.com/Soul-Brews-Studio/arra-oracle-v3-oracle",
+  ];
+
+  it("prefers an exact full oracle repo name over a shorter fuzzy suffix", () => {
+    expect(resolveLocalOracleRepoName("mawjs-codex-oracle", repos)).toEqual({
+      kind: "exact",
+      match: "mawjs-codex-oracle",
+    });
+  });
+
+  it("prefers an exact bare oracle name over a shorter fuzzy suffix", () => {
+    expect(resolveLocalOracleRepoName("mawjs-codex", repos)).toEqual({
+      kind: "exact",
+      match: "mawjs-codex-oracle",
+    });
+  });
+
+  it("strips a numeric fleet session prefix before exact local oracle lookup", () => {
+    expect(resolveLocalOracleRepoName("48-mawjs-codex", repos)).toEqual({
+      kind: "exact",
+      match: "mawjs-codex-oracle",
+    });
+  });
+
+  it("keeps legacy fuzzy lookup for non-exact local oracle abbreviations", () => {
+    expect(resolveLocalOracleRepoName("v3", repos)).toEqual({
+      kind: "fuzzy",
+      match: "arra-oracle-v3-oracle",
+    });
   });
 });

--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -54,11 +54,80 @@ export async function resolveFromWorktrees(
   };
 }
 
+type LocalOracleResolution =
+  | { kind: "none" }
+  | { kind: "exact"; match: string }
+  | { kind: "fuzzy"; match: string }
+  | { kind: "ambiguous"; candidates: string[] };
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function stripOracleSuffix(name: string): string {
+  return name.replace(/-oracle$/i, "");
+}
+
+function stripNumericFleetPrefix(name: string): string {
+  return name.replace(/^\d+-/, "");
+}
+
+function localOracleIntentNames(oracle: string): string[] {
+  const raw = oracle.trim().toLowerCase();
+  const withoutNumeric = stripNumericFleetPrefix(raw);
+  return uniqueStrings([
+    raw,
+    stripOracleSuffix(raw),
+    withoutNumeric,
+    stripOracleSuffix(withoutNumeric),
+  ].filter(Boolean));
+}
+
+/**
+ * Pick a local ghq `*-oracle` repo for a user-typed oracle/session target.
+ *
+ * Exact intent wins before the #997 substring fuzzy fallback. This preserves
+ * "maw wake v3" style fuzzy lookup while preventing a full name like
+ * "mawjs-codex-oracle" (or fleet session "48-mawjs-codex") from being
+ * rejected as ambiguous just because "mawjs-oracle" is also local.
+ *
+ * @internal exported for targeted resolver regression tests.
+ */
+export function resolveLocalOracleRepoName(oracle: string, repos: string[]): LocalOracleResolution {
+  const oracleLower = oracle.trim().toLowerCase();
+  if (!oracleLower) return { kind: "none" };
+
+  const repoNames = repos
+    .filter(p => p.toLowerCase().endsWith("-oracle"))
+    .map(p => p.split("/").pop()!)
+    .filter(Boolean);
+
+  const intents = new Set(localOracleIntentNames(oracle));
+  const exact = uniqueStrings(repoNames.filter(name => {
+    const lower = name.toLowerCase();
+    const bare = stripOracleSuffix(lower);
+    return intents.has(lower) || intents.has(bare);
+  }));
+
+  if (exact.length === 1) return { kind: "exact", match: exact[0]! };
+  if (exact.length > 1) return { kind: "ambiguous", candidates: exact };
+
+  const candidates = uniqueStrings(repoNames.filter(name => {
+    const bare = stripOracleSuffix(name.toLowerCase());
+    return bare.includes(oracleLower) || oracleLower.includes(bare);
+  }));
+
+  if (candidates.length === 1) return { kind: "fuzzy", match: candidates[0]! };
+  if (candidates.length > 1) return { kind: "ambiguous", candidates };
+  return { kind: "none" };
+}
+
 export async function resolveOracle(
   oracle: string,
   opts?: { allLocal?: boolean },
 ): Promise<{ repoPath: string; repoName: string; parentDir: string }> {
-  const ghqHit = await ghqFind(`/${oracle}-oracle`);
+  const oracleRepoStem = oracle.toLowerCase().endsWith("-oracle") ? oracle : `${oracle}-oracle`;
+  const ghqHit = await ghqFind(`/${oracleRepoStem}`);
   if (ghqHit) {
     const repoPath = ghqHit;
     return { repoPath, repoName: repoPath.split("/").pop()!, parentDir: repoPath.replace(/\/[^/]+$/, "") };
@@ -69,23 +138,16 @@ export async function resolveOracle(
   try {
     const { ghqList } = await import("../../core/ghq");
     const repos = await ghqList();
-    const oracleLower = oracle.toLowerCase();
-    const candidates = repos
-      .filter(p => p.endsWith("-oracle"))
-      .map(p => p.split("/").pop()!)
-      .filter(name => {
-        const bare = name.replace(/-oracle$/, "");
-        return bare.includes(oracleLower) || oracleLower.includes(bare);
-      });
-    if (candidates.length === 1) {
-      const match = await ghqFind(`/${candidates[0]}`);
+    const resolvedLocal = resolveLocalOracleRepoName(oracle, repos);
+    if (resolvedLocal.kind === "exact" || resolvedLocal.kind === "fuzzy") {
+      const match = await ghqFind(`/${resolvedLocal.match}`);
       if (match) {
-        console.log(`\x1b[36m→\x1b[0m fuzzy match: ${candidates[0]}`);
+        if (resolvedLocal.kind === "fuzzy") console.log(`\x1b[36m→\x1b[0m fuzzy match: ${resolvedLocal.match}`);
         return { repoPath: match, repoName: match.split("/").pop()!, parentDir: match.replace(/\/[^/]+$/, "") };
       }
-    } else if (candidates.length > 1) {
-      console.error(`\x1b[33m⚠\x1b[0m '${oracle}' matches ${candidates.length} local oracles:`);
-      for (const c of candidates) console.error(`\x1b[90m    • ${c}\x1b[0m`);
+    } else if (resolvedLocal.kind === "ambiguous") {
+      console.error(`\x1b[33m⚠\x1b[0m '${oracle}' matches ${resolvedLocal.candidates.length} local oracles:`);
+      for (const c of resolvedLocal.candidates) console.error(`\x1b[90m    • ${c}\x1b[0m`);
       console.error(`\x1b[90m  use the full name: maw wake <exact-name>\x1b[0m`);
       process.exit(1);
     }

--- a/test/cli/dispatch-match.test.ts
+++ b/test/cli/dispatch-match.test.ts
@@ -265,9 +265,9 @@ describe("resolveTopAlias — RFC #954 verb aliases", () => {
     expect(parsed).toEqual({ oracle: "neo", opts: { split: true, engine: "codex" } });
   });
 
-  test("`bring neo --tab` opts into the top-right/bg-tab mode", () => {
+  test("`bring neo --tab` opts into non-destructive background-tab mode", () => {
     const parsed = parseBringArgs(["neo", "--tab"]);
-    expect(parsed).toEqual({ oracle: "neo", opts: { bring: true } });
+    expect(parsed).toEqual({ oracle: "neo", opts: { bring: true, tab: true } });
   });
 
   test("`audit` → null (does NOT shadow CORE_ROUTES)", () => {


### PR DESCRIPTION
## Summary
- cuts v26.5.16-alpha.2126 from current alpha ancestry
- cherry-picks #1471/#1469 exact oracle/session resolution
- cherry-picks #1473/#1472 non-destructive `maw bring --tab`

## Why recut
The first release PR (#1474) was main-based and conflicted with alpha's release-only ancestry. This branch starts from `origin/alpha`, cherry-picks the two hotfix commits, then bumps package.json.

## Tests
- `MAW_TEST_MODE=1 rtk bun test src/commands/shared/wake-resolve-impl.test.ts test/wake-resolve.test.ts test/cli/dispatch-match.test.ts test/isolated/wake-maybe-split.test.ts test/wake-bring.test.ts`
- `rtk bun run build`
- PR #1471 CI green: test-unit, test-isolated, test-plugin, test-mock-smoke, build
- PR #1473 CI green: test-unit, test-isolated, test-plugin, test-mock-smoke, build

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.