### PR TITLE
test(coverage): cover small API routers

### DIFF
--- a/src/api/asks.ts
+++ b/src/api/asks.ts
@@ -4,24 +4,42 @@ import { join } from "path";
 
 const asksPath = join(import.meta.dir, "../../asks.json");
 
-export const asksApi = new Elysia();
+export interface AsksApiDeps {
+  asksPath: string;
+  existsSync: typeof existsSync;
+  readFileSync: typeof readFileSync;
+  writeFileSync: typeof writeFileSync;
+}
 
-asksApi.get("/asks", () => {
-  try {
-    if (!existsSync(asksPath)) return [];
-    return JSON.parse(readFileSync(asksPath, "utf-8"));
-  } catch {
-    return [];
-  }
-});
+export function createAsksApi(deps: AsksApiDeps = {
+  asksPath,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+}) {
+  const api = new Elysia();
 
-asksApi.post("/asks", async ({ body, set}) => {
-  try {
-    writeFileSync(asksPath, JSON.stringify(body, null, 2), "utf-8");
-    return { ok: true };
-  } catch (e: any) {
-    set.status = 400; return { error: e.message };
-  }
-}, {
-  body: t.Unknown(),
-});
+  api.get("/asks", () => {
+    try {
+      if (!deps.existsSync(deps.asksPath)) return [];
+      return JSON.parse(deps.readFileSync(deps.asksPath, "utf-8") as string);
+    } catch {
+      return [];
+    }
+  });
+
+  api.post("/asks", async ({ body, set}) => {
+    try {
+      deps.writeFileSync(deps.asksPath, JSON.stringify(body, null, 2), "utf-8");
+      return { ok: true };
+    } catch (e: any) {
+      set.status = 400; return { error: e.message };
+    }
+  }, {
+    body: t.Unknown(),
+  });
+
+  return api;
+}
+
+export const asksApi = createAsksApi();

--- a/src/api/fleet.ts
+++ b/src/api/fleet.ts
@@ -3,17 +3,35 @@ import { readdirSync, readFileSync } from "fs";
 import { join } from "path";
 import { FLEET_DIR as fleetDir } from "../core/paths";
 
-export const fleetApi = new Elysia();
+export interface FleetApiDeps {
+  fleetDir: string;
+  readdirSync: typeof readdirSync;
+  readFileSync: typeof readFileSync;
+  join: typeof join;
+}
+
+export function createFleetApi(deps: FleetApiDeps = {
+  fleetDir,
+  readdirSync,
+  readFileSync,
+  join,
+}) {
+  const api = new Elysia();
 
 // PUBLIC FEDERATION API (v1) — no auth. Shape is load-bearing for lens
 // clients that compute lineage by inverting `budded_from`.
 // See docs/federation.md before changing fields.
-fleetApi.get("/fleet-config", () => {
-  try {
-    const files = readdirSync(fleetDir).filter(f => f.endsWith(".json") && !f.endsWith(".disabled"));
-    const configs = files.map(f => JSON.parse(readFileSync(join(fleetDir, f), "utf-8")));
-    return { configs };
-  } catch (e: any) {
-    return { configs: [], error: e.message };
-  }
-});
+  api.get("/fleet-config", () => {
+    try {
+      const files = deps.readdirSync(deps.fleetDir).filter(f => f.endsWith(".json") && !f.endsWith(".disabled"));
+      const configs = files.map(f => JSON.parse(deps.readFileSync(deps.join(deps.fleetDir, f), "utf-8") as string));
+      return { configs };
+    } catch (e: any) {
+      return { configs: [], error: e.message };
+    }
+  });
+
+  return api;
+}
+
+export const fleetApi = createFleetApi();

--- a/src/api/worktrees.ts
+++ b/src/api/worktrees.ts
@@ -1,25 +1,39 @@
 import { Elysia, t} from "elysia";
 import { scanWorktrees, cleanupWorktree } from "../core/fleet/worktrees";
 
-export const worktreesApi = new Elysia();
+export interface WorktreesApiDeps {
+  scanWorktrees: typeof scanWorktrees;
+  cleanupWorktree: typeof cleanupWorktree;
+}
 
