### PR TITLE
test(transport): cover tmux transport

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,13 +1,13 @@
 # Coverage gap analysis
 
-Generated: 2026-05-16T19:32:25.852Z
+Generated: 2026-05-16T19:37:02.881Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **14.6%** (7417/50757)
-Overall function coverage: **55.2%** (776/1407)
+Overall line coverage: **14.7%** (7443/50740)
+Overall function coverage: **56.0%** (788/1408)
 
 ## Module summary
 
@@ -20,7 +20,7 @@ Overall function coverage: **55.2%** (776/1407)
 | other | 174 | 98 | 18.7% (2699/14401) | 57.6% (278/483) | n/a (0/0) |
 | plugin dispatch | 15 | 1 | 67.2% (819/1218) | 83.8% (67/80) | n/a (0/0) |
 | routing/aliases | 4 | 0 | 49.2% (300/610) | 72.7% (32/44) | n/a (0/0) |
-| transport | 28 | 3 | 27.7% (755/2727) | 44.4% (122/275) | n/a (0/0) |
+| transport | 28 | 3 | 28.8% (781/2710) | 48.6% (134/276) | n/a (0/0) |
 | vendor plugins | 245 | 244 | 0.7% (145/21992) | 66.7% (12/18) | n/a (0/0) |
 
 ## Top 20 uncovered files by executable/source line count
@@ -109,6 +109,7 @@ Overall function coverage: **55.2%** (776/1407)
 | transport | `src/transports/scout-pair-proof.ts` | 100.0% | 100.0% |
 | transport | `src/transports/scout-protocol.ts` | 100.0% | 100.0% |
 | transport | `src/transports/scout-state.ts` | 100.0% | 100.0% |
+| transport | `src/transports/tmux.ts` | 100.0% | 100.0% |
 | transport | `src/transports/zenoh-scout.ts` | 90.3% | 66.7% |
 
 ## Critical files below the 80% line target (next queue)

--- a/src/transports/tmux.ts
+++ b/src/transports/tmux.ts
@@ -7,6 +7,7 @@
 
 import { sendKeys, listSessions } from "../core/transport/ssh";
 import { findWindow } from "../core/runtime/find-window";
+import type { Session } from "../core/runtime/find-window";
 import type { Transport, TransportTarget, TransportMessage, TransportPresence } from "../core/transport/transport";
 import type { FeedEvent } from "../lib/feed";
 
