### PR TITLE
test: cover fleet wake and plugin helper slices

### DIFF
--- a/src/commands/plugins/oracle/impl-list.test.ts
+++ b/src/commands/plugins/oracle/impl-list.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "bun:test";
+import { formatRow, type EnrichedEntry } from "./impl-list";
+
+function enriched(partial: Partial<EnrichedEntry> & { name?: string } = {}): EnrichedEntry {
+  const name = partial.name ?? "neo";
+  return {
+    entry: {
+      org: "Soul-Brews-Studio",
+      repo: `${name}-oracle`,
+      name,
+      local_path: `/tmp/${name}-oracle`,
+      has_psi: true,
+      has_fleet_config: false,
+      budded_from: null,
+      budded_at: null,
+      federation_node: null,
+      detected_at: "2026-05-17T00:00:00.000Z",
+    },
+    awake: false,
+    session: null,
+    lineage: {
+      hasPsi: true,
+      hasFleetConfig: false,
+      isAwake: false,
+      inAgents: false,
+      federationNode: undefined,
+    },
+    sources: ["oracles-json"],
+    ...partial,
+  };
+}
+
+describe("formatRow", () => {
+  it("renders fleet+awake entries with federation node", () => {
+    const row = formatRow(
+      enriched({
+        awake: true,
+        session: "team",
+        lineage: {
+          hasPsi: true,
+          hasFleetConfig: true,
+          isAwake: true,
+          inAgents: true,
+          federationNode: "white",
+        },
+      }),
+      { showPath: false },
+    );
+
+    expect(row).toContain("fleet+awake");
+    expect(row).toContain("oracle (ψ/)");
+    expect(row).toContain("· white");
+    expect(row).not.toContain("/tmp/neo-oracle");
+  });
+
+  it("renders sleeping fleet-only manifest entries as not cloned", () => {
+    const row = formatRow(
+      enriched({
+        entry: {
+          ...enriched().entry,
+          local_path: "",
+          has_psi: false,
+          has_fleet_config: true,
+        },
+        lineage: {
+          hasPsi: false,
+          hasFleetConfig: true,
+          isAwake: false,
+          inAgents: false,
+          federationNode: undefined,
+        },
+      }),
+      { showPath: true },
+    );
+
+    expect(row).toContain("fleet      ");
+    expect(row).toContain("fleet-only");
+    expect(row).toContain("not cloned");
+  });
+
+  it("renders filesystem-only rows with register hint and optional path", () => {
+    const row = formatRow(enriched(), { showPath: true });
+
+    expect(row).toContain("fs         ");
+    expect(row).toContain("oracle (ψ/)");
+    expect(row).toContain("not registered");
+    expect(row).toContain("/tmp/neo-oracle");
+  });
+
+  it("renders uncertain rows and pads nickname display by visible width", () => {
+    const row = formatRow(
+      enriched({
+        entry: {
+          ...enriched().entry,
+          name: "morpheus",
+          nickname: "Morph",
+          local_path: "/tmp/morpheus-oracle",
+          has_psi: false,
+          has_fleet_config: false,
+        },
+        lineage: {
+          hasPsi: false,
+          hasFleetConfig: false,
+          isAwake: false,
+          inAgents: false,
+          federationNode: undefined,
+        },
+      }),
+      { showPath: false },
+    );
+
+    expect(row).toContain("fs (?)");
+    expect(row).toContain("morpheus");
+    expect(row).toContain("Morph");
+    expect(row).toContain("uncertain");
+    expect(row).toContain("not registered");
+  });
+
+  it("renders budded lineage before generic filesystem lineage", () => {
+    const row = formatRow(
+      enriched({
+        entry: {
+          ...enriched().entry,
+          budded_from: "trinity",
+        },
+        lineage: {
+          hasPsi: true,
+          hasFleetConfig: false,
+          isAwake: false,
+          inAgents: false,
+          federationNode: undefined,
+        },
+      }),
+      { showPath: false },
+    );
+
+    expect(row).toContain("budded from trinity");
+  });
+});

