### PR TITLE
test(workspace): cover workspace query commands

### DIFF
--- a/src/commands/shared/workspace-query.ts
+++ b/src/commands/shared/workspace-query.ts
@@ -1,19 +1,55 @@
-import { cfgTimeout } from "../../config";
-import { curlFetch } from "../../sdk";
-import { resolveWorkspaceId, reportNoWorkspaceId, loadWorkspace, loadAllWorkspaces, saveWorkspace } from "./workspace-store";
+import { cfgTimeout as defaultCfgTimeout } from "../../config";
+import { curlFetch as defaultCurlFetch } from "../../sdk";
+import {
+  resolveWorkspaceId as defaultResolveWorkspaceId,
+  reportNoWorkspaceId as defaultReportNoWorkspaceId,
+  loadWorkspace as defaultLoadWorkspace,
+  loadAllWorkspaces as defaultLoadAllWorkspaces,
+  saveWorkspace as defaultSaveWorkspace,
+} from "./workspace-store";
+import type { WorkspaceConfig } from "./workspace-store";
+
+export interface WorkspaceQueryDeps {
+  resolveWorkspaceId?: (explicit?: string) => string | null;
+  reportNoWorkspaceId?: () => void;
+  loadWorkspace?: (id: string) => WorkspaceConfig | null;
+  loadAllWorkspaces?: () => WorkspaceConfig[];
+  saveWorkspace?: (ws: WorkspaceConfig) => void;
+  cfgTimeout?: typeof defaultCfgTimeout;
+  curlFetch?: typeof defaultCurlFetch;
+  log?: Pick<Console, "log" | "error">;
+  exit?: (code?: number) => never;
+  now?: () => number;
+}
+
+function workspaceQueryDeps(deps: WorkspaceQueryDeps) {
+  return {
+    resolveWorkspaceId: deps.resolveWorkspaceId ?? defaultResolveWorkspaceId,
+    reportNoWorkspaceId: deps.reportNoWorkspaceId ?? defaultReportNoWorkspaceId,
+    loadWorkspace: deps.loadWorkspace ?? defaultLoadWorkspace,
+    loadAllWorkspaces: deps.loadAllWorkspaces ?? defaultLoadAllWorkspaces,
+    saveWorkspace: deps.saveWorkspace ?? defaultSaveWorkspace,
+    cfgTimeout: deps.cfgTimeout ?? defaultCfgTimeout,
+    curlFetch: deps.curlFetch ?? defaultCurlFetch,
+    log: deps.log ?? console,
+    exit: deps.exit ?? process.exit,
+    now: deps.now ?? Date.now,
+  };
+}
 
 /** maw workspace ls */
