### PR TITLE
fix(wake): reuse stable worktree slots

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,27 +1,27 @@
 # Coverage gap analysis
 
-Generated: 2026-05-17T13:35:47.405Z
+Generated: 2026-05-17T13:55:27.509Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 
-Overall line coverage: **31.7%** (15931/50255)
-Overall function coverage: **82.2%** (1806/2196)
+Overall line coverage: **31.9%** (16036/50277)
+Overall function coverage: **82.5%** (1819/2206)
 
 ## Module summary
 
 | Module | Files | Missing from LCOV | Lines | Functions | Branches |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| cli/dispatch | 90 | 10 | 70.9% (5253/7407) | 83.4% (532/638) | n/a (0/0) |
+| cli/dispatch | 90 | 10 | 72.1% (5357/7431) | 84.1% (545/648) | n/a (0/0) |
 | config/runtime | 19 | 2 | 66.6% (776/1166) | 74.0% (71/96) | n/a (0/0) |
 | fleet | 17 | 0 | 58.4% (609/1042) | 69.9% (58/83) | n/a (0/0) |
 | matcher | 2 | 0 | 100.0% (41/41) | 100.0% (8/8) | n/a (0/0) |
 | other | 174 | 69 | 37.1% (5343/14391) | 75.1% (575/766) | n/a (0/0) |
 | plugin dispatch | 15 | 1 | 86.6% (1015/1172) | 89.9% (80/89) | n/a (0/0) |
-| routing/aliases | 4 | 0 | 91.4% (582/637) | 94.5% (69/73) | n/a (0/0) |
+| routing/aliases | 4 | 0 | 91.4% (583/638) | 94.5% (69/73) | n/a (0/0) |
 | transport | 28 | 1 | 87.4% (2131/2438) | 94.7% (397/419) | n/a (0/0) |
-| vendor plugins | 245 | 243 | 0.8% (181/21961) | 66.7% (16/24) | n/a (0/0) |
+| vendor plugins | 245 | 243 | 0.8% (181/21958) | 66.7% (16/24) | n/a (0/0) |
 
 ## Top 20 uncovered files by executable/source line count
 
@@ -95,6 +95,7 @@ Overall function coverage: **82.2%** (1806/2196)
 | cli/dispatch | `src/commands/shared/wake-maybe-split.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/wake-resolve-impl.ts` | 99.6% | 97.6% |
 | cli/dispatch | `src/commands/shared/wake-resolve.ts` | 100.0% | 100.0% |
+| cli/dispatch | `src/commands/shared/wake-session.ts` | 98.2% | 92.9% |
 | cli/dispatch | `src/commands/shared/wake-target.ts` | 80.0% | 80.0% |
 | cli/dispatch | `src/commands/shared/wake.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/workspace-agents.ts` | 100.0% | 100.0% |
@@ -160,10 +161,10 @@ Overall function coverage: **82.2%** (1806/2196)
 | cli/dispatch | `src/commands/shared/fleet-doctor.ts` | 92 | 12.4% |
 | fleet | `src/core/fleet/worktrees-cleanup.ts` | 88 | 7.4% |
 | plugin dispatch | `src/plugin/types.ts` | 86 | 0.0% |
-| cli/dispatch | `src/commands/shared/wake-session.ts` | 82 | 6.8% |
 | transport | `src/transports/scout-pair.ts` | 80 | 9.1% |
 | transport | `src/transports/index.ts` | 78 | 29.7% |
 | cli/dispatch | `src/commands/shared/artifacts.ts` | 72 | 1.4% |
+| cli/dispatch | `src/commands/shared/plugins-toggle.ts` | 70 | 6.7% |
 
 ## Critical gaps to prioritize
 