-worktreesApi.get("/worktrees", async ({ set }) => {
-  try {
-    return await scanWorktrees();
-  } catch (e: any) {
-    set.status = 500; return { error: e.message };
-  }
-});
+export function createWorktreesApi(deps: WorktreesApiDeps = {
+  scanWorktrees,
+  cleanupWorktree,
+}) {
+  const api = new Elysia();
 
-worktreesApi.post("/worktrees/cleanup", async ({ body, set}) => {
-  const { path } = body;
-  if (!path) { set.status = 400; return { error: "path required" }; }
-  try {
-    const log = await cleanupWorktree(path);
-    return { ok: true, log };
-  } catch (e: any) {
-    set.status = 500; return { error: e.message };
-  }
-}, {
-  body: t.Object({ path: t.String() }),
-});
+  api.get("/worktrees", async ({ set }) => {
+    try {
+      return await deps.scanWorktrees();
+    } catch (e: any) {
+      set.status = 500; return { error: e.message };
+    }
+  });
+
+  api.post("/worktrees/cleanup", async ({ body, set}) => {
+    const { path } = body;
+    if (!path) { set.status = 400; return { error: "path required" }; }
+    try {
+      const log = await deps.cleanupWorktree(path);
+      return { ok: true, log };
+    } catch (e: any) {
+      set.status = 500; return { error: e.message };
+    }
+  }, {
+    body: t.Object({ path: t.String() }),
+  });
+
+  return api;
+}
+
+export const worktreesApi = createWorktreesApi();

