### PR TITLE
chore(test): add coverage report and gap analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ psi/
 
 # Local Codex/OMX runtime state
 .omx/
+
+# Test coverage artifacts
+coverage/

--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,0 +1,137 @@
+# Coverage gap analysis
+
+Generated: 2026-05-16T14:45:01.849Z
+
+Input: `coverage/lcov.info`
+
+Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
+
+Overall line coverage: **12.9%** (6511/50588)
+Overall function coverage: **48.5%** (622/1283)
+
+## Module summary
+
+| Module | Files | Missing from LCOV | Lines | Functions | Branches |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| cli/dispatch | 88 | 28 | 21.2% (1585/7488) | 50.5% (144/285) | n/a (0/0) |
+| config/runtime | 19 | 2 | 43.3% (510/1179) | 40.2% (35/87) | n/a (0/0) |
+| fleet | 16 | 1 | 16.3% (179/1100) | 44.9% (22/49) | n/a (0/0) |
+| matcher | 2 | 0 | 100.0% (41/41) | 100.0% (8/8) | n/a (0/0) |
+| other | 174 | 98 | 18.0% (2575/14322) | 54.2% (252/465) | n/a (0/0) |
+| plugin dispatch | 15 | 1 | 46.6% (595/1276) | 67.2% (45/67) | n/a (0/0) |
+| routing/aliases | 4 | 2 | 41.3% (248/601) | 83.3% (25/30) | n/a (0/0) |
+| transport | 28 | 3 | 23.0% (633/2754) | 28.8% (79/274) | n/a (0/0) |
+| vendor plugins | 244 | 243 | 0.7% (145/21827) | 66.7% (12/18) | n/a (0/0) |
+
+## Top 20 uncovered files by executable/source line count
+
+| Rank | Risk | Module | File | Uncovered | Line coverage | Function coverage | Note |
+| ---: | --- | --- | --- | ---: | ---: | ---: | --- |
+| 1 | low | vendor plugins | `src/vendor/mpr-plugins/dream/impl.ts` | 885 | 0.0% | n/a | absent from LCOV |
+| 2 | critical | cli/dispatch | `src/commands/shared/wake-cmd.ts` | 599 | 5.5% | 4.8% | partial coverage |
+| 3 | medium | other | `src/commands/plugins/tmux/impl.ts` | 524 | 5.2% | 0.0% | partial coverage |
+| 4 | critical | cli/dispatch | `src/commands/shared/comm-send.ts` | 510 | 9.3% | 26.7% | partial coverage |
+| 5 | low | vendor plugins | `src/vendor/mpr-plugins/team/team-charter.ts` | 482 | 0.0% | n/a | absent from LCOV |
+| 6 | medium | other | `src/commands/plugins/team/index.ts` | 477 | 0.0% | n/a | absent from LCOV |
+| 7 | low | vendor plugins | `src/vendor/mpr-plugins/messages/index.ts` | 398 | 0.0% | n/a | absent from LCOV |
+| 8 | medium | other | `src/api/sessions.ts` | 372 | 16.8% | 12.5% | partial coverage |
+| 9 | low | vendor plugins | `src/vendor/mpr-plugins/cleanup/internal/prune-stale-oracles.ts` | 366 | 0.0% | n/a | absent from LCOV |
+| 10 | critical | cli/dispatch | `src/cli/cmd-update.ts` | 364 | 0.0% | n/a | absent from LCOV |
+| 11 | medium | other | `src/core/engine-plugin-registry.ts` | 336 | 0.0% | n/a | absent from LCOV |
+| 12 | low | vendor plugins | `src/vendor/mpr-plugins/doctor/impl.ts` | 332 | 0.0% | n/a | absent from LCOV |
+| 13 | low | vendor plugins | `src/vendor/mpr-plugins/bg/src/impl.ts` | 297 | 0.0% | n/a | absent from LCOV |
+| 14 | low | vendor plugins | `src/vendor/mpr-plugins/team/index.ts` | 291 | 0.0% | n/a | absent from LCOV |
+| 15 | medium | other | `src/commands/plugins/tile/impl.ts` | 283 | 0.0% | n/a | absent from LCOV |
+| 16 | medium | other | `src/commands/plugins/plugin/install-handlers.ts` | 280 | 24.9% | 18.8% | partial coverage |
+| 17 | critical | cli/dispatch | `src/commands/shared/wake-resolve-impl.ts` | 274 | 14.4% | 35.3% | partial coverage |
+| 18 | low | vendor plugins | `src/vendor/mpr-plugins/view/impl.ts` | 269 | 0.0% | n/a | absent from LCOV |
+| 19 | critical | transport | `src/core/transport/tmux-class.ts` | 267 | 15.2% | 30.4% | partial coverage |
+| 20 | medium | other | `src/commands/plugins/tmux/index.ts` | 253 | 0.0% | n/a | absent from LCOV |
+
+## Critical files at or above the 80% line target
+
+| Module | File | Line coverage | Function coverage |
+| --- | --- | ---: | ---: |
+| cli/dispatch | `src/cli/command-registry-match.ts` | 100.0% | 100.0% |
+| cli/dispatch | `src/cli/command-registry-types.ts` | 100.0% | 100.0% |
+| cli/dispatch | `src/cli/command-registry-wasm.ts` | 87.1% | 50.0% |
+| cli/dispatch | `src/cli/command-registry.ts` | 96.7% | 100.0% |
+| cli/dispatch | `src/cli/dispatch-match.ts` | 88.5% | 85.7% |
+| cli/dispatch | `src/cli/parse-args.ts` | 100.0% | 100.0% |
+| cli/dispatch | `src/cli/usage.ts` | 89.6% | 92.9% |
+| cli/dispatch | `src/cli/verbosity.ts` | 100.0% | 100.0% |
+| cli/dispatch | `src/commands/shared/comm.ts` | 100.0% | 100.0% |
+| cli/dispatch | `src/commands/shared/federation-apply.ts` | 100.0% | 100.0% |
+| cli/dispatch | `src/commands/shared/federation-diff.ts` | 100.0% | 100.0% |
+| cli/dispatch | `src/commands/shared/federation-identity.ts` | 100.0% | 100.0% |
+| cli/dispatch | `src/commands/shared/federation-sync.ts` | 100.0% | 100.0% |
+| cli/dispatch | `src/commands/shared/fleet-doctor-checks-repo.ts` | 100.0% | 100.0% |
+| cli/dispatch | `src/commands/shared/fleet-doctor-checks.ts` | 97.5% | 100.0% |
+| cli/dispatch | `src/commands/shared/fleet-doctor-fixer.ts` | 87.3% | 40.0% |
+| cli/dispatch | `src/commands/shared/fleet-wake-failsoft.ts` | 100.0% | 100.0% |
+| cli/dispatch | `src/commands/shared/plugin-create-as.ts` | 100.0% | 100.0% |
+| cli/dispatch | `src/commands/shared/plugin-create-rust.ts` | 100.0% | 100.0% |
+| cli/dispatch | `src/commands/shared/plugin-create-scaffold.ts` | 82.7% | 75.0% |
+| cli/dispatch | `src/commands/shared/plugin-create.ts` | 100.0% | 100.0% |
+| cli/dispatch | `src/commands/shared/plugins-ls-info.ts` | 87.1% | 90.0% |
+| cli/dispatch | `src/commands/shared/plugins-ui.ts` | 96.0% | 100.0% |
+| cli/dispatch | `src/commands/shared/target-cwd.ts` | 100.0% | 100.0% |
+| cli/dispatch | `src/commands/shared/wake-resolve.ts` | 100.0% | 100.0% |
+| cli/dispatch | `src/commands/shared/wake-target.ts` | 80.0% | 80.0% |
+| cli/dispatch | `src/commands/shared/wake.ts` | 100.0% | 100.0% |
+| cli/dispatch | `src/commands/shared/workspace.ts` | 100.0% | 100.0% |
+| fleet | `src/core/fleet/oracle-registry.ts` | 100.0% | 100.0% |
+| fleet | `src/core/fleet/registry-oracle-types.ts` | 100.0% | 100.0% |
+| fleet | `src/core/fleet/snapshot.ts` | 93.4% | 100.0% |
+| fleet | `src/core/fleet/validate.ts` | 100.0% | 100.0% |
+| fleet | `src/core/fleet/worktrees.ts` | 100.0% | 100.0% |
+| matcher | `src/core/matcher/normalize-target.ts` | 100.0% | 100.0% |
+| matcher | `src/core/matcher/resolve-target.ts` | 100.0% | 100.0% |
+| plugin dispatch | `src/plugin/default-active.ts` | 100.0% | 100.0% |
+| plugin dispatch | `src/plugin/manifest-constants.ts` | 100.0% | 100.0% |
+| plugin dispatch | `src/plugin/manifest-load.ts` | 100.0% | 100.0% |
+| plugin dispatch | `src/plugin/manifest-parse.ts` | 96.3% | 100.0% |
+| plugin dispatch | `src/plugin/manifest-validate.ts` | 89.7% | 100.0% |
+| plugin dispatch | `src/plugin/manifest.ts` | 100.0% | 100.0% |
+| plugin dispatch | `src/plugin/tier.ts` | 100.0% | 100.0% |
+| routing/aliases | `src/core/routing.ts` | 89.1% | 91.7% |
+| transport | `src/core/transport/tmux.ts` | 100.0% | 100.0% |
+| transport | `src/core/transport/transport.ts` | 100.0% | 96.4% |
+| transport | `src/transports/hub-config.ts` | 90.0% | 100.0% |
+| transport | `src/transports/hub.ts` | 100.0% | 100.0% |
+| transport | `src/transports/zenoh-scout.ts` | 90.3% | 66.7% |
+
+## Critical files below the 80% line target (next queue)
+
+| Module | File | Uncovered | Line coverage |
+| --- | --- | ---: | ---: |
+| cli/dispatch | `src/commands/shared/wake-cmd.ts` | 599 | 5.5% |
+| cli/dispatch | `src/commands/shared/comm-send.ts` | 510 | 9.3% |
+| cli/dispatch | `src/cli/cmd-update.ts` | 364 | 0.0% |
+| cli/dispatch | `src/commands/shared/wake-resolve-impl.ts` | 274 | 14.4% |
+| transport | `src/core/transport/tmux-class.ts` | 267 | 15.2% |
+| transport | `src/transports/scout.ts` | 248 | 8.5% |
+| cli/dispatch | `src/commands/shared/done.ts` | 207 | 0.0% |
+| plugin dispatch | `src/plugin/registry-invoke.ts` | 200 | 2.4% |
+| transport | `src/transports/mdns.ts` | 184 | 7.5% |
+| fleet | `src/core/fleet/worktrees-scan.ts` | 180 | 3.2% |
+
+## Critical gaps to prioritize
+
+- `src/commands/shared/wake-cmd.ts` (cli/dispatch): 599 uncovered lines, 5.5% line coverage.
+- `src/commands/shared/comm-send.ts` (cli/dispatch): 510 uncovered lines, 9.3% line coverage.
+- `src/cli/cmd-update.ts` (cli/dispatch): 364 uncovered lines, 0.0% line coverage.
+- `src/commands/shared/wake-resolve-impl.ts` (cli/dispatch): 274 uncovered lines, 14.4% line coverage.
+- `src/core/transport/tmux-class.ts` (transport): 267 uncovered lines, 15.2% line coverage.
+
+## Prioritization guidance
+
+- High-signal gaps likely to catch real bugs: wake/bring dispatch (`wake-cmd.ts`, `wake-resolve-impl.ts`), message delivery/routing (`comm-send.ts`, `routing.ts`), tmux transport primitives (`tmux-class.ts`), peer discovery transports (`scout.ts`, `mdns.ts`), plugin invocation (`registry-invoke.ts`), and worktree/fleet scans (`worktrees-scan.ts`).
+- Lower-signal/ceremony gaps: large vendored MPR plugin implementations, UI/cosmetic renderers, and plugin bodies where behavior is better covered by CLI smoke tests or end-to-end plugin tests.
+- Portable-core candidates for #1612 fixture extraction: matcher, routing alias guards, calver, plugin tier/default-active policy, and pure transport-router selection/failover.
+
+## Notes
+
+- Critical = routing/aliases, CLI dispatch, transports, fleet, matcher, and plugin dispatch.
+- Low-risk = vendor plugin surfaces and UI/cosmetic code where smoke/manual tests often provide better value than line-driven unit tests.
+- Files absent from LCOV are counted as zero-covered using non-empty/non-comment source lines so the report exposes untouched modules, not only imported files.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "ship:alpha:dry": "bash scripts/ship-alpha.sh --dry-run",
     "calver": "bun scripts/calver.ts",
     "check:redos": "bun scripts/check-redos.ts",
