### PR TITLE
fix(peers): expose daemon discovery rows

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -27,6 +27,7 @@ import { uploadApi } from "./upload";
 import { pairApi } from "./pair";
 import { consentApi } from "./consent";
 import { claudeFleetApi } from "./claude-fleet";
+import { peerDiscoveriesApi } from "./peers-discoveries";
 import { discoverPackages, invokePlugin } from "../plugin/registry";
 import { federationAuth, fromSigningAuth } from "../lib/elysia-auth";
 
@@ -71,7 +72,8 @@ export const api = new Elysia({ prefix: "/api" })
   .use(uploadApi)
   .use(pairApi)
   .use(consentApi)
-  .use(claudeFleetApi);
+  .use(claudeFleetApi)
+  .use(peerDiscoveriesApi);
 
 // Snapshot direct-handler routes before plugin auto-mount (#705)
 const directRoutes = new Set(

--- a/src/api/peers-discoveries.ts
+++ b/src/api/peers-discoveries.ts
@@ -1,0 +1,89 @@
+import { Elysia } from "elysia";
+import { getTransportRouter } from "../transports";
+import type { DiscoveredPeer } from "../transports/scout-state";
+
+export interface DiscoveryRow {
+  zid: string;
+  node: string;
+  oracle: string;
+  host: string;
+  locators: string[];
+  capabilities: string[];
+  oracles: string[];
+  firstSeen: string;
+  lastSeen: string;
+  seenRel: string;
+  paired: boolean;
+}
+
+export interface DiscoveryResponse {
+  ok: true;
+  total: number;
+  shown: number;
+  filtered: boolean;
+  peers: DiscoveryRow[];
+}
+
+export function toDiscoveryResponse(
+  peers: DiscoveredPeer[],
+  opts: { all?: boolean; limit?: number; now?: number } = {},
+): DiscoveryResponse {
+  const now = opts.now ?? Date.now();
+  const filtered = opts.all ? peers : peers.filter((p) => !p.paired);
+  const sorted = filtered
+    .slice()
+    .sort((a, b) => b.lastSeen - a.lastSeen || a.node.localeCompare(b.node));
+  const limit = opts.limit && opts.limit > 0 ? opts.limit : 50;
+  const shown = sorted.slice(0, limit);
+  return {
+    ok: true,
+    total: sorted.length,
+    shown: shown.length,
+    filtered: !opts.all,
+    peers: shown.map((p) => ({
+      zid: p.zid,
+      node: p.node,
+      oracle: p.oracle,
+      host: p.host,
+      locators: p.locators,
+      capabilities: p.capabilities,
+      oracles: p.oracles,
+      firstSeen: new Date(p.lastSeen).toISOString(),
+      lastSeen: new Date(p.lastSeen).toISOString(),
+      seenRel: relativeSeen(now - p.lastSeen),
+      paired: p.paired,
+    })),
+  };
+}
+
+export function createPeerDiscoveriesApi(
+  listPeers: () => DiscoveredPeer[] = () => getTransportRouter().listDiscoveredPeers() as DiscoveredPeer[],
+) {
+  return new Elysia().get("/peers/discoveries", ({ query, set }) => {
+    const all = query.all === "1" || query.all === "true";
+    const limit = query.limit === undefined
+      ? undefined
+      : Number(query.limit);
+    if (limit !== undefined && (!Number.isFinite(limit) || limit <= 0)) {
+      set.status = 400;
+      return {
+        ok: false,
+        error: "invalid_limit",
+        hint: "limit must be a positive number",
+      };
+    }
+    return toDiscoveryResponse(listPeers(), { all, limit });
+  });
+}
+
+export const peerDiscoveriesApi = createPeerDiscoveriesApi();
+
+function relativeSeen(deltaMs: number): string {
+  const seconds = Math.max(0, Math.floor(deltaMs / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  return `${Math.floor(hours / 24)}d`;
+}

--- a/src/core/transport/transport.ts
+++ b/src/core/transport/transport.ts
@@ -196,4 +196,19 @@ export class TransportRouter {
   status(): { name: string; connected: boolean }[] {
     return this.transports.map((t) => ({ name: t.name, connected: t.connected }));
   }
+
+  /** Collect discovery rows exposed by transports such as Scout. */
+  listDiscoveredPeers(): unknown[] {
+    const peers: unknown[] = [];
+    for (const transport of this.transports) {
+      const listPeers = (transport as Transport & { listPeers?: () => unknown[] }).listPeers;
+      if (typeof listPeers !== "function") continue;
+      try {
+        peers.push(...listPeers.call(transport));
+      } catch {
+        // Discovery should never break the router status/API surface.
+      }
+    }
+    return peers;
+  }
 }

--- a/src/vendor/mpr-plugins/peers/discovered.ts
+++ b/src/vendor/mpr-plugins/peers/discovered.ts
@@ -67,6 +67,14 @@ export async function fetchDiscoveries(opts: { all?: boolean; limit?: number } =
   }
   if (!res.ok) {
     const body = await safeJson(res);
+    if (res.status === 404) {
+      return {
+        ok: false,
+        error: "discovery_endpoint_missing",
+        hint: "daemon doesn't expose /api/peers/discoveries — restart `maw serve` after upgrading",
+        status: 404,
+      };
+    }
     return {
       ok: false,
       error: body?.error ?? `http_${res.status}`,

--- a/test/isolated/peer-discoveries-api.test.ts
+++ b/test/isolated/peer-discoveries-api.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Elysia } from "elysia";
+import type { DiscoveredPeer } from "../../src/transports/scout-state";
+import {
+  createPeerDiscoveriesApi,
+  toDiscoveryResponse,
+} from "../../src/api/peers-discoveries";
+
+const NOW = Date.parse("2026-05-16T00:00:00.000Z");
+
+function peer(overrides: Partial<DiscoveredPeer>): DiscoveredPeer {
+  return {
+    zid: "zid-a",
+    node: "m5",
+    host: "m5.local",
+    oracle: "mawjs",
+    locators: ["http://m5:3456"],
+    capabilities: ["pair", "send"],
+    oracles: ["mawjs-oracle"],
+    lastSeen: NOW - 5_000,
+    paired: false,
+    ...overrides,
+  };
+}
+
+describe("peer discoveries API (#1526)", () => {
+  test("filters paired peers by default and formats discovery rows", () => {
+    const resp = toDiscoveryResponse([
+      peer({ zid: "paired", node: "paired-node", paired: true }),
+      peer({ zid: "fresh", node: "fresh-node", lastSeen: NOW - 65_000 }),
+    ], { now: NOW });
+
+    expect(resp).toMatchObject({
+      ok: true,
+      total: 1,
+      shown: 1,
+      filtered: true,
+    });
+    expect(resp.peers[0]).toMatchObject({
+      zid: "fresh",
+      node: "fresh-node",
+      seenRel: "1m",
+      paired: false,
+    });
+  });
+
+  test("GET /api/peers/discoveries supports --all and --limit shape", async () => {
+    const app = new Elysia({ prefix: "/api" }).use(createPeerDiscoveriesApi(() => [
+      peer({ zid: "older", node: "older", lastSeen: NOW - 10_000 }),
+      peer({ zid: "newer", node: "newer", lastSeen: NOW - 1_000 }),
+    ]));
+
+    const res = await app.handle(new Request("http://local/api/peers/discoveries?all=1&limit=1"));
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.total).toBe(2);
+    expect(body.shown).toBe(1);
+    expect(body.filtered).toBe(false);
+    expect(body.peers[0].zid).toBe("newer");
+  });
+
+  test("GET /api/peers/discoveries rejects invalid limits", async () => {
+    const app = new Elysia({ prefix: "/api" }).use(createPeerDiscoveriesApi(() => []));
+    const res = await app.handle(new Request("http://local/api/peers/discoveries?limit=wat"));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ ok: false, error: "invalid_limit" });
+  });
+});
+
+describe("peer discoveries CLI client (#1526)", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("404 gets an actionable daemon-version hint instead of bare http_404", async () => {
+    globalThis.fetch = (async () => new Response("not found", { status: 404 })) as typeof fetch;
+    const { fetchDiscoveries } = await import("../../src/vendor/mpr-plugins/peers/discovered");
+    const resp = await fetchDiscoveries();
+    expect(resp).toMatchObject({
+      ok: false,
+      error: "discovery_endpoint_missing",
+      status: 404,
+    });
+    expect((resp as any).hint).toContain("restart `maw serve`");
+  });
+});


### PR DESCRIPTION
## Summary

- add `GET /api/peers/discoveries` so `maw peers list --discovered` no longer hits daemon 404
- expose Scout-discovered peers from the transport router, with paired filtering, `--all`, `--limit`, and stable row formatting
- improve old-daemon UX: a 404 now reports `discovery_endpoint_missing` with a restart/upgrade hint instead of bare `http_404`

## Verification

- `rtk bun test test/isolated/peer-discoveries-api.test.ts --path-ignore-patterns '**/agents/**'`
- `rtk bun test test/isolated/peer-discoveries-api.test.ts src/transports/scout-state.test.ts --path-ignore-patterns '**/agents/**'`
- `rtk bun run test:mock-smoke`
- `rtk bun run build`

Fixes #1526.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
