### PR TITLE
test: cover zenoh transport

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,13 +1,13 @@
 # Coverage gap analysis
 
-Generated: 2026-05-16T20:38:44.795Z
+Generated: 2026-05-16T20:48:05.083Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **16.4%** (8289/50623)
-Overall function coverage: **61.3%** (897/1464)
+Overall line coverage: **16.6%** (8411/50591)
+Overall function coverage: **61.8%** (917/1484)
 
 ## Module summary
 
@@ -20,7 +20,7 @@ Overall function coverage: **61.3%** (897/1464)
 | other | 174 | 98 | 18.7% (2699/14401) | 57.6% (278/483) | n/a (0/0) |
 | plugin dispatch | 15 | 1 | 67.2% (819/1218) | 83.8% (67/80) | n/a (0/0) |
 | routing/aliases | 4 | 0 | 49.2% (300/610) | 72.7% (32/44) | n/a (0/0) |
-| transport | 28 | 3 | 40.9% (1085/2650) | 62.3% (187/300) | n/a (0/0) |
+| transport | 28 | 2 | 46.1% (1207/2618) | 64.7% (207/320) | n/a (0/0) |
 | vendor plugins | 245 | 244 | 0.7% (145/21992) | 66.7% (12/18) | n/a (0/0) |
 
 ## Top 20 uncovered files by executable/source line count
@@ -116,6 +116,7 @@ Overall function coverage: **61.3%** (897/1464)
 | transport | `src/transports/scout-state.ts` | 100.0% | 100.0% |
 | transport | `src/transports/tmux.ts` | 100.0% | 100.0% |
 | transport | `src/transports/zenoh-scout.ts` | 90.3% | 66.7% |
+| transport | `src/transports/zenoh.ts` | 100.0% | 100.0% |
 
 ## Critical files below the 80% line target (next queue)
 
@@ -130,7 +131,7 @@ Overall function coverage: **61.3%** (897/1464)
 | cli/dispatch | `src/commands/shared/done.ts` | 207 | 0.0% |
 | transport | `src/transports/mdns.ts` | 184 | 7.5% |
 | transport | `src/core/transport/peers.ts` | 176 | 31.3% |
-| transport | `src/transports/zenoh.ts` | 154 | 0.0% |
+| transport | `src/core/transport/pty.ts` | 150 | 0.0% |
 
 ## Critical gaps to prioritize
 

--- a/src/transports/zenoh.ts
+++ b/src/transports/zenoh.ts
@@ -22,6 +22,17 @@ export interface ZenohTransportConfig {
   node: string;
 }
 
