### PR TITLE
feat(ls): expose activity classification in JSON (#1992)

### DIFF
--- a/src/commands/plugins/tmux/impl.ts
+++ b/src/commands/plugins/tmux/impl.ts
@@ -216,6 +216,13 @@ export interface TmuxLsOpts {
 }
 
 export type PaneStatus = "frozen" | "active" | "idle" | "stale" | "unknown";
+export type PaneActivity = "busy" | "idle" | "stuck" | "unknown";
+
+export interface PaneActivityJson {
+  activity: PaneActivity;
+  activitySource: "context-limit" | "tmux-window-activity" | "unknown";
+  activityWindow: "30s";
+}
 
 interface AnnotatedPane {
   id: string;
@@ -229,6 +236,26 @@ interface AnnotatedPane {
   sessionCreated?: number;
   sessionActivity?: number;
   source?: string;
+}
+
+export function classifyLsPaneActivity(status: PaneStatus): PaneActivity {
+  if (status === "frozen") return "stuck";
+  if (status === "active") return "busy";
+  if (status === "idle" || status === "stale") return "idle";
+  return "unknown";
+}
+
+export function paneActivityJson(pane: Pick<AnnotatedPane, "status">): PaneActivityJson {
+  const activity = classifyLsPaneActivity(pane.status);
+  return {
+    activity,
+    activitySource: activity === "stuck"
+      ? "context-limit"
+      : activity === "unknown"
+      ? "unknown"
+      : "tmux-window-activity",
+    activityWindow: "30s",
+  };
 }
 
 async function markContextLimitedPanes(panes: AnnotatedPane[]): Promise<void> {
@@ -449,6 +476,7 @@ export async function cmdTmuxLs(opts: TmuxLsOpts = {}): Promise<void> {
   await markContextLimitedPanes(scope);
 
   if (opts.json) {
+    const paneRows = scope.map(pane => ({ ...pane, ...paneActivityJson(pane) }));
     const teamRows = visibleTeams.map(team => ({
       kind: "team",
       id: `team:${team.name}`,
@@ -463,7 +491,7 @@ export async function cmdTmuxLs(opts: TmuxLsOpts = {}): Promise<void> {
       members: team.memberCount,
       configPath: team.configPath,
     }));
-    console.log(JSON.stringify([...scope, ...teamRows], null, 2));
+    console.log(JSON.stringify([...paneRows, ...teamRows], null, 2));
     return;
   }
 

--- a/test/ls-json-activity.test.ts
+++ b/test/ls-json-activity.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { join } from "path";
+
+const srcRoot = join(import.meta.dir, "..");
+
+type Pane = { id: string; target: string; command?: string; title?: string; lastActivity?: number };
+
+let panes: Pane[] = [];
+let captures = new Map<string, string>();
+
+mock.module("os", () => ({ homedir: () => "/mock-home" }));
+
+mock.module(join(srcRoot, "src/sdk"), () => ({
+  tmux: {
+    listPanes: async () => panes,
+    capture: async (target: string) => captures.get(target) ?? "",
+  },
+  tmuxCmd: () => "tmux",
+  hostExec: async () => "",
+}));
+
+mock.module(join(srcRoot, "src/commands/shared/fleet-load"), () => ({
+  loadFleetEntries: () => [{ file: "101-mawjs.json" }],
+}));
+
+mock.module(join(srcRoot, "src/core/fleet/worktrees-scan"), () => ({ scanWorktrees: async () => [] }));
+mock.module(join(srcRoot, "src/core/ghq"), () => ({ ghqList: async () => [], ghqListSync: () => [] }));
+
+const { classifyLsPaneActivity, cmdTmuxLs, paneActivityJson } = await import("../src/commands/plugins/tmux/impl");
+
+const original = { log: console.log, now: Date.now };
+
+async function captureJson(fn: () => Promise<void>) {
+  const logs: string[] = [];
+  console.log = (...args: unknown[]) => logs.push(args.map(String).join(" "));
+  try { await fn(); } finally { console.log = original.log; }
+  return JSON.parse(logs.join("\n"));
+}
+
+beforeEach(() => {
+  panes = [];
+  captures = new Map();
+  Date.now = () => 1_700_000_000_000;
+});
+
+afterEach(() => {
+  Date.now = original.now;
+  console.log = original.log;
+});
+
+describe("maw ls --json activity classification (#1992)", () => {
+  test("maps pane age status to busy, idle, and unknown activity fields", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    panes = [
+      { id: "%1", target: "101-mawjs:main.0", command: "claude", lastActivity: now - 5 },
+      { id: "%2", target: "101-mawjs:main.1", command: "zsh", lastActivity: now - 90 },
+      { id: "%3", target: "101-mawjs:main.2", command: "zsh" },
+    ];
+
+    const rows = await captureJson(() => cmdTmuxLs({ all: true, json: true }));
+
+    expect(rows.map((row: any) => [row.id, row.activity, row.activitySource, row.activityWindow])).toEqual([
+      ["%1", "busy", "tmux-window-activity", "30s"],
+      ["%2", "idle", "tmux-window-activity", "30s"],
+      ["%3", "unknown", "unknown", "30s"],
+    ]);
+  });
+
+  test("classifies context-limited agent panes as stuck", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    panes = [{ id: "%4", target: "101-mawjs:main.3", command: "claude", lastActivity: now - 2 }];
+    captures.set("101-mawjs:main.3", "Context limit reached. /compact or /clear to continue");
+
+    const rows = await captureJson(() => cmdTmuxLs({ all: true, json: true }));
+
+    expect(rows[0]).toMatchObject({ status: "frozen", activity: "stuck", activitySource: "context-limit" });
+  });
+
+  test("exports the pure classifier for API stability", () => {
+    expect(classifyLsPaneActivity("frozen")).toBe("stuck");
+    expect(paneActivityJson({ status: "stale" })).toEqual({
+      activity: "idle",
+      activitySource: "tmux-window-activity",
+      activityWindow: "30s",
+    });
+  });
+});


### PR DESCRIPTION
## Problem (#1992)
`maw ls --json` reports pane status details but does not provide a simple machine-readable activity classification.
Downstream dashboards have to reverse-engineer busy, idle, or stuck state from lower-level fields and cannot share one stable contract.

## Root cause
`cmdTmuxLs()` already annotates panes with status information in `src/commands/plugins/tmux/impl.ts`, including context-limit/frozen state and tmux activity age.
JSON mode serialized those lower-level details without mapping them into a stable `activity` field or documenting the source/window used for the classification.

## Fix
Add `activity`, `activitySource`, and `activityWindow` to each pane row in JSON mode.
The classifier maps context-limit/frozen panes to `stuck`, recent active panes to `busy`, inactive panes to `idle`, and incomplete signals to `unknown`, while preserving human `maw ls` output.

## Tests
`test/ls-json-activity.test.ts` asserts JSON rows classify busy, idle, stuck, and unknown panes and expose the classification source/window.
Targeted tmux ls coverage and `bun run build` verify existing ls paths still compile and behave.

Closes #1992
