### PR TITLE
test: cover comm-send helpers in default coverage

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,19 +1,19 @@
 # Coverage gap analysis
 
-Generated: 2026-05-16T20:12:46.803Z
+Generated: 2026-05-16T20:20:43.119Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **15.9%** (8045/50647)
-Overall function coverage: **60.4%** (878/1454)
+Overall line coverage: **16.0%** (8088/50649)
+Overall function coverage: **60.7%** (885/1459)
 
 ## Module summary
 
 | Module | Files | Missing from LCOV | Lines | Functions | Branches |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| cli/dispatch | 88 | 22 | 29.0% (2173/7485) | 61.7% (224/363) | n/a (0/0) |
+| cli/dispatch | 88 | 22 | 29.6% (2216/7487) | 62.8% (231/368) | n/a (0/0) |
 | config/runtime | 19 | 2 | 43.3% (510/1179) | 40.2% (35/87) | n/a (0/0) |
 | fleet | 17 | 0 | 25.5% (273/1071) | 49.3% (35/71) | n/a (0/0) |
 | matcher | 2 | 0 | 100.0% (41/41) | 100.0% (8/8) | n/a (0/0) |
@@ -29,9 +29,9 @@ Overall function coverage: **60.4%** (878/1454)
 | ---: | --- | --- | --- | ---: | ---: | ---: | --- |
 | 1 | low | vendor plugins | `src/vendor/mpr-plugins/dream/impl.ts` | 885 | 0.0% | n/a | absent from LCOV |
 | 2 | medium | other | `src/commands/plugins/tmux/impl.ts` | 590 | 5.1% | 0.0% | partial coverage |
-| 3 | critical | cli/dispatch | `src/commands/shared/comm-send.ts` | 510 | 9.3% | 26.7% | partial coverage |
-| 4 | low | vendor plugins | `src/vendor/mpr-plugins/team/team-charter.ts` | 482 | 0.0% | n/a | absent from LCOV |
-| 5 | medium | other | `src/commands/plugins/team/index.ts` | 477 | 0.0% | n/a | absent from LCOV |
+| 3 | low | vendor plugins | `src/vendor/mpr-plugins/team/team-charter.ts` | 482 | 0.0% | n/a | absent from LCOV |
+| 4 | medium | other | `src/commands/plugins/team/index.ts` | 477 | 0.0% | n/a | absent from LCOV |
+| 5 | critical | cli/dispatch | `src/commands/shared/comm-send.ts` | 469 | 16.8% | 55.0% | partial coverage |
 | 6 | critical | cli/dispatch | `src/commands/shared/wake-cmd.ts` | 443 | 30.9% | 76.7% | partial coverage |
 | 7 | low | vendor plugins | `src/vendor/mpr-plugins/messages/index.ts` | 398 | 0.0% | n/a | absent from LCOV |
 | 8 | critical | cli/dispatch | `src/cli/cmd-update.ts` | 380 | 13.0% | 33.3% | partial coverage |
@@ -120,7 +120,7 @@ Overall function coverage: **60.4%** (878/1454)
 
 | Module | File | Uncovered | Line coverage |
 | --- | --- | ---: | ---: |
-| cli/dispatch | `src/commands/shared/comm-send.ts` | 510 | 9.3% |
+| cli/dispatch | `src/commands/shared/comm-send.ts` | 469 | 16.8% |
 | cli/dispatch | `src/commands/shared/wake-cmd.ts` | 443 | 30.9% |
 | cli/dispatch | `src/cli/cmd-update.ts` | 380 | 13.0% |
 | transport | `src/core/transport/tmux-class.ts` | 267 | 15.2% |
@@ -133,7 +133,7 @@ Overall function coverage: **60.4%** (878/1454)
 
 ## Critical gaps to prioritize
 
-- `src/commands/shared/comm-send.ts` (cli/dispatch): 510 uncovered lines, 9.3% line coverage.
+- `src/commands/shared/comm-send.ts` (cli/dispatch): 469 uncovered lines, 16.8% line coverage.
 - `src/commands/shared/wake-cmd.ts` (cli/dispatch): 443 uncovered lines, 30.9% line coverage.
 - `src/cli/cmd-update.ts` (cli/dispatch): 380 uncovered lines, 13.0% line coverage.
 - `src/core/transport/tmux-class.ts` (transport): 267 uncovered lines, 15.2% line coverage.

--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -30,13 +30,20 @@ import { buildMessageLifecycleFeedEvent, type MessageLifecycleInput } from "../.
  * error path surfaces correctly.
  */
 /** @internal */
