### PR TITLE
fix(plugin-tier): keep Oracle workflow verbs standard

### DIFF
--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -13,9 +13,11 @@ import {
   DEFAULT_ACTIVE_PLUGINS_1514_MIGRATION,
   DEFAULT_ACTIVE_PLUGINS_1523_MIGRATION,
   DEFAULT_ACTIVE_PLUGINS_1524_MIGRATION,
+  DEFAULT_ACTIVE_PLUGINS_1531_MIGRATION,
   isDefaultActive1514Plugin,
   isDefaultActive1523Plugin,
   isDefaultActive1524Plugin,
+  isDefaultActive1531Plugin,
   isDefaultActivePlugin,
 } from "../plugin/default-active";
 
@@ -157,6 +159,30 @@ function maybeMigrateCompletionsStandardPlugin(config: MawConfig): void {
   persistLoadedConfig("config.disabledPlugins migration (#1524)");
 }
 
+function maybeMigrateOracleWorkflowStandardPlugins(config: MawConfig): void {
+  const marker = DEFAULT_ACTIVE_PLUGINS_1531_MIGRATION;
+  if (config.migrations?.[marker]) return;
+  const disabled = config.disabledPlugins ?? [];
+  const promoted = disabled.filter(isDefaultActive1531Plugin);
+  if (promoted.length === 0) return;
+
+  const staleProfileShape =
+    disabled.length >= 20 ||
+    config.migrations?.[DEFAULT_ACTIVE_PLUGINS_1500_MIGRATION] === true ||
+    config.migrations?.[DEFAULT_ACTIVE_PLUGINS_1514_MIGRATION] === true ||
+    config.migrations?.[DEFAULT_ACTIVE_PLUGINS_1523_MIGRATION] === true ||
+    config.migrations?.[DEFAULT_ACTIVE_PLUGINS_1524_MIGRATION] === true;
+  if (!staleProfileShape) return;
+
+  config.disabledPlugins = disabled.filter((name) => !isDefaultActive1531Plugin(name));
+  config.migrations = { ...(config.migrations ?? {}), [marker]: true };
+  process.stderr.write(
+    `[maw] config.disabledPlugins migration (#1531): re-enabled Oracle workflow plugins ` +
+    `${promoted.join(", ")}. Disable them again with \`maw plugin disable <name>\` if intentional.\n`,
+  );
+  persistLoadedConfig("config.disabledPlugins migration (#1531)");
+}
+
 export function loadConfig(): MawConfig {
   if (cached) return cached;
   try {
@@ -232,6 +258,7 @@ export function loadConfig(): MawConfig {
   maybeMigrateSplitTopAliasPlugin(cached);
   maybeMigrateShellenvStandardPlugin(cached);
   maybeMigrateCompletionsStandardPlugin(cached);
+  maybeMigrateOracleWorkflowStandardPlugins(cached);
   // #736 Phase 1.1 — pre-populate config.agents from fleet at loadConfig time
   // so federation routing (`maw hey <oracle>`) sees fleet-known targets even
   // before their first wake. Additive only: hand-tuned config.agents entries

--- a/src/plugin/default-active.ts
+++ b/src/plugin/default-active.ts
@@ -55,10 +55,27 @@ export const DEFAULT_ACTIVE_PLUGINS_1524 = [
 
 export const DEFAULT_ACTIVE_PLUGINS_1524_MIGRATION = "defaultActivePlugins1524";
 
+/**
+ * #1531 follow-up: Oracle workflow and federation-discovery verbs are linked
+ * from day-to-day guidance. Stale profile-generated disabled lists should not
+ * make these commands look missing.
+ */
+export const DEFAULT_ACTIVE_PLUGINS_1531 = [
+  "learn",
+  "find",
+  "talk-to",
+  "project",
+  "workon",
+  "cleanup",
+] as const;
+
+export const DEFAULT_ACTIVE_PLUGINS_1531_MIGRATION = "defaultActivePlugins1531";
+
 const DEFAULT_ACTIVE_SET = new Set<string>(DEFAULT_ACTIVE_PLUGINS_1500);
 const DEFAULT_ACTIVE_1514_SET = new Set<string>(DEFAULT_ACTIVE_PLUGINS_1514);
 const DEFAULT_ACTIVE_1523_SET = new Set<string>(DEFAULT_ACTIVE_PLUGINS_1523);
 const DEFAULT_ACTIVE_1524_SET = new Set<string>(DEFAULT_ACTIVE_PLUGINS_1524);
+const DEFAULT_ACTIVE_1531_SET = new Set<string>(DEFAULT_ACTIVE_PLUGINS_1531);
 
 export function isDefaultActivePlugin(name: string): boolean {
   return DEFAULT_ACTIVE_SET.has(name);
@@ -74,4 +91,8 @@ export function isDefaultActive1523Plugin(name: string): boolean {
 
 export function isDefaultActive1524Plugin(name: string): boolean {
   return DEFAULT_ACTIVE_1524_SET.has(name);
+}
+
+export function isDefaultActive1531Plugin(name: string): boolean {
+  return DEFAULT_ACTIVE_1531_SET.has(name);
 }

--- a/src/vendor/mpr-plugins/cleanup/plugin.json
+++ b/src/vendor/mpr-plugins/cleanup/plugin.json
@@ -3,14 +3,15 @@
   "version": "1.1.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "Cleanup zombie agent panes and stale oracles.json entries.",
+  "description": "Clean zombie agent panes and prune stale Oracle registry entries.",
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "cleanup",
     "aliases": [],
     "help": "maw cleanup --zombie-agents [--yes] — kill orphan panes; maw cleanup --prune-stale [--yes|--ask|--dry-run] — prune dead oracles.json entries"
   },
-  "weight": 50,
+  "weight": 30,
   "license": "MIT",
-  "schemaVersion": 1
+  "schemaVersion": 1,
+  "tier": "standard"
 }

--- a/src/vendor/mpr-plugins/cleanup/registry.meta.json
+++ b/src/vendor/mpr-plugins/cleanup/registry.meta.json
@@ -2,10 +2,10 @@
   "version": "0.1.0",
   "source": "soul-brews-studio/maw-plugin-registry/cleanup@v0.1.0-cleanup",
   "sha256": "88b83b29d037f067a5591c88a3ea31f9acf5817e25c29c1700f3f28a02b2bfac",
-  "summary": "Cleanup zombie agent panes.",
+  "summary": "Clean zombie agent panes and prune stale Oracle registry entries.",
   "author": "Soul-Brews-Studio",
   "license": "MIT",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
   "addedAt": "2026-04-29T02:18:08Z",
-  "tier": "extra"
+  "tier": "standard"
 }

--- a/src/vendor/mpr-plugins/find/plugin.json
+++ b/src/vendor/mpr-plugins/find/plugin.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "Search across agents and fleet data.",
+  "description": "Search agents, sessions, and fleet metadata for matching Oracle context.",
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "find",
@@ -12,7 +12,8 @@
     ],
     "help": "maw find <keyword> [--oracle <name>] — search across agents and fleet data"
   },
-  "weight": 50,
+  "weight": 30,
   "license": "MIT",
-  "schemaVersion": 1
+  "schemaVersion": 1,
+  "tier": "standard"
 }

