### PR TITLE
test: cover update runtime install branches

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,19 +1,19 @@
 # Coverage gap analysis
 
-Generated: 2026-05-16T21:49:50.776Z
+Generated: 2026-05-16T22:07:43.539Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **18.8%** (9434/50183)
-Overall function coverage: **64.8%** (1042/1607)
+Overall line coverage: **19.2%** (9596/50093)
+Overall function coverage: **65.2%** (1051/1612)
 
 ## Module summary
 
 | Module | Files | Missing from LCOV | Lines | Functions | Branches |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| cli/dispatch | 88 | 18 | 43.0% (3121/7256) | 67.7% (297/439) | n/a (0/0) |
+| cli/dispatch | 88 | 18 | 45.8% (3283/7166) | 68.9% (306/444) | n/a (0/0) |
 | config/runtime | 19 | 2 | 45.3% (529/1167) | 43.7% (38/87) | n/a (0/0) |
 | fleet | 17 | 0 | 38.8% (407/1050) | 54.8% (40/73) | n/a (0/0) |
 | matcher | 2 | 0 | 100.0% (41/41) | 100.0% (8/8) | n/a (0/0) |
@@ -37,21 +37,22 @@ Overall function coverage: **64.8%** (1042/1607)
 | 8 | medium | other | `src/core/engine-plugin-registry.ts` | 336 | 0.0% | n/a | absent from LCOV |
 | 9 | low | vendor plugins | `src/vendor/mpr-plugins/doctor/impl.ts` | 332 | 0.0% | n/a | absent from LCOV |
 | 10 | low | vendor plugins | `src/vendor/mpr-plugins/team/index.ts` | 314 | 0.0% | n/a | absent from LCOV |
-| 11 | critical | cli/dispatch | `src/cli/cmd-update.ts` | 308 | 28.7% | 73.3% | partial coverage |
-| 12 | low | vendor plugins | `src/vendor/mpr-plugins/bg/src/impl.ts` | 297 | 0.0% | n/a | absent from LCOV |
-| 13 | medium | other | `src/commands/plugins/tile/impl.ts` | 283 | 0.0% | n/a | absent from LCOV |
-| 14 | medium | other | `src/commands/plugins/plugin/install-handlers.ts` | 280 | 24.9% | 18.8% | partial coverage |
-| 15 | low | vendor plugins | `src/vendor/mpr-plugins/view/impl.ts` | 269 | 0.0% | n/a | absent from LCOV |
-| 16 | medium | other | `src/commands/plugins/tmux/index.ts` | 260 | 0.0% | n/a | absent from LCOV |
-| 17 | low | vendor plugins | `src/vendor/mpr-plugins/init/internal/plugin-lock.ts` | 251 | 0.0% | n/a | absent from LCOV |
-| 18 | low | vendor plugins | `src/vendor/mpr-plugins/peers/index.ts` | 250 | 0.0% | n/a | absent from LCOV |
-| 19 | critical | transport | `src/transports/scout.ts` | 248 | 8.5% | 0.0% | partial coverage |
-| 20 | medium | other | `src/commands/plugins/plugin/index.ts` | 246 | 0.0% | n/a | absent from LCOV |
+| 11 | low | vendor plugins | `src/vendor/mpr-plugins/bg/src/impl.ts` | 297 | 0.0% | n/a | absent from LCOV |
+| 12 | medium | other | `src/commands/plugins/tile/impl.ts` | 283 | 0.0% | n/a | absent from LCOV |
+| 13 | medium | other | `src/commands/plugins/plugin/install-handlers.ts` | 280 | 24.9% | 18.8% | partial coverage |
+| 14 | low | vendor plugins | `src/vendor/mpr-plugins/view/impl.ts` | 269 | 0.0% | n/a | absent from LCOV |
+| 15 | medium | other | `src/commands/plugins/tmux/index.ts` | 260 | 0.0% | n/a | absent from LCOV |
+| 16 | low | vendor plugins | `src/vendor/mpr-plugins/init/internal/plugin-lock.ts` | 251 | 0.0% | n/a | absent from LCOV |
+| 17 | low | vendor plugins | `src/vendor/mpr-plugins/peers/index.ts` | 250 | 0.0% | n/a | absent from LCOV |
+| 18 | critical | transport | `src/transports/scout.ts` | 248 | 8.5% | 0.0% | partial coverage |
+| 19 | medium | other | `src/commands/plugins/plugin/index.ts` | 246 | 0.0% | n/a | absent from LCOV |
+| 20 | medium | other | `src/commands/plugins/oracle/index.ts` | 243 | 0.0% | n/a | absent from LCOV |
 
 ## Critical files at or above the 80% line target
 
 | Module | File | Line coverage | Function coverage |
 | --- | --- | ---: | ---: |
