### PR TITLE
test: cover plugin registry discovery gates

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,13 +1,13 @@
 # Coverage gap analysis
 
-Generated: 2026-05-17T10:25:01.887Z
+Generated: 2026-05-17T10:44:13.632Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **28.6%** (14365/50294)
-Overall function coverage: **79.3%** (1625/2048)
+Overall line coverage: **28.8%** (14479/50238)
+Overall function coverage: **79.7%** (1638/2055)
 
 ## Module summary
 
@@ -17,8 +17,8 @@ Overall function coverage: **79.3%** (1625/2048)
 | config/runtime | 19 | 2 | 66.0% (770/1167) | 72.9% (70/96) | n/a (0/0) |
 | fleet | 17 | 0 | 47.3% (503/1064) | 66.7% (52/78) | n/a (0/0) |
 | matcher | 2 | 0 | 100.0% (41/41) | 100.0% (8/8) | n/a (0/0) |
-| other | 174 | 69 | 36.7% (5290/14413) | 74.4% (569/765) | n/a (0/0) |
-| plugin dispatch | 15 | 1 | 69.8% (849/1217) | 83.8% (67/80) | n/a (0/0) |
+| other | 174 | 69 | 36.8% (5303/14402) | 74.9% (574/766) | n/a (0/0) |
+| plugin dispatch | 15 | 1 | 81.1% (950/1172) | 87.2% (75/86) | n/a (0/0) |
 | routing/aliases | 4 | 0 | 91.4% (582/637) | 94.5% (69/73) | n/a (0/0) |
 | transport | 28 | 2 | 77.8% (1876/2410) | 93.1% (363/390) | n/a (0/0) |
 | vendor plugins | 245 | 243 | 0.8% (181/21961) | 66.7% (16/24) | n/a (0/0) |
@@ -111,6 +111,7 @@ Overall function coverage: **79.3%** (1625/2048)
 | plugin dispatch | `src/plugin/manifest-validate.ts` | 100.0% | 100.0% |
 | plugin dispatch | `src/plugin/manifest.ts` | 100.0% | 100.0% |
 | plugin dispatch | `src/plugin/registry-semver.ts` | 100.0% | 100.0% |
+| plugin dispatch | `src/plugin/registry.ts` | 99.1% | 100.0% |
 | plugin dispatch | `src/plugin/tier.ts` | 100.0% | 100.0% |
 | routing/aliases | `src/cli/route-tools.ts` | 100.0% | 100.0% |
 | routing/aliases | `src/cli/top-aliases.ts` | 100.0% | 100.0% |
@@ -141,7 +142,6 @@ Overall function coverage: **79.3%** (1625/2048)
 | Module | File | Uncovered | Line coverage |
 | --- | --- | ---: | ---: |
 | transport | `src/core/transport/pty.ts` | 150 | 0.0% |
-| plugin dispatch | `src/plugin/registry.ts` | 147 | 8.1% |
 | cli/dispatch | `src/commands/shared/fleet-wake.ts` | 146 | 0.0% |
 | cli/dispatch | `src/commands/shared/pulse-cmd.ts` | 134 | 0.0% |
 | fleet | `src/core/fleet/worktrees-scan.ts` | 128 | 4.5% |
@@ -150,6 +150,7 @@ Overall function coverage: **79.3%** (1625/2048)
 | cli/dispatch | `src/commands/shared/preflight.ts` | 105 | 2.8% |
 | cli/dispatch | `src/commands/shared/queue-store.ts` | 104 | 11.1% |
 | cli/dispatch | `src/commands/shared/fleet-manage.ts` | 101 | 0.0% |
+| cli/dispatch | `src/commands/shared/fleet-resume.ts` | 100 | 0.0% |
 
 ## Critical gaps to prioritize
 

--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,13 +1,13 @@
 # Coverage gap analysis
 
-Generated: 2026-05-17T11:17:36.656Z
+Generated: 2026-05-17T11:26:08.731Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **29.0%** (14573/50230)
-Overall function coverage: **80.3%** (1651/2057)
+Overall line coverage: **29.2%** (14679/50208)
+Overall function coverage: **80.4%** (1657/2062)
 
 ## Module summary
 
@@ -15,7 +15,7 @@ Overall function coverage: **80.3%** (1651/2057)
 | --- | ---: | ---: | ---: | ---: | ---: |
 | cli/dispatch | 90 | 15 | 59.2% (4367/7376) | 79.1% (424/536) | n/a (0/0) |
 | config/runtime | 19 | 2 | 66.0% (770/1167) | 72.9% (70/96) | n/a (0/0) |
-| fleet | 17 | 0 | 47.3% (503/1064) | 66.7% (52/78) | n/a (0/0) |
+| fleet | 17 | 0 | 58.4% (609/1042) | 69.9% (58/83) | n/a (0/0) |
 | matcher | 2 | 0 | 100.0% (41/41) | 100.0% (8/8) | n/a (0/0) |
 | other | 174 | 69 | 36.8% (5303/14402) | 74.9% (574/766) | n/a (0/0) |
 | plugin dispatch | 15 | 1 | 81.1% (950/1172) | 87.2% (75/86) | n/a (0/0) |
@@ -100,6 +100,7 @@ Overall function coverage: **80.3%** (1651/2057)
 | fleet | `src/core/fleet/snapshot.ts` | 93.4% | 100.0% |
 | fleet | `src/core/fleet/validate.ts` | 100.0% | 100.0% |
 | fleet | `src/core/fleet/worktree-window-match.ts` | 100.0% | 100.0% |
+| fleet | `src/core/fleet/worktrees-scan.ts` | 100.0% | 100.0% |
 | fleet | `src/core/fleet/worktrees.ts` | 100.0% | 100.0% |
 | matcher | `src/core/matcher/normalize-target.ts` | 100.0% | 100.0% |
 | matcher | `src/core/matcher/resolve-target.ts` | 100.0% | 100.0% |
@@ -145,13 +146,13 @@ Overall function coverage: **80.3%** (1651/2057)
 | transport | `src/core/transport/pty.ts` | 150 | 0.0% |
 | cli/dispatch | `src/commands/shared/fleet-wake.ts` | 146 | 0.0% |
 | cli/dispatch | `src/commands/shared/pulse-cmd.ts` | 134 | 0.0% |
-| fleet | `src/core/fleet/worktrees-scan.ts` | 128 | 4.5% |
 | cli/dispatch | `src/commands/shared/workspace-lifecycle.ts` | 120 | 4.0% |
 | cli/dispatch | `src/commands/shared/federation-sync-cli.ts` | 116 | 10.8% |
 | cli/dispatch | `src/commands/shared/preflight.ts` | 105 | 2.8% |
 | cli/dispatch | `src/commands/shared/fleet-manage.ts` | 101 | 0.0% |
 | cli/dispatch | `src/commands/shared/fleet-resume.ts` | 100 | 0.0% |
 | cli/dispatch | `src/cli/dispatch.ts` | 97 | 46.4% |
+| fleet | `src/core/fleet/registry-oracle-scan-remote.ts` | 93 | 6.1% |
 
 ## Critical gaps to prioritize
 

--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,19 +1,19 @@
 # Coverage gap analysis
 
-Generated: 2026-05-17T10:44:13.632Z
+Generated: 2026-05-17T11:17:36.656Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **28.8%** (14479/50238)
-Overall function coverage: **79.7%** (1638/2055)
+Overall line coverage: **29.0%** (14573/50230)
+Overall function coverage: **80.3%** (1651/2057)
 
 ## Module summary
 
 | Module | Files | Missing from LCOV | Lines | Functions | Branches |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| cli/dispatch | 90 | 15 | 57.9% (4273/7384) | 77.0% (411/534) | n/a (0/0) |
+| cli/dispatch | 90 | 15 | 59.2% (4367/7376) | 79.1% (424/536) | n/a (0/0) |
 | config/runtime | 19 | 2 | 66.0% (770/1167) | 72.9% (70/96) | n/a (0/0) |
 | fleet | 17 | 0 | 47.3% (503/1064) | 66.7% (52/78) | n/a (0/0) |
 | matcher | 2 | 0 | 100.0% (41/41) | 100.0% (8/8) | n/a (0/0) |
@@ -81,6 +81,7 @@ Overall function coverage: **79.7%** (1638/2055)
 | cli/dispatch | `src/commands/shared/plugin-create.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/plugins-ls-info.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/plugins-ui.ts` | 100.0% | 100.0% |
+| cli/dispatch | `src/commands/shared/queue-store.ts` | 98.2% | 100.0% |
 | cli/dispatch | `src/commands/shared/receiver-inbox.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/target-cwd.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/wake-cmd.ts` | 84.1% | 85.2% |
@@ -148,9 +149,9 @@ Overall function coverage: **79.7%** (1638/2055)
 | cli/dispatch | `src/commands/shared/workspace-lifecycle.ts` | 120 | 4.0% |
 | cli/dispatch | `src/commands/shared/federation-sync-cli.ts` | 116 | 10.8% |
 | cli/dispatch | `src/commands/shared/preflight.ts` | 105 | 2.8% |
-| cli/dispatch | `src/commands/shared/queue-store.ts` | 104 | 11.1% |
 | cli/dispatch | `src/commands/shared/fleet-manage.ts` | 101 | 0.0% |
 | cli/dispatch | `src/commands/shared/fleet-resume.ts` | 100 | 0.0% |
+| cli/dispatch | `src/cli/dispatch.ts` | 97 | 46.4% |
 
 ## Critical gaps to prioritize
 

