### PR TITLE
feat(spawn): propagate parent session identity

### DIFF
--- a/src/cli/cmd-new.ts
+++ b/src/cli/cmd-new.ts
@@ -19,6 +19,7 @@ import { UserError } from "../core/util/user-error";
 import { tmux } from "../sdk";
 import { attachToSession } from "../commands/shared/wake-session";
 import { ensureFleetSessionEntry } from "../commands/shared/fleet-ensure";
+import { prefixCommandWithSpawnSessionEnv } from "../core/fleet/parent-session";
 
 /** Truthy env values: "1", "true", "yes", "on" (case-insensitive). */
 export function isTruthyEnv(v: string | undefined): boolean {
@@ -88,6 +89,8 @@ function printUsage(write: (line: string) => void = console.log): void {
   write("  --json       Alias for --print.");
   write("  --dry-run    Show what WOULD happen without creating any tmux state. (#1913)");
   write("  --no-fleet   Do not auto-register the created session in the fleet registry.");
+  write("  --parent-session-id <id>  Set MAW_PARENT_SESSION_ID for spawned Claude commands (#1925).");
+  write("  --session-id <id>         Set deterministic MAW_SESSION_ID for spawned Claude commands (#1925).");
   write("  Then bring oracles in with: maw team bring <team> [--session <session>]");
   write("  Oracle creation remains: maw awaken <name> (or maw bud <name>).");
 }
@@ -237,6 +240,9 @@ export async function cmdNew(argv: string[]): Promise<void> {
     "--json": Boolean,
     "--dry-run": Boolean,
     "--no-fleet": Boolean,
+    "--parent": String,
+    "--parent-session-id": String,
+    "--session-id": String,
   }, 0);
 
   const explicitName = (flags._ as string[])[0];
@@ -255,7 +261,11 @@ export async function cmdNew(argv: string[]): Promise<void> {
   }
   const commandNameHint = explicitName ?? (slugSegment(basename(cwd)) || "workspace");
   const startupCommand = flags["--claude"]
-    ? buildClaudeStartupCommand(commandNameHint, cwd)
+    ? prefixCommandWithSpawnSessionEnv(buildClaudeStartupCommand(commandNameHint, cwd), {
+        explicit: (flags["--parent-session-id"] as string | undefined) || (flags["--parent"] as string | undefined),
+        sessionId: flags["--session-id"] as string | undefined,
+        cwd,
+      })
     : normalizeStartupCommand(flags["--cmd"]);
   const autoNameCommand = flags["--claude"] ? "claude" : startupCommand;
   let name = explicitName ?? autoWorkspaceSessionName(cwd, autoNameCommand, flags["--path"] !== undefined);

