### PR TITLE
fix(oracle): warn on ambiguous short-name resolution

### DIFF
--- a/src/commands/plugins/oracle/impl-helpers.ts
+++ b/src/commands/plugins/oracle/impl-helpers.ts
@@ -1,12 +1,38 @@
 import { listSessions, type OracleEntry } from "../../../sdk";
-import { ghqFind } from "../../../core/ghq";
+import { ghqFind, ghqList } from "../../../core/ghq";
+import { UserError } from "../../../core/util/user-error";
 import { loadFleetEntries } from "../../shared/fleet-load";
 
 /** Like resolveOracle but returns null instead of throwing on miss */
 export async function resolveOracleSafe(oracle: string): Promise<{ repoPath: string; repoName: string; parentDir: string } | { parentDir: ""; repoName: ""; repoPath: "" }> {
-  // Try oracle-oracle pattern first, then direct name (e.g., homekeeper → homelab)
-  const repoPath = (await ghqFind(`/${oracle}-oracle$`)) ?? (await ghqFind(`/${oracle}$`));
-  if (!repoPath) return { parentDir: "", repoName: "", repoPath: "" };
+  if (oracle.includes("/")) {
+    const repoPath = await ghqFind(`/${oracle}$`).catch(() => null);
+    if (!repoPath) return { parentDir: "", repoName: "", repoPath: "" };
+    return parseRepoPath(repoPath);
+  }
+
+  const repos = await ghqList().catch(() => [] as string[]);
+  const wantedOracle = `${oracle}-oracle`.toLowerCase();
+  const directName = oracle.toLowerCase();
+
+  const oracleCandidates = repos
+    .filter((candidate) => candidate.split("/").pop()?.toLowerCase() === wantedOracle);
+  if (oracleCandidates.length > 1) {
+    throw new UserError(`ambiguous oracle short-name '${oracle}' (${oracleCandidates.length} matches): ${oracleCandidates.map((repoPath) => repoPath.split("/").pop()).join(", ")}`);
+  }
+  if (oracleCandidates.length === 1) return parseRepoPath(oracleCandidates[0]!);
+
+  const directCandidates = repos
+    .filter((candidate) => candidate.split("/").pop()?.toLowerCase() === directName);
+  if (directCandidates.length > 1) {
+    throw new UserError(`ambiguous oracle short-name '${oracle}' (${directCandidates.length} matches): ${directCandidates.map((repoPath) => repoPath.split("/").pop()).join(", ")}`);
+  }
+  if (directCandidates.length === 1) return parseRepoPath(directCandidates[0]!);
+
+  return { parentDir: "", repoName: "", repoPath: "" };
+}
+
+function parseRepoPath(repoPath: string): { repoPath: string; repoName: string; parentDir: string } {
   const repoName = repoPath.split("/").pop()!;
   const parentDir = repoPath.replace(/\/[^/]+$/, "");
   return { repoPath, repoName, parentDir };

--- a/src/vendor/mpr-plugins/about/internal/impl-helpers.ts
+++ b/src/vendor/mpr-plugins/about/internal/impl-helpers.ts
@@ -1,12 +1,38 @@
 import { listSessions, type OracleEntry } from "maw-js/sdk";
-import { ghqFind } from "maw-js/core/ghq";
+import { ghqFind, ghqList } from "maw-js/core/ghq";
 import { loadFleetEntries } from "maw-js/commands/shared/fleet-load";
+import { UserError } from "maw-js/core/util/user-error";
 
 /** Like resolveOracle but returns null instead of throwing on miss */
 export async function resolveOracleSafe(oracle: string): Promise<{ repoPath: string; repoName: string; parentDir: string } | { parentDir: ""; repoName: ""; repoPath: "" }> {
-  // Try oracle-oracle pattern first, then direct name (e.g., homekeeper → homelab)
-  const repoPath = (await ghqFind(`/${oracle}-oracle$`)) ?? (await ghqFind(`/${oracle}$`));
-  if (!repoPath) return { parentDir: "", repoName: "", repoPath: "" };
+  if (oracle.includes("/")) {
+    const repoPath = await ghqFind(`/${oracle}$`).catch(() => null);
+    if (!repoPath) return { parentDir: "", repoName: "", repoPath: "" };
+    return parseRepoPath(repoPath);
+  }
+
+  const repos = await ghqList().catch(() => [] as string[]);
+  const wantedOracle = `${oracle}-oracle`.toLowerCase();
+  const directName = oracle.toLowerCase();
+
+  const oracleCandidates = repos
+    .filter((candidate) => candidate.split("/").pop()?.toLowerCase() === wantedOracle);
+  if (oracleCandidates.length > 1) {
+    throw new UserError(`ambiguous oracle short-name '${oracle}' (${oracleCandidates.length} matches): ${oracleCandidates.map((repoPath) => repoPath.split("/").pop()).join(", ")}`);
+  }
+  if (oracleCandidates.length === 1) return parseRepoPath(oracleCandidates[0]!);
+
+  const directCandidates = repos
+    .filter((candidate) => candidate.split("/").pop()?.toLowerCase() === directName);
+  if (directCandidates.length > 1) {
+    throw new UserError(`ambiguous oracle short-name '${oracle}' (${directCandidates.length} matches): ${directCandidates.map((repoPath) => repoPath.split("/").pop()).join(", ")}`);
+  }
+  if (directCandidates.length === 1) return parseRepoPath(directCandidates[0]!);
+
+  return { parentDir: "", repoName: "", repoPath: "" };
+}
+
+function parseRepoPath(repoPath: string): { repoPath: string; repoName: string; parentDir: string } {
   const repoName = repoPath.split("/").pop()!;
   const parentDir = repoPath.replace(/\/[^/]+$/, "");
   return { repoPath, repoName, parentDir };

--- a/test/isolated/oracle-prune-helpers-extra-coverage.test.ts
+++ b/test/isolated/oracle-prune-helpers-extra-coverage.test.ts
@@ -14,6 +14,7 @@ type Session = { name: string; windows: Array<{ index?: number; name: string }> 
 let sessions: Session[] = [];
 let listSessionsError: Error | null = null;
 let ghqCalls: string[] = [];
+let ghqListResult: string[] = [];
 let ghqResults = new Map<string, string | null>();
 let logs: string[] = [];
 
@@ -56,6 +57,7 @@ mock.module(import.meta.resolve("../../src/core/ghq"), () => ({
     ghqCalls.push(pattern);
     return ghqResults.get(pattern) ?? null;
   },
+  ghqList: async () => ghqListResult,
 }));
 
 const prune = await import("../../src/commands/plugins/oracle/impl-prune.ts?oracle-prune-helpers-extra-coverage");
@@ -114,6 +116,7 @@ beforeEach(() => {
   sessions = [];
   listSessionsError = null;
   ghqCalls = [];
+  ghqListResult = [];
   ghqResults = new Map();
   Date.now = originalDateNow;
   captureConsole();
@@ -231,27 +234,48 @@ describe("oracle prune extra isolated coverage", () => {
 
 describe("oracle helper extra isolated coverage", () => {
   test("resolveOracleSafe prefers -oracle repos, falls back to exact repo names, and reports misses", async () => {
-    ghqResults.set("/neo-oracle$", "/ghq/Soul-Brews-Studio/neo-oracle");
+    ghqListResult = ["/ghq/Soul-Brews-Studio/neo-oracle"];
     await expect(helpers.resolveOracleSafe("neo")).resolves.toEqual({
       repoPath: "/ghq/Soul-Brews-Studio/neo-oracle",
       repoName: "neo-oracle",
       parentDir: "/ghq/Soul-Brews-Studio",
     });
-    expect(ghqCalls).toEqual(["/neo-oracle$"]);
+    expect(ghqCalls).toEqual([]);
 
-    ghqCalls = [];
-    ghqResults = new Map([["/homekeeper$", "/ghq/Soul-Brews-Studio/homekeeper"]]);
+    ghqListResult = ["/ghq/Soul-Brews-Studio/neo-oracle", "/ghq/Soul-Brews-Studio/homekeeper"];
     await expect(helpers.resolveOracleSafe("homekeeper")).resolves.toEqual({
       repoPath: "/ghq/Soul-Brews-Studio/homekeeper",
       repoName: "homekeeper",
       parentDir: "/ghq/Soul-Brews-Studio",
     });
-    expect(ghqCalls).toEqual(["/homekeeper-oracle$", "/homekeeper$"]);
+    expect(ghqCalls).toEqual([]);
 
     ghqCalls = [];
-    ghqResults = new Map();
+    ghqListResult = [];
     await expect(helpers.resolveOracleSafe("missing")).resolves.toEqual({ parentDir: "", repoName: "", repoPath: "" });
-    expect(ghqCalls).toEqual(["/missing-oracle$", "/missing$"]);
+    expect(ghqCalls).toEqual([]);
+    expect(ghqListResult).toEqual([]);
+  });
+
+  test("resolveOracleSafe throws on ambiguous -oracle short-name matches", async () => {
+    ghqCalls = [];
+    ghqListResult = [
+      "/ghq/Soul-Brews-Studio/pulse-oracle",
+      "/ghq/other-org/pulse-oracle",
+    ];
+
+    await expect(helpers.resolveOracleSafe("pulse")).rejects.toThrow(/ambiguous oracle short-name 'pulse'.*2 matches/);
+    expect(ghqCalls).toEqual([]);
+    expect(ghqListResult).toHaveLength(2);
+  });
+
+  test("resolveOracleSafe throws on ambiguous short-name direct matches", async () => {
+    ghqListResult = [
+      "/ghq/Soul-Brews-Studio/neo",
+      "/ghq/other-org/neo",
+    ];
+
+    await expect(helpers.resolveOracleSafe("neo")).rejects.toThrow(/ambiguous oracle short-name 'neo'.*2 matches/);
   });
 
   test("discoverOracles merges valid fleet configs with tmux, skips disabled files, and tolerates bad sources", async () => {

--- a/test/isolated/vendor-about-bud-sleep-run-send-extra-coverage.test.ts
+++ b/test/isolated/vendor-about-bud-sleep-run-send-extra-coverage.test.ts
@@ -14,6 +14,7 @@ let sessions: Session[] = [];
 let listSessionsError: Error | null = null;
 let ghqResults = new Map<string, string | null>();
 let ghqCalls: string[] = [];
+let ghqListResult: string[] = [];
 let hostExecCalls: string[] = [];
 let hostExecQueue: Array<string | Error> = [];
 let configState: Record<string, unknown> = { node: "local" };
@@ -99,6 +100,7 @@ mock.module("maw-js/core/ghq", () => ({
     ghqCalls.push(pattern);
     return ghqResults.get(pattern) ?? null;
   },
+  ghqList: async () => ghqListResult,
 }));
 
 mock.module("maw-js/config", () => ({
@@ -188,6 +190,7 @@ beforeEach(() => {
   listSessionsError = null;
   ghqResults = new Map();
   ghqCalls = [];
+  ghqListResult = [];
   hostExecCalls = [];
   hostExecQueue = [];
   resetSendState();
@@ -212,27 +215,42 @@ afterAll(() => {
 
 describe("about impl helpers", () => {
   test("resolveOracleSafe tries -oracle first, falls back to direct repo, and returns an empty miss", async () => {
-    ghqResults.set("/parent-oracle$", "/repos/parent-oracle");
+    ghqListResult = ["/repos/parent-oracle"];
     await expect(aboutHelpers.resolveOracleSafe("parent")).resolves.toEqual({
       repoPath: "/repos/parent-oracle",
       repoName: "parent-oracle",
       parentDir: "/repos",
     });
-    expect(ghqCalls).toEqual(["/parent-oracle$"]);
+    expect(ghqCalls).toEqual([]);
 
     ghqCalls = [];
-    ghqResults = new Map([["/homekeeper$", "/repos/homekeeper"]]);
+    ghqListResult = ["/repos/parent-oracle", "/repos/homekeeper"];
     await expect(aboutHelpers.resolveOracleSafe("homekeeper")).resolves.toEqual({
       repoPath: "/repos/homekeeper",
       repoName: "homekeeper",
       parentDir: "/repos",
     });
-    expect(ghqCalls).toEqual(["/homekeeper-oracle$", "/homekeeper$"]);
+    expect(ghqCalls).toEqual([]);
 
     ghqCalls = [];
-    ghqResults = new Map();
+    ghqListResult = [];
     await expect(aboutHelpers.resolveOracleSafe("ghost")).resolves.toEqual({ parentDir: "", repoName: "", repoPath: "" });
-    expect(ghqCalls).toEqual(["/ghost-oracle$", "/ghost$"]);
+    expect(ghqCalls).toEqual([]);
+  });
+
+  test("resolveOracleSafe throws for ambiguous short-name matches", async () => {
+    ghqListResult = [
+      "/repos/Soul-Brews-Studio/pulse-oracle",
+      "/repos/other-org/pulse-oracle",
+    ];
+
+    await expect(aboutHelpers.resolveOracleSafe("pulse")).rejects.toThrow(/ambiguous oracle short-name 'pulse'.*2 matches/);
+
+    ghqListResult = [
+      "/repos/Soul-Brews-Studio/pulse",
+      "/repos/other-org/pulse",
+    ];
+    await expect(aboutHelpers.resolveOracleSafe("pulse")).rejects.toThrow(/ambiguous oracle short-name 'pulse'.*2 matches/);
   });
 
   test("discoverOracles merges fleet and tmux names, sorts, and tolerates missing sources", async () => {


### PR DESCRIPTION
## Summary
- make oracle resolve logic scan local ghq repos for short names
- fail fast with UserError when short-name foo matches multiple local repos (e.g. multiple foo-oracle candidates)

This prevents silently selecting the first matching repository from ghq and gives explicit ambiguity errors so callers can use org/repo form.

Closes #1972
