### PR TITLE
test(comm): cover maw ls session listing

### DIFF
--- a/src/commands/shared/comm-list.ts
+++ b/src/commands/shared/comm-list.ts
@@ -9,7 +9,50 @@
  * Regression test: test/isolated/cmd-list-no-new-session-957.test.ts.
  */
 
-import { listSessions, getPaneInfos, scanWorktrees, cleanupWorktree, isAgentCommand } from "../../sdk";
+import {
+  listSessions as defaultListSessions,
+  getPaneInfos as defaultGetPaneInfos,
+  scanWorktrees as defaultScanWorktrees,
+  cleanupWorktree as defaultCleanupWorktree,
+  isAgentCommand as defaultIsAgentCommand,
+} from "../../sdk";
+
+type LatestSnapshot = {
+  timestamp: string;
+  sessions: Array<{ name: string }>;
+};
+
+export interface CommListDeps {
+  listSessions?: typeof defaultListSessions;
+  getPaneInfos?: typeof defaultGetPaneInfos;
+  scanWorktrees?: typeof defaultScanWorktrees;
+  cleanupWorktree?: typeof defaultCleanupWorktree;
+  isAgentCommand?: typeof defaultIsAgentCommand;
+  latestSnapshot?: () => LatestSnapshot | null;
+  log?: Pick<Console, "log" | "error">;
+  env?: Record<string, string | undefined>;
+  now?: () => number;
+}
+
+function commListDeps(deps: CommListDeps) {
+  return {
+    listSessions: deps.listSessions ?? defaultListSessions,
+    getPaneInfos: deps.getPaneInfos ?? defaultGetPaneInfos,
+    scanWorktrees: deps.scanWorktrees ?? defaultScanWorktrees,
+    cleanupWorktree: deps.cleanupWorktree ?? defaultCleanupWorktree,
+    isAgentCommand: deps.isAgentCommand ?? defaultIsAgentCommand,
+    latestSnapshot: deps.latestSnapshot,
+    log: deps.log ?? console,
+    env: deps.env ?? process.env,
+    now: deps.now ?? Date.now,
+  };
+}
+
+async function loadLatestSnapshot(depsLatestSnapshot?: () => LatestSnapshot | null): Promise<LatestSnapshot | null> {
+  if (depsLatestSnapshot) return depsLatestSnapshot();
+  const { latestSnapshot } = await import("../../core/fleet/snapshot");
+  return latestSnapshot();
+}
 
 /**
  * #359 — render a session header line for `maw ls`.
@@ -44,8 +87,9 @@ function isViewDiag(name: string): boolean {
  *                  Threaded from the alias-dispatch path
  *                  (src/cli/top-aliases.ts → invokeDirectHandler).
  */
