### PR TITLE
test(coverage): count PTY bridge in default suite

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,13 +1,13 @@
 # Coverage gap analysis
 
-Generated: 2026-05-17T12:51:00.824Z
+Generated: 2026-05-17T13:04:26.074Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **30.9%** (15526/50217)
-Overall function coverage: **81.3%** (1755/2158)
+Overall line coverage: **31.2%** (15680/50221)
+Overall function coverage: **81.4%** (1772/2177)
 
 ## Module summary
 
@@ -20,7 +20,7 @@ Overall function coverage: **81.3%** (1755/2158)
 | other | 174 | 69 | 37.1% (5343/14391) | 75.1% (575/766) | n/a (0/0) |
 | plugin dispatch | 15 | 1 | 81.1% (950/1172) | 87.2% (75/86) | n/a (0/0) |
 | routing/aliases | 4 | 0 | 91.4% (582/637) | 94.5% (69/73) | n/a (0/0) |
-| transport | 28 | 2 | 77.8% (1876/2410) | 93.1% (363/390) | n/a (0/0) |
+| transport | 28 | 1 | 84.1% (2030/2414) | 92.9% (380/409) | n/a (0/0) |
 | vendor plugins | 245 | 243 | 0.8% (181/21961) | 66.7% (16/24) | n/a (0/0) |
 
 ## Top 20 uncovered files by executable/source line count
@@ -126,6 +126,7 @@ Overall function coverage: **81.3%** (1755/2158)
 | routing/aliases | `src/cli/top-aliases.ts` | 100.0% | 100.0% |
 | routing/aliases | `src/core/routing.ts` | 89.1% | 91.7% |
 | transport | `src/core/transport/peers.ts` | 100.0% | 100.0% |
+| transport | `src/core/transport/pty.ts` | 100.0% | 89.5% |
 | transport | `src/core/transport/tmux-class.ts` | 90.3% | 97.5% |
 | transport | `src/core/transport/tmux-types.ts` | 80.0% | 66.7% |
 | transport | `src/core/transport/tmux.ts` | 100.0% | 100.0% |
@@ -150,7 +151,6 @@ Overall function coverage: **81.3%** (1755/2158)
 
 | Module | File | Uncovered | Line coverage |
 | --- | --- | ---: | ---: |
-| transport | `src/core/transport/pty.ts` | 150 | 0.0% |
 | cli/dispatch | `src/commands/shared/fleet-wake.ts` | 146 | 0.0% |
 | cli/dispatch | `src/cli/dispatch.ts` | 97 | 46.4% |
 | fleet | `src/core/fleet/registry-oracle-scan-remote.ts` | 93 | 6.1% |
@@ -160,6 +160,7 @@ Overall function coverage: **81.3%** (1755/2158)
 | cli/dispatch | `src/commands/shared/wake-session.ts` | 82 | 6.8% |
 | transport | `src/transports/scout-pair.ts` | 80 | 9.1% |
 | transport | `src/transports/index.ts` | 78 | 29.7% |
+| transport | `src/core/transport/ssh.ts` | 77 | 29.4% |
 
 ## Critical gaps to prioritize
 

--- a/src/core/transport/pty.ts
+++ b/src/core/transport/pty.ts
@@ -2,22 +2,66 @@ import { tmux, tmuxCmd } from "./tmux";
 import { loadConfig, cfgTimeout, cfgLimit } from "../../config";
 import type { MawWS } from "../types";
 
-let nextPtyId = 0;
+type PtyProc = ReturnType<typeof Bun.spawn>;
+type PtySpawn = typeof Bun.spawn;
+type PtySpawnSync = typeof Bun.spawnSync;
+type PtyTmux = Pick<typeof tmux, "newGroupedSession" | "setOption" | "killSession">;
+
+export interface PtyDeps {
+  tmux: PtyTmux;
+  tmuxCmd: typeof tmuxCmd;
+  loadConfig: typeof loadConfig;
+  cfgTimeout: typeof cfgTimeout;
+  cfgLimit: typeof cfgLimit;
+  spawn: PtySpawn;
+  spawnSync: PtySpawnSync;
+  env: () => NodeJS.ProcessEnv;
+  platform: () => NodeJS.Platform;
+  now: () => number;
+  setTimeout: typeof setTimeout;
+  clearTimeout: typeof clearTimeout;
+}
+
+export function ptyDeps(overrides: Partial<PtyDeps> = {}): PtyDeps {
+  return {
+    tmux,
+    tmuxCmd,
+    loadConfig,
+    cfgTimeout,
+    cfgLimit,
+    spawn: ((args, opts) => Bun.spawn(args, opts)) as PtySpawn,
+    spawnSync: ((args) => Bun.spawnSync(args)) as PtySpawnSync,
+    env: () => process.env,
+    platform: () => process.platform,
+    now: () => Date.now(),
+    setTimeout,
+    clearTimeout,
+    ...overrides,
+  };
+}
 
 interface PtySession {
-  proc: ReturnType<typeof Bun.spawn>;
+  proc: PtyProc;
   target: string;
   ptySessionName: string;
   viewers: Set<MawWS>;
   cleanupTimer: ReturnType<typeof setTimeout> | null;
 }
 
