### PR TITLE
fix(hey): warn on node-prefixed oracle target mismatch

### DIFF
--- a/src/core/routing.ts
+++ b/src/core/routing.ts
@@ -455,8 +455,8 @@ function uniqueStrings(values: string[]): string[] {
  * window it reached. Intentionally narrow to avoid false positives:
  *   - Only fires for `-oracle`-suffixed intents (operator named a specific
  *     oracle window). Bare session aliases (`mawjs` → `mawjs-oracle`) and
- *     explicit `session:index` / pane forms are exempt — the latter satisfies
- *     the "full-form bypass" escape hatch.
+ *     explicit `session:index` / `peer:session:window` pane forms are exempt
+ *     — the latter satisfies the "full-form bypass" escape hatch.
  *   - No warning when the resolved window's name matches the intent
  *     (modulo a leading `NN-` and case).
  */
@@ -465,10 +465,12 @@ export function detectWindowMismatch(
   resolvedTarget: string,
   sessions: Session[],
 ): string | null {
-  // Explicit tmux address forms are operator-chosen — never second-guess them.
-  if (!query || query.includes(":")) return null;
+  if (!query) return null;
 
-  const qNorm = query.trim().toLowerCase().replace(/^\d+-/, "");
+  const intent = windowMismatchIntent(query);
+  if (!intent) return null;
+
+  const qNorm = intent.toLowerCase().replace(/^\d+-/, "");
   if (!qNorm.endsWith("-oracle")) return null;
 
   const addr = resolvedTarget.match(/^(.+):(\d+)(?:\.\d+)?$/);
@@ -483,9 +485,23 @@ export function detectWindowMismatch(
 
   return (
     `delivered to ${resolvedTarget} (window '${win.name}'), but target was '${query}' — ` +
-    `resolved window is not named '${query.trim()}'; the message may have landed on the ` +
+    `resolved window is not named '${intent}'; the message may have landed on the ` +
     `wrong pane. Use the full 'peer:session:window' form to disambiguate.`
   );
+}
+
+function windowMismatchIntent(query: string): string | null {
+  const trimmed = query.trim();
+  if (!trimmed) return null;
+
+  const parts = trimmed.split(":").filter(Boolean);
+  if (parts.length >= 3) return null; // Full peer:session:window form.
+  if (parts.length === 2) {
+    const targetPart = parts[1]!.trim();
+    if (/^\d+(?:\.\d+)?$/.test(targetPart)) return null; // Explicit session:index(.pane).
+    return targetPart || null;
+  }
+  return trimmed;
 }
 
 /**

--- a/test/routing-window-mismatch.test.ts
+++ b/test/routing-window-mismatch.test.ts
@@ -33,6 +33,14 @@ describe("detectWindowMismatch (#1980)", () => {
   test("explicit session:index form bypasses the check (full-form escape hatch)", () => {
     expect(detectWindowMismatch("mawjs:0", "mawjs:0", SESSIONS)).toBeNull();
     expect(detectWindowMismatch("01-mawjs:1", "01-mawjs:1", SESSIONS)).toBeNull();
+    expect(detectWindowMismatch("oracle-world-oracle:mawjs:0", "mawjs:0", SESSIONS)).toBeNull();
+  });
+
+  test("warns for node-prefixed short-form oracle targets", () => {
+    const warning = detectWindowMismatch("oracle-world-oracle:mawjs-oracle", "mawjs:0", SESSIONS);
+    expect(warning).not.toBeNull();
+    expect(warning).toContain("oracle-world-oracle:mawjs-oracle");
+    expect(warning).toContain("mawjs-oracle");
   });
 
   test("bare session alias resolving to its -oracle window is not flagged", () => {


### PR DESCRIPTION
## Problem

#1980 was already addressed on `alpha` by #1986, but the pure guard still treated every colon-bearing query as an explicit tmux address. That means two-part short forms like:

```bash
maw hey oracle-world-oracle:mawjs-oracle "hello"
```

could skip the mismatch check at call sites that still see the node-prefixed intent, even though only the full `peer:session:window` form should bypass the warning.

## Fix

- Parse the intended oracle-window from two-part `node:oracle-window` / `peer:oracle-window` queries.
- Keep true full forms (`peer:session:window`) and explicit numeric `session:index(.pane)` targets bypassed.
- Keep the warning wording tied to the original query while naming the actual intended oracle window.

## Tests

- `bash scripts/test-default-safe.sh test/routing-window-mismatch.test.ts test/sessions-api-default.test.ts`
- `bun run build`

## Release

Code fix only; no version bump / release cut.

Closes #1980

