### PR TITLE
feat(team): respect charter members in team bring

### DIFF
--- a/src/vendor/mpr-plugins/team/team-workspace.ts
+++ b/src/vendor/mpr-plugins/team/team-workspace.ts
@@ -1,7 +1,10 @@
 import { tmux } from "maw-js/sdk";
 import { cmdWake } from "maw-js/commands/shared/wake";
 import { compactIfPaneContextLimited } from "maw-js/commands/shared/context-limit";
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
 import { loadOracleRegistry, type OracleMember } from "./oracle-members";
+import { resolvePsi } from "./team-helpers";
 
 export interface TeamBringOptions {
   /** Explicit tmux session to bring members into. Defaults to current tmux session or the team name. */
@@ -20,9 +23,49 @@ export function teamOracleMemberNames(members: OracleMember[]): string[] {
   return [...new Set(members.map(m => m.oracle).filter(Boolean))];
 }
 
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter(Boolean))];
+}
+
+function loadTeamManifestMemberNames(teamName: string): string[] {
+  const manifestPath = join(resolvePsi(), "memory", "mailbox", "teams", teamName, "manifest.json");
+  if (!existsSync(manifestPath)) return [];
+
+  try {
+    const raw = JSON.parse(readFileSync(manifestPath, "utf-8"));
+    const out: string[] = [];
+    const candidates = [
+      ...(Array.isArray(raw?.members)
+        ? raw.members.map((entry: unknown) => {
+          if (typeof entry === "string") return entry;
+          if (entry && typeof entry === "object" && typeof (entry as { name?: unknown }).name === "string") {
+            return (entry as { name: string }).name;
+          }
+          return "";
+        })
+        : []),
+      ...(Array.isArray(raw?.charter?.members)
+        ? raw.charter.members.map((entry: unknown) => {
+          if (entry && typeof entry === "object") {
+            if (typeof (entry as { name?: unknown }).name === "string") return (entry as { name: string }).name;
+            if (typeof (entry as { role?: unknown }).role === "string") return (entry as { role: string }).role;
+          }
+          return "";
+        })
+        : []),
+    ];
+
+    return uniqueStrings(candidates);
+  } catch {
+    return [];
+  }
+}
+
 export function loadTeamOracleMemberNames(teamName: string): string[] {
   const registry = loadOracleRegistry(teamName);
-  return registry ? teamOracleMemberNames(registry.members) : [];
+  const fromRegistry = registry ? teamOracleMemberNames(registry.members) : [];
+  const fromManifest = loadTeamManifestMemberNames(teamName);
+  return [...new Set([...fromRegistry, ...fromManifest])];
 }
 
 function validateSessionName(name: string): void {
@@ -90,6 +133,7 @@ export async function cmdTeamBring(teamName: string, opts: TeamBringOptions = {}
       targets.push(`${session}:${oracle}`);
       continue;
     }
+
     const target = await cmdWake(oracle, {
       session,
       noRehydrate: true,

--- a/test/isolated/team-bring-workspace.test.ts
+++ b/test/isolated/team-bring-workspace.test.ts
@@ -12,10 +12,16 @@ let layoutCalls: Array<{ target: string; layout: string }> = [];
 let sentText: Array<{ target: string; text: string }> = [];
 let captureByTarget = new Map<string, string>();
 
+const manifestRoot = join(tmp, "psi", "memory", "mailbox", "teams");
+mock.module("../../src/vendor/mpr-plugins/team/team-helpers", () => ({
+  resolvePsi: () => join(tmp, "psi"),
+}));
+
 mock.module("maw-js/core/paths", () => ({
   CONFIG_DIR: configDir,
   CONFIG_FILE: join(configDir, "maw.config.json"),
   FLEET_DIR: join(configDir, "fleet"),
+  discoverConfigs: () => [],
   MAW_ROOT: "/repo/maw-js",
   resolveHome: () => tmp,
 }));
@@ -52,7 +58,13 @@ writeFileSync(join(registryDir, "oracle-members.json"), JSON.stringify({
   ],
 }, null, 2));
 
-const { cmdTeamBring } = await import("../../src/vendor/mpr-plugins/team/team-workspace");
+const { cmdTeamBring, loadTeamOracleMemberNames } = await import("../../src/vendor/mpr-plugins/team/team-workspace");
+
+function writeManifest(team: string, manifest: unknown): void {
+  const dir = join(manifestRoot, team);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "manifest.json"), JSON.stringify(manifest));
+}
 
 beforeEach(() => {
   wakeCalls = [];
@@ -99,4 +111,40 @@ describe("cmdTeamBring", () => {
     expect(sentText).toEqual([{ target: "project:volt", text: "/compact" }]);
     expect(layoutCalls).toEqual([{ target: "project:lead", layout: "main-vertical" }]);
   });
+
+  test("brings members from charter manifest files and dedupes registry+manifest entries", async () => {
+    writeManifest("charter-only", {
+      name: "charter-only",
+      members: ["alpha-oracle", "reviewer"],
+      charter: {
+        members: [
+          { role: "builder", name: "volt" },
+          { role: "reviewer" },
+          { role: "builder" },
+        ],
+      },
+    });
+
+    const membersBefore = loadTeamOracleMemberNames("charter-only");
+    const targets = await cmdTeamBring("charter-only", { session: "project", dryRun: true });
+
+    expect(membersBefore).toEqual(["alpha-oracle", "reviewer", "volt", "builder"]);
+    expect(targets).toEqual(["project:alpha-oracle", "project:reviewer", "project:volt", "project:builder"]);
+
+    writeManifest("myteam", {
+      name: "myteam",
+      members: ["volt", "odin", "extra"],
+      charter: {
+        members: [
+          { role: "odin", name: "odin-live" },
+          { role: "new-role" },
+        ],
+      },
+    });
+
+    const mergedTargets = await cmdTeamBring("myteam", { session: "project", dryRun: true });
+
+    expect(mergedTargets).toEqual(["project:volt", "project:odin", "project:extra", "project:odin-live", "project:new-role"]);
+  });
+
 });


### PR DESCRIPTION
## Summary
- Load members from team manifest paths at `memory/mailbox/teams/<team>/manifest.json`.
- Merge manifest members with registry members in `loadTeamOracleMemberNames`.
- Add regression in isolated test for manifest-only entries and dedupe behavior.

Closes #1971

Pre-existing test failures unrelated to this change