### PR TITLE
papercut: add layout reset alias and tile swap hint

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -152,6 +152,8 @@ function printLayoutUsage(write: (line: string) => void = console.log): void {
   write("usage: maw layout <preset>");
   write("  Re-apply a tmux layout preset to the current window.");
   write("  presets: even-horizontal, even-vertical, main-horizontal, main-vertical, tiled");
+  write("  alias: reset → main-vertical");
+  write("  To swap two panes predictably: maw tile swap <a> <b>");
   write("  For explicit targets, use: maw tmux layout <target> <preset>");
 }
 
@@ -374,7 +376,8 @@ export async function invokeDirectHandler(
       return;
     }
     const flags = parseFlags(argv, {}, 0);
-    const preset = (flags._ as string[])[0];
+    const rawPreset = (flags._ as string[])[0];
+    const preset = rawPreset === "reset" ? "main-vertical" : rawPreset;
     if (!preset) {
       printLayoutUsage(error);
       throw new UserError("layout: missing preset");

--- a/test/isolated/layout-reset-discoverability.test.ts
+++ b/test/isolated/layout-reset-discoverability.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { invokeDirectHandler } from "../../src/cli/top-aliases";
+
+const OLD_TEST_MODE = process.env.MAW_TEST_MODE;
+
+let logs: string[] = [];
+let errors: string[] = [];
+let layoutCalls: Array<[string, string]> = [];
+
+beforeEach(() => {
+  process.env.MAW_TEST_MODE = "1";
+  logs = [];
+  errors = [];
+  layoutCalls = [];
+});
+
+afterEach(() => {
+  if (OLD_TEST_MODE === undefined) delete process.env.MAW_TEST_MODE;
+  else process.env.MAW_TEST_MODE = OLD_TEST_MODE;
+});
+
+const deps = () => ({
+  cmdTmuxLayout: async (target: string, preset: string) => {
+    layoutCalls.push([target, preset]);
+  },
+  log: (line: string) => logs.push(line),
+  error: (line: string) => errors.push(line),
+});
+
+describe("maw layout reset discoverability (#1966)", () => {
+  test("layout reset aliases to main-vertical on the current window", async () => {
+    await invokeDirectHandler("cmdLayout", ["reset"], deps());
+
+    expect(layoutCalls).toEqual([[".", "main-vertical"]]);
+    expect(errors).toEqual([]);
+  });
+
+  test("layout help points users to reset and tile swap", async () => {
+    await invokeDirectHandler("cmdLayout", ["--help"], deps());
+
+    const help = logs.join("\n");
+    expect(help).toContain("alias: reset → main-vertical");
+    expect(help).toContain("maw tile swap <a> <b>");
+    expect(layoutCalls).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add `maw layout reset` as an alias for `main-vertical`
- add `maw layout --help` copy that points users to `maw tile swap <a> <b>` for predictable pane swaps
- add focused regression coverage for #1966

## Tests
- `MAW_TEST_MODE=1 bun test test/isolated/layout-reset-discoverability.test.ts test/top-aliases-default.test.ts test/isolated/top-aliases-runtime-coverage.test.ts --path-ignore-patterns '**/agents/**'`

Fixes #1966
