### PR TITLE
fix(swarm): reject unknown flags before tmux spawn

### DIFF
--- a/src/commands/plugins/swarm/index.ts
+++ b/src/commands/plugins/swarm/index.ts
@@ -7,6 +7,19 @@ export const command = {
   description: "Spawn multi-AI agent panes — claude, codex, opencode side by side.",
 };
 
+const SUPPORTED_FLAGS = ["--tiled", "--count", "--help", "-h", "--parent", "--parent-session-id", "--session-id"];
+
+function unknownSwarmFlag(positionals: string[]): string | undefined {
+  return positionals.find((arg) => arg.startsWith("-"));
+}
+
+function unknownFlagMessage(flag: string): string {
+  if (flag === "--wt" || flag === "--worktree") {
+    return "unknown flag for swarm: --wt. maw swarm is shared-cwd only; for an isolated worktree-per-member use: maw wake <oracle> --wt <slot> --split -e <engine>";
+  }
+  return `unknown flag for swarm: ${flag} (supported: ${SUPPORTED_FLAGS.join(", ")})`;
+}
+
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
   const logs: string[] = [];
   const origLog = console.log;
@@ -46,6 +59,12 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
 
     const tiled = !!flags["--tiled"];
     const positional = flags._ as string[];
+    const unknownFlag = unknownSwarmFlag(positional);
+    if (unknownFlag) {
+      const message = unknownFlagMessage(unknownFlag);
+      console.log(`[31m✗[0m ${message}`);
+      return { ok: false, error: message, output: logs.join("\n") || undefined };
+    }
 
     let agentList: string[];
     if (positional.length > 0) {

--- a/test/isolated/swarm-index-coverage.test.ts
+++ b/test/isolated/swarm-index-coverage.test.ts
@@ -210,6 +210,28 @@ describe("swarm index handler isolated coverage", () => {
     expect(calls.saveLayoutSnapshot).toEqual([]);
   });
 
+  test("rejects unknown flags before spawning panes and points --wt users to wake split", async () => {
+    const result = await run(["omx", "--wt"]);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("unknown flag for swarm: --wt");
+    expect(result.error).toContain("maw wake <oracle> --wt <slot> --split -e <engine>");
+    expect(result.output).toContain("unknown flag for swarm: --wt");
+    expect(calls.hostExec).toEqual([]);
+    expect(calls.withPaneLock).toBe(0);
+    expect(calls.saveLayoutSnapshot).toEqual([]);
+    expect(existsSync(configPath())).toBe(false);
+  });
+
+  test("rejects generic unknown flags with the supported swarm flag list", async () => {
+    const result = await run(["codex", "--bogus"]);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("unknown flag for swarm: --bogus (supported: --tiled, --count, --help, -h, --parent, --parent-session-id, --session-id)");
+    expect(calls.hostExec).toEqual([]);
+    expect(existsSync(configPath())).toBe(false);
+  });
+
   test("spawns default claude agents from a cli invocation using anchored main-vertical layout", async () => {
     const result = await run([]);
 


### PR DESCRIPTION
## Summary
- reject unknown `maw swarm` flags before any tmux split/send path runs
- special-case `--wt` / `--worktree` with guidance toward `maw wake <oracle> --wt <slot> --split -e <engine>`
- add isolated coverage proving bad flags spawn nothing and do not write swarm config

Closes #1964.

Credit: field repro from arra-oracle-v3, filed by mawjs-oracle.

## Tests
- `bun test test/isolated/swarm-index-coverage.test.ts`
- `bun run build`
- `TMUX=/tmp/tmux-test TMUX_PANE=%fake bun src/cli.ts swarm omx --wt`
- `bun run test:default:safe`
- `git diff --check`

Written by [m5:mawjscodex] — an Oracle AI running gpt-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
