### PR TITLE
test: cover federation sync default save path

### DIFF
--- a/test/isolated/federation-sync-cli.test.ts
+++ b/test/isolated/federation-sync-cli.test.ts
@@ -37,6 +37,7 @@ let mockActive = false;
 
 const _rConfig = await import("../../src/config");
 const realLoadConfig = _rConfig.loadConfig;
+const realSaveConfig = _rConfig.saveConfig;
 
 const _rFetch = await import("../../src/commands/shared/federation-fetch");
 const realFetchPeerIdentities = _rFetch.fetchPeerIdentities;
@@ -56,6 +57,14 @@ mock.module(
     ..._rConfig,
     loadConfig: (...args: unknown[]) =>
       mockActive ? (configStore as MawConfig) : (realLoadConfig as (...a: unknown[]) => MawConfig)(...args),
+    saveConfig: (...args: unknown[]) => {
+      if (mockActive) {
+        const [update] = args as [Partial<MawConfig>];
+        saveCalls.push(update);
+        return;
+      }
+      return (realSaveConfig as (...a: unknown[]) => unknown)(...args);
+    },
   }),
 );
 
@@ -686,6 +695,22 @@ describe("cmdFederationSync — apply path", () => {
     expect(joined).toContain("applied 1 change");
     expect(joined).toContain("+ agents['pulse'] = 'white'");
     expect(joined).toContain("(from peer 'white')");
+  });
+
+  test("default save shim lazily calls config.saveConfig when no save callback is injected", async () => {
+    configStore = {
+      node: "oracle-world",
+      namedPeers: [{ name: "white", url: "https://white.example" }],
+      agents: {},
+    };
+    fetchReturn = [peer("white", "white", ["pulse"])];
+
+    await run(() => cmdFederationSync({}));
+
+    expect(exitCode).toBe(0);
+    expect(saveCalls).toHaveLength(1);
+    expect(saveCalls[0].agents).toEqual({ pulse: "white" });
+    expect(outs.join("\n")).toContain("applied 1 change");
   });
 
   test("multiple adds → 'applied N changes' (plural) + each msg printed", async () => {


### PR DESCRIPTION
## Summary
- mock `saveConfig` in the federation sync CLI test seam
- add coverage for `cmdFederationSync()` using its default lazy save shim without an injected save callback
- completes `src/commands/shared/federation-sync-cli.ts` 100% funcs / 100% lines in targeted coverage

## Verification
- `rtk bun test test/isolated/federation-sync-cli.test.ts --coverage --coverage-reporter=text` → `src/commands/shared/federation-sync-cli.ts` 100% funcs / 100% lines
- `rtk bash scripts/test-isolated.sh test/isolated/federation-sync-cli.test.ts`
- `rtk bun run build`
- `rtk git diff --check`

No alpha release cut.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.