### PR TITLE
feat(cli): add structure-only maw scaffold

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -48,6 +48,7 @@ export const ALIAS_DESCRIPTIONS: Record<string, string> = {
   bring: "Bring an oracle HERE — split current pane and attach",
   b: "Bring an oracle HERE (short form of `bring`)",
   ls: "List sessions (detail default, -c compact, -a roster)",
+  scaffold: "Create oracle repo + skeleton only (no commit, wake, or /awaken)",
   wake: "Wake an oracle session (fuzzy match, auto-clone)",
   awake: "Launch an oracle process with optional engine (does not trigger /awaken)",
   new: "Create a new oracle (friendly door for awaken)",
@@ -76,6 +77,7 @@ export const TOP_ALIASES: Record<string, string[] | DirectHandler> = {
   //   maw ls -c   → compact live-session summary
   //   maw ls -a   → compact + sleeping oracles (roster; legacy behavior)
   ls: { kind: "direct", handler: "cmdLs" },
+  scaffold: ["bud", "--scaffold-only"],
 
   // Direct-handler form — cmdWake is in core (src/commands/shared/wake-cmd.ts)
   // even though the wake/ plugin was extracted to the registry in #918.

--- a/src/vendor/mpr-plugins/bud/impl.ts
+++ b/src/vendor/mpr-plugins/bud/impl.ts
@@ -31,6 +31,8 @@ export interface BudOpts {
   signalOnBirth?: boolean;
   /** Pretty display name — written to ψ/nickname at birth (#643 Phase 3). */
   nickname?: string;
+  /** Create repo + local oracle skeleton only; stop before commit/push/wake/parent mutation. */
+  scaffoldOnly?: boolean;
 }
 
 // TinyBudOpts removed — --tiny deprecated, code moved to deprecated/tiny-bud-209/
@@ -154,8 +156,12 @@ export async function cmdBud(name: string, opts: BudOpts = {}) {
     } else {
       console.log(`  \x1b[36m⬡\x1b[0m [dry-run] root oracle — no parent`);
     }
-    console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would wake ${name}`);
-    if (parentName) {
+    if (opts.scaffoldOnly) {
+      console.log(`  \x1b[36m⬡\x1b[0m [dry-run] scaffold-only: would stop before git commit/push, wake, attach, parent sync_peers, and /awaken`);
+    } else {
+      console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would wake ${name}`);
+    }
+    if (parentName && !opts.scaffoldOnly) {
       console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would add ${name} to ${parentName}'s sync_peers`);
     }
     console.log();
@@ -190,6 +196,23 @@ export async function cmdBud(name: string, opts: BudOpts = {}) {
   }
   const fleetFile = configureFleet(name, org, budRepoName, parentName);
   if (opts.note) writeBirthNote(psiDir, name, parentName, opts.note);
+
+  // #1551 — structure-only oracle creation. This intentionally stops after
+  // the repo/skeleton/fleet scaffolding is present but before any lifecycle
+  // side effects that make the oracle "alive": no initial commit/push, no
+  // parent sync_peers mutation, no wake/split/attach, no /awaken trigger, and
+  // no birth signal. Operators can inspect/edit the scaffold, then choose the
+  // next lifecycle step explicitly.
+  if (opts.scaffoldOnly) {
+    console.log(`\n  \x1b[32m▧ Scaffold complete!\x1b[0m ${name}`);
+    console.log(`  \x1b[90m  repo: ${budRepoSlug}`);
+    console.log(`  \x1b[90m  path: ${budRepoPath}`);
+    console.log(`  \x1b[90m  fleet: ${fleetFile}`);
+    console.log(`  \x1b[90m  skipped: git commit/push, wake, attach, parent sync_peers, /awaken`);
+    console.log(`  \x1b[90m  next: inspect files, then run maw wake ${name} or maw awaken ${name} when ready\x1b[0m`);
+    console.log();
+    return;
+  }
 
   // 5-8.5. Soul-sync, commit, sync peers, wake, split, copy
   await finalizeBud({

--- a/src/vendor/mpr-plugins/bud/index.ts
+++ b/src/vendor/mpr-plugins/bud/index.ts
@@ -37,6 +37,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         "--dry-run": Boolean,
         "--pr": Boolean,
         "--split": Boolean,
+        "--scaffold-only": Boolean,
         "--seed": Boolean,
         "--blank": Boolean,
         "--signal-on-birth": Boolean,
@@ -73,7 +74,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
 
       const name = flags._[0];
       if (!name || name === "--help" || name === "-h") {
-        return { ok: false, error: "usage: maw bud <name> [--from <oracle>] [--root] [--seed] [--org <org>] [--repo org/repo] [--issue N] [--note <text>] [--nickname <pretty>] [--fast] [--split] [--dry-run]\n       Or:    maw bud --from-repo <path|url> --stem <stem> [--pr] [--from <parent>] [--seed] [--sync-peers] [--force] [--track-vault] [--dry-run]  (#588)\n       Default: born blank. Use --seed to pre-load parent's ψ at birth.\n       Pull memory later: maw soul-sync <parent> --from" };
+        return { ok: false, error: "usage: maw bud <name> [--from <oracle>] [--root] [--seed] [--org <org>] [--repo org/repo] [--issue N] [--note <text>] [--nickname <pretty>] [--fast] [--split] [--scaffold-only] [--dry-run]\n       Or:    maw scaffold <name> [bud flags...]  (structure only; no commit/push/wake/awaken)\n       Or:    maw bud --from-repo <path|url> --stem <stem> [--pr] [--from <parent>] [--seed] [--sync-peers] [--force] [--track-vault] [--dry-run]  (#588)\n       Default: born blank. Use --seed to pre-load parent's ψ at birth.\n       Pull memory later: maw soul-sync <parent> --from" };
       }
       if (name.startsWith("-")) {
         return { ok: false, error: `"${name}" looks like a flag, not an oracle name.\n  usage: maw bud <name> ${args.join(" ")}` };
@@ -90,6 +91,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         root: flags["--root"],
         dryRun: flags["--dry-run"],
         split: flags["--split"],
+        scaffoldOnly: flags["--scaffold-only"],
         seed: flags["--seed"],
         blank: flags["--blank"],
         signalOnBirth: flags["--signal-on-birth"],
@@ -109,6 +111,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         root: body.root as boolean | undefined,
         dryRun: body.dryRun as boolean | undefined,
         split: body.split as boolean | undefined,
+        scaffoldOnly: body.scaffoldOnly as boolean | undefined,
         seed: body.seed as boolean | undefined,
         blank: body.blank as boolean | undefined,
         signalOnBirth: body.signalOnBirth as boolean | undefined,

--- a/src/vendor/mpr-plugins/bud/plugin.json
+++ b/src/vendor/mpr-plugins/bud/plugin.json
@@ -6,7 +6,7 @@
   "description": "Create a new oracle (bud from parent)",
   "cli": {
     "command": "bud",
-    "help": "maw bud <name> [--from <oracle>] [--root] [--seed] [--org <org>] [--repo org/repo] [--issue N] [--note <text>] [--fast] [--split] [--dry-run]\n       Or:    maw bud --from-repo <path> --stem <stem> [--pr] [--dry-run]  (#588, scaffold-only)\n       Default: born blank. Use --seed to pre-load parent's ψ at birth.\n       Pull memory later: maw soul-sync <parent> --from\n       NOTE: <name> is the STEM. Repo created as <name>-oracle.\n       e.g. 'maw bud fusion' → 'fusion-oracle'. 'maw bud fusion-oracle' → 'fusion-oracle-oracle' ✗",
+    "help": "maw bud <name> [--from <oracle>] [--root] [--seed] [--org <org>] [--repo org/repo] [--issue N] [--note <text>] [--fast] [--split] [--scaffold-only] [--dry-run]\n       Or:    maw scaffold <name> [bud flags...]  (structure only; no commit/push/wake/awaken)\n       Or:    maw bud --from-repo <path> --stem <stem> [--pr] [--dry-run]  (#588, scaffold-only)\n       Default: born blank. Use --seed to pre-load parent's ψ at birth.\n       Pull memory later: maw soul-sync <parent> --from\n       NOTE: <name> is the STEM. Repo created as <name>-oracle.\n       e.g. 'maw bud fusion' → 'fusion-oracle'. 'maw bud fusion-oracle' → 'fusion-oracle-oracle' ✗",
     "flags": {
       "--from": "string",
       "--from-repo": "string",
@@ -20,6 +20,7 @@
       "--blank": "boolean",
       "--pr": "boolean",
       "--split": "boolean",
+      "--scaffold-only": "boolean",
       "--seed": "boolean",
       "--dry-run": "boolean"
     }

--- a/test/cli/dispatch-match.test.ts
+++ b/test/cli/dispatch-match.test.ts
@@ -356,6 +356,16 @@ describe("resolveTopAlias — RFC #954 verb aliases", () => {
     expect(ALIAS_DESCRIPTIONS.new).toContain("Create a new oracle");
   });
 
+  test("`scaffold neo` → bud --scaffold-only argv rewrite", () => {
+    const out = resolveTopAlias(["scaffold", "neo", "--root"]);
+    expect(out).not.toBeNull();
+    expect(out!.kind).toBe("argv");
+    if (out!.kind === "argv") {
+      expect(out!.argv).toEqual(["bud", "--scaffold-only", "neo", "--root"]);
+    }
+    expect(ALIAS_DESCRIPTIONS.scaffold).toContain("skeleton");
+  });
+
   test("`bring neo` defaults to v1 split-and-attach mode", () => {
     const parsed = parseBringArgs(["neo"]);
     expect(parsed).toEqual({ oracle: "neo", opts: { split: true } });

--- a/test/isolated/bud-scaffold-only.test.ts
+++ b/test/isolated/bud-scaffold-only.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { join } from "path";
+
+const root = join(import.meta.dir, "../../src");
+const calls: string[] = [];
+
+mock.module("maw-js/config", () => ({
+  loadConfig: () => ({ githubOrg: "TestOrg" }),
+}));
+
+mock.module("maw-js/config/ghq-root", () => ({
+  getGhqRoot: () => "/ghq",
+}));
+
+mock.module("maw-js/commands/shared/wake-target", () => ({
+  parseWakeTarget: () => null,
+  ensureCloned: async () => {
+    calls.push("ensureCloned");
+  },
+}));
+
+mock.module("maw-js/core/matcher/normalize-target", () => ({
+  normalizeTarget: (target: string) => target,
+}));
+
+mock.module("maw-js/core/fleet/validate", () => ({
+  assertValidOracleName: () => undefined,
+}));
+
+mock.module("maw-js/sdk", () => ({
+  FLEET_DIR: "/fleet",
+  hostExec: async (cmd: string) => {
+    calls.push(`hostExec:${cmd}`);
+    throw new Error(`hostExec should not be needed in this test: ${cmd}`);
+  },
+}));
+
+mock.module("maw-js/core/fleet/leaf", () => ({
+  writeSignal: () => {
+    calls.push("writeSignal");
+  },
+}));
+
+mock.module("maw-js/core/fleet/nicknames", () => ({
+  validateNickname: (value: string) => ({ ok: true, value }),
+  writeNickname: () => {
+    calls.push("writeNickname");
+  },
+  setCachedNickname: () => {
+    calls.push("setCachedNickname");
+  },
+}));
+
+mock.module(join(root, "vendor/mpr-plugins/bud/smart-default-org"), () => ({
+  resolveOrg: async () => ({ org: "TestOrg", source: "flag" }),
+  formatOrgSource: () => "flag",
+}));
+
+mock.module(join(root, "vendor/mpr-plugins/bud/bud-repo"), () => ({
+  ensureBudRepo: async () => {
+    calls.push("ensureBudRepo");
+    return "/tmp/testscaffold-oracle";
+  },
+}));
+
+mock.module(join(root, "vendor/mpr-plugins/bud/bud-init"), () => ({
+  initVault: () => {
+    calls.push("initVault");
+    return "/tmp/testscaffold-oracle/ψ";
+  },
+  generateClaudeMd: () => {
+    calls.push("generateClaudeMd");
+  },
+  configureFleet: () => {
+    calls.push("configureFleet");
+    return "/fleet/01-testscaffold.json";
+  },
+  writeBirthNote: () => {
+    calls.push("writeBirthNote");
+  },
+}));
+
+mock.module(join(root, "vendor/mpr-plugins/bud/bud-wake"), () => ({
+  finalizeBud: async () => {
+    calls.push("finalizeBud");
+  },
+}));
+
+const { cmdBud } = await import("../../src/vendor/mpr-plugins/bud/impl");
+
+async function withCapturedLogs(fn: () => Promise<void>): Promise<string> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => {
+    logs.push(args.map(String).join(" "));
+  };
+  try {
+    await fn();
+  } finally {
+    console.log = origLog;
+  }
+  return logs.join("\n");
+}
+
+describe("maw scaffold / bud --scaffold-only (#1551)", () => {
+  beforeEach(() => {
+    calls.length = 0;
+  });
+
+  test("scaffold-only creates the skeleton then stops before lifecycle side effects", async () => {
+    const output = await withCapturedLogs(() => cmdBud("testscaffold", {
+      root: true,
+      org: "TestOrg",
+      scaffoldOnly: true,
+      note: "structure only",
+      signalOnBirth: true,
+    }));
+
+    expect(calls).toContain("ensureBudRepo");
+    expect(calls).toContain("initVault");
+    expect(calls).toContain("generateClaudeMd");
+    expect(calls).toContain("configureFleet");
+    expect(calls).toContain("writeBirthNote");
+    expect(calls).not.toContain("finalizeBud");
+    expect(calls).not.toContain("writeSignal");
+    expect(output).toContain("Scaffold complete");
+    expect(output).toContain("skipped: git commit/push, wake, attach, parent sync_peers, /awaken");
+  });
+
+  test("normal bud still continues into finalizeBud", async () => {
+    await withCapturedLogs(() => cmdBud("testnormal", { root: true, org: "TestOrg" }));
+
+    expect(calls).toContain("ensureBudRepo");
+    expect(calls).toContain("configureFleet");
+    expect(calls).toContain("finalizeBud");
+  });
+
+  test("dry-run scaffold describes the stop point instead of wake/sync side effects", async () => {
+    const output = await withCapturedLogs(() =>
+      cmdBud("testdry", {
+        from: "mawjs",
+        org: "TestOrg",
+        dryRun: true,
+        scaffoldOnly: true,
+      }),
+    );
+
+    expect(output).toContain("scaffold-only");
+    expect(output).toContain("would stop before git commit/push");
+    expect(output).not.toContain("would wake testdry");
+    expect(output).not.toContain("would add testdry to mawjs");
+    expect(calls).not.toContain("ensureBudRepo");
+    expect(calls).not.toContain("finalizeBud");
+  });
+});


### PR DESCRIPTION
## Summary

- add top-level `maw scaffold` as `bud --scaffold-only`
- stop after repo/vault/CLAUDE/fleet/birth-note skeleton work
- explicitly skip commit/push, wake, attach, parent `sync_peers`, `/awaken`, and birth signal
- cover CLI aliasing + scaffold-only bud behavior with regression tests

## Verification

- `rtk bun test test/isolated/bud-scaffold-only.test.ts test/cli/dispatch-match.test.ts`
- `rtk bun run build`
- branch-linked user smoke: `maw scaffold --help`
- branch-linked user smoke: `maw scaffold codex-scaffold-smoke --root --org TestOrg --dry-run`
  - confirmed it prints `scaffold-only: would stop before git commit/push, wake, attach, parent sync_peers, and /awaken`
  - confirmed it does **not** print `would wake codex-scaffold-smoke` or parent-sync messaging

## Notes

Live scaffold creation was intentionally not run because it would create a GitHub repo and local project skeleton. The user-visible smoke uses `--dry-run` for the exact CLI path without external side effects.

Closes #1551

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
