### PR TITLE
test(coverage): count preflight command in default suite

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,19 +1,19 @@
 # Coverage gap analysis
 
-Generated: 2026-05-17T12:10:56.041Z
+Generated: 2026-05-17T12:19:26.602Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **30.0%** (15049/50194)
-Overall function coverage: **81.0%** (1693/2089)
+Overall line coverage: **30.2%** (15152/50192)
+Overall function coverage: **81.2%** (1705/2100)
 
 ## Module summary
 
 | Module | Files | Missing from LCOV | Lines | Functions | Branches |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| cli/dispatch | 90 | 15 | 63.6% (4691/7374) | 81.3% (458/563) | n/a (0/0) |
+| cli/dispatch | 90 | 15 | 65.0% (4794/7372) | 81.9% (470/574) | n/a (0/0) |
 | config/runtime | 19 | 2 | 66.6% (776/1166) | 74.0% (71/96) | n/a (0/0) |
 | fleet | 17 | 0 | 58.4% (609/1042) | 69.9% (58/83) | n/a (0/0) |
 | matcher | 2 | 0 | 100.0% (41/41) | 100.0% (8/8) | n/a (0/0) |
@@ -83,6 +83,7 @@ Overall function coverage: **81.0%** (1693/2089)
 | cli/dispatch | `src/commands/shared/plugin-create.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/plugins-ls-info.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/plugins-ui.ts` | 100.0% | 100.0% |
+| cli/dispatch | `src/commands/shared/preflight.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/queue-store.ts` | 98.2% | 100.0% |
 | cli/dispatch | `src/commands/shared/receiver-inbox.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/target-cwd.ts` | 100.0% | 100.0% |
@@ -149,13 +150,13 @@ Overall function coverage: **81.0%** (1693/2089)
 | transport | `src/core/transport/pty.ts` | 150 | 0.0% |
 | cli/dispatch | `src/commands/shared/fleet-wake.ts` | 146 | 0.0% |
 | cli/dispatch | `src/commands/shared/pulse-cmd.ts` | 134 | 0.0% |
-| cli/dispatch | `src/commands/shared/preflight.ts` | 105 | 2.8% |
 | cli/dispatch | `src/commands/shared/fleet-manage.ts` | 101 | 0.0% |
 | cli/dispatch | `src/commands/shared/fleet-resume.ts` | 100 | 0.0% |
 | cli/dispatch | `src/cli/dispatch.ts` | 97 | 46.4% |
 | fleet | `src/core/fleet/registry-oracle-scan-remote.ts` | 93 | 6.1% |
 | cli/dispatch | `src/commands/shared/fleet-doctor.ts` | 92 | 12.4% |
 | fleet | `src/core/fleet/worktrees-cleanup.ts` | 88 | 7.4% |
+| plugin dispatch | `src/plugin/types.ts` | 86 | 0.0% |
 
 ## Critical gaps to prioritize
 

--- a/src/commands/shared/preflight.ts
+++ b/src/commands/shared/preflight.ts
@@ -1,52 +1,96 @@
 import { listSessions, getPaneInfos, isAgentCommand } from "../../sdk";
-import { buildCommandInDir } from "../../config";
+import { buildCommandInDir, loadConfig } from "../../config";
 import { Tmux } from "../../core/transport/tmux";
 
