### PR TITLE
feat(inbox): queue hey messages in receiver inboxes

### DIFF
--- a/src/api/sessions.ts
+++ b/src/api/sessions.ts
@@ -14,6 +14,7 @@ import { WakeBody, SleepBody, SendBody, PaneKeysBody, ProbeBody } from "../lib/s
 import { Tmux } from "../core/transport/tmux";
 import { pushFeedEvent } from "./feed";
 import { buildMessageLifecycleFeedEvent, type MessageLifecycleInput } from "../lib/message-events";
+import { defaultReceiverInboxWriter, type ReceiverInboxResult, type ReceiverInboxWriter } from "../commands/shared/receiver-inbox";
 import type { Session } from "../core/transport/ssh";
 
 type Config = ReturnType<typeof loadConfig>;
@@ -42,6 +43,7 @@ export interface SessionsApiDeps {
   pushFeedEvent?: typeof pushFeedEvent;
   buildMessageLifecycleFeedEvent?: typeof buildMessageLifecycleFeedEvent;
   emitMessageLifecycle?: (input: MessageLifecycleInput) => void;
+  writeReceiverInbox?: ReceiverInboxWriter | null;
   sleep?: (ms: number) => Promise<unknown>;
   shouldAutoWake?: (target: string, opts: AutoWakeOpts) => AutoWakeDecision | Promise<AutoWakeDecision>;
   cmdWake?: (target: string, opts: { noAttach: boolean; task?: string }) => Promise<unknown>;
@@ -68,6 +70,7 @@ function defaults(deps: SessionsApiDeps) {
     pushFeedEvent: deps.pushFeedEvent ?? pushFeedEvent,
     buildMessageLifecycleFeedEvent: deps.buildMessageLifecycleFeedEvent ?? buildMessageLifecycleFeedEvent,
     emitMessageLifecycle: deps.emitMessageLifecycle,
+    writeReceiverInbox: deps.writeReceiverInbox === undefined ? defaultReceiverInboxWriter() : deps.writeReceiverInbox,
     sleep: deps.sleep ?? ((ms: number) => Bun.sleep(ms)),
     shouldAutoWake: deps.shouldAutoWake ?? defaultShouldAutoWake,
     cmdWake: deps.cmdWake ?? defaultCmdWake,
@@ -209,6 +212,45 @@ export function createSessionsApi(deps: SessionsApiDeps = {}) {
       const messageTo = localMessageIdentity(config);
       const messageSigned = messageSignedRequest(request);
       const local = await d.listSessions();
+      const writeInboundInbox = async (tmuxTarget?: string): Promise<ReceiverInboxResult | null> => {
+        if (!d.writeReceiverInbox) return null;
+        try {
+          return await d.writeReceiverInbox({
+            query: target,
+            target: tmuxTarget,
+            to: target,
+            from: messageFrom,
+            message,
+            config,
+          });
+        } catch (error) {
+          return { ok: false, reason: error instanceof Error ? error.message : String(error) };
+        }
+      };
+      const queuedInboxResponse = (inbox: ReceiverInboxResult, tmuxTarget: string, reason: string) => {
+        if (!inbox.ok) return null;
+        emitLifecycle({
+          direction: "inbound",
+          state: "queued",
+          channel: "api-send",
+          route: "inbox",
+          from: messageFrom,
+          to: `${config.node ?? "local"}:${inbox.oracle}`,
+          target: tmuxTarget,
+          text: message,
+          lastLine: reason,
+          signed: messageSigned,
+        });
+        return {
+          ok: true,
+          target: tmuxTarget,
+          text,
+          source: "inbox",
+          state: "queued" as const,
+          inbox: inbox.path,
+          reason,
+        };
+      };
 
       // --- Unified resolution via resolveTarget (#201) ---
       const result = d.resolveTarget(target, config, local);
@@ -228,6 +270,9 @@ export function createSessionsApi(deps: SessionsApiDeps = {}) {
             await d.sleep(500);
             idleCheck = await d.checkPaneIdle(resolved.target);
             if (!idleCheck.idle) {
+              const inbox = await writeInboundInbox(resolved.target);
+              const queued = inbox ? queuedInboxResponse(inbox, resolved.target, "pane not idle") : null;
+              if (queued) return queued;
               set.status = 409;
               emitLifecycle({
                 direction: "inbound",
@@ -247,6 +292,7 @@ export function createSessionsApi(deps: SessionsApiDeps = {}) {
           }
         }
         await d.sendKeys(resolved.target, message);
+        const inbox = await writeInboundInbox(resolved.target);
         await d.sleep(150);
         let lastLine = "";
         // Echo broadcast bug 2026-04-26: claude queues input behind a busy prompt and
@@ -272,7 +318,7 @@ export function createSessionsApi(deps: SessionsApiDeps = {}) {
           lastLine,
           signed: messageSigned,
         });
-        return { ok: true, target: resolved.target, text, source: "local", lastLine, state };
+        return { ok: true, target: resolved.target, text, source: "local", lastLine, state, ...(inbox?.ok ? { inbox: inbox.path } : {}) };
       }
 
       // Remote peer → federation HTTP
@@ -361,6 +407,9 @@ export function createSessionsApi(deps: SessionsApiDeps = {}) {
                   await d.sleep(500);
                   idleCheck = await d.checkPaneIdle(retry.target);
                   if (!idleCheck.idle) {
+                    const inbox = await writeInboundInbox(retry.target);
+                    const queued = inbox ? queuedInboxResponse(inbox, retry.target, "pane not idle after wake") : null;
+                    if (queued) return queued;
                     set.status = 409;
                     emitLifecycle({
                       direction: "inbound",
@@ -380,6 +429,7 @@ export function createSessionsApi(deps: SessionsApiDeps = {}) {
                 }
               }
               await d.sendKeys(retry.target, message);
+              const inbox = await writeInboundInbox(retry.target);
               await d.sleep(150);
               let lastLine = "";
               try { const content = await d.capture(retry.target, 3); lastLine = content.split("\n").filter(l => l.trim()).pop() || ""; } catch {}
@@ -395,13 +445,16 @@ export function createSessionsApi(deps: SessionsApiDeps = {}) {
                 lastLine,
                 signed: messageSigned,
               });
-              return { ok: true, target: retry.target, text, source: "local", lastLine, wokeFor: target };
+              return { ok: true, target: retry.target, text, source: "local", lastLine, wokeFor: target, ...(inbox?.ok ? { inbox: inbox.path } : {}) };
             }
           } catch { /* wake best-effort — fall through to 404 */ }
         }
       }
 
       const errDetail = resolved?.type === "error" ? { reason: resolved.reason, detail: resolved.detail, hint: resolved.hint } : {};
+      const inbox = await writeInboundInbox(target);
+      const queued = inbox ? queuedInboxResponse(inbox, target, errDetail.detail || "target not live; persisted for receiver inbox polling") : null;
+      if (queued) return queued;
       emitLifecycle({
         direction: "inbound",
         state: "failed",

--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -11,6 +11,11 @@ import { AmbiguousMatchError } from "../../core/runtime/find-window";
 import { loadConfig, cfgLimit } from "../../config";
 import { logMessage, emitFeed } from "./comm-log-feed";
 import { buildMessageLifecycleFeedEvent, type MessageLifecycleInput } from "../../lib/message-events";
+import {
+  defaultReceiverInboxWriter,
+  type ReceiverInboxResult,
+  type ReceiverInboxWriter,
+} from "./receiver-inbox";
 
 /**
  * Resolve a `session:window` target to a specific pane running an agent
@@ -250,6 +255,7 @@ function assertBareLocalTarget(
 export interface CmdSendOptions {
   approve?: boolean;
   trust?: boolean;
+  receiverInbox?: ReceiverInboxWriter | false;
 }
 
 export async function cmdSend(
@@ -523,6 +529,43 @@ export async function cmdSend(
 
   const senderName = resolveMyName(config);
   const outboundMessage = formatSignedMessage(message, config, senderName);
+  const receiverInboxWriter = opts.receiverInbox === false
+    ? null
+    : opts.receiverInbox ?? defaultReceiverInboxWriter();
+  const writeReceiverInbox = async (target?: string): Promise<ReceiverInboxResult | null> => {
+    if (!receiverInboxWriter) return null;
+    try {
+      return await receiverInboxWriter({
+        query,
+        target,
+        to: query,
+        from: `${config.node ?? "local"}:${senderName}`,
+        message: outboundMessage,
+        config,
+      });
+    } catch (error) {
+      return { ok: false, reason: error instanceof Error ? error.message : String(error) };
+    }
+  };
+  const logQueuedInbox = (inbox: ReceiverInboxResult | null, target: string, reason: string): boolean => {
+    if (!inbox?.ok) return false;
+    logMessage(senderName, query, outboundMessage, "inbox");
+    emitMessageFeed({
+      direction: "outbound",
+      state: "queued",
+      channel: "hey",
+      route: "inbox",
+      from: `${config.node ?? "local"}:${senderName}`,
+      to: query,
+      target,
+      text: outboundMessage,
+      lastLine: reason,
+      signed: true,
+    }, config.port || 3456);
+    console.log(`\x1b[33mqueued\x1b[0m → ${inbox.oracle} ψ/inbox/${inbox.filename}: ${outboundMessage}`);
+    console.log(`\x1b[90m  ⤷ ${reason}\x1b[0m`);
+    return true;
+  };
 
   // Local target (or self-node) → send via tmux.
   // Resolve to a specific pane first: when the oracle window has multiple
@@ -535,6 +578,7 @@ export async function cmdSend(
       const cmd = await getPaneCommand(target);
       const isAgent = isAgentCommand(cmd);
       if (!isAgent) {
+        if (logQueuedInbox(await writeReceiverInbox(target), target, `pane not running an agent (${cmd})`)) return;
         console.error(`\x1b[31merror\x1b[0m: no active Claude session in ${target} (running: ${cmd})`);
         console.error(`\x1b[33mhint\x1b[0m:  run \x1b[36mmaw wake ${query}\x1b[0m first, or use \x1b[36m--force\x1b[0m to send anyway`);
         process.exit(1);
@@ -545,6 +589,7 @@ export async function cmdSend(
         await Bun.sleep(500);
         idleCheck = await checkPaneIdle(target);
         if (!idleCheck.idle) {
+          if (logQueuedInbox(await writeReceiverInbox(target), target, `pane not idle: ${idleCheck.lastInput.slice(0, 60)}`)) return;
           console.error(`\x1b[31merror\x1b[0m: pane ${target} is not idle — user appears to be typing: "${idleCheck.lastInput.slice(0, 60)}"`);
           console.error(`\x1b[33mhint\x1b[0m:  use \x1b[36m--force\x1b[0m to send anyway`);
           process.exit(1);
@@ -552,6 +597,7 @@ export async function cmdSend(
       }
     }
     await sendKeys(target, outboundMessage);
+    await writeReceiverInbox(target);
     await runHook("after_send", { to: query, message: outboundMessage });
     if (!config.node) throw new Error("config.node is required — set 'node' in maw.config.json");
     logMessage(senderName, query, outboundMessage, "local");
@@ -671,6 +717,9 @@ export async function cmdSend(
     console.error(`\x1b[33mhint\x1b[0m:  check peer connectivity: maw health`);
     process.exit(1);
   }
+
+  // Try receiver inbox queue before surfacing a local-only resolver miss.
+  if (logQueuedInbox(await writeReceiverInbox(), query, "target not live; persisted for receiver inbox polling")) return;
 
   // Local-only miss — no network was attempted (#411). Show resolver's own detail.
   if (result?.type === "error") {

--- a/src/commands/shared/receiver-inbox.ts
+++ b/src/commands/shared/receiver-inbox.ts
@@ -1,0 +1,215 @@
+import { existsSync as fsExistsSync, mkdirSync as fsMkdirSync, writeFileSync as fsWriteFileSync } from "fs";
+import { basename, join } from "path";
+import { getGhqRoot as defaultGetGhqRoot } from "../../config/ghq-root";
+import { ghqFindSync as defaultGhqFindSync } from "../../core/ghq";
+import { loadManifestCached, type OracleManifestEntry } from "../../lib/oracle-manifest";
+import { resolveTargetCwd as defaultResolveTargetCwd } from "./target-cwd";
+
+export interface ReceiverInboxConfig {
+  node?: string;
+  oracle?: string;
+  psiPath?: string;
+}
+
+export interface ReceiverInboxInput {
+  query: string;
+  message: string;
+  from: string;
+  target?: string;
+  to?: string;
+  config?: ReceiverInboxConfig;
+}
+
+export type ReceiverInboxResult =
+  | {
+      ok: true;
+      oracle: string;
+      inboxDir: string;
+      path: string;
+      filename: string;
+    }
+  | {
+      ok: false;
+      oracle?: string;
+      reason: string;
+    };
+
+export type ReceiverInboxWriter = (input: ReceiverInboxInput) => Promise<ReceiverInboxResult> | ReceiverInboxResult;
+
+interface ReceiverInboxDeps {
+  existsSync?: typeof fsExistsSync;
+  mkdirSync?: typeof fsMkdirSync;
+  writeFileSync?: typeof fsWriteFileSync;
+  loadManifest?: () => OracleManifestEntry[];
+  getGhqRoot?: typeof defaultGetGhqRoot;
+  ghqFindSync?: typeof defaultGhqFindSync;
+  resolveTargetCwd?: typeof defaultResolveTargetCwd;
+  now?: () => Date;
+}
+
+function explicitEnabled(value: string | undefined): boolean | null {
+  if (value === undefined) return null;
+  const normalized = value.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
+  return null;
+}
+
+/**
+ * Production defaults to ON. Tests default to OFF unless they opt in, so broad
+ * command test suites do not accidentally write into a developer's real oracle
+ * inbox when exercising `maw hey`.
+ */
+export function receiverInboxAutoWriteEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const explicit = explicitEnabled(env.MAW_HEY_INBOX_AUTOWRITE);
+  if (explicit !== null) return explicit;
+  return env.MAW_TEST_MODE !== "1";
+}
+
+export function defaultReceiverInboxWriter(): ReceiverInboxWriter | null {
+  return receiverInboxAutoWriteEnabled() ? persistReceiverInbox : null;
+}
+
+function stripPaneSuffix(target: string): string {
+  return target.replace(/\.[0-9]+$/, "");
+}
+
+function normalizeOracleName(raw: string | undefined): string | null {
+  if (!raw) return null;
+  let value = raw.trim();
+  if (!value) return null;
+
+  // node:agent or node:session:window → prefer the agent/window component.
+  if (value.includes(":")) {
+    const parts = value.split(":").filter(Boolean);
+    value = parts.length >= 3 ? parts[2]! : parts[1] ?? parts[0]!;
+  }
+
+  value = stripPaneSuffix(value);
+  value = basename(value);
+  value = value.replace(/^\d+-/, "");
+  value = value.replace(/-oracle$/, "");
+  return value || null;
+}
+
+export function resolveReceiverOracle(input: ReceiverInboxInput): string | null {
+  return normalizeOracleName(input.to)
+    ?? normalizeOracleName(input.target)
+    ?? normalizeOracleName(input.query);
+}
+
+function repoPathCandidates(
+  oracle: string,
+  input: ReceiverInboxInput,
+  deps: Required<Pick<ReceiverInboxDeps, "existsSync" | "loadManifest" | "getGhqRoot" | "ghqFindSync" | "resolveTargetCwd">>,
+): string[] {
+  const candidates: string[] = [];
+
+  if (input.config?.psiPath && input.config.oracle && normalizeOracleName(input.config.oracle) === oracle) {
+    candidates.push(input.config.psiPath.replace(/\/+$/, "").replace(/\/ψ$/, "").replace(/\/psi$/, ""));
+  }
+
+  if (input.target) {
+    try {
+      const cwd = deps.resolveTargetCwd(stripPaneSuffix(input.target));
+      if (cwd) candidates.push(cwd);
+    } catch {
+      // Best effort: inbox persistence must never break message delivery.
+    }
+  }
+
+  let manifest: OracleManifestEntry[] = [];
+  try {
+    manifest = deps.loadManifest();
+  } catch {
+    manifest = [];
+  }
+  const entry = manifest.find((e) => normalizeOracleName(e.name) === oracle || normalizeOracleName(e.window) === oracle);
+  if (entry?.localPath) candidates.push(entry.localPath);
+  if (entry?.repo) {
+    candidates.push(join(deps.getGhqRoot(), "github.com", entry.repo));
+    // Legacy callers/tests sometimes configure ghqRoot as github.com-rooted.
+    candidates.push(join(deps.getGhqRoot(), entry.repo));
+  }
+
+  try {
+    const ghqPath = deps.ghqFindSync(`/${oracle}-oracle$`);
+    if (ghqPath) candidates.push(ghqPath);
+  } catch {
+    // Best effort.
+  }
+
+  return [...new Set(candidates)].filter((candidate) => {
+    try {
+      return deps.existsSync(candidate);
+    } catch {
+      return false;
+    }
+  });
+}
+
+function safeSegment(value: string): string {
+  return value
+    .trim()
+    .replace(/[^a-zA-Z0-9_.-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 64) || "unknown";
+}
+
+function slugifyBody(body: string): string {
+  return safeSegment(body.split(/\s+/).slice(0, 6).join("-").toLowerCase()).slice(0, 48);
+}
+
+function buildInboxBody(from: string, to: string, timestamp: string, message: string): string {
+  return [
+    "---",
+    `from: ${from}`,
+    `to: ${to}`,
+    `timestamp: ${timestamp}`,
+    "read: false",
+    "---",
+    "",
+    message,
+    "",
+  ].join("\n");
+}
+
+export function persistReceiverInbox(input: ReceiverInboxInput, deps: ReceiverInboxDeps = {}): ReceiverInboxResult {
+  const existsSync = deps.existsSync ?? fsExistsSync;
+  const mkdirSync = deps.mkdirSync ?? fsMkdirSync;
+  const writeFileSync = deps.writeFileSync ?? fsWriteFileSync;
+  const resolvedDeps = {
+    existsSync,
+    loadManifest: deps.loadManifest ?? loadManifestCached,
+    getGhqRoot: deps.getGhqRoot ?? defaultGetGhqRoot,
+    ghqFindSync: deps.ghqFindSync ?? defaultGhqFindSync,
+    resolveTargetCwd: deps.resolveTargetCwd ?? defaultResolveTargetCwd,
+  };
+
+  const oracle = resolveReceiverOracle(input);
+  if (!oracle) return { ok: false, reason: "receiver oracle could not be inferred" };
+
+  const repoPath = repoPathCandidates(oracle, input, resolvedDeps)[0];
+  if (!repoPath) return { ok: false, oracle, reason: `receiver repo not found for ${oracle}` };
+
+  const now = deps.now?.() ?? new Date();
+  const timestamp = now.toISOString();
+  const datePart = timestamp.slice(0, 10);
+  const timePart = timestamp.slice(11, 16).replace(":", "-");
+  const filename = `${datePart}_${timePart}_${safeSegment(input.from)}_${slugifyBody(input.message)}.md`;
+  const inboxDir = join(repoPath, "ψ", "inbox");
+  const path = join(inboxDir, filename);
+
+  try {
+    mkdirSync(inboxDir, { recursive: true });
+    writeFileSync(path, buildInboxBody(input.from, oracle, timestamp, input.message));
+    return { ok: true, oracle, inboxDir, path, filename };
+  } catch (error) {
+    return {
+      ok: false,
+      oracle,
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/test/comm-send-cmdsend-coverage.test.ts
+++ b/test/comm-send-cmdsend-coverage.test.ts
@@ -198,6 +198,7 @@ const origExit = process.exit;
 const origErr = console.error;
 const origLog = console.log;
 const origAgentName = process.env.CLAUDE_AGENT_NAME;
+const origTestMode = process.env.MAW_TEST_MODE;
 
 (Bun as unknown as { sleep: (ms: number) => Promise<void> }).sleep = async (ms: number) => {
   if (mockActive) sleepCalls.push(ms);
@@ -262,16 +263,21 @@ beforeEach(() => {
   trustAddError = null;
   consentDecision = { allow: true };
   process.env.CLAUDE_AGENT_NAME = "sender";
+  process.env.MAW_TEST_MODE = "1";
   delete process.env.MAW_CONSENT;
   delete process.env.MAW_ACL_BYPASS;
+  delete process.env.MAW_HEY_INBOX_AUTOWRITE;
 });
 
 afterEach(() => {
   mockActive = false;
   delete process.env.MAW_CONSENT;
   delete process.env.MAW_ACL_BYPASS;
+  delete process.env.MAW_HEY_INBOX_AUTOWRITE;
   if (origAgentName === undefined) delete process.env.CLAUDE_AGENT_NAME;
   else process.env.CLAUDE_AGENT_NAME = origAgentName;
+  if (origTestMode === undefined) delete process.env.MAW_TEST_MODE;
+  else process.env.MAW_TEST_MODE = origTestMode;
 });
 
 afterAll(() => {
@@ -296,6 +302,34 @@ describe("cmdSend — delivery branch coverage", () => {
     expect(logs.join("\n")).toContain("accepted");
   });
 
+  test("local delivery mirrors delivered hey messages into the receiver inbox when enabled", async () => {
+    const inboxCalls: any[] = [];
+
+    await runCmd(() => cmdSend("local:session:oracle", "hello", false, {
+      receiverInbox: (input) => {
+        inboxCalls.push(input);
+        return {
+          ok: true,
+          oracle: "oracle",
+          inboxDir: "/repo/ψ/inbox",
+          path: "/repo/ψ/inbox/msg.md",
+          filename: "msg.md",
+        };
+      },
+    }));
+
+    expect(exitCode).toBeUndefined();
+    expect(sendKeysCalls).toEqual([{ target: "session:oracle.0", text: "[test-node:sender] hello" }]);
+    expect(inboxCalls).toEqual([{
+      query: "local:session:oracle",
+      target: "session:oracle.0",
+      to: "local:session:oracle",
+      from: "test-node:sender",
+      message: "[test-node:sender] hello",
+      config,
+    }]);
+  });
+
   test("local delivery refuses non-agent panes unless forced", async () => {
     getPaneCommandReturn = "zsh";
     await runCmd(() => cmdSend("local:session:oracle", "hello"));
@@ -303,6 +337,27 @@ describe("cmdSend — delivery branch coverage", () => {
     expect(exitCode).toBe(1);
     expect(sendKeysCalls).toEqual([]);
     expect(errs.join("\n")).toContain("no active Claude session");
+  });
+
+  test("local delivery queues to receiver inbox instead of dropping when pane is not agent", async () => {
+    getPaneCommandReturn = "zsh";
+
+    await runCmd(() => cmdSend("local:session:oracle", "offline task", false, {
+      receiverInbox: () => ({
+        ok: true,
+        oracle: "oracle",
+        inboxDir: "/repo/ψ/inbox",
+        path: "/repo/ψ/inbox/msg.md",
+        filename: "msg.md",
+      }),
+    }));
+
+    expect(exitCode).toBeUndefined();
+    expect(sendKeysCalls).toEqual([]);
+    expect(logMessageCalls).toEqual([{ from: "sender", to: "local:session:oracle", message: "[test-node:sender] offline task", route: "inbox" }]);
+    expect(emitFeedCalls[0].data).toMatchObject({ route: "inbox", state: "queued" });
+    expect(logs.join("\n")).toContain("queued");
+    expect(logs.join("\n")).toContain("ψ/inbox/msg.md");
   });
 
   test("--force bypasses pane command and idle checks", async () => {
@@ -581,4 +636,3 @@ describe("cmdSend — bare-name, wake, and safety gates", () => {
     expect(errs.join("\n")).toContain("consent required");
   });
 });
-

--- a/test/isolated/comm-send-resolve-pane.test.ts
+++ b/test/isolated/comm-send-resolve-pane.test.ts
@@ -61,6 +61,8 @@ mock.module(join(srcRoot, "src/sdk"), () => ({
   curlFetch: async () => ({ ok: false, status: 0, data: null }),
   runHook: async () => {},
   hostExec: async () => "",
+  tmux: { run: async () => "", tryRun: async () => "" },
+  FLEET_DIR: "/tmp/maw-test-fleet",
 }));
 
 // --- Import the module under test AFTER all mock.module installs ---

--- a/test/receiver-inbox-default.test.ts
+++ b/test/receiver-inbox-default.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  defaultReceiverInboxWriter,
+  persistReceiverInbox,
+  receiverInboxAutoWriteEnabled,
+  resolveReceiverOracle,
+} from "../src/commands/shared/receiver-inbox";
+
+describe("receiver inbox auto-write helpers", () => {
+  test("defaults on in production and off in test mode unless explicitly enabled", () => {
+    expect(receiverInboxAutoWriteEnabled({} as any)).toBe(true);
+    expect(receiverInboxAutoWriteEnabled({ MAW_TEST_MODE: "1" } as any)).toBe(false);
+    expect(receiverInboxAutoWriteEnabled({ MAW_TEST_MODE: "1", MAW_HEY_INBOX_AUTOWRITE: "1" } as any)).toBe(true);
+    expect(receiverInboxAutoWriteEnabled({ MAW_HEY_INBOX_AUTOWRITE: "off" } as any)).toBe(false);
+
+    const oldTestMode = process.env.MAW_TEST_MODE;
+    const oldAutoWrite = process.env.MAW_HEY_INBOX_AUTOWRITE;
+    try {
+      process.env.MAW_TEST_MODE = "1";
+      delete process.env.MAW_HEY_INBOX_AUTOWRITE;
+      expect(defaultReceiverInboxWriter()).toBeNull();
+      process.env.MAW_HEY_INBOX_AUTOWRITE = "1";
+      expect(typeof defaultReceiverInboxWriter()).toBe("function");
+    } finally {
+      if (oldTestMode === undefined) delete process.env.MAW_TEST_MODE;
+      else process.env.MAW_TEST_MODE = oldTestMode;
+      if (oldAutoWrite === undefined) delete process.env.MAW_HEY_INBOX_AUTOWRITE;
+      else process.env.MAW_HEY_INBOX_AUTOWRITE = oldAutoWrite;
+    }
+  });
+
+  test("infers receiver oracle from explicit to, tmux target, and node-prefixed query", () => {
+    expect(resolveReceiverOracle({ query: "m5:digger", to: "m5:mawjs", target: "54-digger:digger-oracle.0", from: "m5:sender", message: "hi" })).toBe("mawjs");
+    expect(resolveReceiverOracle({ query: "m5:digger", target: "54-digger:digger-oracle.0", from: "m5:sender", message: "hi" })).toBe("digger");
+    expect(resolveReceiverOracle({ query: "m5:digger", from: "m5:sender", message: "hi" })).toBe("digger");
+    expect(resolveReceiverOracle({ query: "digger-oracle", from: "m5:sender", message: "hi" })).toBe("digger");
+  });
+
+  test("writes markdown frontmatter to the receiver ψ/inbox using target cwd first", () => {
+    const root = mkdtempSync(join(tmpdir(), "maw-receiver-inbox-"));
+    const repo = join(root, "digger-oracle");
+    mkdirSync(repo, { recursive: true });
+
+    const result = persistReceiverInbox({
+      query: "m5:digger",
+      target: "54-digger:digger-oracle.0",
+      from: "m5:sender",
+      message: "[m5:sender] ralph-dig: oracle-status-tray",
+      config: { node: "m5", oracle: "sender" },
+    }, {
+      resolveTargetCwd: () => repo,
+      loadManifest: () => [],
+      getGhqRoot: () => root,
+      ghqFindSync: () => null,
+      now: () => new Date("2026-05-17T08:00:00.000Z"),
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.reason);
+    expect(result.oracle).toBe("digger");
+    expect(result.filename).toBe("2026-05-17_08-00_m5-sender_m5-sender-ralph-dig-oracle-status-tray.md");
+    expect(existsSync(result.path)).toBe(true);
+    expect(readFileSync(result.path, "utf-8")).toContain("from: m5:sender");
+    expect(readFileSync(result.path, "utf-8")).toContain("to: digger");
+    expect(readFileSync(result.path, "utf-8")).toContain("[m5:sender] ralph-dig: oracle-status-tray");
+  });
+
+  test("falls back to manifest repo path and reports misses without throwing", () => {
+    const root = mkdtempSync(join(tmpdir(), "maw-receiver-inbox-manifest-"));
+    const repo = join(root, "github.com", "Soul-Brews-Studio", "digger-oracle");
+    mkdirSync(repo, { recursive: true });
+
+    const ok = persistReceiverInbox({
+      query: "digger",
+      from: "m5:sender",
+      message: "queue me",
+    }, {
+      resolveTargetCwd: () => null,
+      loadManifest: () => [{ name: "digger", sources: ["fleet"], repo: "Soul-Brews-Studio/digger-oracle", isLive: false }],
+      getGhqRoot: () => root,
+      ghqFindSync: () => null,
+      now: () => new Date("2026-05-17T08:01:00.000Z"),
+    });
+
+    expect(ok.ok).toBe(true);
+    if (ok.ok) expect(ok.inboxDir).toBe(join(repo, "ψ", "inbox"));
+
+    const miss = persistReceiverInbox({
+      query: "ghost",
+      from: "m5:sender",
+      message: "lost",
+    }, {
+      resolveTargetCwd: () => null,
+      loadManifest: () => [],
+      getGhqRoot: () => root,
+      ghqFindSync: () => null,
+    });
+    expect(miss).toEqual({ ok: false, oracle: "ghost", reason: "receiver repo not found for ghost" });
+  });
+
+  test("handles psiPath, discovery exceptions, and write failures safely", () => {
+    const root = mkdtempSync(join(tmpdir(), "maw-receiver-inbox-errors-"));
+    const repo = join(root, "current-oracle");
+    mkdirSync(repo, { recursive: true });
+
+    const psi = persistReceiverInbox({
+      query: "current",
+      from: "m5:sender",
+      message: "via psi path",
+      config: { oracle: "current", psiPath: join(repo, "ψ") },
+    }, {
+      loadManifest: () => { throw new Error("manifest boom"); },
+      ghqFindSync: () => { throw new Error("ghq boom"); },
+      getGhqRoot: () => root,
+      now: () => new Date("2026-05-17T08:02:00.000Z"),
+    });
+    expect(psi.ok).toBe(true);
+    if (psi.ok) expect(psi.inboxDir).toBe(join(repo, "ψ", "inbox"));
+
+    const noRepo = persistReceiverInbox({
+      query: "current",
+      from: "m5:sender",
+      message: "exists throws",
+      config: { oracle: "current", psiPath: join(root, "bad", "ψ") },
+    }, {
+      loadManifest: () => { throw new Error("manifest boom"); },
+      ghqFindSync: () => { throw new Error("ghq boom"); },
+      getGhqRoot: () => root,
+      existsSync: () => { throw new Error("exists boom"); },
+    });
+    expect(noRepo).toEqual({ ok: false, oracle: "current", reason: "receiver repo not found for current" });
+
+    const writeFail = persistReceiverInbox({
+      query: "current",
+      from: "m5:sender",
+      message: "write fails",
+      config: { oracle: "current", psiPath: join(repo, "ψ") },
+    }, {
+      getGhqRoot: () => root,
+      writeFileSync: () => { throw new Error("disk full"); },
+    });
+    expect(writeFail).toEqual({ ok: false, oracle: "current", reason: "disk full" });
+  });
+});

--- a/test/sessions-api-default.test.ts
+++ b/test/sessions-api-default.test.ts
@@ -57,6 +57,7 @@ function makeHarness(overrides: SessionsApiDeps = {}) {
       sendKeys: async (target: string, key: string) => { calls.push(["tmuxKeys", target, key]); },
     } as any),
     emitMessageLifecycle: (input) => { lifecycle.push(input); },
+    writeReceiverInbox: null,
     sleep: async (ms: number) => { calls.push(["sleep", ms]); },
     shouldAutoWake: () => ({ wake: false, reason: "policy" }),
     cmdWake: async (target: string, opts: any) => { calls.push(["cmdWake", target, opts]); },
@@ -193,6 +194,35 @@ describe("POST /send", () => {
     expect(h.lifecycle[0]).toMatchObject({ state: "queued", signed: false });
   });
 
+  test("mirrors inbound local /send deliveries to receiver inbox when enabled", async () => {
+    const inboxCalls: any[] = [];
+    const h = makeHarness({
+      resolveTarget: (() => ({ type: "local", target: "54-digger:digger-oracle.0" })) as any,
+      writeReceiverInbox: (input) => {
+        inboxCalls.push(input);
+        return {
+          ok: true,
+          oracle: "digger",
+          inboxDir: "/repo/ψ/inbox",
+          path: "/repo/ψ/inbox/msg.md",
+          filename: "msg.md",
+        };
+      },
+    });
+
+    const res = await readJson(await h.app.handle(jsonRequest("/send", { target: "digger", text: "dig please" }, { "x-maw-from": "homekeeper:m5" })));
+
+    expect(res).toMatchObject({ ok: true, target: "54-digger:digger-oracle.0", source: "local", inbox: "/repo/ψ/inbox/msg.md" });
+    expect(inboxCalls).toEqual([{
+      query: "digger",
+      target: "54-digger:digger-oracle.0",
+      to: "digger",
+      from: "m5:homekeeper",
+      message: "dig please",
+      config: h.config,
+    }]);
+  });
+
   test("force skips idle guard and capture failures are delivery-safe", async () => {
     const h = makeHarness({
       resolveTarget: (() => ({ type: "local", target: "local:main" })) as any,
@@ -303,6 +333,39 @@ describe("POST /send", () => {
     const res = await outer.app.handle(jsonRequest("/send", { target: "neo", text: "hi" }));
     expect(res.status).toBe(500);
     expect((await readJson(res)).error).toContain("list boom");
+  });
+
+  test("queues inbound /send to receiver inbox when target is offline", async () => {
+    const h = makeHarness({
+      resolveTarget: (() => ({ type: "error", reason: "missing", detail: "not live", hint: "wake" })) as any,
+      writeReceiverInbox: () => ({
+        ok: true,
+        oracle: "digger",
+        inboxDir: "/repo/ψ/inbox",
+        path: "/repo/ψ/inbox/offline.md",
+        filename: "offline.md",
+      }),
+    });
+
+    const res = await h.app.handle(jsonRequest("/send", { target: "digger", text: "offline task" }, { "x-maw-from": "homekeeper:m5" }));
+
+    expect(res.status).toBe(200);
+    expect(await readJson(res)).toEqual({
+      ok: true,
+      target: "digger",
+      text: "offline task",
+      source: "inbox",
+      state: "queued",
+      inbox: "/repo/ψ/inbox/offline.md",
+      reason: "not live",
+    });
+    expect(h.lifecycle[0]).toMatchObject({
+      route: "inbox",
+      state: "queued",
+      from: "m5:homekeeper",
+      to: "m5:digger",
+      target: "digger",
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- Add best-effort receiver `ψ/inbox` persistence for `maw hey` / `/api/send` local deliveries.
- Queue to receiver inbox instead of dropping when the target pane is missing, not an agent, or not idle.
- Keep production auto-write on by default; test mode defaults off unless explicitly enabled.

## Validation
- `MAW_TEST_MODE=1 bun test test/receiver-inbox-default.test.ts test/comm-send-cmdsend-coverage.test.ts test/sessions-api-default.test.ts --timeout 60000` — 54 pass.
- `bun run build` — bundles `dist/maw`.
- `MAW_SKIP_FLAKY=1 bun run test:isolated` — 125/125 isolated files passed after fixing the SDK mock export shape used by `comm-send-resolve-pane`.
- `git diff --check` — clean.
- `MAW_TEST_MODE=1 bun test test/receiver-inbox-default.test.ts --coverage --timeout 60000` — `src/commands/shared/receiver-inbox.ts` 100.00 funcs / 100.00 lines.
- User-visible smoke: temp `MAW_CONFIG_DIR` + `GHQ_ROOT`, `MAW_HEY_INBOX_AUTOWRITE=1 bun src/cli.ts hey m5:digger "ralph-dig smoke"` queued and wrote `digger-oracle/ψ/inbox/2026-05-17_08-06_...md`.

## Notes
- Alpha branch only. No release cut.
- Live cross-node digger-oracle dead-pane federation not tested here; Digger can use this PR to validate the real offline dispatch path.

Closes #1737.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
