### PR TITLE
test: specify calver arithmetic as portable fixtures

### DIFF
--- a/docs/testing/portable-core-spec.md
+++ b/docs/testing/portable-core-spec.md
@@ -14,7 +14,7 @@ maw-js is currently TypeScript/Bun, but several subsystems are pure logic and ca
 | --- | --- | --- | --- |
 | `src/core/matcher/resolve-target.ts` | Pure logic | Ready | First fixture set added in `test/spec/matcher-resolve-target.fixtures.json`. Covers exact, suffix, prefix/middle, substring hints, numeric fleet-session guard, and worktree behavior. |
 | `src/core/matcher/normalize-target.ts` | Pure logic | Ready | Fixture set added in `test/spec/normalize-target.fixtures.json`. Covers whitespace trimming, trailing slash cleanup, trailing `/.git` cleanup, and non-normalized interior/case behavior. |
-| `scripts/calver.ts` | Mostly pure version arithmetic plus git/tag IO | Extract first | Move/calibrate pure HHMM/version arithmetic behind fixtureable helpers before port validation. |
+| `scripts/calver.ts` | Pure version arithmetic plus git/tag/package IO | Ready | Fixture set added in `test/spec/calver.fixtures.json`. Covers date base, HHMM stamp, tag/package suffix parsing, effective base, ghost-date guard, next-calendar base, and full `computeVersion` outcomes; git/package IO stays platform-layer. |
 | Plugin tier/default-active policy | Pure policy tables plus profile IO | Ready | Fixture set added in `test/spec/plugin-policy.fixtures.json`. Covers tier constants, weight boundaries, default-active groups, and migration keys; profile migration tests stay platform-specific. |
 | Routing aliases (`src/core/routing.ts`) | Mixed pure resolver + config/tmux adapters | Extract first | Fixture the input graph (`localNode`, sessions, peers, agents) and expected route/error once IO adapters are separated. |
 | Worktree scan (`src/core/fleet/worktrees-scan.ts`) | Mixed classification + `hostExec`/filesystem | Extract first | The #1553 matching rule is portable; shell/git discovery is platform layer. |
@@ -87,6 +87,32 @@ plugin groups with their migration keys:
 A port should preserve the same tier boundaries (`<10`, `<50`, `>=50`) and the
 same explicit default-active plugin policy. Filesystem-backed profile migration
 and plugin discovery remain platform-layer tests.
+
+
+## Fourth spec: calver arithmetic
+
+The fourth portable spec captures the pure CalVer behavior behind alpha/beta
+suffixes and anti-downgrade rules:
+
+- Fixture data: `test/spec/calver.fixtures.json`
+- TS runner: `test/spec/calver.fixtures.test.ts`
+- Script: `bun run test:spec`
+
+The JSON represents dates as local-naive parts so another language can construct
+an equivalent wall-clock timestamp without inheriting JavaScript object details:
+
+```json
+{
+  "name": "post-midnight package downgrade rolls base forward",
+  "args": { "stable": false, "now": { "year": 2026, "month": 5, "day": 16, "hour": 0, "minute": 27 } },
+  "packageVersion": "26.5.16-alpha.2356",
+  "expected": "26.5.17-alpha.27"
+}
+```
+
+A port should preserve the HHMM invariant: suffixes are wall-clock stamps between
+`0` and `2359`; when a same-base suffix would downgrade after midnight, roll the
+CalVer base forward instead of emitting monotonic values such as `2360`.
 
 ## Boundaries
 

