### PR TITLE
fix(serve): make PID conflicts recoverable

### DIFF
--- a/src/cli/instance-pid.ts
+++ b/src/cli/instance-pid.ts
@@ -9,6 +9,7 @@
  * file, so stale absence is the default state; nothing to reconcile.
  */
 import { openSync, readSync, writeSync, closeSync, unlinkSync, mkdirSync } from "fs";
+import { execFileSync } from "child_process";
 import { join } from "path";
 import { homedir } from "os";
 
@@ -16,7 +17,7 @@ function resolveHome(): string {
   return process.env.MAW_HOME || join(homedir(), ".maw");
 }
 
-function pidFile(): string {
+export function pidFile(): string {
   return join(resolveHome(), "maw.pid");
 }
 
@@ -31,11 +32,85 @@ function isAlive(pid: number): boolean {
   }
 }
 
+function readPid(file = pidFile()): number {
+  let fd: number | null = null;
+  try {
+    fd = openSync(file, "r");
+    const buf = Buffer.alloc(64);
+    const n = readSync(fd, buf, 0, buf.length, 0);
+    return parseInt(buf.subarray(0, n).toString("utf-8").trim(), 10);
+  } catch {
+    return NaN;
+  } finally {
+    if (fd !== null) { try { closeSync(fd); } catch {} }
+  }
+}
+
+function unlinkPid(file = pidFile()): void {
+  try { unlinkSync(file); } catch { /* already gone */ }
+}
+
+function processSummary(pid: number): string {
+  try {
+    const raw = execFileSync("ps", ["-p", String(pid), "-o", "pid=,etime=,command="], {
+      encoding: "utf-8",
+      timeout: 1000,
+    }).trim();
+    const line = raw.split("\n").at(-1)?.trim();
+    if (!line) return "";
+    const match = line.match(/^\s*\d+\s+(\S+)\s+(.+)$/);
+    if (!match) return "";
+    return `, uptime ${match[1]}, cmd: ${match[2].slice(0, 80)}`;
+  } catch {
+    return "";
+  }
+}
+
+export function serveStatus(): { pid: number | null; alive: boolean; file: string } {
+  const file = pidFile();
+  const pid = readPid(file);
+  if (!Number.isFinite(pid)) return { pid: null, alive: false, file };
+  const alive = isAlive(pid);
+  if (!alive) unlinkPid(file);
+  return { pid, alive, file };
+}
+
+export function printServeStatus(): void {
+  const status = serveStatus();
+  if (!status.pid) {
+    console.log(`maw serve: stopped (${status.file})`);
+    return;
+  }
+  if (status.alive) {
+    console.log(`maw serve: running (PID ${status.pid}${processSummary(status.pid)})`);
+  } else {
+    console.log(`maw serve: stopped — removed stale PID ${status.pid} (${status.file})`);
+  }
+}
+
+export function stopServe(): void {
+  const status = serveStatus();
+  if (!status.pid) {
+    console.log("maw serve: already stopped");
+    return;
+  }
+  if (!status.alive) {
+    console.log(`maw serve: removed stale PID ${status.pid}`);
+    return;
+  }
+  process.kill(status.pid, "SIGTERM");
+  unlinkPid(status.file);
+  console.log(`maw serve: stopped PID ${status.pid}`);
+}
+
 /**
  * Acquire the PID lock, or exit(1) with a clear error if another maw serve
  * is already running in this home.
  */
