### PR TITLE
test: cover workspace leave delete fallback

### DIFF
--- a/test/isolated/workspace.test.ts
+++ b/test/isolated/workspace.test.ts
@@ -401,6 +401,30 @@ describe("cmdWorkspaceLeave", () => {
     expect(existsSync(join(WS_DIR, "w-stuck.json"))).toBe(false);
     expect(existsSync(join(WS_DIR, "w-stuck.left.json"))).toBe(true);
   });
+
+  test("rename failure falls back to deleting the local workspace config", async () => {
+    writeWsFile("w-unlink", { id: "w-unlink", name: "unlinkme", hubUrl: "https://h.example", sharedAgents: [], joinedAt: "t" });
+    curlStubs = [{ match: /leave/, response: { ok: true, data: null } }];
+
+    const fs = require("fs");
+    const realRenameSync = fs.renameSync;
+    const realUnlinkSync = fs.unlinkSync;
+    const unlinked: string[] = [];
+    fs.renameSync = () => { throw new Error("rename denied"); };
+    fs.unlinkSync = (path: string) => { unlinked.push(path); return realUnlinkSync(path); };
+    try {
+      await run(() => cmdWorkspaceLeave("w-unlink"));
+    } finally {
+      fs.renameSync = realRenameSync;
+      fs.unlinkSync = realUnlinkSync;
+    }
+
+    expect(exitCode).toBeUndefined();
+    expect(unlinked).toEqual([join(WS_DIR, "w-unlink.json")]);
+    expect(existsSync(join(WS_DIR, "w-unlink.json"))).toBe(false);
+    expect(existsSync(join(WS_DIR, "w-unlink.left.json"))).toBe(false);
+    expect(outs.join("\n")).toContain("left workspace");
+  });
 });
 
 // ════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- add coverage for `cmdWorkspaceLeave()` when archive rename fails
- assert the fallback deletes the local workspace config and still reports successful local leave
- completes `src/commands/shared/workspace-lifecycle.ts` line coverage in the workspace isolated suite

## Verification
- `rtk bun test test/isolated/workspace.test.ts --coverage --coverage-reporter=text` → `src/commands/shared/workspace-lifecycle.ts` 100% funcs / 100% lines
- `rtk bash scripts/test-isolated.sh test/isolated/workspace.test.ts`
- `rtk bun run build`
- `rtk git diff --check`

No alpha release cut.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.