### PR TITLE
feat(plugin): keep shellenv and completions active in standard profile

### DIFF
--- a/completions/_maw
+++ b/completions/_maw
@@ -1,8 +1,5 @@
 #compdef maw
 
-# maw — Multi-Agent Workflow completion
-# Dynamic oracle/window names from fleet configs via `maw completions`
-
 _maw_oracles() {
   local -a oracles
   oracles=(${(f)"$(maw completions oracles 2>/dev/null)"})
@@ -19,119 +16,38 @@ _maw() {
   local curcontext="$curcontext" state line
   typeset -A opt_args
 
-  local -a commands=(
-    'ls:List sessions + windows'
-    'peek:Peek agent screen'
-    'hey:Send message to agent'
-    'wake:Wake oracle in tmux'
-    'fleet:Fleet management'
-    'stop:Stop all fleet sessions'
-    'done:Clean up finished worktree'
-    'overview:War-room view'
-    'about:Oracle profile'
-    'oracle:Fleet status'
-    'pulse:Pulse task management'
-    'serve:Start web UI'
-  )
-
   _arguments -C \
     '1:command:->cmd' \
     '*::arg:->args'
 
   case $state in
     cmd)
-      # Commands + oracle names (shorthand mode)
-      local -a oracles
+      local -a commands oracles all
+      commands=(${(f)"$(maw completions commands 2>/dev/null)"})
       oracles=(${(f)"$(maw completions oracles 2>/dev/null)"})
-      local -a all_completions=($commands)
-      for o in $oracles; do
-        all_completions+=("$o:Oracle (peek/send shorthand)")
-      done
-      _describe 'command' all_completions
+      all=(${commands[@]})
+      for o in ${oracles[@]}; do all+=("$o:Oracle (peek/send shorthand)"); done
+      _describe 'command' all
       ;;
     args)
       case $line[1] in
-        peek|see)
+        peek|see|a|attach|bring|b|hey|send|tell|done|finish)
           _maw_windows
           ;;
-        hey|send|tell)
-          if (( CURRENT == 2 )); then
-            _maw_windows
-          fi
-          ;;
-        done|finish)
-          _maw_windows
-          ;;
-        about|info)
+        wake|about|info)
           _maw_oracles
           ;;
-        wake)
-          if (( CURRENT == 2 )); then
-            local -a wake_targets=('all:Wake entire fleet')
-            local -a oracles=(${(f)"$(maw completions oracles 2>/dev/null)"})
-            for o in $oracles; do wake_targets+=("$o:Oracle"); done
-            _describe 'target' wake_targets
-          else
-            _arguments \
-              '--new[Create new worktree]:name:' \
-              '--issue[Fetch GitHub issue]:number:' \
-              '--repo[Explicit repo]:repo:' \
-              '--kill[Kill existing sessions first]' \
-              '--all[Include dormant oracles]'
-          fi
+        completions)
+          _values 'completion mode' commands oracles windows zsh bash fish --help
           ;;
-        overview|warroom|ov)
-          _arguments \
-            '--kill[Tear down overview]' \
-            '*:oracle:_maw_oracles'
-          ;;
-        fleet)
-          local -a fleet_cmds=(
-            'init:Scan ghq repos, generate configs'
-            'ls:List fleet configs'
-            'renumber:Fix numbering conflicts'
-            'validate:Check for problems'
-            'sync:Add unregistered windows'
-          )
-          _describe 'fleet command' fleet_cmds
-          ;;
-        oracle|oracles)
-          local -a oracle_cmds=(
-            'ls:Fleet status'
-            'list:Fleet status'
-          )
-          _describe 'oracle command' oracle_cmds
-          ;;
-        pulse)
-          if (( CURRENT == 2 )); then
-            local -a pulse_cmds=(
-              'add:Create issue + wake oracle'
-              'ls:Board table'
-              'list:Board table'
-            )
-            _describe 'pulse command' pulse_cmds
-          else
-            case $line[2] in
-              add)
-                _arguments \
-                  '--oracle[Oracle to assign]:oracle:_maw_oracles' \
-                  '--priority[Priority level]:priority:(P0 P1 P2 P3)' \
-                  '--wt[Worktree repo]:repo:' \
-                  '--worktree[Worktree repo]:repo:' \
-                  '*:title:'
-                ;;
-              ls|list)
-                _arguments '--sync[Update daily thread checkboxes]'
-                ;;
-            esac
-          fi
+        plugin|plugins)
+          _values 'plugin action' ls list enable disable info standard full lean nuke
           ;;
         serve)
           _message 'port (default: 3456)'
           ;;
         *)
