### PR TITLE
test(tmux): cover command dispatch

### DIFF
--- a/src/commands/plugins/tmux/index.ts
+++ b/src/commands/plugins/tmux/index.ts
@@ -8,7 +8,35 @@ export const command = {
   description: "tmux control verbs — peek.",
 };
 
-export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+interface TmuxHandlerDeps {
+  cmdTmuxPeek: typeof cmdTmuxPeek;
+  cmdTmuxLs: typeof cmdTmuxLs;
+  cmdTmuxSend: typeof cmdTmuxSend;
+  cmdTmuxSplit: typeof cmdTmuxSplit;
+  cmdTmuxKill: typeof cmdTmuxKill;
+  cmdTmuxLayout: typeof cmdTmuxLayout;
+  cmdTmuxAttach: typeof cmdTmuxAttach;
+  resolveTmuxTarget: typeof resolveTmuxTarget;
+  hostExec: typeof hostExec;
+  cmdSplit: (target: string, opts: { lock?: boolean }) => Promise<void>;
+}
+
+const defaultDeps: TmuxHandlerDeps = {
+  cmdTmuxPeek,
+  cmdTmuxLs,
+  cmdTmuxSend,
+  cmdTmuxSplit,
+  cmdTmuxKill,
+  cmdTmuxLayout,
+  cmdTmuxAttach,
+  resolveTmuxTarget,
+  hostExec,
+  cmdSplit: cmdTmuxSplit as TmuxHandlerDeps["cmdSplit"],
+};
+
+export function createTmuxHandler(overrides: Partial<TmuxHandlerDeps> = {}) {
+  const deps = { ...defaultDeps, ...overrides };
+  return async function handler(ctx: InvokeContext): Promise<InvokeResult> {
   const logs: string[] = [];
   const origLog = console.log;
   const origError = console.error;
@@ -47,7 +75,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         console.log("usage: maw tmux send <target> <command> [--literal] [--allow-destructive] [--force]");
         return { ok: false, error: "target and command required", output: logs.join("\n") };
       }
-      await cmdTmuxSend(target, command, {
+      await deps.cmdTmuxSend(target, command, {
         literal: !!flags["--literal"],
         allowDestructive: !!flags["--allow-destructive"],
         force: !!flags["--force"],
@@ -79,7 +107,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       }
       const recentLimitRaw = (flags._ as string[]).find((arg) => /^\d+$/.test(arg));
       const recentLimit = recentLimitRaw ? Number(recentLimitRaw) : undefined;
-      await cmdTmuxLs({
+      await deps.cmdTmuxLs({
         all: !!flags["--all"] || !!flags["--recent"],
         json: !!flags["--json"],
         compact: !!flags["--compact"] || !!flags["--recent"],
@@ -107,7 +135,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       }
       const lines = (flags["--lines"] as number | undefined) ?? 30;
       const history = !!flags["--history"];
-      await cmdTmuxPeek(target, { lines, history });
+      await deps.cmdTmuxPeek(target, { lines, history });
     } else if (sub === "split") {
       const flags = parseFlags(args, {
         "--vertical": Boolean, "-v": "--vertical",
@@ -125,7 +153,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         console.log("usage: maw tmux split <target> [-v] [--pct N] [--cmd '<cmd>']");
         return { ok: false, error: "target required", output: logs.join("\n") };
       }
-      await cmdTmuxSplit(target, {
+      await deps.cmdTmuxSplit(target, {
         vertical: !!flags["--vertical"],
         pct: flags["--pct"] as number | undefined,
         cmd: flags["--cmd"] as string | undefined,
@@ -147,7 +175,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         console.log("usage: maw tmux kill <target> [--force] [--session]");
         return { ok: false, error: "target required", output: logs.join("\n") };
       }
-      await cmdTmuxKill(target, {
+      await deps.cmdTmuxKill(target, {
         force: !!flags["--force"],
         session: !!flags["--session"],
       });
@@ -164,7 +192,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         console.log("usage: maw tmux layout <target> <preset>");
         return { ok: false, error: "target and preset required", output: logs.join("\n") };
       }
-      await cmdTmuxLayout(target, preset);
+      await deps.cmdTmuxLayout(target, preset);
     } else if (sub === "attach") {
       const flags = parseFlags(args, {
         "--print": Boolean,
@@ -181,14 +209,14 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         console.log("usage: maw tmux attach <target> [--print]");
         return { ok: false, error: "target required", output: logs.join("\n") };
       }
-      cmdTmuxAttach(target, { print: !!flags["--print"] });
+      deps.cmdTmuxAttach(target, { print: !!flags["--print"] });
     } else if (sub === "close" || sub === "unsplit") {
       if (!process.env.TMUX) {
         console.log("\x1b[33m⚠\x1b[0m close requires tmux");
         return { ok: false, error: "not in tmux" };
       }
       const myPane = process.env.TMUX_PANE;
-      const paneList = (await hostExec("tmux list-panes -F '#{pane_id}'")).split("\n").filter(Boolean);
+      const paneList = (await deps.hostExec("tmux list-panes -F '#{pane_id}'")).split("\n").filter(Boolean);
       if (paneList.length <= 1) {
         console.log("\x1b[90mno panes to close\x1b[0m");
         return { ok: true };
@@ -197,7 +225,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       for (const pane of paneList) {
         if (pane === myPane) continue;
         try {
-          await hostExec(`tmux break-pane -d -t '${pane}'`);
+          await deps.hostExec(`tmux break-pane -d -t '${pane}'`);
           hidden++;
         } catch { /* already gone */ }
       }
@@ -210,8 +238,8 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       const target = args[1];
       if (!target) {
         // No target: bring back hidden panes from other windows in this session
-        const myWindow = (await hostExec("tmux display-message -p '#{window_index}'")).trim();
-        const windowList = (await hostExec("tmux list-windows -F '#{window_index}:#{window_panes}'")).split("\n").filter(Boolean);
+        const myWindow = (await deps.hostExec("tmux display-message -p '#{window_index}'")).trim();
+        const windowList = (await deps.hostExec("tmux list-windows -F '#{window_index}:#{window_panes}'")).split("\n").filter(Boolean);
         const hiddenWindows = windowList
           .map(l => { const [idx, count] = l.split(":"); return { idx, count: parseInt(count || "0") }; })
           .filter(w => w.idx !== myWindow && w.count === 1);
@@ -222,15 +250,14 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         let joined = 0;
         for (const w of hiddenWindows) {
           try {
-            await hostExec(`tmux join-pane -h -s ':${w.idx}' -t '${myPane}'`);
+            await deps.hostExec(`tmux join-pane -h -s ':${w.idx}' -t '${myPane}'`);
             joined++;
           } catch { /* pane may have died */ }
         }
         console.log(`\x1b[32m✓\x1b[0m opened ${joined} hidden pane${joined !== 1 ? "s" : ""}`);
       } else {
         // Target given: split and show that session (same as split)
-        const { cmdSplit } = await import("../split/impl");
-        await cmdSplit(target, { lock: true });
+        await deps.cmdSplit(target, { lock: true });
       }
     } else if (sub === "zoom") {
       const target = args[1];
@@ -238,8 +265,8 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         console.log("usage: maw tmux zoom <target>");
         return { ok: false, error: "target required", output: logs.join("\n") };
       }
-      const { resolved } = resolveTmuxTarget(target) ?? { resolved: target };
-      await hostExec(`tmux resize-pane -Z -t '${resolved}'`);
+      const { resolved } = deps.resolveTmuxTarget(target) ?? { resolved: target };
+      await deps.hostExec(`tmux resize-pane -Z -t '${resolved}'`);
       console.log(`\x1b[32m✓\x1b[0m toggled zoom on ${resolved}`);
 
     } else if (!sub || sub === "--help" || sub === "-h") {
@@ -265,4 +292,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     console.log = origLog;
     console.error = origError;
   }
+  };
 }
+
+export default createTmuxHandler();

--- a/test/tmux-index-default.test.ts
+++ b/test/tmux-index-default.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createTmuxHandler } from "../src/commands/plugins/tmux/index";
+import type { InvokeContext } from "../src/plugin/types";
+
+type Call = [string, ...unknown[]];
+
+const OLD_TMUX = process.env.TMUX;
+const OLD_TMUX_PANE = process.env.TMUX_PANE;
+
+afterEach(() => {
+  if (OLD_TMUX === undefined) delete process.env.TMUX;
+  else process.env.TMUX = OLD_TMUX;
+  if (OLD_TMUX_PANE === undefined) delete process.env.TMUX_PANE;
+  else process.env.TMUX_PANE = OLD_TMUX_PANE;
+});
+
+function makeHarness(overrides: Record<string, any> = {}) {
+  const calls: Call[] = [];
+  const deps = {
+    cmdTmuxPeek: async (target: string, opts: unknown) => { calls.push(["peek", target, opts]); },
+    cmdTmuxLs: async (opts: unknown) => { calls.push(["ls", opts]); },
+    cmdTmuxSend: async (target: string, command: string, opts: unknown) => { calls.push(["send", target, command, opts]); },
+    cmdTmuxSplit: async (target: string, opts: unknown) => { calls.push(["split", target, opts]); },
+    cmdTmuxKill: async (target: string, opts: unknown) => { calls.push(["kill", target, opts]); },
+    cmdTmuxLayout: async (target: string, preset: string) => { calls.push(["layout", target, preset]); },
+    cmdTmuxAttach: (target: string, opts: unknown) => { calls.push(["attach", target, opts]); },
+    resolveTmuxTarget: (target: string) => ({ resolved: `resolved-${target}`, source: "test" }),
+    hostExec: async (cmd: string) => { calls.push(["hostExec", cmd]); return ""; },
+    cmdSplit: async (target: string, opts: unknown) => { calls.push(["cmdSplit", target, opts]); },
+    ...overrides,
+  };
+  return { calls, handler: createTmuxHandler(deps as any) };
+}
+
+function cli(args: string[], writer?: (...a: any[]) => void): InvokeContext {
+  return { source: "cli", args, writer } as any;
+}
+
+describe("tmux plugin command handler", () => {
+  test("prints top-level help for no subcommand and non-cli invocations", async () => {
+    const h = makeHarness();
+    const noSub = await h.handler(cli([]));
+    expect(noSub).toMatchObject({ ok: true });
+    expect(noSub.output).toContain("usage: maw tmux");
+
+    const nonCli = await h.handler({ source: "api", args: ["send", "pane", "cmd"] } as any);
+    expect(nonCli).toMatchObject({ ok: true });
+    expect(nonCli.output).toContain("usage: maw tmux");
+  });
+
+  test("routes send help, validation, and flags", async () => {
+    const h = makeHarness();
+    expect((await h.handler(cli(["send", "--help"]))).output).toContain("--allow-destructive");
+    expect(await h.handler(cli(["send", "pane"]))).toMatchObject({ ok: false, error: "target and command required" });
+
+    expect(await h.handler(cli(["send", "pane", "echo", "hi", "--literal", "--allow-destructive", "--force"]))).toMatchObject({ ok: true });
+    expect(h.calls).toContainEqual(["send", "pane", "echo hi", { literal: true, allowDestructive: true, force: true }]);
+  });
+
+  test("routes ls/list help and recent compact options", async () => {
+    const h = makeHarness();
+    expect((await h.handler(cli(["ls", "--help"]))).output).toContain("--recent");
+
+    await h.handler(cli(["list", "--recent", "2", "--json", "--verbose", "--roster"]));
+    expect(h.calls).toContainEqual(["ls", {
+      all: true,
+      json: true,
+      compact: true,
+      verbose: true,
+      roster: true,
+      recent: true,
+      recentLimit: 2,
+    }]);
+
+    await h.handler(cli(["ls", "--compact", "0"]));
+    expect(h.calls).toContainEqual(["ls", {
+      all: false,
+      json: false,
+      compact: true,
+      verbose: false,
+      roster: false,
+      recent: false,
+      recentLimit: undefined,
+    }]);
+  });
+
+  test("routes peek help, validation, and options", async () => {
+    const h = makeHarness();
+    expect((await h.handler(cli(["peek", "--help"]))).output).toContain("maw tmux peek");
+    expect(await h.handler(cli(["peek"]))).toMatchObject({ ok: false, error: "target required" });
+
+    await h.handler(cli(["peek", "pane", "--lines", "12", "--history"]));
+    expect(h.calls).toContainEqual(["peek", "pane", { lines: 12, history: true }]);
+  });
+
+  test("routes split help, validation, and options", async () => {
+    const h = makeHarness();
+    expect((await h.handler(cli(["split", "--help"]))).output).toContain("maw tmux split");
+    expect(await h.handler(cli(["split"]))).toMatchObject({ ok: false, error: "target required" });
+
+    await h.handler(cli(["split", "pane", "-v", "--pct", "40", "--cmd", "bash"]));
+    expect(h.calls).toContainEqual(["split", "pane", { vertical: true, pct: 40, cmd: "bash" }]);
+  });
+
+  test("routes kill help, validation, and options", async () => {
+    const h = makeHarness();
+    expect((await h.handler(cli(["kill", "--help"]))).output).toContain("kill the whole session");
+    expect(await h.handler(cli(["kill"]))).toMatchObject({ ok: false, error: "target required" });
+
+    await h.handler(cli(["kill", "pane", "--force", "--session"]));
+    expect(h.calls).toContainEqual(["kill", "pane", { force: true, session: true }]);
+  });
+
+  test("routes layout help, validation, success, and command errors", async () => {
+    const h = makeHarness();
+    expect((await h.handler(cli(["layout", "--help"]))).output).toContain("presets:");
+    expect(await h.handler(cli(["layout", "pane"]))).toMatchObject({ ok: false, error: "target and preset required" });
+
+    await h.handler(cli(["layout", "pane", "tiled"]));
+    expect(h.calls).toContainEqual(["layout", "pane", "tiled"]);
+
+    const failing = makeHarness({ cmdTmuxLayout: async () => { throw new Error("layout boom"); } });
+    expect(await failing.handler(cli(["layout", "pane", "tiled"]))).toMatchObject({ ok: false, error: "layout boom" });
+  });
+
+  test("routes attach help, validation, and print option", async () => {
+    const h = makeHarness();
+    expect((await h.handler(cli(["attach", "--help"]))).output).toContain("--print");
+    expect(await h.handler(cli(["attach"]))).toMatchObject({ ok: false, error: "target required" });
+
+    await h.handler(cli(["attach", "pane", "--print"]));
+    expect(h.calls).toContainEqual(["attach", "pane", { print: true }]);
+  });
+
+  test("close/unsplit require tmux and hide sibling panes", async () => {
+    const outside = makeHarness();
+    delete process.env.TMUX;
+    expect(await outside.handler(cli(["close"]))).toMatchObject({ ok: false, error: "not in tmux" });
+
+    process.env.TMUX = "/tmp/tmux";
+    process.env.TMUX_PANE = "%1";
+    const onePane = makeHarness({ hostExec: async (cmd: string) => {
+      onePane.calls.push(["hostExec", cmd]);
+      return "%1\n";
+    } });
+    expect(await onePane.handler(cli(["unsplit"]))).toMatchObject({ ok: true });
+
+    const h = makeHarness({ hostExec: async (cmd: string) => {
+      h.calls.push(["hostExec", cmd]);
+      if (cmd.includes("list-panes")) return "%1\n%2\n%3\n";
+      if (cmd.includes("%3")) throw new Error("gone");
+      return "";
+    } });
+    const result = await h.handler(cli(["close"]));
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("closed 1 pane");
+    expect(h.calls.some((c) => String(c[1]).includes("%2"))).toBe(true);
+  });
+
+  test("open requires tmux, restores hidden panes, and delegates target opens to split", async () => {
+    const outside = makeHarness();
+    delete process.env.TMUX;
+    expect(await outside.handler(cli(["open"]))).toMatchObject({ ok: false, error: "not in tmux" });
+
+    process.env.TMUX = "/tmp/tmux";
+    process.env.TMUX_PANE = "%1";
+    const noneWritten: string[] = [];
+    const none = makeHarness({ hostExec: async (cmd: string) => {
+      none.calls.push(["hostExec", cmd]);
+      if (cmd.includes("display-message")) return "0\n";
+      if (cmd.includes("list-windows")) return "0:2\n1:2\n";
+      return "";
+    } });
+    expect(await none.handler(cli(["open"], (...a) => noneWritten.push(a.map(String).join(" "))))).toMatchObject({ ok: true });
+    expect(noneWritten.join("\n")).toContain("no hidden panes");
+
+    const h = makeHarness({ hostExec: async (cmd: string) => {
+      h.calls.push(["hostExec", cmd]);
+      if (cmd.includes("display-message")) return "0\n";
+      if (cmd.includes("list-windows")) return "0:2\n1:1\n2:1\n";
+      return "";
+    } });
+    const opened = await h.handler(cli(["open"]));
+    expect(opened.ok).toBe(true);
+    expect(opened.output).toContain("opened 0 hidden panes");
+
+    const target = makeHarness();
+    await target.handler(cli(["open", "mawjs"]));
+    expect(target.calls).toContainEqual(["cmdSplit", "mawjs", { lock: true }]);
+  });
+
+  test("zoom validates target and resolves before resizing", async () => {
+    const h = makeHarness();
+    expect(await h.handler(cli(["zoom"]))).toMatchObject({ ok: false, error: "target required" });
+
+    await h.handler(cli(["zoom", "pane"]));
+    expect(h.calls).toContainEqual(["hostExec", "tmux resize-pane -Z -t 'resolved-pane'"]);
+
+    const fallback = makeHarness({ resolveTmuxTarget: () => null });
+    await fallback.handler(cli(["zoom", "raw"]));
+    expect(fallback.calls).toContainEqual(["hostExec", "tmux resize-pane -Z -t 'raw'"]);
+  });
+
+  test("unknown subcommands fail and writer receives console output", async () => {
+    const written: string[] = [];
+    const h = makeHarness({
+      cmdTmuxPeek: async () => { console.error("peek note"); },
+    });
+    const unknown = await h.handler(cli(["wat"]));
+    expect(unknown).toMatchObject({ ok: false, error: "unknown subcommand: wat" });
+
+    const writerResult = await h.handler(cli(["peek", "pane"], (...a) => written.push(a.map(String).join(" "))));
+    expect(writerResult).toEqual({ ok: true, output: undefined });
+    expect(written).toContain("peek note");
+  });
+});


### PR DESCRIPTION
## Summary
- add an injectable tmux command handler factory while preserving the default exported handler
- cover tmux send/ls/peek/split/kill/layout/attach/open/close/zoom/help/unknown dispatch without live panes
- route `tmux open <target>` through the existing tmux split command dependency instead of a missing lazy split-plugin import

## Validation
- `bun test test/tmux-index-default.test.ts --coverage --coverage-reporter=text --timeout 60000`
  - `src/commands/plugins/tmux/index.ts | 100.00 | 100.00`
- `bun test test/tmux-index-default.test.ts test/isolated/tmux-action-verbs.test.ts test/isolated/tmux-peek.test.ts test/isolated/tmux-route-tools.test.ts test/isolated/tmux-ls-recent.test.ts --timeout 60000`
- `bun run build`
- `git diff --check`

## Release
- Alpha branch only.
- No release cut.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
