### PR TITLE
P1 heartbeat-reaper: Bun.serve idleTimeout + sendPings (orphan PTY auto-reap)

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -35,6 +35,8 @@ export interface MawTimeouts {
   shellInit?: number;
   wakeRetry?: number;
   wakeVerify?: number;
+  /** WebSocket idle timeout — SECONDS (Bun API constraint, max 960). Other timeouts here are ms; `Sec` suffix makes the unit explicit. Used by Bun.serve websocket idleTimeout — dead ws closes after this, fires close handler → handlePtyClose → detach → grace-timer reap. */
+  wsIdleSec?: number;
 }
 
 export interface MawLimits {
@@ -164,7 +166,7 @@ export interface MawConfig {
 /** Typed defaults for intervals, timeouts, limits (#172) */
 export const D = {
   intervals: { capture: 50, sessions: 5000, status: 3000, teams: 3000, preview: 2000, peerFetch: 10000, crashCheck: 30000 } as const,
-  timeouts: { http: 5000, health: 3000, ping: 5000, pty: 5000, workspace: 5000, shellInit: 3000, wakeRetry: 500, wakeVerify: 3000 } as const,
+  timeouts: { http: 5000, health: 3000, ping: 5000, pty: 5000, workspace: 5000, shellInit: 3000, wakeRetry: 500, wakeVerify: 3000, wsIdleSec: 60 } as const,
   limits: { feedMax: 500, feedDefault: 50, feedHistory: 50, logsMax: 500, logsDefault: 50, logsTruncate: 500, messageTruncate: 100, ptyCols: 500, ptyRows: 200, maxConcurrentAgents: 0 } as const,
   hmacWindowSeconds: 300,
 } as const;

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { MawEngine } from "../engine";
 import type { WSData } from "./types";
-import { loadConfig } from "../config";
+import { loadConfig, cfgTimeout } from "../config";
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
@@ -240,7 +240,12 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
     console.warn(`[startup] peer dedup scan skipped: ${e?.message || e}`);
   }
 
-  const server = Bun.serve({ port, hostname, fetch: fetchHandler, websocket: wsHandler });
+  // P1 heartbeat-reaper: Bun-managed ws ping/pong + idle close. Dead clients
+  // (ungraceful disconnect, no TCP FIN) close after wsIdleSec → close handler
+  // fires → handlePtyClose → detach → grace-timer reaps the maw-pty- tmux session.
+  // sendPings: true is Bun's default but pinned for explicitness.
+  const wsConfig = { ...wsHandler, idleTimeout: cfgTimeout("wsIdleSec"), sendPings: true };
+  const server = Bun.serve({ port, hostname, fetch: fetchHandler, websocket: wsConfig });
   setBunServer(server);
   const bindNote = reason ? ` (${reason})` : "";
   console.log(`maw ${VERSION} serve → ${HTTP_URL} (${WS_URL}) [${hostname}]${bindNote}`);
@@ -250,7 +255,7 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
   if (tlsCfg?.cert && tlsCfg?.key && existsSync(tlsCfg.cert) && existsSync(tlsCfg.key)) {
     const tlsPort = port + 1;
     const tls = { cert: readFileSync(tlsCfg.cert), key: readFileSync(tlsCfg.key) };
-    Bun.serve({ port: tlsPort, tls, fetch: fetchHandler, websocket: wsHandler });
+    Bun.serve({ port: tlsPort, tls, fetch: fetchHandler, websocket: wsConfig });
     console.log(`maw serve → https://localhost:${tlsPort} (wss://localhost:${tlsPort}/ws) [TLS]`);
   }
 


### PR DESCRIPTION
## Summary

- P1 of 3-phase orphan PTY reaper. Enables Bun-native WebSocket ping/pong heartbeat at the `Bun.serve` config so dead ws clients (ungraceful disconnect: tab killed, laptop sleep, network drop — no TCP FIN) close after `wsIdleSec` seconds, firing the existing `handlePtyClose → detach → grace-timer` reap path in `pty.ts:178-191`.
- Root cause: prior to this patch, the `viewers` Set kept dead ws references forever on ungraceful disconnect. `viewers.size` never hit 0 → grace timer never armed → `maw-pty-*` tmux session lingered attached at frozen size. Caused the 2026-06-01 dashboard wedge Labubu diagnosed (2-day-old `maw-pty-1780122262929-30` at 45×30 hijacking the shared window size, claude TUI couldn't redraw).
- Worst-case reap latency: `wsIdleSec + cfgTimeout("pty")` = **~65s default**.

## What changed

- `src/config/types.ts`: add `wsIdleSec?: number` to `MawTimeouts` interface + `wsIdleSec: 60` to `D.timeouts` defaults. Field name uses explicit `Sec` suffix because other timeouts in the map are ms; Bun's `idleTimeout` API takes seconds (max 960).
- `src/core/server.ts`: import `cfgTimeout` (alongside existing `loadConfig`); build `wsConfig = { ...wsHandler, idleTimeout: cfgTimeout("wsIdleSec"), sendPings: true }` once and share across HTTP + TLS `Bun.serve` calls. `sendPings: true` is Bun's default but pinned for explicitness.

## Scope

`wsConfig` applies to **both** WebSocket endpoints — `/ws/pty` (dashboard PTY, the orphan source) and `/ws` (engine, agent runtime) — because `Bun.serve` accepts one `websocket` field per server. `sendPings: true` keeps healthy ws alive (pong resets the idle clock), so only DEAD ws close after timeout. That's the whole reason this shape is correct for both consumers.

## Live verify on srv1439136 (2026-06-01 18:43-18:47 BKK)

| Probe | Setup | Expected | Actual | Result |
|---|---|---|---|---|
| A: healthy ws survival | Bun-spawned WebSocket client to `ws://localhost:3456/ws/pty`, held 75s | Stays open past 60s idleTimeout (server pings + client pongs reset idle clock) | Opened at 4ms, stayed open 75s, normal close at end-of-script (code 1000) | ✅ GREEN |
| B: ungraceful disconnect → orphan reap | Bun ws client opens + attaches to `regression-pty-target` (throwaway tmux session) + `process.exit(0)` mid-stream (no close frame) | `maw-pty-*` grouped session disappears within `~60 + 5 = 65s` | Orphan `maw-pty-1780314337240-1` created at 18:45:38, gone by 18:47:06 (≤88s; actual reap likely ~18:46:43) | ✅ GREEN |
| Oracle base sessions cross-check | 5 sessions (01-labubu, 02-neo, 03-pulse, 04-echo, 05-nari) before + after restart | All 5 alive throughout | All 5 alive at 18:42:51 (pre-restart) + 18:43:30 (post-restart) + 18:47:06 (post-cycle) | ✅ GREEN |
| Service health | `curl /api/health` pre, post-restart, post-cycle | HTTP 200 throughout | HTTP 200 all 3 checkpoints | ✅ GREEN |

**Caveat**: no Boss-side dashboard tab was open during the test (0 `maw-pty-*` at baseline), so browser auto-reconnect after restart was not exercised. The hard gate (no Oracle silently disconnected on a HEALTHY ws) was verified via the synthetic probe-A path which exercises the same wsConfig.

## Boss decisions baked in (per Labubu relay 2026-06-01 13:32)

1. `wsIdleSec` naming (explicit unit) — done
2. Default value: 60s — done
3. Sequencing: P1 standalone; P2 (periodic sweep for restart-orphans) + P3 (attach-time kill) deferred until P1 live ≥24h
4. `window-size manual` hardening: deferred to a separate decision after P1-P3 land

## Test plan
- [ ] Boss / Labubu confirm dashboard tab reconnects cleanly after maw restart in a real browser (gap from synthetic probes)
- [ ] 24h soak: confirm no Oracle base session has silent disconnects + the engine `/ws` doesn't false-close on idle clients
- [ ] If green at 24h: open P2+P3 PR for periodic stale-session sweep + attach-time kill

## Rollback
- `git revert <this PR's commit>` + `pm2 restart maw` — RTO ~2 min. Forward-only schema change (just added a config field with a default); rollback is the inverse delete.

## Provenance
- Inbox: `/root/projects/echo-oracle/ψ/inbox/2026-06-01_0844_from-labubu_maw-dashboard-orphan-pty-wedges-claude-tui.md` (Labubu's diagnosis)
- Plan: `/root/projects/echo-oracle/ψ/writing/maw-pty-heartbeat-reaper-plan.md` (3-phase plan + verify steps + 4 Q's for Boss)
- Greenlight: `/root/projects/echo-oracle/ψ/inbox/2026-06-01_1837_from-labubu_heartbeat-reaper-GREENLIT-P1-proceed-boss-decisions.md` (all 4 Q's resolved to Echo's recs)
- Source verified pre-write: `server.ts:152-164,243,253` + `pty.ts:50-52,178-191,54-72` + `config/load.ts:166-167` (cfgTimeout signature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)