### PR TITLE
test: specify transport routing as portable fixtures

### DIFF
--- a/docs/testing/portable-core-spec.md
+++ b/docs/testing/portable-core-spec.md
@@ -18,7 +18,7 @@ maw-js is currently TypeScript/Bun, but several subsystems are pure logic and ca
 | Plugin tier/default-active policy | Pure policy tables plus profile IO | Ready | Fixture set added in `test/spec/plugin-policy.fixtures.json`. Covers tier constants, weight boundaries, default-active groups, and migration keys; profile migration tests stay platform-specific. |
 | Routing aliases (`src/core/routing.ts`) | Pure resolver over config + session graph, with manifest lookup fallback | Ready | Fixture set added in `test/spec/routing.fixtures.json`. Covers local/session, node/self/peer, legacy peer URL fallback, source filtering, and #1565 session-alias guards; manifest cache lookup remains a best-effort platform fallback. |
 | Worktree window matching (`src/core/fleet/worktree-window-match.ts`) | Pure matcher extracted from filesystem scan | Ready | Fixture set added in `test/spec/worktree-window-match.fixtures.json`. Covers parent-session scoping, numeric session names, global fallback, same-name dedupe, #1553 full-name-first matching, ambiguity, and none results; filesystem/git scan stays platform-layer. |
-| Transport router (`src/core/transport/transport.ts`) | Pure orchestration over transport interface | Ready-ish | Fixtures can cover route selection/failover if represented as deterministic transport outcomes. |
+| Transport router (`src/core/transport/transport.ts`) | Pure orchestration over transport interface | Ready | Fixture set added in `test/spec/transport-router.fixtures.json`. Covers failure classification, connected/reachable filtering, send-false fallback, retryable failover, fatal stop, and explicit unreachable results; concrete transports stay platform-layer. |
 
 ## First spec: matcher resolve-target
 
@@ -171,6 +171,37 @@ expected binding result:
 A port should preserve the #823/#935/#1553 invariants: dedupe same-named windows,
 try parent oracle sessions first, try full worktree names before stripped numeric
 suffixes, and surface ambiguity instead of guessing a binding.
+
+
+## Seventh spec: transport router
+
+The seventh portable spec captures transport-router decisions without importing
+tmux, HTTP, MQTT, or Scout implementations:
+
+- Fixture data: `test/spec/transport-router.fixtures.json`
+- TS runner: `test/spec/transport-router.fixtures.test.ts`
+- Script: `bun run test:spec`
+
+The JSON describes deterministic fake transports and expected router outcomes:
+
+```json
+{
+  "name": "retryable throw falls through",
+  "kind": "send",
+  "transports": [
+    { "name": "mqtt", "send": { "type": "throw", "error": "timeout" } },
+    { "name": "http" }
+  ],
+  "expected": {
+    "result": { "ok": true, "via": "http", "retryable": false },
+    "sent": ["mqtt", "http"]
+  }
+}
+```
+
+A port should preserve transport priority order, skip disconnected/unreachable
+transports, continue after retryable failures or `false` sends, stop on fatal
+failures, and return an explicit unreachable result when no route can deliver.
 
 ## Boundaries
 

--- a/test/spec/transport-router.fixtures.json
+++ b/test/spec/transport-router.fixtures.json
@@ -1,0 +1,107 @@
+[
+  {
+    "kind": "classifyError",
+    "name": "timeout errors are retryable",
+    "error": "ETIMEDOUT while dialing",
+    "expected": { "reason": "timeout", "retryable": true }
+  },
+  {
+    "kind": "classifyError",
+    "name": "connection refused is retryable unreachable",
+    "error": "ECONNREFUSED",
+    "expected": { "reason": "unreachable", "retryable": true }
+  },
+  {
+    "kind": "classifyError",
+    "name": "auth failures are fatal",
+    "error": "403 forbidden",
+    "expected": { "reason": "auth", "retryable": false }
+  },
+  {
+    "kind": "classifyError",
+    "name": "rate limits are retryable",
+    "error": "429 too many requests",
+    "expected": { "reason": "rate_limit", "retryable": true }
+  },
+  {
+    "kind": "classifyError",
+    "name": "peer rejection is fatal",
+    "error": "peer rejected message",
+    "expected": { "reason": "rejected", "retryable": false }
+  },
+  {
+    "kind": "classifyError",
+    "name": "parse errors are fatal",
+    "error": "JSON parse failed",
+    "expected": { "reason": "parse_error", "retryable": false }
+  },
+  {
+    "kind": "classifyError",
+    "name": "empty error is fatal unknown",
+    "error": null,
+    "expected": { "reason": "unknown", "retryable": false }
+  },
+  {
+    "kind": "send",
+    "name": "first connected reachable transport wins",
+    "transports": [
+      { "name": "tmux" },
+      { "name": "http" }
+    ],
+    "expected": { "result": { "ok": true, "via": "tmux", "retryable": false }, "sent": ["tmux"] }
+  },
+  {
+    "kind": "send",
+    "name": "disconnected transports are skipped",
+    "transports": [
+      { "name": "offline", "connected": false },
+      { "name": "http" }
+    ],
+    "expected": { "result": { "ok": true, "via": "http", "retryable": false }, "sent": ["http"] }
+  },
+  {
+    "kind": "send",
+    "name": "unreachable transports are skipped",
+    "transports": [
+      { "name": "tmux", "canReach": false },
+      { "name": "http" }
+    ],
+    "expected": { "result": { "ok": true, "via": "http", "retryable": false }, "sent": ["http"] }
+  },
+  {
+    "kind": "send",
+    "name": "false send result falls through",
+    "transports": [
+      { "name": "mqtt", "send": { "type": "false" } },
+      { "name": "http" }
+    ],
+    "expected": { "result": { "ok": true, "via": "http", "retryable": false }, "sent": ["mqtt", "http"] }
+  },
+  {
+    "kind": "send",
+    "name": "retryable throw falls through",
+    "transports": [
+      { "name": "mqtt", "send": { "type": "throw", "error": "timeout" } },
+      { "name": "http" }
+    ],
+    "expected": { "result": { "ok": true, "via": "http", "retryable": false }, "sent": ["mqtt", "http"] }
+  },
+  {
+    "kind": "send",
+    "name": "fatal throw stops failover",
+    "transports": [
+      { "name": "peer", "send": { "type": "throw", "error": "401 unauthorized" } },
+      { "name": "http" }
+    ],
+    "expected": { "result": { "ok": false, "via": "peer", "reason": "auth", "retryable": false }, "sent": ["peer"] }
+  },
+  {
+    "kind": "send",
+    "name": "no reachable transport is explicit unreachable",
+    "transports": [
+      { "name": "tmux", "canReach": false },
+      { "name": "mqtt", "connected": false }
+    ],
+    "expected": { "result": { "ok": false, "via": "none", "reason": "unreachable", "retryable": false }, "sent": [] }
+  }
+]

