### PR TITLE
ux(wake): numbered picker on ambiguous oracle (#1781)

### DIFF
--- a/src/commands/shared/wake-resolve-impl.test.ts
+++ b/src/commands/shared/wake-resolve-impl.test.ts
@@ -30,7 +30,7 @@ mock.module(join(root, "config"), () => mockConfigModule(() => ({
   peers: [],
 })));
 
-const { detectSession, sanitizeBranchName, resolveLocalOracleRepoName } = await import("./wake-resolve-impl");
+const { detectSession, sanitizeBranchName, resolveLocalOracleRepoName, promptAmbiguousOracleChoice, _picker } = await import("./wake-resolve-impl");
 
 describe("sanitizeBranchName (#823 Bug A) — greedy strip", () => {
   it("strips ALL leading dashes (--no-attach → no-attach)", () => {
@@ -165,5 +165,45 @@ describe("resolveLocalOracleRepoName (#1469) — exact local oracle wins before 
       kind: "fuzzy",
       match: "arra-oracle-v3-oracle",
     });
+  });
+});
+
+describe("promptAmbiguousOracleChoice (#1781) — numbered picker on ambiguous wake", () => {
+  const candidates = ["mother-oracle", "mother-roots-oracle"];
+
+  it("returns the picked candidate when stdin reads a valid choice", () => {
+    _picker.isStdoutTTY = () => true;
+    _picker.readChoice = () => "2";
+    expect(promptAmbiguousOracleChoice("mother", candidates)).toBe("mother-roots-oracle");
+  });
+
+  it("returns null on non-TTY so caller falls back to loud error", () => {
+    _picker.isStdoutTTY = () => false;
+    _picker.readChoice = () => "1";
+    expect(promptAmbiguousOracleChoice("mother", candidates)).toBeNull();
+  });
+
+  it("returns null when read fails (e.g. /dev/tty unavailable)", () => {
+    _picker.isStdoutTTY = () => true;
+    _picker.readChoice = () => null;
+    expect(promptAmbiguousOracleChoice("mother", candidates)).toBeNull();
+  });
+
+  it("returns null when choice is out of range", () => {
+    _picker.isStdoutTTY = () => true;
+    _picker.readChoice = () => "9";
+    expect(promptAmbiguousOracleChoice("mother", candidates)).toBeNull();
+  });
+
+  it("returns null when choice is non-numeric", () => {
+    _picker.isStdoutTTY = () => true;
+    _picker.readChoice = () => "abc";
+    expect(promptAmbiguousOracleChoice("mother", candidates)).toBeNull();
+  });
+
+  it("returns null on empty/whitespace input", () => {
+    _picker.isStdoutTTY = () => true;
+    _picker.readChoice = () => "";
+    expect(promptAmbiguousOracleChoice("mother", candidates)).toBeNull();
   });
 });

--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -60,6 +60,60 @@ type LocalOracleResolution =
   | { kind: "fuzzy"; match: string }
   | { kind: "ambiguous"; candidates: string[] };
 
+/**
+ * Picker hooks for the ambiguous-oracle UX (#1781). Wrapped in an object so
+ * tests can mock both the TTY check and the keystroke read — matches the
+ * `_tty` pattern in tmux/impl.ts.
+ *
+ * @internal — exported for test/wake-resolve-picker.test.ts.
+ */
+export const _picker = {
+  isStdoutTTY: (): boolean => {
+    try {
+      const { isatty } = require("node:tty") as typeof import("node:tty");
+      return isatty(1);
+    } catch {
+      return !!process.stdout.isTTY;
+    }
+  },
+  readChoice: (): string | null => {
+    try {
+      const { openSync, readSync, closeSync } = require("fs") as typeof import("fs");
+      const fd = openSync("/dev/tty", "r");
+      const buf = Buffer.alloc(8);
+      const n = readSync(fd, buf, 0, buf.length, null);
+      closeSync(fd);
+      return buf.slice(0, n).toString().trim();
+    } catch { return null; }
+  },
+};
+
+/**
+ * Show a numbered picker on ambiguous oracle resolution and return the picked
+ * candidate, or null if the choice is invalid / not made (caller falls back to
+ * the loud error). #1781 — mirrors the `maw a` picker UX so wake feels the same.
+ *
+ * @internal — exported for tests.
+ */
+export function promptAmbiguousOracleChoice(
+  oracle: string,
+  candidates: string[],
+): string | null {
+  if (!_picker.isStdoutTTY()) return null;
+  console.log("");
+  console.log(`  '${oracle}' matches ${candidates.length} local oracles — wake which?`);
+  for (let i = 0; i < candidates.length; i++) {
+    console.log(`  \x1b[36m${i + 1}\x1b[0m) ${candidates[i]}`);
+  }
+  console.log("");
+  process.stdout.write(`  Select [1-${candidates.length}]: `);
+  const raw = _picker.readChoice();
+  if (!raw) return null;
+  const choice = parseInt(raw, 10);
+  if (!Number.isFinite(choice) || choice < 1 || choice > candidates.length) return null;
+  return candidates[choice - 1]!;
+}
+
 function uniqueStrings(values: string[]): string[] {
   return [...new Set(values)];
 }
@@ -146,6 +200,16 @@ export async function resolveOracle(
         return { repoPath: match, repoName: match.split("/").pop()!, parentDir: match.replace(/\/[^/]+$/, "") };
       }
     } else if (resolvedLocal.kind === "ambiguous") {
+      // #1781 — show numbered picker on TTY, mirroring `maw a` UX. Fall back
+      // to the loud non-TTY error so scripted callers still fail fast.
+      const picked = promptAmbiguousOracleChoice(oracle, resolvedLocal.candidates);
+      if (picked) {
+        const match = await ghqFind(`/${picked}`);
+        if (match) {
+          console.log(`\x1b[36m→\x1b[0m selected: ${picked}`);
+          return { repoPath: match, repoName: match.split("/").pop()!, parentDir: match.replace(/\/[^/]+$/, "") };
+        }
+      }
       console.error(`\x1b[33m⚠\x1b[0m '${oracle}' matches ${resolvedLocal.candidates.length} local oracles:`);
       for (const c of resolvedLocal.candidates) console.error(`\x1b[90m    • ${c}\x1b[0m`);
       console.error(`\x1b[90m  use the full name: maw wake <exact-name>\x1b[0m`);


### PR DESCRIPTION
## Closes
#1781

## Problem
`maw wake mother` errors out with a list of candidates and tells the user to retype the full name. `maw a mother` already shows a nice numbered picker for the same situation — wake should match that UX.

## Fix
When local ghq has multiple `*-oracle` repos that match the wake target, render `Select [1-N]:` and read a single keystroke from `/dev/tty`. On non-TTY (CI, scripts, redirected stdout) or invalid/empty input, fall back to the existing loud error so scripted callers still fail fast.

Implementation mirrors the `_tty` wrapper pattern from `src/commands/plugins/tmux/impl.ts` — picker hooks live in `_picker` so the prompt logic is unit-testable without touching real `/dev/tty`.

Minimal touch: only `wake-resolve-impl.ts` (the ambiguous branch in `resolveOracle`). No other resolution paths affected.

## Tests
- [x] new test(s) for the picker (6 cases: valid choice, non-TTY, read fail, out-of-range, non-numeric, empty input)
- [x] existing related suite still green (106/106 across 9 wake test files)
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)