### PR TITLE
test(scout): cover pure discovery helpers

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,13 +1,13 @@
 # Coverage gap analysis
 
-Generated: 2026-05-16T18:21:19.718Z
+Generated: 2026-05-16T18:27:35.608Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **13.4%** (6834/50874)
-Overall function coverage: **49.3%** (668/1355)
+Overall line coverage: **13.6%** (6937/50862)
+Overall function coverage: **50.9%** (690/1356)
 
 ## Module summary
 
@@ -20,7 +20,7 @@ Overall function coverage: **49.3%** (668/1355)
 | other | 174 | 98 | 17.9% (2578/14398) | 53.2% (252/474) | n/a (0/0) |
 | plugin dispatch | 15 | 1 | 46.6% (595/1276) | 67.2% (45/67) | n/a (0/0) |
 | routing/aliases | 4 | 0 | 49.2% (300/610) | 72.7% (32/44) | n/a (0/0) |
-| transport | 28 | 3 | 23.0% (633/2754) | 28.8% (79/274) | n/a (0/0) |
+| transport | 28 | 3 | 26.8% (736/2742) | 36.7% (101/275) | n/a (0/0) |
 | vendor plugins | 245 | 244 | 0.7% (145/21992) | 66.7% (12/18) | n/a (0/0) |
 
 ## Top 20 uncovered files by executable/source line count
@@ -101,6 +101,9 @@ Overall function coverage: **49.3%** (668/1355)
 | transport | `src/core/transport/transport.ts` | 100.0% | 96.4% |
 | transport | `src/transports/hub-config.ts` | 90.0% | 100.0% |
 | transport | `src/transports/hub.ts` | 100.0% | 100.0% |
+| transport | `src/transports/scout-pair-proof.ts` | 100.0% | 100.0% |
+| transport | `src/transports/scout-protocol.ts` | 100.0% | 100.0% |
+| transport | `src/transports/scout-state.ts` | 100.0% | 100.0% |
 | transport | `src/transports/zenoh-scout.ts` | 90.3% | 66.7% |
 
 ## Critical files below the 80% line target (next queue)

--- a/test/scout-pair-proof.test.ts
+++ b/test/scout-pair-proof.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { signAutoPairProof, verifyAutoPairProof, type AutoPairIdentity } from "../src/transports/scout-pair-proof";
+
+const identity: AutoPairIdentity = {
+  node: "m5",
+  oracle: "mawjs",
+  url: "http://m5.local:3456",
+  pubkey: "pub-abc",
+};
+
+describe("scout auto-pair proof", () => {
+  test("signs stable HMAC proofs over canonical identity fields", () => {
+    const proof = signAutoPairProof(identity, "token-a");
+    expect(proof).toMatch(/^[0-9a-f]{64}$/);
+    expect(signAutoPairProof({ ...identity }, "token-a")).toBe(proof);
+    expect(signAutoPairProof({ ...identity, node: "other" }, "token-a")).not.toBe(proof);
+  });
+
+  test("verifies valid proofs and rejects wrong token, identity, length, and hex", () => {
+    const proof = signAutoPairProof(identity, "token-a");
+    expect(verifyAutoPairProof(identity, "token-a", proof)).toBe(true);
+    expect(verifyAutoPairProof(identity, "token-b", proof)).toBe(false);
+    expect(verifyAutoPairProof({ ...identity, pubkey: "pub-other" }, "token-a", proof)).toBe(false);
+    expect(verifyAutoPairProof(identity, "token-a", proof.slice(2))).toBe(false);
+    expect(verifyAutoPairProof(identity, "token-a", "z".repeat(64))).toBe(false);
+  });
+});