--- a/test/spec/transport-router.fixtures.test.ts
+++ b/test/spec/transport-router.fixtures.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import {
+  classifyError,
+  TransportRouter,
+  type Transport,
+  type TransportResult,
+  type TransportTarget,
+} from "../../src/core/transport/transport";
+
+type ClassifyFixture = {
+  kind: "classifyError";
+  name: string;
+  error: unknown;
+  expected: ReturnType<typeof classifyError>;
+};
+
+type SendAction =
+  | { type: "ok" }
+  | { type: "false" }
+  | { type: "throw"; error: string };
+
+type TransportFixture = {
+  name: string;
+  connected?: boolean;
+  canReach?: boolean;
+  send?: SendAction;
+};
+
+type SendFixture = {
+  kind: "send";
+  name: string;
+  target?: TransportTarget;
+  message?: string;
+  from?: string;
+  transports: TransportFixture[];
+  expected: { result: TransportResult; sent: string[] };
+};
+
+type Fixture = ClassifyFixture | SendFixture;
+
+const fixtureUrl = new URL("./transport-router.fixtures.json", import.meta.url);
+const fixtures = JSON.parse(readFileSync(fixtureUrl, "utf8")) as Fixture[];
+const defaultTarget: TransportTarget = { oracle: "neo", tmuxTarget: "neo:1" };
+
+function fixtureTransport(fixture: TransportFixture, sent: string[]): Transport {
+  const action = fixture.send ?? { type: "ok" };
+  return {
+    name: fixture.name,
+    connected: fixture.connected ?? true,
+    connect: async () => {},
+    disconnect: async () => {},
+    canReach: () => fixture.canReach ?? true,
+    send: async () => {
+      sent.push(fixture.name);
+      if (action.type === "throw") throw new Error(action.error);
+      return action.type === "ok";
+    },
+    publishPresence: async () => {},
+    publishFeed: async () => {},
+    onMessage: () => {},
+    onPresence: () => {},
+    onFeed: () => {},
+  };
+}
+
+async function withoutTransportLogs<T>(run: () => Promise<T>): Promise<T> {
+  const originalLog = console.log;
+  console.log = () => {};
+  try {
+    return await run();
+  } finally {
+    console.log = originalLog;
+  }
+}
+
+describe("portable transport router fixtures (#1612)", () => {
+  for (const fixture of fixtures) {
+    test(fixture.name, async () => {
+      if (fixture.kind === "classifyError") {
+        expect(classifyError(fixture.error)).toEqual(fixture.expected);
+        return;
+      }
+
+      const router = new TransportRouter();
+      const sent: string[] = [];
+      for (const transport of fixture.transports) {
+        router.register(fixtureTransport(transport, sent));
+      }
+
+      const result = await withoutTransportLogs(() => router.send(
+        fixture.target ?? defaultTarget,
+        fixture.message ?? "hello",
+        fixture.from ?? "codex",
+      ));
+
+      expect(result).toEqual(fixture.expected.result);
+      expect(sent).toEqual(fixture.expected.sent);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Added portable JSON fixtures for `classifyError()` and `TransportRouter.send()` route-selection behavior.
- Covered connected/reachable filtering, first-match priority, `false` send fallback, retryable failover, fatal-stop behavior, and explicit unreachable results.
- Updated the portable core spec to mark the transport router fixture set ready while leaving concrete transports as platform-layer tests.

## Verification
- `bun test test/transport-router.test.ts test/spec/transport-router.fixtures.test.ts`
- `bun run test:spec`
- `bun run build`
- `git diff --check`

## Release
Alpha-only feature/test PR. No release cut.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
