### PR TITLE
fix(wake): make --list a readonly worktree preview

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -155,6 +155,7 @@ function printWakeAliasUsage(verb: "wake" | "awake", write: (line: string) => vo
   } else {
     write("  Wake or reuse an oracle session, fuzzy-resolving repos and worktrees as needed.");
   }
+  write("  --list previews worktrees only; it does not create sessions or respawn windows.");
 }
 
 /**

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -179,6 +179,20 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
     ? repoPath.slice(repoPath.indexOf("github.com/") + "github.com/".length)
     : repoName;
   console.log(`\x1b[36m→\x1b[0m found \x1b[1m${ghSlug}\x1b[0m (${repoPath})`);
+
+  // #1563 — `maw wake <oracle> --list` is a preview/read-only query.
+  // Keep it before detectSession/newSession/respawn so it never creates or
+  // rehydrates tmux windows just to show worktrees.
+  if (opts.listWt) {
+    const worktrees = await findWorktrees(parentDir, repoName);
+    if (!worktrees.length) { console.log(`\x1b[90mNo worktrees for ${oracle}.\x1b[0m`); }
+    else {
+      console.log(`\n\x1b[36mWorktrees for ${oracle}\x1b[0m (${worktrees.length})\n`);
+      for (const wt of worktrees) console.log(`  \x1b[32m●\x1b[0m ${wt.name}  \x1b[90m${wt.path}\x1b[0m`);
+    }
+    return `${oracle}:list`;
+  }
+
   let session = preResolvedSession ?? await detectSession(oracle, opts.urlRepoName);
   if (session) console.log(`\x1b[36m→\x1b[0m session exists: ${session}`);
   else console.log(`\x1b[36m→\x1b[0m no session found, creating...`);
@@ -300,16 +314,6 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
 
   let targetPath = repoPath;
   let windowName = `${oracle}-oracle`;
-
-  if (opts.listWt) {
-    const worktrees = await findWorktrees(parentDir, repoName);
-    if (!worktrees.length) { console.log(`\x1b[90mNo worktrees for ${oracle}.\x1b[0m`); }
-    else {
-      console.log(`\n\x1b[36mWorktrees for ${oracle}\x1b[0m (${worktrees.length})\n`);
-      for (const wt of worktrees) console.log(`  \x1b[32m●\x1b[0m ${wt.name}  \x1b[90m${wt.path}\x1b[0m`);
-    }
-    return `${session}:${windowName}`;
-  }
 
   if (opts.wt || opts.task) {
     const name = sanitizeBranchName(opts.wt || opts.task!);

--- a/src/vendor/mpr-plugins/wake/index.ts
+++ b/src/vendor/mpr-plugins/wake/index.ts
@@ -32,7 +32,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       if (!args[0]) {
         return {
           ok: false,
-          error: "usage: maw wake <oracle|org/repo|URL> [task] [--task \"<prompt>\"] [--wt <name>] [--fresh] [--attach] [--issue N] [--pr N] [--repo org/name] [--list] [--all-local] [--peer <alias>]\n       maw wake all [--kill]\n       (--new is a deprecated alias for --wt, removed in alpha.114)",
+          error: "usage: maw wake <oracle|org/repo|URL> [task] [--task \"<prompt>\"] [--wt <name>] [--fresh] [--attach] [--issue N] [--pr N] [--repo org/name] [--list] [--all-local] [--peer <alias>]\n       maw wake all [--kill]\n       --list previews worktrees only; no tmux session/window changes\n       (--new is a deprecated alias for --wt, removed in alpha.114)",
         };
       }
 

--- a/test/isolated/wake-list-readonly.test.ts
+++ b/test/isolated/wake-list-readonly.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const wakeCmdSrc = readFileSync(join(import.meta.dir, "../../src/commands/shared/wake-cmd.ts"), "utf8");
+
+describe("wake --list readonly preview (#1563)", () => {
+  test("handles listWt before tmux session detection or respawn side effects", () => {
+    const listIdx = wakeCmdSrc.indexOf("if (opts.listWt)");
+    const detectIdx = wakeCmdSrc.indexOf("let session = preResolvedSession");
+    const setEnvIdx = wakeCmdSrc.indexOf("await setSessionEnv(session)");
+    const newSessionIdx = wakeCmdSrc.indexOf("await tmux.newSession");
+    const newWindowIdx = wakeCmdSrc.indexOf("await tmux.newWindow(session");
+
+    expect(listIdx).toBeGreaterThan(-1);
+    expect(detectIdx).toBeGreaterThan(-1);
+    expect(listIdx).toBeLessThan(detectIdx);
+    expect(listIdx).toBeLessThan(setEnvIdx);
+    expect(listIdx).toBeLessThan(newSessionIdx);
+    expect(listIdx).toBeLessThan(newWindowIdx);
+    expect(wakeCmdSrc.indexOf("if (opts.listWt)", listIdx + 1)).toBe(-1);
+  });
+});


### PR DESCRIPTION
## Summary
- Move `maw wake <oracle> --list` ahead of session detection and rehydrate/spawn paths so it is truly read-only.
- Add a regression guard that keeps the list/preview path before tmux mutation paths.
- Update wake help text to state `--list` previews worktrees only and does not change tmux sessions/windows.

Addresses the `--list` side-effect/preview gap in #1563. Dry-run/main-only flags remain future follow-up scope.

## Verification
- `bun test test/isolated/wake-list-readonly.test.ts test/wake-flags.test.ts`
- `bun run build`
- Live smoke: captured `tmux list-windows -t 54-mawjs` before/after `bun src/cli.ts wake mawjs --list`; window set stayed `mawjs-issuer,mawjs-oracle`.

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
