### PR TITLE
fix(ls): dedup --federation rows by (node, port) backend identity (#1941)

### DIFF
--- a/src/vendor/mpr-plugins/ls/internal/peer-call.ts
+++ b/src/vendor/mpr-plugins/ls/internal/peer-call.ts
@@ -333,11 +333,16 @@ export async function lsFederated(opts: LsFederatedOpts = {}): Promise<InvokeRes
     };
   }
 
+  const groups = groupNodesByBackend(nodes);
+  const reachableGroups = groups.filter((g) => !g.representative.error).length;
+  const dedupedSessions = groups.reduce((n, g) => n + (g.representative.error ? 0 : g.representative.sessions.length), 0);
+
   const lines: string[] = [
-    `\x1b[36m📡 fleet view · ${reachableNodes}/${nodes.length} node${nodes.length === 1 ? "" : "s"} reachable · ${totalSessions} session${totalSessions === 1 ? "" : "s"} total\x1b[0m`,
+    `\x1b[36m📡 fleet view · ${reachableGroups}/${groups.length} node${groups.length === 1 ? "" : "s"} reachable · ${dedupedSessions} session${dedupedSessions === 1 ? "" : "s"} total\x1b[0m`,
     "",
   ];
-  for (const node of nodes) {
+  for (const group of groups) {
+    const node = group.representative;
     const label = node.alias ?? node.node ?? node.url ?? "unknown";
     const location = node.local ? "local" : node.url ?? "peer";
     if (node.error) {
@@ -345,6 +350,12 @@ export async function lsFederated(opts: LsFederatedOpts = {}): Promise<InvokeRes
       continue;
     }
     lines.push(`  \x1b[34m●\x1b[0m \x1b[36m${label}\x1b[0m \x1b[90m(${location}) · ${node.sessions.length} session${node.sessions.length === 1 ? "" : "s"}\x1b[0m`);
+    if (group.members.length > 1) {
+      const aliases = group.members.map((m) => m.alias).filter((a): a is string => Boolean(a));
+      const urls = group.members.map((m) => m.url).filter((u): u is string => Boolean(u));
+      if (aliases.length > 1) lines.push(`     \x1b[90maliases: ${aliases.join(", ")}\x1b[0m`);
+      if (urls.length > 1) lines.push(`     \x1b[90murls:    ${urls.join(", ")}\x1b[0m`);
+    }
     for (const session of node.sessions) {
       const source = session.source && session.source !== "local" ? ` \x1b[90mvia ${session.source}\x1b[0m` : "";
       lines.push(`     \x1b[90m●\x1b[0m ${session.name}${source}`);
@@ -352,6 +363,46 @@ export async function lsFederated(opts: LsFederatedOpts = {}): Promise<InvokeRes
   }
   lines.push("", "\x1b[90m  → maw ls   list only local sessions (fast default)\x1b[0m");
   return { ok: true, output: lines.join("\n") };
+}
+
+interface NodeGroup {
+  representative: LsNodePayload;
+  members: LsNodePayload[];
+  key: string | null;
+}
+
+function extractBackendKey(node: LsNodePayload): string | null {
+  if (node.local) return null;
+  if (node.error) return null;
+  if (!node.node || !node.url) return null;
+  try {
+    const u = new URL(node.url);
+    const port = u.port || (u.protocol === "https:" ? "443" : "80");
+    return `${node.node}:${port}`;
+  } catch {
+    return null;
+  }
+}
+
+function groupNodesByBackend(nodes: LsNodePayload[]): NodeGroup[] {
+  const groups: NodeGroup[] = [];
+  const byKey = new Map<string, NodeGroup>();
+  for (const node of nodes) {
+    const key = extractBackendKey(node);
+    if (key === null) {
+      groups.push({ representative: node, members: [node], key: null });
+      continue;
+    }
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.members.push(node);
+    } else {
+      const group: NodeGroup = { representative: node, members: [node], key };
+      byKey.set(key, group);
+      groups.push(group);
+    }
+  }
+  return groups;
 }
 
 export const __private = { payloadFromData, sessionsFromPayload, responseError, sessionsFromFormattedOutput };

