### PR TITLE
fix(cli): show comm usage for help flags

### DIFF
--- a/src/cli/route-comm.ts
+++ b/src/cli/route-comm.ts
@@ -1,6 +1,17 @@
 import { cmdPeek, cmdSend } from "../commands/shared/comm";
 import { UserError } from "../core/util/user-error";
 
+function printCommUsage(cmd: "hey" | "send", write: (line: string) => void = console.log): void {
+  write(`usage: maw ${cmd} <target> <message> [--force] [--approve] [--trust]`);
+  write("  target forms (#759 Phase 2 — bare names removed):");
+  write("    local:<agent>                this node");
+  write("    <node>:<session>             canonical cross-node form (window 1)");
+  write("    <node>:<session>:<window>    target a specific tmux window (#410)");
+  write(`  e.g. maw ${cmd} local:mawjs "hello from neo"`);
+  write(`       maw ${cmd} phaith:01-hojo:3 "hello hojo-hermes"`);
+  write("       run `maw locate <agent>` to enumerate across federation");
+}
+
 export async function routeComm(cmd: string, args: string[]): Promise<boolean> {
   // `peek` is a federation-aware comm verb. Keep `maw tmux peek` as the raw
   // tmux pane reader; top-level `maw peek <node>:<agent>` must reach cmdPeek.
@@ -14,6 +25,11 @@ export async function routeComm(cmd: string, args: string[]): Promise<boolean> {
   // The raw-text compositor plugin remains available through lower-level tmux
   // verbs; top-level `send` must not leave text buffered without Enter.
   if (cmd === "hey" || cmd === "send") {
+    if (args[1] === "--help" || args[1] === "-h" || args[1] === "-help") {
+      printCommUsage(cmd);
+      return true;
+    }
+
     const force = args.includes("--force");
     // #842 Sub-C — `--approve` bypasses the cross-scope ACL queue gate.
     // Operator-explicit opt-in for THIS message; mirrors the consent
@@ -33,14 +49,7 @@ export async function routeComm(cmd: string, args: string[]): Promise<boolean> {
     // same "usage:" error. Now the missing-message case names the target
     // so the user sees their input got through.
     if (!target) {
-      console.error(`usage: maw ${cmd} <target> <message> [--force]`);
-      console.error("  target forms (#759 Phase 2 — bare names removed):");
-      console.error("    local:<agent>                this node");
-      console.error("    <node>:<session>             canonical cross-node form (window 1)");
-      console.error("    <node>:<session>:<window>    target a specific tmux window (#410)");
-      console.error(`  e.g. maw ${cmd} local:mawjs "hello from neo"`);
-      console.error(`       maw ${cmd} phaith:01-hojo:3 "hello hojo-hermes"`);
-      console.error("       run `maw locate <agent>` to enumerate across federation");
+      printCommUsage(cmd, console.error);
       throw new UserError("missing target and message");
     }
     if (!msgArgs.length) {

--- a/test/isolated/route-comm-send.test.ts
+++ b/test/isolated/route-comm-send.test.ts
@@ -6,21 +6,28 @@
  * through the transport and reports `delivered` instead of leaving text in the
  * target prompt buffer.
  */
-import { describe, test, expect, mock, beforeEach } from "bun:test";
+import { describe, test, expect, mock, beforeEach, afterAll } from "bun:test";
 
 const calls: unknown[][] = [];
 const peekCalls: unknown[][] = [];
+const logs: string[] = [];
 
 mock.module("../../src/commands/shared/comm", () => ({
   cmdSend: async (...args: unknown[]) => { calls.push(args); },
   cmdPeek: async (...args: unknown[]) => { peekCalls.push(args); },
 }));
 
+const origLog = console.log;
+console.log = (...args: unknown[]) => { logs.push(args.map(String).join(" ")); };
+
 const { routeComm } = await import("../../src/cli/route-comm");
+
+afterAll(() => { console.log = origLog; });
 
 beforeEach(() => {
   calls.length = 0;
   peekCalls.length = 0;
+  logs.length = 0;
 });
 
 describe("routeComm — top-level send uses core delivery (#1388)", () => {
@@ -49,6 +56,23 @@ describe("routeComm — top-level send uses core delivery (#1388)", () => {
     expect(calls).toEqual([
       ["local:mawjs", "ping", false, { approve: false, trust: false }],
     ]);
+  });
+
+  test("maw send --help prints usage instead of treating --help as a target (#1531)", async () => {
+    const handled = await routeComm("send", ["send", "--help"]);
+
+    expect(handled).toBe(true);
+    expect(calls).toEqual([]);
+    expect(logs.join("\n")).toContain("usage: maw send <target> <message>");
+    expect(logs.join("\n")).toContain("local:<agent>");
+  });
+
+  test("maw hey -h prints usage instead of treating -h as a target (#1531)", async () => {
+    const handled = await routeComm("hey", ["hey", "-h"]);
+
+    expect(handled).toBe(true);
+    expect(calls).toEqual([]);
+    expect(logs.join("\n")).toContain("usage: maw hey <target> <message>");
   });
 
   test("maw peek routes through federation-aware cmdPeek, not tmux alias", async () => {


### PR DESCRIPTION
Part of #1531.

## Summary
- `maw send --help` and `maw hey --help` now render comm usage instead of treating `--help` as a federation target.
- Shared the usage text between explicit help and the zero-arg error path so examples/target forms stay in sync.
- Adds route-level regression coverage for `send --help` and `hey -h`.

## Validation
- `rtk bun test test/isolated/route-comm-send.test.ts --path-ignore-patterns '**/agents/**'`
- `MAW_TEST_MODE=1 bun src/cli.ts send --help`
- `MAW_TEST_MODE=1 bun src/cli.ts hey --help`
- Active command help audit across 47 commands: `count_bad 0 of 47`
- `rtk bun run build`
- `rtk git diff --check`

No alpha release PR/cut from this change. Nat/human owns alpha release creation.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
