### PR TITLE
fix(fleet): protect active worktrees from cleanup

### DIFF
--- a/src/core/fleet/worktree-live-panes.ts
+++ b/src/core/fleet/worktree-live-panes.ts
@@ -1,0 +1,60 @@
+import { hostExec } from "../transport/ssh";
+
+export interface LiveWorktreePane {
+  session: string;
+  windowIndex: string;
+  windowName: string;
+  paneIndex: string;
+  target: string;
+  command: string;
+  cwd: string;
+}
+
+function normalizePath(value: string): string {
+  return value.replace(/\s+\((?:deleted|dead)\)$/i, "").replace(/\/+$/, "");
+}
+
+export function cwdInsideWorktree(cwd: string | undefined, wtPath: string): boolean {
+  if (!cwd) return false;
+  const normalizedCwd = normalizePath(cwd);
+  const normalizedWt = normalizePath(wtPath);
+  return normalizedCwd === normalizedWt || normalizedCwd.startsWith(`${normalizedWt}/`);
+}
+
+export function parseTmuxPaneRows(raw: string): LiveWorktreePane[] {
+  return raw.split("\n").filter(Boolean).flatMap(line => {
+    const [session, windowIndex, windowName, paneIndex, command, cwd] = line.split("|||");
+    if (!session || !windowIndex || !paneIndex) return [];
+    return [{
+      session,
+      windowIndex,
+      windowName: windowName || "",
+      paneIndex,
+      target: `${session}:${windowIndex}.${paneIndex}`,
+      command: command || "",
+      cwd: cwd || "",
+    }];
+  });
+}
+
+export async function listTmuxPanes(): Promise<LiveWorktreePane[]> {
+  try {
+    const raw = await hostExec(
+      "tmux list-panes -a -F '#{session_name}|||#{window_index}|||#{window_name}|||#{pane_index}|||#{pane_current_command}|||#{pane_current_path}' 2>/dev/null || true"
+    );
+    return parseTmuxPaneRows(raw);
+  } catch {
+    return [];
+  }
+}
+
+export function findPanesInWorktree(
+  panes: LiveWorktreePane[],
+  wtPath: string,
+): LiveWorktreePane[] {
+  return panes.filter(pane => cwdInsideWorktree(pane.cwd, wtPath));
+}
+
+export async function listLiveWorktreePanes(wtPath: string): Promise<LiveWorktreePane[]> {
+  return findPanesInWorktree(await listTmuxPanes(), wtPath);
+}

--- a/src/core/fleet/worktrees-cleanup.test.ts
+++ b/src/core/fleet/worktrees-cleanup.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, mock } from "bun:test";
+import { join } from "path";
+
+const root = join(import.meta.dir, "../..");
+const wtPath = "/ghq/github.com/kxlahsimx09/mb-next-payment-gateway.wt-1-codex";
+let commands: string[] = [];
+
+mock.module(join(root, "core/transport/ssh"), () => ({
+  hostExec: async (cmd: string) => {
+    commands.push(cmd);
+    if (cmd.startsWith("tmux list-panes")) {
+      return [
+        "fleet|||1|||next-writer-codex|||0|||codex|||" + wtPath,
+      ].join("\n");
+    }
+    if (cmd.includes("worktree remove")) {
+      throw new Error("worktree remove should not run for active panes");
+    }
+    return "";
+  },
+  listSessions: async () => [
+    { name: "fleet", windows: [{ name: "next-writer-codex", index: 1, active: true }] },
+  ],
+}));
+
+mock.module(join(root, "core/transport/tmux"), () => ({
+  tmux: { killWindow: async () => {} },
+}));
+
+mock.module(join(root, "config/ghq-root"), () => ({
+  getGhqRoot: () => "/ghq",
+}));
+
+mock.module(join(root, "commands/shared/fleet-load"), () => ({
+  loadFleetEntries: () => [],
+}));
+
+const { cleanupWorktree } = await import("./worktrees-cleanup");
+
+describe("cleanupWorktree active-pane guard", () => {
+  it("refuses to remove a worktree while a live pane cwd is inside it", async () => {
+    commands = [];
+
+    const log = await cleanupWorktree(wtPath);
+
+    expect(log.join("\n")).toContain("refusing to remove active worktree");
+    expect(log.join("\n")).toContain("fleet:1.0 codex");
+    expect(commands.some(cmd => cmd.includes("worktree remove"))).toBe(false);
+  });
+});

