### PR TITLE
test(api): cover sessions API routes

### DIFF
--- a/src/api/sessions.ts
+++ b/src/api/sessions.ts
@@ -1,4 +1,4 @@
-import { Elysia, t} from "elysia";
+import { Elysia, t } from "elysia";
 import { listSessions, capture, sendKeys, selectWindow } from "../core/transport/ssh";
 import { checkPaneIdle } from "../commands/shared/comm-send";
 import { findWindow } from "../core/runtime/find-window";
@@ -7,19 +7,79 @@ import { loadConfig } from "../config";
 import { curlFetch } from "../core/transport/curl-fetch";
 import { resolveTarget } from "../core/routing";
 import { processMirror } from "../lib/process-mirror";
-import { resolveFleetSession } from "../commands/shared/wake";
+import { cmdWake as defaultCmdWake, resolveFleetSession } from "../commands/shared/wake";
+import { shouldAutoWake as defaultShouldAutoWake } from "../commands/shared/should-auto-wake";
+import { cmdSleepOne as defaultCmdSleepOne } from "../lib/sleep";
 import { WakeBody, SleepBody, SendBody, PaneKeysBody, ProbeBody } from "../lib/schemas";
 import { Tmux } from "../core/transport/tmux";
 import { pushFeedEvent } from "./feed";
 import { buildMessageLifecycleFeedEvent, type MessageLifecycleInput } from "../lib/message-events";
+import type { Session } from "../core/transport/ssh";
 
-export const sessionsApi = new Elysia();
+type Config = ReturnType<typeof loadConfig>;
+type IdleCheck = Awaited<ReturnType<typeof checkPaneIdle>>;
+type TmuxLike = Pick<Tmux, "sendKeysLiteral" | "sendKeys">;
 
