### PR TITLE
release: v26.5.21-alpha.2319

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.21-alpha.1608",
+  "version": "26.5.21-alpha.2319",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts v26.5.21-alpha.2319 on merge via calver-release.yml.

Rolls up current alpha through 2f0fd5eb, including config-drift doctor and structured federation ls API.

Tested:
- bun run build

Written by [m5:mawjscodex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.