### PR TITLE
feat(cleanup): survey orphan agent worktrees

### DIFF
--- a/src/vendor/mpr-plugins/cleanup/index.ts
+++ b/src/vendor/mpr-plugins/cleanup/index.ts
@@ -25,6 +25,13 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
 
     if (has("--zombie-agents", "--zombies")) {
       await cmdCleanupZombies({ yes: has("--yes", "-y") });
+    } else if (has("--worktrees")) {
+      const { cmdCleanupWorktrees } = await import("./internal/worktrees");
+      const rows = await cmdCleanupWorktrees({
+        yes: has("--yes", "-y"),
+        json: has("--json"),
+      });
+      if (has("--json")) logs.push(JSON.stringify({ ok: true, worktrees: rows }, null, 2));
     } else if (has("--prune-stale")) {
       // Default is dry-run preview; --yes prunes SAFE; --ask walks ASK-FIRST.
       // --dry-run is an explicit alias for the default (helps shell history).
@@ -37,6 +44,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       logs.push("\x1b[36mmaw cleanup\x1b[0m \u2014 Cleanup utilities\n");
       logs.push("  maw cleanup --zombie-agents [--yes]              Find and kill orphan zombie panes");
       logs.push("  maw cleanup --zombies [--yes]                    Alias for --zombie-agents");
+      logs.push("  maw cleanup --worktrees [--yes] [--json]         Survey and safe-remove orphan agent worktrees");
       logs.push("  maw cleanup --prune-stale [--yes|--ask|--dry-run]  Prune dead oracles.json entries\n");
       logs.push("\x1b[90mWithout --yes, only lists candidates without modifying anything.\x1b[0m");
     }

