### PR TITLE
test(coverage): close manifest parse gaps

### DIFF
--- a/test/plugin-manifest.test.ts
+++ b/test/plugin-manifest.test.ts
@@ -62,6 +62,7 @@ describe("parseManifest happy path", () => {
           version: "2.3.4",
           wasm: "plugin.wasm",
           sdk: "~1.2.0",
+          weight: 25,
           cli: { command: "greet", help: "Say hello" },
           api: { path: "/greet", methods: ["GET", "POST"] },
           description: "A greeting plugin",
@@ -69,6 +70,7 @@ describe("parseManifest happy path", () => {
         }),
         dir,
       );
+      expect(manifest.weight).toBe(25);
       expect(manifest.cli?.command).toBe("greet");
       expect(manifest.cli?.help).toBe("Say hello");
       expect(manifest.api?.path).toBe("/greet");
@@ -138,6 +140,25 @@ describe("parseManifest validation failures", () => {
     expect(() => parseManifest("not json!", "/tmp")).toThrow(/JSON/);
   });
 
+  test("throws when plugin.json is not an object", () => {
+    expect(() => parseManifest("null", "/tmp")).toThrow(/must be a JSON object/);
+    expect(() => parseManifest("[]", "/tmp")).toThrow(/must be a JSON object/);
+  });
+
+  test("throws on invalid weight", () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(join(dir, "plugin.wasm"), MINIMAL_WASM);
+      expect(() =>
+        parseManifest(
+          JSON.stringify({ name: "bad-weight", version: "1.0.0", wasm: "plugin.wasm", sdk: "*", weight: 100 }),
+          dir,
+        ),
+      ).toThrow(/weight/);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
 
   test("throws on invalid lifecycle hook declarations", () => {
     const dir = makeTempDir();
@@ -198,6 +219,20 @@ describe("parseManifest validation failures", () => {
           dir,
         ),
       ).toThrow(/wasm/);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  test("throws when entry file does not exist on disk", () => {
+    const dir = makeTempDir();
+    try {
+      expect(() =>
+        parseManifest(
+          JSON.stringify({ name: "my-plugin", version: "1.0.0", entry: "missing.ts", sdk: "*" }),
+          dir,
+        ),
+      ).toThrow(/entry file not found/);
     } finally {
       rmSync(dir, { recursive: true });
     }


### PR DESCRIPTION
## Summary
- Add parseManifest validation coverage for non-object JSON payloads, invalid weights, and missing entry files.
- Assert valid manifest weight retention on the happy path.
- Keeps this as parser-boundary unit coverage; no release work.

## Coverage evidence
- `src/plugin/manifest-parse.ts`: 100.00% funcs / 100.00% lines under targeted coverage.

## Tests
- `rtk bun test test/plugin-manifest.test.ts --coverage --coverage-reporter=text`
- `rtk bun run build`
- `rtk git diff --check`

Part of #1637.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.