### PR TITLE
fix(federation): capture raw body in onParse to avoid 'body_read_failed' (#1790)

### DIFF
--- a/src/lib/elysia-auth.ts
+++ b/src/lib/elysia-auth.ts
@@ -105,8 +105,27 @@ export function lookupCachedPubkey(from: string): string | undefined {
   return undefined;
 }
 
+// #1790: cache raw body bytes per request, captured BEFORE Elysia's body
+// parser consumes the stream. WeakMap so entries are GC'd with the Request.
+const rawBodyCache = new WeakMap<Request, Uint8Array>();
+
 /** Federation auth — from: + signature plugin (#804 Step 4). */
 export const fromSigningAuth = new Elysia({ name: "from-signing-auth" })
+  // #1790: capture raw body in onParse (before schema validation consumes
+  // the stream). Returning undefined lets Elysia's default body parser run
+  // afterwards using the bytes we just buffered (Bun's body parser reads
+  // from request.body; we don't consume request directly here, only clone).
+  .onParse(async ({ request }) => {
+    if (!loadConfig().federationToken) return;
+    if (!request.headers.get("x-maw-from")) return;
+    if (rawBodyCache.has(request)) return;
+    try {
+      const buf = new Uint8Array(await request.clone().arrayBuffer());
+      rawBodyCache.set(request, buf);
+    } catch {
+      // best-effort; auth hook will still try clone and return body_read_failed
+    }
+  })
   .onBeforeHandle(async ({ request, set }) => {
     const config = loadConfig();
     // Backwards compat: no fleet token configured → single-node, no peer
@@ -121,15 +140,18 @@ export const fromSigningAuth = new Elysia({ name: "from-signing-auth" })
     const clientIp = _bunServer?.requestIP?.(request)?.address;
     if (isLoopback(clientIp)) return;
 
-    // Read body once (clone). We need the bytes for the body-hash binding.
-    let body: Uint8Array | undefined;
-    try {
-      const clone = request.clone();
-      body = new Uint8Array(await clone.arrayBuffer());
-    } catch (err) {
-      console.warn(`[from-auth] body read failed for ${request.method} ${path}: ${err instanceof Error ? err.message : String(err)}`);
-      set.status = 401;
-      return { error: "from-signing failed", reason: "body_read_failed" };
+    // #1790: prefer the pre-parse cached bytes; fall back to clone for
+    // unprotected→protected route additions where onParse hasn't run yet.
+    let body: Uint8Array | undefined = rawBodyCache.get(request);
+    if (body === undefined) {
+      try {
+        const clone = request.clone();
+        body = new Uint8Array(await clone.arrayBuffer());
+      } catch (err) {
+        console.warn(`[from-auth] body read failed for ${request.method} ${path}: ${err instanceof Error ? err.message : String(err)}`);
+        set.status = 401;
+        return { error: "from-signing failed", reason: "body_read_failed" };
+      }
     }
 
     const decision: FromVerifyDecision = verifyRequest({

--- a/test/from-signing-body-parser.test.ts
+++ b/test/from-signing-body-parser.test.ts
@@ -1,0 +1,103 @@
+/**
+ * #1790 — cross-node POST with from-signing should NOT fail with
+ * 'body_read_failed' when the route has a `body:` schema declared
+ * (Elysia parses + consumes the body stream before onBeforeHandle runs).
+ *
+ * Reproduces the symptom by mounting fromSigningAuth + HMAC plugin in front
+ * of a route that declares `body: t.Object(...)`, then POSTing a signed
+ * request through the full Elysia pipeline.
+ */
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { Elysia, t } from "elysia";
+import { fromSigningAuth, federationAuth, setBunServer } from "../src/lib/elysia-auth";
+import { signHeadersV3 } from "../src/lib/federation-auth";
+import { writeFileSync, mkdtempSync, mkdirSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const ORIG_HOME = process.env.HOME;
+const ORIG_PEER_KEY = process.env.MAW_PEER_KEY;
+const TMP_HOME = mkdtempSync(join(tmpdir(), "maw-1790-"));
+const SHARED_KEY = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+beforeAll(() => {
+  // Isolate config + peers so test doesn't read real home
+  process.env.HOME = TMP_HOME;
+  process.env.MAW_PEER_KEY = SHARED_KEY;
+  const cfgDir = join(TMP_HOME, ".config", "maw");
+  mkdirSync(cfgDir, { recursive: true });
+  writeFileSync(
+    join(cfgDir, "maw.config.json"),
+    JSON.stringify({
+      federationToken: SHARED_KEY,
+      node: "test-node",
+      oracle: "mawjs",
+      port: 3456,
+      namedPeers: [{ name: "peer-a", url: "http://127.0.0.1:9999" }],
+    }, null, 2),
+  );
+  // peers.json with peer-a stored pubkey = our SHARED_KEY (so verifier accepts)
+  const mawDir = join(TMP_HOME, ".maw");
+  mkdirSync(mawDir, { recursive: true });
+  writeFileSync(
+    join(mawDir, "peers.json"),
+    JSON.stringify({
+      version: 1,
+      peers: {
+        "peer-a": { url: "http://127.0.0.1:9999", node: "peer-a", pubkey: SHARED_KEY, addedAt: new Date().toISOString(), lastSeen: new Date().toISOString() },
+      },
+    }, null, 2),
+  );
+});
+
+afterAll(() => {
+  process.env.HOME = ORIG_HOME;
+  if (ORIG_PEER_KEY) process.env.MAW_PEER_KEY = ORIG_PEER_KEY;
+  else delete process.env.MAW_PEER_KEY;
+});
+
+describe("#1790 from-signing with parsed body schema", () => {
+  test("POST with body:schema + from-signed request succeeds (no body_read_failed)", async () => {
+    // Fake a non-loopback by NOT setting Bun server (the auth path treats
+    // missing _bunServer + missing requestIP as non-loopback by default)
+    const app = new Elysia()
+      .use(federationAuth)
+      .use(fromSigningAuth)
+      .post("/api/wake",
+        ({ body }) => ({ ok: true, target: (body as { target: string }).target }),
+        { body: t.Object({ target: t.String() }) },
+      );
+
+    const bodyStr = JSON.stringify({ target: "test-oracle" });
+    const ts = Math.floor(Date.now() / 1000);
+
+    // Sign with v3 from-signing (peerKey = our shared key)
+    const v3 = signHeadersV3({
+      peerKey: SHARED_KEY,
+      fromAddress: "mawjs:peer-a",
+      method: "POST",
+      path: "/api/wake",
+      body: bodyStr,
+    });
+
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+      "x-maw-from": "mawjs:peer-a",
+      "x-maw-signature-v3": v3.signature,
+      "x-maw-timestamp": String(ts),
+      "x-maw-auth-version": "v3",
+    };
+
+    const res = await app.handle(new Request("http://localhost/api/wake", {
+      method: "POST",
+      headers,
+      body: bodyStr,
+    }));
+
+    expect(res.status).not.toBe(401);
+    // We don't care that the wake itself succeeds (might fail in test env);
+    // we only assert that auth didn't reject for body_read_failed.
+    const text = await res.text();
+    expect(text).not.toContain("body_read_failed");
+  });
+});


### PR DESCRIPTION
## Closes (partial)
Layer 1 of #1790

## Problem
When `/api/wake` or other federated POST routes declare `body: t.Object(...)`, Elysia's body parser consumes the request stream before `fromSigningAuth.onBeforeHandle` runs. The clone-and-read in the auth hook then throws `Body already used` → 401 `body_read_failed`.

## Fix
Capture raw body bytes in `onParse` (which fires BEFORE schema validation), cache in a `WeakMap<Request, Uint8Array>`. The auth hook reads from the cache; falls back to the original clone path for routes where onParse isn't reached (defensive).

WeakMap auto-cleans when Request is GC'd — no leak.

## Test
`test/from-signing-body-parser.test.ts` mounts both auth plugins + a route with `body: t.Object` schema, POSTs a v3-signed request, asserts no 401/body_read_failed.

Federation suite: 124/124 pass.

## IMPORTANT — Layer 1 only
While investigating #1790, found 3 additional v3 protocol mismatches between sender (signRequestV3) and verifier (verifyRequest):

| Layer | Sender | Verifier |
|---|---|---|
| 2 | `X-Maw-Signature-V3` header | reads `x-maw-signature` (no -V3) |
| 3 | `X-Maw-Timestamp` (numeric seconds) | reads `x-maw-signed-at` (ISO string) |
| 4 | Payload `METHOD:PATH:TS:HASH:FROM` (colon) | Payload `FROM\nSIGNED_AT\nMETHOD\nPATH\nHASH` (newline) |

This PR addresses ONLY Layer 1 (the body bug). Layers 2-4 are upstream architectural disagreement and should be addressed in a coordinated PR after maintainers decide which side is canonical. Filing separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)