### PR TITLE
🧹 Orphan-PTY reaper P2+P3 — periodic sweep + attach-time grouped-orphan kill

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -24,6 +24,8 @@ export interface MawIntervals {
   preview?: number;
   peerFetch?: number;
   crashCheck?: number;
+  /** Periodic orphan-PTY sweep cadence (ms). See pty.ts sweepOrphanPtySessions (#P2). */
+  ptySweep?: number;
 }
 
 export interface MawTimeouts {
@@ -201,7 +203,7 @@ export interface MawConfig {
 
 /** Typed defaults for intervals, timeouts, limits (#172) */
 export const D = {
-  intervals: { capture: 50, sessions: 5000, status: 3000, teams: 3000, preview: 2000, peerFetch: 10000, crashCheck: 30000, peerRetryBackoff: 300 } as const,
+  intervals: { capture: 50, sessions: 5000, status: 3000, teams: 3000, preview: 2000, peerFetch: 10000, crashCheck: 30000, peerRetryBackoff: 300, ptySweep: 300000 } as const,
   timeouts: { http: 5000, health: 3000, ping: 5000, pty: 5000, workspace: 5000, shellInit: 3000, wakeRetry: 500, wakeVerify: 3000 } as const,
   limits: { feedMax: 500, feedDefault: 50, feedHistory: 50, logsMax: 500, logsDefault: 50, logsTruncate: 500, messageTruncate: 100, ptyCols: 500, ptyRows: 200, maxConcurrentAgents: 0, peerProbeRetries: 2 } as const,
   hmacWindowSeconds: 300,

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { MawEngine } from "../engine";
 import type { WSData } from "./types";
-import { loadConfig } from "../config";
+import { loadConfig, cfgInterval } from "../config";
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { serveStatic } from "hono/bun";
@@ -12,7 +12,7 @@ import { setupTriggerListener } from "./runtime/trigger-listener";
 import { createTransportRouter } from "../transports";
 import { listSessions } from "./transport/ssh";
 import { Tmux } from "./transport/tmux";
-import { handlePtyMessage, handlePtyClose } from "./transport/pty";
+import { handlePtyMessage, handlePtyClose, sweepOrphanPtySessions } from "./transport/pty";
 import { setBunServer } from "../lib/elysia-auth";
 import { runServeLifecycleHooks } from "../plugin/lifecycle";
 import {
@@ -303,6 +303,21 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
   }
   setBunServer(server);
   startEnginePluginHealthPolling();
+
+  // #P2 — periodic orphan-PTY sweep. The boot reaper above (#300) clears the
+  // server-restart class once at startup; this catches in-memory/tmux drift on
+  // a long-lived process. unref() so it never holds the event loop open.
+  const ptySweepTimer = setInterval(() => {
+    sweepOrphanPtySessions()
+      .then(({ killed, checked }) => {
+        if (killed.length > 0) {
+          console.log(`[pty-sweep] killed ${killed.length} orphan(s): ${killed.join(", ")} (checked ${checked})`);
+        }
+      })
+      .catch((err) => console.error("[pty-sweep] failed:", err));
+  }, cfgInterval("ptySweep"));
+  (ptySweepTimer as { unref?: () => void }).unref?.();
+
   const bindNote = reason ? ` (${reason})` : "";
   console.log(`maw ${VERSION} serve → ${HTTP_URL} (${WS_URL}) [${hostname}]${bindNote}`);
 

--- a/src/core/transport/pty.ts
+++ b/src/core/transport/pty.ts
@@ -5,7 +5,12 @@ import type { MawWS } from "../types";
 type PtyProc = ReturnType<typeof Bun.spawn>;
 type PtySpawn = typeof Bun.spawn;
 type PtySpawnSync = typeof Bun.spawnSync;
-type PtyTmux = Pick<typeof tmux, "newGroupedSession" | "setOption" | "killSession">;
+// listSessionGroups is optional: production always has it (real `tmux` is
+// spread into ptyDeps), but injected test mocks may omit it — in which case
+// the orphan sweep (#P2) and attach-time grouped-orphan kill (#P3) no-op
+// rather than throw.
+type PtyTmux = Pick<typeof tmux, "newGroupedSession" | "setOption" | "killSession">
+  & Partial<Pick<typeof tmux, "listSessionGroups">>;
 
 export interface PtyDeps {
   tmux: PtyTmux;
@@ -51,6 +56,8 @@ interface PtySession {
 interface PtyHandlers {
   handlePtyMessage: (ws: MawWS, msg: string | Buffer) => void;
   handlePtyClose: (ws: MawWS) => void;
+  /** #P2 — kill maw-pty-* tmux sessions no longer tracked in-memory. */
+  sweepOrphanPtySessions: () => Promise<{ killed: string[]; checked: number }>;
 }
 
 function replayLinesFromControl(value: unknown): number {
@@ -76,6 +83,11 @@ export function createPtyHandlers(overrides: Partial<PtyDeps> = {}): PtyHandlers
   let nextPtyId = 0;
   const sessions = new Map<string, PtySession>();
   const attaching = new Set<string>();
+  // PTY session names generated but not yet committed to `sessions` (the
+  // newGroupedSession→setOption→spawn window). The sweep/attach-kill must treat
+  // these as live so a sweep landing mid-create can't reap a session we're
+  // about to track and disconnect the Oracle that just attached.
+  const creatingPtyNames = new Set<string>();
 
 function isLocalHost(): boolean {
   // #713: with bind/host split, config.host is never a bind address (0.0.0.0 etc.)
@@ -86,6 +98,53 @@ function isLocalHost(): boolean {
 function findSession(ws: MawWS): PtySession | undefined {
   for (const s of sessions.values()) {
     if (s.viewers.has(ws)) return s;
+  }
+}
+
+// True when a maw-pty-* tmux session is one we own — either committed to
+// `sessions` or mid-create. Neither must ever be reaped.
+function isTrackedPtyName(ptyName: string): boolean {
+  if (creatingPtyNames.has(ptyName)) return true;
+  for (const s of sessions.values()) {
+    if (s.ptySessionName === ptyName) return true;
+  }
+  return false;
+}
+
+// #P2 — periodic orphan sweep. Kills maw-pty-* tmux sessions that exist
+// server-side but are no longer tracked in-memory (in-memory/tmux drift WITHIN
+// a single server lifecycle — e.g. a kill that raced cleanup, or a future
+// dead-client miss). The boot-time reaper (server.ts #300) already clears the
+// server-RESTART class on startup; this handles runtime drift on a long-lived
+// process. Tracked/attached sessions are always skipped, so a live Oracle
+// terminal is never touched.
+async function sweepOrphanPtySessions(): Promise<{ killed: string[]; checked: number }> {
+  if (!io.tmux.listSessionGroups) return { killed: [], checked: 0 };
+  const all = await io.tmux.listSessionGroups();
+  const killed: string[] = [];
+  for (const { name } of all) {
+    if (!name.startsWith("maw-pty-")) continue;
+    if (isTrackedPtyName(name)) continue;
+    await io.tmux.killSession(name); // best-effort; killSession swallows errors
+    killed.push(name);
+  }
+  return { killed, checked: all.length };
+}
+
+// #P3 — at attach time, remove any pre-existing maw-pty-* sessions grouped to
+// the SAME parent that we don't track. Grouped sessions share the parent's
+// window size, so a stale grouped client (e.g. a frozen 45x30 tab) shrinks the
+// real window — the "size-hijack" vector. Group name == parent session name
+// (verified on live tmux). Untracked-only + group-scoped → never kills a live
+// terminal on this or any other Oracle.
+async function killStaleGroupedSessions(parent: string): Promise<void> {
+  if (!io.tmux.listSessionGroups) return;
+  const all = await io.tmux.listSessionGroups();
+  for (const { name, group } of all) {
+    if (!name.startsWith("maw-pty-")) continue;
+    if (group !== parent) continue;
+    if (isTrackedPtyName(name)) continue;
+    await io.tmux.killSession(name);
   }
 }
 
@@ -149,6 +208,16 @@ async function attach(ws: MawWS, target: string, cols: number, rows: number, rep
   // Create a grouped session — shares windows but has independent client sizing.
   // This prevents the web terminal from shrinking the real terminal.
   const ptySessionName = `maw-pty-${io.now()}-${++nextPtyId}`;
+  creatingPtyNames.add(ptySessionName);
+
+  // #P3 — clear any stale grouped orphan on this parent so a leftover frozen
+  // client can't shrink the shared window. Fire-and-forget: it runs alongside
+  // session creation (killSession is idempotent and tmux resizes the window
+  // after a client leaves regardless of order), and the new ptySessionName is
+  // already in creatingPtyNames so the kill can never reap the session we are
+  // about to track. Keeps attach latency off the tmux-list round-trip.
+  void killStaleGroupedSessions(sessionName).catch(() => { /* expected: tmux listing may transiently fail */ });
+
   try {
     await io.tmux.newGroupedSession(sessionName, ptySessionName, {
       cols: c, rows: r, window: windowPart || undefined,
@@ -156,6 +225,7 @@ async function attach(ws: MawWS, target: string, cols: number, rows: number, rep
     // Hide status bar in PTY sessions so it doesn't appear in terminal output
     await io.tmux.setOption(ptySessionName, "status", "off").catch(() => { /* expected: option may not apply */ });
   } catch {
+    creatingPtyNames.delete(ptySessionName);
     attaching.delete(safe);
     ws.send(JSON.stringify({ type: "error", message: "Failed to create PTY session" }));
     return;
@@ -209,6 +279,7 @@ async function attach(ws: MawWS, target: string, cols: number, rows: number, rep
 
   session = { proc, target: safe, ptySessionName, viewers: new Set([ws]), cleanupTimer: null };
   sessions.set(safe, session);
+  creatingPtyNames.delete(ptySessionName); // now tracked via `sessions`
   attaching.delete(safe);
 
   // Stream PTY stdout → all viewers as binary frames
@@ -262,10 +333,11 @@ function detach(ws: MawWS) {
   }
 }
 
-  return { handlePtyMessage, handlePtyClose };
+  return { handlePtyMessage, handlePtyClose, sweepOrphanPtySessions };
 }
 
 const defaultPtyHandlers = createPtyHandlers();
 
 export const handlePtyMessage = defaultPtyHandlers.handlePtyMessage;
 export const handlePtyClose = defaultPtyHandlers.handlePtyClose;
+export const sweepOrphanPtySessions = defaultPtyHandlers.sweepOrphanPtySessions;

--- a/src/core/transport/tmux-class.ts
+++ b/src/core/transport/tmux-class.ts
@@ -97,6 +97,27 @@ export class Tmux {
     }
   }
 
+  /**
+   * List every session with its group name in a single tmux call.
+   * `#{session_group}` is empty for ungrouped sessions and equals the parent
+   * session name for grouped ones (verified on live tmux: a maw-pty-* grouped
+   * to `01-labubu` reports group `01-labubu`). Used by the orphan-PTY reaper
+   * (#P2 sweep) and attach-time grouped-orphan kill (#P3).
+   */
+  async listSessionGroups(): Promise<Array<{ name: string; group: string }>> {
+    try {
+      const raw = await this.run("list-sessions", "-F", "#{session_name}|||#{session_group}");
+      return raw.split("\n").filter(Boolean).map(line => {
+        const [name, group = ""] = line.split("|||");
+        return { name, group };
+      });
+    } catch (error) {
+      if (isTmuxBinaryMissingError(error)) throw error;
+      if (isTmuxNoServerError(error)) return [];
+      return [];
+    }
+  }
+
   async hasSession(name: string): Promise<boolean> {
     try {
       await this.run("has-session", "-t", name);

--- a/test/isolated/core-server-coverage.test.ts
+++ b/test/isolated/core-server-coverage.test.ts
@@ -100,6 +100,7 @@ mock.module(import.meta.resolve("../../src/core/transport/tmux"), () => ({
 mock.module(import.meta.resolve("../../src/core/transport/pty"), () => ({
   handlePtyMessage: (...args: unknown[]) => { ptyMessages.push(args); },
   handlePtyClose: (ws: unknown) => { ptyCloses.push(ws); },
+  sweepOrphanPtySessions: async () => ({ killed: [], checked: 0 }),
 }));
 mock.module(import.meta.resolve("../../src/lib/elysia-auth"), () => ({ setBunServer: (server: unknown) => setServerCalls.push(server) }));
 mock.module(import.meta.resolve("../../src/plugin/lifecycle"), () => ({

--- a/test/isolated/core-server-more-coverage-2.test.ts
+++ b/test/isolated/core-server-more-coverage-2.test.ts
@@ -74,6 +74,7 @@ mock.module(import.meta.resolve("../../src/core/transport/tmux"), () => ({
 mock.module(import.meta.resolve("../../src/core/transport/pty"), () => ({
   handlePtyMessage: () => {},
   handlePtyClose: () => {},
+  sweepOrphanPtySessions: async () => ({ killed: [], checked: 0 }),
 }));
 mock.module(import.meta.resolve("../../src/lib/elysia-auth"), () => ({ setBunServer: () => {} }));
 mock.module(import.meta.resolve("../../src/plugin/lifecycle"), () => ({

--- a/test/isolated/coverage-core-shared-server.test.ts
+++ b/test/isolated/coverage-core-shared-server.test.ts
@@ -48,6 +48,7 @@ mock.module(import.meta.resolve("../../src/core/transport/tmux"), () => ({
 mock.module(import.meta.resolve("../../src/core/transport/pty"), () => ({
   handlePtyMessage: (...args: unknown[]) => { ptyMessages.push(args); },
   handlePtyClose: (...args: unknown[]) => { ptyCloses.push(args); },
+  sweepOrphanPtySessions: async () => ({ killed: [], checked: 0 }),
 }));
 mock.module(import.meta.resolve("../../src/lib/elysia-auth"), () => ({ setBunServer: () => {} }));
 mock.module(import.meta.resolve("../../src/plugin/lifecycle"), () => ({

--- a/test/isolated/coverage-next-core-instance-server.test.ts
+++ b/test/isolated/coverage-next-core-instance-server.test.ts
@@ -50,7 +50,7 @@ mock.module(import.meta.resolve("../../src/core/transport/tmux"), () => ({
     async run() { return ""; }
   },
 }));
-mock.module(import.meta.resolve("../../src/core/transport/pty"), () => ({ handlePtyMessage: () => {}, handlePtyClose: () => {} }));
+mock.module(import.meta.resolve("../../src/core/transport/pty"), () => ({ handlePtyMessage: () => {}, handlePtyClose: () => {}, sweepOrphanPtySessions: async () => ({ killed: [], checked: 0 }) }));
 mock.module(import.meta.resolve("../../src/lib/elysia-auth"), () => ({ setBunServer: () => {} }));
 mock.module(import.meta.resolve("../../src/plugin/lifecycle"), () => ({
   runServeLifecycleHooks: async () => {},

--- a/test/pty-transport-default.test.ts
+++ b/test/pty-transport-default.test.ts
@@ -55,6 +55,7 @@ function makeHarness(options: {
   spawnSync?: (args: string[]) => { stdout?: Uint8Array };
   groupedImpl?: (sessionName: string, ptySessionName: string, opts: unknown) => Promise<void>;
   setOptionImpl?: (session: string, option: string, value: string) => Promise<void>;
+  listSessionGroupsImpl?: () => Promise<Array<{ name: string; group: string }>>;
 } = {}) {
   const spawnPlans = [...(options.spawnPlans ?? [])];
   const readers: ControlledReader[] = [];
@@ -107,6 +108,9 @@ function makeHarness(options: {
         await options.setOptionImpl?.(session, option, value);
       },
       killSession: async (session: string) => { killSessionCalls.push(session); },
+      // Only present when the test opts in — mirrors production where the real
+      // tmux always has it but injected mocks may omit it (sweep/#P3 no-op).
+      ...(options.listSessionGroupsImpl ? { listSessionGroups: options.listSessionGroupsImpl } : {}),
     },
     setTimeout: ((fn: () => void, _ms?: number) => {
       const timer = { active: true, fn };
@@ -370,5 +374,53 @@ describe("createPtyHandlers", () => {
     await eventually(() => bounded.spawnCalls.length === 1, "bounded replay spawn");
 
     expect(bounded.spawnSyncCalls[0]).toEqual(["tmux", "capture-pane", "-t", "follow:1", "-p", "-e", "-J", "-S", "-12"]);
+  });
+
+  test("#P2 sweep kills untracked maw-pty-* sessions, sparing tracked and non-maw sessions", async () => {
+    const groups = [
+      { name: "01-labubu", group: "01-labubu" },        // parent — not maw-pty
+      { name: "maw-pty-orphan-1", group: "01-labubu" },  // orphan
+      { name: "maw-pty-orphan-2", group: "" },           // ungrouped orphan
+      { name: "some-view", group: "" },                  // not maw-pty
+    ];
+    const h = makeHarness({ listSessionGroupsImpl: async () => groups, spawnPlans: [{ chunks: ["x"], autoEnd: false }] });
+
+    // Attach so one maw-pty session becomes tracked in-memory.
+    const ws = makeWs();
+    h.handlePtyMessage(ws as any, JSON.stringify({ type: "attach", target: "tracked:0" }));
+    await eventually(() => h.groupedCalls.length === 1, "tracked attach");
+    const trackedName = h.groupedCalls[0].ptySessionName;
+    groups.push({ name: trackedName, group: "tracked" });
+
+    const result = await h.sweepOrphanPtySessions();
+    expect(result.killed.sort()).toEqual(["maw-pty-orphan-1", "maw-pty-orphan-2"]);
+    expect(result.checked).toBe(5);
+    expect(result.killed).not.toContain(trackedName);
+    expect(h.killSessionCalls).toContain("maw-pty-orphan-1");
+    expect(h.killSessionCalls).not.toContain(trackedName);
+    await h.finishReaders();
+  });
+
+  test("#P2 sweep no-ops when tmux lacks listSessionGroups (injected mock)", async () => {
+    const h = makeHarness(); // no listSessionGroupsImpl → method absent
+    const result = await h.sweepOrphanPtySessions();
+    expect(result).toEqual({ killed: [], checked: 0 });
+    expect(h.killSessionCalls).toEqual([]);
+  });
+
+  test("#P3 attach kills a pre-existing untracked grouped orphan on the same parent only", async () => {
+    const groups = [
+      { name: "01-labubu", group: "01-labubu" },
+      { name: "maw-pty-stale", group: "01-labubu" },  // same parent, untracked → kill
+      { name: "maw-pty-other", group: "02-neo" },      // different parent → spare
+    ];
+    const h = makeHarness({ listSessionGroupsImpl: async () => groups, spawnPlans: [{ autoEnd: true }] });
+    const ws = makeWs();
+
+    h.handlePtyMessage(ws as any, JSON.stringify({ type: "attach", target: "01-labubu:0" }));
+    // P3 is fire-and-forget alongside session creation — poll for the kill.
+    await eventually(() => h.killSessionCalls.includes("maw-pty-stale"), "P3 stale-orphan kill");
+    expect(h.killSessionCalls).not.toContain("maw-pty-other");
+    await h.finishReaders();
   });
 });


### PR DESCRIPTION
Follow-up to **P1** (ws `idleTimeout` heartbeat, PR #1977) — the two belt-and-suspenders layers Boss sequenced for *"P2+P3 together, after P1 lives ≥24h clean"*. P1 was confirmed GREEN at the 24h soak checkpoint (2026-06-02 18:45 BKK; maw pid 2959287, 0 crashes, 5/5 Oracle sessions alive, 1 maw-pty orphan ≪ threshold) before this PR was opened.

> Branched off `origin/main` (not the P1 alpha branch) since #1977 is still open pending merge. P1 (`server.ts` ws config) and this PR (`pty.ts`/`tmux-class.ts` reaping) touch disjoint code; only `config` defaults are co-edited (P1 adds `wsIdleSec`, this adds `ptySweep`).

## The three layers, and what each covers

| Layer | Orphan class | Mechanism |
|---|---|---|
| boot reaper (`server.ts` #300, *already exists*) | server **restart** — tmux sessions outlive an in-memory map wiped by restart | one-shot scan at startup |
| **P1** (#1977) | **dead client** within a lifecycle — ungraceful disconnect, no TCP FIN, `close` never fires | Bun ws `idleTimeout` + pings → `close` → existing grace-timer reap |
| **P2** (this PR) | **runtime drift** — in-memory/tmux desync on a long-lived process | periodic `setInterval` sweep |
| **P3** (this PR) | **size-hijack** — a stale grouped client shrinks the shared window | kill same-parent untracked orphans at attach |

The plan originally framed P2 as the restart-class fix, but verifying against `origin/main` showed the boot reaper already owns that case — so P2's real, net-new value is **runtime** drift on a long-lived server. Framing corrected here.

## P2 — periodic orphan sweep
`setInterval(cfgInterval("ptySweep"))` (default **300_000ms**), `.unref()`'d. Kills any `maw-pty-*` tmux session not tracked in-memory. Tracked/attached sessions are always skipped → a live Oracle terminal is never touched. Logs only when it kills (signal, not noise).

## P3 — attach-time grouped-orphan kill
Before a new client renders, fire-and-forget removal of pre-existing **untracked** `maw-pty-*` sessions grouped to the **same parent**. Grouped sessions share the parent window size, so a frozen `45×30` leftover shrinks the real window. `#{session_group}` == parent session name — **verified on live tmux** (`maw-pty-…-7 → group=01-labubu`). Fire-and-forget keeps attach latency off the tmux-list round-trip; the new session is registered in `creatingPtyNames` first so it can never be self-reaped.

## Supporting
- `Tmux.listSessionGroups()` — one `list-sessions -F "#{session_name}|||#{session_group}"` call, serves both P2 and P3.
- `PtyTmux` widens `listSessionGroups` as **optional** — injected test mocks omitting it make P2/P3 no-op instead of throwing (production always has it via `ptyDeps` spreading the real `tmux`).
- `creatingPtyNames` race guard — a PTY name is "live" from generation until committed to `sessions`, so a sweep mid-create can't reap a session we're about to track.

## Shared-runtime safety (this is the 5-Oracle live runtime)
Every kill path is **untracked-only** and idempotent (`killSession` swallows errors). P3 is additionally **group-scoped** to the attaching target. No change to the live ws handler config — that is P1/#1977's blast radius, deliberately untouched here.

## Tests
3 new pty tests (sweep kills only untracked & spares tracked/non-maw; sweep no-ops without `listSessionGroups`; P3 kills same-parent orphan only, spares other-parent) + 4 server-coverage pty module-mocks updated for the new export. `pty` + `tmux-class` + server-coverage suites all green; `tsc --noEmit` clean.

— Echo Oracle 📚 (AI, Knowledge Seeker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)