### PR TITLE
test(cli): cover update and dispatch guard paths

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,62 +1,63 @@
 # Coverage gap analysis
 
-Generated: 2026-05-16T14:45:01.849Z
+Generated: 2026-05-16T18:14:38.551Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **12.9%** (6511/50588)
-Overall function coverage: **48.5%** (622/1283)
+Overall line coverage: **13.3%** (6789/50884)
+Overall function coverage: **48.4%** (653/1348)
 
 ## Module summary
 
 | Module | Files | Missing from LCOV | Lines | Functions | Branches |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| cli/dispatch | 88 | 28 | 21.2% (1585/7488) | 50.5% (144/285) | n/a (0/0) |
+| cli/dispatch | 88 | 24 | 23.3% (1760/7538) | 50.0% (159/318) | n/a (0/0) |
 | config/runtime | 19 | 2 | 43.3% (510/1179) | 40.2% (35/87) | n/a (0/0) |
-| fleet | 16 | 1 | 16.3% (179/1100) | 44.9% (22/49) | n/a (0/0) |
+| fleet | 17 | 1 | 20.7% (227/1096) | 53.4% (31/58) | n/a (0/0) |
 | matcher | 2 | 0 | 100.0% (41/41) | 100.0% (8/8) | n/a (0/0) |
-| other | 174 | 98 | 18.0% (2575/14322) | 54.2% (252/465) | n/a (0/0) |
+| other | 174 | 98 | 17.9% (2578/14398) | 53.2% (252/474) | n/a (0/0) |
 | plugin dispatch | 15 | 1 | 46.6% (595/1276) | 67.2% (45/67) | n/a (0/0) |
-| routing/aliases | 4 | 2 | 41.3% (248/601) | 83.3% (25/30) | n/a (0/0) |
+| routing/aliases | 4 | 0 | 49.2% (300/610) | 72.7% (32/44) | n/a (0/0) |
 | transport | 28 | 3 | 23.0% (633/2754) | 28.8% (79/274) | n/a (0/0) |
-| vendor plugins | 244 | 243 | 0.7% (145/21827) | 66.7% (12/18) | n/a (0/0) |
+| vendor plugins | 245 | 244 | 0.7% (145/21992) | 66.7% (12/18) | n/a (0/0) |
 
 ## Top 20 uncovered files by executable/source line count
 
 | Rank | Risk | Module | File | Uncovered | Line coverage | Function coverage | Note |
 | ---: | --- | --- | --- | ---: | ---: | ---: | --- |
 | 1 | low | vendor plugins | `src/vendor/mpr-plugins/dream/impl.ts` | 885 | 0.0% | n/a | absent from LCOV |
-| 2 | critical | cli/dispatch | `src/commands/shared/wake-cmd.ts` | 599 | 5.5% | 4.8% | partial coverage |
-| 3 | medium | other | `src/commands/plugins/tmux/impl.ts` | 524 | 5.2% | 0.0% | partial coverage |
+| 2 | critical | cli/dispatch | `src/commands/shared/wake-cmd.ts` | 621 | 5.3% | 4.5% | partial coverage |
+| 3 | medium | other | `src/commands/plugins/tmux/impl.ts` | 590 | 5.1% | 0.0% | partial coverage |
 | 4 | critical | cli/dispatch | `src/commands/shared/comm-send.ts` | 510 | 9.3% | 26.7% | partial coverage |
 | 5 | low | vendor plugins | `src/vendor/mpr-plugins/team/team-charter.ts` | 482 | 0.0% | n/a | absent from LCOV |
 | 6 | medium | other | `src/commands/plugins/team/index.ts` | 477 | 0.0% | n/a | absent from LCOV |
 | 7 | low | vendor plugins | `src/vendor/mpr-plugins/messages/index.ts` | 398 | 0.0% | n/a | absent from LCOV |
