### PR TITLE
test(fleet): cover Claude session discovery

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,13 +1,13 @@
 # Coverage gap analysis
 
-Generated: 2026-05-16T19:07:49.376Z
+Generated: 2026-05-16T19:13:43.417Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **14.3%** (7265/50800)
-Overall function coverage: **54.0%** (740/1370)
+Overall line coverage: **14.4%** (7287/50777)
+Overall function coverage: **53.7%** (743/1383)
 
 ## Module summary
 
@@ -15,7 +15,7 @@ Overall function coverage: **54.0%** (740/1370)
 | --- | ---: | ---: | ---: | ---: | ---: |
 | cli/dispatch | 88 | 24 | 24.0% (1805/7528) | 53.5% (174/325) | n/a (0/0) |
 | config/runtime | 19 | 2 | 43.3% (510/1179) | 40.2% (35/87) | n/a (0/0) |
-| fleet | 17 | 1 | 20.7% (227/1096) | 53.4% (31/58) | n/a (0/0) |
+| fleet | 17 | 0 | 23.2% (249/1073) | 47.9% (34/71) | n/a (0/0) |
 | matcher | 2 | 0 | 100.0% (41/41) | 100.0% (8/8) | n/a (0/0) |
 | other | 174 | 98 | 18.6% (2672/14403) | 56.8% (270/475) | n/a (0/0) |
 | plugin dispatch | 15 | 1 | 67.2% (819/1218) | 83.8% (67/80) | n/a (0/0) |
@@ -123,7 +123,7 @@ Overall function coverage: **54.0%** (740/1370)
 | cli/dispatch | `src/commands/shared/done.ts` | 207 | 0.0% |
 | transport | `src/transports/mdns.ts` | 184 | 7.5% |
 | transport | `src/core/transport/peers.ts` | 176 | 31.3% |
-| fleet | `src/core/fleet/claude-sessions.ts` | 171 | 0.0% |
+| cli/dispatch | `src/cli/instance-pid.ts` | 164 | 0.0% |
 
 ## Critical gaps to prioritize
 

