### PR TITLE
docs(cli): clarify overlapping command help

### DIFF
--- a/src/commands/plugins/fleet/index.ts
+++ b/src/commands/plugins/fleet/index.ts
@@ -2,7 +2,7 @@ import type { InvokeContext, InvokeResult } from "../../../plugin/types";
 
 export const command = {
   name: "fleet",
-  description: "Fleet management — init, sync, health, doctor, snapshots.",
+  description: "Manage the persistent fleet registry; use maw ls for currently live sessions.",
 };
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
@@ -107,7 +107,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     } else {
       return {
         ok: false,
-        error: `unknown fleet subcommand: ${sub}\nusage: maw fleet <init|ls|renumber|validate|health|doctor|consolidate|sync|sync-windows|snapshots|restore|snapshot>`,
+        error: `unknown fleet subcommand: ${sub}\nusage: maw fleet <init|ls|renumber|validate|health|doctor|consolidate|sync|sync-windows|snapshots|restore|snapshot>\n  tip: maw fleet ls shows registered fleet config; maw ls shows live sessions`,
       };
     }
 

--- a/src/commands/plugins/fleet/plugin.json
+++ b/src/commands/plugins/fleet/plugin.json
@@ -3,11 +3,11 @@
   "version": "1.0.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "Fleet management — init, sync, health, doctor, snapshots.",
+  "description": "Manage the persistent fleet registry; use maw ls for currently live sessions.",
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "fleet",
-    "help": "maw fleet <init|ls|renumber|validate|health|doctor|consolidate|sync|sync-windows|snapshots|restore|snapshot> [args]"
+    "help": "maw fleet <init|ls|renumber|validate|health|doctor|consolidate|sync|sync-windows|snapshots|restore|snapshot> [args] — manage registered fleet config; see maw ls for live sessions"
   },
   "weight": 10,
   "tier": "standard"

--- a/src/commands/plugins/pane/index.ts
+++ b/src/commands/plugins/pane/index.ts
@@ -2,7 +2,7 @@ import type { InvokeContext, InvokeResult } from "../../../plugin/types";
 
 export const command = {
   name: "pane",
-  description: "Pane workflow helpers such as swapping panes in the current tmux window.",
+  description: "Swap panes in the current tmux window; use panes to list metadata or tile to arrange grids.",
 };
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
@@ -23,21 +23,21 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     const sub = args[0]?.toLowerCase();
 
     if (!sub || sub === "--help" || sub === "-h") {
-      console.log("usage: maw pane swap <pane-a> <pane-b>");
+      console.log("usage: maw pane swap <pane-a> <pane-b>  (see: maw panes to list, maw tile for grids)");
       console.log("  pane targets: index (1), pane id (%1), title prefix (tile-1), top, bottom");
       return { ok: true, output: logs.join("\n") || undefined };
     }
 
     if (sub !== "swap") {
       console.log(`unknown pane subcommand: ${sub}`);
-      console.log("usage: maw pane swap <pane-a> <pane-b>");
+      console.log("usage: maw pane swap <pane-a> <pane-b>  (see: maw panes to list, maw tile for grids)");
       return { ok: false, error: `unknown subcommand: ${sub}`, output: logs.join("\n") };
     }
 
     const a = args[1];
     const b = args[2];
     if (!a || !b) {
-      console.log("usage: maw pane swap <pane-a> <pane-b>");
+      console.log("usage: maw pane swap <pane-a> <pane-b>  (see: maw panes to list, maw tile for grids)");
       return { ok: false, error: "two pane targets required", output: logs.join("\n") };
     }
 

--- a/src/commands/plugins/pane/plugin.json
+++ b/src/commands/plugins/pane/plugin.json
@@ -3,10 +3,10 @@
   "version": "1.0.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "Pane workflow helpers such as swapping panes in the current tmux window.",
+  "description": "Swap panes in the current tmux window; use panes to list metadata or tile to arrange grids.",
   "cli": {
     "command": "pane",
-    "help": "maw pane swap <a> <b> — swap panes in the current tmux window"
+    "help": "maw pane swap <a> <b> — swap panes in the current tmux window; see maw panes to list and maw tile for grids"
   },
   "weight": 5
 }

