### PR TITLE
release: v26.5.16-alpha.2157

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.16-alpha.2148",
+  "version": "26.5.16-alpha.2157",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/plugins/tmux/layout-manager.ts
+++ b/src/commands/plugins/tmux/layout-manager.ts
@@ -65,8 +65,30 @@ export async function stylePaneBorder(
   );
 }
 
-export async function enableBorderStatus(windowTarget: string): Promise<void> {
+export const MIN_BORDER_STATUS_PANE_HEIGHT = 4;
+
+export async function canEnableBorderStatus(
+  windowTarget: string,
+  minHeight = MIN_BORDER_STATUS_PANE_HEIGHT,
+): Promise<boolean> {
+  try {
+    const raw = await hostExec(`tmux list-panes -t '${windowTarget}' -F '#{pane_height}'`);
+    const heights = raw
+      .split("\n")
+      .map((line) => Number.parseInt(line.trim(), 10))
+      .filter(Number.isFinite);
+    return heights.length > 0 && heights.every((height) => height >= minHeight);
+  } catch {
+    // Border status is cosmetic; when geometry cannot be trusted, prefer
+    // stable layout over crashing a team/tile/swarm spawn.
+    return false;
+  }
+}
+
+export async function enableBorderStatus(windowTarget: string): Promise<boolean> {
+  if (!(await canEnableBorderStatus(windowTarget))) return false;
   await hostExec(`tmux set-option -w -t '${windowTarget}' pane-border-status bottom`);
+  return true;
 }
 
 // ─── Hide / Show (CC-style break-pane / join-pane) ───────

--- a/test/isolated/tmux-layout-manager.test.ts
+++ b/test/isolated/tmux-layout-manager.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { join } from "path";
+
+const realSdk = await import("../../src/sdk");
+
+let commands: string[] = [];
+let paneHeights = "12\n8\n4";
+let queryError: Error | null = null;
+
+mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
+  ...realSdk,
+  hostExec: async (cmd: string) => {
+    commands.push(cmd);
+    if (cmd.includes("list-panes") && cmd.includes("#{pane_height}")) {
+      if (queryError) throw queryError;
+      return paneHeights;
+    }
+    return "";
+  },
+}));
+
+const {
+  canEnableBorderStatus,
+  enableBorderStatus,
+  MIN_BORDER_STATUS_PANE_HEIGHT,
+} = await import("../../src/commands/plugins/tmux/layout-manager");
+
+describe("tmux layout-manager border status guard (#1468)", () => {
+  beforeEach(() => {
+    commands = [];
+    paneHeights = "12\n8\n4";
+    queryError = null;
+  });
+
+  test("normal panes enable bottom border status", async () => {
+    expect(MIN_BORDER_STATUS_PANE_HEIGHT).toBe(4);
+    expect(await enableBorderStatus("@win1")).toBe(true);
+
+    expect(commands).toEqual([
+      "tmux list-panes -t '@win1' -F '#{pane_height}'",
+      "tmux set-option -w -t '@win1' pane-border-status bottom",
+    ]);
+  });
+
+  test("tiny panes skip the window-wide bottom border status option", async () => {
+    paneHeights = "12\n3\n8";
+
+    expect(await enableBorderStatus("@win1")).toBe(false);
+    expect(commands).toEqual([
+      "tmux list-panes -t '@win1' -F '#{pane_height}'",
+    ]);
+  });
+
+  test("pane-height query failures fail soft and skip cosmetic border status", async () => {
+    queryError = new Error("can't find window");
+
+    expect(await enableBorderStatus("@missing")).toBe(false);
+    expect(commands).toEqual([
+      "tmux list-panes -t '@missing' -F '#{pane_height}'",
+    ]);
+  });
+
+  test("empty or unparsable height output is not trusted", async () => {
+    paneHeights = "\nnot-a-number\n";
+
+    expect(await canEnableBorderStatus("@win1")).toBe(false);
+    expect(commands).toEqual([
+      "tmux list-panes -t '@win1' -F '#{pane_height}'",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- cherry-picks #1478 / #1468 onto alpha
- bumps package.json to v26.5.16-alpha.2157
- merging this PR should trigger calver-release.yml to tag + publish alpha

## Evidence
- #1478 CI green: test-unit, test-isolated, test-plugin, test-mock-smoke, build
- local `bun test test/isolated/tmux-layout-manager.test.ts`
- local `bun test src/commands/plugins/tmux test/isolated/tmux.test.ts`
- local `bun run build`

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
