### PR TITLE
test: specify plugin policy as portable fixtures

### DIFF
--- a/docs/testing/portable-core-spec.md
+++ b/docs/testing/portable-core-spec.md
@@ -15,7 +15,7 @@ maw-js is currently TypeScript/Bun, but several subsystems are pure logic and ca
 | `src/core/matcher/resolve-target.ts` | Pure logic | Ready | First fixture set added in `test/spec/matcher-resolve-target.fixtures.json`. Covers exact, suffix, prefix/middle, substring hints, numeric fleet-session guard, and worktree behavior. |
 | `src/core/matcher/normalize-target.ts` | Pure logic | Ready | Fixture set added in `test/spec/normalize-target.fixtures.json`. Covers whitespace trimming, trailing slash cleanup, trailing `/.git` cleanup, and non-normalized interior/case behavior. |
 | `scripts/calver.ts` | Mostly pure version arithmetic plus git/tag IO | Extract first | Move/calibrate pure HHMM/version arithmetic behind fixtureable helpers before port validation. |
-| Plugin tier/default-active policy | Pure policy tables plus profile IO | Ready for policy fixtures | `src/plugin/default-active.ts` and `src/plugin/tier.ts` are good candidates; profile migration tests stay platform-specific. |
+| Plugin tier/default-active policy | Pure policy tables plus profile IO | Ready | Fixture set added in `test/spec/plugin-policy.fixtures.json`. Covers tier constants, weight boundaries, default-active groups, and migration keys; profile migration tests stay platform-specific. |
 | Routing aliases (`src/core/routing.ts`) | Mixed pure resolver + config/tmux adapters | Extract first | Fixture the input graph (`localNode`, sessions, peers, agents) and expected route/error once IO adapters are separated. |
 | Worktree scan (`src/core/fleet/worktrees-scan.ts`) | Mixed classification + `hostExec`/filesystem | Extract first | The #1553 matching rule is portable; shell/git discovery is platform layer. |
 | Transport router (`src/core/transport/transport.ts`) | Pure orchestration over transport interface | Ready-ish | Fixtures can cover route selection/failover if represented as deterministic transport outcomes. |
@@ -62,6 +62,31 @@ The JSON records only raw user input strings and normalized output strings:
 A port should preserve the same limited scope: trim surrounding whitespace,
 strip trailing slashes and terminal `/.git`, but do not lowercase, parse URLs,
 or mutate interior characters.
+
+
+## Third spec: plugin policy
+
+The third portable spec covers pure plugin policy used by the loader and profile
+migrations:
+
+- Fixture data: `test/spec/plugin-policy.fixtures.json`
+- TS runner: `test/spec/plugin-policy.fixtures.test.ts`
+- Script: `bun run test:spec`
+
+The JSON records tier constants, `weightToTier` thresholds, and default-active
+plugin groups with their migration keys:
+
+```json
+{
+  "name": "standard threshold starts at ten",
+  "weight": 10,
+  "expected": "standard"
+}
+```
+
+A port should preserve the same tier boundaries (`<10`, `<50`, `>=50`) and the
+same explicit default-active plugin policy. Filesystem-backed profile migration
+and plugin discovery remain platform-layer tests.
 
 ## Boundaries
 

--- a/test/spec/plugin-policy.fixtures.json
+++ b/test/spec/plugin-policy.fixtures.json
@@ -1,0 +1,52 @@
+{
+  "constants": {
+    "knownTiers": ["core", "standard", "extra"],
+    "defaultTier": "core"
+  },
+  "weightToTier": [
+    { "name": "negative weights stay core", "weight": -1, "expected": "core" },
+    { "name": "zero weight is core", "weight": 0, "expected": "core" },
+    { "name": "weight just below standard threshold is core", "weight": 9, "expected": "core" },
+    { "name": "standard threshold starts at ten", "weight": 10, "expected": "standard" },
+    { "name": "weight just below extra threshold is standard", "weight": 49, "expected": "standard" },
+    { "name": "extra threshold starts at fifty", "weight": 50, "expected": "extra" },
+    { "name": "large weights stay extra", "weight": 100, "expected": "extra" }
+  ],
+  "defaultActiveGroups": [
+    {
+      "name": "#1500 standard operator primitives stay active",
+      "key": "1500",
+      "migration": "defaultActivePlugins1500",
+      "expectedPlugins": ["team", "fleet", "panes", "peers", "pair", "tmux", "kill", "plugin", "doctor", "inbox"],
+      "excludedPlugins": ["split", "shellenv", "completions", "learn", "dream"]
+    },
+    {
+      "name": "#1514 split remains active after stale profile migration",
+      "key": "1514",
+      "migration": "defaultActivePlugins1514",
+      "expectedPlugins": ["split"],
+      "excludedPlugins": ["team", "shellenv", "completions", "learn", "dream"]
+    },
+    {
+      "name": "#1523 shellenv remains active for direnv shell integration",
+      "key": "1523",
+      "migration": "defaultActivePlugins1523",
+      "expectedPlugins": ["shellenv"],
+      "excludedPlugins": ["team", "split", "completions", "learn", "dream"]
+    },
+    {
+      "name": "#1524 completions remain active for CLI ergonomics",
+      "key": "1524",
+      "migration": "defaultActivePlugins1524",
+      "expectedPlugins": ["completions"],
+      "excludedPlugins": ["team", "split", "shellenv", "learn", "dream"]
+    },
+    {
+      "name": "#1531 Oracle workflow verbs stay active",
+      "key": "1531",
+      "migration": "defaultActivePlugins1531",
+      "expectedPlugins": ["learn", "find", "talk-to", "project", "workon", "cleanup"],
+      "excludedPlugins": ["team", "split", "shellenv", "completions", "dream"]
+    }
+  ]
+}

