### PR TITLE
test(runtime): cover context middleware

### DIFF
--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -14,9 +14,9 @@ import { loadConfig, type MawConfig } from "../config";
 // Lazy singleton — initialized once, reused across requests
 let _config: MawConfig | null = null;
 
-export function withContext(): MiddlewareHandler {
+export function withContext(load: () => MawConfig = loadConfig): MiddlewareHandler {
   return async (c, next) => {
-    if (!_config) _config = loadConfig();
+    if (!_config) _config = load();
     c.set("config" as never, _config as never);
     await next();
   };

--- a/test/lib-context-default.test.ts
+++ b/test/lib-context-default.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+
+const { withContext, refreshContext } = await import("../src/lib/context");
+
+function fakeContext() {
+  const values = new Map<string, unknown>();
+  return {
+    values,
+    context: {
+      set(key: string, value: unknown) {
+        values.set(key, value);
+      },
+    },
+  };
+}
+
+function fakeConfig(label: string) {
+  return {
+    host: "local",
+    port: 3456,
+    oracleUrl: "http://localhost:47779",
+    env: {},
+    commands: { default: "codex" },
+    sessions: {},
+    label,
+  };
+}
+
+describe("withContext default-suite coverage", () => {
+  test("loads config once, injects it into context, and awaits next", async () => {
+    refreshContext();
+    const calls: string[] = [];
+    const middleware = withContext(() => {
+      calls.push("load");
+      return fakeConfig("cached") as never;
+    });
+    const first = fakeContext();
+    const second = fakeContext();
+    const events: string[] = [];
+
+    await middleware(first.context as never, async () => {
+      events.push("first-next");
+    });
+    await middleware(second.context as never, async () => {
+      events.push("second-next");
+    });
+
+    const firstConfig = first.values.get("config");
+    expect(firstConfig).toBeTruthy();
+    expect(second.values.get("config")).toBe(firstConfig);
+    expect(calls).toEqual(["load"]);
+    expect(events).toEqual(["first-next", "second-next"]);
+  });
+
+  test("refreshContext is idempotent and clears middleware cache before reuse", async () => {
+    refreshContext();
+    refreshContext();
+    const middleware = withContext(() => fakeConfig("after-refresh") as never);
+    const ctx = fakeContext();
+
+    await middleware(ctx.context as never, async () => undefined);
+
+    expect(ctx.values.get("config")).toMatchObject({ label: "after-refresh" });
+    expect(refreshContext()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add default-suite coverage for `withContext()` and `refreshContext()`
- prove middleware injects cached config and awaits `next()`
- keep existing isolated tests; this makes the standard coverage report see the module

## Evidence
- `bun test test/lib-context-default.test.ts --coverage --coverage-reporter=text` → `src/lib/context.ts | 100.00 funcs | 100.00 lines`
- `bun run build`
- `git diff --check`

## Notes
- Alpha-only coverage slice for #1637.
- No release cut.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.