### PR TITLE
fix(federation): cross-node hey no longer hard-fails on wake error (#1998)

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../../../.claude/skills

--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -632,17 +632,26 @@ export async function cmdSend(
         }
       } catch { /* fleet/wake best-effort — fall through to existing error path */ }
     } else if (targetNode && bareAgent && !isCanonical) {
-      // #791: cross-node auto-wake. Sender does explicit /api/wake before
+      // #791: cross-node auto-wake. Sender does a best-effort /api/wake before
       // /api/send (Option B). Wake is idempotent on the receiver — if the
-      // session already exists, cmdWake returns quickly. If wake errors,
-      // surface and exit (do NOT silently fall through to send — design
-      // call requires wake errors to be visible).
+      // session already exists, cmdWake returns quickly.
       //
       // #835 — decision routed through shouldAutoWake(). For cross-node hey
       // we don't know the remote isLive locally; the receiver's /api/wake
       // is idempotent, so we always ask. shouldAutoWake gives us
       // wake=true on hey + !isLive + isFleetKnown=true. We model the
       // cross-node target as fleet-known (peer is configured) and not-live.
+      //
+      // #1998 — wake failure is NON-FATAL. The original #791 design hard-exited
+      // on any wake error to keep failures visible. But that wrongly blocks
+      // delivery to targets that are already live yet NOT a wakeable oracle
+      // (a window / worktree-pane / non-repo alias, e.g. `mawjs-oss-world`):
+      // the remote /api/wake can't resolve the bare name to a repo and returns
+      // "missing oracle name", even though `maw peek` on the same target works.
+      // Since the send path below (POST /api/send) uses the receiver's lenient
+      // capture-by-pane resolution — the same path peek uses — we now warn and
+      // fall through. If the target is genuinely unreachable, the send attempt
+      // surfaces its own clear "Remote fetch failed" error (#411 contract).
       const peer = (config.namedPeers || []).find(p => p.name === targetNode);
       if (peer) {
         const { shouldAutoWake } = await import("./should-auto-wake");
@@ -660,11 +669,10 @@ export async function cmdSend(
           });
           if (!wakeRes.ok || !wakeRes.data?.ok) {
             const underlying = wakeRes.data?.error || (wakeRes.status ? `HTTP ${wakeRes.status}` : "connection failed");
-            // #942 — surface as "Remote fetch failed for peer" so callers see a
-            // consistent network-failure shape across wake + send (#411 contract).
-            console.error(`\x1b[31merror\x1b[0m: Remote fetch failed for peer ${peer.url} (${targetNode}): cross-node wake failed for ${bareAgent}: ${underlying}`);
-            console.error(`\x1b[33mhint\x1b[0m:  check peer connectivity: maw health`);
-            process.exit(1);
+            // #1998 — warn (keep wake failure visible) but DO NOT exit. The
+            // target may be a live window that simply isn't a wakeable oracle;
+            // let the send attempt below decide success vs. a real failure.
+            console.warn(`\x1b[33mwarn\x1b[0m:  cross-node wake skipped for ${bareAgent} on ${targetNode}: ${underlying} — attempting direct send (target may be live)`);
           }
         }
       }

--- a/test/comm-send-cmdsend-coverage.test.ts
+++ b/test/comm-send-cmdsend-coverage.test.ts
@@ -207,6 +207,7 @@ const origSleep = Bun.sleep.bind(Bun);
 const origExit = process.exit;
 const origErr = console.error;
 const origLog = console.log;
+const origWarn = console.warn;
 const origAgentName = process.env.CLAUDE_AGENT_NAME;
 const origTestMode = process.env.MAW_TEST_MODE;
 const origMawSender = process.env.MAW_SENDER;
@@ -224,13 +225,16 @@ const { cmdSend } = await import("../src/commands/shared/comm-send");
 let exitCode: number | undefined;
 let errs: string[];
 let logs: string[];
