### PR TITLE
feat(team): detect context-limit frozen workspace panes

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "./lib/sparkline": "./src/lib/sparkline.ts",
     "./commands/shared/comm": "./src/commands/shared/comm.ts",
     "./commands/shared/comm-send": "./src/commands/shared/comm-send.ts",
+    "./commands/shared/context-limit": "./src/commands/shared/context-limit.ts",
     "./commands/shared/done": "./src/commands/shared/done.ts",
     "./commands/shared/fleet": "./src/commands/shared/fleet.ts",
     "./commands/shared/fleet-doctor-fixer": "./src/commands/shared/fleet-doctor-fixer.ts",

--- a/src/commands/plugins/tmux/impl.ts
+++ b/src/commands/plugins/tmux/impl.ts
@@ -7,6 +7,7 @@ import { loadFleetEntries } from "../../shared/fleet-load";
 import { ghqList, ghqListSync } from "../../../core/ghq";
 import { scanWorktrees } from "../../../core/fleet/worktrees-scan";
 import { checkDestructive, isClaudeLikePane, isFleetOrViewSession } from "./safety";
+import { checkPaneContextLimit, isLikelyAgentPaneCommand } from "../../shared/context-limit";
 export {
   PANE_TARGET_FORMAT,
   paneTargetCandidatesFromListPanesOutput,
@@ -154,7 +155,7 @@ export interface TmuxLsOpts {
   recentLimit?: number;
 }
 
-export type PaneStatus = "active" | "idle" | "stale" | "unknown";
+export type PaneStatus = "frozen" | "active" | "idle" | "stale" | "unknown";
 
 interface AnnotatedPane {
   id: string;
@@ -168,6 +169,16 @@ interface AnnotatedPane {
   sessionCreated?: number;
 }
 
+async function markContextLimitedPanes(panes: AnnotatedPane[]): Promise<void> {
+  await Promise.all(panes.map(async (pane) => {
+    if (!isLikelyAgentPaneCommand(pane.command)) return;
+    if (!await checkPaneContextLimit(pane.target)) return;
+    pane.status = "frozen";
+    pane.annotation = pane.annotation
+      ? `${pane.annotation}; context-limit`
+      : "context-limit";
+  }));
+}
 
 export function parseSessionCreatedList(raw: string): Map<string, number> {
   const out = new Map<string, number>();
@@ -275,6 +286,8 @@ export async function cmdTmuxLs(opts: TmuxLsOpts = {}): Promise<void> {
       .sort((a, b) => (order.get(a.session)! - order.get(b.session)!) || a.target.localeCompare(b.target));
   }
 
+  await markContextLimitedPanes(scope);
+
   if (opts.json) {
     console.log(JSON.stringify(scope, null, 2));
     return;
@@ -288,6 +301,7 @@ export async function cmdTmuxLs(opts: TmuxLsOpts = {}): Promise<void> {
   }
 
   const STATUS_DOT: Record<PaneStatus, string> = {
+    frozen: "\x1b[33m⚠\x1b[0m",
     active: "\x1b[32m●\x1b[0m",
     idle: "\x1b[33m◐\x1b[0m",
     stale: "\x1b[31m◌\x1b[0m",
@@ -309,6 +323,7 @@ export async function cmdTmuxLs(opts: TmuxLsOpts = {}): Promise<void> {
       bySession.get(sess)!.push(p);
     }
     const bestStatus = (panes: AnnotatedPane[]): PaneStatus => {
+      if (panes.some(p => p.status === "frozen")) return "frozen";
       if (panes.some(p => p.status === "active")) return "active";
       if (panes.some(p => p.status === "idle")) return "idle";
       if (panes.some(p => p.status === "stale")) return "stale";
@@ -345,6 +360,9 @@ export async function cmdTmuxLs(opts: TmuxLsOpts = {}): Promise<void> {
         console.log(`  ${pad(String(index + 1), 3)} \x1b[36m${sess}\x1b[0m${afterName} ${created} ${pad(dot, 6)} ${pad(count, 8)}${agentTag}`);
       } else {
         console.log(`  ${dot} \x1b[36m${sess}\x1b[0m  \x1b[90m${count}\x1b[0m${agentTag}`);
+      }
+      for (const p of panes.filter(p => p.status === "frozen")) {
+        console.log(`    \x1b[33m⚠\x1b[0m \x1b[90m${p.target} context-limit — /compact needed\x1b[0m`);
       }
       const wts = wtBySession.get(sess) || [];
       for (const wt of wts) {

--- a/src/commands/shared/context-limit.ts
+++ b/src/commands/shared/context-limit.ts
@@ -1,0 +1,93 @@
+import { tmux as defaultTmux } from "../../sdk";
+
+export interface ContextLimitProbeDeps {
+  capture?: (target: string, lines?: number) => Promise<string>;
+  sendText?: (target: string, text: string) => Promise<void>;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+  warn?: (message: string) => void;
+}
+
+export interface ContextLimitRecoveryOptions extends ContextLimitProbeDeps {
+  pollMs?: number;
+  intervalMs?: number;
+  lines?: number;
+  label?: string;
+}
+
+const CONTEXT_LIMIT_PATTERNS = [
+  /context limit reached/i,
+  /\/compact\s+or\s+\/clear\s+to\s+continue/i,
+  /compact\s+or\s+clear\s+to\s+continue/i,
+] as const;
+
+const DEFAULT_POLL_MS = 5000;
+const DEFAULT_INTERVAL_MS = 750;
+const DEFAULT_LINES = 20;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export function isContextLimitOutput(output: string | null | undefined): boolean {
+  if (!output) return false;
+  return CONTEXT_LIMIT_PATTERNS.some(pattern => pattern.test(output));
+}
+
+/**
+ * Only panes that plausibly host an interactive agent need a capture probe.
+ * This keeps `maw ls` from running a capture for every plain shell pane while
+ * still covering Claude, Codex, node/bun wrappers, and version-named panes.
+ */
+export function isLikelyAgentPaneCommand(command: string | undefined): boolean {
+  if (!command) return false;
+  const cmd = command.toLowerCase().trim();
+  if (!cmd) return false;
+  if (/claude|codex|node|bun/.test(cmd)) return true;
+  return /^\d+\.\d+\.\d+$/.test(cmd);
+}
+
+export async function checkPaneContextLimit(
+  target: string,
+  deps: ContextLimitProbeDeps & { lines?: number } = {},
+): Promise<boolean> {
+  const capture = deps.capture ?? defaultTmux.capture?.bind(defaultTmux);
+  if (!capture) return false;
+  const lines = deps.lines ?? DEFAULT_LINES;
+  const output = await capture(target, lines).catch(() => "");
+  return isContextLimitOutput(output);
+}
+
+export async function waitForPaneContextLimit(
+  target: string,
+  opts: ContextLimitRecoveryOptions = {},
+): Promise<boolean> {
+  const pollMs = Math.max(0, opts.pollMs ?? DEFAULT_POLL_MS);
+  const intervalMs = Math.max(50, opts.intervalMs ?? DEFAULT_INTERVAL_MS);
+  const now = opts.now ?? Date.now;
+  const doSleep = opts.sleep ?? sleep;
+  const deadline = now() + pollMs;
+
+  while (true) {
+    if (await checkPaneContextLimit(target, opts)) return true;
+    if (now() >= deadline) return false;
+    await doSleep(Math.min(intervalMs, Math.max(0, deadline - now())));
+  }
+}
+
+export async function compactIfPaneContextLimited(
+  target: string,
+  opts: ContextLimitRecoveryOptions = {},
+): Promise<boolean> {
+  const frozen = await waitForPaneContextLimit(target, opts);
+  if (!frozen) return false;
+
+  const sendText = opts.sendText ?? defaultTmux.sendText?.bind(defaultTmux);
+  if (!sendText) return false;
+  await sendText(target, "/compact");
+
+  const label = opts.label ?? target;
+  const warn = opts.warn ?? console.warn;
+  warn(`  \x1b[33m⚠\x1b[0m ${label}: context limit hit — sent /compact`);
+  return true;
+}

--- a/src/vendor/mpr-plugins/team/team-workspace.ts
+++ b/src/vendor/mpr-plugins/team/team-workspace.ts
@@ -1,5 +1,6 @@
 import { tmux } from "maw-js/sdk";
 import { cmdWake } from "maw-js/commands/shared/wake";
+import { compactIfPaneContextLimited } from "maw-js/commands/shared/context-limit";
 import { loadOracleRegistry, type OracleMember } from "./oracle-members";
 
 export interface TeamBringOptions {
@@ -11,6 +12,8 @@ export interface TeamBringOptions {
   dryRun?: boolean;
   /** Open each brought oracle beside the current pane using maw wake --split. */
   split?: boolean;
+  /** How long to watch newly woken panes for immediate context-limit freeze. */
+  contextLimitPollMs?: number;
 }
 
 export function teamOracleMemberNames(members: OracleMember[]): string[] {
@@ -80,6 +83,7 @@ export async function cmdTeamBring(teamName: string, opts: TeamBringOptions = {}
   console.log(`\x1b[36m⚡\x1b[0m bringing ${members.length} oracle(s) into workspace '${session}'`);
 
   const targets: string[] = [];
+  const woken: Array<{ oracle: string; target: string }> = [];
   for (const oracle of members) {
     if (opts.dryRun) {
       console.log(`  \x1b[90mwould wake ${oracle} --session ${session}${opts.split ? " --split" : ""}\x1b[0m`);
@@ -93,9 +97,19 @@ export async function cmdTeamBring(teamName: string, opts: TeamBringOptions = {}
       split: opts.split,
     });
     targets.push(target);
+    woken.push({ oracle, target });
   }
 
   if (!opts.dryRun) {
+    await Promise.all(woken.map(({ oracle, target }) =>
+      compactIfPaneContextLimited(target, {
+        label: `${session}/${oracle}`,
+        pollMs: opts.contextLimitPollMs,
+      }).catch((error) => {
+        console.warn(`  \x1b[33m⚠\x1b[0m ${session}/${oracle}: context-limit probe failed (${error?.message ?? error})`);
+        return false;
+      })
+    ));
     const layout = await applyTeamBringLayout(session, members.length);
     console.log(`\x1b[32m✓\x1b[0m team '${teamName}' brought into '${session}' (${layout})`);
   }

--- a/test/isolated/context-limit.test.ts
+++ b/test/isolated/context-limit.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import {
+  checkPaneContextLimit,
+  compactIfPaneContextLimited,
+  isContextLimitOutput,
+  isLikelyAgentPaneCommand,
+} from "../../src/commands/shared/context-limit";
+
+describe("context-limit pane detection (#1746)", () => {
+  test("recognizes Claude context-limit prompts", () => {
+    expect(isContextLimitOutput("Context limit reached · /compact or /clear to continue")).toBe(true);
+    expect(isContextLimitOutput("please compact or clear to continue")).toBe(true);
+    expect(isContextLimitOutput("ordinary agent output")).toBe(false);
+    expect(isContextLimitOutput("")).toBe(false);
+  });
+
+  test("only agent-like commands are probed by maw ls", () => {
+    expect(isLikelyAgentPaneCommand("claude")).toBe(true);
+    expect(isLikelyAgentPaneCommand("codex")).toBe(true);
+    expect(isLikelyAgentPaneCommand("node")).toBe(true);
+    expect(isLikelyAgentPaneCommand("2.1.111")).toBe(true);
+    expect(isLikelyAgentPaneCommand("zsh")).toBe(false);
+  });
+
+  test("checks captured pane output", async () => {
+    expect(await checkPaneContextLimit("anon:digger", {
+      capture: async () => "Context limit reached · /compact or /clear to continue",
+    })).toBe(true);
+    expect(await checkPaneContextLimit("anon:digger", {
+      capture: async () => "ready",
+    })).toBe(false);
+  });
+
+  test("sends /compact once a frozen pane is detected", async () => {
+    const sent: Array<{ target: string; text: string }> = [];
+    const recovered = await compactIfPaneContextLimited("anon:digger", {
+      pollMs: 0,
+      capture: async () => "Context limit reached",
+      sendText: async (target, text) => { sent.push({ target, text }); },
+      warn: () => {},
+    });
+
+    expect(recovered).toBe(true);
+    expect(sent).toEqual([{ target: "anon:digger", text: "/compact" }]);
+  });
+});

--- a/test/isolated/team-bring-workspace.test.ts
+++ b/test/isolated/team-bring-workspace.test.ts
@@ -9,6 +9,8 @@ process.env.MAW_CONFIG_DIR = configDir;
 
 let wakeCalls: Array<{ oracle: string; opts: any }> = [];
 let layoutCalls: Array<{ target: string; layout: string }> = [];
+let sentText: Array<{ target: string; text: string }> = [];
+let captureByTarget = new Map<string, string>();
 
 mock.module("maw-js/core/paths", () => ({
   CONFIG_DIR: configDir,
@@ -22,6 +24,10 @@ mock.module("maw-js/sdk", () => ({
   tmux: {
     hasSession: async (name: string) => name === "project" || name === "myteam",
     run: async () => "54-mawjs",
+    capture: async (target: string) => captureByTarget.get(target) ?? "",
+    sendText: async (target: string, text: string) => {
+      sentText.push({ target, text });
+    },
     selectLayout: async (target: string, layout: string) => {
       layoutCalls.push({ target, layout });
     },
@@ -51,6 +57,8 @@ const { cmdTeamBring } = await import("../../src/vendor/mpr-plugins/team/team-wo
 beforeEach(() => {
   wakeCalls = [];
   layoutCalls = [];
+  sentText = [];
+  captureByTarget = new Map();
 });
 
 describe("cmdTeamBring", () => {
@@ -71,13 +79,24 @@ describe("cmdTeamBring", () => {
   });
 
   test("wakes each oracle with --session semantics and applies layout", async () => {
-    const targets = await cmdTeamBring("myteam", { session: "project", engine: "codex", split: true });
+    const targets = await cmdTeamBring("myteam", { session: "project", engine: "codex", split: true, contextLimitPollMs: 0 });
 
     expect(targets).toEqual(["project:volt", "project:odin"]);
     expect(wakeCalls).toEqual([
       { oracle: "volt", opts: { session: "project", noRehydrate: true, engine: "codex", split: true } },
       { oracle: "odin", opts: { session: "project", noRehydrate: true, engine: "codex", split: true } },
     ]);
+    expect(sentText).toEqual([]);
+    expect(layoutCalls).toEqual([{ target: "project:lead", layout: "main-vertical" }]);
+  });
+
+  test("sends /compact when a newly woken workspace pane hits context limit", async () => {
+    captureByTarget.set("project:volt", "Context limit reached · /compact or /clear to continue");
+
+    const targets = await cmdTeamBring("myteam", { session: "project", contextLimitPollMs: 0 });
+
+    expect(targets).toEqual(["project:volt", "project:odin"]);
+    expect(sentText).toEqual([{ target: "project:volt", text: "/compact" }]);
     expect(layoutCalls).toEqual([{ target: "project:lead", layout: "main-vertical" }]);
   });
 });

--- a/test/isolated/tmux-ls-recent.test.ts
+++ b/test/isolated/tmux-ls-recent.test.ts
@@ -13,10 +13,12 @@ type MockPane = {
 
 let panes: MockPane[] = [];
 let sessionCreatedRaw = "";
+let captureByTarget = new Map<string, string>();
 
 mock.module(join(srcRoot, "src/sdk"), () => ({
   tmux: {
     listPanes: async () => panes,
+    capture: async (target: string) => captureByTarget.get(target) ?? "",
   },
   hostExec: async (cmd: string) => {
     if (cmd.includes("list-sessions") && cmd.includes("session_created")) return sessionCreatedRaw;
@@ -63,6 +65,7 @@ beforeEach(() => {
     { id: "%3", target: "mid-session:oracle.0", command: "zsh", title: "mid", lastActivity: now },
   ];
   sessionCreatedRaw = "old-session\t100\nnew-session\t300\nmid-session\t200\n";
+  captureByTarget = new Map();
 });
 
 describe("maw ls --recent (#1628)", () => {
@@ -90,5 +93,18 @@ describe("maw ls --recent (#1628)", () => {
     expect(out).toContain("CREATED");
     expect(out.indexOf("new-session:oracle.0")).toBeLessThan(out.indexOf("mid-session:oracle.0"));
     expect(out.indexOf("mid-session:oracle.0")).toBeLessThan(out.indexOf("old-session:oracle.0"));
+  });
+
+  test("marks context-limit panes and sessions with warning status", async () => {
+    captureByTarget.set("new-session:oracle.0", "Context limit reached · /compact or /clear to continue");
+
+    const compact = await capture(() => cmdTmuxLs({ all: true, compact: true }));
+    expect(compact).toContain("⚠");
+    expect(compact).toContain("new-session");
+    expect(compact).toContain("new-session:oracle.0 context-limit");
+
+    const verbose = await capture(() => cmdTmuxLs({ all: true, verbose: true }));
+    expect(verbose).toContain("new-session:oracle.0");
+    expect(verbose).toContain("context-limit");
   });
 });


### PR DESCRIPTION
## Summary\n- add shared context-limit prompt detection for captured tmux pane output\n- make maw team bring watch newly woken workspace panes and send /compact when they immediately freeze\n- make maw ls show ⚠ context-limit panes/sessions instead of green healthy status\n- add regression tests for detection, team bring recovery, and ls rendering\n\nFixes #1746.\n\n## Validation\n- MAW_TEST_MODE=1 bun test test/isolated/context-limit.test.ts test/isolated/tmux-ls-recent.test.ts test/isolated/team-bring-workspace.test.ts --timeout 60000\n- bun run build\n- timeout 20s env MAW_TEST_MODE=1 bun src/cli.ts ls (live smoke surfaced ⚠ context-limit on 44-thclaws instead of green)\n\nWritten by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.