### PR TITLE
fix(hey): make local oracle names and ls targets pasteable

### DIFF
--- a/src/cli/route-comm.ts
+++ b/src/cli/route-comm.ts
@@ -3,11 +3,14 @@ import { UserError } from "../core/util/user-error";
 
 function printCommUsage(cmd: "hey" | "send", write: (line: string) => void = console.log): void {
   write(`usage: maw ${cmd} <target> <message> [--force] [--approve] [--trust]`);
-  write("  target forms (#759 Phase 2 — bare names removed):");
-  write("    local:<agent>                this node");
+  write("  target forms:");
+  write("    <oracle-window>              same-node window name (local-only)");
+  write("    local:<agent>                explicit same-node target");
+  write("    <session>:<window>[.<pane>]  paste a TARGET from maw ls -v");
   write("    <node>:<session>             canonical cross-node form (window 1)");
   write("    <node>:<session>:<window>    target a specific tmux window (#410)");
-  write(`  e.g. maw ${cmd} local:mawjs "hello from neo"`);
+  write(`  e.g. maw ${cmd} mawjs-oracle "hello from neo"`);
+  write(`       maw ${cmd} local:mawjs "hello from neo"`);
   write(`       maw ${cmd} phaith:01-hojo:3 "hello hojo-hermes"`);
   write("       run `maw locate <agent>` to enumerate across federation");
 }

--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -7,6 +7,7 @@ import {
   curlFetch, runHook,
 } from "../../sdk";
 import { Tmux } from "../../core/transport/tmux";
+import { AmbiguousMatchError } from "../../core/runtime/find-window";
 import { loadConfig, cfgLimit } from "../../config";
 import { logMessage, emitFeed } from "./comm-log-feed";
 
