### PR TITLE
Fix default-active plugin profile drift

### DIFF
--- a/src/cli/dispatch-match.ts
+++ b/src/cli/dispatch-match.ts
@@ -28,6 +28,10 @@ export type DispatchMatch =
   | { kind: "ambiguous"; candidates: Array<{ plugin: string; name: string }> }
   | { kind: "none" };
 
+export interface ResolvePluginMatchOptions {
+  includeDisabled?: boolean;
+}
+
 /**
  * #899: a plugin is CLI-dispatchable if it has either a JS/TS entry or a
  * WASM module. Pure-API / pure-hooks / pure-cron plugins (no entry, no wasm,
@@ -61,6 +65,7 @@ export function pluginCliNames(p: LoadedPlugin): { command: string; aliases: str
 export function resolvePluginMatch(
   plugins: LoadedPlugin[],
   cmdName: string,
+  options: ResolvePluginMatchOptions = {},
 ): DispatchMatch {
   type Hit = { plugin: LoadedPlugin; matchedName: string };
   const exactCommand: Hit[] = [];
@@ -68,6 +73,7 @@ export function resolvePluginMatch(
   const prefixCommand: Hit[] = [];
   const prefixAlias: Hit[] = [];
   for (const p of plugins) {
+    if (p.disabled && !options.includeDisabled) continue;
     const cliNames = pluginCliNames(p);
     if (!cliNames) continue;
 

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -83,6 +83,24 @@ async function dispatchPluginRegistry(cmd: string, args: string[]): Promise<void
     process.exit(0);
   }
 
+  const disabledDispatch = resolvePluginMatch(
+    plugins.filter(p => p.disabled),
+    cmdName,
+    { includeDisabled: true },
+  );
+  if (disabledDispatch.kind === "match") {
+    const pluginName = disabledDispatch.plugin.manifest.name;
+    console.error(`\x1b[31m✗\x1b[0m '${args[0]}' is installed but disabled.`);
+    console.error(`  Run: maw plugin enable ${pluginName}`);
+    throw new UserError(`disabled command: ${args[0]}`);
+  }
+  if (disabledDispatch.kind === "ambiguous") {
+    console.error(`\x1b[31m✗\x1b[0m '${args[0]}' matches disabled plugins.`);
+    console.error(`  candidates: ${disabledDispatch.candidates.map(c => c.plugin).join(", ")}`);
+    console.error(`  Run: maw plugin enable <name>`);
+    throw new UserError(`disabled command: ${args[0]}`);
+  }
+
   // #388.2 — unknown command: fuzzy-suggest against the plugin registry.
   // Only intercepts when cmd is NOT a known route/plugin/alias AND does
   // NOT strictly match an oracle session name. Preserves `maw mawjs`

--- a/src/commands/plugins/fleet/plugin.json
+++ b/src/commands/plugins/fleet/plugin.json
@@ -9,5 +9,6 @@
     "command": "fleet",
     "help": "maw fleet <init|ls|renumber|validate|health|doctor|consolidate|sync|sync-windows|snapshots|restore|snapshot> [args]"
   },
-  "weight": 10
+  "weight": 10,
+  "tier": "standard"
 }

--- a/src/commands/plugins/plugin/plugin.json
+++ b/src/commands/plugins/plugin/plugin.json
@@ -9,5 +9,6 @@
     "command": "plugin",
     "help": "maw plugin <init|build|dev|install> [args]"
   },
-  "weight": 10
+  "weight": 10,
+  "tier": "standard"
 }

--- a/src/commands/plugins/tmux/plugin.json
+++ b/src/commands/plugins/tmux/plugin.json
@@ -9,5 +9,6 @@
     "command": "tmux",
     "help": "maw tmux <peek> — peek a pane by id (%N), session:w.p, or team-agent name"
   },
-  "weight": 10
+  "weight": 10,
+  "tier": "standard"
 }

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -8,6 +8,10 @@ import type { MawConfig } from "./types";
 import { D } from "./types";
 import { validateConfig } from "./validate-ext";
 import { loadFleetAgents } from "./fleet-merge";
+import {
+  DEFAULT_ACTIVE_PLUGINS_1500_MIGRATION,
+  isDefaultActivePlugin,
+} from "../plugin/default-active";
 
 // #680 — ghqRoot is no longer resolved at config-load time. Callers that need
 // a filesystem path go through `getGhqRoot()` (src/config/ghq-root.ts), which
@@ -37,6 +41,43 @@ const BIND_ADDRESSES = new Set(["0.0.0.0", "::", "", "127.0.0.1", "localhost"]);
  * harness forgot to set MAW_HOME / MAW_CONFIG_DIR.
  */
 const REAL_HOME_CONFIG = join(homedir(), ".config", "maw", "maw.config.json");
