### PR TITLE
chore(ci): publish coverage badge endpoint

### DIFF
--- a/.github/workflows/coverage-badge.yml
+++ b/.github/workflows/coverage-badge.yml
@@ -1,0 +1,59 @@
+name: Coverage Badge
+
+on:
+  push:
+    branches: [alpha]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: coverage-badge-alpha
+  cancel-in-progress: true
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
+
+      - name: Cache bun deps
+        uses: actions/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # Keep parity with CI's unit shard: several default-suite tests shell out
+      # to ghq even when the behavior under test is mocked.
+      - name: Install ghq
+        run: |
+          go install github.com/x-motemen/ghq@latest
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+
+      - name: Generate coverage badge endpoint JSON
+        env:
+          MAW_SKIP_FLAKY: "1"
+        run: bun run test:coverage
+
+      - name: Update coverage gist
+        env:
+          GH_TOKEN: ${{ secrets.COVERAGE_GIST_TOKEN }}
+          COVERAGE_GIST_ID: b00c729c7f40d4804f82011167bfd9d8
+        run: |
+          set -euo pipefail
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "::notice title=Coverage badge not published::Set COVERAGE_GIST_TOKEN with gist scope to update ${COVERAGE_GIST_ID}."
+            exit 0
+          fi
+          gh gist edit "$COVERAGE_GIST_ID" --filename maw-js-coverage.json coverage/maw-js-coverage.json
+          echo "### Coverage badge updated" >> "$GITHUB_STEP_SUMMARY"
+          cat coverage/maw-js-coverage.json >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # maw
 
