### PR TITLE
fix(wake): wait for engine to replace shell before liveness check (#1906)

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -5,7 +5,7 @@ import { resolveWorktreeTarget } from "../../core/matcher/resolve-target";
 import { normalizeTarget } from "../../core/matcher/normalize-target";
 import { assertValidOracleName } from "../../core/fleet/validate";
 import { resolveOracle, findWorktrees, getSessionMap, resolveFleetSession, detectSession, setSessionEnv, sanitizeBranchName } from "./wake-resolve";
-import { attachToSession, ensureSessionRunning, createWorktree } from "./wake-session";
+import { attachToSession, ensureSessionRunning, createWorktree, waitForEngine } from "./wake-session";
 import { maybeSplit } from "./wake-maybe-split";
 import { parseWakeTarget, ensureCloned } from "./wake-target";
 
@@ -106,6 +106,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
     await setSessionEnv(session);
     await new Promise(r => setTimeout(r, 300));
     await tmux.sendText(`${session}:${mainWindowName}`, buildCommandInDir(mainWindowName, repoPath, opts.engine));
+    await waitForEngine(`${session}:${mainWindowName}`, getPaneInfos, isAgentCommand);
     console.log(`\x1b[32m+\x1b[0m created session '${session}' (main: ${mainWindowName})`);
 
     // Auto-register agent in config.agents so federation peers can route to it (#285)
@@ -135,6 +136,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
         await tmux.newWindow(session, wtWindowName, { cwd: wt.path });
         await new Promise(r => setTimeout(r, 300));
         await tmux.sendText(`${session}:${wtWindowName}`, buildCommandInDir(wtWindowName, wt.path, opts.engine));
+        await waitForEngine(`${session}:${wtWindowName}`, getPaneInfos, isAgentCommand);
         console.log(`\x1b[32m+\x1b[0m window: ${wtWindowName}`);
       }
     }

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -248,6 +248,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
       if (!agentAlive) {
         console.log(`\x1b[33m⚡\x1b[0m '${existingWindow}' in ${session} — agent dead, re-launching...`);
         await tmux.sendText(target, buildCommandInDir(existingWindow, targetPath, opts.engine));
+        await waitForEngine(target, getPaneInfos, isAgentCommand);
         if (opts.attach) {
           await tmux.selectWindow(target);
           await attachToSession(session);

--- a/src/commands/shared/wake-session.ts
+++ b/src/commands/shared/wake-session.ts
@@ -30,6 +30,39 @@ export async function isPaneIdle(paneTarget: string): Promise<boolean> {
   }
 }
 
+/**
+ * Poll until the pane's command is recognised as an agent binary, or timeout.
+ *
+ * Fixes the new-session race (#1906): after sendText() launches a non-claude
+ * engine (e.g. thclaws --cli), the tmux pane command may still report 'zsh'
+ * for several hundred ms before the shell execs the engine. Without this wait,
+ * the liveness check that follows immediately can see 'zsh', decide the agent
+ * is dead, and issue a second sendText() — which lands in the already-running
+ * engine's chat instead of the shell.
+ *
+ * @returns true when the engine is confirmed, false on timeout (5 s default).
+ */
+export async function waitForEngine(
+  paneTarget: string,
+  getPaneInfos: (targets: string[]) => Promise<Record<string, { command: string }>>,
+  isAgentCommand: (cmd: string | null | undefined) => boolean,
+  timeoutMs = 5000,
+  pollIntervalMs = 250,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const infos = await getPaneInfos([paneTarget]);
+      const info = infos[paneTarget];
+      if (info && isAgentCommand(info.command)) return true;
+    } catch { /* tolerate transient tmux errors during engine startup */ }
+    if (Date.now() < deadline) {
+      await new Promise(r => setTimeout(r, pollIntervalMs));
+    }
+  }
+  return false;
+}
+
 export async function ensureSessionRunning(session: string, excludeNames?: Set<string>, cwdMap?: Record<string, string>): Promise<number> {
   let retried = 0;
   let windows: { index: number; name: string; active: boolean }[];

--- a/test/wake-engine-wait.test.ts
+++ b/test/wake-engine-wait.test.ts
@@ -1,11 +1,13 @@
 import { describe, test, expect } from "bun:test";
+import { waitForEngine } from "../src/commands/shared/wake-session";
 
 /**
- * Tests for waitForEngine logic — the core of the #1906 race-condition fix.
+ * Tests for waitForEngine — the core of the #1906 race-condition fix.
  *
- * We replicate the waitForEngine logic inline with injectable dependencies
- * (same pattern as wake.test.ts / isPaneIdleWith) to avoid mock.module()
- * process-global leakage.
+ * waitForEngine() accepts getPaneInfos and isAgentCommand as parameters so
+ * tests can pass controlled doubles without mock.module() process-global
+ * leakage. We import the real function and exercise it through its public
+ * interface.
  *
  * Scenario being guarded: maw wake with a non-claude engine (e.g. thclaws):
  *   1. newSession() + sendText('thclaws --cli')   ← pane still shows 'zsh'
@@ -13,29 +15,6 @@ import { describe, test, expect } from "bun:test";
  * waitForEngine() sits between step 1 and 2, blocking until the pane command
  * flips to the engine binary.
  */
-
-// --- Inline replication of waitForEngine (keep in sync with wake-session.ts) ---
-
-async function waitForEngineWith(
-  paneTarget: string,
-  getPaneInfos: (targets: string[]) => Promise<Record<string, { command: string }>>,
-  isAgentCommand: (cmd: string | null | undefined) => boolean,
-  timeoutMs = 5000,
-  pollIntervalMs = 250,
-): Promise<boolean> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    try {
-      const infos = await getPaneInfos([paneTarget]);
-      const info = infos[paneTarget];
-      if (info && isAgentCommand(info.command)) return true;
-    } catch { /* tolerate transient tmux errors */ }
-    if (Date.now() < deadline) {
-      await new Promise(r => setTimeout(r, pollIntervalMs));
-    }
-  }
-  return false;
-}
 
 // --- Helpers ---
 
