### PR TITLE
fix(plugin): show dependency enable plans before dispatch

### DIFF
--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -76,6 +76,18 @@ async function dispatchPluginRegistry(cmd: string, args: string[]): Promise<void
   }
   if (dispatch.kind === "match") {
     const matchedWords = dispatch.matchedName.split(/\s+/).filter(Boolean).length;
+    const { dependencyStatus } = await import("../plugin/dependencies");
+    const deps = dependencyStatus(dispatch.plugin, plugins);
+    if (deps.missing.length > 0) {
+      console.error(`\x1b[31m✗\x1b[0m '${dispatch.matchedName}' needs missing plugins: ${deps.missing.join(", ")}`);
+      console.error("  Install or link them, then retry.");
+      throw new UserError(`missing plugin dependency: ${dispatch.matchedName}`);
+    }
+    if (deps.disabled.length > 0) {
+      console.error(`\x1b[31m✗\x1b[0m '${dispatch.matchedName}' needs disabled plugins: ${deps.disabled.join(", ")}`);
+      console.error(`  Run: maw plugin enable ${deps.disabled.join(" ")}`);
+      throw new UserError(`disabled plugin dependency: ${dispatch.matchedName}`);
+    }
     const remaining = args.slice(matchedWords);
     const result = await invokePlugin(dispatch.plugin, { source: "cli", args: remaining });
     if (result.ok && result.output) console.log(result.output);
@@ -90,8 +102,13 @@ async function dispatchPluginRegistry(cmd: string, args: string[]): Promise<void
   );
   if (disabledDispatch.kind === "match") {
     const pluginName = disabledDispatch.plugin.manifest.name;
-    console.error(`\x1b[31m✗\x1b[0m '${args[0]}' is installed but disabled.`);
-    console.error(`  Run: maw plugin enable ${pluginName}`);
+    const { enablePlanFor } = await import("../plugin/dependencies");
+    const plan = enablePlanFor(disabledDispatch.plugin, plugins, true);
+    const label = args[0].toLowerCase() === pluginName.toLowerCase()
+      ? `'${args[0]}' is installed but disabled.`
+      : `'${args[0]}' is provided by disabled plugin '${pluginName}'.`;
+    console.error(`\x1b[31m✗\x1b[0m ${label}`);
+    console.error(`  Run: maw plugin enable ${(plan.length ? plan : [pluginName]).join(" ")}`);
     throw new UserError(`disabled command: ${args[0]}`);
   }
   if (disabledDispatch.kind === "ambiguous") {

--- a/src/cli/route-tools.ts
+++ b/src/cli/route-tools.ts
@@ -2,8 +2,8 @@
 // pass through invokePlugin, so they need their own --help guard to prevent
 // `maw plugin list --help` / `maw agents --help` from running real work.
 const CORE_HELP: Record<string, string> = {
-  plugins: "usage: maw plugins [ls|info <name>|remove <name>|lean|standard|full|nuke|enable <name>|disable <name>] [--json] [--all] [--force]",
-  plugin: "usage: maw plugin <init|build|install|create|ls|info|remove|enable|disable> [args]",
+  plugins: "usage: maw plugins [ls|info <name>|remove <name>|lean|standard|full|nuke|enable <name...>|disable <name>] [--json] [--all] [--force]",
+  plugin: "usage: maw plugin <init|build|install|create|ls|info|remove|enable <name...>|disable> [args]",
   artifacts: "usage: maw artifacts [ls|get] [team] [task-id] [--json]",
   artifact: "usage: maw artifact [ls|get] [team] [task-id] [--json]",
   agents: "usage: maw agents [--json] [--all] [--node <node>]",

--- a/src/commands/shared/plugins-toggle.ts
+++ b/src/commands/shared/plugins-toggle.ts
@@ -4,9 +4,9 @@
 
 import { discoverPackages, resetDiscoverCache } from "../../plugin/registry";
 import { pluginCliNames } from "../../cli/dispatch-match";
+import { pluginDependencyNames } from "../../plugin/dependencies";
 
-function resolvePluginToggleName(input: string): string {
-  const plugins = discoverPackages();
+function resolvePluginToggleName(input: string, plugins = discoverPackages()): string {
   const exact = plugins.find(p => p.manifest.name === input);
   if (exact) return exact.manifest.name;
 
@@ -20,19 +20,48 @@ function resolvePluginToggleName(input: string): string {
   return byCli?.manifest.name ?? input;
 }
 
-export function doEnable(name: string): void {
+export function doEnable(nameOrNames: string | string[]): void {
   const { loadConfig, saveConfig } = require("../../config");
   const config = loadConfig();
   const disabled = config.disabledPlugins ?? [];
-  const pluginName = resolvePluginToggleName(name);
-  if (!disabled.includes(pluginName)) {
-    const label = pluginName === name ? name : `${name} (${pluginName})`;
+  const disabledSet = new Set(disabled as string[]);
+  const plugins = discoverPackages();
+  const names = Array.isArray(nameOrNames) ? nameOrNames : [nameOrNames];
+  const requested = names.map(name => ({ input: name, pluginName: resolvePluginToggleName(name, plugins) }));
+  const byName = new Map(plugins.map(p => [p.manifest.name, p]));
+  const toEnable: string[] = [];
+
+  function addIfDisabled(pluginName: string): void {
+    if (disabledSet.has(pluginName) && !toEnable.includes(pluginName)) toEnable.push(pluginName);
+  }
+
+  function addDisabledDependencies(pluginName: string, seen = new Set<string>()): void {
+    if (seen.has(pluginName)) return;
+    seen.add(pluginName);
+    const plugin = byName.get(pluginName);
+    if (!plugin) return;
+    for (const dep of pluginDependencyNames(plugin)) {
+      addDisabledDependencies(dep, seen);
+      addIfDisabled(dep);
+    }
+  }
+
+  for (const { pluginName } of requested) {
+    addDisabledDependencies(pluginName);
+    addIfDisabled(pluginName);
+  }
+
+  if (toEnable.length === 0) {
+    const label = requested.length === 1 && requested[0].pluginName !== requested[0].input
+      ? `${requested[0].input} (${requested[0].pluginName})`
+      : names.join(", ");
     console.log(`${label} is already enabled`);
     return;
   }
-  saveConfig({ disabledPlugins: disabled.filter((n: string) => n !== pluginName) });
+  const enableSet = new Set(toEnable);
+  saveConfig({ disabledPlugins: disabled.filter((n: string) => !enableSet.has(n)) });
   resetDiscoverCache();  // config change → next discover call reflects it
-  console.log(`\x1b[32m✓\x1b[0m enabled ${pluginName}`);
+  console.log(`\x1b[32m✓\x1b[0m enabled ${toEnable.join(", ")}`);
 }
 
 export function doDisable(name: string): void {

--- a/src/commands/shared/plugins.ts
+++ b/src/commands/shared/plugins.ts
@@ -68,8 +68,8 @@ export async function cmdPlugins(
       }
       return doRemove(name, discover);
     case "enable": {
-      if (!name) { console.error("usage: maw plugin enable <name>"); process.exit(1); }
-      return doEnable(name);
+      if (!name) { console.error("usage: maw plugin enable <name> [more...]"); process.exit(1); }
+      return doEnable(flags._);
     }
     case "disable": {
       if (!name) { console.error("usage: maw plugin disable <name>"); process.exit(1); }

--- a/src/plugin/dependencies.ts
+++ b/src/plugin/dependencies.ts
@@ -1,0 +1,39 @@
+import type { LoadedPlugin } from "./types";
+
+export type PluginDependencyStatus = {
+  disabled: string[];
+  missing: string[];
+};
+
+export function pluginDependencyNames(plugin: LoadedPlugin): string[] {
+  return plugin.manifest.dependencies?.plugins ?? [];
+}
+
+export function dependencyStatus(plugin: LoadedPlugin, plugins: LoadedPlugin[]): PluginDependencyStatus {
+  const byName = new Map(plugins.map(p => [p.manifest.name, p]));
+  const disabled: string[] = [];
+  const missing: string[] = [];
+  const seen = new Set<string>();
+
+  function visit(name: string): void {
+    if (seen.has(name)) return;
+    seen.add(name);
+    const dep = byName.get(name);
+    if (!dep) {
+      missing.push(name);
+      return;
+    }
+    for (const child of pluginDependencyNames(dep)) visit(child);
+    if (dep.disabled) disabled.push(name);
+  }
+
+  for (const name of pluginDependencyNames(plugin)) visit(name);
+  return { disabled, missing };
+}
+
+export function enablePlanFor(plugin: LoadedPlugin, plugins: LoadedPlugin[], includeSelf: boolean): string[] {
+  const { disabled } = dependencyStatus(plugin, plugins);
+  const plan = [...disabled];
+  if (includeSelf && plugin.disabled) plan.push(plugin.manifest.name);
+  return [...new Set(plan)];
+}

--- a/src/plugin/manifest-parse.ts
+++ b/src/plugin/manifest-parse.ts
@@ -15,6 +15,7 @@ import {
   parseTransport,
   parseTarget,
   parseCapabilities,
+  parseDependencies,
   parseArtifact,
   parseTier,
 } from "./manifest-validate";
@@ -91,6 +92,7 @@ export function parseManifest(jsonText: string, dir: string): PluginManifest {
   const transport = parseTransport(r);
   const target = parseTarget(r);
   const capabilities = parseCapabilities(r);
+  const dependencies = parseDependencies(r);
   const artifact = parseArtifact(r);
   const tier = parseTier(r);
 
@@ -112,6 +114,7 @@ export function parseManifest(jsonText: string, dir: string): PluginManifest {
     ...(transport ? { transport } : {}),
     ...(target ? { target } : {}),
     ...(capabilities ? { capabilities } : {}),
+    ...(dependencies ? { dependencies } : {}),
     ...(artifact ? { artifact } : {}),
   };
 }

--- a/src/plugin/manifest-validate.ts
+++ b/src/plugin/manifest-validate.ts
@@ -4,7 +4,7 @@
  */
 
 import type { PluginManifest, PluginTier } from "./types";
-import { KNOWN_CAPABILITY_NAMESPACES } from "./manifest-constants";
+import { KNOWN_CAPABILITY_NAMESPACES, NAME_RE } from "./manifest-constants";
 import { getRuntimeVersionString } from "../core/runtime/build-info";
 
 const VALID_TIERS = new Set<PluginTier>(["core", "standard", "extra"]);
@@ -177,6 +177,27 @@ export function parseCapabilities(r: Record<string, unknown>): PluginManifest["c
     }
   }
   return capabilities;
+}
+
+export function parseDependencies(r: Record<string, unknown>): PluginManifest["dependencies"] {
+  if (r.dependencies === undefined) return undefined;
+
+  const raw = r.dependencies;
+  let plugins: unknown;
+  if (Array.isArray(raw)) {
+    // Compact legacy-friendly shape: "dependencies": ["trace", "dig"]
+    plugins = raw;
+  } else if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+    plugins = (raw as Record<string, unknown>).plugins;
+  } else {
+    throw new Error("plugin.json: dependencies must be an object or array of plugin names");
+  }
+
+  if (plugins === undefined) return {};
+  if (!Array.isArray(plugins) || plugins.some((p: unknown) => typeof p !== "string" || !NAME_RE.test(p))) {
+    throw new Error("plugin.json: dependencies.plugins must be an array of plugin names");
+  }
+  return { plugins: plugins as string[] };
 }
 
 export function parseArtifact(r: Record<string, unknown>): PluginManifest["artifact"] {

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -40,6 +40,9 @@ export interface PluginManifest {
   sdk: string;            // semver range e.g. "^1.0.0"
   target?: PluginTarget;  // compile target (Phase A: "js" only)
   capabilities?: string[];// declared capability strings "namespace:verb" (advisory in Phase A)
+  dependencies?: {        // other maw plugins this plugin needs before dispatch
+    plugins?: string[];
+  };
   artifact?: PluginArtifact; // built-plugin artifact descriptor
   cli?: {
     command: string;

--- a/test/isolated/plugin-default-active-migration.test.ts
+++ b/test/isolated/plugin-default-active-migration.test.ts
@@ -34,6 +34,13 @@ function makePluginDir(): string {
   return dir;
 }
 
+function writeTsPlugin(root: string, manifest: Record<string, unknown>, source = "export default async () => ({ ok: true, output: 'ran' });\n"): void {
+  const dir = join(root, manifest.name as string);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "index.ts"), source);
+  writeFileSync(join(dir, "plugin.json"), JSON.stringify({ version: "1.0.0", sdk: "*", entry: "index.ts", ...manifest }, null, 2) + "\n");
+}
+
 function loadInSubprocess(home: string) {
   return spawnSync("bun", ["-e", `
     const { loadConfig } = await import("${REPO_ROOT}/src/config/load.ts");
@@ -352,6 +359,79 @@ describe("#1500 default-active plugin migration", () => {
     expect(result.stderr).toContain("'completions' is installed but disabled");
     expect(result.stderr).toContain("maw plugin enable completions");
     expect(result.stderr).not.toContain("did you mean: completions");
+  });
+
+  test("#1547: active plugin with disabled dependencies prints enable plan before dispatch", () => {
+    const home = makeHome({
+      host: "local",
+      port: 3456,
+      oracleUrl: "http://localhost:47779",
+      env: {},
+      commands: { default: "claude" },
+      sessions: {},
+      disabledPlugins: ["trace", "dig"],
+    });
+    const pluginDir = makePluginDir();
+    writeTsPlugin(pluginDir, { name: "trace", cli: { command: "trace" } });
+    writeTsPlugin(pluginDir, { name: "dig", cli: { command: "dig" } });
+    writeTsPlugin(pluginDir, {
+      name: "needs-context",
+      cli: { command: "needs-context" },
+      dependencies: { plugins: ["trace", "dig"] },
+    });
+
+    const result = spawnSync("bun", ["src/cli.ts", "--quiet", "needs-context"], {
+      cwd: REPO_ROOT,
+      env: {
+        ...process.env,
+        MAW_HOME: home,
+        MAW_PLUGINS_DIR: pluginDir,
+        MAW_TEST_MODE: "1",
+      },
+      encoding: "utf-8",
+      timeout: 10_000,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).not.toContain("ran");
+    expect(result.stderr).toContain("'needs-context' needs disabled plugins: trace, dig");
+    expect(result.stderr).toContain("maw plugin enable trace dig");
+  });
+
+  test("#1547: disabled command hint includes dependency-first enable plan", () => {
+    const home = makeHome({
+      host: "local",
+      port: 3456,
+      oracleUrl: "http://localhost:47779",
+      env: {},
+      commands: { default: "claude" },
+      sessions: {},
+      disabledPlugins: ["trace", "dig", "needs-context"],
+    });
+    const pluginDir = makePluginDir();
+    writeTsPlugin(pluginDir, { name: "trace", cli: { command: "trace" } });
+    writeTsPlugin(pluginDir, { name: "dig", cli: { command: "dig" } });
+    writeTsPlugin(pluginDir, {
+      name: "needs-context",
+      cli: { command: "needs-context", aliases: ["nc"] },
+      dependencies: { plugins: ["trace", "dig"] },
+    });
+
+    const result = spawnSync("bun", ["src/cli.ts", "--quiet", "nc"], {
+      cwd: REPO_ROOT,
+      env: {
+        ...process.env,
+        MAW_HOME: home,
+        MAW_PLUGINS_DIR: pluginDir,
+        MAW_TEST_MODE: "1",
+      },
+      encoding: "utf-8",
+      timeout: 10_000,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("'nc' is provided by disabled plugin 'needs-context'");
+    expect(result.stderr).toContain("maw plugin enable trace dig needs-context");
   });
 
   test("completions plugin emits command list plus zsh/bash scripts", () => {

--- a/test/isolated/plugins-toggle.test.ts
+++ b/test/isolated/plugins-toggle.test.ts
@@ -135,6 +135,14 @@ function plug(name: string, weight?: number, cli?: LoadedPlugin["manifest"]["cli
   } as LoadedPlugin;
 }
 
+function plugWithDeps(name: string, deps: string[]): LoadedPlugin {
+  const p = plug(name);
+  return {
+    ...p,
+    manifest: { ...p.manifest, dependencies: { plugins: deps } },
+  } as LoadedPlugin;
+}
+
 // ─── nuke-test scratch home ─────────────────────────────────────────────────
 
 const nukeHomes: string[] = [];
@@ -248,6 +256,26 @@ describe("doEnable — enable branch", () => {
     expect(saveConfigCalls).toEqual([{ disabledPlugins: [] }]);
     expect(resetDiscoverCacheCalls).toBe(1);
     expect(outs.join("\n")).toContain("enabled about");
+  });
+
+  test("#1547 — enable includes disabled plugin dependencies before target", () => {
+    configStore = { disabledPlugins: ["trace", "dig", "foo"] };
+    discoverPackagesReturn = [plug("trace"), plug("dig"), plugWithDeps("foo", ["trace", "dig"])];
+
+    run(() => doEnable("foo"));
+
+    expect(saveConfigCalls).toEqual([{ disabledPlugins: [] }]);
+    expect(outs.join("\n")).toContain("enabled trace, dig, foo");
+  });
+
+  test("#1547 — enable accepts multiple plugin names", () => {
+    configStore = { disabledPlugins: ["trace", "dig", "other"] };
+    discoverPackagesReturn = [plug("trace"), plug("dig"), plug("other")];
+
+    run(() => doEnable(["trace", "dig"]));
+
+    expect(saveConfigCalls).toEqual([{ disabledPlugins: ["other"] }]);
+    expect(outs.join("\n")).toContain("enabled trace, dig");
   });
 
   test("preserves OTHER disabled plugins unchanged", () => {

--- a/test/manifest-ext.test.ts
+++ b/test/manifest-ext.test.ts
@@ -184,6 +184,26 @@ describe("new manifest fields accepted", () => {
     }
   });
 
+  test("accepts plugin dependencies", () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(join(dir, "plugin.wasm"), MINIMAL_WASM);
+      const m = parseManifest(
+        JSON.stringify({
+          name: "dep-plugin",
+          version: "1.0.0",
+          wasm: "plugin.wasm",
+          sdk: "*",
+          dependencies: { plugins: ["trace", "dig"] },
+        }),
+        dir,
+      );
+      expect(m.dependencies?.plugins).toEqual(["trace", "dig"]);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
   test("TS plugin with all new fields validates cleanly", () => {
     const dir = makeTempDir();
     try {
@@ -298,6 +318,27 @@ describe("new field validation failures", () => {
           dir,
         ),
       ).toThrow(/cli\.flags/);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  test("dependencies.plugins with invalid names is rejected", () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(join(dir, "plugin.wasm"), MINIMAL_WASM);
+      expect(() =>
+        parseManifest(
+          JSON.stringify({
+            name: "bad",
+            version: "1.0.0",
+            wasm: "plugin.wasm",
+            sdk: "*",
+            dependencies: { plugins: ["Trace"] },
+          }),
+          dir,
+        ),
+      ).toThrow(/dependencies\.plugins/);
     } finally {
       rmSync(dir, { recursive: true });
     }


### PR DESCRIPTION
## Summary

- add manifest-level plugin dependencies (`dependencies.plugins`)
- block plugin dispatch when dependencies are missing or disabled, with a precise enable plan
- let `maw plugin enable` accept multiple names and include disabled dependencies before the target
- improve disabled alias hints (`info`-style aliases say which backing plugin provides them)

## Tests

- `bun test test/manifest-ext.test.ts test/isolated/plugins-toggle.test.ts test/isolated/plugin-default-active-migration.test.ts`
- `bun test test/cli/dispatch-match.test.ts`
- `bun run build`

Closes #1547.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