--- a/src/core/fleet/worktrees-cleanup.ts
+++ b/src/core/fleet/worktrees-cleanup.ts
@@ -6,6 +6,7 @@ import { join } from "path";
 import { parseWorktreePath } from "./worktree-layout";
 import { resolveWorktreeTarget } from "../matcher/resolve-target";
 import { loadFleetEntries } from "../../commands/shared/fleet-load";
+import { listLiveWorktreePanes } from "./worktree-live-panes";
 
 /**
  * Clean up a single worktree by path.
@@ -24,6 +25,15 @@ export async function cleanupWorktree(wtPath: string): Promise<string[]> {
   const dirName = parsed.dirName;
   const mainPath = parsed.mainPath;
   const repo = parsed.repo;
+
+  const livePanes = await listLiveWorktreePanes(wtPath);
+  if (livePanes.length > 0) {
+    log.push(`refusing to remove active worktree ${dirName}`);
+    for (const pane of livePanes) {
+      log.push(`    live pane: ${pane.target} ${pane.command || "?"} (${pane.cwd})`);
+    }
+    return log;
+  }
 
   // 1. Find and kill tmux window
   const sessions = await listSessions();
@@ -62,7 +72,7 @@ export async function cleanupWorktree(wtPath: string): Promise<string[]> {
   try { branch = (await hostExec(`git -C '${wtPath}' rev-parse --abbrev-ref HEAD`)).trim(); } catch { /* expected: worktree may be corrupt */ }
 
   try {
-    await hostExec(`git -C '${mainPath}' worktree remove '${wtPath}' --force`);
+    await hostExec(`git -C '${mainPath}' worktree remove '${wtPath}'`);
     await hostExec(`git -C '${mainPath}' worktree prune`);
     log.push(`removed worktree ${dirName}`);
   } catch (e: any) {

--- a/src/core/fleet/worktrees-scan.test.ts
+++ b/src/core/fleet/worktrees-scan.test.ts
@@ -41,13 +41,10 @@ mock.module(join(root, "config/ghq-root"), () => ({
   getGhqRoot: () => "/ghq",
 }));
 
-// Avoid touching real fleet dir
-mock.module(join(root, "core/paths"), () => ({
-  FLEET_DIR: "/tmp/maw-test-nonexistent-fleet-823",
-}));
-
-mock.module(join(root, "core/xdg"), () => ({
-  mawStatePath: () => "/tmp/maw-test-nonexistent-state-fleet-823",
+mock.module(join(root, "core/fleet/paths"), () => ({
+  fleetDirForWrite: () => "/tmp/maw-test-nonexistent-state-fleet-823",
+  fleetDirsForRead: () => ["/tmp/maw-test-nonexistent-state-fleet-823"],
+  uniqueDirs: (dirs: string[]) => [...new Set(dirs.filter(Boolean))],
 }));
 
 const { scanWorktrees } = await import("./worktrees-scan");
@@ -75,5 +72,44 @@ describe("scanWorktrees (#823 Bug C) — dedupe windows across sessions", () => 
     } finally {
       console.error = origErr;
     }
+  });
+
+  it("live pane cwd marks worktree active even when window names are ambiguous", async () => {
+    const wtPath = "/ghq/github.com/kxlahsimx09/mb-next-payment-gateway.wt-1-codex";
+    const errLogs: string[] = [];
+    const results = await scanWorktrees({
+      hostExec: async (cmd: string) => {
+        if (cmd.includes("find ")) return wtPath;
+        if (cmd.includes("rev-parse --abbrev-ref")) return "agents/1-codex";
+        return "";
+      },
+      listSessions: async () => [
+        { name: "fleet", windows: [
+          { name: "next-writer-codex", index: 1, active: true },
+          { name: "other-codex", index: 2, active: false },
+        ] },
+      ] as any,
+      getGhqRoot: () => "/ghq",
+      readdirSync: () => [],
+      readFileSync: () => "",
+      fleetDir: "/tmp/maw-test-nonexistent-fleet-cwd",
+      fleetDirs: ["/tmp/maw-test-nonexistent-fleet-cwd"],
+      listTmuxPanes: async () => [{
+        session: "fleet",
+        windowIndex: "1",
+        windowName: "next-writer-codex",
+        paneIndex: "0",
+        target: "fleet:1.0",
+        command: "codex",
+        cwd: `${wtPath}/src`,
+      }],
+      error: (...args: unknown[]) => { errLogs.push(args.map(String).join(" ")); },
+    });
+
+    const wt = results.find(r => r.path === wtPath);
+    expect(wt).toBeDefined();
+    expect(wt!.status).toBe("active");
+    expect(wt!.tmuxWindow).toBe("next-writer-codex");
+    expect(errLogs.join("\n")).not.toContain("ambiguous");
   });
 });

