### PR TITLE
test(coverage): lock runtime build info

### DIFF
--- a/test/build-info.test.ts
+++ b/test/build-info.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, mock, test } from "bun:test";
+import * as realChild from "child_process";
+
+let mode: "success" | "throw" = "success";
+const execCalls: string[] = [];
+
+mock.module("child_process", () => ({
+  ...realChild,
+  execSync: (cmd: string, opts?: unknown) => {
+    execCalls.push(`${cmd} cwd=${(opts as { cwd?: string } | undefined)?.cwd ?? ""}`);
+    if (mode === "throw") throw new Error("git unavailable");
+    if (cmd === "git rev-parse --short HEAD") return Buffer.from("abc1234\n");
+    if (cmd === "git log -1 --format=%ci") return Buffer.from("2026-05-17 07:31:00 +0700\n");
+    return realChild.execSync(cmd, opts as never);
+  },
+}));
+
+async function importBuildInfo(label: string) {
+  return import(`${process.cwd()}/src/core/runtime/build-info.ts?coverage=${label}-${Date.now()}-${Math.random()}`);
+}
+
+describe("getRuntimeVersionString", () => {
+  test("renders version, git hash, build date, and caches the string", async () => {
+    mode = "success";
+    execCalls.length = 0;
+    const { getRuntimeVersionString } = await importBuildInfo("success");
+
+    const first = getRuntimeVersionString();
+    const second = getRuntimeVersionString();
+
+    expect(first).toBe(second);
+    expect(first).toContain("maw v");
+    expect(first).toContain("(abc1234)");
+    expect(first).toContain("built 2026-05-17 Sun 07:31");
+    expect(execCalls).toEqual([
+      expect.stringContaining("git rev-parse --short HEAD cwd="),
+      expect.stringContaining("git log -1 --format=%ci cwd="),
+    ]);
+  });
+
+  test("falls back to package version when git metadata is unavailable", async () => {
+    mode = "throw";
+    execCalls.length = 0;
+    const { getRuntimeVersionString } = await importBuildInfo("throw");
+
+    const value = getRuntimeVersionString();
+
+    expect(value).toMatch(/^maw v\d+\.\d+\.\d+/);
+    expect(value).not.toContain("(");
+    expect(value).not.toContain(" built ");
+    expect(execCalls).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Add deterministic unit coverage for runtime version string formatting.
- Covers successful git hash/date rendering, cached reads, and git-unavailable fallback to package version.
- Keeps assertions mocked and fast; no release work.

## Coverage evidence
- `src/core/runtime/build-info.ts`: 100.00% funcs / 100.00% lines under targeted coverage.

## Tests
- `rtk bun test test/build-info.test.ts --coverage --coverage-reporter=text`
- `rtk bun run build`
- `rtk git diff --check`

Part of #1637.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.