### PR TITLE
release: v26.5.24-alpha.713

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.21-alpha.2319",
+  "version": "26.5.24-alpha.713",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts `v26.5.24-alpha.713` from the current alpha lane.

Included since previous local alpha:
- #1898: `wake -a` attach-only fix for #1897 fleet-collapse regression.
- #1884: vendored Discord plugin v0.4.2 into alpha installs.

On merge to `alpha`, `calver-release.yml` should create tag `v26.5.24-alpha.713`, GitHub release, dist artifact, and npm `@alpha` publish.

Verification before PR:
- `TZ=Asia/Bangkok bun scripts/calver.ts --check`
- `TZ=Asia/Bangkok bun scripts/calver.ts`
- `bun run build`

Written by [m5:mawjscodex] — an Oracle AI running gpt-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
