### PR TITLE
fix(team): keep --exec prompt launch paths out of psi (#1797)

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,14 +1,14 @@
 # Coverage gap analysis
 
-Generated: 2026-05-20T06:45:36.240Z
+Generated: 2026-05-20T06:55:25.019Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: source-line-normalized Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 Excluded from Bun LCOV accounting: non-Bun-runtime AssemblyScript sources compiled to WebAssembly and covered by AssemblyScript harness tests instead of Bun line instrumentation.
 
-Overall line coverage: **100.0%** (30873/30873)
-Overall function coverage: **100.0%** (5165/5165)
+Overall line coverage: **100.0%** (30901/30901)
+Overall function coverage: **100.0%** (5169/5169)
 
 ## Module summary
 
@@ -18,11 +18,11 @@ Overall function coverage: **100.0%** (5165/5165)
 | config/runtime | 19 | 0 | 100.0% (780/780) | 100.0% (135/135) | n/a (0/0) |
 | fleet | 19 | 0 | 100.0% (678/678) | 100.0% (108/108) | n/a (0/0) |
 | matcher | 3 | 0 | 100.0% (73/73) | 100.0% (18/18) | n/a (0/0) |
-| other | 172 | 5 | 100.0% (8530/8530) | 100.0% (1464/1464) | n/a (0/0) |
+| other | 172 | 5 | 100.0% (8544/8544) | 100.0% (1466/1466) | n/a (0/0) |
 | plugin dispatch | 15 | 1 | 100.0% (677/677) | 100.0% (89/89) | n/a (0/0) |
 | routing/aliases | 4 | 0 | 100.0% (431/431) | 100.0% (76/76) | n/a (0/0) |
 | transport | 28 | 0 | 100.0% (1695/1695) | 100.0% (452/452) | n/a (0/0) |
-| vendor plugins | 245 | 2 | 100.0% (12362/12362) | 100.0% (1957/1957) | n/a (0/0) |
+| vendor plugins | 245 | 2 | 100.0% (12376/12376) | 100.0% (1959/1959) | n/a (0/0) |
 
 ## Source handled outside Bun LCOV
 

--- a/src/commands/plugins/team/team-lifecycle.ts
+++ b/src/commands/plugins/team/team-lifecycle.ts
@@ -1,10 +1,30 @@
 import { readdirSync, readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync } from "fs";
+import { createHash } from "crypto";
 import { join } from "path";
 import { tmux } from "../../../sdk";
 import { assertValidOracleName } from "../../../core/fleet/validate";
 import { TEAMS_DIR, loadTeam, resolvePsi, writeShutdownRequest, cleanupTeamDir, type TeamConfig, type TeamMember } from "./team-helpers";
 
 const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
+
+function asciiLaunchPromptFileName(role: string): string {
+  const slug = role
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^A-Za-z0-9_.-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48) || "agent";
+  const hash = createHash("sha256").update(role).digest("hex").slice(0, 8);
+  return `${slug}-${hash}-spawn-prompt.md`;
+}
+
+function writeLaunchPromptFile(teamName: string, role: string, prompt: string): string {
+  const launchPromptDir = join(TEAMS_DIR, teamName);
+  mkdirSync(launchPromptDir, { recursive: true });
+  const launchPromptPath = join(launchPromptDir, asciiLaunchPromptFileName(role));
+  writeFileSync(launchPromptPath, prompt);
+  return launchPromptPath;
+}
 
 /**
  * Copy per-member inbox + findings to the vault mailbox, then archive the
@@ -226,6 +246,8 @@ export async function cmdTeamSpawn(
   // Write prompt file for the user to use
   const promptPath = join(teamDir, `${role}-spawn-prompt.md`);
   writeFileSync(promptPath, spawnPrompt);
+  const launchPromptPath = writeLaunchPromptFile(teamName, role, spawnPrompt);
+  const claudeCmd = `${cwdPrefix}claude --model ${model} --system-prompt-file ${shellQuote(launchPromptPath)}`;
 
   // Update manifest with new member
   const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
@@ -262,12 +284,11 @@ export async function cmdTeamSpawn(
     if (!process.env.TMUX) {
       console.log();
       console.log(`  \x1b[33m⚠\x1b[0m --exec requires an active tmux session ($TMUX not set).`);
-      console.log(`  \x1b[36mRun manually:\x1b[0m ${cwdPrefix}claude --model ${model} --system-prompt-file "${promptPath}"`);
+      console.log(`  \x1b[36mRun manually:\x1b[0m ${claudeCmd}`);
       return;
     }
     try {
       const { spawnTeammatePane, colorAnsi } = await import("../tmux/layout-manager");
-      const claudeCmd = `${cwdPrefix}claude --model ${model} --system-prompt-file '${promptPath.replace(/'/g, "'\\''")}'`;
       const teammateCount = manifest.members.filter((m: any) => m.name !== role).length;
       const agentId = `${role}@${teamName}`;
 
@@ -297,11 +318,11 @@ export async function cmdTeamSpawn(
     } catch (e: any) {
       console.log();
       console.log(`  \x1b[33m⚠\x1b[0m --exec split failed: ${e?.message || e}`);
-      console.log(`  \x1b[36mRun manually:\x1b[0m ${cwdPrefix}claude --model ${model} --system-prompt-file "${promptPath}"`);
+      console.log(`  \x1b[36mRun manually:\x1b[0m ${claudeCmd}`);
     }
     return;
   }
 
   console.log();
-  console.log(`  \x1b[36mRun:\x1b[0m ${cwdPrefix}claude --model ${model} --system-prompt-file "${promptPath}"`);
+  console.log(`  \x1b[36mRun:\x1b[0m ${claudeCmd}`);
 }

--- a/src/vendor/mpr-plugins/team/team-lifecycle.ts
+++ b/src/vendor/mpr-plugins/team/team-lifecycle.ts
@@ -1,10 +1,30 @@
 import { readdirSync, readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync } from "fs";
+import { createHash } from "crypto";
 import { join } from "path";
 import { tmux } from "maw-js/sdk";
 import { assertValidOracleName } from "maw-js/core/fleet/validate";
 import { TEAMS_DIR, loadTeam, resolvePsi, writeShutdownRequest, cleanupTeamDir, currentLeadSessionId, type TeamConfig, type TeamMember } from "./team-helpers";
 
 const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
+
+function asciiLaunchPromptFileName(role: string): string {
+  const slug = role
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^A-Za-z0-9_.-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48) || "agent";
+  const hash = createHash("sha256").update(role).digest("hex").slice(0, 8);
+  return `${slug}-${hash}-spawn-prompt.md`;
+}
+
+function writeLaunchPromptFile(teamName: string, role: string, prompt: string): string {
+  const launchPromptDir = join(TEAMS_DIR, teamName);
+  mkdirSync(launchPromptDir, { recursive: true });
+  const launchPromptPath = join(launchPromptDir, asciiLaunchPromptFileName(role));
+  writeFileSync(launchPromptPath, prompt);
+  return launchPromptPath;
+}
 
 /**
  * Copy per-member inbox + findings to the vault mailbox, then archive the
@@ -217,6 +237,8 @@ export async function cmdTeamSpawn(
   // Write prompt file for the user to use
   const promptPath = join(teamDir, `${role}-spawn-prompt.md`);
   writeFileSync(promptPath, spawnPrompt);
+  const launchPromptPath = writeLaunchPromptFile(teamName, role, spawnPrompt);
+  const claudeCmd = `${cwdPrefix}claude --model ${model} --system-prompt-file ${shellQuote(launchPromptPath)}`;
 
   // Update manifest with new member
   const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
@@ -253,23 +275,22 @@ export async function cmdTeamSpawn(
     if (!process.env.TMUX) {
       console.log();
       console.log(`  \x1b[33m⚠\x1b[0m --exec requires an active tmux session ($TMUX not set).`);
-      console.log(`  \x1b[36mRun manually:\x1b[0m ${cwdPrefix}claude --model ${model} --prompt-file "${promptPath}"`);
+      console.log(`  \x1b[36mRun manually:\x1b[0m ${claudeCmd}`);
       return;
     }
     try {
       const { hostExec } = await import("maw-js/sdk");
-      const claudeCmd = `${cwdPrefix}claude --model ${model} --prompt-file '${promptPath.replace(/'/g, "'\\''")}'`;
       await hostExec(`tmux split-window -h -l 50% '${claudeCmd.replace(/'/g, "'\\''")}'`);
       console.log();
       console.log(`  \x1b[32m✓ --exec\x1b[0m spawned ${role} in a new tmux pane (right, 50%)`);
     } catch (e: any) {
       console.log();
       console.log(`  \x1b[33m⚠\x1b[0m --exec split failed: ${e?.message || e}`);
-      console.log(`  \x1b[36mRun manually:\x1b[0m ${cwdPrefix}claude --model ${model} --prompt-file "${promptPath}"`);
+      console.log(`  \x1b[36mRun manually:\x1b[0m ${claudeCmd}`);
     }
     return;
   }
 
   console.log();
-  console.log(`  \x1b[36mRun:\x1b[0m ${cwdPrefix}claude --model ${model} --prompt-file "${promptPath}"`);
+  console.log(`  \x1b[36mRun:\x1b[0m ${claudeCmd}`);
 }

--- a/test/isolated/team-lifecycle-default.test.ts
+++ b/test/isolated/team-lifecycle-default.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdtempSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -196,6 +196,26 @@ describe("team-lifecycle coverage", () => {
     const member = json(join(teamsDir, "qa-team/config.json")).members[0];
     expect(member).toMatchObject({ name: "builder", model: "opus", tmuxPaneId: "%42", color: "green", agentId: "builder@qa-team" });
     expect(logs.join("\n")).toContain("--exec");
+  });
+
+  test("spawn --exec launches from an ASCII prompt copy when the vault path contains Unicode", async () => {
+    lifecycle.cmdTeamCreate("qa-team");
+    process.env.TMUX = "/tmp/tmux,1,0";
+    process.env.TMUX_PANE = "%leader";
+
+    await lifecycle.cmdTeamSpawn("qa-team", "builder-λ", { exec: true, model: "opus" });
+
+    const command = (layoutCalls[0] as unknown[])[2] as string;
+    expect(command).toContain("claude --model opus --system-prompt-file");
+    expect(command).not.toContain("/ψ/");
+    expect(command).not.toContain("λ");
+    const launchFiles = readdirSync(join(teamsDir, "qa-team")).filter((name) => name.endsWith("-spawn-prompt.md"));
+    expect(launchFiles).toHaveLength(1);
+    expect(launchFiles[0]).not.toContain("λ");
+    const launchPrompt = join(teamsDir, "qa-team", launchFiles[0]);
+    expect(command).toContain(launchPrompt);
+    expect(readFileSync(launchPrompt, "utf-8")).toContain("You are 'builder-λ' on team 'qa-team'.");
+    expect(existsSync(join(root, "ψ/memory/mailbox/teams/qa-team/builder-λ-spawn-prompt.md"))).toBe(true);
   });
 
   test("spawn reports missing teams and falls back when pane creation fails", async () => {

--- a/test/isolated/team-lifecycle-second-pass-coverage.test.ts
+++ b/test/isolated/team-lifecycle-second-pass-coverage.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -249,7 +249,7 @@ describe("vendor team-lifecycle second-pass coverage", () => {
     expect(readJson(manifestPath).members).toEqual(["scout"]);
     expect(readFileSync(join(root, "ψ/memory/mailbox/teams/qa-team/scout-spawn-prompt.md"), "utf-8")).toBe("You are 'scout' on team 'qa-team'.");
     expect(logs.join("\n")).toContain("past life: no");
-    expect(logs.join("\n")).toContain("cd '/tmp/path with '\\''quote' && claude --model sonnet --prompt-file");
+    expect(logs.join("\n")).toContain("cd '/tmp/path with '\\''quote' && claude --model sonnet --system-prompt-file");
   });
 
   test("spawn includes past-life standing orders and only the latest findings tail", async () => {
@@ -274,11 +274,21 @@ describe("vendor team-lifecycle second-pass coverage", () => {
     lifecycle.cmdTeamCreate("qa-team");
     process.env.TMUX = "/tmp/tmux,1,0";
 
-    await lifecycle.cmdTeamSpawn("qa-team", "builder", { exec: true, model: "opus" });
+    await lifecycle.cmdTeamSpawn("qa-team", "builder-λ", { exec: true, model: "opus" });
 
     expect(hostExecCalls).toHaveLength(1);
     expect(hostExecCalls[0]).toContain("tmux split-window -h -l 50%");
-    expect(hostExecCalls[0]).toContain("claude --model opus --prompt-file");
+    expect(hostExecCalls[0]).toContain("claude --model opus --system-prompt-file");
+    expect(hostExecCalls[0]).not.toContain("--prompt-file");
+    expect(hostExecCalls[0]).not.toContain("/ψ/");
+    expect(hostExecCalls[0]).not.toContain("λ");
+    const launchFiles = readdirSync(join(teamsDir, "qa-team")).filter((name) => name.endsWith("-spawn-prompt.md"));
+    expect(launchFiles).toHaveLength(1);
+    expect(launchFiles[0]).not.toContain("λ");
+    const launchPrompt = join(teamsDir, "qa-team", launchFiles[0]);
+    expect(hostExecCalls[0]).toContain(launchPrompt);
+    expect(readFileSync(launchPrompt, "utf-8")).toContain("You are 'builder-λ' on team 'qa-team'.");
+    expect(existsSync(join(root, "ψ/memory/mailbox/teams/qa-team/builder-λ-spawn-prompt.md"))).toBe(true);
     expect(logs.join("\n")).toContain("--exec");
 
     logs = [];
@@ -292,7 +302,7 @@ describe("vendor team-lifecycle second-pass coverage", () => {
     expect(hostExecCalls).toHaveLength(2);
     expect(logs.join("\n")).toContain("--exec split failed: tmux denied");
     expect(logs.join("\n")).toContain("Run manually:");
-    expect(logs.join("\n")).toContain("cd '/tmp/work dir' && claude --model haiku --prompt-file");
+    expect(logs.join("\n")).toContain("cd '/tmp/work dir' && claude --model haiku --system-prompt-file");
   });
 
   test("spawn --exec outside tmux prints a manual command instead of starting a pane", async () => {
@@ -303,6 +313,6 @@ describe("vendor team-lifecycle second-pass coverage", () => {
     expect(hostExecCalls).toEqual([]);
     expect(logs.join("\n")).toContain("--exec requires an active tmux session");
     expect(logs.join("\n")).toContain("Run manually:");
-    expect(logs.join("\n")).toContain("claude --model sonnet --prompt-file");
+    expect(logs.join("\n")).toContain("claude --model sonnet --system-prompt-file");
   });
 });


### PR DESCRIPTION
## Summary
- Closes #1797 by copying team spawn launch prompts to an ASCII tool-store path under `TEAMS_DIR/<team>/` while keeping the persistent vault prompt under `ψ/memory/mailbox/teams/`.
- Uses that ASCII launch prompt path for `maw team spawn --exec` command strings before they cross tmux shell wrappers.
- Applies the same fix to the vendor team stack and closes the stale `--prompt-file` drift from #1083 by using `--system-prompt-file` there too.
- Adds Unicode regression coverage for ψ vault paths plus Unicode role names.

## Validation
- `bun run build`
- `bun run test:spec`
- `bun run test:default:safe`
- `bun run test:coverage`
- `bash scripts/test-isolated.sh test/isolated/team-lifecycle-default.test.ts test/isolated/team-lifecycle-second-pass-coverage.test.ts`

Not-tested: live manual tmux `maw team spawn --exec` with Claude Code on Nat pane.