### PR TITLE
fix(team): port `maw team up` into the VENDORED plugin (the runtime copy) (#1976)

### DIFF
--- a/src/vendor/mpr-plugins/team/index.ts
+++ b/src/vendor/mpr-plugins/team/index.ts
@@ -347,9 +347,33 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         console.log(`\x1b[36m↵\x1b[0m enter sent to ${m.agentId || m.name}`);
       }
 
+    } else if (sub === "up") {
+      // #1976 — charter-driven team wake: reconcile the charter against live
+      // panes (skip live, resume dead in place, fresh-wake missing).
+      if (!args[1]) {
+        logs.push("usage: maw team up <team> [--dry-run] [--status] [--force] [--gather] [-e <engine>]");
+        return { ok: false, error: "team required", output: logs.join("\n") };
+      }
+      const { cmdTeamUp } = await import("./team-up");
+      const flags = parseFlags(args, {
+        "--dry-run": Boolean,
+        "--status": Boolean,
+        "--force": Boolean,
+        "--gather": Boolean,
+        "--engine": String,
+        "-e": "--engine",
+      }, 2);
+      await cmdTeamUp(args[1], {
+        dryRun: Boolean(flags["--dry-run"]),
+        status: Boolean(flags["--status"]),
+        force: Boolean(flags["--force"]),
+        gather: Boolean(flags["--gather"]),
+        engine: flags["--engine"] as string | undefined,
+      });
+
     } else {
       logs.push(`unknown team subcommand: ${sub}`);
-      logs.push("usage: maw team <create|plan|preflight|load|spawn-from|spawn|bring|send|shutdown|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members|enter>");
+      logs.push("usage: maw team <create|plan|preflight|load|up|spawn-from|spawn|bring|send|shutdown|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members|enter>");
       return { ok: false, error: `unknown subcommand: ${sub}`, output: logs.join("\n") };
     }
 

--- a/src/vendor/mpr-plugins/team/plugin.json
+++ b/src/vendor/mpr-plugins/team/plugin.json
@@ -1,16 +1,16 @@
 {
   "name": "team",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "Agent reincarnation engine — create, bring, send, shutdown, resume, lives.",
+  "description": "Agent reincarnation engine — create, up, bring, send, shutdown, resume, lives.",
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "team",
     "aliases": [
       "t"
     ],
-    "help": "maw team <create|plan|preflight|load|spawn-from|spawn|bring|send|shutdown|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members|enter>"
+    "help": "maw team <create|plan|preflight|load|up|spawn-from|spawn|bring|send|shutdown|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members|enter>"
   },
   "weight": 30,
   "tier": "standard",

