### PR TITLE
release: v26.5.17-alpha.2103

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.17-alpha.1646",
+  "version": "26.5.17-alpha.2103",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts v26.5.17-alpha.2103 on merge via calver-release.yml.\n\nIncludes #1772 / #1768 wake worktree reuse.\n\nValidation before release:\n- PR #1772 merged to alpha at 39e47aee.\n- Local full suite: 2191 pass / 6 skip / 0 fail.\n- Build passed.\n- Direct worktree smoke confirmed done→wake reuses repo.wt-1-white.\n\nWritten by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.