### PR TITLE
test(coverage): cover runtime API routers

### DIFF
--- a/src/api/claude-fleet.ts
+++ b/src/api/claude-fleet.ts
@@ -10,20 +10,28 @@
 import { Elysia } from "elysia";
 import { listClaudeSessions } from "../core/fleet/claude-sessions";
 
-export const claudeFleetApi = new Elysia();
+export interface ClaudeFleetApiDeps {
+  listClaudeSessions: typeof listClaudeSessions;
+}
 
-claudeFleetApi.get("/fleet/claude", async ({ set }) => {
-  try {
-    const sessions = await listClaudeSessions();
-    return { sessions, count: sessions.length };
-  } catch (e: any) {
-    set.status = 500;
-    return { error: "Failed to discover Claude sessions", detail: e.message };
-  }
-}, {
-  detail: {
-    summary: "List Claude Code sessions",
-    description: "Discovers running and recent Claude Code sessions on this node via ~/.claude/projects/ scan + process correlation.",
-    tags: ["fleet-lens"],
-  },
-});
+export function createClaudeFleetApi(deps: ClaudeFleetApiDeps = {
+  listClaudeSessions,
+}) {
+  return new Elysia().get("/fleet/claude", async ({ set }) => {
+    try {
+      const sessions = await deps.listClaudeSessions();
+      return { sessions, count: sessions.length };
+    } catch (e: any) {
+      set.status = 500;
+      return { error: "Failed to discover Claude sessions", detail: e.message };
+    }
+  }, {
+    detail: {
+      summary: "List Claude Code sessions",
+      description: "Discovers running and recent Claude Code sessions on this node via ~/.claude/projects/ scan + process correlation.",
+      tags: ["fleet-lens"],
+    },
+  });
+}
+
+export const claudeFleetApi = createClaudeFleetApi();

--- a/src/api/transport.ts
+++ b/src/api/transport.ts
@@ -10,33 +10,46 @@ import { Elysia } from "elysia";
 import { getTransportRouter } from "../transports";
 import { TransportSendBody, type TTransportSendBody } from "../lib/schemas";
 
-export const transportApi = new Elysia();
+export interface TransportApiDeps {
+  getTransportRouter: typeof getTransportRouter;
+  now?: () => Date;
+}
 
-// GET /api/transport/status — show all transports and their connectivity
-transportApi.get("/transport/status", () => {
-  const router = getTransportRouter();
-  return {
-    transports: router.status(),
-    timestamp: new Date().toISOString(),
-  };
-});
+export function createTransportApi(deps: TransportApiDeps = {
+  getTransportRouter,
+}) {
+  const api = new Elysia();
 
-// POST /api/transport/send — send a message through the transport router
-transportApi.post("/transport/send", async ({ body }) => {
-  const { oracle, host, message, from } = body as TTransportSendBody;
+  // GET /api/transport/status — show all transports and their connectivity
+  api.get("/transport/status", () => {
+    const router = deps.getTransportRouter();
+    return {
+      transports: router.status(),
+      timestamp: (deps.now ? deps.now() : new Date()).toISOString(),
+    };
+  });
 
-  const router = getTransportRouter();
-  const result = await router.send(
-    { oracle, host: host || undefined },
-    message,
-    from || "api",
-  );
+  // POST /api/transport/send — send a message through the transport router
+  api.post("/transport/send", async ({ body }) => {
+    const { oracle, host, message, from } = body as TTransportSendBody;
 
-  return {
-    ...result,
-    target: oracle,
-    host: host || "local",
-  };
-}, {
-  body: TransportSendBody,
-});
+    const router = deps.getTransportRouter();
+    const result = await router.send(
+      { oracle, host: host || undefined },
+      message,
+      from || "api",
+    );
+
+    return {
+      ...result,
+      target: oracle,
+      host: host || "local",
+    };
+  }, {
+    body: TransportSendBody,
+  });
+
+  return api;
+}
+
+export const transportApi = createTransportApi();

