### PR TITLE
fix(worktree-scan): prefer full wtName before stripped taskPart (#1553)

### DIFF
--- a/src/core/fleet/worktrees-scan.ts
+++ b/src/core/fleet/worktrees-scan.ts
@@ -28,10 +28,13 @@ export async function scanWorktrees(): Promise<WorktreeInfo[]> {
   const fleetDir = FLEET_DIR;
 
   // 1. Find all .wt- directories
+  // #1553 — dedupe paths; `find` can surface the same .wt-* dir multiple times
+  // when nested ghq layouts walk through symlinks or overlapping prefixes,
+  // turning N worktrees into N×K classification rows + ambiguity error spam.
   let wtPaths: string[] = [];
   try {
     const raw = await hostExec(`find ${reposRoot} -maxdepth 4 -name '*.wt-*' -type d 2>/dev/null`);
-    wtPaths = raw.split("\n").filter(Boolean);
+    wtPaths = [...new Set(raw.split("\n").filter(Boolean))];
   } catch { /* no worktrees */ }
 
   // 2. Get running tmux windows for matching
@@ -112,20 +115,34 @@ export async function scanWorktrees(): Promise<WorktreeInfo[]> {
     const parentSessions = sessions.filter(s =>
       s.name === parentOracleName || s.name.endsWith(`-${parentOracleName}`)
     );
+    // #1553 — try the full wtName first (preserves sequence prefix). Without
+    // this, two worktrees `1-tile-1` and `6-tile-1` both collapse to `tile-1`
+    // and ambiguously match windows `mawjs-tile-1` + `mawjs-6-tile-1`. Trying
+    // full wtName first lets `6-tile-1` cleanly bind via `-6-tile-1` suffix.
     let resolved: ReturnType<typeof resolveWorktreeTarget> | undefined;
     if (parentSessions.length > 0) {
       const scopedWindows = [
         ...new Map(parentSessions.flatMap(s => s.windows).map(w => [w.name, w])).values()
       ];
-      const localResolved = resolveWorktreeTarget(taskPart, scopedWindows);
-      if (localResolved.kind === "exact" || localResolved.kind === "fuzzy") {
-        resolved = localResolved;
+      const fullScoped = resolveWorktreeTarget(wtName, scopedWindows);
+      if (fullScoped.kind === "exact" || fullScoped.kind === "fuzzy") {
+        resolved = fullScoped;
+      } else {
+        const localResolved = resolveWorktreeTarget(taskPart, scopedWindows);
+        if (localResolved.kind === "exact" || localResolved.kind === "fuzzy") {
+          resolved = localResolved;
+        }
       }
     }
     // Fall back to global search (existing behavior) when no parent session
     // exists or when the scoped search did not produce a clean bind.
     if (!resolved) {
-      resolved = resolveWorktreeTarget(taskPart, allWindows);
+      const fullGlobal = resolveWorktreeTarget(wtName, allWindows);
+      if (fullGlobal.kind === "exact" || fullGlobal.kind === "fuzzy") {
+        resolved = fullGlobal;
+      } else {
+        resolved = resolveWorktreeTarget(taskPart, allWindows);
+      }
     }
     switch (resolved.kind) {
       case "exact":

--- a/test/isolated/worktree-scope-match-935.test.ts
+++ b/test/isolated/worktree-scope-match-935.test.ts
@@ -34,6 +34,7 @@ const root = join(import.meta.dir, "../../src");
 // Mutable stubs so each test can reshape the world
 let stubFindOutput: string = "";
 let stubSessions: Array<{ name: string; windows: Array<{ name: string; index: number; active: boolean }> }> = [];
+let revParseCalls = 0;
 
 mock.module(join(root, "core/transport/ssh"), () => mockSshModule({
   hostExec: async (cmd: string) => {
@@ -41,6 +42,7 @@ mock.module(join(root, "core/transport/ssh"), () => mockSshModule({
       return stubFindOutput;
     }
     if (cmd.includes("rev-parse --abbrev-ref")) {
+      revParseCalls += 1;
       return "agents/935-test";
     }
     return "";
@@ -66,6 +68,7 @@ const win = (name: string, index = 1) => ({ name, index, active: false });
 beforeEach(() => {
   stubFindOutput = "";
   stubSessions = [];
+  revParseCalls = 0;
 });
 
 describe("scanWorktrees (#935) — scope window match to parent oracle session", () => {
@@ -203,5 +206,45 @@ describe("scanWorktrees (#935) — scope window match to parent oracle session",
     // Single global match remains — current behavior preserved.
     expect(wt!.status).toBe("active");
     expect(wt!.tmuxWindow).toBe("timekeeper--no-attach");
+  });
+
+  it("#1553 full worktree name wins before stripped tile suffix fallback", async () => {
+    // `6-tile-1` must resolve against `mawjs-6-tile-1` before it strips to
+    // `tile-1`; otherwise both `mawjs-tile-1` and `mawjs-6-tile-1` match
+    // suffix `tile-1` and the scan reports ambiguity spam.
+    stubFindOutput = wtPath("Soul-Brews-Studio", "mawjs-oracle", "6-tile-1");
+    stubSessions = [
+      { name: "54-mawjs", windows: [win("mawjs-tile-1"), win("mawjs-6-tile-1")] },
+    ];
+
+    const errLogs: string[] = [];
+    const origErr = console.error;
+    console.error = (...a: unknown[]) => { errLogs.push(a.map(String).join(" ")); };
+
+    try {
+      const results = await scanWorktrees();
+      const wt = results.find(r => r.name === "6-tile-1");
+      expect(wt).toBeDefined();
+      expect(wt!.status).toBe("active");
+      expect(wt!.tmuxWindow).toBe("mawjs-6-tile-1");
+      expect(errLogs.join("\n")).not.toContain("ambiguous");
+    } finally {
+      console.error = origErr;
+    }
+  });
+
+  it("#1553 duplicate find paths are scanned only once", async () => {
+    const path = wtPath("Soul-Brews-Studio", "mawjs-oracle", "6-tile-1");
+    stubFindOutput = [path, path, path].join("\n");
+    stubSessions = [
+      { name: "54-mawjs", windows: [win("mawjs-6-tile-1")] },
+    ];
+
+    const results = await scanWorktrees();
+    const matches = results.filter(r => r.path === path);
+    expect(matches).toHaveLength(1);
+    expect(matches[0]!.status).toBe("active");
+    expect(matches[0]!.tmuxWindow).toBe("mawjs-6-tile-1");
+    expect(revParseCalls).toBe(1);
   });
 });


### PR DESCRIPTION
Closes #1553.

## Why
Worktrees `1-tile-1` and `6-tile-1` collapsed to lookup key `tile-1` via the `^\d+-` strip, then both ambiguously matched windows `mawjs-tile-1` + `mawjs-6-tile-1` via Tier 2a suffix. `maw ls` printed N×K identical ambiguity errors.

## Fix
1. **Tier the lookup** — try `resolveWorktreeTarget(wtName, ...)` with the FULL name first. `6-tile-1` binds cleanly via `-6-tile-1`. Fall back to stripped `taskPart` only when full finds nothing.
2. **Dedupe `wtPaths`** — `find` surfaces duplicates in nested ghq layouts, multiplying every row by K.

## Validation
- `bun test test/isolated/worktree-scope-match-935.test.ts test/matcher-resolve-target.test.ts` → 38/38 pass
- `bun run build` OK
- Reproducing fleet: 9 ambiguity errors → ≤3, and `6-tile-1` now binds active

## Files
- `src/core/fleet/worktrees-scan.ts:30-37` — dedupe wtPaths
- `src/core/fleet/worktrees-scan.ts:118-146` — tier the lookup

## Follow-up (codex hardening candidates)
- Negative-assertion regression test confirming tier ordering
- Test that duplicated wtPath is deduped
- Test that `6-tile-1` binds when both `mawjs-tile-1` + `mawjs-6-tile-1` exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)