### PR TITLE
test(coverage): cover proxy relay paths

### DIFF
--- a/src/api/proxy-relay.ts
+++ b/src/api/proxy-relay.ts
@@ -4,10 +4,16 @@ import { loadConfig } from "../config";
 import { signHeaders } from "../lib/federation-auth";
 import { READONLY_METHODS } from "./proxy-trust";
 
+export interface ProxyRelayDeps {
+  loadConfig?: typeof loadConfig;
+  signHeaders?: typeof signHeaders;
+  fetch?: typeof fetch;
+  now?: () => number;
+}
+
 // --- Peer URL resolution (same as wormhole — acceptable duplication) ----
 
-export function resolveProxyPeerUrl(peer: string): string | null {
-  const config = loadConfig() as any;
+export function resolveProxyPeerUrl(peer: string, config: any = loadConfig()): string | null {
   const namedPeers: Array<{ name: string; url: string }> = config?.namedPeers ?? [];
   const match = namedPeers.find((p) => p.name === peer);
   if (match) return match.url;
@@ -30,16 +36,17 @@ export async function relayHttpToPeer(
   method: string,
   path: string,
   body: string | undefined,
+  deps: ProxyRelayDeps = {},
 ): Promise<RelayResult> {
-  const start = Date.now();
+  const start = deps.now ? deps.now() : Date.now();
   const upper = method.toUpperCase();
   const outHeaders: Record<string, string> = {};
 
   // Sign outbound with existing HMAC mechanism
-  const config = loadConfig() as any;
+  const config = (deps.loadConfig ?? loadConfig)() as any;
   const token = config?.federationToken;
   if (token) {
-    Object.assign(outHeaders, signHeaders(token, upper, path));
+    Object.assign(outHeaders, (deps.signHeaders ?? signHeaders)(token, upper, path));
   }
 
   // Only set Content-Type for methods that can carry a body
@@ -47,7 +54,7 @@ export async function relayHttpToPeer(
     outHeaders["Content-Type"] = "application/json";
   }
 
-  const response = await fetch(`${peerUrl}${path}`, {
+  const response = await (deps.fetch ?? fetch)(`${peerUrl}${path}`, {
     method: upper,
     headers: outHeaders,
     body: READONLY_METHODS.has(upper) ? undefined : body,
@@ -65,6 +72,6 @@ export async function relayHttpToPeer(
     status: response.status,
     headers: safeHeaders,
     body: await response.text(),
-    elapsedMs: Date.now() - start,
+    elapsedMs: (deps.now ? deps.now() : Date.now()) - start,
   };
 }

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -28,6 +28,7 @@ import {
   resolveProxyPeerUrl,
   proxyApi,
 } from "../src/api/proxy";
+import { relayHttpToPeer } from "../src/api/proxy-relay";
 
 // ---- Pure helper tests ---------------------------------------------------
 
@@ -155,6 +156,12 @@ describe("isProxyShellPeerAllowed", () => {
 });
 
 describe("resolveProxyPeerUrl", () => {
+  test("namedPeers config maps bare peer names to URLs", () => {
+    expect(resolveProxyPeerUrl("codex", {
+      namedPeers: [{ name: "codex", url: "http://codex.local:3456" }],
+    })).toBe("http://codex.local:3456");
+  });
+
   test("bare host:port → http://", () => {
     expect(resolveProxyPeerUrl("10.20.0.7:3456")).toBe("http://10.20.0.7:3456");
   });
@@ -173,6 +180,86 @@ describe("resolveProxyPeerUrl", () => {
 
   test("empty input returns null", () => {
     expect(resolveProxyPeerUrl("")).toBeNull();
+  });
+});
+
+describe("relayHttpToPeer", () => {
+  test("signs mutating requests, forwards JSON bodies, and keeps safe response headers", async () => {
+    const requests: any[] = [];
+    const ticks = [100, 125];
+    const result = await relayHttpToPeer(
+      "http://peer.local:3456",
+      "post",
+      "/api/config",
+      "{\"ok\":true}",
+      {
+        loadConfig: () => ({ federationToken: "secret" }) as any,
+        signHeaders: (token, method, path) => ({
+          "x-sig-token": `${token}:${method}:${path}`,
+        }),
+        now: () => ticks.shift() ?? 125,
+        fetch: (async (url, init) => {
+          requests.push({ url, init });
+          return new Response("accepted", {
+            status: 202,
+            headers: {
+              "content-type": "application/json",
+              "cache-control": "no-store",
+              etag: "\"abc\"",
+              "last-modified": "Sun, 17 May 2026 00:00:00 GMT",
+              "set-cookie": "secret=leak",
+            },
+          });
+        }) as any,
+      },
+    );
+
+    expect(result).toEqual({
+      status: 202,
+      headers: {
+        "content-type": "application/json",
+        "cache-control": "no-store",
+        etag: "\"abc\"",
+        "last-modified": "Sun, 17 May 2026 00:00:00 GMT",
+      },
+      body: "accepted",
+      elapsedMs: 25,
+    });
+    expect(requests).toEqual([{
+      url: "http://peer.local:3456/api/config",
+      init: {
+        method: "POST",
+        headers: {
+          "x-sig-token": "secret:POST:/api/config",
+          "Content-Type": "application/json",
+        },
+        body: "{\"ok\":true}",
+      },
+    }]);
+  });
+
+  test("omits readonly request bodies and content-type when relaying GET", async () => {
+    const requests: any[] = [];
+    const result = await relayHttpToPeer(
+      "http://peer.local:3456",
+      "GET",
+      "/api/config",
+      "{\"ignored\":true}",
+      {
+        loadConfig: () => ({}) as any,
+        fetch: (async (url, init) => {
+          requests.push({ url, init });
+          return new Response("config", { status: 200 });
+        }) as any,
+      },
+    );
+
+    expect(result.status).toBe(200);
+    expect(result.body).toBe("config");
+    expect(requests).toEqual([{
+      url: "http://peer.local:3456/api/config",
+      init: { method: "GET", headers: {}, body: undefined },
+    }]);
   });
 });
 
@@ -238,6 +325,18 @@ describe("POST /api/proxy (trust flow)", () => {
     expect(res.status).toBe(400);
     const body = (await res.json()) as any;
     expect(body.error).toBe("missing_fields");
+  });
+
+  test("400 when the parsed body is absent or not an object", async () => {
+    const app = makeApp();
+    const cookie = await proxyCookie(app);
+    const res = await app.handle(new Request("http://localhost/api/proxy", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: cookie },
+      body: "null",
+    }));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "invalid_body" });
   });
 
   test("400 on bad signature", async () => {
@@ -310,6 +409,30 @@ describe("POST /api/proxy (trust flow)", () => {
     expect(body.hint).toContain("anonymous browser visitors can only GET");
   });
 
+  test("403 mutation denial explains allowlisting for named non-allowlisted origins", async () => {
+    const app = makeApp();
+    const cookie = await proxyCookie(app);
+    const res = await app.handle(new Request("http://localhost/api/proxy", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: cookie },
+      body: JSON.stringify({
+        peer: "white",
+        method: "POST",
+        path: "/api/ping",
+        body: "{}",
+        signature: "[local:operator]",
+      }),
+    }));
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as any;
+    expect(body).toMatchObject({
+      error: "mutation_denied",
+      origin: "local",
+      method: "POST",
+      hint: "add this origin to config.proxy.shellPeers to permit mutations",
+    });
+  });
+
   test("403 on non-allowlisted path (even GET)", async () => {
     const app = makeApp();
     const cookie = await proxyCookie(app);
@@ -359,6 +482,77 @@ describe("POST /api/proxy (trust flow)", () => {
     }));
     // Should NOT be 401 (cookie bypassed) — should be 404 (unknown peer)
     expect(res.status).toBe(404);
+  });
+
+  test("dev mode relays readonly requests to explicit peer URLs", async () => {
+    process.env.NODE_ENV = "development";
+    const oldFetch = globalThis.fetch;
+    const requests: any[] = [];
+    globalThis.fetch = (async (url, init) => {
+      requests.push({ url, init });
+      return new Response("{\"remote\":true}", {
+        status: 200,
+        headers: { "content-type": "application/json", "set-cookie": "nope" },
+      });
+    }) as any;
+    try {
+      const app = makeApp();
+      const res = await app.handle(new Request("http://localhost/api/proxy", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          peer: "http://peer.local:3456",
+          method: "GET",
+          path: "/api/config",
+          signature: "[local:anon-1]",
+        }),
+      }));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as any;
+      expect(body).toMatchObject({
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: "{\"remote\":true}",
+        from: "http://peer.local:3456",
+        trust_tier: "readonly_method",
+      });
+      expect(typeof body.elapsed_ms).toBe("number");
+      expect(requests[0]).toMatchObject({
+        url: "http://peer.local:3456/api/config",
+        init: { method: "GET", body: undefined },
+      });
+    } finally {
+      globalThis.fetch = oldFetch;
+    }
+  });
+
+  test("relay failures surface as 502 with peer URL and reason", async () => {
+    process.env.NODE_ENV = "development";
+    const oldFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      throw new Error("connection refused");
+    }) as any;
+    try {
+      const app = makeApp();
+      const res = await app.handle(new Request("http://localhost/api/proxy", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          peer: "http://peer.local:3456",
+          method: "GET",
+          path: "/api/config",
+          signature: "[local:anon-1]",
+        }),
+      }));
+      expect(res.status).toBe(502);
+      expect(await res.json()).toEqual({
+        error: "relay_failed",
+        peer: "http://peer.local:3456",
+        reason: "connection refused",
+      });
+    } finally {
+      globalThis.fetch = oldFetch;
+    }
   });
 
   test("invalid JSON → 400 invalid_body", async () => {


### PR DESCRIPTION
## Summary
- add injectable relay dependencies for deterministic proxy relay tests
- cover named peer resolution, HMAC signing, request body/header forwarding, safe response headers, route success, and relay failure paths
- keep coverage in the existing default `test/proxy.test.ts` suite with scoped fetch stubs and no module mocks

## Validation
- `bun test test/proxy.test.ts --coverage --coverage-reporter=text --timeout 60000` → 100% functions/lines for `src/api/proxy-relay.ts`; 100% functions and 98.59% lines for `src/api/proxy-routes.ts`
- `bun test test/proxy.test.ts --timeout 60000`
- `bun run build`
- `git diff --check`
- no `mock.module` added

## Release
- alpha-only coverage PR
- no release cut

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
