### PR TITLE
docs(cli): declare remaining CLI plugin metadata

### DIFF
--- a/src/vendor/mpr-plugins/dream/index.ts
+++ b/src/vendor/mpr-plugins/dream/index.ts
@@ -3,7 +3,7 @@ import { cmdDream } from "./impl";
 
 export const command = {
   name: "dream",
-  description: "Cross-repo pattern discovery — pains, plans, gains, lost work, feelings.",
+  description: "Discover cross-repo patterns across pains, plans, gains, lost work, memory, and feelings.",
 };
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {

--- a/src/vendor/mpr-plugins/dream/plugin.json
+++ b/src/vendor/mpr-plugins/dream/plugin.json
@@ -2,11 +2,24 @@
   "$schema": "https://maw.soulbrews.studio/schema/plugin.json",
   "name": "dream",
   "version": "0.1.0",
-  "description": "Cross-repo pattern discovery — finds pains, plans, gains, lost work, and feelings across all repositories.",
+  "description": "Discover cross-repo patterns across pains, plans, gains, lost work, memory, and feelings.",
   "author": "Soul-Brews-Studio",
   "license": "BUSL-1.1",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
   "sdk": "^1.0.0",
   "schemaVersion": 1,
-  "entry": "./index.ts"
+  "entry": "./index.ts",
+  "cli": {
+    "command": "dream",
+    "help": "maw dream [--pain|--plan|--gain|--all|--speculate|--between] [--project <name>] — discover cross-repo patterns",
+    "flags": {
+      "--pain": "boolean",
+      "--plan": "boolean",
+      "--gain": "boolean",
+      "--all": "boolean",
+      "--speculate": "boolean",
+      "--between": "boolean",
+      "--project": "string"
+    }
+  }
 }

--- a/src/vendor/mpr-plugins/dream/registry.meta.json
+++ b/src/vendor/mpr-plugins/dream/registry.meta.json
@@ -2,7 +2,7 @@
   "version": "0.1.0",
   "source": "soul-brews-studio/maw-plugin-registry/dream@v0.1.0-dream",
   "sha256": null,
-  "summary": "Cross-repo pattern discovery — finds pains, plans, gains, lost work, and feelings across all repositories.",
+  "summary": "Discover cross-repo patterns across pains, plans, gains, lost work, memory, and feelings.",
   "author": "Soul-Brews-Studio",
   "license": "BUSL-1.1",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",

--- a/src/vendor/mpr-plugins/oracle-skills/index.ts
+++ b/src/vendor/mpr-plugins/oracle-skills/index.ts
@@ -14,7 +14,7 @@ import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 export const command = {
   name: "oracle-skills",
   description:
-    "Wraps the arra-oracle-skills CLI — install Oracle skills to AI coding agents.",
+    "Pass through to arra-oracle-skills to manage Oracle skills across AI coding agents.",
 };
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {

--- a/src/vendor/mpr-plugins/oracle-skills/plugin.json
+++ b/src/vendor/mpr-plugins/oracle-skills/plugin.json
@@ -2,11 +2,15 @@
   "$schema": "https://maw.soulbrews.studio/schema/plugin.json",
   "name": "oracle-skills",
   "version": "0.1.0",
-  "description": "Wraps the arra-oracle-skills CLI — install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents.",
+  "description": "Pass through to arra-oracle-skills to manage Oracle skills across AI coding agents.",
   "author": "Soul-Brews-Studio",
   "license": "MIT",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
   "sdk": "^1.0.0",
   "schemaVersion": 1,
-  "entry": "./index.ts"
+  "entry": "./index.ts",
+  "cli": {
+    "command": "oracle-skills",
+    "help": "maw oracle-skills [args...] — pass through to arra-oracle-skills for skill management"
+  }
 }

--- a/src/vendor/mpr-plugins/oracle-skills/registry.meta.json
+++ b/src/vendor/mpr-plugins/oracle-skills/registry.meta.json
@@ -2,7 +2,7 @@
   "version": "0.1.0",
   "source": "soul-brews-studio/maw-plugin-registry/oracle-skills@v0.1.0-oracle-skills",
   "sha256": null,
