### PR TITLE
fix(federation): expose live-pane delivery receipts

### DIFF
--- a/src/api/sessions.ts
+++ b/src/api/sessions.ts
@@ -97,6 +97,32 @@ export function messageSignedRequest(request: Request): boolean {
   return Boolean(request.headers.get("x-maw-from"));
 }
 
+export type DeliveryReceiptState =
+  | "remote_node_accepted"
+  | "target_pane_resolved"
+  | "send_keys_injected"
+  | "live_pane_consumed"
+  | "fallback_queued"
+  | "busy_rejected"
+  | "stale_target"
+  | "node_unreachable";
+
+function deliveryReceipt(...states: Array<DeliveryReceiptState | undefined | null | false>): DeliveryReceiptState[] {
+  return [...new Set(states.filter(Boolean) as DeliveryReceiptState[])];
+}
+
+function queuedReceipt(reason: string): DeliveryReceiptState[] {
+  if (/busy/i.test(reason)) return deliveryReceipt("busy_rejected", "fallback_queued");
+  if (/unreachable|unavailable|connection|timeout/i.test(reason)) return deliveryReceipt("node_unreachable", "fallback_queued");
+  if (/not live|not found|stale/i.test(reason)) return deliveryReceipt("stale_target", "fallback_queued");
+  return deliveryReceipt("fallback_queued");
+}
+
+function peerReceipt(data: any, state: "delivered" | "queued"): DeliveryReceiptState[] {
+  const remote = Array.isArray(data?.receipt) ? data.receipt : [];
+  return deliveryReceipt("remote_node_accepted", ...remote, state === "queued" ? "fallback_queued" : undefined);
+}
+
 function stripPaneIndex(target: string): string {
   return target.replace(/\.[0-9]+$/, "");
 }
@@ -323,6 +349,7 @@ export function createSessionsApi(deps: SessionsApiDeps = {}) {
           state: "queued" as const,
           inbox: inbox.path,
           reason,
+          receipt: queuedReceipt(reason),
         };
       };
       const queueOrFail = async (tmuxTarget: string, reason: string, status = 502) => {
@@ -406,7 +433,16 @@ export function createSessionsApi(deps: SessionsApiDeps = {}) {
           lastLine,
           signed: messageSigned,
         });
-        return { ok: true, target: resolved.target, text, source: "local", lastLine, state, ...(inbox?.ok ? { inbox: inbox.path } : {}) };
+        return {
+          ok: true,
+          target: resolved.target,
+          text,
+          source: "local",
+          lastLine,
+          state,
+          receipt: deliveryReceipt("target_pane_resolved", "send_keys_injected", state === "delivered" ? "live_pane_consumed" : "fallback_queued"),
+          ...(inbox?.ok ? { inbox: inbox.path } : {}),
+        };
       }
 
       // Remote peer → federation HTTP
@@ -432,7 +468,15 @@ export function createSessionsApi(deps: SessionsApiDeps = {}) {
             lastLine: res.data.lastLine || "",
             signed: messageSigned,
           });
-          return { ok: true, target: res.data.target || target, text, source: resolved.peerUrl, lastLine: res.data.lastLine || "", state };
+          return {
+            ok: true,
+            target: res.data.target || target,
+            text,
+            source: resolved.peerUrl,
+            lastLine: res.data.lastLine || "",
+            state,
+            receipt: peerReceipt(res.data, state),
+          };
         }
         emitLifecycle({
           direction: "forwarded",
@@ -469,7 +513,15 @@ export function createSessionsApi(deps: SessionsApiDeps = {}) {
           signed: messageSigned,
         });
         if (send.ok) {
-          return { ok: true, target: send.target || target, text, source: peerUrl, state: send.state, lastLine: send.lastLine || "" };
+          return {
+            ok: true,
+            target: send.target || target,
+            text,
+            source: peerUrl,
+            state: send.state,
+            lastLine: send.lastLine || "",
+            receipt: deliveryReceipt("remote_node_accepted", ...(send.receipt ?? []), send.state === "queued" ? "fallback_queued" : undefined),
+          };
         }
         set.status = 502; return { error: send.error || "Failed to send to peer", target, source: peerUrl };
       }
