### PR TITLE
feat(plugin): preserve lifecycle hook declarations

### DIFF
--- a/src/plugin/manifest-validate.ts
+++ b/src/plugin/manifest-validate.ts
@@ -3,7 +3,7 @@
  * Each function validates and shapes one optional manifest section.
  */
 
-import type { PluginManifest, PluginTier } from "./types";
+import type { PluginLifecycleHook, PluginManifest, PluginTier } from "./types";
 import { KNOWN_CAPABILITY_NAMESPACES, NAME_RE } from "./manifest-constants";
 import { getRuntimeVersionString } from "../core/runtime/build-info";
 
@@ -60,6 +60,35 @@ export function parseApi(r: Record<string, unknown>): PluginManifest["api"] {
   return { path: a.path, methods: a.methods as ("GET" | "POST")[] };
 }
 
+function parseLifecycleHook(hooks: Record<string, unknown>, key: "wake" | "sleep" | "serve"): PluginLifecycleHook | undefined {
+  const raw = hooks[key];
+  if (raw === undefined) return undefined;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error(`plugin.json: hooks.${key} must be an object`);
+  }
+  const h = raw as Record<string, unknown>;
+  if (h.script !== undefined && (typeof h.script !== "string" || !h.script)) {
+    throw new Error(`plugin.json: hooks.${key}.script must be a non-empty string`);
+  }
+  if (h.handler !== undefined && (typeof h.handler !== "string" || !h.handler)) {
+    throw new Error(`plugin.json: hooks.${key}.handler must be a non-empty string`);
+  }
+  if (h.ensures !== undefined) {
+    if (!Array.isArray(h.ensures) || (h.ensures as unknown[]).some((e: unknown) => typeof e !== "string" || !e)) {
+      throw new Error(`plugin.json: hooks.${key}.ensures must be an array of non-empty strings`);
+    }
+  }
+  if (h.policy !== undefined && h.policy !== "best-effort" && h.policy !== "fail-fast") {
+    throw new Error(`plugin.json: hooks.${key}.policy must be "best-effort" or "fail-fast"`);
+  }
+  return {
+    ...(typeof h.script === "string" ? { script: h.script } : {}),
+    ...(typeof h.handler === "string" ? { handler: h.handler } : {}),
+    ...(Array.isArray(h.ensures) ? { ensures: h.ensures as string[] } : {}),
+    ...(typeof h.policy === "string" ? { policy: h.policy as PluginLifecycleHook["policy"] } : {}),
+  };
+}
+
 export function parseHooks(r: Record<string, unknown>): PluginManifest["hooks"] {
   if (r.hooks === undefined) return undefined;
   if (!r.hooks || typeof r.hooks !== "object" || Array.isArray(r.hooks)) {
@@ -73,11 +102,17 @@ export function parseHooks(r: Record<string, unknown>): PluginManifest["hooks"] 
       }
     }
   }
+  const wake = parseLifecycleHook(h, "wake");
+  const sleep = parseLifecycleHook(h, "sleep");
+  const serve = parseLifecycleHook(h, "serve");
   return {
     ...(Array.isArray(h.gate) ? { gate: h.gate as string[] } : {}),
     ...(Array.isArray(h.filter) ? { filter: h.filter as string[] } : {}),
     ...(Array.isArray(h.on) ? { on: h.on as string[] } : {}),
     ...(Array.isArray(h.late) ? { late: h.late as string[] } : {}),
+    ...(wake ? { wake } : {}),
+    ...(sleep ? { sleep } : {}),
+    ...(serve ? { serve } : {}),
   };
 }
 

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -30,6 +30,17 @@ export interface PluginArtifact {
   sha256: string | null;    // sha256 of the bundle, or null if unbuilt
 }
 
