### PR TITLE
test(config): gate generic engines with golden master

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,9 @@
 // Barrel — re-exports from split config modules.
 export type { TriggerEvent, TriggerConfig, PeerConfig, MawIntervals, MawTimeouts, MawLimits, MawConfig } from "./config/types";
 export { D } from "./config/types";
+export { DEFAULT_ENGINES, resolveEngine } from "./config/engine-registry";
+export type { EngineDef } from "./config/engine-def";
+export type { EngineRegistry } from "./config/engine-registry";
 export { validateConfigShape } from "./config/validate";
 export { loadConfig, loadConfigWithProvenance, resetConfig, saveConfig, configForDisplay, cfgInterval, cfgTimeout, cfgLimit, cfg } from "./config/load";
 export { buildCommand, buildCommandInDir, getEnvVars } from "./config/command";

--- a/src/config/engine-def.ts
+++ b/src/config/engine-def.ts
@@ -1,0 +1,34 @@
+/**
+ * Declarative agent engine definition (#1960).
+ *
+ * P1 is intentionally dormant: command rendering still flows through the
+ * legacy command builder until the golden-master harness gates later phases.
+ */
+export interface EngineDef {
+  /** Stable config key / CLI engine name (for example: claude, codex). */
+  name: string;
+  /** Executable or shell command prefix used to launch the engine. */
+  cmd: string;
+  /** Human label for UI surfaces such as swarm/team panes. */
+  label?: string;
+  /** Arguments for a fresh launch form. Advisory until P2/P3 consumes it. */
+  freshArgs?: string[];
+  /** Resume form for engines that support session resurrection. */
+  resume?: {
+    flag: string;
+    replaces?: string;
+    quoteValue?: boolean;
+  };
+  /** Model selection surface for engines that support model routing. */
+  model?: {
+    flag?: string;
+    env?: string;
+    default?: string;
+  };
+  /** Capability gates consumed by future renderers. */
+  capabilities?: string[];
+  /** Preferred pane placement. Advisory until wake/team routing consumes it. */
+  placement?: "split" | "window";
+  /** Preferred isolation policy. Advisory until worktree routing consumes it. */
+  isolation?: "none" | "worktree";
+}

--- a/src/config/engine-registry.ts
+++ b/src/config/engine-registry.ts
@@ -1,0 +1,52 @@
+import type { MawConfig } from "./types";
+import type { EngineDef } from "./engine-def";
+
+export const DEFAULT_ENGINES = {
+  claude: {
+    name: "claude",
+    cmd: "claude",
+    label: "Claude Code",
+    resume: { flag: "--resume", replaces: "--continue", quoteValue: true },
+    model: { flag: "--model", default: "sonnet" },
+    capabilities: ["channels", "resume", "model", "system-prompt-file"],
+  },
+  codex: { name: "codex", cmd: "codex", label: "Codex CLI" },
+  opencode: { name: "opencode", cmd: "opencode", label: "OpenCode" },
+  aider: { name: "aider", cmd: "aider", label: "Aider" },
+} satisfies Record<string, EngineDef>;
+
+export type EngineRegistry = Record<string, EngineDef>;
+
+function isClaudeLikeCommand(cmd: string): boolean {
+  return /(^|\s)(?:command\s+)?claude[A-Za-z0-9_-]*(?:\s|$)/.test(cmd);
+}
+
+function fromLegacyCommand(name: string, cmd: string): EngineDef {
+  const def: EngineDef = { name, cmd };
+  if (isClaudeLikeCommand(cmd)) {
+    def.resume = { flag: "--resume", replaces: "--continue", quoteValue: true };
+    def.model = { flag: "--model", default: "sonnet" };
+    def.capabilities = ["channels", "resume", "model", "system-prompt-file"];
+  }
+  return def;
+}
+
+/**
+ * Resolve an engine definition without changing any launch behavior yet (#1960 P1).
+ *
+ * Precedence mirrors the planned migration contract:
+ * config.engines[name] > legacy config.commands[name] > DEFAULT_ENGINES[name] >
+ * a raw command named like the requested engine.
+ */
+export function resolveEngine(name: string, config: Partial<MawConfig> = {}): EngineDef {
+  const configured = config.engines?.[name];
+  if (configured) return { name, ...configured };
+
+  const legacy = config.commands?.[name];
+  if (legacy) return fromLegacyCommand(name, legacy);
+
+  const builtIn = DEFAULT_ENGINES[name];
+  if (builtIn) return { ...builtIn };
+
+  return { name, cmd: name };
+}

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -78,6 +78,13 @@ export interface MawConfig {
   oracleUrl: string;
   env: Record<string, string>;
   commands: Record<string, string>;
+  /**
+   * Generic engine definitions (#1960 P1).
+   *
+   * Additive/dormant until later phases route command rendering through the
+   * engine registry. Legacy `commands` remains the active launch surface today.
+   */
+  engines?: Record<string, import("./engine-def").EngineDef>;
   sessions: Record<string, string>;
   tmuxSocket?: string;
   peers?: string[];

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -75,6 +75,30 @@ export function validateBasicFields(
     }
   }
 