+| cli/dispatch | `src/cli/cmd-update.ts` | 83.6% | 100.0% |
 | cli/dispatch | `src/cli/cmd-version.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/cli/command-registry-match.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/cli/command-registry-types.ts` | 100.0% | 100.0% |
@@ -126,7 +127,6 @@ Overall function coverage: **64.8%** (1042/1607)
 
 | Module | File | Uncovered | Line coverage |
 | --- | --- | ---: | ---: |
-| cli/dispatch | `src/cli/cmd-update.ts` | 308 | 28.7% |
 | transport | `src/transports/scout.ts` | 248 | 8.5% |
 | cli/dispatch | `src/commands/shared/wake-resolve-impl.ts` | 226 | 28.7% |
 | transport | `src/transports/mdns.ts` | 184 | 7.5% |
@@ -136,10 +136,10 @@ Overall function coverage: **64.8%** (1042/1607)
 | plugin dispatch | `src/plugin/registry.ts` | 147 | 8.1% |
 | cli/dispatch | `src/commands/shared/fleet-wake.ts` | 146 | 0.0% |
 | cli/dispatch | `src/commands/shared/pulse-cmd.ts` | 134 | 0.0% |
+| fleet | `src/core/fleet/worktrees-scan.ts` | 128 | 4.5% |
 
 ## Critical gaps to prioritize
 
-- `src/cli/cmd-update.ts` (cli/dispatch): 308 uncovered lines, 28.7% line coverage.
 - `src/transports/scout.ts` (transport): 248 uncovered lines, 8.5% line coverage.
 
 ## Prioritization guidance

