### PR TITLE
test(coverage): count fleet resume helpers in default suite

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,19 +1,19 @@
 # Coverage gap analysis
 
-Generated: 2026-05-17T12:35:05.751Z
+Generated: 2026-05-17T12:51:00.824Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **30.7%** (15413/50211)
-Overall function coverage: **81.3%** (1738/2139)
+Overall line coverage: **30.9%** (15526/50217)
+Overall function coverage: **81.3%** (1755/2158)
 
 ## Module summary
 
 | Module | Files | Missing from LCOV | Lines | Functions | Branches |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| cli/dispatch | 90 | 12 | 68.4% (5055/7391) | 82.1% (503/613) | n/a (0/0) |
+| cli/dispatch | 90 | 10 | 69.9% (5168/7397) | 82.3% (520/632) | n/a (0/0) |
 | config/runtime | 19 | 2 | 66.6% (776/1166) | 74.0% (71/96) | n/a (0/0) |
 | fleet | 17 | 0 | 58.4% (609/1042) | 69.9% (58/83) | n/a (0/0) |
 | matcher | 2 | 0 | 100.0% (41/41) | 100.0% (8/8) | n/a (0/0) |
@@ -77,6 +77,7 @@ Overall function coverage: **81.3%** (1738/2139)
 | cli/dispatch | `src/commands/shared/fleet-doctor-checks.ts` | 97.5% | 100.0% |
 | cli/dispatch | `src/commands/shared/fleet-doctor-fixer.ts` | 87.3% | 40.0% |
 | cli/dispatch | `src/commands/shared/fleet-manage.ts` | 100.0% | 100.0% |
+| cli/dispatch | `src/commands/shared/fleet-resume.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/fleet-wake-failsoft.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/plugin-create-as.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/plugin-create-rust.ts` | 100.0% | 100.0% |
@@ -151,7 +152,6 @@ Overall function coverage: **81.3%** (1738/2139)
 | --- | --- | ---: | ---: |
 | transport | `src/core/transport/pty.ts` | 150 | 0.0% |
 | cli/dispatch | `src/commands/shared/fleet-wake.ts` | 146 | 0.0% |
-| cli/dispatch | `src/commands/shared/fleet-resume.ts` | 100 | 0.0% |
 | cli/dispatch | `src/cli/dispatch.ts` | 97 | 46.4% |
 | fleet | `src/core/fleet/registry-oracle-scan-remote.ts` | 93 | 6.1% |
 | cli/dispatch | `src/commands/shared/fleet-doctor.ts` | 92 | 12.4% |
@@ -159,6 +159,7 @@ Overall function coverage: **81.3%** (1738/2139)
 | plugin dispatch | `src/plugin/types.ts` | 86 | 0.0% |
 | cli/dispatch | `src/commands/shared/wake-session.ts` | 82 | 6.8% |
 | transport | `src/transports/scout-pair.ts` | 80 | 9.1% |
+| transport | `src/transports/index.ts` | 78 | 29.7% |
 
 ## Critical gaps to prioritize
 

--- a/src/commands/shared/fleet-resume.ts
+++ b/src/commands/shared/fleet-resume.ts
@@ -5,11 +5,37 @@ import { getGhqRoot } from "../../config/ghq-root";
 import type { FleetSession } from "./fleet-load";
 import { pinWindowWide } from "./wake-pane-size";
 
+type FleetResumeTmux = Pick<typeof tmux, "listSessions" | "listWindows" | "sendText" | "newWindow">;
+
+export interface FleetResumeDeps {
+  ssh: typeof ssh;
+  tmux: FleetResumeTmux;
+  buildCommand: typeof buildCommand;
+  getGhqRoot: typeof getGhqRoot;
+  pinWindowWide: typeof pinWindowWide;
+  sleep: (ms: number) => Promise<void>;
+  log: (...args: unknown[]) => void;
+}
+
+export function fleetResumeDeps(overrides: Partial<FleetResumeDeps> = {}): FleetResumeDeps {
+  return {
+    ssh,
+    tmux,
+    buildCommand,
+    getGhqRoot,
+    pinWindowWide,
+    sleep: (ms: number) => new Promise(r => setTimeout(r, ms)),
+    log: console.log.bind(console) as (...args: unknown[]) => void,
+    ...overrides,
+  };
+}
+
 /** After fleet spawn, send /recap to oracles with active Pulse board items */
