### PR TITLE
fix(routing): stop dragging the wake subsystem into resolveTarget — unblocks CI

### DIFF
--- a/src/commands/shared/fleet-load.ts
+++ b/src/commands/shared/fleet-load.ts
@@ -2,6 +2,7 @@ import { join } from "path";
 import { existsSync, readdirSync, readFileSync } from "fs";
 import * as sdk from "../../sdk";
 import { fleetDirForWrite as coreFleetDirForWrite, fleetDirsForRead as coreFleetDirsForRead, uniqueDirs } from "../../core/fleet/paths";
+import { resolveFleetWindowSessionTarget } from "../../core/matcher/resolve-target";
 
 export interface FleetWindow {
   name: string;
@@ -138,4 +139,22 @@ export async function getSessionNames(): Promise<string[]> {
     const out = await sdk.tmux.run("list-sessions", "-F", "#{session_name}");
     return out.trim().split("\n").filter(Boolean);
   } catch { return []; }
+}
+
+/**
+ * Oracle name → fleet session name via the fleet config (#281).
+ *
+ * Lives here (not in wake-resolve-impl) so the hot, sync `resolveTarget`
+ * path can pull it WITHOUT dragging the whole wake subsystem — wake-resolve-impl
+ * statically `import { hostExec, tmux } from "../../sdk"`, which made any test
+ * partial-mocking the sdk barrel fail to link (the release blocker on
+ * v26.6.5-alpha.1323). This module only uses `import * as sdk` (namespace —
+ * link-safe), and resolveFleetSession itself touches neither hostExec nor tmux.
+ */
+export function resolveFleetSession(oracle: string): string | null {
+  try {
+    const resolved = resolveFleetWindowSessionTarget(oracle, loadFleet());
+    if (resolved.kind === "fuzzy" || resolved.kind === "exact") return resolved.match.name;
+  } catch { /* fleet dir may not exist */ }
+  return null;
 }

--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -2,14 +2,14 @@ import { hostExec, tmux, curlFetch } from "../../sdk";
 import { loadConfig, getEnvVars } from "../../config";
 import { ghqFind, ghqList } from "../../core/ghq";
 import { pickOracle, resolveOracle as resolveSharedOracle, type OracleRef } from "../../core/resolve";
-import { resolveFleetWindowSessionTarget, resolveNumericFleetStemPrefix, resolveSessionTarget } from "../../core/matcher/resolve-target";
+import { resolveNumericFleetStemPrefix, resolveSessionTarget } from "../../core/matcher/resolve-target";
 import { isInfrastructureChannelSessionName } from "../../core/matcher/channel-session";
 import { readdirSync, existsSync, statSync } from "fs";
 import { join } from "path";
 import { worktreeNameFromPath } from "../../core/fleet/worktree-layout";
 import { scanWorktrees, type WorktreeInfo } from "../../core/fleet/worktrees-scan";
 import { scanSuggestOracle } from "./wake-resolve-scan-suggest";
