### PR TITLE
test: count pulse thread helpers in default coverage

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,19 +1,19 @@
 # Coverage gap analysis
 
-Generated: 2026-05-17T13:15:43.907Z
+Generated: 2026-05-17T13:26:36.854Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **31.4%** (15781/50245)
-Overall function coverage: **81.8%** (1789/2187)
+Overall line coverage: **31.6%** (15866/50255)
+Overall function coverage: **82.1%** (1801/2193)
 
 ## Module summary
 
 | Module | Files | Missing from LCOV | Lines | Functions | Branches |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| cli/dispatch | 90 | 10 | 69.9% (5168/7397) | 82.3% (520/632) | n/a (0/0) |
+| cli/dispatch | 90 | 10 | 70.9% (5253/7407) | 83.4% (532/638) | n/a (0/0) |
 | config/runtime | 19 | 2 | 66.6% (776/1166) | 74.0% (71/96) | n/a (0/0) |
 | fleet | 17 | 0 | 58.4% (609/1042) | 69.9% (58/83) | n/a (0/0) |
 | matcher | 2 | 0 | 100.0% (41/41) | 100.0% (8/8) | n/a (0/0) |
@@ -87,6 +87,7 @@ Overall function coverage: **81.8%** (1789/2187)
 | cli/dispatch | `src/commands/shared/plugins-ui.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/preflight.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/pulse-cmd.ts` | 100.0% | 100.0% |
+| cli/dispatch | `src/commands/shared/pulse-thread.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/queue-store.ts` | 98.2% | 100.0% |
 | cli/dispatch | `src/commands/shared/receiver-inbox.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/target-cwd.ts` | 100.0% | 100.0% |
@@ -161,7 +162,7 @@ Overall function coverage: **81.8%** (1789/2187)
 | cli/dispatch | `src/commands/shared/wake-session.ts` | 82 | 6.8% |
 | transport | `src/transports/scout-pair.ts` | 80 | 9.1% |
 | transport | `src/transports/index.ts` | 78 | 29.7% |
-| cli/dispatch | `src/commands/shared/pulse-thread.ts` | 75 | 13.8% |
+| plugin dispatch | `src/plugin/registry-invoke.ts` | 75 | 51.0% |
 
 ## Critical gaps to prioritize
 

--- a/src/commands/shared/pulse-thread.ts
+++ b/src/commands/shared/pulse-thread.ts
@@ -1,21 +1,33 @@
 import { hostExec } from "../../sdk";
 
+export interface PulseThreadDeps {
+  hostExec: typeof hostExec;
+  log: (...args: unknown[]) => void;
+  now: () => Date;
+}
+
+export function pulseThreadDeps(overrides: Partial<PulseThreadDeps> = {}): PulseThreadDeps {
+  return {
+    hostExec,
+    log: console.log.bind(console) as (...args: unknown[]) => void,
+    now: () => new Date(),
+    ...overrides,
+  };
+}
+
 const THAI_DAYS = ["อาทิตย์", "จันทร์", "อังคาร", "พุธ", "พฤหัสบดี", "ศุกร์", "เสาร์"];
 
-export function todayDate(): string {
-  const d = new Date();
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+export function todayDate(date: Date = new Date()): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
 }
 
