### PR TITLE
feat(lifecycle): run plugin serve hooks

### DIFF
--- a/src/cli/route-tools.ts
+++ b/src/cli/route-tools.ts
@@ -166,7 +166,7 @@ export async function routeTools(cmd: string, args: string[]): Promise<boolean> 
     const instanceName = asIdx === -1 ? null : serveArgs[asIdx + 1];
     acquirePidLock(instanceName, { forceTakeover: forceIdx !== -1 });
     const { startServer } = await import("../core/server");
-    startServer(portArg ? +portArg : 3456);
+    await startServer(portArg ? +portArg : 3456);
     return true;
   }
   return false;

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -15,6 +15,7 @@ import { listSessions } from "./transport/ssh";
 import { Tmux } from "./transport/tmux";
 import { handlePtyMessage, handlePtyClose } from "./transport/pty";
 import { setBunServer } from "../lib/elysia-auth";
+import { runServeLifecycleHooks } from "../plugin/lifecycle";
 
 // --- Version info (computed once at startup) ---
 
@@ -248,6 +249,18 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
   setBunServer(server);
   const bindNote = reason ? ` (${reason})` : "";
   console.log(`maw ${VERSION} serve → ${HTTP_URL} (${WS_URL}) [${hostname}]${bindNote}`);
+
+  try {
+    await runServeLifecycleHooks({
+      port,
+      httpUrl: HTTP_URL,
+      wsUrl: WS_URL,
+      hostname,
+    });
+  } catch (err) {
+    try { server.stop(true); } catch { /* best effort */ }
+    throw err;
+  }
 
   // HTTPS server (if TLS configured)
   const tlsCfg = loadConfig().tls;

--- a/src/plugin/lifecycle.ts
+++ b/src/plugin/lifecycle.ts
@@ -23,6 +23,10 @@ export interface PluginLifecycleContext {
   target?: string;
   repoPath?: string;
   repoName?: string;
+  port?: number;
+  httpUrl?: string;
+  wsUrl?: string;
+  hostname?: string;
   ensures?: string[];
 }
 
@@ -38,6 +42,13 @@ export interface SleepLifecycleContextInput {
   session: string;
   window: string;
   target: string;
+}
+
+export interface ServeLifecycleContextInput {
+  port: number;
+  httpUrl: string;
+  wsUrl: string;
+  hostname: string;
 }
 
 export interface LifecycleRunSummary {
@@ -152,4 +163,11 @@ export function runSleepLifecycleHooks(
   discover?: LifecycleDiscover,
 ): Promise<LifecycleRunSummary> {
   return runLifecycleHooks("sleep", context, discover);
+}
+
+export function runServeLifecycleHooks(
+  context: ServeLifecycleContextInput,
+  discover?: LifecycleDiscover,
+): Promise<LifecycleRunSummary> {
+  return runLifecycleHooks("serve", context, discover);
 }

--- a/test/isolated/plugin-lifecycle.test.ts
+++ b/test/isolated/plugin-lifecycle.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import type { LoadedPlugin } from "../../src/plugin/types";
-import { runLifecycleHooks, runSleepLifecycleHooks, runWakeLifecycleHooks } from "../../src/plugin/lifecycle";
+import { runLifecycleHooks, runServeLifecycleHooks, runSleepLifecycleHooks, runWakeLifecycleHooks } from "../../src/plugin/lifecycle";
 
 const tempDirs: string[] = [];
 
@@ -114,6 +114,25 @@ describe("plugin lifecycle hooks (#1576)", () => {
 
     expect(summary).toEqual({ phase: "sleep", ran: 1, skipped: 0, failed: 0 });
     expect(readFileSync(log, "utf8")).toBe("mawjs:mawjs:54-mawjs:mawjs-oracle:sleep\n");
+  });
+
+  test("serve hooks receive maw serve gateway context", async () => {
+    const log = makeLog();
+    const plugin = makePlugin("server", {
+      hook: { serve: { script: "serve.ts", handler: "onServe" } },
+      files: {
+        "index.ts": "export function serve() { throw new Error('entry should not run') }\n",
+        "serve.ts": `export function onServe(ctx) { const fs = require("fs"); fs.appendFileSync(process.env.MAW_LIFECYCLE_LOG, [ctx.phase, ctx.plugin.name, ctx.port, ctx.httpUrl, ctx.wsUrl, ctx.hostname].join("|") + "\\n"); }\n`,
+      },
+    });
+
+    const summary = await runServeLifecycleHooks(
+      { port: 4567, httpUrl: "http://localhost:4567", wsUrl: "ws://localhost:4567/ws", hostname: "127.0.0.1" },
+      () => [plugin],
+    );
+
+    expect(summary).toEqual({ phase: "serve", ran: 1, skipped: 0, failed: 0 });
+    expect(readFileSync(log, "utf8")).toBe("serve|server|4567|http://localhost:4567|ws://localhost:4567/ws|127.0.0.1\n");
   });
 
   test("best-effort failures continue, fail-fast failures throw clearly", async () => {


### PR DESCRIPTION
## Summary
- add `runServeLifecycleHooks()` and serve gateway context (`port`, `httpUrl`, `wsUrl`, `hostname`)
- run `hooks.serve` during `maw serve` startup after the gateway is live
- stop the newly-started server if a fail-fast serve hook aborts startup

## Validation
- `rtk bun test test/isolated/plugin-lifecycle.test.ts`
- `rtk bun run build`
- `git diff --check`
- `rtk bun run test:isolated` → 110/110 files passed
- source smoke: temp `MAW_PLUGINS_DIR` plugin with `hooks.serve`, `bun src/cli.ts serve <port> --as serve-life-smoke --force-takeover`, observed `plugin lifecycle serve: 1 hook`, hook log with gateway context, and `POST /api/probe` returned 200/ok

## Notes
- Alpha branch only. No release-alpha/version/tag/publish cut by Codex.
- This is the #1576 startup-hook slice, not the full #1566 reverse-proxy/persistent-daemon protocol.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.