### PR TITLE
test(transport): cover HTTP federation transport

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,13 +1,13 @@
 # Coverage gap analysis
 
-Generated: 2026-05-16T19:37:02.881Z
+Generated: 2026-05-16T19:41:57.497Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **14.7%** (7443/50740)
-Overall function coverage: **56.0%** (788/1408)
+Overall line coverage: **14.8%** (7490/50723)
+Overall function coverage: **56.9%** (803/1412)
 
 ## Module summary
 
@@ -20,7 +20,7 @@ Overall function coverage: **56.0%** (788/1408)
 | other | 174 | 98 | 18.7% (2699/14401) | 57.6% (278/483) | n/a (0/0) |
 | plugin dispatch | 15 | 1 | 67.2% (819/1218) | 83.8% (67/80) | n/a (0/0) |
 | routing/aliases | 4 | 0 | 49.2% (300/610) | 72.7% (32/44) | n/a (0/0) |
-| transport | 28 | 3 | 28.8% (781/2710) | 48.6% (134/276) | n/a (0/0) |
+| transport | 28 | 3 | 30.7% (828/2693) | 53.2% (149/280) | n/a (0/0) |
 | vendor plugins | 245 | 244 | 0.7% (145/21992) | 66.7% (12/18) | n/a (0/0) |
 
 ## Top 20 uncovered files by executable/source line count
@@ -102,6 +102,7 @@ Overall function coverage: **56.0%** (788/1408)
 | routing/aliases | `src/core/routing.ts` | 89.1% | 91.7% |
 | transport | `src/core/transport/tmux.ts` | 100.0% | 100.0% |
 | transport | `src/core/transport/transport.ts` | 100.0% | 96.4% |
+| transport | `src/transports/http.ts` | 100.0% | 100.0% |
 | transport | `src/transports/hub-config.ts` | 90.0% | 100.0% |
 | transport | `src/transports/hub.ts` | 100.0% | 100.0% |
 | transport | `src/transports/lora.ts` | 100.0% | 90.9% |

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -9,6 +9,7 @@ import { sendKeysToPeer, getAggregatedSessions } from "../core/transport/peers";
 import { cfgTimeout } from "../config";
 import { listSessions } from "../core/transport/ssh";
 import { findWindow } from "../core/runtime/find-window";
+import type { Session } from "../core/runtime/find-window";
 import { curlFetch } from "../core/transport/curl-fetch";
 import type { Transport, TransportTarget, TransportMessage, TransportPresence } from "../core/transport/transport";
 import type { FeedEvent } from "../lib/feed";
@@ -19,6 +20,15 @@ export interface HttpTransportConfig {
   selfHost: string;
 }
 
