### PR TITLE
fix(routing): stop hey from guessing first fleet window

### DIFF
--- a/src/core/routing.ts
+++ b/src/core/routing.ts
@@ -70,20 +70,31 @@ export function resolveTarget(
 
   const selfNode = config.node ?? "local";
 
-  // --- Step 1: Local findWindow + fleet config ---
+  // Fleet config: oracle name → session name → findWindow (#281)
+  //
+  // #1565: fleet-known oracle names must not silently inherit findWindow's
+  // "session exact → first window" behavior. Multi-window oracle sessions often
+  // have helper/issuer windows before the actual `<oracle>-oracle` window, so
+  // route fleet aliases through the explicit fleet-window resolver first.
+  const fleetSession = resolveFleetSession(query) || resolveFleetSession(query.replace(/-oracle$/, ""));
+  if (fleetSession) {
+    const fleetResult = resolveFleetWindowTarget(fleetSession, query, writable, "local");
+    if (fleetResult) return fleetResult;
+  }
+
+  // #1565 also applies when the fleet config does not know the session yet:
+  // a bare `mawjs` query can exact-match session `54-mawjs`, and findWindow()
+  // would return that session's first window. Prefer the stable
+  // `<oracle>-oracle` window convention before allowing that fallback.
+  if (!query.includes(":")) {
+    const sessionAliasResult = resolveSessionAliasWindowTarget(query, writable, "local");
+    if (sessionAliasResult) return sessionAliasResult;
+  }
+
+  // --- Step 1: Local findWindow ---
   const localTarget = findWindow(writable, query);
   if (localTarget) {
     return { type: "local", target: localTarget };
-  }
-  // Fleet config: oracle name → session name → findWindow (#281)
-  const fleetSession = resolveFleetSession(query) || resolveFleetSession(query.replace(/-oracle$/, ""));
-  if (fleetSession) {
-    const fleetTarget = findWindow(writable.filter(s => s.name === fleetSession), query)
-      || findWindow(writable.filter(s => s.name === fleetSession), query.replace(/-oracle$/, ""));
-    if (fleetTarget) return { type: "local", target: fleetTarget };
-    // Fleet config matched but session not running — try first window of fleet session
-    const fleetSess = writable.find(s => s.name === fleetSession);
-    if (fleetSess?.windows.length) return { type: "local", target: `${fleetSession}:${fleetSess.windows[0].index}` };
   }
 
   // --- Step 2: Node:prefix syntax (e.g. "mba:homekeeper") ---
@@ -100,12 +111,11 @@ export function resolveTarget(
     if (nodeName === selfNode || nodeName === "local") {
       const selfFleet = resolveFleetSession(agentName) || resolveFleetSession(agentName.replace(/-oracle$/, ""));
       if (selfFleet) {
-        const fleetTarget = findWindow(writable.filter(s => s.name === selfFleet), agentName)
-          || findWindow(writable.filter(s => s.name === selfFleet), agentName.replace(/-oracle$/, ""));
-        if (fleetTarget) return { type: "self-node", target: fleetTarget };
-        const fleetSess = writable.find(s => s.name === selfFleet);
-        if (fleetSess?.windows.length) return { type: "self-node", target: `${selfFleet}:${fleetSess.windows[0].index}` };
+        const fleetResult = resolveFleetWindowTarget(selfFleet, agentName, writable, "self-node");
+        if (fleetResult) return fleetResult;
       }
+      const sessionAliasResult = resolveSessionAliasWindowTarget(agentName, writable, "self-node");
+      if (sessionAliasResult) return sessionAliasResult;
       const selfTarget = findWindow(writable, agentName);
       if (selfTarget) return { type: "self-node", target: selfTarget };
       return { type: "error", reason: "self_not_running", detail: `'${agentName}' not found in local sessions on ${selfNode}`, hint: `maw wake ${agentName}` };
@@ -163,6 +173,127 @@ function findPeerUrl(nodeName: string, config: MawConfig): string | undefined {
   const peer = config.namedPeers?.find((p) => p.name === nodeName);
   if (peer) return peer.url;
   return config.peers?.find((p) => p.includes(nodeName));
+}
+
+type FleetRouteType = "local" | "self-node";
+type FleetWindowResult =
+  | { type: "local"; target: string }
+  | { type: "self-node"; target: string }
+  | { type: "error"; reason: string; detail: string; hint?: string };
+
+function resolveFleetWindowTarget(
+  fleetSession: string,
+  query: string,
+  writable: Session[],
+  routeType: FleetRouteType,
+): FleetWindowResult | null {
+  const fleetSess = writable.find((s) => s.name === fleetSession);
+  if (!fleetSess?.windows.length) return null;
+
+  const namedTarget = findNamedFleetWindow(fleetSess, query);
+  if (namedTarget) return { type: routeType, target: namedTarget };
+
+  // Preserve the old first-window behavior only when it is truly unambiguous.
+  if (fleetSess.windows.length === 1) {
+    return { type: routeType, target: `${fleetSession}:${fleetSess.windows[0].index}` };
+  }
+
+  const candidateNames = fleetWindowCandidateNames(query);
+  const candidates = fleetSess.windows
+    .map((w) => `${fleetSession}:${w.index} (${w.name})`)
+    .join(", ");
+  return {
+    type: "error",
+    reason: "fleet_window_not_found",
+    detail: `'${query}' matched fleet session '${fleetSession}', but no window named ${candidateNames.map((n) => `'${n}'`).join(" or ")} was found; refusing to default to the first window`,
+    hint: `candidates: ${candidates}`,
+  };
+}
+
+function resolveSessionAliasWindowTarget(
+  query: string,
+  writable: Session[],
+  routeType: FleetRouteType,
+): FleetWindowResult | null {
+  // A full window name like `mawjs-oracle` should keep using findWindow's
+  // ambiguity guard. This helper is only for session/oracle aliases such as
+  // `mawjs` where findWindow would otherwise exact-match the session name and
+  // hand back windows[0].
+  if (/-oracle$/i.test(query.trim())) return null;
+
+  const wanted = new Set(sessionAliasNames(query).map((name) => name.toLowerCase()));
+  if (!wanted.size) return null;
+  const matches = writable.filter((s) =>
+    sessionAliasNames(s.name).some((name) => wanted.has(name.toLowerCase())),
+  );
+  if (!matches.length) return null;
+
+  if (matches.length > 1) {
+    return {
+      type: "error",
+      reason: "session_alias_ambiguous",
+      detail: `'${query}' matches multiple local sessions; refusing to guess a window`,
+      hint: `candidates: ${matches.map((s) => s.name).join(", ")}`,
+    };
+  }
+
+  const session = matches[0];
+  const namedTarget = findNamedFleetWindow(session, query);
+  if (namedTarget) return { type: routeType, target: namedTarget };
+
+  if (session.windows.length === 1) {
+    return { type: routeType, target: `${session.name}:${session.windows[0].index}` };
+  }
+
+  const candidateNames = fleetWindowCandidateNames(query);
+  const candidates = session.windows
+    .map((w) => `${session.name}:${w.index} (${w.name})`)
+    .join(", ");
+  return {
+    type: "error",
+    reason: "session_window_not_found",
+    detail: `'${query}' matched local session '${session.name}', but no window named ${candidateNames.map((n) => `'${n}'`).join(" or ")} was found; refusing to default to the first window`,
+    hint: `candidates: ${candidates}`,
+  };
+}
+
+function findNamedFleetWindow(session: Session, query: string): string | null {
+  for (const name of fleetWindowCandidateNames(query)) {
+    const win = session.windows.find((w) => w.name.toLowerCase() === name.toLowerCase());
+    if (win) return `${session.name}:${win.index}`;
+  }
+  return null;
+}
+
+function fleetWindowCandidateNames(query: string): string[] {
+  const raw = query.trim();
+  const stripped = raw.replace(/-oracle$/i, "");
+  const unnumbered = raw.replace(/^\d+-/, "");
+  const strippedUnnumbered = unnumbered.replace(/-oracle$/i, "");
+  return uniqueStrings([
+    raw,
+    stripped !== raw ? stripped : "",
+    unnumbered !== raw ? unnumbered : "",
+    strippedUnnumbered !== unnumbered ? strippedUnnumbered : "",
+    stripped ? `${stripped}-oracle` : "",
+    raw && !/-oracle$/i.test(raw) ? `${raw}-oracle` : "",
+    strippedUnnumbered ? `${strippedUnnumbered}-oracle` : "",
+  ].filter(Boolean));
+}
+
+function sessionAliasNames(name: string): string[] {
+  const raw = name.trim();
+  const unnumbered = raw.replace(/^\d+-/, "");
+  return uniqueStrings([
+    raw,
+    raw.replace(/-oracle$/i, ""),
+    unnumbered,
+    unnumbered.replace(/-oracle$/i, ""),
+  ].filter(Boolean));
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values)];
 }
 
 /**

--- a/test/isolated/routing-fleet-window.test.ts
+++ b/test/isolated/routing-fleet-window.test.ts
@@ -1,0 +1,130 @@
+/**
+ * routing-fleet-window.test.ts — #1565 regression.
+ *
+ * Fleet-known oracle aliases must not silently route to windows[0] in a
+ * multi-window tmux session. After a session reshuffle, windows[0] can be the
+ * sender/helper pane; `maw hey m5:mawjs` should prefer `mawjs-oracle` or fail
+ * loudly with candidates instead of looping back to the sender.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { join } from "path";
+import type { MawConfig } from "../../src/config";
+import type { Session } from "../../src/core/runtime/find-window";
+
+let fleetSessions: Record<string, string | null> = {};
+
+mock.module(join(import.meta.dir, "../../src/commands/shared/wake"), () => ({
+  resolveFleetSession: (oracle: string) => fleetSessions[oracle] ?? null,
+}));
+
+mock.module(join(import.meta.dir, "../../src/lib/oracle-manifest"), () => ({
+  loadManifestCached: () => [],
+}));
+
+const { resolveTarget } = await import("../../src/core/routing");
+
+const CONFIG: MawConfig = {
+  host: "local",
+  port: 3456,
+  ghqRoot: "/home/nat/Code/github.com",
+  oracleUrl: "http://localhost:47779",
+  env: {},
+  commands: { default: "claude" },
+  sessions: {},
+  node: "m5",
+  namedPeers: [],
+  agents: {},
+  peers: [],
+};
+
+const MULTI_WINDOW_MAWJS: Session[] = [
+  {
+    name: "54-mawjs",
+    windows: [
+      { index: 1, name: "mawjs-issuer", active: true },
+      { index: 2, name: "mawjs-oracle", active: false },
+      { index: 3, name: "mawjs-smoke", active: false },
+      { index: 4, name: "mawjs-codex-headless", active: false },
+    ],
+  },
+];
+
+describe("resolveTarget — fleet window routing (#1565)", () => {
+  beforeEach(() => {
+    fleetSessions = { mawjs: "54-mawjs" };
+  });
+
+  test("self-node fleet alias prefers <query>-oracle over windows[0]", () => {
+    const r = resolveTarget("m5:mawjs", CONFIG, MULTI_WINDOW_MAWJS);
+    expect(r).toEqual({ type: "self-node", target: "54-mawjs:2" });
+  });
+
+  test("bare fleet alias prefers <query>-oracle before generic session-first routing", () => {
+    const r = resolveTarget("mawjs", CONFIG, MULTI_WINDOW_MAWJS);
+    expect(r).toEqual({ type: "local", target: "54-mawjs:2" });
+  });
+
+  test("self-node session alias still prefers <query>-oracle when fleet config misses", () => {
+    fleetSessions = {};
+    const r = resolveTarget("m5:mawjs", CONFIG, MULTI_WINDOW_MAWJS);
+    expect(r).toEqual({ type: "self-node", target: "54-mawjs:2" });
+  });
+
+  test("bare session alias still prefers <query>-oracle when fleet config misses", () => {
+    fleetSessions = {};
+    const r = resolveTarget("mawjs", CONFIG, MULTI_WINDOW_MAWJS);
+    expect(r).toEqual({ type: "local", target: "54-mawjs:2" });
+  });
+
+  test("multi-window fleet alias without oracle window fails loud with candidates", () => {
+    const sessions: Session[] = [
+      {
+        name: "54-mawjs",
+        windows: [
+          { index: 1, name: "mawjs-issuer", active: true },
+          { index: 3, name: "mawjs-smoke", active: false },
+        ],
+      },
+    ];
+
+    const r = resolveTarget("m5:mawjs", CONFIG, sessions);
+
+    expect(r).toMatchObject({
+      type: "error",
+      reason: "fleet_window_not_found",
+    });
+    expect(r && "detail" in r ? r.detail : "").toContain("refusing to default to the first window");
+    expect(r && "hint" in r ? r.hint : "").toContain("54-mawjs:1 (mawjs-issuer)");
+    expect(r && "hint" in r ? r.hint : "").toContain("54-mawjs:3 (mawjs-smoke)");
+  });
+
+  test("multi-window session alias without oracle window fails loud when fleet config misses", () => {
+    fleetSessions = {};
+    const sessions: Session[] = [
+      {
+        name: "54-mawjs",
+        windows: [
+          { index: 1, name: "mawjs-issuer", active: true },
+          { index: 3, name: "mawjs-smoke", active: false },
+        ],
+      },
+    ];
+
+    const r = resolveTarget("m5:mawjs", CONFIG, sessions);
+
+    expect(r).toMatchObject({
+      type: "error",
+      reason: "session_window_not_found",
+    });
+    expect(r && "detail" in r ? r.detail : "").toContain("refusing to default to the first window");
+    expect(r && "hint" in r ? r.hint : "").toContain("54-mawjs:1 (mawjs-issuer)");
+  });
+
+  test("single-window fleet alias keeps unambiguous first-window fallback", () => {
+    const r = resolveTarget("m5:mawjs", CONFIG, [
+      { name: "54-mawjs", windows: [{ index: 7, name: "mawjs-issuer", active: true }] },
+    ]);
+
+    expect(r).toEqual({ type: "self-node", target: "54-mawjs:7" });
+  });
+});


### PR DESCRIPTION
## Summary
- Route fleet-known and self-node session aliases through explicit oracle window names before falling back.
- Prefer `<query>-oracle` for multi-window sessions so `maw hey m5:mawjs` targets `mawjs-oracle`, not `windows[0]`.
- Fail loud with candidate windows when a multi-window session has no matching oracle window; keep first-window fallback only for single-window sessions.

## Verification
- `bun test test/isolated/routing-fleet-window.test.ts test/routing.test.ts test/00-ssh.test.ts`
- `bun run build`
- `bun run test:all`
- Live resolver smoke on m5: `m5:mawjs` resolves to `54-mawjs:2` while live tmux has `54-mawjs:1 mawjs-issuer` and `54-mawjs:2 mawjs-oracle`.

Fixes #1565.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
