### PR TITLE
feat(team): spawn local teams from charters

### DIFF
--- a/src/vendor/mpr-plugins/team/impl.ts
+++ b/src/vendor/mpr-plugins/team/impl.ts
@@ -10,7 +10,7 @@ export { cmdTeamShutdown, cmdTeamCreate, cmdTeamSpawn, mergeTeamKnowledge } from
 export { cmdTeamSend } from "./team-comms";
 export { cmdTeamResume, cmdTeamLives } from "./team-reincarnation";
 export { cmdCleanupZombies } from "./team-cleanup-zombies";
-export { parseTeamCharterText, readTeamCharter, planTeamCharter, formatTeamCharterPlan, preflightTeamCharter, formatTeamCharterPreflight, loadTeamCharter, formatTeamCharterLoad } from "./team-charter";
+export { parseTeamCharterText, readTeamCharter, planTeamCharter, formatTeamCharterPlan, preflightTeamCharter, formatTeamCharterPreflight, loadTeamCharter, formatTeamCharterLoad, composeTeamCharterMemberPrompt, spawnFromTeamCharter, formatTeamCharterSpawn } from "./team-charter";
 
 /**
  * Scan vault for CLI-created team manifests (#393 Bug B).

--- a/src/vendor/mpr-plugins/team/index.ts
+++ b/src/vendor/mpr-plugins/team/index.ts
@@ -107,6 +107,16 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       }
       const { readTeamCharter, loadTeamCharter, formatTeamCharterLoad } = await import("./team-charter");
       logs.push(formatTeamCharterLoad(loadTeamCharter(readTeamCharter(args[1]), { noSpawn: true })));
+    } else if (sub === "spawn-from") {
+      if (!args[1]) {
+        logs.push("usage: maw team spawn-from <team.yaml|team.json> [--approve] [--exec]");
+        return { ok: false, error: "charter path required", output: logs.join("\n") };
+      }
+      const { readTeamCharter, spawnFromTeamCharter, formatTeamCharterSpawn } = await import("./team-charter");
+      const approve = args.includes("--approve");
+      const exec = args.includes("--exec");
+      const result = await spawnFromTeamCharter(readTeamCharter(args[1]), { approve, exec });
+      logs.push(formatTeamCharterSpawn(result));
     } else if (sub === "spawn") {
       if (!args[1] || !args[2]) {
         logs.push("usage: maw team spawn <team> <role> [--model <model>] [--cwd <path>] [--worktree <path>] [--prompt <text>] [--exec]");
@@ -308,7 +318,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
 
     } else {
       logs.push(`unknown team subcommand: ${sub}`);
-      logs.push("usage: maw team <create|plan|preflight|load|spawn|send|shutdown|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members|enter>");
+      logs.push("usage: maw team <create|plan|preflight|load|spawn-from|spawn|send|shutdown|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members|enter>");
       return { ok: false, error: `unknown subcommand: ${sub}`, output: logs.join("\n") };
     }
 

--- a/src/vendor/mpr-plugins/team/plugin.json
+++ b/src/vendor/mpr-plugins/team/plugin.json
@@ -10,7 +10,7 @@
     "aliases": [
       "t"
     ],
-    "help": "maw team <create|plan|preflight|load|spawn|send|shutdown|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members|enter>"
+    "help": "maw team <create|plan|preflight|load|spawn-from|spawn|send|shutdown|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members|enter>"
   },
   "weight": 30,
   "tier": "standard",

--- a/src/vendor/mpr-plugins/team/team-charter.ts
+++ b/src/vendor/mpr-plugins/team/team-charter.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { assertValidOracleName } from "maw-js/core/fleet/validate";
 import { resolvePsi, TEAMS_DIR, type TeamConfig, type TeamMember } from "./team-helpers";
+import { cmdTeamCreate, cmdTeamSpawn } from "./team-lifecycle";
 
 export interface TeamCharterMember {
   role: string;
@@ -30,6 +31,12 @@ export interface TeamCharterPlan {
 export interface TeamCharterLoadResult {
   plan: TeamCharterPlan;
   writtenArtifacts: string[];
+  actions: string[];
+}
+
+export interface TeamCharterSpawnResult {
+  charter: TeamCharter;
+  spawnedRoles: string[];
   actions: string[];
 }
 
@@ -450,6 +457,67 @@ export function formatTeamCharterPreflight(result: TeamCharterPreflightResult): 
     ...result.checks.map((check) => `  ${icon(check.level)} ${check.label}: ${check.detail}`),
     "",
     "preflight safety:",
+    ...result.actions.map((action) => `  - ${action}`),
+  ].join("\n");
+}
+
+
+export function composeTeamCharterMemberPrompt(charter: TeamCharter, member: TeamCharterMember): string {
+  return [
+    charter.goal ? `## Team goal\n${charter.goal}` : undefined,
+    member.prompt ? `## Role prompt\n${member.prompt}` : undefined,
+  ].filter((part): part is string => Boolean(part)).join("\n\n");
+}
+
+export async function spawnFromTeamCharter(
+  charter: TeamCharter,
+  opts: { approve?: boolean; exec?: boolean } = {},
+): Promise<TeamCharterSpawnResult> {
+  const preflight = preflightTeamCharter(charter);
+  if (preflight.errors.length > 0) {
+    throw new Error(`preflight failed: ${preflight.errors.map((check) => `${check.label}: ${check.detail}`).join("; ")}`);
+  }
+  if (charter.governance?.requires_human_approval === true && !opts.approve) {
+    throw new Error("governance requires human approval; re-run with --approve to spawn local target:auto members");
+  }
+  const unsupportedTargets = charter.members
+    .filter((member) => (member.target ?? "auto") !== "auto")
+    .map((member) => `${member.role}=${member.target}`);
+  if (unsupportedTargets.length > 0) {
+    throw new Error(`charter spawn currently supports only target:auto; blocked ${unsupportedTargets.join(", ")}`);
+  }
+
+  cmdTeamCreate(charter.name, { description: charter.description });
+  const spawnedRoles: string[] = [];
+  for (const member of charter.members) {
+    await cmdTeamSpawn(charter.name, member.role, {
+      model: member.model,
+      cwd: member.cwd,
+      prompt: composeTeamCharterMemberPrompt(charter, member),
+      exec: opts.exec,
+    });
+    spawnedRoles.push(member.role);
+  }
+  return {
+    charter,
+    spawnedRoles,
+    actions: [
+      "preflight passed",
+      opts.approve ? "governance approval flag present" : "no governance approval required",
+      opts.exec ? "--exec passed through to local cmdTeamSpawn" : "spawn prompts written; no tmux panes spawned without --exec",
+      "existing:* and new:* targets blocked in this implementation",
+    ],
+  };
+}
+
+export function formatTeamCharterSpawn(result: TeamCharterSpawnResult): string {
+  return [
+    `team charter spawn complete: ${result.charter.name}`,
+    "",
+    `roles (${result.spawnedRoles.length}):`,
+    ...result.spawnedRoles.map((role) => `  - ${role}`),
+    "",
+    "spawn safety:",
     ...result.actions.map((action) => `  - ${action}`),
   ].join("\n");
 }

--- a/test/isolated/team-charter-plan.test.ts
+++ b/test/isolated/team-charter-plan.test.ts
@@ -4,7 +4,7 @@ import { join } from "path";
 import { homedir, tmpdir } from "os";
 
 import teamHandler from "../../src/vendor/mpr-plugins/team/index";
-import { formatTeamCharterLoad, formatTeamCharterPlan, formatTeamCharterPreflight, loadTeamCharter, parseTeamCharterText, planTeamCharter, preflightTeamCharter } from "../../src/vendor/mpr-plugins/team/team-charter";
+import { composeTeamCharterMemberPrompt, formatTeamCharterLoad, formatTeamCharterPlan, formatTeamCharterPreflight, loadTeamCharter, parseTeamCharterText, planTeamCharter, preflightTeamCharter } from "../../src/vendor/mpr-plugins/team/team-charter";
 import { _setDirs, TEAMS_DIR, TASKS_DIR } from "../../src/vendor/mpr-plugins/team/team-helpers";
 
 const tmpDirs: string[] = [];
@@ -217,6 +217,101 @@ members:
     expect(result.ok).toBe(false);
     expect(result.error).toBe("--no-spawn required");
     expect(result.output).toContain("maw team load <team.yaml|team.json> --no-spawn");
+  });
+
+
+
+  test("composes shared goal before each member prompt for charter spawn", () => {
+    const charter = parseTeamCharterText(`
+name: prompt-team
+goal: |
+  Ship the thing.
+members:
+  - role: builder
+    prompt: |
+      Build narrowly.
+`);
+
+    const prompt = composeTeamCharterMemberPrompt(charter, charter.members[0]);
+
+    expect(prompt).toContain("## Team goal\nShip the thing.");
+    expect(prompt).toContain("## Role prompt\nBuild narrowly.");
+    expect(prompt.indexOf("## Team goal")).toBeLessThan(prompt.indexOf("## Role prompt"));
+  });
+
+  test("handler spawn-from blocks governance approval before writing files", async () => {
+    await withIsolatedTeamStores(async (root) => {
+      const file = join(root, "team.yaml");
+      writeFileSync(file, `
+name: guarded-spawn
+members:
+  - role: scout
+    target: auto
+governance:
+  requires_human_approval: true
+`, "utf-8");
+
+      const result = await teamHandler({ source: "cli", args: ["spawn-from", file] });
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("governance requires human approval");
+      expect(existsSync(join(root, "teams", "guarded-spawn", "config.json"))).toBe(false);
+      expect(existsSync(join(root, "ψ", "memory", "mailbox", "teams", "guarded-spawn", "manifest.json"))).toBe(false);
+    });
+  });
+
+  test("handler spawn-from blocks non-auto targets before writing files", async () => {
+    await withIsolatedTeamStores(async (root) => {
+      const file = join(root, "team.yaml");
+      writeFileSync(file, `
+name: remote-blocked
+members:
+  - role: bridge
+    target: existing:mawjs-oracle
+`, "utf-8");
+
+      const result = await teamHandler({ source: "cli", args: ["spawn-from", file, "--approve"] });
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("supports only target:auto");
+      expect(existsSync(join(root, "teams", "remote-blocked", "config.json"))).toBe(false);
+      expect(existsSync(join(root, "ψ", "memory", "mailbox", "teams", "remote-blocked", "manifest.json"))).toBe(false);
+    });
+  });
+
+  test("handler spawn-from materializes local target:auto spawn prompts without --exec", async () => {
+    await withIsolatedTeamStores(async (root) => {
+      const file = join(root, "team.yaml");
+      writeFileSync(file, `
+name: local-spawn
+description: Local charter spawn
+goal: |
+  Ship charter spawn.
+members:
+  - role: scout
+    target: auto
+    model: spark
+    prompt: |
+      Scout narrowly.
+governance:
+  requires_human_approval: true
+`, "utf-8");
+
+      const result = await teamHandler({ source: "cli", args: ["spawn-from", file, "--approve"] });
+      const promptPath = join(root, "ψ", "memory", "mailbox", "teams", "local-spawn", "scout-spawn-prompt.md");
+      const configPath = join(root, "teams", "local-spawn", "config.json");
+
+      expect(result.ok).toBe(true);
+      expect(result.output).toContain("team charter spawn complete: local-spawn");
+      expect(result.output).toContain("spawn prompts written; no tmux panes spawned without --exec");
+      expect(existsSync(configPath)).toBe(true);
+      expect(JSON.parse(readFileSync(configPath, "utf-8"))).toMatchObject({
+        name: "local-spawn",
+        members: [{ name: "scout", model: "spark" }],
+      });
+      expect(readFileSync(promptPath, "utf-8")).toContain("## Team goal\nShip charter spawn.");
+      expect(readFileSync(promptPath, "utf-8")).toContain("## Role prompt\nScout narrowly.");
+    });
   });
 
   test("handler load subcommand materializes files without spawning", async () => {


### PR DESCRIPTION
## Summary
- add `maw team spawn-from <team.yaml|team.json> [--approve] [--exec]`
- compose shared charter `goal` before each member prompt when writing spawn prompts
- pass member `model`/`cwd` through to local `cmdTeamSpawn`
- block `governance.requires_human_approval` unless `--approve` is present
- block `existing:*` and `new:*` targets in this first implementation so remote/new-oracle side effects cannot happen silently
- keep `maw team load ... --no-spawn` unchanged

## Verification
- `rtk bun test test/isolated/team-charter-plan.test.ts test/isolated/message-ledger.test.ts`
- `rtk bun run build`
- `git diff --check`
- Source smoke: `bun src/cli.ts team spawn-from <team.yaml>` blocked on governance before writing files
- Source smoke: `bun src/cli.ts team spawn-from <team.yaml> --approve` created local target:auto config + spawn prompt, proved goal/prompt composition, then cleaned artifacts

Closes #1607
Refs #1594

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
