### PR TITLE
fix(maw): port automation diagnostics to alpha

### DIFF
--- a/src/cli/auto-restore.ts
+++ b/src/cli/auto-restore.ts
@@ -2,14 +2,15 @@
  * Auto-restore: if no live tmux sessions exist and a recent (<24h) snapshot
  * is on disk, prompt the user to revive every session in the snapshot.
  *
- * Skipped for help-style invocations (--help / -h) so `maw --help` never
- * stalls waiting for tty input.
+ * Skipped for help-style invocations (--help / -h), non-interactive shells,
+ * and diagnostic commands so automation output stays machine-readable.
  *
  * Exceptions are intentionally swallowed — auto-restore is best-effort
  * UX sugar, never load-bearing for the actual command the user typed.
  */
 export async function maybeAutoRestore(cmd: string | undefined): Promise<void> {
   if (!cmd || cmd === "--help" || cmd === "-h") return;
+  if (shouldSkipAutoRestore(cmd)) return;
   try {
     const { listSessions } = await import("../sdk");
     const live = await listSessions().catch(() => [] as any[]);
@@ -47,4 +48,16 @@ export async function maybeAutoRestore(cmd: string | undefined): Promise<void> {
     }
     console.log("");
   } catch {}
+}
+
+function shouldSkipAutoRestore(cmd: string): boolean {
+  if (isTruthyEnv(process.env.MAW_NO_PROMPT) || isTruthyEnv(process.env.CI)) return true;
+  if (!process.stdin.isTTY || !process.stdout.isTTY) return true;
+  return new Set(["capture", "locate", "messages", "oracle", "peek"]).has(cmd);
+}
+
+function isTruthyEnv(value: string | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
 }

