### PR TITLE
release: v26.5.16-alpha.2350

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.16-alpha.1053",
+  "version": "26.5.16-alpha.2350",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts `v26.5.16-alpha.2350` on merge to `alpha` via `calver-release.yml`.

Included since last clean alpha:
- #1627 fast targeted isolated runner
- #1630 `maw ls --recent`
- #1631 unknown plugin flag validation before side effects

Validation:
- `TZ=Asia/Bangkok bun scripts/calver.ts --check` → `v26.5.16-alpha.2350`
- `rtk bun run build`

Notes:
- Alpha branch only.
- Suffix is HHMM (`2350`), within the `0000..2359` CalVer contract.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
