### PR TITLE
release: v26.5.16-alpha.2359

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.16-alpha.2358",
+  "version": "26.5.16-alpha.2359",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts `v26.5.16-alpha.2359` from current `alpha` after #1510.

Scope: package.json version bump only.

Expected on merge: `calver-release.yml` creates the GitHub pre-release and attaches the bun-built `maw` binary.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.