### PR TITLE
fix(cli): reject unknown plugin flags before dispatch

### DIFF
--- a/src/cli/dispatch-match.ts
+++ b/src/cli/dispatch-match.ts
@@ -22,6 +22,7 @@
  * could meaningfully respond to a CLI invocation.
  */
 import type { LoadedPlugin } from "../plugin/types";
+import { fuzzyMatch } from "../core/util/fuzzy";
 
 export type DispatchMatch =
   | { kind: "match"; plugin: LoadedPlugin; matchedName: string }
@@ -31,6 +32,12 @@ export type DispatchMatch =
 export interface ResolvePluginMatchOptions {
   includeDisabled?: boolean;
 }
+
+export type PluginCliFlagValidation =
+  | { ok: true }
+  | { ok: false; flag: string; suggestion?: string; allowedFlags: string[] };
+
+const UNIVERSAL_PLUGIN_FLAGS = new Set(["-h", "--help", "-help", "-v", "--version", "-version"]);
 
 /**
  * #899: a plugin is CLI-dispatchable if it has either an explicit `cli`
@@ -137,4 +144,46 @@ export function resolvePluginMatch(
     kind: "ambiguous",
     candidates: winners.map(w => ({ plugin: w.plugin.manifest.name, name: w.matchedName })),
   };
+}
+
+function flagName(arg: string): string | null {
+  if (arg === "--") return null;
+  if (!arg.startsWith("-")) return null;
+  if (/^-\d/.test(arg)) return null;
+  if (arg.length <= 1) return null;
+  const eq = arg.indexOf("=");
+  return eq === -1 ? arg : arg.slice(0, eq);
+}
+
+/**
+ * Validate CLI argv against manifest-declared plugin flags before invoking
+ * the plugin handler. Plugins without `cli.flags` keep their legacy permissive
+ * behavior until their manifests declare the contract.
+ */
+export function validatePluginCliFlags(
+  plugin: LoadedPlugin,
+  argv: string[],
+): PluginCliFlagValidation {
+  const declared = plugin.manifest.cli?.flags;
+  if (!declared) return { ok: true };
+
+  const allowedFlags = Object.keys(declared).sort((a, b) => a.localeCompare(b));
+  const allowed = new Set([...allowedFlags, ...UNIVERSAL_PLUGIN_FLAGS]);
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--") break;
+
+    const name = flagName(arg);
+    if (!name) continue;
+    if (!allowed.has(name)) {
+      const [suggestion] = fuzzyMatch(name, allowedFlags, 1, 2);
+      return { ok: false, flag: name, suggestion, allowedFlags };
+    }
+
+    const type = declared[name];
+    if (type && type !== "boolean" && !arg.includes("=")) i++;
+  }
+
+  return { ok: true };
 }

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -64,7 +64,7 @@ export async function dispatchCommand(cmd: string, args: string[]): Promise<void
  */
 async function dispatchPluginRegistry(cmd: string, args: string[]): Promise<void> {
   const { discoverPackages, invokePlugin } = await import("../plugin/registry");
-  const { resolvePluginMatch, pluginCliNames, pluginNonCliSurfaces } = await import("./dispatch-match");
+  const { resolvePluginMatch, pluginCliNames, pluginNonCliSurfaces, validatePluginCliFlags } = await import("./dispatch-match");
   const plugins = discoverPackages();
   const cmdName = args.join(" ").toLowerCase();
   const dispatch = resolvePluginMatch(plugins, cmdName);
@@ -89,6 +89,14 @@ async function dispatchPluginRegistry(cmd: string, args: string[]): Promise<void
       throw new UserError(`disabled plugin dependency: ${dispatch.matchedName}`);
     }
     const remaining = args.slice(matchedWords);
+    const flagValidation = validatePluginCliFlags(dispatch.plugin, remaining);
+    if (!flagValidation.ok) {
+      console.error(`\x1b[31m✗\x1b[0m unknown flag for ${dispatch.matchedName}: ${flagValidation.flag}`);
+      if (flagValidation.suggestion) console.error(`  did you mean: ${flagValidation.suggestion}`);
+      const help = dispatch.plugin.manifest.cli?.help;
+      if (help) console.error(`\n  usage: ${help}`);
+      throw new UserError(`unknown flag: ${flagValidation.flag}`);
+    }
     const result = await invokePlugin(dispatch.plugin, { source: "cli", args: remaining });
     if (result.ok && result.output) console.log(result.output);
     else if (!result.ok) { console.error(result.error); process.exit(result.exitCode ?? 1); }
