### PR TITLE
test(plugin): cover hot reload watcher

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,13 +1,13 @@
 # Coverage gap analysis
 
-Generated: 2026-05-16T19:18:11.523Z
+Generated: 2026-05-16T19:25:18.591Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **14.5%** (7381/50765)
-Overall function coverage: **54.1%** (757/1399)
+Overall line coverage: **14.6%** (7408/50763)
+Overall function coverage: **54.4%** (765/1407)
 
 ## Module summary
 
@@ -17,7 +17,7 @@ Overall function coverage: **54.1%** (757/1399)
 | config/runtime | 19 | 2 | 43.3% (510/1179) | 40.2% (35/87) | n/a (0/0) |
 | fleet | 17 | 0 | 23.2% (249/1073) | 47.9% (34/71) | n/a (0/0) |
 | matcher | 2 | 0 | 100.0% (41/41) | 100.0% (8/8) | n/a (0/0) |
-| other | 174 | 98 | 18.6% (2672/14403) | 56.8% (270/475) | n/a (0/0) |
+| other | 174 | 98 | 18.7% (2699/14401) | 57.6% (278/483) | n/a (0/0) |
 | plugin dispatch | 15 | 1 | 67.2% (819/1218) | 83.8% (67/80) | n/a (0/0) |
 | routing/aliases | 4 | 0 | 49.2% (300/610) | 72.7% (32/44) | n/a (0/0) |
 | transport | 28 | 3 | 27.3% (746/2733) | 40.4% (111/275) | n/a (0/0) |

--- a/src/plugins/40_watcher.ts
+++ b/src/plugins/40_watcher.ts
@@ -24,9 +24,11 @@ export function watchUserPlugins(
       if (timer) clearTimeout(timer);
       timer = setTimeout(() => {
         timer = null;
-        Promise.resolve(onReload(lastChanged)).catch((err) => {
-          console.error(`[plugin:reload] failed for ${lastChanged}:`, (err as Error).message);
-        });
+        Promise.resolve()
+          .then(() => onReload(lastChanged))
+          .catch((err) => {
+            console.error(`[plugin:reload] failed for ${lastChanged}:`, (err as Error).message);
+          });
       }, debounceMs);
     });
   } catch (err) {

--- a/test/plugin-watcher.test.ts
+++ b/test/plugin-watcher.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { watchUserPlugins } from "../src/plugins/40_watcher";
+
+const tempDirs: string[] = [];
+const originalHotReload = process.env.MAW_HOT_RELOAD;
+const fsModule = require("fs") as typeof import("fs") & {
+  watch: (dir: string, opts: unknown, cb: (event: string, filename: string | null) => void) => { close: () => void };
+  existsSync: (path: string) => boolean;
+};
+const originalWatch = fsModule.watch;
+const originalExistsSync = fsModule.existsSync;
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "maw-plugin-watch-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 600): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await delay(20);
+  }
+}
+
+afterEach(() => {
+  if (originalHotReload === undefined) delete process.env.MAW_HOT_RELOAD;
+  else process.env.MAW_HOT_RELOAD = originalHotReload;
+  fsModule.watch = originalWatch;
+  fsModule.existsSync = originalExistsSync;
+  while (tempDirs.length) rmSync(tempDirs.pop()!, { recursive: true, force: true });
+});
+
+describe("watchUserPlugins", () => {
+  test("returns a no-op closer when hot reload is disabled", () => {
+    process.env.MAW_HOT_RELOAD = "0";
+    const dir = tempDir();
+    let calls = 0;
+
+    const close = watchUserPlugins(dir, () => { calls += 1; }, 1);
+    close();
+
+    expect(calls).toBe(0);
+  });
+
+  test("returns a no-op closer for missing directories", () => {
+    delete process.env.MAW_HOT_RELOAD;
+    let calls = 0;
+
+    const close = watchUserPlugins(join(tempDir(), "missing"), () => { calls += 1; }, 1);
+    close();
+
+    expect(calls).toBe(0);
+  });
+
+  test("debounces ts/js/wasm file changes and ignores unrelated files", async () => {
+    delete process.env.MAW_HOT_RELOAD;
+    let captured: ((event: string, filename: string | null) => void) | null = null;
+    let closed = false;
+    fsModule.existsSync = () => true;
+    fsModule.watch = (_dir, _opts, cb) => {
+      captured = cb;
+      return { close: () => { closed = true; } };
+    };
+    const seen: string[] = [];
+
+    const close = watchUserPlugins("/plugins", (changed) => { seen.push(changed); }, 10);
+    captured?.("change", "notes.md");
+    captured?.("change", "plugin.ts");
+    captured?.("change", "plugin.js");
+    await waitFor(() => seen.length > 0);
+    close();
+
+    expect(seen).toEqual(["plugin.js"]);
+    expect(closed).toBe(true);
+  });
+
+  test("logs reload callback failures without throwing", async () => {
+    delete process.env.MAW_HOT_RELOAD;
+    let captured: ((event: string, filename: string | null) => void) | null = null;
+    fsModule.existsSync = () => true;
+    fsModule.watch = (_dir, _opts, cb) => {
+      captured = cb;
+      return { close: () => {} };
+    };
+    const errors: string[] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => { errors.push(args.map(String).join(" ")); };
+    const close = watchUserPlugins("/plugins", () => { throw new Error("reload broke"); }, 10);
+
+    try {
+      captured?.("change", "plugin.js");
+      await waitFor(() => errors.length > 0);
+    } finally {
+      close();
+      console.error = originalError;
+    }
+
+    expect(errors.join("\n")).toContain("[plugin:reload] failed for plugin.js: reload broke");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds deterministic default-suite coverage for `watchUserPlugins()`.
- Covers hot-reload disabled no-op, missing-directory no-op, debounced ts/js/wasm changes, ignored non-plugin changes, watcher close, and reload failure logging.
- Fixes #1651 by invoking reload callbacks inside a promise turn so synchronous throws are caught and logged instead of escaping the watcher timer.

## Verification

- `rtk bun test test/plugin-watcher.test.ts` → 4 pass / 0 fail
- `rtk bun run test:coverage` → 1527 pass / 6 skip / 0 fail; overall lines 14.6% (7408/50763), functions 54.4% (765/1407)
- `rtk bun run build` → success

## Coverage result

- `src/plugins/40_watcher.ts` moved from 0.0% to 93.1% line coverage and 88.9% function coverage.

## Notes

- Alpha-only coverage PR for #1637 plus bug fix for #1651.
- No release-alpha PR/cut; no main or beta branch work.

Closes part of #1637.
Closes #1651.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
