### PR TITLE
feat(plugin): add opt-in zenoh scout provider

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -143,8 +143,16 @@ export interface MawConfig {
   psiPath?: string;
   /** TLS cert/key paths */
   tls?: { cert: string; key: string };
-  /** Zenoh transport — pub/sub via zenohd remote-api */
-  zenoh?: { locator: string };
+  /** Zenoh transport — pub/sub/discovery via zenohd remote-api */
+  zenoh?: {
+    locator?: string;
+    scout?: {
+      enabled?: boolean;
+      locator?: string;
+      timeoutMs?: number;
+      keyPrefix?: string;
+    };
+  };
   /** Polling intervals (ms) */
   intervals?: MawIntervals;
   /** HTTP/operation timeouts (ms) */

--- a/src/config/validate-ext.ts
+++ b/src/config/validate-ext.ts
@@ -70,12 +70,23 @@ function validateExtFields(
     }
   }
 
-  // zenoh: { locator: string }
+  // zenoh: { locator?: string, scout?: { enabled?: boolean, locator?: string, timeoutMs?: number, keyPrefix?: string } }
   if ("zenoh" in raw && raw.zenoh && typeof raw.zenoh === "object") {
     const z = raw.zenoh as Record<string, unknown>;
+    const zenoh: NonNullable<MawConfig["zenoh"]> = {};
     if (typeof z.locator === "string") {
-      result.zenoh = { locator: z.locator };
+      zenoh.locator = z.locator;
     }
+    if (z.scout && typeof z.scout === "object" && !Array.isArray(z.scout)) {
+      const s = z.scout as Record<string, unknown>;
+      const scout: NonNullable<NonNullable<MawConfig["zenoh"]>["scout"]> = {};
+      if (typeof s.enabled === "boolean") scout.enabled = s.enabled;
+      if (typeof s.locator === "string") scout.locator = s.locator;
+      if (typeof s.timeoutMs === "number" && Number.isFinite(s.timeoutMs) && s.timeoutMs > 0) scout.timeoutMs = s.timeoutMs;
+      if (typeof s.keyPrefix === "string" && s.keyPrefix) scout.keyPrefix = s.keyPrefix;
+      if (Object.keys(scout).length > 0) zenoh.scout = scout;
+    }
+    if (Object.keys(zenoh).length > 0) result.zenoh = zenoh;
   }
 
   // pluginSources: string[] of URLs

