### PR TITLE
test(transport): cover workspace hub transport

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,13 +1,13 @@
 # Coverage gap analysis
 
-Generated: 2026-05-16T19:48:11.533Z
+Generated: 2026-05-16T19:53:26.123Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **15.1%** (7634/50706)
-Overall function coverage: **57.6%** (818/1421)
+Overall line coverage: **15.3%** (7747/50680)
+Overall function coverage: **58.7%** (841/1432)
 
 ## Module summary
 
@@ -20,7 +20,7 @@ Overall function coverage: **57.6%** (818/1421)
 | other | 174 | 98 | 18.7% (2699/14401) | 57.6% (278/483) | n/a (0/0) |
 | plugin dispatch | 15 | 1 | 67.2% (819/1218) | 83.8% (67/80) | n/a (0/0) |
 | routing/aliases | 4 | 0 | 49.2% (300/610) | 72.7% (32/44) | n/a (0/0) |
-| transport | 28 | 3 | 36.3% (972/2676) | 56.7% (164/289) | n/a (0/0) |
+| transport | 28 | 3 | 40.9% (1085/2650) | 62.3% (187/300) | n/a (0/0) |
 | vendor plugins | 245 | 244 | 0.7% (145/21992) | 66.7% (12/18) | n/a (0/0) |
 
 ## Top 20 uncovered files by executable/source line count
@@ -105,6 +105,7 @@ Overall function coverage: **57.6%** (818/1421)
 | transport | `src/transports/http.ts` | 100.0% | 100.0% |
 | transport | `src/transports/hub-config.ts` | 90.0% | 100.0% |
 | transport | `src/transports/hub-connection.ts` | 100.0% | 93.8% |
+| transport | `src/transports/hub-transport.ts` | 99.2% | 92.0% |
 | transport | `src/transports/hub.ts` | 100.0% | 100.0% |
 | transport | `src/transports/lora.ts` | 100.0% | 90.9% |
 | transport | `src/transports/nanoclaw.ts` | 100.0% | 100.0% |

--- a/src/transports/hub-transport.ts
+++ b/src/transports/hub-transport.ts
@@ -12,6 +12,15 @@ import { openWebSocket, cleanupConnection } from "./hub-connection";
 import { loadWorkspaceConfigs } from "./hub-config";
 import type { WorkspaceConfig } from "./hub-config";
 
