### PR TITLE
release: v26.5.16-alpha.2357

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.16-alpha.2356",
+  "version": "26.5.16-alpha.2357",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts `v26.5.16-alpha.2357` on merge via `calver-release.yml`.

Includes:
- #1500 / #1503 default-active plugin profile repair
- #1504 / #1505 CalVer monotonic guard so this release does not downgrade after midnight

Validation:
- `TZ=Asia/Bangkok bun scripts/calver.ts --check` → `v26.5.16-alpha.2357`
- package.json-only diff for this release PR

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
