### PR TITLE
feat(plugin): run wake lifecycle hooks

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -7,6 +7,7 @@ import { assertValidOracleName } from "../../core/fleet/validate";
 import { resolveOracle, findWorktrees, getSessionMap, resolveFleetSession, detectSession, setSessionEnv, sanitizeBranchName } from "./wake-resolve";
 import { attachToSession, ensureSessionRunning, createWorktree } from "./wake-session";
 import { maybeOpenWindow, maybeSplit } from "./wake-maybe-split";
+import { runWakeLifecycleHooks } from "../../plugin/lifecycle";
 import { parseWakeTarget, ensureCloned } from "./wake-target";
 import { assertAgentCapacity } from "./wake-concurrency";
 import { writeSignal } from "../../core/fleet/leaf";
@@ -391,6 +392,8 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
       console.log(`\x1b[32m+\x1b[0m team '${oracle}' auto-created`);
     }
 
+    await runWakeLifecycleHooks({ oracle, session, repoPath, repoName });
+
     if (!opts.task && !opts.wt && !opts.noRehydrate) {
       const allWt = await findWorktrees(parentDir, repoName);
       for (const wt of planRehydrateWorktreeWindows(oracle, allWt)) {
@@ -402,6 +405,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
     }
   } else {
     await setSessionEnv(session);
+    await runWakeLifecycleHooks({ oracle, session, repoPath, repoName });
     let preExistingWindows = new Set<string>();
     try { preExistingWindows = new Set((await tmux.listWindows(session)).map(w => w.name)); } catch { /* ok */ }
 

--- a/src/plugin/lifecycle.ts
+++ b/src/plugin/lifecycle.ts
@@ -1,0 +1,139 @@
+/**
+ * Plugin lifecycle runner (#1576).
+ *
+ * Manifest parsing already preserves hooks.wake/sleep/serve. This module is the
+ * first execution surface: deterministic, enabled-plugin-only, TS/JS module
+ * hooks with explicit failure policy.
+ */
+
+import { existsSync, realpathSync } from "fs";
+import { resolve, sep } from "path";
+import { pathToFileURL } from "url";
+import { discoverPackages } from "./registry";
+import type { LoadedPlugin, PluginLifecycleHook } from "./types";
+
+export type LifecyclePhase = "wake" | "sleep" | "serve";
+
+export interface PluginLifecycleContext {
+  phase: LifecyclePhase;
+  plugin: { name: string; dir: string };
+  oracle?: string;
+  session?: string;
+  repoPath?: string;
+  repoName?: string;
+  ensures?: string[];
+}
+
+export interface WakeLifecycleContextInput {
+  oracle: string;
+  session: string;
+  repoPath: string;
+  repoName: string;
+}
+
+export interface LifecycleRunSummary {
+  phase: LifecyclePhase;
+  ran: number;
+  skipped: number;
+  failed: number;
+}
+
+export type LifecycleDiscover = () => LoadedPlugin[];
+
+function sortByLifecycleOrder(plugins: LoadedPlugin[]): LoadedPlugin[] {
+  return [...plugins].sort((a, b) =>
+    (a.manifest.weight ?? 50) - (b.manifest.weight ?? 50)
+    || a.manifest.name.localeCompare(b.manifest.name),
+  );
+}
+
+function messageOf(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+function resolveHookModulePath(plugin: LoadedPlugin, hook: PluginLifecycleHook): string {
+  const pluginRoot = realpathSync(plugin.dir);
+  const rawPath = hook.script
+    ? resolve(plugin.dir, hook.script)
+    : plugin.entryPath;
+
+  if (!rawPath) {
+    throw new Error("lifecycle hook needs hooks.<phase>.script or plugin entry");
+  }
+
+  if (!existsSync(rawPath)) {
+    throw new Error(`lifecycle hook script missing: ${hook.script ?? rawPath}`);
+  }
+
+  const realPath = realpathSync(rawPath);
+  if (realPath !== pluginRoot && !realPath.startsWith(pluginRoot + sep)) {
+    throw new Error(`lifecycle hook script escapes plugin dir: ${hook.script ?? rawPath}`);
+  }
+  return realPath;
+}
+
+async function runOneLifecycleHook(
+  phase: LifecyclePhase,
+  plugin: LoadedPlugin,
+  hook: PluginLifecycleHook,
+  baseContext: Omit<PluginLifecycleContext, "phase" | "plugin" | "ensures">,
+): Promise<void> {
+  const modulePath = resolveHookModulePath(plugin, hook);
+  const mod = await import(pathToFileURL(modulePath).href);
+  const handlerName = hook.handler ?? phase;
+  const handler = mod[handlerName];
+  if (typeof handler !== "function") {
+    throw new Error(`lifecycle handler '${handlerName}' not exported by ${modulePath}`);
+  }
+
+  const result = await handler({
+    ...baseContext,
+    phase,
+    plugin: { name: plugin.manifest.name, dir: plugin.dir },
+    ensures: hook.ensures ?? [],
+  } satisfies PluginLifecycleContext);
+
+  if (result && typeof result === "object" && "ok" in result && result.ok === false) {
+    throw new Error(typeof result.error === "string" ? result.error : "lifecycle hook returned ok:false");
+  }
+}
+
+export async function runLifecycleHooks(
+  phase: LifecyclePhase,
+  baseContext: Omit<PluginLifecycleContext, "phase" | "plugin" | "ensures"> = {},
+  discover: LifecycleDiscover = discoverPackages,
+): Promise<LifecycleRunSummary> {
+  const summary: LifecycleRunSummary = { phase, ran: 0, skipped: 0, failed: 0 };
+
+  for (const plugin of sortByLifecycleOrder(discover())) {
+    if (plugin.disabled) { summary.skipped++; continue; }
+    const hook = plugin.manifest.hooks?.[phase];
+    if (!hook) continue;
+    if (plugin.kind !== "ts" && !hook.script) { summary.skipped++; continue; }
+
+    try {
+      await runOneLifecycleHook(phase, plugin, hook, baseContext);
+      summary.ran++;
+    } catch (error) {
+      summary.failed++;
+      const msg = messageOf(error);
+      if (hook.policy === "fail-fast") {
+        throw new Error(`plugin lifecycle ${phase} failed for ${plugin.manifest.name}: ${msg}`);
+      }
+      console.warn(`\x1b[33m⚠\x1b[0m plugin lifecycle ${phase}:${plugin.manifest.name} failed: ${msg}`);
+    }
+  }
+
+  if (summary.ran > 0) {
+    console.log(`\x1b[36m↻\x1b[0m plugin lifecycle ${phase}: ${summary.ran} hook${summary.ran === 1 ? "" : "s"}`);
+  }
+  return summary;
+}
+
+export function runWakeLifecycleHooks(
+  context: WakeLifecycleContextInput,
+  discover?: LifecycleDiscover,
+): Promise<LifecycleRunSummary> {
+  return runLifecycleHooks("wake", context, discover);
+}

--- a/test/isolated/plugin-lifecycle.test.ts
+++ b/test/isolated/plugin-lifecycle.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import type { LoadedPlugin } from "../../src/plugin/types";
+import { runLifecycleHooks, runWakeLifecycleHooks } from "../../src/plugin/lifecycle";
+
+const tempDirs: string[] = [];
+
+function makePlugin(
+  name: string,
+  opts: {
+    weight?: number;
+    disabled?: boolean;
+    hook?: LoadedPlugin["manifest"]["hooks"];
+    files?: Record<string, string>;
+    entry?: string;
+  } = {},
+): LoadedPlugin {
+  const dir = mkdtempSync(join(tmpdir(), `maw-life-${name}-`));
+  tempDirs.push(dir);
+  const entry = opts.entry ?? "index.ts";
+  const files = opts.files ?? {
+    [entry]: `export async function wake(ctx) { const fs = await import("fs"); fs.appendFileSync(process.env.MAW_LIFECYCLE_LOG, "${name}:" + ctx.oracle + ":" + ctx.session + "\\n"); }\n`,
+  };
+  for (const [rel, body] of Object.entries(files)) writeFileSync(join(dir, rel), body);
+  return {
+    dir,
+    entryPath: join(dir, entry),
+    wasmPath: "",
+    kind: "ts",
+    disabled: opts.disabled,
+    manifest: {
+      name,
+      version: "1.0.0",
+      sdk: "*",
+      entry,
+      weight: opts.weight,
+      hooks: opts.hook ?? { wake: {} },
+    },
+  };
+}
+
+function makeLog(): string {
+  const dir = mkdtempSync(join(tmpdir(), "maw-life-log-"));
+  tempDirs.push(dir);
+  const path = join(dir, "events.log");
+  writeFileSync(path, "");
+  process.env.MAW_LIFECYCLE_LOG = path;
+  return path;
+}
+
+afterEach(() => {
+  delete process.env.MAW_LIFECYCLE_LOG;
+  while (tempDirs.length) rmSync(tempDirs.pop()!, { recursive: true, force: true });
+});
+
+describe("plugin lifecycle hooks (#1576)", () => {
+  test("wake hooks run enabled plugins in deterministic weight/name order", async () => {
+    const log = makeLog();
+    const plugins = [
+      makePlugin("late-b", { weight: 20 }),
+      makePlugin("early", { weight: 5 }),
+      makePlugin("late-a", { weight: 20 }),
+      makePlugin("disabled", { weight: 1, disabled: true }),
+    ];
+
+    const summary = await runWakeLifecycleHooks(
+      { oracle: "mawjs", session: "47-mawjs", repoPath: "/repo", repoName: "mawjs-oracle" },
+      () => plugins,
+    );
+
+    expect(summary).toEqual({ phase: "wake", ran: 3, skipped: 1, failed: 0 });
+    expect(readFileSync(log, "utf8").trim().split("\n")).toEqual([
+      "early:mawjs:47-mawjs",
+      "late-a:mawjs:47-mawjs",
+      "late-b:mawjs:47-mawjs",
+    ]);
+  });
+
+  test("hooks.wake.script + handler runs the declared module export", async () => {
+    const log = makeLog();
+    const plugin = makePlugin("scripted", {
+      hook: { wake: { script: "setup.ts", handler: "onWake", ensures: ["storage:sqlite"] } },
+      files: {
+        "index.ts": "export function wake() { throw new Error('entry should not run') }\n",
+        "setup.ts": `export function onWake(ctx) { const fs = require("fs"); fs.appendFileSync(process.env.MAW_LIFECYCLE_LOG, ctx.plugin.name + ":" + ctx.ensures.join(",") + "\\n"); }\n`,
+      },
+    });
+
+    const summary = await runWakeLifecycleHooks(
+      { oracle: "mawjs", session: "47-mawjs", repoPath: "/repo", repoName: "mawjs-oracle" },
+      () => [plugin],
+    );
+
+    expect(summary).toEqual({ phase: "wake", ran: 1, skipped: 0, failed: 0 });
+    expect(readFileSync(log, "utf8")).toBe("scripted:storage:sqlite\n");
+  });
+
+  test("best-effort failures continue, fail-fast failures throw clearly", async () => {
+    const log = makeLog();
+    const ok = makePlugin("ok", { weight: 2 });
+    const bestEffort = makePlugin("best-effort", {
+      weight: 1,
+      hook: { wake: { policy: "best-effort" } },
+      files: { "index.ts": `export function wake() { throw new Error("soft boom"); }\n` },
+    });
+    const summary = await runWakeLifecycleHooks(
+      { oracle: "mawjs", session: "47-mawjs", repoPath: "/repo", repoName: "mawjs-oracle" },
+      () => [ok, bestEffort],
+    );
+
+    expect(summary).toEqual({ phase: "wake", ran: 1, skipped: 0, failed: 1 });
+    expect(readFileSync(log, "utf8")).toContain("ok:mawjs:47-mawjs");
+
+    const failFast = makePlugin("fatal", {
+      hook: { wake: { policy: "fail-fast" } },
+      files: { "index.ts": `export function wake() { return { ok: false, error: "fatal boom" }; }\n` },
+    });
+    await expect(runLifecycleHooks("wake", {}, () => [failFast]))
+      .rejects.toThrow(/plugin lifecycle wake failed for fatal: fatal boom/);
+  });
+});


### PR DESCRIPTION
## Summary
- adds `src/plugin/lifecycle.ts` as the first execution surface for plugin lifecycle hooks
- runs enabled TS plugin `hooks.wake` handlers after `maw wake` finds/creates the session and before worktree rehydrate
- keeps execution deterministic by manifest `weight` then plugin name, skips disabled plugins, and supports `best-effort` vs `fail-fast` hook policy

## Scope / remaining for #1576
This is a narrow wake-only slice. Remaining work for #1576: `sleep` / `serve` execution surfaces, restore-from-snapshot semantics, and richer live plugin proof/UX around failures.

## Verification
- `bun test test/isolated/plugin-lifecycle.test.ts test/plugin-manifest.test.ts`
- `bun run test:isolated`
- `bun run build`
- `bun run test` → 1262 pass / 6 skip / 0 fail

Not live-smoked against a real installed `hooks.wake` plugin yet.

Refs #1576.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
