### PR TITLE
fix(cli): expose bg and rename help metadata

### DIFF
--- a/src/vendor/mpr-plugins/bg/plugin.json
+++ b/src/vendor/mpr-plugins/bg/plugin.json
@@ -12,5 +12,18 @@
     "tmux"
   ],
   "schemaVersion": 1,
-  "entry": "./src/index.ts"
+  "entry": "./src/index.ts",
+  "cli": {
+    "command": "bg",
+    "help": "maw bg \"<cmd>\" [--name X] | maw bg <ls|tail|attach|kill|gc> [args] — run commands in detached tmux without blocking",
+    "flags": {
+      "--name": "string",
+      "--json": "boolean",
+      "--lines": "number",
+      "--follow": "boolean",
+      "--all": "boolean",
+      "--dry-run": "boolean",
+      "--older-than": "string"
+    }
+  }
 }

--- a/src/vendor/mpr-plugins/bg/src/index.ts
+++ b/src/vendor/mpr-plugins/bg/src/index.ts
@@ -9,10 +9,9 @@
  *   bg kill <slug> | --all                      reap session(s)
  *   bg gc [--dry-run] [--older-than DUR]        reap stale "done" sessions
  *
- * The host (`maw-js`) calls into this module with an array of argv tokens
- * (everything after `maw bg`). The default export returns an InvokeResult
- * shape compatible with `src/plugin/types` in maw-js — see the bundled
- * `wake` plugin for the closest behavioral cousin.
+ * The host (`maw-js`) may call this module with either an InvokeContext
+ * (`plugin/registry.ts`) or a raw argv array (legacy/new command registry
+ * paths). The default export normalizes both to "everything after maw bg".
  */
 
 import {
@@ -36,6 +35,17 @@ export interface InvokeResult {
   exitCode?: number;
 }
 
+type DualCtx = string[] | {
+  source?: "cli" | "api" | "peer";
+  args?: string[] | Record<string, unknown>;
+};
+
+function extractArgs(ctx: DualCtx): string[] {
+  if (Array.isArray(ctx)) return ctx;
+  if (ctx?.source === "cli" && Array.isArray(ctx.args)) return ctx.args;
+  return [];
+}
+
 const HELP = `maw bg — run long commands in detached tmux without blocking the current pane
 
 usage:
@@ -51,7 +61,8 @@ usage:
 slug refs accept full slug, hash suffix (4 hex), or unique stem prefix.
 `;
 
-export default async function handler(argv: string[]): Promise<InvokeResult> {
+export default async function handler(ctx: DualCtx): Promise<InvokeResult> {
+  const argv = extractArgs(ctx);
   try {
     if (argv.length === 0 || argv[0] === "--help" || argv[0] === "-h") {
       return { ok: true, output: HELP };

--- a/src/vendor/mpr-plugins/rename/plugin.json
+++ b/src/vendor/mpr-plugins/rename/plugin.json
@@ -12,5 +12,9 @@
     "tmux"
   ],
   "schemaVersion": 1,
-  "entry": "./src/index.ts"
+  "entry": "./src/index.ts",
+  "cli": {
+    "command": "rename",
+    "help": "maw rename <tab# or name> <new-name> — rename a tmux tab/window; see maw tab to list tabs"
+  }
 }

--- a/test/isolated/bg-plugin-dispatch.test.ts
+++ b/test/isolated/bg-plugin-dispatch.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import handler from "../../src/vendor/mpr-plugins/bg/src/index";
+
+describe("#1531 bg plugin dispatch shape", () => {
+  test("accepts InvokeContext from the plugin registry", async () => {
+    const result = await handler({ source: "cli", args: ["--help"] });
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("maw bg");
+    expect(result.output).toContain("detached tmux");
+  });
+
+  test("keeps raw argv compatibility", async () => {
+    const result = await handler(["--help"]);
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("maw bg");
+  });
+});

--- a/test/isolated/command-surface-help-copy.test.ts
+++ b/test/isolated/command-surface-help-copy.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { formatUsage } from "../../src/cli/usage";
+import { loadManifestFromDir } from "../../src/plugin/manifest";
 
 function json<T = any>(rel: string): T {
   return JSON.parse(readFileSync(join(process.cwd(), rel), "utf8")) as T;
@@ -16,6 +18,12 @@ function desc(rel: string): string {
 
 function summary(rel: string): string {
   return json<{ summary?: string }>(rel).summary ?? "";
+}
+
+function plugin(rel: string) {
+  const loaded = loadManifestFromDir(join(process.cwd(), rel));
+  if (!loaded) throw new Error(`expected plugin at ${rel}`);
+  return loaded;
 }
 
 describe("#1531 command-surface help copy", () => {
@@ -54,6 +62,17 @@ describe("#1531 command-surface help copy", () => {
     expect(desc("src/vendor/mpr-plugins/tab/plugin.json")).toContain("peek a tab");
     expect(desc("src/vendor/mpr-plugins/bg/plugin.json")).toContain("without blocking");
     expect(desc("src/vendor/mpr-plugins/rename/plugin.json")).toContain("Oracle-prefix");
+    expect(help("src/vendor/mpr-plugins/bg/plugin.json")).toContain("maw bg");
+    expect(help("src/vendor/mpr-plugins/rename/plugin.json")).toContain("maw tab");
+  });
+
+  test("bg and rename explicit cli metadata makes them visible in top-level usage", () => {
+    const usage = formatUsage([
+      plugin("src/vendor/mpr-plugins/bg"),
+      plugin("src/vendor/mpr-plugins/rename"),
+    ]);
+    expect(usage).toContain("maw bg");
+    expect(usage).toContain("maw rename");
   });
 
   test("vendored registry summaries mirror updated manifest descriptions", () => {


### PR DESCRIPTION
## Summary

- Adds explicit `cli` metadata for `bg` and `rename`, so they appear in top-level usage instead of relying on hidden default-name dispatch.
- Normalizes `bg` handler input so it accepts both plugin-registry `InvokeContext` and raw argv callers.
- Extends #1531 command-surface tests for bg/rename visibility.

## Verification

- `rtk bun test test/plugin-manifest.test.ts test/isolated/command-surface-help-copy.test.ts test/isolated/bg-plugin-dispatch.test.ts --path-ignore-patterns '**/agents/**'`
- `rtk bun run test:mock-smoke`
- `rtk bun run build`
- temp `MAW_PLUGINS_DIR` help smoke against `dist/maw --help` and `dist/maw bg --help`

## Release

No alpha release PR/cut created. Nat/human owns alpha releases.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
