### PR TITLE
fix(comm): prevent silent inter-oracle message loss

### DIFF
--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -827,7 +827,18 @@ export async function cmdSend(
       console.error(`\x1b[31merror\x1b[0m: --inbox requested but receiver inbox is unavailable for ${target}${reason}`);
       process.exit(1);
     }
-    await sendKeys(target, outboundMessage);
+    // #1967: the receiver inbox is the durable delivery guarantee; pane
+    // injection is only the live wake-up. Persist first so a tmux race cannot
+    // silently drop the message before it reaches ψ/inbox.
+    const inbox = await writeReceiverInbox(target);
+    try {
+      await sendKeys(target, outboundMessage);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      if (logQueuedInbox(inbox, target, `tmux delivery failed: ${msg}`)) return;
+      console.error(`\x1b[31merror\x1b[0m: tmux delivery failed for ${target}: ${msg}`);
+      process.exit(1);
+    }
     // #1907 — verify the implicit Enter actually submitted. Default-on
     // for live use; opt out per-call with --no-verify-submit; auto-skip
     // under MAW_TEST_MODE so existing cmdSend mock harnesses (which don't
@@ -840,7 +851,6 @@ export async function cmdSend(
         console.log(`  \x1b[33m⚠\x1b[0m submit needed ${verify.retriesNeeded} Enter retry — TUI may have been in scroll-mode`);
       }
     }
-    await writeReceiverInbox(target);
     await runHook("after_send", { to: query, message: outboundMessage });
     if (!config.node) throw new Error("config.node is required — set 'node' in maw.config.json");
     logMessage(senderName, query, outboundMessage, "local");

--- a/src/commands/shared/receiver-inbox.ts
+++ b/src/commands/shared/receiver-inbox.ts
@@ -175,6 +175,20 @@ function buildInboxBody(from: string, to: string, timestamp: string, message: st
   ].join("\n");
 }
 
