### PR TITLE
fix(tmux): allow kill alias force flags

### DIFF
--- a/src/commands/plugins/tmux/plugin.json
+++ b/src/commands/plugins/tmux/plugin.json
@@ -23,7 +23,10 @@
       "--output": "boolean",
       "--no-output": "boolean",
       "--only-if-closed": "boolean",
-      "-o": "boolean"
+      "-o": "boolean",
+      "--force": "boolean",
+      "--session": "boolean",
+      "-s": "boolean"
     }
   },
   "weight": 10,

--- a/test/cli/dispatch-match.test.ts
+++ b/test/cli/dispatch-match.test.ts
@@ -9,6 +9,7 @@
  *  - prefix match with word boundary (e.g. `restart` != `rest`)
  */
 import { describe, test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
 import { resolvePluginMatch, validatePluginCliFlags } from "../../src/cli/dispatch-match";
 import { ALIAS_DESCRIPTIONS, parseBringArgs, parseLsAliasOpts, resolveTopAlias } from "../../src/cli/top-aliases";
 import type { LoadedPlugin } from "../../src/plugin/types";
@@ -281,6 +282,20 @@ describe("validatePluginCliFlags — manifest-declared flags", () => {
     const p = plugin("hello", "hello", [], { "--name": "string" });
 
     expect(validatePluginCliFlags(p, ["--name", "world", "--", "--not-a-flag"])).toEqual({ ok: true });
+  });
+
+  test("tmux manifest allows kill alias subcommand flags (#1954)", () => {
+    const manifest = JSON.parse(readFileSync("src/commands/plugins/tmux/plugin.json", "utf8"));
+    const tmux: LoadedPlugin = {
+      manifest,
+      dir: "src/commands/plugins/tmux",
+      wasmPath: "",
+      kind: "ts",
+    };
+
+    expect(validatePluginCliFlags(tmux, ["kill", "77-mawjs:mawjs-oracle.1", "--force"])).toEqual({ ok: true });
+    expect(validatePluginCliFlags(tmux, ["kill", "77-mawjs", "--session"])).toEqual({ ok: true });
+    expect(validatePluginCliFlags(tmux, ["kill", "77-mawjs", "-s"])).toEqual({ ok: true });
   });
 });
 


### PR DESCRIPTION
## Summary
- declare `--force`, `--session`, and `-s` in the bundled tmux plugin manifest
- add a regression test that validates the real tmux manifest accepts kill alias subcommand flags
- keep the fix narrow: no dispatch bypass, handler behavior unchanged

Closes #1954.

## Tests
- `bun test test/cli/dispatch-match.test.ts test/tmux-index-default.test.ts`
- `bun run build`

Written by [m5:mawjscodex] — an Oracle AI running gpt-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
