### PR TITLE
test(plugin): cover invoke defaults

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,13 +1,13 @@
 # Coverage gap analysis
 
-Generated: 2026-05-16T19:01:47.254Z
+Generated: 2026-05-16T19:07:49.376Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **14.1%** (7192/50852)
-Overall function coverage: **54.1%** (737/1362)
+Overall line coverage: **14.3%** (7265/50800)
+Overall function coverage: **54.0%** (740/1370)
 
 ## Module summary
 
@@ -18,7 +18,7 @@ Overall function coverage: **54.1%** (737/1362)
 | fleet | 17 | 1 | 20.7% (227/1096) | 53.4% (31/58) | n/a (0/0) |
 | matcher | 2 | 0 | 100.0% (41/41) | 100.0% (8/8) | n/a (0/0) |
 | other | 174 | 98 | 18.6% (2672/14403) | 56.8% (270/475) | n/a (0/0) |
-| plugin dispatch | 15 | 1 | 58.7% (746/1270) | 88.9% (64/72) | n/a (0/0) |
+| plugin dispatch | 15 | 1 | 67.2% (819/1218) | 83.8% (67/80) | n/a (0/0) |
 | routing/aliases | 4 | 0 | 49.2% (300/610) | 72.7% (32/44) | n/a (0/0) |
 | transport | 28 | 3 | 27.3% (746/2733) | 40.4% (111/275) | n/a (0/0) |
 | vendor plugins | 245 | 244 | 0.7% (145/21992) | 66.7% (12/18) | n/a (0/0) |
@@ -121,9 +121,9 @@ Overall function coverage: **54.1%** (737/1362)
 | transport | `src/transports/scout.ts` | 248 | 8.5% |
 | cli/dispatch | `src/commands/shared/wake-resolve-impl.ts` | 226 | 28.7% |
 | cli/dispatch | `src/commands/shared/done.ts` | 207 | 0.0% |
-| plugin dispatch | `src/plugin/registry-invoke.ts` | 200 | 2.4% |
 | transport | `src/transports/mdns.ts` | 184 | 7.5% |
 | transport | `src/core/transport/peers.ts` | 176 | 31.3% |
+| fleet | `src/core/fleet/claude-sessions.ts` | 171 | 0.0% |
 
 ## Critical gaps to prioritize
 