+export interface ZenohRuntime {
+  open(config: unknown): Promise<unknown>;
+  Config: new (locator: string) => unknown;
+}
+
+export interface ZenohTransportDeps {
+  importZenoh?: () => Promise<ZenohRuntime>;
+  now?: () => number;
+  logger?: Pick<Console, "log" | "warn">;
+}
+
 export class ZenohTransport implements Transport {
   readonly name = "zenoh";
   private _connected = false;
@@ -32,9 +43,11 @@ export class ZenohTransport implements Transport {
   private feedHandlers = new Set<(e: FeedEvent) => void>();
   private subscribers: any[] = [];
   private livelinessToken: any = null;
+  private deps: ZenohTransportDeps;
 
-  constructor(config: ZenohTransportConfig) {
+  constructor(config: ZenohTransportConfig, deps: ZenohTransportDeps = {}) {
     this.config = config;
+    this.deps = deps;
   }
 
   get connected() {
@@ -43,9 +56,9 @@ export class ZenohTransport implements Transport {
 
   async connect(): Promise<void> {
     try {
-      const { open, Config } = await import("@eclipse-zenoh/zenoh-ts");
+      const { open, Config } = await this.importZenoh();
       const config = new Config(this.config.locator);
-      this.session = await open(config);
+      this.session = await open(config) as any;
       this._connected = true;
 
       // Declare liveliness token for presence
@@ -100,11 +113,11 @@ export class ZenohTransport implements Transport {
       });
       this.subscribers.push(feedSub);
 
-      console.log(
+      (this.deps.logger ?? console).log(
         `[zenoh] connected to ${this.config.locator} as ${this.config.node}`,
       );
     } catch (err) {
-      console.warn(
+      (this.deps.logger ?? console).warn(
         `[zenoh] connect failed: ${err instanceof Error ? err.message : err}`,
       );
       this._connected = false;
@@ -141,7 +154,7 @@ export class ZenohTransport implements Transport {
         from: this.config.node,
         to: target.oracle,
         body: message,
-        timestamp: Date.now(),
+        timestamp: (this.deps.now ?? Date.now)(),
         transport: "zenoh" as any,
       };
       await this.session.put(topic, new TextEncoder().encode(JSON.stringify(msg)));
@@ -183,5 +196,10 @@ export class ZenohTransport implements Transport {
     if (!target.host || target.host === "local" || target.host === "localhost")
       return false;
     return this._connected;
+  }
+
+  private async importZenoh(): Promise<ZenohRuntime> {
+    if (this.deps.importZenoh) return this.deps.importZenoh();
+    return import("@eclipse-zenoh/zenoh-ts") as Promise<ZenohRuntime>;
   }
 }

--- a/test/zenoh-transport.test.ts
+++ b/test/zenoh-transport.test.ts
@@ -1,0 +1,314 @@
+import { describe, expect, test } from "bun:test";
+import { ZenohTransport, type ZenohRuntime } from "../src/transports/zenoh";
+import type { FeedEvent } from "../src/lib/feed";
+import type { TransportMessage, TransportPresence } from "../src/core/transport/transport";
+
+type Handler = (sample: unknown) => void;
+
+function sample(value: unknown) {
+  return {
+    payload() {
+      return {
+        toBytes() {
+          return new TextEncoder().encode(JSON.stringify(value));
+        },
+      };
+    },
+  };
+}
+
+function badSample(bytes = "not-json") {
+  return {
+    payload() {
+      return {
+        toBytes() {
+          return new TextEncoder().encode(bytes);
+        },
+      };
+    },
+  };
+}
+
+function decode(bytes: Uint8Array) {
+  return JSON.parse(new TextDecoder().decode(bytes));
+}
+
+function createFakeZenoh(options: { putFails?: boolean; undeclareFails?: boolean; closeFails?: boolean } = {}) {
+  const subscribers = new Map<string, Handler>();
+  const undeclared: string[] = [];
+  const puts: Array<{ topic: string; payload: Uint8Array }> = [];
+  let openedLocator = "";
+  let closed = false;
+
+  class Config {
+    constructor(public locator: string) {
+      openedLocator = locator;
+    }
+  }
+
+  const session = {
+    liveliness() {
+      return {
+        async declareToken(key: string) {
+          return {
+            async undeclare() {
+              if (options.undeclareFails) throw new Error("token undeclare failed");
+              undeclared.push(`token:${key}`);
+            },
+          };
+        },
+      };
+    },
+    async declareSubscriber(topic: string, opts: { handler: Handler }) {
+      subscribers.set(topic, opts.handler);
+      return {
+        async undeclare() {
+          if (options.undeclareFails) throw new Error(`sub undeclare failed: ${topic}`);
+          undeclared.push(`sub:${topic}`);
+        },
+      };
+    },
+    async put(topic: string, payload: Uint8Array) {
+      if (options.putFails) throw new Error("put failed");
+      puts.push({ topic, payload });
+    },
+    async close() {
+      if (options.closeFails) throw new Error("close failed");
+      closed = true;
+    },
+  };
+
+  const runtime: ZenohRuntime = {
+    Config,
+    async open() {
+      return session;
+    },
+  };
+
+  return { runtime, subscribers, undeclared, puts, get openedLocator() { return openedLocator; }, get closed() { return closed; } };
+}
+
+const quietLogger = {
+  log() {},
+  warn() {},
+};
+
+describe("ZenohTransport", () => {
+  test("connects through injectable zenoh runtime and dispatches pub/sub events", async () => {
+    const fake = createFakeZenoh();
+    const transport = new ZenohTransport(
+      { locator: "ws://router:10000", node: "m5" },
+      { importZenoh: async () => fake.runtime, logger: quietLogger },
+    );
+    const messages: TransportMessage[] = [];
+    const presences: TransportPresence[] = [];
+    const feedEvents: FeedEvent[] = [];
+    transport.onMessage((msg) => messages.push(msg));
+    transport.onPresence((presence) => presences.push(presence));
+    transport.onFeed((event) => feedEvents.push(event));
+
+    await transport.connect();
+
+    expect(transport.connected).toBe(true);
+    expect(fake.openedLocator).toBe("ws://router:10000");
+    expect([...fake.subscribers.keys()]).toEqual([
+      "maw/*/hey/m5",
+      "maw/*/presence",
+      "maw/*/feed",
+    ]);
+
+    fake.subscribers.get("maw/*/hey/m5")?.(sample({
+      from: "white",
+      to: "m5",
+      body: "hello",
+      timestamp: 42,
+      transport: "http",
+    }));
+    fake.subscribers.get("maw/*/hey/m5")?.(badSample());
+    fake.subscribers.get("maw/*/presence")?.(sample({
+      oracle: "pulse",
+      host: "white",
+      status: "ready",
+      timestamp: 43,
+    }));
+    fake.subscribers.get("maw/*/presence")?.(badSample());
+    fake.subscribers.get("maw/*/feed")?.(sample({
+      timestamp: "2026-05-17 08:00:00",
+      oracle: "pulse",
+      host: "white",
+      event: "MessageSend",
+      project: "maw-js",
+      sessionId: "s1",
+      message: "sent",
+      ts: 42,
+    } satisfies FeedEvent));
+    fake.subscribers.get("maw/*/feed")?.(badSample());
+
+    expect(messages).toEqual([expect.objectContaining({
+      from: "white",
+      to: "m5",
+      body: "hello",
+      transport: "zenoh",
+    })]);
+    expect(presences).toEqual([{
+      oracle: "pulse",
+      host: "white",
+      status: "ready",
+      timestamp: 43,
+    }]);
+    expect(feedEvents).toEqual([expect.objectContaining({ event: "MessageSend", message: "sent" })]);
+  });
+
+  test("sends messages and publishes presence/feed while connected", async () => {
+    const fake = createFakeZenoh();
+    const transport = new ZenohTransport(
+      { locator: "ws://router:10000", node: "m5" },
+      { importZenoh: async () => fake.runtime, now: () => 1234, logger: quietLogger },
+    );
+
+    expect(await transport.send({ oracle: "pulse", host: "white" }, "before connect")).toBe(false);
+    await transport.publishPresence({ oracle: "mawjs", host: "m5", status: "ready", timestamp: 1 });
+    await transport.publishFeed({
+      timestamp: "2026-05-17 08:00:00",
+      oracle: "mawjs",
+      host: "m5",
+      event: "MessageSend",
+      project: "maw-js",
+      sessionId: "s1",
+      message: "before connect",
+      ts: 1,
+    });
+    expect(fake.puts).toEqual([]);
+
+    await transport.connect();
+
+    expect(await transport.send({ oracle: "pulse", host: "white" }, "hi")).toBe(true);
+    await transport.publishPresence({ oracle: "mawjs", host: "m5", status: "ready", timestamp: 2 });
+    await transport.publishFeed({
+      timestamp: "2026-05-17 08:01:00",
+      oracle: "mawjs",
+      host: "m5",
+      event: "MessageDeliver",
+      project: "maw-js",
+      sessionId: "s1",
+      message: "delivered",
+      ts: 2,
+    });
+
+    expect(fake.puts.map((put) => put.topic)).toEqual([
+      "maw/m5/hey/pulse",
+      "maw/m5/presence",
+      "maw/m5/feed",
+    ]);
+    expect(decode(fake.puts[0].payload)).toEqual({
+      from: "m5",
+      to: "pulse",
+      body: "hi",
+      timestamp: 1234,
+      transport: "zenoh",
+    });
+    expect(decode(fake.puts[1].payload)).toEqual({
+      oracle: "mawjs",
+      host: "m5",
+      status: "ready",
+      timestamp: 2,
+    });
+    expect(decode(fake.puts[2].payload)).toEqual(expect.objectContaining({
+      event: "MessageDeliver",
+      message: "delivered",
+    }));
+  });
+
+  test("returns false for failed sends and swallows publish failures", async () => {
+    const fake = createFakeZenoh({ putFails: true });
+    const transport = new ZenohTransport(
+      { locator: "ws://router:10000", node: "m5" },
+      { importZenoh: async () => fake.runtime, logger: quietLogger },
+    );
+
+    await transport.connect();
+
+    expect(await transport.send({ oracle: "pulse", host: "white" }, "hi")).toBe(false);
+    await expect(transport.publishPresence({ oracle: "mawjs", host: "m5", status: "ready", timestamp: 1 })).resolves.toBeUndefined();
+    await expect(transport.publishFeed({
+      timestamp: "2026-05-17 08:01:00",
+      oracle: "mawjs",
+      host: "m5",
+      event: "MessageFail",
+      project: "maw-js",
+      sessionId: "s1",
+      message: "failed",
+      ts: 1,
+    })).resolves.toBeUndefined();
+  });
+
+  test("disconnect cleans up best effort and flips connected state", async () => {
+    const fake = createFakeZenoh();
+    const transport = new ZenohTransport(
+      { locator: "ws://router:10000", node: "m5" },
+      { importZenoh: async () => fake.runtime, logger: quietLogger },
+    );
+
+    await transport.connect();
+    await transport.disconnect();
+
+    expect(transport.connected).toBe(false);
+    expect(fake.undeclared).toEqual([
+      "sub:maw/*/hey/m5",
+      "sub:maw/*/presence",
+      "sub:maw/*/feed",
+      "token:maw/m5/alive",
+    ]);
+    expect(fake.closed).toBe(true);
+
+    await transport.disconnect();
+    expect(transport.connected).toBe(false);
+  });
+
+  test("disconnect keeps going when zenoh cleanup throws", async () => {
+    const fake = createFakeZenoh({ undeclareFails: true, closeFails: true });
+    const transport = new ZenohTransport(
+      { locator: "ws://router:10000", node: "m5" },
+      { importZenoh: async () => fake.runtime, logger: quietLogger },
+    );
+
+    await transport.connect();
+    await expect(transport.disconnect()).resolves.toBeUndefined();
+
+    expect(transport.connected).toBe(false);
+  });
+
+  test("reports connect failures without leaving a half-connected transport", async () => {
+    const warnings: string[] = [];
+    const transport = new ZenohTransport(
+      { locator: "ws://router:10000", node: "m5" },
+      {
+        importZenoh: async () => {
+          throw new Error("zenoh bridge missing");
+        },
+        logger: { log() {}, warn: (msg: string) => warnings.push(msg) },
+      },
+    );
+
+    await transport.connect();
+
+    expect(transport.connected).toBe(false);
+    expect(warnings).toEqual(["[zenoh] connect failed: zenoh bridge missing"]);
+  });
+
+  test("canReach only allows non-local targets while connected", async () => {
+    const fake = createFakeZenoh();
+    const transport = new ZenohTransport(
+      { locator: "ws://router:10000", node: "m5" },
+      { importZenoh: async () => fake.runtime, logger: quietLogger },
+    );
+
+    expect(transport.canReach({ oracle: "pulse", host: "white" })).toBe(false);
+    await transport.connect();
+
+    expect(transport.canReach({ oracle: "pulse", host: "white" })).toBe(true);
+    expect(transport.canReach({ oracle: "pulse" })).toBe(false);
+    expect(transport.canReach({ oracle: "pulse", host: "local" })).toBe(false);
+    expect(transport.canReach({ oracle: "pulse", host: "localhost" })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add injectable Zenoh runtime/time/logger seams for deterministic transport tests
- cover Zenoh connect, subscriber dispatch, malformed payload hardening, send/publish behavior, cleanup, connect failure, and reachability
- refresh #1637 coverage gap analysis: `src/transports/zenoh.ts` now reports 100% lines / 100% functions

## Validation
- `rtk bun test test/zenoh-transport.test.ts`
- `rtk bun run test:coverage` — 1633 pass / 6 skip / 0 fail; overall lines 16.6%, functions 61.8%; `src/transports/zenoh.ts` 100% / 100%
- `rtk bun run build`
- `rtk bun run test:isolated` — 119/119 files passed

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
