### PR TITLE
test(wake): cover pure resolver guard paths

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,19 +1,19 @@
 # Coverage gap analysis
 
-Generated: 2026-05-16T18:14:38.551Z
+Generated: 2026-05-16T18:21:19.718Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **13.3%** (6789/50884)
-Overall function coverage: **48.4%** (653/1348)
+Overall line coverage: **13.4%** (6834/50874)
+Overall function coverage: **49.3%** (668/1355)
 
 ## Module summary
 
 | Module | Files | Missing from LCOV | Lines | Functions | Branches |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| cli/dispatch | 88 | 24 | 23.3% (1760/7538) | 50.0% (159/318) | n/a (0/0) |
+| cli/dispatch | 88 | 24 | 24.0% (1805/7528) | 53.5% (174/325) | n/a (0/0) |
 | config/runtime | 19 | 2 | 43.3% (510/1179) | 40.2% (35/87) | n/a (0/0) |
 | fleet | 17 | 1 | 20.7% (227/1096) | 53.4% (31/58) | n/a (0/0) |
 | matcher | 2 | 0 | 100.0% (41/41) | 100.0% (8/8) | n/a (0/0) |
@@ -42,11 +42,11 @@ Overall function coverage: **48.4%** (653/1348)
 | 13 | low | vendor plugins | `src/vendor/mpr-plugins/team/index.ts` | 314 | 0.0% | n/a | absent from LCOV |
 | 14 | low | vendor plugins | `src/vendor/mpr-plugins/bg/src/impl.ts` | 297 | 0.0% | n/a | absent from LCOV |
 | 15 | medium | other | `src/commands/plugins/tile/impl.ts` | 283 | 0.0% | n/a | absent from LCOV |
-| 16 | critical | cli/dispatch | `src/commands/shared/wake-resolve-impl.ts` | 281 | 14.1% | 30.0% | partial coverage |
-| 17 | medium | other | `src/commands/plugins/plugin/install-handlers.ts` | 280 | 24.9% | 18.8% | partial coverage |
-| 18 | low | vendor plugins | `src/vendor/mpr-plugins/view/impl.ts` | 269 | 0.0% | n/a | absent from LCOV |
-| 19 | critical | transport | `src/core/transport/tmux-class.ts` | 267 | 15.2% | 30.4% | partial coverage |
-| 20 | medium | other | `src/commands/plugins/tmux/index.ts` | 260 | 0.0% | n/a | absent from LCOV |
+| 16 | medium | other | `src/commands/plugins/plugin/install-handlers.ts` | 280 | 24.9% | 18.8% | partial coverage |
+| 17 | low | vendor plugins | `src/vendor/mpr-plugins/view/impl.ts` | 269 | 0.0% | n/a | absent from LCOV |
+| 18 | critical | transport | `src/core/transport/tmux-class.ts` | 267 | 15.2% | 30.4% | partial coverage |
+| 19 | medium | other | `src/commands/plugins/tmux/index.ts` | 260 | 0.0% | n/a | absent from LCOV |
+| 20 | low | vendor plugins | `src/vendor/mpr-plugins/init/internal/plugin-lock.ts` | 251 | 0.0% | n/a | absent from LCOV |
 
 ## Critical files at or above the 80% line target
 
@@ -110,9 +110,9 @@ Overall function coverage: **48.4%** (653/1348)
 | cli/dispatch | `src/commands/shared/wake-cmd.ts` | 621 | 5.3% |
 | cli/dispatch | `src/commands/shared/comm-send.ts` | 510 | 9.3% |
 | cli/dispatch | `src/cli/cmd-update.ts` | 380 | 13.0% |
-| cli/dispatch | `src/commands/shared/wake-resolve-impl.ts` | 281 | 14.1% |
 | transport | `src/core/transport/tmux-class.ts` | 267 | 15.2% |
 | transport | `src/transports/scout.ts` | 248 | 8.5% |
+| cli/dispatch | `src/commands/shared/wake-resolve-impl.ts` | 226 | 28.7% |
 | cli/dispatch | `src/commands/shared/done.ts` | 207 | 0.0% |
 | plugin dispatch | `src/plugin/registry-invoke.ts` | 200 | 2.4% |
 | transport | `src/transports/mdns.ts` | 184 | 7.5% |
@@ -123,7 +123,6 @@ Overall function coverage: **48.4%** (653/1348)
 - `src/commands/shared/wake-cmd.ts` (cli/dispatch): 621 uncovered lines, 5.3% line coverage.
 - `src/commands/shared/comm-send.ts` (cli/dispatch): 510 uncovered lines, 9.3% line coverage.
 - `src/cli/cmd-update.ts` (cli/dispatch): 380 uncovered lines, 13.0% line coverage.
-- `src/commands/shared/wake-resolve-impl.ts` (cli/dispatch): 281 uncovered lines, 14.1% line coverage.
 - `src/core/transport/tmux-class.ts` (transport): 267 uncovered lines, 15.2% line coverage.
 
 ## Prioritization guidance