--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,19 +1,19 @@
 # Coverage gap analysis
 
-Generated: 2026-05-17T11:26:08.731Z
+Generated: 2026-05-17T11:36:55.933Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **29.2%** (14679/50208)
-Overall function coverage: **80.4%** (1657/2062)
+Overall line coverage: **29.5%** (14800/50209)
+Overall function coverage: **80.6%** (1669/2071)
 
 ## Module summary
 
 | Module | Files | Missing from LCOV | Lines | Functions | Branches |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| cli/dispatch | 90 | 15 | 59.2% (4367/7376) | 79.1% (424/536) | n/a (0/0) |
+| cli/dispatch | 90 | 15 | 60.8% (4488/7377) | 80.0% (436/545) | n/a (0/0) |
 | config/runtime | 19 | 2 | 66.0% (770/1167) | 72.9% (70/96) | n/a (0/0) |
 | fleet | 17 | 0 | 58.4% (609/1042) | 69.9% (58/83) | n/a (0/0) |
 | matcher | 2 | 0 | 100.0% (41/41) | 100.0% (8/8) | n/a (0/0) |
@@ -91,6 +91,7 @@ Overall function coverage: **80.4%** (1657/2062)
 | cli/dispatch | `src/commands/shared/wake-target.ts` | 80.0% | 80.0% |
 | cli/dispatch | `src/commands/shared/wake.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/workspace-agents.ts` | 100.0% | 100.0% |
+| cli/dispatch | `src/commands/shared/workspace-lifecycle.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/workspace-query.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/workspace.ts` | 100.0% | 100.0% |
 | fleet | `src/core/fleet/leaf.ts` | 100.0% | 100.0% |
@@ -146,13 +147,13 @@ Overall function coverage: **80.4%** (1657/2062)
 | transport | `src/core/transport/pty.ts` | 150 | 0.0% |
 | cli/dispatch | `src/commands/shared/fleet-wake.ts` | 146 | 0.0% |
 | cli/dispatch | `src/commands/shared/pulse-cmd.ts` | 134 | 0.0% |
-| cli/dispatch | `src/commands/shared/workspace-lifecycle.ts` | 120 | 4.0% |
 | cli/dispatch | `src/commands/shared/federation-sync-cli.ts` | 116 | 10.8% |
 | cli/dispatch | `src/commands/shared/preflight.ts` | 105 | 2.8% |
 | cli/dispatch | `src/commands/shared/fleet-manage.ts` | 101 | 0.0% |
 | cli/dispatch | `src/commands/shared/fleet-resume.ts` | 100 | 0.0% |
 | cli/dispatch | `src/cli/dispatch.ts` | 97 | 46.4% |
 | fleet | `src/core/fleet/registry-oracle-scan-remote.ts` | 93 | 6.1% |
+| cli/dispatch | `src/commands/shared/fleet-doctor.ts` | 92 | 12.4% |
 
 ## Critical gaps to prioritize
 

--- a/src/commands/shared/workspace-lifecycle.ts
+++ b/src/commands/shared/workspace-lifecycle.ts
@@ -2,26 +2,69 @@ import { loadConfig } from "../../config";
 import { curlFetch } from "../../sdk";
 import { configPath, resolveHubUrl, resolveWorkspaceId, reportNoWorkspaceId, loadWorkspace, saveWorkspace } from "./workspace-store";
 import type { WorkspaceConfig } from "./workspace-store";
+type RenameSync = typeof import("fs").renameSync;
+type UnlinkSync = typeof import("fs").unlinkSync;
+
+function dynamicFs(): typeof import("fs") {
+  return require("fs") as typeof import("fs");
+}
+
+export interface WorkspaceLifecycleDeps {
+  loadConfig: typeof loadConfig;
+  curlFetch: typeof curlFetch;
+  resolveHubUrl: typeof resolveHubUrl;
+  resolveWorkspaceId: typeof resolveWorkspaceId;
+  reportNoWorkspaceId: typeof reportNoWorkspaceId;
+  loadWorkspace: typeof loadWorkspace;
+  saveWorkspace: typeof saveWorkspace;
+  configPath: typeof configPath;
+  renameSync: RenameSync;
+  unlinkSync: UnlinkSync;
+  now: () => Date;
+  log: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+  exit: (code: number) => never;
+}
+
+function lifecycleDeps(overrides: Partial<WorkspaceLifecycleDeps> = {}): WorkspaceLifecycleDeps {
+  return {
+    loadConfig: overrides.loadConfig ?? loadConfig,
+    curlFetch: overrides.curlFetch ?? curlFetch,
+    resolveHubUrl: overrides.resolveHubUrl ?? resolveHubUrl,
+    resolveWorkspaceId: overrides.resolveWorkspaceId ?? resolveWorkspaceId,
+    reportNoWorkspaceId: overrides.reportNoWorkspaceId ?? reportNoWorkspaceId,
+    loadWorkspace: overrides.loadWorkspace ?? loadWorkspace,
+    saveWorkspace: overrides.saveWorkspace ?? saveWorkspace,
+    configPath: overrides.configPath ?? configPath,
+    renameSync: overrides.renameSync ?? ((src, dest) => dynamicFs().renameSync(src, dest)),
+    unlinkSync: overrides.unlinkSync ?? ((src) => dynamicFs().unlinkSync(src)),
+    now: overrides.now ?? (() => new Date()),
+    log: overrides.log ?? console.log,
+    error: overrides.error ?? console.error,
+    exit: overrides.exit ?? ((code: number): never => process.exit(code)),
+  };
+}
 
 /** maw workspace create <name> [--hub <url>] */