--- a/test/scout-protocol.test.ts
+++ b/test/scout-protocol.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import {
+  generateZid,
+  greaterZid,
+  makeHello,
+  makeScout,
+  parseMessage,
+  MULTICAST_ADDR,
+  MULTICAST_PORT,
+  SCOUT_VERSION,
+} from "../src/transports/scout-protocol";
+
+describe("scout-protocol pure helpers", () => {
+  test("generateZid returns unique 16-byte hex ids", () => {
+    const ids = new Set(Array.from({ length: 20 }, () => generateZid()));
+    expect(ids.size).toBe(20);
+    for (const zid of ids) expect(zid).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  test("greaterZid elects exactly one initiator", () => {
+    expect(greaterZid("ff", "00")).toBe(true);
+    expect(greaterZid("00", "ff")).toBe(false);
+    expect(greaterZid("abc", "abc")).toBe(false);
+    const a = generateZid();
+    const b = generateZid();
+    expect(greaterZid(a, b) !== greaterZid(b, a)).toBe(true);
+  });
+
+  test("makeScout and makeHello produce versioned protocol messages", () => {
+    const zid = generateZid();
+    const scout = makeScout(zid, "hub");
+    expect(scout).toMatchObject({ type: "maw-scout", version: SCOUT_VERSION, zid, whatAmI: "hub" });
+    expect(scout.ts).toBeGreaterThan(0);
+
+    const hello = makeHello({ zid, node: "m5", oracle: "mawjs", locators: ["http://m5:3456"] });
+    expect(hello).toMatchObject({
+      type: "maw-hello",
+      version: SCOUT_VERSION,
+      zid,
+      node: "m5",
+      oracle: "mawjs",
+      capabilities: ["pair", "feed", "send"],
+      oracles: [],
+      whatAmI: "oracle",
+    });
+  });
+
+  test("makeHello preserves explicit capabilities, oracles, and whatAmI", () => {
+    const hello = makeHello({
+      zid: "01",
+      node: "bridge-node",
+      oracle: "bridge",
+      locators: ["ws://bridge:10000"],
+      capabilities: ["pair"],
+      oracles: ["mawjs-oracle"],
+      whatAmI: "bridge",
+    });
+    expect(hello.capabilities).toEqual(["pair"]);
+    expect(hello.oracles).toEqual(["mawjs-oracle"]);
+    expect(hello.whatAmI).toBe("bridge");
+  });
+
+  test("parseMessage accepts scout, hello, and legacy announce messages", () => {
+    const scout = makeScout(generateZid());
+    const hello = makeHello({ zid: generateZid(), node: "n", oracle: "o", locators: [] });
+    const announce = { type: "maw-announce", node: "old", port: 3456, oracles: [], ts: Date.now() };
+    expect(parseMessage(Buffer.from(JSON.stringify(scout)))?.type).toBe("maw-scout");
+    expect(parseMessage(Buffer.from(JSON.stringify(hello)))?.type).toBe("maw-hello");
+    expect(parseMessage(Buffer.from(JSON.stringify(announce)))?.type).toBe("maw-announce");
+  });
+
+  test("parseMessage rejects invalid JSON and unknown message types", () => {
+    expect(parseMessage(Buffer.from("not json"))).toBeNull();
+    expect(parseMessage(Buffer.from(""))).toBeNull();
+    expect(parseMessage(Buffer.from(JSON.stringify({ type: "unknown" })))).toBeNull();
+  });
+
+  test("scout multicast constants stay stable", () => {
+    expect(MULTICAST_ADDR).toBe("224.0.0.224");
+    expect(MULTICAST_PORT).toBe(31746);
+  });
+});

--- a/test/scout-state.test.ts
+++ b/test/scout-state.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { makeHello } from "../src/transports/scout-protocol";
+import { PEER_STALE_MS, SCOUT_INITIAL_MS, SCOUT_MAX_MS, ScoutState } from "../src/transports/scout-state";
+
+describe("scout-state pure state machine", () => {
+  const localZid = "ff" + "0".repeat(30);
+  let state: ScoutState;
+
+  beforeEach(() => {
+    state = new ScoutState(localZid);
+  });
+
+  test("backoff advances, caps, and resets", () => {
+    expect(state.backoffMs).toBe(SCOUT_INITIAL_MS);
+    expect(state.advanceBackoff()).toBe(1000);
+    expect(state.backoffMs).toBe(2000);
+    for (let i = 0; i < 10; i++) state.advanceBackoff();
+    expect(state.backoffMs).toBe(SCOUT_MAX_MS);
+    state.resetBackoff();
+    expect(state.backoffMs).toBe(SCOUT_INITIAL_MS);
+  });
+
+  test("handleHello tracks new peers and ignores self", () => {
+    const self = state.handleHello(makeHello({ zid: localZid, node: "self", oracle: "self", locators: [] }), "127.0.0.1");
+    expect(self).toEqual({ isNew: false, shouldPair: false });
+    expect(state.discoveredPeers.size).toBe(0);
+
+    const hello = makeHello({ zid: "00" + "0".repeat(30), node: "mba", oracle: "neo", locators: ["http://mba:3456"] });
+    const first = state.handleHello(hello, "10.0.0.2");
+    const second = state.handleHello(hello, "10.0.0.2");
+    expect(first.isNew).toBe(true);
+    expect(second.isNew).toBe(false);
+    expect(state.findPeerByNode("mba")?.host).toBe("10.0.0.2");
+  });
+
+  test("GreaterZid pairing policy only pairs when local wins and peer can pair", () => {
+    const canPair = state.handleHello(makeHello({
+      zid: "00" + "0".repeat(30),
+      node: "low",
+      oracle: "neo",
+      locators: [],
+      capabilities: ["pair"],
+    }), "10.0.0.1");
+    expect(canPair.shouldPair).toBe(true);
+
+    const lowState = new ScoutState("00" + "0".repeat(30));
+    const remoteWins = lowState.handleHello(makeHello({
+      zid: "ff" + "0".repeat(30),
+      node: "high",
+      oracle: "neo",
+      locators: [],
+      capabilities: ["pair"],
+    }), "10.0.0.2");
+    expect(remoteWins.shouldPair).toBe(false);
+
+    const noCapability = state.handleHello(makeHello({ zid: "01", node: "feed", oracle: "neo", locators: [], capabilities: ["feed"] }), "10.0.0.3");
+    expect(noCapability.shouldPair).toBe(false);
+  });
+
+  test("pending and paired peers suppress duplicate pairing", () => {
+    const zid = "02";
+    state.markPending(zid);
+    const pending = state.handleHello(makeHello({ zid, node: "pending", oracle: "neo", locators: [], capabilities: ["pair"] }), "10.0.0.4");
+    expect(pending.shouldPair).toBe(false);
+
+    state.markPaired(zid);
+    expect(state.pendingConnections.has(zid)).toBe(false);
+    expect(state.findPeerByZid(zid)?.paired).toBe(true);
+
+    const again = state.handleHello(makeHello({ zid, node: "pending", oracle: "neo", locators: [], capabilities: ["pair"] }), "10.0.0.4");
+    expect(again.shouldPair).toBe(false);
+  });
+
+  test("peer lookup helpers match node and oracle membership", () => {
+    state.handleHello(makeHello({
+      zid: "03",
+      node: "white",
+      oracle: "mawjs",
+      locators: [],
+      oracles: ["mawjs-oracle", "neo-oracle"],
+    }), "10.0.0.5");
+    expect(state.findPeerByNode("white")).toBeDefined();
+    expect(state.findPeerByOracle("neo")).toBeDefined();
+    expect(state.findPeerByZid("03")?.node).toBe("white");
+    expect(state.findPeerByOracle("ghost")).toBeUndefined();
+
+    state.markExistingPeerPaired("white");
+    expect(state.findPeerByNode("white")?.paired).toBe(true);
+    state.clearPending("missing");
+  });
+
+  test("pruneStale removes old peers and pending state", () => {
+    const zid = "04";
+    state.handleHello(makeHello({ zid, node: "old", oracle: "old", locators: [] }), "10.0.0.6");
+    state.markPending(zid);
+    state.discoveredPeers.get(zid)!.lastSeen = Date.now() - PEER_STALE_MS - 1;
+    expect(state.pruneStale()).toEqual(["old"]);
+    expect(state.findPeerByZid(zid)).toBeUndefined();
+    expect(state.pendingConnections.has(zid)).toBe(false);
+
+    state.handleHello(makeHello({ zid: "05", node: "fresh", oracle: "fresh", locators: [] }), "10.0.0.7");
+    expect(state.pruneStale()).toEqual([]);
+    expect(state.findPeerByNode("fresh")).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds pure default-suite tests for scout protocol message construction/parsing.
- Covers the scout discovery state machine: backoff, duplicate-pair suppression, lookup helpers, and stale pruning.
- Covers scout auto-pair HMAC proof signing/verification.
- Updates the coverage gap report after the new tests.

## Verification

- `rtk bun test test/scout-protocol.test.ts test/scout-state.test.ts test/scout-pair-proof.test.ts` → 15 pass / 0 fail
- `rtk bun run test:coverage` → 1441 pass / 6 skip / 0 fail; overall lines 13.6% (6937/50862), functions 50.9% (690/1356)
- `rtk bun run build` → success

## Notes

- Alpha-only coverage PR for #1637.
- No release-alpha PR/cut; no main or beta branch work.

Closes part of #1637.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
