### PR TITLE
feat(team): add charter-driven down and up --only

### DIFF
--- a/src/vendor/mpr-plugins/team/index.ts
+++ b/src/vendor/mpr-plugins/team/index.ts
@@ -197,7 +197,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         return { ok: false, error: "agent name required", output: logs.join("\n") };
       }
       cmdTeamLives(args[1]);
-    } else if (sub === "shutdown" || sub === "down") {
+    } else if (sub === "shutdown") {
       if (!args[1]) {
         logs.push("usage: maw team shutdown <name> [--force] [--merge]");
         return { ok: false, error: "name required", output: logs.join("\n") };
@@ -347,11 +347,32 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         console.log(`\x1b[36m↵\x1b[0m enter sent to ${m.agentId || m.name}`);
       }
 
+    } else if (sub === "down") {
+      // #2002 — charter-driven team teardown: keep lead by default, done live workers.
+      if (!args[1]) {
+        logs.push("usage: maw team down <team> [--all] [--keep <a,b>] [--dry-run] [--status]");
+        return { ok: false, error: "team required", output: logs.join("\n") };
+      }
+      const { cmdTeamDown } = await import("./team-down");
+      const flags = parseFlags(args, {
+        "--all": Boolean,
+        "--keep": String,
+        "--dry-run": Boolean,
+        "--status": Boolean,
+      }, 2);
+      const keep = String(flags["--keep"] || "").split(",").map((s) => s.trim()).filter(Boolean);
+      await cmdTeamDown(args[1], {
+        all: Boolean(flags["--all"]),
+        keep,
+        dryRun: Boolean(flags["--dry-run"]),
+        status: Boolean(flags["--status"]),
+      });
+
     } else if (sub === "up") {
       // #1976 — charter-driven team wake: reconcile the charter against live
       // panes (skip live, resume dead in place, fresh-wake missing).
       if (!args[1]) {
-        logs.push("usage: maw team up <team> [--dry-run] [--status] [--force] [--gather] [-e <engine>]");
+        logs.push("usage: maw team up <team> [--only <a,b>] [--dry-run] [--status] [--force] [--gather] [-e <engine>]");
         return { ok: false, error: "team required", output: logs.join("\n") };
       }
       const { cmdTeamUp } = await import("./team-up");
@@ -362,6 +383,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         "--gather": Boolean,
         "--engine": String,
         "-e": "--engine",
+        "--only": String,
       }, 2);
       await cmdTeamUp(args[1], {
         dryRun: Boolean(flags["--dry-run"]),
@@ -369,11 +391,12 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         force: Boolean(flags["--force"]),
         gather: Boolean(flags["--gather"]),
         engine: flags["--engine"] as string | undefined,
+        only: String(flags["--only"] || "").split(",").map((s) => s.trim()).filter(Boolean),
       });
 
     } else {
       logs.push(`unknown team subcommand: ${sub}`);
-      logs.push("usage: maw team <create|plan|preflight|load|up|spawn-from|spawn|bring|send|shutdown|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members|enter>");
+      logs.push("usage: maw team <create|plan|preflight|load|up|down|spawn-from|spawn|bring|send|shutdown|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members|enter>");
       return { ok: false, error: `unknown subcommand: ${sub}`, output: logs.join("\n") };
     }
 

--- a/src/vendor/mpr-plugins/team/plugin.json
+++ b/src/vendor/mpr-plugins/team/plugin.json
@@ -3,14 +3,14 @@
   "version": "2.1.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "Agent reincarnation engine — create, up, bring, send, shutdown, resume, lives.",
+  "description": "Agent reincarnation engine — create, up, down, bring, send, shutdown, resume, lives.",
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "team",
     "aliases": [
       "t"
     ],
-    "help": "maw team <create|plan|preflight|load|up|spawn-from|spawn|bring|send|shutdown|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members|enter>"
+    "help": "maw team <create|plan|preflight|load|up|down|spawn-from|spawn|bring|send|shutdown|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members|enter>"
   },
   "weight": 30,
   "tier": "standard",