-export async function cmdWorkspaceLs() {
-  const workspaces = loadAllWorkspaces();
+export async function cmdWorkspaceLs(deps: WorkspaceQueryDeps = {}) {
+  const d = workspaceQueryDeps(deps);
+  const workspaces = d.loadAllWorkspaces();
 
   if (workspaces.length === 0) {
-    console.log("\x1b[90mNo workspaces configured.\x1b[0m");
-    console.log("\x1b[90m  maw workspace create <name>   Create a new workspace\x1b[0m");
-    console.log("\x1b[90m  maw workspace join <code>     Join with invite code\x1b[0m");
+    d.log.log("\x1b[90mNo workspaces configured.\x1b[0m");
+    d.log.log("\x1b[90m  maw workspace create <name>   Create a new workspace\x1b[0m");
+    d.log.log("\x1b[90m  maw workspace join <code>     Join with invite code\x1b[0m");
     return;
   }
 
-  console.log(`\n\x1b[36;1mWorkspaces\x1b[0m  \x1b[90m${workspaces.length} joined\x1b[0m\n`);
+  d.log.log(`\n\x1b[36;1mWorkspaces\x1b[0m  \x1b[90m${workspaces.length} joined\x1b[0m\n`);
 
   for (const ws of workspaces) {
     const statusDot = ws.lastStatus === "connected"
@@ -24,73 +60,75 @@ export async function cmdWorkspaceLs() {
       ? "\x1b[90mno agents shared\x1b[0m"
       : `${agentCount} agent${agentCount !== 1 ? "s" : ""} shared`;
 
-    console.log(`  ${statusDot}  \x1b[37;1m${ws.name}\x1b[0m  \x1b[90m(${ws.id})\x1b[0m`);
-    console.log(`     \x1b[36mHub:\x1b[0m     ${ws.hubUrl}`);
-    console.log(`     \x1b[36mAgents:\x1b[0m  ${agentLabel}`);
+    d.log.log(`  ${statusDot}  \x1b[37;1m${ws.name}\x1b[0m  \x1b[90m(${ws.id})\x1b[0m`);
+    d.log.log(`     \x1b[36mHub:\x1b[0m     ${ws.hubUrl}`);
+    d.log.log(`     \x1b[36mAgents:\x1b[0m  ${agentLabel}`);
     if (ws.sharedAgents.length > 0) {
-      console.log(`     \x1b[90m         ${ws.sharedAgents.join(", ")}\x1b[0m`);
+      d.log.log(`     \x1b[90m         ${ws.sharedAgents.join(", ")}\x1b[0m`);
     }
-    console.log(`     \x1b[90mJoined:  ${ws.joinedAt}\x1b[0m`);
+    d.log.log(`     \x1b[90mJoined:  ${ws.joinedAt}\x1b[0m`);
   }
-  console.log();
+  d.log.log();
 }
 
 /** maw workspace invite [workspace-id] */
-export async function cmdWorkspaceInvite(workspaceId?: string) {
-  const id = resolveWorkspaceId(workspaceId);
+export async function cmdWorkspaceInvite(workspaceId?: string, deps: WorkspaceQueryDeps = {}) {
+  const d = workspaceQueryDeps(deps);
+  const id = d.resolveWorkspaceId(workspaceId);
   if (!id) {
-    reportNoWorkspaceId();
-    process.exit(1);
+    d.reportNoWorkspaceId();
+    d.exit(1);
   }
 
-  const ws = loadWorkspace(id);
+  const ws = d.loadWorkspace(id);
   if (!ws) {
-    console.error(`\x1b[31m\u274c\x1b[0m workspace not found: ${id}`);
-    process.exit(1);
+    d.log.error(`\x1b[31m\u274c\x1b[0m workspace not found: ${id}`);
+    d.exit(1);
   }
 
-  const res = await curlFetch(`${ws.hubUrl}/api/workspace/${ws.id}/status`, { timeout: cfgTimeout("workspace") });
+  const res = await d.curlFetch(`${ws.hubUrl}/api/workspace/${ws.id}/status`, { timeout: d.cfgTimeout("workspace") });
 
   if (!res.ok) {
-    console.error(`\x1b[31m\u274c\x1b[0m failed to fetch invite info: ${res.data?.error || `HTTP ${res.status}`}`);
-    process.exit(1);
+    d.log.error(`\x1b[31m\u274c\x1b[0m failed to fetch invite info: ${res.data?.error || `HTTP ${res.status}`}`);
+    d.exit(1);
   }
 
   const joinCode = res.data?.joinCode || ws.joinCode;
   if (!joinCode) {
-    console.error("\x1b[31m\u274c\x1b[0m no join code available for this workspace");
-    process.exit(1);
+    d.log.error("\x1b[31m\u274c\x1b[0m no join code available for this workspace");
+    d.exit(1);
   }
 
-  console.log(`\n\x1b[36;1m${ws.name}\x1b[0m  \x1b[90mInvite\x1b[0m\n`);
-  console.log(`  \x1b[36mJoin code:\x1b[0m  ${joinCode}`);
+  d.log.log(`\n\x1b[36;1m${ws.name}\x1b[0m  \x1b[90mInvite\x1b[0m\n`);
+  d.log.log(`  \x1b[36mJoin code:\x1b[0m  ${joinCode}`);
   if (res.data?.expiry) {
-    console.log(`  \x1b[36mExpires:\x1b[0m    ${res.data.expiry}`);
+    d.log.log(`  \x1b[36mExpires:\x1b[0m    ${res.data.expiry}`);
   }
-  console.log(`\n  \x1b[90mTo join:\x1b[0m  maw workspace join ${joinCode} --hub ${ws.hubUrl}`);
-  console.log();
+  d.log.log(`\n  \x1b[90mTo join:\x1b[0m  maw workspace join ${joinCode} --hub ${ws.hubUrl}`);
+  d.log.log();
 }
 
 /** maw workspace status */
-export async function cmdWorkspaceStatus() {
-  const workspaces = loadAllWorkspaces();
+export async function cmdWorkspaceStatus(deps: WorkspaceQueryDeps = {}) {
+  const d = workspaceQueryDeps(deps);
+  const workspaces = d.loadAllWorkspaces();
 
   if (workspaces.length === 0) {
-    console.log("\x1b[90mNo workspaces configured.\x1b[0m");
+    d.log.log("\x1b[90mNo workspaces configured.\x1b[0m");
     return;
   }
 
-  console.log(`\n\x1b[36;1mWorkspace Status\x1b[0m  \x1b[90m${workspaces.length} workspace${workspaces.length !== 1 ? "s" : ""}\x1b[0m\n`);
+  d.log.log(`\n\x1b[36;1mWorkspace Status\x1b[0m  \x1b[90m${workspaces.length} workspace${workspaces.length !== 1 ? "s" : ""}\x1b[0m\n`);
 
   const results = await Promise.all(
     workspaces.map(async (ws) => {
-      const start = Date.now();
+      const start = d.now();
       try {
-        const res = await curlFetch(`${ws.hubUrl}/api/workspace/${ws.id}/status`, { timeout: cfgTimeout("workspace") });
-        const ms = Date.now() - start;
+        const res = await d.curlFetch(`${ws.hubUrl}/api/workspace/${ws.id}/status`, { timeout: d.cfgTimeout("workspace") });
+        const ms = d.now() - start;
         if (res.ok) {
           ws.lastStatus = "connected";
-          saveWorkspace(ws);
+          d.saveWorkspace(ws);
           return {
             ws,
             ok: true,
@@ -100,12 +138,12 @@ export async function cmdWorkspaceStatus() {
           };
         }
         ws.lastStatus = "disconnected";
-        saveWorkspace(ws);
+        d.saveWorkspace(ws);
         return { ws, ok: false, ms, agentCount: 0, nodeCount: 0 };
       } catch {
         ws.lastStatus = "disconnected";
-        saveWorkspace(ws);
-        return { ws, ok: false, ms: Date.now() - start, agentCount: 0, nodeCount: 0 };
+        d.saveWorkspace(ws);
+        return { ws, ok: false, ms: d.now() - start, agentCount: 0, nodeCount: 0 };
       }
     })
   );
@@ -118,9 +156,9 @@ export async function cmdWorkspaceStatus() {
       ? `\x1b[32mconnected\x1b[0m  \x1b[90m${r.ms}ms \u00b7 ${r.agentCount} agent${r.agentCount !== 1 ? "s" : ""} \u00b7 ${r.nodeCount} node${r.nodeCount !== 1 ? "s" : ""}\x1b[0m`
       : `\x1b[31mdisconnected\x1b[0m  \x1b[90m${r.ms}ms\x1b[0m`;
 
-    console.log(`  ${dot}  \x1b[37;1m${r.ws.name}\x1b[0m  ${status}`);
-    console.log(`     \x1b[90m${r.ws.hubUrl}\x1b[0m`);
+    d.log.log(`  ${dot}  \x1b[37;1m${r.ws.name}\x1b[0m  ${status}`);
+    d.log.log(`     \x1b[90m${r.ws.hubUrl}\x1b[0m`);
   }
 
-  console.log(`\n\x1b[90m${online}/${workspaces.length} connected\x1b[0m\n`);
+  d.log.log(`\n\x1b[90m${online}/${workspaces.length} connected\x1b[0m\n`);
 }

--- a/test/workspace-query-default.test.ts
+++ b/test/workspace-query-default.test.ts
@@ -1,0 +1,262 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+  cmdWorkspaceInvite,
+  cmdWorkspaceLs,
+  cmdWorkspaceStatus,
+  type WorkspaceQueryDeps,
+} from "../src/commands/shared/workspace-query";
+import type { WorkspaceConfig } from "../src/commands/shared/workspace-store";
+
+type Workspace = WorkspaceConfig;
+type CurlData = {
+  error?: string;
+  joinCode?: string;
+  expiry?: string;
+  agentCount?: number;
+  nodeCount?: number;
+} | null;
+type CurlResult = { ok: boolean; status?: number; data?: CurlData };
+type CurlStub = { match: RegExp; response?: CurlResult; error?: string };
+
+let defaultWorkspaceId: string | null = null;
+let workspaces = new Map<string, Workspace>();
+let savedWorkspaces: Workspace[] = [];
+let curlStubs: CurlStub[] = [];
+let curlCalls: Array<{ url: string; opts: Record<string, unknown> }> = [];
+let timeoutCalls: string[] = [];
+let logs: string[] = [];
+let errors: string[] = [];
+let exitCode: number | undefined;
+let clock = 1_000;
+let reportedNoWorkspace = 0;
+
+function workspace(id: string, overrides: Partial<Workspace> = {}): Workspace {
+  return {
+    id,
+    name: `name-${id}`,
+    hubUrl: `https://${id}.example`,
+    sharedAgents: [],
+    joinedAt: "2026-05-17T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function cloneWorkspace(ws: Workspace): Workspace {
+  return { ...ws, sharedAgents: [...ws.sharedAgents] };
+}
+
+function deps(): WorkspaceQueryDeps {
+  return {
+    resolveWorkspaceId: (explicit?: string) => explicit ?? defaultWorkspaceId,
+    reportNoWorkspaceId: () => {
+      reportedNoWorkspace += 1;
+      errors.push("no workspaces joined");
+    },
+    loadWorkspace: (id: string) => {
+      const ws = workspaces.get(id);
+      return ws ? cloneWorkspace(ws) : null;
+    },
+    loadAllWorkspaces: () => [...workspaces.values()].map(cloneWorkspace),
+    saveWorkspace: (ws: Workspace) => {
+      const saved = cloneWorkspace(ws);
+      savedWorkspaces.push(saved);
+      workspaces.set(ws.id, saved);
+    },
+    cfgTimeout: (scope: string) => {
+      timeoutCalls.push(scope);
+      return 1234;
+    },
+    curlFetch: async (url: string, opts?: Record<string, unknown>) => {
+      curlCalls.push({ url, opts: opts ?? {} });
+      const stub = curlStubs.find((entry) => entry.match.test(url));
+      if (stub?.error) throw new Error(stub.error);
+      return (stub?.response ?? { ok: true, data: null }) as Awaited<ReturnType<NonNullable<WorkspaceQueryDeps["curlFetch"]>>>;
+    },
+    log: {
+      log: (...args: unknown[]) => logs.push(args.join(" ")),
+      error: (...args: unknown[]) => errors.push(args.join(" ")),
+    },
+    exit: (code?: number): never => {
+      exitCode = code ?? 0;
+      throw new Error(`__exit__:${exitCode}`);
+    },
+    now: () => {
+      clock += 7;
+      return clock;
+    },
+  };
+}
+
+function output(): string {
+  return [...logs, ...errors].join("\n").replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+async function run(fn: () => Promise<void>): Promise<void> {
+  try {
+    await fn();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!message.startsWith("__exit__")) throw error;
+  }
+}
+
+describe("workspace query command default-suite seams", () => {
+  beforeEach(() => {
+    defaultWorkspaceId = null;
+    workspaces = new Map();
+    savedWorkspaces = [];
+    curlStubs = [];
+    curlCalls = [];
+    timeoutCalls = [];
+    logs = [];
+    errors = [];
+    exitCode = undefined;
+    clock = 1_000;
+    reportedNoWorkspace = 0;
+  });
+
+  test("ls renders onboarding hints when no workspaces are configured", async () => {
+    await run(() => cmdWorkspaceLs(deps()));
+
+    expect(output()).toContain("No workspaces configured");
+    expect(output()).toContain("maw workspace create <name>");
+    expect(output()).toContain("maw workspace join <code>");
+  });
+
+  test("ls renders connected, disconnected, shared, empty, plural, and singular workspace rows", async () => {
+    workspaces.set("ws-one", workspace("ws-one", {
+      name: "one",
+      hubUrl: "https://one.example",
+      sharedAgents: ["alice", "bob"],
+      joinedAt: "2026-05-01",
+      lastStatus: "connected",
+    }));
+    workspaces.set("ws-two", workspace("ws-two", {
+      name: "two",
+      hubUrl: "https://two.example",
+      joinedAt: "2026-05-02",
+      lastStatus: "disconnected",
+    }));
+    workspaces.set("ws-solo", workspace("ws-solo", {
+      name: "solo",
+      sharedAgents: ["carol"],
+      joinedAt: "2026-05-03",
+    }));
+
+    await run(() => cmdWorkspaceLs(deps()));
+
+    const text = output();
+    expect(text).toContain("Workspaces");
+    expect(text).toContain("3 joined");
+    expect(text).toContain("one");
+    expect(text).toContain("two");
+    expect(text).toContain("solo");
+    expect(text).toContain("alice, bob");
+    expect(text).toContain("no agents shared");
+    expect(text).toContain("1 agent shared");
+    expect(logs.join("\n")).toContain("\x1b[32m●\x1b[0m");
+    expect(logs.join("\n")).toContain("\x1b[31m●\x1b[0m");
+  });
+
+  test("invite reports missing workspace context and missing explicit workspaces", async () => {
+    await run(() => cmdWorkspaceInvite(undefined, deps()));
+    expect(exitCode).toBe(1);
+    expect(reportedNoWorkspace).toBe(1);
+
+    exitCode = undefined;
+    await run(() => cmdWorkspaceInvite("ghost", deps()));
+    expect(exitCode).toBe(1);
+    expect(output()).toContain("workspace not found: ghost");
+  });
+
+  test("invite fetches status, prints server join code with expiry, and uses workspace timeout", async () => {
+    workspaces.set("ws-invite", workspace("ws-invite", { name: "invite" }));
+    curlStubs = [{
+      match: /status/,
+      response: { ok: true, data: { joinCode: "CODE-111", expiry: "2026-05-17T12:00:00Z" } },
+    }];
+
+    await run(() => cmdWorkspaceInvite("ws-invite", deps()));
+
+    expect(exitCode).toBeUndefined();
+    expect(timeoutCalls).toEqual(["workspace"]);
+    expect(curlCalls).toEqual([{ url: "https://ws-invite.example/api/workspace/ws-invite/status", opts: { timeout: 1234 } }]);
+    expect(output()).toContain("invite  Invite");
+    expect(output()).toContain("CODE-111");
+    expect(output()).toContain("Expires:");
+    expect(output()).toContain("maw workspace join CODE-111 --hub https://ws-invite.example");
+  });
+
+  test("invite falls back to local join code and omits expiry when the hub omits both", async () => {
+    workspaces.set("ws-local-code", workspace("ws-local-code", { joinCode: "LOCAL-CODE" }));
+    curlStubs = [{ match: /status/, response: { ok: true, data: {} } }];
+
+    await run(() => cmdWorkspaceInvite("ws-local-code", deps()));
+
+    expect(output()).toContain("LOCAL-CODE");
+    expect(output()).not.toContain("Expires:");
+  });
+
+  test("invite exits on hub errors and missing join codes", async () => {
+    workspaces.set("ws-fail", workspace("ws-fail"));
+    curlStubs = [{ match: /status/, response: { ok: false, status: 502, data: { error: "hub down" } } }];
+
+    await run(() => cmdWorkspaceInvite("ws-fail", deps()));
+    expect(exitCode).toBe(1);
+    expect(output()).toContain("failed to fetch invite info: hub down");
+
+    exitCode = undefined;
+    errors = [];
+    curlStubs = [{ match: /status/, response: { ok: true, data: {} } }];
+    await run(() => cmdWorkspaceInvite("ws-fail", deps()));
+    expect(exitCode).toBe(1);
+    expect(output()).toContain("no join code available");
+  });
+
+  test("status renders empty workspace state without network calls", async () => {
+    await run(() => cmdWorkspaceStatus(deps()));
+
+    expect(output()).toContain("No workspaces configured");
+    expect(curlCalls).toEqual([]);
+  });
+
+  test("status updates connected workspaces and renders singular agent/node counts", async () => {
+    workspaces.set("ws-up", workspace("ws-up", { name: "up", hubUrl: "https://up.example" }));
+    curlStubs = [{ match: /up\.example/, response: { ok: true, data: { agentCount: 1, nodeCount: 1 } } }];
+
+    await run(() => cmdWorkspaceStatus(deps()));
+
+    expect(savedWorkspaces).toHaveLength(1);
+    expect(savedWorkspaces[0].lastStatus).toBe("connected");
+    expect(workspaces.get("ws-up")?.lastStatus).toBe("connected");
+    expect(output()).toContain("Workspace Status");
+    expect(output()).toContain("up");
+    expect(output()).toMatch(/1 agent\b/);
+    expect(output()).toMatch(/1 node\b/);
+    expect(output()).toContain("1/1 connected");
+  });
+
+  test("status marks non-ok and throwing workspaces disconnected while preserving total counts", async () => {
+    workspaces.set("ws-up", workspace("ws-up", { hubUrl: "https://up.example" }));
+    workspaces.set("ws-down", workspace("ws-down", { hubUrl: "https://down.example" }));
+    workspaces.set("ws-boom", workspace("ws-boom", { hubUrl: "https://boom.example" }));
+    curlStubs = [
+      { match: /up\.example/, response: { ok: true, data: { agentCount: 3, nodeCount: 2 } } },
+      { match: /down\.example/, response: { ok: false, status: 500, data: null } },
+      { match: /boom\.example/, error: "network down" },
+    ];
+
+    await run(() => cmdWorkspaceStatus(deps()));
+
+    expect(savedWorkspaces.map((ws) => [ws.id, ws.lastStatus])).toEqual([
+      ["ws-up", "connected"],
+      ["ws-down", "disconnected"],
+      ["ws-boom", "disconnected"],
+    ]);
+    expect(output()).toContain("3 agents");
+    expect(output()).toContain("2 nodes");
+    expect(output()).toContain("disconnected");
+    expect(output()).toContain("1/3 connected");
+    expect(timeoutCalls).toEqual(["workspace", "workspace", "workspace"]);
+  });
+});


### PR DESCRIPTION
## Summary
- add injectable seams for workspace query list/invite/status commands
- add default-suite tests covering workspace list rendering, invite code resolution, and status persistence
- keep the new default test free of mock.module usage

## Verification
- `bun test test/workspace-query-default.test.ts --coverage --coverage-reporter=text --timeout 60000` → `src/commands/shared/workspace-query.ts | 100.00 funcs | 100.00 lines`
- `bun test test/workspace-query-default.test.ts test/workspace-agents-default.test.ts test/workspace.test.ts --timeout 60000` → 36 pass / 0 fail
- `bash scripts/test-isolated.sh test/isolated/workspace.test.ts` → 50 pass / 0 fail
- `bun run build`
- `git diff --check`

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
