### PR TITLE
test(coverage): count SSH transport in default suite

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,13 +1,13 @@
 # Coverage gap analysis
 
-Generated: 2026-05-17T13:04:26.074Z
+Generated: 2026-05-17T13:15:43.907Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **31.2%** (15680/50221)
-Overall function coverage: **81.4%** (1772/2177)
+Overall line coverage: **31.4%** (15781/50245)
+Overall function coverage: **81.8%** (1789/2187)
 
 ## Module summary
 
@@ -20,7 +20,7 @@ Overall function coverage: **81.4%** (1772/2177)
 | other | 174 | 69 | 37.1% (5343/14391) | 75.1% (575/766) | n/a (0/0) |
 | plugin dispatch | 15 | 1 | 81.1% (950/1172) | 87.2% (75/86) | n/a (0/0) |
 | routing/aliases | 4 | 0 | 91.4% (582/637) | 94.5% (69/73) | n/a (0/0) |
-| transport | 28 | 1 | 84.1% (2030/2414) | 92.9% (380/409) | n/a (0/0) |
+| transport | 28 | 1 | 87.4% (2131/2438) | 94.7% (397/419) | n/a (0/0) |
 | vendor plugins | 245 | 243 | 0.8% (181/21961) | 66.7% (16/24) | n/a (0/0) |
 
 ## Top 20 uncovered files by executable/source line count
@@ -127,6 +127,7 @@ Overall function coverage: **81.4%** (1772/2177)
 | routing/aliases | `src/core/routing.ts` | 89.1% | 91.7% |
 | transport | `src/core/transport/peers.ts` | 100.0% | 100.0% |
 | transport | `src/core/transport/pty.ts` | 100.0% | 89.5% |
+| transport | `src/core/transport/ssh.ts` | 100.0% | 90.9% |
 | transport | `src/core/transport/tmux-class.ts` | 90.3% | 97.5% |
 | transport | `src/core/transport/tmux-types.ts` | 80.0% | 66.7% |
 | transport | `src/core/transport/tmux.ts` | 100.0% | 100.0% |
@@ -160,7 +161,7 @@ Overall function coverage: **81.4%** (1772/2177)
 | cli/dispatch | `src/commands/shared/wake-session.ts` | 82 | 6.8% |
 | transport | `src/transports/scout-pair.ts` | 80 | 9.1% |
 | transport | `src/transports/index.ts` | 78 | 29.7% |
-| transport | `src/core/transport/ssh.ts` | 77 | 29.4% |
+| cli/dispatch | `src/commands/shared/pulse-thread.ts` | 75 | 13.8% |
 
 ## Critical gaps to prioritize
 

--- a/src/core/transport/ssh.ts
+++ b/src/core/transport/ssh.ts
@@ -1,10 +1,6 @@
 import { loadConfig } from "../../config";
 import { tmuxCmd, Tmux } from "./tmux";
 
-const DEFAULT_HOST = process.env.MAW_HOST || loadConfig().host || "local";
-// #713: with bind/host split, config.host is never a bind address (0.0.0.0 etc.)
-const IS_LOCAL = DEFAULT_HOST === "local" || DEFAULT_HOST === "localhost";
-
 export type HostExecTransport = "local" | "ssh";
 
 /** Error from hostExec — carries target + transport so callers can format. */
@@ -24,26 +20,6 @@ export class HostExecError extends Error {
   }
 }
 
-/** Transport — run on oracle host. local → bash -c | remote → ssh */
-export async function hostExec(cmd: string, host = DEFAULT_HOST): Promise<string> {
-  // #713: with bind/host split, host is never a bind address (0.0.0.0 etc.)
-  const local = host === "local" || host === "localhost" || IS_LOCAL;
-  const transport: HostExecTransport = local ? "local" : "ssh";
-  const args = local ? ["bash", "-c", cmd] : ["ssh", host, cmd];
-  const proc = Bun.spawn(args, { stdout: "pipe", stderr: "pipe", windowsHide: true });
-  const text = await new Response(proc.stdout).text();
-  const code = await proc.exited;
-  if (code !== 0) {
-    const err = await new Response(proc.stderr).text();
-    const underlying = new Error(err.trim() || `exit ${code}`);
-    throw new HostExecError(host, transport, underlying, code);
-  }
-  return text.trim();
-}
-
-/** @deprecated Use hostExec */
-export const ssh = hostExec;
-
 // Window/Session types and findWindow live in ../runtime/find-window.
 // They are NOT re-exported here — callers must import them directly
 // from "../runtime/find-window". This breaks the module dependency chain that
