### PR TITLE
feat(engine): proxy plugin-owned serve processes

### DIFF
--- a/src/api/engine.ts
+++ b/src/api/engine.ts
@@ -1,0 +1,63 @@
+/**
+ * Dynamic engine plugin API (#1566).
+ *
+ * Static plugin APIs are mounted in-process from manifest.api. Dynamic engine
+ * plugins own a persistent local process and register a gateway prefix that
+ * maw serve reverse-proxies to their loopback HTTP server.
+ */
+
+import { Elysia, t } from "elysia";
+import {
+  listEnginePluginRegistrations,
+  registerEnginePlugin,
+  unregisterEnginePlugin,
+} from "../core/engine-plugin-registry";
+
+export const engineApi = new Elysia();
+
+engineApi.get("/_engine/registrations", () => ({
+  ok: true,
+  registrations: listEnginePluginRegistrations(),
+}));
+
+engineApi.post(
+  "/_engine/register",
+  ({ body, set }) => {
+    try {
+      const registration = registerEnginePlugin(body);
+      set.status = 201;
+      return { ok: true, bound: true, registration };
+    } catch (err) {
+      set.status = 400;
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  },
+  {
+    body: t.Object({
+      plugin: t.String(),
+      prefix: t.String(),
+      upstream: t.String(),
+      events: t.Optional(t.Array(t.String())),
+      health: t.Optional(t.String()),
+    }),
+  },
+);
+
+engineApi.post(
+  "/_engine/unregister",
+  ({ body, set }) => {
+    try {
+      const removed = unregisterEnginePlugin(body);
+      return { ok: true, removed };
+    } catch (err) {
+      set.status = 400;
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  },
+  {
+    body: t.Object({
+      plugin: t.Optional(t.String()),
+      prefix: t.Optional(t.String()),
+    }),
+  },
+);

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -28,6 +28,7 @@ import { pairApi } from "./pair";
 import { consentApi } from "./consent";
 import { claudeFleetApi } from "./claude-fleet";
 import { peerDiscoveriesApi } from "./peers-discoveries";
+import { engineApi } from "./engine";
 import { discoverPackages, invokePlugin } from "../plugin/registry";
 import { federationAuth, fromSigningAuth } from "../lib/elysia-auth";
 
@@ -73,7 +74,8 @@ export const api = new Elysia({ prefix: "/api" })
   .use(pairApi)
   .use(consentApi)
   .use(claudeFleetApi)
-  .use(peerDiscoveriesApi);
+  .use(peerDiscoveriesApi)
+  .use(engineApi);
 
 // Snapshot direct-handler routes before plugin auto-mount (#705)
 const directRoutes = new Set(

--- a/src/core/engine-plugin-registry.ts
+++ b/src/core/engine-plugin-registry.ts
@@ -1,0 +1,229 @@
+import { NAME_RE } from "../plugin/manifest-constants";
+
+export interface EnginePluginRegistrationInput {
+  plugin: string;
+  prefix: string;
+  upstream: string;
+  events?: string[];
+  health?: string;
+}
+
+export interface EnginePluginRegistration extends EnginePluginRegistrationInput {
+  prefix: string;
+  upstream: string;
+  registeredAt: string;
+}
+
+const registrations = new Map<string, EnginePluginRegistration>();
+
+function normalizePrefix(prefix: string): string {
+  const trimmed = prefix.trim();
+  if (!trimmed.startsWith("/api/")) {
+    throw new Error("engine prefix must start with /api/");
+  }
+  if (trimmed === "/api/" || trimmed.length <= "/api/".length) {
+    throw new Error("engine prefix must include a plugin path after /api/");
+  }
+  if (trimmed.startsWith("/api/_engine")) {
+    throw new Error("engine prefix may not bind /api/_engine");
+  }
+  if (/\s/.test(trimmed) || trimmed.includes("//") || trimmed.includes("..")) {
+    throw new Error("engine prefix must be a clean absolute /api path");
+  }
+  return trimmed.replace(/\/+$/, "");
+}
+
+function normalizeUpstream(upstream: string): string {
+  let url: URL;
+  try {
+    url = new URL(upstream);
+  } catch {
+    throw new Error("engine upstream must be a URL");
+  }
+  if (url.protocol !== "http:") {
+    throw new Error("engine upstream must be loopback http:// for this alpha slice");
+  }
+  const host = url.hostname;
+  if (host !== "127.0.0.1" && host !== "localhost" && host !== "::1" && host !== "[::1]") {
+    throw new Error("engine upstream must be loopback only");
+  }
+  url.hash = "";
+  if (url.pathname !== "/") url.pathname = url.pathname.replace(/\/+$/, "");
+  return url.toString().replace(/\/$/, "");
+}
+
+function normalizeStringArray(value: string[] | undefined, field: string): string[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || value.some((v) => typeof v !== "string" || !v.trim())) {
+    throw new Error(`engine ${field} must be an array of non-empty strings`);
+  }
+  return [...new Set(value.map((v) => v.trim()))];
+}
+
+function normalizeHealth(health: string | undefined): string | undefined {
+  if (health === undefined) return undefined;
+  const trimmed = health.trim();
+  if (!trimmed || !trimmed.startsWith("/") || trimmed.includes("..") || trimmed.includes("//") || /\s/.test(trimmed)) {
+    throw new Error("engine health must be a clean absolute path");
+  }
+  return trimmed;
+}
+
+export function clearEnginePluginRegistrations(): void {
+  registrations.clear();
+}
+
+export function registerEnginePlugin(input: EnginePluginRegistrationInput): EnginePluginRegistration {
+  if (!NAME_RE.test(input.plugin)) {
+    throw new Error("engine plugin must match /^[a-z0-9-]+$/");
+  }
+  const prefix = normalizePrefix(input.prefix);
+  const upstream = normalizeUpstream(input.upstream);
+  const events = normalizeStringArray(input.events, "events");
+  const health = normalizeHealth(input.health);
+
+  // One live dynamic surface per plugin in this alpha slice. A plugin can
+  // re-register after restart and atomically replace its old binding.
+  for (const [existingPrefix, existing] of registrations) {
+    if (existing.plugin === input.plugin) registrations.delete(existingPrefix);
+  }
+
+  const registration: EnginePluginRegistration = {
+    plugin: input.plugin,
+    prefix,
+    upstream,
+    registeredAt: new Date().toISOString(),
+    ...(events ? { events } : {}),
+    ...(health ? { health } : {}),
+  };
+  registrations.set(prefix, registration);
+  return registration;
+}
+
+export function unregisterEnginePlugin(input: { plugin?: string; prefix?: string }): boolean {
+  let removed = false;
+  if (input.prefix) {
+    const prefix = normalizePrefix(input.prefix);
+    removed = registrations.delete(prefix) || removed;
+  }
+  if (input.plugin) {
+    if (!NAME_RE.test(input.plugin)) {
+      throw new Error("engine plugin must match /^[a-z0-9-]+$/");
+    }
+    for (const [prefix, registration] of registrations) {
+      if (registration.plugin === input.plugin) {
+        registrations.delete(prefix);
+        removed = true;
+      }
+    }
+  }
+  return removed;
+}
+
+export function listEnginePluginRegistrations(): EnginePluginRegistration[] {
+  return [...registrations.values()].sort((a, b) => a.prefix.localeCompare(b.prefix));
+}
+
+export function findEnginePluginRegistration(pathname: string): EnginePluginRegistration | undefined {
+  if (!pathname.startsWith("/api/") || pathname.startsWith("/api/_engine")) return undefined;
+  const candidates = [...registrations.values()]
+    .filter((registration) => pathname === registration.prefix || pathname.startsWith(`${registration.prefix}/`))
+    .sort((a, b) => b.prefix.length - a.prefix.length || a.prefix.localeCompare(b.prefix));
+  return candidates[0];
+}
+
+function targetUrlFor(req: Request, registration: EnginePluginRegistration): URL {
+  const incoming = new URL(req.url);
+  const base = new URL(registration.upstream);
+  const suffix = incoming.pathname.slice(registration.prefix.length);
+  const basePath = base.pathname === "/" ? "" : base.pathname.replace(/\/+$/, "");
+  base.pathname = `${basePath}${suffix || "/"}`;
+  base.search = incoming.search;
+  return base;
+}
+
+function targetUrlForHealth(registration: EnginePluginRegistration): URL | undefined {
+  if (!registration.health) return undefined;
+  const base = new URL(registration.upstream);
+  const basePath = base.pathname === "/" ? "" : base.pathname.replace(/\/+$/, "");
+  base.pathname = `${basePath}${registration.health}`;
+  base.search = "";
+  return base;
+}
+
+export async function checkEnginePluginHealth(registration: EnginePluginRegistration): Promise<boolean> {
+  const target = targetUrlForHealth(registration);
+  if (!target) return true;
+  try {
+    const response = await fetch(target, {
+      method: "GET",
+      headers: {
+        "x-maw-engine-plugin": registration.plugin,
+        "x-forwarded-prefix": registration.prefix,
+      },
+      signal: AbortSignal.timeout(1_000),
+    });
+    if (response.ok) return true;
+    throw new Error(`health returned ${response.status}`);
+  } catch (err) {
+    registrations.delete(registration.prefix);
+    console.warn(`[engine-plugin] unbound ${registration.plugin} at ${registration.prefix}: health check failed (${err instanceof Error ? err.message : String(err)})`);
+    return false;
+  }
+}
+
+export async function pollEnginePluginHealth(): Promise<{ checked: number; removed: number }> {
+  const current = listEnginePluginRegistrations().filter((registration) => !!registration.health);
+  let removed = 0;
+  for (const registration of current) {
+    const ok = await checkEnginePluginHealth(registration);
+    if (!ok) removed++;
+  }
+  return { checked: current.length, removed };
+}
+
+export function startEnginePluginHealthPolling(intervalMs = 5_000): () => void {
+  const timer = setInterval(() => {
+    pollEnginePluginHealth().catch((err) => {
+      console.warn(`[engine-plugin] health poll failed: ${err instanceof Error ? err.message : String(err)}`);
+    });
+  }, intervalMs);
+  timer.unref?.();
+  return () => clearInterval(timer);
+}
+
+export async function proxyEnginePluginRequest(req: Request, registration: EnginePluginRegistration): Promise<Response> {
+  const target = targetUrlFor(req, registration);
+  const headers = new Headers(req.headers);
+  headers.delete("host");
+  headers.set("x-maw-engine-plugin", registration.plugin);
+  headers.set("x-forwarded-prefix", registration.prefix);
+
+  const init: RequestInit = {
+    method: req.method,
+    headers,
+    redirect: "manual",
+  };
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    init.body = await req.arrayBuffer();
+  }
+
+  try {
+    const upstream = await fetch(target, init);
+    const responseHeaders = new Headers(upstream.headers);
+    responseHeaders.set("x-maw-engine-plugin", registration.plugin);
+    responseHeaders.set("x-forwarded-prefix", registration.prefix);
+    return new Response(upstream.body, {
+      status: upstream.status,
+      statusText: upstream.statusText,
+      headers: responseHeaders,
+    });
+  } catch (err) {
+    registrations.delete(registration.prefix);
+    console.warn(`[engine-plugin] unbound ${registration.plugin} at ${registration.prefix}: ${err instanceof Error ? err.message : String(err)}`);
+    return Response.json(
+      { ok: false, error: "engine_plugin_unavailable", plugin: registration.plugin, prefix: registration.prefix },
+      { status: 503 },
+    );
+  }
+}

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -16,6 +16,11 @@ import { Tmux } from "./transport/tmux";
 import { handlePtyMessage, handlePtyClose } from "./transport/pty";
 import { setBunServer } from "../lib/elysia-auth";
 import { runServeLifecycleHooks } from "../plugin/lifecycle";
+import {
+  findEnginePluginRegistration,
+  proxyEnginePluginRequest,
+  startEnginePluginHealthPolling,
+} from "./engine-plugin-registry";
 
 // --- Version info (computed once at startup) ---
 
@@ -197,6 +202,8 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
     }
     // Elysia handles all /api/* routes (has its own CORS)
     if (url.pathname.startsWith("/api")) {
+      const enginePlugin = findEnginePluginRegistration(url.pathname);
+      if (enginePlugin) return proxyEnginePluginRequest(req, enginePlugin);
       return api.handle(req);
     }
     // Hono handles views + static — clone response with CORS headers
