### PR TITLE
papercut: attach to resolved oracle window

### DIFF
--- a/src/commands/plugins/tmux/impl.ts
+++ b/src/commands/plugins/tmux/impl.ts
@@ -901,8 +901,8 @@ export interface TmuxAttachOpts {
  * Attach to a tmux session.
  *
  * Branch behavior (issue #962, fix for #395 print-only regression):
- *   - Inside tmux ($TMUX set) + TTY → `tmux switch-client -t <session>`
- *   - Outside tmux + TTY            → `tmux attach -t <session>`
+ *   - Inside tmux ($TMUX set) + TTY → `tmux switch-client -t <target>`
+ *   - Outside tmux + TTY            → `tmux attach -t <target>`
  *   - No TTY (script/pipe/CI)       → fall back to 3-line print (don't break automation)
  *   - Explicit --print              → force print mode regardless of TTY
  *
@@ -914,7 +914,11 @@ export function cmdTmuxAttach(target: string, opts: TmuxAttachOpts = {}): void {
   const hit = resolveTmuxTarget(target);
   if (!hit) throw new Error(`cannot resolve target '${target}'`);
   const { resolved, source } = hit;
-  const session = resolved.split(":")[0] ?? "";
+  // Preserve an explicit window target (`session:window`) so attach lands on
+  // that window instead of tmux's last-active window. Pane targets still attach
+  // at window granularity by stripping only the trailing `.pane` suffix.
+  const attachTarget = resolved.includes(":") ? resolved.replace(/\.\d+$/, "") : resolved;
+  const session = attachTarget.split(":")[0] ?? "";
 
   // Pre-flight: check if resolved session is actually alive. If not, show
   // recovery suggestions instead of printing stale instructions or failing.
@@ -928,17 +932,17 @@ export function cmdTmuxAttach(target: string, opts: TmuxAttachOpts = {}): void {
   const inTmux = !!process.env.TMUX;
 
   const attachArgs = opts.readonly
-    ? ["attach", "-r", "-t", session]
+    ? ["attach", "-r", "-t", attachTarget]
     : inTmux
-    ? ["switch-client", "-t", session]
-    : ["attach", "-t", session];
+    ? ["switch-client", "-t", attachTarget]
+    : ["attach", "-t", attachTarget];
   const printArgs = opts.readonly
-    ? ["attach", "-r", "-t", session]
-    : ["attach", "-t", session];
+    ? ["attach", "-r", "-t", attachTarget]
+    : ["attach", "-t", attachTarget];
 
   if (opts.print || !isTty) {
     console.log(`\x1b[36mRun:\x1b[0m tmux ${printArgs.join(" ")}`);
-    console.log(`\x1b[90m  resolved: ${target} → ${session} [${source}]${opts.readonly ? " (read-only)" : ""}`);
+    console.log(`\x1b[90m  resolved: ${target} → ${attachTarget} [${source}]${opts.readonly ? " (read-only)" : ""}`);
     console.log(`  detach with: Ctrl-b d\x1b[0m`);
     return;
   }

--- a/test/isolated/tmux-action-verbs.test.ts
+++ b/test/isolated/tmux-action-verbs.test.ts
@@ -134,7 +134,7 @@ describe("cmdTmuxAttach — print fallback (no TTY / --print)", () => {
 });
 
 describe("cmdTmuxAttach — TTY exec branches", () => {
-  test("inside tmux + TTY → spawns `tmux switch-client -t <session>`", () => {
+  test("inside tmux + TTY → spawns `tmux switch-client -t <target>`", () => {
     const origTTY = impl._tty.isStdoutTTY;
     impl._tty.isStdoutTTY = () => true;
     const origTmux = process.env.TMUX;
@@ -157,7 +157,7 @@ describe("cmdTmuxAttach — TTY exec branches", () => {
     }
 
     expect(calls).toHaveLength(1);
-    expect(calls[0].args).toEqual(["tmux", "switch-client", "-t", "some-session"]);
+    expect(calls[0].args).toEqual(["tmux", "switch-client", "-t", "some-session:0"]);
     expect(logs.join("\n")).not.toContain("Run: tmux attach -t");
   });
 
@@ -179,7 +179,7 @@ describe("cmdTmuxAttach — TTY exec branches", () => {
     }
 
     expect(calls).toHaveLength(1);
-    expect(calls[0].args).toEqual(["tmux", "attach", "-t", "some-session"]);
+    expect(calls[0].args).toEqual(["tmux", "attach", "-t", "some-session:0"]);
   });
 
   test("readonly attach uses `tmux attach -r` even from inside tmux", () => {
@@ -201,7 +201,7 @@ describe("cmdTmuxAttach — TTY exec branches", () => {
     }
 
     expect(calls).toHaveLength(1);
-    expect(calls[0].args).toEqual(["tmux", "attach", "-r", "-t", "some-session"]);
+    expect(calls[0].args).toEqual(["tmux", "attach", "-r", "-t", "some-session:0"]);
   });
 
   test("dead resolved session → prints recovery and exits non-zero", () => {

--- a/test/isolated/tmux-attach-window-target.test.ts
+++ b/test/isolated/tmux-attach-window-target.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { cmdTmuxAttach, _tty } from "../../src/commands/plugins/tmux/impl";
+
+const OLD_TMUX = process.env.TMUX;
+const OLD_TTY = _tty.isStdoutTTY;
+
+const encode = (text: string) => new TextEncoder().encode(text);
+const spawnOk = (stdout = "") => ({ exitCode: 0, stdout: encode(stdout), stderr: new Uint8Array(), success: true });
+
+afterEach(() => {
+  if (OLD_TMUX === undefined) delete process.env.TMUX;
+  else process.env.TMUX = OLD_TMUX;
+  _tty.isStdoutTTY = OLD_TTY;
+});
+
+function withMockTmux(aliveSessions: string[], fn: (calls: any[]) => void) {
+  const origSpawnSync = Bun.spawnSync;
+  const calls: any[] = [];
+  (Bun as any).spawnSync = ((args: any, opts: any) => {
+    if (Array.isArray(args) && args[0] === "tmux" && args[1] === "list-sessions") {
+      return spawnOk(aliveSessions.length ? `${aliveSessions.join("\n")}\n` : "");
+    }
+    calls.push({ args, opts });
+    return spawnOk();
+  }) as any;
+  try {
+    fn(calls);
+  } finally {
+    (Bun as any).spawnSync = origSpawnSync;
+  }
+}
+
+describe("cmdTmuxAttach window target preservation (#1982)", () => {
+  test("inside tmux switches to session:window instead of bare session", () => {
+    _tty.isStdoutTTY = () => true;
+    process.env.TMUX = "/tmp/tmux-1000/default,1234,0";
+
+    withMockTmux(["01-yd-patient-flow"], (calls) => {
+      cmdTmuxAttach("01-yd-patient-flow:yd-patient-flow-oracle");
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0].args).toEqual([
+        "tmux",
+        "switch-client",
+        "-t",
+        "01-yd-patient-flow:yd-patient-flow-oracle",
+      ]);
+    });
+  });
+
+  test("print mode shows the preserved session:window attach command", () => {
+    _tty.isStdoutTTY = () => false;
+    delete process.env.TMUX;
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => logs.push(args.map(String).join(" "));
+    try {
+      withMockTmux(["01-yd-patient-flow"], (calls) => {
+        cmdTmuxAttach("01-yd-patient-flow:yd-patient-flow-oracle", { print: true });
+
+        expect(calls).toEqual([]);
+      });
+    } finally {
+      console.log = origLog;
+    }
+
+    expect(logs.join("\n")).toContain("tmux attach -t 01-yd-patient-flow:yd-patient-flow-oracle");
+    expect(logs.join("\n")).toContain("resolved: 01-yd-patient-flow:yd-patient-flow-oracle → 01-yd-patient-flow:yd-patient-flow-oracle");
+  });
+});


### PR DESCRIPTION
## Summary
- keep `session:window` targets intact inside `cmdTmuxAttach` so `maw attach` lands on the resolved oracle window, not the last-active tmux window
- strip only trailing `.pane` suffixes so pane targets attach at window granularity
- add focused regression coverage for #1982 and update attach command expectations

## Tests
- `bash scripts/test-isolated.sh test/isolated/tmux-action-verbs.test.ts test/isolated/tmux-attach-window-target.test.ts test/isolated/attach-impl-coverage.test.ts test/isolated/attach-prefer-oracle-window.test.ts`

Fixes #1982
