### PR TITLE
fix(hey): prefer exact oracle session over stale window match

### DIFF
--- a/src/core/runtime/find-window.ts
+++ b/src/core/runtime/find-window.ts
@@ -83,19 +83,28 @@ export function findWindow(sessions: Session[], query: string): string | null {
   }
 
   // Two-pass bare-name resolution (#414):
-  //   Pass 1 collects exact matches (window name, session name, stripped
-  //   oracle-name). Pass 2 collects substring matches only if Pass 1 was
-  //   empty. Multi-candidate in either pass → AmbiguousMatchError.
+  //   Pass 1a collects exact session/oracle-name matches. These beat exact
+  //   window-name matches because a stale session may still have a window named
+  //   `<name>-oracle` while the live session itself is named `NN-<name>-oracle`
+  //   (#1752). Pass 1b collects exact window matches only when no exact session
+  //   match exists. Pass 2 collects substring matches only if Pass 1 was empty.
+  //   Multi-candidate inside any pass → AmbiguousMatchError.
+  const exactSessions = new Set<string>();
+  for (const s of sessions) {
+    if (s.windows.length > 0) {
+      const sn = s.name.toLowerCase();
+      if (sn === q || sn.replace(/^\d+-/, "") === q) {
+        exactSessions.add(`${s.name}:${s.windows[0].index}`);
+      }
+    }
+  }
+  if (exactSessions.size === 1) return [...exactSessions][0];
+  if (exactSessions.size > 1) throw new AmbiguousMatchError(query, [...exactSessions]);
+
   const exact = new Set<string>();
   for (const s of sessions) {
     for (const w of s.windows) {
       if (w.name.toLowerCase() === q) exact.add(`${s.name}:${w.index}`);
-    }
-    if (s.windows.length > 0) {
-      const sn = s.name.toLowerCase();
-      if (sn === q || sn.replace(/^\d+-/, "") === q) {
-        exact.add(`${s.name}:${s.windows[0].index}`);
-      }
     }
   }
   if (exact.size === 1) return [...exact][0];

--- a/test/00-ssh.test.ts
+++ b/test/00-ssh.test.ts
@@ -121,6 +121,19 @@ describe("findWindow", () => {
       // session name too (dedup keeps them consistent).
       expect(findWindow(MOTHER_SESSIONS, "view")).toBe("mother-view:1");
     });
+
+    test("bare '<name>-oracle' exact session match beats stale exact window matches (#1752)", () => {
+      const odin: Session[] = [
+        { name: "38-odin", windows: [
+          { index: 1, name: "odin-oracle", active: false },
+        ]},
+        { name: "61-odin-oracle", windows: [
+          { index: 1, name: "odin-oracle", active: true },
+        ]},
+      ];
+
+      expect(findWindow(odin, "odin-oracle")).toBe("61-odin-oracle:1");
+    });
   });
 
   describe("session:window syntax (#186)", () => {

--- a/test/routing.test.ts
+++ b/test/routing.test.ts
@@ -94,6 +94,15 @@ describe("resolveTarget", () => {
     expect(r).toEqual({ type: "self-node", target: "08-mawjs:1" });
   });
 
+  test("local:<name>-oracle exact session wins over stale same-name window (#1752)", () => {
+    const sessions: Session[] = [
+      { name: "38-odin", windows: [{ index: 1, name: "odin-oracle", active: false }] },
+      { name: "61-odin-oracle", windows: [{ index: 1, name: "odin-oracle", active: true }] },
+    ];
+    const r = resolveTarget("local:odin-oracle", BASE_CONFIG, sessions);
+    expect(r).toEqual({ type: "self-node", target: "61-odin-oracle:1" });
+  });
+
   test("local: prefix miss is local/self miss, not unknown peer", () => {
     const r = resolveTarget("local:ghost", BASE_CONFIG, SESSIONS);
     expect(r).toMatchObject({ type: "error", reason: "self_not_running" });


### PR DESCRIPTION
## Summary
- split findWindow bare exact matching into exact session/oracle-name first, then exact window-name
- fixes #1752 shape where live `61-odin-oracle` should beat stale `38-odin` that still has an `odin-oracle` window
- preserves the #406 guard: duplicate exact windows still throw when no exact session identity resolves the query

## Validation
- `timeout 30s env MAW_TEST_MODE=1 bun test test/00-ssh.test.ts test/routing.test.ts test/routing-session-alias.test.ts` → 54 pass, 0 fail, 171ms
- `timeout 180s env MAW_TEST_MODE=1 bun test test/ --path-ignore-patterns "**/test/isolated/**" --path-ignore-patterns "**/zz-mock-tmux-smoke*" --path-ignore-patterns "**/agents/**"` → 2043 pass, 6 skip, 0 fail, 27.33s
- `bun run build`

Fixes #1752

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