-import { loadFleet, type FleetWindow } from "./fleet-load";
+import { loadFleet, resolveFleetSession, type FleetWindow } from "./fleet-load";
 import type { Session } from "../../core/runtime/find-window";
 
 /**
@@ -424,13 +424,10 @@ export function findReusableWorktreeBySlug(
 
 export function getSessionMap(): Record<string, string> { return loadConfig().sessions; }
 
-export function resolveFleetSession(oracle: string): string | null {
-  try {
-    const resolved = resolveFleetWindowSessionTarget(oracle, loadFleet());
-    if (resolved.kind === "fuzzy" || resolved.kind === "exact") return resolved.match.name;
-  } catch { /* fleet dir may not exist */ }
-  return null;
-}
+// #1976-release: resolveFleetSession moved to ./fleet-load so the sync
+// resolveTarget path can import it without pulling this sdk-coupled module.
+// Re-exported here to keep existing importers (wake barrel, etc.) working.
+export { resolveFleetSession };
 
 function knownFleetSessionStems(): string[] {
   try {

--- a/src/core/routing.ts
+++ b/src/core/routing.ts
@@ -37,7 +37,12 @@
 
 import { findWindow, type Session } from "./runtime/find-window";
 import type { MawConfig } from "../config";
-import { resolveFleetSession } from "../commands/shared/wake";
+// #1976-release: import from the light fleet-load module, NOT the wake barrel.
+// The wake barrel statically pulls wake-session/wake-resolve-impl, which
+// `import { hostExec, tmux } from "../../sdk"` — dragging the sdk barrel into
+// every routing/comm-send consumer's graph and breaking tests that partially
+// mock it ("Export named 'hostExec' not found", the v26.6.5-alpha.1323 CI block).
+import { resolveFleetSession } from "../commands/shared/fleet-load";
 import { loadManifestCached, type OracleManifestEntry } from "../lib/oracle-manifest";
 import { loadPeers, type Peer } from "../lib/peers/store";
 

--- a/test/comm-send-focused-gaps.test.ts
+++ b/test/comm-send-focused-gaps.test.ts
@@ -96,6 +96,10 @@ mock.module(join(srcRoot, "src/commands/shared/receiver-inbox"), () => ({
 
 mock.module(join(srcRoot, "src/lib/oracle-manifest"), () => ({
   findOracle: () => findOracleResult,
+  // routing.ts imports loadManifestCached for its Step-3a manifest lookup;
+  // the mock must provide it or Bun fails to link. Empty list = manifest miss,
+  // which falls through to the legacy agents-map step (correct for these tests).
+  loadManifestCached: () => [],
 }));
 
 mock.module(join(srcRoot, "src/commands/shared/should-auto-wake"), () => ({


### PR DESCRIPTION
## Release blocker

CI on **v26.6.5-alpha.1323** (`aaf140c2`) failed in `test/comm-send-focused-gaps.test.ts` with:

```
SyntaxError: Export named 'hostExec' not found in module '.../src/sdk/index.ts'
```

blocking the `maw team up` (#1976) publish.

## Root cause — NOT a circular import / export-ordering bug

Traced the chain (run-it-not-read-it):

```
comm-send → routing.ts (detectWindowMismatch)
          → import { resolveFleetSession } from "../commands/shared/wake"  (BARREL)
          → re-exports wake-session + wake-resolve-impl
          → import { hostExec, tmux } from "../../sdk"   ← named imports
```

`hostExec` **is** exported (ssh.ts:264) and re-exported (sdk/index.ts:43). The failure is a **link error against an incomplete test mock**: the test partial-mocks the sdk barrel and omits `hostExec`, and a **named** import (`import { hostExec }`) requires that export to exist. `routing.ts` is hot (every `comm-send` / `/api/send`), so importing *anything* from the wake barrel dragged the entire transport-coupled wake subsystem into every consumer's graph.

(I verified the lead's suggested "import hostExec directly from ssh in the consumer" just cascades the problem — it forces `ssh.ts` to load, which named-imports `tmuxCmd` from the *also*-mocked tmux module. The barrel is the intended single mock seam; the real issue is routing pulling the heavy chain.)

## Fix

`resolveFleetSession` is a pure fleet-config lookup (`loadFleet` + `resolveFleetWindowSessionTarget`). Move it to the light **`fleet-load`** module — which only uses `import * as sdk` (a **namespace** import, link-safe under partial mocks) — and point `routing.ts` there. `wake-resolve-impl` re-exports it, so the wake barrel and all other importers are unchanged.

This removes `wake-session`/`wake-cmd`/`wake-resolve-impl` from routing's graph entirely, shrinking the mock surface for routing/comm-send tests from **3 barrels to 0**. Also completes the test's intended `oracle-manifest` mock (`loadManifestCached`), which was masked behind the `hostExec` failure.

## Verification

- `comm-send-focused-gaps` → **5/5 pass** (was 0/33)
- routing / comm-send / wake / fleet / sessions-api suites green individually
- `tsc --noEmit` clean; `bun run build` OK (688 modules, no cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)