### PR TITLE
fix(promote): rollback placeholder session on failed move

### DIFF
--- a/src/commands/shared/promote-cmd.ts
+++ b/src/commands/shared/promote-cmd.ts
@@ -72,6 +72,7 @@ export interface CmdPromoteDeps {
   hasSession?: (name: string) => Promise<boolean>;
   listWindows?: (session: string) => Promise<{ name: string }[]>;
   newSession?: (name: string, opts: { window?: string }) => Promise<string | undefined>;
+  killSession?: (name: string) => Promise<void>;
   killWindow?: (target: string) => Promise<void>;
   run?: (subcommand: string, ...args: string[]) => Promise<string>;
   switchClient?: (session: string, opts?: { readonly?: boolean }) => Promise<void>;
@@ -114,6 +115,7 @@ export async function cmdPromote(argv: string[], deps: CmdPromoteDeps = {}): Pro
   const hasSessionFn = deps.hasSession ?? ((name) => tmux.hasSession(name));
   const listWindowsFn = deps.listWindows ?? ((session) => tmux.listWindows(session));
   const newSessionFn = deps.newSession ?? ((name, opts) => tmux.newSession(name, opts));
+  const killSessionFn = deps.killSession ?? ((name) => tmux.killSession(name));
   const killWindowFn = deps.killWindow ?? ((t) => tmux.killWindow(t));
   const runFn = deps.run ?? ((sub, ...args) => tmux.run(sub, ...args));
   const switchClientFn = deps.switchClient ?? ((s, opts) => tmux.switchClient(s, opts));
@@ -174,21 +176,60 @@ export async function cmdPromote(argv: string[], deps: CmdPromoteDeps = {}): Pro
     throw new UserError(`promote: destination '${dstSession}' already exists`);
   }
 