@@ -247,6 +254,7 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
 
   const server = Bun.serve({ port, hostname, fetch: fetchHandler, websocket: wsHandler });
   setBunServer(server);
+  startEnginePluginHealthPolling();
   const bindNote = reason ? ` (${reason})` : "";
   console.log(`maw ${VERSION} serve → ${HTTP_URL} (${WS_URL}) [${hostname}]${bindNote}`);
 

--- a/src/lib/elysia-auth.ts
+++ b/src/lib/elysia-auth.ts
@@ -30,6 +30,8 @@ const PROTECTED = new Set([
   "/transport/send",
   "/triggers/fire",
   "/worktrees/cleanup",
+  "/_engine/register",
+  "/_engine/unregister",
 ]);
 
 /** POST-only protected (GET is public for UI, POST needs auth) */

--- a/src/plugin/manifest-parse.ts
+++ b/src/plugin/manifest-parse.ts
@@ -13,6 +13,7 @@ import {
   parseCron,
   parseModule,
   parseTransport,
+  parseEngine,
   parseTarget,
   parseCapabilityNamespaces,
   parseCapabilities,
@@ -91,6 +92,7 @@ export function parseManifest(jsonText: string, dir: string): PluginManifest {
   const cron = parseCron(r);
   const module_ = parseModule(r);
   const transport = parseTransport(r);
+  const engine = parseEngine(r);
   const target = parseTarget(r);
   const capabilityNamespaces = parseCapabilityNamespaces(r);
   const capabilities = parseCapabilities(r, capabilityNamespaces);
@@ -114,6 +116,7 @@ export function parseManifest(jsonText: string, dir: string): PluginManifest {
     ...(cron ? { cron } : {}),
     ...(module_ ? { module: module_ } : {}),
     ...(transport ? { transport } : {}),
+    ...(engine ? { engine } : {}),
     ...(target ? { target } : {}),
     ...(capabilityNamespaces ? { capabilityNamespaces } : {}),
     ...(capabilities ? { capabilities } : {}),

--- a/src/plugin/manifest-validate.ts
+++ b/src/plugin/manifest-validate.ts
@@ -163,6 +163,45 @@ export function parseTransport(r: Record<string, unknown>): PluginManifest["tran
   };
 }
 
+export function parseEngine(r: Record<string, unknown>): PluginManifest["engine"] {
+  if (r.engine === undefined) return undefined;
+  if (!r.engine || typeof r.engine !== "object" || Array.isArray(r.engine)) {
+    throw new Error("plugin.json: engine must be an object");
+  }
+  const e = r.engine as Record<string, unknown>;
+  if (e.serve === undefined) return {};
+  if (!e.serve || typeof e.serve !== "object" || Array.isArray(e.serve)) {
+    throw new Error("plugin.json: engine.serve must be an object");
+  }
+  const serve = e.serve as Record<string, unknown>;
+  if (serve.command !== undefined && (typeof serve.command !== "string" || !serve.command)) {
+    throw new Error("plugin.json: engine.serve.command must be a non-empty string");
+  }
+  if (serve.prefix !== undefined) {
+    if (typeof serve.prefix !== "string" || !serve.prefix.startsWith("/api/")) {
+      throw new Error("plugin.json: engine.serve.prefix must start with /api/");
+    }
+  }
+  if (serve.health !== undefined) {
+    if (typeof serve.health !== "string" || !serve.health.startsWith("/")) {
+      throw new Error("plugin.json: engine.serve.health must be an absolute path");
+    }
+  }
+  if (serve.events !== undefined) {
+    if (!Array.isArray(serve.events) || serve.events.some((event: unknown) => typeof event !== "string" || !event)) {
+      throw new Error("plugin.json: engine.serve.events must be an array of non-empty strings");
+    }
+  }
+  return {
+    serve: {
+      ...(typeof serve.command === "string" ? { command: serve.command } : {}),
+      ...(typeof serve.prefix === "string" ? { prefix: serve.prefix } : {}),
+      ...(typeof serve.health === "string" ? { health: serve.health } : {}),
+      ...(Array.isArray(serve.events) ? { events: serve.events as string[] } : {}),
+    },
+  };
+}
+
 export function parseTarget(r: Record<string, unknown>): PluginManifest["target"] {
   if (r.target === undefined) return undefined;
   if (typeof r.target !== "string") {

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -41,6 +41,17 @@ export interface PluginLifecycleHook {
   policy?: "best-effort" | "fail-fast";
 }
 
+export interface PluginEngineServe {
+  /** Command a future runner may use to start the persistent plugin process. */
+  command?: string;
+  /** Gateway prefix the process will register, e.g. /api/hey-ledger. */
+  prefix?: string;
+  /** Health endpoint on the plugin process, e.g. /health. */
+  health?: string;
+  /** Feed events the process wants to subscribe to through the engine. */
+  events?: string[];
+}
+
 export interface PluginManifest {
   name: string;           // unique id, slug-safe /^[a-z0-9-]+$/
   version: string;        // semver e.g. "1.0.0"
@@ -84,6 +95,9 @@ export interface PluginManifest {
   };
   transport?: {
     peer?: boolean;     // enable maw hey plugin:<name>
+  };
+  engine?: {
+    serve?: PluginEngineServe; // persistent process + reverse-proxy metadata (#1566)
   };
 }
 

--- a/test/isolated/engine-api.test.ts
+++ b/test/isolated/engine-api.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { engineApi } from "../../src/api/engine";
+import { clearEnginePluginRegistrations, listEnginePluginRegistrations } from "../../src/core/engine-plugin-registry";
+
+afterEach(() => clearEnginePluginRegistrations());
+
+describe("dynamic engine API (#1566)", () => {
+  test("registers, lists, and unregisters engine plugin routes", async () => {
+    const register = await engineApi.handle(new Request("http://maw.local/_engine/register", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        plugin: "hey-ledger",
+        prefix: "/api/hey-ledger",
+        upstream: "http://127.0.0.1:45678",
+        events: ["MessageSend"],
+        health: "/health",
+      }),
+    }));
+    const registered = await register.json() as Record<string, any>;
+
+    expect(register.status).toBe(201);
+    expect(registered.ok).toBe(true);
+    expect(registered.registration.prefix).toBe("/api/hey-ledger");
+
+    const list = await engineApi.handle(new Request("http://maw.local/_engine/registrations"));
+    const listed = await list.json() as Record<string, any>;
+    expect(listed.registrations).toHaveLength(1);
+
+    const unregister = await engineApi.handle(new Request("http://maw.local/_engine/unregister", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ plugin: "hey-ledger" }),
+    }));
+    const unregistered = await unregister.json() as Record<string, any>;
+    expect(unregistered).toMatchObject({ ok: true, removed: true });
+    expect(listEnginePluginRegistrations()).toEqual([]);
+  });
+
+  test("bad registrations return 400 instead of binding unsafe routes", async () => {
+    const response = await engineApi.handle(new Request("http://maw.local/_engine/register", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ plugin: "bad", prefix: "/api/bad", upstream: "http://example.com" }),
+    }));
+    const body = await response.json() as Record<string, unknown>;
+
+    expect(response.status).toBe(400);
+    expect(body.ok).toBe(false);
+    expect(listEnginePluginRegistrations()).toEqual([]);
+  });
+});

