### PR TITLE
fix(workon): sanitize slash task slugs

### DIFF
--- a/src/vendor/mpr-plugins/workon/impl.ts
+++ b/src/vendor/mpr-plugins/workon/impl.ts
@@ -6,6 +6,10 @@ import { findWorktrees } from "maw-js/commands/shared/wake";
 import { resolveWorktreeTarget } from "maw-js/core/matcher/resolve-target";
 import { normalizeWorktreeLayout, worktreePathForLayout, type WorktreeLayout } from "maw-js/core/fleet/worktree-layout";
 
+export function sanitizeWorkonTaskSlug(task: string): string {
+  return task.replace(/\//g, "-");
+}
+
 async function resolveRepo(repo: string): Promise<{ repoPath: string; repoName: string; parentDir: string }> {
   // Support "org/repo" or bare "repo" — always search by last segment
   const searchTerm = repo.includes("/") ? repo.split("/").pop()! : repo;
@@ -25,6 +29,7 @@ export async function cmdWorkon(repo: string, task?: string, opts: { layout?: Wo
   let windowName = repoName;
 
   if (task) {
+    task = sanitizeWorkonTaskSlug(task);
     const worktrees = await findWorktrees(parentDir, repoName);
     const resolved = resolveWorktreeTarget(task, worktrees);
     let match: { path: string; name: string } | null = null;

--- a/test/isolated/workon-plugin-coverage.test.ts
+++ b/test/isolated/workon-plugin-coverage.test.ts
@@ -55,7 +55,7 @@ mock.module("maw-js/sdk", () => ({
   },
 }));
 
-const { cmdWorkon } = await import("../../src/vendor/mpr-plugins/workon/impl.ts?workon-plugin-coverage");
+const { cmdWorkon, sanitizeWorkonTaskSlug } = await import("../../src/vendor/mpr-plugins/workon/impl.ts?workon-plugin-coverage");
 
 beforeEach(() => {
   ghqFindResult = "/opt/Code/github.com/Soul-Brews-Studio/maw-js";
@@ -141,6 +141,21 @@ describe("workon plugin coverage", () => {
       opts: { cwd: "/opt/Code/github.com/Soul-Brews-Studio/maw-js/agents/8-new-task" },
     });
     expect(sendTextCalls[0]).toEqual({ target: "alpha-session:maw-js-new-task", text: "agent --name maw-js-new-task" });
+  });
+
+  test("sanitizes slash-separated task names before resolving paths and branches", async () => {
+    expect(sanitizeWorkonTaskSlug("feat/message-tracking")).toBe("feat-message-tracking");
+    hostExecFailures.set("branch -D", new Error("branch not found"));
+
+    await cmdWorkon("maw-js", "feat/message-tracking");
+
+    expect(hostExecCalls.some((cmd) => cmd.includes("branch -D 'agents/1-feat-message-tracking'"))).toBe(true);
+    expect(hostExecCalls.some((cmd) => cmd.includes("worktree add '/opt/Code/github.com/Soul-Brews-Studio/maw-js/agents/1-feat-message-tracking' -b 'agents/1-feat-message-tracking'"))).toBe(true);
+    expect(newWindowCalls[0]).toEqual({
+      session: "alpha-session",
+      name: "maw-js-feat-message-tracking",
+      opts: { cwd: "/opt/Code/github.com/Soul-Brews-Studio/maw-js/agents/1-feat-message-tracking" },
+    });
   });
 
   test("honors --layout legacy for new task worktrees", async () => {


### PR DESCRIPTION
## Summary
- sanitizes `/` in `maw workon <repo> <task>` before worktree matching/creation
- keeps worktree paths and branches flat, e.g. `feat/message-tracking` → `agents/1-feat-message-tracking`
- adds isolated coverage for the branch/path/window-name behavior

## Relationship to #1918
This is a small alpha-based replacement for draft PR #1918 with test coverage added. It keeps Wind/Gale's one-line behavior but lands it on the maintained alpha lane.

## Tests
- `bun test ./test/isolated/workon-plugin-coverage.test.ts --path-ignore-patterns '**/agents/**'`
- `bun run build`
- `git diff --check`

Closes #1918.

Written by [m5:mawjscodex] — an Oracle AI running gpt-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
