### PR TITLE
release: v26.5.16-alpha.2245

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.16-alpha.2218",
+  "version": "26.5.16-alpha.2245",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/cli/plugin-bootstrap.test.ts
+++ b/src/cli/plugin-bootstrap.test.ts
@@ -48,7 +48,7 @@ describe("runBootstrap — #817 idempotent bundled-plugin symlinks", () => {
     try { rmSync(workDir, { recursive: true, force: true }); } catch {}
   });
 
-  /** Helper: create a bundled plugin dir that runBootstrap will recognize. */
+  /** Helper: create a bundled plugin dir. Only manifest dirs are valid plugin packages. */
   function makeBundledPlugin(name: string, kind: "manifest" | "index" = "manifest") {
     const dir = join(bundledDir, name);
     mkdirSync(dir, { recursive: true });
@@ -71,7 +71,7 @@ describe("runBootstrap — #817 idempotent bundled-plugin symlinks", () => {
 
   it("empty pluginDir → all bundled plugins symlinked (first install)", async () => {
     makeBundledPlugin("alpha");
-    makeBundledPlugin("beta", "index");
+    makeBundledPlugin("beta");
     makeBundledPlugin("gamma");
 
     await runBootstrap(pluginDir, srcDir);
@@ -96,6 +96,33 @@ describe("runBootstrap — #817 idempotent bundled-plugin symlinks", () => {
     expect(readlinkSync(join(pluginDir, "tile"))).toBe(join(bundledDir, "tile"));
     expect(readlinkSync(join(pluginDir, "wake"))).toBe(join(vendoredDir, "wake"));
     expect(readlinkSync(join(pluginDir, "attach"))).toBe(join(vendoredDir, "attach"));
+  });
+
+  it("#1484 — incomplete in-tree plugin dir does not block vendored manifest plugin", async () => {
+    makeBundledPlugin("team", "index"); // legacy/incomplete in-tree team surface
+    const vendoredTeam = makeVendoredPlugin("team");
+
+    await runBootstrap(pluginDir, srcDir);
+
+    expect(readdirSync(pluginDir).sort()).toEqual(["team"]);
+    expect(lstatSync(join(pluginDir, "team")).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(join(pluginDir, "team"))).toBe(vendoredTeam);
+  });
+
+  it("#1484 — existing symlink to non-manifest plugin dir is healed to vendored plugin", async () => {
+    const incompleteTeam = makeBundledPlugin("team", "index");
+    const vendoredTeam = makeVendoredPlugin("team");
+
+    mkdirSync(pluginDir, { recursive: true });
+    symlinkSync(incompleteTeam, join(pluginDir, "team"));
+    expect(lstatSync(join(pluginDir, "team")).isSymbolicLink()).toBe(true);
+    expect(existsSync(join(pluginDir, "team"))).toBe(true);
+    expect(readlinkSync(join(pluginDir, "team"))).toBe(incompleteTeam);
+
+    await runBootstrap(pluginDir, srcDir);
+
+    expect(lstatSync(join(pluginDir, "team")).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(join(pluginDir, "team"))).toBe(vendoredTeam);
   });
 
   it("#1339 — user plugin dirs override vendored plugin names", async () => {
@@ -166,11 +193,12 @@ describe("runBootstrap — #817 idempotent bundled-plugin symlinks", () => {
     expect(existsSync(join(userDir, "marker.txt"))).toBe(true);
   });
 
-  it("non-plugin dirs (no plugin.json, no index.ts) are skipped", async () => {
+  it("non-plugin dirs (no plugin.json) are skipped even when they have index.ts", async () => {
     makeBundledPlugin("alpha");
     // garbage dir under bundled — not a plugin
     mkdirSync(join(bundledDir, "_shared"), { recursive: true });
     writeFileSync(join(bundledDir, "_shared", "util.ts"), "// helper\n");
+    makeBundledPlugin("index-only", "index");
 
     await runBootstrap(pluginDir, srcDir);
 

--- a/src/cli/plugin-bootstrap.ts
+++ b/src/cli/plugin-bootstrap.ts
@@ -5,7 +5,7 @@ import { join } from "path";
 const URL_SCHEME_RE = /^https?:\/\//;
 
 function isPluginDir(dir: string): boolean {
-  return existsSync(join(dir, "plugin.json")) || existsSync(join(dir, "index.ts"));
+  return existsSync(join(dir, "plugin.json"));
 }
 
 function linkBundledPlugins(pluginDir: string, bundled: string): number {
@@ -28,7 +28,9 @@ function healOrPruneBrokenSymlinks(pluginDir: string, bundledRoots: string[]): {
   for (const entry of readdirSync(pluginDir)) {
     const p = join(pluginDir, entry);
     try {
-      if (!lstatSync(p).isSymbolicLink() || existsSync(p)) continue;
+      if (!lstatSync(p).isSymbolicLink()) continue;
+      const targetIsValidPlugin = existsSync(p) && isPluginDir(p);
+      if (targetIsValidPlugin) continue;
       const replacement = bundledRoots
         .map((root) => join(root, entry))
         .find((candidate) => existsSync(candidate) && isPluginDir(candidate));

--- a/src/commands/plugins/tile/impl.ts
+++ b/src/commands/plugins/tile/impl.ts
@@ -15,6 +15,22 @@ function envExport(assignments: Record<string, string>): string {
     .join(" ");
 }
 
+const TILE_TITLE_RE = /^(?:[A-Za-z0-9_.-]+-)?tile-\d+(?: 🌳)?$/;
+const TILE_WORKTREE_PATH_RE = /\.wt-\d+-(?:[A-Za-z0-9_.-]+-)?tile-\d+$/;
+const TILE_BRANCH_RE = /^agents\/\d+-(?:[A-Za-z0-9_.-]+-)?tile-\d+$/;
+
+function tileScope(parentAddress: string): string {
+  const parentSession = parentAddress.split(":")[0]?.trim() ?? "";
+  return parentSession
+    .replace(/[^A-Za-z0-9_.-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function tileRole(parentAddress: string, tileIndex: number): string {
+  const scope = tileScope(parentAddress);
+  return scope ? `${scope}-tile-${tileIndex}` : `tile-${tileIndex}`;
+}
+
 async function getParentAddress(anchor: string): Promise<string> {
   if (!anchor) return "";
   try {
@@ -47,7 +63,7 @@ async function countExistingTilePanes(window: string): Promise<number> {
     const panes = await listPanes(window, "#{pane_id}|||#{pane_title}|||#{@maw_tile}");
     return panes.filter(line => {
       const [, title = "", marker = ""] = line.split("|||");
-      return marker === "1" || /^tile-\d+(?: 🌳)?$/.test(title);
+      return marker === "1" || TILE_TITLE_RE.test(title);
     }).length;
   } catch {
     return 0;
@@ -120,7 +136,7 @@ export async function cmdTile(count: number, opts: TileOpts = {}): Promise<void>
 
   for (let i = 0; i < count; i++) {
     const tileIndex = existingTileCount + i + 1;
-    const name = `tile-${tileIndex}`;
+    const name = tileRole(parentAddress, tileIndex);
 
     let cwd = "";
     if (opts.wt) {
@@ -209,7 +225,7 @@ export async function cmdTileClean(): Promise<void> {
   for (const line of lines) {
     const [paneId, title = "", marker = ""] = line.split("|||");
     if (paneId === myPane) continue;
-    if (marker !== "1" && !/^tile-\d+(?: 🌳)?$/.test(title)) continue;
+    if (marker !== "1" && !TILE_TITLE_RE.test(title)) continue;
 
     try {
       await hostExec(`tmux kill-pane -t '${paneId}'`);
@@ -239,7 +255,7 @@ export async function cmdTileClean(): Promise<void> {
     }
     if (current) tileWts.push(current);
 
-    for (const wtInfo of tileWts.filter(w => /\.wt-\d+-tile-\d+$/.test(w.path))) {
+    for (const wtInfo of tileWts.filter(w => TILE_WORKTREE_PATH_RE.test(w.path))) {
       const wt = wtInfo.path;
       if (!existsSync(wt)) continue;
       try {
@@ -248,7 +264,7 @@ export async function cmdTileClean(): Promise<void> {
         killed++;
       } catch { /* ok */ }
       const branch = wtInfo.branch;
-      if (branch && /^agents\/\d+-tile-\d+$/.test(branch)) {
+      if (branch && TILE_BRANCH_RE.test(branch)) {
         try {
           await hostExec(`git -C ${shellArg(mainRepo)} branch -d ${shellArg(branch)} 2>/dev/null`);
           console.log(`  \x1b[31m✗\x1b[0m branch ${branch}`);

--- a/test/isolated/tile.test.ts
+++ b/test/isolated/tile.test.ts
@@ -31,6 +31,9 @@ function paneIdsFromPaneList(): string[] {
 }
 
 mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
+  FLEET_DIR: "/tmp/fleet",
+  curlFetch: async () => ({ ok: false, status: 404, text: async () => "" }),
+  tmux: {},
   hostExec: async (cmd: string): Promise<string> => {
     commands.push(cmd);
 
@@ -47,6 +50,7 @@ mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
     }
     if (cmd.includes("git rev-parse --show-toplevel")) return "/tmp/maw-js\n";
     if (cmd.includes("git -C '/tmp/maw-js' worktree list")) return worktreeList;
+    if (cmd.includes("show-ref --verify")) throw new Error("missing branch");
 
     return "";
   },
@@ -60,6 +64,7 @@ beforeEach(() => {
   paneList = "";
   worktreeList = "";
   rmSync("/tmp/maw-js.wt-1-tile-1", { recursive: true, force: true });
+  rmSync("/tmp/maw-js.wt-2-sess-tile-1", { recursive: true, force: true });
   process.env.TMUX_PANE = "%lead";
 });
 
@@ -69,9 +74,9 @@ describe("tile plugin layout", () => {
 
     const splitCommands = commands.filter(cmd => cmd.includes("tmux split-window"));
     expect(splitCommands[0]).toContain("MAW_TILE_PARENT='");
-    expect(splitCommands[0]).toContain("MAW_TILE_ROLE='\\''tile-1'\\''");
+    expect(splitCommands[0]).toContain("MAW_TILE_ROLE='\\''sess-tile-1'\\''");
     expect(splitCommands[0]).toContain("MAW_TILE_TOTAL='\\''2'\\''");
-    expect(splitCommands[1]).toContain("MAW_TILE_ROLE='\\''tile-2'\\''");
+    expect(splitCommands[1]).toContain("MAW_TILE_ROLE='\\''sess-tile-2'\\''");
     expect(commands).toContain("tmux select-layout -t '@win' main-vertical");
     expect(commands).not.toContain("tmux select-layout -t '@win' tiled");
   });
@@ -93,7 +98,7 @@ describe("tile plugin layout", () => {
     await cmdTile(1);
 
     const splitCommand = commands.find(cmd => cmd.includes("tmux split-window"));
-    expect(splitCommand).toContain("MAW_TILE_ROLE='\\''tile-3'\\''");
+    expect(splitCommand).toContain("MAW_TILE_ROLE='\\''sess-tile-3'\\''");
     expect(splitCommand).toContain("MAW_TILE_INDEX='\\''3'\\''");
     expect(splitCommand).toContain("MAW_TILE_TOTAL='\\''3'\\''");
     expect(commands).toContain("tmux select-layout -t '@win' main-vertical");
@@ -129,14 +134,23 @@ describe("tile plugin spawn metadata", () => {
 
     const splitCommand = commands.find(cmd => cmd.includes("tmux split-window"));
     expect(splitCommand).toContain("MAW_TILE_PARENT='\\''sess:1.0'\\''");
-    expect(splitCommand).toContain("MAW_TILE_ROLE='\\''tile-1'\\''");
+    expect(splitCommand).toContain("MAW_TILE_ROLE='\\''sess-tile-1'\\''");
     expect(splitCommand).toContain("MAW_TILE_INDEX='\\''1'\\''");
     expect(splitCommand).toContain("MAW_TILE_TOTAL='\\''1'\\''");
     expect(splitCommand).toContain("MAW_TILE_WINDOW='\\''sess:1'\\''");
     expect(splitCommand).toContain("; claude; exec zsh");
     expect(commands).toContain("tmux set-option -p -t '%p1' @maw_tile '1'");
     expect(commands).toContain("tmux set-option -p -t '%p1' @maw_tile_parent 'sess:1.0'");
-    expect(commands).toContain("tmux set-option -p -t '%p1' @maw_tile_role 'tile-1'");
+    expect(commands).toContain("tmux set-option -p -t '%p1' @maw_tile_role 'sess-tile-1'");
+  });
+
+  test("uses scoped tile roles for worktree names and branches", async () => {
+    await cmdTile(1, { wt: true });
+
+    expect(commands).toContain("git -C '/tmp/maw-js' worktree add '/tmp/maw-js.wt-1-sess-tile-1' -b 'agents/1-sess-tile-1'");
+    const splitCommand = commands.find(cmd => cmd.includes("tmux split-window"));
+    expect(splitCommand).toContain("/tmp/maw-js.wt-1-sess-tile-1");
+    expect(splitCommand).toContain("MAW_TILE_ROLE='\\''sess-tile-1'\\''");
   });
 });
 
@@ -147,18 +161,21 @@ describe("tile clean", () => {
       "%p1|||tile-1|||1",
       "%p2|||zsh|||",
       "%p3|||tile-3 🌳|||",
+      "%p4|||sess-tile-4 🌳|||",
     ].join("\n");
 
     await cmdTileClean();
 
     expect(commands).toContain("tmux kill-pane -t '%p1'");
     expect(commands).toContain("tmux kill-pane -t '%p3'");
+    expect(commands).toContain("tmux kill-pane -t '%p4'");
     expect(commands).not.toContain("tmux kill-pane -t '%p2'");
     expect(commands).not.toContain("tmux kill-pane -t '%lead'");
   });
 
   test("removes tile worktrees and safely deletes matching tile branches", async () => {
     mkdirSync("/tmp/maw-js.wt-1-tile-1", { recursive: true });
+    mkdirSync("/tmp/maw-js.wt-2-sess-tile-1", { recursive: true });
     worktreeList = [
       "worktree /tmp/maw-js",
       "HEAD 1111111111111111111111111111111111111111",
@@ -168,18 +185,25 @@ describe("tile clean", () => {
       "HEAD 2222222222222222222222222222222222222222",
       "branch refs/heads/agents/1-tile-1",
       "",
-      "worktree /tmp/maw-js.wt-2-task",
+      "worktree /tmp/maw-js.wt-2-sess-tile-1",
       "HEAD 3333333333333333333333333333333333333333",
-      "branch refs/heads/agents/2-task",
+      "branch refs/heads/agents/2-sess-tile-1",
+      "",
+      "worktree /tmp/maw-js.wt-3-task",
+      "HEAD 3333333333333333333333333333333333333333",
+      "branch refs/heads/agents/3-task",
     ].join("\n");
 
     await cmdTileClean();
 
     expect(commands).toContain("git -C '/tmp/maw-js' worktree remove '/tmp/maw-js.wt-1-tile-1' --force 2>/dev/null");
     expect(commands).toContain("git -C '/tmp/maw-js' branch -d 'agents/1-tile-1' 2>/dev/null");
-    expect(commands.some(cmd => cmd.includes("agents/2-task"))).toBe(false);
+    expect(commands).toContain("git -C '/tmp/maw-js' worktree remove '/tmp/maw-js.wt-2-sess-tile-1' --force 2>/dev/null");
+    expect(commands).toContain("git -C '/tmp/maw-js' branch -d 'agents/2-sess-tile-1' 2>/dev/null");
+    expect(commands.some(cmd => cmd.includes("agents/3-task"))).toBe(false);
 
     rmSync("/tmp/maw-js.wt-1-tile-1", { recursive: true, force: true });
+    rmSync("/tmp/maw-js.wt-2-sess-tile-1", { recursive: true, force: true });
   });
 });
 


### PR DESCRIPTION
## Summary
- cut `v26.5.16-alpha.2245`
- includes #1485 scoped tile roles/worktrees so `tile-N` names stop colliding across sessions
- includes #1487/#1484 bootstrap repair so `maw team`/`maw t` dispatch resolves to the vendored manifest plugin instead of the incomplete in-tree helper dir

## Validation
- `bun test src/cli/plugin-bootstrap.test.ts`
- `bun test test/isolated/tile.test.ts`
- `git diff --check origin/alpha..HEAD`
- `bun run build`
- `MAW_PLUGINS_DIR=$(mktemp -d) bun src/cli.ts team --help`
- `MAW_PLUGINS_DIR=$(mktemp -d) bun src/cli.ts t --help`

On merge, `calver-release.yml` should tag/publish `v26.5.16-alpha.2245` to npm `@alpha`.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