+interface HttpTransportDeps {
+  listLocalSessions?: typeof listSessions;
+  getAllSessions?: typeof getAggregatedSessions;
+  findTargetWindow?: (sessions: Session[], query: string) => string | null;
+  sendPeerKeys?: typeof sendKeysToPeer;
+  postPeerFeed?: typeof curlFetch;
+  timeoutFor?: typeof cfgTimeout;
+}
+
 export class HttpTransport implements Transport {
   readonly name = "http-federation";
   private _connected = false;
@@ -27,7 +37,10 @@ export class HttpTransport implements Transport {
   private presenceHandlers = new Set<(p: TransportPresence) => void>();
   private feedHandlers = new Set<(e: FeedEvent) => void>();
 
-  constructor(config: HttpTransportConfig) {
+  constructor(
+    config: HttpTransportConfig,
+    private readonly deps: HttpTransportDeps = {},
+  ) {
     this.config = config;
   }
 
@@ -43,8 +56,8 @@ export class HttpTransport implements Transport {
 
   async send(target: TransportTarget, message: string): Promise<boolean> {
     // Find which peer has this target
-    const localSessions = await listSessions();
-    const allSessions = await getAggregatedSessions(localSessions);
+    const localSessions = await (this.deps.listLocalSessions ?? listSessions)();
+    const allSessions = await (this.deps.getAllSessions ?? getAggregatedSessions)(localSessions);
 
     for (const session of allSessions) {
       const source = (session as any).source;
@@ -52,9 +65,9 @@ export class HttpTransport implements Transport {
 
       const match = session.windows.some((w) => w.name.toLowerCase().includes(target.oracle.toLowerCase()));
       if (match) {
-        const tmuxTarget = findWindow([session], target.oracle);
+        const tmuxTarget = (this.deps.findTargetWindow ?? findWindow)([session], target.oracle);
         if (tmuxTarget) {
-          return sendKeysToPeer(source, tmuxTarget, message);
+          return (this.deps.sendPeerKeys ?? sendKeysToPeer)(source, tmuxTarget, message);
         }
       }
     }
@@ -72,11 +85,12 @@ export class HttpTransport implements Transport {
     // rejections so we can warn per failed peer (#385 site 4 — previously double-buried
     // by an inner trySilentAsync inside allSettled, which made cluster-wide drops silent).
     const peers = this.config.peers;
+    const postFeed = this.deps.postPeerFeed ?? curlFetch;
     const results = await Promise.allSettled(
-      peers.map((url) => curlFetch(`${url}/api/feed`, {
+      peers.map((url) => postFeed(`${url}/api/feed`, {
         method: "POST",
         body: JSON.stringify(event),
-        timeout: cfgTimeout("http"),
+        timeout: (this.deps.timeoutFor ?? cfgTimeout)("http"),
       })),
     );
     for (let i = 0; i < results.length; i++) {

--- a/test/http-transport.test.ts
+++ b/test/http-transport.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "bun:test";
+import type { FeedEvent } from "../src/lib/feed";
+import type { Session } from "../src/core/runtime/find-window";
+import { HttpTransport } from "../src/transports/http";
+
+function event(): FeedEvent {
+  return {
+    timestamp: "2026-05-17 00:00:00",
+    oracle: "mawjs",
+    host: "m5",
+    event: "MessageSend",
+    project: "maw-js",
+    sessionId: "test",
+    message: "hello",
+    ts: 1,
+  };
+}
+
+function session(name: string, windowName: string, source?: string): Session & { source?: string } {
+  return {
+    name,
+    source,
+    windows: [{ index: 0, name: windowName, active: true }],
+  };
+}
+
+describe("HttpTransport", () => {
+  test("connects only when peers are configured", async () => {
+    const offline = new HttpTransport({ peers: [], selfHost: "local" });
+    expect(offline.name).toBe("http-federation");
+    expect(offline.connected).toBe(false);
+    await offline.connect();
+    expect(offline.connected).toBe(false);
+
+    const online = new HttpTransport({ peers: ["http://peer"], selfHost: "local" });
+    await online.connect();
+    expect(online.connected).toBe(true);
+    await online.disconnect();
+    expect(online.connected).toBe(false);
+  });
+
+  test("can reach only remote targets when peers exist", () => {
+    const noPeers = new HttpTransport({ peers: [], selfHost: "local" });
+    expect(noPeers.canReach({ oracle: "mawjs", host: "m5" })).toBe(false);
+
+    const transport = new HttpTransport({ peers: ["http://peer"], selfHost: "local" });
+    expect(transport.canReach({ oracle: "mawjs" })).toBe(false);
+    expect(transport.canReach({ oracle: "mawjs", host: "local" })).toBe(false);
+    expect(transport.canReach({ oracle: "mawjs", host: "localhost" })).toBe(false);
+    expect(transport.canReach({ oracle: "mawjs", host: "m5" })).toBe(true);
+  });
+
+  test("sends through the peer that owns a matching remote window", async () => {
+    const localSessions = [session("local", "local-oracle")];
+    const allSessions = [
+      session("local", "local-oracle", "local"),
+      session("remote-a", "other-oracle", "http://peer-a"),
+      session("remote-b", "target-oracle", "http://peer-b"),
+    ];
+    const sent: Array<{ source: string; target: string; message: string }> = [];
+    const transport = new HttpTransport(
+      { peers: ["http://peer-a", "http://peer-b"], selfHost: "local" },
+      {
+        listLocalSessions: async () => localSessions,
+        getAllSessions: async (sessions) => {
+          expect(sessions).toBe(localSessions);
+          return allSessions;
+        },
+        findTargetWindow: (sessions, query) => {
+          expect(sessions).toEqual([allSessions[2]]);
+          expect(query).toBe("target");
+          return "remote-b:0";
+        },
+        sendPeerKeys: async (source, target, message) => {
+          sent.push({ source, target, message });
+          return true;
+        },
+      },
+    );
+
+    expect(await transport.send({ oracle: "target", host: "remote" }, "hello")).toBe(true);
+    expect(sent).toEqual([{ source: "http://peer-b", target: "remote-b:0", message: "hello" }]);
+  });
+
+  test("returns false when no remote session resolves to a tmux target", async () => {
+    const transport = new HttpTransport(
+      { peers: ["http://peer"], selfHost: "local" },
+      {
+        listLocalSessions: async () => [],
+        getAllSessions: async () => [
+          session("local", "target-oracle"),
+          session("remote-a", "other-oracle", "http://peer-a"),
+          session("remote-b", "target-oracle", "http://peer-b"),
+        ],
+        findTargetWindow: () => null,
+        sendPeerKeys: async () => {
+          throw new Error("send should not run without tmux target");
+        },
+      },
+    );
+
+    expect(await transport.send({ oracle: "target", host: "remote" }, "hello")).toBe(false);
+  });
+
+  test("publishes feed events to every peer and warns on rejected publishes", async () => {
+    const calls: Array<{ url: string; method?: string; body?: string; timeout?: number }> = [];
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(" "));
+    try {
+      const transport = new HttpTransport(
+        { peers: ["http://a", "http://b", "http://c"], selfHost: "local" },
+        {
+          timeoutFor: () => 1234,
+          postPeerFeed: async (url, opts) => {
+            calls.push({ url, method: opts?.method, body: opts?.body, timeout: opts?.timeout });
+            if (url === "http://b/api/feed") throw new Error("boom");
+            return { ok: true, status: 200, data: { ok: true } };
+          },
+        },
+      );
+
+      const feed = event();
+      await transport.publishFeed(feed);
+
+      expect(calls).toEqual([
+        { url: "http://a/api/feed", method: "POST", body: JSON.stringify(feed), timeout: 1234 },
+        { url: "http://b/api/feed", method: "POST", body: JSON.stringify(feed), timeout: 1234 },
+        { url: "http://c/api/feed", method: "POST", body: JSON.stringify(feed), timeout: 1234 },
+      ]);
+      expect(warnings.join("\n")).toContain("feed publish failed for http://b: boom");
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  test("accepts handlers and ignores HTTP presence", async () => {
+    const transport = new HttpTransport({ peers: [], selfHost: "local" });
+
+    transport.onMessage(() => {});
+    transport.onPresence(() => {});
+    transport.onFeed(() => {});
+
+    await expect(transport.publishPresence({
+      oracle: "mawjs",
+      host: "m5",
+      status: "ready",
+      timestamp: 1,
+    })).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add deterministic unit coverage for `HttpTransport` lifecycle, remote reachability, peer-send routing, unresolved send paths, feed publish warnings, and handler registration
- add a backwards-compatible optional dependency bag so tests avoid live peers, tmux, config timeout lookup, and process-global mocks
- refresh coverage gap report for #1637

## Verification
- `bun test test/http-transport.test.ts` → 6 pass / 0 fail
- `bun run test:coverage` → 1543 pass / 6 skip / 0 fail; `src/transports/http.ts` 100% funcs / 100% lines; overall funcs 56.0% → 56.9%; overall lines 14.7% → 14.8%
- `bun run build` → success

## Release
- Alpha branch feature/test PR only. No release-alpha cut.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
