### PR TITLE
fix(fleet): tolerate malformed list entries

### DIFF
--- a/src/commands/shared/fleet-manage.ts
+++ b/src/commands/shared/fleet-manage.ts
@@ -1,14 +1,26 @@
 import { join } from "path";
 import { existsSync, renameSync, unlinkSync, readdirSync } from "fs";
 import { tmux, FLEET_DIR } from "../../sdk";
-import { loadFleetEntries, getSessionNames } from "./fleet-load";
+import { loadFleetEntries, getSessionNames, type FleetEntry } from "./fleet-load";
 
-export async function cmdFleetLs() {
-  const entries = loadFleetEntries();
-  const disabled = readdirSync(FLEET_DIR).filter(f => f.endsWith(".disabled")).length;
+function displaySessionName(entry: FleetEntry): string {
+  const session = entry.session as unknown as { name?: unknown } | null | undefined;
+  return typeof session?.name === "string" && session.name.length > 0
+    ? session.name
+    : entry.groupName || entry.file.replace(/\.json$/, "") || "(unnamed)";
+}
 
-  const runningSessions = await getSessionNames();
+function displayWindowCount(entry: FleetEntry): number {
+  const session = entry.session as unknown as { windows?: unknown } | null | undefined;
+  return Array.isArray(session?.windows) ? session.windows.length : 0;
+}
 
+function isMalformedEntry(entry: FleetEntry): boolean {
+  const session = entry.session as unknown as { name?: unknown; windows?: unknown } | null | undefined;
+  return typeof session?.name !== "string" || session.name.length === 0 || !Array.isArray(session?.windows);
+}
+
+export function renderFleetLs(entries: FleetEntry[], disabled: number, runningSessions: string[]): string[] {
   // Detect conflicts (duplicate numbers)
   const numCount = new Map<number, string[]>();
   for (const e of entries) {
@@ -18,28 +30,40 @@ export async function cmdFleetLs() {
   }
 
   const conflicts = [...numCount.entries()].filter(([, names]) => names.length > 1);
+  const lines: string[] = [];
 
-  console.log(`\n  \x1b[36mFleet Configs\x1b[0m (${entries.length} active, ${disabled} disabled)\n`);
-  console.log(`  ${"#".padEnd(4)} ${"Session".padEnd(20)} ${"Win".padEnd(5)} Status`);
-  console.log(`  ${"─".repeat(4)} ${"─".repeat(20)} ${"─".repeat(5)} ${"─".repeat(20)}`);
+  lines.push(`\n  \x1b[36mFleet Configs\x1b[0m (${entries.length} active, ${disabled} disabled)\n`);
+  lines.push(`  ${"#".padEnd(4)} ${"Session".padEnd(20)} ${"Win".padEnd(5)} Status`);
+  lines.push(`  ${"─".repeat(4)} ${"─".repeat(20)} ${"─".repeat(5)} ${"─".repeat(20)}`);
 
   for (const e of entries) {
     const numStr = String(e.num).padStart(2, "0");
-    const name = e.session.name.padEnd(20);
-    const wins = String(e.session.windows.length).padEnd(5);
-    const isRunning = runningSessions.includes(e.session.name);
+    const sessionName = displaySessionName(e);
+    const name = sessionName.padEnd(20);
+    const wins = String(displayWindowCount(e)).padEnd(5);
+    const isRunning = runningSessions.includes(sessionName);
     const isConflict = (numCount.get(e.num)?.length ?? 0) > 1;
 
     let status = isRunning ? "\x1b[32mrunning\x1b[0m" : "\x1b[90mstopped\x1b[0m";
     if (isConflict) status += "  \x1b[31mCONFLICT\x1b[0m";
+    if (isMalformedEntry(e)) status += "  \x1b[33mINVALID\x1b[0m";
 
-    console.log(`  ${numStr}  ${name} ${wins} ${status}`);
+    lines.push(`  ${numStr}  ${name} ${wins} ${status}`);
   }
 
   if (conflicts.length > 0) {
-    console.log(`\n  \x1b[31m⚠ ${conflicts.length} conflict(s) found.\x1b[0m Run \x1b[36mmaw fleet renumber\x1b[0m to fix.`);
+    lines.push(`\n  \x1b[31m⚠ ${conflicts.length} conflict(s) found.\x1b[0m Run \x1b[36mmaw fleet renumber\x1b[0m to fix.`);
   }
-  console.log();
+  lines.push("");
+  return lines;
+}
+
+export async function cmdFleetLs() {
+  const entries = loadFleetEntries();
+  const disabled = readdirSync(FLEET_DIR).filter(f => f.endsWith(".disabled")).length;
+
+  const runningSessions = await getSessionNames();
+  for (const line of renderFleetLs(entries, disabled, runningSessions)) console.log(line);
 }
 
 export async function cmdFleetRenumber() {

--- a/test/isolated/fleet-manage.test.ts
+++ b/test/isolated/fleet-manage.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Regression coverage for #1486 — `maw fleet` must render every config entry
+ * even when one fleet JSON is malformed or missing its `session.name` shape.
+ */
+import { describe, expect, test } from "bun:test";
+import { renderFleetLs } from "../../src/commands/shared/fleet-manage";
+
+describe("renderFleetLs", () => {
+  test("#1486 — malformed entries render with fallback labels instead of crashing", () => {
+    const output = renderFleetLs(
+      [
+        {
+          file: "01-good.json",
+          num: 1,
+          groupName: "good",
+          session: { name: "01-good", windows: [{ name: "main", repo: "org/good" }] },
+        },
+        {
+          file: "02-missing-name.json",
+          num: 2,
+          groupName: "missing-name",
+          session: { windows: [] },
+        },
+        {
+          file: "03-null-session.json",
+          num: 3,
+          groupName: "null-session",
+          session: null,
+        },
+        {
+          file: "04-after-bad.json",
+          num: 4,
+          groupName: "after-bad",
+          session: {
+            name: "04-after-bad",
+            windows: [
+              { name: "main", repo: "org/after" },
+              { name: "aux", repo: "org/after" },
+            ],
+          },
+        },
+      ] as any,
+      1,
+      ["01-good", "04-after-bad"],
+    ).join("\n");
+
+    expect(output).toContain("Fleet Configs");
+    expect(output).toContain("(4 active, 1 disabled)");
+    expect(output).toContain("01-good");
+    expect(output).toContain("missing-name");
+    expect(output).toContain("null-session");
+    expect(output).toContain("04-after-bad");
+    expect(output).toContain("INVALID");
+    expect(output).toContain("running");
+  });
+});


### PR DESCRIPTION
## Summary
- make `maw fleet` render malformed fleet entries with fallback labels instead of crashing
- mark bad rows `INVALID` while continuing the full table
- add regression coverage for missing `session.name`, null `session`, and a good row after bad data

Closes #1486.

## Validation
- `bun test test/isolated/fleet-manage.test.ts`
- `bun test test/isolated/api-fleet-json.test.ts`
- `bun test test/isolated/fleet-doctor.test.ts`
- `MAW_PLUGINS_DIR=$(mktemp -d) bun src/cli.ts fleet`
- `git diff --check`
- `bun run build`

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
