### PR TITLE
test(channel-env): isolate DISCORD_STATE_DIR so channelEnv tests are deterministic

### DIFF
--- a/test/build-command-channel-env.test.ts
+++ b/test/build-command-channel-env.test.ts
@@ -39,6 +39,15 @@ const { buildCommand, buildCommandInDir } = await import("../src/config/command"
 const { saveRepoChannels } = await import("../src/commands/shared/channel-loader");
 
 const origGetuid = process.getuid;
+// These tests assert that channelEnv values are PREPENDED to the command.
+// applyChannelEnv() defers to the shell when a key is already exported
+// (#1148 shell-vs-config precedence), so any ambient `DISCORD_STATE_DIR` —
+// e.g. the manual `.envrc` workaround discord-oracle uses on oss — would
+// suppress the prepend and make these assertions env-dependent (m5 passes,
+// oss fails 3). Isolate the real keys these tests use so they're deterministic
+// regardless of the runner's environment.
+const ISOLATED_ENV_KEYS = ["DISCORD_STATE_DIR", "WEIRD", "TRICKY", "JUST_TILDE"];
+let savedEnv: Record<string, string | undefined> = {};
 beforeEach(() => {
   fakeConfig = {
     host: "local",
@@ -53,9 +62,18 @@ beforeEach(() => {
   };
   fakeSessionIds = {};
   (process as any).getuid = () => 1000;
+  savedEnv = {};
+  for (const key of ISOLATED_ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
 });
 afterEach(() => {
   (process as any).getuid = origGetuid;
+  for (const key of ISOLATED_ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
 });
 
 describe("buildCommand — channelEnv tilde expansion (#1135)", () => {


### PR DESCRIPTION
## Problem

oss ran `bun test` on alpha from oracle-world and saw `build-command-channel-env.test.ts` → **10 pass / 3 fail** (deterministic on their box, green on m5).

## Root cause — test env-leak, NOT a production bug

The 3 failing tests all key on the real env var `DISCORD_STATE_DIR`. `applyChannelEnv()` defers to the shell when a key is already exported (`#1148` shell-vs-config precedence — intentional). oss runs a manual `.envrc export DISCORD_STATE_DIR=…` as a discord-oracle migration workaround, so on their machine the var is set → the config value is correctly suppressed → the tests' hard-coded `expect(out).toContain("DISCORD_STATE_DIR=…")` fail. m5 has the var unset, so it passed there.

Reproduced exactly:

```
$ DISCORD_STATE_DIR=/home/oss/.claude/channels/mybot bun test test/build-command-channel-env.test.ts
10 pass / 3 fail   ← matches oss
```

The production `applyChannelEnv` code is **working as designed**. The gap is that the `#1135` tilde and `#1877` repo-injection cases reuse real env keys without isolating them.

## Fix

Save + delete `DISCORD_STATE_DIR` / `WEIRD` / `TRICKY` / `JUST_TILDE` in `beforeEach`, restore in `afterEach`. Now deterministic:

```
$ bun test … (clean)                         → 13 pass / 0 fail
$ DISCORD_STATE_DIR=… bun test … (oss repro)  → 13 pass / 0 fail
```

## Related / out of scope

- Registry-helpers env-leak (the `#1984` additive-scan masking) was already fixed by `4d81c12e "Isolate plugin scan dir override test"`.
- **Open design question for the noah real-world report** (maw wake not injecting `DISCORD_STATE_DIR` → plugin silent-mute): should a repo's `.claude/channel.json` env *override* an ambient shell value, rather than defer to it (`#1148`)? That's a behavior change to channelEnv precedence, separate from this test fix — flagging for a product decision; couldn't reproduce the real-world case without oss's actual repo + env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)