### PR TITLE
fix(ls): show stable window-name pane targets

### DIFF
--- a/src/commands/plugins/tmux/impl.ts
+++ b/src/commands/plugins/tmux/impl.ts
@@ -307,8 +307,10 @@ export async function cmdTmuxLs(opts: TmuxLsOpts = {}): Promise<void> {
     return;
   }
 
+  const targetWidth = Math.max(28, ...scope.map(p => p.target.length));
+
   console.log();
-  console.log(`  \x1b[36;1m  ${pad("TARGET", 28)} ${pad("CMD", 10)} ${pad("AGE", 6)} ${pad("ANNOTATION", 30)} TITLE\x1b[0m`);
+  console.log(`  \x1b[36;1m  ${pad("TARGET", targetWidth)} ${pad("CMD", 10)} ${pad("AGE", 6)} ${pad("ANNOTATION", 30)} TITLE\x1b[0m`);
   for (const p of scope) {
     const dot = STATUS_DOT[p.status];
     const age = formatAge(p.lastActivitySec);
@@ -319,7 +321,7 @@ export async function cmdTmuxLs(opts: TmuxLsOpts = {}): Promise<void> {
       : "";
     const annPad = pad(p.annotation, 30);
     const annRendered = annColored ? annColored + annPad.slice(p.annotation.length) : annPad;
-    console.log(`  ${dot} ${pad(p.target, 28)} ${pad(p.command || "", 10)} ${pad(age, 6)} ${annRendered} \x1b[90m${(p.title || "").slice(0, 50)}\x1b[0m`);
+    console.log(`  ${dot} ${pad(p.target, targetWidth)} ${pad(p.command || "", 10)} ${pad(age, 6)} ${annRendered} \x1b[90m${(p.title || "").slice(0, 50)}\x1b[0m`);
   }
   console.log();
 }

