### PR TITLE
feat(engine): forward feed events to plugin engines

### DIFF
--- a/src/api/engine.ts
+++ b/src/api/engine.ts
@@ -38,6 +38,7 @@ engineApi.post(
       prefix: t.String(),
       upstream: t.String(),
       events: t.Optional(t.Array(t.String())),
+      eventPath: t.Optional(t.String()),
       health: t.Optional(t.String()),
     }),
   },

--- a/src/core/engine-plugin-registry.ts
+++ b/src/core/engine-plugin-registry.ts
@@ -1,10 +1,12 @@
 import { NAME_RE } from "../plugin/manifest-constants";
+import type { FeedEvent } from "../lib/feed";
 
 export interface EnginePluginRegistrationInput {
   plugin: string;
   prefix: string;
   upstream: string;
   events?: string[];
+  eventPath?: string;
   health?: string;
 }
 
@@ -61,10 +63,18 @@ function normalizeStringArray(value: string[] | undefined, field: string): strin
 }
 
 function normalizeHealth(health: string | undefined): string | undefined {
-  if (health === undefined) return undefined;
-  const trimmed = health.trim();
+  return normalizeCleanPath(health, "health");
+}
+
+function normalizeEventPath(eventPath: string | undefined): string | undefined {
+  return normalizeCleanPath(eventPath, "eventPath");
+}
+
+function normalizeCleanPath(value: string | undefined, field: string): string | undefined {
+  if (value === undefined) return undefined;
+  const trimmed = value.trim();
   if (!trimmed || !trimmed.startsWith("/") || trimmed.includes("..") || trimmed.includes("//") || /\s/.test(trimmed)) {
-    throw new Error("engine health must be a clean absolute path");
+    throw new Error(`engine ${field} must be a clean absolute path`);
   }
   return trimmed;
 }
@@ -80,6 +90,7 @@ export function registerEnginePlugin(input: EnginePluginRegistrationInput): Engi
   const prefix = normalizePrefix(input.prefix);
   const upstream = normalizeUpstream(input.upstream);
   const events = normalizeStringArray(input.events, "events");
+  const eventPath = normalizeEventPath(input.eventPath);
   const health = normalizeHealth(input.health);
 
   // One live dynamic surface per plugin in this alpha slice. A plugin can
@@ -94,6 +105,7 @@ export function registerEnginePlugin(input: EnginePluginRegistrationInput): Engi
     upstream,
     registeredAt: new Date().toISOString(),
     ...(events ? { events } : {}),
+    ...(eventPath ? { eventPath } : {}),
     ...(health ? { health } : {}),
   };
   registrations.set(prefix, registration);
@@ -144,9 +156,17 @@ function targetUrlFor(req: Request, registration: EnginePluginRegistration): URL
 
 function targetUrlForHealth(registration: EnginePluginRegistration): URL | undefined {
   if (!registration.health) return undefined;
+  return targetUrlForPath(registration, registration.health);
+}
+
+function targetUrlForEvent(registration: EnginePluginRegistration): URL {
+  return targetUrlForPath(registration, registration.eventPath ?? "/events")!;
+}
+
+function targetUrlForPath(registration: EnginePluginRegistration, path: string): URL | undefined {
   const base = new URL(registration.upstream);
   const basePath = base.pathname === "/" ? "" : base.pathname.replace(/\/+$/, "");
-  base.pathname = `${basePath}${registration.health}`;
+  base.pathname = `${basePath}${path}`;
   base.search = "";
   return base;
 }
@@ -190,6 +210,44 @@ export function startEnginePluginHealthPolling(intervalMs = 5_000): () => void {
   }, intervalMs);
   timer.unref?.();
   return () => clearInterval(timer);