-          # Shorthand: maw <oracle> <message>
-          _message 'message'
+          _message 'argument'
           ;;
       esac
       ;;

--- a/completions/maw.bash
+++ b/completions/maw.bash
@@ -1,0 +1,33 @@
+# maw bash completion
+_maw_complete() {
+  local cur cmd words
+  COMPREPLY=()
+  cur="${COMP_WORDS[COMP_CWORD]}"
+
+  if [[ $COMP_CWORD -eq 1 ]]; then
+    words="$(maw completions commands 2>/dev/null)"
+    COMPREPLY=( $(compgen -W "$words" -- "$cur") )
+    return 0
+  fi
+
+  cmd="${COMP_WORDS[1]}"
+  case "$cmd" in
+    peek|see|a|attach|bring|b|hey|send|tell|done|finish)
+      words="$(maw completions windows 2>/dev/null)"
+      ;;
+    wake|about|info)
+      words="$(maw completions oracles 2>/dev/null)"
+      ;;
+    completions)
+      words="commands oracles windows zsh bash fish --help"
+      ;;
+    plugin|plugins)
+      words="ls list enable disable info standard full lean nuke"
+      ;;
+    *)
+      words=""
+      ;;
+  esac
+  COMPREPLY=( $(compgen -W "$words" -- "$cur") )
+}
+complete -F _maw_complete maw

--- a/completions/maw.fish
+++ b/completions/maw.fish
@@ -1,0 +1,5 @@
+# maw fish completion
+complete -c maw -f -n '__fish_use_subcommand' -a '(maw completions commands 2>/dev/null)'
+complete -c maw -f -n '__fish_seen_subcommand_from wake about info' -a '(maw completions oracles 2>/dev/null)'
+complete -c maw -f -n '__fish_seen_subcommand_from peek see a attach bring b hey send tell done finish' -a '(maw completions windows 2>/dev/null)'
+complete -c maw -f -n '__fish_seen_subcommand_from completions' -a 'commands oracles windows zsh bash fish --help'

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -12,8 +12,10 @@ import {
   DEFAULT_ACTIVE_PLUGINS_1500_MIGRATION,
   DEFAULT_ACTIVE_PLUGINS_1514_MIGRATION,
   DEFAULT_ACTIVE_PLUGINS_1523_MIGRATION,
+  DEFAULT_ACTIVE_PLUGINS_1524_MIGRATION,
   isDefaultActive1514Plugin,
   isDefaultActive1523Plugin,
+  isDefaultActive1524Plugin,
   isDefaultActivePlugin,
 } from "../plugin/default-active";
 
@@ -132,6 +134,29 @@ function maybeMigrateShellenvStandardPlugin(config: MawConfig): void {
   persistLoadedConfig("config.disabledPlugins migration (#1523)");
 }
 