--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -152,7 +152,7 @@ function printBringUsage(write: (line: string) => void = console.log): void {
 }
 
 function printWakeAliasUsage(verb: "wake" | "awake", write: (line: string) => void = console.log): void {
-  write(`usage: maw ${verb} <oracle> [--session <tmux-session>] [--task <s>] [--wt <s>] [--bud] [--signal-on-birth] [-p|--prompt <s>] [--incubate <slug>] [--fresh] [-a|--attach] [--list] [--dry-run] [--from-snapshot|--snapshot <id>] [--main|--solo|--no-rehydrate] [--split] [--all-local] [-e|--engine <name>]`);
+  write(`usage: maw ${verb} <oracle> [--session <tmux-session>] [--task <s>] [--wt <s>] [--bud] [--signal-on-birth] [-p|--prompt <s>] [--incubate <slug>] [--fresh|--new] [-a|--attach] [--list] [--dry-run] [--from-snapshot|--snapshot <id>] [--main|--solo|--no-rehydrate] [--split] [--all-local] [-e|--engine <name>]`);
   if (verb === "awake") {
     write("  Launch/start an oracle process with the selected engine. Does not send /awaken.");
     write("  Use `maw awaken` for the awakening ritual; use `maw new` for a plain workspace session.");
@@ -160,6 +160,7 @@ function printWakeAliasUsage(verb: "wake" | "awake", write: (line: string) => vo
     write("  Wake or reuse an oracle session, fuzzy-resolving repos and worktrees as needed.");
   }
   write("  --session targets an existing foreign workspace session instead of the oracle's own session.");
+  write("  --fresh/--new forces a new numbered worktree slot; default prefers a stable reusable slot.");
   write("  --list previews worktrees only; it does not create sessions or respawn windows.");
   write("  --from-snapshot restores missing windows from the latest recovery snapshot; --snapshot <id> selects one.");
   write("  --bud with --task/--wt writes ψ/.lineage.yaml in the worktree (no repo/fleet mutation).");
@@ -267,7 +268,7 @@ export async function invokeDirectHandler(
       "--session": String,
       "--prompt": String, "-p": "--prompt",
       "--incubate": String,
-      "--fresh": Boolean,
+      "--fresh": Boolean, "--new": "--fresh",
       "--bud": Boolean,
       "--signal-on-birth": Boolean,
       "--attach": Boolean, "-a": "--attach",

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -668,7 +668,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
       targetPath = match.path;
       windowName = `${oracle}-${name}`;
     } else {
-      const result = await createWorktree(repoPath, parentDir, repoName, oracle, name, worktrees);
+      const result = await createWorktree(repoPath, parentDir, repoName, oracle, name, worktrees, { fresh: !!opts.fresh });
       targetPath = result.wtPath;
       windowName = result.windowName;
     }

--- a/src/commands/shared/wake-session.ts
+++ b/src/commands/shared/wake-session.ts
@@ -2,12 +2,43 @@ import { hostExec, tmux } from "../../sdk";
 import { buildCommand, buildCommandInDir, cfgTimeout } from "../../config";
 import { execSync } from "child_process";
 
+type WakeTmuxDeps = Pick<typeof tmux, "switchClient" | "listWindows" | "getPaneCommands" | "sendText">;
+
+export interface WakeSessionDeps {
+  hostExec: typeof hostExec;
+  tmux: WakeTmuxDeps;
+  buildCommand: typeof buildCommand;
+  buildCommandInDir: typeof buildCommandInDir;
+  cfgTimeout: typeof cfgTimeout;
+  execSync: typeof execSync;
+  sleep: (ms: number) => Promise<void>;
+  log: (...args: unknown[]) => void;
+  /** Force a new numbered worktree slot instead of preferring a stable reusable slot. */
+  fresh: boolean;
+}
+
+export function wakeSessionDeps(overrides: Partial<WakeSessionDeps> = {}): WakeSessionDeps {
+  return {
+    hostExec,
+    tmux,
+    buildCommand,
+    buildCommandInDir,
+    cfgTimeout,
+    execSync,
+    sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+    log: console.log.bind(console),
+    fresh: false,
+    ...overrides,
+  };
+}
+
 /** Attach to tmux session — switch-client if inside tmux, attach if fresh shell */
-export async function attachToSession(session: string) {
+export async function attachToSession(session: string, deps: Partial<WakeSessionDeps> = {}) {
+  const d = wakeSessionDeps(deps);
   if (process.env.TMUX) {
-    await tmux.switchClient(session);
+    await d.tmux.switchClient(session);
   } else {
-    execSync(`tmux attach-session -t ${session}`, { stdio: "inherit" });
+    d.execSync(`tmux attach-session -t ${session}`, { stdio: "inherit" });
   }
 }
 
@@ -16,40 +47,47 @@ export async function attachToSession(session: string) {
  * Returns true when the shell has no children → safe to retry.
  * Returns true on error as a fail-safe (preserves existing retry behavior).
  */
-export async function isPaneIdle(paneTarget: string): Promise<boolean> {
+export async function isPaneIdle(paneTarget: string, deps: Partial<WakeSessionDeps> = {}): Promise<boolean> {
+  const d = wakeSessionDeps(deps);
   try {
-    const panePid = (await hostExec(
+    const panePid = (await d.hostExec(
       `tmux display-message -t '${paneTarget}' -p '#{pane_pid}'`
     )).trim();
     if (!panePid) return true;
     // pgrep -P shows direct children — if any, the shell is busy
-    const children = (await hostExec(`pgrep -P ${panePid} 2>/dev/null || true`)).trim();
+    const children = (await d.hostExec(`pgrep -P ${panePid} 2>/dev/null || true`)).trim();
     return children.length === 0;
   } catch {
     return true; // fail-safe to current behavior
   }
 }
 
-export async function ensureSessionRunning(session: string, excludeNames?: Set<string>, cwdMap?: Record<string, string>): Promise<number> {
+export async function ensureSessionRunning(
+  session: string,
+  excludeNames?: Set<string>,
+  cwdMap?: Record<string, string>,
+  deps: Partial<WakeSessionDeps> = {},
+): Promise<number> {
+  const d = wakeSessionDeps(deps);
   let retried = 0;
   let windows: { index: number; name: string; active: boolean }[];
-  try { windows = await tmux.listWindows(session); } catch { return 0; }
+  try { windows = await d.tmux.listWindows(session); } catch { return 0; }
 
   const targets = windows.map(w => `${session}:${w.name}`);
-  const cmds = await tmux.getPaneCommands(targets);
+  const cmds = await d.tmux.getPaneCommands(targets);
 
   for (const win of windows) {
     if (excludeNames?.has(win.name)) continue;
     const target = `${session}:${win.name}`;
     const paneCmd = (cmds[target] || "").trim().toLowerCase();
     if (paneCmd === "zsh" || paneCmd === "bash" || paneCmd === "sh" || paneCmd === "") {
-      if (!(await isPaneIdle(target))) continue; // shell has children → mid-startup, skip
+      if (!(await isPaneIdle(target, d))) continue; // shell has children → mid-startup, skip
       try {
-        await new Promise(r => setTimeout(r, cfgTimeout("wakeRetry")));
+        await d.sleep(d.cfgTimeout("wakeRetry"));
         const cwd = cwdMap?.[win.name];
-        const cmd = cwd ? buildCommandInDir(win.name, cwd) : buildCommand(win.name);
-        await tmux.sendText(target, cmd);
-        console.log(`\x1b[33m↻\x1b[0m retry: ${win.name} (was ${paneCmd || "empty"})`);
+        const cmd = cwd ? d.buildCommandInDir(win.name, cwd) : d.buildCommand(win.name);
+        await d.tmux.sendText(target, cmd);
+        d.log(`\x1b[33m↻\x1b[0m retry: ${win.name} (was ${paneCmd || "empty"})`);
         retried++;
       } catch { /* window may have been killed */ }
     }
@@ -68,17 +106,20 @@ export async function createWorktree(
   oracle: string,
   name: string,
   existingWorktrees: { name: string; path: string }[],
+  deps: Partial<WakeSessionDeps> = {},
 ): Promise<{ wtPath: string; windowName: string }> {
+  const d = wakeSessionDeps(deps);
   const nums = existingWorktrees.map(w => parseInt(w.name) || 0);
-  let nextNum = nums.length > 0 ? Math.max(...nums) + 1 : 1;
+  let nextNum = d.fresh && nums.length > 0 ? Math.max(...nums) + 1 : 1;
   const safe = (s: string) => s.replace(/'/g, "'\\''");
-  try { await hostExec(`git -C '${safe(repoPath)}' rev-parse HEAD 2>/dev/null`); } catch {
-    await hostExec(`git -C '${safe(repoPath)}' commit --allow-empty -m "init: bootstrap for worktree"`);
+  try { await d.hostExec(`git -C '${safe(repoPath)}' rev-parse HEAD 2>/dev/null`); } catch {
+    await d.hostExec(`git -C '${safe(repoPath)}' commit --allow-empty -m "init: bootstrap for worktree"`);
   }
 
   let wtName = "";
   let wtPath = "";
   let branch = "";
+  let branchExists = false;
   let allocated = false;
   for (let attempts = 0; attempts < 1000; attempts++) {
     wtName = `${nextNum}-${name}`;
@@ -90,20 +131,27 @@ export async function createWorktree(
       continue;
     }
     try {
-      await hostExec(`git -C '${safe(repoPath)}' show-ref --verify --quiet 'refs/heads/${safe(branch)}'`);
-      nextNum++;
-      continue;
+      await d.hostExec(`git -C '${safe(repoPath)}' show-ref --verify --quiet 'refs/heads/${safe(branch)}'`);
+      branchExists = true;
+      if (d.fresh) {
+        nextNum++;
+        continue;
+      }
     } catch {
-      allocated = true;
-      break;
+      branchExists = false;
     }
+    allocated = true;
+    break;
   }
 
   if (!allocated || !wtName || !wtPath || !branch) {
     throw new Error(`could not allocate worktree for ${name}`);
   }
 
-  await hostExec(`git -C '${safe(repoPath)}' worktree add '${safe(wtPath)}' -b '${safe(branch)}'`);
-  console.log(`\x1b[32m+\x1b[0m worktree: ${wtPath} (${branch})`);
+  const addArgs = branchExists
+    ? `'${safe(wtPath)}' '${safe(branch)}'`
+    : `'${safe(wtPath)}' -b '${safe(branch)}'`;
+  await d.hostExec(`git -C '${safe(repoPath)}' worktree add ${addArgs}`);
+  d.log(`\x1b[32m+\x1b[0m worktree: ${wtPath} (${branch}${branchExists ? ", reused branch" : ""})`);
   return { wtPath, windowName: `${oracle}-${name}` };
 }

--- a/src/vendor/mpr-plugins/wake/index.ts
+++ b/src/vendor/mpr-plugins/wake/index.ts
@@ -32,7 +32,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       if (!args[0]) {
         return {
           ok: false,
-          error: "usage: maw wake <oracle|org/repo|URL> [task] [--task \"<prompt>\"] [--wt <name>] [--fresh] [--attach] [--issue N] [--pr N] [--repo org/name] [--list] [--dry-run] [--from-snapshot|--snapshot <id>] [--main|--solo|--no-rehydrate] [--all-local] [--peer <alias>]\n       maw wake all [--kill]\n       --list previews worktrees only; no tmux session/window changes\n       --dry-run previews session/worktree rehydrate actions; --from-snapshot previews/restores missing snapshot windows; --main skips worktree rehydrate\n       (--new is a deprecated alias for --wt, removed in alpha.114)",
+          error: "usage: maw wake <oracle|org/repo|URL> [task] [--task \"<prompt>\"] [--wt <name>] [--fresh|--new] [--attach] [--issue N] [--pr N] [--repo org/name] [--list] [--dry-run] [--from-snapshot|--snapshot <id>] [--main|--solo|--no-rehydrate] [--all-local] [--peer <alias>]\n       maw wake all [--kill]\n       --list previews worktrees only; no tmux session/window changes\n       --dry-run previews session/worktree rehydrate actions; --from-snapshot previews/restores missing snapshot windows; --main skips worktree rehydrate\n       --new is an alias for --fresh: force a new numbered worktree slot",
         };
       }
 
@@ -42,15 +42,11 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         return { ok: true, output: logs.join("\n") || undefined };
       }
 
-      if (args.includes("--new")) {
-        console.error("\x1b[33m⚠\x1b[0m --new renamed to --wt (removed in alpha.114)");
-      }
-
       const flags = parseFlags(args, {
-        "--wt": String, "--new": "--wt",
+        "--wt": String,
         "--incubate": String, "--issue": Number,
         "--pr": Number, "--repo": String, "--task": String,
-        "--fresh": Boolean, "--attach": Boolean, "-a": "--attach",
+        "--fresh": Boolean, "--new": "--fresh", "--attach": Boolean, "-a": "--attach",
         "--no-attach": Boolean, // #823 Bug B — register so it doesn't fall through to positional → wakeOpts.task
         "--list": Boolean, "--ls": "--list",
         "--dry-run": Boolean,

--- a/src/vendor/mpr-plugins/wake/plugin.json
+++ b/src/vendor/mpr-plugins/wake/plugin.json
@@ -6,10 +6,10 @@
   "description": "Spawn or attach to an oracle session",
   "cli": {
     "command": "wake",
-    "help": "maw wake <oracle|org/repo|URL> [task] [--task '<prompt>'] [--wt <name>] [--fresh] [--no-attach] [--issue N] [--pr N] [--repo org/name] [--list] [--peer <alias>]  (--new is deprecated alias for --wt, removed in alpha.114)",
+    "help": "maw wake <oracle|org/repo|URL> [task] [--task '<prompt>'] [--wt <name>] [--fresh|--new] [--no-attach] [--issue N] [--pr N] [--repo org/name] [--list] [--peer <alias>]  (--new forces a fresh numbered worktree)",
     "flags": {
       "--wt": "string",
-      "--new": "string",
+      "--new": "boolean",
       "--incubate": "string",
       "--issue": "number",
       "--pr": "number",

--- a/test/isolated/wake-session-worktree.test.ts
+++ b/test/isolated/wake-session-worktree.test.ts
@@ -38,10 +38,20 @@ describe("createWorktree", () => {
     expect(commands).toContain("git -C '/repo' worktree add '/tmp/repo.wt-1-tile-1' -b 'agents/1-tile-1'");
   });
 
-  test("skips stale branch names instead of clobbering them", async () => {
+  test("reattaches an existing stale branch at the stable reusable slot", async () => {
     existingBranches.add("agents/1-tile-1");
 
     await createWorktree("/repo", "/tmp", "repo", "oracle", "tile-1", []);
+
+    expect(commands.some(cmd => cmd.includes("branch -D"))).toBe(false);
+    expect(commands).toContain("git -C '/repo' show-ref --verify --quiet 'refs/heads/agents/1-tile-1'");
+    expect(commands).toContain("git -C '/repo' worktree add '/tmp/repo.wt-1-tile-1' 'agents/1-tile-1'");
+  });
+
+  test("fresh mode skips stale branch names instead of clobbering them", async () => {
+    existingBranches.add("agents/1-tile-1");
+
+    await createWorktree("/repo", "/tmp", "repo", "oracle", "tile-1", [], { fresh: true });
 
     expect(commands.some(cmd => cmd.includes("branch -D"))).toBe(false);
     expect(commands).toContain("git -C '/repo' show-ref --verify --quiet 'refs/heads/agents/1-tile-1'");

--- a/test/wake-cmd-cmdwake-coverage.test.ts
+++ b/test/wake-cmd-cmdwake-coverage.test.ts
@@ -344,12 +344,18 @@ mock.module(
   join(import.meta.dir, "../src/commands/shared/wake-session"),
   () => ({
     ..._rWakeSession,
-    attachToSession: async (session: string) => {
-      if (!mockActive) return realWakeSession.attachToSession(session);
+    attachToSession: async (
+      ...args: Parameters<typeof _rWakeSession.attachToSession>
+    ) => {
+      if (!mockActive) return realWakeSession.attachToSession(...args);
+      const [session] = args;
       attachCalls.push(session);
     },
-    ensureSessionRunning: async (session: string) => {
-      if (!mockActive) return realWakeSession.ensureSessionRunning(session);
+    ensureSessionRunning: async (
+      ...args: Parameters<typeof _rWakeSession.ensureSessionRunning>
+    ) => {
+      if (!mockActive) return realWakeSession.ensureSessionRunning(...args);
+      const [session] = args;
       ensureSessionRunningCalls.push(session);
       return ensureSessionRunningReturn;
     },
@@ -359,6 +365,8 @@ mock.module(
       repoNameArg: string,
       oracleArg: string,
       name: string,
+      existingWorktrees: { name: string; path: string }[] = [],
+      deps?: Parameters<typeof _rWakeSession.createWorktree>[6],
     ) => {
       if (!mockActive)
         return realWakeSession.createWorktree(
@@ -367,7 +375,8 @@ mock.module(
           repoNameArg,
           oracleArg,
           name,
-          [],
+          existingWorktrees,
+          deps,
         );
       createdWorktrees.push({
         repoPath: repoPathArg,

--- a/test/wake-flags.test.ts
+++ b/test/wake-flags.test.ts
@@ -33,6 +33,7 @@ function buildWakeOpts(args: string[]): { opts: WakeOpts; repo: string | undefin
     "--repo": String,
     "--task": String,
     "--fresh": Boolean,
+    "--new": "--fresh",
     "--no-attach": Boolean,
     "--list": Boolean,
     "--ls": "--list",
@@ -150,6 +151,12 @@ describe("wake preview/control flags (#1563)", () => {
     expect(buildWakeOpts(["wake", "neo", "--main"]).opts.noRehydrate).toBe(true);
     expect(buildWakeOpts(["wake", "neo", "--solo"]).opts.noRehydrate).toBe(true);
     expect(buildWakeOpts(["wake", "neo", "--no-rehydrate"]).opts.noRehydrate).toBe(true);
+  });
+
+  test("--new is an alias for --fresh, not --wt", () => {
+    const { opts } = buildWakeOpts(["wake", "neo", "--wt", "white", "--new"]);
+    expect(opts.wt).toBe("white");
+    expect(opts.fresh).toBe(true);
   });
 });
 

--- a/test/wake-session-default.test.ts
+++ b/test/wake-session-default.test.ts
@@ -1,0 +1,258 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  attachToSession,
+  createWorktree,
+  ensureSessionRunning,
+  isPaneIdle,
+} from "../src/commands/shared/wake-session";
+
+const originalTmux = process.env.TMUX;
+
+afterEach(() => {
+  if (originalTmux === undefined) delete process.env.TMUX;
+  else process.env.TMUX = originalTmux;
+});
+
+function makeTmux(overrides: Record<string, unknown> = {}) {
+  return {
+    switchClient: async () => {},
+    listWindows: async () => [] as Array<{ index: number; name: string; active: boolean }>,
+    getPaneCommands: async () => ({} as Record<string, string>),
+    sendText: async () => {},
+    ...overrides,
+  } as any;
+}
+
+describe("wake-session dependency seam", () => {
+  test("attachToSession switches tmux clients inside tmux", async () => {
+    process.env.TMUX = "/tmp/tmux-501/default,1,0";
+    const calls: string[] = [];
+
+    await attachToSession("54-mawjs", {
+      tmux: makeTmux({ switchClient: async (session: string) => calls.push(session) }),
+      execSync: (() => { throw new Error("should not attach"); }) as any,
+    });
+
+    expect(calls).toEqual(["54-mawjs"]);
+  });
+
+  test("attachToSession attaches a fresh shell outside tmux", async () => {
+    delete process.env.TMUX;
+    const calls: Array<{ cmd: string; opts: unknown }> = [];
+
+    await attachToSession("54-mawjs", {
+      tmux: makeTmux({ switchClient: async () => { throw new Error("should not switch"); } }),
+      execSync: ((cmd: string, opts: unknown) => calls.push({ cmd, opts })) as any,
+    });
+
+    expect(calls).toEqual([{ cmd: "tmux attach-session -t 54-mawjs", opts: { stdio: "inherit" } }]);
+  });
+});
+
+describe("isPaneIdle", () => {
+  test("returns true when pane pid is empty or has no children", async () => {
+    expect(await isPaneIdle("s:win", { hostExec: async () => "\n" })).toBe(true);
+
+    const commands: string[] = [];
+    const idle = await isPaneIdle("s:win", {
+      hostExec: async (cmd: string) => {
+        commands.push(cmd);
+        return cmd.includes("display-message") ? "123\n" : "\n";
+      },
+    });
+
+    expect(idle).toBe(true);
+    expect(commands).toEqual([
+      "tmux display-message -t 's:win' -p '#{pane_pid}'",
+      "pgrep -P 123 2>/dev/null || true",
+    ]);
+  });
+
+  test("returns false for child processes and true on host errors", async () => {
+    expect(await isPaneIdle("s:win", {
+      hostExec: async (cmd: string) => cmd.includes("display-message") ? "123\n" : "456\n",
+    })).toBe(false);
+
+    expect(await isPaneIdle("s:win", {
+      hostExec: async () => { throw new Error("tmux unavailable"); },
+    })).toBe(true);
+  });
+});
+
+describe("ensureSessionRunning", () => {
+  test("returns 0 when windows cannot be listed", async () => {
+    const retried = await ensureSessionRunning("missing", undefined, undefined, {
+      tmux: makeTmux({ listWindows: async () => { throw new Error("missing"); } }),
+    });
+    expect(retried).toBe(0);
+  });
+
+  test("retries idle shell panes, skips excluded, busy, and non-shell windows", async () => {
+    const sent: Array<{ target: string; cmd: string }> = [];
+    const logs: string[] = [];
+    const hostCommands: string[] = [];
+    const panePids: Record<string, string> = {
+      "s:idle": "111\n",
+      "s:busy": "222\n",
+      "s:cwd": "333\n",
+      "s:empty": "444\n",
+    };
+
+    const retried = await ensureSessionRunning(
+      "s",
+      new Set(["skip"]),
+      { cwd: "/work/cwd" },
+      {
+        tmux: makeTmux({
+          listWindows: async () => [
+            { index: 0, name: "idle", active: true },
+            { index: 1, name: "busy", active: false },
+            { index: 2, name: "node", active: false },
+            { index: 3, name: "skip", active: false },
+            { index: 4, name: "cwd", active: false },
+            { index: 5, name: "empty", active: false },
+            { index: 6, name: "killed", active: false },
+          ],
+          getPaneCommands: async () => ({
+            "s:idle": "zsh",
+            "s:busy": "bash",
+            "s:node": "node",
+            "s:skip": "zsh",
+            "s:cwd": "sh",
+            "s:empty": "",
+            "s:killed": "zsh",
+          }),
+          sendText: async (target: string, cmd: string) => {
+            if (target === "s:killed") throw new Error("gone");
+            sent.push({ target, cmd });
+          },
+        }),
+        hostExec: async (cmd: string) => {
+          hostCommands.push(cmd);
+          if (cmd.includes("display-message")) {
+            const target = cmd.match(/-t '([^']+)'/)?.[1] ?? "";
+            return panePids[target] ?? "555\n";
+          }
+          if (cmd.includes("pgrep -P 222")) return "999\n";
+          return "\n";
+        },
+        sleep: async () => {},
+        cfgTimeout: () => 0,
+        buildCommand: (name: string) => `run ${name}`,
+        buildCommandInDir: (name: string, cwd: string) => `cd ${cwd} && run ${name}`,
+        log: (...args: unknown[]) => logs.push(args.map(String).join(" ")),
+      },
+    );
+
+    expect(retried).toBe(3);
+    expect(sent).toEqual([
+      { target: "s:idle", cmd: "run idle" },
+      { target: "s:cwd", cmd: "cd /work/cwd && run cwd" },
+      { target: "s:empty", cmd: "run empty" },
+    ]);
+    expect(logs.join("\n")).toContain("retry: idle");
+    expect(logs.join("\n")).toContain("retry: cwd");
+    expect(logs.join("\n")).toContain("retry: empty (was empty)");
+    expect(hostCommands.some(cmd => cmd.includes("s:skip"))).toBe(false);
+    expect(hostCommands.some(cmd => cmd.includes("s:node"))).toBe(false);
+  });
+});
+
+describe("createWorktree", () => {
+  test("defaults to the lowest reusable target-specific slot instead of global max+1", async () => {
+    const commands: string[] = [];
+    const result = await createWorktree(
+      "/repo",
+      "/tmp",
+      "repo",
+      "oracle",
+      "white",
+      [
+        { name: "1-alpha", path: "/tmp/repo.wt-1-alpha" },
+        { name: "2-beta", path: "/tmp/repo.wt-2-beta" },
+      ],
+      {
+        hostExec: async (cmd: string) => {
+          commands.push(cmd);
+          if (cmd.includes("rev-parse HEAD")) return "abc\n";
+          if (cmd.includes("show-ref")) throw new Error("missing branch");
+          return "";
+        },
+        log: () => {},
+      },
+    );
+
+    expect(result).toEqual({ wtPath: "/tmp/repo.wt-1-white", windowName: "oracle-white" });
+    expect(commands).toContain("git -C '/repo' worktree add '/tmp/repo.wt-1-white' -b 'agents/1-white'");
+  });
+
+  test("reattaches an existing branch for the stable slot when the worktree dir is gone", async () => {
+    const commands: string[] = [];
+    const logs: string[] = [];
+
+    const result = await createWorktree("/repo", "/tmp", "repo", "oracle", "white", [], {
+      hostExec: async (cmd: string) => {
+        commands.push(cmd);
+        if (cmd.includes("rev-parse HEAD")) return "abc\n";
+        if (cmd.includes("show-ref")) return "";
+        return "";
+      },
+      log: (...args: unknown[]) => logs.push(args.map(String).join(" ")),
+    });
+
+    expect(result.wtPath).toBe("/tmp/repo.wt-1-white");
+    expect(commands).toContain("git -C '/repo' worktree add '/tmp/repo.wt-1-white' 'agents/1-white'");
+    expect(logs.join("\n")).toContain("reused branch");
+  });
+
+  test("fresh mode keeps the old max+1 behavior for one-shot worktrees", async () => {
+    const commands: string[] = [];
+
+    const result = await createWorktree(
+      "/repo",
+      "/tmp",
+      "repo",
+      "oracle",
+      "white",
+      [{ name: "7-alpha", path: "/tmp/repo.wt-7-alpha" }],
+      {
+        fresh: true,
+        hostExec: async (cmd: string) => {
+          commands.push(cmd);
+          if (cmd.includes("rev-parse HEAD")) return "abc\n";
+          if (cmd.includes("show-ref")) throw new Error("missing branch");
+          return "";
+        },
+        log: () => {},
+      },
+    );
+
+    expect(result).toEqual({ wtPath: "/tmp/repo.wt-8-white", windowName: "oracle-white" });
+    expect(commands).toContain("git -C '/repo' worktree add '/tmp/repo.wt-8-white' -b 'agents/8-white'");
+  });
+
+  test("bootstraps unborn repos, escapes shell args, and errors after allocation exhaustion", async () => {
+    const commands: string[] = [];
+    await createWorktree("/repo's", "/tmp", "repo", "oracle", "white", [], {
+      hostExec: async (cmd: string) => {
+        commands.push(cmd);
+        if (cmd.includes("rev-parse HEAD")) throw new Error("unborn");
+        if (cmd.includes("show-ref")) throw new Error("missing branch");
+        return "";
+      },
+      log: () => {},
+    });
+
+    expect(commands[0]).toBe("git -C '/repo'\\''s' rev-parse HEAD 2>/dev/null");
+    expect(commands[1]).toBe("git -C '/repo'\\''s' commit --allow-empty -m \"init: bootstrap for worktree\"");
+
+    const existing = Array.from({ length: 1000 }, (_, i) => ({
+      name: `${i + 1}-white`,
+      path: `/tmp/repo.wt-${i + 1}-white`,
+    }));
+    await expect(createWorktree("/repo", "/tmp", "repo", "oracle", "white", existing, {
+      hostExec: async (cmd: string) => cmd.includes("rev-parse") ? "abc\n" : "",
+      log: () => {},
+    })).rejects.toThrow("could not allocate worktree for white");
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes #1768 by making `maw wake <oracle> --wt <name>` reuse the stable lowest task-specific worktree slot by default.
- Reattaches an existing `agents/1-<name>` branch after `maw done` removes the worktree, preserving the encoded Claude project path across done→wake cycles.
- Keeps forced one-shot behavior behind `--fresh` / `--new`.
- Adds dependency seams and default-suite coverage for wake-session helpers.

## Validation
- `bun test --coverage test/wake-session-default.test.ts`
- `bun test test/wake-flags.test.ts test/top-aliases-default.test.ts test/wake-session-default.test.ts`
- `bash scripts/test-isolated.sh test/isolated/wake-session-worktree.test.ts test/isolated/top-aliases-runtime-coverage.test.ts`
- `bun test test/wake-cmd-cmdwake-coverage.test.ts test/wake-session-default.test.ts`
- `bun run build`
- `bun run test:coverage` — 2191 pass / 6 skip / 0 fail; functions 82.5%, lines 31.9%
- `git diff --check`
- Direct git worktree smoke confirmed create→remove→recreate reuses `repo.wt-1-white` and existing `agents/1-white`.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.