-[![CI](https://github.com/Soul-Brews-Studio/maw-js/actions/workflows/ci.yml/badge.svg)](https://github.com/Soul-Brews-Studio/maw-js/actions/workflows/ci.yml) [![License](https://img.shields.io/badge/license-BUSL--1.1-blue)](./LICENSE) [![CalVer](https://img.shields.io/badge/calver-v26.4.18--alpha.19-blue)](https://calver.org) [![Bun](https://img.shields.io/badge/runtime-Bun%201.3%2B-f9f1e1)](https://bun.sh)
+[![CI](https://github.com/Soul-Brews-Studio/maw-js/actions/workflows/ci.yml/badge.svg)](https://github.com/Soul-Brews-Studio/maw-js/actions/workflows/ci.yml) [![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnazt%2Fb00c729c7f40d4804f82011167bfd9d8%2Fraw%2Fmaw-js-coverage.json&cacheSeconds=300)](docs/testing/coverage-gap-analysis.md) [![License](https://img.shields.io/badge/license-BUSL--1.1-blue)](./LICENSE) [![CalVer](https://img.shields.io/badge/calver-v26.4.18--alpha.19-blue)](https://calver.org) [![Bun](https://img.shields.io/badge/runtime-Bun%201.3%2B-f9f1e1)](https://bun.sh)
 
 > Multi-Agent Workflow — wake agents, talk across machines, see the mesh.
 

--- a/scripts/coverage-badge.ts
+++ b/scripts/coverage-badge.ts
@@ -1,0 +1,122 @@
+#!/usr/bin/env bun
+import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+
+type Counts = { linesFound: number; linesHit: number; funcsFound: number; funcsHit: number };
+
+type Badge = {
+  schemaVersion: 1;
+  label: string;
+  message: string;
+  color: string;
+};
+
+const cwd = realpathSync(process.cwd());
+const lcovPath = process.argv[2] || "coverage/lcov.info";
+const outPath = process.argv[3] || "coverage/maw-js-coverage.json";
+
+function relPath(file: string): string {
+  const realFile = existsSync(file) ? realpathSync(file) : file;
+  const normalized = realFile.replaceAll("\\", "/");
+  const normalizedCwd = cwd.replaceAll("\\", "/");
+  const rel = normalized.startsWith(normalizedCwd) ? relative(cwd, normalized).replaceAll("\\", "/") : normalized;
+  return rel.replace(/^\.\//, "");
+}
+
+function countSourceLines(file: string): number {
+  const text = readFileSync(file, "utf8");
+  return text.split(/\r?\n/).filter((line) => {
+    const trimmed = line.trim();
+    return trimmed.length > 0 && !trimmed.startsWith("//") && !trimmed.startsWith("/*") && !trimmed.startsWith("*");
+  }).length;
+}
+
+function walkSource(dir: string, out: string[] = []): string[] {
+  if (!existsSync(dir)) return out;
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      if (name === "node_modules" || name === "dist" || name === "coverage") continue;
+      walkSource(full, out);
+    } else if (/\.tsx?$/.test(name) && !name.endsWith(".d.ts") && !name.endsWith(".test.ts")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function parseLcov(path: string): Map<string, Counts> {
+  if (!existsSync(path)) throw new Error(`coverage lcov not found: ${path}`);
+  const files = new Map<string, Counts>();
+  for (const record of readFileSync(path, "utf8").split("end_of_record")) {
+    const lines = record.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+    const source = lines.find((line) => line.startsWith("SF:"));
+    if (!source) continue;
+    const file = relPath(source.slice(3));
+    if (!file.startsWith("src/") || !/\.tsx?$/.test(file) || file.endsWith(".d.ts") || file.endsWith(".test.ts")) continue;
+
+    const counts: Counts = { linesFound: 0, linesHit: 0, funcsFound: 0, funcsHit: 0 };
+    const lineHits = new Map<number, number>();
+    for (const line of lines) {
+      if (line.startsWith("DA:")) {
+        const [lineNo, hits] = line.slice(3).split(",").map(Number);
+        if (Number.isFinite(lineNo) && Number.isFinite(hits)) lineHits.set(lineNo, hits);
+      } else if (line.startsWith("LF:")) counts.linesFound = Number(line.slice(3)) || 0;
+      else if (line.startsWith("LH:")) counts.linesHit = Number(line.slice(3)) || 0;
+      else if (line.startsWith("FNF:")) counts.funcsFound = Number(line.slice(4)) || 0;
+      else if (line.startsWith("FNH:")) counts.funcsHit = Number(line.slice(4)) || 0;
+    }
+    if (counts.linesFound === 0 && lineHits.size > 0) {
+      counts.linesFound = lineHits.size;
+      counts.linesHit = [...lineHits.values()].filter((hits) => hits > 0).length;
+    }
+    files.set(file, counts);
+  }
+  return files;
+}
+
+function add(into: Counts, from: Counts): void {
+  into.linesFound += from.linesFound;
+  into.linesHit += from.linesHit;
+  into.funcsFound += from.funcsFound;
+  into.funcsHit += from.funcsHit;
+}
+
+function pct(hit: number, found: number): number {
+  return found ? (hit / found) * 100 : 0;
+}
+
+function colorFor(percent: number): string {
+  if (percent < 50) return "red";
+  if (percent < 70) return "yellow";
+  if (percent < 90) return "green";
+  return "brightgreen";
+}
+
+function formatPercent(percent: number): string {
+  return `${percent.toFixed(1).replace(/\.0$/, "")}%`;
+}
+
+const files = parseLcov(lcovPath);
+for (const abs of walkSource("src")) {
+  const file = relPath(abs);
+  if (files.has(file)) continue;
+  files.set(file, { linesFound: countSourceLines(abs), linesHit: 0, funcsFound: 0, funcsHit: 0 });
+}
+
+const overall: Counts = { linesFound: 0, linesHit: 0, funcsFound: 0, funcsHit: 0 };
+for (const counts of files.values()) add(overall, counts);
+
+const functionPercent = pct(overall.funcsHit, overall.funcsFound);
+const linePercent = pct(overall.linesHit, overall.linesFound);
+const badge: Badge = {
+  schemaVersion: 1,
+  label: "coverage",
+  message: `${formatPercent(functionPercent)} functions`,
+  color: colorFor(functionPercent),
+};
+
+mkdirSync(dirname(outPath), { recursive: true });
+writeFileSync(outPath, `${JSON.stringify(badge, null, 2)}\n`);
+console.log(`coverage badge: ${badge.message}, ${formatPercent(linePercent)} lines → ${outPath}`);

--- a/scripts/test-coverage.sh
+++ b/scripts/test-coverage.sh
@@ -13,3 +13,4 @@ MAW_TEST_MODE=1 bun test test/ \
   --path-ignore-patterns '**/agents/**'
 
 bun scripts/coverage-gap-analysis.ts coverage/lcov.info docs/testing/coverage-gap-analysis.md
+bun scripts/coverage-badge.ts coverage/lcov.info coverage/maw-js-coverage.json


### PR DESCRIPTION
## Summary

- add a README coverage badge backed by a Shields endpoint reading `maw-js-coverage.json` from a gist
- add `scripts/coverage-badge.ts` and wire `scripts/test-coverage.sh` to emit `coverage/maw-js-coverage.json`
- add an alpha-push workflow that runs coverage and updates the gist when `COVERAGE_GIST_TOKEN` is configured

## Notes

- Initial gist endpoint created: https://gist.github.com/nazt/b00c729c7f40d4804f82011167bfd9d8
- The workflow intentionally skips publishing with a GitHub Actions notice if `COVERAGE_GIST_TOKEN` is missing, because `GITHUB_TOKEN` cannot edit gists.
- This is release-neutral: no package version change, no alpha cut.

## Validation

- `bash -n scripts/test-coverage.sh`
- `bun build scripts/coverage-badge.ts --target=bun --outfile /tmp/maw-coverage-badge-check`
- fixture smoke for `scripts/coverage-badge.ts`
- `bun run build`
- `git diff --cached --check`

Closes #1684.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
