### PR TITLE
feat(config): add cwd-aware weighted config layers

### DIFF
--- a/src/commands/plugins/config/index.ts
+++ b/src/commands/plugins/config/index.ts
@@ -1,0 +1,59 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { loadConfigWithProvenance } from "../../../config";
+
+export const command = {
+  name: "config",
+  description: "Inspect cwd-aware maw config layers and provenance.",
+};
+
+function valueAtPath(root: unknown, keyPath: string): unknown {
+  return keyPath.split(".").reduce((node: any, key) => node?.[key], root as any);
+}
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const writer = ctx.writer ?? ((...args: unknown[]) => logs.push(args.map(String).join(" ")));
+  const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+  const sub = args[0] ?? "show";
+  const json = args.includes("--json");
+  const loaded = loadConfigWithProvenance({ cwd: process.cwd() });
+
+  if (sub === "show") {
+    writer(JSON.stringify(loaded.config, null, 2));
+    return { ok: true, output: logs.join("\n") || undefined };
+  }
+
+  if (sub === "sources") {
+    const rows = loaded.sources.map((source) => ({
+      weight: source.weight,
+      scope: source.scope,
+      local: source.isLocal,
+      file: source.path,
+    }));
+    if (json) writer(JSON.stringify({ sources: rows, warnings: loaded.warnings }, null, 2));
+    else {
+      for (const row of rows) writer(`${String(row.weight).padStart(3)} ${row.scope.padEnd(7)} ${row.local ? "local" : "     "} ${row.file}`);
+      for (const warning of loaded.warnings) writer(warning);
+    }
+    return { ok: true, output: logs.join("\n") || undefined };
+  }
+
+  if (sub === "explain") {
+    const key = args.find((arg, index) => index > 0 && !arg.startsWith("-"));
+    if (!key) return { ok: false, error: "usage: maw config explain <key> [--json]" };
+    const entries = loaded.provenance[key] ?? [];
+    const finalValue = valueAtPath(loaded.config, key);
+    if (json) writer(JSON.stringify({ key, finalValue, entries }, null, 2));
+    else {
+      writer(`key: ${key}`);
+      for (const entry of entries) {
+        writer(`${entry.weight} ${entry.scope}${entry.isLocal ? ".local" : ""} ${entry.action} ${entry.path}`);
+        writer(`  ${JSON.stringify(entry.value)}`);
+      }
+      writer(`FINAL ${JSON.stringify(finalValue)}`);
+    }
+    return { ok: true, output: logs.join("\n") || undefined };
+  }
+
+  return { ok: false, error: "usage: maw config <show|sources|explain <key>> [--json]" };
+}

--- a/src/commands/plugins/config/plugin.json
+++ b/src/commands/plugins/config/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "config",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Inspect cwd-aware maw config layers and provenance.",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "config",
+    "help": "maw config <show|sources|explain <key>> [--json] — inspect merged config and config layer provenance"
+  },
+  "weight": 10,
+  "tier": "standard"
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,5 +2,5 @@
 export type { TriggerEvent, TriggerConfig, PeerConfig, MawIntervals, MawTimeouts, MawLimits, MawConfig } from "./config/types";
 export { D } from "./config/types";
 export { validateConfigShape } from "./config/validate";
-export { loadConfig, resetConfig, saveConfig, configForDisplay, cfgInterval, cfgTimeout, cfgLimit, cfg } from "./config/load";
+export { loadConfig, loadConfigWithProvenance, resetConfig, saveConfig, configForDisplay, cfgInterval, cfgTimeout, cfgLimit, cfg } from "./config/load";
 export { buildCommand, buildCommandInDir, getEnvVars } from "./config/command";

