### PR TITLE
vendor: discord plugin v0.4.2 (survive bun install -g rewipes)

### DIFF
--- a/src/vendor/mpr-plugins/discord/README.md
+++ b/src/vendor/mpr-plugins/discord/README.md
@@ -1,0 +1,105 @@
+# maw discord
+
+Discord fleet ops plugin — token audit + fleet status (v0.2). bind/pair/route/serve coming.
+
+## Hybrid pattern
+
+Tokens stay in **`pass`** (central, GPG-encrypted, shared via `laris-co/password-store`).
+Per-bot non-secret state lives in **`<bot-repo>/.discord/`** (access.json, channel-map.json, config.json, .envrc).
+
+See: `discord-oracle/ψ/outbox/ideas/2026-05-17_self-contained-bot-repo-gpg-pattern.md`
+
+## Subcommands
+
+### v0.1 — tokens
+
+| Command | Purpose | Side effects |
+|---|---|---|
+| `maw discord` | help | none |
+| `maw discord tokens ls` | list all tokens in `~/.password-store/discord/` (name + size + mtime) | none (no decrypt, no network) |
+| `maw discord tokens check [bot]` | decrypt each token + ping Discord REST | network (HTTPS to discord.com) |
+
+### v0.2 — status (NEW)
+
+| Command | Purpose | Side effects |
+|---|---|---|
+| `maw discord status` | fleet inspection table — all bots × pass × legacy × hybrid × tmux × registry | none (filesystem only) |
+| `maw discord status <bot>` | detailed card for one bot | none |
+| `maw discord status --check` | + Discord REST per bot (slower) | network |
+| `maw discord status --redact` | hide dates (screen-share safe — date drift can leak rotation patterns) | none |
+| `maw discord status --json` | machine-readable output with severity for CI/alerting | none |
+
+### v0.3 — planned
+
+| Command | Purpose |
+|---|---|
+| `maw discord bind <bot>` | end-to-end onboard (ghq get + direnv allow + maw wake) |
+| `maw discord pair <oracle> <channel>` | seed access.json + channel-map.json |
+| `maw discord route <from> <to>` | rewire channel-map.json entry |
+| `maw discord serve [--detach]` | daemon — heartbeat, presence, webhook receive (engine.serve pattern) |
+
+## Severity model (status output)
+
+| Severity | When | Action |
+|---|---|---|
+| `ok` ✓ | token + registered + (hybrid OR running locally) | no action |
+| `warn` ○ | registered + has hybrid, not running locally | probably fine, just offline on this host |
+| `info` · | legacy state-dir only, hybrid not applied | migration TODO |
+| `error` ✗ | token-only (orphan in pass) OR registered-only (missing token) OR Discord REST failure | investigate |
+
+Maps to syslog levels — pipe `--json` to log aggregator for free severity routing.
+
+## Known v0.1+v0.2 caveats
+
+- **`discord-token` (no -oracle suffix)** — legacy aggregate from early provisioning. Rotated away, returns 401. Safe to remove from pass.
+- **`pulse-token` (no -oracle suffix)** — legacy duplicate of `pulse-oracle-token`. Same identity.
+- **`timekeeper-oracle-token`** — known attribution issue documented in `discord-oracle/CLAUDE.md`.
+
+Clean run baseline today: **18/20 green** via `tokens check`, **18 info / 2 error** via `status` (the 2 errors are the legacy tokens above).
+
+## Security posture
+
+- ✅ Tokens never printed (only username on successful Discord 200)
+- ✅ Decrypt via `pass show` (caller must have GPG private key)
+- ✅ `fetch()` calls use 5-second `AbortController` timeout
+- ✅ Sequential REST calls (rate-limit polite, debug-friendly)
+- ✅ `--redact` hides date metadata for screen-sharing (rotation cadence leak)
+- ⚠️ No `--strict` mode yet — fail count goes to stdout but exit is `ok:true`. v0.3 backlog.
+
+## Capabilities (plugin.json)
+
+- `fs:read` — reads `~/.password-store/discord/*.gpg`, `~/.claude/channels/<bot>/`, `<bot-repo>/.discord/`, `discord-oracle/src/state-dirs.ts`
+- `net` — outbound HTTPS to `discord.com/api/v10/users/@me` (--check only)
+
+## state-dirs.ts parsing
+
+v0.2 parses `discord-oracle/src/state-dirs.ts` via regex to find registered bots.
+v0.3 should switch to a canonical `bun src/scripts/list-registered.ts --json` API in discord-oracle.
+Issue filed against discord-oracle to ship that script.
+
+If discord-oracle isn't cloned locally, registry column shows everything as not-registered (graceful degradation).
+
+## Development
+
+- Pattern reference: `maw-plugin-registry/plugins/team/index.ts` (mawjs-oracle's recommendation)
+- SDK guide: shared by `[m5:homekeeper]` 2026-05-17
+- engine.serve reference (v0.3): `maw-js/src/vendor/mpr-plugins/messages/` (per mawjs-oracle)
+- Shared utilities in `lib.ts` — `tokens.ts` and `status.ts` both import; no duplication
+
+## Layout
+
+```
+plugins/discord/
+├── plugin.json     declares 'discord' top-level
+├── README.md       (this file)
+├── index.ts        subcommand dispatch (args[0]?.toLowerCase() pattern)
+├── lib.ts          shared utilities (pass, GPG decrypt, REST ping, ghq path, state-dirs parse)
+├── tokens.ts       tokens ls + tokens check
+└── status.ts       status [bot] [--check] [--redact] [--json]
+```
+
+## History
+
+- **2026-05-17** v0.1 shipped — tokens ls/check. Reviewed by [m5:homekeeper] (5 items applied).
+- **2026-05-17** v0.2 shipped — status added. `lib.ts` extracted. Severity + --redact + --json baked in per homekeeper Q1-Q3 review.
+- Pattern: build from real friction, ship narrow surface, refactor before adding side-effect verbs.

--- a/src/vendor/mpr-plugins/discord/access.ts
+++ b/src/vendor/mpr-plugins/discord/access.ts
@@ -1,0 +1,434 @@
+/**
+ * `maw discord access <bot> ...` — channel + allowlist management per bot.
+ *
+ * Design: WRAP the global `discord-access` CLI (which lives in the discord-oracle
+ * repo, exposed via `bun link`). Don't reinvent. Add the missing flags
+ * (`--no-mention`, `--allow`, multi-guild `--refresh`) via post-processing the
+ * access.json the raw tool emits.
+ *
+ * Per-bot resolution: <bot> → state-dirs.ts entry → DISCORD_STATE_DIR env →
+ * discord-access reads access.json from there.
+ *
+ * Subcommands:
+ *   list                                 show enabled channels for <bot>
+ *   show <channel>                       inspect one channel's config
+ *   map [--guild <id>] [--refresh]       list/refresh channel-map.json
+ *   add <channel> [--no-mention] [--allow <id>...]
+ *                                        enable channel + optional flags
+ *   rm <channel> [--dry-run]             remove channel access
+ *   set <channel> [--no-mention|--mention] [--allow <id>...]
+ *                                        toggle existing channel without rm+add
+ *   allow <add|rm|ls> [<user-id>]        global DM allowlist management
+ *   lockdown [--off] [--dry-run]         dmPolicy=allowlist (or revert)
+ *
+ * Output: action lines for mutations, table for list/show/map, --json for piping.
+ */
+import { hostExec } from "maw-js/sdk";
+import { findHybridDiscord, findLegacyStateDir, loadStateDirsRegistry, listPassTokens, decryptToken } from "./lib";
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+
+interface BotResolved {
+  bot: string;
+  stateDir: string;
+  tokenName: string;
+  isHybrid: boolean;
+  accessJson: string;
+  channelMap: string;
+}
+
+async function resolveBot(log: (s: string) => void, bot: string): Promise<BotResolved | null> {
+  const registry = await loadStateDirsRegistry();
+  const hybrid = await findHybridDiscord(bot);
+  const legacy = findLegacyStateDir(bot);
+  const stateDir = hybrid || legacy;
+  if (!stateDir) {
+    log(`✗ no state-dir found for '${bot}' (checked hybrid <repo>/.discord/ and ${process.env.HOME}/.claude/channels/${bot}/)`);
+    return null;
+  }
+  const tokens = listPassTokens();
+  const tokEntry = tokens.find(t => t.bot === bot);
+  if (!tokEntry) {
+    log(`✗ no pass entry for '${bot}' (looked for discord/${bot}-token.gpg)`);
+    return null;
+  }
+  if (!registry.has(bot)) {
+    log(`⚠ '${bot}' not in discord-oracle/src/state-dirs.ts — dashboard won't see it`);
+  }
+  return {
+    bot,
+    stateDir,
+    tokenName: tokEntry.name,
+    isHybrid: !!hybrid,
+    accessJson: join(stateDir, "access.json"),
+    channelMap: join(stateDir, "channel-map.json"),
+  };
+}
+
+function loadAccess(path: string): any {
+  if (!existsSync(path)) {
+    return { dmPolicy: "allowlist", allowFrom: [], groups: {}, pending: {} };
+  }
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function saveAccess(path: string, data: any): void {
+  writeFileSync(path, JSON.stringify(data, null, 2) + "\n");
+}
+
+function loadChannelMap(path: string): Record<string, string> {
+  if (!existsSync(path)) return {};
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function resolveChannel(map: Record<string, string>, name: string): string | null {
+  if (/^\d+$/.test(name)) return name; // already an id
+  return map[name] ?? null;
+}
+
+async function execDiscordAccess(pre: BotResolved, args: string[], extraEnv: Record<string, string> = {}): Promise<string> {
+  const token = await decryptToken(pre.tokenName);
+  if (!token) throw new Error(`pass decrypt failed for ${pre.tokenName}`);
+  const env = [
+    `DISCORD_STATE_DIR=${pre.stateDir}`,
+    `DISCORD_BOT_TOKEN=${token}`,
+    `DISCORD_USER_ID=${extraEnv.DISCORD_USER_ID || process.env.DISCORD_USER_ID || "691531480689541170"}`,
+    ...(extraEnv.DISCORD_GUILD_ID ? [`DISCORD_GUILD_ID=${extraEnv.DISCORD_GUILD_ID}`] : []),
+  ].join(" ");
+  const cmd = `${env} discord-access ${args.join(" ")} 2>&1`;
+  return await hostExec(cmd);
+}
+
+function parseFlags(args: string[]): { positional: string[]; flags: Record<string, string | boolean | string[]> } {
+  const positional: string[] = [];
+  const flags: Record<string, string | boolean | string[]> = {};
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]!;
+    if (a === "--no-mention") flags.noMention = true;
+    else if (a === "--mention") flags.mention = true;
+    else if (a === "--dry-run") flags.dryRun = true;
+    else if (a === "--json") flags.json = true;
+    else if (a === "--refresh") flags.refresh = true;
+    else if (a === "--off") flags.off = true;
+    else if (a === "--guild") flags.guild = args[++i] ?? "";
+    else if (a === "--allow") {
+      const cur = (flags.allow as string[] | undefined) ?? [];
+      cur.push(args[++i] ?? "");
+      flags.allow = cur;
+    } else positional.push(a);
+  }
+  return { positional, flags };
+}
+
+export const cmdAccess = {
+  async run(log: (s: string) => void, args: string[]): Promise<void> {
+    if (args.length === 0) {
+      this.printUsage(log);
+      return;
+    }
+    const bot = args[0]!;
+    const sub = (args[1] || "").toLowerCase();
+    const rest = args.slice(2);
+
+    if (!sub || sub === "help" || sub === "-h" || sub === "--help") {
+      this.printUsage(log);
+      return;
+    }
+
+    const pre = await resolveBot(log, bot);
+    if (!pre) return;
+
+    log(`🪪 maw discord access ${bot} ${sub}${rest.length ? " " + rest.join(" ") : ""}`);
+    log(`  state-dir: ${pre.stateDir}${pre.isHybrid ? " (hybrid)" : " (legacy)"}`);
+    log("");
+
+    switch (sub) {
+      case "list":      return this.list(log, pre, rest);
+      case "show":      return this.show(log, pre, rest);
+      case "map":       return this.map(log, pre, rest);
+      case "add":       return this.add(log, pre, rest);
+      case "rm":        return this.rm(log, pre, rest);
+      case "set":       return this.set(log, pre, rest);
+      case "allow":     return this.allow(log, pre, rest);
+      case "lockdown":  return this.lockdown(log, pre, rest);
+      default:
+        log(`✗ unknown subcommand: ${sub}`);
+        this.printUsage(log);
+        return;
+    }
+  },
+
+  printUsage(log: (s: string) => void): void {
+    log("usage: maw discord access <bot> <subcommand> [args]");
+    log("");
+    log("subcommands:");
+    log("  list [--json]                       enabled channels for <bot>");
+    log("  show <channel> [--json]             inspect one channel's config");
+    log("  map [--guild <id>] [--refresh]      channel-map (name → id), --refresh from Discord");
+    log("  add <channel> [--no-mention] [--allow <id>...]");
+    log("                                      enable channel access");
+    log("  rm <channel> [--dry-run]            remove channel access");
+    log("  set <channel> [--no-mention|--mention] [--allow <id>...]");
+    log("                                      toggle existing channel without rm+add");
+    log("  allow <add|rm|ls> [<user-id>]       global DM allowlist management");
+    log("  lockdown [--off] [--dry-run]        dmPolicy=allowlist (or revert with --off)");
+  },
+
+  async list(log: (s: string) => void, pre: BotResolved, args: string[]): Promise<void> {
+    const { flags } = parseFlags(args);
+    const access = loadAccess(pre.accessJson);
+    const map = loadChannelMap(pre.channelMap);
+    const reverseMap: Record<string, string> = {};
+    for (const [name, id] of Object.entries(map)) reverseMap[id] = name;
+
+    const groups = access.groups || {};
+    const entries = Object.entries(groups).map(([id, cfg]: [string, any]) => ({
+      id,
+      name: reverseMap[id] || "(unknown)",
+      requireMention: cfg.requireMention,
+      allowFrom: cfg.allowFrom || [],
+    }));
+
+    if (flags.json) {
+      log(JSON.stringify({ bot: pre.bot, channels: entries }, null, 2));
+      return;
+    }
+
+    if (entries.length === 0) {
+      log("  (no channels enabled)");
+      return;
+    }
+    log(`  ${entries.length} channel(s):`);
+    log("");
+    log("  channel-name                     id                    mention  allowFrom");
+    log("  ─────────────────────────────────────────────────────────────────────────");
+    for (const e of entries) {
+      const name = e.name.padEnd(32);
+      const id = e.id.padEnd(20);
+      const m = e.requireMention ? "✓ tag  " : "○ all  ";
+      const allow = e.allowFrom.length ? e.allowFrom.join(",") : "(none)";
+      log(`  ${name} ${id}  ${m}  ${allow}`);
+    }
+  },
+
+  async show(log: (s: string) => void, pre: BotResolved, args: string[]): Promise<void> {
+    const { positional, flags } = parseFlags(args);
+    const channelArg = positional[0];
+    if (!channelArg) {
+      log("usage: maw discord access <bot> show <channel> [--json]");
+      return;
+    }
+    const map = loadChannelMap(pre.channelMap);
+    const id = resolveChannel(map, channelArg);
+    if (!id) {
+      log(`✗ channel '${channelArg}' not in channel-map (run 'access map --refresh')`);
+      return;
+    }
+    const access = loadAccess(pre.accessJson);
+    const cfg = access.groups?.[id];
+    if (!cfg) {
+      log(`✗ channel '${channelArg}' (${id}) not in access.json`);
+      return;
+    }
+    const reverseMap: Record<string, string> = {};
+    for (const [name, mapId] of Object.entries(map)) reverseMap[mapId] = name;
+    const out = {
+      bot: pre.bot,
+      channel: { id, name: reverseMap[id] || "(unknown)" },
+      requireMention: cfg.requireMention,
+      allowFrom: cfg.allowFrom || [],
+    };
+    if (flags.json) {
+      log(JSON.stringify(out, null, 2));
+      return;
+    }
+    log(`  #${out.channel.name} (${id})`);
+    log(`    requireMention: ${out.requireMention}`);
+    log(`    allowFrom:      ${out.allowFrom.join(", ") || "(none)"}`);
+  },
+
+  async map(log: (s: string) => void, pre: BotResolved, args: string[]): Promise<void> {
+    const { flags } = parseFlags(args);
+    if (flags.refresh) {
+      log("  refreshing channel-map from Discord...");
+      const out = await execDiscordAccess(pre, ["refresh"], flags.guild ? { DISCORD_GUILD_ID: flags.guild as string } : {});
+      log(out.split("\n").map(l => `    ${l}`).join("\n"));
+      log("");
+    }
+    const map = loadChannelMap(pre.channelMap);
+    const entries = Object.entries(map).sort((a, b) => a[0].localeCompare(b[0]));
+    if (entries.length === 0) {
+      log("  (no channels mapped — run with --refresh --guild <id>)");
+      return;
+    }
+    log(`  ${entries.length} channel(s) in map:`);
+    log("");
+    log("  channel-name                     id");
+    log("  ──────────────────────────────────────────────");
+    for (const [name, id] of entries) {
+      log(`  ${name.padEnd(32)} ${id}`);
+    }
+  },
+
+  async add(log: (s: string) => void, pre: BotResolved, args: string[]): Promise<void> {
+    const { positional, flags } = parseFlags(args);
+    const channelArg = positional[0];
+    if (!channelArg) {
+      log("usage: maw discord access <bot> add <channel> [--no-mention] [--allow <id>...]");
+      return;
+    }
+    const map = loadChannelMap(pre.channelMap);
+    const id = resolveChannel(map, channelArg);
+    if (!id) {
+      log(`✗ channel '${channelArg}' not in channel-map`);
+      log(`  run 'maw discord access ${pre.bot} map --refresh' first`);
+      return;
+    }
+    // Delegate add to discord-access (handles channel-name resolution + access.json create)
+    const reverseMap: Record<string, string> = {};
+    for (const [name, mapId] of Object.entries(map)) reverseMap[mapId] = name;
+    const channelName = reverseMap[id] || channelArg;
+    const out = await execDiscordAccess(pre, ["add", channelName]);
+    log(out.split("\n").map(l => `    ${l}`).join("\n"));
+
+    // Post-process for missing flags
+    const access = loadAccess(pre.accessJson);
+    if (!access.groups[id]) {
+      log(`✗ post-add check: access.json missing groups[${id}] — discord-access may have failed`);
+      return;
+    }
+    const before = JSON.stringify(access.groups[id]);
+    if (flags.noMention) {
+      access.groups[id].requireMention = false;
+    }
+    if (flags.allow && (flags.allow as string[]).length > 0) {
+      access.groups[id].allowFrom = flags.allow as string[];
+    }
+    const after = JSON.stringify(access.groups[id]);
+    if (before !== after) {
+      saveAccess(pre.accessJson, access);
+      log(`  ✓ flags applied: ${flags.noMention ? "mention=false " : ""}${flags.allow ? `allow=[${(flags.allow as string[]).join(",")}]` : ""}`);
+    } else {
+      log("  (defaults applied: requireMention=true, allowFrom=[$DISCORD_USER_ID])");
+    }
+  },
+
+  async rm(log: (s: string) => void, pre: BotResolved, args: string[]): Promise<void> {
+    const { positional, flags } = parseFlags(args);
+    const channelArg = positional[0];
+    if (!channelArg) {
+      log("usage: maw discord access <bot> rm <channel> [--dry-run]");
+      return;
+    }
+    const map = loadChannelMap(pre.channelMap);
+    const id = resolveChannel(map, channelArg);
+    if (!id) {
+      log(`✗ channel '${channelArg}' not in channel-map`);
+      return;
+    }
+    const reverseMap: Record<string, string> = {};
+    for (const [name, mapId] of Object.entries(map)) reverseMap[mapId] = name;
+    const channelName = reverseMap[id] || channelArg;
+    const access = loadAccess(pre.accessJson);
+    if (!access.groups?.[id]) {
+      log(`✗ channel '${channelName}' not currently enabled`);
+      return;
+    }
+    if (flags.dryRun) {
+      log(`  [dry-run] would remove #${channelName} (${id}) from access`);
+      log(`            current config: ${JSON.stringify(access.groups[id])}`);
+      return;
+    }
+    const out = await execDiscordAccess(pre, ["rm", channelName]);
+    log(out.split("\n").map(l => `    ${l}`).join("\n"));
+  },
+
+  async set(log: (s: string) => void, pre: BotResolved, args: string[]): Promise<void> {
+    const { positional, flags } = parseFlags(args);
+    const channelArg = positional[0];
+    if (!channelArg) {
+      log("usage: maw discord access <bot> set <channel> [--no-mention|--mention] [--allow <id>...]");
+      return;
+    }
+    const map = loadChannelMap(pre.channelMap);
+    const id = resolveChannel(map, channelArg);
+    if (!id) {
+      log(`✗ channel '${channelArg}' not in channel-map`);
+      return;
+    }
+    const access = loadAccess(pre.accessJson);
+    if (!access.groups?.[id]) {
+      log(`✗ channel not currently enabled — use 'add' instead`);
+      return;
+    }
+    const before = JSON.stringify(access.groups[id]);
+    if (flags.noMention) access.groups[id].requireMention = false;
+    if (flags.mention) access.groups[id].requireMention = true;
+    if (flags.allow && (flags.allow as string[]).length > 0) {
+      access.groups[id].allowFrom = flags.allow as string[];
+    }
+    const after = JSON.stringify(access.groups[id]);
+    if (before === after) {
+      log("  ○ no changes — already configured as requested");
+      return;
+    }
+    saveAccess(pre.accessJson, access);
+    log(`  ✓ updated: ${access.groups[id].requireMention ? "mention=true " : "mention=false "}allow=[${access.groups[id].allowFrom.join(",")}]`);
+  },
+
+  async allow(log: (s: string) => void, pre: BotResolved, args: string[]): Promise<void> {
+    const action = (args[0] || "").toLowerCase();
+    const userId = args[1];
+    if (!action || !["add", "rm", "ls"].includes(action)) {
+      log("usage: maw discord access <bot> allow <add|rm|ls> [<user-id>]");
+      return;
+    }
+    const access = loadAccess(pre.accessJson);
+    access.allowFrom = access.allowFrom || [];
+    if (action === "ls") {
+      log(`  global allowlist (${access.allowFrom.length}):`);
+      for (const id of access.allowFrom) log(`    ${id}`);
+      return;
+    }
+    if (!userId) {
+      log(`usage: maw discord access <bot> allow ${action} <user-id>`);
+      return;
+    }
+    if (action === "add") {
+      if (access.allowFrom.includes(userId)) {
+        log(`  ○ ${userId} already in allowlist`);
+        return;
+      }
+      access.allowFrom.push(userId);
+      saveAccess(pre.accessJson, access);
+      log(`  ✓ added ${userId} to global allowlist`);
+    } else { // rm
+      const before = access.allowFrom.length;
+      access.allowFrom = access.allowFrom.filter((id: string) => id !== userId);
+      if (access.allowFrom.length === before) {
+        log(`  ○ ${userId} not in allowlist`);
+        return;
+      }
+      saveAccess(pre.accessJson, access);
+      log(`  ✓ removed ${userId} from global allowlist`);
+    }
+  },
+
+  async lockdown(log: (s: string) => void, pre: BotResolved, args: string[]): Promise<void> {
+    const { flags } = parseFlags(args);
+    const access = loadAccess(pre.accessJson);
+    const current = access.dmPolicy;
+    const target = flags.off ? "pairing" : "allowlist";
+    if (current === target) {
+      log(`  ○ dmPolicy already '${target}' — no change`);
+      return;
+    }
+    if (flags.dryRun) {
+      log(`  [dry-run] would set dmPolicy: '${current}' → '${target}'`);
+      return;
+    }
+    access.dmPolicy = target;
+    saveAccess(pre.accessJson, access);
+    log(`  ✓ dmPolicy: '${current}' → '${target}'`);
+  },
+};

--- a/src/vendor/mpr-plugins/discord/bind.ts
+++ b/src/vendor/mpr-plugins/discord/bind.ts
@@ -1,0 +1,274 @@
+/**
+ * `maw discord bind <bot> [--apply] [--restart] [--session <name>]`
+ *
+ * End-to-end Discord-online for a bot ON THIS HOST. Codifies the manual
+ * pattern proven 3 times (odin + digger on m5, xiaoer on white):
+ *
+ *   1. Pre-flight: token in pass, state-dir, repo via ghq, REST 200, not-already-online
+ *   2. Spawn tmux session (default name: <bot>-discord)
+ *   3. Inject env (DISCORD_STATE_DIR + token from pass)
+ *   4. Launch `claude --dangerously-skip-permissions --channels plugin:discord@claude-plugins-official`
+ *   5. Wait + verify "Listening for channel messages" marker
+ *   6. Verify bun discord/0.0.4 process holds matching DISCORD_STATE_DIR
+ *
+ * Safety (per side-effect-verb-checklist + telegraph-destructive-tmux):
+ *   - DRY-RUN by default — shows plan, no writes
+ *   - --apply required to execute
+ *   - If bot already online → refuse without --restart (which adds telegraph + kill)
+ *   - --restart pre-checks attached clients; refuses if any (forces detach first)
+ *
+ * v0.3 scope: SINGLE-HOST (this host). Cross-host wake in v0.4.
+ */
+import { hostExec } from "maw-js/sdk";
+import {
+  listPassTokens, decryptToken, pingDiscord,
+  findLegacyStateDir, findGhqPath, findOnlineBunForBot,
+} from "./lib";
+
+interface BindOpts {
+  bot: string;
+  apply: boolean;
+  restart: boolean;
+  session?: string;
+  force: boolean;
+}
+
+interface PreflightResult {
+  ok: boolean;
+  rows: { check: string; status: "ok" | "warn" | "fail"; detail: string }[];
+  tokenName?: string;
+  stateDir?: string;
+  repoPath?: string;
+  online?: Awaited<ReturnType<typeof findOnlineBunForBot>>;
+  attachedClients?: string;
+}
+
+function parseOpts(args: string[]): BindOpts {
+  const positional = args.filter(a => !a.startsWith("--"));
+  const sessionIdx = args.indexOf("--session");
+  return {
+    bot: positional[0] || "",
+    apply: args.includes("--apply"),
+    restart: args.includes("--restart"),
+    session: sessionIdx !== -1 ? args[sessionIdx + 1] : undefined,
+    force: args.includes("--force"),
+  };
+}
+
+function sym(status: "ok" | "warn" | "fail"): string {
+  return status === "ok" ? "✓" : status === "warn" ? "○" : "✗";
+}
+
+async function runPreflight(bot: string): Promise<PreflightResult> {
+  const result: PreflightResult = { ok: true, rows: [] };
+
+  // 1. Token in pass
+  const tokens = listPassTokens();
+  const tok = tokens.find(t => t.bot === bot);
+  if (!tok) {
+    result.rows.push({ check: "token in pass", status: "fail", detail: `no discord/${bot}-token in pass` });
+    result.ok = false;
+    return result;
+  }
+  result.tokenName = tok.name;
+  result.rows.push({ check: "token in pass", status: "ok", detail: `discord/${tok.name}` });
+
+  // 2. State-dir exists
+  const stateDir = findLegacyStateDir(bot);
+  if (!stateDir) {
+    result.rows.push({ check: "state-dir", status: "fail", detail: `~/.claude/channels/${bot}/ missing` });
+    result.ok = false;
+    return result;
+  }
+  result.stateDir = stateDir;
+  result.rows.push({ check: "state-dir", status: "ok", detail: stateDir });
+
+  // 3. Repo via ghq
+  const repo = await findGhqPath(bot);
+  if (!repo) {
+    result.rows.push({ check: "repo (ghq)", status: "warn", detail: `no ghq match for '${bot}' — will cwd to state-dir parent` });
+    // Not fatal — can still run with state-dir as cwd
+  } else {
+    result.repoPath = repo;
+    result.rows.push({ check: "repo (ghq)", status: "ok", detail: repo });
+  }
+
+  // 4. Discord REST 200
+  const token = await decryptToken(tok.name);
+  if (!token) {
+    result.rows.push({ check: "Discord REST", status: "fail", detail: "decrypt failed" });
+    result.ok = false;
+    return result;
+  }
+  const ping = await pingDiscord(token);
+  if (!ping.ok) {
+    result.rows.push({ check: "Discord REST", status: "fail", detail: `${ping.status || "ERR"}` });
+    result.ok = false;
+    return result;
+  }
+  result.rows.push({ check: "Discord REST", status: "ok", detail: `200 — ${ping.username || "?"}` });
+
+  // 5. Already online?
+  const online = await findOnlineBunForBot(bot);
+  if (online) {
+    result.online = online;
+    const where = online.tmuxSession ? `tmux ${online.tmuxSession}` : "(unknown tmux)";
+    result.rows.push({
+      check: "not already online",
+      status: "fail",
+      detail: `already online — bun pid ${online.bunPid} in ${where}`,
+    });
+    result.ok = false;
+  } else {
+    result.rows.push({ check: "not already online", status: "ok", detail: "no live Gateway for this token on this host" });
+  }
+
+  return result;
+}
+
+function emitPreflight(log: (s: string) => void, pre: PreflightResult): void {
+  log("  pre-flight:");
+  for (const row of pre.rows) {
+    log(`    ${sym(row.status)} ${row.check.padEnd(22)} ${row.detail}`);
+  }
+}
+
+function planSummary(opts: BindOpts, pre: PreflightResult): string[] {
+  const session = opts.session || `${opts.bot}-discord`;
+  const cwd = pre.repoPath || pre.stateDir!;
+  return [
+    `  plan:`,
+    `    session   tmux new-session -d -s ${session} -c ${cwd}`,
+    `    env       DISCORD_STATE_DIR=${pre.stateDir}`,
+    `    env       DISCORD_BOT_TOKEN=$(pass show discord/${pre.tokenName})  [redacted]`,
+    `    launch    claude --dangerously-skip-permissions --channels plugin:discord@claude-plugins-official`,
+    `    wait      12s for Gateway connect`,
+    `    verify    "Listening for channel messages" marker + bun discord/0.0.4 with matching STATE_DIR`,
+  ];
+}
+
+async function executeBind(log: (s: string) => void, opts: BindOpts, pre: PreflightResult): Promise<boolean> {
+  const session = opts.session || `${opts.bot}-discord`;
+  const cwd = pre.repoPath || pre.stateDir!;
+
+  // Step 1: create tmux session
+  log(`  + tmux new-session -d -s ${session} -c ${cwd}`);
+  try {
+    await hostExec(`tmux new-session -d -s ${session} -c ${cwd}`);
+  } catch (e: any) {
+    log(`  ✗ tmux session create failed: ${e?.message || e}`);
+    return false;
+  }
+
+  // Step 2: inject env + claude via maw run (safety-hook compliant)
+  const cmd = `export DISCORD_STATE_DIR=${pre.stateDir} && export DISCORD_BOT_TOKEN=$(pass show discord/${pre.tokenName}) && claude --dangerously-skip-permissions --channels plugin:discord@claude-plugins-official`;
+  log(`  + maw run ${session} <env-injection + claude --channels>`);
+  try {
+    await hostExec(`maw run ${session} ${JSON.stringify(cmd)} 2>&1 | tail -1`);
+  } catch (e: any) {
+    log(`  ✗ maw run failed: ${e?.message || e}`);
+    return false;
+  }
+
+  // Step 3: wait + verify
+  log(`  ⏳ waiting 12s for claude + Discord Gateway boot...`);
+  await new Promise(r => setTimeout(r, 12000));
+
+  // Step 4: check for Listening marker
+  let listening = false;
+  try {
+    const peek = await hostExec(`tmux capture-pane -t ${session} -p 2>/dev/null | grep -c "Listening for channel messages" || true`);
+    listening = parseInt(peek.trim(), 10) > 0;
+  } catch { /* skip */ }
+  log(`  ${listening ? "✓" : "✗"} "Listening for channel messages" marker ${listening ? "present" : "MISSING"}`);
+
+  // Step 5: verify bun discord plugin process
+  const online = await findOnlineBunForBot(opts.bot);
+  if (online) {
+    log(`  ✓ bun discord/0.0.4 running (pid ${online.bunPid}, tmux ${online.tmuxSession || "?"})`);
+  } else {
+    log(`  ✗ no bun discord/0.0.4 process found matching this bot's state-dir`);
+  }
+
+  return listening && !!online;
+}
+
+export const cmdBind = {
+  async run(log: (s: string) => void, args: string[]): Promise<void> {
+    const opts = parseOpts(args);
+
+    if (!opts.bot) {
+      log("usage: maw discord bind <bot> [--apply] [--restart] [--session <name>] [--force]");
+      log("");
+      log("  --apply      execute the plan (default: dry-run)");
+      log("  --restart    if already online, telegraph + kill the existing session first");
+      log("  --session    custom tmux session name (default: <bot>-discord)");
+      log("  --force      override 'attached clients' check on --restart (yanks panes)");
+      return;
+    }
+
+    log(`🪣 maw discord bind ${opts.bot}${opts.apply ? " --apply" : " (dry-run — pass --apply to execute)"}`);
+    log("");
+
+    const pre = await runPreflight(opts.bot);
+    emitPreflight(log, pre);
+    log("");
+
+    // Handle --restart: if online + restart flag, telegraph + kill + treat as not-online
+    if (pre.online && opts.restart) {
+      log("  → --restart: pre-checking attached clients to existing session");
+      const sess = pre.online.tmuxSession;
+      if (sess) {
+        const clients = await hostExec(`tmux list-clients -t ${sess} 2>/dev/null || true`);
+        const clientCount = clients.split("\n").filter(Boolean).length;
+        log(`    attached clients to '${sess}': ${clientCount}`);
+        if (clientCount > 0 && !opts.force) {
+          log(`  🛑 ${clientCount} client(s) attached to '${sess}' — refusing kill without --force`);
+          log(`     detach first (Ctrl-b d in each terminal) and re-run, or add --force to yank panes`);
+          return;
+        }
+        log(`  + tmux kill-session -t ${sess}`);
+        if (opts.apply) {
+          try { await hostExec(`tmux kill-session -t ${sess}`); } catch { /* maybe gone */ }
+          log(`  ⏳ sleeping 3s for Gateway disconnect`);
+          await new Promise(r => setTimeout(r, 3000));
+          // Reset pre-flight state — we just killed the old one
+          pre.online = null;
+          // Remove the failing row
+          pre.rows = pre.rows.filter(r => r.check !== "not already online");
+          pre.rows.push({ check: "not already online", status: "ok", detail: "killed old session for restart" });
+          pre.ok = pre.rows.every(r => r.status !== "fail");
+        }
+      }
+    }
+
+    if (!pre.ok) {
+      log("");
+      log("  ✗ pre-flight failed. fix the failing checks above and re-run.");
+      if (pre.online && !opts.restart) {
+        log("     to restart anyway, re-run with --restart (telegraphs + kills the existing session)");
+      }
+      return;
+    }
+
+    const plan = planSummary(opts, pre);
+    for (const line of plan) log(line);
+    log("");
+
+    if (!opts.apply) {
+      log("  ⓘ dry-run only — re-run with --apply to execute");
+      return;
+    }
+
+    log("  🪝 executing...");
+    log("");
+    const success = await executeBind(log, opts, pre);
+    log("");
+
+    if (success) {
+      log(`  🎯 ${opts.bot} is now ONLINE on Discord (session: ${opts.session || `${opts.bot}-discord`})`);
+    } else {
+      log(`  ⚠ bind completed but verification was incomplete. Check 'maw discord status ${opts.bot} --check' + tmux peek.`);
+    }
+  },
+};

--- a/src/vendor/mpr-plugins/discord/index.ts
+++ b/src/vendor/mpr-plugins/discord/index.ts
@@ -1,0 +1,145 @@
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import { cmdTokens } from "./tokens";
+import { cmdStatus } from "./status";
+import { cmdBind } from "./bind";
+import { cmdAccess } from "./access";
+import { cmdGuilds, cmdChannels, cmdMembers, cmdInventory } from "./inventory";
+import { readFileSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+export const command = {
+  name: "discord",
+  description: "Discord fleet ops — tokens, status, bind, (pair/route/serve coming).",
+};
+
+function getVersion(): string {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const pkg = JSON.parse(readFileSync(join(here, "plugin.json"), "utf8"));
+    return pkg.version || "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+function printVersion(log: (s: string) => void): void {
+  log(`maw discord v${getVersion()}`);
+  log("");
+  log("subcommand status:");
+  log("  ✓ tokens ls / check        v0.1");
+  log("  ✓ status [bot] [flags]     v0.3.1 (real online/where via bun ancestry)");
+  log("  ✓ bind <bot>               v0.3 (rewrite to use 'maw wake' pending)");
+  log("  ✓ access <bot> ...         v0.4 (list/show/map/add/rm/set/allow/lockdown)");
+  log("  ✓ guilds/channels/members/inventory <bot>  v0.4.2 (Discord-state visibility)");
+  log("  ⏸ pair <oracle> <chan>     v0.5 planned");
+  log("  ⏸ route <from> <to>        v0.5 planned");
+  log("  ⏸ serve (after_send hook)  v0.5 planned (replaces daemon — engine.serve)");
+}
+
+function printUsage(log: (s: string) => void): void {
+  log("usage: maw discord <subcommand> [args]");
+  log("");
+  log("subcommands:");
+  log("  version                            show plugin version + subcommand status");
+  log("  tokens ls                          list all Discord bot tokens in pass (no reveal)");
+  log("  tokens check [bot]                 verify each token decrypts + Discord REST 200");
+  log("  status [bot] [--check] [--redact] [--json]");
+  log("                                     fleet inspection from this host — pass × legacy × hybrid × tmux × registry");
+  log("  bind <bot> [--apply] [--restart] [--session <name>] [--force]");
+  log("                                     end-to-end Discord-online for a bot on this host");
+  log("  access <bot> <list|show|map|add|rm|set|allow|lockdown> [...]");
+  log("                                     channel + allowlist management per bot (NEW v0.4)");
+  log("");
+  log("subcommands (planned):");
+  log("  pair <oracle> <channel>            access.json + channel-map.json bootstrap (v0.5)");
+  log("  route <from> <to>                  channel-map.json entry (v0.5)");
+  log("  serve (hook handler)               wires after_send → Discord post (v0.5)");
+  log("");
+  log("token strategy: HYBRID — tokens in pass (central), .discord/ config in bot repo.");
+  log("see: ψ/outbox/ideas/2026-05-17_self-contained-bot-repo-gpg-pattern.md");
+}
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const log = (s: string) => {
+    if (ctx.writer) ctx.writer(s);
+    else logs.push(s);
+  };
+
+  try {
+    const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+    const sub = args[0]?.toLowerCase();
+
+    if (!sub || sub === "help" || sub === "-h" || sub === "--help") {
+      printUsage(log);
+      return { ok: true, output: logs.join("\n") };
+    }
+
+    if (sub === "version" || sub === "-v" || sub === "--version") {
+      printVersion(log);
+      return { ok: true, output: logs.join("\n") };
+    }
+
+    if (sub === "tokens") {
+      const action = args[1]?.toLowerCase();
+      if (!action || action === "ls") {
+        await cmdTokens.ls(log);
+      } else if (action === "check") {
+        await cmdTokens.check(log, args[2]);
+      } else {
+        log(`unknown subcommand: tokens ${action}`);
+        log("usage: maw discord tokens <ls|check> [bot]");
+        return { ok: false, error: `unknown action: ${action}`, output: logs.join("\n") };
+      }
+      return { ok: true, output: logs.join("\n") };
+    }
+
+    if (sub === "status") {
+      await cmdStatus.run(log, args.slice(1));
+      return { ok: true, output: logs.join("\n") };
+    }
+
+    if (sub === "bind") {
+      await cmdBind.run(log, args.slice(1));
+      return { ok: true, output: logs.join("\n") };
+    }
+
+    if (sub === "access") {
+      await cmdAccess.run(log, args.slice(1));
+      return { ok: true, output: logs.join("\n") };
+    }
+
+    if (sub === "guilds") {
+      await cmdGuilds.run(log, args.slice(1));
+      return { ok: true, output: logs.join("\n") };
+    }
+
+    if (sub === "channels") {
+      await cmdChannels.run(log, args.slice(1));
+      return { ok: true, output: logs.join("\n") };
+    }
+
+    if (sub === "members") {
+      await cmdMembers.run(log, args.slice(1));
+      return { ok: true, output: logs.join("\n") };
+    }
+
+    if (sub === "inventory") {
+      await cmdInventory.run(log, args.slice(1));
+      return { ok: true, output: logs.join("\n") };
+    }
+
+    if (sub === "pair" || sub === "route" || sub === "serve") {
+      log(`✗ '${sub}' not implemented yet (v0.4 ships tokens + status + bind + access).`);
+      log("planned for v0.5 — see 'maw discord' for full subcommand list.");
+      return { ok: false, error: `${sub} not implemented`, output: logs.join("\n") };
+    }
+
+    log(`unknown subcommand: ${sub}`);
+    printUsage(log);
+    return { ok: false, error: `unknown subcommand: ${sub}`, output: logs.join("\n") };
+  } catch (e: any) {
+    return { ok: false, error: e?.message || String(e), output: logs.join("\n") };
+  }
+}

--- a/src/vendor/mpr-plugins/discord/inventory.ts
+++ b/src/vendor/mpr-plugins/discord/inventory.ts
@@ -1,0 +1,349 @@
+/**
+ * `maw discord <guilds|channels|inventory|members>` — Discord-state visibility.
+ *
+ * Complements access.ts (config side) with the REST/Discord side:
+ *   - guilds:    which servers is this bot in?
+ *   - channels:  what channels exist per guild?
+ *   - members:   who can chat in a channel (allowFrom + optional REST member list)?
+ *   - inventory: full report — guilds × channels × access cross-reference
+ *
+ * All read-only. No JSON mutation. Heavy callers should use --json to pipe.
+ */
+import { listPassTokens, decryptToken, findHybridDiscord, findLegacyStateDir } from "./lib";
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+
+interface BotPre {
+  bot: string;
+  stateDir: string;
+  tokenName: string;
+  token: string;
+  accessJson: string;
+  channelMap: string;
+}
+
+async function resolveBot(log: (s: string) => void, bot: string): Promise<BotPre | null> {
+  const hybrid = await findHybridDiscord(bot);
+  const legacy = findLegacyStateDir(bot);
+  const stateDir = hybrid || legacy;
+  if (!stateDir) {
+    log(`✗ no state-dir for '${bot}'`);
+    return null;
+  }
+  const tokens = listPassTokens();
+  const tok = tokens.find(t => t.bot === bot);
+  if (!tok) {
+    log(`✗ no pass entry for '${bot}'`);
+    return null;
+  }
+  const token = await decryptToken(tok.name);
+  if (!token) {
+    log(`✗ failed to decrypt pass entry for '${bot}'`);
+    return null;
+  }
+  return {
+    bot,
+    stateDir,
+    tokenName: tok.name,
+    token,
+    accessJson: join(stateDir, "access.json"),
+    channelMap: join(stateDir, "channel-map.json"),
+  };
+}
+
+interface Guild {
+  id: string;
+  name: string;
+}
+
+interface Channel {
+  id: string;
+  name: string;
+  type: number;
+  parent_id?: string | null;
+  guild_id?: string;
+}
+
+async function fetchGuilds(token: string): Promise<Guild[]> {
+  const res = await fetch("https://discord.com/api/v10/users/@me/guilds", {
+    headers: { Authorization: `Bot ${token}` },
+  });
+  if (!res.ok) throw new Error(`guilds REST ${res.status}`);
+  return await res.json() as Guild[];
+}
+
+// Per-process user-name cache so repeated id→name lookups don't refetch
+const _userCache: Map<string, string> = new Map();
+
+async function resolveUserName(token: string, userId: string): Promise<string> {
+  if (_userCache.has(userId)) return _userCache.get(userId)!;
+  try {
+    const res = await fetch(`https://discord.com/api/v10/users/${userId}`, {
+      headers: { Authorization: `Bot ${token}` },
+    });
+    if (res.status === 429) {
+      const retry = parseFloat(res.headers.get("retry-after") || "1");
+      await new Promise(r => setTimeout(r, (retry + 0.2) * 1000));
+      return resolveUserName(token, userId);
+    }
+    if (!res.ok) { _userCache.set(userId, userId); return userId; }
+    const u: any = await res.json();
+    const name = u.global_name || u.username || userId;
+    _userCache.set(userId, name);
+    return name;
+  } catch {
+    _userCache.set(userId, userId);
+    return userId;
+  }
+}
+
+async function resolveUserList(token: string, ids: string[]): Promise<string[]> {
+  const out: string[] = [];
+  for (const id of ids) {
+    out.push(await resolveUserName(token, id));
+    await new Promise(r => setTimeout(r, 80));
+  }
+  return out;
+}
+
+async function fetchChannels(token: string, guildId: string, retries = 2): Promise<Channel[]> {
+  for (let i = 0; i <= retries; i++) {
+    const res = await fetch(`https://discord.com/api/v10/guilds/${guildId}/channels`, {
+      headers: { Authorization: `Bot ${token}` },
+    });
+    if (res.status === 429) {
+      const retryAfter = parseFloat(res.headers.get("retry-after") || "1");
+      await new Promise(r => setTimeout(r, (retryAfter + 0.2) * 1000));
+      continue;
+    }
+    if (!res.ok) throw new Error(`channels REST ${res.status} for guild ${guildId}`);
+    return await res.json() as Channel[];
+  }
+  throw new Error(`channels REST 429 (exhausted retries) for guild ${guildId}`);
+}
+
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
+
+function channelTypeLabel(t: number): string {
+  switch (t) {
+    case 0: return "text";
+    case 2: return "voice";
+    case 4: return "cat";
+    case 5: return "news";
+    case 10: case 11: case 12: return "thread";
+    case 13: return "stage";
+    case 15: return "forum";
+    case 16: return "media";
+    default: return `t${t}`;
+  }
+}
+
+function loadAccessGroups(path: string): Record<string, any> {
+  if (!existsSync(path)) return {};
+  try { return JSON.parse(readFileSync(path, "utf8")).groups || {}; } catch { return {}; }
+}
+
+function parseFlags(args: string[]): { positional: string[]; flags: Record<string, any> } {
+  const positional: string[] = [];
+  const flags: Record<string, any> = {};
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]!;
+    if (a === "--json") flags.json = true;
+    else if (a === "--all-guilds") flags.allGuilds = true;
+    else if (a === "--with-threads") flags.withThreads = true;
+    else if (a === "--guild") flags.guild = args[++i] ?? "";
+    else positional.push(a);
+  }
+  return { positional, flags };
+}
+
+export const cmdGuilds = {
+  async run(log: (s: string) => void, args: string[]): Promise<void> {
+    const [bot, ...rest] = args;
+    if (!bot) { log("usage: maw discord guilds <bot> [--json]"); return; }
+    const pre = await resolveBot(log, bot);
+    if (!pre) return;
+    const { flags } = parseFlags(rest);
+    const guilds = await fetchGuilds(pre.token);
+    if (flags.json) {
+      log(JSON.stringify({ bot, guilds }, null, 2));
+      return;
+    }
+    log(`🌐 ${bot} is in ${guilds.length} server(s):`);
+    log("");
+    log("  id                    name");
+    log("  ────────────────────  ────────────────────────────────────");
+    for (const g of guilds) {
+      log(`  ${g.id}  ${g.name}`);
+    }
+  },
+};
+
+export const cmdChannels = {
+  async run(log: (s: string) => void, args: string[]): Promise<void> {
+    const [bot, ...rest] = args;
+    if (!bot) { log("usage: maw discord channels <bot> [--guild <id>] [--all-guilds] [--json] [--with-threads]"); return; }
+    const pre = await resolveBot(log, bot);
+    if (!pre) return;
+    const { flags } = parseFlags(rest);
+
+    const guilds = await fetchGuilds(pre.token);
+    const targets = flags.guild
+      ? guilds.filter(g => g.id === flags.guild)
+      : (flags.allGuilds ? guilds : guilds.slice(0, 1));
+
+    const out: Array<{ guild: Guild; channels: Channel[] }> = [];
+    for (const g of targets) {
+      try {
+        await sleep(250); // pace requests to stay under Discord per-route limits
+        const chs = await fetchChannels(pre.token, g.id);
+        const filtered = flags.withThreads ? chs : chs.filter(c => c.type !== 10 && c.type !== 11 && c.type !== 12);
+        out.push({ guild: g, channels: filtered });
+      } catch (e: any) {
+        log(`  ⚠ ${g.id} ${g.name}: ${e.message}`);
+      }
+    }
+    if (flags.json) {
+      log(JSON.stringify({ bot, guilds: out }, null, 2));
+      return;
+    }
+    log(`📺 ${bot} channels across ${out.length} guild(s):`);
+    log("");
+    for (const { guild, channels } of out) {
+      log(`  ▼ ${guild.name} (${guild.id})  ·  ${channels.length} channel(s)`);
+      const groups: Record<string, Channel[]> = {};
+      for (const c of channels) {
+        const cat = c.parent_id || "_root";
+        if (!groups[cat]) groups[cat] = [];
+        groups[cat]!.push(c);
+      }
+      const cats = channels.filter(c => c.type === 4);
+      const catNameById = new Map(cats.map(c => [c.id, c.name]));
+      for (const c of channels.filter(c => c.type !== 4).sort((a, b) => a.name.localeCompare(b.name))) {
+        const catLabel = c.parent_id ? `[${catNameById.get(c.parent_id) || "?"}]` : "";
+        log(`     ${c.id}  ${channelTypeLabel(c.type).padEnd(6)}  #${c.name.padEnd(36)} ${catLabel}`);
+      }
+      log("");
+    }
+  },
+};
+
+export const cmdMembers = {
+  async run(log: (s: string) => void, args: string[]): Promise<void> {
+    const [bot, channelArg] = args;
+    if (!bot || !channelArg) { log("usage: maw discord members <bot> <channel-name-or-id> [--json]"); return; }
+    const pre = await resolveBot(log, bot);
+    if (!pre) return;
+
+    // Resolve channel to id
+    let channelId = /^\d+$/.test(channelArg) ? channelArg : null;
+    if (!channelId) {
+      const map = existsSync(pre.channelMap) ? JSON.parse(readFileSync(pre.channelMap, "utf8")) : {};
+      channelId = map[channelArg] || null;
+    }
+    if (!channelId) {
+      log(`✗ channel '${channelArg}' not in channel-map. Run 'maw discord access ${bot} map --guild <id> --refresh'`);
+      return;
+    }
+    const groups = loadAccessGroups(pre.accessJson);
+    const cfg = groups[channelId];
+    if (!cfg) {
+      log(`✗ channel ${channelId} not in access.json groups for ${bot}`);
+      return;
+    }
+    const { flags } = parseFlags(args.slice(2));
+    const ids: string[] = cfg.allowFrom || [];
+    const names = await resolveUserList(pre.token, ids);
+    const pairs = ids.map((id, i) => ({ id, name: names[i]! }));
+    const result = {
+      bot,
+      channel: { id: channelId, name: channelArg },
+      requireMention: cfg.requireMention,
+      allowFrom: pairs,
+      effective: ids.length === 0 ? "EVERYONE (no allowlist)" : `${ids.length} user(s)`,
+    };
+    if (flags.json) { log(JSON.stringify(result, null, 2)); return; }
+    log(`👥 ${bot} · #${channelArg} (${channelId})`);
+    log(`   requireMention: ${result.requireMention}`);
+    if (pairs.length === 0) {
+      log(`   allowFrom:      (none)`);
+    } else {
+      log(`   allowFrom:`);
+      for (const p of pairs) log(`     · ${p.name.padEnd(18)} (${p.id})`);
+    }
+    log(`   effective:      ${result.effective}`);
+  },
+};
+
+export const cmdInventory = {
+  async run(log: (s: string) => void, args: string[]): Promise<void> {
+    const [bot, ...rest] = args;
+    if (!bot) { log("usage: maw discord inventory <bot> [--json]"); return; }
+    const pre = await resolveBot(log, bot);
+    if (!pre) return;
+    const { flags } = parseFlags(rest);
+
+    const guilds = await fetchGuilds(pre.token);
+    const groups = loadAccessGroups(pre.accessJson);
+
+    interface Row {
+      guild: Guild;
+      channels: Array<{ channel: Channel; enabled: boolean; mention?: boolean; allowFrom?: string[] }>;
+    }
+    const rows: Row[] = [];
+    for (const g of guilds) {
+      try {
+        await sleep(250); // pace requests to stay under Discord per-route limits
+        const chs = await fetchChannels(pre.token, g.id);
+        const visible = chs.filter(c => c.type === 0 || c.type === 5 || c.type === 15);
+        const annotated = visible.map(c => {
+          const cfg = groups[c.id];
+          return {
+            channel: c,
+            enabled: !!cfg,
+            mention: cfg?.requireMention,
+            allowFrom: cfg?.allowFrom || [],
+          };
+        });
+        rows.push({ guild: g, channels: annotated });
+      } catch (e: any) {
+        log(`  ⚠ ${g.id} ${g.name}: ${e.message}`);
+      }
+    }
+
+    if (flags.json) {
+      log(JSON.stringify({ bot, inventory: rows }, null, 2));
+      return;
+    }
+
+    // Pre-resolve all unique user ids referenced in access.json for nicer rendering
+    const allIds = new Set<string>();
+    for (const r of rows) for (const c of r.channels) (c.allowFrom || []).forEach(id => allIds.add(id));
+    const nameById = new Map<string, string>();
+    for (const id of allIds) nameById.set(id, await resolveUserName(pre.token, id));
+
+    let totalEnabled = 0;
+    let totalChannels = 0;
+    log(`📋 ${bot} — full inventory`);
+    log("");
+    for (const { guild, channels } of rows) {
+      const enabled = channels.filter(c => c.enabled).length;
+      totalEnabled += enabled;
+      totalChannels += channels.length;
+      log(`  ▼ ${guild.name}  (${guild.id})  ·  ${enabled}/${channels.length} enabled`);
+      for (const c of channels.sort((a, b) => a.channel.name.localeCompare(b.channel.name))) {
+        if (c.enabled) {
+          const mention = c.mention ? "✓ tag " : "○ all ";
+          const allow = c.allowFrom!.length === 0
+            ? "EVERYONE"
+            : c.allowFrom!.map(id => nameById.get(id) || id).join(", ");
+          log(`     ✓ #${c.channel.name.padEnd(36)} ${mention} ${allow}`);
+        } else {
+          log(`     · #${c.channel.name.padEnd(36)} (in guild, no access)`);
+        }
+      }
+      log("");
+    }
+    log(`summary: ${guilds.length} server(s) · ${totalChannels} channels visible · ${totalEnabled} enabled · ${nameById.size} unique allow-users resolved`);
+  },
+};