@@ -519,7 +571,17 @@ export function createSessionsApi(deps: SessionsApiDeps = {}) {
                 lastLine,
                 signed: messageSigned,
               });
-              return { ok: true, target: retry.target, text, source: "local", lastLine, wokeFor: target, ...(inbox?.ok ? { inbox: inbox.path } : {}) };
+              return {
+                ok: true,
+                target: retry.target,
+                text,
+                source: "local",
+                lastLine,
+                state: "delivered" as const,
+                receipt: deliveryReceipt("target_pane_resolved", "send_keys_injected", "live_pane_consumed"),
+                wokeFor: target,
+                ...(inbox?.ok ? { inbox: inbox.path } : {}),
+              };
             }
           } catch { /* wake best-effort — fall through to 404 */ }
         }

--- a/src/core/transport/peers.ts
+++ b/src/core/transport/peers.ts
@@ -396,6 +396,7 @@ export interface PeerSendResult {
   state: "delivered" | "queued" | "failed";
   target?: string;
   lastLine?: string;
+  receipt?: string[];
   error?: string;
   status?: number;
 }
@@ -432,6 +433,7 @@ export async function sendKeysToPeerDetailed(
         state: res.data.state === "delivered" ? "delivered" : "queued",
         target: typeof res.data.target === "string" ? res.data.target : target,
         lastLine: typeof res.data.lastLine === "string" ? res.data.lastLine : "",
+        receipt: Array.isArray(res.data.receipt) ? res.data.receipt : undefined,
       };
     }
 

