### PR TITLE
test: specify worktree window matching as portable fixtures

### DIFF
--- a/docs/testing/portable-core-spec.md
+++ b/docs/testing/portable-core-spec.md
@@ -17,7 +17,7 @@ maw-js is currently TypeScript/Bun, but several subsystems are pure logic and ca
 | `scripts/calver.ts` | Pure version arithmetic plus git/tag/package IO | Ready | Fixture set added in `test/spec/calver.fixtures.json`. Covers date base, HHMM stamp, tag/package suffix parsing, effective base, ghost-date guard, next-calendar base, and full `computeVersion` outcomes; git/package IO stays platform-layer. |
 | Plugin tier/default-active policy | Pure policy tables plus profile IO | Ready | Fixture set added in `test/spec/plugin-policy.fixtures.json`. Covers tier constants, weight boundaries, default-active groups, and migration keys; profile migration tests stay platform-specific. |
 | Routing aliases (`src/core/routing.ts`) | Pure resolver over config + session graph, with manifest lookup fallback | Ready | Fixture set added in `test/spec/routing.fixtures.json`. Covers local/session, node/self/peer, legacy peer URL fallback, source filtering, and #1565 session-alias guards; manifest cache lookup remains a best-effort platform fallback. |
-| Worktree scan (`src/core/fleet/worktrees-scan.ts`) | Mixed classification + `hostExec`/filesystem | Extract first | The #1553 matching rule is portable; shell/git discovery is platform layer. |
+| Worktree window matching (`src/core/fleet/worktree-window-match.ts`) | Pure matcher extracted from filesystem scan | Ready | Fixture set added in `test/spec/worktree-window-match.fixtures.json`. Covers parent-session scoping, numeric session names, global fallback, same-name dedupe, #1553 full-name-first matching, ambiguity, and none results; filesystem/git scan stays platform-layer. |
 | Transport router (`src/core/transport/transport.ts`) | Pure orchestration over transport interface | Ready-ish | Fixtures can cover route selection/failover if represented as deterministic transport outcomes. |
 
 ## First spec: matcher resolve-target
@@ -140,6 +140,37 @@ A port should preserve local-first routing, explicit `node:agent` routing,
 legacy peer URL fallback, local-only source filtering, and the #1565 invariant:
 fleet/session aliases must fail loudly instead of silently defaulting to a
 multi-window session's first window.
+
+
+## Sixth spec: worktree window matching
+
+The sixth portable spec captures the pure worktree-to-window binding policy used
+by `maw ls` / fleet worktree scans:
+
+- Fixture data: `test/spec/worktree-window-match.fixtures.json`
+- TS runner: `test/spec/worktree-window-match.fixtures.test.ts`
+- Script: `bun run test:spec`
+
+The JSON includes the parent repo name, worktree name, session/window graph, and
+expected binding result:
+
+```json
+{
+  "name": "full worktree name wins before stripped tile suffix fallback",
+  "input": {
+    "mainRepoName": "mawjs-oracle",
+    "wtName": "6-tile-1",
+    "sessions": [
+      { "name": "54-mawjs", "windows": [{ "index": 2, "name": "mawjs-6-tile-1", "active": false }] }
+    ]
+  },
+  "expected": { "kind": "bound", "window": "mawjs-6-tile-1" }
+}
+```
+
+A port should preserve the #823/#935/#1553 invariants: dedupe same-named windows,
+try parent oracle sessions first, try full worktree names before stripped numeric
+suffixes, and surface ambiguity instead of guessing a binding.
 
 ## Boundaries
 

