### PR TITLE
test(federation): cover status renderer branches

### DIFF
--- a/src/commands/shared/federation.ts
+++ b/src/commands/shared/federation.ts
@@ -1,9 +1,38 @@
 import { getFederationStatus, getPeers, curlFetch, listSessions } from "../../sdk";
-import { loadConfig } from "../../config";
+import { loadConfig, type MawConfig } from "../../config";
+import { getFederationStatusSymmetric, type PeerStatus } from "../../core/transport/peers";
+import type { Session } from "../../core/runtime/find-window";
 
-async function fetchPeerAgentCount(url: string): Promise<number> {
+type LogFn = (message?: unknown, ...optionalParams: unknown[]) => void;
+type CurlFetch = typeof curlFetch;
+type FederationStatus = Awaited<ReturnType<typeof getFederationStatus>>;
+type PairState = "healthy" | "half-up" | "down" | "unknown";
+type SymmetricPair = { url: string; pair: PairState; reason?: string };
+type SymmetricStatus = {
+  totalPairs: number;
+  healthyPairs: number;
+  localNode: string;
+  pairs: SymmetricPair[];
+};
+
+export type FederationStatusDeps = {
+  getPeers?: () => string[];
+  loadConfig?: () => MawConfig;
+  getFederationStatus?: () => Promise<FederationStatus>;
+  listSessions?: () => Promise<Session[]>;
+  curlFetch?: CurlFetch;
+  log?: LogFn;
+};
+
+export type FederationStatusVerifyDeps = {
+  loadConfig?: () => MawConfig;
+  getFederationStatusSymmetric?: () => Promise<SymmetricStatus>;
+  log?: LogFn;
+};
+
+async function fetchPeerAgentCount(url: string, fetch: CurlFetch = curlFetch): Promise<number> {
   try {
-    const res = await curlFetch(`${url}/api/sessions`, { timeout: 3000 });
+    const res = await fetch(`${url}/api/sessions`, { timeout: 3000 });
     if (!res.ok) return 0;
     const sessions: { windows: unknown[] }[] = res.data || [];
     return sessions.reduce((n, s) => n + (s.windows?.length || 0), 0);
@@ -13,9 +42,9 @@ async function fetchPeerAgentCount(url: string): Promise<number> {
 }
 
 /** Count local agents = sum of windows across local tmux sessions. */
-async function countLocalAgents(): Promise<number> {
+async function countLocalAgents(loadSessions: () => Promise<Session[]> = listSessions): Promise<number> {
   try {
-    const sessions = await listSessions();
+    const sessions = await loadSessions();
     return sessions.reduce((n, s) => n + (s.windows?.length || 0), 0);
   } catch {
     return 0;
@@ -34,15 +63,16 @@ function labelForPeer(url: string, named: { name: string; url: string }[]): stri
 }
 
 /** maw federation status — show all nodes (local + peers) with connectivity + agent counts */
-export async function cmdFederationStatus() {
-  const peers = getPeers();
-  const config = loadConfig();
+export async function cmdFederationStatus(deps: FederationStatusDeps = {}) {
+  const peers = (deps.getPeers ?? getPeers)();
+  const config = (deps.loadConfig ?? loadConfig)();
   const named = config.namedPeers ?? [];
   const totalNodes = peers.length + 1; // +1 for local
   const localLabel = config.node ? `${config.node} (local)` : "local";
+  const log = deps.log ?? console.log;
 
   // Header always includes local, so "N nodes (1 local + M peers)"
-  console.log(
+  log(
     `\n\x1b[36;1mFederation Status\x1b[0m  ` +
     `\x1b[90m${totalNodes} node${totalNodes !== 1 ? "s" : ""} ` +
     `(1 local + ${peers.length} peer${peers.length !== 1 ? "s" : ""})\x1b[0m\n`
@@ -50,33 +80,33 @@ export async function cmdFederationStatus() {
 
   // Fetch local + peer state in parallel
   const [localCount, { peers: statuses, localUrl }] = await Promise.all([
-    countLocalAgents(),
-    getFederationStatus(),
+    countLocalAgents(deps.listSessions ?? listSessions),
+    (deps.getFederationStatus ?? getFederationStatus)(),
   ]);
 
   // Render local row FIRST — the triangle is only visible if local is in the table
-  console.log(
+  log(
     `  \x1b[32m●\x1b[0m  \x1b[37m${localLabel}\x1b[0m  ` +
     `\x1b[32monline\x1b[0m  ` +
     `\x1b[90m${localCount} agent${localCount !== 1 ? "s" : ""}\x1b[0m`
   );
-  console.log(`     \x1b[90m${localUrl}\x1b[0m`);
+  log(`     \x1b[90m${localUrl}\x1b[0m`);
 
   // No peers? Still show helpful hint.
   if (peers.length === 0) {
-    console.log("\n\x1b[90mNo peers configured. Add namedPeers[] to maw.config.json.\x1b[0m");
-    console.log('\x1b[90mExample: { "namedPeers": [{ "name": "other", "url": "http://other-host:3456" }] }\x1b[0m\n');
+    log("\n\x1b[90mNo peers configured. Add namedPeers[] to maw.config.json.\x1b[0m");
+    log('\x1b[90mExample: { "namedPeers": [{ "name": "other", "url": "http://other-host:3456" }] }\x1b[0m\n');
     return;
   }
 
   // Fetch peer agent counts in parallel for reachable peers
   const counts = await Promise.all(
-    statuses.map(p => p.reachable ? fetchPeerAgentCount(p.url) : Promise.resolve(0))
+    statuses.map(p => p.reachable ? fetchPeerAgentCount(p.url, deps.curlFetch ?? curlFetch) : Promise.resolve(0))
   );
 
   let reachableCount = 1; // local is always reachable (we're executing in it)
   for (let i = 0; i < statuses.length; i++) {
-    const { url, reachable, latency } = statuses[i];
+    const { url, reachable, latency } = statuses[i] as PeerStatus;
     const agentCount = counts[i];
     if (reachable) reachableCount++;
 
@@ -89,11 +119,11 @@ export async function cmdFederationStatus() {
       : "\x1b[31munreachable\x1b[0m";
 
     const label = labelForPeer(url, named);
-    console.log(`  ${dot}  \x1b[37m${label}\x1b[0m  ${status}`);
-    console.log(`     \x1b[90m${url}\x1b[0m`);
+    log(`  ${dot}  \x1b[37m${label}\x1b[0m  ${status}`);
+    log(`     \x1b[90m${url}\x1b[0m`);
   }
 
-  console.log(`\n\x1b[90m${reachableCount}/${totalNodes} reachable (one-way; use --verify for pair-symmetric check — PR #398)\x1b[0m\n`);
+  log(`\n\x1b[90m${reachableCount}/${totalNodes} reachable (one-way; use --verify for pair-symmetric check — PR #398)\x1b[0m\n`);
 }
 
 /**
@@ -108,19 +138,20 @@ export async function cmdFederationStatus() {
  *   0 : all pairs healthy
  *   1 : at least one pair non-healthy
  */
-export async function cmdFederationStatusVerify(): Promise<{ ok: boolean }> {
-  const { getFederationStatusSymmetric } = await import("../../core/transport/peers");
-  const config = loadConfig();
+export async function cmdFederationStatusVerify(deps: FederationStatusVerifyDeps = {}): Promise<{ ok: boolean }> {
+  const getSymmetric = deps.getFederationStatusSymmetric ?? getFederationStatusSymmetric;
+  const config = (deps.loadConfig ?? loadConfig)();
   const named = config.namedPeers ?? [];
-  const result = await getFederationStatusSymmetric();
+  const result = await getSymmetric();
+  const log = deps.log ?? console.log;
 
-  console.log(
+  log(
     `\n\x1b[36;1mFederation Status — Symmetric\x1b[0m  ` +
     `\x1b[90m${result.totalPairs} pair${result.totalPairs !== 1 ? "s" : ""} · local: ${result.localNode}\x1b[0m\n`
   );
 
   if (result.totalPairs === 0) {
-    console.log("\x1b[90mNo peers configured. Add namedPeers[] to maw.config.json.\x1b[0m\n");
+    log("\x1b[90mNo peers configured. Add namedPeers[] to maw.config.json.\x1b[0m\n");
     return { ok: true };
   }
 
@@ -146,10 +177,10 @@ export async function cmdFederationStatusVerify(): Promise<{ ok: boolean }> {
         state = `\x1b[90munknown\x1b[0m  \x1b[90m(${p.reason ?? "reverse check inconclusive"})\x1b[0m`;
         break;
     }
-    console.log(`  ${dot}  \x1b[37m${label}\x1b[0m  ${state}`);
-    console.log(`     \x1b[90m${p.url}\x1b[0m`);
+    log(`  ${dot}  \x1b[37m${label}\x1b[0m  ${state}`);
+    log(`     \x1b[90m${p.url}\x1b[0m`);
   }
 
-  console.log(`\n\x1b[90m${result.healthyPairs}/${result.totalPairs} pairs healthy\x1b[0m\n`);
+  log(`\n\x1b[90m${result.healthyPairs}/${result.totalPairs} pairs healthy\x1b[0m\n`);
   return { ok: result.healthyPairs === result.totalPairs };
 }

--- a/test/federation-status-cmd.test.ts
+++ b/test/federation-status-cmd.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from "bun:test";
+import { cmdFederationStatus, cmdFederationStatusVerify } from "../src/commands/shared/federation";
+import type { Session } from "../src/core/runtime/find-window";
+
+function stripAnsi(text: string): string {
+  return text.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function captureLog() {
+  const lines: string[] = [];
+  return {
+    log: (message?: unknown) => lines.push(String(message ?? "")),
+    text: () => stripAnsi(lines.join("\n")),
+  };
+}
+
+function session(name: string, windows: number): Session {
+  return {
+    name,
+    windows: Array.from({ length: windows }, (_, index) => ({ index, name: `w${index}`, active: index === 0 })),
+  };
+}
+
+describe("cmdFederationStatus", () => {
+  test("renders local-only status with the no-peers hint and fail-soft local count", async () => {
+    const logs = captureLog();
+
+    await cmdFederationStatus({
+      getPeers: () => [],
+      loadConfig: () => ({ namedPeers: [] }),
+      listSessions: async () => { throw new Error("tmux unavailable"); },
+      getFederationStatus: async () => ({
+        localUrl: "http://localhost:3456",
+        peers: [],
+        totalPeers: 0,
+        reachablePeers: 0,
+        clockHealth: { clockUtc: "2026-05-17T00:00:00.000Z", timezone: "UTC", uptimeSeconds: 1 },
+      }),
+      log: logs.log,
+    });
+
+    const out = logs.text();
+    expect(out).toContain("Federation Status  1 node (1 local + 0 peers)");
+    expect(out).toContain("local  online  0 agents");
+    expect(out).toContain("No peers configured");
+    expect(out).toContain("namedPeers");
+  });
+
+  test("renders named, host, localhost, throwing, and unreachable peers", async () => {
+    const logs = captureLog();
+    const fetched: string[] = [];
+
+    await cmdFederationStatus({
+      getPeers: () => [
+        "http://named:3456",
+        "http://localhost:4567",
+        "http://other-host:3456",
+        "http://throw-host:3456",
+        "not a url",
+      ],
+      loadConfig: () => ({
+        node: "m5",
+        namedPeers: [{ name: "named-peer", url: "http://named:3456" }],
+      }),
+      listSessions: async () => [session("local-a", 1), session("local-b", 2)],
+      getFederationStatus: async () => ({
+        localUrl: "http://localhost:3456",
+        peers: [
+          { url: "http://named:3456", reachable: true, latency: 7 },
+          { url: "http://localhost:4567", reachable: true, latency: 8 },
+          { url: "http://other-host:3456", reachable: true, latency: 9 },
+          { url: "http://throw-host:3456", reachable: true, latency: 10 },
+          { url: "not a url", reachable: false },
+        ],
+        totalPeers: 5,
+        reachablePeers: 4,
+        clockHealth: { clockUtc: "2026-05-17T00:00:00.000Z", timezone: "UTC", uptimeSeconds: 1 },
+      }),
+      curlFetch: async (url: string) => {
+        fetched.push(url);
+        if (url.includes("named")) return { ok: true, status: 200, data: [session("r1", 2), session("r2", 1)] } as never;
+        if (url.includes("localhost")) return { ok: true, status: 200, data: [session("solo", 1)] } as never;
+        if (url.includes("other-host")) return { ok: false, status: 503 } as never;
+        throw new Error("network down");
+      },
+      log: logs.log,
+    });
+
+    const out = logs.text();
+    expect(fetched).toEqual([
+      "http://named:3456/api/sessions",
+      "http://localhost:4567/api/sessions",
+      "http://other-host:3456/api/sessions",
+      "http://throw-host:3456/api/sessions",
+    ]);
+    expect(out).toContain("Federation Status  6 nodes (1 local + 5 peers)");
+    expect(out).toContain("m5 (local)  online  3 agents");
+    expect(out).toContain("named-peer  reachable  7ms · 3 agents");
+    expect(out).toContain("localhost:4567  reachable  8ms · 1 agent");
+    expect(out).toContain("other-host:3456  reachable  9ms · 0 agents");
+    expect(out).toContain("throw-host:3456  reachable  10ms · 0 agents");
+    expect(out).toContain("not a url  unreachable");
+    expect(out).toContain("5/6 reachable");
+  });
+});
+
+describe("cmdFederationStatusVerify", () => {
+  test("returns ok for zero pair symmetric status", async () => {
+    const logs = captureLog();
+
+    const result = await cmdFederationStatusVerify({
+      loadConfig: () => ({ namedPeers: [] }),
+      getFederationStatusSymmetric: async () => ({ totalPairs: 0, healthyPairs: 0, localNode: "m5", pairs: [] }),
+      log: logs.log,
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(logs.text()).toContain("Federation Status — Symmetric  0 pairs · local: m5");
+    expect(logs.text()).toContain("No peers configured");
+  });
+
+  test("renders every symmetric pair state and returns non-ok on unhealthy pairs", async () => {
+    const logs = captureLog();
+
+    const result = await cmdFederationStatusVerify({
+      loadConfig: () => ({ namedPeers: [{ name: "named-peer", url: "http://named:3456" }] }),
+      getFederationStatusSymmetric: async () => ({
+        totalPairs: 6,
+        healthyPairs: 1,
+        localNode: "m5",
+        pairs: [
+          { url: "http://named:3456", pair: "healthy" },
+          { url: "http://half:3456", pair: "half-up", reason: "missing reverse route" },
+          { url: "http://half-no-reason:3456", pair: "half-up" },
+          { url: "http://down:3456", pair: "down", reason: "forward unreachable" },
+          { url: "http://down-no-reason:3456", pair: "down" },
+          { url: "bad url", pair: "unknown" },
+        ],
+      }),
+      log: logs.log,
+    });
+
+    const out = logs.text();
+    expect(result).toEqual({ ok: false });
+    expect(out).toContain("Federation Status — Symmetric  6 pairs · local: m5");
+    expect(out).toContain("named-peer  healthy  (A↔B)");
+    expect(out).toContain("half:3456  half-up  (A→B OK, B→A failed: missing reverse route)");
+    expect(out).toContain("half-no-reason:3456  half-up  (A→B OK, B→A failed)");
+    expect(out).toContain("down:3456  down  (forward unreachable)");
+    expect(out).toContain("down-no-reason:3456  down  (both directions failing)");
+    expect(out).toContain("bad url  unknown  (reverse check inconclusive)");
+    expect(out).toContain("1/6 pairs healthy");
+  });
+});


### PR DESCRIPTION
## Summary
- add dependency seams to `cmdFederationStatus` and `cmdFederationStatusVerify` for config/session/network/status dependencies
- add direct renderer coverage for local-only status, peer labels, agent counts, fetch failures, unreachable peers, and symmetric pair states
- keep runtime CLI behavior unchanged while avoiding process-global module mocks

## Evidence
- `bun test test/federation-status-cmd.test.ts --coverage --coverage-reporter=text --timeout 60000` → `src/commands/shared/federation.ts | 100.00 funcs | 100.00 lines`
- `timeout 60 bun test test/federation-status-cmd.test.ts test/federation-symmetric.test.ts test/federation-sync.test.ts --timeout 60000` passed: 41 pass, 0 fail
- `bun run build` passed
- `git diff --check` passed

No release cut.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.