--- a/src/core/fleet/worktrees-scan.ts
+++ b/src/core/fleet/worktrees-scan.ts
@@ -5,6 +5,11 @@ import { join } from "path";
 import { parseWorktreePath } from "./worktree-layout";
 import { fleetDirForWrite, fleetDirsForRead, uniqueDirs } from "./paths";
 import { resolveWorktreeWindow } from "./worktree-window-match";
+import {
+  findPanesInWorktree,
+  listTmuxPanes,
+  type LiveWorktreePane,
+} from "./worktree-live-panes";
 import type { Session } from "../runtime/find-window";
 
 export interface WorktreeInfo {
@@ -28,6 +33,7 @@ export interface ScanWorktreesDeps {
   fleetDir: string;
   /** State-first fleet dirs; when omitted, XDG state falls back to legacy config. */
   fleetDirs?: string[];
+  listTmuxPanes: () => Promise<LiveWorktreePane[]>;
   error: (...args: unknown[]) => void;
 }
 
@@ -40,6 +46,7 @@ function scanDeps(overrides: Partial<ScanWorktreesDeps>): ScanWorktreesDeps {
     readFileSync: overrides.readFileSync ?? (readFileSync as unknown as ScanWorktreesDeps["readFileSync"]),
     fleetDir: overrides.fleetDir ?? fleetDirForWrite(),
     fleetDirs: overrides.fleetDirs ?? (overrides.fleetDir ? [overrides.fleetDir] : fleetDirsForRead()),
+    listTmuxPanes: overrides.listTmuxPanes ?? listTmuxPanes,
     error: overrides.error ?? console.error,
   };
 }
@@ -80,6 +87,11 @@ export async function scanWorktrees(deps: Partial<ScanWorktreesDeps> = {}): Prom
     }
   }
 
+  let livePanes: LiveWorktreePane[] = [];
+  try {
+    livePanes = await d.listTmuxPanes();
+  } catch { /* pane cwd detection is best-effort */ }
+
   // 3. Load fleet configs for matching
   const fleetWindows = new Map<string, string>(); // repo -> fleet file
   const seenFleetFiles = new Set<string>();
@@ -115,27 +127,30 @@ export async function scanWorktrees(deps: Partial<ScanWorktreesDeps> = {}): Prom
       branch = (await d.hostExec(`git -C '${wtPath}' rev-parse --abbrev-ref HEAD 2>/dev/null`)).trim();
     } catch { branch = "unknown"; }
 
-    // Match to tmux window — check fleet config or name pattern.
-    // The matching policy is pure and fixture-backed in worktree-window-match
-    // (#823/#935/#1553/#1612); scanWorktrees owns only IO and rendering.
+    // Match to tmux window. First bind by live pane cwd, which is
+    // authoritative even when generic task names (e.g. "codex") make
+    // window-name matching ambiguous. Fall back to the pure name policy.
     let tmuxWindow: string | undefined;
     const fleetFile = fleetWindows.get(repo);
