### PR TITLE
fix(messages): avoid duplicate engine event sinks

### DIFF
--- a/src/core/engine-plugin-registry.ts
+++ b/src/core/engine-plugin-registry.ts
@@ -195,6 +195,14 @@ export function listEnginePluginRegistrations(): EnginePluginRegistration[] {
   return [...registrations.values()].sort((a, b) => a.prefix.localeCompare(b.prefix));
 }
 
+export function hasEnginePluginEventSink(plugin: string | undefined, event: string): boolean {
+  if (!plugin) return false;
+  return listEnginePluginRegistrations().some((registration) =>
+    registration.plugin === plugin &&
+    registration.events?.includes(event),
+  );
+}
+
 export function findEnginePluginRegistration(pathname: string): EnginePluginRegistration | undefined {
   if (!pathname.startsWith("/api/") || pathname.startsWith("/api/_engine")) return undefined;
   const candidates = [...registrations.values()]

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -19,6 +19,7 @@ import { runServeLifecycleHooks } from "../plugin/lifecycle";
 import {
   dispatchEnginePluginEvent,
   findEnginePluginRegistration,
+  hasEnginePluginEventSink,
   proxyEnginePluginRequest,
   startEnginePluginHealthPolling,
 } from "./engine-plugin-registry";
@@ -129,7 +130,10 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
     const { PluginSystem, loadPlugins, reloadUserPlugins, watchUserPlugins, registerManifestHooks } = require("../plugins/index");
     const { homedir } = require("os");
     const { join, resolve, dirname } = require("path");
-    const plugins = new PluginSystem();
+    const plugins = new PluginSystem({
+      shouldSkipHandler: (eventName: string, pluginName: string | undefined) =>
+        hasEnginePluginEventSink(pluginName, eventName),
+    });
 
     // Built-in plugins (ship with maw-js)
     const builtinDir = resolve(dirname(new URL(import.meta.url).pathname), "plugins", "builtin");

--- a/src/plugins/10_system.ts
+++ b/src/plugins/10_system.ts
@@ -6,6 +6,10 @@
 import type { FeedEvent } from "../lib/feed";
 import type { Gate, Filter, Handler, Late, MawPlugin, MawHooks, PluginScope, PluginInfo, Scoped } from "./00_types";
 
+export interface PluginSystemOptions {
+  shouldSkipHandler?: (eventName: string, pluginName: string | undefined) => boolean;
+}
+
 export class PluginSystem {
   private gates = new Map<string, Scoped<Gate>[]>();
   private filters = new Map<string, Scoped<Filter>[]>();
@@ -21,6 +25,21 @@ export class PluginSystem {
   private _currentPluginName?: string;
   private _reloads = 0;
   private _lastReloadAt?: string;
+
+  constructor(private readonly opts: PluginSystemOptions = {}) {}
+
+  withPluginContext<T>(name: string | undefined, scope: PluginScope, fn: () => T): T {
+    const prevScope = this._currentScope;
+    const prevName = this._currentPluginName;
+    this._currentScope = scope;
+    this._currentPluginName = name;
+    try {
+      return fn();
+    } finally {
+      this._currentScope = prevScope;
+      this._currentPluginName = prevName;
+    }
+  }
 
   private _addTo<T>(map: Map<string, Scoped<T>[]>, event: string, fn: T) {
     const entry: Scoped<T> = { fn, scope: this._currentScope, name: this._currentPluginName };
@@ -67,6 +86,7 @@ export class PluginSystem {
     // Phase 2: HANDLE
     const readOnly = Object.freeze({ ...event });
     for (const { fn, name } of [...(this.handlers.get(event.event) ?? []), ...(this.handlers.get("*") ?? [])]) {
+      if (this.opts.shouldSkipHandler?.(event.event, name)) continue;
       try { await fn(readOnly); }
       catch (err) { console.error(`[plugin] ${event.event}:`, (err as Error).message); this._recordError(name, err as Error); }
     }
@@ -82,14 +102,10 @@ export class PluginSystem {
   }
 
   load(plugin: MawPlugin, scope: PluginScope = "user", name?: string) {
-    const prevScope = this._currentScope;
-    const prevName = this._currentPluginName;
-    this._currentScope = scope;
-    this._currentPluginName = name;
-    try {
+    return this.withPluginContext(name, scope, () => {
       const teardown = plugin(this.hooks);
       if (typeof teardown === "function") this.teardowns.push({ fn: teardown, scope });
-    } finally { this._currentScope = prevScope; this._currentPluginName = prevName; }
+    });
   }
 
   register(name: string, type: PluginInfo["type"], source: PluginScope = "user") {

--- a/src/plugins/30_hooks-registry.ts
+++ b/src/plugins/30_hooks-registry.ts
@@ -26,21 +26,31 @@ export async function registerManifestHooks(system: PluginSystem): Promise<numbe
     try { mod = await import(plugin.entryPath); } catch { continue; }
 
     const hooks = plugin.manifest.hooks;
+    let registeredForPlugin = 0;
 
-    for (const [phase, exportNames] of Object.entries(PHASE_EXPORTS)) {
-      const events = hooks[phase as keyof typeof hooks];
-      if (!events) continue;
+    const registerHookEntries = () => {
+      for (const [phase, exportNames] of Object.entries(PHASE_EXPORTS)) {
+        const events = hooks[phase as keyof typeof hooks];
+        if (!events) continue;
 
-      const fn = exportNames.reduce((f: any, name: string) => f ?? mod[name], null);
-      if (typeof fn !== "function") continue;
+        const fn = exportNames.reduce((f: any, name: string) => f ?? mod[name], null);
+        if (typeof fn !== "function") continue;
 
-      for (const event of events) {
-        (system.hooks as any)[phase](event, fn);
-        registered++;
+        for (const event of events) {
+          (system.hooks as any)[phase](event, fn);
+          registered++;
+          registeredForPlugin++;
+        }
       }
+    };
+
+    if (typeof (system as any).withPluginContext === "function") {
+      (system as any).withPluginContext(plugin.manifest.name, "user", registerHookEntries);
+    } else {
+      registerHookEntries();
     }
 
-    if (registered > 0) {
+    if (registeredForPlugin > 0) {
       system.register(plugin.manifest.name, "ts", "user");
     }
   }

--- a/test/hooks-registry.test.ts
+++ b/test/hooks-registry.test.ts
@@ -33,7 +33,8 @@ mock.module(BOTH_ENTRY, () => ({ onGate: gateFn, onEvent: onFn }));
 // --- Minimal PluginSystem stand-in (avoids pulling in full dependency chain) ---
 
 function makeSystem() {
-  const hookCalls: Record<string, Array<[string, Function]>> = {
+  let currentName: string | undefined;
+  const hookCalls: Record<string, Array<[string, Function, string | undefined]>> = {
     gate: [],
     filter: [],
     on: [],
@@ -42,10 +43,15 @@ function makeSystem() {
   const registered: Array<{ name: string; type: string }> = [];
   return {
     hooks: {
-      gate: (ev: string, fn: Function) => hookCalls.gate.push([ev, fn]),
-      filter: (ev: string, fn: Function) => hookCalls.filter.push([ev, fn]),
-      on: (ev: string, fn: Function) => hookCalls.on.push([ev, fn]),
-      late: (ev: string, fn: Function) => hookCalls.late.push([ev, fn]),
+      gate: (ev: string, fn: Function) => hookCalls.gate.push([ev, fn, currentName]),
+      filter: (ev: string, fn: Function) => hookCalls.filter.push([ev, fn, currentName]),
+      on: (ev: string, fn: Function) => hookCalls.on.push([ev, fn, currentName]),
+      late: (ev: string, fn: Function) => hookCalls.late.push([ev, fn, currentName]),
+    },
+    withPluginContext: (name: string, _scope: string, fn: Function) => {
+      const prev = currentName;
+      currentName = name;
+      try { return fn(); } finally { currentName = prev; }
     },
     register: (name: string, type: string) => registered.push({ name, type }),
     _hookCalls: hookCalls,
@@ -106,6 +112,7 @@ describe("registerManifestHooks", () => {
     expect(count).toBe(1);
     expect(system._hookCalls.on).toHaveLength(1);
     expect(system._hookCalls.on[0][0]).toBe("feed:update");
+    expect(system._hookCalls.on[0][2]).toBe("on-plugin");
   });
 
   test("WASM plugin is skipped (only TS supported)", async () => {

--- a/test/isolated/engine-plugin-registry.test.ts
+++ b/test/isolated/engine-plugin-registry.test.ts
@@ -6,6 +6,7 @@ import {
   clearEnginePluginRegistrations,
   dispatchEnginePluginEvent,
   findEnginePluginRegistration,
+  hasEnginePluginEventSink,
   listEnginePluginRegistrations,
   pollEnginePluginHealth,
   proxyEnginePluginRequest,
@@ -45,6 +46,22 @@ describe("engine plugin registry (#1566)", () => {
     expect(findEnginePluginRegistration("/api/hey-ledger/admin/users")?.plugin).toBe(nested.plugin);
     expect(findEnginePluginRegistration("/api/hey-ledger/messages")?.plugin).toBe(root.plugin);
     expect(findEnginePluginRegistration("/api/_engine/register")).toBeUndefined();
+  });
+
+  test("reports active event sinks by plugin and event", () => {
+    expect(hasEnginePluginEventSink("messages", "MessageSend")).toBe(false);
+    registerEnginePlugin({
+      plugin: "messages",
+      prefix: "/api/message-ledger",
+      upstream: "http://127.0.0.1:43210",
+      events: ["MessageSend", "MessageDeliver"],
+      eventPath: "/events",
+    });
+
+    expect(hasEnginePluginEventSink("messages", "MessageSend")).toBe(true);
+    expect(hasEnginePluginEventSink("messages", "MessageFail")).toBe(false);
+    expect(hasEnginePluginEventSink("other", "MessageSend")).toBe(false);
+    expect(hasEnginePluginEventSink(undefined, "MessageSend")).toBe(false);
   });
 
   test("rejects unsafe prefixes and non-loopback upstreams", () => {

--- a/test/plugins.test.ts
+++ b/test/plugins.test.ts
@@ -70,6 +70,24 @@ describe("PluginSystem", () => {
     expect(order).toEqual([1, 2]);
   });
 
+  test("can skip a named in-process handler when an external event sink owns the event", async () => {
+    const sys = new PluginSystem({
+      shouldSkipHandler: (eventName, pluginName) =>
+        eventName === "MessageSend" && pluginName === "messages",
+    });
+    const received: string[] = [];
+
+    sys.load((hooks) => {
+      hooks.on("MessageSend", () => received.push("messages"));
+    }, "user", "messages");
+    sys.load((hooks) => {
+      hooks.on("MessageSend", () => received.push("other"));
+    }, "user", "other");
+
+    await sys.emit({ ...mockEvent, event: "MessageSend" });
+    expect(received).toEqual(["other"]);
+  });
+
   test("error in one plugin does not crash others", async () => {
     const sys = new PluginSystem();
     const received: string[] = [];


### PR DESCRIPTION
## Summary
- add engine-registration event sink detection by plugin + event
- keep manifest hook plugin context so dynamic engine plugins can stand down only their own in-process handlers
- preserve in-process manifest hooks as fallback when no engine process owns the event

Fixes #1609.

## Verification
- `rtk bun test test/plugins.test.ts test/hooks-registry.test.ts test/isolated/engine-plugin-registry.test.ts test/isolated/message-ledger.test.ts`
- isolated two-node `maw messages serve --detach --engine` proof: sender outbound + receiver inbound ledger rows written, no `[plugin] Message...`, `database is locked`, or `no such table` log errors
- `rtk bun run build`
- `git diff --check`

## Release lane
- Targets `alpha` only. No release-alpha/version/tag/publish cut.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.