### PR TITLE
fix(plugin): resolve enable and disable through CLI aliases

### DIFF
--- a/src/commands/shared/plugins-toggle.ts
+++ b/src/commands/shared/plugins-toggle.ts
@@ -3,35 +3,55 @@
  */
 
 import { discoverPackages, resetDiscoverCache } from "../../plugin/registry";
+import { pluginCliNames } from "../../cli/dispatch-match";
+
+function resolvePluginToggleName(input: string): string {
+  const plugins = discoverPackages();
+  const exact = plugins.find(p => p.manifest.name === input);
+  if (exact) return exact.manifest.name;
+
+  const lower = input.toLowerCase();
+  const byCli = plugins.find(p => {
+    const cli = pluginCliNames(p);
+    if (!cli) return false;
+    return cli.command.toLowerCase() === lower
+      || cli.aliases.some(alias => alias.toLowerCase() === lower);
+  });
+  return byCli?.manifest.name ?? input;
+}
 
 export function doEnable(name: string): void {
   const { loadConfig, saveConfig } = require("../../config");
   const config = loadConfig();
   const disabled = config.disabledPlugins ?? [];
-  if (!disabled.includes(name)) {
-    console.log(`${name} is already enabled`);
+  const pluginName = resolvePluginToggleName(name);
+  if (!disabled.includes(pluginName)) {
+    const label = pluginName === name ? name : `${name} (${pluginName})`;
+    console.log(`${label} is already enabled`);
     return;
   }
-  saveConfig({ disabledPlugins: disabled.filter((n: string) => n !== name) });
+  saveConfig({ disabledPlugins: disabled.filter((n: string) => n !== pluginName) });
   resetDiscoverCache();  // config change → next discover call reflects it
-  console.log(`\x1b[32m✓\x1b[0m enabled ${name}`);
+  console.log(`\x1b[32m✓\x1b[0m enabled ${pluginName}`);
 }
 
 export function doDisable(name: string): void {
   const { loadConfig, saveConfig } = require("../../config");
   const config = loadConfig();
   const disabled = config.disabledPlugins ?? [];
-  if (disabled.includes(name)) {
-    console.log(`${name} is already disabled`);
+  const pluginName = resolvePluginToggleName(name);
+  if (disabled.includes(pluginName)) {
+    const label = pluginName === name ? name : `${name} (${pluginName})`;
+    console.log(`${label} is already disabled`);
     return;
   }
   // Verify plugin exists
   const plugins = discoverPackages();
-  if (!plugins.find(p => p.manifest.name === name)) {
+  if (!plugins.find(p => p.manifest.name === pluginName)) {
     console.error(`plugin not found: ${name}`);
     process.exit(1);
   }
-  saveConfig({ disabledPlugins: [...disabled, name] });
+  saveConfig({ disabledPlugins: [...disabled, pluginName] });
   resetDiscoverCache();  // config change → next discover call reflects it
-  console.log(`\x1b[33m✗\x1b[0m disabled ${name}`);
+  console.log(`\x1b[33m✗\x1b[0m disabled ${pluginName}`);
 }

--- a/test/isolated/plugins-toggle.test.ts
+++ b/test/isolated/plugins-toggle.test.ts
@@ -125,11 +125,12 @@ function run(fn: () => void): void {
 
 // ─── Fixture helpers ────────────────────────────────────────────────────────
 
-function plug(name: string, weight?: number): LoadedPlugin {
+function plug(name: string, weight?: number, cli?: LoadedPlugin["manifest"]["cli"]): LoadedPlugin {
   return {
-    manifest: { name, version: "1.0.0", sdk: "^1.0.0", ...(weight !== undefined && { weight }) },
+    manifest: { name, version: "1.0.0", sdk: "^1.0.0", ...(weight !== undefined && { weight }), ...(cli && { cli }) },
     dir: `/tmp/fake/${name}`,
     wasmPath: "",
+    entryPath: `/tmp/fake/${name}/index.ts`,
     kind: "ts",
   } as LoadedPlugin;
 }
@@ -206,6 +207,7 @@ describe("doEnable — already-enabled short-circuit", () => {
 describe("doEnable — enable branch", () => {
   test("name in disabledPlugins → saveConfig filters it, resetDiscoverCache, success log", () => {
     configStore = { disabledPlugins: ["foo", "bar"] };
+    discoverPackagesReturn = [plug("foo"), plug("bar")];
 
     run(() => doEnable("foo"));
 
@@ -219,6 +221,7 @@ describe("doEnable — enable branch", () => {
 
   test("name is the only disabled plugin → saveConfig with empty array", () => {
     configStore = { disabledPlugins: ["foo"] };
+    discoverPackagesReturn = [plug("foo")];
 
     run(() => doEnable("foo"));
 
@@ -227,10 +230,24 @@ describe("doEnable — enable branch", () => {
 
   test("resetDiscoverCache fires AFTER saveConfig (alpha.67 ordering)", () => {
     configStore = { disabledPlugins: ["foo"] };
+    discoverPackagesReturn = [plug("foo")];
 
     run(() => doEnable("foo"));
 
     expect(trace).toEqual(["saveConfig", "resetDiscoverCache"]);
+  });
+
+  test("#1541 — enable resolves CLI alias to owning plugin name", () => {
+    configStore = { disabledPlugins: ["about"] };
+    discoverPackagesReturn = [
+      plug("about", 10, { command: "about", aliases: ["info"], help: "maw about <oracle>" }),
+    ];
+
+    run(() => doEnable("info"));
+
+    expect(saveConfigCalls).toEqual([{ disabledPlugins: [] }]);
+    expect(resetDiscoverCacheCalls).toBe(1);
+    expect(outs.join("\n")).toContain("enabled about");
   });
 
   test("preserves OTHER disabled plugins unchanged", () => {
@@ -318,6 +335,19 @@ describe("doDisable — disable branch", () => {
 
     expect(saveConfigCalls).toEqual([{ disabledPlugins: ["foo"] }]);
     expect(resetDiscoverCacheCalls).toBe(1);
+  });
+
+  test("#1541 — disable resolves CLI alias to owning plugin name", () => {
+    configStore = { disabledPlugins: [] };
+    discoverPackagesReturn = [
+      plug("about", 10, { command: "about", aliases: ["info"], help: "maw about <oracle>" }),
+    ];
+
+    run(() => doDisable("info"));
+
+    expect(saveConfigCalls).toEqual([{ disabledPlugins: ["about"] }]);
+    expect(resetDiscoverCacheCalls).toBe(1);
+    expect(outs.join("\n")).toContain("disabled about");
   });
 
   test("resetDiscoverCache fires AFTER saveConfig (alpha.67 ordering)", () => {


### PR DESCRIPTION
Fixes #1541.

## Summary
- Resolve `maw plugin enable <command-or-alias>` through plugin CLI metadata before mutating `disabledPlugins`.
- Apply the same alias resolution to `maw plugin disable <command-or-alias>` so toggles stay symmetric.
- Preserve exact plugin-name behavior and keep unknown-plugin errors tied to the typed input.

## Validation
- `rtk bun test test/isolated/plugins-toggle.test.ts test/cli/dispatch-match.test.ts test/isolated/source-plugin-execution.test.ts --path-ignore-patterns '**/agents/**'`
- `rtk bun run test:mock-smoke`
- `rtk bun run build`
- `rtk git diff --check`
- Temp `MAW_CONFIG_DIR` smoke: disabled `about`, ran `bun src/cli.ts plugin enable info`, confirmed config removed `about`.

## Release note
No alpha release PR/cut from this change. Nat/human owns alpha release creation.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