--- a/src/vendor/mpr-plugins/zenoh-scout/impl.ts
+++ b/src/vendor/mpr-plugins/zenoh-scout/impl.ts
@@ -1,0 +1,255 @@
+import { createHash } from "crypto";
+import type { MawConfig } from "maw-js/config/types";
+
+export interface ZenohScoutConfig {
+  enabled: boolean;
+  locator: string;
+  timeoutMs: number;
+  keyPrefix: string;
+  node: string;
+  oracle: string;
+  apiUrl: string;
+  capabilities: string[];
+  advertise?: boolean;
+}
+
+export interface ZenohScoutPeer {
+  zid: string;
+  node: string;
+  oracle: string;
+  host: string;
+  locators: string[];
+  capabilities: string[];
+  oracles: string[];
+  firstSeen: string;
+  lastSeen: string;
+  seenRel: string;
+  paired: boolean;
+  transport: "zenoh";
+}
+
+export interface ZenohScoutResult {
+  ok: boolean;
+  enabled: boolean;
+  locator: string;
+  keyPrefix: string;
+  total: number;
+  peers: ZenohScoutPeer[];
+  error?: string;
+  hint?: string;
+}
+
+export interface ZenohApi {
+  Config: new (locator: string, timeoutMs?: number) => unknown;
+  KeyExpr: new (key: string) => unknown;
+  Session?: { open(config: unknown): Promise<ZenohSession> };
+  open?: (config: unknown) => Promise<ZenohSession>;
+  Duration?: { milliseconds?: { of(ms: number): unknown } };
+}
+
+export interface ZenohSession {
+  liveliness(): {
+    declareToken(key: unknown): Promise<{ undeclare(): Promise<void> }>;
+    get(key: unknown, opts?: Record<string, unknown>): Promise<AsyncIterable<unknown> | undefined>;
+  };
+  close(): Promise<void>;
+}
+
+export type ImportZenoh = () => Promise<ZenohApi>;
+
+const DEFAULT_LOCATOR = "ws://127.0.0.1:10000";
+const DEFAULT_TIMEOUT_MS = 750;
+const DEFAULT_KEY_PREFIX = "maw/discovery/v1";
+const DEFAULT_CAPABILITIES = ["pair", "feed", "send"];
+
+export function readZenohScoutConfig(config: MawConfig): ZenohScoutConfig {
+  const rawZenoh = config.zenoh ?? {};
+  const rawScout = rawZenoh.scout ?? {};
+  const node = config.node ?? "local";
+  const oracle = config.oracle ?? "mawjs";
+  const port = config.port ?? 3456;
+  const locator = rawScout.locator ?? rawZenoh.locator ?? DEFAULT_LOCATOR;
+  const timeoutMs = Number.isFinite(rawScout.timeoutMs)
+    ? Math.max(1, Number(rawScout.timeoutMs))
+    : DEFAULT_TIMEOUT_MS;
+  const keyPrefix = rawScout.keyPrefix?.replace(/\/+$/g, "") || DEFAULT_KEY_PREFIX;
+
+  return {
+    enabled: rawScout.enabled === true,
+    locator,
+    timeoutMs,
+    keyPrefix,
+    node,
+    oracle,
+    apiUrl: `http://${node}:${port}`,
+    capabilities: DEFAULT_CAPABILITIES,
+    advertise: true,
+  };
+}
+
+export function encodeSegment(value: string): string {
+  return Buffer.from(value, "utf8").toString("base64url");
+}
+
+export function decodeSegment(value: string): string | null {
+  try {
+    return Buffer.from(value, "base64url").toString("utf8");
+  } catch {
+    return null;
+  }
+}
+
+export function discoveryKey(config: ZenohScoutConfig): string {
+  return [
+    config.keyPrefix,
+    encodeSegment(config.node),
+    encodeSegment(config.oracle),
+    encodeSegment(config.apiUrl),
+    encodeSegment(config.capabilities.join(",")),
+    "alive",
+  ].join("/");
+}
+
+export function parseDiscoveryKey(key: string, keyPrefix = DEFAULT_KEY_PREFIX, now = new Date()): ZenohScoutPeer | null {
+  const prefix = keyPrefix.replace(/\/+$/g, "");
+  if (!key.startsWith(prefix + "/")) return null;
+  const rest = key.slice(prefix.length + 1).split("/");
+  if (rest.length !== 5 || rest[4] !== "alive") return null;
+  const [nodeRaw, oracleRaw, urlRaw, capsRaw] = rest;
+  const node = decodeSegment(nodeRaw ?? "");
+  const oracle = decodeSegment(oracleRaw ?? "");
+  const url = decodeSegment(urlRaw ?? "");
+  const caps = decodeSegment(capsRaw ?? "");
+  if (!node || !oracle || !url) return null;
+  const iso = now.toISOString();
+  return {
+    zid: `zenoh:${hashKey(key).slice(0, 16)}`,
+    node,
+    oracle,
+    host: hostFromUrl(url),
+    locators: [url],
+    capabilities: caps ? caps.split(",").filter(Boolean) : [],
+    oracles: [oracle],
+    firstSeen: iso,
+    lastSeen: iso,
+    seenRel: "now",
+    paired: false,
+    transport: "zenoh",
+  };
+}
+
+export async function runZenohScout(
+  config: ZenohScoutConfig,
+  deps: { importZenoh?: ImportZenoh; now?: () => Date } = {},
+): Promise<ZenohScoutResult> {
+  const importZenoh = deps.importZenoh ?? (() => import("@eclipse-zenoh/zenoh-ts") as Promise<ZenohApi>);
+  const now = deps.now ?? (() => new Date());
+  let session: ZenohSession | null = null;
+  let token: { undeclare(): Promise<void> } | null = null;
+
+  try {
+    const zenoh = await importZenoh();
+    const sessionConfig = new zenoh.Config(config.locator, config.timeoutMs);
+    session = zenoh.Session?.open
+      ? await zenoh.Session.open(sessionConfig)
+      : await zenoh.open!(sessionConfig);
+
+    const liveliness = session.liveliness();
+    if (config.advertise !== false) {
+      token = await liveliness.declareToken(new zenoh.KeyExpr(discoveryKey(config)));
+    }
+
+    const timeout = zenoh.Duration?.milliseconds?.of(config.timeoutMs) ?? config.timeoutMs;
+    const receiver = await liveliness.get(new zenoh.KeyExpr(`${config.keyPrefix}/**`), { timeout });
+    const peers = new Map<string, ZenohScoutPeer>();
+    if (receiver) {
+      for await (const reply of receiver) {
+        const key = keyexprFromReply(reply);
+        if (!key) continue;
+        const peer = parseDiscoveryKey(key, config.keyPrefix, now());
+        if (!peer) continue;
+        if (peer.node === config.node && peer.oracle === config.oracle) continue;
+        peers.set(peer.zid, peer);
+      }
+    }
+
+    const rows = [...peers.values()].sort((a, b) => a.node.localeCompare(b.node) || a.oracle.localeCompare(b.oracle));
+    return {
+      ok: true,
+      enabled: true,
+      locator: config.locator,
+      keyPrefix: config.keyPrefix,
+      total: rows.length,
+      peers: rows,
+    };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      enabled: true,
+      locator: config.locator,
+      keyPrefix: config.keyPrefix,
+      total: 0,
+      peers: [],
+      error: "zenoh_unavailable",
+      hint: `${message} — ${zenohUnavailableHint(message)}`,
+    };
+  } finally {
+    if (token) await token.undeclare().catch(() => {});
+    if (session) await session.close().catch(() => {});
+  }
+}
+
+export function formatZenohScoutResult(result: ZenohScoutResult): string {
+  if (!result.enabled) {
+    return `zenoh-scout disabled\n  locator: ${result.locator}\n  hint: ${result.hint ?? "set zenoh.scout.enabled=true"}`;
+  }
+  if (!result.ok) {
+    return `zenoh-scout unavailable\n  locator: ${result.locator}\n  error: ${result.error ?? "unknown"}\n  hint: ${result.hint ?? "check zenohd remote-api"}`;
+  }
+  if (result.peers.length === 0) {
+    return `no zenoh discoveries\n  locator: ${result.locator}\n  key: ${result.keyPrefix}/**`;
+  }
+  const header = ["zid", "node", "oracle", "host", "caps"];
+  const rows = result.peers.map((p) => [
+    p.zid.replace(/^zenoh:/, "").slice(0, 8) + "…",
+    p.node,
+    p.oracle,
+    p.host,
+    p.capabilities.join(",") || "-",
+  ]);
+  const widths = header.map((h, i) => Math.max(h.length, ...rows.map((r) => r[i]!.length)));
+  const fmt = (cols: string[]) => cols.map((c, i) => c.padEnd(widths[i]!)).join("  ");
+  return [fmt(header), fmt(widths.map((w) => "-".repeat(w))), ...rows.map(fmt)].join("\n");
+}
+
+function keyexprFromReply(reply: unknown): string | null {
+  const maybeResult = typeof (reply as any)?.result === "function" ? (reply as any).result() : reply;
+  const maybeSample = maybeResult && typeof (maybeResult as any).keyexpr === "function" ? maybeResult : null;
+  if (!maybeSample) return null;
+  const keyexpr = (maybeSample as any).keyexpr();
+  if (keyexpr && typeof keyexpr.toString === "function") return keyexpr.toString();
+  return typeof keyexpr === "string" ? keyexpr : null;
+}
+
+function hostFromUrl(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
+}
+
+function hashKey(key: string): string {
+  return createHash("sha1").update(key).digest("hex");
+}
+
+function zenohUnavailableHint(message: string): string {
+  if (/wasm|__wbindgen|WebAssembly/i.test(message)) {
+    return "zenoh-ts failed to initialize in this runtime; keep zenoh-scout opt-in and verify the zenoh-ts/remote-api runtime before enabling";
+  }
+  if (/Cannot find module|Module not found|not found/i.test(message)) {
+    return "install @eclipse-zenoh/zenoh-ts or run a maw build that bundles/externalizes it correctly";
+  }
+  return "start zenohd with the remote-api bridge or pass --locator";
+}