--- a/test/isolated/engine-plugin-registry.test.ts
+++ b/test/isolated/engine-plugin-registry.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  clearEnginePluginRegistrations,
+  findEnginePluginRegistration,
+  listEnginePluginRegistrations,
+  pollEnginePluginHealth,
+  proxyEnginePluginRequest,
+  registerEnginePlugin,
+} from "../../src/core/engine-plugin-registry";
+
+afterEach(() => clearEnginePluginRegistrations());
+
+describe("engine plugin registry (#1566)", () => {
+  test("registers loopback API prefixes and matches the longest prefix", () => {
+    const root = registerEnginePlugin({
+      plugin: "hey-ledger",
+      prefix: "/api/hey-ledger/",
+      upstream: "http://127.0.0.1:43210/",
+      events: ["MessageSend", "MessageDeliver", "MessageSend"],
+      health: "/health",
+    });
+    const nested = registerEnginePlugin({
+      plugin: "hey-ledger-admin",
+      prefix: "/api/hey-ledger/admin",
+      upstream: "http://localhost:43211/internal",
+    });
+
+    expect(root.prefix).toBe("/api/hey-ledger");
+    expect(root.events).toEqual(["MessageSend", "MessageDeliver"]);
+    expect(listEnginePluginRegistrations().map((r) => r.prefix)).toEqual([
+      "/api/hey-ledger",
+      "/api/hey-ledger/admin",
+    ]);
+    expect(findEnginePluginRegistration("/api/hey-ledger/admin/users")?.plugin).toBe(nested.plugin);
+    expect(findEnginePluginRegistration("/api/hey-ledger/messages")?.plugin).toBe(root.plugin);
+    expect(findEnginePluginRegistration("/api/_engine/register")).toBeUndefined();
+  });
+
+  test("rejects unsafe prefixes and non-loopback upstreams", () => {
+    expect(() => registerEnginePlugin({ plugin: "Bad", prefix: "/api/bad", upstream: "http://127.0.0.1:1" }))
+      .toThrow(/plugin/);
+    expect(() => registerEnginePlugin({ plugin: "bad", prefix: "/bad", upstream: "http://127.0.0.1:1" }))
+      .toThrow(/prefix/);
+    expect(() => registerEnginePlugin({ plugin: "bad", prefix: "/api/_engine/bad", upstream: "http://127.0.0.1:1" }))
+      .toThrow(/_engine/);
+    expect(() => registerEnginePlugin({ plugin: "bad", prefix: "/api/bad", upstream: "http://example.com:1" }))
+      .toThrow(/loopback/);
+  });
+
+  test("proxies requests to the registered upstream preserving suffix, query, body, and gateway headers", async () => {
+    const upstream = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      async fetch(req) {
+        const url = new URL(req.url);
+        const body = await req.text();
+        return Response.json({
+          method: req.method,
+          path: url.pathname,
+          query: url.search,
+          body,
+          plugin: req.headers.get("x-maw-engine-plugin"),
+          prefix: req.headers.get("x-forwarded-prefix"),
+        });
+      },
+    });
+    try {
+      const registration = registerEnginePlugin({
+        plugin: "hey-ledger",
+        prefix: "/api/hey-ledger",
+        upstream: `http://127.0.0.1:${upstream.port}/internal`,
+      });
+
+      const response = await proxyEnginePluginRequest(
+        new Request("http://maw.local/api/hey-ledger/items?q=1", {
+          method: "POST",
+          body: "hello",
+          headers: { "content-type": "text/plain" },
+        }),
+        registration,
+      );
+      const body = await response.json() as Record<string, unknown>;
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("x-maw-engine-plugin")).toBe("hey-ledger");
+      expect(body).toMatchObject({
+        method: "POST",
+        path: "/internal/items",
+        query: "?q=1",
+        body: "hello",
+        plugin: "hey-ledger",
+        prefix: "/api/hey-ledger",
+      });
+    } finally {
+      upstream.stop(true);
+    }
+  });
+
+  test("unregisters crashed upstreams and returns a 503", async () => {
+    const upstream = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => Response.json({ ok: true }) });
+    const registration = registerEnginePlugin({
+      plugin: "crashy",
+      prefix: "/api/crashy",
+      upstream: `http://127.0.0.1:${upstream.port}`,
+    });
+    upstream.stop(true);
+
+    const response = await proxyEnginePluginRequest(new Request("http://maw.local/api/crashy/ping"), registration);
+    const body = await response.json() as Record<string, unknown>;
+
+    expect(response.status).toBe(503);
+    expect(body).toMatchObject({ ok: false, error: "engine_plugin_unavailable", plugin: "crashy" });
+    expect(findEnginePluginRegistration("/api/crashy/ping")).toBeUndefined();
+  });
+
+  test("health polling removes dead registered plugin processes before the next request", async () => {
+    const upstream = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: (req) => new URL(req.url).pathname === "/health"
+        ? Response.json({ ok: true })
+        : Response.json({ ok: true }),
+    });
+    const registration = registerEnginePlugin({
+      plugin: "health-ledger",
+      prefix: "/api/health-ledger",
+      upstream: `http://127.0.0.1:${upstream.port}`,
+      health: "/health",
+    });
+
+    expect(await pollEnginePluginHealth()).toEqual({ checked: 1, removed: 0 });
+    expect(findEnginePluginRegistration("/api/health-ledger/messages")).toBe(registration);
+
+    upstream.stop(true);
+    expect(await pollEnginePluginHealth()).toEqual({ checked: 1, removed: 1 });
+    expect(findEnginePluginRegistration("/api/health-ledger/messages")).toBeUndefined();
+  });
+});

