### PR TITLE
fix(split): heal stale profile disables for help-prominent split

### DIFF
--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -10,6 +10,8 @@ import { validateConfig } from "./validate-ext";
 import { loadFleetAgents } from "./fleet-merge";
 import {
   DEFAULT_ACTIVE_PLUGINS_1500_MIGRATION,
+  DEFAULT_ACTIVE_PLUGINS_1514_MIGRATION,
+  isDefaultActive1514Plugin,
   isDefaultActivePlugin,
 } from "../plugin/default-active";
 
@@ -77,6 +79,30 @@ function maybeMigrateDefaultActivePlugins(config: MawConfig): void {
     `${promoted.join(", ")}. Disable them again with \`maw plugin disable <name>\` if intentional.\n`,
   );
   persistLoadedConfig("config.disabledPlugins migration (#1500)");
+}
+
+function maybeMigrateSplitTopAliasPlugin(config: MawConfig): void {
+  const marker = DEFAULT_ACTIVE_PLUGINS_1514_MIGRATION;
+  if (config.migrations?.[marker]) return;
+  const disabled = config.disabledPlugins ?? [];
+  const promoted = disabled.filter(isDefaultActive1514Plugin);
+  if (promoted.length === 0) return;
+
+  // Same safety posture as #1500: avoid overriding a tiny, clearly manual
+  // disable list. If #1500 already ran, this is a continuation of that stale
+  // profile-generated list heal; otherwise require the legacy large-list shape.
+  const staleProfileShape =
+    disabled.length >= 20 ||
+    config.migrations?.[DEFAULT_ACTIVE_PLUGINS_1500_MIGRATION] === true;
+  if (!staleProfileShape) return;
+
+  config.disabledPlugins = disabled.filter((name) => !isDefaultActive1514Plugin(name));
+  config.migrations = { ...(config.migrations ?? {}), [marker]: true };
+  process.stderr.write(
+    `[maw] config.disabledPlugins migration (#1514): re-enabled help-prominent plugins ` +
+    `${promoted.join(", ")}. Disable them again with \`maw plugin disable <name>\` if intentional.\n`,
+  );
+  persistLoadedConfig("config.disabledPlugins migration (#1514)");
 }
 
 export function loadConfig(): MawConfig {
@@ -151,6 +177,7 @@ export function loadConfig(): MawConfig {
     persistLoadedConfig("config.host migration");
   }
   maybeMigrateDefaultActivePlugins(cached);
+  maybeMigrateSplitTopAliasPlugin(cached);
   // #736 Phase 1.1 — pre-populate config.agents from fleet at loadConfig time
   // so federation routing (`maw hey <oracle>`) sees fleet-known targets even
   // before their first wake. Additive only: hand-tuned config.agents entries

--- a/src/plugin/default-active.ts
+++ b/src/plugin/default-active.ts
@@ -22,8 +22,24 @@ export const DEFAULT_ACTIVE_PLUGINS_1500 = [
 
 export const DEFAULT_ACTIVE_PLUGINS_1500_MIGRATION = "defaultActivePlugins1500";
 
+/**
+ * #1514 follow-up: `maw split` is a help-prominent top-level verb in
+ * src/cli/top-aliases.ts, so stale profile-generated disabled lists must not
+ * keep it hidden after #1500 already ran.
+ */
+export const DEFAULT_ACTIVE_PLUGINS_1514 = [
+  "split",
+] as const;
+
+export const DEFAULT_ACTIVE_PLUGINS_1514_MIGRATION = "defaultActivePlugins1514";
+
 const DEFAULT_ACTIVE_SET = new Set<string>(DEFAULT_ACTIVE_PLUGINS_1500);
+const DEFAULT_ACTIVE_1514_SET = new Set<string>(DEFAULT_ACTIVE_PLUGINS_1514);
 
 export function isDefaultActivePlugin(name: string): boolean {
   return DEFAULT_ACTIVE_SET.has(name);
+}
+
+export function isDefaultActive1514Plugin(name: string): boolean {
+  return DEFAULT_ACTIVE_1514_SET.has(name);
 }

--- a/test/isolated/plugin-default-active-migration.test.ts
+++ b/test/isolated/plugin-default-active-migration.test.ts
@@ -8,7 +8,10 @@ import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs"
 import { tmpdir } from "os";
 import { join } from "path";
 import { spawnSync } from "child_process";
-import { DEFAULT_ACTIVE_PLUGINS_1500_MIGRATION } from "../../src/plugin/default-active";
+import {
+  DEFAULT_ACTIVE_PLUGINS_1500_MIGRATION,
+  DEFAULT_ACTIVE_PLUGINS_1514_MIGRATION,
+} from "../../src/plugin/default-active";
 
 const REPO_ROOT = join(import.meta.dir, "..", "..");
 const homes: string[] = [];
@@ -95,6 +98,52 @@ describe("#1500 default-active plugin migration", () => {
     const disk = readConfig(home);
     expect(disk.disabledPlugins).toEqual(["team"]);
     expect(disk.migrations?.[DEFAULT_ACTIVE_PLUGINS_1500_MIGRATION]).toBeUndefined();
+  });
+
+  test("#1514 re-enables split when #1500 already healed a stale profile list", () => {
+    const home = makeHome({
+      host: "local",
+      port: 3456,
+      oracleUrl: "http://localhost:47779",
+      env: {},
+      commands: { default: "claude" },
+      sessions: {},
+      migrations: { [DEFAULT_ACTIVE_PLUGINS_1500_MIGRATION]: true },
+      disabledPlugins: [
+        "split", "costs", "learn", "archive", "broadcast", "demo", "find",
+        "project", "scope", "tab", "trust", "workspace", "resume",
+      ],
+    });
+
+    const result = loadInSubprocess(home);
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain("config.disabledPlugins migration (#1514)");
+
+    const disk = readConfig(home);
+    expect(disk.disabledPlugins).not.toContain("split");
+    expect(disk.disabledPlugins).toContain("costs");
+    expect(disk.migrations?.[DEFAULT_ACTIVE_PLUGINS_1500_MIGRATION]).toBe(true);
+    expect(disk.migrations?.[DEFAULT_ACTIVE_PLUGINS_1514_MIGRATION]).toBe(true);
+  });
+
+  test("#1514 preserves a small manual split disable list", () => {
+    const home = makeHome({
+      host: "local",
+      port: 3456,
+      oracleUrl: "http://localhost:47779",
+      env: {},
+      commands: { default: "claude" },
+      sessions: {},
+      disabledPlugins: ["split"],
+    });
+
+    const result = loadInSubprocess(home);
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toContain("config.disabledPlugins migration (#1514)");
+
+    const disk = readConfig(home);
+    expect(disk.disabledPlugins).toEqual(["split"]);
+    expect(disk.migrations?.[DEFAULT_ACTIVE_PLUGINS_1514_MIGRATION]).toBeUndefined();
   });
 
   test("typing a disabled installed plugin explains the real fix", () => {


### PR DESCRIPTION
## Why

#1498's fast skill/plugin audit found one active-help dispatch mismatch: `maw --help` advertises `maw split`, but stale profile-generated `disabledPlugins` lists can still keep the `split` plugin disabled after the earlier #1500 migration has already run.

## What

- Adds a #1514 follow-up migration marker that re-enables only `split` when the config shape indicates the old stale profile list.
- Preserves small manual disable lists (`disabledPlugins: ["split"]`).
- Keeps scope narrow: this does not re-enable every standard plugin.

## Evidence

- `rtk bun test test/isolated/plugin-default-active-migration.test.ts --path-ignore-patterns '**/agents/**'` → 5 pass.
- `rtk bun test test/cli/dispatch-match.test.ts test/isolated/tmux-action-verbs.test.ts --path-ignore-patterns '**/agents/**'` → 47 pass.
- `rtk bun run build` → bundled 651 modules.
- Source smoke: `bun src/cli.ts split --help` prints split usage.
- Installed/local config smoke after migration: `maw split --help` prints split usage.

Closes #1514.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
