### PR TITLE
fix(wake): nudge tmux redraws after split

### DIFF
--- a/src/commands/shared/wake-maybe-split.ts
+++ b/src/commands/shared/wake-maybe-split.ts
@@ -30,6 +30,15 @@ async function restoreSplitLayout(anchor?: string): Promise<void> {
   }
 }
 
+async function refreshSplitClient(): Promise<void> {
+  try {
+    await hostExec("tmux refresh-client -S");
+  } catch {
+    // Best-effort redraw nudge only (#1562): if tmux rejects refresh-client
+    // in a headless or old-server environment, keep the successful split.
+  }
+}
+
 async function isMawTilePane(anchor?: string): Promise<boolean> {
   if (!anchor) return false;
   try {
@@ -89,6 +98,7 @@ export async function maybeSplit(target: string, opts: { split?: boolean }): Pro
       if (!(await isMawTilePane(anchor))) {
         await restoreSplitLayout(anchor);
       }
+      await refreshSplitClient();
       console.log(`  \x1b[32m✓\x1b[0m split beside — ${target} (50%)`);
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);

--- a/test/isolated/wake-maybe-split.test.ts
+++ b/test/isolated/wake-maybe-split.test.ts
@@ -5,10 +5,15 @@ let hostExecCalls: string[] = [];
 let listPanesResponse = "3\n";
 let tileMarkerResponse = "";
 let paneGeometryResponse = "%42|0|0|\n%43|0|81|1\n%44|26|81|1\n";
+let refreshClientThrows = false;
 
 mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
   hostExec: async (cmd: string) => {
     hostExecCalls.push(cmd);
+    if (cmd.includes("refresh-client")) {
+      if (refreshClientThrows) throw new Error("refresh unsupported");
+      return "";
+    }
     if (cmd.includes("show-options") && cmd.includes("@maw_tile")) return tileMarkerResponse;
     if (cmd.includes("list-panes") && cmd.includes("#{pane_id}|#{pane_top}|#{pane_left}|#{@maw_tile}")) {
       return paneGeometryResponse;
@@ -29,6 +34,7 @@ describe("wake maybeSplit", () => {
     listPanesResponse = "3\n";
     tileMarkerResponse = "";
     paneGeometryResponse = "%42|0|0|\n%43|0|81|1\n%44|26|81|1\n";
+    refreshClientThrows = false;
     process.env.TMUX = "/tmp/tmux-501/default,123,0";
     process.env.TMUX_PANE = "%42";
   });
@@ -41,7 +47,7 @@ describe("wake maybeSplit", () => {
   test("splits current pane and attaches target without importing removed split plugin", async () => {
     await maybeSplit("20-homekeeper:homekeeper-oracle", { split: true });
 
-    expect(hostExecCalls).toHaveLength(4);
+    expect(hostExecCalls).toHaveLength(5);
     expect(hostExecCalls[0]).toContain("tmux split-window");
     expect(hostExecCalls[0]).toContain("-t '%42'");
     expect(hostExecCalls[0]).toContain("-h -l 50%");
@@ -50,6 +56,7 @@ describe("wake maybeSplit", () => {
     expect(hostExecCalls[1]).toContain("tmux show-options -p -t '%42' -v @maw_tile");
     expect(hostExecCalls[2]).toContain("tmux list-panes -t '%42'");
     expect(hostExecCalls[3]).toContain("tmux select-layout -t '%42' main-vertical");
+    expect(hostExecCalls[4]).toBe("tmux refresh-client -S");
   });
 
   test("does not reset layout when split leaves only two panes", async () => {
@@ -57,10 +64,11 @@ describe("wake maybeSplit", () => {
 
     await maybeSplit("20-homekeeper:homekeeper-oracle", { split: true });
 
-    expect(hostExecCalls).toHaveLength(3);
+    expect(hostExecCalls).toHaveLength(4);
     expect(hostExecCalls[0]).toContain("tmux split-window");
     expect(hostExecCalls[1]).toContain("tmux show-options -p -t '%42' -v @maw_tile");
     expect(hostExecCalls[2]).toContain("tmux list-panes -t '%42'");
+    expect(hostExecCalls[3]).toBe("tmux refresh-client -S");
     expect(hostExecCalls.some(cmd => cmd.includes("tmux select-layout"))).toBe(false);
   });
 
@@ -69,11 +77,12 @@ describe("wake maybeSplit", () => {
 
     await maybeSplit("20-homekeeper:homekeeper-oracle", { split: true });
 
-    expect(hostExecCalls).toHaveLength(2);
+    expect(hostExecCalls).toHaveLength(3);
     expect(hostExecCalls[0]).toContain("tmux split-window");
     expect(hostExecCalls[0]).toContain("-t '%42'");
     expect(hostExecCalls[0]).toContain("-h -l 50%");
     expect(hostExecCalls[1]).toContain("tmux show-options -p -t '%42' -v @maw_tile");
+    expect(hostExecCalls[2]).toBe("tmux refresh-client -S");
     expect(hostExecCalls.some(cmd => cmd.includes("tmux select-layout"))).toBe(false);
   });
 
@@ -82,11 +91,12 @@ describe("wake maybeSplit", () => {
 
     await maybeSplit("20-homekeeper:homekeeper-oracle", { split: true });
 
-    expect(hostExecCalls).toHaveLength(3);
+    expect(hostExecCalls).toHaveLength(4);
     expect(hostExecCalls[0]).not.toContain("-t '%");
     expect(hostExecCalls[0]).toContain("tmux split-window -h -l 50%");
     expect(hostExecCalls[1]).toContain("tmux list-panes ");
     expect(hostExecCalls[2]).toContain("tmux select-layout main-vertical");
+    expect(hostExecCalls[3]).toBe("tmux refresh-client -S");
   });
 
   test("uses tiled layout after split when pane count is high", async () => {
@@ -95,6 +105,15 @@ describe("wake maybeSplit", () => {
     await maybeSplit("20-homekeeper:homekeeper-oracle", { split: true });
 
     expect(hostExecCalls[3]).toContain("tmux select-layout -t '%42' tiled");
+    expect(hostExecCalls[4]).toBe("tmux refresh-client -S");
+  });
+
+  test("redraw nudge failure does not fail the split", async () => {
+    refreshClientThrows = true;
+
+    await maybeSplit("20-homekeeper:homekeeper-oracle", { split: true });
+
+    expect(hostExecCalls.at(-1)).toBe("tmux refresh-client -S");
   });
 
   test("finds the top-right tile pane, excluding the caller", async () => {


### PR DESCRIPTION
## Summary
- add a best-effort `tmux refresh-client -S` after `maw wake --split` creates/reflows the split
- keep the existing split success path intact if the redraw nudge fails
- extend wake-maybe-split tests for the redraw command and failure swallowing

Mitigates #1562. I am not closing #1562 yet because the exact busy Claude Code TUI smear needs Nat/user-visible confirmation.

## Verification
- `bun test test/isolated/wake-maybe-split.test.ts`
- `bun run build`
- `tmux refresh-client -S` exits 0 on m5

Written by [m5:mawjs-codex] — an Oracle AI running gpt-5.5 in Nat's m5 Codex session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.