+function filenameWithCollisionSuffix(base: string, attempt: number): string {
+  if (attempt <= 1) return base;
+  return base.replace(/\.md$/, `-${attempt}.md`);
+}
+
+function isExistingFileError(error: unknown): boolean {
+  return Boolean(
+    error &&
+    typeof error === "object" &&
+    "code" in error &&
+    (error as { code?: string }).code === "EEXIST",
+  );
+}
+
 export function persistReceiverInbox(input: ReceiverInboxInput, deps: ReceiverInboxDeps = {}): ReceiverInboxResult {
   const existsSync = deps.existsSync ?? fsExistsSync;
   const mkdirSync = deps.mkdirSync ?? fsMkdirSync;
@@ -197,14 +211,28 @@ export function persistReceiverInbox(input: ReceiverInboxInput, deps: ReceiverIn
   const timestamp = now.toISOString();
   const datePart = timestamp.slice(0, 10);
   const timePart = timestamp.slice(11, 16).replace(":", "-");
-  const filename = `${datePart}_${timePart}_${safeSegment(input.from)}_${slugifyBody(input.message)}.md`;
+  const baseFilename = `${datePart}_${timePart}_${safeSegment(input.from)}_${slugifyBody(input.message)}.md`;
   const inboxDir = join(repoPath, "ψ", "inbox");
-  const path = join(inboxDir, filename);
+  const body = buildInboxBody(input.from, oracle, timestamp, input.message);
 
   try {
     mkdirSync(inboxDir, { recursive: true });
-    writeFileSync(path, buildInboxBody(input.from, oracle, timestamp, input.message));
-    return { ok: true, oracle, inboxDir, path, filename };
+    for (let attempt = 1; attempt <= 1000; attempt += 1) {
+      const filename = filenameWithCollisionSuffix(baseFilename, attempt);
+      const path = join(inboxDir, filename);
+      try {
+        writeFileSync(path, body, { flag: "wx" });
+        return { ok: true, oracle, inboxDir, path, filename };
+      } catch (error) {
+        if (isExistingFileError(error)) continue;
+        throw error;
+      }
+    }
+    return {
+      ok: false,
+      oracle,
+      reason: `receiver inbox filename collision limit reached for ${baseFilename}`,
+    };
   } catch (error) {
     return {
       ok: false,

--- a/test/comm-send-durable-inbox.test.ts
+++ b/test/comm-send-durable-inbox.test.ts
@@ -1,0 +1,128 @@
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { join } from "path";
+
+const srcRoot = join(import.meta.dir, "..");
+
+let sendKeysShouldThrow = false;
+let order: string[];
+let logs: string[];
+let errs: string[];
+let exitCode: number | undefined;
+let runHookCalls: unknown[];
+let logMessageCalls: unknown[];
+let emitFeedCalls: unknown[];
+
+mock.module(join(srcRoot, "src/sdk"), () => ({
+  listSessions: async () => [{ name: "session", windows: [{ index: 0, name: "oracle", active: true }] }],
+  capture: async () => "",
+  sendKeys: async () => {
+    order.push("sendKeys");
+    if (sendKeysShouldThrow) throw new Error("pane vanished");
+  },
+  isAgentCommand: () => true,
+  findPeerForTarget: async () => null,
+  resolveTarget: () => ({ type: "local", target: "session:oracle.0" }),
+  curlFetch: async () => ({ ok: true, data: { ok: true } }),
+  runHook: async (...args: unknown[]) => {
+    runHookCalls.push(args);
+  },
+}));
+
+mock.module(join(srcRoot, "src/config"), () => ({
+  loadConfig: () => ({ node: "test-node", oracle: "sender", port: 3456, namedPeers: [] }),
+  cfgLimit: () => 120,
+}));
+
+mock.module(join(srcRoot, "src/commands/shared/comm-log-feed"), () => ({
+  logMessage: (...args: unknown[]) => {
+    logMessageCalls.push(args);
+  },
+  emitFeed: (...args: unknown[]) => {
+    emitFeedCalls.push(args);
+  },
+}));
+
+mock.module(join(srcRoot, "src/lib/oracle-manifest"), () => ({
+  findOracle: () => ({ name: "oracle", node: "test-node" }),
+  loadManifestCached: () => [],
+}));
+
+mock.module(join(srcRoot, "src/commands/shared/should-auto-wake"), () => ({
+  shouldAutoWake: () => ({ wake: false }),
+}));
+
+const origExit = process.exit;
+const origLog = console.log;
+const origErr = console.error;
+const origAgentName = process.env.CLAUDE_AGENT_NAME;
+
+const { cmdSend } = await import("../src/commands/shared/comm-send");
+
+async function runCmd() {
+  console.log = (...args: unknown[]) => { logs.push(args.map(String).join(" ")); };
+  console.error = (...args: unknown[]) => { errs.push(args.map(String).join(" ")); };
+  (process as unknown as { exit: (code?: number) => never }).exit = (code?: number): never => {
+    exitCode = code ?? 0;
+    throw new Error(`__exit__:${exitCode}`);
+  };
+  try {
+    await cmdSend("oracle", "hello", false, {
+      noVerifySubmit: true,
+      receiverInbox: async () => {
+        order.push("receiverInbox");
+        return { ok: true, oracle: "oracle", inboxDir: "/tmp/inbox", path: "/tmp/inbox/msg.md", filename: "msg.md" };
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!message.startsWith("__exit__")) throw error;
+  } finally {
+    console.log = origLog;
+    console.error = origErr;
+    (process as unknown as { exit: typeof origExit }).exit = origExit;
+  }
+}
+
+beforeEach(() => {
+  process.env.CLAUDE_AGENT_NAME = "sender";
+  sendKeysShouldThrow = false;
+  order = [];
+  logs = [];
+  errs = [];
+  exitCode = undefined;
+  runHookCalls = [];
+  logMessageCalls = [];
+  emitFeedCalls = [];
+});
+
+afterEach(() => {
+  if (origAgentName === undefined) delete process.env.CLAUDE_AGENT_NAME;
+  else process.env.CLAUDE_AGENT_NAME = origAgentName;
+});
+
+afterAll(() => {
+  console.log = origLog;
+  console.error = origErr;
+  (process as unknown as { exit: typeof origExit }).exit = origExit;
+});
+
+describe("cmdSend durable receiver inbox (#1967)", () => {
+  test("persists inbox before pane injection and queues when injection fails", async () => {
+    sendKeysShouldThrow = true;
+
+    await runCmd();
+
+    expect(exitCode).toBeUndefined();
+    expect(order).toEqual(["receiverInbox", "sendKeys"]);
+    expect(logs.join("\n")).toContain("queued");
+    expect(logs.join("\n")).toContain("tmux delivery failed: pane vanished");
+    expect(errs).toEqual([]);
+    expect(runHookCalls).toEqual([]);
+    expect(logMessageCalls).toContainEqual(["sender", "oracle", "[test-node:sender] hello", "inbox"]);
+    expect((emitFeedCalls[0] as any[])[5]).toMatchObject({
+      state: "queued",
+      route: "inbox",
+      lastLine: "tmux delivery failed: pane vanished",
+    });
+  });
+});

--- a/test/receiver-inbox-collision.test.ts
+++ b/test/receiver-inbox-collision.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { persistReceiverInbox } from "../src/commands/shared/receiver-inbox";
+
+describe("receiver inbox filename collisions (#1967)", () => {
+  test("keeps same-minute messages with matching first six words", () => {
+    const root = mkdtempSync(join(tmpdir(), "maw-receiver-inbox-collision-"));
+    const repo = join(root, "digger-oracle");
+    mkdirSync(repo, { recursive: true });
+    const deps = {
+      resolveTargetCwd: () => repo,
+      loadManifest: () => [],
+      getGhqRoot: () => root,
+      ghqFindSync: () => null,
+      now: () => new Date("2026-05-17T08:00:42.000Z"),
+    };
+
+    const first = persistReceiverInbox({
+      query: "digger",
+      target: "54-digger:digger-oracle.0",
+      from: "m5:sender",
+      message: "one two three four five six alpha",
+    }, deps);
+    const second = persistReceiverInbox({
+      query: "digger",
+      target: "54-digger:digger-oracle.0",
+      from: "m5:sender",
+      message: "one two three four five six beta",
+    }, deps);
+
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+    if (!first.ok || !second.ok) throw new Error("expected both writes to succeed");
+    expect(first.filename).toBe("2026-05-17_08-00_m5-sender_one-two-three-four-five-six.md");
+    expect(second.filename).toBe("2026-05-17_08-00_m5-sender_one-two-three-four-five-six-2.md");
+    expect(existsSync(first.path)).toBe(true);
+    expect(existsSync(second.path)).toBe(true);
+
+    const files = readdirSync(first.inboxDir).sort();
+    expect(files).toEqual([first.filename, second.filename].sort());
+    expect(readFileSync(first.path, "utf-8")).toContain("alpha");
+    expect(readFileSync(second.path, "utf-8")).toContain("beta");
+  });
+});


### PR DESCRIPTION
## Problem

#1967 reports two silent-loss paths in inter-oracle delivery:

1. `cmdSend` local delivery injected into tmux before the receiver inbox write, so a pane race/restart could throw before any durable fallback was persisted.
2. `persistReceiverInbox` used minute-resolution filenames plus unguarded `writeFileSync`, so same-sender same-minute messages with the same first six words overwrote each other.

## Fix

- Persist the receiver inbox before best-effort local pane injection.
- If pane injection fails after the inbox write, report the message as `queued` with the tmux failure reason instead of losing it.
- Write receiver inbox files with no-overwrite semantics and append `-2`, `-3`, ... on filename collisions while preserving the existing base filename shape.

## Tests

- `bun test test/routing-window-mismatch.test.ts` (verified existing #1980 alpha fix)
- `bash scripts/test-default-safe.sh test/comm-send-durable-inbox.test.ts test/receiver-inbox-collision.test.ts test/receiver-inbox-default.test.ts test/comm-send-focused-gaps.test.ts test/comm-send-cmdsend-coverage.test.ts test/sessions-api-default.test.ts`
- `bun run build`

## Release

Code fix only; no version bump / release cut.

Closes #1967

