### PR TITLE
Fix post-midnight alpha calver downgrades

### DIFF
--- a/scripts/calver.ts
+++ b/scripts/calver.ts
@@ -241,12 +241,18 @@ export function computeVersion(args: Args, tags: string[] = [], packageVersion: 
   const base = args.stable ? todayBase : effectiveBase(todayBase, packageVersion);
   if (args.stable) return base;
   const channel = args.channel ?? "alpha";
-  // HHMM scheme: pre-release ID is the local-time hour+minute. Naturally
-  // unique-per-minute, no tag-walk + package-walk reconciliation needed.
-  // tags + packageVersion params kept for back-compat with callers/tests.
-  void tags; void packageVersion;
-  const stamp = hhmmStamp(now);
-  return `${base}-${channel}.${stamp}`;
+  // HHMM is the preferred wall-clock stamp, but it is not strictly monotonic
+  // across midnight when package.json still carries the same CalVer base with
+  // a late-night suffix (for example 26.5.16-alpha.2356 at 00:27).
+  // Preserve wall-clock readability when possible, and fall back to max+1
+  // when tags/package.json prove that HHMM would be a semver downgrade.
+  const stamp = parseInt(hhmmStamp(now), 10);
+  const maxExisting = Math.max(
+    maxNFromTags(base, channel, tags),
+    maxNFromPackageJson(base, channel, packageVersion),
+  );
+  const next = Math.max(stamp, maxExisting + 1);
+  return `${base}-${channel}.${next}`;
 }
 
 async function tagExists(version: string): Promise<boolean> {

--- a/test/calver.test.ts
+++ b/test/calver.test.ts
@@ -92,20 +92,34 @@ describe("calver computeVersion (HMM scheme)", () => {
     expect(computeVersion({ stable: true, check: false, now: jan1_0005 })).toBe("27.1.1");
   });
 
-  it("alpha: yy.m.d-alpha.HMM regardless of tag state", () => {
+  it("alpha: yy.m.d-alpha.HMM when no existing suffix is higher", () => {
     expect(computeVersion({ stable: false, check: false, now: apr18_0937 }, [])).toBe("26.4.18-alpha.937");
     expect(computeVersion({ stable: false, check: false, now: jan1_0005 }, [])).toBe("27.1.1-alpha.5");
   });
 
-  it("alpha: ignores tags entirely (HMM is unique-per-minute)", () => {
+  it("alpha: keeps HMM when tags are lower than the current wall-clock stamp", () => {
     const tags = ["v26.4.27-alpha.11", "v26.4.27-alpha.12"];
     expect(computeVersion({ stable: false, check: false, now: apr27_1200 }, tags)).toBe("26.4.27-alpha.1200");
   });
 
-  it("alpha: ignores legacy monotonic package.json counter", () => {
+  it("alpha: keeps HMM when package.json suffix is lower than the current wall-clock stamp", () => {
     expect(
       computeVersion({ stable: false, check: false, now: apr27_1200 }, [], "26.4.27-alpha.48"),
     ).toBe("26.4.27-alpha.1200");
+  });
+
+  it("#1504: alpha uses max+1 when post-midnight HMM would downgrade package.json", () => {
+    const may16_0027 = new Date(2026, 4, 16, 0, 27);
+    expect(
+      computeVersion({ stable: false, check: false, now: may16_0027 }, [], "26.5.16-alpha.2356"),
+    ).toBe("26.5.16-alpha.2357");
+  });
+
+  it("#1504: alpha uses max+1 when post-midnight HMM would downgrade tags", () => {
+    const may16_0027 = new Date(2026, 4, 16, 0, 27);
+    expect(
+      computeVersion({ stable: false, check: false, now: may16_0027 }, ["v26.5.16-alpha.2358"]),
+    ).toBe("26.5.16-alpha.2359");
   });
 
   it("--stable ignores tags entirely", () => {


### PR DESCRIPTION
## Summary
- prevent alpha/beta CalVer targets from going backwards after midnight on the same effective base
- keep HMM when it is greater than existing tags/package suffixes; otherwise use `maxExisting + 1`
- add regression tests for package.json and tag downgrade cases

Closes #1504.

## Tests
- `bun test test/calver.test.ts --path-ignore-patterns "**/agents/**"` → 56 pass
- `TZ=Asia/Bangkok bun scripts/calver.ts --check` → `Target: v26.5.16-alpha.2357 [alpha]`
- `bun run build` → bundled 650 modules

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
