### PR TITLE
fix(done): recover orphan worktree dirs

### DIFF
--- a/src/commands/shared/done.ts
+++ b/src/commands/shared/done.ts
@@ -1,4 +1,4 @@
-import { basename, join } from "path";
+import { basename, dirname, join } from "path";
 import { parseWorktreePath } from "../../core/fleet/worktree-layout";
 import { appendFileSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "fs";
 import { homedir } from "os";
@@ -80,6 +80,57 @@ type ResolvedDoneDeps = ReturnType<typeof doneDeps>;
 
 function shellArg(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function isNotWorkingTreeError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /not a working tree/i.test(message);
+}
+
+function archivePathFor(wtPath: string, d: ResolvedDoneDeps): string {
+  const stamp = d.now().toISOString().replace(/[^0-9A-Za-z_.-]/g, "-");
+  const safeBase = basename(wtPath).replace(/[^0-9A-Za-z_.-]/g, "-");
+  return `/tmp/maw-done-orphan-worktrees/${safeBase}-${stamp}`;
+}
+
+async function dirExists(path: string, d: ResolvedDoneDeps): Promise<boolean> {
+  try {
+    await d.hostExec(`test -d ${shellArg(path)}`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function movePrunedWorktreeDir(wtPath: string, mainPath: string, d: ResolvedDoneDeps): Promise<boolean> {
+  if (!(await dirExists(wtPath, d))) return false;
+  const archived = archivePathFor(wtPath, d);
+  try {
+    await d.hostExec(`mkdir -p ${shellArg(dirname(archived))}`);
+    await d.hostExec(`mv ${shellArg(wtPath)} ${shellArg(archived)}`);
+    await d.hostExec(`git -C ${shellArg(mainPath)} worktree prune`);
+    d.logger.log(`  \x1b[32m✓\x1b[0m moved orphan directory ${basename(wtPath)} to ${archived}`);
+    return true;
+  } catch (e: any) {
+    d.logger.log(`  \x1b[33m⚠\x1b[0m orphan directory move failed: ${e?.message || e}`);
+    return false;
+  }
+}
+
+async function findMatchingWorktreePaths(
+  windowName: string,
+  reposRoot: string,
+  d: ResolvedDoneDeps,
+): Promise<string[]> {
+  const suffix = windowName.replace(/^[^-]+-/, "");
+  const ghqOut = await d.hostExec(`find ${shellArg(reposRoot)} -maxdepth 4 -type d \\( -name '*.wt-*' -o -path '*/agents/*' \\) 2>/dev/null`);
+  const allWtPaths = ghqOut.trim().split("\n").filter(Boolean);
+  return allWtPaths.filter(p => {
+    const parsed = parseWorktreePath(p, reposRoot);
+    if (!parsed) return false;
+    const wtSuffix = parsed.wtName.replace(/^\d+-/, "");
+    return wtSuffix.toLowerCase() === suffix.toLowerCase();
+  });
 }
 
 async function cwdMainPath(cwd: string | undefined, reposRoot: string, d: ResolvedDoneDeps): Promise<string | null> {
@@ -245,6 +296,8 @@ export async function cmdDone(windowName_: string, opts: DoneOpts = {}, deps: Do
   }
   if (!removedWorktree) {
     d.logger.log(`  \x1b[90m○\x1b[0m no worktree to remove (may be a main window)`);
+  } else if (!opts.dryRun && opts.cwd) {
+    await warnRemainingWorktrees(windowName, reposRoot, deps);
   }
 
   const matchedWindow = sessionName !== null && windowIndex !== null;
@@ -373,14 +426,17 @@ export async function removeWorktreeViaConfig(
         let branch = "";
         try { branch = (await d.hostExec(`git -C '${fullPath}' rev-parse --abbrev-ref HEAD`)).trim(); } catch { /* expected */ }
         // #1968: force removes ignored engine scratch (for example .omx/) left in finished worktrees.
-        await d.hostExec(`git -C '${mainPath}' worktree remove '${fullPath}' --force`);
-        await d.hostExec(`git -C '${mainPath}' worktree prune`);
+        await d.hostExec(`git -C ${shellArg(mainPath)} worktree remove ${shellArg(fullPath)} --force`);
+        await d.hostExec(`git -C ${shellArg(mainPath)} worktree prune`);
         d.logger.log(`  \x1b[32m✓\x1b[0m removed worktree ${win.repo}`);
         if (branch && branch !== "main" && branch !== "HEAD") {
           await cleanupDoneBranch(mainPath, branch, opts, deps);
         }
         return true;
       } catch (e: any) {
+        if (isNotWorkingTreeError(e) && await movePrunedWorktreeDir(fullPath, mainPath, d)) {
+          return true;
+        }
         d.logger.log(`  \x1b[33m⚠\x1b[0m worktree remove failed: ${e.message || e}`);
       }
       break;
@@ -399,15 +455,7 @@ export async function removeWorktreeByGhqScan(
   let removed = false;
   try {
     const suffix = windowName.replace(/^[^-]+-/, "");
-    const safeRoot = reposRoot.replace(/'/g, "'\''");
-    const ghqOut = await d.hostExec(`find '${safeRoot}' -maxdepth 4 -type d \\( -name '*.wt-*' -o -path '*/agents/*' \\) 2>/dev/null`);
-    const allWtPaths = ghqOut.trim().split("\n").filter(Boolean);
-    const exactMatch = allWtPaths.filter(p => {
-      const parsed = parseWorktreePath(p, reposRoot);
-      if (!parsed) return false;
-      const wtSuffix = parsed.wtName.replace(/^\d+-/, "");
-      return wtSuffix.toLowerCase() === suffix.toLowerCase();
-    });
+    const exactMatch = await findMatchingWorktreePaths(windowName, reposRoot, d);
     let matches = exactMatch;
     if (matches.length > 1) {
       const mainPath = await cwdMainPath(opts.cwd, reposRoot, d);
@@ -439,17 +487,44 @@ export async function removeWorktreeByGhqScan(
         let branch = "";
         try { branch = (await d.hostExec(`git -C '${wtPath}' rev-parse --abbrev-ref HEAD`)).trim(); } catch { /* expected */ }
         // #1968: force removes ignored engine scratch (for example .omx/) left in finished worktrees.
-        await d.hostExec(`git -C '${mainPath}' worktree remove '${wtPath}' --force`);
-        await d.hostExec(`git -C '${mainPath}' worktree prune`);
+        await d.hostExec(`git -C ${shellArg(mainPath)} worktree remove ${shellArg(wtPath)} --force`);
+        await d.hostExec(`git -C ${shellArg(mainPath)} worktree prune`);
         d.logger.log(`  \x1b[32m✓\x1b[0m removed worktree ${base}`);
         removed = true;
         if (branch && branch !== "main" && branch !== "HEAD") {
           await cleanupDoneBranch(mainPath, branch, opts, deps);
         }
-      } catch (e) { d.logger.error(`  \x1b[33m⚠\x1b[0m worktree remove failed: ${e}`); }
+      } catch (e) {
+        if (isNotWorkingTreeError(e) && await movePrunedWorktreeDir(wtPath, mainPath, d)) {
+          removed = true;
+          continue;
+        }
+        d.logger.error(`  \x1b[33m⚠\x1b[0m worktree remove failed: ${e}`);
+      }
     }
   } catch (e) { d.logger.error(`  \x1b[33m⚠\x1b[0m worktree scan failed: ${e}`); }
   return removed;
+}
+
+export async function warnRemainingWorktrees(
+  windowName: string,
+  reposRoot: string,
+  deps: DoneDeps = {},
+): Promise<string[]> {
+  const d = doneDeps(deps);
+  let matches: string[] = [];
+  try {
+    matches = await findMatchingWorktreePaths(windowName, reposRoot, d);
+  } catch (e: any) {
+    d.logger.log(`  \x1b[33m⚠\x1b[0m cross-repo worktree scan failed: ${e?.message || e}`);
+    return [];
+  }
+  if (matches.length === 0) return [];
+
+  d.logger.log(`  \x1b[33m⚠\x1b[0m ${matches.length} same-member worktree(s) still exist in other repo(s):`);
+  for (const match of matches) d.logger.log(`  \x1b[90m    • ${match}\x1b[0m`);
+  d.logger.log(`  \x1b[90m  inspect them or run maw cleanup --worktrees before respawning\x1b[0m`);
+  return matches;
 }
 
 export function removeFromFleetConfig(windowNameLower: string, deps: DoneDeps = {}): boolean {

--- a/src/vendor/mpr-plugins/done/done-worktree.ts
+++ b/src/vendor/mpr-plugins/done/done-worktree.ts
@@ -1,6 +1,6 @@
 import { hostExec } from "maw-js/sdk";
 import { readdirSync, readFileSync, writeFileSync } from "fs";
-import { join } from "path";
+import { basename, dirname, join } from "path";
 import { fleetDirsForRead } from "maw-js/commands/shared/fleet-load";
 import { parseWorktreePath } from "maw-js/core/fleet/worktree-layout";
 
@@ -29,6 +29,53 @@ function activeFleetConfigFiles(): Array<{ file: string; path: string }> {
 
 function shellArg(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function isNotWorkingTreeError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /not a working tree/i.test(message);
+}
+
+function archivePathFor(wtPath: string): string {
+  const stamp = new Date().toISOString().replace(/[^0-9A-Za-z_.-]/g, "-");
+  const safeBase = basename(wtPath).replace(/[^0-9A-Za-z_.-]/g, "-");
+  return `/tmp/maw-done-orphan-worktrees/${safeBase}-${stamp}`;
+}
+
+async function dirExists(path: string): Promise<boolean> {
+  try {
+    await hostExec(`test -d ${shellArg(path)}`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function movePrunedWorktreeDir(wtPath: string, mainPath: string): Promise<boolean> {
+  if (!(await dirExists(wtPath))) return false;
+  const archived = archivePathFor(wtPath);
+  try {
+    await hostExec(`mkdir -p ${shellArg(dirname(archived))}`);
+    await hostExec(`mv ${shellArg(wtPath)} ${shellArg(archived)}`);
+    await hostExec(`git -C ${shellArg(mainPath)} worktree prune`);
+    console.log(`  \x1b[32m✓\x1b[0m moved orphan directory ${basename(wtPath)} to ${archived}`);
+    return true;
+  } catch (e: any) {
+    console.log(`  \x1b[33m⚠\x1b[0m orphan directory move failed: ${e?.message || e}`);
+    return false;
+  }
+}
+
+async function findMatchingWorktreePaths(windowName: string, reposRoot: string): Promise<string[]> {
+  const suffix = windowName.replace(/^[^-]+-/, "");
+  const ghqOut = await hostExec(`find ${shellArg(reposRoot)} -maxdepth 4 -type d \\( -name '*.wt-*' -o -path '*/agents/*' \\) 2>/dev/null`);
+  const allWtPaths = ghqOut.trim().split("\n").filter(Boolean);
+  return allWtPaths.filter(p => {
+    const parsed = parseWorktreePath(p, reposRoot);
+    if (!parsed) return false;
+    const wtSuffix = parsed.wtName.replace(/^\d+-/, "");
+    return wtSuffix.toLowerCase() === suffix.toLowerCase();
+  });
 }
 
 async function cwdMainPath(cwd: string | undefined, reposRoot: string): Promise<string | null> {
@@ -144,12 +191,15 @@ export async function removeWorktreeViaConfig(
         let branch = "";
         try { branch = (await hostExec(`git -C '${fullPath}' rev-parse --abbrev-ref HEAD`)).trim(); } catch { /* expected */ }
         // #1968: force removes ignored engine scratch (for example .omx/) left in finished worktrees.
-        await hostExec(`git -C '${mainPath}' worktree remove '${fullPath}' --force`);
-        await hostExec(`git -C '${mainPath}' worktree prune`);
+        await hostExec(`git -C ${shellArg(mainPath)} worktree remove ${shellArg(fullPath)} --force`);
+        await hostExec(`git -C ${shellArg(mainPath)} worktree prune`);
         console.log(`  \x1b[32m✓\x1b[0m removed worktree ${win.repo}`);
         await cleanupDoneBranch(mainPath, branch, opts);
         return true;
       } catch (e: any) {
+        if (isNotWorkingTreeError(e) && await movePrunedWorktreeDir(fullPath, mainPath)) {
+          return true;
+        }
         console.log(`  \x1b[33m⚠\x1b[0m worktree remove failed: ${e.message || e}`);
       }
       break;
@@ -171,15 +221,7 @@ export async function removeWorktreeByGhqScan(
   let removed = false;
   try {
     const suffix = windowName.replace(/^[^-]+-/, ""); // e.g. "mother-schedule" → "schedule"
-    const safeRoot = reposRoot.replace(/'/g, "'\''");
-    const ghqOut = await hostExec(`find '${safeRoot}' -maxdepth 4 -type d \\( -name '*.wt-*' -o -path '*/agents/*' \\) 2>/dev/null`);
-    const allWtPaths = ghqOut.trim().split("\n").filter(Boolean);
-    const exactMatch = allWtPaths.filter(p => {
-      const parsed = parseWorktreePath(p, reposRoot);
-      if (!parsed) return false;
-      const wtSuffix = parsed.wtName.replace(/^\d+-/, "");
-      return wtSuffix.toLowerCase() === suffix.toLowerCase();
-    });
+    const exactMatch = await findMatchingWorktreePaths(windowName, reposRoot);
     let matches = exactMatch;
     if (matches.length > 1) {
       const mainPath = await cwdMainPath(opts.cwd, reposRoot);
@@ -211,15 +253,37 @@ export async function removeWorktreeByGhqScan(
         let branch = "";
         try { branch = (await hostExec(`git -C '${wtPath}' rev-parse --abbrev-ref HEAD`)).trim(); } catch { /* expected */ }
         // #1968: force removes ignored engine scratch (for example .omx/) left in finished worktrees.
-        await hostExec(`git -C '${mainPath}' worktree remove '${wtPath}' --force`);
-        await hostExec(`git -C '${mainPath}' worktree prune`);
+        await hostExec(`git -C ${shellArg(mainPath)} worktree remove ${shellArg(wtPath)} --force`);
+        await hostExec(`git -C ${shellArg(mainPath)} worktree prune`);
         console.log(`  \x1b[32m✓\x1b[0m removed worktree ${base}`);
         removed = true;
         await cleanupDoneBranch(mainPath, branch, opts);
-      } catch (e) { console.error(`  \x1b[33m⚠\x1b[0m worktree remove failed: ${e}`); }
+      } catch (e) {
+        if (isNotWorkingTreeError(e) && await movePrunedWorktreeDir(wtPath, mainPath)) {
+          removed = true;
+          continue;
+        }
+        console.error(`  \x1b[33m⚠\x1b[0m worktree remove failed: ${e}`);
+      }
     }
   } catch (e) { console.error(`  \x1b[33m⚠\x1b[0m worktree scan failed: ${e}`); }
   return removed;
+}
+
+export async function warnRemainingWorktrees(windowName: string, reposRoot: string): Promise<string[]> {
+  let matches: string[] = [];
+  try {
+    matches = await findMatchingWorktreePaths(windowName, reposRoot);
+  } catch (e: any) {
+    console.log(`  \x1b[33m⚠\x1b[0m cross-repo worktree scan failed: ${e?.message || e}`);
+    return [];
+  }
+  if (matches.length === 0) return [];
+
+  console.log(`  \x1b[33m⚠\x1b[0m ${matches.length} same-member worktree(s) still exist in other repo(s):`);
+  for (const match of matches) console.log(`  \x1b[90m    • ${match}\x1b[0m`);
+  console.log(`  \x1b[90m  inspect them or run maw cleanup --worktrees before respawning\x1b[0m`);
+  return matches;
 }
 
 /** Remove a window entry from all fleet config JSON files. Returns true if any file was updated. */

--- a/src/vendor/mpr-plugins/done/impl.ts
+++ b/src/vendor/mpr-plugins/done/impl.ts
@@ -5,7 +5,7 @@ import { takeSnapshot } from "maw-js/sdk";
 import { tmux } from "maw-js/sdk";
 import { normalizeTarget } from "maw-js/core/matcher/normalize-target";
 import { signalParentInbox, autoSave } from "./done-autosave";
-import { removeWorktreeViaConfig, removeWorktreeByGhqScan, removeFromFleetConfig } from "./done-worktree";
+import { removeWorktreeViaConfig, removeWorktreeByGhqScan, removeFromFleetConfig, warnRemainingWorktrees } from "./done-worktree";
 
 export interface DoneOpts {
   force?: boolean;
@@ -115,6 +115,8 @@ export async function cmdDone(windowName_: string, opts: DoneOpts = {}) {
   }
   if (!removedWorktree) {
     console.log(`  \x1b[90m○\x1b[0m no worktree to remove (may be a main window)`);
+  } else if (!opts.dryRun && opts.cwd) {
+    await warnRemainingWorktrees(windowName, reposRoot);
   }
 
   const matchedWindow = sessionName !== null && windowIndex !== null;

--- a/test/isolated/coverage-100b-vendor-c-core.test.ts
+++ b/test/isolated/coverage-100b-vendor-c-core.test.ts
@@ -53,6 +53,7 @@ mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/done/done-worktree
   removeWorktreeViaConfig: async () => false,
   removeWorktreeByGhqScan: async () => false,
   removeFromFleetConfig: () => false,
+  warnRemainingWorktrees: async () => [],
 }));
 mock.module("maw-js/plugin/lifecycle", () => ({ runSleepLifecycleHooks: async () => undefined, runWakeLifecycleHooks: async () => undefined }));
 mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/sleep/resolve-target.ts"), () => ({

--- a/test/isolated/done-all.test.ts
+++ b/test/isolated/done-all.test.ts
@@ -72,6 +72,7 @@ mock.module(join(import.meta.dir, "../../src/vendor/mpr-plugins/done/done-worktr
     removedFleetEntries.push(windowNameLower);
     return false;
   },
+  warnRemainingWorktrees: async () => [],
 }));
 
 const { cmdDoneAll } = await import("../../src/vendor/mpr-plugins/done/impl");

--- a/test/isolated/done-orphan-worktree.test.ts
+++ b/test/isolated/done-orphan-worktree.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "path";
+import { cmdDone, type DoneDeps } from "../../src/commands/shared/done";
+
+const reposRoot = "/repos/github.com";
+const main = `${reposRoot}/org/repo`;
+const primary = `${main}/agents/1-codex`;
+const other = `${reposRoot}/org/engine/agents/1-codex`;
+
+function harness(hostExec: (command: string) => string | Promise<string>) {
+  const logs: string[] = [];
+  const commands: string[] = [];
+  const files = new Map<string, string>([[
+    "/fleet/team.json",
+    JSON.stringify({ windows: [{ name: "mawjs-codex", repo: "org/repo/agents/1-codex" }] }),
+  ]]);
+  const deps: DoneDeps = {
+    listSessions: async () => [],
+    ghqRoot: "/repos",
+    fleetDir: "/fleet",
+    now: () => new Date("2026-06-06T01:02:03.004Z"),
+    hostExec: async (command) => {
+      commands.push(command);
+      return await hostExec(command);
+    },
+    fs: {
+      readdirSync: () => ["team.json"],
+      readFileSync: (path: string) => files.get(path) ?? "{}",
+      writeFileSync: (path: string, data: string) => files.set(path, data),
+    },
+    logger: {
+      log: (...args: unknown[]) => logs.push(args.map(String).join(" ")),
+      error: (...args: unknown[]) => logs.push(args.map(String).join(" ")),
+    },
+    takeSnapshot: async () => undefined,
+  };
+  return { deps, logs, commands, files };
+}
+
+describe("maw done orphan worktree cleanup", () => {
+  test("moves an already-pruned configured directory instead of reporting no worktree", async () => {
+    const h = harness((command) => {
+      if (command.includes("rev-parse --abbrev-ref")) throw new Error("not git");
+      if (command.includes("worktree remove")) throw new Error(`fatal: '${primary}' is not a working tree`);
+      if (command.startsWith("test -d")) return "";
+      if (command.startsWith("mkdir -p") || command.startsWith("mv ")) return "";
+      if (command.includes("worktree prune")) return "";
+      if (command.startsWith("find ")) return "";
+      return "";
+    });
+
+    await cmdDone("mawjs-codex", { force: true, cwd: main }, h.deps);
+
+    expect(h.logs.join("\n")).toContain("moved orphan directory 1-codex to /tmp/maw-done-orphan-worktrees");
+    expect(h.logs.join("\n")).not.toContain("no worktree to remove");
+    expect(h.commands).toContain(
+      `mv '${primary}' '/tmp/maw-done-orphan-worktrees/1-codex-2026-06-06T01-02-03.004Z'`,
+    );
+  });
+
+  test("surfaces same-member worktrees that remain in other repos", async () => {
+    const h = harness((command) => {
+      if (command.includes("rev-parse --abbrev-ref")) return "main\n";
+      if (command.includes("worktree remove") || command.includes("worktree prune")) return "";
+      if (command.startsWith("find ")) return other;
+      return "";
+    });
+
+    await cmdDone("mawjs-codex", { force: true, cwd: main }, h.deps);
+
+    expect(h.logs.join("\n")).toContain("same-member worktree(s) still exist");
+    expect(h.logs.join("\n")).toContain(other);
+    expect(JSON.parse(h.files.get("/fleet/team.json")!).windows).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem (#1997)
`maw done <member>` can leave agent worktree directories behind after teardown. Operators see stale `agents/N-*` dirs or same-member worktrees in other repos, which can later confuse respawn/wake flows.

## Root cause
The done path removes the configured/found worktree with `git worktree remove` from the main repo, then treats failures as a logged warning. If git metadata was already pruned, `git worktree remove` returns “not a working tree” while the plain directory remains on disk. After removing the primary worktree, the code also did not rescan for same-member worktrees created in other repos. PR #2026 added `failMissingDoneTarget`; this rebased fix keeps that guard while treating recovered orphan dirs as matched cleanup.

## Fix
When `git worktree remove` reports “not a working tree”, `maw done` now checks whether the directory still exists, moves it to recoverable `/tmp/maw-done-orphan-worktrees/...` storage, and runs `git worktree prune`. After a successful removal, CLI calls with a cwd rescan matching worktree suffixes and explicitly warn if same-member worktrees remain in other repos.

## Tests
- `test/isolated/done-orphan-worktree.test.ts` asserts already-pruned dirs are moved instead of reported as no worktree, and cross-repo same-member leftovers are surfaced.
- `test/isolated/done-index-coverage.test.ts` verifies the done command wrapper behavior, including the #2026 missing-target path.

Commands run:
- `MAW_TEST_MODE=1 bun test ./test/isolated/done-orphan-worktree.test.ts`
- `MAW_TEST_MODE=1 bun test ./test/isolated/done-index-coverage.test.ts`

Supersedes #2027 without force-pushing.
Closes #1997