### PR TITLE
feat(messages): serve ledger as an engine plugin

### DIFF
--- a/src/vendor/mpr-plugins/messages/index.ts
+++ b/src/vendor/mpr-plugins/messages/index.ts
@@ -3,6 +3,9 @@ import { isMessageLifecycleData, type MessageDirection, type MessageState } from
 import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { listMessageLedgerEvents, messageLedgerDbPath, recordMessageLedgerEvent, type MessageLedgerQuery } from "./ledger";
 
+const ENGINE_PREFIX = "/api/message-ledger";
+const ENGINE_EVENTS = ["MessageSend", "MessageDeliver", "MessageFail"];
+
 export const command = {
   name: "messages",
   description: "Query the SQLite-backed maw hey/message lifecycle ledger.",
@@ -45,6 +48,12 @@ function state(value: unknown): MessageState | undefined {
   return value === "queued" || value === "delivered" || value === "failed" ? value : undefined;
 }
 
+function numberOption(value: unknown): number | undefined {
+  if (value === undefined || value === null || value === "") return undefined;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : undefined;
+}
+
 function queryFrom(ctx: InvokeContext): MessageLedgerQuery & { json: boolean } {
   const args = cliArgs(ctx);
   const query = argsObject(ctx);
@@ -57,6 +66,17 @@ function queryFrom(ctx: InvokeContext): MessageLedgerQuery & { json: boolean } {
     state: state(readOption(args, "--state") ?? query.state),
     q: readOption(args, "--q") ?? (typeof query.q === "string" ? query.q : undefined),
     json: args.includes("--json") || boolish(query.json) || ctx.source === "api",
+  };
+}
+
+function queryFromUrl(url: URL): MessageLedgerQuery {
+  return {
+    limit: numberOption(url.searchParams.get("limit")) ?? 100,
+    from: url.searchParams.get("from") ?? undefined,
+    to: url.searchParams.get("to") ?? undefined,
+    direction: direction(url.searchParams.get("direction")),
+    state: state(url.searchParams.get("state")),
+    q: url.searchParams.get("q") ?? undefined,
   };
 }
 
@@ -75,8 +95,111 @@ function short(value: string, max = 90): string {
   return value.length > max ? `${value.slice(0, max - 1)}…` : value;
 }
 
+function engineUrlFromArgs(args: string[]): string {
+  const raw = readOption(args, "--engine") ?? process.env.MAW_ENGINE_URL ?? `http://127.0.0.1:${process.env.MAW_PORT || "3456"}`;
+  return raw.replace(/\/+$/, "");
+}
+
+function parsePort(args: string[]): number {
+  const raw = readOption(args, "--port") ?? process.env.MAW_MESSAGES_PORT ?? "0";
+  const port = Number(raw);
+  if (!Number.isInteger(port) || port < 0 || port > 65535) {
+    throw new Error(`invalid --port: ${raw}`);
+  }
+  return port;
+}
+
+function isRecordableMessageEvent(event: unknown): event is FeedEvent {
+  if (!event || typeof event !== "object") return false;
+  const e = event as FeedEvent;
+  return ENGINE_EVENTS.includes(e.event) && isMessageLifecycleData(e.data);
+}
+
+export async function messagesEngineFetch(req: Request): Promise<Response> {
+  const url = new URL(req.url);
+  if (req.method === "GET" && url.pathname === "/health") {
+    return Response.json({ ok: true, plugin: "messages", dbPath: messageLedgerDbPath() });
+  }
+  if (req.method === "POST" && url.pathname === "/events") {
+    const event = await req.json().catch(() => null);
+    const recorded = isRecordableMessageEvent(event);
+    if (recorded) recordMessageLedgerEvent(event.data);
+    return Response.json({ ok: true, recorded });
+  }
+  if (req.method === "GET" && (url.pathname === "/" || url.pathname === "/messages")) {
+    const messages = listMessageLedgerEvents(queryFromUrl(url));
+    return Response.json({ ok: true, messages, total: messages.length, source: "sqlite", dbPath: messageLedgerDbPath() });
+  }
+  return Response.json({ ok: false, error: "not_found" }, { status: 404 });
+}
+
+async function registerWithEngine(engineUrl: string, upstream: string): Promise<void> {
+  const response = await fetch(`${engineUrl}/api/_engine/register`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      plugin: "messages",
+      prefix: ENGINE_PREFIX,
+      upstream,
+      events: ENGINE_EVENTS,
+      eventPath: "/events",
+      health: "/health",
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(`engine register failed ${response.status}: ${await response.text()}`);
+  }
+}
+
+async function unregisterFromEngine(engineUrl: string): Promise<void> {
+  await fetch(`${engineUrl}/api/_engine/unregister`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ plugin: "messages", prefix: ENGINE_PREFIX }),
+  }).catch(() => undefined);
+}
+
+async function serveEngine(ctx: InvokeContext, args: string[]): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const engineUrl = engineUrlFromArgs(args);
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: parsePort(args),
+    fetch: messagesEngineFetch,
+  });
+  const upstream = `http://127.0.0.1:${server.port}`;
+
+  try {
+    await registerWithEngine(engineUrl, upstream);
+  } catch (err) {
+    server.stop(true);
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+
+  emit(ctx, logs, `maw messages serve → ${upstream} (registered ${ENGINE_PREFIX} on ${engineUrl})`);
+  emit(ctx, logs, `events: ${ENGINE_EVENTS.join(", ")} → /events`);
+
+  let shuttingDown = false;
+  const shutdown = () => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    unregisterFromEngine(engineUrl).finally(() => {
+      server.stop(true);
+      process.exit(0);
+    });
+  };
+  process.once("SIGTERM", shutdown);
+  process.once("SIGINT", shutdown);
+
+  await new Promise(() => undefined);
+  return { ok: true, output: logs.join("\n") };
+}
+
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult & Record<string, unknown>> {
   const logs: string[] = [];
+  const args = cliArgs(ctx);
+  if (args[0] === "serve") return serveEngine(ctx, args.slice(1));
+
   const query = queryFrom(ctx);
   const rows = listMessageLedgerEvents(query);
   const payload = { ok: true, messages: rows, total: rows.length, dbPath: messageLedgerDbPath() };

--- a/src/vendor/mpr-plugins/messages/plugin.json
+++ b/src/vendor/mpr-plugins/messages/plugin.json
@@ -24,15 +24,30 @@
       "GET"
     ]
   },
