### PR TITLE
fix(team): bring into team workspace session

### DIFF
--- a/src/vendor/mpr-plugins/team/team-workspace.ts
+++ b/src/vendor/mpr-plugins/team/team-workspace.ts
@@ -43,12 +43,15 @@ export async function resolveTeamBringSession(teamName: string, opts: TeamBringO
     return explicit;
   }
 
+  // Prefer the team-named workspace whenever it exists. This keeps the natural
+  // flow pasteable from any pane:
+  //   maw new <team>; maw team bring <team>
+  // Without this, running the command from an oracle's home tmux session brings
+  // teammates back into that home session instead of the workspace (#1633).
+  if (await tmux.hasSession(teamName)) return teamName;
+
   const current = await currentTmuxSession();
   if (current) return current;
-
-  // Non-interactive path: if the workspace session is named after the team,
-  // allow `maw new <team>; maw team bring <team>` from outside tmux.
-  if (await tmux.hasSession(teamName)) return teamName;
 
   throw new Error(`not in tmux and no '${teamName}' session exists — run: maw new ${teamName}`);
 }

--- a/test/isolated/team-bring-workspace.test.ts
+++ b/test/isolated/team-bring-workspace.test.ts
@@ -4,15 +4,24 @@ import { tmpdir } from "os";
 import { join } from "path";
 
 const tmp = mkdtempSync(join(tmpdir(), "maw-team-bring-"));
-process.env.MAW_CONFIG_DIR = join(tmp, "config");
+const configDir = join(tmp, "config");
+process.env.MAW_CONFIG_DIR = configDir;
 
 let wakeCalls: Array<{ oracle: string; opts: any }> = [];
 let layoutCalls: Array<{ target: string; layout: string }> = [];
 
+mock.module("maw-js/core/paths", () => ({
+  CONFIG_DIR: configDir,
+  CONFIG_FILE: join(configDir, "maw.config.json"),
+  FLEET_DIR: join(configDir, "fleet"),
+  MAW_ROOT: "/repo/maw-js",
+  resolveHome: () => tmp,
+}));
+
 mock.module("maw-js/sdk", () => ({
   tmux: {
-    hasSession: async (name: string) => name === "project",
-    run: async () => "project",
+    hasSession: async (name: string) => name === "project" || name === "myteam",
+    run: async () => "54-mawjs",
     selectLayout: async (target: string, layout: string) => {
       layoutCalls.push({ target, layout });
     },
@@ -49,6 +58,14 @@ describe("cmdTeamBring", () => {
     const targets = await cmdTeamBring("myteam", { session: "project", dryRun: true });
 
     expect(targets).toEqual(["project:volt", "project:odin"]);
+    expect(wakeCalls).toEqual([]);
+    expect(layoutCalls).toEqual([]);
+  });
+
+  test("prefers an existing team-named workspace over the current tmux session", async () => {
+    const targets = await cmdTeamBring("myteam", { dryRun: true });
+
+    expect(targets).toEqual(["myteam:volt", "myteam:odin"]);
     expect(wakeCalls).toEqual([]);
     expect(layoutCalls).toEqual([]);
   });


### PR DESCRIPTION
## Summary
- Fix `maw team bring <team>` so an existing team-named workspace wins over the caller's current tmux session.
- Keep explicit `--session` as the highest-precedence target.
- Add a regression that simulates running from `54-mawjs` while `myteam` exists.

Closes #1633

## Verification
- `rtk bun test test/isolated/wake-foreign-session.test.ts test/isolated/team-bring-workspace.test.ts`
- `rtk bun run build`
- Disposable user-visible tmux smoke: temp `MAW_CONFIG_DIR`, `codex-1633-workspace` session, `team bring codex-1633-workspace` created `mawjs` window inside `codex-1633-workspace` with command `true`.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