-export async function resolveOraclePane(target: string): Promise<string> {
+export async function resolveOraclePane(
+  target: string,
+  deps: {
+    tmuxRun?: (...args: string[]) => Promise<string>;
+    isAgentCommandFn?: typeof isAgentCommand;
+  } = {},
+): Promise<string> {
   // Already pane-specific — honor caller's choice.
   if (/\.[0-9]+$/.test(target)) return target;
 
   try {
-    const t = new Tmux();
-    const raw = await t.run("list-panes", "-t", target, "-F", "#{pane_index} #{pane_current_command}");
+    const run = deps.tmuxRun ?? ((...args: string[]) => new Tmux().run(...args));
+    const isAgent = deps.isAgentCommandFn ?? isAgentCommand;
+    const raw = await run("list-panes", "-t", target, "-F", "#{pane_index} #{pane_current_command}");
     const lines = raw.split("\n").map((l: string) => l.trim()).filter(Boolean);
     if (lines.length <= 1) return target; // single-pane window: active pane is the only pane
 
@@ -46,7 +53,7 @@ export async function resolveOraclePane(target: string): Promise<string> {
       if (spaceIdx < 0) continue;
       const idx = parseInt(line.slice(0, spaceIdx), 10);
       const cmd = line.slice(spaceIdx + 1);
-      if (Number.isFinite(idx) && isAgentCommand(cmd)) {
+      if (Number.isFinite(idx) && isAgent(cmd)) {
         agentIndexes.push(idx);
       }
     }
@@ -108,9 +115,14 @@ function emitMessageFeed(input: MessageLifecycleInput, port: number) {
  * Errors and non-shell panes (running agent) conservatively return idle=true.
  * (#405 — idle guard before send-keys)
  */
-export async function checkPaneIdle(target: string, host?: string): Promise<{ idle: boolean; lastInput: string }> {
+export async function checkPaneIdle(
+  target: string,
+  host?: string,
+  deps: { captureFn?: typeof capture } = {},
+): Promise<{ idle: boolean; lastInput: string }> {
+  const capturePane = deps.captureFn ?? capture;
   try {
-    const content = await capture(target, 5, host);
+    const content = await capturePane(target, 5, host);
     const lines = content.split("\n").filter(l => l.trim());
     const lastLine = lines.at(-1) ?? "";
     // Strip ANSI escape codes

--- a/test/comm-send-default.test.ts
+++ b/test/comm-send-default.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  checkPaneIdle,
+  formatSignedMessage,
+  resolveMyName,
+  resolveOraclePane,
+} from "../src/commands/shared/comm-send";
+
+describe("resolveOraclePane — default coverage seams", () => {
+  test("honors pane-specific targets without consulting tmux", async () => {
+    let called = false;
+
+    const out = await resolveOraclePane("54-mawjs:mawjs-oracle.2", {
+      tmuxRun: async () => {
+        called = true;
+        throw new Error("should not run tmux for pane-specific targets");
+      },
+    });
+
+    expect(out).toBe("54-mawjs:mawjs-oracle.2");
+    expect(called).toBe(false);
+  });
+
+  test("leaves single-pane windows unchanged", async () => {
+    const out = await resolveOraclePane("54-mawjs:mawjs-oracle", {
+      tmuxRun: async (...args: string[]) => {
+        expect(args).toEqual([
+          "list-panes",
+          "-t",
+          "54-mawjs:mawjs-oracle",
+          "-F",
+          "#{pane_index} #{pane_current_command}",
+        ]);
+        return "0 zsh\n";
+      },
+    });
+
+    expect(out).toBe("54-mawjs:mawjs-oracle");
+  });
+
+  test("chooses the lowest-index agent pane from multi-pane windows", async () => {
+    const out = await resolveOraclePane("54-mawjs:mawjs-oracle", {
+      tmuxRun: async () => [
+        "0 zsh",
+        "3 codex",
+        "1 claude",
+        "2 node",
+      ].join("\n"),
+      isAgentCommandFn: (cmd: string) => ["claude", "codex", "node"].includes(cmd),
+    });
+
+    expect(out).toBe("54-mawjs:mawjs-oracle.1");
+  });
+
+  test("skips malformed pane rows before choosing an agent", async () => {
+    const out = await resolveOraclePane("54-mawjs:mawjs-oracle", {
+      tmuxRun: async () => [
+        "not-a-pane-row",
+        "NaN claude",
+        "4 zsh",
+        "2 claude",
+      ].join("\n"),
+      isAgentCommandFn: (cmd: string) => cmd === "claude",
+    });
+
+    expect(out).toBe("54-mawjs:mawjs-oracle.2");
+  });
+
+  test("leaves multi-pane windows unchanged when no agent pane exists", async () => {
+    const out = await resolveOraclePane("54-mawjs:mawjs-oracle", {
+      tmuxRun: async () => "0 zsh\n1 bash\n",
+      isAgentCommandFn: () => false,
+    });
+
+    expect(out).toBe("54-mawjs:mawjs-oracle");
+  });
+
+  test("leaves targets unchanged when tmux pane listing fails", async () => {
+    const out = await resolveOraclePane("54-mawjs:mawjs-oracle", {
+      tmuxRun: async () => {
+        throw new Error("tmux unavailable");
+      },
+    });
+
+    expect(out).toBe("54-mawjs:mawjs-oracle");
+  });
+});
+
+describe("checkPaneIdle — default coverage seams", () => {
+  test("treats an empty shell prompt as idle", async () => {
+    const out = await checkPaneIdle("54-mawjs:mawjs-oracle.0", undefined, {
+      captureFn: async () => "previous output\nuser@host:~$ ",
+    });
+
+    expect(out).toEqual({ idle: true, lastInput: "" });
+  });
+
+  test("treats a zsh prompt with no typed input as idle", async () => {
+    const out = await checkPaneIdle("54-mawjs:mawjs-oracle.0", undefined, {
+      captureFn: async () => "❯ ",
+    });
+
+    expect(out).toEqual({ idle: true, lastInput: "" });
+  });
+
+  test("returns typed input after a prompt marker", async () => {
+    const out = await checkPaneIdle("54-mawjs:mawjs-oracle.0", undefined, {
+      captureFn: async () => "❯ maw hey le:hojo hi",
+    });
+
+    expect(out).toEqual({ idle: false, lastInput: "maw hey le:hojo hi" });
+  });
+
+  test("strips ANSI escape sequences before detecting typed input", async () => {
+    const out = await checkPaneIdle("54-mawjs:mawjs-oracle.0", undefined, {
+      captureFn: async () => "\x1b[32m❯\x1b[0m maw ls",
+    });
+
+    expect(out).toEqual({ idle: false, lastInput: "maw ls" });
+  });
+
+  test("treats command output with no visible prompt as idle", async () => {
+    const out = await checkPaneIdle("54-mawjs:mawjs-oracle.0", undefined, {
+      captureFn: async () => "building...\nstill running",
+    });
+
+    expect(out).toEqual({ idle: true, lastInput: "" });
+  });
+
+  test("treats capture failures as idle", async () => {
+    const out = await checkPaneIdle("54-mawjs:mawjs-oracle.0", undefined, {
+      captureFn: async () => {
+        throw new Error("capture failed");
+      },
+    });
+
+    expect(out).toEqual({ idle: true, lastInput: "" });
+  });
+
+  test("forwards target, line count, and host to the capture dependency", async () => {
+    const seen: unknown[][] = [];
+    await checkPaneIdle("mba:48-mawjs:oracle.0", "mba", {
+      captureFn: async (...args: unknown[]) => {
+        seen.push(args);
+        return "❯ ";
+      },
+    });
+
+    expect(seen).toEqual([["mba:48-mawjs:oracle.0", 5, "mba"]]);
+  });
+});
+
+describe("resolveMyName — environment attribution", () => {
+  const originalName = process.env.CLAUDE_AGENT_NAME;
+
+  afterEach(() => {
+    if (originalName === undefined) {
+      delete process.env.CLAUDE_AGENT_NAME;
+    } else {
+      process.env.CLAUDE_AGENT_NAME = originalName;
+    }
+  });
+
+  test("uses CLAUDE_AGENT_NAME before shelling out to tmux", () => {
+    process.env.CLAUDE_AGENT_NAME = "mawjs-codex";
+
+    expect(resolveMyName({ node: "m5" } as never)).toBe("mawjs-codex");
+  });
+});
+
+describe("formatSignedMessage — edge branches", () => {
+  test("leaves empty and whitespace-only messages unchanged", () => {
+    expect(formatSignedMessage("", { node: "m5" }, "mawjs-codex")).toBe("");
+    expect(formatSignedMessage("   ", { node: "m5" }, "mawjs-codex")).toBe("   ");
+  });
+
+  test("falls back to local when config.node is absent", () => {
+    expect(formatSignedMessage("hello", {}, "mawjs-codex")).toBe("[local:mawjs-codex] hello");
+  });
+
+  test("does not double-prefix after leading whitespace", () => {
+    expect(formatSignedMessage("  [m5:mawjs-codex] hello", { node: "m5" }, "mawjs-codex"))
+      .toBe("  [m5:mawjs-codex] hello");
+  });
+});


### PR DESCRIPTION
## Summary
- add mock-free default tests for comm-send pane resolution, idle detection, sender attribution, and signing edge branches
- add narrow optional dependency seams for `resolveOraclePane` and `checkPaneIdle` so default coverage does not import process-global mock suites
- refresh coverage gap report: comm-send uncovered lines 510 → 469, line coverage 9.3% → 16.8%, function coverage 26.7% → 55.0%

## Validation
- `rtk bun test test/comm-send-default.test.ts test/comm-send-signing.test.ts test/comm-send-deprecation-759.test.ts`
- `rtk bun run test:coverage` — 1616 pass / 6 skip / 0 fail; overall functions 60.7%
- `rtk bun run build`
- `rtk bun run test:isolated` — 119/119 files passed / 0 failed

## Release
- alpha branch only
- no release-alpha cut

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.