### PR TITLE
fix(test): keep curlFetch all-test gate portable on macOS

### DIFF
--- a/src/core/transport/curl-fetch.ts
+++ b/src/core/transport/curl-fetch.ts
@@ -19,7 +19,18 @@ import { signHeaders, signHeadersV3, resolveFromAddress } from "../../lib/federa
 import { getPeerKey } from "../../lib/peer-key";
 import { loadConfig } from "../../config";
 
-const IS_MACOS = process.platform === "darwin";
+type CurlFetchTransport = "native" | "curl";
+
+function selectTransport(): CurlFetchTransport {
+  // Test/dev escape hatch: the macOS default intentionally shells out to curl
+  // to avoid Apple's Local Network Privacy prompt path, but unit tests need a
+  // deterministic way to exercise the native-fetch branch with mocked
+  // `globalThis.fetch` on Nat's m5. Production behavior is unchanged when the
+  // env var is absent.
+  const forced = process.env.MAW_CURL_FETCH_TRANSPORT;
+  if (forced === "native" || forced === "curl") return forced;
+  return process.platform === "darwin" ? "curl" : "native";
+}
 
 // #653: cap response body to defend against a hostile peer returning an
 // unbounded stream. 10 MB matches the project convention for untrusted
@@ -103,9 +114,9 @@ export async function curlFetch(url: string, opts?: {
     return { ok: false, status: 0, data: null };
   }
 
-  // Prefer native fetch (Linux, remote hosts)
-  // Fall back to curl on macOS (Local Network Privacy blocks fetch for LAN/WG)
-  if (!IS_MACOS) {
+  // Prefer native fetch (Linux, remote hosts).
+  // Fall back to curl on macOS (Local Network Privacy blocks fetch for LAN/WG).
+  if (selectTransport() === "native") {
     return nativeFetch(url, opts, headers);
   }
   return curlSpawn(url, opts, headers);

--- a/test/curl-fetch.test.ts
+++ b/test/curl-fetch.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock, beforeEach } from "bun:test";
+import { describe, test, expect, mock, beforeEach, afterAll } from "bun:test";
 
 // Mock config
 mock.module("../src/core/paths", () => ({
@@ -12,6 +12,7 @@ mock.module("../src/core/paths", () => ({
 
 let mockToken: string | undefined = "test-token-16chars!";
 let mockConfigThrows = false;
+const origCurlFetchTransport = process.env.MAW_CURL_FETCH_TRANSPORT;
 import { mockConfigModule } from "./helpers/mock-config";
 mock.module("../src/config", () => mockConfigModule(() => {
   if (mockConfigThrows) throw new Error("simulated config load failure");
@@ -32,13 +33,30 @@ try {
   hasLocalMawServer = probe.ok;
 } catch { /* unreachable — skip integration tests */ }
 
-const liveTest = hasLocalMawServer ? test : test.skip;
+const liveTest = process.env.MAW_TEST_LIVE_CURL === "1" && hasLocalMawServer ? test : test.skip;
 
 describe("curlFetch", () => {
-  test("uses native fetch on Linux", async () => {
-    // On Linux (this test runs on white.local), curlFetch should use native fetch
-    // We can verify by checking process.platform
-    expect(process.platform).toBe("linux");
+  beforeEach(() => {
+    mockToken = "test-token-16chars!";
+    mockConfigThrows = false;
+    process.env.MAW_CURL_FETCH_TRANSPORT = "native";
+  });
+
+  test("can force native fetch for deterministic unit coverage", async () => {
+    const origFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = (async () =>
+        new Response(JSON.stringify({ transport: "native" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })) as typeof fetch;
+
+      const res = await curlFetch("http://example.invalid/native", { timeout: 1000 });
+      expect(res.ok).toBe(true);
+      expect(res.data).toEqual({ transport: "native" });
+    } finally {
+      globalThis.fetch = origFetch;
+    }
   });
 
   test("returns ok:false for unreachable host", async () => {
@@ -99,6 +117,7 @@ describe("curlFetch", () => {
   });
 
   liveTest("sends HMAC headers when token configured", async () => {
+    delete process.env.MAW_CURL_FETCH_TRANSPORT;
     // Test against local maw server — auth/status is public so it won't reject
     const res = await curlFetch("http://white.local:3456/api/auth/status", { timeout: 5000 });
     expect(res.ok).toBe(true);
@@ -106,6 +125,7 @@ describe("curlFetch", () => {
   });
 
   liveTest("sends POST with body and auth headers", async () => {
+    delete process.env.MAW_CURL_FETCH_TRANSPORT;
     // POST to auth/status (public endpoint, accepts any method)
     const res = await curlFetch("http://white.local:3456/api/auth/status", {
       method: "POST",
@@ -117,6 +137,7 @@ describe("curlFetch", () => {
   });
 
   liveTest("works without federation token", async () => {
+    delete process.env.MAW_CURL_FETCH_TRANSPORT;
     mockToken = undefined;
     const res = await curlFetch("http://white.local:3456/api/auth/status", { timeout: 5000 });
     expect(res.ok).toBe(true);
@@ -124,6 +145,7 @@ describe("curlFetch", () => {
   });
 
   liveTest("parses JSON response", async () => {
+    delete process.env.MAW_CURL_FETCH_TRANSPORT;
     const res = await curlFetch("http://white.local:3456/api/auth/status", { timeout: 5000 });
     expect(res.ok).toBe(true);
     expect(typeof res.data).toBe("object");
@@ -134,6 +156,12 @@ describe("curlFetch", () => {
 describe("curlFetch body size cap (#653)", () => {
   // Tests snapshot global.fetch per-case so they don't leak across the file.
   // Pattern lifted from costs.test.ts fix (#649) to keep snapshot/restore safe.
+
+  beforeEach(() => {
+    mockToken = "test-token-16chars!";
+    mockConfigThrows = false;
+    process.env.MAW_CURL_FETCH_TRANSPORT = "native";
+  });
 
   test("rejects body exceeding maxBytes (streaming)", async () => {
     const origFetch = globalThis.fetch;
@@ -213,6 +241,7 @@ describe("curlFetch body size cap (#653)", () => {
 
 describe("curlFetch federation auth", () => {
   liveTest("protected endpoint with wrong token gets rejected", async () => {
+    delete process.env.MAW_CURL_FETCH_TRANSPORT;
     // Wrong token → signature mismatch → 401 from remote, but from white.local
     // the server sees non-loopback IP so it checks HMAC
     mockToken = "wrong-token-that-wont-match";
@@ -228,6 +257,7 @@ describe("curlFetch federation auth", () => {
   });
 
   liveTest("POST with body does not hang", async () => {
+    delete process.env.MAW_CURL_FETCH_TRANSPORT;
     // This specifically tests the bug where POST + headers caused Bun.spawn curl to hang
     const start = Date.now();
     const res = await curlFetch("http://white.local:3456/api/send", {
@@ -241,4 +271,12 @@ describe("curlFetch federation auth", () => {
     // 404 is expected (target not found) — but it didn't hang
     expect(res.status).toBeDefined();
   });
+});
+
+afterAll(() => {
+  if (origCurlFetchTransport === undefined) {
+    delete process.env.MAW_CURL_FETCH_TRANSPORT;
+  } else {
+    process.env.MAW_CURL_FETCH_TRANSPORT = origCurlFetchTransport;
+  }
 });


### PR DESCRIPTION
## Summary

- add `MAW_CURL_FETCH_TRANSPORT=native|curl` as a deterministic test/dev override while preserving the macOS production default of spawning `curl`
- replace the Linux-only curlFetch assertion with a mocked native-fetch unit path that works on m5/darwin
- make live `white.local` curlFetch checks opt-in via `MAW_TEST_LIVE_CURL=1` so the default local all-test gate does not depend on a specific daemon/auth state

## Verification

- Reproduced before patch: `bun run test:all` failed on m5 with 7 failures in `test/curl-fetch.test.ts`
- `rtk bun test test/curl-fetch.test.ts`
- `rtk bun run build && rtk bun run test:all` — pass in 63s

## Notes

This keeps the body-size, signing, and native-fetch regressions covered in the default local gate instead of skipping the whole curlFetch file on macOS. Live federation curl checks remain available with `MAW_TEST_LIVE_CURL=1`.

Closes #1559

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
