### PR TITLE
fix(wake): skip layout reset when split produced ≤2 panes (#1549)

### DIFF
--- a/src/commands/shared/wake-maybe-split.ts
+++ b/src/commands/shared/wake-maybe-split.ts
@@ -21,7 +21,8 @@ async function restoreSplitLayout(anchor?: string): Promise<void> {
     const targetFlag = windowTarget ? `-t ${shellArg(windowTarget)} ` : "";
     const raw = await hostExec(`tmux list-panes ${targetFlag}| wc -l`);
     const total = Number.parseInt(String(raw).trim(), 10);
-    const layout = Number.isFinite(total) && total > 4 ? "tiled" : "main-vertical";
+    if (!Number.isFinite(total) || total <= 2) return;
+    const layout = total > 4 ? "tiled" : "main-vertical";
     await hostExec(`tmux select-layout ${targetFlag}${layout}`);
   } catch {
     // Best-effort polish only: split succeeded, so never fail delivery because

--- a/test/isolated/wake-maybe-split.test.ts
+++ b/test/isolated/wake-maybe-split.test.ts
@@ -52,6 +52,18 @@ describe("wake maybeSplit", () => {
     expect(hostExecCalls[3]).toContain("tmux select-layout -t '%42' main-vertical");
   });
 
+  test("does not reset layout when split leaves only two panes", async () => {
+    listPanesResponse = "2\n";
+
+    await maybeSplit("20-homekeeper:homekeeper-oracle", { split: true });
+
+    expect(hostExecCalls).toHaveLength(3);
+    expect(hostExecCalls[0]).toContain("tmux split-window");
+    expect(hostExecCalls[1]).toContain("tmux show-options -p -t '%42' -v @maw_tile");
+    expect(hostExecCalls[2]).toContain("tmux list-panes -t '%42'");
+    expect(hostExecCalls.some(cmd => cmd.includes("tmux select-layout"))).toBe(false);
+  });
+
   test("preserves horizontal split when splitting from a maw tile pane", async () => {
     tileMarkerResponse = "1\n";
 


### PR DESCRIPTION
## Summary
Skip the redundant `tmux select-layout` call in `restoreSplitLayout()` when the window has ≤2 panes after a `--split`. Eliminates the second SIGWINCH that was causing starship/prompt redraw residue in the originating pane.

Closes #1549.

## Why
`maybeSplit()` ran two back-to-back tmux ops — `split-window` then `select-layout main-vertical` — each emitting SIGWINCH. For the common 1-pane → 2-panes case, the layout reset is purely redundant: `split-window -h -l 50%` already gives the correct layout. The double-SIGWINCH made prompt renderers (e.g. starship with `truncation_length = 0`) draw at two different widths in rapid succession, leaving visible residue.

The fix adds an early-return guard: `if (!Number.isFinite(total) || total <= 2) return;`. Layouts for 3+ panes (the case `restoreSplitLayout` was actually built for) still reflow as before.

## Diff
```ts
async function restoreSplitLayout(anchor?: string): Promise<void> {
  try {
    const windowTarget = anchor || process.env.TMUX_PANE;
    const targetFlag = windowTarget ? `-t ${shellArg(windowTarget)} ` : "";
    const raw = await hostExec(`tmux list-panes ${targetFlag}| wc -l`);
    const total = Number.parseInt(String(raw).trim(), 10);
+   if (!Number.isFinite(total) || total <= 2) return;
-   const layout = Number.isFinite(total) && total > 4 ? "tiled" : "main-vertical";
+   const layout = total > 4 ? "tiled" : "main-vertical";
    await hostExec(`tmux select-layout ${targetFlag}${layout}`);
  } catch { /* best-effort */ }
}
```

## Test plan
- [x] Existing `test/isolated/wake-maybe-split.test.ts` passes (10/10)
- [x] `bun build` smoke succeeds (653 modules, 1.79 MB)
- [ ] Manual repro on alpha: `maw wake <oracle> --wt <slug> --split` from a single-pane tmux window — confirm no prompt residue in originating pane
- [ ] Manual: same command from a window already containing 3+ panes — confirm layout still reflows correctly to main-vertical/tiled

🤖 Generated with [Claude Code](https://claude.com/claude-code)