### PR TITLE
test: cover local oracle registry scan

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,13 +1,13 @@
 # Coverage gap analysis
 
-Generated: 2026-05-16T20:28:01.628Z
+Generated: 2026-05-16T20:38:44.795Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **16.1%** (8155/50644)
-Overall function coverage: **61.0%** (892/1462)
+Overall line coverage: **16.4%** (8289/50623)
+Overall function coverage: **61.3%** (897/1464)
 
 ## Module summary
 
@@ -15,7 +15,7 @@ Overall function coverage: **61.0%** (892/1462)
 | --- | ---: | ---: | ---: | ---: | ---: |
 | cli/dispatch | 88 | 22 | 30.5% (2283/7482) | 64.2% (238/371) | n/a (0/0) |
 | config/runtime | 19 | 2 | 43.3% (510/1179) | 40.2% (35/87) | n/a (0/0) |
-| fleet | 17 | 0 | 25.5% (273/1071) | 49.3% (35/71) | n/a (0/0) |
+| fleet | 17 | 0 | 38.8% (407/1050) | 54.8% (40/73) | n/a (0/0) |
 | matcher | 2 | 0 | 100.0% (41/41) | 100.0% (8/8) | n/a (0/0) |
 | other | 174 | 98 | 18.7% (2699/14401) | 57.6% (278/483) | n/a (0/0) |
 | plugin dispatch | 15 | 1 | 67.2% (819/1218) | 83.8% (67/80) | n/a (0/0) |
@@ -83,6 +83,7 @@ Overall function coverage: **61.0%** (892/1462)
 | cli/dispatch | `src/commands/shared/workspace.ts` | 100.0% | 100.0% |
 | fleet | `src/core/fleet/leaf.ts` | 100.0% | 100.0% |
 | fleet | `src/core/fleet/oracle-registry.ts` | 100.0% | 100.0% |
+| fleet | `src/core/fleet/registry-oracle-scan-local.ts` | 100.0% | 100.0% |
 | fleet | `src/core/fleet/registry-oracle-types.ts` | 100.0% | 100.0% |
 | fleet | `src/core/fleet/snapshot.ts` | 93.4% | 100.0% |
 | fleet | `src/core/fleet/validate.ts` | 100.0% | 100.0% |
@@ -129,7 +130,7 @@ Overall function coverage: **61.0%** (892/1462)
 | cli/dispatch | `src/commands/shared/done.ts` | 207 | 0.0% |
 | transport | `src/transports/mdns.ts` | 184 | 7.5% |
 | transport | `src/core/transport/peers.ts` | 176 | 31.3% |
-| fleet | `src/core/fleet/registry-oracle-scan-local.ts` | 155 | 4.3% |
+| transport | `src/transports/zenoh.ts` | 154 | 0.0% |
 
 ## Critical gaps to prioritize
 

--- a/src/core/fleet/registry-oracle-scan-local.ts
+++ b/src/core/fleet/registry-oracle-scan-local.ts
@@ -13,6 +13,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from "fs";
 import { join } from "path";
 import { FLEET_DIR } from "../paths";
 import { loadConfig } from "../../config";
+import type { MawConfig } from "../../config/types";
 import { getGhqRoot } from "../../config/ghq-root";
 import type { OracleEntry } from "./registry-oracle-types";
 
@@ -25,12 +26,12 @@ interface FleetLineage {
 }
 
 /** @internal */
