### PR TITLE
fix(office): replay cached PTY scrollback on attach

### DIFF
--- a/src/core/transport/pty.ts
+++ b/src/core/transport/pty.ts
@@ -67,6 +67,16 @@ async function attach(ws: MawWS, target: string, cols: number, rows: number) {
       session.cleanupTimer = null;
     }
     session.viewers.add(ws);
+    // Late viewer: cached PTY only streams *new* output, so without a replay
+    // the screen stays empty until something happens in the pane → looks like
+    // "black pane covering tmux". Mirror the new-session capture-pane block.
+    try {
+      const cap = Bun.spawnSync(["tmux", "capture-pane", "-t", safe, "-p", "-e", "-J", "-S", "-2000"]);
+      if (cap.stdout && cap.stdout.length > 0) {
+        ws.send(cap.stdout);
+        ws.send(new TextEncoder().encode("\r\n"));
+      }
+    } catch { /* expected: capture-pane may fail if target gone or tmux missing */ }
     ws.send(JSON.stringify({ type: "attached", target: safe }));
     return;
   }
@@ -94,6 +104,18 @@ async function attach(ws: MawWS, target: string, cols: number, rows: number) {
     ws.send(JSON.stringify({ type: "error", message: "Failed to create PTY session" }));
     return;
   }
+
+  // Replay scrollback history so xterm.js can scroll up. Without this, tmux
+  // attach only redraws current pane → viewer's local buffer has no history.
+  // capture-pane reads tmux server-side history (limit set by history-limit).
+  // -p stdout, -e include ANSI attrs, -S -2000 last 2000 lines, -J join wrapped.
+  try {
+    const cap = Bun.spawnSync(["tmux", "capture-pane", "-t", safe, "-p", "-e", "-J", "-S", "-2000"]);
+    if (cap.stdout && cap.stdout.length > 0) {
+      ws.send(cap.stdout);
+      ws.send(new TextEncoder().encode("\r\n"));
+    }
+  } catch { /* expected: capture-pane may fail if target gone or tmux missing */ }
 
   // Spawn PTY wrapper — attach to our grouped session (not the original).
   //

