### PR TITLE
fix(cli): reserve awake for launch semantics

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -49,6 +49,7 @@ export const ALIAS_DESCRIPTIONS: Record<string, string> = {
   b: "Bring an oracle HERE (short form of `bring`)",
   ls: "List sessions (compact, -a roster, -v detail)",
   wake: "Wake an oracle session (fuzzy match, auto-clone)",
+  awake: "Launch an oracle process with optional engine (does not trigger /awaken)",
   new: "Create a new oracle (friendly door for awaken)",
   preflight: "Pre-flight check — version, plugins, dead agents, config",
 };
@@ -78,6 +79,7 @@ export const TOP_ALIASES: Record<string, string[] | DirectHandler> = {
   // Direct-handler form — cmdWake is in core (src/commands/shared/wake-cmd.ts)
   // even though the wake/ plugin was extracted to the registry in #918.
   wake: { kind: "direct", handler: "../commands/shared/wake-cmd:cmdWake" },
+  awake: { kind: "direct", handler: "../commands/shared/wake-cmd:cmdAwake" },
   new: { kind: "direct", handler: "./cmd-new:cmdNew" },
 
   preflight: { kind: "direct", handler: "../commands/shared/preflight:cmdPreflight" },
@@ -142,6 +144,16 @@ function printBringUsage(write: (line: string) => void = console.log): void {
   write("  Symmetric with `maw a` (attach goes there, bring comes here).");
 }
 
+function printWakeAliasUsage(verb: "wake" | "awake", write: (line: string) => void = console.log): void {
+  write(`usage: maw ${verb} <oracle> [--task <s>] [--wt <s>] [-p|--prompt <s>] [--incubate <slug>] [--fresh] [-a|--attach] [--list] [--split] [--all-local] [-e|--engine <name>]`);
+  if (verb === "awake") {
+    write("  Launch/start an oracle process with the selected engine. Does not send /awaken.");
+    write("  Use `maw awaken` for the awakening ritual; use `maw new` for the creation door.");
+  } else {
+    write("  Wake or reuse an oracle session, fuzzy-resolving repos and worktrees as needed.");
+  }
+}
+
 /**
  * Invoke a direct-handler alias. Used by `wake` and `ls`.
  *
@@ -178,7 +190,13 @@ export async function invokeDirectHandler(
     return;
   }
 
-  if (exportName === "cmdWake") {
+  if (exportName === "cmdWake" || exportName === "cmdAwake") {
+    const verb = exportName === "cmdAwake" ? "awake" : "wake";
+    if (argv.some(a => a === "-h" || a === "--help" || a === "-help")) {
+      printWakeAliasUsage(verb);
+      return;
+    }
+
     const flags = parseFlags(argv, {
       "--task": String,
       "--wt": String,
@@ -195,8 +213,8 @@ export async function invokeDirectHandler(
     const positional = flags._;
     const oracle = positional[0];
     if (!oracle) {
-      console.error("usage: maw wake <oracle> [--task <s>] [--wt <s>] [-p|--prompt <s>] [--incubate <slug>] [--fresh] [-a|--attach] [--list] [--split] [--all-local] [-e|--engine <name>]");
-      throw new UserError("wake: missing oracle name");
+      printWakeAliasUsage(verb, console.error);
+      throw new UserError(`${verb}: missing oracle name`);
     }
 
     const opts: {

--- a/test/cli/dispatch-match.test.ts
+++ b/test/cli/dispatch-match.test.ts
@@ -288,6 +288,19 @@ describe("resolveTopAlias — RFC #954 verb aliases", () => {
     }
   });
 
+  test("`awake neo -e codex` → direct launch handler, not awaken prefix", () => {
+    const out = resolveTopAlias(["awake", "neo", "-e", "codex"]);
+    expect(out).not.toBeNull();
+    expect(out!.kind).toBe("direct");
+    if (out!.kind === "direct") {
+      expect(out!.handler).toContain("wake-cmd");
+      expect(out!.handler).toContain("cmdAwake");
+      expect(out!.argv).toEqual(["neo", "-e", "codex"]);
+    }
+    expect(ALIAS_DESCRIPTIONS.awake).toContain("Launch");
+    expect(ALIAS_DESCRIPTIONS.awake).toContain("does not trigger /awaken");
+  });
+
   test("`new neo --no-attach` → direct-handler cmdNew friendly creation door", () => {
     const out = resolveTopAlias(["new", "neo", "--no-attach"]);
     expect(out).not.toBeNull();


### PR DESCRIPTION
Partial progress for #1542.

## Summary
- Adds an explicit top-level `maw awake` direct handler so `awake` no longer prefix-resolves to `awaken`.
- `maw awake --help` now shows launch/process semantics and explicitly says it does not send `/awaken`.
- Keeps `maw wake`, `maw awaken`, and `maw new` as separate help rows so the command surface no longer hides the awake/awaken distinction.

## Scope note
This PR intentionally does **not** change `maw new` to scaffold-only or rewrite `maw awaken` away from the existing bud+wake+trigger behavior. Those would reverse recently restored #1272/#1497 behavior and should be a separate product decision/migration. This PR fixes the clear routing bug: `awake` was not reserved and therefore fell through to the `awaken` prefix path.

## Validation
- `rtk bun test test/cli/dispatch-match.test.ts --path-ignore-patterns '**/agents/**'`
- `MAW_TEST_MODE=1 bun src/cli.ts awake --help`
- `MAW_TEST_MODE=1 bun src/cli.ts awaken --help`
- `MAW_TEST_MODE=1 bun src/cli.ts new --help`
- `MAW_TEST_MODE=1 bun src/cli.ts --help` grep for awake/awaken/wake/new
- `rtk bun run test:mock-smoke`
- `rtk bun run build`
- `rtk git diff --check`

No alpha release PR/cut from this change. Nat/human owns alpha release creation.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
