### PR TITLE
feat(discover): include tmux live state (#1831)

### DIFF
--- a/docs/testing/coverage-gap-analysis.md
+++ b/docs/testing/coverage-gap-analysis.md
@@ -1,24 +1,24 @@
 # Coverage gap analysis
 
-Generated: 2026-05-20T09:52:07.059Z
+Generated: 2026-05-20T10:26:10.246Z
 
 Input: `coverage/lcov.info`
 
 Coverage scope: source-line-normalized Bun LCOV plus zero-coverage accounting for tracked `src/**/*.ts` files absent from LCOV.
 Excluded from Bun LCOV accounting: non-Bun-runtime AssemblyScript sources compiled to WebAssembly and covered by AssemblyScript harness tests instead of Bun line instrumentation.
 
-Overall line coverage: **100.0%** (31312/31313)
-Overall function coverage: **100.0%** (5273/5273)
+Overall line coverage: **100.0%** (31403/31404)
+Overall function coverage: **100.0%** (5306/5306)
 
 ## Module summary
 
 | Module | Files | Missing from LCOV | Lines | Functions | Branches |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| cli/dispatch | 94 | 0 | 100.0% (5785/5786) | 100.0% (907/907) | n/a (0/0) |
+| cli/dispatch | 95 | 0 | 100.0% (5857/5858) | 100.0% (938/938) | n/a (0/0) |
 | config/runtime | 19 | 0 | 100.0% (780/780) | 100.0% (135/135) | n/a (0/0) |
-| fleet | 19 | 0 | 100.0% (678/678) | 100.0% (108/108) | n/a (0/0) |
+| fleet | 19 | 0 | 100.0% (680/680) | 100.0% (108/108) | n/a (0/0) |
 | matcher | 3 | 0 | 100.0% (73/73) | 100.0% (18/18) | n/a (0/0) |
-| other | 175 | 5 | 100.0% (8691/8691) | 100.0% (1501/1501) | n/a (0/0) |
+| other | 175 | 5 | 100.0% (8708/8708) | 100.0% (1503/1503) | n/a (0/0) |
 | plugin dispatch | 15 | 1 | 100.0% (705/705) | 100.0% (91/91) | n/a (0/0) |
 | routing/aliases | 4 | 0 | 100.0% (431/431) | 100.0% (76/76) | n/a (0/0) |
 | transport | 28 | 0 | 100.0% (1698/1698) | 100.0% (454/454) | n/a (0/0) |
@@ -72,6 +72,7 @@ Overall function coverage: **100.0%** (5273/5273)
 | cli/dispatch | `src/commands/shared/comm-send.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/comm.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/context-limit.ts` | 100.0% | 100.0% |
+| cli/dispatch | `src/commands/shared/discover-live-state.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/done.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/federation-apply.ts` | 100.0% | 100.0% |
 | cli/dispatch | `src/commands/shared/federation-diff.ts` | 100.0% | 100.0% |

--- a/src/commands/plugins/discover/index.ts
+++ b/src/commands/plugins/discover/index.ts
@@ -1,14 +1,22 @@
 import type { InvokeContext, InvokeResult } from "../../../plugin/types";
 import { loadConfig } from "../../../config";
 import {
+  formatTmuxLiveState,
+  markPeerTargetsLive,
+  resolveTmuxLiveState,
+  type PeerTargetWithLive,
+  type TmuxLiveStateResult,
+} from "../../shared/discover-live-state";
+import {
   formatPeerSources,
   parsePeerSourceMode,
   resolvePeerSources,
+  type PeerSourceMode,
 } from "../../shared/peer-sources";
 
 export const command = {
   name: "discover",
-  description: "List configured and discovered federation peers.",
+  description: "List configured/discovered federation peers and live tmux state.",
 };
 
 function cliArgs(ctx: InvokeContext): string[] {
@@ -56,18 +64,50 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     return {
       ok: false,
       error: "invalid_peer_source",
-      output: "usage: maw discover [--peers config|scout|both] [--json]",
+      output: "usage: maw discover [--peers config|scout|both] [--awake] [--json]",
     };
   }
 
   const json = args.includes("--json") || boolish(query.json) === true;
+  const awake = args.includes("--awake") || boolish(query.awake) === true;
   const result = await resolvePeerSources(loadConfig(), mode);
+  const includeLiveState = json || awake;
+  const liveState = includeLiveState
+    ? await resolveTmuxLiveState(result.peers)
+    : { source: "tmux" as const, live: [], warnings: [] };
+  const peersWithLive = markPeerTargetsLive(result.peers, liveState.live);
+  const visiblePeers = awake ? peersWithLive.filter((peer) => peer.awake) : peersWithLive;
+  const warnings = includeLiveState ? [...result.warnings, ...liveState.warnings] : result.warnings;
   emit(json ? JSON.stringify({
     ok: true,
     mode: result.mode,
-    total: result.peers.length,
-    peers: result.peers,
-    warnings: result.warnings,
-  }, null, 2) : formatPeerSources(result));
+    awake,
+    total: visiblePeers.length,
+    peers: visiblePeers,
+    liveTotal: liveState.live.length,
+    live: liveState.live,
+    warnings,
+  }, null, 2) : formatDiscoverText({
+    mode: result.mode,
+    peers: visiblePeers,
+    warnings,
+    liveState,
+    awake,
+  }));
   return { ok: true, output: logs.join("\n") || undefined };