--- a/test/spec/calver.fixtures.json
+++ b/test/spec/calver.fixtures.json
@@ -1,0 +1,81 @@
+{
+  "dateBase": [
+    { "name": "standard release day", "now": { "year": 2026, "month": 4, "day": 18, "hour": 9, "minute": 37 }, "expected": "26.4.18" },
+    { "name": "no zero padding in month/day", "now": { "year": 2026, "month": 2, "day": 5, "hour": 9, "minute": 5 }, "expected": "26.2.5" },
+    { "name": "year rolls to yy", "now": { "year": 2027, "month": 1, "day": 1, "hour": 0, "minute": 5 }, "expected": "27.1.1" }
+  ],
+  "hhmmStamp": [
+    { "name": "midnight is zero", "now": { "year": 2026, "month": 4, "day": 18, "hour": 0, "minute": 0 }, "expected": "0" },
+    { "name": "midnight minute drops leading zero", "now": { "year": 2026, "month": 4, "day": 18, "hour": 0, "minute": 5 }, "expected": "5" },
+    { "name": "single digit hour uses HMM integer", "now": { "year": 2026, "month": 4, "day": 18, "hour": 9, "minute": 29 }, "expected": "929" },
+    { "name": "double digit hour uses HMM integer", "now": { "year": 2026, "month": 4, "day": 18, "hour": 10, "minute": 1 }, "expected": "1001" },
+    { "name": "latest valid wall clock stamp", "now": { "year": 2026, "month": 4, "day": 18, "hour": 23, "minute": 59 }, "expected": "2359" }
+  ],
+  "extractBaseFromVersion": [
+    { "name": "alpha suffix stripped", "version": "26.4.29-alpha.5", "expected": "26.4.29" },
+    { "name": "beta suffix stripped", "version": "26.4.29-beta.0", "expected": "26.4.29" },
+    { "name": "leading v accepted", "version": "v26.4.29-alpha.5", "expected": "26.4.29" },
+    { "name": "bare stable accepted", "version": "26.4.29", "expected": "26.4.29" },
+    { "name": "empty version rejected", "version": "", "expected": null },
+    { "name": "malformed version rejected", "version": "not-a-version", "expected": null },
+    { "name": "four-segment shape rejected", "version": "26.4.29.1", "expected": null }
+  ],
+  "compareBases": [
+    { "name": "day compares numerically", "a": "26.4.30", "b": "26.4.4", "expectedSign": "positive" },
+    { "name": "reverse day comparison", "a": "26.4.4", "b": "26.4.30", "expectedSign": "negative" },
+    { "name": "same base", "a": "26.4.28", "b": "26.4.28", "expectedSign": "zero" },
+    { "name": "year dominates", "a": "27.1.1", "b": "26.12.31", "expectedSign": "positive" },
+    { "name": "month dominates", "a": "26.5.1", "b": "26.4.99", "expectedSign": "positive" }
+  ],
+  "isValidCalendarDate": [
+    { "name": "valid first day", "base": "26.1.1", "expected": true },
+    { "name": "valid leap-day permissive February", "base": "26.2.29", "expected": true },
+    { "name": "valid month end", "base": "26.12.31", "expected": true },
+    { "name": "ghost April day rejected", "base": "26.4.31", "expected": false },
+    { "name": "February day beyond permissive max rejected", "base": "26.2.30", "expected": false },
+    { "name": "month zero rejected", "base": "26.0.1", "expected": false },
+    { "name": "day zero rejected", "base": "26.1.0", "expected": false },
+    { "name": "malformed base rejected", "base": "26.4", "expected": false }
+  ],
+  "nextCalendarBase": [
+    { "name": "advances within month", "base": "26.5.16", "expected": "26.5.17" },
+    { "name": "advances across month", "base": "26.5.31", "expected": "26.6.1" },
+    { "name": "advances across year", "base": "26.12.31", "expected": "27.1.1" }
+  ],
+  "maxNFromTags": [
+    { "name": "no matching tags", "base": "26.4.18", "channel": "alpha", "tags": ["v26.4.17-alpha.5", "v26.4.19-alpha.0"], "expected": -1 },
+    { "name": "max alpha across matching tags", "base": "26.4.27", "channel": "alpha", "tags": ["v26.4.27-alpha.11", "v26.4.27-alpha.12", "v26.4.27-alpha.13"], "expected": 13 },
+    { "name": "non-monotonic tag order", "base": "26.4.27", "channel": "alpha", "tags": ["v26.4.27-alpha.13", "v26.4.27-alpha.0", "v26.4.27-alpha.7"], "expected": 13 },
+    { "name": "channel isolation", "base": "26.4.28", "channel": "beta", "tags": ["v26.4.28-alpha.99", "v26.4.28-beta.5", "v26.4.28-beta.12.0"], "expected": 5 },
+    { "name": "non-integer suffix rejected", "base": "26.4.27", "channel": "alpha", "tags": ["v26.4.27-alpha.5", "v26.4.27-alpha.12.0"], "expected": 5 }
+  ],
+  "maxNFromPackageJson": [
+    { "name": "matching alpha with v prefix", "base": "26.4.28", "channel": "alpha", "packageVersion": "v26.4.28-alpha.7", "expected": 7 },
+    { "name": "matching beta", "base": "26.4.28", "channel": "beta", "packageVersion": "26.4.28-beta.3", "expected": 3 },
+    { "name": "date mismatch", "base": "26.4.28", "channel": "alpha", "packageVersion": "26.4.27-alpha.99", "expected": -1 },
+    { "name": "channel mismatch", "base": "26.4.28", "channel": "alpha", "packageVersion": "26.4.28-beta.5", "expected": -1 },
+    { "name": "non-integer suffix rejected", "base": "26.4.28", "channel": "alpha", "packageVersion": "26.4.28-alpha.12.0", "expected": -1 },
+    { "name": "substring trap rejected", "base": "26.4.2", "channel": "alpha", "packageVersion": "26.4.28-alpha.5", "expected": -1 },
+    { "name": "zero-padded suffix parses as decimal", "base": "26.4.28", "channel": "alpha", "packageVersion": "26.4.28-alpha.05", "expected": 5 }
+  ],
+  "effectiveBase": [
+    { "name": "future package base wins", "todayBase": "26.4.28", "packageVersion": "26.4.29-alpha.5", "expected": "26.4.29" },
+    { "name": "today wins over old package base", "todayBase": "26.4.28", "packageVersion": "26.4.27-alpha.99", "expected": "26.4.28" },
+    { "name": "equal base keeps today", "todayBase": "26.4.28", "packageVersion": "26.4.28-alpha.18", "expected": "26.4.28" },
+    { "name": "empty package version keeps today", "todayBase": "26.4.28", "packageVersion": "", "expected": "26.4.28" },
+    { "name": "bare future stable wins", "todayBase": "26.4.28", "packageVersion": "26.4.30", "expected": "26.4.30" },
+    { "name": "ghost package date throws", "todayBase": "26.4.30", "packageVersion": "26.4.53", "errorIncludes": "ghost date" }
+  ],
+  "computeVersion": [
+    { "name": "stable uses today's base", "args": { "stable": true, "now": { "year": 2026, "month": 4, "day": 18, "hour": 9, "minute": 37 } }, "tags": [], "packageVersion": "", "expected": "26.4.18" },
+    { "name": "alpha emits HHMM when no existing suffix is higher", "args": { "stable": false, "now": { "year": 2026, "month": 4, "day": 18, "hour": 9, "minute": 37 } }, "tags": [], "packageVersion": "", "expected": "26.4.18-alpha.937" },
+    { "name": "midnight alpha drops leading zero", "args": { "stable": false, "now": { "year": 2027, "month": 1, "day": 1, "hour": 0, "minute": 5 } }, "tags": [], "packageVersion": "", "expected": "27.1.1-alpha.5" },
+    { "name": "lower existing tags do not change HHMM", "args": { "stable": false, "now": { "year": 2026, "month": 4, "day": 27, "hour": 12, "minute": 0 } }, "tags": ["v26.4.27-alpha.11", "v26.4.27-alpha.12"], "packageVersion": "", "expected": "26.4.27-alpha.1200" },
+    { "name": "post-midnight package downgrade rolls base forward", "args": { "stable": false, "now": { "year": 2026, "month": 5, "day": 16, "hour": 0, "minute": 27 } }, "tags": [], "packageVersion": "26.5.16-alpha.2356", "expected": "26.5.17-alpha.27" },
+    { "name": "post-midnight tag downgrade rolls base forward", "args": { "stable": false, "now": { "year": 2026, "month": 5, "day": 16, "hour": 0, "minute": 27 } }, "tags": ["v26.5.16-alpha.2358"], "packageVersion": "", "expected": "26.5.17-alpha.27" },
+    { "name": "impossible monotonic suffix never emitted", "args": { "stable": false, "now": { "year": 2026, "month": 5, "day": 16, "hour": 6, "minute": 29 } }, "tags": ["v26.5.16-alpha.2364"], "packageVersion": "26.5.16-alpha.2364", "expected": "26.5.17-alpha.629", "maxSuffix": 2359 },
+    { "name": "beta shares HHMM but differs by channel", "args": { "stable": false, "channel": "beta", "now": { "year": 2026, "month": 4, "day": 27, "hour": 12, "minute": 0 } }, "tags": [], "packageVersion": "", "expected": "26.4.27-beta.1200" },
+    { "name": "future package base is preserved", "args": { "stable": false, "now": { "year": 2026, "month": 4, "day": 28, "hour": 12, "minute": 0 } }, "tags": [], "packageVersion": "26.4.29-alpha.5", "expected": "26.4.29-alpha.1200" },
+    { "name": "stable ignores future package base", "args": { "stable": true, "now": { "year": 2026, "month": 4, "day": 28, "hour": 12, "minute": 0 } }, "tags": [], "packageVersion": "26.4.29-alpha.5", "expected": "26.4.28" }
+  ]
+}

