### PR TITLE
test: cover cmd-update filesystem helpers

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,19 +1,19 @@
 # Coverage gap analysis
 
-Generated: 2026-05-16T20:20:43.119Z
+Generated: 2026-05-16T20:28:01.628Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **16.0%** (8088/50649)
-Overall function coverage: **60.7%** (885/1459)
+Overall line coverage: **16.1%** (8155/50644)
+Overall function coverage: **61.0%** (892/1462)
 
 ## Module summary
 
 | Module | Files | Missing from LCOV | Lines | Functions | Branches |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| cli/dispatch | 88 | 22 | 29.6% (2216/7487) | 62.8% (231/368) | n/a (0/0) |
+| cli/dispatch | 88 | 22 | 30.5% (2283/7482) | 64.2% (238/371) | n/a (0/0) |
 | config/runtime | 19 | 2 | 43.3% (510/1179) | 40.2% (35/87) | n/a (0/0) |
 | fleet | 17 | 0 | 25.5% (273/1071) | 49.3% (35/71) | n/a (0/0) |
 | matcher | 2 | 0 | 100.0% (41/41) | 100.0% (8/8) | n/a (0/0) |
@@ -34,12 +34,12 @@ Overall function coverage: **60.7%** (885/1459)
 | 5 | critical | cli/dispatch | `src/commands/shared/comm-send.ts` | 469 | 16.8% | 55.0% | partial coverage |
 | 6 | critical | cli/dispatch | `src/commands/shared/wake-cmd.ts` | 443 | 30.9% | 76.7% | partial coverage |
 | 7 | low | vendor plugins | `src/vendor/mpr-plugins/messages/index.ts` | 398 | 0.0% | n/a | absent from LCOV |
-| 8 | critical | cli/dispatch | `src/cli/cmd-update.ts` | 380 | 13.0% | 33.3% | partial coverage |
-| 9 | medium | other | `src/api/sessions.ts` | 372 | 16.8% | 12.5% | partial coverage |
-| 10 | low | vendor plugins | `src/vendor/mpr-plugins/cleanup/internal/prune-stale-oracles.ts` | 366 | 0.0% | n/a | absent from LCOV |
-| 11 | medium | other | `src/core/engine-plugin-registry.ts` | 336 | 0.0% | n/a | absent from LCOV |
-| 12 | low | vendor plugins | `src/vendor/mpr-plugins/doctor/impl.ts` | 332 | 0.0% | n/a | absent from LCOV |
-| 13 | low | vendor plugins | `src/vendor/mpr-plugins/team/index.ts` | 314 | 0.0% | n/a | absent from LCOV |
+| 8 | medium | other | `src/api/sessions.ts` | 372 | 16.8% | 12.5% | partial coverage |
+| 9 | low | vendor plugins | `src/vendor/mpr-plugins/cleanup/internal/prune-stale-oracles.ts` | 366 | 0.0% | n/a | absent from LCOV |
+| 10 | medium | other | `src/core/engine-plugin-registry.ts` | 336 | 0.0% | n/a | absent from LCOV |
+| 11 | low | vendor plugins | `src/vendor/mpr-plugins/doctor/impl.ts` | 332 | 0.0% | n/a | absent from LCOV |
+| 12 | low | vendor plugins | `src/vendor/mpr-plugins/team/index.ts` | 314 | 0.0% | n/a | absent from LCOV |
+| 13 | critical | cli/dispatch | `src/cli/cmd-update.ts` | 308 | 28.7% | 73.3% | partial coverage |
 | 14 | low | vendor plugins | `src/vendor/mpr-plugins/bg/src/impl.ts` | 297 | 0.0% | n/a | absent from LCOV |
 | 15 | medium | other | `src/commands/plugins/tile/impl.ts` | 283 | 0.0% | n/a | absent from LCOV |
 | 16 | medium | other | `src/commands/plugins/plugin/install-handlers.ts` | 280 | 24.9% | 18.8% | partial coverage |