-export async function resumeActiveItems() {
+export async function resumeActiveItems(deps: Partial<FleetResumeDeps> = {}) {
+  const io = fleetResumeDeps(deps);
   const repo = "laris-co/pulse-oracle";
   try {
-    const issuesJson = await ssh(
+    const issuesJson = await io.ssh(
       `gh issue list --repo ${repo} --state open --json number,title,labels --limit 50`
     );
     const issues: { number: number; title: string; labels: { name: string }[] }[] = JSON.parse(issuesJson || "[]");
@@ -24,7 +50,7 @@ export async function resumeActiveItems() {
       .filter(i => i.oracle);
 
     if (!oracleItems.length) {
-      console.log("  \x1b[90mNo active board items to resume.\x1b[0m");
+      io.log("  \x1b[90mNo active board items to resume.\x1b[0m");
       return;
     }
 
@@ -39,24 +65,24 @@ export async function resumeActiveItems() {
     for (const [oracle, items] of byOracle) {
       const windowName = `${oracle}-oracle`;
       // Find which session has this window
-      const sessions = await tmux.listSessions();
+      const sessions = await io.tmux.listSessions();
       for (const sess of sessions) {
         try {
-          const windows = await tmux.listWindows(sess.name);
+          const windows = await io.tmux.listWindows(sess.name);
           const win = windows.find(w => w.name.toLowerCase() === windowName.toLowerCase());
           if (win) {
             const titles = items.map(i => `#${i.number}`).join(", ");
             // Wait for Claude to be ready (give it time to start)
-            await new Promise(r => setTimeout(r, 2000));
-            await tmux.sendText(`${sess.name}:${win.name}`, `/recap --deep — Resume after reboot. Active items: ${titles}`);
-            console.log(`  \x1b[32m↻\x1b[0m ${oracle}: /recap sent (${titles})`);
+            await io.sleep(2000);
+            await io.tmux.sendText(`${sess.name}:${win.name}`, `/recap --deep — Resume after reboot. Active items: ${titles}`);
+            io.log(`  \x1b[32m↻\x1b[0m ${oracle}: /recap sent (${titles})`);
             break;
           }
         } catch { /* window not found in this session */ }
       }
     }
   } catch (e) {
-    console.log(`  \x1b[33mresume skipped:\x1b[0m ${e}`);
+    io.log(`  \x1b[33mresume skipped:\x1b[0m ${e}`);
   }
 }
 
@@ -65,8 +91,9 @@ export async function resumeActiveItems() {
  * For each running session, check if there are worktrees on disk
  * that don't have a corresponding tmux window, and spawn them.
  */
-export async function respawnMissingWorktrees(sessions: FleetSession[]): Promise<number> {
-  const reposRoot = join(getGhqRoot(), "github.com");
+export async function respawnMissingWorktrees(sessions: FleetSession[], deps: Partial<FleetResumeDeps> = {}): Promise<number> {
+  const io = fleetResumeDeps(deps);
+  const reposRoot = join(io.getGhqRoot(), "github.com");
   let spawned = 0;
 
   for (const sess of sessions) {
@@ -85,14 +112,14 @@ export async function respawnMissingWorktrees(sessions: FleetSession[]): Promise
       // Scan disk for worktrees
       let wtPaths: string[] = [];
       try {
-        const raw = await ssh(`ls -d ${parentDir}/${repoName}.wt-* 2>/dev/null || true`);
+        const raw = await io.ssh(`ls -d ${parentDir}/${repoName}.wt-* 2>/dev/null || true`);
         wtPaths = raw.split("\n").filter(Boolean);
       } catch { continue; }
 
       // Get running windows for this session
       let runningWindows: string[] = [];
       try {
-        const windows = await tmux.listWindows(sess.name);
+        const windows = await io.tmux.listWindows(sess.name);
         runningWindows = windows.map(w => w.name);
       } catch { continue; }
 
@@ -116,11 +143,11 @@ export async function respawnMissingWorktrees(sessions: FleetSession[]): Promise
 
         usedNames.add(windowName);
         try {
-          await tmux.newWindow(sess.name, windowName, { cwd: wtPath });
-          await pinWindowWide(`${sess.name}:${windowName}`);
-          await new Promise(r => setTimeout(r, 300));
-          await tmux.sendText(`${sess.name}:${windowName}`, buildCommand(windowName));
-          console.log(`  \x1b[32m↻\x1b[0m ${windowName} (discovered on disk)`);
+          await io.tmux.newWindow(sess.name, windowName, { cwd: wtPath });
+          await io.pinWindowWide(`${sess.name}:${windowName}`);
+          await io.sleep(300);
+          await io.tmux.sendText(`${sess.name}:${windowName}`, io.buildCommand(windowName));
+          io.log(`  \x1b[32m↻\x1b[0m ${windowName} (discovered on disk)`);
           spawned++;
         } catch { /* window creation failed */ }
       }

--- a/test/fleet-resume-default.test.ts
+++ b/test/fleet-resume-default.test.ts
@@ -1,0 +1,202 @@
+/**
+ * fleet-resume.ts — default-suite coverage for reboot recap + worktree respawn helpers.
+ */
+import { describe, expect, test } from "bun:test";
+import { fleetResumeDeps, respawnMissingWorktrees, resumeActiveItems, type FleetResumeDeps } from "../src/commands/shared/fleet-resume";
+import type { FleetSession } from "../src/commands/shared/fleet-load";
+
+const issue = (number: number, title: string, labels: string[] = []) => ({
+  number,
+  title,
+  labels: labels.map(name => ({ name })),
+});
+
+function makeDeps(options: {
+  sshResponses?: string[];
+  sshThrowsOn?: (cmd: string, index: number) => boolean;
+  sessions?: Array<{ name: string }>;
+  windows?: Record<string, Array<{ name: string }>>;
+  windowThrows?: Set<string>;
+  newWindowThrows?: Set<string>;
+  ghqRoot?: string;
+} = {}) {
+  const logs: string[] = [];
+  const sshCommands: string[] = [];
+  const sentText: Array<{ target: string; text: string }> = [];
+  const newWindows: Array<{ session: string; name: string; cwd?: string }> = [];
+  const pins: string[] = [];
+  const sleeps: number[] = [];
+  const responses = [...(options.sshResponses ?? [])];
+
+  const deps = fleetResumeDeps({
+    ssh: async (cmd: string) => {
+      const index = sshCommands.length;
+      sshCommands.push(cmd);
+      if (options.sshThrowsOn?.(cmd, index)) throw new Error(`ssh boom ${index}`);
+      return responses.shift() ?? "";
+    },
+    tmux: {
+      listSessions: async () => options.sessions ?? [],
+      listWindows: async (session: string) => {
+        if (options.windowThrows?.has(session)) throw new Error(`window boom ${session}`);
+        return (options.windows?.[session] ?? []).map((w, index) => ({ index, active: index === 0, ...w }));
+      },
+      sendText: async (target: string, text: string) => { sentText.push({ target, text }); },
+      newWindow: async (session: string, name: string, opts: { cwd?: string }) => {
+        if (options.newWindowThrows?.has(`${session}:${name}`)) throw new Error(`new window boom ${name}`);
+        newWindows.push({ session, name, cwd: opts.cwd });
+      },
+    },
+    buildCommand: (name: string) => `run-${name}`,
+    getGhqRoot: () => options.ghqRoot ?? "/ghq",
+    pinWindowWide: async (target: string) => { pins.push(target); },
+    sleep: async (ms: number) => { sleeps.push(ms); },
+    log: (...args: unknown[]) => { logs.push(args.map(String).join(" ")); },
+  } satisfies Partial<FleetResumeDeps>);
+
+  return { deps, logs, sshCommands, sentText, newWindows, pins, sleeps };
+}
+
+describe("fleetResumeDeps", () => {
+  test("exposes production defaults with requested overrides", async () => {
+    const ssh = async () => "[]";
+    const originalLog = console.log;
+    const seen: string[] = [];
+    console.log = (line?: unknown) => { seen.push(String(line ?? "")); };
+    const deps = fleetResumeDeps({ ssh });
+
+    try {
+      await deps.sleep(0);
+      deps.log("fleet-resume-default");
+    } finally {
+      console.log = originalLog;
+    }
+
+    expect(seen).toEqual(["fleet-resume-default"]);
+    expect(deps.ssh).toBe(ssh);
+    expect(typeof deps.tmux.listSessions).toBe("function");
+    expect(typeof deps.tmux.listWindows).toBe("function");
+    expect(typeof deps.tmux.sendText).toBe("function");
+    expect(typeof deps.tmux.newWindow).toBe("function");
+    expect(typeof deps.buildCommand).toBe("function");
+    expect(typeof deps.getGhqRoot).toBe("function");
+    expect(typeof deps.pinWindowWide).toBe("function");
+    expect(typeof deps.sleep).toBe("function");
+    expect(typeof deps.log).toBe("function");
+  });
+});
+
+describe("resumeActiveItems", () => {
+  test("reports when the Pulse board has no oracle-assigned active items", async () => {
+    const h = makeDeps({
+      sshResponses: [JSON.stringify([
+        issue(1, "Daily", ["daily-thread"]),
+        issue(2, "Unassigned task"),
+      ])],
+    });
+
+    await resumeActiveItems(h.deps);
+
+    expect(h.sshCommands[0]).toContain("gh issue list --repo laris-co/pulse-oracle");
+    expect(h.sentText).toEqual([]);
+    expect(h.logs.join("\n")).toContain("No active board items to resume");
+  });
+
+  test("sends one recap per oracle, grouping active item numbers and ignoring session scan misses", async () => {
+    const h = makeDeps({
+      sshResponses: [JSON.stringify([
+        issue(1, "Daily", ["daily-thread"]),
+        issue(2, "Fix route", ["oracle:mawjs"]),
+        issue(3, "Fix coverage", ["oracle:mawjs"]),
+        issue(4, "File issue", ["oracle:issuer"]),
+        issue(5, "Needs triage"),
+      ])],
+      sessions: [{ name: "broken" }, { name: "54-mawjs" }],
+      windowThrows: new Set(["broken"]),
+      windows: {
+        "54-mawjs": [{ name: "mawjs-oracle" }, { name: "Issuer-Oracle" }],
+      },
+    });
+
+    await resumeActiveItems(h.deps);
+
+    expect(h.sleeps).toEqual([2000, 2000]);
+    expect(h.sentText).toEqual([
+      { target: "54-mawjs:mawjs-oracle", text: "/recap --deep — Resume after reboot. Active items: #2, #3" },
+      { target: "54-mawjs:Issuer-Oracle", text: "/recap --deep — Resume after reboot. Active items: #4" },
+    ]);
+    expect(h.logs.join("\n")).toContain("mawjs: /recap sent (#2, #3)");
+    expect(h.logs.join("\n")).toContain("issuer: /recap sent (#4)");
+  });
+
+  test("fails soft when Pulse issue lookup fails", async () => {
+    const h = makeDeps({ sshThrowsOn: () => true });
+
+    await resumeActiveItems(h.deps);
+
+    expect(h.sentText).toEqual([]);
+    expect(h.logs.join("\n")).toContain("resume skipped:");
+  });
+});
+
+describe("respawnMissingWorktrees", () => {
+  const mainSession: FleetSession = {
+    name: "54-mawjs",
+    windows: [
+      { name: "mawjs-oracle", repo: "Soul-Brews-Studio/maw-js" },
+      { name: "mawjs-existing", repo: "Soul-Brews-Studio/maw-js" },
+      { name: "mawjs-5-alias", repo: "Soul-Brews-Studio/maw-js" },
+      { name: "helper", repo: "Soul-Brews-Studio/other" },
+    ],
+  };
+
+  test("spawns missing worktrees, pins them, sends launch commands, and skips covered names", async () => {
+    const h = makeDeps({
+      sshResponses: [
+        [
+          "/ghq/github.com/Soul-Brews-Studio/maw-js.wt-1-existing",
+          "/ghq/github.com/Soul-Brews-Studio/maw-js.wt-2-new-task",
+          "/ghq/github.com/Soul-Brews-Studio/maw-js.wt-3-new-task",
+          "/ghq/github.com/Soul-Brews-Studio/maw-js.wt-4-running",
+          "/ghq/github.com/Soul-Brews-Studio/maw-js.wt-5-alias",
+          "/ghq/github.com/Soul-Brews-Studio/maw-js.wt-6-fail",
+        ].join("\n"),
+      ],
+      windows: { "54-mawjs": [{ name: "mawjs-oracle" }, { name: "mawjs-existing" }, { name: "mawjs-running" }] },
+      newWindowThrows: new Set(["54-mawjs:mawjs-fail"]),
+    });
+
+    const spawned = await respawnMissingWorktrees([mainSession], h.deps);
+
+    expect(spawned).toBe(2);
+    expect(h.sshCommands[0]).toBe("ls -d /ghq/github.com/Soul-Brews-Studio/maw-js.wt-* 2>/dev/null || true");
+    expect(h.newWindows).toEqual([
+      { session: "54-mawjs", name: "mawjs-new-task", cwd: "/ghq/github.com/Soul-Brews-Studio/maw-js.wt-2-new-task" },
+      { session: "54-mawjs", name: "mawjs-3-new-task", cwd: "/ghq/github.com/Soul-Brews-Studio/maw-js.wt-3-new-task" },
+    ]);
+    expect(h.pins).toEqual(["54-mawjs:mawjs-new-task", "54-mawjs:mawjs-3-new-task"]);
+    expect(h.sleeps).toEqual([300, 300]);
+    expect(h.sentText).toEqual([
+      { target: "54-mawjs:mawjs-new-task", text: "run-mawjs-new-task" },
+      { target: "54-mawjs:mawjs-3-new-task", text: "run-mawjs-3-new-task" },
+    ]);
+    expect(h.logs.join("\n")).toContain("mawjs-new-task (discovered on disk)");
+  });
+
+  test("skips disabled sessions and fails soft on worktree scans or tmux window listing", async () => {
+    const skipped: FleetSession = { name: "skip", skip_command: true, windows: [{ name: "skip-oracle", repo: "Org/skip" }] };
+    const scanFails: FleetSession = { name: "scan-fails", windows: [{ name: "scan-oracle", repo: "Org/scan" }] };
+    const windowsFail: FleetSession = { name: "windows-fail", windows: [{ name: "win-oracle", repo: "Org/win" }] };
+    const h = makeDeps({
+      sshResponses: ["/ghq/github.com/Org/scan.wt-1-a", "/ghq/github.com/Org/win.wt-1-b"],
+      sshThrowsOn: (cmd) => cmd.includes("/Org/scan.wt-"),
+      windowThrows: new Set(["windows-fail"]),
+    });
+
+    const spawned = await respawnMissingWorktrees([skipped, scanFails, windowsFail], h.deps);
+
+    expect(spawned).toBe(0);
+    expect(h.newWindows).toEqual([]);
+    expect(h.sentText).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add injectable seams for fleet resume GitHub lookup, tmux, command building, pinning, sleeps, and logging
- add default-suite tests for active Pulse recap grouping and disk worktree respawn behavior
- refresh coverage gap analysis after counting fleet-resume.ts

## Validation
- rtk bun test --coverage test/fleet-resume-default.test.ts — fleet-resume.ts 100% functions / 100% lines, 6 pass / 0 fail
- rtk bun test test/fleet-resume-default.test.ts test/isolated/fleet-wake-runtime-coverage.test.ts test/fleet-respawn.test.ts — 19 pass / 0 fail
- rtk bun run test:coverage — 2149 pass / 6 skip / 0 fail; overall 81.3% functions / 30.9% lines
- rtk bun run build

Alpha-only #1611 coverage work. No release cut.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.