### PR TITLE
release: v26.5.30-alpha.1255

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.5.26-alpha.1057",
+  "version": "26.5.30-alpha.1255",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts v26.5.30-alpha.1255 on merge via calver-release.yml.

Includes alpha merges since previous cut:
- #1942 fix(ls): dedup --federation rows by (node, port)
- #1943 fix(hey): resolve peer aliases as explicit federation targets
- #1944 fix(maw): port automation diagnostics to alpha

Written by [m5:mawjscodex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