-| 8 | medium | other | `src/api/sessions.ts` | 372 | 16.8% | 12.5% | partial coverage |
-| 9 | low | vendor plugins | `src/vendor/mpr-plugins/cleanup/internal/prune-stale-oracles.ts` | 366 | 0.0% | n/a | absent from LCOV |
-| 10 | critical | cli/dispatch | `src/cli/cmd-update.ts` | 364 | 0.0% | n/a | absent from LCOV |
+| 8 | critical | cli/dispatch | `src/cli/cmd-update.ts` | 380 | 13.0% | 33.3% | partial coverage |
+| 9 | medium | other | `src/api/sessions.ts` | 372 | 16.8% | 12.5% | partial coverage |
+| 10 | low | vendor plugins | `src/vendor/mpr-plugins/cleanup/internal/prune-stale-oracles.ts` | 366 | 0.0% | n/a | absent from LCOV |
 | 11 | medium | other | `src/core/engine-plugin-registry.ts` | 336 | 0.0% | n/a | absent from LCOV |
 | 12 | low | vendor plugins | `src/vendor/mpr-plugins/doctor/impl.ts` | 332 | 0.0% | n/a | absent from LCOV |
-| 13 | low | vendor plugins | `src/vendor/mpr-plugins/bg/src/impl.ts` | 297 | 0.0% | n/a | absent from LCOV |
-| 14 | low | vendor plugins | `src/vendor/mpr-plugins/team/index.ts` | 291 | 0.0% | n/a | absent from LCOV |
+| 13 | low | vendor plugins | `src/vendor/mpr-plugins/team/index.ts` | 314 | 0.0% | n/a | absent from LCOV |
+| 14 | low | vendor plugins | `src/vendor/mpr-plugins/bg/src/impl.ts` | 297 | 0.0% | n/a | absent from LCOV |
 | 15 | medium | other | `src/commands/plugins/tile/impl.ts` | 283 | 0.0% | n/a | absent from LCOV |
-| 16 | medium | other | `src/commands/plugins/plugin/install-handlers.ts` | 280 | 24.9% | 18.8% | partial coverage |
-| 17 | critical | cli/dispatch | `src/commands/shared/wake-resolve-impl.ts` | 274 | 14.4% | 35.3% | partial coverage |
+| 16 | critical | cli/dispatch | `src/commands/shared/wake-resolve-impl.ts` | 281 | 14.1% | 30.0% | partial coverage |
+| 17 | medium | other | `src/commands/plugins/plugin/install-handlers.ts` | 280 | 24.9% | 18.8% | partial coverage |
 | 18 | low | vendor plugins | `src/vendor/mpr-plugins/view/impl.ts` | 269 | 0.0% | n/a | absent from LCOV |
 | 19 | critical | transport | `src/core/transport/tmux-class.ts` | 267 | 15.2% | 30.4% | partial coverage |
-| 20 | medium | other | `src/commands/plugins/tmux/index.ts` | 253 | 0.0% | n/a | absent from LCOV |
+| 20 | medium | other | `src/commands/plugins/tmux/index.ts` | 260 | 0.0% | n/a | absent from LCOV |
 
 ## Critical files at or above the 80% line target
 
 | Module | File | Line coverage | Function coverage |
 | --- | --- | ---: | ---: |
+| cli/dispatch | `src/cli/cmd-version.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/cli/command-registry-match.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/cli/command-registry-types.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/cli/command-registry-wasm.ts` | 87.1% | 50.0% |
 | cli/dispatch | `src/cli/command-registry.ts` | 96.7% | 100.0% |
-| cli/dispatch | `src/cli/dispatch-match.ts` | 88.5% | 85.7% |
+| cli/dispatch | `src/cli/dispatch-match.ts` | 91.7% | 90.0% |
 | cli/dispatch | `src/cli/parse-args.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/cli/usage.ts` | 89.6% | 92.9% |
 | cli/dispatch | `src/cli/verbosity.ts` | 100.0% | 100.0% |