+  "engine": {
+    "serve": {
+      "command": "maw messages serve",
+      "prefix": "/api/message-ledger",
+      "health": "/health",
+      "eventPath": "/events",
+      "events": [
+        "MessageSend",
+        "MessageDeliver",
+        "MessageFail"
+      ]
+    }
+  },
   "cli": {
     "command": "messages",
     "aliases": [
       "message-log",
       "hey-log"
     ],
-    "help": "maw messages [--limit N] [--from ID] [--to ID] [--direction outbound|inbound|forwarded] [--state queued|delivered|failed] [--q text] [--json] \u2014 query the message ledger",
+    "help": "maw messages [serve [--engine URL] [--port N] | --limit N --from ID --to ID --direction outbound|inbound|forwarded --state queued|delivered|failed --q text --json] \u2014 query or serve the message ledger",
     "flags": {
+      "--engine": "string",
       "--limit": "number",
+      "--port": "number",
       "--from": "string",
       "--to": "string",
       "--direction": "string",

--- a/test/isolated/message-ledger.test.ts
+++ b/test/isolated/message-ledger.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "os";
 import { join } from "path";
 import { buildMessageLifecycleFeedEvent } from "../../src/lib/message-events";
 import { listMessageLedgerEvents, messageLedgerDbPath, recordMessageLedgerEvent } from "../../src/vendor/mpr-plugins/messages/ledger";
-import { onEvent } from "../../src/vendor/mpr-plugins/messages/index";
+import { messagesEngineFetch, onEvent } from "../../src/vendor/mpr-plugins/messages/index";
 import { messagesHtml, messagesView } from "../../src/views/messages";
 import type { FeedEvent } from "../../src/lib/feed";
 
@@ -124,5 +124,47 @@ describe("messages browser view", () => {
 
     expect(html).toContain("textContent");
     expect(html).not.toContain("innerHTML");
+  });
+});
+
+describe("messages engine serve surface", () => {
+  test("serves health, query, and event ingestion endpoints", async () => {
+    const health = await messagesEngineFetch(new Request("http://plugin.local/health"));
+    await expect(health.json()).resolves.toMatchObject({ ok: true, plugin: "messages" });
+
+    const event = buildMessageLifecycleFeedEvent({
+      id: "engine-1",
+      ts: "2026-05-16T01:05:03.000Z",
+      direction: "outbound",
+      state: "delivered",
+      channel: "hey",
+      route: "local",
+      from: "m5:mawjs-codex",
+      to: "m5:mawjs-oracle",
+      text: "engine event",
+      signed: true,
+    }) as FeedEvent;
+
+    const ingest = await messagesEngineFetch(new Request("http://plugin.local/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(event),
+    }));
+    await expect(ingest.json()).resolves.toMatchObject({ ok: true, recorded: true });
+
+    const ignored = await messagesEngineFetch(new Request("http://plugin.local/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ event: "Notification", message: "ignore" }),
+    }));
+    await expect(ignored.json()).resolves.toMatchObject({ ok: true, recorded: false });
+
+    const query = await messagesEngineFetch(new Request("http://plugin.local/?limit=5&q=engine"));
+    await expect(query.json()).resolves.toMatchObject({
+      ok: true,
+      total: 1,
+      source: "sqlite",
+      messages: [{ id: "engine-1", text: "engine event" }],
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add `engine.serve` metadata to the bundled `messages` ledger plugin
- add `maw messages serve [--engine URL] [--port N]` as a foreground plugin-owned HTTP process
- expose `/health`, `/events`, and query endpoints from that plugin process
- register `/api/message-ledger` with the engine gateway so feed events can be delivered out-of-process while the in-process hook/API path remains the default fallback

Refs #1566.

## Verification
- `rtk bun test test/isolated/message-ledger.test.ts test/manifest-ext.test.ts` → 25 pass / 0 fail
- `rtk bun test test/isolated/engine-plugin-registry.test.ts test/isolated/engine-api.test.ts test/isolated/message-ledger.test.ts test/manifest-ext.test.ts` → 34 pass / 0 fail
- `rtk bun run build` → OK
- `git diff --check` → clean
- Linked smoke with isolated `MAW_HOME`: temp `maw serve` gateway + `maw messages serve --engine <gateway>`; engine registration appeared for `/api/message-ledger`; `POST /api/feed` `MessageSend` recorded through `/events`; `GET /api/message-ledger?q=serve%20smoke` returned the SQLite row; stopping the plugin process unregistered it.

## Follow-ups intentionally not included
- detached supervisor/start-stop daemon UX
- `unix://` upstream transport

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
