### PR TITLE
revert(ls): restore compact default

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -47,7 +47,7 @@ export const ALIAS_DESCRIPTIONS: Record<string, string> = {
   tile: "Tile current window or spawn N panes tiled",
   bring: "Bring an oracle HERE — split current pane and attach",
   b: "Bring an oracle HERE (short form of `bring`)",
-  ls: "List sessions (detail default, -c compact, -a roster)",
+  ls: "List sessions (compact default, -v detail, -a roster)",
   scaffold: "Create oracle repo + skeleton only (no commit, wake, or /awaken)",
   wake: "Wake an oracle session (fuzzy match, auto-clone)",
   awake: "Launch an oracle process with optional engine (does not trigger /awaken)",
@@ -73,9 +73,9 @@ export const TOP_ALIASES: Record<string, string[] | DirectHandler> = {
   b: { kind: "direct", handler: "../commands/shared/wake-cmd:cmdBring" },
 
   // Direct-handler form — `ls` flags differ from tmux ls:
-  //   maw ls      → full per-pane detail (#1556)
-  //   maw ls -v   → no-op alias for muscle memory (same as default)
-  //   maw ls -c   → compact live-session summary
+  //   maw ls      → compact live-session summary (#1613)
+  //   maw ls -v   → full per-pane detail
+  //   maw ls -c   → explicit compact alias
   //   maw ls -a   → compact + sleeping oracles (roster; legacy behavior)
   ls: { kind: "direct", handler: "cmdLs" },
   scaffold: ["bud", "--scaffold-only"],
@@ -170,8 +170,9 @@ function printWakeAliasUsage(verb: "wake" | "awake", write: (line: string) => vo
  * help-text rendering, but the path is no longer used at runtime —
  * dispatch is by `exportName` against a static handler map.
  *
- * For `ls`, detail is the default; `-v` is a no-op alias, `-c` returns the
- * compact summary, and `-a` preserves the legacy compact+roster behavior.
+ * For `ls`, compact summary is the default; `-v` returns full per-pane detail,
+ * `-c` is an explicit compact alias, and `-a` preserves the legacy
+ * compact+roster behavior.
  * For `wake`, parses the 9 known flags and calls cmdWake(oracle, opts).
  */
 export function parseLsAliasOpts(argv: string[]) {
@@ -183,16 +184,16 @@ export function parseLsAliasOpts(argv: string[]) {
     "--json": Boolean,
   }, 0);
 
-  // #1556 — Nat's UX preference: detailed per-pane output is the default,
-  // `-v` stays accepted as a no-op muscle-memory alias, and `-c/--compact`
-  // is the opt-in condensed summary. `-a/--all` historically meant
-  // "include sleeping roster" on top-level `maw ls`; keep that legacy shape
-  // by rendering the compact roster view.
-  const compact = !!flags["--compact"] || !!flags["--all"];
+  // #1613 — restore the original compact default. `-v/--verbose` opts into
+  // per-pane detail; `-c/--compact` is an explicit alias for the default.
+  // `-a/--all` historically meant "include sleeping roster" on top-level
+  // `maw ls`; keep that legacy shape by rendering the compact roster view.
+  const verbose = !!flags["--verbose"] && !flags["--compact"] && !flags["--all"];
+  const compact = !verbose || !!flags["--compact"] || !!flags["--all"];
   return {
     all: true,
     compact,
-    verbose: !compact,
+    verbose,
     roster: !!flags["--all"],
     json: !!flags["--json"],
   };

--- a/src/commands/plugins/tmux/impl.ts
+++ b/src/commands/plugins/tmux/impl.ts
@@ -142,9 +142,9 @@ export interface TmuxLsOpts {
   all?: boolean;
   /** JSON output for scripting. */
   json?: boolean;
-  /** Compact: one line per session. Top-level `maw ls -c` uses this mode. */
+  /** Compact: one line per session. Top-level `maw ls` and `maw ls -c` use this mode. */
   compact?: boolean;
-  /** Verbose: full per-pane detail. Top-level `maw ls` defaults to this mode. */
+  /** Verbose: full per-pane detail. Top-level `maw ls -v` opts into this mode. */
   verbose?: boolean;
   /** Roster: include sleeping oracles from ghq (compact mode only). */
   roster?: boolean;
@@ -302,7 +302,7 @@ export async function cmdTmuxLs(opts: TmuxLsOpts = {}): Promise<void> {
     }
 
     console.log();
-    console.log(`\x1b[90m  → maw ls       full detail\x1b[0m`);
+    console.log(`\x1b[90m  → maw ls -v    full detail\x1b[0m`);
     console.log();
     return;
   }

--- a/src/commands/plugins/tmux/index.ts
+++ b/src/commands/plugins/tmux/index.ts
@@ -69,7 +69,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         console.log("usage: maw tmux ls [--all|-a] [--compact|-c] [-v|--verbose] [--roster] [--json]");
         console.log("  default:    panes in current session only");
         console.log("  --all:      panes across every session");
-        console.log("  --compact:  one line per session (`maw ls -c` for top-level compact)");
+        console.log("  --compact:  one line per session (`maw ls` / `maw ls -c` top-level)");
         console.log("  -v:         full per-pane detail");
         console.log("  --roster:   include sleeping oracles from ghq");
         return { ok: true, output: logs.join("\n") || undefined };

--- a/test/cli/dispatch-match.test.ts
+++ b/test/cli/dispatch-match.test.ts
@@ -229,7 +229,7 @@ describe("resolvePluginMatch — two-pass dispatch", () => {
 });
 
 describe("resolveTopAlias — RFC #954 verb aliases", () => {
-  test("`ls` → direct-handler cmdLs (detail default)", () => {
+  test("`ls` → direct-handler cmdLs (compact default)", () => {
     const out = resolveTopAlias(["ls"]);
     expect(out).not.toBeNull();
     expect(out!.kind).toBe("direct");
@@ -249,7 +249,7 @@ describe("resolveTopAlias — RFC #954 verb aliases", () => {
     }
   });
 
-  test("`ls -v` → direct-handler cmdLs with -v (no-op detail alias)", () => {
+  test("`ls -v` → direct-handler cmdLs with -v (detail alias)", () => {
     const out = resolveTopAlias(["ls", "-v"]);
     expect(out).not.toBeNull();
     expect(out!.kind).toBe("direct");
@@ -259,15 +259,32 @@ describe("resolveTopAlias — RFC #954 verb aliases", () => {
     }
   });
 
-  test("#1556 parse ls opts: default and -v both render per-pane detail", () => {
+  test("#1613 parse ls opts: default and -c render compact summary", () => {
     expect(parseLsAliasOpts([])).toEqual({
+      all: true,
+      compact: true,
+      verbose: false,
+      roster: false,
+      json: false,
+    });
+    expect(parseLsAliasOpts(["-c"])).toEqual({
+      all: true,
+      compact: true,
+      verbose: false,
+      roster: false,
+      json: false,
+    });
+  });
+
+  test("#1613 parse ls opts: -v/--verbose opt into per-pane detail", () => {
+    expect(parseLsAliasOpts(["-v"])).toEqual({
       all: true,
       compact: false,
       verbose: true,
       roster: false,
       json: false,
     });
-    expect(parseLsAliasOpts(["-v"])).toEqual({
+    expect(parseLsAliasOpts(["--verbose"])).toEqual({
       all: true,
       compact: false,
       verbose: true,
@@ -276,14 +293,7 @@ describe("resolveTopAlias — RFC #954 verb aliases", () => {
     });
   });
 
-  test("#1556 parse ls opts: -c/--compact opt into condensed summary", () => {
-    expect(parseLsAliasOpts(["-c"])).toEqual({
-      all: true,
-      compact: true,
-      verbose: false,
-      roster: false,
-      json: false,
-    });
+  test("#1613 parse ls opts: --compact is explicit condensed summary", () => {
     expect(parseLsAliasOpts(["--compact"])).toEqual({
       all: true,
       compact: true,
@@ -293,7 +303,7 @@ describe("resolveTopAlias — RFC #954 verb aliases", () => {
     });
   });
 
-  test("#1556 parse ls opts: -a keeps legacy compact roster behavior", () => {
+  test("#1613 parse ls opts: -a keeps legacy compact roster behavior", () => {
     expect(parseLsAliasOpts(["-a"])).toEqual({
       all: true,
       compact: true,


### PR DESCRIPTION
## Summary
- Restore top-level `maw ls` to the compact session summary default.
- Keep `maw ls -v` as the detailed per-pane/TARGET view.
- Keep `maw ls -c` / `--compact` as explicit compact aliases and update hints/help text.

## Validation
- `rtk bun test test/cli/dispatch-match.test.ts`
- `rtk bun run build`
- User-visible smoke: `maw ls` prints compact session rows and no `TARGET` header.
- User-visible smoke: `maw ls -v` prints the detailed `TARGET` table.
- User-visible smoke: `maw ls -c` stays compact.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.

Closes #1613