--- a/src/vendor/mpr-plugins/find/registry.meta.json
+++ b/src/vendor/mpr-plugins/find/registry.meta.json
@@ -2,10 +2,10 @@
   "version": "0.1.0",
   "source": "soul-brews-studio/maw-plugin-registry/find@v0.1.0-find",
   "sha256": "6d80a8fea7c1ef2a536e364b082b7025d6a4edeb8d61d01cc0b6e51c5c07fb4e",
-  "summary": "Search across agents and fleet data.",
+  "summary": "Search agents, sessions, and fleet metadata for matching Oracle context.",
   "author": "Soul-Brews-Studio",
   "license": "MIT",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
   "addedAt": "2026-04-29T01:40:01Z",
-  "tier": "extra"
+  "tier": "standard"
 }

--- a/src/vendor/mpr-plugins/learn/index.ts
+++ b/src/vendor/mpr-plugins/learn/index.ts
@@ -2,7 +2,7 @@ import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 
 export const command = {
   name: "learn",
-  description: "Scaffold (stub): explore a codebase with parallel agents.",
+  description: "Expose codebase exploration through the Oracle /learn workflow.",
 };
 
 /**

--- a/src/vendor/mpr-plugins/learn/plugin.json
+++ b/src/vendor/mpr-plugins/learn/plugin.json
@@ -3,17 +3,18 @@
   "version": "0.1.0-alpha.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "Scaffold (stub): explore a codebase with parallel agents. Full impl lives in the Oracle /learn skill — core plugin is a dispatcher shape only.",
+  "description": "Expose the maw learn verb for codebase exploration and route users to the Oracle /learn workflow while native execution lands.",
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "learn",
-    "help": "maw learn <repo> [--fast|--deep] — scaffold stub (impl pending, see Oracle skill /learn)",
+    "help": "maw learn <repo> [--fast|--deep] — explore a codebase via the Oracle /learn workflow",
     "flags": {
       "--fast": "boolean",
       "--deep": "boolean"
     }
   },
-  "weight": 50,
+  "weight": 30,
   "license": "MIT",
-  "schemaVersion": 1
+  "schemaVersion": 1,
+  "tier": "standard"
 }

--- a/src/vendor/mpr-plugins/learn/registry.meta.json
+++ b/src/vendor/mpr-plugins/learn/registry.meta.json
@@ -2,10 +2,10 @@
   "version": "0.1.0",
   "source": "soul-brews-studio/maw-plugin-registry/learn@v0.1.0-learn",
   "sha256": "777d6a193879e998b448a43e00279b2ce6d64bcb3f83c10ee6828ce1c92d37e5",
-  "summary": "Scaffold (stub): explore a codebase with parallel agents. Full impl lives in the Oracle /learn skill \u2014 core plugin is a dispatcher shape only.",
+  "summary": "Expose the maw learn verb for codebase exploration and route users to the Oracle /learn workflow while native execution lands.",
   "author": "Soul-Brews-Studio",
   "license": "MIT",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
   "addedAt": "2026-04-29T01:35:48Z",
-  "tier": "extra"
+  "tier": "standard"
 }

--- a/src/vendor/mpr-plugins/project/index.ts
+++ b/src/vendor/mpr-plugins/project/index.ts
@@ -2,7 +2,7 @@ import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 
 export const command = {
   name: "project",
-  description: "Scaffold (stub): clone and track external repos (learn/incubate/find/list).",
+  description: "Expose project discovery through the Oracle /project workflow.",
 };
 
 /**

--- a/src/vendor/mpr-plugins/project/plugin.json
+++ b/src/vendor/mpr-plugins/project/plugin.json
@@ -3,13 +3,14 @@
   "version": "0.1.0-alpha.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "Scaffold (stub): clone and track external repos (learn/incubate/find/list). Full impl lives in the Oracle /project skill — core plugin is a dispatcher shape only.",
+  "description": "Expose project learn/incubate/find/list verbs and route users to the Oracle /project workflow while native execution lands.",
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "project",
-    "help": "maw project <learn|incubate|find|list> ... — scaffold stub (impl pending, see Oracle skill /project)"
+    "help": "maw project <learn|incubate|find|list> ... — manage project discovery through the Oracle /project workflow"
   },
-  "weight": 50,
+  "weight": 30,
   "license": "MIT",
-  "schemaVersion": 1
+  "schemaVersion": 1,
+  "tier": "standard"
 }

--- a/src/vendor/mpr-plugins/project/registry.meta.json
+++ b/src/vendor/mpr-plugins/project/registry.meta.json
@@ -2,10 +2,10 @@
   "version": "0.1.0",
   "source": "soul-brews-studio/maw-plugin-registry/project@v0.1.0-project",
   "sha256": "9098f93596ae8228da6434a35a9cc349c0076c4400de12e66ad6b8496b8dbcef",
-  "summary": "Scaffold (stub): clone and track external repos (learn/incubate/find/list). Full impl lives in the Oracle /project skill \u2014 core plugin is a dispatcher shape only.",
+  "summary": "Expose project learn/incubate/find/list verbs and route users to the Oracle /project workflow while native execution lands.",
   "author": "Soul-Brews-Studio",
   "license": "MIT",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
   "addedAt": "2026-04-29T01:39:41Z",
-  "tier": "extra"
+  "tier": "standard"
 }

--- a/src/vendor/mpr-plugins/talk-to/plugin.json
+++ b/src/vendor/mpr-plugins/talk-to/plugin.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "Talk to a remote agent on another node.",
+  "description": "Send signed messages to another Oracle or agent through maw federation.",
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "talk-to",
@@ -16,7 +16,8 @@
       "--force": "boolean"
     }
   },
-  "weight": 50,
+  "weight": 30,
   "license": "MIT",
-  "schemaVersion": 1
+  "schemaVersion": 1,
+  "tier": "standard"
 }

--- a/src/vendor/mpr-plugins/talk-to/registry.meta.json
+++ b/src/vendor/mpr-plugins/talk-to/registry.meta.json
@@ -2,10 +2,10 @@
   "version": "0.1.0",
   "source": "soul-brews-studio/maw-plugin-registry/talk-to@v0.1.0-talk-to",
   "sha256": "786a372c425803c9f4fdd90add6cffa457a3198726023cf8521fdb84cf1459a7",
-  "summary": "Talk to a remote agent on another node.",
+  "summary": "Send signed messages to another Oracle or agent through maw federation.",
   "author": "Soul-Brews-Studio",
   "license": "MIT",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
   "addedAt": "2026-04-29T02:49:11Z",
-  "tier": "extra"
+  "tier": "standard"
 }

--- a/src/vendor/mpr-plugins/workon/plugin.json
+++ b/src/vendor/mpr-plugins/workon/plugin.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "Start working on a repo with optional task context.",
+  "description": "Open or resume work on a repository with optional task context.",
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "workon",
@@ -12,7 +12,8 @@
     ],
     "help": "maw workon <repo> [task]"
   },
-  "weight": 50,
+  "weight": 30,
   "license": "MIT",
-  "schemaVersion": 1
+  "schemaVersion": 1,
+  "tier": "standard"
 }

--- a/src/vendor/mpr-plugins/workon/registry.meta.json
+++ b/src/vendor/mpr-plugins/workon/registry.meta.json
@@ -2,10 +2,10 @@
   "version": "0.1.0",
   "source": "soul-brews-studio/maw-plugin-registry/workon@v0.1.0-workon",
   "sha256": "e404553ff41eeea3652784b286aa55645cbace499dd74072a8be0070560a9426",
-  "summary": "Start working on a repo with optional task context.",
+  "summary": "Open or resume work on a repository with optional task context.",
   "author": "Soul-Brews-Studio",
   "license": "MIT",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
   "addedAt": "2026-04-29T02:49:08Z",
-  "tier": "extra"
+  "tier": "standard"
 }

--- a/test/isolated/plugin-default-active-migration.test.ts
+++ b/test/isolated/plugin-default-active-migration.test.ts
@@ -13,6 +13,7 @@ import {
   DEFAULT_ACTIVE_PLUGINS_1514_MIGRATION,
   DEFAULT_ACTIVE_PLUGINS_1523_MIGRATION,
   DEFAULT_ACTIVE_PLUGINS_1524_MIGRATION,
+  DEFAULT_ACTIVE_PLUGINS_1531_MIGRATION,
 } from "../../src/plugin/default-active";
 
 const REPO_ROOT = join(import.meta.dir, "..", "..");
@@ -78,8 +79,12 @@ describe("#1500 default-active plugin migration", () => {
     expect(disk.disabledPlugins).not.toContain("fleet");
     expect(disk.disabledPlugins).not.toContain("pair");
     expect(disk.disabledPlugins).toContain("costs");
-    expect(disk.disabledPlugins).toContain("learn");
+    expect(disk.disabledPlugins).not.toContain("learn");
+    expect(disk.disabledPlugins).not.toContain("find");
+    expect(disk.disabledPlugins).not.toContain("project");
+    expect(disk.disabledPlugins).toContain("archive");
     expect(disk.migrations?.[DEFAULT_ACTIVE_PLUGINS_1500_MIGRATION]).toBe(true);
+    expect(disk.migrations?.[DEFAULT_ACTIVE_PLUGINS_1531_MIGRATION]).toBe(true);
   });
 
   test("small manual disable list is preserved", () => {
@@ -239,6 +244,55 @@ describe("#1500 default-active plugin migration", () => {
     const disk = readConfig(home);
     expect(disk.disabledPlugins).toEqual(["completions"]);
     expect(disk.migrations?.[DEFAULT_ACTIVE_PLUGINS_1524_MIGRATION]).toBeUndefined();
+  });
+
+  test("#1531 re-enables Oracle workflow plugins after stale profile migrations", () => {
+    const home = makeHome({
+      host: "local",
+      port: 3456,
+      oracleUrl: "http://localhost:47779",
+      env: {},
+      commands: { default: "claude" },
+      sessions: {},
+      migrations: {
+        [DEFAULT_ACTIVE_PLUGINS_1500_MIGRATION]: true,
+        [DEFAULT_ACTIVE_PLUGINS_1514_MIGRATION]: true,
+        [DEFAULT_ACTIVE_PLUGINS_1523_MIGRATION]: true,
+        [DEFAULT_ACTIVE_PLUGINS_1524_MIGRATION]: true,
+      },
+      disabledPlugins: ["learn", "find", "talk-to", "project", "workon", "cleanup", "costs"],
+    });
+
+    const result = loadInSubprocess(home);
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain("config.disabledPlugins migration (#1531)");
+
+    const disk = readConfig(home);
+    for (const plugin of ["learn", "find", "talk-to", "project", "workon", "cleanup"]) {
+      expect(disk.disabledPlugins).not.toContain(plugin);
+    }
+    expect(disk.disabledPlugins).toContain("costs");
+    expect(disk.migrations?.[DEFAULT_ACTIVE_PLUGINS_1531_MIGRATION]).toBe(true);
+  });
+
+  test("#1531 preserves small manual Oracle workflow disable lists", () => {
+    const home = makeHome({
+      host: "local",
+      port: 3456,
+      oracleUrl: "http://localhost:47779",
+      env: {},
+      commands: { default: "claude" },
+      sessions: {},
+      disabledPlugins: ["learn", "project"],
+    });
+
+    const result = loadInSubprocess(home);
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toContain("config.disabledPlugins migration (#1531)");
+
+    const disk = readConfig(home);
+    expect(disk.disabledPlugins).toEqual(["learn", "project"]);
+    expect(disk.migrations?.[DEFAULT_ACTIVE_PLUGINS_1531_MIGRATION]).toBeUndefined();
   });
 
   test("typing a disabled installed plugin explains the real fix", () => {


### PR DESCRIPTION
## Summary

Partial slice of #1531.

- promote common Oracle workflow/federation commands to the standard plugin surface: learn, find, talk-to, project, workon, cleanup
- add a #1531 migration that heals stale profile-generated disabled lists while preserving small manual disable lists
- refresh user-facing descriptions for the promoted plugins, especially learn/project scaffold wording

## Why this slice

Current alpha still reports everyday verbs like `maw learn --help`, `maw project --help`, `maw find --help`, and `maw talk-to --help` as installed-but-disabled on stale configs. That makes the commands look missing even though they are bundled.

## Verification

- `rtk bun test test/isolated/plugin-default-active-migration.test.ts --path-ignore-patterns '**/agents/**'`
- `rtk bun run test:mock-smoke`
- `rtk bun run build`
- `jq` check confirmed all six plugin manifests now report `tier=standard` and `weight=30`

Refs #1531.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
