### PR TITLE
test: cover tmux command wrapper contracts

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,26 +1,26 @@
 # Coverage gap analysis
 
-Generated: 2026-05-16T21:05:18.178Z
+Generated: 2026-05-16T21:17:34.599Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **17.1%** (8650/50593)
-Overall function coverage: **62.4%** (939/1504)
+Overall line coverage: **17.4%** (8786/50488)
+Overall function coverage: **65.2%** (1003/1538)
 
 ## Module summary
 
 | Module | Files | Missing from LCOV | Lines | Functions | Branches |
 | --- | ---: | ---: | ---: | ---: | ---: |
 | cli/dispatch | 88 | 21 | 33.4% (2504/7496) | 66.0% (258/391) | n/a (0/0) |
-| config/runtime | 19 | 2 | 45.2% (528/1167) | 42.5% (37/87) | n/a (0/0) |
+| config/runtime | 19 | 2 | 45.3% (529/1167) | 43.7% (38/87) | n/a (0/0) |
 | fleet | 17 | 0 | 38.8% (407/1050) | 54.8% (40/73) | n/a (0/0) |
 | matcher | 2 | 0 | 100.0% (41/41) | 100.0% (8/8) | n/a (0/0) |
 | other | 174 | 98 | 18.7% (2699/14401) | 57.6% (278/483) | n/a (0/0) |
 | plugin dispatch | 15 | 1 | 67.2% (819/1218) | 83.8% (67/80) | n/a (0/0) |
 | routing/aliases | 4 | 0 | 49.2% (300/610) | 72.7% (32/44) | n/a (0/0) |
-| transport | 28 | 2 | 46.1% (1207/2618) | 64.7% (207/320) | n/a (0/0) |
+| transport | 28 | 2 | 53.4% (1342/2513) | 76.3% (270/354) | n/a (0/0) |
 | vendor plugins | 245 | 244 | 0.7% (145/21992) | 66.7% (12/18) | n/a (0/0) |
 
 ## Top 20 uncovered files by executable/source line count
@@ -44,9 +44,9 @@ Overall function coverage: **62.4%** (939/1504)
 | 15 | medium | other | `src/commands/plugins/tile/impl.ts` | 283 | 0.0% | n/a | absent from LCOV |
 | 16 | medium | other | `src/commands/plugins/plugin/install-handlers.ts` | 280 | 24.9% | 18.8% | partial coverage |
 | 17 | low | vendor plugins | `src/vendor/mpr-plugins/view/impl.ts` | 269 | 0.0% | n/a | absent from LCOV |
-| 18 | critical | transport | `src/core/transport/tmux-class.ts` | 267 | 15.2% | 30.4% | partial coverage |
-| 19 | medium | other | `src/commands/plugins/tmux/index.ts` | 260 | 0.0% | n/a | absent from LCOV |
-| 20 | low | vendor plugins | `src/vendor/mpr-plugins/init/internal/plugin-lock.ts` | 251 | 0.0% | n/a | absent from LCOV |
+| 18 | medium | other | `src/commands/plugins/tmux/index.ts` | 260 | 0.0% | n/a | absent from LCOV |
+| 19 | low | vendor plugins | `src/vendor/mpr-plugins/init/internal/plugin-lock.ts` | 251 | 0.0% | n/a | absent from LCOV |
+| 20 | low | vendor plugins | `src/vendor/mpr-plugins/peers/index.ts` | 250 | 0.0% | n/a | absent from LCOV |
 
 ## Critical files at or above the 80% line target
 
@@ -103,6 +103,7 @@ Overall function coverage: **62.4%** (939/1504)
 | plugin dispatch | `src/plugin/registry-semver.ts` | 100.0% | 100.0% |
 | plugin dispatch | `src/plugin/tier.ts` | 100.0% | 100.0% |
 | routing/aliases | `src/core/routing.ts` | 89.1% | 91.7% |
+| transport | `src/core/transport/tmux-class.ts` | 87.1% | 96.3% |
 | transport | `src/core/transport/tmux.ts` | 100.0% | 100.0% |
 | transport | `src/core/transport/transport.ts` | 100.0% | 96.4% |
 | transport | `src/transports/http.ts` | 100.0% | 100.0% |
