### PR TITLE
feat(wake): restore windows from snapshots

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -150,7 +150,7 @@ function printBringUsage(write: (line: string) => void = console.log): void {
 }
 
 function printWakeAliasUsage(verb: "wake" | "awake", write: (line: string) => void = console.log): void {
-  write(`usage: maw ${verb} <oracle> [--task <s>] [--wt <s>] [--bud] [--signal-on-birth] [-p|--prompt <s>] [--incubate <slug>] [--fresh] [-a|--attach] [--list] [--dry-run] [--main|--solo|--no-rehydrate] [--split] [--all-local] [-e|--engine <name>]`);
+  write(`usage: maw ${verb} <oracle> [--task <s>] [--wt <s>] [--bud] [--signal-on-birth] [-p|--prompt <s>] [--incubate <slug>] [--fresh] [-a|--attach] [--list] [--dry-run] [--from-snapshot|--snapshot <id>] [--main|--solo|--no-rehydrate] [--split] [--all-local] [-e|--engine <name>]`);
   if (verb === "awake") {
     write("  Launch/start an oracle process with the selected engine. Does not send /awaken.");
     write("  Use `maw awaken` for the awakening ritual; use `maw new` for the creation door.");
@@ -158,6 +158,7 @@ function printWakeAliasUsage(verb: "wake" | "awake", write: (line: string) => vo
     write("  Wake or reuse an oracle session, fuzzy-resolving repos and worktrees as needed.");
   }
   write("  --list previews worktrees only; it does not create sessions or respawn windows.");
+  write("  --from-snapshot restores missing windows from the latest recovery snapshot; --snapshot <id> selects one.");
   write("  --bud with --task/--wt writes ψ/.lineage.yaml in the worktree (no repo/fleet mutation).");
   write("  --signal-on-birth with --bud also drops a parent ψ/memory/signals birth signal.");
 }
@@ -229,6 +230,8 @@ export async function invokeDirectHandler(
       "--attach": Boolean, "-a": "--attach",
       "--list": Boolean,
       "--dry-run": Boolean,
+      "--from-snapshot": Boolean,
+      "--snapshot": String,
       "--main": Boolean, "--solo": "--main", "--no-rehydrate": "--main",
       "--split": Boolean,
       "--all-local": Boolean,
@@ -257,6 +260,8 @@ export async function invokeDirectHandler(
       signalOnBirth?: boolean;
       allLocal?: boolean;
       engine?: string;
+      fromSnapshot?: boolean;
+      snapshotId?: string;
     } = {};
     if (flags["--task"]) opts.task = flags["--task"];
     if (flags["--wt"]) opts.wt = flags["--wt"];
@@ -268,6 +273,11 @@ export async function invokeDirectHandler(
     if (flags["--attach"]) opts.attach = true;
     if (flags["--list"]) opts.listWt = true;
     if (flags["--dry-run"]) opts.dryRun = true;
+    if (flags["--from-snapshot"]) opts.fromSnapshot = true;
+    if (flags["--snapshot"]) {
+      opts.snapshotId = flags["--snapshot"];
+      opts.fromSnapshot = true;
+    }
     if (flags["--main"]) opts.noRehydrate = true;
     if (flags["--split"]) opts.split = true;
     if (flags["--all-local"]) opts.allLocal = true;

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -11,6 +11,7 @@ import { runWakeLifecycleHooks } from "../../plugin/lifecycle";
 import { parseWakeTarget, ensureCloned } from "./wake-target";
 import { assertAgentCapacity } from "./wake-concurrency";
 import { writeSignal } from "../../core/fleet/leaf";
+import { latestSnapshot, loadSnapshot, type Snapshot, type SnapshotSession } from "../../core/fleet/snapshot";
 import { mkdirSync, writeFileSync } from "fs";
 import { join } from "path";
 
@@ -185,6 +186,35 @@ export type RehydrateWorktreePlan = {
   path: string;
 };
 
+export type SnapshotRestorePlan = {
+  windowName: string;
+  cwd: string;
+  source: "repo" | "worktree";
+};
+
+export interface WakeOptions {
+  task?: string;
+  wt?: string;
+  prompt?: string;
+  incubate?: string;
+  fresh?: boolean;
+  attach?: boolean;
+  listWt?: boolean;
+  dryRun?: boolean;
+  noRehydrate?: boolean;
+  split?: boolean;
+  bring?: boolean;
+  tab?: boolean;
+  bud?: boolean;
+  signalOnBirth?: boolean;
+  repoPath?: string;
+  urlRepoName?: string;
+  allLocal?: boolean;
+  engine?: string;
+  fromSnapshot?: boolean;
+  snapshotId?: string;
+}
+
 export function planRehydrateWorktreeWindows(
   oracle: string,
   worktrees: { name: string; path: string }[],
@@ -211,6 +241,93 @@ export function planRehydrateWorktreeWindows(
   return planned;
 }
 
+function stripFleetPrefix(name: string): string {
+  return name.replace(/^\d+-/, "");
+}
+
+export function findWakeSnapshotSession(
+  snapshot: Snapshot,
+  oracle: string,
+  session?: string | null,
+): SnapshotSession | null {
+  if (session) {
+    const exact = snapshot.sessions.find(s => s.name === session);
+    if (exact) return exact;
+  }
+
+  const oracleBase = stripFleetPrefix(oracle);
+  return snapshot.sessions.find(s => {
+    const sessionBase = stripFleetPrefix(s.name);
+    return sessionBase === oracleBase
+      || s.name === oracleBase
+      || s.name.endsWith(`-${oracleBase}`);
+  }) ?? null;
+}
+
+export function planSnapshotRestoreWindows(
+  oracle: string,
+  snapshotSession: SnapshotSession,
+  existingWindows: Iterable<string>,
+  worktrees: { name: string; path: string }[],
+  repoPath: string,
+): SnapshotRestorePlan[] {
+  const existing = new Set(existingWindows);
+  const planned: SnapshotRestorePlan[] = [];
+  const seen = new Set<string>();
+
+  for (const win of snapshotSession.windows) {
+    const windowName = win.name?.trim();
+    if (!windowName || existing.has(windowName) || seen.has(windowName)) continue;
+    seen.add(windowName);
+
+    let cwd = repoPath;
+    let source: SnapshotRestorePlan["source"] = "repo";
+    const prefix = `${oracle}-`;
+    if (windowName.startsWith(prefix)) {
+      const suffix = windowName.slice(prefix.length);
+      const wt = worktrees.find(w =>
+        w.name === suffix
+        || stripFleetPrefix(w.name) === suffix
+        || `${oracle}-${w.name}` === windowName
+        || `${oracle}-${stripFleetPrefix(w.name)}` === windowName
+      );
+      if (wt) {
+        cwd = wt.path;
+        source = "worktree";
+      }
+    }
+
+    planned.push({ windowName, cwd, source });
+  }
+
+  return planned;
+}
+
+function loadRequestedSnapshot(snapshotId?: string): Snapshot | null {
+  return snapshotId ? loadSnapshot(snapshotId) : latestSnapshot();
+}
+
+async function restoreSnapshotWindows(
+  oracle: string,
+  session: string,
+  snapshotSession: SnapshotSession,
+  existingWindows: Set<string>,
+  worktrees: { name: string; path: string }[],
+  repoPath: string,
+  engine?: string,
+): Promise<number> {
+  const planned = planSnapshotRestoreWindows(oracle, snapshotSession, existingWindows, worktrees, repoPath);
+  for (const win of planned) {
+    await tmux.newWindow(session, win.windowName, { cwd: win.cwd });
+    await new Promise(r => setTimeout(r, 300));
+    await tmux.sendText(`${session}:${win.windowName}`, buildCommandInDir(win.windowName, win.cwd, engine));
+    existingWindows.add(win.windowName);
+    const label = win.source === "worktree" ? "worktree" : "repo";
+    console.log(`\x1b[36m↻\x1b[0m snapshot window: ${win.windowName}  \x1b[90m${label}: ${win.cwd}\x1b[0m`);
+  }
+  return planned.length;
+}
+
 async function chooseWakeSessionName(oracle: string, urlRepoName?: string): Promise<string> {
   const baseName = getSessionMap()[oracle] || resolveFleetSession(oracle) || urlRepoName || oracle;
   if (/^\d+-/.test(baseName)) return baseName;
@@ -225,7 +342,7 @@ async function chooseWakeSessionName(oracle: string, urlRepoName?: string): Prom
   return `${String(maxNum + 1).padStart(2, "0")}-${baseName}`;
 }
 
-export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean; dryRun?: boolean; noRehydrate?: boolean; split?: boolean; bring?: boolean; tab?: boolean; bud?: boolean; signalOnBirth?: boolean; repoPath?: string; urlRepoName?: string; allLocal?: boolean; engine?: string }): Promise<string> {
+export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string> {
   // Canonicalize the bare name before any lookup — strips trailing `/`, `/.git`, `/.git/`
   // so `maw wake token-oracle/` (tab-completion artifact) resolves the same as `token-oracle`.
   oracle = normalizeTarget(oracle);
@@ -320,6 +437,15 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
   if (session) console.log(`\x1b[36m→\x1b[0m session exists: ${session}`);
   else console.log(`\x1b[36m→\x1b[0m no session found, creating...`);
 
+  const requestedSnapshot = opts.fromSnapshot ? loadRequestedSnapshot(opts.snapshotId) : null;
+  if (opts.fromSnapshot && !requestedSnapshot) {
+    throw new Error(opts.snapshotId ? `snapshot not found: ${opts.snapshotId}` : "no snapshot found");
+  }
+  const requestedSnapshotSession = requestedSnapshot ? findWakeSnapshotSession(requestedSnapshot, oracle, session) : null;
+  if (opts.fromSnapshot && requestedSnapshot && !requestedSnapshotSession) {
+    throw new Error(`snapshot ${requestedSnapshot.timestamp} has no session for ${oracle}`);
+  }
+
   // #835 — consult unified shouldAutoWake. cmdWake is idempotent: if the
   // session already exists, the helper returns wake=false and we skip the
   // session-create branch (we still proceed to attach/select-window below).
@@ -348,15 +474,24 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
       return session ? `${session}:${mainWindowName}` : `${oracle}:dry-run`;
     }
 
+    const allWt = await findWorktrees(parentDir, repoName);
+    const existingWindows = session
+      ? (await tmux.listWindows(session).catch(() => [] as { name: string }[])).map(w => w.name)
+      : [];
+    if (requestedSnapshotSession) {
+      const planned = planSnapshotRestoreWindows(oracle, requestedSnapshotSession, existingWindows, allWt, repoPath);
+      if (planned.length === 0) {
+        console.log(`\x1b[90m↻ would restore snapshot windows: none\x1b[0m`);
+      } else {
+        for (const win of planned) console.log(`\x1b[36m↻\x1b[0m would restore snapshot window: ${win.windowName}  \x1b[90m${win.cwd}\x1b[0m`);
+      }
+    }
+
     if (opts.noRehydrate) {
       console.log(`\x1b[90m↻ worktree rehydrate skipped (--main/--solo/--no-rehydrate)\x1b[0m`);
       return session ? `${session}:${mainWindowName}` : `${oracle}:dry-run`;
     }
 
-    const allWt = await findWorktrees(parentDir, repoName);
-    const existingWindows = session
-      ? (await tmux.listWindows(session).catch(() => [] as { name: string }[])).map(w => w.name)
-      : [];
     const liveTileRoles = session ? await getLiveTileRoles(session) : new Set<string>();
     const planned = planRehydrateWorktreeWindows(oracle, allWt, existingWindows, liveTileRoles);
     if (planned.length === 0) {
@@ -403,12 +538,20 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
 
     await runWakeLifecycleHooks({ oracle, session, repoPath, repoName });
 
+    let existingWindows = new Set((await tmux.listWindows(session).catch(() => [] as { name: string }[])).map(w => w.name));
+    if (requestedSnapshotSession) {
+      const allWt = await findWorktrees(parentDir, repoName);
+      const restored = await restoreSnapshotWindows(oracle, session, requestedSnapshotSession, existingWindows, allWt, repoPath, opts.engine);
+      console.log(`\x1b[36m↻\x1b[0m snapshot restore: ${restored} window${restored === 1 ? "" : "s"}`);
+    }
+
     if (!opts.task && !opts.wt && !opts.noRehydrate) {
       const allWt = await findWorktrees(parentDir, repoName);
-      for (const wt of planRehydrateWorktreeWindows(oracle, allWt)) {
+      for (const wt of planRehydrateWorktreeWindows(oracle, allWt, [...existingWindows])) {
         await tmux.newWindow(session, wt.windowName, { cwd: wt.path });
         await new Promise(r => setTimeout(r, 300));
         await tmux.sendText(`${session}:${wt.windowName}`, buildCommandInDir(wt.windowName, wt.path, opts.engine));
+        existingWindows.add(wt.windowName);
         console.log(`\x1b[32m+\x1b[0m window: ${wt.windowName}`);
       }
     }
@@ -417,6 +560,12 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
     await runWakeLifecycleHooks({ oracle, session, repoPath, repoName });
     let preExistingWindows = new Set<string>();
     try { preExistingWindows = new Set((await tmux.listWindows(session)).map(w => w.name)); } catch { /* ok */ }
+
+    if (requestedSnapshotSession) {
+      const allWt = await findWorktrees(parentDir, repoName);
+      const restored = await restoreSnapshotWindows(oracle, session, requestedSnapshotSession, preExistingWindows, allWt, repoPath, opts.engine);
+      console.log(`\x1b[36m↻\x1b[0m snapshot restore: ${restored} window${restored === 1 ? "" : "s"}`);
+    }
 
     if (!opts.task && !opts.wt && !opts.noRehydrate) {
       const allWt = await findWorktrees(parentDir, repoName);

--- a/src/vendor/mpr-plugins/wake/index.ts
+++ b/src/vendor/mpr-plugins/wake/index.ts
@@ -32,7 +32,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       if (!args[0]) {
         return {
           ok: false,
-          error: "usage: maw wake <oracle|org/repo|URL> [task] [--task \"<prompt>\"] [--wt <name>] [--fresh] [--attach] [--issue N] [--pr N] [--repo org/name] [--list] [--dry-run] [--main|--solo|--no-rehydrate] [--all-local] [--peer <alias>]\n       maw wake all [--kill]\n       --list previews worktrees only; no tmux session/window changes\n       --dry-run previews session/worktree rehydrate actions; --main skips worktree rehydrate\n       (--new is a deprecated alias for --wt, removed in alpha.114)",
+          error: "usage: maw wake <oracle|org/repo|URL> [task] [--task \"<prompt>\"] [--wt <name>] [--fresh] [--attach] [--issue N] [--pr N] [--repo org/name] [--list] [--dry-run] [--from-snapshot|--snapshot <id>] [--main|--solo|--no-rehydrate] [--all-local] [--peer <alias>]\n       maw wake all [--kill]\n       --list previews worktrees only; no tmux session/window changes\n       --dry-run previews session/worktree rehydrate actions; --from-snapshot previews/restores missing snapshot windows; --main skips worktree rehydrate\n       (--new is a deprecated alias for --wt, removed in alpha.114)",
         };
       }
 
@@ -54,6 +54,8 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         "--no-attach": Boolean, // #823 Bug B — register so it doesn't fall through to positional → wakeOpts.task
         "--list": Boolean, "--ls": "--list",
         "--dry-run": Boolean,
+        "--from-snapshot": Boolean,
+        "--snapshot": String,
         "--main": Boolean, "--solo": "--main", "--no-rehydrate": "--main",
         "--split": Boolean,
         "--all-local": Boolean,
@@ -69,6 +71,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         incubate?: string; fresh?: boolean; attach?: boolean; listWt?: boolean;
         dryRun?: boolean; noRehydrate?: boolean;
         split?: boolean; urlRepoName?: string; allLocal?: boolean;
+        fromSnapshot?: boolean; snapshotId?: string;
       } = {};
       let issueNum: number | null = flags["--issue"] ?? null;
       let repo: string | undefined = flags["--repo"];
@@ -90,6 +93,11 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       if (flags["--no-attach"]) wakeOpts.attach = false; // #823 Bug B — explicit opt-out; preserves default when neither flag is set
       if (flags["--list"]) wakeOpts.listWt = true;
       if (flags["--dry-run"]) wakeOpts.dryRun = true;
+      if (flags["--from-snapshot"]) wakeOpts.fromSnapshot = true;
+      if (flags["--snapshot"]) {
+        wakeOpts.snapshotId = flags["--snapshot"];
+        wakeOpts.fromSnapshot = true;
+      }
       if (flags["--main"]) wakeOpts.noRehydrate = true;
       if (flags["--split"]) wakeOpts.split = true;
       if (flags["--all-local"]) wakeOpts.allLocal = true;
@@ -124,6 +132,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     const wakeOpts: {
       task?: string; prompt?: string; wt?: string;
       fresh?: boolean; attach?: boolean; dryRun?: boolean; noRehydrate?: boolean;
+      fromSnapshot?: boolean; snapshotId?: string;
     } = {};
     if (body.task) wakeOpts.task = body.task as string;
     if (body.wt) wakeOpts.wt = body.wt as string;
@@ -141,6 +150,11 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     if (body.attach) wakeOpts.attach = true;
     if (body.dryRun) wakeOpts.dryRun = true;
     if (body.noRehydrate || body.main || body.solo) wakeOpts.noRehydrate = true;
+    if (body.fromSnapshot) wakeOpts.fromSnapshot = true;
+    if (typeof body.snapshot === "string") {
+      wakeOpts.snapshotId = body.snapshot;
+      wakeOpts.fromSnapshot = true;
+    }
 
     await cmdWake(oracle, wakeOpts);
     return { ok: true, output: logs.join("\n") || undefined };

--- a/test/isolated/wake-list-readonly.test.ts
+++ b/test/isolated/wake-list-readonly.test.ts
@@ -6,18 +6,21 @@ const wakeCmdSrc = readFileSync(join(import.meta.dir, "../../src/commands/shared
 
 describe("wake --list readonly preview (#1563)", () => {
   test("handles listWt before tmux session detection or respawn side effects", () => {
-    const listIdx = wakeCmdSrc.indexOf("if (opts.listWt)");
-    const detectIdx = wakeCmdSrc.indexOf("let session = preResolvedSession");
-    const setEnvIdx = wakeCmdSrc.indexOf("await setSessionEnv(session)");
-    const newSessionIdx = wakeCmdSrc.indexOf("await tmux.newSession");
-    const newWindowIdx = wakeCmdSrc.indexOf("await tmux.newWindow(session");
+    const cmdWakeIdx = wakeCmdSrc.indexOf("export async function cmdWake");
+    const cmdWakeSrc = wakeCmdSrc.slice(cmdWakeIdx);
+    const listIdx = cmdWakeSrc.indexOf("if (opts.listWt)");
+    const detectIdx = cmdWakeSrc.indexOf("let session = preResolvedSession");
+    const setEnvIdx = cmdWakeSrc.indexOf("await setSessionEnv(session)");
+    const newSessionIdx = cmdWakeSrc.indexOf("await tmux.newSession");
+    const newWindowIdx = cmdWakeSrc.indexOf("await tmux.newWindow(session");
 
+    expect(cmdWakeIdx).toBeGreaterThan(-1);
     expect(listIdx).toBeGreaterThan(-1);
     expect(detectIdx).toBeGreaterThan(-1);
     expect(listIdx).toBeLessThan(detectIdx);
     expect(listIdx).toBeLessThan(setEnvIdx);
     expect(listIdx).toBeLessThan(newSessionIdx);
     expect(listIdx).toBeLessThan(newWindowIdx);
-    expect(wakeCmdSrc.indexOf("if (opts.listWt)", listIdx + 1)).toBe(-1);
+    expect(cmdWakeSrc.indexOf("if (opts.listWt)", listIdx + 1)).toBe(-1);
   });
 });

--- a/test/isolated/wake-snapshot-restore-plan.test.ts
+++ b/test/isolated/wake-snapshot-restore-plan.test.ts
@@ -1,0 +1,72 @@
+/**
+ * #1576 — wake snapshot restore planning.
+ *
+ * Restore is intentionally conservative: snapshots only know window names, so
+ * the planner recreates missing windows and chooses a worktree cwd only when
+ * the window name can be mapped back to an existing worktree.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  findWakeSnapshotSession,
+  planSnapshotRestoreWindows,
+} from "../../src/commands/shared/wake-cmd";
+import type { Snapshot } from "../../src/core/fleet/snapshot";
+
+const snapshot: Snapshot = {
+  timestamp: "2026-05-16T11:00:00.000Z",
+  trigger: "wake",
+  node: "m5",
+  sessions: [
+    { name: "54-mawjs", windows: [{ name: "mawjs-oracle" }, { name: "mawjs-feature-a" }] },
+    { name: "discord", windows: [{ name: "discord-oracle" }] },
+  ],
+};
+
+describe("wake --from-snapshot planning (#1576)", () => {
+  test("finds exact session first, then numeric-prefix oracle session", () => {
+    expect(findWakeSnapshotSession(snapshot, "mawjs", "54-mawjs")?.name).toBe("54-mawjs");
+    expect(findWakeSnapshotSession(snapshot, "mawjs", null)?.name).toBe("54-mawjs");
+    expect(findWakeSnapshotSession(snapshot, "discord", null)?.name).toBe("discord");
+    expect(findWakeSnapshotSession(snapshot, "missing", null)).toBeNull();
+  });
+
+  test("plans only missing windows and maps worktree-shaped names to cwd", () => {
+    const planned = planSnapshotRestoreWindows(
+      "mawjs",
+      {
+        name: "54-mawjs",
+        windows: [
+          { name: "mawjs-oracle" },
+          { name: "mawjs-feature-a" },
+          { name: "mawjs-2-feature-b" },
+          { name: "notes" },
+          { name: "mawjs-feature-a" },
+        ],
+      },
+      ["mawjs-oracle"],
+      [
+        { name: "1-feature-a", path: "/repo/mawjs-oracle.wt-1-feature-a" },
+        { name: "2-feature-b", path: "/repo/mawjs-oracle.wt-2-feature-b" },
+      ],
+      "/repo/mawjs-oracle",
+    );
+
+    expect(planned).toEqual([
+      {
+        windowName: "mawjs-feature-a",
+        cwd: "/repo/mawjs-oracle.wt-1-feature-a",
+        source: "worktree",
+      },
+      {
+        windowName: "mawjs-2-feature-b",
+        cwd: "/repo/mawjs-oracle.wt-2-feature-b",
+        source: "worktree",
+      },
+      {
+        windowName: "notes",
+        cwd: "/repo/mawjs-oracle",
+        source: "repo",
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Refs #1576.

Adds an opt-in recovery path for `maw wake`:
- `--from-snapshot` restores missing windows from the latest fleet snapshot.
- `--snapshot <id>` restores from a selected snapshot file/prefix.
- Existing windows are skipped; duplicate snapshot window names are ignored.
- Worktree-shaped window names resolve to matching worktree cwd when possible; otherwise repo cwd is used.
- `--dry-run` previews snapshot restore, including when `--main` skips normal worktree rehydrate.

## Verification

- `rtk bun test test/isolated/wake-snapshot-restore-plan.test.ts test/isolated/wake-snapshot-after-existing.test.ts test/snapshot.test.ts` — 15 pass / 0 fail
- `rtk bun test test/isolated/wake-list-readonly.test.ts` — 1 pass / 0 fail
- `rtk bun test test/cli/dispatch-match.test.ts` — 34 pass / 0 fail
- `rtk bun run build` — pass
- `git diff --check` — clean
- `rtk bun run test:isolated` — 111/111 files passed, 0 failed
- User-visible smoke: created a disposable snapshot in a temp `MAW_CONFIG_DIR`, ran `bun src/cli.ts wake mawjs --snapshot <id> --main`, verified tmux created the missing `mawjs-zz-snapshot-smoke-*` window, then killed the window and removed temp state.

## Release lane

Targets `alpha` only. No release/tag/version cut from Codex.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
