### PR TITLE
feat(serve): show engine plugins in status

### DIFF
--- a/src/cli/instance-pid.ts
+++ b/src/cli/instance-pid.ts
@@ -88,6 +88,53 @@ export function printServeStatus(): void {
   }
 }
 
+function defaultEngineUrl(): string {
+  return (process.env.MAW_ENGINE_URL || `http://127.0.0.1:${process.env.MAW_PORT || "3456"}`).replace(/\/+$/, "");
+}
+
+function formatEngineRegistration(registration: Record<string, unknown>): string {
+  const plugin = typeof registration.plugin === "string" ? registration.plugin : "unknown";
+  const prefix = typeof registration.prefix === "string" ? registration.prefix : "unknown-prefix";
+  const upstream = typeof registration.upstream === "string" ? registration.upstream : "unknown-upstream";
+  const health = typeof registration.health === "string" ? ` health=${registration.health}` : "";
+  const events = Array.isArray(registration.events) && registration.events.length > 0
+    ? ` events=${registration.events.join(",")}`
+    : "";
+  return `  - ${plugin}: ${prefix} → ${upstream}${health}${events}`;
+}
+
+async function fetchEngineRegistrations(engineUrl = defaultEngineUrl()): Promise<
+  | { ok: true; engineUrl: string; registrations: Array<Record<string, unknown>> }
+  | { ok: false; engineUrl: string; error: string }
+> {
+  try {
+    const response = await fetch(`${engineUrl}/api/_engine/registrations`, { signal: AbortSignal.timeout(1_000) });
+    if (!response.ok) return { ok: false, engineUrl, error: `HTTP ${response.status}` };
+    const body = await response.json() as { registrations?: Array<Record<string, unknown>> };
+    return { ok: true, engineUrl, registrations: Array.isArray(body.registrations) ? body.registrations : [] };
+  } catch (err) {
+    return { ok: false, engineUrl, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export async function printServeStatusWithPlugins(engineUrl = defaultEngineUrl()): Promise<void> {
+  printServeStatus();
+  const status = serveStatus();
+  if (!status.alive) return;
+
+  const result = await fetchEngineRegistrations(engineUrl);
+  if (!result.ok) {
+    console.log(`engine plugins: unavailable (${result.engineUrl}: ${result.error})`);
+    return;
+  }
+  if (result.registrations.length === 0) {
+    console.log(`engine plugins: none (${result.engineUrl})`);
+    return;
+  }
+  console.log(`engine plugins (${result.engineUrl}):`);
+  for (const registration of result.registrations) console.log(formatEngineRegistration(registration));
+}
+
 export function stopServe(): void {
   const status = serveStatus();
   if (!status.pid) {

--- a/src/cli/route-tools.ts
+++ b/src/cli/route-tools.ts
@@ -9,7 +9,7 @@ const CORE_HELP: Record<string, string> = {
   agents: "usage: maw agents [--json] [--all] [--node <node>]",
   agent: "usage: maw agent [--json] [--all] [--node <node>]",
   audit: "usage: maw audit [limit]",
-  serve: "usage: maw serve [port] [--as <name>] [--force-takeover] | maw serve status|stop",
+  serve: "usage: maw serve [port] [--as <name>] [--force-takeover] | maw serve status|--status|stop",
 };
 
 function hasHelpFlag(args: string[]): boolean {
@@ -141,10 +141,10 @@ export async function routeTools(cmd: string, args: string[]): Promise<boolean> 
     const filteredArgs = forceIdx === -1
       ? withoutAs
       : withoutAs.filter(a => a !== "--force-takeover");
-    const sub = filteredArgs[0];
+    const sub = filteredArgs[0] === "--status" ? "status" : filteredArgs[0];
     if (sub === "status" || sub === "stop") {
-      const { printServeStatus, stopServe } = await import("./instance-pid");
-      if (sub === "status") printServeStatus();
+      const { printServeStatusWithPlugins, stopServe } = await import("./instance-pid");
+      if (sub === "status") await printServeStatusWithPlugins();
       else stopServe();
       return true;
     }

--- a/test/isolated/instance-pid.test.ts
+++ b/test/isolated/instance-pid.test.ts
@@ -6,12 +6,14 @@ import { tmpdir } from "os";
 import {
   acquirePidLock,
   pidFile,
+  printServeStatusWithPlugins,
   serveStatus,
   stopServe,
 } from "../../src/cli/instance-pid";
 
 let tempHome = "";
 const origHome = process.env.MAW_HOME;
+const origEngineUrl = process.env.MAW_ENGINE_URL;
 const origExit = process.exit;
 const origKill = process.kill;
 
@@ -23,6 +25,8 @@ beforeEach(() => {
 afterEach(() => {
   if (origHome === undefined) delete process.env.MAW_HOME;
   else process.env.MAW_HOME = origHome;
+  if (origEngineUrl === undefined) delete process.env.MAW_ENGINE_URL;
+  else process.env.MAW_ENGINE_URL = origEngineUrl;
   process.exit = origExit;
   process.kill = origKill;
   rmSync(tempHome, { recursive: true, force: true });
@@ -96,5 +100,45 @@ describe("maw serve PID lock UX (#1434)", () => {
       { pid: 4242, signal: "SIGTERM" },
     ]);
     expect(serveStatus()).toEqual({ pid: null, alive: false, file: pidFile() });
+  });
+
+  test("serve status includes registered engine plugins when the gateway is reachable", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname === "/api/_engine/registrations") {
+          return Response.json({
+            ok: true,
+            registrations: [{
+              plugin: "messages",
+              prefix: "/api/message-ledger",
+              upstream: "unix:///tmp/maw-messages.sock",
+              health: "/health",
+              events: ["MessageSend"],
+            }],
+          });
+        }
+        return Response.json({ ok: false }, { status: 404 });
+      },
+    });
+    const lines: string[] = [];
+    const origLog = console.log;
+    writeFileSync(pidFile(), String(process.pid));
+    process.env.MAW_ENGINE_URL = `http://127.0.0.1:${server.port}`;
+    console.log = (...args: unknown[]) => { lines.push(args.join(" ")); };
+
+    try {
+      await printServeStatusWithPlugins();
+    } finally {
+      console.log = origLog;
+      server.stop(true);
+    }
+
+    const text = lines.join("\n");
+    expect(text).toContain("maw serve: running");
+    expect(text).toContain("engine plugins");
+    expect(text).toContain("messages: /api/message-ledger");
+    expect(text).toContain("events=MessageSend");
   });
 });


### PR DESCRIPTION
## Summary
- Add `maw serve --status` as an alias for the existing `maw serve status` surface.
- When the gateway is running, status now queries `/api/_engine/registrations` and lists registered engine-plugin daemons.
- Keeps stopped/stale PID behavior unchanged and reports engine plugin status as best-effort if the gateway cannot be reached.

Completes the remaining generic operator-view slice for #1599 after #1601 shipped `maw messages serve --detach/status/stop`.

## Verification
- `rtk bun test test/isolated/instance-pid.test.ts test/isolated/message-ledger.test.ts test/isolated/engine-api.test.ts`
- `rtk bun run build`
- `git diff --check`
- source smoke: temp `maw serve`, manual engine registration, `maw serve --status` listed `smoke: /api/smoke` with events/health.

## Release lane
Feature/fix PR targets `alpha` only. No release-alpha/version/tag/publish step from Codex.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
