### PR TITLE
test(coverage): count pulse command in default suite

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,19 +1,19 @@
 # Coverage gap analysis
 
-Generated: 2026-05-17T12:26:29.215Z
+Generated: 2026-05-17T12:35:05.751Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **30.4%** (15261/50200)
-Overall function coverage: **81.3%** (1721/2116)
+Overall line coverage: **30.7%** (15413/50211)
+Overall function coverage: **81.3%** (1738/2139)
 
 ## Module summary
 
 | Module | Files | Missing from LCOV | Lines | Functions | Branches |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| cli/dispatch | 90 | 14 | 66.4% (4903/7380) | 82.4% (486/590) | n/a (0/0) |
+| cli/dispatch | 90 | 12 | 68.4% (5055/7391) | 82.1% (503/613) | n/a (0/0) |
 | config/runtime | 19 | 2 | 66.6% (776/1166) | 74.0% (71/96) | n/a (0/0) |
 | fleet | 17 | 0 | 58.4% (609/1042) | 69.9% (58/83) | n/a (0/0) |
 | matcher | 2 | 0 | 100.0% (41/41) | 100.0% (8/8) | n/a (0/0) |
@@ -85,6 +85,7 @@ Overall function coverage: **81.3%** (1721/2116)
 | cli/dispatch | `src/commands/shared/plugins-ls-info.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/plugins-ui.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/preflight.ts` | 100.0% | 100.0% |
+| cli/dispatch | `src/commands/shared/pulse-cmd.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/queue-store.ts` | 98.2% | 100.0% |
 | cli/dispatch | `src/commands/shared/receiver-inbox.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/target-cwd.ts` | 100.0% | 100.0% |
@@ -150,14 +151,14 @@ Overall function coverage: **81.3%** (1721/2116)
 | --- | --- | ---: | ---: |
 | transport | `src/core/transport/pty.ts` | 150 | 0.0% |
 | cli/dispatch | `src/commands/shared/fleet-wake.ts` | 146 | 0.0% |
-| cli/dispatch | `src/commands/shared/pulse-cmd.ts` | 134 | 0.0% |
 | cli/dispatch | `src/commands/shared/fleet-resume.ts` | 100 | 0.0% |
 | cli/dispatch | `src/cli/dispatch.ts` | 97 | 46.4% |
 | fleet | `src/core/fleet/registry-oracle-scan-remote.ts` | 93 | 6.1% |
 | cli/dispatch | `src/commands/shared/fleet-doctor.ts` | 92 | 12.4% |
 | fleet | `src/core/fleet/worktrees-cleanup.ts` | 88 | 7.4% |
 | plugin dispatch | `src/plugin/types.ts` | 86 | 0.0% |
-| cli/dispatch | `src/commands/shared/pulse-thread.ts` | 82 | 0.0% |
+| cli/dispatch | `src/commands/shared/wake-session.ts` | 82 | 6.8% |
+| transport | `src/transports/scout-pair.ts` | 80 | 9.1% |
 
 ## Critical gaps to prioritize
 

--- a/src/commands/shared/pulse-cmd.ts
+++ b/src/commands/shared/pulse-cmd.ts
@@ -5,13 +5,45 @@ import {
   findOrCreateDailyThread, addTaskToPeriodComment,
 } from "./pulse-thread";
 
