### PR TITLE
test(coverage): cover pair API

### DIFF
--- a/src/api/pair.ts
+++ b/src/api/pair.ts
@@ -15,58 +15,29 @@ import { cmdAdd } from "../lib/peers/impl";
 import { getPeerKey } from "../lib/peer-key";
 import { signAutoPairProof, type AutoPairIdentity } from "../transports/scout-pair-proof";
 
-export const pairApi = new Elysia();
-
 const DEFAULT_TTL_MS = 120_000;
 const results = new Map<string, { consumedAt: number; remoteNode: string; remoteUrl: string }>();
 
-const me = () => {
-  const c = loadConfig();
+export interface PairApiDeps {
+  loadConfig: typeof loadConfig;
+  randomBytes: typeof randomBytes;
+  register: typeof register;
+  lookup: typeof lookup;
+  consume: typeof consume;
+  isValidShape: typeof isValidShape;
+  normalize: typeof normalize;
+  pretty: typeof pretty;
+  generateCode: typeof generateCode;
+  cmdAdd: typeof cmdAdd;
+  getPeerKey: typeof getPeerKey;
+  signAutoPairProof: typeof signAutoPairProof;
+  now: () => number;
+}
+
+const me = (deps: Pick<PairApiDeps, "loadConfig">) => {
+  const c = deps.loadConfig();
   return { node: c.node ?? "local", oracle: c.oracle ?? "mawjs", port: c.port ?? 3456 };
 };
-
-pairApi.post("/pair/generate", ({ body, set }) => {
-  const b = (body ?? {}) as { ttlMs?: number; expires?: number };
-  const ttlMs = typeof b.ttlMs === "number" ? b.ttlMs
-    : typeof b.expires === "number" ? b.expires * 1000 : DEFAULT_TTL_MS;
-  const entry = register(generateCode(), ttlMs);
-  const id = me();
-  set.status = 201;
-  return { ok: true, code: pretty(entry.code), expiresAt: entry.expiresAt, ttlMs, node: id.node, port: id.port };
-});
-
-pairApi.get("/pair/:code/probe", ({ params, set }) => {
-  if (!isValidShape(params.code)) { set.status = 400; return { ok: false, error: "invalid_shape" }; }
-  const r = lookup(params.code);
-  if (!r.ok) { set.status = r.reason === "not_found" ? 404 : 410; return { ok: false, error: r.reason }; }
-  return { ok: true, node: me().node };
-});
-
-pairApi.post("/pair/:code", async ({ params, body, set }) => {
-  if (!isValidShape(params.code)) { set.status = 400; return { ok: false, error: "invalid_shape" }; }
-  const b = (body ?? {}) as { node?: string; url?: string };
-  if (typeof b.node !== "string" || typeof b.url !== "string" || !b.node || !b.url) {
-    set.status = 400; return { ok: false, error: "bad_request" };
-  }
-  const r = consume(params.code);
-  if (!r.ok) { set.status = r.reason === "not_found" ? 404 : 410; return { ok: false, error: r.reason }; }
-  const id = me();
-  try { await cmdAdd({ alias: b.node, url: b.url, node: b.node }); } catch { /* ignore bad remote */ }
-  results.set(normalize(params.code), { consumedAt: Date.now(), remoteNode: b.node, remoteUrl: b.url });
-  return { ok: true, node: id.node, url: `http://localhost:${id.port}`, federationToken: randomBytes(32).toString("hex") };
-});
-
-pairApi.get("/pair/:code/status", ({ params, set }) => {
-  const code = normalize(params.code);
-  const rec = results.get(code);
-  if (rec) return { ok: true, consumed: true, remoteNode: rec.remoteNode, remoteUrl: rec.remoteUrl };
-  const r = lookup(code);
-  if (!r.ok && r.reason === "not_found") { set.status = 404; return { ok: false, error: "not_found" }; }
-  if (!r.ok && r.reason === "expired") { set.status = 410; return { ok: false, error: "expired" }; }
-  return { ok: true, consumed: false };
-});
-
-export function _resetResults(): void { results.clear(); }
 
 // ─── Auto-pair (scout discovery) ─────────────────────────────────────
 
@@ -74,72 +45,140 @@ const recentHellos = new Map<string, number>();
 const HELLO_WINDOW_MS = 60_000;
 
 /** Called by ScoutTransport when a Hello is received, to track zid for anti-replay */
-export function recordHelloZid(zid: string): void {
-  recentHellos.set(zid, Date.now());
+export function recordHelloZid(zid: string, now = Date.now()): void {
+  recentHellos.set(zid, now);
   // prune old entries
-  const cutoff = Date.now() - HELLO_WINDOW_MS;
+  const cutoff = now - HELLO_WINDOW_MS;
   for (const [k, v] of recentHellos) {
     if (v < cutoff) recentHellos.delete(k);
   }
 }
 
-pairApi.post("/pair/auto", async ({ body, set }) => {
-  const b = (body ?? {}) as { node?: string; oracle?: string; url?: string; zid?: string; pubkey?: string; capabilities?: string[] };
+export function _resetResults(): void {
+  results.clear();
+  recentHellos.clear();
+}
 
-  if (!b.node || !b.url || !b.zid) {
-    set.status = 400;
-    return { ok: false, error: "missing_fields" };
-  }
+export function createPairApi(deps: PairApiDeps = {
+  loadConfig,
+  randomBytes,
+  register,
+  lookup,
+  consume,
+  isValidShape,
+  normalize,
+  pretty,
+  generateCode,
+  cmdAdd,
+  getPeerKey,
+  signAutoPairProof,
+  now: Date.now,
+}) {
+  const api = new Elysia();
 
-  // anti-replay: must have seen a Hello from this zid recently
-  const helloTs = recentHellos.get(b.zid);
-  if (!helloTs || Date.now() - helloTs > HELLO_WINDOW_MS) {
-    set.status = 403;
-    return { ok: false, error: "no_recent_hello" };
-  }
+  api.post("/pair/generate", ({ body, set }) => {
+    const b = (body ?? {}) as { ttlMs?: number; expires?: number };
+    const ttlMs = typeof b.ttlMs === "number" ? b.ttlMs
+      : typeof b.expires === "number" ? b.expires * 1000 : DEFAULT_TTL_MS;
+    const entry = deps.register(deps.generateCode(), ttlMs);
+    const id = me(deps);
+    set.status = 201;
+    return { ok: true, code: deps.pretty(entry.code), expiresAt: entry.expiresAt, ttlMs, node: id.node, port: id.port };
+  });
 
-  const id = me();
-  let oneWay: boolean | undefined;
-  try {
-    const addResult = await cmdAdd({
-      alias: b.node,
-      url: b.url,
-      node: b.node,
-      pubkey: typeof b.pubkey === "string" && b.pubkey.length > 0 ? b.pubkey : undefined,
-      identity: b.oracle ? { oracle: b.oracle, node: b.node } : undefined,
-      markSymmetricCheck: true,
-    });
-    if (addResult.pubkeyMismatch) {
-      set.status = 409;
-      return { ok: false, error: addResult.pubkeyMismatch.message };
+  api.get("/pair/:code/probe", ({ params, set }) => {
+    if (!deps.isValidShape(params.code)) { set.status = 400; return { ok: false, error: "invalid_shape" }; }
+    const r = deps.lookup(params.code);
+    if (!r.ok) { set.status = r.reason === "not_found" ? 404 : 410; return { ok: false, error: r.reason }; }
+    return { ok: true, node: me(deps).node };
+  });
+
+  api.post("/pair/:code", async ({ params, body, set }) => {
+    if (!deps.isValidShape(params.code)) { set.status = 400; return { ok: false, error: "invalid_shape" }; }
+    const b = (body ?? {}) as { node?: string; url?: string };
+    if (typeof b.node !== "string" || typeof b.url !== "string" || !b.node || !b.url) {
+      set.status = 400; return { ok: false, error: "bad_request" };
     }
-    oneWay = addResult.peer.oneWay;
-  } catch (err) {
-    set.status = 400;
-    return { ok: false, error: err instanceof Error ? err.message : String(err) };
-  }
+    const r = deps.consume(params.code);
+    if (!r.ok) { set.status = r.reason === "not_found" ? 404 : 410; return { ok: false, error: r.reason }; }
+    const id = me(deps);
+    try { await deps.cmdAdd({ alias: b.node, url: b.url, node: b.node }); } catch { /* ignore bad remote */ }
+    results.set(deps.normalize(params.code), { consumedAt: deps.now(), remoteNode: b.node, remoteUrl: b.url });
+    return { ok: true, node: id.node, url: `http://localhost:${id.port}`, federationToken: deps.randomBytes(32).toString("hex") };
+  });
 
-  recentHellos.delete(b.zid);
-  const config = loadConfig();
-  const pubkey = getPeerKey();
-  const url = `http://localhost:${id.port}`;
-  const identity: AutoPairIdentity = {
-    node: id.node,
-    oracle: id.oracle,
-    url,
-    pubkey,
-  };
-  const proof = config.federationToken
-    ? signAutoPairProof(identity, config.federationToken)
-    : undefined;
+  api.get("/pair/:code/status", ({ params, set }) => {
+    const code = deps.normalize(params.code);
+    const rec = results.get(code);
+    if (rec) return { ok: true, consumed: true, remoteNode: rec.remoteNode, remoteUrl: rec.remoteUrl };
+    const r = deps.lookup(code);
+    if (!r.ok && r.reason === "not_found") { set.status = 404; return { ok: false, error: "not_found" }; }
+    if (!r.ok && r.reason === "expired") { set.status = 410; return { ok: false, error: "expired" }; }
+    return { ok: true, consumed: false };
+  });
 
-  return {
-    ok: true,
-    node: id.node,
-    oracle: id.oracle,
-    url,
-    pubkey,
-    proof,
-    oneWay,
-  };
-});
+  api.post("/pair/auto", async ({ body, set }) => {
+    const b = (body ?? {}) as { node?: string; oracle?: string; url?: string; zid?: string; pubkey?: string; capabilities?: string[] };
+
+    if (!b.node || !b.url || !b.zid) {
+      set.status = 400;
+      return { ok: false, error: "missing_fields" };
+    }
+
+    // anti-replay: must have seen a Hello from this zid recently
+    const helloTs = recentHellos.get(b.zid);
+    if (!helloTs || deps.now() - helloTs > HELLO_WINDOW_MS) {
+      set.status = 403;
+      return { ok: false, error: "no_recent_hello" };
+    }
+
+    const id = me(deps);
+    let oneWay: boolean | undefined;
+    try {
+      const addResult = await deps.cmdAdd({
+        alias: b.node,
+        url: b.url,
+        node: b.node,
+        pubkey: typeof b.pubkey === "string" && b.pubkey.length > 0 ? b.pubkey : undefined,
+        identity: b.oracle ? { oracle: b.oracle, node: b.node } : undefined,
+        markSymmetricCheck: true,
+      });
+      if (addResult.pubkeyMismatch) {
+        set.status = 409;
+        return { ok: false, error: addResult.pubkeyMismatch.message };
+      }
+      oneWay = addResult.peer.oneWay;
+    } catch (err) {
+      set.status = 400;
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+
+    recentHellos.delete(b.zid);
+    const config = deps.loadConfig();
+    const pubkey = deps.getPeerKey();
+    const url = `http://localhost:${id.port}`;
+    const identity: AutoPairIdentity = {
+      node: id.node,
+      oracle: id.oracle,
+      url,
+      pubkey,
+    };
+    const proof = config.federationToken
+      ? deps.signAutoPairProof(identity, config.federationToken)
+      : undefined;
+
+    return {
+      ok: true,
+      node: id.node,
+      oracle: id.oracle,
+      url,
+      pubkey,
+      proof,
+      oneWay,
+    };
+  });
+
+  return api;
+}
+
+export const pairApi = createPairApi();

--- a/test/isolated/auto-pair-mutual.test.ts
+++ b/test/isolated/auto-pair-mutual.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs"
 import { tmpdir } from "os";
 import { join } from "path";
 import { Elysia } from "elysia";
+import { randomBytes } from "crypto";
 
 const TEST_HOME = mkdtempSync(join(tmpdir(), "maw-auto-pair-1494-"));
 const TOKEN = "0123456789abcdef-auto-pair-token";
@@ -24,11 +25,32 @@ writeFileSync(
   }, null, 2),
 );
 
-const { pairApi, recordHelloZid } = await import("../../src/api/pair");
-const { verifyAutoPairProof } = await import("../../src/transports/scout-pair-proof");
+const { createPairApi, recordHelloZid } = await import("../../src/api/pair");
+const pairCodes = await import("../../src/lib/pair-codes");
+const { cmdAdd } = await import("../../src/lib/peers/impl");
+const { getPeerKey } = await import("../../src/lib/peer-key");
+const { signAutoPairProof, verifyAutoPairProof } = await import("../../src/transports/scout-pair-proof");
 const { initiatePair } = await import("../../src/transports/scout-pair");
 
-const app = new Elysia().use(pairApi);
+function loadTestConfig() {
+  return JSON.parse(readFileSync(join(TEST_HOME, "config", "maw.config.json"), "utf-8"));
+}
+
+const app = new Elysia().use(createPairApi({
+  loadConfig: loadTestConfig as any,
+  randomBytes,
+  register: pairCodes.register,
+  lookup: pairCodes.lookup,
+  consume: pairCodes.consume,
+  isValidShape: pairCodes.isValidShape,
+  normalize: pairCodes.normalize,
+  pretty: pairCodes.pretty,
+  generateCode: pairCodes.generateCode,
+  cmdAdd,
+  getPeerKey,
+  signAutoPairProof,
+  now: Date.now,
+}));
 
 afterAll(() => {
   rmSync(TEST_HOME, { recursive: true, force: true });

--- a/test/pair-api-default.test.ts
+++ b/test/pair-api-default.test.ts
@@ -1,0 +1,308 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { Elysia } from "elysia";
+import {
+  _resetResults,
+  createPairApi,
+  recordHelloZid,
+  type PairApiDeps,
+} from "../src/api/pair";
+import {
+  isValidShape,
+  normalize,
+  pretty,
+  type PairEntry,
+  type LookupResult,
+} from "../src/lib/pair-codes";
+
+interface Harness {
+  app: Elysia;
+  entries: Map<string, PairEntry>;
+  addCalls: any[];
+  setNow(value: number): void;
+  setCmdAdd(fn: PairApiDeps["cmdAdd"]): void;
+  setConfig(config: any): void;
+}
+
+function json(res: Response): Promise<any> {
+  return res.json();
+}
+
+function makeHarness(): Harness {
+  const entries = new Map<string, PairEntry>();
+  const addCalls: any[] = [];
+  let now = 1_000_000;
+  let config: any = { node: "node-a", oracle: "oracle-a", port: 4567, federationToken: "token-a" };
+  let cmdAdd: PairApiDeps["cmdAdd"] = (async (opts) => {
+    addCalls.push(opts);
+    return {
+      alias: opts.alias,
+      overwrote: false,
+      peer: {
+        url: opts.url,
+        node: opts.node ?? null,
+        oneWay: true,
+        addedAt: new Date(now).toISOString(),
+      },
+    } as any;
+  }) as PairApiDeps["cmdAdd"];
+
+  const lookup = ((code: string): LookupResult => {
+    const entry = entries.get(normalize(code));
+    if (!entry) return { ok: false, reason: "not_found" };
+    if (entry.consumed) return { ok: false, reason: "consumed" };
+    if (now > entry.expiresAt) return { ok: false, reason: "expired" };
+    return { ok: true, entry };
+  }) as PairApiDeps["lookup"];
+
+  const deps: PairApiDeps = {
+    loadConfig: (() => config) as PairApiDeps["loadConfig"],
+    randomBytes: ((size: number) => Buffer.alloc(size, 0xab)) as PairApiDeps["randomBytes"],
+    register: ((code: string, ttlMs: number) => {
+      const entry = { code: normalize(code), expiresAt: now + ttlMs, consumed: false, createdAt: now };
+      entries.set(entry.code, entry);
+      return entry;
+    }) as PairApiDeps["register"],
+    lookup,
+    consume: ((code: string) => {
+      const result = lookup(code);
+      if (!result.ok) return result;
+      result.entry.consumed = true;
+      return result;
+    }) as PairApiDeps["consume"],
+    isValidShape,
+    normalize,
+    pretty,
+    generateCode: () => "ABC234",
+    cmdAdd: ((opts) => cmdAdd(opts)) as PairApiDeps["cmdAdd"],
+    getPeerKey: () => "p".repeat(64),
+    signAutoPairProof: ((identity, token) => `proof:${identity.node}:${identity.pubkey}:${token}`) as PairApiDeps["signAutoPairProof"],
+    now: () => now,
+  };
+
+  return {
+    app: new Elysia().use(createPairApi(deps)),
+    entries,
+    addCalls,
+    setNow(value: number) { now = value; },
+    setCmdAdd(fn: PairApiDeps["cmdAdd"]) { cmdAdd = fn; },
+    setConfig(next: any) { config = next; },
+  };
+}
+
+beforeEach(() => {
+  _resetResults();
+});
+
+describe("pair API default-suite coverage", () => {
+  test("default router factory is constructible", () => {
+    expect(createPairApi()).toBeInstanceOf(Elysia);
+  });
+
+  test("generates pretty pair codes with default, expires, and ttlMs TTL inputs", async () => {
+    const h = makeHarness();
+
+    let res = await h.app.handle(new Request("http://local/pair/generate", { method: "POST" }));
+    expect(res.status).toBe(201);
+    expect(await json(res)).toMatchObject({
+      ok: true,
+      code: "ABC-234",
+      expiresAt: 1_120_000,
+      ttlMs: 120_000,
+      node: "node-a",
+      port: 4567,
+    });
+
+    res = await h.app.handle(new Request("http://local/pair/generate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ expires: 5 }),
+    }));
+    expect(await json(res)).toMatchObject({ ttlMs: 5_000, expiresAt: 1_005_000 });
+
+    res = await h.app.handle(new Request("http://local/pair/generate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ttlMs: 42 }),
+    }));
+    expect(await json(res)).toMatchObject({ ttlMs: 42, expiresAt: 1_000_042 });
+  });
+
+  test("probes invalid, missing, expired, and live pair codes", async () => {
+    const h = makeHarness();
+
+    let res = await h.app.handle(new Request("http://local/pair/bad/probe"));
+    expect(res.status).toBe(400);
+    expect(await json(res)).toEqual({ ok: false, error: "invalid_shape" });
+
+    res = await h.app.handle(new Request("http://local/pair/ABC234/probe"));
+    expect(res.status).toBe(404);
+    expect(await json(res)).toEqual({ ok: false, error: "not_found" });
+
+    h.entries.set("ABC234", { code: "ABC234", createdAt: 0, expiresAt: 1, consumed: false });
+    res = await h.app.handle(new Request("http://local/pair/ABC234/probe"));
+    expect(res.status).toBe(410);
+    expect(await json(res)).toEqual({ ok: false, error: "expired" });
+
+    h.entries.set("ABC234", { code: "ABC234", createdAt: 0, expiresAt: 2_000_000, consumed: false });
+    res = await h.app.handle(new Request("http://local/pair/ABC234/probe"));
+    expect(res.status).toBe(200);
+    expect(await json(res)).toEqual({ ok: true, node: "node-a" });
+  });
+
+  test("accepts pair posts, records consumed status, and ignores cmdAdd failures", async () => {
+    const h = makeHarness();
+
+    let res = await h.app.handle(new Request("http://local/pair/bad", { method: "POST" }));
+    expect(res.status).toBe(400);
+    expect(await json(res)).toEqual({ ok: false, error: "invalid_shape" });
+
+    res = await h.app.handle(new Request("http://local/pair/ABC234", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ node: "remote" }),
+    }));
+    expect(res.status).toBe(400);
+    expect(await json(res)).toEqual({ ok: false, error: "bad_request" });
+
+    res = await h.app.handle(new Request("http://local/pair/ABC234", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ node: "remote", url: "http://remote" }),
+    }));
+    expect(res.status).toBe(404);
+    expect(await json(res)).toEqual({ ok: false, error: "not_found" });
+
+    h.entries.set("ABC234", { code: "ABC234", createdAt: 0, expiresAt: 1, consumed: false });
+    res = await h.app.handle(new Request("http://local/pair/ABC234", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ node: "remote", url: "http://remote" }),
+    }));
+    expect(res.status).toBe(410);
+    expect(await json(res)).toEqual({ ok: false, error: "expired" });
+
+    h.entries.set("ABC234", { code: "ABC234", createdAt: 0, expiresAt: 2_000_000, consumed: false });
+    h.setCmdAdd((async () => { throw new Error("peer write failed"); }) as PairApiDeps["cmdAdd"]);
+    res = await h.app.handle(new Request("http://local/pair/ABC234", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ node: "remote", url: "http://remote" }),
+    }));
+    expect(res.status).toBe(200);
+    expect(await json(res)).toEqual({
+      ok: true,
+      node: "node-a",
+      url: "http://localhost:4567",
+      federationToken: "ab".repeat(32),
+    });
+
+    res = await h.app.handle(new Request("http://local/pair/ABC-234/status"));
+    expect(res.status).toBe(200);
+    expect(await json(res)).toEqual({ ok: true, consumed: true, remoteNode: "remote", remoteUrl: "http://remote" });
+  });
+
+  test("reports pending, missing, and expired status for unconsumed codes", async () => {
+    const h = makeHarness();
+
+    let res = await h.app.handle(new Request("http://local/pair/ABC234/status"));
+    expect(res.status).toBe(404);
+    expect(await json(res)).toEqual({ ok: false, error: "not_found" });
+
+    h.entries.set("ABC234", { code: "ABC234", createdAt: 0, expiresAt: 1, consumed: false });
+    res = await h.app.handle(new Request("http://local/pair/ABC234/status"));
+    expect(res.status).toBe(410);
+    expect(await json(res)).toEqual({ ok: false, error: "expired" });
+
+    h.entries.set("ABC234", { code: "ABC234", createdAt: 0, expiresAt: 2_000_000, consumed: false });
+    res = await h.app.handle(new Request("http://local/pair/ABC234/status"));
+    expect(res.status).toBe(200);
+    expect(await json(res)).toEqual({ ok: true, consumed: false });
+  });
+
+  test("auto-pair validates hello freshness, reports add errors, and returns signed identity", async () => {
+    const h = makeHarness();
+
+    let res = await h.app.handle(new Request("http://local/pair/auto", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ node: "remote" }),
+    }));
+    expect(res.status).toBe(400);
+    expect(await json(res)).toEqual({ ok: false, error: "missing_fields" });
+
+    res = await h.app.handle(new Request("http://local/pair/auto", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ node: "remote", url: "http://remote", zid: "missing" }),
+    }));
+    expect(res.status).toBe(403);
+    expect(await json(res)).toEqual({ ok: false, error: "no_recent_hello" });
+
+    recordHelloZid("old", 0);
+    recordHelloZid("fresh", 70_001);
+    h.setNow(70_001);
+    res = await h.app.handle(new Request("http://local/pair/auto", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ node: "remote", url: "http://remote", zid: "old" }),
+    }));
+    expect(res.status).toBe(403);
+    expect(await json(res)).toEqual({ ok: false, error: "no_recent_hello" });
+
+    recordHelloZid("mismatch", 70_001);
+    h.setCmdAdd((async () => ({ pubkeyMismatch: { message: "key mismatch" }, peer: {} })) as PairApiDeps["cmdAdd"]);
+    res = await h.app.handle(new Request("http://local/pair/auto", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ node: "remote", url: "http://remote", zid: "mismatch" }),
+    }));
+    expect(res.status).toBe(409);
+    expect(await json(res)).toEqual({ ok: false, error: "key mismatch" });
+
+    recordHelloZid("throws", 70_001);
+    h.setCmdAdd((async () => { throw "bad peer"; }) as PairApiDeps["cmdAdd"]);
+    res = await h.app.handle(new Request("http://local/pair/auto", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ node: "remote", url: "http://remote", zid: "throws" }),
+    }));
+    expect(res.status).toBe(400);
+    expect(await json(res)).toEqual({ ok: false, error: "bad peer" });
+
+    recordHelloZid("success", 70_001);
+    h.setConfig({ node: "node-a", oracle: "oracle-a", port: 4567, federationToken: "token-a" });
+    h.setCmdAdd((async (opts) => {
+      h.addCalls.push(opts);
+      return { peer: { oneWay: false } } as any;
+    }) as PairApiDeps["cmdAdd"]);
+    res = await h.app.handle(new Request("http://local/pair/auto", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        node: "remote",
+        oracle: "remote-oracle",
+        url: "http://remote",
+        zid: "success",
+        pubkey: "r".repeat(64),
+      }),
+    }));
+    expect(res.status).toBe(200);
+    expect(await json(res)).toEqual({
+      ok: true,
+      node: "node-a",
+      oracle: "oracle-a",
+      url: "http://localhost:4567",
+      pubkey: "p".repeat(64),
+      proof: `proof:node-a:${"p".repeat(64)}:token-a`,
+      oneWay: false,
+    });
+    expect(h.addCalls.at(-1)).toMatchObject({
+      alias: "remote",
+      url: "http://remote",
+      node: "remote",
+      pubkey: "r".repeat(64),
+      identity: { oracle: "remote-oracle", node: "remote" },
+      markSymmetricCheck: true,
+    });
+  });
+});

