### PR TITLE
test(transport): cover nanoclaw transport

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,13 +1,13 @@
 # Coverage gap analysis
 
-Generated: 2026-05-16T19:25:18.591Z
+Generated: 2026-05-16T19:32:25.852Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **14.6%** (7408/50763)
-Overall function coverage: **54.4%** (765/1407)
+Overall line coverage: **14.6%** (7417/50757)
+Overall function coverage: **55.2%** (776/1407)
 
 ## Module summary
 
@@ -20,7 +20,7 @@ Overall function coverage: **54.4%** (765/1407)
 | other | 174 | 98 | 18.7% (2699/14401) | 57.6% (278/483) | n/a (0/0) |
 | plugin dispatch | 15 | 1 | 67.2% (819/1218) | 83.8% (67/80) | n/a (0/0) |
 | routing/aliases | 4 | 0 | 49.2% (300/610) | 72.7% (32/44) | n/a (0/0) |
-| transport | 28 | 3 | 27.3% (746/2733) | 40.4% (111/275) | n/a (0/0) |
+| transport | 28 | 3 | 27.7% (755/2727) | 44.4% (122/275) | n/a (0/0) |
 | vendor plugins | 245 | 244 | 0.7% (145/21992) | 66.7% (12/18) | n/a (0/0) |
 
 ## Top 20 uncovered files by executable/source line count
@@ -105,6 +105,7 @@ Overall function coverage: **54.4%** (765/1407)
 | transport | `src/transports/hub-config.ts` | 90.0% | 100.0% |
 | transport | `src/transports/hub.ts` | 100.0% | 100.0% |
 | transport | `src/transports/lora.ts` | 100.0% | 90.9% |
+| transport | `src/transports/nanoclaw.ts` | 100.0% | 100.0% |
 | transport | `src/transports/scout-pair-proof.ts` | 100.0% | 100.0% |
 | transport | `src/transports/scout-protocol.ts` | 100.0% | 100.0% |
 | transport | `src/transports/scout-state.ts` | 100.0% | 100.0% |

--- a/src/transports/nanoclaw.ts
+++ b/src/transports/nanoclaw.ts
@@ -19,15 +19,20 @@ export class NanoclawTransport implements Transport {
   private presenceHandlers = new Set<(p: TransportPresence) => void>();
   private feedHandlers = new Set<(e: FeedEvent) => void>();
 
+  constructor(
+    private readonly resolveTarget: typeof resolveNanoclawJid = resolveNanoclawJid,
+    private readonly sendMessage: typeof sendViaNanoclaw = sendViaNanoclaw,
+  ) {}
+
   get connected() { return this._connected; }
 
   async connect(): Promise<void> { this._connected = true; }
   async disconnect(): Promise<void> { this._connected = false; }
 
   async send(target: TransportTarget, message: string): Promise<boolean> {
-    const resolved = resolveNanoclawJid(target.oracle);
+    const resolved = this.resolveTarget(target.oracle);
     if (!resolved) return false;
-    return sendViaNanoclaw(resolved.jid, message, resolved.url);
+    return this.sendMessage(resolved.jid, message, resolved.url);
   }
 
   async publishPresence(_presence: TransportPresence): Promise<void> {}
@@ -39,6 +44,6 @@ export class NanoclawTransport implements Transport {
 
   /** Can reach targets that resolve to a nanoclaw channel JID */
   canReach(target: TransportTarget): boolean {
-    return resolveNanoclawJid(target.oracle) !== null;
+    return this.resolveTarget(target.oracle) !== null;
   }
 }

--- a/test/nanoclaw-transport.test.ts
+++ b/test/nanoclaw-transport.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import type { FeedEvent } from "../src/lib/feed";
+import { NanoclawTransport } from "../src/transports/nanoclaw";
+
+describe("NanoclawTransport", () => {
+  test("tracks stateless HTTP lifecycle", async () => {
+    const transport = new NanoclawTransport();
+
+    expect(transport.name).toBe("nanoclaw");
+    expect(transport.connected).toBe(true);
+
+    await transport.disconnect();
+    expect(transport.connected).toBe(false);
+
+    await transport.connect();
+    expect(transport.connected).toBe(true);
+  });
+
+  test("does not send when the target cannot resolve", async () => {
+    let sendCalls = 0;
+    const transport = new NanoclawTransport(
+      () => null,
+      async () => {
+        sendCalls += 1;
+        return true;
+      },
+    );
+
+    expect(transport.canReach({ oracle: "missing" })).toBe(false);
+    expect(await transport.send({ oracle: "missing" }, "hello")).toBe(false);
+    expect(sendCalls).toBe(0);
+  });
+
+  test("delegates resolved targets to the nanoclaw sender", async () => {
+    const sends: Array<{ jid: string; text: string; url: string }> = [];
+    const transport = new NanoclawTransport(
+      (oracle) => oracle === "nat" ? { jid: "tg:12345", url: "http://nanoclaw.local" } : null,
+      async (jid, text, url) => {
+        sends.push({ jid, text, url });
+        return text === "delivered";
+      },
+    );
+
+    expect(transport.canReach({ oracle: "nat" })).toBe(true);
+    expect(transport.canReach({ oracle: "ghost" })).toBe(false);
+
+    expect(await transport.send({ oracle: "nat" }, "delivered")).toBe(true);
+    expect(await transport.send({ oracle: "nat" }, "rejected")).toBe(false);
+    expect(sends).toEqual([
+      { jid: "tg:12345", text: "delivered", url: "http://nanoclaw.local" },
+      { jid: "tg:12345", text: "rejected", url: "http://nanoclaw.local" },
+    ]);
+  });
+
+  test("accepts handlers and ignores publish-only hooks", async () => {
+    const transport = new NanoclawTransport();
+
+    transport.onMessage(() => {});
+    transport.onPresence(() => {});
+    transport.onFeed(() => {});
+
+    await expect(transport.publishPresence({
+      oracle: "mawjs",
+      host: "m5",
+      status: "ready",
+      timestamp: 1,
+    })).resolves.toBeUndefined();
+
+    const event: FeedEvent = {
+      timestamp: "2026-05-17 00:00:00",
+      oracle: "mawjs",
+      host: "m5",
+      event: "MessageSend",
+      project: "maw-js",
+      sessionId: "test",
+      message: "hello",
+      ts: 1,
+    };
+    await expect(transport.publishFeed(event)).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add deterministic unit coverage for `NanoclawTransport` lifecycle, reachability, send delegation, and publish no-op hooks
- add constructor-injected resolver/sender defaults so tests avoid network calls and process-global module mocks
- refresh coverage gap report for #1637

## Verification
- `bun test test/nanoclaw-transport.test.ts` → 4 pass / 0 fail
- `bun run test:coverage` → 1531 pass / 6 skip / 0 fail; `src/transports/nanoclaw.ts` 100% funcs / 100% lines; overall funcs 54.4% → 55.2%
- `bun run build` → success

## Release
- Alpha branch feature/test PR only. No release-alpha cut.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