--- a/test/api-small-default.test.ts
+++ b/test/api-small-default.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, test } from "bun:test";
+import { Elysia } from "elysia";
+import { createAsksApi } from "../src/api/asks";
+import { createFleetApi } from "../src/api/fleet";
+import { createWorktreesApi } from "../src/api/worktrees";
+
+async function json(res: Response): Promise<any> {
+  return await res.json();
+}
+
+function apiWith(plugin: Elysia) {
+  return new Elysia({ prefix: "/api" }).use(plugin);
+}
+
+describe("small API routers default-suite coverage", () => {
+  test("worktrees API returns scanned rows and cleanup logs", async () => {
+    const calls: string[] = [];
+    const app = apiWith(createWorktreesApi({
+      async scanWorktrees() {
+        calls.push("scan");
+        return [{
+          path: "/repo/.wt-demo",
+          branch: "codex/demo",
+          repo: "Soul-Brews-Studio/maw-js.wt-demo",
+          mainRepo: "Soul-Brews-Studio/maw-js",
+          name: "demo",
+          status: "active",
+          tmuxWindow: "mawjs-demo",
+        }];
+      },
+      async cleanupWorktree(path) {
+        calls.push(`cleanup:${path}`);
+        return [`removed ${path}`];
+      },
+    }));
+
+    const list = await app.handle(new Request("http://local/api/worktrees"));
+    expect(list.status).toBe(200);
+    expect(await json(list)).toEqual([{
+      path: "/repo/.wt-demo",
+      branch: "codex/demo",
+      repo: "Soul-Brews-Studio/maw-js.wt-demo",
+      mainRepo: "Soul-Brews-Studio/maw-js",
+      name: "demo",
+      status: "active",
+      tmuxWindow: "mawjs-demo",
+    }]);
+
+    const cleanup = await app.handle(new Request("http://local/api/worktrees/cleanup", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ path: "/repo/.wt-demo" }),
+    }));
+    expect(cleanup.status).toBe(200);
+    expect(await json(cleanup)).toEqual({ ok: true, log: ["removed /repo/.wt-demo"] });
+    expect(calls).toEqual(["scan", "cleanup:/repo/.wt-demo"]);
+  });
+
+  test("worktrees API maps scan, validation, and cleanup failures to errors", async () => {
+    const app = apiWith(createWorktreesApi({
+      async scanWorktrees() {
+        throw new Error("tmux unavailable");
+      },
+      async cleanupWorktree() {
+        throw new Error("cleanup denied");
+      },
+    }));
+
+    const list = await app.handle(new Request("http://local/api/worktrees"));
+    expect(list.status).toBe(500);
+    expect(await json(list)).toEqual({ error: "tmux unavailable" });
+
+    const missing = await app.handle(new Request("http://local/api/worktrees/cleanup", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ path: "" }),
+    }));
+    expect(missing.status).toBe(400);
+    expect(await json(missing)).toEqual({ error: "path required" });
+
+    const cleanup = await app.handle(new Request("http://local/api/worktrees/cleanup", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ path: "/repo/.wt-demo" }),
+    }));
+    expect(cleanup.status).toBe(500);
+    expect(await json(cleanup)).toEqual({ error: "cleanup denied" });
+  });
+
+  test("fleet API loads JSON configs and ignores disabled or non-json files", async () => {
+    const reads: string[] = [];
+    const app = apiWith(createFleetApi({
+      fleetDir: "/fleet",
+      readdirSync: () => ["m5.json", "disabled.json.disabled", "notes.txt"] as any,
+      readFileSync: (path) => {
+        reads.push(String(path));
+        return JSON.stringify({ node: "m5", windows: [{ name: "mawjs" }] });
+      },
+      join: (...parts) => parts.join("/"),
+    }));
+
+    const res = await app.handle(new Request("http://local/api/fleet-config"));
+    expect(res.status).toBe(200);
+    expect(await json(res)).toEqual({
+      configs: [{ node: "m5", windows: [{ name: "mawjs" }] }],
+    });
+    expect(reads).toEqual(["/fleet/m5.json"]);
+  });
+
+  test("fleet API returns an empty config list with an error when IO fails", async () => {
+    const app = apiWith(createFleetApi({
+      fleetDir: "/fleet",
+      readdirSync: () => {
+        throw new Error("no fleet dir");
+      },
+      readFileSync: (() => "{}") as any,
+      join: (...parts) => parts.join("/"),
+    }));
+
+    const res = await app.handle(new Request("http://local/api/fleet-config"));
+    expect(res.status).toBe(200);
+    expect(await json(res)).toEqual({ configs: [], error: "no fleet dir" });
+  });
+
+  test("asks API reads missing, invalid, and valid JSON safely", async () => {
+    let mode: "missing" | "invalid" | "valid" = "missing";
+    const app = apiWith(createAsksApi({
+      asksPath: "/asks.json",
+      existsSync: () => mode !== "missing",
+      readFileSync: () => {
+        if (mode === "invalid") return "{";
+        return JSON.stringify([{ question: "ship alpha?", answer: "Nat decides" }]);
+      },
+      writeFileSync: (() => undefined) as any,
+    }));
+
+    let res = await app.handle(new Request("http://local/api/asks"));
+    expect(res.status).toBe(200);
+    expect(await json(res)).toEqual([]);
+
+    mode = "invalid";
+    res = await app.handle(new Request("http://local/api/asks"));
+    expect(res.status).toBe(200);
+    expect(await json(res)).toEqual([]);
+
+    mode = "valid";
+    res = await app.handle(new Request("http://local/api/asks"));
+    expect(res.status).toBe(200);
+    expect(await json(res)).toEqual([{ question: "ship alpha?", answer: "Nat decides" }]);
+  });
+
+  test("asks API writes JSON payloads and reports write failures", async () => {
+    const writes: Array<{ path: string; payload: string }> = [];
+    const app = apiWith(createAsksApi({
+      asksPath: "/asks.json",
+      existsSync: () => false,
+      readFileSync: (() => "[]") as any,
+      writeFileSync: (path, payload) => {
+        writes.push({ path: String(path), payload: String(payload) });
+      },
+    }));
+
+    const ok = await app.handle(new Request("http://local/api/asks", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ question: "coverage?", answer: "targeted" }),
+    }));
+    expect(ok.status).toBe(200);
+    expect(await json(ok)).toEqual({ ok: true });
+    expect(writes).toEqual([{
+      path: "/asks.json",
+      payload: '{\n  "question": "coverage?",\n  "answer": "targeted"\n}',
+    }]);
+
+    const failing = apiWith(createAsksApi({
+      asksPath: "/asks.json",
+      existsSync: () => false,
+      readFileSync: (() => "[]") as any,
+      writeFileSync: () => {
+        throw new Error("readonly");
+      },
+    }));
+    const bad = await failing.handle(new Request("http://local/api/asks", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ question: "coverage?" }),
+    }));
+    expect(bad.status).toBe(400);
+    expect(await json(bad)).toEqual({ error: "readonly" });
+  });
+});


### PR DESCRIPTION
## Summary
- add dependency-injected router factories for asks, fleet config, and worktree APIs
- cover success/error paths for all three routers in the default Bun test suite
- keep production exports (`asksApi`, `fleetApi`, `worktreesApi`) as stable factory wrappers

## Validation
- `bun test test/api-small-default.test.ts --coverage --coverage-reporter=text --timeout 60000` → 100% functions/lines for `src/api/asks.ts`, `src/api/fleet.ts`, `src/api/worktrees.ts`
- `bun test test/api-small-default.test.ts --timeout 60000`
- `bun run build`
- `git diff --check`
- no `mock.module` in the new default test

## Release
- alpha-only coverage PR
- no release cut

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
