### PR TITLE
test: specify routing behavior as portable fixtures

### DIFF
--- a/docs/testing/portable-core-spec.md
+++ b/docs/testing/portable-core-spec.md
@@ -16,7 +16,7 @@ maw-js is currently TypeScript/Bun, but several subsystems are pure logic and ca
 | `src/core/matcher/normalize-target.ts` | Pure logic | Ready | Fixture set added in `test/spec/normalize-target.fixtures.json`. Covers whitespace trimming, trailing slash cleanup, trailing `/.git` cleanup, and non-normalized interior/case behavior. |
 | `scripts/calver.ts` | Pure version arithmetic plus git/tag/package IO | Ready | Fixture set added in `test/spec/calver.fixtures.json`. Covers date base, HHMM stamp, tag/package suffix parsing, effective base, ghost-date guard, next-calendar base, and full `computeVersion` outcomes; git/package IO stays platform-layer. |
 | Plugin tier/default-active policy | Pure policy tables plus profile IO | Ready | Fixture set added in `test/spec/plugin-policy.fixtures.json`. Covers tier constants, weight boundaries, default-active groups, and migration keys; profile migration tests stay platform-specific. |
-| Routing aliases (`src/core/routing.ts`) | Mixed pure resolver + config/tmux adapters | Extract first | Fixture the input graph (`localNode`, sessions, peers, agents) and expected route/error once IO adapters are separated. |
+| Routing aliases (`src/core/routing.ts`) | Pure resolver over config + session graph, with manifest lookup fallback | Ready | Fixture set added in `test/spec/routing.fixtures.json`. Covers local/session, node/self/peer, legacy peer URL fallback, source filtering, and #1565 session-alias guards; manifest cache lookup remains a best-effort platform fallback. |
 | Worktree scan (`src/core/fleet/worktrees-scan.ts`) | Mixed classification + `hostExec`/filesystem | Extract first | The #1553 matching rule is portable; shell/git discovery is platform layer. |
 | Transport router (`src/core/transport/transport.ts`) | Pure orchestration over transport interface | Ready-ish | Fixtures can cover route selection/failover if represented as deterministic transport outcomes. |
 
@@ -113,6 +113,33 @@ an equivalent wall-clock timestamp without inheriting JavaScript object details:
 A port should preserve the HHMM invariant: suffixes are wall-clock stamps between
 `0` and `2359`; when a same-base suffix would downgrade after midnight, roll the
 CalVer base forward instead of emitting monotonic values such as `2360`.
+
+
+## Fifth spec: routing resolveTarget
+
+The fifth portable spec captures the shared `maw hey` / API routing resolver over
+plain config and session data:
+
+- Fixture data: `test/spec/routing.fixtures.json`
+- TS runner: `test/spec/routing.fixtures.test.ts`
+- Script: `bun run test:spec`
+
+The JSON describes a base config plus per-case sessions, query, optional config
+overrides, and the expected route/error object:
+
+```json
+{
+  "name": "bare oracle alias prefers oracle-named window",
+  "query": "specbot",
+  "sessions": [{ "name": "54-specbot", "windows": [{ "index": 1, "name": "specbot-issuer", "active": true }, { "index": 2, "name": "specbot-oracle", "active": true }] }],
+  "expected": { "type": "local", "target": "54-specbot:2" }
+}
+```
+
+A port should preserve local-first routing, explicit `node:agent` routing,
+legacy peer URL fallback, local-only source filtering, and the #1565 invariant:
+fleet/session aliases must fail loudly instead of silently defaulting to a
+multi-window session's first window.
 
 ## Boundaries
 

