### PR TITLE
test(coverage): cover config API routes

### DIFF
--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -1,202 +1,246 @@
-import { Elysia, t} from "elysia";
+import { Elysia, t } from "elysia";
 import { readdirSync, readFileSync, writeFileSync, renameSync, unlinkSync, existsSync } from "fs";
 import { join, basename } from "path";
 import { type MawConfig, loadConfig, saveConfig, configForDisplay } from "../config";
 import { FLEET_DIR as fleetDir } from "../core/paths";
 
-export const configApi = new Elysia();
-
 // Rate limit: max 5 attempts per IP per minute
 const pinAttempts = new Map<string, { count: number; resetAt: number }>();
 
-// List all config files (maw.config.json + fleet/*.json + fleet/*.json.disabled)
-configApi.get("/config-files", () => {
-  const files: { name: string; path: string; enabled: boolean }[] = [
-    { name: "maw.config.json", path: "maw.config.json", enabled: true },
-  ];
-  try {
-    const entries = readdirSync(fleetDir).filter(f => f.endsWith(".json") || f.endsWith(".json.disabled")).sort();
-    for (const f of entries) {
-      const enabled = !f.endsWith(".disabled");
-      files.push({ name: f, path: `fleet/${f}`, enabled });
-    }
-  } catch { /* expected: fleet dir may not exist */ }
-  return { files };
-});
+export interface ConfigApiDeps {
+  readdirSync?: typeof readdirSync;
+  readFileSync?: typeof readFileSync;
+  writeFileSync?: typeof writeFileSync;
+  renameSync?: typeof renameSync;
+  unlinkSync?: typeof unlinkSync;
+  existsSync?: typeof existsSync;
+  join?: typeof join;
+  basename?: typeof basename;
+  loadConfig?: typeof loadConfig;
+  saveConfig?: typeof saveConfig;
+  configForDisplay?: typeof configForDisplay;
+  fleetDir?: string;
+  rootDir?: string;
+  pinAttempts?: Map<string, { count: number; resetAt: number }>;
+  now?: () => number;
+  createToken?: () => string | Promise<string>;
+}
 
