### PR TITLE
feat(team): add node guards and channels to team up

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -361,6 +361,8 @@ export interface WakeOptions {
   snapshotId?: string;
   /** Filesystem layout for newly-created worktrees (#1850): default nested, legacy sibling via --layout legacy. */
   layout?: WorktreeLayout;
+  /** Force Discord channel launch for Claude-like engines (#1999). */
+  channels?: boolean;
 }
 
 function isAttachOnlyWake(opts: WakeOptions): boolean {
@@ -383,13 +385,14 @@ function isAttachOnlyWake(opts: WakeOptions): boolean {
     && !opts.bud
     && !opts.signalOnBirth
     && !opts.engine
+    && !opts.channels
     && !opts.fromSnapshot
     && !opts.snapshotId;
 }
 
-function buildWakeCommand(windowName: string, cwd: string, opts: Pick<WakeOptions, "engine" | "parentSessionId" | "sessionId">): string {
+function buildWakeCommand(windowName: string, cwd: string, opts: Pick<WakeOptions, "engine" | "parentSessionId" | "sessionId" | "channels">): string {
   return prefixCommandWithSpawnSessionEnv(
-    buildCommandInDir(windowName, cwd, opts.engine),
+    buildCommandInDir(windowName, cwd, opts.channels ? { engine: opts.engine, channels: ["plugin:discord@claude-plugins-official"] } : opts.engine),
     { explicit: opts.parentSessionId, sessionId: opts.sessionId, cwd },
   );
 }

--- a/src/vendor/mpr-plugins/team/team-charter.ts
+++ b/src/vendor/mpr-plugins/team/team-charter.ts
@@ -14,6 +14,8 @@ export interface TeamCharterMember {
   engine?: string;
   worktree?: boolean | string;
   queue?: string[];
+  node?: string;
+  channels?: boolean;
 }
 
 export interface TeamCharter {
@@ -232,6 +234,8 @@ function normalizeCharter(value: unknown): TeamCharter {
       ...(typeof m.worktree === "string" && m.worktree.trim() ? { worktree: m.worktree.trim() } : {}),
       ...(Array.isArray(m.queue) ? { queue: m.queue.filter((item): item is string => typeof item === "string" && item.trim()).map((item) => item.trim()) } : {}),
       ...(typeof m.queue === "string" && m.queue.trim() ? { queue: [m.queue.trim()] } : {}),
+      ...(typeof m.node === "string" && m.node.trim() ? { node: m.node.trim() } : {}),
+      ...(typeof m.channels === "boolean" ? { channels: m.channels } : {}),
     };
   });
   return {

--- a/src/vendor/mpr-plugins/team/team-liveness.ts
+++ b/src/vendor/mpr-plugins/team/team-liveness.ts
@@ -7,7 +7,7 @@ import type { MawConfig } from "../../../config/types";
 import { cmdWake, type WakeOptions } from "../../../commands/shared/wake-cmd";
 import type { TeamCharterMember } from "./team-charter";
 
-export type TeamMemberState = "live" | "dead" | "missing";
+export type TeamMemberState = "live" | "dead" | "missing" | "skipped";
 
 export interface TeamPaneSnapshot {
   sessionName: string;
@@ -25,6 +25,7 @@ export interface ClassifiedTeamMember {
   windowIdentity: string;
   state: TeamMemberState;
   pane?: TeamPaneSnapshot;
+  skipReason?: string;
 }
 
 export interface WakeMemberDeps {
@@ -120,5 +121,6 @@ export async function wakeMember(
     engine: opts.engine,
     session: opts.session,
     repoPath: opts.repoPath,
+    ...(member.channels === true ? { channels: true } : {}),
   });
 }

--- a/src/vendor/mpr-plugins/team/team-up.ts
+++ b/src/vendor/mpr-plugins/team/team-up.ts
@@ -59,6 +59,44 @@ export interface TeamUpDeps {
 const DEFAULT_SLEEP = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 const SHELL_RE = /^-?(zsh|bash|sh|fish)$/i;
 
+function memberWindowIdentity(member: TeamCharter["members"][number]): string {
+  return member.name?.trim() || member.role;
+}
+
+function memberEngine(member: TeamCharter["members"][number], override?: string): string {
+  return override ?? member.engine ?? member.model ?? "claude";
+}
+
+function memberWorktree(member: TeamCharter["members"][number]): string {
+  const identity = memberWindowIdentity(member);
+  return typeof member.worktree === "string" && member.worktree.trim() ? member.worktree.trim() : identity;
+}
+
+function isOtherNodeMember(member: TeamCharter["members"][number], currentNode?: string): boolean {
+  return Boolean(member.node && member.node !== currentNode);
+}
+
+function classifyRosterMember(
+  member: TeamCharter["members"][number],
+  panes: Parameters<typeof classifyMember>[1],
+  session: string,
+  opts: { engine?: string; currentNode?: string } = {},
+): ClassifiedTeamMember {
+  if (isOtherNodeMember(member, opts.currentNode)) {
+    const role = member.role;
+    return {
+      member,
+      role,
+      engine: memberEngine(member, opts.engine),
+      worktree: memberWorktree(member),
+      windowIdentity: memberWindowIdentity(member),
+      state: "skipped",
+      skipReason: `other node: ${member.node}`,
+    };
+  }
+  return classifyMember(member, panes, session, { engine: opts.engine });
+}
+
 function renderRoster(team: string, session: string, roster: ClassifiedTeamMember[], actions: TeamUpAction[], warnings: string[], tail?: string): string {
   const actionByRole = new Map(actions.map((action) => [action.role, action]));
   const lines = [`team up: ${team} (${session})`, "role\tengine\tstate\taction"];
@@ -114,10 +152,16 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
   }
 
   const panes = await listPaneSnapshots(tmux);
-  const roster = charter.members.map((member) => classifyMember(member, panes, session, { engine: opts.engine }));
+  const roster = charter.members.map((member) => classifyRosterMember(member, panes, session, { engine: opts.engine, currentNode: config.node }));
   const actions: TeamUpAction[] = [];
 
   if (opts.status) {
+    for (const item of roster) {
+      if (item.state === "skipped") actions.push({ role: item.role, state: item.state, action: `skip (${item.skipReason ?? "guard"})` });
+      else if (item.state === "missing") actions.push({ role: item.role, state: item.state, action: `wakeable --wt ${item.worktree} -e ${item.engine} --session ${session}${item.member.channels ? " --channels" : ""}` });
+      else if (item.state === "dead") actions.push({ role: item.role, state: item.state, action: "wakeable resume in place" });
+      else actions.push({ role: item.role, state: item.state, action: "skip live" });
+    }
     warnOnPathCollisions(roster, warnings);
     const output = renderRoster(team, session, roster, actions, warnings);
     if (deps.logger) deps.logger(output); else console.log(output);
@@ -126,9 +170,11 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
 
   if (opts.dryRun) {
     for (const item of roster) {
-      if (opts.force) {
+      if (item.state === "skipped") {
+        actions.push({ role: item.role, state: item.state, action: `skip (${item.skipReason ?? "guard"})` });
+      } else if (opts.force) {
         const command = engineCommand(item.engine, { resume: false }, config);
-        actions.push({ role: item.role, state: item.state, action: `would force fresh wake --wt ${item.worktree} -e ${item.engine} --session ${session}`, command });
+        actions.push({ role: item.role, state: item.state, action: `would force fresh wake --wt ${item.worktree} -e ${item.engine} --session ${session}${item.member.channels ? " --channels" : ""}`, command });
       } else if (item.state === "live") {
         actions.push({ role: item.role, state: item.state, action: "skip live" });
       } else if (item.state === "dead") {
@@ -136,7 +182,7 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
         actions.push({ role: item.role, state: item.state, action: "would relaunch in place with resume", command });
       } else {
         const command = engineCommand(item.engine, { resume: false }, config);
-        actions.push({ role: item.role, state: item.state, action: `would fresh wake --wt ${item.worktree} -e ${item.engine} --session ${session}`, command });
+        actions.push({ role: item.role, state: item.state, action: `would fresh wake --wt ${item.worktree} -e ${item.engine} --session ${session}${item.member.channels ? " --channels" : ""}`, command });
       }
     }
     warnOnPathCollisions(roster, warnings);
@@ -147,7 +193,9 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
 
   const sleep = deps.sleep ?? DEFAULT_SLEEP;
   for (const item of roster) {
-    if (opts.force) {
+    if (item.state === "skipped") {
+      actions.push({ role: item.role, state: item.state, action: `skip (${item.skipReason ?? "guard"})` });
+    } else if (opts.force) {
       if (item.pane) await tmux.run("kill-window", "-t", `${item.pane.sessionName ?? session}:${item.pane.windowName}`);
       const command = engineCommand(item.engine, { resume: false }, config);
       await wakeMember(repoSlug, item.member, { engine: item.engine, session, repoPath: repoRoot }, { cmdWakeFn: deps.cmdWakeFn });
@@ -169,7 +217,7 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
   }
 
   const finalPanes = await listPaneSnapshots(tmux).catch(() => panes);
-  const finalRoster = charter.members.map((member) => classifyMember(member, finalPanes, session, { engine: opts.engine }));
+  const finalRoster = charter.members.map((member) => classifyRosterMember(member, finalPanes, session, { engine: opts.engine, currentNode: config.node }));
   warnOnPathCollisions(finalRoster, warnings);
 
   if (opts.gather) {

--- a/test/isolated/team-up-coverage.test.ts
+++ b/test/isolated/team-up-coverage.test.ts
@@ -71,11 +71,104 @@ members:
     name: mawjs-codex
     engine: omx
     worktree: true
+    node: m5
+    channels: true
     queue:
       - next
 `);
     expect(charter.session).toBe("named-session");
-    expect(charter.members[0]).toMatchObject({ role: "coder", name: "mawjs-codex", engine: "omx", worktree: true, queue: ["next"] });
+    expect(charter.members[0]).toMatchObject({ role: "coder", name: "mawjs-codex", engine: "omx", worktree: true, node: "m5", channels: true, queue: ["next"] });
+  });
+
+  test("node-guarded members on another node are skipped, not reported missing or woken", async () => {
+    const root = tempRepo();
+    writeFileSync(join(root, ".maw", "teams", "nodes.yaml"), `
+name: nodes
+session: charter-session
+members:
+  - role: lead
+    name: mawjs-oracle
+    engine: claude
+  - role: bridge
+    name: mawjs-oss-world
+    engine: claude
+    node: oracle-world
+    channels: true
+`, "utf-8");
+    const { tmux, calls } = fakeTmux([
+      "charter-session|mawjs-oracle|claude|/wt/oracle|%1",
+    ]);
+    const wakes: any[] = [];
+
+    const status = await cmdTeamUp("nodes", { status: true }, {
+      cwd: root,
+      tmux,
+      loadConfigFn: () => ({ ...config, node: "m5" }),
+      cmdWakeFn: async (...a: any[]) => { wakes.push(a); return "woke"; },
+      logger: () => {},
+    });
+
+    expect(status.roster.map((m) => [m.role, m.state, m.skipReason])).toEqual([
+      ["lead", "live", undefined],
+      ["bridge", "skipped", "other node: oracle-world"],
+    ]);
+    expect(status.output).toContain("bridge\tclaude\tskipped\tskip (other node: oracle-world)");
+    expect(status.output).not.toContain("bridge\tclaude\tmissing");
+    expect(wakes).toHaveLength(0);
+
+    await cmdTeamUp("nodes", { force: true }, {
+      cwd: root,
+      tmux,
+      loadConfigFn: () => ({ ...config, node: "m5" }),
+      cmdWakeFn: async (...a: any[]) => { wakes.push(a); return "woke"; },
+      sleep: async () => {},
+      logger: () => {},
+    });
+    expect(wakes.map((w) => w[1].wt)).toEqual(["mawjs-oracle"]);
+    expect(calls.filter((c) => c[0] === "kill-window")).toHaveLength(1);
+  });
+
+  test("same-node channels member is wakeable with --channels and fresh wake passes channels", async () => {
+    const root = tempRepo();
+    writeFileSync(join(root, ".maw", "teams", "bridge.yaml"), `
+name: bridge
+session: charter-session
+members:
+  - role: bridge
+    name: mawjs-oss-world
+    engine: claude
+    node: oracle-world
+    channels: true
+`, "utf-8");
+    const { tmux } = fakeTmux([]);
+    const wakes: any[] = [];
+
+    const status = await cmdTeamUp("bridge", { status: true }, {
+      cwd: root,
+      tmux,
+      loadConfigFn: () => ({ ...config, node: "oracle-world" }),
+      logger: () => {},
+    });
+    expect(status.roster.map((m) => [m.role, m.state])).toEqual([["bridge", "missing"]]);
+    expect(status.output).toContain("wakeable --wt mawjs-oss-world -e claude --session charter-session --channels");
+
+    const dry = await cmdTeamUp("bridge", { dryRun: true }, {
+      cwd: root,
+      tmux,
+      loadConfigFn: () => ({ ...config, node: "oracle-world" }),
+      logger: () => {},
+    });
+    expect(dry.output).toContain("would fresh wake --wt mawjs-oss-world -e claude --session charter-session --channels");
+
+    await cmdTeamUp("bridge", {}, {
+      cwd: root,
+      tmux,
+      loadConfigFn: () => ({ ...config, node: "oracle-world" }),
+      cmdWakeFn: async (...a: any[]) => { wakes.push(a); return "woke"; },
+      sleep: async () => {},
+      logger: () => {},
+    });
+    expect(wakes).toEqual([[expect.any(String), { wt: "mawjs-oss-world", engine: "claude", session: "charter-session", repoPath: root, channels: true }]]);
   });
 
 


### PR DESCRIPTION
## Summary\n- retain new vendored team charter member fields: `node` and `channels`\n- make `maw team up` skip node-guarded members whose `node` does not match `config.node` instead of reporting them missing/waking them\n- pass `channels: true` through fresh/force wakes so Claude-like bridge windows launch with Discord channels\n- add vendored runtime tests for parser retention, node-skip, same-node `--channels`, and installed-dispatch guard\n\n## Acceptance evidence\n- `MAW_TEST_MODE=1 bun test test/isolated/team-up-coverage.test.ts --path-ignore-patterns '**/agents/**'`\n- `bun run build`\n- `bun run test:default:safe`\n- installed binary: `maw team up mawjs-dev --status` on m5 shows bridge skipped as other node\n- installed binary with sandbox `config.node=oracle-world`: `maw team up mawjs-dev --status` shows bridge missing/wakeable with `--channels`\n\n## Companion charter commit\n- mawjs-oracle `vault-sync-2026-05-26`: `cd2c9aa` declares `oss-world` bridge in `.maw/teams/mawjs-dev.yaml`\n\nFixes #1999