+}
+
+function formatDiscoverText(input: {
+  mode: PeerSourceMode;
+  peers: PeerTargetWithLive[];
+  warnings: string[];
+  liveState: TmuxLiveStateResult;
+  awake: boolean;
+}): string {
+  if (input.awake) return formatTmuxLiveState(input.liveState);
+  return formatPeerSources({
+    mode: input.mode,
+    peers: input.peers,
+    warnings: input.warnings,
+  });
 }

--- a/src/commands/plugins/discover/plugin.json
+++ b/src/commands/plugins/discover/plugin.json
@@ -3,13 +3,14 @@
   "version": "1.0.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "List configured and discovered federation peers.",
+  "description": "List configured/discovered federation peers and live tmux state.",
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "discover",
-    "help": "maw discover [--peers config|scout|both] [--json]",
+    "help": "maw discover [--peers config|scout|both] [--awake] [--json]",
     "flags": {
       "--peers": "string",
+      "--awake": "boolean",
       "--json": "boolean"
     }
   },

--- a/src/commands/shared/discover-live-state.ts
+++ b/src/commands/shared/discover-live-state.ts
@@ -1,0 +1,182 @@
+import { basename } from "path";
+import { tmux, type TmuxPane } from "../../core/transport/tmux";
+import type { PeerTarget } from "./peer-sources";
+
+export type DiscoverLiveSource = "tmux";
+
+export interface TmuxPaneTargetParts {
+  session: string;
+  window: string;
+  pane: string;
+}
+
+export interface DiscoverLivePane extends TmuxPaneTargetParts {
+  source: DiscoverLiveSource;
+  id: string;
+  target: string;
+  command?: string;
+  title?: string;
+  pid?: number;
+  cwd?: string;
+  lastActivity?: number;
+  awake: true;
+  matches: string[];
+}
+
+export interface PeerTargetWithLive extends PeerTarget {
+  awake: boolean;
+  liveTargets: string[];
+  liveSessions: string[];
+}
+
+export interface TmuxLiveStateResult {
+  source: DiscoverLiveSource;
+  live: DiscoverLivePane[];
+  warnings: string[];
+}
+
+export interface TmuxLiveStateDeps {
+  listPanes?: () => Promise<TmuxPane[]>;
+}
+
+export function parseTmuxPaneTarget(target: string): TmuxPaneTargetParts | null {
+  const colon = target.indexOf(":");
+  const dot = target.lastIndexOf(".");
+  if (colon <= 0 || dot <= colon + 1 || dot === target.length - 1) return null;
+  return {
+    session: target.slice(0, colon),
+    window: target.slice(colon + 1, dot),
+    pane: target.slice(dot + 1),
+  };
+}
+
+export async function resolveTmuxLiveState(
+  peers: PeerTarget[] = [],
+  deps: TmuxLiveStateDeps = {},
+): Promise<TmuxLiveStateResult> {
+  const listPanes = deps.listPanes ?? (() => tmux.listPanes());
+  try {
+    const panes = await listPanes();
+    const live = panes
+      .map((pane) => tmuxPaneToLivePane(pane, peers))
+      .sort((a, b) => a.target.localeCompare(b.target));
+    return { source: "tmux", live, warnings: [] };
+  } catch (error) {
+    return {
+      source: "tmux",
+      live: [],
+      warnings: [`tmux unavailable (${errorMessage(error)})`],
+    };
+  }
+}
+
+export function markPeerTargetsLive(peers: PeerTarget[], live: DiscoverLivePane[]): PeerTargetWithLive[] {
+  return peers.map((peer) => {
+    const peerSignals = normalizedPeerSignals(peer);
+    const matching = live.filter((pane) =>
+      paneSignals(pane).some((signal) => peerSignals.has(signal))
+    );
+    return {
+      ...peer,
+      awake: matching.length > 0,
+      liveTargets: matching.map((pane) => pane.target),
+      liveSessions: [...new Set(matching.map((pane) => pane.session))],
+    };
+  });
+}
+
+export function formatTmuxLiveState(result: TmuxLiveStateResult): string {
+  if (result.live.length === 0) {
+    return result.warnings.length > 0
+      ? `no live tmux sessions/windows found\n${result.warnings.map((w) => `warning: ${w}`).join("\n")}`
+      : "no live tmux sessions/windows found";
+  }
+
+  const header = ["source", "session", "window", "pane", "command", "cwd", "matches"];
+  const rows = result.live.map((pane) => [
+    pane.source,
+    pane.session,
+    pane.window,
+    pane.pane,
+    pane.command ?? "-",
+    pane.cwd ?? "-",
+    pane.matches.length > 0 ? pane.matches.join(",") : "-",
+  ]);
+  const widths = header.map((h, i) => Math.max(h.length, ...rows.map((r) => r[i].length)));
+  const fmt = (cols: string[]) => cols.map((c, i) => c.padEnd(widths[i])).join("  ");
+  const lines = [fmt(header), fmt(widths.map((w) => "-".repeat(w))), ...rows.map(fmt)];
+  for (const warning of result.warnings) lines.push(`warning: ${warning}`);
+  return lines.join("\n");
+}
+
+function tmuxPaneToLivePane(pane: TmuxPane, peers: PeerTarget[]): DiscoverLivePane {
+  const parsed = parseTmuxPaneTarget(pane.target) ?? fallbackTargetParts(pane.target);
+  const live: DiscoverLivePane = {
+    source: "tmux",
+    id: pane.id,
+    target: pane.target,
+    session: parsed.session,
+    window: parsed.window,
+    pane: parsed.pane,
+    command: emptyToUndefined(pane.command),
+    title: emptyToUndefined(pane.title),
+    pid: pane.pid,
+    cwd: emptyToUndefined(pane.cwd),
+    lastActivity: pane.lastActivity,
+    awake: true,
+    matches: [],
+  };
+  const liveSignals = paneSignals(live);
+  live.matches = peers
+    .filter((peer) => {
+      const peerSignals = normalizedPeerSignals(peer);
+      return liveSignals.some((signal) => peerSignals.has(signal));
+    })
+    .map((peer) => peer.name ?? peer.node ?? peer.oracle ?? peer.url);
+  return live;
+}
+
+function fallbackTargetParts(target: string): TmuxPaneTargetParts {
+  const session = target.split(":")[0] || target;
+  return { session, window: "", pane: "" };
+}
+
+function paneSignals(pane: DiscoverLivePane): string[] {
+  return [
+    pane.session,
+    pane.window,
+    pane.title,
+    pane.cwd ? basename(pane.cwd) : undefined,
+  ].flatMap(normalizedAliases);
+}
+
+function normalizedPeerSignals(peer: PeerTarget): Set<string> {
+  return new Set([
+    peer.name,
+    peer.node,
+    peer.oracle,
+  ].flatMap(normalizedAliases));
+}
+
+function normalizedAliases(value: string | undefined): string[] {
+  const normalized = normalizeSignal(value);
+  if (!normalized) return [];
+  const aliases = new Set([normalized]);
+  aliases.add(normalized.replace(/^\d+-/, ""));
+  aliases.add(normalized.replace(/-oracle$/, ""));
+  aliases.add(normalized.replace(/^\d+-/, "").replace(/-oracle$/, ""));
+  return [...aliases].filter(Boolean);
+}
+
+function normalizeSignal(value: string | undefined): string {
+  return (value ?? "").trim().toLowerCase();
+}
+
+function emptyToUndefined(value: string | undefined): string | undefined {
+  const trimmed = (value ?? "").trim();
+  return trimmed || undefined;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/test/isolated/discover-live-state-coverage.test.ts
+++ b/test/isolated/discover-live-state-coverage.test.ts
@@ -1,0 +1,138 @@
+/** Targeted isolated coverage for src/commands/shared/discover-live-state.ts. */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { TmuxPane } from "../../src/core/transport/tmux";
+
+let panes: TmuxPane[] = [];
+
+mock.module(import.meta.resolve("../../src/core/transport/tmux"), () => ({
+  tmux: {
+    listPanes: async () => panes,
+  },
+}));
+
+const {
+  formatTmuxLiveState,
+  markPeerTargetsLive,
+  parseTmuxPaneTarget,
+  resolveTmuxLiveState,
+} = await import("../../src/commands/shared/discover-live-state");
+
+describe("discover live-state isolated coverage", () => {
+  beforeEach(() => {
+    panes = [];
+  });
+
+  test("default tmux source resolves pane targets, fallback targets, matches, and peer awake metadata", async () => {
+    panes = [
+      {
+        id: "%1",
+        command: "claude",
+        target: "101-mawjs-oracle:agent.0",
+        title: "MAWJS",
+        pid: 101,
+        cwd: "/repo/mawjs-oracle",
+        lastActivity: 123,
+      },
+      {
+        id: "%2",
+        command: "",
+        target: "scratch",
+        title: "",
+        cwd: "",
+      },
+    ];
+
+    const result = await resolveTmuxLiveState([
+      { name: "mawjs", url: "http://mawjs:3456", source: "config" },
+      { name: "sleeping", url: "http://sleeping:3456", source: "scout", oracle: "sleeping-oracle" },
+    ]);
+    const peers = markPeerTargetsLive(result.live.length ? [
+      { name: "mawjs", url: "http://mawjs:3456", source: "config" },
+      { name: "sleeping", url: "http://sleeping:3456", source: "scout", oracle: "sleeping-oracle" },
+    ] : [], result.live);
+
+    expect(result.source).toBe("tmux");
+    expect(result.warnings).toEqual([]);
+    expect(result.live.map((pane) => pane.target)).toEqual(["101-mawjs-oracle:agent.0", "scratch"]);
+    expect(result.live[0]).toMatchObject({
+      session: "101-mawjs-oracle",
+      window: "agent",
+      pane: "0",
+      command: "claude",
+      title: "MAWJS",
+      pid: 101,
+      cwd: "/repo/mawjs-oracle",
+      lastActivity: 123,
+      awake: true,
+      matches: ["mawjs"],
+    });
+    expect(result.live[1]).toMatchObject({
+      session: "scratch",
+      window: "",
+      pane: "",
+      command: undefined,
+      title: undefined,
+      cwd: undefined,
+      matches: [],
+    });
+    expect(peers).toEqual([
+      expect.objectContaining({
+        name: "mawjs",
+        awake: true,
+        liveTargets: ["101-mawjs-oracle:agent.0"],
+        liveSessions: ["101-mawjs-oracle"],
+      }),
+      expect.objectContaining({
+        name: "sleeping",
+        awake: false,
+        liveTargets: [],
+        liveSessions: [],
+      }),
+    ]);
+  });
+
+  test("parser and formatter cover invalid, empty, warning, and row paths", async () => {
+    expect(parseTmuxPaneTarget("demo:win.2")).toEqual({ session: "demo", window: "win", pane: "2" });
+    expect(parseTmuxPaneTarget(":win.2")).toBeNull();
+    expect(parseTmuxPaneTarget("demo:.2")).toBeNull();
+    expect(parseTmuxPaneTarget("demo:win.")).toBeNull();
+
+    expect(formatTmuxLiveState({ source: "tmux", live: [], warnings: [] })).toBe("no live tmux sessions/windows found");
+    expect(formatTmuxLiveState({
+      source: "tmux",
+      live: [{
+        source: "tmux",
+        id: "%9",
+        target: "demo:win.2",
+        session: "demo",
+        window: "win",
+        pane: "2",
+        awake: true,
+        matches: [],
+      }],
+      warnings: ["partial probe"],
+    })).toContain("warning: partial probe");
+  });
+
+  test("list failures degrade to warnings for Error and non-Error throws", async () => {
+    await expect(resolveTmuxLiveState([], {
+      listPanes: async () => {
+        throw new Error("no server");
+      },
+    })).resolves.toEqual({
+      source: "tmux",
+      live: [],
+      warnings: ["tmux unavailable (no server)"],
+    });
+
+    await expect(resolveTmuxLiveState([], {
+      listPanes: async () => {
+        throw "offline";
+      },
+    })).resolves.toEqual({
+      source: "tmux",
+      live: [],
+      warnings: ["tmux unavailable (offline)"],
+    });
+  });
+});

--- a/test/isolated/discover-plugin-peer-sources.test.ts
+++ b/test/isolated/discover-plugin-peer-sources.test.ts
@@ -4,10 +4,28 @@ import type { DiscoveryError, DiscoveryResponse } from "../../src/vendor/mpr-plu
 
 const configPath = import.meta.resolve("../../src/config");
 const discoveredPath = import.meta.resolve("../../src/vendor/mpr-plugins/peers/discovered");
+const liveStatePath = import.meta.resolve("../../src/commands/shared/discover-live-state");
 
 let configValue: Record<string, unknown> = {};
 let discoveryResult: DiscoveryResponse | DiscoveryError;
 let fetchCalls: Array<Record<string, unknown> | undefined> = [];
+let liveCalls: unknown[] = [];
+let liveStateResult: {
+  source: "tmux";
+  live: Array<{
+    source: "tmux";
+    id: string;
+    target: string;
+    session: string;
+    window: string;
+    pane: string;
+    command?: string;
+    cwd?: string;
+    awake: true;
+    matches: string[];
+  }>;
+  warnings: string[];
+};
 
 mock.module(configPath, () => ({
   ...mockConfigModule(() => configValue as never),
@@ -18,6 +36,27 @@ mock.module(discoveredPath, () => ({
     fetchCalls.push(opts);
     return discoveryResult;
   },
+}));
+
+mock.module(liveStatePath, () => ({
+  resolveTmuxLiveState: async (peers: Array<Record<string, unknown>>) => {
+    liveCalls.push(peers);
+    return liveStateResult;
+  },
+  markPeerTargetsLive: (peers: Array<Record<string, unknown>>, live: Array<Record<string, unknown>>) => peers.map((peer) => {
+    const signals = new Set([peer.name, peer.node, peer.oracle, peer.url].filter(Boolean));
+    const matching = live.filter((pane) => Array.isArray(pane.matches) && pane.matches.some((match) => signals.has(match)));
+    return {
+      ...peer,
+      awake: matching.length > 0,
+      liveTargets: matching.map((pane) => pane.target),
+      liveSessions: [...new Set(matching.map((pane) => pane.session))],
+    };
+  }),
+  formatTmuxLiveState: (result: { live: Array<Record<string, unknown>>; warnings: string[] }) =>
+    result.live.length > 0
+      ? result.live.map((pane) => `tmux ${pane.session}:${pane.window}.${pane.pane} ${pane.command ?? "-"}`).join("\n")
+      : `no live tmux sessions/windows found${result.warnings.length ? `\nwarning: ${result.warnings.join(",")}` : ""}`,
 }));
 
 const { command, default: handler } = await import("../../src/commands/plugins/discover/index.ts?discover-plugin-peer-sources");
@@ -51,13 +90,30 @@ beforeEach(() => {
   };
   discoveryResult = discovery("http://scout:3456");
   fetchCalls = [];
+  liveCalls = [];
+  liveStateResult = {
+    source: "tmux",
+    live: [{
+      source: "tmux",
+      id: "%1",
+      target: "101-mawjs:agent.0",
+      session: "101-mawjs",
+      window: "agent",
+      pane: "0",
+      command: "claude",
+      cwd: "/repo/mawjs-oracle",
+      awake: true,
+      matches: ["named"],
+    }],
+    warnings: [],
+  };
 });
 
 describe("discover plugin peer-source integration (#1808)", () => {
   test("exports command metadata", () => {
     expect(command).toEqual({
       name: "discover",
-      description: "List configured and discovered federation peers.",
+      description: "List configured/discovered federation peers and live tmux state.",
     });
   });
 
@@ -67,9 +123,10 @@ describe("discover plugin peer-source integration (#1808)", () => {
     expect(result).toEqual({
       ok: false,
       error: "invalid_peer_source",
-      output: "usage: maw discover [--peers config|scout|both] [--json]",
+      output: "usage: maw discover [--peers config|scout|both] [--awake] [--json]",
     });
     expect(fetchCalls).toEqual([]);
+    expect(liveCalls).toEqual([]);
   });
 
   test("renders text output for inline scout mode", async () => {
@@ -79,16 +136,20 @@ describe("discover plugin peer-source integration (#1808)", () => {
     expect(result.ok).toBe(true);
     expect(result.output).toContain("scout-node");
     expect(result.output).toContain("http://scout:3456");
+    expect(liveCalls).toEqual([]);
   });
 
   test("renders config-only JSON without calling scout", async () => {
     const result = await handler({ source: "cli", args: ["--peers", "config", "--json"] } as any);
 
     expect(fetchCalls).toEqual([]);
+    expect(liveCalls).toHaveLength(1);
     expect(result.ok).toBe(true);
     const parsed = JSON.parse(result.output ?? "{}");
     expect(parsed.mode).toBe("config");
     expect(parsed.total).toBe(2);
+    expect(parsed.liveTotal).toBe(1);
+    expect(parsed.live[0].target).toBe("101-mawjs:agent.0");
     expect(parsed.peers.map((peer: { url: string }) => peer.url)).toEqual(["http://config:3456", "http://named:3456"]);
   });
 
@@ -103,9 +164,12 @@ describe("discover plugin peer-source integration (#1808)", () => {
 
     expect(result).toEqual({ ok: true, output: undefined });
     expect(fetchCalls).toEqual([{ all: true }]);
+    expect(liveCalls).toHaveLength(1);
     const parsed = JSON.parse(writes[0]);
     expect(parsed.mode).toBe("both");
     expect(parsed.total).toBe(3);
+    expect(parsed.liveTotal).toBe(1);
+    expect(parsed.peers.find((peer: { name?: string }) => peer.name === "named").awake).toBe(true);
   });
 
   test("API source accepts string false json and renders warnings in text", async () => {
@@ -123,6 +187,26 @@ describe("discover plugin peer-source integration (#1808)", () => {
     } as any);
 
     expect(result).toEqual({ ok: true, output: undefined });
+    expect(liveCalls).toEqual([]);
     expect(writes.join("\n")).toContain("warning: scout unavailable");
+  });
+
+  test("awake mode renders live tmux state through the discover surface", async () => {
+    const result = await handler({ source: "cli", args: ["--awake"] } as any);
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("tmux 101-mawjs:agent.0 claude");
+    expect(liveCalls).toHaveLength(1);
+  });
+
+  test("awake JSON filters peer rows to live matches while preserving live rows", async () => {
+    const result = await handler({ source: "cli", args: ["--awake", "--json"] } as any);
+
+    expect(result.ok).toBe(true);
+    const parsed = JSON.parse(result.output ?? "{}");
+    expect(parsed.awake).toBe(true);
+    expect(parsed.total).toBe(1);
+    expect(parsed.peers.map((peer: { name?: string }) => peer.name)).toEqual(["named"]);
+    expect(parsed.liveTotal).toBe(1);
   });
 });

--- a/test/spec/discover-tmux-live-state.fixtures.json
+++ b/test/spec/discover-tmux-live-state.fixtures.json
@@ -1,0 +1,71 @@
+[
+  {
+    "name": "live panes expose session window pane cwd and peer matches",
+    "peers": [
+      { "name": "mawjs", "url": "http://mawjs:3456", "source": "config" },
+      { "name": "other", "url": "http://other:3456", "source": "scout", "node": "other" }
+    ],
+    "panes": [
+      {
+        "id": "%1",
+        "command": "claude",
+        "target": "101-mawjs:agent.0",
+        "title": "mawjs",
+        "pid": 111,
+        "cwd": "/repo/mawjs-oracle",
+        "lastActivity": 1800000000
+      },
+      {
+        "id": "%2",
+        "command": "zsh",
+        "target": "scratch:shell.1",
+        "title": "scratch",
+        "pid": 222,
+        "cwd": "/tmp/scratch",
+        "lastActivity": 1800000001
+      }
+    ],
+    "expected": {
+      "liveTargets": ["101-mawjs:agent.0", "scratch:shell.1"],
+      "sessions": ["101-mawjs", "scratch"],
+      "windows": ["agent", "shell"],
+      "panes": ["0", "1"],
+      "matches": [["mawjs"], []],
+      "awakePeers": ["mawjs"]
+    }
+  },
+  {
+    "name": "no tmux panes returns empty live state without warnings",
+    "peers": [{ "name": "mawjs", "url": "http://mawjs:3456", "source": "config" }],
+    "panes": [],
+    "expected": {
+      "liveTargets": [],
+      "sessions": [],
+      "windows": [],
+      "panes": [],
+      "matches": [],
+      "awakePeers": []
+    }
+  },
+  {
+    "name": "unmatched live session stays visible but does not mark peers awake",
+    "peers": [{ "name": "mawjs", "url": "http://mawjs:3456", "source": "config" }],
+    "panes": [
+      {
+        "id": "%9",
+        "command": "vim",
+        "target": "unregistered:notes.0",
+        "title": "notes",
+        "cwd": "/tmp/not-an-oracle"
+      }
+    ],
+    "expected": {
+      "liveTargets": ["unregistered:notes.0"],
+      "sessions": ["unregistered"],
+      "windows": ["notes"],
+      "panes": ["0"],
+      "matches": [[]],
+      "awakePeers": []
+    }
+  }
+]

--- a/test/spec/discover-tmux-live-state.fixtures.test.ts
+++ b/test/spec/discover-tmux-live-state.fixtures.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import fixtures from "./discover-tmux-live-state.fixtures.json";
+import {
+  formatTmuxLiveState,
+  markPeerTargetsLive,
+  parseTmuxPaneTarget,
+  resolveTmuxLiveState,
+  type DiscoverLivePane,
+} from "../../src/commands/shared/discover-live-state";
+import type { PeerTarget } from "../../src/commands/shared/peer-sources";
+import type { TmuxPane } from "../../src/core/transport/tmux";
+
+type Fixture = {
+  name: string;
+  peers: PeerTarget[];
+  panes: TmuxPane[];
+  expected: {
+    liveTargets: string[];
+    sessions: string[];
+    windows: string[];
+    panes: string[];
+    matches: string[][];
+    awakePeers: string[];
+  };
+};
+
+describe("discover tmux live-state fixtures (#1831)", () => {
+  for (const fixture of fixtures as Fixture[]) {
+    test(fixture.name, async () => {
+      const result = await resolveTmuxLiveState(fixture.peers, {
+        listPanes: async () => fixture.panes,
+      });
+      const peers = markPeerTargetsLive(fixture.peers, result.live);
+
+      expect(result.live.map((pane) => pane.target)).toEqual(fixture.expected.liveTargets);
+      expect(result.live.map((pane) => pane.session)).toEqual(fixture.expected.sessions);
+      expect(result.live.map((pane) => pane.window)).toEqual(fixture.expected.windows);
+      expect(result.live.map((pane) => pane.pane)).toEqual(fixture.expected.panes);
+      expect(result.live.map((pane) => pane.matches)).toEqual(fixture.expected.matches);
+      expect(peers.filter((peer) => peer.awake).map((peer) => peer.name ?? peer.node ?? peer.url)).toEqual(fixture.expected.awakePeers);
+    });
+  }
+
+  test("target parser is a pure portable helper", () => {
+    expect(parseTmuxPaneTarget("101-mawjs:agent.0")).toEqual({
+      session: "101-mawjs",
+      window: "agent",
+      pane: "0",
+    });
+    expect(parseTmuxPaneTarget("not-a-pane-target")).toBeNull();
+  });
+
+  test("live-state resolver degrades list failures to warnings", async () => {
+    const result = await resolveTmuxLiveState([], {
+      listPanes: async () => {
+        throw new Error("no server running");
+      },
+    });
+
+    expect(result.live).toEqual([]);
+    expect(result.warnings.join("\n")).toContain("tmux unavailable");
+    expect(formatTmuxLiveState(result)).toContain("warning: tmux unavailable");
+  });
+
+  test("formatting includes live rows and unmatched marker", () => {
+    const live: DiscoverLivePane[] = [{
+      source: "tmux",
+      id: "%1",
+      target: "scratch:shell.0",
+      session: "scratch",
+      window: "shell",
+      pane: "0",
+      command: "zsh",
+      cwd: "/tmp/scratch",
+      awake: true,
+      matches: [],
+    }];
+
+    const output = formatTmuxLiveState({ source: "tmux", live, warnings: [] });
+    expect(output).toContain("scratch");
+    expect(output).toContain("shell");
+    expect(output).toContain("zsh");
+    expect(output).toContain("-");
+  });
+});


### PR DESCRIPTION
Closes #1831
Partial #1805

## Summary
- Adds a shared injectable tmux live-state resolver for pane-level session/window/pane inventory.
- Wires `maw discover --json` to include `liveTotal`, `live.panes`, `live.sessions`, and peer awake/live target metadata.
- Adds `maw discover --awake` for live tmux pane rows while keeping default text mode from probing tmux.
- Integrates with current alpha discover inventory sources: plugin registry, ghq, fleet config, and oracle manifest.

## Tests
- `bun run build`
- `bun run test:spec`
- `bun run test:default:safe`
- `bun run test:coverage`

Coverage held at 100.0% lines; isolated sweep 535/535 green. No wake-maybe-split, XDG, or config-state touches.