--- a/test/helpers/fleet-wake-harness.ts
+++ b/test/helpers/fleet-wake-harness.ts
@@ -1,0 +1,163 @@
+import { afterAll, afterEach, beforeEach, mock } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const root = join(import.meta.dir, "../..");
+
+export interface FleetWindowFixture {
+  name: string;
+  repo: string;
+}
+
+export interface FleetSessionFixture {
+  name: string;
+  windows: FleetWindowFixture[];
+  skip_command?: boolean;
+}
+
+export const fleetDir = mkdtempSync(join(tmpdir(), "maw-fleet-wake-fleet-"));
+export const ghqRoot = mkdtempSync(join(tmpdir(), "maw-fleet-wake-ghq-"));
+
+export const state = {
+  fleet: [] as FleetSessionFixture[],
+  hasSessions: new Set<string>(),
+  retried: 0,
+  extraWorktrees: 0,
+  restoreCounts: new Map<string, number>(),
+  restoreThrows: new Map<string, unknown>(),
+  newWindowThrows: new Map<string, unknown>(),
+  ensureThrows: undefined as unknown | undefined,
+  respawnArgs: [] as FleetSessionFixture[][],
+  resumeCalls: 0,
+  captured: [] as string[],
+};
+
+const realSetTimeout = globalThis.setTimeout;
+globalThis.setTimeout = ((handler: TimerHandler, _timeout?: number, ...args: unknown[]) =>
+  realSetTimeout(handler, 0, ...args)) as typeof setTimeout;
+
+export function resetState() {
+  rmSync(fleetDir, { recursive: true, force: true });
+  rmSync(ghqRoot, { recursive: true, force: true });
+  mkdirSync(fleetDir, { recursive: true });
+  mkdirSync(ghqRoot, { recursive: true });
+  state.fleet = [];
+  state.hasSessions = new Set();
+  state.retried = 0;
+  state.extraWorktrees = 0;
+  state.restoreCounts = new Map();
+  state.restoreThrows = new Map();
+  state.newWindowThrows = new Map();
+  state.ensureThrows = undefined;
+  state.respawnArgs = [];
+  state.resumeCalls = 0;
+  state.captured = [];
+}
+
+export function addRepo(repo: string) {
+  mkdirSync(join(ghqRoot, repo), { recursive: true });
+}
+
+mock.module(join(root, "src/sdk"), () => ({
+  get FLEET_DIR() { return fleetDir; },
+  tmux: {
+    hasSession: async (name: string) => {
+      state.captured.push(`hasSession ${name}`);
+      return state.hasSessions.has(name);
+    },
+    newSession: async (name: string, opts: { window?: string; cwd?: string } = {}) => {
+      state.captured.push(`newSession ${name} ${opts.window ?? ""} ${opts.cwd ?? ""}`);
+      state.hasSessions.add(name);
+    },
+    newWindow: async (session: string, name: string, opts: { cwd?: string } = {}) => {
+      state.captured.push(`newWindow ${session}:${name} ${opts.cwd ?? ""}`);
+      const thrown = state.newWindowThrows.get(`${session}:${name}`);
+      if (thrown) throw thrown;
+    },
+    setEnvironment: async (session: string, key: string, value: string) => {
+      state.captured.push(`setEnvironment ${session} ${key}=${value}`);
+    },
+    sendText: async (target: string, text: string) => {
+      state.captured.push(`sendText ${target} ${text}`);
+    },
+    selectWindow: async (target: string) => {
+      state.captured.push(`selectWindow ${target}`);
+    },
+    killSession: async (name: string) => {
+      state.captured.push(`killSession ${name}`);
+      if (!state.hasSessions.delete(name)) throw new Error("missing session");
+    },
+  },
+  saveTabOrder: async (name: string) => {
+    state.captured.push(`saveTabOrder ${name}`);
+  },
+  restoreTabOrder: async (name: string) => {
+    state.captured.push(`restoreTabOrder ${name}`);
+    const thrown = state.restoreThrows.get(name);
+    if (thrown) throw thrown;
+    return state.restoreCounts.get(name) ?? 0;
+  },
+}));
+
+mock.module(join(root, "src/config"), () => {
+  const { mockConfigModule } = require("./mock-config");
+  return {
+    ...mockConfigModule(() => ({ node: "test-node", commands: {} })),
+    buildCommand: (name: string) => `run ${name}`,
+    getEnvVars: () => ({ MAW_TEST_ENV: "yes" }),
+  };
+});
+
+mock.module(join(root, "src/config/ghq-root"), () => ({
+  getGhqRoot: () => ghqRoot,
+}));
+
+mock.module(join(root, "src/commands/shared/fleet-load"), () => ({
+  loadFleet: () => state.fleet,
+  loadFleetEntries: () => [],
+  getSessionNames: async () => state.fleet.map(s => s.name),
+}));
+
+mock.module(join(root, "src/commands/shared/wake"), () => ({
+  ensureSessionRunning: async (name: string) => {
+    state.captured.push(`ensureSessionRunning ${name}`);
+    if (state.ensureThrows) throw state.ensureThrows;
+    return state.retried;
+  },
+}));
+
+mock.module(join(root, "src/commands/shared/fleet-resume"), () => ({
+  respawnMissingWorktrees: async (sessions: FleetSessionFixture[]) => {
+    state.captured.push(`respawnMissingWorktrees ${sessions.map(s => s.name).join(",")}`);
+    state.respawnArgs.push(sessions);
+    return state.extraWorktrees;
+  },
+  resumeActiveItems: async () => {
+    state.captured.push("resumeActiveItems");
+    state.resumeCalls++;
+  },
+}));
+
+mock.module(join(root, "src/commands/shared/wake-pane-size"), () => ({
+  pinSessionWide: async (session: string) => {
+    state.captured.push(`pinSessionWide ${session}`);
+  },
+  pinWindowWide: async (target: string) => {
+    state.captured.push(`pinWindowWide ${target}`);
+  },
+}));
+
+export const { cmdSleep, cmdWakeAll } = await import("../../src/commands/shared/fleet-wake");
+export const { HostExecError } = await import("../../src/core/transport/ssh");
+
+beforeEach(resetState);
+
+afterEach(() => {
+  rmSync(fleetDir, { recursive: true, force: true });
+  rmSync(ghqRoot, { recursive: true, force: true });
+});
+
+afterAll(() => {
+  globalThis.setTimeout = realSetTimeout;
+});

