### PR TITLE
fix(wake): fail loud on ambiguous oracle repo names

### DIFF
--- a/src/commands/plugins/tmux/impl.ts
+++ b/src/commands/plugins/tmux/impl.ts
@@ -716,9 +716,9 @@ function suggestRecovery(target: string, session: string, source: string): void 
   }
 
   for (const s of findSimilarOracles(target).slice(0, 5)) {
-    const name = s.replace(/-oracle$/, "");
-    if (!candidates.some(c => c.oracle === name)) {
-      candidates.push({ oracle: name, label: s });
+    const wakeArg = wakeArgForSimilarOracle(s);
+    if (!candidates.some(c => c.oracle === wakeArg)) {
+      candidates.push({ oracle: wakeArg, label: s });
     }
   }
 
@@ -781,14 +781,38 @@ function ghqFindOracleSync(slug: string): string | null {
   } catch { return null; }
 }
 
+function repoNameFromPath(path: string): string {
+  return path.split("/").pop() ?? "";
+}
+
+function repoSlugFromPath(path: string): string {
+  const parts = path.split("/").filter(Boolean);
+  return parts.length >= 2 ? parts.slice(-2).join("/") : repoNameFromPath(path);
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+export function similarOracleCandidatesFromRepos(target: string, repos: string[]): string[] {
+  const lc = target.toLowerCase();
+  return uniqueStrings(
+    repos
+      .filter(r => {
+        const name = repoNameFromPath(r);
+        return name.endsWith("-oracle") && name.toLowerCase().includes(lc);
+      })
+      .map(repoSlugFromPath),
+  );
+}
+
+function wakeArgForSimilarOracle(candidate: string): string {
+  return candidate.includes("/") ? candidate : candidate.replace(/-oracle$/, "");
+}
+
 function findSimilarOracles(target: string): string[] {
   try {
-    const lc = target.toLowerCase();
-    const repos = ghqListSync();
-    return repos
-      .map(r => r.split("/").pop() ?? "")
-      .filter(name => name.endsWith("-oracle") && name.toLowerCase().includes(lc))
-      .filter((v, i, a) => a.indexOf(v) === i);
+    return similarOracleCandidatesFromRepos(target, ghqListSync());
   } catch { return []; }
 }
 

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -357,8 +357,13 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
   oracle = normalizeTarget(oracle);
 
   const parsed = parseWakeTarget(oracle);
+  let parsedRepoPath: string | null = null;
   if (parsed) {
     await ensureCloned(parsed.slug);
+    // #1635 — full org/repo input is an explicit disambiguation. Preserve the
+    // exact cloned/local slug instead of later resolving the bare oracle name
+    // through `ghqFind(/repo)`, which can silently pick a different org.
+    parsedRepoPath = await ghqFind(`/${parsed.slug}`);
     oracle = parsed.oracle;
     if (!opts.urlRepoName) opts.urlRepoName = parsed.slug.split("/").pop();
   }
@@ -385,6 +390,9 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
     // just cloned it). Skip resolveOracle so a stale same-named repo in a
     // different org can't shadow the freshly-created one.
     const repoPath = opts.repoPath;
+    resolved = { repoPath, repoName: repoPath.split("/").pop()!, parentDir: repoPath.replace(/\/[^/]+$/, "") };
+  } else if (parsedRepoPath) {
+    const repoPath = parsedRepoPath;
     resolved = { repoPath, repoName: repoPath.split("/").pop()!, parentDir: repoPath.replace(/\/[^/]+$/, "") };
   } else if (opts.incubate) {
     const slug = opts.incubate;

--- a/src/commands/shared/wake-resolve-impl.test.ts
+++ b/src/commands/shared/wake-resolve-impl.test.ts
@@ -166,4 +166,17 @@ describe("resolveLocalOracleRepoName (#1469) — exact local oracle wins before 
       match: "arra-oracle-v3-oracle",
     });
   });
+
+  it("fails loudly when a bare oracle name exists in multiple orgs (#1635)", () => {
+    expect(resolveLocalOracleRepoName("pulse", [
+      "github.com/laris-co/pulse-oracle",
+      "github.com/Soul-Brews-Studio/pulse-oracle",
+    ])).toEqual({
+      kind: "ambiguous",
+      candidates: [
+        "laris-co/pulse-oracle",
+        "Soul-Brews-Studio/pulse-oracle",
+      ],
+    });
+  });
 });