--- a/src/cli/verbosity.ts
+++ b/src/cli/verbosity.ts
@@ -71,7 +71,7 @@ export function isQuiet(): boolean {
   // forms too — `maw oracle scan --help` etc.
   if (
     process.argv.some(
-      a => a === "--help" || a === "-h" || a === "--version" || a === "-v",
+      a => a === "--help" || a === "-h" || a === "--version" || a === "-v" || a === "--json",
     )
   ) return true;
   // FIX-A — selected verbs (ls, a, attach, wake, activity) don't need

--- a/src/config/ghq-root.ts
+++ b/src/config/ghq-root.ts
@@ -82,7 +82,10 @@ export function getGhqRoot(): string {
 
   // (3) shell out to ghq
   try {
-    const out = execSync("ghq root", { encoding: "utf-8" }).trim();
+    const out = execSync("ghq root", {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
     if (out.length > 0) {
       _cached = normalizeBare(out);
       return _cached;

--- a/src/core/repo-discovery/ghq-discovery.ts
+++ b/src/core/repo-discovery/ghq-discovery.ts
@@ -40,7 +40,10 @@ export const GhqDiscovery: RepoDiscovery = {
 
   listSync(): string[] {
     try {
-      return normalize(execSync("ghq list --full-path", { encoding: "utf-8" }));
+      return normalize(execSync("ghq list --full-path", {
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "pipe"],
+      }));
     } catch {
       return [];
     }

--- a/src/core/transport/tmux-class.ts
+++ b/src/core/transport/tmux-class.ts
@@ -50,7 +50,9 @@ export class Tmux {
   /** Base runner — executes `tmux [-S socket] <subcommand> [args...]` via hostExec. */
   async run(subcommand: string, ...args: (string | number)[]): Promise<string> {
     const socketFlag = this.socket ? `-S ${q(this.socket)} ` : "";
-    const cmd = `tmux ${socketFlag}${subcommand} ${args.map(q).join(" ")}`;
+    const needsTermFallback = !process.env.TERM && process.env.MAW_TEST_MODE !== "1";
+    const termPrefix = needsTermFallback ? "TERM=xterm " : "";
+    const cmd = `${termPrefix}tmux ${socketFlag}${subcommand} ${args.map(q).join(" ")}`;
     return hostExec(cmd, this.host);
   }
 

--- a/src/vendor/mpr-plugins/locate/impl.ts
+++ b/src/vendor/mpr-plugins/locate/impl.ts
@@ -19,6 +19,7 @@ import { loadFleetEntries, type FleetEntry } from "maw-js/commands/shared/fleet-
 import { loadConfig } from "maw-js/config";
 import { resolveSessionTarget } from "maw-js/core/matcher/resolve-target";
 import { UserError } from "maw-js/core/util/user-error";
+import { loadManifestCached, type OracleManifestEntry } from "maw-js/lib/oracle-manifest";
 import { fetchPeerPayload, type PeerSession } from "../ls/internal/peer-call";
 import { resolveAllPeers } from "../ls/internal/peer-resolve";
 
@@ -37,6 +38,7 @@ interface LocateResult {
   federationNode: string | null;
   inAgentsConfig: boolean;
   federation: LocateFederationHit[];
+  manifestEntry: OracleManifestEntry | null;
 }
 
 interface LocateFederationHit {
@@ -109,6 +111,19 @@ function findFleetConfigPath(oracle: string, sessionName: string | null): string
   return null;
 }
 
+function lookupManifestEntry(oracle: string): OracleManifestEntry | undefined {
+  try {
+    const manifest = loadManifestCached();
+    const stripped = oracle.replace(/-oracle$/, "");
+    return (
+      manifest.find((entry) => entry.name === oracle) ||
+      (stripped !== oracle ? manifest.find((entry) => entry.name === stripped) : undefined)
+    );
+  } catch {
+    return undefined;
+  }
+}
+
 async function gatherInfo(oracle: string, opts: { scanFederation?: boolean } = {}): Promise<LocateResult> {
   // ghq repo path — try `<name>-oracle` suffix first (canonical), then bare name
   const repoPath =
@@ -136,24 +151,34 @@ async function gatherInfo(oracle: string, opts: { scanFederation?: boolean } = {
   // shadow legacy entries and report the exact source path.
   const fleetConfigPath = findFleetConfigPath(oracle, sessionName);
 
+  // Manifest fallback — includes oracles.json entries that do not have a
+  // local repo, tmux session, or fleet config yet. This keeps `maw locate`
+  // aligned with `maw oracle list` for registry-only oracles.
+  const manifestEntry = lookupManifestEntry(oracle);
+
   // Federation — config.agents map + node
   const config = loadConfig();
   const agents = config.agents ?? {};
   const inAgentsConfig = oracle in agents;
-  const federationNode = inAgentsConfig ? agents[oracle]! : (config.node ?? null);
+  const federationNode = inAgentsConfig
+    ? agents[oracle]!
+    : sessionName
+      ? (config.node ?? "local")
+      : (manifestEntry?.node ?? config.node ?? null);
 
   const federation = opts.scanFederation === false ? [] : await findFederationHits(oracle);
 
   return {
     name: oracle,
-    repoPath,
-    hasPsi,
+    repoPath: repoPath ?? manifestEntry?.localPath ?? null,
+    hasPsi: repoPath ? hasPsi : (manifestEntry?.hasPsi ?? false),
     sessionName,
     windowCount,
     fleetConfigPath,
     federationNode,
     inAgentsConfig,
     federation,
+    manifestEntry: manifestEntry ?? null,
   };
 }
 
@@ -167,7 +192,7 @@ export async function cmdLocate(oracle: string | undefined, opts: LocateOpts = {
   const info = await gatherInfo(oracle, { scanFederation: !opts.path });
 
   // Nothing found at all → not-found error (mirrors alpha.75 oracle-about fix)
-  if (!info.repoPath && !info.sessionName && !info.fleetConfigPath && info.federation.length === 0) {
+  if (!info.repoPath && !info.sessionName && !info.fleetConfigPath && info.federation.length === 0 && !info.manifestEntry) {
     throw new UserError(`no oracle named '${oracle}' — try: maw oracle ls`);
   }
 
@@ -200,8 +225,23 @@ export async function cmdLocate(oracle: string | undefined, opts: LocateOpts = {
   if (info.fleetConfigPath) {
     console.log(`   fleet:    ${info.fleetConfigPath}`);
   }
+  if (info.manifestEntry) {
+    console.log(`   source:   ${info.manifestEntry.sources.join(", ")}`);
+    if (info.manifestEntry.repo && !info.repoPath) {
+      console.log(`   repo:     ${info.manifestEntry.repo}`);
+    }
+    if (info.manifestEntry.hasFleetConfig && !info.fleetConfigPath) {
+      console.log("   fleet:    known (manifest)");
+    }
+  }
   if (info.federationNode) {
-    const suffix = info.inAgentsConfig ? " (from config.agents)" : " (this node)";
+    const suffix = info.inAgentsConfig
+      ? " (from config.agents)"
+      : info.sessionName
+        ? " (this node)"
+        : info.manifestEntry?.node
+          ? " (from manifest)"
+          : " (this node)";
     console.log(`   node:     ${info.federationNode}${suffix}`);
   }
   for (const hit of info.federation) {

--- a/test/cli/verbosity.test.ts
+++ b/test/cli/verbosity.test.ts
@@ -102,6 +102,11 @@ describe("verbosity", () => {
       expect(isQuiet()).toBe(true);
     });
 
+    test("any --json invocation suppresses bootstrap chatter", () => {
+      process.argv = ["bun", "/path/to/cli.ts", "fleet", "status", "--json"];
+      expect(isQuiet()).toBe(true);
+    });
+
     test("`maw bud --as ls` → NOT quiet (positional check at argv[2], not .some)", () => {
       // Regression guard: an `--as ls` value buried later in argv must not
       // false-positive into the suppression path.

--- a/test/isolated/auto-restore-transport-coverage.test.ts
+++ b/test/isolated/auto-restore-transport-coverage.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 const sdkPath = import.meta.resolve("../../src/sdk/index.ts");
 const snapshotPath = import.meta.resolve("../../src/core/fleet/snapshot.ts");
@@ -60,6 +60,8 @@ const { cmdTransportStatus } = await import("../../src/commands/shared/transport
 
 const originalLog = console.log;
 const originalWrite = process.stdout.write;
+const originalStdinIsTTY = process.stdin.isTTY;
+const originalStdoutIsTTY = process.stdout.isTTY;
 
 beforeEach(() => {
   sessions = [];
@@ -77,6 +79,19 @@ beforeEach(() => {
     writes.push(String(chunk));
     return true;
   }) as typeof process.stdout.write;
+  delete process.env.MAW_NO_PROMPT;
+  delete process.env.CI;
+  Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+  Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
+});
+
+afterEach(() => {
+  console.log = originalLog;
+  process.stdout.write = originalWrite;
+  delete process.env.MAW_NO_PROMPT;
+  delete process.env.CI;
+  Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: originalStdinIsTTY });
+  Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: originalStdoutIsTTY });
 });
 
 describe("auto restore startup helper", () => {
@@ -98,6 +113,27 @@ describe("auto restore startup helper", () => {
     snapshot = { timestamp: new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString(), sessions: [{ name: "01-old" }] };
     await maybeAutoRestore("wake");
     expect(wakeCalls).toEqual([]);
+  });
+
+  test("skips diagnostics, env-disabled prompts, CI, and non-tty automation", async () => {
+    snapshot = { timestamp: new Date(Date.now() - 10 * 60_000).toISOString(), sessions: [{ name: "01-alpha" }] };
+
+    await maybeAutoRestore("locate");
+    expect(writes.join("")).not.toContain("Restore all?");
+
+    process.env.MAW_NO_PROMPT = "1";
+    await maybeAutoRestore("wake");
+    expect(writes.join("")).not.toContain("Restore all?");
+    delete process.env.MAW_NO_PROMPT;
+
+    process.env.CI = "true";
+    await maybeAutoRestore("wake");
+    expect(writes.join("")).not.toContain("Restore all?");
+    delete process.env.CI;
+
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: false });
+    await maybeAutoRestore("wake");
+    expect(writes.join("")).not.toContain("Restore all?");
   });
 
   test("swallows list/session errors and handles declined restore prompts", async () => {

--- a/test/isolated/locate-impl-coverage.test.ts
+++ b/test/isolated/locate-impl-coverage.test.ts
@@ -10,6 +10,7 @@ let config: { agents?: Record<string, string>; node?: string } = { node: "local-
 let listSessionsThrows = false;
 let curlFetchCalls: Array<{ url: string; options: any }> = [];
 let curlFetchQueue: any[] = [];
+let manifestEntries: any[] = [];
 let originalPeersFile: string | undefined;
 
 const fleetDir = join(tmpdir(), `maw-locate-fleet-${process.pid}`);
@@ -50,6 +51,9 @@ mock.module("maw-js/config", () => ({
 mock.module("maw-js/core/matcher/resolve-target", () => ({
   resolveSessionTarget: () => resolved,
 }));
+mock.module("maw-js/lib/oracle-manifest", () => ({
+  loadManifestCached: () => manifestEntries,
+}));
 
 const { cmdLocate } = await import("../../src/vendor/mpr-plugins/locate/impl.ts?locate-impl-coverage");
 
@@ -86,6 +90,7 @@ describe("locate command implementation coverage", () => {
     listSessionsThrows = false;
     curlFetchCalls = [];
     curlFetchQueue = [];
+    manifestEntries = [];
   });
 
   afterEach(() => {
@@ -218,5 +223,59 @@ describe("locate command implementation coverage", () => {
     expect(text).toContain(`fleet:    ${join(fleetDir, "nodeonly-oracle.json")}`);
     expect(text).toContain("node:     white (this node)");
     expect(text).not.toContain("repo:");
+  });
+
+  test("falls back to manifest-only oracle records and labels manifest node", async () => {
+    ghqResults = [null, null];
+    manifestEntries = [{
+      name: "mira",
+      sources: ["oracles-json"],
+      node: "sgp1",
+      repo: "Soul-Brews-Studio/mira-oracle",
+      localPath: "/opt/Code/github.com/Soul-Brews-Studio/mira-oracle",
+      hasPsi: true,
+      hasFleetConfig: true,
+      isLive: false,
+    }];
+
+    const output = await capture(() => cmdLocate("mira", { json: true }));
+    const parsed = JSON.parse(output.logs.join("\n"));
+
+    expect(parsed).toMatchObject({
+      name: "mira",
+      repoPath: "/opt/Code/github.com/Soul-Brews-Studio/mira-oracle",
+      hasPsi: true,
+      federationNode: "sgp1",
+      manifestEntry: {
+        name: "mira",
+        node: "sgp1",
+      },
+    });
+
+    const human = await capture(() => cmdLocate("mira", {}));
+    const text = human.logs.join("\n");
+    expect(text).toContain("source:   oracles-json");
+    expect(text).toContain("node:     sgp1 (from manifest)");
+    expect(text).toContain("fleet:    known (manifest)");
+  });
+
+  test("prefers a live local session node over stale manifest node metadata", async () => {
+    ghqResults = [null, null];
+    sessions = [{ name: "77-mawjs", windows: [{ name: "main" }] }];
+    resolved = { kind: "exact", match: sessions[0] };
+    config = { node: "m5" };
+    manifestEntries = [{
+      name: "mawjs",
+      sources: ["oracles-json"],
+      node: "stale-remote",
+      isLive: false,
+    }];
+
+    const output = await capture(() => cmdLocate("mawjs", {}));
+    const text = output.logs.join("\n");
+
+    expect(text).toContain("session:  77-mawjs (1 window)");
+    expect(text).toContain("node:     m5 (this node)");
+    expect(text).not.toContain("stale-remote");
   });
 });


### PR DESCRIPTION
## Summary

Ports the still-wanted automation/diagnostic fixes from stale main-targeted PR #1883 onto current `alpha`, without regressing newer alpha federation locate behavior.

- skip auto-restore prompts for noninteractive/CI/diagnostic commands
- quiet bootstrap chatter for all `--json` invocations
- contain missing-`ghq` shell noise in sync ghq fallbacks
- inject `TERM=xterm` for non-tty tmux automation paths
- add manifest fallback to `maw locate` while preserving federation hits
- prefer live local session node over stale manifest node metadata

Supersedes #1883 for the alpha lane.

## Validation

- `bun test test/isolated/locate-impl-coverage.test.ts test/isolated/auto-restore-transport-coverage.test.ts test/cli/verbosity.test.ts`
- `bun test test/isolated/tmux.test.ts test/isolated/tmux-class-coverage.test.ts test/isolated/tmux-class-eleventh-pass-coverage.test.ts test/isolated/tmux-class-fourteenth-pass-coverage.test.ts`
- `bun run build`
- `./dist/maw locate mawjs --json | python3 -m json.tool`

Written by [m5:mawjscodex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