+interface HubTransportDeps {
+  loadConfig?: typeof loadConfig;
+  loadWorkspaces?: typeof loadWorkspaceConfigs;
+  openSocket?: typeof openWebSocket;
+  cleanup?: typeof cleanupConnection;
+  setConnectTimeout?: typeof setTimeout;
+  clearConnectTimeout?: typeof clearTimeout;
+}
+
 export class HubTransport implements Transport {
   readonly name = "workspace-hub";
   readonly priority = 30;  // between MQTT (20) and HTTP (40)
@@ -23,8 +32,11 @@ export class HubTransport implements Transport {
   private presenceHandlers = new Set<(p: TransportPresence) => void>();
   private feedHandlers = new Set<(e: FeedEvent) => void>();
 
-  constructor(nodeId?: string) {
-    const config = loadConfig();
+  constructor(
+    nodeId?: string,
+    private readonly deps: HubTransportDeps = {},
+  ) {
+    const config = (this.deps.loadConfig ?? loadConfig)();
     this.nodeId = nodeId ?? config.node ?? "local";
     this.federationToken = config.federationToken;
   }
@@ -32,7 +44,7 @@ export class HubTransport implements Transport {
   get connected() { return this._connected; }
 
   async connect(): Promise<void> {
-    const workspaces = loadWorkspaceConfigs();
+    const workspaces = (this.deps.loadWorkspaces ?? loadWorkspaceConfigs)();
     if (workspaces.length === 0) {
       console.log("[hub] no workspace configs found");
       return;
@@ -53,7 +65,7 @@ export class HubTransport implements Transport {
 
   async disconnect(): Promise<void> {
     for (const conn of this.connections.values()) {
-      cleanupConnection(conn);
+      (this.deps.cleanup ?? cleanupConnection)(conn);
     }
     this.connections.clear();
     this._connected = false;
@@ -166,14 +178,14 @@ export class HubTransport implements Transport {
       };
 
       this.connections.set(config.id, conn);
-      const timeout = setTimeout(() => {
+      const timeout = (this.deps.setConnectTimeout ?? setTimeout)(() => {
         if (!conn.connected) {
           console.warn(`[hub] workspace ${config.id}: connection timeout`);
           resolve(false);
         }
       }, 10_000);
 
-      openWebSocket(
+      (this.deps.openSocket ?? openWebSocket)(
         conn,
         this.nodeId,
         this.federationToken,
@@ -182,7 +194,7 @@ export class HubTransport implements Transport {
         this.feedHandlers,
         () => { this._connected = true; },
         () => this.updateConnectedState(),
-        () => { clearTimeout(timeout); resolve(true); },
+        () => { (this.deps.clearConnectTimeout ?? clearTimeout)(timeout); resolve(true); },
       );
     });
   }

--- a/test/hub-transport.test.ts
+++ b/test/hub-transport.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, test } from "bun:test";
+import type { FeedEvent } from "../src/lib/feed";
+import type { HubConnection } from "../src/transports/hub-connection";
+import type { WorkspaceConfig } from "../src/transports/hub-config";
+import { HubTransport } from "../src/transports/hub-transport";
+
+function workspace(id = "ws-a"): WorkspaceConfig {
+  return {
+    id,
+    hubUrl: `ws://${id}.example/ws`,
+    token: "workspace-token",
+    sharedAgents: ["mawjs"],
+  };
+}
+
+function conn(id: string, connected: boolean, agents: string[], sent: string[] = []): HubConnection {
+  return {
+    config: workspace(id),
+    ws: {
+      send(payload: string) {
+        sent.push(payload);
+      },
+    } as unknown as WebSocket,
+    connected,
+    heartbeatTimer: null,
+    reconnectTimer: null,
+    reconnectAttempt: 0,
+    remoteAgents: new Set(agents),
+  };
+}
+
+function feedEvent(): FeedEvent {
+  return {
+    timestamp: "2026-05-17 00:00:00",
+    oracle: "pulse",
+    host: "m5",
+    event: "MessageSend",
+    project: "maw-js",
+    sessionId: "test",
+    message: "hello",
+    ts: 1,
+  };
+}
+
+describe("HubTransport", () => {
+  test("connect reports no workspace configs without marking connected", async () => {
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => logs.push(args.map(String).join(" "));
+    try {
+      const transport = new HubTransport(undefined, {
+        loadConfig: () => ({ node: "m5" } as any),
+        loadWorkspaces: () => [],
+      });
+
+      await transport.connect();
+      expect(transport.name).toBe("workspace-hub");
+      expect(transport.priority).toBe(30);
+      expect(transport.connected).toBe(false);
+      expect(logs.join("\n")).toContain("no workspace configs found");
+    } finally {
+      console.log = originalLog;
+    }
+  });
+
+  test("connect marks connected when a workspace reaches first-connect callback", async () => {
+    const ws = workspace("ws-ok");
+    const opened: Array<{ id: string; nodeId: string; token?: string }> = [];
+    let cleared = 0;
+    const transport = new HubTransport(undefined, {
+      loadConfig: () => ({ node: "m5", federationToken: "fed-secret" } as any),
+      loadWorkspaces: () => [ws],
+      setConnectTimeout: (() => ({ kind: "timeout" })) as typeof setTimeout,
+      clearConnectTimeout: (() => { cleared += 1; }) as typeof clearTimeout,
+      openSocket: (connection, nodeId, federationToken, _msg, _presence, _feed, onSetConnected, _onUpdateState, onFirstConnect) => {
+        opened.push({ id: connection.config.id, nodeId, token: federationToken });
+        connection.connected = true;
+        onSetConnected();
+        onFirstConnect?.();
+      },
+    });
+
+    await transport.connect();
+    expect(transport.connected).toBe(true);
+    expect(opened).toEqual([{ id: "ws-ok", nodeId: "m5", token: "fed-secret" }]);
+    expect(cleared).toBe(1);
+    expect(transport.workspaceStatus()).toEqual([
+      { id: "ws-ok", connected: true, remoteAgents: [] },
+    ]);
+  });
+
+  test("connect timeout leaves transport disconnected", async () => {
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(" "));
+    try {
+      const transport = new HubTransport("forced-node", {
+        loadConfig: () => ({ node: "ignored" } as any),
+        loadWorkspaces: () => [workspace("ws-timeout")],
+        setConnectTimeout: ((cb: () => void) => {
+          cb();
+          return { kind: "timeout" };
+        }) as typeof setTimeout,
+        openSocket: () => {},
+      });
+
+      await transport.connect();
+      expect(transport.connected).toBe(false);
+      expect(warnings.join("\n")).toContain("workspace ws-timeout: connection timeout");
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  test("routes sends, publishes best-effort events, reports status, and disconnects", async () => {
+    const cleanups: string[] = [];
+    const warnLogs: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => warnLogs.push(args.map(String).join(" "));
+    try {
+      const transport = new HubTransport("m5", {
+        loadConfig: () => ({ federationToken: "fed" } as any),
+        cleanup: (connection) => {
+          cleanups.push(connection.config.id);
+          connection.connected = false;
+        },
+      });
+      const sentA: string[] = [];
+      const sentB: string[] = [];
+      const sentThrow: string[] = [];
+      const throwing = conn("ws-throw", true, ["remote:pulse"], sentThrow);
+      throwing.ws = {
+        send(payload: string) {
+          sentThrow.push(payload);
+          throw new Error("socket closed");
+        },
+      } as unknown as WebSocket;
+      const connected = conn("ws-b", true, ["pulse", "remote:pulse"], sentB);
+      const disconnected = conn("ws-a", false, ["pulse"], sentA);
+      (transport as any).connections.set("ws-a", disconnected);
+      (transport as any).connections.set("ws-throw", throwing);
+      (transport as any).connections.set("ws-b", connected);
+
+      expect(transport.canReach({ oracle: "pulse", host: "remote" })).toBe(false);
+      (transport as any)._connected = true;
+      expect(transport.canReach({ oracle: "pulse", host: "remote" })).toBe(true);
+      expect(transport.canReach({ oracle: "ghost", host: "remote" })).toBe(false);
+
+      expect(await transport.send({ oracle: "pulse", host: "remote" }, "hello")).toBe(true);
+      expect(JSON.parse(sentB[0])).toMatchObject({
+        type: "message",
+        to: "remote:pulse",
+        body: "hello",
+        from: "m5:pulse",
+      });
+      expect(warnLogs.join("\n")).toContain("send failed on workspace ws-throw");
+      expect(await transport.send({ oracle: "ghost", host: "remote" }, "hello")).toBe(false);
+
+      await transport.publishPresence({ oracle: "mawjs", host: "m5", status: "ready", timestamp: 123 });
+      await transport.publishFeed(feedEvent());
+      expect(sentA).toEqual([]);
+      expect(sentB.map((payload) => JSON.parse(payload).type)).toEqual(["message", "presence", "feed"]);
+
+      expect(transport.workspaceStatus()).toEqual([
+        { id: "ws-a", connected: false, remoteAgents: ["pulse"] },
+        { id: "ws-throw", connected: true, remoteAgents: ["remote:pulse"] },
+        { id: "ws-b", connected: true, remoteAgents: ["pulse", "remote:pulse"] },
+      ]);
+
+      await transport.disconnect();
+      expect(cleanups).toEqual(["ws-a", "ws-throw", "ws-b"]);
+      expect(transport.connected).toBe(false);
+      expect(transport.workspaceStatus()).toEqual([]);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  test("registers handlers for openSocket wiring", async () => {
+    const transport = new HubTransport("m5", {
+      loadConfig: () => ({} as any),
+      loadWorkspaces: () => [workspace("ws-handlers")],
+      setConnectTimeout: (() => ({ kind: "timeout" })) as typeof setTimeout,
+      clearConnectTimeout: (() => {}) as typeof clearTimeout,
+      openSocket: (_connection, _nodeId, _token, msgHandlers, presenceHandlers, feedHandlers, _onSetConnected, _onUpdateState, onFirstConnect) => {
+        expect(msgHandlers.size).toBe(1);
+        expect(presenceHandlers.size).toBe(1);
+        expect(feedHandlers.size).toBe(1);
+        onFirstConnect?.();
+      },
+    });
+    transport.onMessage(() => {});
+    transport.onPresence(() => {});
+    transport.onFeed(() => {});
+
+    await transport.connect();
+    expect(transport.connected).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add deterministic unit coverage for `HubTransport` connect, timeout, send routing, best-effort publish, status, handler wiring, and disconnect behavior
- add a backwards-compatible optional dependency bag so tests avoid real workspace files, WebSockets, and timers
- refresh coverage gap report for #1637

## Verification
- `bun test test/hub-transport.test.ts` → 5 pass / 0 fail
- `bun run test:coverage` → 1552 pass / 6 skip / 0 fail; `src/transports/hub-transport.ts` 99.2% lines / 92.0% funcs; overall funcs 57.6% → 58.7%; overall lines 15.1% → 15.3%
- `bun run build` → success

## Release
- Alpha branch feature/test PR only. No release-alpha cut.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
