### PR TITLE
fix(hey): exit tmux copy-mode before text delivery

### DIFF
--- a/src/core/transport/ssh.ts
+++ b/src/core/transport/ssh.ts
@@ -141,6 +141,7 @@ export async function sendKeys(target: string, text: string, host?: string): Pro
     "\x15": "C-u",
   };
   if (SPECIAL_KEYS[text]) {
+    if (text !== "\x1b") await t.exitModeIfNeeded(target);
     await t.sendKeys(target, SPECIAL_KEYS[text]);
     return;
   }
@@ -151,12 +152,14 @@ export async function sendKeys(target: string, text: string, host?: string): Pro
 
   // If only the enter was left after stripping, just send Enter
   if (!body) {
+    await t.exitModeIfNeeded(target);
     await t.sendKeys(target, "Enter");
     return;
   }
 
   if (body.startsWith("/")) {
     // Slash commands: send char by char for interactive tools (Claude Code, etc.)
+    await t.exitModeIfNeeded(target);
     for (const ch of body) {
       await t.sendKeysLiteral(target, ch);
     }

--- a/src/core/transport/tmux-class.ts
+++ b/src/core/transport/tmux-class.ts
@@ -261,6 +261,38 @@ export class Tmux {
     await this.run("send-keys", "-t", target, "-l", text);
   }
 
+  /**
+   * Leave copy-mode / transient tmux modes before delivering text.
+   *
+   * tmux `send-keys -l` is not mode-safe: in copy-mode literal text is still
+   * interpreted by the mode key table, so uppercase/status text can exit the
+   * mode mid-string and make tmux print repeated "not in a mode" errors for
+   * the remaining characters. `maw hey` wants message delivery, not copy-mode
+   * navigation, so high-level text sends normalize the pane first while raw
+   * `Tmux.sendKeys()` remains available for callers that intentionally drive
+   * tmux modes.
+   */
+  async exitModeIfNeeded(target: string): Promise<boolean> {
+    let inMode = false;
+    try {
+      inMode = (await this.run("display-message", "-t", target, "-p", "#{pane_in_mode}")).trim() === "1";
+    } catch {
+      // If the probe fails, let the subsequent send surface the real target
+      // error (for example "can't find pane") instead of hiding it here.
+      return false;
+    }
+    if (!inMode) return false;
+    try {
+      await this.run("send-keys", "-t", target, "-X", "cancel");
+      return true;
+    } catch (e: any) {
+      // The pane can leave copy-mode between probe and cancel; that race is
+      // harmless and should not block delivery.
+      if (String(e?.message ?? e).includes("not in a mode")) return false;
+      throw e;
+    }
+  }
+
   // --- Buffers ---
 
   async loadBuffer(text: string): Promise<void> {
@@ -287,6 +319,7 @@ export class Tmux {
    * was silently left unexecuted.
    */
   async sendText(target: string, text: string): Promise<void> {
+    await this.exitModeIfNeeded(target);
     if (text.includes("\n") || text.length > 500) {
       // Buffer method — reliable for multiline/long content
       await this.loadBuffer(text);

--- a/test/isolated/tmux.test.ts
+++ b/test/isolated/tmux.test.ts
@@ -245,6 +245,25 @@ describe("Tmux", () => {
     });
   });
 
+  describe("exitModeIfNeeded", () => {
+    test("cancels copy-mode before high-level text delivery", async () => {
+      sshResult = "1";
+      expect(await t.exitModeIfNeeded("s:0")).toBe(true);
+      expect(commands).toEqual([
+        "tmux display-message -t s:0 -p '#{pane_in_mode}'",
+        "tmux send-keys -t s:0 -X cancel",
+      ]);
+    });
+
+    test("does not cancel panes already in normal mode", async () => {
+      sshResult = "0";
+      expect(await t.exitModeIfNeeded("s:0")).toBe(false);
+      expect(commands).toEqual([
+        "tmux display-message -t s:0 -p '#{pane_in_mode}'",
+      ]);
+    });
+  });
+
   // --- Options ---
 
   describe("setOption", () => {

--- a/test/tmux-sendtext-submit.test.ts
+++ b/test/tmux-sendtext-submit.test.ts
@@ -45,6 +45,9 @@ class FakeTmux extends Tmux {
   async pasteBuffer(_target: string): Promise<void> {
     this.calls.push("pasteBuffer");
   }
+  async exitModeIfNeeded(_target: string): Promise<boolean> {
+    return false;
+  }
 }
 
 const PROMPT_IDLE = "agent@host:~$ "; // prompt marker + trailing space → submitted


### PR DESCRIPTION
## Summary
- fix `maw hey` delivery into panes that are in tmux copy-mode / transient modes
- add `Tmux.exitModeIfNeeded()` for high-level text delivery while leaving raw `Tmux.sendKeys()` unchanged
- cover mode cancellation with isolated tmux tests and keep existing submit-confirmation tests green

## Root cause
`tmux send-keys -l` is not safe while a pane is in copy-mode: literal mixed-case signed messages are still interpreted by the copy-mode key table. Some characters exit the mode mid-string, then tmux emits repeated `not in a mode` errors for the remaining characters.

## Tests
- `bun test test/isolated/tmux.test.ts test/tmux-sendtext-submit.test.ts`
- `bun test test/isolated/comm-list.test.ts test/isolated/send-idle-guard.test.ts`
- real tmux copy-mode smoke: throwaway pane in copy-mode + `bun src/cli.ts hey <pane> ... --force` delivered with exit code 0
- `bun run build`

Closes #1467.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