--- a/test/sessions-api-default.test.ts
+++ b/test/sessions-api-default.test.ts
@@ -191,7 +191,13 @@ describe("POST /send", () => {
     const res = await h.app.handle(jsonRequest("/send", { target: "neo", text: "hello", attachments: ["a", "b"] }, { "x-maw-from": "sender:white" }));
 
     expect(res.status).toBe(200);
-    expect(await readJson(res)).toMatchObject({ ok: true, target: "local:main", source: "local", state: "delivered" });
+    expect(await readJson(res)).toMatchObject({
+      ok: true,
+      target: "local:main",
+      source: "local",
+      state: "delivered",
+      receipt: ["target_pane_resolved", "send_keys_injected", "live_pane_consumed"],
+    });
     expect(h.calls.some((c) => c[0] === "idle")).toBe(false);
     expect(h.calls).toContainEqual(["sendKeys", "local:main", "a\nb\nhello"]);
     expect(h.lifecycle[0]).toMatchObject({ state: "delivered", from: "white:sender", signed: true, text: "a\nb\nhello" });
@@ -210,7 +216,14 @@ describe("POST /send", () => {
 
     const res = await h.app.handle(jsonRequest("/send", { target: "neo-oracle", text: "hello" }));
 
-    expect(await readJson(res)).toMatchObject({ ok: true, target: "neo:main", source: "local", state: "queued", lastLine: "queued line" });
+    expect(await readJson(res)).toMatchObject({
+      ok: true,
+      target: "neo:main",
+      source: "local",
+      state: "queued",
+      lastLine: "queued line",
+      receipt: ["target_pane_resolved", "send_keys_injected", "fallback_queued"],
+    });
     expect(h.calls).toContainEqual(["sendKeys", "neo:main", "hello"]);
     expect(h.lifecycle[0]).toMatchObject({ state: "queued", signed: false });
   });
@@ -282,6 +295,7 @@ describe("POST /send", () => {
       state: "queued",
       inbox: "/repo/ψ/inbox/inbox-only.md",
       reason: "--inbox requested; pane injection skipped",
+      receipt: ["fallback_queued"],
     });
     expect(h.calls.some((c) => c[0] === "sendKeys")).toBe(false);
     expect(inboxCalls).toHaveLength(1);
@@ -305,16 +319,25 @@ describe("POST /send", () => {
   test("forwards peer sends and reports peer failures", async () => {
     const success = makeHarness({
       resolveTarget: (() => ({ type: "peer", node: "white", peerUrl: "http://peer", target: "remote:main" })) as any,
-      curlFetch: async () => ({ ok: true, status: 200, data: { ok: true, target: "actual", state: "queued", lastLine: "queued" } }) as any,
+      curlFetch: async () => ({ ok: true, status: 200, data: { ok: true, target: "actual", state: "queued", lastLine: "queued", receipt: ["target_pane_resolved", "send_keys_injected", "fallback_queued"] } }) as any,
     });
-    expect(await readJson(await success.app.handle(jsonRequest("/send", { target: "remote", text: "hi" })))).toMatchObject({ ok: true, source: "http://peer", target: "actual", state: "queued" });
+    expect(await readJson(await success.app.handle(jsonRequest("/send", { target: "remote", text: "hi" })))).toMatchObject({
+      ok: true,
+      source: "http://peer",
+      target: "actual",
+      state: "queued",
+      receipt: ["remote_node_accepted", "target_pane_resolved", "send_keys_injected", "fallback_queued"],
+    });
     expect(success.lifecycle[0]).toMatchObject({ route: "peer", state: "queued", to: "white:remote:main" });
 
     const acceptedOnly = makeHarness({
       resolveTarget: (() => ({ type: "peer", node: "white", peerUrl: "http://peer", target: "remote:main" })) as any,
       curlFetch: async () => ({ ok: true, status: 200, data: { ok: true, target: "actual" } }) as any,
     });
-    expect(await readJson(await acceptedOnly.app.handle(jsonRequest("/send", { target: "remote", text: "hi" })))).toMatchObject({ state: "queued" });
+    expect(await readJson(await acceptedOnly.app.handle(jsonRequest("/send", { target: "remote", text: "hi" })))).toMatchObject({
+      state: "queued",
+      receipt: ["remote_node_accepted", "fallback_queued"],
+    });
     expect(acceptedOnly.lifecycle[0]).toMatchObject({ route: "peer", state: "queued" });
 
     const failure = makeHarness({
@@ -330,7 +353,7 @@ describe("POST /send", () => {
   test("falls back to peer discovery and preserves receiver delivery state", async () => {
     const ok = makeHarness({
       findPeerForTarget: async () => "http://found",
-      sendKeysToPeerDetailed: async () => ({ ok: true, state: "delivered", target: "remote:main", lastLine: "landed" }) as any,
+      sendKeysToPeerDetailed: async () => ({ ok: true, state: "delivered", target: "remote:main", lastLine: "landed", receipt: ["target_pane_resolved", "send_keys_injected", "live_pane_consumed"] }) as any,
     });
     expect(await readJson(await ok.app.handle(jsonRequest("/send", { target: "remote", text: "hi" })))).toMatchObject({
       ok: true,
@@ -338,6 +361,7 @@ describe("POST /send", () => {
       target: "remote:main",
       state: "delivered",
       lastLine: "landed",
+      receipt: ["remote_node_accepted", "target_pane_resolved", "send_keys_injected", "live_pane_consumed"],
     });
 
     const queued = makeHarness({
@@ -544,6 +568,7 @@ describe("POST /send", () => {
       state: "queued",
       inbox: "/repo/ψ/inbox/offline.md",
       reason: "not live",
+      receipt: ["stale_target", "fallback_queued"],
     });
     expect(h.lifecycle[0]).toMatchObject({
       route: "inbox",


### PR DESCRIPTION
Refs #1939.

## Summary
- Adds explicit `/api/send` delivery receipts for the native remote live-pane path.
- Distinguishes `remote_node_accepted`, `target_pane_resolved`, `send_keys_injected`, `live_pane_consumed`, and `fallback_queued` instead of making callers infer from a coarse state.
- Propagates peer receipt data through direct peer routing and discovery fallback.

## Why this slice
The existing cross-node `maw hey <node>:<session>:<window>` path already forwards to the peer `/api/send`, which resolves locally on that node and attempts tmux `sendKeys`. The missing piece from Snailflyer's review was the proof surface: accepted HTTP must not accidentally imply live pane delivery.

## Tests
- `MAW_TEST_MODE=1 bun test test/sessions-api-default.test.ts test/peers-transport-coverage.test.ts`
- `bun run build`

## Not tested
- Live two-node manual pane injection; this branch was verified with API/unit seams only.