--- a/src/vendor/mpr-plugins/team/team-liveness.ts
+++ b/src/vendor/mpr-plugins/team/team-liveness.ts
@@ -1,0 +1,124 @@
+import { existsSync } from "fs";
+import { basename, dirname, join } from "path";
+import { Tmux } from "../../../core/transport/tmux";
+import { isAgentCommand } from "../../../core/agent-detect";
+import { loadConfig } from "../../../config/load";
+import type { MawConfig } from "../../../config/types";
+import { cmdWake, type WakeOptions } from "../../../commands/shared/wake-cmd";
+import type { TeamCharterMember } from "./team-charter";
+
+export type TeamMemberState = "live" | "dead" | "missing";
+
+export interface TeamPaneSnapshot {
+  sessionName: string;
+  windowName: string;
+  command: string;
+  path: string;
+  paneId: string;
+}
+
+export interface ClassifiedTeamMember {
+  member: TeamCharterMember;
+  role: string;
+  engine: string;
+  worktree: string;
+  windowIdentity: string;
+  state: TeamMemberState;
+  pane?: TeamPaneSnapshot;
+}
+
+export interface WakeMemberDeps {
+  cmdWakeFn?: typeof cmdWake;
+}
+
+const SHELL_RE = /^-?(zsh|bash|sh|fish)$/i;
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function findRepoRoot(cwd = process.cwd()): string {
+  let dir = cwd;
+  while (true) {
+    if (existsSync(join(dir, ".git"))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) return cwd;
+    dir = parent;
+  }
+}
+
+export function resolveCharterPath(team: string, cwd = process.cwd()): string | null {
+  const root = findRepoRoot(cwd);
+  const local = join(root, ".maw", "teams", `${team}.yaml`);
+  if (existsSync(local)) return local;
+  const psi = join(root, "ψ", "teams", `${team}.yaml`);
+  if (existsSync(psi)) return psi;
+  return null;
+}
+
+export async function listPaneSnapshots(tmux: Pick<Tmux, "run"> = new Tmux()): Promise<TeamPaneSnapshot[]> {
+  const raw = await tmux.run("list-panes", "-a", "-F", "#{session_name}|#{window_name}|#{pane_current_command}|#{pane_current_path}|#{pane_id}");
+  return raw.split(/\r?\n/).map((line) => line.trim()).filter(Boolean).map((line) => {
+    const [sessionName = "", windowName = "", command = "", path = "", paneId = ""] = line.split("|");
+    return { sessionName, windowName, command, path, paneId };
+  });
+}
+
+export async function currentTmuxSession(tmux: Pick<Tmux, "run"> = new Tmux()): Promise<string> {
+  return (await tmux.run("display-message", "-p", "#S")).trim();
+}
+
+export function classifyMember(
+  member: TeamCharterMember,
+  panes: TeamPaneSnapshot[],
+  session: string,
+  opts: { engine?: string } = {},
+): ClassifiedTeamMember {
+  const role = member.role;
+  const windowIdentity = member.name?.trim() || role;
+  const suffix = new RegExp(`-${escapeRegex(windowIdentity)}$`);
+  const pane = panes.find((candidate) =>
+    candidate.sessionName === session && (candidate.windowName === windowIdentity || suffix.test(candidate.windowName))
+  );
+  const engine = opts.engine ?? member.engine ?? member.model ?? "claude";
+  const worktree = typeof member.worktree === "string" && member.worktree.trim() ? member.worktree.trim() : windowIdentity;
+  if (!pane) return { member, role, engine, worktree, windowIdentity, state: "missing" };
+  if (SHELL_RE.test(pane.command)) return { member, role, engine, worktree, windowIdentity, state: "dead", pane };
+  if (isAgentCommand(pane.command)) return { member, role, engine, worktree, windowIdentity, state: "live", pane };
+  return { member, role, engine, worktree, windowIdentity, state: "dead", pane };
+}
+
+export function engineCommand(engine: string, opts: { resume?: boolean } = {}, config: MawConfig = loadConfig()): string {
+  const key = opts.resume ? `${engine}-resume` : engine;
+  return config.commands?.[key] ?? config.commands?.default ?? key;
+}
+
+export function repoSlugFromRoot(root: string): string {
+  try {
+    const proc = Bun.spawnSync(["git", "-C", root, "remote", "get-url", "origin"], { stdout: "pipe", stderr: "pipe" });
+    const remote = new TextDecoder().decode(proc.stdout).trim();
+    const match = remote.match(/github\.com[:/](.+?)(?:\.git)?$/);
+    if (match?.[1]) return match[1];
+  } catch { /* best effort */ }
+  const parts = root.split(/[\\/]+/);
+  const githubIdx = parts.lastIndexOf("github.com");
+  if (githubIdx !== -1 && parts[githubIdx + 1] && parts[githubIdx + 2]) {
+    return `${parts[githubIdx + 1]}/${parts[githubIdx + 2]}`;
+  }
+  return basename(root);
+}
+
+export async function wakeMember(
+  repoSlug: string,
+  member: TeamCharterMember,
+  opts: WakeOptions & { engine: string; session: string; repoPath: string },
+  deps: WakeMemberDeps = {},
+): Promise<string> {
+  const wake = deps.cmdWakeFn ?? cmdWake;
+  return wake(repoSlug, {
+    wt: typeof member.worktree === "string" && member.worktree.trim() ? member.worktree.trim() : (member.name?.trim() || member.role),
+    engine: opts.engine,
+    session: opts.session,
+    repoPath: opts.repoPath,
+  });
+}

