### PR TITLE
test(core): cover tiny helpers and transport stubs

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,13 +1,13 @@
 # Coverage gap analysis
 
-Generated: 2026-05-16T18:43:12.255Z
+Generated: 2026-05-16T18:48:20.494Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **13.9%** (7070/50865)
-Overall function coverage: **52.4%** (711/1358)
+Overall line coverage: **13.9%** (7090/50857)
+Overall function coverage: **53.3%** (724/1359)
 
 ## Module summary
 
@@ -17,10 +17,10 @@ Overall function coverage: **52.4%** (711/1358)
 | config/runtime | 19 | 2 | 43.3% (510/1179) | 40.2% (35/87) | n/a (0/0) |
 | fleet | 17 | 1 | 20.7% (227/1096) | 53.4% (31/58) | n/a (0/0) |
 | matcher | 2 | 0 | 100.0% (41/41) | 100.0% (8/8) | n/a (0/0) |
-| other | 174 | 98 | 18.5% (2662/14402) | 56.3% (267/474) | n/a (0/0) |
+| other | 174 | 98 | 18.6% (2672/14403) | 56.8% (270/475) | n/a (0/0) |
 | plugin dispatch | 15 | 1 | 50.5% (644/1275) | 73.9% (51/69) | n/a (0/0) |
 | routing/aliases | 4 | 0 | 49.2% (300/610) | 72.7% (32/44) | n/a (0/0) |
-| transport | 28 | 3 | 26.8% (736/2742) | 36.7% (101/275) | n/a (0/0) |
+| transport | 28 | 3 | 27.3% (746/2733) | 40.4% (111/275) | n/a (0/0) |
 | vendor plugins | 245 | 244 | 0.7% (145/21992) | 66.7% (12/18) | n/a (0/0) |
 
 ## Top 20 uncovered files by executable/source line count
@@ -103,6 +103,7 @@ Overall function coverage: **52.4%** (711/1358)
 | transport | `src/core/transport/transport.ts` | 100.0% | 96.4% |
 | transport | `src/transports/hub-config.ts` | 90.0% | 100.0% |
 | transport | `src/transports/hub.ts` | 100.0% | 100.0% |
+| transport | `src/transports/lora.ts` | 100.0% | 90.9% |
 | transport | `src/transports/scout-pair-proof.ts` | 100.0% | 100.0% |
 | transport | `src/transports/scout-protocol.ts` | 100.0% | 100.0% |
 | transport | `src/transports/scout-state.ts` | 100.0% | 100.0% |

--- a/test/tiny-core-transport.test.ts
+++ b/test/tiny-core-transport.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { processMirror } from "../src/lib/process-mirror";
+import { isUserError, UserError } from "../src/core/util/user-error";
+import { LoRaTransport } from "../src/transports/lora";
+import { discoveryTransport } from "../src/transports";
+
+describe("tiny pure core helpers and transport stubs", () => {
+  test("processMirror filters empty lines, normalizes separators, tails, and pads", () => {
+    const raw = [
+      "",
+      "first",
+      "────── decorative ━━━━━━",
+      "   ",
+      "second",
+      "third",
+    ].join("\n");
+
+    expect(processMirror(raw, 2)).toBe("second\nthird");
+    expect(processMirror(raw, 5)).toBe([
+      "",
+      "first",
+      `${"─".repeat(60)} decorative ${"─".repeat(60)}`,
+      "second",
+      "third",
+    ].join("\n"));
+    expect(processMirror("only", 3)).toBe("\n\nonly");
+    expect(processMirror("\n  \n", 2)).toBe("\n\n");
+  });
+
+  test("UserError carries the cross-module brand and guard rejects impostors", () => {
+    const err = new UserError("bad target");
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("UserError");
+    expect(err.message).toBe("bad target");
+    expect(err.isUserError).toBe(true);
+    expect(isUserError(err)).toBe(true);
+    expect(isUserError(new Error("regular"))).toBe(false);
+    expect(isUserError({ isUserError: true })).toBe(false);
+    expect(isUserError(null)).toBe(false);
+  });
+
+  test("LoRa transport stays an inert disconnected future-hardware stub", async () => {
+    const transport = new LoRaTransport();
+    const calls: string[] = [];
+    transport.onMessage(() => calls.push("message"));
+    transport.onPresence(() => calls.push("presence"));
+    transport.onFeed(() => calls.push("feed"));
+
+    expect(transport.name).toBe("lora");
+    expect(transport.connected).toBe(false);
+    await transport.connect();
+    expect(transport.connected).toBe(false);
+    expect(transport.canReach({ oracle: "neo" })).toBe(false);
+    expect(await transport.send({ oracle: "neo" }, "hello")).toBe(false);
+    await transport.publishPresence({ oracle: "neo", host: "m5", status: "ready", timestamp: 1 });
+    await transport.publishFeed({ timestamp: "2026-05-16 00:00:00", oracle: "neo", host: "m5", event: "SessionStart", project: "", sessionId: "", message: "", ts: 1 });
+    await transport.disconnect();
+    expect(transport.connected).toBe(false);
+    expect(calls).toEqual([]);
+  });
+
+  test("discoveryTransport honors configured fallbacks and disabled zenoh-scout plugin", () => {
+    expect(discoveryTransport({})).toBe("scout");
+    expect(discoveryTransport({ discovery: { transport: "scout" } })).toBe("scout");
+    expect(discoveryTransport({ discovery: { transport: "off" } })).toBe("off");
+    expect(discoveryTransport({ discovery: { transport: "zenoh" } })).toBe("zenoh");
+    expect(discoveryTransport({ discovery: { transport: "both" } })).toBe("both");
+    expect(discoveryTransport({ zenoh: { scout: { enabled: true } } })).toBe("both");
+    expect(discoveryTransport({ zenoh: { scout: { enabled: false } } })).toBe("scout");
+    expect(discoveryTransport({ discovery: { transport: "zenoh" }, disabledPlugins: ["zenoh-scout"] })).toBe("off");
+    expect(discoveryTransport({ discovery: { transport: "both" }, disabledPlugins: ["zenoh-scout"] })).toBe("scout");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds default-suite unit tests for small core helpers and transport stubs.
- Covers `processMirror`, `UserError` branding/guard behavior, LoRa's inert future-hardware contract, and `discoveryTransport` fallback selection.
- Updates the coverage gap report after the new tests.

## Verification

- `rtk bun test test/tiny-core-transport.test.ts` → 4 pass / 0 fail
- `rtk bun run test:coverage` → 1494 pass / 6 skip / 0 fail; overall lines 13.9% (7090/50857), functions 53.3% (724/1359)
- `rtk bun run build` → success

## Coverage result

- `src/lib/process-mirror.ts` → 100.0% lines / 100.0% functions
- `src/core/util/user-error.ts` → 7/7 lines, 2/2 functions in LCOV
- `src/transports/lora.ts` → 100.0% lines / 90.9% functions
- transport module functions rose to 40.4%

## Notes

- Alpha-only coverage PR for #1637.
- No release-alpha PR/cut; no main or beta branch work.

Closes part of #1637.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
