### PR TITLE
test(coverage): cover proxy allowlisted mutations

### DIFF
--- a/src/api/proxy-routes.ts
+++ b/src/api/proxy-routes.ts
@@ -5,13 +5,36 @@ import { setProxySessionCookie, hasValidProxySessionCookie, parseProxySignature 
 import { isKnownMethod, isReadOnlyMethod, isPathProxyable, isProxyShellPeerAllowed, READONLY_METHODS, MUTATING_METHODS } from "./proxy-trust";
 import { resolveProxyPeerUrl, relayHttpToPeer } from "./proxy-relay";
 
-export const proxyApi = new Elysia();
+export interface ProxyApiDeps {
+  setProxySessionCookie?: typeof setProxySessionCookie;
+  hasValidProxySessionCookie?: typeof hasValidProxySessionCookie;
+  parseProxySignature?: typeof parseProxySignature;
+  isKnownMethod?: typeof isKnownMethod;
+  isReadOnlyMethod?: typeof isReadOnlyMethod;
+  isPathProxyable?: typeof isPathProxyable;
+  isProxyShellPeerAllowed?: typeof isProxyShellPeerAllowed;
+  resolveProxyPeerUrl?: typeof resolveProxyPeerUrl;
+  relayHttpToPeer?: typeof relayHttpToPeer;
+}
+
+export function createProxyApi(deps: ProxyApiDeps = {}) {
+  const setProxyCookie = deps.setProxySessionCookie ?? setProxySessionCookie;
+  const hasValidCookie = deps.hasValidProxySessionCookie ?? hasValidProxySessionCookie;
+  const parseSignature = deps.parseProxySignature ?? parseProxySignature;
+  const knownMethod = deps.isKnownMethod ?? isKnownMethod;
+  const readOnlyMethod = deps.isReadOnlyMethod ?? isReadOnlyMethod;
+  const pathProxyable = deps.isPathProxyable ?? isPathProxyable;
+  const shellPeerAllowed = deps.isProxyShellPeerAllowed ?? isProxyShellPeerAllowed;
+  const resolvePeerUrl = deps.resolveProxyPeerUrl ?? resolveProxyPeerUrl;
+  const relayToPeer = deps.relayHttpToPeer ?? relayHttpToPeer;
+
+  const proxyApi = new Elysia();
 
 /**
  * GET /api/proxy/session — bootstrap a proxy session cookie.
  */
 proxyApi.get("/proxy/session", ({ set }) => {
-  setProxySessionCookie(set);
+  setProxyCookie(set);
   return { ok: true, rotates: "on_server_restart" };
 });
 
@@ -40,7 +63,7 @@ proxyApi.post("/proxy", async ({ body, set, request }) => {
   }
 
   // 1. Parse signature
-  const parsed = parseProxySignature(signature);
+  const parsed = parseSignature(signature);
   if (!parsed) {
     set.status = 400;
     return { error: "bad_signature", expected: "[host:agent]" };
@@ -49,21 +72,21 @@ proxyApi.post("/proxy", async ({ body, set, request }) => {
   // 2. Session cookie check
   // Bypass ONLY when explicitly in dev mode. Default (unset NODE_ENV) = secure.
   const devBypass = process.env.NODE_ENV === "development";
-  if (!devBypass && !hasValidProxySessionCookie(request)) {
+  if (!devBypass && !hasValidCookie(request)) {
     set.status = 401;
     return { error: "no_session", hint: "GET /api/proxy/session first" };
   }
 
   // 3. Method classification
-  if (!isKnownMethod(method)) {
+  if (!knownMethod(method)) {
     set.status = 400;
     return { error: "unknown_method", method, allowed: [...READONLY_METHODS, ...MUTATING_METHODS] };
   }
 
   // 4. Trust boundary: readonly methods always OK; mutations need allowlist
-  const readonly = isReadOnlyMethod(method);
+  const readonly = readOnlyMethod(method);
   if (!readonly) {
-    const allowed = isProxyShellPeerAllowed(parsed.originHost);
+    const allowed = shellPeerAllowed(parsed.originHost);
     if (!allowed) {
       set.status = 403;
       return {
@@ -78,13 +101,13 @@ proxyApi.post("/proxy", async ({ body, set, request }) => {
   }
 
   // 5. Path allowlist
-  if (!isPathProxyable(path)) {
+  if (!pathProxyable(path)) {
     set.status = 403;
     return { error: "path_not_proxyable", path, hint: "only v1 REST endpoints are proxyable in the prototype" };
   }
 
   // 6. Resolve peer
-  const peerUrl = resolveProxyPeerUrl(peer);
+  const peerUrl = resolvePeerUrl(peer);
   if (!peerUrl) {
     set.status = 404;
     return { error: "unknown_peer", peer };
@@ -92,7 +115,7 @@ proxyApi.post("/proxy", async ({ body, set, request }) => {
 
   // 7. Relay and return
   try {
-    const result = await relayHttpToPeer(peerUrl, method, path, forwardBody);
+    const result = await relayToPeer(peerUrl, method, path, forwardBody);
     return {
       status: result.status,
       headers: result.headers,
@@ -106,3 +129,8 @@ proxyApi.post("/proxy", async ({ body, set, request }) => {
     return { error: "relay_failed", peer: peerUrl, reason: err?.message ?? String(err) };
   }
 });
+
+  return proxyApi;
+}
+
+export const proxyApi = createProxyApi();

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -29,6 +29,7 @@ import {
   proxyApi,
 } from "../src/api/proxy";
 import { relayHttpToPeer } from "../src/api/proxy-relay";
+import { createProxyApi } from "../src/api/proxy-routes";
 
 // ---- Pure helper tests ---------------------------------------------------
 
@@ -524,6 +525,52 @@ describe("POST /api/proxy (trust flow)", () => {
     } finally {
       globalThis.fetch = oldFetch;
     }
+  });
+
+
+  test("allowlisted mutations relay with shell trust tier", async () => {
+    const relayCalls: any[] = [];
+    const app = new Elysia({ prefix: "/api" }).use(createProxyApi({
+      hasValidProxySessionCookie: () => true,
+      parseProxySignature: () => ({ originHost: "trusted-host", originAgent: "operator", isAnon: false }),
+      isKnownMethod: () => true,
+      isReadOnlyMethod: () => false,
+      isProxyShellPeerAllowed: (origin) => origin === "trusted-host",
+      isPathProxyable: () => true,
+      resolveProxyPeerUrl: () => "http://peer.local:3456",
+      relayHttpToPeer: (async (peerUrl, method, path, forwardBody) => {
+        relayCalls.push({ peerUrl, method, path, forwardBody });
+        return { status: 202, headers: { "content-type": "application/json" }, body: "accepted", elapsedMs: 7 };
+      }) as typeof relayHttpToPeer,
+    }));
+
+    const res = await app.handle(new Request("http://localhost/api/proxy", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: "proxy_session=fake" },
+      body: JSON.stringify({
+        peer: "peer",
+        method: "POST",
+        path: "/api/ping",
+        body: "{}",
+        signature: "[trusted-host:operator]",
+      }),
+    }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      status: 202,
+      headers: { "content-type": "application/json" },
+      body: "accepted",
+      from: "http://peer.local:3456",
+      elapsed_ms: 7,
+      trust_tier: "shell_allowlisted",
+    });
+    expect(relayCalls).toEqual([{
+      peerUrl: "http://peer.local:3456",
+      method: "POST",
+      path: "/api/ping",
+      forwardBody: "{}",
+    }]);
   });
 
   test("relay failures surface as 502 with peer URL and reason", async () => {


### PR DESCRIPTION
## Summary
- add `createProxyApi()` with injectable route helpers while preserving the production `proxyApi`
- add a focused route test for allowlisted mutating proxy requests
- covers the `shell_allowlisted` branch in `src/api/proxy-routes.ts`

## Validation
- `bun test test/proxy.test.ts --coverage --coverage-reporter=text --timeout 60000`
  - `src/api/proxy-routes.ts | 100.00 | 100.00`
- `bun test test/proxy.test.ts --timeout 60000`
- `bun run build`
- `git diff --check`

## Release
- Alpha branch only.
- No release cut.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