--- a/test/cmd-update-runtime-coverage.test.ts
+++ b/test/cmd-update-runtime-coverage.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Runtime coverage for maw update's install path without touching the real
+ * Bun global install. Mocks are gated and delegate when inactive so this main
+ * suite file contributes to `test:coverage` without polluting other tests.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+let mockActive = false;
+
+const _rChild = await import("child_process");
+const _rOs = await import("os");
+const _rVersion = await import("../src/cli/cmd-version");
+const _rGhq = await import("../src/core/ghq");
+const _rUpdateLock = await import("../src/cli/update-lock");
+
+const realChild = { execSync: _rChild.execSync };
+const realOs = { homedir: _rOs.homedir };
+const realVersion = { getVersionString: _rVersion.getVersionString };
+const realGhq = { ghqFindSync: _rGhq.ghqFindSync };
+const realUpdateLock = { withUpdateLock: _rUpdateLock.withUpdateLock };
+
+let tempRoot: string;
+let homeDir: string;
+let mawBin: string;
+let cloneDir: string;
+let currentVersion: string;
+let ghqFindReturn: string | null;
+let execSyncCalls: string[];
+let spawnCalls: string[][];
+let spawnExitQueue: number[];
+let lsRemoteOutput: string;
+let execThrow: Error | null;
+let lockCalls: number;
+
+const original = {
+  spawn: Bun.spawn,
+  exit: process.exit,
+  log: console.log,
+  warn: console.warn,
+  error: console.error,
+  stdoutWrite: process.stdout.write,
+  testMode: process.env.MAW_TEST_MODE,
+  home: process.env.HOME,
+};
+
+type Capture = {
+  code: number | undefined;
+  stdout: string;
+  stderr: string;
+  threw: unknown;
+};
+
+function mkdirp(path: string): void {
+  mkdirSync(path, { recursive: true });
+}
+
+function prepareInstallHome(version = "26.5.16-alpha.1053"): void {
+  const bunBin = join(homeDir, ".bun", "bin");
+  const global = join(homeDir, ".bun", "install", "global");
+  const nodeModules = join(global, "node_modules");
+  const cache = join(homeDir, ".bun", "install", "cache");
+  mkdirp(bunBin);
+  mkdirp(nodeModules);
+  mkdirp(cache);
+  mkdirp(join(nodeModules, "maw-js"));
+  mkdirp(join(cache, "maw-js-old"));
+  writeFileSync(join(nodeModules, "maw-js", "package.json"), JSON.stringify({ name: "maw-js", version }));
+  writeFileSync(join(global, "package.json"), JSON.stringify({ dependencies: { "maw-js": "old", maw: "old", keep: "1" } }, null, 2));
+  writeFileSync(join(global, "bun.lock"), "old lock");
+  writeFileSync(join(global, "bun.lockb"), "old binary lock");
+  writeFileSync(mawBin, "#!/bin/sh\necho maw\n");
+}
+
+function prepareLocalClone(version = "26.5.16-alpha.1053"): void {
+  mkdirp(cloneDir);
+  writeFileSync(join(cloneDir, "package.json"), JSON.stringify({ version }));
+}
+
+function prepareBundledPluginRoot(): void {
+  const mawSrc = join(homeDir, ".bun", "bin");
+  const pluginRoot = join(mawSrc, "commands", "plugins");
+  mkdirp(join(pluginRoot, "runtime-plugin"));
+  writeFileSync(join(pluginRoot, "runtime-plugin", "plugin.json"), "{}");
+}
+
+async function captureRun(
+  args: string[],
+  opts: { testMode?: string | null } = {},
+): Promise<Capture> {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  let code: number | undefined;
+  let threw: unknown;
+
+  process.env.HOME = homeDir;
+  if (opts.testMode === null) delete process.env.MAW_TEST_MODE;
+  else process.env.MAW_TEST_MODE = opts.testMode ?? "1";
+
+  (process as any).exit = (exitCode?: number) => {
+    code = exitCode ?? 0;
+    throw new Error(`exit:${code}`);
+  };
+  console.log = (...parts: unknown[]) => { stdout.push(parts.map(String).join(" ")); };
+  console.warn = (...parts: unknown[]) => { stderr.push(parts.map(String).join(" ")); };
+  console.error = (...parts: unknown[]) => { stderr.push(parts.map(String).join(" ")); };
+  (process.stdout as any).write = (chunk: unknown) => {
+    stdout.push(String(chunk));
+    return true;
+  };
+
+  try {
+    const { runUpdate } = await import("../src/cli/cmd-update");
+    await runUpdate(args);
+  } catch (err) {
+    threw = err;
+    if (!(err instanceof Error) || !err.message.startsWith("exit:")) throw err;
+  }
+
+  return { code, stdout: stdout.join("\n"), stderr: stderr.join("\n"), threw };
+}
+
+mock.module("child_process", () => ({
+  ..._rChild,
+  execSync: (cmd: string, opts?: any) => {
+    if (!mockActive) return realChild.execSync(cmd, opts);
+    execSyncCalls.push(cmd);
+    if (execThrow) throw execThrow;
+    if (cmd.includes("git ls-remote")) return lsRemoteOutput;
+    if (cmd === "which maw") return `${mawBin}\n`;
+    if (cmd === "maw --version") return `${currentVersion}\n`;
+    return "";
+  },
+}));
+
+mock.module("os", () => ({
+  ..._rOs,
+  homedir: () => (mockActive ? homeDir : realOs.homedir()),
+}));
+
+mock.module(join(import.meta.dir, "../src/cli/cmd-version"), () => ({
+  ..._rVersion,
+  getVersionString: () => (mockActive ? currentVersion : realVersion.getVersionString()),
+}));
+
+mock.module(join(import.meta.dir, "../src/core/ghq"), () => ({
+  ..._rGhq,
+  ghqFindSync: (suffix: string) =>
+    mockActive ? ghqFindReturn : realGhq.ghqFindSync(suffix),
+}));
+
+mock.module(join(import.meta.dir, "../src/cli/update-lock"), () => ({
+  ..._rUpdateLock,
+  withUpdateLock: async <T,>(fn: () => Promise<T>): Promise<T> => {
+    if (!mockActive) return realUpdateLock.withUpdateLock(fn);
+    lockCalls += 1;
+    return await fn();
+  },
+}));
+
+beforeEach(() => {
+  mockActive = true;
+  tempRoot = mkdtempSync(join(tmpdir(), "maw-update-runtime-"));
+  homeDir = join(tempRoot, "home");
+  mawBin = join(homeDir, ".bun", "bin", "maw");
+  cloneDir = join(tempRoot, "maw-js-clone");
+  currentVersion = "maw v26.5.16-alpha.1053";
+  ghqFindReturn = cloneDir;
+  execSyncCalls = [];
+  spawnCalls = [];
+  spawnExitQueue = [];
+  lsRemoteOutput = [
+    "111111\trefs/tags/v26.5.15-alpha.2350",
+    "222222\trefs/tags/v26.5.16-alpha.716",
+    "333333\trefs/tags/v26.5.16-alpha.1053",
+    "444444\trefs/tags/v26.5.16-beta.10",
+    "555555\trefs/tags/not-maw",
+  ].join("\n");
+  execThrow = null;
+  lockCalls = 0;
+
+  (Bun as any).spawn = (cmd: string[]) => {
+    if (!mockActive) return original.spawn(cmd as any);
+    spawnCalls.push([...cmd]);
+    const code = spawnExitQueue.length ? spawnExitQueue.shift()! : 0;
+    return { exited: Promise.resolve(code) };
+  };
+});
+
+afterEach(() => {
+  mockActive = false;
+  (Bun as any).spawn = original.spawn;
+  (process as any).exit = original.exit;
+  console.log = original.log;
+  console.warn = original.warn;
+  console.error = original.error;
+  (process.stdout as any).write = original.stdoutWrite;
+  if (original.testMode === undefined) delete process.env.MAW_TEST_MODE;
+  else process.env.MAW_TEST_MODE = original.testMode;
+  if (original.home === undefined) delete process.env.HOME;
+  else process.env.HOME = original.home;
+  if (tempRoot && existsSync(tempRoot)) rmSync(tempRoot, { recursive: true, force: true });
+});
+
+describe("cmd-update runtime coverage", () => {
+  test("resolves the alpha channel to the latest calver tag before the test-mode boundary", async () => {
+    const res = await captureRun(["update", "alpha", "--yes"], { testMode: "1" });
+
+    expect(res.code).toBeUndefined();
+    expect(execSyncCalls).toContain("git ls-remote --tags --refs https://github.com/Soul-Brews-Studio/maw-js.git");
+    expect(res.stdout).toContain("alpha channel → v26.5.16-alpha.1053");
+    expect(res.stdout).toContain('[test-mode] ref "v26.5.16-alpha.1053" accepted');
+  });
+
+  test("fails loudly when a requested channel has no release tags", async () => {
+    lsRemoteOutput = "111111\trefs/tags/v26.5.16-alpha.716\n";
+
+    const res = await captureRun(["update", "beta", "--yes"], { testMode: "1" });
+
+    expect(res.code).toBe(1);
+    expect(res.stderr).toContain("no beta tags");
+    expect(spawnCalls).toHaveLength(0);
+  });
+
+  test("surfaces ls-remote failures while resolving a channel", async () => {
+    execThrow = new Error("network down");
+
+    const res = await captureRun(["update", "alpha", "--yes"], { testMode: "1" });
+
+    expect(res.code).toBe(1);
+    expect(res.stderr).toContain("failed to resolve alpha channel: network down");
+    expect(spawnCalls).toHaveLength(0);
+  });
+
+  test("runs the successful install path under the update lock and refreshes SDK/plugin links", async () => {
+    prepareInstallHome();
+    prepareLocalClone();
+    prepareBundledPluginRoot();
+    spawnExitQueue = [0];
+
+    const res = await captureRun(["update", "v26.5.16-alpha.1053", "--yes"], { testMode: null });
+
+    expect(res.code).toBeUndefined();
+    expect(lockCalls).toBe(1);
+    expect(spawnCalls).toEqual([
+      ["bun", "add", "-g", "github:Soul-Brews-Studio/maw-js#v26.5.16-alpha.1053"],
+    ]);
+    expect(execSyncCalls).toContain(`cd ${cloneDir} && bun link`);
+    expect(execSyncCalls).toContain(`cd ${join(homeDir, ".oracle")} && bun link maw`);
+    expect(execSyncCalls).toContain("which maw");
+    expect(existsSync(join(homeDir, ".maw", "plugins", "runtime-plugin", "plugin.json"))).toBe(true);
+    expect(res.stdout).toContain("SDK linked");
+    expect(res.stdout).toContain("bundled plugins re-linked");
+    expect(res.stdout).toContain("✅");
+  });
+
+  test("restores binary and package stashes when install, retry, and release fallback all fail", async () => {
+    prepareInstallHome();
+    writeFileSync(mawBin, "old working maw");
+    spawnExitQueue = [1, 1, 1];
+
+    const res = await captureRun(["update", "v26.5.16-alpha.1053", "--yes"], { testMode: null });
+
+    expect(res.code).toBe(1);
+    expect(spawnCalls).toEqual([
+      ["bun", "add", "-g", "github:Soul-Brews-Studio/maw-js#v26.5.16-alpha.1053"],
+      ["bun", "add", "-g", "github:Soul-Brews-Studio/maw-js#v26.5.16-alpha.1053"],
+      ["curl", "-fsSL", "-o", mawBin, "https://github.com/Soul-Brews-Studio/maw-js/releases/download/v26.5.16-alpha.1053/maw"],
+    ]);
+    expect(res.stderr).toContain("first install attempt failed");
+    expect(res.stderr).toContain("bun add failed — trying release-binary fallback");
+    expect(res.stderr).toContain("restored previous maw binary from stash");
+    expect(res.stderr).toContain("previous maw restored from stash");
+    expect(readFileSync(mawBin, "utf-8")).toBe("old working maw");
+    expect(existsSync(`${mawBin}.prev`)).toBe(false);
+    expect(existsSync(join(homeDir, ".bun", "install", "global", "node_modules", "maw-js"))).toBe(true);
+    expect(existsSync(join(homeDir, ".bun", "install", "global", "node_modules", "maw-js.update-stash"))).toBe(false);
+    const restoredPkg = JSON.parse(readFileSync(join(homeDir, ".bun", "install", "global", "package.json"), "utf-8"));
+    expect(restoredPkg.dependencies["maw-js"]).toBe("old");
+    expect(restoredPkg.dependencies.maw).toBe("old");
+  });
+});


### PR DESCRIPTION
## Summary
- Add main-suite runtime coverage for `maw update` channel resolution, install, SDK/plugin relink, and rollback branches.
- Keep destructive update behavior mocked behind temp HOME + gated module mocks so tests never touch the real Bun global install.
- Regenerate the coverage gap analysis: `src/cli/cmd-update.ts` is now above the 80% critical-file target.

## Coverage
- `src/cli/cmd-update.ts`: 28.7% → 83.6% line coverage; 73.3% → 100.0% function coverage.
- Overall: 19.2% lines (9596/50093); 65.2% functions (1051/1612).
- Next critical queue remains headed by `src/transports/scout.ts`.

## Validation
- `rtk bun test test/cmd-update-runtime-coverage.test.ts`
- `rtk bun run build`
- `rtk bun run test:mock-smoke`
- `rtk bun run test:plugin`
- `rtk bun run test:isolated`
- `rtk bun run test`
- `rtk bun run test:coverage`

Part of #1637.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
