### PR TITLE
fix(wake): findWorktrees scans cross-repo naming variants (#1775)

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -302,7 +302,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
   let windowName = `${oracle}-oracle`;
 
   if (opts.listWt) {
-    const worktrees = await findWorktrees(parentDir, repoName);
+    const worktrees = await findWorktrees(parentDir, repoName, oracle);
     if (!worktrees.length) { console.log(`\x1b[90mNo worktrees for ${oracle}.\x1b[0m`); }
     else {
       console.log(`\n\x1b[36mWorktrees for ${oracle}\x1b[0m (${worktrees.length})\n`);
@@ -313,7 +313,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
 
   if (opts.wt || opts.task) {
     const name = sanitizeBranchName(opts.wt || opts.task!);
-    const worktrees = await findWorktrees(parentDir, repoName);
+    const worktrees = await findWorktrees(parentDir, repoName, oracle);
     let match: { path: string; name: string } | null = null;
     if (!opts.fresh) {
       const resolvedTarget = resolveWorktreeTarget(name, worktrees);

--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -279,11 +279,43 @@ export async function resolveOracle(
   process.exit(1);
 }
 
-export async function findWorktrees(parentDir: string, repoName: string): Promise<{ path: string; name: string }[]> {
-  const lsOut = await hostExec(`ls -d ${parentDir}/${repoName}.wt-* 2>/dev/null || true`);
-  return lsOut.split("\n").filter(Boolean).map(p => ({
-    path: p, name: p.split("/").pop()!.replace(`${repoName}.wt-`, ""),
-  }));
+export async function findWorktrees(
+  parentDir: string,
+  repoName: string,
+  oracle?: string,
+): Promise<{ path: string; name: string }[]> {
+  // #1775: scan multiple naming variants for cross-repo worktrees.
+  // When oracle "homekeeper" resolves to repo "homelab", existing wt may be
+  // under "homekeeper-oracle.wt-*" or "homekeeper.wt-*" — without these we
+  // miss them and create a new homelab.wt-1 duplicate.
+  // Patterns are disjoint by literal prefix; no over-glob risk (per #1780).
+  const patterns = new Set<string>([`${repoName}.wt-*`]);
+  if (oracle && oracle !== repoName) {
+    patterns.add(`${oracle}-oracle.wt-*`);
+    patterns.add(`${oracle}.wt-*`);
+  }
+
+  const seen = new Set<string>();
+  const results: { path: string; name: string }[] = [];
+  for (const pattern of patterns) {
+    const lsOut = await hostExec(`ls -d ${parentDir}/${pattern} 2>/dev/null || true`);
+    for (const p of lsOut.split("\n").filter(Boolean)) {
+      if (seen.has(p)) continue;
+      seen.add(p);
+      const base = p.split("/").pop()!;
+      // Try each prefix in order to find the right strip:
+      const prefixes = [`${repoName}.wt-`];
+      if (oracle && oracle !== repoName) {
+        prefixes.push(`${oracle}-oracle.wt-`, `${oracle}.wt-`);
+      }
+      let name = base;
+      for (const prefix of prefixes) {
+        if (base.startsWith(prefix)) { name = base.slice(prefix.length); break; }
+      }
+      results.push({ path: p, name });
+    }
+  }
+  return results;
 }
 
 export function getSessionMap(): Record<string, string> { return loadConfig().sessions; }

--- a/test/wake-find-worktrees-cross-repo.test.ts
+++ b/test/wake-find-worktrees-cross-repo.test.ts
@@ -1,0 +1,67 @@
+/**
+ * #1775 — findWorktrees should find cross-repo worktrees when oracle name
+ * differs from repo name. Without the oracle arg it stays backward-compat.
+ */
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { findWorktrees } from "../src/commands/shared/wake-resolve-impl";
+
+const TMP_BASE = mkdtempSync(join(tmpdir(), "maw-1775-"));
+
+beforeAll(() => {
+  // Simulate ghq org dir holding repos for the same oracle "homekeeper":
+  //   parentDir/homelab.wt-1-white          (main repo, default scan)
+  //   parentDir/homekeeper-oracle.wt-2-white (oracle-suffixed, cross-repo)
+  //   parentDir/homekeeper.wt-3-white        (oracle direct)
+  //   parentDir/other-repo.wt-9-white        (unrelated repo — MUST NOT match)
+  for (const name of [
+    "homelab.wt-1-white",
+    "homekeeper-oracle.wt-2-white",
+    "homekeeper.wt-3-white",
+    "other-repo.wt-9-white",
+  ]) {
+    mkdirSync(join(TMP_BASE, name), { recursive: true });
+  }
+});
+
+afterAll(() => {
+  rmSync(TMP_BASE, { recursive: true, force: true });
+});
+
+describe("findWorktrees · #1775 cross-repo scan", () => {
+  test("without oracle arg — backward compat: only main repo's wt", async () => {
+    const wts = await findWorktrees(TMP_BASE, "homelab");
+    const names = wts.map(w => w.name).sort();
+    expect(names).toEqual(["1-white"]);
+  });
+
+  test("with oracle arg — finds main repo + oracle-suffixed + oracle-direct", async () => {
+    const wts = await findWorktrees(TMP_BASE, "homelab", "homekeeper");
+    const names = wts.map(w => w.name).sort();
+    expect(names).toEqual(["1-white", "2-white", "3-white"]);
+  });
+
+  test("does NOT over-glob unrelated repos (#1780 guard)", async () => {
+    const wts = await findWorktrees(TMP_BASE, "homelab", "homekeeper");
+    const paths = wts.map(w => w.path);
+    for (const p of paths) {
+      expect(p.includes("other-repo")).toBe(false);
+    }
+  });
+
+  test("oracle === repoName: behaves as backward-compat (no dup pattern)", async () => {
+    const wts = await findWorktrees(TMP_BASE, "homelab", "homelab");
+    const names = wts.map(w => w.name).sort();
+    expect(names).toEqual(["1-white"]);
+  });
+
+  test("dedup: same path matched by multiple patterns counted once", async () => {
+    // homelab pattern matches homelab.wt-*; if oracle were also "homelab"
+    // (degenerate), Set dedup prevents double-listing.
+    const wts = await findWorktrees(TMP_BASE, "homelab", "homelab");
+    const paths = wts.map(w => w.path);
+    expect(new Set(paths).size).toBe(paths.length);
+  });
+});

--- a/test/wake-find-worktrees-cross-repo.test.ts
+++ b/test/wake-find-worktrees-cross-repo.test.ts
@@ -21,6 +21,8 @@ beforeAll(() => {
     "homekeeper-oracle.wt-2-white",
     "homekeeper.wt-3-white",
     "other-repo.wt-9-white",
+    "mother-oracle",
+    "volt-oracle.wt-1-white",
   ]) {
     mkdirSync(join(TMP_BASE, name), { recursive: true });
   }
@@ -63,5 +65,15 @@ describe("findWorktrees · #1775 cross-repo scan", () => {
     const wts = await findWorktrees(TMP_BASE, "homelab", "homelab");
     const paths = wts.map(w => w.path);
     expect(new Set(paths).size).toBe(paths.length);
+  });
+
+  test("#1780 guard: oracle=mother does NOT match volt-oracle.wt-*", async () => {
+    // Mimic real #1780 symptom — mother shouldn't attach to volt's wt
+    const wts = await findWorktrees(TMP_BASE, "mother-oracle", "mother");
+    const names = wts.map(w => w.path.split("/").pop()!);
+    for (const n of names) {
+      expect(n.startsWith("volt-")).toBe(false);
+      expect(n.startsWith("homekeeper-")).toBe(false);
+    }
   });
 });


### PR DESCRIPTION
## Closes

#1775 (data-layer fix)

## Problem

When an oracle name differs from the resolved main repo name (e.g. oracle `homekeeper` → repo `homelab`), and a prior worktree exists under the oracle-suffixed name (`homekeeper-oracle.wt-2-white`), `maw wake homekeeper --wt white` creates a new duplicate `homelab.wt-1-white` instead of reusing the existing one.

Root cause: `findWorktrees(parentDir, repoName)` glob is `${parentDir}/${repoName}.wt-*` — it only scans the main repo name and misses cross-repo naming variants.

## Fix

`findWorktrees()` now takes an optional `oracle?` arg. When provided, it additionally scans:
- `${oracle}-oracle.wt-*` (oracle-suffixed naming)
- `${oracle}.wt-*` (oracle-direct naming)

Patterns are disjoint by literal prefix — no over-glob (heeding #1780's warning about previous overly-broad attempt).

Paths are deduped via `Set`; each match strips the longest matching prefix to compute its display name.

Callers in `wake-cmd.ts` (listWt + wt/task branches) updated to pass `oracle`. Vendor `workon` plugin stays unchanged (no oracle context, remains backward-compat).

## Tests

`test/wake-find-worktrees-cross-repo.test.ts` — 5 new cases on real tmpdir fixtures:
1. Backward compat (no oracle arg)
2. Cross-repo scan finds all 3 naming variants
3. Over-glob guard: unrelated `other-repo` MUST NOT match
4. Degenerate case `oracle === repoName`
5. Dedup verification

Suite status:
- `bun test test/wake*.test.ts`: **120 pass, 0 fail**
- Pre-existing unrelated failures in `test/isolated/` confirmed identical against rollback SHA (not caused by this change)

## Note on the `--pick` UX layer

Issue #1775 also proposes a `--pick` flag. This PR is the data-layer prerequisite — once findWorktrees finds cross-repo wts, `maw wake X --wt Y` already reuses them via existing `resolveWorktreeTarget` logic. A separate PR can add the `--pick` flag on top of this for explicit picker UX.

## Test plan
- [x] `bun test test/wake-find-worktrees-cross-repo.test.ts` — 5/5 pass
- [x] `bun test test/wake*.test.ts` — 120/120 pass
- [x] No regression vs rollback SHA 740db2ea
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)