### PR TITLE
feat(discovery): gate Zenoh scout as optional transport upgrade

### DIFF
--- a/src/api/peers-discoveries.ts
+++ b/src/api/peers-discoveries.ts
@@ -59,7 +59,7 @@ export function toDiscoveryResponse(
 export function createPeerDiscoveriesApi(
   listPeers: () => DiscoveredPeer[] = () => getTransportRouter().listDiscoveredPeers() as DiscoveredPeer[],
 ) {
-  return new Elysia().get("/peers/discoveries", ({ query, set }) => {
+  const handler = ({ query, set }: { query: Record<string, string | undefined>; set: { status?: number } }) => {
     const all = query.all === "1" || query.all === "true";
     const limit = query.limit === undefined
       ? undefined
@@ -73,7 +73,10 @@ export function createPeerDiscoveriesApi(
       };
     }
     return toDiscoveryResponse(listPeers(), { all, limit });
-  });
+  };
+  return new Elysia()
+    .get("/peers/discoveries", handler)
+    .get("/peers/discovered", handler);
 }
 
 export const peerDiscoveriesApi = createPeerDiscoveriesApi();

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -153,6 +153,10 @@ export interface MawConfig {
       keyPrefix?: string;
     };
   };
+  /** Discovery provider selection for peer presence candidates. */
+  discovery?: {
+    transport?: "scout" | "zenoh" | "both" | "off";
+  };
   /** Polling intervals (ms) */
   intervals?: MawIntervals;
   /** HTTP/operation timeouts (ms) */

--- a/src/config/validate-ext.ts
+++ b/src/config/validate-ext.ts
@@ -89,6 +89,20 @@ function validateExtFields(
     if (Object.keys(zenoh).length > 0) result.zenoh = zenoh;
   }
 
