### PR TITLE
fix: keep team lifecycle session-safe

### DIFF
--- a/.maw/teams/scratch-2005.yaml
+++ b/.maw/teams/scratch-2005.yaml
@@ -1,7 +1,0 @@
-name: scratch-2005
-session: scr-2005
-members:
-  - role: lead
-    name: scratch-2005-bot
-    engine: node
-    worktree: false

--- a/.maw/teams/scratch-2005.yaml
+++ b/.maw/teams/scratch-2005.yaml
@@ -1,0 +1,7 @@
+name: scratch-2005
+session: scr-2005
+members:
+  - role: lead
+    name: scratch-2005-bot
+    engine: node
+    worktree: false

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -861,13 +861,15 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
   }
 
   const foreignSession = requestedForeignSession;
-  let session = foreignSession || preResolvedSession || await detectSession(oracle, opts.urlRepoName);
+  let session = foreignSession ? "" : (preResolvedSession || await detectSession(oracle, opts.urlRepoName));
   if (foreignSession) {
     const exists = opts.dryRun || await tmux.hasSession(foreignSession);
-    if (!exists) {
-      throw new Error(`target session '${foreignSession}' not found — run: maw new ${foreignSession}`);
+    if (exists) {
+      session = foreignSession;
+      console.log(`\x1b[36m→\x1b[0m target workspace session: ${foreignSession}`);
+    } else {
+      console.log(`\x1b[36m→\x1b[0m target workspace session missing, creating: ${foreignSession}`);
     }
-    console.log(`\x1b[36m→\x1b[0m target workspace session: ${foreignSession}`);
   } else if (session) console.log(`\x1b[36m→\x1b[0m session exists: ${session}`);
   else console.log(`\x1b[36m→\x1b[0m no session found, creating...`);
 
@@ -891,12 +893,13 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
   });
 
   const mainWindowName = foreignSession ? oracle : `${oracle}-oracle`;
