### PR TITLE
fix(wake): keep attach-only wake from linking tmux windows

### DIFF
--- a/src/commands/plugins/oracle/impl-stale.ts
+++ b/src/commands/plugins/oracle/impl-stale.ts
@@ -171,8 +171,11 @@ export async function runStaleScan(
   return opts.all ? sorted : sorted.filter((e) => e.tier === "STALE" || e.tier === "DEAD");
 }
 
-export async function cmdOracleScanStale(opts: StaleScanOpts = {}): Promise<void> {
-  const results = await runStaleScan(opts);
+export async function cmdOracleScanStale(
+  opts: StaleScanOpts = {},
+  deps: StaleScanDeps = {},
+): Promise<void> {
+  const results = await runStaleScan(opts, deps);
 
   if (opts.json) {
     console.log(JSON.stringify({ schema: 1, count: results.length, oracles: results }, null, 2));

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -356,6 +356,30 @@ export interface WakeOptions {
   layout?: WorktreeLayout;
 }
 
+function isAttachOnlyWake(opts: WakeOptions): boolean {
+  return Boolean(opts.attach)
+    && !opts.task
+    && !opts.wt
+    && !opts.prompt
+    && !opts.session
+    && !opts.incubate
+    && !opts.fresh
+    && !opts.pick
+    && !opts.name
+    && !opts.listWt
+    && !opts.dryRun
+    && !opts.split
+    && !opts.splitTarget
+    && !opts.bringAlias
+    && !opts.bring
+    && !opts.tab
+    && !opts.bud
+    && !opts.signalOnBirth
+    && !opts.engine
+    && !opts.fromSnapshot
+    && !opts.snapshotId;
+}
+
 function loadRequestedSnapshot(snapshotId?: string): Snapshot | null {
   return snapshotId ? loadSnapshot(snapshotId) : latestSnapshot();
 }
@@ -704,6 +728,21 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
   if (requestedForeignSession) validateForeignSessionName(requestedForeignSession);
 
   console.log(`\x1b[36m⚡\x1b[0m resolving ${oracle}...`);
+
+  // #1897 — explicit attach is a tmux client handoff, not bring delivery.
+  // When the target is already live, avoid the bring/split/open-window pipeline
+  // and skip wake maintenance work that can mutate tmux windows before the
+  // attach. Missing sessions still fall through to normal wake/create behavior.
+  if (isAttachOnlyWake(opts)) {
+    const liveAttachSession = preResolvedSession || await detectSession(oracle, opts.urlRepoName);
+    if (liveAttachSession) {
+      console.log(`\x1b[36m→\x1b[0m live tmux session: ${liveAttachSession}`);
+      await attachToSession(liveAttachSession);
+      await recordWakeSnapshot();
+      const attachWindow = preResolvedFleetSession?.windowName || `${oracle}-oracle`;
+      return `${liveAttachSession}:${attachWindow}`;
+    }
+  }
 
   const existingSessionBringTarget = await resolveExistingSessionBringTarget(oracle, opts, preResolvedSession);
   if (existingSessionBringTarget) {

--- a/test/isolated/oracle-stale-nickname-extra-coverage.test.ts
+++ b/test/isolated/oracle-stale-nickname-extra-coverage.test.ts
@@ -231,7 +231,7 @@ describe("oracle stale extra coverage", () => {
     currentCache = cache([entry({ name: "dead", local_path: "/repos/dead", has_psi: false })]);
     execResponses.set("/repos/dead", iso(120));
 
-    const jsonOut = await captureLog(() => stale.cmdOracleScanStale({ json: true }));
+    const jsonOut = await captureLog(() => stale.cmdOracleScanStale({ json: true }, { now: () => NOW }));
     const parsed = JSON.parse(jsonOut);
     expect(parsed).toMatchObject({ schema: 1, count: 1 });
     expect(parsed.oracles[0]).toMatchObject({
@@ -243,7 +243,7 @@ describe("oracle stale extra coverage", () => {
     currentCache = cache([entry({ name: "fresh", local_path: "/repos/fresh" })]);
     execResponses.set("/repos/fresh", iso(1));
 
-    const clearOut = stripAnsi(await captureLog(() => stale.cmdOracleScanStale()));
+    const clearOut = stripAnsi(await captureLog(() => stale.cmdOracleScanStale({}, { now: () => NOW })));
     expect(clearOut).toContain("No stale oracles — all clear.");
 
     currentCache = cache([
@@ -259,7 +259,7 @@ describe("oracle stale extra coverage", () => {
     execResponses.set("/repos/fresh", iso(1));
     execResponses.set("/repos/awake", iso(200));
 
-    const formatted = stripAnsi(await captureLog(() => stale.cmdOracleScanStale({ all: true })));
+    const formatted = stripAnsi(await captureLog(() => stale.cmdOracleScanStale({ all: true }, { now: () => NOW })));
 
     expect(formatted).toContain("Stale oracle scan  (DEAD 1  STALE 1  SLOW 1  ACTIVE 2)");
     expect(formatted).toContain("DEAD");

--- a/test/isolated/wake-cmd-thirteenth-pass-coverage.test.ts
+++ b/test/isolated/wake-cmd-thirteenth-pass-coverage.test.ts
@@ -869,7 +869,7 @@ describe("wake-cmd thirteenth-pass isolated coverage", () => {
 
   test("dead existing windows relaunch, and unreliable window listings refuse duplicate creation", async () => {
     paneCommand = "zsh";
-    let result = await captureLogs(() => cmdWake("neo", { repoPath, noRehydrate: true, attach: true }));
+    let result = await captureLogs(() => cmdWake("neo", { repoPath, noRehydrate: true, attach: true, engine: "codex" }));
 
     expect(result).toBe("54-neo:neo-oracle");
     expect(sentText).toContainEqual({
@@ -885,7 +885,7 @@ describe("wake-cmd thirteenth-pass isolated coverage", () => {
       .rejects.toThrow("could not list windows for session '54-neo'");
   });
 
-  test("plain live existing windows attach without relaunching", async () => {
+  test("plain live existing windows attach without relaunching or bring delivery", async () => {
     paneCommand = "codex";
     listWindowsReturn = [{ name: "neo-oracle" }];
 
@@ -894,9 +894,9 @@ describe("wake-cmd thirteenth-pass isolated coverage", () => {
     expect(result).toBe("54-neo:neo-oracle");
     expect(sentText).toEqual([]);
     expect(respawnCalls).toEqual([]);
-    expect(selectedWindows).toEqual(["54-neo:neo-oracle"]);
+    expect(selectedWindows).toEqual([]);
     expect(attachCalls).toEqual(["54-neo"]);
-    expect(splitCalls).toEqual(["54-neo:neo-oracle"]);
-    expect(openCalls).toEqual(["54-neo:neo-oracle"]);
+    expect(splitCalls).toEqual([]);
+    expect(openCalls).toEqual([]);
   });
 });

--- a/test/top-aliases-default.test.ts
+++ b/test/top-aliases-default.test.ts
@@ -293,6 +293,14 @@ describe("direct handler invocation", () => {
     }]]);
   });
 
+  test("#1897 wake -a is attach-only and does not set bring/split flags", async () => {
+    const { calls, deps } = makeDeps();
+
+    await invokeDirectHandler("../commands/shared/wake-cmd:cmdWake", ["neo", "-a"], deps);
+
+    expect(calls.wake).toEqual([["neo", { attach: true }]]);
+  });
+
   test("awake supports help and explicit engine without loading config", async () => {
     const { calls, deps } = makeDeps();
 

--- a/test/wake-cmd-cmdwake-coverage.test.ts
+++ b/test/wake-cmd-cmdwake-coverage.test.ts
@@ -722,6 +722,37 @@ describe("cmdWake main-suite coverage", () => {
     expect(sendTextCalls).toHaveLength(0);
   });
 
+  test("#1897 wake -a attaches to live targets without bring/split/window mutation", async () => {
+    worktrees = [
+      { name: "1-alpha", path: join(parentDir, `${repoName}.wt-1-alpha`) },
+    ];
+
+    let result = await captureLogs(() => cmdWake("mawjs", { attach: true }));
+
+    expect(result.result).toBe("54-mawjs:mawjs-oracle");
+    expect(result.logs.join("\n")).toContain("live tmux session: 54-mawjs");
+    expect(attachCalls).toEqual(["54-mawjs"]);
+    expect(maybeSplitCalls).toEqual([]);
+    expect(maybeOpenWindowCalls).toEqual([]);
+    expect(newWindowCalls).toEqual([]);
+    expect(sendTextCalls).toEqual([]);
+    expect(findWorktreesCalls).toEqual([]);
+    expect(setSessionEnvCalls).toEqual([]);
+    expect(ensureSessionRunningCalls).toEqual([]);
+    expect(takeSnapshotCalls).toEqual(["wake"]);
+
+    attachCalls = [];
+    takeSnapshotCalls = [];
+    result = await captureLogs(() => cmdWake("54-mawjs", { attach: true }));
+
+    expect(result.result).toBe("54-mawjs:mawjs-oracle");
+    expect(attachCalls).toEqual(["54-mawjs"]);
+    expect(detectSessionCalls).toEqual([{ oracle: "mawjs", urlRepoName: undefined }]);
+    expect(maybeSplitCalls).toEqual([]);
+    expect(maybeOpenWindowCalls).toEqual([]);
+    expect(takeSnapshotCalls).toEqual(["wake"]);
+  });
+
   test("#1816 bring resolves an exact live tmux window before fuzzy oracle lookup", async () => {
     addWindow("54-mawjs", "mawjs-features");
 


### PR DESCRIPTION
## Summary
- Make explicit `maw wake <target> -a` attach-only for already-live tmux targets.
- Bypass wake maintenance, bring/split, tab/open-window, and prompt delivery before attach.
- Add regression coverage for CLI alias parsing and cmdWake live-target behavior.

## Verification
- `bun test test/top-aliases-default.test.ts --path-ignore-patterns '**/agents/**'`
- `bun test test/wake-cmd-cmdwake-coverage.test.ts --path-ignore-patterns '**/agents/**'`
- `bun test test/isolated/wake-cmd-thirteenth-pass-coverage.test.ts --path-ignore-patterns '**/agents/**'`
- `bun test test/wake-maybe-split-coverage.test.ts --path-ignore-patterns '**/agents/**'`
- `bun run build`
- `bun run test:default:safe`
- Isolated tmux repro: from `79-mawjscodex`, `maw wake mawjs -a` left `77-mawjs` and `79-mawjscodex` windows unchanged.

Fixes #1897.

Written by [m5:mawjscodex] — an Oracle AI running gpt-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
