### PR TITLE
test(coverage): count fleet manage commands in default suite

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,19 +1,19 @@
 # Coverage gap analysis
 
-Generated: 2026-05-17T12:19:26.602Z
+Generated: 2026-05-17T12:26:29.215Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **30.2%** (15152/50192)
-Overall function coverage: **81.2%** (1705/2100)
+Overall line coverage: **30.4%** (15261/50200)
+Overall function coverage: **81.3%** (1721/2116)
 
 ## Module summary
 
 | Module | Files | Missing from LCOV | Lines | Functions | Branches |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| cli/dispatch | 90 | 15 | 65.0% (4794/7372) | 81.9% (470/574) | n/a (0/0) |
+| cli/dispatch | 90 | 14 | 66.4% (4903/7380) | 82.4% (486/590) | n/a (0/0) |
 | config/runtime | 19 | 2 | 66.6% (776/1166) | 74.0% (71/96) | n/a (0/0) |
 | fleet | 17 | 0 | 58.4% (609/1042) | 69.9% (58/83) | n/a (0/0) |
 | matcher | 2 | 0 | 100.0% (41/41) | 100.0% (8/8) | n/a (0/0) |
@@ -76,6 +76,7 @@ Overall function coverage: **81.2%** (1705/2100)
 | cli/dispatch | `src/commands/shared/fleet-doctor-checks-repo.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/fleet-doctor-checks.ts` | 97.5% | 100.0% |
 | cli/dispatch | `src/commands/shared/fleet-doctor-fixer.ts` | 87.3% | 40.0% |
+| cli/dispatch | `src/commands/shared/fleet-manage.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/fleet-wake-failsoft.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/plugin-create-as.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/plugin-create-rust.ts` | 100.0% | 100.0% |
@@ -150,13 +151,13 @@ Overall function coverage: **81.2%** (1705/2100)
 | transport | `src/core/transport/pty.ts` | 150 | 0.0% |
 | cli/dispatch | `src/commands/shared/fleet-wake.ts` | 146 | 0.0% |
 | cli/dispatch | `src/commands/shared/pulse-cmd.ts` | 134 | 0.0% |
-| cli/dispatch | `src/commands/shared/fleet-manage.ts` | 101 | 0.0% |
 | cli/dispatch | `src/commands/shared/fleet-resume.ts` | 100 | 0.0% |
 | cli/dispatch | `src/cli/dispatch.ts` | 97 | 46.4% |
 | fleet | `src/core/fleet/registry-oracle-scan-remote.ts` | 93 | 6.1% |
 | cli/dispatch | `src/commands/shared/fleet-doctor.ts` | 92 | 12.4% |
 | fleet | `src/core/fleet/worktrees-cleanup.ts` | 88 | 7.4% |
 | plugin dispatch | `src/plugin/types.ts` | 86 | 0.0% |
+| cli/dispatch | `src/commands/shared/pulse-thread.ts` | 82 | 0.0% |
 
 ## Critical gaps to prioritize
 

--- a/src/commands/shared/fleet-manage.ts
+++ b/src/commands/shared/fleet-manage.ts
@@ -3,6 +3,37 @@ import { existsSync, renameSync, unlinkSync, readdirSync } from "fs";
 import { tmux, FLEET_DIR } from "../../sdk";
 import { loadFleetEntries, getSessionNames, type FleetEntry } from "./fleet-load";
 