--- a/test/isolated/pty-attach-replay.test.ts
+++ b/test/isolated/pty-attach-replay.test.ts
@@ -1,0 +1,145 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const encode = (text: string) => new TextEncoder().encode(text);
+const decode = (data: unknown) => data instanceof Uint8Array ? new TextDecoder().decode(data) : String(data);
+
+mock.module("../../src/config", () => ({
+  loadConfig: () => ({ host: "local" }),
+  cfgTimeout: () => 5,
+  cfgLimit: (key: string) => key === "ptyRows" ? 80 : 200,
+}));
+
+mock.module("../../src/core/transport/tmux", () => ({
+  tmuxCmd: () => "tmux",
+  tmux: {
+    newGroupedSession: async () => {},
+    setOption: async () => {},
+    killSession: async () => {},
+  },
+}));
+
+interface MockWs {
+  sent: unknown[];
+  send(data: unknown): void;
+}
+
+function makeWs(): MockWs {
+  return {
+    sent: [],
+    send(data: unknown) { this.sent.push(data); },
+  };
+}
+
+const originalSpawn = Bun.spawn;
+const originalSpawnSync = Bun.spawnSync;
+let spawnCalls: unknown[][] = [];
+let spawnSyncImpl: (args: string[]) => { stdout: Uint8Array } = () => ({ stdout: encode("captured-pane") });
+
+function installSpawnMocks() {
+  spawnCalls = [];
+  (Bun as any).spawnSync = (args: string[]) => spawnSyncImpl(args);
+  (Bun as any).spawn = (args: unknown[]) => {
+    spawnCalls.push(args);
+    return {
+      stdin: { write() {}, flush() {} },
+      stdout: { getReader: () => ({ read: () => new Promise<never>(() => {}) }) },
+      kill() {},
+    };
+  };
+}
+
+async function eventually(predicate: () => boolean, label: string) {
+  const start = Date.now();
+  while (Date.now() - start < 200) {
+    if (predicate()) return;
+    await new Promise(resolve => setTimeout(resolve, 5));
+  }
+  throw new Error(`timed out waiting for ${label}`);
+}
+
+beforeEach(() => installSpawnMocks());
+afterAll(() => {
+  (Bun as any).spawn = originalSpawn;
+  (Bun as any).spawnSync = originalSpawnSync;
+});
+
+describe("PTY attach scrollback replay (#1588)", async () => {
+  const { handlePtyMessage } = await import("../../src/core/transport/pty");
+
+  async function createCachedSession(target: string) {
+    const ws = makeWs();
+    spawnSyncImpl = () => ({ stdout: encode(`initial:${target}`) });
+    const initialSpawnCount = spawnCalls.length;
+    handlePtyMessage(ws as any, JSON.stringify({ type: "attach", target, cols: 100, rows: 40 }));
+    await eventually(() => spawnCalls.length > initialSpawnCount, `initial spawn for ${target}`);
+    return ws;
+  }
+
+  test("cached attach replays captured pane bytes before attached control message", async () => {
+    const target = "replay-cache:0";
+    await createCachedSession(target);
+
+    spawnSyncImpl = (args) => {
+      expect(args).toEqual(["tmux", "capture-pane", "-t", target, "-p", "-e", "-J", "-S", "-2000"]);
+      return { stdout: encode("cached screen") };
+    };
+
+    const lateViewer = makeWs();
+    handlePtyMessage(lateViewer as any, JSON.stringify({ type: "attach", target }));
+
+    expect(lateViewer.sent.map(decode)).toEqual([
+      "cached screen",
+      "\r\n",
+      JSON.stringify({ type: "attached", target }),
+    ]);
+  });
+
+  test("fresh attach sends capture-pane bytes before spawning the live PTY", async () => {
+    const target = "replay-fresh:0";
+    const sequence: string[] = [];
+    spawnCalls = [];
+    spawnSyncImpl = () => {
+      sequence.push("capture");
+      return { stdout: encode("fresh screen") };
+    };
+    (Bun as any).spawn = (args: unknown[]) => {
+      sequence.push(`spawn:${JSON.stringify(args)}`);
+      spawnCalls.push(args);
+      return {
+        stdin: { write() {}, flush() {} },
+        stdout: { getReader: () => ({ read: () => new Promise<never>(() => {}) }) },
+        kill() {},
+      };
+    };
+
+    const viewer = makeWs();
+    const originalSend = viewer.send.bind(viewer);
+    viewer.send = (data: unknown) => {
+      sequence.push(`send:${decode(data)}`);
+      originalSend(data);
+    };
+
+    handlePtyMessage(viewer as any, JSON.stringify({ type: "attach", target, cols: 100, rows: 40 }));
+    await eventually(() => spawnCalls.length === 1, `fresh spawn for ${target}`);
+
+    expect(sequence.slice(0, 4)).toEqual([
+      "capture",
+      "send:fresh screen",
+      "send:\r\n",
+      expect.stringContaining("spawn:"),
+    ]);
+  });
+
+  test("capture-pane failure does not abort cached attach", async () => {
+    const target = "replay-fail:0";
+    await createCachedSession(target);
+
+    spawnSyncImpl = () => { throw new Error("tmux target disappeared"); };
+    const lateViewer = makeWs();
+    handlePtyMessage(lateViewer as any, JSON.stringify({ type: "attach", target }));
+
+    expect(lateViewer.sent.map(decode)).toEqual([
+      JSON.stringify({ type: "attached", target }),
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1588 by carrying PR #1587's PTY replay idea onto the current `alpha` lane with regression coverage.

- cached PTY viewers now receive bounded `tmux capture-pane -p -e -J -S -2000` bytes before `{type:"attached"}`;
- fresh PTY attach also seeds capture-pane bytes before spawning the live PTY bridge;
- capture failures remain non-fatal because tmux targets can disappear.

## Why not merge #1587 directly?

PR #1587 currently targets `main` from a stale base. The active maw-js lane is alpha-only, and retargeting that branch would show a large unrelated alpha-vs-main diff. This PR is the same narrow fix rebuilt from current `alpha`.

## Test plan

- [x] `bun test test/isolated/pty-attach-replay.test.ts` → 3 pass / 0 fail
- [x] `bun run test:isolated` → 107/107 files passed, 0 failed
- [x] `bun run build` OK
- [ ] PR CI
- [ ] Live browser/xterm cached office modal attach on m5 (not run locally)

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
