### PR TITLE
feat(ls): unify worktree and provenance JSON fields (#1990 #1991)

### DIFF
--- a/src/commands/plugins/tmux/impl.ts
+++ b/src/commands/plugins/tmux/impl.ts
@@ -218,6 +218,23 @@ export interface TmuxLsOpts {
 export type PaneStatus = "frozen" | "active" | "idle" | "stale" | "unknown";
 export type PaneActivity = "busy" | "idle" | "stuck" | "unknown";
 
+export interface PaneWorktreeJson {
+  path: string;
+  branch: string | null;
+  head: string | null;
+}
+
+export interface PaneProvenanceJson {
+  oracle: string | null;
+  machine: string | null;
+  session: string | null;
+  federation: string | null;
+  org: string | null;
+  repo: string | null;
+  commit: string | null;
+  engine: string | null;
+}
+
 export interface PaneActivityJson {
   activity: PaneActivity;
   activitySource: "context-limit" | "tmux-window-activity" | "unknown";
@@ -236,6 +253,7 @@ interface AnnotatedPane {
   sessionCreated?: number;
   sessionActivity?: number;
   source?: string;
+  cwd?: string;
 }
 
 export function classifyLsPaneActivity(status: PaneStatus): PaneActivity {
@@ -256,6 +274,139 @@ export function paneActivityJson(pane: Pick<AnnotatedPane, "status">): PaneActiv
       : "tmux-window-activity",
     activityWindow: "30s",
   };
+}
+
+function sh(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+export interface PaneGitMetadata {
+  root: string;
+  branch: string | null;
+  head: string | null;
+  org: string | null;
+  repo: string | null;
+}
+
+function paneWindowName(target: string): string | null {
+  const afterColon = target.split(":").slice(1).join(":");
+  if (!afterColon) return null;
+  const match = /^(.*)\.\d+$/.exec(afterColon);
+  return (match?.[1] ?? afterColon).trim() || null;
+}
+
+function oracleNameForPane(session: string, target: string, configured?: string): string | null {
+  const window = paneWindowName(target);
+  if (window && !/^\d+$/.test(window)) return window;
+  const fallback = configured || session.replace(/^\d+-/, "");
+  if (!fallback) return null;
+  return fallback.endsWith("-oracle") ? fallback : `${fallback}-oracle`;
+}
+
+function repoPartsFromRemote(remote: string): { org: string | null; repo: string | null } {
+  const trimmed = remote.trim().replace(/\.git$/, "");
+  const match = /[:/]([^/:\s]+)\/([^/\s]+)$/.exec(trimmed);
+  return { org: match?.[1] ?? null, repo: match?.[2] ?? null };
+}
+
+function repoPartsFromPath(path: string): { org: string | null; repo: string | null } {
+  const parts = path.split("/").filter(Boolean);
+  const hostIndex = parts.lastIndexOf("github.com");
+  if (hostIndex >= 0 && parts[hostIndex + 1] && parts[hostIndex + 2]) {
+    return { org: parts[hostIndex + 1], repo: parts[hostIndex + 2] };
+  }
+  return { org: null, repo: parts.at(-1) ?? null };
+}
+
+export async function resolvePaneGitMetadata(cwd: string | undefined): Promise<PaneGitMetadata | null> {
+  const start = cwd?.trim();
+  if (!start) return null;
+  const root = (await hostExec(`git -C ${sh(start)} rev-parse --show-toplevel`).catch(() => "")).trim();
+  if (!root) return null;
+  const [branch, head, remote] = await Promise.all([
+    hostExec(`git -C ${sh(root)} branch --show-current`).catch(() => ""),
+    hostExec(`git -C ${sh(root)} rev-parse --short=8 HEAD`).catch(() => ""),
+    hostExec(`git -C ${sh(root)} config --get remote.origin.url`).catch(() => ""),
+  ]);
+  const parts = remote.trim() ? repoPartsFromRemote(remote) : repoPartsFromPath(root);
+  return {
+    root,
+    branch: branch.trim() || null,
+    head: head.trim() || null,
+    ...parts,
+  };
+}
+
+export async function describePaneWorktree(
+  cwd: string | undefined,
+  git?: PaneGitMetadata | null,
+): Promise<PaneWorktreeJson | null> {
+  const metadata = git === undefined ? await resolvePaneGitMetadata(cwd) : git;
+  if (!metadata) return null;
+  return {
+    path: metadata.root,
+    branch: metadata.branch,
+    head: metadata.head,
+  };
+}
+
+type ProvenanceConfig = { node?: string; oracle?: string; sessionIds?: Record<string, string> };
+
+async function loadProvenanceConfig(): Promise<ProvenanceConfig> {
+  try {
+    const mod = await import("../../../config");
+    return mod.loadConfig() as ProvenanceConfig;
+  } catch {
+    return {};
+  }
+}
+
+async function fallbackHostname(): Promise<string | null> {
+  try {
+    const os = await import("os");
+    return typeof os.hostname === "function" ? os.hostname() || null : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function paneProvenance(
+  pane: Pick<AnnotatedPane, "target" | "session" | "command" | "cwd">,
+  config?: ProvenanceConfig,
+  git?: PaneGitMetadata | null,
+): Promise<PaneProvenanceJson> {
+  const resolvedConfig = config ?? await loadProvenanceConfig();
+  const metadata = git === undefined ? await resolvePaneGitMetadata(pane.cwd) : git;
+  const oracle = oracleNameForPane(pane.session, pane.target, resolvedConfig.oracle);
+  const machine = resolvedConfig.node || process.env.MAW_NODE || await fallbackHostname();
+  const logicalSession = (oracle && (resolvedConfig.sessionIds?.[oracle] || resolvedConfig.sessionIds?.[oracle.replace(/-oracle$/, "")]))
+    || process.env.MAW_SESSION_ID
+    || null;
+  return {
+    oracle,
+    machine,
+    session: logicalSession,
+    federation: oracle && machine ? `${machine}:${oracle}` : null,
+    org: metadata?.org ?? null,
+    repo: metadata?.repo ?? null,
+    commit: metadata?.head ?? null,
+    engine: pane.command?.trim() || null,
+  };
+}
+
+async function panesForJson(
+  panes: AnnotatedPane[],
+): Promise<Array<AnnotatedPane & PaneActivityJson & { worktree: PaneWorktreeJson | null; provenance: PaneProvenanceJson }>> {
+  const config = await loadProvenanceConfig();
+  return await Promise.all(panes.map(async (pane) => {
+    const git = await resolvePaneGitMetadata(pane.cwd);
+    return {
+      ...pane,
+      ...paneActivityJson(pane),
+      worktree: await describePaneWorktree(pane.cwd, git),
+      provenance: await paneProvenance(pane, config, git),
+    };
+  }));
 }
 
 async function markContextLimitedPanes(panes: AnnotatedPane[]): Promise<void> {
@@ -416,6 +567,7 @@ export async function cmdTmuxLs(opts: TmuxLsOpts = {}): Promise<void> {
       sessionCreated: createdBySession.get(session),
       sessionActivity: activityBySession.get(session),
       source: (p as { source?: string; node?: string }).source ?? (p as { node?: string }).node,
+      cwd: p.cwd,
     };
   });
 
@@ -476,7 +628,7 @@ export async function cmdTmuxLs(opts: TmuxLsOpts = {}): Promise<void> {
   await markContextLimitedPanes(scope);
 
   if (opts.json) {
-    const paneRows = scope.map(pane => ({ ...pane, ...paneActivityJson(pane) }));
+    const paneRows = await panesForJson(scope);
     const teamRows = visibleTeams.map(team => ({
       kind: "team",
       id: `team:${team.name}`,

--- a/test/ls-json-worktree-provenance.test.ts
+++ b/test/ls-json-worktree-provenance.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { join } from "path";
+
+const srcRoot = join(import.meta.dir, "..");
+
+type Pane = {
+  id: string;
+  target: string;
+  command?: string;
+  title?: string;
+  cwd?: string;
+  lastActivity?: number;
+};
+
+let panes: Pane[] = [];
+let config: any = {};
+let gitRoots = new Map<string, string>();
+let gitBranches = new Map<string, string>();
+let gitHeads = new Map<string, string>();
+let gitRemotes = new Map<string, string>();
+let commands: string[] = [];
+
+mock.module("os", () => ({
+  homedir: () => "/mock-home",
+  hostname: () => "host-fallback",
+}));
+
+mock.module(join(srcRoot, "src/config"), () => ({
+  loadConfig: () => config,
+}));
+
+mock.module(join(srcRoot, "src/sdk"), () => ({
+  tmux: { listPanes: async () => panes, capture: async () => "" },
+  tmuxCmd: () => "tmux",
+  hostExec: async (cmd: string) => {
+    commands.push(cmd);
+    if (cmd.includes("rev-parse --show-toplevel")) {
+      for (const [cwd, root] of gitRoots) if (cmd.includes(`'${cwd}'`)) return root;
+      throw new Error("not a git repo");
+    }
+    if (cmd.includes("branch --show-current")) {
+      for (const [root, branch] of gitBranches) if (cmd.includes(`'${root}'`)) return branch;
+      return "";
+    }
+    if (cmd.includes("rev-parse --short=8 HEAD")) {
+      for (const [root, head] of gitHeads) if (cmd.includes(`'${root}'`)) return head;
+      return "";
+    }
+    if (cmd.includes("config --get remote.origin.url")) {
+      for (const [root, remote] of gitRemotes) if (cmd.includes(`'${root}'`)) return remote;
+      return "";
+    }
+    return "";
+  },
+}));
+
+mock.module(join(srcRoot, "src/commands/shared/fleet-load"), () => ({
+  loadFleetEntries: () => [{ file: "101-mawjs.json" }],
+}));
+
+mock.module(join(srcRoot, "src/core/fleet/worktrees-scan"), () => ({ scanWorktrees: async () => [] }));
+mock.module(join(srcRoot, "src/core/ghq"), () => ({ ghqList: async () => [], ghqListSync: () => [] }));
+
+const { cmdTmuxLs, describePaneWorktree, paneProvenance } = await import("../src/commands/plugins/tmux/impl");
+
+const originalLog = console.log;
+
+async function captureJson(fn: () => Promise<void>) {
+  const logs: string[] = [];
+  console.log = (...args: unknown[]) => logs.push(args.map(String).join(" "));
+  try { await fn(); } finally { console.log = originalLog; }
+  return JSON.parse(logs.join("\n"));
+}
+
+const countCommands = (needle: string) => commands.filter(cmd => cmd.includes(needle)).length;
+
+beforeEach(() => {
+  panes = [];
+  config = { node: "m5", oracle: "mawjs", sessionIds: { "mawjs-oracle": "26a2aa25" } };
+  gitRoots = new Map();
+  gitBranches = new Map();
+  gitHeads = new Map();
+  gitRemotes = new Map();
+  commands = [];
+  delete process.env.MAW_NODE;
+  delete process.env.MAW_SESSION_ID;
+});
+
+describe("maw ls --json worktree and provenance metadata (#1990/#1991)", () => {
+  test("adds worktree and provenance while preserving cwd and sharing git metadata", async () => {
+    panes = [{ id: "%1", target: "101-mawjs:mawjs-oracle.1", command: "claude", cwd: "/repo/agents/1" }];
+    gitRoots.set("/repo/agents/1", "/repo/agents/1");
+    gitBranches.set("/repo/agents/1", "agents/1-codex");
+    gitHeads.set("/repo/agents/1", "a596969b");
+    gitRemotes.set("/repo/agents/1", "git@github.com:Soul-Brews-Studio/mawjs-oracle.git");
+
+    const rows = await captureJson(() => cmdTmuxLs({ all: true, json: true }));
+
+    expect(rows[0]).toMatchObject({ cwd: "/repo/agents/1", activity: "unknown" });
+    expect(rows[0].worktree).toEqual({ path: "/repo/agents/1", branch: "agents/1-codex", head: "a596969b" });
+    expect(rows[0].provenance).toEqual({
+      oracle: "mawjs-oracle",
+      machine: "m5",
+      session: "26a2aa25",
+      federation: "m5:mawjs-oracle",
+      org: "Soul-Brews-Studio",
+      repo: "mawjs-oracle",
+      commit: "a596969b",
+      engine: "claude",
+    });
+    expect(countCommands("rev-parse --show-toplevel")).toBe(1);
+    expect(countCommands("rev-parse --short=8 HEAD")).toBe(1);
+  });
+
+  test("keeps null-safe metadata for panes outside git", async () => {
+    expect(await describePaneWorktree(undefined)).toBeNull();
+    config = {};
+    process.env.MAW_SESSION_ID = "env-session";
+    panes = [{ id: "%2", target: "scratch:0.0", command: "zsh", cwd: "/tmp" }];
+
+    const rows = await captureJson(() => cmdTmuxLs({ all: true, json: true }));
+
+    expect(rows[0].cwd).toBe("/tmp");
+    expect(rows[0].worktree).toBeNull();
+    expect(rows[0].provenance).toMatchObject({
+      oracle: "scratch-oracle",
+      machine: "host-fallback",
+      session: "env-session",
+      org: null,
+      repo: null,
+      commit: null,
+      engine: "zsh",
+    });
+  });
+
+  test("exports provenance helper with hostname fallback", async () => {
+    config = {};
+    process.env.MAW_SESSION_ID = "env-session";
+
+    await expect(paneProvenance({ target: "scratch:0.0", session: "scratch", command: "zsh" })).resolves.toMatchObject({
+      oracle: "scratch-oracle",
+      machine: "host-fallback",
+      session: "env-session",
+      commit: null,
+      engine: "zsh",
+    });
+  });
+});


### PR DESCRIPTION
## Problem (#1990/#1991)
`maw ls --json` now exposes activity from #1992, but still lacks the worktree and provenance fields needed by dashboards and fleet automation.
The earlier split PRs for worktree and provenance touched the same JSON transform and conflicted with each other once activity merged.

## Root cause
`cmdTmuxLs()` in `src/commands/plugins/tmux/impl.ts` built pane JSON rows inline from `AnnotatedPane` plus activity data.
Worktree and provenance both need the pane cwd and git state, but implementing them separately duplicated shell quoting and would call `git rev-parse` twice per pane.

## Fix
Centralize pane JSON enrichment in one `panesForJson()` transform that keeps raw `cwd`, preserves activity fields, and adds `worktree` plus `provenance` objects.
A single `resolvePaneGitMetadata()` call per pane resolves git top-level, branch, short HEAD, and remote-derived org/repo, then shares that metadata with both worktree and provenance output.

## Tests
`test/ls-json-worktree-provenance.test.ts` asserts JSON rows preserve `cwd`, expose worktree path/branch/head, expose provenance oracle/machine/session/federation/org/repo/commit/engine, and call `rev-parse --show-toplevel` plus `--short=8 HEAD` only once per pane.
Also ran the existing activity JSON test to verify the unified transform keeps busy/idle/stuck fields intact, plus build and full default suite validation.
Aligned stale isolated wake fixtures with current alpha #1998 warn-and-fall-through behavior so isolated CI shards no longer assert the pre-#1998 hard-exit path.

Closes #1990
Closes #1991