+  // engines: Record<string, EngineDef> (#1960 P1). Dormant typed surface; keep
+  // validation intentionally light so future optional EngineDef fields can roll
+  // out without rejecting existing config.
+  if ("engines" in raw) {
+    if (raw.engines && typeof raw.engines === "object" && !Array.isArray(raw.engines)) {
+      const engines: Record<string, unknown> = {};
+      for (const [name, value] of Object.entries(raw.engines as Record<string, unknown>)) {
+        if (!value || typeof value !== "object" || Array.isArray(value)) {
+          warn(`engines.${name}`, "must be an object");
+          continue;
+        }
+        const def = value as Record<string, unknown>;
+        if (typeof def.cmd !== "string" || def.cmd.trim().length === 0) {
+          warn(`engines.${name}.cmd`, "must be a non-empty string");
+          continue;
+        }
+        engines[name] = { ...def, name: typeof def.name === "string" && def.name ? def.name : name };
+      }
+      if (Object.keys(engines).length > 0) result.engines = engines;
+    } else {
+      warn("engines", "must be an object");
+    }
+  }
+
   // sessions: Record<string, string>
   if ("sessions" in raw) {
     if (raw.sessions && typeof raw.sessions === "object" && !Array.isArray(raw.sessions)) {
@@ -129,6 +153,22 @@ export function validateConfigShape(config: unknown): string[] {
     } else {
       for (const [k, v] of Object.entries(c.commands as Record<string, unknown>)) {
         if (typeof v !== "string") errors.push(`commands.${k} must be a string`);
+      }
+    }
+  }
+
+  if (c.engines !== undefined) {
+    if (!c.engines || typeof c.engines !== "object" || Array.isArray(c.engines)) {
+      errors.push("engines must be a Record<string, EngineDef>");
+    } else {
+      for (const [k, v] of Object.entries(c.engines as Record<string, unknown>)) {
+        if (!v || typeof v !== "object" || Array.isArray(v)) {
+          errors.push(`engines.${k} must be an object`);
+          continue;
+        }
+        const def = v as Record<string, unknown>;
+        if (def.name !== undefined && typeof def.name !== "string") errors.push(`engines.${k}.name must be a string`);
+        if (typeof def.cmd !== "string" || def.cmd.length === 0) errors.push(`engines.${k}.cmd must be a non-empty string`);
       }
     }
   }

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -24,6 +24,9 @@ export {
   getEnvVars, cfgTimeout, cfgLimit, cfgInterval, cfg, D,
   resetConfig,
 } from "../config";
+export { DEFAULT_ENGINES, resolveEngine } from "../config/engine-registry";
+export type { EngineDef } from "../config/engine-def";
+export type { EngineRegistry } from "../config/engine-registry";
 export type { MawConfig } from "../config";
 
 // ─── Transport ───────────────────────────────────────────────────────────────

--- a/test/command-golden-master.test.ts
+++ b/test/command-golden-master.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const { buildCommandFromConfig, buildCommandInDirFromConfig } = await import("../src/config/command-logic");
+
+const baseConfig = {
+  host: "local",
+  port: 3456,
+  oracleUrl: "http://localhost:47779",
+  env: {},
+  commands: {
+    default: "claude",
+    claude: "claude",
+    codex: "codex",
+    opencode: "opencode",
+    aider: "aider",
+  },
+  sessions: {},
+  node: "local",
+};
+
+const origGetuid = process.getuid;
+
+beforeEach(() => {
+  (process as any).getuid = () => 1000;
+});
+
+afterEach(() => {
+  (process as any).getuid = origGetuid;
+});
+
+function build(engine: string, extra: Record<string, unknown> = {}, opts?: any): string {
+  return buildCommandFromConfig({ ...baseConfig, ...extra } as any, `${engine}-agent`, opts ?? engine);
+}
+
+describe("buildCommandFromConfig golden master (#1960 P0)", () => {
+  test("snapshots fresh/resume/channel/model behavior for the four seeded engines", () => {
+    const cases = [
+      ["claude fresh", build("claude"), "claude"],
+      ["claude resume", build("claude", { sessionIds: { "claude-agent": "uuid-claude" } }), 'claude --resume "uuid-claude"'],
+      ["claude channels", build("claude", {}, { engine: "claude", channels: ["plugin:discord@claude-plugins-official"] }), "claude --channels plugin:discord@claude-plugins-official --dangerously-skip-permissions"],
+      ["claude model", buildCommandFromConfig({ ...baseConfig, commands: { ...baseConfig.commands, claude: "claude --model opus" } } as any, "claude-agent", "claude"), "claude --model opus"],
+
+      ["codex fresh", build("codex"), "codex"],
+      ["codex resume legacy-bug", build("codex", { sessionIds: { "codex-agent": "uuid-codex" } }), 'codex --resume "uuid-codex"'],
+      ["codex channels ignored", build("codex", {}, { engine: "codex", channels: ["plugin:discord@claude-plugins-official"] }), "codex"],
+      ["codex model literal", buildCommandFromConfig({ ...baseConfig, commands: { ...baseConfig.commands, codex: "codex --model gpt-5.5" } } as any, "codex-agent", "codex"), "codex --model gpt-5.5"],
+
+      ["opencode fresh", build("opencode"), "opencode"],
+      ["opencode resume legacy-bug", build("opencode", { sessionIds: { "opencode-agent": "uuid-open" } }), 'opencode --resume "uuid-open"'],
+      ["opencode channels ignored", build("opencode", {}, { engine: "opencode", channels: ["plugin:discord@claude-plugins-official"] }), "opencode"],
+      ["opencode model literal", buildCommandFromConfig({ ...baseConfig, commands: { ...baseConfig.commands, opencode: "opencode --model qwen" } } as any, "opencode-agent", "opencode"), "opencode --model qwen"],
+
+      ["aider fresh", build("aider"), "aider"],
+      ["aider resume legacy-bug", build("aider", { sessionIds: { "aider-agent": "uuid-aider" } }), 'aider --resume "uuid-aider"'],
+      ["aider channels ignored", build("aider", {}, { engine: "aider", channels: ["plugin:discord@claude-plugins-official"] }), "aider"],
+      ["aider model literal", buildCommandFromConfig({ ...baseConfig, commands: { ...baseConfig.commands, aider: "aider --model sonnet" } } as any, "aider-agent", "aider"), "aider --model sonnet"],
+    ];
+
+    for (const [name, actual, expected] of cases) {
+      expect(actual, name).toBe(expected);
+    }
+  });
+
+  test("snapshots root uid permission stripping", () => {
+    (process as any).getuid = () => 0;
+
+    expect(buildCommandFromConfig({ ...baseConfig, commands: { default: "claude --dangerously-skip-permissions" } } as any, "root-agent")).toBe("claude");
+  });
+
+  test("snapshots Discord auto-inject for Claude repos only", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "maw-engine-golden-"));
+    mkdirSync(join(tmp, ".discord"));
+
+    expect(buildCommandInDirFromConfig(baseConfig as any, "claude-agent", tmp, "claude")).toBe(
+      "claude --channels plugin:discord@claude-plugins-official",
+    );
+    expect(buildCommandInDirFromConfig(baseConfig as any, "codex-agent", tmp, "codex")).toBe("codex");
+  });
+});

