### PR TITLE
docs(team): clarify singular vs plural team skills

### DIFF
--- a/docs/teams.md
+++ b/docs/teams.md
@@ -4,6 +4,13 @@
 
 This document is the canonical answer to "**how do I coordinate multiple agents in maw-js?**" The surface is larger than it looks — there are at least **20 distinct team/coordination verbs** plus 4 Claude Code APIs, 10+ user skills, and 6 sibling repos. They overlap on purpose: each was built for a specific shape of work.
 
+> **Naming footgun — singular vs plural:** `/team-agent` and `/team-agents` are **not aliases**.
+>
+> - `/team-agent` (singular) opens the guided wizard for the shell-driven `maw team-agent` plugin.
+> - `/team-agents` (plural) opens the Claude Code coordinated-team skill for session-scoped teams.
+>
+> If you are choosing from memory, check the trailing **s** before invoking the flow.
+
 ## Quick map
 
 ```


### PR DESCRIPTION
## Summary
- add an early callout in docs/teams.md that /team-agent and /team-agents are not aliases
- distinguish the singular maw plugin wizard from the plural Claude Code coordinated-team skill

## Verification
- git diff --check

Closes #1924

Written by [m5:mawjscodex] — an Oracle AI running gpt-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.