### PR TITLE
feat(team): create shared oracle workspaces

### DIFF
--- a/src/cli/cmd-new.ts
+++ b/src/cli/cmd-new.ts
@@ -1,92 +1,19 @@
 /**
- * `maw new` — TTY-aware oracle creation with attach prompt (#1272).
+ * `maw new` — shared workspace tmux session factory (#1616).
  *
- * Delegates creation to the awaken plugin (which buds + wakes + fires
- * /awaken), then offers to attach. Behavior is TTY-aware:
+ * Creates a named tmux session with a plain shell lead window. It does not
+ * create, wake, bud, or awaken an oracle. Use it as the first step in a shared
+ * workspace:
  *
- *   --no-attach            never attach, print session ref
- *   --auto-attach / -y     skip prompt, attach immediately
- *   MAW_NO_PROMPT=1        env equivalent of --no-attach
- *   TTY (default)          prompt "Attach now? [Y/n]" (default yes)
- *   non-TTY (default)      silent auto-attach
- *
- * Implementation note (PR #1272):
- *   The "create oracle" surface today is `maw awaken` (plugin in the
- *   maw-plugin-registry repo) — `maw bud` does the bud half, `maw awaken`
- *   composes bud + wake + fire `/awaken`. Neither lives inside maw-js as a
- *   command source. `maw new` was previously an argv-rewrite alias to
- *   awaken; we promote it to a direct handler so the prompt lives at the
- *   verb level without forking the registry plugin.
- *
- *   Awaken's own pre-create confirmation ("Will create: ... Proceed? [y/N]")
- *   is preserved. `maw new foo -y` skips BOTH that and our attach prompt
- *   in a single keystroke — the "I know what I'm doing" path.
+ *   maw new my-project
+ *   maw team oracle-invite volt odin --team my-project
+ *   maw team bring my-project
  */
 
 import { parseFlags } from "./parse-args";
 import { UserError } from "../core/util/user-error";