-// Read a single config file
-configApi.get("/config-file", ({ query, set}) => {
-  const filePath = query.path;
-  if (!filePath) { set.status = 400; return { error: "path required" }; }
-  if (filePath.includes("..")) { set.status = 400; return { error: "invalid path" }; }
-  const fullPath = join(import.meta.dir, "../..", filePath);
-  if (!existsSync(fullPath)) { set.status = 404; return { error: "not found" }; }
-  try {
-    const content = readFileSync(fullPath, "utf-8");
-    // For maw.config.json, mask env values
-    if (filePath === "maw.config.json") {
-      const data = JSON.parse(content);
-      const display = configForDisplay();
-      data.env = display.envMasked;
-      return { content: JSON.stringify(data, null, 2) };
-    }
-    return { content };
-  } catch (e: unknown) {
-    set.status = 500; return { error: e instanceof Error ? e.message : String(e) };
-  }
-}, {
-  query: t.Object({ path: t.Optional(t.String()) }),
-});
-
-// Save a config file
-configApi.post("/config-file", async ({ query, body, set}) => {
-  const filePath = query.path;
-  if (!filePath) { set.status = 400; return { error: "path required" }; }
-  // Only allow maw.config.json and fleet/ files
-  if (filePath !== "maw.config.json" && !filePath.startsWith("fleet/")) {
-    set.status = 403; return { error: "invalid path" };
-  }
-  try {
-    const { content } = body;
-    JSON.parse(content); // validate JSON
-    const fullPath = join(import.meta.dir, "../..", filePath);
-    if (filePath === "maw.config.json") {
-      // Handle masked env values
-      const parsed = JSON.parse(content);
-      if (parsed.env && typeof parsed.env === "object") {
-        const current = loadConfig();
-        for (const [k, v] of Object.entries(parsed.env as Record<string, string>)) {
-          if (/\u2022/.test(v)) parsed.env[k] = current.env[k] || v;
-        }
-      }
-      saveConfig(parsed);
-    } else {
-      writeFileSync(fullPath, content + "\n", "utf-8");
-    }
-    return { ok: true };
-  } catch (e: unknown) {
-    set.status = 400; return { error: e instanceof Error ? e.message : String(e) };
-  }
-}, {
-  query: t.Object({ path: t.Optional(t.String()) }),
-  body: t.Object({ content: t.String() }),
-});
-
-// Toggle enable/disable a fleet file
-configApi.post("/config-file/toggle", ({ query, set}) => {
-  const filePath = query.path;
-  if (!filePath || !filePath.startsWith("fleet/")) { set.status = 400; return { error: "invalid path" }; }
-  const fullPath = join(import.meta.dir, "../..", filePath);
-  if (!existsSync(fullPath)) { set.status = 404; return { error: "not found" }; }
-  const isDisabled = filePath.endsWith(".disabled");
-  const newPath = isDisabled ? fullPath.replace(/\.disabled$/, "") : fullPath + ".disabled";
-  const newRelPath = isDisabled ? filePath.replace(/\.disabled$/, "") : filePath + ".disabled";
-  renameSync(fullPath, newPath);
-  return { ok: true, newPath: newRelPath };
-}, {
-  query: t.Object({ path: t.Optional(t.String()) }),
-});
-
-// Delete a fleet file
-configApi.delete("/config-file", ({ query, set}) => {
-  const filePath = query.path;
-  if (!filePath || !filePath.startsWith("fleet/")) { set.status = 400; return { error: "cannot delete" }; }
-  const fullPath = join(import.meta.dir, "../..", filePath);
-  if (!existsSync(fullPath)) { set.status = 404; return { error: "not found" }; }
-  unlinkSync(fullPath);
-  return { ok: true };
-}, {
-  query: t.Object({ path: t.Optional(t.String()) }),
-});
-
-// Create a new fleet file
-configApi.put("/config-file", async ({ body, set}) => {
-  const { name, content } = body;
-  if (!name || !name.endsWith(".json")) { set.status = 400; return { error: "name must end with .json" }; }
-  const safeName = basename(name);
-  const fullPath = join(fleetDir, safeName);
-  try { JSON.parse(content); } catch { set.status = 400; return { error: "invalid JSON" }; }
-  // Atomic create: O_CREAT | O_EXCL. Kernel rejects on EEXIST — no TOCTOU window. (#484)
-  try {
-    writeFileSync(fullPath, content + "\n", { encoding: "utf-8", flag: "wx" });
-  } catch (e: unknown) {
-    if ((e as NodeJS.ErrnoException).code === "EEXIST") {
-      set.status = 409; return { error: "file already exists" };
-    }
-    throw e;
-  }
-  return { ok: true, path: `fleet/${safeName}` };
-}, {
-  body: t.Object({ name: t.String(), content: t.String() }),
-});
-
-configApi.get("/pin-info", () => {
-  const config = loadConfig();
-  const pin = config.pin || "";
-  return { length: pin.length, enabled: pin.length > 0 };
-});
-
-configApi.post("/pin-set", async ({ body }) => {
-  const { pin } = body;
-  const newPin = typeof pin === "string" ? pin.replace(/\D/g, "") : "";
-  saveConfig({ pin: newPin });
-  return { ok: true, length: newPin.length, enabled: newPin.length > 0 };
-}, {
-  body: t.Object({ pin: t.Optional(t.String()) }),
-});
-
-configApi.post("/pin-verify", async ({ body, headers, set}) => {
-  const ip = headers["cf-connecting-ip"] || headers["x-forwarded-for"] || "local";
-  const now = Date.now();
-  const entry = pinAttempts.get(ip) || { count: 0, resetAt: now + 60_000 };
-  if (now > entry.resetAt) { entry.count = 0; entry.resetAt = now + 60_000; }
-  entry.count++;
-  pinAttempts.set(ip, entry);
-  if (entry.count > 5) {
-    set.status = 429; return { ok: false, error: "Too many attempts. Wait 1 minute." };
-  }
-
-  const { pin } = body;
-  const config = loadConfig();
-  const correct = config.pin || "";
-  if (!correct) return { ok: true };
-  const ok = pin === correct;
-  if (ok) {
-    pinAttempts.delete(ip);
+export function createConfigApi(deps: ConfigApiDeps = {}) {
+  const readDir = deps.readdirSync ?? readdirSync;
+  const readFile = deps.readFileSync ?? readFileSync;
+  const writeFile = deps.writeFileSync ?? writeFileSync;
+  const rename = deps.renameSync ?? renameSync;
+  const unlink = deps.unlinkSync ?? unlinkSync;
+  const exists = deps.existsSync ?? existsSync;
+  const pathJoin = deps.join ?? join;
+  const pathBasename = deps.basename ?? basename;
+  const load = deps.loadConfig ?? loadConfig;
+  const save = deps.saveConfig ?? saveConfig;
+  const displayConfig = deps.configForDisplay ?? configForDisplay;
+  const fleetRoot = deps.fleetDir ?? fleetDir;
+  const rootDir = deps.rootDir ?? pathJoin(import.meta.dir, "../..");
+  const attempts = deps.pinAttempts ?? pinAttempts;
+  const now = deps.now ?? (() => Date.now());
+  const createAuthToken = deps.createToken ?? (async () => {
     const { createToken } = await import("../lib/auth");
-    return { ok, token: createToken() };
-  }
-  return { ok };
-}, {
-  body: t.Object({ pin: t.Optional(t.String()) }),
-});
+    return createToken();
+  });
 
-// PUBLIC FEDERATION API (v1) — no auth. Shape is load-bearing for lens
-// clients (e.g. maw-ui#8). See docs/federation.md before changing fields.
-configApi.get("/config", ({ query }) => {
-  if (query.raw === "1") return loadConfig();
-  return configForDisplay();
-}, {
-  query: t.Object({ raw: t.Optional(t.String()) }),
-});
+  const configApi = new Elysia();
 
-configApi.post("/config", async ({ body, set}) => {
-  try {
-    const data = body as Partial<MawConfig>;
-    // If env has masked values (bullet chars), keep originals for those keys
-    if (data.env && typeof data.env === "object") {
-      const current = loadConfig();
-      const merged: Record<string, string> = {};
-      for (const [k, v] of Object.entries(data.env as Record<string, string>)) {
-        merged[k] = /\u2022/.test(v) ? (current.env[k] || v) : v;
+  // List all config files (maw.config.json + fleet/*.json + fleet/*.json.disabled)
+  configApi.get("/config-files", () => {
+    const files: { name: string; path: string; enabled: boolean }[] = [
+      { name: "maw.config.json", path: "maw.config.json", enabled: true },
+    ];
+    try {
+      const entries = readDir(fleetRoot).filter((f) => f.endsWith(".json") || f.endsWith(".json.disabled")).sort();
+      for (const f of entries) {
+        const enabled = !f.endsWith(".disabled");
+        files.push({ name: f, path: `fleet/${f}`, enabled });
       }
-      data.env = merged;
+    } catch { /* expected: fleet dir may not exist */ }
+    return { files };
+  });
+
+  // Read a single config file
+  configApi.get("/config-file", ({ query, set }) => {
+    const filePath = query.path;
+    if (!filePath) { set.status = 400; return { error: "path required" }; }
+    if (filePath.includes("..")) { set.status = 400; return { error: "invalid path" }; }
+    const fullPath = pathJoin(rootDir, filePath);
+    if (!exists(fullPath)) { set.status = 404; return { error: "not found" }; }
+    try {
+      const content = readFile(fullPath, "utf-8");
+      // For maw.config.json, mask env values
+      if (filePath === "maw.config.json") {
+        const data = JSON.parse(content);
+        const display = displayConfig();
+        data.env = display.envMasked;
+        return { content: JSON.stringify(data, null, 2) };
+      }
+      return { content };
+    } catch (e: unknown) {
+      set.status = 500; return { error: e instanceof Error ? e.message : String(e) };
     }
-    saveConfig(data);
+  }, {
+    query: t.Object({ path: t.Optional(t.String()) }),
+  });
+
+  // Save a config file
+  configApi.post("/config-file", async ({ query, body, set }) => {
+    const filePath = query.path;
+    if (!filePath) { set.status = 400; return { error: "path required" }; }
+    // Only allow maw.config.json and fleet/ files
+    if (filePath !== "maw.config.json" && !filePath.startsWith("fleet/")) {
+      set.status = 403; return { error: "invalid path" };
+    }
+    try {
+      const { content } = body;
+      JSON.parse(content); // validate JSON
+      const fullPath = pathJoin(rootDir, filePath);
+      if (filePath === "maw.config.json") {
+        // Handle masked env values
+        const parsed = JSON.parse(content);
+        if (parsed.env && typeof parsed.env === "object") {
+          const current = load();
+          for (const [k, v] of Object.entries(parsed.env as Record<string, string>)) {
+            if (/\u2022/.test(v)) parsed.env[k] = current.env[k] || v;
+          }
+        }
+        save(parsed);
+      } else {
+        writeFile(fullPath, content + "\n", "utf-8");
+      }
+      return { ok: true };
+    } catch (e: unknown) {
+      set.status = 400; return { error: e instanceof Error ? e.message : String(e) };
+    }
+  }, {
+    query: t.Object({ path: t.Optional(t.String()) }),
+    body: t.Object({ content: t.String() }),
+  });
+
+  // Toggle enable/disable a fleet file
+  configApi.post("/config-file/toggle", ({ query, set }) => {
+    const filePath = query.path;
+    if (!filePath || !filePath.startsWith("fleet/")) { set.status = 400; return { error: "invalid path" }; }
+    const fullPath = pathJoin(rootDir, filePath);
+    if (!exists(fullPath)) { set.status = 404; return { error: "not found" }; }
+    const isDisabled = filePath.endsWith(".disabled");
+    const newPath = isDisabled ? fullPath.replace(/\.disabled$/, "") : fullPath + ".disabled";
+    const newRelPath = isDisabled ? filePath.replace(/\.disabled$/, "") : filePath + ".disabled";
+    rename(fullPath, newPath);
+    return { ok: true, newPath: newRelPath };
+  }, {
+    query: t.Object({ path: t.Optional(t.String()) }),
+  });
+
+  // Delete a fleet file
+  configApi.delete("/config-file", ({ query, set }) => {
+    const filePath = query.path;
+    if (!filePath || !filePath.startsWith("fleet/")) { set.status = 400; return { error: "cannot delete" }; }
+    const fullPath = pathJoin(rootDir, filePath);
+    if (!exists(fullPath)) { set.status = 404; return { error: "not found" }; }
+    unlink(fullPath);
     return { ok: true };
-  } catch (e: unknown) {
-    set.status = 400; return { error: e instanceof Error ? e.message : String(e) };
-  }
-}, {
-  body: t.Unknown(),
-});
+  }, {
+    query: t.Object({ path: t.Optional(t.String()) }),
+  });
+
+  // Create a new fleet file
+  configApi.put("/config-file", async ({ body, set }) => {
+    const { name, content } = body;
+    if (!name || !name.endsWith(".json")) { set.status = 400; return { error: "name must end with .json" }; }
+    const safeName = pathBasename(name);
+    const fullPath = pathJoin(fleetRoot, safeName);
+    try { JSON.parse(content); } catch { set.status = 400; return { error: "invalid JSON" }; }
+    // Atomic create: O_CREAT | O_EXCL. Kernel rejects on EEXIST — no TOCTOU window. (#484)
+    try {
+      writeFile(fullPath, content + "\n", { encoding: "utf-8", flag: "wx" });
+    } catch (e: unknown) {
+      if ((e as NodeJS.ErrnoException).code === "EEXIST") {
+        set.status = 409; return { error: "file already exists" };
+      }
+      throw e;
+    }
+    return { ok: true, path: `fleet/${safeName}` };
+  }, {
+    body: t.Object({ name: t.String(), content: t.String() }),
+  });
+
+  configApi.get("/pin-info", () => {
+    const config = load();
+    const pin = config.pin || "";
+    return { length: pin.length, enabled: pin.length > 0 };
+  });
+
+  configApi.post("/pin-set", async ({ body }) => {
+    const { pin } = body;
+    const newPin = typeof pin === "string" ? pin.replace(/\D/g, "") : "";
+    save({ pin: newPin });
+    return { ok: true, length: newPin.length, enabled: newPin.length > 0 };
+  }, {
+    body: t.Object({ pin: t.Optional(t.String()) }),
+  });
+
+  configApi.post("/pin-verify", async ({ body, headers, set }) => {
+    const ip = headers["cf-connecting-ip"] || headers["x-forwarded-for"] || "local";
+    const currentTime = now();
+    const entry = attempts.get(ip) || { count: 0, resetAt: currentTime + 60_000 };
+    if (currentTime > entry.resetAt) { entry.count = 0; entry.resetAt = currentTime + 60_000; }
+    entry.count++;
+    attempts.set(ip, entry);
+    if (entry.count > 5) {
+      set.status = 429; return { ok: false, error: "Too many attempts. Wait 1 minute." };
+    }
+
+    const { pin } = body;
+    const config = load();
+    const correct = config.pin || "";
+    if (!correct) return { ok: true };
+    const ok = pin === correct;
+    if (ok) {
+      attempts.delete(ip);
+      return { ok, token: await createAuthToken() };
+    }
+    return { ok };
+  }, {
+    body: t.Object({ pin: t.Optional(t.String()) }),
+  });
+
+  // PUBLIC FEDERATION API (v1) — no auth. Shape is load-bearing for lens
+  // clients (e.g. maw-ui#8). See docs/federation.md before changing fields.
+  configApi.get("/config", ({ query }) => {
+    if (query.raw === "1") return load();
+    return displayConfig();
+  }, {
+    query: t.Object({ raw: t.Optional(t.String()) }),
+  });
+
+  configApi.post("/config", async ({ body, set }) => {
+    try {
+      const data = body as Partial<MawConfig>;
+      // If env has masked values (bullet chars), keep originals for those keys
+      if (data.env && typeof data.env === "object") {
+        const current = load();
+        const merged: Record<string, string> = {};
+        for (const [k, v] of Object.entries(data.env as Record<string, string>)) {
+          merged[k] = /\u2022/.test(v) ? (current.env[k] || v) : v;
+        }
+        data.env = merged;
+      }
+      save(data);
+      return { ok: true };
+    } catch (e: unknown) {
+      set.status = 400; return { error: e instanceof Error ? e.message : String(e) };
+    }
+  }, {
+    body: t.Unknown(),
+  });
+
+  return configApi;
+}
+
+export const configApi = createConfigApi();

--- a/test/config-api-default.test.ts
+++ b/test/config-api-default.test.ts
@@ -1,0 +1,259 @@
+import { describe, test, expect } from "bun:test";
+import { Elysia } from "elysia";
+import { createConfigApi, type ConfigApiDeps } from "../src/api/config";
+
+function makeApp(deps: ConfigApiDeps = {}) {
+  return new Elysia().use(createConfigApi(deps));
+}
+
+function jsonRequest(path: string, method: string, body?: unknown, headers: Record<string, string> = {}) {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers: { "content-type": "application/json", ...headers },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+async function readJson(res: Response) {
+  return await res.json() as any;
+}
+
+describe("config API file routes", () => {
+  test("lists maw config and sorted fleet JSON files", async () => {
+    const app = makeApp({
+      fleetDir: "/fleet",
+      readdirSync: ((dir: string) => {
+        expect(dir).toBe("/fleet");
+        return ["z.txt", "b.json.disabled", "a.json"] as any;
+      }) as any,
+    });
+
+    const res = await app.handle(new Request("http://localhost/config-files"));
+
+    expect(res.status).toBe(200);
+    expect(await readJson(res)).toEqual({
+      files: [
+        { name: "maw.config.json", path: "maw.config.json", enabled: true },
+        { name: "a.json", path: "fleet/a.json", enabled: true },
+        { name: "b.json.disabled", path: "fleet/b.json.disabled", enabled: false },
+      ],
+    });
+  });
+
+  test("lists only maw config when fleet directory cannot be read", async () => {
+    const app = makeApp({ readdirSync: (() => { throw new Error("missing fleet"); }) as any });
+
+    const res = await app.handle(new Request("http://localhost/config-files"));
+
+    expect(res.status).toBe(200);
+    expect(await readJson(res)).toEqual({
+      files: [{ name: "maw.config.json", path: "maw.config.json", enabled: true }],
+    });
+  });
+
+  test("GET /config-file validates and reads files", async () => {
+    const app = makeApp({
+      rootDir: "/root",
+      existsSync: ((path: string) => path !== "/root/fleet/missing.json") as any,
+      readFileSync: ((path: string) => {
+        if (path === "/root/maw.config.json") return JSON.stringify({ env: { SECRET: "raw" }, host: "local" });
+        if (path === "/root/fleet/a.json") return "{\"fleet\":true}";
+        throw new Error("read boom");
+      }) as any,
+      configForDisplay: (() => ({ envMasked: { SECRET: "••••" } })) as any,
+    });
+
+    expect((await app.handle(new Request("http://localhost/config-file"))).status).toBe(400);
+    expect((await readJson(await app.handle(new Request("http://localhost/config-file?path=../x")))).error).toBe("invalid path");
+    expect((await app.handle(new Request("http://localhost/config-file?path=fleet/missing.json"))).status).toBe(404);
+
+    const configRes = await app.handle(new Request("http://localhost/config-file?path=maw.config.json"));
+    expect(JSON.parse((await readJson(configRes)).content).env).toEqual({ SECRET: "••••" });
+
+    const fleetRes = await app.handle(new Request("http://localhost/config-file?path=fleet/a.json"));
+    expect(await readJson(fleetRes)).toEqual({ content: "{\"fleet\":true}" });
+
+    const errorRes = await app.handle(new Request("http://localhost/config-file?path=fleet/boom.json"));
+    expect(errorRes.status).toBe(500);
+    expect((await readJson(errorRes)).error).toBe("read boom");
+  });
+
+  test("POST /config-file validates paths, preserves masked env, and writes fleet files", async () => {
+    const writes: any[] = [];
+    const saves: any[] = [];
+    const app = makeApp({
+      rootDir: "/root",
+      loadConfig: (() => ({ env: { SECRET: "raw-secret" } })) as any,
+      saveConfig: ((data: any) => { saves.push(data); }) as any,
+      writeFileSync: ((...args: any[]) => { writes.push(args); }) as any,
+    });
+
+    expect((await app.handle(jsonRequest("/config-file", "POST", { content: "{}" }))).status).toBe(400);
+    expect((await app.handle(jsonRequest("/config-file?path=other.json", "POST", { content: "{}" }))).status).toBe(403);
+
+    const invalidJson = await app.handle(jsonRequest("/config-file?path=fleet/a.json", "POST", { content: "{bad" }));
+    expect(invalidJson.status).toBe(400);
+
+    const mawSave = await app.handle(jsonRequest("/config-file?path=maw.config.json", "POST", {
+      content: JSON.stringify({ env: { SECRET: "••••", PLAIN: "value" } }),
+    }));
+    expect(mawSave.status).toBe(200);
+    expect(saves).toEqual([{ env: { SECRET: "raw-secret", PLAIN: "value" } }]);
+
+    const fleetSave = await app.handle(jsonRequest("/config-file?path=fleet/a.json", "POST", { content: "{\"ok\":true}" }));
+    expect(fleetSave.status).toBe(200);
+    expect(writes).toEqual([["/root/fleet/a.json", "{\"ok\":true}\n", "utf-8"]]);
+  });
+
+  test("POST /config-file reports save errors", async () => {
+    const app = makeApp({
+      saveConfig: (() => { throw new Error("save boom"); }) as any,
+    });
+
+    const res = await app.handle(jsonRequest("/config-file?path=maw.config.json", "POST", { content: "{}" }));
+
+    expect(res.status).toBe(400);
+    expect((await readJson(res)).error).toBe("save boom");
+  });
+
+  test("toggle and delete validate fleet paths and mutate existing files", async () => {
+    const renames: any[] = [];
+    const unlinks: any[] = [];
+    const app = makeApp({
+      rootDir: "/root",
+      existsSync: ((path: string) => !path.includes("missing")) as any,
+      renameSync: ((...args: any[]) => { renames.push(args); }) as any,
+      unlinkSync: ((...args: any[]) => { unlinks.push(args); }) as any,
+    });
+
+    expect((await app.handle(jsonRequest("/config-file/toggle", "POST"))).status).toBe(400);
+    expect((await app.handle(jsonRequest("/config-file/toggle?path=fleet/missing.json", "POST"))).status).toBe(404);
+
+    expect(await readJson(await app.handle(jsonRequest("/config-file/toggle?path=fleet/a.json", "POST")))).toEqual({
+      ok: true,
+      newPath: "fleet/a.json.disabled",
+    });
+    expect(await readJson(await app.handle(jsonRequest("/config-file/toggle?path=fleet/a.json.disabled", "POST")))).toEqual({
+      ok: true,
+      newPath: "fleet/a.json",
+    });
+    expect(renames).toEqual([
+      ["/root/fleet/a.json", "/root/fleet/a.json.disabled"],
+      ["/root/fleet/a.json.disabled", "/root/fleet/a.json"],
+    ]);
+
+    expect((await app.handle(new Request("http://localhost/config-file", { method: "DELETE" }))).status).toBe(400);
+    expect((await app.handle(new Request("http://localhost/config-file?path=fleet/missing.json", { method: "DELETE" }))).status).toBe(404);
+    expect(await readJson(await app.handle(new Request("http://localhost/config-file?path=fleet/a.json", { method: "DELETE" })))).toEqual({ ok: true });
+    expect(unlinks).toEqual([["/root/fleet/a.json"]]);
+  });
+
+  test("PUT /config-file validates names, atomically creates, and reports write conflicts", async () => {
+    const writes: any[] = [];
+    const app = makeApp({
+      fleetDir: "/fleet",
+      basename: ((name: string) => name.split("/").pop() ?? name) as any,
+      writeFileSync: ((path: string, content: string, options: any) => {
+        writes.push([path, content, options]);
+        if (path.includes("exists")) throw Object.assign(new Error("exists"), { code: "EEXIST" });
+        if (path.includes("boom")) throw new Error("write boom");
+      }) as any,
+    });
+
+    expect((await app.handle(jsonRequest("/config-file", "PUT", { name: "a.txt", content: "{}" }))).status).toBe(400);
+    expect((await app.handle(jsonRequest("/config-file", "PUT", { name: "a.json", content: "{bad" }))).status).toBe(400);
+
+    expect(await readJson(await app.handle(jsonRequest("/config-file", "PUT", { name: "../new.json", content: "{}" })))).toEqual({
+      ok: true,
+      path: "fleet/new.json",
+    });
+
+    const conflict = await app.handle(jsonRequest("/config-file", "PUT", { name: "exists.json", content: "{}" }));
+    expect(conflict.status).toBe(409);
+    expect(await readJson(conflict)).toEqual({ error: "file already exists" });
+
+    const boom = await app.handle(jsonRequest("/config-file", "PUT", { name: "boom.json", content: "{}" }));
+    expect(boom.status).toBe(500);
+    expect(writes[0]).toEqual(["/fleet/new.json", "{}\n", { encoding: "utf-8", flag: "wx" }]);
+  });
+});
+
+describe("config API pin and public config routes", () => {
+  test("pin info, set, verify, reset, and rate-limit branches", async () => {
+    const saves: any[] = [];
+    const attempts = new Map<string, { count: number; resetAt: number }>();
+    let pin = "";
+    let tick = 1_000;
+    const app = makeApp({
+      pinAttempts: attempts,
+      now: () => tick,
+      loadConfig: (() => ({ pin, env: { SECRET: "raw-secret" } })) as any,
+      saveConfig: ((data: any) => { saves.push(data); pin = data.pin ?? pin; }) as any,
+      createToken: () => "token-123",
+    });
+
+    expect(await readJson(await app.handle(new Request("http://localhost/pin-info")))).toEqual({ length: 0, enabled: false });
+    expect(await readJson(await app.handle(jsonRequest("/pin-set", "POST", { pin: "a1-2b3" })))).toEqual({
+      ok: true,
+      length: 3,
+      enabled: true,
+    });
+    expect(saves).toEqual([{ pin: "123" }]);
+
+    expect(await readJson(await app.handle(jsonRequest("/pin-verify", "POST", { pin: "000" })))).toEqual({ ok: false });
+    expect(await readJson(await app.handle(jsonRequest("/pin-verify", "POST", { pin: "123" })))).toEqual({ ok: true, token: "token-123" });
+    expect(attempts.has("local")).toBe(false);
+
+    pin = "";
+    expect(await readJson(await app.handle(jsonRequest("/pin-verify", "POST", { pin: "anything" }, { "x-forwarded-for": "proxy" })))).toEqual({ ok: true });
+
+    pin = "9";
+    for (let i = 0; i < 5; i++) {
+      expect((await app.handle(jsonRequest("/pin-verify", "POST", { pin: "bad" }, { "cf-connecting-ip": "rate" }))).status).toBe(200);
+    }
+    const limited = await app.handle(jsonRequest("/pin-verify", "POST", { pin: "bad" }, { "cf-connecting-ip": "rate" }));
+    expect(limited.status).toBe(429);
+
+    attempts.set("old", { count: 5, resetAt: 10 });
+    tick = 70_000;
+    const reset = await app.handle(jsonRequest("/pin-verify", "POST", { pin: "bad" }, { "cf-connecting-ip": "old" }));
+    expect(reset.status).toBe(200);
+    expect(attempts.get("old")?.count).toBe(1);
+  });
+
+  test("default pin verifier uses auth token factory when no override is provided", async () => {
+    const app = makeApp({
+      pinAttempts: new Map(),
+      loadConfig: (() => ({ pin: "42" })) as any,
+    });
+
+    const res = await app.handle(jsonRequest("/pin-verify", "POST", { pin: "42" }));
+    const body = await readJson(res);
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(typeof body.token).toBe("string");
+    expect(body.token.length).toBeGreaterThan(10);
+  });
+
+  test("GET and POST /config preserve masked env values and report save errors", async () => {
+    const saves: any[] = [];
+    const app = makeApp({
+      loadConfig: (() => ({ raw: true, env: { SECRET: "raw-secret" } })) as any,
+      configForDisplay: (() => ({ display: true, envMasked: { SECRET: "••••" } })) as any,
+      saveConfig: ((data: any) => { saves.push(data); }) as any,
+    });
+
+    expect(await readJson(await app.handle(new Request("http://localhost/config?raw=1")))).toEqual({ raw: true, env: { SECRET: "raw-secret" } });
+    expect(await readJson(await app.handle(new Request("http://localhost/config")))).toEqual({ display: true, envMasked: { SECRET: "••••" } });
+
+    const save = await app.handle(jsonRequest("/config", "POST", { env: { SECRET: "••••", PLAIN: "ok" } }));
+    expect(save.status).toBe(200);
+    expect(saves).toEqual([{ env: { SECRET: "raw-secret", PLAIN: "ok" } }]);
+
+    const failing = makeApp({ saveConfig: (() => { throw new Error("config save boom"); }) as any });
+    const error = await failing.handle(jsonRequest("/config", "POST", { host: "local" }));
+    expect(error.status).toBe(400);
+    expect((await readJson(error)).error).toBe("config save boom");
+  });
+});


### PR DESCRIPTION
## Summary
- add a dependency-injected config API factory while preserving production `configApi`
- cover config file listing/read/write/toggle/delete/create branches
- cover PIN verification/rate-limit and public `/config` masked-env branches

## Validation
- `bun test test/config-api-default.test.ts --coverage --coverage-reporter=text --timeout 60000`
  - `src/api/config.ts | 100.00 | 100.00`
- `bun test test/config-api-default.test.ts test/isolated/api-config-file-atomic.test.ts --timeout 60000`
- `bun run build`
- `git diff --check`

## Release
- Alpha branch only.
- No release cut.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