+}
+
+export async function dispatchEnginePluginEvent(event: FeedEvent): Promise<{ delivered: number; failed: number; removed: number }> {
+  const current = listEnginePluginRegistrations().filter((registration) =>
+    registration.events?.includes(event.event),
+  );
+  let delivered = 0;
+  let failed = 0;
+  let removed = 0;
+
+  for (const registration of current) {
+    const target = targetUrlForEvent(registration);
+    try {
+      const response = await fetch(target, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-maw-engine-plugin": registration.plugin,
+          "x-forwarded-prefix": registration.prefix,
+        },
+        body: JSON.stringify(event),
+        signal: AbortSignal.timeout(1_000),
+      });
+      if (response.ok) {
+        delivered++;
+      } else {
+        failed++;
+        console.warn(`[engine-plugin] event delivery to ${registration.plugin} returned ${response.status} for ${event.event}`);
+      }
+    } catch (err) {
+      failed++;
+      removed++;
+      registrations.delete(registration.prefix);
+      console.warn(`[engine-plugin] unbound ${registration.plugin} at ${registration.prefix}: event delivery failed (${err instanceof Error ? err.message : String(err)})`);
+    }
+  }
+
+  return { delivered, failed, removed };
 }
 
 export async function proxyEnginePluginRequest(req: Request, registration: EnginePluginRegistration): Promise<Response> {

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -17,6 +17,7 @@ import { handlePtyMessage, handlePtyClose } from "./transport/pty";
 import { setBunServer } from "../lib/elysia-auth";
 import { runServeLifecycleHooks } from "../plugin/lifecycle";
 import {
+  dispatchEnginePluginEvent,
   findEnginePluginRegistration,
   proxyEnginePluginRequest,
   startEnginePluginHealthPolling,
@@ -117,6 +118,11 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
 
   // Hook workflow triggers into feed events
   setupTriggerListener(feedListeners);
+  feedListeners.add((event) => {
+    dispatchEnginePluginEvent(event).catch((err) => {
+      console.warn(`[engine-plugin] event dispatch failed: ${err instanceof Error ? err.message : String(err)}`);
+    });
+  });
 
   // Plugin system — built-in + user plugins
   try {

--- a/src/plugin/manifest-validate.ts
+++ b/src/plugin/manifest-validate.ts
@@ -187,6 +187,11 @@ export function parseEngine(r: Record<string, unknown>): PluginManifest["engine"
       throw new Error("plugin.json: engine.serve.health must be an absolute path");
     }
   }
+  if (serve.eventPath !== undefined) {
+    if (typeof serve.eventPath !== "string" || !serve.eventPath.startsWith("/")) {
+      throw new Error("plugin.json: engine.serve.eventPath must be an absolute path");
+    }
+  }
   if (serve.events !== undefined) {
     if (!Array.isArray(serve.events) || serve.events.some((event: unknown) => typeof event !== "string" || !event)) {
       throw new Error("plugin.json: engine.serve.events must be an array of non-empty strings");
@@ -198,6 +203,7 @@ export function parseEngine(r: Record<string, unknown>): PluginManifest["engine"
       ...(typeof serve.prefix === "string" ? { prefix: serve.prefix } : {}),
       ...(typeof serve.health === "string" ? { health: serve.health } : {}),
       ...(Array.isArray(serve.events) ? { events: serve.events as string[] } : {}),
+      ...(typeof serve.eventPath === "string" ? { eventPath: serve.eventPath } : {}),
     },
   };
 }

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -50,6 +50,8 @@ export interface PluginEngineServe {
   health?: string;
   /** Feed events the process wants to subscribe to through the engine. */
   events?: string[];
+  /** HTTP path on the plugin process that receives subscribed feed events. */
+  eventPath?: string;
 }
 
 export interface PluginManifest {

--- a/test/isolated/engine-api.test.ts
+++ b/test/isolated/engine-api.test.ts
@@ -14,6 +14,7 @@ describe("dynamic engine API (#1566)", () => {
         prefix: "/api/hey-ledger",
         upstream: "http://127.0.0.1:45678",
         events: ["MessageSend"],
+        eventPath: "/events",
         health: "/health",
       }),
     }));
