### PR TITLE
test(coverage): count peek routing in default suite

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,19 +1,19 @@
 # Coverage gap analysis
 
-Generated: 2026-05-17T12:01:01.665Z
+Generated: 2026-05-17T12:10:56.041Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **29.8%** (14956/50191)
-Overall function coverage: **80.8%** (1680/2078)
+Overall line coverage: **30.0%** (15049/50194)
+Overall function coverage: **81.0%** (1693/2089)
 
 ## Module summary
 
 | Module | Files | Missing from LCOV | Lines | Functions | Branches |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| cli/dispatch | 90 | 15 | 62.4% (4598/7371) | 80.6% (445/552) | n/a (0/0) |
+| cli/dispatch | 90 | 15 | 63.6% (4691/7374) | 81.3% (458/563) | n/a (0/0) |
 | config/runtime | 19 | 2 | 66.6% (776/1166) | 74.0% (71/96) | n/a (0/0) |
 | fleet | 17 | 0 | 58.4% (609/1042) | 69.9% (58/83) | n/a (0/0) |
 | matcher | 2 | 0 | 100.0% (41/41) | 100.0% (8/8) | n/a (0/0) |
@@ -63,6 +63,7 @@ Overall function coverage: **80.8%** (1680/2078)
 | cli/dispatch | `src/cli/usage.ts` | 89.6% | 92.9% |
 | cli/dispatch | `src/cli/verbosity.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/comm-list.ts` | 100.0% | 100.0% |
+| cli/dispatch | `src/commands/shared/comm-peek.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/comm-send.ts` | 93.3% | 97.2% |
 | cli/dispatch | `src/commands/shared/comm.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/done.ts` | 100.0% | 100.0% |
@@ -154,7 +155,7 @@ Overall function coverage: **80.8%** (1680/2078)
 | cli/dispatch | `src/cli/dispatch.ts` | 97 | 46.4% |
 | fleet | `src/core/fleet/registry-oracle-scan-remote.ts` | 93 | 6.1% |
 | cli/dispatch | `src/commands/shared/fleet-doctor.ts` | 92 | 12.4% |
-| cli/dispatch | `src/commands/shared/comm-peek.ts` | 90 | 5.3% |
+| fleet | `src/core/fleet/worktrees-cleanup.ts` | 88 | 7.4% |
 
 ## Critical gaps to prioritize
 

--- a/src/commands/shared/comm-peek.ts
+++ b/src/commands/shared/comm-peek.ts
@@ -7,11 +7,32 @@ import { loadConfig } from "../../config";
 import { resolveFleetSession } from "./wake";
 import { normalizeTarget } from "../../core/matcher/normalize-target";
 import type { SshSession as Session } from "../../sdk";
+import { shouldAutoWake } from "./should-auto-wake";
 
 /** Resolve which sessions to search for an oracle query (#86). */
 /** @internal */
