### PR TITLE
test(coverage): cover engine unregister errors

### DIFF
--- a/test/isolated/engine-api.test.ts
+++ b/test/isolated/engine-api.test.ts
@@ -39,6 +39,21 @@ describe("dynamic engine API (#1566)", () => {
     expect(listEnginePluginRegistrations()).toEqual([]);
   });
 
+
+  test("bad unregister requests return 400 instead of throwing", async () => {
+    const response = await engineApi.handle(new Request("http://maw.local/_engine/unregister", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ plugin: "Bad_Plugin" }),
+    }));
+    const body = await response.json() as Record<string, unknown>;
+
+    expect(response.status).toBe(400);
+    expect(body.ok).toBe(false);
+    expect(String(body.error)).toContain("engine plugin must match");
+    expect(listEnginePluginRegistrations()).toEqual([]);
+  });
+
   test("bad registrations return 400 instead of binding unsafe routes", async () => {
     const response = await engineApi.handle(new Request("http://maw.local/_engine/register", {
       method: "POST",


### PR DESCRIPTION
## Summary
- add a focused engine API regression test for invalid unregister payloads
- covers the unregister catch branch without changing production behavior

## Validation
- `bun test test/isolated/engine-api.test.ts --coverage --coverage-reporter=text --timeout 60000`
  - `src/api/engine.ts | 100.00 | 100.00`
- `bun test test/isolated/engine-api.test.ts --timeout 60000`
- `bun run build`
- `git diff --check`

## Release
- Alpha branch only.
- No release cut.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
