### PR TITLE
test(lib): cover pure message and pair-code helpers

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,13 +1,13 @@
 # Coverage gap analysis
 
-Generated: 2026-05-16T18:27:35.608Z
+Generated: 2026-05-16T18:33:52.372Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **13.6%** (6937/50862)
-Overall function coverage: **50.9%** (690/1356)
+Overall line coverage: **13.8%** (7021/50866)
+Overall function coverage: **52.0%** (705/1356)
 
 ## Module summary
 
@@ -17,7 +17,7 @@ Overall function coverage: **50.9%** (690/1356)
 | config/runtime | 19 | 2 | 43.3% (510/1179) | 40.2% (35/87) | n/a (0/0) |
 | fleet | 17 | 1 | 20.7% (227/1096) | 53.4% (31/58) | n/a (0/0) |
 | matcher | 2 | 0 | 100.0% (41/41) | 100.0% (8/8) | n/a (0/0) |
-| other | 174 | 98 | 17.9% (2578/14398) | 53.2% (252/474) | n/a (0/0) |
+| other | 174 | 98 | 18.5% (2662/14402) | 56.3% (267/474) | n/a (0/0) |
 | plugin dispatch | 15 | 1 | 46.6% (595/1276) | 67.2% (45/67) | n/a (0/0) |
 | routing/aliases | 4 | 0 | 49.2% (300/610) | 72.7% (32/44) | n/a (0/0) |
 | transport | 28 | 3 | 26.8% (736/2742) | 36.7% (101/275) | n/a (0/0) |

--- a/test/message-events.test.ts
+++ b/test/message-events.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildMessageLifecycleData,
+  buildMessageLifecycleFeedEvent,
+  isMessageLifecycleData,
+  type MessageLifecycleInput,
+} from "../src/lib/message-events";
+
+const baseInput: MessageLifecycleInput = {
+  id: "msg-1",
+  ts: new Date("2026-05-16T01:02:03.000Z"),
+  direction: "outbound",
+  state: "queued",
+  channel: "hey",
+  route: "peer",
+  from: "m5:mawjs-codex",
+  to: "m5:mawjs-oracle",
+  target: "54-mawjs:mawjs-oracle.0",
+  peerUrl: "http://m5.local:3456",
+  text: "hello",
+  signed: true,
+};
+
+describe("message lifecycle event builders", () => {
+  test("buildMessageLifecycleData fills stable fields and optional metadata", () => {
+    const data = buildMessageLifecycleData(baseInput);
+    expect(data).toEqual({
+      id: "msg-1",
+      ts: "2026-05-16T01:02:03.000Z",
+      direction: "outbound",
+      state: "queued",
+      channel: "hey",
+      route: "peer",
+      from: "m5:mawjs-codex",
+      to: "m5:mawjs-oracle",
+      target: "54-mawjs:mawjs-oracle.0",
+      peerUrl: "http://m5.local:3456",
+      text: "hello",
+      signed: true,
+    });
+  });
+
+  test("buildMessageLifecycleData normalizes timestamps and truncates long fields", () => {
+    const longText = "x".repeat(2_010);
+    const longError = "e".repeat(1_010);
+    const longLastLine = "l".repeat(1_010);
+    const data = buildMessageLifecycleData({
+      ...baseInput,
+      id: undefined,
+      ts: 1_700_000_000_000,
+      text: longText,
+      error: longError,
+      lastLine: longLastLine,
+      signed: false,
+    });
+
+    expect(data.id).toBeTruthy();
+    expect(data.ts).toBe("2023-11-14T22:13:20.000Z");
+    expect(data.text).toHaveLength(2_000);
+    expect(data.text.endsWith("…")).toBe(true);
+    expect(data.error).toHaveLength(1_000);
+    expect(data.error?.endsWith("…")).toBe(true);
+    expect(data.lastLine).toHaveLength(1_000);
+    expect(data.lastLine?.endsWith("…")).toBe(true);
+    expect(data.signed).toBe(false);
+  });
+
+  test("buildMessageLifecycleFeedEvent maps direction/state to feed metadata", () => {
+    const outbound = buildMessageLifecycleFeedEvent(baseInput);
+    expect(outbound.event).toBe("MessageSend");
+    expect(outbound.host).toBe("m5");
+    expect(outbound.oracle).toBe("mawjs-codex");
+    expect(outbound.sessionId).toBe("54-mawjs:mawjs-oracle.0");
+    expect(outbound.message).toContain("outbound/queued");
+    expect(outbound.message).toContain("m5:mawjs-codex → m5:mawjs-oracle");
+
+    const inbound = buildMessageLifecycleFeedEvent({ ...baseInput, direction: "inbound", state: "delivered", to: "white:neo" });
+    expect(inbound.event).toBe("MessageDeliver");
+    expect(inbound.host).toBe("white");
+    expect(inbound.oracle).toBe("neo");
+
+    const failed = buildMessageLifecycleFeedEvent({ ...baseInput, state: "failed", error: "boom" });
+    expect(failed.event).toBe("MessageFail");
+    expect(failed.message).toContain("error=boom");
+  });
+
+  test("buildMessageLifecycleData defaults blank timestamps to now", () => {
+    const before = Date.now();
+    const data = buildMessageLifecycleData({ ...baseInput, ts: "" });
+    const after = Date.now();
+    expect(new Date(data.ts).getTime()).toBeGreaterThanOrEqual(before);
+    expect(new Date(data.ts).getTime()).toBeLessThanOrEqual(after + 5);
+  });
+
+  test("buildMessageLifecycleFeedEvent handles local identities and invalid timestamp fallback", () => {
+    const before = Date.now();
+    const event = buildMessageLifecycleFeedEvent({
+      ...baseInput,
+      ts: "not-a-date",
+      from: "solo-oracle",
+      to: "receiver",
+      target: undefined,
+      text: "short text",
+    });
+    const after = Date.now();
+    expect(event.host).toBe("local");
+    expect(event.oracle).toBe("solo-oracle");
+    expect(event.sessionId).toBe("");
+    expect(event.ts).toBeGreaterThanOrEqual(before);
+    expect(event.ts).toBeLessThanOrEqual(after + 5);
+  });
+
+  test("isMessageLifecycleData accepts complete payloads and rejects malformed values", () => {
+    const data = buildMessageLifecycleData(baseInput);
+    expect(isMessageLifecycleData(data)).toBe(true);
+    expect(isMessageLifecycleData(null)).toBe(false);
+    expect(isMessageLifecycleData("nope")).toBe(false);
+    expect(isMessageLifecycleData({ ...data, id: 123 })).toBe(false);
+    expect(isMessageLifecycleData({ ...data, direction: "sideways" })).toBe(false);
+    expect(isMessageLifecycleData({ ...data, state: "lost" })).toBe(false);
+    expect(isMessageLifecycleData({ ...data, channel: 7 })).toBe(false);
+    expect(isMessageLifecycleData({ ...data, route: 7 })).toBe(false);
+    expect(isMessageLifecycleData({ ...data, from: 7 })).toBe(false);
+    expect(isMessageLifecycleData({ ...data, to: 7 })).toBe(false);
+    expect(isMessageLifecycleData({ ...data, text: 7 })).toBe(false);
+  });
+});