@@ -169,7 +177,16 @@ async function dispatchPluginRegistry(cmd: string, args: string[]): Promise<void
       const retryPlugin = resolvePluginMatch(plugins, args.join(" ").toLowerCase());
       if (retryPlugin.kind === "match") {
         const matchedWords = retryPlugin.matchedName.split(/\s+/).filter(Boolean).length;
-        const result = await invokePlugin(retryPlugin.plugin, { source: "cli", args: args.slice(matchedWords) });
+        const remaining = args.slice(matchedWords);
+        const flagValidation = validatePluginCliFlags(retryPlugin.plugin, remaining);
+        if (!flagValidation.ok) {
+          console.error(`\x1b[31m✗\x1b[0m unknown flag for ${retryPlugin.matchedName}: ${flagValidation.flag}`);
+          if (flagValidation.suggestion) console.error(`  did you mean: ${flagValidation.suggestion}`);
+          const help = retryPlugin.plugin.manifest.cli?.help;
+          if (help) console.error(`\n  usage: ${help}`);
+          throw new UserError(`unknown flag: ${flagValidation.flag}`);
+        }
+        const result = await invokePlugin(retryPlugin.plugin, { source: "cli", args: remaining });
         if (result.ok && result.output) console.log(result.output);
         else if (!result.ok) { console.error(result.error); process.exit(result.exitCode ?? 1); }
         process.exit(0);

--- a/test/cli/dispatch-match.test.ts
+++ b/test/cli/dispatch-match.test.ts
@@ -9,17 +9,22 @@
  *  - prefix match with word boundary (e.g. `restart` != `rest`)
  */
 import { describe, test, expect } from "bun:test";
-import { resolvePluginMatch } from "../../src/cli/dispatch-match";
+import { resolvePluginMatch, validatePluginCliFlags } from "../../src/cli/dispatch-match";
 import { ALIAS_DESCRIPTIONS, parseBringArgs, parseLsAliasOpts, resolveTopAlias } from "../../src/cli/top-aliases";
 import type { LoadedPlugin } from "../../src/plugin/types";
 
-function plugin(name: string, command: string, aliases: string[] = []): LoadedPlugin {
+function plugin(
+  name: string,
+  command: string,
+  aliases: string[] = [],
+  flags?: Record<string, string>,
+): LoadedPlugin {
   return {
     manifest: {
       name,
       version: "1.0.0",
       sdk: "^1.0.0",
-      cli: { command, aliases, help: "" },
+      cli: { command, aliases, help: "", ...(flags ? { flags } : {}) },
     } as LoadedPlugin["manifest"],
     dir: `/tmp/${name}`,
     wasmPath: "",
@@ -225,6 +230,57 @@ describe("resolvePluginMatch — two-pass dispatch", () => {
     const out = resolvePluginMatch([view], "attach");
     expect(out.kind).toBe("match");
     if (out.kind === "match") expect(out.matchedName).toBe("attach");
+  });
+});
+
+describe("validatePluginCliFlags — manifest-declared flags", () => {
+  test("#1629 rejects unknown long flags before handler execution", () => {
+    const bud = plugin("bud", "bud", [], {
+      "--org": "string",
+      "--from": "string",
+      "--dry-run": "boolean",
+    });
+
+    const out = validatePluginCliFlags(bud, ["digger", "--orgs", "laris-co", "--dry-run"]);
+
+    expect(out.ok).toBe(false);
+    if (!out.ok) {
+      expect(out.flag).toBe("--orgs");
+      expect(out.suggestion).toBe("--org");
+    }
+  });
+
+  test("allows declared string/number flags and skips their value token", () => {
+    const bud = plugin("bud", "bud", [], {
+      "--org": "string",
+      "--issue": "number",
+      "--dry-run": "boolean",
+    });
+
+    const out = validatePluginCliFlags(bud, ["digger", "--org", "--dashy-org", "--issue=1629", "--dry-run"]);
+
+    expect(out).toEqual({ ok: true });
+  });
+
+  test("keeps legacy permissive behavior until cli.flags is declared", () => {
+    const legacy = plugin("legacy", "legacy");
+
+    const out = validatePluginCliFlags(legacy, ["--whatever"]);
+
+    expect(out).toEqual({ ok: true });
+  });
+
+  test("allows universal plugin help/version flags", () => {
+    const p = plugin("hello", "hello", [], { "--name": "string" });
+
+    expect(validatePluginCliFlags(p, ["--help"])).toEqual({ ok: true });
+    expect(validatePluginCliFlags(p, ["--version"])).toEqual({ ok: true });
+  });
+
+  test("stops validation after -- terminator", () => {
+    const p = plugin("hello", "hello", [], { "--name": "string" });
+
+    expect(validatePluginCliFlags(p, ["--name", "world", "--", "--not-a-flag"])).toEqual({ ok: true });
   });
 });
 


### PR DESCRIPTION
## Summary
- validate plugin CLI args against `plugin.json` `cli.flags` before handler invocation
- fail fast on unknown flags with fuzzy suggestion and manifest usage
- cover direct plugin dispatch and prefix-resolved dispatch paths

## Validation
- `rtk bun test test/cli/dispatch-match.test.ts`
- `rtk bun run build`
- `bun src/cli.ts bud flag-smoke --orgs laris-co --dry-run` → exits 1 with `did you mean: --org`
- `bun src/cli.ts scaffold flag-smoke --orgs laris-co --dry-run` → exits 1 with `did you mean: --org`
- `bun src/cli.ts bud --help` → exits 0

Closes #1629

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
