### PR TITLE
test(workspace): cover agent sharing commands

### DIFF
--- a/src/commands/shared/workspace-agents.ts
+++ b/src/commands/shared/workspace-agents.ts
@@ -1,128 +1,163 @@
-import { loadConfig, cfgTimeout } from "../../config";
-import { curlFetch } from "../../sdk";
-import { resolveWorkspaceId, reportNoWorkspaceId, loadWorkspace, saveWorkspace } from "./workspace-store";
+import { loadConfig as defaultLoadConfig, cfgTimeout as defaultCfgTimeout } from "../../config";
+import { curlFetch as defaultCurlFetch } from "../../sdk";
+import {
+  resolveWorkspaceId as defaultResolveWorkspaceId,
+  reportNoWorkspaceId as defaultReportNoWorkspaceId,
+  loadWorkspace as defaultLoadWorkspace,
+  saveWorkspace as defaultSaveWorkspace,
+} from "./workspace-store";
+import type { WorkspaceConfig } from "./workspace-store";
+
+export interface WorkspaceAgentsDeps {
+  resolveWorkspaceId?: (explicit?: string) => string | null;
+  reportNoWorkspaceId?: () => void;
+  loadWorkspace?: (id: string) => WorkspaceConfig | null;
+  saveWorkspace?: (ws: WorkspaceConfig) => void;
+  loadConfig?: typeof defaultLoadConfig;
+  cfgTimeout?: typeof defaultCfgTimeout;
+  curlFetch?: typeof defaultCurlFetch;
+  log?: Pick<Console, "log" | "error">;
+  exit?: (code?: number) => never;
+}
+
+function workspaceAgentDeps(deps: WorkspaceAgentsDeps) {
+  return {
+    resolveWorkspaceId: deps.resolveWorkspaceId ?? defaultResolveWorkspaceId,
+    reportNoWorkspaceId: deps.reportNoWorkspaceId ?? defaultReportNoWorkspaceId,
+    loadWorkspace: deps.loadWorkspace ?? defaultLoadWorkspace,
+    saveWorkspace: deps.saveWorkspace ?? defaultSaveWorkspace,
+    loadConfig: deps.loadConfig ?? defaultLoadConfig,
+    cfgTimeout: deps.cfgTimeout ?? defaultCfgTimeout,
+    curlFetch: deps.curlFetch ?? defaultCurlFetch,
+    log: deps.log ?? console,
+    exit: deps.exit ?? process.exit,
+  };
+}
 
 /** maw workspace share <agent...> [--workspace <id>] */
