### PR TITLE
fix(update): refresh stale bundled plugin symlinks

### DIFF
--- a/src/cli/plugin-bootstrap.test.ts
+++ b/src/cli/plugin-bootstrap.test.ts
@@ -69,6 +69,20 @@ describe("runBootstrap — #817 idempotent bundled-plugin symlinks", () => {
     return dir;
   }
 
+  /** Helper: create a previous maw-js package root with a bundled plugin. */
+  function makeStaleMawJsBundledPlugin(name: string, lane: "commands" | "vendor" = "commands") {
+    const root = join(workDir, `old-maw-js-${lane}-${name}`);
+    mkdirSync(root, { recursive: true });
+    writeFileSync(join(root, "package.json"), JSON.stringify({ name: "maw-js", version: "0.0.0-old" }));
+    const dir = lane === "commands"
+      ? join(root, "src", "commands", "plugins", name)
+      : join(root, "src", "vendor", "mpr-plugins", name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "plugin.json"), JSON.stringify({ name }));
+    writeFileSync(join(dir, "index.ts"), `export default async () => ({ stale: true });\n`);
+    return dir;
+  }
+
   it("empty pluginDir → all bundled plugins symlinked (first install)", async () => {
     makeBundledPlugin("alpha");
     makeBundledPlugin("beta");
@@ -123,6 +137,50 @@ describe("runBootstrap — #817 idempotent bundled-plugin symlinks", () => {
 
     expect(lstatSync(join(pluginDir, "team")).isSymbolicLink()).toBe(true);
     expect(readlinkSync(join(pluginDir, "team"))).toBe(vendoredTeam);
+  });
+
+  it("#1491 — stale symlink to an older maw-js bundled plugin is healed to current package", async () => {
+    const currentFleet = makeBundledPlugin("fleet");
+    const staleFleet = makeStaleMawJsBundledPlugin("fleet");
+
+    mkdirSync(pluginDir, { recursive: true });
+    symlinkSync(staleFleet, join(pluginDir, "fleet"));
+    expect(readlinkSync(join(pluginDir, "fleet"))).toBe(staleFleet);
+
+    await runBootstrap(pluginDir, srcDir);
+
+    expect(lstatSync(join(pluginDir, "fleet")).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(join(pluginDir, "fleet"))).toBe(currentFleet);
+  });
+
+  it("#1491 — stale symlink to an older vendored maw-js plugin is healed to current vendor", async () => {
+    const currentWake = makeVendoredPlugin("wake");
+    const staleWake = makeStaleMawJsBundledPlugin("wake", "vendor");
+
+    mkdirSync(pluginDir, { recursive: true });
+    symlinkSync(staleWake, join(pluginDir, "wake"));
+    expect(readlinkSync(join(pluginDir, "wake"))).toBe(staleWake);
+
+    await runBootstrap(pluginDir, srcDir);
+
+    expect(lstatSync(join(pluginDir, "wake")).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(join(pluginDir, "wake"))).toBe(currentWake);
+  });
+
+  it("#1491 — symlinked user plugin override is not treated as stale maw-js bundle", async () => {
+    makeBundledPlugin("fleet");
+    const userFleet = join(workDir, "user-plugins", "fleet");
+    mkdirSync(userFleet, { recursive: true });
+    writeFileSync(join(userFleet, "plugin.json"), JSON.stringify({ name: "fleet" }));
+    writeFileSync(join(userFleet, "index.ts"), `export default async () => ({ user: true });\n`);
+
+    mkdirSync(pluginDir, { recursive: true });
+    symlinkSync(userFleet, join(pluginDir, "fleet"));
+
+    await runBootstrap(pluginDir, srcDir);
+
+    expect(lstatSync(join(pluginDir, "fleet")).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(join(pluginDir, "fleet"))).toBe(userFleet);
   });
 
   it("#1339 — user plugin dirs override vendored plugin names", async () => {

--- a/src/cli/plugin-bootstrap.ts
+++ b/src/cli/plugin-bootstrap.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, existsSync, readdirSync, symlinkSync, cpSync, readFileSync, lstatSync, unlinkSync } from "fs";
+import { mkdirSync, existsSync, readdirSync, symlinkSync, cpSync, readFileSync, lstatSync, unlinkSync, realpathSync } from "fs";
 import { join } from "path";
 
 /** Allowlist: only http/https URLs may be used as plugin sources */
@@ -22,6 +22,45 @@ function linkBundledPlugins(pluginDir: string, bundled: string): number {
   return linked;
 }
 
+function replacementForPlugin(entry: string, bundledRoots: string[]): string | undefined {
+  return bundledRoots
+    .map((root) => join(root, entry))
+    .find((candidate) => existsSync(candidate) && isPluginDir(candidate));
+}
+
+function bundledMawJsRoot(target: string, entry: string): string | undefined {
+  const normalized = target.replace(/\\/g, "/");
+  const suffixes = [
+    `/src/commands/plugins/${entry}`,
+    `/src/vendor/mpr-plugins/${entry}`,
+  ];
+  for (const suffix of suffixes) {
+    if (!normalized.endsWith(suffix)) continue;
+    return target.slice(0, target.length - suffix.length);
+  }
+}
+
+function isMawJsPackageRoot(root: string | undefined): boolean {
+  if (!root) return false;
+  try {
+    const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf-8"));
+    return pkg?.name === "maw-js";
+  } catch {
+    return false;
+  }
+}
+
+function pointsAtStaleMawJsBundledPlugin(symlinkPath: string, entry: string, replacement: string): boolean {
+  try {
+    const currentTarget = realpathSync(replacement);
+    const existingTarget = realpathSync(symlinkPath);
+    if (existingTarget === currentTarget) return false;
+    return isMawJsPackageRoot(bundledMawJsRoot(existingTarget, entry));
+  } catch {
+    return false;
+  }
+}
+
 function healOrPruneBrokenSymlinks(pluginDir: string, bundledRoots: string[]): { healed: number; pruned: number } {
   let healed = 0;
   let pruned = 0;
@@ -29,11 +68,9 @@ function healOrPruneBrokenSymlinks(pluginDir: string, bundledRoots: string[]): {
     const p = join(pluginDir, entry);
     try {
       if (!lstatSync(p).isSymbolicLink()) continue;
+      const replacement = replacementForPlugin(entry, bundledRoots);
       const targetIsValidPlugin = existsSync(p) && isPluginDir(p);
-      if (targetIsValidPlugin) continue;
-      const replacement = bundledRoots
-        .map((root) => join(root, entry))
-        .find((candidate) => existsSync(candidate) && isPluginDir(candidate));
+      if (targetIsValidPlugin && (!replacement || !pointsAtStaleMawJsBundledPlugin(p, entry, replacement))) continue;
       unlinkSync(p);
       if (replacement) {
         symlinkSync(replacement, p);


### PR DESCRIPTION
## Summary
- heal stale `~/.maw/plugins/<core>` symlinks that point at an older maw-js package root
- only relink symlinks that point to another maw-js bundled plugin path for the same plugin name
- preserve user plugin directory/symlink overrides
- add regression coverage for stale in-tree and vendored plugin symlinks

Closes #1491.

## Validation
- `bun test src/cli/plugin-bootstrap.test.ts`
- `MAW_PLUGINS_DIR=<tmp with fleet -> stale /opt maw-js symlink> bun src/cli.ts fleet`
- `git diff --check`
- `bun run build`

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
