### PR TITLE
feat(snapshots): expose recovery snapshots as a top-level command

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -53,6 +53,7 @@ export const ALIAS_DESCRIPTIONS: Record<string, string> = {
   awake: "Launch an oracle process with optional engine (does not trigger /awaken)",
   new: "Create a new oracle (friendly door for awaken)",
   preflight: "Pre-flight check — version, plugins, dead agents, config",
+  snapshots: "List and inspect fleet recovery snapshots",
 };
 
 export const TOP_ALIASES: Record<string, string[] | DirectHandler> = {
@@ -86,6 +87,7 @@ export const TOP_ALIASES: Record<string, string[] | DirectHandler> = {
   new: { kind: "direct", handler: "./cmd-new:cmdNew" },
 
   preflight: { kind: "direct", handler: "../commands/shared/preflight:cmdPreflight" },
+  snapshots: ["fleet", "snapshots"],
 };
 
 /**

--- a/src/commands/plugins/fleet/index.ts
+++ b/src/commands/plugins/fleet/index.ts
@@ -55,17 +55,46 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       const { cmdFleetSync } = await import("../../shared/fleet");
       await cmdFleetSync();
     } else if (sub === "snapshots" || sub === "snapshot-ls") {
-      const { listSnapshots } = await import("../../../core/fleet/snapshot");
-      const snaps = listSnapshots();
-      if (snaps.length === 0) {
-        console.log("no snapshots yet");
-        return { ok: true, output: logs.join("\n") || "no snapshots yet" };
-      }
-      console.log(`\x1b[36m📸 ${snaps.length} snapshots\x1b[0m\n`);
-      for (const s of snaps) {
-        const d = new Date(s.timestamp);
-        const local = d.toLocaleString("en-GB", { timeZone: "Asia/Bangkok", hour12: false });
-        console.log(`  ${s.file.replace(".json", "")}  ${local}  \x1b[90m${s.trigger}\x1b[0m  ${s.sessionCount} sessions, ${s.windowCount} windows`);
+      const { listSnapshots, loadSnapshot, latestSnapshot } = await import("../../../core/fleet/snapshot");
+      const action = sub === "snapshot-ls" ? "list" : (args[1] || "list");
+      const json = args.includes("--json");
+      if (action === "list" || action === "ls") {
+        const snaps = listSnapshots();
+        if (json) {
+          console.log(JSON.stringify({ snapshots: snaps }, null, 2));
+        } else if (snaps.length === 0) {
+          console.log("no snapshots yet");
+          return { ok: true, output: logs.join("\n") || "no snapshots yet" };
+        } else {
+          console.log(`\x1b[36m📸 ${snaps.length} snapshots\x1b[0m\n`);
+          for (const s of snaps) {
+            const d = new Date(s.timestamp);
+            const local = d.toLocaleString("en-GB", { timeZone: "Asia/Bangkok", hour12: false });
+            console.log(`  ${s.file.replace(".json", "")}  ${local}  \x1b[90m${s.trigger}\x1b[0m  ${s.sessionCount} sessions, ${s.windowCount} windows`);
+          }
+        }
+      } else if (action === "show" || action === "view") {
+        const id = args[2];
+        const snap = id && id !== "latest" ? loadSnapshot(id) : latestSnapshot();
+        if (!snap) {
+          return { ok: false, error: "no snapshot found" };
+        }
+        if (json) {
+          console.log(JSON.stringify(snap, null, 2));
+        } else {
+          const d = new Date(snap.timestamp);
+          const local = d.toLocaleString("en-GB", { timeZone: "Asia/Bangkok", hour12: false });
+          console.log(`\x1b[36m📸 Snapshot: ${local} (${snap.trigger})\x1b[0m\n`);
+          for (const s of snap.sessions) {
+            console.log(`\x1b[33m${s.name}\x1b[0m (${s.windows.length} windows)`);
+            for (const w of s.windows) console.log(`  ${w.name}`);
+          }
+        }
+      } else {
+        return {
+          ok: false,
+          error: "usage: maw snapshots [list|show <id>|show latest] [--json]",
+        };
       }
     } else if (sub === "restore") {
       const { loadSnapshot, latestSnapshot } = await import("../../../core/fleet/snapshot");

--- a/src/commands/plugins/fleet/plugin.json
+++ b/src/commands/plugins/fleet/plugin.json
@@ -7,7 +7,7 @@
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "fleet",
-    "help": "maw fleet <init|ls|renumber|validate|health|doctor|consolidate|sync|sync-windows|snapshots|restore|snapshot> [args] — manage registered fleet config; see maw ls for live sessions"
+    "help": "maw fleet <init|ls|renumber|validate|health|doctor|consolidate|sync|sync-windows|snapshots|restore|snapshot> [args] — manage registered fleet config; see maw snapshots for recovery points and maw ls for live sessions"
   },
   "weight": 10,
   "tier": "standard"

--- a/test/cli/dispatch-match.test.ts
+++ b/test/cli/dispatch-match.test.ts
@@ -366,6 +366,16 @@ describe("resolveTopAlias — RFC #954 verb aliases", () => {
     expect(ALIAS_DESCRIPTIONS.scaffold).toContain("skeleton");
   });
 
+  test("`snapshots list --json` → fleet snapshots top-level alias", () => {
+    const out = resolveTopAlias(["snapshots", "list", "--json"]);
+    expect(out).not.toBeNull();
+    expect(out!.kind).toBe("argv");
+    if (out!.kind === "argv") {
+      expect(out!.argv).toEqual(["fleet", "snapshots", "list", "--json"]);
+    }
+    expect(ALIAS_DESCRIPTIONS.snapshots).toContain("recovery snapshots");
+  });
+
   test("`bring neo` defaults to v1 split-and-attach mode", () => {
     const parsed = parseBringArgs(["neo"]);
     expect(parsed).toEqual({ oracle: "neo", opts: { split: true } });


### PR DESCRIPTION
## Summary
- add `maw snapshots ...` as a top-level recovery-inspection alias for the existing fleet snapshot surface
- support `maw snapshots list --json` and `maw snapshots show [latest|id] --json`
- keep snapshot inspection read-only; restore/replay remains under explicit restore flows

## Verification
- `rtk bun test test/cli/dispatch-match.test.ts` → 34 pass / 0 fail
- `rtk bun test test/snapshot.test.ts` → 11 pass / 0 fail
- `bun run build` → OK
- `bun src/cli.ts snapshots list --json | jq 'has("snapshots")'` → `true`
- `bun src/cli.ts snapshots show latest --json | jq 'has("timestamp") and has("sessions")'` → `true`

Note: I intentionally ran dispatch and snapshot tests separately because `test/snapshot.test.ts` uses a process-global Bun `mock.module` for `core/transport/ssh`; combined with dispatch it hits the known cross-file mock leak (`sendKeys` export mock), unrelated to this change.

No release-alpha/version/tag/publish PR cut; alpha branch only.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
