### PR TITLE
test(wake): cover command helper seams

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,21 +1,21 @@
 # Coverage gap analysis
 
-Generated: 2026-05-16T20:06:04.897Z
+Generated: 2026-05-16T20:12:46.803Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **15.5%** (7858/50664)
-Overall function coverage: **59.1%** (855/1446)
+Overall line coverage: **15.9%** (8045/50647)
+Overall function coverage: **60.4%** (878/1454)
 
 ## Module summary
 
 | Module | Files | Missing from LCOV | Lines | Functions | Branches |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| cli/dispatch | 88 | 22 | 26.8% (2010/7500) | 56.9% (202/355) | n/a (0/0) |
+| cli/dispatch | 88 | 22 | 29.0% (2173/7485) | 61.7% (224/363) | n/a (0/0) |
 | config/runtime | 19 | 2 | 43.3% (510/1179) | 40.2% (35/87) | n/a (0/0) |
-| fleet | 17 | 0 | 23.2% (249/1073) | 47.9% (34/71) | n/a (0/0) |
+| fleet | 17 | 0 | 25.5% (273/1071) | 49.3% (35/71) | n/a (0/0) |
 | matcher | 2 | 0 | 100.0% (41/41) | 100.0% (8/8) | n/a (0/0) |
 | other | 174 | 98 | 18.7% (2699/14401) | 57.6% (278/483) | n/a (0/0) |
 | plugin dispatch | 15 | 1 | 67.2% (819/1218) | 83.8% (67/80) | n/a (0/0) |
@@ -28,11 +28,11 @@ Overall function coverage: **59.1%** (855/1446)
 | Rank | Risk | Module | File | Uncovered | Line coverage | Function coverage | Note |
 | ---: | --- | --- | --- | ---: | ---: | ---: | --- |
 | 1 | low | vendor plugins | `src/vendor/mpr-plugins/dream/impl.ts` | 885 | 0.0% | n/a | absent from LCOV |
-| 2 | critical | cli/dispatch | `src/commands/shared/wake-cmd.ts` | 621 | 5.3% | 4.5% | partial coverage |
-| 3 | medium | other | `src/commands/plugins/tmux/impl.ts` | 590 | 5.1% | 0.0% | partial coverage |
-| 4 | critical | cli/dispatch | `src/commands/shared/comm-send.ts` | 510 | 9.3% | 26.7% | partial coverage |
-| 5 | low | vendor plugins | `src/vendor/mpr-plugins/team/team-charter.ts` | 482 | 0.0% | n/a | absent from LCOV |
-| 6 | medium | other | `src/commands/plugins/team/index.ts` | 477 | 0.0% | n/a | absent from LCOV |
+| 2 | medium | other | `src/commands/plugins/tmux/impl.ts` | 590 | 5.1% | 0.0% | partial coverage |
+| 3 | critical | cli/dispatch | `src/commands/shared/comm-send.ts` | 510 | 9.3% | 26.7% | partial coverage |
+| 4 | low | vendor plugins | `src/vendor/mpr-plugins/team/team-charter.ts` | 482 | 0.0% | n/a | absent from LCOV |
+| 5 | medium | other | `src/commands/plugins/team/index.ts` | 477 | 0.0% | n/a | absent from LCOV |
+| 6 | critical | cli/dispatch | `src/commands/shared/wake-cmd.ts` | 443 | 30.9% | 76.7% | partial coverage |
 | 7 | low | vendor plugins | `src/vendor/mpr-plugins/messages/index.ts` | 398 | 0.0% | n/a | absent from LCOV |
 | 8 | critical | cli/dispatch | `src/cli/cmd-update.ts` | 380 | 13.0% | 33.3% | partial coverage |
 | 9 | medium | other | `src/api/sessions.ts` | 372 | 16.8% | 12.5% | partial coverage |
@@ -81,6 +81,7 @@ Overall function coverage: **59.1%** (855/1446)
 | cli/dispatch | `src/commands/shared/wake-target.ts` | 80.0% | 80.0% |
 | cli/dispatch | `src/commands/shared/wake.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/workspace.ts` | 100.0% | 100.0% |
+| fleet | `src/core/fleet/leaf.ts` | 100.0% | 100.0% |
 | fleet | `src/core/fleet/oracle-registry.ts` | 100.0% | 100.0% |
 | fleet | `src/core/fleet/registry-oracle-types.ts` | 100.0% | 100.0% |
 | fleet | `src/core/fleet/snapshot.ts` | 93.4% | 100.0% |
@@ -119,8 +120,8 @@ Overall function coverage: **59.1%** (855/1446)
 
 | Module | File | Uncovered | Line coverage |
 | --- | --- | ---: | ---: |