+export interface PluginLifecycleHook {
+  /** Relative script/module path reserved for lifecycle runners (#1576). */
+  script?: string;
+  /** Exported handler name; defaults to the lifecycle name when omitted. */
+  handler?: string;
+  /** Advisory resources/capabilities this hook ensures before the lifecycle continues. */
+  ensures?: string[];
+  /** Failure policy for future runners; manifest parsing only in this slice. */
+  policy?: "best-effort" | "fail-fast";
+}
+
 export interface PluginManifest {
   name: string;           // unique id, slug-safe /^[a-z0-9-]+$/
   version: string;        // semver e.g. "1.0.0"
@@ -59,6 +70,9 @@ export interface PluginManifest {
     filter?: string[];  // event names to filter
     on?: string[];      // event names to handle
     late?: string[];    // event names for cleanup
+    wake?: PluginLifecycleHook;  // lifecycle: oracle/session wake (#1576)
+    sleep?: PluginLifecycleHook; // lifecycle: oracle/session sleep (#1576)
+    serve?: PluginLifecycleHook; // lifecycle: plugin persistent serve (#1576)
   };
   cron?: {
     schedule: string;   // cron expression

--- a/test/plugin-manifest.test.ts
+++ b/test/plugin-manifest.test.ts
@@ -80,6 +80,40 @@ describe("parseManifest happy path", () => {
     }
   });
 
+
+  test("preserves feed hooks and lifecycle hook declarations", () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(join(dir, "index.ts"), "export default () => ({ ok: true })\n");
+      const manifest = parseManifest(
+        JSON.stringify({
+          name: "life-plugin",
+          version: "1.0.0",
+          entry: "index.ts",
+          sdk: "*",
+          hooks: {
+            on: ["MessageSend"],
+            wake: { script: "setup.ts", handler: "onWake", ensures: ["storage:sqlite"], policy: "best-effort" },
+            sleep: { handler: "onSleep" },
+            serve: { script: "serve.ts", policy: "fail-fast" },
+          },
+        }),
+        dir,
+      );
+
+      expect(manifest.hooks?.on).toEqual(["MessageSend"]);
+      expect(manifest.hooks?.wake).toEqual({
+        script: "setup.ts",
+        handler: "onWake",
+        ensures: ["storage:sqlite"],
+        policy: "best-effort",
+      });
+      expect(manifest.hooks?.sleep).toEqual({ handler: "onSleep" });
+      expect(manifest.hooks?.serve).toEqual({ script: "serve.ts", policy: "fail-fast" });
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
   test("accepts * as sdk range", () => {
     const dir = makeTempDir();
     try {
@@ -104,6 +138,27 @@ describe("parseManifest validation failures", () => {
     expect(() => parseManifest("not json!", "/tmp")).toThrow(/JSON/);
   });
 
+
+  test("throws on invalid lifecycle hook declarations", () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(join(dir, "index.ts"), "export default () => ({ ok: true })\n");
+      expect(() =>
+        parseManifest(
+          JSON.stringify({ name: "bad-life", version: "1.0.0", entry: "index.ts", sdk: "*", hooks: { wake: [] } }),
+          dir,
+        ),
+      ).toThrow(/hooks\.wake must be an object/);
+      expect(() =>
+        parseManifest(
+          JSON.stringify({ name: "bad-policy", version: "1.0.0", entry: "index.ts", sdk: "*", hooks: { serve: { policy: "always" } } }),
+          dir,
+        ),
+      ).toThrow(/hooks\.serve\.policy/);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
   test("throws on invalid name (uppercase, special chars)", () => {
     const dir = makeTempDir();
     try {


### PR DESCRIPTION
## Summary
- allow `plugin.json` to declare lifecycle hooks under `hooks.wake`, `hooks.sleep`, and `hooks.serve`
- validate lifecycle hook shape (`script`, `handler`, `ensures`, `policy`)
- preserve existing feed hook behavior (`hooks.on/gate/filter/late`) without treating lifecycle declarations as feed subscriptions

## Issue
- First manifest-contract slice for #1576.

## Validation
- `rtk bun test test/plugin-manifest.test.ts`
- `bun run build`
- `git diff --check`

## Not included
- wake-time execution of lifecycle hooks
- snapshot creation/restore
- dynamic `engine.serve` proxy/registration

## Release lane
Targets `alpha` only. No release-alpha/version/tag/publish PR cut.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