--- a/test/isolated/fleet-wake-error-paths.test.ts
+++ b/test/isolated/fleet-wake-error-paths.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Focused isolated coverage for src/commands/shared/fleet-wake.ts failure paths.
+ */
+import { describe, expect, test } from "bun:test";
+import { join } from "path";
+import { addRepo, cmdWakeAll, ghqRoot, HostExecError, state } from "../helpers/fleet-wake-harness";
+
+describe("cmdWakeAll fail-soft cases", () => {
+  test("throws a clear error when the first window cwd is missing", async () => {
+    state.fleet = [{ name: "01-bad", windows: [{ name: "bad-oracle", repo: "missing-repo" }] }];
+    await expect(cmdWakeAll()).rejects.toThrow(/refusing to spawn 01-bad/);
+    expect(state.captured).toContain("hasSession 01-bad");
+    expect(state.captured.some(c => c.startsWith("newSession 01-bad"))).toBe(false);
+  });
+
+  test("skips missing secondary window cwd while still waking the session", async () => {
+    state.fleet = [{ name: "01-partial", windows: [{ name: "partial-oracle", repo: "partial" }, { name: "partial-missing", repo: "partial-missing" }] }];
+    addRepo("partial");
+    await cmdWakeAll();
+    expect(state.captured).toContain(`newSession 01-partial partial-oracle ${join(ghqRoot, "partial")}`);
+    expect(state.captured.some(c => c.startsWith("newWindow 01-partial:partial-missing"))).toBe(false);
+    expect(state.captured).toContain("selectWindow 01-partial:1");
+  });
+
+  test("ssh transport errors during secondary window creation produce a remote-skip warning", async () => {
+    state.fleet = [
+      { name: "01-remote-window", windows: [{ name: "remote-oracle", repo: "remote" }, { name: "remote-tools", repo: "remote-tools" }] },
+      { name: "02-local", windows: [{ name: "local-oracle", repo: "local" }] },
+    ];
+    addRepo("remote");
+    addRepo("remote-tools");
+    addRepo("local");
+    state.newWindowThrows = new Map([[
+      "01-remote-window:remote-tools",
+      new HostExecError("white", "ssh", new Error("ssh unavailable"), 255),
+    ]]);
+
+    await cmdWakeAll();
+
+    expect(state.captured).toContain(`newWindow 01-remote-window:remote-tools ${join(ghqRoot, "remote-tools")}`);
+    expect(state.captured).toContain(`newSession 02-local local-oracle ${join(ghqRoot, "local")}`);
+    expect(state.captured).not.toContain("selectWindow 01-remote-window:1");
+    expect(state.captured).toContain("selectWindow 02-local:1");
+  });
+
+  test("ssh transport errors from verification and restore are skipped", async () => {
+    state.fleet = [{ name: "01-remote", windows: [{ name: "remote-oracle", repo: "remote" }] }];
+    addRepo("remote");
+    const sshError = new HostExecError("white", "ssh", new Error("ssh unavailable"), 255);
+    state.ensureThrows = sshError;
+    state.restoreThrows = new Map([["01-remote", sshError]]);
+
+    await cmdWakeAll();
+
+    expect(state.captured).toContain("ensureSessionRunning 01-remote");
+    expect(state.captured).toContain("restoreTabOrder 01-remote");
+  });
+});