@@ -126,20 +127,19 @@ Overall function coverage: **62.4%** (939/1504)
 | cli/dispatch | `src/commands/shared/comm-send.ts` | 469 | 16.8% |
 | cli/dispatch | `src/commands/shared/wake-cmd.ts` | 443 | 30.9% |
 | cli/dispatch | `src/cli/cmd-update.ts` | 308 | 28.7% |
-| transport | `src/core/transport/tmux-class.ts` | 267 | 15.2% |
 | transport | `src/transports/scout.ts` | 248 | 8.5% |
 | cli/dispatch | `src/commands/shared/wake-resolve-impl.ts` | 226 | 28.7% |
 | transport | `src/transports/mdns.ts` | 184 | 7.5% |
 | transport | `src/core/transport/peers.ts` | 176 | 31.3% |
 | transport | `src/core/transport/pty.ts` | 150 | 0.0% |
 | routing/aliases | `src/cli/top-aliases.ts` | 148 | 41.3% |
+| plugin dispatch | `src/plugin/registry.ts` | 147 | 8.1% |
 
 ## Critical gaps to prioritize
 
 - `src/commands/shared/comm-send.ts` (cli/dispatch): 469 uncovered lines, 16.8% line coverage.
 - `src/commands/shared/wake-cmd.ts` (cli/dispatch): 443 uncovered lines, 30.9% line coverage.
 - `src/cli/cmd-update.ts` (cli/dispatch): 308 uncovered lines, 28.7% line coverage.
-- `src/core/transport/tmux-class.ts` (transport): 267 uncovered lines, 15.2% line coverage.
 
 ## Prioritization guidance
 