--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -166,7 +166,7 @@ function printBringUsage(write: (line: string) => void = console.log): void {
 }
 
 function printWakeAliasUsage(verb: "wake" | "awake", write: (line: string) => void = console.log): void {
-  write(`usage: maw ${verb} <oracle> [--session <tmux-session>] [--task <s>] [--wt <s>] [--layout nested|legacy] [--bud] [--signal-on-birth] [-p|--prompt <s>] [--incubate <slug>] [--fresh|--new] [--pick] [--name <s>] [-a|--attach] [--list] [--dry-run] [--from-snapshot|--snapshot <id>] [--main|--solo|--no-rehydrate] [--no-fleet] [--split] [--all-local] [-e|--engine <name>]`);
+  write(`usage: maw ${verb} <oracle> [--session <tmux-session>] [--task <s>] [--wt <s>] [--layout nested|legacy] [--bud] [--signal-on-birth] [-p|--prompt <s>] [--incubate <slug>] [--fresh|--new] [--pick] [--name <s>] [-a|--attach] [--list] [--dry-run] [--from-snapshot|--snapshot <id>] [--main|--solo|--no-rehydrate] [--no-fleet] [--split] [--parent-session-id <id>] [--session-id <id>] [--all-local] [-e|--engine <name>]`);
   if (verb === "awake") {
     write("  Launch/start an oracle process with the selected engine. Does not send /awaken.");
     write("  Use `maw awaken` for the awakening ritual; use `maw new` for a plain workspace session.");
@@ -181,6 +181,7 @@ function printWakeAliasUsage(verb: "wake" | "awake", write: (line: string) => vo
   write("  --from-snapshot restores missing windows from the latest recovery snapshot; --snapshot <id> selects one.");
   write("  --bud with --task/--wt writes ψ/.lineage.yaml in the worktree (no repo/fleet mutation).");
   write("  --signal-on-birth with --bud also drops a parent ψ/memory/signals birth signal.");
+  write("  --parent-session-id/--parent sets MAW_PARENT_SESSION_ID for spawned agents; --session-id sets MAW_SESSION_ID (#1925).");
 }
 
 /**
@@ -432,6 +433,9 @@ export async function invokeDirectHandler(
       "--bring-alias": Boolean,
       "--all-local": Boolean,
       "--engine": String, "-e": "--engine",
+      "--parent": String,
+      "--parent-session-id": String,
+      "--session-id": String,
     }, 0);
 
     const positional = flags._;
@@ -462,6 +466,8 @@ export async function invokeDirectHandler(
       signalOnBirth?: boolean;
       allLocal?: boolean;
       engine?: string;
+      parentSessionId?: string;
+      sessionId?: string;
       fromSnapshot?: boolean;
       snapshotId?: string;
       layout?: "nested" | "legacy";
@@ -496,6 +502,10 @@ export async function invokeDirectHandler(
     if (flags["--bring-alias"]) opts.bringAlias = true;
     if (flags["--all-local"]) opts.allLocal = true;
     if (flags["--engine"]) opts.engine = flags["--engine"];
+    if (flags["--parent-session-id"] || flags["--parent"]) {
+      opts.parentSessionId = (flags["--parent-session-id"] as string | undefined) || (flags["--parent"] as string | undefined);
+    }
+    if (flags["--session-id"]) opts.sessionId = flags["--session-id"] as string;
 
     // Shorthand: --codex, --gemini etc. → engine from config.commands
     // Unknown flags land in flags._ (permissive mode), so scan for --<engine>

--- a/src/commands/plugins/swarm/index.ts
+++ b/src/commands/plugins/swarm/index.ts
@@ -33,10 +33,13 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       "--tiled": Boolean,
       "--count": Number,
       "--help": Boolean, "-h": "--help",
+      "--parent": String,
+      "--parent-session-id": String,
+      "--session-id": String,
     }, 0);
 
     if (flags["--help"]) {
-      console.log("usage: maw swarm [agents...] [--tiled] [--count N]");
+      console.log("usage: maw swarm [agents...] [--tiled] [--count N] [--parent-session-id <id>] [--session-id <id>]");
       console.log("");
       console.log("  maw swarm                         3 claude agents (default)");
       console.log("  maw swarm claude codex opencode    one of each");
@@ -72,6 +75,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     const { existsSync, readFileSync, writeFileSync, mkdirSync } = await import("fs");
     const { join } = await import("path");
     const { homedir } = await import("os");
+    const { prefixCommandWithSpawnSessionEnv } = await import("../../../core/fleet/parent-session");
 
     const anchor = process.env.TMUX_PANE ?? "";
     const teamName = "swarm";
@@ -132,7 +136,11 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     for (const agent of spawned) {
       await stylePaneBorder(agent.paneId, `${agent.name} (${agent.label})`, agent.color);
 
-      const escaped = agent.agentCmd.replace(/'/g, "'\\''");
+      const commandWithEnv = prefixCommandWithSpawnSessionEnv(agent.agentCmd, {
+        explicit: (flags["--parent-session-id"] as string | undefined) || (flags["--parent"] as string | undefined),
+        sessionId: agentList.length === 1 ? flags["--session-id"] as string | undefined : undefined,
+      });
+      const escaped = commandWithEnv.replace(/'/g, "'\\''");
       await hostExec(
         `tmux send-keys -t '${agent.paneId}' '${escaped}; printf "\\e[?1049l"; clear; exec zsh -li' Enter`,
       );

--- a/src/commands/plugins/team/index.ts
+++ b/src/commands/plugins/team/index.ts
@@ -81,7 +81,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       cmdTeamCreate(args[1], { description });
     } else if (sub === "spawn") {
       if (!args[1] || !args[2]) {
-        logs.push("usage: maw team spawn <team> <role> [--model <model>] [--cwd <path>] [--worktree <path>] [--prompt <text>] [--exec]");
+        logs.push("usage: maw team spawn <team> <role> [--model <model>] [--cwd <path>] [--worktree <path>] [--prompt <text>] [--parent-session-id <id>] [--session-id <id>] [--exec]");
         return { ok: false, error: "team and role required", output: logs.join("\n") };
       }
       const modelIdx = args.indexOf("--model");
@@ -89,6 +89,10 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       const cwdIdx = args.indexOf("--cwd");
       const worktreeIdx = args.indexOf("--worktree");
       const cwd = cwdIdx !== -1 ? args[cwdIdx + 1] : (worktreeIdx !== -1 ? args[worktreeIdx + 1] : undefined);
+      const parentIdx = args.indexOf("--parent-session-id") !== -1 ? args.indexOf("--parent-session-id") : args.indexOf("--parent");
+      const parentSessionId = parentIdx !== -1 ? args[parentIdx + 1] : undefined;
+      const sessionIdx = args.indexOf("--session-id");
+      const sessionId = sessionIdx !== -1 ? args[sessionIdx + 1] : undefined;
       const promptIdx = args.indexOf("--prompt");
       const exec = args.includes("--exec");
       // --prompt is greedy to end-of-argv; strip --exec if it appears in the tail
@@ -99,7 +103,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         for (let i = 0; i < rawTail.length; i++) {
           const a = rawTail[i];
           if (a === "--exec") continue;
-          if (a === "--model" || a === "--cwd" || a === "--worktree") {
+          if (a === "--model" || a === "--cwd" || a === "--worktree" || a === "--parent" || a === "--parent-session-id" || a === "--session-id") {
             i++;
             continue;
           }
@@ -107,7 +111,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         }
         prompt = tail.join(" ") || undefined;
       }
-      await cmdTeamSpawn(args[1], args[2], { model, prompt, exec, cwd });
+      await cmdTeamSpawn(args[1], args[2], { model, prompt, exec, cwd, parentSessionId, sessionId });
     } else if (sub === "send" || sub === "msg") {
       if (!args[1] || !args[2] || !args[3]) {
         logs.push("usage: maw team send <team> <agent> <message>");

--- a/src/commands/plugins/team/team-lifecycle.ts
+++ b/src/commands/plugins/team/team-lifecycle.ts
@@ -3,6 +3,7 @@ import { createHash } from "crypto";
 import { join } from "path";
 import { tmux } from "../../../sdk";
 import { assertValidOracleName } from "../../../core/fleet/validate";
+import { prefixCommandWithSpawnSessionEnv } from "../../../core/fleet/parent-session";
 import { TEAMS_DIR, loadTeam, resolvePsi, writeShutdownRequest, cleanupTeamDir, type TeamConfig, type TeamMember } from "./team-helpers";
 
 const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
@@ -203,7 +204,7 @@ export function cmdTeamCreate(name: string, opts: { description?: string } = {})
 export async function cmdTeamSpawn(
   teamName: string,
   role: string,
-  opts: { model?: string; prompt?: string; exec?: boolean; cwd?: string } = {},
+  opts: { model?: string; prompt?: string; exec?: boolean; cwd?: string; parentSessionId?: string; sessionId?: string } = {},
 ) {
   const PSI = resolvePsi();
   const teamDir = join(PSI, "memory", "mailbox", "teams", teamName);
@@ -254,7 +255,11 @@ export async function cmdTeamSpawn(
   const promptPath = join(teamDir, `${role}-spawn-prompt.md`);
   writeFileSync(promptPath, spawnPrompt);
   const launchPromptPath = writeLaunchPromptFile(teamName, role, spawnPrompt) ?? promptPath;
-  const claudeCmd = `${cwdPrefix}claude --model ${model} --system-prompt-file ${shellQuote(launchPromptPath)}`;
+  const claudeCmd = `${cwdPrefix}${prefixCommandWithSpawnSessionEnv(`claude --model ${model} --system-prompt-file ${shellQuote(launchPromptPath)}`, {
+    explicit: opts.parentSessionId,
+    sessionId: opts.sessionId,
+    cwd: opts.cwd,
+  })}`;
 
   // Update manifest with new member
   const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));

--- a/src/commands/plugins/tile/impl.ts
+++ b/src/commands/plugins/tile/impl.ts
@@ -5,6 +5,7 @@ import {
 import { hostExec } from "../../../sdk";
 import { withPaneLock } from "../../../core/transport/tmux-pane-lock";
 import { worktreePathForLayout, type WorktreeLayout } from "../../../core/fleet/worktree-layout";
+import { spawnSessionEnv } from "../../../core/fleet/parent-session";
 
 function shellArg(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
@@ -116,6 +117,8 @@ export interface TileOpts {
   shell?: boolean;
   engine?: string;
   layout?: WorktreeLayout;
+  parentSessionId?: string;
+  sessionId?: string;
 }
 
 function expandHome(raw: string): string {
@@ -266,6 +269,11 @@ export async function cmdTile(count: number, opts: TileOpts = {}): Promise<void>
       MAW_TILE_INDEX: String(tileIndex),
       MAW_TILE_TOTAL: String(finalTileTotal),
       MAW_TILE_WINDOW: windowAddress,
+      ...spawnSessionEnv({
+        explicit: opts.parentSessionId,
+        sessionId: count === 1 ? opts.sessionId : undefined,
+        cwd,
+      }),
     });
 
     const launchCmd = requestedCmd || engineCmd;

--- a/src/commands/plugins/tile/index.ts
+++ b/src/commands/plugins/tile/index.ts
@@ -55,10 +55,13 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       "--shell": Boolean,
       "--engine": String, "-e": "--engine",
       "--layout": String,
+      "--parent": String,
+      "--parent-session-id": String,
+      "--session-id": String,
     }, 0);
 
     if (flags["--help"]) {
-      console.log("usage: maw tile [N] [--wt <name>] [--layout nested|legacy] [--path <dir>] [--cmd <cmd>] [--shell] [--engine <name>]");
+      console.log("usage: maw tile [N] [--wt <name>] [--layout nested|legacy] [--path <dir>] [--cmd <cmd>] [--shell] [--engine <name>] [--parent-session-id <id>] [--session-id <id>]");
       console.log("       maw tile clean");
       console.log("       maw tile swap <a> <b>");
       console.log("");
@@ -118,6 +121,8 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       shell: !!flags["--shell"],
       engine: flags["--engine"] as string | undefined,
       layout: layout as "nested" | "legacy" | undefined,
+      parentSessionId: (flags["--parent-session-id"] as string | undefined) || (flags["--parent"] as string | undefined),
+      sessionId: count === 1 ? flags["--session-id"] as string | undefined : undefined,
     });
     return { ok: true, output: logs.join("\n") || undefined };
   } catch (e: any) {

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -4,6 +4,7 @@ import { ghqFind } from "../../core/ghq";
 import { buildCommandInDir, cfgTimeout, loadConfig, saveConfig } from "../../config";
 import { resolveWorktreeTarget } from "../../core/matcher/resolve-target";
 import { normalizeWorktreeLayout, type WorktreeLayout } from "../../core/fleet/worktree-layout";
+import { prefixCommandWithSpawnSessionEnv } from "../../core/fleet/parent-session";
 import { normalizeTarget } from "../../core/matcher/normalize-target";
 import { assertValidOracleName } from "../../core/fleet/validate";
 import { canonicalSessionName } from "../../core/fleet/session-name";
@@ -352,6 +353,10 @@ export interface WakeOptions {
   urlRepoName?: string;
   allLocal?: boolean;
   engine?: string;
+  /** Parent session to expose to newly spawned agents (#1925). */
+  parentSessionId?: string;
+  /** Deterministic child session id to expose to newly spawned agents (#1925). */
+  sessionId?: string;
   fromSnapshot?: boolean;
   snapshotId?: string;
   /** Filesystem layout for newly-created worktrees (#1850): default nested, legacy sibling via --layout legacy. */
@@ -382,6 +387,13 @@ function isAttachOnlyWake(opts: WakeOptions): boolean {
     && !opts.snapshotId;
 }
 
+function buildWakeCommand(windowName: string, cwd: string, opts: Pick<WakeOptions, "engine" | "parentSessionId" | "sessionId">): string {
+  return prefixCommandWithSpawnSessionEnv(
+    buildCommandInDir(windowName, cwd, opts.engine),
+    { explicit: opts.parentSessionId, sessionId: opts.sessionId, cwd },
+  );
+}
+
 function loadRequestedSnapshot(snapshotId?: string): Snapshot | null {
   return snapshotId ? loadSnapshot(snapshotId) : latestSnapshot();
 }
@@ -399,7 +411,7 @@ async function restoreSnapshotWindows(
   for (const win of planned) {
     await tmux.newWindow(session, win.windowName, { cwd: win.cwd });
     await new Promise(r => setTimeout(r, 300));
-    await tmux.sendText(`${session}:${win.windowName}`, buildCommandInDir(win.windowName, win.cwd, engine));
+    await tmux.sendText(`${session}:${win.windowName}`, buildWakeCommand(win.windowName, win.cwd, { engine }));
     existingWindows.add(win.windowName);
     const label = win.source === "worktree" ? "worktree" : "repo";
     console.log(`\x1b[36m↻\x1b[0m snapshot window: ${win.windowName}  \x1b[90m${label}: ${win.cwd}\x1b[0m`);
@@ -942,7 +954,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
     });
     await new Promise(r => setTimeout(r, 300));
     await retryFreshSessionTmuxStep(session, "launch main window", () =>
-      tmux.sendText(`${session}:${mainWindowName}`, buildCommandInDir(mainWindowName, repoPath, opts.engine))
+      tmux.sendText(`${session}:${mainWindowName}`, buildWakeCommand(mainWindowName, repoPath, opts))
     , {
       hasSession: tmux.hasSession,
     });
@@ -987,7 +999,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
       for (const wt of planRehydrateWorktreeWindows(oracle, allWt, [...existingWindows])) {
         await tmux.newWindow(session, wt.windowName, { cwd: wt.path });
         await new Promise(r => setTimeout(r, 300));
-        await tmux.sendText(`${session}:${wt.windowName}`, buildCommandInDir(wt.windowName, wt.path, opts.engine));
+        await tmux.sendText(`${session}:${wt.windowName}`, buildWakeCommand(wt.windowName, wt.path, opts));
         await wakeSession.waitForEngine(`${session}:${wt.windowName}`, getPaneInfos, isAgentCommand);
         existingWindows.add(wt.windowName);
         console.log(`\x1b[32m+\x1b[0m window: ${wt.windowName}`);
@@ -1018,7 +1030,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
         for (const wt of planRehydrateWorktreeWindows(oracle, allWt, existingWindows, liveTileRoles)) {
           await tmux.newWindow(session, wt.windowName, { cwd: wt.path });
           await new Promise(r => setTimeout(r, 300));
-          await tmux.sendText(`${session}:${wt.windowName}`, buildCommandInDir(wt.windowName, wt.path, opts.engine));
+          await tmux.sendText(`${session}:${wt.windowName}`, buildWakeCommand(wt.windowName, wt.path, opts));
           preExistingWindows.add(wt.windowName);
           console.log(`\x1b[32m↻\x1b[0m respawned: ${wt.windowName}`);
         }
@@ -1138,7 +1150,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
       if (opts.prompt) {
         await tmux.selectWindow(target);
         const escaped = opts.prompt.replace(/'/g, "'\\''");
-        const promptCommand = `${buildCommandInDir(existingWindow, targetPath, opts.engine)} -p '${escaped}'`;
+        const promptCommand = `${buildWakeCommand(existingWindow, targetPath, opts)} -p '${escaped}'`;
         if (opts.engine) {
           if (!(await respawnPaneWithCommand(target, promptCommand))) {
             await tmux.sendText(target, promptCommand);
@@ -1159,7 +1171,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
 
       if (!agentAlive) {
         console.log(`\x1b[33m⚡\x1b[0m '${existingWindow}' in ${session} — agent dead, re-launching...`);
-        await tmux.sendText(target, buildCommandInDir(existingWindow, targetPath, opts.engine));
+        await tmux.sendText(target, buildWakeCommand(existingWindow, targetPath, opts));
         await wakeSession.waitForEngine(target, getPaneInfos, isAgentCommand);
         if (opts.attach) {
           await tmux.selectWindow(target);
@@ -1173,7 +1185,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
 
       if (opts.engine) {
         console.log(`\x1b[33m⚡\x1b[0m '${existingWindow}' in ${session} — switching engine to ${opts.engine}...`);
-        const command = buildCommandInDir(existingWindow, targetPath, opts.engine);
+        const command = buildWakeCommand(existingWindow, targetPath, opts);
         if (!(await respawnPaneWithCommand(target, command))) {
           await tmux.sendText(target, command);
         }
@@ -1220,7 +1232,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
 
   await tmux.newWindow(session, windowName, { cwd: targetPath });
   await new Promise(r => setTimeout(r, 300));
-  const cmd = buildCommandInDir(windowName, targetPath, opts.engine);
+  const cmd = buildWakeCommand(windowName, targetPath, opts);
   if (opts.prompt) {
     const escaped = opts.prompt.replace(/'/g, "'\\''");
     await tmux.sendText(`${session}:${windowName}`, `${cmd} -p '${escaped}'`);

--- a/src/core/fleet/parent-session.ts
+++ b/src/core/fleet/parent-session.ts
@@ -1,0 +1,78 @@
+import { existsSync, readdirSync, statSync } from "fs";
+import { homedir } from "os";
+import { resolve, join } from "path";
+
+export interface ResolveParentSessionIdInput {
+  explicit?: string;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface SpawnSessionEnvInput extends ResolveParentSessionIdInput {
+  sessionId?: string;
+}
+
+function cleanSessionId(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function claudeProjectDirForCwd(cwd: string, env: NodeJS.ProcessEnv): string {
+  const projectsRoot = env.MAW_CLAUDE_PROJECTS_DIR || join(homedir(), ".claude", "projects");
+  const encoded = resolve(cwd).replace(/^\//, "-").replace(/\//g, "-");
+  return join(projectsRoot, encoded);
+}
+
+function newestClaudeJsonlSessionId(cwd: string, env: NodeJS.ProcessEnv): string | undefined {
+  const dir = claudeProjectDirForCwd(cwd, env);
+  let newest: { id: string; mtimeMs: number } | undefined;
+  try {
+    for (const entry of readdirSync(dir)) {
+      if (!entry.endsWith(".jsonl") || entry.includes("subagents")) continue;
+      const path = join(dir, entry);
+      let st: ReturnType<typeof statSync>;
+      try { st = statSync(path); } catch { continue; }
+      if (!newest || st.mtimeMs > newest.mtimeMs) {
+        newest = { id: entry.slice(0, -".jsonl".length), mtimeMs: st.mtimeMs };
+      }
+    }
+  } catch {
+    return undefined;
+  }
+  return newest?.id;
+}
+
+export function resolveParentSessionId(input: ResolveParentSessionIdInput = {}): string | undefined {
+  const env = input.env ?? process.env;
+  return cleanSessionId(input.explicit)
+    || cleanSessionId(env.MAW_PARENT_SESSION_ID)
+    || cleanSessionId(env.CLAUDE_SESSION_ID)
+    || newestClaudeJsonlSessionId(input.cwd ?? process.cwd(), env);
+}
+
+export function spawnSessionEnv(input: SpawnSessionEnvInput = {}): Record<string, string> {
+  const env: Record<string, string> = {};
+  const parent = resolveParentSessionId(input);
+  const sessionId = cleanSessionId(input.sessionId);
+  if (parent) env.MAW_PARENT_SESSION_ID = parent;
+  if (sessionId) env.MAW_SESSION_ID = sessionId;
+  return env;
+}
+
+export function shellQuoteEnv(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+export function prefixCommandWithSpawnSessionEnv(
+  command: string,
+  input: SpawnSessionEnvInput = {},
+): string {
+  const env = spawnSessionEnv(input);
+  const prefix = Object.entries(env).map(([key, value]) => `${key}=${shellQuoteEnv(value)}`).join(" ");
+  return prefix ? `${prefix} ${command}` : command;
+}
+
+export function hasClaudeSessionForCwd(cwd: string, env: NodeJS.ProcessEnv = process.env): boolean {
+  return existsSync(claudeProjectDirForCwd(cwd, env));
+}

--- a/src/vendor/mpr-plugins/awaken/index.ts
+++ b/src/vendor/mpr-plugins/awaken/index.ts
@@ -50,6 +50,9 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
           "--force": Boolean,
           "--track-vault": Boolean,
           "--sync-peers": Boolean,
+          "--parent": String,
+          "--parent-session-id": String,
+          "--session-id": String,
           "--yes": Boolean,
           "-y": "--yes",
         },
@@ -84,6 +87,8 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         blank: flags["--blank"],
         signalOnBirth: flags["--signal-on-birth"],
         yes: flags["--yes"],
+        parentSessionId: (flags["--parent-session-id"] as string | undefined) || (flags["--parent"] as string | undefined),
+        sessionId: flags["--session-id"],
       });
     } else if (ctx.source === "api") {
       const body = ctx.args as Record<string, unknown>;
@@ -105,6 +110,8 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         seed: body.seed as boolean | undefined,
         blank: body.blank as boolean | undefined,
         signalOnBirth: body.signalOnBirth as boolean | undefined,
+        parentSessionId: (body.parentSessionId as string | undefined) || (body.parent as string | undefined),
+        sessionId: body.sessionId as string | undefined,
         // API/HTTP path has no TTY by definition, but pass through for parity.
         yes: (body.yes as boolean | undefined) ?? true,
       });

--- a/src/vendor/mpr-plugins/bud/bud-wake.ts
+++ b/src/vendor/mpr-plugins/bud/bud-wake.ts
@@ -23,6 +23,8 @@ export interface BudFinalizeCtx {
     repo?: string;
     split?: boolean;
     fast?: boolean;
+    parentSessionId?: string;
+    sessionId?: string;
   };
 }
 
@@ -143,6 +145,8 @@ export async function finalizeBud(ctx: BudFinalizeCtx): Promise<void> {
   // #421 — pass the exact cloned path so wake doesn't re-resolve via ghqFind,
   // which would match any same-named repo in any org (stale-clone bug).
   const wakeOpts: any = { noAttach: true, repoPath: budRepoPath };
+  if (opts.parentSessionId) wakeOpts.parentSessionId = opts.parentSessionId;
+  if (opts.sessionId) wakeOpts.sessionId = opts.sessionId;
   if (opts.issue) {
     const { fetchIssuePrompt } = await import("maw-js/commands/shared/wake");
     const issueRepo = await resolveIssueRepoForBud(ctx);

--- a/src/vendor/mpr-plugins/bud/impl.ts
+++ b/src/vendor/mpr-plugins/bud/impl.ts
@@ -36,6 +36,10 @@ export interface BudOpts {
   nickname?: string;
   /** Create repo + local oracle skeleton only; stop before commit/push/wake/parent mutation. */
   scaffoldOnly?: boolean;
+  /** Parent session id to expose to the spawned bud's wake command (#1925). */
+  parentSessionId?: string;
+  /** Deterministic child session id to expose to the spawned bud's wake command (#1925). */
+  sessionId?: string;
 }
 
 function oracleStemFromMaybeWorktreePath(path: string): string {
@@ -225,7 +229,16 @@ export async function cmdBud(name: string, opts: BudOpts = {}) {
   // 5-8.5. Soul-sync, commit, sync peers, wake, split, copy
   await finalizeBud({
     name, parentName, org, budRepoName, budRepoPath, psiDir, fleetFile,
-    opts: { seed: opts.seed, issue: opts.issue, issueRepo: opts.issueRepo, repo: opts.repo, split: opts.split, fast: opts.fast },
+    opts: {
+      seed: opts.seed,
+      issue: opts.issue,
+      issueRepo: opts.issueRepo,
+      repo: opts.repo,
+      split: opts.split,
+      fast: opts.fast,
+      parentSessionId: opts.parentSessionId,
+      sessionId: opts.sessionId,
+    },
   });
 
   // Optional: drop birth signal into parent's ψ/

--- a/src/vendor/mpr-plugins/bud/index.ts
+++ b/src/vendor/mpr-plugins/bud/index.ts
@@ -45,6 +45,9 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         "--force": Boolean,
         "--track-vault": Boolean,
         "--sync-peers": Boolean,
+        "--parent": String,
+        "--parent-session-id": String,
+        "--session-id": String,
       }, 0);
 
       // --from-repo branches early: inject scaffolding into an existing repo (#588).
@@ -97,6 +100,8 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         seed: flags["--seed"],
         blank: flags["--blank"],
         signalOnBirth: flags["--signal-on-birth"],
+        parentSessionId: (flags["--parent-session-id"] as string | undefined) || (flags["--parent"] as string | undefined),
+        sessionId: flags["--session-id"],
       });
     } else if (ctx.source === "api") {
       const body = ctx.args as Record<string, unknown>;
@@ -118,6 +123,8 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         seed: body.seed as boolean | undefined,
         blank: body.blank as boolean | undefined,
         signalOnBirth: body.signalOnBirth as boolean | undefined,
+        parentSessionId: (body.parentSessionId as string | undefined) || (body.parent as string | undefined),
+        sessionId: body.sessionId as string | undefined,
       });
     }
 

--- a/src/vendor/mpr-plugins/team/index.ts
+++ b/src/vendor/mpr-plugins/team/index.ts
@@ -120,7 +120,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       logs.push(formatTeamCharterSpawn(result));
     } else if (sub === "spawn") {
       if (!args[1] || !args[2]) {
-        logs.push("usage: maw team spawn <team> <role> [--model <model>] [--cwd <path>] [--worktree <path>] [--prompt <text>] [--exec]");
+        logs.push("usage: maw team spawn <team> <role> [--model <model>] [--cwd <path>] [--worktree <path>] [--prompt <text>] [--parent-session-id <id>] [--session-id <id>] [--exec]");
         return { ok: false, error: "team and role required", output: logs.join("\n") };
       }
       const modelIdx = args.indexOf("--model");
@@ -128,6 +128,10 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       const cwdIdx = args.indexOf("--cwd");
       const worktreeIdx = args.indexOf("--worktree");
       const cwd = cwdIdx !== -1 ? args[cwdIdx + 1] : (worktreeIdx !== -1 ? args[worktreeIdx + 1] : undefined);
+      const parentIdx = args.indexOf("--parent-session-id") !== -1 ? args.indexOf("--parent-session-id") : args.indexOf("--parent");
+      const parentSessionId = parentIdx !== -1 ? args[parentIdx + 1] : undefined;
+      const sessionIdx = args.indexOf("--session-id");
+      const sessionId = sessionIdx !== -1 ? args[sessionIdx + 1] : undefined;
       const promptIdx = args.indexOf("--prompt");
       const exec = args.includes("--exec");
       // --prompt is greedy to end-of-argv; strip known flags if they appear in the tail.
@@ -138,7 +142,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         for (let i = 0; i < rawTail.length; i++) {
           const a = rawTail[i];
           if (a === "--exec") continue;
-          if (a === "--model" || a === "--cwd" || a === "--worktree") {
+          if (a === "--model" || a === "--cwd" || a === "--worktree" || a === "--parent" || a === "--parent-session-id" || a === "--session-id") {
             i++;
             continue;
           }
@@ -146,7 +150,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         }
         prompt = tail.join(" ") || undefined;
       }
-      await cmdTeamSpawn(args[1], args[2], { model, prompt, exec, cwd });
+      await cmdTeamSpawn(args[1], args[2], { model, prompt, exec, cwd, parentSessionId, sessionId });
     } else if (sub === "send" || sub === "msg") {
       if (!args[1] || !args[2]) {
         logs.push("usage: maw team send <team> <message>");

--- a/src/vendor/mpr-plugins/team/team-lifecycle.ts
+++ b/src/vendor/mpr-plugins/team/team-lifecycle.ts
@@ -3,6 +3,7 @@ import { createHash } from "crypto";
 import { join } from "path";
 import { tmux } from "maw-js/sdk";
 import { assertValidOracleName } from "maw-js/core/fleet/validate";
+import { prefixCommandWithSpawnSessionEnv } from "../../../core/fleet/parent-session";
 import { TEAMS_DIR, loadTeam, resolvePsi, writeShutdownRequest, cleanupTeamDir, currentLeadSessionId, type TeamConfig, type TeamMember } from "./team-helpers";
 
 const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
@@ -194,7 +195,7 @@ export function cmdTeamCreate(name: string, opts: { description?: string } = {})
 export async function cmdTeamSpawn(
   teamName: string,
   role: string,
-  opts: { model?: string; prompt?: string; exec?: boolean; cwd?: string } = {},
+  opts: { model?: string; prompt?: string; exec?: boolean; cwd?: string; parentSessionId?: string; sessionId?: string } = {},
 ) {
   const PSI = resolvePsi();
   const teamDir = join(PSI, "memory", "mailbox", "teams", teamName);
@@ -245,7 +246,11 @@ export async function cmdTeamSpawn(
   const promptPath = join(teamDir, `${role}-spawn-prompt.md`);
   writeFileSync(promptPath, spawnPrompt);
   const launchPromptPath = writeLaunchPromptFile(teamName, role, spawnPrompt) ?? promptPath;
-  const claudeCmd = `${cwdPrefix}claude --model ${model} --system-prompt-file ${shellQuote(launchPromptPath)}`;
+  const claudeCmd = `${cwdPrefix}${prefixCommandWithSpawnSessionEnv(`claude --model ${model} --system-prompt-file ${shellQuote(launchPromptPath)}`, {
+    explicit: opts.parentSessionId,
+    sessionId: opts.sessionId,
+    cwd: opts.cwd,
+  })}`;
 
   // Update manifest with new member
   const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));

--- a/src/vendor/mpr-plugins/wake/index.ts
+++ b/src/vendor/mpr-plugins/wake/index.ts
@@ -57,6 +57,9 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         "--split": Boolean,
         "--all-local": Boolean,
         "--peer": String,
+        "--parent": String,
+        "--parent-session-id": String,
+        "--session-id": String,
       }, 1);
 
       if (flags["--peer"]) {
@@ -70,6 +73,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         split?: boolean; urlRepoName?: string; allLocal?: boolean;
         fromSnapshot?: boolean; snapshotId?: string;
         layout?: "nested" | "legacy";
+        parentSessionId?: string; sessionId?: string;
       } = {};
       let issueNum: number | null = flags["--issue"] ?? null;
       let repo: string | undefined = flags["--repo"];
@@ -107,6 +111,10 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       if (flags["--main"]) wakeOpts.noRehydrate = true;
       if (flags["--split"]) wakeOpts.split = true;
       if (flags["--all-local"]) wakeOpts.allLocal = true;
+      if (flags["--parent-session-id"] || flags["--parent"]) {
+        wakeOpts.parentSessionId = (flags["--parent-session-id"] as string | undefined) || (flags["--parent"] as string | undefined);
+      }
+      if (flags["--session-id"]) wakeOpts.sessionId = flags["--session-id"];
 
       const positionals = flags._;
       if (positionals.length > 0) wakeOpts.task = positionals[0];
@@ -140,6 +148,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       fresh?: boolean; pick?: boolean; name?: string; attach?: boolean; dryRun?: boolean; noRehydrate?: boolean;
       fromSnapshot?: boolean; snapshotId?: string;
       layout?: "nested" | "legacy";
+      parentSessionId?: string; sessionId?: string;
     } = {};
     if (body.task) wakeOpts.task = body.task as string;
     if (body.wt) wakeOpts.wt = body.wt as string;
@@ -165,6 +174,9 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       wakeOpts.snapshotId = body.snapshot;
       wakeOpts.fromSnapshot = true;
     }
+    if (typeof body.parentSessionId === "string") wakeOpts.parentSessionId = body.parentSessionId;
+    if (typeof body.parent === "string") wakeOpts.parentSessionId = body.parent;
+    if (typeof body.sessionId === "string") wakeOpts.sessionId = body.sessionId;
 
     await cmdWake(oracle, wakeOpts);
     return { ok: true, output: logs.join("\n") || undefined };

--- a/test/parent-session-default.test.ts
+++ b/test/parent-session-default.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, utimesSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  prefixCommandWithSpawnSessionEnv,
+  resolveParentSessionId,
+  spawnSessionEnv,
+} from "../src/core/fleet/parent-session";
+
+const roots: string[] = [];
+
+function tempRoot(): string {
+  const root = join(tmpdir(), `maw-parent-session-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(root, { recursive: true });
+  roots.push(root);
+  return root;
+}
+
+function encodeProjectPath(path: string): string {
+  return path.replace(/^\//, "-").replace(/\//g, "-");
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("parent session resolution", () => {
+  test("prefers explicit parent over inherited session env", () => {
+    expect(resolveParentSessionId({
+      explicit: "parent-explicit",
+      env: { CLAUDE_SESSION_ID: "claude-current" } as NodeJS.ProcessEnv,
+      cwd: "/tmp/unused",
+    })).toBe("parent-explicit");
+  });
+
+  test("falls back through Claude session env before project jsonl scan", () => {
+    expect(resolveParentSessionId({
+      env: { CLAUDE_SESSION_ID: "claude-current" } as NodeJS.ProcessEnv,
+      cwd: "/tmp/unused",
+    })).toBe("claude-current");
+  });
+
+  test("uses newest Claude project jsonl when env does not identify the caller", () => {
+    const root = tempRoot();
+    const cwd = join(root, "repo");
+    const projects = join(root, "projects");
+    const projectDir = join(projects, encodeProjectPath(cwd));
+    mkdirSync(projectDir, { recursive: true });
+    const older = join(projectDir, "older.jsonl");
+    const newer = join(projectDir, "newer.jsonl");
+    writeFileSync(older, "{}\n");
+    writeFileSync(newer, "{}\n");
+    utimesSync(older, new Date(Date.now() - 10_000), new Date(Date.now() - 10_000));
+    utimesSync(newer, new Date(), new Date());
+    writeFileSync(join(projectDir, "newest-subagents.jsonl"), "{}\n");
+
+    expect(resolveParentSessionId({
+      cwd,
+      env: { MAW_CLAUDE_PROJECTS_DIR: projects } as NodeJS.ProcessEnv,
+    })).toBe("newer");
+  });
+
+  test("builds spawn env and shell prefix without empty values", () => {
+    expect(spawnSessionEnv({
+      explicit: "parent-1",
+      sessionId: "child-1",
+      env: {} as NodeJS.ProcessEnv,
+    })).toEqual({
+      MAW_PARENT_SESSION_ID: "parent-1",
+      MAW_SESSION_ID: "child-1",
+    });
+    expect(prefixCommandWithSpawnSessionEnv("claude", {
+      explicit: "parent 1",
+      sessionId: "child'1",
+      env: {} as NodeJS.ProcessEnv,
+    })).toBe("MAW_PARENT_SESSION_ID='parent 1' MAW_SESSION_ID='child'\\''1' claude");
+  });
+});

--- a/test/top-aliases-default.test.ts
+++ b/test/top-aliases-default.test.ts
@@ -277,6 +277,8 @@ describe("direct handler invocation", () => {
       "--snapshot", "snap-1",
       "--solo",
       "--split",
+      "--parent-session-id", "parent-1",
+      "--session-id", "child-1",
       "--all-local",
       "--codex",
     ], deps);
@@ -302,6 +304,8 @@ describe("direct handler invocation", () => {
       snapshotId: "snap-1",
       noRehydrate: true,
       split: true,
+      parentSessionId: "parent-1",
+      sessionId: "child-1",
       allLocal: true,
       engine: "codex",
     }]]);


### PR DESCRIPTION
## Summary
- adds shared `resolveParentSessionId` / spawn env helpers
- wires `--parent` / `--parent-session-id` and `--session-id` through wake/awake/bring, team spawn, bud/awaken, swarm, tile, and `maw new --claude`
- exposes metadata as `MAW_PARENT_SESSION_ID` and optional `MAW_SESSION_ID` instead of passing unproven engine-specific flags

## Scope notes
- no fleet parent-field migration; #1921 should own registry authority/backfill semantics
- no silent registration or migration
- multi-pane swarm/tile only applies `--session-id` when spawning one pane to avoid duplicate child IDs

## Tests
- `bun run build`
- `git diff --check`
- `MAW_TEST_MODE=1 bun test ./test/parent-session-default.test.ts ./test/top-aliases-default.test.ts ./test/isolated/tile-ls-coverage.test.ts ./test/isolated/top-aliases-runtime-coverage.test.ts --path-ignore-patterns '**/agents/**'`
- `MAW_TEST_MODE=1 bun test ./test/isolated/team-index-coverage.test.ts --path-ignore-patterns '**/agents/**'`
- `MAW_TEST_MODE=1 bun test ./test/isolated/team-lifecycle-second-pass-coverage.test.ts --path-ignore-patterns '**/agents/**'`

Closes #1925.

Written by [m5:mawjscodex] — an Oracle AI running gpt-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