--- a/test/isolated/fleet-wake-sleep-basic.test.ts
+++ b/test/isolated/fleet-wake-sleep-basic.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Focused isolated coverage for src/commands/shared/fleet-wake.ts happy paths.
+ */
+import { describe, expect, test } from "bun:test";
+import { join } from "path";
+import { addRepo, cmdSleep, cmdWakeAll, fleetDir, ghqRoot, state } from "../helpers/fleet-wake-harness";
+
+describe("cmdSleep", () => {
+  test("saves tab order and counts only sessions that were killed", async () => {
+    state.fleet = [
+      { name: "01-awake", windows: [{ name: "awake-oracle", repo: "awake" }] },
+      { name: "02-missing", windows: [{ name: "missing-oracle", repo: "missing" }] },
+    ];
+    state.hasSessions = new Set(["01-awake"]);
+
+    await cmdSleep();
+
+    expect(state.captured).toEqual([
+      "saveTabOrder 01-awake",
+      "killSession 01-awake",
+      "saveTabOrder 02-missing",
+      "killSession 02-missing",
+    ]);
+  });
+});
+
+describe("cmdWakeAll", () => {
+  test("wakes non-dormant sessions, skips dormant by default, restores order, and resumes on request", async () => {
+    state.fleet = [
+      { name: "01-alpha", windows: [{ name: "alpha-oracle", repo: "alpha" }, { name: "alpha-tools", repo: "alpha-tools" }] },
+      { name: "20-dormant", windows: [{ name: "dormant-oracle", repo: "dormant" }] },
+      { name: "99-system", windows: [{ name: "system-oracle", repo: "system" }], skip_command: true },
+    ];
+    addRepo("alpha");
+    addRepo("alpha-tools");
+    addRepo("system");
+    state.retried = 1;
+    state.extraWorktrees = 2;
+    state.restoreCounts = new Map([["01-alpha", 1], ["99-system", 2]]);
+
+    await cmdWakeAll({ resume: true });
+
+    expect(state.respawnArgs[0].map(s => s.name)).toEqual(["01-alpha", "99-system"]);
+    expect(state.resumeCalls).toBe(1);
+    expect(state.captured).toContain(`newSession 01-alpha alpha-oracle ${join(ghqRoot, "alpha")}`);
+    expect(state.captured).toContain(`newWindow 01-alpha:alpha-tools ${join(ghqRoot, "alpha-tools")}`);
+    expect(state.captured).toContain("setEnvironment 01-alpha MAW_TEST_ENV=yes");
+    expect(state.captured).toContain("sendText 01-alpha:alpha-oracle run alpha-oracle");
+    expect(state.captured).toContain("sendText 01-alpha:alpha-tools run alpha-tools");
+    expect(state.captured).toContain("ensureSessionRunning 01-alpha");
+    expect(state.captured).not.toContain("ensureSessionRunning 99-system");
+    expect(state.captured.some(c => c.includes("20-dormant"))).toBe(false);
+    expect(state.captured).toContain("restoreTabOrder 01-alpha");
+    expect(state.captured).toContain("restoreTabOrder 99-system");
+    expect(state.captured).toContain("resumeActiveItems");
+  });
+
+  test("--all includes dormant sessions and existing sessions are left untouched", async () => {
+    state.fleet = [{ name: "20-dormant", windows: [{ name: "dormant-oracle", repo: "dormant" }] }];
+    state.hasSessions = new Set(["20-dormant"]);
+    addRepo("dormant");
+
+    await cmdWakeAll({ all: true });
+
+    expect(state.captured).toContain("hasSession 20-dormant");
+    expect(state.captured.some(c => c.startsWith("newSession 20-dormant"))).toBe(false);
+    expect(state.captured).toContain("respawnMissingWorktrees 20-dormant");
+  });
+
+  test("--kill sleeps existing sessions before waking", async () => {
+    state.fleet = [{ name: "01-alpha", windows: [{ name: "alpha-oracle", repo: "alpha" }] }];
+    state.hasSessions = new Set(["01-alpha"]);
+    addRepo("alpha");
+    await cmdWakeAll({ kill: true });
+    expect(state.captured.slice(0, 3)).toEqual(["saveTabOrder 01-alpha", "killSession 01-alpha", "hasSession 01-alpha"]);
+    expect(state.captured).toContain(`newSession 01-alpha alpha-oracle ${join(ghqRoot, "alpha")}`);
+  });
+});