--- a/test/spec/routing.fixtures.json
+++ b/test/spec/routing.fixtures.json
@@ -1,0 +1,168 @@
+{
+  "baseConfig": {
+    "host": "local",
+    "port": 3456,
+    "ghqRoot": "/tmp/ghq",
+    "oracleUrl": "http://localhost:47779",
+    "env": {},
+    "commands": { "default": "claude" },
+    "sessions": {},
+    "node": "selfnode",
+    "namedPeers": [
+      { "name": "peerbox", "url": "http://peerbox.local:3457" },
+      { "name": "farbox", "url": "http://farbox.local:3458" }
+    ],
+    "agents": {
+      "remoteagent": "peerbox",
+      "selfagent": "selfnode",
+      "nopurlagent": "ghostnode"
+    },
+    "peers": []
+  },
+  "cases": [
+    {
+      "name": "empty query fails with usage hint",
+      "query": "",
+      "sessions": [],
+      "expected": { "type": "error", "reason": "empty_query", "detail": "no target specified", "hint": "usage: maw hey <agent> <message>" }
+    },
+    {
+      "name": "bare window name resolves locally",
+      "query": "local-oracle",
+      "sessions": [
+        { "name": "01-local", "windows": [{ "index": 1, "name": "local-oracle", "active": true }] }
+      ],
+      "expected": { "type": "local", "target": "01-local:1" }
+    },
+    {
+      "name": "session window name resolves locally before peer routing",
+      "query": "01-local:local-oracle",
+      "sessions": [
+        { "name": "01-local", "windows": [{ "index": 1, "name": "local-oracle", "active": true }] }
+      ],
+      "expected": { "type": "local", "target": "01-local:1" }
+    },
+    {
+      "name": "session window pane address stays local",
+      "query": "01-local:local-oracle.0",
+      "sessions": [
+        { "name": "01-local", "windows": [{ "index": 1, "name": "local-oracle", "active": true }] }
+      ],
+      "expected": { "type": "local", "target": "01-local:1.0" }
+    },
+    {
+      "name": "node agent resolves to named peer",
+      "query": "peerbox:remoteagent",
+      "sessions": [],
+      "expected": { "type": "peer", "peerUrl": "http://peerbox.local:3457", "target": "remoteagent", "node": "peerbox" }
+    },
+    {
+      "name": "self-node prefix resolves locally",
+      "query": "selfnode:local-oracle",
+      "sessions": [
+        { "name": "01-local", "windows": [{ "index": 1, "name": "local-oracle", "active": true }] }
+      ],
+      "expected": { "type": "self-node", "target": "01-local:1" }
+    },
+    {
+      "name": "local prefix miss is a self-node miss",
+      "query": "local:ghost",
+      "sessions": [],
+      "expected": { "type": "error", "reason": "self_not_running", "detail": "'ghost' not found in local sessions on selfnode", "hint": "maw wake ghost" }
+    },
+    {
+      "name": "unknown node fails loudly",
+      "query": "unknown:remoteagent",
+      "sessions": [],
+      "expected": { "type": "error", "reason": "unknown_node", "detail": "node 'unknown' not in namedPeers or peers", "hint": "add to maw.config.json namedPeers" }
+    },
+    {
+      "name": "bare agent map routes to peer",
+      "query": "remoteagent",
+      "sessions": [],
+      "expected": { "type": "peer", "peerUrl": "http://peerbox.local:3457", "target": "remoteagent", "node": "peerbox" }
+    },
+    {
+      "name": "bare agent mapped to self reports local miss",
+      "query": "selfagent",
+      "sessions": [],
+      "expected": { "type": "error", "reason": "self_not_running", "detail": "'selfagent' mapped to selfnode (local) but not found in sessions", "hint": "maw wake selfagent" }
+    },
+    {
+      "name": "agent mapped to node without peer url fails loudly",
+      "query": "nopurlagent",
+      "sessions": [],
+      "expected": { "type": "error", "reason": "no_peer_url", "detail": "'nopurlagent' mapped to node 'ghostnode' but no URL found", "hint": "add ghostnode to maw.config.json namedPeers" }
+    },
+    {
+      "name": "query with slash is not node routing",
+      "query": "01-local/worktree",
+      "sessions": [],
+      "expected": { "type": "error", "reason": "not_found", "detail": "'01-local/worktree' not in local sessions or agents map", "hint": "check: maw ls" }
+    },
+    {
+      "name": "legacy peers array can provide node url",
+      "query": "peerbox:remoteagent",
+      "config": { "namedPeers": [], "peers": ["http://peerbox.wg:3457"] },
+      "sessions": [],
+      "expected": { "type": "peer", "peerUrl": "http://peerbox.wg:3457", "target": "remoteagent", "node": "peerbox" }
+    },
+    {
+      "name": "multiple colons keep agent suffix intact",
+      "query": "peerbox:remote:agent",
+      "sessions": [],
+      "expected": { "type": "peer", "peerUrl": "http://peerbox.local:3457", "target": "remote:agent", "node": "peerbox" }
+    },
+    {
+      "name": "view mirrors are ignored before local ambiguity",
+      "query": "local-oracle",
+      "sessions": [
+        { "name": "01-local", "windows": [{ "index": 1, "name": "local-oracle", "active": true }], "source": "local" },
+        { "name": "local-view", "windows": [{ "index": 1, "name": "local-oracle", "active": false }], "source": "local" }
+      ],
+      "expected": { "type": "local", "target": "01-local:1" }
+    },
+    {
+      "name": "federated sessions are ignored as local send targets",
+      "query": "local-oracle",
+      "sessions": [
+        { "name": "01-local", "windows": [{ "index": 1, "name": "local-oracle", "active": true }], "source": "local" },
+        { "name": "99-local", "windows": [{ "index": 1, "name": "local-oracle", "active": true }], "source": "http://peerbox.local:3457" }
+      ],
+      "expected": { "type": "local", "target": "01-local:1" }
+    },
+    {
+      "name": "bare oracle alias prefers oracle-named window",
+      "query": "specbot",
+      "sessions": [
+        { "name": "54-specbot", "windows": [{ "index": 1, "name": "specbot-issuer", "active": true }, { "index": 2, "name": "specbot-oracle", "active": true }] }
+      ],
+      "expected": { "type": "local", "target": "54-specbot:2" }
+    },
+    {
+      "name": "bare oracle alias strips numeric session prefix for single-window session",
+      "query": "specbot-codex",
+      "sessions": [
+        { "name": "48-specbot-codex", "windows": [{ "index": 7, "name": "codex-main", "active": true }] }
+      ],
+      "expected": { "type": "local", "target": "48-specbot-codex:7" }
+    },
+    {
+      "name": "ambiguous session aliases fail loudly",
+      "query": "specbot",
+      "sessions": [
+        { "name": "54-specbot", "windows": [{ "index": 1, "name": "specbot-oracle", "active": true }] },
+        { "name": "99-specbot", "windows": [{ "index": 1, "name": "specbot-oracle", "active": true }] }
+      ],
+      "expected": { "type": "error", "reason": "session_alias_ambiguous", "detail": "'specbot' matches multiple local sessions; refusing to guess a window", "hint": "candidates: 54-specbot, 99-specbot" }
+    },
+    {
+      "name": "multi-window alias without oracle window refuses first-window fallback",
+      "query": "specbot",
+      "sessions": [
+        { "name": "54-specbot", "windows": [{ "index": 1, "name": "helper", "active": true }, { "index": 2, "name": "notes", "active": true }] }
+      ],
+      "expected": { "type": "error", "reason": "session_window_not_found", "detail": "'specbot' matched local session '54-specbot', but no window named 'specbot' or 'specbot-oracle' was found; refusing to default to the first window", "hint": "candidates: 54-specbot:1 (helper), 54-specbot:2 (notes)" }
+    }
+  ]
+}