--- a/src/vendor/mpr-plugins/team/team-up.ts
+++ b/src/vendor/mpr-plugins/team/team-up.ts
@@ -1,0 +1,186 @@
+// Vendored copy of the team-up verb (#1976). The runtime loads THIS plugin
+// (~/.maw/plugins/team → src/vendor/mpr-plugins/team), not src/commands/plugins/team.
+// Paths differ from the core copy: charter is a sibling here, and commands/shared
+// is three levels up (vendored dir is src/vendor/mpr-plugins/team).
+import { readTeamCharter, type TeamCharter } from "./team-charter";
+import { loadConfig } from "../../../config/load";
+import type { MawConfig } from "../../../config/types";
+import { Tmux } from "../../../core/transport/tmux";
+import { cmdWake } from "../../../commands/shared/wake-cmd";
+import {
+  classifyMember,
+  currentTmuxSession,
+  engineCommand,
+  findRepoRoot,
+  listPaneSnapshots,
+  repoSlugFromRoot,
+  resolveCharterPath,
+  wakeMember,
+  type ClassifiedTeamMember,
+} from "./team-liveness";
+
+export interface TeamUpOptions {
+  dryRun?: boolean;
+  force?: boolean;
+  status?: boolean;
+  gather?: boolean;
+  engine?: string;
+}
+
+export interface TeamUpAction {
+  role: string;
+  state: string;
+  action: string;
+  command?: string;
+}
+
+export interface TeamUpResult {
+  team: string;
+  session: string;
+  roster: ClassifiedTeamMember[];
+  actions: TeamUpAction[];
+  warnings: string[];
+  output: string;
+}
+
+export interface TeamUpDeps {
+  tmux?: Pick<Tmux, "run">;
+  cwd?: string;
+  charterPath?: string | null;
+  readTeamCharterFn?: typeof readTeamCharter;
+  loadConfigFn?: typeof loadConfig;
+  cmdWakeFn?: typeof cmdWake;
+  sleep?: (ms: number) => Promise<void>;
+  repoRoot?: string;
+  repoSlug?: string;
+  logger?: (line: string) => void;
+}
+
+const DEFAULT_SLEEP = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+const SHELL_RE = /^-?(zsh|bash|sh|fish)$/i;
+
+function renderRoster(team: string, session: string, roster: ClassifiedTeamMember[], actions: TeamUpAction[], warnings: string[], tail?: string): string {
+  const actionByRole = new Map(actions.map((action) => [action.role, action]));
+  const lines = [`team up: ${team} (${session})`, "role\tengine\tstate\taction"];
+  for (const item of roster) {
+    const action = actionByRole.get(item.role)?.action ?? "skip";
+    lines.push(`${item.role}\t${item.engine}\t${item.state}\t${action}`);
+  }
+  if (warnings.length) lines.push("", "warnings:", ...warnings.map((warning) => `  - ${warning}`));
+  if (tail) lines.push("", tail);
+  return lines.join("\n");
+}
+
+async function waitForNonShell(
+  role: string,
+  session: string,
+  tmux: Pick<Tmux, "run">,
+  sleep: (ms: number) => Promise<void>,
+): Promise<void> {
+  for (let i = 0; i < 10; i++) {
+    const panes = await listPaneSnapshots(tmux);
+    const current = classifyMember({ role }, panes, session);
+    if (current.pane && !SHELL_RE.test(current.pane.command)) return;
+    await sleep(1000);
+  }
+}
+
+function warnOnPathCollisions(roster: ClassifiedTeamMember[], warnings: string[]): void {
+  const seen = new Map<string, string>();
+  for (const item of roster) {
+    if (!item.member.worktree || !item.pane?.path) continue;
+    const prior = seen.get(item.pane.path);
+    if (prior && prior !== item.role) warnings.push(`worktree path collision: ${prior} and ${item.role} both at ${item.pane.path}`);
+    else seen.set(item.pane.path, item.role);
+  }
+}
+
+export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: TeamUpDeps = {}): Promise<TeamUpResult> {
+  const cwd = deps.cwd ?? process.cwd();
+  const charterPath = deps.charterPath !== undefined ? deps.charterPath : resolveCharterPath(team, cwd);
+  if (!charterPath) throw new Error(`charter not found: ${team}`);
+
+  const read = deps.readTeamCharterFn ?? readTeamCharter;
+  const charter: TeamCharter = read(charterPath);
+  const tmux = deps.tmux ?? new Tmux();
+  const config: MawConfig = (deps.loadConfigFn ?? loadConfig)();
+  const repoRoot = deps.repoRoot ?? findRepoRoot(cwd);
+  const repoSlug = deps.repoSlug ?? repoSlugFromRoot(repoRoot);
+  const currentSession = await currentTmuxSession(tmux).catch(() => "");
+  const session = charter.session ?? currentSession;
+  const warnings: string[] = [];
+  if (charter.session && currentSession && charter.session !== currentSession) {
+    warnings.push(`current tmux session '${currentSession}' differs from charter.session '${charter.session}'; targeting charter session`);
+  }
+
+  const panes = await listPaneSnapshots(tmux);
+  const roster = charter.members.map((member) => classifyMember(member, panes, session, { engine: opts.engine }));
+  const actions: TeamUpAction[] = [];
+
+  if (opts.status) {
+    warnOnPathCollisions(roster, warnings);
+    const output = renderRoster(team, session, roster, actions, warnings);
+    if (deps.logger) deps.logger(output); else console.log(output);
+    return { team, session, roster, actions, warnings, output };
+  }
+
+  if (opts.dryRun) {
+    for (const item of roster) {
+      if (opts.force) {
+        const command = engineCommand(item.engine, { resume: false }, config);
+        actions.push({ role: item.role, state: item.state, action: `would force fresh wake --wt ${item.worktree} -e ${item.engine} --session ${session}`, command });
+      } else if (item.state === "live") {
+        actions.push({ role: item.role, state: item.state, action: "skip live" });
+      } else if (item.state === "dead") {
+        const command = engineCommand(item.engine, { resume: true }, config);
+        actions.push({ role: item.role, state: item.state, action: "would relaunch in place with resume", command });
+      } else {
+        const command = engineCommand(item.engine, { resume: false }, config);
+        actions.push({ role: item.role, state: item.state, action: `would fresh wake --wt ${item.worktree} -e ${item.engine} --session ${session}`, command });
+      }
+    }
+    warnOnPathCollisions(roster, warnings);
+    const output = renderRoster(team, session, roster, actions, warnings, "No changes made");
+    if (deps.logger) deps.logger(output); else console.log(output);
+    return { team, session, roster, actions, warnings, output };
+  }
+
+  const sleep = deps.sleep ?? DEFAULT_SLEEP;
+  for (const item of roster) {
+    if (opts.force) {
+      if (item.pane) await tmux.run("kill-window", "-t", `${item.pane.sessionName ?? session}:${item.pane.windowName}`);
+      const command = engineCommand(item.engine, { resume: false }, config);
+      await wakeMember(repoSlug, item.member, { engine: item.engine, session, repoPath: repoRoot }, { cmdWakeFn: deps.cmdWakeFn });
+      actions.push({ role: item.role, state: item.state, action: "force fresh wake", command });
+      await waitForNonShell(item.role, session, tmux, sleep);
+    } else if (item.state === "live") {
+      actions.push({ role: item.role, state: item.state, action: "skip live" });
+    } else if (item.state === "dead") {
+      const command = engineCommand(item.engine, { resume: true }, config);
+      await tmux.run("send-keys", "-t", item.pane!.paneId, command, "Enter");
+      actions.push({ role: item.role, state: item.state, action: "resume in place", command });
+      await waitForNonShell(item.role, session, tmux, sleep);
+    } else {
+      const command = engineCommand(item.engine, { resume: false }, config);
+      await wakeMember(repoSlug, item.member, { engine: item.engine, session, repoPath: repoRoot }, { cmdWakeFn: deps.cmdWakeFn });
+      actions.push({ role: item.role, state: item.state, action: "fresh wake", command });
+      await waitForNonShell(item.role, session, tmux, sleep);
+    }
+  }
+
+  const finalPanes = await listPaneSnapshots(tmux).catch(() => panes);
+  const finalRoster = charter.members.map((member) => classifyMember(member, finalPanes, session, { engine: opts.engine }));
+  warnOnPathCollisions(finalRoster, warnings);
+
+  if (opts.gather) {
+    for (const item of finalRoster) {
+      if (item.pane && item.state === "live") await tmux.run("join-pane", "-s", item.pane.paneId);
+    }
+    await tmux.run("select-layout", "main-vertical");
+    actions.push({ role: "*", state: "live", action: "gather main-vertical" });
+  }
+
+  const output = renderRoster(team, session, finalRoster, actions, warnings);
+  if (deps.logger) deps.logger(output); else console.log(output);
+  return { team, session, roster: finalRoster, actions, warnings, output };
+}

