### PR TITLE
feat(discover): resolve peers from config and scout (#1808)

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,27 +1,27 @@
 # Coverage gap analysis
 
-Generated: 2026-05-20T08:25:24.638Z
+Generated: 2026-05-20T09:46:37.847Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: source-line-normalized Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 Excluded from Bun LCOV accounting: non-Bun-runtime AssemblyScript sources compiled to WebAssembly and covered by AssemblyScript harness tests instead of Bun line instrumentation.
 
-Overall line coverage: **100.0%** (31039/31039)
-Overall function coverage: **100.0%** (5193/5193)
+Overall line coverage: **100.0%** (31188/31189)
+Overall function coverage: **100.0%** (5234/5234)
 
 ## Module summary
 
 | Module | Files | Missing from LCOV | Lines | Functions | Branches |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| cli/dispatch | 93 | 0 | 100.0% (5684/5684) | 100.0% (877/877) | n/a (0/0) |
+| cli/dispatch | 94 | 0 | 100.0% (5784/5785) | 100.0% (906/906) | n/a (0/0) |
 | config/runtime | 19 | 0 | 100.0% (780/780) | 100.0% (135/135) | n/a (0/0) |
 | fleet | 19 | 0 | 100.0% (678/678) | 100.0% (108/108) | n/a (0/0) |
 | matcher | 3 | 0 | 100.0% (73/73) | 100.0% (18/18) | n/a (0/0) |
-| other | 173 | 5 | 100.0% (8613/8613) | 100.0% (1477/1477) | n/a (0/0) |
+| other | 174 | 5 | 100.0% (8659/8659) | 100.0% (1487/1487) | n/a (0/0) |
 | plugin dispatch | 15 | 1 | 100.0% (705/705) | 100.0% (91/91) | n/a (0/0) |
 | routing/aliases | 4 | 0 | 100.0% (431/431) | 100.0% (76/76) | n/a (0/0) |
-| transport | 28 | 0 | 100.0% (1695/1695) | 100.0% (452/452) | n/a (0/0) |
+| transport | 28 | 0 | 100.0% (1698/1698) | 100.0% (454/454) | n/a (0/0) |
 | vendor plugins | 245 | 2 | 100.0% (12380/12380) | 100.0% (1959/1959) | n/a (0/0) |
 
 ## Source handled outside Bun LCOV
@@ -36,6 +36,7 @@ Overall function coverage: **100.0%** (5193/5193)
 
 | Rank | Risk | Module | File | Uncovered | Line coverage | Function coverage | Note |
 | ---: | --- | --- | --- | ---: | ---: | ---: | --- |
+| 1 | critical | cli/dispatch | `src/commands/shared/federation-sync-cli.ts` | 1 | 98.9% | 100.0% | partial coverage |
 
 ## Critical files at or above the 80% line target
 
@@ -76,7 +77,7 @@ Overall function coverage: **100.0%** (5193/5193)
 | cli/dispatch | `src/commands/shared/federation-diff.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/federation-fetch.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/federation-identity.ts` | 100.0% | 100.0% |
-| cli/dispatch | `src/commands/shared/federation-sync-cli.ts` | 100.0% | 100.0% |
+| cli/dispatch | `src/commands/shared/federation-sync-cli.ts` | 98.9% | 100.0% |
 | cli/dispatch | `src/commands/shared/federation-sync.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/federation.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/fleet-doctor-checks-repo.ts` | 100.0% | 100.0% |
@@ -94,6 +95,7 @@ Overall function coverage: **100.0%** (5193/5193)
 | cli/dispatch | `src/commands/shared/fleet-wake.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/fleet.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/pane-target-resolver.ts` | 100.0% | 100.0% |
+| cli/dispatch | `src/commands/shared/peer-sources.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/plugin-create-as.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/plugin-create-cmd.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/plugin-create-rust.ts` | 100.0% | 100.0% |
@@ -210,7 +212,7 @@ Overall function coverage: **100.0%** (5193/5193)
 
 ## Critical gaps to prioritize
 
-No critical files appeared in the top 20 uncovered files.
+- `src/commands/shared/federation-sync-cli.ts` (cli/dispatch): 1 uncovered lines, 98.9% line coverage.
 
 ## Prioritization guidance
 

--- a/src/commands/plugins/discover/index.ts
+++ b/src/commands/plugins/discover/index.ts
@@ -1,0 +1,73 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { loadConfig } from "../../../config";
+import {
+  formatPeerSources,
+  parsePeerSourceMode,
+  resolvePeerSources,
+} from "../../shared/peer-sources";
+
+export const command = {
+  name: "discover",
+  description: "List configured and discovered federation peers.",
+};
+
+function cliArgs(ctx: InvokeContext): string[] {
+  return ctx.source === "cli" && Array.isArray(ctx.args) ? ctx.args : [];
+}
+
+function argsObject(ctx: InvokeContext): Record<string, unknown> {
+  return ctx.source !== "cli" && ctx.args && !Array.isArray(ctx.args)
+    ? ctx.args as Record<string, unknown>
+    : {};
+}
+
+function readOption(args: string[], name: string): string | undefined {
+  const inline = args.find((arg) => arg.startsWith(`${name}=`));
+  if (inline) return inline.slice(name.length + 1);
+  const idx = args.indexOf(name);
+  if (idx < 0) return undefined;
+  const value = args[idx + 1];
+  return value && !value.startsWith("--") ? value : undefined;
+}
+
+function boolish(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    const v = value.toLowerCase();
+    if (v === "1" || v === "true" || v === "yes" || v === "on") return true;
+    if (v === "0" || v === "false" || v === "no" || v === "off") return false;
+  }
+  return undefined;
+}
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const args = cliArgs(ctx);
+  const query = argsObject(ctx);
+  const logs: string[] = [];
+  const emit = (...values: unknown[]) => {
+    if (ctx.writer) ctx.writer(...values);
+    else logs.push(values.map(String).join(" "));
+  };
+
+  const peerSourceRaw = readOption(args, "--peers")
+    ?? (typeof query.peers === "string" ? query.peers : undefined);
+  const mode = parsePeerSourceMode(peerSourceRaw, "both");
+  if (!mode) {
+    return {
+      ok: false,
+      error: "invalid_peer_source",
+      output: "usage: maw discover [--peers config|scout|both] [--json]",
+    };
+  }
+
+  const json = args.includes("--json") || boolish(query.json) === true;
+  const result = await resolvePeerSources(loadConfig(), mode);
+  emit(json ? JSON.stringify({
+    ok: true,
+    mode: result.mode,
+    total: result.peers.length,
+    peers: result.peers,
+    warnings: result.warnings,
+  }, null, 2) : formatPeerSources(result));
+  return { ok: true, output: logs.join("\n") || undefined };
+}