--- a/src/vendor/mpr-plugins/zenoh-scout/index.ts
+++ b/src/vendor/mpr-plugins/zenoh-scout/index.ts
@@ -1,0 +1,118 @@
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import { loadConfig } from "maw-js/config";
+import {
+  formatZenohScoutResult,
+  readZenohScoutConfig,
+  runZenohScout,
+  type ZenohScoutResult,
+} from "./impl";
+
+export const command = {
+  name: "scout",
+  description: "Opt-in Zenoh liveliness discovery provider for maw peers (#1455).",
+};
+
+function emit(ctx: InvokeContext, logs: string[], ...args: unknown[]): void {
+  if (ctx.writer) ctx.writer(...args);
+  else logs.push(args.map(String).join(" "));
+}
+
+function argsObject(ctx: InvokeContext): Record<string, unknown> {
+  return ctx.source === "api" && ctx.args && !Array.isArray(ctx.args)
+    ? ctx.args as Record<string, unknown>
+    : {};
+}
+
+function cliArgs(ctx: InvokeContext): string[] {
+  return ctx.source === "cli" && Array.isArray(ctx.args) ? ctx.args : [];
+}
+
+function hasFlag(args: string[], name: string): boolean {
+  return args.includes(name);
+}
+
+function readOption(args: string[], name: string): string | undefined {
+  const idx = args.indexOf(name);
+  if (idx < 0) return undefined;
+  const value = args[idx + 1];
+  return value && !value.startsWith("--") ? value : undefined;
+}
+
+function boolish(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    const v = value.toLowerCase();
+    if (v === "1" || v === "true" || v === "yes" || v === "on") return true;
+    if (v === "0" || v === "false" || v === "no" || v === "off") return false;
+  }
+  return undefined;
+}
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult & Partial<ZenohScoutResult>> {
+  const logs: string[] = [];
+  const args = cliArgs(ctx);
+  const query = argsObject(ctx);
+
+  try {
+    const config = loadConfig();
+    const base = readZenohScoutConfig(config);
+
+    const locator = readOption(args, "--locator")
+      ?? (typeof query.locator === "string" ? query.locator : undefined)
+      ?? base.locator;
+    const timeoutRaw = readOption(args, "--timeout")
+      ?? (typeof query.timeoutMs === "string" ? query.timeoutMs : undefined)
+      ?? (typeof query.timeout === "string" ? query.timeout : undefined);
+    const timeoutMs = timeoutRaw ? Number(timeoutRaw) : base.timeoutMs;
+    const force = hasFlag(args, "--force") || boolish(query.force) === true;
+    const json = hasFlag(args, "--json") || boolish(query.json) === true;
+    const advertise = hasFlag(args, "--no-advertise")
+      ? false
+      : hasFlag(args, "--advertise")
+        ? true
+        : boolish(query.advertise) ?? true;
+
+    if (hasFlag(args, "--status")) {
+      const result: ZenohScoutResult = {
+        ok: true,
+        enabled: base.enabled,
+        locator,
+        keyPrefix: base.keyPrefix,
+        total: 0,
+        peers: [],
+        hint: base.enabled
+          ? "zenoh-scout enabled; run `maw scout --force` to query now"
+          : "zenoh-scout disabled; set zenoh.scout.enabled=true or pass --force for a one-shot query",
+      };
+      emit(ctx, logs, json ? JSON.stringify(result, null, 2) : formatZenohScoutResult(result));
+      return { ...result, output: logs.join("\n") || undefined };
+    }
+
+    if (!base.enabled && !force) {
+      const result: ZenohScoutResult = {
+        ok: true,
+        enabled: false,
+        locator,
+        keyPrefix: base.keyPrefix,
+        total: 0,
+        peers: [],
+        hint: "zenoh-scout is opt-in; set zenoh.scout.enabled=true or pass --force for a one-shot query",
+      };
+      emit(ctx, logs, json ? JSON.stringify(result, null, 2) : formatZenohScoutResult(result));
+      return { ...result, output: logs.join("\n") || undefined };
+    }
+
+    const result = await runZenohScout({
+      ...base,
+      enabled: true,
+      locator,
+      timeoutMs,
+      advertise,
+    });
+    emit(ctx, logs, json ? JSON.stringify(result, null, 2) : formatZenohScoutResult(result));
+    return { ...result, output: logs.join("\n") || undefined };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: message, output: logs.join("\n") || undefined };
+  }
+}