@@ -84,6 +85,7 @@ Overall function coverage: **48.5%** (622/1283)
 | fleet | `src/core/fleet/registry-oracle-types.ts` | 100.0% | 100.0% |
 | fleet | `src/core/fleet/snapshot.ts` | 93.4% | 100.0% |
 | fleet | `src/core/fleet/validate.ts` | 100.0% | 100.0% |
+| fleet | `src/core/fleet/worktree-window-match.ts` | 100.0% | 100.0% |
 | fleet | `src/core/fleet/worktrees.ts` | 100.0% | 100.0% |
 | matcher | `src/core/matcher/normalize-target.ts` | 100.0% | 100.0% |
 | matcher | `src/core/matcher/resolve-target.ts` | 100.0% | 100.0% |
@@ -105,23 +107,23 @@ Overall function coverage: **48.5%** (622/1283)
 
 | Module | File | Uncovered | Line coverage |
 | --- | --- | ---: | ---: |
-| cli/dispatch | `src/commands/shared/wake-cmd.ts` | 599 | 5.5% |
+| cli/dispatch | `src/commands/shared/wake-cmd.ts` | 621 | 5.3% |
 | cli/dispatch | `src/commands/shared/comm-send.ts` | 510 | 9.3% |
-| cli/dispatch | `src/cli/cmd-update.ts` | 364 | 0.0% |
-| cli/dispatch | `src/commands/shared/wake-resolve-impl.ts` | 274 | 14.4% |
+| cli/dispatch | `src/cli/cmd-update.ts` | 380 | 13.0% |
+| cli/dispatch | `src/commands/shared/wake-resolve-impl.ts` | 281 | 14.1% |
 | transport | `src/core/transport/tmux-class.ts` | 267 | 15.2% |
 | transport | `src/transports/scout.ts` | 248 | 8.5% |
 | cli/dispatch | `src/commands/shared/done.ts` | 207 | 0.0% |
 | plugin dispatch | `src/plugin/registry-invoke.ts` | 200 | 2.4% |
 | transport | `src/transports/mdns.ts` | 184 | 7.5% |
-| fleet | `src/core/fleet/worktrees-scan.ts` | 180 | 3.2% |
+| transport | `src/core/transport/peers.ts` | 176 | 31.3% |
 
 ## Critical gaps to prioritize
 
-- `src/commands/shared/wake-cmd.ts` (cli/dispatch): 599 uncovered lines, 5.5% line coverage.
+- `src/commands/shared/wake-cmd.ts` (cli/dispatch): 621 uncovered lines, 5.3% line coverage.
 - `src/commands/shared/comm-send.ts` (cli/dispatch): 510 uncovered lines, 9.3% line coverage.
-- `src/cli/cmd-update.ts` (cli/dispatch): 364 uncovered lines, 0.0% line coverage.
-- `src/commands/shared/wake-resolve-impl.ts` (cli/dispatch): 274 uncovered lines, 14.4% line coverage.
+- `src/cli/cmd-update.ts` (cli/dispatch): 380 uncovered lines, 13.0% line coverage.
+- `src/commands/shared/wake-resolve-impl.ts` (cli/dispatch): 281 uncovered lines, 14.1% line coverage.
 - `src/core/transport/tmux-class.ts` (transport): 267 uncovered lines, 15.2% line coverage.
 
 ## Prioritization guidance

