### PR TITLE
fix(federation): retry peer probe to absorb WireGuard jitter (#1975)

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -201,8 +201,8 @@ export interface MawConfig {
 
 /** Typed defaults for intervals, timeouts, limits (#172) */
 export const D = {
-  intervals: { capture: 50, sessions: 5000, status: 3000, teams: 3000, preview: 2000, peerFetch: 10000, crashCheck: 30000 } as const,
+  intervals: { capture: 50, sessions: 5000, status: 3000, teams: 3000, preview: 2000, peerFetch: 10000, crashCheck: 30000, peerRetryBackoff: 300 } as const,
   timeouts: { http: 5000, health: 3000, ping: 5000, pty: 5000, workspace: 5000, shellInit: 3000, wakeRetry: 500, wakeVerify: 3000 } as const,
-  limits: { feedMax: 500, feedDefault: 50, feedHistory: 50, logsMax: 500, logsDefault: 50, logsTruncate: 500, messageTruncate: 100, ptyCols: 500, ptyRows: 200, maxConcurrentAgents: 0 } as const,
+  limits: { feedMax: 500, feedDefault: 50, feedHistory: 50, logsMax: 500, logsDefault: 50, logsTruncate: 500, messageTruncate: 100, ptyCols: 500, ptyRows: 200, maxConcurrentAgents: 0, peerProbeRetries: 2 } as const,
   hmacWindowSeconds: 300,
 } as const;

--- a/src/core/transport/peers.ts
+++ b/src/core/transport/peers.ts
@@ -1,4 +1,4 @@
-import { loadConfig, cfgTimeout } from "../../config";
+import { loadConfig, cfgTimeout, cfgLimit, cfgInterval } from "../../config";
 import type { Session } from "./ssh";
 import { curlFetch } from "./curl-fetch";
 
@@ -59,12 +59,46 @@ export interface FederationStatusOptions {
  * For symmetric pair verification, see `getFederationStatusSymmetric()`
  * (PR #398) and the `maw federation --verify` CLI flag.
  */
+/**
+ * #1975: Probe `GET /api/sessions` with retries to absorb transient WG jitter.
+ *
+ * Attempts up to `1 + limits.peerProbeRetries` times, sleeping
+ * `intervals.peerRetryBackoff` ms between tries. Returns the first `ok`
+ * response; otherwise returns the LAST response/throw so the caller's
+ * existing `res.ok` / catch handling is unchanged. A thrown final attempt
+ * propagates (caught upstream → `reachable: false`), matching prior behavior
+ * when every attempt fails.
+ */
+async function probeSessionsWithRetry(url: string) {
+  const retries = Math.max(0, cfgLimit("peerProbeRetries"));
+  const backoff = Math.max(0, cfgInterval("peerRetryBackoff"));
+  let lastErr: unknown;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    if (attempt > 0 && backoff > 0) await Bun.sleep(backoff);
+    try {
+      const res = await curlFetch(`${url}/api/sessions`, { timeout: cfgTimeout("http") });
+      if (res.ok || attempt === retries) return res;
+    } catch (err) {
+      lastErr = err;
+      if (attempt === retries) throw err;
+    }
+  }
+  // Unreachable in practice — the loop always returns or throws on the final
+  // attempt — but satisfies the type checker.
+  throw lastErr ?? new Error(`peer probe failed: ${url}`);
+}
+
 async function checkPeerReachable(url: string): Promise<{
   reachable: boolean; latency: number; node?: string; agents?: string[]; clockDeltaMs?: number;
 }> {
   const start = Date.now();
   try {
-    const res = await curlFetch(`${url}/api/sessions`, { timeout: cfgTimeout("http") });
+    // #1975: WireGuard links jitter — a single timed-out probe used to mark a
+    // healthy peer `unreachable` for the whole run. Retry the reachability
+    // probe (GET /api/sessions is read-only, safe to repeat) with a short
+    // backoff before giving up. Identity fetch below stays single-shot — it's
+    // already best-effort and never gates `reachable`.
+    const res = await probeSessionsWithRetry(url);
     const latency = Date.now() - start;
     // Fetch identity for node dedup (#192) + clock delta (#268)
     let node: string | undefined;

--- a/test/peers-transport-coverage.test.ts
+++ b/test/peers-transport-coverage.test.ts
@@ -11,7 +11,10 @@ const realCurl = await import("../src/core/transport/curl-fetch");
 
 let mockActive = false;
 let config: any;
-let responses: Array<{ match: string; res?: any; error?: Error; advanceMs?: number }> = [];
+// `seq` lets a matched URL return a different result per call (shifted in
+// order) — used to model #1975 transient-then-recovered probes. When `seq`
+// is exhausted (or absent), the entry falls back to its `res`/`error`.
+let responses: Array<{ match: string; res?: any; error?: Error; advanceMs?: number; seq?: Array<{ res?: any; error?: Error }> }> = [];
 let curlCalls: Array<{ url: string; opts: any }> = [];
 let warns: string[] = [];
 let now = 1_700_000_000_000;
@@ -24,6 +27,19 @@ mock.module(import.meta.resolve("../src/config"), () => ({
   cfgTimeout: (kind: Parameters<typeof realConfig.cfgTimeout>[0]) => (
     mockActive ? 1234 : realConfig.cfgTimeout(kind)
   ),
+  // #1975: default the peer-probe retry knobs OFF (retries 0, backoff 0) so the
+  // shared suite stays single-shot + no real sleeps. The dedicated retry tests
+  // opt in via config.limits / config.intervals.
+  cfgLimit: (key: Parameters<typeof realConfig.cfgLimit>[0]) => {
+    if (!mockActive) return realConfig.cfgLimit(key);
+    if (config?.limits && key in config.limits) return config.limits[key];
+    return key === "peerProbeRetries" ? 0 : realConfig.cfgLimit(key);
+  },
+  cfgInterval: (key: Parameters<typeof realConfig.cfgInterval>[0]) => {
+    if (!mockActive) return realConfig.cfgInterval(key);
+    if (config?.intervals && key in config.intervals) return config.intervals[key];
+    return key === "peerRetryBackoff" ? 0 : realConfig.cfgInterval(key);
+  },
 }));
 
 mock.module(import.meta.resolve("../src/core/transport/curl-fetch"), () => ({
@@ -33,6 +49,11 @@ mock.module(import.meta.resolve("../src/core/transport/curl-fetch"), () => ({
     curlCalls.push({ url, opts });
     const hit = responses.find((entry) => url.includes(entry.match));
     if (hit?.advanceMs) now += hit.advanceMs;
+    if (hit?.seq && hit.seq.length > 0) {
+      const step = hit.seq.shift()!;
+      if (step.error) throw step.error;
+      return step.res ?? { ok: false, status: 404, data: null };
+    }
     if (hit?.error) throw hit.error;
     return hit?.res ?? { ok: false, status: 404, data: null };
   },
@@ -373,5 +394,77 @@ describe("symmetric status dependency seam", () => {
       ["http://url-match:3456", "healthy", true, undefined],
       ["http://throws:3456", "unknown", null, "peer status fetch failed: peer boom"],
     ]);
+  });
+});
+
+describe("#1975 peer probe retry on transient jitter", () => {
+  test("a peer that throws once then answers 200 is reported reachable", async () => {
+    config = {
+      node: "m5",
+      port: 4567,
+      peers: ["http://jitter:3456"],
+      limits: { peerProbeRetries: 2 },
+      intervals: { peerRetryBackoff: 0 },
+    };
+    responses = [
+      { match: "localhost:4567/api/sessions", res: { ok: true, status: 200, data: [] } },
+      { match: "localhost:4567/api/identity", res: { ok: true, status: 200, data: { node: "m5", agents: ["local"] } } },
+      {
+        match: "jitter:3456/api/sessions",
+        // first attempt times out (WG jitter), second recovers
+        seq: [{ error: new Error("ETIMEDOUT") }, { res: { ok: true, status: 200, data: [] } }],
+      },
+      { match: "jitter:3456/api/identity", res: { ok: true, status: 200, data: { node: "jitter", agents: ["peer"] } } },
+    ];
+
+    const status = await getFederationStatus();
+
+    expect(status.reachablePeers).toBe(1);
+    const jitter = status.peers.find((p) => p.url === "http://jitter:3456");
+    expect(jitter?.reachable).toBe(true);
+    // first throw + recovery = exactly 2 /api/sessions probes to the peer
+    expect(curlCalls.filter((c) => c.url.includes("jitter:3456/api/sessions"))).toHaveLength(2);
+  });
+
+  test("a peer down for every attempt stays unreachable after exhausting retries", async () => {
+    config = {
+      node: "m5",
+      port: 4567,
+      peers: ["http://dead:3456"],
+      limits: { peerProbeRetries: 2 },
+      intervals: { peerRetryBackoff: 0 },
+    };
+    responses = [
+      { match: "localhost:4567/api/sessions", res: { ok: true, status: 200, data: [] } },
+      { match: "localhost:4567/api/identity", res: { ok: true, status: 200, data: { node: "m5", agents: ["local"] } } },
+      { match: "dead:3456/api/sessions", error: new Error("ECONNREFUSED") },
+    ];
+
+    const status = await getFederationStatus();
+
+    expect(status.reachablePeers).toBe(0);
+    const dead = status.peers.find((p) => p.url === "http://dead:3456");
+    expect(dead?.reachable).toBe(false);
+    // 1 initial attempt + 2 retries = 3 probes before giving up
+    expect(curlCalls.filter((c) => c.url.includes("dead:3456/api/sessions"))).toHaveLength(3);
+  });
+
+  test("retries=0 preserves the legacy single-shot probe", async () => {
+    config = {
+      node: "m5",
+      port: 4567,
+      peers: ["http://once:3456"],
+      limits: { peerProbeRetries: 0 },
+    };
+    responses = [
+      { match: "localhost:4567/api/sessions", res: { ok: true, status: 200, data: [] } },
+      { match: "localhost:4567/api/identity", res: { ok: true, status: 200, data: { node: "m5", agents: ["local"] } } },
+      { match: "once:3456/api/sessions", error: new Error("ETIMEDOUT") },
+    ];
+
+    const status = await getFederationStatus();
+
+    expect(status.reachablePeers).toBe(0);
+    expect(curlCalls.filter((c) => c.url.includes("once:3456/api/sessions"))).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Problem

`maw federation` probed each peer's reachability with a single `GET /api/sessions` and no retry (`peers.ts` `checkPeerReachable`). On WireGuard links with intermittent latency, one timed-out probe marked a healthy node `unreachable` for the entire run — `white.wg:3456` flapped `unreachable` → `reachable` (221–281ms) across consecutive runs seconds apart while `curl` returned 200 throughout. Transient jitter read as permanent offline (not a `.wg` DNS bug — `/etc/hosts` resolves correctly).

## Fix

`probeSessionsWithRetry()` retries the **read-only** reachability probe (safe to repeat) up to `limits.peerProbeRetries` times (default **2**) with `intervals.peerRetryBackoff` ms backoff (default **300**) before declaring the peer down. It returns the first `ok` response, else the last response/throw, so the existing `res.ok` / catch handling is unchanged.

- Identity fetch stays single-shot — it's already best-effort and never gates `reachable`.
- Knobs are config-driven (added to `D.limits` / `D.intervals`), so operators can tune or disable; `peerProbeRetries: 0` restores the exact legacy single-shot behavior.

## Tests

`test/peers-transport-coverage.test.ts` — 3 new cases in a dedicated `#1975` block:
- throw-once-then-200 → reported **reachable**, exactly 2 probes
- down-every-attempt → stays **unreachable** after 1 + 2 = 3 probes
- `retries=0` → legacy single-shot (1 probe)

The shared mock now defaults the retry knobs **off** (retries 0, backoff 0) so existing down-peer cases keep their 1-call / no-sleep behavior; retry tests opt in explicitly with backoff 0 (deterministic, no real sleeps). 15/15 green, tsc clean.

Closes #1975

🤖 Generated with [Claude Code](https://claude.com/claude-code)