--- a/src/vendor/mpr-plugins/discord/lib.ts
+++ b/src/vendor/mpr-plugins/discord/lib.ts
@@ -1,0 +1,239 @@
+/**
+ * Shared utilities for the `maw discord` plugin family.
+ *
+ * All side-effect-free or read-only. Subcommand modules (tokens.ts, status.ts)
+ * import from here so we never duplicate decrypt/REST/filesystem helpers.
+ */
+import { hostExec } from "maw-js/sdk";
+import { existsSync, readdirSync, readFileSync, statSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+export const PASS_DIR = join(homedir(), ".password-store", "discord");
+export const LEGACY_STATE_DIR_ROOT = join(homedir(), ".claude", "channels");
+
+export interface TokenEntry {
+  name: string;     // e.g. "pulse-oracle-token"
+  bot: string;      // e.g. "pulse-oracle"  (token name without -token suffix)
+  file: string;
+  sizeBytes: number;
+  mtime: Date;
+}
+
+export function listPassTokens(): TokenEntry[] {
+  if (!existsSync(PASS_DIR)) return [];
+  return readdirSync(PASS_DIR)
+    .filter(f => f.endsWith(".gpg"))
+    .map(f => {
+      const file = join(PASS_DIR, f);
+      const stat = statSync(file);
+      const name = f.replace(/\.gpg$/, "");
+      const bot = name.replace(/-token$/, "");
+      return { name, bot, file, sizeBytes: stat.size, mtime: stat.mtime };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function decryptToken(passName: string): Promise<string | null> {
+  try {
+    const out = await hostExec(`pass show discord/${passName} 2>/dev/null`);
+    return out.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+export interface DiscordPing {
+  ok: boolean;
+  status: number;
+  username?: string;
+}
+
+export async function pingDiscord(token: string, timeoutMs = 5000): Promise<DiscordPing> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const res = await fetch("https://discord.com/api/v10/users/@me", {
+      headers: { Authorization: `Bot ${token}` },
+      signal: ctrl.signal,
+    });
+    if (res.ok) {
+      const data: any = await res.json();
+      return { ok: true, status: res.status, username: data.username };
+    }
+    return { ok: false, status: res.status };
+  } catch {
+    return { ok: false, status: 0 };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Resolve a bot/repo name to its on-disk ghq path. Returns the first match
+ * (prefers Soul-Brews-Studio over forks if both exist).
+ */
+export async function findGhqPath(name: string): Promise<string | null> {
+  try {
+    // grep (not -F) for end-of-line anchor; escape regex metacharacters in name
+    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const out = await hostExec(`ghq list -p 2>/dev/null | grep "/${escaped}$" || true`);
+    const lines = out.split("\n").map(s => s.trim()).filter(Boolean);
+    if (lines.length === 0) return null;
+    // Prefer Soul-Brews-Studio paths over forks/duplicates
+    const preferred = lines.find(l => l.includes("/Soul-Brews-Studio/"));
+    return preferred ?? lines[0];
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Legacy state-dir check: `~/.claude/channels/<bot>/` exists?
+ */
+export function findLegacyStateDir(bot: string): string | null {
+  const path = join(LEGACY_STATE_DIR_ROOT, bot);
+  return existsSync(path) ? path : null;
+}
+
+/**
+ * Hybrid pattern check: `<bot-repo>/.discord/` exists?
+ */
+export async function findHybridDiscord(bot: string): Promise<string | null> {
+  const repo = await findGhqPath(bot);
+  if (!repo) return null;
+  const discoDir = join(repo, ".discord");
+  return existsSync(discoDir) ? discoDir : null;
+}
+
+/**
+ * tmux session lookup — finds any session whose name contains <bot>.
+ * Returns the full session line (e.g. "07-pulse-oracle: 1 windows ...") or null.
+ */
+export async function findTmuxSession(bot: string): Promise<string | null> {
+  try {
+    const out = await hostExec(`tmux ls 2>/dev/null | grep -F "${bot}" || true`);
+    const first = out.split("\n")[0]?.trim();
+    return first || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse discord-oracle/src/state-dirs.ts to get the set of registered bots.
+ * Returns empty set if discord-oracle isn't cloned locally.
+ */
+export async function loadStateDirsRegistry(): Promise<Set<string>> {
+  const repo = await findGhqPath("discord-oracle");
+  if (!repo) return new Set();
+  const file = join(repo, "src", "state-dirs.ts");
+  if (!existsSync(file)) return new Set();
+  try {
+    const content = readFileSync(file, "utf8");
+    // Limit to STATE_DIRS block (avoid matching ANCHORS keys)
+    const stateBlock = content.split(/export const ANCHORS/)[0]!;
+    const matches = stateBlock.matchAll(/"([a-z][a-z0-9-]+)":/gi);
+    return new Set(Array.from(matches, m => m[1]!));
+  } catch {
+    return new Set();
+  }
+}
+
+/**
+ * Parse the ANCHORS export from discord-oracle/src/state-dirs.ts.
+ * Returns bot → canonical-host mapping. Bots not in ANCHORS have no anchor.
+ */
+export async function loadAnchors(): Promise<Record<string, string>> {
+  const repo = await findGhqPath("discord-oracle");
+  if (!repo) return {};
+  const file = join(repo, "src", "state-dirs.ts");
+  if (!existsSync(file)) return {};
+  try {
+    const content = readFileSync(file, "utf8");
+    const block = content.split(/export const ANCHORS[^{]*{/)[1];
+    if (!block) return {};
+    const body = block.split(/^};/m)[0] || "";
+    const out: Record<string, string> = {};
+    for (const m of body.matchAll(/"([a-z][a-z0-9-]+)"\s*:\s*"([^"]+)"/gi)) {
+      out[m[1]!] = m[2]!;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Pretty-printed file size — bytes only for v0.2 (most files <1KB).
+ */
+export function fmtSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  return `${(bytes / 1024).toFixed(1)}K`;
+}
+
+/**
+ * Find a running bun process for the discord plugin whose env DISCORD_STATE_DIR
+ * matches the bot's state-dir. Returns the bun pid + the owning tmux session
+ * (walked through claude parent + tmux pane lookup), or null if not online.
+ *
+ * Used by `bind` for the "already online?" pre-flight check and by v0.3 status
+ * to replace the brittle name-grep tmux lookup.
+ */
+export async function findOnlineBunForBot(bot: string): Promise<{
+  bunPid: number;
+  claudePid?: number;
+  tmuxSession?: string;
+} | null> {
+  try {
+    // Find all bun processes running the discord plugin
+    const bunList = await hostExec(`pgrep -f 'discord/0.0.4' 2>/dev/null || true`);
+    const pids = bunList.split("\n").map(s => s.trim()).filter(s => /^\d+$/.test(s));
+
+    for (const pidStr of pids) {
+      const pid = parseInt(pidStr, 10);
+      // Read env to check DISCORD_STATE_DIR
+      const env = await hostExec(`ps Eww -p ${pid} 2>/dev/null || true`);
+      const match = env.match(/DISCORD_STATE_DIR=(\S+)/);
+      if (!match) continue;
+      const stateDir = match[1]!;
+      // Must end with /<bot>
+      if (!stateDir.endsWith(`/${bot}`) && !stateDir.endsWith(`/${bot}/`)) continue;
+
+      // Walk up to claude parent
+      const parentRaw = await hostExec(`ps -o ppid= -p ${pid} 2>/dev/null || true`);
+      const claudePid = parseInt(parentRaw.trim(), 10);
+
+      // Find tmux session containing this claude via pane_pid ancestry
+      // We need ancestry walk because pane_pid is typically a shell (zsh) that spawned claude
+      let tmuxSession: string | undefined;
+      try {
+        const panes = await hostExec(`tmux list-panes -a -F '#{session_name}|#{pane_pid}' 2>/dev/null || true`);
+        // For each pane_pid, check if claudePid is a descendant
+        for (const line of panes.split("\n").filter(Boolean)) {
+          const [sess, panePidStr] = line.split("|");
+          const panePid = parseInt(panePidStr || "0", 10);
+          if (!panePid) continue;
+          // Walk claudePid's parents to see if any is panePid
+          let cursor = claudePid;
+          for (let i = 0; i < 6; i++) {
+            if (cursor === panePid) {
+              tmuxSession = sess;
+              break;
+            }
+            const parent = await hostExec(`ps -o ppid= -p ${cursor} 2>/dev/null || true`);
+            const next = parseInt(parent.trim(), 10);
+            if (!next || next === cursor || next === 1) break;
+            cursor = next;
+          }
+          if (tmuxSession) break;
+        }
+      } catch { /* tmux not available */ }
+
+      return { bunPid: pid, claudePid: isFinite(claudePid) ? claudePid : undefined, tmuxSession };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/src/vendor/mpr-plugins/discord/plugin.json
+++ b/src/vendor/mpr-plugins/discord/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "discord",
+  "version": "0.4.2",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Discord fleet ops — tokens, bind, status, route, pair. Hybrid pattern (token in pass, config in repo).",
+  "author": "Soul-Brews-Studio",
+  "capabilities": ["fs:read", "net"],
+  "cli": {
+    "command": "discord",
+    "help": "maw discord <tokens|status|bind|access|...> — fleet ops"
+  },
+  "weight": 50,
+  "license": "MIT",
+  "schemaVersion": 1
+}

--- a/src/vendor/mpr-plugins/discord/registry.meta.json
+++ b/src/vendor/mpr-plugins/discord/registry.meta.json
@@ -1,11 +1,11 @@
 {
-  "version": "0.4.2",
-  "source": "soul-brews-studio/maw-plugin-registry/discord@v0.4.2",
+  "version": "0.4.2+2c18c43",
+  "source": "soul-brews-studio/maw-plugin-registry/discord@2c18c43",
   "sha256": "3ab1887c1e9da1cea220d7c11a5d7ff70e99df0752ddf4cd4e920bc999004c28",
   "summary": "Discord fleet ops — tokens, status, bind, access, inventory. Hybrid pattern (token in pass, config in repo).",
   "author": "Soul-Brews-Studio",
   "license": "MIT",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
-  "addedAt": "2026-05-22T00:00:00Z",
+  "addedAt": "2026-05-22T01:03:03Z",
   "tier": "extra"
 }

--- a/src/vendor/mpr-plugins/discord/registry.meta.json
+++ b/src/vendor/mpr-plugins/discord/registry.meta.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.4.2",
+  "source": "soul-brews-studio/maw-plugin-registry/discord@v0.4.2",
+  "sha256": "3ab1887c1e9da1cea220d7c11a5d7ff70e99df0752ddf4cd4e920bc999004c28",
+  "summary": "Discord fleet ops — tokens, status, bind, access, inventory. Hybrid pattern (token in pass, config in repo).",
+  "author": "Soul-Brews-Studio",
+  "license": "MIT",
+  "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+  "addedAt": "2026-05-22T00:00:00Z",
+  "tier": "extra"
+}

--- a/src/vendor/mpr-plugins/discord/status.ts
+++ b/src/vendor/mpr-plugins/discord/status.ts
@@ -1,0 +1,316 @@
+/**
+ * `maw discord status` — fleet inspection from this host's perspective.
+ *
+ * Surfaces the configuration chain per bot:
+ *   pass token  →  legacy state-dir  →  hybrid .discord/  →  tmux session  →  state-dirs.ts registry
+ *
+ * Union of pass(20) ∪ state-dirs.ts(18) so anomalies are visible:
+ *   - token-only (orphan in pass)
+ *   - registered-only (broken: registered but no token)
+ *   - normal intersection
+ *
+ * No side effects. Read-only filesystem + optional Discord REST (--check).
+ * Flags: --check (ping Discord REST), --redact (hide dates), --json (machine-readable),
+ *        <bot> narrows to a single detail card.
+ */
+import {
+  listPassTokens, decryptToken, pingDiscord,
+  findLegacyStateDir, findHybridDiscord, findTmuxSession,
+  loadStateDirsRegistry, loadAnchors, findOnlineBunForBot, fmtSize,
+} from "./lib";
+import { readdirSync, statSync } from "fs";
+import { join } from "path";
+import { hostname } from "os";
+
+interface BotRow {
+  bot: string;
+  inPass: boolean;
+  inRegistry: boolean;
+  legacyPath: string | null;
+  hybridPath: string | null;
+  tmuxLine: string | null;
+  online: boolean;
+  onlineSession: string | null;
+  onlineBunPid: number | null;
+  anchor: string | null;
+  discordOK?: boolean;
+  discordStatus?: number;
+  discordUsername?: string;
+}
+
+type Severity = "ok" | "warn" | "info" | "error";
+
+function classifyBot(row: BotRow): { severity: Severity; reason: string } {
+  // error: registered but no token (broken bot)
+  if (row.inRegistry && !row.inPass) {
+    return { severity: "error", reason: "registered but no token in pass" };
+  }
+  // error: token in pass but not registered (orphan)
+  if (row.inPass && !row.inRegistry) {
+    return { severity: "error", reason: "token in pass but not in state-dirs.ts" };
+  }
+  // error: --check showed Discord REST failure
+  if (row.discordOK === false) {
+    return { severity: "error", reason: `Discord REST returned ${row.discordStatus}` };
+  }
+  // error: tmux exists but no Gateway bun (orphan tmux — bind verification failure)
+  if (row.tmuxLine && !row.online) {
+    return { severity: "error", reason: "tmux session exists but no Gateway bun — orphan (bind incomplete)" };
+  }
+  // info: hybrid pattern not yet applied (migration TODO)
+  if (row.inPass && row.inRegistry && !row.hybridPath && row.online) {
+    return { severity: "info", reason: "online but using legacy state-dir — hybrid pattern not applied" };
+  }
+  // warn: registered, has hybrid/legacy, but not running locally (probably fine, just offline on this host)
+  if (row.inRegistry && !row.online) {
+    return { severity: "warn", reason: "offline on this host" };
+  }
+  return { severity: "ok", reason: "" };
+}
+
+async function gatherRows(): Promise<BotRow[]> {
+  const tokens = listPassTokens();
+  const registry = await loadStateDirsRegistry();
+  const anchors = await loadAnchors();
+  const allBots = new Set<string>([...tokens.map(t => t.bot), ...registry]);
+
+  const rows: BotRow[] = [];
+  for (const bot of Array.from(allBots).sort()) {
+    const inPass = tokens.some(t => t.bot === bot);
+    const inRegistry = registry.has(bot);
+    const legacyPath = findLegacyStateDir(bot);
+    const hybridPath = await findHybridDiscord(bot);
+    const tmuxLine = await findTmuxSession(bot);
+    const onlineInfo = await findOnlineBunForBot(bot);
+    rows.push({
+      bot,
+      inPass,
+      inRegistry,
+      legacyPath,
+      hybridPath,
+      tmuxLine,
+      online: !!onlineInfo,
+      onlineSession: onlineInfo?.tmuxSession ?? null,
+      onlineBunPid: onlineInfo?.bunPid ?? null,
+      anchor: anchors[bot] ?? null,
+    });
+  }
+  return rows;
+}
+
+async function addDiscordChecks(rows: BotRow[]): Promise<void> {
+  const tokens = listPassTokens();
+  // Sequential — Discord REST 50 req/s global, serial keeps output readable + leaves headroom
+  for (const row of rows) {
+    if (!row.inPass) continue;
+    const tokEntry = tokens.find(t => t.bot === row.bot);
+    if (!tokEntry) continue;
+    const tok = await decryptToken(tokEntry.name);
+    if (!tok) {
+      row.discordOK = false;
+      row.discordStatus = 0;
+      continue;
+    }
+    const ping = await pingDiscord(tok);
+    row.discordOK = ping.ok;
+    row.discordStatus = ping.status;
+    row.discordUsername = ping.username;
+  }
+}
+
+function sevIcon(s: Severity): string {
+  switch (s) {
+    case "ok": return "✓";
+    case "warn": return "○";
+    case "info": return "·";
+    case "error": return "✗";
+  }
+}
+
+interface StatusOpts {
+  check: boolean;
+  redact: boolean;
+  json: boolean;
+  filter?: string;
+}
+
+function parseOpts(args: string[]): StatusOpts {
+  const opts: StatusOpts = {
+    check: args.includes("--check"),
+    redact: args.includes("--redact"),
+    json: args.includes("--json"),
+  };
+  const positional = args.filter(a => !a.startsWith("--"));
+  if (positional[0]) opts.filter = positional[0];
+  return opts;
+}
+
+export const cmdStatus = {
+  async run(log: (s: string) => void, args: string[]): Promise<void> {
+    const opts = parseOpts(args);
+
+    let rows = await gatherRows();
+    if (opts.filter) {
+      rows = rows.filter(r => r.bot === opts.filter || r.bot === `${opts.filter}-oracle`);
+      if (rows.length === 0) {
+        log(`✗ no bot matching '${opts.filter}' in pass or state-dirs.ts`);
+        return;
+      }
+    }
+
+    if (opts.check) {
+      await addDiscordChecks(rows);
+    }
+
+    if (opts.json) {
+      return this.emitJson(log, rows, opts);
+    }
+
+    if (opts.filter && rows.length === 1) {
+      return this.emitDetailed(log, rows[0]!, opts);
+    }
+
+    return this.emitTable(log, rows, opts);
+  },
+
+  emitTable(log: (s: string) => void, rows: BotRow[], opts: StatusOpts): void {
+    const host = hostname().split(".")[0];
+    log(`🔍 maw discord status @ ${host} — ${rows.length} bot(s) | ${opts.redact ? "REDACTED · " : ""}${opts.check ? "with Discord REST" : "online/where via bun ancestry — use --check for REST"}`);
+    log("");
+    const head = "  bot                          online  anchor              drift  where (tmux session)              severity";
+    log(head);
+    log("  " + "─".repeat(head.length - 2));
+
+    const counts: Record<Severity, number> = { ok: 0, warn: 0, info: 0, error: 0 };
+    let driftCount = 0;
+    for (const row of rows) {
+      const cls = classifyBot(row);
+      counts[cls.severity]++;
+      const bot = row.bot.padEnd(28);
+      const online = row.online ? "✓ ON  " : "✗ off ";
+      const anchor = (row.anchor || "—").padEnd(18);
+      // Drift detection: bot is online HERE but its anchor is elsewhere → ⚠ drift
+      const hostNow = host;
+      const isHere = row.anchor === hostNow || row.anchor === `nat@${hostNow}` || row.anchor?.endsWith(`@${hostNow}`) || row.anchor?.endsWith(`@${hostNow}.wg`);
+      let drift = "  ─  ";
+      if (row.online && row.anchor && !isHere) { drift = "⚠ here"; driftCount++; }
+      else if (row.online && row.anchor) drift = " ✓ ok ";
+      else if (!row.online && row.anchor && isHere) drift = "⚠ down";
+      const where = (row.onlineSession || (row.tmuxLine ? "(orphan tmux)" : "—")).padEnd(33);
+      const sev = `${sevIcon(cls.severity)} ${cls.severity}`;
+      log(`  ${bot}${online}  ${anchor}  ${drift}  ${where} ${sev}`);
+    }
+
+    log("");
+    log(`summary @ ${host}: ${counts.ok} ok · ${counts.warn} warn · ${counts.info} info · ${counts.error} error`);
+    log(`  online: ${rows.filter(r => r.online).length}/${rows.length}  ·  anchors: ${rows.filter(r => r.anchor).length}/${rows.length}  ·  drift: ${driftCount}`);
+    log(`  legend: ✓ ON = Gateway bun verified · anchor = canonical host (state-dirs.ts ANCHORS) · drift = bot online but not on anchor host`);
+    if (counts.error > 0 || driftCount > 0) {
+      log(`run 'maw discord status <bot>' for details on any error/drift row`);
+    }
+  },
+
+  emitDetailed(log: (s: string) => void, row: BotRow, opts: StatusOpts): void {
+    const cls = classifyBot(row);
+    const host = hostname().split(".")[0];
+    log(`🔍 ${row.bot}  @ ${host}    ${sevIcon(cls.severity)} ${cls.severity}${cls.reason ? ` — ${cls.reason}` : ""}`);
+    log("");
+
+    // Online state (real Gateway, bun ancestry-verified)
+    if (row.online) {
+      log(`  Gateway:           ✓ ONLINE on ${host}`);
+      log(`                       bun pid:      ${row.onlineBunPid}`);
+      log(`                       tmux session: ${row.onlineSession || "(detached)"}`);
+    } else if (row.tmuxLine) {
+      log(`  Gateway:           ✗ OFFLINE — tmux session present but no Gateway bun (orphan)`);
+      log(`                       orphan tmux:  ${row.tmuxLine}`);
+    } else {
+      log(`  Gateway:           ✗ OFFLINE on ${host}`);
+    }
+
+
+    // Pass token
+    if (row.inPass) {
+      const tokens = listPassTokens();
+      const t = tokens.find(x => x.bot === row.bot);
+      if (t) {
+        const when = opts.redact ? "—" : t.mtime.toISOString().slice(0, 10);
+        log(`  Pass token:        ✓ discord/${t.name} (${fmtSize(t.sizeBytes)}, ${when})`);
+      }
+    } else {
+      log(`  Pass token:        ✗ missing — no discord/${row.bot}-token in pass`);
+    }
+
+    // Legacy state-dir
+    if (row.legacyPath) {
+      log(`  Legacy state-dir:  ✓ ${row.legacyPath}/`);
+      try {
+        const entries = readdirSync(row.legacyPath).filter(f => !f.startsWith("."));
+        const hidden = readdirSync(row.legacyPath).filter(f => f.startsWith("."));
+        for (const e of [...hidden, ...entries]) {
+          const sub = join(row.legacyPath, e);
+          try {
+            const s = statSync(sub);
+            const when = opts.redact ? "—" : s.mtime.toISOString().slice(0, 10);
+            log(`                       - ${e.padEnd(20)} ${fmtSize(s.size).padStart(6)}  ${when}`);
+          } catch { /* skip */ }
+        }
+      } catch { /* skip */ }
+    } else {
+      log(`  Legacy state-dir:  ✗ not found at ~/.claude/channels/${row.bot}/`);
+    }
+
+    // Hybrid pattern
+    if (row.hybridPath) {
+      log(`  Hybrid .discord/:  ✓ ${row.hybridPath}/`);
+    } else {
+      log(`  Hybrid .discord/:  ✗ not migrated yet (run 'maw discord bind' once shipped)`);
+    }
+
+    // Registry
+    if (row.inRegistry) {
+      log(`  state-dirs.ts:     ✓ registered (discord-oracle dashboard sees it)`);
+    } else {
+      log(`  state-dirs.ts:     ✗ NOT registered — add to discord-oracle/src/state-dirs.ts`);
+    }
+
+    // Discord
+    if (opts.check) {
+      if (row.discordOK) {
+        log(`  Discord identity:  ✓ ${row.discordStatus} — ${row.discordUsername || "—"}`);
+      } else if (row.discordStatus !== undefined) {
+        log(`  Discord identity:  ✗ ${row.discordStatus || "ERR"}`);
+      }
+    } else {
+      log(`  Discord identity:  (run with --check to verify)`);
+    }
+  },
+
+  emitJson(log: (s: string) => void, rows: BotRow[], _opts: StatusOpts): void {
+    const host = hostname().split(".")[0];
+    const out = {
+      host,
+      bots: rows.map(r => {
+        const cls = classifyBot(r);
+        return {
+          bot: r.bot,
+          severity: cls.severity,
+          reason: cls.reason,
+          online: r.online,
+          online_session: r.onlineSession,
+          online_bun_pid: r.onlineBunPid,
+          path: r.hybridPath || r.legacyPath,
+          in_pass: r.inPass,
+          in_registry: r.inRegistry,
+          legacy_path: r.legacyPath,
+          hybrid_path: r.hybridPath,
+          tmux_present: !!r.tmuxLine,
+          discord_ok: r.discordOK,
+          discord_status: r.discordStatus,
+          discord_username: r.discordUsername,
+        };
+      }),
+    };
+    log(JSON.stringify(out, null, 2));
+  },
+};

--- a/src/vendor/mpr-plugins/discord/tokens.ts
+++ b/src/vendor/mpr-plugins/discord/tokens.ts
@@ -1,0 +1,90 @@
+/**
+ * `maw discord tokens` — list/check Discord bot tokens in pass without revealing them.
+ *
+ * Hybrid pattern: tokens live in pass (~/.password-store/discord/*.gpg), config lives
+ * in <bot-repo>/.discord/. This subcommand inspects ONLY the pass side.
+ *
+ * No side effects. Pure functions. Audit-friendly.
+ */
+import { listPassTokens, decryptToken, pingDiscord } from "./lib";
+
+export const cmdTokens = {
+  /**
+   * `maw discord tokens ls` — list tokens in pass without decrypting.
+   * Shows: name, size, last-modified. No reveals, no network.
+   */
+  async ls(log: (s: string) => void): Promise<void> {
+    const tokens = listPassTokens();
+    if (tokens.length === 0) {
+      log(`✗ no tokens in pass (~/.password-store/discord/)`);
+      log("hint: pass insert discord/<bot>-token");
+      return;
+    }
+
+    log(`📦 ${tokens.length} token(s) in pass (~/.password-store/discord/)`);
+    log("");
+    log("  name                                  size    last-modified");
+    log("  ──────────────────────────────────────────────────────────────");
+    for (const t of tokens) {
+      const name = t.name.padEnd(38);
+      const size = `${t.sizeBytes}B`.padEnd(7);
+      const when = t.mtime.toISOString().slice(0, 10);
+      log(`  ${name}${size} ${when}`);
+    }
+    log("");
+    log(`use 'maw discord tokens check' to verify each one decrypts + Discord 200`);
+  },
+
+  /**
+   * `maw discord tokens check [bot]` — decrypt each token + ping Discord REST.
+   * Shows: OK / FAIL with status code + bot username. Token itself is never printed.
+   * Optional <bot> arg narrows to one entry.
+   */
+  async check(log: (s: string) => void, only?: string): Promise<void> {
+    const tokens = listPassTokens();
+    if (tokens.length === 0) {
+      log(`✗ no tokens to check`);
+      return;
+    }
+
+    const filtered = only
+      ? tokens.filter(t => t.name === only || t.name === `${only}-token` || t.bot === only)
+      : tokens;
+
+    if (filtered.length === 0) {
+      log(`✗ no token matching '${only}' (tried '${only}', '${only}-token', bot=='${only}')`);
+      return;
+    }
+
+    log(`🔐 checking ${filtered.length} token(s)...`);
+    log("");
+    log("  name                                  decrypt  discord  bot");
+    log("  ──────────────────────────────────────────────────────────────────");
+
+    let okCount = 0;
+    let failCount = 0;
+    // Sequential intentional — Discord REST allows 50 req/s global, but serial
+    // keeps debug output readable + leaves headroom for other clients on the host.
+    // Each request times out at 5s (AbortController in pingDiscord).
+    for (const t of filtered) {
+      const tok = await decryptToken(t.name);
+      const name = t.name.padEnd(38);
+
+      if (!tok) {
+        log(`  ${name}✗ fail   —        —`);
+        failCount++;
+        continue;
+      }
+
+      const ping = await pingDiscord(tok);
+      const decrypt = "✓ OK   ";
+      const status = ping.ok ? `✓ ${ping.status}    ` : `✗ ${ping.status || "ERR"}   `;
+      const user = ping.username || (ping.ok ? "—" : "—");
+      log(`  ${name}${decrypt} ${status} ${user}`);
+      if (ping.ok) okCount++; else failCount++;
+    }
+
+    log("");
+    log(`summary: ${okCount}/${filtered.length} green${failCount > 0 ? `, ${failCount} fail` : ""}`);
+  },
+};


### PR DESCRIPTION
## Summary

Vendors `Soul-Brews-Studio/maw-plugin-registry` `discord` plugin (v0.4.2) into `src/vendor/mpr-plugins/discord/` so the command surface (`maw discord tokens|status|bind|access|inventory`) survives daily `bun install -g maw-js` alpha rewipes.

Drafted while waiting on Soul-Brews-Studio/maw-plugin-registry#97 to merge — content is identical (cherry-picked from same absorb-plugin commits). Ready to mark ready-for-review once #97 lands.

### Mechanism

`runBootstrap()` already walks `src/vendor/mpr-plugins/` as `bundledRoots[1]` (src/cli/plugin-bootstrap.ts:148) and symlinks any plugin missing from `~/.maw/plugins/`. No loader code change required. Verified locally: `maw discord status` works against the vendored copy.

### Files

- `src/vendor/mpr-plugins/discord/{index,status,bind,access,tokens,inventory,lib}.ts`
- `src/vendor/mpr-plugins/discord/plugin.json`
- `src/vendor/mpr-plugins/discord/registry.meta.json` (provenance)
- `src/vendor/mpr-plugins/discord/README.md`

## Design Qs (per discord-oracle briefing)

**1. Source of truth post-vendor?**  mpr stays canonical. Vendor is a runtime copy for bootstrap-without-network parity with `init` / `shellenv`. Pattern documented in `src/vendor/mpr-plugins/README.md`.

**2. Update path for v0.5?**  Manual re-vendor PR: `cp -r maw-plugin-registry/plugins/discord/* maw-js/src/vendor/mpr-plugins/discord/` excluding tests, bump `registry.meta.json` `version` + `sha256` + `addedAt`. Same flow `init`/`shellenv` followed historically. A sync script would be premature — cadence is low (4 versions in 3 weeks during initial buildout, expected to slow).

**3. Opt-out?**  User-created `~/.maw/plugins/discord/` (real dir or user-pointed symlink) wins — `linkBundledPlugins()` skips existing destinations (plugin-bootstrap.ts:18). So `rm -rf ~/.maw/plugins/discord && ln -s <my-fork> ~/.maw/plugins/discord` is the override. Healing only triggers if the existing symlink points at a *stale maw-js vendored* target (pointsAtStaleMawJsBundledPlugin) or a *legacy mpr root* — user-pointed symlinks are preserved.

**4. Tests?**  None added in this PR. mpr lacks tests for discord today, and the runtime depends on a real `~/.password-store/` + Discord API, which is hostile to CI. Logical follow-up: a smoke test that asserts `plugin.json` parses and `index.ts` registers the expected subcommands — small but not in scope here.

## Related

- Depends on Soul-Brews-Studio/maw-plugin-registry#97 (v0.4.1 + v0.4.2 onto main)
- Unblocks discord-oracle CLAUDE.md anchor migration recipe (which assumes `maw discord status` exists)
- Adjacent to #1815 (`maw wake --channels` gap)

## Test plan

- [x] `maw plugin ls` shows discord loaded from vendor symlink
- [x] `maw discord status` renders 22-bot table with anchor/drift columns
- [ ] After merge: confirm `bun install -g maw-js` from npm @alpha preserves the symlink
- [ ] After merge: re-vendor flow tested on next mpr discord release

🤖 Generated with [Claude Code](https://claude.com/claude-code)