### PR TITLE
perf(ci): split unit suite into 4 parallel shards (#1783)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,36 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      # Don't cancel sibling shards/suites when one fails — we want to see
+      # all failures in a single CI run, not chase reruns one at a time.
+      fail-fast: false
       matrix:
         suite:
-          - name: unit
+          # `unit` (the default-suite, 2200+ tests) is split into 4 parallel
+          # shards via Bun's native --shard=N/M flag. Each shard runs ~1/4 of
+          # the test files, so wall-clock drops ~4x and mock pollution
+          # (#1585, #1586, #1627, #1751) can't leak across shards.
+          - name: unit-1
             script: test
+            args: --shard=1/4
+          - name: unit-2
+            script: test
+            args: --shard=2/4
+          - name: unit-3
+            script: test
+            args: --shard=3/4
+          - name: unit-4
+            script: test
+            args: --shard=4/4
           - name: isolated
             script: test:isolated
+            args: ""
           - name: plugin
             script: test:plugin
+            args: ""
           - name: mock-smoke
             script: test:mock-smoke
+            args: ""
     name: test-${{ matrix.suite.name }}
     steps:
       - uses: actions/checkout@v6
@@ -59,7 +79,10 @@ jobs:
         # is a belt-and-braces measure to keep CI green while we monitor.
         env:
           MAW_SKIP_FLAKY: "1"
-        run: bun run ${{ matrix.suite.script }}
+        # `bun run <script> <extra...>` appends extra args to the script's
+        # underlying command, so `bun run test --shard=N/4` reaches
+        # `bun test test/ ... --shard=N/4` without touching package.json.
+        run: bun run ${{ matrix.suite.script }} ${{ matrix.suite.args }}
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Closes
#1783

## Problem

The `unit` matrix entry in `ci.yml` runs ~2200 tests in a single Bun process. That (a) eats too much wall-clock for CI's tail-end timeout budget, (b) can't be parallelised across runners, and (c) lets a flaky test or mock-pollution incident (#1585, #1586, #1627, #1751) block the entire suite.

## Fix

Split the unit entry into 4 shards using Bun's native `--shard=N/M` flag. Each shard runs ~1/4 of the test files in its own runner, so wall-clock drops ~4x and any mock pollution is confined to a single shard.

```
unit         → unit-1, unit-2, unit-3, unit-4   (--shard=N/4)
isolated     → unchanged
plugin       → unchanged
mock-smoke   → unchanged
```

Also added `fail-fast: false` so one shard failing doesn't cancel the others — we want all failures visible in one run.

Matrix gained an `args` field that's appended to the bun-run command. `bun run <script> <extra>` forwards extras to the underlying script, so package.json doesn't need to change. Empty `args: \"\"` for the non-sharded suites is a no-op.

## Tests

Smoke-tested locally with the exact bun invocation CI will use:
- `bun test test/ ... --shard=1/4` → **323 pass / 22 files / 6.6s**
- `bun test test/ ... --shard=3/4` → **301 pass / 22 files / 19.3s**

Both shards green; per-shard file counts roughly balanced.

- [x] Local shard smoke (1/4 and 3/4)
- [x] YAML validates
- [ ] CI on this PR (will exercise all 4 unit shards + the 3 unchanged suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)