### PR TITLE
feat(api): emit WormholeRequest/WormholeFail feed events from peer-exec

### DIFF
--- a/src/api/peer-exec.ts
+++ b/src/api/peer-exec.ts
@@ -17,6 +17,11 @@
 import { Elysia, t } from "elysia";
 import { loadConfig } from "../config";
 import { signHeaders } from "../lib/federation-auth";
+import { pushFeedEvent } from "./feed";
+import {
+  buildWormholeLifecycleFeedEvent,
+  type WormholeLifecycleInput,
+} from "../lib/wormhole-events";
 import {
   setSessionCookie,
   hasValidSessionCookie,
@@ -27,6 +32,20 @@ import {
 } from "./peer-exec-auth";
 
 export { parseSignature, isReadOnlyCmd, isShellPeerAllowed, resolvePeerUrl } from "./peer-exec-auth";
+
+// Lifecycle emit — mirrors sessions.ts:emitMessageLifecycle. Server-side path:
+// builds a FeedEvent and pushes through the in-process feedListeners ring so
+// installed plugins see WormholeRequest / WormholeFail events alongside the
+// existing MessageSend / MessageDeliver / MessageFail family.
+export function emitWormholeLifecycle(input: WormholeLifecycleInput, deps: PeerExecApiDeps = {}) {
+  try {
+    const build = deps.buildWormholeLifecycleFeedEvent ?? buildWormholeLifecycleFeedEvent;
+    const push = deps.pushFeedEvent ?? pushFeedEvent;
+    push(build(input));
+  } catch {
+    // Hook errors must never change /api/peer/exec response semantics.
+  }
+}
 
 // --- Relay ---------------------------------------------------------------
 
@@ -89,6 +108,9 @@ export interface PeerExecApiDeps {
   isShellPeerAllowed?: typeof isShellPeerAllowed;
   resolvePeerUrl?: typeof resolvePeerUrl;
   relayToPeer?: typeof relayToPeer;
+  pushFeedEvent?: typeof pushFeedEvent;
+  buildWormholeLifecycleFeedEvent?: typeof buildWormholeLifecycleFeedEvent;
+  emitWormholeLifecycle?: (input: WormholeLifecycleInput) => void;
 }
 
 export function createPeerExecApi(deps: PeerExecApiDeps = {}) {
@@ -99,6 +121,7 @@ export function createPeerExecApi(deps: PeerExecApiDeps = {}) {
   const shellAllowed = deps.isShellPeerAllowed ?? isShellPeerAllowed;
   const resolvePeer = deps.resolvePeerUrl ?? resolvePeerUrl;
   const relay = deps.relayToPeer ?? relayToPeer;
+  const emitLifecycle = deps.emitWormholeLifecycle ?? ((input: WormholeLifecycleInput) => emitWormholeLifecycle(input, deps));
 
   const peerExecApi = new Elysia();
 
@@ -120,10 +143,17 @@ export function createPeerExecApi(deps: PeerExecApiDeps = {}) {
       set.status = 400; return { error: "bad_signature", expected: "[host:agent]" };
     }
 
+    const origin = `[${parsed.originHost}:${parsed.originAgent}]`;
+
     // 2. Session cookie check
     // Bypass ONLY when explicitly in dev mode. Default (unset NODE_ENV) = secure.
     const devBypass = process.env.NODE_ENV === "development";
     if (!devBypass && !hasValidCookie(headers)) {
+      emitLifecycle({
+        direction: "relayed", state: "failed",
+        cmd, args, origin, peer, trustTier: "denied",
+        status: 401, error: "no_session",
+      });
       set.status = 401; return { error: "no_session", hint: "GET /api/peer/session first" };
     }
 
@@ -132,6 +162,11 @@ export function createPeerExecApi(deps: PeerExecApiDeps = {}) {
     if (!readonly) {
       const allowed = shellAllowed(parsed.originHost);
       if (!allowed) {
+        emitLifecycle({
+          direction: "relayed", state: "failed",
+          cmd, args, origin, peer, trustTier: "denied",
+          status: 403, error: "shell_peer_denied",
+        });
         set.status = 403; return {
           error: "shell_peer_denied",
           origin: parsed.originHost,
@@ -142,24 +177,44 @@ export function createPeerExecApi(deps: PeerExecApiDeps = {}) {
       }
     }
 
+    const trustTier = readonly ? "readonly" : "shell_allowlisted";
+
     // 5. Resolve peer
     const peerUrl = resolvePeer(peer);
     if (!peerUrl) {
+      emitLifecycle({
+        direction: "relayed", state: "failed",
+        cmd, args, origin, peer, trustTier,
+        status: 404, error: "unknown_peer",
+      });
       set.status = 404; return { error: "unknown_peer", peer };
     }
 
     // 6 + 7. Relay and return
     try {
       const result = await relay(peerUrl, { cmd, args, signature });
+      emitLifecycle({
+        direction: "relayed", state: "delivered",
+        cmd, args, origin, peer, peerUrl, trustTier,
+        elapsedMs: result.elapsedMs,
+        status: result.status,
+        outputBytes: typeof result.output === "string" ? result.output.length : undefined,
+      });
       return {
         output: result.output,
         from: result.from,
         elapsed_ms: result.elapsedMs,
         status: result.status,
-        trust_tier: readonly ? "readonly" : "shell_allowlisted",
+        trust_tier: trustTier,
       };
     } catch (err: any) {
-      set.status = 502; return { error: "relay_failed", peer: peerUrl, reason: err?.message ?? String(err) };
+      const reason = err?.message ?? String(err);
+      emitLifecycle({
+        direction: "relayed", state: "failed",
+        cmd, args, origin, peer, peerUrl, trustTier,
+        status: 502, error: reason,
+      });
+      set.status = 502; return { error: "relay_failed", peer: peerUrl, reason };
     }
   }, {
     body: t.Object({

--- a/src/lib/feed.ts
+++ b/src/lib/feed.ts
@@ -22,6 +22,9 @@ export type FeedEventType =
   | "MessageSend"
   | "MessageDeliver"
   | "MessageFail"
+  // Wormhole lifecycle (peer-exec)
+  | "WormholeRequest"
+  | "WormholeFail"
   // Plugin lifecycle
   | "PluginHook"
   | "PluginFilter"

--- a/src/lib/wormhole-events.ts
+++ b/src/lib/wormhole-events.ts
@@ -1,0 +1,118 @@
+import type { FeedEvent, FeedEventType } from "./feed";
+
+export type WormholeDirection = "inbound" | "outbound" | "relayed";
+export type WormholeState = "queued" | "delivered" | "failed";
+export type WormholeTrustTier = "readonly" | "shell_allowlisted" | "denied";
+
+export interface WormholeLifecycleData {
+  id: string;
+  ts: string;
+  direction: WormholeDirection;
+  state: WormholeState;
+  cmd: string;
+  args: string[];
+  origin: string;
+  peer: string;
+  peerUrl?: string;
+  trustTier: WormholeTrustTier;
+  elapsedMs?: number;
+  status?: number;
+  outputBytes?: number;
+  error?: string;
+}
+
+export type WormholeLifecycleInput = Omit<WormholeLifecycleData, "id" | "ts"> & {
+  id?: string;
+  ts?: string | number | Date;
+};
+
+function randomId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+function isoTs(ts: WormholeLifecycleInput["ts"]): string {
+  if (ts instanceof Date) return ts.toISOString();
+  if (typeof ts === "number") return new Date(ts).toISOString();
+  if (typeof ts === "string" && ts.trim()) return ts;
+  return new Date().toISOString();
+}
+
+function parseIdentity(value: string): { host: string; oracle: string } {
+  // Origin signatures arrive bracketed: "[host:agent]". Strip outer brackets first.
+  const stripped = value.replace(/^\[/, "").replace(/\]$/, "");
+  const idx = stripped.indexOf(":");
+  if (idx > 0 && idx < stripped.length - 1) {
+    return { host: stripped.slice(0, idx), oracle: stripped.slice(idx + 1) };
+  }
+  return { host: "local", oracle: stripped || "unknown" };
+}
+
+function eventTypeFor(input: WormholeLifecycleInput): FeedEventType {
+  if (input.state === "failed") return "WormholeFail";
+  return "WormholeRequest";
+}
+
+function truncate(value: string | undefined, max: number): string | undefined {
+  if (value === undefined) return undefined;
+  return value.length > max ? `${value.slice(0, max - 1)}…` : value;
+}
+
+export function buildWormholeLifecycleData(input: WormholeLifecycleInput): WormholeLifecycleData {
+  return {
+    id: input.id ?? randomId(),
+    ts: isoTs(input.ts),
+    direction: input.direction,
+    state: input.state,
+    cmd: truncate(input.cmd, 500) ?? "",
+    args: Array.isArray(input.args) ? input.args.slice(0, 50) : [],
+    origin: input.origin,
+    peer: input.peer,
+    ...(input.peerUrl ? { peerUrl: input.peerUrl } : {}),
+    trustTier: input.trustTier,
+    ...(input.elapsedMs !== undefined ? { elapsedMs: input.elapsedMs } : {}),
+    ...(input.status !== undefined ? { status: input.status } : {}),
+    ...(input.outputBytes !== undefined ? { outputBytes: input.outputBytes } : {}),
+    ...(input.error ? { error: truncate(input.error, 1_000) } : {}),
+  };
+}
+
+export function buildWormholeLifecycleFeedEvent(input: WormholeLifecycleInput): FeedEvent {
+  const data = buildWormholeLifecycleData(input);
+  const identity = parseIdentity(data.origin);
+  const timestamp = data.ts;
+  const ts = new Date(timestamp).getTime() || Date.now();
+  const message = [
+    `${data.direction}/${data.state}`,
+    `${data.origin} → ${data.peer}`,
+    `cmd=${data.cmd}`,
+    `tier=${data.trustTier}`,
+    data.status !== undefined ? `status=${data.status}` : "",
+    data.error ? `error=${data.error}` : "",
+  ].filter(Boolean).join(" ");
+
+  return {
+    timestamp,
+    oracle: identity.oracle,
+    host: identity.host,
+    event: eventTypeFor(data),
+    project: "",
+    sessionId: data.peer,
+    message,
+    ts,
+    data,
+  };
+}
+
+export function isWormholeLifecycleData(value: unknown): value is WormholeLifecycleData {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.id === "string"
+    && typeof v.ts === "string"
+    && (v.direction === "inbound" || v.direction === "outbound" || v.direction === "relayed")
+    && (v.state === "queued" || v.state === "delivered" || v.state === "failed")
+    && typeof v.cmd === "string"
+    && Array.isArray(v.args)
+    && typeof v.origin === "string"
+    && typeof v.peer === "string"
+    && (v.trustTier === "readonly" || v.trustTier === "shell_allowlisted" || v.trustTier === "denied");
+}

--- a/test/peer-exec.test.ts
+++ b/test/peer-exec.test.ts
@@ -482,3 +482,204 @@ describe("trust boundary — anon-* can only run readonly cmds", () => {
     // Together: readonly = false AND allowlist = false, so denied.
   });
 });
+
+// ---- WormholeRequest / WormholeFail feed events --------------------------
+//
+// peer-exec.ts emits typed wormhole lifecycle events through the plugin
+// feed bus (mirroring MessageSend/MessageDeliver/MessageFail). The fail
+// events are gated behind a successful signature parse — malformed
+// requests do NOT produce events.
+
+describe("wormhole feed lifecycle emission", () => {
+  type EmittedEvent = Parameters<NonNullable<Parameters<typeof createPeerExecApi>[0]>["emitWormholeLifecycle"] & Function>[0];
+
+  function makeAppWith(opts: {
+    overrides?: Parameters<typeof createPeerExecApi>[0];
+    relay?: typeof relayToPeer;
+  } = {}) {
+    const events: EmittedEvent[] = [];
+    const app = new Elysia({ prefix: "/api" }).use(createPeerExecApi({
+      hasValidSessionCookie: () => true,
+      parseSignature: () => ({ originHost: "white", originAgent: "white-wormhole", isAnon: false }),
+      isReadOnlyCmd: () => true,
+      isShellPeerAllowed: () => true,
+      resolvePeerUrl: () => "http://peer.local:3456",
+      relayToPeer: opts.relay ?? ((async () => ({ output: "ok", from: "peer", elapsedMs: 5, status: 200 })) as typeof relayToPeer),
+      emitWormholeLifecycle: (input) => { events.push(input); },
+      ...(opts.overrides ?? {}),
+    }));
+    return { app, events };
+  }
+
+  test("relay success emits WormholeRequest delivered with trust_tier + outputBytes", async () => {
+    const { app, events } = makeAppWith({
+      relay: (async () => ({
+        output: "x".repeat(123),
+        from: "http://peer.local:3456",
+        elapsedMs: 42,
+        status: 200,
+      })) as typeof relayToPeer,
+    });
+
+    const res = await app.handle(new Request("http://localhost/api/peer/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: "pe_session=fake" },
+      body: JSON.stringify({
+        peer: "white",
+        cmd: "/dig",
+        args: ["--deep"],
+        signature: "[white:white-wormhole]",
+      }),
+    }));
+
+    expect(res.status).toBe(200);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      direction: "relayed",
+      state: "delivered",
+      cmd: "/dig",
+      args: ["--deep"],
+      origin: "[white:white-wormhole]",
+      peer: "white",
+      peerUrl: "http://peer.local:3456",
+      trustTier: "readonly",
+      elapsedMs: 42,
+      status: 200,
+      outputBytes: 123,
+    });
+  });
+
+  test("missing session cookie emits WormholeFail with status=401", async () => {
+    // Force production so cookie check runs
+    const savedEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+
+    const { app, events } = makeAppWith({
+      overrides: { hasValidSessionCookie: () => false },
+    });
+
+    const res = await app.handle(new Request("http://localhost/api/peer/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        peer: "white",
+        cmd: "/dig",
+        signature: "[white:white-wormhole]",
+      }),
+    }));
+
+    process.env.NODE_ENV = savedEnv;
+
+    expect(res.status).toBe(401);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      state: "failed",
+      status: 401,
+      trustTier: "denied",
+      error: "no_session",
+      origin: "[white:white-wormhole]",
+      peer: "white",
+    });
+  });
+
+  test("shell_peer_denied emits WormholeFail with status=403 trustTier=denied", async () => {
+    const { app, events } = makeAppWith({
+      overrides: {
+        isReadOnlyCmd: () => false,
+        isShellPeerAllowed: () => false,
+        parseSignature: () => ({ originHost: "unknown-host", originAgent: "stranger", isAnon: false }),
+      },
+    });
+
+    const res = await app.handle(new Request("http://localhost/api/peer/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: "pe_session=fake" },
+      body: JSON.stringify({
+        peer: "white",
+        cmd: "/awaken",
+        signature: "[unknown-host:stranger]",
+      }),
+    }));
+
+    expect(res.status).toBe(403);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      state: "failed",
+      status: 403,
+      trustTier: "denied",
+      error: "shell_peer_denied",
+      origin: "[unknown-host:stranger]",
+    });
+  });
+
+  test("unknown_peer emits WormholeFail with status=404", async () => {
+    const { app, events } = makeAppWith({
+      overrides: { resolvePeerUrl: () => null },
+    });
+
+    const res = await app.handle(new Request("http://localhost/api/peer/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: "pe_session=fake" },
+      body: JSON.stringify({
+        peer: "ghost-peer",
+        cmd: "/dig",
+        signature: "[white:white-wormhole]",
+      }),
+    }));
+
+    expect(res.status).toBe(404);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      state: "failed",
+      status: 404,
+      trustTier: "readonly",
+      error: "unknown_peer",
+      peer: "ghost-peer",
+    });
+  });
+
+  test("relay throw emits WormholeFail with status=502 and the underlying message", async () => {
+    const { app, events } = makeAppWith({
+      relay: (async () => { throw new Error("peer offline"); }) as typeof relayToPeer,
+    });
+
+    const res = await app.handle(new Request("http://localhost/api/peer/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: "pe_session=fake" },
+      body: JSON.stringify({
+        peer: "white",
+        cmd: "/dig",
+        signature: "[white:white-wormhole]",
+      }),
+    }));
+
+    expect(res.status).toBe(502);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      state: "failed",
+      status: 502,
+      error: "peer offline",
+      peer: "white",
+      peerUrl: "http://peer.local:3456",
+    });
+  });
+
+  test("bad_signature (400) does NOT emit (no parsed origin available)", async () => {
+    const { app, events } = makeAppWith({
+      overrides: { parseSignature: () => null },
+    });
+
+    const res = await app.handle(new Request("http://localhost/api/peer/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: "pe_session=fake" },
+      body: JSON.stringify({
+        peer: "white",
+        cmd: "/dig",
+        signature: "not-bracketed",
+      }),
+    }));
+
+    expect(res.status).toBe(400);
+    expect(events).toHaveLength(0);
+  });
+});

