### PR TITLE
test(spec): add portable normalize-target fixtures

### DIFF
--- a/docs/testing/portable-core-spec.md
+++ b/docs/testing/portable-core-spec.md
@@ -13,7 +13,7 @@ maw-js is currently TypeScript/Bun, but several subsystems are pure logic and ca
 | Candidate | Current status | Fixture suitability | Notes |
 | --- | --- | --- | --- |
 | `src/core/matcher/resolve-target.ts` | Pure logic | Ready | First fixture set added in `test/spec/matcher-resolve-target.fixtures.json`. Covers exact, suffix, prefix/middle, substring hints, numeric fleet-session guard, and worktree behavior. |
-| `src/core/matcher/normalize-target.ts` | Pure logic | Ready | Small next candidate; can be fixture-backed without platform dependencies. |
+| `src/core/matcher/normalize-target.ts` | Pure logic | Ready | Fixture set added in `test/spec/normalize-target.fixtures.json`. Covers whitespace trimming, trailing slash cleanup, trailing `/.git` cleanup, and non-normalized interior/case behavior. |
 | `scripts/calver.ts` | Mostly pure version arithmetic plus git/tag IO | Extract first | Move/calibrate pure HHMM/version arithmetic behind fixtureable helpers before port validation. |
 | Plugin tier/default-active policy | Pure policy tables plus profile IO | Ready for policy fixtures | `src/plugin/default-active.ts` and `src/plugin/tier.ts` are good candidates; profile migration tests stay platform-specific. |
 | Routing aliases (`src/core/routing.ts`) | Mixed pure resolver + config/tmux adapters | Extract first | Fixture the input graph (`localNode`, sessions, peers, agents) and expected route/error once IO adapters are separated. |
@@ -40,6 +40,28 @@ The JSON intentionally records only string item names and simple expected shapes
 ```
 
 A non-TypeScript port should implement the same resolver contract and assert the same JSON produces the same portable result shape.
+
+## Second spec: matcher normalize-target
+
+The second portable spec covers the target-name cleanup helper:
+
+- Fixture data: `test/spec/normalize-target.fixtures.json`
+- TS runner: `test/spec/normalize-target.fixtures.test.ts`
+- Script: `bun run test:spec`
+
+The JSON records only raw user input strings and normalized output strings:
+
+```json
+{
+  "name": "trailing .git directory followed by slash is stripped",
+  "input": "token-oracle/.git/",
+  "expected": "token-oracle"
+}
+```
+
+A port should preserve the same limited scope: trim surrounding whitespace,
+strip trailing slashes and terminal `/.git`, but do not lowercase, parse URLs,
+or mutate interior characters.
 
 ## Boundaries
 

--- a/test/spec/normalize-target.fixtures.json
+++ b/test/spec/normalize-target.fixtures.json
@@ -1,0 +1,62 @@
+[
+  {
+    "name": "plain target passes through unchanged",
+    "input": "token-oracle",
+    "expected": "token-oracle"
+  },
+  {
+    "name": "leading and trailing whitespace is trimmed once up front",
+    "input": "  token-oracle/  ",
+    "expected": "token-oracle"
+  },
+  {
+    "name": "single trailing slash is stripped",
+    "input": "token-oracle/",
+    "expected": "token-oracle"
+  },
+  {
+    "name": "multiple trailing slashes are stripped",
+    "input": "token-oracle//",
+    "expected": "token-oracle"
+  },
+  {
+    "name": "trailing slash is stripped from nested bare path",
+    "input": "org/repo/",
+    "expected": "org/repo"
+  },
+  {
+    "name": "trailing .git directory is stripped",
+    "input": "token-oracle/.git",
+    "expected": "token-oracle"
+  },
+  {
+    "name": "trailing .git directory followed by slash is stripped",
+    "input": "token-oracle/.git/",
+    "expected": "token-oracle"
+  },
+  {
+    "name": "stacked .git and slash suffixes collapse until stable",
+    "input": "token-oracle/.git///",
+    "expected": "token-oracle"
+  },
+  {
+    "name": "suffix text named git without slash-dot is preserved",
+    "input": "token-oracle.git",
+    "expected": "token-oracle.git"
+  },
+  {
+    "name": "interior characters and case are not normalized",
+    "input": "Soul-Brews-Studio/MAW-JS",
+    "expected": "Soul-Brews-Studio/MAW-JS"
+  },
+  {
+    "name": "empty string stays empty",
+    "input": "",
+    "expected": ""
+  },
+  {
+    "name": "whitespace-only string normalizes to empty",
+    "input": " \t\n ",
+    "expected": ""
+  }
+]

--- a/test/spec/normalize-target.fixtures.test.ts
+++ b/test/spec/normalize-target.fixtures.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { normalizeTarget } from "../../src/core/matcher/normalize-target";
+
+type Fixture = {
+  name: string;
+  input: string;
+  expected: string;
+};
+
+const fixtureUrl = new URL("./normalize-target.fixtures.json", import.meta.url);
+const fixtures = JSON.parse(readFileSync(fixtureUrl, "utf8")) as Fixture[];
+
+describe("portable normalize-target fixtures (#1612)", () => {
+  for (const fixture of fixtures) {
+    test(fixture.name, () => {
+      expect(normalizeTarget(fixture.input)).toBe(fixture.expected);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add `test/spec/normalize-target.fixtures.json` as the next portable #1612 fixture set
- add a TS fixture runner under `test/spec/` so `bun run test:spec` validates the shared JSON behavior
- update `docs/testing/portable-core-spec.md` with the normalize-target spec boundary

## Verification
- `bun run test:spec`
- `bun test test/core/matcher/normalize-target.test.ts`
- `bun run build`

Alpha-only additive test/spec slice. No release-alpha cut.

Part of #1612.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