--- a/test/spec/calver.fixtures.test.ts
+++ b/test/spec/calver.fixtures.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import {
+  compareBases,
+  computeVersion,
+  dateBase,
+  effectiveBase,
+  extractBaseFromVersion,
+  hhmmStamp,
+  isValidCalendarDate,
+  maxNFromPackageJson,
+  maxNFromTags,
+  nextCalendarBase,
+  type Channel,
+} from "../../scripts/calver";
+
+type DateParts = {
+  year: number;
+  month: number;
+  day: number;
+  hour?: number;
+  minute?: number;
+};
+
+type Sign = "negative" | "zero" | "positive";
+
+type ComputeVersionFixture = {
+  name: string;
+  args: {
+    stable: boolean;
+    channel?: Channel;
+    now: DateParts;
+  };
+  tags: string[];
+  packageVersion: string;
+  expected: string;
+  maxSuffix?: number;
+};
+
+type FixtureRoot = {
+  dateBase: { name: string; now: DateParts; expected: string }[];
+  hhmmStamp: { name: string; now: DateParts; expected: string }[];
+  extractBaseFromVersion: { name: string; version: string; expected: string | null }[];
+  compareBases: { name: string; a: string; b: string; expectedSign: Sign }[];
+  isValidCalendarDate: { name: string; base: string; expected: boolean }[];
+  nextCalendarBase: { name: string; base: string; expected: string }[];
+  maxNFromTags: { name: string; base: string; channel: Channel; tags: string[]; expected: number }[];
+  maxNFromPackageJson: { name: string; base: string; channel: Channel; packageVersion: string; expected: number }[];
+  effectiveBase: ({ name: string; todayBase: string; packageVersion: string; expected: string } | { name: string; todayBase: string; packageVersion: string; errorIncludes: string })[];
+  computeVersion: ComputeVersionFixture[];
+};
+
+const fixtureUrl = new URL("./calver.fixtures.json", import.meta.url);
+const fixtures = JSON.parse(readFileSync(fixtureUrl, "utf8")) as FixtureRoot;
+
+function toDate(parts: DateParts): Date {
+  return new Date(parts.year, parts.month - 1, parts.day, parts.hour ?? 0, parts.minute ?? 0);
+}
+
+function sign(value: number): Sign {
+  if (value < 0) return "negative";
+  if (value > 0) return "positive";
+  return "zero";
+}
+
+describe("portable calver fixtures (#1612)", () => {
+  for (const fixture of fixtures.dateBase) {
+    test(`dateBase: ${fixture.name}`, () => {
+      expect(dateBase(toDate(fixture.now))).toBe(fixture.expected);
+    });
+  }
+
+  for (const fixture of fixtures.hhmmStamp) {
+    test(`hhmmStamp: ${fixture.name}`, () => {
+      expect(hhmmStamp(toDate(fixture.now))).toBe(fixture.expected);
+    });
+  }
+
+  for (const fixture of fixtures.extractBaseFromVersion) {
+    test(`extractBaseFromVersion: ${fixture.name}`, () => {
+      expect(extractBaseFromVersion(fixture.version)).toBe(fixture.expected);
+    });
+  }
+
+  for (const fixture of fixtures.compareBases) {
+    test(`compareBases: ${fixture.name}`, () => {
+      expect(sign(compareBases(fixture.a, fixture.b))).toBe(fixture.expectedSign);
+    });
+  }
+
+  for (const fixture of fixtures.isValidCalendarDate) {
+    test(`isValidCalendarDate: ${fixture.name}`, () => {
+      expect(isValidCalendarDate(fixture.base)).toBe(fixture.expected);
+    });
+  }
+
+  for (const fixture of fixtures.nextCalendarBase) {
+    test(`nextCalendarBase: ${fixture.name}`, () => {
+      expect(nextCalendarBase(fixture.base)).toBe(fixture.expected);
+    });
+  }
+
+  for (const fixture of fixtures.maxNFromTags) {
+    test(`maxNFromTags: ${fixture.name}`, () => {
+      expect(maxNFromTags(fixture.base, fixture.channel, fixture.tags)).toBe(fixture.expected);
+    });
+  }
+
+  for (const fixture of fixtures.maxNFromPackageJson) {
+    test(`maxNFromPackageJson: ${fixture.name}`, () => {
+      expect(maxNFromPackageJson(fixture.base, fixture.channel, fixture.packageVersion)).toBe(fixture.expected);
+    });
+  }
+
+  for (const fixture of fixtures.effectiveBase) {
+    test(`effectiveBase: ${fixture.name}`, () => {
+      if ("errorIncludes" in fixture) {
+        expect(() => effectiveBase(fixture.todayBase, fixture.packageVersion)).toThrow(fixture.errorIncludes);
+        return;
+      }
+      expect(effectiveBase(fixture.todayBase, fixture.packageVersion)).toBe(fixture.expected);
+    });
+  }
+
+  for (const fixture of fixtures.computeVersion) {
+    test(`computeVersion: ${fixture.name}`, () => {
+      const version = computeVersion(
+        {
+          stable: fixture.args.stable,
+          channel: fixture.args.channel,
+          check: false,
+          now: toDate(fixture.args.now),
+        },
+        fixture.tags,
+        fixture.packageVersion,
+      );
+      expect(version).toBe(fixture.expected);
+      if (fixture.maxSuffix !== undefined) {
+        const suffix = Number(version.split(".").at(-1));
+        expect(suffix).toBeLessThanOrEqual(fixture.maxSuffix);
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add JSON fixtures for CalVer/date arithmetic as the next #1612 portable-core slice
- cover date base, HHMM stamp, base extraction/comparison, validity, next-calendar rollover, tag/package suffix parsing, effective base, and full `computeVersion` outputs
- document CalVer as the fourth portable fixture spec

## Verification
- `rtk bun run test:spec`
- `rtk bun test test/calver.test.ts`
- `rtk bun run build`
- `git diff --check`

No release cut. Alpha-only feature/test PR.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
