### PR TITLE
feat(federation): plan expand dry runs

### DIFF
--- a/src/commands/plugins/federation/index.ts
+++ b/src/commands/plugins/federation/index.ts
@@ -2,7 +2,7 @@ import type { InvokeContext, InvokeResult } from "../../../plugin/types";
 
 export const command = {
   name: "federation",
-  description: "Multi-node federation status and sync.",
+  description: "Multi-node federation status, sync, and expansion planning.",
 };
 
 function readOption(args: string[], name: string): string | undefined {
@@ -40,7 +40,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     if (sub === "--help" || sub === "-h" || sub === "help") {
       return {
         ok: false,
-        error: "usage: maw federation <status|sync> [--verify|--dry-run|--check|--prune|--force|--json|--peers config|scout|both]",
+        error: "usage: maw federation <status|sync|expand> [host] [--port <port>] [--user <user>] [--oracle <name>] [--verify|--dry-run|--check|--prune|--force|--json|--peers config|scout|both]",
       };
     }
 
@@ -65,10 +65,63 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         json: args.includes("--json"),
         peers: peerSource,
       });
+    } else if (sub === "expand") {
+      if (args.includes("--apply")) {
+        return { ok: false, error: "maw federation expand is read-only in this release; --apply is not supported" };
+      }
+      const host = args[1];
+      if (!host || host.startsWith("--")) {
+        return { ok: false, error: "usage: maw federation expand <new-node-host> [--port <port>] [--user <user>] [--oracle <name>] [--json]" };
+      }
+      const portRaw = readOption(args, "--port");
+      const port = portRaw ? Number(portRaw) : 3456;
+      if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+        return { ok: false, error: `invalid --port: ${portRaw}` };
+      }
+      const { loadConfig } = await import("../../../config");
+      const { computeExpandPlan, deriveExpandNode } = await import("../../shared/expand-plan");
+      const config = loadConfig();
+      const seen = new Set<string>();
+      const knownPeers = [
+        ...(config.namedPeers ?? []),
+        ...(config.peers ?? []).map((url) => ({ name: deriveExpandNode(url), url })),
+      ].filter((peer) => {
+        const key = `${peer.name}::${peer.url}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      });
+      const plan = computeExpandPlan(host, port, config.node || "local", knownPeers, {
+        user: readOption(args, "--user"),
+        oracle: readOption(args, "--oracle") || config.oracle,
+        targetPlatform: "linux",
+      });
+      if (args.includes("--json")) {
+        console.log(JSON.stringify(plan, null, 2));
+      } else {
+        console.log();
+        console.log(`  🧭 Federation Expand Plan  target: ${plan.target.node} (${plan.target.url})`);
+        console.log(`  dry run — no SSH, no config writes, no network mutations`);
+        console.log();
+        console.log(`  new node seed peers: ${plan.newNodeSeedConfig.namedPeers.length}`);
+        console.log(`  reciprocal route updates: ${plan.reciprocalPeerUpdates.filter((u) => u.kind === "add").length} add · ${plan.reciprocalPeerUpdates.filter((u) => u.kind === "noop").length} noop · ${plan.reciprocalPeerUpdates.filter((u) => u.kind === "conflict").length} conflict`);
+        console.log(`  trust plan: ${plan.peerStoreUpdates.map((u) => u.command).join(", ")}`);
+        console.log(`  service plan: ${plan.servicePlan.kind} (${plan.servicePlan.manager})`);
+        for (const cmd of plan.servicePlan.commands) console.log(`    ${cmd}`);
+        console.log(`  firewall: ${plan.firewallPlan.command}`);
+        for (const warning of [...plan.warnings, ...plan.servicePlan.warnings, ...plan.firewallPlan.warnings]) {
+          console.log(`  ! ${warning}`);
+        }
+        if (plan.blockingIssues.length > 0) {
+          console.log();
+          for (const issue of plan.blockingIssues) console.log(`  BLOCKED: ${issue}`);
+        }
+        console.log();
+      }
     } else {
       return {
         ok: false,
-        error: "usage: maw federation <status|sync> [--verify|--dry-run|--check|--prune|--force|--json|--peers config|scout|both]",
+        error: "usage: maw federation <status|sync|expand> [host] [--port <port>] [--user <user>] [--oracle <name>] [--verify|--dry-run|--check|--prune|--force|--json|--peers config|scout|both]",
       };
     }
 

--- a/src/commands/plugins/federation/plugin.json
+++ b/src/commands/plugins/federation/plugin.json
@@ -3,14 +3,14 @@
   "version": "1.0.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "Multi-node federation status and sync.",
+  "description": "Multi-node federation status, sync, and expansion planning.",
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "federation",
     "aliases": [
       "fed"
     ],
-    "help": "maw federation <status|sync> [--dry-run|--check|--prune|--force|--json] [--peers config|scout|both]",
+    "help": "maw federation <status|sync|expand> [host] [--port <port>] [--user <user>] [--oracle <name>] [--dry-run|--check|--prune|--force|--json] [--peers config|scout|both]",
     "flags": {
       "--dry-run": "boolean",
       "--check": "boolean",
@@ -18,7 +18,11 @@
       "--force": "boolean",
       "--verify": "boolean",
       "--json": "boolean",
-      "--peers": "string"
+      "--peers": "string",
+      "--port": "string",
+      "--user": "string",
+      "--oracle": "string",
+      "--apply": "boolean"
     }
   },
   "weight": 10

--- a/src/commands/shared/expand-plan.ts
+++ b/src/commands/shared/expand-plan.ts
@@ -1,0 +1,235 @@
+/**
+ * expand-plan.ts — pure planner for `maw federation expand`.
+ * No I/O, no network — fully unit-testable.
+ */
+
+import type { PeerConfig } from "../../config";
+
+export type ExpandDeltaKind = "noop" | "add" | "update" | "conflict" | "unsafe";
+
+export interface ExpandPlanOptions {
+  user?: string;
+  oracle?: string;
+  targetPlatform?: NodeJS.Platform | "unknown";
+  subnet?: string;
+}
+
+export interface ExpandTarget {
+  host: string;
+  port: number;
+  node: string;
+  url: string;
+  user?: string;
+  oracle: string;
+  aliases: string[];
+}
+
+export interface ExpandRouteDelta {
+  kind: ExpandDeltaKind;
+  recipient: string;
+  alias: string;
+  url: string;
+  command: string;
+  reason?: string;
+  existingUrl?: string;
+}
+
+export interface ExpandPeerStoreDelta {
+  kind: ExpandDeltaKind;
+  peer: string;
+  command: string;
+  reason: string;
+}
+
+export interface ExpandServicePlan {
+  kind: ExpandDeltaKind;
+  platform: NodeJS.Platform | "unknown";
+  manager: "pm2" | "manual";
+  commands: string[];
+  warnings: string[];
+}
+
+export interface ExpandFirewallPlan {
+  kind: ExpandDeltaKind;
+  subnet: string;
+  command: string;
+  warnings: string[];
+  verification: string[];
+}
+
+export interface ExpandPlan {
+  target: ExpandTarget;
+  localNode: string;
+  newNodeSeedConfig: {
+    kind: ExpandDeltaKind;
+    namedPeers: PeerConfig[];
+    reason?: string;
+  };
+  reciprocalPeerUpdates: ExpandRouteDelta[];
+  peerStoreUpdates: ExpandPeerStoreDelta[];
+  servicePlan: ExpandServicePlan;
+  firewallPlan: ExpandFirewallPlan;
+  warnings: string[];
+  blockingIssues: string[];
+}
+
+const DEFAULT_ORACLE = "mawjs";
+const DEFAULT_SUBNET = "10.20.0.0/24";
+
+function stripProtocol(host: string): string {
+  return host.replace(/^[a-z][a-z0-9+.-]*:\/\//i, "").replace(/\/.*$/, "");
+}
+
+function hostWithoutPort(host: string): string {
+  const stripped = stripProtocol(host).replace(/^\[/, "").replace(/\]$/, "");
+  if (stripped.includes("]:")) return stripped.slice(0, stripped.indexOf("]:"));
+  const parts = stripped.split(":");
+  return parts.length > 1 ? parts[0] : stripped;
+}
+
+export function deriveExpandNode(host: string): string {
+  const bare = hostWithoutPort(host).trim().toLowerCase();
+  const firstLabel = bare.split(".")[0] || bare;
+  return firstLabel.replace(/[^a-z0-9_-]+/g, "-").replace(/^-+|-+$/g, "") || "new-node";
+}
+
+function targetUrl(host: string, port: number): string {
+  const protocolMatch = host.match(/^([a-z][a-z0-9+.-]*):\/\//i);
+  const protocol = protocolMatch?.[1] ?? "http";
+  const bareHost = hostWithoutPort(host);
+  return `${protocol}://${bareHost}:${port}`;
+}
+
+function uniq<T>(items: T[]): T[] {
+  return [...new Set(items)];
+}
+
+function aliasesFor(node: string, oracle: string): string[] {
+  const aliases = [node, `${node}-${oracle}`];
+  if (node.startsWith("oracle-")) aliases.push(`${node.slice("oracle-".length)}-${oracle}`);
+  return uniq(aliases.filter(Boolean));
+}
+
+function routeKind(alias: string, url: string, knownPeers: PeerConfig[]): Pick<ExpandRouteDelta, "kind" | "reason" | "existingUrl"> {
+  const existing = knownPeers.find((p) => p.name === alias);
+  if (!existing) return { kind: "add", reason: "alias is not configured" };
+  if (existing.url === url) return { kind: "noop", reason: "alias already routes to target", existingUrl: existing.url };
+  return { kind: "conflict", reason: "alias already routes to a different URL", existingUrl: existing.url };
+}
+
+/**
+ * Compute a deterministic federation-growth plan.
+ *
+ * This function is intentionally pure: callers provide the target host/port,
+ * local node name, and the known peer list. It does not load config, probe the
+ * network, write files, or SSH anywhere.
+ */
+export function computeExpandPlan(
+  host: string,
+  port: number,
+  localNode: string,
+  knownPeers: PeerConfig[],
+  opts: ExpandPlanOptions = {},
+): ExpandPlan {
+  const oracle = opts.oracle || DEFAULT_ORACLE;
+  const node = deriveExpandNode(host);
+  const url = targetUrl(host, port);
+  const aliases = aliasesFor(node, oracle);
+  const subnet = opts.subnet || DEFAULT_SUBNET;
+  const target: ExpandTarget = {
+    host: hostWithoutPort(host),
+    port,
+    node,
+    url,
+    ...(opts.user ? { user: opts.user } : {}),
+    oracle,
+    aliases,
+  };
+
+  const warnings: string[] = [];
+  const blockingIssues: string[] = [];
+  if (knownPeers.length === 0) {
+    warnings.push("no known peers configured; seed config will be empty except for future local identity");
+  }
+
+  const recipients = uniq([localNode, ...knownPeers.map((p) => p.name)]).filter(Boolean);
+  const reciprocalPeerUpdates = recipients.flatMap((recipient) => aliases.map((alias) => {
+    const classified = routeKind(alias, url, knownPeers);
+    if (classified.kind === "conflict") {
+      blockingIssues.push(`${alias} already routes to ${classified.existingUrl}; refusing to plan overwrite with ${url}`);
+    }
+    return {
+      ...classified,
+      recipient,
+      alias,
+      url,
+      command: `maw peers add ${alias} ${url}`,
+    } satisfies ExpandRouteDelta;
+  }));
+
+  const peerStoreUpdates: ExpandPeerStoreDelta[] = [
+    {
+      kind: "unsafe",
+      peer: aliases[0] ?? node,
+      command: `maw pair ${aliases[0] ?? node}`,
+      reason: "trust is separate from routing; require explicit pair/TOFU handshake before writing peers.json",
+    },
+  ];
+
+  const targetPlatform = opts.targetPlatform || "linux";
+  const servicePlan: ExpandServicePlan = targetPlatform === "linux"
+    ? {
+        kind: "add",
+        platform: targetPlatform,
+        manager: "pm2",
+        commands: [
+          `maw setup auto-wake --dry-run --port ${port}`,
+          "pm2 save",
+        ],
+        warnings: [
+          "pm2 startup may need a login-shell PATH; verify pm2 is visible in the service environment before reporting success",
+          "planner only: commands are emitted for copy/paste and are not executed",
+        ],
+      }
+    : {
+        kind: "unsafe",
+        platform: targetPlatform,
+        manager: "manual",
+        commands: [],
+        warnings: [
+          `service bootstrap is unsupported for target platform ${targetPlatform}; use a manual service plan`,
+        ],
+      };
+  if (servicePlan.kind === "unsafe") blockingIssues.push(servicePlan.warnings[0]);
+
+  const firewallPlan: ExpandFirewallPlan = {
+    kind: "add",
+    subnet,
+    command: `sudo ufw allow proto tcp from ${subnet} to any port ${port} comment "wg1 maw federation ${opts.user || oracle}"`,
+    warnings: [
+      "cross-host probe will TIMEOUT until this rule is applied",
+      "loopback curl is not sufficient; verify from another federation node before reporting listener success",
+    ],
+    verification: [
+      `curl -s http://localhost:${port}/info`,
+      `curl -s --max-time 5 http://<wg1-ip>:${port}/info  # run from another node`,
+      `maw peers probe ${aliases[0] ?? node}`,
+    ],
+  };
+
+  return {
+    target,
+    localNode,
+    newNodeSeedConfig: {
+      kind: knownPeers.length === 0 ? "noop" : "add",
+      namedPeers: knownPeers.map((p) => ({ name: p.name, url: p.url })),
+      reason: knownPeers.length === 0 ? "no known peers to seed" : "copy existing routing peers to the new node seed config",
+    },
+    reciprocalPeerUpdates,
+    peerStoreUpdates,
+    servicePlan,
+    firewallPlan,
+    warnings,
+    blockingIssues: uniq(blockingIssues),
+  };
+}

--- a/test/expand-plan.test.ts
+++ b/test/expand-plan.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import { computeExpandPlan, deriveExpandNode } from "../src/commands/shared/expand-plan";
+
+const peers = [
+  { name: "m5", url: "http://m5.wg:3456" },
+  { name: "white", url: "http://white.wg:3456" },
+];
+
+describe("deriveExpandNode", () => {
+  test("derives node from host argument, not local config", () => {
+    expect(deriveExpandNode("oracle-world.wg")).toBe("oracle-world");
+    expect(deriveExpandNode("http://white.local:3456")).toBe("white");
+  });
+});
+
+describe("computeExpandPlan", () => {
+  test("builds a dry-run-only plan with routing, trust, service, and firewall sections", () => {
+    const plan = computeExpandPlan("oracle-world.wg", 3462, "m5", peers, { user: "mawjs", oracle: "mawjs" });
+
+    expect(plan.target).toMatchObject({
+      host: "oracle-world.wg",
+      port: 3462,
+      node: "oracle-world",
+      url: "http://oracle-world.wg:3462",
+      user: "mawjs",
+      oracle: "mawjs",
+    });
+    expect(plan.target.aliases).toEqual(["oracle-world", "oracle-world-mawjs", "world-mawjs"]);
+    expect(plan.newNodeSeedConfig.namedPeers).toEqual(peers);
+    expect(plan.reciprocalPeerUpdates.some((u) => u.recipient === "m5" && u.alias === "world-mawjs" && u.kind === "add")).toBe(true);
+    expect(plan.peerStoreUpdates[0]).toMatchObject({ kind: "unsafe", command: "maw pair oracle-world" });
+    expect(plan.servicePlan.commands).toContain("maw setup auto-wake --dry-run --port 3462");
+    expect(plan.servicePlan.commands.join("\n")).not.toContain("ssh ");
+    expect(plan.firewallPlan.command).toContain("ufw allow proto tcp from 10.20.0.0/24 to any port 3462");
+    expect(plan.firewallPlan.warnings.join("\n")).toContain("cross-host probe will TIMEOUT");
+  });
+
+  test("no peers configured keeps seed config empty and warns", () => {
+    const plan = computeExpandPlan("newbox.wg", 3459, "m5", []);
+
+    expect(plan.newNodeSeedConfig).toMatchObject({ kind: "noop", namedPeers: [] });
+    expect(plan.warnings.join("\n")).toContain("no known peers configured");
+    expect(plan.reciprocalPeerUpdates.map((u) => u.recipient)).toEqual(["m5", "m5"]);
+  });
+
+  test("target already present is classified as noop", () => {
+    const plan = computeExpandPlan("oracle-world.wg", 3462, "m5", [
+      ...peers,
+      { name: "oracle-world", url: "http://oracle-world.wg:3462" },
+    ]);
+
+    const localRoute = plan.reciprocalPeerUpdates.find((u) => u.recipient === "m5" && u.alias === "oracle-world");
+    expect(localRoute?.kind).toBe("noop");
+    expect(plan.blockingIssues).toEqual([]);
+  });
+
+  test("alias collision and same URL with different identity are conflicts", () => {
+    const plan = computeExpandPlan("oracle-world.wg", 3462, "m5", [
+      ...peers,
+      { name: "oracle-world", url: "http://other.wg:3462" },
+    ]);
+
+    const route = plan.reciprocalPeerUpdates.find((u) => u.alias === "oracle-world");
+    expect(route?.kind).toBe("conflict");
+    expect(route?.existingUrl).toBe("http://other.wg:3462");
+    expect(plan.blockingIssues.join("\n")).toContain("already routes");
+  });
+
+  test("half-up pair stays trust-side and does not become a routing write", () => {
+    const plan = computeExpandPlan("alpha.wg", 3461, "m5", peers);
+
+    expect(plan.peerStoreUpdates).toEqual([
+      expect.objectContaining({
+        kind: "unsafe",
+        peer: "alpha",
+        reason: expect.stringContaining("trust is separate from routing"),
+      }),
+    ]);
+    expect(plan.reciprocalPeerUpdates.every((u) => u.command.startsWith("maw peers add "))).toBe(true);
+  });
+
+  test("unsupported service OS is explicit and blocking for future apply", () => {
+    const plan = computeExpandPlan("macbook.local", 3456, "m5", peers, { targetPlatform: "darwin" });
+
+    expect(plan.servicePlan).toMatchObject({ kind: "unsafe", platform: "darwin", manager: "manual", commands: [] });
+    expect(plan.blockingIssues.join("\n")).toContain("unsupported");
+  });
+});

--- a/test/isolated/federation-index-next-coverage.test.ts
+++ b/test/isolated/federation-index-next-coverage.test.ts
@@ -55,7 +55,7 @@ describe("federation plugin index dispatch", () => {
 
     expect(federationPlugin.command).toEqual({
       name: "federation",
-      description: "Multi-node federation status and sync.",
+      description: "Multi-node federation status, sync, and expansion planning.",
     });
     expect(result).toEqual({ ok: true, output: undefined });
     expect(statusCalls).toEqual([{ peerSourceMode: "both" }]);
@@ -101,7 +101,7 @@ describe("federation plugin index dispatch", () => {
 
     expect(result).toEqual({
       ok: false,
-      error: "usage: maw federation <status|sync> [--verify|--dry-run|--check|--prune|--force|--json|--peers config|scout|both]",
+      error: "usage: maw federation <status|sync|expand> [host] [--port <port>] [--user <user>] [--oracle <name>] [--verify|--dry-run|--check|--prune|--force|--json|--peers config|scout|both]",
     });
 
     statusThrows = new Error("status exploded");


### PR DESCRIPTION
## Summary
- Add pure `computeExpandPlan()` module for `maw federation expand` read-only planning.
- Wire `maw federation expand <host> --port --user --oracle --json` into the federation plugin.
- Emit separate routing (`newNodeSeedConfig`, `reciprocalPeerUpdates`) and trust (`peerStoreUpdates`) streams, plus service and firewall plans.
- Keep PR1 guardrail intact: no `--apply`, no `saveConfig`, no SSH/network/config mutation.

Refs #1933.

## Validation
- `bun test test/expand-plan.test.ts src/commands/plugins/federation/federation.test.ts`
- `bun run build`
- `./dist/maw federation expand oracle-world.wg --port 3462 --user mawjs --json`
- `bun run test:default:safe`

## Attribution
Written by [m5:mawjscodex] — an Oracle AI running gpt-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