--- a/test/00-registry-invoke-default.test.ts
+++ b/test/00-registry-invoke-default.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Default-suite coverage for src/plugin/registry-invoke.ts.
+ *
+ * The 00- prefix is intentional: older default-suite API tests install a
+ * process-global mock for ../src/plugin/registry. Loading the real invoke
+ * module first keeps this focused helper coverage deterministic while the
+ * deeper WASM cases remain isolated under test/isolated/.
+ */
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { invokePlugin } from "../src/plugin/registry-invoke";
+import type { InvokeContext, LoadedPlugin, PluginManifest } from "../src/plugin/types";
+
+const tmp = mkdtempSync(join(tmpdir(), "maw-registry-invoke-default-"));
+let seq = 0;
+
+function writeModule(source: string): string {
+  const path = join(tmp, `plugin-${++seq}-${Date.now()}.mjs`);
+  writeFileSync(path, source);
+  return path;
+}
+
+function tsPlugin(entryPath: string, manifest: Partial<PluginManifest> = {}): LoadedPlugin {
+  return {
+    manifest: {
+      name: manifest.name ?? "plug",
+      version: manifest.version ?? "1.0.0",
+      sdk: manifest.sdk ?? "*",
+      ...manifest,
+    },
+    dir: tmp,
+    entryPath,
+    wasmPath: "",
+    kind: "ts",
+  };
+}
+
+function wasmPlugin(manifest: Partial<PluginManifest> = {}): LoadedPlugin {
+  return {
+    manifest: {
+      name: manifest.name ?? "wasm-plug",
+      version: manifest.version ?? "1.0.0",
+      sdk: manifest.sdk ?? "*",
+      ...manifest,
+    },
+    dir: tmp,
+    wasmPath: join(tmp, "missing.wasm"),
+    kind: "wasm",
+  };
+}
+
+beforeEach(() => {
+  seq += 1;
+});
+
+afterAll(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("invokePlugin universal CLI metadata in the default suite", () => {
+  test("--version reports effective surfaces including default-name TS CLI", async () => {
+    const entry = writeModule(`export default async function handler() { return { ok: true }; }`);
+    const result = await invokePlugin(
+      tsPlugin(entry, {
+        name: "surface",
+        version: "2.3.4",
+        description: "surface reporter",
+        weight: 7,
+        api: { path: "/api/surface", methods: ["GET"] },
+        hooks: { on: ["message:send"] },
+        transport: { peer: true },
+      }),
+      { source: "cli", args: ["--version"] },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("surface v2.3.4 (ts, weight:7)");
+    expect(result.output).toContain("surface reporter");
+    expect(result.output).toContain("cli:surface");
+    expect(result.output).toContain("api:/api/surface");
+    expect(result.output).toContain("hooks");
+    expect(result.output).toContain("peer");
+  });
+
+  test("--help matches anywhere in args and renders declared CLI metadata", async () => {
+    const entry = writeModule(`export const handler = async () => ({ ok: true });`);
+    const result = await invokePlugin(
+      tsPlugin(entry, {
+        name: "helper",
+        version: "1.0.1",
+        description: "helpful plugin",
+        cli: {
+          command: "helper",
+          help: "maw helper <thing>",
+          aliases: ["hp"],
+          flags: { "--name": "Name to render" },
+        },
+        api: { path: "/api/helper", methods: ["GET", "POST"] },
+        hooks: { gate: ["cmd:before"] },
+      }),
+      { source: "cli", args: ["sub", "--help"] },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("helper v1.0.1");
+    expect(result.output).toContain("helpful plugin");
+    expect(result.output).toContain("usage: maw helper <thing>");
+    expect(result.output).toContain("aliases: hp");
+    expect(result.output).toContain("--name");
+    expect(result.output).toContain("api: GET/POST /api/helper");
+    expect(result.output).toContain("hooks: gate");
+  });
+});
+
+describe("invokePlugin TS dispatch in the default suite", () => {
+  test("returns handler InvokeResult objects as-is", async () => {
+    const entry = writeModule(`
+      export default async function handler(ctx) {
+        return { ok: true, output: "args=" + ctx.args.join("|") };
+      }
+    `);
+
+    const result = await invokePlugin(
+      tsPlugin(entry),
+      { source: "api", args: ["a", "b"] } satisfies InvokeContext,
+    );
+
+    expect(result).toEqual({ ok: true, output: "args=a|b" });
+  });
+
+  test("honors caller-provided writer instead of replacing it for CLI calls", async () => {
+    const entry = writeModule(`
+      export async function handler(ctx) {
+        ctx.writer("sent", 42);
+        return { ok: true };
+      }
+    `);
+    const seen: string[] = [];
+
+    const result = await invokePlugin(
+      tsPlugin(entry),
+      {
+        source: "cli",
+        args: [],
+        writer: (...args: unknown[]) => seen.push(args.map(String).join(":")),
+      },
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(seen).toEqual(["sent:42"]);
+  });
+
+  test("missing handlers fail without falling through to WASM", async () => {
+    const entry = writeModule(`export const nope = true;`);
+
+    const result = await invokePlugin(tsPlugin(entry), { source: "api", args: [] });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("TS plugin has no default export or handler");
+  });
+
+  test("thrown non-Error values are coerced into error results", async () => {
+    const entry = writeModule(`export default async function handler() { throw "plain failure"; }`);
+
+    const result = await invokePlugin(tsPlugin(entry), { source: "api", args: [] });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("plain failure");
+  });
+
+  test("non-CLI calls skip universal flags and reach plugin execution", async () => {
+    const result = await invokePlugin(wasmPlugin(), { source: "peer", args: ["--version"] });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("failed to read wasm");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds default-suite coverage for `src/plugin/registry-invoke.ts` metadata and TS-handler branches.
- Covers CLI `--version`, nested `--help`, default-name TS CLI surfaces, returned handler results, caller writer preservation, missing handler errors, non-Error throws, and non-CLI universal-flag bypass.
- Keeps deeper WASM invoke cases in `test/isolated/registry-invoke.test.ts` where their global seams already belong.

## Verification

- `rtk bun test test/00-registry-invoke-default.test.ts` → 7 pass / 0 fail
- `rtk bun run test:coverage` → 1514 pass / 6 skip / 0 fail; overall lines 14.3% (7265/50800), functions 54.0% (740/1370)
- `rtk bun run build` → success

## Coverage result

- `src/plugin/registry-invoke.ts` improved from 0.00%/2.44% to 33.33%/50.98%.
- plugin dispatch module line coverage rose from 58.7% to 67.2%.
- `registry-invoke.ts` left the critical below-80 next queue.

## Notes

- Alpha-only coverage PR for #1637.
- No release-alpha PR/cut; no main or beta branch work.

Closes part of #1637.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
