### PR TITLE
fix(cli): keep headless plugins out of command dispatch

### DIFF
--- a/src/cli/dispatch-match.ts
+++ b/src/cli/dispatch-match.ts
@@ -33,23 +33,52 @@ export interface ResolvePluginMatchOptions {
 }
 
 /**
- * #899: a plugin is CLI-dispatchable if it has either a JS/TS entry or a
- * WASM module. Pure-API / pure-hooks / pure-cron plugins (no entry, no wasm,
- * no artifact) are not dispatchable — the default-cli-name path skips them
- * so unknown commands still error correctly instead of silently matching a
- * headless plugin and crashing inside invokePlugin.
+ * #899: a plugin is CLI-dispatchable if it has either an explicit `cli`
+ * manifest or an implicit legacy command surface. The implicit path exists
+ * for old source plugins that shipped `entry`/`wasm` but no `cli`. It must
+ * NOT catch strategy/API/module/hook surfaces such as attach-ssh or
+ * cross-team-queue: those have executable implementation files, but they are
+ * invoked by another host surface, not as `maw <plugin-name>`.
  */
-function isDispatchable(p: LoadedPlugin): boolean {
+function hasExecutableSurface(p: LoadedPlugin): boolean {
   if (p.kind === "ts" && p.entryPath) return true;
   if (p.kind === "wasm" && p.wasmPath) return true;
   return false;
 }
 
+function hasNonCliSurface(p: LoadedPlugin): boolean {
+  const m = p.manifest;
+  return Boolean(
+    m.api ||
+    m.hooks ||
+    m.cron ||
+    m.module ||
+    m.transport ||
+    (m.capabilities && m.capabilities.length > 0),
+  );
+}
+
+function isImplicitCliDispatchable(p: LoadedPlugin): boolean {
+  return hasExecutableSurface(p) && !hasNonCliSurface(p);
+}
+
+export function pluginNonCliSurfaces(p: LoadedPlugin): string[] {
+  const m = p.manifest;
+  const surfaces: string[] = [];
+  if (m.api) surfaces.push(`api:${m.api.methods.join("/")} ${m.api.path}`);
+  if (m.capabilities?.length) surfaces.push(`capability:${m.capabilities.join(",")}`);
+  if (m.hooks) surfaces.push(`hooks:${Object.keys(m.hooks).join(",")}`);
+  if (m.cron) surfaces.push(`cron:${m.cron.schedule}`);
+  if (m.module) surfaces.push(`module:${m.module.exports.join(",")}`);
+  if (m.transport?.peer) surfaces.push("peer");
+  return surfaces;
+}
+
 /**
  * #899: derive the CLI command names for a plugin. If `manifest.cli` is
  * present, use it (canonical command + aliases). Otherwise default to
- * `manifest.name` IFF the plugin is dispatchable. Returns `null` for
- * plugins that should not participate in CLI dispatch.
+ * `manifest.name` IFF the plugin is an implicit legacy CLI plugin. Returns
+ * `null` for plugins that should not participate in CLI dispatch.
  */
 export function pluginCliNames(p: LoadedPlugin): { command: string; aliases: string[] } | null {
   if (p.manifest.cli) {
@@ -58,7 +87,7 @@ export function pluginCliNames(p: LoadedPlugin): { command: string; aliases: str
       aliases: p.manifest.cli.aliases ?? [],
     };
   }
-  if (!isDispatchable(p)) return null;
+  if (!isImplicitCliDispatchable(p)) return null;
   return { command: p.manifest.name, aliases: [] };
 }
 

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -64,7 +64,7 @@ export async function dispatchCommand(cmd: string, args: string[]): Promise<void
  */
 async function dispatchPluginRegistry(cmd: string, args: string[]): Promise<void> {
   const { discoverPackages, invokePlugin } = await import("../plugin/registry");
-  const { resolvePluginMatch, pluginCliNames } = await import("./dispatch-match");
+  const { resolvePluginMatch, pluginCliNames, pluginNonCliSurfaces } = await import("./dispatch-match");
   const plugins = discoverPackages();
   const cmdName = args.join(" ").toLowerCase();
   const dispatch = resolvePluginMatch(plugins, cmdName);
@@ -99,6 +99,19 @@ async function dispatchPluginRegistry(cmd: string, args: string[]): Promise<void
     console.error(`  candidates: ${disabledDispatch.candidates.map(c => c.plugin).join(", ")}`);
     console.error(`  Run: maw plugin enable <name>`);
     throw new UserError(`disabled command: ${args[0]}`);
+  }
+
+  const headlessPlugin = plugins.find(p =>
+    !p.disabled &&
+    p.manifest.name.toLowerCase() === args[0].toLowerCase() &&
+    !pluginCliNames(p)
+  );
+  if (headlessPlugin) {
+    const surfaces = pluginNonCliSurfaces(headlessPlugin);
+    console.error(`\x1b[31m✗\x1b[0m '${args[0]}' is installed but has no CLI command.`);
+    if (surfaces.length > 0) console.error(`  surfaces: ${surfaces.join(", ")}`);
+    console.error(`  Run: maw plugin ls -v`);
+    throw new UserError(`headless plugin: ${args[0]}`);
   }
 
   // #388.2 — unknown command: fuzzy-suggest against the plugin registry.

--- a/test/cli/dispatch-match.test.ts
+++ b/test/cli/dispatch-match.test.ts
@@ -120,6 +120,36 @@ describe("resolvePluginMatch — two-pass dispatch", () => {
     expect(miss.kind).toBe("none");
   });
 
+  test("entry-backed API or capability plugins without cli are skipped as headless", () => {
+    const apiOnly: LoadedPlugin = {
+      manifest: {
+        name: "cross-team-queue",
+        version: "1.0.0",
+        sdk: "^1.0.0",
+        api: { path: "/cross-team-queue", methods: ["GET"] },
+      } as LoadedPlugin["manifest"],
+      dir: "/tmp/cross-team-queue",
+      wasmPath: "",
+      entryPath: "/tmp/cross-team-queue/src/index.ts",
+      kind: "ts",
+    };
+    const strategy: LoadedPlugin = {
+      manifest: {
+        name: "attach-ssh",
+        version: "1.0.0",
+        sdk: "^1.0.0",
+        capabilities: ["attach:strategy"],
+      } as LoadedPlugin["manifest"],
+      dir: "/tmp/attach-ssh",
+      wasmPath: "",
+      entryPath: "/tmp/attach-ssh/index.ts",
+      kind: "ts",
+    };
+
+    expect(resolvePluginMatch([apiOnly], "cross-team-queue").kind).toBe("none");
+    expect(resolvePluginMatch([strategy], "attach-ssh").kind).toBe("none");
+  });
+
   test("two plugins sharing same exact command → ambiguous", () => {
     const a = plugin("first", "share");
     const b = plugin("second", "share");

--- a/test/isolated/source-plugin-execution.test.ts
+++ b/test/isolated/source-plugin-execution.test.ts
@@ -31,6 +31,8 @@ function tsPlugin(opts: {
   name: string;
   cli?: { command: string; aliases?: string[] };
   entry?: boolean;
+  api?: boolean;
+  capabilities?: string[];
 }): LoadedPlugin {
   return {
     manifest: {
@@ -38,6 +40,8 @@ function tsPlugin(opts: {
       version: "1.0.0",
       sdk: "^1.0.0",
       ...(opts.cli ? { cli: { command: opts.cli.command, aliases: opts.cli.aliases ?? [], help: "" } } : {}),
+      ...(opts.api ? { api: { path: `/${opts.name}`, methods: ["GET"] } } : {}),
+      ...(opts.capabilities ? { capabilities: opts.capabilities } : {}),
     } as LoadedPlugin["manifest"],
     dir: `/tmp/${opts.name}`,
     wasmPath: "",
@@ -95,6 +99,14 @@ describe("#899 — pluginCliNames default-name derivation", () => {
       // no entryPath
     };
     expect(pluginCliNames(p)).toBeNull();
+  });
+
+  test("strategy/API plugins with entry but no cli are headless, not implicit commands", () => {
+    const strategy = tsPlugin({ name: "attach-ssh", capabilities: ["attach:strategy"] });
+    const api = tsPlugin({ name: "cross-team-queue", api: true });
+
+    expect(pluginCliNames(strategy)).toBeNull();
+    expect(pluginCliNames(api)).toBeNull();
   });
 
   test("aliases default to empty array when cli omits them", () => {
@@ -162,6 +174,14 @@ describe("#899 — resolvePluginMatch routes default-name plugins", () => {
     };
     const out = resolvePluginMatch([headless], "ghost");
     expect(out.kind).toBe("none");
+  });
+
+  test("entry-backed strategy/API plugins without cli do not default-name dispatch", () => {
+    const attachSsh = tsPlugin({ name: "attach-ssh", capabilities: ["attach:strategy"] });
+    const queue = tsPlugin({ name: "cross-team-queue", api: true });
+
+    expect(resolvePluginMatch([attachSsh], "attach-ssh")).toEqual({ kind: "none" });
+    expect(resolvePluginMatch([queue], "cross-team-queue")).toEqual({ kind: "none" });
   });
 
   test("unknown command still returns kind:none with a default-name registry", () => {


### PR DESCRIPTION
## Summary
- stop implicit default-name CLI dispatch for plugins that declare non-CLI surfaces (`api`, `hooks`, `cron`, `module`, `transport`, or `capabilities`)
- keep #899 backward compatibility for old pure source/WASM command plugins without explicit `cli` metadata
- add a clearer headless-plugin error for installed plugins such as `attach-ssh` instead of trying to invoke their host-facing implementation entry

## Why
`attach-ssh` is a strategy plugin and `cross-team-queue` is an API plugin. Both have implementation entry files, but neither is meant to run as `maw <plugin-name>`. The old default-name fallback treated any entry-backed plugin as a CLI command, which could route users into non-handler modules and crash.

## Tests
- `rtk bun test test/isolated/source-plugin-execution.test.ts test/cli/dispatch-match.test.ts test/isolated/command-surface-help-copy.test.ts test/plugin-manifest.test.ts --path-ignore-patterns '**/agents/**'`
- `rtk bun run test:mock-smoke`
- `rtk bun run build`
- `rtk git diff --check`
- source-mode temp `MAW_PLUGINS_DIR` smoke for `maw attach-ssh` headless-plugin hint

## Release
No alpha release PR/cut created. Nat/human owns alpha releases.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