+
+function canPersistConfigMigration(): boolean {
+  return !(process.env.MAW_TEST_MODE === "1" && CONFIG_FILE === REAL_HOME_CONFIG);
+}
+
+function persistLoadedConfig(label: string): void {
+  if (!cached) return;
+  if (!canPersistConfigMigration()) return;
+  try {
+    writeFileSync(CONFIG_FILE, JSON.stringify(cached, null, 2) + "\n", "utf-8");
+  } catch (e) {
+    process.stderr.write(
+      `[maw] ${label}: in-memory heal applied but disk persist failed: ` +
+      `${e instanceof Error ? e.message : String(e)}\n`,
+    );
+  }
+}
+
+function maybeMigrateDefaultActivePlugins(config: MawConfig): void {
+  const marker = DEFAULT_ACTIVE_PLUGINS_1500_MIGRATION;
+  if (config.migrations?.[marker]) return;
+  const disabled = config.disabledPlugins ?? [];
+  if (disabled.length < 20) return;
+
+  const promoted = disabled.filter(isDefaultActivePlugin);
+  // Guard against overriding a small manual disable list. The old profile bug
+  // produced a large list containing most default-active names.
+  if (promoted.length < 5) return;
+
+  config.disabledPlugins = disabled.filter((name) => !isDefaultActivePlugin(name));
+  config.migrations = { ...(config.migrations ?? {}), [marker]: true };
+  process.stderr.write(
+    `[maw] config.disabledPlugins migration (#1500): re-enabled default-active plugins ` +
+    `${promoted.join(", ")}. Disable them again with \`maw plugin disable <name>\` if intentional.\n`,
+  );
+  persistLoadedConfig("config.disabledPlugins migration (#1500)");
+}
 
 export function loadConfig(): MawConfig {
   if (cached) return cached;
@@ -107,20 +148,9 @@ export function loadConfig(): MawConfig {
     // forgot to sandbox MAW_HOME (mirrors the #820 saveConfig guard).
     // Tests that DO sandbox via MAW_HOME=<tmpdir> still get the persist
     // (which is exactly what we want — they verify the disk write).
-    if (!(process.env.MAW_TEST_MODE === "1" && CONFIG_FILE === REAL_HOME_CONFIG)) {
-      try {
-        writeFileSync(CONFIG_FILE, JSON.stringify(cached, null, 2) + "\n", "utf-8");
-      } catch (e) {
-        // Defensive — a persist failure (read-only FS, perms) must NOT
-        // break loadConfig. The in-memory heal still applies for this
-        // process; the warning will fire again next boot.
-        process.stderr.write(
-          `[maw] config.host migration: in-memory heal applied but disk persist failed: ` +
-          `${e instanceof Error ? e.message : String(e)}\n`,
-        );
-      }
-    }
+    persistLoadedConfig("config.host migration");
   }
+  maybeMigrateDefaultActivePlugins(cached);
   // #736 Phase 1.1 — pre-populate config.agents from fleet at loadConfig time
   // so federation routing (`maw hey <oracle>`) sees fleet-known targets even
   // before their first wake. Additive only: hand-tuned config.agents entries

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -167,6 +167,8 @@ export interface MawConfig {
   pluginSources?: string[];
   /** Plugin names to disable (skip during scanning and execution) */
   disabledPlugins?: string[];
+  /** One-shot config migrations already applied. */
+  migrations?: Record<string, boolean>;
 }
 
 /** Typed defaults for intervals, timeouts, limits (#172) */

--- a/src/config/validate-ext.ts
+++ b/src/config/validate-ext.ts
@@ -107,6 +107,19 @@ function validateExtFields(
     }
   }
 