+  // discovery: { transport?: "scout" | "zenoh" | "both" | "off" }
+  if ("discovery" in raw && raw.discovery && typeof raw.discovery === "object" && !Array.isArray(raw.discovery)) {
+    const d = raw.discovery as Record<string, unknown>;
+    const discovery: NonNullable<MawConfig["discovery"]> = {};
+    if ("transport" in d) {
+      if (d.transport === "scout" || d.transport === "zenoh" || d.transport === "both" || d.transport === "off") {
+        discovery.transport = d.transport;
+      } else {
+        warn("discovery.transport", "must be one of: scout, zenoh, both, off");
+      }
+    }
+    if (Object.keys(discovery).length > 0) result.discovery = discovery;
+  }
+
   // pluginSources: string[] of URLs
   if ("pluginSources" in raw) {
     if (Array.isArray(raw.pluginSources)) {

--- a/src/transports/index.ts
+++ b/src/transports/index.ts
@@ -11,7 +11,26 @@ import { LoRaTransport } from "./lora";
 import { NanoclawTransport } from "./nanoclaw";
 import { MdnsTransport } from "./mdns";
 import { ScoutTransport } from "./scout";
+import { ZenohScoutTransport } from "./zenoh-scout";
+import { readZenohScoutConfig } from "../vendor/mpr-plugins/zenoh-scout/impl";
 // ZenohTransport loaded dynamically — zenoh-ts bundles WASM that conflicts with single-file build
+
+type DiscoveryTransport = "scout" | "zenoh" | "both" | "off";
+
+const ZENOH_SCOUT_PLUGIN = "zenoh-scout";
+
+export function discoveryTransport(config: ReturnType<typeof loadConfig>): DiscoveryTransport {
+  const zenohPluginEnabled = !(config.disabledPlugins ?? []).includes(ZENOH_SCOUT_PLUGIN);
+  const configured = config.discovery?.transport;
+  if (configured === "scout" || configured === "zenoh" || configured === "both" || configured === "off") {
+    if (zenohPluginEnabled) return configured;
+    if (configured === "zenoh") return "off";
+    if (configured === "both") return "scout";
+    return configured;
+  }
+  if (!zenohPluginEnabled) return "scout";
+  return config.zenoh?.scout?.enabled === true ? "both" : "scout";
+}
 
 /** Singleton router instance */
 let router: TransportRouter | null = null;
@@ -34,17 +53,32 @@ export function createTransportRouter(): TransportRouter {
     router.register(new HubTransport(config.node));
   }
 
-  // 2.5. Scout P2P — zenoh-inspired zero-config LAN discovery + auto-pairing
-  const oracles = Object.keys(config.agents || {}).filter(k => k.endsWith("-oracle"));
-  const scout = new ScoutTransport({
-    node: config.node ?? "local",
-    oracle: config.oracle ?? "mawjs",
-    port: config.port ?? 3456,
-    oracles,
-    autoPair: true,
-  });
-  scout.connect().catch(() => {});
-  router.register(scout);
+  const discovery = discoveryTransport(config);
+
+  // 2.5. Scout P2P — zero-config LAN discovery + auto-pairing.
+  if (discovery === "scout" || discovery === "both") {
+    const oracles = Object.keys(config.agents || {}).filter(k => k.endsWith("-oracle"));
+    const scout = new ScoutTransport({
+      node: config.node ?? "local",
+      oracle: config.oracle ?? "mawjs",
+      port: config.port ?? 3456,
+      oracles,
+      autoPair: true,
+    });
+    scout.connect().catch(() => {});
+    router.register(scout);
+  }
+
+  // 2.5b. Zenoh Scout — opt-in discovery/presence provider only.
+  // Pairing/trust remains in MAW's HTTP pair/peers flow.
+  if (discovery === "zenoh" || discovery === "both") {
+    const zenohScout = new ZenohScoutTransport({
+      ...readZenohScoutConfig(config),
+      enabled: true,
+    });
+    zenohScout.connect().catch(() => {});
+    router.register(zenohScout);
+  }
 
   // 2.6. Zenoh transport — pub/sub + auto-discovery (dynamic import — WASM)
   if (config.zenoh?.locator) {
@@ -97,4 +131,5 @@ export { NanoclawTransport } from "./nanoclaw";
 export { LoRaTransport } from "./lora";
 export { MdnsTransport } from "./mdns";
 export { ScoutTransport } from "./scout";
+export { ZenohScoutTransport } from "./zenoh-scout";
 // ZenohTransport exported via dynamic import only (WASM dependency)

--- a/src/transports/zenoh-scout.ts
+++ b/src/transports/zenoh-scout.ts
@@ -1,0 +1,188 @@
+/**
+ * Zenoh Scout discovery provider.
+ *
+ * This is intentionally discovery-only: it advertises/reads MAW presence via
+ * zenoh liveliness and exposes rows through TransportRouter.listDiscoveredPeers().
+ * Pairing, TOFU/pubkey trust, and user-facing peer registry writes stay in the
+ * existing MAW HTTP pair/peers flow.
+ */
+
+import type {
+  Transport,
+  TransportTarget,
+  TransportMessage,
+  TransportPresence,
+} from "../core/transport/transport";
+import type { FeedEvent } from "../lib/feed";
+import type { DiscoveredPeer } from "./scout-state";
+import {
+  discoveryKey,
+  keyexprFromReply,
+  parseDiscoveryKey,
+  type ImportZenoh,
+  type ZenohApi,
+  type ZenohScoutConfig,
+  type ZenohSession,
+} from "../vendor/mpr-plugins/zenoh-scout/impl";
+
+export interface ZenohScoutTransportConfig extends ZenohScoutConfig {
+  pollMs?: number;
+  importZenoh?: ImportZenoh;
+  now?: () => Date;
+}
+
+const DEFAULT_POLL_MS = 5_000;
+
+export class ZenohScoutTransport implements Transport {
+  readonly name = "zenoh-scout";
+  private _connected = false;
+  private readonly config: ZenohScoutTransportConfig;
+  private zenoh: ZenohApi | null = null;
+  private session: ZenohSession | null = null;
+  private token: { undeclare(): Promise<void> } | null = null;
+  private readonly peers = new Map<string, DiscoveredPeer>();
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private refreshing: Promise<void> | null = null;
+  private msgHandlers = new Set<(msg: TransportMessage) => void>();
+  private presenceHandlers = new Set<(p: TransportPresence) => void>();
+  private feedHandlers = new Set<(e: FeedEvent) => void>();
+
+  constructor(config: ZenohScoutTransportConfig) {
+    this.config = config;
+  }
+
+  get connected() {
+    return this._connected;
+  }
+
+  async connect(): Promise<void> {
+    await this.refresh();
+    const pollMs = Math.max(250, this.config.pollMs ?? DEFAULT_POLL_MS);
+    this.timer = setInterval(() => {
+      this.refresh().catch(() => {});
+    }, pollMs);
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    await this.closeSession();
+    this.peers.clear();
+    this._connected = false;
+  }
+
+  async send(_target: TransportTarget, _message: string): Promise<boolean> {
+    return false;
+  }
+
+  async publishPresence(_presence: TransportPresence): Promise<void> {
+    await this.refresh();
+  }
+
+  async publishFeed(_event: FeedEvent): Promise<void> {}
+
+  onMessage(handler: (msg: TransportMessage) => void) {
+    this.msgHandlers.add(handler);
+  }
+
+  onPresence(handler: (p: TransportPresence) => void) {
+    this.presenceHandlers.add(handler);
+  }
+
+  onFeed(handler: (e: FeedEvent) => void) {
+    this.feedHandlers.add(handler);
+  }
+
+  canReach(_target: TransportTarget): boolean {
+    return false;
+  }
+
+  listPeers(): DiscoveredPeer[] {
+    return [...this.peers.values()];
+  }
+
+  private async refresh(): Promise<void> {
+    if (this.refreshing) return this.refreshing;
+    this.refreshing = this.refreshInner().finally(() => {
+      this.refreshing = null;
+    });
+    return this.refreshing;
+  }
+
+  private async refreshInner(): Promise<void> {
+    try {
+      await this.ensureSession();
+      const zenoh = this.zenoh!;
+      const session = this.session!;
+      const timeout = zenoh.Duration?.milliseconds?.of(this.config.timeoutMs) ?? this.config.timeoutMs;
+      const receiver = await session.liveliness().get(new zenoh.KeyExpr(`${this.config.keyPrefix}/**`), { timeout });
+      const next = new Map<string, DiscoveredPeer>();
+      const now = this.config.now?.() ?? new Date();
+      if (receiver) {
+        for await (const reply of receiver) {
+          const key = keyexprFromReply(reply);
+          if (!key) continue;
+          const peer = parseDiscoveryKey(key, this.config.keyPrefix, now);
+          if (!peer) continue;
+          if (peer.node === this.config.node && peer.oracle === this.config.oracle) continue;
+          const previous = this.peers.get(peer.zid);
+          const lastSeen = Date.parse(peer.lastSeen);
+          next.set(peer.zid, {
+            zid: peer.zid,
+            node: peer.node,
+            host: peer.host,
+            oracle: peer.oracle,
+            locators: peer.locators,
+            capabilities: peer.capabilities,
+            oracles: peer.oracles,
+            lastSeen: Number.isFinite(lastSeen) ? lastSeen : now.getTime(),
+            paired: previous?.paired ?? peer.paired,
+          });
+          this.emitPresence(peer.oracle, peer.host, "ready");
+        }
+      }
+      this.peers.clear();
+      for (const [zid, peer] of next) this.peers.set(zid, peer);
+      this._connected = true;
+    } catch {
+      this._connected = false;
+      await this.closeSession();
+    }
+  }
+
+  private async ensureSession(): Promise<void> {
+    if (this.session && this.zenoh && (this.config.advertise === false || this.token)) return;
+    const importZenoh = this.config.importZenoh ?? (() => import("@eclipse-zenoh/zenoh-ts") as Promise<ZenohApi>);
+    const zenoh = await importZenoh();
+    const sessionConfig = new zenoh.Config(this.config.locator, this.config.timeoutMs);
+    const session = zenoh.Session?.open
+      ? await zenoh.Session.open(sessionConfig)
+      : await zenoh.open!(sessionConfig);
+    const token = this.config.advertise === false
+      ? null
+      : await session.liveliness().declareToken(new zenoh.KeyExpr(discoveryKey(this.config)));
+    this.zenoh = zenoh;
+    this.session = session;
+    this.token = token;
+  }
+
+  private async closeSession(): Promise<void> {
+    if (this.token) {
+      await this.token.undeclare().catch(() => {});
+      this.token = null;
+    }
+    if (this.session) {
+      await this.session.close().catch(() => {});
+      this.session = null;
+    }
+    this.zenoh = null;
+  }
+
+  private emitPresence(oracle: string, host: string, status: TransportPresence["status"]): void {
+    for (const h of this.presenceHandlers) {
+      h({ oracle, host, status, timestamp: Date.now() });
+    }
+  }
+}

--- a/src/vendor/mpr-plugins/zenoh-scout/impl.ts
+++ b/src/vendor/mpr-plugins/zenoh-scout/impl.ts
@@ -223,7 +223,7 @@ export function formatZenohScoutResult(result: ZenohScoutResult): string {
   return [fmt(header), fmt(widths.map((w) => "-".repeat(w))), ...rows.map(fmt)].join("\n");
 }
 
-function keyexprFromReply(reply: unknown): string | null {
+export function keyexprFromReply(reply: unknown): string | null {
   const maybeResult = typeof (reply as any)?.result === "function" ? (reply as any).result() : reply;
   const maybeSample = maybeResult && typeof (maybeResult as any).keyexpr === "function" ? maybeResult : null;
   if (!maybeSample) return null;

--- a/src/vendor/mpr-plugins/zenoh-scout/index.ts
+++ b/src/vendor/mpr-plugins/zenoh-scout/index.ts
@@ -38,6 +38,12 @@ function readOption(args: string[], name: string): string | undefined {
   return value && !value.startsWith("--") ? value : undefined;
 }
 
+function choice(value: unknown): "zenoh" | "scout" | "both" | undefined {
+  if (typeof value !== "string") return undefined;
+  if (value === "zenoh" || value === "scout" || value === "both") return value;
+  return undefined;
+}
+
 function boolish(value: unknown): boolean | undefined {
   if (typeof value === "boolean") return value;
   if (typeof value === "string") {
@@ -56,6 +62,16 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult 
   try {
     const config = loadConfig();
     const base = readZenohScoutConfig(config);
+    const transportRaw = readOption(args, "--transport")
+      ?? (typeof query.transport === "string" ? query.transport : undefined);
+    const transport = choice(transportRaw) ?? "zenoh";
+    if (transportRaw && !choice(transportRaw)) {
+      return {
+        ok: false,
+        error: "invalid_transport",
+        output: "usage: maw scout --transport zenoh|scout|both",
+      };
+    }
 
     const locator = readOption(args, "--locator")
       ?? (typeof query.locator === "string" ? query.locator : undefined)
@@ -71,6 +87,16 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult 
       : hasFlag(args, "--advertise")
         ? true
         : boolish(query.advertise) ?? true;
+
+    if (transport === "scout") {
+      const { fetchDiscoveries, formatDiscoveries } = await import("../peers/discovered");
+      const result = await fetchDiscoveries({
+        all: hasFlag(args, "--all") || boolish(query.all) === true,
+        limit: Number(readOption(args, "--limit") ?? query.limit) || undefined,
+      });
+      emit(ctx, logs, json ? JSON.stringify(result, null, 2) : result.ok ? formatDiscoveries(result) : `${result.error}${result.hint ? ` — ${result.hint}` : ""}`);
+      return { ok: result.ok, output: logs.join("\n") || undefined, ...(result.ok ? { total: result.total, peers: result.peers as any } : { error: result.error }) };
+    }
 
     if (hasFlag(args, "--status")) {
       const result: ZenohScoutResult = {
@@ -98,21 +124,64 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult 
         peers: [],
         hint: "zenoh-scout is opt-in; set zenoh.scout.enabled=true or pass --force for a one-shot query",
       };
-      emit(ctx, logs, json ? JSON.stringify(result, null, 2) : formatZenohScoutResult(result));
-      return { ...result, output: logs.join("\n") || undefined };
+      if (transport === "zenoh") {
+        emit(ctx, logs, json ? JSON.stringify(result, null, 2) : formatZenohScoutResult(result));
+        return { ...result, output: logs.join("\n") || undefined };
+      }
     }
 
-    const result = await runZenohScout({
-      ...base,
-      enabled: true,
-      locator,
-      timeoutMs,
-      advertise,
-    });
-    emit(ctx, logs, json ? JSON.stringify(result, null, 2) : formatZenohScoutResult(result));
-    return { ...result, output: logs.join("\n") || undefined };
+    const zenohResult = base.enabled || force
+      ? await runZenohScout({
+        ...base,
+        enabled: true,
+        locator,
+        timeoutMs,
+        advertise,
+      })
+      : {
+        ok: true,
+        enabled: false,
+        locator,
+        keyPrefix: base.keyPrefix,
+        total: 0,
+        peers: [],
+        hint: "zenoh-scout is opt-in; set zenoh.scout.enabled=true or pass --force for a one-shot query",
+      } satisfies ZenohScoutResult;
+
+    if (transport === "both") {
+      const { fetchDiscoveries, formatDiscoveries } = await import("../peers/discovered");
+      const scoutResult = await fetchDiscoveries({
+        all: hasFlag(args, "--all") || boolish(query.all) === true,
+        limit: Number(readOption(args, "--limit") ?? query.limit) || undefined,
+      });
+      const zenohUsable = zenohResult.enabled ? zenohResult.ok : false;
+      const ok = zenohUsable || scoutResult.ok;
+      if (json) {
+        emit(ctx, logs, JSON.stringify({ ok, zenoh: zenohResult, scout: scoutResult }, null, 2));
+      } else {
+        emit(ctx, logs, [
+          "zenoh:",
+          indent(formatZenohScoutResult(zenohResult)),
+          "",
+          "scout:",
+          indent(scoutResult.ok ? formatDiscoveries(scoutResult) : `${scoutResult.error}${scoutResult.hint ? ` — ${scoutResult.hint}` : ""}`),
+        ].join("\n"));
+      }
+      return {
+        ok,
+        error: ok ? undefined : "discovery_unavailable",
+        output: logs.join("\n") || undefined,
+      };
+    }
+
+    emit(ctx, logs, json ? JSON.stringify(zenohResult, null, 2) : formatZenohScoutResult(zenohResult));
+    return { ...zenohResult, output: logs.join("\n") || undefined };
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     return { ok: false, error: message, output: logs.join("\n") || undefined };
   }
+}
+
+function indent(value: string): string {
+  return value.split("\n").map((line) => `  ${line}`).join("\n");
 }

--- a/src/vendor/mpr-plugins/zenoh-scout/plugin.json
+++ b/src/vendor/mpr-plugins/zenoh-scout/plugin.json
@@ -23,10 +23,13 @@
       "discover",
       "zenoh-scout"
     ],
-    "help": "maw scout [--force] [--json] [--locator ws://127.0.0.1:10000] [--timeout <ms>] — query opt-in Zenoh discovery",
+    "help": "maw scout [--transport zenoh|scout|both] [--force] [--json] [--locator ws://127.0.0.1:10000] [--timeout <ms>] — query peer discovery",
     "flags": {
+      "--transport": "string",
       "--force": "boolean",
+      "--all": "boolean",
       "--json": "boolean",
+      "--limit": "number",
       "--locator": "string",
       "--timeout": "number"
     }

--- a/test/isolated/peer-discoveries-api.test.ts
+++ b/test/isolated/peer-discoveries-api.test.ts
@@ -59,6 +59,20 @@ describe("peer discoveries API (#1526)", () => {
     expect(body.peers[0].zid).toBe("newer");
   });
 
+  test("GET /api/peers/discovered aliases the canonical discoveries route", async () => {
+    const app = new Elysia({ prefix: "/api" }).use(createPeerDiscoveriesApi(() => [
+      peer({ zid: "zenoh-row", node: "zenoh-node", lastSeen: NOW - 1_000 }),
+    ]));
+
+    const res = await app.handle(new Request("http://local/api/peers/discovered?all=1"));
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.peers[0]).toMatchObject({
+      zid: "zenoh-row",
+      node: "zenoh-node",
+    });
+  });
+
   test("GET /api/peers/discoveries rejects invalid limits", async () => {
     const app = new Elysia({ prefix: "/api" }).use(createPeerDiscoveriesApi(() => []));
     const res = await app.handle(new Request("http://local/api/peers/discoveries?limit=wat"));

--- a/test/zenoh-scout-plugin.test.ts
+++ b/test/zenoh-scout-plugin.test.ts
@@ -9,6 +9,8 @@ import {
   runZenohScout,
   type ZenohApi,
 } from "../src/vendor/mpr-plugins/zenoh-scout/impl";
+import { ZenohScoutTransport } from "../src/transports/zenoh-scout";
+import { discoveryTransport } from "../src/transports";
 
 describe("zenoh-scout plugin (#1455)", () => {
   test("manifest is valid and exposes opt-in cli/api surfaces", () => {
@@ -33,6 +35,9 @@ describe("zenoh-scout plugin (#1455)", () => {
           keyPrefix: "maw/test/v1",
         },
       },
+      discovery: {
+        transport: "both",
+      },
     });
 
     expect(cfg.zenoh?.locator).toBe("ws://router:10000");
@@ -40,6 +45,25 @@ describe("zenoh-scout plugin (#1455)", () => {
     expect(cfg.zenoh?.scout?.locator).toBe("ws://scout:10000");
     expect(cfg.zenoh?.scout?.timeoutMs).toBe(1234);
     expect(cfg.zenoh?.scout?.keyPrefix).toBe("maw/test/v1");
+    expect(cfg.discovery?.transport).toBe("both");
+  });
+
+  test("discovery transport treats zenoh-scout as a plugin upgrade that can be disabled", () => {
+    expect(discoveryTransport({
+      zenoh: { scout: { enabled: true } },
+    })).toBe("both");
+    expect(discoveryTransport({
+      zenoh: { scout: { enabled: true } },
+      disabledPlugins: ["zenoh-scout"],
+    })).toBe("scout");
+    expect(discoveryTransport({
+      discovery: { transport: "both" },
+      disabledPlugins: ["zenoh-scout"],
+    })).toBe("scout");
+    expect(discoveryTransport({
+      discovery: { transport: "zenoh" },
+      disabledPlugins: ["zenoh-scout"],
+    })).toBe("off");
   });
 
   test("discovery keys round-trip into maw peer discovery rows", () => {
@@ -150,5 +174,70 @@ describe("zenoh-scout plugin (#1455)", () => {
     expect(result.ok).toBe(false);
     expect(result.error).toBe("zenoh_runtime_unsupported");
     expect(result.hint).toContain("zenoh-ts failed to initialize in this runtime");
+  });
+
+  test("ZenohScoutTransport feeds router-style discovered peers without sending or pairing", async () => {
+    const local = readZenohScoutConfig({ node: "m5", oracle: "mawjs", port: 3456, zenoh: { scout: { enabled: true } } });
+    const remote = readZenohScoutConfig({ node: "clinic", oracle: "pulse", port: 4567, zenoh: { scout: { enabled: true } } });
+    const remoteKey = discoveryKey(remote);
+
+    class FakeConfig {
+      constructor(public locator: string, public timeoutMs?: number) {}
+    }
+    class FakeKeyExpr {
+      constructor(public key: string) {}
+      toString() { return this.key; }
+    }
+
+    const fakeSession = {
+      liveliness() {
+        return {
+          async declareToken() {
+            return { async undeclare() {} };
+          },
+          async get() {
+            return (async function* () {
+              yield { result: () => ({ keyexpr: () => ({ toString: () => remoteKey }) }) };
+            })();
+          },
+        };
+      },
+      async close() {},
+    };
+
+    const fakeZenoh: ZenohApi = {
+      Config: FakeConfig,
+      KeyExpr: FakeKeyExpr,
+      Session: { open: async () => fakeSession },
+      Duration: { milliseconds: { of: (ms: number) => ms } },
+    };
+
+    const transport = new ZenohScoutTransport({
+      ...local,
+      enabled: true,
+      pollMs: 60_000,
+      importZenoh: async () => fakeZenoh,
+      now: () => new Date("2026-05-16T00:00:00.000Z"),
+    });
+    await transport.connect();
+    try {
+      expect(transport.connected).toBe(true);
+      expect(transport.canReach({ oracle: "pulse", host: "clinic" })).toBe(false);
+      expect(await transport.send({ oracle: "pulse", host: "clinic" }, "hello")).toBe(false);
+      expect(transport.listPeers()).toEqual([
+        expect.objectContaining({
+          zid: expect.stringContaining("zenoh:"),
+          node: "clinic",
+          oracle: "pulse",
+          host: "clinic:4567",
+          locators: ["http://clinic:4567"],
+          capabilities: ["pair", "feed", "send"],
+          paired: false,
+          lastSeen: Date.parse("2026-05-16T00:00:00.000Z"),
+        }),
+      ]);
+    } finally {
+      await transport.disconnect();
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Adds `discovery.transport: "scout" | "zenoh" | "both" | "off"` so Zenoh discovery is a selectable presence/discovery transport.
- Wires `zenoh-scout` as a **plugin-gated upgrade**: disabling the MPR plugin removes Zenoh from router discovery selection (`both` falls back to Scout; explicit `zenoh` becomes off).
- Keeps MAW pairing/trust policy unchanged: HTTP pairing, TOFU/pubkey trust, `hey`, CLI UX, and peer registry writes stay in MAW.
- Adds `/api/peers/discovered` as an alias for the canonical `/api/peers/discoveries` response.
- Extends `maw scout` with `--transport zenoh|scout|both` for side-by-side discovery inspection.

## Design note

MPR means the vendored `maw-plugin-registry` plugin surface under `src/vendor/mpr-plugins/`. This keeps Zenoh in the “upgrade can plug in/out” lane: the plugin is the operator-facing surface, and Zenoh remains discovery/presence only rather than replacing Scout pairing or MAW trust policy.

## Verification

- `rtk bun test test/zenoh-scout-plugin.test.ts test/isolated/peer-discoveries-api.test.ts`
- `rtk bun run build`
- `rtk bun run test:all` → 199 pass, 2 skip, 0 fail

Not tested: live multi-host zenohd WebSocket bridge discovery smoke.

Refs #1455.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