@@ -122,7 +122,7 @@ Overall function coverage: **60.7%** (885/1459)
 | --- | --- | ---: | ---: |
 | cli/dispatch | `src/commands/shared/comm-send.ts` | 469 | 16.8% |
 | cli/dispatch | `src/commands/shared/wake-cmd.ts` | 443 | 30.9% |
-| cli/dispatch | `src/cli/cmd-update.ts` | 380 | 13.0% |
+| cli/dispatch | `src/cli/cmd-update.ts` | 308 | 28.7% |
 | transport | `src/core/transport/tmux-class.ts` | 267 | 15.2% |
 | transport | `src/transports/scout.ts` | 248 | 8.5% |
 | cli/dispatch | `src/commands/shared/wake-resolve-impl.ts` | 226 | 28.7% |
@@ -135,7 +135,7 @@ Overall function coverage: **60.7%** (885/1459)
 
 - `src/commands/shared/comm-send.ts` (cli/dispatch): 469 uncovered lines, 16.8% line coverage.
 - `src/commands/shared/wake-cmd.ts` (cli/dispatch): 443 uncovered lines, 30.9% line coverage.
-- `src/cli/cmd-update.ts` (cli/dispatch): 380 uncovered lines, 13.0% line coverage.
+- `src/cli/cmd-update.ts` (cli/dispatch): 308 uncovered lines, 28.7% line coverage.
 - `src/core/transport/tmux-class.ts` (transport): 267 uncovered lines, 15.2% line coverage.
 
 ## Prioritization guidance

--- a/src/cli/cmd-update.ts
+++ b/src/cli/cmd-update.ts
@@ -10,13 +10,14 @@ import { getVersionString } from "./cmd-version";
 import { ghqFindSync } from "../core/ghq";
 import { withUpdateLock } from "./update-lock";
 