--- a/test/isolated/team-up-coverage.test.ts
+++ b/test/isolated/team-up-coverage.test.ts
@@ -3,9 +3,13 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 
+// Test the VENDORED copy — that is what the runtime loads (~/.maw/plugins/team →
+// src/vendor/mpr-plugins/team). #1976 originally landed in src/commands/plugins/team
+// (core), which is tested but NOT dispatched, so `maw team up` was unreachable
+// despite green tests. Guard the copy that actually ships.
 import { parseTeamCharterText } from "../../src/vendor/mpr-plugins/team/team-charter";
-import { classifyMember, engineCommand } from "../../src/commands/plugins/team/team-liveness";
-import { cmdTeamUp } from "../../src/commands/plugins/team/team-up";
+import { classifyMember, engineCommand } from "../../src/vendor/mpr-plugins/team/team-liveness";
+import { cmdTeamUp } from "../../src/vendor/mpr-plugins/team/team-up";
 
 const dirs: string[] = [];
 afterEach(() => {
@@ -154,5 +158,25 @@ members:
   test("engine command resolves resume key only when requested", () => {
     expect(engineCommand("omx", {}, config)).toBe("maw run omx");
     expect(engineCommand("omx", { resume: true }, config)).toBe("maw run omx-resume");
+  });
+});
+
+// Regression guard for the integration miss: #1976 landed in core but the
+// runtime dispatches the VENDORED plugin index, where `up` was an unknown
+// subcommand. Assert the vendored handler routes `up` (usage path), NOT the
+// "unknown subcommand" fallthrough. If this fails, the verb is unreachable
+// from the installed binary even when cmdTeamUp itself is green.
+describe("vendored team plugin routes `up` (#1976 integration)", () => {
+  async function dispatch(args: string[]) {
+    const handler = (await import("../../src/vendor/mpr-plugins/team/index.ts")).default;
+    const out: string[] = [];
+    const res = await handler({ source: "cli", args, writer: (...a: any[]) => out.push(a.map(String).join(" ")) } as any);
+    return { res, out: out.join("\n") };
+  }
+
+  test("`team up` is a known subcommand", async () => {
+    const { res } = await dispatch(["up"]);
+    expect(res.error).not.toContain("unknown subcommand");
+    expect(res.error).toBe("team required");
   });
 });


