### PR TITLE
feat(split): add explicit split orientation flags

### DIFF
--- a/src/cli/cmd-new.ts
+++ b/src/cli/cmd-new.ts
@@ -77,7 +77,7 @@ export function validateWorkspaceWindowName(name: string): void {
 }
 
 function printUsage(write: (line: string) => void = console.log): void {
-  write("usage: maw new [session-name] [--path|-p <dir>] [--window <name>] [--cmd|-c <cmd>|--claude] [--shell] [--split] [--print|--json] [--attach|-a] [--no-attach] [--dry-run]");
+  write("usage: maw new [session-name] [--path|-p <dir>] [--window <name>] [--cmd|-c <cmd>|--claude] [--shell] [--split [--right|--horizontal|--bottom|--vertical]] [--print|--json] [--attach|-a] [--no-attach] [--dry-run]");
   write("  Create a plain tmux workspace session with a shell window.");
   write("  --path, -p   Start the workspace shell in <dir> (absolute, relative, or ~/...)");
   write("  --window     Name the first tmux window (default: lead).");
@@ -85,6 +85,8 @@ function printUsage(write: (line: string) => void = console.log): void {
   write("  --shell      Explicit shell mode (default today; accepted for future symmetry).");
   write("  --claude     Shortcut for Claude Code with maw team env enabled.");
   write("  --split      Open as a split in the current tmux window instead of a new session.");
+  write("  --right, --horizontal  With --split, create the pane to the right (tmux -h).");
+  write("  --bottom, --vertical   With --split, create the pane below (tmux -v; default).");
   write("  --print      Print a JSON payload with session/window/pane_id for scripts.");
   write("  --json       Alias for --print.");
   write("  --dry-run    Show what WOULD happen without creating any tmux state. (#1913)");
@@ -176,6 +178,19 @@ type NewWorkspacePrintPayload = {
   dry_run?: boolean;
 };
 
+type SplitDirection = "horizontal" | "vertical";
+
+function splitDirectionFromFlags(flags: Record<string, unknown>): SplitDirection | undefined {
+  const wantsHorizontal = !!(flags["--right"] || flags["--horizontal"]);
+  const wantsVertical = !!(flags["--bottom"] || flags["--vertical"]);
+  if (wantsHorizontal && wantsVertical) {
+    throw new UserError("new: choose only one split direction (--right/--horizontal or --bottom/--vertical)");
+  }
+  if (wantsHorizontal) return "horizontal";
+  if (wantsVertical) return "vertical";
+  return undefined;
+}
+
 async function workspacePaneId(session: string, windowName: string): Promise<string | undefined> {
   return tmux.firstPaneId?.(`${session}:${windowName}`) ?? undefined;
 }
@@ -236,6 +251,10 @@ export async function cmdNew(argv: string[]): Promise<void> {
     "--shell": Boolean,
     "--claude": Boolean,
     "--split": Boolean,
+    "--right": Boolean,
+    "--horizontal": Boolean,
+    "--bottom": Boolean,
+    "--vertical": Boolean,
     "--print": Boolean,
     "--json": Boolean,
     "--dry-run": Boolean,
@@ -311,6 +330,10 @@ export async function cmdNew(argv: string[]): Promise<void> {
   const machineReadable = !!(flags["--print"] || flags["--json"]);
   const dryRun = !!flags["--dry-run"];
   const split = !!flags["--split"];
+  const splitDirection = splitDirectionFromFlags(flags as Record<string, unknown>);
+  if (!split && splitDirection !== undefined) {
+    throw new UserError("new: split direction flags require --split");
+  }
   if (split && rawWindowName !== undefined) {
     throw new UserError("new: --window only applies when creating or reusing a workspace session, not --split");
   }
@@ -321,6 +344,7 @@ export async function cmdNew(argv: string[]): Promise<void> {
     if (!dryRun) {
       const rawPaneId = await tmux.splitWindow(undefined, {
         cwd,
+        ...(splitDirection ? { direction: splitDirection } : {}),
         ...(tmuxCommand ? { command: tmuxCommand } : {}),
         printFormat: "#{pane_id}",
       });

--- a/src/core/transport/tmux-class.ts
+++ b/src/core/transport/tmux-class.ts
@@ -307,9 +307,12 @@ export class Tmux {
     cwd?: string;
     command?: string;
     printFormat?: string;
+    direction?: "horizontal" | "vertical";
   } = {}): Promise<string> {
     const args: (string | number)[] = [];
     if (opts.printFormat) args.push("-P", "-F", opts.printFormat);
+    if (opts.direction === "horizontal") args.push("-h");
+    if (opts.direction === "vertical") args.push("-v");
     if (target) args.push("-t", target);
     if (opts.cwd) args.push("-c", opts.cwd);
     if (opts.command) args.push(opts.command);

--- a/src/vendor/mpr-plugins/split/impl.ts
+++ b/src/vendor/mpr-plugins/split/impl.ts
@@ -56,6 +56,8 @@ export interface SplitOpts {
   pct?: number;
   /** Split vertical (top/bottom) instead of horizontal (side-by-side). */
   vertical?: boolean;
+  /** Explicit horizontal/right split alias. Default when vertical is false. */
+  horizontal?: boolean;
   /** Split without attaching — leaves a plain shell in the new pane. */
   noAttach?: boolean;
   /** Serialize via the pane-creation lock + settle. Opt-in — only matters
@@ -72,7 +74,7 @@ export interface SplitOpts {
 }
 
 /**
- * maw split <target> [--pct N] [--vertical] [--no-attach]
+ * maw split <target> [--pct N] [--horizontal|--right|--vertical|--bottom] [--no-attach]
  *
  * Split the current tmux pane and attach to a target session in the new pane.
  *
@@ -96,16 +98,19 @@ export async function cmdSplit(target: string, opts: SplitOpts = {}) {
   }
 
   if (!target) {
-    console.error("usage: maw split <target> [--pct N] [--vertical] [--no-attach]");
+    console.error("usage: maw split <target> [--pct N] [--horizontal|--right|--vertical|--bottom] [--no-attach]");
     console.error("  e.g. maw split yeast");
     console.error("       maw split mawjs-view --pct 30 --vertical");
-    throw new Error("usage: maw split <target> [--pct N] [--vertical] [--no-attach]");
+    throw new Error("usage: maw split <target> [--pct N] [--horizontal|--right|--vertical|--bottom] [--no-attach]");
   }
 
   // Validate pct early so bad input never reaches tmux
   const pct = opts.pct ?? 50;
   if (!Number.isFinite(pct) || pct < 1 || pct > 99) {
     throw new Error(`--pct must be 1-99 (got ${pct})`);
+  }
+  if (opts.vertical && opts.horizontal) {
+    throw new Error("choose only one split direction (--horizontal/--right or --vertical/--bottom)");
   }
 
   // Resolve target to session:window if bare name given. Resolution rules

--- a/src/vendor/mpr-plugins/split/index.ts
+++ b/src/vendor/mpr-plugins/split/index.ts
@@ -28,13 +28,16 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       const flags = parseFlags(args, {
         "--pct": Number,
         "--vertical": Boolean,
+        "--bottom": "--vertical",
+        "--horizontal": Boolean,
+        "--right": "--horizontal",
         "--no-attach": Boolean,
         "--claude-pane-policy": String,
       }, 0);
 
       target = flags._[0];
       if (!target || target === "--help" || target === "-h") {
-        return { ok: false, error: "usage: maw split <target> [--pct N] [--vertical] [--no-attach]" };
+        return { ok: false, error: "usage: maw split <target> [--pct N] [--horizontal|--vertical] [--no-attach]" };
       }
       if (target.startsWith("-")) {
         return { ok: false, error: `"${target}" looks like a flag, not a target.\n  usage: maw split <target>` };
@@ -43,6 +46,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       opts = {
         pct: flags["--pct"],
         vertical: flags["--vertical"],
+        horizontal: flags["--horizontal"],
         noAttach: flags["--no-attach"],
       };
       if (flags["--claude-pane-policy"] !== undefined) {
@@ -57,6 +61,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       opts = {
         pct: body.pct as number | undefined,
         vertical: body.vertical as boolean | undefined,
+        horizontal: body.horizontal as boolean | undefined,
         noAttach: body.noAttach as boolean | undefined,
       };
       if (body.claudePanePolicy !== undefined) {

--- a/src/vendor/mpr-plugins/split/plugin.json
+++ b/src/vendor/mpr-plugins/split/plugin.json
@@ -6,10 +6,13 @@
   "description": "Split current tmux pane and attach to a session (vesicle beside).",
   "cli": {
     "command": "split",
-    "help": "maw split <target> [--pct N] [--vertical] [--no-attach]",
+    "help": "maw split <target> [--pct N] [--horizontal|--right|--vertical|--bottom] [--no-attach]",
     "flags": {
       "--pct": "number",
       "--vertical": "boolean",
+      "--bottom": "boolean",
+      "--horizontal": "boolean",
+      "--right": "boolean",
       "--no-attach": "boolean"
     }
   },

--- a/test/isolated/cmd-new-workspace.test.ts
+++ b/test/isolated/cmd-new-workspace.test.ts
@@ -477,6 +477,22 @@ describe("cmdNew workspace session factory", () => {
     }
   });
 
+  test("--split accepts explicit right/horizontal and bottom/vertical direction flags", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "maw-new-"));
+    try {
+      await cmdNew(["righty", "-p", dir, "--split", "--right", "--no-attach"]);
+      await cmdNew(["bottomy", "-p", dir, "--split", "--bottom", "--no-attach"]);
+
+      expect(splitWindowCalls.map(call => call.opts.direction)).toEqual(["horizontal", "vertical"]);
+      await expect(cmdNew(["conflict", "-p", dir, "--split", "--right", "--vertical", "--no-attach"]))
+        .rejects.toThrow("choose only one split direction");
+      await expect(cmdNew(["no-split", "-p", dir, "--right", "--no-attach"]))
+        .rejects.toThrow("split direction flags require --split");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("prints machine-readable payloads for new and existing lead panes", async () => {
     const dir = mkdtempSync(join(tmpdir(), "maw-new-"));
     const lines: string[] = [];

--- a/test/isolated/tmux.test.ts
+++ b/test/isolated/tmux.test.ts
@@ -247,6 +247,16 @@ describe("Tmux", () => {
       })).resolves.toBe("%77\n");
       expect(commands[0]).toBe("tmux split-window -P -F '#{pane_id}' -c /tmp/work 'bun dev; exec zsh'");
     });
+
+    test("passes explicit split direction before cwd and command", async () => {
+      await t.splitWindow(undefined, {
+        direction: "horizontal",
+        cwd: "/tmp/work",
+        command: "zsh",
+        printFormat: "#{pane_id}",
+      });
+      expect(commands[0]).toBe("tmux split-window -P -F '#{pane_id}' -h -c /tmp/work zsh");
+    });
   });
 
   describe("selectPane", () => {

--- a/test/isolated/vendor-dispatch-extra-coverage.test.ts
+++ b/test/isolated/vendor-dispatch-extra-coverage.test.ts
@@ -271,10 +271,16 @@ describe("tag and split plugin dispatchers", () => {
 
     const res = await splitHandler(ctx("cli", ["mawjs", "--pct", "44", "--vertical", "--no-attach", "--claude-pane-policy", "background-tab"]));
     expect(res.ok).toBe(true);
-    expect(splitCalls).toEqual([{ target: "mawjs", opts: { pct: 44, vertical: true, noAttach: true, claudePanePolicy: "background-tab" } }]);
+    expect(splitCalls).toEqual([{ target: "mawjs", opts: { pct: 44, vertical: true, horizontal: undefined, noAttach: true, claudePanePolicy: "background-tab" } }]);
 
-    await splitHandler(ctx("api", { target: "api-split", pct: 60, vertical: false, noAttach: true, claudePanePolicy: "refuse" }));
-    expect(splitCalls.at(-1)).toEqual({ target: "api-split", opts: { pct: 60, vertical: false, noAttach: true, claudePanePolicy: "refuse" } });
+    await splitHandler(ctx("cli", ["righty", "--right"]));
+    expect(splitCalls.at(-1)).toEqual({
+      target: "righty",
+      opts: { pct: undefined, vertical: undefined, horizontal: true, noAttach: undefined, claudePanePolicy: undefined },
+    });
+
+    await splitHandler(ctx("api", { target: "api-split", pct: 60, vertical: false, horizontal: true, noAttach: true, claudePanePolicy: "refuse" }));
+    expect(splitCalls.at(-1)).toEqual({ target: "api-split", opts: { pct: 60, vertical: false, horizontal: true, noAttach: true, claudePanePolicy: "refuse" } });
   });
 
   test("split catch branch prefers captured logs over thrown message", async () => {

--- a/test/isolated/vendor-split-helpers-coverage.test.ts
+++ b/test/isolated/vendor-split-helpers-coverage.test.ts
@@ -164,7 +164,7 @@ for (const helper of helpers) {
       normalizeImpl = () => "";
 
       await expect(helper.cmdSplit("anything/.git/")).rejects.toThrow(
-        "usage: maw split <target> [--pct N] [--vertical] [--no-attach]",
+        "usage: maw split <target> [--pct N] [--horizontal|--right|--vertical|--bottom] [--no-attach]",
       );
 
       expect(stderr()).toContain("usage: maw split <target>");
@@ -207,6 +207,12 @@ for (const helper of helpers) {
       const escapedAnchor = "%a'b".replace(/'/g, "'\\''");
       expect(hostExecCalls).toEqual([`tmux split-window -t '${escapedAnchor}' -v -l 33% "bash"`]);
       expect(stdout()).toContain("split below — empty pane (33%) (anchored at %a'b)");
+    });
+
+    test("rejects conflicting split direction options", async () => {
+      await expect(helper.cmdSplit("alpha:2", { vertical: true, horizontal: true }))
+        .rejects.toThrow("choose only one split direction");
+      expect(hostExecCalls).toEqual([]);
     });
 
     test("resolves bare targets to their window index and falls back to window zero", async () => {


### PR DESCRIPTION
## Summary
- Add explicit split orientation flags to `maw new --split`: `--right`/`--horizontal` for tmux `-h`, `--bottom`/`--vertical` for tmux `-v`.
- Preserve existing `maw new --split` behavior by omitting tmux orientation unless the user opts in.
- Add `maw split` aliases (`--right`, `--bottom`) plus conflict validation and API/dispatcher propagation for `horizontal`.

Closes #1937.

## Tests
- `bun test test/isolated/cmd-new-workspace.test.ts`
- `bun test test/isolated/tmux.test.ts`
- `bun test test/isolated/vendor-split-helpers-coverage.test.ts`
- `bun test test/isolated/vendor-dispatch-extra-coverage.test.ts`
- `bun run build`
- `git diff --check`

Written by [m5:mawjscodex] — an Oracle AI running gpt-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