--- a/test/scout-transport-coverage.test.ts
+++ b/test/scout-transport-coverage.test.ts
@@ -123,8 +123,8 @@ mock.module(join(import.meta.dir, "../src/lib/peers/store"), () => ({
 
 mock.module(join(import.meta.dir, "../src/transports/scout-pair"), () => ({
   ..._rPair,
-  initiatePair: async (peer: any, localNode: string, localOracle: string, localPort: number) => {
-    if (!mockActive) return real.initiatePair(peer, localNode, localOracle, localPort);
+  initiatePair: async (peer: any, localNode: string, localOracle: string, localPort: number, deps?: any) => {
+    if (!mockActive) return real.initiatePair(peer, localNode, localOracle, localPort, deps);
     pairCalls.push({ zid: peer.zid, localNode, localOracle, localPort });
     return pairResults.shift() ?? { ok: true };
   },
@@ -132,8 +132,8 @@ mock.module(join(import.meta.dir, "../src/transports/scout-pair"), () => ({
 
 mock.module(join(import.meta.dir, "../src/api/pair"), () => ({
   ..._rApiPair,
-  recordHelloZid: (zid: string) => {
-    if (!mockActive) return real.recordHelloZid(zid);
+  recordHelloZid: (zid: string, now?: number) => {
+    if (!mockActive) return real.recordHelloZid(zid, now);
     recordHelloCalls.push(zid);
   },
 }));


### PR DESCRIPTION
## Summary
- add `createPairApi` so pair API routes can be tested with injected config/code/peer/proof dependencies
- cover manual pair generate/probe/accept/status paths and scout auto-pair success/error paths
- harden existing scout/auto-pair tests so module wrappers preserve optional args/deps and do not leak ambient config

## Validation
- `bun test test/pair-api-default.test.ts --coverage --coverage-reporter=text --timeout 60000` → `src/api/pair.ts | 100.00 | 100.00`
- `bun test test/pair-api-default.test.ts test/isolated/auto-pair-mutual.test.ts test/scout-transport-coverage.test.ts --timeout 60000`
- `bun run build`
- `git diff --check`
- `grep -R "mock\\.module" test/pair-api-default.test.ts || true` → no `mock.module`

## Release
- alpha-only coverage PR
- no release cut

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
