### PR TITLE
release: v26.6.6-alpha.838

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.6.6-alpha.830",
+  "version": "26.6.6-alpha.839",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.6.6-alpha.334",
+  "version": "26.6.6-alpha.830",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
## Sprint Release Round 2

Cuts v26.6.6-alpha.838 on merge via calver-release.yml.

### Included (on top of v26.6.6-alpha.830)
- #2029 fix(done): recover orphan worktree dirs (#1997) — rebased, mock fix verified
- #2031 feat(ls): unified worktree+provenance JSON (#1990, #1991) — shared git lookup, cwd preserved