### PR TITLE
feat(team): preflight team charters before spawning

### DIFF
--- a/src/vendor/mpr-plugins/team/impl.ts
+++ b/src/vendor/mpr-plugins/team/impl.ts
@@ -10,7 +10,7 @@ export { cmdTeamShutdown, cmdTeamCreate, cmdTeamSpawn, mergeTeamKnowledge } from
 export { cmdTeamSend } from "./team-comms";
 export { cmdTeamResume, cmdTeamLives } from "./team-reincarnation";
 export { cmdCleanupZombies } from "./team-cleanup-zombies";
-export { parseTeamCharterText, readTeamCharter, planTeamCharter, formatTeamCharterPlan, loadTeamCharter, formatTeamCharterLoad } from "./team-charter";
+export { parseTeamCharterText, readTeamCharter, planTeamCharter, formatTeamCharterPlan, preflightTeamCharter, formatTeamCharterPreflight, loadTeamCharter, formatTeamCharterLoad } from "./team-charter";
 
 /**
  * Scan vault for CLI-created team manifests (#393 Bug B).

--- a/src/vendor/mpr-plugins/team/index.ts
+++ b/src/vendor/mpr-plugins/team/index.ts
@@ -84,6 +84,17 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       }
       const { readTeamCharter, planTeamCharter, formatTeamCharterPlan } = await import("./team-charter");
       logs.push(formatTeamCharterPlan(planTeamCharter(readTeamCharter(args[1]))));
+    } else if (sub === "preflight" || sub === "check") {
+      if (!args[1]) {
+        logs.push("usage: maw team preflight <team.yaml|team.json>");
+        return { ok: false, error: "charter path required", output: logs.join("\n") };
+      }
+      const { readTeamCharter, preflightTeamCharter, formatTeamCharterPreflight } = await import("./team-charter");
+      const result = preflightTeamCharter(readTeamCharter(args[1]));
+      logs.push(formatTeamCharterPreflight(result));
+      if (result.errors.length > 0) {
+        return { ok: false, error: "preflight failed", output: logs.join("\n") };
+      }
     } else if (sub === "load") {
       if (!args[1]) {
         logs.push("usage: maw team load <team.yaml|team.json> --no-spawn");
@@ -297,7 +308,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
 
     } else {
       logs.push(`unknown team subcommand: ${sub}`);
-      logs.push("usage: maw team <create|plan|load|spawn|send|shutdown|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members|enter>");
+      logs.push("usage: maw team <create|plan|preflight|load|spawn|send|shutdown|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members|enter>");
       return { ok: false, error: `unknown subcommand: ${sub}`, output: logs.join("\n") };
     }
 

--- a/src/vendor/mpr-plugins/team/plugin.json
+++ b/src/vendor/mpr-plugins/team/plugin.json
@@ -10,7 +10,7 @@
     "aliases": [
       "t"
     ],
-    "help": "maw team <create|plan|load|spawn|send|shutdown|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members|enter>"
+    "help": "maw team <create|plan|preflight|load|spawn|send|shutdown|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members|enter>"
   },
   "weight": 30,
   "tier": "standard",

--- a/src/vendor/mpr-plugins/team/team-charter.ts
+++ b/src/vendor/mpr-plugins/team/team-charter.ts
@@ -33,6 +33,22 @@ export interface TeamCharterLoadResult {
   actions: string[];
 }
 
+export type TeamCharterPreflightLevel = "ok" | "warn" | "error";
+
+export interface TeamCharterPreflightCheck {
+  level: TeamCharterPreflightLevel;
+  label: string;
+  detail: string;
+}
+
+export interface TeamCharterPreflightResult {
+  charter: TeamCharter;
+  checks: TeamCharterPreflightCheck[];
+  errors: TeamCharterPreflightCheck[];
+  warnings: TeamCharterPreflightCheck[];
+  actions: string[];
+}
+
 function stripComment(line: string): string {
   let quote: string | null = null;
   for (let i = 0; i < line.length; i++) {
@@ -343,4 +359,97 @@ export function formatTeamCharterLoad(result: TeamCharterLoadResult): string {
   }
   lines.push("", `next: maw team list`);
   return lines.join("\n");
+}
+
+
+function addPreflightCheck(
+  checks: TeamCharterPreflightCheck[],
+  level: TeamCharterPreflightLevel,
+  label: string,
+  detail: string,
+): void {
+  checks.push({ level, label, detail });
+}
+
+export function preflightTeamCharter(charter: TeamCharter): TeamCharterPreflightResult {
+  const checks: TeamCharterPreflightCheck[] = [];
+  try {
+    assertValidOracleName(charter.name);
+    addPreflightCheck(checks, "ok", "team name", `'${charter.name}' is accepted`);
+  } catch (e: any) {
+    addPreflightCheck(checks, "error", "team name", e?.message || String(e));
+  }
+
+  const roles = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const member of charter.members) {
+    if (roles.has(member.role)) duplicates.add(member.role);
+    roles.add(member.role);
+  }
+  if (duplicates.size > 0) {
+    addPreflightCheck(checks, "error", "member roles", `duplicate role(s): ${[...duplicates].join(", ")}`);
+  } else {
+    addPreflightCheck(checks, "ok", "member roles", `${charter.members.length} unique role(s)`);
+  }
+
+  const plan = planTeamCharter(charter);
+  const existing = plan.artifacts.filter((artifact) => existsSync(artifact));
+  if (existing.length > 0) {
+    addPreflightCheck(checks, "error", "existing artifacts", `would refuse to overwrite: ${existing.join(", ")}`);
+  } else {
+    addPreflightCheck(checks, "ok", "existing artifacts", "no config/inbox/manifest collisions found");
+  }
+
+  for (const member of charter.members) {
+    const target = member.target ?? "auto";
+    if (target === "auto") {
+      addPreflightCheck(checks, "ok", `target:${member.role}`, "auto target stays local and deferred");
+    } else if (/^existing:[^:]+$/.test(target)) {
+      addPreflightCheck(checks, "warn", `target:${member.role}`, `${target} needs a future existing-oracle resolver and human-visible preflight`);
+    } else if (/^new:[^:]+$/.test(target)) {
+      addPreflightCheck(checks, "warn", `target:${member.role}`, `${target} needs a future new-oracle/bud governance gate`);
+    } else {
+      addPreflightCheck(checks, "error", `target:${member.role}`, `unsupported target '${target}' (expected auto, existing:<oracle>, or new:<stem>)`);
+    }
+
+    if (member.cwd) {
+      if (existsSync(member.cwd)) addPreflightCheck(checks, "ok", `cwd:${member.role}`, member.cwd);
+      else addPreflightCheck(checks, "warn", `cwd:${member.role}`, `${member.cwd} does not exist on this machine yet`);
+    }
+  }
+
+  if (charter.governance?.requires_human_approval === true) {
+    addPreflightCheck(checks, "warn", "governance", "human approval is required before future spawn/load escalation");
+  } else {
+    addPreflightCheck(checks, "ok", "governance", "no explicit human-approval gate requested");
+  }
+
+  return {
+    charter,
+    checks,
+    errors: checks.filter((check) => check.level === "error"),
+    warnings: checks.filter((check) => check.level === "warn"),
+    actions: [
+      "read-only preflight only",
+      "no files written",
+      "no tmux panes changed",
+      "no claude processes spawned",
+      "no maw bud or fleet writes",
+    ],
+  };
+}
+
+export function formatTeamCharterPreflight(result: TeamCharterPreflightResult): string {
+  const status = result.errors.length > 0 ? "failed" : result.warnings.length > 0 ? "passed with warnings" : "passed";
+  const icon = (level: TeamCharterPreflightLevel) => level === "ok" ? "✓" : level === "warn" ? "⚠" : "✗";
+  return [
+    `team charter preflight: ${result.charter.name}`,
+    `status: ${status}`,
+    "",
+    "checks:",
+    ...result.checks.map((check) => `  ${icon(check.level)} ${check.label}: ${check.detail}`),
+    "",
+    "preflight safety:",
+    ...result.actions.map((action) => `  - ${action}`),
+  ].join("\n");
 }

--- a/test/isolated/team-charter-plan.test.ts
+++ b/test/isolated/team-charter-plan.test.ts
@@ -4,7 +4,7 @@ import { join } from "path";
 import { homedir, tmpdir } from "os";
 
 import teamHandler from "../../src/vendor/mpr-plugins/team/index";
-import { formatTeamCharterLoad, formatTeamCharterPlan, loadTeamCharter, parseTeamCharterText, planTeamCharter } from "../../src/vendor/mpr-plugins/team/team-charter";
+import { formatTeamCharterLoad, formatTeamCharterPlan, formatTeamCharterPreflight, loadTeamCharter, parseTeamCharterText, planTeamCharter, preflightTeamCharter } from "../../src/vendor/mpr-plugins/team/team-charter";
 import { _setDirs, TEAMS_DIR, TASKS_DIR } from "../../src/vendor/mpr-plugins/team/team-helpers";
 
 const tmpDirs: string[] = [];
@@ -109,6 +109,55 @@ members:
     expect(result.output).toContain("inboxes/scout.json");
     expect(result.output).toContain("no tmux panes changed");
     expect(result.output).toContain("target 'existing:mawjs-oracle' is planned only");
+  });
+
+
+
+  test("preflights charters without writing files", async () => {
+    await withIsolatedTeamStores(async (root) => {
+      const charter = parseTeamCharterText(`
+name: preflight-team
+members:
+  - role: scout
+    target: auto
+  - role: bridge
+    target: existing:mawjs-oracle
+governance:
+  requires_human_approval: true
+`);
+
+      const result = preflightTeamCharter(charter);
+      const rendered = formatTeamCharterPreflight(result);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.warnings.length).toBeGreaterThan(0);
+      expect(rendered).toContain("team charter preflight: preflight-team");
+      expect(rendered).toContain("status: passed with warnings");
+      expect(rendered).toContain("read-only preflight only");
+      expect(rendered).toContain("no files written");
+      expect(rendered).toContain("target:bridge");
+      expect(existsSync(join(root, "teams", "preflight-team", "config.json"))).toBe(false);
+      expect(existsSync(join(root, "ψ", "memory", "mailbox", "teams", "preflight-team", "manifest.json"))).toBe(false);
+    });
+  });
+
+  test("handler preflight fails loudly for duplicate roles and unsupported targets", async () => {
+    const file = tmpFile("team.yaml", `
+name: bad-preflight
+members:
+  - role: scout
+    target: auto
+  - role: scout
+    target: nowhere
+`);
+
+    const result = await teamHandler({ source: "cli", args: ["preflight", file] });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("preflight failed");
+    expect(result.output).toContain("team charter preflight: bad-preflight");
+    expect(result.output).toContain("duplicate role(s): scout");
+    expect(result.output).toContain("unsupported target 'nowhere'");
   });
 
   test("loads a charter into config, inboxes, and vault manifest only when --no-spawn is set", async () => {


### PR DESCRIPTION
## Summary
- add `maw team preflight <team.yaml|team.json>` / `maw team check` as a read-only charter validation gate
- reports errors for duplicate roles, unsupported targets, and existing artifact collisions before load/spawn
- reports warnings for future `existing:*` / `new:*` target semantics, missing local cwd, and governance approval gates
- keeps preflight side-effect free: no files, no tmux panes, no Claude processes, no `maw bud`/fleet writes

## Verification
- `rtk bun test test/isolated/team-charter-plan.test.ts test/isolated/message-ledger.test.ts`
- `rtk bun run build`
- `git diff --check`
- Source smoke: `bun src/cli.ts team preflight <team.yaml>` returned `passed with warnings`, safety lines, and no config/manifest artifacts were written

Refs #1594

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