-function clearBunGlobalResolverState(): () => void {
+/** @internal exported for default-run coverage tests. */
+export function clearBunGlobalResolverState(home = homedir()): () => void {
   // #1449 — Bun can reject `bun add -g github:...#newRef` before it mutates
   // anything when the global package.json/lock still pins maw-js to a
   // different GitHub ref. Remove only resolver metadata before the *first*
   // install attempt; keep the current bin + node_modules in place so a
   // network/auth failure still leaves the running maw usable.
-  const bunGlobal = join(homedir(), ".bun", "install", "global");
+  const bunGlobal = join(home, ".bun", "install", "global");
   const globalPkg = join(bunGlobal, "package.json");
   let pkgBackup: string | null = null;
   try {
@@ -36,7 +37,7 @@ function clearBunGlobalResolverState(): () => void {
     }
   } catch {}
   try {
-    const cacheDir = join(homedir(), ".bun", "install", "cache");
+    const cacheDir = join(home, ".bun", "install", "cache");
     if (existsSync(cacheDir)) {
       for (const entry of readdirSync(cacheDir)) {
         if (entry.includes("maw-js")) {
@@ -52,11 +53,13 @@ function clearBunGlobalResolverState(): () => void {
   };
 }
 
-function isPluginSourceDir(dir: string): boolean {
+/** @internal exported for default-run coverage tests. */
+export function isPluginSourceDir(dir: string): boolean {
   return existsSync(join(dir, "plugin.json")) || existsSync(join(dir, "index.ts"));
 }
 
-function linkBundledPluginRoots(pluginDir: string, roots: string[]): number {
+/** @internal exported for default-run coverage tests. */
+export function linkBundledPluginRoots(pluginDir: string, roots: string[]): number {
   let refreshed = 0;
   for (const root of roots) {
     if (!existsSync(root)) continue;
@@ -73,7 +76,8 @@ function linkBundledPluginRoots(pluginDir: string, roots: string[]): number {
   return refreshed;
 }
 
-function healBrokenPluginSymlinks(pluginDir: string, roots: string[]): { healed: number; pruned: number } {
+/** @internal exported for default-run coverage tests. */
+export function healBrokenPluginSymlinks(pluginDir: string, roots: string[]): { healed: number; pruned: number } {
   let healed = 0;
   let pruned = 0;
   for (const entry of readdirSync(pluginDir)) {

--- a/test/cmd-update-helpers.test.ts
+++ b/test/cmd-update-helpers.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync, readFileSync, lstatSync, symlinkSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  clearBunGlobalResolverState,
+  healBrokenPluginSymlinks,
+  isPluginSourceDir,
+  linkBundledPluginRoots,
+} from "../src/cli/cmd-update";
+
+const roots: string[] = [];
+
+function tmpRoot(label: string): string {
+  const dir = mkdtempSync(join(tmpdir(), `maw-update-${label}-`));
+  roots.push(dir);
+  return dir;
+}
+
+function mkdirp(path: string): void {
+  mkdirSync(path, { recursive: true });
+}
+
+afterEach(() => {
+  while (roots.length) {
+    rmSync(roots.pop()!, { recursive: true, force: true });
+  }
+});
+
+describe("cmd-update helper coverage", () => {
+  test("clearBunGlobalResolverState removes maw resolver pins, locks, and cache entries, then restores package.json", () => {
+    const home = tmpRoot("resolver");
+    const bunGlobal = join(home, ".bun", "install", "global");
+    const cacheDir = join(home, ".bun", "install", "cache");
+    mkdirp(bunGlobal);
+    mkdirp(cacheDir);
+
+    const packageJson = join(bunGlobal, "package.json");
+    const original = {
+      dependencies: {
+        "maw-js": "github:Soul-Brews-Studio/maw-js#old",
+        maw: "github:Soul-Brews-Studio/maw-js#older",
+        hono: "^4.0.0",
+      },
+      devDependencies: { keep: "1.0.0" },
+    };
+    writeFileSync(packageJson, JSON.stringify(original, null, 2) + "\n");
+    writeFileSync(join(bunGlobal, "bun.lock"), "old lock");
+    writeFileSync(join(bunGlobal, "bun.lockb"), "old binary lock");
+    mkdirp(join(cacheDir, "maw-js-stale"));
+    mkdirp(join(cacheDir, "other-package"));
+
+    const restore = clearBunGlobalResolverState(home);
+
+    const cleaned = JSON.parse(readFileSync(packageJson, "utf-8"));
+    expect(cleaned.dependencies).toEqual({ hono: "^4.0.0" });
+    expect(cleaned.devDependencies).toEqual({ keep: "1.0.0" });
+    expect(existsSync(join(bunGlobal, "bun.lock"))).toBe(false);
+    expect(existsSync(join(bunGlobal, "bun.lockb"))).toBe(false);
+    expect(existsSync(join(cacheDir, "maw-js-stale"))).toBe(false);
+    expect(existsSync(join(cacheDir, "other-package"))).toBe(true);
+
+    restore();
+
+    expect(JSON.parse(readFileSync(packageJson, "utf-8"))).toEqual(original);
+  });
+
+  test("clearBunGlobalResolverState is best-effort when package metadata is absent", () => {
+    const home = tmpRoot("missing");
+    const bunGlobal = join(home, ".bun", "install", "global");
+    mkdirp(bunGlobal);
+    writeFileSync(join(bunGlobal, "bun.lock"), "old lock");
+
+    const restore = clearBunGlobalResolverState(home);
+
+    expect(existsSync(join(bunGlobal, "bun.lock"))).toBe(false);
+    expect(() => restore()).not.toThrow();
+  });
+
+  test("isPluginSourceDir recognizes plugin.json and index.ts roots only", () => {
+    const root = tmpRoot("source-dir");
+    const withManifest = join(root, "with-manifest");
+    const withIndex = join(root, "with-index");
+    const empty = join(root, "empty");
+    mkdirp(withManifest);
+    mkdirp(withIndex);
+    mkdirp(empty);
+    writeFileSync(join(withManifest, "plugin.json"), "{}");
+    writeFileSync(join(withIndex, "index.ts"), "export default {};");
+
+    expect(isPluginSourceDir(withManifest)).toBe(true);
+    expect(isPluginSourceDir(withIndex)).toBe(true);
+    expect(isPluginSourceDir(empty)).toBe(false);
+  });
+
+  test("linkBundledPluginRoots links plugin source dirs, ignores non-sources, and is idempotent", () => {
+    const root = tmpRoot("link");
+    const pluginDir = join(root, "plugins");
+    const bundled = join(root, "bundled");
+    mkdirp(pluginDir);
+    mkdirp(join(bundled, "alpha"));
+    mkdirp(join(bundled, "beta"));
+    mkdirp(join(bundled, "not-a-plugin"));
+    writeFileSync(join(bundled, "alpha", "plugin.json"), "{}");
+    writeFileSync(join(bundled, "beta", "index.ts"), "export default {};");
+    writeFileSync(join(bundled, "not-a-plugin", "README.md"), "no command");
+
+    expect(linkBundledPluginRoots(pluginDir, [join(root, "missing"), bundled])).toBe(2);
+    expect(lstatSync(join(pluginDir, "alpha")).isSymbolicLink()).toBe(true);
+    expect(lstatSync(join(pluginDir, "beta")).isSymbolicLink()).toBe(true);
+    expect(existsSync(join(pluginDir, "not-a-plugin"))).toBe(false);
+
+    expect(linkBundledPluginRoots(pluginDir, [bundled])).toBe(0);
+  });
+
+  test("linkBundledPluginRoots replaces stale broken symlink destinations before linking", () => {
+    const root = tmpRoot("stale-link");
+    const pluginDir = join(root, "plugins");
+    const bundled = join(root, "bundled");
+    mkdirp(pluginDir);
+    mkdirp(join(bundled, "alpha"));
+    writeFileSync(join(bundled, "alpha", "plugin.json"), "{}");
+    symlinkSync(join(root, "gone", "alpha"), join(pluginDir, "alpha"));
+
+    expect(existsSync(join(pluginDir, "alpha"))).toBe(false);
+    expect(linkBundledPluginRoots(pluginDir, [bundled])).toBe(1);
+    expect(existsSync(join(pluginDir, "alpha", "plugin.json"))).toBe(true);
+  });
+
+  test("healBrokenPluginSymlinks relinks recoverable stale plugins and prunes missing ones", () => {
+    const root = tmpRoot("heal");
+    const pluginDir = join(root, "plugins");
+    const bundled = join(root, "bundled");
+    mkdirp(pluginDir);
+    mkdirp(join(bundled, "recover"));
+    mkdirp(join(bundled, "live"));
+    writeFileSync(join(bundled, "recover", "plugin.json"), "{}");
+    writeFileSync(join(bundled, "live", "plugin.json"), "{}");
+    symlinkSync(join(root, "gone", "recover"), join(pluginDir, "recover"));
+    symlinkSync(join(root, "gone", "prune"), join(pluginDir, "prune"));
+    symlinkSync(join(bundled, "live"), join(pluginDir, "live"));
+
+    const result = healBrokenPluginSymlinks(pluginDir, [bundled]);
+
+    expect(result).toEqual({ healed: 1, pruned: 1 });
+    expect(existsSync(join(pluginDir, "recover", "plugin.json"))).toBe(true);
+    expect(existsSync(join(pluginDir, "prune"))).toBe(false);
+    expect(existsSync(join(pluginDir, "live", "plugin.json"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Exports narrow `cmd-update` filesystem helpers as internal seams so default-run coverage can exercise them without running the destructive installer path.
- Adds temp-directory tests for Bun global resolver cleanup, bundled plugin source symlink linking, stale symlink replacement, and broken-symlink healing/pruning.
- Regenerates the coverage gap report: overall line coverage 16.0% → 16.1%, function coverage 60.7% → 61.0%; `src/cli/cmd-update.ts` improves from 13.0% lines / 33.3% funcs to 28.7% lines / 73.3% funcs.

## Validation
- `rtk bun test test/cmd-update-helpers.test.ts test/cmd-update-direct.test.ts test/cmd-update-ref-validation.test.ts test/update-help.test.ts`
- `rtk bun run test:coverage` (1622 pass / 6 skip / 0 fail)
- `rtk bun run build`
- `rtk bun run test:isolated` (119/119 files passed, 0 failed)

## Release lane
- Alpha branch only.
- No `release-alpha` cut.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