-export async function cmdWorkspaceCreate(name: string, hubUrl?: string) {
-  const hub = resolveHubUrl(hubUrl);
+export async function cmdWorkspaceCreate(name: string, hubUrl?: string, deps: Partial<WorkspaceLifecycleDeps> = {}) {
+  const d = lifecycleDeps(deps);
+  const hub = d.resolveHubUrl(hubUrl);
   if (!hub) {
-    console.error("\x1b[31m\u274c\x1b[0m no hub URL — pass --hub <url> or configure a peer");
-    process.exit(1);
+    d.error("\x1b[31m\u274c\x1b[0m no hub URL — pass --hub <url> or configure a peer");
+    d.exit(1);
   }
 
-  console.log(`\x1b[36mcreating\x1b[0m workspace "${name}" on ${hub}...`);
+  d.log(`\x1b[36mcreating\x1b[0m workspace "${name}" on ${hub}...`);
 
-  const config = loadConfig();
-  const res = await curlFetch(`${hub}/api/workspace/create`, {
+  const config = d.loadConfig();
+  const res = await d.curlFetch(`${hub}/api/workspace/create`, {
     method: "POST",
     body: JSON.stringify({ name, nodeId: config.node ?? "local" }),
   });
 
   if (!res.ok || !res.data?.id) {
-    console.error(`\x1b[31m\u274c\x1b[0m failed to create workspace: ${res.data?.error || `HTTP ${res.status}`}`);
-    process.exit(1);
+    d.error(`\x1b[31m\u274c\x1b[0m failed to create workspace: ${res.data?.error || `HTTP ${res.status}`}`);
+    d.exit(1);
   }
 
   const ws: WorkspaceConfig = {
@@ -30,40 +73,41 @@ export async function cmdWorkspaceCreate(name: string, hubUrl?: string) {
     hubUrl: hub,
     joinCode: res.data.joinCode,
     sharedAgents: [],
-    joinedAt: new Date().toISOString(),
+    joinedAt: d.now().toISOString(),
     lastStatus: "connected",
   };
-  saveWorkspace(ws);
+  d.saveWorkspace(ws);
 
-  console.log(`\x1b[32m\u2705\x1b[0m workspace created`);
-  console.log(`  \x1b[36mID:\x1b[0m        ${ws.id}`);
-  console.log(`  \x1b[36mName:\x1b[0m      ${ws.name}`);
-  console.log(`  \x1b[36mHub:\x1b[0m       ${ws.hubUrl}`);
+  d.log(`\x1b[32m\u2705\x1b[0m workspace created`);
+  d.log(`  \x1b[36mID:\x1b[0m        ${ws.id}`);
+  d.log(`  \x1b[36mName:\x1b[0m      ${ws.name}`);
+  d.log(`  \x1b[36mHub:\x1b[0m       ${ws.hubUrl}`);
   if (ws.joinCode) {
-    console.log(`  \x1b[36mJoin code:\x1b[0m ${ws.joinCode}`);
+    d.log(`  \x1b[36mJoin code:\x1b[0m ${ws.joinCode}`);
   }
-  console.log(`\n\x1b[90mConfig saved to ${configPath(ws.id)}\x1b[0m`);
+  d.log(`\n\x1b[90mConfig saved to ${d.configPath(ws.id)}\x1b[0m`);
 }
 
 /** maw workspace join <code> [--hub <url>] */
-export async function cmdWorkspaceJoin(code: string, hubUrl?: string) {
-  const hub = resolveHubUrl(hubUrl);
+export async function cmdWorkspaceJoin(code: string, hubUrl?: string, deps: Partial<WorkspaceLifecycleDeps> = {}) {
+  const d = lifecycleDeps(deps);
+  const hub = d.resolveHubUrl(hubUrl);
   if (!hub) {
-    console.error("\x1b[31m\u274c\x1b[0m no hub URL — pass --hub <url> or configure a peer");
-    process.exit(1);
+    d.error("\x1b[31m\u274c\x1b[0m no hub URL — pass --hub <url> or configure a peer");
+    d.exit(1);
   }
 
-  console.log(`\x1b[36mjoining\x1b[0m workspace with code "${code}" on ${hub}...`);
+  d.log(`\x1b[36mjoining\x1b[0m workspace with code "${code}" on ${hub}...`);
 
-  const config = loadConfig();
-  const res = await curlFetch(`${hub}/api/workspace/join`, {
+  const config = d.loadConfig();
+  const res = await d.curlFetch(`${hub}/api/workspace/join`, {
     method: "POST",
     body: JSON.stringify({ code, node: config.node ?? "local" }),
   });
 
   if (!res.ok || !res.data?.id) {
-    console.error(`\x1b[31m\u274c\x1b[0m failed to join workspace: ${res.data?.error || `HTTP ${res.status}`}`);
-    process.exit(1);
+    d.error(`\x1b[31m\u274c\x1b[0m failed to join workspace: ${res.data?.error || `HTTP ${res.status}`}`);
+    d.exit(1);
   }
 
   const ws: WorkspaceConfig = {
@@ -72,65 +116,64 @@ export async function cmdWorkspaceJoin(code: string, hubUrl?: string) {
     hubUrl: hub,
     joinCode: code,
     sharedAgents: [],
-    joinedAt: new Date().toISOString(),
+    joinedAt: d.now().toISOString(),
     lastStatus: "connected",
   };
-  saveWorkspace(ws);
+  d.saveWorkspace(ws);
 
-  console.log(`\x1b[32m\u2705\x1b[0m joined workspace`);
-  console.log(`  \x1b[36mName:\x1b[0m    ${ws.name}`);
-  console.log(`  \x1b[36mID:\x1b[0m      ${ws.id}`);
+  d.log(`\x1b[32m\u2705\x1b[0m joined workspace`);
+  d.log(`  \x1b[36mName:\x1b[0m    ${ws.name}`);
+  d.log(`  \x1b[36mID:\x1b[0m      ${ws.id}`);
   if (res.data.agents?.length) {
-    console.log(`  \x1b[36mAgents:\x1b[0m  ${res.data.agents.length} available`);
+    d.log(`  \x1b[36mAgents:\x1b[0m  ${res.data.agents.length} available`);
     for (const a of res.data.agents) {
-      console.log(`    \x1b[90m\u2022\x1b[0m ${a.name || a}`);
+      d.log(`    \x1b[90m\u2022\x1b[0m ${a.name || a}`);
     }
   }
-  console.log(`\n\x1b[90mConfig saved to ${configPath(ws.id)}\x1b[0m`);
+  d.log(`\n\x1b[90mConfig saved to ${d.configPath(ws.id)}\x1b[0m`);
 }
 
 /** maw workspace leave [workspace-id] */
-export async function cmdWorkspaceLeave(workspaceId?: string) {
-  const id = resolveWorkspaceId(workspaceId);
+export async function cmdWorkspaceLeave(workspaceId?: string, deps: Partial<WorkspaceLifecycleDeps> = {}) {
+  const d = lifecycleDeps(deps);
+  const id = d.resolveWorkspaceId(workspaceId);
   if (!id) {
-    reportNoWorkspaceId();
-    process.exit(1);
+    d.reportNoWorkspaceId();
+    d.exit(1);
   }
 
-  const ws = loadWorkspace(id);
+  const ws = d.loadWorkspace(id);
   if (!ws) {
-    console.error(`\x1b[31m\u274c\x1b[0m workspace not found: ${id}`);
-    process.exit(1);
+    d.error(`\x1b[31m\u274c\x1b[0m workspace not found: ${id}`);
+    d.exit(1);
   }
 
-  console.log(`\x1b[36mleaving\x1b[0m workspace "${ws.name}"...`);
+  d.log(`\x1b[36mleaving\x1b[0m workspace "${ws.name}"...`);
 
-  const config = loadConfig();
-  const res = await curlFetch(`${ws.hubUrl}/api/workspace/${ws.id}/leave`, {
+  const config = d.loadConfig();
+  const res = await d.curlFetch(`${ws.hubUrl}/api/workspace/${ws.id}/leave`, {
     method: "POST",
     body: JSON.stringify({ node: config.node ?? "local" }),
   });
 
   if (!res.ok) {
-    console.error(`\x1b[31m\u274c\x1b[0m failed to leave workspace: ${res.data?.error || `HTTP ${res.status}`}`);
+    d.error(`\x1b[31m\u274c\x1b[0m failed to leave workspace: ${res.data?.error || `HTTP ${res.status}`}`);
     // Still remove local config — hub might be unreachable
-    console.log("\x1b[33m\u26a0\x1b[0m removing local config anyway...");
+    d.log("\x1b[33m\u26a0\x1b[0m removing local config anyway...");
   }
 
   // Remove local workspace config (soft-delete: rename with .left suffix)
-  const src = configPath(ws.id);
-  const dest = configPath(ws.id + ".left");
+  const src = d.configPath(ws.id);
+  const dest = d.configPath(ws.id + ".left");
   try {
-    const { renameSync } = require("fs");
-    renameSync(src, dest);
+    d.renameSync(src, dest);
   } catch {
     // If rename fails, just delete
     try {
-      const { unlinkSync } = require("fs");
-      unlinkSync(src);
+      d.unlinkSync(src);
     } catch {}
   }
 
-  console.log(`\x1b[32m\u2705\x1b[0m left workspace "${ws.name}"`);
-  console.log(`\x1b[90m  config archived to ${dest}\x1b[0m`);
+  d.log(`\x1b[32m\u2705\x1b[0m left workspace "${ws.name}"`);
+  d.log(`\x1b[90m  config archived to ${dest}\x1b[0m`);
 }

--- a/src/core/fleet/worktrees-scan.ts
+++ b/src/core/fleet/worktrees-scan.ts
@@ -4,6 +4,7 @@ import { readdirSync, readFileSync } from "fs";
 import { join } from "path";
 import { FLEET_DIR } from "../paths";
 import { resolveWorktreeWindow } from "./worktree-window-match";
+import type { Session } from "../runtime/find-window";
 
 export interface WorktreeInfo {
   path: string;
@@ -16,6 +17,28 @@ export interface WorktreeInfo {
   fleetFile?: string; // fleet config if registered
 }
 
+export interface ScanWorktreesDeps {
+  hostExec: (cmd: string) => Promise<string>;
+  listSessions: () => Promise<Session[]>;
+  getGhqRoot: () => string;
+  readdirSync: (path: string) => string[];
+  readFileSync: (path: string, encoding: "utf-8") => string;
+  fleetDir: string;
+  error: (...args: unknown[]) => void;
+}
+
+function scanDeps(overrides: Partial<ScanWorktreesDeps>): ScanWorktreesDeps {
+  return {
+    hostExec: overrides.hostExec ?? hostExec,
+    listSessions: overrides.listSessions ?? (listSessions as unknown as () => Promise<Session[]>),
+    getGhqRoot: overrides.getGhqRoot ?? getGhqRoot,
+    readdirSync: overrides.readdirSync ?? (readdirSync as unknown as ScanWorktreesDeps["readdirSync"]),
+    readFileSync: overrides.readFileSync ?? (readFileSync as unknown as ScanWorktreesDeps["readFileSync"]),
+    fleetDir: overrides.fleetDir ?? FLEET_DIR,
+    error: overrides.error ?? console.error,
+  };
+}
+
 /**
  * Scan all worktrees across ghq repos.
  * Classifies:
@@ -23,9 +46,10 @@ export interface WorktreeInfo {
  *   stale   — exists on disk, no tmux window
  *   orphan  — git reports prunable
  */
-export async function scanWorktrees(): Promise<WorktreeInfo[]> {
-  const reposRoot = join(getGhqRoot(), "github.com");
-  const fleetDir = FLEET_DIR;
+export async function scanWorktrees(deps: Partial<ScanWorktreesDeps> = {}): Promise<WorktreeInfo[]> {
+  const d = scanDeps(deps);
+  const reposRoot = join(d.getGhqRoot(), "github.com");
+  const fleetDir = d.fleetDir;
 
   // 1. Find all .wt- directories
   // #1553 — dedupe paths; `find` can surface the same .wt-* dir multiple times
@@ -33,16 +57,16 @@ export async function scanWorktrees(): Promise<WorktreeInfo[]> {
   // turning N worktrees into N×K classification rows + ambiguity error spam.
   let wtPaths: string[] = [];
   try {
-    const raw = await hostExec(`find ${reposRoot} -maxdepth 4 -name '*.wt-*' -type d 2>/dev/null`);
+    const raw = await d.hostExec(`find ${reposRoot} -maxdepth 4 -name '*.wt-*' -type d 2>/dev/null`);
     wtPaths = [...new Set(raw.split("\n").filter(Boolean))];
   } catch { /* no worktrees */ }
 
   // 2. Get running tmux windows for matching
   // listSessions() can throw if tmux is down or SSH fails — treat as empty
   // (all worktrees will classify as stale, which is correct: no windows running).
-  let sessions: Awaited<ReturnType<typeof listSessions>> = [];
+  let sessions: Session[] = [];
   try {
-    sessions = await listSessions();
+    sessions = await d.listSessions();
   } catch { /* tmux unavailable — proceed with no running windows */ }
   const runningWindows = new Set<string>();
   for (const s of sessions) {
@@ -54,8 +78,8 @@ export async function scanWorktrees(): Promise<WorktreeInfo[]> {
   // 3. Load fleet configs for matching
   const fleetWindows = new Map<string, string>(); // repo -> fleet file
   try {
-    for (const file of readdirSync(fleetDir).filter(f => f.endsWith(".json"))) {
-      const cfg = JSON.parse(readFileSync(join(fleetDir, file), "utf-8"));
+    for (const file of d.readdirSync(fleetDir).filter(f => f.endsWith(".json"))) {
+      const cfg = JSON.parse(d.readFileSync(join(fleetDir, file), "utf-8"));
       for (const w of cfg.windows || []) {
         if (w.repo) fleetWindows.set(w.repo, file);
       }
@@ -84,7 +108,7 @@ export async function scanWorktrees(): Promise<WorktreeInfo[]> {
     // Get branch
     let branch = "";
     try {
-      branch = (await hostExec(`git -C '${wtPath}' rev-parse --abbrev-ref HEAD 2>/dev/null`)).trim();
+      branch = (await d.hostExec(`git -C '${wtPath}' rev-parse --abbrev-ref HEAD 2>/dev/null`)).trim();
     } catch { branch = "unknown"; }
 
     // Match to tmux window — check fleet config or name pattern.
@@ -98,11 +122,11 @@ export async function scanWorktrees(): Promise<WorktreeInfo[]> {
         tmuxWindow = windowMatch.window;
         break;
       case "ambiguous":
-        console.error(`  \x1b[31m✗\x1b[0m '${windowMatch.query}' is ambiguous — matches ${windowMatch.candidates.length} windows:`);
+        d.error(`  \x1b[31m✗\x1b[0m '${windowMatch.query}' is ambiguous — matches ${windowMatch.candidates.length} windows:`);
         for (const c of windowMatch.candidates) {
-          console.error(`  \x1b[90m    • ${c}\x1b[0m`);
+          d.error(`  \x1b[90m    • ${c}\x1b[0m`);
         }
-        console.error(`  \x1b[90m  leaving worktree ${wtName} unbound (status: stale)\x1b[0m`);
+        d.error(`  \x1b[90m  leaving worktree ${wtName} unbound (status: stale)\x1b[0m`);
         // tmuxWindow stays undefined → status = stale
         break;
       case "none":
@@ -130,7 +154,7 @@ export async function scanWorktrees(): Promise<WorktreeInfo[]> {
   for (const mainRepo of mainRepos) {
     const mainPath = join(reposRoot, mainRepo);
     try {
-      const prunable = await hostExec(`git -C '${mainPath}' worktree list --porcelain 2>/dev/null | grep -A1 'prunable' | grep 'worktree' | sed 's/worktree //'`);
+      const prunable = await d.hostExec(`git -C '${mainPath}' worktree list --porcelain 2>/dev/null | grep -A1 'prunable' | grep 'worktree' | sed 's/worktree //'`);
       for (const orphanPath of prunable.split("\n").filter(Boolean)) {
         // Check if we already have this path
         const existing = results.find(r => r.path === orphanPath);

--- a/src/plugin/registry.ts
+++ b/src/plugin/registry.ts
@@ -24,6 +24,7 @@ import { join } from "path";
 import { loadManifestFromDir } from "./manifest";
 import { loadConfig } from "../config";
 import { verbose, info } from "../cli/verbosity";
+import type { MawConfig } from "../config/types";
 import type { LoadedPlugin } from "./types";
 import { satisfies, formatSdkMismatchError } from "./registry-semver";
 import {
@@ -77,10 +78,19 @@ export function resetDiscoverCache(): void {
  * Result is memoized within the current process. Call `resetDiscoverCache()`
  * after mutating plugin state (install, build) to force a fresh scan.
  */
-export function discoverPackages(): LoadedPlugin[] {
-  if (_discoverCache !== null) return _discoverCache;
+export interface DiscoverPackagesDeps {
+  loadConfig?: () => Pick<MawConfig, "disabledPlugins">;
+  resolveActiveProfileFilter?: typeof resolveActiveProfileFilter;
+  scanDirs?: typeof scanDirs;
+  useCache?: boolean;
+}
+
+export function discoverPackages(deps: DiscoverPackagesDeps = {}): LoadedPlugin[] {
+  const useCache = deps.useCache ?? (!deps.loadConfig && !deps.resolveActiveProfileFilter && !deps.scanDirs);
+  if (useCache && _discoverCache !== null) return _discoverCache;
+  const pluginDirs = (deps.scanDirs ?? scanDirs)();
   const plugins: LoadedPlugin[] = [];
-  const disabled = loadConfig().disabledPlugins ?? [];
+  const disabled = (deps.loadConfig ?? loadConfig)().disabledPlugins ?? [];
   const runtimeVer = runtimeSdkVersion();
   let legacyCount = 0;
   // #355 — aggregate mode counts for a single compact summary line instead
@@ -89,7 +99,7 @@ export function discoverPackages(): LoadedPlugin[] {
   // invariant (#343), but the right grain is SUMMARY, not per-entry.
   const modeCounts = { symlink: 0, artifact: 0, unbuilt: 0, legacy: 0 };
 
-  for (const baseDir of scanDirs()) {
+  for (const baseDir of pluginDirs) {
     if (!existsSync(baseDir)) continue;
     let entries: string[];
     try {
@@ -186,14 +196,17 @@ export function discoverPackages(): LoadedPlugin[] {
 
   // #404 — apply weight overrides so category survives `install --link` replaces
   // where the new plugin.json omitted `weight`.
-  const overridesPath = join(scanDirs()[0]!, ".overrides.json");
-  try {
-    const overrides = JSON.parse(readFileSync(overridesPath, "utf8")) as Record<string, number>;
-    for (const p of plugins) {
-      const w = overrides[p.manifest.name];
-      if (typeof w === "number") p.manifest.weight = w;
-    }
-  } catch { /* absent or unreadable */ }
+  const primaryPluginDir = pluginDirs[0];
+  if (primaryPluginDir) {
+    const overridesPath = join(primaryPluginDir, ".overrides.json");
+    try {
+      const overrides = JSON.parse(readFileSync(overridesPath, "utf8")) as Record<string, number>;
+      for (const p of plugins) {
+        const w = overrides[p.manifest.name];
+        if (typeof w === "number") p.manifest.weight = w;
+      }
+    } catch { /* absent or unreadable */ }
+  }
 
   // Sort by weight (lower = first, default 50) — like Drupal module weight
   plugins.sort((a, b) => (a.manifest.weight ?? 50) - (b.manifest.weight ?? 50));
@@ -211,7 +224,7 @@ export function discoverPackages(): LoadedPlugin[] {
   // The pure resolver in profile-loader.ts keeps its Phase-1 contract
   // (untiered = excluded); the default lives here in the wiring layer where
   // the audit doc's "missing → core" convention applies.
-  const filter = resolveActiveProfileFilter(
+  const filter = (deps.resolveActiveProfileFilter ?? resolveActiveProfileFilter)(
     plugins.map((p) => ({
       name: p.manifest.name,
       tier: p.manifest.tier ?? "core",
@@ -221,6 +234,6 @@ export function discoverPackages(): LoadedPlugin[] {
     ? plugins
     : plugins.filter((p) => filter.has(p.manifest.name));
 
-  _discoverCache = filtered;
+  if (useCache) _discoverCache = filtered;
   return filtered;
 }

--- a/test/plugin-registry-default.test.ts
+++ b/test/plugin-registry-default.test.ts
@@ -1,0 +1,223 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createHash } from "crypto";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "fs";
+import { dirname, join } from "path";
+import { tmpdir } from "os";
+import {
+  discoverPackages,
+  hashFile,
+  resetDiscoverCache,
+  type DiscoverPackagesDeps,
+} from "../src/plugin/registry.ts?plugin-registry-default";
+import type { PluginNameAndTier } from "../src/lib/profile-loader";
+
+let testRoot = "";
+let pluginsDir = "";
+let mawHome = "";
+let originalPluginsDir: string | undefined;
+let originalMawHome: string | undefined;
+let originalWarnStateFile: string | undefined;
+let originalWarn: typeof console.warn;
+let warns: string[] = [];
+
+function sha256(text: string): string {
+  return `sha256:${createHash("sha256").update(text).digest("hex")}`;
+}
+
+function writePlugin(root: string, name: string, manifest: Record<string, unknown>, files: Record<string, string> = {}) {
+  const dir = join(root, name);
+  mkdirSync(dir, { recursive: true });
+  for (const [rel, text] of Object.entries(files)) {
+    const path = join(dir, rel);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, text);
+  }
+  writeFileSync(join(dir, "plugin.json"), JSON.stringify({
+    name,
+    version: "1.0.0",
+    sdk: "*",
+    target: "js",
+    ...manifest,
+  }, null, 2));
+  return dir;
+}
+
+function writeEntryPlugin(root: string, name: string, manifest: Record<string, unknown> = {}) {
+  return writePlugin(root, name, { entry: "index.ts", ...manifest }, {
+    "index.ts": `export default async function ${name.replaceAll("-", "_")}() {}\n`,
+  });
+}
+
+function writeArtifactPlugin(
+  root: string,
+  name: string,
+  artifactText: string,
+  sha: string | null,
+  manifest: Record<string, unknown> = {},
+) {
+  const dir = writePlugin(root, name, {
+    artifact: { path: "dist/index.js", sha256: sha },
+    ...manifest,
+  }, {
+    "dist/index.js": artifactText,
+  });
+  return { dir, artifactPath: join(dir, "dist/index.js") };
+}
+
+function names() {
+  return discoverPackages({
+    scanDirs: () => [pluginsDir],
+    loadConfig: () => ({ disabledPlugins: [] }),
+  }).map((p) => p.manifest.name);
+}
+
+beforeEach(() => {
+  testRoot = mkdtempSync(join(tmpdir(), "maw-plugin-registry-default-"));
+  pluginsDir = join(testRoot, "plugins");
+  mawHome = join(testRoot, "maw-home");
+  mkdirSync(pluginsDir, { recursive: true });
+  mkdirSync(mawHome, { recursive: true });
+
+  originalPluginsDir = process.env.MAW_PLUGINS_DIR;
+  originalMawHome = process.env.MAW_HOME;
+  originalWarnStateFile = process.env.MAW_WARN_STATE_FILE;
+  originalWarn = console.warn;
+  warns = [];
+
+  process.env.MAW_PLUGINS_DIR = pluginsDir;
+  process.env.MAW_HOME = mawHome;
+  process.env.MAW_WARN_STATE_FILE = join(testRoot, "warnings.json");
+  console.warn = (line?: unknown) => { warns.push(String(line ?? "")); };
+  resetDiscoverCache();
+});
+
+afterEach(() => {
+  resetDiscoverCache();
+  console.warn = originalWarn;
+  if (originalPluginsDir === undefined) delete process.env.MAW_PLUGINS_DIR;
+  else process.env.MAW_PLUGINS_DIR = originalPluginsDir;
+  if (originalMawHome === undefined) delete process.env.MAW_HOME;
+  else process.env.MAW_HOME = originalMawHome;
+  if (originalWarnStateFile === undefined) delete process.env.MAW_WARN_STATE_FILE;
+  else process.env.MAW_WARN_STATE_FILE = originalWarnStateFile;
+  if (testRoot && existsSync(testRoot)) rmSync(testRoot, { recursive: true, force: true });
+});
+
+describe("discoverPackages default-suite coverage", () => {
+  test("returns an empty list for a missing plugin root", () => {
+    expect(discoverPackages({
+      scanDirs: () => [join(testRoot, "missing-root")],
+      loadConfig: () => ({ disabledPlugins: [] }),
+    })).toEqual([]);
+  });
+
+  test("memoizes default discovery until resetDiscoverCache is called", () => {
+    writeEntryPlugin(pluginsDir, "registry-cache-a");
+
+    const first = discoverPackages({ scanDirs: () => [pluginsDir], useCache: true });
+    const second = discoverPackages({ scanDirs: () => [pluginsDir], useCache: true });
+    writeEntryPlugin(pluginsDir, "registry-cache-b");
+    const cachedAfterMutation = discoverPackages({ scanDirs: () => [pluginsDir], useCache: true });
+
+    expect(second).toBe(first);
+    expect(cachedAfterMutation).toBe(first);
+    expect(first.map((p) => p.manifest.name)).toEqual(["registry-cache-a"]);
+
+    resetDiscoverCache();
+    expect(discoverPackages({ scanDirs: () => [pluginsDir], useCache: true }).map((p) => p.manifest.name).sort()).toEqual([
+      "registry-cache-a",
+      "registry-cache-b",
+    ]);
+  });
+
+  test("applies manifest skip, SDK, artifact, dev-mode, disabled, override, and sorting gates", () => {
+    mkdirSync(join(pluginsDir, "invalid-json"));
+    writeFileSync(join(pluginsDir, "invalid-json", "plugin.json"), "not json");
+    mkdirSync(join(pluginsDir, "no-plugin-json"));
+
+    writeEntryPlugin(pluginsDir, "registry-bad-sdk", { sdk: ">=999.0.0" });
+    writeArtifactPlugin(pluginsDir, "registry-unbuilt", "export default 'unbuilt';\n", null);
+    writePlugin(pluginsDir, "registry-missing-artifact", {
+      artifact: { path: "dist/missing.js", sha256: "sha256:expected" },
+    });
+    writeArtifactPlugin(pluginsDir, "registry-hash-mismatch", "export default 'actual';\n", "sha256:expected");
+
+    const artifactText = "export default 'artifact';\n";
+    const disabledText = "export default 'disabled';\n";
+    const artifactOk = writeArtifactPlugin(pluginsDir, "registry-artifact-ok", artifactText, sha256(artifactText), {
+      weight: 80,
+      tier: "standard",
+    });
+    const disabledOk = writeArtifactPlugin(pluginsDir, "registry-disabled-ok", disabledText, sha256(disabledText), {
+      weight: 70,
+    });
+    writeEntryPlugin(pluginsDir, "registry-legacy-ok", { weight: 50 });
+
+    const devSourceRoot = join(testRoot, "dev-source");
+    mkdirSync(devSourceRoot, { recursive: true });
+    writeArtifactPlugin(devSourceRoot, "registry-dev-artifact", "export default 'dev';\n", null, { weight: 60 });
+    symlinkSync(join(devSourceRoot, "registry-dev-artifact"), join(pluginsDir, "registry-dev-artifact"));
+
+    writeFileSync(join(pluginsDir, ".overrides.json"), JSON.stringify({
+      "registry-artifact-ok": 5,
+      "registry-disabled-ok": 1,
+    }));
+
+    const discovered = discoverPackages({
+      scanDirs: () => [pluginsDir],
+      loadConfig: () => ({ disabledPlugins: ["registry-disabled-ok"] }),
+    });
+
+    expect(discovered.map((p) => p.manifest.name)).toEqual([
+      "registry-disabled-ok",
+      "registry-artifact-ok",
+      "registry-legacy-ok",
+      "registry-dev-artifact",
+    ]);
+    expect(discovered.find((p) => p.manifest.name === "registry-disabled-ok")?.disabled).toBe(true);
+    expect(discovered.find((p) => p.manifest.name === "registry-artifact-ok")?.manifest.weight).toBe(5);
+    expect(discovered.find((p) => p.manifest.name === "registry-disabled-ok")?.manifest.weight).toBe(1);
+    expect(discovered.find((p) => p.manifest.name === "registry-dev-artifact")?.entryPath).toContain("dist/index.js");
+    expect(hashFile(artifactOk.artifactPath)).toBe(sha256(artifactText));
+    expect(hashFile(disabledOk.artifactPath)).toBe(sha256(disabledText));
+
+    const warningText = warns.join("\n");
+    expect(warningText).toContain("requires maw SDK");
+    expect(warningText).toContain("plugin 'registry-unbuilt' is unbuilt");
+    expect(warningText).toContain("plugin 'registry-missing-artifact' artifact missing");
+    expect(warningText).toContain("plugin 'registry-hash-mismatch' artifact hash mismatch");
+  });
+
+  test("applies injected active profile filters after defaulting missing tiers to core", () => {
+    const artifactText = "export default 'profile artifact';\n";
+    writeArtifactPlugin(pluginsDir, "registry-profile-artifact", artifactText, sha256(artifactText), {
+      tier: "standard",
+      weight: 1,
+    });
+    writeEntryPlugin(pluginsDir, "registry-profile-legacy", { weight: 2 });
+    let seenPlugins: PluginNameAndTier[] = [];
+    const deps: DiscoverPackagesDeps = {
+      scanDirs: () => [pluginsDir],
+      loadConfig: () => ({ disabledPlugins: [] }),
+      resolveActiveProfileFilter: (plugins) => {
+        seenPlugins = plugins;
+        return new Set(["registry-profile-legacy"]);
+      },
+    };
+
+    const filtered = discoverPackages(deps);
+
+    expect(seenPlugins).toEqual([
+      { name: "registry-profile-artifact", tier: "standard" },
+      { name: "registry-profile-legacy", tier: "core" },
+    ]);
+    expect(filtered.map((p) => p.manifest.name)).toEqual(["registry-profile-legacy"]);
+  });
+
+  test("no injected profile filter is a passthrough", () => {
+    writeEntryPlugin(pluginsDir, "registry-passthrough-a");
+    writeEntryPlugin(pluginsDir, "registry-passthrough-b");
+
+    expect(names().sort()).toEqual(["registry-passthrough-a", "registry-passthrough-b"]);
+  });
+});

--- a/test/queue-store-default.test.ts
+++ b/test/queue-store-default.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Default-suite coverage for queue-store so pending approval storage counts in
+ * `bun run test:coverage` (isolated tests validate the same behavior in CI but
+ * are intentionally excluded from LCOV generation).
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  TTL_MS,
+  deletePending,
+  isExpired,
+  loadPending,
+  loadPendingById,
+  newPendingId,
+  pendingDir,
+  pendingPath,
+  savePending,
+  updatePending,
+} from "../src/commands/shared/queue-store";
+
+let testDir: string;
+let originalConfigDir: string | undefined;
+let originalHome: string | undefined;
+
+function resetEnv(dir: string = testDir) {
+  process.env.MAW_CONFIG_DIR = dir;
+  delete process.env.MAW_HOME;
+}
+
+beforeEach(() => {
+  testDir = mkdtempSync(join(tmpdir(), "maw-queue-store-default-"));
+  originalConfigDir = process.env.MAW_CONFIG_DIR;
+  originalHome = process.env.MAW_HOME;
+  resetEnv();
+});
+
+afterEach(() => {
+  if (originalConfigDir === undefined) delete process.env.MAW_CONFIG_DIR;
+  else process.env.MAW_CONFIG_DIR = originalConfigDir;
+  if (originalHome === undefined) delete process.env.MAW_HOME;
+  else process.env.MAW_HOME = originalHome;
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+describe("queue-store default coverage", () => {
+  test("resolves pending paths from MAW_CONFIG_DIR and MAW_HOME precedence", () => {
+    expect(pendingDir()).toBe(join(testDir, "pending"));
+    expect(pendingPath("abc")).toBe(join(testDir, "pending", "abc.json"));
+
+    const home = join(testDir, "home");
+    process.env.MAW_HOME = home;
+    process.env.MAW_CONFIG_DIR = join(testDir, "ignored-config");
+    expect(pendingDir()).toBe(join(home, "config", "pending"));
+  });
+
+  test("newPendingId is filesystem-safe and chronological", () => {
+    const id = newPendingId(new Date("2026-05-17T11:22:33.444Z"));
+    expect(id).toMatch(/^2026-05-17T11-22-33-444Z-[0-9a-f]{6}$/);
+    expect(id).not.toContain(":");
+  });
+
+  test("savePending writes a record atomically and loadPending returns oldest first", async () => {
+    const first = savePending({ sender: "alpha", target: "beta", message: "hi", query: "m5:beta" });
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const second = savePending({ sender: "alpha", target: "gamma", message: "again" });
+
+    expect(first).toMatchObject({ sender: "alpha", target: "beta", message: "hi", query: "m5:beta", status: "pending" });
+    const onDisk = JSON.parse(readFileSync(pendingPath(first.id), "utf-8"));
+    expect(onDisk.id).toBe(first.id);
+    expect(readdirSync(pendingDir()).some((file) => file.endsWith(".tmp"))).toBe(false);
+
+    expect(loadPending().map((record) => record.id)).toEqual([first.id, second.id]);
+  });
+
+  test("loadPending handles missing dirs, corrupt files, malformed records, and id fallback sorting", () => {
+    expect(loadPending()).toEqual([]);
+    mkdirSync(pendingDir(), { recursive: true });
+    writeFileSync(join(pendingDir(), "z.json"), JSON.stringify({ id: "z", sender: "s", target: "t", message: "late", sentAt: "", status: "pending" }));
+    writeFileSync(join(pendingDir(), "a.json"), JSON.stringify({ id: "a", sender: "s", target: "t", message: "early", sentAt: "", status: "pending" }));
+    writeFileSync(join(pendingDir(), "bad.json"), "{not json");
+    writeFileSync(join(pendingDir(), "missing-id.json"), JSON.stringify({ sender: "s" }));
+    writeFileSync(join(pendingDir(), "note.txt"), "ignored");
+
+    expect(loadPending().map((record) => record.id)).toEqual(["a", "z"]);
+  });
+
+  test("loadPending and loadPendingById reap expired entries but preserve fresh or unparseable timestamps", () => {
+    const old = savePending({ sender: "a", target: "b", message: "old" });
+    const fresh = savePending({ sender: "a", target: "b", message: "fresh" });
+    const weird = savePending({ sender: "a", target: "b", message: "weird" });
+
+    const oldRecord = JSON.parse(readFileSync(pendingPath(old.id), "utf-8"));
+    oldRecord.sentAt = new Date(Date.now() - TTL_MS - 1000).toISOString();
+    writeFileSync(pendingPath(old.id), JSON.stringify(oldRecord));
+
+    const freshRecord = JSON.parse(readFileSync(pendingPath(fresh.id), "utf-8"));
+    freshRecord.sentAt = new Date(Date.now() - TTL_MS + 60_000).toISOString();
+    writeFileSync(pendingPath(fresh.id), JSON.stringify(freshRecord));
+
+    const weirdRecord = JSON.parse(readFileSync(pendingPath(weird.id), "utf-8"));
+    weirdRecord.sentAt = "not-a-date";
+    writeFileSync(pendingPath(weird.id), JSON.stringify(weirdRecord));
+
+    expect(loadPendingById(old.id)).toBeNull();
+    expect(existsSync(pendingPath(old.id))).toBe(false);
+    expect(loadPending().map((record) => record.id).sort()).toEqual([fresh.id, weird.id].sort());
+    expect(isExpired(weirdRecord)).toBe(false);
+  });
+
+  test("loadPendingById returns null for missing, unreadable-looking, corrupt, and malformed files", () => {
+    expect(loadPendingById("missing")).toBeNull();
+    mkdirSync(pendingDir(), { recursive: true });
+    mkdirSync(pendingPath("directory"), { recursive: true });
+    writeFileSync(pendingPath("corrupt"), "{nope");
+    writeFileSync(pendingPath("malformed"), JSON.stringify({ id: 42 }));
+    expect(loadPendingById("directory")).toBeNull();
+    expect(loadPendingById("corrupt")).toBeNull();
+    expect(loadPendingById("malformed")).toBeNull();
+  });
+
+  test("loadPending returns [] when the pending path exists but is not readable as a directory", () => {
+    writeFileSync(pendingDir(), "not a directory");
+    expect(loadPending()).toEqual([]);
+  });
+
+  test("updatePending preserves id, writes atomically, and rejects unknown ids", () => {
+    const record = savePending({ sender: "a", target: "b", message: "m" });
+    const updated = updatePending(record.id, { id: "evil", status: "approved", message: "changed" });
+    expect(updated).toMatchObject({ id: record.id, status: "approved", message: "changed" });
+    expect(loadPendingById(record.id)?.status).toBe("approved");
+    expect(readdirSync(pendingDir()).some((file) => file.endsWith(".tmp"))).toBe(false);
+    expect(() => updatePending("does-not-exist", { status: "rejected" })).toThrow(/pending message not found/);
+  });
+
+  test("deletePending reports missing files and unlink failures", () => {
+    expect(deletePending("missing")).toBe(false);
+    const record = savePending({ sender: "a", target: "b", message: "m" });
+    expect(deletePending(record.id)).toBe(true);
+    expect(existsSync(pendingPath(record.id))).toBe(false);
+
+    mkdirSync(pendingPath("directory-id"), { recursive: true });
+    expect(deletePending("directory-id")).toBe(false);
+  });
+});

--- a/test/workspace-lifecycle-default.test.ts
+++ b/test/workspace-lifecycle-default.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Default-suite coverage for workspace lifecycle commands.
+ *
+ * The historical workspace suite is isolated because it stubs modules with
+ * mock.module(). These tests use the injected dependency seam so lifecycle
+ * command behavior contributes to LCOV without crossing the mock boundary.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  cmdWorkspaceCreate,
+  cmdWorkspaceJoin,
+  cmdWorkspaceLeave,
+  type WorkspaceLifecycleDeps,
+} from "../src/commands/shared/workspace-lifecycle";
+import type { WorkspaceConfig } from "../src/commands/shared/workspace-store";
+
+type CurlResponse = Awaited<ReturnType<WorkspaceLifecycleDeps["curlFetch"]>>;
+
+function makeHarness(opts: {
+  hub?: string | null;
+  workspaceId?: string | null;
+  workspace?: WorkspaceConfig | null;
+  config?: Record<string, unknown>;
+  response?: CurlResponse;
+  renameThrows?: boolean;
+  unlinkThrows?: boolean;
+  useDefaultNow?: boolean;
+} = {}) {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  const calls: Array<{ url: string; opts: RequestInit }> = [];
+  const saved: WorkspaceConfig[] = [];
+  const renames: Array<[string, string]> = [];
+  const unlinks: string[] = [];
+  let reportedNoWorkspace = false;
+  let exitCode: number | undefined;
+
+  const deps: Partial<WorkspaceLifecycleDeps> = {
+    loadConfig: () => opts.config ?? {},
+    curlFetch: async (url, init) => {
+      calls.push({ url, opts: init ?? {} });
+      return opts.response ?? { ok: true, status: 200, data: null };
+    },
+    resolveHubUrl: () => opts.hub ?? null,
+    resolveWorkspaceId: () => opts.workspaceId ?? null,
+    reportNoWorkspaceId: () => { reportedNoWorkspace = true; errors.push("no workspace id"); },
+    loadWorkspace: () => opts.workspace ?? null,
+    saveWorkspace: (ws) => { saved.push(ws); },
+    configPath: (id) => `/workspaces/${id}.json`,
+    renameSync: (src, dest) => {
+      if (opts.renameThrows) throw new Error("rename denied");
+      renames.push([src, dest]);
+    },
+    unlinkSync: (src) => {
+      if (opts.unlinkThrows) throw new Error("unlink denied");
+      unlinks.push(src);
+    },
+    log: (...args) => logs.push(args.map(String).join(" ")),
+    error: (...args) => errors.push(args.map(String).join(" ")),
+    exit: (code): never => {
+      exitCode = code;
+      throw new Error(`__exit__:${code}`);
+    },
+  };
+
+  if (!opts.useDefaultNow) {
+    deps.now = () => new Date("2026-05-17T11:30:00.000Z");
+  }
+
+  async function run(fn: () => Promise<unknown>) {
+    try {
+      await fn();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (!message.startsWith("__exit__:")) throw error;
+    }
+  }
+
+  return {
+    deps,
+    run,
+    state: {
+      logs,
+      errors,
+      calls,
+      saved,
+      renames,
+      unlinks,
+      get reportedNoWorkspace() { return reportedNoWorkspace; },
+      get exitCode() { return exitCode; },
+    },
+  };
+}
+
+describe("workspace lifecycle default-suite seams", () => {
+  test("create posts node identity, saves the returned workspace, and renders join code", async () => {
+    const h = makeHarness({
+      hub: "https://hub.example",
+      config: { node: "m5" },
+      response: { ok: true, status: 200, data: { id: "ws-1", name: "alpha", joinCode: "abc123" } },
+      useDefaultNow: true,
+    });
+
+    await h.run(() => cmdWorkspaceCreate("alpha", "https://ignored.example", h.deps));
+
+    expect(h.state.exitCode).toBeUndefined();
+    expect(h.state.calls[0]).toMatchObject({ url: "https://hub.example/api/workspace/create" });
+    expect(JSON.parse(String(h.state.calls[0].opts.body))).toEqual({ name: "alpha", nodeId: "m5" });
+    expect(h.state.saved[0]).toMatchObject({
+      id: "ws-1",
+      name: "alpha",
+      hubUrl: "https://hub.example",
+      joinCode: "abc123",
+      sharedAgents: [],
+      lastStatus: "connected",
+    });
+    expect(h.state.saved[0].joinedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(h.state.logs.join("\n")).toContain("workspace created");
+    expect(h.state.logs.join("\n")).toContain("Join code:");
+    expect(h.state.logs.join("\n")).toContain("/workspaces/ws-1.json");
+  });
+
+  test("create exits when no hub exists or when the hub response has no workspace id", async () => {
+    const noHub = makeHarness({ hub: null });
+    await noHub.run(() => cmdWorkspaceCreate("alpha", undefined, noHub.deps));
+    expect(noHub.state.exitCode).toBe(1);
+    expect(noHub.state.errors.join("\n")).toContain("no hub URL");
+
+    const badHub = makeHarness({
+      hub: "https://hub.example",
+      response: { ok: false, status: 503, data: { error: "hub down" } },
+    });
+    await badHub.run(() => cmdWorkspaceCreate("beta", undefined, badHub.deps));
+    expect(badHub.state.exitCode).toBe(1);
+    expect(badHub.state.errors.join("\n")).toContain("failed to create workspace");
+    expect(badHub.state.errors.join("\n")).toContain("hub down");
+  });
+
+  test("create default exit path delegates to process.exit", async () => {
+    const originalExit = process.exit;
+    let processExitCode: number | string | null | undefined;
+    process.exit = ((code?: number | string | null): never => {
+      processExitCode = code;
+      throw new Error("__process_exit__");
+    }) as typeof process.exit;
+
+    try {
+      await expect(cmdWorkspaceCreate("alpha", undefined, {
+        resolveHubUrl: () => null,
+        error: () => {},
+      })).rejects.toThrow("__process_exit__");
+    } finally {
+      process.exit = originalExit;
+    }
+
+    expect(processExitCode).toBe(1);
+  });
+
+  test("join saves defaults, renders object/string agents, and uses local node fallback", async () => {
+    const h = makeHarness({
+      hub: "https://hub.example",
+      response: {
+        ok: true,
+        status: 200,
+        data: { id: "ws-j", agents: [{ name: "alice" }, "bob"] },
+      },
+    });
+
+    await h.run(() => cmdWorkspaceJoin("invite-code", undefined, h.deps));
+
+    expect(JSON.parse(String(h.state.calls[0].opts.body))).toEqual({ code: "invite-code", node: "local" });
+    expect(h.state.saved[0]).toMatchObject({
+      id: "ws-j",
+      name: "unknown",
+      hubUrl: "https://hub.example",
+      joinCode: "invite-code",
+      sharedAgents: [],
+      lastStatus: "connected",
+    });
+    expect(h.state.logs.join("\n")).toContain("2 available");
+    expect(h.state.logs.join("\n")).toContain("alice");
+    expect(h.state.logs.join("\n")).toContain("bob");
+  });
+
+  test("join exits on no hub or a response without id", async () => {
+    const noHub = makeHarness({ hub: null });
+    await noHub.run(() => cmdWorkspaceJoin("code", undefined, noHub.deps));
+    expect(noHub.state.exitCode).toBe(1);
+    expect(noHub.state.errors.join("\n")).toContain("no hub URL");
+
+    const badHub = makeHarness({
+      hub: "https://hub.example",
+      response: { ok: true, status: 200, data: { error: "bad code" } },
+    });
+    await badHub.run(() => cmdWorkspaceJoin("bad", undefined, badHub.deps));
+    expect(badHub.state.exitCode).toBe(1);
+    expect(badHub.state.errors.join("\n")).toContain("failed to join workspace");
+    expect(badHub.state.errors.join("\n")).toContain("bad code");
+  });
+
+  test("leave reports missing context and missing workspace before contacting the hub", async () => {
+    const noId = makeHarness({ workspaceId: null });
+    await noId.run(() => cmdWorkspaceLeave(undefined, noId.deps));
+    expect(noId.state.exitCode).toBe(1);
+    expect(noId.state.reportedNoWorkspace).toBe(true);
+    expect(noId.state.calls).toEqual([]);
+
+    const missing = makeHarness({ workspaceId: "ghost", workspace: null });
+    await missing.run(() => cmdWorkspaceLeave("ghost", missing.deps));
+    expect(missing.state.exitCode).toBe(1);
+    expect(missing.state.errors.join("\n")).toContain("workspace not found: ghost");
+    expect(missing.state.calls).toEqual([]);
+  });
+
+  test("leave posts to the hub and archives local config even when the hub reports failure", async () => {
+    const h = makeHarness({
+      workspaceId: "ws-leave",
+      workspace: {
+        id: "ws-leave",
+        name: "leaveme",
+        hubUrl: "https://hub.example",
+        sharedAgents: [],
+        joinedAt: "then",
+      },
+      config: { node: "m5" },
+      response: { ok: false, status: 500, data: { error: "hub err" } },
+    });
+
+    await h.run(() => cmdWorkspaceLeave("ws-leave", h.deps));
+
+    expect(h.state.exitCode).toBeUndefined();
+    expect(h.state.calls[0].url).toBe("https://hub.example/api/workspace/ws-leave/leave");
+    expect(JSON.parse(String(h.state.calls[0].opts.body))).toEqual({ node: "m5" });
+    expect(h.state.errors.join("\n")).toContain("hub err");
+    expect(h.state.logs.join("\n")).toContain("removing local config anyway");
+    expect(h.state.renames).toEqual([["/workspaces/ws-leave.json", "/workspaces/ws-leave.left.json"]]);
+  });
+
+  test("leave falls back to unlink when archive rename fails", async () => {
+    const h = makeHarness({
+      workspaceId: "ws-unlink",
+      workspace: {
+        id: "ws-unlink",
+        name: "unlinkme",
+        hubUrl: "https://hub.example",
+        sharedAgents: [],
+        joinedAt: "then",
+      },
+      response: { ok: true, status: 200, data: null },
+      renameThrows: true,
+    });
+
+    await h.run(() => cmdWorkspaceLeave("ws-unlink", h.deps));
+
+    expect(h.state.exitCode).toBeUndefined();
+    expect(h.state.unlinks).toEqual(["/workspaces/ws-unlink.json"]);
+    expect(h.state.logs.join("\n")).toContain("left workspace");
+    expect(h.state.logs.join("\n")).toContain("/workspaces/ws-unlink.left.json");
+  });
+
+  test("leave default filesystem archivers rename and unlink fallback", async () => {
+    const fs = require("fs") as typeof import("fs");
+    const os = require("os") as typeof import("os");
+    const path = require("path") as typeof import("path");
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "maw-workspace-lifecycle-"));
+
+    try {
+      const renamed = makeHarness({
+        workspaceId: "ws-fs",
+        workspace: {
+          id: "ws-fs",
+          name: "fs rename",
+          hubUrl: "https://hub.example",
+          sharedAgents: [],
+          joinedAt: "then",
+        },
+        response: { ok: true, status: 200, data: null },
+      });
+      fs.writeFileSync(path.join(tmp, "ws-fs.json"), "{}");
+      const { renameSync: _renameSync, unlinkSync: _unlinkSync, ...renameDeps } = renamed.deps;
+
+      await renamed.run(() => cmdWorkspaceLeave("ws-fs", {
+        ...renameDeps,
+        configPath: (id) => path.join(tmp, `${id}.json`),
+      }));
+
+      expect(fs.existsSync(path.join(tmp, "ws-fs.json"))).toBe(false);
+      expect(fs.existsSync(path.join(tmp, "ws-fs.left.json"))).toBe(true);
+
+      const unlinked = makeHarness({
+        workspaceId: "ws-fallback",
+        workspace: {
+          id: "ws-fallback",
+          name: "fs unlink",
+          hubUrl: "https://hub.example",
+          sharedAgents: [],
+          joinedAt: "then",
+        },
+        response: { ok: true, status: 200, data: null },
+      });
+      fs.writeFileSync(path.join(tmp, "ws-fallback.json"), "{}");
+      const realRenameSync = fs.renameSync;
+      const realUnlinkSync = fs.unlinkSync;
+      const unlinkedPaths: string[] = [];
+      fs.renameSync = (() => { throw new Error("rename denied"); }) as typeof fs.renameSync;
+      fs.unlinkSync = ((target: fs.PathLike) => {
+        unlinkedPaths.push(String(target));
+        return realUnlinkSync(target);
+      }) as typeof fs.unlinkSync;
+
+      try {
+        const { renameSync: _renameFallback, unlinkSync: _unlinkFallback, ...unlinkDeps } = unlinked.deps;
+        await unlinked.run(() => cmdWorkspaceLeave("ws-fallback", {
+          ...unlinkDeps,
+          configPath: (id) => path.join(tmp, `${id}.json`),
+        }));
+      } finally {
+        fs.renameSync = realRenameSync;
+        fs.unlinkSync = realUnlinkSync;
+      }
+
+      expect(unlinkedPaths).toEqual([path.join(tmp, "ws-fallback.json")]);
+      expect(fs.existsSync(path.join(tmp, "ws-fallback.json"))).toBe(false);
+      expect(fs.existsSync(path.join(tmp, "ws-fallback.left.json"))).toBe(false);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/worktrees-scan-default.test.ts
+++ b/test/worktrees-scan-default.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Default-suite coverage for scanWorktrees().
+ *
+ * The deeper regression suite lives in test/isolated because it historically
+ * used mock.module(). These seam tests use injected dependencies instead so the
+ * core fleet scanner contributes to LCOV without polluting the shared suite.
+ */
+import { describe, expect, test } from "bun:test";
+import { basename, join } from "path";
+import { scanWorktrees, type ScanWorktreesDeps } from "../src/core/fleet/worktrees-scan";
+import type { Session, Window } from "../src/core/runtime/find-window";
+
+const reposRoot = "/ghq/github.com";
+
+function wtPath(org: string, oracle: string, wt: string): string {
+  return `${reposRoot}/${org}/${oracle}/${oracle}.wt-${wt}`;
+}
+
+function derived(path: string) {
+  const dirName = path.split("/").pop()!;
+  const mainRepoName = dirName.split(".wt-")[0]!;
+  const relPath = path.replace(`${reposRoot}/`, "");
+  const parentParts = relPath.split("/");
+  parentParts.pop();
+  const org = parentParts.join("/");
+  const mainRepo = `${org}/${mainRepoName}`;
+  return {
+    dirName,
+    repo: `${org}/${dirName}`,
+    mainRepo,
+    mainPath: join(reposRoot, mainRepo),
+  };
+}
+
+function win(name: string): Window {
+  return { name, index: 1, active: false };
+}
+
+function session(name: string, windows: Window[]): Session {
+  return { name, windows };
+}
+
+function makeDeps(opts: {
+  findPaths?: string[];
+  findThrows?: boolean;
+  sessions?: Session[];
+  sessionsThrow?: boolean;
+  branches?: Record<string, string | Error>;
+  fleet?: Record<string, unknown>;
+  fleetThrows?: boolean;
+  prunable?: Record<string, string>;
+  errors?: string[];
+  commands?: string[];
+} = {}): ScanWorktreesDeps {
+  const errors = opts.errors ?? [];
+  const commands = opts.commands ?? [];
+  return {
+    getGhqRoot: () => "/ghq",
+    fleetDir: "/fleet",
+    listSessions: async () => {
+      if (opts.sessionsThrow) throw new Error("tmux unavailable");
+      return opts.sessions ?? [];
+    },
+    readdirSync: () => {
+      if (opts.fleetThrows) throw new Error("fleet unavailable");
+      return Object.keys(opts.fleet ?? {});
+    },
+    readFileSync: (path) => {
+      const value = opts.fleet?.[basename(path)];
+      if (value instanceof Error) throw value;
+      return typeof value === "string" ? value : JSON.stringify(value ?? {});
+    },
+    hostExec: async (cmd) => {
+      commands.push(cmd);
+      if (cmd.startsWith(`find ${reposRoot} `)) {
+        if (opts.findThrows) throw new Error("find failed");
+        return (opts.findPaths ?? []).join("\n");
+      }
+
+      const gitPath = cmd.match(/git -C '([^']+)'/)?.[1] ?? "";
+      if (cmd.includes("rev-parse --abbrev-ref")) {
+        const branch = opts.branches?.[gitPath] ?? "main";
+        if (branch instanceof Error) throw branch;
+        return branch;
+      }
+      if (cmd.includes("worktree list --porcelain")) {
+        return opts.prunable?.[gitPath] ?? "";
+      }
+      return "";
+    },
+    error: (...args) => errors.push(args.map(String).join(" ")),
+  };
+}
+
+describe("scanWorktrees default-suite coverage", () => {
+  test("dedupes find paths, binds running windows, attaches fleet metadata, and marks existing prunable paths", async () => {
+    const activePath = wtPath("Org", "mawjs-oracle", "6-tile-1");
+    const prunablePath = wtPath("Org", "ghost-oracle", "1-later");
+    const active = derived(activePath);
+    const prunable = derived(prunablePath);
+    const commands: string[] = [];
+
+    const results = await scanWorktrees(makeDeps({
+      findPaths: [activePath, activePath, prunablePath, "/ghq/github.com/Org/not-a-worktree"],
+      sessions: [session("54-mawjs", [win("mawjs-6-tile-1")])],
+      branches: {
+        [activePath]: "feature/tile",
+        [prunablePath]: "feature/ghost",
+      },
+      fleet: {
+        "01-mawjs.json": { windows: [{ repo: active.repo }] },
+      },
+      prunable: {
+        [prunable.mainPath]: prunablePath,
+      },
+      commands,
+    }));
+
+    expect(results.filter((r) => r.path === activePath)).toHaveLength(1);
+    expect(results.find((r) => r.path === activePath)).toMatchObject({
+      branch: "feature/tile",
+      repo: active.repo,
+      mainRepo: active.mainRepo,
+      name: "6-tile-1",
+      status: "active",
+      tmuxWindow: "mawjs-6-tile-1",
+      fleetFile: "01-mawjs.json",
+    });
+    expect(results.find((r) => r.path === prunablePath)).toMatchObject({
+      branch: "feature/ghost",
+      status: "orphan",
+    });
+    expect(commands.filter((cmd) => cmd.includes("rev-parse --abbrev-ref"))).toHaveLength(2);
+  });
+
+  test("falls back cleanly for tmux, branch, and fleet failures while adding unseen prunable worktrees", async () => {
+    const stalePath = wtPath("Org", "stale-oracle", "1-task");
+    const stale = derived(stalePath);
+    const unseenOrphan = "/ghq/github.com/Org/stale-oracle/stale-oracle.wt-pruned";
+
+    const results = await scanWorktrees(makeDeps({
+      findPaths: [stalePath],
+      sessionsThrow: true,
+      branches: { [stalePath]: new Error("branch failed") },
+      fleetThrows: true,
+      prunable: { [stale.mainPath]: unseenOrphan },
+    }));
+
+    expect(results.find((r) => r.path === stalePath)).toMatchObject({
+      branch: "unknown",
+      status: "stale",
+      tmuxWindow: undefined,
+      fleetFile: undefined,
+    });
+    expect(results.find((r) => r.path === unseenOrphan)).toMatchObject({
+      branch: "(prunable)",
+      repo: "stale-oracle.wt-pruned",
+      mainRepo: stale.mainRepo,
+      name: "stale-oracle.wt-pruned",
+      status: "orphan",
+    });
+  });
+
+  test("logs ambiguous window matches and leaves the worktree stale", async () => {
+    const path = wtPath("Org", "shared-oracle", "1-tile");
+    const errors: string[] = [];
+
+    const results = await scanWorktrees(makeDeps({
+      findPaths: [path],
+      sessions: [
+        session("alpha", [win("alpha-tile")]),
+        session("beta", [win("beta-tile")]),
+      ],
+      errors,
+    }));
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ path, status: "stale", tmuxWindow: undefined });
+    expect(errors.join("\n")).toContain("'tile' is ambiguous");
+    expect(errors.join("\n")).toContain("alpha-tile");
+    expect(errors.join("\n")).toContain("beta-tile");
+  });
+
+  test("returns an empty list when the worktree discovery command fails", async () => {
+    await expect(scanWorktrees(makeDeps({ findThrows: true }))).resolves.toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add default-suite coverage for `src/plugin/registry.ts` discovery gates: missing roots, cache reset, SDK/artifact/hash/dev-mode filtering, disabled flags, overrides, sorting, and active-profile filtering
- add narrow injectable seams for registry discovery dependencies so tests avoid global env and Bun `mock.module` pollution while preserving production defaults
- refresh coverage gap analysis: plugin dispatch rises to 81.1% lines / 87.2% funcs; `src/plugin/registry.ts` is now 99.1% lines / 100% funcs

## Validation
- `MAW_TEST_MODE=1 bun test test/plugin-registry-default.test.ts`
- `MAW_TEST_MODE=1 bun test test/hooks-registry.test.ts test/plugin-registry-default.test.ts`
- `MAW_TEST_MODE=1 bun test test/plugin-registry-default.test.ts --coverage --coverage-reporter=text --coverage-dir=/tmp/maw-coverage-plugin-registry` (`src/plugin/registry.ts`: 99.13% lines / 100% funcs)
- `MAW_TEST_MODE=1 bun run test` (2072 pass / 6 skip / 0 fail)
- `MAW_TEST_MODE=1 bun run test:coverage` (2072 pass / 6 skip / 0 fail; overall 79.7% funcs / 28.8% lines)
- `MAW_TEST_MODE=1 bun run test:isolated` (127/127 files passed)
- `MAW_TEST_MODE=1 bun run test:plugin` (199 pass / 2 skip / 0 fail)
- `MAW_TEST_MODE=1 bun run test:mock-smoke` (6 pass / 0 fail)
- `bun run build`

Part of #1637.

No release cut; alpha feature PR only.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat’s m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