@@ -56,21 +35,18 @@ function makeGetPaneInfos(sequence: string[]): (targets: string[]) => Promise<Re
 
 describe("waitForEngine (#1906 race condition fix)", () => {
   test("engine already running → returns true on first poll", async () => {
-    const getPaneInfos = makeGetPaneInfos(["thclaws"]);
-    const result = await waitForEngineWith("sess:oracle", getPaneInfos, isAgent, 500, 50);
+    const result = await waitForEngine("sess:oracle", makeGetPaneInfos(["thclaws"]), isAgent, 500, 50);
     expect(result).toBe(true);
   });
 
   test("engine starts after a few polls → returns true", async () => {
     // First 2 polls return 'zsh', third returns 'thclaws'
-    const getPaneInfos = makeGetPaneInfos(["zsh", "zsh", "thclaws"]);
-    const result = await waitForEngineWith("sess:oracle", getPaneInfos, isAgent, 1000, 50);
+    const result = await waitForEngine("sess:oracle", makeGetPaneInfos(["zsh", "zsh", "thclaws"]), isAgent, 1000, 50);
     expect(result).toBe(true);
   });
 
   test("engine never starts → returns false on timeout", async () => {
-    const getPaneInfos = makeGetPaneInfos(["zsh"]);
-    const result = await waitForEngineWith("sess:oracle", getPaneInfos, isAgent, 150, 50);
+    const result = await waitForEngine("sess:oracle", makeGetPaneInfos(["zsh"]), isAgent, 150, 50);
     expect(result).toBe(false);
   });
 
@@ -80,45 +56,37 @@ describe("waitForEngine (#1906 race condition fix)", () => {
       calls++;
       throw new Error("tmux not ready");
     };
-    const result = await waitForEngineWith("sess:oracle", getPaneInfos, isAgent, 150, 50);
+    const result = await waitForEngine("sess:oracle", getPaneInfos, isAgent, 150, 50);
     expect(result).toBe(false);
-    expect(calls).toBeGreaterThan(1); // polled multiple times despite errors
+    expect(calls).toBeGreaterThan(1);
   });
 
   test("pane not in result → continues polling", async () => {
     let call = 0;
     const getPaneInfos = async (targets: string[]) => {
-      // First call: pane missing from result; second call: pane present with engine
       if (call++ === 0) return {} as Record<string, { command: string }>;
       return Object.fromEntries(targets.map(t => [t, { command: "claude" }]));
     };
-    const result = await waitForEngineWith("sess:oracle", getPaneInfos, isAgent, 500, 50);
+    const result = await waitForEngine("sess:oracle", getPaneInfos, isAgent, 500, 50);
     expect(result).toBe(true);
   });
 
   test("versioned claude binary (2.1.121) recognised as agent", async () => {
-    const getPaneInfos = makeGetPaneInfos(["2.1.121"]);
-    const result = await waitForEngineWith("sess:oracle", getPaneInfos, isAgent, 500, 50);
+    const result = await waitForEngine("sess:oracle", makeGetPaneInfos(["2.1.121"]), isAgent, 500, 50);
     expect(result).toBe(true);
   });
 
   test("shell commands are never recognised as agents", async () => {
     for (const shell of ["zsh", "bash", "sh", ""]) {
-      const getPaneInfos = makeGetPaneInfos([shell]);
-      const result = await waitForEngineWith("sess:oracle", getPaneInfos, isAgent, 100, 40);
+      const result = await waitForEngine("sess:oracle", makeGetPaneInfos([shell]), isAgent, 100, 40);
       expect(result).toBe(false);
     }
   });
 
   test("multiple pane targets — correct pane is checked", async () => {
-    const getPaneInfos = async (targets: string[]) => {
-      // Only "sess:oracle" has the engine; others have zsh
-      return Object.fromEntries(targets.map(t => [
-        t,
-        { command: t === "sess:oracle" ? "thclaws" : "zsh" },
-      ]));
-    };
-    const result = await waitForEngineWith("sess:oracle", getPaneInfos, isAgent, 500, 50);
+    const getPaneInfos = async (targets: string[]) =>
+      Object.fromEntries(targets.map(t => [t, { command: t === "sess:oracle" ? "thclaws" : "zsh" }]));
+    const result = await waitForEngine("sess:oracle", getPaneInfos, isAgent, 500, 50);
     expect(result).toBe(true);
   });
 });