### PR DESCRIPTION
## The blocker (integration-level, run-it-not-read-it)

#1976 added `team-up.ts` + `team-liveness.ts` + the `up` route to **`src/commands/plugins/team`** (CORE). But the runtime dispatches the **VENDORED** plugin:

- `~/.maw/plugins/team` → `src/vendor/mpr-plugins/team` (its `plugin.json` is the *only* manifest declaring command `team`)
- CORE has **no `plugin.json`** and its `index.ts` is imported by nothing at runtime
- Result: `maw team up` → `unknown subcommand: up` on the **installed binary** (m5 + oss), despite green tests + build

Tests passed because they imported the CORE copy; build passed because CORE compiles. The verb was unreachable via the CLI. This is exactly the run-it gate #1976 missed.

## Fix — make the verb reachable from the installed binary

- **Copy** `team-up.ts` + `team-liveness.ts` into the vendored plugin, fixing the two import paths that differ at the vendored location (`./team-charter` sibling; `../../../commands/shared/wake-cmd`).
- **Route** `up` in the vendored `index.ts` (reconciled with its chain) and add `up` to `plugin.json` help; bump `2.0.1 → 2.1.0`.
- **Repoint** `test/isolated/team-up-coverage.test.ts` at the VENDORED copy (guard what ships) and add a regression test asserting the vendored handler **routes `up`** (not the unknown-subcommand fallthrough).

## Verified at runtime (invoked the vendored handler directly)

```
team up            → error "team required"  (routed, NOT "unknown subcommand")
team up demo --status (real on-disk charter):
  ok: true
  role      engine    state  action
  lead      claude    live   skip      ← mawjs-oracle matched by name
  reviewer  claude48  live   skip      ← mawjs-coder-1 matched by name
```

Name-bridge reconciliation (the #1976 option-b fix) works through the vendored copy too. tsc clean; `bun run build` OK (688 modules); all vendored team suites green.

## Investigation answers (per the ask)

- **Is CORE loaded?** No — no `plugin.json`, index unimported at runtime. It's a *tested-but-undispatched* parallel copy.
- **Precedence?** Only vendored loads; no conflict.
- **Upstream?** Vendored is sourced from `soul-brews-studio/maw-plugin-registry/team@v0.1.1-team` (per `registry.meta.json`). No re-vendor script in maw-js, so this edit ships safely — but upstream needs the same `up` addition for permanence.

## Follow-ups (flagged, not in this release fix)

- Resolve the CORE↔VENDORED team-plugin duplication (the root cause of this miss).
- Port `up` to upstream `maw-plugin-registry/team`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)