@@ -121,16 +122,11 @@ export async function checkPaneIdle(target: string, host?: string): Promise<{ id
 }
 
 /**
- * Phase 2 of #759 — bare-name hard rejection. The bare-name path is removed
- * outright: cmdSend prints this error to stderr and exits non-zero before
- * any resolution attempt. Replaces the Phase 1 `formatBareNameDeprecation`
- * warning. Shape is fixed per the issue and exercised by
- * test/isolated/hey-bare-name-rejection.test.ts.
+ * #1572 — bare oracle names are allowed only as a same-node convenience.
  *
- * The triple `<node>:<session>:<agent>` form keeps `<node>` and `<session>`
- * as literal placeholders — the user is meant to run `maw locate <agent>`
- * to enumerate concrete candidates across the federation. Only `<agent>`
- * is substituted with the bare query the user actually typed.
+ * `maw hey <oracle-window> "..."` now resolves locally first. If there is no
+ * local window match, we still refuse to fall through to peer discovery or the
+ * agents map: cross-node delivery must keep an explicit `<node>:` prefix.
  *
  * @internal — exported for tests only (test/comm-send-deprecation-759.test.ts).
  *   The production caller is `cmdSend` in this same file. No other module
@@ -142,16 +138,83 @@ export function formatBareNameError(query: string): string {
   const D = "\x1b[90m";   // dim — for explanatory tail
   const R = "\x1b[0m";
   return [
-    `${RED}error${R}: bare-name target removed — node prefix required`,
+    `${RED}error${R}: bare target '${query}' not found locally`,
     ``,
-    `  this node:`,
+    `  same-node targets:`,
     `    ${C}maw hey local:${query} "..."${R}`,
+    `    ${D}or copy a TARGET from \`maw ls -v\`${R}`,
     ``,
-    `  cross-node candidates:`,
-    `    ${C}maw hey <node>:<session>:${query} "..."${R}`,
+    `  cross-node targets:`,
+    `    ${C}maw hey <node>:${query} "..."${R}`,
+    `    ${C}maw hey <node>:<session>:<window> "..."${R}`,
     ``,
-    `  ${D}run \`maw locate ${query}\` to enumerate across federation${R}`,
+    `  ${D}bare names are local-only; run \`maw locate ${query}\` to enumerate federation candidates${R}`,
   ].join("\n");
+}
+
+/** @internal exported for tests only. */
+export function formatBareNameAmbiguousError(query: string, candidates: string[]): string {
+  const RED = "\x1b[31m";
+  const C = "\x1b[36m";
+  const R = "\x1b[0m";
+  return [
+    `${RED}error${R}: bare target '${query}' is ambiguous — matches ${candidates.length} local windows:`,
+    ...candidates.map((candidate) => `  ${C}${candidate}${R}`),
+    ``,
+    `Use one full TARGET from \`maw ls -v\`, for example:`,
+    `  ${C}maw hey ${candidates[0] ?? `local:${query}`} "..."${R}`,
+  ].join("\n");
+}
+
+function isBareLocalHeyTarget(query: string): boolean {
+  return query.length > 0 && !query.includes(":") && !query.includes("/");
+}
+
+function formatAmbiguousCandidates(query: string, candidates: string[]): string[] {
+  if (candidates.length) return candidates;
+  return [query];
+}
+
+function rejectBareMiss(query: string): never {
+  console.error(formatBareNameError(query));
+  process.exit(1);
+}
+
+function rejectBareAmbiguous(query: string, candidates: string[]): never {
+  console.error(formatBareNameAmbiguousError(query, formatAmbiguousCandidates(query, candidates)));
+  process.exit(1);
+}
+
+function normalizeBareLocalResult(
+  query: string,
+  result: ReturnType<typeof resolveTarget>,
+): ReturnType<typeof resolveTarget> | null {
+  if (!result) return null;
+  if (result.type === "local" || result.type === "self-node") return result;
+  // A bare query may discover a remote peer via config.agents/manifest. Do not
+  // use that implicit remote route: #1572 makes bare names local-only so
+  // operators must spell cross-node delivery with `<node>:`.
+  return null;
+}
+
+function assertBareLocalTarget(
+  query: string,
+  config: ReturnType<typeof loadConfig>,
+  sessions: Awaited<ReturnType<typeof listSessions>>,
+): ReturnType<typeof resolveTarget> | null {
+  if (!isBareLocalHeyTarget(query)) return null;
+
+  try {
+    const localResult = normalizeBareLocalResult(query, resolveTarget(query, config, sessions));
+    if (localResult) return localResult;
+  } catch (e) {
+    if (e instanceof AmbiguousMatchError) {
+      rejectBareAmbiguous(query, e.candidates);
+    }
+    throw e;
+  }
+
+  rejectBareMiss(query);
 }
 
 /**
@@ -178,17 +241,6 @@ export async function cmdSend(
   opts: CmdSendOptions = {},
 ) {
   const config = loadConfig();
-
-  // #759 Phase 2 — bare-name targets are now a hard error. Reject before any
-  // resolution work so users get a fast, deterministic failure pushing them
-  // onto the canonical `<node>:<agent>` form. `team:` and `plugin:` prefixes
-  // are special-cased downstream and have their own colon, so they pass.
-  // `/` is reserved for path-style targets. MAW_QUIET no longer suppresses —
-  // Phase 1's quiet-opt-out was a deprecation-window concession only.
-  if (!query.includes(":") && !query.includes("/")) {
-    console.error(formatBareNameError(query));
-    process.exit(1);
-  }
 
   // --- Team fan-out routing: maw hey team:<team-name> <msg> (#627) ---
   if (query.startsWith("team:")) {
@@ -256,6 +308,7 @@ export async function cmdSend(
   }
 
   let sessions = await listSessions();
+  const bareLocalResult = assertBareLocalTarget(query, config, sessions);
 
   // --- #736 Phase 1.2 + #791: auto-wake fleet-known targets (parity with maw view) ---
   // Mirrors view/impl.ts:107 — if the user's hey target is fleet-known but
@@ -350,7 +403,7 @@ export async function cmdSend(
   }
 
   // --- Unified resolution via resolveTarget (#201) ---
-  const result = resolveTarget(query, config, sessions);
+  const result = bareLocalResult ?? resolveTarget(query, config, sessions);
 
   // --- #842 Sub-C — cross-oracle ACL gate (Phase 2 of #642) ---
   //

--- a/src/core/runtime/find-window.ts
+++ b/src/core/runtime/find-window.ts
@@ -64,7 +64,10 @@ export function findWindow(sessions: Session[], query: string): string | null {
   // session:window syntax — strict session match to prevent node:agent collision (#186)
   // "white:mawjs" must NOT match "105-whitekeeper" via substring
   if (query.includes(":")) {
-    const [sessPart, winPart] = q.split(":", 2);
+    const [sessPart, rawWinPart = ""] = q.split(":", 2);
+    const paneMatch = rawWinPart.match(/^(.+)\.(\d+)$/);
+    const winPart = paneMatch ? paneMatch[1] : rawWinPart;
+    const paneSuffix = paneMatch ? `.${paneMatch[2]}` : "";
     const sess = matchSession(sessions, sessPart, true);
     if (sess) {
       // Empty window part → return session's first window
@@ -72,7 +75,7 @@ export function findWindow(sessions: Session[], query: string): string | null {
         if (sess.windows.length > 0) return `${sess.name}:${sess.windows[0].index}`;
       } else {
         for (const w of sess.windows) {
-          if (w.name.toLowerCase().includes(winPart)) return `${sess.name}:${w.index}`;
+          if (w.name.toLowerCase().includes(winPart)) return `${sess.name}:${w.index}${paneSuffix}`;
         }
       }
     }

--- a/test/00-ssh.test.ts
+++ b/test/00-ssh.test.ts
@@ -142,6 +142,11 @@ describe("findWindow", () => {
         .toBe("08-mawjs:1");
     });
 
+    test("full session name + window name + pane suffix", () => {
+      expect(findWindow(MAW_SESSIONS, "08-mawjs:mawjs-oracle.0"))
+        .toBe("08-mawjs:1.0");
+    });
+
     test("oracle short name resolves to NN-prefixed session, not substring collision", () => {
       // 'mawjs' must NOT route to 'mawjs-view' — it should hit '08-mawjs'
       // because 'mawjs' is the oracle-name match (08-mawjs strip → mawjs).

--- a/test/comm-send-deprecation-759.test.ts
+++ b/test/comm-send-deprecation-759.test.ts
@@ -1,38 +1,32 @@
 /**
- * #759 Phase 2 — bare-name hard rejection error formatter.
+ * #1572 — bare-name local-only error formatter.
  *
- * The Phase 1 deprecation warning has been converted into a hard error. The
- * formatter is tested directly (pure function). The cmdSend wiring (early
- * exit, gating on `!query.includes(":")`) is covered by the isolated test
- * `test/isolated/hey-bare-name-rejection.test.ts`.
- *
- * History: this file used to assert `formatBareNameDeprecation` — Phase 2
- * renamed the export to `formatBareNameError` and changed the shape from
- * yellow `⚠ deprecation` to red `error:`. See issue #759.
+ * Bare names are accepted only when they resolve to a local tmux window.
+ * Misses stay local-only and must not silently fall through to remote peer
+ * routing.
  */
 import { describe, test, expect } from "bun:test";
