### PR TITLE
fix(workon): sanitize slashes in task slugs

### DIFF
--- a/src/vendor/mpr-plugins/workon/impl.ts
+++ b/src/vendor/mpr-plugins/workon/impl.ts
@@ -25,6 +25,7 @@ export async function cmdWorkon(repo: string, task?: string, opts: { layout?: Wo
   let windowName = repoName;
 
   if (task) {
+    task = task.replace(/\//g, "-");
     const worktrees = await findWorktrees(parentDir, repoName);
     const resolved = resolveWorktreeTarget(task, worktrees);
     let match: { path: string; name: string } | null = null;


### PR DESCRIPTION
Slashes in task names (e.g. feat/message-tracking) create nested worktree directories that break git worktree remove cleanup — the orphaned parent directory is left behind.

One-line fix: `task = task.replace(/\//g, "-")` before building the worktree path and branch name.

## Test plan

- [ ] `maw workon <repo> feat/test-slash` creates `1-feat-test-slash` (not nested)
- [ ] `maw done <window>` cleans up without orphaned directories
- [ ] Existing worktrees without slashes still work normally
