### PR TITLE
test(coverage): cover top-level alias dispatch

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,13 +1,13 @@
 # Coverage gap analysis
 
-Generated: 2026-05-17T10:12:44.328Z
+Generated: 2026-05-17T10:25:01.887Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **28.3%** (14239/50316)
-Overall function coverage: **79.2%** (1619/2045)
+Overall line coverage: **28.6%** (14365/50294)
+Overall function coverage: **79.3%** (1625/2048)
 
 ## Module summary
 
@@ -19,7 +19,7 @@ Overall function coverage: **79.2%** (1619/2045)
 | matcher | 2 | 0 | 100.0% (41/41) | 100.0% (8/8) | n/a (0/0) |
 | other | 174 | 69 | 36.7% (5290/14413) | 74.4% (569/765) | n/a (0/0) |
 | plugin dispatch | 15 | 1 | 69.8% (849/1217) | 83.8% (67/80) | n/a (0/0) |
-| routing/aliases | 4 | 0 | 69.2% (456/659) | 90.0% (63/70) | n/a (0/0) |
+| routing/aliases | 4 | 0 | 91.4% (582/637) | 94.5% (69/73) | n/a (0/0) |
 | transport | 28 | 2 | 77.8% (1876/2410) | 93.1% (363/390) | n/a (0/0) |
 | vendor plugins | 245 | 243 | 0.8% (181/21961) | 66.7% (16/24) | n/a (0/0) |
 
@@ -113,6 +113,7 @@ Overall function coverage: **79.2%** (1619/2045)
 | plugin dispatch | `src/plugin/registry-semver.ts` | 100.0% | 100.0% |
 | plugin dispatch | `src/plugin/tier.ts` | 100.0% | 100.0% |
 | routing/aliases | `src/cli/route-tools.ts` | 100.0% | 100.0% |
+| routing/aliases | `src/cli/top-aliases.ts` | 100.0% | 100.0% |
 | routing/aliases | `src/core/routing.ts` | 89.1% | 91.7% |
 | transport | `src/core/transport/peers.ts` | 100.0% | 100.0% |
 | transport | `src/core/transport/tmux-class.ts` | 90.3% | 97.5% |
@@ -140,7 +141,6 @@ Overall function coverage: **79.2%** (1619/2045)
 | Module | File | Uncovered | Line coverage |
 | --- | --- | ---: | ---: |
 | transport | `src/core/transport/pty.ts` | 150 | 0.0% |
-| routing/aliases | `src/cli/top-aliases.ts` | 148 | 40.8% |
 | plugin dispatch | `src/plugin/registry.ts` | 147 | 8.1% |
 | cli/dispatch | `src/commands/shared/fleet-wake.ts` | 146 | 0.0% |
 | cli/dispatch | `src/commands/shared/pulse-cmd.ts` | 134 | 0.0% |
@@ -149,6 +149,7 @@ Overall function coverage: **79.2%** (1619/2045)
 | cli/dispatch | `src/commands/shared/federation-sync-cli.ts` | 116 | 10.8% |
 | cli/dispatch | `src/commands/shared/preflight.ts` | 105 | 2.8% |
 | cli/dispatch | `src/commands/shared/queue-store.ts` | 104 | 11.1% |
+| cli/dispatch | `src/commands/shared/fleet-manage.ts` | 101 | 0.0% |
 
 ## Critical gaps to prioritize
 

--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -113,7 +113,10 @@ export function resolveTopAlias(args: string[]): AliasResolution | null {
   return { kind: "direct", handler: entry.handler, argv: args.slice(1) };
 }
 
