### PR TITLE
ux(ls): sort live sessions by recent creation time

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -47,7 +47,7 @@ export const ALIAS_DESCRIPTIONS: Record<string, string> = {
   tile: "Tile current window or spawn N panes tiled",
   bring: "Bring an oracle HERE — split current pane and attach",
   b: "Bring an oracle HERE (short form of `bring`)",
-  ls: "List sessions (compact default, -v detail, -a roster)",
+  ls: "List sessions (compact default, -v detail, -r recent, -a roster)",
   scaffold: "Create oracle repo + skeleton only (no commit, wake, or /awaken)",
   wake: "Wake an oracle session (fuzzy match, auto-clone)",
   awake: "Launch an oracle process with optional engine (does not trigger /awaken)",
@@ -77,6 +77,7 @@ export const TOP_ALIASES: Record<string, string[] | DirectHandler> = {
   //   maw ls -v   → full per-pane detail
   //   maw ls -c   → explicit compact alias
   //   maw ls -a   → compact + sleeping oracles (roster; legacy behavior)
+  //   maw ls -r   → compact sessions sorted newest-first by tmux creation time
   ls: { kind: "direct", handler: "cmdLs" },
   scaffold: ["bud", "--scaffold-only"],
 
@@ -172,8 +173,8 @@ function printWakeAliasUsage(verb: "wake" | "awake", write: (line: string) => vo
  * dispatch is by `exportName` against a static handler map.
  *
  * For `ls`, compact summary is the default; `-v` returns full per-pane detail,
- * `-c` is an explicit compact alias, and `-a` preserves the legacy
- * compact+roster behavior.
+ * `-c` is an explicit compact alias, `-a` preserves the legacy
+ * compact+roster behavior, and `-r/--recent [N]` sorts newest-first.
  * For `wake`, parses the 9 known flags and calls cmdWake(oracle, opts).
  */
 export function parseLsAliasOpts(argv: string[]) {
@@ -183,6 +184,7 @@ export function parseLsAliasOpts(argv: string[]) {
     "--verbose": Boolean, "-v": "--verbose",
     "--fix": Boolean,
     "--json": Boolean,
+    "--recent": Boolean, "-r": "--recent",
   }, 0);
 
   // #1613 — restore the original compact default. `-v/--verbose` opts into
@@ -191,13 +193,30 @@ export function parseLsAliasOpts(argv: string[]) {
   // `maw ls`; keep that legacy shape by rendering the compact roster view.
   const verbose = !!flags["--verbose"] && !flags["--compact"] && !flags["--all"];
   const compact = !verbose || !!flags["--compact"] || !!flags["--all"];
-  return {
+  const opts: {
+    all: true;
+    compact: boolean;
+    verbose: boolean;
+    roster: boolean;
+    json: boolean;
+    recent?: boolean;
+    recentLimit?: number;
+  } = {
     all: true,
     compact,
     verbose,
     roster: !!flags["--all"],
     json: !!flags["--json"],
   };
+  if (flags["--recent"]) {
+    opts.recent = true;
+    const limitRaw = (flags._ as string[]).find((arg) => /^\d+$/.test(arg));
+    if (limitRaw) {
+      const limit = Number(limitRaw);
+      if (Number.isSafeInteger(limit) && limit > 0) opts.recentLimit = limit;
+    }
+  }
+  return opts;
 }
 
 export async function invokeDirectHandler(

--- a/src/commands/plugins/tmux/impl.ts
+++ b/src/commands/plugins/tmux/impl.ts
@@ -148,6 +148,10 @@ export interface TmuxLsOpts {
   verbose?: boolean;
   /** Roster: include sleeping oracles from ghq (compact mode only). */
   roster?: boolean;
+  /** Sort sessions newest-first using tmux #{session_created}. */
+  recent?: boolean;
+  /** Limit recent mode to the N newest sessions. */
+  recentLimit?: number;
 }
 
 export type PaneStatus = "active" | "idle" | "stale" | "unknown";
@@ -155,11 +159,42 @@ export type PaneStatus = "active" | "idle" | "stale" | "unknown";
 interface AnnotatedPane {
   id: string;
   target: string;
+  session: string;
   command: string | undefined;
   title: string | undefined;
   annotation: string; // "fleet: X" | "team: agent @ team-name" | "orphan" | ""
   status: PaneStatus;
   lastActivitySec: number;
+  sessionCreated?: number;
+}
+
+
+export function parseSessionCreatedList(raw: string): Map<string, number> {
+  const out = new Map<string, number>();
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    const [name, createdRaw] = line.split("\t");
+    const created = Number(createdRaw);
+    if (name && Number.isFinite(created) && created > 0) out.set(name, created);
+  }
+  return out;
+}
+
+export function formatSessionCreated(epochSeconds?: number): string {
+  if (!epochSeconds || !Number.isFinite(epochSeconds)) return "—";
+  const d = new Date(epochSeconds * 1000);
+  if (Number.isNaN(d.getTime())) return "—";
+  const pad2 = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())} ${pad2(d.getHours())}:${pad2(d.getMinutes())}:${pad2(d.getSeconds())}`;
+}
+
+function sessionNameFromPaneTarget(target: string): string {
+  return target.split(":")[0] || target;
+}
+
+async function sessionCreatedTimes(): Promise<Map<string, number>> {
+  const raw = await hostExec(`${tmuxCmd()} list-sessions -F '#{session_name}\t#{session_created}'`).catch(() => "");
+  return parseSessionCreatedList(raw);
 }
 
 /**
@@ -198,24 +233,47 @@ export async function cmdTmuxLs(opts: TmuxLsOpts = {}): Promise<void> {
     }
   }
 
+  const createdBySession = opts.recent ? await sessionCreatedTimes() : new Map<string, number>();
   const nowEpoch = Math.floor(Date.now() / 1000);
   const annotated: AnnotatedPane[] = allPanes.map(p => {
     const ageSec = p.lastActivity ? nowEpoch - p.lastActivity : -1;
     const status: PaneStatus = ageSec < 0 ? "unknown" : ageSec < 30 ? "active" : ageSec < 300 ? "idle" : "stale";
+    const session = sessionNameFromPaneTarget(p.target);
     return {
       id: p.id,
       target: p.target,
+      session,
       command: p.command,
       title: p.title,
       annotation: annotatePane(p, fleetSessions, teamByPane),
       status,
       lastActivitySec: ageSec < 0 ? 0 : ageSec,
+      sessionCreated: createdBySession.get(session),
     };
   });
 
-  const scope = opts.all
+  let scope = opts.all
     ? annotated
     : annotated.filter(p => p.target.startsWith(`${currentSession}:`));
+
+  const recentSessionOrder = (items: AnnotatedPane[]): string[] => {
+    const byName = new Map<string, number | undefined>();
+    for (const p of items) {
+      if (!byName.has(p.session)) byName.set(p.session, p.sessionCreated);
+    }
+    return [...byName.entries()]
+      .sort((a, b) => (b[1] ?? 0) - (a[1] ?? 0) || a[0].localeCompare(b[0]))
+      .map(([name]) => name);
+  };
+
+  if (opts.recent) {
+    const ordered = recentSessionOrder(scope);
+    const limited = opts.recentLimit ? ordered.slice(0, opts.recentLimit) : ordered;
+    const order = new Map(limited.map((name, index) => [name, index]));
+    scope = scope
+      .filter(p => order.has(p.session))
+      .sort((a, b) => (order.get(a.session)! - order.get(b.session)!) || a.target.localeCompare(b.target));
+  }
 
   if (opts.json) {
     console.log(JSON.stringify(scope, null, 2));
@@ -246,7 +304,7 @@ export async function cmdTmuxLs(opts: TmuxLsOpts = {}): Promise<void> {
   if (opts.compact && !opts.verbose) {
     const bySession = new Map<string, AnnotatedPane[]>();
     for (const p of scope) {
-      const sess = p.target.split(":")[0]!;
+      const sess = p.session;
       if (!bySession.has(sess)) bySession.set(sess, []);
       bySession.get(sess)!.push(p);
     }
@@ -267,13 +325,27 @@ export async function cmdTmuxLs(opts: TmuxLsOpts = {}): Promise<void> {
 
     console.log();
     const awakeNames = new Set<string>();
-    for (const [sess, panes] of bySession) {
+    const sessionRows = [...bySession.entries()];
+    if (opts.recent) {
+      sessionRows.sort((a, b) => (b[1][0]?.sessionCreated ?? 0) - (a[1][0]?.sessionCreated ?? 0) || a[0].localeCompare(b[0]));
+      if (opts.recentLimit) sessionRows.splice(opts.recentLimit);
+      const sessionWidth = Math.max(18, ...sessionRows.map(([sess]) => sess.length));
+      console.log(`  ${pad("#", 3)} ${pad("SESSION", sessionWidth)} ${pad("CREATED", 19)} ${pad("STATUS", 6)} ${pad("PANES", 8)} AGENTS`);
+    }
+    for (const [index, [sess, panes]] of sessionRows.entries()) {
       awakeNames.add(sess);
       const dot = STATUS_DOT[bestStatus(panes)];
       const count = `${panes.length} pane${panes.length !== 1 ? "s" : ""}`;
       const agents = panes.filter(p => /claude|node/i.test(p.command || "")).length;
       const agentTag = agents > 0 ? `  \x1b[34m${agents} agent${agents !== 1 ? "s" : ""}\x1b[0m` : "";
-      console.log(`  ${dot} \x1b[36m${sess}\x1b[0m  \x1b[90m${count}\x1b[0m${agentTag}`);
+      if (opts.recent) {
+        const sessionWidth = Math.max(18, ...sessionRows.map(([name]) => name.length));
+        const created = formatSessionCreated(panes[0]?.sessionCreated);
+        const afterName = " ".repeat(Math.max(1, sessionWidth - sess.length + 1));
+        console.log(`  ${pad(String(index + 1), 3)} \x1b[36m${sess}\x1b[0m${afterName} ${created} ${pad(dot, 6)} ${pad(count, 8)}${agentTag}`);
+      } else {
+        console.log(`  ${dot} \x1b[36m${sess}\x1b[0m  \x1b[90m${count}\x1b[0m${agentTag}`);
+      }
       const wts = wtBySession.get(sess) || [];
       for (const wt of wts) {
         const wtDot = wt.status === "active" ? "\x1b[32m├─\x1b[0m" : "\x1b[90m├─\x1b[0m";
@@ -309,8 +381,11 @@ export async function cmdTmuxLs(opts: TmuxLsOpts = {}): Promise<void> {
 
   const targetWidth = Math.max(28, ...scope.map(p => p.target.length));
 
+  const createdWidth = opts.recent ? 20 : 0;
   console.log();
-  console.log(`  \x1b[36;1m  ${pad("TARGET", targetWidth)} ${pad("CMD", 10)} ${pad("AGE", 6)} ${pad("ANNOTATION", 30)} TITLE\x1b[0m`);
+  console.log(opts.recent
+    ? `  \x1b[36;1m  ${pad("TARGET", targetWidth)} ${pad("CMD", 10)} ${pad("AGE", 6)} ${pad("CREATED", createdWidth)} ${pad("ANNOTATION", 30)} TITLE\x1b[0m`
+    : `  \x1b[36;1m  ${pad("TARGET", targetWidth)} ${pad("CMD", 10)} ${pad("AGE", 6)} ${pad("ANNOTATION", 30)} TITLE\x1b[0m`);
   for (const p of scope) {
     const dot = STATUS_DOT[p.status];
     const age = formatAge(p.lastActivitySec);
@@ -321,7 +396,8 @@ export async function cmdTmuxLs(opts: TmuxLsOpts = {}): Promise<void> {
       : "";
     const annPad = pad(p.annotation, 30);
     const annRendered = annColored ? annColored + annPad.slice(p.annotation.length) : annPad;
-    console.log(`  ${dot} ${pad(p.target, targetWidth)} ${pad(p.command || "", 10)} ${pad(age, 6)} ${annRendered} \x1b[90m${(p.title || "").slice(0, 50)}\x1b[0m`);
+    const created = opts.recent ? `${pad(formatSessionCreated(p.sessionCreated), createdWidth)} ` : "";
+    console.log(`  ${dot} ${pad(p.target, targetWidth)} ${pad(p.command || "", 10)} ${pad(age, 6)} ${created}${annRendered} \x1b[90m${(p.title || "").slice(0, 50)}\x1b[0m`);
   }
   console.log();
 }

--- a/src/commands/plugins/tmux/index.ts
+++ b/src/commands/plugins/tmux/index.ts
@@ -62,24 +62,31 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         "--verbose": Boolean,
         "-v": "--verbose",
         "--roster": Boolean,
+        "--recent": Boolean,
+        "-r": "--recent",
         "--help": Boolean,
         "-h": "--help",
       }, 1);
       if (flags["--help"]) {
-        console.log("usage: maw tmux ls [--all|-a] [--compact|-c] [-v|--verbose] [--roster] [--json]");
+        console.log("usage: maw tmux ls [--all|-a] [--compact|-c] [-v|--verbose] [--recent|-r [N]] [--roster] [--json]");
         console.log("  default:    panes in current session only");
         console.log("  --all:      panes across every session");
         console.log("  --compact:  one line per session (`maw ls` / `maw ls -c` top-level)");
         console.log("  -v:         full per-pane detail");
         console.log("  --roster:   include sleeping oracles from ghq");
+        console.log("  --recent:   sort sessions newest-first by tmux creation time; optional N limits sessions");
         return { ok: true, output: logs.join("\n") || undefined };
       }
+      const recentLimitRaw = (flags._ as string[]).find((arg) => /^\d+$/.test(arg));
+      const recentLimit = recentLimitRaw ? Number(recentLimitRaw) : undefined;
       await cmdTmuxLs({
-        all: !!flags["--all"],
+        all: !!flags["--all"] || !!flags["--recent"],
         json: !!flags["--json"],
-        compact: !!flags["--compact"],
+        compact: !!flags["--compact"] || !!flags["--recent"],
         verbose: !!flags["--verbose"],
         roster: !!flags["--roster"],
+        recent: !!flags["--recent"],
+        recentLimit: Number.isSafeInteger(recentLimit) && recentLimit! > 0 ? recentLimit : undefined,
       });
     } else if (sub === "peek") {
       const flags = parseFlags(args, {

--- a/src/commands/plugins/tmux/plugin.json
+++ b/src/commands/plugins/tmux/plugin.json
@@ -7,13 +7,15 @@
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "tmux",
-    "help": "maw tmux <peek|ls|attach|kill|open|close|zoom> [...] — tmux pane/session tools; ls supports --json",
+    "help": "maw tmux <peek|ls|attach|kill|open|close|zoom> [...] — tmux pane/session tools; ls supports --json and --recent",
     "flags": {
       "--json": "boolean",
       "--all": "boolean",
       "--compact": "boolean",
       "--verbose": "boolean",
-      "--roster": "boolean"
+      "--roster": "boolean",
+      "--recent": "boolean",
+      "-r": "boolean"
     }
   },
   "weight": 10,

--- a/src/vendor/mpr-plugins/ls/plugin.json
+++ b/src/vendor/mpr-plugins/ls/plugin.json
@@ -10,11 +10,13 @@
     "aliases": [
       "list"
     ],
-    "help": "maw ls [<peer>] [--all] [--json] [--fix] — list live sessions; see maw fleet ls for registered fleet config",
+    "help": "maw ls [<peer>] [--all] [--json] [--fix] [--recent|-r [N]] — list live sessions; see maw fleet ls for registered fleet config",
     "flags": {
       "--all": "boolean",
       "--json": "boolean",
-      "--fix": "boolean"
+      "--fix": "boolean",
+      "--recent": "boolean",
+      "-r": "boolean"
     }
   },
   "weight": 0,

--- a/test/cli/dispatch-match.test.ts
+++ b/test/cli/dispatch-match.test.ts
@@ -313,6 +313,26 @@ describe("resolveTopAlias — RFC #954 verb aliases", () => {
     });
   });
 
+  test("#1628 parse ls opts: -r/--recent sorts by creation time with optional limit", () => {
+    expect(parseLsAliasOpts(["-r"])).toEqual({
+      all: true,
+      compact: true,
+      verbose: false,
+      roster: false,
+      json: false,
+      recent: true,
+    });
+    expect(parseLsAliasOpts(["--recent", "5", "-v"])).toEqual({
+      all: true,
+      compact: false,
+      verbose: true,
+      roster: false,
+      json: false,
+      recent: true,
+      recentLimit: 5,
+    });
+  });
+
   test("`a neo` → argv rewrite to ['tmux', 'attach', 'neo']", () => {
     const out = resolveTopAlias(["a", "neo"]);
     expect(out).not.toBeNull();

--- a/test/isolated/tmux-ls-recent.test.ts
+++ b/test/isolated/tmux-ls-recent.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { join } from "path";
+
+const srcRoot = join(import.meta.dir, "../..");
+
+type MockPane = {
+  id: string;
+  target: string;
+  command?: string;
+  title?: string;
+  lastActivity?: number;
+};
+
+let panes: MockPane[] = [];
+let sessionCreatedRaw = "";
+
+mock.module(join(srcRoot, "src/sdk"), () => ({
+  tmux: {
+    listPanes: async () => panes,
+  },
+  hostExec: async (cmd: string) => {
+    if (cmd.includes("list-sessions") && cmd.includes("session_created")) return sessionCreatedRaw;
+    if (cmd.includes("display-message") && cmd.includes("session_name")) return "old-session\n";
+    return "";
+  },
+  tmuxCmd: () => "tmux",
+}));
+
+mock.module(join(srcRoot, "src/commands/shared/fleet-load"), () => ({
+  loadFleetEntries: () => [],
+}));
+
+mock.module(join(srcRoot, "src/core/fleet/worktrees-scan"), () => ({
+  scanWorktrees: async () => [],
+}));
+
+mock.module(join(srcRoot, "src/core/ghq"), () => ({
+  ghqList: async () => [],
+  ghqListSync: () => [],
+}));
+
+const { cmdTmuxLs, formatSessionCreated, parseSessionCreatedList } = await import("../../src/commands/plugins/tmux/impl");
+
+const origLog = console.log;
+let outs: string[] = [];
+
+async function capture(fn: () => Promise<void>) {
+  outs = [];
+  console.log = (...args: unknown[]) => outs.push(args.map(String).join(" "));
+  try {
+    await fn();
+  } finally {
+    console.log = origLog;
+  }
+  return outs.join("\n");
+}
+
+beforeEach(() => {
+  const now = Math.floor(Date.now() / 1000);
+  panes = [
+    { id: "%1", target: "old-session:oracle.0", command: "claude", title: "old", lastActivity: now },
+    { id: "%2", target: "new-session:oracle.0", command: "claude", title: "new", lastActivity: now },
+    { id: "%3", target: "mid-session:oracle.0", command: "zsh", title: "mid", lastActivity: now },
+  ];
+  sessionCreatedRaw = "old-session\t100\nnew-session\t300\nmid-session\t200\n";
+});
+
+describe("maw ls --recent (#1628)", () => {
+  test("parses and formats tmux session_created epochs", () => {
+    expect([...parseSessionCreatedList(sessionCreatedRaw).entries()]).toEqual([
+      ["old-session", 100],
+      ["new-session", 300],
+      ["mid-session", 200],
+    ]);
+    expect(formatSessionCreated(undefined)).toBe("—");
+    expect(formatSessionCreated(300)).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:05:00$/);
+  });
+
+  test("compact recent view sorts sessions newest-first and honors limit", async () => {
+    const out = await capture(() => cmdTmuxLs({ all: true, compact: true, recent: true, recentLimit: 2 }));
+
+    expect(out).toContain("CREATED");
+    expect(out.indexOf("new-session")).toBeLessThan(out.indexOf("mid-session"));
+    expect(out).not.toContain("old-session");
+  });
+
+  test("verbose recent view keeps panes grouped by newest session", async () => {
+    const out = await capture(() => cmdTmuxLs({ all: true, verbose: true, recent: true }));
+
+    expect(out).toContain("CREATED");
+    expect(out.indexOf("new-session:oracle.0")).toBeLessThan(out.indexOf("mid-session:oracle.0"));
+    expect(out.indexOf("mid-session:oracle.0")).toBeLessThan(out.indexOf("old-session:oracle.0"));
+  });
+});


### PR DESCRIPTION
## Summary
- adds `maw ls --recent` / `maw ls -r` with optional numeric limit
- sorts live sessions newest-first using tmux `#{session_created}`
- shows an absolute CREATED datetime in compact and verbose recent views
- keeps default `maw ls`, `-c`, `-v`, and `-a` behavior unchanged

## Verification
- `rtk bun test test/cli/dispatch-match.test.ts test/isolated/tmux-ls-recent.test.ts`
- `rtk bun run build`
- `bun src/cli.ts ls --recent 5`
- `bun src/cli.ts ls -r 2 -v`

Closes #1628.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.