### PR TITLE
feat(pair): strengthen scout auto-pair identity continuity

### DIFF
--- a/src/api/pair.ts
+++ b/src/api/pair.ts
@@ -12,13 +12,18 @@ import { randomBytes } from "crypto";
 import { loadConfig } from "../config";
 import { register, lookup, consume, isValidShape, normalize, pretty, generateCode } from "../lib/pair-codes";
 import { cmdAdd } from "../lib/peers/impl";
+import { getPeerKey } from "../lib/peer-key";
+import { signAutoPairProof, type AutoPairIdentity } from "../transports/scout-pair-proof";
 
 export const pairApi = new Elysia();
 
 const DEFAULT_TTL_MS = 120_000;
 const results = new Map<string, { consumedAt: number; remoteNode: string; remoteUrl: string }>();
 
-const me = () => { const c = loadConfig(); return { node: c.node ?? "local", port: c.port ?? 3456 }; };
+const me = () => {
+  const c = loadConfig();
+  return { node: c.node ?? "local", oracle: c.oracle ?? "mawjs", port: c.port ?? 3456 };
+};
 
 pairApi.post("/pair/generate", ({ body, set }) => {
   const b = (body ?? {}) as { ttlMs?: number; expires?: number };
@@ -79,7 +84,7 @@ export function recordHelloZid(zid: string): void {
 }
 
 pairApi.post("/pair/auto", async ({ body, set }) => {
-  const b = (body ?? {}) as { node?: string; oracle?: string; url?: string; zid?: string; capabilities?: string[] };
+  const b = (body ?? {}) as { node?: string; oracle?: string; url?: string; zid?: string; pubkey?: string; capabilities?: string[] };
 
   if (!b.node || !b.url || !b.zid) {
     set.status = 400;
@@ -94,16 +99,47 @@ pairApi.post("/pair/auto", async ({ body, set }) => {
   }
 
   const id = me();
+  let oneWay: boolean | undefined;
   try {
-    await cmdAdd({ alias: b.node, url: b.url, node: b.node });
-  } catch {}
+    const addResult = await cmdAdd({
+      alias: b.node,
+      url: b.url,
+      node: b.node,
+      pubkey: typeof b.pubkey === "string" && b.pubkey.length > 0 ? b.pubkey : undefined,
+      identity: b.oracle ? { oracle: b.oracle, node: b.node } : undefined,
+      markSymmetricCheck: true,
+    });
+    if (addResult.pubkeyMismatch) {
+      set.status = 409;
+      return { ok: false, error: addResult.pubkeyMismatch.message };
+    }
+    oneWay = addResult.peer.oneWay;
+  } catch (err) {
+    set.status = 400;
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
 
   recentHellos.delete(b.zid);
+  const config = loadConfig();
+  const pubkey = getPeerKey();
+  const url = `http://localhost:${id.port}`;
+  const identity: AutoPairIdentity = {
+    node: id.node,
+    oracle: id.oracle,
+    url,
+    pubkey,
+  };
+  const proof = config.federationToken
+    ? signAutoPairProof(identity, config.federationToken)
+    : undefined;
 
   return {
     ok: true,
     node: id.node,
-    oracle: "mawjs",
-    url: `http://localhost:${id.port}`,
+    oracle: id.oracle,
+    url,
+    pubkey,
+    proof,
+    oneWay,
   };
 });

--- a/src/lib/peers/impl.ts
+++ b/src/lib/peers/impl.ts
@@ -47,6 +47,14 @@ export interface AddOptions {
   alias: string;
   url: string;
   node?: string;
+  /** Peer pubkey supplied by an authenticated higher-level handshake. */
+  pubkey?: string;
+  /** Peer identity supplied by an authenticated higher-level handshake. */
+  identity?: { oracle: string; node: string };
+  /** Stamp pair-symmetry fields while adding/updating the peer (#1494). */
+  markSymmetricCheck?: boolean;
+  /** Explicit symmetry result from the responder; defaults to probe failure. */
+  oneWay?: boolean;
 }
 
 export interface AddResult {
@@ -69,6 +77,7 @@ export async function cmdAdd(opts: AddOptions): Promise<AddResult> {
   // we still probe to surface errors, but the user-supplied node wins.
   const probe = await probePeer(opts.url);
   const resolvedNode = opts.node ?? probe.node ?? null;
+  const observedPubkey = opts.pubkey ?? probe.pubkey;
 
   // TOFU evaluation against any pre-existing cache entry for this alias.
   // Decided BEFORE we overwrite so a re-`add` of the same alias against a
@@ -76,7 +85,25 @@ export async function cmdAdd(opts: AddOptions): Promise<AddResult> {
   // `maw peers forget` first). Bootstrap path stamps the pubkey on the
   // freshly-written entry, so we evaluate now but apply after the write.
   const existingForTofu = loadPeers().peers[opts.alias];
-  const tofuDecision = evaluatePeerIdentity(opts.alias, existingForTofu, probe.pubkey);
+  if (opts.pubkey && probe.pubkey && opts.pubkey !== probe.pubkey) {
+    return {
+      alias: opts.alias,
+      overwrote: Boolean(existingForTofu),
+      peer: existingForTofu ?? {
+        url: opts.url,
+        node: resolvedNode,
+        addedAt: new Date().toISOString(),
+        lastSeen: null,
+      },
+      probeError: probe.error,
+      pubkeyMismatch: new PeerPubkeyMismatchError(
+        opts.alias,
+        opts.pubkey,
+        probe.pubkey,
+      ),
+    };
+  }
+  const tofuDecision = evaluatePeerIdentity(opts.alias, existingForTofu, observedPubkey);
   if (tofuDecision.kind === "mismatch") {
     return {
       alias: opts.alias,
@@ -91,11 +118,12 @@ export async function cmdAdd(opts: AddOptions): Promise<AddResult> {
     };
   }
 
+  const now = new Date().toISOString();
   const peer: Peer = {
     url: opts.url,
     node: resolvedNode,
-    addedAt: new Date().toISOString(),
-    lastSeen: probe.error ? null : new Date().toISOString(),
+    addedAt: now,
+    lastSeen: probe.error ? null : now,
   };
   if (probe.error) peer.lastError = probe.error;
   if (probe.nickname) peer.nickname = probe.nickname;
@@ -114,8 +142,17 @@ export async function cmdAdd(opts: AddOptions): Promise<AddResult> {
   // re-add doesn't lose what we already know about this peer.
   if (probe.identity) {
     peer.identity = probe.identity;
+  } else if (opts.identity) {
+    peer.identity = opts.identity;
   } else if (existingForTofu?.identity) {
     peer.identity = existingForTofu.identity;
+  }
+  if (opts.markSymmetricCheck) {
+    peer.lastSymmetricCheck = now;
+    peer.oneWay = opts.oneWay ?? Boolean(probe.error);
+  } else if (existingForTofu?.lastSymmetricCheck) {
+    peer.lastSymmetricCheck = existingForTofu.lastSymmetricCheck;
+    if (existingForTofu.oneWay !== undefined) peer.oneWay = existingForTofu.oneWay;
   }
 
   let existed = false;

--- a/src/lib/peers/store.ts
+++ b/src/lib/peers/store.ts
@@ -10,7 +10,7 @@
  * Schema v1:
  *   { version: 1, peers: { <alias>: { url, node, addedAt, lastSeen,
  *                                     [lastError, nickname, pubkey, pubkeyFirstSeen,
- *                                      identity] } } }
+ *                                      identity, oneWay, lastSymmetricCheck] } } }
  *   — fields in brackets are optional. `pubkey` / `pubkeyFirstSeen` were
  *   added in #804 Step 2 for TOFU peer-identity pinning. `identity` was
  *   added in #804 Step 3 to capture the peer's self-reported `<oracle>:<node>`
@@ -84,6 +84,17 @@ export interface Peer {
    * Doctor + boot-warn skip undefined identity (no false-positive collision).
    */
   identity?: { oracle: string; node: string };
+  /**
+   * Pair-symmetry marker (#1494).
+   *
+   * `true` means the last auto-pair handshake could write this peer locally
+   * but the reciprocal reachability/probe was not proven. `false` means the
+   * last pair-time symmetric check completed. Undefined means no pair-time
+   * check has been recorded for this legacy entry.
+   */
+  oneWay?: boolean;
+  /** ISO timestamp for the last pair-time symmetric reachability check. */
+  lastSymmetricCheck?: string;
 }
 
 export interface PeersFile {

--- a/src/transports/scout-pair-proof.ts
+++ b/src/transports/scout-pair-proof.ts
@@ -1,0 +1,37 @@
+import { createHmac, timingSafeEqual } from "crypto";
+
+export interface AutoPairIdentity {
+  node: string;
+  oracle: string;
+  url: string;
+  pubkey: string;
+}
+
+function canonicalAutoPairIdentity(identity: AutoPairIdentity): string {
+  return [
+    identity.oracle,
+    identity.node,
+    identity.url,
+    identity.pubkey,
+  ].join("\n");
+}
+
+export function signAutoPairProof(identity: AutoPairIdentity, federationToken: string): string {
+  return createHmac("sha256", federationToken)
+    .update(canonicalAutoPairIdentity(identity))
+    .digest("hex");
+}
+
+export function verifyAutoPairProof(
+  identity: AutoPairIdentity,
+  federationToken: string,
+  proof: string,
+): boolean {
+  const expected = signAutoPairProof(identity, federationToken);
+  if (expected.length !== proof.length) return false;
+  try {
+    return timingSafeEqual(Buffer.from(expected, "hex"), Buffer.from(proof, "hex"));
+  } catch {
+    return false;
+  }
+}

--- a/src/transports/scout-pair.ts
+++ b/src/transports/scout-pair.ts
@@ -6,13 +6,17 @@
  */
 
 import { cmdAdd } from "../lib/peers/impl";
+import { getPeerKey } from "../lib/peer-key";
+import { loadConfig } from "../config";
 import type { DiscoveredPeer } from "./scout-state";
+import { verifyAutoPairProof } from "./scout-pair-proof";
 
 export interface AutoPairRequest {
   node: string;
   oracle: string;
   url: string;
   zid: string;
+  pubkey?: string;
   capabilities: string[];
 }
 
@@ -21,50 +25,105 @@ export interface AutoPairResponse {
   node?: string;
   oracle?: string;
   url?: string;
+  pubkey?: string;
+  proof?: string;
+  oneWay?: boolean;
   error?: string;
 }
+
+export interface InitiatePairDeps {
+  fetchFn?: typeof fetch;
+  sleep?: (ms: number) => Promise<void>;
+  cmdAddFn?: typeof cmdAdd;
+  getPeerKeyFn?: typeof getPeerKey;
+  loadConfigFn?: typeof loadConfig;
+}
+
+const AUTO_PAIR_PATH = "/api/pair/auto";
+const PAIR_POST_TIMEOUT_MS = 2_000;
+const PAIR_RETRY_DELAYS_MS = [0, 200, 800] as const;
+
+const sleepDefault = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 export async function initiatePair(
   peer: DiscoveredPeer,
   localNode: string,
   localOracle: string,
   localPort: number,
+  deps: InitiatePairDeps = {},
 ): Promise<{ ok: boolean; error?: string }> {
   const locator = peer.locators[0];
   if (!locator) return { ok: false, error: "no_locator" };
+  const fetchFn = deps.fetchFn ?? fetch;
+  const sleep = deps.sleep ?? sleepDefault;
+  const addPeer = deps.cmdAddFn ?? cmdAdd;
+  const peerKey = (deps.getPeerKeyFn ?? getPeerKey)();
+  const config = (deps.loadConfigFn ?? loadConfig)();
 
   const body: AutoPairRequest = {
     node: localNode,
     oracle: localOracle,
     url: `http://${localNode}:${localPort}`,
     zid: peer.zid,
+    pubkey: peerKey,
     capabilities: ["pair", "feed", "send"],
   };
+  const bodyJson = JSON.stringify(body);
 
-  try {
-    const res = await fetch(`${locator}/api/pair/auto`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-      signal: AbortSignal.timeout(5000),
-    });
+  let lastError = "pair_failed";
+  for (const [attempt, delayMs] of PAIR_RETRY_DELAYS_MS.entries()) {
+    if (delayMs > 0) await sleep(delayMs);
 
-    if (!res.ok) {
-      const text = await res.text().catch(() => "");
-      return { ok: false, error: `http_${res.status}: ${text}` };
+    try {
+      const res = await fetchFn(new URL(AUTO_PAIR_PATH, locator), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: bodyJson,
+        signal: AbortSignal.timeout(PAIR_POST_TIMEOUT_MS),
+      });
+
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        lastError = `http_${res.status}: ${text}`;
+        if (res.status >= 400 && res.status < 500) return { ok: false, error: lastError };
+        continue;
+      }
+
+      const data = (await res.json()) as AutoPairResponse;
+      if (!data.ok) {
+        lastError = data.error ?? "rejected";
+        return { ok: false, error: lastError };
+      }
+
+      if (data.proof && data.pubkey && config.federationToken) {
+        const valid = verifyAutoPairProof({
+          node: data.node ?? peer.node,
+          oracle: data.oracle ?? "mawjs",
+          url: data.url ?? locator,
+          pubkey: data.pubkey,
+        }, config.federationToken, data.proof);
+        if (!valid) return { ok: false, error: "bad_proof" };
+      } else if (data.proof && (!data.pubkey || !config.federationToken)) {
+        return { ok: false, error: "bad_proof_payload" };
+      }
+
+      const addResult = await addPeer({
+        alias: peer.node,
+        url: locator,
+        node: peer.node,
+        pubkey: data.pubkey,
+        identity: data.node ? { oracle: data.oracle ?? "mawjs", node: data.node } : undefined,
+        markSymmetricCheck: true,
+        oneWay: data.oneWay,
+      });
+      if (addResult.pubkeyMismatch) return { ok: false, error: addResult.pubkeyMismatch.message };
+
+      return { ok: true };
+    } catch (err) {
+      lastError = err instanceof Error ? err.message : String(err);
+      if (attempt === PAIR_RETRY_DELAYS_MS.length - 1) break;
     }
-
-    const data = (await res.json()) as AutoPairResponse;
-    if (!data.ok) return { ok: false, error: data.error ?? "rejected" };
-
-    await cmdAdd({
-      alias: peer.node,
-      url: locator,
-      node: peer.node,
-    });
-
-    return { ok: true };
-  } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : String(err) };
   }
+
+  return { ok: false, error: lastError };
 }

--- a/test/isolated/auto-pair-mutual.test.ts
+++ b/test/isolated/auto-pair-mutual.test.ts
@@ -1,0 +1,206 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { Elysia } from "elysia";
+
+const TEST_HOME = mkdtempSync(join(tmpdir(), "maw-auto-pair-1494-"));
+const TOKEN = "0123456789abcdef-auto-pair-token";
+const ALICE_PUBKEY = "a".repeat(64);
+
+process.env.MAW_HOME = TEST_HOME;
+process.env.PEERS_FILE = join(TEST_HOME, "peers.json");
+process.env.MAW_TEST_MODE = "1";
+delete process.env.MAW_PEER_KEY;
+
+mkdirSync(join(TEST_HOME, "config", "fleet"), { recursive: true });
+writeFileSync(
+  join(TEST_HOME, "config", "maw.config.json"),
+  JSON.stringify({
+    node: "bob",
+    oracle: "mawjs",
+    port: 3456,
+    federationToken: TOKEN,
+  }, null, 2),
+);
+
+const { pairApi, recordHelloZid } = await import("../../src/api/pair");
+const { verifyAutoPairProof } = await import("../../src/transports/scout-pair-proof");
+const { initiatePair } = await import("../../src/transports/scout-pair");
+
+const app = new Elysia().use(pairApi);
+
+afterAll(() => {
+  rmSync(TEST_HOME, { recursive: true, force: true });
+  delete process.env.MAW_HOME;
+  delete process.env.PEERS_FILE;
+});
+
+describe("Scout auto-pair mutual pubkey/proof (#1494)", () => {
+  test("responder pins request pubkey and signs its identity response", async () => {
+    recordHelloZid("zid-mutual");
+
+    const res = await app.handle(new Request("http://local/pair/auto", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        node: "alice",
+        oracle: "mawjs",
+        url: "http://127.0.0.1:1",
+        zid: "zid-mutual",
+        pubkey: ALICE_PUBKEY,
+        capabilities: ["pair"],
+      }),
+    }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as {
+      ok: boolean;
+      node: string;
+      oracle: string;
+      url: string;
+      pubkey: string;
+      proof: string;
+      oneWay: boolean;
+    };
+    expect(body.ok).toBe(true);
+    expect(body.node).toBe("bob");
+    expect(body.oracle).toBe("mawjs");
+    expect(body.pubkey).toMatch(/^[0-9a-f]{64}$/);
+    expect(verifyAutoPairProof({
+      node: body.node,
+      oracle: body.oracle,
+      url: body.url,
+      pubkey: body.pubkey,
+    }, TOKEN, body.proof)).toBe(true);
+
+    const peers = JSON.parse(readFileSync(process.env.PEERS_FILE!, "utf-8"));
+    expect(peers.peers.alice.pubkey).toBe(ALICE_PUBKEY);
+    expect(peers.peers.alice.identity).toEqual({ oracle: "mawjs", node: "alice" });
+    expect(peers.peers.alice.oneWay).toBe(true);
+    expect(typeof peers.peers.alice.lastSymmetricCheck).toBe("string");
+  });
+
+  test("initiator retries transient POST failure and writes responder pubkey", async () => {
+    const calls: Array<RequestInfo | URL> = [];
+    const addCalls: unknown[] = [];
+    const responderPubkey = "b".repeat(64);
+    const proof = verifyAutoPairProof;
+    const { signAutoPairProof } = await import("../../src/transports/scout-pair-proof");
+    const response = {
+      ok: true,
+      node: "bob",
+      oracle: "mawjs",
+      url: "http://bob:3456",
+      pubkey: responderPubkey,
+      proof: signAutoPairProof({
+        node: "bob",
+        oracle: "mawjs",
+        url: "http://bob:3456",
+        pubkey: responderPubkey,
+      }, TOKEN),
+      oneWay: false,
+    };
+
+    const result = await initiatePair(
+      {
+        node: "bob",
+        zid: "zid-retry",
+        host: "bob",
+        oracle: "mawjs",
+        locators: ["http://bob:3456"],
+        capabilities: ["pair"],
+        oracles: ["mawjs"],
+        lastSeen: Date.now(),
+        paired: false,
+      },
+      "alice",
+      "mawjs",
+      3456,
+      {
+        fetchFn: (async (input: RequestInfo | URL) => {
+          calls.push(input);
+          if (calls.length === 1) throw new Error("temporary timeout");
+          return new Response(JSON.stringify(response), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }) as typeof fetch,
+        sleep: async () => {},
+        cmdAddFn: (async (opts) => {
+          addCalls.push(opts);
+          return {
+            alias: opts.alias,
+            overwrote: false,
+            peer: {
+              url: opts.url,
+              node: opts.node ?? null,
+              addedAt: new Date().toISOString(),
+              lastSeen: new Date().toISOString(),
+            },
+          };
+        }) as typeof import("../../src/lib/peers/impl").cmdAdd,
+        getPeerKeyFn: () => ALICE_PUBKEY,
+        loadConfigFn: () => ({ federationToken: TOKEN } as any),
+      },
+    );
+
+    expect(proof({
+      node: response.node,
+      oracle: response.oracle,
+      url: response.url,
+      pubkey: response.pubkey,
+    }, TOKEN, response.proof)).toBe(true);
+    expect(result).toEqual({ ok: true });
+    expect(calls.length).toBe(2);
+    expect(addCalls[0]).toMatchObject({
+      alias: "bob",
+      url: "http://bob:3456",
+      node: "bob",
+      pubkey: responderPubkey,
+      identity: { oracle: "mawjs", node: "bob" },
+      markSymmetricCheck: true,
+      oneWay: false,
+    });
+  });
+
+  test("initiator rejects bad proof and does not write peers.json", async () => {
+    let addCalled = false;
+    const result = await initiatePair(
+      {
+        node: "mallory",
+        zid: "zid-proof",
+        host: "mallory",
+        oracle: "mawjs",
+        locators: ["http://mallory:3456"],
+        capabilities: ["pair"],
+        oracles: ["mawjs"],
+        lastSeen: Date.now(),
+        paired: false,
+      },
+      "alice",
+      "mawjs",
+      3456,
+      {
+        fetchFn: (async () => new Response(JSON.stringify({
+          ok: true,
+          node: "mallory",
+          oracle: "mawjs",
+          url: "http://mallory:3456",
+          pubkey: "c".repeat(64),
+          proof: "0".repeat(64),
+        }), { status: 200 })) as typeof fetch,
+        sleep: async () => {},
+        cmdAddFn: (async () => {
+          addCalled = true;
+          throw new Error("should not write");
+        }) as typeof import("../../src/lib/peers/impl").cmdAdd,
+        getPeerKeyFn: () => ALICE_PUBKEY,
+        loadConfigFn: () => ({ federationToken: TOKEN } as any),
+      },
+    );
+
+    expect(result).toEqual({ ok: false, error: "bad_proof" });
+    expect(addCalled).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add pubkey exchange to Scout auto-pair requests/responses
- sign responder identity proofs when federationToken is configured and reject bad proofs
- retry transient pair POST failures and record pair-symmetry markers in peers.json
- add isolated #1494 regression coverage

## Verification
- `bun test test/isolated/auto-pair-mutual.test.ts --path-ignore-patterns '**/agents/**'`
- `bun test src/transports/scout-protocol.test.ts src/transports/scout-state.test.ts --path-ignore-patterns '**/agents/**'`
- `bun test test/isolated/peers.test.ts --path-ignore-patterns '**/agents/**'`
- `bun test test/isolated/peer-key-persist.test.ts --path-ignore-patterns '**/agents/**'`
- `bun test test/isolated/api-identity-fields.test.ts --path-ignore-patterns '**/agents/**'`
- `bun test src/transports/scout-integration.test.ts test/federation-auth.test.ts test/federation-symmetric.test.ts --path-ignore-patterns '**/agents/**'`
- `bun run build`

Closes #1494

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