+  // migrations: one-shot migration markers
+  if ("migrations" in raw) {
+    if (raw.migrations && typeof raw.migrations === "object" && !Array.isArray(raw.migrations)) {
+      const migrations: Record<string, boolean> = {};
+      for (const [k, v] of Object.entries(raw.migrations as Record<string, unknown>)) {
+        if (typeof v === "boolean") migrations[k] = v;
+      }
+      result.migrations = migrations;
+    } else {
+      warn("migrations", "must be an object of boolean markers");
+    }
+  }
+
   // node: string if present
   if ("node" in raw) {
     if (typeof raw.node === "string" && raw.node.trim().length > 0) {

--- a/src/plugin/default-active.ts
+++ b/src/plugin/default-active.ts
@@ -1,0 +1,29 @@
+/**
+ * Default-active plugin policy.
+ *
+ * These plugins are operator-facing primitives that should stay active under
+ * the normal/standard profile. #1500 found existing configs where an older
+ * profile run left them in `disabledPlugins`, making installed commands look
+ * removed. Keep the list small and explicit: niche/heavy plugins should remain
+ * opt-in.
+ */
+export const DEFAULT_ACTIVE_PLUGINS_1500 = [
+  "team",
+  "fleet",
+  "panes",
+  "peers",
+  "pair",
+  "tmux",
+  "kill",
+  "plugin",
+  "doctor",
+  "inbox",
+] as const;
+
+export const DEFAULT_ACTIVE_PLUGINS_1500_MIGRATION = "defaultActivePlugins1500";
+
+const DEFAULT_ACTIVE_SET = new Set<string>(DEFAULT_ACTIVE_PLUGINS_1500);
+
+export function isDefaultActivePlugin(name: string): boolean {
+  return DEFAULT_ACTIVE_SET.has(name);
+}

--- a/src/vendor/mpr-plugins/doctor/plugin.json
+++ b/src/vendor/mpr-plugins/doctor/plugin.json
@@ -9,7 +9,8 @@
     "command": "doctor",
     "help": "maw doctor [install] — run install-check (and future: config-check, peer-check)"
   },
-  "weight": 80,
+  "weight": 30,
+  "tier": "standard",
   "license": "MIT",
   "schemaVersion": 1
 }

--- a/src/vendor/mpr-plugins/inbox/plugin.json
+++ b/src/vendor/mpr-plugins/inbox/plugin.json
@@ -9,7 +9,8 @@
     "command": "inbox",
     "help": "maw inbox [--unread] [--from <peer>] [--last N] | read <id> | show [N] | write <msg> | pending | approve <id> | reject <id> | show-pending <id>"
   },
-  "weight": 50,
+  "weight": 30,
+  "tier": "standard",
   "license": "MIT",
   "schemaVersion": 1
 }

--- a/src/vendor/mpr-plugins/kill/plugin.json
+++ b/src/vendor/mpr-plugins/kill/plugin.json
@@ -19,6 +19,7 @@
     ]
   },
   "weight": 10,
+  "tier": "standard",
   "license": "MIT",
   "schemaVersion": 1
 }

--- a/src/vendor/mpr-plugins/pair/plugin.json
+++ b/src/vendor/mpr-plugins/pair/plugin.json
@@ -10,7 +10,8 @@
     "aliases": [],
     "help": "maw pair | maw pair accept <code> [--at <url>] — ephemeral federation pairing"
   },
-  "weight": 50,
+  "weight": 30,
+  "tier": "standard",
   "license": "MIT",
   "schemaVersion": 1
 }

--- a/src/vendor/mpr-plugins/panes/plugin.json
+++ b/src/vendor/mpr-plugins/panes/plugin.json
@@ -19,6 +19,7 @@
     ]
   },
   "weight": 10,
+  "tier": "standard",
   "license": "MIT",
   "schemaVersion": 1
 }

