### PR TITLE
fix(relocate): accept tmux trailing-dash window names

### DIFF
--- a/src/commands/shared/promote-cmd.ts
+++ b/src/commands/shared/promote-cmd.ts
@@ -32,6 +32,11 @@ function targetWindow(target: string): string | null {
   return win.length > 0 ? win : null;
 }
 
+function stripTmuxDisplaySuffix(window: string): string | null {
+  if (!window.endsWith("-") || window.length <= 1) return null;
+  return window.slice(0, -1);
+}
+
 const PROMOTE_PLACEHOLDER = "__promote_placeholder__";
 
 /**
@@ -50,7 +55,15 @@ export async function resolvePromoteTarget(
   const explicitWindow = targetWindow(target);
 
   if (explicitWindow) {
-    return { session: explicitSession, window: explicitWindow };
+    const sessions = await listAllFn();
+    const srcSession = sessions.find(s => s.name.toLowerCase() === explicitSession.toLowerCase());
+    if (!srcSession) return { session: explicitSession, window: explicitWindow };
+    const exact = srcSession.windows.find(w => w.name.toLowerCase() === explicitWindow.toLowerCase());
+    if (exact) return { session: srcSession.name, window: exact.name };
+    const canonical = stripTmuxDisplaySuffix(explicitWindow);
+    if (!canonical) return { session: srcSession.name, window: explicitWindow };
+    const canonicalMatch = srcSession.windows.find(w => w.name.toLowerCase() === canonical.toLowerCase());
+    return { session: srcSession.name, window: canonicalMatch?.name ?? explicitWindow };
   }
 
   const sessions = await listAllFn();
@@ -58,6 +71,16 @@ export async function resolvePromoteTarget(
   for (const s of sessions) {
     for (const w of s.windows) {
       if (w.name === target) matches.push({ session: s.name, window: w.name });
+    }
+  }
+  if (matches.length === 0) {
+    const canonical = stripTmuxDisplaySuffix(target);
+    if (canonical) {
+      for (const s of sessions) {
+        for (const w of s.windows) {
+          if (w.name === canonical) matches.push({ session: s.name, window: w.name });
+        }
+      }
     }
   }
 

--- a/src/vendor/mpr-plugins/take/impl.ts
+++ b/src/vendor/mpr-plugins/take/impl.ts
@@ -10,6 +10,33 @@ import { buildCommandInDir } from "maw-js/config";
  *
  * The window's worktree/cwd stays the same. Only the tmux home changes.
  */
+
+function stripTmuxDisplaySuffix(window: string): string | null {
+  if (!window.endsWith("-") || window.length <= 1) return null;
+  return window.slice(0, -1);
+}
+
+function defaultSplitTargetName(window: string): string {
+  return stripTmuxDisplaySuffix(window) ?? window;
+}
+
+function resolveSourceWindow(
+  windows: Array<{ index: number; name: string }>,
+  requested: string,
+): { index: number; name: string } | undefined {
+  const exact = windows.find(w =>
+    w.name.toLowerCase() === requested.toLowerCase() || String(w.index) === requested
+  );
+  if (exact) return exact;
+
+  const canonical = stripTmuxDisplaySuffix(requested);
+  if (!canonical) return undefined;
+
+  return windows.find(w =>
+    w.name.toLowerCase() === canonical.toLowerCase() || String(w.index) === canonical
+  );
+}
+
 export async function cmdTake(source: string, targetSession?: string) {
   // Parse source — "neo:skills-cli" or "neo:3"
   const [srcSession, srcWindow] = source.includes(":") ? source.split(":", 2) : [source, ""];
@@ -26,7 +53,7 @@ export async function cmdTake(source: string, targetSession?: string) {
 
   if (split) {
     // Create a new session named after the window
-    target = srcWindow;
+    target = defaultSplitTargetName(srcWindow);
     try {
       await hostExec(`tmux new-session -d -s '${target}'`);
     } catch (e: any) {
@@ -48,9 +75,7 @@ export async function cmdTake(source: string, targetSession?: string) {
     throw new Error(`session '${srcSession}' not found`);
   }
 
-  const srcWin = srcSess.windows.find(w =>
-    w.name.toLowerCase() === srcWindow.toLowerCase() || String(w.index) === srcWindow
-  );
+  const srcWin = resolveSourceWindow(srcSess.windows, srcWindow);
   if (!srcWin) {
     throw new Error(`window '${srcWindow}' not found in session '${srcSession}'`);
   }

--- a/test/isolated/promote-cmd.test.ts
+++ b/test/isolated/promote-cmd.test.ts
@@ -50,8 +50,18 @@ describe("resolvePromoteTarget (#1910)", () => {
     expect(r).toEqual({ session: "77-mawjs", window: "test-cli" });
   });
 
+  test("qualified session:window with tmux trailing-dash display suffix resolves to canonical window", async () => {
+    const r = await resolvePromoteTarget("77-mawjs:test-cli-", listAll);
+    expect(r).toEqual({ session: "77-mawjs", window: "test-cli" });
+  });
+
   test("bare name with single match resolves cleanly", async () => {
     const r = await resolvePromoteTarget("test-cli", listAll);
+    expect(r).toEqual({ session: "77-mawjs", window: "test-cli" });
+  });
+
+  test("bare name with tmux trailing-dash display suffix resolves to canonical window", async () => {
+    const r = await resolvePromoteTarget("test-cli-", listAll);
     expect(r).toEqual({ session: "77-mawjs", window: "test-cli" });
   });
 

--- a/test/isolated/vendor-take-impl-coverage.test.ts
+++ b/test/isolated/vendor-take-impl-coverage.test.ts
@@ -89,6 +89,17 @@ describe("vendor take impl coverage", () => {
     await expect(cmdTake("neo:skills", "pulse")).rejects.toThrow("window 'skills' not found in session 'neo'");
   });
 
+  test("accepts tmux displayed trailing-dash window names by moving canonical window", async () => {
+    sessions = [{ name: "neo", windows: [{ index: 2, name: "skills" }] }];
+
+    await cmdTake("neo:skills-");
+
+    expect(hostExecCalls[0]).toContain("tmux new-session -d -s 'skills'");
+    expect(hostExecCalls).toContain("tmux display-message -t 'neo:skills' -p '#{pane_current_path}'");
+    expect(hostExecCalls).toContain("tmux move-window -s 'neo:skills' -t 'skills:'");
+    expect(logs.join("\n")).toContain("neo:skills → skills (new session)");
+  });
+
   test("moves by numeric window index, tolerates cwd and kill-window failures, and wraps move errors", async () => {
     sessions = [{ name: "Neo", windows: [{ index: 2, name: "skills" }] }];
     hostExecImpl = async (cmd: string) => {


### PR DESCRIPTION
Closes #1948.

## Summary
- Preserves exact window-name matches first.
- When exact lookup fails, accepts tmux's trailing-dash duplicate-window display form by resolving it to the canonical unsuffixed window name.
- Applies the fix to both `maw take` and `maw promote` relocation paths.

## Tests
- `bun test test/isolated/promote-cmd.test.ts` (23 pass)
- `bun test test/isolated/vendor-take-impl-coverage.test.ts` (7 pass)
- `bun run build`

## Notes
- Scoped to #1948; does not touch #1933 expand-plan work.
