### PR TITLE
feat(wake): stamp worktrees with bud lineage

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -148,7 +148,7 @@ function printBringUsage(write: (line: string) => void = console.log): void {
 }
 
 function printWakeAliasUsage(verb: "wake" | "awake", write: (line: string) => void = console.log): void {
-  write(`usage: maw ${verb} <oracle> [--task <s>] [--wt <s>] [-p|--prompt <s>] [--incubate <slug>] [--fresh] [-a|--attach] [--list] [--dry-run] [--main|--solo|--no-rehydrate] [--split] [--all-local] [-e|--engine <name>]`);
+  write(`usage: maw ${verb} <oracle> [--task <s>] [--wt <s>] [--bud] [-p|--prompt <s>] [--incubate <slug>] [--fresh] [-a|--attach] [--list] [--dry-run] [--main|--solo|--no-rehydrate] [--split] [--all-local] [-e|--engine <name>]`);
   if (verb === "awake") {
     write("  Launch/start an oracle process with the selected engine. Does not send /awaken.");
     write("  Use `maw awaken` for the awakening ritual; use `maw new` for the creation door.");
@@ -156,6 +156,7 @@ function printWakeAliasUsage(verb: "wake" | "awake", write: (line: string) => vo
     write("  Wake or reuse an oracle session, fuzzy-resolving repos and worktrees as needed.");
   }
   write("  --list previews worktrees only; it does not create sessions or respawn windows.");
+  write("  --bud with --task/--wt writes ψ/.lineage.yaml in the worktree (no repo/fleet mutation).");
 }
 
 /**
@@ -220,6 +221,7 @@ export async function invokeDirectHandler(
       "--prompt": String, "-p": "--prompt",
       "--incubate": String,
       "--fresh": Boolean,
+      "--bud": Boolean,
       "--attach": Boolean, "-a": "--attach",
       "--list": Boolean,
       "--dry-run": Boolean,
@@ -247,6 +249,7 @@ export async function invokeDirectHandler(
       dryRun?: boolean;
       noRehydrate?: boolean;
       split?: boolean;
+      bud?: boolean;
       allLocal?: boolean;
       engine?: string;
     } = {};
@@ -255,6 +258,7 @@ export async function invokeDirectHandler(
     if (flags["--prompt"]) opts.prompt = flags["--prompt"];
     if (flags["--incubate"]) opts.incubate = flags["--incubate"];
     if (flags["--fresh"]) opts.fresh = true;
+    if (flags["--bud"]) opts.bud = true;
     if (flags["--attach"]) opts.attach = true;
     if (flags["--list"]) opts.listWt = true;
     if (flags["--dry-run"]) opts.dryRun = true;

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -9,6 +9,47 @@ import { attachToSession, ensureSessionRunning, createWorktree } from "./wake-se
 import { maybeOpenWindow, maybeSplit } from "./wake-maybe-split";
 import { parseWakeTarget, ensureCloned } from "./wake-target";
 import { assertAgentCapacity } from "./wake-concurrency";
+import { mkdirSync, writeFileSync } from "fs";
+import { join } from "path";
+
+export interface WakeBudLineageInput {
+  parentOracle: string;
+  task: string;
+  branch?: string;
+  buddedAt?: string;
+  buddedBy?: string;
+}
+
+function yamlScalar(value: string): string {
+  return JSON.stringify(value);
+}
+
+function wakeBudActor(): string {
+  return process.env.CLAUDE_AGENT_NAME
+    || process.env.MAW_ORACLE_NAME
+    || process.env.TMUX_PANE
+    || process.env.USER
+    || "unknown";
+}
+
+export function buildWakeBudLineage(input: WakeBudLineageInput): string {
+  const rows: [string, string][] = [
+    ["budded_from", input.parentOracle],
+    ["budded_at", input.buddedAt ?? new Date().toISOString()],
+    ["budded_by", input.buddedBy ?? wakeBudActor()],
+    ["branch", input.branch ?? ""],
+    ["task", input.task],
+  ];
+  return `${rows.map(([key, value]) => `${key}: ${yamlScalar(value)}`).join("\n")}\n`;
+}
+
+export function writeWakeBudLineage(worktreePath: string, input: WakeBudLineageInput): string {
+  const psiDir = join(worktreePath, "ψ");
+  mkdirSync(psiDir, { recursive: true });
+  const file = join(psiDir, ".lineage.yaml");
+  writeFileSync(file, buildWakeBudLineage(input), "utf-8");
+  return file;
+}
 
 export function shouldOfferExistingSessionAttach(
   opts: { attach?: boolean; split?: boolean; bring?: boolean },
@@ -156,7 +197,7 @@ async function chooseWakeSessionName(oracle: string, urlRepoName?: string): Prom
   return `${String(maxNum + 1).padStart(2, "0")}-${baseName}`;
 }
 
-export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; dryRun?: boolean; noRehydrate?: boolean; split?: boolean; bring?: boolean; tab?: boolean; repoPath?: string; urlRepoName?: string; allLocal?: boolean; engine?: string }): Promise<string> {
+export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; dryRun?: boolean; noRehydrate?: boolean; split?: boolean; bring?: boolean; tab?: boolean; bud?: boolean; repoPath?: string; urlRepoName?: string; allLocal?: boolean; engine?: string }): Promise<string> {
   // Canonicalize the bare name before any lookup — strips trailing `/`, `/.git`, `/.git/`
   // so `maw wake token-oracle/` (tab-completion artifact) resolves the same as `token-oracle`.
   oracle = normalizeTarget(oracle);
@@ -213,6 +254,10 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
 
   const { repoPath, repoName, parentDir } = resolved;
 
+  if (opts.bud && !opts.task && !opts.wt) {
+    throw new Error("--bud requires --task <slug> or --wt <slug>");
+  }
+
   // #997 — when fuzzy match resolved a different repo (e.g. "v3" → "arra-oracle-v3-oracle"),
   // update oracle to the resolved name so session/window names are correct.
   const resolvedOracle = repoName.replace(/-oracle$/, "");
@@ -266,6 +311,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
 
     if (opts.task || opts.wt) {
       console.log(`\x1b[33m⚡\x1b[0m would wake worktree/task: ${sanitizeBranchName(opts.wt || opts.task!)}`);
+      if (opts.bud) console.log(`\x1b[90m🌱 would stamp wake-bud lineage for ${oracle}\x1b[0m`);
       return session ? `${session}:${mainWindowName}` : `${oracle}:dry-run`;
     }
 
@@ -394,6 +440,17 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
       const result = await createWorktree(repoPath, parentDir, repoName, oracle, name, worktrees);
       targetPath = result.wtPath;
       windowName = result.windowName;
+    }
+
+    if (opts.bud) {
+      const safePath = targetPath.replace(/'/g, "'\\''");
+      const branch = (await hostExec(`git -C '${safePath}' branch --show-current 2>/dev/null || true`)).trim();
+      const lineageFile = writeWakeBudLineage(targetPath, {
+        parentOracle: oracle,
+        task: name,
+        branch,
+      });
+      console.log(`\x1b[32m🌱\x1b[0m lineage: ${lineageFile}`);
     }
   }
 

--- a/test/isolated/wake-bud-lineage.test.ts
+++ b/test/isolated/wake-bud-lineage.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { buildWakeBudLineage, writeWakeBudLineage } from "../../src/commands/shared/wake-cmd";
+
+describe("wake --bud lineage", () => {
+  test("builds deterministic YAML for a lineage-stamped worktree", () => {
+    const yaml = buildWakeBudLineage({
+      parentOracle: "mawjs",
+      task: "features",
+      branch: "agents/1-features",
+      buddedAt: "2026-05-16T09:30:00.000Z",
+      buddedBy: "m5:mawjs-codex",
+    });
+
+    expect(yaml).toBe([
+      'budded_from: "mawjs"',
+      'budded_at: "2026-05-16T09:30:00.000Z"',
+      'budded_by: "m5:mawjs-codex"',
+      'branch: "agents/1-features"',
+      'task: "features"',
+      '',
+    ].join("\n"));
+  });
+
+  test("writes ψ/.lineage.yaml without mutating fleet or repo metadata", () => {
+    const dir = mkdtempSync(join(tmpdir(), "maw-wake-bud-"));
+    try {
+      const file = writeWakeBudLineage(dir, {
+        parentOracle: "mawjs",
+        task: "channel",
+        branch: "agents/7-channel",
+        buddedAt: "2026-05-16T09:31:00.000Z",
+        buddedBy: "tester",
+      });
+
+      expect(file).toBe(join(dir, "ψ", ".lineage.yaml"));
+      expect(readFileSync(file, "utf-8")).toContain('budded_from: "mawjs"');
+      expect(readFileSync(file, "utf-8")).toContain('task: "channel"');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add `--bud` to `maw wake --task/--wt`
- write `ψ/.lineage.yaml` in the target worktree with parent oracle, timestamp, actor, branch, and task
- keep `--bud` scoped to reversible worktree semantics: no new repo and no fleet mutation
- show the lineage intent in `--dry-run`

## Issue
- First implementation slice for #1581.

## Validation
- `rtk bun test test/isolated/wake-bud-lineage.test.ts test/cli/dispatch-match.test.ts`
- `bun run build`
- `bun src/cli.ts wake mawjs --task codex-smoke --bud --dry-run --all-local`
- `git diff --check`

## Not included
- optional parent `ψ/memory/signals` birth note
- real worktree creation smoke with `--bud` (avoided creating user worktrees in this quick slice)

## Release lane
Targets `alpha` only. No release-alpha/version/tag/publish PR cut.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