+  const shouldCreateSession = !session && (wakeDecision.wake || Boolean(foreignSession));
 
   if (opts.dryRun) {
     console.log(`\x1b[90mdry-run — no tmux sessions/windows will be changed\x1b[0m`);
     if (foreignSession) {
       console.log(`\x1b[32m+\x1b[0m would wake window '${mainWindowName}' in workspace session '${foreignSession}'`);
-    } else if (!session && wakeDecision.wake) {
+    } else if (shouldCreateSession) {
       const plannedSession = await chooseWakeSessionName(oracle, opts.urlRepoName);
       console.log(`\x1b[32m+\x1b[0m would create session '${plannedSession}' (main: ${mainWindowName})`);
     } else if (session) {
@@ -942,7 +945,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
   let knownWindows = new Set<string>();
   let knownWindowsReliable = true;
 
-  if (!session && wakeDecision.wake) {
+  if (shouldCreateSession) {
     // #2 — refuse to spawn a brand-new session/agent once the fleet is at the
     // configured concurrency cap (no-op when limits.maxConcurrentAgents is 0).
     await assertAgentCapacity(oracle);
@@ -950,7 +953,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
     // #769 — URL input names the new session after the full repo (e.g.
     // "m5-oracle") so it's distinct from any unrelated sub-token sessions
     // and immediately disambiguates future `maw wake` calls.
-    session = await chooseWakeSessionName(oracle, opts.urlRepoName);
+    session = foreignSession || await chooseWakeSessionName(oracle, opts.urlRepoName);
     await tmux.newSession(session, { window: mainWindowName, cwd: repoPath });
     await retryFreshSessionTmuxStep(session, "set session environment", () => setSessionEnv(session), {
       hasSession: tmux.hasSession,

--- a/src/vendor/mpr-plugins/team/index.ts
+++ b/src/vendor/mpr-plugins/team/index.ts
@@ -372,7 +372,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       // #1976 — charter-driven team wake: reconcile the charter against live
       // panes (skip live, resume dead in place, fresh-wake missing).
       if (!args[1]) {
-        logs.push("usage: maw team up <team> [--only <a,b>] [--dry-run] [--status] [--force] [--gather] [-e <engine>]");
+        logs.push("usage: maw team up <team> [--session <name>] [--only <a,b>] [--dry-run] [--status] [--force] [--gather] [-e <engine>]");
         return { ok: false, error: "team required", output: logs.join("\n") };
       }
       const { cmdTeamUp } = await import("./team-up");
@@ -384,6 +384,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         "--engine": String,
         "-e": "--engine",
         "--only": String,
+        "--session": String,
       }, 2);
       await cmdTeamUp(args[1], {
         dryRun: Boolean(flags["--dry-run"]),
@@ -392,6 +393,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         gather: Boolean(flags["--gather"]),
         engine: flags["--engine"] as string | undefined,
         only: String(flags["--only"] || "").split(",").map((s) => s.trim()).filter(Boolean),
+        session: flags["--session"] as string | undefined,
       });
 
     } else {

--- a/src/vendor/mpr-plugins/team/team-down.ts
+++ b/src/vendor/mpr-plugins/team/team-down.ts
@@ -12,6 +12,8 @@ import {
   type ClassifiedTeamMember,
 } from "./team-liveness";
 
+export const TEAM_LIFECYCLE_GUARD_WINDOW = "maw-team-lifecycle-guard";
+
 export interface TeamDownOptions {
   all?: boolean;
   keep?: string[];
@@ -82,6 +84,23 @@ export async function cmdTeamDown(team: string, opts: TeamDownOptions = {}, deps
   const keep = opts.keep ?? [];
   const actions: TeamDownAction[] = [];
   let done = deps.cmdDoneFn;
+
+  const killableLive = roster.filter((item) => {
+    const reason = keepReason(item, keep, Boolean(opts.all));
+    return !reason && item.state === "live";
+  });
+  const sessionWindows = new Set(
+    panes
+      .filter((pane) => pane.sessionName === session)
+      .map((pane) => pane.windowName)
+      .filter((name) => name !== TEAM_LIFECYCLE_GUARD_WINDOW),
+  );
+  const killWindows = new Set(killableLive.map((item) => item.pane?.windowName ?? item.windowIdentity));
+  const wouldKillLastTeamWindow = sessionWindows.size > 0 && [...sessionWindows].every((window) => killWindows.has(window));
+  if (!opts.status && !opts.dryRun && wouldKillLastTeamWindow) {
+    await tmux.run("new-window", "-d", "-t", `${session}:`, "-n", TEAM_LIFECYCLE_GUARD_WINDOW);
+    actions.push({ role: "session", state: "guard", action: `created ${TEAM_LIFECYCLE_GUARD_WINDOW}` });
+  }
 
   for (const item of roster) {
     const reason = keepReason(item, keep, Boolean(opts.all));

--- a/src/vendor/mpr-plugins/team/team-liveness.ts
+++ b/src/vendor/mpr-plugins/team/team-liveness.ts
@@ -17,6 +17,11 @@ export interface TeamPaneSnapshot {
   paneId: string;
 }
 
+export interface TeamSessionSnapshot {
+  name: string;
+  windows: string[];
+}
+
 export interface ClassifiedTeamMember {
   member: TeamCharterMember;
   role: string;
@@ -36,9 +41,30 @@ export interface ClassifyMemberOptions {
   engine?: string;
   currentNode?: string;
   only?: Set<string>;
+  repoSlug?: string;
 }
 
 const SHELL_RE = /^-?(zsh|bash|sh|fish)$/i;
+
+export function oracleStemFromRepoSlug(repoSlug: string): string {
+  return (repoSlug.split("/").pop() || repoSlug).replace(/-oracle$/i, "");
+}
+
+export function memberWakeTarget(repoSlug: string, member: TeamCharterMember): string {
+  if (member.worktree === false) return member.name?.trim() || oracleStemFromRepoSlug(repoSlug);
+  return repoSlug;
+}
+
+export function memberWakeOptions(member: TeamCharterMember, opts: WakeOptions & { engine: string; session: string; repoPath: string }): WakeOptions {
+  const base: WakeOptions = {
+    engine: opts.engine,
+    session: opts.session,
+    repoPath: opts.repoPath,
+    ...(member.channels === true ? { channels: true } : {}),
+  };
+  if (member.worktree === false) return base;
+  return { ...base, wt: memberWorktree(member) };
+}
 
 export function memberWindowIdentity(member: TeamCharterMember): string {
   return member.name?.trim() || member.role;
@@ -98,6 +124,29 @@ export async function currentTmuxSession(tmux: Pick<Tmux, "run"> = new Tmux()): 
   return (await tmux.run("display-message", "-p", "#S")).trim();
 }
 
+export async function listSessionSnapshots(tmux: Pick<Tmux, "run"> = new Tmux()): Promise<TeamSessionSnapshot[]> {
+  const raw = await tmux.run("list-windows", "-a", "-F", "#{session_name}|#{window_name}");
+  const sessions = new Map<string, string[]>();
+  for (const line of raw.split(/\r?\n/).map((l) => l.trim()).filter(Boolean)) {
+    const [name = "", window = ""] = line.split("|");
+    if (!name) continue;
+    const windows = sessions.get(name) ?? [];
+    if (window) windows.push(window);
+    sessions.set(name, windows);
+  }
+  return [...sessions.entries()].map(([name, windows]) => ({ name, windows }));
+}
+
+export function memberWindowCandidates(member: TeamCharterMember, repoSlug = ""): string[] {
+  const identity = memberWindowIdentity(member);
+  const candidates = [identity];
+  if (member.worktree === false) {
+    const stem = oracleStemFromRepoSlug(repoSlug || identity);
+    candidates.push(stem, `${stem}-oracle`, identity.replace(/-oracle$/i, ""));
+  }
+  return [...new Set(candidates.filter(Boolean))];
+}
+
 export function classifyMember(
   member: TeamCharterMember,
   panes: TeamPaneSnapshot[],
@@ -116,9 +165,10 @@ export function classifyMember(
     return { member, role, engine, worktree, windowIdentity, state: "skipped", skipReason: "outside --only" };
   }
 
-  const suffix = new RegExp(`-${escapeRegex(windowIdentity)}$`);
+  const candidates = memberWindowCandidates(member, opts.repoSlug);
+  const suffixes = candidates.map((candidate) => new RegExp(`-${escapeRegex(candidate)}$`));
   const pane = panes.find((candidate) =>
-    candidate.sessionName === session && (candidate.windowName === windowIdentity || suffix.test(candidate.windowName))
+    candidate.sessionName === session && (candidates.includes(candidate.windowName) || suffixes.some((suffix) => suffix.test(candidate.windowName)))
   );
   if (!pane) return { member, role, engine, worktree, windowIdentity, state: "missing" };
   if (SHELL_RE.test(pane.command)) return { member, role, engine, worktree, windowIdentity, state: "dead", pane };
@@ -153,11 +203,5 @@ export async function wakeMember(
   deps: WakeMemberDeps = {},
 ): Promise<string> {
   const wake = deps.cmdWakeFn ?? cmdWake;
-  return wake(repoSlug, {
-    wt: memberWorktree(member),
-    engine: opts.engine,
-    session: opts.session,
-    repoPath: opts.repoPath,
-    ...(member.channels === true ? { channels: true } : {}),
-  });
+  return wake(memberWakeTarget(repoSlug, member), memberWakeOptions(member, opts));
 }

--- a/src/vendor/mpr-plugins/team/team-up.ts
+++ b/src/vendor/mpr-plugins/team/team-up.ts
@@ -7,6 +7,7 @@ import { loadConfig } from "../../../config/load";
 import type { MawConfig } from "../../../config/types";
 import { Tmux } from "../../../core/transport/tmux";
 import { cmdWake } from "../../../commands/shared/wake-cmd";
+import { TEAM_LIFECYCLE_GUARD_WINDOW } from "./team-down";
 import {
   classifyMember,
   currentTmuxSession,
@@ -15,6 +16,7 @@ import {
   listPaneSnapshots,
   repoSlugFromRoot,
   resolveCharterPath,
+  memberWakeTarget,
   wakeMember,
   type ClassifiedTeamMember,
 } from "./team-liveness";
@@ -26,6 +28,7 @@ export interface TeamUpOptions {
   gather?: boolean;
   engine?: string;
   only?: string[];
+  session?: string;
 }
 
 export interface TeamUpAction {
@@ -73,14 +76,15 @@ function renderRoster(team: string, session: string, roster: ClassifiedTeamMembe
 }
 
 async function waitForNonShell(
-  role: string,
+  member: TeamCharter["members"][number],
   session: string,
   tmux: Pick<Tmux, "run">,
   sleep: (ms: number) => Promise<void>,
+  repoSlug: string,
 ): Promise<void> {
   for (let i = 0; i < 10; i++) {
     const panes = await listPaneSnapshots(tmux);
-    const current = classifyMember({ role }, panes, session);
+    const current = classifyMember(member, panes, session, { repoSlug });
     if (current.pane && !SHELL_RE.test(current.pane.command)) return;
     await sleep(1000);
   }
@@ -96,6 +100,20 @@ function warnOnPathCollisions(roster: ClassifiedTeamMember[], warnings: string[]
   }
 }
 
+function wakePlan(item: ClassifiedTeamMember, repoSlug: string, session: string): string {
+  if (item.member.worktree === false) {
+    return `wakeable ${memberWakeTarget(repoSlug, item.member)} -e ${item.engine} --session ${session}${item.member.channels ? " --channels" : ""}`;
+  }
+  return `wakeable --wt ${item.worktree} -e ${item.engine} --session ${session}${item.member.channels ? " --channels" : ""}`;
+}
+
+function freshWakePlan(item: ClassifiedTeamMember, repoSlug: string, session: string, prefix = "would fresh wake"): string {
+  if (item.member.worktree === false) {
+    return `${prefix} ${memberWakeTarget(repoSlug, item.member)} -e ${item.engine} --session ${session}${item.member.channels ? " --channels" : ""}`;
+  }
+  return `${prefix} --wt ${item.worktree} -e ${item.engine} --session ${session}${item.member.channels ? " --channels" : ""}`;
+}
+
 export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: TeamUpDeps = {}): Promise<TeamUpResult> {
   const cwd = deps.cwd ?? process.cwd();
   const charterPath = deps.charterPath !== undefined ? deps.charterPath : resolveCharterPath(team, cwd);
@@ -108,21 +126,24 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
   const repoRoot = deps.repoRoot ?? findRepoRoot(cwd);
   const repoSlug = deps.repoSlug ?? repoSlugFromRoot(repoRoot);
   const currentSession = await currentTmuxSession(tmux).catch(() => "");
-  const session = charter.session ?? currentSession;
+  const session = opts.session?.trim() || charter.session || currentSession;
+  if (!session) throw new Error(`session required: pass --session <name> when running team up outside tmux and charter.session is omitted`);
   const warnings: string[] = [];
-  if (charter.session && currentSession && charter.session !== currentSession) {
+  if (opts.session && currentSession && opts.session !== currentSession) {
+    warnings.push(`current tmux session '${currentSession}' differs from --session '${opts.session}'; targeting explicit session`);
+  } else if (charter.session && currentSession && charter.session !== currentSession) {
     warnings.push(`current tmux session '${currentSession}' differs from charter.session '${charter.session}'; targeting charter session`);
   }
 
   const panes = await listPaneSnapshots(tmux);
   const only = opts.only?.length ? new Set(opts.only.map((item) => item.trim()).filter(Boolean)) : undefined;
-  const roster = charter.members.map((member) => classifyMember(member, panes, session, { engine: opts.engine, currentNode: config.node, only }));
+  const roster = charter.members.map((member) => classifyMember(member, panes, session, { engine: opts.engine, currentNode: config.node, only, repoSlug }));
   const actions: TeamUpAction[] = [];
 
   if (opts.status) {
     for (const item of roster) {
       if (item.state === "skipped") actions.push({ role: item.role, state: item.state, action: `skip (${item.skipReason ?? "guard"})` });
-      else if (item.state === "missing") actions.push({ role: item.role, state: item.state, action: `wakeable --wt ${item.worktree} -e ${item.engine} --session ${session}${item.member.channels ? " --channels" : ""}` });
+      else if (item.state === "missing") actions.push({ role: item.role, state: item.state, action: wakePlan(item, repoSlug, session) });
       else if (item.state === "dead") actions.push({ role: item.role, state: item.state, action: "wakeable resume in place" });
       else actions.push({ role: item.role, state: item.state, action: "skip live" });
     }
@@ -138,7 +159,7 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
         actions.push({ role: item.role, state: item.state, action: `skip (${item.skipReason ?? "guard"})` });
       } else if (opts.force) {
         const command = engineCommand(item.engine, { resume: false }, config);
-        actions.push({ role: item.role, state: item.state, action: `would force fresh wake --wt ${item.worktree} -e ${item.engine} --session ${session}${item.member.channels ? " --channels" : ""}`, command });
+        actions.push({ role: item.role, state: item.state, action: freshWakePlan(item, repoSlug, session, "would force fresh wake"), command });
       } else if (item.state === "live") {
         actions.push({ role: item.role, state: item.state, action: "skip live" });
       } else if (item.state === "dead") {
@@ -146,7 +167,7 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
         actions.push({ role: item.role, state: item.state, action: "would relaunch in place with resume", command });
       } else {
         const command = engineCommand(item.engine, { resume: false }, config);
-        actions.push({ role: item.role, state: item.state, action: `would fresh wake --wt ${item.worktree} -e ${item.engine} --session ${session}${item.member.channels ? " --channels" : ""}`, command });
+        actions.push({ role: item.role, state: item.state, action: freshWakePlan(item, repoSlug, session), command });
       }
     }
     warnOnPathCollisions(roster, warnings);
@@ -164,24 +185,24 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
       const command = engineCommand(item.engine, { resume: false }, config);
       await wakeMember(repoSlug, item.member, { engine: item.engine, session, repoPath: repoRoot }, { cmdWakeFn: deps.cmdWakeFn });
       actions.push({ role: item.role, state: item.state, action: "force fresh wake", command });
-      await waitForNonShell(item.role, session, tmux, sleep);
+      await waitForNonShell(item.member, session, tmux, sleep, repoSlug);
     } else if (item.state === "live") {
       actions.push({ role: item.role, state: item.state, action: "skip live" });
     } else if (item.state === "dead") {
       const command = engineCommand(item.engine, { resume: true }, config);
       await tmux.run("send-keys", "-t", item.pane!.paneId, command, "Enter");
       actions.push({ role: item.role, state: item.state, action: "resume in place", command });
-      await waitForNonShell(item.role, session, tmux, sleep);
+      await waitForNonShell(item.member, session, tmux, sleep, repoSlug);
     } else {
       const command = engineCommand(item.engine, { resume: false }, config);
       await wakeMember(repoSlug, item.member, { engine: item.engine, session, repoPath: repoRoot }, { cmdWakeFn: deps.cmdWakeFn });
       actions.push({ role: item.role, state: item.state, action: "fresh wake", command });
-      await waitForNonShell(item.role, session, tmux, sleep);
+      await waitForNonShell(item.member, session, tmux, sleep, repoSlug);
     }
   }
 
   const finalPanes = await listPaneSnapshots(tmux).catch(() => panes);
-  const finalRoster = charter.members.map((member) => classifyMember(member, finalPanes, session, { engine: opts.engine, currentNode: config.node, only }));
+  const finalRoster = charter.members.map((member) => classifyMember(member, finalPanes, session, { engine: opts.engine, currentNode: config.node, only, repoSlug }));
   warnOnPathCollisions(finalRoster, warnings);
 
   if (opts.gather) {
@@ -190,6 +211,10 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
     }
     await tmux.run("select-layout", "main-vertical");
     actions.push({ role: "*", state: "live", action: "gather main-vertical" });
+  }
+
+  if (!opts.status && !opts.dryRun && finalRoster.some((item) => item.state === "live")) {
+    await tmux.run("kill-window", "-t", `${session}:${TEAM_LIFECYCLE_GUARD_WINDOW}`).catch(() => undefined);
   }
 
   const output = renderRoster(team, session, finalRoster, actions, warnings);

--- a/test/isolated/team-up-coverage.test.ts
+++ b/test/isolated/team-up-coverage.test.ts
@@ -8,9 +8,9 @@ import { tmpdir } from "os";
 // (core), which is tested but NOT dispatched, so `maw team up` was unreachable
 // despite green tests. Guard the copy that actually ships.
 import { parseTeamCharterText } from "../../src/vendor/mpr-plugins/team/team-charter";
-import { classifyMember, engineCommand } from "../../src/vendor/mpr-plugins/team/team-liveness";
+import { classifyMember, engineCommand, memberWakeOptions, memberWakeTarget } from "../../src/vendor/mpr-plugins/team/team-liveness";
 import { cmdTeamUp } from "../../src/vendor/mpr-plugins/team/team-up";
-import { cmdTeamDown } from "../../src/vendor/mpr-plugins/team/team-down";
+import { cmdTeamDown, TEAM_LIFECYCLE_GUARD_WINDOW } from "../../src/vendor/mpr-plugins/team/team-down";
 
 const dirs: string[] = [];
 afterEach(() => {
@@ -126,7 +126,7 @@ members:
       logger: () => {},
     });
     expect(wakes.map((w) => w[1].wt)).toEqual(["mawjs-oracle"]);
-    expect(calls.filter((c) => c[0] === "kill-window")).toHaveLength(1);
+    expect(calls.filter((c) => c[0] === "kill-window" && !c.join(" ").includes(TEAM_LIFECYCLE_GUARD_WINDOW))).toHaveLength(1);
   });
 
   test("same-node channels member is wakeable with --channels and fresh wake passes channels", async () => {
@@ -244,7 +244,7 @@ members:
     ]);
     const wakes: any[] = [];
     await cmdTeamUp("alpha", { force: true }, { cwd: root, tmux, loadConfigFn: () => config, cmdWakeFn: async (...a: any[]) => { wakes.push(a); return "woke"; }, sleep: async () => {}, logger: () => {} });
-    expect(calls.filter((c) => c[0] === "kill-window")).toHaveLength(3);
+    expect(calls.filter((c) => c[0] === "kill-window" && !c.join(" ").includes(TEAM_LIFECYCLE_GUARD_WINDOW))).toHaveLength(3);
     expect(calls.some((c) => c.includes("omx-resume") || c.includes("claude48-resume") || c.includes("codex-resume"))).toBe(false);
     expect(wakes.map((w) => w[1].engine)).toEqual(["omx", "claude48", "codex"]);
   });
@@ -276,6 +276,41 @@ members:
       logger: () => {},
     });
     expect(wakes.map((w) => w[1].wt)).toEqual(["coder-1"]);
+  });
+
+
+  test("worktree:false lead adopts base oracle window and fresh wake avoids --wt double-prefix", async () => {
+    const root = tempRepo();
+    writeFileSync(join(root, ".maw", "teams", "lead.yaml"), `
+name: lead
+session: charter-session
+members:
+  - role: lead
+    name: mawjs-oracle
+    engine: claude
+    worktree: false
+`, "utf-8");
+
+    const live = fakeTmux(["charter-session|mawjs|claude|/repo|%1"]);
+    const adopted = await cmdTeamUp("lead", { status: true }, { cwd: root, tmux: live.tmux, repoSlug: "Soul-Brews-Studio/mawjs-oracle", loadConfigFn: () => config, logger: () => {} });
+    expect(adopted.roster.map((m) => [m.role, m.windowIdentity, m.state, m.pane?.windowName])).toEqual([["lead", "mawjs-oracle", "live", "mawjs"]]);
+
+    const missing = fakeTmux([]);
+    const status = await cmdTeamUp("lead", { status: true }, { cwd: root, tmux: missing.tmux, repoSlug: "Soul-Brews-Studio/mawjs-oracle", loadConfigFn: () => config, logger: () => {} });
+    expect(status.output).toContain("lead\tclaude\tmissing\twakeable mawjs-oracle -e claude --session charter-session");
+    expect(status.output).not.toContain("--wt mawjs-oracle");
+
+    expect(memberWakeTarget("Soul-Brews-Studio/mawjs-oracle", status.roster[0].member)).toBe("mawjs-oracle");
+    expect(memberWakeOptions(status.roster[0].member, { engine: "claude", session: "charter-session", repoPath: root })).toEqual({ engine: "claude", session: "charter-session", repoPath: root });
+  });
+
+  test("--session overrides current tmux session for headless/ssh-safe targeting", async () => {
+    const root = tempRepo();
+    const { tmux } = fakeTmux([]);
+    const result = await cmdTeamUp("alpha", { status: true, session: "01-mawjs" }, { cwd: root, tmux, loadConfigFn: () => config, logger: () => {} });
+    expect(result.session).toBe("01-mawjs");
+    expect(result.output).toContain("team up: alpha (01-mawjs)");
+    expect(result.warnings).toContain("current tmux session 'lead-session' differs from --session '01-mawjs'; targeting explicit session");
   });
 
   test("engine command resolves resume key only when requested", () => {
@@ -352,7 +387,7 @@ members:
     engine: claude48
     worktree: true
 `, "utf-8");
-    const { tmux } = fakeTmux([
+    const { tmux, calls } = fakeTmux([
       "charter-session|mawjs-oracle|claude|/repo|%1",
       "charter-session|mawjs-codex|codex|/wt/codex|%2",
       "charter-session|mawjs-coder-1|claude|/wt/coder-1|%3",
@@ -377,6 +412,7 @@ members:
       logger: () => {},
     });
     expect(doneCalls.map((c) => c[0])).toEqual(["mawjs-oracle", "mawjs-codex", "mawjs-coder-1"]);
+    expect(calls).toContainEqual(["new-window", "-d", "-t", "charter-session:", "-n", TEAM_LIFECYCLE_GUARD_WINDOW]);
   });
 });
 

--- a/test/isolated/wake-cmd-branch-coverage.test.ts
+++ b/test/isolated/wake-cmd-branch-coverage.test.ts
@@ -284,13 +284,16 @@ describe("wake-cmd isolated executable branch coverage", () => {
     expect(sendTextCalls).toEqual([]);
   });
 
-  test("rejects missing foreign workspace sessions", async () => {
+  test("creates missing foreign workspace sessions", async () => {
     hasSessions = new Set();
 
-    await expect(cmdWake("mawjs", { session: "project", noRehydrate: true })).rejects.toThrow("target session 'project' not found");
+    const result = await cmdWake("mawjs", { session: "project", noRehydrate: true });
 
+    expect(result).toBe("project:mawjs");
+    expect(sessions).toContainEqual({ name: "project" });
+    expect(windowsBySession.project).toEqual([{ name: "mawjs", cwd: repoPath }]);
     expect(newWindowCalls).toEqual([]);
-    expect(sendTextCalls).toEqual([]);
+    expect(sendTextCalls).toEqual([{ target: "project:mawjs", text: expect.stringContaining("--agent mawjs") }]);
   });
 
   test("rejects unavailable and non-matching requested snapshots", async () => {

--- a/test/isolated/wake-cmd-extra-coverage.test.ts
+++ b/test/isolated/wake-cmd-extra-coverage.test.ts
@@ -24,6 +24,7 @@ let setEnvCalls: string[] = [];
 let ensureSessionRunningCalls: string[] = [];
 let maybeSplitCalls: string[] = [];
 let maybeOpenWindowCalls: string[] = [];
+let newSessionCalls: Array<{ session: string; opts: any }> = [];
 
 function resetState(): void {
   parentDir = "/tmp/ghq/github.com/Soul-Brews-Studio";
@@ -47,6 +48,7 @@ function resetState(): void {
   ensureSessionRunningCalls = [];
   maybeSplitCalls = [];
   maybeOpenWindowCalls = [];
+  newSessionCalls = [];
 }
 
 async function captureLogs<T>(fn: () => Promise<T>): Promise<T> {
@@ -78,7 +80,9 @@ mock.module(import.meta.resolve("../../src/sdk"), () => ({
       if (listWindowsThrows) throw new Error("tmux list failed");
       return listWindowsReturn;
     },
-    newSession: async () => {},
+    newSession: async (session: string, opts: any) => {
+      newSessionCalls.push({ session, opts });
+    },
     newWindow: async () => {},
     sendText: async (target: string, text: string) => {
       sentText.push({ target, text });
@@ -229,11 +233,13 @@ describe("wake-cmd extra isolated coverage", () => {
     ).rejects.toThrow("could not list windows for session '54-neo'");
   });
 
-  test("errors when a requested foreign workspace session is missing", async () => {
+  test("creates a requested foreign workspace session when missing", async () => {
     hasSessionReturn = false;
 
-    await expect(captureLogs(() => cmdWake("neo", { repoPath, session: "project-dev" }))).rejects.toThrow(
-      "target session 'project-dev' not found",
-    );
+    const result = await captureLogs(() => cmdWake("neo", { repoPath, session: "project-dev", noRehydrate: true }));
+
+    expect(result).toBe("project-dev:neo");
+    expect(newSessionCalls).toEqual([{ session: "project-dev", opts: { window: "neo", cwd: repoPath } }]);
+    expect(logs.join("\n")).toContain("target workspace session missing, creating: project-dev");
   });
 });

--- a/test/isolated/wake-cmd-thirteenth-pass-coverage.test.ts
+++ b/test/isolated/wake-cmd-thirteenth-pass-coverage.test.ts
@@ -479,8 +479,10 @@ describe("wake-cmd thirteenth-pass isolated coverage", () => {
       .rejects.toThrow("invalid target session 'bad/session'");
 
     hasSessionReturn = false;
-    await expect(captureLogs(() => cmdWake("neo", { repoPath, session: "missing" })))
-      .rejects.toThrow("target session 'missing' not found");
+    const created = await captureLogs(() => cmdWake("neo", { repoPath, session: "missing", noRehydrate: true }));
+    expect(created).toBe("missing:neo");
+    expect(newSessions).toContainEqual({ session: "missing", opts: { window: "neo", cwd: repoPath } });
+    expect(plain()).toContain("target workspace session missing, creating: missing");
   });
 
   test("dry-run snapshot planning reports empty and concrete restore windows", async () => {

--- a/test/isolated/wake-list-readonly.test.ts
+++ b/test/isolated/wake-list-readonly.test.ts
@@ -9,7 +9,7 @@ describe("wake --list readonly preview (#1563)", () => {
     const cmdWakeIdx = wakeCmdSrc.indexOf("export async function cmdWake");
     const cmdWakeSrc = wakeCmdSrc.slice(cmdWakeIdx);
     const listIdx = cmdWakeSrc.indexOf("if (opts.listWt)");
-    const detectIdx = cmdWakeSrc.indexOf("let session = foreignSession || preResolvedSession");
+    const detectIdx = cmdWakeSrc.indexOf("let session = foreignSession ?");
     const setEnvIdx = cmdWakeSrc.indexOf("await setSessionEnv(session)");
     const newSessionIdx = cmdWakeSrc.indexOf("await tmux.newSession");
     const newWindowIdx = cmdWakeSrc.indexOf("await tmux.newWindow(session");

--- a/test/wake-cmd-cmdwake-coverage.test.ts
+++ b/test/wake-cmd-cmdwake-coverage.test.ts
@@ -1219,10 +1219,18 @@ describe("cmdWake main-suite coverage", () => {
     await expect(captureLogs(() => cmdWake("mawjs", { bud: true }))).rejects.toThrow("--bud requires --task <slug> or --wt <slug>");
     await expect(captureLogs(() => cmdWake("mawjs", { signalOnBirth: true }))).rejects.toThrow("--signal-on-birth requires --bud");
     await expect(captureLogs(() => cmdWake("mawjs", { session: "bad/session" }))).rejects.toThrow("invalid target session 'bad/session'");
+    expect(newSessionCalls).toEqual([]);
+    expect(newWindowCalls).toEqual([]);
+  });
+
+  test("creates missing explicit workspace sessions for lifecycle reconcile", async () => {
     sessions = [];
     hasSessions = new Set();
-    await expect(captureLogs(() => cmdWake("mawjs", { session: "project" }))).rejects.toThrow("target session 'project' not found");
-    expect(newSessionCalls).toEqual([]);
+    const { result, logs } = await captureLogs(() => cmdWake("mawjs", { session: "project", noRehydrate: true }));
+
+    expect(result).toBe("project:mawjs");
+    expect(logs.join("\n")).toContain("target workspace session missing, creating: project");
+    expect(newSessionCalls).toEqual([{ name: "project", opts: { window: "mawjs", cwd: repoPath } }]);
     expect(newWindowCalls).toEqual([]);
   });
 
@@ -1343,6 +1351,41 @@ describe("cmdWake main-suite coverage", () => {
       text: `cd ${repoPath} && codex --agent mawjs-oracle`,
     });
     expect(attachCalls).toEqual(["63-mawjs"]);
+  });
+
+  test("#2005 --session into a MISSING workspace session creates it (no adhoc 'maw new')", async () => {
+    // Regression for the team down --all → up cycle: a destroyed target session
+    // must be re-created by wake, not error with "run: maw new <session>".
+    shouldWakeDecision = { wake: true, reason: "missing" };
+    hasSessions = new Set(["54-mawjs"]); // target "01-mawjs" absent
+    newSessionVisibleToHasSession = true;
+    windowsBySession = {};
+
+    const { result, logs } = await captureLogs(() =>
+      cmdWake("mawjs", { session: "01-mawjs", engine: "codex", noRehydrate: true }),
+    );
+
+    expect(result).toBe("01-mawjs:mawjs");
+    expect(newSessionCalls).toEqual([
+      { name: "01-mawjs", opts: { window: "mawjs", cwd: repoPath } },
+    ]);
+    const rendered = logs.join("\n");
+    expect(rendered).toContain("target workspace session missing, creating: 01-mawjs");
+    expect(rendered).not.toContain("maw new");
+  });
+
+  test("#2005 --session into an EXISTING workspace session reuses it (no newSession)", async () => {
+    shouldWakeDecision = { wake: true, reason: "missing" };
+    hasSessions = new Set(["54-mawjs", "01-mawjs"]); // target already present
+    windowsBySession = { "01-mawjs": [] };
+
+    const { result, logs } = await captureLogs(() =>
+      cmdWake("mawjs", { session: "01-mawjs", engine: "codex", noRehydrate: true }),
+    );
+
+    expect(result).toBe("01-mawjs:mawjs");
+    expect(newSessionCalls).toEqual([]); // reused, not recreated
+    expect(logs.join("\n")).toContain("target workspace session: 01-mawjs");
   });
 
   test("restores requested snapshot windows, rehydrates missing worktrees, and relaunches a dead existing agent", async () => {


### PR DESCRIPTION
## Summary\n- add explicit `maw team up --session` targeting for headless/SSH-safe reconciliation\n- let `maw wake --session <missing>` create the target workspace session instead of requiring manual `maw new`\n- keep worktree:false leads out of `--wt`, align lead adoption/wake identity, and guard tmux sessions during `team down --all`\n\n## Tests\n- `bun test test/isolated/team-up-coverage.test.ts --path-ignore-patterns '**/agents/**'`\n- targeted wake-cmd coverage files\n- `bun run build`\n- `bun run test:default:safe`\n- installed binary: `maw team up mawjs-dev --session 77-mawjs --status`\n- installed binary: `maw team up mawjs-dev --session zz-2005-missing --status`\n\n## Note\n- `bun run test:isolated` was run; all changed/related files passed, but the full sweep still has an unrelated workspace-store environment leak in `test/isolated/coverage-100b-shared-helpers.test.ts`.