### PR TITLE
papercut(tmux): preserve window name on close

### DIFF
--- a/src/commands/plugins/tmux/index.ts
+++ b/src/commands/plugins/tmux/index.ts
@@ -23,6 +23,21 @@ interface TmuxHandlerDeps {
   cmdSplit: (target: string, opts: { lock?: boolean }) => Promise<void>;
 }
 
+function shellArg(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+async function breakPaneDetached(hostExecFn: typeof hostExec, pane: string): Promise<void> {
+  let windowName = "";
+  try {
+    windowName = (await hostExecFn(`tmux display-message -p -t ${shellArg(pane)} '#{window_name}'`)).trim();
+  } catch {
+    // Let break-pane surface the actionable tmux error below.
+  }
+  const nameArg = windowName ? ` -n ${shellArg(windowName)}` : "";
+  await hostExecFn(`tmux break-pane -d -t ${shellArg(pane)}${nameArg}`);
+}
+
 const defaultDeps: TmuxHandlerDeps = {
   cmdTmuxPeek,
   cmdTmuxLs,
@@ -304,7 +319,7 @@ export function createTmuxHandler(overrides: Partial<TmuxHandlerDeps> = {}) {
           return { ok: false, error: "cannot close current pane" };
         }
         try {
-          await deps.hostExec(`tmux break-pane -d -t '${explicitTarget}'`);
+          await breakPaneDetached(deps.hostExec, explicitTarget);
           console.log(`\x1b[32m✓\x1b[0m closed ${explicitTarget} (hidden — still alive)`);
         } catch (e: any) {
           console.log(`\x1b[31m✗\x1b[0m close failed for '${explicitTarget}': ${e?.message ?? e}`);
@@ -320,7 +335,7 @@ export function createTmuxHandler(overrides: Partial<TmuxHandlerDeps> = {}) {
         for (const pane of paneList) {
           if (pane === myPane) continue;
           try {
-            await deps.hostExec(`tmux break-pane -d -t '${pane}'`);
+            await breakPaneDetached(deps.hostExec, pane);
             hidden++;
           } catch { /* already gone */ }
         }

--- a/test/isolated/tmux-close-preserve-window-name.test.ts
+++ b/test/isolated/tmux-close-preserve-window-name.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createTmuxHandler } from "../../src/commands/plugins/tmux/index";
+import type { InvokeContext } from "../../src/plugin/types";
+
+const OLD_TMUX = process.env.TMUX;
+const OLD_TMUX_PANE = process.env.TMUX_PANE;
+
+afterEach(() => {
+  if (OLD_TMUX === undefined) delete process.env.TMUX;
+  else process.env.TMUX = OLD_TMUX;
+  if (OLD_TMUX_PANE === undefined) delete process.env.TMUX_PANE;
+  else process.env.TMUX_PANE = OLD_TMUX_PANE;
+});
+
+function cli(args: string[]): InvokeContext {
+  return { source: "cli", args } as any;
+}
+
+function handlerWithHostExec(hostExec: (cmd: string) => Promise<string>) {
+  return createTmuxHandler({
+    hostExec,
+    cmdTmuxPeek: async () => {},
+    cmdTmuxLs: async () => {},
+    cmdTmuxSend: async () => {},
+    cmdTmuxSplit: async () => {},
+    cmdTmuxKill: async () => {},
+    cmdTmuxLayout: async () => {},
+    cmdTmuxPipePane: async () => {},
+    cmdTmuxSynchronizePanes: async () => {},
+    cmdTmuxAttach: () => {},
+    resolveTmuxTarget: (target: string) => ({ resolved: target, source: "test" }),
+    cmdSplit: async () => {},
+  } as any);
+}
+
+describe("maw tmux close window-name preservation (#1974)", () => {
+  test("explicit close names the broken-out pane window after its current window", async () => {
+    process.env.TMUX = "/tmp/tmux";
+    process.env.TMUX_PANE = "%1";
+    const calls: string[] = [];
+    const handler = handlerWithHostExec(async (cmd) => {
+      calls.push(cmd);
+      if (cmd.includes("display-message")) return "volt-coder-1\n";
+      return "";
+    });
+
+    const result = await handler(cli(["close", "%2"]));
+
+    expect(result.ok).toBe(true);
+    expect(calls).toEqual([
+      "tmux display-message -p -t '%2' '#{window_name}'",
+      "tmux break-pane -d -t '%2' -n 'volt-coder-1'",
+    ]);
+  });
+
+  test("sweep close preserves each sibling pane's window name", async () => {
+    process.env.TMUX = "/tmp/tmux";
+    process.env.TMUX_PANE = "%1";
+    const calls: string[] = [];
+    const handler = handlerWithHostExec(async (cmd) => {
+      calls.push(cmd);
+      if (cmd.includes("list-panes")) return "%1\n%2\n%3\n";
+      if (cmd.includes("display-message")) return "main-work\n";
+      return "";
+    });
+
+    const result = await handler(cli(["close"]));
+
+    expect(result.ok).toBe(true);
+    expect(calls).toContain("tmux break-pane -d -t '%2' -n 'main-work'");
+    expect(calls).toContain("tmux break-pane -d -t '%3' -n 'main-work'");
+  });
+});


### PR DESCRIPTION
## Summary
- preserve the source tmux window name when `maw tmux close` hides a pane via `break-pane -n`
- apply the behavior to both explicit pane close and sibling sweep close
- add focused regression coverage for #1974

## Tests
- `bun test test/isolated/tmux-close-preserve-window-name.test.ts test/tmux-index-default.test.ts --path-ignore-patterns '**/agents/**'`

Fixes #1974
