### PR TITLE
test: cover done command lifecycle

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,20 +1,20 @@
 # Coverage gap analysis
 
-Generated: 2026-05-16T20:48:05.083Z
+Generated: 2026-05-16T21:05:18.178Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **16.6%** (8411/50591)
-Overall function coverage: **61.8%** (917/1484)
+Overall line coverage: **17.1%** (8650/50593)
+Overall function coverage: **62.4%** (939/1504)
 
 ## Module summary
 
 | Module | Files | Missing from LCOV | Lines | Functions | Branches |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| cli/dispatch | 88 | 22 | 30.5% (2283/7482) | 64.2% (238/371) | n/a (0/0) |
-| config/runtime | 19 | 2 | 43.3% (510/1179) | 40.2% (35/87) | n/a (0/0) |
+| cli/dispatch | 88 | 21 | 33.4% (2504/7496) | 66.0% (258/391) | n/a (0/0) |
+| config/runtime | 19 | 2 | 45.2% (528/1167) | 42.5% (37/87) | n/a (0/0) |
 | fleet | 17 | 0 | 38.8% (407/1050) | 54.8% (40/73) | n/a (0/0) |
 | matcher | 2 | 0 | 100.0% (41/41) | 100.0% (8/8) | n/a (0/0) |
 | other | 174 | 98 | 18.7% (2699/14401) | 57.6% (278/483) | n/a (0/0) |
@@ -62,6 +62,7 @@ Overall function coverage: **61.8%** (917/1484)
 | cli/dispatch | `src/cli/usage.ts` | 89.6% | 92.9% |
 | cli/dispatch | `src/cli/verbosity.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/comm.ts` | 100.0% | 100.0% |
+| cli/dispatch | `src/commands/shared/done.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/federation-apply.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/federation-diff.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/federation-identity.ts` | 100.0% | 100.0% |
@@ -128,10 +129,10 @@ Overall function coverage: **61.8%** (917/1484)
 | transport | `src/core/transport/tmux-class.ts` | 267 | 15.2% |
 | transport | `src/transports/scout.ts` | 248 | 8.5% |
 | cli/dispatch | `src/commands/shared/wake-resolve-impl.ts` | 226 | 28.7% |
-| cli/dispatch | `src/commands/shared/done.ts` | 207 | 0.0% |
 | transport | `src/transports/mdns.ts` | 184 | 7.5% |
 | transport | `src/core/transport/peers.ts` | 176 | 31.3% |
 | transport | `src/core/transport/pty.ts` | 150 | 0.0% |
+| routing/aliases | `src/cli/top-aliases.ts` | 148 | 41.3% |
 
 ## Critical gaps to prioritize
 

