### PR TITLE
test: cover cmdSend delivery and safety gates

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,23 +1,23 @@
 # Coverage gap analysis
 
-Generated: 2026-05-16T21:17:34.599Z
+Generated: 2026-05-16T21:34:15.654Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **17.4%** (8786/50488)
-Overall function coverage: **65.2%** (1003/1538)
+Overall line coverage: **18.2%** (9149/50284)
+Overall function coverage: **64.6%** (1018/1575)
 
 ## Module summary
 
 | Module | Files | Missing from LCOV | Lines | Functions | Branches |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| cli/dispatch | 88 | 21 | 33.4% (2504/7496) | 66.0% (258/391) | n/a (0/0) |
+| cli/dispatch | 88 | 18 | 38.8% (2849/7338) | 65.9% (273/414) | n/a (0/0) |
 | config/runtime | 19 | 2 | 45.3% (529/1167) | 43.7% (38/87) | n/a (0/0) |
 | fleet | 17 | 0 | 38.8% (407/1050) | 54.8% (40/73) | n/a (0/0) |
 | matcher | 2 | 0 | 100.0% (41/41) | 100.0% (8/8) | n/a (0/0) |
-| other | 174 | 98 | 18.7% (2699/14401) | 57.6% (278/483) | n/a (0/0) |
+| other | 174 | 95 | 18.9% (2717/14355) | 55.9% (278/497) | n/a (0/0) |
 | plugin dispatch | 15 | 1 | 67.2% (819/1218) | 83.8% (67/80) | n/a (0/0) |
 | routing/aliases | 4 | 0 | 49.2% (300/610) | 72.7% (32/44) | n/a (0/0) |
 | transport | 28 | 2 | 53.4% (1342/2513) | 76.3% (270/354) | n/a (0/0) |
@@ -31,22 +31,22 @@ Overall function coverage: **65.2%** (1003/1538)
 | 2 | medium | other | `src/commands/plugins/tmux/impl.ts` | 590 | 5.1% | 0.0% | partial coverage |
 | 3 | low | vendor plugins | `src/vendor/mpr-plugins/team/team-charter.ts` | 482 | 0.0% | n/a | absent from LCOV |
 | 4 | medium | other | `src/commands/plugins/team/index.ts` | 477 | 0.0% | n/a | absent from LCOV |
-| 5 | critical | cli/dispatch | `src/commands/shared/comm-send.ts` | 469 | 16.8% | 55.0% | partial coverage |
-| 6 | critical | cli/dispatch | `src/commands/shared/wake-cmd.ts` | 443 | 30.9% | 76.7% | partial coverage |
-| 7 | low | vendor plugins | `src/vendor/mpr-plugins/messages/index.ts` | 398 | 0.0% | n/a | absent from LCOV |
-| 8 | medium | other | `src/api/sessions.ts` | 372 | 16.8% | 12.5% | partial coverage |
-| 9 | low | vendor plugins | `src/vendor/mpr-plugins/cleanup/internal/prune-stale-oracles.ts` | 366 | 0.0% | n/a | absent from LCOV |
-| 10 | medium | other | `src/core/engine-plugin-registry.ts` | 336 | 0.0% | n/a | absent from LCOV |
-| 11 | low | vendor plugins | `src/vendor/mpr-plugins/doctor/impl.ts` | 332 | 0.0% | n/a | absent from LCOV |
-| 12 | low | vendor plugins | `src/vendor/mpr-plugins/team/index.ts` | 314 | 0.0% | n/a | absent from LCOV |
-| 13 | critical | cli/dispatch | `src/cli/cmd-update.ts` | 308 | 28.7% | 73.3% | partial coverage |
-| 14 | low | vendor plugins | `src/vendor/mpr-plugins/bg/src/impl.ts` | 297 | 0.0% | n/a | absent from LCOV |
-| 15 | medium | other | `src/commands/plugins/tile/impl.ts` | 283 | 0.0% | n/a | absent from LCOV |
-| 16 | medium | other | `src/commands/plugins/plugin/install-handlers.ts` | 280 | 24.9% | 18.8% | partial coverage |
-| 17 | low | vendor plugins | `src/vendor/mpr-plugins/view/impl.ts` | 269 | 0.0% | n/a | absent from LCOV |
-| 18 | medium | other | `src/commands/plugins/tmux/index.ts` | 260 | 0.0% | n/a | absent from LCOV |
-| 19 | low | vendor plugins | `src/vendor/mpr-plugins/init/internal/plugin-lock.ts` | 251 | 0.0% | n/a | absent from LCOV |
-| 20 | low | vendor plugins | `src/vendor/mpr-plugins/peers/index.ts` | 250 | 0.0% | n/a | absent from LCOV |
+| 5 | critical | cli/dispatch | `src/commands/shared/wake-cmd.ts` | 443 | 30.9% | 76.7% | partial coverage |
+| 6 | low | vendor plugins | `src/vendor/mpr-plugins/messages/index.ts` | 398 | 0.0% | n/a | absent from LCOV |
+| 7 | medium | other | `src/api/sessions.ts` | 372 | 16.8% | 12.5% | partial coverage |
+| 8 | low | vendor plugins | `src/vendor/mpr-plugins/cleanup/internal/prune-stale-oracles.ts` | 366 | 0.0% | n/a | absent from LCOV |
+| 9 | medium | other | `src/core/engine-plugin-registry.ts` | 336 | 0.0% | n/a | absent from LCOV |
+| 10 | low | vendor plugins | `src/vendor/mpr-plugins/doctor/impl.ts` | 332 | 0.0% | n/a | absent from LCOV |
+| 11 | low | vendor plugins | `src/vendor/mpr-plugins/team/index.ts` | 314 | 0.0% | n/a | absent from LCOV |
+| 12 | critical | cli/dispatch | `src/cli/cmd-update.ts` | 308 | 28.7% | 73.3% | partial coverage |
+| 13 | low | vendor plugins | `src/vendor/mpr-plugins/bg/src/impl.ts` | 297 | 0.0% | n/a | absent from LCOV |
+| 14 | medium | other | `src/commands/plugins/tile/impl.ts` | 283 | 0.0% | n/a | absent from LCOV |
+| 15 | medium | other | `src/commands/plugins/plugin/install-handlers.ts` | 280 | 24.9% | 18.8% | partial coverage |
+| 16 | low | vendor plugins | `src/vendor/mpr-plugins/view/impl.ts` | 269 | 0.0% | n/a | absent from LCOV |
+| 17 | medium | other | `src/commands/plugins/tmux/index.ts` | 260 | 0.0% | n/a | absent from LCOV |
+| 18 | low | vendor plugins | `src/vendor/mpr-plugins/init/internal/plugin-lock.ts` | 251 | 0.0% | n/a | absent from LCOV |
+| 19 | low | vendor plugins | `src/vendor/mpr-plugins/peers/index.ts` | 250 | 0.0% | n/a | absent from LCOV |
+| 20 | critical | transport | `src/transports/scout.ts` | 248 | 8.5% | 0.0% | partial coverage |
 
 ## Critical files at or above the 80% line target
 
