### PR TITLE
test(config): cover command builder safety branches

### DIFF
--- a/test/command-simplified.test.ts
+++ b/test/command-simplified.test.ts
@@ -67,6 +67,13 @@ describe("buildCommand — post-#541 contract", () => {
     );
   });
 
+  test("strips --dangerously-skip-permissions when running as root", () => {
+    (process as any).getuid = () => 0;
+    fakeConfig.commands = { default: "claude --dangerously-skip-permissions" };
+
+    expect(buildCommand("root-agent")).toBe("claude");
+  });
+
   test("pattern-match wins over default", () => {
     fakeConfig.commands = { default: "claude", "foo-*": "echo hi" };
     expect(buildCommand("foo-bar")).toBe("echo hi");
@@ -102,6 +109,16 @@ describe("buildCommand — post-#541 contract", () => {
     expect(primary).toContain('--resume "uuid-2"');
     expect(fallback).toContain('--session-id "uuid-2"');
     expect(fallback).not.toContain("--resume");
+  });
+
+  test("sessionId supports glob fallback when there is no exact agent key", () => {
+    fakeConfig.commands = { default: "claude" };
+    fakeSessionIds = { "*-oracle": "uuid-glob" };
+
+    const out = buildCommand("mawjs-oracle");
+
+    expect(out).toContain('--resume "uuid-glob"');
+    expect(out).toContain('--session-id "uuid-glob"');
   });
 
   test("buildCommandInDir returns buildCommand verbatim (no cd, no wrapper)", () => {


### PR DESCRIPTION
## Summary

- cover command-builder root safety stripping for `--dangerously-skip-permissions`
- cover persisted session ID glob fallback when an exact agent key is absent
- brings `src/config/command-logic.ts` to 100% targeted function and line coverage

## Validation

- `bun test test/command-simplified.test.ts --coverage --coverage-reporter=text`
  - `src/config/command-logic.ts | 100.00 funcs | 100.00 lines`
- `bun run build`
- `git diff --check`

Part of #1637.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
