### PR TITLE
chore(cli): declare JSON flags in plugin metadata

### DIFF
--- a/src/commands/plugins/federation/plugin.json
+++ b/src/commands/plugins/federation/plugin.json
@@ -10,7 +10,15 @@
     "aliases": [
       "fed"
     ],
-    "help": "maw federation <status|sync> [--dry-run|--check|--prune|--force|--json]"
+    "help": "maw federation <status|sync> [--dry-run|--check|--prune|--force|--json]",
+    "flags": {
+      "--dry-run": "boolean",
+      "--check": "boolean",
+      "--prune": "boolean",
+      "--force": "boolean",
+      "--verify": "boolean",
+      "--json": "boolean"
+    }
   },
   "weight": 10
 }

--- a/src/commands/plugins/oracle/plugin.json
+++ b/src/commands/plugins/oracle/plugin.json
@@ -9,7 +9,12 @@
     "aliases": [
       "oracles"
     ],
-    "help": "maw oracle [ls|scan|fleet|about <name>]"
+    "help": "maw oracle [ls|scan|fleet|about <name>|search <query>] [--json]",
+    "flags": {
+      "--json": "boolean",
+      "--awake": "boolean",
+      "--org": "string"
+    }
   },
   "api": {
     "path": "/api/oracle",

--- a/src/commands/plugins/tmux/plugin.json
+++ b/src/commands/plugins/tmux/plugin.json
@@ -7,7 +7,14 @@
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "tmux",
-    "help": "maw tmux <peek> — peek a pane by id (%N), session:w.p, or team-agent name"
+    "help": "maw tmux <peek|ls|attach|kill|open|close|zoom> [...] — tmux pane/session tools; ls supports --json",
+    "flags": {
+      "--json": "boolean",
+      "--all": "boolean",
+      "--compact": "boolean",
+      "--verbose": "boolean",
+      "--roster": "boolean"
+    }
   },
   "weight": 10,
   "tier": "standard"

--- a/src/vendor/mpr-plugins/costs/plugin.json
+++ b/src/vendor/mpr-plugins/costs/plugin.json
@@ -7,7 +7,12 @@
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "costs",
-    "help": "maw costs — show token usage and cost breakdown per agent"
+    "help": "maw costs [--daily] [--days N] [--json] — show token usage and cost breakdown per agent",
+    "flags": {
+      "--daily": "boolean",
+      "--days": "number",
+      "--json": "boolean"
+    }
   },
   "weight": 50,
   "license": "MIT",

--- a/src/vendor/mpr-plugins/locate/plugin.json
+++ b/src/vendor/mpr-plugins/locate/plugin.json
@@ -6,7 +6,11 @@
   "description": "Locate an oracle — repo path, session, fleet config, federation node. Diagnostic, no side effects.",
   "cli": {
     "command": "locate",
-    "help": "maw locate <oracle> [--path | --json]"
+    "help": "maw locate <oracle> [--path | --json]",
+    "flags": {
+      "--path": "boolean",
+      "--json": "boolean"
+    }
   },
   "weight": 15,
   "license": "MIT",

--- a/src/vendor/mpr-plugins/ls/plugin.json
+++ b/src/vendor/mpr-plugins/ls/plugin.json
@@ -10,7 +10,12 @@
     "aliases": [
       "list"
     ],
-    "help": "maw ls [<peer>] [--all] [--json] [--fix] — list live sessions; see maw fleet ls for registered fleet config"
+    "help": "maw ls [<peer>] [--all] [--json] [--fix] — list live sessions; see maw fleet ls for registered fleet config",
+    "flags": {
+      "--all": "boolean",
+      "--json": "boolean",
+      "--fix": "boolean"
+    }
   },
   "weight": 0,
   "license": "MIT",

--- a/src/vendor/mpr-plugins/peers/plugin.json
+++ b/src/vendor/mpr-plugins/peers/plugin.json
@@ -10,7 +10,13 @@
     "aliases": [
       "peer"
     ],
-    "help": "maw peers <add|list|info|remove> [...] — federation peer aliases (see issue #568)"
+    "help": "maw peers <add|list|info|remove> [...] — federation peer aliases; list supports --discovered --all --json --limit N",
+    "flags": {
+      "--discovered": "boolean",
+      "--all": "boolean",
+      "--json": "boolean",
+      "--limit": "number"
+    }
   },
   "weight": 30,
   "tier": "standard",

--- a/src/vendor/mpr-plugins/zenoh-scout/plugin.json
+++ b/src/vendor/mpr-plugins/zenoh-scout/plugin.json
@@ -23,7 +23,13 @@
       "discover",
       "zenoh-scout"
     ],
-    "help": "maw scout [--force] [--json] [--locator ws://127.0.0.1:10000] [--timeout <ms>] — query opt-in Zenoh discovery"
+    "help": "maw scout [--force] [--json] [--locator ws://127.0.0.1:10000] [--timeout <ms>] — query opt-in Zenoh discovery",
+    "flags": {
+      "--force": "boolean",
+      "--json": "boolean",
+      "--locator": "string",
+      "--timeout": "number"
+    }
   },
   "weight": 30,
   "license": "MIT",


### PR DESCRIPTION
Part of #1531.

## Summary
- Adds `cli.flags` metadata for `--json` on commands that already support or document structured output:
  - `ls`, `peers`, `locate`, `scout`, `federation`, `oracle`, `tmux`, `costs`
- Refreshes a few help strings so registry/help surfaces mention the JSON-capable subcommands more accurately.
- No new command behavior in this slice; this is metadata/help consistency for already-supported flags.

## Validation
- `rtk bun test test/plugin-manifest.test.ts --path-ignore-patterns '**/agents/**'`
- `jq` manifest check that all 8 updated plugins declare `cli.flags["--json"] == "boolean"`
- `rtk bun run build`
- `rtk git diff --check`

No alpha release PR/cut from this change. Nat/human owns alpha release creation.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
