### PR TITLE
release: v26.5.16-alpha.1053

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.16-alpha.716",
+  "version": "26.5.16-alpha.1053",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts `v26.5.16-alpha.1053` so the verified alpha head becomes consumable via the release workflow.

Evidence before PR:
- `alpha` was clean at `53c404d9`, ahead of latest published alpha `v26.5.16-alpha.716` (`c3d6be3a`).
- Open issues/PRs were verified at `0/0` before this release bump.
- Local linked maw already verified at `53c404d9` with user-visible smokes and full gate earlier.

Fast release gate on this branch:
- `TZ=Asia/Bangkok bun scripts/calver.ts --check`
- `bun test test/calver.test.ts`
- `bun run build`

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
