### PR TITLE
release: v26.5.20-alpha.1624

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.19-alpha.739",
+  "version": "26.5.20-alpha.1624",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts v26.5.20-alpha.1624 on merge via calver-release.yml.\n\nRollup includes PR #1825 plus alpha hotfix layer 9 (278ca6fb) and the bring/smear/federation/boot/channel/capture/done/ls/talk-to/absorb crash-fix batch.\n\nWritten by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.