-
-/** Decision returned by {@link decideAttachAction}. Stable for testing/logs. */
-export type AttachDecision =
-  | { action: "attach"; reason: string }
-  | { action: "skip"; reason: "no-attach-flag" | "env-no-prompt" | "already-attached" | "user-declined" }
-  | { action: "prompt"; reason: string }
-  | { action: "abort"; reason: "creation-failed" };
-
-/** Inputs to {@link decideAttachAction}. All facts pre-collected by the caller. */
-export interface DecideAttachOpts {
-  /** --no-attach flag. */
-  noAttach: boolean;
-  /** --auto-attach / -y flag (either implies attach without prompt). */
-  autoAttach: boolean;
-  /** MAW_NO_PROMPT=1 (or any truthy value) — env override for --no-attach. */
-  envNoPrompt: boolean;
-  /** process.stdin.isTTY at call time. */
-  stdinIsTTY: boolean;
-  /** process.stdout.isTTY at call time. */
-  stdoutIsTTY: boolean;
-  /** Was oracle creation successful? false → abort, don't prompt. */
-  creationOk: boolean;
-  /** Are we already inside this oracle's tmux session? true → no-op. */
-  alreadyAttached: boolean;
-}
-
-/**
- * Pure decision for the post-create attach step. Priority (highest first):
- *
- *   1. creation failed            → abort
- *   2. already attached           → skip (no-op)
- *   3. --no-attach                → skip
- *   4. MAW_NO_PROMPT=1            → skip
- *   5. --auto-attach / -y         → attach
- *   6. both stdin & stdout TTY    → prompt
- *   7. otherwise (non-TTY)        → attach (silent default)
- *
- * No I/O — caller renders the decision (prompt UI, attach call, exit).
- */
-export function decideAttachAction(opts: DecideAttachOpts): AttachDecision {
-  if (!opts.creationOk) return { action: "abort", reason: "creation-failed" };
-  if (opts.alreadyAttached) return { action: "skip", reason: "already-attached" };
-  if (opts.noAttach) return { action: "skip", reason: "no-attach-flag" };
-  if (opts.envNoPrompt) return { action: "skip", reason: "env-no-prompt" };
-  if (opts.autoAttach) return { action: "attach", reason: "auto-attach flag" };
-  if (opts.stdinIsTTY && opts.stdoutIsTTY) return { action: "prompt", reason: "interactive TTY" };
-  return { action: "attach", reason: "non-TTY silent default" };
-}
-
-/**
- * Interpret a y/n answer where Enter (empty) defaults to YES.
- *
- *   "" / "\n"         → true   (Enter = default yes)
- *   "y" / "Y" / "yes" → true
- *   anything else     → false  ("n", "N", "no", garbage)
- */
-export function interpretYesNoDefaultYes(answer: string): boolean {
-  const t = answer.trim().toLowerCase();
-  if (t === "") return true;
-  if (t === "y" || t === "yes") return true;
-  return false;
-}
+import { tmux } from "../sdk";
+import { attachToSession } from "../commands/shared/wake-session";
 
 /** Truthy env values: "1", "true", "yes", "on" (case-insensitive). */
 export function isTruthyEnv(v: string | undefined): boolean {
@@ -95,183 +22,93 @@ export function isTruthyEnv(v: string | undefined): boolean {
   return norm === "1" || norm === "true" || norm === "yes" || norm === "on";
 }
 
-/**
- * Read a single line from /dev/tty so a piped stdin can't break the prompt.
- * Mirrors the helper in maw-plugin-registry's awaken/attach plugins.
- */
-function readLineFromTty(question: string): string {
-  const fs = require("fs");
-  let fd: number | null = null;
-  try {
-    fd = fs.openSync("/dev/tty", "r");
-    process.stderr.write(question);
-    const buf = Buffer.alloc(64);
-    const bytesRead = fs.readSync(fd, buf, 0, 64, null);
-    return buf.toString("utf-8", 0, bytesRead);
-  } catch {
-    return "";
-  } finally {
-    if (fd !== null) { try { fs.closeSync(fd); } catch {} }
-  }
+export interface NewWorkspaceAttachOpts {
+  attach: boolean;
+  noAttach: boolean;
+  envNoPrompt: boolean;
+  stdinIsTTY: boolean;
+  stdoutIsTTY: boolean;
 }
 
+export type NewWorkspaceAttachDecision =
+  | { action: "attach"; reason: "attach-flag" | "interactive-tty" }
+  | { action: "skip"; reason: "no-attach-flag" | "env-no-prompt" | "non-tty" };
+
 /**
- * Best-effort check: are we already inside the target oracle's tmux session?
- * Strips the `NN-` prefix (fleet sessions are `42-foo` for oracle `foo`).
+ * Pure attach/switch decision for `maw new`.
  *
- * Returns false on any failure (no TMUX, tmux not on PATH, etc).
+ * Defaults are intentionally ergonomic but automation-safe:
+ * - `--no-attach` and `MAW_NO_PROMPT=1` always print-only.
+ * - `--attach` forces attach/switch.
+ * - interactive shells attach/switch by default.
+ * - non-TTY scripts print instructions instead of blocking on tmux attach.
  */
-async function detectAlreadyAttached(name: string): Promise<boolean> {
-  if (!process.env.TMUX) return false;
-  try {
-    const proc = Bun.spawn(["tmux", "display-message", "-p", "#S"], {
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const sessionName = (await new Response(proc.stdout).text()).trim();
-    await proc.exited;
-    if (!sessionName) return false;
-    const stripped = sessionName.replace(/^\d+-/, "");
-    return stripped === name || sessionName === name;
-  } catch {
-    return false;
-  }
+export function decideNewWorkspaceAttach(opts: NewWorkspaceAttachOpts): NewWorkspaceAttachDecision {
+  if (opts.noAttach) return { action: "skip", reason: "no-attach-flag" };
+  if (opts.envNoPrompt) return { action: "skip", reason: "env-no-prompt" };
+  if (opts.attach) return { action: "attach", reason: "attach-flag" };
+  if (opts.stdinIsTTY && opts.stdoutIsTTY) return { action: "attach", reason: "interactive-tty" };
+  return { action: "skip", reason: "non-tty" };
 }
 
-/** Filter the raw argv to remove flags consumed by cmdNew itself. */
-export function stripCmdNewFlags(argv: string[]): string[] {
-  const out: string[] = [];
-  for (const a of argv) {
-    if (a === "--no-attach" || a === "--auto-attach") continue;
-    if (a === "-y" || a === "--yes") continue;
-    out.push(a);
-  }
-  return out;
-}
-
-/**
- * Implementation of `maw new <name> [flags...]`.
- *
- * 1. Parse our own flags (--no-attach, --auto-attach, -y).
- * 2. Pass remaining args through to the awaken plugin.
- * 3. After awaken returns, decide+execute the attach step.
- */
-export async function cmdNew(argv: string[]): Promise<void> {
-  const flags = parseFlags(
-    argv,
-    {
-      "--no-attach": Boolean,
-      "--auto-attach": Boolean,
-      "--yes": Boolean,
-      "-y": "--yes",
-    },
-    0,
-  );
-
-  const positional = flags._;
-  const name = positional[0];
-  if (!name || name === "--help" || name === "-h") {
-    console.error(
-      "usage: maw new <name> [--no-attach] [--auto-attach|-y] [awaken flags...]",
+export function validateWorkspaceSessionName(name: string): void {
+  if (!/^[A-Za-z0-9][A-Za-z0-9_.-]{0,79}$/.test(name)) {
+    throw new UserError(
+      `new: invalid session name '${name}' — use letters, numbers, dot, underscore, or dash`,
     );
-    throw new UserError("new: missing oracle name");
+  }
+  if (name.endsWith("-view")) {
+    throw new UserError("new: session names ending in '-view' are reserved for maw view");
+  }
+}
+
+function printUsage(write: (line: string) => void = console.log): void {
+  write("usage: maw new <session-name> [--attach|-a] [--no-attach]");
+  write("  Create a plain tmux workspace session with a lead shell window.");
+  write("  Then bring oracles in with: maw team bring <team> [--session <session>]");
+  write("  Oracle creation remains: maw awaken <name> (or maw bud <name>).");
+}
+
+/** Implementation of `maw new <name>` as a workspace/session factory. */
+export async function cmdNew(argv: string[]): Promise<void> {
+  const flags = parseFlags(argv, {
+    "--attach": Boolean,
+    "-a": "--attach",
+    "--no-attach": Boolean,
+  }, 0);
+
+  const name = (flags._ as string[])[0];
+  if (!name || name === "--help" || name === "-h") {
+    printUsage(console.error);
+    throw new UserError("new: missing session name");
   }
   if (name.startsWith("-")) {
-    console.error(`"${name}" looks like a flag, not an oracle name.`);
-    throw new UserError(`new: invalid name '${name}'`);
+    printUsage(console.error);
+    throw new UserError(`new: invalid session name '${name}'`);
+  }
+  validateWorkspaceSessionName(name);
+
+  const existed = await tmux.hasSession(name);
+  if (!existed) {
+    await tmux.newSession(name, { window: "lead", cwd: process.cwd() });
+    console.log(`\x1b[32m✓\x1b[0m created workspace session '${name}' (lead shell)`);
+  } else {
+    console.log(`\x1b[36m→\x1b[0m session exists: ${name}`);
   }
 
-  const noAttach = !!flags["--no-attach"];
-  const autoAttach = !!flags["--auto-attach"] || !!flags["--yes"];
-  const envNoPrompt = isTruthyEnv(process.env.MAW_NO_PROMPT);
-
-  // Forward args to awaken with our flags stripped. -y carries the same
-  // "I know what I'm doing" intent through to awaken's pre-create confirm.
-  const awakenArgs = stripCmdNewFlags(argv);
-  if (autoAttach) awakenArgs.push("-y");
-
-  // 1. Invoke the awaken plugin.
-  const { discoverPackages, invokePlugin } = await import("../plugin/registry");
-  const { resolvePluginMatch } = await import("./dispatch-match");
-  const plugins = discoverPackages();
-  const awakenMatch = resolvePluginMatch(plugins, "awaken");
-  if (awakenMatch.kind !== "match") {
-    console.error(
-      "\x1b[31m✗\x1b[0m awaken plugin not installed — run `maw plugin install awaken`",
-    );
-    throw new UserError("new: awaken plugin not found");
-  }
-
-  const result = await invokePlugin(awakenMatch.plugin, {
-    source: "cli",
-    args: awakenArgs,
-  });
-
-  if (!result.ok) {
-    if (result.error) console.error(result.error);
-    console.error(`\x1b[31m✗\x1b[0m creation failed`);
-    console.error(
-      `\x1b[90m  cleanup hint: maw kill ${name} (then remove the repo dir if it was created)\x1b[0m`,
-    );
-    throw new UserError("new: creation failed");
-  }
-
-  // 2. Decide and execute the attach step.
-  const alreadyAttached = await detectAlreadyAttached(name);
-  const decision = decideAttachAction({
-    noAttach,
-    autoAttach,
-    envNoPrompt,
+  const decision = decideNewWorkspaceAttach({
+    attach: !!flags["--attach"],
+    noAttach: !!flags["--no-attach"],
+    envNoPrompt: isTruthyEnv(process.env.MAW_NO_PROMPT),
     stdinIsTTY: !!process.stdin.isTTY,
     stdoutIsTTY: !!process.stdout.isTTY,
-    creationOk: true,
-    alreadyAttached,
   });
 
-  if (decision.action === "skip") {
-    if (decision.reason === "already-attached") {
-      console.log(`\x1b[90m  · already attached to ${name}\x1b[0m`);
-      return;
-    }
-    console.log(
-      `\x1b[36m💡\x1b[0m Attach later: \x1b[36mmaw a ${name}\x1b[0m`,
-    );
+  if (decision.action === "attach") {
+    await attachToSession(name);
     return;
   }
 
-  let shouldAttach = decision.action === "attach";
-  if (decision.action === "prompt") {
-    const answer = readLineFromTty("Attach now? [Y/n] ");
-    shouldAttach = interpretYesNoDefaultYes(answer);
-    if (!shouldAttach) {
-      console.log(
-        `\x1b[36m💡\x1b[0m Attach later: \x1b[36mmaw a ${name}\x1b[0m`,
-      );
-      return;
-    }
-  }
-
-  if (shouldAttach) await invokeAttach(name);
-}
-
-async function invokeAttach(name: string): Promise<void> {
-  const { discoverPackages, invokePlugin } = await import("../plugin/registry");
-  const { resolvePluginMatch } = await import("./dispatch-match");
-  const plugins = discoverPackages();
-  const attachMatch = resolvePluginMatch(plugins, "attach");
-  if (attachMatch.kind !== "match") {
-    console.error("\x1b[33m⚠\x1b[0m attach plugin not installed");
-    console.log(
-      `\x1b[36m💡\x1b[0m Attach manually: \x1b[36mmaw a ${name}\x1b[0m`,
-    );
-    return;
-  }
-  const result = await invokePlugin(attachMatch.plugin, {
-    source: "cli",
-    args: [name],
-  });
-  if (!result.ok && result.error) {
-    console.error(result.error);
-    console.log(`\x1b[36m💡\x1b[0m Retry: \x1b[36mmaw a ${name}\x1b[0m`);
-  }
+  console.log(`\x1b[36mRun:\x1b[0m maw a ${name}`);
+  console.log(`\x1b[90m  next: maw team bring ${name}\x1b[0m`);
 }

--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -51,7 +51,7 @@ export const ALIAS_DESCRIPTIONS: Record<string, string> = {
   scaffold: "Create oracle repo + skeleton only (no commit, wake, or /awaken)",
   wake: "Wake an oracle session (fuzzy match, auto-clone)",
   awake: "Launch an oracle process with optional engine (does not trigger /awaken)",
-  new: "Create a new oracle (friendly door for awaken)",
+  new: "Create a plain tmux workspace session",
   preflight: "Pre-flight check — version, plugins, dead agents, config",
   snapshots: "List and inspect fleet recovery snapshots",
 };
@@ -150,13 +150,14 @@ function printBringUsage(write: (line: string) => void = console.log): void {
 }
 
 function printWakeAliasUsage(verb: "wake" | "awake", write: (line: string) => void = console.log): void {
-  write(`usage: maw ${verb} <oracle> [--task <s>] [--wt <s>] [--bud] [--signal-on-birth] [-p|--prompt <s>] [--incubate <slug>] [--fresh] [-a|--attach] [--list] [--dry-run] [--from-snapshot|--snapshot <id>] [--main|--solo|--no-rehydrate] [--split] [--all-local] [-e|--engine <name>]`);
+  write(`usage: maw ${verb} <oracle> [--session <tmux-session>] [--task <s>] [--wt <s>] [--bud] [--signal-on-birth] [-p|--prompt <s>] [--incubate <slug>] [--fresh] [-a|--attach] [--list] [--dry-run] [--from-snapshot|--snapshot <id>] [--main|--solo|--no-rehydrate] [--split] [--all-local] [-e|--engine <name>]`);
   if (verb === "awake") {
     write("  Launch/start an oracle process with the selected engine. Does not send /awaken.");
-    write("  Use `maw awaken` for the awakening ritual; use `maw new` for the creation door.");
+    write("  Use `maw awaken` for the awakening ritual; use `maw new` for a plain workspace session.");
   } else {
     write("  Wake or reuse an oracle session, fuzzy-resolving repos and worktrees as needed.");
   }
+  write("  --session targets an existing foreign workspace session instead of the oracle's own session.");
   write("  --list previews worktrees only; it does not create sessions or respawn windows.");
   write("  --from-snapshot restores missing windows from the latest recovery snapshot; --snapshot <id> selects one.");
   write("  --bud with --task/--wt writes ψ/.lineage.yaml in the worktree (no repo/fleet mutation).");
@@ -223,6 +224,7 @@ export async function invokeDirectHandler(
     const flags = parseFlags(argv, {
       "--task": String,
       "--wt": String,
+      "--session": String,
       "--prompt": String, "-p": "--prompt",
       "--incubate": String,
       "--fresh": Boolean,
@@ -249,6 +251,7 @@ export async function invokeDirectHandler(
     const opts: {
       task?: string;
       wt?: string;
+      session?: string;
       prompt?: string;
       incubate?: string;
       fresh?: boolean;
@@ -266,6 +269,7 @@ export async function invokeDirectHandler(
     } = {};
     if (flags["--task"]) opts.task = flags["--task"];
     if (flags["--wt"]) opts.wt = flags["--wt"];
+    if (flags["--session"]) opts.session = flags["--session"];
     if (flags["--prompt"]) opts.prompt = flags["--prompt"];
     if (flags["--incubate"]) opts.incubate = flags["--incubate"];
     if (flags["--fresh"]) opts.fresh = true;

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -196,6 +196,8 @@ export interface WakeOptions {
   task?: string;
   wt?: string;
   prompt?: string;
+  /** Target an existing foreign tmux workspace session instead of the oracle's own session (#1616). */
+  session?: string;
   incubate?: string;
   fresh?: boolean;
   attach?: boolean;
@@ -328,6 +330,13 @@ async function restoreSnapshotWindows(
   return planned.length;
 }
 
+
+function validateForeignSessionName(name: string): void {
+  if (!/^[A-Za-z0-9][A-Za-z0-9_.-]{0,79}$/.test(name)) {
+    throw new Error(`invalid target session '${name}' — use letters, numbers, dot, underscore, or dash`);
+  }
+}
+
 async function chooseWakeSessionName(oracle: string, urlRepoName?: string): Promise<string> {
   const baseName = getSessionMap()[oracle] || resolveFleetSession(oracle) || urlRepoName || oracle;
   if (/^\d+-/.test(baseName)) return baseName;
@@ -433,8 +442,16 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
     return `${oracle}:list`;
   }
 
-  let session = preResolvedSession ?? await detectSession(oracle, opts.urlRepoName);
-  if (session) console.log(`\x1b[36m→\x1b[0m session exists: ${session}`);
+  const foreignSession = opts.session?.trim();
+  if (foreignSession) validateForeignSessionName(foreignSession);
+  let session = foreignSession || preResolvedSession || await detectSession(oracle, opts.urlRepoName);
+  if (foreignSession) {
+    const exists = opts.dryRun || await tmux.hasSession(foreignSession);
+    if (!exists) {
+      throw new Error(`target session '${foreignSession}' not found — run: maw new ${foreignSession}`);
+    }
+    console.log(`\x1b[36m→\x1b[0m target workspace session: ${foreignSession}`);
+  } else if (session) console.log(`\x1b[36m→\x1b[0m session exists: ${session}`);
   else console.log(`\x1b[36m→\x1b[0m no session found, creating...`);
 
   const requestedSnapshot = opts.fromSnapshot ? loadRequestedSnapshot(opts.snapshotId) : null;
@@ -456,11 +473,13 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
     isLive: Boolean(session),
   });
 
-  const mainWindowName = `${oracle}-oracle`;
+  const mainWindowName = foreignSession ? oracle : `${oracle}-oracle`;
 
   if (opts.dryRun) {
     console.log(`\x1b[90mdry-run — no tmux sessions/windows will be changed\x1b[0m`);
-    if (!session && wakeDecision.wake) {
+    if (foreignSession) {
+      console.log(`\x1b[32m+\x1b[0m would wake window '${mainWindowName}' in workspace session '${foreignSession}'`);
+    } else if (!session && wakeDecision.wake) {
       const plannedSession = await chooseWakeSessionName(oracle, opts.urlRepoName);
       console.log(`\x1b[32m+\x1b[0m would create session '${plannedSession}' (main: ${mainWindowName})`);
     } else if (session) {
@@ -487,8 +506,9 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
       }
     }
 
-    if (opts.noRehydrate) {
-      console.log(`\x1b[90m↻ worktree rehydrate skipped (--main/--solo/--no-rehydrate)\x1b[0m`);
+    if (opts.noRehydrate || foreignSession) {
+      const reason = foreignSession ? "foreign workspace session" : "--main/--solo/--no-rehydrate";
+      console.log(`\x1b[90m↻ worktree rehydrate skipped (${reason})\x1b[0m`);
       return session ? `${session}:${mainWindowName}` : `${oracle}:dry-run`;
     }
 
@@ -545,7 +565,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
       console.log(`\x1b[36m↻\x1b[0m snapshot restore: ${restored} window${restored === 1 ? "" : "s"}`);
     }
 
-    if (!opts.task && !opts.wt && !opts.noRehydrate) {
+    if (!foreignSession && !opts.task && !opts.wt && !opts.noRehydrate) {
       const allWt = await findWorktrees(parentDir, repoName);
       for (const wt of planRehydrateWorktreeWindows(oracle, allWt, [...existingWindows])) {
         await tmux.newWindow(session, wt.windowName, { cwd: wt.path });
@@ -567,7 +587,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
       console.log(`\x1b[36m↻\x1b[0m snapshot restore: ${restored} window${restored === 1 ? "" : "s"}`);
     }
 
-    if (!opts.task && !opts.wt && !opts.noRehydrate) {
+    if (!foreignSession && !opts.task && !opts.wt && !opts.noRehydrate) {
       const allWt = await findWorktrees(parentDir, repoName);
       if (allWt.length > 0) {
         const existingWindows = [...preExistingWindows];
@@ -586,7 +606,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
     if (retried > 0) console.log(`\x1b[33m${retried} window(s) retried.\x1b[0m`);
   }
 
-  const reordered = await restoreTabOrder(session);
+  const reordered = foreignSession ? 0 : await restoreTabOrder(session);
   if (reordered > 0) console.log(`\x1b[36m↻ ${reordered} window(s) reordered to saved positions.\x1b[0m`);
 
   let targetPath = repoPath;

--- a/src/vendor/mpr-plugins/completions/impl.ts
+++ b/src/vendor/mpr-plugins/completions/impl.ts
@@ -12,7 +12,7 @@ const CORE_COMMANDS = [
 
 const TOP_ALIASES = [
   "a", "kill", "split", "open", "close", "t", "layout", "zoom",
-  "panes", "cleanup", "tile", "bring", "b", "ls", "wake", "new", "preflight",
+  "panes", "cleanup", "tile", "bring", "b", "ls", "wake", "new", "preflight", "snapshots",
 ];
 
 const HELP = `usage: maw completions <commands|oracles|windows|zsh|bash|fish>
@@ -125,6 +125,9 @@ _maw() {
         plugin|plugins)
           _values 'plugin action' ls list enable disable info standard full lean nuke
           ;;
+        team|t)
+          _values 'team action' create new plan preflight load spawn-from spawn bring send msg shutdown down resume lives list ls status add tasks done assign delete rm invite oracle-invite oracle-remove members enter
+          ;;
         serve)
           _message 'port (default: 3456)'
           ;;
@@ -164,6 +167,9 @@ _maw_complete() {
     plugin|plugins)
       words="ls list enable disable info standard full lean nuke"
       ;;
+    team|t)
+      words="create new plan preflight load spawn-from spawn bring send msg shutdown down resume lives list ls status add tasks done assign delete rm invite oracle-invite oracle-remove members enter"
+      ;;
     *)
       words=""
       ;;
@@ -176,7 +182,8 @@ const FISH_COMPLETION = `# maw fish completion
 complete -c maw -f -n '__fish_use_subcommand' -a '(maw completions commands 2>/dev/null)'
 complete -c maw -f -n '__fish_seen_subcommand_from wake about info' -a '(maw completions oracles 2>/dev/null)'
 complete -c maw -f -n '__fish_seen_subcommand_from peek see a attach bring b hey send tell done finish' -a '(maw completions windows 2>/dev/null)'
-complete -c maw -f -n '__fish_seen_subcommand_from completions' -a 'commands oracles windows zsh bash fish --help'`;
+complete -c maw -f -n '__fish_seen_subcommand_from completions' -a 'commands oracles windows zsh bash fish --help'
+complete -c maw -f -n '__fish_seen_subcommand_from team t' -a 'create new plan preflight load spawn-from spawn bring send msg shutdown down resume lives list ls status add tasks done assign delete rm invite oracle-invite oracle-remove members enter'`;
 
 export async function cmdCompletions(sub?: string) {
   const mode = (sub ?? "--help").toLowerCase();

--- a/src/vendor/mpr-plugins/team/impl.ts
+++ b/src/vendor/mpr-plugins/team/impl.ts
@@ -7,7 +7,8 @@ import { findZombiePanes } from "./team-cleanup-zombies";
 // Re-export everything so index.ts and tests continue to import from "./impl"
 export { _setDirs, loadTeam, writeShutdownRequest, writeMessage } from "./team-helpers";
 export { cmdTeamShutdown, cmdTeamCreate, cmdTeamSpawn, mergeTeamKnowledge } from "./team-lifecycle";
-export { cmdTeamSend } from "./team-comms";
+export { cmdTeamSend, cmdTeamBroadcast } from "./team-comms";
+export { cmdTeamBring, resolveTeamBringSession, teamOracleMemberNames, loadTeamOracleMemberNames, applyTeamBringLayout } from "./team-workspace";
 export { cmdTeamResume, cmdTeamLives } from "./team-reincarnation";
 export { cmdCleanupZombies } from "./team-cleanup-zombies";
 export { parseTeamCharterText, readTeamCharter, planTeamCharter, formatTeamCharterPlan, preflightTeamCharter, formatTeamCharterPreflight, loadTeamCharter, formatTeamCharterLoad, composeTeamCharterMemberPrompt, spawnFromTeamCharter, formatTeamCharterSpawn } from "./team-charter";

--- a/src/vendor/mpr-plugins/team/index.ts
+++ b/src/vendor/mpr-plugins/team/index.ts
@@ -4,14 +4,15 @@ import { join } from "path";
 import { homedir } from "os";
 import {
   cmdTeamShutdown, cmdTeamList, cmdTeamCreate, cmdTeamSpawn,
-  cmdTeamSend, cmdTeamResume, cmdTeamLives,
+  cmdTeamSend, cmdTeamBroadcast, cmdTeamBring, cmdTeamResume, cmdTeamLives,
 } from "./impl";
+import { resolveTeamSendMode, teamMessageTargets } from "./team-comms";
 import { parseFlags } from "maw-js/cli/parse-args";
 import { hostExec } from "maw-js/sdk";
 
 export const command = {
   name: "team",
-  description: "Agent reincarnation engine — create, spawn, send, shutdown, resume, lives.",
+  description: "Agent reincarnation engine — create, bring, send, shutdown, resume, lives.",
 };
 
 /**
@@ -147,11 +148,33 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       }
       await cmdTeamSpawn(args[1], args[2], { model, prompt, exec, cwd });
     } else if (sub === "send" || sub === "msg") {
-      if (!args[1] || !args[2] || !args[3]) {
-        logs.push("usage: maw team send <team> <agent> <message>");
-        return { ok: false, error: "team, agent, and message required", output: logs.join("\n") };
+      if (!args[1] || !args[2]) {
+        logs.push("usage: maw team send <team> <message>");
+        logs.push("       maw team send <team> <agent> <message>  # legacy single-agent inbox send");
+        return { ok: false, error: "team and message required", output: logs.join("\n") };
       }
-      cmdTeamSend(args[1], args[2], args.slice(3).join(" "));
+      const sendMode = resolveTeamSendMode(args.slice(2), teamMessageTargets(args[1]));
+      if (sendMode.mode === "single") {
+        cmdTeamSend(args[1], sendMode.agent, sendMode.message);
+      } else {
+        await cmdTeamBroadcast(args[1], sendMode.message);
+      }
+    } else if (sub === "bring") {
+      const flags = parseFlags(args, {
+        "--session": String,
+        "--engine": String, "-e": "--engine",
+        "--dry-run": Boolean,
+      }, 1);
+      const team = flags._[0];
+      if (!team) {
+        logs.push("usage: maw team bring <team> [--session <session>] [-e|--engine <name>] [--dry-run]");
+        return { ok: false, error: "team required", output: logs.join("\n") };
+      }
+      await cmdTeamBring(team, {
+        session: flags["--session"] as string | undefined,
+        engine: flags["--engine"] as string | undefined,
+        dryRun: !!flags["--dry-run"],
+      });
     } else if (sub === "resume") {
       if (!args[1]) {
         logs.push("usage: maw team resume <name> [--model <model>]");
@@ -318,7 +341,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
 
     } else {
       logs.push(`unknown team subcommand: ${sub}`);
-      logs.push("usage: maw team <create|plan|preflight|load|spawn-from|spawn|send|shutdown|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members|enter>");
+      logs.push("usage: maw team <create|plan|preflight|load|spawn-from|spawn|bring|send|shutdown|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members|enter>");
       return { ok: false, error: `unknown subcommand: ${sub}`, output: logs.join("\n") };
     }
 

--- a/src/vendor/mpr-plugins/team/team-comms.ts
+++ b/src/vendor/mpr-plugins/team/team-comms.ts
@@ -1,6 +1,39 @@
 import { writeFileSync, existsSync, mkdirSync } from "fs";
 import { join } from "path";
 import { loadTeam, writeMessage, resolvePsi } from "./team-helpers";
+import { loadOracleRegistry } from "./oracle-members";
+
+export type TeamSendMode =
+  | { mode: "broadcast"; message: string }
+  | { mode: "single"; agent: string; message: string };
+
+export function teamMessageTargets(teamName: string): string[] {
+  const registry = loadOracleRegistry(teamName);
+  const oracleTargets = registry?.members.map(m => m.oracle).filter(Boolean) ?? [];
+  const liveTeam = loadTeam(teamName);
+  const liveTargets = liveTeam?.members
+    .filter(m => m.agentType !== "team-lead")
+    .map(m => m.name) ?? [];
+  return [...new Set([...oracleTargets, ...liveTargets])];
+}
+
+export function resolveTeamSendMode(args: string[], knownTargets: string[]): TeamSendMode {
+  if (args.length === 0) throw new Error("usage: maw team send <team> <message>");
+  if (args.length === 1) return { mode: "broadcast", message: args[0]! };
+
+  const first = args[0]!;
+  const tail = args.slice(1).join(" ");
+  // Preserve the legacy single-agent form when the candidate is a known team
+  // member, or when no membership registry exists and the command would have
+  // historically fallen back to an async mailbox write.
+  if (knownTargets.length === 0 || knownTargets.includes(first)) {
+    return { mode: "single", agent: first, message: tail };
+  }
+
+  // Otherwise, treat all remaining argv as an unquoted broadcast message:
+  // `maw team send myteam hello team` should not require shell quotes.
+  return { mode: "broadcast", message: args.join(" ") };
+}
 
 // ─── maw team send <team> <agent> <message> ───
 
@@ -29,4 +62,48 @@ export function cmdTeamSend(teamName: string, agent: string, message: string) {
     timestamp: new Date().toISOString(),
   }, null, 2));
   console.log(`\x1b[32m✓\x1b[0m message written to ψ/memory/mailbox/${agent}/ (team not live)`);
+}
+
+
+// ─── maw team send <team> <message> (#1616 broadcast mode) ───
+
+export async function cmdTeamBroadcast(teamName: string, message: string) {
+  if (!message) {
+    throw new Error("usage: maw team send <team> <message>");
+  }
+
+  const targets = teamMessageTargets(teamName);
+  if (targets.length === 0) {
+    throw new Error(`no members in team '${teamName}' — run: maw team oracle-invite <oracle> --team ${teamName}`);
+  }
+
+  console.log(`\x1b[36m⚡\x1b[0m broadcast to ${targets.length} member(s) in team '${teamName}':`);
+  let delivered = 0;
+  let failed = 0;
+  const { cmdSend } = await import("maw-js/commands/shared/comm-send");
+  const origExit = process.exit;
+  try {
+    for (const target of targets) {
+      let exited = false;
+      process.exit = ((code?: number) => {
+        exited = true;
+        throw new Error(`send exited${code === undefined ? "" : ` with ${code}`}`);
+      }) as never;
+      try {
+        await cmdSend(target, message, false);
+        if (exited) failed++;
+        else delivered++;
+      } catch (e: any) {
+        failed++;
+        console.error(`  \x1b[31m✗\x1b[0m ${target}: ${e?.message || "failed"}`);
+      }
+    }
+  } finally {
+    process.exit = origExit;
+  }
+
+  if (failed > 0) {
+    throw new Error(`broadcast partial failure: ${delivered} delivered, ${failed} failed`);
+  }
+  console.log(`\x1b[32m✓\x1b[0m broadcast delivered to ${delivered} member(s)`);
 }

--- a/src/vendor/mpr-plugins/team/team-workspace.ts
+++ b/src/vendor/mpr-plugins/team/team-workspace.ts
@@ -1,0 +1,98 @@
+import { tmux } from "maw-js/sdk";
+import { cmdWake } from "maw-js/commands/shared/wake";
+import { loadOracleRegistry, type OracleMember } from "./oracle-members";
+
+export interface TeamBringOptions {
+  /** Explicit tmux session to bring members into. Defaults to current tmux session or the team name. */
+  session?: string;
+  /** Engine forwarded to maw wake. */
+  engine?: string;
+  /** Preview without creating windows or launching engines. */
+  dryRun?: boolean;
+}
+
+export function teamOracleMemberNames(members: OracleMember[]): string[] {
+  return [...new Set(members.map(m => m.oracle).filter(Boolean))];
+}
+
+export function loadTeamOracleMemberNames(teamName: string): string[] {
+  const registry = loadOracleRegistry(teamName);
+  return registry ? teamOracleMemberNames(registry.members) : [];
+}
+
+function validateSessionName(name: string): void {
+  if (!/^[A-Za-z0-9][A-Za-z0-9_.-]{0,79}$/.test(name)) {
+    throw new Error(`invalid session name '${name}' — use letters, numbers, dot, underscore, or dash`);
+  }
+}
+
+async function currentTmuxSession(): Promise<string | null> {
+  if (!process.env.TMUX) return null;
+  const out = await tmux.run("display-message", "-p", "#{session_name}").catch(() => "");
+  const session = out.trim();
+  return session || null;
+}
+
+export async function resolveTeamBringSession(teamName: string, opts: TeamBringOptions = {}): Promise<string> {
+  const explicit = opts.session?.trim();
+  if (explicit) {
+    validateSessionName(explicit);
+    if (!await tmux.hasSession(explicit)) {
+      throw new Error(`target session '${explicit}' not found — run: maw new ${explicit}`);
+    }
+    return explicit;
+  }
+
+  const current = await currentTmuxSession();
+  if (current) return current;
+
+  // Non-interactive path: if the workspace session is named after the team,
+  // allow `maw new <team>; maw team bring <team>` from outside tmux.
+  if (await tmux.hasSession(teamName)) return teamName;
+
+  throw new Error(`not in tmux and no '${teamName}' session exists — run: maw new ${teamName}`);
+}
+
+export async function applyTeamBringLayout(session: string, count: number): Promise<string> {
+  const layout = count <= 4 ? "main-vertical" : "tiled";
+  // #1616 asks for an automatic layout step. Team members currently wake as
+  // tmux windows, so this is best-effort against the human lead window: if the
+  // workspace already has panes, tmux arranges them; if it is a single pane,
+  // this is harmless and preserves the future pane-join path.
+  await tmux.selectLayout(`${session}:lead`, layout).catch(async () => {
+    await tmux.selectLayout(`${session}:0`, layout).catch(() => {});
+  });
+  return layout;
+}
+
+export async function cmdTeamBring(teamName: string, opts: TeamBringOptions = {}): Promise<string[]> {
+  const members = loadTeamOracleMemberNames(teamName);
+  if (members.length === 0) {
+    throw new Error(`no oracle members in team '${teamName}' — run: maw team oracle-invite <oracle> --team ${teamName}`);
+  }
+
+  const session = await resolveTeamBringSession(teamName, opts);
+  console.log(`\x1b[36m⚡\x1b[0m bringing ${members.length} oracle(s) into workspace '${session}'`);
+
+  const targets: string[] = [];
+  for (const oracle of members) {
+    if (opts.dryRun) {
+      console.log(`  \x1b[90mwould wake ${oracle} --session ${session}\x1b[0m`);
+      targets.push(`${session}:${oracle}`);
+      continue;
+    }
+    const target = await cmdWake(oracle, {
+      session,
+      noRehydrate: true,
+      engine: opts.engine,
+    });
+    targets.push(target);
+  }
+
+  if (!opts.dryRun) {
+    const layout = await applyTeamBringLayout(session, members.length);
+    console.log(`\x1b[32m✓\x1b[0m team '${teamName}' brought into '${session}' (${layout})`);
+  }
+
+  return targets;
+}

--- a/test/cli/dispatch-match.test.ts
+++ b/test/cli/dispatch-match.test.ts
@@ -330,15 +330,15 @@ describe("resolveTopAlias — RFC #954 verb aliases", () => {
     expect(out).toBeNull();
   });
 
-  test("`wake neo --task X` → direct-handler form with cmdWake handler", () => {
-    const out = resolveTopAlias(["wake", "neo", "--task", "X"]);
+  test("`wake neo --session project --task X` → direct-handler form with cmdWake handler", () => {
+    const out = resolveTopAlias(["wake", "neo", "--session", "project", "--task", "X"]);
     expect(out).not.toBeNull();
     expect(out!.kind).toBe("direct");
     if (out!.kind === "direct") {
       expect(out!.handler).toContain("wake-cmd");
       expect(out!.handler).toContain("cmdWake");
       // argv passed to handler is everything AFTER the verb
-      expect(out!.argv).toEqual(["neo", "--task", "X"]);
+      expect(out!.argv).toEqual(["neo", "--session", "project", "--task", "X"]);
     }
   });
 
@@ -355,15 +355,15 @@ describe("resolveTopAlias — RFC #954 verb aliases", () => {
     expect(ALIAS_DESCRIPTIONS.awake).toContain("does not trigger /awaken");
   });
 
-  test("`new neo --no-attach` → direct-handler cmdNew friendly creation door", () => {
-    const out = resolveTopAlias(["new", "neo", "--no-attach"]);
+  test("`new workspace --no-attach` → direct-handler cmdNew workspace session factory", () => {
+    const out = resolveTopAlias(["new", "workspace", "--no-attach"]);
     expect(out).not.toBeNull();
     expect(out!.kind).toBe("direct");
     if (out!.kind === "direct") {
       expect(out!.handler).toContain("cmdNew");
-      expect(out!.argv).toEqual(["neo", "--no-attach"]);
+      expect(out!.argv).toEqual(["workspace", "--no-attach"]);
     }
-    expect(ALIAS_DESCRIPTIONS.new).toContain("Create a new oracle");
+    expect(ALIAS_DESCRIPTIONS.new).toContain("workspace session");
   });
 
   test("`scaffold neo` → bud --scaffold-only argv rewrite", () => {

--- a/test/isolated/cmd-new-workspace.test.ts
+++ b/test/isolated/cmd-new-workspace.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { join } from "path";
+
+let sessions = new Set<string>();
+let newSessionCalls: Array<{ name: string; opts: any }> = [];
+let attached: string[] = [];
+
+mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
+  tmux: {
+    hasSession: async (name: string) => sessions.has(name),
+    newSession: async (name: string, opts: any = {}) => {
+      sessions.add(name);
+      newSessionCalls.push({ name, opts });
+    },
+  },
+}));
+
+mock.module(join(import.meta.dir, "../../src/commands/shared/wake-session"), () => ({
+  attachToSession: async (name: string) => { attached.push(name); },
+}));
+
+const { cmdNew } = await import("../../src/cli/cmd-new");
+
+beforeEach(() => {
+  sessions = new Set<string>();
+  newSessionCalls = [];
+  attached = [];
+});
+
+describe("cmdNew workspace session factory", () => {
+  test("creates a detached tmux session with a lead shell window", async () => {
+    await cmdNew(["my-project", "--no-attach"]);
+
+    expect(newSessionCalls).toEqual([
+      { name: "my-project", opts: { window: "lead", cwd: process.cwd() } },
+    ]);
+    expect(attached).toEqual([]);
+  });
+
+  test("reuses an existing workspace session and can attach", async () => {
+    sessions.add("my-project");
+
+    await cmdNew(["my-project", "--attach"]);
+
+    expect(newSessionCalls).toEqual([]);
+    expect(attached).toEqual(["my-project"]);
+  });
+});

--- a/test/isolated/team-bring-workspace.test.ts
+++ b/test/isolated/team-bring-workspace.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const tmp = mkdtempSync(join(tmpdir(), "maw-team-bring-"));
+process.env.MAW_CONFIG_DIR = join(tmp, "config");
+
+let wakeCalls: Array<{ oracle: string; opts: any }> = [];
+let layoutCalls: Array<{ target: string; layout: string }> = [];
+
+mock.module("maw-js/sdk", () => ({
+  tmux: {
+    hasSession: async (name: string) => name === "project",
+    run: async () => "project",
+    selectLayout: async (target: string, layout: string) => {
+      layoutCalls.push({ target, layout });
+    },
+  },
+}));
+
+mock.module("maw-js/commands/shared/wake", () => ({
+  cmdWake: async (oracle: string, opts: any) => {
+    wakeCalls.push({ oracle, opts });
+    return `${opts.session}:${oracle}`;
+  },
+}));
+
+const registryDir = join(process.env.MAW_CONFIG_DIR!, "teams", "myteam");
+mkdirSync(registryDir, { recursive: true });
+writeFileSync(join(registryDir, "oracle-members.json"), JSON.stringify({
+  name: "myteam",
+  createdAt: new Date().toISOString(),
+  members: [
+    { oracle: "volt", role: "builder", addedAt: new Date().toISOString() },
+    { oracle: "odin", role: "reviewer", addedAt: new Date().toISOString() },
+  ],
+}, null, 2));
+
+const { cmdTeamBring } = await import("../../src/vendor/mpr-plugins/team/team-workspace");
+
+beforeEach(() => {
+  wakeCalls = [];
+  layoutCalls = [];
+});
+
+describe("cmdTeamBring", () => {
+  test("dry-run previews each oracle in the target workspace session", async () => {
+    const targets = await cmdTeamBring("myteam", { session: "project", dryRun: true });
+
+    expect(targets).toEqual(["project:volt", "project:odin"]);
+    expect(wakeCalls).toEqual([]);
+    expect(layoutCalls).toEqual([]);
+  });
+
+  test("wakes each oracle with --session semantics and applies layout", async () => {
+    const targets = await cmdTeamBring("myteam", { session: "project", engine: "codex" });
+
+    expect(targets).toEqual(["project:volt", "project:odin"]);
+    expect(wakeCalls).toEqual([
+      { oracle: "volt", opts: { session: "project", noRehydrate: true, engine: "codex" } },
+      { oracle: "odin", opts: { session: "project", noRehydrate: true, engine: "codex" } },
+    ]);
+    expect(layoutCalls).toEqual([{ target: "project:lead", layout: "main-vertical" }]);
+  });
+});

--- a/test/isolated/team-workspace.test.ts
+++ b/test/isolated/team-workspace.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { teamOracleMemberNames } from "../../src/vendor/mpr-plugins/team/team-workspace";
+import { resolveTeamSendMode } from "../../src/vendor/mpr-plugins/team/team-comms";
+
+describe("team workspace helpers", () => {
+  test("deduplicates oracle member names while preserving first-seen order", () => {
+    expect(teamOracleMemberNames([
+      { oracle: "volt", role: "builder", addedAt: "2026-05-16T00:00:00Z" },
+      { oracle: "odin", role: "reviewer", addedAt: "2026-05-16T00:00:00Z" },
+      { oracle: "volt", role: "builder", addedAt: "2026-05-16T00:00:00Z" },
+    ])).toEqual(["volt", "odin"]);
+  });
+
+  test("resolves unquoted multi-word team send as broadcast unless first word is a member", () => {
+    expect(resolveTeamSendMode(["hello", "team"], ["volt", "odin"])).toEqual({
+      mode: "broadcast",
+      message: "hello team",
+    });
+    expect(resolveTeamSendMode(["volt", "hello"], ["volt", "odin"])).toEqual({
+      mode: "single",
+      agent: "volt",
+      message: "hello",
+    });
+    expect(resolveTeamSendMode(["agent", "legacy"], [])).toEqual({
+      mode: "single",
+      agent: "agent",
+      message: "legacy",
+    });
+  });
+});

--- a/test/isolated/wake-foreign-session.test.ts
+++ b/test/isolated/wake-foreign-session.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { join } from "path";
+
+const repoPath = "/repo/volt-oracle";
+let newWindows: Array<{ session: string; name: string; cwd?: string }> = [];
+let sentText: string[] = [];
+let detectSessionCalls = 0;
+let restoreTabOrderCalls = 0;
+let findWorktreesCalls = 0;
+
+mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
+  hostExec: async () => "",
+  restoreTabOrder: async () => { restoreTabOrderCalls++; return 0; },
+  takeSnapshot: async () => "/tmp/wake.json",
+  getPaneInfos: async (targets: string[]) => Object.fromEntries(targets.map((t) => [t, { command: "", cwd: "/tmp" }])),
+  isAgentCommand: () => false,
+  tmux: {
+    hasSession: async (name: string) => name === "project",
+    listSessions: async () => [{ name: "project" }],
+    listWindows: async (session: string) => session === "project"
+      ? [{ index: 0, name: "lead", active: true }]
+      : [],
+    newSession: async () => {},
+    newWindow: async (session: string, name: string, opts: any = {}) => {
+      newWindows.push({ session, name, cwd: opts.cwd });
+    },
+    sendText: async (target: string) => { sentText.push(target); },
+    selectWindow: async () => {},
+    setEnvironment: async () => {},
+  },
+}));
+
+mock.module(join(import.meta.dir, "../../src/config"), () => ({
+  buildCommandInDir: (windowName: string, cwd: string) => `cd ${cwd} && ${windowName}`,
+  cfgTimeout: () => 0,
+  cfgLimit: () => 0,
+  loadConfig: () => ({ node: "m5" }),
+  saveConfig: () => {},
+}));
+
+mock.module(join(import.meta.dir, "../../src/commands/shared/wake-resolve"), () => ({
+  resolveOracle: async () => ({ repoPath, repoName: "volt-oracle", parentDir: "/repo" }),
+  findWorktrees: async () => { findWorktreesCalls++; return []; },
+  getSessionMap: () => ({}),
+  resolveFleetSession: () => null,
+  detectSession: async () => { detectSessionCalls++; return "51-volt"; },
+  setSessionEnv: async () => {},
+  sanitizeBranchName: (value: string) => value,
+}));
+
+mock.module(join(import.meta.dir, "../../src/commands/shared/wake-session"), () => ({
+  attachToSession: async () => {},
+  ensureSessionRunning: async () => 0,
+  createWorktree: async () => { throw new Error("createWorktree should not run"); },
+}));
+
+mock.module(join(import.meta.dir, "../../src/commands/shared/wake-maybe-split"), () => ({
+  maybeSplit: async () => {},
+  maybeOpenWindow: async () => {},
+}));
+
+mock.module(join(import.meta.dir, "../../src/plugin/lifecycle"), () => ({
+  runWakeLifecycleHooks: async () => ({ phase: "wake", ran: 0, skipped: 0, failed: 0 }),
+}));
+
+mock.module(join(import.meta.dir, "../../src/commands/shared/wake-target"), () => ({
+  parseWakeTarget: () => null,
+  ensureCloned: async () => {},
+}));
+
+mock.module(join(import.meta.dir, "../../src/commands/shared/wake-concurrency"), () => ({
+  assertAgentCapacity: async () => {},
+}));
+
+mock.module(join(import.meta.dir, "../../src/core/fleet/leaf"), () => ({
+  writeSignal: () => "/tmp/signal.json",
+}));
+
+mock.module(join(import.meta.dir, "../../src/commands/shared/should-auto-wake"), () => ({
+  shouldAutoWake: () => ({ wake: false, reason: "foreign-session" }),
+}));
+
+const { cmdWake } = await import("../../src/commands/shared/wake-cmd");
+
+beforeEach(() => {
+  newWindows = [];
+  sentText = [];
+  detectSessionCalls = 0;
+  restoreTabOrderCalls = 0;
+  findWorktreesCalls = 0;
+});
+
+describe("cmdWake --session", () => {
+  test("wakes oracle as a window named after the oracle in a foreign workspace session", async () => {
+    const target = await cmdWake("volt", { repoPath, session: "project", noRehydrate: true });
+
+    expect(target).toBe("project:volt");
+    expect(detectSessionCalls).toBe(0);
+    expect(restoreTabOrderCalls).toBe(0);
+    expect(findWorktreesCalls).toBe(0);
+    expect(newWindows).toEqual([{ session: "project", name: "volt", cwd: repoPath }]);
+    expect(sentText).toEqual(["project:volt"]);
+  });
+});

--- a/test/isolated/wake-list-readonly.test.ts
+++ b/test/isolated/wake-list-readonly.test.ts
@@ -9,7 +9,7 @@ describe("wake --list readonly preview (#1563)", () => {
     const cmdWakeIdx = wakeCmdSrc.indexOf("export async function cmdWake");
     const cmdWakeSrc = wakeCmdSrc.slice(cmdWakeIdx);
     const listIdx = cmdWakeSrc.indexOf("if (opts.listWt)");
-    const detectIdx = cmdWakeSrc.indexOf("let session = preResolvedSession");
+    const detectIdx = cmdWakeSrc.indexOf("let session = foreignSession || preResolvedSession");
     const setEnvIdx = cmdWakeSrc.indexOf("await setSessionEnv(session)");
     const newSessionIdx = cmdWakeSrc.indexOf("await tmux.newSession");
     const newWindowIdx = cmdWakeSrc.indexOf("await tmux.newWindow(session");

--- a/test/new-attach-prompt.test.ts
+++ b/test/new-attach-prompt.test.ts
@@ -1,190 +1,71 @@
-import { describe, test, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import {
-  decideAttachAction,
-  interpretYesNoDefaultYes,
+  decideNewWorkspaceAttach,
   isTruthyEnv,
-  stripCmdNewFlags,
+  validateWorkspaceSessionName,
 } from "../src/cli/cmd-new";
 
-/**
- * Tests for `maw new` TTY-aware attach prompt (#1272).
- *
- * The flow has three pure pieces that this file exercises directly:
- *
- *   - decideAttachAction(opts)        — pure decision matrix
- *   - interpretYesNoDefaultYes(answer) — default-yes y/N parser
- *   - isTruthyEnv / stripCmdNewFlags   — small helpers
- *
- * cmdNew itself is integration-shaped (invokes the awaken plugin via
- * discoverPackages + invokePlugin) — covered by manual smoke-test in the
- * PR body. Following wake.test.ts convention, we lean on testing the
- * branching helpers rather than mock-poisoning the plugin registry.
- */
-
-const BASE = {
-  noAttach: false,
-  autoAttach: false,
-  envNoPrompt: false,
-  stdinIsTTY: true,
-  stdoutIsTTY: true,
-  creationOk: true,
-  alreadyAttached: false,
-} as const;
-
-describe("decideAttachAction — priority gates", () => {
-  test("creation failed → abort (highest priority)", () => {
-    const d = decideAttachAction({ ...BASE, creationOk: false, autoAttach: true });
-    expect(d.action).toBe("abort");
+describe("decideNewWorkspaceAttach — workspace session factory", () => {
+  test("--no-attach beats --attach", () => {
+    const d = decideNewWorkspaceAttach({
+      attach: true,
+      noAttach: true,
+      envNoPrompt: false,
+      stdinIsTTY: true,
+      stdoutIsTTY: true,
+    });
+    expect(d).toEqual({ action: "skip", reason: "no-attach-flag" });
   });
 
-  test("already attached → skip with reason 'already-attached'", () => {
-    const d = decideAttachAction({ ...BASE, alreadyAttached: true });
-    expect(d.action).toBe("skip");
-    if (d.action === "skip") expect(d.reason).toBe("already-attached");
+  test("MAW_NO_PROMPT=1 skips attach", () => {
+    const d = decideNewWorkspaceAttach({
+      attach: true,
+      noAttach: false,
+      envNoPrompt: true,
+      stdinIsTTY: true,
+      stdoutIsTTY: true,
+    });
+    expect(d).toEqual({ action: "skip", reason: "env-no-prompt" });
   });
 
-  test("--no-attach beats --auto-attach", () => {
-    const d = decideAttachAction({ ...BASE, noAttach: true, autoAttach: true });
-    expect(d.action).toBe("skip");
-    if (d.action === "skip") expect(d.reason).toBe("no-attach-flag");
+  test("interactive TTY defaults to attach/switch", () => {
+    const d = decideNewWorkspaceAttach({
+      attach: false,
+      noAttach: false,
+      envNoPrompt: false,
+      stdinIsTTY: true,
+      stdoutIsTTY: true,
+    });
+    expect(d).toEqual({ action: "attach", reason: "interactive-tty" });
   });
 
-  test("MAW_NO_PROMPT=1 behaves as --no-attach (skip)", () => {
-    const d = decideAttachAction({ ...BASE, envNoPrompt: true });
-    expect(d.action).toBe("skip");
-    if (d.action === "skip") expect(d.reason).toBe("env-no-prompt");
-  });
-});
-
-describe("decideAttachAction — TTY branches", () => {
-  test("TTY (stdin+stdout) default → prompt", () => {
-    const d = decideAttachAction({ ...BASE, stdinIsTTY: true, stdoutIsTTY: true });
-    expect(d.action).toBe("prompt");
-  });
-
-  test("--auto-attach in TTY → attach without prompt", () => {
-    const d = decideAttachAction({ ...BASE, autoAttach: true });
-    expect(d.action).toBe("attach");
-  });
-
-  test("non-TTY (stdin=false) default → attach silently", () => {
-    const d = decideAttachAction({ ...BASE, stdinIsTTY: false, stdoutIsTTY: false });
-    expect(d.action).toBe("attach");
-  });
-
-  test("non-TTY + --no-attach → skip (script can opt out)", () => {
-    const d = decideAttachAction({
-      ...BASE,
+  test("non-TTY defaults to print-only", () => {
+    const d = decideNewWorkspaceAttach({
+      attach: false,
+      noAttach: false,
+      envNoPrompt: false,
       stdinIsTTY: false,
       stdoutIsTTY: false,
-      noAttach: true,
     });
-    expect(d.action).toBe("skip");
-  });
-
-  test("stdout TTY but stdin piped → attach (not promptable)", () => {
-    // Both must be TTY to prompt — single missing side is non-interactive.
-    const d = decideAttachAction({ ...BASE, stdinIsTTY: false, stdoutIsTTY: true });
-    expect(d.action).toBe("attach");
+    expect(d).toEqual({ action: "skip", reason: "non-tty" });
   });
 });
 
-describe("interpretYesNoDefaultYes", () => {
-  test("Enter / empty → yes (default)", () => {
-    expect(interpretYesNoDefaultYes("")).toBe(true);
-    expect(interpretYesNoDefaultYes("\n")).toBe(true);
-    expect(interpretYesNoDefaultYes("   ")).toBe(true);
+describe("maw new workspace validation", () => {
+  test("accepts ordinary workspace names", () => {
+    expect(() => validateWorkspaceSessionName("my-project_1.dev")).not.toThrow();
   });
 
-  test("y / Y / yes / YES → yes", () => {
-    expect(interpretYesNoDefaultYes("y")).toBe(true);
-    expect(interpretYesNoDefaultYes("Y")).toBe(true);
-    expect(interpretYesNoDefaultYes("yes")).toBe(true);
-    expect(interpretYesNoDefaultYes("YES\n")).toBe(true);
+  test("rejects shell-shaped or tmux-target-shaped names", () => {
+    expect(() => validateWorkspaceSessionName("bad:name")).toThrow();
+    expect(() => validateWorkspaceSessionName("../bad")).toThrow();
+    expect(() => validateWorkspaceSessionName("-bad")).toThrow();
   });
 
-  test("n / N / no → no", () => {
-    expect(interpretYesNoDefaultYes("n")).toBe(false);
-    expect(interpretYesNoDefaultYes("N")).toBe(false);
-    expect(interpretYesNoDefaultYes("no")).toBe(false);
-  });
-
-  test("garbage → no (conservative)", () => {
-    expect(interpretYesNoDefaultYes("maybe")).toBe(false);
-    expect(interpretYesNoDefaultYes("q")).toBe(false);
-  });
-});
-
-describe("isTruthyEnv", () => {
-  test("truthy values", () => {
+  test("truthy env helper remains stable", () => {
     expect(isTruthyEnv("1")).toBe(true);
-    expect(isTruthyEnv("true")).toBe(true);
     expect(isTruthyEnv("TRUE")).toBe(true);
-    expect(isTruthyEnv("yes")).toBe(true);
-    expect(isTruthyEnv("on")).toBe(true);
-  });
-
-  test("falsy values", () => {
-    expect(isTruthyEnv(undefined)).toBe(false);
-    expect(isTruthyEnv("")).toBe(false);
-    expect(isTruthyEnv("0")).toBe(false);
-    expect(isTruthyEnv("false")).toBe(false);
     expect(isTruthyEnv("no")).toBe(false);
-  });
-});
-
-describe("stripCmdNewFlags", () => {
-  test("strips --no-attach, --auto-attach, -y, --yes", () => {
-    const argv = ["foo", "--no-attach", "--from", "neo", "--auto-attach", "-y", "--yes"];
-    expect(stripCmdNewFlags(argv)).toEqual(["foo", "--from", "neo"]);
-  });
-
-  test("preserves positional args + passthrough flags", () => {
-    const argv = ["foo", "--from", "neo", "--seed", "--fast"];
-    expect(stripCmdNewFlags(argv)).toEqual(argv);
-  });
-
-  test("empty argv → empty", () => {
-    expect(stripCmdNewFlags([])).toEqual([]);
-  });
-});
-
-describe("decideAttachAction — issue acceptance criteria", () => {
-  test("`maw new <name>` with TTY → prompts", () => {
-    const d = decideAttachAction({ ...BASE });
-    expect(d.action).toBe("prompt");
-  });
-
-  test("`maw new <name>` without TTY → silent default-attach", () => {
-    const d = decideAttachAction({ ...BASE, stdinIsTTY: false, stdoutIsTTY: false });
-    expect(d.action).toBe("attach");
-  });
-
-  test("--no-attach works as documented", () => {
-    const d = decideAttachAction({ ...BASE, noAttach: true });
-    expect(d.action).toBe("skip");
-  });
-
-  test("--auto-attach / -y skips prompt", () => {
-    const d = decideAttachAction({ ...BASE, autoAttach: true });
-    expect(d.action).toBe("attach");
-  });
-
-  test("MAW_NO_PROMPT=1 = --no-attach semantics", () => {
-    // Both should skip.
-    const env = decideAttachAction({ ...BASE, envNoPrompt: true });
-    const flag = decideAttachAction({ ...BASE, noAttach: true });
-    expect(env.action).toBe("skip");
-    expect(flag.action).toBe("skip");
-  });
-
-  test("creation failed → don't prompt, signal abort", () => {
-    const d = decideAttachAction({ ...BASE, creationOk: false });
-    expect(d.action).toBe("abort");
-  });
-
-  test("already attached to same session → no-op skip", () => {
-    const d = decideAttachAction({ ...BASE, alreadyAttached: true });
-    expect(d.action).toBe("skip");
+    expect(isTruthyEnv(undefined)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- repurpose `maw new <name>` as a plain tmux workspace session factory with a lead shell window
- add `maw wake --session <foreign>` and `maw team bring <team>` to bring oracle members into a shared workspace as named windows
- add `maw team send <team> <message>` broadcast mode while preserving the legacy single-agent send path
- update completions/help and add regression coverage for workspace/new/wake/team bring behavior

## Notes
- Alpha-only feature PR; no release-alpha PR/tag/cut here.
- This slice follows the issue's window-based workspace wording. The layout step is best-effort on the lead window and preserves a future pane-join path; it does not yet join every oracle into visible panes in one window.

## Verification
- `bun run build`
- `bun run test:all`
- `bun run preflight`
- user-visible smoke with disposable tmux session: `maw new`, `maw team bring --dry-run`, `maw wake --session --dry-run`; confirmed only the `lead` window exists after dry-runs

Closes #1616.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
