### PR TITLE
feat(engine): support unix plugin upstreams

### DIFF
--- a/src/core/engine-plugin-registry.ts
+++ b/src/core/engine-plugin-registry.ts
@@ -1,5 +1,7 @@
 import { NAME_RE } from "../plugin/manifest-constants";
 import type { FeedEvent } from "../lib/feed";
+import { homedir, tmpdir } from "os";
+import { resolve, sep } from "path";
 
 export interface EnginePluginRegistrationInput {
   plugin: string;
@@ -17,6 +19,9 @@ export interface EnginePluginRegistration extends EnginePluginRegistrationInput 
 }
 
 const registrations = new Map<string, EnginePluginRegistration>();
+
+type EngineFetchTarget = { url: URL; unix?: string };
+type BunUnixRequestInit = RequestInit & { unix?: string };
 
 function normalizePrefix(prefix: string): string {
   const trimmed = prefix.trim();
@@ -36,14 +41,21 @@ function normalizePrefix(prefix: string): string {
 }
 
 function normalizeUpstream(upstream: string): string {
+  const raw = upstream.trim();
+  if (raw.startsWith("unix:") && /(?:\.\.|%2e)/i.test(raw)) {
+    throw new Error("engine unix upstream path must not contain traversal");
+  }
   let url: URL;
   try {
-    url = new URL(upstream);
+    url = new URL(raw);
   } catch {
     throw new Error("engine upstream must be a URL");
   }
+  if (url.protocol === "unix:") {
+    return normalizeUnixUpstream(url);
+  }
   if (url.protocol !== "http:") {
-    throw new Error("engine upstream must be loopback http:// for this alpha slice");
+    throw new Error("engine upstream must be loopback http:// or local unix://");
   }
   const host = url.hostname;
   if (host !== "127.0.0.1" && host !== "localhost" && host !== "::1" && host !== "[::1]") {
@@ -52,6 +64,53 @@ function normalizeUpstream(upstream: string): string {
   url.hash = "";
   if (url.pathname !== "/") url.pathname = url.pathname.replace(/\/+$/, "");
   return url.toString().replace(/\/$/, "");
+}
+
+function normalizeUnixUpstream(url: URL): string {
+  if (url.hostname || url.search || url.hash) {
+    throw new Error("engine unix upstream must be unix:///absolute/path.sock with no host, query, or hash");
+  }
+  const socketPath = decodeURIComponent(url.pathname);
+  return `unix://${normalizeUnixSocketPath(socketPath)}`;
+}
+
+function activeMawHome(): string {
+  return process.env.MAW_HOME || `${homedir()}/.maw`;
+}
+
+function isInside(path: string, root: string): boolean {
+  const normalizedRoot = resolve(root);
+  return path === normalizedRoot || path.startsWith(`${normalizedRoot}${sep}`);
+}
+
+function normalizeUnixSocketPath(socketPath: string): string {
+  if (!socketPath.startsWith("/")) {
+    throw new Error("engine unix upstream must use an absolute socket path");
+  }
+  if (socketPath.includes("\0") || /\s/.test(socketPath)) {
+    throw new Error("engine unix upstream path must not contain null bytes or whitespace");
+  }
+  if (!socketPath.endsWith(".sock")) {
+    throw new Error("engine unix upstream path must end with .sock");
+  }
+  const normalized = resolve(socketPath);
+  if (normalized !== socketPath) {
+    throw new Error("engine unix upstream path must not contain traversal");
+  }
+
+  // Do not let a dynamic engine registration turn maw into a reverse proxy for
+  // privileged local sockets such as /var/run/docker.sock. Plugin sockets must
+  // live in operator-owned temp space or MAW_HOME.
+  const allowedRoots = [
+    tmpdir(),
+    "/tmp",
+    "/private/tmp",
+    activeMawHome(),
+  ].map((root) => resolve(root));
+  if (!allowedRoots.some((root) => isInside(normalized, root))) {
+    throw new Error("engine unix upstream path must live under tmpdir or MAW_HOME");
+  }
+  return normalized;
 }
 
 function normalizeStringArray(value: string[] | undefined, field: string): string[] | undefined {
@@ -144,7 +203,26 @@ export function findEnginePluginRegistration(pathname: string): EnginePluginRegi
   return candidates[0];
 }
 
-function targetUrlFor(req: Request, registration: EnginePluginRegistration): URL {
+function isUnixUpstream(upstream: string): boolean {
+  return upstream.startsWith("unix://");
+}
+
+function unixSocketPath(upstream: string): string {
+  return upstream.slice("unix://".length);
+}
+
+function targetForRequest(req: Request, registration: EnginePluginRegistration): EngineFetchTarget {
+  if (isUnixUpstream(registration.upstream)) {
+    const incoming = new URL(req.url);
+    const suffix = incoming.pathname.slice(registration.prefix.length);
+    const target = new URL(`http://localhost${suffix || "/"}`);
+    target.search = incoming.search;
+    return { url: target, unix: unixSocketPath(registration.upstream) };
+  }
+  return { url: targetUrlForHttp(req, registration) };
+}
+
+function targetUrlForHttp(req: Request, registration: EnginePluginRegistration): URL {
   const incoming = new URL(req.url);
   const base = new URL(registration.upstream);
   const suffix = incoming.pathname.slice(registration.prefix.length);
@@ -154,28 +232,36 @@ function targetUrlFor(req: Request, registration: EnginePluginRegistration): URL
   return base;
 }
 
-function targetUrlForHealth(registration: EnginePluginRegistration): URL | undefined {
+function targetForHealth(registration: EnginePluginRegistration): EngineFetchTarget | undefined {
   if (!registration.health) return undefined;
-  return targetUrlForPath(registration, registration.health);
+  return targetForPath(registration, registration.health);
 }
 
-function targetUrlForEvent(registration: EnginePluginRegistration): URL {
-  return targetUrlForPath(registration, registration.eventPath ?? "/events")!;
+function targetForEvent(registration: EnginePluginRegistration): EngineFetchTarget {
+  return targetForPath(registration, registration.eventPath ?? "/events")!;
 }
 
-function targetUrlForPath(registration: EnginePluginRegistration, path: string): URL | undefined {
+function targetForPath(registration: EnginePluginRegistration, path: string): EngineFetchTarget | undefined {
+  if (isUnixUpstream(registration.upstream)) {
+    return { url: new URL(`http://localhost${path}`), unix: unixSocketPath(registration.upstream) };
+  }
   const base = new URL(registration.upstream);
   const basePath = base.pathname === "/" ? "" : base.pathname.replace(/\/+$/, "");
   base.pathname = `${basePath}${path}`;
   base.search = "";
-  return base;
+  return { url: base };
+}
+
+function engineFetch(target: EngineFetchTarget, init: RequestInit): Promise<Response> {
+  const opts: BunUnixRequestInit = target.unix ? { ...init, unix: target.unix } : init;
+  return fetch(target.url, opts);
 }
 
 export async function checkEnginePluginHealth(registration: EnginePluginRegistration): Promise<boolean> {
-  const target = targetUrlForHealth(registration);
+  const target = targetForHealth(registration);
   if (!target) return true;
   try {
-    const response = await fetch(target, {
+    const response = await engineFetch(target, {
       method: "GET",
       headers: {
         "x-maw-engine-plugin": registration.plugin,
@@ -221,9 +307,9 @@ export async function dispatchEnginePluginEvent(event: FeedEvent): Promise<{ del
   let removed = 0;
 
   for (const registration of current) {
-    const target = targetUrlForEvent(registration);
+    const target = targetForEvent(registration);
     try {
-      const response = await fetch(target, {
+      const response = await engineFetch(target, {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -251,7 +337,7 @@ export async function dispatchEnginePluginEvent(event: FeedEvent): Promise<{ del
 }
 
 export async function proxyEnginePluginRequest(req: Request, registration: EnginePluginRegistration): Promise<Response> {
-  const target = targetUrlFor(req, registration);
+  const target = targetForRequest(req, registration);
   const headers = new Headers(req.headers);
   headers.delete("host");
   headers.set("x-maw-engine-plugin", registration.plugin);
@@ -267,7 +353,7 @@ export async function proxyEnginePluginRequest(req: Request, registration: Engin
   }
 
   try {
-    const upstream = await fetch(target, init);
+    const upstream = await engineFetch(target, init);
     const responseHeaders = new Headers(upstream.headers);
     responseHeaders.set("x-maw-engine-plugin", registration.plugin);
     responseHeaders.set("x-forwarded-prefix", registration.prefix);

--- a/test/isolated/engine-plugin-registry.test.ts
+++ b/test/isolated/engine-plugin-registry.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 import {
   clearEnginePluginRegistrations,
   dispatchEnginePluginEvent,
@@ -10,6 +13,11 @@ import {
 } from "../../src/core/engine-plugin-registry";
 
 afterEach(() => clearEnginePluginRegistrations());
+
+function unixSocketPath(name = "plugin.sock"): { dir: string; socket: string } {
+  const dir = mkdtempSync(join(tmpdir(), "maw-engine-unix-"));
+  return { dir, socket: join(dir, name) };
+}
 
 describe("engine plugin registry (#1566)", () => {
   test("registers loopback API prefixes and matches the longest prefix", () => {
@@ -48,6 +56,14 @@ describe("engine plugin registry (#1566)", () => {
       .toThrow(/_engine/);
     expect(() => registerEnginePlugin({ plugin: "bad", prefix: "/api/bad", upstream: "http://example.com:1" }))
       .toThrow(/loopback/);
+    expect(() => registerEnginePlugin({ plugin: "bad", prefix: "/api/bad", upstream: "unix://localhost/tmp/maw.sock" }))
+      .toThrow(/unix upstream/);
+    expect(() => registerEnginePlugin({ plugin: "bad", prefix: "/api/bad", upstream: "unix:///var/run/docker.sock" }))
+      .toThrow(/tmpdir|MAW_HOME/);
+    expect(() => registerEnginePlugin({ plugin: "bad", prefix: "/api/bad", upstream: "unix:///tmp/%2e%2e/var/run/maw.sock" }))
+      .toThrow(/traversal/);
+    expect(() => registerEnginePlugin({ plugin: "bad", prefix: "/api/bad", upstream: "unix:///tmp/maw-engine" }))
+      .toThrow(/\.sock/);
   });
 
   test("proxies requests to the registered upstream preserving suffix, query, body, and gateway headers", async () => {
@@ -223,5 +239,148 @@ describe("engine plugin registry (#1566)", () => {
     upstream.stop(true);
     expect(await pollEnginePluginHealth()).toEqual({ checked: 1, removed: 1 });
     expect(findEnginePluginRegistration("/api/health-ledger/messages")).toBeUndefined();
+  });
+
+  test("proxies requests to unix upstreams preserving suffix, query, body, and headers", async () => {
+    const { dir, socket } = unixSocketPath();
+    const upstream = Bun.serve({
+      unix: socket,
+      async fetch(req) {
+        const url = new URL(req.url);
+        return Response.json({
+          method: req.method,
+          path: url.pathname,
+          query: url.search,
+          body: await req.text(),
+          plugin: req.headers.get("x-maw-engine-plugin"),
+          prefix: req.headers.get("x-forwarded-prefix"),
+        });
+      },
+    });
+    try {
+      const registration = registerEnginePlugin({
+        plugin: "unix-ledger",
+        prefix: "/api/unix-ledger",
+        upstream: `unix://${socket}`,
+      });
+
+      const response = await proxyEnginePluginRequest(
+        new Request("http://maw.local/api/unix-ledger/items?q=1", {
+          method: "POST",
+          body: "hello unix",
+          headers: { "content-type": "text/plain" },
+        }),
+        registration,
+      );
+      const body = await response.json() as Record<string, unknown>;
+
+      expect(response.status).toBe(200);
+      expect(registration.upstream).toBe(`unix://${socket}`);
+      expect(body).toMatchObject({
+        method: "POST",
+        path: "/items",
+        query: "?q=1",
+        body: "hello unix",
+        plugin: "unix-ledger",
+        prefix: "/api/unix-ledger",
+      });
+    } finally {
+      upstream.stop(true);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("health polling works for unix upstreams", async () => {
+    const { dir, socket } = unixSocketPath();
+    const upstream = Bun.serve({
+      unix: socket,
+      fetch: (req) => new URL(req.url).pathname === "/health"
+        ? Response.json({ ok: true })
+        : Response.json({ ok: false }, { status: 404 }),
+    });
+    try {
+      const registration = registerEnginePlugin({
+        plugin: "unix-health",
+        prefix: "/api/unix-health",
+        upstream: `unix://${socket}`,
+        health: "/health",
+      });
+
+      expect(await pollEnginePluginHealth()).toEqual({ checked: 1, removed: 0 });
+      expect(findEnginePluginRegistration("/api/unix-health/messages")).toBe(registration);
+    } finally {
+      upstream.stop(true);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("event delivery works for unix upstreams", async () => {
+    const { dir, socket } = unixSocketPath();
+    const seen: Array<Record<string, unknown>> = [];
+    const upstream = Bun.serve({
+      unix: socket,
+      async fetch(req) {
+        const url = new URL(req.url);
+        seen.push({
+          path: url.pathname,
+          plugin: req.headers.get("x-maw-engine-plugin"),
+          prefix: req.headers.get("x-forwarded-prefix"),
+          body: await req.json(),
+        });
+        return Response.json({ ok: true });
+      },
+    });
+    try {
+      registerEnginePlugin({
+        plugin: "unix-events",
+        prefix: "/api/unix-events",
+        upstream: `unix://${socket}`,
+        events: ["MessageSend"],
+        eventPath: "/events",
+      });
+
+      const delivered = await dispatchEnginePluginEvent({
+        timestamp: "2026-05-16T01:02:03.000Z",
+        oracle: "mawjs-codex",
+        host: "m5",
+        event: "MessageSend",
+        project: "",
+        sessionId: "",
+        message: "hello unix",
+        ts: Date.now(),
+        data: { id: "unix-m1", text: "hello unix" },
+      });
+
+      expect(delivered).toEqual({ delivered: 1, failed: 0, removed: 0 });
+      expect(seen).toHaveLength(1);
+      expect(seen[0]).toMatchObject({
+        path: "/events",
+        plugin: "unix-events",
+        prefix: "/api/unix-events",
+      });
+      expect(seen[0].body).toMatchObject({ event: "MessageSend", message: "hello unix" });
+    } finally {
+      upstream.stop(true);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("unix upstream crashes unbind and return 503", async () => {
+    const { dir, socket } = unixSocketPath();
+    const upstream = Bun.serve({ unix: socket, fetch: () => Response.json({ ok: true }) });
+    const registration = registerEnginePlugin({
+      plugin: "unix-crashy",
+      prefix: "/api/unix-crashy",
+      upstream: `unix://${socket}`,
+    });
+    upstream.stop(true);
+    rmSync(dir, { recursive: true, force: true });
+
+    const response = await proxyEnginePluginRequest(new Request("http://maw.local/api/unix-crashy/ping"), registration);
+    const body = await response.json() as Record<string, unknown>;
+
+    expect(response.status).toBe(503);
+    expect(body).toMatchObject({ ok: false, error: "engine_plugin_unavailable", plugin: "unix-crashy" });
+    expect(findEnginePluginRegistration("/api/unix-crashy/ping")).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- Add `unix:///absolute/path.sock` support for dynamic engine plugin upstreams.
- Proxy request path/query/body/headers to unix-socket plugin engines using Bun's `fetch(..., { unix })` support.
- Route health polling and feed event delivery through the same unix upstream path.
- Reject unsafe socket paths (hosts, query/hash, traversal, whitespace/null bytes, non-`.sock`, and paths outside tmpdir/MAW_HOME) so maw cannot proxy privileged sockets such as `/var/run/docker.sock`.

Closes #1600.

## Verification
- `rtk bun test test/isolated/engine-plugin-registry.test.ts test/isolated/engine-api.test.ts`
- `rtk bun run build`
- `git diff --check`
- User-visible unix smoke: `maw serve` + unix `Bun.serve({ unix })` upstream; registered `/api/unix-smoke`; verified proxied POST path/query/body/headers, `MessageSend` event delivery to `/events`, and crash/unbind returning `503 engine_plugin_unavailable`.
- `rtk bun run test:isolated` → 113/113 files passed, 0 failed

## Release lane
Feature/fix PR targets `alpha` only. No release-alpha/version/tag/publish step from Codex.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