--- a/src/commands/plugins/tile/index.ts
+++ b/src/commands/plugins/tile/index.ts
@@ -3,7 +3,7 @@ import { parseFlags } from "../../../cli/parse-args";
 
 export const command = {
   name: "tile",
-  description: "Tile current window or spawn N colored panes in a tiled grid.",
+  description: "Arrange the current window into a grid or spawn tile panes; use panes to inspect and pane swap to move panes.",
 };
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
@@ -28,11 +28,11 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     }, 0);
 
     if (flags["--help"]) {
-      console.log("usage: maw tile [N] [--wt] [--engine <name>]");
+      console.log("usage: maw tile [N] [--wt] [--engine <name>]  (see: maw panes to inspect, maw pane swap to move)");
       console.log("       maw tile clean");
       console.log("       maw tile swap <a> <b>");
       console.log("");
-      console.log("  maw tile              apply tiled layout to current window");
+      console.log("  maw tile              apply tiled layout to current window (pane grid)");
       console.log("  maw tile 3            spawn 3 empty panes and tile them");
       console.log("  maw tile 3 --wt       spawn 3 worktree-backed panes, each with own branch");
       console.log("  maw tile 3 -e claude  spawn 3 panes running claude, tiled");

--- a/src/commands/plugins/tile/plugin.json
+++ b/src/commands/plugins/tile/plugin.json
@@ -3,10 +3,10 @@
   "version": "1.0.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "Tile current window or spawn N colored panes in a tiled grid.",
+  "description": "Arrange the current window into a grid or spawn tile panes; use panes to inspect and pane swap to move panes.",
   "cli": {
     "command": "tile",
-    "help": "maw tile [N] — tile window, or spawn N panes tiled"
+    "help": "maw tile [N] — arrange current window or spawn N panes; see maw panes to inspect and maw pane swap to move panes"
   },
   "weight": 5
 }

--- a/src/vendor/mpr-plugins/bg/plugin.json
+++ b/src/vendor/mpr-plugins/bg/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://maw.soulbrews.studio/schema/plugin.json",
   "name": "bg",
   "version": "0.1.2",
-  "description": "Run long commands in detached tmux; sample output non-destructively",
+  "description": "Run long commands in detached tmux and sample output without blocking the current pane.",
   "author": "Soul-Brews-Studio",
   "license": "MIT",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-bg",

--- a/src/vendor/mpr-plugins/bg/registry.meta.json
+++ b/src/vendor/mpr-plugins/bg/registry.meta.json
@@ -2,7 +2,7 @@
   "version": "0.1.2",
   "source": "soul-brews-studio/maw-plugin-registry/bg@v0.1.2-bg",
   "sha256": "b14f2689c2904d4646c18e661d18e50f621d013c783833829a8909c627ce8e20",
-  "summary": "Run long commands in detached tmux; sample output non-destructively",
+  "summary": "Run long commands in detached tmux and sample output without blocking the current pane.",
   "author": "Soul-Brews-Studio",
   "license": "MIT",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-bg",

