### PR TITLE
test(coverage): cover peer exec relay

### DIFF
--- a/src/api/peer-exec.ts
+++ b/src/api/peer-exec.ts
@@ -14,7 +14,7 @@
  *   Issues a localhost-only cookie on first request, verifies on subsequent calls.
  */
 
-import { Elysia, t} from "elysia";
+import { Elysia, t } from "elysia";
 import { loadConfig } from "../config";
 import { signHeaders } from "../lib/federation-auth";
 import {
@@ -30,28 +30,41 @@ export { parseSignature, isReadOnlyCmd, isShellPeerAllowed, resolvePeerUrl } fro
 
 // --- Relay ---------------------------------------------------------------
 
-interface RelayResult {
+export interface PeerExecRelayResult {
   output: string;
   from: string;
   elapsedMs: number;
   status: number;
 }
 
-async function relayToPeer(
+export interface PeerExecRelayDeps {
+  loadConfig?: typeof loadConfig;
+  signHeaders?: typeof signHeaders;
+  fetch?: typeof fetch;
+  now?: () => number;
+}
+
+export async function relayToPeer(
   peerUrl: string,
   body: { cmd: string; args: string[]; signature: string },
-): Promise<RelayResult> {
-  const start = Date.now();
+  deps: PeerExecRelayDeps = {},
+): Promise<PeerExecRelayResult> {
+  const load = deps.loadConfig ?? loadConfig;
+  const sign = deps.signHeaders ?? signHeaders;
+  const fetchImpl = deps.fetch ?? fetch;
+  const now = deps.now ?? (() => Date.now());
+
+  const start = now();
   const path = "/api/peer/exec";
   const headers: Record<string, string> = { "Content-Type": "application/json" };
 
-  const config = loadConfig() as any;
+  const config = load() as any;
   const token = config?.federationToken;
   if (token) {
-    Object.assign(headers, signHeaders(token, "POST", path));
+    Object.assign(headers, sign(token, "POST", path));
   }
 
-  const response = await fetch(`${peerUrl}${path}`, {
+  const response = await fetchImpl(`${peerUrl}${path}`, {
     method: "POST",
     headers,
     body: JSON.stringify(body),
@@ -61,79 +74,103 @@ async function relayToPeer(
   return {
     output: text,
     from: peerUrl,
-    elapsedMs: Date.now() - start,
+    elapsedMs: now() - start,
     status: response.status,
   };
 }
 
 // --- Route ---------------------------------------------------------------
 
-export const peerExecApi = new Elysia();
+export interface PeerExecApiDeps {
+  setSessionCookie?: typeof setSessionCookie;
+  hasValidSessionCookie?: typeof hasValidSessionCookie;
+  parseSignature?: typeof parseSignature;
+  isReadOnlyCmd?: typeof isReadOnlyCmd;
+  isShellPeerAllowed?: typeof isShellPeerAllowed;
+  resolvePeerUrl?: typeof resolvePeerUrl;
+  relayToPeer?: typeof relayToPeer;
+}
 
-peerExecApi.get("/peer/session", ({ set }) => {
-  setSessionCookie(set as any);
-  return { ok: true, rotates: "on_server_restart" };
-});
+export function createPeerExecApi(deps: PeerExecApiDeps = {}) {
+  const setCookie = deps.setSessionCookie ?? setSessionCookie;
+  const hasValidCookie = deps.hasValidSessionCookie ?? hasValidSessionCookie;
+  const parseSig = deps.parseSignature ?? parseSignature;
+  const readOnlyCmd = deps.isReadOnlyCmd ?? isReadOnlyCmd;
+  const shellAllowed = deps.isShellPeerAllowed ?? isShellPeerAllowed;
+  const resolvePeer = deps.resolvePeerUrl ?? resolvePeerUrl;
+  const relay = deps.relayToPeer ?? relayToPeer;
 
-peerExecApi.post("/peer/exec", async ({ body, headers, set}) => {
-  const { peer, cmd, args = [], signature } = body;
+  const peerExecApi = new Elysia();
 
-  if (!peer || !cmd || !signature) {
-    set.status = 400; return { error: "missing_fields", required: ["peer", "cmd", "signature"] };
-  }
+  peerExecApi.get("/peer/session", ({ set }) => {
+    setCookie(set as any);
+    return { ok: true, rotates: "on_server_restart" };
+  });
 
-  // 1. Parse signature
-  const parsed = parseSignature(signature);
-  if (!parsed) {
-    set.status = 400; return { error: "bad_signature", expected: "[host:agent]" };
-  }
+  peerExecApi.post("/peer/exec", async ({ body, headers, set }) => {
+    const { peer, cmd, args = [], signature } = body;
 
-  // 2. Session cookie check
-  // Bypass ONLY when explicitly in dev mode. Default (unset NODE_ENV) = secure.
-  const devBypass = process.env.NODE_ENV === "development";
-  if (!devBypass && !hasValidSessionCookie(headers)) {
-    set.status = 401; return { error: "no_session", hint: "GET /api/peer/session first" };
-  }
-
-  // 3 + 4. Trust boundary
-  const readonly = isReadOnlyCmd(cmd);
-  if (!readonly) {
-    const allowed = isShellPeerAllowed(parsed.originHost);
-    if (!allowed) {
-      set.status = 403; return {
-        error: "shell_peer_denied",
-        origin: parsed.originHost,
-        hint: parsed.isAnon
-          ? "anonymous browser visitors are read-only; only /dig, /trace, /recap and similar work"
-          : "add this origin to config.wormhole.shellPeers to permit shell cmds",
-      };
+    if (!peer || !cmd || !signature) {
+      set.status = 400; return { error: "missing_fields", required: ["peer", "cmd", "signature"] };
     }
-  }
 
-  // 5. Resolve peer
-  const peerUrl = resolvePeerUrl(peer);
-  if (!peerUrl) {
-    set.status = 404; return { error: "unknown_peer", peer };
-  }
+    // 1. Parse signature
+    const parsed = parseSig(signature);
+    if (!parsed) {
+      set.status = 400; return { error: "bad_signature", expected: "[host:agent]" };
+    }
 
-  // 6 + 7. Relay and return
-  try {
-    const result = await relayToPeer(peerUrl, { cmd, args, signature });
-    return {
-      output: result.output,
-      from: result.from,
-      elapsed_ms: result.elapsedMs,
-      status: result.status,
-      trust_tier: readonly ? "readonly" : "shell_allowlisted",
-    };
-  } catch (err: any) {
-    set.status = 502; return { error: "relay_failed", peer: peerUrl, reason: err?.message ?? String(err) };
-  }
-}, {
-  body: t.Object({
-    peer: t.Optional(t.String()),
-    cmd: t.Optional(t.String()),
-    args: t.Optional(t.Array(t.String())),
-    signature: t.Optional(t.String()),
-  }),
-});
+    // 2. Session cookie check
+    // Bypass ONLY when explicitly in dev mode. Default (unset NODE_ENV) = secure.
+    const devBypass = process.env.NODE_ENV === "development";
+    if (!devBypass && !hasValidCookie(headers)) {
+      set.status = 401; return { error: "no_session", hint: "GET /api/peer/session first" };
+    }
+
+    // 3 + 4. Trust boundary
+    const readonly = readOnlyCmd(cmd);
+    if (!readonly) {
+      const allowed = shellAllowed(parsed.originHost);
+      if (!allowed) {
+        set.status = 403; return {
+          error: "shell_peer_denied",
+          origin: parsed.originHost,
+          hint: parsed.isAnon
+            ? "anonymous browser visitors are read-only; only /dig, /trace, /recap and similar work"
+            : "add this origin to config.wormhole.shellPeers to permit shell cmds",
+        };
+      }
+    }
+
+    // 5. Resolve peer
+    const peerUrl = resolvePeer(peer);
+    if (!peerUrl) {
+      set.status = 404; return { error: "unknown_peer", peer };
+    }
+
+    // 6 + 7. Relay and return
+    try {
+      const result = await relay(peerUrl, { cmd, args, signature });
+      return {
+        output: result.output,
+        from: result.from,
+        elapsed_ms: result.elapsedMs,
+        status: result.status,
+        trust_tier: readonly ? "readonly" : "shell_allowlisted",
+      };
+    } catch (err: any) {
+      set.status = 502; return { error: "relay_failed", peer: peerUrl, reason: err?.message ?? String(err) };
+    }
+  }, {
+    body: t.Object({
+      peer: t.Optional(t.String()),
+      cmd: t.Optional(t.String()),
+      args: t.Optional(t.Array(t.String())),
+      signature: t.Optional(t.String()),
+    }),
+  });
+
+  return peerExecApi;
+}
+
+export const peerExecApi = createPeerExecApi();

--- a/test/peer-exec.test.ts
+++ b/test/peer-exec.test.ts
@@ -23,6 +23,8 @@ import {
   isReadOnlyCmd,
   isShellPeerAllowed,
   resolvePeerUrl,
+  relayToPeer,
+  createPeerExecApi,
   peerExecApi,
 } from "../src/api/peer-exec";
 
@@ -150,6 +152,73 @@ describe("resolvePeerUrl", () => {
 
   test("returns null for empty input", () => {
     expect(resolvePeerUrl("")).toBeNull();
+  });
+});
+
+describe("relayToPeer", () => {
+  test("posts JSON, signs when a federation token exists, and reports elapsed time", async () => {
+    const requests: any[] = [];
+    const ticks = [100, 137];
+
+    const result = await relayToPeer(
+      "http://peer.local:3456",
+      { cmd: "/dig", args: ["--deep"], signature: "[local:oracle]" },
+      {
+        loadConfig: () => ({ federationToken: "secret" }) as any,
+        signHeaders: (token, method, path) => ({
+          "x-signed": `${token}:${method}:${path}`,
+        }),
+        now: () => ticks.shift() ?? 137,
+        fetch: (async (url, init) => {
+          requests.push({ url, init });
+          return new Response("accepted", { status: 202 });
+        }) as typeof fetch,
+      },
+    );
+
+    expect(result).toEqual({
+      output: "accepted",
+      from: "http://peer.local:3456",
+      elapsedMs: 37,
+      status: 202,
+    });
+    expect(requests).toEqual([
+      {
+        url: "http://peer.local:3456/api/peer/exec",
+        init: {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "x-signed": "secret:POST:/api/peer/exec",
+          },
+          body: JSON.stringify({
+            cmd: "/dig",
+            args: ["--deep"],
+            signature: "[local:oracle]",
+          }),
+        },
+      },
+    ]);
+  });
+
+  test("omits signing headers when no federation token exists", async () => {
+    const requests: any[] = [];
+
+    const result = await relayToPeer(
+      "http://peer.local:3456",
+      { cmd: "/recap", args: [], signature: "[local:anon]" },
+      {
+        loadConfig: () => ({}) as any,
+        fetch: (async (url, init) => {
+          requests.push({ url, init });
+          return new Response("readonly", { status: 200 });
+        }) as typeof fetch,
+      },
+    );
+
+    expect(result.output).toBe("readonly");
+    expect(requests[0].init.headers).toEqual({ "Content-Type": "application/json" });
+    expect(typeof result.elapsedMs).toBe("number");
   });
 });
 
@@ -285,6 +354,68 @@ describe("POST /api/peer/exec (trust flow)", () => {
     expect(res.status).toBe(404);
     const body = (await res.json()) as any;
     expect(body.error).toBe("unknown_peer");
+  });
+
+  test("allowlisted shell peers relay with shell trust tier", async () => {
+    const relayCalls: any[] = [];
+    const app = new Elysia({ prefix: "/api" }).use(createPeerExecApi({
+      hasValidSessionCookie: () => true,
+      parseSignature: () => ({ originHost: "trusted-host", originAgent: "operator", isAnon: false }),
+      isReadOnlyCmd: () => false,
+      isShellPeerAllowed: (origin) => origin === "trusted-host",
+      resolvePeerUrl: () => "http://peer.local:3456",
+      relayToPeer: (async (peerUrl, body) => {
+        relayCalls.push({ peerUrl, body });
+        return { output: "done", from: peerUrl, elapsedMs: 9, status: 201 };
+      }) as typeof relayToPeer,
+    }));
+
+    const res = await app.handle(new Request("http://localhost/api/peer/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: "pe_session=fake" },
+      body: JSON.stringify({
+        peer: "peer",
+        cmd: "/awaken",
+        args: ["--fast"],
+        signature: "[trusted-host:operator]",
+      }),
+    }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      output: "done",
+      from: "http://peer.local:3456",
+      elapsed_ms: 9,
+      status: 201,
+      trust_tier: "shell_allowlisted",
+    });
+    expect(relayCalls).toEqual([{
+      peerUrl: "http://peer.local:3456",
+      body: { cmd: "/awaken", args: ["--fast"], signature: "[trusted-host:operator]" },
+    }]);
+  });
+
+  test("relay failures surface as 502", async () => {
+    const app = new Elysia({ prefix: "/api" }).use(createPeerExecApi({
+      hasValidSessionCookie: () => true,
+      parseSignature: () => ({ originHost: "local", originAgent: "anon", isAnon: true }),
+      isReadOnlyCmd: () => true,
+      resolvePeerUrl: () => "http://peer.local:3456",
+      relayToPeer: (async () => { throw new Error("peer offline"); }) as typeof relayToPeer,
+    }));
+
+    const res = await app.handle(new Request("http://localhost/api/peer/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: "pe_session=fake" },
+      body: JSON.stringify({ peer: "peer", cmd: "/dig", signature: "[local:anon]" }),
+    }));
+
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({
+      error: "relay_failed",
+      peer: "http://peer.local:3456",
+      reason: "peer offline",
+    });
   });
 
   test("invalid JSON body → 400 invalid_body", async () => {


### PR DESCRIPTION
## Summary
- add injectable peer exec route and relay seams while preserving production `peerExecApi`
- cover signed relay requests, no-token relay requests, allowlisted shell relay, and relay failures

## Validation
- `bun test test/peer-exec.test.ts --coverage --coverage-reporter=text --timeout 60000`
  - `src/api/peer-exec.ts | 100.00 | 100.00`
- `bun test test/peer-exec.test.ts --timeout 60000`
- `bun run build`
- `git diff --check`

## Release
- Alpha branch only.
- No release cut.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
