### PR TITLE
test(coverage): isolate config-dependent runtime tests

### DIFF
--- a/src/api/peer-exec-auth.ts
+++ b/src/api/peer-exec-auth.ts
@@ -61,17 +61,23 @@ export function isReadOnlyCmd(cmd: string): boolean {
   );
 }
 
-export function isShellPeerAllowed(originHost: string): boolean {
+export interface PeerConfigDeps {
+  loadConfig?: typeof loadConfig;
+}
+
+export function isShellPeerAllowed(originHost: string, deps: PeerConfigDeps = {}): boolean {
   if (originHost.startsWith("anon-")) return false;
-  const config = loadConfig() as any;
+  const readConfig = deps.loadConfig ?? loadConfig;
+  const config = readConfig() as any;
   const allowed: string[] = config?.wormhole?.shellPeers ?? [];
   return allowed.includes(originHost);
 }
 
 // --- Peer URL resolution --------------------------------------------------
 
-export function resolvePeerUrl(peer: string): string | null {
-  const config = loadConfig() as any;
+export function resolvePeerUrl(peer: string, deps: PeerConfigDeps = {}): string | null {
+  const readConfig = deps.loadConfig ?? loadConfig;
+  const config = readConfig() as any;
   const namedPeers: Array<{ name: string; url: string }> = config?.namedPeers ?? [];
   const match = namedPeers.find((p) => p.name === peer);
   if (match) return match.url;

--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -368,20 +368,30 @@ export async function detectSession(oracle: string, urlRepoName?: string): Promi
   return null;
 }
 
-export async function setSessionEnv(session: string): Promise<void> {
-  for (const [key, val] of Object.entries(getEnvVars())) {
+export interface SetSessionEnvDeps {
+  getEnvVars?: typeof getEnvVars;
+  spawn?: typeof Bun.spawn;
+  setEnvironment?: typeof tmux.setEnvironment;
+}
+
+export async function setSessionEnv(session: string, deps: SetSessionEnvDeps = {}): Promise<void> {
+  const readEnvVars = deps.getEnvVars ?? getEnvVars;
+  const spawn = deps.spawn ?? Bun.spawn;
+  const setEnvironment = deps.setEnvironment ?? tmux.setEnvironment.bind(tmux);
+
+  for (const [key, val] of Object.entries(readEnvVars())) {
     if (val.startsWith("pass:")) {
       const secretName = val.slice(5);
-      const proc = Bun.spawn(["pass", "show", secretName], { stdout: "pipe", stderr: "pipe" });
+      const proc = spawn(["pass", "show", secretName], { stdout: "pipe", stderr: "pipe" });
       const [secret, , code] = await Promise.all([
         new Response(proc.stdout).text(),
         new Response(proc.stderr).text(),
         proc.exited,
       ]);
       if (code !== 0) throw new Error(`pass show '${secretName}' failed (exit ${code})`);
-      await tmux.setEnvironment(session, key, secret.trimEnd());
+      await setEnvironment(session, key, secret.trimEnd());
     } else {
-      await tmux.setEnvironment(session, key, val);
+      await setEnvironment(session, key, val);
     }
   }
 }

--- a/test/peer-exec.test.ts
+++ b/test/peer-exec.test.ts
@@ -25,7 +25,6 @@ import {
   resolvePeerUrl,
   relayToPeer,
   createPeerExecApi,
-  peerExecApi,
 } from "../src/api/peer-exec";
 
 // ---- Pure helper tests ---------------------------------------------------
@@ -121,37 +120,38 @@ describe("isShellPeerAllowed", () => {
   });
 
   test("unknown origin is denied (no config.wormhole.shellPeers entry)", () => {
-    // The real config probably doesn't have any wormhole.shellPeers yet,
-    // so any origin returns false. This test locks that default.
-    expect(isShellPeerAllowed("some-random-host-xyz-does-not-exist")).toBe(false);
+    expect(isShellPeerAllowed("some-random-host-xyz-does-not-exist", {
+      loadConfig: () => ({ wormhole: { shellPeers: [] } }) as any,
+    })).toBe(false);
   });
 });
 
 describe("resolvePeerUrl", () => {
+  const noNamedPeers = { loadConfig: () => ({ namedPeers: [] }) as any };
+
   test("resolves a bare host:port to http://host:port", () => {
-    expect(resolvePeerUrl("10.20.0.7:3456")).toBe("http://10.20.0.7:3456");
-    expect(resolvePeerUrl("localhost:3457")).toBe("http://localhost:3457");
+    expect(resolvePeerUrl("10.20.0.7:3456", noNamedPeers)).toBe("http://10.20.0.7:3456");
+    expect(resolvePeerUrl("localhost:3457", noNamedPeers)).toBe("http://localhost:3457");
   });
 
   test("returns a full http:// URL unchanged", () => {
-    expect(resolvePeerUrl("http://oracle-world.example:3456")).toBe(
+    expect(resolvePeerUrl("http://oracle-world.example:3456", noNamedPeers)).toBe(
       "http://oracle-world.example:3456",
     );
   });
 
   test("returns a full https:// URL unchanged", () => {
-    expect(resolvePeerUrl("https://local.buildwithoracle.com")).toBe(
+    expect(resolvePeerUrl("https://local.buildwithoracle.com", noNamedPeers)).toBe(
       "https://local.buildwithoracle.com",
     );
   });
 
   test("returns null for an unknown bare peer name", () => {
-    // Assuming the real config doesn't have "ghost-peer-xyz" in namedPeers
-    expect(resolvePeerUrl("ghost-peer-xyz")).toBeNull();
+    expect(resolvePeerUrl("ghost-peer-xyz", noNamedPeers)).toBeNull();
   });
 
   test("returns null for empty input", () => {
-    expect(resolvePeerUrl("")).toBeNull();
+    expect(resolvePeerUrl("", noNamedPeers)).toBeNull();
   });
 });
 
@@ -227,7 +227,7 @@ describe("relayToPeer", () => {
 // Mount peerExecApi on an Elysia app so we can call it with app.handle().
 // This avoids booting the full server and keeps the tests deterministic.
 
-function makeApp() {
+function makeApp(deps: Parameters<typeof createPeerExecApi>[0] = {}) {
   return new Elysia({ prefix: "/api" })
     .onError(({ code, set }) => {
       if (code === "PARSE") {
@@ -235,7 +235,11 @@ function makeApp() {
         return { error: "invalid_body" };
       }
     })
-    .use(peerExecApi);
+    .use(createPeerExecApi({
+      isShellPeerAllowed: () => false,
+      resolvePeerUrl: () => null,
+      ...deps,
+    }));
 }
 
 // Force production mode so the cookie check is active (dev bypass off).

--- a/test/wake-resolve-impl-runtime-coverage.test.ts
+++ b/test/wake-resolve-impl-runtime-coverage.test.ts
@@ -73,6 +73,16 @@ const originalLog = console.log;
 const originalError = console.error;
 let spawnSpy: ReturnType<typeof spyOn> | null = null;
 
+function setSessionEnvTestDeps() {
+  return {
+    getEnvVars: () => envVars,
+    setEnvironment: async (session: string, key: string, val: string) => {
+      setEnvCalls.push({ session, key, val });
+    },
+    spawn: Bun.spawn,
+  };
+}
+
 mock.module(join(import.meta.dir, "../src/sdk"), () => ({
   ..._rSdk,
   FLEET_DIR: fleetRoot,
@@ -448,7 +458,7 @@ describe("setSessionEnv runtime paths", () => {
     envVars = { FOO: "bar", EMPTY: "" };
     spawnSpy = spyOn(Bun, "spawn");
 
-    await setSessionEnv("mysession");
+    await setSessionEnv("mysession", setSessionEnvTestDeps());
 
     expect(setEnvCalls).toEqual([
       { session: "mysession", key: "FOO", val: "bar" },
@@ -471,7 +481,7 @@ describe("setSessionEnv runtime paths", () => {
     };
     spawnSpy = spyOn(Bun, "spawn").mockReturnValue(fakeProc as any);
 
-    await setSessionEnv("mysession");
+    await setSessionEnv("mysession", setSessionEnvTestDeps());
 
     expect(spawnSpy).toHaveBeenCalledWith(["pass", "show", "path/to/secret"], { stdout: "pipe", stderr: "pipe" });
     expect(setEnvCalls).toEqual([{ session: "mysession", key: "SECRET", val: "resolved" }]);
@@ -491,7 +501,7 @@ describe("setSessionEnv runtime paths", () => {
     };
     spawnSpy = spyOn(Bun, "spawn").mockReturnValue(fakeProc as any);
 
-    await expect(setSessionEnv("mysession")).rejects.toThrow("pass show 'missing' failed (exit 2)");
+    await expect(setSessionEnv("mysession", setSessionEnvTestDeps())).rejects.toThrow("pass show 'missing' failed (exit 2)");
     expect(setEnvCalls).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary\n- add dependency seams for peer-exec config helpers and wake setSessionEnv\n- keep peer-exec route/helper tests off real/global config while mixed with coverage module mocks\n- preserve production behavior while making #1751 repro deterministic and fast\n\n## Validation\n- timeout 30s env MAW_TEST_MODE=1 bun test test/peers-transport-coverage.test.ts test/wake-resolve-impl-runtime-coverage.test.ts test/peer-exec.test.ts → 86 pass, 0 fail, 192ms\n- timeout 180s env MAW_TEST_MODE=1 bun test test/ --path-ignore-patterns "**/test/isolated/**" --path-ignore-patterns "**/zz-mock-tmux-smoke*" --path-ignore-patterns "**/agents/**" → 2041 pass, 6 skip, 0 fail, 27.62s\n- bun run build\n\nFixes #1751\n\nWritten by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.