### PR TITLE
release: v26.5.16-alpha.2362

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.16-alpha.2361",
+  "version": "26.5.16-alpha.2362",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts v26.5.16-alpha.2362 on merge via calver-release.yml.

Includes #1519 / #1518 so installed `maw scout --force --json` reports `zenoh_runtime_unsupported` for zenoh-ts Bun/WASM init failures instead of generic `zenoh_unavailable`.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.