@@ -16,6 +17,12 @@ export class TmuxTransport implements Transport {
   private msgHandlers = new Set<(msg: TransportMessage) => void>();
   private presenceHandlers = new Set<(p: TransportPresence) => void>();
   private feedHandlers = new Set<(e: FeedEvent) => void>();
+
+  constructor(
+    private readonly sendToTmux: typeof sendKeys = sendKeys,
+    private readonly listTmuxSessions: typeof listSessions = listSessions,
+    private readonly findTmuxWindow: (sessions: Session[], query: string) => string | null = findWindow,
+  ) {}
 
   get connected() { return this._connected; }
 
@@ -38,12 +45,12 @@ export class TmuxTransport implements Transport {
       // Resolve tmux target if not provided
       let tmuxTarget = target.tmuxTarget;
       if (!tmuxTarget) {
-        const sessions = await listSessions();
-        tmuxTarget = findWindow(sessions, target.oracle);
+        const sessions = await this.listTmuxSessions();
+        tmuxTarget = this.findTmuxWindow(sessions, target.oracle);
         if (!tmuxTarget) return false;
       }
 
-      await sendKeys(tmuxTarget, message);
+      await this.sendToTmux(tmuxTarget, message);
       return true;
     } catch {
       return false;

--- a/test/tmux-transport.test.ts
+++ b/test/tmux-transport.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+import type { FeedEvent } from "../src/lib/feed";
+import type { Session } from "../src/core/runtime/find-window";
+import { TmuxTransport } from "../src/transports/tmux";
+
+function sampleSessions(): Session[] {
+  return [
+    {
+      name: "47-mawjs",
+      windows: [
+        { index: 0, name: "mawjs-oracle", active: true },
+        { index: 1, name: "mawjs-codex", active: false },
+      ],
+    },
+  ];
+}
+
+describe("TmuxTransport", () => {
+  test("tracks local tmux lifecycle", async () => {
+    const transport = new TmuxTransport();
+
+    expect(transport.name).toBe("tmux");
+    expect(transport.connected).toBe(false);
+
+    await transport.connect();
+    expect(transport.connected).toBe(true);
+
+    await transport.disconnect();
+    expect(transport.connected).toBe(false);
+  });
+
+  test("can only reach local targets", () => {
+    const transport = new TmuxTransport();
+
+    expect(transport.canReach({ oracle: "mawjs" })).toBe(true);
+    expect(transport.canReach({ oracle: "mawjs", host: "local" })).toBe(true);
+    expect(transport.canReach({ oracle: "mawjs", host: "localhost" })).toBe(true);
+    expect(transport.canReach({ oracle: "mawjs", host: "m5" })).toBe(false);
+  });
+
+  test("uses explicit tmux target without scanning sessions", async () => {
+    const sends: Array<{ target: string; message: string }> = [];
+    let scanned = false;
+    const transport = new TmuxTransport(
+      async (target, message) => { sends.push({ target, message }); },
+      async () => {
+        scanned = true;
+        return sampleSessions();
+      },
+    );
+
+    expect(await transport.send({ oracle: "ignored", tmuxTarget: "47-mawjs:1" }, "hello")).toBe(true);
+    expect(scanned).toBe(false);
+    expect(sends).toEqual([{ target: "47-mawjs:1", message: "hello" }]);
+  });
+
+  test("resolves a local oracle through tmux session scan", async () => {
+    const sends: Array<{ target: string; message: string }> = [];
+    const scanned: Session[][] = [];
+    const queries: string[] = [];
+    const transport = new TmuxTransport(
+      async (target, message) => { sends.push({ target, message }); },
+      async () => {
+        const sessions = sampleSessions();
+        scanned.push(sessions);
+        return sessions;
+      },
+      (sessions, query) => {
+        queries.push(query);
+        expect(sessions).toBe(scanned[0]);
+        return "47-mawjs:1";
+      },
+    );
+
+    expect(await transport.send({ oracle: "mawjs-codex" }, "ping")).toBe(true);
+    expect(queries).toEqual(["mawjs-codex"]);
+    expect(sends).toEqual([{ target: "47-mawjs:1", message: "ping" }]);
+  });
+
+  test("returns false for remote, unresolved, and throwing send paths", async () => {
+    let sendCalls = 0;
+    const remote = new TmuxTransport(
+      async () => { sendCalls += 1; },
+      async () => sampleSessions(),
+    );
+    expect(await remote.send({ oracle: "mawjs", host: "remote" }, "nope")).toBe(false);
+    expect(sendCalls).toBe(0);
+
+    const unresolved = new TmuxTransport(
+      async () => { sendCalls += 1; },
+      async () => sampleSessions(),
+      () => null,
+    );
+    expect(await unresolved.send({ oracle: "missing" }, "nope")).toBe(false);
+
+    const throwing = new TmuxTransport(
+      async () => { throw new Error("tmux rejected"); },
+      async () => sampleSessions(),
+      () => "47-mawjs:1",
+    );
+    expect(await throwing.send({ oracle: "mawjs" }, "nope")).toBe(false);
+    expect(sendCalls).toBe(0);
+  });
+
+  test("accepts handlers and ignores publish-only hooks", async () => {
+    const transport = new TmuxTransport();
+
+    transport.onMessage(() => {});
+    transport.onPresence(() => {});
+    transport.onFeed(() => {});
+
+    await expect(transport.publishPresence({
+      oracle: "mawjs",
+      host: "m5",
+      status: "ready",
+      timestamp: 1,
+    })).resolves.toBeUndefined();
+
+    const event: FeedEvent = {
+      timestamp: "2026-05-17 00:00:00",
+      oracle: "mawjs",
+      host: "m5",
+      event: "MessageSend",
+      project: "maw-js",
+      sessionId: "test",
+      message: "hello",
+      ts: 1,
+    };
+    await expect(transport.publishFeed(event)).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add deterministic unit coverage for `TmuxTransport` lifecycle, local reachability, explicit target sends, session-scan resolution, failure paths, and publish no-op hooks
- add constructor-injected tmux collaborators so default unit tests avoid spawning tmux or process-global module mocks
- refresh coverage gap report for #1637

## Verification
- `bun test test/tmux-transport.test.ts` → 6 pass / 0 fail
- `bun run test:coverage` → 1537 pass / 6 skip / 0 fail; `src/transports/tmux.ts` 100% funcs / 100% lines; overall funcs 55.2% → 56.0%; overall lines 14.6% → 14.7%
- `bun run build` → success

## Release
- Alpha branch feature/test PR only. No release-alpha cut.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
