### PR TITLE
release: v26.6.6-alpha.830

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.6.6-alpha.334",
+  "version": "26.6.6-alpha.830",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
## Sprint Release — 12 PRs

Cuts v26.6.6-alpha.830 on merge via calver-release.yml.

### Included
- #2014 fix(federation): cross-node hey no longer hard-fails on wake error (#1998)
- #2015 papercut(tmux): preserve window name on close (#1974)
- #2017 fix(cli): avoid undefined on failed plugin results (#1983)
- #2018 papercut: layout reset alias + tile swap hint (#1966)
- #2019 fix(comm): prevent silent inter-oracle message loss (#1967)
- #2021 feat(cleanup): survey orphan agent worktrees (#1996)
- #2022 fix(done): force-remove worktrees with engine scratch (#1968)
- #2023 feat(ls): expose activity classification in JSON (#1992)
- #2024 fix(hey): warn on node-prefixed oracle target mismatch (#1980 follow-up)
- #2025 papercut: attach to resolved oracle window (#1982)
- #2026 fix(done): fail on missing teardown targets (#1969)
- #2028 test(done): guard vendor worktree force cleanup (#1968 follow-up)

### Pending (next release)
- #2027 fix(done): recover orphan worktree dirs (#1997) — rebasing
- codex-4 unified ls worktree+provenance (#1990, #1991) — in progress