--- a/src/config/command.ts
+++ b/src/config/command.ts
@@ -15,7 +15,7 @@ export function buildCommand(agentName: string, optsOrEngine?: BuildCommandInput
  * detection such as Discord bot `--channels` injection.
  */
 export function buildCommandInDir(agentName: string, cwd: string, optsOrEngine?: BuildCommandInput): string {
-  return buildCommandInDirFromConfig(loadConfig(), agentName, cwd, optsOrEngine);
+  return buildCommandInDirFromConfig(loadConfig({ cwd }), agentName, cwd, optsOrEngine);
 }
 
 export function getEnvVars(): Record<string, string> {

--- a/src/config/deep-merge.ts
+++ b/src/config/deep-merge.ts
@@ -1,0 +1,57 @@
+export interface ProvenanceEntry {
+  path: string;
+  weight: number;
+  scope: string;
+  isLocal: boolean;
+  value: unknown;
+  action: "set" | "delete";
+}
+
+export type ProvenanceMap = Record<string, ProvenanceEntry[]>;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function joinKey(parent: string, key: string): string {
+  return parent ? `${parent}.${key}` : key;
+}
+
+export function deepMerge<T extends Record<string, unknown>>(
+  base: T,
+  override: Record<string, unknown> | null | undefined,
+): T {
+  const result: Record<string, unknown> = { ...base };
+  for (const [key, value] of Object.entries(override ?? {})) {
+    if (value === null) {
+      delete result[key];
+    } else if (isPlainObject(value) && isPlainObject(result[key])) {
+      result[key] = deepMerge(result[key] as Record<string, unknown>, value);
+    } else if (isPlainObject(value)) {
+      result[key] = deepMerge({}, value);
+    } else {
+      result[key] = value;
+    }
+  }
+  return result as T;
+}
+
+export function recordProvenance(
+  provenance: ProvenanceMap,
+  source: { path: string; weight: number; scope: string; isLocal: boolean },
+  value: Record<string, unknown> | null | undefined,
+  parent = "",
+): void {
+  for (const [key, child] of Object.entries(value ?? {})) {
+    const keyPath = joinKey(parent, key);
+    if (child === null) {
+      (provenance[keyPath] ??= []).push({ ...source, value: null, action: "delete" });
+      continue;
+    }
+    if (isPlainObject(child)) {
+      recordProvenance(provenance, source, child, keyPath);
+      continue;
+    }
+    (provenance[keyPath] ??= []).push({ ...source, value: child, action: "set" });
+  }
+}

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -1,13 +1,14 @@
-import { readFileSync, writeFileSync } from "fs";
+import { existsSync, readFileSync, writeFileSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
-import { CONFIG_FILE } from "../core/paths";
+import { CONFIG_FILE, CONFIG_WEIGHTED_FILE, discoverConfigs, type DiscoveredConfig } from "../core/paths";
 import { refreshContext } from "../lib/context";
 import { verbose, info } from "../cli/verbosity";
 import type { MawConfig } from "./types";
 import { D } from "./types";
 import { validateConfig } from "./validate-ext";
 import { loadFleetAgents } from "./fleet-merge";
+import { deepMerge, recordProvenance, type ProvenanceMap } from "./deep-merge";
 import {
   DEFAULT_ACTIVE_PLUGINS_1500_MIGRATION,
   DEFAULT_ACTIVE_PLUGINS_1514_MIGRATION,
@@ -41,6 +42,32 @@ let warnedHostMigrated = false;
 let warnedHostNodeConflated = false;
 
 let cached: MawConfig | null = null;
+let cachedKey = "";
+let cachedSources: DiscoveredConfig[] = [];
+let cachedProvenance: ProvenanceMap = {};
+let cachedWarnings: string[] = [];
+
+export interface LoadConfigOptions {
+  cwd?: string;
+}
+
+export interface LoadedConfigWithProvenance {
+  config: MawConfig;
+  sources: DiscoveredConfig[];
+  provenance: ProvenanceMap;
+  warnings: string[];
+}
+
+const RESTRICTED_PROJECT_KEYS = new Set([
+  "node",
+  "port",
+  "bind",
+  "federationToken",
+  "agents",
+  "namedPeers",
+  "peers",
+  "sessions",
+]);
 
 /** Bind-address values that should never appear as an outbound target (#713). */
 const BIND_ADDRESSES = new Set(["0.0.0.0", "::", "", "127.0.0.1", "localhost"]);
@@ -56,17 +83,125 @@ function canPersistConfigMigration(): boolean {
   return !(process.env.MAW_TEST_MODE === "1" && CONFIG_FILE === REAL_HOME_CONFIG);
 }
 
+function maybeMigrateLegacyConfigFile(): void {
+  if (process.env.MAW_TEST_MODE === "1") return;
+  if (!canPersistConfigMigration()) return;
+  if (!existsSync(CONFIG_FILE) || existsSync(CONFIG_WEIGHTED_FILE)) return;
+  try {
+    const body = readFileSync(CONFIG_FILE, "utf-8");
+    writeFileSync(CONFIG_WEIGHTED_FILE, body.endsWith("\n") ? body : `${body}\n`, "utf-8");
+    process.stderr.write(
+      `[maw] migrating ${CONFIG_FILE} → ${CONFIG_WEIGHTED_FILE} ` +
+      `(legacy file kept for compatibility)\n`,
+    );
+  } catch (e) {
+    process.stderr.write(
+      `[maw] config migration skipped: ${e instanceof Error ? e.message : String(e)}\n`,
+    );
+  }
+}
+
 function persistLoadedConfig(label: string): void {
   if (!cached) return;
   if (!canPersistConfigMigration()) return;
   try {
-    writeFileSync(CONFIG_FILE, JSON.stringify(cached, null, 2) + "\n", "utf-8");
+    const body = JSON.stringify(cached, null, 2) + "\n";
+    writeFileSync(CONFIG_FILE, body, "utf-8");
+    if (existsSync(CONFIG_WEIGHTED_FILE)) writeFileSync(CONFIG_WEIGHTED_FILE, body, "utf-8");
   } catch (e) {
     process.stderr.write(
       `[maw] ${label}: in-memory heal applied but disk persist failed: ` +
       `${e instanceof Error ? e.message : String(e)}\n`,
     );
   }
+}
+
+function configCacheKey(sources: DiscoveredConfig[], cwd: string): string {
+  return JSON.stringify({
+    cwd,
+    configFile: CONFIG_FILE,
+    sources: sources.map((source) => [source.path, source.weight, source.scopeRank, source.isLocal, source.mtimeMs]),
+  });
+}
+
+function readConfigLayer(source: DiscoveredConfig): Partial<MawConfig> | null {
+  try {
+    const raw = JSON.parse(readFileSync(source.path, "utf-8"));
+    return validateConfig(raw);
+  } catch {
+    return null;
+  }
+}
+
+function restrictedProjectWarnings(source: DiscoveredConfig, layer: Partial<MawConfig>): string[] {
+  if (source.scope !== "project") return [];
+  return Object.keys(layer)
+    .filter((key) => RESTRICTED_PROJECT_KEYS.has(key))
+    .map((key) =>
+      `[maw] project config ${source.path} overrides restricted key "${key}". ` +
+      `Move identity/routing keys to user-global config unless this cwd-specific split is intentional.`,
+    );
+}
+
+function buildLoadedConfig(opts: LoadConfigOptions = {}): LoadedConfigWithProvenance {
+  const cwd = opts.cwd ?? process.cwd();
+  if (cached && !opts.cwd) {
+    return { config: cached, sources: cachedSources, provenance: cachedProvenance, warnings: cachedWarnings };
+  }
+  maybeMigrateLegacyConfigFile();
+  let sources = discoverConfigs(cwd);
+  if (sources.length === 0) {
+    sources = [{
+      path: CONFIG_FILE,
+      weight: 50,
+      isLocal: false,
+      scope: "legacy",
+      scopeRank: 20,
+      depth: 0,
+      mtimeMs: 0,
+    }];
+  }
+  const key = configCacheKey(sources, cwd);
+  if (cached && cachedKey === key) {
+    return { config: cached, sources: cachedSources, provenance: cachedProvenance, warnings: cachedWarnings };
+  }
+
+  let merged: Record<string, unknown> = {};
+  const provenance: ProvenanceMap = {};
+  const warnings: string[] = [];
+  let loadedAny = false;
+  for (const source of sources) {
+    const layer = readConfigLayer(source);
+    if (!layer) continue;
+    loadedAny = true;
+    warnings.push(...restrictedProjectWarnings(source, layer));
+    recordProvenance(provenance, source, layer as Record<string, unknown>);
+    merged = deepMerge(merged, layer as Record<string, unknown>);
+  }
+  if (!loadedAny && !sources.some((source) => source.path === CONFIG_FILE)) {
+    const legacySource: DiscoveredConfig = {
+      path: CONFIG_FILE,
+      weight: 50,
+      isLocal: false,
+      scope: "legacy",
+      scopeRank: 20,
+      depth: 0,
+      mtimeMs: 0,
+    };
+    const layer = readConfigLayer(legacySource);
+    if (layer) {
+      sources = [legacySource];
+      recordProvenance(provenance, legacySource, layer as Record<string, unknown>);
+      merged = deepMerge(merged, layer as Record<string, unknown>);
+    }
+  }
+
+  cached = { ...DEFAULTS, ...(merged as Partial<MawConfig>) };
+  cachedKey = key;
+  cachedSources = sources;
+  cachedProvenance = provenance;
+  cachedWarnings = warnings;
+  return { config: cached, sources, provenance, warnings };
 }
 
 function maybeMigrateDefaultActivePlugins(config: MawConfig): void {
@@ -210,15 +345,12 @@ function maybeMigrateViewStandardPlugin(config: MawConfig): void {
   persistLoadedConfig("config.disabledPlugins migration (#1854)");
 }
 
-export function loadConfig(): MawConfig {
-  if (cached) return cached;
-  try {
-    const raw = JSON.parse(readFileSync(CONFIG_FILE, "utf-8"));
-    const validated = validateConfig(raw);
-    cached = { ...DEFAULTS, ...validated };
-  } catch {
-    cached = { ...DEFAULTS };
-  }
+export function loadConfig(opts: LoadConfigOptions = {}): MawConfig {
+  const hadDefaultCache = cached !== null && !opts.cwd;
+  buildLoadedConfig(opts);
+  if (!cached) cached = { ...DEFAULTS };
+  for (const warning of cachedWarnings) process.stderr.write(`${warning}\n`);
+  if (hadDefaultCache) return cached;
   // #713 — migrate bind-address values out of `host` into `bind`.
   // If `host` is a bind address (0.0.0.0, ::, 127.0.0.1, localhost, ""),
   // move it to `bind` (if not already set) and reset `host` to "local".
@@ -317,9 +449,23 @@ export function loadConfig(): MawConfig {
   return cached;
 }
 
+export function loadConfigWithProvenance(opts: LoadConfigOptions = {}): LoadedConfigWithProvenance {
+  loadConfig(opts);
+  return {
+    config: cached ?? { ...DEFAULTS },
+    sources: cachedSources,
+    provenance: cachedProvenance,
+    warnings: cachedWarnings,
+  };
+}
+
 /** Reset cached config (for hot-reload or testing) */
 export function resetConfig() {
   cached = null;
+  cachedKey = "";
+  cachedSources = [];
+  cachedProvenance = {};
+  cachedWarnings = [];
   warnedGhqRoot = false;
   warnedHostMigrated = false;
   warnedHostNodeConflated = false;
@@ -350,9 +496,15 @@ export function saveConfig(update: Partial<MawConfig>) {
       `import is resolved (see src/core/paths.ts). (#820)`,
     );
   }
-  const current = loadConfig();
+  const target = existsSync(CONFIG_WEIGHTED_FILE) ? CONFIG_WEIGHTED_FILE : CONFIG_FILE;
+  let current: Partial<MawConfig> = {};
+  try {
+    current = validateConfig(JSON.parse(readFileSync(target, "utf-8")));
+  } catch {
+    current = {};
+  }
   const merged = { ...current, ...update };
-  writeFileSync(CONFIG_FILE, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  writeFileSync(target, JSON.stringify(merged, null, 2) + "\n", "utf-8");
   resetConfig(); // clear cache so next loadConfig() reads fresh
   refreshContext(); // clear DI cache so middleware picks up new config
   return loadConfig();

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -1,5 +1,5 @@
 import { join, resolve, dirname } from "path";
-import { mkdirSync } from "fs";
+import { existsSync, mkdirSync, readdirSync, statSync } from "fs";
 import { mawConfigDir, mawRuntimeHomeDir } from "./xdg";
 
 export const MAW_ROOT = resolve(dirname(new URL(import.meta.url).pathname), "..");
@@ -31,6 +31,94 @@ export function resolveHome(): string {
 export const CONFIG_DIR = mawConfigDir();
 export const FLEET_DIR = join(CONFIG_DIR, "fleet");
 export const CONFIG_FILE = join(CONFIG_DIR, "maw.config.json");
+export const CONFIG_WEIGHTED_FILE = join(CONFIG_DIR, "maw.config.50.json");
+
+const CONFIG_FILE_REGEX = /^maw\.config\.(\d+)(\.local)?\.json$/;
+
+export type ConfigScope = "system" | "user" | "project" | "legacy";
+
+export interface DiscoveredConfig {
+  path: string;
+  weight: number;
+  isLocal: boolean;
+  scope: ConfigScope;
+  scopeRank: number;
+  depth: number;
+  mtimeMs: number;
+}
 
 // Ensure dirs exist on first import
 mkdirSync(FLEET_DIR, { recursive: true });
+
+function scanConfigDir(dir: string, scope: ConfigScope, scopeRank: number, depth = 0): DiscoveredConfig[] {
+  if (!existsSync(dir)) return [];
+  try {
+    return readdirSync(dir)
+      .map((name) => {
+        const match = name.match(CONFIG_FILE_REGEX);
+        if (!match) return null;
+        const path = join(dir, name);
+        return {
+          path,
+          weight: Number.parseInt(match[1]!, 10),
+          isLocal: Boolean(match[2]),
+          scope,
+          scopeRank,
+          depth,
+          mtimeMs: statSync(path).mtimeMs,
+        } satisfies DiscoveredConfig;
+      })
+      .filter((item): item is DiscoveredConfig => item !== null);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Discover maw config layers for a cwd-aware invocation.
+ *
+ * Phase 1 intentionally skips /etc/maw managed config. The global layer still
+ * honors CONFIG_DIR/MAW_HOME/MAW_CONFIG_DIR. Legacy maw.config.json is loaded
+ * as weight 50 only when no weighted user-global file exists.
+ */
+export function discoverConfigs(cwd = process.cwd()): DiscoveredConfig[] {
+  const found: DiscoveredConfig[] = [];
+
+  const userWeighted = scanConfigDir(CONFIG_DIR, "user", 20, 0);
+  found.push(...userWeighted);
+  if (userWeighted.length === 0 && existsSync(CONFIG_FILE)) {
+    try {
+      found.push({
+        path: CONFIG_FILE,
+        weight: 50,
+        isLocal: false,
+        scope: "legacy",
+        scopeRank: 20,
+        depth: 0,
+        mtimeMs: statSync(CONFIG_FILE).mtimeMs,
+      });
+    } catch {
+      // Ignore unreadable legacy config; loadConfig will fall back to defaults.
+    }
+  }
+
+  const chain: string[] = [];
+  let dir = resolve(cwd);
+  for (let i = 0; i < 32; i += 1) {
+    chain.push(dir);
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  chain.reverse();
+  chain.forEach((entry, index) => {
+    found.push(...scanConfigDir(join(entry, ".maw"), "project", 30 + index, index));
+  });
+
+  return found.sort((a, b) =>
+    a.weight - b.weight ||
+    a.scopeRank - b.scopeRank ||
+    Number(a.isLocal) - Number(b.isLocal) ||
+    a.path.localeCompare(b.path)
+  );
+}

--- a/test/isolated/config-load-second-pass-coverage.test.ts
+++ b/test/isolated/config-load-second-pass-coverage.test.ts
@@ -42,6 +42,16 @@ await mock.module("fs", () => ({
 await mock.module(import.meta.resolve("../../src/core/paths"), () => ({
   ...realPaths,
   CONFIG_FILE: MOCK_CONFIG_FILE,
+  CONFIG_WEIGHTED_FILE: MOCK_CONFIG_FILE.replace(/\.json$/, ".50.json"),
+  discoverConfigs: () => [{
+    path: MOCK_CONFIG_FILE,
+    weight: 50,
+    isLocal: false,
+    scope: "legacy",
+    scopeRank: 20,
+    depth: 0,
+    mtimeMs: 0,
+  }],
 }));
 
 await mock.module(import.meta.resolve("../../src/lib/context"), () => ({

--- a/test/isolated/config-load-second-pass.test.ts
+++ b/test/isolated/config-load-second-pass.test.ts
@@ -51,6 +51,16 @@ await mock.module("fs", () => ({
 await mock.module(import.meta.resolve("../../src/core/paths"), () => ({
   ...realPaths,
   CONFIG_FILE: MOCK_CONFIG_FILE,
+  CONFIG_WEIGHTED_FILE: MOCK_CONFIG_FILE.replace(/\.json$/, ".50.json"),
+  discoverConfigs: () => [{
+    path: MOCK_CONFIG_FILE,
+    weight: 50,
+    isLocal: false,
+    scope: "legacy",
+    scopeRank: 20,
+    depth: 0,
+    mtimeMs: 0,
+  }],
 }));
 
 await mock.module(import.meta.resolve("../../src/lib/context"), () => ({

--- a/test/isolated/config-local-layers.test.ts
+++ b/test/isolated/config-local-layers.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { runBunChild } from "./helpers/run-bun-child";
+
+function run(script: string, cwd: string, env: Record<string, string>) {
+  return runBunChild({
+    cwd,
+    script,
+    env: { ...process.env, MAW_TEST_MODE: "1", MAW_QUIET: "1", ...env },
+  });
+}
+
+function jsonLine(stdout: string) {
+  const line = stdout.split("\n").find((entry) => entry.startsWith("RESULT:"));
+  expect(line).toBeTruthy();
+  return JSON.parse(line!.slice("RESULT:".length));
+}
+
+describe("cwd-aware local config layers", () => {
+  test("loadConfig and buildCommandInDir use cwd-specific project layers", () => {
+    const sandbox = mkdtempSync(join(tmpdir(), "maw-local-config-"));
+    try {
+      const mawHome = join(sandbox, "home");
+      const repoA = join(sandbox, "repo-a");
+      const repoB = join(sandbox, "repo-b");
+      mkdirSync(join(mawHome, "config"), { recursive: true });
+      mkdirSync(join(repoA, ".maw"), { recursive: true });
+      mkdirSync(join(repoB, ".maw"), { recursive: true });
+      writeFileSync(join(mawHome, "config", "maw.config.50.json"), JSON.stringify({
+        commands: { default: "global-engine" },
+        env: { GLOBAL: "1" },
+      }));
+      writeFileSync(join(repoA, ".maw", "maw.config.80.json"), JSON.stringify({
+        commands: { default: "repo-a-engine" },
+        env: { PROJECT: "a" },
+      }));
+      writeFileSync(join(repoB, ".maw", "maw.config.80.json"), JSON.stringify({
+        commands: { default: "repo-b-engine" },
+        env: { PROJECT: "b" },
+      }));
+
+      const result = run(`
+        const { loadConfig, buildCommandInDir } = await import("${process.cwd()}/src/config.ts");
+        const a = loadConfig({ cwd: ${JSON.stringify(repoA)} });
+        const b = loadConfig({ cwd: ${JSON.stringify(repoB)} });
+        console.log("RESULT:" + JSON.stringify({
+          aDefault: a.commands.default,
+          bDefault: b.commands.default,
+          aEnv: a.env,
+          cmdA: buildCommandInDir("worker", ${JSON.stringify(repoA)}),
+          cmdB: buildCommandInDir("worker", ${JSON.stringify(repoB)}),
+        }));
+      `, repoA, { MAW_HOME: mawHome });
+
+      expect(result.code).toBe(0);
+      const payload = jsonLine(result.stdout);
+      expect(payload.aDefault).toBe("repo-a-engine");
+      expect(payload.bDefault).toBe("repo-b-engine");
+      expect(payload.aEnv).toEqual({ GLOBAL: "1", PROJECT: "a" });
+      expect(payload.cmdA).toBe("repo-a-engine");
+      expect(payload.cmdB).toBe("repo-b-engine");
+    } finally {
+      rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+
+  test("arrays replace, null deletes, provenance records null delete source, and restricted project keys warn", () => {
+    const sandbox = mkdtempSync(join(tmpdir(), "maw-local-config-provenance-"));
+    try {
+      const mawHome = join(sandbox, "home");
+      const repo = join(sandbox, "repo");
+      mkdirSync(join(mawHome, "config"), { recursive: true });
+      mkdirSync(join(repo, ".maw"), { recursive: true });
+      writeFileSync(join(mawHome, "config", "maw.config.50.json"), JSON.stringify({
+        commands: { default: "global", extra: "keep" },
+        peers: ["https://global.example"],
+        env: { KEEP: "1", DROP: "1" },
+      }));
+      writeFileSync(join(repo, ".maw", "maw.config.80.json"), JSON.stringify({
+        commands: { default: "project" },
+        peers: ["https://project.example"],
+        port: 4567,
+        env: { DROP: null },
+      }));
+
+      const result = run(`
+        const { loadConfigWithProvenance } = await import("${process.cwd()}/src/config.ts");
+        const loaded = loadConfigWithProvenance({ cwd: ${JSON.stringify(repo)} });
+        console.log("RESULT:" + JSON.stringify({
+          config: loaded.config,
+          warnings: loaded.warnings,
+          drop: loaded.provenance["env.DROP"],
+          peers: loaded.provenance.peers,
+        }));
+      `, repo, { MAW_HOME: mawHome });
+
+      expect(result.code).toBe(0);
+      const payload = jsonLine(result.stdout);
+      expect(payload.config.commands).toEqual({ default: "project", extra: "keep" });
+      expect(payload.config.peers).toEqual(["https://project.example"]);
+      expect(payload.config.env).toEqual({ KEEP: "1" });
+      expect(payload.warnings.join("\n")).toContain('restricted key "port"');
+      expect(payload.warnings.join("\n")).toContain('restricted key "peers"');
+      expect(payload.drop.at(-1).action).toBe("delete");
+      expect(payload.peers.at(-1).value).toEqual(["https://project.example"]);
+    } finally {
+      rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/isolated/coverage-100b-config-transport-hooks-hub.test.ts
+++ b/test/isolated/coverage-100b-config-transport-hooks-hub.test.ts
@@ -49,6 +49,8 @@ let configState: Record<string, any> = { node: "local", federationToken: "test-f
 mock.module(join(root, "src/core/paths"), () => ({
   CONFIG_DIR: mockConfigDir,
   CONFIG_FILE: mockConfigFile,
+  CONFIG_WEIGHTED_FILE: mockConfigFile.replace(/\.json$/, ".50.json"),
+  discoverConfigs: () => [{ path: mockConfigFile, weight: 50, isLocal: false, scope: "legacy", scopeRank: 20, depth: 0, mtimeMs: 0 }],
   BASE_DIR: mockConfigDir,
   FLEET_DIR: join(mockConfigDir, "fleet"),
   MAW_ROOT: root,

--- a/test/isolated/coverage-100b-config-transport-real-home.test.ts
+++ b/test/isolated/coverage-100b-config-transport-real-home.test.ts
@@ -9,6 +9,8 @@ const realConfigFile = join(realConfigDir, "maw.config.json");
 
 mock.module(join(root, "src/core/paths"), () => ({
   CONFIG_FILE: realConfigFile,
+  CONFIG_WEIGHTED_FILE: realConfigFile.replace(/\.json$/, ".50.json"),
+  discoverConfigs: () => [{ path: realConfigFile, weight: 50, isLocal: false, scope: "legacy", scopeRank: 20, depth: 0, mtimeMs: 0 }],
   CONFIG_DIR: realConfigDir,
   BASE_DIR: realConfigDir,
   FLEET_DIR: join(realConfigDir, "fleet"),

--- a/test/isolated/coverage-100b-leader-shims.test.ts
+++ b/test/isolated/coverage-100b-leader-shims.test.ts
@@ -25,6 +25,8 @@ mock.module(import.meta.resolve("../../src/core/paths"), () => ({
   CONFIG_DIR: "/tmp/maw-coverage-home/config",
   FLEET_DIR: "/tmp/maw-coverage-home/config/fleet",
   CONFIG_FILE: "/tmp/maw-coverage-home/config/maw.config.json",
+  CONFIG_WEIGHTED_FILE: "/tmp/maw-coverage-home/config/maw.config.50.json",
+  discoverConfigs: () => [],
 }));
 mock.module(import.meta.resolve("../../src/config"), () => ({
   D: { limits: {}, intervals: {}, timeouts: {} },

--- a/test/isolated/migration-persist-913.test.ts
+++ b/test/isolated/migration-persist-913.test.ts
@@ -338,7 +338,8 @@ test("#913 — load.ts contains a writeFileSync inside the host=node migration b
   // The fix must call writeFileSync after setting cached.host = "local"
   // in the host=node branch. We check the structural pattern rather
   // than exact whitespace so a future refactor can rearrange comments.
-  expect(src).toMatch(/cached\.host = "local";[\s\S]*writeFileSync\(CONFIG_FILE/);
+  expect(src).toMatch(/cached\.host = "local";[\s\S]*persistLoadedConfig\("config\.host migration"\)/);
+  expect(src).toMatch(/function persistLoadedConfig[\s\S]*writeFileSync\(CONFIG_FILE/);
   // The #820-style guard must wrap the persist.
   expect(src).toMatch(/MAW_TEST_MODE.*REAL_HOME_CONFIG/);
 });

--- a/test/isolated/oracle-ls-manifest.test.ts
+++ b/test/isolated/oracle-ls-manifest.test.ts
@@ -22,12 +22,14 @@ import { tmpdir } from "os";
 // ─── Pin CONFIG_DIR + cache/FLEET dirs to sandboxed tmp dirs BEFORE imports ─
 const TEST_CONFIG_DIR = mkdtempSync(join(tmpdir(), "maw-oracle-ls-841-"));
 const TEST_CACHE_DIR = mkdtempSync(join(tmpdir(), "maw-oracle-ls-cache-"));
+const TEST_STATE_DIR = mkdtempSync(join(tmpdir(), "maw-oracle-ls-state-"));
 const TEST_FLEET_DIR = join(TEST_CONFIG_DIR, "fleet");
 mkdirSync(TEST_FLEET_DIR, { recursive: true });
 mkdirSync(TEST_CACHE_DIR, { recursive: true });
 
 process.env.MAW_CONFIG_DIR = TEST_CONFIG_DIR;
 process.env.MAW_CACHE_DIR = TEST_CACHE_DIR;
+process.env.MAW_STATE_DIR = TEST_STATE_DIR;
 delete process.env.MAW_HOME;
 process.env.MAW_TEST_MODE = "1";
 
@@ -63,17 +65,19 @@ const config = await import("../../src/config");
 const manifest = await import("../../src/lib/oracle-manifest");
 
 const CONFIG_FILE = join(TEST_CONFIG_DIR, "maw.config.json");
+const CONFIG_WEIGHTED_FILE = join(TEST_CONFIG_DIR, "maw.config.50.json");
 const ORACLES_JSON = join(TEST_CACHE_DIR, "oracles.json");
 const ORACLE_BIRTHS_JSON = join(TEST_CACHE_DIR, "oracle-births.json");
 
 afterAll(() => {
   rmSync(TEST_CONFIG_DIR, { recursive: true, force: true });
   rmSync(TEST_CACHE_DIR, { recursive: true, force: true });
+  rmSync(TEST_STATE_DIR, { recursive: true, force: true });
 });
 
 beforeEach(() => {
   mkdirSync(TEST_CACHE_DIR, { recursive: true });
-  for (const f of [CONFIG_FILE, ORACLES_JSON, ORACLE_BIRTHS_JSON]) {
+  for (const f of [CONFIG_FILE, CONFIG_WEIGHTED_FILE, ORACLES_JSON, ORACLE_BIRTHS_JSON]) {
     try { rmSync(f, { force: true }); } catch { /* ok */ }
   }
   try {

--- a/test/isolated/oracle-manifest.test.ts
+++ b/test/isolated/oracle-manifest.test.ts
@@ -23,12 +23,14 @@ import { tmpdir } from "os";
 // ─── Pin CONFIG_DIR + FLEET_DIR to a sandboxed tmp dir BEFORE imports ───────
 const TEST_CONFIG_DIR = mkdtempSync(join(tmpdir(), "maw-manifest-836-"));
 const TEST_CACHE_DIR = mkdtempSync(join(tmpdir(), "maw-manifest-cache-"));
+const TEST_STATE_DIR = mkdtempSync(join(tmpdir(), "maw-manifest-state-"));
 const TEST_FLEET_DIR = join(TEST_CONFIG_DIR, "fleet");
 mkdirSync(TEST_FLEET_DIR, { recursive: true });
 mkdirSync(TEST_CACHE_DIR, { recursive: true });
 
 process.env.MAW_CONFIG_DIR = TEST_CONFIG_DIR;
 process.env.MAW_CACHE_DIR = TEST_CACHE_DIR;
+process.env.MAW_STATE_DIR = TEST_STATE_DIR;
 delete process.env.MAW_HOME;
 // MAW_TEST_MODE prevents accidental writes to the real homedir if a test
 // strays. Mirrors test/isolated/auth-secret-persist.test.ts hardening (#820).
@@ -48,6 +50,7 @@ const {
 } = manifest;
 
 const CONFIG_FILE = join(TEST_CONFIG_DIR, "maw.config.json");
+const CONFIG_WEIGHTED_FILE = join(TEST_CONFIG_DIR, "maw.config.50.json");
 const ORACLES_JSON = join(TEST_CACHE_DIR, "oracles.json");
 const ORACLE_BIRTHS_JSON = join(TEST_CACHE_DIR, "oracle-births.json");
 const LEGACY_ORACLE_BIRTHS_JSON = join(TEST_CONFIG_DIR, "oracle-births.json");
@@ -55,13 +58,14 @@ const LEGACY_ORACLE_BIRTHS_JSON = join(TEST_CONFIG_DIR, "oracle-births.json");
 afterAll(() => {
   rmSync(TEST_CONFIG_DIR, { recursive: true, force: true });
   rmSync(TEST_CACHE_DIR, { recursive: true, force: true });
+  rmSync(TEST_STATE_DIR, { recursive: true, force: true });
 });
 
 beforeEach(() => {
   // Wipe all 5 file-backed registries between tests (config.agents
   // pre-population is recomputed on every loadConfig() call).
   mkdirSync(TEST_CACHE_DIR, { recursive: true });
-  for (const f of [CONFIG_FILE, ORACLES_JSON, ORACLE_BIRTHS_JSON, LEGACY_ORACLE_BIRTHS_JSON]) {
+  for (const f of [CONFIG_FILE, CONFIG_WEIGHTED_FILE, ORACLES_JSON, ORACLE_BIRTHS_JSON, LEGACY_ORACLE_BIRTHS_JSON]) {
     try { rmSync(f, { force: true }); } catch { /* missing is fine */ }
   }
   // Wipe fleet dir.


### PR DESCRIPTION
## Summary
- add cwd-aware discovery for weighted global/project config files (`maw.config.<weight>[.local].json`)
- deep-merge config layers with null-delete provenance and restricted project-key warnings
- make `buildCommandInDir` load config with the target cwd
- add `maw config show|sources|explain` inspection surface
- migrate legacy `maw.config.json` to `maw.config.50.json` outside test mode / real-home guardrails

## Verification
- `bun test test/isolated/config-local-layers.test.ts --path-ignore-patterns '**/agents/**'`
- `bun test test/isolated/config-load-coverage.test.ts --path-ignore-patterns '**/agents/**'`
- `bun test test/isolated/config-load-second-pass-coverage.test.ts --path-ignore-patterns '**/agents/**'`
- `bun test test/isolated/save-config-test-mode-guard.test.ts --path-ignore-patterns '**/agents/**'`
- `bun run build`
- `git diff --check`
- manual `maw config explain commands.default --json` with MAW_HOME + repo .maw layer

Closes #1919

Written by [m5:mawjscodex] — an Oracle AI running gpt-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