-const sessions = new Map<string, PtySession>();
-const attaching = new Set<string>();
+interface PtyHandlers {
+  handlePtyMessage: (ws: MawWS, msg: string | Buffer) => void;
+  handlePtyClose: (ws: MawWS) => void;
+}
+
+export function createPtyHandlers(overrides: Partial<PtyDeps> = {}): PtyHandlers {
+  const io = ptyDeps(overrides);
+  let nextPtyId = 0;
+  const sessions = new Map<string, PtySession>();
+  const attaching = new Set<string>();
 
 function isLocalHost(): boolean {
   // #713: with bind/host split, config.host is never a bind address (0.0.0.0 etc.)
-  const host = process.env.MAW_HOST || loadConfig().host || "local";
+  const host = io.env().MAW_HOST || io.loadConfig().host || "local";
   return host === "local" || host === "localhost";
 }
 
@@ -27,7 +71,7 @@ function findSession(ws: MawWS): PtySession | undefined {
   }
 }
 
-export function handlePtyMessage(ws: MawWS, msg: string | Buffer) {
+function handlePtyMessage(ws: MawWS, msg: string | Buffer) {
   if (typeof msg !== "string") {
     // Binary → keystroke to PTY stdin
     const session = findSession(ws);
@@ -47,7 +91,7 @@ export function handlePtyMessage(ws: MawWS, msg: string | Buffer) {
   } catch { /* expected: malformed WS message */ }
 }
 
-export function handlePtyClose(ws: MawWS) {
+function handlePtyClose(ws: MawWS) {
   detach(ws);
 }
 
@@ -63,7 +107,7 @@ async function attach(ws: MawWS, target: string, cols: number, rows: number) {
   let session = sessions.get(safe);
   if (session) {
     if (session.cleanupTimer) {
-      clearTimeout(session.cleanupTimer);
+      io.clearTimeout(session.cleanupTimer);
       session.cleanupTimer = null;
     }
     session.viewers.add(ws);
@@ -71,7 +115,7 @@ async function attach(ws: MawWS, target: string, cols: number, rows: number) {
     // the screen stays empty until something happens in the pane → looks like
     // "black pane covering tmux". Mirror the new-session capture-pane block.
     try {
-      const cap = Bun.spawnSync(["tmux", "capture-pane", "-t", safe, "-p", "-e", "-J", "-S", "-2000"]);
+      const cap = io.spawnSync(["tmux", "capture-pane", "-t", safe, "-p", "-e", "-J", "-S", "-2000"]);
       if (cap.stdout && cap.stdout.length > 0) {
         ws.send(cap.stdout);
         ws.send(new TextEncoder().encode("\r\n"));
@@ -87,18 +131,18 @@ async function attach(ws: MawWS, target: string, cols: number, rows: number) {
 
   const sessionName = safe.split(":")[0];
   const windowPart = safe.includes(":") ? safe.split(":").slice(1).join(":") : "";
-  const c = Math.max(1, Math.min(cfgLimit("ptyCols"), Math.floor(cols)));
-  const r = Math.max(1, Math.min(cfgLimit("ptyRows"), Math.floor(rows)));
+  const c = Math.max(1, Math.min(io.cfgLimit("ptyCols"), Math.floor(cols)));
+  const r = Math.max(1, Math.min(io.cfgLimit("ptyRows"), Math.floor(rows)));
 
   // Create a grouped session — shares windows but has independent client sizing.
   // This prevents the web terminal from shrinking the real terminal.
-  const ptySessionName = `maw-pty-${Date.now()}-${++nextPtyId}`;
+  const ptySessionName = `maw-pty-${io.now()}-${++nextPtyId}`;
   try {
-    await tmux.newGroupedSession(sessionName, ptySessionName, {
+    await io.tmux.newGroupedSession(sessionName, ptySessionName, {
       cols: c, rows: r, window: windowPart || undefined,
     });
     // Hide status bar in PTY sessions so it doesn't appear in terminal output
-    await tmux.setOption(ptySessionName, "status", "off").catch(() => { /* expected: option may not apply */ });
+    await io.tmux.setOption(ptySessionName, "status", "off").catch(() => { /* expected: option may not apply */ });
   } catch {
     attaching.delete(safe);
     ws.send(JSON.stringify({ type: "error", message: "Failed to create PTY session" }));
@@ -110,7 +154,7 @@ async function attach(ws: MawWS, target: string, cols: number, rows: number) {
   // capture-pane reads tmux server-side history (limit set by history-limit).
   // -p stdout, -e include ANSI attrs, -S -2000 last 2000 lines, -J join wrapped.
   try {
-    const cap = Bun.spawnSync(["tmux", "capture-pane", "-t", safe, "-p", "-e", "-J", "-S", "-2000"]);
+    const cap = io.spawnSync(["tmux", "capture-pane", "-t", safe, "-p", "-e", "-J", "-S", "-2000"]);
     if (cap.stdout && cap.stdout.length > 0) {
       ws.send(cap.stdout);
       ws.send(new TextEncoder().encode("\r\n"));
@@ -136,8 +180,8 @@ async function attach(ws: MawWS, target: string, cols: number, rows: number) {
   // every macOS.
   let args: string[];
   if (isLocalHost()) {
-    const cmd = `stty rows ${r} cols ${c} 2>/dev/null; TERM=xterm-256color ${tmuxCmd()} attach-session -t '${ptySessionName}'`;
-    if (process.platform === "darwin") {
+    const cmd = `stty rows ${r} cols ${c} 2>/dev/null; TERM=xterm-256color ${io.tmuxCmd()} attach-session -t '${ptySessionName}'`;
+    if (io.platform() === "darwin") {
       // Shell-escape cmd for embedding inside expect's double-quoted string.
       const esc = cmd.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\$/g, "\\$").replace(/\[/g, "\\[").replace(/\]/g, "\\]");
       args = ["/usr/bin/expect", "-c", `spawn -noecho sh -c "${esc}"; interact`];
@@ -145,15 +189,15 @@ async function attach(ws: MawWS, target: string, cols: number, rows: number) {
       args = ["script", "-qfc", cmd, "/dev/null"];
     }
   } else {
-    const host = process.env.MAW_HOST || loadConfig().host || "local";
-    args = ["ssh", "-tt", host, `TERM=xterm-256color ${tmuxCmd()} attach-session -t '${ptySessionName}'`];
+    const host = io.env().MAW_HOST || io.loadConfig().host || "local";
+    args = ["ssh", "-tt", host, `TERM=xterm-256color ${io.tmuxCmd()} attach-session -t '${ptySessionName}'`];
   }
 
-  const proc = Bun.spawn(args, {
+  const proc = io.spawn(args, {
     stdin: "pipe",
     stdout: "pipe",
     stderr: "ignore",
-    env: { ...process.env, TERM: "xterm-256color" },
+    env: { ...io.env(), TERM: "xterm-256color" },
     windowsHide: true,
   });
 
@@ -184,7 +228,7 @@ async function attach(ws: MawWS, target: string, cols: number, rows: number) {
     } catch { /* expected: PTY stream ended */ }
     // PTY process ended — clean up grouped session
     sessions.delete(safe);
-    tmux.killSession(s.ptySessionName);
+    io.tmux.killSession(s.ptySessionName);
     for (const v of s.viewers) {
       try { v.send(JSON.stringify({ type: "detached", target: safe })); } catch { /* expected: viewer may have disconnected */ }
     }
@@ -203,11 +247,19 @@ function detach(ws: MawWS) {
     session.viewers.delete(ws);
     if (session.viewers.size === 0) {
       // Grace period before killing PTY
-      session.cleanupTimer = setTimeout(() => {
+      session.cleanupTimer = io.setTimeout(() => {
         try { session.proc.kill(); } catch { /* expected: process may already be dead */ }
-        tmux.killSession(session.ptySessionName);
+        io.tmux.killSession(session.ptySessionName);
         sessions.delete(target);
-      }, cfgTimeout("pty"));
+      }, io.cfgTimeout("pty"));
     }
   }
 }
+
+  return { handlePtyMessage, handlePtyClose };
+}
+
+const defaultPtyHandlers = createPtyHandlers();
+
+export const handlePtyMessage = defaultPtyHandlers.handlePtyMessage;
+export const handlePtyClose = defaultPtyHandlers.handlePtyClose;

--- a/test/pty-transport-default.test.ts
+++ b/test/pty-transport-default.test.ts
@@ -1,0 +1,339 @@
+/**
+ * pty.ts — default-suite coverage for the websocket PTY bridge using injected
+ * process/tmux/config seams instead of global Bun/tmux mocks.
+ */
+import { describe, expect, test } from "bun:test";
+import { createPtyHandlers, ptyDeps, type PtyDeps } from "../src/core/transport/pty";
+
+const encode = (text: string) => new TextEncoder().encode(text);
+const decode = (data: unknown) => data instanceof Uint8Array ? new TextDecoder().decode(data) : String(data);
+
+type ReadResult = { done: boolean; value?: Uint8Array };
+type SpawnPlan = { chunks?: string[]; autoEnd?: boolean; killThrows?: boolean };
+
+class ControlledReader {
+  private chunks: Uint8Array[];
+  private ended = false;
+  private pending: Array<(value: ReadResult) => void> = [];
+
+  constructor(chunks: string[], private readonly autoEnd: boolean) {
+    this.chunks = chunks.map(encode);
+  }
+
+  read(): Promise<ReadResult> {
+    if (this.chunks.length > 0) return Promise.resolve({ done: false, value: this.chunks.shift() });
+    if (this.autoEnd || this.ended) return Promise.resolve({ done: true });
+    return new Promise((resolve) => this.pending.push(resolve));
+  }
+
+  finish() {
+    this.ended = true;
+    for (const resolve of this.pending.splice(0)) resolve({ done: true });
+  }
+}
+
+interface MockWs {
+  sent: unknown[];
+  send(data: unknown): void;
+}
+
+function makeWs(): MockWs {
+  return {
+    sent: [],
+    send(data: unknown) { this.sent.push(data); },
+  };
+}
+
+function makeHarness(options: {
+  host?: string;
+  envHost?: string;
+  platform?: NodeJS.Platform;
+  timeout?: number;
+  colsLimit?: number;
+  rowsLimit?: number;
+  spawnPlans?: SpawnPlan[];
+  spawnSync?: (args: string[]) => { stdout?: Uint8Array };
+  groupedImpl?: (sessionName: string, ptySessionName: string, opts: unknown) => Promise<void>;
+  setOptionImpl?: (session: string, option: string, value: string) => Promise<void>;
+} = {}) {
+  const spawnPlans = [...(options.spawnPlans ?? [])];
+  const readers: ControlledReader[] = [];
+  const stdinWrites: Uint8Array[] = [];
+  const spawnCalls: Array<{ args: string[]; opts: any }> = [];
+  const spawnSyncCalls: string[][] = [];
+  const groupedCalls: Array<{ sessionName: string; ptySessionName: string; opts: any }> = [];
+  const setOptionCalls: Array<{ session: string; option: string; value: string }> = [];
+  const killSessionCalls: string[] = [];
+  const timerCallbacks: Array<{ active: boolean; fn: () => void }> = [];
+  const clearedTimers: unknown[] = [];
+  let procKills = 0;
+
+  const deps: Partial<PtyDeps> = {
+    loadConfig: () => ({ host: options.host ?? "local" } as any),
+    cfgTimeout: (key) => key === "pty" ? options.timeout ?? 10 : 0,
+    cfgLimit: (key) => key === "ptyCols" ? options.colsLimit ?? 200 : options.rowsLimit ?? 80,
+    tmuxCmd: () => "tmux-mock",
+    env: () => options.envHost === undefined ? {} as NodeJS.ProcessEnv : { MAW_HOST: options.envHost } as NodeJS.ProcessEnv,
+    platform: () => options.platform ?? "linux",
+    now: () => 123456,
+    spawnSync: (args: string[]) => {
+      spawnSyncCalls.push(args);
+      return (options.spawnSync ?? (() => ({ stdout: encode("scrollback") })))(args) as ReturnType<typeof Bun.spawnSync>;
+    },
+    spawn: (args: string[], opts: any) => {
+      spawnCalls.push({ args, opts });
+      const plan = spawnPlans.shift() ?? { autoEnd: true };
+      const reader = new ControlledReader(plan.chunks ?? [], plan.autoEnd ?? true);
+      readers.push(reader);
+      return {
+        stdin: {
+          write(data: Uint8Array) { stdinWrites.push(data); },
+          flush() { /* observed by write count */ },
+        },
+        stdout: { getReader: () => reader },
+        kill() {
+          procKills += 1;
+          if (plan.killThrows) throw new Error("already gone");
+        },
+      } as unknown as ReturnType<typeof Bun.spawn>;
+    },
+    tmux: {
+      newGroupedSession: async (sessionName: string, ptySessionName: string, opts: any) => {
+        groupedCalls.push({ sessionName, ptySessionName, opts });
+        await options.groupedImpl?.(sessionName, ptySessionName, opts);
+      },
+      setOption: async (session: string, option: string, value: string) => {
+        setOptionCalls.push({ session, option, value });
+        await options.setOptionImpl?.(session, option, value);
+      },
+      killSession: async (session: string) => { killSessionCalls.push(session); },
+    },
+    setTimeout: ((fn: () => void, _ms?: number) => {
+      const timer = { active: true, fn };
+      timerCallbacks.push(timer);
+      return timer as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout,
+    clearTimeout: ((timer: unknown) => {
+      clearedTimers.push(timer);
+      if (timer && typeof timer === "object" && "active" in timer) {
+        (timer as { active: boolean }).active = false;
+      }
+    }) as typeof clearTimeout,
+  };
+
+  const handlers = createPtyHandlers(deps);
+  const finishReaders = async () => {
+    for (const reader of readers) reader.finish();
+    await Promise.resolve();
+    await Promise.resolve();
+  };
+  const runTimers = async () => {
+    for (const timer of timerCallbacks.splice(0)) {
+      if (timer.active) timer.fn();
+    }
+    await Promise.resolve();
+  };
+
+  return {
+    ...handlers,
+    readers,
+    stdinWrites,
+    spawnCalls,
+    spawnSyncCalls,
+    groupedCalls,
+    setOptionCalls,
+    killSessionCalls,
+    timerCallbacks,
+    clearedTimers,
+    get procKills() { return procKills; },
+    finishReaders,
+    runTimers,
+  };
+}
+
+async function flush() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+async function eventually(predicate: () => boolean, label: string) {
+  const start = Date.now();
+  while (Date.now() - start < 250) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(`timed out waiting for ${label}`);
+}
+
+describe("ptyDeps", () => {
+  test("exposes overridable production defaults", () => {
+    const loadConfig = () => ({ host: "local" }) as any;
+    const deps = ptyDeps({ loadConfig });
+
+    expect(deps.loadConfig).toBe(loadConfig);
+    expect(typeof deps.tmux.newGroupedSession).toBe("function");
+    expect(typeof deps.tmux.setOption).toBe("function");
+    expect(typeof deps.tmux.killSession).toBe("function");
+    expect(typeof deps.tmuxCmd).toBe("function");
+    expect(typeof deps.cfgTimeout).toBe("function");
+    expect(typeof deps.cfgLimit).toBe("function");
+    expect(typeof deps.spawn).toBe("function");
+    expect(typeof deps.spawnSync).toBe("function");
+    expect(typeof deps.env()).toBe("object");
+    expect(typeof deps.platform()).toBe("string");
+    expect(typeof deps.now()).toBe("number");
+    expect(typeof deps.setTimeout).toBe("function");
+    expect(typeof deps.clearTimeout).toBe("function");
+  });
+});
+
+describe("createPtyHandlers", () => {
+  test("ignores malformed controls, empty sanitized targets, resize/detach, and binary before attach", () => {
+    const h = makeHarness();
+    const ws = makeWs();
+
+    h.handlePtyMessage(ws as any, Buffer.from("typed-before-attach"));
+    h.handlePtyMessage(ws as any, "not json");
+    h.handlePtyMessage(ws as any, JSON.stringify({ type: "resize", cols: 10, rows: 5 }));
+    h.handlePtyMessage(ws as any, JSON.stringify({ type: "detach" }));
+    h.handlePtyMessage(ws as any, JSON.stringify({ type: "attach", target: "!!!" }));
+
+    expect(ws.sent).toEqual([]);
+    expect(h.spawnCalls).toEqual([]);
+    expect(h.groupedCalls).toEqual([]);
+  });
+
+  test("creates a darwin local grouped PTY, clamps dimensions, replays capture, streams output, and cleans up on EOF", async () => {
+    const h = makeHarness({ platform: "darwin", colsLimit: 200, rowsLimit: 80, spawnPlans: [{ chunks: ["live bytes"], autoEnd: true }] });
+    const ws = makeWs();
+
+    h.handlePtyMessage(ws as any, JSON.stringify({ type: "attach", target: "demo:oracle", cols: 999, rows: 0.4 }));
+    await eventually(() => ws.sent.map(decode).includes(JSON.stringify({ type: "detached", target: "demo:oracle" })), "darwin PTY detach");
+
+    expect(h.groupedCalls[0]).toMatchObject({
+      sessionName: "demo",
+      ptySessionName: "maw-pty-123456-1",
+      opts: { cols: 200, rows: 1, window: "oracle" },
+    });
+    expect(h.setOptionCalls[0]).toEqual({ session: "maw-pty-123456-1", option: "status", value: "off" });
+    expect(h.spawnSyncCalls[0]).toEqual(["tmux", "capture-pane", "-t", "demo:oracle", "-p", "-e", "-J", "-S", "-2000"]);
+    expect(h.spawnCalls[0].args[0]).toBe("/usr/bin/expect");
+    expect(h.spawnCalls[0].opts).toMatchObject({ stdin: "pipe", stdout: "pipe", stderr: "ignore", windowsHide: true });
+    expect(h.spawnCalls[0].opts.env.TERM).toBe("xterm-256color");
+    expect(ws.sent.map(decode)).toEqual([
+      "scrollback",
+      "\r\n",
+      JSON.stringify({ type: "attached", target: "demo:oracle" }),
+      "live bytes",
+      JSON.stringify({ type: "detached", target: "demo:oracle" }),
+    ]);
+    expect(h.killSessionCalls).toContain("maw-pty-123456-1");
+  });
+
+  test("reuses cached sessions, cancels cleanup, replays capture, forwards keystrokes, and timer-cleans empty sessions", async () => {
+    const h = makeHarness({ spawnPlans: [{ chunks: ["initial output"], autoEnd: false, killThrows: true }] });
+    const first = makeWs();
+
+    h.handlePtyMessage(first as any, JSON.stringify({ type: "attach", target: "cached:main" }));
+    await eventually(() => first.sent.map(decode).includes("initial output"), "initial cached PTY output");
+    expect(first.sent.map(decode)).toContain("initial output");
+
+    h.handlePtyMessage(first as any, Buffer.from("abc"));
+    expect(h.stdinWrites.map(decode)).toEqual(["abc"]);
+
+    h.handlePtyMessage(first as any, JSON.stringify({ type: "detach" }));
+    expect(h.timerCallbacks).toHaveLength(1);
+
+    const late = makeWs();
+    h.handlePtyMessage(late as any, JSON.stringify({ type: "attach", target: "cached:main" }));
+    expect(h.clearedTimers).toHaveLength(1);
+    expect(late.sent.map(decode)).toEqual([
+      "scrollback",
+      "\r\n",
+      JSON.stringify({ type: "attached", target: "cached:main" }),
+    ]);
+
+    h.handlePtyClose(late as any);
+    await h.runTimers();
+    expect(h.procKills).toBe(1);
+    expect(h.killSessionCalls).toContain("maw-pty-123456-1");
+    await h.finishReaders();
+  });
+
+  test("uses remote ssh hosts and tolerates capture plus status-option failures", async () => {
+    const h = makeHarness({
+      host: "remote.example",
+      setOptionImpl: async () => { throw new Error("option unsupported"); },
+      spawnSync: () => { throw new Error("capture failed"); },
+      spawnPlans: [{ autoEnd: true }],
+    });
+    const ws = makeWs();
+
+    h.handlePtyMessage(ws as any, JSON.stringify({ type: "attach", target: "remote!bad:win", cols: 33, rows: 22 }));
+    await eventually(() => h.spawnCalls.length === 1, "remote PTY spawn");
+
+    expect(h.groupedCalls[0]).toMatchObject({ sessionName: "remotebad", opts: { cols: 33, rows: 22, window: "win" } });
+    expect(h.spawnCalls[0].args[0]).toBe("ssh");
+    expect(h.spawnCalls[0].args[1]).toBe("-tt");
+    expect(h.spawnCalls[0].args[2]).toBe("remote.example");
+    expect(h.spawnCalls[0].args[3]).toContain("tmux-mock attach-session");
+    expect(ws.sent.map(decode)).toContain(JSON.stringify({ type: "detached", target: "remotebad:win" }));
+  });
+
+  test("uses MAW_HOST over config host and script on non-darwin local hosts", async () => {
+    const h = makeHarness({ host: "ignored.example", envHost: "localhost", platform: "linux", spawnPlans: [{ autoEnd: true }] });
+    const ws = makeWs();
+
+    h.handlePtyMessage(ws as any, JSON.stringify({ type: "attach", target: "linux:main", cols: 70, rows: 20 }));
+    await eventually(() => h.spawnCalls.length === 1, "linux PTY spawn");
+
+    expect(h.spawnCalls[0].args).toEqual([
+      "script",
+      "-qfc",
+      expect.stringContaining("TERM=xterm-256color tmux-mock attach-session"),
+      "/dev/null",
+    ]);
+  });
+
+  test("fails closed on grouped-session creation errors and suppresses duplicate concurrent attaches", async () => {
+    let release!: () => void;
+    const h = makeHarness({ groupedImpl: () => new Promise<void>((resolve) => { release = resolve; }) });
+    const blocked = makeWs();
+
+    h.handlePtyMessage(blocked as any, JSON.stringify({ type: "attach", target: "same:win" }));
+    h.handlePtyMessage(makeWs() as any, JSON.stringify({ type: "attach", target: "same:win" }));
+    expect(h.groupedCalls).toHaveLength(1);
+    release();
+    await eventually(() => h.spawnCalls.length === 1, "blocked attach release");
+    expect(h.spawnCalls).toHaveLength(1);
+    await h.finishReaders();
+
+    const failedHarness = makeHarness({ groupedImpl: async () => { throw new Error("no tmux"); } });
+    const failed = makeWs();
+    failedHarness.handlePtyMessage(failed as any, JSON.stringify({ type: "attach", target: "fails" }));
+    await eventually(() => failed.sent.length === 1, "grouped-session failure");
+
+    expect(failed.sent.map(decode)).toEqual([
+      JSON.stringify({ type: "error", message: "Failed to create PTY session" }),
+    ]);
+  });
+
+  test("fresh and cached capture failures do not abort attach", async () => {
+    const h = makeHarness({ spawnSync: () => { throw new Error("tmux target disappeared"); }, spawnPlans: [{ chunks: ["first"], autoEnd: false }] });
+    const first = makeWs();
+    h.handlePtyMessage(first as any, JSON.stringify({ type: "attach", target: "capture-fail:0" }));
+    await eventually(() => first.sent.map(decode).includes("first"), "capture failure fresh output");
+
+    expect(first.sent.map(decode)).toEqual([
+      JSON.stringify({ type: "attached", target: "capture-fail:0" }),
+      "first",
+    ]);
+
+    const late = makeWs();
+    h.handlePtyMessage(late as any, JSON.stringify({ type: "attach", target: "capture-fail:0" }));
+    expect(late.sent.map(decode)).toEqual([
+      JSON.stringify({ type: "attached", target: "capture-fail:0" }),
+    ]);
+    await h.finishReaders();
+  });
+});


### PR DESCRIPTION
## Summary
- add an injectable PTY handler factory so default-suite tests can cover the websocket PTY bridge without real tmux/ssh/script/expect side effects
- cover attach sanitization, local/remote launch args, scrollback replay, cached sessions, keystroke forwarding, detach timers, duplicate attach suppression, and fail-soft paths
- refresh coverage gap analysis; `src/core/transport/pty.ts` is now 100% line-covered in the counted suite

## Validation
- `rtk bun test --coverage test/pty-transport-default.test.ts` — 8 pass / 0 fail; `src/core/transport/pty.ts` 100.00% lines
- `rtk bash scripts/test-isolated.sh test/isolated/pty-transport-coverage.test.ts test/isolated/pty-attach-replay.test.ts` — 2/2 files passed
- `rtk bun run test:coverage` — 2157 pass / 6 skip / 0 fail; overall functions 81.4%, lines 31.2%
- `rtk bun run build` — bundled 666 modules
- `rtk git diff --check`

Constraint: alpha-only #1611 coverage work; no release cut.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.