-  "summary": "Wraps the arra-oracle-skills CLI — install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents.",
+  "summary": "Pass through to arra-oracle-skills to manage Oracle skills across AI coding agents.",
   "author": "Soul-Brews-Studio",
   "license": "MIT",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",

--- a/src/vendor/mpr-plugins/park/plugin.json
+++ b/src/vendor/mpr-plugins/park/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://maw.soulbrews.studio/schema/plugin.json",
   "name": "park",
   "version": "0.1.2",
-  "description": "Park (pause) tmux windows with git context for later resume",
+  "description": "Park or list paused tmux windows with git context for later resume.",
   "author": "Soul-Brews-Studio",
   "license": "MIT",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-park",
@@ -13,5 +13,9 @@
     "fs"
   ],
   "schemaVersion": 1,
-  "entry": "./src/index.ts"
+  "entry": "./src/index.ts",
+  "cli": {
+    "command": "park",
+    "help": "maw park [<window>] [note] | maw park ls — pause a tmux window with git context for later resume"
+  }
 }

--- a/src/vendor/mpr-plugins/park/registry.meta.json
+++ b/src/vendor/mpr-plugins/park/registry.meta.json
@@ -2,7 +2,7 @@
   "version": "0.1.2",
   "source": "soul-brews-studio/maw-plugin-registry/park@v0.1.2-park",
   "sha256": "73cba3fe50950b881c197ae29410717fb863861dd294b8672d0b7ac4171ea441",
-  "summary": "Park (pause) tmux windows with git context for later resume",
+  "summary": "Park or list paused tmux windows with git context for later resume.",
   "author": "Soul-Brews-Studio",
   "license": "MIT",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-park",

--- a/src/vendor/mpr-plugins/park/src/index.ts
+++ b/src/vendor/mpr-plugins/park/src/index.ts
@@ -2,7 +2,7 @@ import type { InvokeContext, InvokeResult } from "@maw-js/sdk/plugin";
 
 export const command = {
   name: "park",
-  description: "Park (pause) a tmux window or list parked windows.",
+  description: "Park or list paused tmux windows with git context for later resume.",
 };
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {

--- a/src/vendor/mpr-plugins/shellenv/plugin.json
+++ b/src/vendor/mpr-plugins/shellenv/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://maw.soulbrews.studio/schema/plugin.json",
   "name": "shellenv",
   "version": "0.1.2",
-  "description": "Emit shell init code for the maw warp ergonomic — eval-style install for zsh/bash",
+  "description": "Emit shell init code for eval-style zsh/bash integration, including maw warp.",
   "author": "Soul-Brews-Studio",
   "license": "MIT",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-shellenv",
@@ -12,5 +12,9 @@
   "tier": "standard",
   "capabilities": [],
   "schemaVersion": 1,
-  "entry": "./src/index.ts"
+  "entry": "./src/index.ts",
+  "cli": {
+    "command": "shellenv",
+    "help": "maw shellenv <zsh|bash> — emit shell init code for eval-style integration and maw warp"
+  }
 }

--- a/src/vendor/mpr-plugins/shellenv/registry.meta.json
+++ b/src/vendor/mpr-plugins/shellenv/registry.meta.json
@@ -2,7 +2,7 @@
   "version": "0.1.2",
   "source": "soul-brews-studio/maw-plugin-registry/shellenv@v0.1.2-shellenv",
   "sha256": "356a007e5bf066cf08c343a40b40b691a132d1ba45237e581a3e51bb915b206d",
-  "summary": "Emit shell init code for the maw warp ergonomic \u2014 eval-style install for zsh/bash",
+  "summary": "Emit shell init code for eval-style zsh/bash integration, including maw warp.",
   "author": "Soul-Brews-Studio",
   "license": "MIT",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-shellenv",

