### PR TITLE
fix(kill): use pane-title fallback from top-level kill

### DIFF
--- a/src/commands/plugins/tmux/impl.ts
+++ b/src/commands/plugins/tmux/impl.ts
@@ -2,97 +2,24 @@ import { readdirSync, existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 import { hostExec, tmux, tmuxCmd } from "../../../sdk";
-import { resolveByName, resolveSessionTarget } from "../../../core/matcher/resolve-target";
+import { resolveSessionTarget } from "../../../core/matcher/resolve-target";
 import { loadFleetEntries } from "../../shared/fleet-load";
 import { ghqList, ghqListSync } from "../../../core/ghq";
 import { scanWorktrees } from "../../../core/fleet/worktrees-scan";
 import { checkDestructive, isClaudeLikePane, isFleetOrViewSession } from "./safety";
+export {
+  PANE_TARGET_FORMAT,
+  paneTargetCandidatesFromListPanesOutput,
+  resolvePaneTargetFromCandidates,
+  resolvePaneTargetFromListPanesOutput,
+} from "../../shared/pane-target-resolver";
+import {
+  PANE_TARGET_FORMAT,
+  resolvePaneTargetFromListPanesOutput,
+  type PaneTargetResolution,
+} from "../../shared/pane-target-resolver";
 
 const TEAMS_DIR = join(homedir(), ".claude/teams");
-
-const PANE_TARGET_FORMAT = "#{pane_id}|||#{session_name}:#{window_index}.#{pane_index}|||#{pane_title}|||#{@maw_tile_role}|||#{pane_current_path}";
-
-export interface PaneTargetCandidate {
-  name: string;
-  resolved: string;
-  source: string;
-  target: string;
-}
-
-export type PaneTargetResolution =
-  | { kind: "none" }
-  | { kind: "match"; candidate: PaneTargetCandidate }
-  | { kind: "ambiguous"; candidates: PaneTargetCandidate[] };
-
-function basename(path: string): string {
-  return path.split("/").filter(Boolean).pop() || path;
-}
-
-function worktreeNamesFromCwd(cwd: string): Array<{ name: string; source: string }> {
-  const base = basename(cwd);
-  if (!base) return [];
-  const out: Array<{ name: string; source: string }> = [{ name: base, source: "worktree-dir" }];
-
-  const match = base.match(/^(?<repo>.+)\.wt-\d+-(?<role>.+)$/);
-  const role = match?.groups?.role?.trim();
-  const repo = match?.groups?.repo?.trim();
-  if (role) {
-    out.push({ name: role, source: "worktree-role" });
-    // Natural user target for repo worktrees: mawjs-oracle.wt-7-codex →
-    // mawjs-codex. This covers orphan panes whose title diverges from the
-    // requested oracle-ish handle (#1502) while staying deterministic.
-    const repoStem = repo?.replace(/-oracle$/, "");
-    if (repoStem && repoStem !== repo) out.push({ name: `${repoStem}-${role}`, source: "worktree-alias" });
-  }
-
-  return out;
-}
-
-export function paneTargetCandidatesFromListPanesOutput(raw: string): PaneTargetCandidate[] {
-  const candidates: PaneTargetCandidate[] = [];
-  for (const line of raw.split("\n")) {
-    if (!line.trim()) continue;
-    const [id = "", target = "", title = "", tileRole = "", cwd = ""] = line.split("|||");
-    const resolved = id.trim() || target.trim();
-    if (!resolved) continue;
-    const paneTarget = target.trim();
-    const add = (name: string, source: string) => {
-      const trimmed = name.trim();
-      if (!trimmed) return;
-      candidates.push({ name: trimmed, resolved, source, target: paneTarget });
-    };
-    add(title, "pane-title");
-    add(tileRole, "tile-role");
-    for (const wt of worktreeNamesFromCwd(cwd)) add(wt.name, wt.source);
-  }
-  return candidates;
-}
-
-function uniqueByResolved(candidates: PaneTargetCandidate[]): PaneTargetCandidate[] {
-  const seen = new Set<string>();
-  const out: PaneTargetCandidate[] = [];
-  for (const candidate of candidates) {
-    if (seen.has(candidate.resolved)) continue;
-    seen.add(candidate.resolved);
-    out.push(candidate);
-  }
-  return out;
-}
-
-export function resolvePaneTargetFromCandidates(target: string, candidates: readonly PaneTargetCandidate[]): PaneTargetResolution {
-  const exact = uniqueByResolved(candidates.filter(c => c.name.toLowerCase() === target.trim().toLowerCase()));
-  if (exact.length === 1) return { kind: "match", candidate: exact[0]! };
-  if (exact.length > 1) return { kind: "ambiguous", candidates: exact };
-
-  const byName = resolveByName(target, candidates);
-  if (byName.kind === "exact" || byName.kind === "fuzzy") return { kind: "match", candidate: byName.match };
-  if (byName.kind === "ambiguous") return { kind: "ambiguous", candidates: uniqueByResolved(byName.candidates) };
-  return { kind: "none" };
-}
-
-export function resolvePaneTargetFromListPanesOutput(target: string, raw: string): PaneTargetResolution {
-  return resolvePaneTargetFromCandidates(target, paneTargetCandidatesFromListPanesOutput(raw));
-}
 
 async function resolvePaneTargetForKill(target: string): Promise<PaneTargetResolution> {
   const raw = await hostExec(`${tmuxCmd()} list-panes -a -F '${PANE_TARGET_FORMAT}'`).catch(() => "");

--- a/src/commands/shared/pane-target-resolver.ts
+++ b/src/commands/shared/pane-target-resolver.ts
@@ -1,0 +1,85 @@
+import { resolveByName } from "../../core/matcher/resolve-target";
+
+export const PANE_TARGET_FORMAT = "#{pane_id}|||#{session_name}:#{window_index}.#{pane_index}|||#{pane_title}|||#{@maw_tile_role}|||#{pane_current_path}";
+
+export interface PaneTargetCandidate {
+  name: string;
+  resolved: string;
+  source: string;
+  target: string;
+}
+
+export type PaneTargetResolution =
+  | { kind: "none" }
+  | { kind: "match"; candidate: PaneTargetCandidate }
+  | { kind: "ambiguous"; candidates: PaneTargetCandidate[] };
+
+function basename(path: string): string {
+  return path.split("/").filter(Boolean).pop() || path;
+}
+
+function worktreeNamesFromCwd(cwd: string): Array<{ name: string; source: string }> {
+  const base = basename(cwd);
+  if (!base) return [];
+  const out: Array<{ name: string; source: string }> = [{ name: base, source: "worktree-dir" }];
+
+  const match = base.match(/^(?<repo>.+)\.wt-\d+-(?<role>.+)$/);
+  const role = match?.groups?.role?.trim();
+  const repo = match?.groups?.repo?.trim();
+  if (role) {
+    out.push({ name: role, source: "worktree-role" });
+    // Natural user target for repo worktrees: mawjs-oracle.wt-7-codex →
+    // mawjs-codex. This covers orphan panes whose title diverges from the
+    // requested oracle-ish handle (#1502) while staying deterministic.
+    const repoStem = repo?.replace(/-oracle$/, "");
+    if (repoStem && repoStem !== repo) out.push({ name: `${repoStem}-${role}`, source: "worktree-alias" });
+  }
+
+  return out;
+}
+
+export function paneTargetCandidatesFromListPanesOutput(raw: string): PaneTargetCandidate[] {
+  const candidates: PaneTargetCandidate[] = [];
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    const [id = "", target = "", title = "", tileRole = "", cwd = ""] = line.split("|||");
+    const resolved = id.trim() || target.trim();
+    if (!resolved) continue;
+    const paneTarget = target.trim();
+    const add = (name: string, source: string) => {
+      const trimmed = name.trim();
+      if (!trimmed) return;
+      candidates.push({ name: trimmed, resolved, source, target: paneTarget });
+    };
+    add(title, "pane-title");
+    add(tileRole, "tile-role");
+    for (const wt of worktreeNamesFromCwd(cwd)) add(wt.name, wt.source);
+  }
+  return candidates;
+}
+
+function uniqueByResolved(candidates: PaneTargetCandidate[]): PaneTargetCandidate[] {
+  const seen = new Set<string>();
+  const out: PaneTargetCandidate[] = [];
+  for (const candidate of candidates) {
+    if (seen.has(candidate.resolved)) continue;
+    seen.add(candidate.resolved);
+    out.push(candidate);
+  }
+  return out;
+}
+
+export function resolvePaneTargetFromCandidates(target: string, candidates: readonly PaneTargetCandidate[]): PaneTargetResolution {
+  const exact = uniqueByResolved(candidates.filter(c => c.name.toLowerCase() === target.trim().toLowerCase()));
+  if (exact.length === 1) return { kind: "match", candidate: exact[0]! };
+  if (exact.length > 1) return { kind: "ambiguous", candidates: exact };
+
+  const byName = resolveByName(target, candidates);
+  if (byName.kind === "exact" || byName.kind === "fuzzy") return { kind: "match", candidate: byName.match };
+  if (byName.kind === "ambiguous") return { kind: "ambiguous", candidates: uniqueByResolved(byName.candidates) };
+  return { kind: "none" };
+}
+
+export function resolvePaneTargetFromListPanesOutput(target: string, raw: string): PaneTargetResolution {
+  return resolvePaneTargetFromCandidates(target, paneTargetCandidatesFromListPanesOutput(raw));
+}

--- a/src/vendor/mpr-plugins/kill/impl.ts
+++ b/src/vendor/mpr-plugins/kill/impl.ts
@@ -1,5 +1,9 @@
 import { listSessions, hostExec, tmuxCmd } from "maw-js/sdk";
 import { resolveSessionTarget } from "maw-js/core/matcher/resolve-target";
+import {
+  PANE_TARGET_FORMAT,
+  resolvePaneTargetFromListPanesOutput,
+} from "../../../commands/shared/pane-target-resolver";
 
 export interface KillOpts {
   /** Pane index — narrows kill to a specific pane of the resolved window. */
@@ -45,6 +49,32 @@ export async function cmdKill(target: string, opts: KillOpts = {}) {
     throw new Error(`'${rawSession}' is ambiguous`);
   }
   if (r.kind === "none") {
+    if (!rawWindow && opts.pane === undefined) {
+      const paneRaw = await hostExec(`${tmuxCmd()} list-panes -a -F '${PANE_TARGET_FORMAT}'`).catch(() => "");
+      if (paneRaw.trim()) {
+        const paneHit = resolvePaneTargetFromListPanesOutput(rawSession, paneRaw);
+        if (paneHit.kind === "match") {
+          const pane = paneHit.candidate.resolved;
+          await hostExec(`${tmuxCmd()} kill-pane -t '${pane}'`);
+          console.log(
+            `  \x1b[32m✓\x1b[0m killed pane ${rawSession} → ${pane} ` +
+            `\x1b[90m[${paneHit.candidate.source} (${paneHit.candidate.name})]\x1b[0m`,
+          );
+          return;
+        }
+        if (paneHit.kind === "ambiguous") {
+          console.error(`  \x1b[31m✗\x1b[0m '${rawSession}' is ambiguous — matches ${paneHit.candidates.length} panes:`);
+          for (const candidate of paneHit.candidates) {
+            console.error(
+              `  \x1b[90m    • ${candidate.name} → ${candidate.resolved}` +
+              `${candidate.target ? ` (${candidate.target})` : ""} [${candidate.source}]\x1b[0m`,
+            );
+          }
+          console.error(`  \x1b[90m  use the pane id or full session:window.pane target\x1b[0m`);
+          throw new Error(`'${rawSession}' is ambiguous`);
+        }
+      }
+    }
     console.error(`  \x1b[31m✗\x1b[0m session '${rawSession}' not found`);
     if (r.hints && r.hints.length > 0) {
       console.error(`  \x1b[90m  did you mean:\x1b[0m`);

--- a/test/isolated/kill-pane-range.test.ts
+++ b/test/isolated/kill-pane-range.test.ts
@@ -13,6 +13,10 @@ mock.module("maw-js/sdk", () => ({
   hostExec: async (cmd: string) => {
     hostExecCalls.push(cmd);
     if (cmd.includes("list-panes -t '47-mawjs:0'")) return "0\n1\n2\n";
+    if (cmd.includes("list-panes -a -F")) {
+      return "%101|||47-mawjs:1.0|||codex-headless-demo-layout|||tile-1|||/opt/Code/github.com/Soul-Brews-Studio/mawjs-oracle.wt-7-codex-headless";
+    }
+    if (cmd.includes("kill-pane -t '%101'")) return "";
     if (cmd.includes("kill-pane -t '47-mawjs:0.2'")) return "";
     throw new Error(`unexpected command: ${cmd}`);
   },
@@ -39,5 +43,12 @@ describe("kill --pane range validation (#1441)", () => {
 
     expect(hostExecCalls[0]).toContain("list-panes -t '47-mawjs:0'");
     expect(hostExecCalls[1]).toContain("kill-pane -t '47-mawjs:0.2'");
+  });
+
+  test("falls back to pane-title/worktree aliases when no session matches", async () => {
+    await expect(cmdKill("mawjs-codex-headless")).resolves.toBeUndefined();
+
+    expect(hostExecCalls[0]).toContain("list-panes -a -F");
+    expect(hostExecCalls[1]).toContain("kill-pane -t '%101'");
   });
 });

--- a/test/isolated/tmux-kill-pane-target.test.ts
+++ b/test/isolated/tmux-kill-pane-target.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   paneTargetCandidatesFromListPanesOutput,
   resolvePaneTargetFromListPanesOutput,
-} from "../../src/commands/plugins/tmux/impl";
+} from "../../src/commands/shared/pane-target-resolver";
 
 const raw = [
   "%101|||47-mawjs:1.0|||codex-headless-demo-layout|||tile-1|||/opt/Code/github.com/Soul-Brews-Studio/mawjs-oracle.wt-7-codex-headless",


### PR DESCRIPTION
## Summary

Fixes #1552 by making top-level `maw kill` share the same pane-title/worktree alias fallback used by tmux kill.

## What changed

- Moved pure pane-target candidate/resolution logic into `src/commands/shared/pane-target-resolver.ts`.
- Kept `maw tmux kill` exporting the same resolver helpers for existing callers/tests.
- Updated the vendored top-level `kill` plugin to try pane-title/worktree alias resolution when no tmux session matches.
- Preserved existing `maw kill <session> --pane N` range validation and session-kill semantics.

## Verification

- `bun test test/isolated/kill-pane-range.test.ts test/isolated/tmux-kill-pane-target.test.ts` → 7 pass
- `bun run build` → success

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
