### PR TITLE
feat(user-setup): audit Claude project dirs

### DIFF
--- a/src/vendor/mpr-plugins/user-setup/impl.ts
+++ b/src/vendor/mpr-plugins/user-setup/impl.ts
@@ -1,0 +1,335 @@
+import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from "fs";
+import { homedir } from "os";
+import { basename, dirname, join, resolve, sep } from "path";
+import { execSync } from "child_process";
+
+export const USER_SETUP_AUDIT_USAGE = "usage: maw user-setup projects audit --json";
+
+export type PathConfidence = "exact" | "probable" | "ambiguous" | "unknown";
+
+export interface PathFinding {
+  encoded: string;
+  inferred?: string;
+  confidence: PathConfidence;
+  evidence: string[];
+}
+
+export interface RepoFinding {
+  owner?: string;
+  name?: string;
+  remote?: string;
+}
+
+export interface WorktreeFinding {
+  detected: boolean;
+  alive?: boolean;
+  evidence: string[];
+}
+
+export interface FileFinding {
+  name: string;
+  sizeBytes: number;
+  lastModified: string | null;
+}
+
+export interface UserSetupAuditEntry {
+  encoded: string;
+  path: PathFinding;
+  sizeBytes: number;
+  sessionCount: number;
+  lastModified: string | null;
+  sourceExists?: boolean;
+  repo?: RepoFinding;
+  worktree?: WorktreeFinding;
+  largestFiles: FileFinding[];
+  warnings: string[];
+}
+
+export interface UserSetupAuditResult {
+  root: string;
+  generatedAt: string;
+  projectCount: number;
+  totalSizeBytes: number;
+  entries: UserSetupAuditEntry[];
+  warnings: string[];
+}
+
+type DirentLike = { name: string; isDirectory(): boolean; isFile(): boolean; isSymbolicLink?(): boolean };
+type StatLike = { size: number; mtimeMs: number; isDirectory(): boolean; isFile(): boolean; isSymbolicLink?(): boolean };
+type ExecSyncString = (command: string, options?: { encoding: BufferEncoding; timeout?: number; maxBuffer?: number }) => string;
+
+export interface UserSetupAuditDeps {
+  now?: () => Date;
+  homeDir?: () => string;
+  cwd?: () => string;
+  existsSync?: (path: string) => boolean;
+  statSync?: (path: string) => StatLike;
+  readdirSync?: (path: string, options?: { withFileTypes?: boolean }) => string[] | DirentLike[];
+  readFileSync?: (path: string, encoding: BufferEncoding) => string;
+  realpathSync?: (path: string) => string;
+  execSync?: ExecSyncString;
+  maxLargestFiles?: number;
+  projectsRoot?: string;
+}
+
+interface ScanSummary {
+  sizeBytes: number;
+  lastModifiedMs: number | null;
+  sessionCount: number;
+  largestFiles: FileFinding[];
+  warnings: string[];
+}
+
+const DEFAULT_LARGEST_FILES = 5;
+
+function depsWithDefaults(deps: UserSetupAuditDeps): Required<Omit<UserSetupAuditDeps, "projectsRoot">> & { projectsRoot?: string } {
+  return {
+    now: deps.now ?? (() => new Date()),
+    homeDir: deps.homeDir ?? homedir,
+    cwd: deps.cwd ?? (() => process.cwd()),
+    existsSync: deps.existsSync ?? existsSync,
+    statSync: deps.statSync ?? statSync,
+    readdirSync: deps.readdirSync ?? ((path, options) => readdirSync(path, options as any) as any),
+    readFileSync: deps.readFileSync ?? ((path, encoding) => readFileSync(path, encoding)),
+    realpathSync: deps.realpathSync ?? realpathSync,
+    execSync: deps.execSync ?? (execSync as ExecSyncString),
+    maxLargestFiles: deps.maxLargestFiles ?? DEFAULT_LARGEST_FILES,
+    projectsRoot: deps.projectsRoot,
+  };
+}
+
+function isoFromMs(ms: number | null): string | null {
+  return ms == null ? null : new Date(ms).toISOString();
+}
+
+function encodeClaudeProjectPath(path: string): string {
+  return resolve(path).replace(/^\//, "-").replace(/\//g, "-");
+}
+
+/** Claude's project-dir encoding is lossy for hyphenated path segments; never treat this reversal as exact by itself. */
+export function inferPathFromEncoded(encoded: string, deps: UserSetupAuditDeps = {}): PathFinding {
+  const d = depsWithDefaults(deps);
+  const evidence: string[] = [];
+  if (!encoded.startsWith("-")) {
+    return { encoded, confidence: "unknown", evidence: ["encoded-name-does-not-look-like-absolute-claude-project-dir"] };
+  }
+
+  const inferred = encoded.replace(/^-/, "/").replace(/-/g, "/");
+  evidence.push("dash-decoded-from-claude-project-dir");
+
+  let exists = false;
+  try { exists = d.existsSync(inferred); } catch { exists = false; }
+  if (exists) evidence.push("inferred-path-exists");
+
+  // Exact only when an independent runtime path re-encodes to this directory name.
+  // That avoids promoting lossy dash reversal to truth while allowing the active cwd
+  // to anchor confidence when it is the current project.
+  try {
+    const cwd = d.cwd();
+    if (cwd && encodeClaudeProjectPath(cwd) === encoded) {
+      evidence.push("current-working-directory-reencodes-to-project-dir");
+      return { encoded, inferred: resolve(cwd), confidence: "exact", evidence };
+    }
+  } catch { /* ignore cwd evidence failures */ }
+
+  return { encoded, inferred, confidence: exists ? "probable" : "ambiguous", evidence };
+}
+
+function isDirentDirectory(entry: DirentLike): boolean {
+  return entry.isDirectory() || Boolean(entry.isSymbolicLink?.());
+}
+
+function readDirents(path: string, deps: ReturnType<typeof depsWithDefaults>): DirentLike[] {
+  const entries = deps.readdirSync(path, { withFileTypes: true }) as Array<string | DirentLike>;
+  return entries.map((entry) => {
+    if (typeof entry !== "string") return entry;
+    const full = join(path, entry);
+    const st = deps.statSync(full);
+    return {
+      name: entry,
+      isDirectory: () => st.isDirectory(),
+      isFile: () => st.isFile(),
+      isSymbolicLink: () => Boolean(st.isSymbolicLink?.()),
+    };
+  });
+}
+
+function addLargest(largest: FileFinding[], file: FileFinding, max: number): void {
+  largest.push(file);
+  largest.sort((a, b) => b.sizeBytes - a.sizeBytes || a.name.localeCompare(b.name));
+  if (largest.length > max) largest.length = max;
+}
+
+function scanProjectDir(root: string, dirPath: string, deps: ReturnType<typeof depsWithDefaults>): ScanSummary {
+  const warnings: string[] = [];
+  const largestFiles: FileFinding[] = [];
+  let sizeBytes = 0;
+  let lastModifiedMs: number | null = null;
+  let sessionCount = 0;
+
+  function visit(path: string): void {
+    let st: StatLike;
+    try { st = deps.statSync(path); }
+    catch (e: unknown) {
+      warnings.push(`stat failed for ${path.slice(root.length + 1) || basename(path)}: ${e instanceof Error ? e.message : String(e)}`);
+      return;
+    }
+
+    lastModifiedMs = Math.max(lastModifiedMs ?? 0, st.mtimeMs || 0);
+    if (st.isFile()) {
+      sizeBytes += st.size || 0;
+      const rel = path.startsWith(root + sep) ? path.slice(root.length + 1) : basename(path);
+      if (rel.endsWith(".jsonl")) sessionCount += 1;
+      addLargest(largestFiles, { name: rel, sizeBytes: st.size || 0, lastModified: isoFromMs(st.mtimeMs || null) }, deps.maxLargestFiles);
+      return;
+    }
+    if (!st.isDirectory()) return;
+
+    let entries: DirentLike[];
+    try { entries = readDirents(path, deps); }
+    catch (e: unknown) {
+      warnings.push(`read failed for ${path.slice(root.length + 1) || basename(path)}: ${e instanceof Error ? e.message : String(e)}`);
+      return;
+    }
+    for (const entry of entries) visit(join(path, entry.name));
+  }
+
+  visit(dirPath);
+  return { sizeBytes, lastModifiedMs, sessionCount, largestFiles, warnings };
+}
+
+function normalizeRemote(remote: string): string {
+  return remote.trim()
+    .replace(/^(ssh:\/\/)?git@/, "")
+    .replace(/^https?:\/\//, "")
+    .replace(/:/, "/")
+    .replace(/\.git$/, "");
+}
+
+function parseRepo(remote: string): RepoFinding {
+  const normalized = normalizeRemote(remote);
+  const parts = normalized.split("/").filter(Boolean);
+  const githubIdx = parts.findIndex(p => p === "github.com");
+  const owner = githubIdx >= 0 ? parts[githubIdx + 1] : parts.at(-2);
+  const name = githubIdx >= 0 ? parts[githubIdx + 2] : parts.at(-1);
+  return { remote: normalized, ...(owner ? { owner } : {}), ...(name ? { name } : {}) };
+}
+
+function shellQuote(s: string): string {
+  return `'${s.replace(/'/g, `'"'"'`)}'`;
+}
+
+function detectRepo(path: PathFinding, deps: ReturnType<typeof depsWithDefaults>): RepoFinding | undefined {
+  if (!path.inferred || (path.confidence !== "exact" && path.confidence !== "probable")) return undefined;
+  try {
+    if (!deps.existsSync(path.inferred)) return undefined;
+    const remote = deps.execSync(`git -C ${shellQuote(path.inferred)} remote get-url origin 2>/dev/null`, {
+      encoding: "utf-8",
+      timeout: 1500,
+      maxBuffer: 64 * 1024,
+    }).trim();
+    return remote ? parseRepo(remote) : undefined;
+  } catch { return undefined; }
+}
+
+function detectWorktree(encoded: string, path: PathFinding, deps: ReturnType<typeof depsWithDefaults>): WorktreeFinding {
+  const evidence: string[] = [];
+  const candidates = [encoded, path.inferred ?? ""].filter(Boolean);
+  if (candidates.some(v => /(?:^|[\/.-])wt[-_]/i.test(v) || /[\/]agents[\/]/i.test(v) || /worktree/i.test(v))) {
+    evidence.push("path-shape-suggests-worktree");
+  }
+
+  let alive: boolean | undefined;
+  if (path.inferred && (path.confidence === "exact" || path.confidence === "probable")) {
+    try {
+      if (deps.existsSync(path.inferred)) {
+        const raw = deps.execSync(`git -C ${shellQuote(path.inferred)} worktree list --porcelain 2>/dev/null`, {
+          encoding: "utf-8",
+          timeout: 1500,
+          maxBuffer: 256 * 1024,
+        });
+        const realInferred = safeRealpath(path.inferred, deps);
+        const listed = raw.split("\n").some(line => {
+          if (!line.startsWith("worktree ")) return false;
+          const listedPath = line.slice("worktree ".length).trim();
+          return safeRealpath(listedPath, deps) === realInferred;
+        });
+        if (listed) {
+          alive = true;
+          evidence.push("git-worktree-list-confirms-path");
+        } else if (raw.trim()) {
+          alive = false;
+          evidence.push("git-worktree-list-did-not-include-path");
+        }
+      }
+    } catch { /* not a git worktree, or git unavailable */ }
+  }
+
+  return { detected: evidence.length > 0, ...(alive === undefined ? {} : { alive }), evidence };
+}
+
+function safeRealpath(path: string, deps: ReturnType<typeof depsWithDefaults>): string {
+  try { return deps.realpathSync(path); } catch { return resolve(path); }
+}
+
+export async function auditClaudeProjects(deps: UserSetupAuditDeps = {}): Promise<UserSetupAuditResult> {
+  const d = depsWithDefaults(deps);
+  const root = d.projectsRoot ?? process.env.MAW_CLAUDE_PROJECTS_DIR ?? join(d.homeDir(), ".claude", "projects");
+  const warnings: string[] = [];
+  const entries: UserSetupAuditEntry[] = [];
+
+  let projectDirs: DirentLike[];
+  try {
+    projectDirs = readDirents(root, d).filter(isDirentDirectory);
+  } catch (e: unknown) {
+    warnings.push(`cannot read Claude projects dir ${root}: ${e instanceof Error ? e.message : String(e)}`);
+    return {
+      root,
+      generatedAt: d.now().toISOString(),
+      projectCount: 0,
+      totalSizeBytes: 0,
+      entries: [],
+      warnings,
+    };
+  }
+
+  for (const dirent of projectDirs.sort((a, b) => a.name.localeCompare(b.name))) {
+    const encoded = dirent.name;
+    const dirPath = join(root, encoded);
+    const path = inferPathFromEncoded(encoded, d);
+    const scan = scanProjectDir(dirPath, dirPath, d);
+    const warningsForEntry = [...scan.warnings];
+    if (path.confidence === "ambiguous" || path.confidence === "unknown") warningsForEntry.push(`path confidence is ${path.confidence}`);
+    if (scan.sessionCount === 0) warningsForEntry.push("no JSONL sessions found");
+
+    let sourceExists: boolean | undefined;
+    if (path.inferred && (path.confidence === "exact" || path.confidence === "probable")) {
+      try { sourceExists = d.existsSync(path.inferred); } catch { sourceExists = false; }
+    }
+
+    const repo = detectRepo(path, d);
+    const worktree = detectWorktree(encoded, path, d);
+    entries.push({
+      encoded,
+      path,
+      sizeBytes: scan.sizeBytes,
+      sessionCount: scan.sessionCount,
+      lastModified: isoFromMs(scan.lastModifiedMs),
+      ...(sourceExists === undefined ? {} : { sourceExists }),
+      ...(repo ? { repo } : {}),
+      worktree,
+      largestFiles: scan.largestFiles,
+      warnings: warningsForEntry,
+    });
+  }
+
+  const totalSizeBytes = entries.reduce((sum, entry) => sum + entry.sizeBytes, 0);
+  return {
+    root,
+    generatedAt: d.now().toISOString(),
+    projectCount: entries.length,
+    totalSizeBytes,
+    entries,
+    warnings,
+  };
+}

--- a/src/vendor/mpr-plugins/user-setup/index.ts
+++ b/src/vendor/mpr-plugins/user-setup/index.ts
@@ -1,0 +1,36 @@
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import { parseFlags } from "maw-js/cli/parse-args";
+import { auditClaudeProjects, USER_SETUP_AUDIT_USAGE } from "./impl";
+
+export const command = {
+  name: "user-setup",
+  description: "Read-only user setup inventory tools.",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const args = ctx.args ?? [];
+  const flags = parseFlags(args, {
+    "--json": Boolean,
+  }, 0);
+
+  const [scope, action] = flags._;
+  if (scope !== "projects" || action !== "audit") {
+    return { ok: false, error: USER_SETUP_AUDIT_USAGE, output: USER_SETUP_AUDIT_USAGE, exitCode: 2 };
+  }
+  if (!flags["--json"]) {
+    return {
+      ok: false,
+      error: `${USER_SETUP_AUDIT_USAGE}\n\nOnly --json is implemented in the first read-only #1934 slice.`,
+      output: USER_SETUP_AUDIT_USAGE,
+      exitCode: 2,
+    };
+  }
+
+  try {
+    const result = await auditClaudeProjects();
+    return { ok: true, output: JSON.stringify(result, null, 2) };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, error: msg, exitCode: 1 };
+  }
+}

--- a/src/vendor/mpr-plugins/user-setup/plugin.json
+++ b/src/vendor/mpr-plugins/user-setup/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "user-setup",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Audit Claude project-log directories before any user-setup organize or prune flow. Read-only.",
+  "cli": {
+    "command": "user-setup",
+    "help": "maw user-setup projects audit --json",
+    "flags": {
+      "--json": "boolean"
+    }
+  },
+  "tier": "extra",
+  "license": "MIT",
+  "schemaVersion": 1
+}

