### PR TITLE
fix(maw): clean diagnostics and routing for automation

### DIFF
--- a/src/cli/auto-restore.ts
+++ b/src/cli/auto-restore.ts
@@ -2,14 +2,15 @@
  * Auto-restore: if no live tmux sessions exist and a recent (<24h) snapshot
  * is on disk, prompt the user to revive every session in the snapshot.
  *
- * Skipped for help-style invocations (--help / -h) so `maw --help` never
- * stalls waiting for tty input.
+ * Skipped for help-style invocations (--help / -h), non-interactive shells,
+ * and diagnostic commands so automation output stays machine-readable.
  *
  * Exceptions are intentionally swallowed — auto-restore is best-effort
  * UX sugar, never load-bearing for the actual command the user typed.
  */
 export async function maybeAutoRestore(cmd: string | undefined): Promise<void> {
   if (!cmd || cmd === "--help" || cmd === "-h") return;
+  if (shouldSkipAutoRestore(cmd)) return;
   try {
     const { listSessions } = await import("../sdk");
     const live = await listSessions().catch(() => [] as any[]);
@@ -47,4 +48,16 @@ export async function maybeAutoRestore(cmd: string | undefined): Promise<void> {
     }
     console.log("");
   } catch {}
+}
+
+function shouldSkipAutoRestore(cmd: string): boolean {
+  if (isTruthyEnv(process.env.MAW_NO_PROMPT) || isTruthyEnv(process.env.CI)) return true;
+  if (!process.stdin.isTTY || !process.stdout.isTTY) return true;
+  return new Set(["capture", "locate", "messages", "oracle", "peek"]).has(cmd);
+}
+
+function isTruthyEnv(value: string | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
 }