--- a/test/wake-engine-wait.test.ts
+++ b/test/wake-engine-wait.test.ts
@@ -1,0 +1,124 @@
+import { describe, test, expect } from "bun:test";
+
+/**
+ * Tests for waitForEngine logic — the core of the #1906 race-condition fix.
+ *
+ * We replicate the waitForEngine logic inline with injectable dependencies
+ * (same pattern as wake.test.ts / isPaneIdleWith) to avoid mock.module()
+ * process-global leakage.
+ *
+ * Scenario being guarded: maw wake with a non-claude engine (e.g. thclaws):
+ *   1. newSession() + sendText('thclaws --cli')   ← pane still shows 'zsh'
+ *   2. liveness check: getPaneInfos → 'zsh' → isAgentCommand=false → re-sends ← BUG
+ * waitForEngine() sits between step 1 and 2, blocking until the pane command
+ * flips to the engine binary.
+ */
+
+// --- Inline replication of waitForEngine (keep in sync with wake-session.ts) ---
+
+async function waitForEngineWith(
+  paneTarget: string,
+  getPaneInfos: (targets: string[]) => Promise<Record<string, { command: string }>>,
+  isAgentCommand: (cmd: string | null | undefined) => boolean,
+  timeoutMs = 5000,
+  pollIntervalMs = 250,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const infos = await getPaneInfos([paneTarget]);
+      const info = infos[paneTarget];
+      if (info && isAgentCommand(info.command)) return true;
+    } catch { /* tolerate transient tmux errors */ }
+    if (Date.now() < deadline) {
+      await new Promise(r => setTimeout(r, pollIntervalMs));
+    }
+  }
+  return false;
+}
+
+// --- Helpers ---
+
+const isAgent = (cmd: string | null | undefined) => {
+  const c = (cmd ?? "").trim();
+  return /claude|codex|node|thclaws/i.test(c) || /^\d+\.\d+\.\d+$/.test(c);
+};
+
+function makeGetPaneInfos(sequence: string[]): (targets: string[]) => Promise<Record<string, { command: string }>> {
+  let call = 0;
+  return async (targets: string[]) => {
+    const cmd = sequence[Math.min(call++, sequence.length - 1)];
+    return Object.fromEntries(targets.map(t => [t, { command: cmd }]));
+  };
+}
+
+// --- Tests ---
+
+describe("waitForEngine (#1906 race condition fix)", () => {
+  test("engine already running → returns true on first poll", async () => {
+    const getPaneInfos = makeGetPaneInfos(["thclaws"]);
+    const result = await waitForEngineWith("sess:oracle", getPaneInfos, isAgent, 500, 50);
+    expect(result).toBe(true);
+  });
+
+  test("engine starts after a few polls → returns true", async () => {
+    // First 2 polls return 'zsh', third returns 'thclaws'
+    const getPaneInfos = makeGetPaneInfos(["zsh", "zsh", "thclaws"]);
+    const result = await waitForEngineWith("sess:oracle", getPaneInfos, isAgent, 1000, 50);
+    expect(result).toBe(true);
+  });
+
+  test("engine never starts → returns false on timeout", async () => {
+    const getPaneInfos = makeGetPaneInfos(["zsh"]);
+    const result = await waitForEngineWith("sess:oracle", getPaneInfos, isAgent, 150, 50);
+    expect(result).toBe(false);
+  });
+
+  test("getPaneInfos throws → keeps polling, returns false on timeout", async () => {
+    let calls = 0;
+    const getPaneInfos = async (_targets: string[]) => {
+      calls++;
+      throw new Error("tmux not ready");
+    };
+    const result = await waitForEngineWith("sess:oracle", getPaneInfos, isAgent, 150, 50);
+    expect(result).toBe(false);
+    expect(calls).toBeGreaterThan(1); // polled multiple times despite errors
+  });
+
+  test("pane not in result → continues polling", async () => {
+    let call = 0;
+    const getPaneInfos = async (targets: string[]) => {
+      // First call: pane missing from result; second call: pane present with engine
+      if (call++ === 0) return {} as Record<string, { command: string }>;
+      return Object.fromEntries(targets.map(t => [t, { command: "claude" }]));
+    };
+    const result = await waitForEngineWith("sess:oracle", getPaneInfos, isAgent, 500, 50);
+    expect(result).toBe(true);
+  });
+
+  test("versioned claude binary (2.1.121) recognised as agent", async () => {
+    const getPaneInfos = makeGetPaneInfos(["2.1.121"]);
+    const result = await waitForEngineWith("sess:oracle", getPaneInfos, isAgent, 500, 50);
+    expect(result).toBe(true);
+  });
+
+  test("shell commands are never recognised as agents", async () => {
+    for (const shell of ["zsh", "bash", "sh", ""]) {
+      const getPaneInfos = makeGetPaneInfos([shell]);
+      const result = await waitForEngineWith("sess:oracle", getPaneInfos, isAgent, 100, 40);
+      expect(result).toBe(false);
+    }
+  });
+
+  test("multiple pane targets — correct pane is checked", async () => {
+    const getPaneInfos = async (targets: string[]) => {
+      // Only "sess:oracle" has the engine; others have zsh
+      return Object.fromEntries(targets.map(t => [
+        t,
+        { command: t === "sess:oracle" ? "thclaws" : "zsh" },
+      ]));
+    };
+    const result = await waitForEngineWith("sess:oracle", getPaneInfos, isAgent, 500, 50);
+    expect(result).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

When waking an oracle that uses a non-claude engine (e.g. `thclaws --cli`), two `sendText()` calls fire in sequence:

1. **New-session path** (intended): `sendText('thclaws --cli')` → engine starts booting in the shell ✓
2. **Liveness check** (race): `getPaneInfos()` fires before the engine has replaced the shell → pane command is still `'zsh'` → `isAgentCommand('zsh') = false` → `sendText('thclaws --cli')` again → lands in the already-running engine's **chat** as literal text ✗

## Root cause

The 300 ms `setTimeout` after `newSession()` is enough for tmux to create the pane, but not enough for a slow engine to exec and update the pane command. `claude` starts fast enough to escape the window; `thclaws` (and other external engines) do not.

## Fix

Add `waitForEngine()` to `wake-session.ts` — polls `getPaneInfos()` until `isAgentCommand()` returns `true`, with a 5 s timeout and 250 ms poll interval. Call it after every `sendText()` in the new-session branch of `cmdWake`.

```
sendText(target, cmd)               ← existing
waitForEngine(target, ...)          ← NEW: blocks until engine confirms
// ... liveness check now sees the engine, not 'zsh'
```

## Changes

| File | Change |
|---|---|
| `src/commands/shared/wake-session.ts` | export `waitForEngine()` with injectable deps |
| `src/commands/shared/wake-cmd.ts` | import + call `waitForEngine()` after `sendText()` in new-session path (main window + worktree windows) |
| `test/wake-engine-wait.test.ts` | 8 unit tests — inline-replicated logic, no `mock.module()` leakage |

## Tests

```
8 pass / 0 fail  (wake-engine-wait.test.ts)
```

Pre-existing failures in `curlFetch` and `Tmux.newGroupedSession` are unrelated to this change (confirmed by running the same suite on `main` before the patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)