--- a/test/wormhole-events.test.ts
+++ b/test/wormhole-events.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildWormholeLifecycleData,
+  buildWormholeLifecycleFeedEvent,
+  isWormholeLifecycleData,
+  type WormholeLifecycleInput,
+} from "../src/lib/wormhole-events";
+
+const baseInput: WormholeLifecycleInput = {
+  id: "wh-1",
+  ts: new Date("2026-05-20T11:51:00.000Z"),
+  direction: "relayed",
+  state: "delivered",
+  cmd: "/dig",
+  args: ["--deep"],
+  origin: "[oracle-world:mawjs]",
+  peer: "white",
+  peerUrl: "http://white.wg:3456",
+  trustTier: "readonly",
+  elapsedMs: 137,
+  status: 200,
+  outputBytes: 9_482,
+};
+
+describe("wormhole lifecycle event builders", () => {
+  test("buildWormholeLifecycleData fills stable fields and optional metadata", () => {
+    const data = buildWormholeLifecycleData(baseInput);
+    expect(data).toEqual({
+      id: "wh-1",
+      ts: "2026-05-20T11:51:00.000Z",
+      direction: "relayed",
+      state: "delivered",
+      cmd: "/dig",
+      args: ["--deep"],
+      origin: "[oracle-world:mawjs]",
+      peer: "white",
+      peerUrl: "http://white.wg:3456",
+      trustTier: "readonly",
+      elapsedMs: 137,
+      status: 200,
+      outputBytes: 9_482,
+    });
+  });
+
+  test("buildWormholeLifecycleData normalizes timestamps and truncates long fields", () => {
+    const longCmd = "/x" + "y".repeat(600);
+    const longError = "e".repeat(1_010);
+    const tooManyArgs = Array.from({ length: 60 }, (_, i) => `arg${i}`);
+    const data = buildWormholeLifecycleData({
+      ...baseInput,
+      id: undefined,
+      ts: 1_700_000_000_000,
+      cmd: longCmd,
+      args: tooManyArgs,
+      error: longError,
+      state: "failed",
+    });
+
+    expect(data.id).toBeTruthy();
+    expect(data.ts).toBe("2023-11-14T22:13:20.000Z");
+    expect(data.cmd).toHaveLength(500);
+    expect(data.cmd.endsWith("…")).toBe(true);
+    expect(data.args).toHaveLength(50);
+    expect(data.error).toHaveLength(1_000);
+    expect(data.error?.endsWith("…")).toBe(true);
+  });
+
+  test("buildWormholeLifecycleFeedEvent maps state to feed event type", () => {
+    const delivered = buildWormholeLifecycleFeedEvent(baseInput);
+    expect(delivered.event).toBe("WormholeRequest");
+    expect(delivered.host).toBe("oracle-world");
+    expect(delivered.oracle).toBe("mawjs");
+    expect(delivered.sessionId).toBe("white");
+    expect(delivered.message).toContain("relayed/delivered");
+    expect(delivered.message).toContain("[oracle-world:mawjs] → white");
+    expect(delivered.message).toContain("cmd=/dig");
+    expect(delivered.message).toContain("tier=readonly");
+    expect(delivered.message).toContain("status=200");
+
+    const failed = buildWormholeLifecycleFeedEvent({
+      ...baseInput,
+      state: "failed",
+      error: "shell_peer_denied",
+      trustTier: "denied",
+    });
+    expect(failed.event).toBe("WormholeFail");
+    expect(failed.message).toContain("error=shell_peer_denied");
+    expect(failed.message).toContain("tier=denied");
+
+    const queued = buildWormholeLifecycleFeedEvent({ ...baseInput, state: "queued" });
+    expect(queued.event).toBe("WormholeRequest");
+  });
+
+  test("buildWormholeLifecycleFeedEvent handles unsigned origin and invalid timestamp fallback", () => {
+    const before = Date.now();
+    const event = buildWormholeLifecycleFeedEvent({
+      ...baseInput,
+      ts: "not-a-date",
+      origin: "unsigned",
+    });
+    const after = Date.now();
+    expect(event.host).toBe("local");
+    expect(event.oracle).toBe("unsigned");
+    expect(event.ts).toBeGreaterThanOrEqual(before);
+    expect(event.ts).toBeLessThanOrEqual(after + 5);
+  });
+
+  test("buildWormholeLifecycleData defaults blank timestamps to now", () => {
+    const before = Date.now();
+    const data = buildWormholeLifecycleData({ ...baseInput, ts: "" });
+    const after = Date.now();
+    expect(new Date(data.ts).getTime()).toBeGreaterThanOrEqual(before);
+    expect(new Date(data.ts).getTime()).toBeLessThanOrEqual(after + 5);
+  });
+
+  test("buildWormholeLifecycleData omits undefined optional fields", () => {
+    const data = buildWormholeLifecycleData({
+      ...baseInput,
+      peerUrl: undefined,
+      elapsedMs: undefined,
+      status: undefined,
+      outputBytes: undefined,
+    });
+    expect(data.peerUrl).toBeUndefined();
+    expect(data.elapsedMs).toBeUndefined();
+    expect(data.status).toBeUndefined();
+    expect(data.outputBytes).toBeUndefined();
+  });
+
+  test("isWormholeLifecycleData accepts complete payloads and rejects malformed values", () => {
+    const data = buildWormholeLifecycleData(baseInput);
+    expect(isWormholeLifecycleData(data)).toBe(true);
+    expect(isWormholeLifecycleData(null)).toBe(false);
+    expect(isWormholeLifecycleData("nope")).toBe(false);
+    expect(isWormholeLifecycleData({ ...data, id: 123 })).toBe(false);
+    expect(isWormholeLifecycleData({ ...data, direction: "sideways" })).toBe(false);
+    expect(isWormholeLifecycleData({ ...data, state: "lost" })).toBe(false);
+    expect(isWormholeLifecycleData({ ...data, cmd: 7 })).toBe(false);
+    expect(isWormholeLifecycleData({ ...data, args: "not-an-array" })).toBe(false);
+    expect(isWormholeLifecycleData({ ...data, origin: 7 })).toBe(false);
+    expect(isWormholeLifecycleData({ ...data, peer: 7 })).toBe(false);
+    expect(isWormholeLifecycleData({ ...data, trustTier: "owner" })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Extends the plugin event bus with typed wormhole lifecycle events, mirroring the existing `MessageSend`/`MessageDeliver`/`MessageFail` shape.
- Adds 2 new types to `FeedEventType` (`WormholeRequest`, `WormholeFail`) and a new `src/lib/wormhole-events.ts` (data type + builders + guard).
- Emits at 5 sites in `/api/peer/exec`: `401 no_session`, `403 shell_peer_denied`, `404 unknown_peer`, `200 delivered`, `502 relay_failed`. Bad-signature (400) deliberately does NOT emit because no parsed origin is available.
- Plugins can now hook the wormhole protocol the same way they hook hey delivery — Discord forwarders, audit logs, rate-limiters all become 1-plugin features.

## Why this gap exists

Before this PR, `/api/peer/exec` — formerly `/api/wormhole/request`, renamed in PR #264 (b6ff0aff) — emitted zero structured signal to the feed bus. Every signed remote-command relay was invisible to plugins. Background context: [`ψ/ralph/49-wormhole-federation.md`](https://github.com/Soul-Brews-Studio/digger-oracle/blob/agents/1-wormhole-federation/%CF%88/ralph/49-wormhole-federation.md) in digger-oracle (the dig that named the gap).

## Event payload shape

\`\`\`ts
interface WormholeLifecycleData {
  id: string;
  ts: string;
  direction: \"inbound\" | \"outbound\" | \"relayed\";
  state: \"queued\" | \"delivered\" | \"failed\";
  cmd: string;
  args: string[];
  origin: string;          // \"[host:agent]\" — the parsed signature
  peer: string;            // peer alias from the request body
  peerUrl?: string;        // resolved URL (present once resolvePeerUrl succeeds)
  trustTier: \"readonly\" | \"shell_allowlisted\" | \"denied\";
  elapsedMs?: number;
  status?: number;
  outputBytes?: number;    // size of response body, NOT the body itself
  error?: string;
}
\`\`\`

Trust tier is derived from the existing readonly/allowlist decision. \`outputBytes\` reports response size without the body (privacy-preserving). All fail emits are wrapped in try/catch so hook errors can never change route response semantics — matches the \`sessions.ts:114-122\` pattern for message lifecycle.

## Out of scope (intentionally)

- Inbound-side emission on the receiving peer — needs the per-peer executor first.
- SQLite logging in the \`messages\` plugin for wormhole events — opt-in by plugin authors via \`hooks.on: [\"WormholeRequest\", \"WormholeFail\"]\`.
- A Discord-forwarder plugin — separate PR, uses the same event shape.

## Backward compatibility

Non-breaking:
- Union additions to \`FeedEventType\` are forward-compatible — existing consumers (parsers, switches) fall through their default cases.
- \`PeerExecApiDeps\` extensions are all optional with sensible defaults.
- The injected \`emitWormholeLifecycle\` is wrapped in try/catch — hook misbehavior cannot alter HTTP response semantics.

## Test plan

- [x] \`bun test test/wormhole-events.test.ts\` — 7 builder/guard cases pass
- [x] \`bun test test/peer-exec.test.ts\` — existing 14 cases + 6 new emission cases pass
- [x] \`bun run test:default:safe\` — **2369 pass, 0 fail** across the full default suite
- [x] \`bunx tsc --noEmit\` — zero errors in changed files (\`peer-exec.ts\`, \`feed.ts\`, \`wormhole-events.ts\`; pre-existing unrelated errors in \`wake-cmd.ts\` and \`command-registry-wasm.ts\` remain)

🤖 ตอบโดย digger-wormhole-federation จาก Nat → digger-oracle (worker on \`agents/1-wormhole-federation\`)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>