### PR TITLE
test(plugin): cover dependency planning helpers

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,13 +1,13 @@
 # Coverage gap analysis
 
-Generated: 2026-05-16T18:33:52.372Z
+Generated: 2026-05-16T18:38:35.679Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **13.8%** (7021/50866)
-Overall function coverage: **52.0%** (705/1356)
+Overall line coverage: **13.8%** (7043/50864)
+Overall function coverage: **52.3%** (710/1358)
 
 ## Module summary
 
@@ -18,7 +18,7 @@ Overall function coverage: **52.0%** (705/1356)
 | fleet | 17 | 1 | 20.7% (227/1096) | 53.4% (31/58) | n/a (0/0) |
 | matcher | 2 | 0 | 100.0% (41/41) | 100.0% (8/8) | n/a (0/0) |
 | other | 174 | 98 | 18.5% (2662/14402) | 56.3% (267/474) | n/a (0/0) |
-| plugin dispatch | 15 | 1 | 46.6% (595/1276) | 67.2% (45/67) | n/a (0/0) |
+| plugin dispatch | 15 | 1 | 48.4% (617/1274) | 72.5% (50/69) | n/a (0/0) |
 | routing/aliases | 4 | 0 | 49.2% (300/610) | 72.7% (32/44) | n/a (0/0) |
 | transport | 28 | 3 | 26.8% (736/2742) | 36.7% (101/275) | n/a (0/0) |
 | vendor plugins | 245 | 244 | 0.7% (145/21992) | 66.7% (12/18) | n/a (0/0) |
@@ -90,6 +90,7 @@ Overall function coverage: **52.0%** (705/1356)
 | matcher | `src/core/matcher/normalize-target.ts` | 100.0% | 100.0% |
 | matcher | `src/core/matcher/resolve-target.ts` | 100.0% | 100.0% |
 | plugin dispatch | `src/plugin/default-active.ts` | 100.0% | 100.0% |
+| plugin dispatch | `src/plugin/dependencies.ts` | 100.0% | 100.0% |
 | plugin dispatch | `src/plugin/manifest-constants.ts` | 100.0% | 100.0% |
 | plugin dispatch | `src/plugin/manifest-load.ts` | 100.0% | 100.0% |
 | plugin dispatch | `src/plugin/manifest-parse.ts` | 96.3% | 100.0% |

--- a/test/plugin-dependencies.test.ts
+++ b/test/plugin-dependencies.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { dependencyStatus, enablePlanFor, pluginDependencyNames } from "../src/plugin/dependencies";
+import type { LoadedPlugin, PluginManifest } from "../src/plugin/types";
+
+function plugin(name: string, deps: string[] = [], disabled = false): LoadedPlugin {
+  const manifest: PluginManifest = {
+    name,
+    version: "1.0.0",
+    sdk: "^1.0.0",
+    entry: "index.ts",
+    ...(deps.length ? { dependencies: { plugins: deps } } : {}),
+  };
+  return {
+    manifest,
+    dir: `/tmp/${name}`,
+    wasmPath: "",
+    entryPath: `/tmp/${name}/index.ts`,
+    kind: "ts",
+    ...(disabled ? { disabled: true } : {}),
+  };
+}
+
+describe("plugin dependency helpers", () => {
+  test("pluginDependencyNames returns declared dependencies or an empty list", () => {
+    expect(pluginDependencyNames(plugin("plain"))).toEqual([]);
+    expect(pluginDependencyNames(plugin("consumer", ["trace", "dig"]))).toEqual(["trace", "dig"]);
+  });
+
+  test("dependencyStatus reports recursive disabled and missing dependencies", () => {
+    const target = plugin("target", ["trace", "ghost"]);
+    const trace = plugin("trace", ["dig"], true);
+    const dig = plugin("dig", [], true);
+
+    expect(dependencyStatus(target, [target, trace, dig])).toEqual({
+      disabled: ["dig", "trace"],
+      missing: ["ghost"],
+    });
+  });
+
+  test("dependencyStatus de-duplicates shared dependencies and survives cycles", () => {
+    const target = plugin("target", ["a", "b", "missing", "missing"]);
+    const a = plugin("a", ["shared", "b"], true);
+    const b = plugin("b", ["a", "shared"], true);
+    const shared = plugin("shared", [], true);
+
+    expect(dependencyStatus(target, [target, a, b, shared])).toEqual({
+      disabled: ["shared", "b", "a"],
+      missing: ["missing"],
+    });
+  });
+
+  test("enablePlanFor returns disabled dependencies and optionally the target plugin", () => {
+    const target = plugin("target", ["trace", "dig"], true);
+    const trace = plugin("trace", [], true);
+    const dig = plugin("dig", [], false);
+
+    expect(enablePlanFor(target, [target, trace, dig], false)).toEqual(["trace"]);
+    expect(enablePlanFor(target, [target, trace, dig], true)).toEqual(["trace", "target"]);
+  });
+
+  test("enablePlanFor keeps a stable unique plan when self also appears as a dependency", () => {
+    const target = plugin("target", ["target"], true);
+    expect(enablePlanFor(target, [target], true)).toEqual(["target"]);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds default-suite unit tests for plugin dependency helpers.
- Covers recursive disabled/missing dependency detection, cycle de-duplication, and enable-plan generation.
- Updates the coverage gap report after the new tests.

## Verification

- `rtk bun test test/plugin-dependencies.test.ts` → 5 pass / 0 fail
- `rtk bun run test:coverage` → 1457 pass / 6 skip / 0 fail; overall lines 13.8% (7043/50864), functions 52.3% (710/1358)
- `rtk bun run build` → success

## Coverage result

- `src/plugin/dependencies.ts` → 100.0% lines / 100.0% functions

## Notes

- Alpha-only coverage PR for #1637.
- No release-alpha PR/cut; no main or beta branch work.

Closes part of #1637.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
