### PR TITLE
test(runtime): count cron parser in default coverage

### DIFF
--- a/test/triggers-cron.test.ts
+++ b/test/triggers-cron.test.ts
@@ -5,9 +5,8 @@
  *   - parseCronField(expr, min, max) → Set<number>
  *   - wouldFireAt(cronExpr, now)     → Date | null (strictly > now, ≤ ~1y)
  *
- * Isolated by convention with the 15 preceding alpha coverage tests, but
- * the Bun mock.module gotcha catalog is N/A for this target — it has no
- * seams to mock:
+ * Default-suite coverage: this target has no mock.module seams, no I/O, and no
+ * global timers. Keeping it under test/ makes it visible to `test:coverage`:
  *   (1) Capture real fn refs BEFORE mock.module    — nothing imported
  *   (2) Passthrough wrappers use (...args)          — no wrappers needed
  *   (3) os.homedir() caching                        — no fs/os calls
@@ -16,7 +15,7 @@
  * Date.now state leaks to sibling suites.
  */
 import { describe, test, expect } from "bun:test";
-import { parseCronField, wouldFireAt } from "../../src/core/runtime/triggers-cron";
+import { parseCronField, wouldFireAt } from "../src/core/runtime/triggers-cron";
 
 // ─── parseCronField ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- move the pure `triggers-cron` suite from `test/isolated/` into the default `test/` coverage path
- keep the same assertions and update comments/import path only
- makes `src/core/runtime/triggers-cron.ts` visible to `test:coverage`

## Validation

- `bun test test/triggers-cron.test.ts --coverage --coverage-reporter=text`
  - `src/core/runtime/triggers-cron.ts | 100.00 funcs | 100.00 lines`
- `bun run build`
- `git diff --check`

Part of #1637.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
