### PR TITLE
feat(team): support gather on team bring to pull live members

### DIFF
--- a/src/vendor/mpr-plugins/team/index.ts
+++ b/src/vendor/mpr-plugins/team/index.ts
@@ -171,10 +171,11 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         "--engine": String, "-e": "--engine",
         "--dry-run": Boolean,
         "--split": Boolean,
+        "--gather": Boolean,
       }, 1);
       const team = flags._[0];
       if (!team) {
-        logs.push("usage: maw team bring <team> [--session <session>] [-e|--engine <name>] [--split] [--dry-run]");
+        logs.push("usage: maw team bring <team> [--session <session>] [-e|--engine <name>] [--split] [--gather] [--dry-run]");
         return { ok: false, error: "team required", output: logs.join("\n") };
       }
       await cmdTeamBring(team, {
@@ -182,6 +183,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         engine: flags["--engine"] as string | undefined,
         dryRun: !!flags["--dry-run"],
         split: !!flags["--split"],
+        gather: !!flags["--gather"],
       });
     } else if (sub === "resume") {
       if (!args[1]) {

--- a/src/vendor/mpr-plugins/team/team-workspace.ts
+++ b/src/vendor/mpr-plugins/team/team-workspace.ts
@@ -2,6 +2,7 @@ import { tmux } from "maw-js/sdk";
 import { cmdWake } from "maw-js/commands/shared/wake";
 import { compactIfPaneContextLimited } from "maw-js/commands/shared/context-limit";
 import { loadOracleRegistry, type OracleMember } from "./oracle-members";
+import { listPaneSnapshots } from "./team-liveness";
 
 export interface TeamBringOptions {
   /** Explicit tmux session to bring members into. Defaults to current tmux session or the team name. */
@@ -12,12 +13,20 @@ export interface TeamBringOptions {
   dryRun?: boolean;
   /** Open each brought oracle beside the current pane using maw wake --split. */
   split?: boolean;
+  /** Pull already-live members from existing windows instead of re-waking them. */
+  gather?: boolean;
   /** How long to watch newly woken panes for immediate context-limit freeze. */
   contextLimitPollMs?: number;
 }
 
 export function teamOracleMemberNames(members: OracleMember[]): string[] {
   return [...new Set(members.map(m => m.oracle).filter(Boolean))];
+}
+
+function teamWorkspaceWindowCandidates(member: string): string[] {
+  const raw = member.trim();
+  const stripped = raw.replace(/-oracle$/i, "");
+  return [...new Set([raw, stripped, stripped ? `${stripped}-oracle` : ""].filter(Boolean))];
 }
 
 export function loadTeamOracleMemberNames(teamName: string): string[] {
@@ -84,17 +93,39 @@ export async function cmdTeamBring(teamName: string, opts: TeamBringOptions = {}
 
   const targets: string[] = [];
   const woken: Array<{ oracle: string; target: string }> = [];
+  const liveTargets = opts.gather ? await findLiveTeamTargets(members, session).catch(() => new Map()) : new Map<string, string | null>();
   for (const oracle of members) {
+    const liveTarget = liveTargets.get(oracle) ?? null;
+    const alreadyInSession = liveTarget && liveTarget.startsWith(`${session}:`);
+
     if (opts.dryRun) {
-      console.log(`  \x1b[90mwould wake ${oracle} --session ${session}${opts.split ? " --split" : ""}\x1b[0m`);
+      if (opts.gather && liveTarget && !alreadyInSession) {
+        console.log(`  \x1b[90mwould gather ${oracle} from ${liveTarget}\x1b[0m`);
+      } else if (opts.gather && liveTarget && alreadyInSession) {
+        console.log(`  \x1b[90m${oracle} already live in ${liveTarget}\x1b[0m`);
+      } else {
+        console.log(`  \x1b[90mwould wake ${oracle} --session ${session}${opts.split && !opts.gather ? " --split" : ""}\x1b[0m`);
+      }
+      targets.push(liveTarget && !alreadyInSession ? `${session}:${oracle}` : liveTarget ?? `${session}:${oracle}`);
+      continue;
+    }
+
+    if (opts.gather && liveTarget && alreadyInSession) {
+      targets.push(liveTarget);
+      continue;
+    }
+
+    if (opts.gather && liveTarget && !alreadyInSession) {
+      await tmux.run("join-pane", "-s", liveTarget);
       targets.push(`${session}:${oracle}`);
       continue;
     }
+
     const target = await cmdWake(oracle, {
       session,
       noRehydrate: true,
       engine: opts.engine,
-      split: opts.split,
+      split: opts.gather ? false : opts.split,
     });
     targets.push(target);
     woken.push({ oracle, target });
@@ -115,4 +146,33 @@ export async function cmdTeamBring(teamName: string, opts: TeamBringOptions = {}
   }
 
   return targets;
+}
+
+async function findLiveTeamTargets(members: string[], session: string): Promise<Map<string, string | null>> {
+  const targetSet = new Set(members);
+  if (targetSet.size === 0) return new Map();
+
+  const panes = await listPaneSnapshots();
+  const output = new Map<string, string | null>();
+
+  for (const oracle of members) {
+    if (!targetSet.has(oracle)) continue;
+
+    const wanted = new Set(teamWorkspaceWindowCandidates(oracle).map((value) => value.toLowerCase()));
+
+    const inSession = panes.find((pane) =>
+      pane.sessionName === session && wanted.has(pane.windowName.toLowerCase())
+    );
+    if (inSession) {
+      output.set(oracle, `${session}:${inSession.windowName}`);
+      continue;
+    }
+
+    const inOther = panes.find((pane) =>
+      pane.sessionName !== session && wanted.has(pane.windowName.toLowerCase())
+    );
+    output.set(oracle, inOther ? `${inOther.sessionName}:${inOther.windowName}` : null);
+  }
+
+  return output;
 }

--- a/test/isolated/team-bring-workspace.test.ts
+++ b/test/isolated/team-bring-workspace.test.ts
@@ -11,6 +11,19 @@ let wakeCalls: Array<{ oracle: string; opts: any }> = [];
 let layoutCalls: Array<{ target: string; layout: string }> = [];
 let sentText: Array<{ target: string; text: string }> = [];
 let captureByTarget = new Map<string, string>();
+let joinPaneCalls: Array<string[]> = [];
+let listPanesOutput = "";
+
+mock.module("../../src/vendor/mpr-plugins/team/team-liveness", () => ({
+  listPaneSnapshots: async () => listPanesOutput
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [sessionName = "", windowName = "", command = "", path = "", paneId = ""] = line.split("|");
+      return { sessionName, windowName, command, path, paneId };
+    }),
+}));
 
 mock.module("maw-js/core/paths", () => ({
   CONFIG_DIR: configDir,
@@ -23,7 +36,14 @@ mock.module("maw-js/core/paths", () => ({
 mock.module("maw-js/sdk", () => ({
   tmux: {
     hasSession: async (name: string) => name === "project" || name === "myteam",
-    run: async () => "54-mawjs",
+    run: async (command: string, ...args: string[]) => {
+      if (command === "list-panes") return listPanesOutput;
+      if (command === "join-pane") {
+        joinPaneCalls.push([command, ...args]);
+        return "";
+      }
+      return "54-mawjs";
+    },
     capture: async (target: string) => captureByTarget.get(target) ?? "",
     sendText: async (target: string, text: string) => {
       sentText.push({ target, text });
@@ -58,7 +78,9 @@ beforeEach(() => {
   wakeCalls = [];
   layoutCalls = [];
   sentText = [];
+  joinPaneCalls = [];
   captureByTarget = new Map();
+  listPanesOutput = "";
 });
 
 describe("cmdTeamBring", () => {
@@ -98,5 +120,58 @@ describe("cmdTeamBring", () => {
     expect(targets).toEqual(["project:volt", "project:odin"]);
     expect(sentText).toEqual([{ target: "project:volt", text: "/compact" }]);
     expect(layoutCalls).toEqual([{ target: "project:lead", layout: "main-vertical" }]);
+  });
+
+  test("when --gather is set, live windows are pulled with join-pane and existing windows are skipped", async () => {
+    const manualRegistryDir = join(process.env.MAW_CONFIG_DIR!, "teams", "gather-team");
+    mkdirSync(manualRegistryDir, { recursive: true });
+    writeFileSync(join(manualRegistryDir, "oracle-members.json"), JSON.stringify({
+      name: "gather-team",
+      members: [
+        { oracle: "volt", role: "builder", addedAt: new Date().toISOString() },
+        { oracle: "odin", role: "reviewer", addedAt: new Date().toISOString() },
+      ],
+      createdAt: new Date().toISOString(),
+    }, null, 2));
+
+    listPanesOutput = [
+      "lead-session|volter|claude|/tmp|%10",
+      "gather-session|volt|claude|/tmp|%11",
+      "gather-session|odin|claude|/tmp|%12",
+    ].join("\n");
+
+    const targets = await cmdTeamBring("gather-team", { session: "project", gather: true });
+
+    expect(targets).toEqual(["project:volt", "project:odin"]);
+    expect(wakeCalls).toHaveLength(0);
+    expect(joinPaneCalls).toEqual([
+      ["join-pane", "-s", "gather-session:volt"],
+      ["join-pane", "-s", "gather-session:odin"],
+    ]);
+  });
+
+  test("--gather ignores --split and wakes missing members without split", async () => {
+    const missingDir = join(process.env.MAW_CONFIG_DIR!, "teams", "missing-team");
+    mkdirSync(missingDir, { recursive: true });
+    writeFileSync(join(missingDir, "oracle-members.json"), JSON.stringify({
+      name: "missing-team",
+      members: [{ oracle: "neo", role: "builder", addedAt: new Date().toISOString() }],
+      createdAt: new Date().toISOString(),
+    }, null, 2));
+
+    await cmdTeamBring("missing-team", { session: "project", gather: true, split: true, contextLimitPollMs: 0 });
+
+    expect(wakeCalls).toEqual([
+      {
+        oracle: "neo",
+        opts: {
+          session: "project",
+          noRehydrate: true,
+          engine: undefined,
+          split: false,
+        },
+      },
+    ]);
+    expect(joinPaneCalls).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary
- Add `--gather` mode to `maw team bring`.
- Reuse live tmux windows by matching candidate window names and joining with `tmux join-pane`.
- Keep windows already in the target session, and ignore `--split` while gathering.

Closes #1973

Pre-existing test failures unrelated to this change