--- a/src/cli/verbosity.ts
+++ b/src/cli/verbosity.ts
@@ -45,7 +45,18 @@ export function isSilent(): boolean {
  * side-effects in load.ts / registry.ts, well before cli.ts can call
  * setVerbosityFlags(). Mirroring the help/version guard's structure.
  */
-const QUIET_TOP_ALIASES = new Set(["ls", "a", "attach", "wake", "activity"]);
+const QUIET_TOP_ALIASES = new Set([
+  "a",
+  "activity",
+  "attach",
+  "capture",
+  "locate",
+  "ls",
+  "messages",
+  "oracle",
+  "peek",
+  "wake",
+]);
 
 export function isQuiet(): boolean {
   // --silent implies --quiet
@@ -59,7 +70,7 @@ export function isQuiet(): boolean {
   // forms too — `maw oracle scan --help` etc.
   if (
     process.argv.some(
-      a => a === "--help" || a === "-h" || a === "--version" || a === "-v",
+      a => a === "--help" || a === "-h" || a === "--version" || a === "-v" || a === "--json",
     )
   ) return true;
   // FIX-A — selected verbs (ls, a, attach, wake, activity) don't need

--- a/src/config/ghq-root.ts
+++ b/src/config/ghq-root.ts
@@ -82,7 +82,10 @@ export function getGhqRoot(): string {
 
   // (3) shell out to ghq
   try {
-    const out = execSync("ghq root", { encoding: "utf-8" }).trim();
+    const out = execSync("ghq root", {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
     if (out.length > 0) {
       _cached = normalizeBare(out);
       return _cached;

--- a/src/core/repo-discovery/ghq-discovery.ts
+++ b/src/core/repo-discovery/ghq-discovery.ts
@@ -40,7 +40,10 @@ export const GhqDiscovery: RepoDiscovery = {
 
   listSync(): string[] {
     try {
-      return normalize(execSync("ghq list --full-path", { encoding: "utf-8" }));
+      return normalize(execSync("ghq list --full-path", {
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "pipe"],
+      }));
     } catch {
       return [];
     }

--- a/src/core/transport/tmux-class.ts
+++ b/src/core/transport/tmux-class.ts
@@ -50,7 +50,8 @@ export class Tmux {
   /** Base runner — executes `tmux [-S socket] <subcommand> [args...]` via hostExec. */
   async run(subcommand: string, ...args: (string | number)[]): Promise<string> {
     const socketFlag = this.socket ? `-S ${q(this.socket)} ` : "";
-    const cmd = `tmux ${socketFlag}${subcommand} ${args.map(q).join(" ")}`;
+    const termPrefix = process.env.TERM ? "" : "TERM=xterm ";
+    const cmd = `${termPrefix}tmux ${socketFlag}${subcommand} ${args.map(q).join(" ")}`;
     return hostExec(cmd, this.host);
   }
 

--- a/src/vendor/mpr-plugins/locate/impl.ts
+++ b/src/vendor/mpr-plugins/locate/impl.ts
@@ -19,6 +19,7 @@ import { loadFleetEntries, type FleetEntry } from "maw-js/commands/shared/fleet-
 import { loadConfig } from "maw-js/config";
 import { resolveSessionTarget } from "maw-js/core/matcher/resolve-target";
 import { UserError } from "maw-js/core/util/user-error";
+import { loadManifestCached, type OracleManifestEntry } from "maw-js/lib/oracle-manifest";
 
 export interface LocateOpts {
   path?: boolean;
@@ -34,6 +35,7 @@ interface LocateResult {
   fleetConfigPath: string | null;
   federationNode: string | null;
   inAgentsConfig: boolean;
+  manifestEntry: OracleManifestEntry | null;
 }
 
 function fleetEntryMatches(entry: FleetEntry, names: Set<string>): boolean {
@@ -85,22 +87,41 @@ async function gatherInfo(oracle: string): Promise<LocateResult> {
   // shadow legacy entries and report the exact source path.
   const fleetConfigPath = findFleetConfigPath(oracle, sessionName);
 
+  // Manifest fallback — includes oracles.json entries that do not have a
+  // local repo, tmux session, or fleet config yet. This keeps `maw locate`
+  // aligned with `maw oracle list` for registry-only oracles.
+  const manifestEntry = lookupManifestEntry(oracle);
+
   // Federation — config.agents map + node
   const config = loadConfig();
   const agents = config.agents ?? {};
   const inAgentsConfig = oracle in agents;
-  const federationNode = inAgentsConfig ? agents[oracle]! : (config.node ?? null);
+  const federationNode = inAgentsConfig ? agents[oracle]! : (manifestEntry?.node ?? config.node ?? null);
 
   return {
     name: oracle,
-    repoPath,
-    hasPsi,
+    repoPath: repoPath ?? manifestEntry?.localPath ?? null,
+    hasPsi: repoPath ? hasPsi : (manifestEntry?.hasPsi ?? false),
     sessionName,
     windowCount,
     fleetConfigPath,
     federationNode,
     inAgentsConfig,
+    manifestEntry: manifestEntry ?? null,
   };
+}
+
+function lookupManifestEntry(oracle: string): OracleManifestEntry | undefined {
+  try {
+    const manifest = loadManifestCached();
+    const stripped = oracle.replace(/-oracle$/, "");
+    return (
+      manifest.find((entry) => entry.name === oracle) ||
+      (stripped !== oracle ? manifest.find((entry) => entry.name === stripped) : undefined)
+    );
+  } catch {
+    return undefined;
+  }
 }
 
 export async function cmdLocate(oracle: string | undefined, opts: LocateOpts = {}): Promise<void> {
@@ -113,7 +134,7 @@ export async function cmdLocate(oracle: string | undefined, opts: LocateOpts = {
   const info = await gatherInfo(oracle);
 
   // Nothing found at all → not-found error (mirrors alpha.75 oracle-about fix)
-  if (!info.repoPath && !info.sessionName && !info.fleetConfigPath) {
+  if (!info.repoPath && !info.sessionName && !info.fleetConfigPath && !info.manifestEntry) {
     throw new UserError(`no oracle named '${oracle}' — try: maw oracle ls`);
   }
 
@@ -146,8 +167,21 @@ export async function cmdLocate(oracle: string | undefined, opts: LocateOpts = {
   if (info.fleetConfigPath) {
     console.log(`   fleet:    ${info.fleetConfigPath}`);
   }
+  if (info.manifestEntry) {
+    console.log(`   source:   ${info.manifestEntry.sources.join(", ")}`);
+    if (info.manifestEntry.repo && !info.repoPath) {
+      console.log(`   repo:     ${info.manifestEntry.repo}`);
+    }
+    if (info.manifestEntry.hasFleetConfig && !info.fleetConfigPath) {
+      console.log("   fleet:    known (manifest)");
+    }
+  }
   if (info.federationNode) {
-    const suffix = info.inAgentsConfig ? " (from config.agents)" : " (this node)";
+    const suffix = info.inAgentsConfig
+      ? " (from config.agents)"
+      : info.manifestEntry?.node
+        ? " (from manifest)"
+        : " (this node)";
     console.log(`   node:     ${info.federationNode}${suffix}`);
   }
   console.log();

--- a/src/vendor/mpr-plugins/locate/impl.ts
+++ b/src/vendor/mpr-plugins/locate/impl.ts
@@ -96,7 +96,11 @@ async function gatherInfo(oracle: string): Promise<LocateResult> {
   const config = loadConfig();
   const agents = config.agents ?? {};
   const inAgentsConfig = oracle in agents;
-  const federationNode = inAgentsConfig ? agents[oracle]! : (manifestEntry?.node ?? config.node ?? null);
+  const federationNode = inAgentsConfig
+    ? agents[oracle]!
+    : sessionName
+      ? (config.node ?? "local")
+      : (manifestEntry?.node ?? config.node ?? null);
 
   return {
     name: oracle,
@@ -179,7 +183,9 @@ export async function cmdLocate(oracle: string | undefined, opts: LocateOpts = {
   if (info.federationNode) {
     const suffix = info.inAgentsConfig
       ? " (from config.agents)"
-      : info.manifestEntry?.node
+      : info.sessionName
+        ? " (this node)"
+        : info.manifestEntry?.node
         ? " (from manifest)"
         : " (this node)";
     console.log(`   node:     ${info.federationNode}${suffix}`);

--- a/test/cli/verbosity.test.ts
+++ b/test/cli/verbosity.test.ts
@@ -102,6 +102,19 @@ describe("verbosity", () => {
       expect(isQuiet()).toBe(true);
     });
 
+    test.each(["capture", "locate", "messages", "oracle", "peek"])(
+      "`maw %s` diagnostic command -> quiet",
+      (verb) => {
+        process.argv = ["bun", "/path/to/cli.ts", verb];
+        expect(isQuiet()).toBe(true);
+      },
+    );
+
+    test("`maw locate mira --json` -> quiet for parseable JSON output", () => {
+      process.argv = ["bun", "/path/to/cli.ts", "locate", "mira", "--json"];
+      expect(isQuiet()).toBe(true);
+    });
+
     test("`maw bud --as ls` → NOT quiet (positional check at argv[2], not .some)", () => {
       // Regression guard: an `--as ls` value buried later in argv must not
       // false-positive into the suppression path.

--- a/test/isolated/auto-restore-transport-coverage.test.ts
+++ b/test/isolated/auto-restore-transport-coverage.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 const sdkPath = import.meta.resolve("../../src/sdk/index.ts");
 const snapshotPath = import.meta.resolve("../../src/core/fleet/snapshot.ts");
@@ -60,8 +60,16 @@ const { cmdTransportStatus } = await import("../../src/commands/shared/transport
 
 const originalLog = console.log;
 const originalWrite = process.stdout.write;
+const originalCi = process.env.CI;
+const originalNoPrompt = process.env.MAW_NO_PROMPT;
+const originalStdinIsTTY = process.stdin.isTTY;
+const originalStdoutIsTTY = process.stdout.isTTY;
 
 beforeEach(() => {
+  delete process.env.CI;
+  delete process.env.MAW_NO_PROMPT;
+  Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+  Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
   sessions = [];
   listSessionsError = null;
   snapshot = null;
@@ -77,6 +85,17 @@ beforeEach(() => {
     writes.push(String(chunk));
     return true;
   }) as typeof process.stdout.write;
+});
+
+afterEach(() => {
+  console.log = originalLog;
+  process.stdout.write = originalWrite;
+  if (originalCi === undefined) delete process.env.CI;
+  else process.env.CI = originalCi;
+  if (originalNoPrompt === undefined) delete process.env.MAW_NO_PROMPT;
+  else process.env.MAW_NO_PROMPT = originalNoPrompt;
+  Object.defineProperty(process.stdin, "isTTY", { value: originalStdinIsTTY, configurable: true });
+  Object.defineProperty(process.stdout, "isTTY", { value: originalStdoutIsTTY, configurable: true });
 });
 
 describe("auto restore startup helper", () => {

--- a/test/isolated/coverage-100b-vendor-b-doctor-locate.test.ts
+++ b/test/isolated/coverage-100b-vendor-b-doctor-locate.test.ts
@@ -41,6 +41,10 @@ mock.module("maw-js/commands/shared/fleet-load", () => ({
   loadFleetEntries: () => fleetEntries,
 }));
 mock.module("maw-js/config", () => ({ loadConfig: () => config }));
+mock.module("maw-js/lib/oracle-manifest", () => ({
+  invalidateManifest: () => undefined,
+  loadManifestCached: () => [],
+}));
 mock.module("maw-js/core/matcher/resolve-target", () => ({
   resolveSessionTarget: (_oracle: string, list: any[]) => list.length ? { kind: "fuzzy", match: list[0] } : { kind: "none" },
 }));

--- a/test/isolated/soul-sync-family-coverage.test.ts
+++ b/test/isolated/soul-sync-family-coverage.test.ts
@@ -244,7 +244,7 @@ describe("soul-sync family isolated coverage", () => {
       currentPanePath = "__throw__";
       const soulSyncFallbackCwd = await mod.cmdSoulSync();
       expect(soulSyncFallbackCwd).toEqual([]);
-      expect(logs.join("\n")).toContain("no sync_peers configured for 'maw-js'");
+      expect(logs.join("\n")).toContain(`no sync_peers configured for '${process.cwd().split("/").pop()}'`);
 
       const absorbed = await mod.cmdSoulSyncProject({ cwd: fx.alphaPath });
       expect(absorbed).toEqual([

--- a/test/isolated/split-lock.test.ts
+++ b/test/isolated/split-lock.test.ts
@@ -7,10 +7,14 @@ let commands: Array<{ cmd: string; time: number }> = [];
 let execDelay = 0;
 let execResponder: (cmd: string) => string = () => "";
 
+const normalizeTmuxCmd = (cmd: string) =>
+  cmd.replace(/^(TERM=xterm tmux) -S '[^']+' /, "$1 ");
+
 const mockExec = async (cmd: string, _host?: string) => {
-  commands.push({ cmd, time: Date.now() });
+  const normalized = normalizeTmuxCmd(cmd);
+  commands.push({ cmd: normalized, time: Date.now() });
   if (execDelay > 0) await new Promise((r) => setTimeout(r, execDelay));
-  return execResponder(cmd);
+  return execResponder(normalized);
 };
 
 mock.module("../../src/config", () =>
@@ -32,6 +36,7 @@ const {
 } = await import("../../src/core/transport/tmux");
 
 beforeEach(() => {
+  delete process.env.MAW_TMUX_SOCKET;
   commands = [];
   execDelay = 0;
   execResponder = () => "";
@@ -80,7 +85,7 @@ describe("splitWindowLocked", () => {
     const elapsed = Date.now() - start;
 
     expect(commands).toHaveLength(1);
-    expect(commands[0].cmd).toBe("tmux split-window -t mawjs:0");
+    expect(commands[0].cmd).toBe("TERM=xterm tmux split-window -t mawjs:0");
     // Allow 5ms jitter on either side of 40ms.
     expect(elapsed).toBeGreaterThanOrEqual(35);
   });
@@ -91,8 +96,8 @@ describe("splitWindowLocked", () => {
     await Promise.all([p1, p2]);
 
     expect(commands).toHaveLength(2);
-    expect(commands[0].cmd).toBe("tmux split-window -t s:0");
-    expect(commands[1].cmd).toBe("tmux split-window -t s:1");
+    expect(commands[0].cmd).toBe("TERM=xterm tmux split-window -t s:0");
+    expect(commands[1].cmd).toBe("TERM=xterm tmux split-window -t s:1");
     // Second split must start after first's settle window.
     const gap = commands[1].time - commands[0].time;
     expect(gap).toBeGreaterThanOrEqual(45);
@@ -106,7 +111,7 @@ describe("splitWindowLocked", () => {
       settleMs: 0,
     });
     // q() single-quotes `%` since it's outside the safe-char regex.
-    expect(commands[0].cmd).toBe("tmux split-window -t s:0 -v -l '30%' bash");
+    expect(commands[0].cmd).toBe("TERM=xterm tmux split-window -t s:0 -v -l '30%' bash");
   });
 });
 
@@ -114,7 +119,7 @@ describe("tagPane", () => {
   test("sets title via select-pane -T", async () => {
     await tagPane("s:0.1", { title: "oracle" });
     expect(commands).toEqual([
-      { cmd: "tmux select-pane -t s:0.1 -T oracle", time: expect.any(Number) },
+      { cmd: "TERM=xterm tmux select-pane -t s:0.1 -T oracle", time: expect.any(Number) },
     ]);
   });
 
@@ -124,14 +129,14 @@ describe("tagPane", () => {
     });
     // q() single-quotes `@` since it's outside the safe-char regex.
     expect(commands.map((c) => c.cmd)).toEqual([
-      "tmux set-option -p -t s:0.1 '@agent-name' scout",
-      "tmux set-option -p -t s:0.1 '@role' teammate",
+      "TERM=xterm tmux set-option -p -t s:0.1 '@agent-name' scout",
+      "TERM=xterm tmux set-option -p -t s:0.1 '@role' teammate",
     ]);
   });
 
   test("quotes values containing spaces", async () => {
     await tagPane("s:0.1", { title: "oracle main" });
-    expect(commands[0].cmd).toBe("tmux select-pane -t s:0.1 -T 'oracle main'");
+    expect(commands[0].cmd).toBe("TERM=xterm tmux select-pane -t s:0.1 -T 'oracle main'");
   });
 });
 
@@ -144,7 +149,7 @@ describe("readPaneTags (round-trip)", () => {
 
     execResponder = (cmd: string) => {
       // select-pane -T <title>
-      let m = cmd.match(/^tmux select-pane -t (\S+) -T (?:'((?:[^']|'\\'')*)'|(\S+))$/);
+      let m = cmd.match(/^(?:TERM=xterm )?tmux select-pane -t (\S+) -T (?:'((?:[^']|'\\'')*)'|(\S+))$/);
       if (m) {
         const t = m[1];
         const title = m[2] !== undefined ? m[2].replace(/'\\''/g, "'") : m[3]!;
@@ -153,7 +158,7 @@ describe("readPaneTags (round-trip)", () => {
         return "";
       }
       // set-option -p -t <target> <@key|'@key'> <val>
-      m = cmd.match(/^tmux set-option -p -t (\S+) (?:'(@[^']+)'|(@\S+)) (?:'((?:[^']|'\\'')*)'|(\S+))$/);
+      m = cmd.match(/^(?:TERM=xterm )?tmux set-option -p -t (\S+) (?:'(@[^']+)'|(@\S+)) (?:'((?:[^']|'\\'')*)'|(\S+))$/);
       if (m) {
         const t = m[1];
         const key = m[2] ?? m[3]!;
@@ -163,10 +168,10 @@ describe("readPaneTags (round-trip)", () => {
         return "";
       }
       // display-message -p -t <target> '#{pane_title}'
-      m = cmd.match(/^tmux display-message -p -t (\S+) '#\{pane_title\}'$/);
+      m = cmd.match(/^(?:TERM=xterm )?tmux display-message -p -t (\S+) '#\{pane_title\}'$/);
       if (m) return `${store[m[1]]?.title ?? ""}\n`;
       // show-options -p -t <target>
-      m = cmd.match(/^tmux show-options -p -t (\S+)$/);
+      m = cmd.match(/^(?:TERM=xterm )?tmux show-options -p -t (\S+)$/);
       if (m) {
         const entries = store[m[1]]?.meta ?? {};
         return Object.entries(entries)

--- a/test/isolated/tmux-class-coverage.test.ts
+++ b/test/isolated/tmux-class-coverage.test.ts
@@ -126,7 +126,7 @@ describe("tmux-class isolated coverage", () => {
 
     expect(hostExecCalls).toEqual([
       {
-        cmd: "tmux -S '/tmp/maw socket.sock' list-panes -t sess:oracle.0 -F '#{pane_id}'",
+        cmd: "TERM=xterm tmux -S '/tmp/maw socket.sock' list-panes -t sess:oracle.0 -F '#{pane_id}'",
         host: "remote-box",
       },
       {

--- a/test/isolated/tmux-class-eleventh-pass-coverage.test.ts
+++ b/test/isolated/tmux-class-eleventh-pass-coverage.test.ts
@@ -71,7 +71,7 @@ describe("tmux-class eleventh-pass isolated coverage", () => {
     await t.loadBuffer("don't quote twice");
 
     expect(hostExecCalls).toEqual([
-      { cmd: "tmux display-message 'hello world'", host: "remote-box" },
+      { cmd: "TERM=xterm tmux display-message 'hello world'", host: "remote-box" },
       { cmd: "tmux capture-pane -t session:win.0 -e -p 2>/dev/null | tail -7", host: "remote-box" },
       { cmd: "printf '%s' 'don'\\''t quote twice' | tmux load-buffer -", host: "remote-box" },
     ]);
@@ -85,7 +85,7 @@ describe("tmux-class eleventh-pass isolated coverage", () => {
     await t.run("display-message", "#{session_name}");
 
     expect(hostExecCalls).toEqual([
-      { cmd: "tmux -S '/tmp/env socket.sock' display-message '#{session_name}'", host: "remote-box" },
+      { cmd: "TERM=xterm tmux -S '/tmp/env socket.sock' display-message '#{session_name}'", host: "remote-box" },
     ]);
   });
 

--- a/test/isolated/tmux-class-fourteenth-pass-coverage.test.ts
+++ b/test/isolated/tmux-class-fourteenth-pass-coverage.test.ts
@@ -121,7 +121,7 @@ describe("tmux-class fourteenth-pass isolated coverage", () => {
 
     expect(hostExecCalls).toEqual([
       {
-        cmd: "tmux -S '/tmp/fourteenth pass.sock' resize-pane -t 'alpha pane' -x 80 -y 24",
+        cmd: "TERM=xterm tmux -S '/tmp/fourteenth pass.sock' resize-pane -t 'alpha pane' -x 80 -y 24",
         host: "remote-box",
       },
       {
@@ -129,7 +129,7 @@ describe("tmux-class fourteenth-pass isolated coverage", () => {
         host: "remote-box",
       },
       {
-        cmd: "tmux -S '/tmp/fourteenth pass.sock' display-message -p ignored",
+        cmd: "TERM=xterm tmux -S '/tmp/fourteenth pass.sock' display-message -p ignored",
         host: "remote-box",
       },
       {

--- a/test/isolated/tmux-class-fourth-pass-coverage.test.ts
+++ b/test/isolated/tmux-class-fourth-pass-coverage.test.ts
@@ -139,11 +139,11 @@ describe("tmux-class fourth-pass isolated coverage", () => {
 
     expect(hostExecCalls).toEqual([
       {
-        cmd: "tmux -S '/tmp/fourth pass.sock' display-message -p 'ready now'",
+        cmd: "TERM=xterm tmux -S '/tmp/fourth pass.sock' display-message -p 'ready now'",
         host: undefined,
       },
       {
-        cmd: "tmux display-message ",
+        cmd: "TERM=xterm tmux display-message ",
         host: "remote-box",
       },
       {
@@ -155,11 +155,11 @@ describe("tmux-class fourth-pass isolated coverage", () => {
         host: "remote-box",
       },
       {
-        cmd: "tmux display-message -p 'safe arg'",
+        cmd: "TERM=xterm tmux display-message -p 'safe arg'",
         host: "remote-box",
       },
       {
-        cmd: "tmux display-message -p ignored",
+        cmd: "TERM=xterm tmux display-message -p ignored",
         host: "remote-box",
       },
     ]);

--- a/test/isolated/tmux-class-seventh-pass-coverage.test.ts
+++ b/test/isolated/tmux-class-seventh-pass-coverage.test.ts
@@ -117,7 +117,7 @@ describe("tmux-class seventh-pass isolated coverage", () => {
 
     expect(hostExecCalls).toEqual([
       {
-        cmd: "tmux display-message -p '#{session_name}'",
+        cmd: "TERM=xterm tmux display-message -p '#{session_name}'",
         host: "remote-box",
       },
       {

--- a/test/isolated/tmux-class-sixth-pass-coverage.test.ts
+++ b/test/isolated/tmux-class-sixth-pass-coverage.test.ts
@@ -127,7 +127,7 @@ describe("tmux-class sixth-pass isolated coverage", () => {
 
     expect(hostExecCalls).toEqual([
       {
-        cmd: "tmux -S '/tmp/explicit socket.sock' display-message ",
+        cmd: "TERM=xterm tmux -S '/tmp/explicit socket.sock' display-message ",
         host: "remote-box",
       },
       {

--- a/test/isolated/tmux.test.ts
+++ b/test/isolated/tmux.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock, beforeEach } from "bun:test";
+import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
 import { Tmux } from "../../src/core/transport/tmux";
 
 // Capture all commands sent to ssh()
@@ -30,6 +30,7 @@ installDefaultSshMock();
 
 // Ensure no socket env var leaks into tests
 delete process.env.MAW_TMUX_SOCKET;
+const originalTerm = process.env.TERM;
 
 describe("Tmux", () => {
   let t: Tmux;
@@ -37,8 +38,14 @@ describe("Tmux", () => {
   beforeEach(() => {
     commands = [];
     sshResult = "";
+    process.env.TERM = "xterm";
     installDefaultSshMock();
     t = new Tmux();
+  });
+
+  afterEach(() => {
+    if (originalTerm === undefined) delete process.env.TERM;
+    else process.env.TERM = originalTerm;
   });
 
   // --- q() quoting (tested indirectly through commands) ---
@@ -62,6 +69,12 @@ describe("Tmux", () => {
     test("numbers are converted to strings", async () => {
       await t.tryRun("resize-pane", "-t", "s:0", "-x", 80, "-y", 24);
       expect(commands[0]).toBe("tmux resize-pane -t s:0 -x 80 -y 24");
+    });
+
+    test("injects TERM for tmux when running from non-tty automation", async () => {
+      delete process.env.TERM;
+      await t.tryRun("has-session", "-t", "oracles");
+      expect(commands[0]).toBe("TERM=xterm tmux has-session -t oracles");
     });
   });
 


### PR DESCRIPTION
## Summary

This PR repairs MAW diagnostic and automation behavior found while testing the sgp1 / Oracle / Codex routing lane.

- Align `maw locate` with the Oracle manifest so registry-only oracles such as Mira can be located.
- Keep JSON and diagnostic command output parseable by suppressing restore prompts and bootstrap chatter.
- Make tmux transport work from non-tty automation by injecting `TERM=xterm` when the caller has no terminal environment.
- Silence missing `ghq` shell noise while preserving safe empty-list fallback.
- Prefer live tmux session node over stale manifest metadata in `maw locate`.

## Root Cause

Several diagnostics were mixing human UX behavior with machine-readable or automation paths:

- `maw locate` did not consider manifest-only entries, so `maw oracle list` and `maw locate` disagreed.
- Auto-restore prompts could appear before diagnostic command output.
- Bootstrap chatter polluted `--json` output.
- tmux commands can fail under ssh/Codex non-tty shells when `TERM` is absent.
- Missing `ghq` could leak shell noise into otherwise successful commands.
- Stale manifest metadata could override a live local tmux session in `maw locate`.

## Validation

- `bun run build`
- `MAW_TEST_MODE=1 bun test test/cli/verbosity.test.ts`
- `MAW_TEST_MODE=1 bun test test/isolated/tmux.test.ts`
- `bun test test/ghq-helper.test.ts`
- `./dist/maw locate mira --json` parsed with `python3 -m json.tool`
- `./dist/maw locate brain` reports `node: sgp1 (this node)`
- `./dist/maw peek brain` exits `0` from Codex/ssh non-tty path
- `./dist/maw ls` no longer emits missing-ghq shell noise

## Safety

- No services restarted.
- No runtime configs mutated.
- No secrets read or copied.
- This is a code-only repair patchset.
