### PR TITLE
release: v26.5.16-alpha.2364

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.16-alpha.2363",
+  "version": "26.5.16-alpha.2364",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts v26.5.16-alpha.2364 on merge via calver-release.yml.

Includes merged alpha fix:
- #1529 / #1528 sorted `maw plugin ls` tier groups

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.