### PR TITLE
fix(done): keep dry-run worktree cleanup non-mutating

### DIFF
--- a/src/commands/shared/done.ts
+++ b/src/commands/shared/done.ts
@@ -12,6 +12,7 @@ export interface DoneOpts {
   force?: boolean;
   dryRun?: boolean;
   cleanBranch?: boolean;
+  cwd?: string;
 }
 
 type SessionInfo = { name: string; windows: { index: number; name: string; active: boolean }[] };
@@ -79,6 +80,18 @@ type ResolvedDoneDeps = ReturnType<typeof doneDeps>;
 
 function shellArg(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+async function cwdMainPath(cwd: string | undefined, reposRoot: string, d: ResolvedDoneDeps): Promise<string | null> {
+  if (!cwd) return null;
+  try {
+    const top = (await d.hostExec(`git -C ${shellArg(cwd)} rev-parse --show-toplevel`)).trim();
+    if (!top) return null;
+    const parsed = parseWorktreePath(top, reposRoot);
+    return parsed?.mainPath ?? top;
+  } catch {
+    return null;
+  }
 }
 
 function branchBaseFor(mainPath: string, d: ResolvedDoneDeps): string {
@@ -223,6 +236,12 @@ export async function cmdDone(windowName_: string, opts: DoneOpts = {}, deps: Do
     d.logger.log(`  \x1b[90m○\x1b[0m no worktree to remove (may be a main window)`);
   }
 
+  if (opts.dryRun) {
+    d.logger.log(`  \x1b[36m⬡\x1b[0m [dry-run] would remove '${windowNameLower}' from fleet config if present`);
+    d.logger.log();
+    return;
+  }
+
   const removedFromConfig = removeFromFleetConfig(windowNameLower, deps);
   if (!removedFromConfig) {
     d.logger.log(`  \x1b[90m○\x1b[0m not in any fleet config`);
@@ -333,6 +352,10 @@ export async function removeWorktreeViaConfig(
       const mainPath = parsed.mainPath;
 
       try {
+        if (opts.dryRun) {
+          d.logger.log(`  \x1b[36m⬡\x1b[0m [dry-run] would remove worktree ${win.repo}`);
+          return true;
+        }
         let branch = "";
         try { branch = (await d.hostExec(`git -C '${fullPath}' rev-parse --abbrev-ref HEAD`)).trim(); } catch { /* expected */ }
         await d.hostExec(`git -C '${mainPath}' worktree remove '${fullPath}' --force`);
@@ -370,18 +393,34 @@ export async function removeWorktreeByGhqScan(
       const wtSuffix = parsed.wtName.replace(/^\d+-/, "");
       return wtSuffix.toLowerCase() === suffix.toLowerCase();
     });
-    if (exactMatch.length > 1) {
-      d.logger.error(`  \x1b[31m✗\x1b[0m refusing to remove worktree '${suffix}' — matches ${exactMatch.length} repos:`);
-      for (const wtPath of exactMatch) d.logger.error(`  \x1b[90m    • ${wtPath}\x1b[0m`);
+    let matches = exactMatch;
+    if (matches.length > 1) {
+      const mainPath = await cwdMainPath(opts.cwd, reposRoot, d);
+      if (mainPath) {
+        const scoped = matches.filter((p) => parseWorktreePath(p, reposRoot)?.mainPath === mainPath);
+        if (scoped.length === 1) {
+          matches = scoped;
+          d.logger.log(`  \x1b[36m⬡\x1b[0m scoped ambiguous worktree '${suffix}' to cwd repo ${mainPath}`);
+        }
+      }
+    }
+    if (matches.length > 1) {
+      d.logger.error(`  \x1b[31m✗\x1b[0m refusing to remove worktree '${suffix}' — matches ${matches.length} repos:`);
+      for (const wtPath of matches) d.logger.error(`  \x1b[90m    • ${wtPath}\x1b[0m`);
       d.logger.error(`  \x1b[90m  use fleet config or remove the exact worktree manually\x1b[0m`);
       return false;
     }
-    for (const wtPath of exactMatch) {
+    for (const wtPath of matches) {
       const base = basename(wtPath);
       const parsed = parseWorktreePath(wtPath, reposRoot);
       if (!parsed) continue;
       const mainPath = parsed.mainPath;
       try {
+        if (opts.dryRun) {
+          d.logger.log(`  \x1b[36m⬡\x1b[0m [dry-run] would remove worktree ${base}`);
+          removed = true;
+          continue;
+        }
         let branch = "";
         try { branch = (await d.hostExec(`git -C '${wtPath}' rev-parse --abbrev-ref HEAD`)).trim(); } catch { /* expected */ }
         await d.hostExec(`git -C '${mainPath}' worktree remove '${wtPath}' --force`);

--- a/src/vendor/mpr-plugins/done/done-worktree.ts
+++ b/src/vendor/mpr-plugins/done/done-worktree.ts
@@ -7,6 +7,8 @@ import { parseWorktreePath } from "maw-js/core/fleet/worktree-layout";
 export interface DoneBranchCleanupOpts {
   cleanBranch?: boolean;
   branchBase?: string;
+  dryRun?: boolean;
+  cwd?: string;
 }
 
 function activeFleetConfigFiles(): Array<{ file: string; path: string }> {
@@ -27,6 +29,18 @@ function activeFleetConfigFiles(): Array<{ file: string; path: string }> {
 
 function shellArg(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+async function cwdMainPath(cwd: string | undefined, reposRoot: string): Promise<string | null> {
+  if (!cwd) return null;
+  try {
+    const top = (await hostExec(`git -C ${shellArg(cwd)} rev-parse --show-toplevel`)).trim();
+    if (!top) return null;
+    const parsed = parseWorktreePath(top, reposRoot);
+    return parsed?.mainPath ?? top;
+  } catch {
+    return null;
+  }
 }
 
 function branchBaseFor(mainPath: string, opts: DoneBranchCleanupOpts = {}): string {
@@ -123,6 +137,10 @@ export async function removeWorktreeViaConfig(
       const mainPath = parsed.mainPath;
 
       try {
+        if (opts.dryRun) {
+          console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would remove worktree ${win.repo}`);
+          return true;
+        }
         let branch = "";
         try { branch = (await hostExec(`git -C '${fullPath}' rev-parse --abbrev-ref HEAD`)).trim(); } catch { /* expected */ }
         await hostExec(`git -C '${mainPath}' worktree remove '${fullPath}' --force`);
@@ -161,18 +179,34 @@ export async function removeWorktreeByGhqScan(
       const wtSuffix = parsed.wtName.replace(/^\d+-/, "");
       return wtSuffix.toLowerCase() === suffix.toLowerCase();
     });
-    if (exactMatch.length > 1) {
-      console.error(`  \x1b[31m✗\x1b[0m refusing to remove worktree '${suffix}' — matches ${exactMatch.length} repos:`);
-      for (const wtPath of exactMatch) console.error(`  \x1b[90m    • ${wtPath}\x1b[0m`);
+    let matches = exactMatch;
+    if (matches.length > 1) {
+      const mainPath = await cwdMainPath(opts.cwd, reposRoot);
+      if (mainPath) {
+        const scoped = matches.filter((p) => parseWorktreePath(p, reposRoot)?.mainPath === mainPath);
+        if (scoped.length === 1) {
+          matches = scoped;
+          console.log(`  \x1b[36m⬡\x1b[0m scoped ambiguous worktree '${suffix}' to cwd repo ${mainPath}`);
+        }
+      }
+    }
+    if (matches.length > 1) {
+      console.error(`  \x1b[31m✗\x1b[0m refusing to remove worktree '${suffix}' — matches ${matches.length} repos:`);
+      for (const wtPath of matches) console.error(`  \x1b[90m    • ${wtPath}\x1b[0m`);
       console.error(`  \x1b[90m  use fleet config or remove the exact worktree manually\x1b[0m`);
       return false;
     }
-    for (const wtPath of exactMatch) {
+    for (const wtPath of matches) {
       const parsed = parseWorktreePath(wtPath, reposRoot);
       if (!parsed) continue;
       const base = parsed.dirName;
       const mainPath = parsed.mainPath;
       try {
+        if (opts.dryRun) {
+          console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would remove worktree ${base}`);
+          removed = true;
+          continue;
+        }
         let branch = "";
         try { branch = (await hostExec(`git -C '${wtPath}' rev-parse --abbrev-ref HEAD`)).trim(); } catch { /* expected */ }
         await hostExec(`git -C '${mainPath}' worktree remove '${wtPath}' --force`);

--- a/src/vendor/mpr-plugins/done/impl.ts
+++ b/src/vendor/mpr-plugins/done/impl.ts
@@ -11,6 +11,7 @@ export interface DoneOpts {
   force?: boolean;
   dryRun?: boolean;
   cleanBranch?: boolean;
+  cwd?: string;
   /** Restrict window-name lookup to a specific tmux session. Used by done --all. */
   sessionName?: string;
 }
@@ -103,6 +104,12 @@ export async function cmdDone(windowName_: string, opts: DoneOpts = {}) {
   }
   if (!removedWorktree) {
     console.log(`  \x1b[90m○\x1b[0m no worktree to remove (may be a main window)`);
+  }
+
+  if (opts.dryRun) {
+    console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would remove '${windowNameLower}' from fleet config if present`);
+    console.log();
+    return;
   }
 
   // 3. Remove from fleet config

--- a/src/vendor/mpr-plugins/done/index.ts
+++ b/src/vendor/mpr-plugins/done/index.ts
@@ -44,7 +44,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     }
 
     if (all) {
-      await cmdDoneAll({ force, dryRun, cleanBranch });
+      await cmdDoneAll({ force, dryRun, cleanBranch, cwd: process.cwd() });
       return { ok: true, output: logs.join("\n") || undefined };
     }
 
@@ -52,7 +52,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       return { ok: false, error: "usage: maw done <window-name> [--force] [--dry-run] [--clean-branch] or maw done --all [--force] [--dry-run] [--clean-branch]  (see: maw sleep/kill for non-worktree shutdown)" };
     }
 
-    await cmdDone(name, { force, dryRun, cleanBranch });
+    await cmdDone(name, { force, dryRun, cleanBranch, cwd: process.cwd() });
     return { ok: true, output: logs.join("\n") || undefined };
   } catch (e: any) {
     return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };

--- a/test/done-command.test.ts
+++ b/test/done-command.test.ts
@@ -221,17 +221,27 @@ describe("cmdDone", () => {
     expect(h.logs.join("\n")).toContain("killed window work:tile-1");
   });
 
-  test("dry-run for a missing window reports that no autosave target is running", async () => {
+  test("dry-run for a missing window reports lookup paths without mutating cleanup state", async () => {
+    const fleetFile = "/fleet/team.json";
     const h = createHarness({
       sessions: [{ name: "work", windows: [{ index: 0, name: "lead", active: true }] }],
+      files: {
+        [fleetFile]: JSON.stringify({ windows: [{ name: "missing", repo: "org/repo.wt-missing" }] }),
+      },
+      hostExec: (command) => {
+        if (command.startsWith("find ")) return "";
+        throw new Error(`dry-run should not mutate: ${command}`);
+      },
     });
 
     await cmdDone("missing", { dryRun: true }, h.deps);
 
     expect(h.logs.join("\n")).toContain("window 'missing' not running — nothing to auto-save");
-    expect(h.logs.join("\n")).toContain("window 'missing' not running");
+    expect(h.logs.join("\n")).toContain("[dry-run] would remove worktree org/repo.wt-missing");
+    expect(h.logs.join("\n")).toContain("[dry-run] would remove 'missing' from fleet config if present");
     expect(h.killed).toEqual([]);
-    expect(h.snapshots).toEqual(["done"]);
+    expect(h.snapshots).toEqual([]);
+    expect(JSON.parse(h.files.get(fleetFile)!)).toEqual({ windows: [{ name: "missing", repo: "org/repo.wt-missing" }] });
   });
 });
 
@@ -567,6 +577,44 @@ describe("done worktree cleanup helpers", () => {
     expect(h.commands).toEqual(["find '/repos/github.com' -maxdepth 4 -type d \\( -name '*.wt-*' -o -path '*/agents/*' \\) 2>/dev/null"]);
     expect(h.errors.join("\n")).toContain("refusing to remove worktree 'tile-1' — matches 2 repos");
     expect(h.errors.join("\n")).toContain("/repos/github.com/Other/repo.wt-tile-1");
+  });
+
+
+  test("removeWorktreeByGhqScan uses caller cwd to disambiguate same-suffix worktrees", async () => {
+    const h = createHarness({
+      hostExec: (command) => {
+        if (command.startsWith("find ")) {
+          return [
+            "/repos/github.com/laris-co/ccc-oracle.wt-trio-coder",
+            "/repos/github.com/Soul-Brews-Studio/mawjs-oracle/agents/1-trio-coder",
+          ].join("\n");
+        }
+        if (command.includes("rev-parse --show-toplevel")) return "/repos/github.com/Soul-Brews-Studio/mawjs-oracle/agents/1-trio-coder\n";
+        if (command.includes("rev-parse --abbrev-ref HEAD")) return "feature/trio\n";
+        if (command.includes("merge-base --is-ancestor")) return "";
+        return "";
+      },
+    });
+
+    await expect(removeWorktreeByGhqScan("mawjs-trio-coder", "/repos/github.com", h.deps, { cwd: "/repos/github.com/Soul-Brews-Studio/mawjs-oracle" })).resolves.toBe(true);
+
+    expect(h.logs.join("\n")).toContain("scoped ambiguous worktree 'trio-coder' to cwd repo /repos/github.com/Soul-Brews-Studio/mawjs-oracle");
+    expect(h.commands).toContain("git -C '/repos/github.com/Soul-Brews-Studio/mawjs-oracle' worktree remove '/repos/github.com/Soul-Brews-Studio/mawjs-oracle/agents/1-trio-coder' --force");
+    expect(h.commands.join("\n")).not.toContain("ccc-oracle.wt-trio-coder' --force");
+  });
+
+  test("removeWorktreeByGhqScan dry-run reports resolved worktrees without removing them", async () => {
+    const h = createHarness({
+      hostExec: (command) => {
+        if (command.startsWith("find ")) return "/repos/github.com/Soul-Brews-Studio/maw-js.wt-tile-1\n";
+        throw new Error(`dry-run should not run git mutation: ${command}`);
+      },
+    });
+
+    await expect(removeWorktreeByGhqScan("x-tile-1", "/repos/github.com", h.deps, { dryRun: true })).resolves.toBe(true);
+
+    expect(h.commands).toEqual(["find '/repos/github.com' -maxdepth 4 -type d \\( -name '*.wt-*' -o -path '*/agents/*' \\) 2>/dev/null"]);
+    expect(h.logs.join("\n")).toContain("[dry-run] would remove worktree maw-js.wt-tile-1");
   });
 
   test("removeWorktreeByGhqScan reports find and per-worktree failures", async () => {

--- a/test/isolated/done-index-coverage.test.ts
+++ b/test/isolated/done-index-coverage.test.ts
@@ -46,7 +46,7 @@ describe("done plugin index wrapper", () => {
     } as InvokeCtx);
 
     expect(result).toEqual({ ok: true, output: "done:tile-1:true:true" });
-    expect(doneCalls).toEqual([{ name: "tile-1", opts: { force: true, dryRun: true, cleanBranch: true } }]);
+    expect(doneCalls).toEqual([{ name: "tile-1", opts: { force: true, dryRun: true, cleanBranch: true, cwd: process.cwd() } }]);
     expect(doneAllCalls).toEqual([]);
   });
 
@@ -60,7 +60,7 @@ describe("done plugin index wrapper", () => {
     } as InvokeCtx);
 
     expect(result).toEqual({ ok: true, output: undefined });
-    expect(doneAllCalls).toEqual([{ force: true, dryRun: false, cleanBranch: true }]);
+    expect(doneAllCalls).toEqual([{ force: true, dryRun: false, cleanBranch: true, cwd: process.cwd() }]);
     expect(lines).toEqual(["all:true:false"]);
   });
 
@@ -71,7 +71,7 @@ describe("done plugin index wrapper", () => {
     } as InvokeCtx);
 
     expect(result.ok).toBe(true);
-    expect(doneCalls).toEqual([{ name: "tile-2", opts: { force: true, dryRun: false, cleanBranch: true } }]);
+    expect(doneCalls).toEqual([{ name: "tile-2", opts: { force: true, dryRun: false, cleanBranch: true, cwd: process.cwd() } }]);
   });
 
   test("returns usage for missing API name without calling implementation", async () => {

--- a/test/isolated/done-worktree-coverage.test.ts
+++ b/test/isolated/done-worktree-coverage.test.ts
@@ -295,6 +295,37 @@ describe("removeWorktreeByGhqScan", () => {
     expect(output).toContain("use fleet config or remove the exact worktree manually");
   });
 
+
+  test("uses caller cwd to disambiguate exact suffix matches and dry-run avoids worktree removal", async () => {
+    const one = join(REPOS_ROOT, "github.com", "laris-co", "ccc-oracle.wt-trio-coder");
+    const two = join(REPOS_ROOT, "github.com", "Soul-Brews-Studio", "mawjs-oracle", "agents", "1-trio-coder");
+    hostExecHandler = (command) => {
+      if (command.startsWith(`find '${REPOS_ROOT}'`)) return [one, two].join("\n");
+      if (command.includes("rev-parse --show-toplevel")) return `${join(REPOS_ROOT, "github.com", "Soul-Brews-Studio", "mawjs-oracle", "agents", "1-trio-coder")}\n`;
+      if (command.includes("rev-parse --abbrev-ref HEAD")) return "feature/trio\n";
+      return "";
+    };
+
+    const output = await captureConsole(async () => {
+      expect(await removeWorktreeByGhqScan("mawjs-trio-coder", REPOS_ROOT, { cwd: join(REPOS_ROOT, "github.com", "Soul-Brews-Studio", "mawjs-oracle") })).toBe(true);
+    });
+
+    expect(output).toContain("scoped ambiguous worktree 'trio-coder'");
+    expect(hostExecCalls).toContain(`git -C '${join(REPOS_ROOT, "github.com", "Soul-Brews-Studio", "mawjs-oracle")}' worktree remove '${two}' --force`);
+    expect(hostExecCalls.join("\n")).not.toContain("ccc-oracle.wt-trio-coder' --force");
+
+    hostExecCalls = [];
+    hostExecHandler = (command) => {
+      if (command.startsWith(`find '${REPOS_ROOT}'`)) return two;
+      throw new Error(`dry-run should not mutate: ${command}`);
+    };
+    const dryRunOutput = await captureConsole(async () => {
+      expect(await removeWorktreeByGhqScan("mawjs-trio-coder", REPOS_ROOT, { dryRun: true })).toBe(true);
+    });
+    expect(hostExecCalls).toEqual([`find '${REPOS_ROOT}' -maxdepth 4 -type d \\( -name '*.wt-*' -o -path '*/agents/*' \\) 2>/dev/null`]);
+    expect(dryRunOutput).toContain("[dry-run] would remove worktree agents/1-trio-coder");
+  });
+
   test("reports scan failures and returns false", async () => {
     hostExecHandler = () => {
       throw new Error("find denied");


### PR DESCRIPTION
## Summary
- make `maw done --dry-run` non-mutating when the target window is already gone and cleanup falls back to configured/ghq worktree cleanup
- thread caller cwd into done cleanup so duplicate worktree suffixes can be scoped to the current repo before refusing ambiguity
- cover cwd-scoped disambiguation, ghq dry-run, plugin index cwd wiring, and missing-window dry-run no-mutation

Closes #1955.

## Tests
- `bun test test/done-command.test.ts test/isolated/done-worktree-coverage.test.ts`
- `bun test test/isolated/done-index-coverage.test.ts`
- `bun test test/isolated/done-all.test.ts`
- `bun run build`
- `bun run test:default:safe`

Written by [m5:mawjscodex] — an Oracle AI running gpt-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