+export interface FleetManageDeps {
+  loadFleetEntries: typeof loadFleetEntries;
+  getSessionNames: typeof getSessionNames;
+  readdirSync: typeof readdirSync;
+  fleetDir: string;
+  writeFile: (path: string, contents: string) => Promise<unknown>;
+  renameSync: typeof renameSync;
+  existsSync: typeof existsSync;
+  unlinkSync: typeof unlinkSync;
+  join: typeof join;
+  tmuxRun: (...args: string[]) => Promise<string>;
+  log: (...args: unknown[]) => void;
+}
+
+export function fleetManageDeps(overrides: Partial<FleetManageDeps> = {}): FleetManageDeps {
+  return {
+    loadFleetEntries,
+    getSessionNames,
+    readdirSync,
+    fleetDir: FLEET_DIR,
+    writeFile: Bun.write.bind(Bun) as (path: string, contents: string) => Promise<unknown>,
+    renameSync,
+    existsSync,
+    unlinkSync,
+    join,
+    tmuxRun: tmux.run.bind(tmux) as (...args: string[]) => Promise<string>,
+    log: console.log.bind(console) as (...args: unknown[]) => void,
+    ...overrides,
+  };
+}
+
 function displaySessionName(entry: FleetEntry): string {
   const session = entry.session as unknown as { name?: unknown } | null | undefined;
   return typeof session?.name === "string" && session.name.length > 0
@@ -58,16 +89,18 @@ export function renderFleetLs(entries: FleetEntry[], disabled: number, runningSe
   return lines;
 }
 
-export async function cmdFleetLs() {
-  const entries = loadFleetEntries();
-  const disabled = readdirSync(FLEET_DIR).filter(f => f.endsWith(".disabled")).length;
+export async function cmdFleetLs(deps: Partial<FleetManageDeps> = {}) {
+  const io = fleetManageDeps(deps);
+  const entries = io.loadFleetEntries();
+  const disabled = io.readdirSync(io.fleetDir).filter(f => f.endsWith(".disabled")).length;
 
-  const runningSessions = await getSessionNames();
-  for (const line of renderFleetLs(entries, disabled, runningSessions)) console.log(line);
+  const runningSessions = await io.getSessionNames();
+  for (const line of renderFleetLs(entries, disabled, runningSessions)) io.log(line);
 }
 
-export async function cmdFleetRenumber() {
-  const entries = loadFleetEntries();
+export async function cmdFleetRenumber(deps: Partial<FleetManageDeps> = {}) {
+  const io = fleetManageDeps(deps);
+  const entries = io.loadFleetEntries();
 
   // Check for conflicts first
   const numCount = new Map<number, number>();
@@ -75,13 +108,13 @@ export async function cmdFleetRenumber() {
   const hasConflicts = [...numCount.values()].some(c => c > 1);
 
   if (!hasConflicts) {
-    console.log("\n  \x1b[32mNo conflicts found.\x1b[0m Fleet numbering is clean.\n");
+    io.log("\n  \x1b[32mNo conflicts found.\x1b[0m Fleet numbering is clean.\n");
     return;
   }
 
-  const runningSessions = await getSessionNames();
+  const runningSessions = await io.getSessionNames();
 
-  console.log("\n  \x1b[36mRenumbering fleet...\x1b[0m\n");
+  io.log("\n  \x1b[36mRenumbering fleet...\x1b[0m\n");
 
   // Sort by current number, then by name for stability
   const sorted = [...entries].sort((a, b) => a.num - b.num || a.groupName.localeCompare(b.groupName));
@@ -99,14 +132,14 @@ export async function cmdFleetRenumber() {
     if (newFile !== e.file) {
       // Update config.name in JSON — write to temp file then atomically rename
       e.session.name = newName;
-      const tmpPath = join(FLEET_DIR, `.tmp-${newFile}`);
-      await Bun.write(tmpPath, JSON.stringify(e.session, null, 2) + "\n");
-      renameSync(tmpPath, join(FLEET_DIR, newFile));
+      const tmpPath = io.join(io.fleetDir, `.tmp-${newFile}`);
+      await io.writeFile(tmpPath, JSON.stringify(e.session, null, 2) + "\n");
+      io.renameSync(tmpPath, io.join(io.fleetDir, newFile));
 
       // Remove old file (only if name changed)
-      const oldPath = join(FLEET_DIR, e.file);
-      if (existsSync(oldPath) && newFile !== e.file) {
-        unlinkSync(oldPath);
+      const oldPath = io.join(io.fleetDir, e.file);
+      if (io.existsSync(oldPath) && newFile !== e.file) {
+        io.unlinkSync(oldPath);
       }
 
       // Rename running tmux session (#84) — try exact name first, then pattern match
@@ -114,19 +147,19 @@ export async function cmdFleetRenumber() {
         || runningSessions.find(s => s.replace(/^\d+-/, "") === e.groupName);
       if (runningMatch && runningMatch !== newName) {
         try {
-          await tmux.run("rename-session", "-t", runningMatch, newName);
-          console.log(`  ${e.file.padEnd(28)} → ${newFile}  (tmux: ${runningMatch} → ${newName})`);
+          await io.tmuxRun("rename-session", "-t", runningMatch, newName);
+          io.log(`  ${e.file.padEnd(28)} → ${newFile}  (tmux: ${runningMatch} → ${newName})`);
         } catch {
-          console.log(`  ${e.file.padEnd(28)} → ${newFile}  (tmux rename failed: ${runningMatch})`);
+          io.log(`  ${e.file.padEnd(28)} → ${newFile}  (tmux rename failed: ${runningMatch})`);
         }
       } else {
-        console.log(`  ${e.file.padEnd(28)} → ${newFile}`);
+        io.log(`  ${e.file.padEnd(28)} → ${newFile}`);
       }
     } else {
-      console.log(`  ${e.file.padEnd(28)}   (unchanged)`);
+      io.log(`  ${e.file.padEnd(28)}   (unchanged)`);
     }
     num++;
   }
 
-  console.log(`\n  \x1b[32mDone.\x1b[0m ${regular.length} configs renumbered.\n`);
+  io.log(`\n  \x1b[32mDone.\x1b[0m ${regular.length} configs renumbered.\n`);
 }

--- a/test/fleet-manage-default.test.ts
+++ b/test/fleet-manage-default.test.ts
@@ -1,0 +1,204 @@
+/**
+ * fleet-manage.ts — default-suite coverage for fleet list/renumber helpers.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  cmdFleetLs,
+  cmdFleetRenumber,
+  fleetManageDeps,
+  renderFleetLs,
+  type FleetManageDeps,
+} from "../src/commands/shared/fleet-manage";
+import type { FleetEntry, FleetSession } from "../src/commands/shared/fleet-load";
+
+const session = (name: string, windows: Array<{ name: string; repo?: string }> = []): FleetSession => ({
+  name,
+  windows: windows.map(w => ({ name: w.name, repo: w.repo ?? "Soul-Brews-Studio/example" })),
+});
+
+const entry = (file: string, num: number, groupName: string, fleetSession: FleetSession): FleetEntry => ({
+  file,
+  num,
+  groupName,
+  session: fleetSession,
+});
+
+const text = (lines: string[]) => lines.join("\n");
+
+function makeDeps(entries: FleetEntry[], options: {
+  files?: string[];
+  running?: string[];
+  exists?: (path: string) => boolean;
+  tmuxThrowsFor?: Set<string>;
+} = {}) {
+  const logs: string[] = [];
+  const writes: Array<{ path: string; contents: string }> = [];
+  const renames: Array<{ from: string; to: string }> = [];
+  const unlinks: string[] = [];
+  const tmuxRuns: string[][] = [];
+
+  const deps = fleetManageDeps({
+    loadFleetEntries: () => entries,
+    getSessionNames: async () => options.running ?? [],
+    readdirSync: () => options.files ?? [],
+    fleetDir: "/fleet",
+    writeFile: async (path: string, contents: string) => {
+      writes.push({ path, contents });
+      return undefined;
+    },
+    renameSync: (from: string, to: string) => { renames.push({ from, to }); },
+    existsSync: (path: string) => options.exists?.(path) ?? true,
+    unlinkSync: (path: string) => { unlinks.push(path); },
+    join: (...parts: string[]) => parts.join("/"),
+    tmuxRun: async (...args: string[]) => {
+      tmuxRuns.push(args);
+      const runningName = args[2];
+      if (options.tmuxThrowsFor?.has(runningName)) throw new Error("tmux rename failed");
+      return "";
+    },
+    log: (...args: unknown[]) => { logs.push(args.map(String).join(" ")); },
+  } satisfies Partial<FleetManageDeps>);
+
+  return { deps, logs, writes, renames, unlinks, tmuxRuns };
+}
+
+describe("fleetManageDeps", () => {
+  test("exposes production defaults with safe overrides", () => {
+    const loadFleetEntries = () => [] as FleetEntry[];
+    const deps = fleetManageDeps({ loadFleetEntries });
+
+    expect(deps.loadFleetEntries).toBe(loadFleetEntries);
+    expect(typeof deps.getSessionNames).toBe("function");
+    expect(typeof deps.readdirSync).toBe("function");
+    expect(typeof deps.fleetDir).toBe("string");
+    expect(typeof deps.writeFile).toBe("function");
+    expect(typeof deps.renameSync).toBe("function");
+    expect(typeof deps.existsSync).toBe("function");
+    expect(typeof deps.unlinkSync).toBe("function");
+    expect(deps.join("a", "b")).toBe("a/b");
+    expect(typeof deps.tmuxRun).toBe("function");
+    expect(typeof deps.log).toBe("function");
+  });
+});
+
+describe("renderFleetLs", () => {
+  test("renders running/stopped sessions, conflicts, invalid entries, and fallback names", () => {
+    const lines = renderFleetLs([
+      entry("01-alpha.json", 1, "alpha", session("01-alpha", [{ name: "alpha-oracle" }])),
+      entry("01-beta.json", 1, "beta", session("01-beta", [])),
+      entry("bad.json", 3, "fallback", { windows: "bad" } as unknown as FleetSession),
+      entry(".json", 4, "", {} as unknown as FleetSession),
+    ], 2, ["01-alpha"]);
+
+    const out = text(lines);
+    expect(out).toContain("Fleet Configs");
+    expect(out).toContain("4 active, 2 disabled");
+    expect(out).toContain("01-alpha");
+    expect(out).toContain("running");
+    expect(out).toContain("01-beta");
+    expect(out).toContain("stopped");
+    expect(out).toContain("CONFLICT");
+    expect(out).toContain("INVALID");
+    expect(out).toContain("fallback");
+    expect(out).toContain("(unnamed)");
+    expect(out).toContain("maw fleet renumber");
+  });
+});
+
+describe("cmdFleetLs", () => {
+  test("loads entries, counts disabled configs, gets running sessions, and prints rendered rows", async () => {
+    const h = makeDeps([
+      entry("01-alpha.json", 1, "alpha", session("01-alpha", [{ name: "alpha-oracle" }])),
+    ], {
+      files: ["01-alpha.json", "02-beta.json.disabled", "notes.txt", "03-gamma.disabled"],
+      running: ["01-alpha"],
+    });
+
+    await cmdFleetLs(h.deps);
+
+    const out = text(h.logs);
+    expect(out).toContain("1 active, 2 disabled");
+    expect(out).toContain("01-alpha");
+    expect(out).toContain("running");
+  });
+});
+
+describe("cmdFleetRenumber", () => {
+  test("prints a clean message and stops before side effects when no conflicts exist", async () => {
+    const h = makeDeps([
+      entry("01-alpha.json", 1, "alpha", session("01-alpha")),
+      entry("02-beta.json", 2, "beta", session("02-beta")),
+    ]);
+
+    await cmdFleetRenumber(h.deps);
+
+    expect(text(h.logs)).toContain("No conflicts found");
+    expect(h.writes).toEqual([]);
+    expect(h.renames).toEqual([]);
+    expect(h.unlinks).toEqual([]);
+    expect(h.tmuxRuns).toEqual([]);
+  });
+
+  test("renumbers conflicting configs, skips overview, updates tmux when possible, and logs failures", async () => {
+    const h = makeDeps([
+      entry("02-delta.json", 2, "delta", session("02-delta")),
+      entry("02-bravo.json", 2, "bravo", session("old-bravo")),
+      entry("99-overview.json", 99, "overview", session("99-overview")),
+      entry("02-alpha.json", 2, "alpha", session("02-alpha")),
+      entry("02-charlie.json", 2, "charlie", session("02-charlie")),
+    ], {
+      running: ["02-alpha", "99-charlie"],
+      tmuxThrowsFor: new Set(["99-charlie"]),
+    });
+
+    await cmdFleetRenumber(h.deps);
+
+    expect(h.writes.map(w => w.path)).toEqual([
+      "/fleet/.tmp-01-alpha.json",
+      "/fleet/.tmp-03-charlie.json",
+      "/fleet/.tmp-04-delta.json",
+    ]);
+    expect(JSON.parse(h.writes[0].contents).name).toBe("01-alpha");
+    expect(h.renames).toEqual([
+      { from: "/fleet/.tmp-01-alpha.json", to: "/fleet/01-alpha.json" },
+      { from: "/fleet/.tmp-03-charlie.json", to: "/fleet/03-charlie.json" },
+      { from: "/fleet/.tmp-04-delta.json", to: "/fleet/04-delta.json" },
+    ]);
+    expect(h.unlinks).toEqual([
+      "/fleet/02-alpha.json",
+      "/fleet/02-charlie.json",
+      "/fleet/02-delta.json",
+    ]);
+    expect(h.tmuxRuns).toEqual([
+      ["rename-session", "-t", "02-alpha", "01-alpha"],
+      ["rename-session", "-t", "99-charlie", "03-charlie"],
+    ]);
+
+    const out = text(h.logs);
+    expect(out).toContain("Renumbering fleet");
+    expect(out).toContain("02-alpha.json");
+    expect(out).toContain("tmux: 02-alpha → 01-alpha");
+    expect(out).toContain("02-bravo.json");
+    expect(out).toContain("(unchanged)");
+    expect(out).toContain("tmux rename failed: 99-charlie");
+    expect(out).toContain("02-delta.json");
+    expect(out).toContain("Done.");
+    expect(out).toContain("4 configs renumbered");
+    expect(out).not.toContain("99-overview.json");
+  });
+
+  test("does not unlink a missing old config while still writing the replacement", async () => {
+    const h = makeDeps([
+      entry("05-alpha.json", 5, "alpha", session("05-alpha")),
+      entry("05-beta.json", 5, "beta", session("05-beta")),
+    ], {
+      exists: path => !path.endsWith("05-alpha.json"),
+    });
+
+    await cmdFleetRenumber(h.deps);
+
+    expect(h.writes.map(w => w.path)).toEqual(["/fleet/.tmp-01-alpha.json", "/fleet/.tmp-02-beta.json"]);
+    expect(h.unlinks).toEqual(["/fleet/05-beta.json"]);
+    expect(text(h.logs)).toContain("02-beta.json");
+  });
+});


### PR DESCRIPTION
## Summary
- add dependency seams for `maw fleet ls` and `maw fleet renumber` filesystem/tmux/output paths
- cover fleet list rendering for conflicts, invalid entries, fallback display names, and disabled counts
- cover renumber clean/no-op, conflict sorting, overview skip, tmux rename success/failure, and missing old config cleanup
- refresh coverage gap analysis with fleet-manage at 100% functions / 100% lines

## Validation
- `rtk bun test --coverage test/fleet-manage-default.test.ts` → fleet-manage.ts 100% functions / 100% lines, 6 pass / 0 fail
- `rtk bun test test/fleet-manage-default.test.ts test/fleet-doctor.test.ts test/config-fleet-merge.test.ts` → 47 pass / 0 fail
- `rtk bun run test:coverage` → 2137 pass / 6 skip / 0 fail; overall 81.3% functions / 30.4% lines
- `rtk bun run build` → bundled dist/maw cleanly

Alpha-only #1611 coverage work. No release cut.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.