### PR TITLE
release: v26.5.21-alpha.1020

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.20-alpha.2203",
+  "version": "26.5.21-alpha.1020",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts v26.5.21-alpha.1020 on merge via calver-release.yml.

Includes the already-landed alpha change:
- 061e6182 — maw new supports --window <name> while preserving lead as the default.

Validation before this release branch:
- MAW_TEST_MODE=1 rtk bun test test/isolated/cmd-new-workspace.test.ts test/new-attach-prompt.test.ts test/cli/dispatch-match.test.ts
- rtk bun run build
- rtk git diff --check
- local link verified: maw v26.5.20-alpha.2203 (061e6182)

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.