-export async function cmdList(opts: { fix?: boolean } = {}) {
-  const rawSessions = await listSessions();
+export async function cmdList(opts: { fix?: boolean } = {}, deps: CommListDeps = {}) {
+  const d = commListDeps(deps);
+  const rawSessions = await d.listSessions();
   const sessions = rawSessions.filter(s => !isViewDiag(s.name));
 
   // Batch-check process + cwd for each pane
@@ -53,14 +97,14 @@ export async function cmdList(opts: { fix?: boolean } = {}) {
   for (const s of sessions) {
     for (const w of s.windows) targets.push(`${s.name}:${w.index}`);
   }
-  const infos = await getPaneInfos(targets);
+  const infos = await d.getPaneInfos(targets);
 
   for (const s of sessions) {
-    console.log(renderSessionName(s.name));
+    d.log.log(renderSessionName(s.name));
     for (const w of s.windows) {
       const target = `${s.name}:${w.index}`;
       const info = infos[target] || { command: "", cwd: "" };
-      const isAgent = isAgentCommand(info.command);
+      const isAgent = d.isAgentCommand(info.command);
       const cwdBroken = info.cwd.includes("(deleted)") || info.cwd.includes("(dead)");
 
       let dot: string;
@@ -76,55 +120,54 @@ export async function cmdList(opts: { fix?: boolean } = {}) {
         dot = "\x1b[31m●\x1b[0m"; // red — dead (shell only)
         suffix = `  \x1b[90m(${info.command || "?"})\x1b[0m`;
       }
-      console.log(`  ${dot} ${w.index}: ${w.name}${suffix}`);
+      d.log.log(`  ${dot} ${w.index}: ${w.name}${suffix}`);
     }
   }
 
   // Detect orphaned worktree directories (on disk but no tmux window)
-  let orphans: Awaited<ReturnType<typeof scanWorktrees>> = [];
+  let orphans: Awaited<ReturnType<typeof defaultScanWorktrees>> = [];
   try {
-    const worktrees = await scanWorktrees();
+    const worktrees = await d.scanWorktrees();
     orphans = worktrees.filter(wt => wt.status === "stale" || wt.status === "orphan");
     if (orphans.length > 0) {
-      console.log("");
+      d.log.log("");
       for (const wt of orphans) {
         const dirName = wt.path.split("/").pop() || wt.name;
         const label = wt.status === "orphan" ? "orphaned (prunable)" : "no tmux window";
-        console.log(`  \x1b[33m⚠ orphaned:\x1b[0m ${dirName} \x1b[90m(${label})\x1b[0m`);
+        d.log.log(`  \x1b[33m⚠ orphaned:\x1b[0m ${dirName} \x1b[90m(${label})\x1b[0m`);
       }
-      console.log("");
+      d.log.log("");
       if (!opts.fix) {
-        console.log(`\x1b[90m  → maw ls --fix       to prune orphans\x1b[0m`);
+        d.log.log(`\x1b[90m  → maw ls --fix       to prune orphans\x1b[0m`);
       }
     }
   } catch (e: any) {
     // Don't crash maw ls on scan failure (non-critical) — but surface the error in debug mode
     // so silent failures have a diagnosable cause.
-    if (process.env.MAW_DEBUG) {
-      console.error(`\x1b[33m⚠ maw ls: scanWorktrees failed (non-fatal): ${e?.message || e}\x1b[0m`);
+    if (d.env.MAW_DEBUG) {
+      d.log.error(`\x1b[33m⚠ maw ls: scanWorktrees failed (non-fatal): ${e?.message || e}\x1b[0m`);
     }
   }
 
   if (sessions.length === 0 && orphans.length === 0) {
-    console.log("\x1b[90mNo active sessions.\x1b[0m");
+    d.log.log("\x1b[90mNo active sessions.\x1b[0m");
 
     try {
-      const { latestSnapshot } = await import("../../core/fleet/snapshot");
-      const snap = latestSnapshot();
+      const snap = await loadLatestSnapshot(d.latestSnapshot);
       if (snap) {
-        const ageMs = Date.now() - new Date(snap.timestamp).getTime();
+        const ageMs = d.now() - new Date(snap.timestamp).getTime();
         if (ageMs < 24 * 60 * 60 * 1000) {
           const mins = Math.round(ageMs / 60000);
           const ageStr = mins >= 60 ? `${Math.round(mins / 60)}h ago` : `${mins}m ago`;
-          console.log(`\n\x1b[36m📸\x1b[0m Last snapshot (${ageStr}):`);
-          for (const s of snap.sessions) console.log(`   \x1b[33m${s.name}\x1b[0m`);
-          console.log(`\n\x1b[90m  → maw fleet restore --all   wake all from snapshot\x1b[0m`);
+          d.log.log(`\n\x1b[36m📸\x1b[0m Last snapshot (${ageStr}):`);
+          for (const s of snap.sessions) d.log.log(`   \x1b[33m${s.name}\x1b[0m`);
+          d.log.log(`\n\x1b[90m  → maw fleet restore --all   wake all from snapshot\x1b[0m`);
         }
       }
     } catch {}
 
-    console.log("\x1b[90m  → maw bud <name>     create new oracle\x1b[0m");
-    console.log("\x1b[90m  → maw wake <name>    attach existing\x1b[0m");
+    d.log.log("\x1b[90m  → maw bud <name>     create new oracle\x1b[0m");
+    d.log.log("\x1b[90m  → maw wake <name>    attach existing\x1b[0m");
   }
 
   // --fix — prune orphans we just listed. Calls cleanupWorktree() per
@@ -132,24 +175,24 @@ export async function cmdList(opts: { fix?: boolean } = {}) {
   // matches user expectations from existing maintenance commands.
   // Read-only contract above is preserved when --fix is absent (default).
   if (opts.fix && orphans.length > 0) {
-    console.log("");
-    console.log(`\x1b[36m→ pruning ${orphans.length} orphan${orphans.length === 1 ? "" : "s"}…\x1b[0m`);
+    d.log.log("");
+    d.log.log(`\x1b[36m→ pruning ${orphans.length} orphan${orphans.length === 1 ? "" : "s"}…\x1b[0m`);
     let pruned = 0;
     for (const wt of orphans) {
       const dirName = wt.path.split("/").pop() || wt.name;
       try {
-        const log = await cleanupWorktree(wt.path);
-        console.log(`  \x1b[32m✓\x1b[0m ${dirName}`);
-        for (const line of log) console.log(`    \x1b[90m${line}\x1b[0m`);
+        const log = await d.cleanupWorktree(wt.path);
+        d.log.log(`  \x1b[32m✓\x1b[0m ${dirName}`);
+        for (const line of log) d.log.log(`    \x1b[90m${line}\x1b[0m`);
         pruned++;
       } catch (e: any) {
-        console.log(`  \x1b[31m✗\x1b[0m ${dirName} \x1b[90m(${e?.message || e})\x1b[0m`);
+        d.log.log(`  \x1b[31m✗\x1b[0m ${dirName} \x1b[90m(${e?.message || e})\x1b[0m`);
       }
     }
-    console.log("");
-    console.log(`\x1b[90m  pruned ${pruned}/${orphans.length}\x1b[0m`);
+    d.log.log("");
+    d.log.log(`\x1b[90m  pruned ${pruned}/${orphans.length}\x1b[0m`);
   } else if (opts.fix && orphans.length === 0) {
-    console.log("");
-    console.log(`\x1b[90m  → nothing to prune\x1b[0m`);
+    d.log.log("");
+    d.log.log(`\x1b[90m  → nothing to prune\x1b[0m`);
   }
 }

--- a/test/comm-list-default.test.ts
+++ b/test/comm-list-default.test.ts
@@ -1,0 +1,235 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { cmdList, renderSessionName, type CommListDeps } from "../src/commands/shared/comm-list";
+
+type Session = Awaited<ReturnType<NonNullable<CommListDeps["listSessions"]>>>[number];
+type PaneInfoMap = Awaited<ReturnType<NonNullable<CommListDeps["getPaneInfos"]>>>;
+type Worktree = Awaited<ReturnType<NonNullable<CommListDeps["scanWorktrees"]>>>[number];
+
+let sessions: Session[] = [];
+let paneInfos: PaneInfoMap = {};
+let paneTargets: string[][] = [];
+let worktrees: Worktree[] = [];
+let scanError: Error | null = null;
+let cleanupCalls: string[] = [];
+let cleanupErrors = new Map<string, Error>();
+let cleanupLogs = new Map<string, string[]>();
+let logs: string[] = [];
+let errors: string[] = [];
+let env: Record<string, string | undefined> = {};
+let snapshot: { timestamp: string; sessions: Array<{ name: string }> } | null = null;
+let snapshotThrows = false;
+let now = Date.parse("2026-05-17T12:00:00.000Z");
+
+function deps(): CommListDeps {
+  return {
+    listSessions: async () => sessions,
+    getPaneInfos: async (targets: string[]) => {
+      paneTargets.push([...targets]);
+      return paneInfos;
+    },
+    scanWorktrees: async () => {
+      if (scanError) throw scanError;
+      return worktrees;
+    },
+    cleanupWorktree: async (path: string) => {
+      cleanupCalls.push(path);
+      const error = cleanupErrors.get(path);
+      if (error) throw error;
+      return cleanupLogs.get(path) ?? [];
+    },
+    isAgentCommand: (command: string | null | undefined) => /^(claude|codex|node)$/i.test(String(command ?? "").trim()),
+    latestSnapshot: () => {
+      if (snapshotThrows) throw new Error("snapshot unavailable");
+      return snapshot;
+    },
+    log: {
+      log: (...args: unknown[]) => logs.push(args.join(" ")),
+      error: (...args: unknown[]) => errors.push(args.join(" ")),
+    },
+    env,
+    now: () => now,
+  };
+}
+
+function session(name: string, windows: Session["windows"]): Session {
+  return { name, windows };
+}
+
+function text(): string {
+  return [...logs, ...errors].join("\n").replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+describe("comm-list default-suite seams", () => {
+  beforeEach(() => {
+    sessions = [];
+    paneInfos = {};
+    paneTargets = [];
+    worktrees = [];
+    scanError = null;
+    cleanupCalls = [];
+    cleanupErrors = new Map();
+    cleanupLogs = new Map();
+    logs = [];
+    errors = [];
+    env = {};
+    snapshot = null;
+    snapshotThrows = false;
+    now = Date.parse("2026-05-17T12:00:00.000Z");
+  });
+
+  test("renderSessionName distinguishes source, suffixed view, and maw-view sessions", () => {
+    expect(renderSessionName("08-mawjs")).toBe("\x1b[36m08-mawjs\x1b[0m");
+    expect(renderSessionName("08-mawjs-view")).toBe("\x1b[90m08-mawjs-view\x1b[0m \x1b[90m[view]\x1b[0m");
+    expect(renderSessionName("maw-view")).toBe("\x1b[90mmaw-view\x1b[0m \x1b[90m[view]\x1b[0m");
+    expect(renderSessionName("preview-win")).toBe("\x1b[36mpreview-win\x1b[0m");
+  });
+
+  test("cmdList renders pane states and filters diagnostic view sessions", async () => {
+    sessions = [
+      session("08-mawjs", [
+        { index: 0, name: "active-agent", active: true },
+        { index: 1, name: "inactive-agent", active: false },
+        { index: 2, name: "shell", active: false },
+        { index: 3, name: "deleted-agent", active: true },
+        { index: 4, name: "missing-info", active: false },
+      ]),
+      session("08-mawjs-view", [{ index: 0, name: "view-pane", active: false }]),
+      session("08-mawjs-view-diag", [{ index: 0, name: "diag-pane", active: true }]),
+    ];
+    paneInfos = {
+      "08-mawjs:0": { command: "claude", cwd: "/home/nat" },
+      "08-mawjs:1": { command: "Node", cwd: "/home/nat" },
+      "08-mawjs:2": { command: "zsh", cwd: "/home/nat" },
+      "08-mawjs:3": { command: "claude", cwd: "/old/path (deleted)" },
+      "08-mawjs-view:0": { command: "zsh", cwd: "/tmp (dead)" },
+    };
+
+    await cmdList({}, deps());
+
+    expect(paneTargets).toEqual([[
+      "08-mawjs:0",
+      "08-mawjs:1",
+      "08-mawjs:2",
+      "08-mawjs:3",
+      "08-mawjs:4",
+      "08-mawjs-view:0",
+    ]]);
+    expect(logs.join("\n")).toContain("\x1b[32m●\x1b[0m");
+    expect(logs.join("\n")).toContain("\x1b[34m●\x1b[0m");
+    expect(logs.join("\n")).toContain("\x1b[31m●\x1b[0m");
+    expect(text()).toContain("(zsh)");
+    expect(text()).toContain("(path deleted)");
+    expect(text()).toContain("(?)");
+    expect(text()).toContain("[view]");
+    expect(text()).not.toContain("diag-pane");
+  });
+
+  test("orphan scan renders stale/orphan warnings and keeps default listing read-only", async () => {
+    sessions = [session("08-mawjs", [{ index: 0, name: "mawjs-oracle", active: true }])];
+    paneInfos = { "08-mawjs:0": { command: "claude", cwd: "/home/nat" } };
+    worktrees = [
+      { path: "/ghq/org/repo.wt-1-stale", status: "stale", name: "1-stale" },
+      { path: "", status: "orphan", name: "fallback-orphan" },
+      { path: "/ghq/org/repo", status: "active", name: "main" },
+    ];
+
+    await cmdList({}, deps());
+
+    expect(cleanupCalls).toEqual([]);
+    expect(text()).toContain("repo.wt-1-stale");
+    expect(text()).toContain("(no tmux window)");
+    expect(text()).toContain("fallback-orphan");
+    expect(text()).toContain("(orphaned (prunable))");
+    expect(text()).toContain("→ maw ls --fix");
+    expect(text()).not.toContain("main");
+  });
+
+  test("scan errors are silent by default and diagnostic when MAW_DEBUG is set", async () => {
+    sessions = [session("08-mawjs", [{ index: 0, name: "mawjs-oracle", active: true }])];
+    paneInfos = { "08-mawjs:0": { command: "claude", cwd: "/home/nat" } };
+    scanError = new Error("scan exploded");
+
+    await cmdList({}, deps());
+    expect(text()).toContain("mawjs-oracle");
+    expect(errors.join("\n")).not.toContain("scanWorktrees failed");
+
+    errors = [];
+    env.MAW_DEBUG = "1";
+    await cmdList({}, deps());
+    expect(errors.join("\n")).toContain("scanWorktrees failed");
+    expect(errors.join("\n")).toContain("scan exploded");
+  });
+
+  test("empty state renders recent snapshots and onboarding hints", async () => {
+    snapshot = {
+      timestamp: "2026-05-17T10:00:00.000Z",
+      sessions: [{ name: "47-mawjs" }, { name: "54-mawjs" }],
+    };
+
+    await cmdList({}, deps());
+
+    expect(text()).toContain("No active sessions.");
+    expect(text()).toContain("Last snapshot (2h ago)");
+    expect(text()).toContain("47-mawjs");
+    expect(text()).toContain("maw fleet restore --all");
+    expect(text()).toContain("maw bud <name>");
+    expect(text()).toContain("maw wake <name>");
+  });
+
+  test("empty state ignores stale or throwing snapshot lookups", async () => {
+    snapshot = {
+      timestamp: "2026-05-15T10:00:00.000Z",
+      sessions: [{ name: "old" }],
+    };
+
+    await cmdList({}, deps());
+    expect(text()).toContain("No active sessions.");
+    expect(text()).not.toContain("Last snapshot");
+
+    logs = [];
+    snapshotThrows = true;
+    await cmdList({}, deps());
+    expect(text()).toContain("No active sessions.");
+    expect(text()).not.toContain("snapshot unavailable");
+  });
+
+  test("empty state default snapshot loader remains wired for production callers", async () => {
+    const d = deps();
+    delete d.latestSnapshot;
+
+    await cmdList({}, d);
+
+    expect(text()).toContain("No active sessions.");
+    expect(text()).toContain("maw bud <name>");
+  });
+
+  test("--fix prunes all orphans, prints cleanup logs, and reports failures without stopping", async () => {
+    worktrees = [
+      { path: "/ghq/org/repo.wt-good", status: "stale", name: "good" },
+      { path: "/ghq/org/repo.wt-bad", status: "orphan", name: "bad" },
+    ];
+    cleanupLogs.set("/ghq/org/repo.wt-good", ["removed branch", "deleted dir"]);
+    cleanupErrors.set("/ghq/org/repo.wt-bad", new Error("permission denied"));
+
+    await cmdList({ fix: true }, deps());
+
+    expect(cleanupCalls).toEqual(["/ghq/org/repo.wt-good", "/ghq/org/repo.wt-bad"]);
+    expect(text()).toContain("pruning 2 orphans");
+    expect(text()).toContain("repo.wt-good");
+    expect(text()).toContain("removed branch");
+    expect(text()).toContain("permission denied");
+    expect(text()).toContain("pruned 1/2");
+    expect(text()).not.toContain("→ maw ls --fix");
+  });
+
+  test("--fix with no orphans reports nothing to prune", async () => {
+    sessions = [session("08-mawjs", [{ index: 0, name: "mawjs-oracle", active: true }])];
+    paneInfos = { "08-mawjs:0": { command: "claude", cwd: "/home/nat" } };
+    worktrees = [{ path: "/ghq/org/repo", status: "active", name: "main" }];
+
+    await cmdList({ fix: true }, deps());
+
+    expect(cleanupCalls).toEqual([]);
+    expect(text()).toContain("nothing to prune");
+  });
+});


### PR DESCRIPTION
## Summary
- add injectable seams for `maw ls` session, worktree, snapshot, and logging dependencies
- add default-suite coverage for comm-list rendering, orphan warnings, debug scan failures, snapshot hints, and `--fix` pruning
- keep the new default test free of `mock.module` usage and preserve read-only behavior unless `--fix` is explicit

## Verification
- `bun test test/comm-list-default.test.ts --coverage --coverage-reporter=text --timeout 60000` → `src/commands/shared/comm-list.ts | 100.00 funcs | 100.00 lines`
- `bun test test/comm-list-default.test.ts test/comm-send-default.test.ts test/comm-send-signing.test.ts --timeout 60000` → 31 pass / 0 fail
- `bash scripts/test-isolated.sh test/isolated/comm-list.test.ts` → 69 pass / 0 fail
- `bun run build`
- `git diff --check`

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