--- a/src/vendor/mpr-plugins/team/team-down.ts
+++ b/src/vendor/mpr-plugins/team/team-down.ts
@@ -1,0 +1,109 @@
+// Charter-driven team teardown (#2002). Runtime loads this vendored plugin copy.
+import { readTeamCharter, type TeamCharterMember } from "./team-charter";
+import { loadConfig } from "../../../config/load";
+import type { MawConfig } from "../../../config/types";
+import { Tmux } from "../../../core/transport/tmux";
+import {
+  classifyMember,
+  currentTmuxSession,
+  listPaneSnapshots,
+  memberMatchesSelector,
+  resolveCharterPath,
+  type ClassifiedTeamMember,
+} from "./team-liveness";
+
+export interface TeamDownOptions {
+  all?: boolean;
+  keep?: string[];
+  status?: boolean;
+  dryRun?: boolean;
+}
+
+export interface TeamDownAction {
+  role: string;
+  state: string;
+  action: string;
+  target?: string;
+}
+
+export interface TeamDownResult {
+  team: string;
+  session: string;
+  roster: ClassifiedTeamMember[];
+  actions: TeamDownAction[];
+  output: string;
+}
+
+export interface TeamDownDeps {
+  tmux?: Pick<Tmux, "run">;
+  cwd?: string;
+  charterPath?: string | null;
+  readTeamCharterFn?: typeof readTeamCharter;
+  loadConfigFn?: typeof loadConfig;
+  cmdDoneFn?: (windowName: string, opts?: { sessionName?: string; dryRun?: boolean; force?: boolean }) => Promise<void>;
+  logger?: (line: string) => void;
+}
+
+function isLead(member: TeamCharterMember): boolean {
+  return member.role === "lead" || member.worktree === false;
+}
+
+function renderRoster(team: string, session: string, roster: ClassifiedTeamMember[], actions: TeamDownAction[], tail?: string): string {
+  const actionByRole = new Map(actions.map((action) => [action.role, action]));
+  const lines = [`team down: ${team} (${session})`, "role\tengine\tstate\taction"];
+  for (const item of roster) {
+    const action = actionByRole.get(item.role)?.action ?? "skip";
+    lines.push(`${item.role}\t${item.engine}\t${item.state}\t${action}`);
+  }
+  if (tail) lines.push("", tail);
+  return lines.join("\n");
+}
+
+function keepReason(item: ClassifiedTeamMember, keep: string[], includeLead: boolean): string | null {
+  if (item.state === "skipped") return item.skipReason ?? "guard";
+  if (!includeLead && isLead(item.member)) return "lead";
+  if (keep.some((selector) => memberMatchesSelector(item.member, selector))) return "--keep";
+  return null;
+}
+
+export async function cmdTeamDown(team: string, opts: TeamDownOptions = {}, deps: TeamDownDeps = {}): Promise<TeamDownResult> {
+  const cwd = deps.cwd ?? process.cwd();
+  const charterPath = deps.charterPath !== undefined ? deps.charterPath : resolveCharterPath(team, cwd);
+  if (!charterPath) throw new Error(`charter not found: ${team}`);
+
+  const read = deps.readTeamCharterFn ?? readTeamCharter;
+  const charter = read(charterPath);
+  const tmux = deps.tmux ?? new Tmux();
+  const config: MawConfig = (deps.loadConfigFn ?? loadConfig)();
+  const currentSession = await currentTmuxSession(tmux).catch(() => "");
+  const session = charter.session ?? currentSession;
+  const panes = await listPaneSnapshots(tmux);
+  const roster = charter.members.map((member) => classifyMember(member, panes, session, { currentNode: config.node }));
+  const keep = opts.keep ?? [];
+  const actions: TeamDownAction[] = [];
+  let done = deps.cmdDoneFn;
+
+  for (const item of roster) {
+    const reason = keepReason(item, keep, Boolean(opts.all));
+    if (reason) {
+      actions.push({ role: item.role, state: item.state, action: `keep (${reason})` });
+      continue;
+    }
+    if (item.state !== "live") {
+      actions.push({ role: item.role, state: item.state, action: `skip ${item.state}` });
+      continue;
+    }
+    const target = item.pane?.windowName ?? item.windowIdentity;
+    if (opts.status || opts.dryRun) {
+      actions.push({ role: item.role, state: item.state, action: `would maw done ${target}`, target });
+      continue;
+    }
+    if (!done) done = (await import("../done/impl")).cmdDone;
+    await done(target, { sessionName: session });
+    actions.push({ role: item.role, state: item.state, action: `maw done ${target}`, target });
+  }
+
+  const output = renderRoster(team, session, roster, actions, opts.dryRun ? "No changes made" : undefined);
+  if (deps.logger) deps.logger(output); else console.log(output);
+  return { team, session, roster, actions, output };
+}

