### PR TITLE
feat(config): route teams through generic engines

### DIFF
--- a/src/commands/plugins/swarm/index.ts
+++ b/src/commands/plugins/swarm/index.ts
@@ -7,13 +7,6 @@ export const command = {
   description: "Spawn multi-AI agent panes — claude, codex, opencode side by side.",
 };
 
-const KNOWN_AGENTS: Record<string, { cmd: string; label: string }> = {
-  claude:   { cmd: "claude",   label: "Claude Code" },
-  codex:    { cmd: "codex",    label: "Codex CLI" },
-  opencode: { cmd: "opencode", label: "OpenCode" },
-  aider:    { cmd: "aider",    label: "Aider" },
-};
-
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
   const logs: string[] = [];
   const origLog = console.log;
@@ -92,15 +85,15 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     }
 
     const { loadConfig } = await import("../../../config");
-    const configCommands = loadConfig().commands || {};
+    const { resolveEngine } = await import("../../../config/engine-registry");
+    const mawConfig = loadConfig();
 
     const paneIds: { name: string; agentId: string; agentCmd: string; label: string; color: AgentColor }[] = [];
     for (let i = 0; i < agentList.length; i++) {
       const agentType = agentList[i];
-      const known = KNOWN_AGENTS[agentType];
-      const fromConfig = configCommands[agentType];
-      const agentCmd = fromConfig || (known ? known.cmd : agentType);
-      const label = known ? known.label : agentType;
+      const engine = resolveEngine(agentType, mawConfig);
+      const agentCmd = engine.cmd;
+      const label = engine.label || agentType;
       const name = `${agentType}-${i + 1}`;
       const color = nextAgentColor(i);
       const agentId = `${name}@${teamName}`;

--- a/src/commands/plugins/team/index.ts
+++ b/src/commands/plugins/team/index.ts
@@ -81,9 +81,11 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       cmdTeamCreate(args[1], { description });
     } else if (sub === "spawn") {
       if (!args[1] || !args[2]) {
-        logs.push("usage: maw team spawn <team> <role> [--model <model>] [--cwd <path>] [--worktree <path>] [--prompt <text>] [--parent-session-id <id>] [--session-id <id>] [--exec]");
+        logs.push("usage: maw team spawn <team> <role> [--engine <engine>] [--model <model>] [--cwd <path>] [--worktree <path>] [--prompt <text>] [--parent-session-id <id>] [--session-id <id>] [--exec]");
         return { ok: false, error: "team and role required", output: logs.join("\n") };
       }
+      const engineIdx = args.indexOf("--engine") !== -1 ? args.indexOf("--engine") : args.indexOf("-e");
+      const engine = engineIdx !== -1 ? args[engineIdx + 1] : undefined;
       const modelIdx = args.indexOf("--model");
       const model = modelIdx !== -1 ? args[modelIdx + 1] : undefined;
       const cwdIdx = args.indexOf("--cwd");
@@ -103,7 +105,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         for (let i = 0; i < rawTail.length; i++) {
           const a = rawTail[i];
           if (a === "--exec") continue;
-          if (a === "--model" || a === "--cwd" || a === "--worktree" || a === "--parent" || a === "--parent-session-id" || a === "--session-id") {
+          if (a === "--engine" || a === "-e" || a === "--model" || a === "--cwd" || a === "--worktree" || a === "--parent" || a === "--parent-session-id" || a === "--session-id") {
             i++;
             continue;
           }
@@ -111,7 +113,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         }
         prompt = tail.join(" ") || undefined;
       }
-      await cmdTeamSpawn(args[1], args[2], { model, prompt, exec, cwd, parentSessionId, sessionId });
+      await cmdTeamSpawn(args[1], args[2], { engine, model, prompt, exec, cwd, parentSessionId, sessionId });
     } else if (sub === "send" || sub === "msg") {
       if (!args[1] || !args[2] || !args[3]) {
         logs.push("usage: maw team send <team> <agent> <message>");

--- a/src/commands/plugins/team/team-helpers.ts
+++ b/src/commands/plugins/team/team-helpers.ts
@@ -18,6 +18,7 @@ export interface TeamMember {
   agentType?: string;
   tmuxPaneId?: string;
   color?: string;
+  engine?: string;
   model?: string;
   backendType?: string;
 }

--- a/src/commands/plugins/team/team-lifecycle.ts
+++ b/src/commands/plugins/team/team-lifecycle.ts
@@ -4,6 +4,7 @@ import { join } from "path";
 import { tmux } from "../../../sdk";
 import { assertValidOracleName } from "../../../core/fleet/validate";
 import { prefixCommandWithSpawnSessionEnv } from "../../../core/fleet/parent-session";
+import { buildCommand, buildCommandInDir } from "../../../config/command";
 import { TEAMS_DIR, loadTeam, resolvePsi, writeShutdownRequest, cleanupTeamDir, type TeamConfig, type TeamMember } from "./team-helpers";
 
 const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
@@ -204,7 +205,7 @@ export function cmdTeamCreate(name: string, opts: { description?: string } = {})
 export async function cmdTeamSpawn(
   teamName: string,
   role: string,
-  opts: { model?: string; prompt?: string; exec?: boolean; cwd?: string; parentSessionId?: string; sessionId?: string } = {},
+  opts: { engine?: string; model?: string; prompt?: string; exec?: boolean; cwd?: string; parentSessionId?: string; sessionId?: string } = {},
 ) {
   const PSI = resolvePsi();
   const teamDir = join(PSI, "memory", "mailbox", "teams", teamName);
@@ -240,7 +241,8 @@ export async function cmdTeamSpawn(
   }
 
   // Build spawn prompt
-  const model = opts.model || "sonnet";
+  const engine = opts.engine || "claude";
+  const model = opts.model || (engine === "claude" ? "sonnet" : undefined);
   const shellQuote = (s: string) => `'${s.replace(/'/g, "'\\''")}'`;
   const cwdPrefix = opts.cwd ? `cd ${shellQuote(opts.cwd)} && ` : "";
   const parts: string[] = [];
@@ -255,7 +257,10 @@ export async function cmdTeamSpawn(
   const promptPath = join(teamDir, `${role}-spawn-prompt.md`);
   writeFileSync(promptPath, spawnPrompt);
   const launchPromptPath = writeLaunchPromptFile(teamName, role, spawnPrompt) ?? promptPath;
-  const claudeCmd = `${cwdPrefix}${prefixCommandWithSpawnSessionEnv(`claude --model ${model} --system-prompt-file ${shellQuote(launchPromptPath)}`, {
+  const baseCommand = opts.cwd
+    ? buildCommandInDir(role, opts.cwd, { engine, fresh: true, model, systemPromptFile: launchPromptPath })
+    : buildCommand(role, { engine, fresh: true, model, systemPromptFile: launchPromptPath });
+  const claudeCmd = `${cwdPrefix}${prefixCommandWithSpawnSessionEnv(baseCommand, {
     explicit: opts.parentSessionId,
     sessionId: opts.sessionId,
     cwd: opts.cwd,
@@ -274,7 +279,7 @@ export async function cmdTeamSpawn(
   if (existsSync(toolConfigPath)) {
     try {
       const toolConfig = JSON.parse(readFileSync(toolConfigPath, "utf-8"));
-      const member: TeamMember = { name: role, model };
+      const member: TeamMember = { name: role, ...(engine !== "claude" || opts.engine ? { engine } : {}), ...(model ? { model } : {}) };
       if (!toolConfig.members.some((m: any) => m.name === role)) {
         toolConfig.members.push(member);
         // lgtm[js/file-system-race] — PRIVATE-PATH: tool config under ~/.maw/teams/<team>/ (#393), see docs/security/file-system-race-stance.md
@@ -285,7 +290,8 @@ export async function cmdTeamSpawn(
 
   console.log(`\x1b[32m✓\x1b[0m spawn prompt written for '${role}'`);
   console.log(`  \x1b[90mpast life: ${pastLife ? "yes" : "no"}\x1b[0m`);
-  console.log(`  \x1b[90mmodel: ${model}\x1b[0m`);
+  console.log(`  \x1b[90mengine: ${engine}\x1b[0m`);
+  if (model) console.log(`  \x1b[90mmodel: ${model}\x1b[0m`);
   console.log(`  \x1b[90mprompt: ${promptPath}\x1b[0m`);
 
   // #393 Bug C — opt-in auto-spawn via splitWindowLocked. Default behavior

--- a/src/config/command-logic.ts
+++ b/src/config/command-logic.ts
@@ -2,8 +2,9 @@ import { existsSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
 import type { MawConfig } from "./types";
+import type { EngineDef } from "./engine-def";
 import { getChannelEnv, getChannelPermissionMode, getChannelPluginIds } from "../commands/shared/channel-loader";
-import { resolveEngine } from "./engine-registry";
+import { DEFAULT_ENGINES, resolveEngine } from "./engine-registry";
 
 const DISCORD_CHANNEL_PLUGIN = "plugin:discord@claude-plugins-official";
 
@@ -13,6 +14,12 @@ export interface BuildCommandOpts {
   channelEnv?: Record<string, string>;
   devChannels?: boolean;
   permissionMode?: "skip" | "relay";
+  /** Force a fresh launch form by removing engine resume/continue placeholders when possible. */
+  fresh?: boolean;
+  /** Optional model value for engines that declare a model flag. */
+  model?: string;
+  /** Optional system prompt file path for engines that support that launch form. */
+  systemPromptFile?: string;
   /** @internal: set when channels came from repo/global channel config rather than explicit opts. */
   channelConfigLoaded?: boolean;
 }
@@ -29,6 +36,11 @@ function isClaudeLikeCommand(cmd: string): boolean {
 
 function hasChannelsFlag(cmd: string): boolean {
   return /\s--channels(?:\s|=|$)/.test(cmd);
+}
+
+function hasLongFlag(cmd: string, flag: string): boolean {
+  const escaped = flag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`\\s${escaped}(?:\\s|=|$)`).test(cmd);
 }
 
 function expandLeadingTilde(value: string): string {
@@ -119,20 +131,21 @@ function legacyCommandForAgent(
   return cmd;
 }
 
-function renderCommandFromEngine(
+function selectEngineForAgent(
   config: Partial<MawConfig>,
   agentName: string,
   opts: BuildCommandOpts,
-): string {
+): EngineDef {
   const commands = config.commands || { default: "claude" };
 
   // Preserve the legacy "unknown explicit engine falls back to default/pattern"
   // behavior unless the new typed engine registry has an explicit entry.
-  if (opts.engine && config.engines?.[opts.engine]) {
-    return resolveEngine(opts.engine, config).cmd;
-  }
-  if (opts.engine && commands[opts.engine]) {
-    return resolveEngine(opts.engine, config).cmd;
+  if (opts.engine && (
+    config.engines?.[opts.engine]
+    || commands[opts.engine]
+    || DEFAULT_ENGINES[opts.engine as keyof typeof DEFAULT_ENGINES]
+  )) {
+    return resolveEngine(opts.engine, config);
   }
 
   let engineName = "default";
@@ -141,7 +154,43 @@ function renderCommandFromEngine(
     if (matchGlob(pattern, agentName)) { engineName = pattern; break; }
   }
 
-  return resolveEngine(engineName, config).cmd;
+  return resolveEngine(engineName, config);
+}
+
+function engineHas(engine: EngineDef | null, capability: string): boolean {
+  return Boolean(engine?.capabilities?.includes(capability));
+}
+
+function applyFreshLaunch(cmd: string, engine: EngineDef | null, opts: BuildCommandOpts): string {
+  if (!opts.fresh || !engine?.resume?.replaces || !engineHas(engine, "resume")) return cmd;
+  const escaped = engine.resume.replaces.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return cmd.replace(new RegExp(`\\s*${escaped}\\b`), "");
+}
+
+function applyModelFlag(cmd: string, engine: EngineDef | null, opts: BuildCommandOpts): string {
+  const flag = engine?.model?.flag;
+  if (!opts.model || !flag || !engineHas(engine, "model") || hasLongFlag(cmd, flag)) return cmd;
+  return `${cmd} ${flag} ${opts.model}`;
+}
+
+function applySystemPromptFile(cmd: string, engine: EngineDef | null, opts: BuildCommandOpts): string {
+  if (!opts.systemPromptFile || !engineHas(engine, "system-prompt-file") || hasLongFlag(cmd, "--system-prompt-file")) return cmd;
+  return `${cmd} --system-prompt-file ${shellQuote(opts.systemPromptFile)}`;
+}
+
+function applyResumeFlag(cmd: string, engine: EngineDef | null, sessionId: string, genericRenderer: boolean): string {
+  if (!genericRenderer) {
+    if (cmd.includes("--continue")) return cmd.replace(/\s*--continue\b/, ` --resume "${sessionId}"`);
+    return `${cmd} --resume "${sessionId}"`;
+  }
+
+  if (!engineHas(engine, "resume") || !engine?.resume?.flag) return cmd;
+  const value = engine.resume.quoteValue === false ? sessionId : `"${sessionId}"`;
+  if (engine.resume.replaces && cmd.includes(engine.resume.replaces)) {
+    const escaped = engine.resume.replaces.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    return cmd.replace(new RegExp(`\\s*${escaped}\\b`), ` ${engine.resume.flag} ${value}`);
+  }
+  return `${cmd} ${engine.resume.flag} ${value}`;
 }
 
 function addDiscordChannelsForClaude(cmd: string, cwd?: string): string {
@@ -158,9 +207,15 @@ export function buildCommandFromConfig(
   context: { cwd?: string } = {},
 ): string {
   const opts = enrichOptionsFromChannelConfig(agentName, normalizeBuildCommandOpts(optsOrEngine), context.cwd);
-  let cmd = process.env.MAW_GENERIC_ENGINES === "0"
-    ? legacyCommandForAgent(config, agentName, opts)
-    : renderCommandFromEngine(config, agentName, opts);
+  const genericRenderer = process.env.MAW_GENERIC_ENGINES !== "0";
+  const engine = genericRenderer ? selectEngineForAgent(config, agentName, opts) : null;
+  let cmd = genericRenderer
+    ? engine!.cmd
+    : legacyCommandForAgent(config, agentName, opts);
+
+  cmd = applyFreshLaunch(cmd, engine, opts);
+  cmd = applyModelFlag(cmd, engine, opts);
+  cmd = applySystemPromptFile(cmd, engine, opts);
 
   const commandOpts = opts.channelConfigLoaded && !isClaudeLikeCommand(cmd)
     ? { ...opts, channels: [], channelEnv: undefined }
@@ -177,11 +232,7 @@ export function buildCommandFromConfig(
   const sessionId = sessionIds[agentName]
     || Object.entries(sessionIds).find(([p]) => p !== "default" && matchGlob(p, agentName))?.[1];
   if (sessionId) {
-    if (cmd.includes("--continue")) {
-      cmd = cmd.replace(/\s*--continue\b/, ` --resume "${sessionId}"`);
-    } else {
-      cmd += ` --resume "${sessionId}"`;
-    }
+    cmd = applyResumeFlag(cmd, engine, sessionId, genericRenderer);
   }
 
   cmd = applyChannelEnv(cmd, commandOpts.channelEnv);

--- a/src/config/engine-registry.ts
+++ b/src/config/engine-registry.ts
@@ -22,7 +22,8 @@ function isClaudeLikeCommand(cmd: string): boolean {
 }
 
 function fromLegacyCommand(name: string, cmd: string): EngineDef {
-  const def: EngineDef = { name, cmd };
+  const builtIn = DEFAULT_ENGINES[name];
+  const def: EngineDef = { name, cmd, ...(builtIn?.label ? { label: builtIn.label } : {}) };
   if (isClaudeLikeCommand(cmd)) {
     def.resume = { flag: "--resume", replaces: "--continue", quoteValue: true };
     def.model = { flag: "--model", default: "sonnet" };

--- a/src/vendor/mpr-plugins/team/index.ts
+++ b/src/vendor/mpr-plugins/team/index.ts
@@ -120,9 +120,11 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       logs.push(formatTeamCharterSpawn(result));
     } else if (sub === "spawn") {
       if (!args[1] || !args[2]) {
-        logs.push("usage: maw team spawn <team> <role> [--model <model>] [--cwd <path>] [--worktree <path>] [--prompt <text>] [--parent-session-id <id>] [--session-id <id>] [--exec]");
+        logs.push("usage: maw team spawn <team> <role> [--engine <engine>] [--model <model>] [--cwd <path>] [--worktree <path>] [--prompt <text>] [--parent-session-id <id>] [--session-id <id>] [--exec]");
         return { ok: false, error: "team and role required", output: logs.join("\n") };
       }
+      const engineIdx = args.indexOf("--engine") !== -1 ? args.indexOf("--engine") : args.indexOf("-e");
+      const engine = engineIdx !== -1 ? args[engineIdx + 1] : undefined;
       const modelIdx = args.indexOf("--model");
       const model = modelIdx !== -1 ? args[modelIdx + 1] : undefined;
       const cwdIdx = args.indexOf("--cwd");
@@ -142,7 +144,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         for (let i = 0; i < rawTail.length; i++) {
           const a = rawTail[i];
           if (a === "--exec") continue;
-          if (a === "--model" || a === "--cwd" || a === "--worktree" || a === "--parent" || a === "--parent-session-id" || a === "--session-id") {
+          if (a === "--engine" || a === "-e" || a === "--model" || a === "--cwd" || a === "--worktree" || a === "--parent" || a === "--parent-session-id" || a === "--session-id") {
             i++;
             continue;
           }
@@ -150,7 +152,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         }
         prompt = tail.join(" ") || undefined;
       }
-      await cmdTeamSpawn(args[1], args[2], { model, prompt, exec, cwd, parentSessionId, sessionId });
+      await cmdTeamSpawn(args[1], args[2], { engine, model, prompt, exec, cwd, parentSessionId, sessionId });
     } else if (sub === "send" || sub === "msg") {
       if (!args[1] || !args[2]) {
         logs.push("usage: maw team send <team> <message>");

--- a/src/vendor/mpr-plugins/team/team-helpers.ts
+++ b/src/vendor/mpr-plugins/team/team-helpers.ts
@@ -19,6 +19,7 @@ export interface TeamMember {
   agentType?: string;
   tmuxPaneId?: string;
   color?: string;
+  engine?: string;
   model?: string;
   backendType?: string;
 }

--- a/src/vendor/mpr-plugins/team/team-lifecycle.ts
+++ b/src/vendor/mpr-plugins/team/team-lifecycle.ts
@@ -4,6 +4,7 @@ import { join } from "path";
 import { tmux } from "maw-js/sdk";
 import { assertValidOracleName } from "maw-js/core/fleet/validate";
 import { prefixCommandWithSpawnSessionEnv } from "../../../core/fleet/parent-session";
+import { buildCommand, buildCommandInDir } from "../../../config/command";
 import { TEAMS_DIR, loadTeam, resolvePsi, writeShutdownRequest, cleanupTeamDir, currentLeadSessionId, type TeamConfig, type TeamMember } from "./team-helpers";
 
 const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
@@ -195,7 +196,7 @@ export function cmdTeamCreate(name: string, opts: { description?: string } = {})
 export async function cmdTeamSpawn(
   teamName: string,
   role: string,
-  opts: { model?: string; prompt?: string; exec?: boolean; cwd?: string; parentSessionId?: string; sessionId?: string } = {},
+  opts: { engine?: string; model?: string; prompt?: string; exec?: boolean; cwd?: string; parentSessionId?: string; sessionId?: string } = {},
 ) {
   const PSI = resolvePsi();
   const teamDir = join(PSI, "memory", "mailbox", "teams", teamName);
@@ -231,7 +232,8 @@ export async function cmdTeamSpawn(
   }
 
   // Build spawn prompt
-  const model = opts.model || "sonnet";
+  const engine = opts.engine || "claude";
+  const model = opts.model || (engine === "claude" ? "sonnet" : undefined);
   const shellQuote = (s: string) => `'${s.replace(/'/g, "'\\''")}'`;
   const cwdPrefix = opts.cwd ? `cd ${shellQuote(opts.cwd)} && ` : "";
   const parts: string[] = [];
@@ -246,7 +248,10 @@ export async function cmdTeamSpawn(
   const promptPath = join(teamDir, `${role}-spawn-prompt.md`);
   writeFileSync(promptPath, spawnPrompt);
   const launchPromptPath = writeLaunchPromptFile(teamName, role, spawnPrompt) ?? promptPath;
-  const claudeCmd = `${cwdPrefix}${prefixCommandWithSpawnSessionEnv(`claude --model ${model} --system-prompt-file ${shellQuote(launchPromptPath)}`, {
+  const baseCommand = opts.cwd
+    ? buildCommandInDir(role, opts.cwd, { engine, fresh: true, model, systemPromptFile: launchPromptPath })
+    : buildCommand(role, { engine, fresh: true, model, systemPromptFile: launchPromptPath });
+  const claudeCmd = `${cwdPrefix}${prefixCommandWithSpawnSessionEnv(baseCommand, {
     explicit: opts.parentSessionId,
     sessionId: opts.sessionId,
     cwd: opts.cwd,
@@ -265,7 +270,7 @@ export async function cmdTeamSpawn(
   if (existsSync(toolConfigPath)) {
     try {
       const toolConfig = JSON.parse(readFileSync(toolConfigPath, "utf-8"));
-      const member: TeamMember = { name: role, model };
+      const member: TeamMember = { name: role, ...(engine !== "claude" || opts.engine ? { engine } : {}), ...(model ? { model } : {}) };
       if (!toolConfig.members.some((m: any) => m.name === role)) {
         toolConfig.members.push(member);
         // lgtm[js/file-system-race] — PRIVATE-PATH: tool config under ~/.maw/teams/<team>/ (#393), see docs/security/file-system-race-stance.md
@@ -276,7 +281,8 @@ export async function cmdTeamSpawn(
 
   console.log(`\x1b[32m✓\x1b[0m spawn prompt written for '${role}'`);
   console.log(`  \x1b[90mpast life: ${pastLife ? "yes" : "no"}\x1b[0m`);
-  console.log(`  \x1b[90mmodel: ${model}\x1b[0m`);
+  console.log(`  \x1b[90mengine: ${engine}\x1b[0m`);
+  if (model) console.log(`  \x1b[90mmodel: ${model}\x1b[0m`);
   console.log(`  \x1b[90mprompt: ${promptPath}\x1b[0m`);
 
   // #393 Bug C — opt-in auto-spawn via splitWindowLocked. Default behavior

--- a/test/command-golden-master.test.ts
+++ b/test/command-golden-master.test.ts
@@ -47,17 +47,17 @@ describe("buildCommandFromConfig golden master (#1960 P0)", () => {
       ["claude model", buildCommandFromConfig({ ...baseConfig, commands: { ...baseConfig.commands, claude: "claude --model opus" } } as any, "claude-agent", "claude"), "claude --model opus"],
 
       ["codex fresh", build("codex"), "codex"],
-      ["codex resume legacy-bug", build("codex", { sessionIds: { "codex-agent": "uuid-codex" } }), 'codex --resume "uuid-codex"'],
+      ["codex resume capability-gated", build("codex", { sessionIds: { "codex-agent": "uuid-codex" } }), "codex"],
       ["codex channels ignored", build("codex", {}, { engine: "codex", channels: ["plugin:discord@claude-plugins-official"] }), "codex"],
       ["codex model literal", buildCommandFromConfig({ ...baseConfig, commands: { ...baseConfig.commands, codex: "codex --model gpt-5.5" } } as any, "codex-agent", "codex"), "codex --model gpt-5.5"],
 
       ["opencode fresh", build("opencode"), "opencode"],
-      ["opencode resume legacy-bug", build("opencode", { sessionIds: { "opencode-agent": "uuid-open" } }), 'opencode --resume "uuid-open"'],
+      ["opencode resume capability-gated", build("opencode", { sessionIds: { "opencode-agent": "uuid-open" } }), "opencode"],
       ["opencode channels ignored", build("opencode", {}, { engine: "opencode", channels: ["plugin:discord@claude-plugins-official"] }), "opencode"],
       ["opencode model literal", buildCommandFromConfig({ ...baseConfig, commands: { ...baseConfig.commands, opencode: "opencode --model qwen" } } as any, "opencode-agent", "opencode"), "opencode --model qwen"],
 
       ["aider fresh", build("aider"), "aider"],
-      ["aider resume legacy-bug", build("aider", { sessionIds: { "aider-agent": "uuid-aider" } }), 'aider --resume "uuid-aider"'],
+      ["aider resume capability-gated", build("aider", { sessionIds: { "aider-agent": "uuid-aider" } }), "aider"],
       ["aider channels ignored", build("aider", {}, { engine: "aider", channels: ["plugin:discord@claude-plugins-official"] }), "aider"],
       ["aider model literal", buildCommandFromConfig({ ...baseConfig, commands: { ...baseConfig.commands, aider: "aider --model sonnet" } } as any, "aider-agent", "aider"), "aider --model sonnet"],
     ];
@@ -91,6 +91,15 @@ describe("buildCommandFromConfig golden master (#1960 P0)", () => {
       commands: { default: "claude", codex: "codex --legacy" },
       engines: { codex: { name: "codex", cmd: "codex --typed" } },
     } as any, "codex-agent", "codex")).toBe("codex --legacy");
+  });
+
+  test("MAW_GENERIC_ENGINES=0 preserves legacy non-Claude resume behavior", () => {
+    process.env.MAW_GENERIC_ENGINES = "0";
+
+    expect(buildCommandFromConfig({
+      ...baseConfig,
+      sessionIds: { "codex-agent": "uuid-codex" },
+    } as any, "codex-agent", "codex")).toBe('codex --resume "uuid-codex"');
   });
 
   test("typed engines can override legacy commands when the generic renderer is enabled", () => {

--- a/test/command-simplified.test.ts
+++ b/test/command-simplified.test.ts
@@ -142,6 +142,11 @@ describe("buildCommand — post-#541 contract", () => {
     expect(buildCommand("any-agent", "codex")).toBe("codex --search");
   });
 
+  test("engine param selects built-in engines even when config omits them", () => {
+    fakeConfig.commands = { default: "claude" };
+    expect(buildCommand("any-agent", "codex")).toBe("codex");
+  });
+
   test("engine param falls back to default when engine not in config", () => {
     fakeConfig.commands = { default: "claude" };
     expect(buildCommand("any-agent", "gemini")).toBe("claude");

--- a/test/isolated/team-lifecycle-default.test.ts
+++ b/test/isolated/team-lifecycle-default.test.ts
@@ -170,7 +170,10 @@ describe("team-lifecycle coverage", () => {
     expect(json(join(root, "ψ/memory/mailbox/teams/qa-team/manifest.json")).members).toEqual(["reviewer"]);
     expect(json(join(teamsDir, "qa-team/config.json")).members).toEqual([{ name: "reviewer", model: "opus" }]);
     expect(logs.join("\n")).toContain("past life: yes");
-    expect(logs.join("\n")).toContain("cd '/tmp/work dir' && claude --model opus");
+    expect(logs.join("\n")).toContain("cd '/tmp/work dir' && ");
+    expect(logs.join("\n")).toContain("--model opus");
+    expect(logs.join("\n")).toContain("--system-prompt-file");
+    expect(logs.join("\n")).not.toContain("--continue");
   });
 
   test("spawn still succeeds when launch prompt mirror cannot write to the tool store", async () => {
@@ -185,6 +188,22 @@ describe("team-lifecycle coverage", () => {
     expect(json(join(root, "ψ/memory/mailbox/teams/qa-team/manifest.json")).members).toEqual(["reviewer"]);
     expect(logs.join("\n")).toContain("--system-prompt-file");
     expect(logs.join("\n")).toContain("ψ/memory/mailbox/teams/qa-team/reviewer-spawn-prompt.md");
+  });
+
+
+  test("spawn can render a non-Claude engine through buildCommandFromConfig", async () => {
+    lifecycle.cmdTeamCreate("qa-team");
+
+    await lifecycle.cmdTeamSpawn("qa-team", "codexer", { engine: "codex" });
+
+    const output = logs.join("\n");
+    expect(output).toContain("engine: codex");
+    expect(output).toContain("Run:");
+    expect(output).toContain("codex");
+    expect(output).not.toContain("--model sonnet");
+    expect(output).not.toContain("--system-prompt-file");
+    expect(output).not.toContain("--resume");
+    expect(json(join(teamsDir, "qa-team/config.json")).members).toEqual([{ name: "codexer", engine: "codex" }]);
   });
 
   test("spawn --exec outside tmux leaves a manual command instead of spawning", async () => {
@@ -205,7 +224,9 @@ describe("team-lifecycle coverage", () => {
 
     await lifecycle.cmdTeamSpawn("qa-team", "builder", { exec: true, model: "opus" });
 
-    expect(layoutCalls[0]).toEqual(["spawnTeammatePane", "builder", expect.stringContaining("claude --model opus"), { colorIndex: 1 }]);
+    expect(layoutCalls[0]).toEqual(["spawnTeammatePane", "builder", expect.stringContaining("--model opus"), { colorIndex: 1 }]);
+    expect((layoutCalls[0] as unknown[])[2] as string).toContain("--system-prompt-file");
+    expect((layoutCalls[0] as unknown[])[2] as string).not.toContain("--continue");
     expect(snapshotCalls).toEqual([["qa-team", "%leader"]]);
     const member = json(join(teamsDir, "qa-team/config.json")).members[0];
     expect(member).toMatchObject({ name: "builder", model: "opus", tmuxPaneId: "%42", color: "green", agentId: "builder@qa-team" });
@@ -220,7 +241,9 @@ describe("team-lifecycle coverage", () => {
     await lifecycle.cmdTeamSpawn("qa-team", "builder-λ", { exec: true, model: "opus" });
 
     const command = (layoutCalls[0] as unknown[])[2] as string;
-    expect(command).toContain("claude --model opus --system-prompt-file");
+    expect(command).toContain("--model opus");
+    expect(command).toContain("--system-prompt-file");
+    expect(command).not.toContain("--continue");
     expect(command).not.toContain("/ψ/");
     expect(command).not.toContain("λ");
     const launchFiles = readdirSync(join(teamsDir, "qa-team")).filter((name) => name.endsWith("-spawn-prompt.md"));
@@ -244,7 +267,9 @@ describe("team-lifecycle coverage", () => {
 
     await lifecycle.cmdTeamSpawn("qa-team", "scout", { exec: true, model: "haiku" });
 
-    expect(layoutCalls[0]).toEqual(["spawnTeammatePane", "scout", expect.stringContaining("claude --model haiku"), { colorIndex: 1 }]);
+    expect(layoutCalls[0]).toEqual(["spawnTeammatePane", "scout", expect.stringContaining("--model haiku"), { colorIndex: 1 }]);
+    expect((layoutCalls[0] as unknown[])[2] as string).toContain("--system-prompt-file");
+    expect((layoutCalls[0] as unknown[])[2] as string).not.toContain("--continue");
     expect(logs.join("\n")).toContain("--exec split failed: split denied");
     expect(logs.join("\n")).toContain("Run manually:");
   });

--- a/test/isolated/team-lifecycle-second-pass-coverage.test.ts
+++ b/test/isolated/team-lifecycle-second-pass-coverage.test.ts
@@ -249,7 +249,10 @@ describe("vendor team-lifecycle second-pass coverage", () => {
     expect(readJson(manifestPath).members).toEqual(["scout"]);
     expect(readFileSync(join(root, "ψ/memory/mailbox/teams/qa-team/scout-spawn-prompt.md"), "utf-8")).toBe("You are 'scout' on team 'qa-team'.");
     expect(logs.join("\n")).toContain("past life: no");
-    expect(logs.join("\n")).toContain("cd '/tmp/path with '\\''quote' && claude --model sonnet --system-prompt-file");
+    expect(logs.join("\n")).toContain("cd '/tmp/path with '\\''quote' && ");
+    expect(logs.join("\n")).toContain("--model sonnet");
+    expect(logs.join("\n")).toContain("--system-prompt-file");
+    expect(logs.join("\n")).not.toContain("--continue");
   });
 
   test("spawn falls back to the vault prompt when tool-store launch prompt mirroring fails", async () => {
@@ -292,7 +295,9 @@ describe("vendor team-lifecycle second-pass coverage", () => {
 
     expect(hostExecCalls).toHaveLength(1);
     expect(hostExecCalls[0]).toContain("tmux split-window -h -l 50%");
-    expect(hostExecCalls[0]).toContain("claude --model opus --system-prompt-file");
+    expect(hostExecCalls[0]).toContain("--model opus");
+    expect(hostExecCalls[0]).toContain("--system-prompt-file");
+    expect(hostExecCalls[0]).not.toContain("--continue");
     expect(hostExecCalls[0]).not.toContain("--prompt-file");
     expect(hostExecCalls[0]).not.toContain("/ψ/");
     expect(hostExecCalls[0]).not.toContain("λ");
@@ -316,7 +321,25 @@ describe("vendor team-lifecycle second-pass coverage", () => {
     expect(hostExecCalls).toHaveLength(2);
     expect(logs.join("\n")).toContain("--exec split failed: tmux denied");
     expect(logs.join("\n")).toContain("Run manually:");
-    expect(logs.join("\n")).toContain("cd '/tmp/work dir' && claude --model haiku --system-prompt-file");
+    expect(logs.join("\n")).toContain("cd '/tmp/work dir' && ");
+    expect(logs.join("\n")).toContain("--model haiku");
+    expect(logs.join("\n")).toContain("--system-prompt-file");
+    expect(logs.join("\n")).not.toContain("--continue");
+  });
+
+
+  test("spawn supports non-Claude engines without Claude-only launch flags", async () => {
+    lifecycle.cmdTeamCreate("qa-team");
+
+    await lifecycle.cmdTeamSpawn("qa-team", "codexer", { engine: "codex" });
+
+    const output = logs.join("\n");
+    expect(output).toContain("engine: codex");
+    expect(output).toContain("codex");
+    expect(output).not.toContain("--model sonnet");
+    expect(output).not.toContain("--system-prompt-file");
+    expect(output).not.toContain("--resume");
+    expect(readJson(join(teamsDir, "qa-team/config.json")).members).toEqual([{ name: "codexer", engine: "codex" }]);
   });
 
   test("spawn --exec outside tmux prints a manual command instead of starting a pane", async () => {
@@ -327,6 +350,8 @@ describe("vendor team-lifecycle second-pass coverage", () => {
     expect(hostExecCalls).toEqual([]);
     expect(logs.join("\n")).toContain("--exec requires an active tmux session");
     expect(logs.join("\n")).toContain("Run manually:");
-    expect(logs.join("\n")).toContain("claude --model sonnet --system-prompt-file");
+    expect(logs.join("\n")).toContain("--model sonnet");
+    expect(logs.join("\n")).toContain("--system-prompt-file");
+    expect(logs.join("\n")).not.toContain("--continue");
   });
 });


### PR DESCRIPTION
## Summary
- capability-gate session resume so only engines with resume support receive `--resume`
- route `maw team spawn` through `buildCommandFromConfig` with `--engine` support
- preserve `MAW_GENERIC_ENGINES=0` rollback for legacy non-Claude resume behavior
- resolve swarm commands through the shared engine registry instead of local `KNOWN_AGENTS`

Refs #1960.

## Tests
- `bun test test/command-golden-master.test.ts && bun test test/command-simplified.test.ts && bun test test/engine-registry.test.ts && bun test test/isolated/team-lifecycle-default.test.ts && bun test test/isolated/team-lifecycle-second-pass-coverage.test.ts && bun test test/isolated/swarm-index-coverage.test.ts`
- `bun run build`
- `git diff --check`
- `bun run test:default:safe`

## Not included
- ServeProfile / serve-as-plugin P4/P5
- deleting any persisted legacy team model fields
- live tmux non-Claude team smoke

Written by [m5:mawjscodex] — an Oracle AI running gpt-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
