### PR TITLE
P1: WebSocket heartbeat-reaper via Bun.serve idleTimeout + sendPings (recut of #1970)

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -35,6 +35,8 @@ export interface MawTimeouts {
   shellInit?: number;
   wakeRetry?: number;
   wakeVerify?: number;
+  /** WebSocket idle timeout — SECONDS (Bun API constraint, max 960). Other timeouts here are ms; `Sec` suffix makes the unit explicit. Used by Bun.serve websocket idleTimeout — dead ws closes after this, fires close handler → handlePtyClose → detach → grace-timer reap. */
+  wsIdleSec?: number;
 }
 
 export interface MawLimits {
@@ -202,7 +204,7 @@ export interface MawConfig {
 /** Typed defaults for intervals, timeouts, limits (#172) */
 export const D = {
   intervals: { capture: 50, sessions: 5000, status: 3000, teams: 3000, preview: 2000, peerFetch: 10000, crashCheck: 30000, peerRetryBackoff: 300 } as const,
-  timeouts: { http: 5000, health: 3000, ping: 5000, pty: 5000, workspace: 5000, shellInit: 3000, wakeRetry: 500, wakeVerify: 3000 } as const,
+  timeouts: { http: 5000, health: 3000, ping: 5000, pty: 5000, workspace: 5000, shellInit: 3000, wakeRetry: 500, wakeVerify: 3000, wsIdleSec: 60 } as const,
   limits: { feedMax: 500, feedDefault: 50, feedHistory: 50, logsMax: 500, logsDefault: 50, logsTruncate: 500, messageTruncate: 100, ptyCols: 500, ptyRows: 200, maxConcurrentAgents: 0, peerProbeRetries: 2 } as const,
   hmacWindowSeconds: 300,
 } as const;

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { MawEngine } from "../engine";
 import type { WSData } from "./types";
-import { loadConfig } from "../config";
+import { loadConfig, cfgTimeout } from "../config";
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { serveStatic } from "hono/bun";
@@ -291,9 +291,16 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
     console.warn(`[startup] peer dedup scan skipped: ${e?.message || e}`);
   }
 
+  // P1 heartbeat-reaper: Bun-managed ws ping/pong + idle close. Dead clients
+  // (ungraceful disconnect, no TCP FIN) close after wsIdleSec → close handler
+  // fires → handlePtyClose → detach → grace-timer reaps the maw-pty- tmux session.
+  // sendPings: true is Bun's default but pinned for explicitness. Shared across
+  // the HTTP + TLS Bun.serve calls below so both ws surfaces get the heartbeat.
+  const wsConfig = { ...wsHandler, idleTimeout: cfgTimeout("wsIdleSec"), sendPings: true };
+
   let server: ReturnType<typeof Bun.serve>;
   try {
-    server = Bun.serve({ port, hostname, fetch: fetchHandler, websocket: wsHandler });
+    server = Bun.serve({ port, hostname, fetch: fetchHandler, websocket: wsConfig });
   } catch (err) {
     if (isAddressInUseError(err)) {
       for (const line of servePortInUseInstructions(port, hostname)) console.error(line);
@@ -323,7 +330,7 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
   if (tlsCfg?.cert && tlsCfg?.key && existsSync(tlsCfg.cert) && existsSync(tlsCfg.key)) {
     const tlsPort = port + 1;
     const tls = { cert: readFileSync(tlsCfg.cert), key: readFileSync(tlsCfg.key) };
-    Bun.serve({ port: tlsPort, tls, fetch: fetchHandler, websocket: wsHandler });
+    Bun.serve({ port: tlsPort, tls, fetch: fetchHandler, websocket: wsConfig });
     console.log(`maw serve → https://localhost:${tlsPort} (wss://localhost:${tlsPort}/ws) [TLS]`);
   }
 


### PR DESCRIPTION
## Recut of #1970 onto current `main`

#1970 was cut from a deploy-pinned base now **932 commits behind `main`**, and both touched files were churned upstream → it went `CONFLICTING` and couldn't be cleanly rebased. Per recut-vs-rebase doctrine this re-applies the same fix adapted to upstream's current structure. Closes #1970 in favour of this clean-base PR.

Confirmed upstream `main` does **not** already have ws heartbeat (no `sendPings` / ws `idleTimeout` / `wsIdleSec`) — the fix is still needed.

## Problem
ws on `/ws/pty` had no ping/pong heartbeat. Ungraceful disconnect (tab killed, laptop sleep, network drop — no TCP FIN) left a dead ws in `viewers`, `viewers.size` never reached 0, so the `maw-pty-*` tmux session lingered attached at its frozen window size forever. Symptom: 2026-05-30 shared-window-size hijack + claude TUI wedge.

## Fix
Enable Bun's native ws heartbeat at `Bun.serve` config — `idleTimeout` + `sendPings: true`. Dead clients close after `wsIdleSec` → close handler fires → `handlePtyClose` → detach → existing grace-timer reaps the tmux session. Healthy ws stay alive (pong resets the idle clock); only dead ws close. Worst-case reap latency ≈ `wsIdleSec + cfgTimeout("pty")` ≈ 65s default.

## Changes
- `config/types.ts`: add `wsIdleSec?: number` to `MawTimeouts` + `D.timeouts` (default **60**). Unit is **seconds** (Bun API constraint); the `Sec` suffix flags the mixed-unit map (other timeouts are ms).
- `core/server.ts`: import `cfgTimeout`, build `wsConfig` once, share it across the HTTP + TLS `Bun.serve` calls so both ws surfaces (`/ws` engine + `/ws/pty` dashboard) get the heartbeat.

## Verification
- Effect-identical to the patch **live on srv1439136 since 2026-06-01 18:43**, where the cross-Oracle regression gate was GREEN (healthy ws survived 75s past idleTimeout; orphan `maw-pty-` reaped within 65s of abrupt client exit; all 5 base sessions alive; HTTP 200 throughout).
- `bun run build` clean against current `main` (680 modules bundled). Note: project has no `tsc` gate; `bun build` is a bundler. The change is type-safe by construction (`cfgTimeout` keys off `D.timeouts`, which now includes `wsIdleSec`).

⏳ **Do not merge yet** — held until the 24h soak checkpoint goes green (2026-06-02 18:45 BKK) per Boss directive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)