### PR TITLE
test(coverage): cover feed API

### DIFF
--- a/src/api/feed.ts
+++ b/src/api/feed.ts
@@ -6,61 +6,89 @@ import { cfgLimit } from "../config";
 export const feedBuffer: FeedEvent[] = [];
 export const feedListeners = new Set<(event: FeedEvent) => void>();
 
-export function pushFeedEvent(event: FeedEvent) {
-  feedBuffer.push(event);
-  const feedMax = cfgLimit("feedMax");
-  if (feedBuffer.length > feedMax) feedBuffer.splice(0, feedBuffer.length - feedMax);
-  for (const fn of feedListeners) fn(event);
+export interface FeedApiDeps {
+  feedBuffer: FeedEvent[];
+  feedListeners: Set<(event: FeedEvent) => void>;
+  cfgLimit: typeof cfgLimit;
+  markRealFeedEvent: typeof markRealFeedEvent;
+  now: () => number;
+  isoNow: () => string;
 }
 
-export const feedApi = new Elysia();
+export const defaultFeedApiDeps: FeedApiDeps = {
+  feedBuffer,
+  feedListeners,
+  cfgLimit,
+  markRealFeedEvent,
+  now: Date.now,
+  isoNow: () => new Date().toISOString(),
+};
+
+export function pushFeedEventWithDeps(event: FeedEvent, deps: FeedApiDeps = defaultFeedApiDeps) {
+  deps.feedBuffer.push(event);
+  const feedMax = deps.cfgLimit("feedMax");
+  if (deps.feedBuffer.length > feedMax) deps.feedBuffer.splice(0, deps.feedBuffer.length - feedMax);
+  for (const fn of deps.feedListeners) fn(event);
+}
+
+export function pushFeedEvent(event: FeedEvent) {
+  pushFeedEventWithDeps(event);
+}
+
+export function createFeedApi(deps: FeedApiDeps = defaultFeedApiDeps) {
+  const api = new Elysia();
 
 // PUBLIC FEDERATION API (v1) — no auth. Shape is load-bearing for lens
 // clients filtering `event === "MessageSend"`. See docs/federation.md.
-feedApi.get("/feed", ({ query }) => {
-  const limit = Math.min(200, +(query.limit || String(cfgLimit("feedDefault"))));
-  const oracle = query.oracle || undefined;
-  let events = feedBuffer.slice(-limit);
-  if (oracle) events = events.filter(e => e.oracle === oracle);
-  const activeMap = new Map<string, FeedEvent>();
-  const cutoff = Date.now() - 5 * 60_000;
-  for (const e of feedBuffer) { if (e.ts >= cutoff) activeMap.set(e.oracle, e); }
-  return { events: events.reverse(), total: events.length, active_oracles: [...activeMap.keys()] };
-}, {
-  query: t.Object({
-    limit: t.Optional(t.String()),
-    oracle: t.Optional(t.String()),
-  }),
-});
+  api.get("/feed", ({ query }) => {
+    const limit = Math.min(200, +(query.limit || String(deps.cfgLimit("feedDefault"))));
+    const oracle = query.oracle || undefined;
+    let events = deps.feedBuffer.slice(-limit);
+    if (oracle) events = events.filter(e => e.oracle === oracle);
+    const activeMap = new Map<string, FeedEvent>();
+    const cutoff = deps.now() - 5 * 60_000;
+    for (const e of deps.feedBuffer) { if (e.ts >= cutoff) activeMap.set(e.oracle, e); }
+    return { events: events.reverse(), total: events.length, active_oracles: [...activeMap.keys()] };
+  }, {
+    query: t.Object({
+      limit: t.Optional(t.String()),
+      oracle: t.Optional(t.String()),
+    }),
+  });
 
-feedApi.post("/feed", async ({ body }) => {
-  const b = body as any;
-  const event: FeedEvent = {
-    timestamp: b.timestamp || new Date().toISOString(),
-    oracle: b.oracle || "unknown",
-    host: b.host || "local",
-    event: b.event || "Notification",
-    project: b.project || "",
-    sessionId: b.sessionId || "",
-    message: b.message || "",
-    ts: b.ts || Date.now(),
-    ...(b.data !== undefined ? { data: b.data } : {}),
-  };
-  pushFeedEvent(event);
-  markRealFeedEvent(event.oracle);
-  const wtMatch = event.project.match(/[.-]wt-(?:\d+-)?(.+)$/);
-  if (wtMatch) markRealFeedEvent(`${event.oracle}-${wtMatch[1]}`);
-  return { ok: true };
-}, {
-  body: t.Object({
-    timestamp: t.Optional(t.String()),
-    oracle: t.Optional(t.String()),
-    host: t.Optional(t.String()),
-    event: t.Optional(t.String()),
-    project: t.Optional(t.String()),
-    sessionId: t.Optional(t.String()),
-    message: t.Optional(t.String()),
-    ts: t.Optional(t.Number()),
-    data: t.Optional(t.Unknown()),
-  }),
-});
+  api.post("/feed", async ({ body }) => {
+    const b = body as any;
+    const event: FeedEvent = {
+      timestamp: b.timestamp || deps.isoNow(),
+      oracle: b.oracle || "unknown",
+      host: b.host || "local",
+      event: b.event || "Notification",
+      project: b.project || "",
+      sessionId: b.sessionId || "",
+      message: b.message || "",
+      ts: b.ts || deps.now(),
+      ...(b.data !== undefined ? { data: b.data } : {}),
+    };
+    pushFeedEventWithDeps(event, deps);
+    deps.markRealFeedEvent(event.oracle);
+    const wtMatch = event.project.match(/[.-]wt-(?:\d+-)?(.+)$/);
+    if (wtMatch) deps.markRealFeedEvent(`${event.oracle}-${wtMatch[1]}`);
+    return { ok: true };
+  }, {
+    body: t.Object({
+      timestamp: t.Optional(t.String()),
+      oracle: t.Optional(t.String()),
+      host: t.Optional(t.String()),
+      event: t.Optional(t.String()),
+      project: t.Optional(t.String()),
+      sessionId: t.Optional(t.String()),
+      message: t.Optional(t.String()),
+      ts: t.Optional(t.Number()),
+      data: t.Optional(t.Unknown()),
+    }),
+  });
+
+  return api;
+}
+
+export const feedApi = createFeedApi();

--- a/test/feed-api-default.test.ts
+++ b/test/feed-api-default.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, test } from "bun:test";
+import { Elysia } from "elysia";
+import {
+  createFeedApi,
+  defaultFeedApiDeps,
+  feedBuffer,
+  feedListeners,
+  pushFeedEvent,
+  pushFeedEventWithDeps,
+  type FeedApiDeps,
+} from "../src/api/feed";
+import type { FeedEvent } from "../src/lib/feed";
+
+const NOW = Date.parse("2026-05-17T00:00:00.000Z");
+
+async function json(res: Response): Promise<any> {
+  return await res.json();
+}
+
+function event(overrides: Partial<FeedEvent> = {}): FeedEvent {
+  return {
+    timestamp: "2026-05-17T00:00:00.000Z",
+    oracle: "mawjs",
+    host: "m5",
+    event: "MessageSend",
+    project: "maw-js",
+    sessionId: "s1",
+    message: "hello",
+    ts: NOW,
+    ...overrides,
+  };
+}
+
+function deps(overrides: Partial<FeedApiDeps> = {}): FeedApiDeps {
+  return {
+    feedBuffer: [],
+    feedListeners: new Set(),
+    cfgLimit: ((name: string) => {
+      if (name === "feedMax") return 2;
+      if (name === "feedDefault") return 2;
+      return 100;
+    }) as any,
+    markRealFeedEvent: (() => undefined) as any,
+    now: () => NOW,
+    isoNow: () => "2026-05-17T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function appWith(d: FeedApiDeps) {
+  return new Elysia({ prefix: "/api" }).use(createFeedApi(d));
+}
+
+describe("feed API default-suite coverage", () => {
+  test("pushFeedEventWithDeps truncates to feedMax and notifies listeners", () => {
+    const seen: FeedEvent[] = [];
+    const d = deps();
+    d.feedListeners.add((e) => seen.push(e));
+
+    pushFeedEventWithDeps(event({ oracle: "old", ts: NOW - 3 }), d);
+    pushFeedEventWithDeps(event({ oracle: "mid", ts: NOW - 2 }), d);
+    pushFeedEventWithDeps(event({ oracle: "new", ts: NOW - 1 }), d);
+
+    expect(d.feedBuffer.map((e) => e.oracle)).toEqual(["mid", "new"]);
+    expect(seen.map((e) => e.oracle)).toEqual(["old", "mid", "new"]);
+  });
+
+  test("pushFeedEvent uses the exported default buffer/listeners", () => {
+    const previousBuffer = feedBuffer.splice(0);
+    const previousListeners = [...feedListeners];
+    feedListeners.clear();
+    const seen: FeedEvent[] = [];
+    feedListeners.add((e) => seen.push(e));
+    try {
+      const row = event({ oracle: "default-buffer" });
+      pushFeedEvent(row);
+      expect(feedBuffer.at(-1)).toEqual(row);
+      expect(seen).toEqual([row]);
+    } finally {
+      feedBuffer.splice(0, feedBuffer.length, ...previousBuffer);
+      feedListeners.clear();
+      for (const listener of previousListeners) feedListeners.add(listener);
+    }
+  });
+
+  test("default feed dependency clock helpers are callable", () => {
+    expect(Number.isNaN(defaultFeedApiDeps.now())).toBe(false);
+    expect(Number.isNaN(Date.parse(defaultFeedApiDeps.isoNow()))).toBe(false);
+  });
+
+  test("GET /api/feed returns newest first, filters by oracle, caps limit, and lists active oracles", async () => {
+    const d = deps({
+      feedBuffer: [
+        event({ oracle: "old", ts: NOW - 10 * 60_000, message: "old" }),
+        event({ oracle: "mawjs", ts: NOW - 1_000, message: "one" }),
+        event({ oracle: "mawjs", ts: NOW - 2_000, message: "two" }),
+        event({ oracle: "issuer", ts: NOW - 3_000, message: "three" }),
+      ],
+    });
+    const app = appWith(d);
+
+    const res = await app.handle(new Request("http://local/api/feed?limit=999&oracle=mawjs"));
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    expect(body.total).toBe(2);
+    expect(body.events.map((e: FeedEvent) => e.message)).toEqual(["two", "one"]);
+    expect(body.active_oracles).toEqual(["mawjs", "issuer"]);
+  });
+
+  test("GET /api/feed uses feedDefault when limit is omitted", async () => {
+    const d = deps({
+      feedBuffer: [
+        event({ oracle: "one", ts: NOW - 3 }),
+        event({ oracle: "two", ts: NOW - 2 }),
+        event({ oracle: "three", ts: NOW - 1 }),
+      ],
+    });
+    const app = appWith(d);
+
+    const res = await app.handle(new Request("http://local/api/feed"));
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    expect(body.total).toBe(2);
+    expect(body.events.map((e: FeedEvent) => e.oracle)).toEqual(["three", "two"]);
+  });
+
+  test("POST /api/feed fills defaults, stores data, and marks worktree aliases", async () => {
+    const marked: string[] = [];
+    const d = deps({
+      markRealFeedEvent: ((oracle: string) => marked.push(oracle)) as any,
+    });
+    const app = appWith(d);
+
+    const res = await app.handle(new Request("http://local/api/feed", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        oracle: "mawjs",
+        project: "maw-js.wt-7-codex-headless",
+        event: "MessageDeliver",
+        message: "delivered",
+        data: { route: "tmux" },
+      }),
+    }));
+    expect(res.status).toBe(200);
+    expect(await json(res)).toEqual({ ok: true });
+    expect(d.feedBuffer).toEqual([{
+      timestamp: "2026-05-17T00:00:00.000Z",
+      oracle: "mawjs",
+      host: "local",
+      event: "MessageDeliver",
+      project: "maw-js.wt-7-codex-headless",
+      sessionId: "",
+      message: "delivered",
+      ts: NOW,
+      data: { route: "tmux" },
+    }]);
+    expect(marked).toEqual(["mawjs", "mawjs-codex-headless"]);
+  });
+
+  test("POST /api/feed accepts an empty body shape with notification defaults", async () => {
+    const marked: string[] = [];
+    const d = deps({
+      markRealFeedEvent: ((oracle: string) => marked.push(oracle)) as any,
+    });
+    const app = appWith(d);
+
+    const res = await app.handle(new Request("http://local/api/feed", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    }));
+    expect(res.status).toBe(200);
+    expect(await json(res)).toEqual({ ok: true });
+    expect(d.feedBuffer[0]).toEqual({
+      timestamp: "2026-05-17T00:00:00.000Z",
+      oracle: "unknown",
+      host: "local",
+      event: "Notification",
+      project: "",
+      sessionId: "",
+      message: "",
+      ts: NOW,
+    });
+    expect(marked).toEqual(["unknown"]);
+  });
+});


### PR DESCRIPTION
## Summary
- add injectable runtime dependencies for feed API tests while preserving exported production surfaces
- cover feed buffer truncation, listener fanout, listing/filtering, active oracle calculation, POST defaults, data payloads, and worktree alias marking
- keep tests in the default Bun suite with no module mocks

## Validation
- `bun test test/feed-api-default.test.ts --coverage --coverage-reporter=text --timeout 60000` → 100% functions/lines for `src/api/feed.ts`
- `bun test test/feed-api-default.test.ts --timeout 60000`
- `bun run build`
- `git diff --check`
- no `mock.module` in the new default test

## Release
- alpha-only coverage PR
- no release cut

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