@@ -22,6 +23,7 @@ describe("dynamic engine API (#1566)", () => {
     expect(register.status).toBe(201);
     expect(registered.ok).toBe(true);
     expect(registered.registration.prefix).toBe("/api/hey-ledger");
+    expect(registered.registration.eventPath).toBe("/events");
 
     const list = await engineApi.handle(new Request("http://maw.local/_engine/registrations"));
     const listed = await list.json() as Record<string, any>;

--- a/test/isolated/engine-plugin-registry.test.ts
+++ b/test/isolated/engine-plugin-registry.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
   clearEnginePluginRegistrations,
+  dispatchEnginePluginEvent,
   findEnginePluginRegistration,
   listEnginePluginRegistrations,
   pollEnginePluginHealth,
@@ -17,6 +18,7 @@ describe("engine plugin registry (#1566)", () => {
       prefix: "/api/hey-ledger/",
       upstream: "http://127.0.0.1:43210/",
       events: ["MessageSend", "MessageDeliver", "MessageSend"],
+      eventPath: "/events",
       health: "/health",
     });
     const nested = registerEnginePlugin({
@@ -27,6 +29,7 @@ describe("engine plugin registry (#1566)", () => {
 
     expect(root.prefix).toBe("/api/hey-ledger");
     expect(root.events).toEqual(["MessageSend", "MessageDeliver"]);
+    expect(root.eventPath).toBe("/events");
     expect(listEnginePluginRegistrations().map((r) => r.prefix)).toEqual([
       "/api/hey-ledger",
       "/api/hey-ledger/admin",
@@ -94,6 +97,92 @@ describe("engine plugin registry (#1566)", () => {
     } finally {
       upstream.stop(true);
     }
+  });
+
+  test("delivers subscribed feed events to plugin-owned event endpoints", async () => {
+    const seen: Array<Record<string, unknown>> = [];
+    const upstream = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      async fetch(req) {
+        const url = new URL(req.url);
+        seen.push({
+          path: url.pathname,
+          plugin: req.headers.get("x-maw-engine-plugin"),
+          prefix: req.headers.get("x-forwarded-prefix"),
+          body: await req.json(),
+        });
+        return Response.json({ ok: true });
+      },
+    });
+    try {
+      registerEnginePlugin({
+        plugin: "hey-ledger",
+        prefix: "/api/hey-ledger",
+        upstream: `http://127.0.0.1:${upstream.port}/engine`,
+        events: ["MessageSend"],
+        eventPath: "/events",
+      });
+
+      const ignored = await dispatchEnginePluginEvent({
+        timestamp: "2026-05-16T01:02:02.000Z",
+        oracle: "mawjs-codex",
+        host: "m5",
+        event: "Notification",
+        project: "",
+        sessionId: "",
+        message: "ignored",
+        ts: Date.now(),
+      });
+      const delivered = await dispatchEnginePluginEvent({
+        timestamp: "2026-05-16T01:02:03.000Z",
+        oracle: "mawjs-codex",
+        host: "m5",
+        event: "MessageSend",
+        project: "",
+        sessionId: "",
+        message: "hello",
+        ts: Date.now(),
+        data: { id: "m1", text: "hello" },
+      });
+
+      expect(ignored).toEqual({ delivered: 0, failed: 0, removed: 0 });
+      expect(delivered).toEqual({ delivered: 1, failed: 0, removed: 0 });
+      expect(seen).toHaveLength(1);
+      expect(seen[0]).toMatchObject({
+        path: "/engine/events",
+        plugin: "hey-ledger",
+        prefix: "/api/hey-ledger",
+      });
+      expect(seen[0].body).toMatchObject({ event: "MessageSend", message: "hello", data: { id: "m1" } });
+    } finally {
+      upstream.stop(true);
+    }
+  });
+
+  test("event delivery connection failures unbind crashed plugin engines", async () => {
+    const upstream = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => Response.json({ ok: true }) });
+    registerEnginePlugin({
+      plugin: "event-crashy",
+      prefix: "/api/event-crashy",
+      upstream: `http://127.0.0.1:${upstream.port}`,
+      events: ["MessageDeliver"],
+    });
+    upstream.stop(true);
+
+    const result = await dispatchEnginePluginEvent({
+      timestamp: "2026-05-16T01:02:04.000Z",
+      oracle: "mawjs-oracle",
+      host: "m5",
+      event: "MessageDeliver",
+      project: "",
+      sessionId: "",
+      message: "inbound",
+      ts: Date.now(),
+    });
+
+    expect(result).toEqual({ delivered: 0, failed: 1, removed: 1 });
+    expect(findEnginePluginRegistration("/api/event-crashy/messages")).toBeUndefined();
   });
 
   test("unregisters crashed upstreams and returns a 503", async () => {

--- a/test/manifest-ext.test.ts
+++ b/test/manifest-ext.test.ts
@@ -241,6 +241,7 @@ describe("new manifest fields accepted", () => {
               command: "bun run serve",
               prefix: "/api/hey-ledger",
               health: "/health",
+              eventPath: "/events",
               events: ["MessageSend", "MessageDeliver"],
             },
           },
@@ -251,6 +252,7 @@ describe("new manifest fields accepted", () => {
         command: "bun run serve",
         prefix: "/api/hey-ledger",
         health: "/health",
+        eventPath: "/events",
         events: ["MessageSend", "MessageDeliver"],
       });
     } finally {
@@ -276,7 +278,7 @@ describe("new manifest fields accepted", () => {
           cron: { schedule: "*/5 * * * *" },
           module: { exports: ["doStuff"], path: "./lib.ts" },
           transport: { peer: true },
-          engine: { serve: { prefix: "/api/full", health: "/health" } },
+          engine: { serve: { prefix: "/api/full", health: "/health", eventPath: "/events" } },
         }),
         dir,
       );
@@ -287,6 +289,7 @@ describe("new manifest fields accepted", () => {
       expect(m.module?.exports).toEqual(["doStuff"]);
       expect(m.transport?.peer).toBe(true);
       expect(m.engine?.serve?.prefix).toBe("/api/full");
+      expect(m.engine?.serve?.eventPath).toBe("/events");
     } finally {
       rmSync(dir, { recursive: true });
     }


### PR DESCRIPTION
## Summary
- add `eventPath` to dynamic engine registrations and `engine.serve` metadata
- forward maw feed events to registered plugin engines whose `events` list includes the event type
- default event delivery endpoint to `/events` and unbind crashed plugin engines on connection failure
- wire the bridge into `maw serve` feed listeners so out-of-process ledger plugins can observe message lifecycle events

Refs #1566.

## Verification
- `rtk bun test test/isolated/engine-plugin-registry.test.ts test/isolated/engine-api.test.ts test/manifest-ext.test.ts` → 28 pass / 0 fail
- `rtk bun test test/isolated/elysia-auth-protected.test.ts test/isolated/elysia-auth-global-scope.test.ts test/isolated/message-ledger.test.ts` → 21 pass / 0 fail
- `rtk bun run build` → OK
- `git diff --check` → clean
- `rtk bun run test:isolated` → 113/113 files passed, 0 failed
- Source smoke: temp `maw serve` gateway + temp upstream; register events-proxy; `POST /api/feed` `Notification` ignored; `POST /api/feed` `MessageSend` delivered to upstream `/events`; kill upstream; next `MessageSend` unbinds route.

## Follow-ups intentionally not included
- `maw <plugin> serve` process start/stop UX
- `unix://` upstream transport

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
