### PR TITLE
fix(team): route team fan-out into workspace windows

### DIFF
--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -193,6 +193,43 @@ function isBareLocalHeyTarget(query: string): boolean {
   return query.length > 0 && !query.includes(":") && !query.includes("/");
 }
 
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function teamWorkspaceWindowCandidates(member: string): string[] {
+  const raw = member.trim();
+  const stripped = raw.replace(/-oracle$/i, "");
+  return uniqueStrings([
+    raw,
+    stripped,
+    stripped ? `${stripped}-oracle` : "",
+  ]);
+}
+
+/**
+ * Resolve a persistent team member to its workspace window when
+ * `maw team bring <team>` already opened that oracle inside the team session.
+ *
+ * This is intentionally scoped to team fan-out only: ordinary `maw hey
+ * <oracle>` keeps its local/home-session behavior, while `maw hey team:<team>`
+ * now targets the workspace windows that `maw team bring` created (#1742).
+ *
+ * @internal exported for regression tests.
+ */
+export function resolveTeamWorkspaceMemberTarget(
+  teamName: string,
+  member: string,
+  sessions: Awaited<ReturnType<typeof listSessions>>,
+): string | null {
+  const workspace = sessions.find((s) => s.name === teamName);
+  if (!workspace) return null;
+
+  const wanted = new Set(teamWorkspaceWindowCandidates(member).map((name) => name.toLowerCase()));
+  const win = workspace.windows.find((w) => wanted.has(w.name.toLowerCase()));
+  return win ? `${workspace.name}:${win.name}` : null;
+}
+
 function formatAmbiguousCandidates(query: string, candidates: string[]): string[] {
   if (candidates.length) return candidates;
   return [query];
@@ -295,22 +332,24 @@ export async function cmdSend(
     }
     let delivered = 0;
     let failed = 0;
+    const sessions = await listSessions();
 
     // Fan-out sends individually. cmdSend calls process.exit on failure,
     // so we override it temporarily to keep iterating (#627 resilient fan-out).
     const origExit = process.exit;
     for (const member of members) {
+      const routedMember = resolveTeamWorkspaceMemberTarget(teamName, member, sessions) ?? member;
       let memberFailed = false;
       process.exit = ((code?: number) => {
         memberFailed = true;
       }) as never;
       try {
-        await cmdSend(member, message, force);
+        await cmdSend(routedMember, message, force);
         if (!memberFailed) delivered++;
         else failed++;
       } catch (e: any) {
         failed++;
-        console.error(`  \x1b[31m✗\x1b[0m ${member}: ${e?.message || "failed"}`);
+        console.error(`  \x1b[31m✗\x1b[0m ${routedMember}: ${e?.message || "failed"}`);
       }
     }
     process.exit = origExit;

--- a/src/vendor/mpr-plugins/team/index.ts
+++ b/src/vendor/mpr-plugins/team/index.ts
@@ -164,16 +164,18 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         "--session": String,
         "--engine": String, "-e": "--engine",
         "--dry-run": Boolean,
+        "--split": Boolean,
       }, 1);
       const team = flags._[0];
       if (!team) {
-        logs.push("usage: maw team bring <team> [--session <session>] [-e|--engine <name>] [--dry-run]");
+        logs.push("usage: maw team bring <team> [--session <session>] [-e|--engine <name>] [--split] [--dry-run]");
         return { ok: false, error: "team required", output: logs.join("\n") };
       }
       await cmdTeamBring(team, {
         session: flags["--session"] as string | undefined,
         engine: flags["--engine"] as string | undefined,
         dryRun: !!flags["--dry-run"],
+        split: !!flags["--split"],
       });
     } else if (sub === "resume") {
       if (!args[1]) {

--- a/src/vendor/mpr-plugins/team/team-workspace.ts
+++ b/src/vendor/mpr-plugins/team/team-workspace.ts
@@ -9,6 +9,8 @@ export interface TeamBringOptions {
   engine?: string;
   /** Preview without creating windows or launching engines. */
   dryRun?: boolean;
+  /** Open each brought oracle beside the current pane using maw wake --split. */
+  split?: boolean;
 }
 
 export function teamOracleMemberNames(members: OracleMember[]): string[] {
@@ -80,7 +82,7 @@ export async function cmdTeamBring(teamName: string, opts: TeamBringOptions = {}
   const targets: string[] = [];
   for (const oracle of members) {
     if (opts.dryRun) {
-      console.log(`  \x1b[90mwould wake ${oracle} --session ${session}\x1b[0m`);
+      console.log(`  \x1b[90mwould wake ${oracle} --session ${session}${opts.split ? " --split" : ""}\x1b[0m`);
       targets.push(`${session}:${oracle}`);
       continue;
     }
@@ -88,6 +90,7 @@ export async function cmdTeamBring(teamName: string, opts: TeamBringOptions = {}
       session,
       noRehydrate: true,
       engine: opts.engine,
+      split: opts.split,
     });
     targets.push(target);
   }

--- a/test/comm-send-cmdsend-coverage.test.ts
+++ b/test/comm-send-cmdsend-coverage.test.ts
@@ -59,6 +59,8 @@ let config: any;
 let listSessionsReturn: Session[];
 let resolveTargetReturn: ResolvedTarget;
 let resolveTargetError: Error | null;
+let resolveTargetCalls: string[];
+let resolveTargetHandler: ((query: string) => ResolvedTarget) | null;
 let findPeerUrl: string | null;
 let getPaneCommandReturn: string;
 let captureResponses: string[];
@@ -103,7 +105,9 @@ mock.module(join(import.meta.dir, "../src/sdk"), () => ({
   findPeerForTarget: async (...args: Parameters<typeof realSdk.findPeerForTarget>) => mockActive ? findPeerUrl : realSdk.findPeerForTarget(...args),
   resolveTarget: (...args: Parameters<typeof _rSdk.resolveTarget>) => {
     if (!mockActive) return realSdk.resolveTarget(...args);
+    resolveTargetCalls.push(args[0]);
     if (resolveTargetError) throw resolveTargetError;
+    if (resolveTargetHandler) return resolveTargetHandler(args[0]);
     return resolveTargetReturn as ReturnType<typeof _rSdk.resolveTarget>;
   },
   curlFetch: async (url: string, options: any) => {
@@ -239,6 +243,8 @@ beforeEach(() => {
   listSessionsReturn = [{ name: "session", windows: [{ index: 0, name: "oracle", active: true }] }];
   resolveTargetReturn = { type: "local", target: "session:oracle.0" };
   resolveTargetError = null;
+  resolveTargetCalls = [];
+  resolveTargetHandler = null;
   findPeerUrl = null;
   getPaneCommandReturn = "claude";
   captureResponses = ["❯ ", "accepted"];
@@ -510,6 +516,35 @@ describe("cmdSend — prefix routers", () => {
     expect(exitCode).toBe(1);
     expect(errs.join("\n")).toContain("no oracle members in team 'missing'");
     expect(errs.join("\n")).toContain("maw team oracle-invite");
+  });
+
+  test("team fan-out prefers brought workspace windows over oracle home sessions", async () => {
+    oracleMembers = ["digger-oracle", "discord-oracle"];
+    oracleRegistry = { members: ["digger-oracle", "discord-oracle", "sender"] };
+    listSessionsReturn = [
+      { name: "anon", windows: [
+        { index: 0, name: "lead", active: true },
+        { index: 1, name: "digger", active: false },
+        { index: 2, name: "discord", active: false },
+      ] },
+      { name: "33-digger", windows: [{ index: 0, name: "digger-oracle", active: true }] },
+      { name: "23-discord", windows: [{ index: 0, name: "discord-oracle", active: true }] },
+    ];
+    resolveTargetHandler = (query) => {
+      if (query === "anon:digger") return { type: "local", target: "anon:1" };
+      if (query === "anon:discord") return { type: "local", target: "anon:2" };
+      return { type: "local", target: `HOME:${query}` };
+    };
+
+    await runCmd(() => cmdSend("team:anon", "hello"));
+
+    expect(exitCode).toBeUndefined();
+    expect(resolveTargetCalls).toEqual(["anon:digger", "anon:discord"]);
+    expect(sendKeysCalls).toEqual([
+      { target: "anon:1", text: "[test-node:sender] hello" },
+      { target: "anon:2", text: "[test-node:sender] hello" },
+    ]);
+    expect(logs.join("\n")).toContain("fan-out complete: 2 delivered, 0 failed");
   });
 });
 

--- a/test/isolated/team-bring-workspace.test.ts
+++ b/test/isolated/team-bring-workspace.test.ts
@@ -71,12 +71,12 @@ describe("cmdTeamBring", () => {
   });
 
   test("wakes each oracle with --session semantics and applies layout", async () => {
-    const targets = await cmdTeamBring("myteam", { session: "project", engine: "codex" });
+    const targets = await cmdTeamBring("myteam", { session: "project", engine: "codex", split: true });
 
     expect(targets).toEqual(["project:volt", "project:odin"]);
     expect(wakeCalls).toEqual([
-      { oracle: "volt", opts: { session: "project", noRehydrate: true, engine: "codex" } },
-      { oracle: "odin", opts: { session: "project", noRehydrate: true, engine: "codex" } },
+      { oracle: "volt", opts: { session: "project", noRehydrate: true, engine: "codex", split: true } },
+      { oracle: "odin", opts: { session: "project", noRehydrate: true, engine: "codex", split: true } },
     ]);
     expect(layoutCalls).toEqual([{ target: "project:lead", layout: "main-vertical" }]);
   });


### PR DESCRIPTION
## Summary
- route `maw hey team:<team>` fan-out into windows from a matching `maw team bring <team>` workspace before falling back to home oracle routing
- thread `maw team bring --split` through the team CLI parser, `TeamBringOptions`, and `cmdWake`
- add regression coverage for workspace-preferring team fan-out and split propagation

## Validation
- `MAW_TEST_MODE=1 bun test test/comm-send-cmdsend-coverage.test.ts test/isolated/team-bring-workspace.test.ts --timeout 60000`
- `bun run build`

Closes #1742
Closes #1741

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
