### PR TITLE
fix(wake): prevent duplicate window after listWindows race

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -351,6 +351,13 @@ async function chooseWakeSessionName(oracle: string, urlRepoName?: string): Prom
   return `${String(maxNum + 1).padStart(2, "0")}-${baseName}`;
 }
 
+function findExistingWakeWindow(windowNames: Iterable<string>, oracle: string, windowName: string): string | undefined {
+  const names = [...windowNames];
+  const nameSuffix = windowName.replace(`${oracle}-`, "");
+  return names.find(w => w === windowName)
+    || names.find(w => new RegExp(`^${oracle}-\\d+-${nameSuffix}$`).test(w));
+}
+
 export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string> {
   // Canonicalize the bare name before any lookup — strips trailing `/`, `/.git`, `/.git/`
   // so `maw wake token-oracle/` (tab-completion artifact) resolves the same as `token-oracle`.
@@ -530,6 +537,9 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
     return session ? `${session}:${mainWindowName}` : `${oracle}:dry-run`;
   }
 
+  let knownWindows = new Set<string>();
+  let knownWindowsReliable = true;
+
   if (!session && wakeDecision.wake) {
     // #2 — refuse to spawn a brand-new session/agent once the fleet is at the
     // configured concurrency cap (no-op when limits.maxConcurrentAgents is 0).
@@ -567,6 +577,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
     await runWakeLifecycleHooks({ oracle, session, repoPath, repoName });
 
     let existingWindows = new Set((await tmux.listWindows(session).catch(() => [] as { name: string }[])).map(w => w.name));
+    existingWindows.add(mainWindowName);
     if (requestedSnapshotSession) {
       const allWt = await findWorktrees(parentDir, repoName);
       const restored = await restoreSnapshotWindows(oracle, session, requestedSnapshotSession, existingWindows, allWt, repoPath, opts.engine);
@@ -583,11 +594,16 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
         console.log(`\x1b[32m+\x1b[0m window: ${wt.windowName}`);
       }
     }
+    knownWindows = existingWindows;
   } else {
     await setSessionEnv(session);
     await runWakeLifecycleHooks({ oracle, session, repoPath, repoName });
     let preExistingWindows = new Set<string>();
-    try { preExistingWindows = new Set((await tmux.listWindows(session)).map(w => w.name)); } catch { /* ok */ }
+    try {
+      preExistingWindows = new Set((await tmux.listWindows(session)).map(w => w.name));
+    } catch {
+      knownWindowsReliable = false;
+    }
 
     if (requestedSnapshotSession) {
       const allWt = await findWorktrees(parentDir, repoName);
@@ -604,6 +620,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
           await tmux.newWindow(session, wt.windowName, { cwd: wt.path });
           await new Promise(r => setTimeout(r, 300));
           await tmux.sendText(`${session}:${wt.windowName}`, buildCommandInDir(wt.windowName, wt.path, opts.engine));
+          preExistingWindows.add(wt.windowName);
           console.log(`\x1b[32m↻\x1b[0m respawned: ${wt.windowName}`);
         }
       }
@@ -612,6 +629,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
     await new Promise(r => setTimeout(r, cfgTimeout("wakeVerify")));
     const retried = await ensureSessionRunning(session, preExistingWindows);
     if (retried > 0) console.log(`\x1b[33m${retried} window(s) retried.\x1b[0m`);
+    knownWindows = preExistingWindows;
   }
 
   const reordered = foreignSession ? 0 : await restoreTabOrder(session);
@@ -675,12 +693,8 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
     }
   }
 