--- a/src/commands/shared/done.ts
+++ b/src/commands/shared/done.ts
@@ -12,10 +12,63 @@ export interface DoneOpts {
 
 type SessionInfo = { name: string; windows: { index: number; name: string; active: boolean }[] };
 
-export async function cmdDone(windowName_: string, opts: DoneOpts = {}) {
+type DoneFs = {
+  appendFileSync: typeof appendFileSync;
+  mkdirSync: typeof mkdirSync;
+  readdirSync: typeof readdirSync;
+  readFileSync: typeof readFileSync;
+  writeFileSync: typeof writeFileSync;
+};
+
+type DoneLogger = Pick<typeof console, "error" | "log">;
+
+export interface DoneDeps {
+  listSessions?: () => Promise<SessionInfo[]>;
+  hostExec?: (command: string) => Promise<string>;
+  tmux?: {
+    killWindow?: (target: string) => Promise<unknown>;
+    sendText?: (target: string, text: string) => Promise<unknown>;
+  };
+  fleetDir?: string;
+  ghqRoot?: string;
+  homeDir?: string;
+  takeSnapshot?: (trigger: string) => Promise<unknown>;
+  now?: () => Date;
+  sleep?: (ms: number) => Promise<void>;
+  fs?: Partial<DoneFs>;
+  logger?: DoneLogger;
+}
+
+function doneDeps(deps: DoneDeps = {}) {
+  return {
+    listSessions: deps.listSessions ?? (listSessions as () => Promise<SessionInfo[]>),
+    hostExec: deps.hostExec ?? hostExec,
+    tmux: {
+      killWindow: deps.tmux?.killWindow ?? tmux.killWindow,
+      sendText: deps.tmux?.sendText ?? tmux.sendText,
+    },
+    fleetDir: deps.fleetDir ?? FLEET_DIR,
+    ghqRoot: deps.ghqRoot ?? getGhqRoot(),
+    homeDir: deps.homeDir ?? homedir(),
+    takeSnapshot: deps.takeSnapshot ?? takeSnapshot,
+    now: deps.now ?? (() => new Date()),
+    sleep: deps.sleep ?? Bun.sleep,
+    fs: {
+      appendFileSync: deps.fs?.appendFileSync ?? appendFileSync,
+      mkdirSync: deps.fs?.mkdirSync ?? mkdirSync,
+      readdirSync: deps.fs?.readdirSync ?? readdirSync,
+      readFileSync: deps.fs?.readFileSync ?? readFileSync,
+      writeFileSync: deps.fs?.writeFileSync ?? writeFileSync,
+    },
+    logger: deps.logger ?? console,
+  };
+}
+
+export async function cmdDone(windowName_: string, opts: DoneOpts = {}, deps: DoneDeps = {}) {
+  const d = doneDeps(deps);
   let windowName = normalizeTarget(windowName_);
-  const sessions = await listSessions();
-  const reposRoot = join(getGhqRoot(), "github.com");
+  const sessions = await d.listSessions();
+  const reposRoot = join(d.ghqRoot, "github.com");
 
   const windowNameLower = windowName.toLowerCase();
   let sessionName: string | null = null;
@@ -26,125 +79,131 @@ export async function cmdDone(windowName_: string, opts: DoneOpts = {}) {
   }
 
   if (sessionName) {
-    signalParentInbox(windowName, sessionName, sessions as any);
+    signalParentInbox(windowName, sessionName, sessions, deps);
   }
 
   if (sessionName !== null && windowIndex !== null && !opts.force) {
-    await autoSave(windowName, sessionName, opts);
+    await autoSave(windowName, sessionName, opts, deps);
     if (opts.dryRun) return;
   } else if (opts.dryRun) {
-    console.log(`  \x1b[36m⬡\x1b[0m [dry-run] window '${windowName}' not running — nothing to auto-save`);
+    d.logger.log(`  \x1b[36m⬡\x1b[0m [dry-run] window '${windowName}' not running — nothing to auto-save`);
   }
 
   if (sessionName !== null && windowIndex !== null) {
     try {
-      await tmux.killWindow(`${sessionName}:${windowName}`);
-      console.log(`  \x1b[32m✓\x1b[0m killed window ${sessionName}:${windowName}`);
+      await d.tmux.killWindow(`${sessionName}:${windowName}`);
+      d.logger.log(`  \x1b[32m✓\x1b[0m killed window ${sessionName}:${windowName}`);
     } catch {
-      console.log(`  \x1b[33m⚠\x1b[0m could not kill window (may already be closed)`);
+      d.logger.log(`  \x1b[33m⚠\x1b[0m could not kill window (may already be closed)`);
     }
   } else {
-    console.log(`  \x1b[90m○\x1b[0m window '${windowName}' not running`);
+    d.logger.log(`  \x1b[90m○\x1b[0m window '${windowName}' not running`);
   }
 
-  let removedWorktree = await removeWorktreeViaConfig(windowNameLower, reposRoot);
+  let removedWorktree = await removeWorktreeViaConfig(windowNameLower, reposRoot, deps);
   if (!removedWorktree) {
-    removedWorktree = await removeWorktreeByGhqScan(windowName, reposRoot);
+    removedWorktree = await removeWorktreeByGhqScan(windowName, reposRoot, deps);
   }
   if (!removedWorktree) {
-    console.log(`  \x1b[90m○\x1b[0m no worktree to remove (may be a main window)`);
+    d.logger.log(`  \x1b[90m○\x1b[0m no worktree to remove (may be a main window)`);
   }
 
-  const removedFromConfig = removeFromFleetConfig(windowNameLower);
+  const removedFromConfig = removeFromFleetConfig(windowNameLower, deps);
   if (!removedFromConfig) {
-    console.log(`  \x1b[90m○\x1b[0m not in any fleet config`);
+    d.logger.log(`  \x1b[90m○\x1b[0m not in any fleet config`);
   }
 
-  takeSnapshot("done").catch(() => {});
-  console.log();
+  d.takeSnapshot("done").catch(() => {});
+  d.logger.log();
 }
 
-function signalParentInbox(
+export function signalParentInbox(
   windowName: string,
   sessionName: string,
   sessions: SessionInfo[],
+  deps: DoneDeps = {},
 ): void {
+  const d = doneDeps(deps);
   const from = process.env.CLAUDE_AGENT_NAME || windowName;
   const parentWindow = sessions.find(s => s.name === sessionName)?.windows[0]?.name;
   if (!parentWindow) return;
   const parentTarget = parentWindow.replace(/[^a-zA-Z0-9_-]/g, "");
-  const inboxDir = join(homedir(), ".oracle", "inbox");
+  const inboxDir = join(d.homeDir, ".oracle", "inbox");
   const signal =
-    JSON.stringify({ ts: new Date().toISOString(), from, type: "done", msg: `worktree ${windowName} completed`, thread: null }) + "\n";
+    JSON.stringify({ ts: d.now().toISOString(), from, type: "done", msg: `worktree ${windowName} completed`, thread: null }) + "\n";
   try {
-    mkdirSync(inboxDir, { recursive: true });
-    appendFileSync(join(inboxDir, `${parentTarget}.jsonl`), signal);
+    d.fs.mkdirSync(inboxDir, { recursive: true });
+    d.fs.appendFileSync(join(inboxDir, `${parentTarget}.jsonl`), signal);
   } catch (e) {
-    console.error(`  \x1b[33m⚠\x1b[0m inbox signal failed: ${e}`);
+    d.logger.error(`  \x1b[33m⚠\x1b[0m inbox signal failed: ${e}`);
   }
 }
 
-async function autoSave(
+export async function autoSave(
   windowName: string,
   sessionName: string,
   opts: DoneOpts,
+  deps: DoneDeps = {},
 ): Promise<void> {
+  const d = doneDeps(deps);
   const target = `${sessionName}:${windowName}`;
 
   let paneCwd = "";
   try {
-    paneCwd = (await hostExec(`tmux display-message -t '${target}' -p '#{pane_current_path}'`)).trim();
+    paneCwd = (await d.hostExec(`tmux display-message -t '${target}' -p '#{pane_current_path}'`)).trim();
   } catch { /* pane may not exist */ }
 
   if (opts.dryRun) {
-    console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would send /rrr to ${target} and wait 10s`);
+    d.logger.log(`  \x1b[36m⬡\x1b[0m [dry-run] would send /rrr to ${target} and wait 10s`);
     if (paneCwd) {
-      console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would git add + commit + push in ${paneCwd}`);
+      d.logger.log(`  \x1b[36m⬡\x1b[0m [dry-run] would git add + commit + push in ${paneCwd}`);
     }
-    console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would kill window ${target}`);
-    console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would remove worktree + fleet config`);
-    console.log();
+    d.logger.log(`  \x1b[36m⬡\x1b[0m [dry-run] would kill window ${target}`);
+    d.logger.log(`  \x1b[36m⬡\x1b[0m [dry-run] would remove worktree + fleet config`);
+    d.logger.log();
     return;
   }
 
-  console.log(`  \x1b[36m⏳\x1b[0m sending /rrr to ${target}...`);
+  d.logger.log(`  \x1b[36m⏳\x1b[0m sending /rrr to ${target}...`);
   try {
-    await tmux.sendText(target, "/rrr");
-    await new Promise(r => setTimeout(r, 10_000));
-    console.log(`  \x1b[32m✓\x1b[0m /rrr sent (waited 10s)`);
+    await d.tmux.sendText(target, "/rrr");
+    await d.sleep(10_000);
+    d.logger.log(`  \x1b[32m✓\x1b[0m /rrr sent (waited 10s)`);
   } catch {
-    console.log(`  \x1b[33m⚠\x1b[0m could not send /rrr (agent may not be running)`);
+    d.logger.log(`  \x1b[33m⚠\x1b[0m could not send /rrr (agent may not be running)`);
   }
 
   if (paneCwd) {
-    console.log(`  \x1b[36m⏳\x1b[0m git auto-save in ${paneCwd}...`);
+    d.logger.log(`  \x1b[36m⏳\x1b[0m git auto-save in ${paneCwd}...`);
     try {
-      await hostExec(`git -C '${paneCwd}' add -A`);
+      await d.hostExec(`git -C '${paneCwd}' add -A`);
       try {
-        await hostExec(`git -C '${paneCwd}' commit -m 'chore: auto-save before done'`);
-        console.log(`  \x1b[32m✓\x1b[0m committed changes`);
+        await d.hostExec(`git -C '${paneCwd}' commit -m 'chore: auto-save before done'`);
+        d.logger.log(`  \x1b[32m✓\x1b[0m committed changes`);
       } catch {
-        console.log(`  \x1b[90m○\x1b[0m nothing to commit`);
+        d.logger.log(`  \x1b[90m○\x1b[0m nothing to commit`);
       }
       try {
-        await hostExec(`git -C '${paneCwd}' push`);
-        console.log(`  \x1b[32m✓\x1b[0m pushed to remote`);
+        await d.hostExec(`git -C '${paneCwd}' push`);
+        d.logger.log(`  \x1b[32m✓\x1b[0m pushed to remote`);
       } catch {
-        console.log(`  \x1b[33m⚠\x1b[0m push failed (no remote or auth issue)`);
+        d.logger.log(`  \x1b[33m⚠\x1b[0m push failed (no remote or auth issue)`);
       }
     } catch (e: any) {
-      console.log(`  \x1b[33m⚠\x1b[0m git auto-save failed: ${e.message || e}`);
+      d.logger.log(`  \x1b[33m⚠\x1b[0m git auto-save failed: ${e.message || e}`);
     }
   }
 }
 
-async function removeWorktreeViaConfig(
+export async function removeWorktreeViaConfig(
   windowNameLower: string,
   reposRoot: string,
+  deps: DoneDeps = {},
 ): Promise<boolean> {
+  const d = doneDeps(deps);
   try {
-    for (const file of readdirSync(FLEET_DIR).filter(f => f.endsWith(".json"))) {
-      const config = JSON.parse(readFileSync(join(FLEET_DIR, file), "utf-8"));
+    for (const file of d.fs.readdirSync(d.fleetDir).filter(f => f.endsWith(".json"))) {
+      const config = JSON.parse(d.fs.readFileSync(join(d.fleetDir, file), "utf-8"));
       const win = (config.windows || []).find((w: any) => w.name.toLowerCase() === windowNameLower);
       if (!win?.repo) continue;
 
@@ -159,31 +218,33 @@ async function removeWorktreeViaConfig(
 
       try {
         let branch = "";
-        try { branch = (await hostExec(`git -C '${fullPath}' rev-parse --abbrev-ref HEAD`)).trim(); } catch { /* expected */ }
-        await hostExec(`git -C '${mainPath}' worktree remove '${fullPath}' --force`);
-        await hostExec(`git -C '${mainPath}' worktree prune`);
-        console.log(`  \x1b[32m✓\x1b[0m removed worktree ${win.repo}`);
+        try { branch = (await d.hostExec(`git -C '${fullPath}' rev-parse --abbrev-ref HEAD`)).trim(); } catch { /* expected */ }
+        await d.hostExec(`git -C '${mainPath}' worktree remove '${fullPath}' --force`);
+        await d.hostExec(`git -C '${mainPath}' worktree prune`);
+        d.logger.log(`  \x1b[32m✓\x1b[0m removed worktree ${win.repo}`);
         if (branch && branch !== "main" && branch !== "HEAD") {
-          try { await hostExec(`git -C '${mainPath}' branch -d '${branch}'`); console.log(`  \x1b[32m✓\x1b[0m deleted branch ${branch}`); } catch { /* expected */ }
+          try { await d.hostExec(`git -C '${mainPath}' branch -d '${branch}'`); d.logger.log(`  \x1b[32m✓\x1b[0m deleted branch ${branch}`); } catch { /* expected */ }
         }
         return true;
       } catch (e: any) {
-        console.log(`  \x1b[33m⚠\x1b[0m worktree remove failed: ${e.message || e}`);
+        d.logger.log(`  \x1b[33m⚠\x1b[0m worktree remove failed: ${e.message || e}`);
       }
       break;
     }
-  } catch (e) { console.error(`  \x1b[33m⚠\x1b[0m fleet scan failed: ${e}`); }
+  } catch (e) { d.logger.error(`  \x1b[33m⚠\x1b[0m fleet scan failed: ${e}`); }
   return false;
 }
 
-async function removeWorktreeByGhqScan(
+export async function removeWorktreeByGhqScan(
   windowName: string,
   reposRoot: string,
+  deps: DoneDeps = {},
 ): Promise<boolean> {
+  const d = doneDeps(deps);
   let removed = false;
   try {
     const suffix = windowName.replace(/^[^-]+-/, "");
-    const ghqOut = await hostExec(`find ${reposRoot} -maxdepth 3 -name '*.wt-*' -type d 2>/dev/null`);
+    const ghqOut = await d.hostExec(`find ${reposRoot} -maxdepth 3 -name '*.wt-*' -type d 2>/dev/null`);
     const allWtPaths = ghqOut.trim().split("\n").filter(Boolean);
     const exactMatch = allWtPaths.filter(p => {
       const base = p.split("/").pop()!;
@@ -196,31 +257,32 @@ async function removeWorktreeByGhqScan(
       const mainPath = wtPath.replace(base, mainRepo);
       try {
         let branch = "";
-        try { branch = (await hostExec(`git -C '${wtPath}' rev-parse --abbrev-ref HEAD`)).trim(); } catch { /* expected */ }
-        await hostExec(`git -C '${mainPath}' worktree remove '${wtPath}' --force`);
-        await hostExec(`git -C '${mainPath}' worktree prune`);
-        console.log(`  \x1b[32m✓\x1b[0m removed worktree ${base}`);
+        try { branch = (await d.hostExec(`git -C '${wtPath}' rev-parse --abbrev-ref HEAD`)).trim(); } catch { /* expected */ }
+        await d.hostExec(`git -C '${mainPath}' worktree remove '${wtPath}' --force`);
+        await d.hostExec(`git -C '${mainPath}' worktree prune`);
+        d.logger.log(`  \x1b[32m✓\x1b[0m removed worktree ${base}`);
         removed = true;
         if (branch && branch !== "main" && branch !== "HEAD") {
-          try { await hostExec(`git -C '${mainPath}' branch -d '${branch}'`); console.log(`  \x1b[32m✓\x1b[0m deleted branch ${branch}`); } catch { /* expected */ }
+          try { await d.hostExec(`git -C '${mainPath}' branch -d '${branch}'`); d.logger.log(`  \x1b[32m✓\x1b[0m deleted branch ${branch}`); } catch { /* expected */ }
         }
-      } catch (e) { console.error(`  \x1b[33m⚠\x1b[0m worktree remove failed: ${e}`); }
+      } catch (e) { d.logger.error(`  \x1b[33m⚠\x1b[0m worktree remove failed: ${e}`); }
     }
-  } catch (e) { console.error(`  \x1b[33m⚠\x1b[0m worktree scan failed: ${e}`); }
+  } catch (e) { d.logger.error(`  \x1b[33m⚠\x1b[0m worktree scan failed: ${e}`); }
   return removed;
 }
 
-function removeFromFleetConfig(windowNameLower: string): boolean {
+export function removeFromFleetConfig(windowNameLower: string, deps: DoneDeps = {}): boolean {
+  const d = doneDeps(deps);
   let removed = false;
   try {
-    for (const file of readdirSync(FLEET_DIR).filter(f => f.endsWith(".json"))) {
-      const filePath = join(FLEET_DIR, file);
-      const config = JSON.parse(readFileSync(filePath, "utf-8"));
+    for (const file of d.fs.readdirSync(d.fleetDir).filter(f => f.endsWith(".json"))) {
+      const filePath = join(d.fleetDir, file);
+      const config = JSON.parse(d.fs.readFileSync(filePath, "utf-8"));
       const before = config.windows?.length || 0;
       config.windows = (config.windows || []).filter((w: any) => w.name.toLowerCase() !== windowNameLower);
       if (config.windows.length < before) {
-        writeFileSync(filePath, JSON.stringify(config, null, 2) + "\n");
-        console.log(`  \x1b[32m✓\x1b[0m removed from ${file}`);
+        d.fs.writeFileSync(filePath, JSON.stringify(config, null, 2) + "\n");
+        d.logger.log(`  \x1b[32m✓\x1b[0m removed from ${file}`);
         removed = true;
       }
     }

--- a/test/done-command.test.ts
+++ b/test/done-command.test.ts
@@ -1,0 +1,435 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { basename, dirname, join } from "path";
+import {
+  autoSave,
+  cmdDone,
+  removeFromFleetConfig,
+  removeWorktreeByGhqScan,
+  removeWorktreeViaConfig,
+  signalParentInbox,
+  type DoneDeps,
+} from "../src/commands/shared/done";
+
+type WindowInfo = { index: number; name: string; active: boolean };
+type SessionInfo = { name: string; windows: WindowInfo[] };
+
+function createMemoryFs(initial: Record<string, string> = {}, options: { failReaddir?: boolean; failAppend?: boolean } = {}) {
+  const files = new Map(Object.entries(initial));
+  const dirs: string[] = [];
+
+  return {
+    files,
+    dirs,
+    fs: {
+      mkdirSync(path: string) {
+        dirs.push(path);
+      },
+      appendFileSync(path: string, data: string) {
+        if (options.failAppend) throw new Error("append failed");
+        files.set(path, (files.get(path) ?? "") + data);
+      },
+      readdirSync(path: string) {
+        if (options.failReaddir) throw new Error("readdir failed");
+        const entries = [...files.keys()]
+          .filter((file) => dirname(file) === path)
+          .map((file) => basename(file));
+        return [...new Set(entries)];
+      },
+      readFileSync(path: string) {
+        const data = files.get(path);
+        if (data === undefined) throw new Error(`missing ${path}`);
+        return data;
+      },
+      writeFileSync(path: string, data: string) {
+        files.set(path, data);
+      },
+    } satisfies NonNullable<DoneDeps["fs"]>,
+  };
+}
+
+function createHarness(options: {
+  sessions?: SessionInfo[];
+  files?: Record<string, string>;
+  hostExec?: (command: string) => Promise<string> | string;
+  tmuxKillFails?: boolean;
+  tmuxSendFails?: boolean;
+  fsFailReaddir?: boolean;
+  fsFailAppend?: boolean;
+} = {}) {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  const commands: string[] = [];
+  const killed: string[] = [];
+  const sent: Array<{ target: string; text: string }> = [];
+  const sleeps: number[] = [];
+  const snapshots: string[] = [];
+  const memory = createMemoryFs(options.files, {
+    failReaddir: options.fsFailReaddir,
+    failAppend: options.fsFailAppend,
+  });
+  const sessions = options.sessions ?? [
+    {
+      name: "work",
+      windows: [
+        { index: 0, name: "lead/main", active: true },
+        { index: 1, name: "tile-1", active: false },
+      ],
+    },
+  ];
+
+  const deps: DoneDeps = {
+    listSessions: async () => sessions,
+    ghqRoot: "/repos",
+    fleetDir: "/fleet",
+    homeDir: "/home/tester",
+    now: () => new Date("2026-05-17T01:02:03.004Z"),
+    fs: memory.fs,
+    logger: {
+      log: (...args: unknown[]) => logs.push(args.map(String).join(" ")),
+      error: (...args: unknown[]) => errors.push(args.map(String).join(" ")),
+    },
+    hostExec: async (command: string) => {
+      commands.push(command);
+      if (options.hostExec) return await options.hostExec(command);
+      if (command.includes("pane_current_path")) return "/repos/github.com/Soul-Brews-Studio/maw-js.wt-tile-1\n";
+      if (command.startsWith("find ")) return "";
+      return "";
+    },
+    tmux: {
+      killWindow: async (target: string) => {
+        killed.push(target);
+        if (options.tmuxKillFails) throw new Error("kill failed");
+      },
+      sendText: async (target: string, text: string) => {
+        sent.push({ target, text });
+        if (options.tmuxSendFails) throw new Error("send failed");
+      },
+    },
+    sleep: async (ms: number) => {
+      sleeps.push(ms);
+    },
+    takeSnapshot: async (trigger: string) => {
+      snapshots.push(trigger);
+      return "/snapshot.json";
+    },
+  };
+
+  return { deps, logs, errors, commands, killed, sent, sleeps, snapshots, files: memory.files, dirs: memory.dirs };
+}
+
+let oldAgentName: string | undefined;
+
+beforeEach(() => {
+  oldAgentName = process.env.CLAUDE_AGENT_NAME;
+  process.env.CLAUDE_AGENT_NAME = "codex-agent";
+});
+
+afterEach(() => {
+  if (oldAgentName === undefined) delete process.env.CLAUDE_AGENT_NAME;
+  else process.env.CLAUDE_AGENT_NAME = oldAgentName;
+});
+
+describe("cmdDone", () => {
+  test("dry-run on a running window signals parent and stops before destructive cleanup", async () => {
+    const h = createHarness();
+
+    await cmdDone(" tile-1/ ", { dryRun: true }, h.deps);
+
+    expect(h.commands).toEqual(["tmux display-message -t 'work:tile-1' -p '#{pane_current_path}'"]);
+    expect(h.killed).toEqual([]);
+    expect(h.snapshots).toEqual([]);
+    expect(h.logs.join("\n")).toContain("would send /rrr to work:tile-1");
+    expect(h.logs.join("\n")).toContain("would git add + commit + push");
+
+    const inboxPath = "/home/tester/.oracle/inbox/leadmain.jsonl";
+    expect(h.dirs).toContain("/home/tester/.oracle/inbox");
+    const signal = JSON.parse(h.files.get(inboxPath)!.trim());
+    expect(signal).toEqual({
+      ts: "2026-05-17T01:02:03.004Z",
+      from: "codex-agent",
+      type: "done",
+      msg: "worktree tile-1 completed",
+      thread: null,
+    });
+  });
+
+  test("--force skips autosave, kills the window, removes configured worktree, updates fleet, and snapshots", async () => {
+    const fleetFile = "/fleet/team.json";
+    const h = createHarness({
+      files: {
+        [fleetFile]: JSON.stringify({
+          windows: [
+            { name: "tile-1", repo: "Soul-Brews-Studio/maw-js.wt-tile-1" },
+            { name: "lead", repo: "Soul-Brews-Studio/maw-js" },
+          ],
+        }),
+      },
+      hostExec: (command) => {
+        if (command.includes("rev-parse")) return "feature/done\n";
+        return "";
+      },
+    });
+
+    await cmdDone("TILE-1", { force: true }, h.deps);
+
+    expect(h.commands).not.toContain("tmux display-message -t 'work:tile-1' -p '#{pane_current_path}'");
+    expect(h.killed).toEqual(["work:tile-1"]);
+    expect(h.commands).toEqual([
+      "git -C '/repos/github.com/Soul-Brews-Studio/maw-js.wt-tile-1' rev-parse --abbrev-ref HEAD",
+      "git -C '/repos/github.com/Soul-Brews-Studio/maw-js' worktree remove '/repos/github.com/Soul-Brews-Studio/maw-js.wt-tile-1' --force",
+      "git -C '/repos/github.com/Soul-Brews-Studio/maw-js' worktree prune",
+      "git -C '/repos/github.com/Soul-Brews-Studio/maw-js' branch -d 'feature/done'",
+    ]);
+    expect(JSON.parse(h.files.get(fleetFile)!)).toEqual({
+      windows: [{ name: "lead", repo: "Soul-Brews-Studio/maw-js" }],
+    });
+    expect(h.snapshots).toEqual(["done"]);
+  });
+
+  test("kill failure and missing cleanup targets are reported without throwing", async () => {
+    const h = createHarness({ tmuxKillFails: true });
+
+    await cmdDone("tile-1", { force: true }, h.deps);
+
+    expect(h.killed).toEqual(["work:tile-1"]);
+    expect(h.logs.join("\n")).toContain("could not kill window");
+    expect(h.logs.join("\n")).toContain("no worktree to remove");
+    expect(h.logs.join("\n")).toContain("not in any fleet config");
+    expect(h.snapshots).toEqual(["done"]);
+  });
+
+  test("snapshot failures are swallowed after cleanup completes", async () => {
+    const h = createHarness();
+    const deps: DoneDeps = {
+      ...h.deps,
+      takeSnapshot: async () => {
+        throw new Error("snapshot offline");
+      },
+    };
+
+    await cmdDone("tile-1", { force: true }, deps);
+    await Promise.resolve();
+
+    expect(h.killed).toEqual(["work:tile-1"]);
+    expect(h.logs.join("\n")).toContain("killed window work:tile-1");
+  });
+
+  test("dry-run for a missing window reports that no autosave target is running", async () => {
+    const h = createHarness({
+      sessions: [{ name: "work", windows: [{ index: 0, name: "lead", active: true }] }],
+    });
+
+    await cmdDone("missing", { dryRun: true }, h.deps);
+
+    expect(h.logs.join("\n")).toContain("window 'missing' not running — nothing to auto-save");
+    expect(h.logs.join("\n")).toContain("window 'missing' not running");
+    expect(h.killed).toEqual([]);
+    expect(h.snapshots).toEqual(["done"]);
+  });
+});
+
+describe("done inbox and autosave helpers", () => {
+  test("signalParentInbox no-ops without a parent and logs fs errors", () => {
+    const noParent = createHarness();
+    signalParentInbox("tile-1", "missing", [], noParent.deps);
+    expect(noParent.files.size).toBe(0);
+
+    const failing = createHarness({ fsFailAppend: true });
+    signalParentInbox("tile-1", "work", [
+      { name: "work", windows: [{ index: 0, name: "lead", active: true }] },
+    ], failing.deps);
+    expect(failing.errors.join("\n")).toContain("inbox signal failed");
+  });
+
+  test("signalParentInbox can use the default clock when tests inject only filesystem paths", () => {
+    const memory = createMemoryFs();
+    signalParentInbox("tile-1", "work", [
+      { name: "work", windows: [{ index: 0, name: "lead", active: true }] },
+    ], {
+      fs: memory.fs,
+      homeDir: "/home/default-clock",
+      logger: { log() {}, error() {} },
+    });
+
+    const signal = JSON.parse(memory.files.get("/home/default-clock/.oracle/inbox/lead.jsonl")!.trim());
+    expect(Number.isNaN(Date.parse(signal.ts))).toBe(false);
+    expect(signal.msg).toBe("worktree tile-1 completed");
+  });
+
+  test("autoSave sends /rrr, waits, and commits/pushes when pane cwd is known", async () => {
+    const h = createHarness();
+
+    await autoSave("tile-1", "work", {}, h.deps);
+
+    expect(h.sent).toEqual([{ target: "work:tile-1", text: "/rrr" }]);
+    expect(h.sleeps).toEqual([10_000]);
+    expect(h.commands).toEqual([
+      "tmux display-message -t 'work:tile-1' -p '#{pane_current_path}'",
+      "git -C '/repos/github.com/Soul-Brews-Studio/maw-js.wt-tile-1' add -A",
+      "git -C '/repos/github.com/Soul-Brews-Studio/maw-js.wt-tile-1' commit -m 'chore: auto-save before done'",
+      "git -C '/repos/github.com/Soul-Brews-Studio/maw-js.wt-tile-1' push",
+    ]);
+    expect(h.logs.join("\n")).toContain("committed changes");
+    expect(h.logs.join("\n")).toContain("pushed to remote");
+  });
+
+  test("autoSave reports tmux send, commit, push, and git add failures", async () => {
+    const sendFail = createHarness({ tmuxSendFails: true });
+    await autoSave("tile-1", "work", {}, sendFail.deps);
+    expect(sendFail.logs.join("\n")).toContain("could not send /rrr");
+
+    const commitPushFail = createHarness({
+      hostExec: (command) => {
+        if (command.includes("pane_current_path")) return "/repo";
+        if (command.includes(" commit ")) throw new Error("nothing");
+        if (command.endsWith(" push")) throw new Error("denied");
+        return "";
+      },
+    });
+    await autoSave("tile-1", "work", {}, commitPushFail.deps);
+    expect(commitPushFail.logs.join("\n")).toContain("nothing to commit");
+    expect(commitPushFail.logs.join("\n")).toContain("push failed");
+
+    const addFail = createHarness({
+      hostExec: (command) => {
+        if (command.includes("pane_current_path")) return "/repo";
+        if (command.endsWith(" add -A")) throw new Error("add failed");
+        return "";
+      },
+    });
+    await autoSave("tile-1", "work", {}, addFail.deps);
+    expect(addFail.logs.join("\n")).toContain("git auto-save failed: add failed");
+  });
+
+  test("autoSave dry-run still explains the flow when pane cwd lookup fails", async () => {
+    const h = createHarness({
+      hostExec: () => {
+        throw new Error("pane missing");
+      },
+    });
+
+    await autoSave("tile-1", "work", { dryRun: true }, h.deps);
+
+    expect(h.logs.join("\n")).toContain("would send /rrr to work:tile-1");
+    expect(h.logs.join("\n")).not.toContain("would git add + commit + push");
+  });
+});
+
+describe("done worktree cleanup helpers", () => {
+  test("removeWorktreeViaConfig removes configured worktrees and skips main/HEAD branch deletion", async () => {
+    const h = createHarness({
+      files: {
+        "/fleet/team.json": JSON.stringify({
+          windows: [{ name: "tile-1", repo: "Soul-Brews-Studio/maw-js.wt-tile-1" }],
+        }),
+      },
+      hostExec: (command) => {
+        if (command.includes("rev-parse")) return "main\n";
+        return "";
+      },
+    });
+
+    await expect(removeWorktreeViaConfig("tile-1", "/repos/github.com", h.deps)).resolves.toBe(true);
+
+    expect(h.commands).toEqual([
+      "git -C '/repos/github.com/Soul-Brews-Studio/maw-js.wt-tile-1' rev-parse --abbrev-ref HEAD",
+      "git -C '/repos/github.com/Soul-Brews-Studio/maw-js' worktree remove '/repos/github.com/Soul-Brews-Studio/maw-js.wt-tile-1' --force",
+      "git -C '/repos/github.com/Soul-Brews-Studio/maw-js' worktree prune",
+    ]);
+  });
+
+  test("removeWorktreeViaConfig returns false for non-worktrees, remove failures, and fleet scan errors", async () => {
+    const nonWorktree = createHarness({
+      files: {
+        "/fleet/team.json": JSON.stringify({
+          windows: [{ name: "lead", repo: "Soul-Brews-Studio/maw-js" }],
+        }),
+      },
+    });
+    await expect(removeWorktreeViaConfig("lead", "/repos/github.com", nonWorktree.deps)).resolves.toBe(false);
+
+    const removeFail = createHarness({
+      files: {
+        "/fleet/team.json": JSON.stringify({
+          windows: [{ name: "tile-1", repo: "Soul-Brews-Studio/maw-js.wt-tile-1" }],
+        }),
+      },
+      hostExec: (command) => {
+        if (command.includes("worktree remove")) throw new Error("busy");
+        return "feature\n";
+      },
+    });
+    await expect(removeWorktreeViaConfig("tile-1", "/repos/github.com", removeFail.deps)).resolves.toBe(false);
+    expect(removeFail.logs.join("\n")).toContain("worktree remove failed: busy");
+
+    const scanFail = createHarness({ fsFailReaddir: true });
+    await expect(removeWorktreeViaConfig("tile-1", "/repos/github.com", scanFail.deps)).resolves.toBe(false);
+    expect(scanFail.errors.join("\n")).toContain("fleet scan failed");
+  });
+
+  test("removeWorktreeByGhqScan removes matching suffix worktrees and ignores branch-delete failures", async () => {
+    const h = createHarness({
+      hostExec: (command) => {
+        if (command.startsWith("find ")) {
+          return [
+            "/repos/github.com/Soul-Brews-Studio/maw-js.wt-6-tile-1",
+            "/repos/github.com/Soul-Brews-Studio/maw-js.wt-other",
+          ].join("\n");
+        }
+        if (command.includes("rev-parse")) return "feature/scan\n";
+        if (command.includes("branch -d")) throw new Error("not merged");
+        return "";
+      },
+    });
+
+    await expect(removeWorktreeByGhqScan("6-tile-1", "/repos/github.com", h.deps)).resolves.toBe(true);
+
+    expect(h.commands).toContain("git -C '/repos/github.com/Soul-Brews-Studio/maw-js.wt-6-tile-1' rev-parse --abbrev-ref HEAD");
+    expect(h.commands).toContain("git -C '/repos/github.com/Soul-Brews-Studio/maw-js' worktree remove '/repos/github.com/Soul-Brews-Studio/maw-js.wt-6-tile-1' --force");
+    expect(h.logs.join("\n")).toContain("removed worktree maw-js.wt-6-tile-1");
+    expect(h.logs.join("\n")).not.toContain("deleted branch feature/scan");
+  });
+
+  test("removeWorktreeByGhqScan reports find and per-worktree failures", async () => {
+    const findFail = createHarness({
+      hostExec: () => {
+        throw new Error("find failed");
+      },
+    });
+    await expect(removeWorktreeByGhqScan("tile-1", "/repos/github.com", findFail.deps)).resolves.toBe(false);
+    expect(findFail.errors.join("\n")).toContain("worktree scan failed: Error: find failed");
+
+    const removeFail = createHarness({
+      hostExec: (command) => {
+        if (command.startsWith("find ")) return "/repos/github.com/Soul-Brews-Studio/maw-js.wt-tile-1\n";
+        if (command.includes("worktree remove")) throw new Error("busy");
+        return "";
+      },
+    });
+    await expect(removeWorktreeByGhqScan("x-tile-1", "/repos/github.com", removeFail.deps)).resolves.toBe(false);
+    expect(removeFail.errors.join("\n")).toContain("worktree remove failed: Error: busy");
+  });
+
+  test("removeFromFleetConfig rewrites matching configs and ignores missing fleet dirs", () => {
+    const h = createHarness({
+      files: {
+        "/fleet/team.json": JSON.stringify({
+          windows: [
+            { name: "tile-1", repo: "repo.wt-tile-1" },
+            { name: "lead", repo: "repo" },
+          ],
+        }),
+        "/fleet/readme.txt": "ignored",
+      },
+    });
+
+    expect(removeFromFleetConfig("tile-1", h.deps)).toBe(true);
+    expect(JSON.parse(h.files.get("/fleet/team.json")!)).toEqual({
+      windows: [{ name: "lead", repo: "repo" }],
+    });
+    expect(h.logs.join("\n")).toContain("removed from team.json");
+
+    const missing = createHarness({ fsFailReaddir: true });
+    expect(removeFromFleetConfig("tile-1", missing.deps)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- adds an explicit dependency seam to `cmdDone` so lifecycle behavior can be tested without real tmux, git, or fleet state
- covers done autosave, inbox signal, worktree cleanup, fleet config cleanup, snapshot failure handling, and dry-run/no-op branches
- regenerates coverage gap analysis: `src/commands/shared/done.ts` is now 100% line/function coverage; overall lines moved to 17.1%, funcs to 62.4%

## Validation
- `rtk bun test test/done-command.test.ts` — 15 pass / 0 fail
- `rtk bun run test:coverage` — 1648 pass / 6 skip / 0 fail; done.ts 100% / 100%
- `rtk bun run build` — OK
- `rtk bun run test:isolated` — 119/119 files passed

## Release
- alpha-only feature PR
- no release/alpha cut

Refs #1637

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