@@ -51,33 +27,106 @@ export const ssh = hostExec;
 // in tests (see #198). Direct imports bypass the mock entirely.
 import type { Session } from "../runtime/find-window";
 
-export async function listSessions(host?: string): Promise<Session[]> {
-  const t = new Tmux(host);
-  return t.listSessions();
+type HostExecSpawn = typeof Bun.spawn;
+type SshTmux = Pick<Tmux,
+  | "listSessions"
+  | "capture"
+  | "selectWindow"
+  | "getPaneCommand"
+  | "getPaneCommands"
+  | "getPaneInfos"
+  | "exitModeIfNeeded"
+  | "sendKeys"
+  | "sendKeysLiteral"
+  | "sendText"
+>;
+
+export interface SshDeps {
+  spawn: HostExecSpawn;
+  createTmux: (host?: string) => SshTmux;
+  tmuxCmd: typeof tmuxCmd;
+  loadConfig: typeof loadConfig;
+  env: () => NodeJS.ProcessEnv;
+  requireConfig: () => { loadConfig: typeof loadConfig };
 }
 
-export async function capture(target: string, lines = 80, host?: string): Promise<string> {
-  const t = new Tmux(host);
-  return t.capture(target, lines);
+export interface SshTransport {
+  hostExec: (cmd: string, host?: string) => Promise<string>;
+  ssh: (cmd: string, host?: string) => Promise<string>;
+  listSessions: (host?: string) => Promise<Session[]>;
+  capture: (target: string, lines?: number, host?: string) => Promise<string>;
+  selectWindow: (target: string, host?: string) => Promise<void>;
+  switchClient: (session: string, host?: string) => Promise<void>;
+  getPaneCommand: (target: string, host?: string) => Promise<string>;
+  isAgentCommand: (cmd: string | null | undefined) => boolean;
+  getPaneCommands: (targets: string[], host?: string) => Promise<Record<string, string>>;
+  getPaneInfos: (targets: string[], host?: string) => Promise<Record<string, { command: string; cwd: string }>>;
+  sendKeys: (target: string, text: string, host?: string) => Promise<void>;
 }
 
-export async function selectWindow(target: string, host?: string): Promise<void> {
-  const t = new Tmux(host);
-  await t.selectWindow(target);
+export function sshDeps(overrides: Partial<SshDeps> = {}): SshDeps {
+  return {
+    spawn: ((args, opts) => Bun.spawn(args, opts)) as HostExecSpawn,
+    createTmux: (host?: string) => new Tmux(host),
+    tmuxCmd,
+    loadConfig,
+    env: () => process.env,
+    requireConfig: () => require("../../config"),
+    ...overrides,
+  };
 }
 
-export async function switchClient(session: string, host?: string): Promise<void> {
-  if (process.env.TMUX) {
-    await ssh(`${tmuxCmd()} switch-client -t '${session}' 2>/dev/null`, host).catch(() => {});
+export function createSshTransport(overrides: Partial<SshDeps> = {}): SshTransport {
+  const io = sshDeps(overrides);
+  const defaultHost = io.env().MAW_HOST || io.loadConfig().host || "local";
+  // #713: with bind/host split, config.host is never a bind address (0.0.0.0 etc.)
+  const isLocal = defaultHost === "local" || defaultHost === "localhost";
+
+  /** Transport — run on oracle host. local → bash -c | remote → ssh */
+  async function hostExec(cmd: string, host = defaultHost): Promise<string> {
+    // #713: with bind/host split, host is never a bind address (0.0.0.0 etc.)
+    const local = host === "local" || host === "localhost" || isLocal;
+    const transport: HostExecTransport = local ? "local" : "ssh";
+    const args = local ? ["bash", "-c", cmd] : ["ssh", host, cmd];
+    const proc = io.spawn(args, { stdout: "pipe", stderr: "pipe", windowsHide: true });
+    const text = await new Response(proc.stdout).text();
+    const code = await proc.exited;
+    if (code !== 0) {
+      const err = await new Response(proc.stderr).text();
+      const underlying = new Error(err.trim() || `exit ${code}`);
+      throw new HostExecError(host, transport, underlying, code);
+    }
+    return text.trim();
   }
-}
 
-/** Get the command running in a tmux pane (e.g. "claude", "zsh") */
-export async function getPaneCommand(target: string, host?: string): Promise<string> {
-  const { Tmux } = await import("./tmux");
-  const t = new Tmux(host);
-  return t.getPaneCommand(target);
-}
+  const ssh = hostExec;
+
+  async function listSessions(host?: string): Promise<Session[]> {
+    const t = io.createTmux(host);
+    return t.listSessions();
+  }
+
+  async function capture(target: string, lines = 80, host?: string): Promise<string> {
+    const t = io.createTmux(host);
+    return t.capture(target, lines);
+  }
+
+  async function selectWindow(target: string, host?: string): Promise<void> {
+    const t = io.createTmux(host);
+    await t.selectWindow(target);
+  }
+
+  async function switchClient(session: string, host?: string): Promise<void> {
+    if (io.env().TMUX) {
+      await ssh(`${io.tmuxCmd()} switch-client -t '${session}' 2>/dev/null`, host).catch(() => {});
+    }
+  }
+
+  /** Get the command running in a tmux pane (e.g. "claude", "zsh") */
+  async function getPaneCommand(target: string, host?: string): Promise<string> {
+    const t = io.createTmux(host);
+    return t.getPaneCommand(target);
+  }
 
 /** Pane command looks like an AI agent — name match (claude/codex/node),
  *  Claude Code 2.1+ versioned-binary signature (e.g. "2.1.121"), or any
@@ -90,82 +139,109 @@ export async function getPaneCommand(target: string, host?: string): Promise<str
  *  non-agent tools. So `node` (and configured binaries) are matched as the
  *  WHOLE command name — not loose substrings — so non-agent node processes
  *  don't pass. */
-export function isAgentCommand(cmd: string | null | undefined): boolean {
-  const c = (cmd ?? "").trim();
-  if (!c) return false;
-  if (/claude|codex/i.test(c)) return true;
-  if (/^node$/i.test(c)) return true;
-  if (/^\d+\.\d+\.\d+$/.test(c)) return true;
-  try {
-    const { loadConfig } = require("../../config");
-    const commands: Record<string, string> = loadConfig().commands || {};
-    const lc = c.toLowerCase();
-    for (const v of Object.values(commands)) {
-      const bin = v.split(/\s/)[0];
-      // Exact name match, not substring — a configured `node`-launched agent
-      // must not make every `nodemon`/`node-*` pane look like an agent.
-      if (bin && bin !== "default" && lc === bin.toLowerCase()) return true;
-    }
-  } catch {}
-  return false;
-}
+  function isAgentCommand(cmd: string | null | undefined): boolean {
+    const c = (cmd ?? "").trim();
+    if (!c) return false;
+    if (/claude|codex/i.test(c)) return true;
+    if (/^node$/i.test(c)) return true;
+    if (/^\d+\.\d+\.\d+$/.test(c)) return true;
+    try {
+      const { loadConfig } = io.requireConfig();
+      const commands: Record<string, string> = loadConfig().commands || {};
+      const lc = c.toLowerCase();
+      for (const v of Object.values(commands)) {
+        const bin = v.split(/\s/)[0];
+        // Exact name match, not substring — a configured `node`-launched agent
+        // must not make every `nodemon`/`node-*` pane look like an agent.
+        if (bin && bin !== "default" && lc === bin.toLowerCase()) return true;
+      }
+    } catch {}
+    return false;
+  }
 
 /** Batch-check which panes are running what command. */
-export async function getPaneCommands(targets: string[], host?: string): Promise<Record<string, string>> {
-  const { Tmux } = await import("./tmux");
-  const t = new Tmux(host);
-  return t.getPaneCommands(targets);
-}
+  async function getPaneCommands(targets: string[], host?: string): Promise<Record<string, string>> {
+    const t = io.createTmux(host);
+    return t.getPaneCommands(targets);
+  }
 
 /** Batch-check command + cwd for all panes. */
-export async function getPaneInfos(targets: string[], host?: string): Promise<Record<string, { command: string; cwd: string }>> {
-  const { Tmux } = await import("./tmux");
-  const t = new Tmux(host);
-  return t.getPaneInfos(targets);
-}
-
-export async function sendKeys(target: string, text: string, host?: string): Promise<void> {
-  const { Tmux } = await import("./tmux");
-  const t = new Tmux(host);
-
-  // Special keys → send as tmux key names (no Enter appended)
-  const SPECIAL_KEYS: Record<string, string> = {
-    "\x1b": "Escape",
-    "\x1b[A": "Up",
-    "\x1b[B": "Down",
-    "\x1b[C": "Right",
-    "\x1b[D": "Left",
-    "\r": "Enter",
-    "\n": "Enter",
-    "\b": "BSpace",
-    "\x15": "C-u",
-  };
-  if (SPECIAL_KEYS[text]) {
-    if (text !== "\x1b") await t.exitModeIfNeeded(target);
-    await t.sendKeys(target, SPECIAL_KEYS[text]);
-    return;
+  async function getPaneInfos(targets: string[], host?: string): Promise<Record<string, { command: string; cwd: string }>> {
+    const t = io.createTmux(host);
+    return t.getPaneInfos(targets);
   }
 
-  // Strip trailing \r or \n — Enter is appended separately
-  const endsWithEnter = text.endsWith("\r") || text.endsWith("\n");
-  const body = endsWithEnter ? text.slice(0, -1) : text;
+  async function sendKeys(target: string, text: string, host?: string): Promise<void> {
+    const t = io.createTmux(host);
 
-  // If only the enter was left after stripping, just send Enter
-  if (!body) {
-    await t.exitModeIfNeeded(target);
-    await t.sendKeys(target, "Enter");
-    return;
-  }
-
-  if (body.startsWith("/")) {
-    // Slash commands: send char by char for interactive tools (Claude Code, etc.)
-    await t.exitModeIfNeeded(target);
-    for (const ch of body) {
-      await t.sendKeysLiteral(target, ch);
+    // Special keys → send as tmux key names (no Enter appended)
+    const SPECIAL_KEYS: Record<string, string> = {
+      "\x1b": "Escape",
+      "\x1b[A": "Up",
+      "\x1b[B": "Down",
+      "\x1b[C": "Right",
+      "\x1b[D": "Left",
+      "\r": "Enter",
+      "\n": "Enter",
+      "\b": "BSpace",
+      "\x15": "C-u",
+    };
+    if (SPECIAL_KEYS[text]) {
+      if (text !== "\x1b") await t.exitModeIfNeeded(target);
+      await t.sendKeys(target, SPECIAL_KEYS[text]);
+      return;
     }
-    await t.sendKeys(target, "Enter");
-  } else {
-    // Smart send — uses buffer for multiline/long, send-keys for short
-    await t.sendText(target, body);
+
+    // Strip trailing \r or \n — Enter is appended separately
+    const endsWithEnter = text.endsWith("\r") || text.endsWith("\n");
+    const body = endsWithEnter ? text.slice(0, -1) : text;
+
+    // If only the enter was left after stripping, just send Enter
+    if (!body) {
+      await t.exitModeIfNeeded(target);
+      await t.sendKeys(target, "Enter");
+      return;
+    }
+
+    if (body.startsWith("/")) {
+      // Slash commands: send char by char for interactive tools (Claude Code, etc.)
+      await t.exitModeIfNeeded(target);
+      for (const ch of body) {
+        await t.sendKeysLiteral(target, ch);
+      }
+      await t.sendKeys(target, "Enter");
+    } else {
+      // Smart send — uses buffer for multiline/long, send-keys for short
+      await t.sendText(target, body);
+    }
   }
+
+  return {
+    hostExec,
+    ssh,
+    listSessions,
+    capture,
+    selectWindow,
+    switchClient,
+    getPaneCommand,
+    isAgentCommand,
+    getPaneCommands,
+    getPaneInfos,
+    sendKeys,
+  };
 }
+
+const defaultSshTransport = createSshTransport();
+
+export const hostExec = defaultSshTransport.hostExec;
+/** @deprecated Use hostExec */
+export const ssh = defaultSshTransport.ssh;
+export const listSessions = defaultSshTransport.listSessions;
+export const capture = defaultSshTransport.capture;
+export const selectWindow = defaultSshTransport.selectWindow;
+export const switchClient = defaultSshTransport.switchClient;
+export const getPaneCommand = defaultSshTransport.getPaneCommand;
+export const isAgentCommand = defaultSshTransport.isAgentCommand;
+export const getPaneCommands = defaultSshTransport.getPaneCommands;
+export const getPaneInfos = defaultSshTransport.getPaneInfos;
+export const sendKeys = defaultSshTransport.sendKeys;

--- a/test/ssh-transport-default.test.ts
+++ b/test/ssh-transport-default.test.ts
@@ -1,0 +1,237 @@
+/**
+ * ssh.ts — default-suite coverage for host execution and high-level tmux
+ * forwarding without spawning real local shells, ssh, or tmux clients.
+ */
+import { describe, expect, test } from "bun:test";
+import { createSshTransport, HostExecError, sshDeps, type SshDeps } from "../src/core/transport/ssh";
+
+const body = (text: string) => new ReadableStream({
+  start(controller) {
+    controller.enqueue(new TextEncoder().encode(text));
+    controller.close();
+  },
+});
+
+type TmuxCall = [string, ...unknown[]];
+
+function makeHarness(options: {
+  host?: string;
+  env?: NodeJS.ProcessEnv;
+  spawnResults?: Array<{ stdout?: string; stderr?: string; code?: number }>;
+  commands?: Record<string, string>;
+  requireThrows?: boolean;
+} = {}) {
+  const spawnResults = [...(options.spawnResults ?? [])];
+  const spawnCalls: Array<{ args: string[]; opts: unknown }> = [];
+  const tmuxHosts: Array<string | undefined> = [];
+  const tmuxCalls: TmuxCall[] = [];
+  const tmux = {
+    listSessions: async () => {
+      tmuxCalls.push(["listSessions"]);
+      return [{ name: "s", windows: [{ index: 1, name: "w", active: true }] }];
+    },
+    capture: async (target: string, lines = 80) => {
+      tmuxCalls.push(["capture", target, lines]);
+      return `capture:${target}:${lines}`;
+    },
+    selectWindow: async (target: string) => { tmuxCalls.push(["selectWindow", target]); },
+    getPaneCommand: async (target: string) => {
+      tmuxCalls.push(["getPaneCommand", target]);
+      return `cmd:${target}`;
+    },
+    getPaneCommands: async (targets: string[]) => {
+      tmuxCalls.push(["getPaneCommands", targets]);
+      return Object.fromEntries(targets.map((target) => [target, `cmd:${target}`]));
+    },
+    getPaneInfos: async (targets: string[]) => {
+      tmuxCalls.push(["getPaneInfos", targets]);
+      return Object.fromEntries(targets.map((target) => [target, { command: `cmd:${target}`, cwd: `/cwd/${target}` }]));
+    },
+    exitModeIfNeeded: async (target: string) => {
+      tmuxCalls.push(["exitModeIfNeeded", target]);
+      return true;
+    },
+    sendKeys: async (target: string, ...keys: string[]) => { tmuxCalls.push(["sendKeys", target, ...keys]); },
+    sendKeysLiteral: async (target: string, text: string) => { tmuxCalls.push(["sendKeysLiteral", target, text]); },
+    sendText: async (target: string, text: string) => { tmuxCalls.push(["sendText", target, text]); },
+  };
+
+  const deps: Partial<SshDeps> = {
+    loadConfig: () => ({ host: options.host ?? "local" } as any),
+    env: () => options.env ?? {},
+    tmuxCmd: () => "tmux-mock",
+    spawn: (args: string[], opts: unknown) => {
+      spawnCalls.push({ args, opts });
+      const result = spawnResults.shift() ?? { stdout: " ok \n", code: 0 };
+      return {
+        stdout: body(result.stdout ?? ""),
+        stderr: body(result.stderr ?? ""),
+        exited: Promise.resolve(result.code ?? 0),
+      } as unknown as ReturnType<typeof Bun.spawn>;
+    },
+    createTmux: (host?: string) => {
+      tmuxHosts.push(host);
+      return tmux as any;
+    },
+    requireConfig: () => {
+      if (options.requireThrows) throw new Error("missing config");
+      return { loadConfig: () => ({ commands: options.commands ?? {} }) as any };
+    },
+  };
+
+  return {
+    transport: createSshTransport(deps),
+    spawnCalls,
+    tmuxHosts,
+    tmuxCalls,
+  };
+}
+
+describe("sshDeps", () => {
+  test("exposes overridable defaults", () => {
+    const spawn = (() => { throw new Error("unused"); }) as unknown as typeof Bun.spawn;
+    const deps = sshDeps({ spawn });
+
+    expect(deps.spawn).toBe(spawn);
+    expect(typeof deps.createTmux).toBe("function");
+    expect(typeof deps.tmuxCmd).toBe("function");
+    expect(typeof deps.loadConfig).toBe("function");
+    expect(typeof deps.env()).toBe("object");
+    expect(typeof deps.requireConfig).toBe("function");
+  });
+});
+
+describe("createSshTransport", () => {
+  test("hostExec runs local commands by default, trims stdout, and exposes ssh alias", async () => {
+    const h = makeHarness({ spawnResults: [{ stdout: "  hello\n", code: 0 }, { stdout: "alias\n", code: 0 }] });
+
+    await expect(h.transport.hostExec("echo hello")).resolves.toBe("hello");
+    await expect(h.transport.ssh("echo alias")).resolves.toBe("alias");
+
+    expect(h.spawnCalls[0]).toMatchObject({
+      args: ["bash", "-c", "echo hello"],
+      opts: { stdout: "pipe", stderr: "pipe", windowsHide: true },
+    });
+  });
+
+  test("hostExec uses ssh for explicit remote hosts and reports stderr with metadata", async () => {
+    const h = makeHarness({ host: "hub.example", spawnResults: [{ stderr: "remote failed\n", code: 7 }] });
+
+    try {
+      await h.transport.hostExec("uptime", "remote.example");
+      throw new Error("expected hostExec to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(HostExecError);
+      const err = error as HostExecError;
+      expect(err.message).toBe("[ssh:remote.example] remote failed");
+      expect(err.target).toBe("remote.example");
+      expect(err.transport).toBe("ssh");
+      expect(err.exitCode).toBe(7);
+      expect(err.underlying.message).toBe("remote failed");
+    }
+
+    expect(h.spawnCalls[0].args).toEqual(["ssh", "remote.example", "uptime"]);
+  });
+
+  test("hostExec falls back to exit-code text when stderr is empty", async () => {
+    const h = makeHarness({ spawnResults: [{ code: 42 }] });
+
+    await expect(h.transport.hostExec("nope", "local")).rejects.toThrow("[local:local] exit 42");
+  });
+
+  test("config local host keeps explicit remote-looking host on the local transport", async () => {
+    const h = makeHarness({ host: "localhost", spawnResults: [{ stdout: "local\n", code: 0 }] });
+
+    await expect(h.transport.hostExec("pwd", "other-host")).resolves.toBe("local");
+
+    expect(h.spawnCalls[0].args).toEqual(["bash", "-c", "pwd"]);
+  });
+
+  test("tmux wrappers construct per-call clients with the requested host", async () => {
+    const h = makeHarness();
+
+    await expect(h.transport.listSessions("h1")).resolves.toEqual([{ name: "s", windows: [{ index: 1, name: "w", active: true }] }]);
+    await expect(h.transport.capture("s:1", 12, "h2")).resolves.toBe("capture:s:1:12");
+    await h.transport.selectWindow("s:2", "h3");
+    await expect(h.transport.getPaneCommand("s:3", "h4")).resolves.toBe("cmd:s:3");
+    await expect(h.transport.getPaneCommands(["a", "b"], "h5")).resolves.toEqual({ a: "cmd:a", b: "cmd:b" });
+    await expect(h.transport.getPaneInfos(["a"], "h6")).resolves.toEqual({ a: { command: "cmd:a", cwd: "/cwd/a" } });
+
+    expect(h.tmuxHosts).toEqual(["h1", "h2", "h3", "h4", "h5", "h6"]);
+    expect(h.tmuxCalls).toEqual([
+      ["listSessions"],
+      ["capture", "s:1", 12],
+      ["selectWindow", "s:2"],
+      ["getPaneCommand", "s:3"],
+      ["getPaneCommands", ["a", "b"]],
+      ["getPaneInfos", ["a"]],
+    ]);
+  });
+
+  test("switchClient is gated on TMUX and swallows switch failures", async () => {
+    const outside = makeHarness({ env: {}, spawnResults: [{ code: 0 }] });
+    await outside.transport.switchClient("s", "remote");
+    expect(outside.spawnCalls).toEqual([]);
+
+    const inside = makeHarness({ host: "hub.example", env: { TMUX: "/tmp/tmux" } as NodeJS.ProcessEnv, spawnResults: [{ stderr: "no client", code: 1 }] });
+    await inside.transport.switchClient("session's", "remote");
+    expect(inside.spawnCalls[0].args).toEqual([
+      "ssh",
+      "remote",
+      "tmux-mock switch-client -t 'session's' 2>/dev/null",
+    ]);
+  });
+
+  test("isAgentCommand matches configured binaries and tolerates config loading failure", () => {
+    const h = makeHarness({ commands: { opus: "opencode --model x", skip: "default" } });
+
+    expect(h.transport.isAgentCommand("opencode")).toBe(true);
+    expect(h.transport.isAgentCommand("default")).toBe(false);
+    expect(h.transport.isAgentCommand("claude-code")).toBe(true);
+    expect(h.transport.isAgentCommand("codex")).toBe(true);
+    expect(h.transport.isAgentCommand("node")).toBe(true);
+    expect(h.transport.isAgentCommand("nodemon")).toBe(false);
+    expect(h.transport.isAgentCommand("2.1.121")).toBe(true);
+    expect(h.transport.isAgentCommand("  ")).toBe(false);
+
+    expect(makeHarness({ requireThrows: true }).transport.isAgentCommand("opencode")).toBe(false);
+  });
+
+  test("sendKeys maps special keys, handles enter-only input, slash commands, and smart text", async () => {
+    const h = makeHarness();
+
+    await h.transport.sendKeys("pane", "\x1b");
+    await h.transport.sendKeys("pane", "\x1b[A");
+    await h.transport.sendKeys("pane", "\r");
+    await h.transport.sendKeys("pane", "\n");
+    await h.transport.sendKeys("pane", "\b");
+    await h.transport.sendKeys("pane", "\x15");
+    await h.transport.sendKeys("pane", "/compact\n");
+    await h.transport.sendKeys("pane", "hello\n");
+
+    expect(h.tmuxCalls).toEqual([
+      ["sendKeys", "pane", "Escape"],
+      ["exitModeIfNeeded", "pane"],
+      ["sendKeys", "pane", "Up"],
+      ["exitModeIfNeeded", "pane"],
+      ["sendKeys", "pane", "Enter"],
+      ["exitModeIfNeeded", "pane"],
+      ["sendKeys", "pane", "Enter"],
+      ["exitModeIfNeeded", "pane"],
+      ["sendKeys", "pane", "BSpace"],
+      ["exitModeIfNeeded", "pane"],
+      ["sendKeys", "pane", "C-u"],
+      ["exitModeIfNeeded", "pane"],
+      ["sendKeysLiteral", "pane", "/"],
+      ["sendKeysLiteral", "pane", "c"],
+      ["sendKeysLiteral", "pane", "o"],
+      ["sendKeysLiteral", "pane", "m"],
+      ["sendKeysLiteral", "pane", "p"],
+      ["sendKeysLiteral", "pane", "a"],
+      ["sendKeysLiteral", "pane", "c"],
+      ["sendKeysLiteral", "pane", "t"],
+      ["sendKeys", "pane", "Enter"],
+      ["sendText", "pane", "hello"],
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add an injectable SSH/host-exec transport factory so default-suite tests can cover host execution and tmux forwarding without real shell, ssh, or tmux side effects
- cover local/remote hostExec, structured HostExecError metadata, switch-client gating, tmux wrapper forwarding, configured agent-command matching, and sendKeys branching
- refresh coverage gap analysis; `src/core/transport/ssh.ts` is now 100% line-covered in the counted suite

## Validation
- `rtk bun test --coverage test/ssh-transport-default.test.ts` — 9 pass / 0 fail; `src/core/transport/ssh.ts` 100.00% lines
- `rtk bun test test/ssh-transport-default.test.ts test/is-agent-command.test.ts test/00-ssh.test.ts` — 40 pass / 0 fail
- `rtk bash scripts/test-isolated.sh test/isolated/is-agent-command-config.test.ts test/isolated/host-exec-error.test.ts test/isolated/ssh-transport.test.ts` — 3/3 files passed
- `rtk bun run test:coverage` — 2166 pass / 6 skip / 0 fail; overall functions 81.8%, lines 31.4%
- `rtk bun run build` — bundled 666 modules
- `rtk git diff --check`

Constraint: alpha-only #1611 coverage work; no release cut.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.