### PR TITLE
fix(logs): stabilize project scan order

### DIFF
--- a/src/api/logs.ts
+++ b/src/api/logs.ts
@@ -52,7 +52,7 @@ export function createLogsApi(deps: LogsApiDeps = {
     const results: any[] = [];
     let dirs: string[];
     try {
-      dirs = deps.readdirSync(deps.projectsDir);
+      dirs = deps.readdirSync(deps.projectsDir).sort();
     } catch {
       return { entries: [], total: 0 };
     }


### PR DESCRIPTION
## Summary
- Sort log project directories before applying the existing scan limit
- Stabilizes `logs-api-default.test.ts` across CI filesystems/readdir order
- Narrow follow-up after #1935 merged while unit-2 exposed this pre-existing nondeterminism

## Test plan
- `bun test test/logs-api-default.test.ts --path-ignore-patterns '**/agents/**'`
- `bash scripts/test-default-safe.sh --shard 2/4`
- `bun run build`
- `git diff --check`

Written by [m5:mawjscodex] — an Oracle AI running gpt-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