--- a/test/isolated/tmux-impl-mocked.test.ts
+++ b/test/isolated/tmux-impl-mocked.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { join } from "path";
+
+const srcRoot = join(import.meta.dir, "../..");
+
+type Pane = { id: string; target: string; command?: string; title?: string; lastActivity?: number };
+
+let hostCalls: string[] = [];
+let paneCommand = "zsh\n";
+let captureOutput = "pane output\n";
+let panes: Pane[] = [];
+let fleetFiles: string[] = [];
+let ghqRepos: string[] = [];
+let worktrees: unknown[] = [];
+
+mock.module(join(srcRoot, "src/sdk"), () => ({
+  FLEET_DIR: "/tmp/maw-test/fleet",
+  CONFIG_DIR: "/tmp/maw-test/config",
+  hostExec: async (cmd: string) => {
+    hostCalls.push(cmd);
+    if (cmd.includes("capture-pane")) return captureOutput;
+    if (cmd.includes("pane_current_command")) return paneCommand;
+    if (cmd.includes("display-message") && cmd.includes("session_name")) return "current-session\n";
+    if (cmd.includes("list-sessions") && cmd.includes("session_created")) return "";
+    return "";
+  },
+  listSessions: async () => [],
+  readCache: () => ({ oracles: [], updated_at: "2026-05-17T00:00:00.000Z" }),
+  scanAndCache: async () => ({ oracles: [], updated_at: "2026-05-17T00:00:00.000Z" }),
+  isCacheStale: () => false,
+  loadConfig: () => ({ agents: [], sessions: [] }),
+  tmux: {
+    listPanes: async () => panes,
+    capture: async () => "",
+  },
+  tmuxCmd: () => "tmux",
+}));
+
+mock.module(join(srcRoot, "src/commands/shared/fleet-load"), () => ({
+  loadFleetEntries: () => fleetFiles.map(file => ({ file })),
+}));
+
+mock.module(join(srcRoot, "src/core/ghq"), () => ({
+  ghqList: async () => ghqRepos,
+  ghqListSync: () => ghqRepos,
+  ghqFind: async (suffix: string) => ghqRepos.find(repo => repo.endsWith(suffix)) ?? null,
+  ghqFindSync: (suffix: string) => ghqRepos.find(repo => repo.endsWith(suffix)) ?? null,
+}));
+
+mock.module(join(srcRoot, "src/core/fleet/worktrees-scan"), () => ({
+  scanWorktrees: async () => worktrees,
+}));
+
+const impl = await import("../../src/commands/plugins/tmux/impl");
+const {
+  _sendTracker,
+  cmdTmuxKill,
+  cmdTmuxLayout,
+  cmdTmuxLs,
+  cmdTmuxPeek,
+  cmdTmuxSend,
+  cmdTmuxSplit,
+} = impl;
+
+async function captureLogs(fn: () => void | Promise<void>) {
+  const logs: string[] = [];
+  const warnings: string[] = [];
+  const origLog = console.log;
+  const origWarn = console.warn;
+  console.log = (...args: unknown[]) => logs.push(args.map(String).join(" "));
+  console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(" "));
+  try {
+    await fn();
+  } finally {
+    console.log = origLog;
+    console.warn = origWarn;
+  }
+  return { logs: logs.join("\n"), warnings: warnings.join("\n") };
+}
+
+beforeEach(() => {
+  hostCalls = [];
+  paneCommand = "zsh\n";
+  captureOutput = "pane output\n";
+  panes = [];
+  fleetFiles = [];
+  ghqRepos = [];
+  worktrees = [];
+  _sendTracker.clear();
+});
+
+describe("cmdTmuxPeek — mocked tmux side effects", () => {
+  test("captures default tail lines for pane id targets and prints resolution", async () => {
+    const { logs } = await captureLogs(() => cmdTmuxPeek("%321"));
+    expect(hostCalls).toEqual(["tmux capture-pane -pt '%321' -S -30 -J"]);
+    expect(logs).toContain("%321 → %321 [pane-id]");
+    expect(logs).toContain("pane output");
+  });
+
+  test("history mode captures full scrollback instead of bounded tail", async () => {
+    await captureLogs(() => cmdTmuxPeek("%321", { lines: 7, history: true }));
+    expect(hostCalls).toEqual(["tmux capture-pane -pt '%321' -S - -J"]);
+  });
+});
+
+describe("cmdTmuxSend — mocked safety gates and send command", () => {
+  test("checks pane command, sends Enter by default, and records success", async () => {
+    const { logs } = await captureLogs(() => cmdTmuxSend("%321", "echo hello"));
+    expect(hostCalls).toEqual([
+      "tmux display-message -p -t '%321' '#{pane_current_command}'",
+      "tmux send-keys -t '%321' 'echo hello' Enter",
+    ]);
+    expect(logs).toContain("sent to %321 → %321");
+  });
+
+  test("literal mode omits Enter and shell-quotes single quotes", async () => {
+    await captureLogs(() => cmdTmuxSend("%321", "echo 'hi'", { literal: true }));
+    expect(hostCalls.at(-1)).toBe("tmux send-keys -t '%321' 'echo '\\''hi'\\'''");
+  });
+
+  test("refuses claude-like panes before sending keys unless forced", async () => {
+    paneCommand = "claude\n";
+    await expect(cmdTmuxSend("%321", "echo unsafe")).rejects.toThrow(/refusing to send: pane '%321' is running 'claude'/);
+    expect(hostCalls).toEqual(["tmux display-message -p -t '%321' '#{pane_current_command}'"]);
+  });
+
+  test("force bypasses cooldown and claude-pane refusal", async () => {
+    paneCommand = "claude\n";
+    _sendTracker.set("%321", { lastTs: Date.now(), count: 100, windowStart: Date.now() });
+    await captureLogs(() => cmdTmuxSend("%321", "echo forced", { force: true }));
+    expect(hostCalls).toEqual([
+      "tmux display-message -p -t '%321' '#{pane_current_command}'",
+      "tmux send-keys -t '%321' 'echo forced' Enter",
+    ]);
+  });
+
+  test("cooldown throttles repeated sends before pane lookup", async () => {
+    await captureLogs(() => cmdTmuxSend("%321", "echo first"));
+    hostCalls = [];
+
+    const { warnings } = await captureLogs(() => cmdTmuxSend("%321", "echo second"));
+
+    expect(warnings).toContain("send throttled");
+    expect(hostCalls).toEqual([]);
+  });
+});
+
+describe("cmdTmuxSplit/Layout/Kill — mocked tmux commands", () => {
+  test("split builds vertical percent command with an optional shell command", async () => {
+    await captureLogs(() => cmdTmuxSplit("%321", { vertical: true, pct: 33, cmd: "pwd" }));
+    expect(hostCalls).toEqual(["tmux split-window -v -l 33% -t '%321' 'pwd'"]);
+  });
+
+  test("layout strips pane index and targets the tmux window", async () => {
+    await captureLogs(() => cmdTmuxLayout("demo:2.3", "tiled"));
+    expect(hostCalls).toEqual(["tmux select-layout -t 'demo:2' tiled"]);
+  });
+
+  test("kill refuses fleet sessions without force before hostExec kill", async () => {
+    fleetFiles = ["101-mawjs.json"];
+
+    await expect(cmdTmuxKill("101-mawjs:0.1")).rejects.toThrow(/refusing to kill: session '101-mawjs'/);
+    expect(hostCalls).toEqual([]);
+  });
+
+  test("forced session kill targets the resolved session name", async () => {
+    fleetFiles = ["101-mawjs.json"];
+
+    await captureLogs(() => cmdTmuxKill("101-mawjs:0.1", { session: true, force: true }));
+
+    expect(hostCalls).toEqual(["tmux kill-session -t '101-mawjs'"]);
+  });
+});
+
+describe("cmdTmuxLs — mocked pane listing", () => {
+  test("json mode emits annotated panes without real tmux", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    fleetFiles = ["101-mawjs.json"];
+    panes = [
+      { id: "%1", target: "101-mawjs:0.0", command: "claude", title: "fleet", lastActivity: now },
+      { id: "%2", target: "scratch:0.0", command: "zsh", title: "shell", lastActivity: now - 60 },
+    ];
+
+    const { logs } = await captureLogs(() => cmdTmuxLs({ all: true, json: true }));
+    const parsed = JSON.parse(logs);
+    expect(parsed).toMatchObject([
+      { id: "%1", session: "101-mawjs", annotation: "fleet: mawjs", status: "active" },
+      { id: "%2", session: "scratch", annotation: "", status: "idle" },
+    ]);
+    expect(hostCalls.filter(cmd => cmd.includes("display-message"))).toEqual(process.env.TMUX ? ["tmux display-message -p '#{session_name}'"] : []);
+  });
+});


### PR DESCRIPTION
## Summary
- add focused oracle impl-list coverage
- split the oversized fleet-wake isolated coverage into two small specs with a shared harness
- add mocked tmux impl coverage without real tmux side effects

## Verification
- 
- bun test v1.3.14-canary.1 (e750984db)
- 

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