--- a/src/core/fleet/worktree-window-match.ts
+++ b/src/core/fleet/worktree-window-match.ts
@@ -1,0 +1,77 @@
+import type { Session, Window } from "../runtime/find-window";
+import { resolveWorktreeTarget } from "../matcher/resolve-target";
+
+export type WorktreeWindowResolution =
+  | { kind: "bound"; window: string }
+  | { kind: "ambiguous"; query: string; candidates: string[] }
+  | { kind: "none" };
+
+function dedupeWindowsByName(sessions: Session[]): Window[] {
+  return [...new Map(sessions.flatMap(s => s.windows).map(w => [w.name, w])).values()];
+}
+
+function parentOracleNameFromMainRepo(mainRepoName: string): string {
+  return mainRepoName.replace(/-oracle$/, "");
+}
+
+function parentSessionsFor(mainRepoName: string, sessions: Session[]): Session[] {
+  const parentOracleName = parentOracleNameFromMainRepo(mainRepoName);
+  return sessions.filter(s =>
+    s.name === parentOracleName || s.name.endsWith(`-${parentOracleName}`)
+  );
+}
+
+function boundWindow(
+  target: string,
+  windows: Window[],
+): string | null {
+  const resolved = resolveWorktreeTarget(target, windows);
+  if (resolved.kind === "exact" || resolved.kind === "fuzzy") {
+    return resolved.match.name;
+  }
+  return null;
+}
+
+/**
+ * Pure worktree-to-window matching policy used by scanWorktrees().
+ *
+ * Matching order preserves the production invariants fixed by #823/#935/#1553:
+ * 1. dedupe same-named windows across sessions,
+ * 2. try parent oracle sessions before global search,
+ * 3. try the full worktree name before stripping its numeric prefix,
+ * 4. fail with explicit ambiguity instead of binding a guessed window.
+ */
+export function resolveWorktreeWindow(
+  mainRepoName: string,
+  wtName: string,
+  sessions: Session[],
+): WorktreeWindowResolution {
+  const taskPart = wtName.replace(/^\d+-/, "");
+  const parentSessions = parentSessionsFor(mainRepoName, sessions);
+
+  if (parentSessions.length > 0) {
+    const scopedWindows = dedupeWindowsByName(parentSessions);
+    const fullScoped = boundWindow(wtName, scopedWindows);
+    if (fullScoped) return { kind: "bound", window: fullScoped };
+
+    const taskScoped = boundWindow(taskPart, scopedWindows);
+    if (taskScoped) return { kind: "bound", window: taskScoped };
+  }
+
+  const allWindows = dedupeWindowsByName(sessions);
+  const fullGlobal = boundWindow(wtName, allWindows);
+  if (fullGlobal) return { kind: "bound", window: fullGlobal };
+
+  const taskResolved = resolveWorktreeTarget(taskPart, allWindows);
+  if (taskResolved.kind === "exact" || taskResolved.kind === "fuzzy") {
+    return { kind: "bound", window: taskResolved.match.name };
+  }
+  if (taskResolved.kind === "ambiguous") {
+    return {
+      kind: "ambiguous",
+      query: taskPart,
+      candidates: taskResolved.candidates.map(candidate => candidate.name),
+    };
+  }
+  return { kind: "none" };
+}

--- a/src/core/fleet/worktrees-scan.ts
+++ b/src/core/fleet/worktrees-scan.ts
@@ -3,7 +3,7 @@ import { getGhqRoot } from "../../config/ghq-root";
 import { readdirSync, readFileSync } from "fs";
 import { join } from "path";
 import { FLEET_DIR } from "../paths";