--- a/test/isolated/user-setup-audit.test.ts
+++ b/test/isolated/user-setup-audit.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, statSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join, resolve } from "path";
+import { auditClaudeProjects, inferPathFromEncoded } from "../../src/vendor/mpr-plugins/user-setup/impl";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function tempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "maw-user-setup-audit-"));
+  roots.push(root);
+  return root;
+}
+
+function encodeClaudeProjectPath(path: string): string {
+  return resolve(path).replace(/^\//, "-").replace(/\//g, "-");
+}
+
+function writeJsonl(path: string, lines = 1): void {
+  const body = Array.from({ length: lines }, (_, i) => JSON.stringify({ type: "user", message: { content: `m${i}` } })).join("\n") + "\n";
+  writeFileSync(path, body);
+}
+
+describe("user-setup projects audit", () => {
+  test("returns a stable empty result when Claude projects root is missing", async () => {
+    const root = join(tempRoot(), "missing", "projects");
+    const result = await auditClaudeProjects({ projectsRoot: root, now: () => new Date("2026-05-30T00:00:00Z") });
+
+    expect(result).toEqual({
+      root,
+      generatedAt: "2026-05-30T00:00:00.000Z",
+      projectCount: 0,
+      totalSizeBytes: 0,
+      entries: [],
+      warnings: [expect.stringContaining("cannot read Claude projects dir")],
+    });
+  });
+
+  test("audits probable existing paths with sessions, nested subagents, largest files, and git remote evidence", async () => {
+    const root = tempRoot();
+    const sourceRoot = join(tmpdir(), `mawusersetupprobable${process.pid}`);
+    roots.push(sourceRoot);
+    const source = join(sourceRoot, "src", "plainrepo");
+    mkdirSync(source, { recursive: true });
+    const encoded = encodeClaudeProjectPath(source);
+    const projectDir = join(root, "claude", encoded);
+    mkdirSync(join(projectDir, "subagents"), { recursive: true });
+    writeJsonl(join(projectDir, "a-session.jsonl"), 2);
+    writeJsonl(join(projectDir, "subagents", "nested-session.jsonl"), 1);
+    writeFileSync(join(projectDir, "large.txt"), "x".repeat(128));
+
+    const result = await auditClaudeProjects({
+      projectsRoot: join(root, "claude"),
+      now: () => new Date("2026-05-30T01:02:03Z"),
+      cwd: () => "/not/the/source",
+      execSync: (cmd) => {
+        if (cmd.includes("remote get-url origin")) return "git@github.com:Soul-Brews-Studio/plainrepo.git\n";
+        if (cmd.includes("worktree list")) return "";
+        return "";
+      },
+    });
+
+    expect(result.projectCount).toBe(1);
+    const entry = result.entries[0];
+    expect(entry.encoded).toBe(encoded);
+    expect(entry.path).toMatchObject({ inferred: source, confidence: "probable" });
+    expect(entry.path.evidence).toContain("dash-decoded-from-claude-project-dir");
+    expect(entry.path.evidence).toContain("inferred-path-exists");
+    expect(entry.sourceExists).toBe(true);
+    expect(entry.sessionCount).toBe(2);
+    expect(entry.sizeBytes).toBeGreaterThan(128);
+    expect(entry.repo).toEqual({ remote: "github.com/Soul-Brews-Studio/plainrepo", owner: "Soul-Brews-Studio", name: "plainrepo" });
+    expect(entry.largestFiles[0]).toMatchObject({ name: "large.txt", sizeBytes: 128 });
+    expect(entry.warnings).not.toContain("path confidence is ambiguous");
+  });
+
+  test("does not overclaim exactness for lossy hyphenated project names", async () => {
+    const encoded = "-opt-Code-github.com-Soul-Brews-Studio-maw-js";
+    const finding = inferPathFromEncoded(encoded, { existsSync: () => false, cwd: () => "/elsewhere" });
+
+    expect(finding.inferred).toBe("/opt/Code/github.com/Soul/Brews/Studio/maw/js");
+    expect(finding.confidence).toBe("ambiguous");
+    expect(finding.evidence).toContain("dash-decoded-from-claude-project-dir");
+  });
+
+  test("marks non-absolute encoded directories as unknown and flags empty project dirs", async () => {
+    const root = tempRoot();
+    const projectDir = join(root, "relative-name");
+    mkdirSync(projectDir, { recursive: true });
+
+    const result = await auditClaudeProjects({ projectsRoot: root, now: () => new Date("2026-05-30T00:00:00Z") });
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].path).toEqual({
+      encoded: "relative-name",
+      confidence: "unknown",
+      evidence: ["encoded-name-does-not-look-like-absolute-claude-project-dir"],
+    });
+    expect(result.entries[0].warnings).toContain("path confidence is unknown");
+    expect(result.entries[0].warnings).toContain("no JSONL sessions found");
+  });
+
+  test("surfaces worktree-shaped directories and stat failures without throwing", async () => {
+    const root = tempRoot();
+    const source = join(root, "agents", "1", "mawjs");
+    const encoded = encodeClaudeProjectPath(source);
+    const projectDir = join(root, "claude", encoded);
+    mkdirSync(projectDir, { recursive: true });
+    writeJsonl(join(projectDir, "session.jsonl"));
+
+    const result = await auditClaudeProjects({
+      projectsRoot: join(root, "claude"),
+      cwd: () => "/elsewhere",
+      statSync: (path) => {
+        if (String(path).endsWith("session.jsonl")) throw new Error("boom");
+        return statSync(path);
+      },
+    });
+
+    const entry = result.entries[0];
+    expect(entry.worktree.detected).toBe(true);
+    expect(entry.worktree.evidence).toContain("path-shape-suggests-worktree");
+    expect(entry.warnings.some(w => w.includes("stat failed") && w.includes("boom"))).toBe(true);
+  });
+});


### PR DESCRIPTION
Refs #1934.

## Summary
- Adds `maw user-setup projects audit --json` as the first read-only #1934 slice.
- Emits a stable JSON inventory for Claude project dirs: encoded name, inferred path confidence/evidence, size/session counts, largest files, source existence, repo/worktree hints, warnings.
- Intentionally does **not** organize, prune, symlink, archive, delete, or run `git worktree prune`.

## Tests
- `MAW_TEST_MODE=1 bun test test/isolated/user-setup-audit.test.ts`
- `bun run build`
- `./dist/maw user-setup projects audit --json` parsed successfully on m5 (`projectCount=417`, `totalSizeBytes=7000499758`).

## Notes
This keeps dash-decoded Claude project names below exact confidence unless independent evidence anchors them, so lossy hyphenated paths stay ambiguous/probable instead of being treated as truth.
