### PR TITLE
test(coverage): cover plugins API

### DIFF
--- a/src/api/plugins.ts
+++ b/src/api/plugins.ts
@@ -15,53 +15,32 @@ import { Elysia, t } from "elysia";
 import type { LoadedPlugin, InvokeContext, InvokeResult } from "../plugin/types";
 import { discoverPackages, invokePlugin } from "../plugin/registry";
 
-export const pluginsRouter = new Elysia();
+export interface PluginsRouterDeps {
+  discoverPackages: typeof discoverPackages;
+  invokePlugin: typeof invokePlugin;
+}
 
-// GET /plugins — list all plugins that expose an API surface
-pluginsRouter.get("/plugins", () => {
-  const all = discoverPackages();
-  return all
-    .filter((p: LoadedPlugin) => !!p.manifest.api)
-    .map((p: LoadedPlugin) => ({
-      name: p.manifest.name,
-      version: p.manifest.version,
-      api: p.manifest.api,
-    }));
-});
+export function createPluginsRouter(deps: PluginsRouterDeps = {
+  discoverPackages,
+  invokePlugin,
+}) {
+  const router = new Elysia();
 
-// GET /plugins/:name — invoke plugin via GET (args from query params)
-pluginsRouter.get("/plugins/:name", async ({ params, query, set }) => {
-  const all = discoverPackages();
-  const plugin: LoadedPlugin | undefined = all.find(
-    (p: LoadedPlugin) => p.manifest.name === params.name
-  );
+  // GET /plugins — list all plugins that expose an API surface
+  router.get("/plugins", () => {
+    const all = deps.discoverPackages();
+    return all
+      .filter((p: LoadedPlugin) => !!p.manifest.api)
+      .map((p: LoadedPlugin) => ({
+        name: p.manifest.name,
+        version: p.manifest.version,
+        api: p.manifest.api,
+      }));
+  });
 
-  if (!plugin) {
-    set.status = 404;
-    return { ok: false, error: `plugin '${params.name}' not found` };
-  }
-  if (!plugin.manifest.api?.methods.includes("GET")) {
-    set.status = 405;
-    return { ok: false, error: "method not allowed" };
-  }
-
-  const result: InvokeResult = await invokePlugin(plugin, {
-    source: "api",
-    args: query as Record<string, unknown>,
-  } satisfies InvokeContext);
-
-  if (!result.ok) {
-    set.status = 500;
-    return { ok: false, error: result.error ?? "invoke failed" };
-  }
-  return { ok: true, output: result.output };
-});
-
-// POST /plugins/:name — invoke plugin via POST (args from request body)
-pluginsRouter.post(
-  "/plugins/:name",
-  async ({ params, body, set }) => {
-    const all = discoverPackages();
+  // GET /plugins/:name — invoke plugin via GET (args from query params)
+  router.get("/plugins/:name", async ({ params, query, set }) => {
+    const all = deps.discoverPackages();
     const plugin: LoadedPlugin | undefined = all.find(
       (p: LoadedPlugin) => p.manifest.name === params.name
     );
@@ -70,14 +49,14 @@ pluginsRouter.post(
       set.status = 404;
       return { ok: false, error: `plugin '${params.name}' not found` };
     }
-    if (!plugin.manifest.api?.methods.includes("POST")) {
+    if (!plugin.manifest.api?.methods.includes("GET")) {
       set.status = 405;
       return { ok: false, error: "method not allowed" };
     }
 
-    const result: InvokeResult = await invokePlugin(plugin, {
+    const result: InvokeResult = await deps.invokePlugin(plugin, {
       source: "api",
-      args: (body ?? {}) as Record<string, unknown>,
+      args: query as Record<string, unknown>,
     } satisfies InvokeContext);
 
     if (!result.ok) {
@@ -85,6 +64,41 @@ pluginsRouter.post(
       return { ok: false, error: result.error ?? "invoke failed" };
     }
     return { ok: true, output: result.output };
-  },
-  { body: t.Optional(t.Unknown()) }
-);
+  });
+
+  // POST /plugins/:name — invoke plugin via POST (args from request body)
+  router.post(
+    "/plugins/:name",
+    async ({ params, body, set }) => {
+      const all = deps.discoverPackages();
+      const plugin: LoadedPlugin | undefined = all.find(
+        (p: LoadedPlugin) => p.manifest.name === params.name
+      );
+
+      if (!plugin) {
+        set.status = 404;
+        return { ok: false, error: `plugin '${params.name}' not found` };
+      }
+      if (!plugin.manifest.api?.methods.includes("POST")) {
+        set.status = 405;
+        return { ok: false, error: "method not allowed" };
+      }
+
+      const result: InvokeResult = await deps.invokePlugin(plugin, {
+        source: "api",
+        args: (body ?? {}) as Record<string, unknown>,
+      } satisfies InvokeContext);
+
+      if (!result.ok) {
+        set.status = 500;
+        return { ok: false, error: result.error ?? "invoke failed" };
+      }
+      return { ok: true, output: result.output };
+    },
+    { body: t.Optional(t.Unknown()) }
+  );
+
+  return router;
+}
+
+export const pluginsRouter = createPluginsRouter();

--- a/test/api-plugins.test.ts
+++ b/test/api-plugins.test.ts
@@ -1,26 +1,14 @@
 /**
  * Tests for src/api/plugins.ts — GET/POST /api/plugins surface.
  *
- * Registry is stubbed via mock.module (manifest-foundation may not be landed).
- * Uses Elysia's .handle() for in-process dispatch — no port binding.
+ * Uses the router factory dependency seam so the default suite stays isolated
+ * from the developer machine plugin registry and avoids module-cache mocks.
  */
 
-import { describe, test, expect, beforeAll } from "bun:test";
-import { mock } from "bun:test";
+import { describe, test, expect, beforeEach } from "bun:test";
 import { Elysia } from "elysia";
-
-// --- Stub types (mirrors src/plugin/types.ts contract) ---
-
-interface PluginManifest {
-  name: string;
-  version: string;
-  wasm: string;
-  sdk: string;
-  api?: { path: string; methods: ("GET" | "POST")[] };
-}
-interface LoadedPlugin { manifest: PluginManifest; dir: string; wasmPath: string; }
-
-// --- Stub registry data ---
+import { createPluginsRouter } from "../src/api/plugins";
+import type { InvokeResult, LoadedPlugin } from "../src/plugin/types";
 
 const FAKE_PLUGINS: LoadedPlugin[] = [
   {
@@ -32,34 +20,30 @@ const FAKE_PLUGINS: LoadedPlugin[] = [
     dir: "/tmp/info", wasmPath: "/tmp/info/info.wasm",
   },
   {
+    manifest: { name: "both", version: "0.3.0", wasm: "both.wasm", sdk: "maw", api: { path: "/both", methods: ["GET", "POST"] } },
+    dir: "/tmp/both", wasmPath: "/tmp/both/both.wasm",
+  },
+  {
     manifest: { name: "no-api", version: "0.1.0", wasm: "noop.wasm", sdk: "maw" },
     dir: "/tmp/no-api", wasmPath: "/tmp/no-api/noop.wasm",
   },
 ];
 
-// Mutable invoke result — set per-test to control invokePlugin behaviour
-let fakeInvokeResult: { ok: boolean; output?: string; error?: string } =
-  { ok: true, output: "ok" };
-
-// Register module stubs BEFORE dynamic import of the router
-mock.module("../src/plugin/registry", () => ({
-  discoverPackages: () => FAKE_PLUGINS,
-  invokePlugin: async (_p: LoadedPlugin, _ctx: unknown) => fakeInvokeResult,
-}));
-
-// Stub types module (import type is erased at runtime, but guard for safety)
-mock.module("../src/plugin/types", () => ({}));
-
-// --- Build test app ---
-
+let fakeInvokeResult: InvokeResult = { ok: true, output: "ok" };
+let calls: any[] = [];
 let app: Elysia;
 
-beforeAll(async () => {
-  const { pluginsRouter } = await import("../src/api/plugins");
-  app = new Elysia({ prefix: "/api" }).use(pluginsRouter);
+beforeEach(() => {
+  fakeInvokeResult = { ok: true, output: "ok" };
+  calls = [];
+  app = new Elysia({ prefix: "/api" }).use(createPluginsRouter({
+    discoverPackages: () => FAKE_PLUGINS,
+    invokePlugin: async (plugin, ctx) => {
+      calls.push({ plugin: plugin.manifest.name, ctx });
+      return fakeInvokeResult;
+    },
+  }));
 });
-
-// --- Tests ---
 
 describe("GET /api/plugins", () => {
   test("returns only plugins that expose an api surface", async () => {
@@ -67,8 +51,7 @@ describe("GET /api/plugins", () => {
     expect(res.status).toBe(200);
     const body: { name: string }[] = await res.json();
     expect(Array.isArray(body)).toBe(true);
-    // 'no-api' plugin has no manifest.api — must be excluded
-    expect(body.map(p => p.name)).toEqual(["hello", "info"]);
+    expect(body.map(p => p.name)).toEqual(["hello", "info", "both"]);
   });
 });
 
@@ -88,7 +71,6 @@ describe("POST /api/plugins/:name", () => {
   });
 
   test("405 when POST not listed in manifest.api.methods", async () => {
-    // 'info' plugin only exposes GET
     const res = await app.handle(
       new Request("http://localhost/api/plugins/info", {
         method: "POST",
@@ -114,6 +96,22 @@ describe("POST /api/plugins/:name", () => {
     const body = await res.json();
     expect(body.ok).toBe(true);
     expect(body.output).toBe("hello world");
+    expect(calls).toEqual([
+      { plugin: "hello", ctx: { source: "api", args: { message: "hi" } } },
+    ]);
+  });
+
+  test("defaults missing body to empty args", async () => {
+    fakeInvokeResult = { ok: true, output: "empty" };
+    const res = await app.handle(
+      new Request("http://localhost/api/plugins/hello", { method: "POST" })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true, output: "empty" });
+    expect(calls).toEqual([
+      { plugin: "hello", ctx: { source: "api", args: {} } },
+    ]);
   });
 
   test("500 when invokePlugin returns ok:false", async () => {
@@ -133,6 +131,13 @@ describe("POST /api/plugins/:name", () => {
 });
 
 describe("GET /api/plugins/:name", () => {
+  test("404 for unknown plugin name", async () => {
+    const res = await app.handle(new Request("http://localhost/api/plugins/missing"));
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body).toEqual({ ok: false, error: "plugin 'missing' not found" });
+  });
+
   test("200 for GET-enabled plugin with query args", async () => {
     fakeInvokeResult = { ok: true, output: "info output" };
     const res = await app.handle(
@@ -142,15 +147,27 @@ describe("GET /api/plugins/:name", () => {
     const body = await res.json();
     expect(body.ok).toBe(true);
     expect(body.output).toBe("info output");
+    expect(calls).toEqual([
+      { plugin: "info", ctx: { source: "api", args: { key: "val" } } },
+    ]);
   });
 
   test("405 when GET not listed in manifest.api.methods", async () => {
-    // 'hello' plugin only exposes POST
     const res = await app.handle(
       new Request("http://localhost/api/plugins/hello")
     );
     expect(res.status).toBe(405);
     const body = await res.json();
     expect(body.ok).toBe(false);
+  });
+
+  test("500 with default error when invokePlugin returns ok:false", async () => {
+    fakeInvokeResult = { ok: false };
+    const res = await app.handle(
+      new Request("http://localhost/api/plugins/info")
+    );
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body).toEqual({ ok: false, error: "invoke failed" });
   });
 });


### PR DESCRIPTION
## Summary
- add `createPluginsRouter` so plugin API tests inject registry dependencies directly
- replace brittle `mock.module` coverage in `test/api-plugins.test.ts` with deterministic DI
- cover GET 404, GET invoke failure fallback, POST missing-body args, and existing list/method/invoke paths

## Validation
- `bun test test/api-plugins.test.ts --coverage --coverage-reporter=text --timeout 60000` → `src/api/plugins.ts | 100.00 | 100.00`
- `bun test test/api-plugins.test.ts --timeout 60000`
- `bun run build`
- `git diff --check`
- `grep -R "mock\\.module" test/api-plugins.test.ts || true` → no `mock.module`

## Release
- alpha-only coverage PR
- no release cut

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