--- a/test/config-validate.test.ts
+++ b/test/config-validate.test.ts
@@ -18,6 +18,7 @@ describe("validateBasicFields", () => {
       oracleUrl: "http://localhost:47779",
       env: { A: "B" },
       commands: { default: "claude", codex: "codex" },
+      engines: { codex: { cmd: "codex", label: "Codex CLI" } },
       sessions: { mawjs: "54-mawjs" },
       tmuxSocket: "maw",
     });
@@ -31,6 +32,7 @@ describe("validateBasicFields", () => {
       oracleUrl: "http://localhost:47779",
       env: { A: "B" },
       commands: { default: "claude", codex: "codex" },
+      engines: { codex: { name: "codex", cmd: "codex", label: "Codex CLI" } },
       sessions: { mawjs: "54-mawjs" },
       tmuxSocket: "maw",
     });
@@ -63,6 +65,9 @@ describe("validateBasicFields", () => {
       [{ commands: [] }, "commands: must be an object"],
       [{ commands: { codex: "codex" } }, "commands: must include a 'default' string entry"],
       [{ commands: { default: 123 } }, "commands: must include a 'default' string entry"],
+      [{ engines: [] }, "engines: must be an object"],
+      [{ engines: { codex: false } }, "engines.codex: must be an object"],
+      [{ engines: { codex: { cmd: "" } } }, "engines.codex.cmd: must be a non-empty string"],
       [{ sessions: [] }, "sessions: must be an object"],
     ] as const;
 
@@ -91,6 +96,7 @@ describe("validateConfigShape", () => {
       federationToken: "x".repeat(16),
       env: { A: "B" },
       commands: { default: "claude" },
+      engines: { codex: { cmd: "codex" } },
       sessions: { mawjs: "54-mawjs" },
       peers: ["http://peer:3456"],
     })).toEqual([]);