+let warns: string[];
 
 async function runCmd(fn: () => Promise<unknown>) {
   exitCode = undefined;
   errs = [];
   logs = [];
+  warns = [];
   console.error = (...args: unknown[]) => { errs.push(args.map(String).join(" ")); };
   console.log = (...args: unknown[]) => { logs.push(args.map(String).join(" ")); };
+  console.warn = (...args: unknown[]) => { warns.push(args.map(String).join(" ")); };
   (process as unknown as { exit: (code?: number) => never }).exit = (code?: number): never => {
     exitCode = code ?? 0;
     throw new Error(`__exit__:${exitCode}`);
@@ -243,6 +247,7 @@ async function runCmd(fn: () => Promise<unknown>) {
   } finally {
     console.error = origErr;
     console.log = origLog;
+    console.warn = origWarn;
     (process as unknown as { exit: typeof origExit }).exit = origExit;
   }
 }
@@ -314,6 +319,7 @@ afterAll(() => {
   (Bun as unknown as { sleep: typeof origSleep }).sleep = origSleep;
   console.error = origErr;
   console.log = origLog;
+  console.warn = origWarn;
   (process as unknown as { exit: typeof origExit }).exit = origExit;
 });
 
@@ -788,19 +794,41 @@ describe("cmdSend — bare-name, wake, and safety gates", () => {
     expect(JSON.parse(curlFetchCalls[0].options.body)).toMatchObject({ target: "volt-oracle:1" });
   });
 
-  test("cross-node wake failures stop before send", async () => {
+  test("#1998: cross-node wake failure warns but still attempts send (live non-wakeable target)", async () => {
+    // Repro: target is a live window/pane that isn't a wakeable oracle (repo),
+    // so remote /api/wake returns "missing oracle name" — but /api/send to the
+    // same target succeeds via the receiver's lenient pane resolution.
     config.namedPeers = [{ name: "remote", url: "http://remote:3456" }];
     resolveTargetReturn = { type: "peer", target: "oracle", node: "remote", peerUrl: "http://remote:3456" };
     curlFetchHandler = (url) => {
-      if (url.endsWith("/api/wake")) return { ok: false, status: 503, data: { error: "wake down" } };
-      return { ok: true, status: 200, data: { ok: true } };
+      if (url.endsWith("/api/wake")) return { ok: false, status: 200, data: { ok: false, error: "missing oracle name" } };
+      return { ok: true, status: 200, data: { ok: true, target: "oracle.0", state: "delivered" } };
+    };
+
+    await runCmd(() => cmdSend("remote:oracle", "hello"));
+
+    // No hard exit — send was attempted and succeeded.
+    expect(exitCode).toBeUndefined();
+    expect(curlFetchCalls.map(c => c.url)).toEqual(["http://remote:3456/api/wake", "http://remote:3456/api/send"]);
+    // Wake failure is surfaced as a non-fatal warning, not a fatal error.
+    expect(warns.join("\n")).toContain("cross-node wake skipped");
+  });
+
+  test("#1998: when wake fails AND send fails, the send error surfaces and exits", async () => {
+    // Genuinely unreachable peer: wake fails, then send also fails → clean exit
+    // with the send-path "Remote fetch failed" error (#411 contract preserved).
+    config.namedPeers = [{ name: "remote", url: "http://remote:3456" }];
+    resolveTargetReturn = { type: "peer", target: "oracle", node: "remote", peerUrl: "http://remote:3456" };
+    curlFetchHandler = (url) => {
+      if (url.endsWith("/api/wake")) return { ok: false, status: 0, data: undefined };
+      return { ok: false, status: 0, data: undefined };
     };
 
     await runCmd(() => cmdSend("remote:oracle", "hello"));
 
     expect(exitCode).toBe(1);
-    expect(curlFetchCalls.map(c => c.url)).toEqual(["http://remote:3456/api/wake"]);
-    expect(errs.join("\n")).toContain("cross-node wake failed");
+    expect(curlFetchCalls.map(c => c.url)).toEqual(["http://remote:3456/api/wake", "http://remote:3456/api/send"]);
+    expect(errs.join("\n")).toContain("Remote fetch failed for peer");
   });
 
   test("ACL queue stores pending peer sends instead of delivering", async () => {


### PR DESCRIPTION
## Problem (#1998)

Cross-node `maw hey <peer>:<agent>` fails for **every** target that is a live window/pane but not a wakeable oracle:

```
error: Remote fetch failed for peer http://world.wg:3463 (oracle-world-oracle): cross-node wake failed for oracle: missing oracle name
```

…while `maw peek` on the *same* target succeeds (proving the session is live + reachable).

### Root cause
`src/commands/shared/comm-send.ts` force-woke the target via `POST /api/wake` **before** sending, then `process.exit(1)` on any wake error (the #791 "wake errors must be visible" design). But `/api/wake` errors with `missing oracle name` when the bare name maps to a window/worktree-pane/non-repo alias rather than a wakeable repo — so the send was never attempted even though the target was demonstrably live.

## Fix

Make the cross-node wake **best-effort**:
- On wake failure, **warn** (failure stays visible) and **fall through** to the send attempt.
- `POST /api/send` uses the receiver's lenient capture-by-pane resolution — the same path `peek` uses — so it delivers to live targets.
- If the peer is genuinely unreachable, the send attempt surfaces its own clear `Remote fetch failed` error → exit 1, preserving the #411 network-failure contract.

This is the issue's suggested fix #1 (try-send-after-wake) with minimal, surgical change.

## Tests
- Replaced the now-obsolete `cross-node wake failures stop before send` test with `#1998: cross-node wake failure warns but still attempts send` (asserts wake→send sequence, no exit, warning emitted).
- Added `#1998: when wake fails AND send fails, the send error surfaces and exits` (preserves #411).
- Added `console.warn` capture to the test harness.
- `bun test test/comm-send-cmdsend-coverage.test.ts` → 42 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)