--- a/src/vendor/mpr-plugins/cleanup/internal/worktrees.ts
+++ b/src/vendor/mpr-plugins/cleanup/internal/worktrees.ts
@@ -1,0 +1,196 @@
+import { statSync } from "fs";
+import { isAbsolute, join, relative } from "path";
+import { getGhqRoot } from "maw-js/config/ghq-root";
+import { hostExec, tmux, type TmuxPane } from "maw-js/sdk";
+import { parseWorktreePath } from "../../../../core/fleet/worktree-layout";
+
+export type CleanupWorktreeClass = "KEEP" | "CLEAN" | "ASK" | "SKIP";
+
+export interface CleanupWorktreeRow {
+  path: string;
+  repo: string;
+  mainRepo: string;
+  mainPath: string;
+  name: string;
+  branch: string;
+  classification: CleanupWorktreeClass;
+  reason: string;
+  livePane?: string;
+  removed?: boolean;
+  error?: string;
+}
+
+export interface CleanupWorktreesDeps {
+  hostExec: (command: string) => Promise<string>;
+  listPanes: () => Promise<TmuxPane[]>;
+  getGhqRoot: () => string;
+  statSync: typeof statSync;
+  getUid: () => number | undefined;
+}
+
+export interface CleanupWorktreesOpts {
+  yes?: boolean;
+  json?: boolean;
+  deps?: Partial<CleanupWorktreesDeps>;
+}
+
+function deps(overrides: Partial<CleanupWorktreesDeps> = {}): CleanupWorktreesDeps {
+  return {
+    hostExec: overrides.hostExec ?? hostExec,
+    listPanes: overrides.listPanes ?? (() => tmux.listPanes()),
+    getGhqRoot: overrides.getGhqRoot ?? getGhqRoot,
+    statSync: overrides.statSync ?? statSync,
+    getUid: overrides.getUid ?? (() => process.getuid?.()),
+  };
+}
+
+function shellArg(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function pathIsInside(base: string, child: string): boolean {
+  const rel = relative(base, child);
+  return rel === "" || (rel !== "" && !rel.startsWith("..") && !isAbsolute(rel));
+}
+
+async function findCandidatePaths(d: CleanupWorktreesDeps, reposRoot: string): Promise<string[]> {
+  try {
+    const raw = await d.hostExec(
+      `find ${shellArg(reposRoot)} -maxdepth 4 -type d \\( -name '*.wt-*' -o -path '*/agents/*' \\) 2>/dev/null`,
+    );
+    return [...new Set(raw.split("\n").map(s => s.trim()).filter(Boolean))].sort();
+  } catch {
+    return [];
+  }
+}
+
+async function hasUnpushedCommits(
+  d: CleanupWorktreesDeps,
+  wtPath: string,
+  branch: string,
+): Promise<boolean | "unknown"> {
+  if (!branch || branch === "HEAD" || branch === "unknown") return "unknown";
+  const upstream = `origin/${branch}`;
+  try {
+    await d.hostExec(`git -C ${shellArg(wtPath)} rev-parse --verify --quiet ${shellArg(upstream)}`);
+  } catch {
+    return true;
+  }
+  try {
+    const count = Number((await d.hostExec(
+      `git -C ${shellArg(wtPath)} rev-list --count ${shellArg(`${upstream}..HEAD`)}`,
+    )).trim() || "0");
+    return count > 0;
+  } catch {
+    return "unknown";
+  }
+}
+
+async function classifyPath(
+  d: CleanupWorktreesDeps,
+  reposRoot: string,
+  path: string,
+  livePanes: TmuxPane[],
+): Promise<CleanupWorktreeRow | null> {
+  const parsed = parseWorktreePath(path, reposRoot);
+  if (!parsed) return null;
+
+  const base = {
+    path,
+    repo: parsed.repo,
+    mainRepo: parsed.mainRepo,
+    mainPath: parsed.mainPath,
+    name: parsed.wtName,
+  };
+
+  try {
+    const owner = d.statSync(path).uid;
+    const uid = d.getUid();
+    if (uid !== undefined && owner !== uid) {
+      return { ...base, branch: "", classification: "SKIP", reason: `owned by uid ${owner}` };
+    }
+  } catch (e: any) {
+    return { ...base, branch: "", classification: "ASK", reason: `stat failed: ${e?.message || e}` };
+  }
+
+  const livePane = livePanes.find(p => p.cwd && pathIsInside(path, p.cwd));
+  if (livePane) {
+    return {
+      ...base,
+      branch: "",
+      classification: "KEEP",
+      reason: "live pane cwd is inside worktree",
+      livePane: livePane.target || livePane.id,
+    };
+  }
+
+  let branch = "";
+  try {
+    branch = (await d.hostExec(`git -C ${shellArg(path)} rev-parse --abbrev-ref HEAD`)).trim();
+  } catch {
+    return { ...base, branch: "", classification: "ASK", reason: "not a git worktree" };
+  }
+
+  try {
+    const status = await d.hostExec(`git -C ${shellArg(path)} status --porcelain`);
+    if (status.trim()) {
+      return { ...base, branch, classification: "ASK", reason: "uncommitted changes" };
+    }
+  } catch (e: any) {
+    return { ...base, branch, classification: "ASK", reason: `git status failed: ${e?.message || e}` };
+  }
+
+  const unpushed = await hasUnpushedCommits(d, path, branch);
+  if (unpushed === true) return { ...base, branch, classification: "ASK", reason: "unpushed commits" };
+  if (unpushed === "unknown") return { ...base, branch, classification: "ASK", reason: "upstream unknown" };
+
+  return { ...base, branch, classification: "CLEAN", reason: "no live pane, clean git state" };
+}
+
+export async function surveyCleanupWorktrees(opts: CleanupWorktreesOpts = {}): Promise<CleanupWorktreeRow[]> {
+  const d = deps(opts.deps);
+  const reposRoot = join(d.getGhqRoot(), "github.com");
+  const [paths, panes] = await Promise.all([
+    findCandidatePaths(d, reposRoot),
+    d.listPanes().catch(() => []),
+  ]);
+  const rows = await Promise.all(paths.map(p => classifyPath(d, reposRoot, p, panes)));
+  return rows.filter((row): row is CleanupWorktreeRow => row !== null);
+}
+
+export async function cmdCleanupWorktrees(opts: CleanupWorktreesOpts = {}): Promise<CleanupWorktreeRow[]> {
+  const d = deps(opts.deps);
+  const rows = await surveyCleanupWorktrees({ ...opts, deps: d });
+
+  if (!opts.json) {
+    console.log("\x1b[36mmaw cleanup --worktrees\x1b[0m — orphan worktree survey");
+    if (rows.length === 0) console.log("  \x1b[32m✓\x1b[0m no agent worktrees found");
+    for (const row of rows) {
+      const branch = row.branch || "-";
+      const live = row.livePane ? ` live=${row.livePane}` : "";
+      console.log(
+        `  ${row.classification.padEnd(5)} ${row.name.padEnd(24)} ${branch.padEnd(24)} ${row.reason}${live}`,
+      );
+      console.log(`        \x1b[90m${row.path}\x1b[0m`);
+    }
+  }
+
+  if (!opts.yes) {
+    if (!opts.json) console.log("\nDry-run only. Run with \x1b[36m--yes\x1b[0m to remove CLEAN worktrees.");
+    return rows;
+  }
+
+  for (const row of rows.filter(r => r.classification === "CLEAN")) {
+    try {
+      await d.hostExec(`git -C ${shellArg(row.mainPath)} worktree remove ${shellArg(row.path)} --force`);
+      await d.hostExec(`git -C ${shellArg(row.mainPath)} worktree prune`);
+      row.removed = true;
+      if (!opts.json) console.log(`  \x1b[32m✓\x1b[0m removed ${row.repo}`);
+    } catch (e: any) {
+      row.error = e?.message || String(e);
+      if (!opts.json) console.log(`  \x1b[33m⚠\x1b[0m remove failed for ${row.repo}: ${row.error}`);
+    }
+  }
+
+  return rows;
+}

--- a/src/vendor/mpr-plugins/cleanup/plugin.json
+++ b/src/vendor/mpr-plugins/cleanup/plugin.json
@@ -3,12 +3,12 @@
   "version": "1.1.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "Clean zombie agent panes and prune stale Oracle registry entries.",
+  "description": "Clean zombie agent panes, orphan worktrees, and stale Oracle registry entries.",
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "cleanup",
     "aliases": [],
-    "help": "maw cleanup --zombie-agents [--yes] — kill orphan panes; maw cleanup --prune-stale [--yes|--ask|--dry-run] — prune dead oracles.json entries"
+    "help": "maw cleanup --zombie-agents [--yes] — kill orphan panes; maw cleanup --worktrees [--yes] [--json] — safe-remove orphan worktrees; maw cleanup --prune-stale [--yes|--ask|--dry-run] — prune dead oracles.json entries"
   },
   "weight": 30,
   "license": "MIT",

