### PR TITLE
fix(plugin): install bare registry GitHub sources

### DIFF
--- a/src/commands/plugins/plugin/registry-resolve.ts
+++ b/src/commands/plugins/plugin/registry-resolve.ts
@@ -17,7 +17,7 @@
  */
 
 import type { RegistryManifest } from "./registry-fetch";
-import { parseMonorepoRef } from "./install-source-detect";
+import { parseGithubRef as parseInstallGithubRef, parseMonorepoRef } from "./install-source-detect";
 
 export type SourceKind = "npm" | "github" | "https" | "monorepo";
 
@@ -86,6 +86,13 @@ export function resolvePluginSource(
 
   const gh = parseGithubRef(raw);
   if (gh) return { kind: "github", source: githubTarballUrl(gh), ...common };
+
+  // Current registry entries use the same Vercel-style GitHub source
+  // accepted by `maw plugin install owner/repo[/subpath][@ref]`. Pass it
+  // through so install-source-detect.ts can preserve subpath/ref semantics
+  // and resolve the actual archive/release fallback in one place.
+  const installGh = parseInstallGithubRef(raw);
+  if (installGh) return { kind: "github", source: raw, ...common };
 
   // monorepo: passthrough — the install dispatcher (detectMode →
   // installFromMonorepo) handles URL construction and subpath walk.

--- a/test/registry-resolve.test.ts
+++ b/test/registry-resolve.test.ts
@@ -86,6 +86,12 @@ describe("resolvePluginSource", () => {
     expect(r.source).toBe("https://github.com/soulbrews/maw-foo/archive/refs/tags/v2.tar.gz");
   });
 
+  it("passes through bare owner/repo[/subpath][@ref] GitHub sources", () => {
+    const r = resolvePluginSource("foo", manifestWith("soul-brews-studio/maw-plugin-registry/session-chain@main"))!;
+    expect(r.kind).toBe("github");
+    expect(r.source).toBe("soul-brews-studio/maw-plugin-registry/session-chain@main");
+  });
+
   it("passes through https://.../.tgz", () => {
     const url = "https://cdn.example.com/foo-1.2.3.tgz";
     const r = resolvePluginSource("foo", manifestWith(url))!;


### PR DESCRIPTION
## Summary

- fixes #1759
- lets registry entries using `owner/repo[/subpath][@ref]` pass through to the existing GitHub installer path
- keeps legacy `github:OWNER/REPO#REF`, `npm:`, `monorepo:`, and tarball handling intact

## Validation

- `MAW_TEST_MODE=1 bun test test/registry-resolve.test.ts`
- `MAW_TEST_MODE=1 bun test test/registry-resolve.test.ts test/install-github.test.ts`

## Notes

This unblocks maw-plugin-registry #84 (`session-chain`), whose registry entry uses the current bare source format.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.