--- a/src/vendor/mpr-plugins/peers/plugin.json
+++ b/src/vendor/mpr-plugins/peers/plugin.json
@@ -12,7 +12,8 @@
     ],
     "help": "maw peers <add|list|info|remove> [...] — federation peer aliases (see issue #568)"
   },
-  "weight": 50,
+  "weight": 30,
+  "tier": "standard",
   "license": "MIT",
   "schemaVersion": 1
 }

--- a/src/vendor/mpr-plugins/team/plugin.json
+++ b/src/vendor/mpr-plugins/team/plugin.json
@@ -12,7 +12,8 @@
     ],
     "help": "maw team <create|spawn|send|shutdown|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members|enter>"
   },
-  "weight": 50,
+  "weight": 30,
+  "tier": "standard",
   "license": "MIT",
   "schemaVersion": 1
 }

--- a/src/vendor/mpr-plugins/zenoh-scout/plugin.json
+++ b/src/vendor/mpr-plugins/zenoh-scout/plugin.json
@@ -25,7 +25,7 @@
     ],
     "help": "maw scout [--force] [--json] [--locator ws://127.0.0.1:10000] [--timeout <ms>] — query opt-in Zenoh discovery"
   },
-  "weight": 50,
+  "weight": 30,
   "license": "MIT",
   "schemaVersion": 1
 }

--- a/test/cli/dispatch-match.test.ts
+++ b/test/cli/dispatch-match.test.ts
@@ -85,6 +85,21 @@ describe("resolvePluginMatch — two-pass dispatch", () => {
     expect(out.kind).toBe("none");
   });
 