-import { formatBareNameError } from "../src/commands/shared/comm-send";
+import { formatBareNameAmbiguousError, formatBareNameError } from "../src/commands/shared/comm-send";
 
-describe("#759 Phase 2 — bare-name hard rejection", () => {
-  test("error marker, removal phrase, and node-prefix demand are all present", () => {
+describe("#1572 — bare-name local-only errors", () => {
+  test("error marker, local miss, and cross-node demand are all present", () => {
     const out = formatBareNameError("mawjs-oracle");
     expect(out).toContain("error");
-    expect(out).toContain("bare-name target removed");
-    expect(out).toContain("node prefix required");
+    expect(out).toContain("not found locally");
+    expect(out).toContain("bare names are local-only");
   });
 
   test("shows local: form with the user's bare query substituted", () => {
     const out = formatBareNameError("mawjs-oracle");
-    expect(out).toContain("this node:");
+    expect(out).toContain("same-node targets:");
     expect(out).toContain("maw hey local:mawjs-oracle");
   });
 
-  test("shows cross-node placeholder form with <node>:<session>: literal", () => {
+  test("shows explicit cross-node placeholder forms", () => {
     const out = formatBareNameError("mawjs-oracle");
-    expect(out).toContain("cross-node candidates:");
-    // <node> and <session> stay as literal placeholders — the user runs
-    // `maw locate` to enumerate concrete candidates. Only <agent> substitutes.
-    expect(out).toContain("maw hey <node>:<session>:mawjs-oracle");
+    expect(out).toContain("cross-node targets:");
+    expect(out).toContain("maw hey <node>:mawjs-oracle");
+    expect(out).toContain("maw hey <node>:<session>:<window>");
   });
 
   test("references `maw locate <agent>` for federation enumeration", () => {
@@ -53,11 +47,22 @@ describe("#759 Phase 2 — bare-name hard rejection", () => {
     const stripped = out.replace(/\x1b\[[0-9;]*m/g, "");
     const lines = stripped.split("\n");
     // First line is the error header
-    expect(lines[0]).toBe("error: bare-name target removed — node prefix required");
-    expect(lines.some(l => l.trim() === "this node:")).toBe(true);
+    expect(lines[0]).toBe("error: bare target 'mawjs-oracle' not found locally");
+    expect(lines.some(l => l.trim() === "same-node targets:")).toBe(true);
     expect(lines.some(l => l.trim().startsWith("maw hey local:mawjs-oracle"))).toBe(true);
-    expect(lines.some(l => l.trim() === "cross-node candidates:")).toBe(true);
-    expect(lines.some(l => l.trim().startsWith("maw hey <node>:<session>:mawjs-oracle"))).toBe(true);
+    expect(lines.some(l => l.trim() === "cross-node targets:")).toBe(true);
+    expect(lines.some(l => l.trim().startsWith("maw hey <node>:mawjs-oracle"))).toBe(true);
     expect(lines.some(l => l.includes("maw locate mawjs-oracle"))).toBe(true);
+  });
+
+  test("ambiguous formatter lists local candidates", () => {
+    const out = formatBareNameAmbiguousError("mawjs-oracle", [
+      "47-mawjs:mawjs-oracle",
+      "54-mawjs:mawjs-oracle",
+    ]).replace(/\x1b\[[0-9;]*m/g, "");
+    expect(out).toContain("ambiguous");
+    expect(out).toContain("matches 2 local windows");
+    expect(out).toContain("47-mawjs:mawjs-oracle");
+    expect(out).toContain("maw hey 47-mawjs:mawjs-oracle");
   });
 });

--- a/test/isolated/comm-list.test.ts
+++ b/test/isolated/comm-list.test.ts
@@ -797,14 +797,11 @@ describe("resolveOraclePane", () => {
 // comm-send.ts — cmdSend (bare-name tip, local, peer, plugin, error paths)
 // ════════════════════════════════════════════════════════════════════════════
 
-describe("cmdSend — bare-name rejection (#362b → #759 Phase 2)", () => {
-  // History: Phase 1 emitted a deprecation warning on bare-name targets but
-  // still resolved them. Phase 2 (#759) removes the bare-name path entirely
-  // — cmdSend now exits non-zero with a hard error before any resolution.
-  // The Phase 1 warning + MAW_QUIET escape hatch are gone. Coverage of the
-  // new error-shape lives in test/isolated/hey-bare-name-rejection.test.ts.
+describe("cmdSend — bare-name local-only routing (#1572)", () => {
+  // Bare names are a same-node convenience only. A local resolver hit is
+  // allowed, but a miss must not fall through to implicit peer routing.
 
-  test("bare name → hard error + exit 1, no deprecation phrasing", async () => {
+  test("bare name miss → local-only error + exit 1, no deprecation phrasing", async () => {
     configOverride = { node: "white" };
     resolveTargetReturn = { type: "error", reason: "not_found", detail: "…" };
 
@@ -812,9 +809,8 @@ describe("cmdSend — bare-name rejection (#362b → #759 Phase 2)", () => {
 
     expect(exitCode).toBe(1);
     const joined = errs.join("\n");
-    // New Phase 2 shape — no longer the yellow ⚠ deprecation
-    expect(joined).toContain("bare-name target removed");
-    expect(joined).toContain("node prefix required");
+    expect(joined).toContain("not found locally");
+    expect(joined).toContain("bare names are local-only");
     expect(joined).not.toContain("deprecation");
   });
 
@@ -824,11 +820,11 @@ describe("cmdSend — bare-name rejection (#362b → #759 Phase 2)", () => {
 
     await run(() => cmdSend("white:mawjs", "hi"));
 
-    // Bare-name guard does not fire on prefixed queries
-    expect(errs.some((e) => e.includes("bare-name target removed"))).toBe(false);
+    // Bare-name local-only guard does not fire on prefixed queries
+    expect(errs.some((e) => e.includes("not found locally"))).toBe(false);
   });
 
-  test("MAW_QUIET=1 does NOT bypass the rejection — Phase 1 escape hatch is gone", async () => {
+  test("MAW_QUIET=1 does NOT bypass local-only miss — Phase 1 escape hatch is gone", async () => {
     process.env.MAW_QUIET = "1";
     configOverride = { node: "white" };
     resolveTargetReturn = { type: "error", reason: "not_found", detail: "…" };
@@ -836,7 +832,7 @@ describe("cmdSend — bare-name rejection (#362b → #759 Phase 2)", () => {
     await run(() => cmdSend("mawjs", "hi"));
 
     expect(exitCode).toBe(1);
-    expect(errs.join("\n")).toContain("bare-name target removed");
+    expect(errs.join("\n")).toContain("not found locally");
   });
 });
 

--- a/test/isolated/hey-bare-name-rejection.test.ts
+++ b/test/isolated/hey-bare-name-rejection.test.ts
@@ -1,10 +1,9 @@
 /**
- * hey-bare-name-rejection.test.ts — #759 Phase 2.
+ * hey-bare-name-rejection.test.ts — #1572.
  *
- * Verifies that `maw hey <bare-name> "..."` is now a hard error: cmdSend
- * MUST print the Phase 2 error shape on stderr and exit non-zero BEFORE
- * any tmux / sdk / network resolution work happens. No fallthrough, no
- * MAW_QUIET escape hatch.
+ * Verifies that `maw hey <bare-name> "..."` is local-first: cmdSend accepts a
+ * bare name only when the shared resolver finds a local tmux target. Misses do
+ * not fall through to peer routing; cross-node delivery still needs `<node>:`.
  *
  * Mocked seams: src/sdk, src/config, src/core/routing,
  *   src/core/runtime/hooks, src/commands/shared/comm-log-feed,
@@ -30,6 +29,8 @@ let sendKeysCalls: Array<{ target: string; text: string }> = [];
 let resolveTargetCalls = 0;
 let listSessionsCalls = 0;
 let cmdWakeCalls = 0;
+let resolveTargetReturn: unknown = { type: "error", reason: "not_found", detail: "…" };
+let listSessionsReturn: Array<{ name: string; windows: Array<{ index: number; name: string; active: boolean }> }> = [];
 
 // ─── Mocks ───────────────────────────────────────────────────────────────────
 
@@ -44,9 +45,13 @@ mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
   listSessions: async () => {
     if (!mockActive) return [];
     listSessionsCalls++;
-    return [];
+    return listSessionsReturn;
   },
   findPeerForTarget: async () => null,
+  resolveTarget: () => {
+    resolveTargetCalls++;
+    return resolveTargetReturn;
+  },
   curlFetch: async () => ({ ok: false, status: 500, data: {} }),
   runHook: async () => {},
   hostExec: async () => "",
@@ -56,13 +61,6 @@ mock.module(join(import.meta.dir, "../../src/config"), () => {
   const { mockConfigModule } = require("../helpers/mock-config");
   return mockConfigModule(() => ({ node: "test-node", port: 3456 }));
 });
-
-mock.module(join(import.meta.dir, "../../src/core/routing"), () => ({
-  resolveTarget: () => {
-    resolveTargetCalls++;
-    return { type: "local", target: "x:y.0" };
-  },
-}));
 
 mock.module(join(import.meta.dir, "../../src/core/runtime/hooks"), () => ({
   runHook: async () => {},
@@ -125,6 +123,8 @@ beforeEach(() => {
   resolveTargetCalls = 0;
   listSessionsCalls = 0;
   cmdWakeCalls = 0;
+  resolveTargetReturn = { type: "error", reason: "not_found", detail: "…" };
+  listSessionsReturn = [];
   delete process.env.MAW_QUIET;
 });
 
@@ -136,67 +136,79 @@ afterAll(() => {
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
-describe("cmdSend — bare-name hard rejection (#759 Phase 2)", () => {
-  test("bare name 'mawjs-oracle' → exits 1, prints Phase 2 error, no resolution work", async () => {
+describe("cmdSend — bare-name local-first (#1572)", () => {
+  test("bare name 'mawjs-oracle' → local resolver hit sends to same-node target", async () => {
+    listSessionsReturn = [
+      { name: "47-mawjs", windows: [{ index: 0, name: "mawjs-oracle", active: true }] },
+    ];
+    resolveTargetReturn = { type: "local", target: "47-mawjs:0" };
+
+    await run(() => cmdSend("mawjs-oracle", "test"));
+
+    expect(exitCode).toBeUndefined();
+    expect(resolveTargetCalls).toBeGreaterThanOrEqual(1);
+    expect(listSessionsCalls).toBeGreaterThanOrEqual(1);
+    expect(sendKeysCalls.length).toBe(1);
+    expect(sendKeysCalls[0].target).toBe("47-mawjs:0");
+  });
+
+  test("bare name 'mawjs-oracle' with no local hit → exits 1, prints local-only error, no send", async () => {
+    resolveTargetReturn = { type: "peer", peerUrl: "http://remote", target: "mawjs-oracle", node: "mba" };
     await run(() => cmdSend("mawjs-oracle", "test"));
 
     expect(exitCode).toBe(1);
     const allErr = errs.join("\n");
-    // Error header
     expect(allErr).toContain("error");
-    expect(allErr).toContain("bare-name target removed");
-    expect(allErr).toContain("node prefix required");
-    // this-node form with substituted agent
-    expect(allErr).toContain("this node:");
+    expect(allErr).toContain("not found locally");
+    expect(allErr).toContain("bare names are local-only");
+    expect(allErr).toContain("same-node targets:");
     expect(allErr).toContain("maw hey local:mawjs-oracle");
-    // cross-node placeholder form
-    expect(allErr).toContain("cross-node candidates:");
-    expect(allErr).toContain("maw hey <node>:<session>:mawjs-oracle");
-    // locate hint
+    expect(allErr).toContain("cross-node targets:");
+    expect(allErr).toContain("maw hey <node>:mawjs-oracle");
     expect(allErr).toContain("maw locate mawjs-oracle");
-    // No downstream work happened
-    expect(resolveTargetCalls).toBe(0);
-    expect(listSessionsCalls).toBe(0);
+    // Local resolution happened, but remote/fallback delivery did not.
+    expect(resolveTargetCalls).toBe(1);
+    expect(listSessionsCalls).toBe(1);
     expect(cmdWakeCalls).toBe(0);
     expect(sendKeysCalls.length).toBe(0);
   });
 
-  test("MAW_QUIET=1 does NOT bypass the rejection — Phase 1 escape hatch is gone", async () => {
+  test("MAW_QUIET=1 does NOT bypass the local-only miss", async () => {
     process.env.MAW_QUIET = "1";
     await run(() => cmdSend("mawjs-oracle", "test"));
     expect(exitCode).toBe(1);
-    expect(errs.join("\n")).toContain("bare-name target removed");
+    expect(errs.join("\n")).toContain("not found locally");
     expect(sendKeysCalls.length).toBe(0);
   });
 
   test("node-prefixed target 'test-node:foo' passes — no rejection", async () => {
     await run(() => cmdSend("test-node:foo", "hi"));
     // Either resolved as local/self-node and sent, or hit a downstream branch —
-    // the key invariant is we did NOT exit on the bare-name guard.
+    // the key invariant is we did NOT exit on the bare-name local-only guard.
     const allErr = errs.join("\n");
-    expect(allErr).not.toContain("bare-name target removed");
+    expect(allErr).not.toContain("not found locally");
     // Resolution was attempted
     expect(resolveTargetCalls).toBeGreaterThanOrEqual(1);
   });
 
   test("team:<name> prefix passes the bare-name guard", async () => {
     // team: routing has its own validation downstream; we only assert the
-    // bare-name guard didn't fire.
+    // bare-name local-only guard didn't fire.
     await run(() => cmdSend("team:nonexistent-team", "hi"));
     const allErr = errs.join("\n");
-    expect(allErr).not.toContain("bare-name target removed");
+    expect(allErr).not.toContain("not found locally");
   });
 
   test("plugin:<name> prefix passes the bare-name guard", async () => {
     await run(() => cmdSend("plugin:nonexistent-plugin", "hi"));
     const allErr = errs.join("\n");
-    expect(allErr).not.toContain("bare-name target removed");
+    expect(allErr).not.toContain("not found locally");
   });
 
   test("path-style target with '/' passes the bare-name guard", async () => {
     await run(() => cmdSend("some/path", "hi"));
     const allErr = errs.join("\n");
-    expect(allErr).not.toContain("bare-name target removed");
+    expect(allErr).not.toContain("not found locally");
     expect(resolveTargetCalls).toBeGreaterThanOrEqual(1);
   });
 });

--- a/test/routing.test.ts
+++ b/test/routing.test.ts
@@ -62,6 +62,15 @@ describe("resolveTarget", () => {
     expect(r).toEqual({ type: "local", target: "47-mawjs:1.0" });
   });
 
+  test("session:window-name.pane from maw ls stays local before node:agent routing (#1572)", () => {
+    const sessions: Session[] = [
+      ...SESSIONS,
+      { name: "20-homekeeper", windows: [{ index: 2, name: "homekeeper-oracle", active: true }] },
+    ];
+    const r = resolveTarget("20-homekeeper:homekeeper-oracle.0", BASE_CONFIG, sessions);
+    expect(r).toEqual({ type: "local", target: "20-homekeeper:2.0" });
+  });
+
   // #3: NODE:AGENT → REMOTE PEER
   test("node:agent resolves to remote peer", () => {
     const r = resolveTarget("mba:homekeeper", BASE_CONFIG, SESSIONS);


### PR DESCRIPTION
## Summary
- allow bare `maw hey <oracle-window>` only when it resolves to a local tmux target
- keep bare misses local-only with explicit cross-node guidance instead of implicit peer fallback
- make `session:window-name.pane` TARGETs from `maw ls -v` resolve locally before node routing
- refresh `maw hey --help` target forms

Closes #1572.

## Verification
- `bun test test/comm-send-deprecation-759.test.ts test/isolated/hey-bare-name-rejection.test.ts test/routing.test.ts test/00-ssh.test.ts`
- `bun test test/isolated/comm-list.test.ts`
- `bun run build`
- user-visible smoke: `bun src/cli.ts hey mawjs-oracle ...` delivered
- user-visible smoke: `bun src/cli.ts hey 54-mawjs:mawjs-oracle.0 ...` delivered

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.