-| cli/dispatch | `src/commands/shared/wake-cmd.ts` | 621 | 5.3% |
 | cli/dispatch | `src/commands/shared/comm-send.ts` | 510 | 9.3% |
+| cli/dispatch | `src/commands/shared/wake-cmd.ts` | 443 | 30.9% |
 | cli/dispatch | `src/cli/cmd-update.ts` | 380 | 13.0% |
 | transport | `src/core/transport/tmux-class.ts` | 267 | 15.2% |
 | transport | `src/transports/scout.ts` | 248 | 8.5% |
@@ -132,8 +133,8 @@ Overall function coverage: **59.1%** (855/1446)
 
 ## Critical gaps to prioritize
 
-- `src/commands/shared/wake-cmd.ts` (cli/dispatch): 621 uncovered lines, 5.3% line coverage.
 - `src/commands/shared/comm-send.ts` (cli/dispatch): 510 uncovered lines, 9.3% line coverage.
+- `src/commands/shared/wake-cmd.ts` (cli/dispatch): 443 uncovered lines, 30.9% line coverage.
 - `src/cli/cmd-update.ts` (cli/dispatch): 380 uncovered lines, 13.0% line coverage.
 - `src/core/transport/tmux-class.ts` (transport): 267 uncovered lines, 15.2% line coverage.
 

