### PR TITLE
test(coverage): count federation sync CLI in default suite

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,23 +1,23 @@
 # Coverage gap analysis
 
-Generated: 2026-05-17T11:36:55.933Z
+Generated: 2026-05-17T12:01:01.665Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **29.5%** (14800/50209)
-Overall function coverage: **80.6%** (1669/2071)
+Overall line coverage: **29.8%** (14956/50191)
+Overall function coverage: **80.8%** (1680/2078)
 
 ## Module summary
 
 | Module | Files | Missing from LCOV | Lines | Functions | Branches |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| cli/dispatch | 90 | 15 | 60.8% (4488/7377) | 80.0% (436/545) | n/a (0/0) |
-| config/runtime | 19 | 2 | 66.0% (770/1167) | 72.9% (70/96) | n/a (0/0) |
+| cli/dispatch | 90 | 15 | 62.4% (4598/7371) | 80.6% (445/552) | n/a (0/0) |
+| config/runtime | 19 | 2 | 66.6% (776/1166) | 74.0% (71/96) | n/a (0/0) |
 | fleet | 17 | 0 | 58.4% (609/1042) | 69.9% (58/83) | n/a (0/0) |
 | matcher | 2 | 0 | 100.0% (41/41) | 100.0% (8/8) | n/a (0/0) |
-| other | 174 | 69 | 36.8% (5303/14402) | 74.9% (574/766) | n/a (0/0) |
+| other | 174 | 69 | 37.1% (5343/14391) | 75.1% (575/766) | n/a (0/0) |
 | plugin dispatch | 15 | 1 | 81.1% (950/1172) | 87.2% (75/86) | n/a (0/0) |
 | routing/aliases | 4 | 0 | 91.4% (582/637) | 94.5% (69/73) | n/a (0/0) |
 | transport | 28 | 2 | 77.8% (1876/2410) | 93.1% (363/390) | n/a (0/0) |
@@ -69,6 +69,7 @@ Overall function coverage: **80.6%** (1669/2071)
 | cli/dispatch | `src/commands/shared/federation-apply.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/federation-diff.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/federation-identity.ts` | 100.0% | 100.0% |
+| cli/dispatch | `src/commands/shared/federation-sync-cli.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/federation-sync.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/federation.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/fleet-doctor-checks-repo.ts` | 100.0% | 100.0% |
@@ -147,13 +148,13 @@ Overall function coverage: **80.6%** (1669/2071)
 | transport | `src/core/transport/pty.ts` | 150 | 0.0% |
 | cli/dispatch | `src/commands/shared/fleet-wake.ts` | 146 | 0.0% |
 | cli/dispatch | `src/commands/shared/pulse-cmd.ts` | 134 | 0.0% |
-| cli/dispatch | `src/commands/shared/federation-sync-cli.ts` | 116 | 10.8% |
 | cli/dispatch | `src/commands/shared/preflight.ts` | 105 | 2.8% |
 | cli/dispatch | `src/commands/shared/fleet-manage.ts` | 101 | 0.0% |
 | cli/dispatch | `src/commands/shared/fleet-resume.ts` | 100 | 0.0% |
 | cli/dispatch | `src/cli/dispatch.ts` | 97 | 46.4% |
 | fleet | `src/core/fleet/registry-oracle-scan-remote.ts` | 93 | 6.1% |
 | cli/dispatch | `src/commands/shared/fleet-doctor.ts` | 92 | 12.4% |
+| cli/dispatch | `src/commands/shared/comm-peek.ts` | 90 | 5.3% |
 
 ## Critical gaps to prioritize
 

--- a/src/commands/shared/federation-sync-cli.ts
+++ b/src/commands/shared/federation-sync-cli.ts
@@ -26,6 +26,27 @@ export interface SyncOptions {
   json?: boolean;
 }
 