-export async function cmdPulseAdd(title: string, opts: { oracle?: string; priority?: string; wt?: string }) {
+export interface PulseIssue {
+  number: number;
+  title: string;
+  labels: { name: string }[];
+}
+
+export interface PulseDeps {
+  hostExec: typeof hostExec;
+  cmdWake: typeof cmdWake;
+  timePeriod: typeof timePeriod;
+  todayDate: typeof todayDate;
+  todayLabel: typeof todayLabel;
+  findOrCreateDailyThread: typeof findOrCreateDailyThread;
+  addTaskToPeriodComment: typeof addTaskToPeriodComment;
+  log: (...args: unknown[]) => void;
+}
+
+export function pulseDeps(overrides: Partial<PulseDeps> = {}): PulseDeps {
+  return {
+    hostExec,
+    cmdWake,
+    timePeriod,
+    todayDate,
+    todayLabel,
+    findOrCreateDailyThread,
+    addTaskToPeriodComment,
+    log: console.log.bind(console) as (...args: unknown[]) => void,
+    ...overrides,
+  };
+}
+
+export async function cmdPulseAdd(title: string, opts: { oracle?: string; priority?: string; wt?: string }, deps: Partial<PulseDeps> = {}) {
+  const io = pulseDeps(deps);
   const repo = "laris-co/pulse-oracle";
   const projectNum = 6; // Master Board
-  const period = timePeriod();
+  const period = io.timePeriod();
 
   // 0. Find or create daily thread
-  const thread = await findOrCreateDailyThread(repo);
+  const thread = await io.findOrCreateDailyThread(repo);
 
   // 1. Create task issue
   const escaped = title.replace(/'/g, "'\\''");
@@ -19,23 +51,23 @@ export async function cmdPulseAdd(title: string, opts: { oracle?: string; priori
   if (opts.oracle) labels.push(`oracle:${opts.oracle}`);
   const labelFlags = labels.length ? labels.map(l => `-l '${l}'`).join(" ") : "";
 
-  const issueUrl = (await hostExec(
+  const issueUrl = (await io.hostExec(
     `gh issue create --repo ${repo} -t '${escaped}' ${labelFlags} -b 'Parent: #${thread.num}'`
   )).trim();
   const m = issueUrl.match(/\/(\d+)$/);
   const issueNum = m ? +m[1] : 0;
-  console.log(`\x1b[32m+\x1b[0m issue #${issueNum} (${period}): ${issueUrl}`);
+  io.log(`\x1b[32m+\x1b[0m issue #${issueNum} (${period}): ${issueUrl}`);
 
   // 2. Add task to period comment in daily thread (edit triggers webhook!)
-  await addTaskToPeriodComment(repo, thread.num, period, issueNum, title, opts.oracle);
-  console.log(`\x1b[32m+\x1b[0m added to ${period} in daily thread #${thread.num}`);
+  await io.addTaskToPeriodComment(repo, thread.num, period, issueNum, title, opts.oracle);
+  io.log(`\x1b[32m+\x1b[0m added to ${period} in daily thread #${thread.num}`);
 
   // 3. Add to Master Board
   try {
-    await hostExec(`gh project item-add ${projectNum} --owner laris-co --url '${issueUrl}'`);
-    console.log(`\x1b[32m+\x1b[0m added to Master Board (#${projectNum})`);
+    await io.hostExec(`gh project item-add ${projectNum} --owner laris-co --url '${issueUrl}'`);
+    io.log(`\x1b[32m+\x1b[0m added to Master Board (#${projectNum})`);
   } catch (e) {
-    console.log(`\x1b[33mwarn:\x1b[0m could not add to project board: ${e}`);
+    io.log(`\x1b[33mwarn:\x1b[0m could not add to project board: ${e}`);
   }
 
   // 4. Wake oracle if specified
@@ -47,19 +79,20 @@ export async function cmdPulseAdd(title: string, opts: { oracle?: string; priori
     const prompt = `/recap --deep — You have been assigned issue #${issueNum}: ${title}. Issue URL: ${issueUrl}. Orient yourself, then wait for human instructions.`;
     wakeOpts.prompt = prompt;
 
-    const target = await cmdWake(opts.oracle, wakeOpts);
-    console.log(`\x1b[32m🚀\x1b[0m ${target}: waking up with /recap --deep → then --continue`);
+    const target = await io.cmdWake(opts.oracle, wakeOpts);
+    io.log(`\x1b[32m🚀\x1b[0m ${target}: waking up with /recap --deep → then --continue`);
   }
 }
 
-export async function cmdPulseLs(opts: { sync?: boolean }) {
+export async function cmdPulseLs(opts: { sync?: boolean }, deps: Partial<PulseDeps> = {}) {
+  const io = pulseDeps(deps);
   const repo = "laris-co/pulse-oracle";
 
   // Fetch all open issues
-  const issuesJson = (await hostExec(
+  const issuesJson = (await io.hostExec(
     `gh issue list --repo ${repo} --state open --json number,title,labels --limit 50`
   )).trim();
-  const issues: { number: number; title: string; labels: { name: string }[] }[] = JSON.parse(issuesJson || "[]");
+  const issues: PulseIssue[] = JSON.parse(issuesJson || "[]");
 
   // Categorize
   const projects: typeof issues = [];
@@ -88,44 +121,44 @@ export async function cmdPulseLs(opts: { sync?: boolean }) {
   };
 
   // Terminal table
-  console.log(`\n\x1b[36m📋 Pulse Board\x1b[0m\n`);
+  io.log(`\n\x1b[36m📋 Pulse Board\x1b[0m\n`);
 
   if (projects.length) {
-    console.log(`\x1b[33mProjects (${projects.length})\x1b[0m`);
-    console.log(`┌──────┬${"─".repeat(50)}┬──────────────┐`);
+    io.log(`\x1b[33mProjects (${projects.length})\x1b[0m`);
+    io.log(`┌──────┬${"─".repeat(50)}┬──────────────┐`);
     for (const p of projects.sort((a, b) => a.number - b.number)) {
       const oracle = getOracle(p);
-      console.log(`│ \x1b[32m#${String(p.number).padEnd(3)}\x1b[0m │ ${p.title.slice(0, 48).padEnd(48)} │ ${oracle.padEnd(12)} │`);
+      io.log(`│ \x1b[32m#${String(p.number).padEnd(3)}\x1b[0m │ ${p.title.slice(0, 48).padEnd(48)} │ ${oracle.padEnd(12)} │`);
     }
-    console.log(`└──────┴${"─".repeat(50)}┴──────────────┘`);
+    io.log(`└──────┴${"─".repeat(50)}┴──────────────┘`);
   }
 
   if (toolIssues.length) {
-    console.log(`\n\x1b[33mTools/Infra (${toolIssues.length})\x1b[0m`);
-    console.log(`┌──────┬${"─".repeat(50)}┬──────────────┐`);
+    io.log(`\n\x1b[33mTools/Infra (${toolIssues.length})\x1b[0m`);
+    io.log(`┌──────┬${"─".repeat(50)}┬──────────────┐`);
     for (const t of toolIssues.sort((a, b) => a.number - b.number)) {
       const oracle = getOracle(t);
-      console.log(`│ \x1b[32m#${String(t.number).padEnd(3)}\x1b[0m │ ${t.title.slice(0, 48).padEnd(48)} │ ${oracle.padEnd(12)} │`);
+      io.log(`│ \x1b[32m#${String(t.number).padEnd(3)}\x1b[0m │ ${t.title.slice(0, 48).padEnd(48)} │ ${oracle.padEnd(12)} │`);
     }
-    console.log(`└──────┴${"─".repeat(50)}┴──────────────┘`);
+    io.log(`└──────┴${"─".repeat(50)}┴──────────────┘`);
   }
 
   if (activeIssues.length) {
-    console.log(`\n\x1b[33mActive Today (${activeIssues.length})\x1b[0m`);
+    io.log(`\n\x1b[33mActive Today (${activeIssues.length})\x1b[0m`);
     for (const a of activeIssues.sort((a2, b) => a2.number - b.number)) {
       const oracle = getOracle(a);
-      console.log(`  \x1b[33m🟡\x1b[0m #${a.number} ${a.title} → ${oracle}`);
+      io.log(`  \x1b[33m🟡\x1b[0m #${a.number} ${a.title} → ${oracle}`);
     }
   }
 
-  console.log(`\n\x1b[36m${issues.length - threads.length} open\x1b[0m\n`);
+  io.log(`\n\x1b[36m${issues.length - threads.length} open\x1b[0m\n`);
 
   // --sync: update daily thread with checkboxes
   if (opts.sync) {
-    const thread = threads.find(t => t.title.includes(todayDate()));
-    if (!thread) { console.log("No daily thread found for today"); return; }
+    const thread = threads.find(t => t.title.includes(io.todayDate()));
+    if (!thread) { io.log("No daily thread found for today"); return; }
 
-    const lines: string[] = [`## 📋 Pulse Board Index (${todayLabel()})`, ""];
+    const lines: string[] = [`## 📋 Pulse Board Index (${io.todayLabel()})`, ""];
 
     if (projects.length) {
       lines.push(`### Projects (${projects.length})`, "");
@@ -153,18 +186,18 @@ export async function cmdPulseLs(opts: { sync?: boolean }) {
     const body = lines.join("\n").replace(/'/g, "'\\''");
 
     // Find or create index comment
-    const commentsJson2 = (await hostExec(
+    const commentsJson2 = (await io.hostExec(
       `gh api repos/${repo}/issues/${thread.number}/comments --jq '[.[] | {id: .id, body: .body}]'`
     )).trim();
     const comments: { id: string; body: string }[] = JSON.parse(commentsJson2 || "[]");
     const indexComment = comments.find(c => c.body.includes("Pulse Board Index"));
 
     if (indexComment) {
-      await hostExec(`gh api repos/${repo}/issues/comments/${indexComment.id} -X PATCH -f body='${body}'`);
-      console.log(`\x1b[32m✅\x1b[0m synced to daily thread #${thread.number}`);
+      await io.hostExec(`gh api repos/${repo}/issues/comments/${indexComment.id} -X PATCH -f body='${body}'`);
+      io.log(`\x1b[32m✅\x1b[0m synced to daily thread #${thread.number}`);
     } else {
-      await hostExec(`gh api repos/${repo}/issues/${thread.number}/comments -f body='${body}'`);
-      console.log(`\x1b[32m+\x1b[0m index posted to daily thread #${thread.number}`);
+      await io.hostExec(`gh api repos/${repo}/issues/${thread.number}/comments -f body='${body}'`);
+      io.log(`\x1b[32m+\x1b[0m index posted to daily thread #${thread.number}`);
     }
   }
 }

--- a/test/pulse-cmd-default.test.ts
+++ b/test/pulse-cmd-default.test.ts
@@ -1,0 +1,170 @@
+/**
+ * pulse-cmd.ts — default-suite coverage for Pulse board CLI commands.
+ */
+import { describe, expect, test } from "bun:test";
+import { cmdPulseAdd, cmdPulseLs, pulseDeps, type PulseDeps, type PulseIssue } from "../src/commands/shared/pulse-cmd";
+
+const issue = (number: number, title: string, labels: string[] = []): PulseIssue => ({
+  number,
+  title,
+  labels: labels.map(name => ({ name })),
+});
+
+const out = (logs: string[]) => logs.join("\n");
+
+function makeDeps(options: {
+  hostResponses?: string[];
+  hostThrowsOn?: (cmd: string, index: number) => boolean;
+  thread?: { url: string; num: number; isNew: boolean };
+  period?: string;
+  today?: string;
+  label?: string;
+  wakeTarget?: string;
+} = {}) {
+  const logs: string[] = [];
+  const hostCommands: string[] = [];
+  const addTaskCalls: Array<{ repo: string; threadNum: number; period: string; issueNum: number; title: string; oracle?: string }> = [];
+  const wakeCalls: Array<{ oracle: string; opts: { task?: string; wt?: string; prompt?: string } }> = [];
+  const responses = [...(options.hostResponses ?? [])];
+
+  const deps = pulseDeps({
+    hostExec: async (cmd: string) => {
+      const index = hostCommands.length;
+      hostCommands.push(cmd);
+      if (options.hostThrowsOn?.(cmd, index)) throw new Error(`host boom ${index}`);
+      return responses.shift() ?? "";
+    },
+    cmdWake: async (oracle: string, opts: { task?: string; wt?: string; prompt?: string }) => {
+      wakeCalls.push({ oracle, opts });
+      return options.wakeTarget ?? `${oracle}-target`;
+    },
+    timePeriod: () => options.period ?? "morning",
+    todayDate: () => options.today ?? "2026-05-17",
+    todayLabel: () => options.label ?? "2026-05-17 (อาทิตย์)",
+    findOrCreateDailyThread: async () => options.thread ?? { url: "https://github.com/laris-co/pulse-oracle/issues/100", num: 100, isNew: false },
+    addTaskToPeriodComment: async (repo, threadNum, period, issueNum, title, oracle) => {
+      addTaskCalls.push({ repo, threadNum, period, issueNum, title, oracle });
+    },
+    log: (...args: unknown[]) => { logs.push(args.map(String).join(" ")); },
+  } satisfies Partial<PulseDeps>);
+
+  return { deps, logs, hostCommands, addTaskCalls, wakeCalls };
+}
+
+describe("pulseDeps", () => {
+  test("exposes production defaults with safe overrides", () => {
+    const hostExec = async () => "ok";
+    const deps = pulseDeps({ hostExec });
+
+    expect(deps.hostExec).toBe(hostExec);
+    expect(typeof deps.cmdWake).toBe("function");
+    expect(typeof deps.timePeriod).toBe("function");
+    expect(typeof deps.todayDate).toBe("function");
+    expect(typeof deps.todayLabel).toBe("function");
+    expect(typeof deps.findOrCreateDailyThread).toBe("function");
+    expect(typeof deps.addTaskToPeriodComment).toBe("function");
+    expect(typeof deps.log).toBe("function");
+  });
+});
+
+describe("cmdPulseAdd", () => {
+  test("creates an issue, adds it to the period comment and board, then wakes the assigned oracle", async () => {
+    const h = makeDeps({
+      hostResponses: ["https://github.com/laris-co/pulse-oracle/issues/321"],
+      period: "afternoon",
+      wakeTarget: "54-mawjs:mawjs-oracle",
+    });
+
+    await cmdPulseAdd("Fix Nat's board", { oracle: "mawjs", wt: "board-fix" }, h.deps);
+
+    expect(h.hostCommands[0]).toContain("gh issue create");
+    expect(h.hostCommands[0]).toContain("-t 'Fix Nat'\\''s board'");
+    expect(h.hostCommands[0]).toContain("-l 'oracle:mawjs'");
+    expect(h.hostCommands[0]).toContain("Parent: #100");
+    expect(h.addTaskCalls).toEqual([{ repo: "laris-co/pulse-oracle", threadNum: 100, period: "afternoon", issueNum: 321, title: "Fix Nat's board", oracle: "mawjs" }]);
+    expect(h.hostCommands[1]).toBe("gh project item-add 6 --owner laris-co --url 'https://github.com/laris-co/pulse-oracle/issues/321'");
+    expect(h.wakeCalls).toHaveLength(1);
+    expect(h.wakeCalls[0].oracle).toBe("mawjs");
+    expect(h.wakeCalls[0].opts.wt).toBe("board-fix");
+    expect(h.wakeCalls[0].opts.prompt).toContain("issue #321");
+    expect(out(h.logs)).toContain("issue #321 (afternoon)");
+    expect(out(h.logs)).toContain("added to Master Board");
+    expect(out(h.logs)).toContain("54-mawjs:mawjs-oracle");
+  });
+
+  test("warns when project add fails and skips wake when no oracle was assigned", async () => {
+    const h = makeDeps({
+      hostResponses: ["https://github.com/laris-co/pulse-oracle/issues/not-a-number"],
+      hostThrowsOn: (_cmd, index) => index === 1,
+    });
+
+    await cmdPulseAdd("Unassigned task", {}, h.deps);
+
+    expect(h.addTaskCalls[0].issueNum).toBe(0);
+    expect(h.wakeCalls).toEqual([]);
+    expect(out(h.logs)).toContain("could not add to project board");
+  });
+});
+
+describe("cmdPulseLs", () => {
+  const issues = [
+    issue(10, "📅 2026-05-17 Daily Thread", ["daily-thread"]),
+    issue(2, "P001 Build dashboard", ["oracle:dash"]),
+    issue(5, "P002 Ship widget", ["oracle:widget"]),
+    issue(3, "Old infra chore", ["oracle:ops"]),
+    issue(4, "Another old tool"),
+    issue(11, "Fix current bug", ["oracle:mawjs"]),
+    issue(12, "Another active task"),
+  ];
+
+  test("renders projects, tools, active items, oracle labels, and open count", async () => {
+    const h = makeDeps({ hostResponses: [JSON.stringify(issues)] });
+
+    await cmdPulseLs({}, h.deps);
+
+    const text = out(h.logs);
+    expect(text).toContain("Pulse Board");
+    expect(text).toContain("Projects (2)");
+    expect(text).toContain("P001 Build dashboard");
+    expect(text).toContain("dash");
+    expect(text).toContain("Tools/Infra (2)");
+    expect(text).toContain("Old infra chore");
+    expect(text).toContain("Active Today (2)");
+    expect(text).toContain("Fix current bug → mawjs");
+    expect(text).toContain("Another active task → —");
+    expect(text).toContain("6 open");
+  });
+
+  test("sync patches an existing Pulse Board Index comment", async () => {
+    const h = makeDeps({
+      hostResponses: [
+        JSON.stringify(issues),
+        JSON.stringify([{ id: "c1", body: "Pulse Board Index old" }]),
+      ],
+      today: "2026-05-17",
+      label: "2026-05-17 (อาทิตย์)",
+    });
+
+    await cmdPulseLs({ sync: true }, h.deps);
+
+    expect(h.hostCommands[1]).toContain("issues/10/comments");
+    expect(h.hostCommands[2]).toContain("issues/comments/c1 -X PATCH");
+    expect(h.hostCommands[2]).toContain("Pulse Board Index (2026-05-17");
+    expect(h.hostCommands[2]).toContain("#2 P001 Build dashboard → dash");
+    expect(h.hostCommands[2]).toContain("#11 Fix current bug → mawjs 🟡");
+    expect(out(h.logs)).toContain("synced to daily thread #10");
+  });
+
+  test("sync creates an index comment when missing and reports missing daily thread", async () => {
+    const create = makeDeps({ hostResponses: [JSON.stringify(issues), JSON.stringify([])] });
+    await cmdPulseLs({ sync: true }, create.deps);
+
+    expect(create.hostCommands[2]).toContain("issues/10/comments -f body=");
+    expect(out(create.logs)).toContain("index posted to daily thread #10");
+
+    const missing = makeDeps({ hostResponses: [JSON.stringify([issue(1, "No thread")])] });
+    await cmdPulseLs({ sync: true }, missing.deps);
+
+    expect(out(missing.logs)).toContain("No daily thread found for today");
+  });
+});


### PR DESCRIPTION
## Summary
- add injectable Pulse command dependencies for hostExec, wake, daily-thread, date, and output seams
- add default-suite tests for pulse add and pulse ls/sync without touching live GitHub/Pulse state
- refresh coverage gap analysis after counting pulse-cmd.ts

## Validation
- rtk bun test --coverage test/pulse-cmd-default.test.ts — pulse-cmd.ts 100% functions / 100% lines, 6 pass / 0 fail
- rtk bun test test/pulse-cmd-default.test.ts test/top-aliases-default.test.ts test/isolated/top-aliases-runtime-coverage.test.ts — 31 pass / 0 fail
- rtk bun run test:coverage — 2143 pass / 6 skip / 0 fail; overall 81.3% functions / 30.7% lines
- rtk bun run build

Alpha-only #1611 coverage work. No release cut.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.