### PR TITLE
test: add portable matcher behavior fixtures

### DIFF
--- a/docs/testing/portable-core-spec.md
+++ b/docs/testing/portable-core-spec.md
@@ -1,0 +1,46 @@
+# Portable core behavioral specs
+
+Issue: #1612
+
+maw-js is currently TypeScript/Bun, but several subsystems are pure logic and can be specified with data fixtures that another implementation language can consume. The portable spec shape is:
+
+1. Store behavior as JSON fixtures under `test/spec/*.fixtures.json`.
+2. Keep each fixture to input data and expected output only; no Bun mocks, tmux handles, filesystem paths, or TypeScript-only object identity.
+3. Run the fixtures from TypeScript tests today, and reuse the same JSON from a Rust/Go/etc. port later.
+
+## Phase 2 portable-core map
+
+| Candidate | Current status | Fixture suitability | Notes |
+| --- | --- | --- | --- |
+| `src/core/matcher/resolve-target.ts` | Pure logic | Ready | First fixture set added in `test/spec/matcher-resolve-target.fixtures.json`. Covers exact, suffix, prefix/middle, substring hints, numeric fleet-session guard, and worktree behavior. |
+| `src/core/matcher/normalize-target.ts` | Pure logic | Ready | Small next candidate; can be fixture-backed without platform dependencies. |
+| `scripts/calver.ts` | Mostly pure version arithmetic plus git/tag IO | Extract first | Move/calibrate pure HHMM/version arithmetic behind fixtureable helpers before port validation. |
+| Plugin tier/default-active policy | Pure policy tables plus profile IO | Ready for policy fixtures | `src/plugin/default-active.ts` and `src/plugin/tier.ts` are good candidates; profile migration tests stay platform-specific. |
+| Routing aliases (`src/core/routing.ts`) | Mixed pure resolver + config/tmux adapters | Extract first | Fixture the input graph (`localNode`, sessions, peers, agents) and expected route/error once IO adapters are separated. |
+| Worktree scan (`src/core/fleet/worktrees-scan.ts`) | Mixed classification + `hostExec`/filesystem | Extract first | The #1553 matching rule is portable; shell/git discovery is platform layer. |
+| Transport router (`src/core/transport/transport.ts`) | Pure orchestration over transport interface | Ready-ish | Fixtures can cover route selection/failover if represented as deterministic transport outcomes. |
+
+## First spec: matcher resolve-target
+
+The first committed portable spec is the matcher fixture set:
+
+- Fixture data: `test/spec/matcher-resolve-target.fixtures.json`
+- TS runner: `test/spec/matcher-resolve-target.fixtures.test.ts`
+- Script: `bun run test:spec`
+
+The JSON intentionally records only string item names and simple expected shapes:
+
+```json
+{
+  "name": "session numeric-prefix guard blocks middle-segment false match",
+  "mode": "session",
+  "input": { "target": "mawjs", "items": ["114-mawjs-no2"] },
+  "expected": { "kind": "none", "hints": ["114-mawjs-no2"] }
+}
+```
+
+A non-TypeScript port should implement the same resolver contract and assert the same JSON produces the same portable result shape.
+
+## Boundaries
+
+Portable fixtures are **not** a replacement for integration tests. They should define behavior for modules whose decisions can be expressed as stable input/output data. Tmux, Bun.serve, filesystem, network, GitHub, and plugin process lifecycle remain platform-layer tests.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:mock-smoke": "MAW_TEST_MODE=1 bun test test/zz-mock-tmux-smoke.test.ts --path-ignore-patterns '**/agents/**'",
     "test:plugin": "MAW_TEST_MODE=1 bun test src/commands/plugins/ --path-ignore-patterns '**/agents/**'",
     "test:all": "bun run test && bun run test:isolated && bun run test:mock-smoke && bun run test:plugin",
+    "test:spec": "MAW_TEST_MODE=1 bun test test/spec/",
     "ci:local": "docker compose -f docker-compose.ci.yml run --rm ci",
     "ship:alpha": "bash scripts/ship-alpha.sh",
     "ship:alpha:dry": "bash scripts/ship-alpha.sh --dry-run",

