### PR TITLE
test(coverage): stabilize config API default pin verifier

### DIFF
--- a/test/config-api-default.test.ts
+++ b/test/config-api-default.test.ts
@@ -222,18 +222,25 @@ describe("config API pin and public config routes", () => {
   });
 
   test("default pin verifier uses auth token factory when no override is provided", async () => {
-    const app = makeApp({
-      pinAttempts: new Map(),
-      loadConfig: (() => ({ pin: "42" })) as any,
-    });
+    const previousSecret = process.env.MAW_JWT_SECRET;
+    process.env.MAW_JWT_SECRET = "test-config-api-default-pin-secret";
+    try {
+      const app = makeApp({
+        pinAttempts: new Map(),
+        loadConfig: (() => ({ pin: "42" })) as any,
+      });
 
-    const res = await app.handle(jsonRequest("/pin-verify", "POST", { pin: "42" }));
-    const body = await readJson(res);
+      const res = await app.handle(jsonRequest("/pin-verify", "POST", { pin: "42" }));
+      const body = await readJson(res);
 
-    expect(res.status).toBe(200);
-    expect(body.ok).toBe(true);
-    expect(typeof body.token).toBe("string");
-    expect(body.token.length).toBeGreaterThan(10);
+      expect(res.status).toBe(200);
+      expect(body.ok).toBe(true);
+      expect(typeof body.token).toBe("string");
+      expect(body.token.length).toBeGreaterThan(10);
+    } finally {
+      if (previousSecret === undefined) delete process.env.MAW_JWT_SECRET;
+      else process.env.MAW_JWT_SECRET = previousSecret;
+    }
   });
 
   test("GET and POST /config preserve masked env values and report save errors", async () => {


### PR DESCRIPTION
## Summary
- make the default `/pin-verify` config API coverage test use a deterministic `MAW_JWT_SECRET`
- restore the prior env after the assertion so the suite does not leak auth state
- keeps the real default auth token factory path covered; no `createToken` mock added

## Validation
- `MAW_TEST_MODE=1 bun test test/config-api-default.test.ts --timeout 60000`
- `MAW_TEST_MODE=1 bun test test/config-api-default.test.ts --coverage --coverage-reporter=text --coverage-dir=/tmp/maw-config-api-coverage --timeout 60000`
- `timeout 90s bash scripts/test-coverage.sh` — config segment passed with no `(fail)`/`Failed to parse JSON`; command capped later before full suite completion

Closes #1743

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
