### PR TITLE
test(plugin): cover registry semver helpers

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,13 +1,13 @@
 # Coverage gap analysis
 
-Generated: 2026-05-16T18:38:35.679Z
+Generated: 2026-05-16T18:43:12.255Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **13.8%** (7043/50864)
-Overall function coverage: **52.3%** (710/1358)
+Overall line coverage: **13.9%** (7070/50865)
+Overall function coverage: **52.4%** (711/1358)
 
 ## Module summary
 
@@ -18,7 +18,7 @@ Overall function coverage: **52.3%** (710/1358)
 | fleet | 17 | 1 | 20.7% (227/1096) | 53.4% (31/58) | n/a (0/0) |
 | matcher | 2 | 0 | 100.0% (41/41) | 100.0% (8/8) | n/a (0/0) |
 | other | 174 | 98 | 18.5% (2662/14402) | 56.3% (267/474) | n/a (0/0) |
-| plugin dispatch | 15 | 1 | 48.4% (617/1274) | 72.5% (50/69) | n/a (0/0) |
+| plugin dispatch | 15 | 1 | 50.5% (644/1275) | 73.9% (51/69) | n/a (0/0) |
 | routing/aliases | 4 | 0 | 49.2% (300/610) | 72.7% (32/44) | n/a (0/0) |
 | transport | 28 | 3 | 26.8% (736/2742) | 36.7% (101/275) | n/a (0/0) |
 | vendor plugins | 245 | 244 | 0.7% (145/21992) | 66.7% (12/18) | n/a (0/0) |
@@ -96,6 +96,7 @@ Overall function coverage: **52.3%** (710/1358)
 | plugin dispatch | `src/plugin/manifest-parse.ts` | 96.3% | 100.0% |
 | plugin dispatch | `src/plugin/manifest-validate.ts` | 89.7% | 100.0% |
 | plugin dispatch | `src/plugin/manifest.ts` | 100.0% | 100.0% |
+| plugin dispatch | `src/plugin/registry-semver.ts` | 100.0% | 100.0% |
 | plugin dispatch | `src/plugin/tier.ts` | 100.0% | 100.0% |
 | routing/aliases | `src/core/routing.ts` | 89.1% | 91.7% |
 | transport | `src/core/transport/tmux.ts` | 100.0% | 100.0% |

--- a/test/registry-semver.test.ts
+++ b/test/registry-semver.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { formatSdkMismatchError, satisfies } from "../src/plugin/registry-semver";
+
+describe("plugin registry semver helpers", () => {
+  test("rejects invalid versions and invalid ranges", () => {
+    expect(satisfies("not-a-version", "*")).toBe(false);
+    expect(satisfies("1.2", "*")).toBe(false);
+    expect(satisfies("1.2.3", "garbage")).toBe(false);
+    expect(satisfies("1.2.3", ">=")).toBe(false);
+    expect(satisfies("1.2.3", "^bad")).toBe(false);
+  });
+
+  test("supports wildcard, whitespace, exact matches, prerelease, and build metadata", () => {
+    expect(satisfies("0.0.0", "*")).toBe(true);
+    expect(satisfies(" 1.2.3 ", " 1.2.3 ")).toBe(true);
+    expect(satisfies("1.2.3-alpha.1", "1.2.3")).toBe(true);
+    expect(satisfies("1.2.3+build.7", "1.2.3")).toBe(true);
+    expect(satisfies("1.2.4", "1.2.3")).toBe(false);
+  });
+
+  test.each([
+    ["1.2.3", "^1.2.3", true],
+    ["1.3.0", "^1.2.3", true],
+    ["2.0.0", "^1.2.3", false],
+    ["1.2.2", "^1.2.3", false],
+    ["0.2.4", "^0.2.3", true],
+    ["0.3.0", "^0.2.3", false],
+    ["0.2.2", "^0.2.3", false],
+    ["1.2.3", "^0.2.3", false],
+    ["0.0.5", "^0.0.5", true],
+    ["0.0.6", "^0.0.5", false],
+    ["0.1.5", "^0.0.5", false],
+  ])("caret range %s satisfies %s => %s", (version, range, expected) => {
+    expect(satisfies(version, range)).toBe(expected);
+  });
+
+  test.each([
+    ["1.2.3", "~1.2.3", true],
+    ["1.2.99", "~1.2.3", true],
+    ["1.2.2", "~1.2.3", false],
+    ["1.3.0", "~1.2.3", false],
+    ["2.2.3", "~1.2.3", false],
+  ])("tilde range %s satisfies %s => %s", (version, range, expected) => {
+    expect(satisfies(version, range)).toBe(expected);
+  });
+
+  test.each([
+    ["1.2.3", ">=1.2.3", true],
+    ["2.0.0", ">=1.2.3", true],
+    ["1.2.2", ">=1.2.3", false],
+    ["1.2.3", "<=1.2.3", true],
+    ["0.9.9", "<=1.2.3", true],
+    ["1.2.4", "<=1.2.3", false],
+    ["1.2.4", ">1.2.3", true],
+    ["1.2.3", ">1.2.3", false],
+    ["1.2.2", ">1.2.3", false],
+    ["1.2.2", "<1.2.3", true],
+    ["1.2.3", "<1.2.3", false],
+    ["1.2.4", "<1.2.3", false],
+    ["2.0.0", ">1.99.99", true],
+    ["1.3.0", ">1.2.99", true],
+  ])("comparison range %s satisfies %s => %s", (version, range, expected) => {
+    expect(satisfies(version, range)).toBe(expected);
+  });
+
+  test("formatSdkMismatchError renders the canonical multi-line fix text", () => {
+    const out = formatSdkMismatchError("cool-plug", "^2.0.0", "1.9.3");
+    const lines = out.split("\n");
+    expect(lines).toHaveLength(7);
+    expect(lines[0]).toContain("\x1b[31m✗\x1b[0m plugin 'cool-plug' requires maw SDK ^2.0.0");
+    expect(lines[1]).toContain("your maw: 1.9.3  (SDK 1.9.3)");
+    expect(lines[2]).toBe("");
+    expect(lines[3]).toContain("fix:");
+    expect(out).toContain("maw update");
+    expect(out).toContain("maw plugin install cool-plug@<old-version>");
+    expect(out).toContain('edit plugin.json "sdk"');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds default-suite unit tests for plugin registry semver helpers.
- Covers invalid input handling, wildcard/exact ranges, caret and tilde ranges, comparison operators, prerelease/build metadata stripping, and SDK mismatch error text.
- Updates the coverage gap report after the new tests.

## Verification

- `rtk bun test test/registry-semver.test.ts` → 33 pass / 0 fail
- `rtk bun run test:coverage` → 1490 pass / 6 skip / 0 fail; overall lines 13.9% (7070/50865), functions 52.4% (711/1358)
- `rtk bun run build` → success

## Coverage result

- `src/plugin/registry-semver.ts` → 100.0% lines / 100.0% functions

## Notes

- Alpha-only coverage PR for #1637.
- No release-alpha PR/cut; no main or beta branch work.

Closes part of #1637.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
