### PR TITLE
perf(ci): coverage-badge runs on release only (#1774)

### DIFF
--- a/.github/workflows/coverage-badge.yml
+++ b/.github/workflows/coverage-badge.yml
@@ -1,29 +1,23 @@
 name: Coverage Badge
 
 on:
-  workflow_run:
-    workflows: [CI]
-    branches: [alpha]
-    types: [completed]
   release:
     types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: coverage-badge-alpha
+  group: coverage-badge
   cancel-in-progress: true
 
 jobs:
   update:
-    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
       - uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
## Closes
#1774

## Problem

`coverage-badge.yml` was running on every alpha CI completion via `workflow_run`, which fires on every push. During the recent 165-push marathon that meant ~16 hours of CI burn on the badge alone, plus stale runs piling up and blocking other workflows via concurrency.

## Fix

Switch trigger to:
- `release: published` — the only event the badge actually needs (Option A from the issue, recommended)
- `workflow_dispatch` — manual refresh when needed

Also dropped:
- The `workflow_run` conditional `if:` (no longer reachable)
- The `workflow_run`-aware checkout ref hint (default checkout is fine on release/manual events)
- The `-alpha` concurrency suffix (no longer alpha-scoped)

Minimal change: 1 file, only the `on:`/`concurrency:`/job-`if`/checkout block are touched.

## Tests
- [x] YAML validates (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] No code path or test suite affected — workflow trigger change only
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)