### PR TITLE
ux(plugin): sort plugin ls tiers alphabetically

### DIFF
--- a/src/commands/shared/plugins-ls-info.ts
+++ b/src/commands/shared/plugins-ls-info.ts
@@ -74,6 +74,7 @@ export function doLs(json: boolean, showAll: boolean, discover: () => LoadedPlug
   }
 
   for (const tier of tiers) {
+    tier.plugins.sort((a, b) => a.manifest.name.localeCompare(b.manifest.name));
     if (tier.plugins.length === 0) continue;
     console.log(`\n\x1b[1m${tier.label}\x1b[0m (${tier.plugins.length})`);
     const rows = tier.plugins.map(p => {

--- a/test/isolated/plugin-ls-sort.test.ts
+++ b/test/isolated/plugin-ls-sort.test.ts
@@ -1,0 +1,67 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { spawnSync } from "child_process";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+const homes: string[] = [];
+
+function makeHome(): string {
+  const home = mkdtempSync(join(tmpdir(), "maw-plugin-ls-sort-"));
+  homes.push(home);
+  const configDir = join(home, "config");
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(join(configDir, "maw.config.json"), JSON.stringify({
+    host: "local",
+    port: 3456,
+    oracleUrl: "http://localhost:47779",
+    env: {},
+    commands: { default: "claude" },
+    sessions: {},
+  }) + "\n");
+  return home;
+}
+
+afterAll(() => {
+  for (const home of homes) rmSync(home, { recursive: true, force: true });
+});
+
+describe("plugin ls", () => {
+  test("sorts each tier alphabetically by plugin name", () => {
+    const home = makeHome();
+    const script = `
+      const { doLs } = await import("${REPO_ROOT}/src/commands/shared/plugins-ls-info.ts");
+      const plugin = (name, tier) => ({
+        kind: "ts",
+        dir: "/tmp/" + name,
+        entryPath: "/tmp/" + name + "/index.ts",
+        manifest: {
+          name,
+          version: "1.0.0",
+          sdk: "^1.0.0",
+          tier,
+          entry: "./index.ts",
+          cli: { command: name },
+        },
+      });
+      doLs(false, true, () => [
+        plugin("zeta", "core"),
+        plugin("alpha", "core"),
+        plugin("beta", "standard"),
+        plugin("aardvark", "standard"),
+      ]);
+    `;
+
+    const result = spawnSync("bun", ["-e", script], {
+      cwd: REPO_ROOT,
+      env: { ...process.env, MAW_HOME: home, MAW_TEST_MODE: "1", MAW_QUIET: "1" },
+      encoding: "utf-8",
+      timeout: 10_000,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.indexOf("alpha")).toBeLessThan(result.stdout.indexOf("zeta"));
+    expect(result.stdout.indexOf("aardvark")).toBeLessThan(result.stdout.indexOf("beta"));
+  });
+});


### PR DESCRIPTION
## Summary
- sort each `maw plugin ls` tier bucket by plugin name before rendering
- add an isolated regression test for core/standard ordering

## Issue
Closes #1528

## Test plan
- `rtk bun test test/isolated/plugin-ls-sort.test.ts test/isolated/plugin-default-active-migration.test.ts --path-ignore-patterns '**/agents/**'`
- `rtk bun run build`
- `rtk bun run test:mock-smoke`
- `bun link`
- `maw --version`
- `maw plugin ls` verified core/standard/extra sorted A→Z locally

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.