--- a/src/commands/plugins/discover/plugin.json
+++ b/src/commands/plugins/discover/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "discover",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "List configured and discovered federation peers.",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "discover",
+    "help": "maw discover [--peers config|scout|both] [--json]",
+    "flags": {
+      "--peers": "string",
+      "--json": "boolean"
+    }
+  },
+  "weight": 10
+}

--- a/src/commands/plugins/federation/index.ts
+++ b/src/commands/plugins/federation/index.ts
@@ -5,6 +5,15 @@ export const command = {
   description: "Multi-node federation status and sync.",
 };
 
+function readOption(args: string[], name: string): string | undefined {
+  const inline = args.find((arg) => arg.startsWith(`${name}=`));
+  if (inline) return inline.slice(name.length + 1);
+  const idx = args.indexOf(name);
+  if (idx < 0) return undefined;
+  const value = args[idx + 1];
+  return value && !value.startsWith("--") ? value : undefined;
+}
+
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
   const logs: string[] = [];
   const origLog = console.log;
@@ -21,8 +30,21 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
   try {
     const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
     const sub = args[0]?.toLowerCase();
+    const { parsePeerSourceMode } = await import("../../shared/peer-sources");
+    const peerSourceRaw = readOption(args, "--peers");
+    const peerSource = parsePeerSourceMode(peerSourceRaw, "both");
+    if (!peerSource) {
+      return { ok: false, error: "usage: --peers config|scout|both" };
+    }
 
-    if (!sub || sub === "status" || sub === "ls") {
+    if (sub === "--help" || sub === "-h" || sub === "help") {
+      return {
+        ok: false,
+        error: "usage: maw federation <status|sync> [--verify|--dry-run|--check|--prune|--force|--json|--peers config|scout|both]",
+      };
+    }
+
+    if (!sub || sub === "status" || sub === "ls" || sub.startsWith("--")) {
       if (args.includes("--verify")) {
         const { cmdFederationStatusVerify } = await import("../../shared/federation");
         const res = await cmdFederationStatusVerify();
@@ -31,7 +53,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         }
       } else {
         const { cmdFederationStatus } = await import("../../shared/federation");
-        await cmdFederationStatus();
+        await cmdFederationStatus({ peerSourceMode: peerSource });
       }
     } else if (sub === "sync") {
       const { cmdFederationSync } = await import("../../shared/federation-sync");
@@ -41,11 +63,12 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         prune: args.includes("--prune"),
         force: args.includes("--force"),
         json: args.includes("--json"),
+        peers: peerSource,
       });
     } else {
       return {
         ok: false,
-        error: "usage: maw federation <status|sync> [--verify|--dry-run|--check|--prune|--force|--json]",
+        error: "usage: maw federation <status|sync> [--verify|--dry-run|--check|--prune|--force|--json|--peers config|scout|both]",
       };
     }
 

--- a/src/commands/plugins/federation/plugin.json
+++ b/src/commands/plugins/federation/plugin.json
@@ -10,14 +10,15 @@
     "aliases": [
       "fed"
     ],
-    "help": "maw federation <status|sync> [--dry-run|--check|--prune|--force|--json]",
+    "help": "maw federation <status|sync> [--dry-run|--check|--prune|--force|--json] [--peers config|scout|both]",
     "flags": {
       "--dry-run": "boolean",
       "--check": "boolean",
       "--prune": "boolean",
       "--force": "boolean",
       "--verify": "boolean",
-      "--json": "boolean"
+      "--json": "boolean",
+      "--peers": "string"
     }
   },
   "weight": 10

--- a/src/commands/shared/federation-sync-cli.ts
+++ b/src/commands/shared/federation-sync-cli.ts
@@ -7,6 +7,11 @@ import type { MawConfig } from "../../config";
 import { fetchPeerIdentities } from "./federation-fetch";
 import { computeSyncDiff } from "./federation-diff";
 import { applySyncDiff } from "./federation-apply";
