### PR TITLE
test(coverage): cover logs API

### DIFF
--- a/src/api/logs.ts
+++ b/src/api/logs.ts
@@ -11,103 +11,133 @@ export { logsAgentsApi } from "./logs-agents";
 
 const projectsDir = join(homedir(), ".claude", "projects");
 
-export const logsApi = new Elysia()
-  .use(logsAgentsApi);
+export interface LogsApiDeps {
+  projectsDir: string;
+  cfgLimit: typeof cfgLimit;
+  existsSync: typeof existsSync;
+  readdirSync: typeof readdirSync;
+  readFileSync: typeof readFileSync;
+  statSync: typeof statSync;
+  join: typeof join;
+  agentFromDir: typeof agentFromDir;
+  findJsonlFiles: typeof findJsonlFiles;
+  logsAgentsApi: Elysia;
+}
 
-// GET /api/logs?q=error&agent=neo&limit=50
-logsApi.get("/logs", ({ query }) => {
-  const q = query.q || "";
-  const agentFilter = query.agent || "";
-  const limit = Math.min(parseInt(query.limit || String(cfgLimit("logsDefault")), 10) || cfgLimit("logsDefault"), cfgLimit("logsMax"));
+export function createLogsApi(deps: LogsApiDeps = {
+  projectsDir,
+  cfgLimit,
+  existsSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  join,
+  agentFromDir,
+  findJsonlFiles,
+  logsAgentsApi,
+}) {
+  const api = new Elysia()
+    .use(deps.logsAgentsApi);
 
-  if (!existsSync(projectsDir)) {
-    return { entries: [], total: 0 };
-  }
+  // GET /api/logs?q=error&agent=neo&limit=50
+  api.get("/logs", ({ query }) => {
+    const q = query.q || "";
+    const agentFilter = query.agent || "";
+    const limit = Math.min(parseInt(query.limit || String(deps.cfgLimit("logsDefault")), 10) || deps.cfgLimit("logsDefault"), deps.cfgLimit("logsMax"));
 
-  const results: any[] = [];
-  let dirs: string[];
-  try {
-    dirs = readdirSync(projectsDir);
-  } catch {
-    return { entries: [], total: 0 };
-  }
-
-  for (const dir of dirs) {
-    const agent = agentFromDir(dir);
-
-    if (agentFilter && !agent.toLowerCase().includes(agentFilter.toLowerCase())) {
-      continue;
+    if (!deps.existsSync(deps.projectsDir)) {
+      return { entries: [], total: 0 };
     }
 
-    const dirPath = join(projectsDir, dir);
+    const results: any[] = [];
+    let dirs: string[];
     try {
-      if (!statSync(dirPath).isDirectory()) continue;
+      dirs = deps.readdirSync(deps.projectsDir);
     } catch {
-      continue;
+      return { entries: [], total: 0 };
     }
 
-    const jsonlFiles = findJsonlFiles(dirPath);
+    for (const dir of dirs) {
+      const agent = deps.agentFromDir(dir);
 
-    for (const file of jsonlFiles) {
+      if (agentFilter && !agent.toLowerCase().includes(agentFilter.toLowerCase())) {
+        continue;
+      }
+
+      const dirPath = deps.join(deps.projectsDir, dir);
       try {
-        const content = readFileSync(file, "utf-8");
-        const lines = content.split("\n").filter((l) => l.length > 0);
+        if (!deps.statSync(dirPath).isDirectory()) continue;
+      } catch {
+        continue;
+      }
 
-        for (let i = lines.length - 1; i >= 0 && results.length < limit; i--) {
-          const line = lines[i];
+      const jsonlFiles = deps.findJsonlFiles(dirPath);
 
-          if (q && !line.toLowerCase().includes(q.toLowerCase())) continue;
+      for (const file of jsonlFiles) {
+        try {
+          const content = deps.readFileSync(file, "utf-8") as string;
+          const lines = content.split("\n").filter((l) => l.length > 0);
 
-          try {
-            const parsed = JSON.parse(line);
-            if (parsed.type === "file-history-snapshot") continue;
+          for (let i = lines.length - 1; i >= 0 && results.length < limit; i--) {
+            const line = lines[i];
 
-            results.push({
-              agent,
-              sessionId: parsed.sessionId || null,
-              type: parsed.type || null,
-              timestamp: parsed.timestamp || null,
-              gitBranch: parsed.gitBranch || null,
-              message:
-                parsed.message?.role === "user"
-                  ? {
-                      role: "user",
-                      content:
-                        typeof parsed.message.content === "string"
-                          ? parsed.message.content.slice(0, cfgLimit("logsTruncate"))
-                          : "[structured]",
-                    }
-                  : parsed.message?.role === "assistant"
+            if (q && !line.toLowerCase().includes(q.toLowerCase())) continue;
+
+            try {
+              const parsed = JSON.parse(line);
+              if (parsed.type === "file-history-snapshot") continue;
+
+              results.push({
+                agent,
+                sessionId: parsed.sessionId || null,
+                type: parsed.type || null,
+                timestamp: parsed.timestamp || null,
+                gitBranch: parsed.gitBranch || null,
+                message:
+                  parsed.message?.role === "user"
                     ? {
+                        role: "user",
+                        content:
+                          typeof parsed.message.content === "string"
+                            ? parsed.message.content.slice(0, deps.cfgLimit("logsTruncate"))
+                            : "[structured]",
+                      }
+                    : parsed.message?.role === "assistant"
+                      ? {
                         role: "assistant",
                         content:
                           typeof parsed.message.content === "string"
-                            ? parsed.message.content.slice(0, cfgLimit("logsTruncate"))
+                            ? parsed.message.content.slice(0, deps.cfgLimit("logsTruncate"))
                             : Array.isArray(parsed.message.content)
                               ? "[tool_use/text blocks]"
                               : "[structured]",
-                      }
-                    : null,
-            });
-          } catch {
-            // Skip malformed JSON
+                        }
+                      : null,
+              });
+            } catch {
+              // Skip malformed JSON
+            }
           }
+        } catch {
+          // Skip unreadable files
         }
-      } catch {
-        // Skip unreadable files
+
+        if (results.length >= limit) break;
       }
 
       if (results.length >= limit) break;
     }
 
-    if (results.length >= limit) break;
-  }
+    results.sort((a, b) => {
+      if (!a.timestamp) return 1;
+      if (!b.timestamp) return -1;
+      return b.timestamp.localeCompare(a.timestamp);
+    });
 
-  results.sort((a, b) => {
-    if (!a.timestamp) return 1;
-    if (!b.timestamp) return -1;
-    return b.timestamp.localeCompare(a.timestamp);
+    return { entries: results.slice(0, limit), total: results.length };
   });
 
-  return { entries: results.slice(0, limit), total: results.length };
-});
+  return api;
+}
+
+export const logsApi = createLogsApi();

--- a/test/logs-api-default.test.ts
+++ b/test/logs-api-default.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, test } from "bun:test";
+import { Elysia } from "elysia";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createLogsApi } from "../src/api/logs";
+import { agentFromDir, findJsonlFiles } from "../src/api/logs-helpers";
+
+async function json(res: Response): Promise<any> {
+  return await res.json();
+}
+
+function cfgLimit(name: string): number {
+  if (name === "logsDefault") return 3;
+  if (name === "logsMax") return 3;
+  if (name === "logsTruncate") return 5;
+  return 10;
+}
+
+function logsApp(projectsDir: string) {
+  return new Elysia({ prefix: "/api" }).use(createLogsApi({
+    projectsDir,
+    cfgLimit: cfgLimit as any,
+    existsSync: () => true,
+    readdirSync,
+    readFileSync,
+    statSync,
+    join,
+    agentFromDir,
+    findJsonlFiles,
+    logsAgentsApi: new Elysia(),
+  }));
+}
+
+function line(entry: Record<string, unknown>): string {
+  return JSON.stringify(entry);
+}
+
+describe("logs API default-suite coverage", () => {
+  test("default logs router factory is constructible", () => {
+    expect(createLogsApi()).toBeInstanceOf(Elysia);
+  });
+
+  test("returns empty when projects dir is missing or unreadable", async () => {
+    const missing = new Elysia({ prefix: "/api" }).use(createLogsApi({
+      projectsDir: "/missing",
+      cfgLimit: cfgLimit as any,
+      existsSync: () => false,
+      readdirSync,
+      readFileSync,
+      statSync,
+      join,
+      agentFromDir,
+      findJsonlFiles,
+      logsAgentsApi: new Elysia(),
+    }));
+    let res = await missing.handle(new Request("http://local/api/logs"));
+    expect(res.status).toBe(200);
+    expect(await json(res)).toEqual({ entries: [], total: 0 });
+
+    const unreadable = new Elysia({ prefix: "/api" }).use(createLogsApi({
+      projectsDir: "/throws",
+      cfgLimit: cfgLimit as any,
+      existsSync: () => true,
+      readdirSync: (() => { throw new Error("denied"); }) as any,
+      readFileSync,
+      statSync,
+      join,
+      agentFromDir,
+      findJsonlFiles,
+      logsAgentsApi: new Elysia(),
+    }));
+    res = await unreadable.handle(new Request("http://local/api/logs"));
+    expect(res.status).toBe(200);
+    expect(await json(res)).toEqual({ entries: [], total: 0 });
+  });
+
+  test("parses user and assistant entries, skips snapshots/malformed lines, sorts newest first", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "maw-logs-api-"));
+    try {
+      const mawjsDir = join(dir, "-opt-Code-github-com-Soul-Brews-Studio-mawjs-oracle");
+      const issuerDir = join(dir, "-opt-Code-github-com-Soul-Brews-Studio-mawjs-issuer");
+      mkdirSync(mawjsDir);
+      mkdirSync(issuerDir);
+      writeFileSync(join(dir, "not-a-dir"), "skip");
+
+      writeFileSync(join(mawjsDir, "session.jsonl"), [
+        line({
+          sessionId: "s1",
+          type: "message",
+          timestamp: "2026-05-17T00:01:00.000Z",
+          gitBranch: "alpha",
+          message: { role: "user", content: "hello world" },
+        }),
+        line({
+          sessionId: "s1",
+          type: "message",
+          timestamp: "2026-05-17T00:02:00.000Z",
+          message: { role: "assistant", content: [{ type: "tool_use" }] },
+        }),
+        line({
+          sessionId: "s1",
+          type: "file-history-snapshot",
+          timestamp: "2026-05-17T00:03:00.000Z",
+        }),
+        "{bad json",
+        line({
+          sessionId: "s1",
+          type: "message",
+          timestamp: "2026-05-17T00:04:00.000Z",
+          message: { role: "assistant", content: "assist reply" },
+        }),
+      ].join("\n") + "\n");
+
+      writeFileSync(join(issuerDir, "issuer.jsonl"), [
+        line({
+          sessionId: "s2",
+          type: "event",
+          timestamp: null,
+          message: { role: "user", content: ["structured"] },
+        }),
+      ].join("\n") + "\n");
+
+      const res = await logsApp(dir).handle(new Request("http://local/api/logs?limit=999"));
+      expect(res.status).toBe(200);
+      expect(await json(res)).toEqual({
+        total: 3,
+        entries: [
+          {
+            agent: "mawjs-oracle",
+            sessionId: "s1",
+            type: "message",
+            timestamp: "2026-05-17T00:04:00.000Z",
+            gitBranch: null,
+            message: { role: "assistant", content: "assis" },
+          },
+          {
+            agent: "mawjs-oracle",
+            sessionId: "s1",
+            type: "message",
+            timestamp: "2026-05-17T00:02:00.000Z",
+            gitBranch: null,
+            message: { role: "assistant", content: "[tool_use/text blocks]" },
+          },
+          {
+            agent: "mawjs-issuer",
+            sessionId: "s2",
+            type: "event",
+            timestamp: null,
+            gitBranch: null,
+            message: { role: "user", content: "[structured]" },
+          },
+        ],
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("agent and query filters narrow the scan and invalid limit falls back to default", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "maw-logs-filter-"));
+    try {
+      const mawjsDir = join(dir, "-opt-Code-github-com-Soul-Brews-Studio-mawjs-oracle");
+      const issuerDir = join(dir, "-opt-Code-github-com-Soul-Brews-Studio-mawjs-issuer");
+      mkdirSync(mawjsDir);
+      mkdirSync(issuerDir);
+      writeFileSync(join(mawjsDir, "session.jsonl"), line({
+        sessionId: "s1",
+        type: "message",
+        timestamp: "2026-05-17T00:01:00.000Z",
+        message: { role: "user", content: "no match" },
+      }) + "\n");
+      writeFileSync(join(issuerDir, "issuer.jsonl"), line({
+        sessionId: "s2",
+        type: "message",
+        timestamp: "2026-05-17T00:02:00.000Z",
+        message: { role: "user", content: "needle found" },
+      }) + "\n");
+
+      const res = await logsApp(dir).handle(new Request("http://local/api/logs?agent=issuer&q=NEEDLE&limit=bad"));
+      expect(res.status).toBe(200);
+      const body = await json(res);
+      expect(body.total).toBe(1);
+      expect(body.entries[0]).toMatchObject({
+        agent: "mawjs-issuer",
+        sessionId: "s2",
+        message: { role: "user", content: "needl" },
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("continues past stat and read failures", async () => {
+    const app = new Elysia({ prefix: "/api" }).use(createLogsApi({
+      projectsDir: "/projects",
+      cfgLimit: cfgLimit as any,
+      existsSync: () => true,
+      readdirSync: (() => ["broken-dir", "agent-a"]) as any,
+      readFileSync: (() => { throw new Error("deleted"); }) as any,
+      statSync: ((path: string) => {
+        if (path === "/projects/broken-dir") throw new Error("stat failed");
+        return { isDirectory: () => true } as any;
+      }) as any,
+      join: (...parts) => parts.join("/"),
+      agentFromDir: (name) => name,
+      findJsonlFiles: (dirPath) => [`${dirPath}/missing.jsonl`],
+      logsAgentsApi: new Elysia(),
+    }));
+
+    const res = await app.handle(new Request("http://local/api/logs"));
+    expect(res.status).toBe(200);
+    expect(await json(res)).toEqual({ entries: [], total: 0 });
+  });
+});


### PR DESCRIPTION
## Summary
- add `createLogsApi` so `/api/logs` can be tested without scanning a real Claude projects directory
- cover log parsing, malformed/snapshot skipping, filtering, truncation, timestamp sorting, and filesystem failure paths
- preserve the production `logsApi` export for existing callers

## Validation
- `bun test test/logs-api-default.test.ts --coverage --coverage-reporter=text --timeout 60000` → `src/api/logs.ts | 100.00 | 100.00`
- `bun test test/logs-api-default.test.ts --timeout 60000`
- `bun run build`
- `git diff --check`
- `grep -R "mock\\.module" test/logs-api-default.test.ts || true` → no `mock.module`

## Release
- alpha-only coverage PR
- no release cut

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