--- a/src/vendor/mpr-plugins/bg/src/index.ts
+++ b/src/vendor/mpr-plugins/bg/src/index.ts
@@ -25,7 +25,7 @@ import { parseFlags } from "./internal/parse-flags";
 export const manifest = {
   name: "bg",
   version: "0.1.0",
-  description: "Run long commands in detached tmux; sample output non-destructively",
+  description: "Run long commands in detached tmux and sample output without blocking the current pane.",
 };
 
 export interface InvokeResult {
@@ -36,7 +36,7 @@ export interface InvokeResult {
   exitCode?: number;
 }
 
-const HELP = `maw bg — run long commands in detached tmux
+const HELP = `maw bg — run long commands in detached tmux without blocking the current pane
 
 usage:
   maw bg "<cmd>" [--name X]              spawn detached tmux session

--- a/src/vendor/mpr-plugins/capture/index.ts
+++ b/src/vendor/mpr-plugins/capture/index.ts
@@ -4,7 +4,7 @@ import { parseFlags } from "maw-js/cli/parse-args";
 
 export const command = {
   name: "capture",
-  description: "Capture tmux pane content.",
+  description: "Capture visible pane output or full scrollback; use peek for a quick latest-output glance.",
 };
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
@@ -33,10 +33,10 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
 
       target = flags._[0];
       if (!target || target === "--help" || target === "-h") {
-        return { ok: false, error: "usage: maw capture <target> [--pane N] [--lines N] [--full]" };
+        return { ok: false, error: "usage: maw capture <target> [--pane N] [--lines N] [--full]  (see: maw peek for quick glance)" };
       }
       if (target.startsWith("-")) {
-        return { ok: false, error: `"${target}" looks like a flag, not a target.\n  usage: maw capture <target>` };
+        return { ok: false, error: `"${target}" looks like a flag, not a target.\n  usage: maw capture <target>  (see: maw peek for quick glance)` };
       }
       opts = {
         pane: flags["--pane"],

--- a/src/vendor/mpr-plugins/capture/plugin.json
+++ b/src/vendor/mpr-plugins/capture/plugin.json
@@ -3,10 +3,10 @@
   "version": "1.0.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "Capture tmux pane content — visible history or full scrollback.",
+  "description": "Capture visible pane output or full scrollback; use peek for a quick latest-output glance.",
   "cli": {
     "command": "capture",
-    "help": "maw capture <target> [--pane N] [--lines N] [--full]",
+    "help": "maw capture <target> [--pane N] [--lines N] [--full] — capture pane output or scrollback; see maw peek for a quick glance",
     "flags": {
       "--pane": "number",
       "--lines": "number",

--- a/src/vendor/mpr-plugins/capture/registry.meta.json
+++ b/src/vendor/mpr-plugins/capture/registry.meta.json
@@ -2,7 +2,7 @@
   "version": "0.1.0",
   "source": "soul-brews-studio/maw-plugin-registry/capture@v0.1.0-capture",
   "sha256": "db636cbd88ca442492eba49c513d08614f9c96cf24aff5e7e94a54cc9c2aa874",
-  "summary": "Capture tmux pane content \u2014 visible history or full scrollback.",
+  "summary": "Capture visible pane output or full scrollback; use peek for a quick latest-output glance.",
   "author": "Soul-Brews-Studio",
   "license": "MIT",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",

--- a/src/vendor/mpr-plugins/done/index.ts
+++ b/src/vendor/mpr-plugins/done/index.ts
@@ -3,7 +3,7 @@ import { cmdDone, cmdDoneAll } from "./impl";
 
 export const command = {
   name: ["done", "finish"],
-  description: "Clean up a finished worktree window: rrr, git save, kill, remove worktree.",
+  description: "Finish a worktree session: retrospective/save, kill window, and remove worktree.",
 };
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
@@ -46,7 +46,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     }
 
     if (!name) {
-      return { ok: false, error: "usage: maw done <window-name> [--force] [--dry-run] or maw done --all [--force] [--dry-run]" };
+      return { ok: false, error: "usage: maw done <window-name> [--force] [--dry-run] or maw done --all [--force] [--dry-run]  (see: maw sleep/kill for non-worktree shutdown)" };
     }
 
     await cmdDone(name, { force, dryRun });

--- a/src/vendor/mpr-plugins/done/plugin.json
+++ b/src/vendor/mpr-plugins/done/plugin.json
@@ -3,14 +3,14 @@
   "version": "1.0.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "Clean up a finished worktree window: rrr, git save, kill, remove worktree.",
+  "description": "Finish a worktree session: retrospective/save, kill window, and remove worktree; use sleep/kill for non-worktree shutdown.",
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "done",
     "aliases": [
       "finish"
     ],
-    "help": "maw done <window-name> [--force] [--dry-run] | maw done --all [--force] [--dry-run] — clean up finished worktrees"
+    "help": "maw done <window-name> [--force] [--dry-run] | maw done --all [--force] [--dry-run] — finish worktrees; see maw sleep/kill for non-worktree shutdown"
   },
   "api": {
     "path": "/api/done",

--- a/src/vendor/mpr-plugins/done/registry.meta.json
+++ b/src/vendor/mpr-plugins/done/registry.meta.json
@@ -2,7 +2,7 @@
   "version": "0.1.0",
   "source": "soul-brews-studio/maw-plugin-registry/done@v0.1.0-done",
   "sha256": "b27124336937bf46bc30d7bd80611d78956157975b3d5f7c708e3ca4a8772f75",
-  "summary": "Clean up a finished worktree window: rrr, git save, kill, remove worktree.",
+  "summary": "Finish a worktree session: retrospective/save, kill window, and remove worktree; use sleep/kill for non-worktree shutdown.",
   "author": "Soul-Brews-Studio",
   "license": "MIT",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",

--- a/src/vendor/mpr-plugins/kill/index.ts
+++ b/src/vendor/mpr-plugins/kill/index.ts
@@ -4,7 +4,7 @@ import { parseFlags } from "maw-js/cli/parse-args";
 
 export const command = {
   name: "kill",
-  description: "Kill a tmux session, window, or pane.",
+  description: "Immediately kill a tmux session, window, or pane; use sleep for graceful stop or done for worktrees.",
 };
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
@@ -29,10 +29,10 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
 
       target = flags._[0];
       if (!target || target === "--help" || target === "-h") {
-        return { ok: false, error: "usage: maw kill <target>[:window] [--pane N] [--peer <alias>]" };
+        return { ok: false, error: "usage: maw kill <target>[:window] [--pane N] [--peer <alias>]  (see: maw sleep for graceful stop, maw done for worktrees)" };
       }
       if (target.startsWith("-")) {
-        return { ok: false, error: `"${target}" looks like a flag, not a target.\n  usage: maw kill <target>` };
+        return { ok: false, error: `"${target}" looks like a flag, not a target.\n  usage: maw kill <target>  (see: maw sleep for graceful stop, maw done for worktrees)` };
       }
 
       if (flags["--peer"]) {

--- a/src/vendor/mpr-plugins/kill/plugin.json
+++ b/src/vendor/mpr-plugins/kill/plugin.json
@@ -3,10 +3,10 @@
   "version": "1.1.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "Kill a tmux session, window, or pane (trusts the user — no --force).",
+  "description": "Immediately kill a tmux session, window, or pane; use sleep for graceful single-agent shutdown or done for finished worktrees.",
   "cli": {
     "command": "kill",
-    "help": "maw kill <target>[:window] [--pane N] [--peer <alias>]",
+    "help": "maw kill <target>[:window] [--pane N] [--peer <alias>] — immediate tmux kill; see maw sleep for graceful stop and maw done for worktree cleanup",
     "flags": {
       "--pane": "number",
       "--peer": "string"

--- a/src/vendor/mpr-plugins/kill/registry.meta.json
+++ b/src/vendor/mpr-plugins/kill/registry.meta.json
@@ -2,7 +2,7 @@
   "version": "0.1.0",
   "source": "soul-brews-studio/maw-plugin-registry/kill@v0.1.0-kill",
   "sha256": "a1f3101cd6065e1191e880707b4ee08d86ef7f4b33c2176ca5d9409153b9b3b4",
-  "summary": "Kill a tmux session, window, or pane (trusts the user \u2014 no --force).",
+  "summary": "Immediately kill a tmux session, window, or pane; use sleep for graceful single-agent shutdown or done for finished worktrees.",
   "author": "Soul-Brews-Studio",
   "license": "MIT",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",

--- a/src/vendor/mpr-plugins/ls/index.ts
+++ b/src/vendor/mpr-plugins/ls/index.ts
@@ -2,19 +2,20 @@ import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdList } from "maw-js/commands/shared/comm";
 import { parseFlags } from "maw-js/cli/parse-args";
 
-export const command = { name: "ls", description: "List all agents and their status." };
+export const command = { name: "ls", description: "List live sessions and agents; use maw fleet ls for registered fleet config." };
 
 const HELP = [
-  "maw ls — list sessions (local or cross-node)",
+  "maw ls — list live sessions (local or cross-node)",
   "",
   "Usage:",
-  "  maw ls                  list local sessions (default)",
+  "  maw ls                  list live local sessions (default)",
   "  maw ls <peer>           list sessions on a federation peer",
   "  maw ls --all            aggregate sessions from all known peers",
   "  maw ls --json           emit JSON (combine with <peer> or --all)",
   "  maw ls --fix            prune orphaned worktrees (local only)",
   "",
   "Peer aliases are resolved from ~/.maw/peers.json (see: maw peers list).",
+  "For registered fleet config, use maw fleet ls.",
 ].join("\n");
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {

--- a/src/vendor/mpr-plugins/ls/plugin.json
+++ b/src/vendor/mpr-plugins/ls/plugin.json
@@ -3,14 +3,14 @@
   "version": "1.1.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "List sessions — local, on a federation peer, or aggregated across all peers.",
+  "description": "List live sessions and agents; use maw fleet ls for registered fleet config.",
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "ls",
     "aliases": [
       "list"
     ],
-    "help": "maw ls [<peer>] [--all] [--json] [--fix] — list local or cross-node sessions"
+    "help": "maw ls [<peer>] [--all] [--json] [--fix] — list live sessions; see maw fleet ls for registered fleet config"
   },
   "weight": 0,
   "license": "MIT",

--- a/src/vendor/mpr-plugins/ls/registry.meta.json
+++ b/src/vendor/mpr-plugins/ls/registry.meta.json
@@ -2,7 +2,7 @@
   "version": "0.1.0",
   "source": "soul-brews-studio/maw-plugin-registry/ls@v0.1.0-ls",
   "sha256": "1b1fb2a893430d0dd50e70211c3dcad49bb4f8801f1d10afb7b6a2ec7480f517",
-  "summary": "List all agents and their status.",
+  "summary": "List live sessions and agents; use maw fleet ls for registered fleet config.",
   "author": "Soul-Brews-Studio",
   "license": "MIT",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",

--- a/src/vendor/mpr-plugins/panes/index.ts
+++ b/src/vendor/mpr-plugins/panes/index.ts
@@ -4,7 +4,7 @@ import { parseFlags } from "maw-js/cli/parse-args";
 
 export const command = {
   name: "panes",
-  description: "List tmux panes with metadata.",
+  description: "List pane metadata; use pane swap to move panes or tile to arrange/spawn grids.",
 };
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
@@ -31,10 +31,10 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
 
       const first = flags._[0];
       if (first === "--help" || first === "-h") {
-        return { ok: false, error: "usage: maw panes [target] [--pid] [--all|-a]" };
+        return { ok: false, error: "usage: maw panes [target] [--pid] [--all|-a]  (see: maw pane swap, maw tile)" };
       }
       if (first && first.startsWith("-")) {
-        return { ok: false, error: `"${first}" looks like a flag, not a target.\n  usage: maw panes [target] [--pid] [--all|-a]` };
+        return { ok: false, error: `"${first}" looks like a flag, not a target.\n  usage: maw panes [target] [--pid] [--all|-a]  (see: maw pane swap, maw tile)` };
       }
       target = first;
       pid = !!flags["--pid"];

--- a/src/vendor/mpr-plugins/panes/plugin.json
+++ b/src/vendor/mpr-plugins/panes/plugin.json
@@ -3,10 +3,10 @@
   "version": "1.0.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "List tmux panes with metadata (index, size, command, title).",
+  "description": "List pane metadata; use pane swap to move panes or tile to arrange/spawn grids.",
   "cli": {
     "command": "panes",
-    "help": "maw panes [target] [--pid] [--all|-a] — list panes in current window, or all panes in <target>, or --all to list every pane across every session",
+    "help": "maw panes [target] [--pid] [--all|-a] — list pane metadata; see maw pane swap to move panes and maw tile for grids",
     "flags": {
       "--pid": "boolean",
       "--all": "boolean"

--- a/src/vendor/mpr-plugins/panes/registry.meta.json
+++ b/src/vendor/mpr-plugins/panes/registry.meta.json
@@ -2,7 +2,7 @@
   "version": "0.1.0",
   "source": "soul-brews-studio/maw-plugin-registry/panes@v0.1.0-panes",
   "sha256": "cd98d6bb4fdfd22286e85c66fae96cf7918878565e39930babe525c2eecce1d3",
-  "summary": "List tmux panes with metadata (index, size, command, title).",
+  "summary": "List pane metadata; use pane swap to move panes or tile to arrange/spawn grids.",
   "author": "Soul-Brews-Studio",
   "license": "MIT",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",

--- a/src/vendor/mpr-plugins/peek/index.ts
+++ b/src/vendor/mpr-plugins/peek/index.ts
@@ -1,7 +1,7 @@
 import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdPeek } from "maw-js/commands/shared/comm";
 
-export const command = { name: "peek", description: "Peek at an agent's latest output." };
+export const command = { name: "peek", description: "Peek at the latest output from an agent without attaching; use capture for scrollback or view to attach." };
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
   const logs: string[] = [];

--- a/src/vendor/mpr-plugins/peek/plugin.json
+++ b/src/vendor/mpr-plugins/peek/plugin.json
@@ -3,14 +3,14 @@
   "version": "1.0.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "Peek at an agent's latest output.",
+  "description": "Peek at the latest output from an agent without attaching; use capture for scrollback or view to attach.",
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "peek",
     "aliases": [
       "see"
     ],
-    "help": "maw peek <agent> — peek at an agent's latest output"
+    "help": "maw peek <agent> — read latest output without attaching; see maw capture for scrollback and maw view to attach"
   },
   "weight": 0,
   "license": "MIT",

--- a/src/vendor/mpr-plugins/peek/registry.meta.json
+++ b/src/vendor/mpr-plugins/peek/registry.meta.json
@@ -2,7 +2,7 @@
   "version": "0.1.0",
   "source": "soul-brews-studio/maw-plugin-registry/peek@v0.1.0-peek",
   "sha256": "ed4ce7c9254f1288348476322cb799b102f73569b206002f7d12734b87267eb5",
-  "summary": "Peek at an agent's latest output.",
+  "summary": "Peek at the latest output from an agent without attaching; use capture for scrollback or view to attach.",
   "author": "Soul-Brews-Studio",
   "license": "MIT",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",

--- a/src/vendor/mpr-plugins/rename/plugin.json
+++ b/src/vendor/mpr-plugins/rename/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://maw.soulbrews.studio/schema/plugin.json",
   "name": "rename",
   "version": "0.1.2",
-  "description": "Tmux window rename with oracle-prefix auto-format",
+  "description": "Rename tmux tabs/windows with Oracle-prefix auto-formatting; use tab to list or message tabs.",
   "author": "Soul-Brews-Studio",
   "license": "MIT",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-rename",

--- a/src/vendor/mpr-plugins/rename/registry.meta.json
+++ b/src/vendor/mpr-plugins/rename/registry.meta.json
@@ -2,7 +2,7 @@
   "version": "0.1.2",
   "source": "soul-brews-studio/maw-plugin-registry/rename@v0.1.2-rename",
   "sha256": "f09816a8e9214fb01b7c5555f31fbe4b2a787b21f7f198c835d5c78c153a560b",
-  "summary": "Tmux window rename with oracle-prefix auto-format",
+  "summary": "Rename tmux tabs/windows with Oracle-prefix auto-formatting; use tab to list or message tabs.",
   "author": "Soul-Brews-Studio",
   "license": "MIT",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-rename",

--- a/src/vendor/mpr-plugins/rename/src/index.ts
+++ b/src/vendor/mpr-plugins/rename/src/index.ts
@@ -3,7 +3,7 @@ import { cmdRename } from "./impl";
 
 export const command = {
   name: "rename",
-  description: "Rename a tmux tab or agent.",
+  description: "Rename tmux tabs/windows with Oracle-prefix auto-formatting; use tab to list or message tabs.",
 };
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
@@ -21,7 +21,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
   try {
     const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
     if (!args[0] || !args[1]) {
-      throw new Error("usage: maw rename <tab# or name> <new-name>");
+      throw new Error("usage: maw rename <tab# or name> <new-name>  (see: maw tab to list tabs)");
     }
     await cmdRename(args[0], args[1]);
     return { ok: true, output: logs.join("\n") || undefined };

--- a/src/vendor/mpr-plugins/sleep/index.ts
+++ b/src/vendor/mpr-plugins/sleep/index.ts
@@ -3,7 +3,7 @@ import { cmdSleepOne } from "./impl";
 
 export const command = {
   name: ["sleep"],
-  description: "Gracefully stop a single Oracle agent's tmux window.",
+  description: "Gracefully stop one Oracle window; use kill for immediate tmux removal or done for worktree cleanup.",
 };
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
@@ -25,7 +25,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     if (ctx.source === "cli") {
       const args = ctx.args as string[];
       if (!args[0]) {
-        return { ok: false, error: "usage: maw sleep <oracle> [window]" };
+        return { ok: false, error: "usage: maw sleep <oracle> [window]  (see: maw kill for immediate removal, maw done for worktrees)" };
       }
       if (args[0] === "--all-done") {
         logs.push("(placeholder) maw sleep --all-done — sleep ALL agents. Not yet implemented.");
@@ -36,7 +36,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     } else {
       const args = ctx.args as Record<string, unknown>;
       if (!args.oracle) {
-        return { ok: false, error: "oracle is required" };
+        return { ok: false, error: "oracle is required (usage: maw sleep <oracle> [window])" };
       }
       oracle = args.oracle as string;
       window = args.window as string | undefined;

--- a/src/vendor/mpr-plugins/sleep/plugin.json
+++ b/src/vendor/mpr-plugins/sleep/plugin.json
@@ -3,11 +3,11 @@
   "version": "1.0.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "Gracefully stop a single Oracle agent's tmux window.",
+  "description": "Gracefully stop one Oracle window; use kill for immediate tmux removal or done for worktree cleanup.",
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "sleep",
-    "help": "maw sleep <oracle> [window] — gracefully stop an oracle window"
+    "help": "maw sleep <oracle> [window] — gracefully stop one Oracle window; see maw kill for immediate removal and maw done for worktrees"
   },
   "api": {
     "path": "/api/sleep",

--- a/src/vendor/mpr-plugins/sleep/registry.meta.json
+++ b/src/vendor/mpr-plugins/sleep/registry.meta.json
@@ -2,7 +2,7 @@
   "version": "0.1.0",
   "source": "soul-brews-studio/maw-plugin-registry/sleep@v0.1.0-sleep",
   "sha256": "7f53cf07b44f47ef575d538f6a9e896ef2f516525f52bc26a21aaa8c8c1709fd",
-  "summary": "Gracefully stop a single Oracle agent's tmux window.",
+  "summary": "Gracefully stop one Oracle window; use kill for immediate tmux removal or done for worktree cleanup.",
   "author": "Soul-Brews-Studio",
   "license": "MIT",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",

--- a/src/vendor/mpr-plugins/tab/index.ts
+++ b/src/vendor/mpr-plugins/tab/index.ts
@@ -2,7 +2,7 @@ import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 
 export const command = {
   name: "tab",
-  description: "Manage tmux tabs.",
+  description: "List tmux tabs/windows, peek a tab, or send a message to it; use rename to change tab names.",
 };
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {

--- a/src/vendor/mpr-plugins/tab/plugin.json
+++ b/src/vendor/mpr-plugins/tab/plugin.json
@@ -3,14 +3,14 @@
   "version": "1.0.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "Manage tmux tabs.",
+  "description": "List tmux tabs/windows, peek a tab, or send a message to it; use rename to change tab names.",
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "tab",
     "aliases": [
       "tabs"
     ],
-    "help": "maw tab [args] — manage tmux tabs"
+    "help": "maw tab [N] [message|--talk message] — list tabs, peek a tab, or message it; see maw rename to rename tabs"
   },
   "weight": 50,
   "license": "MIT",

--- a/src/vendor/mpr-plugins/tab/registry.meta.json
+++ b/src/vendor/mpr-plugins/tab/registry.meta.json
@@ -2,7 +2,7 @@
   "version": "0.1.0",
   "source": "soul-brews-studio/maw-plugin-registry/tab@v0.1.0-tab",
   "sha256": "fa1cb5b76e700b03750c198f71af6a52bc65e349582827995e6c66175376ceef",
-  "summary": "Manage tmux tabs.",
+  "summary": "List tmux tabs/windows, peek a tab, or send a message to it; use rename to change tab names.",
   "author": "Soul-Brews-Studio",
   "license": "MIT",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",

--- a/src/vendor/mpr-plugins/view/index.ts
+++ b/src/vendor/mpr-plugins/view/index.ts
@@ -2,7 +2,7 @@ import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 
 export const command = {
   name: "view",
-  description: "Create or attach to an agent's tmux view.",
+  description: "Create or attach to an agent tmux view; use peek/capture for read-only inspection.",
 };
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
@@ -43,7 +43,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     if (!scanned[0]) {
       return {
         ok: false,
-        error: "usage: maw view <agent> [window] [--clean] [--kill] [--split[=<anchor>]]",
+        error: "usage: maw view <agent> [window] [--clean] [--kill] [--split[=<anchor>]]  (see: maw peek/capture for read-only inspection)",
       };
     }
 

--- a/src/vendor/mpr-plugins/view/plugin.json
+++ b/src/vendor/mpr-plugins/view/plugin.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "Create or attach to an agent's tmux view.",
+  "description": "Create or attach to an agent tmux view; use peek/capture for read-only inspection.",
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "view",
@@ -12,7 +12,7 @@
       "attach",
       "a"
     ],
-    "help": "maw view <agent> [window] [--clean] [--kill] [--split[=<anchor>]] [--wake|--no-wake] — create or attach to an agent's tmux view. --split splits the caller's active pane; --split=<anchor> splits the pane hosting <anchor>'s view (auto-creates if missing). On missing target in a TTY, prompts y/N to wake; --wake skips the prompt and wakes; --no-wake skips the prompt and errors as before.",
+    "help": "maw view <agent> [window] [--clean] [--kill] [--split[=<anchor>]] [--wake|--no-wake] — attach to an agent view; use maw peek/capture for read-only inspection",
     "flags": {
       "--clean": "boolean",
       "--kill": "boolean",

--- a/src/vendor/mpr-plugins/view/registry.meta.json
+++ b/src/vendor/mpr-plugins/view/registry.meta.json
@@ -2,7 +2,7 @@
   "version": "0.1.0",
   "source": "soul-brews-studio/maw-plugin-registry/view@v0.1.0-view",
   "sha256": "a4d46e5120ebc282576de42498397f3c850f5ac8fa642b18b47ffae690426b16",
-  "summary": "Create or attach to an agent's tmux view.",
+  "summary": "Create or attach to an agent tmux view; use peek/capture for read-only inspection.",
   "author": "Soul-Brews-Studio",
   "license": "MIT",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",

--- a/test/isolated/command-surface-help-copy.test.ts
+++ b/test/isolated/command-surface-help-copy.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+function json<T = any>(rel: string): T {
+  return JSON.parse(readFileSync(join(process.cwd(), rel), "utf8")) as T;
+}
+
+function help(rel: string): string {
+  return json<{ cli?: { help?: string } }>(rel).cli?.help ?? "";
+}
+
+function desc(rel: string): string {
+  return json<{ description?: string }>(rel).description ?? "";
+}
+
+function summary(rel: string): string {
+  return json<{ summary?: string }>(rel).summary ?? "";
+}
+
+describe("#1531 command-surface help copy", () => {
+  test("ls and fleet cross-reference live sessions vs registered fleet config", () => {
+    expect(help("src/vendor/mpr-plugins/ls/plugin.json")).toContain("maw fleet ls");
+    expect(help("src/commands/plugins/fleet/plugin.json")).toContain("maw ls");
+    expect(desc("src/vendor/mpr-plugins/ls/plugin.json")).toContain("live sessions");
+    expect(desc("src/commands/plugins/fleet/plugin.json")).toContain("persistent fleet registry");
+  });
+
+  test("pane, panes, and tile explain their distinct pane-management roles", () => {
+    expect(help("src/vendor/mpr-plugins/panes/plugin.json")).toContain("maw pane swap");
+    expect(help("src/vendor/mpr-plugins/panes/plugin.json")).toContain("maw tile");
+    expect(help("src/commands/plugins/pane/plugin.json")).toContain("maw panes");
+    expect(help("src/commands/plugins/pane/plugin.json")).toContain("maw tile");
+    expect(help("src/commands/plugins/tile/plugin.json")).toContain("maw panes");
+    expect(help("src/commands/plugins/tile/plugin.json")).toContain("maw pane swap");
+  });
+
+  test("peek, capture, and view clarify read-only glance, scrollback, and attach", () => {
+    expect(help("src/vendor/mpr-plugins/peek/plugin.json")).toContain("maw capture");
+    expect(help("src/vendor/mpr-plugins/peek/plugin.json")).toContain("maw view");
+    expect(help("src/vendor/mpr-plugins/capture/plugin.json")).toContain("maw peek");
+    expect(help("src/vendor/mpr-plugins/view/plugin.json")).toContain("maw peek/capture");
+  });
+
+  test("kill, sleep, and done clarify immediate, graceful, and worktree shutdown", () => {
+    expect(help("src/vendor/mpr-plugins/kill/plugin.json")).toContain("maw sleep");
+    expect(help("src/vendor/mpr-plugins/kill/plugin.json")).toContain("maw done");
+    expect(help("src/vendor/mpr-plugins/sleep/plugin.json")).toContain("maw kill");
+    expect(help("src/vendor/mpr-plugins/sleep/plugin.json")).toContain("maw done");
+    expect(help("src/vendor/mpr-plugins/done/plugin.json")).toContain("maw sleep/kill");
+  });
+
+  test("tab, bg, and rename descriptions are concrete instead of vague", () => {
+    expect(desc("src/vendor/mpr-plugins/tab/plugin.json")).toContain("peek a tab");
+    expect(desc("src/vendor/mpr-plugins/bg/plugin.json")).toContain("without blocking");
+    expect(desc("src/vendor/mpr-plugins/rename/plugin.json")).toContain("Oracle-prefix");
+  });
+
+  test("vendored registry summaries mirror updated manifest descriptions", () => {
+    for (const name of [
+      "ls", "peek", "capture", "view", "kill", "done", "sleep", "panes", "tab", "bg", "rename",
+    ]) {
+      expect(summary(`src/vendor/mpr-plugins/${name}/registry.meta.json`)).toBe(
+        desc(`src/vendor/mpr-plugins/${name}/plugin.json`),
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Clarifies #1531 overlap pairs in command descriptions/help: `ls` vs `fleet`, `pane`/`panes`/`tile`, `peek`/`capture`/`view`, and `kill`/`sleep`/`done`.
- Refreshes vague `tab`, `bg`, and `rename` descriptions.
- Keeps vendored registry summaries in sync with manifest descriptions.
- Adds focused tests to lock the cross-reference copy.

## Verification

- `rtk bun test test/plugin-manifest.test.ts test/isolated/command-surface-help-copy.test.ts --path-ignore-patterns '**/agents/**'`
- `rtk bun run test:mock-smoke`
- `rtk bun run build`
- temp `MAW_PLUGINS_DIR` help smoke against `dist/maw --help`

## Release

No alpha release PR/cut created. Nat/human owns alpha releases.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
