### PR TITLE
release: v26.5.16-alpha.2338

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.16-alpha.2307",
+  "version": "26.5.16-alpha.2338",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts v26.5.16-alpha.2338 from the alpha branch after #1495 merged.

Includes:
- #1495 opt-in `zenoh-scout` plugin POC for #1455.
- Correct alpha-only lane: package bump targets `alpha`, not `main`.

On merge, `calver-release.yml` should create tag/release `v26.5.16-alpha.2338` and attach `dist/maw`.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