--- a/test/tmux-class-command-builders.test.ts
+++ b/test/tmux-class-command-builders.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, test } from "bun:test";
+import { Tmux } from "../src/core/transport/tmux-class";
+
+type RunCall = { subcommand: string; args: (string | number)[] };
+type RunHandler = (subcommand: string, args: (string | number)[], callIndex: number) => string | Promise<string>;
+
+class FakeTmux extends Tmux {
+  calls: RunCall[] = [];
+  handler: RunHandler;
+
+  constructor(handler: RunHandler = () => "") {
+    super(undefined, "");
+    this.handler = handler;
+  }
+
+  async run(subcommand: string, ...args: (string | number)[]): Promise<string> {
+    const callIndex = this.calls.length;
+    this.calls.push({ subcommand, args });
+    return this.handler(subcommand, args, callIndex);
+  }
+
+  callStrings(): string[] {
+    return this.calls.map(c => [c.subcommand, ...c.args].join(" "));
+  }
+}
+
+function byCommand(outputs: Record<string, string | Error>): RunHandler {
+  return (subcommand, args) => {
+    const key = [subcommand, ...args].join(" ");
+    const value = outputs[key] ?? outputs[subcommand] ?? "";
+    if (value instanceof Error) throw value;
+    return value;
+  };
+}
+
+describe("Tmux command wrapper coverage", () => {
+  test("listSessions loads windows per session and fails soft when tmux is absent", async () => {
+    const t = new FakeTmux(byCommand({
+      "list-sessions -F #{session_name}": "alpha\nbeta\n",
+      "list-windows -t alpha -F #{window_index}:#{window_name}:#{window_active}": "0:main:1\n1:work:0",
+      "list-windows -t beta -F #{window_index}:#{window_name}:#{window_active}": "2:solo:1",
+    }));
+
+    expect(await t.listSessions()).toEqual([
+      { name: "alpha", windows: [{ index: 0, name: "main", active: true }, { index: 1, name: "work", active: false }] },
+      { name: "beta", windows: [{ index: 2, name: "solo", active: true }] },
+    ]);
+    expect(t.callStrings()[0]).toBe("list-sessions -F #{session_name}");
+
+    const missing = new FakeTmux(() => { throw new Error("no server"); });
+    expect(await missing.listSessions()).toEqual([]);
+  });
+
+  test("listAll groups windows and returns empty on tmux failure", async () => {
+    const t = new FakeTmux(() => [
+      "alpha|||0|||main|||1|||/repo/a",
+      "alpha|||1|||work|||0|||",
+      "beta|||3|||solo|||1|||/repo/b",
+    ].join("\n"));
+
+    expect(await t.listAll()).toEqual([
+      { name: "alpha", windows: [{ index: 0, name: "main", active: true, cwd: "/repo/a" }, { index: 1, name: "work", active: false, cwd: undefined }] },
+      { name: "beta", windows: [{ index: 3, name: "solo", active: true, cwd: "/repo/b" }] },
+    ]);
+
+    const failing = new FakeTmux(() => { throw new Error("tmux down"); });
+    expect(await failing.listAll()).toEqual([]);
+  });
+
+  test("session and window mutators build the expected tmux subcommands", async () => {
+    const t = new FakeTmux();
+
+    expect(await t.hasSession("oracle")).toBe(true);
+    await t.newSession("oracle", { window: "main", cwd: "/repo", detached: false });
+    await t.newGroupedSession("oracle", "maw-pty-1", { cols: 120, rows: 40, windowSize: "manual", window: "work" });
+    await t.newWindow("oracle", "child", { cwd: "/repo/child" });
+    await t.selectWindow("oracle:child");
+    await t.switchClient("oracle");
+    await t.killWindow("oracle:child");
+    await t.killSession("maw-pty-1");
+
+    expect(t.callStrings()).toEqual([
+      "has-session -t oracle",
+      "new-session -s oracle -n main -c /repo",
+      "set-option -t oracle renumber-windows on",
+      "new-session -d -t oracle -s maw-pty-1 -x 120 -y 40",
+      "set-option -t maw-pty-1 window-size manual",
+      "select-window -t maw-pty-1:work",
+      "new-window -t oracle: -n child -c /repo/child",
+      "select-window -t oracle:child",
+      "switch-client -t oracle",
+      "kill-window -t oracle:child",
+      "kill-session -t maw-pty-1",
+    ]);
+  });
+
+  test("hasSession and tryRun convert tmux errors to falsey results", async () => {
+    const t = new FakeTmux(() => { throw new Error("can't find session"); });
+
+    expect(await t.hasSession("missing")).toBe(false);
+    expect(await t.tryRun("kill-window", "-t", "missing:0")).toBe("");
+  });
+
+  test("pane list/info helpers parse optional fields and tolerate failures", async () => {
+    const t = new FakeTmux(byCommand({
+      "list-panes -a -F #{pane_id}": "%1\n%2\n",
+      "list-panes -a -F #{pane_id}|||#{pane_current_command}|||#{session_name}:#{window_name}.#{pane_index}|||#{pane_title}|||#{pane_pid}|||#{pane_current_path}|||#{window_activity}": [
+        "%1|||claude|||s:main.0|||oracle|||123|||/repo|||1715840000",
+        "%2|||zsh|||s:shell.1||||||",
+      ].join("\n"),
+      "list-panes -t s:main.0 -F #{pane_current_command}": "claude\n",
+      "list-panes -a -F #{session_name}:#{window_index}|||#{pane_current_command}": "s:0|||claude\ns:1|||zsh\n",
+      "list-panes -t s:main.0 -F #{pane_current_command}\t#{pane_current_path}": "claude\t/repo\n",
+      "list-panes -t s:shell.1 -F #{pane_current_command}\t#{pane_current_path}": "zsh\t/tmp\n",
+    }));
+
+    expect(await t.listPaneIds()).toEqual(new Set(["%1", "%2"]));
+    expect(await t.listPanes()).toEqual([
+      { id: "%1", command: "claude", target: "s:main.0", title: "oracle", pid: 123, cwd: "/repo", lastActivity: 1715840000 },
+      { id: "%2", command: "zsh", target: "s:shell.1", title: "", pid: undefined, cwd: undefined, lastActivity: undefined },
+    ]);
+    expect(await t.getPaneCommand("s:main.0")).toBe("claude");
+    expect(await t.getPaneCommands(["s:0", "s:missing"])).toEqual({ "s:0": "claude" });
+    expect(await t.getPaneInfo("s:main.0")).toEqual({ command: "claude", cwd: "/repo" });
+    expect(await t.getPaneInfos(["s:main.0", "s:shell.1"])).toEqual({
+      "s:main.0": { command: "claude", cwd: "/repo" },
+      "s:shell.1": { command: "zsh", cwd: "/tmp" },
+    });
+
+    const failing = new FakeTmux(() => { throw new Error("tmux down"); });
+    expect(await failing.listPaneIds()).toEqual(new Set());
+    expect(await failing.listPanes()).toEqual([]);
+    expect(await failing.getPaneCommands(["s:0"])).toEqual({});
+    expect(await failing.getPaneInfos(["s:0"])).toEqual({});
+  });
+
+  test("pane and option mutators clamp dimensions and preserve target arguments", async () => {
+    const t = new FakeTmux();
+
+    await t.killPane("s:0.1");
+    await t.resizePane("s:0.1", 9999, -5);
+    await t.resizeWindow("s:0", 80.8, 24.2);
+    await t.splitWindow("s:0");
+    await t.selectPane("s:0.1", { title: "work pane" });
+    await t.selectLayout("s:0", "tiled");
+    await t.sendKeys("s:0.1", "C-c", "Enter");
+    await t.sendKeysLiteral("s:0.1", "hello world");
+    await t.pasteBuffer("s:0.1");
+    await t.setEnvironment("s", "MAW_TEST", "1");
+    await t.setOption("s", "status", "off");
+    await t.set("s", "status-style", "bg=colour235,fg=colour248");
+
+    expect(t.callStrings()).toEqual([
+      "kill-pane -t s:0.1",
+      "resize-pane -t s:0.1 -x 500 -y 1",
+      "resize-window -t s:0 -x 80 -y 24",
+      "split-window -t s:0",
+      "select-pane -t s:0.1 -T work pane",
+      "select-layout -t s:0 tiled",
+      "send-keys -t s:0.1 C-c Enter",
+      "send-keys -t s:0.1 -l hello world",
+      "paste-buffer -t s:0.1",
+      "set-environment -t s MAW_TEST 1",
+      "set-option -t s status off",
+      "set -t s status-style bg=colour235,fg=colour248",
+    ]);
+  });
+
+  test("exitModeIfNeeded cancels copy-mode only when necessary and treats benign races as no-op", async () => {
+    const normal = new FakeTmux(() => "0");
+    expect(await normal.exitModeIfNeeded("s:0")).toBe(false);
+    expect(normal.callStrings()).toEqual(["display-message -t s:0 -p #{pane_in_mode}"]);
+
+    const copy = new FakeTmux((subcommand, _args, index) => {
+      if (index === 0) return "1";
+      expect(subcommand).toBe("send-keys");
+      return "";
+    });
+    expect(await copy.exitModeIfNeeded("s:0")).toBe(true);
+    expect(copy.callStrings()).toEqual([
+      "display-message -t s:0 -p #{pane_in_mode}",
+      "send-keys -t s:0 -X cancel",
+    ]);
+
+    const probeFails = new FakeTmux(() => { throw new Error("can't find pane"); });
+    expect(await probeFails.exitModeIfNeeded("s:0")).toBe(false);
+
+    const race = new FakeTmux((_subcommand, _args, index) => {
+      if (index === 0) return "1";
+      throw new Error("not in a mode");
+    });
+    expect(await race.exitModeIfNeeded("s:0")).toBe(false);
+
+    const hardFailure = new FakeTmux((_subcommand, _args, index) => {
+      if (index === 0) return "1";
+      throw new Error("permission denied");
+    });
+    await expect(hardFailure.exitModeIfNeeded("s:0")).rejects.toThrow("permission denied");
+  });
+});


### PR DESCRIPTION
## Summary
- Add deterministic FakeTmux coverage for tmux-class command wrappers and fail-soft helpers.
- Move `src/core/transport/tmux-class.ts` above the critical 80% line target.
- Refresh the #1637 coverage gap report after the new tests.

## Coverage impact
- `src/core/transport/tmux-class.ts`: 87.1% line / 96.3% function coverage.
- Overall: 17.4% line / 65.2% function coverage.

## Validation
- `rtk bun test test/tmux-class-command-builders.test.ts --coverage --coverage-reporter=text`
- `rtk bun test test/tmux-class-command-builders.test.ts test/tmux-sendtext-submit.test.ts --coverage --coverage-reporter=text`
- `rtk bun run test:coverage`
- `rtk bun run build`
- `rtk bun run test:isolated`

Refs #1637

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
