### PR TITLE
test(cli): cover serve PID status helpers

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,19 +1,19 @@
 # Coverage gap analysis
 
-Generated: 2026-05-16T19:13:43.417Z
+Generated: 2026-05-16T19:18:11.523Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **14.4%** (7287/50777)
-Overall function coverage: **53.7%** (743/1383)
+Overall line coverage: **14.5%** (7381/50765)
+Overall function coverage: **54.1%** (757/1399)
 
 ## Module summary
 
 | Module | Files | Missing from LCOV | Lines | Functions | Branches |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| cli/dispatch | 88 | 24 | 24.0% (1805/7528) | 53.5% (174/325) | n/a (0/0) |
+| cli/dispatch | 88 | 23 | 25.3% (1899/7516) | 55.1% (188/341) | n/a (0/0) |
 | config/runtime | 19 | 2 | 43.3% (510/1179) | 40.2% (35/87) | n/a (0/0) |
 | fleet | 17 | 0 | 23.2% (249/1073) | 47.9% (34/71) | n/a (0/0) |
 | matcher | 2 | 0 | 100.0% (41/41) | 100.0% (8/8) | n/a (0/0) |
@@ -123,7 +123,7 @@ Overall function coverage: **53.7%** (743/1383)
 | cli/dispatch | `src/commands/shared/done.ts` | 207 | 0.0% |
 | transport | `src/transports/mdns.ts` | 184 | 7.5% |
 | transport | `src/core/transport/peers.ts` | 176 | 31.3% |
-| cli/dispatch | `src/cli/instance-pid.ts` | 164 | 0.0% |
+| transport | `src/transports/hub-connection.ts` | 161 | 5.8% |
 
 ## Critical gaps to prioritize
 

--- a/test/instance-pid-default.test.ts
+++ b/test/instance-pid-default.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  pidFile,
+  printServeStatus,
+  printServeStatusWithPlugins,
+  serveStatus,
+  stopServe,
+} from "../src/cli/instance-pid";
+
+const originalHome = process.env.MAW_HOME;
+const originalEngineUrl = process.env.MAW_ENGINE_URL;
+const originalLog = console.log;
+let tempHome = "";
+let lines: string[] = [];
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), "maw-instance-pid-default-"));
+  process.env.MAW_HOME = tempHome;
+  delete process.env.MAW_ENGINE_URL;
+  lines = [];
+  console.log = (...args: unknown[]) => { lines.push(args.join(" ")); };
+});
+
+afterEach(() => {
+  if (originalHome === undefined) delete process.env.MAW_HOME;
+  else process.env.MAW_HOME = originalHome;
+  if (originalEngineUrl === undefined) delete process.env.MAW_ENGINE_URL;
+  else process.env.MAW_ENGINE_URL = originalEngineUrl;
+  console.log = originalLog;
+  rmSync(tempHome, { recursive: true, force: true });
+});
+
+describe("maw serve PID status helpers in the default suite", () => {
+  test("pidFile resolves under MAW_HOME", () => {
+    expect(pidFile()).toBe(join(tempHome, "maw.pid"));
+  });
+
+  test("serveStatus removes stale pid files", () => {
+    writeFileSync(pidFile(), "99999999");
+
+    expect(serveStatus()).toEqual({ pid: 99999999, alive: false, file: pidFile() });
+    expect(existsSync(pidFile())).toBe(false);
+    expect(serveStatus()).toEqual({ pid: null, alive: false, file: pidFile() });
+  });
+
+  test("printServeStatus renders stopped and running states", () => {
+    printServeStatus();
+    expect(lines.at(-1)).toBe(`maw serve: stopped (${pidFile()})`);
+
+    writeFileSync(pidFile(), String(process.pid));
+    printServeStatus();
+    expect(lines.at(-1)).toContain(`maw serve: running (PID ${process.pid}`);
+  });
+
+  test("stopServe is a no-op with a clear message when no PID exists", () => {
+    stopServe();
+
+    expect(lines).toEqual(["maw serve: already stopped"]);
+  });
+
+  test("printServeStatusWithPlugins reports registered engine plugins for a live serve", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname === "/api/_engine/registrations") {
+          return Response.json({
+            registrations: [{
+              plugin: "ledger",
+              prefix: "/api/ledger",
+              upstream: "unix:///tmp/maw-ledger.sock",
+              health: "/health",
+              events: ["MessageSend", "MessageDeliver"],
+            }],
+          });
+        }
+        return Response.json({ ok: false }, { status: 404 });
+      },
+    });
+    writeFileSync(pidFile(), String(process.pid));
+
+    try {
+      await printServeStatusWithPlugins(`http://127.0.0.1:${server.port}`);
+    } finally {
+      server.stop(true);
+    }
+
+    const output = lines.join("\n");
+    expect(output).toContain(`maw serve: running (PID ${process.pid}`);
+    expect(output).toContain("engine plugins (http://127.0.0.1:");
+    expect(output).toContain("ledger: /api/ledger → unix:///tmp/maw-ledger.sock health=/health events=MessageSend,MessageDeliver");
+  });
+
+  test("printServeStatusWithPlugins reports unavailable and empty plugin registries", async () => {
+    writeFileSync(pidFile(), String(process.pid));
+    await printServeStatusWithPlugins("http://127.0.0.1:1");
+    expect(lines.join("\n")).toContain("engine plugins: unavailable");
+
+    lines = [];
+    const server = Bun.serve({
+      port: 0,
+      fetch() { return Response.json({ registrations: [] }); },
+    });
+    try {
+      await printServeStatusWithPlugins(`http://127.0.0.1:${server.port}`);
+    } finally {
+      server.stop(true);
+    }
+
+    expect(lines.join("\n")).toContain("engine plugins: none");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds default-suite coverage for safe `maw serve` PID status helpers.
- Covers `MAW_HOME` PID path resolution, stale PID cleanup, stopped/running status output, no-op stop, unavailable/empty engine plugin registration reporting, and rendered dynamic plugin registration details.
- Keeps process-signal / force-takeover lock behavior in the existing isolated suite.

## Verification

- `rtk bun test test/instance-pid-default.test.ts` → 6 pass / 0 fail
- `rtk bun run test:coverage` → 1523 pass / 6 skip / 0 fail; overall lines 14.5% (7381/50765), functions 54.1% (757/1399)
- `rtk bun run build` → success

## Coverage result

- `src/cli/instance-pid.ts` moved from absent-from-LCOV / 0.0% to 61.8% line coverage and 87.5% function coverage.
- `instance-pid.ts` left the critical below-80 next queue.

## Notes

- Alpha-only coverage PR for #1637.
- No release-alpha PR/cut; no main or beta branch work.

Closes part of #1637.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
