### PR TITLE
feat(lifecycle): run plugin sleep hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "./cli/parse-args": "./src/cli/parse-args.ts",
     "./plugin/types": "./src/plugin/types.ts",
     "./plugin/manifest": "./src/plugin/manifest.ts",
+    "./plugin/lifecycle": "./src/plugin/lifecycle.ts",
     "./plugin/registry": "./src/plugin/registry.ts",
     "./core/consent": "./src/core/consent/index.ts",
     "./core/fleet/audit": "./src/core/fleet/audit.ts",

--- a/src/lib/sleep.ts
+++ b/src/lib/sleep.ts
@@ -20,6 +20,7 @@ import { detectSession } from "../commands/shared/wake";
 import { appendFile, mkdir } from "fs/promises";
 import { homedir } from "os";
 import { join } from "path";
+import { runSleepLifecycleHooks } from "../plugin/lifecycle";
 
 export async function cmdSleepOne(oracle: string, window?: string) {
   const session = await detectSession(oracle);
@@ -31,6 +32,12 @@ export async function cmdSleepOne(oracle: string, window?: string) {
 
   // Save tab order before sleeping (so wake can restore positions)
   await saveTabOrder(session);
+  await runSleepLifecycleHooks({
+    oracle,
+    target: oracle,
+    session,
+    window: windowName,
+  });
 
   let windows;
   try {

--- a/src/plugin/lifecycle.ts
+++ b/src/plugin/lifecycle.ts
@@ -19,6 +19,8 @@ export interface PluginLifecycleContext {
   plugin: { name: string; dir: string };
   oracle?: string;
   session?: string;
+  window?: string;
+  target?: string;
   repoPath?: string;
   repoName?: string;
   ensures?: string[];
@@ -29,6 +31,13 @@ export interface WakeLifecycleContextInput {
   session: string;
   repoPath: string;
   repoName: string;
+}
+
+export interface SleepLifecycleContextInput {
+  oracle: string;
+  session: string;
+  window: string;
+  target: string;
 }
 
 export interface LifecycleRunSummary {
@@ -136,4 +145,11 @@ export function runWakeLifecycleHooks(
   discover?: LifecycleDiscover,
 ): Promise<LifecycleRunSummary> {
   return runLifecycleHooks("wake", context, discover);
+}
+
+export function runSleepLifecycleHooks(
+  context: SleepLifecycleContextInput,
+  discover?: LifecycleDiscover,
+): Promise<LifecycleRunSummary> {
+  return runLifecycleHooks("sleep", context, discover);
 }

--- a/src/vendor/mpr-plugins/sleep/impl.ts
+++ b/src/vendor/mpr-plugins/sleep/impl.ts
@@ -6,6 +6,7 @@ import { appendFile, mkdir } from "fs/promises";
 import { homedir } from "os";
 import { join } from "path";
 import { takeSnapshot } from "maw-js/sdk";
+import { runSleepLifecycleHooks } from "maw-js/plugin/lifecycle";
 import { resolveSleepTarget } from "./resolve-target";
 
 /**
@@ -43,6 +44,12 @@ export async function cmdSleepOne(target: string, windowOverride?: string) {
 
   // Save tab order before sleeping (so wake can restore positions)
   await saveTabOrder(session);
+  await runSleepLifecycleHooks({
+    oracle: target,
+    target,
+    session,
+    window: windowName,
+  });
 
   await doSleep(session, windowName, target);
 }

--- a/test/isolated/plugin-lifecycle.test.ts
+++ b/test/isolated/plugin-lifecycle.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import type { LoadedPlugin } from "../../src/plugin/types";
-import { runLifecycleHooks, runWakeLifecycleHooks } from "../../src/plugin/lifecycle";
+import { runLifecycleHooks, runSleepLifecycleHooks, runWakeLifecycleHooks } from "../../src/plugin/lifecycle";
 
 const tempDirs: string[] = [];
 
@@ -95,6 +95,25 @@ describe("plugin lifecycle hooks (#1576)", () => {
 
     expect(summary).toEqual({ phase: "wake", ran: 1, skipped: 0, failed: 0 });
     expect(readFileSync(log, "utf8")).toBe("scripted:storage:sqlite\n");
+  });
+
+  test("sleep hooks receive resolved session/window context", async () => {
+    const log = makeLog();
+    const plugin = makePlugin("sleeper", {
+      hook: { sleep: { script: "cleanup.ts", handler: "onSleep" } },
+      files: {
+        "index.ts": "export function sleep() { throw new Error('entry should not run') }\n",
+        "cleanup.ts": `export function onSleep(ctx) { const fs = require("fs"); fs.appendFileSync(process.env.MAW_LIFECYCLE_LOG, [ctx.oracle, ctx.target, ctx.session, ctx.window, ctx.phase].join(":") + "\\n"); }\n`,
+      },
+    });
+
+    const summary = await runSleepLifecycleHooks(
+      { oracle: "mawjs", target: "mawjs", session: "54-mawjs", window: "mawjs-oracle" },
+      () => [plugin],
+    );
+
+    expect(summary).toEqual({ phase: "sleep", ran: 1, skipped: 0, failed: 0 });
+    expect(readFileSync(log, "utf8")).toBe("mawjs:mawjs:54-mawjs:mawjs-oracle:sleep\n");
   });
 
   test("best-effort failures continue, fail-fast failures throw clearly", async () => {

--- a/test/isolated/sleep-lifecycle.test.ts
+++ b/test/isolated/sleep-lifecycle.test.ts
@@ -1,0 +1,155 @@
+/**
+ * #1576 — `maw sleep` should execute plugin sleep lifecycle hooks before it
+ * starts sending /exit into the target pane.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import type { LoadedPlugin } from "../../src/plugin/types";
+
+let calls: string[] = [];
+let hookShouldThrow = false;
+let plugins: LoadedPlugin[] = [];
+const tempDirs: string[] = [];
+
+const session = { name: "54-mawjs", windows: [{ name: "mawjs-oracle" }] };
+
+const sdkMock = () => ({
+  listSessions: async () => {
+    calls.push("listSessions");
+    return [session];
+  },
+  saveTabOrder: async (name: string) => {
+    calls.push(`save:${name}`);
+  },
+  takeSnapshot: async (trigger: string) => {
+    calls.push(`snapshot:${trigger}`);
+    return "/tmp/snapshot.json";
+  },
+  tmux: {
+    listWindows: async (name: string) => {
+      calls.push(`listWindows:${name}`);
+      return session.windows;
+    },
+    sendKeysLiteral: async (target: string, ch: string) => {
+      calls.push(`literal:${target}:${ch}`);
+    },
+    sendKeys: async (target: string, key: string) => {
+      calls.push(`key:${target}:${key}`);
+    },
+    killWindow: async (target: string) => {
+      calls.push(`kill:${target}`);
+    },
+  },
+});
+
+const wakeMock = () => ({
+  detectSession: async (target: string) => {
+    calls.push(`detect:${target}`);
+    return session.name;
+  },
+});
+
+const fleetMock = () => ({
+  loadFleet: () => {
+    calls.push("loadFleet");
+    return [session];
+  },
+});
+
+mock.module("maw-js/sdk", sdkMock);
+mock.module("maw-js/commands/shared/wake", wakeMock);
+mock.module("maw-js/commands/shared/fleet-load", fleetMock);
+
+mock.module(join(import.meta.dir, "../../src/sdk"), sdkMock);
+mock.module(join(import.meta.dir, "../../src/commands/shared/wake"), wakeMock);
+mock.module(join(import.meta.dir, "../../src/plugin/registry"), () => ({
+  discoverPackages: () => plugins,
+}));
+
+function makeSleepPlugin(): LoadedPlugin {
+  const dir = mkdtempSync(join(tmpdir(), "maw-sleep-life-"));
+  tempDirs.push(dir);
+  const entry = "index.ts";
+  writeFileSync(join(dir, entry), `
+    export function sleep(ctx) {
+      globalThis.__mawSleepLifecycleCalls.push("hook:" + ctx.oracle + ":" + ctx.target + ":" + ctx.session + ":" + ctx.window);
+      if (globalThis.__mawSleepLifecycleThrow) throw new Error("fatal sleep hook");
+    }
+  `);
+  return {
+    dir,
+    entryPath: join(dir, entry),
+    wasmPath: "",
+    kind: "ts",
+    manifest: {
+      name: "sleep-ledger",
+      version: "1.0.0",
+      sdk: "*",
+      entry,
+      hooks: { sleep: { policy: "fail-fast" } },
+    },
+  };
+}
+
+const realSetTimeout = globalThis.setTimeout;
+
+beforeEach(() => {
+  calls = [];
+  hookShouldThrow = false;
+  (globalThis as unknown as { __mawSleepLifecycleCalls: string[] }).__mawSleepLifecycleCalls = calls;
+  (globalThis as unknown as { __mawSleepLifecycleThrow: boolean }).__mawSleepLifecycleThrow = hookShouldThrow;
+  plugins = [makeSleepPlugin()];
+  (globalThis as unknown as { setTimeout: typeof setTimeout }).setTimeout = ((fn: TimerHandler, ms?: number, ...args: unknown[]) => {
+    calls.push(`wait:${ms}`);
+    if (typeof fn === "function") fn(...args as []);
+    return 0 as unknown as ReturnType<typeof setTimeout>;
+  }) as typeof setTimeout;
+});
+
+afterEach(() => {
+  globalThis.setTimeout = realSetTimeout;
+  delete (globalThis as unknown as { __mawSleepLifecycleCalls?: string[] }).__mawSleepLifecycleCalls;
+  delete (globalThis as unknown as { __mawSleepLifecycleThrow?: boolean }).__mawSleepLifecycleThrow;
+  plugins = [];
+  while (tempDirs.length) rmSync(tempDirs.pop()!, { recursive: true, force: true });
+});
+
+const { cmdSleepOne: cmdPluginSleepOne } = await import("../../src/vendor/mpr-plugins/sleep/impl");
+const { cmdSleepOne: cmdLibSleepOne } = await import("../../src/lib/sleep");
+
+describe("sleep lifecycle hooks (#1576)", () => {
+  test("plugin sleep command runs hook after target resolution and before /exit", async () => {
+    await cmdPluginSleepOne("mawjs");
+
+    const hookIndex = calls.indexOf("hook:mawjs:mawjs:54-mawjs:mawjs-oracle");
+    const exitIndex = calls.findIndex((entry) => entry.startsWith("literal:54-mawjs:mawjs-oracle:/"));
+    expect(hookIndex).toBeGreaterThan(-1);
+    expect(exitIndex).toBeGreaterThan(-1);
+    expect(hookIndex).toBeLessThan(exitIndex);
+    expect(calls).toContain("snapshot:sleep");
+  });
+
+  test("fail-fast sleep hooks abort before sending /exit", async () => {
+    hookShouldThrow = true;
+    (globalThis as unknown as { __mawSleepLifecycleThrow: boolean }).__mawSleepLifecycleThrow = true;
+
+    await expect(cmdPluginSleepOne("mawjs")).rejects.toThrow(/plugin lifecycle sleep failed for sleep-ledger: fatal sleep hook/);
+
+    expect(calls).toContain("hook:mawjs:mawjs:54-mawjs:mawjs-oracle");
+    expect(calls.some((entry) => entry.startsWith("literal:"))).toBe(false);
+    expect(calls.some((entry) => entry.startsWith("kill:"))).toBe(false);
+    expect(calls).not.toContain("snapshot:sleep");
+  });
+
+  test("shared lib sleep path used by /api/sleep also runs hooks before /exit", async () => {
+    await cmdLibSleepOne("mawjs");
+
+    const hookIndex = calls.indexOf("hook:mawjs:mawjs:54-mawjs:mawjs-oracle");
+    const exitIndex = calls.findIndex((entry) => entry.startsWith("literal:54-mawjs:mawjs-oracle:/"));
+    expect(hookIndex).toBeGreaterThan(-1);
+    expect(exitIndex).toBeGreaterThan(-1);
+    expect(hookIndex).toBeLessThan(exitIndex);
+  });
+});


### PR DESCRIPTION
## Summary
- Extends #1576 lifecycle execution to `hooks.sleep` with a `runSleepLifecycleHooks()` wrapper and sleep context (`oracle`, `target`, `session`, `window`).
- Runs sleep hooks after target resolution / tab-order save and before `/exit` is sent, so cleanup hooks still see the live pane and `fail-fast` can abort shutdown.
- Covers both sleep entrypoints: vendored `maw sleep` plugin implementation and shared `src/lib/sleep.ts` used by `/api/sleep`.
- Exposes `maw-js/plugin/lifecycle` for in-tree/bundled plugin imports.

## Verification
- `bun test test/isolated/sleep-lifecycle.test.ts` → 3 pass / 0 fail
- `bun test test/isolated/plugin-lifecycle.test.ts` → 4 pass / 0 fail
- `bun test test/isolated/plugin-lifecycle.test.ts test/isolated/sleep-lifecycle.test.ts` → 7 pass / 0 fail
- `bun run build` → pass
- `bun run test:isolated` → 110/110 files passed, 0 failed
- `git diff --check` → clean

## Release lane
- Targets `alpha` only.
- No release-alpha/version/tag/publish step performed; Nat/human owns alpha cuts.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