--- a/test/isolated/ls-peer-call-coverage.test.ts
+++ b/test/isolated/ls-peer-call-coverage.test.ts
@@ -154,6 +154,50 @@ describe("localLsPayload and lsFederated", () => {
       { name: "volt-oracle", windows: [{ index: 0, name: "claude", active: true }, { index: 1, name: "logs", active: false }] },
     ]);
   });
+
+  test("dedups two aliases pointing to the same backend (node+port) into one rendered row (#1941)", async () => {
+    writePeers({
+      "world-mawjs": { url: "http://world.wg:3462", node: "oracle-world" },
+      "oracle-world-mawjs": { url: "http://oracle-world.wg:3462", node: "oracle-world" },
+    });
+    curlFetchHandler = () => ({ ok: true, status: 200, data: [] });
+
+    const result = await lsFederated({ json: false, includeLocal: false });
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("fleet view · 1/1 node reachable · 0 sessions total");
+    expect(result.output).toContain("aliases: world-mawjs, oracle-world-mawjs");
+    expect(result.output).toContain("urls:    http://world.wg:3462, http://oracle-world.wg:3462");
+    expect((result.output ?? "").match(/oracle-world/g)?.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("keeps aliases on different ports as separate rows (no false dedup)", async () => {
+    writePeers({
+      "white-main": { url: "http://white.wg:3456", node: "white" },
+      "white-alpha": { url: "http://white.wg:3461", node: "white" },
+    });
+    curlFetchHandler = () => ({ ok: true, status: 200, data: [] });
+
+    const result = await lsFederated({ json: false, includeLocal: false });
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("fleet view · 2/2 nodes reachable");
+    expect(result.output).not.toContain("aliases:");
+  });
+
+  test("does not dedup errored peers (no handshake identity available)", async () => {
+    writePeers({
+      "down-a": { url: "http://down.local:3462", node: "down" },
+      "down-b": { url: "http://down.local:3462", node: "down" },
+    });
+    curlFetchHandler = () => ({ ok: false, status: 0, data: null });
+
+    const result = await lsFederated({ json: false, includeLocal: false });
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("fleet view · 0/2 nodes reachable");
+    expect(result.output).not.toContain("aliases:");
+  });
 });
 
 


### PR DESCRIPTION
## Summary

Fixes #1941 — `maw ls --federation` previously rendered the same backend twice when two peer aliases pointed at the same `(node, port)` via different URL hostnames.

## Before (repro from issue)

```
● oracle-world (http://world.wg:3462)         · 0 sessions
● oracle-world (http://oracle-world.wg:3462)  · 0 sessions
```

## After

```
● world-mawjs (http://world.wg:3462) · 0 sessions
   aliases: world-mawjs, oracle-world-mawjs
   urls:    http://world.wg:3462, http://oracle-world.wg:3462
```

## Scope (intentionally narrow)

- **Display-only**: render path in `lsFederated` groups successful-handshake nodes by `(node, parsed_port)` before rendering. Local + errored nodes are never deduped (no handshake identity to key on).
- **JSON output unchanged** (`opts.json: true`) — keeps existing programmatic consumers stable. Issue says cosmetic display gap; this PR matches that scope.
- **Resolver semantics untouched** — disjoint from #1940 (alias resolver gap). No changes to `peer-resolve.ts`, `peers.json` schema, or alias lookup paths.

## Tests

3 new isolated tests in `test/isolated/ls-peer-call-coverage.test.ts`:

1. `dedups two aliases pointing to the same backend (node+port) into one rendered row (#1941)` — exact repro from the issue
2. `keeps aliases on different ports as separate rows (no false dedup)` — guardrail against over-dedup (e.g. white:3456 vs white:3461)
3. `does not dedup errored peers (no handshake identity available)` — guardrail for error rows

All 19 tests in the file pass (16 existing + 3 new).

## Test plan
- [ ] `bun test test/isolated/ls-peer-call-coverage.test.ts` — passes locally (verified 19/19)
- [ ] `maw ls --federation` on m5 — verify mawjs@oracle-world appears once with alias list
- [ ] `maw ls --federation --json` — verify nodes array unchanged (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)