### PR TITLE
ux(ls): make detailed pane view the default

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -47,7 +47,7 @@ export const ALIAS_DESCRIPTIONS: Record<string, string> = {
   tile: "Tile current window or spawn N panes tiled",
   bring: "Bring an oracle HERE — split current pane and attach",
   b: "Bring an oracle HERE (short form of `bring`)",
-  ls: "List sessions (compact, -a roster, -v detail)",
+  ls: "List sessions (detail default, -c compact, -a roster)",
   wake: "Wake an oracle session (fuzzy match, auto-clone)",
   awake: "Launch an oracle process with optional engine (does not trigger /awaken)",
   new: "Create a new oracle (friendly door for awaken)",
@@ -71,9 +71,10 @@ export const TOP_ALIASES: Record<string, string[] | DirectHandler> = {
   b: { kind: "direct", handler: "../commands/shared/wake-cmd:cmdBring" },
 
   // Direct-handler form — `ls` flags differ from tmux ls:
-  //   maw ls      → compact, live sessions only
-  //   maw ls -a   → compact + sleeping oracles (roster)
-  //   maw ls -v   → full per-pane detail
+  //   maw ls      → full per-pane detail (#1556)
+  //   maw ls -v   → no-op alias for muscle memory (same as default)
+  //   maw ls -c   → compact live-session summary
+  //   maw ls -a   → compact + sleeping oracles (roster; legacy behavior)
   ls: { kind: "direct", handler: "cmdLs" },
 
   // Direct-handler form — cmdWake is in core (src/commands/shared/wake-cmd.ts)
@@ -161,9 +162,34 @@ function printWakeAliasUsage(verb: "wake" | "awake", write: (line: string) => vo
  * help-text rendering, but the path is no longer used at runtime —
  * dispatch is by `exportName` against a static handler map.
  *
- * For `ls`, `-a` = roster (sleeping oracles), `-v` = full detail.
+ * For `ls`, detail is the default; `-v` is a no-op alias, `-c` returns the
+ * compact summary, and `-a` preserves the legacy compact+roster behavior.
  * For `wake`, parses the 9 known flags and calls cmdWake(oracle, opts).
  */
+export function parseLsAliasOpts(argv: string[]) {
+  const flags = parseFlags(argv, {
+    "--all": Boolean, "-a": "--all",
+    "--compact": Boolean, "-c": "--compact",
+    "--verbose": Boolean, "-v": "--verbose",
+    "--fix": Boolean,
+    "--json": Boolean,
+  }, 0);
+
+  // #1556 — Nat's UX preference: detailed per-pane output is the default,
+  // `-v` stays accepted as a no-op muscle-memory alias, and `-c/--compact`
+  // is the opt-in condensed summary. `-a/--all` historically meant
+  // "include sleeping roster" on top-level `maw ls`; keep that legacy shape
+  // by rendering the compact roster view.
+  const compact = !!flags["--compact"] || !!flags["--all"];
+  return {
+    all: true,
+    compact,
+    verbose: !compact,
+    roster: !!flags["--all"],
+    json: !!flags["--json"],
+  };
+}
+
 export async function invokeDirectHandler(
   handler: string,
   argv: string[],
@@ -174,19 +200,7 @@ export async function invokeDirectHandler(
   }
 
   if (exportName === "cmdLs") {
-    const flags = parseFlags(argv, {
-      "--all": Boolean, "-a": "--all",
-      "--verbose": Boolean, "-v": "--verbose",
-      "--fix": Boolean,
-      "--json": Boolean,
-    }, 0);
-    await cmdTmuxLs({
-      all: true,
-      compact: !flags["--verbose"],
-      verbose: !!flags["--verbose"],
-      roster: !!flags["--all"],
-      json: !!flags["--json"],
-    });
+    await cmdTmuxLs(parseLsAliasOpts(argv));
     return;
   }
 

--- a/src/commands/plugins/tmux/impl.ts
+++ b/src/commands/plugins/tmux/impl.ts
@@ -142,9 +142,9 @@ export interface TmuxLsOpts {
   all?: boolean;
   /** JSON output for scripting. */
   json?: boolean;
-  /** Compact: one line per session. Default for `maw ls`. Use -v for full detail. */
+  /** Compact: one line per session. Top-level `maw ls -c` uses this mode. */
   compact?: boolean;
-  /** Verbose: full per-pane detail. Overrides --compact. */
+  /** Verbose: full per-pane detail. Top-level `maw ls` defaults to this mode. */
   verbose?: boolean;
   /** Roster: include sleeping oracles from ghq (compact mode only). */
   roster?: boolean;
@@ -302,7 +302,7 @@ export async function cmdTmuxLs(opts: TmuxLsOpts = {}): Promise<void> {
     }
 
     console.log();
-    console.log(`\x1b[90m  → maw ls -v     full detail\x1b[0m`);
+    console.log(`\x1b[90m  → maw ls       full detail\x1b[0m`);
     console.log();
     return;
   }

--- a/src/commands/plugins/tmux/index.ts
+++ b/src/commands/plugins/tmux/index.ts
@@ -58,6 +58,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         "-a": "--all",
         "--json": Boolean,
         "--compact": Boolean,
+        "-c": "--compact",
         "--verbose": Boolean,
         "-v": "--verbose",
         "--roster": Boolean,
@@ -65,11 +66,11 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         "-h": "--help",
       }, 1);
       if (flags["--help"]) {
-        console.log("usage: maw tmux ls [--all|-a] [--compact] [-v|--verbose] [--roster] [--json]");
+        console.log("usage: maw tmux ls [--all|-a] [--compact|-c] [-v|--verbose] [--roster] [--json]");
         console.log("  default:    panes in current session only");
         console.log("  --all:      panes across every session");
-        console.log("  --compact:  one line per session (default for `maw ls`)");
-        console.log("  -v:         full per-pane detail (overrides --compact)");
+        console.log("  --compact:  one line per session (`maw ls -c` for top-level compact)");
+        console.log("  -v:         full per-pane detail");
         console.log("  --roster:   include sleeping oracles from ghq");
         return { ok: true, output: logs.join("\n") || undefined };
       }

--- a/test/cli/dispatch-match.test.ts
+++ b/test/cli/dispatch-match.test.ts
@@ -10,7 +10,7 @@
  */
 import { describe, test, expect } from "bun:test";
 import { resolvePluginMatch } from "../../src/cli/dispatch-match";
-import { ALIAS_DESCRIPTIONS, parseBringArgs, resolveTopAlias } from "../../src/cli/top-aliases";
+import { ALIAS_DESCRIPTIONS, parseBringArgs, parseLsAliasOpts, resolveTopAlias } from "../../src/cli/top-aliases";
 import type { LoadedPlugin } from "../../src/plugin/types";
 
 function plugin(name: string, command: string, aliases: string[] = []): LoadedPlugin {
@@ -229,7 +229,7 @@ describe("resolvePluginMatch — two-pass dispatch", () => {
 });
 
 describe("resolveTopAlias — RFC #954 verb aliases", () => {
-  test("`ls` → direct-handler cmdLs (compact, no roster)", () => {
+  test("`ls` → direct-handler cmdLs (detail default)", () => {
     const out = resolveTopAlias(["ls"]);
     expect(out).not.toBeNull();
     expect(out!.kind).toBe("direct");
@@ -239,7 +239,7 @@ describe("resolveTopAlias — RFC #954 verb aliases", () => {
     }
   });
 
-  test("`ls -a` → direct-handler cmdLs with -a (roster)", () => {
+  test("`ls -a` → direct-handler cmdLs with -a (compact roster)", () => {
     const out = resolveTopAlias(["ls", "-a"]);
     expect(out).not.toBeNull();
     expect(out!.kind).toBe("direct");
@@ -249,7 +249,7 @@ describe("resolveTopAlias — RFC #954 verb aliases", () => {
     }
   });
 
-  test("`ls -v` → direct-handler cmdLs with -v (verbose)", () => {
+  test("`ls -v` → direct-handler cmdLs with -v (no-op detail alias)", () => {
     const out = resolveTopAlias(["ls", "-v"]);
     expect(out).not.toBeNull();
     expect(out!.kind).toBe("direct");
@@ -257,6 +257,50 @@ describe("resolveTopAlias — RFC #954 verb aliases", () => {
       expect(out!.handler).toBe("cmdLs");
       expect(out!.argv).toEqual(["-v"]);
     }
+  });
+
+  test("#1556 parse ls opts: default and -v both render per-pane detail", () => {
+    expect(parseLsAliasOpts([])).toEqual({
+      all: true,
+      compact: false,
+      verbose: true,
+      roster: false,
+      json: false,
+    });
+    expect(parseLsAliasOpts(["-v"])).toEqual({
+      all: true,
+      compact: false,
+      verbose: true,
+      roster: false,
+      json: false,
+    });
+  });
+
+  test("#1556 parse ls opts: -c/--compact opt into condensed summary", () => {
+    expect(parseLsAliasOpts(["-c"])).toEqual({
+      all: true,
+      compact: true,
+      verbose: false,
+      roster: false,
+      json: false,
+    });
+    expect(parseLsAliasOpts(["--compact"])).toEqual({
+      all: true,
+      compact: true,
+      verbose: false,
+      roster: false,
+      json: false,
+    });
+  });
+
+  test("#1556 parse ls opts: -a keeps legacy compact roster behavior", () => {
+    expect(parseLsAliasOpts(["-a"])).toEqual({
+      all: true,
+      compact: true,
+      verbose: false,
+      roster: true,
+      json: false,
+    });
   });
 
   test("`a neo` → argv rewrite to ['tmux', 'attach', 'neo']", () => {


### PR DESCRIPTION
## Summary
- Flip top-level `maw ls` to the detailed per-pane view (current `maw ls -v` behavior).
- Keep `-v` as a no-op alias for muscle memory.
- Add `-c` / `--compact` for the previous condensed session summary.
- Preserve `-a` as the legacy compact roster path.
- Update the compact-mode hint to point back to `maw ls` for full detail.

## Verification
- `rtk bun test test/cli/dispatch-match.test.ts test/isolated/tmux-ls.test.ts` → 44 pass.
- `rtk bun run build` → OK.
- Branch-linked exact user-visible smoke:
  - `maw ls` → shows `TARGET CMD AGE ANNOTATION TITLE` detail table.
  - `maw ls -c` → shows compact session rows and `→ maw ls full detail` hint.
  - `maw ls -v` → shows `TARGET CMD AGE ANNOTATION TITLE` detail table.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