-    "preflight": "bash scripts/preflight.sh"
+    "preflight": "bash scripts/preflight.sh",
+    "test:coverage": "bash scripts/test-coverage.sh",
+    "coverage:gap": "bun scripts/coverage-gap-analysis.ts coverage/lcov.info docs/testing/coverage-gap-analysis.md"
   },
   "description": "maw.js — Multi-Agent Workflow in Bun/TS. Remote tmux orchestra control. CLI + Web UI.",
   "dependencies": {

--- a/scripts/coverage-gap-analysis.ts
+++ b/scripts/coverage-gap-analysis.ts
@@ -1,0 +1,256 @@
+#!/usr/bin/env bun
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+
+type Counts = { linesFound: number; linesHit: number; funcsFound: number; funcsHit: number; branchesFound: number; branchesHit: number };
+type FileCov = Counts & { file: string; sourceLines: number; missingFromLcov: boolean };
+
+type ModuleSummary = Counts & { files: number; missingFiles: number };
+
+const cwd = process.cwd();
+const lcovPath = process.argv[2] || "coverage/lcov.info";
+const outPath = process.argv[3] || "docs/testing/coverage-gap-analysis.md";
+
+function relPath(file: string): string {
+  const normalized = file.replaceAll("\\", "/");
+  const rel = normalized.startsWith(cwd.replaceAll("\\", "/"))
+    ? relative(cwd, normalized).replaceAll("\\", "/")
+    : normalized;
+  return rel.replace(/^\.\//, "");
+}
+
+function countSourceLines(file: string): number {
+  const text = readFileSync(file, "utf8");
+  return text.split(/\r?\n/).filter((line) => {
+    const trimmed = line.trim();
+    return trimmed.length > 0 && !trimmed.startsWith("//") && !trimmed.startsWith("/*") && !trimmed.startsWith("*");
+  }).length;
+}
+
+function walk(dir: string, out: string[] = []): string[] {
+  if (!existsSync(dir)) return out;
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      if (name === "node_modules" || name === "dist" || name === "coverage") continue;
+      walk(full, out);
+    } else if (/\.tsx?$/.test(name) && !name.endsWith(".d.ts") && !name.endsWith(".test.ts")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function emptyCounts(): Counts {
+  return { linesFound: 0, linesHit: 0, funcsFound: 0, funcsHit: 0, branchesFound: 0, branchesHit: 0 };
+}
+
+function parseLcov(path: string): Map<string, FileCov> {
+  if (!existsSync(path)) throw new Error(`coverage lcov not found: ${path}`);
+  const map = new Map<string, FileCov>();
+  const records = readFileSync(path, "utf8").split("end_of_record");
+  for (const record of records) {
+    const lines = record.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+    const sf = lines.find((line) => line.startsWith("SF:"));
+    if (!sf) continue;
+    const file = relPath(sf.slice(3));
+    if (!file.startsWith("src/") || !/\.tsx?$/.test(file) || file.endsWith(".d.ts") || file.endsWith(".test.ts")) continue;
+
+    const cov: FileCov = { file, sourceLines: existsSync(file) ? countSourceLines(file) : 0, missingFromLcov: false, ...emptyCounts() };
+    const da = new Map<number, number>();
+    for (const line of lines) {
+      if (line.startsWith("DA:")) {
+        const [lineNo, hits] = line.slice(3).split(",").map(Number);
+        if (Number.isFinite(lineNo) && Number.isFinite(hits)) da.set(lineNo, hits);
+      } else if (line.startsWith("LF:")) cov.linesFound = Number(line.slice(3)) || 0;
+      else if (line.startsWith("LH:")) cov.linesHit = Number(line.slice(3)) || 0;
+      else if (line.startsWith("FNF:")) cov.funcsFound = Number(line.slice(4)) || 0;
+      else if (line.startsWith("FNH:")) cov.funcsHit = Number(line.slice(4)) || 0;
+      else if (line.startsWith("BRF:")) cov.branchesFound = Number(line.slice(4)) || 0;
+      else if (line.startsWith("BRH:")) cov.branchesHit = Number(line.slice(4)) || 0;
+    }
+    if (cov.linesFound === 0 && da.size > 0) {
+      cov.linesFound = da.size;
+      cov.linesHit = [...da.values()].filter((hits) => hits > 0).length;
+    }
+    map.set(file, cov);
+  }
+  return map;
+}
+
+function moduleOf(file: string): string {
+  if (file.startsWith("src/core/matcher/")) return "matcher";
+  if (file === "src/core/routing.ts" || file.startsWith("src/cli/route-") || file.startsWith("src/cli/top-aliases")) return "routing/aliases";
+  if (file.startsWith("src/cli/") || file.startsWith("src/commands/shared/")) return "cli/dispatch";
+  if (file.startsWith("src/core/transport/") || file.startsWith("src/transports/")) return "transport";
+  if (file.startsWith("src/core/fleet/")) return "fleet";
+  if (file.startsWith("src/plugin/")) return "plugin dispatch";
+  if (file.startsWith("src/config/") || file.startsWith("src/core/runtime/")) return "config/runtime";
+  if (file.startsWith("src/vendor/")) return "vendor plugins";
+  if (file.startsWith("src/ui/") || file.includes("/style") || file.includes("/theme")) return "ui/cosmetic";
+  return "other";
+}
+
+function riskOf(file: string): "critical" | "medium" | "low" {
+  const mod = moduleOf(file);
+  if (["matcher", "routing/aliases", "cli/dispatch", "transport", "fleet", "plugin dispatch"].includes(mod)) return "critical";
+  if (["config/runtime"].includes(mod)) return "medium";
+  if (["ui/cosmetic", "vendor plugins"].includes(mod)) return "low";
+  return "medium";
+}
+
+function add(into: Counts, from: Counts): void {
+  into.linesFound += from.linesFound;
+  into.linesHit += from.linesHit;
+  into.funcsFound += from.funcsFound;
+  into.funcsHit += from.funcsHit;
+  into.branchesFound += from.branchesFound;
+  into.branchesHit += from.branchesHit;
+}
+
+function ratio(hit: number, found: number): number {
+  return found ? hit / found : 0;
+}
+
+function pct(hit: number, found: number): string {
+  if (!found) return "n/a";
+  return `${(ratio(hit, found) * 100).toFixed(1)}%`;
+}
+
+function escCell(value: string): string {
+  return value.replaceAll("|", "\\|");
+}
+
+const lcov = parseLcov(lcovPath);
+for (const abs of walk("src")) {
+  const file = relPath(abs);
+  if (lcov.has(file)) continue;
+  const sourceLines = countSourceLines(abs);
+  lcov.set(file, {
+    file,
+    sourceLines,
+    missingFromLcov: true,
+    linesFound: sourceLines,
+    linesHit: 0,
+    funcsFound: 0,
+    funcsHit: 0,
+    branchesFound: 0,
+    branchesHit: 0,
+  });
+}
+
+const files = [...lcov.values()].sort((a, b) => a.file.localeCompare(b.file));
+const modules = new Map<string, ModuleSummary>();
+const overall = emptyCounts();
+for (const file of files) {
+  add(overall, file);
+  const name = moduleOf(file.file);
+  const summary = modules.get(name) || { files: 0, missingFiles: 0, ...emptyCounts() };
+  summary.files += 1;
+  if (file.missingFromLcov) summary.missingFiles += 1;
+  add(summary, file);
+  modules.set(name, summary);
+}
+
+const top20 = files
+  .map((file) => ({ ...file, uncovered: Math.max(0, file.linesFound - file.linesHit), risk: riskOf(file.file), module: moduleOf(file.file) }))
+  .filter((file) => file.uncovered > 0)
+  .sort((a, b) => b.uncovered - a.uncovered || a.file.localeCompare(b.file))
+  .slice(0, 20);
+
+const criticalPriorities = top20.filter((file) => file.risk === "critical").slice(0, 10);
+
+const criticalWithCoverage = files
+  .map((file) => ({ ...file, uncovered: Math.max(0, file.linesFound - file.linesHit), risk: riskOf(file.file), module: moduleOf(file.file) }))
+  .filter((file) => file.risk === "critical" && file.linesFound > 0);
+const criticalAtTarget = criticalWithCoverage
+  .filter((file) => ratio(file.linesHit, file.linesFound) >= 0.8)
+  .sort((a, b) => a.module.localeCompare(b.module) || a.file.localeCompare(b.file));
+const criticalBelowTarget = criticalWithCoverage
+  .filter((file) => ratio(file.linesHit, file.linesFound) < 0.8)
+  .sort((a, b) => b.uncovered - a.uncovered || a.file.localeCompare(b.file))
+  .slice(0, 10);
+const generatedAt = new Date().toISOString();
+const md: string[] = [];
+md.push(`# Coverage gap analysis`);
+md.push("");
+md.push(`Generated: ${generatedAt}`);
+md.push("");
+md.push(`Input: \`${lcovPath}\``);
+md.push("");
+md.push(`Coverage scope: Bun LCOV plus zero-coverage accounting for tracked \`src/**/*.ts\` files absent from LCOV.`);
+md.push("");
+md.push(`Overall line coverage: **${pct(overall.linesHit, overall.linesFound)}** (${overall.linesHit}/${overall.linesFound})`);
+md.push(`Overall function coverage: **${pct(overall.funcsHit, overall.funcsFound)}** (${overall.funcsHit}/${overall.funcsFound})`);
+if (overall.branchesFound) md.push(`Overall branch coverage: **${pct(overall.branchesHit, overall.branchesFound)}** (${overall.branchesHit}/${overall.branchesFound})`);
+md.push("");
+md.push(`## Module summary`);
+md.push("");
+md.push(`| Module | Files | Missing from LCOV | Lines | Functions | Branches |`);
+md.push(`| --- | ---: | ---: | ---: | ---: | ---: |`);
+for (const [name, summary] of [...modules.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+  md.push(`| ${escCell(name)} | ${summary.files} | ${summary.missingFiles} | ${pct(summary.linesHit, summary.linesFound)} (${summary.linesHit}/${summary.linesFound}) | ${pct(summary.funcsHit, summary.funcsFound)} (${summary.funcsHit}/${summary.funcsFound}) | ${pct(summary.branchesHit, summary.branchesFound)} (${summary.branchesHit}/${summary.branchesFound}) |`);
+}
+md.push("");
+md.push(`## Top 20 uncovered files by executable/source line count`);
+md.push("");
+md.push(`| Rank | Risk | Module | File | Uncovered | Line coverage | Function coverage | Note |`);
+md.push(`| ---: | --- | --- | --- | ---: | ---: | ---: | --- |`);
+top20.forEach((file, index) => {
+  const note = file.missingFromLcov ? "absent from LCOV" : "partial coverage";
+  md.push(`| ${index + 1} | ${file.risk} | ${escCell(file.module)} | \`${file.file}\` | ${file.uncovered} | ${pct(file.linesHit, file.linesFound)} | ${pct(file.funcsHit, file.funcsFound)} | ${note} |`);
+});
+md.push("");
+md.push(`## Critical files at or above the 80% line target`);
+md.push("");
+if (criticalAtTarget.length === 0) {
+  md.push(`No critical files are currently at the 80% line target.`);
+} else {
+  md.push(`| Module | File | Line coverage | Function coverage |`);
+  md.push(`| --- | --- | ---: | ---: |`);
+  for (const file of criticalAtTarget) {
+    md.push(`| ${escCell(file.module)} | \`${file.file}\` | ${pct(file.linesHit, file.linesFound)} | ${pct(file.funcsHit, file.funcsFound)} |`);
+  }
+}
+md.push("");
+md.push(`## Critical files below the 80% line target (next queue)`);
+md.push("");
+md.push(`| Module | File | Uncovered | Line coverage |`);
+md.push(`| --- | --- | ---: | ---: |`);
+for (const file of criticalBelowTarget) {
+  md.push(`| ${escCell(file.module)} | \`${file.file}\` | ${file.uncovered} | ${pct(file.linesHit, file.linesFound)} |`);
+}
+
+md.push("");
+md.push(`## Critical gaps to prioritize`);
+md.push("");
+if (criticalPriorities.length === 0) {
+  md.push(`No critical files appeared in the top 20 uncovered files.`);
+} else {
+  for (const file of criticalPriorities) {
+    md.push(`- \`${file.file}\` (${file.module}): ${file.uncovered} uncovered lines, ${pct(file.linesHit, file.linesFound)} line coverage.`);
+  }
+}
+md.push("");
+md.push(`## Prioritization guidance`);
+md.push("");
+md.push(`- High-signal gaps likely to catch real bugs: wake/bring dispatch (\`wake-cmd.ts\`, \`wake-resolve-impl.ts\`), message delivery/routing (\`comm-send.ts\`, \`routing.ts\`), tmux transport primitives (\`tmux-class.ts\`), peer discovery transports (\`scout.ts\`, \`mdns.ts\`), plugin invocation (\`registry-invoke.ts\`), and worktree/fleet scans (\`worktrees-scan.ts\`).`);
+md.push(`- Lower-signal/ceremony gaps: large vendored MPR plugin implementations, UI/cosmetic renderers, and plugin bodies where behavior is better covered by CLI smoke tests or end-to-end plugin tests.`);
+md.push(`- Portable-core candidates for #1612 fixture extraction: matcher, routing alias guards, calver, plugin tier/default-active policy, and pure transport-router selection/failover.`);
+md.push("");
+md.push(`## Notes`);
+md.push("");
+md.push(`- Critical = routing/aliases, CLI dispatch, transports, fleet, matcher, and plugin dispatch.`);
+md.push(`- Low-risk = vendor plugin surfaces and UI/cosmetic code where smoke/manual tests often provide better value than line-driven unit tests.`);
+md.push(`- Files absent from LCOV are counted as zero-covered using non-empty/non-comment source lines so the report exposes untouched modules, not only imported files.`);
+md.push("");
+
+mkdirSync(dirname(outPath), { recursive: true });
+writeFileSync(outPath, md.join("\n"));
+console.log(`wrote ${outPath}`);
+console.log(`overall lines ${pct(overall.linesHit, overall.linesFound)} (${overall.linesHit}/${overall.linesFound}); functions ${pct(overall.funcsHit, overall.funcsFound)} (${overall.funcsHit}/${overall.funcsFound})`);
+console.log("top uncovered:");
+for (const file of top20.slice(0, 10)) {
+  console.log(`  ${file.uncovered.toString().padStart(4)}  ${file.risk.padEnd(8)}  ${file.file}`);
+}

--- a/scripts/test-coverage.sh
+++ b/scripts/test-coverage.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+rm -rf coverage
+MAW_TEST_MODE=1 bun test test/ \
+  --coverage \
+  --coverage-reporter=text \
+  --coverage-reporter=lcov \
+  --coverage-dir=coverage \
+  --path-ignore-patterns '**/test/isolated/**' \
+  --path-ignore-patterns '**/zz-mock-tmux-smoke*' \
+  --path-ignore-patterns '**/agents/**'
+
+bun scripts/coverage-gap-analysis.ts coverage/lcov.info docs/testing/coverage-gap-analysis.md

--- a/test/plugin-default-active.test.ts
+++ b/test/plugin-default-active.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isDefaultActive1514Plugin,
+  isDefaultActive1523Plugin,
+  isDefaultActive1524Plugin,
+  isDefaultActive1531Plugin,
+  isDefaultActivePlugin,
+} from "../src/plugin/default-active";
+
+describe("default-active plugin tier guards", () => {
+  test("baseline operator plugins stay active by default", () => {
+    for (const name of ["team", "fleet", "panes", "peers", "pair", "tmux", "kill", "plugin", "doctor", "inbox"]) {
+      expect(isDefaultActivePlugin(name)).toBe(true);
+    }
+    expect(isDefaultActivePlugin("dream")).toBe(false);
+  });
+
+  test("follow-up migrations expose help-prominent commands", () => {
+    expect(isDefaultActive1514Plugin("split")).toBe(true);
+    expect(isDefaultActive1523Plugin("shellenv")).toBe(true);
+    expect(isDefaultActive1524Plugin("completions")).toBe(true);
+    for (const name of ["learn", "find", "talk-to", "project", "workon", "cleanup"]) {
+      expect(isDefaultActive1531Plugin(name)).toBe(true);
+    }
+    expect(isDefaultActive1531Plugin("fleet")).toBe(false);
+  });
+});

--- a/test/routing-session-alias.test.ts
+++ b/test/routing-session-alias.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { resolveTarget } from "../src/core/routing";
+import type { MawConfig } from "../src/config";
+import type { Session } from "../src/core/runtime/find-window";
+
+const CONFIG: MawConfig = {
+  host: "local",
+  port: 3456,
+  ghqRoot: "/tmp/ghq",
+  oracleUrl: "http://localhost:47779",
+  env: {},
+  commands: { default: "claude" },
+  sessions: {},
+  node: "m5",
+  namedPeers: [],
+  agents: {},
+  peers: [],
+};
+
+const win = (index: number, name: string) => ({ index, name, active: true });
+
+describe("resolveTarget — session alias window guards (#1565/#1611)", () => {
+  test("bare oracle alias prefers the '<name>-oracle' window over first helper pane", () => {
+    const sessions: Session[] = [
+      { name: "54-mawjs", windows: [win(1, "mawjs-issuer"), win(2, "mawjs-oracle")] },
+    ];
+
+    expect(resolveTarget("mawjs", CONFIG, sessions)).toEqual({ type: "local", target: "54-mawjs:2" });
+  });
+
+  test("bare oracle alias can strip numeric session prefix and route a single-window session", () => {
+    const sessions: Session[] = [
+      { name: "48-mawjs-codex", windows: [win(7, "codex-main")] },
+    ];
+
+    expect(resolveTarget("mawjs-codex", CONFIG, sessions)).toEqual({ type: "local", target: "48-mawjs-codex:7" });
+  });
+
+  test("ambiguous aliases fail loudly instead of guessing a window", () => {
+    const sessions: Session[] = [
+      { name: "54-mawjs", windows: [win(1, "mawjs-oracle")] },
+      { name: "99-mawjs", windows: [win(1, "mawjs-oracle")] },
+    ];
+
+    expect(resolveTarget("mawjs", CONFIG, sessions)).toMatchObject({
+      type: "error",
+      reason: "session_alias_ambiguous",
+      hint: "candidates: 54-mawjs, 99-mawjs",
+    });
+  });
+
+  test("multi-window alias without an oracle window refuses the first-window fallback", () => {
+    const sessions: Session[] = [
+      { name: "54-mawjs", windows: [win(1, "mawjs-issuer"), win(2, "notes")] },
+    ];
+
+    const result = resolveTarget("mawjs", CONFIG, sessions);
+    expect(result).toMatchObject({ type: "error", reason: "session_window_not_found" });
+    if (result?.type === "error") {
+      expect(result.hint).toContain("54-mawjs:1 (mawjs-issuer)");
+      expect(result.hint).toContain("54-mawjs:2 (notes)");
+    }
+  });
+});

--- a/test/transport-router.test.ts
+++ b/test/transport-router.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "bun:test";
+import { classifyError, TransportRouter, type Transport } from "../src/core/transport/transport";
+
+type Handler<T> = (value: T) => void;
+type FakeTransportOverrides = Partial<Transport> & { name: string; listPeers?: () => unknown[] };
+
+function fakeTransport(overrides: FakeTransportOverrides): Transport & {
+  messages: Handler<any>[];
+  presences: Handler<any>[];
+  feeds: Handler<any>[];
+  sent: string[];
+} {
+  const messages: Handler<any>[] = [];
+  const presences: Handler<any>[] = [];
+  const feeds: Handler<any>[] = [];
+  const sent: string[] = [];
+  return {
+    name: overrides.name,
+    connected: overrides.connected ?? true,
+    connect: overrides.connect ?? (async () => {}),
+    disconnect: overrides.disconnect ?? (async () => {}),
+    canReach: overrides.canReach ?? (() => true),
+    send: overrides.send ?? (async (_target, message) => { sent.push(message); return true; }),
+    publishPresence: overrides.publishPresence ?? (async () => {}),
+    publishFeed: overrides.publishFeed ?? (async () => {}),
+    onMessage: (handler) => messages.push(handler),
+    onPresence: (handler) => presences.push(handler),
+    onFeed: (handler) => feeds.push(handler),
+    listPeers: overrides.listPeers,
+    messages,
+    presences,
+    feeds,
+    sent,
+  } as Transport & { listPeers?: () => unknown[]; messages: Handler<any>[]; presences: Handler<any>[]; feeds: Handler<any>[]; sent: string[] };
+}
+
+describe("transport coverage — failure classification", () => {
+  test("classifyError maps retryable and fatal errors", () => {
+    expect(classifyError("ETIMEDOUT while dialing")).toEqual({ reason: "timeout", retryable: true });
+    expect(classifyError("ECONNREFUSED")).toEqual({ reason: "unreachable", retryable: true });
+    expect(classifyError("403 forbidden")).toEqual({ reason: "auth", retryable: false });
+    expect(classifyError("429 too many requests")).toEqual({ reason: "rate_limit", retryable: true });
+    expect(classifyError("peer rejected message")).toEqual({ reason: "rejected", retryable: false });
+    expect(classifyError("JSON parse failed")).toEqual({ reason: "parse_error", retryable: false });
+    expect(classifyError(null)).toEqual({ reason: "unknown", retryable: false });
+  });
+});
+
+describe("TransportRouter", () => {
+  const target = { oracle: "neo", tmuxTarget: "neo:1" };
+
+  test("routes through the first connected reachable transport", async () => {
+    const router = new TransportRouter();
+    const first = fakeTransport({ name: "tmux" });
+    const second = fakeTransport({ name: "http" });
+    router.register(first);
+    router.register(second);
+
+    expect(await router.send(target, "hi", "codex")).toEqual({ ok: true, via: "tmux", retryable: false });
+    expect(first.sent).toEqual(["hi"]);
+    expect(second.sent).toEqual([]);
+  });
+
+  test("retryable transport errors fall through to the next route", async () => {
+    const router = new TransportRouter();
+    router.register(fakeTransport({ name: "mqtt", send: async () => { throw new Error("timeout"); } }));
+    router.register(fakeTransport({ name: "http" }));
+
+    expect(await router.send(target, "hello", "codex")).toEqual({ ok: true, via: "http", retryable: false });
+  });
+
+  test("fatal transport errors stop failover", async () => {
+    const router = new TransportRouter();
+    const fallback = fakeTransport({ name: "http" });
+    router.register(fakeTransport({ name: "peer", send: async () => { throw new Error("401 unauthorized"); } }));
+    router.register(fallback);
+
+    expect(await router.send(target, "secret", "codex")).toEqual({ ok: false, via: "peer", reason: "auth", retryable: false });
+    expect(fallback.sent).toEqual([]);
+  });
+
+  test("false send result and disconnected transports continue to fallback", async () => {
+    const router = new TransportRouter();
+    router.register(fakeTransport({ name: "offline", connected: false }));
+    router.register(fakeTransport({ name: "rejecting", send: async () => false }));
+    router.register(fakeTransport({ name: "http" }));
+
+    expect(await router.send(target, "fallback", "codex")).toEqual({ ok: true, via: "http", retryable: false });
+  });
+
+
+  test("connect/disconnect and broadcast methods fan out to connected transports", async () => {
+    const calls: string[] = [];
+    const router = new TransportRouter();
+    router.register(fakeTransport({
+      name: "online",
+      connect: async () => { calls.push("connect"); },
+      disconnect: async () => { calls.push("disconnect"); },
+      publishPresence: async () => { calls.push("presence"); },
+      publishFeed: async () => { calls.push("feed"); },
+    }));
+    router.register(fakeTransport({
+      name: "offline",
+      connected: false,
+      connect: async () => { calls.push("offline-connect"); },
+      disconnect: async () => { calls.push("offline-disconnect"); },
+      publishPresence: async () => { calls.push("offline-presence"); },
+      publishFeed: async () => { calls.push("offline-feed"); },
+    }));
+
+    await router.connectAll();
+    await router.publishPresence({ oracle: "neo", host: "m5", status: "ready", timestamp: 1 });
+    await router.publishFeed({ type: "message", ts: 1 } as any);
+    await router.disconnectAll();
+
+    expect(calls).toEqual(["connect", "offline-connect", "presence", "feed", "disconnect", "offline-disconnect"]);
+  });
+
+  test("no reachable transport returns an explicit unreachable result", async () => {
+    const router = new TransportRouter();
+    router.register(fakeTransport({ name: "miss", canReach: () => false }));
+
+    expect(await router.send(target, "hi", "codex")).toEqual({ ok: false, via: "none", reason: "unreachable", retryable: false });
+  });
+
+  test("discovery ignores transports whose listPeers throws", () => {
+    const router = new TransportRouter();
+    router.register(fakeTransport({ name: "bad-scout", listPeers: () => { throw new Error("boom"); } }));
+    router.register(fakeTransport({ name: "good-scout", listPeers: () => [{ id: "peer-b" }] }));
+
+    expect(router.listDiscoveredPeers()).toEqual([{ id: "peer-b" }]);
+  });
+
+  test("event handlers and discovery are wired through registered transports", async () => {
+    const router = new TransportRouter();
+    const transport = fakeTransport({ name: "scout", listPeers: () => [{ id: "peer-a" }] });
+    router.register(transport);
+
+    const messages: unknown[] = [];
+    const presences: unknown[] = [];
+    const feeds: unknown[] = [];
+    router.onMessage((msg) => messages.push(msg));
+    router.onPresence((presence) => presences.push(presence));
+    router.onFeed((event) => feeds.push(event));
+
+    transport.messages[0]?.({ from: "a", to: "b", body: "hi", timestamp: 1, transport: "tmux" });
+    transport.presences[0]?.({ oracle: "neo", host: "m5", status: "ready", timestamp: 1 });
+    transport.feeds[0]?.({ type: "message", ts: 1 } as any);
+
+    expect(messages).toHaveLength(1);
+    expect(presences).toHaveLength(1);
+    expect(feeds).toHaveLength(1);
+    expect(router.status()).toEqual([{ name: "scout", connected: true }]);
+    expect(router.listDiscoveredPeers()).toEqual([{ id: "peer-a" }]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add Bun-native coverage scripts:
  - `bun run test:coverage` generates text + LCOV under ignored `coverage/` and refreshes the markdown gap report.
  - `bun run coverage:gap` regenerates the gap analysis from an existing `coverage/lcov.info`.
- Commit `docs/testing/coverage-gap-analysis.md` with module rollups, top 20 uncovered files, critical vs low-risk categorization, and #1612 portable-core candidates.
- Add small focused tests for critical surfaces:
  - routing/session alias guard regressions (#1565 class)
  - transport router failover/discovery/event fanout
  - default-active plugin tier policy

## Coverage highlights
- Coverage run: `1281 pass / 6 skip / 0 fail`.
- `src/core/routing.ts`: 89.1% line coverage.
- `src/core/transport/transport.ts`: 100.0% line coverage.
- `src/plugin/default-active.ts`: 100.0% line coverage.
- Matcher remains at 100% for both matcher modules.
- The report documents remaining high-signal gaps (`wake-cmd.ts`, `comm-send.ts`, `tmux-class.ts`, `registry-invoke.ts`, `worktrees-scan.ts`) instead of hiding them behind imported-only LCOV accounting.

## Validation
- `rtk bun run test:coverage`
- `rtk bun run coverage:gap`
- `rtk bun test test/routing-session-alias.test.ts test/transport-router.test.ts test/plugin-default-active.test.ts`
- `rtk bun run build`

No release-alpha cut performed.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.

Closes #1611