@@ -120,10 +126,14 @@ describe("validateConfigShape", () => {
     expect(validateConfigShape({
       env: { GOOD: "ok", BAD: 1 },
       commands: { default: "claude", bad: false },
+      engines: { nope: false, broken: { cmd: "" }, badName: { name: 7, cmd: "tool" } },
       sessions: { ok: "54-mawjs", bad: 2 },
     })).toEqual([
       "env.BAD must be a string",
       "commands.bad must be a string",
+      "engines.nope must be an object",
+      "engines.broken.cmd must be a non-empty string",
+      "engines.badName.name must be a string",
       "sessions.bad must be a string",
     ]);
 

--- a/test/engine-registry.test.ts
+++ b/test/engine-registry.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+
+const { DEFAULT_ENGINES, resolveEngine } = await import("../src/config/engine-registry");
+
+describe("generic engine registry (#1960 P1)", () => {
+  test("lowers the legacy swarm known agents into dormant EngineDef defaults", () => {
+    expect(DEFAULT_ENGINES.claude).toMatchObject({
+      name: "claude",
+      cmd: "claude",
+      label: "Claude Code",
+      capabilities: ["channels", "resume", "model", "system-prompt-file"],
+      resume: { flag: "--resume", replaces: "--continue", quoteValue: true },
+      model: { flag: "--model", default: "sonnet" },
+    });
+    expect(DEFAULT_ENGINES.codex).toMatchObject({ name: "codex", cmd: "codex", label: "Codex CLI" });
+    expect(DEFAULT_ENGINES.opencode).toMatchObject({ name: "opencode", cmd: "opencode", label: "OpenCode" });
+    expect(DEFAULT_ENGINES.aider).toMatchObject({ name: "aider", cmd: "aider", label: "Aider" });
+  });
+
+  test("resolves config.engines before legacy commands and built-ins", () => {
+    const engine = resolveEngine("codex", {
+      engines: { codex: { name: "codex", cmd: "codex --config custom", label: "Custom Codex" } },
+      commands: { default: "claude", codex: "codex --legacy" },
+    } as any);
+
+    expect(engine).toEqual({ name: "codex", cmd: "codex --config custom", label: "Custom Codex" });
+  });
+
+  test("synthesizes Claude capabilities for legacy Claude-like command aliases", () => {
+    const engine = resolveEngine("claude47", {
+      commands: { default: "claude", claude47: "claude47 --continue" },
+    } as any);
+
+    expect(engine).toMatchObject({
+      name: "claude47",
+      cmd: "claude47 --continue",
+      capabilities: ["channels", "resume", "model", "system-prompt-file"],
+      resume: { flag: "--resume", replaces: "--continue", quoteValue: true },
+    });
+  });
+
+  test("falls back to built-in engines, then raw command names", () => {
+    expect(resolveEngine("aider", { commands: { default: "claude" } } as any)).toMatchObject({
+      name: "aider",
+      cmd: "aider",
+      label: "Aider",
+    });
+    expect(resolveEngine("gemini", { commands: { default: "claude" } } as any)).toEqual({
+      name: "gemini",
+      cmd: "gemini",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add P0 golden-master coverage for current `buildCommandFromConfig` behavior across seeded engines, resume/channels/model cases, root UID stripping, and Discord auto-inject
- add dormant `EngineDef` + engine registry with `DEFAULT_ENGINES` lowered from the legacy swarm known-agent table
- add additive `engines?` config validation and export the new engine surface from config + SDK

This intentionally does **not** route command rendering through `resolveEngine`; P1 remains dormant so launch behavior is unchanged.

Refs #1960.

## Tests
- `bun test test/engine-registry.test.ts test/command-golden-master.test.ts test/config-validate.test.ts`
- `bun run build`
- `bun run test:default:safe`

## Not included
- serve boot/bind golden-master snapshot from #1960 P0
- P2 buildCommandFromConfig renderer rewrite
- P3 team/swarm behavior changes or resume-gate flip

Written by [m5:mawjscodex] — an Oracle AI running gpt-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