--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -64,6 +64,20 @@ function uniqueStrings(values: string[]): string[] {
   return [...new Set(values)];
 }
 
+function repoNameFromPath(path: string): string {
+  return path.split("/").pop() ?? "";
+}
+
+function repoSlugFromPath(path: string): string {
+  const parts = path.split("/").filter(Boolean);
+  return parts.length >= 2 ? parts.slice(-2).join("/") : repoNameFromPath(path);
+}
+
+function localOracleRepoPath(match: string, repos: string[]): string | null {
+  const lower = match.toLowerCase();
+  return repos.find(p => repoNameFromPath(p).toLowerCase() === lower) ?? null;
+}
+
 function stripOracleSuffix(name: string): string {
   return name.replace(/-oracle$/i, "");
 }
@@ -97,28 +111,30 @@ export function resolveLocalOracleRepoName(oracle: string, repos: string[]): Loc
   const oracleLower = oracle.trim().toLowerCase();
   if (!oracleLower) return { kind: "none" };
 
-  const repoNames = repos
+  const repoRefs = repos
     .filter(p => p.toLowerCase().endsWith("-oracle"))
-    .map(p => p.split("/").pop()!)
-    .filter(Boolean);
+    .map(p => ({ path: p, name: repoNameFromPath(p), slug: repoSlugFromPath(p) }))
+    .filter(r => r.name);
 
   const intents = new Set(localOracleIntentNames(oracle));
-  const exact = uniqueStrings(repoNames.filter(name => {
-    const lower = name.toLowerCase();
+  const exactRefs = repoRefs.filter(ref => {
+    const lower = ref.name.toLowerCase();
     const bare = stripOracleSuffix(lower);
     return intents.has(lower) || intents.has(bare);
-  }));
+  });
+  const exactSlugs = uniqueStrings(exactRefs.map(ref => ref.slug));
 
-  if (exact.length === 1) return { kind: "exact", match: exact[0]! };
-  if (exact.length > 1) return { kind: "ambiguous", candidates: exact };
+  if (exactSlugs.length === 1) return { kind: "exact", match: exactRefs[0]!.name };
+  if (exactSlugs.length > 1) return { kind: "ambiguous", candidates: exactSlugs };
 
-  const candidates = uniqueStrings(repoNames.filter(name => {
-    const bare = stripOracleSuffix(name.toLowerCase());
+  const candidateRefs = repoRefs.filter(ref => {
+    const bare = stripOracleSuffix(ref.name.toLowerCase());
     return bare.includes(oracleLower) || oracleLower.includes(bare);
-  }));
+  });
+  const candidateSlugs = uniqueStrings(candidateRefs.map(ref => ref.slug));
 
-  if (candidates.length === 1) return { kind: "fuzzy", match: candidates[0]! };
-  if (candidates.length > 1) return { kind: "ambiguous", candidates };
+  if (candidateSlugs.length === 1) return { kind: "fuzzy", match: candidateRefs[0]!.name };
+  if (candidateSlugs.length > 1) return { kind: "ambiguous", candidates: candidateSlugs };
   return { kind: "none" };
 }
 