--- a/src/vendor/mpr-plugins/zenoh-scout/plugin.json
+++ b/src/vendor/mpr-plugins/zenoh-scout/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "zenoh-scout",
+  "version": "0.1.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "tier": "standard",
+  "description": "Opt-in Zenoh liveliness discovery provider for maw peers (#1455).",
+  "author": "Soul-Brews-Studio",
+  "capabilities": [
+    "peer:scout",
+    "net:websocket",
+    "sdk:config"
+  ],
+  "api": {
+    "path": "/api/peers/discovered",
+    "methods": [
+      "GET"
+    ]
+  },
+  "cli": {
+    "command": "scout",
+    "aliases": [
+      "discover",
+      "zenoh-scout"
+    ],
+    "help": "maw scout [--force] [--json] [--locator ws://127.0.0.1:10000] [--timeout <ms>] — query opt-in Zenoh discovery"
+  },
+  "weight": 50,
+  "license": "MIT",
+  "schemaVersion": 1
+}

--- a/test/zenoh-scout-plugin.test.ts
+++ b/test/zenoh-scout-plugin.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "path";
+import { loadManifestFromDir } from "../src/plugin/manifest";
+import { validateConfig } from "../src/config/validate-ext";
+import {
+  discoveryKey,
+  parseDiscoveryKey,
+  readZenohScoutConfig,
+  runZenohScout,
+  type ZenohApi,
+} from "../src/vendor/mpr-plugins/zenoh-scout/impl";
+
+describe("zenoh-scout plugin (#1455)", () => {
+  test("manifest is valid and exposes opt-in cli/api surfaces", () => {
+    const loaded = loadManifestFromDir(join(import.meta.dir, "../src/vendor/mpr-plugins/zenoh-scout"));
+    expect(loaded?.manifest.name).toBe("zenoh-scout");
+    expect(loaded?.manifest.cli?.command).toBe("scout");
+    expect(loaded?.manifest.cli?.aliases).toContain("zenoh-scout");
+    expect(loaded?.manifest.api?.path).toBe("/api/peers/discovered");
+    expect(loaded?.manifest.capabilities).toEqual(expect.arrayContaining(["peer:scout", "net:websocket"]));
+  });
+
+  test("config validator preserves nested zenoh.scout options", () => {
+    const cfg = validateConfig({
+      node: "m5",
+      oracle: "mawjs",
+      zenoh: {
+        locator: "ws://router:10000",
+        scout: {
+          enabled: true,
+          locator: "ws://scout:10000",
+          timeoutMs: 1234,
+          keyPrefix: "maw/test/v1",
+        },
+      },
+    });
+
+    expect(cfg.zenoh?.locator).toBe("ws://router:10000");
+    expect(cfg.zenoh?.scout?.enabled).toBe(true);
+    expect(cfg.zenoh?.scout?.locator).toBe("ws://scout:10000");
+    expect(cfg.zenoh?.scout?.timeoutMs).toBe(1234);
+    expect(cfg.zenoh?.scout?.keyPrefix).toBe("maw/test/v1");
+  });
+
+  test("discovery keys round-trip into maw peer discovery rows", () => {
+    const cfg = readZenohScoutConfig({
+      node: "m5",
+      oracle: "mawjs",
+      port: 3456,
+      zenoh: { scout: { enabled: true, keyPrefix: "maw/test/v1" } },
+    });
+    const key = discoveryKey(cfg);
+    const row = parseDiscoveryKey(key, "maw/test/v1", new Date("2026-05-15T00:00:00.000Z"));
+
+    expect(row).toMatchObject({
+      node: "m5",
+      oracle: "mawjs",
+      host: "m5:3456",
+      locators: ["http://m5:3456"],
+      capabilities: ["pair", "feed", "send"],
+      firstSeen: "2026-05-15T00:00:00.000Z",
+      transport: "zenoh",
+    });
+    expect(row?.zid).toStartWith("zenoh:");
+  });
+
+  test("queries zenoh liveliness via injectable zenoh-ts API and skips self", async () => {
+    const local = readZenohScoutConfig({ node: "m5", oracle: "mawjs", port: 3456, zenoh: { scout: { enabled: true } } });
+    const remote = readZenohScoutConfig({ node: "white", oracle: "pulse", port: 4567, zenoh: { scout: { enabled: true } } });
+    const remoteKey = discoveryKey(remote);
+    const localKey = discoveryKey(local);
+    const calls: string[] = [];
+
+    class FakeConfig {
+      constructor(public locator: string, public timeoutMs?: number) {}
+    }
+    class FakeKeyExpr {
+      constructor(public key: string) {}
+      toString() { return this.key; }
+    }
+
+    const fakeSession = {
+      liveliness() {
+        return {
+          async declareToken(key: FakeKeyExpr) {
+            calls.push(`declare:${key}`);
+            return { async undeclare() { calls.push("undeclare"); } };
+          },
+          async get(key: FakeKeyExpr) {
+            calls.push(`get:${key}`);
+            return (async function* () {
+              yield { result: () => ({ keyexpr: () => ({ toString: () => remoteKey }) }) };
+              yield { result: () => ({ keyexpr: () => ({ toString: () => localKey }) }) };
+            })();
+          },
+        };
+      },
+      async close() { calls.push("close"); },
+    };
+
+    const fakeZenoh: ZenohApi = {
+      Config: FakeConfig,
+      KeyExpr: FakeKeyExpr,
+      Session: { open: async () => fakeSession },
+      Duration: { milliseconds: { of: (ms: number) => ms } },
+    };
+
+    const result = await runZenohScout(local, {
+      importZenoh: async () => fakeZenoh,
+      now: () => new Date("2026-05-15T00:00:00.000Z"),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.total).toBe(1);
+    expect(result.peers[0]).toMatchObject({
+      node: "white",
+      oracle: "pulse",
+      locators: ["http://white:4567"],
+      transport: "zenoh",
+    });
+    expect(calls).toEqual([
+      `declare:${localKey}`,
+      "get:maw/discovery/v1/**",
+      "undeclare",
+      "close",
+    ]);
+  });
+
+  test("missing zenoh bridge is reported as actionable unavailability", async () => {
+    const cfg = readZenohScoutConfig({ node: "m5", oracle: "mawjs", zenoh: { scout: { enabled: true } } });
+    const result = await runZenohScout(cfg, {
+      importZenoh: async () => {
+        throw new Error("Cannot connect to remote API");
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("zenoh_unavailable");
+    expect(result.hint).toContain("start zenohd");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds vendored `zenoh-scout` plugin as an **opt-in** discovery provider for #1455.
- Exposes CLI `maw scout` / `maw discover` / `maw zenoh-scout` and API `GET /api/peers/discovered`.
- Extends `zenoh.scout` config shape: `enabled`, `locator`, `timeoutMs`, `keyPrefix`.
- Uses Zenoh liveliness metadata keys to build maw-style discovery rows while leaving existing Scout + HTTP fallback untouched.
- Fails closed with actionable diagnostics when `zenoh-ts` / remote-api runtime is unavailable.

## Important scope note

This intentionally does **not** promote Zenoh to core/default transport and does **not** delete `src/transports/scout*.ts`. Local smoke confirms why: `@eclipse-zenoh/zenoh-ts` currently fails to initialize in this Bun runtime with `wasm.__wbindgen_start is not a function`, so the plugin remains opt-in and diagnostic-first until live remote-api fleet smoke proves the lifecycle.

#1494 is related but separate: this PR only discovers peers. The mutual pubkey/proof/retry pairing work should strengthen `/api/pair/auto` before any Zenoh-discovered peer is auto-accepted by default.

Refs #1455 for the opt-in POC scaffold; leaves #1455/#1436 default/deletion decisions blocked on real Zenoh lifecycle proof.

## Tests

- `bun test test/zenoh-scout-plugin.test.ts src/cli/plugin-bootstrap.test.ts`
- `bun run test:plugin`
- `bun run build`
- Source CLI smoke:
  - `MAW_PLUGINS_DIR=$(mktemp -d)/plugins bun src/cli.ts scout --status --json`
  - `MAW_PLUGINS_DIR=$(mktemp -d)/plugins bun src/cli.ts scout --force` → fail-closed diagnostic for current `zenoh-ts` wasm init issue

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