--- a/test/wake-resolve-pure.test.ts
+++ b/test/wake-resolve-pure.test.ts
@@ -1,0 +1,76 @@
+/** Pure wake-resolver coverage for high-signal name normalization guards. */
+import { describe, expect, test } from "bun:test";
+import {
+  resolveLocalOracleRepoName,
+  sanitizeBranchName,
+} from "../src/commands/shared/wake-resolve-impl";
+
+describe("sanitizeBranchName — pure normalization", () => {
+  test("strips repeated leading/trailing dashes and dots", () => {
+    expect(sanitizeBranchName("--no-attach")).toBe("no-attach");
+    expect(sanitizeBranchName("...feature...")).toBe("feature");
+    expect(sanitizeBranchName("--foo--")).toBe("foo");
+  });
+
+  test("normalizes whitespace, case, punctuation, and length", () => {
+    expect(sanitizeBranchName("My Task Name")).toBe("my-task-name");
+    expect(sanitizeBranchName("Feature: Pulse Board!")).toBe("feature-pulse-board");
+    expect(sanitizeBranchName("x".repeat(80))).toHaveLength(50);
+  });
+
+  test("collapses pure separator input to empty string", () => {
+    expect(sanitizeBranchName("--")).toBe("");
+    expect(sanitizeBranchName("...")).toBe("");
+  });
+});
+
+describe("resolveLocalOracleRepoName — exact before fuzzy", () => {
+  const repos = [
+    "github.com/Soul-Brews-Studio/mawjs-oracle",
+    "github.com/Soul-Brews-Studio/mawjs-codex-oracle",
+    "github.com/Soul-Brews-Studio/arra-oracle-v3-oracle",
+  ];
+
+  test("prefers exact full and bare oracle names over shorter fuzzy suffixes", () => {
+    expect(resolveLocalOracleRepoName("mawjs-codex-oracle", repos)).toEqual({
+      kind: "exact",
+      match: "mawjs-codex-oracle",
+    });
+    expect(resolveLocalOracleRepoName("mawjs-codex", repos)).toEqual({
+      kind: "exact",
+      match: "mawjs-codex-oracle",
+    });
+  });
+
+  test("strips numeric fleet prefixes before exact local lookup", () => {
+    expect(resolveLocalOracleRepoName("48-mawjs-codex", repos)).toEqual({
+      kind: "exact",
+      match: "mawjs-codex-oracle",
+    });
+  });
+
+  test("keeps legacy fuzzy lookup for unambiguous abbreviations", () => {
+    expect(resolveLocalOracleRepoName("v3", repos)).toEqual({
+      kind: "fuzzy",
+      match: "arra-oracle-v3-oracle",
+    });
+  });
+
+  test("fails loud for same oracle name across multiple orgs", () => {
+    expect(resolveLocalOracleRepoName("pulse", [
+      "github.com/laris-co/pulse-oracle",
+      "github.com/Soul-Brews-Studio/pulse-oracle",
+    ])).toEqual({
+      kind: "ambiguous",
+      candidates: [
+        "laris-co/pulse-oracle",
+        "Soul-Brews-Studio/pulse-oracle",
+      ],
+    });
+  });
+
+  test("returns none for empty or non-oracle inputs", () => {
+    expect(resolveLocalOracleRepoName("", repos)).toEqual({ kind: "none" });
+    expect(resolveLocalOracleRepoName("ghost", repos)).toEqual({ kind: "none" });
+  });
+});


### PR DESCRIPTION
## Why

Incremental alpha-only coverage work for #1637. `wake-resolve-impl.ts` is one of the high-signal critical gaps in the coverage report. The existing richer wake resolver regression file lives under `src/commands/shared/*.test.ts`, outside the default coverage runner; this PR adds pure, no-mock tests under `test/` for the safest resolver pieces.

## What changed

- Added `test/wake-resolve-pure.test.ts` covering:
  - `sanitizeBranchName()` normalization guards.
  - `resolveLocalOracleRepoName()` exact-before-fuzzy behavior.
  - numeric fleet prefix stripping.
  - same-oracle/multiple-org ambiguity from #1635.
  - empty/missing local repo resolution.
- Refreshed `docs/testing/coverage-gap-analysis.md`.

## Evidence

- `rtk bun test test/wake-resolve-pure.test.ts test/wake-resolve.test.ts` → 15 pass / 0 fail in ~0.15s.
- `rtk bun run test:coverage` → 1426 pass / 6 skip / 0 fail in ~22s; overall tracked-source lines 13.4% (6834/50874), functions 49.3% (668/1355).
- `wake-resolve-impl.ts` line coverage moved from 14.1% to 28.7% in the generated report.
- `rtk bun run build` → success.

## Release

No release-alpha cut. No main/beta work. PR targets `alpha` only.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