+function maybeMigrateCompletionsStandardPlugin(config: MawConfig): void {
+  const marker = DEFAULT_ACTIVE_PLUGINS_1524_MIGRATION;
+  if (config.migrations?.[marker]) return;
+  const disabled = config.disabledPlugins ?? [];
+  const promoted = disabled.filter(isDefaultActive1524Plugin);
+  if (promoted.length === 0) return;
+
+  const staleProfileShape =
+    disabled.length >= 20 ||
+    config.migrations?.[DEFAULT_ACTIVE_PLUGINS_1500_MIGRATION] === true ||
+    config.migrations?.[DEFAULT_ACTIVE_PLUGINS_1514_MIGRATION] === true ||
+    config.migrations?.[DEFAULT_ACTIVE_PLUGINS_1523_MIGRATION] === true;
+  if (!staleProfileShape) return;
+
+  config.disabledPlugins = disabled.filter((name) => !isDefaultActive1524Plugin(name));
+  config.migrations = { ...(config.migrations ?? {}), [marker]: true };
+  process.stderr.write(
+    `[maw] config.disabledPlugins migration (#1524): re-enabled completion plugins ` +
+    `${promoted.join(", ")}. Disable them again with \`maw plugin disable <name>\` if intentional.\n`,
+  );
+  persistLoadedConfig("config.disabledPlugins migration (#1524)");
+}
+
 export function loadConfig(): MawConfig {
   if (cached) return cached;
   try {
@@ -206,6 +231,7 @@ export function loadConfig(): MawConfig {
   maybeMigrateDefaultActivePlugins(cached);
   maybeMigrateSplitTopAliasPlugin(cached);
   maybeMigrateShellenvStandardPlugin(cached);
+  maybeMigrateCompletionsStandardPlugin(cached);
   // #736 Phase 1.1 — pre-populate config.agents from fleet at loadConfig time
   // so federation routing (`maw hey <oracle>`) sees fleet-known targets even
   // before their first wake. Additive only: hand-tuned config.agents entries

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -11,7 +11,9 @@ import { loadFleetAgents } from "./fleet-merge";
 import {
   DEFAULT_ACTIVE_PLUGINS_1500_MIGRATION,
   DEFAULT_ACTIVE_PLUGINS_1514_MIGRATION,
+  DEFAULT_ACTIVE_PLUGINS_1523_MIGRATION,
   isDefaultActive1514Plugin,
+  isDefaultActive1523Plugin,
   isDefaultActivePlugin,
 } from "../plugin/default-active";
 
@@ -105,6 +107,31 @@ function maybeMigrateSplitTopAliasPlugin(config: MawConfig): void {
   persistLoadedConfig("config.disabledPlugins migration (#1514)");
 }
 
+function maybeMigrateShellenvStandardPlugin(config: MawConfig): void {
+  const marker = DEFAULT_ACTIVE_PLUGINS_1523_MIGRATION;
+  if (config.migrations?.[marker]) return;
+  const disabled = config.disabledPlugins ?? [];
+  const promoted = disabled.filter(isDefaultActive1523Plugin);
+  if (promoted.length === 0) return;
+
+  // Preserve manual tiny disables. If #1500/#1514 already ran, this is a
+  // continuation of the stale profile-generated disabled-list repair; otherwise
+  // require the old large-list profile shape.
+  const staleProfileShape =
+    disabled.length >= 20 ||
+    config.migrations?.[DEFAULT_ACTIVE_PLUGINS_1500_MIGRATION] === true ||
+    config.migrations?.[DEFAULT_ACTIVE_PLUGINS_1514_MIGRATION] === true;
+  if (!staleProfileShape) return;
+
+  config.disabledPlugins = disabled.filter((name) => !isDefaultActive1523Plugin(name));
+  config.migrations = { ...(config.migrations ?? {}), [marker]: true };
+  process.stderr.write(
+    `[maw] config.disabledPlugins migration (#1523): re-enabled shell integration plugins ` +
+    `${promoted.join(", ")}. Disable them again with \`maw plugin disable <name>\` if intentional.\n`,
+  );
+  persistLoadedConfig("config.disabledPlugins migration (#1523)");
+}
+
 export function loadConfig(): MawConfig {
   if (cached) return cached;
   try {
@@ -178,6 +205,7 @@ export function loadConfig(): MawConfig {
   }
   maybeMigrateDefaultActivePlugins(cached);
   maybeMigrateSplitTopAliasPlugin(cached);
+  maybeMigrateShellenvStandardPlugin(cached);
   // #736 Phase 1.1 — pre-populate config.agents from fleet at loadConfig time
   // so federation routing (`maw hey <oracle>`) sees fleet-known targets even
   // before their first wake. Additive only: hand-tuned config.agents entries

--- a/src/plugin/default-active.ts
+++ b/src/plugin/default-active.ts
@@ -33,8 +33,20 @@ export const DEFAULT_ACTIVE_PLUGINS_1514 = [
 
 export const DEFAULT_ACTIVE_PLUGINS_1514_MIGRATION = "defaultActivePlugins1514";
 
+/**
+ * #1523 follow-up: shellenv powers direnv/shell integration and should be part
+ * of the standard operator surface. Stale profile-generated disabled lists can
+ * hide it and make every shell action print an installed-but-disabled hint.
+ */
+export const DEFAULT_ACTIVE_PLUGINS_1523 = [
+  "shellenv",
+] as const;
+
+export const DEFAULT_ACTIVE_PLUGINS_1523_MIGRATION = "defaultActivePlugins1523";
+
 const DEFAULT_ACTIVE_SET = new Set<string>(DEFAULT_ACTIVE_PLUGINS_1500);
 const DEFAULT_ACTIVE_1514_SET = new Set<string>(DEFAULT_ACTIVE_PLUGINS_1514);
+const DEFAULT_ACTIVE_1523_SET = new Set<string>(DEFAULT_ACTIVE_PLUGINS_1523);
 
 export function isDefaultActivePlugin(name: string): boolean {
   return DEFAULT_ACTIVE_SET.has(name);
@@ -42,4 +54,8 @@ export function isDefaultActivePlugin(name: string): boolean {
 
 export function isDefaultActive1514Plugin(name: string): boolean {
   return DEFAULT_ACTIVE_1514_SET.has(name);
+}
+
+export function isDefaultActive1523Plugin(name: string): boolean {
+  return DEFAULT_ACTIVE_1523_SET.has(name);
 }

--- a/src/plugin/default-active.ts
+++ b/src/plugin/default-active.ts
@@ -44,9 +44,21 @@ export const DEFAULT_ACTIVE_PLUGINS_1523 = [
 
 export const DEFAULT_ACTIVE_PLUGINS_1523_MIGRATION = "defaultActivePlugins1523";
 
+/**
+ * #1524 follow-up: completions are baseline CLI ergonomics for the 80+ plugin
+ * surface. Keep the generator callable under the standard profile and heal
+ * stale profile-generated disabled lists that hide it.
+ */
+export const DEFAULT_ACTIVE_PLUGINS_1524 = [
+  "completions",
+] as const;
+
+export const DEFAULT_ACTIVE_PLUGINS_1524_MIGRATION = "defaultActivePlugins1524";
+
 const DEFAULT_ACTIVE_SET = new Set<string>(DEFAULT_ACTIVE_PLUGINS_1500);
 const DEFAULT_ACTIVE_1514_SET = new Set<string>(DEFAULT_ACTIVE_PLUGINS_1514);
 const DEFAULT_ACTIVE_1523_SET = new Set<string>(DEFAULT_ACTIVE_PLUGINS_1523);
+const DEFAULT_ACTIVE_1524_SET = new Set<string>(DEFAULT_ACTIVE_PLUGINS_1524);
 
 export function isDefaultActivePlugin(name: string): boolean {
   return DEFAULT_ACTIVE_SET.has(name);
@@ -58,4 +70,8 @@ export function isDefaultActive1514Plugin(name: string): boolean {
 
 export function isDefaultActive1523Plugin(name: string): boolean {
   return DEFAULT_ACTIVE_1523_SET.has(name);
+}
+
+export function isDefaultActive1524Plugin(name: string): boolean {
+  return DEFAULT_ACTIVE_1524_SET.has(name);
 }

--- a/src/vendor/mpr-plugins/completions/impl.ts
+++ b/src/vendor/mpr-plugins/completions/impl.ts
@@ -1,67 +1,203 @@
 import { readdirSync, readFileSync } from "fs";
-import { join, dirname } from "path";
+import { join } from "path";
 import { FLEET_DIR } from "maw-js/sdk";
+import { discoverPackages } from "maw-js/plugin/registry";
 
-// Auto-discover commands from src/commands/*.ts
-// No manual list — add a file, it shows up in completions
-const SKIP = new Set(["completions"]); // don't list ourselves
-const ALIASES: Record<string, string[]> = {
-  comm: ["ls", "peek", "hey"],        // comm.ts exports 3 commands
-  fleet: ["fleet"],                     // fleet subcommands handled separately
-  "fleet-init": [],                     // accessed via "fleet init"
-  sleep: ["sleep"],
-  wake: ["wake"],
-  done: ["done"],
-  "talk-to": ["talk-to"],
-};
-const EXTRA = ["stop", "serve", "create-view", "about"]; // aliases defined in cli.ts router
+const CORE_COMMANDS = [
+  "hey", "send",
+  "plugins", "plugin", "artifacts", "artifact",
+  "agents", "agent", "audit", "serve",
+  "update", "upgrade", "version",
+];
 
-function discoverCommands(): string[] {
-  try {
-    const dir = join(dirname(new URL(import.meta.url).pathname), ".");
-    const files = readdirSync(dir).filter(f => f.endsWith(".ts") && !SKIP.has(f.replace(".ts", "")));
-    const cmds = new Set<string>();
-    for (const f of files) {
-      const name = f.replace(".ts", "");
-      const aliases = ALIASES[name];
-      if (aliases) {
-        for (const a of aliases) cmds.add(a);
-      } else {
-        cmds.add(name);
-      }
-    }
-    for (const e of EXTRA) cmds.add(e);
-    return [...cmds].sort();
-  } catch {
-    // Fallback if dir scan fails (bundled)
-    return ["ls", "peek", "hey", "wake", "fleet", "stop", "done", "overview",
-      "about", "oracle", "pulse", "view", "tab", "rename", "talk-to",
-      "workon", "park", "resume", "inbox", "contacts", "serve"];
-  }
+const TOP_ALIASES = [
+  "a", "kill", "split", "open", "close", "t", "layout", "zoom",
+  "panes", "cleanup", "tile", "bring", "b", "ls", "wake", "new", "preflight",
+];
+
+const HELP = `usage: maw completions <commands|oracles|windows|zsh|bash|fish>
+
+Generate maw shell completions or dynamic completion data.
+
+Install examples:
+  zsh:  mkdir -p ~/.zsh/completions && maw completions zsh > ~/.zsh/completions/_maw
+        add to ~/.zshrc before compinit: fpath=(~/.zsh/completions $fpath)
+  bash: maw completions bash > ~/.maw-completion.bash
+        add to ~/.bashrc: source ~/.maw-completion.bash
+  fish: mkdir -p ~/.config/fish/completions && maw completions fish > ~/.config/fish/completions/maw.fish
+
+Data subcommands:
+  commands   command names for first-position completion
+  oracles    oracle names from fleet configs
+  windows    tmux window/session names from fleet configs`;
+
+function pluginCliNames(p: ReturnType<typeof discoverPackages>[number]): string[] {
+  if (p.disabled) return [];
+  if (p.manifest.cli) return [
+    p.manifest.cli.command,
+    ...(p.manifest.cli.aliases ?? []),
+  ];
+  if (p.kind === "ts" && p.entryPath) return [p.manifest.name];
+  if (p.kind === "wasm" && p.wasmPath) return [p.manifest.name];
+  return [];
 }
 
-export async function cmdCompletions(sub: string) {
-  if (sub === "commands") {
-    console.log(discoverCommands().join(" "));
-  } else if (sub === "oracles" || sub === "windows") {
-    const fleetDir = FLEET_DIR;
-    const names = new Set<string>();
-    try {
-      for (const f of readdirSync(fleetDir).filter(f => f.endsWith(".json") && !f.endsWith(".disabled"))) {
-        const config = JSON.parse(readFileSync(join(fleetDir, f), "utf-8"));
-        for (const w of (config.windows || [])) {
-          if (sub === "oracles") {
-            if (w.name.endsWith("-oracle")) names.add(w.name.replace(/-oracle$/, ""));
-          } else {
-            names.add(w.name);
-          }
+function discoverCommands(): string[] {
+  const cmds = new Set<string>([...CORE_COMMANDS, ...TOP_ALIASES]);
+  try {
+    for (const plugin of discoverPackages()) {
+      for (const name of pluginCliNames(plugin)) cmds.add(name);
+    }
+  } catch {
+    // Fallback if plugin discovery fails during early shell init.
+    for (const name of ["ls", "peek", "hey", "wake", "bring", "b", "fleet", "tile", "team", "plugin", "serve"]) {
+      cmds.add(name);
+    }
+  }
+  return [...cmds].filter(Boolean).sort();
+}
+
+function completionTargets(kind: "oracles" | "windows"): string[] {
+  const names = new Set<string>();
+  try {
+    for (const f of readdirSync(FLEET_DIR).filter(f => f.endsWith(".json") && !f.endsWith(".disabled"))) {
+      const config = JSON.parse(readFileSync(join(FLEET_DIR, f), "utf-8"));
+      for (const w of (config.windows || [])) {
+        if (kind === "oracles") {
+          if (w.name.endsWith("-oracle")) names.add(w.name.replace(/-oracle$/, ""));
+        } else if (typeof w.name === "string") {
+          names.add(w.name);
         }
       }
-    } catch { /* expected: tmux may not be running */ }
-    console.log([...names].sort().join("\n"));
-  } else if (sub === "fleet") {
+    }
+  } catch { /* expected: fleet or tmux may not be initialized yet */ }
+  return [...names].sort();
+}
+
+const ZSH_COMPLETION = `#compdef maw
+
+_maw_dynamic_words() {
+  local out
+  out=(\${(f)"$(maw completions "$1" 2>/dev/null)"})
+  print -l -- \${out[@]}
+}
+
+_maw_oracles() {
+  local -a oracles
+  oracles=(\${(f)"$(maw completions oracles 2>/dev/null)"})
+  _describe 'oracle' oracles
+}
+
+_maw_windows() {
+  local -a windows
+  windows=(\${(f)"$(maw completions windows 2>/dev/null)"})
+  _describe 'window' windows
+}
+
+_maw() {
+  local curcontext="$curcontext" state line
+  typeset -A opt_args
+
+  _arguments -C \\
+    '1:command:->cmd' \\
+    '*::arg:->args'
+
+  case $state in
+    cmd)
+      local -a commands oracles all
+      commands=(\${(f)"$(maw completions commands 2>/dev/null)"})
+      oracles=(\${(f)"$(maw completions oracles 2>/dev/null)"})
+      all=(\${commands[@]})
+      for o in \${oracles[@]}; do all+=("$o:Oracle (peek/send shorthand)"); done
+      _describe 'command' all
+      ;;
+    args)
+      case $line[1] in
+        peek|see|a|attach|bring|b|hey|send|tell|done|finish)
+          _maw_windows
+          ;;
+        wake|about|info)
+          _maw_oracles
+          ;;
+        completions)
+          _values 'completion mode' commands oracles windows zsh bash fish --help
+          ;;
+        plugin|plugins)
+          _values 'plugin action' ls list enable disable info standard full lean nuke
+          ;;
+        serve)
+          _message 'port (default: 3456)'
+          ;;
+        *)
+          _message 'argument'
+          ;;
+      esac
+      ;;
+  esac
+}
+
+_maw "$@"`;
+
+const BASH_COMPLETION = `# maw bash completion
+_maw_complete() {
+  local cur cmd words
+  COMPREPLY=()
+  cur="\${COMP_WORDS[COMP_CWORD]}"
+
+  if [[ $COMP_CWORD -eq 1 ]]; then
+    words="$(maw completions commands 2>/dev/null)"
+    COMPREPLY=( $(compgen -W "$words" -- "$cur") )
+    return 0
+  fi
+
+  cmd="\${COMP_WORDS[1]}"
+  case "$cmd" in
+    peek|see|a|attach|bring|b|hey|send|tell|done|finish)
+      words="$(maw completions windows 2>/dev/null)"
+      ;;
+    wake|about|info)
+      words="$(maw completions oracles 2>/dev/null)"
+      ;;
+    completions)
+      words="commands oracles windows zsh bash fish --help"
+      ;;
+    plugin|plugins)
+      words="ls list enable disable info standard full lean nuke"
+      ;;
+    *)
+      words=""
+      ;;
+  esac
+  COMPREPLY=( $(compgen -W "$words" -- "$cur") )
+}
+complete -F _maw_complete maw`;
+
+const FISH_COMPLETION = `# maw fish completion
+complete -c maw -f -n '__fish_use_subcommand' -a '(maw completions commands 2>/dev/null)'
+complete -c maw -f -n '__fish_seen_subcommand_from wake about info' -a '(maw completions oracles 2>/dev/null)'
+complete -c maw -f -n '__fish_seen_subcommand_from peek see a attach bring b hey send tell done finish' -a '(maw completions windows 2>/dev/null)'
+complete -c maw -f -n '__fish_seen_subcommand_from completions' -a 'commands oracles windows zsh bash fish --help'`;
+
+export async function cmdCompletions(sub?: string) {
+  const mode = (sub ?? "--help").toLowerCase();
+  if (mode === "--help" || mode === "-h" || mode === "help") {
+    console.log(HELP);
+  } else if (mode === "commands") {
+    console.log(discoverCommands().join(" "));
+  } else if (mode === "oracles" || mode === "windows") {
+    console.log(completionTargets(mode).join("\n"));
+  } else if (mode === "fleet") {
     console.log("init ls renumber validate sync");
-  } else if (sub === "pulse") {
+  } else if (mode === "pulse") {
     console.log("add ls list");
+  } else if (mode === "zsh") {
+    console.log(ZSH_COMPLETION);
+  } else if (mode === "bash") {
+    console.log(BASH_COMPLETION);
+  } else if (mode === "fish") {
+    console.log(FISH_COMPLETION);
+  } else {
+    console.error(HELP);
+    throw new Error(`unknown completion mode: ${sub}`);
   }
 }

--- a/src/vendor/mpr-plugins/completions/plugin.json
+++ b/src/vendor/mpr-plugins/completions/plugin.json
@@ -9,7 +9,8 @@
     "command": "completions",
     "help": "maw completions [shell] — Generate shell completions for maw CLI"
   },
-  "weight": 50,
+  "weight": 10,
+  "tier": "standard",
   "license": "MIT",
   "schemaVersion": 1
 }

--- a/src/vendor/mpr-plugins/completions/registry.meta.json
+++ b/src/vendor/mpr-plugins/completions/registry.meta.json
@@ -7,5 +7,5 @@
   "license": "MIT",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
   "addedAt": "2026-04-29T01:39:35Z",
-  "tier": "extra"
+  "tier": "standard"
 }

--- a/src/vendor/mpr-plugins/shellenv/plugin.json
+++ b/src/vendor/mpr-plugins/shellenv/plugin.json
@@ -8,6 +8,8 @@
   "homepage": "https://github.com/Soul-Brews-Studio/maw-shellenv",
   "sdk": "^1.0.0-alpha",
   "target": "js",
+  "weight": 10,
+  "tier": "standard",
   "capabilities": [],
   "schemaVersion": 1,
   "entry": "./src/index.ts"

--- a/test/isolated/plugin-default-active-migration.test.ts
+++ b/test/isolated/plugin-default-active-migration.test.ts
@@ -11,6 +11,7 @@ import { spawnSync } from "child_process";
 import {
   DEFAULT_ACTIVE_PLUGINS_1500_MIGRATION,
   DEFAULT_ACTIVE_PLUGINS_1514_MIGRATION,
+  DEFAULT_ACTIVE_PLUGINS_1523_MIGRATION,
 } from "../../src/plugin/default-active";
 
 const REPO_ROOT = join(import.meta.dir, "..", "..");
@@ -144,6 +145,53 @@ describe("#1500 default-active plugin migration", () => {
     const disk = readConfig(home);
     expect(disk.disabledPlugins).toEqual(["split"]);
     expect(disk.migrations?.[DEFAULT_ACTIVE_PLUGINS_1514_MIGRATION]).toBeUndefined();
+  });
+
+  test("#1523 re-enables shellenv when earlier default-active migrations already healed a stale profile list", () => {
+    const home = makeHome({
+      host: "local",
+      port: 3456,
+      oracleUrl: "http://localhost:47779",
+      env: {},
+      commands: { default: "claude" },
+      sessions: {},
+      migrations: {
+        [DEFAULT_ACTIVE_PLUGINS_1500_MIGRATION]: true,
+        [DEFAULT_ACTIVE_PLUGINS_1514_MIGRATION]: true,
+      },
+      disabledPlugins: ["shellenv", "costs"],
+    });
+
+    const result = loadInSubprocess(home);
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain("config.disabledPlugins migration (#1523)");
+
+    const disk = readConfig(home);
+    expect(disk.disabledPlugins).not.toContain("shellenv");
+    expect(disk.disabledPlugins).toContain("costs");
+    expect(disk.migrations?.[DEFAULT_ACTIVE_PLUGINS_1500_MIGRATION]).toBe(true);
+    expect(disk.migrations?.[DEFAULT_ACTIVE_PLUGINS_1514_MIGRATION]).toBe(true);
+    expect(disk.migrations?.[DEFAULT_ACTIVE_PLUGINS_1523_MIGRATION]).toBe(true);
+  });
+
+  test("#1523 preserves a small manual shellenv disable list", () => {
+    const home = makeHome({
+      host: "local",
+      port: 3456,
+      oracleUrl: "http://localhost:47779",
+      env: {},
+      commands: { default: "claude" },
+      sessions: {},
+      disabledPlugins: ["shellenv"],
+    });
+
+    const result = loadInSubprocess(home);
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toContain("config.disabledPlugins migration (#1523)");
+
+    const disk = readConfig(home);
+    expect(disk.disabledPlugins).toEqual(["shellenv"]);
+    expect(disk.migrations?.[DEFAULT_ACTIVE_PLUGINS_1523_MIGRATION]).toBeUndefined();
   });
 
   test("typing a disabled installed plugin explains the real fix", () => {

--- a/test/isolated/plugin-default-active-migration.test.ts
+++ b/test/isolated/plugin-default-active-migration.test.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_ACTIVE_PLUGINS_1500_MIGRATION,
   DEFAULT_ACTIVE_PLUGINS_1514_MIGRATION,
   DEFAULT_ACTIVE_PLUGINS_1523_MIGRATION,
+  DEFAULT_ACTIVE_PLUGINS_1524_MIGRATION,
 } from "../../src/plugin/default-active";
 
 const REPO_ROOT = join(import.meta.dir, "..", "..");
@@ -194,6 +195,52 @@ describe("#1500 default-active plugin migration", () => {
     expect(disk.migrations?.[DEFAULT_ACTIVE_PLUGINS_1523_MIGRATION]).toBeUndefined();
   });
 
+  test("#1524 re-enables completions when prior default-active migrations already healed a stale profile list", () => {
+    const home = makeHome({
+      host: "local",
+      port: 3456,
+      oracleUrl: "http://localhost:47779",
+      env: {},
+      commands: { default: "claude" },
+      sessions: {},
+      migrations: {
+        [DEFAULT_ACTIVE_PLUGINS_1500_MIGRATION]: true,
+        [DEFAULT_ACTIVE_PLUGINS_1514_MIGRATION]: true,
+        [DEFAULT_ACTIVE_PLUGINS_1523_MIGRATION]: true,
+      },
+      disabledPlugins: ["completions", "costs"],
+    });
+
+    const result = loadInSubprocess(home);
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain("config.disabledPlugins migration (#1524)");
+
+    const disk = readConfig(home);
+    expect(disk.disabledPlugins).not.toContain("completions");
+    expect(disk.disabledPlugins).toContain("costs");
+    expect(disk.migrations?.[DEFAULT_ACTIVE_PLUGINS_1524_MIGRATION]).toBe(true);
+  });
+
+  test("#1524 preserves a small manual completions disable list", () => {
+    const home = makeHome({
+      host: "local",
+      port: 3456,
+      oracleUrl: "http://localhost:47779",
+      env: {},
+      commands: { default: "claude" },
+      sessions: {},
+      disabledPlugins: ["completions"],
+    });
+
+    const result = loadInSubprocess(home);
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toContain("config.disabledPlugins migration (#1524)");
+
+    const disk = readConfig(home);
+    expect(disk.disabledPlugins).toEqual(["completions"]);
+    expect(disk.migrations?.[DEFAULT_ACTIVE_PLUGINS_1524_MIGRATION]).toBeUndefined();
+  });
+
   test("typing a disabled installed plugin explains the real fix", () => {
     const home = makeHome({
       host: "local",
@@ -221,5 +268,85 @@ describe("#1500 default-active plugin migration", () => {
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("'costs' is installed but disabled");
     expect(result.stderr).toContain("maw plugin enable costs");
+  });
+
+  test("typing disabled completions prints enable hint instead of self-suggesting", () => {
+    const home = makeHome({
+      host: "local",
+      port: 3456,
+      oracleUrl: "http://localhost:47779",
+      env: {},
+      commands: { default: "claude" },
+      sessions: {},
+      disabledPlugins: ["completions"],
+    });
+    const pluginDir = makePluginDir();
+
+    const result = spawnSync("bun", ["src/cli.ts", "--quiet", "completions"], {
+      cwd: REPO_ROOT,
+      env: {
+        ...process.env,
+        MAW_HOME: home,
+        MAW_PLUGINS_DIR: pluginDir,
+        MAW_TEST_MODE: "1",
+      },
+      encoding: "utf-8",
+      timeout: 10_000,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("'completions' is installed but disabled");
+    expect(result.stderr).toContain("maw plugin enable completions");
+    expect(result.stderr).not.toContain("did you mean: completions");
+  });
+
+  test("completions plugin emits command list plus zsh/bash scripts", () => {
+    const home = makeHome({
+      host: "local",
+      port: 3456,
+      oracleUrl: "http://localhost:47779",
+      env: {},
+      commands: { default: "claude" },
+      sessions: {},
+    });
+    const pluginDir = makePluginDir();
+    const env = {
+      ...process.env,
+      MAW_HOME: home,
+      MAW_PLUGINS_DIR: pluginDir,
+      MAW_TEST_MODE: "1",
+      MAW_QUIET: "1",
+    };
+
+    const commands = spawnSync("bun", ["src/cli.ts", "--quiet", "completions", "commands"], {
+      cwd: REPO_ROOT,
+      env,
+      encoding: "utf-8",
+      timeout: 10_000,
+    });
+    expect(commands.status).toBe(0);
+    expect(commands.stdout).toContain("completions");
+    expect(commands.stdout).toContain("bring");
+    expect(commands.stdout).toContain("plugin");
+
+    const zsh = spawnSync("bun", ["src/cli.ts", "--quiet", "completions", "zsh"], {
+      cwd: REPO_ROOT,
+      env,
+      encoding: "utf-8",
+      timeout: 10_000,
+    });
+    expect(zsh.status).toBe(0);
+    expect(zsh.stdout).toContain("#compdef maw");
+    expect(zsh.stdout).toContain("maw completions windows");
+
+    const bash = spawnSync("bun", ["src/cli.ts", "--quiet", "completions", "bash"], {
+      cwd: REPO_ROOT,
+      env,
+      encoding: "utf-8",
+      timeout: 10_000,
+    });
+    expect(bash.status).toBe(0);
+    expect(bash.stdout).toContain("complete -F _maw_complete maw");
+    expect(bash.stdout).toContain("maw completions commands");
   });
 });


### PR DESCRIPTION
## Summary
- promote vendored shellenv to the standard plugin surface
- migrate stale profile-generated disabled lists that still hide shellenv
- promote completions to standard and migrate stale disables
- make `maw completions` emit commands plus zsh/bash/fish scripts with install guidance
- lock disabled-known completions to print `maw plugin enable completions` instead of self-suggesting

## Issues
Closes #1523
Closes #1524

## Test plan
- `rtk bun test test/hub-config.test.ts test/isolated/plugin-default-active-migration.test.ts --path-ignore-patterns '**/agents/**'`
- `rtk bun run test:mock-smoke`
- `MAW_TEST_MODE=1 rtk bun test src/transports/scout-integration.test.ts test/peer-exec.integration.test.ts --path-ignore-patterns '**/agents/**'`
- `rtk bun run build`
- `bun src/cli.ts --quiet completions bash | bash -n`
- `bun src/cli.ts --quiet completions zsh | zsh -n`

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.