--- a/src/commands/shared/agents.ts
+++ b/src/commands/shared/agents.ts
@@ -33,12 +33,16 @@ export function buildAgentRows(
   const rows: AgentRow[] = [];
 
   for (const pane of panes) {
-    // target format from listPanes(): "session_name:window_index.pane_index"
-    const m = pane.target.match(/^(.+):(\d+)\.\d+$/);
+    // target format from listPanes(): "session_name:window_name.pane_index"
+    // Older callers/tests may still pass "session_name:window_index.pane_index";
+    // keep both so the command survives mixed alpha/dev surfaces.
+    const m = pane.target.match(/^(.+):(.+)\.\d+$/);
     if (!m) continue;
-    const [, session, winIdxStr] = m;
+    const [, session, winPart] = m;
 
-    const windowName = windowNames.get(`${session}:${winIdxStr}`) ?? "";
+    const windowName = /^\d+$/.test(winPart)
+      ? windowNames.get(`${session}:${winPart}`) ?? ""
+      : winPart;
     const isOracle = windowName.endsWith(ORACLE_SUFFIX);
 
     if (!opts.all && !isOracle) continue;

--- a/src/core/transport/tmux-class.ts
+++ b/src/core/transport/tmux-class.ts
@@ -165,7 +165,7 @@ export class Tmux {
   async listPanes(): Promise<TmuxPane[]> {
     try {
       const raw = await this.run("list-panes", "-a", "-F",
-        "#{pane_id}|||#{pane_current_command}|||#{session_name}:#{window_index}.#{pane_index}|||#{pane_title}|||#{pane_pid}|||#{pane_current_path}|||#{window_activity}");
+        "#{pane_id}|||#{pane_current_command}|||#{session_name}:#{window_name}.#{pane_index}|||#{pane_title}|||#{pane_pid}|||#{pane_current_path}|||#{window_activity}");
       return raw.split("\n").filter(Boolean).map(line => {
         const [id, command, target, title, pid, cwd, winAct] = line.split("|||");
         return { id, command, target, title, pid: pid ? Number(pid) : undefined, cwd: cwd || undefined, lastActivity: winAct ? Number(winAct) : undefined };

--- a/src/vendor/mpr-plugins/cleanup/internal/team-cleanup-zombies.ts
+++ b/src/vendor/mpr-plugins/cleanup/internal/team-cleanup-zombies.ts
@@ -141,8 +141,10 @@ export function findZombiePanes(allPanes: TmuxPane[]): ZombiePane[] {
   // guard prevents killing the operator's live oracle Claude. Team-spawned
   // agents always land in window 2+ or pane 1+, never window 1, pane 0.
   const isPrimaryOraclePane = (target: string): boolean => {
-    const m = /^[^:]+:(\d+)\.(\d+)$/.exec(target);
-    return m !== null && m[1] === "1" && m[2] === "0";
+    const indexed = /^[^:]+:(\d+)\.(\d+)$/.exec(target);
+    if (indexed) return indexed[1] === "1" && indexed[2] === "0";
+    const named = /^[^:]+:[^.]+-oracle\.(\d+)$/.exec(target);
+    return named !== null && named[1] === "0";
   };
 
   const isFleetPane = (target: string): boolean => {

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -9,7 +9,7 @@ function makeWindowNames(entries: Array<[string, string]>): Map<string, string> 
 
 describe("buildAgentRows — oracle detection", () => {
   test("oracle window is included and oracle name is extracted", () => {
-    const panes = [{ command: "claude", target: "01-mawjs:0.0", pid: 1234 }];
+    const panes = [{ command: "claude", target: "01-mawjs:mawjs-oracle.0", pid: 1234 }];
     const wn = makeWindowNames([["01-mawjs:0", "mawjs-oracle"]]);
     const rows = buildAgentRows(panes, wn, "oracle-world");
     expect(rows).toHaveLength(1);
@@ -20,15 +20,27 @@ describe("buildAgentRows — oracle detection", () => {
     expect(rows[0].pid).toBe(1234);
   });
 
+  test("legacy numeric pane target still resolves window name from listAll", () => {
+    const panes = [{ command: "claude", target: "01-mawjs:0.0", pid: 1234 }];
+    const wn = makeWindowNames([["01-mawjs:0", "mawjs-oracle"]]);
+    const rows = buildAgentRows(panes, wn, "oracle-world");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      session: "01-mawjs",
+      window: "mawjs-oracle",
+      oracle: "mawjs",
+    });
+  });
+
   test("non-oracle window is excluded by default", () => {
-    const panes = [{ command: "zsh", target: "01-mawjs:1.0", pid: 5678 }];
+    const panes = [{ command: "zsh", target: "01-mawjs:shell.0", pid: 5678 }];
     const wn = makeWindowNames([["01-mawjs:1", "shell"]]);
     const rows = buildAgentRows(panes, wn, "oracle-world");
     expect(rows).toHaveLength(0);
   });
 
   test("non-oracle window is included with --all", () => {
-    const panes = [{ command: "zsh", target: "01-mawjs:1.0", pid: 5678 }];
+    const panes = [{ command: "zsh", target: "01-mawjs:shell.0", pid: 5678 }];
     const wn = makeWindowNames([["01-mawjs:1", "shell"]]);
     const rows = buildAgentRows(panes, wn, "oracle-world", { all: true });
     expect(rows).toHaveLength(1);
@@ -39,14 +51,14 @@ describe("buildAgentRows — oracle detection", () => {
 
 describe("buildAgentRows — state detection", () => {
   test("shell command produces idle state", () => {
-    const panes = [{ command: "zsh", target: "02-neo:0.0", pid: 999 }];
+    const panes = [{ command: "zsh", target: "02-neo:neo-oracle.0", pid: 999 }];
     const wn = makeWindowNames([["02-neo:0", "neo-oracle"]]);
     const rows = buildAgentRows(panes, wn, "oracle-world");
     expect(rows[0].state).toBe("idle");
   });
 
   test("non-shell command produces active state", () => {
-    const panes = [{ command: "claude", target: "02-neo:0.0", pid: 888 }];
+    const panes = [{ command: "claude", target: "02-neo:neo-oracle.0", pid: 888 }];
     const wn = makeWindowNames([["02-neo:0", "neo-oracle"]]);
     const rows = buildAgentRows(panes, wn, "oracle-world");
     expect(rows[0].state).toBe("active");
@@ -54,9 +66,9 @@ describe("buildAgentRows — state detection", () => {
 
   test("multiple panes: mix of oracle and non-oracle, mix of states", () => {
     const panes = [
-      { command: "claude", target: "01-mawjs:0.0", pid: 100 },
-      { command: "zsh",    target: "02-neo:0.0",   pid: 200 },
-      { command: "bash",   target: "03-shell:0.0", pid: 300 }, // non-oracle
+      { command: "claude", target: "01-mawjs:mawjs-oracle.0", pid: 100 },
+      { command: "zsh",    target: "02-neo:neo-oracle.0",     pid: 200 },
+      { command: "bash",   target: "03-shell:shell.0",        pid: 300 }, // non-oracle
     ];
     const wn = makeWindowNames([
       ["01-mawjs:0", "mawjs-oracle"],

--- a/test/isolated/tmux.test.ts
+++ b/test/isolated/tmux.test.ts
@@ -167,6 +167,28 @@ describe("Tmux", () => {
 
   // --- Panes ---
 
+  describe("listPanes", () => {
+    test("uses stable window-name targets, not window indexes (#1567)", async () => {
+      sshResult = "%42|||claude|||54-mawjs:mawjs-oracle.0|||oracle title|||1234|||/tmp/maw|||1715840000";
+
+      const panes = await t.listPanes();
+
+      expect(commands[0]).toContain("#{session_name}:#{window_name}.#{pane_index}");
+      expect(commands[0]).not.toContain("#{session_name}:#{window_index}.#{pane_index}");
+      expect(panes).toEqual([
+        {
+          id: "%42",
+          command: "claude",
+          target: "54-mawjs:mawjs-oracle.0",
+          title: "oracle title",
+          pid: 1234,
+          cwd: "/tmp/maw",
+          lastActivity: 1715840000,
+        },
+      ]);
+    });
+  });
+
   describe("resizePane", () => {
     test("clamps values", async () => {
       await t.resizePane("s:0", 9999, -5);


### PR DESCRIPTION
## Summary
- Make `tmux.listPanes()` emit stable `session:window-name.pane` targets instead of fragile window indexes.
- Keep legacy numeric pane targets readable in agent-row parsing for mixed alpha/dev surfaces.
- Widen the `maw ls -v` TARGET column dynamically so name-based targets stay copy-pastable.
- Update cleanup's primary-oracle-pane guard for named `*-oracle.0` targets.

Fixes #1567.

## Verification
- `bun test test/isolated/tmux.test.ts test/agents.test.ts test/isolated/tmux-ls.test.ts`
- `bun run build`
- `bun run test:all` — 199 pass, 2 skip, 0 fail
- Live user-visible smoke: `bun src/cli.ts ls -v | rg '54-mawjs'` showed `54-mawjs:mawjs-issuer.0` and `54-mawjs:mawjs-oracle.0`.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