--- a/test/cleanup-worktrees-classify.test.ts
+++ b/test/cleanup-worktrees-classify.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import {
+  cmdCleanupWorktrees,
+  surveyCleanupWorktrees,
+  type CleanupWorktreesDeps,
+} from "../src/vendor/mpr-plugins/cleanup/internal/worktrees.ts?cleanup-worktrees-classify";
+
+const reposRoot = "/repos/github.com";
+const live = `${reposRoot}/org/repo/agents/1-live`;
+const clean = `${reposRoot}/org/repo/agents/2-clean`;
+const dirty = `${reposRoot}/org/repo/agents/3-dirty`;
+const otherUser = `${reposRoot}/org/repo.wt-4-other`;
+
+function deps(commands: string[] = []): CleanupWorktreesDeps {
+  const paths = [live, clean, dirty, otherUser];
+  return {
+    getGhqRoot: () => "/repos",
+    getUid: () => 501,
+    statSync: ((path: string) => ({ uid: path === otherUser ? 999 : 501 })) as any,
+    listPanes: async () => [{
+      id: "%1",
+      command: "codex",
+      target: "team:live.0",
+      title: "",
+      cwd: `${live}/src`,
+    }],
+    hostExec: async (command: string) => {
+      commands.push(command);
+      if (command.startsWith("find ")) return paths.join("\n");
+      if (command.includes("rev-parse --abbrev-ref HEAD")) {
+        if (command.includes("2-clean")) return "feature/clean\n";
+        if (command.includes("3-dirty")) return "feature/dirty\n";
+        return "feature/live\n";
+      }
+      if (command.includes("status --porcelain")) {
+        return command.includes("3-dirty") ? " M changed.txt\n" : "";
+      }
+      if (command.includes("rev-parse --verify")) return "";
+      if (command.includes("rev-list --count")) return "0\n";
+      if (command.includes("worktree remove") || command.includes("worktree prune")) return "";
+      throw new Error(`unexpected command: ${command}`);
+    },
+  };
+}
+
+describe("cleanup --worktrees survey", () => {
+  test("classifies by pane cwd, git safety, and ownership", async () => {
+    const rows = await surveyCleanupWorktrees({ deps: deps() });
+    const byName = new Map(rows.map(row => [row.name, row]));
+
+    expect(byName.get("1-live")?.classification).toBe("KEEP");
+    expect(byName.get("1-live")?.livePane).toBe("team:live.0");
+    expect(byName.get("2-clean")?.classification).toBe("CLEAN");
+    expect(byName.get("3-dirty")?.classification).toBe("ASK");
+    expect(byName.get("4-other")?.classification).toBe("SKIP");
+  });
+
+  test("--yes removes only CLEAN rows from the main repo", async () => {
+    const commands: string[] = [];
+    const rows = await cmdCleanupWorktrees({ yes: true, deps: deps(commands) });
+
+    expect(rows.find(row => row.name === "2-clean")?.removed).toBe(true);
+    expect(rows.filter(row => row.removed).map(row => row.name)).toEqual(["2-clean"]);
+    expect(commands).toContain(`git -C '${reposRoot}/org/repo' worktree remove '${clean}' --force`);
+    expect(commands).toContain(`git -C '${reposRoot}/org/repo' worktree prune`);
+    expect(commands.join("\n")).not.toContain("3-dirty' --force");
+  });
+});

