### PR TITLE
test(coverage): cover consent API loopback branches

### DIFF
--- a/src/api/consent.ts
+++ b/src/api/consent.ts
@@ -26,7 +26,7 @@ import {
 
 export const consentApi = new Elysia();
 
-function isLoopback(remoteAddress: string | undefined | null): boolean {
+export function isLoopbackAddress(remoteAddress: string | undefined | null): boolean {
   if (!remoteAddress) return true; // local in-process call (no socket)
   return remoteAddress === "127.0.0.1"
     || remoteAddress === "::1"
@@ -66,7 +66,7 @@ consentApi.post("/consent/request", async ({ body, set }) => {
 
 // --- GET /consent/list — operator view (loopback-only) ---
 consentApi.get("/consent/list", ({ server, request, set }) => {
-  if (!isLoopback(clientAddr(server, request))) { set.status = 403; return { ok: false, error: "loopback only" }; }
+  if (!isLoopbackAddress(clientAddr(server, request))) { set.status = 403; return { ok: false, error: "loopback only" }; }
   return { ok: true, pending: listPending() };
 });
 
@@ -81,7 +81,7 @@ consentApi.get("/consent/:id", ({ params, set }) => {
 
 // --- POST /consent/:id/approve — operator approves with PIN (loopback) ---
 consentApi.post("/consent/:id/approve", async ({ params, body, server, request, set }) => {
-  if (!isLoopback(clientAddr(server, request))) { set.status = 403; return { ok: false, error: "loopback only" }; }
+  if (!isLoopbackAddress(clientAddr(server, request))) { set.status = 403; return { ok: false, error: "loopback only" }; }
   const b = (body ?? {}) as { pin?: string };
   if (typeof b.pin !== "string" || !b.pin) { set.status = 400; return { ok: false, error: "pin required" }; }
   const r = await approveConsent(params.id, b.pin);
@@ -91,7 +91,7 @@ consentApi.post("/consent/:id/approve", async ({ params, body, server, request, 
 
 // --- POST /consent/:id/reject — operator rejects (loopback) ---
 consentApi.post("/consent/:id/reject", ({ params, server, request, set }) => {
-  if (!isLoopback(clientAddr(server, request))) { set.status = 403; return { ok: false, error: "loopback only" }; }
+  if (!isLoopbackAddress(clientAddr(server, request))) { set.status = 403; return { ok: false, error: "loopback only" }; }
   const r = rejectConsent(params.id);
   if (!r.ok) { set.status = 400; return r; }
   return { ok: true };

--- a/test/core/consent/api.test.ts
+++ b/test/core/consent/api.test.ts
@@ -12,7 +12,7 @@ import { mkdtempSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 
-import { consentApi } from "../../../src/api/consent";
+import { consentApi, isLoopbackAddress } from "../../../src/api/consent";
 import { hashPin, isTrusted, listPending } from "../../../src/core/consent";
 
 let workdir: string;
@@ -160,5 +160,18 @@ describe("GET /consent/list", () => {
     const body = await res.json() as any;
     expect(body.ok).toBe(true);
     expect(body.pending.length).toBe(2);
+  });
+});
+
+describe("loopback address helper", () => {
+  it("accepts local addresses and rejects remote addresses", () => {
+    expect(isLoopbackAddress(undefined)).toBe(true);
+    expect(isLoopbackAddress(null)).toBe(true);
+    expect(isLoopbackAddress("127.0.0.1")).toBe(true);
+    expect(isLoopbackAddress("127.0.0.2")).toBe(true);
+    expect(isLoopbackAddress("::1")).toBe(true);
+    expect(isLoopbackAddress("::ffff:127.0.0.1")).toBe(true);
+    expect(isLoopbackAddress("localhost")).toBe(true);
+    expect(isLoopbackAddress("10.0.0.2")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- export the consent API loopback address helper for direct pure testing
- cover undefined/null/local IPv4/IPv6/localhost and remote address branches
- keep existing in-process consent API tests unchanged in behavior

## Validation
- `bun test test/core/consent/api.test.ts --coverage --coverage-reporter=text --timeout 60000` → `src/api/consent.ts | 100.00 | 100.00`
- `bun test test/core/consent/api.test.ts --timeout 60000`
- `bun run build`
- `git diff --check`

## Release
- alpha-only coverage PR
- no release cut

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
