### PR TITLE
fix(done): fail on missing teardown targets

### DIFF
--- a/src/commands/shared/done.ts
+++ b/src/commands/shared/done.ts
@@ -167,6 +167,17 @@ export async function cleanupDoneBranch(
   }
 }
 
+function missingDoneTargetMessage(windowName: string): string {
+  const hint = windowName.toLowerCase() === "all" ? "\n  did you mean `maw done --all`?" : "";
+  return `no done target matched '${windowName}'${hint}`;
+}
+
+function failMissingDoneTarget(windowName: string, d: ResolvedDoneDeps): never {
+  const message = missingDoneTargetMessage(windowName);
+  d.logger.error(`  \x1b[31m✗\x1b[0m ${message}`);
+  throw new Error(message);
+}
+
 function activeFleetConfigFiles(d: ResolvedDoneDeps): Array<{ file: string; path: string }> {
   const filesByName = new Map<string, { file: string; path: string }>();
   const dirs = uniqueDirs(d.fleetDirs?.length ? d.fleetDirs : [d.fleetDir]);
@@ -236,7 +247,9 @@ export async function cmdDone(windowName_: string, opts: DoneOpts = {}, deps: Do
     d.logger.log(`  \x1b[90m○\x1b[0m no worktree to remove (may be a main window)`);
   }
 
+  const matchedWindow = sessionName !== null && windowIndex !== null;
   if (opts.dryRun) {
+    if (!matchedWindow && !removedWorktree) failMissingDoneTarget(windowName, d);
     d.logger.log(`  \x1b[36m⬡\x1b[0m [dry-run] would remove '${windowNameLower}' from fleet config if present`);
     d.logger.log();
     return;
@@ -246,6 +259,7 @@ export async function cmdDone(windowName_: string, opts: DoneOpts = {}, deps: Do
   if (!removedFromConfig) {
     d.logger.log(`  \x1b[90m○\x1b[0m not in any fleet config`);
   }
+  if (!matchedWindow && !removedWorktree && !removedFromConfig) failMissingDoneTarget(windowName, d);
 
   d.takeSnapshot("done").catch(() => {});
   d.logger.log();

--- a/src/vendor/mpr-plugins/done/impl.ts
+++ b/src/vendor/mpr-plugins/done/impl.ts
@@ -46,6 +46,17 @@ function nonLeadWindows(session: DoneSession): DoneWindow[] {
     .sort((a, b) => a.index - b.index);
 }
 
+function missingDoneTargetMessage(windowName: string): string {
+  const hint = windowName.toLowerCase() === "all" ? "\n  did you mean `maw done --all`?" : "";
+  return `no done target matched '${windowName}'${hint}`;
+}
+
+function failMissingDoneTarget(windowName: string): never {
+  const message = missingDoneTargetMessage(windowName);
+  console.error(`  \x1b[31m✗\x1b[0m ${message}`);
+  throw new Error(message);
+}
+
 /**
  * maw done <window-name> [--force] [--dry-run] [--clean-branch]
  *
@@ -106,7 +117,9 @@ export async function cmdDone(windowName_: string, opts: DoneOpts = {}) {
     console.log(`  \x1b[90m○\x1b[0m no worktree to remove (may be a main window)`);
   }
 
+  const matchedWindow = sessionName !== null && windowIndex !== null;
   if (opts.dryRun) {
+    if (!matchedWindow && !removedWorktree) failMissingDoneTarget(windowName);
     console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would remove '${windowNameLower}' from fleet config if present`);
     console.log();
     return;
@@ -117,6 +130,7 @@ export async function cmdDone(windowName_: string, opts: DoneOpts = {}) {
   if (!removedFromConfig) {
     console.log(`  \x1b[90m○\x1b[0m not in any fleet config`);
   }
+  if (!matchedWindow && !removedWorktree && !removedFromConfig) failMissingDoneTarget(windowName);
 
   // Snapshot after done
   takeSnapshot("done").catch(() => {});

--- a/src/vendor/mpr-plugins/done/index.ts
+++ b/src/vendor/mpr-plugins/done/index.ts
@@ -33,6 +33,14 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       dryRun = args.includes("--dry-run");
       all = args.includes("--all");
       cleanBranch = args.includes("--clean-branch");
+      if (all && positional.length > 0) {
+        return { ok: false, error: `unexpected positional arg(s) with maw done --all: ${positional.join(" ")}\n  usage: maw done --all [--force] [--dry-run] [--clean-branch]` };
+      }
+      if (!all && positional.length > 1) {
+        const ignored = positional.slice(1).join(" ");
+        const hint = positional[0]?.toLowerCase() === "all" ? "\n  did you mean `maw done --all`?" : "";
+        return { ok: false, error: `unexpected extra positional arg(s) for maw done: ${ignored}${hint}\n  usage: maw done <window-name> [--force] [--dry-run] [--clean-branch] or maw done --all [--force] [--dry-run] [--clean-branch]` };
+      }
       name = positional[0];
     } else {
       const args = ctx.args as Record<string, unknown>;

--- a/test/isolated/done-all.test.ts
+++ b/test/isolated/done-all.test.ts
@@ -207,7 +207,7 @@ describe("cmdDoneAll", () => {
     expect(tmuxCommands).toContain("kill work:alpha");
 
     const { cmdDone } = await import("../../src/vendor/mpr-plugins/done/impl");
-    await cmdDone("missing-window", { dryRun: true });
+    await expect(cmdDone("missing-window", { dryRun: true })).rejects.toThrow("no done target matched 'missing-window'");
     expect(autoSaveCalls.map(c => c.windowName)).not.toContain("missing-window");
   });
 

--- a/test/isolated/done-index-coverage.test.ts
+++ b/test/isolated/done-index-coverage.test.ts
@@ -74,6 +74,29 @@ describe("done plugin index wrapper", () => {
     expect(doneCalls).toEqual([{ name: "tile-2", opts: { force: true, dryRun: false, cleanBranch: true, cwd: process.cwd() } }]);
   });
 
+
+  test("rejects ambiguous CLI positional args before invoking teardown", async () => {
+    const typo = await donePlugin.default({
+      source: "cli",
+      args: ["all", "33-arraoraclev3", "--dry-run"],
+    } as InvokeCtx);
+
+    expect(typo.ok).toBe(false);
+    expect(typo.error).toContain("unexpected extra positional");
+    expect(typo.error).toContain("33-arraoraclev3");
+    expect(typo.error).toContain("did you mean `maw done --all`");
+
+    const allWithTarget = await donePlugin.default({
+      source: "cli",
+      args: ["--all", "33-arraoraclev3"],
+    } as InvokeCtx);
+
+    expect(allWithTarget.ok).toBe(false);
+    expect(allWithTarget.error).toContain("unexpected positional arg(s) with maw done --all");
+    expect(doneCalls).toEqual([]);
+    expect(doneAllCalls).toEqual([]);
+  });
+
   test("returns usage for missing API name without calling implementation", async () => {
     const result = await donePlugin.default({ source: "api", args: {} } as InvokeCtx);
 

--- a/test/isolated/done-missing-target-shared.test.ts
+++ b/test/isolated/done-missing-target-shared.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { cmdDone, type DoneDeps } from "../../src/commands/shared/done";
+
+function deps() {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  const commands: string[] = [];
+  const snapshots: string[] = [];
+  const d: DoneDeps = {
+    listSessions: async () => [{ name: "work", windows: [{ index: 0, name: "lead", active: true }] }],
+    ghqRoot: "/repos",
+    fleetDir: "/fleet",
+    fleetDirs: ["/fleet"],
+    fs: {
+      readdirSync: () => [],
+      readFileSync: () => { throw new Error("no file"); },
+      writeFileSync: () => {},
+      mkdirSync: () => {},
+      appendFileSync: () => {},
+    },
+    hostExec: async (command) => {
+      commands.push(command);
+      if (command.startsWith("find ")) return "";
+      throw new Error(`unexpected command: ${command}`);
+    },
+    tmux: {
+      killWindow: async () => { throw new Error("should not kill"); },
+      sendText: async () => { throw new Error("should not send"); },
+    },
+    takeSnapshot: async (trigger) => { snapshots.push(trigger); },
+    logger: {
+      log: (...args: unknown[]) => logs.push(args.map(String).join(" ")),
+      error: (...args: unknown[]) => errors.push(args.map(String).join(" ")),
+    },
+  };
+  return { d, logs, errors, commands, snapshots };
+}
+
+describe("done missing target safety", () => {
+  test("fails non-zero semantics for missing windows with no worktree match", async () => {
+    const h = deps();
+
+    await expect(cmdDone("missing-window", { dryRun: true }, h.d))
+      .rejects.toThrow("no done target matched 'missing-window'");
+
+    expect(h.logs.join("\n")).toContain("window 'missing-window' not running");
+    expect(h.logs.join("\n")).toContain("no worktree to remove");
+    expect(h.errors.join("\n")).toContain("no done target matched 'missing-window'");
+    expect(h.snapshots).toEqual([]);
+  });
+
+  test("adds a --all hint only after confirming literal all was not a target", async () => {
+    const h = deps();
+
+    await expect(cmdDone("all", { force: true }, h.d))
+      .rejects.toThrow("did you mean `maw done --all`");
+
+    expect(h.commands).toEqual(["find '/repos/github.com' -maxdepth 4 -type d \\( -name '*.wt-*' -o -path '*/agents/*' \\) 2>/dev/null"]);
+    expect(h.snapshots).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary\n- make maw done fail when a named target matches no running window, worktree, or fleet config entry\n- reject extra positional args before teardown starts\n- add a literal all hint after confirming it was not a real target\n\nCloses #1969.\n\n## Tests\n- MAW_TEST_MODE=1 bun test test/isolated/done-missing-target-shared.test.ts --path-ignore-patterns '**/agents/**'\n- MAW_TEST_MODE=1 bun test test/isolated/done-index-coverage.test.ts --path-ignore-patterns '**/agents/**'\n- MAW_TEST_MODE=1 bun test test/isolated/done-all.test.ts --path-ignore-patterns '**/agents/**'\n- MAW_TEST_MODE=1 bun test test/done-command.test.ts --path-ignore-patterns '**/agents/**'\n\nNote: done-index and done-all were run separately because their isolated Bun mocks contaminate each other when combined in one process.\n\n## Release\n- code fix only; no version bump