### PR TITLE
test(config): cover fleet merge unreadable path

### DIFF
--- a/test/config-fleet-merge.test.ts
+++ b/test/config-fleet-merge.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, chmodSync } from "fs";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -78,6 +78,13 @@ describe("readFleetDir (#736 Phase 1.1)", () => {
 
   test("returns [] when directory does not exist", () => {
     expect(readFleetDir(join(dir, "does-not-exist"))).toEqual([]);
+  });
+
+  test("returns [] when directory exists but cannot be read as a directory", () => {
+    const filePath = join(dir, "not-a-directory");
+    writeFileSync(filePath, "not a fleet dir");
+
+    expect(readFleetDir(filePath)).toEqual([]);
   });
 
   test("loads every *.json file, skips *.disabled", () => {


### PR DESCRIPTION
## Summary

- add deterministic coverage for `readFleetDir()` when the requested fleet path exists but cannot be read as a directory
- remove an unused filesystem import from the fleet-merge test
- brings `src/config/fleet-merge.ts` to 100% targeted function and line coverage

## Validation

- `bun test test/config-fleet-merge.test.ts --coverage --coverage-reporter=text`
  - `src/config/fleet-merge.ts | 100.00 funcs | 100.00 lines`
- `bun run build`
- `git diff --check`

Part of #1637.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
