### PR TITLE
feat(wake): preview or skip worktree rehydrate

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -148,7 +148,7 @@ function printBringUsage(write: (line: string) => void = console.log): void {
 }
 
 function printWakeAliasUsage(verb: "wake" | "awake", write: (line: string) => void = console.log): void {
-  write(`usage: maw ${verb} <oracle> [--task <s>] [--wt <s>] [-p|--prompt <s>] [--incubate <slug>] [--fresh] [-a|--attach] [--list] [--split] [--all-local] [-e|--engine <name>]`);
+  write(`usage: maw ${verb} <oracle> [--task <s>] [--wt <s>] [-p|--prompt <s>] [--incubate <slug>] [--fresh] [-a|--attach] [--list] [--dry-run] [--main|--solo|--no-rehydrate] [--split] [--all-local] [-e|--engine <name>]`);
   if (verb === "awake") {
     write("  Launch/start an oracle process with the selected engine. Does not send /awaken.");
     write("  Use `maw awaken` for the awakening ritual; use `maw new` for the creation door.");
@@ -222,6 +222,8 @@ export async function invokeDirectHandler(
       "--fresh": Boolean,
       "--attach": Boolean, "-a": "--attach",
       "--list": Boolean,
+      "--dry-run": Boolean,
+      "--main": Boolean, "--solo": "--main", "--no-rehydrate": "--main",
       "--split": Boolean,
       "--all-local": Boolean,
       "--engine": String, "-e": "--engine",
@@ -242,6 +244,8 @@ export async function invokeDirectHandler(
       fresh?: boolean;
       attach?: boolean;
       listWt?: boolean;
+      dryRun?: boolean;
+      noRehydrate?: boolean;
       split?: boolean;
       allLocal?: boolean;
       engine?: string;
@@ -253,6 +257,8 @@ export async function invokeDirectHandler(
     if (flags["--fresh"]) opts.fresh = true;
     if (flags["--attach"]) opts.attach = true;
     if (flags["--list"]) opts.listWt = true;
+    if (flags["--dry-run"]) opts.dryRun = true;
+    if (flags["--main"]) opts.noRehydrate = true;
     if (flags["--split"]) opts.split = true;
     if (flags["--all-local"]) opts.allLocal = true;
     if (flags["--engine"]) opts.engine = flags["--engine"];

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -110,7 +110,53 @@ export async function retryFreshSessionTmuxStep<T>(
   throw new Error(`unreachable: fresh tmux session setup step '${label}' exhausted without throwing`);
 }
 
-export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; split?: boolean; bring?: boolean; tab?: boolean; repoPath?: string; urlRepoName?: string; allLocal?: boolean; engine?: string }): Promise<string> {
+export type RehydrateWorktreePlan = {
+  worktreeName: string;
+  windowName: string;
+  path: string;
+};
+
+export function planRehydrateWorktreeWindows(
+  oracle: string,
+  worktrees: { name: string; path: string }[],
+  existingWindows: string[] = [],
+  liveTileRoles: Set<string> = new Set(),
+): RehydrateWorktreePlan[] {
+  const usedNames = new Set(existingWindows);
+  const planned: RehydrateWorktreePlan[] = [];
+  for (const wt of worktrees) {
+    const taskPart = wt.name.replace(/^\d+-/, "");
+    // #1445 — tile panes are split panes (role metadata), not windows.
+    // If the role is already alive in-session, skip respawn.
+    if (liveTileRoles.has(taskPart)) continue;
+    let wtWindowName = `${oracle}-${taskPart}`;
+    if (usedNames.has(wtWindowName)) {
+      if (existingWindows.includes(wtWindowName)) continue;
+      wtWindowName = `${oracle}-${wt.name}`;
+    }
+    const altName = `${oracle}-${wt.name}`;
+    if (existingWindows.includes(wtWindowName) || existingWindows.includes(altName)) continue;
+    usedNames.add(wtWindowName);
+    planned.push({ worktreeName: wt.name, windowName: wtWindowName, path: wt.path });
+  }
+  return planned;
+}
+
+async function chooseWakeSessionName(oracle: string, urlRepoName?: string): Promise<string> {
+  const baseName = getSessionMap()[oracle] || resolveFleetSession(oracle) || urlRepoName || oracle;
+  if (/^\d+-/.test(baseName)) return baseName;
+  // #994 — auto-assign NN- prefix to match fleet convention (01-maw-m5, 02-...).
+  // Scan existing sessions for numeric prefixes, pick max+1, zero-pad to 2 digits.
+  const sessions = await tmux.listSessions().catch(() => [] as { name: string }[]);
+  let maxNum = 0;
+  for (const s of sessions) {
+    const m = s.name.match(/^(\d+)-/);
+    if (m) maxNum = Math.max(maxNum, parseInt(m[1], 10));
+  }
+  return `${String(maxNum + 1).padStart(2, "0")}-${baseName}`;
+}
+
+export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; dryRun?: boolean; noRehydrate?: boolean; split?: boolean; bring?: boolean; tab?: boolean; repoPath?: string; urlRepoName?: string; allLocal?: boolean; engine?: string }): Promise<string> {
   // Canonicalize the bare name before any lookup — strips trailing `/`, `/.git`, `/.git/`
   // so `maw wake token-oracle/` (tab-completion artifact) resolves the same as `token-oracle`.
   oracle = normalizeTarget(oracle);
@@ -207,6 +253,41 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
     isLive: Boolean(session),
   });
 
+  const mainWindowName = `${oracle}-oracle`;
+
+  if (opts.dryRun) {
+    console.log(`\x1b[90mdry-run — no tmux sessions/windows will be changed\x1b[0m`);
+    if (!session && wakeDecision.wake) {
+      const plannedSession = await chooseWakeSessionName(oracle, opts.urlRepoName);
+      console.log(`\x1b[32m+\x1b[0m would create session '${plannedSession}' (main: ${mainWindowName})`);
+    } else if (session) {
+      console.log(`\x1b[36m→\x1b[0m would reuse session: ${session}`);
+    }
+
+    if (opts.task || opts.wt) {
+      console.log(`\x1b[33m⚡\x1b[0m would wake worktree/task: ${sanitizeBranchName(opts.wt || opts.task!)}`);
+      return session ? `${session}:${mainWindowName}` : `${oracle}:dry-run`;
+    }
+
+    if (opts.noRehydrate) {
+      console.log(`\x1b[90m↻ worktree rehydrate skipped (--main/--solo/--no-rehydrate)\x1b[0m`);
+      return session ? `${session}:${mainWindowName}` : `${oracle}:dry-run`;
+    }
+
+    const allWt = await findWorktrees(parentDir, repoName);
+    const existingWindows = session
+      ? (await tmux.listWindows(session).catch(() => [] as { name: string }[])).map(w => w.name)
+      : [];
+    const liveTileRoles = session ? await getLiveTileRoles(session) : new Set<string>();
+    const planned = planRehydrateWorktreeWindows(oracle, allWt, existingWindows, liveTileRoles);
+    if (planned.length === 0) {
+      console.log(`\x1b[90m↻ would respawn: none\x1b[0m`);
+    } else {
+      for (const wt of planned) console.log(`\x1b[32m↻\x1b[0m would respawn: ${wt.windowName}  \x1b[90m${wt.path}\x1b[0m`);
+    }
+    return session ? `${session}:${mainWindowName}` : `${oracle}:dry-run`;
+  }
+
   if (!session && wakeDecision.wake) {
     // #2 — refuse to spawn a brand-new session/agent once the fleet is at the
     // configured concurrency cap (no-op when limits.maxConcurrentAgents is 0).
@@ -215,24 +296,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
     // #769 — URL input names the new session after the full repo (e.g.
     // "m5-oracle") so it's distinct from any unrelated sub-token sessions
     // and immediately disambiguates future `maw wake` calls.
-    const baseName = getSessionMap()[oracle] || resolveFleetSession(oracle) || opts.urlRepoName || oracle;
-
-    // #994 — auto-assign NN- prefix to match fleet convention (01-maw-m5, 02-...).
-    // Scan existing sessions for numeric prefixes, pick max+1, zero-pad to 2 digits.
-    let session_: string;
-    if (/^\d+-/.test(baseName)) {
-      session_ = baseName;
-    } else {
-      const sessions = await tmux.listSessions().catch(() => [] as { name: string }[]);
-      let maxNum = 0;
-      for (const s of sessions) {
-        const m = s.name.match(/^(\d+)-/);
-        if (m) maxNum = Math.max(maxNum, parseInt(m[1], 10));
-      }
-      session_ = `${String(maxNum + 1).padStart(2, "0")}-${baseName}`;
-    }
-    session = session_;
-    const mainWindowName = `${oracle}-oracle`;
+    session = await chooseWakeSessionName(oracle, opts.urlRepoName);
     await tmux.newSession(session, { window: mainWindowName, cwd: repoPath });
     await waitForTmuxSessionReady(session);
     await retryFreshSessionTmuxStep(session, "set session environment", () => setSessionEnv(session));
@@ -258,18 +322,13 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
       console.log(`\x1b[32m+\x1b[0m team '${oracle}' auto-created`);
     }
 
-    if (!opts.task && !opts.wt) {
+    if (!opts.task && !opts.wt && !opts.noRehydrate) {
       const allWt = await findWorktrees(parentDir, repoName);
-      const usedNames = new Set<string>();
-      for (const wt of allWt) {
-        const taskPart = wt.name.replace(/^\d+-/, "");
-        let wtWindowName = `${oracle}-${taskPart}`;
-        if (usedNames.has(wtWindowName)) wtWindowName = `${oracle}-${wt.name}`;
-        usedNames.add(wtWindowName);
-        await tmux.newWindow(session, wtWindowName, { cwd: wt.path });
+      for (const wt of planRehydrateWorktreeWindows(oracle, allWt)) {
+        await tmux.newWindow(session, wt.windowName, { cwd: wt.path });
         await new Promise(r => setTimeout(r, 300));
-        await tmux.sendText(`${session}:${wtWindowName}`, buildCommandInDir(wtWindowName, wt.path, opts.engine));
-        console.log(`\x1b[32m+\x1b[0m window: ${wtWindowName}`);
+        await tmux.sendText(`${session}:${wt.windowName}`, buildCommandInDir(wt.windowName, wt.path, opts.engine));
+        console.log(`\x1b[32m+\x1b[0m window: ${wt.windowName}`);
       }
     }
   } else {
@@ -277,29 +336,16 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
     let preExistingWindows = new Set<string>();
     try { preExistingWindows = new Set((await tmux.listWindows(session)).map(w => w.name)); } catch { /* ok */ }
 
-    if (!opts.task && !opts.wt) {
+    if (!opts.task && !opts.wt && !opts.noRehydrate) {
       const allWt = await findWorktrees(parentDir, repoName);
       if (allWt.length > 0) {
         const existingWindows = [...preExistingWindows];
-        const usedNames = new Set(existingWindows);
         const liveTileRoles = await getLiveTileRoles(session);
-        for (const wt of allWt) {
-          const taskPart = wt.name.replace(/^\d+-/, "");
-          // #1445 — tile panes are split panes (role metadata), not windows.
-          // If the role is already alive in-session, skip respawn.
-          if (liveTileRoles.has(taskPart)) continue;
-          let wtWindowName = `${oracle}-${taskPart}`;
-          if (usedNames.has(wtWindowName)) {
-            if (existingWindows.includes(wtWindowName)) continue;
-            wtWindowName = `${oracle}-${wt.name}`;
-          }
-          const altName = `${oracle}-${wt.name}`;
-          if (existingWindows.includes(wtWindowName) || existingWindows.includes(altName)) continue;
-          usedNames.add(wtWindowName);
-          await tmux.newWindow(session, wtWindowName, { cwd: wt.path });
+        for (const wt of planRehydrateWorktreeWindows(oracle, allWt, existingWindows, liveTileRoles)) {
+          await tmux.newWindow(session, wt.windowName, { cwd: wt.path });
           await new Promise(r => setTimeout(r, 300));
-          await tmux.sendText(`${session}:${wtWindowName}`, buildCommandInDir(wtWindowName, wt.path, opts.engine));
-          console.log(`\x1b[32m↻\x1b[0m respawned: ${wtWindowName}`);
+          await tmux.sendText(`${session}:${wt.windowName}`, buildCommandInDir(wt.windowName, wt.path, opts.engine));
+          console.log(`\x1b[32m↻\x1b[0m respawned: ${wt.windowName}`);
         }
       }
     }
@@ -313,7 +359,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
   if (reordered > 0) console.log(`\x1b[36m↻ ${reordered} window(s) reordered to saved positions.\x1b[0m`);
 
   let targetPath = repoPath;
-  let windowName = `${oracle}-oracle`;
+  let windowName = mainWindowName;
 
   if (opts.wt || opts.task) {
     const name = sanitizeBranchName(opts.wt || opts.task!);

--- a/src/vendor/mpr-plugins/wake/index.ts
+++ b/src/vendor/mpr-plugins/wake/index.ts
@@ -32,7 +32,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       if (!args[0]) {
         return {
           ok: false,
-          error: "usage: maw wake <oracle|org/repo|URL> [task] [--task \"<prompt>\"] [--wt <name>] [--fresh] [--attach] [--issue N] [--pr N] [--repo org/name] [--list] [--all-local] [--peer <alias>]\n       maw wake all [--kill]\n       --list previews worktrees only; no tmux session/window changes\n       (--new is a deprecated alias for --wt, removed in alpha.114)",
+          error: "usage: maw wake <oracle|org/repo|URL> [task] [--task \"<prompt>\"] [--wt <name>] [--fresh] [--attach] [--issue N] [--pr N] [--repo org/name] [--list] [--dry-run] [--main|--solo|--no-rehydrate] [--all-local] [--peer <alias>]\n       maw wake all [--kill]\n       --list previews worktrees only; no tmux session/window changes\n       --dry-run previews session/worktree rehydrate actions; --main skips worktree rehydrate\n       (--new is a deprecated alias for --wt, removed in alpha.114)",
         };
       }
 
@@ -53,6 +53,8 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         "--fresh": Boolean, "--attach": Boolean, "-a": "--attach",
         "--no-attach": Boolean, // #823 Bug B — register so it doesn't fall through to positional → wakeOpts.task
         "--list": Boolean, "--ls": "--list",
+        "--dry-run": Boolean,
+        "--main": Boolean, "--solo": "--main", "--no-rehydrate": "--main",
         "--split": Boolean,
         "--all-local": Boolean,
         "--peer": String,
@@ -65,6 +67,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       const wakeOpts: {
         task?: string; wt?: string; prompt?: string;
         incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean;
+        dryRun?: boolean; noRehydrate?: boolean;
         split?: boolean; urlRepoName?: string; allLocal?: boolean;
       } = {};
       let issueNum: number | null = flags["--issue"] ?? null;
@@ -86,6 +89,8 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       if (flags["--attach"]) wakeOpts.attach = true;
       if (flags["--no-attach"]) wakeOpts.attach = false; // #823 Bug B — explicit opt-out; preserves default when neither flag is set
       if (flags["--list"]) wakeOpts.listWt = true;
+      if (flags["--dry-run"]) wakeOpts.dryRun = true;
+      if (flags["--main"]) wakeOpts.noRehydrate = true;
       if (flags["--split"]) wakeOpts.split = true;
       if (flags["--all-local"]) wakeOpts.allLocal = true;
 
@@ -118,7 +123,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
 
     const wakeOpts: {
       task?: string; prompt?: string; wt?: string;
-      fresh?: boolean; attach?: boolean;
+      fresh?: boolean; attach?: boolean; dryRun?: boolean; noRehydrate?: boolean;
     } = {};
     if (body.task) wakeOpts.task = body.task as string;
     if (body.wt) wakeOpts.wt = body.wt as string;
@@ -134,6 +139,8 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     }
     if (body.fresh) wakeOpts.fresh = true;
     if (body.attach) wakeOpts.attach = true;
+    if (body.dryRun) wakeOpts.dryRun = true;
+    if (body.noRehydrate || body.main || body.solo) wakeOpts.noRehydrate = true;
 
     await cmdWake(oracle, wakeOpts);
     return { ok: true, output: logs.join("\n") || undefined };

--- a/test/isolated/wake-rehydrate-plan.test.ts
+++ b/test/isolated/wake-rehydrate-plan.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { planRehydrateWorktreeWindows } from "../../src/commands/shared/wake-cmd";
+
+describe("planRehydrateWorktreeWindows (#1563)", () => {
+  const worktrees = [
+    { name: "1-alpha", path: "/repo.wt-1-alpha" },
+    { name: "2-alpha", path: "/repo.wt-2-alpha" },
+    { name: "3-beta", path: "/repo.wt-3-beta" },
+  ];
+
+  test("plans stable de-numbered window names and numbered fallback for true collisions", () => {
+    const planned = planRehydrateWorktreeWindows("mawjs", worktrees);
+    expect(planned.map(p => p.windowName)).toEqual(["mawjs-alpha", "mawjs-2-alpha", "mawjs-beta"]);
+  });
+
+  test("skips existing windows and live tile roles before respawn", () => {
+    const planned = planRehydrateWorktreeWindows(
+      "mawjs",
+      worktrees,
+      ["mawjs-alpha"],
+      new Set(["beta"]),
+    );
+    expect(planned.map(p => p.windowName)).toEqual([]);
+  });
+});

--- a/test/wake-flags.test.ts
+++ b/test/wake-flags.test.ts
@@ -19,6 +19,8 @@ interface WakeOpts {
   fresh?: boolean;
   noAttach?: boolean;
   listWt?: boolean;
+  dryRun?: boolean;
+  noRehydrate?: boolean;
 }
 
 function buildWakeOpts(args: string[]): { opts: WakeOpts; repo: string | undefined } {
@@ -34,6 +36,10 @@ function buildWakeOpts(args: string[]): { opts: WakeOpts; repo: string | undefin
     "--no-attach": Boolean,
     "--list": Boolean,
     "--ls": "--list",
+    "--dry-run": Boolean,
+    "--main": Boolean,
+    "--solo": "--main",
+    "--no-rehydrate": "--main",
   }, 2);
 
   const opts: WakeOpts = {};
@@ -44,6 +50,8 @@ function buildWakeOpts(args: string[]): { opts: WakeOpts; repo: string | undefin
   if (flags["--fresh"]) opts.fresh = true;
   if (flags["--no-attach"]) opts.noAttach = true;
   if (flags["--list"]) opts.listWt = true;
+  if (flags["--dry-run"]) opts.dryRun = true;
+  if (flags["--main"]) opts.noRehydrate = true;
   if (flags["--task"]) opts.noAttach = true;
 
   const positionals = flags._;
@@ -129,6 +137,19 @@ describe("--task flag (fire-and-forget)", () => {
     expect(opts.prompt).toBe("__FETCHED_ISSUE_99__");
     // --task still implies fire-and-forget
     expect(opts.noAttach).toBe(true);
+  });
+});
+
+describe("wake preview/control flags (#1563)", () => {
+  test("--dry-run is forwarded to cmdWake options", () => {
+    const { opts } = buildWakeOpts(["wake", "neo", "--dry-run"]);
+    expect(opts.dryRun).toBe(true);
+  });
+
+  test("--main / --solo / --no-rehydrate all disable worktree rehydrate", () => {
+    expect(buildWakeOpts(["wake", "neo", "--main"]).opts.noRehydrate).toBe(true);
+    expect(buildWakeOpts(["wake", "neo", "--solo"]).opts.noRehydrate).toBe(true);
+    expect(buildWakeOpts(["wake", "neo", "--no-rehydrate"]).opts.noRehydrate).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add `maw wake --dry-run` to preview session/worktree rehydrate actions without changing tmux state.
- Add explicit main-only aliases: `--main`, `--solo`, and `--no-rehydrate` to wake/reuse only the main oracle window and skip dormant worktree respawn.
- Share the worktree rehydrate planning logic between real execution and dry-run preview so preview matches what wake would do.
- Update wake help/dispatch surfaces for top-level and plugin paths.

Completes the remaining preview/control pieces from #1563 without flipping the default bare-wake behavior.

## Verification
- `bun test test/isolated/wake-rehydrate-plan.test.ts test/wake-flags.test.ts test/isolated/wake-list-readonly.test.ts`
- `bun run build`
- Live smoke on m5: `bun src/cli.ts wake mawjs --dry-run` and `bun src/cli.ts wake mawjs --main` both exited 0 and left `tmux list-windows -t 54-mawjs` unchanged (`mawjs-issuer,mawjs-oracle`).

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