-export async function cmdWorkspaceShare(agents: string[], workspaceId?: string) {
-  const id = resolveWorkspaceId(workspaceId);
+export async function cmdWorkspaceShare(agents: string[], workspaceId?: string, deps: WorkspaceAgentsDeps = {}) {
+  const d = workspaceAgentDeps(deps);
+  const id = d.resolveWorkspaceId(workspaceId);
   if (!id) {
-    reportNoWorkspaceId();
-    process.exit(1);
+    d.reportNoWorkspaceId();
+    d.exit(1);
   }
 
-  const ws = loadWorkspace(id);
+  const ws = d.loadWorkspace(id);
   if (!ws) {
-    console.error(`\x1b[31m\u274c\x1b[0m workspace not found: ${id}`);
-    process.exit(1);
+    d.log.error(`\x1b[31m\u274c\x1b[0m workspace not found: ${id}`);
+    d.exit(1);
   }
 
-  console.log(`\x1b[36msharing\x1b[0m ${agents.length} agent(s) to workspace "${ws.name}"...`);
+  d.log.log(`\x1b[36msharing\x1b[0m ${agents.length} agent(s) to workspace "${ws.name}"...`);
 
-  const config = loadConfig();
-  const res = await curlFetch(`${ws.hubUrl}/api/workspace/${ws.id}/agents`, {
+  const config = d.loadConfig();
+  const res = await d.curlFetch(`${ws.hubUrl}/api/workspace/${ws.id}/agents`, {
     method: "POST",
     body: JSON.stringify({ action: "share", agents, node: config.node ?? "local" }),
   });
 
   if (!res.ok) {
-    console.error(`\x1b[31m\u274c\x1b[0m failed to share agents: ${res.data?.error || `HTTP ${res.status}`}`);
-    process.exit(1);
+    d.log.error(`\x1b[31m\u274c\x1b[0m failed to share agents: ${res.data?.error || `HTTP ${res.status}`}`);
+    d.exit(1);
   }
 
   // Update local config
   const newAgents = new Set([...ws.sharedAgents, ...agents]);
   ws.sharedAgents = [...newAgents];
-  saveWorkspace(ws);
+  d.saveWorkspace(ws);
 
-  console.log(`\x1b[32m\u2705\x1b[0m shared ${agents.length} agent(s)`);
+  d.log.log(`\x1b[32m\u2705\x1b[0m shared ${agents.length} agent(s)`);
   for (const a of agents) {
-    console.log(`  \x1b[32m+\x1b[0m ${a}`);
+    d.log.log(`  \x1b[32m+\x1b[0m ${a}`);
   }
-  console.log(`\x1b[90m  total shared: ${ws.sharedAgents.length}\x1b[0m`);
+  d.log.log(`\x1b[90m  total shared: ${ws.sharedAgents.length}\x1b[0m`);
 }
 
 /** maw workspace unshare <agent...> [--workspace <id>] */
-export async function cmdWorkspaceUnshare(agents: string[], workspaceId?: string) {
-  const id = resolveWorkspaceId(workspaceId);
+export async function cmdWorkspaceUnshare(agents: string[], workspaceId?: string, deps: WorkspaceAgentsDeps = {}) {
+  const d = workspaceAgentDeps(deps);
+  const id = d.resolveWorkspaceId(workspaceId);
   if (!id) {
-    reportNoWorkspaceId();
-    process.exit(1);
+    d.reportNoWorkspaceId();
+    d.exit(1);
   }
 
-  const ws = loadWorkspace(id);
+  const ws = d.loadWorkspace(id);
   if (!ws) {
-    console.error(`\x1b[31m\u274c\x1b[0m workspace not found: ${id}`);
-    process.exit(1);
+    d.log.error(`\x1b[31m\u274c\x1b[0m workspace not found: ${id}`);
+    d.exit(1);
   }
 
-  console.log(`\x1b[36mremoving\x1b[0m ${agents.length} agent(s) from workspace "${ws.name}"...`);
+  d.log.log(`\x1b[36mremoving\x1b[0m ${agents.length} agent(s) from workspace "${ws.name}"...`);
 
-  const config = loadConfig();
-  const res = await curlFetch(`${ws.hubUrl}/api/workspace/${ws.id}/agents`, {
+  const config = d.loadConfig();
+  const res = await d.curlFetch(`${ws.hubUrl}/api/workspace/${ws.id}/agents`, {
     method: "POST",
     body: JSON.stringify({ action: "unshare", agents, node: config.node ?? "local" }),
   });
 
   if (!res.ok) {
-    console.error(`\x1b[31m\u274c\x1b[0m failed to unshare agents: ${res.data?.error || `HTTP ${res.status}`}`);
-    process.exit(1);
+    d.log.error(`\x1b[31m\u274c\x1b[0m failed to unshare agents: ${res.data?.error || `HTTP ${res.status}`}`);
+    d.exit(1);
   }
 
   // Update local config
   const removeSet = new Set(agents);
   ws.sharedAgents = ws.sharedAgents.filter(a => !removeSet.has(a));
-  saveWorkspace(ws);
+  d.saveWorkspace(ws);
 
-  console.log(`\x1b[32m\u2705\x1b[0m removed ${agents.length} agent(s)`);
+  d.log.log(`\x1b[32m\u2705\x1b[0m removed ${agents.length} agent(s)`);
   for (const a of agents) {
-    console.log(`  \x1b[31m-\x1b[0m ${a}`);
+    d.log.log(`  \x1b[31m-\x1b[0m ${a}`);
   }
-  console.log(`\x1b[90m  total shared: ${ws.sharedAgents.length}\x1b[0m`);
+  d.log.log(`\x1b[90m  total shared: ${ws.sharedAgents.length}\x1b[0m`);
 }
 
 /** maw workspace agents [workspace-id] */
-export async function cmdWorkspaceAgents(workspaceId?: string) {
-  const id = resolveWorkspaceId(workspaceId);
+export async function cmdWorkspaceAgents(workspaceId?: string, deps: WorkspaceAgentsDeps = {}) {
+  const d = workspaceAgentDeps(deps);
+  const id = d.resolveWorkspaceId(workspaceId);
   if (!id) {
-    reportNoWorkspaceId();
-    process.exit(1);
+    d.reportNoWorkspaceId();
+    d.exit(1);
   }
 
-  const ws = loadWorkspace(id);
+  const ws = d.loadWorkspace(id);
   if (!ws) {
-    console.error(`\x1b[31m\u274c\x1b[0m workspace not found: ${id}`);
-    process.exit(1);
+    d.log.error(`\x1b[31m\u274c\x1b[0m workspace not found: ${id}`);
+    d.exit(1);
   }
 
-  console.log(`\x1b[36mfetching\x1b[0m agents for workspace "${ws.name}"...`);
+  d.log.log(`\x1b[36mfetching\x1b[0m agents for workspace "${ws.name}"...`);
 
-  const res = await curlFetch(`${ws.hubUrl}/api/workspace/${ws.id}/agents`, { timeout: cfgTimeout("workspace") });
+  const res = await d.curlFetch(`${ws.hubUrl}/api/workspace/${ws.id}/agents`, { timeout: d.cfgTimeout("workspace") });
 
   if (!res.ok) {
-    console.error(`\x1b[31m\u274c\x1b[0m failed to fetch agents: ${res.data?.error || `HTTP ${res.status}`}`);
-    process.exit(1);
+    d.log.error(`\x1b[31m\u274c\x1b[0m failed to fetch agents: ${res.data?.error || `HTTP ${res.status}`}`);
+    d.exit(1);
   }
 
   const nodes: Record<string, string[]> = res.data?.nodes || {};
   const nodeNames = Object.keys(nodes);
 
   if (nodeNames.length === 0) {
-    console.log("\x1b[90mNo agents in workspace yet.\x1b[0m");
-    console.log("\x1b[90m  maw workspace share <agent...>  Share your agents\x1b[0m");
+    d.log.log("\x1b[90mNo agents in workspace yet.\x1b[0m");
+    d.log.log("\x1b[90m  maw workspace share <agent...>  Share your agents\x1b[0m");
     return;
   }
 
-  console.log(`\n\x1b[36;1m${ws.name}\x1b[0m  \x1b[90mAgents by node\x1b[0m\n`);
+  d.log.log(`\n\x1b[36;1m${ws.name}\x1b[0m  \x1b[90mAgents by node\x1b[0m\n`);
 
   let totalAgents = 0;
   for (const node of nodeNames) {
     const agents = nodes[node] || [];
     totalAgents += agents.length;
-    console.log(`  \x1b[37;1m${node}\x1b[0m  \x1b[90m(${agents.length} agent${agents.length !== 1 ? "s" : ""})\x1b[0m`);
+    d.log.log(`  \x1b[37;1m${node}\x1b[0m  \x1b[90m(${agents.length} agent${agents.length !== 1 ? "s" : ""})\x1b[0m`);
     for (const a of agents) {
-      console.log(`    \x1b[90m\u25cf\x1b[0m ${a}`);
+      d.log.log(`    \x1b[90m\u25cf\x1b[0m ${a}`);
     }
   }
 
-  console.log(`\n\x1b[90m${totalAgents} total agents across ${nodeNames.length} node${nodeNames.length !== 1 ? "s" : ""}\x1b[0m\n`);
+  d.log.log(`\n\x1b[90m${totalAgents} total agents across ${nodeNames.length} node${nodeNames.length !== 1 ? "s" : ""}\x1b[0m\n`);
 }

--- a/test/workspace-agents-default.test.ts
+++ b/test/workspace-agents-default.test.ts
@@ -1,0 +1,229 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+  cmdWorkspaceAgents,
+  cmdWorkspaceShare,
+  cmdWorkspaceUnshare,
+  type WorkspaceAgentsDeps,
+} from "../src/commands/shared/workspace-agents";
+import type { WorkspaceConfig } from "../src/commands/shared/workspace-store";
+
+type Workspace = WorkspaceConfig;
+type CurlResult = { ok: boolean; status?: number; data?: { error?: string; nodes?: Record<string, string[]> } | null };
+
+let defaultWorkspaceId: string | null = null;
+let workspaces = new Map<string, Workspace>();
+let savedWorkspaces: Workspace[] = [];
+let reportedNoWorkspace = 0;
+let configNode: string | undefined;
+let curlResult: CurlResult = { ok: true, data: null };
+let curlCalls: Array<{ url: string; opts: Record<string, unknown> }> = [];
+let timeoutCalls: string[] = [];
+let logs: string[] = [];
+let errors: string[] = [];
+let exitCode: number | undefined;
+
+function workspace(id: string, sharedAgents: string[] = []): Workspace {
+  return {
+    id,
+    name: `name-${id}`,
+    hubUrl: `https://${id}.example`,
+    sharedAgents,
+    joinedAt: "2026-05-17T00:00:00.000Z",
+  };
+}
+
+function deps(): WorkspaceAgentsDeps {
+  return {
+    resolveWorkspaceId: (explicit?: string) => explicit ?? defaultWorkspaceId,
+    reportNoWorkspaceId: () => {
+      reportedNoWorkspace += 1;
+      errors.push("no workspaces joined");
+    },
+    loadWorkspace: (id: string) => {
+      const ws = workspaces.get(id);
+      return ws ? { ...ws, sharedAgents: [...ws.sharedAgents] } : null;
+    },
+    saveWorkspace: (ws: Workspace) => {
+      const saved = { ...ws, sharedAgents: [...ws.sharedAgents] };
+      savedWorkspaces.push(saved);
+      workspaces.set(ws.id, saved);
+    },
+    loadConfig: () => (configNode === undefined ? {} : { node: configNode }),
+    cfgTimeout: (scope: string) => {
+      timeoutCalls.push(scope);
+      return 1234;
+    },
+    curlFetch: async (url: string, opts?: Record<string, unknown>) => {
+      curlCalls.push({ url, opts: opts ?? {} });
+      return curlResult as Awaited<ReturnType<NonNullable<WorkspaceAgentsDeps["curlFetch"]>>>;
+    },
+    log: {
+      log: (...args: unknown[]) => logs.push(args.join(" ")),
+      error: (...args: unknown[]) => errors.push(args.join(" ")),
+    },
+    exit: (code?: number): never => {
+      exitCode = code ?? 0;
+      throw new Error(`__exit__:${exitCode}`);
+    },
+  };
+}
+
+function output(): string {
+  return [...logs, ...errors].join("\n").replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+async function run(fn: () => Promise<void>): Promise<void> {
+  try {
+    await fn();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!message.startsWith("__exit__")) throw error;
+  }
+}
+
+describe("workspace agents command default-suite seams", () => {
+  beforeEach(() => {
+    defaultWorkspaceId = null;
+    workspaces = new Map();
+    savedWorkspaces = [];
+    reportedNoWorkspace = 0;
+    configNode = undefined;
+    curlResult = { ok: true, data: null };
+    curlCalls = [];
+    timeoutCalls = [];
+    logs = [];
+    errors = [];
+    exitCode = undefined;
+  });
+
+  test("share reports missing workspace context and missing explicit workspaces", async () => {
+    await run(() => cmdWorkspaceShare(["alice"], undefined, deps()));
+    expect(exitCode).toBe(1);
+    expect(reportedNoWorkspace).toBe(1);
+    expect(curlCalls).toEqual([]);
+
+    exitCode = undefined;
+    await run(() => cmdWorkspaceShare(["alice"], "ghost", deps()));
+    expect(exitCode).toBe(1);
+    expect(output()).toContain("workspace not found: ghost");
+  });
+
+  test("share posts agents, dedupes local state, saves, and prints totals", async () => {
+    const ws = workspace("ws-share", ["alice"]);
+    workspaces.set(ws.id, ws);
+    configNode = "m5";
+
+    await run(() => cmdWorkspaceShare(["alice", "bob"], ws.id, deps()));
+
+    expect(exitCode).toBeUndefined();
+    expect(curlCalls).toEqual([{ url: "https://ws-share.example/api/workspace/ws-share/agents", opts: {
+      method: "POST",
+      body: JSON.stringify({ action: "share", agents: ["alice", "bob"], node: "m5" }),
+    } }]);
+    expect(savedWorkspaces).toHaveLength(1);
+    expect(savedWorkspaces[0].sharedAgents.sort()).toEqual(["alice", "bob"]);
+    expect(output()).toContain("shared 2 agent(s)");
+    expect(output()).toContain("+ bob");
+    expect(output()).toContain("total shared: 2");
+  });
+
+  test("share exits on hub errors before mutating local state", async () => {
+    const ws = workspace("ws-share-fail", ["eve"]);
+    workspaces.set(ws.id, ws);
+    curlResult = { ok: false, status: 502, data: { error: "hub rejected" } };
+
+    await run(() => cmdWorkspaceShare(["mallory"], ws.id, deps()));
+
+    expect(exitCode).toBe(1);
+    expect(savedWorkspaces).toEqual([]);
+    expect(workspaces.get(ws.id)?.sharedAgents).toEqual(["eve"]);
+    expect(output()).toContain("failed to share agents: hub rejected");
+  });
+
+  test("unshare reports missing workspace context and missing explicit workspaces", async () => {
+    await run(() => cmdWorkspaceUnshare(["alice"], undefined, deps()));
+    expect(exitCode).toBe(1);
+    expect(reportedNoWorkspace).toBe(1);
+
+    exitCode = undefined;
+    await run(() => cmdWorkspaceUnshare(["alice"], "ghost", deps()));
+    expect(exitCode).toBe(1);
+    expect(output()).toContain("workspace not found: ghost");
+  });
+
+  test("unshare posts removals, filters local state, and falls back to local node", async () => {
+    const ws = workspace("ws-unshare", ["alice", "bob", "carol"]);
+    workspaces.set(ws.id, ws);
+
+    await run(() => cmdWorkspaceUnshare(["bob"], ws.id, deps()));
+
+    const body = JSON.parse(String(curlCalls[0].opts.body));
+    expect(body).toEqual({ action: "unshare", agents: ["bob"], node: "local" });
+    expect(savedWorkspaces[0].sharedAgents).toEqual(["alice", "carol"]);
+    expect(output()).toContain("removed 1 agent(s)");
+    expect(output()).toContain("- bob");
+    expect(output()).toContain("total shared: 2");
+  });
+
+  test("unshare exits on hub errors before saving", async () => {
+    const ws = workspace("ws-unshare-fail", ["alice"]);
+    workspaces.set(ws.id, ws);
+    curlResult = { ok: false, status: 500, data: null };
+
+    await run(() => cmdWorkspaceUnshare(["alice"], ws.id, deps()));
+
+    expect(exitCode).toBe(1);
+    expect(savedWorkspaces).toEqual([]);
+    expect(output()).toContain("failed to unshare agents: HTTP 500");
+  });
+
+  test("agents reports missing workspace context and missing explicit workspaces", async () => {
+    await run(() => cmdWorkspaceAgents(undefined, deps()));
+    expect(exitCode).toBe(1);
+    expect(reportedNoWorkspace).toBe(1);
+
+    exitCode = undefined;
+    await run(() => cmdWorkspaceAgents("ghost", deps()));
+    expect(exitCode).toBe(1);
+    expect(output()).toContain("workspace not found: ghost");
+  });
+
+  test("agents treats missing node data as empty and shows the share hint", async () => {
+    const ws = workspace("ws-empty");
+    workspaces.set(ws.id, ws);
+    curlResult = { ok: true, data: {} };
+
+    await run(() => cmdWorkspaceAgents(ws.id, deps()));
+
+    expect(timeoutCalls).toEqual(["workspace"]);
+    expect(curlCalls).toEqual([{ url: "https://ws-empty.example/api/workspace/ws-empty/agents", opts: { timeout: 1234 } }]);
+    expect(output()).toContain("No agents in workspace yet");
+    expect(output()).toContain("maw workspace share <agent...>");
+  });
+
+  test("agents renders grouped nodes with singular and plural counts", async () => {
+    const ws = workspace("ws-agents");
+    workspaces.set(ws.id, ws);
+    curlResult = { ok: true, data: { nodes: { m5: ["alice", "bob"], mba: ["carol"], empty: [] } } };
+
+    await run(() => cmdWorkspaceAgents(ws.id, deps()));
+
+    expect(output()).toContain("name-ws-agents  Agents by node");
+    expect(output()).toContain("m5  (2 agents)");
+    expect(output()).toContain("mba  (1 agent)");
+    expect(output()).toContain("empty  (0 agents)");
+    expect(output()).toContain("alice");
+    expect(output()).toContain("3 total agents across 3 nodes");
+  });
+
+  test("agents exits on hub errors", async () => {
+    const ws = workspace("ws-agents-fail");
+    workspaces.set(ws.id, ws);
+    curlResult = { ok: false, status: 503, data: { error: "hub down" } };
+
+    await run(() => cmdWorkspaceAgents(ws.id, deps()));
+
+    expect(exitCode).toBe(1);
+    expect(output()).toContain("failed to fetch agents: hub down");
+  });
+});


### PR DESCRIPTION
## Summary
- add default-suite coverage for `cmdWorkspaceShare`, `cmdWorkspaceUnshare`, and `cmdWorkspaceAgents`
- cover missing workspace errors, hub failures, local shared-agent mutations, local node fallback, timeout wiring, and grouped agent rendering
- add narrow dependency-injection seams to `workspace-agents.ts` so default coverage avoids `mock.module` pollution

## Evidence
- `bun test test/workspace-agents-default.test.ts --coverage --coverage-reporter=text --timeout 60000` → `src/commands/shared/workspace-agents.ts | 100.00 funcs | 100.00 lines`
- `bun test test/workspace-agents-default.test.ts test/workspace.test.ts test/runtime-sdk-coverage.test.ts --timeout 60000` → 31 pass / 0 fail
- `bash scripts/test-isolated.sh test/isolated/workspace.test.ts` → 50 pass / 0 fail
- `bun run build` passed
- `git diff --check` passed
- `scripts/check-mock-boundary.sh` still reports pre-existing allowlist/grandfathered default-suite mock users; this PR adds no new `mock.module` usage (`grep -R "mock.module" test/workspace-agents-default.test.ts` → no matches)

No release cut.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
