### PR TITLE
test: cover Claude session discovery

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,13 +1,13 @@
 # Coverage gap analysis
 
-Generated: 2026-05-17T09:54:45.572Z
+Generated: 2026-05-17T10:12:44.328Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **28.1%** (14130/50313)
-Overall function coverage: **78.8%** (1604/2035)
+Overall line coverage: **28.3%** (14239/50316)
+Overall function coverage: **79.2%** (1619/2045)
 
 ## Module summary
 
@@ -15,7 +15,7 @@ Overall function coverage: **78.8%** (1604/2035)
 | --- | ---: | ---: | ---: | ---: | ---: |
 | cli/dispatch | 90 | 15 | 57.9% (4273/7384) | 77.0% (411/534) | n/a (0/0) |
 | config/runtime | 19 | 2 | 66.0% (770/1167) | 72.9% (70/96) | n/a (0/0) |
-| fleet | 17 | 0 | 37.1% (394/1061) | 54.4% (37/68) | n/a (0/0) |
+| fleet | 17 | 0 | 47.3% (503/1064) | 66.7% (52/78) | n/a (0/0) |
 | matcher | 2 | 0 | 100.0% (41/41) | 100.0% (8/8) | n/a (0/0) |
 | other | 174 | 69 | 36.7% (5290/14413) | 74.4% (569/765) | n/a (0/0) |
 | plugin dispatch | 15 | 1 | 69.8% (849/1217) | 83.8% (67/80) | n/a (0/0) |
@@ -139,7 +139,6 @@ Overall function coverage: **78.8%** (1604/2035)
 
 | Module | File | Uncovered | Line coverage |
 | --- | --- | ---: | ---: |
-| fleet | `src/core/fleet/claude-sessions.ts` | 150 | 5.7% |
 | transport | `src/core/transport/pty.ts` | 150 | 0.0% |
 | routing/aliases | `src/cli/top-aliases.ts` | 148 | 40.8% |
 | plugin dispatch | `src/plugin/registry.ts` | 147 | 8.1% |
@@ -149,6 +148,7 @@ Overall function coverage: **78.8%** (1604/2035)
 | cli/dispatch | `src/commands/shared/workspace-lifecycle.ts` | 120 | 4.0% |
 | cli/dispatch | `src/commands/shared/federation-sync-cli.ts` | 116 | 10.8% |
 | cli/dispatch | `src/commands/shared/preflight.ts` | 105 | 2.8% |
+| cli/dispatch | `src/commands/shared/queue-store.ts` | 104 | 11.1% |
 
 ## Critical gaps to prioritize
 

--- a/src/core/fleet/claude-sessions.ts
+++ b/src/core/fleet/claude-sessions.ts
@@ -12,6 +12,11 @@ import { join, resolve } from "path";
 import { homedir } from "os";
 import { execSync } from "child_process";
 
