### PR TITLE
test(coverage): cover route-tools default dispatch

### DIFF
--- a/src/cli/route-tools.ts
+++ b/src/cli/route-tools.ts
@@ -1,3 +1,8 @@
+import { existsSync } from "fs";
+import { join, resolve } from "path";
+import { homedir } from "os";
+import { UserError } from "../core/util/user-error";
+
 // #388.1 — core-route usage strings for --help intercept. These routes don't
 // pass through invokePlugin, so they need their own --help guard to prevent
 // `maw plugin list --help` / `maw agents --help` from running real work.
@@ -12,19 +17,161 @@ const CORE_HELP: Record<string, string> = {
   serve: "usage: maw serve [port] [--as <name>] [--force-takeover] | maw serve status|--status|stop",
 };
 
-function hasHelpFlag(args: string[]): boolean {
+type ParseFlags = (args: string[], spec: Record<string, unknown>, skip?: number) => any;
+type InvokeResult = { ok: boolean; output?: string; error?: string; exitCode?: number };
+
+type PluginLegacyTools = {
+  cmdPlugins: (sub: string, args: string[], flags: any) => Promise<void> | void;
+  parseFlags: ParseFlags;
+};
+
+type PluginLifecycleTools = {
+  loadManifestFromDir: (dir: string) => any;
+  invokePlugin: (plugin: any, ctx: { source: "cli"; args: string[] }) => Promise<InvokeResult> | InvokeResult;
+};
+
+type PathTools = {
+  resolve: (...parts: string[]) => string;
+  join: (...parts: string[]) => string;
+  existsSync: (path: string) => boolean;
+  homedir: () => string;
+  sourceDir: string;
+};
+
+type PluginCreateTools = {
+  cmdPluginCreate: (name: string | undefined, flags: any) => Promise<void> | void;
+  parseFlags: ParseFlags;
+};
+
+type ArtifactsTools = {
+  cmdArtifacts: (sub: string, args: string[], flags: any) => Promise<void> | void;
+  parseFlags: ParseFlags;
+};
+
+type AgentsTools = {
+  cmdAgents: (opts: { json?: boolean; all?: boolean; node?: string }) => Promise<void> | void;
+  parseFlags: ParseFlags;
+};
+
+type TmuxTools = {
+  tmuxHandler: (ctx: { source: "cli"; args: string[]; writer: (...a: unknown[]) => void }) => Promise<InvokeResult> | InvokeResult;
+};
+
+type ServeStatusTools = {
+  printServeStatusWithPlugins: () => Promise<void> | void;
+  stopServe: () => Promise<void> | void;
+};
+
+type ServeStartTools = {
+  acquirePidLock: (instanceName: string | null, opts: { forceTakeover: boolean }) => void;
+  startServer: (port: number) => Promise<void> | void;
+};
+
+type CoreServerTools = {
+  startServer: (port: number) => Promise<void> | void;
+};
+type CoreServerLoader = () => Promise<CoreServerTools>;
+
+export type RouteToolsDeps = {
+  log: (...a: unknown[]) => void;
+  error: (...a: unknown[]) => void;
+  stdoutWrite: (chunk: string) => void;
+  exit: (code?: number) => never;
+  paths: PathTools;
+  loadPluginLegacyTools: () => Promise<PluginLegacyTools>;
+  loadPluginLifecycleTools: () => Promise<PluginLifecycleTools>;
+  loadPluginCreateTools: () => Promise<PluginCreateTools>;
+  loadArtifactsTools: () => Promise<ArtifactsTools>;
+  loadAgentsTools: () => Promise<AgentsTools>;
+  loadAuditTools: () => Promise<{ cmdAudit: (args: string[]) => Promise<void> | void }>;
+  loadTmuxTools: () => Promise<TmuxTools>;
+  loadServeStatusTools: () => Promise<ServeStatusTools>;
+  loadServeStartTools: () => Promise<ServeStartTools>;
+};
+
+export function createDefaultRouteToolsDeps(loadCoreServer?: CoreServerLoader): RouteToolsDeps {
+  return {
+    log: (...a: unknown[]) => console.log(...a),
+    error: (...a: unknown[]) => console.error(...a),
+    stdoutWrite: (chunk: string) => { process.stdout.write(chunk); },
+    exit: (code?: number) => process.exit(code),
+    paths: { resolve, join, existsSync, homedir, sourceDir: import.meta.dir },
+    loadPluginLegacyTools: async () => {
+      const [{ cmdPlugins }, { parseFlags }] = await Promise.all([
+        import("../commands/shared/plugins"),
+        import("./parse-args"),
+      ]);
+      return { cmdPlugins, parseFlags };
+    },
+    loadPluginLifecycleTools: async () => {
+      const [{ loadManifestFromDir }, { invokePlugin }] = await Promise.all([
+        import("../plugin/manifest"),
+        import("../plugin/registry"),
+      ]);
+      return { loadManifestFromDir, invokePlugin };
+    },
+    loadPluginCreateTools: async () => {
+      const [{ cmdPluginCreate }, { parseFlags }] = await Promise.all([
+        import("../commands/shared/plugin-create"),
+        import("./parse-args"),
+      ]);
+      return { cmdPluginCreate, parseFlags };
+    },
+    loadArtifactsTools: async () => {
+      const [{ cmdArtifacts }, { parseFlags }] = await Promise.all([
+        import("../commands/shared/artifacts"),
+        import("./parse-args"),
+      ]);
+      return { cmdArtifacts, parseFlags };
+    },
+    loadAgentsTools: async () => {
+      const [{ cmdAgents }, { parseFlags }] = await Promise.all([
+        import("../commands/shared/agents"),
+        import("./parse-args"),
+      ]);
+      return { cmdAgents, parseFlags };
+    },
+    loadAuditTools: async () => {
+      const { cmdAudit } = await import("../commands/shared/audit");
+      return { cmdAudit };
+    },
+    loadTmuxTools: async () => {
+      const { default: tmuxHandler } = await import("../commands/plugins/tmux/index");
+      return { tmuxHandler };
+    },
+    loadServeStatusTools: async () => {
+      const { printServeStatusWithPlugins, stopServe } = await import("./instance-pid");
+      return { printServeStatusWithPlugins, stopServe };
+    },
+    loadServeStartTools: async () => {
+      const { acquirePidLock } = await import("./instance-pid");
+      return {
+        acquirePidLock,
+        startServer: async (port: number) => {
+          const { startServer } = loadCoreServer ? await loadCoreServer() : await import("../core/server");
+          await startServer(port);
+        },
+      };
+    },
+  };
+}
+
+export function hasHelpFlag(args: string[]): boolean {
   return args.some(a => a === "--help" || a === "-h");
 }
 
 export async function routeTools(cmd: string, args: string[]): Promise<boolean> {
+  return routeToolsWithDeps(cmd, args, createDefaultRouteToolsDeps());
+}
+
+export async function routeToolsWithDeps(cmd: string, args: string[], deps: RouteToolsDeps): Promise<boolean> {
   // Short-circuit --help for core routes — prints usage and does NO work.
   if (CORE_HELP[cmd] && hasHelpFlag(args.slice(1))) {
-    console.log(CORE_HELP[cmd]);
+    deps.log(CORE_HELP[cmd]);
     return true;
   }
   if (cmd === "plugins") {
-    const { cmdPlugins } = await import("../commands/shared/plugins");
-    const { parseFlags } = await import("./parse-args");
+    const { cmdPlugins, parseFlags } = await deps.loadPluginLegacyTools();
     const sub = args[1] ?? "ls";
     const flags = parseFlags(args, { "--json": Boolean, "--force": Boolean, "--all": Boolean }, 2);
     await cmdPlugins(sub, args.slice(2), flags);
@@ -36,18 +183,15 @@ export async function routeTools(cmd: string, args: string[]): Promise<boolean> 
     // forward to the plugin-lifecycle plugin (marketplace pipeline).
     const lifecycleSubs = new Set(["init", "build", "install", "search", "registry", "pin", "unpin", "dev"]);
     if (sub && lifecycleSubs.has(sub)) {
-      const { loadManifestFromDir } = await import("../plugin/manifest");
-      const { invokePlugin } = await import("../plugin/registry");
-      const { resolve, join } = await import("path");
-      const { existsSync } = await import("fs");
-      const { homedir } = await import("os");
+      const { loadManifestFromDir, invokePlugin } = await deps.loadPluginLifecycleTools();
+      const { resolve, join, existsSync, homedir, sourceDir } = deps.paths;
       // #853 — `import.meta.dir` resolves to the source tree in dev but to
       // `~/.local/bin/` in the bundled binary, where there's no
       // commands/plugins/ subtree. Try the dev path first, then fall back to
       // the bootstrapped symlink at ~/.maw/plugins/plugin (populated by
       // runBootstrap on every CLI start).
       const candidates = [
-        resolve(import.meta.dir, "..", "commands", "plugins", "plugin"),
+        resolve(sourceDir, "..", "commands", "plugins", "plugin"),
         join(homedir(), ".maw", "plugins", "plugin"),
       ];
       const pluginDir = candidates.find(p => existsSync(join(p, "plugin.json")));
@@ -55,9 +199,9 @@ export async function routeTools(cmd: string, args: string[]): Promise<boolean> 
         const loaded = loadManifestFromDir(pluginDir);
         if (loaded) {
           const result = await invokePlugin(loaded, { source: "cli", args: args.slice(1) });
-          if (result.ok && result.output) console.log(result.output);
-          if (!result.ok && result.error) console.error(result.error);
-          if (!result.ok) process.exit(1);
+          if (result.ok && result.output) deps.log(result.output);
+          if (!result.ok && result.error) deps.error(result.error);
+          if (!result.ok) deps.exit(1);
           return true;
         }
       }
@@ -66,15 +210,13 @@ export async function routeTools(cmd: string, args: string[]): Promise<boolean> 
     // `install` is NOT in this list anymore — it's handled above by the new
     // install-impl.ts via the plugin dispatcher.
     if (sub && ["ls", "list", "info", "remove", "uninstall", "rm", "lean", "standard", "full", "nuke", "enable", "disable"].includes(sub)) {
-      const { cmdPlugins } = await import("../commands/shared/plugins");
-      const { parseFlags } = await import("./parse-args");
+      const { cmdPlugins, parseFlags } = await deps.loadPluginLegacyTools();
       const flags = parseFlags(args, { "--json": Boolean, "--force": Boolean, "--all": Boolean }, 2);
       await cmdPlugins(sub, args.slice(2), flags);
       return true;
     }
     if (sub === "create") {
-      const { cmdPluginCreate } = await import("../commands/shared/plugin-create");
-      const { parseFlags } = await import("./parse-args");
+      const { cmdPluginCreate, parseFlags } = await deps.loadPluginCreateTools();
       const flags = parseFlags(args, {
         "--rust": Boolean,
         "--as": Boolean,
@@ -83,35 +225,33 @@ export async function routeTools(cmd: string, args: string[]): Promise<boolean> 
       }, 2);
       await cmdPluginCreate(flags._[0], flags);
     } else {
-      console.error("usage: maw plugin create [--rust | --as] <name> [--here]");
-      process.exit(1);
+      deps.error("usage: maw plugin create [--rust | --as] <name> [--here]");
+      deps.exit(1);
     }
     return true;
   }
   if (cmd === "artifacts" || cmd === "artifact") {
-    const { cmdArtifacts } = await import("../commands/shared/artifacts");
-    const { parseFlags } = await import("./parse-args");
+    const { cmdArtifacts, parseFlags } = await deps.loadArtifactsTools();
     const sub = args[1] ?? "ls";
     const flags = parseFlags(args, { "--json": Boolean }, 2);
     await cmdArtifacts(sub, args.slice(2), flags);
     return true;
   }
   if (cmd === "agents" || cmd === "agent") {
-    const { cmdAgents } = await import("../commands/shared/agents");
-    const { parseFlags } = await import("./parse-args");
+    const { cmdAgents, parseFlags } = await deps.loadAgentsTools();
     const flags = parseFlags(args, { "--json": Boolean, "--all": Boolean, "--node": String }, 1);
     await cmdAgents({ json: flags["--json"], all: flags["--all"], node: flags["--node"] });
     return true;
   }
   if (cmd === "audit") {
-    const { cmdAudit } = await import("../commands/shared/audit");
+    const { cmdAudit } = await deps.loadAuditTools();
     await cmdAudit(args.slice(1));
     return true;
   }
   if (cmd === "tmux") {
     // #1459 — route the tmux command through its handler directly, with a
     // CLI InvokeContext so output streams to process.stdout.
-    const { default: tmuxHandler } = await import("../commands/plugins/tmux/index");
+    const { tmuxHandler } = await deps.loadTmuxTools();
     const result = await tmuxHandler({
       source: "cli",
       args: args.slice(1),
@@ -120,12 +260,12 @@ export async function routeTools(cmd: string, args: string[]): Promise<boolean> 
       // writer that calls console.log re-enters that wrapper and recurses
       // until "Maximum call stack size exceeded" (#1459).
       writer: (...a: unknown[]) => {
-        process.stdout.write(`${a.map(String).join(" ")}\n`);
+        deps.stdoutWrite(`${a.map(String).join(" ")}\n`);
       },
     });
     if (!result.ok) {
-      if (result.error) console.error(result.error);
-      process.exit(result.exitCode ?? 1);
+      if (result.error) deps.error(result.error);
+      deps.exit(result.exitCode ?? 1);
     }
     return true;
   }
@@ -143,9 +283,9 @@ export async function routeTools(cmd: string, args: string[]): Promise<boolean> 
       : withoutAs.filter(a => a !== "--force-takeover");
     const sub = filteredArgs[0] === "--status" ? "status" : filteredArgs[0];
     if (sub === "status" || sub === "stop") {
-      const { printServeStatusWithPlugins, stopServe } = await import("./instance-pid");
+      const { printServeStatusWithPlugins, stopServe } = await deps.loadServeStatusTools();
       if (sub === "status") await printServeStatusWithPlugins();
-      else stopServe();
+      else await stopServe();
       return true;
     }
     // Reject unknown flags BEFORE starting the server — alpha.72 gate already
@@ -154,18 +294,16 @@ export async function routeTools(cmd: string, args: string[]): Promise<boolean> 
     // duplicate server (integration-tester iter 13 recon).
     const unknownFlag = filteredArgs.find(a => a.startsWith("-"));
     if (unknownFlag) {
-      const { UserError } = await import("../core/util/user-error");
-      console.error(`\x1b[31m✗\x1b[0m unknown flag '${unknownFlag}' for 'maw serve'`);
-      console.error(`  usage: maw serve [port] [--as <name>] [--force-takeover]  (run 'maw serve --help' for more)`);
+      deps.error(`\x1b[31m✗\x1b[0m unknown flag '${unknownFlag}' for 'maw serve'`);
+      deps.error(`  usage: maw serve [port] [--as <name>] [--force-takeover]  (run 'maw serve --help' for more)`);
       throw new UserError(`unknown flag '${unknownFlag}'`);
     }
     const portArg = filteredArgs.find(a => /^\d+$/.test(a));
     // PID handshake (#566) — refuse if another maw serve is already running
     // under the same MAW_HOME.
-    const { acquirePidLock } = await import("./instance-pid");
+    const { acquirePidLock, startServer } = await deps.loadServeStartTools();
     const instanceName = asIdx === -1 ? null : serveArgs[asIdx + 1];
     acquirePidLock(instanceName, { forceTakeover: forceIdx !== -1 });
-    const { startServer } = await import("../core/server");
     await startServer(portArg ? +portArg : 3456);
     return true;
   }

--- a/test/route-tools-default.test.ts
+++ b/test/route-tools-default.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, test } from "bun:test";
+import { UserError } from "../src/core/util/user-error";
+import { createDefaultRouteToolsDeps, hasHelpFlag, routeTools, routeToolsWithDeps, type RouteToolsDeps } from "../src/cli/route-tools";
+
+function parseFlags(args: string[], spec: Record<string, unknown>, skip = 0): any {
+  const out: any = { _: [] as string[] };
+  const argv = args.slice(skip);
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const kind = spec[arg];
+    if (kind === Boolean) out[arg] = true;
+    else if (kind === String) out[arg] = argv[++i];
+    else out._.push(arg);
+  }
+  return out;
+}
+
+type HarnessOptions = {
+  lifecycleExists?: "dev" | "home" | "none";
+  lifecycleManifest?: any;
+  lifecycleResult?: { ok: boolean; output?: string; error?: string; exitCode?: number };
+  tmuxResult?: { ok: boolean; output?: string; error?: string; exitCode?: number };
+};
+
+function harness(options: HarnessOptions = {}) {
+  const calls = {
+    logs: [] as string[],
+    errors: [] as string[],
+    stdout: [] as string[],
+    exits: [] as number[],
+    plugins: [] as any[],
+    manifests: [] as string[],
+    invokes: [] as any[],
+    creates: [] as any[],
+    artifacts: [] as any[],
+    agents: [] as any[],
+    audits: [] as any[],
+    tmux: [] as any[],
+    status: 0,
+    stop: 0,
+    locks: [] as any[],
+    servers: [] as number[],
+    exists: [] as string[],
+  };
+
+  const deps: RouteToolsDeps = {
+    log: (...a) => calls.logs.push(a.map(String).join(" ")),
+    error: (...a) => calls.errors.push(a.map(String).join(" ")),
+    stdoutWrite: (chunk) => { calls.stdout.push(chunk); },
+    exit: (code = 0) => {
+      calls.exits.push(code);
+      throw new Error(`exit:${code}`);
+    },
+    paths: {
+      sourceDir: "/src/cli",
+      resolve: (...parts) => parts.join("/"),
+      join: (...parts) => parts.join("/"),
+      homedir: () => "/home/test",
+      existsSync: (path) => {
+        calls.exists.push(path);
+        if (options.lifecycleExists === "dev") return path.includes("commands/plugins/plugin/plugin.json");
+        if (options.lifecycleExists === "home") return path.includes(".maw/plugins/plugin/plugin.json");
+        return false;
+      },
+    },
+    loadPluginLegacyTools: async () => ({
+      parseFlags,
+      cmdPlugins: (sub, args, flags) => { calls.plugins.push({ sub, args, flags }); },
+    }),
+    loadPluginLifecycleTools: async () => ({
+      loadManifestFromDir: (dir) => {
+        calls.manifests.push(dir);
+        return options.lifecycleManifest === undefined ? { manifest: { name: "plugin" } } : options.lifecycleManifest;
+      },
+      invokePlugin: async (plugin, ctx) => {
+        calls.invokes.push({ plugin, ctx });
+        return options.lifecycleResult ?? { ok: true, output: "lifecycle ok" };
+      },
+    }),
+    loadPluginCreateTools: async () => ({
+      parseFlags,
+      cmdPluginCreate: (name, flags) => { calls.creates.push({ name, flags }); },
+    }),
+    loadArtifactsTools: async () => ({
+      parseFlags,
+      cmdArtifacts: (sub, args, flags) => { calls.artifacts.push({ sub, args, flags }); },
+    }),
+    loadAgentsTools: async () => ({
+      parseFlags,
+      cmdAgents: (opts) => { calls.agents.push(opts); },
+    }),
+    loadAuditTools: async () => ({
+      cmdAudit: (args) => { calls.audits.push(args); },
+    }),
+    loadTmuxTools: async () => ({
+      tmuxHandler: async (ctx) => {
+        calls.tmux.push(ctx);
+        ctx.writer("tmux", "stream");
+        return options.tmuxResult ?? { ok: true };
+      },
+    }),
+    loadServeStatusTools: async () => ({
+      printServeStatusWithPlugins: () => { calls.status++; },
+      stopServe: () => { calls.stop++; },
+    }),
+    loadServeStartTools: async () => ({
+      acquirePidLock: (instanceName, opts) => { calls.locks.push({ instanceName, opts }); },
+      startServer: (port) => { calls.servers.push(port); },
+    }),
+  };
+
+  return { calls, deps };
+}
+
+describe("routeTools default-suite seams", () => {
+
+  test("default dependency loader factory stays wired to production modules", async () => {
+    const original = {
+      log: console.log,
+      error: console.error,
+      write: process.stdout.write,
+      errWrite: process.stderr.write,
+      exit: process.exit,
+    };
+    const seen = { logs: [] as string[], errors: [] as string[], writes: [] as string[], errWrites: [] as string[], exits: [] as number[] };
+    console.log = (...a: unknown[]) => { seen.logs.push(a.map(String).join(" ")); };
+    console.error = (...a: unknown[]) => { seen.errors.push(a.map(String).join(" ")); };
+    process.stdout.write = ((chunk: unknown) => { seen.writes.push(String(chunk)); return true; }) as typeof process.stdout.write;
+    process.stderr.write = ((chunk: unknown) => { seen.errWrites.push(String(chunk)); return true; }) as typeof process.stderr.write;
+    (process as any).exit = (code?: number) => {
+      seen.exits.push(code ?? 0);
+      throw new Error(`default-exit:${code ?? 0}`);
+    };
+
+    try {
+      const serverStarts: number[] = [];
+      const deps = createDefaultRouteToolsDeps(async () => ({
+        startServer: (port) => { serverStarts.push(port); },
+      }));
+      deps.log("hello", "log");
+      deps.error("hello", "err");
+      deps.stdoutWrite("hello write");
+      expect(() => deps.exit(42)).toThrow("default-exit:42");
+      expect(seen).toMatchObject({
+        logs: ["hello log"],
+        errors: ["hello err"],
+        writes: ["hello write"],
+        exits: [42],
+      });
+
+      expect(typeof deps.paths.resolve).toBe("function");
+      expect(typeof deps.paths.join).toBe("function");
+      expect(typeof deps.paths.existsSync).toBe("function");
+      expect(typeof deps.paths.homedir).toBe("function");
+      expect(deps.paths.sourceDir).toContain("src/cli");
+
+      expect(typeof (await deps.loadPluginLegacyTools()).cmdPlugins).toBe("function");
+      expect(typeof (await deps.loadPluginLifecycleTools()).invokePlugin).toBe("function");
+      expect(typeof (await deps.loadPluginCreateTools()).cmdPluginCreate).toBe("function");
+      expect(typeof (await deps.loadArtifactsTools()).cmdArtifacts).toBe("function");
+      expect(typeof (await deps.loadAgentsTools()).cmdAgents).toBe("function");
+      expect(typeof (await deps.loadAuditTools()).cmdAudit).toBe("function");
+      expect(typeof (await deps.loadTmuxTools()).tmuxHandler).toBe("function");
+      expect(typeof (await deps.loadServeStatusTools()).stopServe).toBe("function");
+      const serveStart = await deps.loadServeStartTools();
+      expect(typeof serveStart.startServer).toBe("function");
+      await serveStart.startServer(6789);
+      expect(serverStarts).toEqual([6789]);
+    } finally {
+      console.log = original.log;
+      console.error = original.error;
+      process.stdout.write = original.write;
+      process.stderr.write = original.errWrite;
+      (process as any).exit = original.exit;
+    }
+  });
+  test("help detection short-circuits core routes and misses unknown commands", async () => {
+    const h = harness();
+    expect(hasHelpFlag(["-h"])).toBe(true);
+    expect(hasHelpFlag(["--help"])).toBe(true);
+    expect(hasHelpFlag(["--json"])).toBe(false);
+
+    expect(await routeToolsWithDeps("plugins", ["plugins", "--help"], h.deps)).toBe(true);
+    expect(h.calls.logs.join("\n")).toContain("usage: maw plugins");
+    expect(h.calls.plugins).toEqual([]);
+
+    expect(await routeTools("definitely-not-a-route", ["definitely-not-a-route"])).toBe(false);
+    expect(await routeToolsWithDeps("definitely-not-a-route", ["definitely-not-a-route"], h.deps)).toBe(false);
+  });
+
+  test("routes plugins, artifacts, agents, and audit through injected handlers", async () => {
+    const h = harness();
+
+    expect(await routeToolsWithDeps("plugins", ["plugins", "info", "about", "--json"], h.deps)).toBe(true);
+    expect(h.calls.plugins[0]).toMatchObject({ sub: "info", args: ["about", "--json"], flags: { "--json": true } });
+
+    expect(await routeToolsWithDeps("plugin", ["plugin", "ls", "--all"], h.deps)).toBe(true);
+    expect(h.calls.plugins[1]).toMatchObject({ sub: "ls", args: ["--all"], flags: { "--all": true } });
+
+    expect(await routeToolsWithDeps("artifact", ["artifact", "get", "team", "task-1", "--json"], h.deps)).toBe(true);
+    expect(h.calls.artifacts[0]).toMatchObject({ sub: "get", args: ["team", "task-1", "--json"], flags: { "--json": true } });
+
+    expect(await routeToolsWithDeps("agents", ["agents", "--json", "--all", "--node", "m5"], h.deps)).toBe(true);
+    expect(h.calls.agents[0]).toEqual({ json: true, all: true, node: "m5" });
+
+    expect(await routeToolsWithDeps("audit", ["audit", "5"], h.deps)).toBe(true);
+    expect(h.calls.audits).toEqual([["5"]]);
+  });
+
+  test("plugin lifecycle dispatch uses dev/home candidates, logs output, and fails loudly", async () => {
+    const dev = harness({ lifecycleExists: "dev" });
+    expect(await routeToolsWithDeps("plugin", ["plugin", "install", "demo"], dev.deps)).toBe(true);
+    expect(dev.calls.manifests[0]).toContain("commands/plugins/plugin");
+    expect(dev.calls.invokes[0].ctx.args).toEqual(["install", "demo"]);
+    expect(dev.calls.logs).toContain("lifecycle ok");
+
+    const home = harness({ lifecycleExists: "home", lifecycleResult: { ok: true } });
+    expect(await routeToolsWithDeps("plugin", ["plugin", "search", "demo"], home.deps)).toBe(true);
+    expect(home.calls.manifests[0]).toContain(".maw/plugins/plugin");
+    expect(home.calls.logs).toEqual([]);
+
+    const failing = harness({ lifecycleExists: "dev", lifecycleResult: { ok: false, error: "install exploded", exitCode: 9 } });
+    await expect(routeToolsWithDeps("plugin", ["plugin", "build"], failing.deps)).rejects.toThrow("exit:1");
+    expect(failing.calls.errors).toContain("install exploded");
+    expect(failing.calls.exits).toEqual([1]);
+
+    const missing = harness({ lifecycleExists: "none" });
+    await expect(routeToolsWithDeps("plugin", ["plugin", "install"], missing.deps)).rejects.toThrow("exit:1");
+    expect(missing.calls.errors.join("\n")).toContain("usage: maw plugin create");
+
+    const nullManifest = harness({ lifecycleExists: "dev", lifecycleManifest: null });
+    await expect(routeToolsWithDeps("plugin", ["plugin", "dev"], nullManifest.deps)).rejects.toThrow("exit:1");
+    expect(nullManifest.calls.manifests).toHaveLength(1);
+  });
+
+  test("plugin create and invalid plugin subcommands keep the legacy CLI contract", async () => {
+    const create = harness();
+    expect(await routeToolsWithDeps("plugin", ["plugin", "create", "ledger", "--rust", "--dest", "/tmp/ledger"], create.deps)).toBe(true);
+    expect(create.calls.creates[0]).toMatchObject({
+      name: "ledger",
+      flags: { _: ["ledger"], "--rust": true, "--dest": "/tmp/ledger" },
+    });
+
+    const invalid = harness();
+    await expect(routeToolsWithDeps("plugin", ["plugin", "wat"], invalid.deps)).rejects.toThrow("exit:1");
+    expect(invalid.calls.errors.join("\n")).toContain("usage: maw plugin create");
+  });
+
+  test("tmux streams through stdout writer and exits on handler errors", async () => {
+    const ok = harness();
+    expect(await routeToolsWithDeps("tmux", ["tmux", "peek", "47-mawjs:1.0"], ok.deps)).toBe(true);
+    expect(ok.calls.tmux[0].args).toEqual(["peek", "47-mawjs:1.0"]);
+    expect(ok.calls.stdout.join("")).toContain("tmux stream");
+
+    const fail = harness({ tmuxResult: { ok: false, error: "tmux failed", exitCode: 7 } });
+    await expect(routeToolsWithDeps("tmux", ["tmux", "send", "pane", "cmd"], fail.deps)).rejects.toThrow("exit:7");
+    expect(fail.calls.errors).toContain("tmux failed");
+    expect(fail.calls.exits).toEqual([7]);
+  });
+
+  test("serve status/stop/start/default-port and unknown-flag paths stay side-effect bounded", async () => {
+    const status = harness();
+    expect(await routeToolsWithDeps("serve", ["serve", "--status"], status.deps)).toBe(true);
+    expect(status.calls.status).toBe(1);
+    expect(status.calls.servers).toEqual([]);
+
+    const stop = harness();
+    expect(await routeToolsWithDeps("serve", ["serve", "stop"], stop.deps)).toBe(true);
+    expect(stop.calls.stop).toBe(1);
+
+    const start = harness();
+    expect(await routeToolsWithDeps("serve", ["serve", "4567", "--as", "blue", "--force-takeover"], start.deps)).toBe(true);
+    expect(start.calls.locks).toEqual([{ instanceName: "blue", opts: { forceTakeover: true } }]);
+    expect(start.calls.servers).toEqual([4567]);
+
+    const defaultPort = harness();
+    expect(await routeToolsWithDeps("serve", ["serve"], defaultPort.deps)).toBe(true);
+    expect(defaultPort.calls.locks).toEqual([{ instanceName: null, opts: { forceTakeover: false } }]);
+    expect(defaultPort.calls.servers).toEqual([3456]);
+
+    const bad = harness();
+    await expect(routeToolsWithDeps("serve", ["serve", "--as", "blue", "--force-takeover", "--bogus"], bad.deps)).rejects.toBeInstanceOf(UserError);
+    expect(bad.calls.errors.join("\n")).toContain("unknown flag '--bogus'");
+    expect(bad.calls.locks).toEqual([]);
+    expect(bad.calls.servers).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- extract a small dependency seam for `src/cli/route-tools.ts` while keeping production `routeTools()` behavior delegated through the default loader
- add default-suite coverage for core route help, plugin lifecycle routing, plugin create, artifacts, agents, audit, tmux writer/error behavior, and serve status/stop/start/unknown-flag paths
- raise `src/cli/route-tools.ts` to 100% lines/functions in the bounded coverage run

## Verification
- `bun test test/route-tools-default.test.ts --coverage --coverage-reporter=text --timeout 60000`
  - `src/cli/route-tools.ts | 100.00 funcs | 100.00 lines`
- `grep -R "mock\.module" test/route-tools-default.test.ts || true`
- `bun test test/route-tools-default.test.ts test/dispatch-direct.test.ts test/cli/dispatch-match.test.ts test/plugins-cli.test.ts --timeout 60000`
- `bash scripts/test-isolated.sh test/isolated/tmux-route-tools.test.ts`
- `bun run build`
- `git diff --check`

## Notes
Alpha-only coverage work for #1611. No release cut.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