@@ -61,6 +61,7 @@ Overall function coverage: **65.2%** (1003/1538)
 | cli/dispatch | `src/cli/parse-args.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/cli/usage.ts` | 89.6% | 92.9% |
 | cli/dispatch | `src/cli/verbosity.ts` | 100.0% | 100.0% |
+| cli/dispatch | `src/commands/shared/comm-send.ts` | 88.2% | 92.6% |
 | cli/dispatch | `src/commands/shared/comm.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/done.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/federation-apply.ts` | 100.0% | 100.0% |
@@ -124,7 +125,6 @@ Overall function coverage: **65.2%** (1003/1538)
 
 | Module | File | Uncovered | Line coverage |
 | --- | --- | ---: | ---: |
-| cli/dispatch | `src/commands/shared/comm-send.ts` | 469 | 16.8% |
 | cli/dispatch | `src/commands/shared/wake-cmd.ts` | 443 | 30.9% |
 | cli/dispatch | `src/cli/cmd-update.ts` | 308 | 28.7% |
 | transport | `src/transports/scout.ts` | 248 | 8.5% |
@@ -134,12 +134,13 @@ Overall function coverage: **65.2%** (1003/1538)
 | transport | `src/core/transport/pty.ts` | 150 | 0.0% |
 | routing/aliases | `src/cli/top-aliases.ts` | 148 | 41.3% |
 | plugin dispatch | `src/plugin/registry.ts` | 147 | 8.1% |
+| cli/dispatch | `src/commands/shared/fleet-wake.ts` | 146 | 0.0% |
 
 ## Critical gaps to prioritize
 
-- `src/commands/shared/comm-send.ts` (cli/dispatch): 469 uncovered lines, 16.8% line coverage.
 - `src/commands/shared/wake-cmd.ts` (cli/dispatch): 443 uncovered lines, 30.9% line coverage.
 - `src/cli/cmd-update.ts` (cli/dispatch): 308 uncovered lines, 28.7% line coverage.
+- `src/transports/scout.ts` (transport): 248 uncovered lines, 8.5% line coverage.
 
 ## Prioritization guidance
 