-import { resolveWorktreeTarget } from "../matcher/resolve-target";
+import { resolveWorktreeWindow } from "./worktree-window-match";
 
 export interface WorktreeInfo {
   path: string;
@@ -87,72 +87,20 @@ export async function scanWorktrees(): Promise<WorktreeInfo[]> {
       branch = (await hostExec(`git -C '${wtPath}' rev-parse --abbrev-ref HEAD 2>/dev/null`)).trim();
     } catch { branch = "unknown"; }
 
-    // Match to tmux window — check fleet config or name pattern
+    // Match to tmux window — check fleet config or name pattern.
+    // The matching policy is pure and fixture-backed in worktree-window-match
+    // (#823/#935/#1553/#1612); scanWorktrees owns only IO and rendering.
     let tmuxWindow: string | undefined;
     const fleetFile = fleetWindows.get(repo);
-
-    // Try to find matching window by name pattern
-    // Window names like "neo-freelance" match wt name "1-freelance"
-    const taskPart = wtName.replace(/^\d+-/, "");
-    // #823 Bug C — dedupe windows by name across sessions. Without this, a
-    // window named X that exists in 2 sessions surfaces as 2 candidates in
-    // the ambiguous-match list, manufacturing phantom duplicates.
-    const allWindows = [
-      ...new Map(sessions.flatMap(s => s.windows).map(w => [w.name, w])).values()
-    ];
-
-    // #935 — scope window search to PARENT oracle's session first.
-    // Pre-fix: a global search across all sessions ambiguously matched
-    // generic worktree names (e.g. `1--no-attach`) when 4 oracles each had
-    // a `--no-attach` window. Post-fix: try the parent oracle's session
-    // first; only fall back to global if the scoped search finds nothing.
-    //
-    // Parent oracle name is derived by stripping the trailing `-oracle`
-    // suffix from the main repo (e.g. `pulse-oracle` → `pulse`). Sessions
-    // can be named bare (`pulse`) or with a fleet-numeric prefix
-    // (`NN-pulse`), so we accept either shape.
-    const parentOracleName = mainRepoName.replace(/-oracle$/, "");
-    const parentSessions = sessions.filter(s =>
-      s.name === parentOracleName || s.name.endsWith(`-${parentOracleName}`)
-    );
-    // #1553 — try the full wtName first (preserves sequence prefix). Without
-    // this, two worktrees `1-tile-1` and `6-tile-1` both collapse to `tile-1`
-    // and ambiguously match windows `mawjs-tile-1` + `mawjs-6-tile-1`. Trying
-    // full wtName first lets `6-tile-1` cleanly bind via `-6-tile-1` suffix.
-    let resolved: ReturnType<typeof resolveWorktreeTarget> | undefined;
-    if (parentSessions.length > 0) {
-      const scopedWindows = [
-        ...new Map(parentSessions.flatMap(s => s.windows).map(w => [w.name, w])).values()
-      ];
-      const fullScoped = resolveWorktreeTarget(wtName, scopedWindows);
-      if (fullScoped.kind === "exact" || fullScoped.kind === "fuzzy") {
-        resolved = fullScoped;
-      } else {
-        const localResolved = resolveWorktreeTarget(taskPart, scopedWindows);
-        if (localResolved.kind === "exact" || localResolved.kind === "fuzzy") {
-          resolved = localResolved;
-        }
-      }
-    }
-    // Fall back to global search (existing behavior) when no parent session
-    // exists or when the scoped search did not produce a clean bind.
-    if (!resolved) {
-      const fullGlobal = resolveWorktreeTarget(wtName, allWindows);
-      if (fullGlobal.kind === "exact" || fullGlobal.kind === "fuzzy") {
-        resolved = fullGlobal;
-      } else {
-        resolved = resolveWorktreeTarget(taskPart, allWindows);
-      }
-    }
-    switch (resolved.kind) {
-      case "exact":
-      case "fuzzy":
-        tmuxWindow = resolved.match.name;
+    const windowMatch = resolveWorktreeWindow(mainRepoName, wtName, sessions);
+    switch (windowMatch.kind) {
+      case "bound":
+        tmuxWindow = windowMatch.window;
         break;
       case "ambiguous":
-        console.error(`  \x1b[31m✗\x1b[0m '${taskPart}' is ambiguous — matches ${resolved.candidates.length} windows:`);
-        for (const c of resolved.candidates) {
-          console.error(`  \x1b[90m    • ${c.name}\x1b[0m`);
+        console.error(`  \x1b[31m✗\x1b[0m '${windowMatch.query}' is ambiguous — matches ${windowMatch.candidates.length} windows:`);
+        for (const c of windowMatch.candidates) {
+          console.error(`  \x1b[90m    • ${c}\x1b[0m`);
         }
         console.error(`  \x1b[90m  leaving worktree ${wtName} unbound (status: stale)\x1b[0m`);
         // tmuxWindow stays undefined → status = stale

--- a/test/spec/worktree-window-match.fixtures.json
+++ b/test/spec/worktree-window-match.fixtures.json
@@ -1,0 +1,100 @@
+[
+  {
+    "name": "parent-scoped matching avoids global generic ambiguity",
+    "input": {
+      "mainRepoName": "pulse-oracle",
+      "wtName": "1--no-attach",
+      "sessions": [
+        { "name": "pulse", "windows": [{ "index": 1, "name": "pulse--no-attach", "active": false }] },
+        { "name": "timekeeper", "windows": [{ "index": 1, "name": "timekeeper--no-attach", "active": false }] }
+      ]
+    },
+    "expected": { "kind": "bound", "window": "pulse--no-attach" }
+  },
+  {
+    "name": "fleet numeric parent session matches by suffix",
+    "input": {
+      "mainRepoName": "mawjs-oracle",
+      "wtName": "1--no-attach",
+      "sessions": [
+        { "name": "114-mawjs", "windows": [{ "index": 1, "name": "mawjs--no-attach", "active": false }] },
+        { "name": "200-another", "windows": [{ "index": 1, "name": "another--no-attach", "active": false }] }
+      ]
+    },
+    "expected": { "kind": "bound", "window": "mawjs--no-attach" }
+  },
+  {
+    "name": "missing parent session falls back to global single match",
+    "input": {
+      "mainRepoName": "lone-oracle",
+      "wtName": "1-feature",
+      "sessions": [
+        { "name": "other", "windows": [{ "index": 1, "name": "feature", "active": false }] }
+      ]
+    },
+    "expected": { "kind": "bound", "window": "feature" }
+  },
+  {
+    "name": "parent session without match falls back to global single match",
+    "input": {
+      "mainRepoName": "mawjs-oracle",
+      "wtName": "1-feature",
+      "sessions": [
+        { "name": "54-mawjs", "windows": [{ "index": 1, "name": "notes", "active": false }] },
+        { "name": "other", "windows": [{ "index": 1, "name": "feature", "active": false }] }
+      ]
+    },
+    "expected": { "kind": "bound", "window": "feature" }
+  },
+  {
+    "name": "same-named windows across sessions dedupe before ambiguity",
+    "input": {
+      "mainRepoName": "foo-oracle",
+      "wtName": "1-neo",
+      "sessions": [
+        { "name": "session-a", "windows": [{ "index": 1, "name": "neo", "active": false }] },
+        { "name": "session-b", "windows": [{ "index": 1, "name": "neo", "active": false }] }
+      ]
+    },
+    "expected": { "kind": "bound", "window": "neo" }
+  },
+  {
+    "name": "full worktree name wins before stripped tile suffix fallback",
+    "input": {
+      "mainRepoName": "mawjs-oracle",
+      "wtName": "6-tile-1",
+      "sessions": [
+        { "name": "54-mawjs", "windows": [
+          { "index": 1, "name": "mawjs-tile-1", "active": false },
+          { "index": 2, "name": "mawjs-6-tile-1", "active": false }
+        ] }
+      ]
+    },
+    "expected": { "kind": "bound", "window": "mawjs-6-tile-1" }
+  },
+  {
+    "name": "stripped tile suffix ambiguity fails loud",
+    "input": {
+      "mainRepoName": "mawjs-oracle",
+      "wtName": "1-tile-1",
+      "sessions": [
+        { "name": "other", "windows": [
+          { "index": 1, "name": "mawjs-tile-1", "active": false },
+          { "index": 2, "name": "mawjs-6-tile-1", "active": false }
+        ] }
+      ]
+    },
+    "expected": { "kind": "ambiguous", "query": "tile-1", "candidates": ["mawjs-tile-1", "mawjs-6-tile-1"] }
+  },
+  {
+    "name": "unmatched worktree is none",
+    "input": {
+      "mainRepoName": "ghost-oracle",
+      "wtName": "1-missing",
+      "sessions": [
+        { "name": "other", "windows": [{ "index": 1, "name": "notes", "active": false }] }
+      ]
+    },
+    "expected": { "kind": "none" }
+  }
+]

--- a/test/spec/worktree-window-match.fixtures.test.ts
+++ b/test/spec/worktree-window-match.fixtures.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolveWorktreeWindow, type WorktreeWindowResolution } from "../../src/core/fleet/worktree-window-match";
+import type { Session } from "../../src/core/runtime/find-window";
+
+type Fixture = {
+  name: string;
+  input: {
+    mainRepoName: string;
+    wtName: string;
+    sessions: Session[];
+  };
+  expected: WorktreeWindowResolution;
+};
+
+const fixtureUrl = new URL("./worktree-window-match.fixtures.json", import.meta.url);
+const fixtures = JSON.parse(readFileSync(fixtureUrl, "utf8")) as Fixture[];
+
+describe("portable worktree window match fixtures (#1612)", () => {
+  for (const fixture of fixtures) {
+    test(fixture.name, () => {
+      expect(resolveWorktreeWindow(
+        fixture.input.mainRepoName,
+        fixture.input.wtName,
+        fixture.input.sessions,
+      )).toEqual(fixture.expected);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Extracted worktree-to-window binding from `scanWorktrees()` into pure `resolveWorktreeWindow()` logic.
- Added portable JSON fixtures for parent-session scoping, numeric session names, global fallback, dedupe, #1553 full-name-first matching, ambiguity, and no-match results.
- Updated the portable core spec roadmap to mark worktree window matching as ready while keeping filesystem/git/tmux scanning platform-layered.

## Verification
- `bun test src/core/fleet/worktrees-scan.test.ts test/isolated/worktree-scope-match-935.test.ts`
- `bun run test:spec`
- `bun run build`
- `git diff --check`

## Release
Alpha-only feature/test PR. No release cut.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