-export function parseBringArgs(argv: string[]): {
+export function parseBringArgs(
+  argv: string[],
+  writeUsage: (line: string) => void = console.error,
+): {
   oracle: string;
   opts: { bring?: true; split?: boolean; tab?: boolean; engine?: string };
 } {
@@ -129,7 +132,7 @@ export function parseBringArgs(argv: string[]): {
   }, 0);
   const oracle = (flags._ as string[])[0];
   if (!oracle) {
-    printBringUsage(console.error);
+    printBringUsage(writeUsage);
     throw new UserError("bring: missing oracle name");
   }
   const opts: { bring?: true; split?: boolean; tab?: boolean; engine?: string } = flags["--tab"]
@@ -217,24 +220,44 @@ export function parseLsAliasOpts(argv: string[]) {
   return opts;
 }
 
+type MaybePromise<T = unknown> = T | Promise<T>;
+
+export interface TopAliasHandlerDeps {
+  cmdTmuxLs?: (opts: ReturnType<typeof parseLsAliasOpts>) => MaybePromise;
+  cmdWake?: (oracle: string, opts: Record<string, unknown>) => MaybePromise;
+  cmdNew?: (argv: string[]) => MaybePromise;
+  cmdPreflight?: (opts: { fix: boolean }) => MaybePromise;
+  loadConfig?: () => { commands?: Record<string, unknown> };
+  log?: (line: string) => void;
+  error?: (line: string) => void;
+}
+
 export async function invokeDirectHandler(
   handler: string,
   argv: string[],
+  deps: TopAliasHandlerDeps = {},
 ): Promise<void> {
   const exportName = handler.includes(":") ? handler.split(":")[1] : handler;
   if (!exportName) {
     throw new Error(`top-alias: malformed handler spec '${handler}' — expected '<module>:<export>' or name`);
   }
 
+  const directCmdTmuxLs = deps.cmdTmuxLs ?? cmdTmuxLs;
+  const directCmdWake = deps.cmdWake ?? cmdWake;
+  const directCmdNew = deps.cmdNew ?? cmdNew;
+  const directCmdPreflight = deps.cmdPreflight ?? cmdPreflight;
+  const log = deps.log ?? console.log;
+  const error = deps.error ?? console.error;
+
   if (exportName === "cmdLs") {
-    await cmdTmuxLs(parseLsAliasOpts(argv));
+    await directCmdTmuxLs(parseLsAliasOpts(argv));
     return;
   }
 
   if (exportName === "cmdWake" || exportName === "cmdAwake") {
     const verb = exportName === "cmdAwake" ? "awake" : "wake";
     if (argv.some(a => a === "-h" || a === "--help" || a === "-help")) {
-      printWakeAliasUsage(verb);
+      printWakeAliasUsage(verb, log);
       return;
     }
 
@@ -261,7 +284,7 @@ export async function invokeDirectHandler(
     const positional = flags._;
     const oracle = positional[0];
     if (!oracle) {
-      printWakeAliasUsage(verb, console.error);
+      printWakeAliasUsage(verb, error);
       throw new UserError(`${verb}: missing oracle name`);
     }
 
@@ -308,7 +331,7 @@ export async function invokeDirectHandler(
     // Shorthand: --codex, --gemini etc. → engine from config.commands
     // Unknown flags land in flags._ (permissive mode), so scan for --<engine>
     if (!opts.engine) {
-      const { loadConfig } = await import("../config");
+      const loadConfig = deps.loadConfig ?? (await import("../config")).loadConfig;
       const commands = loadConfig().commands || {};
       for (const arg of (flags._ as string[])) {
         if (arg.startsWith("--") && commands[arg.slice(2)]) {
@@ -318,7 +341,7 @@ export async function invokeDirectHandler(
       }
     }
 
-    await cmdWake(oracle, opts);
+    await directCmdWake(oracle, opts);
     return;
   }
 
@@ -326,22 +349,22 @@ export async function invokeDirectHandler(
     // `maw bring <oracle>` defaults to the v1 current-pane split path.
     // `--tab` opts into the non-destructive background tmux-window path.
     if (argv.some(a => a === "-h" || a === "--help" || a === "-help")) {
-      printBringUsage();
+      printBringUsage(log);
       return;
     }
-    const { oracle, opts } = parseBringArgs(argv);
-    await cmdWake(oracle, opts);
+    const { oracle, opts } = parseBringArgs(argv, error);
+    await directCmdWake(oracle, opts);
     return;
   }
 
   if (exportName === "cmdNew") {
-    await cmdNew(argv);
+    await directCmdNew(argv);
     return;
   }
 
   if (exportName === "cmdPreflight") {
     const flags = parseFlags(argv, { "--fix": Boolean }, 0);
-    await cmdPreflight({ fix: !!flags["--fix"] });
+    await directCmdPreflight({ fix: !!flags["--fix"] });
     return;
   }
 

--- a/test/top-aliases-default.test.ts
+++ b/test/top-aliases-default.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ALIAS_DESCRIPTIONS,
+  invokeDirectHandler,
+  parseBringArgs,
+  parseLsAliasOpts,
+  resolveTopAlias,
+  type TopAliasHandlerDeps,
+} from "../src/cli/top-aliases";
+import { UserError } from "../src/core/util/user-error";
+
+function makeDeps() {
+  const calls = {
+    tmuxLs: [] as unknown[],
+    wake: [] as unknown[][],
+    new: [] as unknown[][],
+    preflight: [] as unknown[],
+    loadConfig: 0,
+    logs: [] as string[],
+    errors: [] as string[],
+  };
+  const deps: TopAliasHandlerDeps = {
+    cmdTmuxLs: async (opts) => { calls.tmuxLs.push(opts); },
+    cmdWake: async (...args) => { calls.wake.push(args); },
+    cmdNew: async (...args) => { calls.new.push(args); },
+    cmdPreflight: async (opts) => { calls.preflight.push(opts); },
+    loadConfig: () => {
+      calls.loadConfig += 1;
+      return { commands: { codex: "codex", spark: "spark" } };
+    },
+    log: (line) => { calls.logs.push(line); },
+    error: (line) => { calls.errors.push(line); },
+  };
+  return { calls, deps };
+}
+
+describe("top alias resolution table", () => {
+  test("empty, blank, and unknown argv do not resolve", () => {
+    expect(resolveTopAlias([])).toBeNull();
+    expect(resolveTopAlias([""])).toBeNull();
+    expect(resolveTopAlias(["unknown"])).toBeNull();
+  });
+
+  test("argv rewrite aliases preserve remaining argv", () => {
+    const cases: Array<[string[], string[]]> = [
+      [["A", "neo"], ["tmux", "attach", "neo"]],
+      [["kill", "pane"], ["tmux", "kill", "pane"]],
+      [["split", "target"], ["split", "target"]],
+      [["open", "target"], ["tmux", "open", "target"]],
+      [["close", "target"], ["tmux", "close", "target"]],
+      [["t", "send"], ["team", "send"]],
+      [["layout", "tiled"], ["team", "layout", "tiled"]],
+      [["zoom", "42"], ["tmux", "zoom", "42"]],
+      [["panes"], ["tmux", "ls", "--all", "--verbose"]],
+      [["cleanup"], ["team", "cleanup", "--zombie-agents"]],
+      [["tile", "4"], ["tile", "4"]],
+      [["scaffold", "neo"], ["bud", "--scaffold-only", "neo"]],
+      [["snapshots", "list"], ["fleet", "snapshots", "list"]],
+    ];
+
+    for (const [input, expected] of cases) {
+      expect(resolveTopAlias(input)).toEqual({ kind: "argv", argv: expected });
+    }
+    expect(ALIAS_DESCRIPTIONS.cleanup).toContain("zombie");
+    expect(ALIAS_DESCRIPTIONS.bring).toContain("Bring");
+  });
+
+  test("direct aliases return handler specs and trimmed argv", () => {
+    expect(resolveTopAlias(["ls", "-v"])).toEqual({ kind: "direct", handler: "cmdLs", argv: ["-v"] });
+    expect(resolveTopAlias(["bring", "neo"])).toEqual({
+      kind: "direct",
+      handler: "../commands/shared/wake-cmd:cmdBring",
+      argv: ["neo"],
+    });
+    expect(resolveTopAlias(["b", "neo"])).toEqual({
+      kind: "direct",
+      handler: "../commands/shared/wake-cmd:cmdBring",
+      argv: ["neo"],
+    });
+    expect(resolveTopAlias(["wake", "neo"])).toEqual({
+      kind: "direct",
+      handler: "../commands/shared/wake-cmd:cmdWake",
+      argv: ["neo"],
+    });
+    expect(resolveTopAlias(["awake", "neo"])).toEqual({
+      kind: "direct",
+      handler: "../commands/shared/wake-cmd:cmdAwake",
+      argv: ["neo"],
+    });
+    expect(resolveTopAlias(["new", "workspace"])).toEqual({
+      kind: "direct",
+      handler: "./cmd-new:cmdNew",
+      argv: ["workspace"],
+    });
+    expect(resolveTopAlias(["preflight", "--fix"])).toEqual({
+      kind: "direct",
+      handler: "../commands/shared/preflight:cmdPreflight",
+      argv: ["--fix"],
+    });
+  });
+});
+
+describe("top alias option parsers", () => {
+  test("ls opts cover compact defaults, verbose, roster, json, and recent limits", () => {
+    expect(parseLsAliasOpts([])).toEqual({
+      all: true,
+      compact: true,
+      verbose: false,
+      roster: false,
+      json: false,
+    });
+    expect(parseLsAliasOpts(["--json", "--all", "--recent", "12", "--compact", "--verbose"])).toEqual({
+      all: true,
+      compact: true,
+      verbose: false,
+      roster: true,
+      json: true,
+      recent: true,
+      recentLimit: 12,
+    });
+    expect(parseLsAliasOpts(["--recent", "0"])).toEqual({
+      all: true,
+      compact: true,
+      verbose: false,
+      roster: false,
+      json: false,
+      recent: true,
+    });
+    expect(parseLsAliasOpts(["-v"])).toEqual({
+      all: true,
+      compact: false,
+      verbose: true,
+      roster: false,
+      json: false,
+    });
+  });
+
+  test("bring opts default to split, let tab win, and reject missing oracle", () => {
+    expect(parseBringArgs(["neo", "--tab", "--split", "-e", "codex"])).toEqual({
+      oracle: "neo",
+      opts: { bring: true, tab: true, engine: "codex" },
+    });
+    expect(parseBringArgs(["neo"])).toEqual({ oracle: "neo", opts: { split: true } });
+
+    const errors: string[] = [];
+    expect(() => parseBringArgs(["--tab"], (line) => errors.push(line))).toThrow(UserError);
+    expect(errors.join("\n")).toContain("usage: maw bring");
+  });
+});
+
+describe("direct handler invocation", () => {
+  test("cmdLs dispatches parsed options to tmux ls", async () => {
+    const { calls, deps } = makeDeps();
+
+    await invokeDirectHandler("cmdLs", ["--json", "-r", "5", "-v"], deps);
+
+    expect(calls.tmuxLs).toEqual([{
+      all: true,
+      compact: false,
+      verbose: true,
+      roster: false,
+      json: true,
+      recent: true,
+      recentLimit: 5,
+    }]);
+  });
+
+  test("wake help prints usage without invoking wake", async () => {
+    const { calls, deps } = makeDeps();
+
+    await invokeDirectHandler("../commands/shared/wake-cmd:cmdWake", ["--help"], deps);
+
+    expect(calls.wake).toEqual([]);
+    expect(calls.logs.join("\n")).toContain("usage: maw wake");
+  });
+
+  test("wake parses full option surface including engine shorthand", async () => {
+    const { calls, deps } = makeDeps();
+
+    await invokeDirectHandler("../commands/shared/wake-cmd:cmdWake", [
+      "neo",
+      "--task", "fix bug",
+      "--wt", "issue-1",
+      "--session", "workspace",
+      "-p", "hello",
+      "--incubate", "Soul-Brews-Studio/maw-js",
+      "--fresh",
+      "--bud",
+      "--signal-on-birth",
+      "-a",
+      "--list",
+      "--dry-run",
+      "--snapshot", "snap-1",
+      "--solo",
+      "--split",
+      "--all-local",
+      "--codex",
+    ], deps);
+
+    expect(calls.loadConfig).toBe(1);
+    expect(calls.wake).toEqual([["neo", {
+      task: "fix bug",
+      wt: "issue-1",
+      session: "workspace",
+      prompt: "hello",
+      incubate: "Soul-Brews-Studio/maw-js",
+      fresh: true,
+      bud: true,
+      signalOnBirth: true,
+      attach: true,
+      listWt: true,
+      dryRun: true,
+      fromSnapshot: true,
+      snapshotId: "snap-1",
+      noRehydrate: true,
+      split: true,
+      allLocal: true,
+      engine: "codex",
+    }]]);
+  });
+
+  test("awake supports help and explicit engine without loading config", async () => {
+    const { calls, deps } = makeDeps();
+
+    await invokeDirectHandler("../commands/shared/wake-cmd:cmdAwake", ["--help"], deps);
+    expect(calls.logs.join("\n")).toContain("usage: maw awake");
+    expect(calls.logs.join("\n")).toContain("Does not send /awaken");
+
+    calls.logs = [];
+    await invokeDirectHandler("../commands/shared/wake-cmd:cmdAwake", ["neo", "--engine", "spark"], deps);
+    expect(calls.loadConfig).toBe(0);
+    expect(calls.wake).toEqual([["neo", { engine: "spark" }]]);
+  });
+
+  test("wake missing oracle prints usage and throws UserError", async () => {
+    const { calls, deps } = makeDeps();
+
+    await expect(invokeDirectHandler("../commands/shared/wake-cmd:cmdWake", ["--dry-run"], deps)).rejects.toThrow(UserError);
+
+    expect(calls.errors.join("\n")).toContain("usage: maw wake");
+    expect(calls.wake).toEqual([]);
+  });
+
+  test("bring help and direct invocation route through cmdWake", async () => {
+    const { calls, deps } = makeDeps();
+
+    await invokeDirectHandler("../commands/shared/wake-cmd:cmdBring", ["--help"], deps);
+    expect(calls.logs.join("\n")).toContain("usage: maw bring");
+
+    calls.logs = [];
+    await invokeDirectHandler("../commands/shared/wake-cmd:cmdBring", ["neo", "--tab", "-e", "codex"], deps);
+    expect(calls.wake).toEqual([["neo", { bring: true, tab: true, engine: "codex" }]]);
+  });
+
+  test("new and preflight handlers dispatch to their static imports", async () => {
+    const { calls, deps } = makeDeps();
+
+    await invokeDirectHandler("./cmd-new:cmdNew", ["workspace", "--no-attach"], deps);
+    await invokeDirectHandler("../commands/shared/preflight:cmdPreflight", ["--fix"], deps);
+    await invokeDirectHandler("../commands/shared/preflight:cmdPreflight", [], deps);
+
+    expect(calls.new).toEqual([[["workspace", "--no-attach"]]]);
+    expect(calls.preflight).toEqual([{ fix: true }, { fix: false }]);
+  });
+
+  test("malformed and unknown direct handlers fail loudly", async () => {
+    await expect(invokeDirectHandler("module:", [])).rejects.toThrow("malformed handler spec");
+    await expect(invokeDirectHandler("cmdNope", [])).rejects.toThrow("unknown direct-handler export");
+  });
+});


### PR DESCRIPTION
## Summary
- add a tiny dependency seam to top-level direct alias dispatch so handler branches can run in the default suite without global module mocks
- add default-suite tests for alias resolution, `ls`/`bring` option parsing, wake/awake/bring/new/preflight direct handlers, help output, engine shorthand, and loud failure branches
- refresh coverage gap analysis; `src/cli/top-aliases.ts` is now 100% line/function coverage in the default coverage table

## Validation
- `MAW_TEST_MODE=1 bun test test/top-aliases-default.test.ts`
- targeted coverage: `src/cli/top-aliases.ts` 100% lines / 100% functions
- `MAW_TEST_MODE=1 bun run test` → 2067 pass / 6 skip / 0 fail
- `MAW_TEST_MODE=1 bun run test:coverage` → 2067 pass / 6 skip / 0 fail; overall 79.3% functions / 28.6% lines
- `MAW_TEST_MODE=1 bun run test:isolated` → 127/127 files passed
- `MAW_TEST_MODE=1 bun run test:plugin` → 199 pass / 2 skip / 0 fail
- `MAW_TEST_MODE=1 bun run test:mock-smoke` → 6 pass / 0 fail
- `bun run build`

Refs #1637. Alpha-only; no release cut.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
