### PR TITLE
Heal legacy plugin registry symlinks

### DIFF
--- a/src/cli/plugin-bootstrap.test.ts
+++ b/src/cli/plugin-bootstrap.test.ts
@@ -83,6 +83,18 @@ describe("runBootstrap — #817 idempotent bundled-plugin symlinks", () => {
     return dir;
   }
 
+  /** Helper: create a legacy maw-plugin-registry checkout plugin. */
+  function makeLegacyMawPluginRegistryPlugin(name: string) {
+    const root = join(workDir, `maw-plugin-registry-${name}`);
+    mkdirSync(root, { recursive: true });
+    writeFileSync(join(root, "package.json"), JSON.stringify({ name: "maw-plugin-registry", version: "0.0.0-old" }));
+    const dir = join(root, "plugins", name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "plugin.json"), JSON.stringify({ name, weight: 80 }));
+    writeFileSync(join(dir, "index.ts"), `export default async () => ({ legacyMpr: true });\n`);
+    return dir;
+  }
+
   it("empty pluginDir → all bundled plugins symlinked (first install)", async () => {
     makeBundledPlugin("alpha");
     makeBundledPlugin("beta");
@@ -165,6 +177,20 @@ describe("runBootstrap — #817 idempotent bundled-plugin symlinks", () => {
 
     expect(lstatSync(join(pluginDir, "wake")).isSymbolicLink()).toBe(true);
     expect(readlinkSync(join(pluginDir, "wake"))).toBe(currentWake);
+  });
+
+  it("#1507 — legacy maw-plugin-registry symlink is healed to current vendored plugin", async () => {
+    const currentInbox = makeVendoredPlugin("inbox");
+    const legacyInbox = makeLegacyMawPluginRegistryPlugin("inbox");
+
+    mkdirSync(pluginDir, { recursive: true });
+    symlinkSync(legacyInbox, join(pluginDir, "inbox"));
+    expect(readlinkSync(join(pluginDir, "inbox"))).toBe(legacyInbox);
+
+    await runBootstrap(pluginDir, srcDir);
+
+    expect(lstatSync(join(pluginDir, "inbox")).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(join(pluginDir, "inbox"))).toBe(currentInbox);
   });
 
   it("#1491 — symlinked user plugin override is not treated as stale maw-js bundle", async () => {

--- a/src/cli/plugin-bootstrap.ts
+++ b/src/cli/plugin-bootstrap.ts
@@ -50,12 +50,39 @@ function isMawJsPackageRoot(root: string | undefined): boolean {
   }
 }
 
+function mawPluginRegistryRoot(target: string, entry: string): string | undefined {
+  const normalized = target.replace(/\\/g, "/");
+  const suffix = `/plugins/${entry}`;
+  if (!normalized.endsWith(suffix)) return undefined;
+  return target.slice(0, target.length - suffix.length);
+}
+
+function isMawPluginRegistryRoot(root: string | undefined): boolean {
+  if (!root) return false;
+  try {
+    const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf-8"));
+    if (pkg?.name === "maw-plugin-registry") return true;
+  } catch {}
+  return root.replace(/\\/g, "/").endsWith("/maw-plugin-registry");
+}
+
 function pointsAtStaleMawJsBundledPlugin(symlinkPath: string, entry: string, replacement: string): boolean {
   try {
     const currentTarget = realpathSync(replacement);
     const existingTarget = realpathSync(symlinkPath);
     if (existingTarget === currentTarget) return false;
     return isMawJsPackageRoot(bundledMawJsRoot(existingTarget, entry));
+  } catch {
+    return false;
+  }
+}
+
+function pointsAtLegacyMawPluginRegistryPlugin(symlinkPath: string, entry: string, replacement: string): boolean {
+  try {
+    const currentTarget = realpathSync(replacement);
+    const existingTarget = realpathSync(symlinkPath);
+    if (existingTarget === currentTarget) return false;
+    return isMawPluginRegistryRoot(mawPluginRegistryRoot(existingTarget, entry));
   } catch {
     return false;
   }
@@ -70,7 +97,11 @@ function healOrPruneBrokenSymlinks(pluginDir: string, bundledRoots: string[]): {
       if (!lstatSync(p).isSymbolicLink()) continue;
       const replacement = replacementForPlugin(entry, bundledRoots);
       const targetIsValidPlugin = existsSync(p) && isPluginDir(p);
-      if (targetIsValidPlugin && (!replacement || !pointsAtStaleMawJsBundledPlugin(p, entry, replacement))) continue;
+      const shouldHealValidTarget = replacement && (
+        pointsAtStaleMawJsBundledPlugin(p, entry, replacement) ||
+        pointsAtLegacyMawPluginRegistryPlugin(p, entry, replacement)
+      );
+      if (targetIsValidPlugin && !shouldHealValidTarget) continue;
       unlinkSync(p);
       if (replacement) {
         symlinkSync(replacement, p);


### PR DESCRIPTION
## Summary
- heal legacy symlinks pointing at external `maw-plugin-registry/plugins/<name>` when maw-js now vendors the same plugin
- preserve real user-owned plugin dirs and unrelated symlink overrides
- add regression coverage alongside the existing #1491 stale symlink healing tests

Closes #1507.

## Tests
- `bun test src/cli/plugin-bootstrap.test.ts --path-ignore-patterns "**/agents/**"` → 17 pass
- `bun run build` → bundled 650 modules
- `git diff --check`

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
