### PR TITLE
feat(team): load team charters without spawning

### DIFF
--- a/src/vendor/mpr-plugins/team/impl.ts
+++ b/src/vendor/mpr-plugins/team/impl.ts
@@ -10,7 +10,7 @@ export { cmdTeamShutdown, cmdTeamCreate, cmdTeamSpawn, mergeTeamKnowledge } from
 export { cmdTeamSend } from "./team-comms";
 export { cmdTeamResume, cmdTeamLives } from "./team-reincarnation";
 export { cmdCleanupZombies } from "./team-cleanup-zombies";
-export { parseTeamCharterText, readTeamCharter, planTeamCharter, formatTeamCharterPlan } from "./team-charter";
+export { parseTeamCharterText, readTeamCharter, planTeamCharter, formatTeamCharterPlan, loadTeamCharter, formatTeamCharterLoad } from "./team-charter";
 
 /**
  * Scan vault for CLI-created team manifests (#393 Bug B).

--- a/src/vendor/mpr-plugins/team/index.ts
+++ b/src/vendor/mpr-plugins/team/index.ts
@@ -84,6 +84,18 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       }
       const { readTeamCharter, planTeamCharter, formatTeamCharterPlan } = await import("./team-charter");
       logs.push(formatTeamCharterPlan(planTeamCharter(readTeamCharter(args[1]))));
+    } else if (sub === "load") {
+      if (!args[1]) {
+        logs.push("usage: maw team load <team.yaml|team.json> --no-spawn");
+        return { ok: false, error: "charter path required", output: logs.join("\n") };
+      }
+      if (!args.includes("--no-spawn")) {
+        logs.push("usage: maw team load <team.yaml|team.json> --no-spawn");
+        logs.push("Phase 1 only supports materializing charter files; spawning remains a separate future step.");
+        return { ok: false, error: "--no-spawn required", output: logs.join("\n") };
+      }
+      const { readTeamCharter, loadTeamCharter, formatTeamCharterLoad } = await import("./team-charter");
+      logs.push(formatTeamCharterLoad(loadTeamCharter(readTeamCharter(args[1]), { noSpawn: true })));
     } else if (sub === "spawn") {
       if (!args[1] || !args[2]) {
         logs.push("usage: maw team spawn <team> <role> [--model <model>] [--cwd <path>] [--worktree <path>] [--prompt <text>] [--exec]");
@@ -285,7 +297,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
 
     } else {
       logs.push(`unknown team subcommand: ${sub}`);
-      logs.push("usage: maw team <create|plan|spawn|send|shutdown|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members|enter>");
+      logs.push("usage: maw team <create|plan|load|spawn|send|shutdown|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members|enter>");
       return { ok: false, error: `unknown subcommand: ${sub}`, output: logs.join("\n") };
     }
 

--- a/src/vendor/mpr-plugins/team/plugin.json
+++ b/src/vendor/mpr-plugins/team/plugin.json
@@ -10,7 +10,7 @@
     "aliases": [
       "t"
     ],
-    "help": "maw team <create|plan|spawn|send|shutdown|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members|enter>"
+    "help": "maw team <create|plan|load|spawn|send|shutdown|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members|enter>"
   },
   "weight": 30,
   "tier": "standard",

--- a/src/vendor/mpr-plugins/team/team-charter.ts
+++ b/src/vendor/mpr-plugins/team/team-charter.ts
@@ -1,7 +1,7 @@
-import { readFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
-import { homedir } from "os";
-import { resolvePsi } from "./team-helpers";
+import { assertValidOracleName } from "maw-js/core/fleet/validate";
+import { resolvePsi, TEAMS_DIR, type TeamConfig, type TeamMember } from "./team-helpers";
 
 export interface TeamCharterMember {
   role: string;
@@ -25,6 +25,12 @@ export interface TeamCharterPlan {
   artifacts: string[];
   actions: string[];
   warnings: string[];
+}
+
+export interface TeamCharterLoadResult {
+  plan: TeamCharterPlan;
+  writtenArtifacts: string[];
+  actions: string[];
 }
 
 function stripComment(line: string): string {
@@ -199,12 +205,12 @@ export function readTeamCharter(path: string): TeamCharter {
 }
 
 export function planTeamCharter(charter: TeamCharter): TeamCharterPlan {
-  const teamDir = join(homedir(), ".claude", "teams", charter.name);
+  const teamDir = join(TEAMS_DIR, charter.name);
   const psi = resolvePsi();
   const warnings: string[] = [];
   for (const member of charter.members) {
     const target = member.target ?? "auto";
-    if (target !== "auto") warnings.push(`${member.role}: target '${target}' is planned only; Phase 0 does not spawn or mutate panes`);
+    if (target !== "auto") warnings.push(`${member.role}: target '${target}' is planned only; charter flow does not spawn or mutate panes yet`);
   }
   if (charter.governance?.requires_human_approval === true) {
     warnings.push("governance requires human approval before any future load/spawn action");
@@ -251,5 +257,90 @@ export function formatTeamCharterPlan(plan: TeamCharterPlan): string {
   if (plan.warnings.length) {
     lines.push("", "warnings:", ...plan.warnings.map((warning) => `  - ${warning}`));
   }
+  return lines.join("\n");
+}
+
+
+export function loadTeamCharter(charter: TeamCharter, opts: { noSpawn?: boolean; now?: () => number } = {}): TeamCharterLoadResult {
+  if (!opts.noSpawn) throw new Error("team charter load currently requires --no-spawn");
+  assertValidOracleName(charter.name);
+
+  const plan = planTeamCharter(charter);
+  const createdAt = opts.now?.() ?? Date.now();
+  const teamDir = join(TEAMS_DIR, charter.name);
+  const inboxDir = join(teamDir, "inboxes");
+  const toolConfigPath = join(teamDir, "config.json");
+  const psi = resolvePsi();
+  const vaultTeamDir = join(psi, "memory", "mailbox", "teams", charter.name);
+  const vaultManifestPath = join(vaultTeamDir, "manifest.json");
+
+  const existing = [
+    existsSync(toolConfigPath) ? toolConfigPath : undefined,
+    existsSync(vaultManifestPath) ? vaultManifestPath : undefined,
+  ].filter((value): value is string => Boolean(value));
+  if (existing.length) {
+    throw new Error(`team '${charter.name}' already exists; refusing to overwrite ${existing.join(", ")}`);
+  }
+
+  const members: TeamMember[] = charter.members.map((member) => ({
+    name: member.role,
+    ...(member.model ? { model: member.model } : {}),
+    ...(member.target && member.target !== "auto" ? { backendType: member.target } : {}),
+  }));
+  const config: TeamConfig = {
+    name: charter.name,
+    ...(charter.description ? { description: charter.description } : {}),
+    members,
+    createdAt,
+  };
+  const manifest = {
+    name: charter.name,
+    createdAt,
+    description: charter.description ?? "",
+    goal: charter.goal ?? "",
+    members: charter.members.map((member) => member.role),
+    source: "team-charter",
+    charter: {
+      members: charter.members,
+      ...(charter.lifecycle ? { lifecycle: charter.lifecycle } : {}),
+      ...(charter.governance ? { governance: charter.governance } : {}),
+    },
+  };
+
+  mkdirSync(inboxDir, { recursive: true });
+  mkdirSync(vaultTeamDir, { recursive: true });
+  writeFileSync(toolConfigPath, JSON.stringify(config, null, 2));
+  for (const member of charter.members) {
+    writeFileSync(join(inboxDir, `${member.role}.json`), JSON.stringify([], null, 2));
+  }
+  writeFileSync(vaultManifestPath, JSON.stringify(manifest, null, 2));
+
+  return {
+    plan,
+    writtenArtifacts: [toolConfigPath, ...charter.members.map((member) => join(inboxDir, `${member.role}.json`)), vaultManifestPath],
+    actions: [
+      "--no-spawn respected",
+      "no tmux panes changed",
+      "no claude processes spawned",
+      "no maw bud or fleet writes",
+    ],
+  };
+}
+
+export function formatTeamCharterLoad(result: TeamCharterLoadResult): string {
+  const { charter } = result.plan;
+  const lines = [
+    `team charter loaded: ${charter.name}`,
+    "",
+    "wrote artifacts:",
+    ...result.writtenArtifacts.map((artifact) => `  - ${artifact}`),
+    "",
+    "load safety:",
+    ...result.actions.map((action) => `  - ${action}`),
+  ];
+  if (result.plan.warnings.length) {
+    lines.push("", "warnings:", ...result.plan.warnings.map((warning) => `  - ${warning}`));
+  }
+  lines.push("", `next: maw team list`);
   return lines.join("\n");
 }

--- a/test/isolated/team-charter-plan.test.ts
+++ b/test/isolated/team-charter-plan.test.ts
@@ -1,14 +1,16 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
-import { tmpdir } from "os";
+import { homedir, tmpdir } from "os";
 
 import teamHandler from "../../src/vendor/mpr-plugins/team/index";
-import { formatTeamCharterPlan, parseTeamCharterText, planTeamCharter } from "../../src/vendor/mpr-plugins/team/team-charter";
+import { formatTeamCharterLoad, formatTeamCharterPlan, loadTeamCharter, parseTeamCharterText, planTeamCharter } from "../../src/vendor/mpr-plugins/team/team-charter";
+import { _setDirs, TEAMS_DIR, TASKS_DIR } from "../../src/vendor/mpr-plugins/team/team-helpers";
 
 const tmpDirs: string[] = [];
 
 afterEach(() => {
+  _setDirs(join(homedir(), ".claude/teams"), join(homedir(), ".claude/tasks"));
   for (const dir of tmpDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
 });
 
@@ -18,6 +20,24 @@ function tmpFile(name: string, content: string): string {
   const file = join(dir, name);
   writeFileSync(file, content, "utf-8");
   return file;
+}
+
+async function withIsolatedTeamStores<T>(fn: (root: string) => T | Promise<T>): Promise<T> {
+  const originalCwd = process.cwd();
+  const originalTeams = TEAMS_DIR;
+  const originalTasks = TASKS_DIR;
+  const root = mkdtempSync(join(tmpdir(), "maw-team-charter-store-"));
+  tmpDirs.push(root);
+  mkdirSync(join(root, "ψ"), { recursive: true });
+  writeFileSync(join(root, "CLAUDE.md"), "test oracle\n", "utf-8");
+  _setDirs(join(root, "teams"), join(root, "tasks"));
+  process.chdir(root);
+  try {
+    return await fn(root);
+  } finally {
+    process.chdir(originalCwd);
+    _setDirs(originalTeams, originalTasks);
+  }
 }
 
 describe("team charter plan (#1594)", () => {
@@ -89,5 +109,86 @@ members:
     expect(result.output).toContain("inboxes/scout.json");
     expect(result.output).toContain("no tmux panes changed");
     expect(result.output).toContain("target 'existing:mawjs-oracle' is planned only");
+  });
+
+  test("loads a charter into config, inboxes, and vault manifest only when --no-spawn is set", async () => {
+    await withIsolatedTeamStores(async (root) => {
+      const charter = parseTeamCharterText(`
+name: load-team
+members:
+  - role: scout
+    target: auto
+    model: spark
+  - role: bridge
+    target: existing:mawjs-oracle
+governance:
+  requires_human_approval: true
+`);
+
+      const result = loadTeamCharter(charter, { noSpawn: true, now: () => 123 });
+      const rendered = formatTeamCharterLoad(result);
+      const configPath = join(root, "teams", "load-team", "config.json");
+      const scoutInbox = join(root, "teams", "load-team", "inboxes", "scout.json");
+      const bridgeInbox = join(root, "teams", "load-team", "inboxes", "bridge.json");
+      const manifestPath = join(root, "ψ", "memory", "mailbox", "teams", "load-team", "manifest.json");
+
+      expect(rendered).toContain("team charter loaded: load-team");
+      expect(rendered).toContain("--no-spawn respected");
+      expect(rendered).toContain("no tmux panes changed");
+      expect(rendered).toContain("no claude processes spawned");
+      expect(existsSync(configPath)).toBe(true);
+      expect(JSON.parse(readFileSync(configPath, "utf-8"))).toMatchObject({
+        name: "load-team",
+        createdAt: 123,
+        members: [
+          { name: "scout", model: "spark" },
+          { name: "bridge", backendType: "existing:mawjs-oracle" },
+        ],
+      });
+      expect(JSON.parse(readFileSync(scoutInbox, "utf-8"))).toEqual([]);
+      expect(JSON.parse(readFileSync(bridgeInbox, "utf-8"))).toEqual([]);
+      expect(JSON.parse(readFileSync(manifestPath, "utf-8"))).toMatchObject({
+        name: "load-team",
+        source: "team-charter",
+        members: ["scout", "bridge"],
+        charter: { governance: { requires_human_approval: true } },
+      });
+    });
+  });
+
+  test("handler refuses load without explicit --no-spawn", async () => {
+    const file = tmpFile("team.yaml", `
+name: require-safe-load
+members:
+  - role: scout
+`);
+
+    const result = await teamHandler({ source: "cli", args: ["load", file] });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("--no-spawn required");
+    expect(result.output).toContain("maw team load <team.yaml|team.json> --no-spawn");
+  });
+
+  test("handler load subcommand materializes files without spawning", async () => {
+    await withIsolatedTeamStores(async (root) => {
+      const file = join(root, "team.yaml");
+      writeFileSync(file, `
+name: handler-load
+members:
+  - role: scout
+    target: auto
+`, "utf-8");
+
+      const result = await teamHandler({ source: "cli", args: ["load", file, "--no-spawn"] });
+
+      expect(result.ok).toBe(true);
+      expect(result.output).toContain("team charter loaded: handler-load");
+      expect(result.output).toContain("no tmux panes changed");
+      expect(result.output).toContain("no claude processes spawned");
+      expect(existsSync(join(root, "teams", "handler-load", "config.json"))).toBe(true);
+      expect(existsSync(join(root, "teams", "handler-load", "inboxes", "scout.json"))).toBe(true);
+      expect(existsSync(join(root, "ψ", "memory", "mailbox", "teams", "handler-load", "manifest.json"))).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add `maw team load <team.yaml|team.json> --no-spawn` as the next safe team-charter phase
- materialize only bounded files: `~/.claude/teams/<name>/config.json`, per-role empty inbox JSON, and `ψ/memory/mailbox/teams/<name>/manifest.json`
- require explicit `--no-spawn`, refuse to overwrite existing teams, and keep tmux/Claude/fleet untouched

## Verification
- `rtk bun test test/isolated/team-charter-plan.test.ts test/isolated/message-ledger.test.ts`
- `rtk bun run build`
- `git diff --check`
- Source smoke: `bun src/cli.ts team plan <team.yaml>` + `bun src/cli.ts team load <team.yaml> --no-spawn`, verified files existed and cleaned smoke artifacts

Refs #1594

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