@@ -126,21 +142,21 @@ export async function resolveOracle(
   oracle: string,
   opts?: { allLocal?: boolean },
 ): Promise<{ repoPath: string; repoName: string; parentDir: string }> {
-  const oracleRepoStem = oracle.toLowerCase().endsWith("-oracle") ? oracle : `${oracle}-oracle`;
-  const ghqHit = await ghqFind(`/${oracleRepoStem}`);
-  if (ghqHit) {
-    const repoPath = ghqHit;
-    return { repoPath, repoName: repoPath.split("/").pop()!, parentDir: repoPath.replace(/\/[^/]+$/, "") };
-  }
-
-  // #997 — fuzzy match against local *-oracle repos in ghq before remote lookups.
+  // #997 — match against local *-oracle repos in ghq before remote lookups.
   // e.g. "v3" matches "arra-oracle-v3-oracle" so `maw wake v3` works like `maw ls -a`.
+  //
+  // #1635 — do this from the full ghq list before the old `ghqFind(/name)`
+  // fast path. `ghqFind(/pulse-oracle)` returns the first suffix hit, which
+  // silently picks one org when both `laris-co/pulse-oracle` and
+  // `Soul-Brews-Studio/pulse-oracle` are local. Bare-name ambiguity must fail
+  // loudly with org/repo candidates.
   try {
     const { ghqList } = await import("../../core/ghq");
     const repos = await ghqList();
     const resolvedLocal = resolveLocalOracleRepoName(oracle, repos);
     if (resolvedLocal.kind === "exact" || resolvedLocal.kind === "fuzzy") {
-      const match = await ghqFind(`/${resolvedLocal.match}`);
+      const match = localOracleRepoPath(resolvedLocal.match, repos)
+        ?? await ghqFind(`/${resolvedLocal.match}`);
       if (match) {
         if (resolvedLocal.kind === "fuzzy") console.log(`\x1b[36m→\x1b[0m fuzzy match: ${resolvedLocal.match}`);
         return { repoPath: match, repoName: match.split("/").pop()!, parentDir: match.replace(/\/[^/]+$/, "") };
@@ -148,7 +164,7 @@ export async function resolveOracle(
     } else if (resolvedLocal.kind === "ambiguous") {
       console.error(`\x1b[33m⚠\x1b[0m '${oracle}' matches ${resolvedLocal.candidates.length} local oracles:`);
       for (const c of resolvedLocal.candidates) console.error(`\x1b[90m    • ${c}\x1b[0m`);
-      console.error(`\x1b[90m  use the full name: maw wake <exact-name>\x1b[0m`);
+      console.error(`\x1b[90m  use the full name: maw wake <org>/<repo>\x1b[0m`);
       process.exit(1);
     }
   } catch { /* ghq unavailable — fall through */ }

--- a/test/isolated/tmux-action-verbs.test.ts
+++ b/test/isolated/tmux-action-verbs.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { cmdTmuxLayout, cmdTmuxSplit, cmdTmuxAttach, _sendTracker } from "../../src/commands/plugins/tmux/impl";
+import { cmdTmuxLayout, cmdTmuxSplit, cmdTmuxAttach, similarOracleCandidatesFromRepos, _sendTracker } from "../../src/commands/plugins/tmux/impl";
 import * as impl from "../../src/commands/plugins/tmux/impl";
 import { readFileSync } from "fs";
 import { join } from "path";
@@ -228,6 +228,18 @@ describe("cmdTmuxAttach — TTY exec branches", () => {
 
     expect(calls).toHaveLength(0);
     expect(logs.join("\n")).toContain("tmux attach -t");
+  });
+});
+
+describe("cmdTmuxAttach — oracle recovery candidates", () => {
+  test("same repo name across orgs stays ambiguous with org/repo wake args (#1635)", () => {
+    expect(similarOracleCandidatesFromRepos("pulse", [
+      "/opt/Code/github.com/laris-co/pulse-oracle",
+      "/opt/Code/github.com/Soul-Brews-Studio/pulse-oracle",
+    ])).toEqual([
+      "laris-co/pulse-oracle",
+      "Soul-Brews-Studio/pulse-oracle",
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary
- make bare oracle repo lookup inspect the full local ghq list before choosing a repo
- fail loud when the same `*-oracle` repo name exists in multiple orgs, listing `org/repo` candidates
- preserve explicit `org/repo` wake targets as exact disambiguation and make `maw a` recovery suggestions use `maw wake <org>/<repo>`

## Verification
- `rtk bun test src/commands/shared/wake-resolve-impl.test.ts test/isolated/tmux-action-verbs.test.ts test/wake-target-parser.test.ts`
- `rtk bun run build`
- `git diff --check`
- fake-ghq user-visible smoke:
  - `bun dist/maw wake codex1635 --list` exits non-zero and lists both org/repo candidates
  - `bun dist/maw a codex1635` exits non-zero and lists both `maw wake <org>/<repo>` choices

Closes #1635

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
