### PR TITLE
release: v26.5.16-alpha.2363

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.16-alpha.2362",
+  "version": "26.5.16-alpha.2363",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts v26.5.16-alpha.2363 on merge via calver-release.yml.

Includes merged alpha fixes:
- #1522 hub workspace warning reasons
- #1525 shellenv + completions standard/default-active ergonomics

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.