### PR TITLE
feat(federation): probe expand targets on demand

### DIFF
--- a/src/commands/plugins/federation/index.ts
+++ b/src/commands/plugins/federation/index.ts
@@ -40,7 +40,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     if (sub === "--help" || sub === "-h" || sub === "help") {
       return {
         ok: false,
-        error: "usage: maw federation <status|sync|expand> [host] [--port <port>] [--user <user>] [--oracle <name>] [--verify|--dry-run|--check|--prune|--force|--json|--peers config|scout|both]",
+        error: "usage: maw federation <status|sync|expand> [host] [--port <port>] [--user <user>] [--oracle <name>] [--verify|--dry-run|--check|--prune|--force|--json|--probe|--peers config|scout|both]",
       };
     }
 
@@ -71,7 +71,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       }
       const host = args[1];
       if (!host || host.startsWith("--")) {
-        return { ok: false, error: "usage: maw federation expand <new-node-host> [--port <port>] [--user <user>] [--oracle <name>] [--json]" };
+        return { ok: false, error: "usage: maw federation expand <new-node-host> [--port <port>] [--user <user>] [--oracle <name>] [--probe] [--json]" };
       }
       const portRaw = readOption(args, "--port");
       const port = portRaw ? Number(portRaw) : 3456;
@@ -91,11 +91,20 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         seen.add(key);
         return true;
       });
-      const plan = computeExpandPlan(host, port, config.node || "local", knownPeers, {
+      const baseOpts = {
         user: readOption(args, "--user"),
         oracle: readOption(args, "--oracle") || config.oracle,
-        targetPlatform: "linux",
-      });
+        targetPlatform: "linux" as const,
+      };
+      const initialPlan = computeExpandPlan(host, port, config.node || "local", knownPeers, baseOpts);
+      let probeIdentity;
+      if (args.includes("--probe")) {
+        const { fetchExpandProbeIdentity } = await import("../../shared/expand-probe");
+        probeIdentity = await fetchExpandProbeIdentity(initialPlan.target.url);
+      }
+      const plan = probeIdentity
+        ? computeExpandPlan(host, port, config.node || "local", knownPeers, { ...baseOpts, probeIdentity })
+        : initialPlan;
       if (args.includes("--json")) {
         console.log(JSON.stringify(plan, null, 2));
       } else {
@@ -109,6 +118,12 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         console.log(`  service plan: ${plan.servicePlan.kind} (${plan.servicePlan.manager})`);
         for (const cmd of plan.servicePlan.commands) console.log(`    ${cmd}`);
         console.log(`  firewall: ${plan.firewallPlan.command}`);
+        if (plan.probePlan) {
+          const advertised = plan.probePlan.advertisedNode ? ` node=${plan.probePlan.advertisedNode}` : "";
+          const agentCount = plan.probePlan.agents.length;
+          console.log(`  probe: ${plan.probePlan.kind} reachable=${plan.probePlan.reachable}${advertised} agents=${agentCount}`);
+          for (const warning of plan.probePlan.warnings) console.log(`  ! ${warning}`);
+        }
         for (const warning of [...plan.warnings, ...plan.servicePlan.warnings, ...plan.firewallPlan.warnings]) {
           console.log(`  ! ${warning}`);
         }
@@ -121,7 +136,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     } else {
       return {
         ok: false,
-        error: "usage: maw federation <status|sync|expand> [host] [--port <port>] [--user <user>] [--oracle <name>] [--verify|--dry-run|--check|--prune|--force|--json|--peers config|scout|both]",
+        error: "usage: maw federation <status|sync|expand> [host] [--port <port>] [--user <user>] [--oracle <name>] [--verify|--dry-run|--check|--prune|--force|--json|--probe|--peers config|scout|both]",
       };
     }
 

--- a/src/commands/plugins/federation/plugin.json
+++ b/src/commands/plugins/federation/plugin.json
@@ -10,7 +10,7 @@
     "aliases": [
       "fed"
     ],
