### PR TITLE
fix(hey): resolve peer aliases as explicit federation targets (#1940)

### DIFF
--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -344,13 +344,30 @@ function rejectBareAmbiguous(query: string, candidates: string[]): never {
 function normalizeBareLocalResult(
   query: string,
   result: ReturnType<typeof resolveTarget>,
+  config: ReturnType<typeof loadConfig>,
 ): ReturnType<typeof resolveTarget> | null {
   if (!result) return null;
   if (result.type === "local" || result.type === "self-node") return result;
   // A bare query may discover a remote peer via config.agents/manifest. Do not
   // use that implicit remote route: #1572 makes bare names local-only so
-  // operators must spell cross-node delivery with `<node>:`.
+  // operators must spell cross-node delivery with `<node>:`. Peer aliases are
+  // the narrow exception: `maw peers add world-mawjs ...` should make
+  // `maw hey world-mawjs ...` usable (#1940).
+  if (result.type === "peer" && isConfiguredPeerAlias(query, config)) return result;
   return null;
+}
+
+function isConfiguredPeerAlias(query: string, config: ReturnType<typeof loadConfig>): boolean {
+  if (!isBareLocalHeyTarget(query)) return false;
+  const peer = (config.namedPeers ?? []).find((p: any) => p?.name === query);
+  if (peer && (typeof (peer as any).node === "string" || typeof (peer as any).identity?.node === "string")) return true;
+  try {
+    const { loadPeers } = require("../../lib/peers/store");
+    const stored = loadPeers().peers?.[query];
+    return Boolean(stored && (typeof stored.node === "string" || typeof stored.identity?.node === "string"));
+  } catch {
+    return false;
+  }
 }
 
 function assertBareLocalTarget(
@@ -361,7 +378,7 @@ function assertBareLocalTarget(
   if (!isBareLocalHeyTarget(query)) return null;
 
   try {
-    const localResult = normalizeBareLocalResult(query, resolveTarget(query, config, sessions));
+    const localResult = normalizeBareLocalResult(query, resolveTarget(query, config, sessions), config);
     if (localResult) return localResult;
   } catch (e) {
     if (e instanceof AmbiguousMatchError) {

--- a/src/core/routing.ts
+++ b/src/core/routing.ts
@@ -5,7 +5,8 @@
  *   1. Local findWindow → { type: 'local' }
  *   2. Node:prefix → namedPeers → { type: 'peer' } or { type: 'self-node' }
  *   3. Agents map → peer URL → { type: 'peer' } (skip if self-node)
- *   4. null (caller handles peer discovery fallback separately — it's async/network)
+ *   4. Peer alias → peers.json node/identity → { type: 'peer' }
+ *   5. null (caller handles peer discovery fallback separately — it's async/network)
  *
  * Sub-PR 3 of #841 — manifest as primary lookup
  * ─────────────────────────────────────────────
@@ -38,6 +39,7 @@ import { findWindow, type Session } from "./runtime/find-window";
 import type { MawConfig } from "../config";
 import { resolveFleetSession } from "../commands/shared/wake";
 import { loadManifestCached, type OracleManifestEntry } from "../lib/oracle-manifest";
+import { loadPeers, type Peer } from "../lib/peers/store";
 
 export type { Session };
 
@@ -50,7 +52,7 @@ export type ResolveResult =
 
 /**
  * Resolve a query to a local target, remote peer, or null.
- * Pure + sync — no network calls, no side effects. Testable without mocks.
+ * Sync and read-only — no network calls. Testable without mocks.
  */
 export function resolveTarget(
   query: string,
@@ -172,8 +174,70 @@ export function resolveTarget(
     return { type: "error", reason: "no_peer_url", detail: `'${query}' mapped to node '${agentNode}' but no URL found`, hint: `add ${agentNode} to maw.config.json namedPeers` };
   }
 
+  // --- Step 3c: peer alias (e.g. `maw hey world-mawjs`) ---
+  // Peers added through `maw peers add <alias> <url> --node <node>` live in
+  // peers.json, not necessarily in config.namedPeers. A bare alias should be
+  // a usable federation target: resolve the backend node + default oracle and
+  // route as if the user typed `<node>:<oracle>` (#1940).
+  const peerAlias = findPeerAliasRoute(query, config);
+  if (peerAlias) return peerAlias;
+
   // --- Step 4: Not resolved (caller handles peer discovery fallback) ---
-  return { type: "error", reason: "not_found", detail: `'${query}' not in local sessions or agents map`, hint: "check: maw ls" };
+  return { type: "error", reason: "not_found", detail: `'${query}' not in local sessions, agents map, or peer aliases`, hint: "check: maw ls" };
+}
+
+
+function findPeerAliasRoute(query: string, config: MawConfig): ResolveResult {
+  if (!query || query.includes(":") || query.includes("/")) return null;
+
+  const configured = config.namedPeers?.find((p) => p.name === query) as (PeerConfigLike | undefined);
+  if (configured?.url) {
+    const node = configured.node || configured.identity?.node;
+    const target = defaultPeerOracle(query, node, configured.identity?.oracle, config);
+    if (node && target) return { type: "peer", peerUrl: configured.url, target, node };
+  }
+
+  const stored = readStoredPeer(query);
+  if (!stored?.url) return null;
+  const node = stored.node || stored.identity?.node;
+  const target = defaultPeerOracle(query, node, stored.identity?.oracle, config);
+  if (!node || !target) return null;
+  return { type: "peer", peerUrl: stored.url, target, node };
+}
+
+type PeerConfigLike = {
+  name: string;
+  url: string;
+  node?: string | null;
+  identity?: { oracle?: string; node?: string };
+};
+
+function readStoredPeer(alias: string): Peer | null {
+  try {
+    return loadPeers().peers[alias] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function defaultPeerOracle(alias: string, node: string | null | undefined, identityOracle: string | undefined, config: MawConfig): string | null {
+  if (identityOracle?.trim()) return identityOracle.trim();
+
+  const agentsForNode = Object.entries(config.agents ?? {})
+    .filter(([, agentNode]) => node && agentNode === node)
+    .map(([agent]) => agent);
+  if (agentsForNode.length === 1) return agentsForNode[0];
+
+  const aliasLower = alias.toLowerCase();
+  const aliasMatched = agentsForNode.find((agent) => {
+    const a = agent.toLowerCase();
+    return aliasLower === a || aliasLower.endsWith(`-${a}`) || aliasLower.includes(a);
+  });
+  if (aliasMatched) return aliasMatched;
+
+  // maw-js federation listeners default to the mawjs oracle when older peers
+  // have node but not /api/identity yet. This matches ADR family-default use.
+  return "mawjs";
 }
 
 /** Find a peer URL by node name from namedPeers or legacy peers[] */

--- a/test/comm-send-cmdsend-coverage.test.ts
+++ b/test/comm-send-cmdsend-coverage.test.ts
@@ -699,6 +699,23 @@ describe("cmdSend — bare-name, wake, and safety gates", () => {
     expect(errs.join("\n")).toContain("not found locally");
   });
 
+  test("bare peer aliases are allowed as explicit federation targets (#1940)", async () => {
+    config.namedPeers = [{
+      name: "world-mawjs",
+      url: "http://oracle-world.wg:3462",
+      node: "oracle-world",
+      identity: { oracle: "mawjs", node: "oracle-world" },
+    }];
+    resolveTargetReturn = { type: "peer", target: "mawjs", node: "oracle-world", peerUrl: "http://oracle-world.wg:3462" };
+    curlFetchHandler = () => ({ ok: true, status: 200, data: { ok: true, delivered: true, target: "mawjs" } });
+
+    await runCmd(() => cmdSend("world-mawjs", "hello"));
+
+    expect(exitCode).toBeUndefined();
+    expect(curlFetchCalls.map((c) => c.url)).toEqual(["http://oracle-world.wg:3462/api/send"]);
+    expect(JSON.parse(curlFetchCalls[0].options.body)).toMatchObject({ target: "mawjs" });
+  });
+
   test("bare target rejects ambiguous local candidates with candidate list", async () => {
     resolveTargetError = new _rFindWindow.AmbiguousMatchError("oracle", ["47-mawjs:oracle", "54-mawjs:oracle"]);
 

--- a/test/routing.test.ts
+++ b/test/routing.test.ts
@@ -3,10 +3,13 @@
  * Test cases designed by oracle-world:mawjs, implemented by white:mawjs-oracle.
  * See: #201
  */
-import { describe, test, expect } from "bun:test";
+import { afterEach, describe, test, expect } from "bun:test";
 import { resolveTarget } from "../src/core/routing";
 import type { Session } from "../src/core/runtime/find-window";
 import type { MawConfig } from "../src/config";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
 
 // --- Fixtures ---
 
@@ -15,6 +18,21 @@ const SESSIONS: Session[] = [
   { name: "13-mother", windows: [{ index: 1, name: "mother-oracle", active: true }] },
   { name: "01-pulse", windows: [{ index: 1, name: "pulse-oracle", active: true }] },
 ];
+
+const ORIGINAL_PEERS_FILE = process.env.PEERS_FILE;
+
+afterEach(() => {
+  if (ORIGINAL_PEERS_FILE === undefined) delete process.env.PEERS_FILE;
+  else process.env.PEERS_FILE = ORIGINAL_PEERS_FILE;
+});
+
+function withPeersFile(peers: Record<string, unknown>): string {
+  const dir = mkdtempSync(join(tmpdir(), "maw-routing-peers-"));
+  const file = join(dir, "peers.json");
+  writeFileSync(file, JSON.stringify({ version: 1, peers }), "utf-8");
+  process.env.PEERS_FILE = file;
+  return dir;
+}
 
 const BASE_CONFIG: MawConfig = {
   host: "local",
@@ -156,6 +174,52 @@ describe("resolveTarget", () => {
     const config = { ...BASE_CONFIG, namedPeers: [], peers: [] };
     const r = resolveTarget("homekeeper", config, SESSIONS);
     expect(r).toMatchObject({ type: "error", reason: "no_peer_url" });
+  });
+
+
+  test("bare peer alias routes to the peer identity oracle (#1940)", () => {
+    const dir = withPeersFile({
+      "world-mawjs": {
+        url: "http://oracle-world.wg:3462",
+        node: "oracle-world",
+        addedAt: "2026-05-30T00:00:00.000Z",
+        lastSeen: "2026-05-30T00:00:00.000Z",
+        identity: { oracle: "mawjs", node: "oracle-world" },
+      },
+    });
+    try {
+      const r = resolveTarget("world-mawjs", { ...BASE_CONFIG, agents: {}, namedPeers: [] }, []);
+      expect(r).toEqual({
+        type: "peer",
+        peerUrl: "http://oracle-world.wg:3462",
+        target: "mawjs",
+        node: "oracle-world",
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("bare peer alias can infer a single configured agent for that node (#1940)", () => {
+    const dir = withPeersFile({
+      alpha: {
+        url: "http://white.wg:3461",
+        node: "white",
+        addedAt: "2026-05-30T00:00:00.000Z",
+        lastSeen: "2026-05-30T00:00:00.000Z",
+      },
+    });
+    try {
+      const r = resolveTarget("alpha", { ...BASE_CONFIG, agents: { volt: "white" }, namedPeers: [] }, []);
+      expect(r).toEqual({
+        type: "peer",
+        peerUrl: "http://white.wg:3461",
+        target: "volt",
+        node: "white",
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   // #15: EMPTY QUERY

--- a/test/spec/routing.fixtures.json
+++ b/test/spec/routing.fixtures.json
@@ -98,7 +98,7 @@
       "name": "query with slash is not node routing",
       "query": "01-local/worktree",
       "sessions": [],
-      "expected": { "type": "error", "reason": "not_found", "detail": "'01-local/worktree' not in local sessions or agents map", "hint": "check: maw ls" }
+      "expected": { "type": "error", "reason": "not_found", "detail": "'01-local/worktree' not in local sessions, agents map, or peer aliases", "hint": "check: maw ls" }
     },
     {
       "name": "legacy peers array can provide node url",


### PR DESCRIPTION
Closes #1940.

## Summary
- add peer-alias lookup after local/agent routing so `maw hey <alias>` can resolve configured `peers.<alias>.node` entries
- preserve the bare-name local-only guard for ordinary remote oracle names while allowing explicit configured peer aliases
- update portable routing fixture text for the new peer-alias miss surface

## Tests
- `bun test test/spec/routing.fixtures.test.ts test/routing.test.ts test/comm-send-cmdsend-coverage.test.ts`
- `bun run build`

Written by [m5:mawjscodex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
