### PR TITLE
refactor(config): render commands through engine registry

### DIFF
--- a/src/config/command-logic.ts
+++ b/src/config/command-logic.ts
@@ -3,6 +3,7 @@ import { homedir } from "os";
 import { join } from "path";
 import type { MawConfig } from "./types";
 import { getChannelEnv, getChannelPermissionMode, getChannelPluginIds } from "../commands/shared/channel-loader";
+import { resolveEngine } from "./engine-registry";
 
 const DISCORD_CHANNEL_PLUGIN = "plugin:discord@claude-plugins-official";
 
@@ -97,6 +98,52 @@ function shouldAutoDiscordChannels(cwd?: string): boolean {
   try { return existsSync(join(cwd, ".discord")); } catch { return false; }
 }
 
+function legacyCommandForAgent(
+  config: Partial<MawConfig>,
+  agentName: string,
+  opts: BuildCommandOpts,
+): string {
+  const commands = config.commands || { default: "claude" };
+  let cmd: string;
+
+  if (opts.engine && commands[opts.engine]) {
+    cmd = commands[opts.engine];
+  } else {
+    cmd = commands.default || "claude";
+    for (const [pattern, command] of Object.entries(commands)) {
+      if (pattern === "default") continue;
+      if (matchGlob(pattern, agentName)) { cmd = command; break; }
+    }
+  }
+
+  return cmd;
+}
+
+function renderCommandFromEngine(
+  config: Partial<MawConfig>,
+  agentName: string,
+  opts: BuildCommandOpts,
+): string {
+  const commands = config.commands || { default: "claude" };
+
+  // Preserve the legacy "unknown explicit engine falls back to default/pattern"
+  // behavior unless the new typed engine registry has an explicit entry.
+  if (opts.engine && config.engines?.[opts.engine]) {
+    return resolveEngine(opts.engine, config).cmd;
+  }
+  if (opts.engine && commands[opts.engine]) {
+    return resolveEngine(opts.engine, config).cmd;
+  }
+
+  let engineName = "default";
+  for (const pattern of Object.keys(commands)) {
+    if (pattern === "default") continue;
+    if (matchGlob(pattern, agentName)) { engineName = pattern; break; }
+  }
+
+  return resolveEngine(engineName, config).cmd;
+}
+
 function addDiscordChannelsForClaude(cmd: string, cwd?: string): string {
   if (!shouldAutoDiscordChannels(cwd)) return cmd;
   if (hasChannelsFlag(cmd)) return cmd;
@@ -111,18 +158,9 @@ export function buildCommandFromConfig(
   context: { cwd?: string } = {},
 ): string {
   const opts = enrichOptionsFromChannelConfig(agentName, normalizeBuildCommandOpts(optsOrEngine), context.cwd);
-  const commands = config.commands || { default: "claude" };
-  let cmd: string;
-
-  if (opts.engine && commands[opts.engine]) {
-    cmd = commands[opts.engine];
-  } else {
-    cmd = commands.default || "claude";
-    for (const [pattern, command] of Object.entries(commands)) {
-      if (pattern === "default") continue;
-      if (matchGlob(pattern, agentName)) { cmd = command; break; }
-    }
-  }
+  let cmd = process.env.MAW_GENERIC_ENGINES === "0"
+    ? legacyCommandForAgent(config, agentName, opts)
+    : renderCommandFromEngine(config, agentName, opts);
 
   const commandOpts = opts.channelConfigLoaded && !isClaudeLikeCommand(cmd)
     ? { ...opts, channels: [], channelEnv: undefined }

--- a/test/command-golden-master.test.ts
+++ b/test/command-golden-master.test.ts
@@ -22,6 +22,7 @@ const baseConfig = {
 };
 
 const origGetuid = process.getuid;
+const origGenericEngines = process.env.MAW_GENERIC_ENGINES;
 
 beforeEach(() => {
   (process as any).getuid = () => 1000;
@@ -29,6 +30,8 @@ beforeEach(() => {
 
 afterEach(() => {
   (process as any).getuid = origGetuid;
+  if (origGenericEngines === undefined) delete process.env.MAW_GENERIC_ENGINES;
+  else process.env.MAW_GENERIC_ENGINES = origGenericEngines;
 });
 
 function build(engine: string, extra: Record<string, unknown> = {}, opts?: any): string {
@@ -78,5 +81,25 @@ describe("buildCommandFromConfig golden master (#1960 P0)", () => {
       "claude --channels plugin:discord@claude-plugins-official",
     );
     expect(buildCommandInDirFromConfig(baseConfig as any, "codex-agent", tmp, "codex")).toBe("codex");
+  });
+
+  test("MAW_GENERIC_ENGINES=0 preserves the legacy renderer rollback path", () => {
+    process.env.MAW_GENERIC_ENGINES = "0";
+
+    expect(buildCommandFromConfig({
+      ...baseConfig,
+      commands: { default: "claude", codex: "codex --legacy" },
+      engines: { codex: { name: "codex", cmd: "codex --typed" } },
+    } as any, "codex-agent", "codex")).toBe("codex --legacy");
+  });
+
+  test("typed engines can override legacy commands when the generic renderer is enabled", () => {
+    delete process.env.MAW_GENERIC_ENGINES;
+
+    expect(buildCommandFromConfig({
+      ...baseConfig,
+      commands: { default: "claude", codex: "codex --legacy" },
+      engines: { codex: { name: "codex", cmd: "codex --typed" } },
+    } as any, "codex-agent", "codex")).toBe("codex --typed");
   });
 });


### PR DESCRIPTION
## Summary
- route buildCommandFromConfig command selection through resolveEngine
- preserve the legacy selector behind MAW_GENERIC_ENGINES=0
- keep legacy output byte-identical under the P0 golden-master harness
- allow typed config.engines entries to override legacy command strings only when the generic renderer is enabled

Refs #1960.

## Tests
- `bun test test/command-golden-master.test.ts test/command-simplified.test.ts test/engine-registry.test.ts`
- `bun run build`
- `bun run test:default:safe`

## Not included
- P3 resume-gate flip
- P3 team-lifecycle.ts:258 fold into buildCommandFromConfig
- swarm KNOWN_AGENTS deletion

Written by [m5:mawjscodex] — an Oracle AI running gpt-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