--- a/test/spec/matcher-resolve-target.fixtures.json
+++ b/test/spec/matcher-resolve-target.fixtures.json
@@ -1,0 +1,158 @@
+[
+  {
+    "name": "exact match wins before fuzzy candidates",
+    "mode": "byName",
+    "input": {
+      "target": "view",
+      "items": ["mawjs-view", "view", "mawui-view"]
+    },
+    "expected": { "kind": "exact", "match": "view" }
+  },
+  {
+    "name": "exact match is case-insensitive",
+    "mode": "byName",
+    "input": {
+      "target": "MAWJS",
+      "items": ["Mawjs"]
+    },
+    "expected": { "kind": "exact", "match": "Mawjs" }
+  },
+  {
+    "name": "single suffix segment resolves as fuzzy",
+    "mode": "byName",
+    "input": {
+      "target": "yeast",
+      "items": ["110-yeast", "120-brew"]
+    },
+    "expected": { "kind": "fuzzy", "match": "110-yeast" }
+  },
+  {
+    "name": "multiple suffix segment matches are ambiguous",
+    "mode": "byName",
+    "input": {
+      "target": "view",
+      "items": ["mawjs-view", "mawui-view", "skills-cli-view", "unrelated"]
+    },
+    "expected": {
+      "kind": "ambiguous",
+      "candidates": ["mawjs-view", "mawui-view", "skills-cli-view"]
+    }
+  },
+  {
+    "name": "suffix segment is preferred over prefix segment",
+    "mode": "byName",
+    "input": {
+      "target": "maw",
+      "items": ["maw-js", "110-maw", "other"]
+    },
+    "expected": { "kind": "fuzzy", "match": "110-maw" }
+  },
+  {
+    "name": "single prefix segment resolves only when no suffix match exists",
+    "mode": "byName",
+    "input": {
+      "target": "maw",
+      "items": ["maw-js", "other"]
+    },
+    "expected": { "kind": "fuzzy", "match": "maw-js" }
+  },
+  {
+    "name": "middle word segment can resolve a non-fleet session",
+    "mode": "session",
+    "input": {
+      "target": "cli",
+      "items": ["skills-cli-view", "114-mawjs-no2"]
+    },
+    "expected": { "kind": "fuzzy", "match": "skills-cli-view" }
+  },
+  {
+    "name": "multiple middle word segment matches are ambiguous",
+    "mode": "byName",
+    "input": {
+      "target": "cli",
+      "items": ["skills-cli-view", "maw-cli-tool", "other"]
+    },
+    "expected": {
+      "kind": "ambiguous",
+      "candidates": ["skills-cli-view", "maw-cli-tool"]
+    }
+  },
+  {
+    "name": "substring fallback returns none with hints",
+    "mode": "byName",
+    "input": {
+      "target": "maw",
+      "items": ["mawjs-view", "mawjs-view-view", "mawui-view"]
+    },
+    "expected": {
+      "kind": "none",
+      "hints": ["mawjs-view", "mawjs-view-view", "mawui-view"]
+    }
+  },
+  {
+    "name": "single substring fallback is still none, never fuzzy",
+    "mode": "byName",
+    "input": {
+      "target": "awjs",
+      "items": ["mawjs-view"]
+    },
+    "expected": { "kind": "none", "hints": ["mawjs-view"] }
+  },
+  {
+    "name": "empty target returns none without matching everything",
+    "mode": "byName",
+    "input": {
+      "target": "",
+      "items": ["a", "b-c"]
+    },
+    "expected": { "kind": "none" }
+  },
+  {
+    "name": "target is trimmed before matching",
+    "mode": "byName",
+    "input": {
+      "target": "\tyeast\n",
+      "items": ["110-yeast"]
+    },
+    "expected": { "kind": "fuzzy", "match": "110-yeast" }
+  },
+  {
+    "name": "session numeric-prefix guard blocks middle-segment false match",
+    "mode": "session",
+    "input": {
+      "target": "mawjs",
+      "items": ["114-mawjs-no2"]
+    },
+    "expected": { "kind": "none", "hints": ["114-mawjs-no2"] }
+  },
+  {
+    "name": "session numeric-prefix exact suffix still resolves",
+    "mode": "session",
+    "input": {
+      "target": "mawjs-no2",
+      "items": ["114-mawjs-no2", "101-mawjs"]
+    },
+    "expected": { "kind": "fuzzy", "match": "114-mawjs-no2" }
+  },
+  {
+    "name": "worktree numeric prefixes are sequence counters and keep middle matching",
+    "mode": "worktree",
+    "input": {
+      "target": "pay",
+      "items": ["2-pay-v1", "2-pay-v2"]
+    },
+    "expected": {
+      "kind": "ambiguous",
+      "candidates": ["2-pay-v1", "2-pay-v2"]
+    }
+  },
+  {
+    "name": "generic byName keeps legacy numeric-prefix middle matching",
+    "mode": "byName",
+    "input": {
+      "target": "mawjs",
+      "items": ["114-mawjs-no2"]
+    },
+    "expected": { "kind": "fuzzy", "match": "114-mawjs-no2" }
+  }
+]