-export function resolveSearchSessions(query: string, sessions: Session[]): Session[] {
-  const config = loadConfig();
+export interface ResolveSearchSessionsDeps {
+  loadConfig: typeof loadConfig;
+  resolveFleetSession: typeof resolveFleetSession;
+}
+
+export function resolveSearchSessionsDeps(
+  overrides: Partial<ResolveSearchSessionsDeps> = {},
+): ResolveSearchSessionsDeps {
+  return {
+    loadConfig,
+    resolveFleetSession,
+    ...overrides,
+  };
+}
+
+export function resolveSearchSessions(
+  query: string,
+  sessions: Session[],
+  deps: Partial<ResolveSearchSessionsDeps> = {},
+): Session[] {
+  const io = resolveSearchSessionsDeps(deps);
+  const config = io.loadConfig();
   // 1. Check config.sessions mapping
   const mapped = (config.sessions as Record<string, string>)?.[query];
   if (mapped) {
@@ -19,7 +40,7 @@ export function resolveSearchSessions(query: string, sessions: Session[]): Sessi
     if (filtered.length > 0) return filtered;
   }
   // 2. Check fleet configs for oracle → session mapping
-  const fleetSession = resolveFleetSession(query);
+  const fleetSession = io.resolveFleetSession(query);
   if (fleetSession) {
     const filtered = sessions.filter(s => s.name === fleetSession);
     if (filtered.length > 0) return filtered;
@@ -28,18 +49,45 @@ export function resolveSearchSessions(query: string, sessions: Session[]): Sessi
   return sessions;
 }
 
-export async function cmdPeek(query?: string) {
+export interface CmdPeekDeps extends ResolveSearchSessionsDeps {
+  listSessions: typeof listSessions;
+  capture: typeof capture;
+  findWindow: typeof findWindow;
+  curlFetch: typeof curlFetch;
+  shouldAutoWake: typeof shouldAutoWake;
+  log: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+  exit: (code?: number) => never;
+}
+
+export function cmdPeekDeps(overrides: Partial<CmdPeekDeps> = {}): CmdPeekDeps {
+  return {
+    ...resolveSearchSessionsDeps(),
+    listSessions,
+    capture,
+    findWindow,
+    curlFetch,
+    shouldAutoWake,
+    log: (...args: unknown[]) => console.log(...args),
+    error: (...args: unknown[]) => console.error(...args),
+    exit: (code?: number): never => process.exit(code),
+    ...overrides,
+  };
+}
+
+export async function cmdPeek(query?: string, deps: Partial<CmdPeekDeps> = {}) {
+  const io = cmdPeekDeps(deps);
   // Canonicalize first — strip trailing `/`, `/.git`, `/.git/` tab-completion artifacts.
   // Preserve undefined (no-arg case prints the fleet overview).
   if (query !== undefined) query = normalizeTarget(query);
-  const config = loadConfig();
+  const config = io.loadConfig();
 
   // #362b — inform users when they omit the node prefix. Canonical form is
   // `<node>:<oracle>` (matches contacts.json). Bare name works for local
   // peek but scripts should use the prefixed form for fleet portability.
   // Silent when MAW_QUIET=1.
   if (query && !query.includes(":") && !query.includes("/") && !process.env.MAW_QUIET && config.node) {
-    console.error(`\x1b[90mℹ tip: use canonical form 'maw peek ${config.node}:${query}' for cross-node scripts (bare name resolves locally)\x1b[0m`);
+    io.error(`\x1b[90mℹ tip: use canonical form 'maw peek ${config.node}:${query}' for cross-node scripts (bare name resolves locally)\x1b[0m`);
   }
 
   // Node prefix: "white:neo-maw-js" → peek remote agent via federation
@@ -53,31 +101,30 @@ export async function cmdPeek(query?: string) {
       const peer = config.namedPeers?.find(p => p.name === nodeName);
       const peerUrl = peer?.url || config.peers?.find(p => p.includes(nodeName));
       if (peerUrl) {
-        const res = await curlFetch(`${peerUrl}/api/capture?target=${encodeURIComponent(agentName)}`);
+        const res = await io.curlFetch(`${peerUrl}/api/capture?target=${encodeURIComponent(agentName)}`);
         if (res.ok && res.data?.content) {
-          console.log(`\x1b[36m--- ${nodeName}:${agentName} (${nodeName}) ---\x1b[0m`);
-          console.log(res.data.content);
+          io.log(`\x1b[36m--- ${nodeName}:${agentName} (${nodeName}) ---\x1b[0m`);
+          io.log(res.data.content);
           return;
         }
-        console.error(`\x1b[31merror\x1b[0m: capture failed for ${agentName} on ${nodeName}${res.data?.error ? `: ${res.data.error}` : ""}`);
-        process.exit(1);
+        io.error(`\x1b[31merror\x1b[0m: capture failed for ${agentName} on ${nodeName}${res.data?.error ? `: ${res.data.error}` : ""}`);
+        io.exit(1);
       }
     }
   }
 
-  const sessions = await listSessions();
+  const sessions = await io.listSessions();
 
   // #835 — peek's policy is "never auto-wake" (read-only by design). The
   // unified shouldAutoWake() helper is consulted for transparency: if the
   // policy ever changes, the call site is already wired in.
   if (query) {
-    const { shouldAutoWake } = await import("./should-auto-wake");
-    const decision = shouldAutoWake(query, { site: "peek" });
+    const decision = io.shouldAutoWake(query, { site: "peek" });
     if (decision.wake) {
       // Defensive: site=peek always returns wake=false. If a future helper
       // change flips this, we'd need to choose how peek handles a wake; for
       // now we explicitly do nothing (preserve historical behavior) but log.
-      console.error(`\x1b[33mwarn\x1b[0m: shouldAutoWake suggested wake but peek refuses (${decision.reason})`);
+      io.error(`\x1b[33mwarn\x1b[0m: shouldAutoWake suggested wake but peek refuses (${decision.reason})`);
     }
   }
 
@@ -87,21 +134,21 @@ export async function cmdPeek(query?: string) {
       for (const w of s.windows) {
         const target = `${s.name}:${w.index}`;
         try {
-          const content = await capture(target, 3);
+          const content = await io.capture(target, 3);
           const lastLine = content.split("\n").filter(l => l.trim()).pop() || "(empty)";
           const dot = w.active ? "\x1b[32m*\x1b[0m" : " ";
-          console.log(`${dot} \x1b[36m${w.name.padEnd(22)}\x1b[0m ${lastLine.slice(0, 80)}`);
+          io.log(`${dot} \x1b[36m${w.name.padEnd(22)}\x1b[0m ${lastLine.slice(0, 80)}`);
         } catch {
-          console.log(`  \x1b[36m${w.name.padEnd(22)}\x1b[0m (unreachable)`);
+          io.log(`  \x1b[36m${w.name.padEnd(22)}\x1b[0m (unreachable)`);
         }
       }
     }
     return;
   }
-  const searchIn = resolveSearchSessions(query, sessions);
-  const target = findWindow(searchIn, query);
-  if (!target) { console.error(`window not found: ${query}`); process.exit(1); }
-  const content = await capture(target);
-  console.log(`\x1b[36m--- ${target} ---\x1b[0m`);
-  console.log(content);
+  const searchIn = resolveSearchSessions(query, sessions, io);
+  const target = io.findWindow(searchIn, query);
+  if (!target) { io.error(`window not found: ${query}`); io.exit(1); }
+  const content = await io.capture(target);
+  io.log(`\x1b[36m--- ${target} ---\x1b[0m`);
+  io.log(content);
 }

--- a/test/comm-peek-default.test.ts
+++ b/test/comm-peek-default.test.ts
@@ -1,0 +1,316 @@
+/**
+ * comm-peek.ts — default-suite coverage through explicit DI.
+ */
+import { describe, expect, test } from "bun:test";
+import type { MawConfig } from "../src/config";
+import type { SshSession as Session } from "../src/sdk";
+import {
+  cmdPeek,
+  cmdPeekDeps,
+  resolveSearchSessions,
+  resolveSearchSessionsDeps,
+  type CmdPeekDeps,
+} from "../src/commands/shared/comm-peek";
+
+interface HarnessOptions {
+  config?: Partial<MawConfig>;
+  sessions?: Session[];
+  capture?: Record<string, string | Error>;
+  findWindow?: string | null;
+  fleet?: Record<string, string | null>;
+  curl?: Record<string, { ok: boolean; data?: any; status?: number }>;
+  shouldWake?: boolean;
+}
+
+function makeHarness(options: HarnessOptions = {}) {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  const exits: number[] = [];
+  const captureCalls: Array<{ target: string; lines?: number }> = [];
+  const findCalls: Array<{ sessions: Session[]; query: string }> = [];
+  const curlCalls: string[] = [];
+  const fleetCalls: string[] = [];
+  const config = options.config ?? {};
+  const sessions = options.sessions ?? [];
+
+  const deps = cmdPeekDeps({
+    loadConfig: () => config as MawConfig,
+    resolveFleetSession: (name: string) => {
+      fleetCalls.push(name);
+      return options.fleet && name in options.fleet ? options.fleet[name]! : null;
+    },
+    listSessions: async () => sessions,
+    capture: async (target: string, lines?: number) => {
+      captureCalls.push({ target, lines });
+      const value = options.capture?.[target];
+      if (value instanceof Error) throw value;
+      return value ?? "";
+    },
+    findWindow: (search: Session[], query: string) => {
+      findCalls.push({ sessions: search, query });
+      return options.findWindow ?? null;
+    },
+    curlFetch: async (url: string) => {
+      curlCalls.push(url);
+      return options.curl?.[url] ?? { ok: false, status: 0, data: null };
+    },
+    shouldAutoWake: (query: string) => ({
+      wake: options.shouldWake ?? false,
+      reason: `test-decision:${query}`,
+    }),
+    log: (...args: unknown[]) => { logs.push(args.map(String).join(" ")); },
+    error: (...args: unknown[]) => { errors.push(args.map(String).join(" ")); },
+    exit: (code = 0): never => {
+      exits.push(code);
+      throw new Error(`__exit__:${code}`);
+    },
+  });
+
+  async function run(query?: string) {
+    try {
+      await cmdPeek(query, deps);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      if (!message.startsWith("__exit__")) throw e;
+    }
+  }
+
+  return { deps, logs, errors, exits, captureCalls, findCalls, curlCalls, fleetCalls, run };
+}
+
+const session = (name: string, windows: Array<{ index: number; name: string; active?: boolean }>): Session => ({
+  name,
+  windows: windows.map((w) => ({ index: w.index, name: w.name, active: !!w.active })),
+});
+
+const joined = (rows: string[]) => rows.join("\n");
+
+describe("comm peek dependency factories", () => {
+  test("resolveSearchSessionsDeps and cmdPeekDeps expose overridable defaults", () => {
+    const loadConfig = () => ({ sessions: {} }) as MawConfig;
+    const resolveFleetSession = () => null;
+    const resolveDeps = resolveSearchSessionsDeps({ loadConfig, resolveFleetSession });
+    const peekDeps = cmdPeekDeps({ loadConfig, resolveFleetSession });
+
+    expect(resolveDeps.loadConfig).toBe(loadConfig);
+    expect(resolveDeps.resolveFleetSession).toBe(resolveFleetSession);
+    expect(peekDeps.loadConfig).toBe(loadConfig);
+    expect(peekDeps.resolveFleetSession).toBe(resolveFleetSession);
+    expect(typeof peekDeps.listSessions).toBe("function");
+    expect(typeof peekDeps.capture).toBe("function");
+    expect(typeof peekDeps.findWindow).toBe("function");
+    expect(typeof peekDeps.curlFetch).toBe("function");
+    expect(typeof peekDeps.shouldAutoWake).toBe("function");
+    expect(typeof peekDeps.log).toBe("function");
+    expect(typeof peekDeps.error).toBe("function");
+    expect(typeof peekDeps.exit).toBe("function");
+  });
+
+  test("default console and exit delegates are callable", () => {
+    const deps = cmdPeekDeps();
+    const origLog = console.log;
+    const origErr = console.error;
+    const origExit = process.exit;
+    const logs: string[] = [];
+    const errors: string[] = [];
+    let code: number | undefined;
+    console.log = (...args: unknown[]) => { logs.push(args.map(String).join(" ")); };
+    console.error = (...args: unknown[]) => { errors.push(args.map(String).join(" ")); };
+    (process as unknown as { exit: (code?: number) => never }).exit = (c = 0): never => {
+      code = c;
+      throw new Error(`__exit__:${c}`);
+    };
+    try {
+      deps.log("log", "line");
+      deps.error("err", "line");
+      expect(() => deps.exit(9)).toThrow("__exit__:9");
+    } finally {
+      console.log = origLog;
+      console.error = origErr;
+      (process as unknown as { exit: typeof origExit }).exit = origExit;
+    }
+    expect(logs).toEqual(["log line"]);
+    expect(errors).toEqual(["err line"]);
+    expect(code).toBe(9);
+  });
+});
+
+describe("resolveSearchSessions", () => {
+  const sessions = [
+    session("05-neo", [{ index: 0, name: "neo-oracle" }]),
+    session("08-mawjs", [{ index: 0, name: "mawjs-oracle" }]),
+  ];
+
+  test("prefers config.sessions mapping, then fleet mapping, then all sessions", () => {
+    expect(resolveSearchSessions("mawjs", sessions, {
+      loadConfig: () => ({ sessions: { mawjs: "08-mawjs" } }) as MawConfig,
+      resolveFleetSession: () => "05-neo",
+    }).map((s) => s.name)).toEqual(["08-mawjs"]);
+
+    expect(resolveSearchSessions("mawjs", sessions, {
+      loadConfig: () => ({ sessions: { mawjs: "missing" } }) as MawConfig,
+      resolveFleetSession: () => "05-neo",
+    }).map((s) => s.name)).toEqual(["05-neo"]);
+
+    expect(resolveSearchSessions("mawjs", sessions, {
+      loadConfig: () => ({}) as MawConfig,
+      resolveFleetSession: () => null,
+    })).toBe(sessions);
+  });
+});
+
+describe("cmdPeek", () => {
+  test("bare-name tip, slash normalization, and missing window error are visible", async () => {
+    const previousQuiet = process.env.MAW_QUIET;
+    delete process.env.MAW_QUIET;
+    const h = makeHarness({ config: { node: "m5", sessions: {} } });
+    try {
+      await h.run("mawjs/");
+    } finally {
+      if (previousQuiet === undefined) delete process.env.MAW_QUIET;
+      else process.env.MAW_QUIET = previousQuiet;
+    }
+
+    expect(h.exits).toEqual([1]);
+    expect(joined(h.errors)).toContain("maw peek m5:mawjs");
+    expect(joined(h.errors)).toContain("window not found: mawjs");
+    expect(h.findCalls[0].query).toBe("mawjs");
+  });
+
+  test("quiet mode suppresses bare-name tip", async () => {
+    const previousQuiet = process.env.MAW_QUIET;
+    process.env.MAW_QUIET = "1";
+    const h = makeHarness({ config: { node: "m5", sessions: {} } });
+    try {
+      await h.run("mawjs");
+    } finally {
+      if (previousQuiet === undefined) delete process.env.MAW_QUIET;
+      else process.env.MAW_QUIET = previousQuiet;
+    }
+    expect(joined(h.errors)).not.toContain("tip");
+  });
+
+  test("remote namedPeer capture prints content and skips local session search", async () => {
+    const url = "https://white.example/api/capture?target=mawjs";
+    const h = makeHarness({
+      config: { node: "m5", namedPeers: [{ name: "white", url: "https://white.example" }] },
+      curl: { [url]: { ok: true, status: 200, data: { content: "remote body" } } },
+    });
+
+    await h.run("white:mawjs");
+
+    expect(h.curlCalls).toEqual([url]);
+    expect(h.findCalls).toEqual([]);
+    expect(joined(h.logs)).toContain("white:mawjs");
+    expect(joined(h.logs)).toContain("remote body");
+  });
+
+  test("remote peers[] fallback encodes target and failed capture exits 1", async () => {
+    const h = makeHarness({
+      config: { node: "m5", peers: ["https://white.example:3456"] },
+      curl: {
+        "https://white.example:3456/api/capture?target=name%20with%20space": {
+          ok: false,
+          status: 500,
+          data: { error: "peer down" },
+        },
+      },
+    });
+
+    await h.run("white:name with space");
+
+    expect(h.curlCalls).toEqual(["https://white.example:3456/api/capture?target=name%20with%20space"]);
+    expect(h.exits).toEqual([1]);
+    expect(joined(h.errors)).toContain("peer down");
+  });
+
+  test("local and local-node prefixes strip before local lookup", async () => {
+    const h = makeHarness({
+      config: { node: "m5", sessions: {} },
+      sessions: [session("54-mawjs", [{ index: 0, name: "mawjs-oracle", active: true }])],
+      findWindow: "54-mawjs:0",
+      capture: { "54-mawjs:0": "local body" },
+    });
+
+    await h.run("local:mawjs");
+
+    expect(h.curlCalls).toEqual([]);
+    expect(h.findCalls[0].query).toBe("mawjs");
+    expect(joined(h.logs)).toContain("local body");
+  });
+
+  test("unknown remote node falls through to local miss with original query", async () => {
+    const h = makeHarness({
+      config: { node: "m5", namedPeers: [{ name: "other", url: "https://other.example" }], sessions: {} },
+      sessions: [session("54-mawjs", [{ index: 0, name: "mawjs-oracle" }])],
+    });
+
+    await h.run("ghost:mawjs");
+
+    expect(h.curlCalls).toEqual([]);
+    expect(h.findCalls[0].query).toBe("ghost:mawjs");
+    expect(h.exits).toEqual([1]);
+  });
+
+  test("no-query overview prints last non-empty lines, empty fallback, and unreachable rows", async () => {
+    const h = makeHarness({
+      config: { sessions: {} },
+      sessions: [session("54-mawjs", [
+        { index: 0, name: "active-win", active: true },
+        { index: 1, name: "blank-win" },
+        { index: 2, name: "dead-win" },
+      ])],
+      capture: {
+        "54-mawjs:0": "prompt\nlast line",
+        "54-mawjs:1": "\n  \n",
+        "54-mawjs:2": new Error("tmux refused"),
+      },
+    });
+
+    await h.run();
+
+    expect(h.captureCalls).toEqual([
+      { target: "54-mawjs:0", lines: 3 },
+      { target: "54-mawjs:1", lines: 3 },
+      { target: "54-mawjs:2", lines: 3 },
+    ]);
+    const out = joined(h.logs);
+    expect(out).toContain("active-win");
+    expect(out).toContain("last line");
+    expect(out).toContain("blank-win");
+    expect(out).toContain("(empty)");
+    expect(out).toContain("dead-win");
+    expect(out).toContain("(unreachable)");
+  });
+
+  test("single-target local peek narrows mapped session and prints captured content", async () => {
+    const h = makeHarness({
+      config: { sessions: { mawjs: "54-mawjs" } },
+      sessions: [
+        session("33-other", [{ index: 0, name: "other" }]),
+        session("54-mawjs", [{ index: 0, name: "mawjs-oracle" }]),
+      ],
+      findWindow: "54-mawjs:0",
+      capture: { "54-mawjs:0": "pane body" },
+    });
+
+    await h.run("mawjs");
+
+    expect(h.findCalls[0].sessions.map((s) => s.name)).toEqual(["54-mawjs"]);
+    expect(h.captureCalls).toEqual([{ target: "54-mawjs:0", lines: undefined }]);
+    expect(joined(h.logs)).toContain("--- 54-mawjs:0 ---");
+    expect(joined(h.logs)).toContain("pane body");
+  });
+
+  test("defensive auto-wake warning branch stays non-waking", async () => {
+    const h = makeHarness({
+      config: { sessions: {} },
+      shouldWake: true,
+    });
+
+    await h.run("mawjs");
+
+    expect(joined(h.errors)).toContain("peek refuses");
+    expect(h.exits).toEqual([1]);
+  });
+});


### PR DESCRIPTION
## Summary
- add explicit dependencies for comm peek routing/output seams while preserving existing call shapes
- add default-suite coverage for local peek, remote node peek, overview rows, missing-window errors, canonical tip output, and defensive no-wake warning
- regenerate the coverage gap report

## Verification
- rtk bun test test/comm-peek-default.test.ts
- rtk bun test --coverage test/comm-peek-default.test.ts
- rtk bun test test/isolated/comm-peek.test.ts
- rtk bun run test:coverage
- rtk bun run build

Coverage evidence: comm-peek.ts is 100% funcs / 100% lines; overall default coverage is 81.0% functions / 30.0% lines.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.