--- a/src/vendor/mpr-plugins/shellenv/src/index.ts
+++ b/src/vendor/mpr-plugins/shellenv/src/index.ts
@@ -5,7 +5,7 @@ import { parseFlags } from "./internal/parse-flags";
 export const command = {
   name: "shellenv",
   description:
-    "Emit shell init code for eval-style installation (adds maw warp).",
+    "Emit shell init code for eval-style zsh/bash integration, including maw warp.",
 };
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {

--- a/src/vendor/mpr-plugins/token/index.ts
+++ b/src/vendor/mpr-plugins/token/index.ts
@@ -22,7 +22,7 @@ import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 export const command = {
   name: "token",
   description:
-    "Store & restore .envrc files via pass, manage active Claude OAuth tokens.",
+    "Store and restore .envrc files via pass, and manage active Claude OAuth tokens.",
 };
 
 function helpText(): string {

--- a/src/vendor/mpr-plugins/token/plugin.json
+++ b/src/vendor/mpr-plugins/token/plugin.json
@@ -2,11 +2,19 @@
   "$schema": "https://maw.soulbrews.studio/schema/plugin.json",
   "name": "token",
   "version": "0.1.0",
-  "description": "Store & restore .envrc files via pass, manage active Claude OAuth tokens (#54).",
+  "description": "Store and restore .envrc files via pass, and manage active Claude OAuth tokens.",
   "author": "Soul-Brews-Studio",
   "license": "MIT",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
   "sdk": "^1.0.0",
   "schemaVersion": 1,
-  "entry": "./index.ts"
+  "entry": "./index.ts",
+  "cli": {
+    "command": "token",
+    "help": "maw token <list|use|current|save|load|scan> [args] — manage .envrc and Claude OAuth tokens securely",
+    "flags": {
+      "--no-team": "boolean",
+      "--force": "boolean"
+    }
+  }
 }

--- a/src/vendor/mpr-plugins/token/registry.meta.json
+++ b/src/vendor/mpr-plugins/token/registry.meta.json
@@ -2,7 +2,7 @@
   "version": "0.1.0",
   "source": "soul-brews-studio/maw-plugin-registry/token@v0.1.0-token",
   "sha256": null,
-  "summary": "Store & restore .envrc files via pass, manage active Claude OAuth tokens (#54).",
+  "summary": "Store and restore .envrc files via pass, and manage active Claude OAuth tokens.",
   "author": "Soul-Brews-Studio",
   "license": "MIT",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",

--- a/test/isolated/command-surface-help-copy.test.ts
+++ b/test/isolated/command-surface-help-copy.test.ts
@@ -75,9 +75,19 @@ describe("#1531 command-surface help copy", () => {
     expect(usage).toContain("maw rename");
   });
 
+  test("remaining real CLI plugins have explicit metadata and appear in usage", () => {
+    const names = ["dream", "oracle-skills", "park", "shellenv", "token"];
+    const usage = formatUsage(names.map((name) => plugin(`src/vendor/mpr-plugins/${name}`)));
+    for (const name of names) {
+      expect(help(`src/vendor/mpr-plugins/${name}/plugin.json`)).toContain(`maw ${name}`);
+      expect(usage).toContain(`maw ${name}`);
+    }
+  });
+
   test("vendored registry summaries mirror updated manifest descriptions", () => {
     for (const name of [
-      "ls", "peek", "capture", "view", "kill", "done", "sleep", "panes", "tab", "bg", "rename",
+      "ls", "peek", "capture", "view", "kill", "done", "sleep", "panes", "tab",
+      "bg", "rename", "dream", "oracle-skills", "park", "shellenv", "token",
     ]) {
       expect(summary(`src/vendor/mpr-plugins/${name}/registry.meta.json`)).toBe(
         desc(`src/vendor/mpr-plugins/${name}/plugin.json`),


### PR DESCRIPTION
## Summary
- declare explicit CLI metadata for the remaining real CLI plugins: dream, oracle-skills, park, shellenv, and token
- sync vendored registry summaries and plugin descriptions so top-level usage/help copy stays aligned
- keep strategy/API-only plugins (`attach-ssh`, `cross-team-queue`) out of the user-facing command surface for a later headless-plugin treatment

## Tests
- `rtk bun test test/isolated/command-surface-help-copy.test.ts --path-ignore-patterns '**/agents/**'`
- `rtk bun test test/plugin-manifest.test.ts test/isolated/command-surface-help-copy.test.ts --path-ignore-patterns '**/agents/**'`
- `rtk bun run test:mock-smoke`
- `rtk bun run build`
- `rtk git diff --check`
- temp `MAW_PLUGINS_DIR` smoke of `dist/maw --help` confirms `maw shellenv`, `maw token`, `maw oracle-skills`, `maw park`, and `maw dream` appear

## Release
No alpha release PR/cut created. Nat/human owns alpha releases.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
