### PR TITLE
feat(absorb): archive donor and switch to receiver (#1800)

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,14 +1,14 @@
 # Coverage gap analysis
 
-Generated: 2026-05-20T08:25:24.638Z
+Generated: 2026-05-20T09:02:15.451Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: source-line-normalized Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 Excluded from Bun LCOV accounting: non-Bun-runtime AssemblyScript sources compiled to WebAssembly and covered by AssemblyScript harness tests instead of Bun line instrumentation.
 
-Overall line coverage: **100.0%** (31039/31039)
-Overall function coverage: **100.0%** (5193/5193)
+Overall line coverage: **100.0%** (31130/31130)
+Overall function coverage: **100.0%** (5217/5217)
 
 ## Module summary
 
@@ -22,7 +22,7 @@ Overall function coverage: **100.0%** (5193/5193)
 | plugin dispatch | 15 | 1 | 100.0% (705/705) | 100.0% (91/91) | n/a (0/0) |
 | routing/aliases | 4 | 0 | 100.0% (431/431) | 100.0% (76/76) | n/a (0/0) |
 | transport | 28 | 0 | 100.0% (1695/1695) | 100.0% (452/452) | n/a (0/0) |
-| vendor plugins | 245 | 2 | 100.0% (12380/12380) | 100.0% (1959/1959) | n/a (0/0) |
+| vendor plugins | 247 | 2 | 100.0% (12471/12471) | 100.0% (1983/1983) | n/a (0/0) |
 
 ## Source handled outside Bun LCOV
 

--- a/src/vendor/mpr-plugins/absorb/impl.ts
+++ b/src/vendor/mpr-plugins/absorb/impl.ts
@@ -1,0 +1,141 @@
+import { existsSync } from "fs";
+import { join } from "path";
+import { FLEET_DIR, hostExec } from "maw-js/sdk";
+import { getGhqRoot } from "maw-js/config/ghq-root";
+import { loadFleetEntries, type FleetEntry } from "maw-js/commands/shared/fleet-load";
+import { cmdArchive } from "../archive/impl";
+import { resolveOraclePath } from "../soul-sync/resolve";
+import { syncOracleVaults } from "../soul-sync/sync-helpers";
+
+export interface AbsorbOptions {
+  dryRun?: boolean;
+}
+
+function stripSessionPrefix(name: string) {
+  return name.replace(/^\d+-/, "");
+}
+
+function stripOracleSuffix(name: string) {
+  return name.replace(/-oracle$/, "");
+}
+
+function normalizeName(name: string) {
+  return stripOracleSuffix(stripSessionPrefix(name)).toLowerCase();
+}
+
+function repoName(repoSlug: string | undefined) {
+  return (repoSlug || "").split("/").filter(Boolean).pop() || "";
+}
+
+function shellQuote(value: string) {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function entryNames(entry: FleetEntry): string[] {
+  const sessionName = stripSessionPrefix(entry.session.name);
+  const groupName = stripSessionPrefix(entry.groupName);
+  const windowNames = entry.session.windows.flatMap(win => [win.name, repoName(win.repo)]);
+  return [entry.session.name, sessionName, groupName, ...windowNames].filter(Boolean);
+}
+
+export function findAbsorbFleetEntry(entries: FleetEntry[], query: string): FleetEntry | undefined {
+  const raw = query.toLowerCase();
+  const normalized = normalizeName(query);
+  return entries.find(entry => entryNames(entry).some(name => {
+    const candidate = name.toLowerCase();
+    return candidate === raw || normalizeName(name) === normalized;
+  }));
+}
+
+async function resolveEntryPath(entry: FleetEntry, displayName: string): Promise<string | null> {
+  const resolved = await resolveOraclePath(displayName);
+  if (resolved) return resolved;
+
+  const repo = entry.session.windows[0]?.repo;
+  if (!repo) return null;
+
+  const fallback = join(getGhqRoot(), "github.com", repo);
+  return existsSync(fallback) ? fallback : null;
+}
+
+function formatSyncSummary(synced: Record<string, number>) {
+  return Object.entries(synced).map(([dir, count]) => `${count} ${dir.split("/").pop()}`).join(", ");
+}
+
+async function switchToReceiver(sessionName: string, opts: AbsorbOptions) {
+  const command = `tmux switch-client -t ${shellQuote(sessionName)}`;
+  if (opts.dryRun) {
+    console.log(`  [dry-run] would switch client: ${command}`);
+    return;
+  }
+
+  if (!process.env.TMUX) {
+    console.log(`  [info] not inside tmux; run manually: ${command}`);
+    return;
+  }
+
+  try {
+    await hostExec(command);
+    console.log(`  [ok] switched client to ${sessionName}`);
+  } catch (e: any) {
+    console.log(`  [warn] could not switch to receiver: ${e.message || e}`);
+    console.log(`  [hint] run manually: ${command}`);
+  }
+}
+
+/**
+ * maw absorb <donor> --into <receiver>
+ *
+ * Lifecycle wrap:
+ *   1. Copy new donor psi memory into the receiver using the soul-sync primitive.
+ *   2. Archive the donor using the existing archive primitive.
+ *   3. Switch the active tmux client to the receiver session.
+ */
+export async function cmdAbsorb(donor: string, receiver: string, opts: AbsorbOptions = {}) {
+  const entries = loadFleetEntries();
+  const donorEntry = findAbsorbFleetEntry(entries, donor);
+  if (!donorEntry) throw new Error(`donor oracle '${donor}' not found in fleet config`);
+
+  const receiverEntry = findAbsorbFleetEntry(entries, receiver);
+  if (!receiverEntry) throw new Error(`receiver oracle '${receiver}' not found in fleet config`);
+
+  const donorName = stripSessionPrefix(donorEntry.session.name);
+  const receiverName = stripSessionPrefix(receiverEntry.session.name);
+  const receiverSession = receiverEntry.session.name;
+
+  if (donorEntry.file === receiverEntry.file || normalizeName(donorName) === normalizeName(receiverName)) {
+    throw new Error("donor and receiver must be different oracles");
+  }
+
+  const donorPath = await resolveEntryPath(donorEntry, donorName);
+  if (!donorPath) throw new Error(`could not resolve donor oracle path for '${donorName}'`);
+
+  const receiverPath = await resolveEntryPath(receiverEntry, receiverName);
+  if (!receiverPath) throw new Error(`could not resolve receiver oracle path for '${receiverName}'`);
+
+  console.log(`\n  Absorbing ${donorName} -> ${receiverName}\n`);
+
+  if (opts.dryRun) {
+    console.log(`  [dry-run] would sync psi memory: ${donorPath} -> ${receiverPath}`);
+    console.log(`  [dry-run] would archive donor via: maw archive ${donorName}`);
+  } else {
+    const result = syncOracleVaults(donorPath, receiverPath, donorName, receiverName);
+    if (result.total === 0) {
+      console.log(`  [ok] psi memory sync complete: nothing new`);
+    } else {
+      console.log(`  [ok] psi memory sync complete: ${formatSyncSummary(result.synced)}`);
+    }
+
+    await cmdArchive(donorName, { dryRun: false });
+  }
+
+  await switchToReceiver(receiverSession, opts);
+
+  if (opts.dryRun) {
+    console.log(`\n  [dry-run] absorb preview complete; no files, fleet entries, repos, or tmux clients changed.\n`);
+  } else {
+    const disabledFile = join(FLEET_DIR, `${donorEntry.file}.disabled`);
+    const archived = existsSync(disabledFile) ? "archived" : "archive attempted";
+    console.log(`\n  ${donorName} absorbed into ${receiverName}; donor ${archived}.\n`);
+  }
+}

--- a/src/vendor/mpr-plugins/absorb/index.ts
+++ b/src/vendor/mpr-plugins/absorb/index.ts
@@ -1,0 +1,57 @@
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import { cmdAbsorb } from "./impl";
+
+export const command = {
+  name: "absorb",
+  description: "Absorb one oracle into another, archive the donor, and switch to the receiver.",
+};
+
+function usage() {
+  return "usage: maw absorb <donor> --into <receiver> [--dry-run]";
+}
+
+function parseArgs(args: string[]) {
+  const intoIndex = args.indexOf("--into");
+  const donor = args.find(arg => !arg.startsWith("--"));
+  const receiver = intoIndex >= 0 ? args[intoIndex + 1] : undefined;
+  const dryRun = args.includes("--dry-run");
+
+  if (!donor || intoIndex < 0 || !receiver || receiver.startsWith("--")) {
+    throw new Error(usage());
+  }
+
+  return { donor, receiver, dryRun };
+}
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+
+  if (args[0] === "--help" || args[0] === "-h") {
+    const help = `${usage()} — absorb donor knowledge, archive donor, and switch to receiver`;
+    if (ctx.writer) ctx.writer(help);
+    else console.log(help);
+    return { ok: true };
+  }
+
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  const write = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.log = write;
+  console.error = write;
+
+  try {
+    const parsed = parseArgs(args);
+    await cmdAbsorb(parsed.donor, parsed.receiver, { dryRun: parsed.dryRun });
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    const output = logs.join("\n") || undefined;
+    return { ok: false, error: output || e.message, output };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/src/vendor/mpr-plugins/absorb/plugin.json
+++ b/src/vendor/mpr-plugins/absorb/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "absorb",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Absorb one oracle into another, archive the donor, and switch to the receiver.",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "absorb",
+    "help": "maw absorb <donor> --into <receiver> [--dry-run] — absorb donor knowledge, archive donor, and switch to receiver"
+  },
+  "weight": 50,
+  "license": "MIT",
+  "schemaVersion": 1
+}

--- a/test/isolated/absorb-coverage.test.ts
+++ b/test/isolated/absorb-coverage.test.ts
@@ -1,0 +1,344 @@
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "maw-absorb-coverage-"));
+const fleetDir = join(tmpRoot, "fleet");
+const archiveSoulSyncPath = import.meta.resolve("../../src/vendor/mpr-plugins/archive/internal/soul-sync-impl.ts");
+
+let ghqRoot = join(tmpRoot, "ghq");
+let fleetEntries: any[] = [];
+let ghqFindResults = new Map<string, string | null>();
+let ghqFindCalls: string[] = [];
+let hostExecCalls: string[] = [];
+let hostExecErrorFor: string | null = null;
+let hostExecError: Error | null = null;
+let soulSyncCalls: unknown[][] = [];
+let logs: string[] = [];
+let errors: string[] = [];
+
+const originalLog = console.log;
+const originalError = console.error;
+const originalTmux = process.env.TMUX;
+
+mock.module("maw-js/sdk", () => ({
+  FLEET_DIR: fleetDir,
+  hostExec: async (cmd: string) => {
+    hostExecCalls.push(cmd);
+    if (hostExecErrorFor && cmd.includes(hostExecErrorFor)) {
+      throw hostExecError ?? new Error("host exec failed");
+    }
+    return "";
+  },
+}));
+
+mock.module("maw-js/config/ghq-root", () => ({
+  getGhqRoot: () => ghqRoot,
+}));
+
+mock.module("maw-js/core/ghq", () => ({
+  ghqFind: async (pattern: string) => {
+    ghqFindCalls.push(pattern);
+    return ghqFindResults.get(pattern) ?? null;
+  },
+}));
+
+mock.module("maw-js/commands/shared/fleet-load", () => ({
+  loadFleetEntries: () => fleetEntries,
+  loadFleet: () => fleetEntries.map(entry => entry.session),
+}));
+
+mock.module(archiveSoulSyncPath, () => ({
+  cmdSoulSync: async (...args: unknown[]) => {
+    soulSyncCalls.push(args);
+  },
+}));
+
+const { default: absorbHandler } = await import("../../src/vendor/mpr-plugins/absorb/index.ts?absorb-coverage");
+const { cmdAbsorb, findAbsorbFleetEntry } = await import("../../src/vendor/mpr-plugins/absorb/impl.ts?absorb-coverage");
+
+function resetConsoleCapture() {
+  logs = [];
+  errors = [];
+  console.log = (...args: any[]) => logs.push(args.map(String).join(" "));
+  console.error = (...args: any[]) => errors.push(args.map(String).join(" "));
+}
+
+function output() {
+  return [...logs, ...errors].join("\n");
+}
+
+function stripAnsi(value: string | undefined) {
+  return String(value ?? "").replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "");
+}
+
+function resetFleetDir() {
+  rmSync(fleetDir, { recursive: true, force: true });
+  mkdirSync(fleetDir, { recursive: true });
+}
+
+function writeFleetFile(file: string) {
+  writeFileSync(join(fleetDir, file), JSON.stringify({ session: "stub" }), "utf-8");
+}
+
+function repoPath(slug: string) {
+  return join(ghqRoot, "github.com", slug);
+}
+
+function prepareRepo(slug: string) {
+  const path = repoPath(slug);
+  mkdirSync(path, { recursive: true });
+  return path;
+}
+
+function writeLearning(slug: string, name: string, body = "lesson") {
+  const dir = join(repoPath(slug), "ψ", "memory", "learnings");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, name), body, "utf-8");
+}
+
+function fleetEntry(
+  name: string,
+  file: string,
+  opts: { repo?: string; groupName?: string; syncPeers?: string[]; windows?: Array<Record<string, unknown>> } = {},
+) {
+  const groupName = opts.groupName ?? file.replace(/^\d+-/, "").replace(/\.json$/, "");
+  return {
+    file,
+    num: parseInt(file, 10) || 0,
+    groupName,
+    session: {
+      name,
+      windows: opts.windows ?? [{ name: groupName, repo: opts.repo }],
+      ...(opts.syncPeers === undefined ? {} : { sync_peers: opts.syncPeers }),
+    },
+  };
+}
+
+beforeEach(() => {
+  ghqRoot = join(tmpRoot, "ghq");
+  fleetEntries = [];
+  ghqFindResults = new Map();
+  ghqFindCalls = [];
+  hostExecCalls = [];
+  hostExecErrorFor = null;
+  hostExecError = null;
+  soulSyncCalls = [];
+  delete process.env.TMUX;
+  resetFleetDir();
+  rmSync(ghqRoot, { recursive: true, force: true });
+  resetConsoleCapture();
+});
+
+afterEach(() => {
+  console.log = originalLog;
+  console.error = originalError;
+  if (originalTmux === undefined) delete process.env.TMUX;
+  else process.env.TMUX = originalTmux;
+});
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe("absorb handler", () => {
+  test("prints help directly without patching console", async () => {
+    const result = await absorbHandler({ source: "cli", args: ["--help"] } as any);
+
+    expect(result).toEqual({ ok: true });
+    expect(stripAnsi(output())).toContain("usage: maw absorb <donor> --into <receiver> [--dry-run]");
+  });
+
+  test("rejects missing --into before running absorb work", async () => {
+    const result = await absorbHandler({ source: "cli", args: ["donor"] } as any);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("usage: maw absorb <donor> --into <receiver> [--dry-run]");
+    expect(hostExecCalls).toEqual([]);
+  });
+
+  test("captures command output through the writer on success", async () => {
+    const writes: string[] = [];
+    const donorFile = "011-donor.json";
+    const receiverFile = "012-receiver.json";
+    fleetEntries = [
+      fleetEntry("011-donor", donorFile, { repo: "owner/donor-oracle" }),
+      fleetEntry("012-receiver", receiverFile, { repo: "owner/receiver-oracle" }),
+    ];
+    writeFleetFile(donorFile);
+    writeFleetFile(receiverFile);
+    prepareRepo("owner/donor-oracle");
+    prepareRepo("owner/receiver-oracle");
+
+    const result = await absorbHandler({
+      source: "cli",
+      args: ["donor-oracle", "--into", "receiver-oracle", "--dry-run"],
+      writer: (...args: any[]) => writes.push(args.map(String).join(" ")),
+    } as any);
+
+    expect(result).toEqual({ ok: true, output: undefined });
+    expect(stripAnsi(writes.join("\n"))).toContain("Absorbing donor -> receiver");
+    expect(stripAnsi(writes.join("\n"))).toContain("[dry-run] would switch client: tmux switch-client -t '012-receiver'");
+  });
+});
+
+describe("absorb impl", () => {
+  test("matches donor and receiver names across session, group, repo, and -oracle suffixes", () => {
+    const entries = [
+      fleetEntry("050-sage-vector-fix", "050-sage-vector-fix.json", { repo: "Soul-Brews-Studio/sage-vector-fix-oracle" }),
+    ];
+
+    expect(findAbsorbFleetEntry(entries as any, "050-sage-vector-fix")?.session.name).toBe("050-sage-vector-fix");
+    expect(findAbsorbFleetEntry(entries as any, "sage-vector-fix")?.session.name).toBe("050-sage-vector-fix");
+    expect(findAbsorbFleetEntry(entries as any, "sage-vector-fix-oracle")?.session.name).toBe("050-sage-vector-fix");
+  });
+
+  test("dry-run previews sync, archive, and the final switch without side effects", async () => {
+    const donorFile = "021-donor.json";
+    const receiverFile = "022-receiver.json";
+    fleetEntries = [
+      fleetEntry("021-donor", donorFile, { repo: "owner/donor-oracle", syncPeers: ["peer"] }),
+      fleetEntry("022-receiver", receiverFile, { repo: "owner/receiver-oracle" }),
+    ];
+    writeFleetFile(donorFile);
+    writeFleetFile(receiverFile);
+    prepareRepo("owner/donor-oracle");
+    prepareRepo("owner/receiver-oracle");
+
+    await cmdAbsorb("donor", "receiver", { dryRun: true });
+
+    const out = stripAnsi(output());
+    expect(hostExecCalls).toEqual([]);
+    expect(soulSyncCalls).toEqual([]);
+    expect(existsSync(join(fleetDir, donorFile))).toBe(true);
+    expect(existsSync(join(fleetDir, `${donorFile}.disabled`))).toBe(false);
+    expect(out).toContain("Absorbing donor -> receiver");
+    expect(out).toContain("[dry-run] would sync psi memory:");
+    expect(out).toContain("[dry-run] would archive donor via: maw archive donor");
+    expect(out).toContain("[dry-run] would switch client: tmux switch-client -t '022-receiver'");
+    expect(out).toContain("absorb preview complete; no files, fleet entries, repos, or tmux clients changed");
+  });
+
+  test("syncs donor psi memory, archives donor, then switches to the receiver session", async () => {
+    process.env.TMUX = "/tmp/tmux-100/default,1,0";
+    const donorFile = "031-donor.json";
+    const receiverFile = "032-receiver.json";
+    fleetEntries = [
+      fleetEntry("031-donor", donorFile, { repo: "owner/donor-oracle", syncPeers: ["peer"] }),
+      fleetEntry("032-receiver", receiverFile, { repo: "owner/receiver-oracle" }),
+    ];
+    writeFleetFile(donorFile);
+    writeFleetFile(receiverFile);
+    prepareRepo("owner/donor-oracle");
+    prepareRepo("owner/receiver-oracle");
+    writeLearning("owner/donor-oracle", "lesson.md", "absorbed");
+
+    await cmdAbsorb("donor-oracle", "receiver-oracle");
+
+    const out = stripAnsi(output());
+    expect(existsSync(join(repoPath("owner/receiver-oracle"), "ψ", "memory", "learnings", "lesson.md"))).toBe(true);
+    expect(soulSyncCalls).toEqual([[undefined, { cwd: repoPath("owner/donor-oracle") }]]);
+    expect(hostExecCalls).toEqual([
+      "gh repo archive owner/donor-oracle --yes",
+      "tmux switch-client -t '032-receiver'",
+    ]);
+    expect(existsSync(join(fleetDir, `${donorFile}.disabled`))).toBe(true);
+    expect(out).toContain("psi memory sync complete: 1 learnings");
+    expect(out).toContain("switched client to 032-receiver");
+    expect(out).toContain("donor absorbed into receiver; donor archived");
+  });
+
+  test("reports a no-op psi sync and manual switch command outside tmux", async () => {
+    const donorFile = "041-donor.json";
+    const receiverFile = "042-receiver.json";
+    fleetEntries = [
+      fleetEntry("041-donor", donorFile, { repo: "owner/donor-oracle" }),
+      fleetEntry("042-receiver", receiverFile, { repo: "owner/receiver-oracle" }),
+    ];
+    writeFleetFile(donorFile);
+    writeFleetFile(receiverFile);
+    prepareRepo("owner/donor-oracle");
+    prepareRepo("owner/receiver-oracle");
+
+    await cmdAbsorb("donor", "receiver");
+
+    const out = stripAnsi(output());
+    expect(hostExecCalls).toEqual(["gh repo archive owner/donor-oracle --yes"]);
+    expect(out).toContain("psi memory sync complete: nothing new");
+    expect(out).toContain("not inside tmux; run manually: tmux switch-client -t '042-receiver'");
+  });
+
+  test("keeps absorb successful when only the final tmux switch fails", async () => {
+    process.env.TMUX = "/tmp/tmux-100/default,1,0";
+    hostExecErrorFor = "tmux switch-client";
+    hostExecError = new Error("no current client");
+    const donorFile = "051-donor.json";
+    const receiverFile = "052-receiver.json";
+    fleetEntries = [
+      fleetEntry("051-donor", donorFile, { repo: "owner/donor-oracle" }),
+      fleetEntry("052-receiver", receiverFile, { repo: "owner/receiver-oracle" }),
+    ];
+    writeFleetFile(donorFile);
+    writeFleetFile(receiverFile);
+    prepareRepo("owner/donor-oracle");
+    prepareRepo("owner/receiver-oracle");
+
+    await cmdAbsorb("donor", "receiver");
+
+    const out = stripAnsi(output());
+    expect(hostExecCalls).toEqual([
+      "gh repo archive owner/donor-oracle --yes",
+      "tmux switch-client -t '052-receiver'",
+    ]);
+    expect(out).toContain("could not switch to receiver: no current client");
+    expect(out).toContain("run manually: tmux switch-client -t '052-receiver'");
+    expect(out).toContain("donor absorbed into receiver; donor archived");
+  });
+
+  test("accepts ghq-resolved paths before falling back to fleet repo paths", async () => {
+    const donorFile = "061-donor.json";
+    const receiverFile = "062-receiver.json";
+    const donorResolved = join(tmpRoot, "custom", "donor-oracle");
+    const receiverResolved = join(tmpRoot, "custom", "receiver-oracle");
+    fleetEntries = [
+      fleetEntry("061-donor", donorFile, { repo: "owner/donor-oracle" }),
+      fleetEntry("062-receiver", receiverFile, { repo: "owner/receiver-oracle" }),
+    ];
+    writeFleetFile(donorFile);
+    writeFleetFile(receiverFile);
+    mkdirSync(donorResolved, { recursive: true });
+    mkdirSync(receiverResolved, { recursive: true });
+    ghqFindResults.set("/donor-oracle$", donorResolved);
+    ghqFindResults.set("/receiver-oracle$", receiverResolved);
+
+    await cmdAbsorb("donor", "receiver", { dryRun: true });
+
+    const out = stripAnsi(output());
+    expect(ghqFindCalls).toEqual(["/donor-oracle$", "/receiver-oracle$"]);
+    expect(out).toContain(`would sync psi memory: ${donorResolved} -> ${receiverResolved}`);
+  });
+
+  test("rejects missing donors, missing receivers, self-absorbs, and unresolved paths", async () => {
+    const donorFile = "071-donor.json";
+    fleetEntries = [fleetEntry("071-donor", donorFile, { repo: "owner/donor-oracle" })];
+    writeFleetFile(donorFile);
+
+    await expect(cmdAbsorb("ghost", "donor")).rejects.toThrow("donor oracle 'ghost' not found");
+    await expect(cmdAbsorb("donor", "ghost")).rejects.toThrow("receiver oracle 'ghost' not found");
+    await expect(cmdAbsorb("donor", "donor")).rejects.toThrow("donor and receiver must be different");
+
+    fleetEntries = [
+      fleetEntry("081-donor", "081-donor.json", { repo: "owner/missing-donor-oracle" }),
+      fleetEntry("082-receiver", "082-receiver.json", { repo: "owner/receiver-oracle" }),
+    ];
+    writeFleetFile("081-donor.json");
+    writeFleetFile("082-receiver.json");
+    prepareRepo("owner/receiver-oracle");
+    await expect(cmdAbsorb("donor", "receiver")).rejects.toThrow("could not resolve donor oracle path");
+
+    prepareRepo("owner/missing-donor-oracle");
+    rmSync(repoPath("owner/receiver-oracle"), { recursive: true, force: true });
+    await expect(cmdAbsorb("donor", "receiver")).rejects.toThrow("could not resolve receiver oracle path");
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #1800
- Introduces maw absorb command surface (was implicit assumption in issue)
- Copies donor psi memory into receiver via soul-sync, archives donor, then switches the active tmux client to the receiver
- No wake/xdg/config touches

## Validation
- bun run build
- bun run test:spec
- bun run test:default:safe
- bun run test:coverage
- 100% coverage held: 31130/31130 lines, 5217/5217 functions