--- a/test/comm-send-cmdsend-coverage.test.ts
+++ b/test/comm-send-cmdsend-coverage.test.ts
@@ -1,0 +1,584 @@
+/**
+ * cmdSend coverage without live tmux or network.
+ *
+ * This file stays in the main test suite (not test/isolated) so it contributes
+ * to `test:coverage`. Mocks are gated: when mockActive=false, they delegate to
+ * the real modules so later tests do not inherit fake behavior.
+ */
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { join } from "path";
+
+let mockActive = false;
+
+const _rSdk = await import("../src/sdk");
+const _rConfig = await import("../src/config");
+const _rFeed = await import("../src/commands/shared/comm-log-feed");
+const _rRegistry = await import("../src/plugin/registry");
+const _rOracleMembers = await import("../src/lib/oracle-members");
+const _rOracleManifest = await import("../src/lib/oracle-manifest");
+const _rWakeCmd = await import("../src/commands/shared/wake-cmd");
+const _rScopeAcl = await import("../src/commands/shared/scope-acl");
+const _rQueueStore = await import("../src/commands/shared/queue-store");
+const _rTrustStore = await import("../src/lib/trust-store");
+const _rConsentGate = await import("../src/core/consent/gate");
+const _rFindWindow = await import("../src/core/runtime/find-window");
+const realSdk = {
+  listSessions: _rSdk.listSessions,
+  capture: _rSdk.capture,
+  sendKeys: _rSdk.sendKeys,
+  getPaneCommand: _rSdk.getPaneCommand,
+  isAgentCommand: _rSdk.isAgentCommand,
+  resolveTarget: _rSdk.resolveTarget,
+  curlFetch: _rSdk.curlFetch,
+  runHook: _rSdk.runHook,
+  findPeerForTarget: _rSdk.findPeerForTarget,
+};
+const realConfig = { loadConfig: _rConfig.loadConfig, cfgLimit: _rConfig.cfgLimit };
+const realFeed = { logMessage: _rFeed.logMessage, emitFeed: _rFeed.emitFeed };
+const realRegistry = { discoverPackages: _rRegistry.discoverPackages, invokePlugin: _rRegistry.invokePlugin };
+const realOracleMembers = { getOracleMembers: _rOracleMembers.getOracleMembers, loadOracleRegistry: _rOracleMembers.loadOracleRegistry };
+const realOracleManifest = { findOracle: _rOracleManifest.findOracle };
+const realWakeCmd = { cmdWake: _rWakeCmd.cmdWake };
+const realScopeAcl = { loadAllScopes: _rScopeAcl.loadAllScopes, evaluateAclFromDisk: _rScopeAcl.evaluateAclFromDisk };
+const realQueueStore = { savePending: _rQueueStore.savePending };
+const realTrustStore = { cmdAdd: _rTrustStore.cmdAdd };
+const realConsentGate = { maybeGateConsent: _rConsentGate.maybeGateConsent };
+
+type Session = { name: string; windows: Array<{ index: number; name: string; active: boolean }> };
+type ResolvedTarget =
+  | { type: "local" | "self-node"; target: string }
+  | { type: "peer"; target: string; node: string; peerUrl: string }
+  | { type: "error"; target?: string; detail: string; hint?: string }
+  | null;
+
+type CurlResult = { ok: boolean; status?: number; data?: any };
+
+type PluginPackage = { manifest: { name: string } };
+
+let config: any;
+let listSessionsReturn: Session[];
+let resolveTargetReturn: ResolvedTarget;
+let resolveTargetError: Error | null;
+let findPeerUrl: string | null;
+let getPaneCommandReturn: string;
+let captureResponses: string[];
+let sendKeysCalls: Array<{ target: string; text: string }>;
+let captureCalls: Array<{ target: string; lines: number; host?: string }>;
+let curlFetchCalls: Array<{ url: string; options: any }>;
+let curlFetchHandler: (url: string, options: any) => CurlResult | Promise<CurlResult>;
+let runHookCalls: Array<{ name: string; payload: any }>;
+let logMessageCalls: Array<{ from: string; to: string; message: string; route: string }>;
+let emitFeedCalls: Array<{ event: string; oracle: string; host: string; message: string; port: number; data: any }>;
+let sleepCalls: number[];
+let plugins: PluginPackage[];
+let invokePluginResult: { ok: boolean; output?: string; error?: string };
+let oracleMembers: string[];
+let oracleRegistry: { members: string[] } | null;
+let findOracleResult: any;
+let cmdWakeCalls: Array<{ oracle: string; opts: any }>;
+let scopes: any[];
+let aclDecision: "allow" | "queue";
+let savePendingCalls: any[];
+let trustAddCalls: Array<{ sender: string; target: string }>;
+let trustAddError: Error | null;
+let consentDecision: { allow: boolean; message?: string; exitCode?: number };
+
+mock.module(join(import.meta.dir, "../src/sdk"), () => ({
+  ..._rSdk,
+  listSessions: async () => mockActive ? listSessionsReturn : realSdk.listSessions(),
+  capture: async (target: string, lines: number, host?: string) => {
+    if (!mockActive) return realSdk.capture(target, lines, host);
+    captureCalls.push({ target, lines, host });
+    return captureResponses.length ? captureResponses.shift()! : "";
+  },
+  sendKeys: async (target: string, text: string) => {
+    if (!mockActive) return realSdk.sendKeys(target, text);
+    sendKeysCalls.push({ target, text });
+  },
+  getPaneCommand: async () => mockActive ? getPaneCommandReturn : realSdk.getPaneCommand(""),
+  isAgentCommand: (cmd: string | null | undefined) => {
+    if (!mockActive) return realSdk.isAgentCommand(cmd);
+    return ["claude", "codex", "node"].includes((cmd ?? "").trim());
+  },
+  findPeerForTarget: async (...args: Parameters<typeof realSdk.findPeerForTarget>) => mockActive ? findPeerUrl : realSdk.findPeerForTarget(...args),
+  resolveTarget: (...args: Parameters<typeof _rSdk.resolveTarget>) => {
+    if (!mockActive) return realSdk.resolveTarget(...args);
+    if (resolveTargetError) throw resolveTargetError;
+    return resolveTargetReturn as ReturnType<typeof _rSdk.resolveTarget>;
+  },
+  curlFetch: async (url: string, options: any) => {
+    if (!mockActive) return realSdk.curlFetch(url, options);
+    curlFetchCalls.push({ url, options });
+    return curlFetchHandler(url, options);
+  },
+  runHook: async (name: string, payload: any) => {
+    if (!mockActive) return realSdk.runHook(name, payload);
+    runHookCalls.push({ name, payload });
+  },
+}));
+
+mock.module(join(import.meta.dir, "../src/config"), () => ({
+  ..._rConfig,
+  loadConfig: () => mockActive ? config : realConfig.loadConfig(),
+  cfgLimit: (key: Parameters<typeof _rConfig.cfgLimit>[0]) => mockActive ? 100 : realConfig.cfgLimit(key),
+}));
+
+mock.module(join(import.meta.dir, "../src/commands/shared/comm-log-feed"), () => ({
+  ..._rFeed,
+  logMessage: (from: string, to: string, message: string, route: string) => {
+    if (!mockActive) return realFeed.logMessage(from, to, message, route);
+    logMessageCalls.push({ from, to, message, route });
+  },
+  emitFeed: (event: string, oracle: string, host: string, message: string, port: number, data: any) => {
+    if (!mockActive) return realFeed.emitFeed(event, oracle, host, message, port, data);
+    emitFeedCalls.push({ event, oracle, host, message, port, data });
+  },
+}));
+
+mock.module(join(import.meta.dir, "../src/plugin/registry"), () => ({
+  ..._rRegistry,
+  discoverPackages: () => mockActive ? plugins : realRegistry.discoverPackages(),
+  invokePlugin: async (...args: Parameters<typeof realRegistry.invokePlugin>) => mockActive ? invokePluginResult : realRegistry.invokePlugin(...args),
+}));
+
+mock.module(join(import.meta.dir, "../src/lib/oracle-members"), () => ({
+  ..._rOracleMembers,
+  getOracleMembers: (...args: Parameters<typeof realOracleMembers.getOracleMembers>) => mockActive ? oracleMembers : realOracleMembers.getOracleMembers(...args),
+  loadOracleRegistry: (...args: Parameters<typeof realOracleMembers.loadOracleRegistry>) => mockActive ? oracleRegistry : realOracleMembers.loadOracleRegistry(...args),
+}));
+
+mock.module(join(import.meta.dir, "../src/lib/oracle-manifest"), () => ({
+  ..._rOracleManifest,
+  findOracle: (name: string) => mockActive ? findOracleResult : realOracleManifest.findOracle(name),
+}));
+
+mock.module(join(import.meta.dir, "../src/commands/shared/wake-cmd"), () => ({
+  ..._rWakeCmd,
+  cmdWake: async (oracle: string, opts: any) => {
+    if (!mockActive) return realWakeCmd.cmdWake(oracle, opts);
+    cmdWakeCalls.push({ oracle, opts });
+    return `${oracle}-session`;
+  },
+}));
+
+mock.module(join(import.meta.dir, "../src/commands/shared/scope-acl"), () => ({
+  ..._rScopeAcl,
+  loadAllScopes: () => mockActive ? scopes : realScopeAcl.loadAllScopes(),
+  evaluateAclFromDisk: () => {
+    if (!mockActive) return realScopeAcl.evaluateAclFromDisk("", "");
+    return aclDecision;
+  },
+}));
+
+mock.module(join(import.meta.dir, "../src/commands/shared/queue-store"), () => ({
+  ..._rQueueStore,
+  savePending: (record: any) => {
+    if (!mockActive) return realQueueStore.savePending(record);
+    savePendingCalls.push(record);
+    return { id: "pending-1", ...record };
+  },
+}));
+
+mock.module(join(import.meta.dir, "../src/lib/trust-store"), () => ({
+  ..._rTrustStore,
+  cmdAdd: (sender: string, target: string) => {
+    if (!mockActive) return realTrustStore.cmdAdd(sender, target);
+    if (trustAddError) throw trustAddError;
+    trustAddCalls.push({ sender, target });
+  },
+}));
+
+mock.module(join(import.meta.dir, "../src/core/consent/gate"), () => ({
+  ..._rConsentGate,
+  maybeGateConsent: async (...args: Parameters<typeof realConsentGate.maybeGateConsent>) => mockActive ? consentDecision : realConsentGate.maybeGateConsent(...args),
+}));
+
+const origSleep = Bun.sleep.bind(Bun);
+const origExit = process.exit;
+const origErr = console.error;
+const origLog = console.log;
+const origAgentName = process.env.CLAUDE_AGENT_NAME;
+
+(Bun as unknown as { sleep: (ms: number) => Promise<void> }).sleep = async (ms: number) => {
+  if (mockActive) sleepCalls.push(ms);
+  else await origSleep(ms);
+};
+
+const { cmdSend } = await import("../src/commands/shared/comm-send");
+
+let exitCode: number | undefined;
+let errs: string[];
+let logs: string[];
+
+async function runCmd(fn: () => Promise<unknown>) {
+  exitCode = undefined;
+  errs = [];
+  logs = [];
+  console.error = (...args: unknown[]) => { errs.push(args.map(String).join(" ")); };
+  console.log = (...args: unknown[]) => { logs.push(args.map(String).join(" ")); };
+  (process as unknown as { exit: (code?: number) => never }).exit = (code?: number): never => {
+    exitCode = code ?? 0;
+    throw new Error(`__exit__:${exitCode}`);
+  };
+  try {
+    await fn();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!message.startsWith("__exit__")) throw error;
+  } finally {
+    console.error = origErr;
+    console.log = origLog;
+    (process as unknown as { exit: typeof origExit }).exit = origExit;
+  }
+}
+
+beforeEach(() => {
+  mockActive = true;
+  config = { node: "test-node", oracle: "sender", port: 3456, namedPeers: [] };
+  listSessionsReturn = [{ name: "session", windows: [{ index: 0, name: "oracle", active: true }] }];
+  resolveTargetReturn = { type: "local", target: "session:oracle.0" };
+  resolveTargetError = null;
+  findPeerUrl = null;
+  getPaneCommandReturn = "claude";
+  captureResponses = ["❯ ", "accepted"];
+  sendKeysCalls = [];
+  captureCalls = [];
+  curlFetchCalls = [];
+  curlFetchHandler = () => ({ ok: true, status: 200, data: { ok: true, target: "remote:0", lastLine: "ack" } });
+  runHookCalls = [];
+  logMessageCalls = [];
+  emitFeedCalls = [];
+  sleepCalls = [];
+  plugins = [];
+  invokePluginResult = { ok: true, output: "plugin ok" };
+  oracleMembers = [];
+  oracleRegistry = null;
+  findOracleResult = undefined;
+  cmdWakeCalls = [];
+  scopes = [];
+  aclDecision = "allow";
+  savePendingCalls = [];
+  trustAddCalls = [];
+  trustAddError = null;
+  consentDecision = { allow: true };
+  process.env.CLAUDE_AGENT_NAME = "sender";
+  delete process.env.MAW_CONSENT;
+  delete process.env.MAW_ACL_BYPASS;
+});
+
+afterEach(() => {
+  mockActive = false;
+  delete process.env.MAW_CONSENT;
+  delete process.env.MAW_ACL_BYPASS;
+  if (origAgentName === undefined) delete process.env.CLAUDE_AGENT_NAME;
+  else process.env.CLAUDE_AGENT_NAME = origAgentName;
+});
+
+afterAll(() => {
+  mockActive = false;
+  (Bun as unknown as { sleep: typeof origSleep }).sleep = origSleep;
+  console.error = origErr;
+  console.log = origLog;
+  (process as unknown as { exit: typeof origExit }).exit = origExit;
+});
+
+describe("cmdSend — delivery branch coverage", () => {
+  test("local delivery signs, sends, logs, hooks, captures last line, and emits feed", async () => {
+    await runCmd(() => cmdSend("local:session:oracle", "hello"));
+
+    expect(exitCode).toBeUndefined();
+    expect(sendKeysCalls).toEqual([{ target: "session:oracle.0", text: "[test-node:sender] hello" }]);
+    expect(runHookCalls).toEqual([{ name: "after_send", payload: { to: "local:session:oracle", message: "[test-node:sender] hello" } }]);
+    expect(logMessageCalls).toEqual([{ from: "sender", to: "local:session:oracle", message: "[test-node:sender] hello", route: "local" }]);
+    expect(captureCalls.map(c => c.lines)).toEqual([5, 3]);
+    expect(emitFeedCalls[0].data.route).toBe("local");
+    expect(logs.join("\n")).toContain("delivered");
+    expect(logs.join("\n")).toContain("accepted");
+  });
+
+  test("local delivery refuses non-agent panes unless forced", async () => {
+    getPaneCommandReturn = "zsh";
+    await runCmd(() => cmdSend("local:session:oracle", "hello"));
+
+    expect(exitCode).toBe(1);
+    expect(sendKeysCalls).toEqual([]);
+    expect(errs.join("\n")).toContain("no active Claude session");
+  });
+
+  test("--force bypasses pane command and idle checks", async () => {
+    getPaneCommandReturn = "zsh";
+    captureResponses = ["post-send"];
+
+    await runCmd(() => cmdSend("local:session:oracle", "forced", true));
+
+    expect(exitCode).toBeUndefined();
+    expect(sendKeysCalls).toEqual([{ target: "session:oracle.0", text: "[test-node:sender] forced" }]);
+    expect(captureCalls.map(c => c.lines)).toEqual([3]);
+  });
+
+  test("idle guard retries once and exits when the pane stays busy", async () => {
+    captureResponses = ["❯ git status", "❯ maw hey someone hi"];
+
+    await runCmd(() => cmdSend("local:session:oracle", "blocked"));
+
+    expect(exitCode).toBe(1);
+    expect(sleepCalls).toContain(500);
+    expect(sendKeysCalls).toEqual([]);
+    expect(errs.join("\n")).toContain("pane session:oracle.0 is not idle");
+  });
+
+  test("peer delivery signs POST body, logs success, and emits peer lifecycle feed", async () => {
+    resolveTargetReturn = { type: "peer", target: "oracle", node: "remote", peerUrl: "http://remote:3456" };
+    curlFetchHandler = () => ({ ok: true, status: 200, data: { ok: true, target: "remote-session:oracle.0", lastLine: "remote ack", state: "queued" } });
+
+    await runCmd(() => cmdSend("remote:session:oracle", "ping"));
+
+    expect(exitCode).toBeUndefined();
+    expect(curlFetchCalls).toHaveLength(1);
+    expect(curlFetchCalls[0].url).toBe("http://remote:3456/api/send");
+    expect(JSON.parse(curlFetchCalls[0].options.body)).toEqual({ target: "oracle", text: "[test-node:sender] ping" });
+    expect(logMessageCalls[0].route).toBe("peer:remote");
+    expect(emitFeedCalls[0].data.route).toBe("peer");
+    expect(emitFeedCalls[0].data.state).toBe("queued");
+    expect(runHookCalls[0].name).toBe("after_send");
+  });
+
+  test("peer delivery failures emit a failed lifecycle event and exit", async () => {
+    resolveTargetReturn = { type: "peer", target: "oracle", node: "remote", peerUrl: "http://remote:3456" };
+    curlFetchHandler = () => ({ ok: false, status: 503, data: { error: "down" } });
+
+    await runCmd(() => cmdSend("remote:session:oracle", "ping"));
+
+    expect(exitCode).toBe(1);
+    expect(emitFeedCalls[0].data.route).toBe("peer");
+    expect(emitFeedCalls[0].data.state).toBe("failed");
+    expect(emitFeedCalls[0].data.error).toBe("down");
+    expect(errs.join("\n")).toContain("Remote fetch failed");
+  });
+
+  test("discovery fallback delivers through discovered peer when normal resolution misses", async () => {
+    resolveTargetReturn = null;
+    findPeerUrl = "http://discovered:3456";
+    curlFetchHandler = () => ({ ok: true, status: 200, data: { ok: true, target: "found:0", lastLine: "found ack" } });
+
+    await runCmd(() => cmdSend("path/target", "hello"));
+
+    expect(exitCode).toBeUndefined();
+    expect(curlFetchCalls[0].url).toBe("http://discovered:3456/api/send");
+    expect(logMessageCalls[0].route).toBe("discovery");
+    expect(emitFeedCalls[0].data.route).toBe("discovery");
+  });
+
+  test("discovery fallback failures surface network error instead of local miss", async () => {
+    resolveTargetReturn = null;
+    findPeerUrl = "http://discovered:3456";
+    curlFetchHandler = () => ({ ok: false, status: 502, data: {} });
+
+    await runCmd(() => cmdSend("path/target", "hello"));
+
+    expect(exitCode).toBe(1);
+    expect(emitFeedCalls[0].data.route).toBe("discovery");
+    expect(emitFeedCalls[0].data.error).toBe("HTTP 502");
+    expect(errs.join("\n")).toContain("Remote fetch failed for peer http://discovered:3456");
+  });
+
+  test("resolver error prints detail and hint", async () => {
+    resolveTargetReturn = { type: "error", detail: "window missing", hint: "run maw ls" };
+
+    await runCmd(() => cmdSend("local:missing:oracle", "hello"));
+
+    expect(exitCode).toBe(1);
+    expect(errs.join("\n")).toContain("window missing");
+    expect(errs.join("\n")).toContain("run maw ls");
+  });
+
+  test("plain miss lists configured agents when available", async () => {
+    config.agents = { alpha: "http://alpha" };
+    resolveTargetReturn = null;
+
+    await runCmd(() => cmdSend("path/unknown", "hello"));
+
+    expect(exitCode).toBe(1);
+    expect(errs.join("\n")).toContain("window not found");
+    expect(errs.join("\n")).toContain("known agents: alpha");
+  });
+});
+
+describe("cmdSend — prefix routers", () => {
+  test("plugin route returns plugin output on success", async () => {
+    plugins = [{ manifest: { name: "echo" } }];
+    invokePluginResult = { ok: true, output: "echoed" };
+
+    await runCmd(() => cmdSend("plugin:echo", "hello"));
+
+    expect(exitCode).toBeUndefined();
+    expect(logs.join("\n")).toContain("echoed");
+    expect(sendKeysCalls).toEqual([]);
+  });
+
+  test("plugin route exits when plugin is missing or returns an error", async () => {
+    await runCmd(() => cmdSend("plugin:missing", "hello"));
+    expect(exitCode).toBe(1);
+    expect(errs.join("\n")).toContain("plugin not found: missing");
+
+    plugins = [{ manifest: { name: "bad" } }];
+    invokePluginResult = { ok: false, error: "boom" };
+    await runCmd(() => cmdSend("plugin:bad", "hello"));
+    expect(exitCode).toBe(1);
+    expect(errs.join("\n")).toContain("plugin error: boom");
+  });
+
+  test("empty team target exits with usage before loading members", async () => {
+    await runCmd(() => cmdSend("team:", "hello"));
+
+    expect(exitCode).toBe(1);
+    expect(errs.join("\n")).toContain("usage: maw hey team:<team-name> <message>");
+  });
+
+  test("team with only sender explains invite guidance", async () => {
+    oracleMembers = [];
+    oracleRegistry = { members: ["sender"] };
+
+    await runCmd(() => cmdSend("team:solo", "hello"));
+
+    expect(exitCode).toBe(1);
+    expect(errs.join("\n")).toContain("has only the sender");
+    expect(errs.join("\n")).toContain("invite more members");
+  });
+
+  test("empty team registry explains how to invite members", async () => {
+    oracleMembers = [];
+    oracleRegistry = null;
+
+    await runCmd(() => cmdSend("team:missing", "hello"));
+
+    expect(exitCode).toBe(1);
+    expect(errs.join("\n")).toContain("no oracle members in team 'missing'");
+    expect(errs.join("\n")).toContain("maw team oracle-invite");
+  });
+});
+
+describe("cmdSend — bare-name, wake, and safety gates", () => {
+  test("bare local target accepts same-node resolver hits", async () => {
+    listSessionsReturn = [{ name: "session", windows: [{ index: 0, name: "oracle", active: true }] }];
+    resolveTargetReturn = { type: "local", target: "session:oracle.0" };
+
+    await runCmd(() => cmdSend("oracle", "hello"));
+
+    expect(exitCode).toBeUndefined();
+    expect(sendKeysCalls).toEqual([{ target: "session:oracle.0", text: "[test-node:sender] hello" }]);
+  });
+
+  test("bare target rejects remote-only resolver hits before network delivery", async () => {
+    resolveTargetReturn = { type: "peer", target: "oracle", node: "remote", peerUrl: "http://remote:3456" };
+
+    await runCmd(() => cmdSend("oracle", "hello"));
+
+    expect(exitCode).toBe(1);
+    expect(curlFetchCalls).toEqual([]);
+    expect(errs.join("\n")).toContain("not found locally");
+  });
+
+  test("bare target rejects ambiguous local candidates with candidate list", async () => {
+    resolveTargetError = new _rFindWindow.AmbiguousMatchError("oracle", ["47-mawjs:oracle", "54-mawjs:oracle"]);
+
+    await runCmd(() => cmdSend("oracle", "hello"));
+
+    expect(exitCode).toBe(1);
+    expect(errs.join("\n")).toContain("ambiguous");
+    expect(errs.join("\n")).toContain("47-mawjs:oracle");
+  });
+
+  test("local short-form hey auto-wakes fleet-known targets before resolving", async () => {
+    listSessionsReturn = [];
+    findOracleResult = { name: "volt", sources: ["fleet"], isLive: false };
+    resolveTargetReturn = { type: "local", target: "volt-session:volt-oracle.0" };
+
+    await runCmd(() => cmdSend("test-node:volt", "hello"));
+
+    expect(exitCode).toBeUndefined();
+    expect(cmdWakeCalls).toEqual([{ oracle: "volt", opts: {} }]);
+    expect(logs.join("\n")).toContain("auto-wake");
+    expect(sendKeysCalls[0].target).toBe("volt-session:volt-oracle.0");
+  });
+
+  test("cross-node short-form hey calls remote wake before send", async () => {
+    config.namedPeers = [{ name: "remote", url: "http://remote:3456" }];
+    resolveTargetReturn = { type: "peer", target: "oracle", node: "remote", peerUrl: "http://remote:3456" };
+    curlFetchHandler = (url) => {
+      if (url.endsWith("/api/wake")) return { ok: true, status: 200, data: { ok: true } };
+      return { ok: true, status: 200, data: { ok: true, target: "oracle.0" } };
+    };
+
+    await runCmd(() => cmdSend("remote:oracle", "hello"));
+
+    expect(exitCode).toBeUndefined();
+    expect(curlFetchCalls.map(c => c.url)).toEqual(["http://remote:3456/api/wake", "http://remote:3456/api/send"]);
+    expect(JSON.parse(curlFetchCalls[0].options.body)).toEqual({ target: "oracle" });
+  });
+
+  test("cross-node wake failures stop before send", async () => {
+    config.namedPeers = [{ name: "remote", url: "http://remote:3456" }];
+    resolveTargetReturn = { type: "peer", target: "oracle", node: "remote", peerUrl: "http://remote:3456" };
+    curlFetchHandler = (url) => {
+      if (url.endsWith("/api/wake")) return { ok: false, status: 503, data: { error: "wake down" } };
+      return { ok: true, status: 200, data: { ok: true } };
+    };
+
+    await runCmd(() => cmdSend("remote:oracle", "hello"));
+
+    expect(exitCode).toBe(1);
+    expect(curlFetchCalls.map(c => c.url)).toEqual(["http://remote:3456/api/wake"]);
+    expect(errs.join("\n")).toContain("cross-node wake failed");
+  });
+
+  test("ACL queue stores pending peer sends instead of delivering", async () => {
+    resolveTargetReturn = { type: "peer", target: "receiver", node: "remote", peerUrl: "http://remote:3456" };
+    scopes = [{ name: "default" }];
+    aclDecision = "queue";
+
+    await runCmd(() => cmdSend("remote:session:receiver", "needs approval"));
+
+    expect(exitCode).toBeUndefined();
+    expect(savePendingCalls).toEqual([{ sender: "sender", target: "receiver", message: "needs approval", query: "remote:session:receiver" }]);
+    expect(curlFetchCalls).toEqual([]);
+    expect(logs.join("\n")).toContain("queued for approval");
+  });
+
+  test("--approve --trust records trust before peer delivery", async () => {
+    resolveTargetReturn = { type: "peer", target: "receiver", node: "remote", peerUrl: "http://remote:3456" };
+    curlFetchHandler = () => ({ ok: true, status: 200, data: { ok: true, target: "receiver.0" } });
+
+    await runCmd(() => cmdSend("remote:session:receiver", "approved", false, { approve: true, trust: true }));
+
+    expect(exitCode).toBeUndefined();
+    expect(trustAddCalls).toEqual([{ sender: "sender", target: "receiver" }]);
+    expect(curlFetchCalls[0].url).toBe("http://remote:3456/api/send");
+    expect(logs.join("\n")).toContain("trusted sender");
+  });
+
+  test("trust persistence warnings do not block approved peer delivery", async () => {
+    resolveTargetReturn = { type: "peer", target: "receiver", node: "remote", peerUrl: "http://remote:3456" };
+    trustAddError = new Error("disk full");
+    curlFetchHandler = () => ({ ok: true, status: 200, data: { ok: true, target: "receiver.0" } });
+
+    await runCmd(() => cmdSend("remote:session:receiver", "approved", false, { approve: true, trust: true }));
+
+    expect(exitCode).toBeUndefined();
+    expect(errs.join("\n")).toContain("trust persistence failed");
+    expect(curlFetchCalls[0].url).toBe("http://remote:3456/api/send");
+  });
+
+  test("consent gate can stop peer sends with its own exit code", async () => {
+    resolveTargetReturn = { type: "peer", target: "receiver", node: "remote", peerUrl: "http://remote:3456" };
+    process.env.MAW_CONSENT = "1";
+    consentDecision = { allow: false, message: "consent required", exitCode: 42 };
+
+    await runCmd(() => cmdSend("remote:session:receiver", "hello"));
+
+    expect(exitCode).toBe(42);
+    expect(curlFetchCalls).toEqual([]);
+    expect(errs.join("\n")).toContain("consent required");
+  });
+});
+


### PR DESCRIPTION
## Summary
- add main-suite coverage for `cmdSend` local, peer, discovery, plugin/team, wake, ACL, trust, and consent branches without requiring live tmux/network
- gate global `mock.module` replacements behind captured-real fallbacks so other tests keep real behavior
- update coverage gap report: `src/commands/shared/comm-send.ts` now clears the 80% target

## Coverage impact
- `src/commands/shared/comm-send.ts`: 88.2% line / 92.6% function coverage
- overall: 18.2% line / 64.6% function coverage

Refs #1637

## Validation
- `rtk bun run test` — 1680 pass / 6 skip / 0 fail
- `rtk bun run test:coverage` — 1680 pass / 6 skip / 0 fail; wrote gap analysis
- `rtk bun run build`
- `rtk bun run test:isolated` — 119/119 files passed

## Release
- alpha-only PR; no release-alpha cut

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