--- a/src/core/fleet/claude-sessions.ts
+++ b/src/core/fleet/claude-sessions.ts
@@ -44,6 +44,7 @@ export function decodeProjectDir(encoded: string): string {
 let pidCache: { data: PidInfo[]; ts: number } | null = null;
 
 function listClaudePids(): PidInfo[] {
+  if (process.env.MAW_CLAUDE_SKIP_PID_SCAN === "1") return [];
   const now = Date.now();
   if (pidCache && now - pidCache.ts < 5_000) return pidCache.data;
   const results: PidInfo[] = [];
@@ -148,11 +149,15 @@ function extractLastMessages(filePath: string): { lastUser: string | null; lastA
 
 let sessionCache: { data: ClaudeSession[]; ts: number } | null = null;
 
+function claudeProjectsDir(): string {
+  return process.env.MAW_CLAUDE_PROJECTS_DIR || join(homedir(), ".claude", "projects");
+}
+
 export async function listClaudeSessions(): Promise<ClaudeSession[]> {
   const now = Date.now();
   if (sessionCache && now - sessionCache.ts < 5_000) return sessionCache.data;
 
-  const claudeDir = join(homedir(), ".claude", "projects");
+  const claudeDir = claudeProjectsDir();
   const pids = listClaudePids();
   const pidByCwd = new Map(pids.map(p => [p.cwd, p]));
   const results: ClaudeSession[] = [];
@@ -190,6 +195,8 @@ export async function listClaudeSessions(): Promise<ClaudeSession[]> {
       const tmuxTarget = chain.some(c => c.toLowerCase().includes("tmux"))
         ? `(tmux: ${projectPath.split("/").pop()})` : null;
 
+      const { lastUser, lastAssistant } = extractLastMessages(filePath);
+
       results.push({
         sessionId, projectPath,
         repo: resolveRepo(projectPath),
@@ -198,7 +205,8 @@ export async function listClaudeSessions(): Promise<ClaudeSession[]> {
         ppid: pidInfo?.ppid ?? null,
         parentChain: chain, tmuxTarget, triggeredFrom: trigger, status,
         lastActivityAt: new Date(mtimeMs).toISOString(),
-        ...extractLastMessages(filePath),
+        lastUserMessage: lastUser,
+        lastAssistantMessage: lastAssistant,
         sizeBytes: st.size,
       });
     }

--- a/test/claude-sessions.test.ts
+++ b/test/claude-sessions.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const tempDirs: string[] = [];
+const originalProjectsDir = process.env.MAW_CLAUDE_PROJECTS_DIR;
+const originalSkipPidScan = process.env.MAW_CLAUDE_SKIP_PID_SCAN;
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "mawclaudesessions"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function encodeProjectPath(path: string): string {
+  return path.replace(/^\//, "-").replace(/[/.]/g, "-");
+}
+
+async function freshModule(): Promise<typeof import("../src/core/fleet/claude-sessions")> {
+  return import(`../src/core/fleet/claude-sessions.ts?test=${Date.now()}-${Math.random()}`);
+}
+
+afterEach(() => {
+  if (originalProjectsDir === undefined) delete process.env.MAW_CLAUDE_PROJECTS_DIR;
+  else process.env.MAW_CLAUDE_PROJECTS_DIR = originalProjectsDir;
+  if (originalSkipPidScan === undefined) delete process.env.MAW_CLAUDE_SKIP_PID_SCAN;
+  else process.env.MAW_CLAUDE_SKIP_PID_SCAN = originalSkipPidScan;
+  while (tempDirs.length) rmSync(tempDirs.pop()!, { recursive: true, force: true });
+});
+
+describe("Claude Code session discovery", () => {
+  test("decodeProjectDir reverses Claude's dash path encoding and leaves plain names alone", async () => {
+    const { decodeProjectDir } = await freshModule();
+
+    expect(decodeProjectDir("-opt-Code-repo")).toBe("/opt/Code/repo");
+    expect(decodeProjectDir("plain-name")).toBe("plain-name");
+  });
+
+  test("listClaudeSessions reads recent JSONL sessions from HOME without exposing old or subagent files", async () => {
+    const home = tempDir();
+    const projectsRoot = join(home, ".claude", "projects");
+    process.env.MAW_CLAUDE_PROJECTS_DIR = projectsRoot;
+    process.env.MAW_CLAUDE_SKIP_PID_SCAN = "1";
+    const projectPath = join(home, "projects", "mawrepo");
+    mkdirSync(projectPath, { recursive: true });
+
+    const encoded = encodeProjectPath(projectPath);
+    const claudeProjectDir = join(projectsRoot, encoded);
+    mkdirSync(claudeProjectDir, { recursive: true });
+
+    const freshSession = join(claudeProjectDir, "session-1.jsonl");
+    writeFileSync(freshSession, [
+      JSON.stringify({ type: "user", message: { content: "hello from user" } }),
+      JSON.stringify({ type: "assistant", message: { content: [{ type: "text", text: "hello from assistant" }] } }),
+      "{bad json",
+    ].join("\n"));
+
+    const oldSession = join(claudeProjectDir, "old-session.jsonl");
+    writeFileSync(oldSession, JSON.stringify({ type: "user", message: { content: "too old" } }));
+    const old = new Date(Date.now() - 2 * 86_400_000);
+    utimesSync(oldSession, old, old);
+
+    writeFileSync(
+      join(claudeProjectDir, "session-1-subagents.jsonl"),
+      JSON.stringify({ type: "user", message: { content: "subagent" } }),
+    );
+
+    const { listClaudeSessions } = await freshModule();
+    const sessions = await listClaudeSessions();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({
+      sessionId: "session-1",
+      projectPath,
+      repo: null,
+      worktree: null,
+      pid: null,
+      ppid: null,
+      parentChain: [],
+      tmuxTarget: null,
+      triggeredFrom: "unknown",
+      status: "ended",
+      lastUserMessage: "hello from user",
+      lastAssistantMessage: "hello from assistant",
+    });
+    expect(sessions[0].sizeBytes).toBeGreaterThan(0);
+    expect(Date.parse(sessions[0].lastActivityAt)).not.toBeNaN();
+  });
+
+  test("listClaudeSessions returns [] when the Claude projects directory is absent", async () => {
+    const home = tempDir();
+    process.env.MAW_CLAUDE_PROJECTS_DIR = join(home, ".claude", "projects");
+    process.env.MAW_CLAUDE_SKIP_PID_SCAN = "1";
+    const { listClaudeSessions } = await freshModule();
+
+    await expect(listClaudeSessions()).resolves.toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds deterministic default-suite coverage for Claude session discovery.
- Covers Claude project path decoding, recent JSONL extraction, old/subagent filtering, absent-projects fallback, and offline ended-session shaping.
- Adds explicit test seams (`MAW_CLAUDE_PROJECTS_DIR`, `MAW_CLAUDE_SKIP_PID_SCAN`) so unit tests never scan Nat's real `~/.claude/projects` or live process table.
- Fixes #1648 by mapping extracted `lastUser` / `lastAssistant` values into the exported `ClaudeSession.lastUserMessage` / `lastAssistantMessage` fields.

## Verification

- `rtk bun test test/claude-sessions.test.ts` → 3 pass / 0 fail
- `rtk bun run test:coverage` → 1517 pass / 6 skip / 0 fail; overall lines 14.4% (7287/50777), functions 53.7% (743/1383)
- `rtk bun run build` → success

## Coverage result

- `src/core/fleet/claude-sessions.ts` moved from absent-from-LCOV / 0.0% to imported and partially covered.
- fleet missing-from-LCOV count dropped from 1 to 0.
- `claude-sessions.ts` left the critical below-80 next queue.

## Notes

- Alpha-only coverage PR for #1637 plus bug fix for #1648.
- No release-alpha PR/cut; no main or beta branch work.

Closes part of #1637.
Closes #1648.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