--- a/test/cleanup-worktrees-handler.test.ts
+++ b/test/cleanup-worktrees-handler.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { resetGhqRootCache } from "../src/config/ghq-root";
+
+const cleanupHandler = (await import("../src/vendor/mpr-plugins/cleanup/index.ts?cleanup-worktrees-handler")).default;
+
+let tempRoot: string | null = null;
+const oldGhq = process.env.GHQ_ROOT;
+
+afterEach(() => {
+  if (tempRoot) rmSync(tempRoot, { recursive: true, force: true });
+  tempRoot = null;
+  if (oldGhq === undefined) delete process.env.GHQ_ROOT;
+  else process.env.GHQ_ROOT = oldGhq;
+  resetGhqRootCache();
+});
+
+describe("cleanup --worktrees handler", () => {
+  test("routes --json through the worktree survey", async () => {
+    tempRoot = mkdtempSync(join(tmpdir(), "maw-cleanup-handler-"));
+    mkdirSync(join(tempRoot, "github.com"), { recursive: true });
+    process.env.GHQ_ROOT = tempRoot;
+    resetGhqRootCache();
+
+    const result = await cleanupHandler({ source: "cli", args: ["--worktrees", "--json"] } as any);
+    const payload = JSON.parse(result.output ?? "{}");
+
+    expect(result.ok).toBe(true);
+    expect(payload).toEqual({ ok: true, worktrees: [] });
+  });
+
+  test("help advertises worktree cleanup", async () => {
+    const result = await cleanupHandler({ source: "cli", args: [] } as any);
+
+    expect(result.output).toContain("maw cleanup --worktrees [--yes] [--json]");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `maw cleanup --worktrees` dry-run survey with KEEP/CLEAN/ASK/SKIP classification
- Detect live panes by `pane_current_path`/cwd containment instead of window slug matching
- Remove only CLEAN rows with `--yes`; support `--json` output

## Safety
- ASK rows cover dirty worktrees, unpushed commits, unknown upstreams, and non-git dirs
- SKIP rows cover worktrees owned by another uid
- No version bump

## Tests
- `bun test test/cleanup-worktrees-classify.test.ts test/cleanup-worktrees-handler.test.ts test/isolated/vendor-indexes-info-cleanup-extra-coverage.test.ts`
- `bun run build`

Closes #1996