### PR TITLE
release: v26.5.21-beta.828

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.20-alpha.2203",
+  "version": "26.5.21-beta.828",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts `v26.5.21-beta.828` on merge via `calver-release.yml`.

## Source
Branched from tag `v26.5.20-alpha.2203` (commit `1af25062`) — the verified release point with #1837 all 6 phases, #1838-#1842, #1845, etc.

## Note: beta branch newly bootstrapped
The `beta` branch did not exist on origin; bootstrapped it from `v26.5.20-alpha.2203` so this PR has a base. This PR adds the CalVer bump commit.

## Why beta now
Nat called for beta + main release of `v26.5.20-alpha.2203` content. Companion to PR #1846 (sync main from same tag).

## Promotion flow
```
alpha (45ce878d, today's tip) → beta (this PR) → main (PR #1846)
```

## On merge
`calver-release.yml` will:
- Tag `v26.5.21-beta.828`
- Create GitHub release with built `dist/maw`
- Publish to npm `@beta`