### PR TITLE
fix(hub): explain invalid workspace configs

### DIFF
--- a/src/transports/hub-config.ts
+++ b/src/transports/hub-config.ts
@@ -30,10 +30,11 @@ export function loadWorkspaceConfigs(): WorkspaceConfig[] {
   for (const file of files) {
     try {
       const raw = JSON.parse(readFileSync(join(WORKSPACES_DIR, file), "utf-8"));
-      if (validateWorkspaceConfig(raw)) {
+      const validation = validateWorkspaceConfig(raw);
+      if (validation.ok) {
         configs.push(raw as WorkspaceConfig);
       } else {
-        console.warn(`[hub] invalid workspace config: ${file}`);
+        console.warn(`[hub] invalid workspace config: ${file} (${validation.reason})`);
       }
     } catch (err) {
       console.warn(`[hub] failed to parse workspace config: ${file}`, err);
@@ -44,17 +45,19 @@ export function loadWorkspaceConfigs(): WorkspaceConfig[] {
 }
 
 /** Validate workspace config shape */
-function validateWorkspaceConfig(raw: any): boolean {
-  if (!raw || typeof raw !== "object") return false;
-  if (typeof raw.id !== "string" || raw.id.length === 0) return false;
-  if (typeof raw.hubUrl !== "string" || raw.hubUrl.length === 0) return false;
-  if (typeof raw.token !== "string" || raw.token.length === 0) return false;
-  if (!Array.isArray(raw.sharedAgents)) return false;
+export function validateWorkspaceConfig(raw: any): { ok: true } | { ok: false; reason: string } {
+  if (!raw || typeof raw !== "object") return { ok: false, reason: "not an object" };
+  if (typeof raw.id !== "string" || raw.id.length === 0) return { ok: false, reason: "missing/empty id" };
+  if (typeof raw.hubUrl !== "string" || raw.hubUrl.length === 0) return { ok: false, reason: "missing/empty hubUrl" };
+  if (typeof raw.token !== "string" || raw.token.length === 0) return { ok: false, reason: "missing/empty token" };
+  if (!Array.isArray(raw.sharedAgents)) return { ok: false, reason: "sharedAgents must be array" };
   try {
     const url = new URL(raw.hubUrl);
-    if (url.protocol !== "ws:" && url.protocol !== "wss:") return false;
+    if (url.protocol !== "ws:" && url.protocol !== "wss:") {
+      return { ok: false, reason: `hubUrl must be ws:|wss: (got ${url.protocol})` };
+    }
   } catch {
-    return false;
+    return { ok: false, reason: "hubUrl not a valid URL" };
   }
-  return true;
+  return { ok: true };
 }

--- a/test/hub-config.test.ts
+++ b/test/hub-config.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+const tmpConfigDir = mkdtempSync(join(tmpdir(), "maw-hub-config-test-"));
+process.env.MAW_CONFIG_DIR = tmpConfigDir;
+
+const { WORKSPACES_DIR, loadWorkspaceConfigs, validateWorkspaceConfig } = await import("../src/transports/hub-config");
+
+describe("hub workspace config validation (#1521)", () => {
+  test("returns actionable reasons for invalid fields", () => {
+    expect(validateWorkspaceConfig(null)).toEqual({ ok: false, reason: "not an object" });
+    expect(validateWorkspaceConfig({ hubUrl: "ws://hub", token: "t", sharedAgents: [] })).toEqual({ ok: false, reason: "missing/empty id" });
+    expect(validateWorkspaceConfig({ id: "ws", token: "t", sharedAgents: [] })).toEqual({ ok: false, reason: "missing/empty hubUrl" });
+    expect(validateWorkspaceConfig({ id: "ws", hubUrl: "ws://hub", sharedAgents: [] })).toEqual({ ok: false, reason: "missing/empty token" });
+    expect(validateWorkspaceConfig({ id: "ws", hubUrl: "ws://hub", token: "t" })).toEqual({ ok: false, reason: "sharedAgents must be array" });
+    expect(validateWorkspaceConfig({ id: "ws", hubUrl: "http://hub", token: "t", sharedAgents: [] })).toEqual({ ok: false, reason: "hubUrl must be ws:|wss: (got http:)" });
+    expect(validateWorkspaceConfig({ id: "ws", hubUrl: "not a url", token: "t", sharedAgents: [] })).toEqual({ ok: false, reason: "hubUrl not a valid URL" });
+  });
+
+  test("accepts ws/wss configs", () => {
+    expect(validateWorkspaceConfig({ id: "ws", hubUrl: "ws://hub", token: "t", sharedAgents: [] })).toEqual({ ok: true });
+    expect(validateWorkspaceConfig({ id: "ws", hubUrl: "wss://hub", token: "t", sharedAgents: ["agent"] })).toEqual({ ok: true });
+  });
+
+  test("warning includes the invalid filename and reason", () => {
+    mkdirSync(WORKSPACES_DIR, { recursive: true });
+    writeFileSync(join(WORKSPACES_DIR, "bad.json"), JSON.stringify({ id: "ws-bad", hubUrl: "http://hub", token: "t", sharedAgents: [] }));
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(" "));
+    try {
+      expect(loadWorkspaceConfigs()).toEqual([]);
+    } finally {
+      console.warn = originalWarn;
+    }
+    expect(warnings.join("\n")).toContain("[hub] invalid workspace config: bad.json (hubUrl must be ws:|wss: (got http:))");
+  });
+});


### PR DESCRIPTION
## Summary

- make hub workspace validation return an actionable reason
- include the reason in `[hub] invalid workspace config` startup warnings
- add regression coverage for each invalid field and the warn line

Closes #1521.

## Test plan

- `rtk bun test test/hub-config.test.ts --path-ignore-patterns '**/agents/**'`
- `MAW_TEST_MODE=1 rtk bun test src/transports/scout-integration.test.ts test/peer-exec.integration.test.ts --path-ignore-patterns '**/agents/**'`
- `rtk bun run build`

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.