### PR TITLE
fix(team): advertise bring in plugin help

### DIFF
--- a/src/vendor/mpr-plugins/team/plugin.json
+++ b/src/vendor/mpr-plugins/team/plugin.json
@@ -3,14 +3,14 @@
   "version": "2.0.1",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "Agent reincarnation engine — create, spawn, send, shutdown, resume, lives.",
+  "description": "Agent reincarnation engine — create, bring, send, shutdown, resume, lives.",
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "team",
     "aliases": [
       "t"
     ],
-    "help": "maw team <create|plan|preflight|load|spawn-from|spawn|send|shutdown|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members|enter>"
+    "help": "maw team <create|plan|preflight|load|spawn-from|spawn|bring|send|shutdown|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members|enter>"
   },
   "weight": 30,
   "tier": "standard",

--- a/src/vendor/mpr-plugins/team/registry.meta.json
+++ b/src/vendor/mpr-plugins/team/registry.meta.json
@@ -2,7 +2,7 @@
   "version": "0.1.1",
   "source": "soul-brews-studio/maw-plugin-registry/team@v0.1.1-team",
   "sha256": null,
-  "summary": "Agent team engine with worktree cwd spawn, inbox send, status, tasks, and pane submit.",
+  "summary": "Agent reincarnation engine — create, bring, send, shutdown, resume, lives.",
   "author": "Soul-Brews-Studio",
   "license": "MIT",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",

--- a/test/isolated/command-surface-help-copy.test.ts
+++ b/test/isolated/command-surface-help-copy.test.ts
@@ -75,6 +75,15 @@ describe("#1531 command-surface help copy", () => {
     expect(usage).toContain("maw rename");
   });
 
+  test("team help advertises shared-workspace bring", () => {
+    expect(desc("src/vendor/mpr-plugins/team/plugin.json")).toContain("bring");
+    expect(help("src/vendor/mpr-plugins/team/plugin.json")).toContain("spawn|bring|send");
+
+    const usage = formatUsage([plugin("src/vendor/mpr-plugins/team")]);
+    expect(usage).toContain("maw team");
+    expect(usage).toContain("bring");
+  });
+
   test("remaining real CLI plugins have explicit metadata and appear in usage", () => {
     const names = ["dream", "oracle-skills", "park", "shellenv", "token"];
     const usage = formatUsage(names.map((name) => plugin(`src/vendor/mpr-plugins/${name}`)));


### PR DESCRIPTION
## Summary
- Fixed the team plugin manifest so `maw team --help` advertises the shipped `bring` subcommand from #1616.
- Updated the vendored registry summary to match the shared-workspace/team-bring surface.
- Added a command-surface regression assertion so future metadata drift catches this.

## Verification
- `bun test test/isolated/command-surface-help-copy.test.ts`
- `bun run build`
- `git diff --check`

## Release
Alpha-only fix PR. No release cut.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