-    const windowMatch = resolveWorktreeWindow(mainRepoName, wtName, sessions);
-    switch (windowMatch.kind) {
-      case "bound":
-        tmuxWindow = windowMatch.window;
-        break;
-      case "ambiguous":
-        d.error(`  \x1b[31m✗\x1b[0m '${windowMatch.query}' is ambiguous — matches ${windowMatch.candidates.length} windows:`);
-        for (const c of windowMatch.candidates) {
-          d.error(`  \x1b[90m    • ${c}\x1b[0m`);
-        }
-        d.error(`  \x1b[90m  leaving worktree ${wtName} unbound (status: stale)\x1b[0m`);
-        // tmuxWindow stays undefined → status = stale
-        break;
-      case "none":
-        // no running window → status = stale
-        break;
+    const livePane = findPanesInWorktree(livePanes, wtPath)[0];
+    if (livePane) {
+      tmuxWindow = livePane.windowName || livePane.target;
+    } else {
+      const windowMatch = resolveWorktreeWindow(mainRepoName, wtName, sessions);
+      switch (windowMatch.kind) {
+        case "bound":
+          tmuxWindow = windowMatch.window;
+          break;
+        case "ambiguous":
+          d.error(`  \x1b[31m✗\x1b[0m '${windowMatch.query}' is ambiguous — matches ${windowMatch.candidates.length} windows:`);
+          for (const c of windowMatch.candidates) {
+            d.error(`  \x1b[90m    • ${c}\x1b[0m`);
+          }
+          d.error(`  \x1b[90m  leaving worktree ${wtName} unbound (status: stale)\x1b[0m`);
+          break;
+        case "none":
+          break;
+      }
     }
 
     const status: WorktreeInfo["status"] = tmuxWindow ? "active" : "stale";

--- a/test/isolated/worktree-scope-match-935.test.ts
+++ b/test/isolated/worktree-scope-match-935.test.ts
@@ -54,12 +54,10 @@ mock.module(join(root, "config/ghq-root"), () => ({
   getGhqRoot: () => "/ghq",
 }));
 
-mock.module(join(root, "core/paths"), () => ({
-  FLEET_DIR: "/tmp/maw-test-nonexistent-fleet-935",
-}));
-
-mock.module(join(root, "core/xdg"), () => ({
-  mawStatePath: () => "/tmp/maw-test-nonexistent-state-fleet-935",
+mock.module(join(root, "core/fleet/paths"), () => ({
+  fleetDirForWrite: () => "/tmp/maw-test-nonexistent-state-fleet-935",
+  fleetDirsForRead: () => ["/tmp/maw-test-nonexistent-state-fleet-935"],
+  uniqueDirs: (dirs: string[]) => [...new Set(dirs.filter(Boolean))],
 }));
 
 const { scanWorktrees } = await import(join(root, "core/fleet/worktrees-scan"));


### PR DESCRIPTION
## Summary
- Bind worktree liveness from live tmux pane cwd before falling back to window-name matching.
- Prevent `cleanupWorktree()` from removing a worktree while any pane is still inside it.
- Drop forced `git worktree remove` in cleanup so dirty/still-used worktrees fail safely instead of being deleted.

## Why
A Codex agent pane can be running in a worktree like `mb-next-payment-gateway.wt-1-codex` while the window-name matcher sees only the generic task part `codex`. If multiple `*-codex` windows exist or naming drifts, scan marks the live worktree as stale/orphan and cleanup can remove it, leaving the terminal with a deleted cwd and hook failures like `No such file or directory`.

## Validation
- `bun test src/core/fleet/worktrees-scan.test.ts src/core/fleet/worktrees-cleanup.test.ts test/isolated/worktree-scope-match-935.test.ts`

## Local repair performed
- Recreated `/Users/dev01/Code/github.com/kxlahsimx09/mb-next-payment-gateway.wt-1-codex` from `origin/main` on `agents/1-codex`.
- Restored `.agent` and `.secrets` symlinks.
- Verified `%140` zsh and Codex cwd point at the recreated directory, not a deleted inode.