-export function readFleetLineage(): Map<string, FleetLineage> {
+export function readFleetLineage(fleetDir: string = FLEET_DIR): Map<string, FleetLineage> {
   const map = new Map<string, FleetLineage>();
   try {
-    for (const file of readdirSync(FLEET_DIR).filter(f => f.endsWith(".json"))) {
+    for (const file of readdirSync(fleetDir).filter(f => f.endsWith(".json"))) {
       try {
-        const config = JSON.parse(readFileSync(join(FLEET_DIR, file), "utf-8"));
+        const config = JSON.parse(readFileSync(join(fleetDir, file), "utf-8"));
         const repos: string[] = config.project_repos || [];
         for (const r of repos) {
           map.set(r, {
@@ -62,22 +63,31 @@ export function deriveName(repo: string): string {
 
 // ---------- Local scan ----------
 
+interface ScanLocalDeps {
+  config?: Pick<MawConfig, "node" | "agents">;
+  fleetDir?: string;
+  ghqRoot?: string;
+  now?: string;
+  fleetLineage?: Map<string, FleetLineage>;
+}
+
 /**
  * Scan local ghq for oracles. Verbose-by-default per user direction
  * (alpha.74, 2026-04-16) — pass verbose=false for the terse summary.
  * See `feedback_verbose_by_default`.
  */
-export function scanLocal(verbose = true): OracleEntry[] {
-  const config = loadConfig();
-  const reposRoot = join(getGhqRoot(), "github.com");
-  const now = new Date().toISOString();
-  const fleetLineage = readFleetLineage();
+export function scanLocal(verbose = true, deps: ScanLocalDeps = {}): OracleEntry[] {
+  const config = deps.config ?? loadConfig();
+  const fleetDir = deps.fleetDir ?? FLEET_DIR;
+  const reposRoot = join(deps.ghqRoot ?? getGhqRoot(), "github.com");
+  const now = deps.now ?? new Date().toISOString();
+  const fleetLineage = deps.fleetLineage ?? readFleetLineage(fleetDir);
   const entries: OracleEntry[] = [];
   const seen = new Set<string>();
 
   if (verbose) {
     console.log(`  \x1b[90m⏳ scanning repos root: ${reposRoot}\x1b[0m`);
-    console.log(`  \x1b[90m  fleet lineage: ${fleetLineage.size} entries from ${FLEET_DIR}\x1b[0m`);
+    console.log(`  \x1b[90m  fleet lineage: ${fleetLineage.size} entries from ${fleetDir}\x1b[0m`);
   }
 
   // Walk reposRoot: <reposRoot>/<org>/<repo>/

--- a/test/registry-oracle-scan-local.test.ts
+++ b/test/registry-oracle-scan-local.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { deriveName, readFleetLineage, scanLocal } from "../src/core/fleet/registry-oracle-scan-local";
+
+const roots: string[] = [];
+
+function tmpRoot(label: string): string {
+  const dir = mkdtempSync(join(tmpdir(), `maw-local-scan-${label}-`));
+  roots.push(dir);
+  return dir;
+}
+
+function mkdirp(path: string): void {
+  mkdirSync(path, { recursive: true });
+}
+
+function writeJson(path: string, value: unknown): void {
+  writeFileSync(path, JSON.stringify(value, null, 2) + "\n");
+}
+
+function makeRepo(ghqRoot: string, org: string, repo: string, opts: { psi?: boolean } = {}): string {
+  const repoDir = join(ghqRoot, "github.com", org, repo);
+  mkdirp(repoDir);
+  if (opts.psi) mkdirp(join(repoDir, "ψ"));
+  return repoDir;
+}
+
+afterEach(() => {
+  while (roots.length) {
+    rmSync(roots.pop()!, { recursive: true, force: true });
+  }
+});
+
+describe("registry-oracle-scan-local", () => {
+  test("readFleetLineage merges project_repos and window repo references while skipping invalid files", () => {
+    const root = tmpRoot("lineage");
+    const fleetDir = join(root, "fleet");
+    mkdirp(fleetDir);
+    writeJson(join(fleetDir, "alpha.json"), {
+      project_repos: ["Soul-Brews-Studio/mawjs-oracle", "Soul-Brews-Studio/fleet-only-oracle"],
+      windows: [
+        { name: "mawjs", repo: "Soul-Brews-Studio/mawjs-oracle" },
+        { name: "issuer", repo: "Soul-Brews-Studio/mawjs-issuer-oracle" },
+      ],
+      budded_from: "seed-oracle",
+      budded_at: "2026-05-16T00:00:00.000Z",
+    });
+    writeFileSync(join(fleetDir, "broken.json"), "{ nope");
+    writeJson(join(fleetDir, "ignored.json.disabled"), {
+      project_repos: ["Soul-Brews-Studio/ignored-oracle"],
+    });
+
+    const lineage = readFleetLineage(fleetDir);
+
+    expect([...lineage.keys()].sort()).toEqual([
+      "Soul-Brews-Studio/fleet-only-oracle",
+      "Soul-Brews-Studio/mawjs-issuer-oracle",
+      "Soul-Brews-Studio/mawjs-oracle",
+    ]);
+    expect(lineage.get("Soul-Brews-Studio/mawjs-issuer-oracle")).toMatchObject({
+      budded_from: "seed-oracle",
+      budded_at: "2026-05-16T00:00:00.000Z",
+    });
+    expect(readFleetLineage(join(root, "missing")).size).toBe(0);
+  });
+
+  test("deriveName removes only the canonical -oracle suffix", () => {
+    expect(deriveName("mawjs-oracle")).toBe("mawjs");
+    expect(deriveName("mawjs-issuer")).toBe("mawjs-issuer");
+  });
+
+  test("scanLocal detects ψ dirs, fleet lineage, -oracle suffixes, fleet-only refs, and federation nodes", () => {
+    const root = tmpRoot("scan");
+    const ghqRoot = join(root, "ghq");
+    const fleetDir = join(root, "fleet");
+    mkdirp(fleetDir);
+    mkdirp(join(ghqRoot, "github.com", "Soul-Brews-Studio"));
+    writeFileSync(join(ghqRoot, "github.com", "not-an-org"), "file");
+    writeFileSync(join(ghqRoot, "github.com", "Soul-Brews-Studio", "not-a-repo"), "file");
+
+    const psiDir = makeRepo(ghqRoot, "Soul-Brews-Studio", "psi-oracle", { psi: true });
+    const fleetDirRepo = makeRepo(ghqRoot, "Soul-Brews-Studio", "fleet-member");
+    const suffixDir = makeRepo(ghqRoot, "Soul-Brews-Studio", "suffix-oracle");
+    makeRepo(ghqRoot, "Soul-Brews-Studio", "plain-repo");
+    makeRepo(ghqRoot, "Other", "zeta-oracle");
+
+    writeJson(join(fleetDir, "fleet.json"), {
+      project_repos: ["Soul-Brews-Studio/fleet-member", "Missing/remote-oracle"],
+      windows: [{ name: "psi", repo: "Soul-Brews-Studio/psi-oracle" }],
+      budded_from: "root-oracle",
+      budded_at: "2026-05-16T01:02:03.000Z",
+    });
+
+    const entries = scanLocal(false, {
+      ghqRoot,
+      fleetDir,
+      now: "2026-05-16T04:05:06.000Z",
+      config: { node: "m5", agents: { "fleet-member": "m6" } },
+    });
+
+    expect(entries.map(e => `${e.org}/${e.repo}`)).toEqual([
+      "Missing/remote-oracle",
+      "Other/zeta-oracle",
+      "Soul-Brews-Studio/fleet-member",
+      "Soul-Brews-Studio/psi-oracle",
+      "Soul-Brews-Studio/suffix-oracle",
+    ]);
+    expect(entries.find(e => e.repo === "plain-repo")).toBeUndefined();
+    expect(entries.find(e => e.repo === "psi-oracle")).toMatchObject({
+      name: "psi",
+      local_path: psiDir,
+      has_psi: true,
+      has_fleet_config: true,
+      budded_from: "root-oracle",
+      federation_node: "m5",
+      detected_at: "2026-05-16T04:05:06.000Z",
+    });
+    expect(entries.find(e => e.repo === "fleet-member")).toMatchObject({
+      name: "fleet-member",
+      local_path: fleetDirRepo,
+      has_psi: false,
+      has_fleet_config: true,
+      federation_node: "m6",
+    });
+    expect(entries.find(e => e.repo === "suffix-oracle")).toMatchObject({
+      name: "suffix",
+      local_path: suffixDir,
+      has_psi: false,
+      has_fleet_config: false,
+      federation_node: "m5",
+    });
+    expect(entries.find(e => e.repo === "remote-oracle")).toMatchObject({
+      name: "remote",
+      local_path: "",
+      has_psi: false,
+      has_fleet_config: true,
+      federation_node: null,
+    });
+  });
+
+  test("scanLocal verbose mode reports scan sources, fleet-only refs, enrichment, and walk failures", () => {
+    const root = tmpRoot("verbose");
+    const ghqRoot = join(root, "ghq");
+    const fleetDir = join(root, "fleet");
+    mkdirp(fleetDir);
+    makeRepo(ghqRoot, "Soul-Brews-Studio", "mawjs-oracle", { psi: true });
+    writeJson(join(fleetDir, "fleet.json"), {
+      project_repos: ["Missing/remote-oracle"],
+    });
+
+    const logs: string[] = [];
+    const warnings: string[] = [];
+    const logSpy = spyOn(console, "log").mockImplementation((...args: unknown[]) => logs.push(args.map(String).join(" ")));
+    const warnSpy = spyOn(console, "warn").mockImplementation((...args: unknown[]) => warnings.push(args.map(String).join(" ")));
+    try {
+      scanLocal(true, {
+        ghqRoot,
+        fleetDir,
+        config: { node: "m5", agents: { mawjs: "m5-agent" } },
+        now: "2026-05-16T04:05:06.000Z",
+      });
+      scanLocal(true, {
+        ghqRoot: join(root, "missing-ghq"),
+        fleetDir,
+        config: { node: "m5", agents: {} },
+        fleetLineage: new Map(),
+      });
+    } finally {
+      logSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+
+    expect(logs.some(line => line.includes("scanning repos root:"))).toBe(true);
+    expect(logs.some(line => line.includes("fleet lineage: 1 entries"))).toBe(true);
+    expect(logs.some(line => line.includes("Soul-Brews-Studio/mawjs-oracle"))).toBe(true);
+    expect(logs.some(line => line.includes("federation-enriched 1"))).toBe(true);
+    expect(logs.some(line => line.includes("fleet-only oracles"))).toBe(true);
+    expect(warnings.some(line => line.includes("failed to walk repos root"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds injectable `scanLocal`/`readFleetLineage` seams so the local oracle registry scan can be tested without touching Nat's real `ghq` tree or fleet config.
- Covers ghq repo detection via `ψ/`, fleet lineage, `-oracle` suffix, fleet-only entries, federation node enrichment, verbose reporting, invalid fleet files, and walk-failure handling.
- Regenerates coverage gap analysis: overall line coverage 16.1% → 16.4%, function coverage 61.0% → 61.3%; `src/core/fleet/registry-oracle-scan-local.ts` is now 100% line / 100% function coverage.

## Validation
- `rtk bun test test/registry-oracle-scan-local.test.ts`
- `rtk bun run test:coverage` (1626 pass / 6 skip / 0 fail)
- `rtk bun run build`
- `rtk bun run test:isolated` (119/119 files passed, 0 failed)

## Release lane
- Alpha branch only.
- No `release-alpha` cut.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
