### PR TITLE
feat(ls): expose provenance in JSON (#1991)

### DIFF
--- a/src/commands/plugins/tmux/impl.ts
+++ b/src/commands/plugins/tmux/impl.ts
@@ -217,6 +217,17 @@ export interface TmuxLsOpts {
 
 export type PaneStatus = "frozen" | "active" | "idle" | "stale" | "unknown";
 
+export interface PaneProvenanceJson {
+  oracle: string | null;
+  machine: string | null;
+  session: string | null;
+  federation: string | null;
+  org: string | null;
+  repo: string | null;
+  commit: string | null;
+  engine: string | null;
+}
+
 interface AnnotatedPane {
   id: string;
   target: string;
@@ -229,6 +240,105 @@ interface AnnotatedPane {
   sessionCreated?: number;
   sessionActivity?: number;
   source?: string;
+  cwd?: string;
+}
+
+function sh(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function paneWindowName(target: string): string | null {
+  const afterColon = target.split(":").slice(1).join(":");
+  if (!afterColon) return null;
+  const match = /^(.*)\.\d+$/.exec(afterColon);
+  return (match?.[1] ?? afterColon).trim() || null;
+}
+
+function oracleNameForPane(session: string, target: string, configured?: string): string | null {
+  const window = paneWindowName(target);
+  if (window && !/^\d+$/.test(window)) return window;
+  const fallback = configured || session.replace(/^\d+-/, "");
+  if (!fallback) return null;
+  return fallback.endsWith("-oracle") ? fallback : `${fallback}-oracle`;
+}
+
+function repoPartsFromRemote(remote: string): { org: string | null; repo: string | null } {
+  const trimmed = remote.trim().replace(/\.git$/, "");
+  const match = /[:/]([^/:\s]+)\/([^/\s]+)$/.exec(trimmed);
+  return { org: match?.[1] ?? null, repo: match?.[2] ?? null };
+}
+
+function repoPartsFromPath(path: string): { org: string | null; repo: string | null } {
+  const parts = path.split("/").filter(Boolean);
+  const hostIndex = parts.lastIndexOf("github.com");
+  if (hostIndex >= 0 && parts[hostIndex + 1] && parts[hostIndex + 2]) {
+    return { org: parts[hostIndex + 1], repo: parts[hostIndex + 2] };
+  }
+  return { org: null, repo: parts.at(-1) ?? null };
+}
+
+async function gitProvenance(cwd: string | undefined): Promise<{ org: string | null; repo: string | null; commit: string | null }> {
+  const start = cwd?.trim();
+  if (!start) return { org: null, repo: null, commit: null };
+  const root = (await hostExec(`git -C ${sh(start)} rev-parse --show-toplevel`).catch(() => "")).trim();
+  if (!root) return { org: null, repo: null, commit: null };
+  const [remote, commit] = await Promise.all([
+    hostExec(`git -C ${sh(root)} config --get remote.origin.url`).catch(() => ""),
+    hostExec(`git -C ${sh(root)} rev-parse --short=8 HEAD`).catch(() => ""),
+  ]);
+  const parts = remote.trim() ? repoPartsFromRemote(remote) : repoPartsFromPath(root);
+  return { ...parts, commit: commit.trim() || null };
+}
+
+type ProvenanceConfig = { node?: string; oracle?: string; sessionIds?: Record<string, string> };
+
+async function loadProvenanceConfig(): Promise<ProvenanceConfig> {
+  try {
+    const mod = await import("../../../config");
+    return mod.loadConfig() as ProvenanceConfig;
+  } catch {
+    return {};
+  }
+}
+
+async function fallbackHostname(): Promise<string | null> {
+  try {
+    const os = await import("os");
+    return typeof os.hostname === "function" ? os.hostname() || null : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function paneProvenance(
+  pane: Pick<AnnotatedPane, "target" | "session" | "command" | "cwd">,
+  config?: ProvenanceConfig,
+): Promise<PaneProvenanceJson> {
+  const resolvedConfig = config ?? await loadProvenanceConfig();
+  const oracle = oracleNameForPane(pane.session, pane.target, resolvedConfig.oracle);
+  const machine = resolvedConfig.node || process.env.MAW_NODE || await fallbackHostname();
+  const logicalSession = (oracle && (resolvedConfig.sessionIds?.[oracle] || resolvedConfig.sessionIds?.[oracle.replace(/-oracle$/, "")]))
+    || process.env.MAW_SESSION_ID
+    || null;
+  const git = await gitProvenance(pane.cwd);
+  return {
+    oracle,
+    machine,
+    session: logicalSession,
+    federation: oracle && machine ? `${machine}:${oracle}` : null,
+    org: git.org,
+    repo: git.repo,
+    commit: git.commit,
+    engine: pane.command?.trim() || null,
+  };
+}
+
+async function panesForJson(panes: AnnotatedPane[]): Promise<Array<Omit<AnnotatedPane, "cwd"> & { provenance: PaneProvenanceJson }>> {
+  const config = await loadProvenanceConfig();
+  return await Promise.all(panes.map(async ({ cwd, ...pane }) => ({
+    ...pane,
+    provenance: await paneProvenance({ ...pane, cwd }, config),
+  })));
 }
 
 async function markContextLimitedPanes(panes: AnnotatedPane[]): Promise<void> {
@@ -389,6 +499,7 @@ export async function cmdTmuxLs(opts: TmuxLsOpts = {}): Promise<void> {
       sessionCreated: createdBySession.get(session),
       sessionActivity: activityBySession.get(session),
       source: (p as { source?: string; node?: string }).source ?? (p as { node?: string }).node,
+      cwd: p.cwd,
     };
   });
 
@@ -449,6 +560,7 @@ export async function cmdTmuxLs(opts: TmuxLsOpts = {}): Promise<void> {
   await markContextLimitedPanes(scope);
 
   if (opts.json) {
+    const paneRows = await panesForJson(scope);
     const teamRows = visibleTeams.map(team => ({
       kind: "team",
       id: `team:${team.name}`,
@@ -463,7 +575,7 @@ export async function cmdTmuxLs(opts: TmuxLsOpts = {}): Promise<void> {
       members: team.memberCount,
       configPath: team.configPath,
     }));
-    console.log(JSON.stringify([...scope, ...teamRows], null, 2));
+    console.log(JSON.stringify([...paneRows, ...teamRows], null, 2));
     return;
   }
 

--- a/test/ls-json-provenance.test.ts
+++ b/test/ls-json-provenance.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { join } from "path";
+
+const srcRoot = join(import.meta.dir, "..");
+
+type Pane = { id: string; target: string; command?: string; title?: string; cwd?: string };
+
+let panes: Pane[] = [];
+let config: any = {};
+let gitRoots = new Map<string, string>();
+let gitRemotes = new Map<string, string>();
+let gitCommits = new Map<string, string>();
+
+mock.module("os", () => ({
+  homedir: () => "/mock-home",
+  hostname: () => "host-fallback",
+}));
+
+mock.module(join(srcRoot, "src/config"), () => ({
+  loadConfig: () => config,
+}));
+
+mock.module(join(srcRoot, "src/sdk"), () => ({
+  tmux: { listPanes: async () => panes, capture: async () => "" },
+  tmuxCmd: () => "tmux",
+  hostExec: async (cmd: string) => {
+    if (cmd.includes("rev-parse --show-toplevel")) {
+      for (const [cwd, root] of gitRoots) if (cmd.includes(`'${cwd}'`)) return root;
+      throw new Error("not a git repo");
+    }
+    if (cmd.includes("config --get remote.origin.url")) {
+      for (const [root, remote] of gitRemotes) if (cmd.includes(`'${root}'`)) return remote;
+      return "";
+    }
+    if (cmd.includes("rev-parse --short=8 HEAD")) {
+      for (const [root, commit] of gitCommits) if (cmd.includes(`'${root}'`)) return commit;
+      return "";
+    }
+    return "";
+  },
+}));
+
+mock.module(join(srcRoot, "src/commands/shared/fleet-load"), () => ({
+  loadFleetEntries: () => [{ file: "101-mawjs.json" }],
+}));
+
+mock.module(join(srcRoot, "src/core/fleet/worktrees-scan"), () => ({ scanWorktrees: async () => [] }));
+mock.module(join(srcRoot, "src/core/ghq"), () => ({ ghqList: async () => [], ghqListSync: () => [] }));
+
+const { cmdTmuxLs, paneProvenance } = await import("../src/commands/plugins/tmux/impl");
+
+const originalLog = console.log;
+
+async function captureJson(fn: () => Promise<void>) {
+  const logs: string[] = [];
+  console.log = (...args: unknown[]) => logs.push(args.map(String).join(" "));
+  try { await fn(); } finally { console.log = originalLog; }
+  return JSON.parse(logs.join("\n"));
+}
+
+beforeEach(() => {
+  panes = [];
+  config = { node: "m5", oracle: "mawjs", sessionIds: { "mawjs-oracle": "26a2aa25" } };
+  gitRoots = new Map();
+  gitRemotes = new Map();
+  gitCommits = new Map();
+  delete process.env.MAW_SESSION_ID;
+});
+
+describe("maw ls --json provenance metadata (#1991)", () => {
+  test("adds oracle, machine, logical session, repo, commit, and engine", async () => {
+    panes = [{ id: "%1", target: "101-mawjs:mawjs-oracle.1", command: "claude", cwd: "/repo/agents/1" }];
+    gitRoots.set("/repo/agents/1", "/repo/agents/1");
+    gitRemotes.set("/repo/agents/1", "git@github.com:Soul-Brews-Studio/mawjs-oracle.git");
+    gitCommits.set("/repo/agents/1", "a596969b");
+
+    const rows = await captureJson(() => cmdTmuxLs({ all: true, json: true }));
+
+    expect(rows[0].provenance).toEqual({
+      oracle: "mawjs-oracle",
+      machine: "m5",
+      session: "26a2aa25",
+      federation: "m5:mawjs-oracle",
+      org: "Soul-Brews-Studio",
+      repo: "mawjs-oracle",
+      commit: "a596969b",
+      engine: "claude",
+    });
+    expect(rows[0].cwd).toBeUndefined();
+  });
+
+  test("falls back safely when config and git metadata are missing", async () => {
+    config = {};
+    process.env.MAW_SESSION_ID = "env-session";
+
+    expect(await paneProvenance({ target: "scratch:0.0", session: "scratch", command: "zsh" })).toMatchObject({
+      oracle: "scratch-oracle",
+      machine: "host-fallback",
+      session: "env-session",
+      commit: null,
+      engine: "zsh",
+    });
+  });
+});


### PR DESCRIPTION
## Problem (#1991)
`maw ls --json` exposes pane state but not where that state came from.
Fleet consumers cannot reliably attribute panes to oracle, machine, logical session, repository, commit, or engine without running extra commands.

## Root cause
`cmdTmuxLs()` serializes annotated pane rows in `src/commands/plugins/tmux/impl.ts` with window/session fields only.
The code never enriches JSON rows from maw config, pane cwd git metadata, or pane command provenance before writing the JSON payload.

## Fix
Add a null-safe `provenance` object to each pane row in JSON mode with oracle, machine, session, federation, org, repo, commit, and engine fields.
The implementation derives oracle/session from tmux naming plus config, machine from config/env/hostname fallback, repository metadata from pane cwd git state, and engine from the pane command while leaving human output unchanged.

## Tests
`test/ls-json-provenance.test.ts` asserts JSON provenance is derived from config, pane metadata, git remote/HEAD, and remains null-safe outside git.
Targeted isolated tmux ls coverage and `bun run build` verify existing ls behavior and types remain intact.

Closes #1991