--- a/test/pair-codes.test.ts
+++ b/test/pair-codes.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+  _inject,
+  _resetStore,
+  ALPHABET,
+  consume,
+  generateCode,
+  isValidShape,
+  lookup,
+  normalize,
+  pretty,
+  redact,
+  register,
+  type PairEntry,
+} from "../src/lib/pair-codes";
+
+describe("pair-codes pure helpers", () => {
+  beforeEach(() => {
+    _resetStore();
+  });
+
+  test("normalizes, formats, and redacts operator-entered codes", () => {
+    expect(normalize("abc-def\n")).toBe("ABCDEF");
+    expect(pretty("abc def")).toBe("ABC-DEF");
+    expect(pretty("ab")).toBe("AB");
+    expect(redact("abc-def")).toBe("ABC-***");
+    expect(redact("ab")).toBe("***");
+  });
+
+  test("validates the reduced six-character alphabet", () => {
+    expect(isValidShape("ABC-234")).toBe(true);
+    expect(isValidShape("ABC23")).toBe(false);
+    expect(isValidShape("ABC2345")).toBe(false);
+    expect(isValidShape("ABC10O")).toBe(false);
+    for (const ch of ALPHABET) expect(isValidShape(`AAA${ch}22`)).toBe(true);
+  });
+
+  test("generates six-character codes from the allowed alphabet", () => {
+    for (let i = 0; i < 20; i++) {
+      const code = generateCode();
+      expect(code).toHaveLength(6);
+      expect(isValidShape(code)).toBe(true);
+    }
+  });
+
+  test("registers, looks up, consumes, and rejects reused codes", () => {
+    const entry = register("abc-def", 60_000);
+    expect(entry.code).toBe("ABCDEF");
+    expect(entry.consumed).toBe(false);
+    expect(entry.expiresAt).toBeGreaterThanOrEqual(entry.createdAt);
+
+    const found = lookup("ABC DEF");
+    expect(found.ok).toBe(true);
+    if (found.ok) expect(found.entry).toBe(entry);
+
+    const consumed = consume("abcdef");
+    expect(consumed.ok).toBe(true);
+    expect(entry.consumed).toBe(true);
+    expect(lookup("abcdef")).toEqual({ ok: false, reason: "consumed" });
+    expect(consume("abcdef")).toEqual({ ok: false, reason: "consumed" });
+  });
+
+  test("reports missing and expired pair codes", () => {
+    expect(lookup("missing")).toEqual({ ok: false, reason: "not_found" });
+
+    const expired: PairEntry = {
+      code: "ABCDEF",
+      createdAt: Date.now() - 10_000,
+      expiresAt: Date.now() - 1,
+      consumed: false,
+    };
+    _inject(expired);
+    expect(lookup("abc-def")).toEqual({ ok: false, reason: "expired" });
+    expect(consume("abc-def")).toEqual({ ok: false, reason: "expired" });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds default-suite unit tests for `src/lib/pair-codes.ts`.
- Adds default-suite unit tests for `src/lib/message-events.ts`.
- Updates the coverage gap report after the new tests.

## Verification

- `rtk bun test test/pair-codes.test.ts test/message-events.test.ts` → 11 pass / 0 fail
- `rtk bun run test:coverage` → 1452 pass / 6 skip / 0 fail; overall lines 13.8% (7021/50866), functions 52.0% (705/1356)
- `rtk bun run build` → success

## Coverage result

- `src/lib/pair-codes.ts` → 38/38 lines, 10/10 functions
- `src/lib/message-events.ts` → 71/71 lines, 8/8 functions

## Notes

- Alpha-only coverage PR for #1637.
- No release-alpha PR/cut; no main or beta branch work.

Closes part of #1637.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