+type ExecSyncString = (
+  command: string,
+  options?: { encoding: BufferEncoding; timeout?: number; maxBuffer?: number },
+) => string;
+
 export interface ClaudeSession {
   sessionId: string;
   projectPath: string;
@@ -31,6 +36,12 @@ export interface ClaudeSession {
 
 interface PidInfo { pid: number; ppid: number; cwd: string; command: string }
 
+export interface ClaudeSessionDeps {
+  execSync?: ExecSyncString;
+}
+
+const defaultExecSync = execSync as ExecSyncString;
+
 // ── Path encoding ────────────────────────────────────────────────
 
 /** Decode Claude Code project dir name → absolute path. */
@@ -43,13 +54,13 @@ export function decodeProjectDir(encoded: string): string {
 
 let pidCache: { data: PidInfo[]; ts: number } | null = null;
 
-function listClaudePids(): PidInfo[] {
+function listClaudePids(exec: ExecSyncString): PidInfo[] {
   if (process.env.MAW_CLAUDE_SKIP_PID_SCAN === "1") return [];
   const now = Date.now();
   if (pidCache && now - pidCache.ts < 5_000) return pidCache.data;
   const results: PidInfo[] = [];
   try {
-    const raw = execSync(`ps -eo pid,ppid,command 2>/dev/null | grep '[c]laude'`, {
+    const raw = exec(`ps -eo pid,ppid,command 2>/dev/null | grep '[c]laude'`, {
       encoding: "utf-8", timeout: 3000,
     });
     for (const line of raw.split("\n").filter(Boolean)) {
@@ -59,8 +70,8 @@ function listClaudePids(): PidInfo[] {
       let cwd = "";
       try {
         cwd = process.platform === "linux"
-          ? execSync(`readlink /proc/${pidStr}/cwd 2>/dev/null`, { encoding: "utf-8", timeout: 1000 }).trim()
-          : execSync(`lsof -p ${pidStr} -Fn 2>/dev/null | grep '^n/' | head -1`, { encoding: "utf-8", timeout: 2000 }).replace(/^n/, "").trim();
+          ? exec(`readlink /proc/${pidStr}/cwd 2>/dev/null`, { encoding: "utf-8", timeout: 1000 }).trim()
+          : exec(`lsof -p ${pidStr} -Fn 2>/dev/null | grep '^n/' | head -1`, { encoding: "utf-8", timeout: 2000 }).replace(/^n/, "").trim();
       } catch { /* cwd not resolvable */ }
       if (cwd) results.push({ pid: +pidStr, ppid: +ppidStr, cwd, command });
     }
@@ -71,14 +82,17 @@ function listClaudePids(): PidInfo[] {
 
 // ── Parent chain + trigger classification ────────────────────────
 
-function classifyTrigger(ppid: number): { chain: string[]; trigger: ClaudeSession["triggeredFrom"] } {
+function classifyTrigger(
+  ppid: number,
+  exec: ExecSyncString,
+): { chain: string[]; trigger: ClaudeSession["triggeredFrom"] } {
   const chain: string[] = [];
   let cur = ppid;
   const seen = new Set<number>();
   for (let i = 0; i < 10 && cur > 1 && !seen.has(cur); i++) {
     seen.add(cur);
     try {
-      const info = execSync(`ps -o comm=,ppid= -p ${cur} 2>/dev/null`, { encoding: "utf-8", timeout: 1000 }).trim();
+      const info = exec(`ps -o comm=,ppid= -p ${cur} 2>/dev/null`, { encoding: "utf-8", timeout: 1000 }).trim();
       const parts = info.split(/\s+/);
       const comm = parts.slice(0, -1).join(" ");
       cur = +(parts.at(-1) || "0");
@@ -95,16 +109,16 @@ function classifyTrigger(ppid: number): { chain: string[]; trigger: ClaudeSessio
 
 // ── Git helpers ──────────────────────────────────────────────────
 
-function resolveRepo(cwd: string): string | null {
+function resolveRepo(cwd: string, exec: ExecSyncString): string | null {
   try {
-    return execSync(`git -C '${cwd}' remote get-url origin 2>/dev/null`, { encoding: "utf-8", timeout: 2000 })
+    return exec(`git -C '${cwd}' remote get-url origin 2>/dev/null`, { encoding: "utf-8", timeout: 2000 })
       .trim().replace(/^(ssh:\/\/)?git@/, "").replace(/^https?:\/\//, "").replace(/:/, "/").replace(/\.git$/, "");
   } catch { return null; }
 }
 
-function resolveWorktree(cwd: string): ClaudeSession["worktree"] {
+function resolveWorktree(cwd: string, exec: ExecSyncString): ClaudeSession["worktree"] {
   try {
-    const raw = execSync(`git -C '${cwd}' worktree list --porcelain 2>/dev/null`, { encoding: "utf-8", timeout: 2000 });
+    const raw = exec(`git -C '${cwd}' worktree list --porcelain 2>/dev/null`, { encoding: "utf-8", timeout: 2000 });
     for (const block of raw.split("\n\n").filter(Boolean)) {
       const lines = block.split("\n");
       const wt = lines.find(l => l.startsWith("worktree "))?.slice(9);
@@ -117,11 +131,14 @@ function resolveWorktree(cwd: string): ClaudeSession["worktree"] {
 
 // ── Last-message extraction (tail-based, avoids full read) ───────
 
-function extractLastMessages(filePath: string): { lastUser: string | null; lastAssistant: string | null } {
+function extractLastMessages(
+  filePath: string,
+  exec: ExecSyncString,
+): { lastUser: string | null; lastAssistant: string | null } {
   let lastUser: string | null = null;
   let lastAssistant: string | null = null;
   try {
-    const tail = execSync(`tail -100 '${filePath}' 2>/dev/null`, {
+    const tail = exec(`tail -100 '${filePath}' 2>/dev/null`, {
       encoding: "utf-8", timeout: 2000, maxBuffer: 512 * 1024,
     });
     for (const line of tail.split("\n").filter(Boolean).reverse()) {
@@ -149,16 +166,22 @@ function extractLastMessages(filePath: string): { lastUser: string | null; lastA
 
 let sessionCache: { data: ClaudeSession[]; ts: number } | null = null;
 
+export function __resetClaudeSessionCachesForTests(): void {
+  pidCache = null;
+  sessionCache = null;
+}
+
 function claudeProjectsDir(): string {
   return process.env.MAW_CLAUDE_PROJECTS_DIR || join(homedir(), ".claude", "projects");
 }
 
-export async function listClaudeSessions(): Promise<ClaudeSession[]> {
+export async function listClaudeSessions(deps: ClaudeSessionDeps = {}): Promise<ClaudeSession[]> {
+  const exec = deps.execSync ?? defaultExecSync;
   const now = Date.now();
   if (sessionCache && now - sessionCache.ts < 5_000) return sessionCache.data;
 
   const claudeDir = claudeProjectsDir();
-  const pids = listClaudePids();
+  const pids = listClaudePids(exec);
   const pidByCwd = new Map(pids.map(p => [p.cwd, p]));
   const results: ClaudeSession[] = [];
 
@@ -189,18 +212,18 @@ export async function listClaudeSessions(): Promise<ClaudeSession[]> {
         : "ended";
 
       const { chain, trigger } = pidInfo
-        ? classifyTrigger(pidInfo.ppid)
+        ? classifyTrigger(pidInfo.ppid, exec)
         : { chain: [] as string[], trigger: "unknown" as const };
 
       const tmuxTarget = chain.some(c => c.toLowerCase().includes("tmux"))
         ? `(tmux: ${projectPath.split("/").pop()})` : null;
 
-      const { lastUser, lastAssistant } = extractLastMessages(filePath);
+      const { lastUser, lastAssistant } = extractLastMessages(filePath, exec);
 
       results.push({
         sessionId, projectPath,
-        repo: resolveRepo(projectPath),
-        worktree: resolveWorktree(projectPath),
+        repo: resolveRepo(projectPath, exec),
+        worktree: resolveWorktree(projectPath, exec),
         pid: pidInfo?.pid ?? null,
         ppid: pidInfo?.ppid ?? null,
         parentChain: chain, tmuxTarget, triggeredFrom: trigger, status,

--- a/test/claude-sessions-default.test.ts
+++ b/test/claude-sessions-default.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  utimesSync,
+  writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { execFileSync } from "child_process";
+import {
+  type ClaudeSessionDeps,
+  __resetClaudeSessionCachesForTests,
+  decodeProjectDir,
+  listClaudeSessions,
+} from "../src/core/fleet/claude-sessions";
+
+const originalProjectsDir = process.env.MAW_CLAUDE_PROJECTS_DIR;
+const originalSkipPidScan = process.env.MAW_CLAUDE_SKIP_PID_SCAN;
+const created: string[] = [];
+
+function restoreEnv() {
+  if (originalProjectsDir === undefined) delete process.env.MAW_CLAUDE_PROJECTS_DIR;
+  else process.env.MAW_CLAUDE_PROJECTS_DIR = originalProjectsDir;
+
+  if (originalSkipPidScan === undefined) delete process.env.MAW_CLAUDE_SKIP_PID_SCAN;
+  else process.env.MAW_CLAUDE_SKIP_PID_SCAN = originalSkipPidScan;
+}
+
+function tempPath(name: string): string {
+  const path = join(
+    realpathSync(tmpdir()),
+    `mawcs${process.pid}${Date.now()}${Math.random().toString(36).slice(2)}${name}`,
+  );
+  created.push(path);
+  return path;
+}
+
+function encodeProjectPath(path: string): string {
+  return path.replace(/^\//, "-").replace(/[/.]/g, "-");
+}
+
+function writeSession(
+  projectsRoot: string,
+  projectPath: string,
+  sessionId: string,
+  ageMs: number,
+  body = "",
+): string {
+  const dir = join(projectsRoot, encodeProjectPath(projectPath));
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, `${sessionId}.jsonl`);
+  writeFileSync(file, body);
+  const d = new Date(Date.now() - ageMs);
+  utimesSync(file, d, d);
+  return file;
+}
+
+function initGitRepo(path: string) {
+  mkdirSync(path, { recursive: true });
+  execFileSync("git", ["init"], { cwd: path, stdio: "ignore" });
+  execFileSync("git", ["checkout", "-B", "main"], { cwd: path, stdio: "ignore" });
+  writeFileSync(join(path, "README.md"), "fixture\n");
+  execFileSync("git", ["add", "README.md"], { cwd: path, stdio: "ignore" });
+  execFileSync(
+    "git",
+    ["-c", "user.name=maw-test", "-c", "user.email=maw-test@example.invalid", "commit", "-m", "fixture"],
+    { cwd: path, stdio: "ignore" },
+  );
+  execFileSync("git", ["remote", "add", "origin", "git@github.com:Org/claude-repo.git"], {
+    cwd: path,
+    stdio: "ignore",
+  });
+}
+
+const execSyncFixture: NonNullable<ClaudeSessionDeps["execSync"]> = (cmd) => {
+  const remoteMatch = cmd.match(/^git -C '([^']+)' remote get-url origin/);
+  if (remoteMatch) {
+    return execFileSync("git", ["-C", remoteMatch[1], "remote", "get-url", "origin"], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  }
+
+  const worktreeMatch = cmd.match(/^git -C '([^']+)' worktree list --porcelain/);
+  if (worktreeMatch) {
+    return execFileSync("git", ["-C", worktreeMatch[1], "worktree", "list", "--porcelain"], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  }
+
+  const tailMatch = cmd.match(/^tail -100 '([^']+)'/);
+  if (tailMatch) return readFileSync(tailMatch[1], "utf-8").split("\n").slice(-100).join("\n");
+
+  throw new Error(`unexpected fixture exec: ${cmd}`);
+};
+
+beforeEach(() => {
+  __resetClaudeSessionCachesForTests();
+  process.env.MAW_CLAUDE_SKIP_PID_SCAN = "1";
+});
+
+afterEach(() => {
+  __resetClaudeSessionCachesForTests();
+  restoreEnv();
+  while (created.length) rmSync(created.pop()!, { recursive: true, force: true });
+});
+
+describe("Claude session discovery default-suite coverage", () => {
+  test("decodeProjectDir mirrors Claude's path encoding", () => {
+    expect(decodeProjectDir("plain-name")).toBe("plain-name");
+    expect(decodeProjectDir("-opt-Code-repo")).toBe("/opt/Code/repo");
+  });
+
+  test("missing project root is fail-soft and deterministic when PID scan is disabled", async () => {
+    process.env.MAW_CLAUDE_PROJECTS_DIR = join(tempPath("missing"), "projects");
+    await expect(listClaudeSessions({ execSync: execSyncFixture })).resolves.toEqual([]);
+  });
+
+  test("scans recent JSONL sessions, extracts git metadata and messages, filters stale/noisy entries, and caches results", async () => {
+    const root = tempPath("root");
+    const projectsRoot = join(root, "claude", "projects");
+    const repoPath = join(root, "repo");
+    const nonGitProject = join(root, "nogit");
+    initGitRepo(repoPath);
+    mkdirSync(nonGitProject, { recursive: true });
+    process.env.MAW_CLAUDE_PROJECTS_DIR = projectsRoot;
+
+    const userMessage = "user ".repeat(60);
+    const assistantMessage = "assistant ".repeat(40);
+    const newestBody = [
+      JSON.stringify({ type: "user", message: { content: "older user" } }),
+      JSON.stringify({
+        type: "assistant",
+        message: { content: [{ type: "text", text: assistantMessage }] },
+      }),
+      JSON.stringify({ type: "user", message: { content: [{ type: "text", text: userMessage }] } }),
+      "{malformed json",
+    ].join("\n");
+    writeSession(projectsRoot, repoPath, "newest", 1_000, newestBody);
+    writeSession(projectsRoot, nonGitProject, "older", 5_000, "");
+
+    const noisyDir = join(projectsRoot, encodeProjectPath(nonGitProject));
+    writeFileSync(join(noisyDir, "older-subagents.jsonl"), "ignored");
+    writeFileSync(join(noisyDir, "notes.txt"), "ignored");
+    const stale = join(noisyDir, "stale.jsonl");
+    writeFileSync(stale, "too old");
+    const old = new Date(Date.now() - 2 * 86_400_000);
+    utimesSync(stale, old, old);
+    symlinkSync("/definitely/missing", join(noisyDir, "missing-stat.jsonl"));
+    writeFileSync(join(projectsRoot, "-not-a-directory"), "forces readdir failure");
+    writeFileSync(join(projectsRoot, "plain-name"), "filtered before readdir");
+
+    const sessions = await listClaudeSessions({ execSync: execSyncFixture });
+    const cached = await listClaudeSessions({ execSync: execSyncFixture });
+
+    expect(cached).toBe(sessions);
+    expect(sessions.map((s) => s.sessionId)).toEqual(["newest", "older"]);
+    expect(sessions[0]).toMatchObject({
+      projectPath: repoPath,
+      repo: "github.com/Org/claude-repo",
+      worktree: { name: repoPath.split("/").pop(), branch: "main" },
+      pid: null,
+      ppid: null,
+      parentChain: [],
+      tmuxTarget: null,
+      triggeredFrom: "unknown",
+      status: "ended",
+      lastUserMessage: userMessage.slice(0, 200),
+      lastAssistantMessage: assistantMessage.slice(0, 200),
+    });
+    expect(sessions[0].sizeBytes).toBeGreaterThan(0);
+    expect(sessions[0].lastActivityAt).toMatch(/T/);
+    expect(sessions[1]).toMatchObject({
+      projectPath: nonGitProject,
+      repo: null,
+      worktree: null,
+      lastUserMessage: null,
+      lastAssistantMessage: null,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add deterministic default-suite coverage for Claude session discovery and JSONL scanning
- add a tiny test cache reset seam for claude-sessions so default tests do not leak cached state
- refresh coverage gap analysis; fleet coverage rises and claude-sessions leaves the critical top-gap table

## Verification
- MAW_TEST_MODE=1 bun test test/claude-sessions-default.test.ts
- targeted coverage: src/core/fleet/claude-sessions.ts at 83.33% functions / 73.38% lines
- MAW_TEST_MODE=1 bun run test:coverage — 2054 pass, 6 skip, 0 fail
- bun run build

Refs #1637

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
