### PR TITLE
fix(hey): warn on silent misdelivery to wrong window (#1980)

### DIFF
--- a/src/api/sessions.ts
+++ b/src/api/sessions.ts
@@ -5,7 +5,7 @@ import { findWindow } from "../core/runtime/find-window";
 import { getAggregatedSessions, findPeerForTarget, sendKeysToPeer, sendKeysToPeerDetailed } from "../core/transport/peers";
 import { loadConfig } from "../config";
 import { curlFetch } from "../core/transport/curl-fetch";
-import { resolveTarget } from "../core/routing";
+import { resolveTarget, detectWindowMismatch } from "../core/routing";
 import { processMirror } from "../lib/process-mirror";
 import { cmdWake as defaultCmdWake, resolveFleetSession } from "../commands/shared/wake";
 import { shouldAutoWake as defaultShouldAutoWake } from "../commands/shared/should-auto-wake";
@@ -433,6 +433,11 @@ export function createSessionsApi(deps: SessionsApiDeps = {}) {
           lastLine,
           signed: messageSigned,
         });
+        // #1980: flag silent misdelivery — a forwarded `<oracle>-oracle`
+        // target that resolved to a window NOT named like that oracle (e.g.
+        // `mawjs-oracle` landing on a bare `mawjs` shell pane). The sender
+        // surfaces this warning alongside its `delivered` line.
+        const mismatch = detectWindowMismatch(target, resolved.target, local);
         return {
           ok: true,
           target: resolved.target,
@@ -442,6 +447,7 @@ export function createSessionsApi(deps: SessionsApiDeps = {}) {
           state,
           receipt: deliveryReceipt("target_pane_resolved", "send_keys_injected", state === "delivered" ? "live_pane_consumed" : "fallback_queued"),
           ...(inbox?.ok ? { inbox: inbox.path } : {}),
+          ...(mismatch ? { warning: mismatch } : {}),
         };
       }
 

--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -8,6 +8,7 @@ import {
 } from "../../sdk";
 import { Tmux } from "../../core/transport/tmux";
 import { AmbiguousMatchError } from "../../core/runtime/find-window";
+import { detectWindowMismatch } from "../../core/routing";
 import { loadConfig, cfgLimit } from "../../config";
 import { logMessage, emitFeed } from "./comm-log-feed";
 import { buildMessageLifecycleFeedEvent, type MessageLifecycleInput } from "../../lib/message-events";
@@ -860,6 +861,9 @@ export async function cmdSend(
     }, config.port || 3456);
     console.log(`\x1b[32mdelivered\x1b[0m → ${target}: ${outboundMessage}`);
     if (lastLine) console.log(`\x1b[90m  ⤷ ${lastLine.slice(0, cfgLimit("messageTruncate"))}\x1b[0m`);
+    // #1980: warn on silent misdelivery to a window that isn't the named oracle.
+    const mismatch = detectWindowMismatch(query, result.target, sessions);
+    if (mismatch) console.log(`  \x1b[33m⚠\x1b[0m ${mismatch}`);
     return;
   }
 
@@ -889,6 +893,8 @@ export async function cmdSend(
       const color = state === "queued" ? "\x1b[33m" : "\x1b[32m";
       console.log(`${color}${state}\x1b[0m ⚡ ${result.node} → ${res.data.target || result.target}: ${outboundMessage}`);
       if (res.data.lastLine) console.log(`\x1b[90m  ⤷ ${res.data.lastLine.slice(0, cfgLimit("messageTruncate"))}\x1b[0m`);
+      // #1980: surface the receiving node's misdelivery warning, if any.
+      if (res.data.warning) console.log(`  \x1b[33m⚠\x1b[0m ${res.data.warning}`);
       await runHook("after_send", { to: query, message: outboundMessage });
       return;
     }