--- a/src/api/triggers.ts
+++ b/src/api/triggers.ts
@@ -3,52 +3,68 @@ import { getTriggers, getTriggerHistory, fire, type TriggerContext } from "../co
 import type { TriggerEvent } from "../config";
 import { TriggerFireBody, type TTriggerFireBody } from "../lib/schemas";
 
-export const triggersApi = new Elysia();
+export interface TriggersApiDeps {
+  getTriggers: typeof getTriggers;
+  getTriggerHistory: typeof getTriggerHistory;
+  fire: typeof fire;
+}
 
-/** GET /triggers — list configured triggers + last fired */
-triggersApi.get("/triggers", () => {
-  const triggers = getTriggers();
-  const history = getTriggerHistory();
+export function createTriggersApi(deps: TriggersApiDeps = {
+  getTriggers,
+  getTriggerHistory,
+  fire,
+}) {
+  const api = new Elysia();
 
-  const items = triggers.map((t, i) => {
-    const last = history.find(h => h.index === i);
-    return {
-      index: i,
-      on: t.on,
-      repo: t.repo || null,
-      timeout: t.timeout || null,
-      action: t.action,
-      name: t.name || null,
-      lastFired: last ? {
-        ts: last.result.ts,
-        ok: last.result.ok,
-        action: last.result.action,
-        error: last.result.error || null,
-      } : null,
-    };
+  /** GET /triggers — list configured triggers + last fired */
+  api.get("/triggers", () => {
+    const triggers = deps.getTriggers();
+    const history = deps.getTriggerHistory();
+
+    const items = triggers.map((t, i) => {
+      const last = history.find(h => h.index === i);
+      return {
+        index: i,
+        on: t.on,
+        repo: t.repo || null,
+        timeout: t.timeout || null,
+        action: t.action,
+        name: t.name || null,
+        lastFired: last ? {
+          ts: last.result.ts,
+          ok: last.result.ok,
+          action: last.result.action,
+          error: last.result.error || null,
+        } : null,
+      };
+    });
+
+    return { triggers: items, total: items.length };
   });
 
-  return { triggers: items, total: items.length };
-});
+  /** POST /triggers/fire — manually fire a trigger event */
+  api.post("/triggers/fire", async ({ body }) => {
+    const typedBody = body as TTriggerFireBody;
+    const event = typedBody.event as TriggerEvent;
+    const ctx: TriggerContext = typedBody.context || {};
 
-/** POST /triggers/fire — manually fire a trigger event */
-triggersApi.post("/triggers/fire", async ({ body }) => {
-  const typedBody = body as TTriggerFireBody;
-  const event = typedBody.event as TriggerEvent;
-  const ctx: TriggerContext = typedBody.context || {};
+    const results = await deps.fire(event, ctx);
+    return {
+      ok: true,
+      event,
+      fired: results.length,
+      results: results.map(r => ({
+        action: r.action,
+        ok: r.ok,
+        output: r.output || null,
+        error: r.error || null,
+      })),
+    };
+  }, {
+    body: TriggerFireBody,
+  });
 
-  const results = fire(event, ctx);
-  return {
-    ok: true,
-    event,
-    fired: results.length,
-    results: results.map(r => ({
-      action: r.action,
-      ok: r.ok,
-      output: r.output || null,
-      error: r.error || null,
-    })),
-  };
-}, {
-  body: TriggerFireBody,
-});
+  return api;
+}
+
+export const triggersApi = createTriggersApi();

--- a/src/api/ui-state.ts
+++ b/src/api/ui-state.ts
@@ -17,19 +17,33 @@ export function writeUiState(data: object, filePath = DEFAULT_PATH): void {
   writeFileSync(filePath, JSON.stringify(data, null, 2), "utf-8");
 }
 
-export const uiStateApi = new Elysia();
+export interface UiStateApiDeps {
+  readUiState: typeof readUiState;
+  writeUiState: typeof writeUiState;
+}
 
-uiStateApi.get("/ui-state", () => {
-  return readUiState();
-});
+export function createUiStateApi(deps: UiStateApiDeps = {
+  readUiState,
+  writeUiState,
+}) {
+  const api = new Elysia();
 
-uiStateApi.post("/ui-state", async ({ body, set}) => {
-  try {
-    writeUiState(body as object);
-    return { ok: true };
-  } catch (e: any) {
-    set.status = 400; return { error: e.message };
-  }
-}, {
-  body: t.Unknown(),
-});
+  api.get("/ui-state", () => {
+    return deps.readUiState();
+  });
+
+  api.post("/ui-state", async ({ body, set}) => {
+    try {
+      deps.writeUiState(body as object);
+      return { ok: true };
+    } catch (e: any) {
+      set.status = 400; return { error: e.message };
+    }
+  }, {
+    body: t.Unknown(),
+  });
+
+  return api;
+}
+
+export const uiStateApi = createUiStateApi();

--- a/test/api-runtime-default.test.ts
+++ b/test/api-runtime-default.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { Elysia } from "elysia";
+import { createClaudeFleetApi } from "../src/api/claude-fleet";
+import { createTransportApi } from "../src/api/transport";
+import { createTriggersApi } from "../src/api/triggers";
+import {
+  createUiStateApi,
+  readUiState,
+  writeUiState,
+} from "../src/api/ui-state";
+
+async function json(res: Response): Promise<any> {
+  return await res.json();
+}
+
+function apiWith(plugin: Elysia) {
+  return new Elysia({ prefix: "/api" }).use(plugin);
+}
+
+describe("runtime API routers default-suite coverage", () => {
+  test("ui-state helpers read missing, invalid, valid, and written JSON", () => {
+    const dir = mkdtempSync(join(tmpdir(), "maw-ui-state-"));
+    try {
+      const statePath = join(dir, "ui-state.json");
+      expect(readUiState(statePath)).toEqual({});
+
+      writeFileSync(statePath, "{", "utf-8");
+      expect(readUiState(statePath)).toEqual({});
+
+      writeUiState({ panel: "fleet", width: 42 }, statePath);
+      expect(readUiState(statePath)).toEqual({ panel: "fleet", width: 42 });
+      expect(readFileSync(statePath, "utf-8")).toBe('{\n  "panel": "fleet",\n  "width": 42\n}');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("ui-state API delegates reads and maps write failures to 400", async () => {
+    const writes: object[] = [];
+    const app = apiWith(createUiStateApi({
+      readUiState: () => ({ sidebar: "open" }),
+      writeUiState: (data) => {
+        writes.push(data);
+      },
+    }));
+
+    const get = await app.handle(new Request("http://local/api/ui-state"));
+    expect(get.status).toBe(200);
+    expect(await json(get)).toEqual({ sidebar: "open" });
+
+    const post = await app.handle(new Request("http://local/api/ui-state", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sidebar: "closed" }),
+    }));
+    expect(post.status).toBe(200);
+    expect(await json(post)).toEqual({ ok: true });
+    expect(writes).toEqual([{ sidebar: "closed" }]);
+
+    const failing = apiWith(createUiStateApi({
+      readUiState: () => ({}),
+      writeUiState: () => {
+        throw new Error("readonly");
+      },
+    }));
+    const bad = await failing.handle(new Request("http://local/api/ui-state", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sidebar: "closed" }),
+    }));
+    expect(bad.status).toBe(400);
+    expect(await json(bad)).toEqual({ error: "readonly" });
+  });
+
+  test("transport API reports status and sends with explicit host/from", async () => {
+    const sends: any[] = [];
+    const router = {
+      status: () => [{ name: "tmux", connected: true }],
+      send: async (target: any, message: string, from: string) => {
+        sends.push({ target, message, from });
+        return { ok: true, via: "tmux", retryable: false };
+      },
+    };
+    const app = apiWith(createTransportApi({
+      getTransportRouter: (() => router) as any,
+      now: () => new Date("2026-05-17T00:00:00.000Z"),
+    }));
+
+    const status = await app.handle(new Request("http://local/api/transport/status"));
+    expect(status.status).toBe(200);
+    expect(await json(status)).toEqual({
+      transports: [{ name: "tmux", connected: true }],
+      timestamp: "2026-05-17T00:00:00.000Z",
+    });
+
+    const sent = await app.handle(new Request("http://local/api/transport/send", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        oracle: "mawjs-oracle",
+        host: "m5",
+        message: "ping",
+        from: "mawjs-codex",
+      }),
+    }));
+    expect(sent.status).toBe(200);
+    expect(await json(sent)).toEqual({
+      ok: true,
+      via: "tmux",
+      retryable: false,
+      target: "mawjs-oracle",
+      host: "m5",
+    });
+    expect(sends).toEqual([{
+      target: { oracle: "mawjs-oracle", host: "m5" },
+      message: "ping",
+      from: "mawjs-codex",
+    }]);
+  });
+
+  test("transport API defaults host and sender for local sends", async () => {
+    const sends: any[] = [];
+    const app = apiWith(createTransportApi({
+      getTransportRouter: (() => ({
+        status: () => [],
+        send: async (target: any, message: string, from: string) => {
+          sends.push({ target, message, from });
+          return { ok: false, via: "none", reason: "unreachable", retryable: false };
+        },
+      })) as any,
+      now: () => new Date("2026-05-17T00:00:00.000Z"),
+    }));
+
+    const res = await app.handle(new Request("http://local/api/transport/send", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ oracle: "mawjs-oracle", message: "ping" }),
+    }));
+    expect(res.status).toBe(200);
+    expect(await json(res)).toEqual({
+      ok: false,
+      via: "none",
+      reason: "unreachable",
+      retryable: false,
+      target: "mawjs-oracle",
+      host: "local",
+    });
+    expect(sends).toEqual([{
+      target: { oracle: "mawjs-oracle" },
+      message: "ping",
+      from: "api",
+    }]);
+  });
+
+  test("transport API can stamp status with the default clock branch", async () => {
+    const app = apiWith(createTransportApi({
+      getTransportRouter: (() => ({
+        status: () => [{ name: "http", connected: false }],
+        send: async () => ({ ok: false, via: "none", retryable: false }),
+      })) as any,
+    }));
+
+    const res = await app.handle(new Request("http://local/api/transport/status"));
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    expect(body.transports).toEqual([{ name: "http", connected: false }]);
+    expect(Number.isNaN(Date.parse(body.timestamp))).toBe(false);
+  });
+
+  test("triggers API renders configured triggers with last-fired history", async () => {
+    const app = apiWith(createTriggersApi({
+      getTriggers: () => [
+        { on: "pr-merge", repo: "Soul-Brews-Studio/maw-js", action: "maw hey", name: "notify" },
+        { on: "agent-idle", timeout: 60, action: "maw wake" },
+      ],
+      getTriggerHistory: () => [{
+        index: 0,
+        result: {
+          trigger: { on: "pr-merge", action: "maw hey" },
+          action: "maw hey",
+          ok: true,
+          output: "sent",
+          ts: 123,
+        },
+      }],
+      fire: (async () => []) as any,
+    }));
+
+    const res = await app.handle(new Request("http://local/api/triggers"));
+    expect(res.status).toBe(200);
+    expect(await json(res)).toEqual({
+      total: 2,
+      triggers: [
+        {
+          index: 0,
+          on: "pr-merge",
+          repo: "Soul-Brews-Studio/maw-js",
+          timeout: null,
+          action: "maw hey",
+          name: "notify",
+          lastFired: { ts: 123, ok: true, action: "maw hey", error: null },
+        },
+        {
+          index: 1,
+          on: "agent-idle",
+          repo: null,
+          timeout: 60,
+          action: "maw wake",
+          name: null,
+          lastFired: null,
+        },
+      ],
+    });
+  });
+
+  test("triggers API awaits fire results and normalizes optional output/error", async () => {
+    const calls: any[] = [];
+    const app = apiWith(createTriggersApi({
+      getTriggers: () => [],
+      getTriggerHistory: () => [],
+      fire: async (event, ctx) => {
+        calls.push({ event, ctx });
+        return [
+          {
+            trigger: { on: "issue-close", action: "ok" },
+            action: "ok",
+            ok: true,
+            output: "done",
+            ts: 1,
+          },
+          {
+            trigger: { on: "issue-close", action: "bad" },
+            action: "bad",
+            ok: false,
+            error: "boom",
+            ts: 2,
+          },
+        ];
+      },
+    }));
+
+    const res = await app.handle(new Request("http://local/api/triggers/fire", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        event: "issue-close",
+        context: { repo: "Soul-Brews-Studio/maw-js", issue: "1709" },
+      }),
+    }));
+    expect(res.status).toBe(200);
+    expect(await json(res)).toEqual({
+      ok: true,
+      event: "issue-close",
+      fired: 2,
+      results: [
+        { action: "ok", ok: true, output: "done", error: null },
+        { action: "bad", ok: false, output: null, error: "boom" },
+      ],
+    });
+    expect(calls).toEqual([{
+      event: "issue-close",
+      ctx: { repo: "Soul-Brews-Studio/maw-js", issue: "1709" },
+    }]);
+  });
+
+  test("claude fleet API returns session count and discovery failures", async () => {
+    const session = {
+      sessionId: "abc",
+      projectPath: "/repo",
+      repo: "Soul-Brews-Studio/maw-js",
+      worktree: null,
+      pid: 123,
+      ppid: 1,
+      parentChain: ["maw"],
+      tmuxTarget: "54-mawjs:mawjs-oracle.0",
+      triggeredFrom: "maw-wake",
+      status: "active",
+      lastActivityAt: "2026-05-17T00:00:00.000Z",
+      lastUserMessage: "test",
+      lastAssistantMessage: "pass",
+      sizeBytes: 42,
+    };
+    const okApp = apiWith(createClaudeFleetApi({
+      listClaudeSessions: async () => [session] as any,
+    }));
+
+    const ok = await okApp.handle(new Request("http://local/api/fleet/claude"));
+    expect(ok.status).toBe(200);
+    expect(await json(ok)).toEqual({ sessions: [session], count: 1 });
+
+    const badApp = apiWith(createClaudeFleetApi({
+      listClaudeSessions: async () => {
+        throw new Error("scan failed");
+      },
+    }));
+    const bad = await badApp.handle(new Request("http://local/api/fleet/claude"));
+    expect(bad.status).toBe(500);
+    expect(await json(bad)).toEqual({
+      error: "Failed to discover Claude sessions",
+      detail: "scan failed",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add dependency-injected router factories for UI state, transport, triggers, and Claude fleet endpoints
- cover success/error/default behavior for all four routers in the default Bun test suite
- fix the trigger fire endpoint to await the async runtime fire() contract before rendering fired/results

## Validation
- `bun test test/api-runtime-default.test.ts --coverage --coverage-reporter=text --timeout 60000` → 100% functions/lines for `src/api/ui-state.ts`, `src/api/transport.ts`, `src/api/triggers.ts`, `src/api/claude-fleet.ts`
- `bun test test/api-runtime-default.test.ts --timeout 60000`
- `bun run build`
- `git diff --check`
- no `mock.module` in the new default test

## Release
- alpha-only coverage PR
- no release cut

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
