### PR TITLE
fix(calver): keep alpha suffixes valid HHMM

### DIFF
--- a/scripts/calver.ts
+++ b/scripts/calver.ts
@@ -20,11 +20,9 @@
 // cadence.
 //
 // Cutover note: the legacy monotonic counter produced low integers
-// (alpha.0 through alpha.~50). Today's wall-clock HMM at any post-midnight
-// time is strictly greater (`30` > legacy `48` is false, but `100` > `48`
-// is true; in practice merge-time HMM values are always large enough that
-// no downgrade occurs). The `--check` path can be used to verify before
-// merge.
+// (alpha.0 through alpha.~50). HHMM is the invariant for alpha/beta suffixes:
+// if same-base HHMM would be a semver downgrade after midnight, roll the
+// CalVer base forward instead of emitting an impossible suffix like 2360.
 //
 // Usage:
 //   bun scripts/calver.ts                  → 26.4.18-alpha.{HMM}
@@ -47,7 +45,7 @@ function parseArgs(argv: string[]): Args {
     else if (a === "--beta") args.channel = "beta";
     else if (a === "--check" || a === "--dry-run") args.check = true;
     else if (a === "--hour") {
-      console.error("--hour deprecated as of #766; CalVer now uses tag-walk monotonic counter");
+      console.error("--hour deprecated as of #766; CalVer now uses wall-clock HMM suffixes");
       process.exit(2);
     }
     else if (a === "-h" || a === "--help") {
@@ -190,11 +188,10 @@ export function maxAlphaFromTags(base: string, tags: string[]): number {
 }
 
 /**
- * #784: walk package.json.version as an additional source-of-truth for the
- * monotonic counter. Post-#767, alpha releases merge to the `alpha` branch,
- * but `calver-release.yml` only fires on push to `main` — so no git tags get
- * created for in-flight alphas. Without this, tag-walk returns -1 and we
- * regress to alpha.0 on every alpha-branch run.
+ * #784: walk package.json.version as an additional source-of-truth for
+ * anti-downgrade checks. Post-#767, alpha releases merge to the `alpha`
+ * branch, but `calver-release.yml` only fires on push to `main` — so no git
+ * tags get created for in-flight alphas.
  *
  * Parses `vYY.M.D-{channel}.{N}` (with or without leading "v") and returns N
  * only if base+channel match today's. Rejects non-integer suffixes and
@@ -233,6 +230,15 @@ export function hhmmStamp(now: Date): string {
   return String(now.getHours() * 100 + now.getMinutes());
 }
 
+export function nextCalendarBase(base: string): string {
+  if (!isValidCalendarDate(base)) {
+    throw new Error(`nextCalendarBase expects a real YY.M.D date, got "${base}"`);
+  }
+  const [yy, m, d] = base.split(".").map((x) => parseInt(x, 10));
+  const next = new Date(2000 + yy, m - 1, d + 1);
+  return `${next.getFullYear() % 100}.${next.getMonth() + 1}.${next.getDate()}`;
+}
+
 export function computeVersion(args: Args, tags: string[] = [], packageVersion: string = ""): string {
   const now = args.now ?? new Date();
   const todayBase = dateBase(now);
@@ -241,18 +247,16 @@ export function computeVersion(args: Args, tags: string[] = [], packageVersion: 
   const base = args.stable ? todayBase : effectiveBase(todayBase, packageVersion);
   if (args.stable) return base;
   const channel = args.channel ?? "alpha";
-  // HHMM is the preferred wall-clock stamp, but it is not strictly monotonic
-  // across midnight when package.json still carries the same CalVer base with
-  // a late-night suffix (for example 26.5.16-alpha.2356 at 00:27).
-  // Preserve wall-clock readability when possible, and fall back to max+1
-  // when tags/package.json prove that HHMM would be a semver downgrade.
   const stamp = parseInt(hhmmStamp(now), 10);
   const maxExisting = Math.max(
     maxNFromTags(base, channel, tags),
     maxNFromPackageJson(base, channel, packageVersion),
   );
-  const next = Math.max(stamp, maxExisting + 1);
-  return `${base}-${channel}.${next}`;
+  // HHMM suffixes must remain valid wall-clock stamps (max 2359). If the
+  // current HHMM would be a same-base semver downgrade after midnight, roll
+  // the CalVer base forward instead of reviving a monotonic counter.
+  const versionBase = stamp > maxExisting ? base : nextCalendarBase(base);
+  return `${versionBase}-${channel}.${stamp}`;
 }
 
 async function tagExists(version: string): Promise<boolean> {
@@ -265,8 +269,8 @@ async function main() {
   const now = args.now ?? new Date();
   const todayBase = dateBase(now);
 
-  // #784: read package.json once up front so its version participates in the
-  // source-of-truth set for the monotonic counter (see computeVersion).
+  // #784: read package.json once up front so its version participates in
+  // anti-downgrade checks (see computeVersion).
   const pkgPath = join(process.cwd(), "package.json");
   const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
 
@@ -306,7 +310,7 @@ async function main() {
   }
 
   if (await tagExists(version)) {
-    // Should never happen for alpha (we picked max+1) but stable can collide.
+    // Stable can collide; alpha/beta same-minute reruns can also collide.
     console.error(`\n❌ tag v${version} already exists`);
     if (args.stable) {
       console.error(`   → stable for today already cut; nothing to do`);

--- a/test/calver.test.ts
+++ b/test/calver.test.ts
@@ -10,6 +10,7 @@ import {
   maxAlphaFromTags,
   maxNFromPackageJson,
   maxNFromTags,
+  nextCalendarBase,
 } from "../scripts/calver";
 
 describe("calver dateBase", () => {
@@ -108,18 +109,30 @@ describe("calver computeVersion (HMM scheme)", () => {
     ).toBe("26.4.27-alpha.1200");
   });
 
-  it("#1504: alpha uses max+1 when post-midnight HMM would downgrade package.json", () => {
+  it("#1504/#1532: alpha rolls base forward when post-midnight HMM would downgrade package.json", () => {
     const may16_0027 = new Date(2026, 4, 16, 0, 27);
     expect(
       computeVersion({ stable: false, check: false, now: may16_0027 }, [], "26.5.16-alpha.2356"),
-    ).toBe("26.5.16-alpha.2357");
+    ).toBe("26.5.17-alpha.27");
   });
 
-  it("#1504: alpha uses max+1 when post-midnight HMM would downgrade tags", () => {
+  it("#1504/#1532: alpha rolls base forward when post-midnight HMM would downgrade tags", () => {
     const may16_0027 = new Date(2026, 4, 16, 0, 27);
     expect(
       computeVersion({ stable: false, check: false, now: may16_0027 }, ["v26.5.16-alpha.2358"]),
-    ).toBe("26.5.16-alpha.2359");
+    ).toBe("26.5.17-alpha.27");
+  });
+
+  it("#1532: never emits impossible HMM suffixes above 2359", () => {
+    const may16_0629 = new Date(2026, 4, 16, 6, 29);
+    const version = computeVersion(
+      { stable: false, check: false, now: may16_0629 },
+      ["v26.5.16-alpha.2364"],
+      "26.5.16-alpha.2364",
+    );
+    expect(version).toBe("26.5.17-alpha.629");
+    const suffix = Number(version.split(".").at(-1));
+    expect(suffix).toBeLessThanOrEqual(2359);
   });
 
   it("--stable ignores tags entirely", () => {
@@ -297,6 +310,17 @@ describe("calver isValidCalendarDate (#1015)", () => {
   it("malformed input fails", () => {
     expect(isValidCalendarDate("26.4")).toBe(false);
     expect(isValidCalendarDate("26.4.5.1")).toBe(false);
+  });
+});
+
+describe("calver nextCalendarBase (#1532)", () => {
+  it("advances within a month", () => {
+    expect(nextCalendarBase("26.5.16")).toBe("26.5.17");
+  });
+
+  it("advances across month and year boundaries", () => {
+    expect(nextCalendarBase("26.5.31")).toBe("26.6.1");
+    expect(nextCalendarBase("26.12.31")).toBe("27.1.1");
   });
 });
 


### PR DESCRIPTION
## Summary

- restore PR #923's invariant that alpha/beta suffixes are real wall-clock HMM values (`0..2359`)
- fix #1504 without resurrecting monotonic suffix overflow: when same-base HMM would downgrade after midnight, roll the CalVer base forward instead
- update calver tests to cover the invalid `alpha.2364` regression and the post-midnight downgrade case

## Root cause

PR #1505 / commits `79232795` and `1805cfc0` fixed a real post-midnight downgrade bug by using `Math.max(HMM, maxExisting + 1)`. That allowed semver to keep increasing, but after `2359` it stopped being HHMM and produced impossible versions like `v26.5.16-alpha.2364`.

## Fix shape

If current HMM is higher than the same-base max, keep the current base:

```text
26.5.16-alpha.629
```

If current HMM would be same-base lower/equal, roll the base:

```text
26.5.16-alpha.2356 + 00:27 → 26.5.17-alpha.27
```

## Verification

- `rtk bun test test/calver.test.ts --path-ignore-patterns '**/agents/**'`
- `TZ=Asia/Bangkok bun scripts/calver.ts --check` → `Target: v26.5.17-alpha.639  [alpha]`
- `rtk bun run build`

Fixes #1532.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