--- a/test/spec/routing.fixtures.test.ts
+++ b/test/spec/routing.fixtures.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import type { MawConfig } from "../../src/config";
+import { resolveTarget, type ResolveResult, type Session } from "../../src/core/routing";
+
+type FixtureSession = Session & { source?: string };
+type Fixture = {
+  name: string;
+  query: string;
+  config?: Partial<MawConfig>;
+  sessions: FixtureSession[];
+  expected: ResolveResult;
+};
+
+type FixtureRoot = {
+  baseConfig: MawConfig;
+  cases: Fixture[];
+};
+
+const fixtureUrl = new URL("./routing.fixtures.json", import.meta.url);
+const fixtures = JSON.parse(readFileSync(fixtureUrl, "utf8")) as FixtureRoot;
+
+function configFor(fixture: Fixture): MawConfig {
+  return { ...fixtures.baseConfig, ...(fixture.config ?? {}) };
+}
+
+describe("portable routing resolveTarget fixtures (#1612)", () => {
+  for (const fixture of fixtures.cases) {
+    test(fixture.name, () => {
+      expect(resolveTarget(fixture.query, configFor(fixture), fixture.sessions)).toEqual(fixture.expected);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add JSON fixtures for routing `resolveTarget()` as the next #1612 portable-core slice
- cover local/session routing, node/self/peer routing, legacy peers[] fallback, source filtering, and #1565 fail-loud session-alias guards
- document routing as the fifth portable spec

## Verification
- `rtk bun run test:spec`
- `rtk bun test test/routing.test.ts test/routing-session-alias.test.ts test/isolated/routing-fleet-window.test.ts`
- `rtk bun run build`
- `git diff --check`

No release cut. Alpha-only feature/test PR.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
