### PR TITLE
feat(ls): expose worktree metadata in JSON (#1990)

### DIFF
--- a/src/commands/plugins/tmux/impl.ts
+++ b/src/commands/plugins/tmux/impl.ts
@@ -217,6 +217,12 @@ export interface TmuxLsOpts {
 
 export type PaneStatus = "frozen" | "active" | "idle" | "stale" | "unknown";
 
+export interface PaneWorktreeJson {
+  path: string;
+  branch: string | null;
+  head: string | null;
+}
+
 interface AnnotatedPane {
   id: string;
   target: string;
@@ -229,6 +235,34 @@ interface AnnotatedPane {
   sessionCreated?: number;
   sessionActivity?: number;
   source?: string;
+  cwd?: string;
+}
+
+function sh(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+export async function describePaneWorktree(cwd: string | undefined): Promise<PaneWorktreeJson | null> {
+  const start = cwd?.trim();
+  if (!start) return null;
+  const path = (await hostExec(`git -C ${sh(start)} rev-parse --show-toplevel`).catch(() => "")).trim();
+  if (!path) return null;
+  const [branch, head] = await Promise.all([
+    hostExec(`git -C ${sh(path)} branch --show-current`).catch(() => ""),
+    hostExec(`git -C ${sh(path)} rev-parse --short=8 HEAD`).catch(() => ""),
+  ]);
+  return {
+    path,
+    branch: branch.trim() || null,
+    head: head.trim() || null,
+  };
+}
+
+async function panesForJson(panes: AnnotatedPane[]): Promise<Array<Omit<AnnotatedPane, "cwd"> & { worktree: PaneWorktreeJson | null }>> {
+  return await Promise.all(panes.map(async ({ cwd, ...pane }) => ({
+    ...pane,
+    worktree: await describePaneWorktree(cwd),
+  })));
 }
 
 async function markContextLimitedPanes(panes: AnnotatedPane[]): Promise<void> {
@@ -389,6 +423,7 @@ export async function cmdTmuxLs(opts: TmuxLsOpts = {}): Promise<void> {
       sessionCreated: createdBySession.get(session),
       sessionActivity: activityBySession.get(session),
       source: (p as { source?: string; node?: string }).source ?? (p as { node?: string }).node,
+      cwd: p.cwd,
     };
   });
 
@@ -449,6 +484,7 @@ export async function cmdTmuxLs(opts: TmuxLsOpts = {}): Promise<void> {
   await markContextLimitedPanes(scope);
 
   if (opts.json) {
+    const paneRows = await panesForJson(scope);
     const teamRows = visibleTeams.map(team => ({
       kind: "team",
       id: `team:${team.name}`,
@@ -463,7 +499,7 @@ export async function cmdTmuxLs(opts: TmuxLsOpts = {}): Promise<void> {
       members: team.memberCount,
       configPath: team.configPath,
     }));
-    console.log(JSON.stringify([...scope, ...teamRows], null, 2));
+    console.log(JSON.stringify([...paneRows, ...teamRows], null, 2));
     return;
   }
 

--- a/test/ls-json-worktree.test.ts
+++ b/test/ls-json-worktree.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { join } from "path";
+
+const srcRoot = join(import.meta.dir, "..");
+
+type Pane = {
+  id: string;
+  target: string;
+  command?: string;
+  title?: string;
+  cwd?: string;
+  lastActivity?: number;
+};
+
+let panes: Pane[] = [];
+let gitRoots = new Map<string, string>();
+let gitBranches = new Map<string, string>();
+let gitHeads = new Map<string, string>();
+let commands: string[] = [];
+
+mock.module(join(srcRoot, "src/sdk"), () => ({
+  tmux: { listPanes: async () => panes, capture: async () => "" },
+  tmuxCmd: () => "tmux",
+  hostExec: async (cmd: string) => {
+    commands.push(cmd);
+    if (cmd.includes("rev-parse --show-toplevel")) {
+      for (const [cwd, root] of gitRoots) if (cmd.includes(`'${cwd}'`)) return root;
+      throw new Error("not a git repo");
+    }
+    if (cmd.includes("branch --show-current")) {
+      for (const [root, branch] of gitBranches) if (cmd.includes(`'${root}'`)) return branch;
+      return "";
+    }
+    if (cmd.includes("rev-parse --short=8 HEAD")) {
+      for (const [root, head] of gitHeads) if (cmd.includes(`'${root}'`)) return head;
+      return "";
+    }
+    return "";
+  },
+}));
+
+mock.module(join(srcRoot, "src/commands/shared/fleet-load"), () => ({
+  loadFleetEntries: () => [{ file: "101-mawjs.json" }],
+}));
+
+mock.module(join(srcRoot, "src/core/fleet/worktrees-scan"), () => ({
+  scanWorktrees: async () => [],
+}));
+
+mock.module(join(srcRoot, "src/core/ghq"), () => ({
+  ghqList: async () => [],
+  ghqListSync: () => [],
+}));
+
+const { cmdTmuxLs, describePaneWorktree } = await import("../src/commands/plugins/tmux/impl");
+
+const originalLog = console.log;
+
+async function captureJson(fn: () => Promise<void>) {
+  const logs: string[] = [];
+  console.log = (...args: unknown[]) => logs.push(args.map(String).join(" "));
+  try {
+    await fn();
+  } finally {
+    console.log = originalLog;
+  }
+  return JSON.parse(logs.join("\n"));
+}
+
+beforeEach(() => {
+  panes = [];
+  commands = [];
+  gitRoots = new Map();
+  gitBranches = new Map();
+  gitHeads = new Map();
+});
+
+describe("maw ls --json worktree metadata (#1990)", () => {
+  test("adds git worktree path, branch, and head for pane cwd", async () => {
+    panes = [{ id: "%1", target: "101-mawjs:main.0", command: "claude", cwd: "/repo/agents/1-codex" }];
+    gitRoots.set("/repo/agents/1-codex", "/repo/agents/1-codex");
+    gitBranches.set("/repo/agents/1-codex", "agents/1-codex");
+    gitHeads.set("/repo/agents/1-codex", "a596969b");
+
+    const rows = await captureJson(() => cmdTmuxLs({ all: true, json: true }));
+
+    expect(rows[0].worktree).toEqual({
+      path: "/repo/agents/1-codex",
+      branch: "agents/1-codex",
+      head: "a596969b",
+    });
+    expect(rows[0].cwd).toBeUndefined();
+  });
+
+  test("uses null worktree when cwd is absent or not inside git", async () => {
+    expect(await describePaneWorktree(undefined)).toBeNull();
+
+    panes = [{ id: "%2", target: "scratch:main.0", command: "zsh", cwd: "/tmp" }];
+    const rows = await captureJson(() => cmdTmuxLs({ all: true, json: true }));
+
+    expect(rows[0].worktree).toBeNull();
+    expect(commands.some(cmd => cmd.includes("/tmp"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem (#1990)
`maw ls --json` identifies panes and oracle status, but consumers cannot tell which filesystem worktree a pane belongs to.
Automation has to infer paths from display labels or make extra tmux queries, which is brittle for multi-worktree fleets.

## Root cause
`cmdTmuxLs()` builds JSON directly from annotated tmux panes in `src/commands/plugins/tmux/impl.ts`.
Although the tmux transport already exposes each pane cwd, the JSON serialization dropped that cwd and did not resolve git worktree metadata before printing.

## Fix
Add a null-safe `worktree` object to each pane row in JSON mode with `path`, `branch`, and `head`.
The resolver uses the pane cwd, asks git for the top-level worktree plus branch/short HEAD when available, and keeps human `maw ls` output unchanged.

## Tests
`test/ls-json-worktree.test.ts` asserts JSON rows include worktree path/branch/head for panes inside a git worktree and `null` for panes without usable cwd.
Targeted tmux ls coverage and `bun run build` verify the existing human/json ls paths still compile and behave.

Closes #1990