-export function acquirePidLock(instanceName: string | null): void {
+export function acquirePidLock(
+  instanceName: string | null,
+  opts: { forceTakeover?: boolean } = {},
+): void {
   const home = resolveHome();
   mkdirSync(home, { recursive: true });
   const file = pidFile();
@@ -55,28 +130,28 @@ export function acquirePidLock(instanceName: string | null): void {
       // fd-based read prevents path-TOCTOU (symlink swap between wx open and
       // the probe read). Mirrors the #562 / #581 fix in src/cli/update-lock.ts.
       // Fixed 64-byte buffer — PIDs are ≤20 digits, no fstatSync needed.
-      let prior = NaN;
-      let readFd: number | null = null;
-      try {
-        readFd = openSync(file, "r");
-        const buf = Buffer.alloc(64);
-        const n = readSync(readFd, buf, 0, buf.length, 0);
-        prior = parseInt(buf.subarray(0, n).toString("utf-8").trim(), 10);
-      } catch { /* malformed — treat as stale */ }
-      finally { if (readFd !== null) { try { closeSync(readFd); } catch {} } }
+      const prior = readPid(file);
       if (Number.isFinite(prior) && isAlive(prior)) {
+        if (opts.forceTakeover) {
+          process.kill(prior, "SIGTERM");
+          unlinkPid(file);
+          continue;
+        }
         const label = instanceName ? ` as ${instanceName}` : "";
-        console.error(`\x1b[31m✗\x1b[0m another maw serve is already running${label} (PID ${prior}). Stop it first.`);
+        console.error(`\x1b[31m✗\x1b[0m maw serve already running${label} (PID ${prior}${processSummary(prior)})`);
+        console.error(`  stop:  \x1b[36mmaw serve stop\x1b[0m`);
+        console.error(`  check: \x1b[36mmaw serve status\x1b[0m`);
+        console.error(`  force: \x1b[36mmaw serve --force-takeover\x1b[0m`);
         process.exit(1);
       }
       // Stale PID — remove and retry the atomic create once.
-      try { unlinkSync(file); } catch { /* already gone */ }
+      unlinkPid(file);
     }
   }
 
   // Clean up on clean shutdown. Best-effort — never crash if unlink fails.
   const cleanup = () => {
-    try { unlinkSync(file); } catch { /* already gone or disk full */ }
+    unlinkPid(file);
   };
   process.on("SIGTERM", () => { cleanup(); process.exit(0); });
   process.on("SIGINT", () => { cleanup(); process.exit(0); });

--- a/src/cli/route-tools.ts
+++ b/src/cli/route-tools.ts
@@ -9,7 +9,7 @@ const CORE_HELP: Record<string, string> = {
   agents: "usage: maw agents [--json] [--all] [--node <node>]",
   agent: "usage: maw agent [--json] [--all] [--node <node>]",
   audit: "usage: maw audit [limit]",
-  serve: "usage: maw serve [port] [--as <name>]",
+  serve: "usage: maw serve [port] [--as <name>] [--force-takeover] | maw serve status|stop",
 };
 
 function hasHelpFlag(args: string[]): boolean {
@@ -113,9 +113,20 @@ export async function routeTools(cmd: string, args: string[]): Promise<boolean> 
     // applyInstancePreset() in cli.ts. Any OTHER flag is still a typo.
     const serveArgs = args.slice(1);
     const asIdx = serveArgs.indexOf("--as");
-    const filteredArgs = asIdx === -1
+    const forceIdx = serveArgs.indexOf("--force-takeover");
+    const withoutAs = asIdx === -1
       ? serveArgs
       : [...serveArgs.slice(0, asIdx), ...serveArgs.slice(asIdx + 2)];
+    const filteredArgs = forceIdx === -1
+      ? withoutAs
+      : withoutAs.filter(a => a !== "--force-takeover");
+    const sub = filteredArgs[0];
+    if (sub === "status" || sub === "stop") {
+      const { printServeStatus, stopServe } = await import("./instance-pid");
+      if (sub === "status") printServeStatus();
+      else stopServe();
+      return true;
+    }
     // Reject unknown flags BEFORE starting the server — alpha.72 gate already
     // caught --help (hasHelpFlag). Anything else starting with "-" is a typo.
     // Footgun without this: `maw serve --unknown-flag` silently started a
@@ -124,7 +135,7 @@ export async function routeTools(cmd: string, args: string[]): Promise<boolean> 
     if (unknownFlag) {
       const { UserError } = await import("../core/util/user-error");
       console.error(`\x1b[31m✗\x1b[0m unknown flag '${unknownFlag}' for 'maw serve'`);
-      console.error(`  usage: maw serve [port] [--as <name>]  (run 'maw serve --help' for more)`);
+      console.error(`  usage: maw serve [port] [--as <name>] [--force-takeover]  (run 'maw serve --help' for more)`);
       throw new UserError(`unknown flag '${unknownFlag}'`);
     }
     const portArg = filteredArgs.find(a => /^\d+$/.test(a));
@@ -132,7 +143,7 @@ export async function routeTools(cmd: string, args: string[]): Promise<boolean> 
     // under the same MAW_HOME.
     const { acquirePidLock } = await import("./instance-pid");
     const instanceName = asIdx === -1 ? null : serveArgs[asIdx + 1];
-    acquirePidLock(instanceName);
+    acquirePidLock(instanceName, { forceTakeover: forceIdx !== -1 });
     const { startServer } = await import("../core/server");
     startServer(portArg ? +portArg : 3456);
     return true;

--- a/test/isolated/instance-pid.test.ts
+++ b/test/isolated/instance-pid.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+import {
+  acquirePidLock,
+  pidFile,
+  serveStatus,
+  stopServe,
+} from "../../src/cli/instance-pid";
+
+let tempHome = "";
+const origHome = process.env.MAW_HOME;
+const origExit = process.exit;
+const origKill = process.kill;
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), "maw-pid-"));
+  process.env.MAW_HOME = tempHome;
+});
+
+afterEach(() => {
+  if (origHome === undefined) delete process.env.MAW_HOME;
+  else process.env.MAW_HOME = origHome;
+  process.exit = origExit;
+  process.kill = origKill;
+  rmSync(tempHome, { recursive: true, force: true });
+});
+
+describe("maw serve PID lock UX (#1434)", () => {
+  test("stale PID files are removed and replaced", () => {
+    writeFileSync(pidFile(), "99999999");
+
+    acquirePidLock(null);
+
+    expect(readFileSync(pidFile(), "utf-8")).toBe(String(process.pid));
+  });
+
+  test("live PID failure prints actionable status/stop/force hints", () => {
+    writeFileSync(pidFile(), String(process.pid));
+    const err: string[] = [];
+    const origErr = console.error;
+    console.error = (...args: unknown[]) => { err.push(args.join(" ")); };
+    process.exit = ((code?: number) => { throw new Error(`exit:${code}`); }) as never;
+
+    try {
+      expect(() => acquirePidLock("dev")).toThrow("exit:1");
+    } finally {
+      console.error = origErr;
+    }
+
+    const text = err.join("\n");
+    expect(text).toContain("maw serve already running as dev");
+    expect(text).toContain("maw serve stop");
+    expect(text).toContain("maw serve status");
+    expect(text).toContain("maw serve --force-takeover");
+  });
+
+  test("serve status cleans stale PID files", () => {
+    writeFileSync(pidFile(), "99999999");
+
+    expect(serveStatus()).toEqual({ pid: 99999999, alive: false, file: pidFile() });
+    expect(serveStatus()).toEqual({ pid: null, alive: false, file: pidFile() });
+  });
+
+  test("force takeover kills prior process and acquires the lock", () => {
+    writeFileSync(pidFile(), "4242");
+    const kills: Array<{ pid: number; signal?: string | number }> = [];
+    process.kill = ((pid: number, signal?: string | number) => {
+      kills.push({ pid, signal });
+      return true;
+    }) as typeof process.kill;
+
+    acquirePidLock(null, { forceTakeover: true });
+
+    expect(kills).toEqual([
+      { pid: 4242, signal: 0 },
+      { pid: 4242, signal: "SIGTERM" },
+    ]);
+    expect(readFileSync(pidFile(), "utf-8")).toBe(String(process.pid));
+  });
+
+  test("serve stop terminates live PID and removes the lock", () => {
+    writeFileSync(pidFile(), "4242");
+    const kills: Array<{ pid: number; signal?: string | number }> = [];
+    process.kill = ((pid: number, signal?: string | number) => {
+      kills.push({ pid, signal });
+      return true;
+    }) as typeof process.kill;
+
+    stopServe();
+
+    expect(kills).toEqual([
+      { pid: 4242, signal: 0 },
+      { pid: 4242, signal: "SIGTERM" },
+    ]);
+    expect(serveStatus()).toEqual({ pid: null, alive: false, file: pidFile() });
+  });
+});


### PR DESCRIPTION
## Summary
- add `maw serve status` and `maw serve stop`
- improve live-lock errors with PID, process summary, and stop/status/force hints
- add `--force-takeover` for explicit recovery from a live stale/conflicting daemon

Closes #1434.

## Validation
- `bun test test/isolated/instance-pid.test.ts`
- `git diff --check`
- `bun run build`

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.