-function localMessageIdentity(config: ReturnType<typeof loadConfig>): string {
+type AutoWakeDecision = Awaited<ReturnType<typeof defaultShouldAutoWake>>;
+type AutoWakeOpts = Parameters<typeof defaultShouldAutoWake>[1];
+
+export interface SessionsApiDeps {
+  listSessions?: typeof listSessions;
+  capture?: typeof capture;
+  sendKeys?: typeof sendKeys;
+  selectWindow?: typeof selectWindow;
+  checkPaneIdle?: typeof checkPaneIdle;
+  findWindow?: typeof findWindow;
+  getAggregatedSessions?: typeof getAggregatedSessions;
+  findPeerForTarget?: typeof findPeerForTarget;
+  sendKeysToPeer?: typeof sendKeysToPeer;
+  loadConfig?: typeof loadConfig;
+  curlFetch?: typeof curlFetch;
+  resolveTarget?: typeof resolveTarget;
+  processMirror?: typeof processMirror;
+  resolveFleetSession?: typeof resolveFleetSession;
+  createTmux?: () => TmuxLike;
+  pushFeedEvent?: typeof pushFeedEvent;
+  buildMessageLifecycleFeedEvent?: typeof buildMessageLifecycleFeedEvent;
+  emitMessageLifecycle?: (input: MessageLifecycleInput) => void;
+  sleep?: (ms: number) => Promise<unknown>;
+  shouldAutoWake?: (target: string, opts: AutoWakeOpts) => AutoWakeDecision | Promise<AutoWakeDecision>;
+  cmdWake?: (target: string, opts: { noAttach: boolean; task?: string }) => Promise<unknown>;
+  cmdSleepOne?: (target: string) => Promise<unknown>;
+}
+
+function defaults(deps: SessionsApiDeps) {
+  return {
+    listSessions: deps.listSessions ?? listSessions,
+    capture: deps.capture ?? capture,
+    sendKeys: deps.sendKeys ?? sendKeys,
+    selectWindow: deps.selectWindow ?? selectWindow,
+    checkPaneIdle: deps.checkPaneIdle ?? checkPaneIdle,
+    findWindow: deps.findWindow ?? findWindow,
+    getAggregatedSessions: deps.getAggregatedSessions ?? getAggregatedSessions,
+    findPeerForTarget: deps.findPeerForTarget ?? findPeerForTarget,
+    sendKeysToPeer: deps.sendKeysToPeer ?? sendKeysToPeer,
+    loadConfig: deps.loadConfig ?? loadConfig,
+    curlFetch: deps.curlFetch ?? curlFetch,
+    resolveTarget: deps.resolveTarget ?? resolveTarget,
+    processMirror: deps.processMirror ?? processMirror,
+    resolveFleetSession: deps.resolveFleetSession ?? resolveFleetSession,
+    createTmux: deps.createTmux ?? (() => new Tmux()),
+    pushFeedEvent: deps.pushFeedEvent ?? pushFeedEvent,
+    buildMessageLifecycleFeedEvent: deps.buildMessageLifecycleFeedEvent ?? buildMessageLifecycleFeedEvent,
+    emitMessageLifecycle: deps.emitMessageLifecycle,
+    sleep: deps.sleep ?? ((ms: number) => Bun.sleep(ms)),
+    shouldAutoWake: deps.shouldAutoWake ?? defaultShouldAutoWake,
+    cmdWake: deps.cmdWake ?? defaultCmdWake,
+    cmdSleepOne: deps.cmdSleepOne ?? defaultCmdSleepOne,
+  };
+}
+
+export function localMessageIdentity(config: Config): string {
   return `${config.node ?? "local"}:${config.oracle ?? "mawjs"}`;
 }
 
-function requestMessageFrom(request: Request, config: ReturnType<typeof loadConfig>): string {
+export function requestMessageFrom(request: Request, config: Config): string {
   const from = request.headers.get("x-maw-from");
   if (!from) return localMessageIdentity(config);
   // Wire auth uses <oracle>:<node>; user-facing/message ledger uses <node>:<oracle>.
@@ -28,13 +88,15 @@ function requestMessageFrom(request: Request, config: ReturnType<typeof loadConf
   return from;
 }
 
-function messageSignedRequest(request: Request): boolean {
+export function messageSignedRequest(request: Request): boolean {
   return Boolean(request.headers.get("x-maw-from"));
 }
 
-function emitMessageLifecycle(input: MessageLifecycleInput) {
+export function emitMessageLifecycle(input: MessageLifecycleInput, deps: SessionsApiDeps = {}) {
   try {
-    pushFeedEvent(buildMessageLifecycleFeedEvent(input));
+    const build = deps.buildMessageLifecycleFeedEvent ?? buildMessageLifecycleFeedEvent;
+    const push = deps.pushFeedEvent ?? pushFeedEvent;
+    push(build(input));
   } catch {
     // Ledger/event hooks must never change /api/send delivery semantics.
   }
@@ -70,457 +132,449 @@ export function dedupeSessionWindows<T extends { windows: { name: string; active
 }
 
 /** Resolve oracle name → tmux target, same logic as local peek (#273). */
-function resolveCapture(query: string, sessions: { name: string }[]): string {
-  const config = loadConfig();
+export function resolveCapture(query: string, sessions: { name: string }[], deps: SessionsApiDeps = {}): string {
+  const d = defaults(deps);
+  const config = d.loadConfig();
   const mapped = (config.sessions as Record<string, string>)?.[query];
   if (mapped) {
     const filtered = sessions.filter(s => s.name === mapped);
-    if (filtered.length > 0) return findWindow(filtered, query) || query;
+    if (filtered.length > 0) return d.findWindow(filtered, query) || query;
   }
-  const fleetSession = resolveFleetSession(query);
+  const fleetSession = d.resolveFleetSession(query);
   if (fleetSession) {
     const filtered = sessions.filter(s => s.name === fleetSession);
-    if (filtered.length > 0) return findWindow(filtered, query) || query;
+    if (filtered.length > 0) return d.findWindow(filtered, query) || query;
   }
-  return findWindow(sessions, query) || query;
+  return d.findWindow(sessions, query) || query;
 }
 
-sessionsApi.get("/sessions", async ({ query }) => {
-  const local = await listSessions();
-  if (query.local === "true") {
-    return dedupeSessionWindows(local.map(s => ({ ...s, source: "local" })));
-  }
-  const aggregated = await getAggregatedSessions(local);
-  return dedupeSessionWindows(aggregated);
-}, {
-  query: t.Object({
-    local: t.Optional(t.String()),
-  }),
-});
+export function createSessionsApi(deps: SessionsApiDeps = {}) {
+  const d = defaults(deps);
+  const emitLifecycle = d.emitMessageLifecycle ?? ((input: MessageLifecycleInput) => emitMessageLifecycle(input, d));
+  const api = new Elysia();
 
-sessionsApi.get("/capture", async ({ query, set}) => {
-  const target = query.target;
-  if (!target) { set.status = 400; return { error: "target required" }; }
-  try {
-    const sessions = await listSessions();
-    const resolved = resolveCapture(target, sessions);
-    return { content: await capture(resolved) };
-  } catch (e: any) {
-    return { content: "", error: e.message };
-  }
-}, {
-  query: t.Object({
-    target: t.Optional(t.String()),
-  }),
-});
+  api.get("/sessions", async ({ query }) => {
+    const local = await d.listSessions();
+    if (query.local === "true") {
+      return dedupeSessionWindows(local.map(s => ({ ...s, source: "local" })));
+    }
+    const aggregated = await d.getAggregatedSessions(local);
+    return dedupeSessionWindows(aggregated);
+  }, {
+    query: t.Object({
+      local: t.Optional(t.String()),
+    }),
+  });
 
-sessionsApi.get("/mirror", async ({ query, set}) => {
-  const target = query.target;
-  if (!target) { set.status = 400; return "target required"; }
-  const lines = +(query.lines || "40");
-  const sessions = await listSessions();
-  const resolved = resolveCapture(target, sessions);
-  const raw = await capture(resolved);
-  return processMirror(raw, lines);
-}, {
-  query: t.Object({
-    target: t.Optional(t.String()),
-    lines: t.Optional(t.String()),
-  }),
-});
+  api.get("/capture", async ({ query, set }) => {
+    const target = query.target;
+    if (!target) { set.status = 400; return { error: "target required" }; }
+    try {
+      const sessions = await d.listSessions();
+      const resolved = resolveCapture(target, sessions, d);
+      return { content: await d.capture(resolved) };
+    } catch (e: any) {
+      return { content: "", error: e.message };
+    }
+  }, {
+    query: t.Object({
+      target: t.Optional(t.String()),
+    }),
+  });
 
-sessionsApi.post("/send", async ({ body, request, set}) => {
-  try {
-    const { target, text, force, attachments } = body;
-    const message = attachments?.length
-      ? attachments.join("\n") + "\n" + text
-      : text;
+  api.get("/mirror", async ({ query, set }) => {
+    const target = query.target;
+    if (!target) { set.status = 400; return "target required"; }
+    const lines = +(query.lines || "40");
+    const sessions = await d.listSessions();
+    const resolved = resolveCapture(target, sessions, d);
+    const raw = await d.capture(resolved);
+    return d.processMirror(raw, lines);
+  }, {
+    query: t.Object({
+      target: t.Optional(t.String()),
+      lines: t.Optional(t.String()),
+    }),
+  });
 
-    const config = loadConfig();
-    const messageFrom = requestMessageFrom(request, config);
-    const messageTo = localMessageIdentity(config);
-    const messageSigned = messageSignedRequest(request);
-    const local = await listSessions();
+  api.post("/send", async ({ body, request, set }) => {
+    try {
+      const { target, text, force, attachments } = body;
+      const message = attachments?.length
+        ? attachments.join("\n") + "\n" + text
+        : text;
 
-    // --- Unified resolution via resolveTarget (#201) ---
-    const result = resolveTarget(target, config, local);
+      const config = d.loadConfig();
+      const messageFrom = requestMessageFrom(request, config);
+      const messageTo = localMessageIdentity(config);
+      const messageSigned = messageSignedRequest(request);
+      const local = await d.listSessions();
 
-    // Also try with -oracle stripped (backwards compat)
-    const isResolved = result && result.type !== "error";
-    const altResult = !isResolved ? resolveTarget(target.replace(/-oracle$/, ""), config, local) : null;
-    const altResolved = altResult && altResult.type !== "error";
-    const resolved = isResolved ? result : altResolved ? altResult : (result || altResult);
+      // --- Unified resolution via resolveTarget (#201) ---
+      const result = d.resolveTarget(target, config, local);
 
-    // Local or self-node → send via tmux
-    if (resolved?.type === "local" || resolved?.type === "self-node") {
-      // #405: idle guard — reject if user has in-progress input on the prompt line
-      if (!force) {
-        let idleCheck = await checkPaneIdle(resolved.target);
-        if (!idleCheck.idle) {
-          await Bun.sleep(500);
-          idleCheck = await checkPaneIdle(resolved.target);
+      // Also try with -oracle stripped (backwards compat)
+      const isResolved = result && result.type !== "error";
+      const altResult = !isResolved ? d.resolveTarget(target.replace(/-oracle$/, ""), config, local) : null;
+      const altResolved = altResult && altResult.type !== "error";
+      const resolved = isResolved ? result : altResolved ? altResult : (result || altResult);
+
+      // Local or self-node → send via tmux
+      if (resolved?.type === "local" || resolved?.type === "self-node") {
+        // #405: idle guard — reject if user has in-progress input on the prompt line
+        if (!force) {
+          let idleCheck = await d.checkPaneIdle(resolved.target);
           if (!idleCheck.idle) {
-            set.status = 409;
-            emitMessageLifecycle({
-              direction: "inbound",
-              state: "failed",
-              channel: "api-send",
-              route: resolved.type,
-              from: messageFrom,
-              to: messageTo,
-              target: resolved.target,
-              text: message,
-              error: "pane not idle",
-              lastLine: idleCheck.lastInput,
-              signed: messageSigned,
-            });
-            return { ok: false, error: "pane not idle", target: resolved.target, lastInput: idleCheck.lastInput };
+            await d.sleep(500);
+            idleCheck = await d.checkPaneIdle(resolved.target);
+            if (!idleCheck.idle) {
+              set.status = 409;
+              emitLifecycle({
+                direction: "inbound",
+                state: "failed",
+                channel: "api-send",
+                route: resolved.type,
+                from: messageFrom,
+                to: messageTo,
+                target: resolved.target,
+                text: message,
+                error: "pane not idle",
+                lastLine: idleCheck.lastInput,
+                signed: messageSigned,
+              });
+              return { ok: false, error: "pane not idle", target: resolved.target, lastInput: idleCheck.lastInput };
+            }
           }
         }
+        await d.sendKeys(resolved.target, message);
+        await d.sleep(150);
+        let lastLine = "";
+        // Echo broadcast bug 2026-04-26: claude queues input behind a busy prompt and
+        // tmux send-keys still succeeds, so callers think delivery worked. Detect the
+        // "Press up to edit queued messages" indicator so the API can distinguish
+        // delivered vs queued.
+        let state: "delivered" | "queued" = "delivered";
+        try {
+          const content = await d.capture(resolved.target, 8);
+          const lines = content.split("\n").filter(l => l.trim());
+          lastLine = lines.pop() || "";
+          if (/Press up to edit queued messages/i.test(content)) state = "queued";
+        } catch {}
+        emitLifecycle({
+          direction: "inbound",
+          state,
+          channel: "api-send",
+          route: resolved.type,
+          from: messageFrom,
+          to: messageTo,
+          target: resolved.target,
+          text: message,
+          lastLine,
+          signed: messageSigned,
+        });
+        return { ok: true, target: resolved.target, text, source: "local", lastLine, state };
       }
-      await sendKeys(resolved.target, message);
-      await Bun.sleep(150);
-      let lastLine = "";
-      // Echo broadcast bug 2026-04-26: claude queues input behind a busy prompt and
-      // tmux send-keys still succeeds, so callers think delivery worked. Detect the
-      // "Press up to edit queued messages" indicator so the API can distinguish
-      // delivered vs queued.
-      let state: "delivered" | "queued" = "delivered";
-      try {
-        const content = await capture(resolved.target, 8);
-        const lines = content.split("\n").filter(l => l.trim());
-        lastLine = lines.pop() || "";
-        if (/Press up to edit queued messages/i.test(content)) state = "queued";
-      } catch {}
-      emitMessageLifecycle({
-        direction: "inbound",
-        state,
-        channel: "api-send",
-        route: resolved.type,
-        from: messageFrom,
-        to: messageTo,
-        target: resolved.target,
-        text: message,
-        lastLine,
-        signed: messageSigned,
-      });
-      return { ok: true, target: resolved.target, text, source: "local", lastLine, state };
-    }
 
-    // Remote peer → federation HTTP
-    if (resolved?.type === "peer") {
-      const res = await curlFetch(`${resolved.peerUrl}/api/send`, {
-        method: "POST",
-        body: JSON.stringify({ target: resolved.target, text: message }),
-        timeout: 10000,
-        from: "auto", // #804 Step 4 SIGN — sign cross-node forwarded /api/send
-      });
-      if (res.ok && res.data?.ok) {
-        emitMessageLifecycle({
+      // Remote peer → federation HTTP
+      if (resolved?.type === "peer") {
+        const res = await d.curlFetch(`${resolved.peerUrl}/api/send`, {
+          method: "POST",
+          body: JSON.stringify({ target: resolved.target, text: message }),
+          timeout: 10000,
+          from: "auto", // #804 Step 4 SIGN — sign cross-node forwarded /api/send
+        });
+        if (res.ok && res.data?.ok) {
+          emitLifecycle({
+            direction: "forwarded",
+            state: res.data.state === "queued" ? "queued" : "delivered",
+            channel: "api-send",
+            route: "peer",
+            from: messageFrom,
+            to: `${resolved.node}:${resolved.target}`,
+            target: res.data.target || resolved.target,
+            peerUrl: resolved.peerUrl,
+            text: message,
+            lastLine: res.data.lastLine || "",
+            signed: messageSigned,
+          });
+          return { ok: true, target: res.data.target || target, text, source: resolved.peerUrl, lastLine: res.data.lastLine || "", state: res.data.state ?? "delivered" };
+        }
+        emitLifecycle({
           direction: "forwarded",
-          state: res.data.state === "queued" ? "queued" : "delivered",
+          state: "failed",
           channel: "api-send",
           route: "peer",
           from: messageFrom,
           to: `${resolved.node}:${resolved.target}`,
-          target: res.data.target || resolved.target,
+          target: resolved.target,
           peerUrl: resolved.peerUrl,
           text: message,
-          lastLine: res.data.lastLine || "",
+          error: `${resolved.node} → ${resolved.target} send failed`,
           signed: messageSigned,
         });
-        return { ok: true, target: res.data.target || target, text, source: resolved.peerUrl, lastLine: res.data.lastLine || "", state: res.data.state ?? "delivered" };
+        set.status = 502; return { error: `${resolved.node} → ${resolved.target} send failed`, target, source: resolved.peerUrl };
       }
-      emitMessageLifecycle({
-        direction: "forwarded",
-        state: "failed",
-        channel: "api-send",
-        route: "peer",
-        from: messageFrom,
-        to: `${resolved.node}:${resolved.target}`,
-        target: resolved.target,
-        peerUrl: resolved.peerUrl,
-        text: message,
-        error: `${resolved.node} → ${resolved.target} send failed`,
-        signed: messageSigned,
-      });
-      set.status = 502; return { error: `${resolved.node} → ${resolved.target} send failed`, target, source: resolved.peerUrl };
-    }
 
-    // Fallback: async peer discovery
-    const peerUrl = await findPeerForTarget(target, local);
-    if (peerUrl) {
-      const ok = await sendKeysToPeer(peerUrl, target, message);
-      emitMessageLifecycle({
-        direction: "forwarded",
-        state: ok ? "delivered" : "failed",
-        channel: "api-send",
-        route: "discovery",
-        from: messageFrom,
-        to: target,
-        target,
-        peerUrl,
-        text: message,
-        error: ok ? undefined : "Failed to send to peer",
-        signed: messageSigned,
-      });
-      if (ok) return { ok: true, target, text, source: peerUrl, state: "delivered" as const };
-      set.status = 502; return { error: "Failed to send to peer", target, source: peerUrl };
-    }
+      // Fallback: async peer discovery
+      const peerUrl = await d.findPeerForTarget(target, local);
+      if (peerUrl) {
+        const ok = await d.sendKeysToPeer(peerUrl, target, message);
+        emitLifecycle({
+          direction: "forwarded",
+          state: ok ? "delivered" : "failed",
+          channel: "api-send",
+          route: "discovery",
+          from: messageFrom,
+          to: target,
+          target,
+          peerUrl,
+          text: message,
+          error: ok ? undefined : "Failed to send to peer",
+          signed: messageSigned,
+        });
+        if (ok) return { ok: true, target, text, source: peerUrl, state: "delivered" as const };
+        set.status = 502; return { error: "Failed to send to peer", target, source: peerUrl };
+      }
 
-    // #835 — consult shouldAutoWake for the "implicit wake on send" decision.
-    // Fleet-known target with no local session → wake then retry resolve once.
-    // Unknown targets fall through to the existing 404 (no behavior change).
-    {
-      const isFleetKnown = Boolean(resolveFleetSession(target));
-      const { shouldAutoWake } = await import("../commands/shared/should-auto-wake");
-      const decision = shouldAutoWake(target, {
-        site: "api-send",
-        isLive: false,
-        isFleetKnown,
-      });
-      if (decision.wake) {
-        try {
-          const { cmdWake } = await import("../commands/shared/wake");
-          await cmdWake(target, { noAttach: true });
-          // Retry resolution once, after the wake. If it now resolves locally,
-          // recurse the local-send path. This branch is opt-in via fleet
-          // membership — unknown targets still 404.
-          const refreshed = await listSessions();
-          const retry = resolveTarget(target, config, refreshed);
-          if (retry?.type === "local" || retry?.type === "self-node") {
-            if (!force) {
-              let idleCheck = await checkPaneIdle(retry.target);
-              if (!idleCheck.idle) {
-                await Bun.sleep(500);
-                idleCheck = await checkPaneIdle(retry.target);
+      // #835 — consult shouldAutoWake for the "implicit wake on send" decision.
+      // Fleet-known target with no local session → wake then retry resolve once.
+      // Unknown targets fall through to the existing 404 (no behavior change).
+      {
+        const isFleetKnown = Boolean(d.resolveFleetSession(target));
+        const decision = await d.shouldAutoWake(target, {
+          site: "api-send",
+          isLive: false,
+          isFleetKnown,
+        });
+        if (decision.wake) {
+          try {
+            await d.cmdWake(target, { noAttach: true });
+            // Retry resolution once, after the wake. If it now resolves locally,
+            // recurse the local-send path. This branch is opt-in via fleet
+            // membership — unknown targets still 404.
+            const refreshed = await d.listSessions();
+            const retry = d.resolveTarget(target, config, refreshed);
+            if (retry?.type === "local" || retry?.type === "self-node") {
+              if (!force) {
+                let idleCheck = await d.checkPaneIdle(retry.target);
                 if (!idleCheck.idle) {
-                  set.status = 409;
-                  emitMessageLifecycle({
-                    direction: "inbound",
-                    state: "failed",
-                    channel: "api-send",
-                    route: "local",
-                    from: messageFrom,
-                    to: messageTo,
-                    target: retry.target,
-                    text: message,
-                    error: "pane not idle",
-                    lastLine: idleCheck.lastInput,
-                    signed: messageSigned,
-                  });
-                  return { ok: false, error: "pane not idle", target: retry.target, lastInput: idleCheck.lastInput };
+                  await d.sleep(500);
+                  idleCheck = await d.checkPaneIdle(retry.target);
+                  if (!idleCheck.idle) {
+                    set.status = 409;
+                    emitLifecycle({
+                      direction: "inbound",
+                      state: "failed",
+                      channel: "api-send",
+                      route: "local",
+                      from: messageFrom,
+                      to: messageTo,
+                      target: retry.target,
+                      text: message,
+                      error: "pane not idle",
+                      lastLine: idleCheck.lastInput,
+                      signed: messageSigned,
+                    });
+                    return { ok: false, error: "pane not idle", target: retry.target, lastInput: idleCheck.lastInput };
+                  }
                 }
               }
+              await d.sendKeys(retry.target, message);
+              await d.sleep(150);
+              let lastLine = "";
+              try { const content = await d.capture(retry.target, 3); lastLine = content.split("\n").filter(l => l.trim()).pop() || ""; } catch {}
+              emitLifecycle({
+                direction: "inbound",
+                state: "delivered",
+                channel: "api-send",
+                route: "local",
+                from: messageFrom,
+                to: messageTo,
+                target: retry.target,
+                text: message,
+                lastLine,
+                signed: messageSigned,
+              });
+              return { ok: true, target: retry.target, text, source: "local", lastLine, wokeFor: target };
             }
-            await sendKeys(retry.target, message);
-            await Bun.sleep(150);
-            let lastLine = "";
-            try { const content = await capture(retry.target, 3); lastLine = content.split("\n").filter(l => l.trim()).pop() || ""; } catch {}
-            emitMessageLifecycle({
-              direction: "inbound",
-              state: "delivered",
-              channel: "api-send",
-              route: "local",
-              from: messageFrom,
-              to: messageTo,
-              target: retry.target,
-              text: message,
-              lastLine,
-              signed: messageSigned,
-            });
-            return { ok: true, target: retry.target, text, source: "local", lastLine, wokeFor: target };
-          }
-        } catch { /* wake best-effort — fall through to 404 */ }
+          } catch { /* wake best-effort — fall through to 404 */ }
+        }
       }
+
+      const errDetail = resolved?.type === "error" ? { reason: resolved.reason, detail: resolved.detail, hint: resolved.hint } : {};
+      emitLifecycle({
+        direction: "inbound",
+        state: "failed",
+        channel: "api-send",
+        route: "local",
+        from: messageFrom,
+        to: messageTo,
+        target,
+        text: message,
+        error: errDetail.detail || `target not found: ${target}`,
+        signed: messageSigned,
+      });
+      set.status = 404; return { error: `target not found: ${target}`, target, ...errDetail };
+    } catch (err) {
+      set.status = 500; return { error: String(err) };
     }
+  }, {
+    body: SendBody,
+  });
 
-    const errDetail = resolved?.type === "error" ? { reason: resolved.reason, detail: resolved.detail, hint: resolved.hint } : {};
-    emitMessageLifecycle({
-      direction: "inbound",
-      state: "failed",
-      channel: "api-send",
-      route: "local",
-      from: messageFrom,
-      to: messageTo,
-      target,
-      text: message,
-      error: errDetail.detail || `target not found: ${target}`,
-      signed: messageSigned,
-    });
-    set.status = 404; return { error: `target not found: ${target}`, target, ...errDetail };
-  } catch (err) {
-    set.status = 500; return { error: String(err) };
-  }
-}, {
-  body: SendBody,
-});
-
-/**
- * POST /api/pane-keys — raw send-keys to any tmux pane (#757).
- *
- * Body: { target, text, enter? }
- *   - text is sent literally via `tmux send-keys -l` (no paste-mode, no
- *     interpretation of special chars like |). Empty text is allowed.
- *   - enter=true appends `tmux send-keys Enter` after the text.
- *
- * No readiness guard, no paste delay — this is the dual of `maw send-enter`.
- * Used by `maw send` (enter=false) and `maw run` (enter=true) cross-node.
- */
-sessionsApi.post("/pane-keys", async ({ body, set }) => {
-  try {
-    const { target, text, enter } = body;
-    if (!target) { set.status = 400; return { error: "target required" }; }
-    const t = new Tmux();
-    if (text && text.length > 0) {
-      await t.sendKeysLiteral(target, text);
-    }
-    if (enter) {
-      await t.sendKeys(target, "Enter");
-    }
-    return { ok: true, target, enter: !!enter };
-  } catch (err) {
-    set.status = 500; return { error: String(err) };
-  }
-}, {
-  body: PaneKeysBody,
-});
-
-/**
- * POST /api/probe — real-write-path health check (#804 Step 5).
- *
- * Walks the same resolveTarget/tmux-session-exists branches as /api/send but
- * stops short of `sendKeys` — never mutates a pane. With no `target`, only
- * proves the handler can run (config loads, listSessions returns) so peers
- * can confirm reachability without naming a deliverable agent.
- *
- * Auth: federationAuth + fromSigningAuth (it's a write-path endpoint — same
- * surface as /send, /wake). Loopback is exempted via the same gate. Callers
- * sign with `from: "auto"` so peer continuity (Step 4) is exercised too.
- *
- * Response shape:
- *   - { ok: true, target?, transport: "local"|"ssh", source }
- *   - { ok: false, error, target? } with HTTP 4xx/5xx
- *
- * Lesson banked from #795 schema-drift: /api/identity returning 200 doesn't
- * mean /api/send works — different code paths fail independently. /probe
- * exercises the same writer-side branches /send does, so green here means
- * green for delivery (modulo the actual sendKeys, which is the only step we
- * skip). See ADR docs/federation/0001-peer-identity.md.
- */
-sessionsApi.post("/probe", async ({ body, set }) => {
-  try {
-    const target = body?.target;
-
-    // Bare healthcheck — no target. Just prove we can walk the write path
-    // setup (loadConfig + listSessions). If either throws, /send would too.
-    if (!target) {
-      const config = loadConfig();
-      const local = await listSessions();
-      return {
-        ok: true,
-        transport: "local" as const,
-        source: config.node ?? "local",
-        sessions: local.length,
-      };
-    }
-
-    const config = loadConfig();
-    const local = await listSessions();
-
-    // Same resolution as /send — including the -oracle stripped retry — so a
-    // probe failure here means /send would fail with the same reason.
-    const result = resolveTarget(target, config, local);
-    const isResolved = result && result.type !== "error";
-    const altResult = !isResolved ? resolveTarget(target.replace(/-oracle$/, ""), config, local) : null;
-    const altResolved = altResult && altResult.type !== "error";
-    const resolved = isResolved ? result : altResolved ? altResult : (result || altResult);
-
-    if (resolved?.type === "local" || resolved?.type === "self-node") {
-      // Validate the tmux session in `<session>:<window>` actually exists.
-      // resolveTarget already implies the window resolved, but a probe should
-      // confirm the tmux server still answers (the #795-style failure mode).
-      const sessionName = resolved.target.split(":")[0] ?? "";
-      const sessionExists = local.some(s => s.name === sessionName);
-      if (!sessionExists) {
-        set.status = 404;
-        return { ok: false, error: `tmux session not found: ${sessionName}`, target };
+  /**
+   * POST /api/pane-keys — raw send-keys to any tmux pane (#757).
+   *
+   * Body: { target, text, enter? }
+   *   - text is sent literally via `tmux send-keys -l` (no paste-mode, no
+   *     interpretation of special chars like |). Empty text is allowed.
+   *   - enter=true appends `tmux send-keys Enter` after the text.
+   *
+   * No readiness guard, no paste delay — this is the dual of `maw send-enter`.
+   * Used by `maw send` (enter=false) and `maw run` (enter=true) cross-node.
+   */
+  api.post("/pane-keys", async ({ body, set }) => {
+    try {
+      const { target, text, enter } = body;
+      if (!target) { set.status = 400; return { error: "target required" }; }
+      const t = d.createTmux();
+      if (text && text.length > 0) {
+        await t.sendKeysLiteral(target, text);
       }
-      return {
-        ok: true,
-        target: resolved.target,
-        transport: "local" as const,
-        source: config.node ?? "local",
-      };
+      if (enter) {
+        await t.sendKeys(target, "Enter");
+      }
+      return { ok: true, target, enter: !!enter };
+    } catch (err) {
+      set.status = 500; return { error: String(err) };
     }
+  }, {
+    body: PaneKeysBody,
+  });
 
-    if (resolved?.type === "peer") {
-      // We don't forward the probe further — that's the caller's job. Report
-      // that this node would forward to <peerUrl> if /send were called.
-      return {
-        ok: true,
-        target: resolved.target,
-        transport: "ssh" as const,
-        source: resolved.peerUrl,
-        node: resolved.node,
-      };
+  /**
+   * POST /api/probe — real-write-path health check (#804 Step 5).
+   *
+   * Walks the same resolveTarget/tmux-session-exists branches as /api/send but
+   * stops short of `sendKeys` — never mutates a pane. With no `target`, only
+   * proves the handler can run (config loads, listSessions returns) so peers
+   * can confirm reachability without naming a deliverable agent.
+   */
+  api.post("/probe", async ({ body, set }) => {
+    try {
+      const target = body?.target;
+
+      // Bare healthcheck — no target. Just prove we can walk the write path
+      // setup (loadConfig + listSessions). If either throws, /send would too.
+      if (!target) {
+        const config = d.loadConfig();
+        const local = await d.listSessions();
+        return {
+          ok: true,
+          transport: "local" as const,
+          source: config.node ?? "local",
+          sessions: local.length,
+        };
+      }
+
+      const config = d.loadConfig();
+      const local = await d.listSessions();
+
+      // Same resolution as /send — including the -oracle stripped retry — so a
+      // probe failure here means /send would fail with the same reason.
+      const result = d.resolveTarget(target, config, local);
+      const isResolved = result && result.type !== "error";
+      const altResult = !isResolved ? d.resolveTarget(target.replace(/-oracle$/, ""), config, local) : null;
+      const altResolved = altResult && altResult.type !== "error";
+      const resolved = isResolved ? result : altResolved ? altResult : (result || altResult);
+
+      if (resolved?.type === "local" || resolved?.type === "self-node") {
+        // Validate the tmux session in `<session>:<window>` actually exists.
+        // resolveTarget already implies the window resolved, but a probe should
+        // confirm the tmux server still answers (the #795-style failure mode).
+        const sessionName = resolved.target.split(":")[0] ?? "";
+        const sessionExists = local.some(s => s.name === sessionName);
+        if (!sessionExists) {
+          set.status = 404;
+          return { ok: false, error: `tmux session not found: ${sessionName}`, target };
+        }
+        return {
+          ok: true,
+          target: resolved.target,
+          transport: "local" as const,
+          source: config.node ?? "local",
+        };
+      }
+
+      if (resolved?.type === "peer") {
+        // We don't forward the probe further — that's the caller's job. Report
+        // that this node would forward to <peerUrl> if /send were called.
+        return {
+          ok: true,
+          target: resolved.target,
+          transport: "ssh" as const,
+          source: resolved.peerUrl,
+          node: resolved.node,
+        };
+      }
+
+      const errDetail = resolved?.type === "error"
+        ? { reason: resolved.reason, detail: resolved.detail, hint: resolved.hint }
+        : {};
+      set.status = 404;
+      return { ok: false, error: `target not found: ${target}`, target, ...errDetail };
+    } catch (err) {
+      set.status = 500;
+      return { ok: false, error: String(err) };
     }
+  }, {
+    body: ProbeBody,
+  });
 
-    const errDetail = resolved?.type === "error"
-      ? { reason: resolved.reason, detail: resolved.detail, hint: resolved.hint }
-      : {};
-    set.status = 404;
-    return { ok: false, error: `target not found: ${target}`, target, ...errDetail };
-  } catch (err) {
-    set.status = 500;
-    return { ok: false, error: String(err) };
-  }
-}, {
-  body: ProbeBody,
-});
-
-sessionsApi.post("/select", async ({ body, set}) => {
-  const { target } = body;
-  if (!target) { set.status = 400; return { error: "target required" }; }
-  await selectWindow(target);
-  return { ok: true, target };
-}, {
-  body: t.Object({ target: t.String() }),
-});
-
-sessionsApi.post("/wake", async ({ body, set}) => {
-  try {
-    const target = body.target ?? body.oracle;
-    if (!target) { set.status = 400; return { error: "target required (or 'oracle' for legacy peers)" }; }
-    // #835 — consult unified shouldAutoWake helper. /api/wake's policy is
-    // "always wake" (the endpoint exists for that). The helper makes that
-    // decision explicit and auditable, mirroring the other 6 sites.
-    const { shouldAutoWake } = await import("../commands/shared/should-auto-wake");
-    const decision = shouldAutoWake(target, { site: "api-wake" });
-    if (!decision.wake) {
-      // Defensive — site=api-wake never returns false today, but keep the
-      // branch so future policy changes can't silently no-op the endpoint.
-      set.status = 500; return { error: `wake denied: ${decision.reason}` };
-    }
-    const { cmdWake } = await import("../commands/shared/wake");
-    await cmdWake(target, { noAttach: true, task: body.task });
-    return { ok: true, target };
-  } catch (err) {
-    set.status = 500; return { error: String(err) };
-  }
-}, {
-  body: WakeBody,
-});
-
-sessionsApi.post("/sleep", async ({ body, set}) => {
-  try {
+  api.post("/select", async ({ body, set }) => {
     const { target } = body;
-    const { cmdSleepOne } = await import("../lib/sleep");
-    await cmdSleepOne(target);
+    if (!target) { set.status = 400; return { error: "target required" }; }
+    await d.selectWindow(target);
     return { ok: true, target };
-  } catch (err) {
-    set.status = 500; return { error: String(err) };
-  }
-}, {
-  body: SleepBody,
-});
+  }, {
+    body: t.Object({ target: t.String() }),
+  });
+
+  api.post("/wake", async ({ body, set }) => {
+    try {
+      const target = body.target ?? body.oracle;
+      if (!target) { set.status = 400; return { error: "target required (or 'oracle' for legacy peers)" }; }
+      // #835 — consult unified shouldAutoWake helper. /api/wake's policy is
+      // "always wake" (the endpoint exists for that). The helper makes that
+      // decision explicit and auditable, mirroring the other 6 sites.
+      const decision = await d.shouldAutoWake(target, { site: "api-wake" });
+      if (!decision.wake) {
+        // Defensive — site=api-wake never returns false today, but keep the
+        // branch so future policy changes can't silently no-op the endpoint.
+        set.status = 500; return { error: `wake denied: ${decision.reason}` };
+      }
+      await d.cmdWake(target, { noAttach: true, task: body.task });
+      return { ok: true, target };
+    } catch (err) {
+      set.status = 500; return { error: String(err) };
+    }
+  }, {
+    body: WakeBody,
+  });
+
+  api.post("/sleep", async ({ body, set }) => {
+    try {
+      const { target } = body;
+      await d.cmdSleepOne(target);
+      return { ok: true, target };
+    } catch (err) {
+      set.status = 500; return { error: String(err) };
+    }
+  }, {
+    body: SleepBody,
+  });
+
+  return api;
+}
+
+export const sessionsApi = createSessionsApi();

--- a/test/sessions-api-default.test.ts
+++ b/test/sessions-api-default.test.ts
@@ -1,0 +1,415 @@
+import { describe, test, expect } from "bun:test";
+import { Elysia } from "elysia";
+import {
+  createSessionsApi,
+  emitMessageLifecycle,
+  localMessageIdentity,
+  messageSignedRequest,
+  requestMessageFrom,
+  resolveCapture,
+  type SessionsApiDeps,
+} from "../src/api/sessions";
+
+function session(name: string, windows = [{ index: 0, name: "main", active: true }]) {
+  return { name, windows } as any;
+}
+
+function jsonRequest(path: string, body: unknown, headers: Record<string, string> = {}) {
+  return new Request(`http://local${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+async function readJson(res: Response) {
+  return await res.json() as any;
+}
+
+function makeHarness(overrides: SessionsApiDeps = {}) {
+  const calls: any[] = [];
+  let localSessions = [session("local", [{ index: 0, name: "main", active: true }])];
+  const config: any = { node: "m5", oracle: "mawjs", sessions: {} };
+  const lifecycle: any[] = [];
+  const deps: SessionsApiDeps = {
+    listSessions: async () => localSessions as any,
+    capture: async (target: string, lines?: number) => {
+      calls.push(["capture", target, lines]);
+      return "line one\nlast line";
+    },
+    sendKeys: async (target: string, text: string) => { calls.push(["sendKeys", target, text]); },
+    selectWindow: async (target: string) => { calls.push(["selectWindow", target]); },
+    checkPaneIdle: async (target: string) => { calls.push(["idle", target]); return { idle: true, lastInput: "" } as any; },
+    findWindow: ((sessions: any[], query: string) => `${sessions[0]?.name ?? "missing"}:${query}`) as any,
+    getAggregatedSessions: async (local: any[]) => [...local, session("remote", [
+      { index: 0, name: "dup", active: false },
+      { index: 1, name: "dup", active: true },
+    ])] as any,
+    findPeerForTarget: async () => null,
+    sendKeysToPeer: async (peer: string, target: string, message: string) => { calls.push(["sendKeysToPeer", peer, target, message]); return true; },
+    loadConfig: (() => config) as any,
+    curlFetch: async (url: string, opts: any) => { calls.push(["curlFetch", url, opts]); return { ok: true, status: 200, data: { ok: true } } as any; },
+    resolveTarget: (() => ({ type: "error", reason: "missing", detail: "not found", hint: "try wake" })) as any,
+    processMirror: ((raw: string, lines: number) => ({ raw, lines, processed: true })) as any,
+    resolveFleetSession: () => null,
+    createTmux: () => ({
+      sendKeysLiteral: async (target: string, text: string) => { calls.push(["literal", target, text]); },
+      sendKeys: async (target: string, key: string) => { calls.push(["tmuxKeys", target, key]); },
+    } as any),
+    emitMessageLifecycle: (input) => { lifecycle.push(input); },
+    sleep: async (ms: number) => { calls.push(["sleep", ms]); },
+    shouldAutoWake: () => ({ wake: false, reason: "policy" }),
+    cmdWake: async (target: string, opts: any) => { calls.push(["cmdWake", target, opts]); },
+    cmdSleepOne: async (target: string) => { calls.push(["cmdSleepOne", target]); },
+    ...overrides,
+  };
+  const app = new Elysia().use(createSessionsApi(deps));
+  return { app, calls, config, lifecycle, deps, setSessions: (s: any[]) => { localSessions = s; } };
+}
+
+describe("sessions API helpers", () => {
+  test("message identity helpers normalize signed and unsigned senders", () => {
+    const config: any = { node: "m5", oracle: "codex" };
+    expect(localMessageIdentity(config)).toBe("m5:codex");
+    expect(localMessageIdentity({} as any)).toBe("local:mawjs");
+
+    const unsigned = new Request("http://local/send");
+    expect(requestMessageFrom(unsigned, config)).toBe("m5:codex");
+    expect(messageSignedRequest(unsigned)).toBe(false);
+
+    const signed = new Request("http://local/send", { headers: { "x-maw-from": "oracle:white" } });
+    expect(requestMessageFrom(signed, config)).toBe("white:oracle");
+    expect(messageSignedRequest(signed)).toBe(true);
+
+    const malformed = new Request("http://local/send", { headers: { "x-maw-from": "wire-formatless" } });
+    expect(requestMessageFrom(malformed, config)).toBe("wire-formatless");
+  });
+
+  test("emitMessageLifecycle pushes built feed events and swallows hook failures", () => {
+    const pushed: any[] = [];
+    emitMessageLifecycle({ direction: "inbound", state: "delivered", channel: "api-send", route: "local", from: "a", to: "b", target: "t", text: "hi" }, {
+      buildMessageLifecycleFeedEvent: ((input: any) => ({ built: input.text })) as any,
+      pushFeedEvent: ((event: any) => pushed.push(event)) as any,
+    });
+    expect(pushed).toEqual([{ built: "hi" }]);
+
+    expect(() => emitMessageLifecycle({ direction: "inbound", state: "failed", channel: "api-send", route: "local", from: "a", to: "b", target: "t", text: "hi" }, {
+      buildMessageLifecycleFeedEvent: (() => { throw new Error("boom"); }) as any,
+      pushFeedEvent: (() => { throw new Error("boom"); }) as any,
+    })).not.toThrow();
+  });
+
+  test("resolveCapture uses mapped sessions, fleet sessions, and fallback window lookup", () => {
+    expect(resolveCapture("neo", [session("mapped")], {
+      loadConfig: (() => ({ sessions: { neo: "mapped" } })) as any,
+      findWindow: (() => "mapped:neo") as any,
+      resolveFleetSession: () => null,
+    })).toBe("mapped:neo");
+
+    expect(resolveCapture("tile", [session("fleet")], {
+      loadConfig: (() => ({ sessions: {} })) as any,
+      findWindow: (() => null) as any,
+      resolveFleetSession: () => "fleet",
+    })).toBe("tile");
+
+    expect(resolveCapture("plain", [session("local")], {
+      loadConfig: (() => ({ sessions: {} })) as any,
+      findWindow: (() => "local:plain") as any,
+      resolveFleetSession: () => null,
+    })).toBe("local:plain");
+  });
+});
+
+describe("sessions, capture, and mirror routes", () => {
+  test("GET /sessions returns local or aggregated sessions with deduped windows", async () => {
+    const h = makeHarness();
+    h.setSessions([session("local", [
+      { index: 0, name: "dup", active: false },
+      { index: 1, name: "dup", active: true },
+    ])]);
+
+    const local = await readJson(await h.app.handle(new Request("http://local/sessions?local=true")));
+    expect(local).toEqual([{ name: "local", source: "local", windows: [{ index: 1, name: "dup", active: true }] }]);
+
+    const aggregated = await readJson(await h.app.handle(new Request("http://local/sessions")));
+    expect(aggregated.map((s: any) => [s.name, s.windows.length])).toEqual([["local", 1], ["remote", 1]]);
+  });
+
+  test("GET /capture validates target, resolves aliases, and reports capture errors", async () => {
+    const h = makeHarness();
+    h.config.sessions.neo = "local";
+
+    const missing = await h.app.handle(new Request("http://local/capture"));
+    expect(missing.status).toBe(400);
+
+    const ok = await readJson(await h.app.handle(new Request("http://local/capture?target=neo")));
+    expect(ok).toEqual({ content: "line one\nlast line" });
+    expect(h.calls[0]).toEqual(["capture", "local:neo", undefined]);
+
+    const err = makeHarness({ capture: async () => { throw new Error("capture boom"); } });
+    expect(await readJson(await err.app.handle(new Request("http://local/capture?target=neo")))).toEqual({ content: "", error: "capture boom" });
+  });
+
+  test("GET /mirror validates target and processes captured output", async () => {
+    const h = makeHarness();
+    const missing = await h.app.handle(new Request("http://local/mirror"));
+    expect(missing.status).toBe(400);
+    expect(await missing.text()).toBe("target required");
+
+    const ok = await readJson(await h.app.handle(new Request("http://local/mirror?target=neo&lines=7")));
+    expect(ok).toEqual({ raw: "line one\nlast line", lines: 7, processed: true });
+  });
+});
+
+describe("POST /send", () => {
+  test("rejects local sends when pane remains busy and records signed attachment lifecycle", async () => {
+    const idleChecks = [{ idle: false, lastInput: "draft" }, { idle: false, lastInput: "still typing" }] as any[];
+    const h = makeHarness({
+      checkPaneIdle: async () => idleChecks.shift() as any,
+      resolveTarget: (() => ({ type: "local", target: "local:main" })) as any,
+    });
+
+    const res = await h.app.handle(jsonRequest("/send", { target: "neo", text: "hello", attachments: ["a", "b"] }, { "x-maw-from": "sender:white" }));
+
+    expect(res.status).toBe(409);
+    expect(await readJson(res)).toMatchObject({ ok: false, error: "pane not idle", lastInput: "still typing" });
+    expect(h.lifecycle[0]).toMatchObject({ state: "failed", from: "white:sender", signed: true, text: "a\nb\nhello" });
+  });
+
+  test("delivers local sends, detects queued prompts, and supports stripped -oracle fallback", async () => {
+    let first = true;
+    const h = makeHarness({
+      resolveTarget: ((target: string) => {
+        if (first) { first = false; return { type: "error", reason: "miss" }; }
+        return { type: "self-node", target: `${target}:main` };
+      }) as any,
+      capture: async () => "body\nPress up to edit queued messages\nqueued line",
+    });
+
+    const res = await h.app.handle(jsonRequest("/send", { target: "neo-oracle", text: "hello" }));
+
+    expect(await readJson(res)).toMatchObject({ ok: true, target: "neo:main", source: "local", state: "queued", lastLine: "queued line" });
+    expect(h.calls).toContainEqual(["sendKeys", "neo:main", "hello"]);
+    expect(h.lifecycle[0]).toMatchObject({ state: "queued", signed: false });
+  });
+
+  test("force skips idle guard and capture failures are delivery-safe", async () => {
+    const h = makeHarness({
+      resolveTarget: (() => ({ type: "local", target: "local:main" })) as any,
+      capture: async () => { throw new Error("capture ignored"); },
+    });
+
+    const res = await h.app.handle(jsonRequest("/send", { target: "neo", text: "hello", force: true }));
+
+    expect(await readJson(res)).toMatchObject({ ok: true, lastLine: "", state: "delivered" });
+    expect(h.calls.some((c) => c[0] === "idle")).toBe(false);
+  });
+
+  test("waits once when a local pane is briefly busy then delivers", async () => {
+    const idleChecks = [{ idle: false, lastInput: "typing" }, { idle: true, lastInput: "" }] as any[];
+    const h = makeHarness({
+      resolveTarget: (() => ({ type: "local", target: "local:main" })) as any,
+      checkPaneIdle: async (target: string) => { h.calls.push(["idle", target]); return idleChecks.shift() as any; },
+    });
+
+    expect(await readJson(await h.app.handle(jsonRequest("/send", { target: "neo", text: "hello" })))).toMatchObject({ ok: true, target: "local:main" });
+    expect(h.calls).toContainEqual(["sleep", 500]);
+    expect(h.calls).toContainEqual(["sendKeys", "local:main", "hello"]);
+  });
+
+  test("forwards peer sends and reports peer failures", async () => {
+    const success = makeHarness({
+      resolveTarget: (() => ({ type: "peer", node: "white", peerUrl: "http://peer", target: "remote:main" })) as any,
+      curlFetch: async () => ({ ok: true, status: 200, data: { ok: true, target: "actual", state: "queued", lastLine: "queued" } }) as any,
+    });
+    expect(await readJson(await success.app.handle(jsonRequest("/send", { target: "remote", text: "hi" })))).toMatchObject({ ok: true, source: "http://peer", target: "actual", state: "queued" });
+    expect(success.lifecycle[0]).toMatchObject({ route: "peer", state: "queued", to: "white:remote:main" });
+
+    const failure = makeHarness({
+      resolveTarget: (() => ({ type: "peer", node: "white", peerUrl: "http://peer", target: "remote:main" })) as any,
+      curlFetch: async () => ({ ok: false, status: 500, data: { ok: false } }) as any,
+    });
+    const res = await failure.app.handle(jsonRequest("/send", { target: "remote", text: "hi" }));
+    expect(res.status).toBe(502);
+    expect(await readJson(res)).toEqual({ error: "white → remote:main send failed", target: "remote", source: "http://peer" });
+    expect(failure.lifecycle[0]).toMatchObject({ route: "peer", state: "failed" });
+  });
+
+  test("falls back to peer discovery and reports discovered send failures", async () => {
+    const ok = makeHarness({
+      findPeerForTarget: async () => "http://found",
+      sendKeysToPeer: async () => true,
+    });
+    expect(await readJson(await ok.app.handle(jsonRequest("/send", { target: "remote", text: "hi" })))).toMatchObject({ ok: true, source: "http://found", state: "delivered" });
+
+    const fail = makeHarness({
+      findPeerForTarget: async () => "http://found",
+      sendKeysToPeer: async () => false,
+    });
+    const res = await fail.app.handle(jsonRequest("/send", { target: "remote", text: "hi" }));
+    expect(res.status).toBe(502);
+    expect(await readJson(res)).toEqual({ error: "Failed to send to peer", target: "remote", source: "http://found" });
+    expect(fail.lifecycle[0]).toMatchObject({ route: "discovery", state: "failed" });
+  });
+
+  test("auto-wakes fleet-known targets, retries local resolution, and handles retry busy failure", async () => {
+    let resolveCalls = 0;
+    const ok = makeHarness({
+      resolveFleetSession: () => "54-neo",
+      shouldAutoWake: () => ({ wake: true }),
+      resolveTarget: (() => (++resolveCalls <= 2 ? { type: "error", reason: "missing" } : { type: "local", target: "54-neo:main" })) as any,
+      capture: async () => "after wake\nready",
+    });
+    expect(await readJson(await ok.app.handle(jsonRequest("/send", { target: "neo", text: "wake hi" })))).toMatchObject({ ok: true, target: "54-neo:main", wokeFor: "neo" });
+    expect(ok.calls).toContainEqual(["cmdWake", "neo", { noAttach: true }]);
+
+    let busyResolveCalls = 0;
+    const busy = makeHarness({
+      resolveFleetSession: () => "54-neo",
+      shouldAutoWake: () => ({ wake: true }),
+      resolveTarget: (() => (++busyResolveCalls <= 2 ? { type: "error", reason: "missing" } : { type: "local", target: "54-neo:main" })) as any,
+      checkPaneIdle: async () => ({ idle: false, lastInput: "busy" }) as any,
+    });
+    const res = await busy.app.handle(jsonRequest("/send", { target: "neo", text: "wake hi" }));
+    expect(res.status).toBe(409);
+    expect(await readJson(res)).toMatchObject({ ok: false, error: "pane not idle", target: "54-neo:main" });
+
+    let transientResolveCalls = 0;
+    const transientIdle = [{ idle: false, lastInput: "typing" }, { idle: true, lastInput: "" }] as any[];
+    const transient = makeHarness({
+      resolveFleetSession: () => "54-neo",
+      shouldAutoWake: () => ({ wake: true }),
+      resolveTarget: (() => (++transientResolveCalls <= 2 ? { type: "error", reason: "missing" } : { type: "local", target: "54-neo:main" })) as any,
+      checkPaneIdle: async (target: string) => { transient.calls.push(["idle", target]); return transientIdle.shift() as any; },
+      capture: async () => "after wake\nready",
+    });
+    expect(await readJson(await transient.app.handle(jsonRequest("/send", { target: "neo", text: "wake hi" })))).toMatchObject({ ok: true, target: "54-neo:main", wokeFor: "neo" });
+    expect(transient.calls).toContainEqual(["sleep", 500]);
+  });
+
+  test("falls through after wake errors and returns detailed 404s or outer 500s", async () => {
+    const wakeBoom = makeHarness({
+      resolveFleetSession: () => "54-neo",
+      shouldAutoWake: () => ({ wake: true }),
+      cmdWake: async () => { throw new Error("wake boom"); },
+      resolveTarget: (() => ({ type: "error", reason: "missing", detail: "no target", hint: "try wake" })) as any,
+    });
+    const notFound = await wakeBoom.app.handle(jsonRequest("/send", { target: "neo", text: "hi" }));
+    expect(notFound.status).toBe(404);
+    expect(await readJson(notFound)).toMatchObject({ error: "target not found: neo", reason: "missing", detail: "no target", hint: "try wake" });
+    expect(wakeBoom.lifecycle[0]).toMatchObject({ state: "failed", error: "no target" });
+
+    const outer = makeHarness({ listSessions: async () => { throw new Error("list boom"); } });
+    const res = await outer.app.handle(jsonRequest("/send", { target: "neo", text: "hi" }));
+    expect(res.status).toBe(500);
+    expect((await readJson(res)).error).toContain("list boom");
+  });
+});
+
+describe("pane keys, probe, select, wake, and sleep routes", () => {
+  test("POST /pane-keys validates target, sends literal text, enter, and reports tmux errors", async () => {
+    const h = makeHarness();
+    expect((await h.app.handle(jsonRequest("/pane-keys", { target: "", text: "x" }))).status).toBe(400);
+
+    expect(await readJson(await h.app.handle(jsonRequest("/pane-keys", { target: "pane", text: "hello", enter: true })))).toEqual({ ok: true, target: "pane", enter: true });
+    expect(h.calls).toContainEqual(["literal", "pane", "hello"]);
+    expect(h.calls).toContainEqual(["tmuxKeys", "pane", "Enter"]);
+
+    const noText = makeHarness();
+    expect(await readJson(await noText.app.handle(jsonRequest("/pane-keys", { target: "pane", text: "", enter: false })))).toEqual({ ok: true, target: "pane", enter: false });
+    expect(noText.calls).toEqual([]);
+
+    const boom = makeHarness({ createTmux: () => ({ sendKeysLiteral: async () => { throw new Error("tmux boom"); }, sendKeys: async () => {} }) as any });
+    const res = await boom.app.handle(jsonRequest("/pane-keys", { target: "pane", text: "x" }));
+    expect(res.status).toBe(500);
+    expect((await readJson(res)).error).toContain("tmux boom");
+  });
+
+  test("default dependency factories stay side-effect-safe on no-op routes", async () => {
+    const paneApp = new Elysia().use(createSessionsApi({}));
+    expect(await readJson(await paneApp.handle(jsonRequest("/pane-keys", { target: "pane", text: "", enter: false })))).toEqual({ ok: true, target: "pane", enter: false });
+
+    const h = makeHarness({
+      resolveTarget: (() => ({ type: "local", target: "local:main" })) as any,
+      capture: async () => "ready",
+    });
+    const { sleep: _sleep, ...depsWithoutSleep } = h.deps as any;
+    const sleepApp = new Elysia().use(createSessionsApi(depsWithoutSleep));
+    expect(await readJson(await sleepApp.handle(jsonRequest("/send", { target: "neo", text: "hello", force: true })))).toMatchObject({ ok: true, target: "local:main" });
+
+    const builtEvents: any[] = [];
+    const lifecycleHarness = makeHarness({
+      resolveTarget: (() => ({ type: "local", target: "local:main" })) as any,
+      capture: async () => "ready",
+      buildMessageLifecycleFeedEvent: ((input: any) => ({ state: input.state, target: input.target })) as any,
+      pushFeedEvent: ((event: any) => builtEvents.push(event)) as any,
+    });
+    const { emitMessageLifecycle: _emit, ...depsWithoutLifecycleOverride } = lifecycleHarness.deps as any;
+    const lifecycleApp = new Elysia().use(createSessionsApi(depsWithoutLifecycleOverride));
+    expect(await readJson(await lifecycleApp.handle(jsonRequest("/send", { target: "neo", text: "hello", force: true })))).toMatchObject({ ok: true, target: "local:main" });
+    expect(builtEvents).toContainEqual({ state: "delivered", target: "local:main" });
+  });
+
+  test("POST /probe covers bare, local, missing-session, peer, not-found, and catch branches", async () => {
+    const bare = makeHarness();
+    expect(await readJson(await bare.app.handle(jsonRequest("/probe", {})))).toEqual({ ok: true, transport: "local", source: "m5", sessions: 1 });
+
+    const local = makeHarness({ resolveTarget: (() => ({ type: "local", target: "local:main" })) as any });
+    expect(await readJson(await local.app.handle(jsonRequest("/probe", { target: "neo" })))).toMatchObject({ ok: true, target: "local:main", transport: "local" });
+
+    const missing = makeHarness({ resolveTarget: (() => ({ type: "local", target: "gone:main" })) as any });
+    const missingRes = await missing.app.handle(jsonRequest("/probe", { target: "neo" }));
+    expect(missingRes.status).toBe(404);
+    expect(await readJson(missingRes)).toMatchObject({ ok: false, error: "tmux session not found: gone" });
+
+    const peer = makeHarness({ resolveTarget: (() => ({ type: "peer", target: "remote:main", peerUrl: "http://peer", node: "white" })) as any });
+    expect(await readJson(await peer.app.handle(jsonRequest("/probe", { target: "remote" })))).toEqual({ ok: true, target: "remote:main", transport: "ssh", source: "http://peer", node: "white" });
+
+    const notFound = makeHarness({ resolveTarget: (() => ({ type: "error", reason: "missing", detail: "no", hint: "wake" })) as any });
+    const nf = await notFound.app.handle(jsonRequest("/probe", { target: "ghost" }));
+    expect(nf.status).toBe(404);
+    expect(await readJson(nf)).toMatchObject({ ok: false, error: "target not found: ghost", reason: "missing", detail: "no", hint: "wake" });
+
+    const catchHarness = makeHarness({ loadConfig: (() => { throw new Error("config boom"); }) as any });
+    const err = await catchHarness.app.handle(jsonRequest("/probe", { target: "ghost" }));
+    expect(err.status).toBe(500);
+    expect((await readJson(err)).error).toContain("config boom");
+  });
+
+  test("POST /select selects windows and validates empty targets", async () => {
+    const h = makeHarness();
+    expect((await h.app.handle(jsonRequest("/select", { target: "" }))).status).toBe(400);
+    expect(await readJson(await h.app.handle(jsonRequest("/select", { target: "local:main" })))).toEqual({ ok: true, target: "local:main" });
+    expect(h.calls).toContainEqual(["selectWindow", "local:main"]);
+  });
+
+  test("POST /wake covers missing target, denied, legacy oracle, success, and catch", async () => {
+    const missing = makeHarness();
+    expect((await missing.app.handle(jsonRequest("/wake", {}))).status).toBe(400);
+
+    const denied = makeHarness({ shouldAutoWake: () => ({ wake: false, reason: "blocked" }) });
+    const deniedRes = await denied.app.handle(jsonRequest("/wake", { target: "neo" }));
+    expect(deniedRes.status).toBe(500);
+    expect(await readJson(deniedRes)).toEqual({ error: "wake denied: blocked" });
+
+    const legacy = makeHarness({ shouldAutoWake: () => ({ wake: true }) });
+    expect(await readJson(await legacy.app.handle(jsonRequest("/wake", { oracle: "old", task: "fix" })))).toEqual({ ok: true, target: "old" });
+    expect(legacy.calls).toContainEqual(["cmdWake", "old", { noAttach: true, task: "fix" }]);
+
+    const boom = makeHarness({ shouldAutoWake: () => ({ wake: true }), cmdWake: async () => { throw new Error("wake failed"); } });
+    const res = await boom.app.handle(jsonRequest("/wake", { target: "neo" }));
+    expect(res.status).toBe(500);
+    expect((await readJson(res)).error).toContain("wake failed");
+  });
+
+  test("POST /sleep runs sleep command and reports errors", async () => {
+    const h = makeHarness();
+    expect(await readJson(await h.app.handle(jsonRequest("/sleep", { target: "neo" })))).toEqual({ ok: true, target: "neo" });
+    expect(h.calls).toContainEqual(["cmdSleepOne", "neo"]);
+
+    const boom = makeHarness({ cmdSleepOne: async () => { throw new Error("sleep boom"); } });
+    const res = await boom.app.handle(jsonRequest("/sleep", { target: "neo" }));
+    expect(res.status).toBe(500);
+    expect((await readJson(res)).error).toContain("sleep boom");
+  });
+});


### PR DESCRIPTION
## Summary
- add an injectable sessions API factory while preserving production `sessionsApi`
- cover sessions/capture/mirror/send/pane-keys/probe/select/wake/sleep routes without live tmux or peer calls
- cover message lifecycle helper behavior and capture resolution helpers

## Validation
- `bun test test/sessions-api-default.test.ts --coverage --coverage-reporter=text --timeout 60000`
  - `src/api/sessions.ts | 100.00 | 100.00`
- `bun test test/sessions-api-default.test.ts test/api-sessions-dedup.test.ts --timeout 60000`
- `bun run build`
- `git diff --check`

## Release
- Alpha branch only.
- No release cut.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
