### PR TITLE
feat(wake): signal wake-bud births on request

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -148,7 +148,7 @@ function printBringUsage(write: (line: string) => void = console.log): void {
 }
 
 function printWakeAliasUsage(verb: "wake" | "awake", write: (line: string) => void = console.log): void {
-  write(`usage: maw ${verb} <oracle> [--task <s>] [--wt <s>] [--bud] [-p|--prompt <s>] [--incubate <slug>] [--fresh] [-a|--attach] [--list] [--dry-run] [--main|--solo|--no-rehydrate] [--split] [--all-local] [-e|--engine <name>]`);
+  write(`usage: maw ${verb} <oracle> [--task <s>] [--wt <s>] [--bud] [--signal-on-birth] [-p|--prompt <s>] [--incubate <slug>] [--fresh] [-a|--attach] [--list] [--dry-run] [--main|--solo|--no-rehydrate] [--split] [--all-local] [-e|--engine <name>]`);
   if (verb === "awake") {
     write("  Launch/start an oracle process with the selected engine. Does not send /awaken.");
     write("  Use `maw awaken` for the awakening ritual; use `maw new` for the creation door.");
@@ -157,6 +157,7 @@ function printWakeAliasUsage(verb: "wake" | "awake", write: (line: string) => vo
   }
   write("  --list previews worktrees only; it does not create sessions or respawn windows.");
   write("  --bud with --task/--wt writes ψ/.lineage.yaml in the worktree (no repo/fleet mutation).");
+  write("  --signal-on-birth with --bud also drops a parent ψ/memory/signals birth signal.");
 }
 
 /**
@@ -222,6 +223,7 @@ export async function invokeDirectHandler(
       "--incubate": String,
       "--fresh": Boolean,
       "--bud": Boolean,
+      "--signal-on-birth": Boolean,
       "--attach": Boolean, "-a": "--attach",
       "--list": Boolean,
       "--dry-run": Boolean,
@@ -250,6 +252,7 @@ export async function invokeDirectHandler(
       noRehydrate?: boolean;
       split?: boolean;
       bud?: boolean;
+      signalOnBirth?: boolean;
       allLocal?: boolean;
       engine?: string;
     } = {};
@@ -259,6 +262,7 @@ export async function invokeDirectHandler(
     if (flags["--incubate"]) opts.incubate = flags["--incubate"];
     if (flags["--fresh"]) opts.fresh = true;
     if (flags["--bud"]) opts.bud = true;
+    if (flags["--signal-on-birth"]) opts.signalOnBirth = true;
     if (flags["--attach"]) opts.attach = true;
     if (flags["--list"]) opts.listWt = true;
     if (flags["--dry-run"]) opts.dryRun = true;

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -9,6 +9,7 @@ import { attachToSession, ensureSessionRunning, createWorktree } from "./wake-se
 import { maybeOpenWindow, maybeSplit } from "./wake-maybe-split";
 import { parseWakeTarget, ensureCloned } from "./wake-target";
 import { assertAgentCapacity } from "./wake-concurrency";
+import { writeSignal } from "../../core/fleet/leaf";
 import { mkdirSync, writeFileSync } from "fs";
 import { join } from "path";
 
@@ -49,6 +50,23 @@ export function writeWakeBudLineage(worktreePath: string, input: WakeBudLineageI
   const file = join(psiDir, ".lineage.yaml");
   writeFileSync(file, buildWakeBudLineage(input), "utf-8");
   return file;
+}
+
+export function writeWakeBudBirthSignal(
+  parentRoot: string,
+  childName: string,
+  input: WakeBudLineageInput & { worktreePath: string },
+): string {
+  return writeSignal(parentRoot, childName, {
+    kind: "info",
+    message: `wake-bud born: ${childName}`,
+    context: {
+      buddedFrom: input.parentOracle,
+      task: input.task,
+      branch: input.branch ?? "",
+      worktreePath: input.worktreePath,
+    },
+  });
 }
 
 export function shouldOfferExistingSessionAttach(
@@ -197,7 +215,7 @@ async function chooseWakeSessionName(oracle: string, urlRepoName?: string): Prom
   return `${String(maxNum + 1).padStart(2, "0")}-${baseName}`;
 }
 
-export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; dryRun?: boolean; noRehydrate?: boolean; split?: boolean; bring?: boolean; tab?: boolean; bud?: boolean; repoPath?: string; urlRepoName?: string; allLocal?: boolean; engine?: string }): Promise<string> {
+export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; dryRun?: boolean; noRehydrate?: boolean; split?: boolean; bring?: boolean; tab?: boolean; bud?: boolean; signalOnBirth?: boolean; repoPath?: string; urlRepoName?: string; allLocal?: boolean; engine?: string }): Promise<string> {
   // Canonicalize the bare name before any lookup — strips trailing `/`, `/.git`, `/.git/`
   // so `maw wake token-oracle/` (tab-completion artifact) resolves the same as `token-oracle`.
   oracle = normalizeTarget(oracle);
@@ -258,6 +276,10 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
     throw new Error("--bud requires --task <slug> or --wt <slug>");
   }
 
+  if (opts.signalOnBirth && !opts.bud) {
+    throw new Error("--signal-on-birth requires --bud");
+  }
+
   // #997 — when fuzzy match resolved a different repo (e.g. "v3" → "arra-oracle-v3-oracle"),
   // update oracle to the resolved name so session/window names are correct.
   const resolvedOracle = repoName.replace(/-oracle$/, "");
@@ -312,6 +334,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
     if (opts.task || opts.wt) {
       console.log(`\x1b[33m⚡\x1b[0m would wake worktree/task: ${sanitizeBranchName(opts.wt || opts.task!)}`);
       if (opts.bud) console.log(`\x1b[90m🌱 would stamp wake-bud lineage for ${oracle}\x1b[0m`);
+      if (opts.bud && opts.signalOnBirth) console.log(`\x1b[90m⬡ would drop wake-bud birth signal in ${oracle}'s ψ/memory/signals/\x1b[0m`);
       return session ? `${session}:${mainWindowName}` : `${oracle}:dry-run`;
     }
 
@@ -445,12 +468,20 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
     if (opts.bud) {
       const safePath = targetPath.replace(/'/g, "'\\''");
       const branch = (await hostExec(`git -C '${safePath}' branch --show-current 2>/dev/null || true`)).trim();
-      const lineageFile = writeWakeBudLineage(targetPath, {
+      const lineage = {
         parentOracle: oracle,
         task: name,
         branch,
-      });
+      };
+      const lineageFile = writeWakeBudLineage(targetPath, lineage);
       console.log(`\x1b[32m🌱\x1b[0m lineage: ${lineageFile}`);
+      if (opts.signalOnBirth) {
+        const signalFile = writeWakeBudBirthSignal(repoPath, `${oracle}-${name}`, {
+          ...lineage,
+          worktreePath: targetPath,
+        });
+        console.log(`\x1b[36m⬡\x1b[0m signal: ${signalFile}`);
+      }
     }
   }
 

--- a/test/isolated/wake-bud-lineage.test.ts
+++ b/test/isolated/wake-bud-lineage.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, readFileSync, rmSync } from "fs";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { buildWakeBudLineage, writeWakeBudLineage } from "../../src/commands/shared/wake-cmd";
+import { buildWakeBudLineage, writeWakeBudBirthSignal, writeWakeBudLineage } from "../../src/commands/shared/wake-cmd";
 
 describe("wake --bud lineage", () => {
   test("builds deterministic YAML for a lineage-stamped worktree", () => {
@@ -40,6 +40,34 @@ describe("wake --bud lineage", () => {
       expect(readFileSync(file, "utf-8")).toContain('task: "channel"');
     } finally {
       rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("can drop an optional parent ψ/memory/signals birth signal", () => {
+    const parentRoot = mkdtempSync(join(tmpdir(), "maw-wake-bud-parent-"));
+    try {
+      const file = writeWakeBudBirthSignal(parentRoot, "mawjs-channel", {
+        parentOracle: "mawjs",
+        task: "channel",
+        branch: "agents/7-channel",
+        worktreePath: "/tmp/mawjs-oracle.wt-7-channel",
+      });
+
+      expect(file.startsWith(join(parentRoot, "ψ", "memory", "signals"))).toBe(true);
+      expect(existsSync(file)).toBe(true);
+      expect(readdirSync(join(parentRoot, "ψ", "memory", "signals"))).toHaveLength(1);
+      const signal = JSON.parse(readFileSync(file, "utf-8"));
+      expect(signal.bud).toBe("mawjs-channel");
+      expect(signal.kind).toBe("info");
+      expect(signal.message).toBe("wake-bud born: mawjs-channel");
+      expect(signal.context).toEqual({
+        buddedFrom: "mawjs",
+        task: "channel",
+        branch: "agents/7-channel",
+        worktreePath: "/tmp/mawjs-oracle.wt-7-channel",
+      });
+    } finally {
+      rmSync(parentRoot, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
## Summary
- add `maw wake --task/--wt --bud --signal-on-birth` as the opt-in parent-side proof for wake-bud lineage
- reuse the existing `ψ/memory/signals` writer so plain `--bud` remains only a worktree lineage stamp
- document the flag in wake help and guard `--signal-on-birth` behind `--bud`

## Verification
- `rtk bun test test/isolated/wake-bud-lineage.test.ts test/cli/dispatch-match.test.ts` → 36 pass / 0 fail
- `bun run build` → OK
- `bun src/cli.ts wake mawjs --task codex-signal-smoke --bud --signal-on-birth --dry-run --all-local` → previews lineage + birth signal without tmux changes
- `bun src/cli.ts wake --help | grep -- --signal-on-birth` → help documents the flag
- guard smoke: `bun src/cli.ts wake mawjs --task codex-signal-smoke --signal-on-birth --dry-run --all-local` exits non-zero with `--signal-on-birth requires --bud`

No release-alpha/version/tag/publish PR cut; alpha branch only.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
