### PR TITLE
test(coverage): cover federation API routes

### DIFF
--- a/src/api/federation.ts
+++ b/src/api/federation.ts
@@ -1,8 +1,8 @@
-import { Elysia, t} from "elysia";
+import { Elysia, t } from "elysia";
 import { getFederationStatus } from "../core/transport/peers";
 import { loadConfig } from "../config";
-import { listSnapshots, loadSnapshot, latestSnapshot } from "../core/fleet/snapshot";
-import { hostedAgents } from "../commands/shared/federation-sync";
+import { listSnapshots, loadSnapshot } from "../core/fleet/snapshot";
+import { hostedAgents as defaultHostedAgents } from "../commands/shared/federation-sync";
 import { readFileSync, readdirSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
@@ -28,123 +28,174 @@ const ADVERTISED_ENDPOINTS: string[] = [
 
 // Re-export so existing importers (and any future code) can still reach
 // hostedAgents via the API module. The canonical home is federation-sync.ts.
-export { hostedAgents };
+export { defaultHostedAgents as hostedAgents };
 
-export const federationApi = new Elysia();
+type LedgerModule = {
+  listMessageLedgerEvents: (query: {
+    from?: string;
+    to?: string;
+    limit: number;
+    direction?: any;
+    state?: any;
+    q?: string;
+  }) => any[];
+  messageLedgerDbPath: () => string;
+};
 
-// PUBLIC FEDERATION API (v1) — no auth. Shape is load-bearing for lens
-// clients; `peers[].node` and `peers[].agents` are optional (commit 9a0546d+).
-// See docs/federation.md before changing fields.
-federationApi.get("/federation/status", async () => {
-  const status = await getFederationStatus();
-  return status;
-});
+export interface FederationApiDeps {
+  getFederationStatus?: typeof getFederationStatus;
+  listSnapshots?: typeof listSnapshots;
+  loadSnapshot?: typeof loadSnapshot;
+  loadConfig?: typeof loadConfig;
+  hostedAgents?: typeof defaultHostedAgents;
+  getPeerKey?: typeof getPeerKey;
+  packageVersion?: string;
+  uptime?: () => number;
+  nowIso?: () => string;
+  loadLedger?: () => Promise<LedgerModule>;
+  readFileSync?: typeof readFileSync;
+  readdirSync?: typeof readdirSync;
+  join?: typeof join;
+  homedir?: typeof homedir;
+  fleetDir?: string;
+}
 
-/** Snapshots API — list and view fleet time machine snapshots */
-federationApi.get("/snapshots", () => {
-  return listSnapshots();
-});
+export function createFederationApi(deps: FederationApiDeps = {}) {
+  const federationStatus = deps.getFederationStatus ?? getFederationStatus;
+  const snapshots = deps.listSnapshots ?? listSnapshots;
+  const snapshot = deps.loadSnapshot ?? loadSnapshot;
+  const load = deps.loadConfig ?? loadConfig;
+  const agentsForHost = deps.hostedAgents ?? defaultHostedAgents;
+  const peerKey = deps.getPeerKey ?? getPeerKey;
+  const version = deps.packageVersion ?? require("../../package.json").version;
+  const uptime = deps.uptime ?? (() => process.uptime());
+  const nowIso = deps.nowIso ?? (() => new Date().toISOString());
+  const readFile = deps.readFileSync ?? readFileSync;
+  const readDir = deps.readdirSync ?? readdirSync;
+  const pathJoin = deps.join ?? join;
+  const homeDir = deps.homedir ?? homedir;
+  const fleetDir = deps.fleetDir ?? FLEET_DIR;
+  const loadLedger = deps.loadLedger ?? (async () => await import("../vendor/mpr-plugins/messages/ledger"));
 
-federationApi.get("/snapshots/:id", ({ params, set}) => {
-  const snap = loadSnapshot(params.id);
-  if (!snap) { set.status = 404; return { error: "snapshot not found" }; }
-  return snap;
-});
+  const federationApi = new Elysia();
 
-/**
- * Node identity — public endpoint for federation dedup (#192) + clock health (#268).
- *
- * #804 Step 1 (ADR docs/federation/0001-peer-identity.md): also advertises
- *   - `endpoints`: supported API paths so peers can discover capabilities
- *     in one round-trip (closes the version-skew pressure).
- *   - `pubkey`: per-peer identity for TOFU pinning + Step 4 signing. Persisted
- *     at <CONFIG_DIR>/peer-key (SSH host-key model).
- */
-federationApi.get("/identity", async () => {
-  const config = loadConfig();
-  const node = config.node ?? "local";
-  const oracle = config.oracle ?? "mawjs";
-  const agents = hostedAgents(config.agents || {}, node);
-  const pkg = require("../../package.json");
-  return {
-    node,
-    oracle,
-    version: pkg.version,
-    agents,
-    uptime: Math.floor(process.uptime()),
-    clockUtc: new Date().toISOString(),
-    endpoints: ADVERTISED_ENDPOINTS,
-    pubkey: getPeerKey(),
-  };
-});
+  // PUBLIC FEDERATION API (v1) — no auth. Shape is load-bearing for lens
+  // clients; `peers[].node` and `peers[].agents` are optional (commit 9a0546d+).
+  // See docs/federation.md before changing fields.
+  federationApi.get("/federation/status", async () => {
+    const status = await federationStatus();
+    return status;
+  });
 
-/** Message log — query SQLite message ledger, falling back to legacy maw-log.jsonl. */
-federationApi.get("/messages", async ({ query }) => {
-  const from = query.from;
-  const to = query.to;
-  const limit = Math.min(parseInt(query.limit || "100"), 1000);
-  try {
-    const { listMessageLedgerEvents, messageLedgerDbPath } = await import("../vendor/mpr-plugins/messages/ledger");
-    const messages = listMessageLedgerEvents({
-      from,
-      to,
-      limit,
-      direction: query.direction as any,
-      state: query.state as any,
-      q: query.q,
-    });
-    if (messages.length > 0) {
-      return { messages, total: messages.length, source: "sqlite", dbPath: messageLedgerDbPath() };
+  /** Snapshots API — list and view fleet time machine snapshots */
+  federationApi.get("/snapshots", () => {
+    return snapshots();
+  });
+
+  federationApi.get("/snapshots/:id", ({ params, set }) => {
+    const snap = snapshot(params.id);
+    if (!snap) { set.status = 404; return { error: "snapshot not found" }; }
+    return snap;
+  });
+
+  /**
+   * Node identity — public endpoint for federation dedup (#192) + clock health (#268).
+   *
+   * #804 Step 1 (ADR docs/federation/0001-peer-identity.md): also advertises
+   *   - `endpoints`: supported API paths so peers can discover capabilities
+   *     in one round-trip (closes the version-skew pressure).
+   *   - `pubkey`: per-peer identity for TOFU pinning + Step 4 signing. Persisted
+   *     at <CONFIG_DIR>/peer-key (SSH host-key model).
+   */
+  federationApi.get("/identity", async () => {
+    const config = load();
+    const node = config.node ?? "local";
+    const oracle = config.oracle ?? "mawjs";
+    const agents = agentsForHost(config.agents || {}, node);
+    return {
+      node,
+      oracle,
+      version,
+      agents,
+      uptime: Math.floor(uptime()),
+      clockUtc: nowIso(),
+      endpoints: ADVERTISED_ENDPOINTS,
+      pubkey: peerKey(),
+    };
+  });
+
+  /** Message log — query SQLite message ledger, falling back to legacy maw-log.jsonl. */
+  federationApi.get("/messages", async ({ query }) => {
+    const from = query.from;
+    const to = query.to;
+    const limit = Math.min(parseInt(query.limit || "100"), 1000);
+    try {
+      const { listMessageLedgerEvents, messageLedgerDbPath } = await loadLedger();
+      const messages = listMessageLedgerEvents({
+        from,
+        to,
+        limit,
+        direction: query.direction as any,
+        state: query.state as any,
+        q: query.q,
+      });
+      if (messages.length > 0) {
+        return { messages, total: messages.length, source: "sqlite", dbPath: messageLedgerDbPath() };
+      }
+    } catch {
+      // Keep legacy endpoint non-fatal; fall through to JSONL.
     }
-  } catch {
-    // Keep legacy endpoint non-fatal; fall through to JSONL.
-  }
 
-  const logFile = join(homedir(), ".oracle", "maw-log.jsonl");
-  try {
-    const lines = readFileSync(logFile, "utf-8").trim().split("\n").filter(Boolean);
-    interface MawMessage { ts: string; from: string; to: string; msg: string; host?: string; route?: string }
-    let messages: MawMessage[] = lines.map(l => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean);
-    if (from) messages = messages.filter(m => m.from?.includes(from));
-    if (to) messages = messages.filter(m => m.to?.includes(to));
-    return { messages: messages.slice(-limit), total: messages.length };
-  } catch {
-    return { messages: [], total: 0 };
-  }
-}, {
-  query: t.Object({
-    from: t.Optional(t.String()),
-    to: t.Optional(t.String()),
-    limit: t.Optional(t.String()),
-    direction: t.Optional(t.String()),
-    state: t.Optional(t.String()),
-    q: t.Optional(t.String()),
-  }),
-});
+    const logFile = pathJoin(homeDir(), ".oracle", "maw-log.jsonl");
+    try {
+      const lines = readFile(logFile, "utf-8").trim().split("\n").filter(Boolean);
+      interface MawMessage { ts: string; from: string; to: string; msg: string; host?: string; route?: string }
+      let messages: MawMessage[] = lines.map((l) => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean);
+      if (from) messages = messages.filter((m) => m.from?.includes(from));
+      if (to) messages = messages.filter((m) => m.to?.includes(to));
+      return { messages: messages.slice(-limit), total: messages.length };
+    } catch {
+      return { messages: [], total: 0 };
+    }
+  }, {
+    query: t.Object({
+      from: t.Optional(t.String()),
+      to: t.Optional(t.String()),
+      limit: t.Optional(t.String()),
+      direction: t.Optional(t.String()),
+      state: t.Optional(t.String()),
+      q: t.Optional(t.String()),
+    }),
+  });
 
-/** Fleet configs — serve fleet/*.json with lineage data */
-federationApi.get("/fleet", () => {
-  try {
-    const files = readdirSync(FLEET_DIR).filter(f => f.endsWith(".json") && !f.endsWith(".disabled"));
-    const configs = files.map(f => {
-      try { return { file: f, ...JSON.parse(readFileSync(join(FLEET_DIR, f), "utf-8")) }; } catch { return null; }
-    }).filter(Boolean);
-    return { fleet: configs };
-  } catch {
-    return { fleet: [] };
-  }
-});
+  /** Fleet configs — serve fleet/*.json with lineage data */
+  federationApi.get("/fleet", () => {
+    try {
+      const files = readDir(fleetDir).filter((f) => f.endsWith(".json") && !f.endsWith(".disabled"));
+      const configs = files.map((f) => {
+        try { return { file: f, ...JSON.parse(readFile(pathJoin(fleetDir, f), "utf-8")) }; } catch { return null; }
+      }).filter(Boolean);
+      return { fleet: configs };
+    } catch {
+      return { fleet: [] };
+    }
+  });
 
-/** Auth status — public diagnostic endpoint (never reveals the token) */
-federationApi.get("/auth/status", () => {
-  const config = loadConfig();
-  const token = config.federationToken;
-  return {
-    enabled: !!token,
-    tokenConfigured: !!token,
-    tokenPreview: token ? token.slice(0, 4) + "****" : null,
-    method: token ? "HMAC-SHA256" : "none",
-    clockUtc: new Date().toISOString(),
-    node: config.node ?? "local",
-  };
-});
+  /** Auth status — public diagnostic endpoint (never reveals the token) */
+  federationApi.get("/auth/status", () => {
+    const config = load();
+    const token = config.federationToken;
+    return {
+      enabled: !!token,
+      tokenConfigured: !!token,
+      tokenPreview: token ? token.slice(0, 4) + "****" : null,
+      method: token ? "HMAC-SHA256" : "none",
+      clockUtc: nowIso(),
+      node: config.node ?? "local",
+    };
+  });
+
+  return federationApi;
+}
+
+export const federationApi = createFederationApi();

--- a/test/federation-api-default.test.ts
+++ b/test/federation-api-default.test.ts
@@ -1,0 +1,208 @@
+import { describe, test, expect } from "bun:test";
+import { Elysia } from "elysia";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createFederationApi, type FederationApiDeps } from "../src/api/federation";
+
+function makeApp(deps: FederationApiDeps = {}) {
+  return new Elysia().use(createFederationApi(deps));
+}
+
+async function readJson(res: Response) {
+  return await res.json() as any;
+}
+
+describe("federation API identity/status/snapshot routes", () => {
+  test("serves federation status, snapshots, identity, and auth status", async () => {
+    const app = makeApp({
+      getFederationStatus: async () => ({ peers: [{ name: "m5" }] }) as any,
+      listSnapshots: () => [{ id: "s1" }] as any,
+      loadSnapshot: (id: string) => id === "s1" ? ({ id, sessions: [] }) as any : null,
+      loadConfig: (() => ({
+        node: "m5",
+        oracle: "mawjs-oracle",
+        agents: { codex: { repo: "/repo", session: "54-mawjs" } },
+        federationToken: "abcd-secret",
+      })) as any,
+      hostedAgents: ((agents: any, node: string) => [{ node, name: Object.keys(agents)[0] }]) as any,
+      getPeerKey: () => "peer-public-key",
+      packageVersion: "v.test",
+      uptime: () => 42.9,
+      nowIso: () => "2026-05-17T00:00:00.000Z",
+    });
+
+    expect(await readJson(await app.handle(new Request("http://localhost/federation/status")))).toEqual({ peers: [{ name: "m5" }] });
+    expect(await readJson(await app.handle(new Request("http://localhost/snapshots")))).toEqual([{ id: "s1" }]);
+    expect(await readJson(await app.handle(new Request("http://localhost/snapshots/s1")))).toEqual({ id: "s1", sessions: [] });
+
+    const missing = await app.handle(new Request("http://localhost/snapshots/missing"));
+    expect(missing.status).toBe(404);
+    expect(await readJson(missing)).toEqual({ error: "snapshot not found" });
+
+    expect(await readJson(await app.handle(new Request("http://localhost/identity")))).toEqual({
+      node: "m5",
+      oracle: "mawjs-oracle",
+      version: "v.test",
+      agents: [{ node: "m5", name: "codex" }],
+      uptime: 42,
+      clockUtc: "2026-05-17T00:00:00.000Z",
+      endpoints: [
+        "/api/identity",
+        "/api/messages",
+        "/api/pane-keys",
+        "/api/probe",
+        "/api/send",
+        "/api/sleep",
+        "/api/wake",
+      ],
+      pubkey: "peer-public-key",
+    });
+
+    expect(await readJson(await app.handle(new Request("http://localhost/auth/status")))).toEqual({
+      enabled: true,
+      tokenConfigured: true,
+      tokenPreview: "abcd****",
+      method: "HMAC-SHA256",
+      clockUtc: "2026-05-17T00:00:00.000Z",
+      node: "m5",
+    });
+  });
+
+  test("identity and auth status default missing config fields", async () => {
+    const app = makeApp({
+      loadConfig: (() => ({})) as any,
+      hostedAgents: (() => []) as any,
+      getPeerKey: () => "pub",
+      packageVersion: "v.test",
+      uptime: () => 1,
+      nowIso: () => "now",
+    });
+
+    expect((await readJson(await app.handle(new Request("http://localhost/identity")))).node).toBe("local");
+    expect(await readJson(await app.handle(new Request("http://localhost/auth/status")))).toEqual({
+      enabled: false,
+      tokenConfigured: false,
+      tokenPreview: null,
+      method: "none",
+      clockUtc: "now",
+      node: "local",
+    });
+  });
+
+  test("production default callbacks remain callable without writing peer keys", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "maw-federation-api-"));
+    const savedPeerKey = process.env.MAW_PEER_KEY;
+    const savedConfigDir = process.env.MAW_CONFIG_DIR;
+    process.env.MAW_PEER_KEY = "test-peer-key";
+    process.env.MAW_CONFIG_DIR = tmp;
+    try {
+      const app = makeApp({
+        homedir: () => tmp,
+        readFileSync: (() => { throw new Error("no legacy log"); }) as any,
+      });
+
+      const identity = await readJson(await app.handle(new Request("http://localhost/identity")));
+      expect(identity.pubkey).toBe("test-peer-key");
+      expect(typeof identity.uptime).toBe("number");
+      expect(typeof identity.clockUtc).toBe("string");
+
+      const messages = await readJson(await app.handle(new Request("http://localhost/messages?limit=1")));
+      expect(messages).toEqual({ messages: [], total: 0 });
+    } finally {
+      if (savedPeerKey === undefined) delete process.env.MAW_PEER_KEY;
+      else process.env.MAW_PEER_KEY = savedPeerKey;
+      if (savedConfigDir === undefined) delete process.env.MAW_CONFIG_DIR;
+      else process.env.MAW_CONFIG_DIR = savedConfigDir;
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("federation API messages route", () => {
+  test("returns sqlite ledger messages with bounded query options", async () => {
+    const calls: any[] = [];
+    const app = makeApp({
+      loadLedger: async () => ({
+        listMessageLedgerEvents: (query: any) => {
+          calls.push(query);
+          return [{ id: 1, from: "a", to: "b", body: "hello" }];
+        },
+        messageLedgerDbPath: () => "/tmp/messages.sqlite",
+      }),
+    });
+
+    const res = await app.handle(new Request("http://localhost/messages?from=a&to=b&limit=5000&direction=out&state=sent&q=hel"));
+
+    expect(await readJson(res)).toEqual({
+      messages: [{ id: 1, from: "a", to: "b", body: "hello" }],
+      total: 1,
+      source: "sqlite",
+      dbPath: "/tmp/messages.sqlite",
+    });
+    expect(calls).toEqual([{ from: "a", to: "b", limit: 1000, direction: "out", state: "sent", q: "hel" }]);
+  });
+
+  test("falls back to legacy JSONL log with filters, invalid-line skip, and limit", async () => {
+    const app = makeApp({
+      homedir: () => "/home/test",
+      join: ((...parts: string[]) => parts.join("/")) as any,
+      loadLedger: async () => ({
+        listMessageLedgerEvents: () => [],
+        messageLedgerDbPath: () => "/unused",
+      }),
+      readFileSync: ((path: string) => {
+        expect(path).toBe("/home/test/.oracle/maw-log.jsonl");
+        return [
+          JSON.stringify({ ts: "1", from: "alice", to: "maw", msg: "old" }),
+          "not-json",
+          JSON.stringify({ ts: "2", from: "alice", to: "maw", msg: "newer" }),
+          JSON.stringify({ ts: "3", from: "bob", to: "maw", msg: "skip" }),
+        ].join("\n");
+      }) as any,
+    });
+
+    const res = await app.handle(new Request("http://localhost/messages?from=ali&to=maw&limit=1"));
+
+    expect(await readJson(res)).toEqual({
+      messages: [{ ts: "2", from: "alice", to: "maw", msg: "newer" }],
+      total: 2,
+    });
+  });
+
+  test("falls back to empty messages when sqlite and JSONL both fail", async () => {
+    const app = makeApp({
+      loadLedger: async () => { throw new Error("sqlite missing"); },
+      readFileSync: (() => { throw new Error("no jsonl"); }) as any,
+    });
+
+    expect(await readJson(await app.handle(new Request("http://localhost/messages")))).toEqual({ messages: [], total: 0 });
+  });
+});
+
+describe("federation API fleet route", () => {
+  test("serves active fleet configs and skips disabled or invalid files", async () => {
+    const app = makeApp({
+      fleetDir: "/fleet",
+      join: ((...parts: string[]) => parts.join("/")) as any,
+      readdirSync: ((dir: string) => {
+        expect(dir).toBe("/fleet");
+        return ["m5.json", "bad.json", "off.json.disabled", "notes.txt"] as any;
+      }) as any,
+      readFileSync: ((path: string) => {
+        if (path === "/fleet/m5.json") return JSON.stringify({ node: "m5" });
+        throw new Error("bad json");
+      }) as any,
+    });
+
+    expect(await readJson(await app.handle(new Request("http://localhost/fleet")))).toEqual({
+      fleet: [{ file: "m5.json", node: "m5" }],
+    });
+  });
+
+  test("returns an empty fleet when the fleet directory cannot be read", async () => {
+    const app = makeApp({ readdirSync: (() => { throw new Error("missing fleet"); }) as any });
+
+    expect(await readJson(await app.handle(new Request("http://localhost/fleet")))).toEqual({ fleet: [] });
+  });
+});


### PR DESCRIPTION
## Summary
- add a dependency-injected federation API factory while preserving production `federationApi`
- cover federation status, snapshot, identity, messages, fleet, and auth-status routes
- exercise sqlite-message success, JSONL fallback, empty fallback, and fleet invalid-file branches

## Validation
- `bun test test/federation-api-default.test.ts --coverage --coverage-reporter=text --timeout 60000`
  - `src/api/federation.ts | 100.00 | 100.00`
- `bun test test/federation-api-default.test.ts test/federation-sync.test.ts --timeout 60000`
- `bun run build`
- `git diff --check`

## Release
- Alpha branch only.
- No release cut.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
