### PR TITLE
fix(zenoh-scout): classify runtime init blockers

### DIFF
--- a/src/vendor/mpr-plugins/zenoh-scout/impl.ts
+++ b/src/vendor/mpr-plugins/zenoh-scout/impl.ts
@@ -191,7 +191,7 @@ export async function runZenohScout(
       keyPrefix: config.keyPrefix,
       total: 0,
       peers: [],
-      error: "zenoh_unavailable",
+      error: classifyZenohFailure(message),
       hint: `${message} — ${zenohUnavailableHint(message)}`,
     };
   } finally {
@@ -252,4 +252,9 @@ function zenohUnavailableHint(message: string): string {
     return "install @eclipse-zenoh/zenoh-ts or run a maw build that bundles/externalizes it correctly";
   }
   return "start zenohd with the remote-api bridge or pass --locator";
+}
+
+function classifyZenohFailure(message: string): string {
+  if (/wasm|__wbindgen|WebAssembly/i.test(message)) return "zenoh_runtime_unsupported";
+  return "zenoh_unavailable";
 }

--- a/test/zenoh-scout-plugin.test.ts
+++ b/test/zenoh-scout-plugin.test.ts
@@ -138,4 +138,17 @@ describe("zenoh-scout plugin (#1455)", () => {
     expect(result.error).toBe("zenoh_unavailable");
     expect(result.hint).toContain("start zenohd");
   });
+
+  test("zenoh-ts runtime or wasm init failures are reported separately from bridge unavailability", async () => {
+    const cfg = readZenohScoutConfig({ node: "m5", oracle: "mawjs", zenoh: { scout: { enabled: true } } });
+    const result = await runZenohScout(cfg, {
+      importZenoh: async () => {
+        throw new Error("wasm.__wbindgen_start is not a function");
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("zenoh_runtime_unsupported");
+    expect(result.hint).toContain("zenoh-ts failed to initialize in this runtime");
+  });
 });


### PR DESCRIPTION
## Summary

- distinguish zenoh-ts/Bun/WASM initialization failures from ordinary zenoh bridge/connectivity failures
- return `zenoh_runtime_unsupported` when `@eclipse-zenoh/zenoh-ts` fails before maw can test the remote-api bridge
- keep bridge failures under `zenoh_unavailable`

Closes #1518.

## Test plan

- `rtk bun test test/zenoh-scout-plugin.test.ts --path-ignore-patterns '**/agents/**'`
- `rtk bun run build`
- `bun src/cli.ts scout --force --json --timeout 250`

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.