### PR TITLE
fix(kill): resolve orphan panes by title and worktree alias

### DIFF
--- a/src/commands/plugins/tmux/impl.ts
+++ b/src/commands/plugins/tmux/impl.ts
@@ -1,14 +1,104 @@
 import { readdirSync, existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
-import { hostExec, tmux } from "../../../sdk";
-import { resolveSessionTarget } from "../../../core/matcher/resolve-target";
+import { hostExec, tmux, tmuxCmd } from "../../../sdk";
+import { resolveByName, resolveSessionTarget } from "../../../core/matcher/resolve-target";
 import { loadFleetEntries } from "../../shared/fleet-load";
 import { ghqList, ghqListSync } from "../../../core/ghq";
 import { scanWorktrees } from "../../../core/fleet/worktrees-scan";
 import { checkDestructive, isClaudeLikePane, isFleetOrViewSession } from "./safety";
 
 const TEAMS_DIR = join(homedir(), ".claude/teams");
+
+const PANE_TARGET_FORMAT = "#{pane_id}|||#{session_name}:#{window_index}.#{pane_index}|||#{pane_title}|||#{@maw_tile_role}|||#{pane_current_path}";
+
+export interface PaneTargetCandidate {
+  name: string;
+  resolved: string;
+  source: string;
+  target: string;
+}
+
+export type PaneTargetResolution =
+  | { kind: "none" }
+  | { kind: "match"; candidate: PaneTargetCandidate }
+  | { kind: "ambiguous"; candidates: PaneTargetCandidate[] };
+
+function basename(path: string): string {
+  return path.split("/").filter(Boolean).pop() || path;
+}
+
+function worktreeNamesFromCwd(cwd: string): Array<{ name: string; source: string }> {
+  const base = basename(cwd);
+  if (!base) return [];
+  const out: Array<{ name: string; source: string }> = [{ name: base, source: "worktree-dir" }];
+
+  const match = base.match(/^(?<repo>.+)\.wt-\d+-(?<role>.+)$/);
+  const role = match?.groups?.role?.trim();
+  const repo = match?.groups?.repo?.trim();
+  if (role) {
+    out.push({ name: role, source: "worktree-role" });
+    // Natural user target for repo worktrees: mawjs-oracle.wt-7-codex →
+    // mawjs-codex. This covers orphan panes whose title diverges from the
+    // requested oracle-ish handle (#1502) while staying deterministic.
+    const repoStem = repo?.replace(/-oracle$/, "");
+    if (repoStem && repoStem !== repo) out.push({ name: `${repoStem}-${role}`, source: "worktree-alias" });
+  }
+
+  return out;
+}
+
+export function paneTargetCandidatesFromListPanesOutput(raw: string): PaneTargetCandidate[] {
+  const candidates: PaneTargetCandidate[] = [];
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    const [id = "", target = "", title = "", tileRole = "", cwd = ""] = line.split("|||");
+    const resolved = id.trim() || target.trim();
+    if (!resolved) continue;
+    const paneTarget = target.trim();
+    const add = (name: string, source: string) => {
+      const trimmed = name.trim();
+      if (!trimmed) return;
+      candidates.push({ name: trimmed, resolved, source, target: paneTarget });
+    };
+    add(title, "pane-title");
+    add(tileRole, "tile-role");
+    for (const wt of worktreeNamesFromCwd(cwd)) add(wt.name, wt.source);
+  }
+  return candidates;
+}
+
+function uniqueByResolved(candidates: PaneTargetCandidate[]): PaneTargetCandidate[] {
+  const seen = new Set<string>();
+  const out: PaneTargetCandidate[] = [];
+  for (const candidate of candidates) {
+    if (seen.has(candidate.resolved)) continue;
+    seen.add(candidate.resolved);
+    out.push(candidate);
+  }
+  return out;
+}
+
+export function resolvePaneTargetFromCandidates(target: string, candidates: readonly PaneTargetCandidate[]): PaneTargetResolution {
+  const exact = uniqueByResolved(candidates.filter(c => c.name.toLowerCase() === target.trim().toLowerCase()));
+  if (exact.length === 1) return { kind: "match", candidate: exact[0]! };
+  if (exact.length > 1) return { kind: "ambiguous", candidates: exact };
+
+  const byName = resolveByName(target, candidates);
+  if (byName.kind === "exact" || byName.kind === "fuzzy") return { kind: "match", candidate: byName.match };
+  if (byName.kind === "ambiguous") return { kind: "ambiguous", candidates: uniqueByResolved(byName.candidates) };
+  return { kind: "none" };
+}
+
+export function resolvePaneTargetFromListPanesOutput(target: string, raw: string): PaneTargetResolution {
+  return resolvePaneTargetFromCandidates(target, paneTargetCandidatesFromListPanesOutput(raw));
+}
+
+async function resolvePaneTargetForKill(target: string): Promise<PaneTargetResolution> {
+  const raw = await hostExec(`${tmuxCmd()} list-panes -a -F '${PANE_TARGET_FORMAT}'`).catch(() => "");
+  if (!raw.trim()) return { kind: "none" };
+  return resolvePaneTargetFromListPanesOutput(target, raw);
+}
 
 function listSessionNamesSync(): string[] {
   try {
@@ -463,7 +553,26 @@ export interface TmuxKillOpts {
 export async function cmdTmuxKill(target: string, opts: TmuxKillOpts = {}): Promise<void> {
   const hit = resolveTmuxTarget(target);
   if (!hit) throw new Error(`cannot resolve target '${target}'`);
-  const { resolved, source } = hit;
+  let { resolved, source } = hit;
+
+  // #1502 — top-level `maw kill` routes here (`maw tmux kill`). Unknown
+  // natural names used to fall through as a bare tmux session target and
+  // fail with "can't find pane" even when `maw ls -v` showed an orphan pane
+  // by title/worktree role. Preserve exact/session handling above, but when
+  // the resolver only reached the final session-name fallback, consult pane
+  // titles, @maw_tile_role, and worktree dirname aliases before killing.
+  if (!opts.session && source === "session-name" && resolved === target) {
+    const paneHit = await resolvePaneTargetForKill(target);
+    if (paneHit.kind === "match") {
+      resolved = paneHit.candidate.resolved;
+      source = `${paneHit.candidate.source} (${paneHit.candidate.name})`;
+    } else if (paneHit.kind === "ambiguous") {
+      const lines = paneHit.candidates
+        .map(c => `    • ${c.name} → ${c.resolved}${c.target ? ` (${c.target})` : ""} [${c.source}]`)
+        .join("\n");
+      throw new Error(`'${target}' is ambiguous — matches ${paneHit.candidates.length} panes:\n${lines}\n  use the pane id or full session:window.pane target`);
+    }
+  }
 
   // Fleet/view safety — extract session from resolved target
   const session = resolved.split(":")[0] ?? "";

--- a/test/isolated/tmux-kill-pane-target.test.ts
+++ b/test/isolated/tmux-kill-pane-target.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import {
+  paneTargetCandidatesFromListPanesOutput,
+  resolvePaneTargetFromListPanesOutput,
+} from "../../src/commands/plugins/tmux/impl";
+
+const raw = [
+  "%101|||47-mawjs:1.0|||codex-headless-demo-layout|||tile-1|||/opt/Code/github.com/Soul-Brews-Studio/mawjs-oracle.wt-7-codex-headless",
+  "%202|||47-mawjs:1.1|||notes|||researcher|||/opt/Code/github.com/Soul-Brews-Studio/notes-oracle.wt-2-researcher",
+].join("\n");
+
+describe("tmux kill pane target fallback (#1502)", () => {
+  test("indexes pane titles, tile roles, and worktree aliases", () => {
+    const names = paneTargetCandidatesFromListPanesOutput(raw).map(c => `${c.name}:${c.source}:${c.resolved}`);
+
+    expect(names).toContain("codex-headless-demo-layout:pane-title:%101");
+    expect(names).toContain("tile-1:tile-role:%101");
+    expect(names).toContain("codex-headless:worktree-role:%101");
+    expect(names).toContain("mawjs-codex-headless:worktree-alias:%101");
+  });
+
+  test("resolves the natural mawjs-prefixed worktree alias to the orphan pane id", () => {
+    const hit = resolvePaneTargetFromListPanesOutput("mawjs-codex-headless", raw);
+
+    expect(hit.kind).toBe("match");
+    if (hit.kind !== "match") throw new Error("expected match");
+    expect(hit.candidate.resolved).toBe("%101");
+    expect(hit.candidate.source).toBe("worktree-alias");
+  });
+
+  test("exact pane title wins directly", () => {
+    const hit = resolvePaneTargetFromListPanesOutput("codex-headless-demo-layout", raw);
+
+    expect(hit.kind).toBe("match");
+    if (hit.kind !== "match") throw new Error("expected match");
+    expect(hit.candidate.resolved).toBe("%101");
+    expect(hit.candidate.source).toBe("pane-title");
+  });
+
+  test("ambiguous fuzzy pane/worktree matches refuse to choose silently", () => {
+    const ambiguousRaw = [
+      "%1|||47-mawjs:1.0|||codex-a|||worker|||/tmp/mawjs-oracle.wt-1-codex",
+      "%2|||47-mawjs:1.1|||codex-b|||worker|||/tmp/mawjs-oracle.wt-2-codex",
+    ].join("\n");
+
+    const hit = resolvePaneTargetFromListPanesOutput("worker", ambiguousRaw);
+
+    expect(hit.kind).toBe("ambiguous");
+    if (hit.kind !== "ambiguous") throw new Error("expected ambiguous");
+    expect(hit.candidates.map(c => c.resolved).sort()).toEqual(["%1", "%2"]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1502 by letting top-level `maw kill <name>` (which routes through `maw tmux kill`) resolve orphan panes by the names users actually see:

- pane title (`#{pane_title}`)
- tile role (`#{@maw_tile_role}`)
- worktree directory basename (`*.wt-N-<role>`)
- natural repo-role alias (`mawjs-oracle.wt-7-codex-headless` → `mawjs-codex-headless`)

The fallback only runs after normal pane-id / session:w.p / team / fleet / live-session resolution falls through to the final bare `session-name` path. Existing exact session/address behavior stays ahead of the fallback. Ambiguous pane matches refuse to choose silently and ask for pane id/full target.

## Tests

- `bun test test/isolated/tmux-kill-pane-target.test.ts test/isolated/tmux-action-verbs.test.ts test/isolated/tmux-peek.test.ts --path-ignore-patterns '**/agents/**'` → 33 pass
- `bun run build` → bundled 650 modules

## Attribution

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.