-  // 5. Execute eject.
-  try {
-    if (!dstExists) {
-      await newSessionFn(dstSession, { window: PROMOTE_PLACEHOLDER });
-    }
-    await runFn("move-window", "-s", srcTarget, "-t", `${dstSession}:`);
-    if (!dstExists) {
+  async function rollbackCreatedDestination(reason: string): Promise<void> {
+    try {
+      await killSessionFn(dstSession);
+    } catch {
       try {
         await killWindowFn(`${dstSession}:${PROMOTE_PLACEHOLDER}`);
       } catch {
-        // Placeholder may already be auto-cleaned by tmux; safe to ignore.
+        // Best-effort rollback only; preserve the primary move failure.
       }
     }
+    error(`      \x1b[90mrollback: removed placeholder session '${dstSession}' after ${reason}\x1b[0m`);
+  }
+
+  // 5. Execute eject.
+  let createdDestination = false;
+  try {
+    if (!dstExists) {
+      await newSessionFn(dstSession, { window: PROMOTE_PLACEHOLDER });
+      createdDestination = true;
+    }
+    await runFn("move-window", "-s", srcTarget, "-t", `${dstSession}:`);
   } catch (e: unknown) {
+    if (createdDestination) await rollbackCreatedDestination("move-window failure");
     throw new UserError(`promote: tmux move failed — ${e instanceof Error ? e.message : String(e)}`);
+  }
+
+  let dstWindows: { name: string }[];
+  try {
+    dstWindows = await listWindowsFn(dstSession);
+  } catch (e: unknown) {
+    throw new UserError(
+      `promote: tmux move verification failed — cannot list destination session '${dstSession}': ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+
+  if (!dstWindows.some(w => w.name === srcWindow)) {
+    const onlyPlaceholder = dstWindows.length === 0 || dstWindows.every(w => w.name === PROMOTE_PLACEHOLDER);
+    if (createdDestination && onlyPlaceholder) {
+      await rollbackCreatedDestination("move verification failure");
+      throw new UserError(
+        `promote: tmux move failed — '${srcTarget}' did not appear in '${dstSession}' after move-window; rolled back placeholder session`,
+      );
+    }
+    throw new UserError(
+      `promote: tmux move verification failed — '${srcTarget}' did not appear in '${dstSession}' after move-window`,
+    );
+  }
+
+  if (createdDestination) {
+    try {
+      await killWindowFn(`${dstSession}:${PROMOTE_PLACEHOLDER}`);
+    } catch {
+      // Placeholder may already be auto-cleaned by tmux; safe to ignore.
+    }
   }
 
   // 6. Report (Q5 β+γ — raw tmux undo since `maw take` doesn't exist yet).

--- a/test/isolated/promote-cmd.test.ts
+++ b/test/isolated/promote-cmd.test.ts
@@ -25,9 +25,11 @@ function makeDeps(overrides: Partial<CmdPromoteDeps> = {}): CmdPromoteDeps & { l
       calls.push(["listWindows", s]);
       if (s === "77-mawjs") return [{ name: "mawjs-oracle" }, { name: "test-cli" }];
       if (s === "scratch") return [{ name: "scratch" }];
+      if (s === "isolated") return [{ name: "test-cli" }, { name: "__promote_placeholder__" }];
       return [];
     },
     newSession: async (n: string, opts) => { calls.push(["newSession", n, opts]); return undefined; },
+    killSession: async (n: string) => { calls.push(["killSession", n]); },
     killWindow: async (t: string) => { calls.push(["killWindow", t]); },
     run: async (sub: string, ...args: string[]) => { calls.push(["run", sub, ...args]); return ""; },
     switchClient: async (s: string) => { calls.push(["switchClient", s]); },
@@ -199,6 +201,41 @@ describe("cmdPromote (#1910)", () => {
     });
     await expect(cmdPromote(["77-mawjs:test-cli", "--as", "isolated"], deps))
       .rejects.toThrow(/tmux move failed — permission denied/);
+    expect(deps.calls).toContainEqual(["killSession", "isolated"]);
+  });
+
+  test("move-window failure rollback falls back to killing placeholder window", async () => {
+    const deps = makeDeps({
+      hasSession: async () => false,
+      killSession: async (n) => {
+        deps.calls.push(["killSession", n]);
+        throw new Error("session busy");
+      },
+      run: async (sub) => {
+        if (sub === "move-window") throw new Error("permission denied");
+        return "";
+      },
+    });
+    await expect(cmdPromote(["77-mawjs:test-cli", "--as", "isolated"], deps))
+      .rejects.toThrow(/tmux move failed — permission denied/);
+    expect(deps.calls).toContainEqual(["killSession", "isolated"]);
+    expect(deps.calls).toContainEqual(["killWindow", "isolated:__promote_placeholder__"]);
+  });
+
+  test("move-window silent no-op → verifies destination and rolls back placeholder session", async () => {
+    const deps = makeDeps({
+      hasSession: async () => false,
+      listWindows: async (s: string) => {
+        deps.calls.push(["listWindows", s]);
+        if (s === "77-mawjs") return [{ name: "mawjs-oracle" }, { name: "test-cli" }];
+        if (s === "isolated") return [{ name: "__promote_placeholder__" }];
+        return [];
+      },
+    });
+    await expect(cmdPromote(["77-mawjs:test-cli", "--as", "isolated"], deps))
+      .rejects.toThrow(/did not appear in 'isolated'.*rolled back placeholder session/);
+    expect(deps.calls).toContainEqual(["run", "move-window", "-s", "77-mawjs:test-cli", "-t", "isolated:"]);
+    expect(deps.calls).toContainEqual(["killSession", "isolated"]);
   });
 
   test("listWindows failure → throws UserError with source-list reason", async () => {


### PR DESCRIPTION
Closes #1949.

## Summary
- Rolls back the destination session when `maw promote` creates `__promote_placeholder__` and `tmux move-window` fails.
- Adds post-move destination inspection before reporting success, so silent no-op moves surface as errors.
- Keeps existing placeholder cleanup behavior after successful moves.

## Tests
- `bun test test/isolated/promote-cmd.test.ts` (clean detached worktree at `ac36c6db`, 21 pass)
- `bun run build` (clean detached worktree at `ac36c6db`)

## Notes
- Scoped to promote rollback/verification only.
- Existing local dirty files for #1933 (`expand-plan` / federation plugin) were not staged or included.