--- a/test/cmd-update-direct.test.ts
+++ b/test/cmd-update-direct.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Direct unit coverage for maw update's safe gates.
+ *
+ * These tests intentionally stop before destructive install operations by
+ * setting MAW_TEST_MODE=1 and/or intercepting process.exit. The older
+ * subprocess tests prove CLI wiring; this file imports cmd-update directly so
+ * Bun coverage accounts for the guard logic in src/cli/cmd-update.ts.
+ */
+import { afterEach, describe, expect, it } from "bun:test";
+import { runUpdate } from "../src/cli/cmd-update";
+
+type Capture = { code: number | undefined; stdout: string; stderr: string; threw: unknown };
+
+const original = {
+  exit: process.exit,
+  log: console.log,
+  error: console.error,
+  stdoutWrite: process.stdout.write,
+  stdinIsTTY: Object.getOwnPropertyDescriptor(process.stdin, "isTTY"),
+  testMode: process.env.MAW_TEST_MODE,
+};
+
+function setStdinIsTTY(value: boolean): void {
+  Object.defineProperty(process.stdin, "isTTY", { configurable: true, value });
+}
+
+async function captureRun(args: string[], opts: { testMode?: string; stdinIsTTY?: boolean } = {}): Promise<Capture> {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  let code: number | undefined;
+  let threw: unknown;
+
+  if (opts.testMode === undefined) delete process.env.MAW_TEST_MODE;
+  else process.env.MAW_TEST_MODE = opts.testMode;
+  if (opts.stdinIsTTY !== undefined) setStdinIsTTY(opts.stdinIsTTY);
+
+  (process as any).exit = (exitCode?: number) => {
+    code = exitCode ?? 0;
+    throw new Error(`exit:${code}`);
+  };
+  console.log = (...parts: unknown[]) => { stdout.push(parts.map(String).join(" ")); };
+  console.error = (...parts: unknown[]) => { stderr.push(parts.map(String).join(" ")); };
+  (process.stdout as any).write = (chunk: unknown) => {
+    stdout.push(String(chunk));
+    return true;
+  };
+
+  try {
+    await runUpdate(args);
+  } catch (err) {
+    threw = err;
+    if (!(err instanceof Error) || !err.message.startsWith("exit:")) throw err;
+  }
+
+  return { code, stdout: stdout.join("\n"), stderr: stderr.join("\n"), threw };
+}
+
+afterEach(() => {
+  (process as any).exit = original.exit;
+  console.log = original.log;
+  console.error = original.error;
+  (process.stdout as any).write = original.stdoutWrite;
+  if (original.stdinIsTTY) Object.defineProperty(process.stdin, "isTTY", original.stdinIsTTY);
+  else delete (process.stdin as any).isTTY;
+  if (original.testMode === undefined) delete process.env.MAW_TEST_MODE;
+  else process.env.MAW_TEST_MODE = original.testMode;
+});
+
+describe("cmd-update direct safe gates", () => {
+  it("prints help and exits before version/install side effects", async () => {
+    const res = await captureRun(["update", "--help"], { testMode: "1" });
+    expect(res.code).toBe(0);
+    expect(res.stdout).toContain("usage: maw update [ref]");
+    expect(res.stdout).toContain("--yes, -y");
+    expect(res.stderr).toBe("");
+  });
+
+  it("rejects unknown flag-looking args before install", async () => {
+    const res = await captureRun(["update", "--yess"], { testMode: "1" });
+    expect(res.code).toBe(1);
+    expect(res.stderr).toContain('invalid ref "--yess"');
+    expect(res.stdout).not.toContain("[test-mode]");
+  });
+
+  it("requires --yes in non-interactive mode", async () => {
+    const res = await captureRun(["update", "main"], { testMode: "1", stdinIsTTY: false });
+    expect(res.code).toBe(1);
+    expect(res.stderr).toContain("non-interactive environment");
+    expect(res.stderr).toContain("--yes");
+  });
+
+  it("accepts valid refs and stops at the MAW_TEST_MODE safety boundary", async () => {
+    const res = await captureRun(["update", "feat/coverage-direct", "--yes"], { testMode: "1" });
+    expect(res.code).toBeUndefined();
+    expect(res.stderr).toBe("");
+    expect(res.stdout).toContain("feat/coverage-direct");
+    expect(res.stdout).toContain('[test-mode] ref "feat/coverage-direct" accepted');
+  });
+
+  it("ignores flag-looking values when choosing the positional ref", async () => {
+    const res = await captureRun(["update", "--yes"], { testMode: "1" });
+    expect(res.code).toBeUndefined();
+    expect(res.stderr).toBe("");
+    expect(res.stdout).toContain('[test-mode] ref "main" accepted');
+  });
+});

