### PR TITLE
fix(done): force-remove worktrees with engine scratch

### DIFF
--- a/src/commands/shared/done.ts
+++ b/src/commands/shared/done.ts
@@ -358,6 +358,7 @@ export async function removeWorktreeViaConfig(
         }
         let branch = "";
         try { branch = (await d.hostExec(`git -C '${fullPath}' rev-parse --abbrev-ref HEAD`)).trim(); } catch { /* expected */ }
+        // #1968: force removes ignored engine scratch (for example .omx/) left in finished worktrees.
         await d.hostExec(`git -C '${mainPath}' worktree remove '${fullPath}' --force`);
         await d.hostExec(`git -C '${mainPath}' worktree prune`);
         d.logger.log(`  \x1b[32m✓\x1b[0m removed worktree ${win.repo}`);
@@ -423,6 +424,7 @@ export async function removeWorktreeByGhqScan(
         }
         let branch = "";
         try { branch = (await d.hostExec(`git -C '${wtPath}' rev-parse --abbrev-ref HEAD`)).trim(); } catch { /* expected */ }
+        // #1968: force removes ignored engine scratch (for example .omx/) left in finished worktrees.
         await d.hostExec(`git -C '${mainPath}' worktree remove '${wtPath}' --force`);
         await d.hostExec(`git -C '${mainPath}' worktree prune`);
         d.logger.log(`  \x1b[32m✓\x1b[0m removed worktree ${base}`);

--- a/src/vendor/mpr-plugins/done/done-worktree.ts
+++ b/src/vendor/mpr-plugins/done/done-worktree.ts
@@ -143,6 +143,7 @@ export async function removeWorktreeViaConfig(
         }
         let branch = "";
         try { branch = (await hostExec(`git -C '${fullPath}' rev-parse --abbrev-ref HEAD`)).trim(); } catch { /* expected */ }
+        // #1968: force removes ignored engine scratch (for example .omx/) left in finished worktrees.
         await hostExec(`git -C '${mainPath}' worktree remove '${fullPath}' --force`);
         await hostExec(`git -C '${mainPath}' worktree prune`);
         console.log(`  \x1b[32m✓\x1b[0m removed worktree ${win.repo}`);
@@ -209,6 +210,7 @@ export async function removeWorktreeByGhqScan(
         }
         let branch = "";
         try { branch = (await hostExec(`git -C '${wtPath}' rev-parse --abbrev-ref HEAD`)).trim(); } catch { /* expected */ }
+        // #1968: force removes ignored engine scratch (for example .omx/) left in finished worktrees.
         await hostExec(`git -C '${mainPath}' worktree remove '${wtPath}' --force`);
         await hostExec(`git -C '${mainPath}' worktree prune`);
         console.log(`  \x1b[32m✓\x1b[0m removed worktree ${base}`);

--- a/test/isolated/done-worktree-force-real.test.ts
+++ b/test/isolated/done-worktree-force-real.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { execSync } from "child_process";
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { removeWorktreeViaConfig } from "../../src/commands/shared/done";
+
+const roots: string[] = [];
+
+function sh(command: string, cwd?: string): string {
+  return execSync(command, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+}
+
+function setupRepo() {
+  const root = mkdtempSync(join(tmpdir(), "maw-done-force-"));
+  roots.push(root);
+
+  const reposRoot = join(root, "github.com");
+  const mainPath = join(reposRoot, "Soul-Brews-Studio", "maw-js");
+  const worktreePath = join(mainPath, "agents", "1-codex");
+  mkdirSync(mainPath, { recursive: true });
+
+  sh("git init -q", mainPath);
+  sh("git config user.email test@example.com", mainPath);
+  sh("git config user.name 'Maw Test'", mainPath);
+  writeFileSync(join(mainPath, ".gitignore"), "agents/\n");
+  writeFileSync(join(mainPath, "README.md"), "main\n");
+  sh("git add README.md .gitignore && git commit -q -m init", mainPath);
+  sh("git branch alpha", mainPath);
+  sh("git branch feature/codex", mainPath);
+  sh(`git worktree add -q '${worktreePath}' feature/codex`, mainPath);
+
+  mkdirSync(join(worktreePath, ".omx", "state"), { recursive: true });
+  writeFileSync(join(worktreePath, ".omx", "state", "scratch.json"), "{}\n");
+
+  return { root, reposRoot, mainPath, worktreePath };
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("done worktree forced removal", () => {
+  test("removes a worktree containing engine scratch and then deletes the merged branch", async () => {
+    const { root, reposRoot, mainPath, worktreePath } = setupRepo();
+    const fleetDir = join(root, "fleet");
+    mkdirSync(fleetDir, { recursive: true });
+    writeFileSync(join(fleetDir, "test.json"), JSON.stringify({
+      windows: [{ name: "Codex", repo: "Soul-Brews-Studio/maw-js/agents/1-codex" }],
+    }));
+
+    const commands: string[] = [];
+    const removed = await removeWorktreeViaConfig("codex", reposRoot, {
+      fleetDir,
+      fleetDirs: [fleetDir],
+      branchBase: "alpha",
+      hostExec: async (command) => {
+        commands.push(command);
+        return sh(command);
+      },
+      logger: { log: () => {}, error: () => {} },
+    });
+
+    expect(removed).toBe(true);
+    expect(existsSync(worktreePath)).toBe(false);
+    expect(commands.some(command => /worktree remove .* --force/.test(command))).toBe(true);
+    expect(sh("git branch --list feature/codex", mainPath).trim()).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary\n- document that done worktree cleanup must keep git worktree remove --force for ignored engine scratch like .omx/\n- add a focused real-git regression that removes a nested worktree containing .omx/ scratch\n- verify merged branch cleanup still runs after forced removal\n\nCloses #1968.\n\n## Tests\n- MAW_TEST_MODE=1 bun test test/isolated/done-worktree-force-real.test.ts test/done-command.test.ts --path-ignore-patterns '**/agents/**'\n- MAW_TEST_MODE=1 bun test test/isolated/done-worktree-coverage.test.ts --path-ignore-patterns '**/agents/**'\n\n## Release\n- code fix only; no version bump