### PR TITLE
feat(done): safely clean dissolved worktree branches

### DIFF
--- a/src/commands/shared/done.ts
+++ b/src/commands/shared/done.ts
@@ -11,6 +11,7 @@ import { fleetDirForWrite, fleetDirsForRead, uniqueDirs } from "../../core/fleet
 export interface DoneOpts {
   force?: boolean;
   dryRun?: boolean;
+  cleanBranch?: boolean;
 }
 
 type SessionInfo = { name: string; windows: { index: number; name: string; active: boolean }[] };
@@ -38,6 +39,7 @@ export interface DoneDeps {
   homeDir?: string;
   inboxDir?: string;
   takeSnapshot?: (trigger: string) => Promise<unknown>;
+  branchBase?: string;
   now?: () => Date;
   sleep?: (ms: number) => Promise<void>;
   fs?: Partial<DoneFs>;
@@ -59,6 +61,7 @@ function doneDeps(deps: DoneDeps = {}) {
     homeDir,
     inboxDir: deps.inboxDir ?? mawDataPath("inbox"),
     takeSnapshot: deps.takeSnapshot ?? takeSnapshot,
+    branchBase: deps.branchBase,
     now: deps.now ?? (() => new Date()),
     sleep: deps.sleep ?? Bun.sleep,
     fs: {
@@ -73,6 +76,83 @@ function doneDeps(deps: DoneDeps = {}) {
 }
 
 type ResolvedDoneDeps = ReturnType<typeof doneDeps>;
+
+function shellArg(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function branchBaseFor(mainPath: string, d: ResolvedDoneDeps): string {
+  if (d.branchBase) return d.branchBase;
+  const normalized = mainPath.split("\\").join("/");
+  if (normalized.endsWith("/Soul-Brews-Studio/maw-js") || normalized.includes("/github.com/Soul-Brews-Studio/maw-js")) {
+    return "alpha";
+  }
+  return "main";
+}
+
+function isProtectedBranch(branch: string, baseBranch: string): boolean {
+  return branch === "HEAD" || branch === "main" || branch === "master" || branch === "alpha" || branch === baseBranch;
+}
+
+async function ghMergedPrExists(branch: string, d: ResolvedDoneDeps): Promise<"yes" | "no" | "unavailable"> {
+  try {
+    const out = await d.hostExec(`gh pr list --head ${shellArg(branch)} --state merged --json number --limit 1`);
+    const parsed = JSON.parse(out || "[]");
+    return Array.isArray(parsed) && parsed.length > 0 ? "yes" : "no";
+  } catch {
+    return "unavailable";
+  }
+}
+
+export async function cleanupDoneBranch(
+  mainPath: string,
+  branch: string,
+  opts: DoneOpts = {},
+  deps: DoneDeps = {},
+): Promise<void> {
+  const d = doneDeps(deps);
+  const cleanBranch = Boolean(opts.cleanBranch);
+  const baseBranch = branchBaseFor(mainPath, d);
+  if (!branch || isProtectedBranch(branch, baseBranch)) return;
+
+  const quotedMain = shellArg(mainPath);
+  const quotedBranch = shellArg(branch);
+  if (cleanBranch) {
+    try {
+      await d.hostExec(`git -C ${quotedMain} branch -D ${quotedBranch}`);
+      d.logger.log(`  \x1b[32m✓\x1b[0m force-deleted branch ${branch}`);
+    } catch (e: any) {
+      d.logger.log(`  \x1b[33m⚠\x1b[0m branch retained (${branch}): force delete failed: ${e?.message || e}`);
+    }
+    return;
+  }
+
+  try {
+    await d.hostExec(`git -C ${quotedMain} merge-base --is-ancestor ${quotedBranch} ${shellArg(baseBranch)}`);
+    await d.hostExec(`git -C ${quotedMain} branch -d ${quotedBranch}`);
+    d.logger.log(`  \x1b[32m✓\x1b[0m deleted branch ${branch} (merged into ${baseBranch})`);
+    return;
+  } catch {
+    // Not an ancestor of the configured base, or local refs are unavailable.
+  }
+
+  const prState = await ghMergedPrExists(branch, d);
+  if (prState === "yes") {
+    try {
+      await d.hostExec(`git -C ${quotedMain} branch -D ${quotedBranch}`);
+      d.logger.log(`  \x1b[32m✓\x1b[0m deleted branch ${branch} (merged PR)`);
+    } catch (e: any) {
+      d.logger.log(`  \x1b[33m⚠\x1b[0m branch retained (${branch}): delete failed after merged PR proof: ${e?.message || e}`);
+    }
+    return;
+  }
+
+  if (prState === "unavailable") {
+    d.logger.log(`  \x1b[33m⚠\x1b[0m branch retained (${branch}): gh unavailable and not merged into ${baseBranch}`);
+  } else {
+    d.logger.log(`  \x1b[90m○\x1b[0m branch retained (${branch}): not merged into ${baseBranch} and no merged PR found`);
+  }
+}
 
 function activeFleetConfigFiles(d: ResolvedDoneDeps): Array<{ file: string; path: string }> {
   const filesByName = new Map<string, { file: string; path: string }>();
@@ -135,9 +215,9 @@ export async function cmdDone(windowName_: string, opts: DoneOpts = {}, deps: Do
     d.logger.log(`  \x1b[90m○\x1b[0m window '${windowName}' not running`);
   }
 
-  let removedWorktree = await removeWorktreeViaConfig(windowNameLower, reposRoot, deps);
+  let removedWorktree = await removeWorktreeViaConfig(windowNameLower, reposRoot, deps, opts);
   if (!removedWorktree) {
-    removedWorktree = await removeWorktreeByGhqScan(windowName, reposRoot, deps);
+    removedWorktree = await removeWorktreeByGhqScan(windowName, reposRoot, deps, opts);
   }
   if (!removedWorktree) {
     d.logger.log(`  \x1b[90m○\x1b[0m no worktree to remove (may be a main window)`);
@@ -234,6 +314,7 @@ export async function removeWorktreeViaConfig(
   windowNameLower: string,
   reposRoot: string,
   deps: DoneDeps = {},
+  opts: DoneOpts = {},
 ): Promise<boolean> {
   const d = doneDeps(deps);
   try {
@@ -258,7 +339,7 @@ export async function removeWorktreeViaConfig(
         await d.hostExec(`git -C '${mainPath}' worktree prune`);
         d.logger.log(`  \x1b[32m✓\x1b[0m removed worktree ${win.repo}`);
         if (branch && branch !== "main" && branch !== "HEAD") {
-          try { await d.hostExec(`git -C '${mainPath}' branch -d '${branch}'`); d.logger.log(`  \x1b[32m✓\x1b[0m deleted branch ${branch}`); } catch { /* expected */ }
+          await cleanupDoneBranch(mainPath, branch, opts, deps);
         }
         return true;
       } catch (e: any) {
@@ -274,6 +355,7 @@ export async function removeWorktreeByGhqScan(
   windowName: string,
   reposRoot: string,
   deps: DoneDeps = {},
+  opts: DoneOpts = {},
 ): Promise<boolean> {
   const d = doneDeps(deps);
   let removed = false;
@@ -307,7 +389,7 @@ export async function removeWorktreeByGhqScan(
         d.logger.log(`  \x1b[32m✓\x1b[0m removed worktree ${base}`);
         removed = true;
         if (branch && branch !== "main" && branch !== "HEAD") {
-          try { await d.hostExec(`git -C '${mainPath}' branch -d '${branch}'`); d.logger.log(`  \x1b[32m✓\x1b[0m deleted branch ${branch}`); } catch { /* expected */ }
+          await cleanupDoneBranch(mainPath, branch, opts, deps);
         }
       } catch (e) { d.logger.error(`  \x1b[33m⚠\x1b[0m worktree remove failed: ${e}`); }
     }

--- a/src/vendor/mpr-plugins/done/done-worktree.ts
+++ b/src/vendor/mpr-plugins/done/done-worktree.ts
@@ -4,6 +4,11 @@ import { join } from "path";
 import { fleetDirsForRead } from "maw-js/commands/shared/fleet-load";
 import { parseWorktreePath } from "maw-js/core/fleet/worktree-layout";
 
+export interface DoneBranchCleanupOpts {
+  cleanBranch?: boolean;
+  branchBase?: string;
+}
+
 function activeFleetConfigFiles(): Array<{ file: string; path: string }> {
   const filesByName = new Map<string, { file: string; path: string }>();
   for (const fleetDir of fleetDirsForRead()) {
@@ -20,6 +25,80 @@ function activeFleetConfigFiles(): Array<{ file: string; path: string }> {
   return [...filesByName.values()].sort((a, b) => a.file.localeCompare(b.file));
 }
 
+function shellArg(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function branchBaseFor(mainPath: string, opts: DoneBranchCleanupOpts = {}): string {
+  if (opts.branchBase) return opts.branchBase;
+  const normalized = mainPath.split("\\").join("/");
+  if (normalized.endsWith("/Soul-Brews-Studio/maw-js") || normalized.includes("/github.com/Soul-Brews-Studio/maw-js")) {
+    return "alpha";
+  }
+  return "main";
+}
+
+function isProtectedBranch(branch: string, baseBranch: string): boolean {
+  return branch === "HEAD" || branch === "main" || branch === "master" || branch === "alpha" || branch === baseBranch;
+}
+
+async function ghMergedPrExists(branch: string): Promise<"yes" | "no" | "unavailable"> {
+  try {
+    const out = await hostExec(`gh pr list --head ${shellArg(branch)} --state merged --json number --limit 1`);
+    const parsed = JSON.parse(out || "[]");
+    return Array.isArray(parsed) && parsed.length > 0 ? "yes" : "no";
+  } catch {
+    return "unavailable";
+  }
+}
+
+export async function cleanupDoneBranch(
+  mainPath: string,
+  branch: string,
+  opts: DoneBranchCleanupOpts = {},
+): Promise<void> {
+  const baseBranch = branchBaseFor(mainPath, opts);
+  if (!branch || isProtectedBranch(branch, baseBranch)) return;
+
+  const quotedMain = shellArg(mainPath);
+  const quotedBranch = shellArg(branch);
+  if (opts.cleanBranch) {
+    try {
+      await hostExec(`git -C ${quotedMain} branch -D ${quotedBranch}`);
+      console.log(`  \x1b[32m✓\x1b[0m force-deleted branch ${branch}`);
+    } catch (e: any) {
+      console.log(`  \x1b[33m⚠\x1b[0m branch retained (${branch}): force delete failed: ${e?.message || e}`);
+    }
+    return;
+  }
+
+  try {
+    await hostExec(`git -C ${quotedMain} merge-base --is-ancestor ${quotedBranch} ${shellArg(baseBranch)}`);
+    await hostExec(`git -C ${quotedMain} branch -d ${quotedBranch}`);
+    console.log(`  \x1b[32m✓\x1b[0m deleted branch ${branch} (merged into ${baseBranch})`);
+    return;
+  } catch {
+    // Not an ancestor of the configured base, or local refs are unavailable.
+  }
+
+  const prState = await ghMergedPrExists(branch);
+  if (prState === "yes") {
+    try {
+      await hostExec(`git -C ${quotedMain} branch -D ${quotedBranch}`);
+      console.log(`  \x1b[32m✓\x1b[0m deleted branch ${branch} (merged PR)`);
+    } catch (e: any) {
+      console.log(`  \x1b[33m⚠\x1b[0m branch retained (${branch}): delete failed after merged PR proof: ${e?.message || e}`);
+    }
+    return;
+  }
+
+  if (prState === "unavailable") {
+    console.log(`  \x1b[33m⚠\x1b[0m branch retained (${branch}): gh unavailable and not merged into ${baseBranch}`);
+  } else {
+    console.log(`  \x1b[90m○\x1b[0m branch retained (${branch}): not merged into ${baseBranch} and no merged PR found`);
+  }
+}
+
 /**
  * Remove a git worktree via fleet config lookup.
  * Returns true if a worktree was removed.
@@ -27,6 +106,7 @@ function activeFleetConfigFiles(): Array<{ file: string; path: string }> {
 export async function removeWorktreeViaConfig(
   windowNameLower: string,
   reposRoot: string,
+  opts: DoneBranchCleanupOpts = {},
 ): Promise<boolean> {
   try {
     for (const { file, path } of activeFleetConfigFiles()) {
@@ -48,9 +128,7 @@ export async function removeWorktreeViaConfig(
         await hostExec(`git -C '${mainPath}' worktree remove '${fullPath}' --force`);
         await hostExec(`git -C '${mainPath}' worktree prune`);
         console.log(`  \x1b[32m✓\x1b[0m removed worktree ${win.repo}`);
-        if (branch && branch !== "main" && branch !== "HEAD") {
-          try { await hostExec(`git -C '${mainPath}' branch -d '${branch}'`); console.log(`  \x1b[32m✓\x1b[0m deleted branch ${branch}`); } catch { /* expected */ }
-        }
+        await cleanupDoneBranch(mainPath, branch, opts);
         return true;
       } catch (e: any) {
         console.log(`  \x1b[33m⚠\x1b[0m worktree remove failed: ${e.message || e}`);
@@ -69,6 +147,7 @@ export async function removeWorktreeViaConfig(
 export async function removeWorktreeByGhqScan(
   windowName: string,
   reposRoot: string,
+  opts: DoneBranchCleanupOpts = {},
 ): Promise<boolean> {
   let removed = false;
   try {
@@ -100,9 +179,7 @@ export async function removeWorktreeByGhqScan(
         await hostExec(`git -C '${mainPath}' worktree prune`);
         console.log(`  \x1b[32m✓\x1b[0m removed worktree ${base}`);
         removed = true;
-        if (branch && branch !== "main" && branch !== "HEAD") {
-          try { await hostExec(`git -C '${mainPath}' branch -d '${branch}'`); console.log(`  \x1b[32m✓\x1b[0m deleted branch ${branch}`); } catch { /* expected */ }
-        }
+        await cleanupDoneBranch(mainPath, branch, opts);
       } catch (e) { console.error(`  \x1b[33m⚠\x1b[0m worktree remove failed: ${e}`); }
     }
   } catch (e) { console.error(`  \x1b[33m⚠\x1b[0m worktree scan failed: ${e}`); }

--- a/src/vendor/mpr-plugins/done/impl.ts
+++ b/src/vendor/mpr-plugins/done/impl.ts
@@ -10,6 +10,7 @@ import { removeWorktreeViaConfig, removeWorktreeByGhqScan, removeFromFleetConfig
 export interface DoneOpts {
   force?: boolean;
   dryRun?: boolean;
+  cleanBranch?: boolean;
   /** Restrict window-name lookup to a specific tmux session. Used by done --all. */
   sessionName?: string;
 }
@@ -45,7 +46,7 @@ function nonLeadWindows(session: DoneSession): DoneWindow[] {
 }
 
 /**
- * maw done <window-name> [--force] [--dry-run]
+ * maw done <window-name> [--force] [--dry-run] [--clean-branch]
  *
  * Clean up a finished worktree window:
  * 0. Send /rrr to agent + git auto-save (unless --force)
@@ -96,9 +97,9 @@ export async function cmdDone(windowName_: string, opts: DoneOpts = {}) {
   }
 
   // 2. Remove git worktree
-  let removedWorktree = await removeWorktreeViaConfig(windowNameLower, reposRoot);
+  let removedWorktree = await removeWorktreeViaConfig(windowNameLower, reposRoot, opts);
   if (!removedWorktree) {
-    removedWorktree = await removeWorktreeByGhqScan(windowName, reposRoot);
+    removedWorktree = await removeWorktreeByGhqScan(windowName, reposRoot, opts);
   }
   if (!removedWorktree) {
     console.log(`  \x1b[90m○\x1b[0m no worktree to remove (may be a main window)`);

--- a/src/vendor/mpr-plugins/done/index.ts
+++ b/src/vendor/mpr-plugins/done/index.ts
@@ -23,6 +23,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     let force: boolean | undefined;
     let dryRun: boolean | undefined;
     let all: boolean | undefined;
+    let cleanBranch: boolean | undefined;
 
     if (ctx.source === "cli") {
       const args = ctx.args as string[];
@@ -31,6 +32,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       force = args.includes("--force");
       dryRun = args.includes("--dry-run");
       all = args.includes("--all");
+      cleanBranch = args.includes("--clean-branch");
       name = positional[0];
     } else {
       const args = ctx.args as Record<string, unknown>;
@@ -38,18 +40,19 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       force = args.force as boolean | undefined;
       dryRun = args.dryRun as boolean | undefined;
       all = args.all as boolean | undefined;
+      cleanBranch = (args.cleanBranch ?? args.clean_branch) as boolean | undefined;
     }
 
     if (all) {
-      await cmdDoneAll({ force, dryRun });
+      await cmdDoneAll({ force, dryRun, cleanBranch });
       return { ok: true, output: logs.join("\n") || undefined };
     }
 
     if (!name) {
-      return { ok: false, error: "usage: maw done <window-name> [--force] [--dry-run] or maw done --all [--force] [--dry-run]  (see: maw sleep/kill for non-worktree shutdown)" };
+      return { ok: false, error: "usage: maw done <window-name> [--force] [--dry-run] [--clean-branch] or maw done --all [--force] [--dry-run] [--clean-branch]  (see: maw sleep/kill for non-worktree shutdown)" };
     }
 
-    await cmdDone(name, { force, dryRun });
+    await cmdDone(name, { force, dryRun, cleanBranch });
     return { ok: true, output: logs.join("\n") || undefined };
   } catch (e: any) {
     return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };

--- a/src/vendor/mpr-plugins/done/plugin.json
+++ b/src/vendor/mpr-plugins/done/plugin.json
@@ -10,7 +10,7 @@
     "aliases": [
       "finish"
     ],
-    "help": "maw done <window-name> [--force] [--dry-run] | maw done --all [--force] [--dry-run] — finish worktrees; see maw sleep/kill for non-worktree shutdown"
+    "help": "maw done <window-name> [--force] [--dry-run] [--clean-branch] | maw done --all [--force] [--dry-run] [--clean-branch] — finish worktrees; see maw sleep/kill for non-worktree shutdown"
   },
   "api": {
     "path": "/api/done",

--- a/test/done-command.test.ts
+++ b/test/done-command.test.ts
@@ -3,6 +3,7 @@ import { basename, dirname, join } from "path";
 import {
   autoSave,
   cmdDone,
+  cleanupDoneBranch,
   removeFromFleetConfig,
   removeWorktreeByGhqScan,
   removeWorktreeViaConfig,
@@ -183,6 +184,7 @@ describe("cmdDone", () => {
       "git -C '/repos/github.com/Soul-Brews-Studio/maw-js.wt-tile-1' rev-parse --abbrev-ref HEAD",
       "git -C '/repos/github.com/Soul-Brews-Studio/maw-js' worktree remove '/repos/github.com/Soul-Brews-Studio/maw-js.wt-tile-1' --force",
       "git -C '/repos/github.com/Soul-Brews-Studio/maw-js' worktree prune",
+      "git -C '/repos/github.com/Soul-Brews-Studio/maw-js' merge-base --is-ancestor 'feature/done' 'alpha'",
       "git -C '/repos/github.com/Soul-Brews-Studio/maw-js' branch -d 'feature/done'",
     ]);
     expect(JSON.parse(h.files.get(fleetFile)!)).toEqual({
@@ -349,6 +351,100 @@ describe("done inbox and autosave helpers", () => {
   });
 });
 
+describe("cleanupDoneBranch", () => {
+  test("deletes branches that are ancestors of the configured base", async () => {
+    const h = createHarness();
+
+    await cleanupDoneBranch("/repos/github.com/Soul-Brews-Studio/maw-js", "feature/merged", {}, h.deps);
+
+    expect(h.commands).toEqual([
+      "git -C '/repos/github.com/Soul-Brews-Studio/maw-js' merge-base --is-ancestor 'feature/merged' 'alpha'",
+      "git -C '/repos/github.com/Soul-Brews-Studio/maw-js' branch -d 'feature/merged'",
+    ]);
+    expect(h.logs.join("\n")).toContain("deleted branch feature/merged (merged into alpha)");
+  });
+
+  test("deletes squash-merged branches only after merged PR proof", async () => {
+    const h = createHarness({
+      hostExec: (command) => {
+        if (command.includes("merge-base --is-ancestor")) throw new Error("not ancestor");
+        if (command.startsWith("gh pr list")) return JSON.stringify([{ number: 1922 }]);
+        return "";
+      },
+    });
+
+    await cleanupDoneBranch("/repos/github.com/Soul-Brews-Studio/maw-js", "agents/1922-clean-branch", {}, h.deps);
+
+    expect(h.commands).toEqual([
+      "git -C '/repos/github.com/Soul-Brews-Studio/maw-js' merge-base --is-ancestor 'agents/1922-clean-branch' 'alpha'",
+      "gh pr list --head 'agents/1922-clean-branch' --state merged --json number --limit 1",
+      "git -C '/repos/github.com/Soul-Brews-Studio/maw-js' branch -D 'agents/1922-clean-branch'",
+    ]);
+    expect(h.logs.join("\n")).toContain("deleted branch agents/1922-clean-branch (merged PR)");
+  });
+
+  test("keeps branches when local proof fails and gh is unavailable", async () => {
+    const h = createHarness({
+      hostExec: (command) => {
+        if (command.includes("merge-base --is-ancestor")) throw new Error("not ancestor");
+        if (command.startsWith("gh pr list")) throw new Error("gh unavailable");
+        return "";
+      },
+    });
+
+    await cleanupDoneBranch("/repos/github.com/Soul-Brews-Studio/maw-js", "feature/unverified", {}, h.deps);
+
+    expect(h.commands).toEqual([
+      "git -C '/repos/github.com/Soul-Brews-Studio/maw-js' merge-base --is-ancestor 'feature/unverified' 'alpha'",
+      "gh pr list --head 'feature/unverified' --state merged --json number --limit 1",
+    ]);
+    expect(h.logs.join("\n")).toContain("branch retained (feature/unverified): gh unavailable and not merged into alpha");
+  });
+
+  test("keeps unmerged branches when gh finds no merged PR", async () => {
+    const h = createHarness({
+      hostExec: (command) => {
+        if (command.includes("merge-base --is-ancestor")) throw new Error("not ancestor");
+        if (command.startsWith("gh pr list")) return "[]";
+        return "";
+      },
+    });
+
+    await cleanupDoneBranch("/repos/github.com/Soul-Brews-Studio/maw-js", "feature/open", {}, h.deps);
+
+    expect(h.commands).toEqual([
+      "git -C '/repos/github.com/Soul-Brews-Studio/maw-js' merge-base --is-ancestor 'feature/open' 'alpha'",
+      "gh pr list --head 'feature/open' --state merged --json number --limit 1",
+    ]);
+    expect(h.logs.join("\n")).toContain("branch retained (feature/open): not merged into alpha and no merged PR found");
+  });
+
+  test("--clean-branch force-deletes without merge or PR proof", async () => {
+    const h = createHarness();
+
+    await cleanupDoneBranch("/repos/github.com/Soul-Brews-Studio/maw-js", "feature/force", { cleanBranch: true }, h.deps);
+
+    expect(h.commands).toEqual([
+      "git -C '/repos/github.com/Soul-Brews-Studio/maw-js' branch -D 'feature/force'",
+    ]);
+    expect(h.logs.join("\n")).toContain("force-deleted branch feature/force");
+  });
+
+  test("uses alpha for maw-js and main for generic repositories", async () => {
+    const maw = createHarness();
+    await cleanupDoneBranch("/repos/github.com/Soul-Brews-Studio/maw-js", "feature/alpha", {}, maw.deps);
+    expect(maw.commands[0]).toBe(
+      "git -C '/repos/github.com/Soul-Brews-Studio/maw-js' merge-base --is-ancestor 'feature/alpha' 'alpha'",
+    );
+
+    const generic = createHarness();
+    await cleanupDoneBranch("/repos/github.com/acme/tool", "feature/main", {}, generic.deps);
+    expect(generic.commands[0]).toBe(
+      "git -C '/repos/github.com/acme/tool' merge-base --is-ancestor 'feature/main' 'main'",
+    );
+  });
+});
+
 describe("done worktree cleanup helpers", () => {
   test("removeWorktreeViaConfig removes configured worktrees and skips main/HEAD branch deletion", async () => {
     const h = createHarness({
@@ -426,7 +522,7 @@ describe("done worktree cleanup helpers", () => {
     expect(scanFail.errors.join("\n")).toContain("fleet scan failed");
   });
 
-  test("removeWorktreeByGhqScan removes matching suffix worktrees and ignores branch-delete failures", async () => {
+  test("removeWorktreeByGhqScan removes matching suffix worktrees and reports retained unmerged branches", async () => {
     const h = createHarness({
       hostExec: (command) => {
         if (command.startsWith("find ")) {
@@ -436,7 +532,8 @@ describe("done worktree cleanup helpers", () => {
           ].join("\n");
         }
         if (command.includes("rev-parse")) return "feature/scan\n";
-        if (command.includes("branch -d")) throw new Error("not merged");
+        if (command.includes("merge-base --is-ancestor")) throw new Error("not merged");
+        if (command.startsWith("gh pr list")) return "[]";
         return "";
       },
     });
@@ -445,8 +542,10 @@ describe("done worktree cleanup helpers", () => {
 
     expect(h.commands).toContain("git -C '/repos/github.com/Soul-Brews-Studio/maw-js.wt-6-tile-1' rev-parse --abbrev-ref HEAD");
     expect(h.commands).toContain("git -C '/repos/github.com/Soul-Brews-Studio/maw-js' worktree remove '/repos/github.com/Soul-Brews-Studio/maw-js.wt-6-tile-1' --force");
+    expect(h.commands).toContain("git -C '/repos/github.com/Soul-Brews-Studio/maw-js' merge-base --is-ancestor 'feature/scan' 'alpha'");
+    expect(h.commands).toContain("gh pr list --head 'feature/scan' --state merged --json number --limit 1");
     expect(h.logs.join("\n")).toContain("removed worktree maw-js.wt-6-tile-1");
-    expect(h.logs.join("\n")).not.toContain("deleted branch feature/scan");
+    expect(h.logs.join("\n")).toContain("branch retained (feature/scan): not merged into alpha and no merged PR found");
   });
 
 

--- a/test/isolated/done-index-coverage.test.ts
+++ b/test/isolated/done-index-coverage.test.ts
@@ -2,13 +2,14 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 type InvokeCtx = { source: "cli" | "api"; args: unknown; writer?: (...args: unknown[]) => void };
+type DoneOpts = { force?: boolean; dryRun?: boolean; cleanBranch?: boolean };
 
-let doneCalls: Array<{ name: string; opts: { force?: boolean; dryRun?: boolean } }> = [];
-let doneAllCalls: Array<{ force?: boolean; dryRun?: boolean }> = [];
+let doneCalls: Array<{ name: string; opts: DoneOpts }> = [];
+let doneAllCalls: DoneOpts[] = [];
 let mode: "ok" | "throw-with-log" | "throw-plain" = "ok";
 
 mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/done/impl.ts"), () => ({
-  cmdDone: async (name: string, opts: { force?: boolean; dryRun?: boolean }) => {
+  cmdDone: async (name: string, opts: DoneOpts) => {
     doneCalls.push({ name, opts });
     if (mode === "throw-with-log") {
       console.error("logged failure");
@@ -17,7 +18,7 @@ mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/done/impl.ts"), ()
     if (mode === "throw-plain") throw new Error("plain failure");
     console.log(`done:${name}:${Boolean(opts.force)}:${Boolean(opts.dryRun)}`);
   },
-  cmdDoneAll: async (opts: { force?: boolean; dryRun?: boolean }) => {
+  cmdDoneAll: async (opts: DoneOpts) => {
     doneAllCalls.push(opts);
     if (mode === "throw-with-log") {
       console.error("all logged failure");
@@ -41,11 +42,11 @@ describe("done plugin index wrapper", () => {
 
     const result = await donePlugin.default({
       source: "api",
-      args: { name: "tile-1", force: true, dryRun: true },
+      args: { name: "tile-1", force: true, dryRun: true, cleanBranch: true },
     } as InvokeCtx);
 
     expect(result).toEqual({ ok: true, output: "done:tile-1:true:true" });
-    expect(doneCalls).toEqual([{ name: "tile-1", opts: { force: true, dryRun: true } }]);
+    expect(doneCalls).toEqual([{ name: "tile-1", opts: { force: true, dryRun: true, cleanBranch: true } }]);
     expect(doneAllCalls).toEqual([]);
   });
 
@@ -54,13 +55,23 @@ describe("done plugin index wrapper", () => {
 
     const result = await donePlugin.default({
       source: "api",
-      args: { all: true, force: true, dryRun: false },
+      args: { all: true, force: true, dryRun: false, clean_branch: true },
       writer: (...args: unknown[]) => lines.push(args.map(String).join(" ")),
     } as InvokeCtx);
 
     expect(result).toEqual({ ok: true, output: undefined });
-    expect(doneAllCalls).toEqual([{ force: true, dryRun: false }]);
+    expect(doneAllCalls).toEqual([{ force: true, dryRun: false, cleanBranch: true }]);
     expect(lines).toEqual(["all:true:false"]);
+  });
+
+  test("maps CLI --clean-branch to cmdDone", async () => {
+    const result = await donePlugin.default({
+      source: "cli",
+      args: ["tile-2", "--force", "--clean-branch"],
+    } as InvokeCtx);
+
+    expect(result.ok).toBe(true);
+    expect(doneCalls).toEqual([{ name: "tile-2", opts: { force: true, dryRun: false, cleanBranch: true } }]);
   });
 
   test("returns usage for missing API name without calling implementation", async () => {

--- a/test/isolated/done-worktree-coverage.test.ts
+++ b/test/isolated/done-worktree-coverage.test.ts
@@ -32,6 +32,7 @@ mock.module("maw-js/commands/shared/fleet-load", () => ({
 }));
 
 const {
+  cleanupDoneBranch,
   removeFromFleetConfig,
   removeWorktreeByGhqScan,
   removeWorktreeViaConfig,
@@ -78,6 +79,86 @@ afterAll(() => {
   rmSync(SANDBOX, { recursive: true, force: true });
 });
 
+describe("cleanupDoneBranch", () => {
+  test("deletes ancestor branches against the maw-js alpha base", async () => {
+    const mainPath = join(REPOS_ROOT, "Soul-Brews-Studio", "maw-js");
+
+    const output = await captureConsole(async () => {
+      await cleanupDoneBranch(mainPath, "feature/merged");
+    });
+
+    expect(hostExecCalls).toEqual([
+      `git -C '${mainPath}' merge-base --is-ancestor 'feature/merged' 'alpha'`,
+      `git -C '${mainPath}' branch -d 'feature/merged'`,
+    ]);
+    expect(output).toContain("deleted branch feature/merged (merged into alpha)");
+  });
+
+  test("uses merged PR proof for squash-merged branches", async () => {
+    const mainPath = join(REPOS_ROOT, "Soul-Brews-Studio", "maw-js");
+    hostExecHandler = (command) => {
+      if (command.includes("merge-base --is-ancestor")) throw new Error("not ancestor");
+      if (command.startsWith("gh pr list")) return "[{\"number\":1922}]";
+      return "";
+    };
+
+    const output = await captureConsole(async () => {
+      await cleanupDoneBranch(mainPath, "agents/1922-clean-branch");
+    });
+
+    expect(hostExecCalls).toEqual([
+      `git -C '${mainPath}' merge-base --is-ancestor 'agents/1922-clean-branch' 'alpha'`,
+      "gh pr list --head 'agents/1922-clean-branch' --state merged --json number --limit 1",
+      `git -C '${mainPath}' branch -D 'agents/1922-clean-branch'`,
+    ]);
+    expect(output).toContain("deleted branch agents/1922-clean-branch (merged PR)");
+  });
+
+  test("keeps branches when gh proof is unavailable or no merged PR exists", async () => {
+    const mainPath = join(REPOS_ROOT, "Soul-Brews-Studio", "maw-js");
+    hostExecHandler = (command) => {
+      if (command.includes("merge-base --is-ancestor")) throw new Error("not ancestor");
+      if (command.startsWith("gh pr list")) throw new Error("gh missing");
+      return "";
+    };
+
+    let output = await captureConsole(async () => {
+      await cleanupDoneBranch(mainPath, "feature/unverified");
+    });
+    expect(output).toContain("branch retained (feature/unverified): gh unavailable and not merged into alpha");
+    expect(hostExecCalls).not.toContain(`git -C '${mainPath}' branch -D 'feature/unverified'`);
+
+    hostExecCalls = [];
+    hostExecHandler = (command) => {
+      if (command.includes("merge-base --is-ancestor")) throw new Error("not ancestor");
+      if (command.startsWith("gh pr list")) return "[]";
+      return "";
+    };
+    output = await captureConsole(async () => {
+      await cleanupDoneBranch(mainPath, "feature/open");
+    });
+    expect(output).toContain("branch retained (feature/open): not merged into alpha and no merged PR found");
+    expect(hostExecCalls).not.toContain(`git -C '${mainPath}' branch -D 'feature/open'`);
+  });
+
+  test("--clean-branch force-deletes without proof and generic repos use main", async () => {
+    const genericPath = join(REPOS_ROOT, "acme", "tool");
+
+    const output = await captureConsole(async () => {
+      await cleanupDoneBranch(genericPath, "feature/force", { cleanBranch: true });
+    });
+
+    expect(hostExecCalls).toEqual([`git -C '${genericPath}' branch -D 'feature/force'`]);
+    expect(output).toContain("force-deleted branch feature/force");
+
+    hostExecCalls = [];
+    await captureConsole(async () => {
+      await cleanupDoneBranch(genericPath, "feature/default");
+    });
+    expect(hostExecCalls[0]).toBe(`git -C '${genericPath}' merge-base --is-ancestor 'feature/default' 'main'`);
+  });
+});
+
 describe("removeWorktreeViaConfig", () => {
   test("removes a configured worktree and deletes its non-main branch", async () => {
     writeFleetConfig("oracle.json", {
@@ -99,10 +180,11 @@ describe("removeWorktreeViaConfig", () => {
       `git -C '${fullPath}' rev-parse --abbrev-ref HEAD`,
       `git -C '${mainPath}' worktree remove '${fullPath}' --force`,
       `git -C '${mainPath}' worktree prune`,
+      `git -C '${mainPath}' merge-base --is-ancestor 'feature/done-cleanup' 'alpha'`,
       `git -C '${mainPath}' branch -d 'feature/done-cleanup'`,
     ]);
     expect(output).toContain("removed worktree Soul-Brews-Studio/maw-js.wt-123-feature");
-    expect(output).toContain("deleted branch feature/done-cleanup");
+    expect(output).toContain("deleted branch feature/done-cleanup (merged into alpha)");
   });
 
   test("uses state fleet configs before duplicate legacy configs", async () => {
@@ -169,7 +251,8 @@ describe("removeWorktreeByGhqScan", () => {
         return [exact, substringOnly, other].join("\n");
       }
       if (command.includes("rev-parse --abbrev-ref HEAD")) return "feature/done\n";
-      if (command.includes("branch -d")) throw new Error("branch still merged elsewhere");
+      if (command.includes("merge-base --is-ancestor")) throw new Error("not merged");
+      if (command.startsWith("gh pr list")) return "[]";
       return "";
     };
 
@@ -183,9 +266,11 @@ describe("removeWorktreeByGhqScan", () => {
       `git -C '${exact}' rev-parse --abbrev-ref HEAD`,
       `git -C '${mainPath}' worktree remove '${exact}' --force`,
       `git -C '${mainPath}' worktree prune`,
-      `git -C '${mainPath}' branch -d 'feature/done'`,
+      `git -C '${mainPath}' merge-base --is-ancestor 'feature/done' 'main'`,
+      "gh pr list --head 'feature/done' --state merged --json number --limit 1",
     ]);
     expect(output).toContain("removed worktree repo.wt-123-feature");
+    expect(output).toContain("branch retained (feature/done): not merged into main and no merged PR found");
     expect(output).not.toContain("repo.wt-feature-extra");
   });
 


### PR DESCRIPTION
Closes #1922

## Summary
- add `cleanupDoneBranch` safety gate for `maw done` branch cleanup
- default branch deletion now requires local ancestor proof against the repo base (`alpha` for maw-js, `main` otherwise) or a merged GitHub PR proof
- add explicit `--clean-branch` force-delete escape hatch, separate from `--force`
- wire the vendor `done` plugin CLI/API and help text through the new option

## Safety behavior
- ancestor proof: `git merge-base --is-ancestor <branch> <base>` then `git branch -d`
- squash-merge proof: `gh pr list --head <branch> --state merged` then `git branch -D`
- no proof / gh unavailable: retain the branch and report why
- protected/base branches are skipped

## Validation
- `bun test ./test/done-command.test.ts --path-ignore-patterns '**/agents/**'`
- `bun test ./test/isolated/done-worktree-coverage.test.ts --path-ignore-patterns '**/agents/**'`
- `bun test ./test/isolated/done-index-coverage.test.ts --path-ignore-patterns '**/agents/**'`
- `bun test ./test/isolated/coverage-next-vendor-b-core.test.ts --path-ignore-patterns '**/agents/**'`
- `bun run build`
- `git diff --check`

Written by [m5:mawjscodex] — an Oracle AI running gpt-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