--- a/test/dispatch-direct.test.ts
+++ b/test/dispatch-direct.test.ts
@@ -1,0 +1,66 @@
+/** Direct coverage for the CLI dispatch ladder's safe error/shortcut paths. */
+import { afterEach, describe, expect, it } from "bun:test";
+import { dispatchCommand } from "../src/cli/dispatch";
+import { UserError } from "../src/core/util/user-error";
+
+const original = {
+  exit: process.exit,
+  log: console.log,
+  error: console.error,
+  testMode: process.env.MAW_TEST_MODE,
+};
+
+type Capture = { code: number | undefined; stdout: string; stderr: string; error: unknown };
+
+async function captureDispatch(cmd: string, args: string[]): Promise<Capture> {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  let code: number | undefined;
+  let error: unknown;
+
+  process.env.MAW_TEST_MODE = "1";
+  (process as any).exit = (exitCode?: number) => {
+    code = exitCode ?? 0;
+    throw new Error(`exit:${code}`);
+  };
+  console.log = (...parts: unknown[]) => { stdout.push(parts.map(String).join(" ")); };
+  console.error = (...parts: unknown[]) => { stderr.push(parts.map(String).join(" ")); };
+
+  try {
+    await dispatchCommand(cmd, args);
+  } catch (err) {
+    error = err;
+    if (err instanceof Error && err.message.startsWith("exit:")) {
+      // process.exit is part of the old dispatch contract; capture it.
+    } else if (!(err instanceof UserError)) {
+      throw err;
+    }
+  }
+
+  return { code, stdout: stdout.join("\n"), stderr: stderr.join("\n"), error };
+}
+
+afterEach(() => {
+  (process as any).exit = original.exit;
+  console.log = original.log;
+  console.error = original.error;
+  if (original.testMode === undefined) delete process.env.MAW_TEST_MODE;
+  else process.env.MAW_TEST_MODE = original.testMode;
+});
+
+describe("dispatchCommand direct safe paths", () => {
+  it("fails loud for unknown non-oracle-shaped commands", async () => {
+    const res = await captureDispatch("??missing", ["??missing"]);
+    expect(res.error).toBeInstanceOf(UserError);
+    expect(res.stderr).toContain("unknown command: ??missing");
+    expect(res.stderr).toContain("maw --help");
+    expect(res.code).toBeUndefined();
+  });
+
+  it("short-circuits core route help before plugin registry fallback", async () => {
+    const res = await captureDispatch("plugins", ["plugins", "--help"]);
+    expect(res.code).toBeUndefined();
+    expect(res.stdout).toContain("usage: maw plugins");
+    expect(res.stderr).toBe("");
+  });
+});


### PR DESCRIPTION
## Why

Nat asked to push unit coverage toward 100% while staying alpha-only. This is the first small coverage PR after #1611: direct tests for safe CLI guard paths that were only exercised via subprocess smoke before, so Bun LCOV did not credit the source modules.

Closes #1637? No — this is an incremental PR toward #1637, not the full 100% target.

## What changed

- Added direct unit coverage for `src/cli/cmd-update.ts` safe gates:
  - help short-circuit
  - unknown flag rejection
  - non-interactive confirmation guard
  - valid ref reaching `MAW_TEST_MODE` safety boundary
  - `--yes` defaulting to `main`
- Added direct unit coverage for `src/cli/dispatch.ts` safe paths:
  - unknown command fail-loud path
  - core route help short-circuit
- Refreshed `docs/testing/coverage-gap-analysis.md`.

## Evidence

- `rtk bun test test/cmd-update-direct.test.ts test/cmd-update-ref-validation.test.ts test/dispatch-direct.test.ts` → 14 pass / 0 fail in ~0.5s.
- `rtk bun run test:coverage` → 1418 pass / 6 skip / 0 fail in ~22s; overall tracked-source lines 13.3% (6789/50884), functions 48.4% (653/1348).
- `rtk bun run build` → success.

## Release

No release-alpha cut. No main/beta work. PR targets `alpha` only.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