+import {
+  peerTargetsToConfigs,
+  resolvePeerSources,
+  type PeerSourceMode,
+} from "./peer-sources";
 
 const C = {
   red: "\x1b[31m",
@@ -24,6 +29,7 @@ export interface SyncOptions {
   prune?: boolean;
   force?: boolean;
   json?: boolean;
+  peers?: PeerSourceMode;
 }
 
 export interface FederationSyncDeps {
@@ -31,6 +37,7 @@ export interface FederationSyncDeps {
   fetchPeerIdentities: typeof fetchPeerIdentities;
   computeSyncDiff: typeof computeSyncDiff;
   applySyncDiff: typeof applySyncDiff;
+  resolvePeerSources: typeof resolvePeerSources;
   log: (...args: unknown[]) => void;
   exit: (code?: number) => never;
 }
@@ -41,6 +48,7 @@ export function federationSyncDeps(overrides: Partial<FederationSyncDeps> = {}):
     fetchPeerIdentities,
     computeSyncDiff,
     applySyncDiff,
+    resolvePeerSources,
     log: (...args: unknown[]) => console.log(...args),
     exit: (code?: number): never => process.exit(code),
     ...overrides,
@@ -64,16 +72,26 @@ export async function cmdFederationSync(
   const io = federationSyncDeps(deps);
   const config = io.loadConfig();
   const localNode = config.node || "local";
-  const peers = config.namedPeers || [];
+  const peerSource = await io.resolvePeerSources(config, opts.peers ?? "config");
+  const peers = peerTargetsToConfigs(peerSource.peers);
   const agents = config.agents || {};
 
   if (peers.length === 0) {
     if (opts.json) {
-      io.log(JSON.stringify({ node: localNode, diff: null, reason: "no peers" }));
+      io.log(JSON.stringify({
+        node: localNode,
+        diff: null,
+        reason: "no peers",
+        ...(peerSource.warnings.length > 0 ? { peerWarnings: peerSource.warnings } : {}),
+      }));
       io.exit(0);
     }
     io.log();
-    io.log(`  ${C.gray}no namedPeers configured — nothing to sync${C.reset}`);
+    for (const warning of peerSource.warnings) {
+      io.log(`  ${C.yellow}!${C.reset} ${C.gray}${warning}${C.reset}`);
+    }
+    const sourceLabel = (opts.peers ?? "config") === "config" ? "namedPeers configured" : "peers configured or discovered";
+    io.log(`  ${C.gray}no ${sourceLabel} — nothing to sync${C.reset}`);
     io.log();
     io.exit(0);
   }
@@ -82,12 +100,21 @@ export async function cmdFederationSync(
   const diff = io.computeSyncDiff(agents, identities, localNode);
 
   if (opts.json) {
-    io.log(JSON.stringify({ node: localNode, diff, dryRun: !!opts.dryRun }, null, 2));
+    io.log(JSON.stringify({
+      node: localNode,
+      diff,
+      dryRun: !!opts.dryRun,
+      ...(peerSource.warnings.length > 0 ? { peerWarnings: peerSource.warnings } : {}),
+    }, null, 2));
     const dirty = diff.add.length + diff.stale.length + diff.conflict.length > 0;
     io.exit(opts.check && dirty ? 1 : 0);
   }
 
   io.log();
+  for (const warning of peerSource.warnings) {
+    io.log(`  ${C.yellow}!${C.reset} ${C.gray}${warning}${C.reset}`);
+  }
+  if (peerSource.warnings.length > 0) io.log();
   io.log(
     `  ${C.blue}${C.bold}🔄 Federation Sync${C.reset}  ${C.gray}node: ${localNode} · ${peers.length} peers · ${Object.keys(agents).length} agents${C.reset}`,
   );

--- a/src/commands/shared/federation.ts
+++ b/src/commands/shared/federation.ts
@@ -1,7 +1,8 @@
-import { getFederationStatus, getPeers, curlFetch, listSessions } from "../../sdk";
+import { getFederationStatus, curlFetch, listSessions } from "../../sdk";
 import { loadConfig, type MawConfig } from "../../config";
 import { getFederationStatusSymmetric, type PeerStatus } from "../../core/transport/peers";
 import type { Session } from "../../core/runtime/find-window";
+import { resolvePeerSources, type PeerSourceMode, type PeerTarget } from "./peer-sources";
 
 type LogFn = (message?: unknown, ...optionalParams: unknown[]) => void;
 type CurlFetch = typeof curlFetch;
@@ -16,9 +17,11 @@ type SymmetricStatus = {
 };
 
 export type FederationStatusDeps = {
+  peerSourceMode?: PeerSourceMode;
   getPeers?: () => string[];
   loadConfig?: () => MawConfig;
   getFederationStatus?: () => Promise<FederationStatus>;
+  resolvePeerSources?: typeof resolvePeerSources;
   listSessions?: () => Promise<Session[]>;
   curlFetch?: CurlFetch;
   log?: LogFn;
@@ -52,7 +55,9 @@ async function countLocalAgents(loadSessions: () => Promise<Session[]> = listSes
 }
 
 /** Build a human-readable label for a peer URL, preferring namedPeers.name. */
-function labelForPeer(url: string, named: { name: string; url: string }[]): string {
+function labelForPeer(url: string, named: { name: string; url: string }[], peers: PeerTarget[] = []): string {
+  const resolved = peers.find(p => p.url === url && p.name);
+  if (resolved?.name) return resolved.name;
   const match = named.find(p => p.url === url);
   if (match) return match.name;
   try {
@@ -64,8 +69,12 @@ function labelForPeer(url: string, named: { name: string; url: string }[]): stri
 
 /** maw federation status — show all nodes (local + peers) with connectivity + agent counts */
 export async function cmdFederationStatus(deps: FederationStatusDeps = {}) {
-  const peers = (deps.getPeers ?? getPeers)();
   const config = (deps.loadConfig ?? loadConfig)();
+  const resolved = deps.getPeers
+    ? { peers: deps.getPeers().map((url): PeerTarget => ({ url, source: "config" })), warnings: [] as string[] }
+    : await (deps.resolvePeerSources ?? resolvePeerSources)(config, deps.peerSourceMode ?? "both");
+  const peerTargets = resolved.peers;
+  const peers = peerTargets.map((peer) => peer.url);
   const named = config.namedPeers ?? [];
   const totalNodes = peers.length + 1; // +1 for local
   const localLabel = config.node ? `${config.node} (local)` : "local";
@@ -77,11 +86,16 @@ export async function cmdFederationStatus(deps: FederationStatusDeps = {}) {
     `\x1b[90m${totalNodes} node${totalNodes !== 1 ? "s" : ""} ` +
     `(1 local + ${peers.length} peer${peers.length !== 1 ? "s" : ""})\x1b[0m\n`
   );
+  for (const warning of resolved.warnings) {
+    log(`  \x1b[33m!\x1b[0m  \x1b[90m${warning}\x1b[0m`);
+  }
 
   // Fetch local + peer state in parallel
   const [localCount, { peers: statuses, localUrl, localReachable, localLatency }] = await Promise.all([
     countLocalAgents(deps.listSessions ?? listSessions),
-    (deps.getFederationStatus ?? getFederationStatus)(),
+    deps.getFederationStatus
+      ? deps.getFederationStatus()
+      : getFederationStatus({ peers: peerTargets, config }),
   ]);
 
   const effectiveLocalReachable = localReachable ?? true;
@@ -96,7 +110,7 @@ export async function cmdFederationStatus(deps: FederationStatusDeps = {}) {
 
   // No peers? Still show helpful hint.
   if (peers.length === 0) {
-    log("\n\x1b[90mNo peers configured. Add namedPeers[] to maw.config.json.\x1b[0m");
+    log("\n\x1b[90mNo peers configured or discovered. Add namedPeers[] to maw.config.json or run maw serve with discovery enabled.\x1b[0m");
     log('\x1b[90mExample: { "namedPeers": [{ "name": "other", "url": "http://other-host:3456" }] }\x1b[0m\n');
     return;
   }
@@ -120,7 +134,7 @@ export async function cmdFederationStatus(deps: FederationStatusDeps = {}) {
       ? `\x1b[32mreachable\x1b[0m  \x1b[90m${latency}ms · ${agentCount} agent${agentCount !== 1 ? "s" : ""}\x1b[0m`
       : "\x1b[31munreachable\x1b[0m";
 
-    const label = labelForPeer(url, named);
+    const label = labelForPeer(url, named, peerTargets);
     log(`  ${dot}  \x1b[37m${label}\x1b[0m  ${status}`);
     log(`     \x1b[90m${url}\x1b[0m`);
   }

--- a/src/commands/shared/peer-sources.ts
+++ b/src/commands/shared/peer-sources.ts
@@ -1,0 +1,150 @@
+import type { MawConfig, PeerConfig } from "../../config";
+import type {
+  DiscoveryError,
+  DiscoveryResponse,
+  DiscoveryRow,
+} from "../../vendor/mpr-plugins/peers/discovered";
+
+export type PeerSourceMode = "config" | "scout" | "both";
+export type PeerSourceKind = "config" | "scout";
+
+export interface PeerTarget {
+  name?: string;
+  url: string;
+  source: PeerSourceKind;
+  node?: string;
+  oracle?: string;
+}
+
+export interface PeerSourceResult {
+  mode: PeerSourceMode;
+  peers: PeerTarget[];
+  warnings: string[];
+}
+
+export interface PeerSourceDeps {
+  fetchDiscoveries?: (opts?: { all?: boolean; limit?: number }) => Promise<DiscoveryResponse | DiscoveryError>;
+}
+
+export function parsePeerSourceMode(value: unknown, fallback: PeerSourceMode = "both"): PeerSourceMode | null {
+  if (value == null || value === "") return fallback;
+  if (value === "config" || value === "scout" || value === "both") return value;
+  return null;
+}
+
+export function configuredPeerTargets(config: MawConfig): PeerTarget[] {
+  const flat = (config.peers ?? []).map((url) => ({ url, source: "config" as const }));
+  const named = (config.namedPeers ?? []).map((peer) => ({
+    name: peer.name,
+    url: peer.url,
+    source: "config" as const,
+  }));
+  return dedupePeerTargets([...flat, ...named]);
+}
+
+export async function resolvePeerSources(
+  config: MawConfig,
+  mode: PeerSourceMode = "both",
+  deps: PeerSourceDeps = {},
+): Promise<PeerSourceResult> {
+  const configPeers = mode === "scout" ? [] : configuredPeerTargets(config);
+  const warnings: string[] = [];
+  let scoutPeers: PeerTarget[] = [];
+
+  if (mode === "scout" || mode === "both") {
+    const fetchDiscoveries = deps.fetchDiscoveries ?? defaultFetchDiscoveries;
+    const result = await fetchDiscoveries({ all: true });
+    if (result.ok) {
+      scoutPeers = result.peers.flatMap((peer) => {
+        const target = discoveredPeerTarget(peer);
+        return target ? [target] : [];
+      });
+    } else {
+      warnings.push(formatScoutWarning(result));
+    }
+  }
+
+  return {
+    mode,
+    peers: dedupePeerTargets(mode === "scout" ? scoutPeers : [...configPeers, ...scoutPeers]),
+    warnings,
+  };
+}
+
+export function peerTargetsToConfigs(peers: PeerTarget[]): PeerConfig[] {
+  return peers.map((peer) => ({
+    name: peer.name ?? peer.node ?? hostLabel(peer.url),
+    url: peer.url,
+  }));
+}
+
+export function formatPeerSources(result: PeerSourceResult): string {
+  if (result.peers.length === 0) {
+    return result.warnings.length > 0
+      ? `no peers discovered or configured\n${result.warnings.map((w) => `warning: ${w}`).join("\n")}`
+      : "no peers discovered or configured";
+  }
+
+  const header = ["source", "name", "node", "oracle", "url"];
+  const rows = result.peers.map((peer) => [
+    peer.source,
+    peer.name ?? "-",
+    peer.node ?? "-",
+    peer.oracle ?? "-",
+    peer.url,
+  ]);
+  const widths = header.map((h, i) => Math.max(h.length, ...rows.map((r) => r[i].length)));
+  const fmt = (cols: string[]) => cols.map((c, i) => c.padEnd(widths[i])).join("  ");
+  const lines = [fmt(header), fmt(widths.map((w) => "-".repeat(w))), ...rows.map(fmt)];
+  for (const warning of result.warnings) lines.push(`warning: ${warning}`);
+  return lines.join("\n");
+}
+
+export function dedupePeerTargets(peers: PeerTarget[]): PeerTarget[] {
+  const seen = new Set<string>();
+  const merged: PeerTarget[] = [];
+  for (const peer of peers) {
+    const key = peerKey(peer.url);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(peer);
+  }
+  return merged;
+}
+
+function discoveredPeerTarget(peer: DiscoveryRow): PeerTarget | null {
+  const url = peer.locators.find(isHttpUrl);
+  if (!url) return null;
+  return {
+    name: peer.node || peer.host || undefined,
+    url,
+    source: "scout",
+    node: peer.node || undefined,
+    oracle: peer.oracle || undefined,
+  };
+}
+
+function isHttpUrl(value: string): boolean {
+  return /^https?:\/\//i.test(value);
+}
+
+function peerKey(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
+function hostLabel(url: string): string {
+  try {
+    return new URL(url).host || url;
+  } catch {
+    return url;
+  }
+}
+
+function formatScoutWarning(result: DiscoveryError): string {
+  return `scout unavailable (${result.error}${result.hint ? `: ${result.hint}` : ""})`;
+}
+
+async function defaultFetchDiscoveries(opts?: { all?: boolean; limit?: number }): Promise<DiscoveryResponse | DiscoveryError> {
+  const { fetchDiscoveries } = await import("../../vendor/mpr-plugins/peers/discovered");
+  return fetchDiscoveries(opts);
+}

--- a/src/core/transport/peers.ts
+++ b/src/core/transport/peers.ts
@@ -38,6 +38,16 @@ export interface PeerStatus {
 /** Clock drift warning threshold — 3 minutes (early warning before 5-min HMAC cutoff) (#268) */
 const CLOCK_WARN_MS = 3 * 60 * 1000;
 
+export interface FederationPeerInput {
+  url: string;
+  name?: string;
+}
+
+export interface FederationStatusOptions {
+  peers?: FederationPeerInput[];
+  config?: ReturnType<typeof loadConfig>;
+}
+
 /**
  * Check if a peer is reachable by making a GET /api/sessions request.
  *
@@ -179,7 +189,7 @@ export async function getAggregatedSessions(localSessions: Session[]): Promise<(
 /**
  * Get federation status — list peers and check connectivity + clock health (#268)
  */
-export async function getFederationStatus(): Promise<{
+export async function getFederationStatus(options: FederationStatusOptions = {}): Promise<{
   localUrl: string;
   localReachable: boolean;
   localLatency?: number;
@@ -192,10 +202,14 @@ export async function getFederationStatus(): Promise<{
     uptimeSeconds: number;
   };
 }> {
-  const config = loadConfig();
-  const peers = getPeers();
+  const config = options.config ?? loadConfig();
+  const peerInputs = options.peers ?? getPeers().map((url) => ({ url }));
+  const peers = peerInputs.map((peer) => peer.url);
   const peerNameByUrl = new Map((config.namedPeers ?? []).map(p => [p.url, p.name]));
-  const port = loadConfig().port ?? 3456;
+  for (const peer of peerInputs) {
+    if (peer.name && !peerNameByUrl.has(peer.url)) peerNameByUrl.set(peer.url, peer.name);
+  }
+  const port = config.port ?? 3456;
   const localUrl = `http://localhost:${port}`;
 
   const [localProbe, rawStatuses] = await Promise.all([

--- a/test/isolated/discover-plugin-peer-sources.test.ts
+++ b/test/isolated/discover-plugin-peer-sources.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { mockConfigModule } from "../helpers/mock-config";
+import type { DiscoveryError, DiscoveryResponse } from "../../src/vendor/mpr-plugins/peers/discovered";
+
+const configPath = import.meta.resolve("../../src/config");
+const discoveredPath = import.meta.resolve("../../src/vendor/mpr-plugins/peers/discovered");
+
+let configValue: Record<string, unknown> = {};
+let discoveryResult: DiscoveryResponse | DiscoveryError;
+let fetchCalls: Array<Record<string, unknown> | undefined> = [];
+
+mock.module(configPath, () => ({
+  ...mockConfigModule(() => configValue as never),
+}));
+
+mock.module(discoveredPath, () => ({
+  fetchDiscoveries: async (opts?: Record<string, unknown>) => {
+    fetchCalls.push(opts);
+    return discoveryResult;
+  },
+}));
+
+const { command, default: handler } = await import("../../src/commands/plugins/discover/index.ts?discover-plugin-peer-sources");
+
+function discovery(url: string, node = "scout-node"): DiscoveryResponse {
+  return {
+    ok: true,
+    total: 1,
+    shown: 1,
+    filtered: false,
+    peers: [{
+      zid: "z1",
+      node,
+      oracle: "mawjs",
+      host: "scout-host",
+      locators: [url],
+      capabilities: ["send"],
+      oracles: ["mawjs"],
+      firstSeen: "2026-05-20T00:00:00.000Z",
+      lastSeen: "2026-05-20T00:00:01.000Z",
+      seenRel: "now",
+      paired: false,
+    }],
+  };
+}
+
+beforeEach(() => {
+  configValue = {
+    peers: ["http://config:3456"],
+    namedPeers: [{ name: "named", url: "http://named:3456" }],
+  };
+  discoveryResult = discovery("http://scout:3456");
+  fetchCalls = [];
+});
+
+describe("discover plugin peer-source integration (#1808)", () => {
+  test("exports command metadata", () => {
+    expect(command).toEqual({
+      name: "discover",
+      description: "List configured and discovered federation peers.",
+    });
+  });
+
+  test("rejects invalid peer-source mode before loading peers", async () => {
+    const result = await handler({ source: "cli", args: ["--peers", "bogus"] } as any);
+
+    expect(result).toEqual({
+      ok: false,
+      error: "invalid_peer_source",
+      output: "usage: maw discover [--peers config|scout|both] [--json]",
+    });
+    expect(fetchCalls).toEqual([]);
+  });
+
+  test("renders text output for inline scout mode", async () => {
+    const result = await handler({ source: "cli", args: ["--peers=scout"] } as any);
+
+    expect(fetchCalls).toEqual([{ all: true }]);
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("scout-node");
+    expect(result.output).toContain("http://scout:3456");
+  });
+
+  test("renders config-only JSON without calling scout", async () => {
+    const result = await handler({ source: "cli", args: ["--peers", "config", "--json"] } as any);
+
+    expect(fetchCalls).toEqual([]);
+    expect(result.ok).toBe(true);
+    const parsed = JSON.parse(result.output ?? "{}");
+    expect(parsed.mode).toBe("config");
+    expect(parsed.total).toBe(2);
+    expect(parsed.peers.map((peer: { url: string }) => peer.url)).toEqual(["http://config:3456", "http://named:3456"]);
+  });
+
+  test("API source writes JSON and defaults to both mode", async () => {
+    const writes: string[] = [];
+
+    const result = await handler({
+      source: "api",
+      args: { json: true },
+      writer: (...args: unknown[]) => writes.push(args.map(String).join(" ")),
+    } as any);
+
+    expect(result).toEqual({ ok: true, output: undefined });
+    expect(fetchCalls).toEqual([{ all: true }]);
+    const parsed = JSON.parse(writes[0]);
+    expect(parsed.mode).toBe("both");
+    expect(parsed.total).toBe(3);
+  });
+
+  test("API source accepts string false json and renders warnings in text", async () => {
+    const writes: string[] = [];
+    discoveryResult = {
+      ok: false,
+      error: "daemon_unreachable",
+      hint: "is maw serve running?",
+    };
+
+    const result = await handler({
+      source: "api",
+      args: { peers: "both", json: "off" },
+      writer: (...args: unknown[]) => writes.push(args.map(String).join(" ")),
+    } as any);
+
+    expect(result).toEqual({ ok: true, output: undefined });
+    expect(writes.join("\n")).toContain("warning: scout unavailable");
+  });
+});

--- a/test/isolated/federation-index-next-coverage.test.ts
+++ b/test/isolated/federation-index-next-coverage.test.ts
@@ -3,15 +3,15 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 const federationPath = import.meta.resolve("../../src/commands/shared/federation.ts");
 const federationSyncPath = import.meta.resolve("../../src/commands/shared/federation-sync.ts");
 
-let statusCalls = 0;
+let statusCalls: Array<Record<string, unknown> | undefined> = [];
 let verifyCalls = 0;
-let syncCalls: Array<Record<string, boolean>> = [];
+let syncCalls: Array<Record<string, unknown>> = [];
 let verifyResult = { ok: true };
 let statusThrows: Error | null = null;
 
 mock.module(federationPath, () => ({
-  cmdFederationStatus: async () => {
-    statusCalls += 1;
+  cmdFederationStatus: async (opts?: Record<string, unknown>) => {
+    statusCalls.push(opts);
     if (statusThrows) throw statusThrows;
     console.log("federation status ok");
     console.error("federation status stderr");
@@ -24,7 +24,7 @@ mock.module(federationPath, () => ({
 }));
 
 mock.module(federationSyncPath, () => ({
-  cmdFederationSync: async (opts: Record<string, boolean>) => {
+  cmdFederationSync: async (opts: Record<string, unknown>) => {
     syncCalls.push(opts);
     console.log("federation sync ok");
   },
@@ -36,7 +36,7 @@ const federationPlugin = await import(
 const handler = federationPlugin.default;
 
 beforeEach(() => {
-  statusCalls = 0;
+  statusCalls = [];
   verifyCalls = 0;
   syncCalls = [];
   verifyResult = { ok: true };
@@ -58,7 +58,7 @@ describe("federation plugin index dispatch", () => {
       description: "Multi-node federation status and sync.",
     });
     expect(result).toEqual({ ok: true, output: undefined });
-    expect(statusCalls).toBe(1);
+    expect(statusCalls).toEqual([{ peerSourceMode: "both" }]);
     expect(written).toEqual(["federation status ok", "federation status stderr"]);
   });
 
@@ -92,6 +92,7 @@ describe("federation plugin index dispatch", () => {
       prune: true,
       force: true,
       json: true,
+      peers: "both",
     }]);
   });
 
@@ -100,7 +101,7 @@ describe("federation plugin index dispatch", () => {
 
     expect(result).toEqual({
       ok: false,
-      error: "usage: maw federation <status|sync> [--verify|--dry-run|--check|--prune|--force|--json]",
+      error: "usage: maw federation <status|sync> [--verify|--dry-run|--check|--prune|--force|--json|--peers config|scout|both]",
     });
 
     statusThrows = new Error("status exploded");
@@ -111,5 +112,21 @@ describe("federation plugin index dispatch", () => {
       error: "status exploded",
       output: undefined,
     });
+  });
+
+  test("accepts --peers for status/sync and rejects invalid peer source modes", async () => {
+    let result = await handler({ source: "cli", args: ["--peers=scout"] } as any);
+
+    expect(result).toEqual({ ok: true, output: "federation status ok\nfederation status stderr" });
+    expect(statusCalls.at(-1)).toEqual({ peerSourceMode: "scout" });
+
+    result = await handler({ source: "cli", args: ["sync", "--peers", "config"] } as any);
+
+    expect(result).toEqual({ ok: true, output: "federation sync ok" });
+    expect(syncCalls.at(-1)?.peers).toBe("config");
+
+    result = await handler({ source: "cli", args: ["status", "--peers", "bogus"] } as any);
+
+    expect(result).toEqual({ ok: false, error: "usage: --peers config|scout|both" });
   });
 });

--- a/test/isolated/federation-status-peer-sources.test.ts
+++ b/test/isolated/federation-status-peer-sources.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { mockConfigModule } from "../helpers/mock-config";
+
+const sdkPath = import.meta.resolve("../../src/sdk/index.ts");
+const configPath = import.meta.resolve("../../src/config");
+
+let configValue: Record<string, unknown> = {};
+let statusCalls: Array<Record<string, unknown> | undefined> = [];
+
+mock.module(configPath, () => ({
+  ...mockConfigModule(() => configValue as never),
+}));
+
+mock.module(sdkPath, () => ({
+  listSessions: async () => [{ name: "local", windows: [{ index: 0, name: "main", active: true }] }],
+  curlFetch: async () => ({ ok: true, status: 200, data: [] }),
+  getFederationStatus: async (opts?: { peers?: Array<{ name?: string; url: string }> }) => {
+    statusCalls.push(opts as Record<string, unknown> | undefined);
+    return {
+      localUrl: "http://localhost:4567",
+      localReachable: true,
+      localLatency: 3,
+      peers: (opts?.peers ?? []).map((peer) => ({
+        url: peer.url,
+        peerName: peer.name,
+        reachable: true,
+        latency: 5,
+      })),
+      totalPeers: opts?.peers?.length ?? 0,
+      reachablePeers: opts?.peers?.length ?? 0,
+      clockHealth: { clockUtc: "2026-05-20T00:00:00.000Z", timezone: "UTC", uptimeSeconds: 1 },
+    };
+  },
+}));
+
+const { cmdFederationStatus } = await import("../../src/commands/shared/federation.ts?federation-status-peer-sources");
+
+beforeEach(() => {
+  configValue = { node: "m5", port: 4567, namedPeers: [] };
+  statusCalls = [];
+});
+
+describe("cmdFederationStatus peer-source resolver integration (#1808)", () => {
+  test("uses resolver peers, logs scout fallback warnings, and passes ephemeral names into status", async () => {
+    const lines: string[] = [];
+
+    await cmdFederationStatus({
+      resolvePeerSources: async () => ({
+        mode: "both",
+        warnings: ["scout unavailable (daemon_unreachable)"],
+        peers: [{ name: "scout-node", url: "http://scout:3456", source: "scout" }],
+      }),
+      log: (message?: unknown) => lines.push(String(message ?? "")),
+    });
+
+    expect(statusCalls).toHaveLength(1);
+    expect(statusCalls[0]?.peers).toEqual([{ name: "scout-node", url: "http://scout:3456", source: "scout" }]);
+    const out = lines.join("\n").replace(/\x1b\[[0-9;]*m/g, "");
+    expect(out).toContain("scout unavailable");
+    expect(out).toContain("scout-node  reachable");
+    expect(out).toContain("2/2 reachable");
+  });
+});

--- a/test/isolated/federation-sync-cli.test.ts
+++ b/test/isolated/federation-sync-cli.test.ts
@@ -842,4 +842,40 @@ describe("cmdFederationSync — fetch wiring", () => {
 
     expect(outs.join("\n")).toContain("0 agents");
   });
+
+  test("--peers both can feed ephemeral scout peers and preserve scout warnings in JSON", async () => {
+    configStore = { node: "white", namedPeers: [], agents: {} };
+    fetchReturn = [peer("scout-node", "scout-node", [])];
+
+    await run(() => cmdFederationSync({ json: true, peers: "both" }, captureSave, {
+      resolvePeerSources: async () => ({
+        mode: "both",
+        warnings: ["scout unavailable (daemon_unreachable)"],
+        peers: [{ name: "scout-node", url: "https://scout.example", source: "scout" }],
+      }),
+    }));
+
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0].peers).toEqual([{ name: "scout-node", url: "https://scout.example" }]);
+    const parsed = JSON.parse(outs[0]);
+    expect(parsed.peerWarnings).toEqual(["scout unavailable (daemon_unreachable)"]);
+  });
+
+  test("--peers both text mode warns and exits cleanly when no config or scout peers exist", async () => {
+    configStore = { node: "white", namedPeers: [], agents: {} };
+
+    await run(() => cmdFederationSync({ peers: "both" }, captureSave, {
+      resolvePeerSources: async () => ({
+        mode: "both",
+        warnings: ["scout unavailable (daemon_unreachable)"],
+        peers: [],
+      }),
+    }));
+
+    const joined = outs.join("\n");
+    expect(exitCode).toBe(0);
+    expect(joined).toContain("scout unavailable");
+    expect(joined).toContain("no peers configured or discovered — nothing to sync");
+    expect(fetchCalls).toEqual([]);
+  });
 });

--- a/test/peers-transport-coverage.test.ts
+++ b/test/peers-transport-coverage.test.ts
@@ -210,6 +210,41 @@ describe("federation status", () => {
     ]);
   });
 
+  test("getFederationStatus accepts ephemeral peer inputs without mutating config", async () => {
+    config = {
+      node: "m5",
+      port: 4567,
+      peers: [],
+      namedPeers: [],
+    };
+    responses = [
+      { match: "localhost:4567/api/sessions", res: { ok: true, status: 200, data: [] } },
+      { match: "localhost:4567/api/identity", res: { ok: true, status: 200, data: { node: "m5", agents: ["local"] } } },
+      { match: "scout:3456/api/sessions", res: { ok: true, status: 200, data: [] } },
+      { match: "scout:3456/api/identity", res: { ok: true, status: 200, data: { node: "scout", agents: ["pulse"] } } },
+    ];
+
+    const status = await getFederationStatus({
+      config,
+      peers: [{ name: "scout-node", url: "http://scout:3456" }],
+    });
+
+    expect(config.namedPeers).toEqual([]);
+    expect(status.totalPeers).toBe(1);
+    expect(status.peers).toEqual([
+      {
+        url: "http://scout:3456",
+        peerName: "scout-node",
+        reachable: true,
+        latency: 0,
+        node: "scout",
+        agents: ["pulse"],
+        clockDeltaMs: undefined,
+        clockWarning: undefined,
+      },
+    ]);
+  });
+
   test("getFederationStatus warns only when sessions succeed but identity fails", async () => {
     config.peers = ["http://identity-404:3456", "http://identity-throw:3456", "http://fully-down:3456"];
     responses = [

--- a/test/spec/peer-source-resolver.fixtures.json
+++ b/test/spec/peer-source-resolver.fixtures.json
@@ -1,0 +1,155 @@
+[
+  {
+    "name": "config mode returns configured flat and named peers without scouting",
+    "mode": "config",
+    "config": {
+      "peers": ["http://flat:3456"],
+      "namedPeers": [{ "name": "named", "url": "http://named:3456" }]
+    },
+    "discoveries": { "ok": false, "error": "should_not_call" },
+    "expected": {
+      "urls": ["http://flat:3456", "http://named:3456"],
+      "names": [null, "named"],
+      "sources": ["config", "config"],
+      "warnings": [],
+      "fetchCalls": 0
+    }
+  },
+  {
+    "name": "scout mode returns daemon discoveries as ephemeral peer targets",
+    "mode": "scout",
+    "config": {
+      "peers": ["http://flat:3456"],
+      "namedPeers": [{ "name": "named", "url": "http://named:3456" }]
+    },
+    "discoveries": {
+      "ok": true,
+      "total": 1,
+      "shown": 1,
+      "filtered": false,
+      "peers": [
+        {
+          "zid": "z1",
+          "node": "scout-node",
+          "oracle": "mawjs",
+          "host": "scout-host",
+          "locators": ["tcp/opaque", "http://scout:3456"],
+          "capabilities": ["send"],
+          "oracles": ["mawjs"],
+          "firstSeen": "2026-05-20T00:00:00.000Z",
+          "lastSeen": "2026-05-20T00:00:01.000Z",
+          "seenRel": "now",
+          "paired": false
+        }
+      ]
+    },
+    "expected": {
+      "urls": ["http://scout:3456"],
+      "names": ["scout-node"],
+      "sources": ["scout"],
+      "warnings": [],
+      "fetchCalls": 1
+    }
+  },
+  {
+    "name": "both mode keeps config first and dedupes scout duplicates by URL",
+    "mode": "both",
+    "config": {
+      "peers": ["http://dupe:3456/"],
+      "namedPeers": [{ "name": "named", "url": "http://named:3456" }]
+    },
+    "discoveries": {
+      "ok": true,
+      "total": 2,
+      "shown": 2,
+      "filtered": false,
+      "peers": [
+        {
+          "zid": "z-dupe",
+          "node": "dupe-node",
+          "oracle": "mawjs",
+          "host": "dupe-host",
+          "locators": ["http://dupe:3456"],
+          "capabilities": [],
+          "oracles": [],
+          "firstSeen": "2026-05-20T00:00:00.000Z",
+          "lastSeen": "2026-05-20T00:00:01.000Z",
+          "seenRel": "now",
+          "paired": false
+        },
+        {
+          "zid": "z-new",
+          "node": "new-node",
+          "oracle": "pulse",
+          "host": "new-host",
+          "locators": ["http://new:3456"],
+          "capabilities": [],
+          "oracles": [],
+          "firstSeen": "2026-05-20T00:00:00.000Z",
+          "lastSeen": "2026-05-20T00:00:01.000Z",
+          "seenRel": "now",
+          "paired": false
+        }
+      ]
+    },
+    "expected": {
+      "urls": ["http://dupe:3456/", "http://named:3456", "http://new:3456"],
+      "names": [null, "named", "new-node"],
+      "sources": ["config", "config", "scout"],
+      "warnings": [],
+      "fetchCalls": 1
+    }
+  },
+  {
+    "name": "both mode warns and falls back to config when scout fails",
+    "mode": "both",
+    "config": {
+      "namedPeers": [{ "name": "named", "url": "http://named:3456" }]
+    },
+    "discoveries": {
+      "ok": false,
+      "error": "daemon_unreachable",
+      "hint": "is maw serve running?"
+    },
+    "expected": {
+      "urls": ["http://named:3456"],
+      "names": ["named"],
+      "sources": ["config"],
+      "warnings": ["scout unavailable"],
+      "fetchCalls": 1
+    }
+  },
+  {
+    "name": "scout mode drops discoveries without HTTP locators",
+    "mode": "scout",
+    "config": {},
+    "discoveries": {
+      "ok": true,
+      "total": 1,
+      "shown": 1,
+      "filtered": false,
+      "peers": [
+        {
+          "zid": "z-opaque",
+          "node": "opaque",
+          "oracle": "mawjs",
+          "host": "opaque-host",
+          "locators": ["tcp/opaque"],
+          "capabilities": [],
+          "oracles": [],
+          "firstSeen": "2026-05-20T00:00:00.000Z",
+          "lastSeen": "2026-05-20T00:00:01.000Z",
+          "seenRel": "now",
+          "paired": false
+        }
+      ]
+    },
+    "expected": {
+      "urls": [],
+      "names": [],
+      "sources": [],
+      "warnings": [],
+      "fetchCalls": 1
+    }
+  }
+]

--- a/test/spec/peer-source-resolver.fixtures.test.ts
+++ b/test/spec/peer-source-resolver.fixtures.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import fixtures from "./peer-source-resolver.fixtures.json";
+import {
+  configuredPeerTargets,
+  dedupePeerTargets,
+  formatPeerSources,
+  parsePeerSourceMode,
+  peerTargetsToConfigs,
+  resolvePeerSources,
+  type PeerSourceMode,
+} from "../../src/commands/shared/peer-sources";
+import type { MawConfig } from "../../src/config";
+import type { DiscoveryError, DiscoveryResponse } from "../../src/vendor/mpr-plugins/peers/discovered";
+
+type Fixture = {
+  name: string;
+  mode: PeerSourceMode;
+  config: MawConfig;
+  discoveries: DiscoveryResponse | DiscoveryError;
+  expected: {
+    urls: string[];
+    names: Array<string | null>;
+    sources: string[];
+    warnings: string[];
+    fetchCalls: number;
+  };
+};
+
+describe("portable peer-source resolver fixtures (#1808)", () => {
+  for (const fixture of fixtures as Fixture[]) {
+    test(fixture.name, async () => {
+      const calls: unknown[] = [];
+      const result = await resolvePeerSources(fixture.config, fixture.mode, {
+        fetchDiscoveries: async (opts) => {
+          calls.push(opts);
+          return fixture.discoveries;
+        },
+      });
+
+      expect(result.mode).toBe(fixture.mode);
+      expect(result.peers.map((peer) => peer.url)).toEqual(fixture.expected.urls);
+      expect(result.peers.map((peer) => peer.name ?? null)).toEqual(fixture.expected.names);
+      expect(result.peers.map((peer) => peer.source)).toEqual(fixture.expected.sources);
+      for (const warning of fixture.expected.warnings) {
+        expect(result.warnings.join("\n")).toContain(warning);
+      }
+      expect(calls).toHaveLength(fixture.expected.fetchCalls);
+    });
+  }
+
+  test("parser accepts known modes, applies fallback, and rejects unknown modes", () => {
+    expect(parsePeerSourceMode(undefined)).toBe("both");
+    expect(parsePeerSourceMode("", "config")).toBe("config");
+    expect(parsePeerSourceMode("scout")).toBe("scout");
+    expect(parsePeerSourceMode("invalid")).toBeNull();
+  });
+
+  test("formatting and PeerConfig conversion cover empty, warning, and host-label paths", () => {
+    expect(formatPeerSources({ mode: "both", peers: [], warnings: [] })).toBe("no peers discovered or configured");
+    expect(formatPeerSources({ mode: "both", peers: [], warnings: ["scout unavailable"] })).toContain("warning: scout unavailable");
+
+    const deduped = dedupePeerTargets([
+      { url: "http://named:3456", name: "named", source: "config" },
+      { url: "http://named:3456/", name: "duplicate", source: "scout" },
+      { url: "not a url", source: "scout" },
+    ]);
+    expect(deduped).toHaveLength(2);
+    expect(peerTargetsToConfigs(deduped)).toEqual([
+      { name: "named", url: "http://named:3456" },
+      { name: "not a url", url: "not a url" },
+    ]);
+    expect(formatPeerSources({ mode: "both", peers: deduped, warnings: ["fallback"] })).toContain("warning: fallback");
+  });
+
+  test("configuredPeerTargets dedupes flat peers before named peers", () => {
+    expect(configuredPeerTargets({
+      peers: ["http://same:3456"],
+      namedPeers: [{ name: "same-name", url: "http://same:3456" }],
+    } as MawConfig)).toEqual([{ url: "http://same:3456", source: "config" }]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1808. Partial #1805.

- add a shared ephemeral peer-source resolver with config/scout/both modes
- add exact `maw discover` peer enumeration backed by config + zenoh-scout discoveries
- wire `maw federation --peers config|scout|both` and federation sync peer-source plumbing
- preserve config-first URL dedupe and avoid mutating namedPeers
- preserve the existing `maw federation --help` usage path while allowing flag-first `--peers` status

## Validation

- `bun run build`
- `bun run test:spec`
- `bun run test:default:safe`
- `bun run test:coverage` (533/533 isolated files passed; coverage badge 100.0% lines)

## Boundaries

- no `wake-maybe-split.ts` touches
- no XDG/config-state structure touches
- no persistent namedPeers mutation from scout discoveries