### PR TITLE
ci(release): skip unchanged-version alpha feature merges

### DIFF
--- a/.github/workflows/calver-release.yml
+++ b/.github/workflows/calver-release.yml
@@ -101,18 +101,33 @@ jobs:
           echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
           echo "✅ valid CalVer: $TAG (channel=$CHANNEL prerelease=$PRERELEASE)"
 
-      - name: Fail loud on tag collision
+      - name: Check tag collision or unchanged-version no-op
+        id: tagcheck
         if: steps.ver.outputs.skip != 'true'
         run: |
+          set -e
+          VERSION="${{ steps.ver.outputs.version }}"
           TAG="${{ steps.ver.outputs.tag }}"
+          BEFORE="${{ github.event.before }}"
+          if [[ -z "$BEFORE" || "$BEFORE" =~ ^0+$ ]]; then
+            BEFORE="HEAD^"
+          fi
+          PREVIOUS_VERSION="$(git show "$BEFORE:package.json" 2>/dev/null | jq -r '.version // empty' || true)"
+
           if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "::error title=Tag collision::$TAG already exists. Two cuts in one hour? Use the 'alpha.Nb' collision suffix, or wait for the next hour."
+            if [[ "$PREVIOUS_VERSION" == "$VERSION" ]]; then
+              echo "::notice title=Skipped::Tag $TAG already exists and package version did not change ($VERSION); no release cut for this package.json feature merge."
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "::error title=Tag collision::$TAG already exists, but package version changed from '$PREVIOUS_VERSION' to '$VERSION'. Use the same-minute collision suffix (alpha.Nb) or wait for the next minute."
             exit 1
           fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
           echo "✓ $TAG is free"
 
       - name: Install + test + build
-        if: steps.ver.outputs.skip != 'true'
+        if: steps.ver.outputs.skip != 'true' && steps.tagcheck.outputs.skip != 'true'
         # #830 — skip the federation 2-port localhost integration test on this
         # runner. It hits a kernel port-race between getEphemeralPort()→close
         # and Bun.spawn()→listen that's been flaking nightly on alpha cuts:
@@ -128,7 +143,7 @@ jobs:
           bun run build
 
       - name: Tag + GitHub release
-        if: steps.ver.outputs.skip != 'true'
+        if: steps.ver.outputs.skip != 'true' && steps.tagcheck.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -145,7 +160,7 @@ jobs:
           gh release create "$TAG" $FLAGS dist/maw
 
       - name: Summary
-        if: steps.ver.outputs.skip != 'true'
+        if: steps.ver.outputs.skip != 'true' && steps.tagcheck.outputs.skip != 'true'
         run: |
           TAG="${{ steps.ver.outputs.tag }}"
           echo "### 🎉 Released $TAG" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Fixes #1577.

## Summary
- Changes `calver-release.yml` tag collision handling to skip/no-op when the tag already exists **and** the package version did not change from the previous alpha head.
- Keeps the hard failure when the package version changed but the resulting tag already exists (real duplicate release attempt).
- Applies the skip output to install/test/build, tag/release, and release summary steps.

## Why
#1575 changed `package.json` exports but intentionally did not bump version. Because the workflow triggers on any `package.json` edit, alpha went red on the existing human-cut tag `v26.5.16-alpha.1053` even though no release cut was requested.

## Validation
- Local shell simulation with `BEFORE=bc1402f0` confirms `v26.5.16-alpha.1053` exists and previous/current package versions both equal `26.5.16-alpha.1053`, so the new path skips.
- `bun test test/calver.test.ts` → 59 pass, 0 fail.
- `git diff --check`.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