+  test("#1500: disabled plugins are skipped by default but detectable for UX hints", () => {
+    const team = plugin("team", "team");
+    team.disabled = true;
+
+    const skipped = resolvePluginMatch([team], "team status");
+    expect(skipped.kind).toBe("none");
+
+    const detected = resolvePluginMatch([team], "team status", { includeDisabled: true });
+    expect(detected.kind).toBe("match");
+    if (detected.kind === "match") {
+      expect(detected.plugin.manifest.name).toBe("team");
+      expect(detected.matchedName).toBe("team");
+    }
+  });
+
   test("non-dispatchable plugins (no cli, no entry, no wasm) are skipped", () => {
     // #899 — pure-hooks/api/cron plugins still get filtered out: no `cli`
     // field AND no entry/wasm to default to. The default-name fallback

--- a/test/isolated/plugin-default-active-migration.test.ts
+++ b/test/isolated/plugin-default-active-migration.test.ts
@@ -1,0 +1,128 @@
+/**
+ * #1500 — old profile-generated disabledPlugins lists hid essential plugin
+ * commands. The migration should heal only the legacy large-list shape, then
+ * persist a marker so later manual disables still work.
+ */
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { spawnSync } from "child_process";
+import { DEFAULT_ACTIVE_PLUGINS_1500_MIGRATION } from "../../src/plugin/default-active";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+const homes: string[] = [];
+
+function makeHome(config: Record<string, unknown>): string {
+  const home = mkdtempSync(join(tmpdir(), "maw-1500-"));
+  homes.push(home);
+  const configDir = join(home, "config");
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(join(configDir, "maw.config.json"), JSON.stringify(config, null, 2) + "\n");
+  return home;
+}
+
+function makePluginDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "maw-1500-plugins-"));
+  homes.push(dir);
+  return dir;
+}
+
+function loadInSubprocess(home: string) {
+  return spawnSync("bun", ["-e", `
+    const { loadConfig } = await import("${REPO_ROOT}/src/config/load.ts");
+    const cfg = loadConfig();
+    console.log(JSON.stringify({ disabledPlugins: cfg.disabledPlugins ?? [], migrations: cfg.migrations ?? {} }));
+  `], {
+    env: { ...process.env, MAW_HOME: home, MAW_TEST_MODE: "1" },
+    encoding: "utf-8",
+    timeout: 10_000,
+  });
+}
+
+function readConfig(home: string): Record<string, any> {
+  return JSON.parse(readFileSync(join(home, "config", "maw.config.json"), "utf-8"));
+}
+
+afterAll(() => {
+  for (const h of homes) rmSync(h, { recursive: true, force: true });
+});
+
+describe("#1500 default-active plugin migration", () => {
+  test("large legacy disabled list re-enables default-active plugins and persists marker", () => {
+    const home = makeHome({
+      host: "local",
+      port: 3456,
+      oracleUrl: "http://localhost:47779",
+      env: {},
+      commands: { default: "claude" },
+      sessions: {},
+      disabledPlugins: [
+        "team", "fleet", "panes", "peers", "pair", "tmux", "kill", "plugin", "doctor", "inbox",
+        "costs", "learn", "archive", "broadcast", "demo", "find", "project", "scope", "tab", "trust",
+        "workspace", "resume",
+      ],
+    });
+
+    const result = loadInSubprocess(home);
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain("config.disabledPlugins migration (#1500)");
+
+    const disk = readConfig(home);
+    expect(disk.disabledPlugins).not.toContain("team");
+    expect(disk.disabledPlugins).not.toContain("fleet");
+    expect(disk.disabledPlugins).not.toContain("pair");
+    expect(disk.disabledPlugins).toContain("costs");
+    expect(disk.disabledPlugins).toContain("learn");
+    expect(disk.migrations?.[DEFAULT_ACTIVE_PLUGINS_1500_MIGRATION]).toBe(true);
+  });
+
+  test("small manual disable list is preserved", () => {
+    const home = makeHome({
+      host: "local",
+      port: 3456,
+      oracleUrl: "http://localhost:47779",
+      env: {},
+      commands: { default: "claude" },
+      sessions: {},
+      disabledPlugins: ["team"],
+    });
+
+    const result = loadInSubprocess(home);
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toContain("config.disabledPlugins migration (#1500)");
+
+    const disk = readConfig(home);
+    expect(disk.disabledPlugins).toEqual(["team"]);
+    expect(disk.migrations?.[DEFAULT_ACTIVE_PLUGINS_1500_MIGRATION]).toBeUndefined();
+  });
+
+  test("typing a disabled installed plugin explains the real fix", () => {
+    const home = makeHome({
+      host: "local",
+      port: 3456,
+      oracleUrl: "http://localhost:47779",
+      env: {},
+      commands: { default: "claude" },
+      sessions: {},
+      disabledPlugins: ["costs"],
+    });
+    const pluginDir = makePluginDir();
+
+    const result = spawnSync("bun", ["src/cli.ts", "costs"], {
+      cwd: REPO_ROOT,
+      env: {
+        ...process.env,
+        MAW_HOME: home,
+        MAW_PLUGINS_DIR: pluginDir,
+        MAW_TEST_MODE: "1",
+      },
+      encoding: "utf-8",
+      timeout: 10_000,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("'costs' is installed but disabled");
+    expect(result.stderr).toContain("maw plugin enable costs");
+  });
+});


### PR DESCRIPTION
## Summary
- promote operator-critical plugins (`team`, `fleet`, `panes`, `peers`, `pair`, `tmux`, `kill`, `plugin`, `doctor`, `inbox`, plus `zenoh-scout`) so `maw plugin standard` keeps them active
- add a guarded one-shot config migration for large stale `disabledPlugins` lists generated by the old profile behavior
- make disabled-but-installed commands explain the fix (`maw plugin enable <name>`) instead of falling through as unknown

Closes #1500.

## Tests
- `bun test test/cli/dispatch-match.test.ts test/isolated/plugin-default-active-migration.test.ts test/isolated/plugins-toggle.test.ts --path-ignore-patterns "**/agents/**"` → 63 pass
- `bun test test/isolated/plugin-loader-profile.test.ts test/cli/usage.test.ts --path-ignore-patterns "**/agents/**"` → 15 pass
- `bun run build` → bundled 650 modules
- temp `MAW_HOME`/`MAW_PLUGINS_DIR` smoke: `maw plugin standard` leaves 11 default-active/operator plugins active, including `zenoh-scout`; disabled `costs` command prints `maw plugin enable costs`

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