--- a/test/manifest-ext.test.ts
+++ b/test/manifest-ext.test.ts
@@ -226,6 +226,38 @@ describe("new manifest fields accepted", () => {
     }
   });
 
+  test("accepts engine.serve persistent process metadata", () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(join(dir, "plugin.wasm"), MINIMAL_WASM);
+      const m = parseManifest(
+        JSON.stringify({
+          name: "engine-plugin",
+          version: "1.0.0",
+          wasm: "plugin.wasm",
+          sdk: "*",
+          engine: {
+            serve: {
+              command: "bun run serve",
+              prefix: "/api/hey-ledger",
+              health: "/health",
+              events: ["MessageSend", "MessageDeliver"],
+            },
+          },
+        }),
+        dir,
+      );
+      expect(m.engine?.serve).toEqual({
+        command: "bun run serve",
+        prefix: "/api/hey-ledger",
+        health: "/health",
+        events: ["MessageSend", "MessageDeliver"],
+      });
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
   test("TS plugin with all new fields validates cleanly", () => {
     const dir = makeTempDir();
     try {
@@ -244,6 +276,7 @@ describe("new manifest fields accepted", () => {
           cron: { schedule: "*/5 * * * *" },
           module: { exports: ["doStuff"], path: "./lib.ts" },
           transport: { peer: true },
+          engine: { serve: { prefix: "/api/full", health: "/health" } },
         }),
         dir,
       );
@@ -253,6 +286,7 @@ describe("new manifest fields accepted", () => {
       expect(m.cron?.schedule).toBe("*/5 * * * *");
       expect(m.module?.exports).toEqual(["doStuff"]);
       expect(m.transport?.peer).toBe(true);
+      expect(m.engine?.serve?.prefix).toBe("/api/full");
     } finally {
       rmSync(dir, { recursive: true });
     }
@@ -382,6 +416,27 @@ describe("new field validation failures", () => {
           dir,
         ),
       ).toThrow(/capabilityNamespaces/);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  test("engine.serve with non-api prefix is rejected", () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(join(dir, "plugin.wasm"), MINIMAL_WASM);
+      expect(() =>
+        parseManifest(
+          JSON.stringify({
+            name: "bad-engine",
+            version: "1.0.0",
+            wasm: "plugin.wasm",
+            sdk: "*",
+            engine: { serve: { prefix: "/hey-ledger" } },
+          }),
+          dir,
+        ),
+      ).toThrow(/engine\.serve\.prefix/);
     } finally {
       rmSync(dir, { recursive: true });
     }


### PR DESCRIPTION
## Summary

- Add dynamic engine plugin registration API under `/api/_engine/*`.
- Let `maw serve` reverse-proxy registered `/api/<plugin>/*` prefixes to loopback plugin-owned HTTP processes.
- Store `engine.serve` manifest metadata so plugins can advertise persistent serve/process surfaces.
- Add health polling and request-failure unbind so crashed plugin processes stop serving stale routes.

## Scope notes

This is the HTTP loopback gateway slice for #1566. It intentionally does **not** start plugin processes or support `unix://` upstreams yet; those stay follow-up work behind the same manifest/registration contract.

## Verification

- `rtk bun test test/isolated/engine-plugin-registry.test.ts test/isolated/engine-api.test.ts test/manifest-ext.test.ts` → 26 pass / 0 fail
- `rtk bun test test/isolated/elysia-auth-protected.test.ts test/isolated/elysia-auth-global-scope.test.ts test/isolated/message-ledger.test.ts` → 21 pass / 0 fail
- `rtk bun run build` → OK
- `git diff --check` → clean
- `rtk bun run test:isolated` → 113/113 files passed, 0 failed
- Source smoke: temp `maw serve` gateway + temp upstream plugin process; `POST /api/_engine/register` → proxied `POST /api/smoke-proxy/echo?x=1`; killed upstream; health poll unbound route and `/api/_engine/registrations` returned empty.

Closes #1566 for the dynamic engine/reverse-proxy slice; process-start/`unix://` support can be follow-up if Nat wants it separate.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
