### PR TITLE
test(snapshot): complete ssh mock exports for mixed runs

### DIFF
--- a/test/snapshot.test.ts
+++ b/test/snapshot.test.ts
@@ -35,6 +35,13 @@ mock.module("../src/core/transport/ssh", () => ({
   listSessions: async (): Promise<MockSession[]> => mockSessions,
   hostExec: async (): Promise<string> => "",
   ssh: async (): Promise<string> => "",
+  capture: async (): Promise<string> => "",
+  sendKeys: async (): Promise<void> => {},
+  getPaneCommand: async (): Promise<string> => "",
+  getPaneCommands: async (): Promise<Record<string, string>> => ({}),
+  getPaneInfos: async (): Promise<Record<string, { command: string; cwd: string }>> => ({}),
+  isAgentCommand: (): boolean => false,
+  HostExecError: class HostExecError extends Error {},
   // Stub: real findWindow is tested in 00-ssh.test.ts (loads first alphabetically)
   findWindow: (): string | null => null,
 }));

--- a/test/snapshot.test.ts
+++ b/test/snapshot.test.ts
@@ -23,6 +23,7 @@ mock.module("../src/core/paths", () => ({
 }));
 
 import { mockConfigModule } from "./helpers/mock-config";
+import { mockSshModule } from "./helpers/mock-ssh";
 mock.module("../src/config", () => mockConfigModule(() => ({ node: "test-node" })));
 
 // Mock listSessions to return predictable data
@@ -31,17 +32,10 @@ let mockSessions: MockSession[] = [
   { name: "04-homekeeper", windows: [{ name: "homekeeper-oracle", index: 1 }] },
 ];
 
-mock.module("../src/core/transport/ssh", () => ({
+mock.module("../src/core/transport/ssh", () => mockSshModule({
   listSessions: async (): Promise<MockSession[]> => mockSessions,
   hostExec: async (): Promise<string> => "",
   ssh: async (): Promise<string> => "",
-  capture: async (): Promise<string> => "",
-  sendKeys: async (): Promise<void> => {},
-  getPaneCommand: async (): Promise<string> => "",
-  getPaneCommands: async (): Promise<Record<string, string>> => ({}),
-  getPaneInfos: async (): Promise<Record<string, { command: string; cwd: string }>> => ({}),
-  isAgentCommand: (): boolean => false,
-  HostExecError: class HostExecError extends Error {},
   // Stub: real findWindow is tested in 00-ssh.test.ts (loads first alphabetically)
   findWindow: (): string | null => null,
 }));


### PR DESCRIPTION
## Summary
- fixes #1585 by making `test/snapshot.test.ts`'s `core/transport/ssh` mock export the SDK-required runtime shape
- unblocks the previously failing mixed fast test run with dispatch + snapshot tests in one Bun process

## Verification
- `rtk bun test test/cli/dispatch-match.test.ts test/snapshot.test.ts` → 45 pass / 0 fail
- `bun run build` → OK

No release-alpha/version/tag/publish PR cut; alpha branch only.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