-  try {
-    const windows = await tmux.listWindows(session);
-    const nameSuffix = windowName.replace(`${oracle}-`, "");
-    const existingWindow = windows.map(w => w.name).find(w => w === windowName)
-      || windows.map(w => w.name).find(w => new RegExp(`^${oracle}-\\d+-${nameSuffix}$`).test(w));
-    if (existingWindow) {
+  const existingWindow = findExistingWakeWindow(knownWindows, oracle, windowName);
+  if (existingWindow) {
       if (opts.prompt) {
         await tmux.selectWindow(`${session}:${existingWindow}`);
         const escaped = opts.prompt.replace(/'/g, "'\\''");
@@ -732,7 +746,10 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
       await recordWakeSnapshot();
       return target;
     }
-  } catch { /* session might be fresh */ }
+
+  if (!knownWindowsReliable) {
+    throw new Error(`could not list windows for session '${session}' — refusing to create '${windowName}' because it may already exist`);
+  }
 
   // #2 — a new task/worktree window is a net-new agent pane: cap-check before
   // spawning it (no-op when limits.maxConcurrentAgents is 0).

--- a/test/wake-cmd-cmdwake-coverage.test.ts
+++ b/test/wake-cmd-cmdwake-coverage.test.ts
@@ -120,6 +120,8 @@ let liveTileRoles: string[];
 let branchName: string;
 let ensureSessionRunningReturn: number;
 let restoreTabOrderReturn: number;
+let listWindowsCalls: string[];
+let listWindowsThrowOnCall: number | null;
 
 let logs: string[];
 let hostExecCalls: string[];
@@ -246,7 +248,11 @@ mock.module(join(import.meta.dir, "../src/sdk"), () => ({
       mockActive ? sessions : realSdk.tmux.listSessions(),
     listWindows: async (session: string) =>
       mockActive
-        ? [...(windowsBySession[session] ?? [])]
+        ? (() => {
+            listWindowsCalls.push(session);
+            if (listWindowsThrowOnCall === listWindowsCalls.length) throw new Error("tmux busy");
+            return [...(windowsBySession[session] ?? [])];
+          })()
         : realSdk.tmux.listWindows(session),
     newSession: async (name: string, opts: any = {}) => {
       if (!mockActive) return realSdk.tmux.newSession(name, opts);
@@ -504,6 +510,8 @@ beforeEach(() => {
   branchName = "main";
   ensureSessionRunningReturn = 0;
   restoreTabOrderReturn = 0;
+  listWindowsCalls = [];
+  listWindowsThrowOnCall = null;
 
   logs = [];
   hostExecCalls = [];
@@ -691,6 +699,20 @@ describe("cmdWake main-suite coverage", () => {
     expect(rendered).toContain("snapshot restore: 2 windows");
     expect(rendered).toContain("2 window(s) retried");
     expect(rendered).toContain("agent dead, re-launching");
+  });
+
+  test("reuses the first window listing so a later tmux list failure cannot create a duplicate", async () => {
+    listWindowsThrowOnCall = 2;
+
+    const { result, logs } = await captureLogs(() =>
+      cmdWake("mawjs", {}),
+    );
+
+    expect(result).toBe("54-mawjs:mawjs-oracle");
+    expect(listWindowsCalls).toEqual(["54-mawjs"]);
+    expect(newWindowCalls).toEqual([]);
+    expect(sendTextCalls).toEqual([]);
+    expect(logs.join("\n")).toContain("'mawjs-oracle' running in 54-mawjs");
   });
 
   test("creates a wake-bud worktree, stamps lineage, emits birth signal, and launches with prompt", async () => {


### PR DESCRIPTION
## Summary\n- reuse the first session window listing for existing wake-window detection\n- remove the broad second listWindows try/catch path that could skip existence checks\n- fail loud instead of creating a new window when the listing is unreliable\n- add regression coverage for the second-list failure race\n\nFixes #1747.\n\n## Validation\n- MAW_TEST_MODE=1 bun test test/wake-cmd-cmdwake-coverage.test.ts --timeout 60000\n- bun run build\n- timeout 20s env MAW_TEST_MODE=1 bun src/cli.ts wake mawjs --no-rehydrate; 54-mawjs window list stayed at one mawjs-oracle before and after\n\nWritten by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.