--- a/src/vendor/mpr-plugins/team/team-liveness.ts
+++ b/src/vendor/mpr-plugins/team/team-liveness.ts
@@ -32,7 +32,36 @@ export interface WakeMemberDeps {
   cmdWakeFn?: typeof cmdWake;
 }
 
+export interface ClassifyMemberOptions {
+  engine?: string;
+  currentNode?: string;
+  only?: Set<string>;
+}
+
 const SHELL_RE = /^-?(zsh|bash|sh|fish)$/i;
+
+export function memberWindowIdentity(member: TeamCharterMember): string {
+  return member.name?.trim() || member.role;
+}
+
+export function memberWorktree(member: TeamCharterMember): string {
+  const identity = memberWindowIdentity(member);
+  return typeof member.worktree === "string" && member.worktree.trim() ? member.worktree.trim() : identity;
+}
+
+export function memberEngine(member: TeamCharterMember, override?: string): string {
+  return override ?? member.engine ?? member.model ?? "claude";
+}
+
+export function memberMatchesSelector(member: TeamCharterMember, selector: string): boolean {
+  const wanted = selector.trim();
+  if (!wanted) return false;
+  return member.role === wanted || memberWindowIdentity(member) === wanted || memberWorktree(member) === wanted;
+}
+
+export function isOtherNodeMember(member: TeamCharterMember, currentNode?: string): boolean {
+  return Boolean(member.node && member.node !== currentNode);
+}
 
 function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -73,16 +102,24 @@ export function classifyMember(
   member: TeamCharterMember,
   panes: TeamPaneSnapshot[],
   session: string,
-  opts: { engine?: string } = {},
+  opts: ClassifyMemberOptions = {},
 ): ClassifiedTeamMember {
   const role = member.role;
-  const windowIdentity = member.name?.trim() || role;
+  const windowIdentity = memberWindowIdentity(member);
+  const engine = memberEngine(member, opts.engine);
+  const worktree = memberWorktree(member);
+
+  if (isOtherNodeMember(member, opts.currentNode)) {
+    return { member, role, engine, worktree, windowIdentity, state: "skipped", skipReason: `other node: ${member.node}` };
+  }
+  if (opts.only && ![member.role, windowIdentity, worktree].some((value) => opts.only!.has(value))) {
+    return { member, role, engine, worktree, windowIdentity, state: "skipped", skipReason: "outside --only" };
+  }
+
   const suffix = new RegExp(`-${escapeRegex(windowIdentity)}$`);
   const pane = panes.find((candidate) =>
     candidate.sessionName === session && (candidate.windowName === windowIdentity || suffix.test(candidate.windowName))
   );
-  const engine = opts.engine ?? member.engine ?? member.model ?? "claude";
-  const worktree = typeof member.worktree === "string" && member.worktree.trim() ? member.worktree.trim() : windowIdentity;
   if (!pane) return { member, role, engine, worktree, windowIdentity, state: "missing" };
   if (SHELL_RE.test(pane.command)) return { member, role, engine, worktree, windowIdentity, state: "dead", pane };
   if (isAgentCommand(pane.command)) return { member, role, engine, worktree, windowIdentity, state: "live", pane };
@@ -117,7 +154,7 @@ export async function wakeMember(
 ): Promise<string> {
   const wake = deps.cmdWakeFn ?? cmdWake;
   return wake(repoSlug, {
-    wt: typeof member.worktree === "string" && member.worktree.trim() ? member.worktree.trim() : (member.name?.trim() || member.role),
+    wt: memberWorktree(member),
     engine: opts.engine,
     session: opts.session,
     repoPath: opts.repoPath,

--- a/src/vendor/mpr-plugins/team/team-up.ts
+++ b/src/vendor/mpr-plugins/team/team-up.ts
@@ -25,6 +25,7 @@ export interface TeamUpOptions {
   status?: boolean;
   gather?: boolean;
   engine?: string;
+  only?: string[];
 }
 
 export interface TeamUpAction {
@@ -58,44 +59,6 @@ export interface TeamUpDeps {
 
 const DEFAULT_SLEEP = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 const SHELL_RE = /^-?(zsh|bash|sh|fish)$/i;
-
-function memberWindowIdentity(member: TeamCharter["members"][number]): string {
-  return member.name?.trim() || member.role;
-}
-
-function memberEngine(member: TeamCharter["members"][number], override?: string): string {
-  return override ?? member.engine ?? member.model ?? "claude";
-}
-
-function memberWorktree(member: TeamCharter["members"][number]): string {
-  const identity = memberWindowIdentity(member);
-  return typeof member.worktree === "string" && member.worktree.trim() ? member.worktree.trim() : identity;
-}
-
-function isOtherNodeMember(member: TeamCharter["members"][number], currentNode?: string): boolean {
-  return Boolean(member.node && member.node !== currentNode);
-}
-
-function classifyRosterMember(
-  member: TeamCharter["members"][number],
-  panes: Parameters<typeof classifyMember>[1],
-  session: string,
-  opts: { engine?: string; currentNode?: string } = {},
-): ClassifiedTeamMember {
-  if (isOtherNodeMember(member, opts.currentNode)) {
-    const role = member.role;
-    return {
-      member,
-      role,
-      engine: memberEngine(member, opts.engine),
-      worktree: memberWorktree(member),
-      windowIdentity: memberWindowIdentity(member),
-      state: "skipped",
-      skipReason: `other node: ${member.node}`,
-    };
-  }
-  return classifyMember(member, panes, session, { engine: opts.engine });
-}
 
 function renderRoster(team: string, session: string, roster: ClassifiedTeamMember[], actions: TeamUpAction[], warnings: string[], tail?: string): string {
   const actionByRole = new Map(actions.map((action) => [action.role, action]));
@@ -152,7 +115,8 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
   }
 
   const panes = await listPaneSnapshots(tmux);
-  const roster = charter.members.map((member) => classifyRosterMember(member, panes, session, { engine: opts.engine, currentNode: config.node }));
+  const only = opts.only?.length ? new Set(opts.only.map((item) => item.trim()).filter(Boolean)) : undefined;
+  const roster = charter.members.map((member) => classifyMember(member, panes, session, { engine: opts.engine, currentNode: config.node, only }));
   const actions: TeamUpAction[] = [];
 
   if (opts.status) {
@@ -217,7 +181,7 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
   }
 
   const finalPanes = await listPaneSnapshots(tmux).catch(() => panes);
-  const finalRoster = charter.members.map((member) => classifyRosterMember(member, finalPanes, session, { engine: opts.engine, currentNode: config.node }));
+  const finalRoster = charter.members.map((member) => classifyMember(member, finalPanes, session, { engine: opts.engine, currentNode: config.node, only }));
   warnOnPathCollisions(finalRoster, warnings);
 
   if (opts.gather) {

--- a/test/isolated/team-index-third-pass-coverage.test.ts
+++ b/test/isolated/team-index-third-pass-coverage.test.ts
@@ -148,7 +148,7 @@ describe("vendor team index third-pass coverage", () => {
   test("dispatches resume, lives, shutdown, status, and delete success paths", async () => {
     await teamHandler({ source: "cli", args: ["resume", "team-a", "--model", "gpt-x"] });
     await teamHandler({ source: "cli", args: ["history", "agent-a"] });
-    await teamHandler({ source: "cli", args: ["down", "team-a", "--force", "--merge"] });
+    await teamHandler({ source: "cli", args: ["shutdown", "team-a", "--force", "--merge"] });
     await teamHandler({ source: "cli", args: ["status", "team-a"] });
     await teamHandler({ source: "cli", args: ["delete", "team-a"] });
 

--- a/test/isolated/team-up-coverage.test.ts
+++ b/test/isolated/team-up-coverage.test.ts
@@ -10,6 +10,7 @@ import { tmpdir } from "os";
 import { parseTeamCharterText } from "../../src/vendor/mpr-plugins/team/team-charter";
 import { classifyMember, engineCommand } from "../../src/vendor/mpr-plugins/team/team-liveness";
 import { cmdTeamUp } from "../../src/vendor/mpr-plugins/team/team-up";
+import { cmdTeamDown } from "../../src/vendor/mpr-plugins/team/team-down";
 
 const dirs: string[] = [];
 afterEach(() => {
@@ -248,9 +249,134 @@ members:
     expect(wakes.map((w) => w[1].engine)).toEqual(["omx", "claude48", "codex"]);
   });
 
+
+  test("--only skips members outside the selected role/name/worktree set", async () => {
+    const root = tempRepo();
+    const { tmux } = fakeTmux([]);
+    const wakes: any[] = [];
+
+    const status = await cmdTeamUp("alpha", { status: true, only: ["coder-1"] }, {
+      cwd: root,
+      tmux,
+      loadConfigFn: () => config,
+      logger: () => {},
+    });
+    expect(status.roster.map((m) => [m.role, m.state, m.skipReason])).toEqual([
+      ["coder-1", "missing", undefined],
+      ["coder-10", "skipped", "outside --only"],
+      ["oracle", "skipped", "outside --only"],
+    ]);
+
+    await cmdTeamUp("alpha", { only: ["coder-1"] }, {
+      cwd: root,
+      tmux,
+      loadConfigFn: () => config,
+      cmdWakeFn: async (...a: any[]) => { wakes.push(a); return "woke"; },
+      sleep: async () => {},
+      logger: () => {},
+    });
+    expect(wakes.map((w) => w[1].wt)).toEqual(["coder-1"]);
+  });
+
   test("engine command resolves resume key only when requested", () => {
     expect(engineCommand("omx", {}, config)).toBe("maw run omx");
     expect(engineCommand("omx", { resume: true }, config)).toBe("maw run omx-resume");
+  });
+});
+
+describe("maw team down (#2002)", () => {
+  test("status keeps lead, plans maw done for live workers, and skips off-node members", async () => {
+    const root = tempRepo();
+    writeFileSync(join(root, ".maw", "teams", "down.yaml"), `
+name: down
+session: charter-session
+members:
+  - role: lead
+    name: mawjs-oracle
+    engine: claude
+    worktree: false
+  - role: implementer
+    name: codex
+    engine: omx
+    worktree: true
+  - role: reviewer
+    name: coder-1
+    engine: claude48
+    worktree: true
+  - role: bridge
+    name: oss-world
+    engine: claude
+    node: oracle-world
+    worktree: true
+`, "utf-8");
+    const { tmux } = fakeTmux([
+      "charter-session|mawjs-oracle|claude|/repo|%1",
+      "charter-session|mawjs-codex|codex|/wt/codex|%2",
+      "charter-session|mawjs-coder-1|claude|/wt/coder-1|%3",
+    ]);
+    const doneCalls: any[] = [];
+
+    const result = await cmdTeamDown("down", { status: true }, {
+      cwd: root,
+      tmux,
+      loadConfigFn: () => ({ ...config, node: "m5" }),
+      cmdDoneFn: async (...a: any[]) => { doneCalls.push(a); },
+      logger: () => {},
+    });
+
+    expect(result.actions.map((a) => [a.role, a.action, a.target])).toEqual([
+      ["lead", "keep (lead)", undefined],
+      ["implementer", "would maw done mawjs-codex", "mawjs-codex"],
+      ["reviewer", "would maw done mawjs-coder-1", "mawjs-coder-1"],
+      ["bridge", "keep (other node: oracle-world)", undefined],
+    ]);
+    expect(doneCalls).toHaveLength(0);
+  });
+
+  test("down executes done for selected live workers, supports --keep and --all", async () => {
+    const root = tempRepo();
+    writeFileSync(join(root, ".maw", "teams", "down.yaml"), `
+name: down
+session: charter-session
+members:
+  - role: lead
+    name: mawjs-oracle
+    engine: claude
+    worktree: false
+  - role: implementer
+    name: codex
+    engine: omx
+    worktree: true
+  - role: reviewer
+    name: coder-1
+    engine: claude48
+    worktree: true
+`, "utf-8");
+    const { tmux } = fakeTmux([
+      "charter-session|mawjs-oracle|claude|/repo|%1",
+      "charter-session|mawjs-codex|codex|/wt/codex|%2",
+      "charter-session|mawjs-coder-1|claude|/wt/coder-1|%3",
+    ]);
+    const doneCalls: any[] = [];
+
+    await cmdTeamDown("down", { keep: ["coder-1"] }, {
+      cwd: root,
+      tmux,
+      loadConfigFn: () => config,
+      cmdDoneFn: async (...a: any[]) => { doneCalls.push(a); },
+      logger: () => {},
+    });
+    expect(doneCalls).toEqual([["mawjs-codex", { sessionName: "charter-session" }]]);
+
+    doneCalls.length = 0;
+    await cmdTeamDown("down", { all: true }, {
+      cwd: root,
+      tmux,
+      loadConfigFn: () => config,
+      cmdDoneFn: async (...a: any[]) => { doneCalls.push(a); },
+      logger: () => {},
+    });
+    expect(doneCalls.map((c) => c[0])).toEqual(["mawjs-oracle", "mawjs-codex", "mawjs-coder-1"]);
   });
 });
 
@@ -269,6 +395,12 @@ describe("vendored team plugin routes `up` (#1976 integration)", () => {
 
   test("`team up` is a known subcommand", async () => {
     const { res } = await dispatch(["up"]);
+    expect(res.error).not.toContain("unknown subcommand");
+    expect(res.error).toBe("team required");
+  });
+
+  test("`team down` is a known subcommand", async () => {
+    const { res } = await dispatch(["down"]);
     expect(res.error).not.toContain("unknown subcommand");
     expect(res.error).toBe("team required");
   });


### PR DESCRIPTION
## Summary\n- add vendored `maw team down <team>` charter teardown (keep lead by default, --all, --keep, --status/--dry-run)\n- add `maw team up <team> --only <members>` selector before reconcile\n- move node guard / selector handling into shared vendored classifyMember path and update plugin help\n\n## Verification\n- `bun test test/isolated/team-up-coverage.test.ts --path-ignore-patterns '**/agents/**'`\n- `bun run build`\n- `MAW_TEST_MODE=1 bun run test:default:safe`\n- installed binary: `maw team down mawjs-dev --status`\n- installed binary: `maw team down mawjs-dev --dry-run --keep coder-1`\n- installed binary: `maw team up mawjs-dev --only codex --status`\n\nNot run destructively: real `maw team down mawjs-dev`, to avoid closing active implementer/reviewer panes before review.