--- a/test/wake-cmd-default.test.ts
+++ b/test/wake-cmd-default.test.ts
@@ -1,0 +1,318 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  buildWakeBudLineage,
+  findWakeSnapshotSession,
+  getLiveTileRoles,
+  planRehydrateWorktreeWindows,
+  planSnapshotRestoreWindows,
+  retryFreshSessionTmuxStep,
+  shouldOfferExistingSessionAttach,
+  waitForTmuxSessionReady,
+  writeWakeBudBirthSignal,
+  writeWakeBudLineage,
+} from "../src/commands/shared/wake-cmd";
+import type { Snapshot } from "../src/core/fleet/snapshot";
+
+const tempRoots: string[] = [];
+const originalClaudeAgentName = process.env.CLAUDE_AGENT_NAME;
+const originalMawOracleName = process.env.MAW_ORACLE_NAME;
+
+function restoreEnv(name: "CLAUDE_AGENT_NAME" | "MAW_ORACLE_NAME", value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+function tempRoot(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempRoots.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempRoots.splice(0)) rmSync(dir, { recursive: true, force: true });
+  restoreEnv("CLAUDE_AGENT_NAME", originalClaudeAgentName);
+  restoreEnv("MAW_ORACLE_NAME", originalMawOracleName);
+});
+
+describe("wake-bud lineage helpers — default coverage", () => {
+  it("builds stable YAML scalar lineage when all fields are explicit", () => {
+    const lineage = buildWakeBudLineage({
+      parentOracle: "mawjs",
+      task: "issue-1637",
+      branch: "test/coverage",
+      buddedAt: "2026-05-16T20:00:00.000Z",
+      buddedBy: "codex",
+    });
+
+    expect(lineage).toBe([
+      'budded_from: "mawjs"',
+      'budded_at: "2026-05-16T20:00:00.000Z"',
+      'budded_by: "codex"',
+      'branch: "test/coverage"',
+      'task: "issue-1637"',
+      "",
+    ].join("\n"));
+  });
+
+  it("uses the runtime actor fallback and blank branch defaults", () => {
+    process.env.CLAUDE_AGENT_NAME = "mawjs-codex";
+    const lineage = buildWakeBudLineage({
+      parentOracle: "mawjs",
+      task: "cover wake",
+      buddedAt: "2026-05-16T20:01:00.000Z",
+    });
+
+    expect(lineage).toContain('budded_by: "mawjs-codex"');
+    expect(lineage).toContain('branch: ""');
+  });
+
+  it("writes lineage under ψ/.lineage.yaml", () => {
+    const root = tempRoot("maw-wake-lineage-");
+    const file = writeWakeBudLineage(root, {
+      parentOracle: "mawjs",
+      task: "issue-1637",
+      branch: "alpha",
+      buddedAt: "2026-05-16T20:02:00.000Z",
+      buddedBy: "codex",
+    });
+
+    expect(file).toBe(join(root, "ψ", ".lineage.yaml"));
+    expect(readFileSync(file, "utf8")).toContain('task: "issue-1637"');
+  });
+
+  it("writes a wake-bud birth signal with worktree context", () => {
+    const parent = tempRoot("maw-wake-signal-");
+    const file = writeWakeBudBirthSignal(parent, "mawjs-issue-1637", {
+      parentOracle: "mawjs",
+      task: "issue-1637",
+      branch: "alpha",
+      worktreePath: "/repo/mawjs-oracle.wt-issue-1637",
+    });
+
+    expect(existsSync(file)).toBe(true);
+    const signal = JSON.parse(readFileSync(file, "utf8"));
+    expect(signal.kind).toBe("info");
+    expect(signal.message).toBe("wake-bud born: mawjs-issue-1637");
+    expect(signal.context).toEqual({
+      buddedFrom: "mawjs",
+      task: "issue-1637",
+      branch: "alpha",
+      worktreePath: "/repo/mawjs-oracle.wt-issue-1637",
+    });
+  });
+});
+
+describe("wake attach prompt gate — default coverage", () => {
+  it("offers attach only for interactive plain wake", () => {
+    expect(shouldOfferExistingSessionAttach({}, true)).toBe(true);
+    expect(shouldOfferExistingSessionAttach({ attach: true }, true)).toBe(false);
+    expect(shouldOfferExistingSessionAttach({ split: true }, true)).toBe(false);
+    expect(shouldOfferExistingSessionAttach({ bring: true }, true)).toBe(false);
+    expect(shouldOfferExistingSessionAttach({}, false)).toBe(false);
+  });
+});
+
+describe("wake live tile role reader — default coverage", () => {
+  it("returns trimmed non-empty tmux tile roles", async () => {
+    const roles = await getLiveTileRoles("54-mawjs", {
+      hostExecFn: async cmd => {
+        expect(cmd).toBe("tmux list-panes -t '54-mawjs' -F '#{@maw_tile_role}'");
+        return "tile-1\n\n tile-2 \n";
+      },
+    });
+
+    expect([...roles]).toEqual(["tile-1", "tile-2"]);
+  });
+
+  it("fails soft to an empty set when tmux role lookup fails", async () => {
+    const roles = await getLiveTileRoles("missing", {
+      hostExecFn: async () => { throw new Error("can't find session"); },
+    });
+
+    expect(roles.size).toBe(0);
+  });
+});
+
+describe("fresh wake tmux readiness — default coverage", () => {
+  it("waits until the fresh session becomes visible", async () => {
+    let checks = 0;
+    const sleeps: number[] = [];
+
+    await waitForTmuxSessionReady("47-mawjs", {
+      attempts: 4,
+      delayMs: 5,
+      sleep: async ms => { sleeps.push(ms); },
+      hasSession: async session => {
+        expect(session).toBe("47-mawjs");
+        checks++;
+        return checks === 3;
+      },
+    });
+
+    expect(checks).toBe(3);
+    expect(sleeps).toEqual([5, 5]);
+  });
+
+  it("throws after exhausting visibility checks", async () => {
+    const sleeps: number[] = [];
+    await expect(waitForTmuxSessionReady("47-mawjs", {
+      attempts: 3,
+      delayMs: 7,
+      sleep: async ms => { sleeps.push(ms); },
+      hasSession: async () => false,
+    })).rejects.toThrow("tmux did not report fresh session '47-mawjs' ready after 3 checks");
+    expect(sleeps).toEqual([7, 7]);
+  });
+
+  it("retries transient can't-find-session setup races", async () => {
+    let attempts = 0;
+    let visibilityChecks = 0;
+
+    const result = await retryFreshSessionTmuxStep("47-mawjs", "launch main window", async () => {
+      attempts++;
+      if (attempts === 1) throw new Error("[local:local] can't find session: 47-mawjs");
+      return "launched";
+    }, {
+      attempts: 3,
+      delayMs: 5,
+      sleep: async () => {},
+      hasSession: async session => {
+        expect(session).toBe("47-mawjs");
+        visibilityChecks++;
+        return true;
+      },
+    });
+
+    expect(result).toBe("launched");
+    expect(attempts).toBe(2);
+    expect(visibilityChecks).toBe(1);
+  });
+
+  it("does not hide unrelated setup failures", async () => {
+    let attempts = 0;
+
+    await expect(retryFreshSessionTmuxStep("47-mawjs", "set session environment", async () => {
+      attempts++;
+      throw new Error("pass show 'secret' failed (exit 1)");
+    }, {
+      attempts: 3,
+      sleep: async () => {},
+      hasSession: async () => true,
+    })).rejects.toThrow(/pass show/);
+
+    expect(attempts).toBe(1);
+  });
+
+  it("treats nested causes as fresh-session lookup races until attempts exhaust", async () => {
+    let attempts = 0;
+    await expect(retryFreshSessionTmuxStep("47-mawjs", "select window", async () => {
+      attempts++;
+      throw new Error("outer", { cause: new Error("can't find window: 47-mawjs") });
+    }, {
+      attempts: 2,
+      delayMs: 1,
+      sleep: async () => {},
+      hasSession: async () => true,
+    })).rejects.toThrow("outer");
+    expect(attempts).toBe(2);
+  });
+});
+
+describe("wake worktree rehydrate planning — default coverage", () => {
+  it("plans missing worktree windows, skips live tile roles, and avoids duplicate window names", () => {
+    const planned = planRehydrateWorktreeWindows(
+      "mawjs",
+      [
+        { name: "1-feature-a", path: "/repo/mawjs-oracle.wt-1-feature-a" },
+        { name: "2-tile-1", path: "/repo/mawjs-oracle.wt-2-tile-1" },
+        { name: "feature-a", path: "/repo/mawjs-oracle.wt-feature-a" },
+        { name: "3-feature-c", path: "/repo/mawjs-oracle.wt-3-feature-c" },
+      ],
+      ["mawjs-oracle", "mawjs-feature-a"],
+      new Set(["tile-1"]),
+    );
+
+    expect(planned).toEqual([
+      {
+        worktreeName: "3-feature-c",
+        windowName: "mawjs-feature-c",
+        path: "/repo/mawjs-oracle.wt-3-feature-c",
+      },
+    ]);
+  });
+
+  it("falls back to numeric worktree names when the stripped name is already planned", () => {
+    const planned = planRehydrateWorktreeWindows("mawjs", [
+      { name: "feature-a", path: "/repo/wt-feature-a" },
+      { name: "2-feature-a", path: "/repo/wt-2-feature-a" },
+    ]);
+
+    expect(planned).toEqual([
+      { worktreeName: "feature-a", windowName: "mawjs-feature-a", path: "/repo/wt-feature-a" },
+      { worktreeName: "2-feature-a", windowName: "mawjs-2-feature-a", path: "/repo/wt-2-feature-a" },
+    ]);
+  });
+});
+
+describe("wake snapshot restore planning — default coverage", () => {
+  const snapshot: Snapshot = {
+    timestamp: "2026-05-16T11:00:00.000Z",
+    trigger: "wake",
+    node: "m5",
+    sessions: [
+      { name: "54-mawjs", windows: [{ name: "mawjs-oracle" }, { name: "mawjs-feature-a" }] },
+      { name: "discord", windows: [{ name: "discord-oracle" }] },
+    ],
+  };
+
+  it("finds exact sessions before numeric-prefix and suffix oracle matches", () => {
+    expect(findWakeSnapshotSession(snapshot, "mawjs", "54-mawjs")?.name).toBe("54-mawjs");
+    expect(findWakeSnapshotSession(snapshot, "mawjs", null)?.name).toBe("54-mawjs");
+    expect(findWakeSnapshotSession(snapshot, "discord", null)?.name).toBe("discord");
+    expect(findWakeSnapshotSession(snapshot, "missing", null)).toBeNull();
+  });
+
+  it("plans only missing snapshot windows and maps worktree-shaped names to cwd", () => {
+    const planned = planSnapshotRestoreWindows(
+      "mawjs",
+      {
+        name: "54-mawjs",
+        windows: [
+          { name: "mawjs-oracle" },
+          { name: "mawjs-feature-a" },
+          { name: "mawjs-2-feature-b" },
+          { name: "notes" },
+          { name: "mawjs-feature-a" },
+          { name: "   " },
+        ],
+      },
+      ["mawjs-oracle"],
+      [
+        { name: "1-feature-a", path: "/repo/mawjs-oracle.wt-1-feature-a" },
+        { name: "2-feature-b", path: "/repo/mawjs-oracle.wt-2-feature-b" },
+      ],
+      "/repo/mawjs-oracle",
+    );
+
+    expect(planned).toEqual([
+      {
+        windowName: "mawjs-feature-a",
+        cwd: "/repo/mawjs-oracle.wt-1-feature-a",
+        source: "worktree",
+      },
+      {
+        windowName: "mawjs-2-feature-b",
+        cwd: "/repo/mawjs-oracle.wt-2-feature-b",
+        source: "worktree",
+      },
+      {
+        windowName: "notes",
+        cwd: "/repo/mawjs-oracle",
+        source: "repo",
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add a mock-free default coverage suite for wake command helpers
- cover wake-bud lineage/signal helpers, attach prompt gating, live tile-role lookup, fresh tmux readiness retries, worktree rehydrate planning, and snapshot restore planning
- refresh the coverage gap report for #1637

## Coverage impact
- `src/commands/shared/wake-cmd.ts`: 5.3% lines / 4.5% funcs → 30.9% lines / 76.7% funcs
- uncovered wake-cmd lines: 621 → 443
- overall functions: 59.1% → 60.4%

## Verification
- `bun test test/wake-cmd-default.test.ts` → 16 pass / 0 fail
- `bun run test:coverage` → 1599 pass / 6 skip / 0 fail
- `bun run build` → success
- `bun run test:isolated` → 119/119 files passed / 0 failed

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.