-export async function cmdPreflight(opts: { fix?: boolean } = {}) {
-  const t0 = Date.now();
-  const tmux = new Tmux();
+export interface PreflightFs {
+  readdirSync: typeof import("fs").readdirSync;
+  lstatSync: typeof import("fs").lstatSync;
+  existsSync: typeof import("fs").existsSync;
+  unlinkSync: typeof import("fs").unlinkSync;
+}
+
+export interface PreflightDeps {
+  now: () => number;
+  packageVersion: () => string;
+  pluginDir: () => string;
+  fs: () => Promise<PreflightFs>;
+  join: typeof import("path").join;
+  listSessions: typeof listSessions;
+  getPaneInfos: typeof getPaneInfos;
+  isAgentCommand: typeof isAgentCommand;
+  buildCommandInDir: typeof buildCommandInDir;
+  loadConfig: typeof loadConfig;
+  tmux: Pick<Tmux, "sendText">;
+  log: (...args: unknown[]) => void;
+}
+
+export function preflightDeps(overrides: Partial<PreflightDeps> = {}): PreflightDeps {
+  return {
+    now: () => Date.now(),
+    packageVersion: () => require("../../../package.json").version,
+    pluginDir: () => {
+      const { join } = require("path") as typeof import("path");
+      const { homedir } = require("os") as typeof import("os");
+      return join(homedir(), ".maw", "plugins");
+    },
+    fs: async () => await import("fs"),
+    join: (...parts: string[]) => {
+      const { join } = require("path") as typeof import("path");
+      return join(...parts);
+    },
+    listSessions,
+    getPaneInfos,
+    isAgentCommand,
+    buildCommandInDir,
+    loadConfig,
+    tmux: new Tmux(),
+    log: (...args: unknown[]) => console.log(...args),
+    ...overrides,
+  };
+}
+
+export async function cmdPreflight(opts: { fix?: boolean } = {}, deps: Partial<PreflightDeps> = {}) {
+  const io = preflightDeps(deps);
+  const t0 = io.now();
   let pass = 0;
   let fail = 0;
   let fixed = 0;
 
-  console.log(`\n  \x1b[36mmaw preflight\x1b[0m\n`);
+  io.log(`\n  \x1b[36mmaw preflight\x1b[0m\n`);
 
   // 1. Version
-  const pkg = require("../../../package.json");
-  console.log(`  \x1b[32m✓\x1b[0m version: v${pkg.version}`);
+  io.log(`  \x1b[32m✓\x1b[0m version: v${io.packageVersion()}`);
   pass++;
 
   // 2. Plugin count + broken symlinks
-  const { readdirSync, lstatSync, existsSync, unlinkSync } = await import("fs");
-  const { join } = await import("path");
-  const { homedir } = await import("os");
-  const pluginDir = join(homedir(), ".maw", "plugins");
+  const { readdirSync, lstatSync, existsSync, unlinkSync } = await io.fs();
+  const pluginDir = io.pluginDir();
   try {
     const entries = readdirSync(pluginDir);
     const broken: string[] = [];
     for (const e of entries) {
-      const p = join(pluginDir, e);
+      const p = io.join(pluginDir, e);
       try { if (lstatSync(p).isSymbolicLink() && !existsSync(p)) broken.push(e); } catch {}
     }
     if (broken.length > 0) {
       if (opts.fix) {
-        for (const b of broken) { try { unlinkSync(join(pluginDir, b)); fixed++; } catch {} }
-        console.log(`  \x1b[33m⚠\x1b[0m plugins: ${entries.length} loaded, ${broken.length} broken symlinks fixed`);
+        for (const b of broken) { try { unlinkSync(io.join(pluginDir, b)); fixed++; } catch {} }
+        io.log(`  \x1b[33m⚠\x1b[0m plugins: ${entries.length} loaded, ${broken.length} broken symlinks fixed`);
       } else {
-        console.log(`  \x1b[31m✗\x1b[0m plugins: ${entries.length} loaded, ${broken.length} broken symlinks`);
+        io.log(`  \x1b[31m✗\x1b[0m plugins: ${entries.length} loaded, ${broken.length} broken symlinks`);
         fail++;
       }
     } else {
-      console.log(`  \x1b[32m✓\x1b[0m plugins: ${entries.length} loaded, 0 broken`);
+      io.log(`  \x1b[32m✓\x1b[0m plugins: ${entries.length} loaded, 0 broken`);
       pass++;
     }
   } catch {
-    console.log(`  \x1b[31m✗\x1b[0m plugins: dir missing`);
+    io.log(`  \x1b[31m✗\x1b[0m plugins: dir missing`);
     fail++;
   }
 
   // 3. Sessions + dead agent detection
-  const sessions = await listSessions().catch(() => []);
+  const sessions = await io.listSessions().catch(() => []);
   const targets: string[] = [];
   const windowMeta: { session: string; window: string; target: string }[] = [];
   for (const s of sessions) {
@@ -57,13 +101,13 @@ export async function cmdPreflight(opts: { fix?: boolean } = {}) {
     }
   }
 
-  const infos = await getPaneInfos(targets);
+  const infos = await io.getPaneInfos(targets);
   let aliveCount = 0;
   const dead: typeof windowMeta = [];
 
   for (const wm of windowMeta) {
     const info = infos[wm.target];
-    if (info && isAgentCommand(info.command)) {
+    if (info && io.isAgentCommand(info.command)) {
       aliveCount++;
     } else if (info) {
       dead.push(wm);
@@ -71,41 +115,40 @@ export async function cmdPreflight(opts: { fix?: boolean } = {}) {
   }
 
   if (sessions.length === 0) {
-    console.log(`  \x1b[90m○\x1b[0m sessions: none running`);
+    io.log(`  \x1b[90m○\x1b[0m sessions: none running`);
   } else {
-    console.log(`  \x1b[32m✓\x1b[0m sessions: ${sessions.length} (${aliveCount} agents alive)`);
+    io.log(`  \x1b[32m✓\x1b[0m sessions: ${sessions.length} (${aliveCount} agents alive)`);
     pass++;
   }
 
   if (dead.length > 0) {
-    console.log(`  \x1b[31m✗\x1b[0m dead agents: ${dead.length} pane${dead.length === 1 ? "" : "s"} with no agent`);
+    io.log(`  \x1b[31m✗\x1b[0m dead agents: ${dead.length} pane${dead.length === 1 ? "" : "s"} with no agent`);
     for (const d of dead) {
       const info = infos[d.target];
-      console.log(`      \x1b[31m●\x1b[0m ${d.session}:${d.window} \x1b[90m(${info?.command || "?"})\x1b[0m`);
+      io.log(`      \x1b[31m●\x1b[0m ${d.session}:${d.window} \x1b[90m(${info?.command || "?"})\x1b[0m`);
     }
     if (opts.fix) {
-      console.log(`\n  \x1b[36m→ reviving ${dead.length} dead agent${dead.length === 1 ? "" : "s"}…\x1b[0m`);
+      io.log(`\n  \x1b[36m→ reviving ${dead.length} dead agent${dead.length === 1 ? "" : "s"}…\x1b[0m`);
       for (const d of dead) {
-        const cmd = buildCommandInDir(d.window, infos[d.target]?.cwd || "");
-        await tmux.sendText(d.target, cmd);
-        console.log(`    \x1b[32m✓\x1b[0m ${d.session}:${d.window}`);
+        const cmd = io.buildCommandInDir(d.window, infos[d.target]?.cwd || "");
+        await io.tmux.sendText(d.target, cmd);
+        io.log(`    \x1b[32m✓\x1b[0m ${d.session}:${d.window}`);
         fixed++;
       }
     } else {
-      console.log(`\n  \x1b[90m  → maw preflight --fix   to revive dead agents\x1b[0m`);
+      io.log(`\n  \x1b[90m  → maw preflight --fix   to revive dead agents\x1b[0m`);
     }
     fail++;
   }
 
   // 4. Config check
-  const { loadConfig } = await import("../../config");
-  const config = loadConfig();
+  const config = io.loadConfig();
   const engines = Object.keys(config.commands || {}).filter(k => k !== "default");
-  console.log(`  \x1b[32m✓\x1b[0m config: node=${config.node || "?"}, engines=[${engines.join(", ") || "default only"}]`);
+  io.log(`  \x1b[32m✓\x1b[0m config: node=${config.node || "?"}, engines=[${engines.join(", ") || "default only"}]`);
   pass++;
 
   // Summary
-  const elapsed = Date.now() - t0;
+  const elapsed = io.now() - t0;
   const icon = fail === 0 ? "\x1b[32m✓\x1b[0m" : "\x1b[33m⚠\x1b[0m";
-  console.log(`\n  ${icon} ${pass} pass, ${fail} fail${fixed > 0 ? `, ${fixed} fixed` : ""} (${elapsed}ms)\n`);
+  io.log(`\n  ${icon} ${pass} pass, ${fail} fail${fixed > 0 ? `, ${fixed} fixed` : ""} (${elapsed}ms)\n`);
 }

--- a/test/preflight-default.test.ts
+++ b/test/preflight-default.test.ts
@@ -1,0 +1,265 @@
+/**
+ * preflight.ts — default-suite coverage through explicit dependencies.
+ */
+import { describe, expect, test } from "bun:test";
+import type { MawConfig } from "../src/config";
+import type { SshSession as Session } from "../src/sdk";
+import { cmdPreflight, preflightDeps, type PreflightFs } from "../src/commands/shared/preflight";
+
+interface FakeLstat { isSymbolicLink: () => boolean; }
+interface HarnessOptions {
+  entries?: string[] | Error;
+  symlinks?: Record<string, boolean>;
+  exists?: Record<string, boolean>;
+  unlinkThrows?: Set<string>;
+  sessions?: Session[] | Error;
+  paneInfos?: Record<string, { command: string; cwd?: string }>;
+  config?: Partial<MawConfig>;
+  agentCommands?: Set<string>;
+}
+
+function makeHarness(options: HarnessOptions = {}) {
+  const logs: string[] = [];
+  const unlinks: string[] = [];
+  const sendTextCalls: Array<{ target: string; text: string }> = [];
+  const buildCalls: Array<{ name: string; cwd: string }> = [];
+  const nowValues = [1000, 1042];
+  const pluginRoot = "/fake/home/.maw/plugins";
+
+  const deps = preflightDeps({
+    now: () => nowValues.shift() ?? 1042,
+    packageVersion: () => "26.5.17-alpha.1200",
+    pluginDir: () => pluginRoot,
+    join: (...parts: string[]) => parts.join("/"),
+    fs: async () => ({
+      readdirSync: () => {
+        if (options.entries instanceof Error) throw options.entries;
+        return options.entries ?? [];
+      },
+      lstatSync: (path: string): FakeLstat => {
+        const name = path.split("/").pop() ?? path;
+        if (name === "throws-lstat") throw new Error("lstat boom");
+        return { isSymbolicLink: () => !!options.symlinks?.[name] };
+      },
+      existsSync: (path: string) => {
+        const name = path.split("/").pop() ?? path;
+        return options.exists?.[name] ?? true;
+      },
+      unlinkSync: (path: string) => {
+        const name = path.split("/").pop() ?? path;
+        if (options.unlinkThrows?.has(name)) throw new Error("unlink boom");
+        unlinks.push(path);
+      },
+    } as PreflightFs),
+    listSessions: async () => {
+      if (options.sessions instanceof Error) throw options.sessions;
+      return options.sessions ?? [];
+    },
+    getPaneInfos: async (targets: string[]) => {
+      expect(Array.isArray(targets)).toBe(true);
+      return options.paneInfos ?? {};
+    },
+    isAgentCommand: (cmd: string) => options.agentCommands?.has(cmd) ?? cmd.includes("claude"),
+    buildCommandInDir: (name: string, cwd: string) => {
+      buildCalls.push({ name, cwd });
+      return `wake ${name} in ${cwd || "<none>"}`;
+    },
+    loadConfig: () => (options.config ?? {}) as MawConfig,
+    tmux: {
+      sendText: async (target: string, text: string) => {
+        sendTextCalls.push({ target, text });
+      },
+    },
+    log: (...args: unknown[]) => { logs.push(args.map(String).join(" ")); },
+  });
+
+  async function run(fix = false) {
+    await cmdPreflight({ fix }, deps);
+  }
+
+  return { logs, unlinks, sendTextCalls, buildCalls, run };
+}
+
+const session = (name: string, windows: Array<{ index: number; name: string }>): Session => ({
+  name,
+  windows: windows.map((w) => ({ index: w.index, name: w.name, active: false })),
+});
+
+const out = (logs: string[]) => logs.join("\n");
+
+describe("preflight dependency factory", () => {
+  test("exposes overridable defaults without changing production call shape", () => {
+    const loadConfig = () => ({ node: "m5" }) as MawConfig;
+    const deps = preflightDeps({ loadConfig });
+
+    expect(deps.loadConfig).toBe(loadConfig);
+    expect(typeof deps.now).toBe("function");
+    expect(typeof deps.packageVersion).toBe("function");
+    expect(typeof deps.pluginDir).toBe("function");
+    expect(typeof deps.fs).toBe("function");
+    expect(typeof deps.join).toBe("function");
+    expect(typeof deps.listSessions).toBe("function");
+    expect(typeof deps.getPaneInfos).toBe("function");
+    expect(typeof deps.isAgentCommand).toBe("function");
+    expect(typeof deps.buildCommandInDir).toBe("function");
+    expect(typeof deps.tmux.sendText).toBe("function");
+    expect(typeof deps.log).toBe("function");
+  });
+
+  test("default path and filesystem helpers remain lazy and callable", async () => {
+    const deps = preflightDeps();
+    const oldLog = console.log;
+    let logged = "";
+
+    try {
+      console.log = ((...args: unknown[]) => { logged = args.map(String).join(" "); }) as typeof console.log;
+
+      expect(deps.now()).toBeGreaterThan(0);
+      expect(deps.packageVersion()).toMatch(/^\d+\.\d+\.\d+/);
+      expect(deps.pluginDir()).toContain(".maw/plugins");
+      expect(typeof (await deps.fs()).readdirSync).toBe("function");
+      expect(deps.join("tmp", "maw")).toBe("tmp/maw");
+      deps.log("preflight", "default", "log");
+    } finally {
+      console.log = oldLog;
+    }
+
+    expect(logged).toBe("preflight default log");
+  });
+});
+
+describe("cmdPreflight", () => {
+  test("happy path reports version, plugin count, alive sessions, config engines, and pass summary", async () => {
+    const h = makeHarness({
+      entries: ["one", "two"],
+      symlinks: { one: true, two: false },
+      exists: { one: true, two: true },
+      sessions: [session("54-mawjs", [{ index: 0, name: "mawjs-oracle" }])],
+      paneInfos: { "54-mawjs:0": { command: "claude", cwd: "/repo" } },
+      config: { node: "m5", commands: { default: "claude", codex: "codex" } },
+    });
+
+    await h.run();
+
+    const text = out(h.logs);
+    expect(text).toContain("maw preflight");
+    expect(text).toContain("version: v26.5.17-alpha.1200");
+    expect(text).toContain("plugins: 2 loaded, 0 broken");
+    expect(text).toContain("sessions: 1 (1 agents alive)");
+    expect(text).toContain("config: node=m5, engines=[codex]");
+    expect(text).toContain("4 pass, 0 fail");
+  });
+
+  test("missing plugin directory and no sessions produce fail-soft summary", async () => {
+    const h = makeHarness({
+      entries: new Error("missing"),
+      sessions: [],
+      config: { commands: { default: "claude" } },
+    });
+
+    await h.run();
+
+    const text = out(h.logs);
+    expect(text).toContain("plugins: dir missing");
+    expect(text).toContain("sessions: none running");
+    expect(text).toContain("config: node=?, engines=[default only]");
+    expect(text).toContain("2 pass, 1 fail");
+  });
+
+  test("broken plugin symlinks fail without --fix and lstat errors are ignored", async () => {
+    const h = makeHarness({
+      entries: ["broken", "throws-lstat"],
+      symlinks: { broken: true },
+      exists: { broken: false },
+      config: {},
+    });
+
+    await h.run(false);
+
+    const text = out(h.logs);
+    expect(text).toContain("plugins: 2 loaded, 1 broken symlinks");
+    expect(h.unlinks).toEqual([]);
+    expect(text).toContain("2 pass, 1 fail");
+  });
+
+  test("--fix removes broken plugin symlinks and counts unlink successes", async () => {
+    const h = makeHarness({
+      entries: ["broken", "also-broken"],
+      symlinks: { broken: true, "also-broken": true },
+      exists: { broken: false, "also-broken": false },
+      unlinkThrows: new Set(["also-broken"]),
+      config: {},
+    });
+
+    await h.run(true);
+
+    const text = out(h.logs);
+    expect(text).toContain("broken symlinks fixed");
+    expect(h.unlinks).toEqual(["/fake/home/.maw/plugins/broken"]);
+    expect(text).toContain("1 fixed");
+  });
+
+  test("dead agents are listed and non-fix mode prints revive hint", async () => {
+    const h = makeHarness({
+      entries: [],
+      sessions: [session("54-mawjs", [
+        { index: 0, name: "mawjs-oracle" },
+        { index: 1, name: "helper" },
+      ])],
+      paneInfos: {
+        "54-mawjs:0": { command: "claude", cwd: "/repo" },
+        "54-mawjs:1": { command: "zsh", cwd: "/repo" },
+      },
+      config: {},
+    });
+
+    await h.run(false);
+
+    const text = out(h.logs);
+    expect(text).toContain("sessions: 1 (1 agents alive)");
+    expect(text).toContain("dead agents: 1 pane with no agent");
+    expect(text).toContain("54-mawjs:helper");
+    expect(text).toContain("maw preflight --fix");
+    expect(h.sendTextCalls).toEqual([]);
+  });
+
+  test("--fix revives dead agents with built commands and counts fixed panes", async () => {
+    const h = makeHarness({
+      entries: [],
+      sessions: [session("54-mawjs", [
+        { index: 0, name: "dead-a" },
+        { index: 1, name: "dead-b" },
+      ])],
+      paneInfos: {
+        "54-mawjs:0": { command: "zsh", cwd: "/repo/a" },
+        "54-mawjs:1": { command: "bash" },
+      },
+      config: {},
+      agentCommands: new Set(["claude"]),
+    });
+
+    await h.run(true);
+
+    expect(h.buildCalls).toEqual([
+      { name: "dead-a", cwd: "/repo/a" },
+      { name: "dead-b", cwd: "" },
+    ]);
+    expect(h.sendTextCalls).toEqual([
+      { target: "54-mawjs:0", text: "wake dead-a in /repo/a" },
+      { target: "54-mawjs:1", text: "wake dead-b in <none>" },
+    ]);
+    expect(out(h.logs)).toContain("2 fixed");
+  });
+
+  test("session listing errors are treated as no running sessions", async () => {
+    const h = makeHarness({
+      entries: [],
+      sessions: new Error("tmux down"),
+      config: {},
+    });
+
+    await h.run();
+
+    expect(out(h.logs)).toContain("sessions: none running");
+  });
+});


### PR DESCRIPTION
## Summary
- add dependency seams for preflight filesystem, tmux, config, clock, and output paths
- cover plugin health, dead-agent detection, --fix revival, fail-soft session listing, and production dependency defaults
- refresh coverage gap analysis with preflight at 100% functions / 100% lines

## Validation
- `rtk bun test --coverage test/preflight-default.test.ts` → preflight.ts 100% functions / 100% lines, 9 pass / 0 fail
- `rtk bun test test/preflight-default.test.ts test/top-aliases-default.test.ts test/isolated/top-aliases-runtime-coverage.test.ts` → 34 pass / 0 fail
- `rtk bun run test:coverage` → 2131 pass / 6 skip / 0 fail; overall 81.2% functions / 30.2% lines
- `rtk bun run build` → bundled dist/maw cleanly

Alpha-only #1611 coverage work. No release cut.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.