--- a/test/spec/plugin-policy.fixtures.test.ts
+++ b/test/spec/plugin-policy.fixtures.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import {
+  DEFAULT_ACTIVE_PLUGINS_1500,
+  DEFAULT_ACTIVE_PLUGINS_1500_MIGRATION,
+  DEFAULT_ACTIVE_PLUGINS_1514,
+  DEFAULT_ACTIVE_PLUGINS_1514_MIGRATION,
+  DEFAULT_ACTIVE_PLUGINS_1523,
+  DEFAULT_ACTIVE_PLUGINS_1523_MIGRATION,
+  DEFAULT_ACTIVE_PLUGINS_1524,
+  DEFAULT_ACTIVE_PLUGINS_1524_MIGRATION,
+  DEFAULT_ACTIVE_PLUGINS_1531,
+  DEFAULT_ACTIVE_PLUGINS_1531_MIGRATION,
+  isDefaultActive1514Plugin,
+  isDefaultActive1523Plugin,
+  isDefaultActive1524Plugin,
+  isDefaultActive1531Plugin,
+  isDefaultActivePlugin,
+} from "../../src/plugin/default-active";
+import { DEFAULT_TIER, KNOWN_TIERS } from "../../src/plugin/manifest-constants";
+import { weightToTier } from "../../src/plugin/tier";
+import type { PluginTier } from "../../src/plugin/types";
+
+type DefaultActiveKey = "1500" | "1514" | "1523" | "1524" | "1531";
+
+type WeightFixture = {
+  name: string;
+  weight: number;
+  expected: PluginTier;
+};
+
+type DefaultActiveGroupFixture = {
+  name: string;
+  key: DefaultActiveKey;
+  migration: string;
+  expectedPlugins: string[];
+  excludedPlugins: string[];
+};
+
+type FixtureRoot = {
+  constants: {
+    knownTiers: string[];
+    defaultTier: string;
+  };
+  weightToTier: WeightFixture[];
+  defaultActiveGroups: DefaultActiveGroupFixture[];
+};
+
+const fixtureUrl = new URL("./plugin-policy.fixtures.json", import.meta.url);
+const fixtures = JSON.parse(readFileSync(fixtureUrl, "utf8")) as FixtureRoot;
+
+const defaultActivePolicy: Record<DefaultActiveKey, {
+  plugins: readonly string[];
+  migration: string;
+  includes: (name: string) => boolean;
+}> = {
+  "1500": {
+    plugins: DEFAULT_ACTIVE_PLUGINS_1500,
+    migration: DEFAULT_ACTIVE_PLUGINS_1500_MIGRATION,
+    includes: isDefaultActivePlugin,
+  },
+  "1514": {
+    plugins: DEFAULT_ACTIVE_PLUGINS_1514,
+    migration: DEFAULT_ACTIVE_PLUGINS_1514_MIGRATION,
+    includes: isDefaultActive1514Plugin,
+  },
+  "1523": {
+    plugins: DEFAULT_ACTIVE_PLUGINS_1523,
+    migration: DEFAULT_ACTIVE_PLUGINS_1523_MIGRATION,
+    includes: isDefaultActive1523Plugin,
+  },
+  "1524": {
+    plugins: DEFAULT_ACTIVE_PLUGINS_1524,
+    migration: DEFAULT_ACTIVE_PLUGINS_1524_MIGRATION,
+    includes: isDefaultActive1524Plugin,
+  },
+  "1531": {
+    plugins: DEFAULT_ACTIVE_PLUGINS_1531,
+    migration: DEFAULT_ACTIVE_PLUGINS_1531_MIGRATION,
+    includes: isDefaultActive1531Plugin,
+  },
+};
+
+describe("portable plugin policy fixtures (#1612)", () => {
+  test("known tier constants stay portable", () => {
+    expect([...KNOWN_TIERS]).toEqual(fixtures.constants.knownTiers);
+    expect(DEFAULT_TIER).toBe(fixtures.constants.defaultTier);
+  });
+
+  for (const fixture of fixtures.weightToTier) {
+    test(`weightToTier: ${fixture.name}`, () => {
+      expect(weightToTier(fixture.weight)).toBe(fixture.expected);
+    });
+  }
+
+  for (const fixture of fixtures.defaultActiveGroups) {
+    test(`default-active: ${fixture.name}`, () => {
+      const policy = defaultActivePolicy[fixture.key];
+
+      expect([...policy.plugins]).toEqual(fixture.expectedPlugins);
+      expect(policy.migration).toBe(fixture.migration);
+      for (const plugin of fixture.expectedPlugins) {
+        expect(policy.includes(plugin)).toBe(true);
+      }
+      for (const plugin of fixture.excludedPlugins) {
+        expect(policy.includes(plugin)).toBe(false);
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary\n- add JSON fixtures for plugin tier/default-active policy (#1612)\n- verify tier constants, weight boundaries, default-active groups, and migration keys from portable data\n- document the third portable-core spec slice\n\n## Verification\n- rtk bun run test:spec\n- rtk bun test test/plugin-default-active.test.ts test/isolated/plugin-loader-profile.test.ts\n- rtk bun run build\n- git diff --check\n\nNo release cut. Alpha-only feature/test PR.\n\nWritten by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.