+export interface FederationSyncDeps {
+  loadConfig: () => MawConfig;
+  fetchPeerIdentities: typeof fetchPeerIdentities;
+  computeSyncDiff: typeof computeSyncDiff;
+  applySyncDiff: typeof applySyncDiff;
+  log: (...args: unknown[]) => void;
+  exit: (code?: number) => never;
+}
+
+export function federationSyncDeps(overrides: Partial<FederationSyncDeps> = {}): FederationSyncDeps {
+  return {
+    loadConfig,
+    fetchPeerIdentities,
+    computeSyncDiff,
+    applySyncDiff,
+    log: (...args: unknown[]) => console.log(...args),
+    exit: (code?: number): never => process.exit(code),
+    ...overrides,
+  };
+}
+
 /**
  * Lazy save-config shim — same pattern as fleet-doctor, avoids breaking
  * tests that mock.module() the config module globally.
@@ -38,116 +59,118 @@ function defaultSave(update: Partial<MawConfig>): void {
 export async function cmdFederationSync(
   opts: SyncOptions = {},
   save: (update: Partial<MawConfig>) => void = defaultSave,
+  deps: Partial<FederationSyncDeps> = {},
 ): Promise<void> {
-  const config = loadConfig();
+  const io = federationSyncDeps(deps);
+  const config = io.loadConfig();
   const localNode = config.node || "local";
   const peers = config.namedPeers || [];
   const agents = config.agents || {};
 
   if (peers.length === 0) {
     if (opts.json) {
-      console.log(JSON.stringify({ node: localNode, diff: null, reason: "no peers" }));
-      process.exit(0);
+      io.log(JSON.stringify({ node: localNode, diff: null, reason: "no peers" }));
+      io.exit(0);
     }
-    console.log();
-    console.log(`  ${C.gray}no namedPeers configured — nothing to sync${C.reset}`);
-    console.log();
-    process.exit(0);
+    io.log();
+    io.log(`  ${C.gray}no namedPeers configured — nothing to sync${C.reset}`);
+    io.log();
+    io.exit(0);
   }
 
-  const identities = await fetchPeerIdentities(peers);
-  const diff = computeSyncDiff(agents, identities, localNode);
+  const identities = await io.fetchPeerIdentities(peers);
+  const diff = io.computeSyncDiff(agents, identities, localNode);
 
   if (opts.json) {
-    console.log(JSON.stringify({ node: localNode, diff, dryRun: !!opts.dryRun }, null, 2));
+    io.log(JSON.stringify({ node: localNode, diff, dryRun: !!opts.dryRun }, null, 2));
     const dirty = diff.add.length + diff.stale.length + diff.conflict.length > 0;
-    process.exit(opts.check && dirty ? 1 : 0);
+    io.exit(opts.check && dirty ? 1 : 0);
   }
 
-  console.log();
-  console.log(
+  io.log();
+  io.log(
     `  ${C.blue}${C.bold}🔄 Federation Sync${C.reset}  ${C.gray}node: ${localNode} · ${peers.length} peers · ${Object.keys(agents).length} agents${C.reset}`,
   );
-  console.log();
+  io.log();
 
   // Per-peer section
   for (const id of identities) {
     const label = `${id.peerName} ${C.gray}(${id.url})${C.reset}`;
     if (!id.reachable) {
-      console.log(`  ${C.yellow}!${C.reset} ${label}  ${C.gray}unreachable${id.error ? ` — ${id.error}` : ""}${C.reset}`);
+      io.log(`  ${C.yellow}!${C.reset} ${label}  ${C.gray}unreachable${id.error ? ` — ${id.error}` : ""}${C.reset}`);
       continue;
     }
     const adds = diff.add.filter((a) => a.fromPeer === id.peerName);
     const confs = diff.conflict.filter((c) => c.fromPeer === id.peerName);
     const stale = diff.stale.filter((s) => s.peerNode === id.node);
-    console.log(`  ${C.green}●${C.reset} ${label}  ${C.gray}node=${id.node} · ${id.agents.length} oracles${C.reset}`);
+    io.log(`  ${C.green}●${C.reset} ${label}  ${C.gray}node=${id.node} · ${id.agents.length} oracles${C.reset}`);
     for (const a of adds) {
-      console.log(`      ${C.green}+${C.reset} ${a.oracle}  ${C.gray}→ ${a.peerNode}${C.reset}`);
+      io.log(`      ${C.green}+${C.reset} ${a.oracle}  ${C.gray}→ ${a.peerNode}${C.reset}`);
     }
     for (const c of confs) {
-      console.log(
+      io.log(
         `      ${C.yellow}~${C.reset} ${c.oracle}  ${C.gray}currently ${c.current}, peer claims ${c.proposed}${C.reset}`,
       );
     }
     for (const s of stale) {
-      console.log(`      ${C.red}-${C.reset} ${s.oracle}  ${C.gray}no longer hosted on ${s.peerNode}${C.reset}`);
+      io.log(`      ${C.red}-${C.reset} ${s.oracle}  ${C.gray}no longer hosted on ${s.peerNode}${C.reset}`);
     }
   }
-  console.log();
+  io.log();
 
   const dirty = diff.add.length + diff.stale.length + diff.conflict.length > 0;
 
   if (!dirty) {
-    console.log(`  ${C.green}✓${C.reset} in sync. ${C.gray}(${diff.unreachable.length} peers unreachable)${C.reset}`);
-    console.log();
-    process.exit(0);
+    io.log(`  ${C.green}✓${C.reset} in sync. ${C.gray}(${diff.unreachable.length} peers unreachable)${C.reset}`);
+    io.log();
+    io.exit(0);
   }
 
   // Conflicts block apply unless --force
   if (diff.conflict.length > 0 && !opts.force && !opts.dryRun && !opts.check) {
-    console.log(
+    io.log(
       `  ${C.yellow}${diff.conflict.length} conflict${diff.conflict.length === 1 ? "" : "s"}${C.reset} — rerun with ${C.bold}--force${C.reset} to overwrite existing routes.`,
     );
-    console.log();
-    process.exit(2);
+    io.log();
+    io.exit(2);
   }
 
   // Stale entries won't be removed unless --prune
   if (diff.stale.length > 0 && !opts.prune && !opts.dryRun && !opts.check) {
-    console.log(
+    io.log(
       `  ${C.gray}${diff.stale.length} stale entr${diff.stale.length === 1 ? "y" : "ies"} — rerun with ${C.bold}--prune${C.reset}${C.gray} to remove${C.reset}`,
     );
   }
 
   if (opts.check) {
-    console.log(
+    io.log(
       `  ${C.yellow}✖${C.reset} out of sync: ${diff.add.length} add · ${diff.conflict.length} conflict · ${diff.stale.length} stale`,
     );
-    console.log();
-    process.exit(1);
+    io.log();
+    io.exit(1);
   }
 
   if (opts.dryRun) {
-    console.log(`  ${C.gray}dry run — no changes written${C.reset}`);
-    console.log();
-    process.exit(0);
+    io.log(`  ${C.gray}dry run — no changes written${C.reset}`);
+    io.log();
+    io.exit(0);
   }
 
   // Apply
-  const { agents: nextAgents, applied } = applySyncDiff(agents, diff, {
+  const { agents: nextAgents, applied } = io.applySyncDiff(agents, diff, {
     force: opts.force,
     prune: opts.prune,
   });
 
   if (applied.length > 0) {
     save({ agents: nextAgents });
-    console.log(`  ${C.green}✓${C.reset} applied ${applied.length} change${applied.length === 1 ? "" : "s"}:`);
-    for (const msg of applied) console.log(`     ${msg}`);
-    console.log();
+    io.log(`  ${C.green}✓${C.reset} applied ${applied.length} change${applied.length === 1 ? "" : "s"}:`);
+    for (const msg of applied) io.log(`     ${msg}`);
+    io.log();
   } else {
-    console.log(`  ${C.gray}no changes applied (use --force / --prune)${C.reset}`);
-    console.log();
+    io.log(`  ${C.gray}no changes applied (use --force / --prune)${C.reset}`);
+    io.log();
   }
 
-  process.exit(0);
+  io.exit(0);
 }

--- a/test/federation-sync-cli-default.test.ts
+++ b/test/federation-sync-cli-default.test.ts
@@ -1,0 +1,378 @@
+/**
+ * federation-sync-cli.ts — default-suite coverage through explicit DI.
+ *
+ * The isolated suite still owns mock.module compatibility. This file keeps the
+ * default runner on the CLI formatter/orchestrator without network or disk I/O.
+ */
+import { describe, expect, test } from "bun:test";
+import type { MawConfig, PeerConfig } from "../src/config";
+import {
+  cmdFederationSync,
+  federationSyncDeps,
+  type FederationSyncDeps,
+  type SyncOptions,
+} from "../src/commands/shared/federation-sync-cli";
+import { computeSyncDiff } from "../src/commands/shared/federation-diff";
+import { applySyncDiff } from "../src/commands/shared/federation-apply";
+import type { PeerIdentity, SyncDiff } from "../src/commands/shared/federation-identity";
+
+function peer(
+  peerName: string,
+  node: string,
+  agents: string[],
+  reachable = true,
+  error?: string,
+): PeerIdentity {
+  return {
+    peerName,
+    url: `https://${peerName}.example`,
+    node,
+    agents,
+    reachable,
+    ...(error !== undefined ? { error } : {}),
+  };
+}
+
+interface HarnessOptions {
+  config?: Partial<MawConfig>;
+  identities?: PeerIdentity[];
+  deps?: Partial<FederationSyncDeps>;
+}
+
+function makeHarness(options: HarnessOptions = {}) {
+  const logs: string[] = [];
+  const exits: number[] = [];
+  const saves: Array<Partial<MawConfig>> = [];
+  const fetchCalls: PeerConfig[][] = [];
+  const config = options.config ?? {};
+  const identities = options.identities ?? [];
+
+  const deps = federationSyncDeps({
+    loadConfig: () => config as MawConfig,
+    fetchPeerIdentities: async (peers: PeerConfig[]) => {
+      fetchCalls.push(peers);
+      return identities;
+    },
+    computeSyncDiff,
+    applySyncDiff,
+    log: (...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
+    },
+    exit: (code = 0): never => {
+      exits.push(code);
+      throw new Error(`__exit__:${code}`);
+    },
+    ...options.deps,
+  });
+
+  const save = (update: Partial<MawConfig>) => {
+    saves.push(update);
+  };
+
+  async function run(opts: SyncOptions = {}) {
+    try {
+      await cmdFederationSync(opts, save, deps);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      if (!message.startsWith("__exit__")) throw e;
+    }
+  }
+
+  return { deps, logs, exits, saves, fetchCalls, run };
+}
+
+function joined(logs: string[]) {
+  return logs.join("\n");
+}
+
+describe("federationSyncDeps", () => {
+  test("returns production defaults with requested overrides", () => {
+    const loadConfig = () => ({ node: "test" }) as MawConfig;
+    const deps = federationSyncDeps({ loadConfig });
+
+    expect(deps.loadConfig).toBe(loadConfig);
+    expect(typeof deps.fetchPeerIdentities).toBe("function");
+    expect(typeof deps.computeSyncDiff).toBe("function");
+    expect(typeof deps.applySyncDiff).toBe("function");
+    expect(typeof deps.log).toBe("function");
+    expect(typeof deps.exit).toBe("function");
+  });
+
+  test("default log and exit delegates are callable", () => {
+    const deps = federationSyncDeps();
+    const origLog = console.log;
+    const origExit = process.exit;
+    const logs: string[] = [];
+    let exitCode: number | undefined;
+
+    console.log = (...args: unknown[]) => { logs.push(args.map(String).join(" ")); };
+    (process as unknown as { exit: (code?: number) => never }).exit = (code = 0): never => {
+      exitCode = code;
+      throw new Error(`__exit__:${code}`);
+    };
+
+    try {
+      deps.log("hello", "world");
+      expect(() => deps.exit(7)).toThrow("__exit__:7");
+    } finally {
+      console.log = origLog;
+      (process as unknown as { exit: typeof origExit }).exit = origExit;
+    }
+
+    expect(logs).toEqual(["hello world"]);
+    expect(exitCode).toBe(7);
+  });
+});
+
+describe("cmdFederationSync default coverage", () => {
+  test("text mode exits cleanly when namedPeers is empty", async () => {
+    const h = makeHarness({ config: { node: "white", namedPeers: [], agents: {} } });
+
+    await h.run();
+
+    expect(h.exits).toEqual([0]);
+    expect(joined(h.logs)).toContain("no namedPeers configured");
+    expect(h.fetchCalls).toEqual([]);
+    expect(h.saves).toEqual([]);
+  });
+
+  test("json mode reports local node fallback when there are no peers", async () => {
+    const h = makeHarness({ config: { agents: {} } });
+
+    await h.run({ json: true });
+
+    expect(h.exits).toEqual([0]);
+    expect(JSON.parse(h.logs[0])).toEqual({ node: "local", diff: null, reason: "no peers" });
+  });
+
+  test("json mode exits 1 for dirty --check output and includes dryRun", async () => {
+    const h = makeHarness({
+      config: {
+        node: "m5",
+        namedPeers: [{ name: "white", url: "https://white.example" }],
+        agents: {},
+      },
+      identities: [peer("white", "white", ["neo"])],
+    });
+
+    await h.run({ json: true, check: true, dryRun: true });
+
+    expect(h.exits).toEqual([1]);
+    const payload = JSON.parse(h.logs[0]);
+    expect(payload.node).toBe("m5");
+    expect(payload.dryRun).toBe(true);
+    expect(payload.diff.add).toEqual([{ oracle: "neo", peerNode: "white", fromPeer: "white" }]);
+  });
+
+  test("json mode exits 0 for clean output", async () => {
+    const h = makeHarness({
+      config: {
+        node: "m5",
+        namedPeers: [{ name: "white", url: "https://white.example" }],
+        agents: { neo: "white" },
+      },
+      identities: [peer("white", "white", ["neo"])],
+    });
+
+    await h.run({ json: true, check: true });
+
+    expect(h.exits).toEqual([0]);
+    const payload = JSON.parse(h.logs[0]);
+    expect(payload.diff).toMatchObject({ add: [], stale: [], conflict: [], unreachable: [] });
+  });
+
+  test("renders reachable adds/conflicts/stale entries and unreachable errors in dry-run mode", async () => {
+    const h = makeHarness({
+      config: {
+        node: "m5",
+        namedPeers: [
+          { name: "white", url: "https://white.example" },
+          { name: "dead", url: "https://dead.example" },
+        ],
+        agents: { existing: "old-node", stale: "white", local: "local" },
+      },
+      identities: [
+        peer("white", "white", ["neo", "existing"]),
+        peer("dead", "", [], false, "timeout"),
+      ],
+    });
+
+    await h.run({ dryRun: true });
+
+    const out = joined(h.logs);
+    expect(h.exits).toEqual([0]);
+    expect(out).toContain("Federation Sync");
+    expect(out).toContain("unreachable");
+    expect(out).toContain("timeout");
+    expect(out).toContain("+\u001b[0m neo");
+    expect(out).toContain("~\u001b[0m existing");
+    expect(out).toContain("-\u001b[0m stale");
+    expect(out).toContain("dry run");
+    expect(h.saves).toEqual([]);
+  });
+
+  test("prints in-sync summary when no diff is dirty", async () => {
+    const h = makeHarness({
+      config: {
+        node: "m5",
+        namedPeers: [{ name: "white", url: "https://white.example" }],
+        agents: { neo: "white" },
+      },
+      identities: [peer("white", "white", ["neo"])],
+    });
+
+    await h.run();
+
+    expect(h.exits).toEqual([0]);
+    expect(joined(h.logs)).toContain("in sync");
+  });
+
+  test("conflicts fail loudly unless force, dry-run, or check is requested", async () => {
+    const h = makeHarness({
+      config: {
+        node: "m5",
+        namedPeers: [{ name: "white", url: "https://white.example" }],
+        agents: { neo: "old-node" },
+      },
+      identities: [peer("white", "white", ["neo"])],
+    });
+
+    await h.run();
+
+    expect(h.exits).toEqual([2]);
+    expect(joined(h.logs)).toContain("rerun with");
+    expect(joined(h.logs)).toContain("--force");
+    expect(h.saves).toEqual([]);
+  });
+
+  test("stale entries without prune warn and then apply no changes", async () => {
+    const h = makeHarness({
+      config: {
+        node: "m5",
+        namedPeers: [{ name: "white", url: "https://white.example" }],
+        agents: { stale: "white" },
+      },
+      identities: [peer("white", "white", [])],
+    });
+
+    await h.run();
+
+    expect(h.exits).toEqual([0]);
+    const out = joined(h.logs);
+    expect(out).toContain("stale entry");
+    expect(out).toContain("--prune");
+    expect(out).toContain("no changes applied");
+    expect(h.saves).toEqual([]);
+  });
+
+  test("check mode reports out-of-sync summary and exits 1", async () => {
+    const h = makeHarness({
+      config: {
+        node: "m5",
+        namedPeers: [{ name: "white", url: "https://white.example" }],
+        agents: {},
+      },
+      identities: [peer("white", "white", ["neo"])],
+    });
+
+    await h.run({ check: true });
+
+    expect(h.exits).toEqual([1]);
+    expect(joined(h.logs)).toContain("out of sync: 1 add · 0 conflict · 0 stale");
+  });
+
+  test("applies additions and saves the next agents map", async () => {
+    const h = makeHarness({
+      config: {
+        node: "m5",
+        namedPeers: [{ name: "white", url: "https://white.example" }],
+        agents: { local: "local" },
+      },
+      identities: [peer("white", "white", ["neo"])],
+    });
+
+    await h.run();
+
+    expect(h.exits).toEqual([0]);
+    expect(h.saves).toEqual([{ agents: { local: "local", neo: "white" } }]);
+    expect(joined(h.logs)).toContain("applied 1 change");
+  });
+
+  test("force and prune pass through to applySyncDiff", async () => {
+    const h = makeHarness({
+      config: {
+        node: "m5",
+        namedPeers: [{ name: "white", url: "https://white.example" }],
+        agents: { conflict: "old-node", stale: "white" },
+      },
+      identities: [peer("white", "white", ["conflict"])],
+    });
+
+    await h.run({ force: true, prune: true });
+
+    expect(h.exits).toEqual([0]);
+    expect(h.saves).toEqual([{ agents: { conflict: "white" } }]);
+    const out = joined(h.logs);
+    expect(out).toContain("applied 2 changes");
+    expect(out).toContain("--force");
+  });
+
+  test("custom apply dependency can report dirty diff with no applied changes", async () => {
+    const diff: SyncDiff = {
+      add: [{ oracle: "neo", peerNode: "white", fromPeer: "white" }],
+      stale: [],
+      conflict: [],
+      unreachable: [],
+    };
+    const h = makeHarness({
+      config: {
+        node: "m5",
+        namedPeers: [{ name: "white", url: "https://white.example" }],
+        agents: {},
+      },
+      identities: [peer("white", "white", ["neo"])],
+      deps: {
+        computeSyncDiff: () => diff,
+        applySyncDiff: () => ({ agents: {}, applied: [] }),
+      },
+    });
+
+    await h.run();
+
+    expect(h.exits).toEqual([0]);
+    expect(h.saves).toEqual([]);
+    expect(joined(h.logs)).toContain("no changes applied");
+  });
+
+  test("omitted save callback exercises the lazy default save shim safely", async () => {
+    const h = makeHarness({
+      config: {
+        node: "m5",
+        namedPeers: [{ name: "white", url: "https://white.example" }],
+        agents: {},
+      },
+      identities: [peer("white", "white", ["neo"])],
+    });
+    const previousTestMode = process.env.MAW_TEST_MODE;
+    process.env.MAW_TEST_MODE = "1";
+
+    try {
+      await cmdFederationSync({}, undefined as never, h.deps);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      // If the config module resolved to the real home config, #820's guard
+      // proves the lazy shim was reached without risking developer state.
+      // If the runner already sandboxed MAW_HOME/MAW_CONFIG_DIR, the command
+      // may instead persist to that sandbox and exit through the injected seam.
+      if (!message.includes("saveConfig refused") && !message.startsWith("__exit__")) throw e;
+    } finally {
+      if (previousTestMode === undefined) {
+        delete process.env.MAW_TEST_MODE;
+      } else {
+        process.env.MAW_TEST_MODE = previousTestMode;
+      }
+    }
+
+    expect(h.saves).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add injectable dependencies to federation sync CLI while preserving the existing save callback API
- add default-suite coverage for JSON/text output, conflict/stale gates, dry-run/check/apply paths, and the lazy default save shim
- regenerate coverage gap analysis

## Verification
- rtk bun test test/federation-sync-cli-default.test.ts
- rtk bun test --coverage test/federation-sync-cli-default.test.ts
- rtk bun test test/isolated/federation-sync-cli.test.ts
- rtk bun run test:coverage
- rtk bun run build

Coverage evidence: federation-sync-cli.ts is 100% funcs / 100% lines; overall default coverage is 80.8% functions / 29.8% lines.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.