--- a/src/core/routing.ts
+++ b/src/core/routing.ts
@@ -434,6 +434,56 @@ function uniqueStrings(values: string[]): string[] {
 }
 
 /**
+ * #1980: Detect silent misdelivery — flag when a specific `<oracle>-oracle`
+ * window was requested but resolution landed on a window that is NOT that
+ * oracle window.
+ *
+ * The reported failure: `maw hey oracle-world-oracle:mawjs-oracle` forwarded
+ * `mawjs-oracle` to the peer, where fleet/alias resolution picked a bare
+ * `mawjs` shell pane (`mawjs:0`) over the real `mawjs-oracle` window
+ * (`01-mawjs:1`) — because `fleetWindowCandidateNames` matches the
+ * `-oracle`-stripped form `mawjs` against a window literally named `mawjs`.
+ * Injection succeeded on the wrong pane, so `hey` reported `delivered`.
+ *
+ * This runs AFTER resolution, independent of which path resolved the target,
+ * and returns a warning string when the intent was more specific than the
+ * window it reached. Intentionally narrow to avoid false positives:
+ *   - Only fires for `-oracle`-suffixed intents (operator named a specific
+ *     oracle window). Bare session aliases (`mawjs` → `mawjs-oracle`) and
+ *     explicit `session:index` / pane forms are exempt — the latter satisfies
+ *     the "full-form bypass" escape hatch.
+ *   - No warning when the resolved window's name matches the intent
+ *     (modulo a leading `NN-` and case).
+ */
+export function detectWindowMismatch(
+  query: string,
+  resolvedTarget: string,
+  sessions: Session[],
+): string | null {
+  // Explicit tmux address forms are operator-chosen — never second-guess them.
+  if (!query || query.includes(":")) return null;
+
+  const qNorm = query.trim().toLowerCase().replace(/^\d+-/, "");
+  if (!qNorm.endsWith("-oracle")) return null;
+
+  const addr = resolvedTarget.match(/^(.+):(\d+)(?:\.\d+)?$/);
+  if (!addr) return null;
+  const [, sessName, idxStr] = addr;
+  const sess = sessions.find((s) => s.name === sessName);
+  const win = sess?.windows.find((w) => w.index === Number(idxStr));
+  if (!win) return null;
+
+  const wNorm = win.name.trim().toLowerCase().replace(/^\d+-/, "");
+  if (wNorm === qNorm) return null; // exact oracle-window hit — unambiguous
+
+  return (
+    `delivered to ${resolvedTarget} (window '${win.name}'), but target was '${query}' — ` +
+    `resolved window is not named '${query.trim()}'; the message may have landed on the ` +
+    `wrong pane. Use the full 'peer:session:window' form to disambiguate.`
+  );
+}
+
+/**
  * Look up an oracle short-name in the cached `OracleManifest` (Sub-PR 3 of #841).
  *
  * Tries the raw query first, then the `-oracle`-stripped variant — mirrors the

--- a/test/routing-window-mismatch.test.ts
+++ b/test/routing-window-mismatch.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests for detectWindowMismatch() — #1980 silent-misdelivery guard.
+ *
+ * Reproduces the federation failure where `maw hey oracle-world-oracle:mawjs-oracle`
+ * forwarded `mawjs-oracle` to the peer, which resolved it to a bare `mawjs` shell
+ * pane (`mawjs:0`) instead of the real `mawjs-oracle` window (`01-mawjs:1`) — yet
+ * still reported `delivered`. See: #1980.
+ */
+import { describe, test, expect } from "bun:test";
+import { detectWindowMismatch } from "../src/core/routing";
+import type { Session } from "../src/core/runtime/find-window";
+
+// The receiving node's landscape from the bug report: a bare `mawjs` session
+// whose window 0 is a zsh shell named `mawjs`, plus the real oracle window.
+const SESSIONS: Session[] = [
+  { name: "mawjs", windows: [{ index: 0, name: "mawjs", active: true }] },
+  { name: "01-mawjs", windows: [{ index: 1, name: "mawjs-oracle", active: true }] },
+];
+
+describe("detectWindowMismatch (#1980)", () => {
+  test("warns when an -oracle target lands on a non-oracle window", () => {
+    const warning = detectWindowMismatch("mawjs-oracle", "mawjs:0", SESSIONS);
+    expect(warning).not.toBeNull();
+    expect(warning).toContain("mawjs:0");
+    expect(warning).toContain("mawjs-oracle");
+    expect(warning).toContain("wrong pane");
+  });
+
+  test("no warning when the -oracle target lands on the real oracle window", () => {
+    expect(detectWindowMismatch("mawjs-oracle", "01-mawjs:1", SESSIONS)).toBeNull();
+  });
+
+  test("explicit session:index form bypasses the check (full-form escape hatch)", () => {
+    expect(detectWindowMismatch("mawjs:0", "mawjs:0", SESSIONS)).toBeNull();
+    expect(detectWindowMismatch("01-mawjs:1", "01-mawjs:1", SESSIONS)).toBeNull();
+  });
+
+  test("bare session alias resolving to its -oracle window is not flagged", () => {
+    // `mawjs` (no -oracle suffix) → `mawjs-oracle` window is the intended
+    // convention, not a misroute.
+    expect(detectWindowMismatch("mawjs", "01-mawjs:1", SESSIONS)).toBeNull();
+  });
+
+  test("matches the oracle window even with an NN- session prefix on the window name", () => {
+    const sessions: Session[] = [
+      { name: "77-mawjs", windows: [{ index: 2, name: "77-mawjs-oracle", active: true }] },
+    ];
+    expect(detectWindowMismatch("mawjs-oracle", "77-mawjs:2", sessions)).toBeNull();
+  });
+
+  test("pane-addressed targets are parsed and checked", () => {
+    expect(detectWindowMismatch("mawjs-oracle", "mawjs:0.1", SESSIONS)).not.toBeNull();
+  });
+
+  test("returns null when the resolved session/window cannot be found", () => {
+    expect(detectWindowMismatch("mawjs-oracle", "ghost:9", SESSIONS)).toBeNull();
+  });
+
+  test("empty query is a no-op", () => {
+    expect(detectWindowMismatch("", "mawjs:0", SESSIONS)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

`maw hey` reports `delivered ✅` even when the message lands on the wrong tmux window (#1980). A forwarded `<oracle>-oracle` target can resolve to a non-oracle window — e.g. `mawjs-oracle` lands on a bare `mawjs` shell pane (`mawjs:0`) instead of the real `mawjs-oracle` window (`01-mawjs:1`). `fleetWindowCandidateNames` matches the `-oracle`-stripped candidate `mawjs` against a window literally named `mawjs`, pane injection succeeds, and hey reports success → silent data loss.

## Fix

`detectWindowMismatch(query, resolvedTarget, sessions)` — a pure, resolution-path-agnostic post-check in `routing.ts`. Fires only when:
- the intent is `-oracle`-suffixed (operator named a specific oracle window), **and**
- the resolved window's name does not match that intent (modulo leading `NN-` + case).

Bare session aliases (`mawjs` → `mawjs-oracle`) and explicit `session:index`/pane forms are exempt — the latter is the documented full-form escape hatch.

Wiring:
- `/api/send` (receiving node) attaches the warning to its response.
- `cmdSend` surfaces it on both local and peer (`res.data.warning`) routes as `⚠ ...`.

## Tests

`test/routing-window-mismatch.test.ts` (8 cases): ambiguous-resolution warning, correct-resolution no-warning, full-form bypass, bare-alias convention, NN-prefixed window match, pane-addressed, unresolvable target, empty query. All green; no regressions in routing/comm-send/sessions suites.

Acceptance criteria from #1980: warn on mismatch ✓, confirmation includes actual `session:window` ✓ (pre-existing), tests cover the three required cases ✓.

Closes #1980

🤖 Generated with [Claude Code](https://claude.com/claude-code)