-    "help": "maw federation <status|sync|expand> [host] [--port <port>] [--user <user>] [--oracle <name>] [--dry-run|--check|--prune|--force|--json] [--peers config|scout|both]",
+    "help": "maw federation <status|sync|expand> [host] [--port <port>] [--user <user>] [--oracle <name>] [--dry-run|--check|--prune|--force|--probe|--json] [--peers config|scout|both]",
     "flags": {
       "--dry-run": "boolean",
       "--check": "boolean",
@@ -18,6 +18,7 @@
       "--force": "boolean",
       "--verify": "boolean",
       "--json": "boolean",
+      "--probe": "boolean",
       "--peers": "string",
       "--port": "string",
       "--user": "string",

--- a/src/commands/shared/expand-plan.ts
+++ b/src/commands/shared/expand-plan.ts
@@ -7,11 +7,33 @@ import type { PeerConfig } from "../../config";
 
 export type ExpandDeltaKind = "noop" | "add" | "update" | "conflict" | "unsafe";
 
+export interface ExpandProbeIdentity {
+  url: string;
+  reachable: boolean;
+  advertisedNode?: string;
+  agents: string[];
+  status?: number;
+  error?: string;
+}
+
+export interface ExpandProbePlan {
+  kind: ExpandDeltaKind;
+  url: string;
+  reachable: boolean;
+  expectedNode: string;
+  advertisedNode?: string;
+  agents: string[];
+  warnings: string[];
+  blockingIssues: string[];
+  error?: string;
+}
+
 export interface ExpandPlanOptions {
   user?: string;
   oracle?: string;
   targetPlatform?: NodeJS.Platform | "unknown";
   subnet?: string;
+  probeIdentity?: ExpandProbeIdentity;
 }
 
 export interface ExpandTarget {
@@ -69,6 +91,7 @@ export interface ExpandPlan {
   peerStoreUpdates: ExpandPeerStoreDelta[];
   servicePlan: ExpandServicePlan;
   firewallPlan: ExpandFirewallPlan;
+  probePlan?: ExpandProbePlan;
   warnings: string[];
   blockingIssues: string[];
 }
@@ -108,6 +131,65 @@ function aliasesFor(node: string, oracle: string): string[] {
   const aliases = [node, `${node}-${oracle}`];
   if (node.startsWith("oracle-")) aliases.push(`${node.slice("oracle-".length)}-${oracle}`);
   return uniq(aliases.filter(Boolean));
+}
+
+
+function computeProbePlan(expectedNode: string, probe: ExpandProbeIdentity): ExpandProbePlan {
+  const warnings: string[] = [];
+  const blockingIssues: string[] = [];
+  if (!probe.reachable) {
+    warnings.push(`probe could not reach ${probe.url}: ${probe.error || `http ${probe.status ?? "?"}`}`);
+    return {
+      kind: "unsafe",
+      url: probe.url,
+      reachable: false,
+      expectedNode,
+      advertisedNode: probe.advertisedNode,
+      agents: probe.agents,
+      warnings,
+      blockingIssues,
+      ...(probe.error ? { error: probe.error } : {}),
+    };
+  }
+
+  if (!probe.advertisedNode) {
+    blockingIssues.push(`probe reached ${probe.url} but /api/identity did not advertise a node`);
+    return {
+      kind: "unsafe",
+      url: probe.url,
+      reachable: true,
+      expectedNode,
+      agents: probe.agents,
+      warnings,
+      blockingIssues,
+      ...(probe.error ? { error: probe.error } : {}),
+    };
+  }
+
+  if (probe.advertisedNode !== expectedNode) {
+    blockingIssues.push(`probe expected node ${expectedNode} but ${probe.url} advertised ${probe.advertisedNode}`);
+    return {
+      kind: "conflict",
+      url: probe.url,
+      reachable: true,
+      expectedNode,
+      advertisedNode: probe.advertisedNode,
+      agents: probe.agents,
+      warnings,
+      blockingIssues,
+    };
+  }
+
+  return {
+    kind: "noop",
+    url: probe.url,
+    reachable: true,
+    expectedNode,
+    advertisedNode: probe.advertisedNode,
+    agents: probe.agents,
+    warnings,
+    blockingIssues,
+  };
 }
 
 function routeKind(alias: string, url: string, knownPeers: PeerConfig[]): Pick<ExpandRouteDelta, "kind" | "reason" | "existingUrl"> {
@@ -202,6 +284,9 @@ export function computeExpandPlan(
       };
   if (servicePlan.kind === "unsafe") blockingIssues.push(servicePlan.warnings[0]);
 
+  const probePlan = opts.probeIdentity ? computeProbePlan(node, opts.probeIdentity) : undefined;
+  if (probePlan) blockingIssues.push(...probePlan.blockingIssues);
+
   const firewallPlan: ExpandFirewallPlan = {
     kind: "add",
     subnet,
@@ -229,6 +314,7 @@ export function computeExpandPlan(
     peerStoreUpdates,
     servicePlan,
     firewallPlan,
+    ...(probePlan ? { probePlan } : {}),
     warnings,
     blockingIssues: uniq(blockingIssues),
   };

--- a/src/commands/shared/expand-probe.ts
+++ b/src/commands/shared/expand-probe.ts
@@ -1,0 +1,42 @@
+/**
+ * expand-probe.ts — optional live probe for `maw federation expand --probe`.
+ * The planner stays pure; this module owns the opt-in network read.
+ */
+
+import { cfgTimeout } from "../../config";
+import { curlFetch } from "../../sdk";
+import type { ExpandProbeIdentity } from "./expand-plan";
+
+export async function fetchExpandProbeIdentity(url: string, timeout?: number): Promise<ExpandProbeIdentity> {
+  const identityUrl = `${url.replace(/\/+$/, "")}/api/identity`;
+  try {
+    const res = await curlFetch(identityUrl, { timeout: timeout ?? cfgTimeout("http"), from: "auto" });
+    if (!res.ok || !res.data) {
+      return {
+        url: identityUrl,
+        reachable: false,
+        agents: [],
+        status: res.status,
+        error: `http ${res.status ?? "?"}`,
+      };
+    }
+    const data = res.data as { node?: unknown; agents?: unknown };
+    const agents = Array.isArray(data.agents) ? data.agents.filter((agent): agent is string => typeof agent === "string") : [];
+    return {
+      url: identityUrl,
+      reachable: typeof data.node === "string",
+      ...(typeof data.node === "string" ? { advertisedNode: data.node } : {}),
+      agents,
+      status: res.status,
+      ...(typeof data.node === "string" ? {} : { error: "invalid identity shape" }),
+    };
+  } catch (e: any) {
+    return {
+      url: identityUrl,
+      reachable: false,
+      agents: [],
+      status: 0,
+      error: String(e?.message || e).split("\n")[0],
+    };
+  }
+}

--- a/test/expand-plan.test.ts
+++ b/test/expand-plan.test.ts
@@ -86,3 +86,72 @@ describe("computeExpandPlan", () => {
     expect(plan.blockingIssues.join("\n")).toContain("unsupported");
   });
 });
+
+describe("computeExpandPlan probe enrichment", () => {
+  test("keeps the default plan pure when --probe data is absent", () => {
+    const plan = computeExpandPlan("oracle-world.wg", 3462, "m5", peers);
+
+    expect(plan.probePlan).toBeUndefined();
+    expect(JSON.stringify(plan)).not.toContain("/api/identity");
+  });
+
+  test("accepts matching /api/identity data as a read-only noop probe delta", () => {
+    const plan = computeExpandPlan("oracle-world.wg", 3462, "m5", peers, {
+      probeIdentity: {
+        url: "http://oracle-world.wg:3462/api/identity",
+        reachable: true,
+        advertisedNode: "oracle-world",
+        agents: ["mawjs", "sila"],
+      },
+    });
+
+    expect(plan.probePlan).toMatchObject({
+      kind: "noop",
+      reachable: true,
+      expectedNode: "oracle-world",
+      advertisedNode: "oracle-world",
+      agents: ["mawjs", "sila"],
+    });
+    expect(plan.blockingIssues).toEqual([]);
+  });
+
+  test("flags node derivation mismatches from /api/identity as conflicts", () => {
+    const plan = computeExpandPlan("oracle-world.wg", 3462, "m5", peers, {
+      probeIdentity: {
+        url: "http://oracle-world.wg:3462/api/identity",
+        reachable: true,
+        advertisedNode: "white",
+        agents: ["mawjs"],
+      },
+    });
+
+    expect(plan.probePlan).toMatchObject({
+      kind: "conflict",
+      reachable: true,
+      expectedNode: "oracle-world",
+      advertisedNode: "white",
+    });
+    expect(plan.blockingIssues.join("\n")).toContain("expected node oracle-world");
+  });
+
+  test("records unreachable probes without turning the default planner into a mutator", () => {
+    const plan = computeExpandPlan("newbox.wg", 3456, "m5", peers, {
+      probeIdentity: {
+        url: "http://newbox.wg:3456/api/identity",
+        reachable: false,
+        agents: [],
+        status: 0,
+        error: "timeout",
+      },
+    });
+
+    expect(plan.probePlan).toMatchObject({
+      kind: "unsafe",
+      reachable: false,
+      expectedNode: "newbox",
+      error: "timeout",
+    });
+    expect(plan.probePlan?.warnings.join("\n")).toContain("timeout");
+    expect(plan.blockingIssues).toEqual([]);
+  });
+});

--- a/test/expand-probe.test.ts
+++ b/test/expand-probe.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const sdkPath = import.meta.resolve("../src/sdk/index.ts");
+const configPath = import.meta.resolve("../src/config.ts");
+
+let nextResponse: any = { ok: true, status: 200, data: { node: "alpha", agents: ["mawjs", 7, "sila"] } };
+let nextError: Error | null = null;
+let calls: Array<{ url: string; opts: Record<string, unknown> }> = [];
+
+mock.module(configPath, () => ({
+  cfgTimeout: () => 1234,
+}));
+
+mock.module(sdkPath, () => ({
+  curlFetch: async (url: string, opts: Record<string, unknown>) => {
+    calls.push({ url, opts });
+    if (nextError) throw nextError;
+    return nextResponse;
+  },
+}));
+
+const { fetchExpandProbeIdentity } = await import("../src/commands/shared/expand-probe.ts?probe-test");
+
+beforeEach(() => {
+  nextResponse = { ok: true, status: 200, data: { node: "alpha", agents: ["mawjs", 7, "sila"] } };
+  nextError = null;
+  calls = [];
+});
+
+describe("fetchExpandProbeIdentity", () => {
+  test("reads /api/identity with signed auto identity and normalizes agents", async () => {
+    const result = await fetchExpandProbeIdentity("http://alpha.wg:3461/");
+
+    expect(calls).toEqual([{ url: "http://alpha.wg:3461/api/identity", opts: { timeout: 1234, from: "auto" } }]);
+    expect(result).toEqual({
+      url: "http://alpha.wg:3461/api/identity",
+      reachable: true,
+      advertisedNode: "alpha",
+      agents: ["mawjs", "sila"],
+      status: 200,
+    });
+  });
+
+  test("returns structured unreachable probe data for http failures and throws", async () => {
+    nextResponse = { ok: false, status: 503, data: null };
+    let result = await fetchExpandProbeIdentity("http://alpha.wg:3461");
+    expect(result).toMatchObject({ reachable: false, status: 503, error: "http 503" });
+
+    nextError = new Error("connect timeout\nstack");
+    result = await fetchExpandProbeIdentity("http://alpha.wg:3461");
+    expect(result).toMatchObject({ reachable: false, status: 0, error: "connect timeout" });
+  });
+});

--- a/test/isolated/federation-index-next-coverage.test.ts
+++ b/test/isolated/federation-index-next-coverage.test.ts
@@ -101,7 +101,7 @@ describe("federation plugin index dispatch", () => {
 
     expect(result).toEqual({
       ok: false,
-      error: "usage: maw federation <status|sync|expand> [host] [--port <port>] [--user <user>] [--oracle <name>] [--verify|--dry-run|--check|--prune|--force|--json|--peers config|scout|both]",
+      error: "usage: maw federation <status|sync|expand> [host] [--port <port>] [--user <user>] [--oracle <name>] [--verify|--dry-run|--check|--prune|--force|--json|--probe|--peers config|scout|both]",
     });
 
     statusThrows = new Error("status exploded");


### PR DESCRIPTION
## Summary
- add opt-in `maw federation expand --probe` live enrichment for `/api/identity`
- keep default `expand` pure/read-only: no probe unless the flag is present
- report probe reachability, advertised node, agents, and derived-node conflicts in the plan

## Guardrails
- No `--apply`, config writes, SSH, saveConfig, or mutation path added
- `expand-plan.ts` remains pure; network I/O lives in the separate `expand-probe.ts` helper
- Default `maw federation expand ... --json` omits `probePlan` and does not call `/api/identity`

Refs #1933

## Tests
- `bun test test/isolated/federation-index-next-coverage.test.ts test/expand-plan.test.ts test/expand-probe.test.ts`
- `bun run build`
- `./dist/maw federation expand probe-smoke.local --port 9 --json`
- `./dist/maw federation expand 127.0.0.1 --port 9 --probe --json`
- `bun run test:default:safe`

Written by [m5:mawjscodex] — an Oracle AI running gpt-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