-export function todayLabel(): string {
-  const d = new Date();
-  const date = todayDate();
-  const day = THAI_DAYS[d.getDay()];
-  return `${date} (${day})`;
+export function todayLabel(date: Date = new Date()): string {
+  const day = THAI_DAYS[date.getDay()];
+  return `${todayDate(date)} (${day})`;
 }
 
-export function timePeriod(): string {
-  const h = new Date().getHours();
+export function timePeriod(date: Date = new Date()): string {
+  const h = date.getHours();
   if (h >= 6 && h < 12) return "morning";
   if (h >= 12 && h < 18) return "afternoon";
   if (h >= 18) return "evening";
@@ -29,14 +41,19 @@ const PERIODS = [
   { key: "midnight", label: "🌙 Midnight (00:00-06:00)", hours: [0, 6] },
 ] as const;
 
-export async function findOrCreateDailyThread(repo: string): Promise<{ url: string; num: number; isNew: boolean }> {
-  const date = todayDate();
-  const label = todayLabel();
+export async function findOrCreateDailyThread(
+  repo: string,
+  deps: Partial<PulseThreadDeps> = {},
+): Promise<{ url: string; num: number; isNew: boolean }> {
+  const io = pulseThreadDeps(deps);
+  const now = io.now();
+  const date = todayDate(now);
+  const label = todayLabel(now);
   const searchDate = `📅 ${date}`;
   const threadTitle = `📅 ${label} Daily Thread`;
 
   // Search for existing daily thread (match by date only)
-  const existing = (await hostExec(
+  const existing = (await io.hostExec(
     `gh issue list --repo ${repo} --search '${searchDate} in:title' --state open --json number,url,title --limit 1`
   )).trim();
   const parsed = JSON.parse(existing || "[]");
@@ -45,18 +62,24 @@ export async function findOrCreateDailyThread(repo: string): Promise<{ url: stri
   }
 
   // Create new daily thread with Thai day name
-  const url = (await hostExec(
+  const url = (await io.hostExec(
     `gh issue create --repo ${repo} -t '${threadTitle.replace(/'/g, "'\\''")}' -b 'Tasks for ${label}' -l daily-thread`
   )).trim();
   const m = url.match(/\/(\d+)$/);
   const num = m ? +m[1] : 0;
-  console.log(`\x1b[32m+\x1b[0m daily thread #${num}: ${url}`);
+  io.log(`\x1b[32m+\x1b[0m daily thread #${num}: ${url}`);
   return { url, num, isNew: true };
 }
 
-async function ensurePeriodComments(repo: string, threadNum: number): Promise<Record<string, { id: string; body: string }>> {
+async function ensurePeriodComments(
+  repo: string,
+  threadNum: number,
+  deps: Partial<PulseThreadDeps> = {},
+): Promise<Record<string, { id: string; body: string }>> {
+  const io = pulseThreadDeps(deps);
+
   // Fetch existing comments
-  const commentsJson = (await hostExec(
+  const commentsJson = (await io.hostExec(
     `gh api repos/${repo}/issues/${threadNum}/comments --jq '[.[] | {id: .id, body: .body}]'`
   )).trim();
   const comments: { id: string; body: string }[] = JSON.parse(commentsJson || "[]");
@@ -71,7 +94,7 @@ async function ensurePeriodComments(repo: string, threadNum: number): Promise<Re
       // Create period comment
       const body = `${p.label}\n\n_(no tasks yet)_`;
       const escaped = body.replace(/'/g, "'\\''");
-      const created = (await hostExec(
+      const created = (await io.hostExec(
         `gh api repos/${repo}/issues/${threadNum}/comments -f body='${escaped}' --jq '.id'`
       )).trim();
       result[p.key] = { id: created, body };
@@ -81,12 +104,21 @@ async function ensurePeriodComments(repo: string, threadNum: number): Promise<Re
   return result;
 }
 
-export async function addTaskToPeriodComment(repo: string, threadNum: number, period: string, issueNum: number, title: string, oracle?: string) {
-  const periodComments = await ensurePeriodComments(repo, threadNum);
+export async function addTaskToPeriodComment(
+  repo: string,
+  threadNum: number,
+  period: string,
+  issueNum: number,
+  title: string,
+  oracle?: string,
+  deps: Partial<PulseThreadDeps> = {},
+) {
+  const io = pulseThreadDeps(deps);
+  const periodComments = await ensurePeriodComments(repo, threadNum, io);
   const comment = periodComments[period];
   if (!comment) return;
 
-  const now = new Date().toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit" });
+  const now = io.now().toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit" });
   const oracleTag = oracle ? ` → ${oracle}` : "";
   const taskLine = `- [ ] #${issueNum} ${title} (${now}${oracleTag})`;
 
@@ -99,5 +131,5 @@ export async function addTaskToPeriodComment(repo: string, threadNum: number, pe
   }
 
   const escaped = newBody.replace(/'/g, "'\\''");
-  await hostExec(`gh api repos/${repo}/issues/comments/${comment.id} -X PATCH -f body='${escaped}'`);
+  await io.hostExec(`gh api repos/${repo}/issues/comments/${comment.id} -X PATCH -f body='${escaped}'`);
 }

--- a/test/pulse-thread-default.test.ts
+++ b/test/pulse-thread-default.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from "bun:test";
+import {
+  addTaskToPeriodComment,
+  findOrCreateDailyThread,
+  pulseThreadDeps,
+  timePeriod,
+  todayDate,
+  todayLabel,
+} from "../src/commands/shared/pulse-thread";
+
+function fixed(iso: string): Date {
+  return new Date(iso);
+}
+
+function makeDeps(outputs: (string | ((cmd: string) => string))[] = []) {
+  const calls: string[] = [];
+  const logs: string[] = [];
+  const deps = pulseThreadDeps({
+    hostExec: async (cmd: string) => {
+      calls.push(cmd);
+      const output = outputs.shift();
+      if (typeof output === "function") return output(cmd);
+      return output ?? "";
+    },
+    log: (...args: unknown[]) => logs.push(args.map(String).join(" ")),
+    now: () => fixed("2026-05-17T08:09:00.000Z"),
+  });
+  return { calls, deps, logs };
+}
+
+describe("pulse-thread date helpers", () => {
+  test("default dependency factory supplies a runtime clock", () => {
+    expect(pulseThreadDeps().now()).toBeInstanceOf(Date);
+  });
+
+  test("formats stable local dates and Thai day labels with an injected date", () => {
+    const sunday = fixed("2026-05-17T01:02:03.000Z");
+
+    expect(todayDate(sunday)).toBe("2026-05-17");
+    expect(todayLabel(sunday)).toBe("2026-05-17 (อาทิตย์)");
+  });
+
+  test("classifies each period boundary", () => {
+    expect(timePeriod(fixed("2026-05-17T00:00:00.000Z"))).toBe("midnight");
+    expect(timePeriod(fixed("2026-05-17T05:59:00.000Z"))).toBe("midnight");
+    expect(timePeriod(fixed("2026-05-17T06:00:00.000Z"))).toBe("morning");
+    expect(timePeriod(fixed("2026-05-17T11:59:00.000Z"))).toBe("morning");
+    expect(timePeriod(fixed("2026-05-17T12:00:00.000Z"))).toBe("afternoon");
+    expect(timePeriod(fixed("2026-05-17T17:59:00.000Z"))).toBe("afternoon");
+    expect(timePeriod(fixed("2026-05-17T18:00:00.000Z"))).toBe("evening");
+    expect(timePeriod(fixed("2026-05-17T23:59:00.000Z"))).toBe("evening");
+  });
+});
+
+describe("findOrCreateDailyThread", () => {
+  test("returns an existing daily thread matched by date", async () => {
+    const { calls, deps, logs } = makeDeps([
+      JSON.stringify([
+        {
+          number: 42,
+          title: "📅 2026-05-17 (อาทิตย์) Daily Thread",
+          url: "https://github.com/laris-co/pulse-oracle/issues/42",
+        },
+      ]),
+    ]);
+
+    await expect(findOrCreateDailyThread("laris-co/pulse-oracle", deps)).resolves.toEqual({
+      url: "https://github.com/laris-co/pulse-oracle/issues/42",
+      num: 42,
+      isNew: false,
+    });
+    expect(calls).toEqual([
+      "gh issue list --repo laris-co/pulse-oracle --search '📅 2026-05-17 in:title' --state open --json number,url,title --limit 1",
+    ]);
+    expect(logs).toEqual([]);
+  });
+
+  test("creates a daily thread when no existing title matches today", async () => {
+    const { calls, deps, logs } = makeDeps([
+      JSON.stringify([{ number: 41, title: "📅 2026-05-16 (เสาร์) Daily Thread", url: "old" }]),
+      "https://github.com/laris-co/pulse-oracle/issues/43\n",
+    ]);
+
+    await expect(findOrCreateDailyThread("laris-co/pulse-oracle", deps)).resolves.toEqual({
+      url: "https://github.com/laris-co/pulse-oracle/issues/43",
+      num: 43,
+      isNew: true,
+    });
+    expect(calls[1]).toBe(
+      "gh issue create --repo laris-co/pulse-oracle -t '📅 2026-05-17 (อาทิตย์) Daily Thread' -b 'Tasks for 2026-05-17 (อาทิตย์)' -l daily-thread",
+    );
+    expect(logs.join("\n")).toContain("daily thread #43");
+  });
+
+  test("uses issue number 0 when GitHub create output is not a canonical issue URL", async () => {
+    const { deps } = makeDeps(["[]", "not-a-url"]);
+
+    await expect(findOrCreateDailyThread("laris-co/pulse-oracle", deps)).resolves.toMatchObject({
+      url: "not-a-url",
+      num: 0,
+      isNew: true,
+    });
+  });
+});
+
+describe("addTaskToPeriodComment", () => {
+  test("creates missing period comments and replaces the placeholder for the target period", async () => {
+    const { calls, deps } = makeDeps([
+      JSON.stringify([{ id: "existing-evening", body: "🌆 Evening (18:00-24:00)\n\n- [ ] old" }]),
+      "morning-id",
+      "afternoon-id",
+      "midnight-id",
+      "patched",
+    ]);
+
+    await addTaskToPeriodComment(
+      "laris-co/pulse-oracle",
+      43,
+      "morning",
+      123,
+      "Bob's task",
+      "mawjs",
+      deps,
+    );
+
+    expect(calls[0]).toBe(
+      "gh api repos/laris-co/pulse-oracle/issues/43/comments --jq '[.[] | {id: .id, body: .body}]'",
+    );
+    expect(calls[1]).toContain("gh api repos/laris-co/pulse-oracle/issues/43/comments -f body='🌅 Morning");
+    expect(calls[2]).toContain("☀️ Afternoon");
+    expect(calls[3]).toContain("🌙 Midnight");
+    expect(calls[4]).toBe(
+      "gh api repos/laris-co/pulse-oracle/issues/comments/morning-id -X PATCH -f body='🌅 Morning (06:00-12:00)\n\n- [ ] #123 Bob'\\''s task (08:09 → mawjs)'",
+    );
+  });
+
+  test("appends to an existing target period comment without an oracle tag", async () => {
+    const { calls, deps } = makeDeps([
+      JSON.stringify([
+        { id: "m1", body: "🌅 Morning (06:00-12:00)\n\n- [ ] #1 old" },
+        { id: "a1", body: "☀️ Afternoon (12:00-18:00)\n\n_(no tasks yet)_" },
+        { id: "e1", body: "🌆 Evening (18:00-24:00)\n\n_(no tasks yet)_" },
+        { id: "n1", body: "🌙 Midnight (00:00-06:00)\n\n_(no tasks yet)_" },
+      ]),
+      "patched",
+    ]);
+
+    await addTaskToPeriodComment("laris-co/pulse-oracle", 43, "morning", 124, "append me", undefined, deps);
+
+    expect(calls).toHaveLength(2);
+    expect(calls[1]).toBe(
+      "gh api repos/laris-co/pulse-oracle/issues/comments/m1 -X PATCH -f body='🌅 Morning (06:00-12:00)\n\n- [ ] #1 old\n- [ ] #124 append me (08:09)'",
+    );
+  });
+
+  test("returns without patching when the requested period key is unknown", async () => {
+    const { calls, deps } = makeDeps(["[]", "m", "a", "e", "n"]);
+
+    await addTaskToPeriodComment("laris-co/pulse-oracle", 43, "dawn", 125, "ignored", undefined, deps);
+
+    expect(calls).toHaveLength(5);
+    expect(calls.some((cmd) => cmd.includes("-X PATCH"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add a tiny dependency seam to Pulse daily-thread helpers for clock, shell, and logging injection
- cover daily thread lookup/create, period comment creation, task append/replace, and date/period formatting in the default suite
- refresh coverage gap analysis; pulse-thread is now 100% line/function covered

## Validation
- bun test --coverage test/pulse-thread-default.test.ts
- bun test test/pulse-thread-default.test.ts
- bash scripts/test-isolated.sh test/isolated/pulse-cmd-runtime-coverage.test.ts
- bun run test:coverage — 2175 pass / 6 skip / 0 fail; functions 82.1%, lines 31.6%
- bun run build
- git diff --check

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