--- a/test/spec/matcher-resolve-target.fixtures.test.ts
+++ b/test/spec/matcher-resolve-target.fixtures.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import {
+  resolveByName,
+  resolveSessionTarget,
+  resolveWorktreeTarget,
+  type ResolveResult,
+} from "../../src/core/matcher/resolve-target";
+
+type Mode = "byName" | "session" | "worktree";
+type Named = { name: string };
+type Expected = {
+  kind: ResolveResult<Named>["kind"];
+  match?: string;
+  candidates?: string[];
+  hints?: string[];
+};
+type Fixture = {
+  name: string;
+  mode: Mode;
+  input: { target: string; items: string[] };
+  expected: Expected;
+};
+
+const fixtureUrl = new URL("./matcher-resolve-target.fixtures.json", import.meta.url);
+const fixtures = JSON.parse(readFileSync(fixtureUrl, "utf8")) as Fixture[];
+
+function resolveFixture(fixture: Fixture): ResolveResult<Named> {
+  const items = fixture.input.items.map(name => ({ name }));
+  if (fixture.mode === "session") return resolveSessionTarget(fixture.input.target, items);
+  if (fixture.mode === "worktree") return resolveWorktreeTarget(fixture.input.target, items);
+  return resolveByName(fixture.input.target, items);
+}
+
+function portableShape(result: ResolveResult<Named>): Expected {
+  if (result.kind === "exact" || result.kind === "fuzzy") {
+    return { kind: result.kind, match: result.match.name };
+  }
+  if (result.kind === "ambiguous") {
+    return { kind: result.kind, candidates: result.candidates.map(item => item.name) };
+  }
+  const out: Expected = { kind: result.kind };
+  if (result.hints) out.hints = result.hints.map(item => item.name);
+  return out;
+}
+
+describe("portable matcher resolve-target fixtures (#1612)", () => {
+  for (const fixture of fixtures) {
+    test(fixture.name, () => {
+      expect(portableShape(resolveFixture(fixture))).toEqual(fixture.expected);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- add the first #1612 portable behavioral spec as JSON fixtures for `src/core/matcher/resolve-target.ts`
- add a Bun runner that validates the JSON-only input/output contract today
- document the portable-core map and boundaries for later Rust/Go/etc. runners
- add `bun run test:spec` for fast fixture validation

## Notes

This intentionally references #1612 without closing it: #1612 is an epic, and this PR lands the first fixture-backed slice plus the candidate map.

## Verification

- `jq empty test/spec/matcher-resolve-target.fixtures.json`
- `rtk bun run test:spec` → 16 pass / 0 fail
- `rtk bun test test/matcher-resolve-target.test.ts test/spec/matcher-resolve-target.fixtures.test.ts test/core/matcher/normalize-target.test.ts` → 55 pass / 0 fail
- `rtk bun run build` → success

No release-alpha cut; this is an alpha-targeted feature/test PR only.

Refs #1612.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
