### PR TITLE
release: v26.5.16-alpha.2361

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.16-alpha.2360",
+  "version": "26.5.16-alpha.2361",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts v26.5.16-alpha.2361 on merge via calver-release.yml.

Includes #1515 / #1514: heal stale profile disables for help-prominent `maw split`.

Validation before release:
- #1515 CI green: test-unit, test-isolated, test-plugin, test-mock-smoke, build, GitGuardian.
- Local build passed.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
