### PR TITLE
fix(ls): surface L2 Claude teams

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -217,6 +217,7 @@ export function parseLsAliasOpts(argv: string[]) {
     "--node": String,
     "--channels": Boolean,
     "--fleet-only": Boolean,
+    "--no-teams": Boolean,
     "--verify": Boolean,
   }, 0);
 
@@ -240,6 +241,7 @@ export function parseLsAliasOpts(argv: string[]) {
     channels?: boolean;
     fleetOnly?: boolean;
     verify?: boolean;
+    teams?: boolean;
     federation?: boolean;
   } = {
     all: true,
@@ -251,6 +253,7 @@ export function parseLsAliasOpts(argv: string[]) {
   if (flags["--channels"] || flags["--all"]) opts.channels = true;
   if (flags["--fleet-only"]) opts.fleetOnly = true;
   if (flags["--verify"]) opts.verify = true;
+  if (flags["--no-teams"]) opts.teams = false;
   if (flags["--federation"]) opts.federation = true;
   const positionals = flags._ as string[];
   const activeArg = activeDurationArg(argv);
@@ -279,7 +282,7 @@ export function parseLsAliasOpts(argv: string[]) {
 function printLsAliasUsage(write: (line: string) => void): void {
   write("usage: maw ls [filter] [--all|-a] [--verbose|-v] [--compact|-c] [--json] [--recent|-r [N]] [--active [30m|1h]]");
   write("       maw ls --federation [--node <node>] [--json]");
-  write("       maw ls --channels | --fleet-only | --verify | --fix");
+  write("       maw ls --channels | --fleet-only | --no-teams | --verify | --fix");
   write("");
   write("List live local sessions by default. Use --federation for local + peer inventory.");
   write("");
@@ -289,6 +292,7 @@ function printLsAliasUsage(write: (line: string) => void): void {
   write("  -a, --all          include sleeping roster and channel sessions");
   write("  --channels         include channel/infrastructure sessions");
   write("  --fleet-only       hide orphan/ad hoc tmux sessions (legacy compact filter)");
+  write("  --no-teams         hide L2 Claude Code teams from ~/.claude/teams");
   write("  -r, --recent [N]   sort newest-first, optionally limiting to N sessions");
   write("  --active [DUR]     show sessions touched within a duration (default from tmux helper)");
   write("  --node <node>      filter sessions by node/name");
@@ -339,7 +343,7 @@ export async function invokeDirectHandler(
     try {
       const opts = parseLsAliasOpts(argv);
       if (!opts.federation) {
-        await directCmdTmuxLs(opts);
+        await directCmdTmuxLs({ ...opts, teams: opts.teams !== false });
         return;
       }
       const result = await directLsFederated({

--- a/src/commands/plugins/tmux/impl.ts
+++ b/src/commands/plugins/tmux/impl.ts
@@ -23,6 +23,30 @@ import {
 
 const TEAMS_DIR = join(homedir(), ".claude/teams");
 
+export interface ClaudeTeamSummary {
+  name: string;
+  memberCount: number;
+  configPath: string;
+}
+
+export function loadClaudeTeams(teamsDir = TEAMS_DIR): ClaudeTeamSummary[] {
+  if (!existsSync(teamsDir)) return [];
+  const teams: ClaudeTeamSummary[] = [];
+  for (const dir of readdirSync(teamsDir).sort()) {
+    const cfg = join(teamsDir, dir, "config.json");
+    if (!existsSync(cfg)) continue;
+    try {
+      const team = JSON.parse(readFileSync(cfg, "utf-8"));
+      teams.push({
+        name: dir,
+        memberCount: Array.isArray(team.members) ? team.members.length : 0,
+        configPath: cfg,
+      });
+    } catch { /* skip bad config */ }
+  }
+  return teams;
+}
+
 async function resolvePaneTargetForKill(target: string): Promise<PaneTargetResolution> {
   const raw = await hostExec(`${tmuxCmd()} list-panes -a -F '${PANE_TARGET_FORMAT}'`).catch(() => "");
   if (!raw.trim()) return { kind: "none" };
@@ -187,6 +211,8 @@ export interface TmuxLsOpts {
   fleetOnly?: boolean;
   /** Include expensive verification/noise such as worktree-bind rows. */
   verify?: boolean;
+  /** Include L2 Claude Code teams from ~/.claude/teams in maw ls output. */
+  teams?: boolean;
 }
 
 export type PaneStatus = "frozen" | "active" | "idle" | "stale" | "unknown";
@@ -324,8 +350,9 @@ export async function cmdTmuxLs(opts: TmuxLsOpts = {}): Promise<void> {
 
   // Team members for annotation: pane_id → "agent @ team-name"
   const teamByPane = new Map<string, string>();
+  const l2Teams = opts.teams ? loadClaudeTeams() : [];
   if (existsSync(TEAMS_DIR)) {
-    for (const dir of readdirSync(TEAMS_DIR)) {
+    for (const dir of readdirSync(TEAMS_DIR).sort()) {
       const cfg = join(TEAMS_DIR, dir, "config.json");
       if (!existsSync(cfg)) continue;
       try {
@@ -379,6 +406,14 @@ export async function cmdTmuxLs(opts: TmuxLsOpts = {}): Promise<void> {
       .some(value => String(value ?? "").toLowerCase().includes(filter)));
   }
 
+  let visibleTeams = opts.teams && opts.all && !opts.fleetOnly && !opts.active
+    ? l2Teams
+    : [];
+  if (filter) {
+    visibleTeams = visibleTeams.filter(team => [team.name, team.configPath, `${team.memberCount} members`]
+      .some(value => value.toLowerCase().includes(filter)));
+  }
+
   if (opts.fleetOnly && !opts.roster && !opts.channels) {
     scope = scope.filter(p => isFleetListSession(p.session, fleetSessions));
   }
@@ -414,11 +449,25 @@ export async function cmdTmuxLs(opts: TmuxLsOpts = {}): Promise<void> {
   await markContextLimitedPanes(scope);
 
   if (opts.json) {
-    console.log(JSON.stringify(scope, null, 2));
+    const teamRows = visibleTeams.map(team => ({
+      kind: "team",
+      id: `team:${team.name}`,
+      target: `team:${team.name}`,
+      session: team.name,
+      command: "team",
+      title: `L2 team (${team.memberCount} member${team.memberCount === 1 ? "" : "s"})`,
+      annotation: `team: ${team.memberCount} member${team.memberCount === 1 ? "" : "s"}`,
+      status: "unknown",
+      lastActivitySec: 0,
+      source: "l2-team",
+      members: team.memberCount,
+      configPath: team.configPath,
+    }));
+    console.log(JSON.stringify([...scope, ...teamRows], null, 2));
     return;
   }
 
-  if (!scope.length && !(opts.compact && opts.roster)) {
+  if (!scope.length && visibleTeams.length === 0 && !(opts.compact && opts.roster)) {
     console.log(opts.active
       ? `\x1b[90mNo sessions active in the last ${formatDuration(activeThresholdSec)}.\x1b[0m`
       : opts.all
@@ -505,6 +554,11 @@ export async function cmdTmuxLs(opts: TmuxLsOpts = {}): Promise<void> {
         const label = wt.status === "orphan" ? "orphan" : wt.status === "stale" ? "stale" : "worktree";
         console.log(`    ${wtDot} \x1b[90m${wt.name}  (${label})\x1b[0m`);
       }
+    }
+
+    for (const team of visibleTeams) {
+      const memberLabel = `${team.memberCount} member${team.memberCount === 1 ? "" : "s"}`;
+      console.log(`  \x1b[90m·\x1b[0m \x1b[36m${team.name}\x1b[0m  \x1b[90m[team] L2 team (${memberLabel} in ~/.claude/teams/${team.name})\x1b[0m`);
     }
 
     if (opts.roster) {

--- a/src/vendor/mpr-plugins/ls/index.ts
+++ b/src/vendor/mpr-plugins/ls/index.ts
@@ -17,6 +17,7 @@ const HELP = [
   "  maw ls --json           emit JSON",
   "  maw ls --active [30m]   local sessions touched within a recent threshold",
   "  maw ls --fleet-only     hide orphan/ad hoc tmux sessions (legacy filter)",
+  "  maw ls --no-teams       hide L2 Claude Code teams from ~/.claude/teams",
   "  maw ls --verify         include worktree-bind diagnostics",
   "  maw ls --fix            prune orphaned worktrees (local only)",
   "",
@@ -71,6 +72,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       "--active": Boolean,
       "--node": String,
       "--fleet-only": Boolean,
+      "--no-teams": Boolean,
       "--verify": Boolean,
       "--fix": Boolean,
       "--help": Boolean,
@@ -96,6 +98,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         active: true,
         activeThresholdSec: parseActiveDurationSeconds(activeArg),
         fleetOnly: Boolean(flags["--fleet-only"]),
+        teams: !flags["--no-teams"],
       };
       if (localFilter) lsOpts.filter = localFilter;
       await cmdTmuxLs(lsOpts);
@@ -130,6 +133,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         json,
         verify: Boolean(flags["--verify"]),
         fleetOnly: Boolean(flags["--fleet-only"]),
+        teams: !flags["--no-teams"],
       };
       if (localFilter) lsOpts.filter = localFilter;
       await cmdTmuxLs(lsOpts);

--- a/src/vendor/mpr-plugins/ls/plugin.json
+++ b/src/vendor/mpr-plugins/ls/plugin.json
@@ -10,7 +10,7 @@
     "aliases": [
       "list"
     ],
-    "help": "maw ls [filter] [--all] [--json] [--fix] [--fleet-only] [--recent|-r [N]] [--active [30m|1h]] [--federation [peer]] — list local live sessions by default; use --fleet-only for the legacy fleet filter; use --federation for peers; see maw fleet ls for registered fleet config",
+    "help": "maw ls [filter] [--all] [--json] [--fix] [--fleet-only] [--no-teams] [--recent|-r [N]] [--active [30m|1h]] [--federation [peer]] — list local live sessions and L2 teams by default; use --fleet-only for the legacy fleet filter; use --no-teams for tmux-only output; use --federation for peers; see maw fleet ls for registered fleet config",
     "flags": {
       "--all": "boolean",
       "--json": "boolean",
@@ -20,6 +20,7 @@
       "--active": "boolean",
       "--node": "string",
       "--fleet-only": "boolean",
+      "--no-teams": "boolean",
       "--verify": "boolean",
       "--federation": "boolean"
     }

--- a/test/isolated/tile-ls-coverage.test.ts
+++ b/test/isolated/tile-ls-coverage.test.ts
@@ -283,6 +283,7 @@ describe("ls plugin index coverage", () => {
       activeThresholdSec: 3600,
       filter: "mawjs",
       fleetOnly: false,
+      teams: true,
     }]);
     expect(lsPeerCalls).toEqual([]);
     expect(cmdListCalls).toEqual([]);

--- a/test/isolated/tmux-impl-third-pass-coverage.test.ts
+++ b/test/isolated/tmux-impl-third-pass-coverage.test.ts
@@ -203,6 +203,40 @@ describe("tmux impl third-pass branch coverage", () => {
     expect(compactRoster).not.toContain("sleepy-oracle");
   });
 
+  test("cmdTmuxLs surfaces L2 teams as compact and JSON rows when requested", async () => {
+    existingPaths.add(teamsRoot);
+    dirEntries.set(teamsRoot, ["alpha", "bad"]);
+    const alphaCfg = `${teamsRoot}/alpha/config.json`;
+    const badCfg = `${teamsRoot}/bad/config.json`;
+    existingPaths.add(alphaCfg);
+    existingPaths.add(badCfg);
+    fileContents.set(alphaCfg, JSON.stringify({ members: [{ name: "scout" }, { name: "builder" }, { name: "critic" }] }));
+    fileContents.set(badCfg, "{not json");
+    panes = [];
+
+    const compact = await capture(() => cmdTmuxLs({ all: true, compact: true, teams: true }));
+    expect(compact).toContain("alpha");
+    expect(compact).toContain("[team] L2 team (3 members in ~/.claude/teams/alpha)");
+    expect(compact).not.toContain("No panes found");
+    expect(compact).not.toContain("bad");
+
+    const json = await capture(() => cmdTmuxLs({ all: true, json: true, teams: true }));
+    expect(JSON.parse(json)).toMatchObject([
+      {
+        kind: "team",
+        target: "team:alpha",
+        session: "alpha",
+        annotation: "team: 3 members",
+        source: "l2-team",
+        members: 3,
+      },
+    ]);
+
+    const hidden = await capture(() => cmdTmuxLs({ all: true, compact: true, teams: false }));
+    expect(hidden).toContain("No panes found");
+    expect(hidden).not.toContain("[team]");
+  });
+
   test("cmdTmuxLs filters to current session when inside tmux and split defaults to horizontal 50% without command", async () => {
     process.env.TMUX = "/tmp/tmux,1,0";
     panes = [

--- a/test/isolated/top-aliases-runtime-coverage.test.ts
+++ b/test/isolated/top-aliases-runtime-coverage.test.ts
@@ -211,6 +211,7 @@ describe("direct handler invocation", () => {
       verbose: false,
       roster: false,
       json: false,
+      teams: true,
     }]);
     expect(lsFederatedCalls).toEqual([]);
   });
@@ -227,6 +228,7 @@ describe("direct handler invocation", () => {
       recentLimit: 5,
       active: true,
       activeThresholdSec: 2700,
+      teams: true,
     }]);
     expect(lsFederatedCalls).toEqual([]);
   });

--- a/test/top-aliases-default.test.ts
+++ b/test/top-aliases-default.test.ts
@@ -156,6 +156,14 @@ describe("top alias option parsers", () => {
       json: false,
       fleetOnly: true,
     });
+    expect(parseLsAliasOpts(["--no-teams"])).toEqual({
+      all: true,
+      compact: true,
+      verbose: false,
+      roster: false,
+      json: false,
+      teams: false,
+    });
   });
 
   test("bring opts default to split, parse #1816 flags, and reject missing oracle", () => {
@@ -196,6 +204,7 @@ describe("direct handler invocation", () => {
       recentLimit: 5,
       active: true,
       activeThresholdSec: 3600,
+      teams: true,
     }]);
   });
 
@@ -208,6 +217,7 @@ describe("direct handler invocation", () => {
     expect(calls.logs.join("\n")).toContain("usage: maw ls");
     expect(calls.logs.join("\n")).toContain("--active");
     expect(calls.logs.join("\n")).toContain("--fleet-only");
+    expect(calls.logs.join("\n")).toContain("--no-teams");
   });
 
   test("cmdLs missing --node value prints friendly usage instead of ArgError", async () => {


### PR DESCRIPTION
Closes #1923

## Summary
- make top-level `maw ls` include L2 Claude Code teams from `~/.claude/teams/*/config.json` by default
- render compact team rows as `[team] L2 team (<N> members in ~/.claude/teams/<name>)`
- include team pseudo-rows in `maw ls --json` with `kind: "team"` and `source: "l2-team"`
- add `--no-teams` for tmux-only/script-safe output
- keep existing live-pane team annotations intact

## Notes
- This is the tactical #1923 visibility fix only; it does not attempt the broader #1921 registry consolidation.
- I did not add a separate `maw teams ls` verb in this patch.

## Validation
- `bun test ./test/isolated/tmux-impl-third-pass-coverage.test.ts --path-ignore-patterns '**/agents/**'`
- `MAW_TEST_MODE=1 bun test ./test/top-aliases-default.test.ts ./test/cli/dispatch-match.test.ts --path-ignore-patterns '**/agents/**'`
- `bun test ./test/isolated/top-aliases-runtime-coverage.test.ts --path-ignore-patterns '**/agents/**'`
- `bun test ./test/isolated/tile-ls-coverage.test.ts --path-ignore-patterns '**/agents/**'`
- `bun test ./test/tmux-index-default.test.ts --path-ignore-patterns '**/agents/**'`
- `bun run build`
- `git diff --check`

Written by [m5:mawjscodex] — an Oracle AI running gpt-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
