### PR TITLE
Fix team down bridge teardown and charter forward-compat warnings

### DIFF
--- a/src/vendor/mpr-plugins/team/team-charter.ts
+++ b/src/vendor/mpr-plugins/team/team-charter.ts
@@ -26,6 +26,7 @@ export interface TeamCharter {
   members: TeamCharterMember[];
   lifecycle?: Record<string, unknown>;
   governance?: Record<string, unknown>;
+  warnings?: string[];
 }
 
 export interface TeamCharterPlan {
@@ -213,15 +214,33 @@ function parseYamlSubset(text: string): TeamCharter {
   return normalizeCharter(root);
 }
 
+const KNOWN_TOP_LEVEL_KEYS = new Set(["name", "description", "goal", "session", "members", "lifecycle", "governance"]);
+const KNOWN_MEMBER_KEYS = new Set(["role", "name", "target", "model", "cwd", "prompt", "engine", "worktree", "queue", "node", "channels"]);
+
 function normalizeCharter(value: unknown): TeamCharter {
   if (!value || typeof value !== "object") throw new Error("team charter must be an object");
   const raw = value as Record<string, unknown>;
+  const warnings: string[] = [];
+
+  for (const [key] of Object.entries(raw)) {
+    if (!KNOWN_TOP_LEVEL_KEYS.has(key)) {
+      warnings.push(`team charter has unsupported top-level key: ${key}`);
+    }
+  }
+
   if (typeof raw.name !== "string" || !raw.name.trim()) throw new Error("team charter requires name");
   if (!Array.isArray(raw.members) || raw.members.length === 0) throw new Error("team charter requires at least one member");
   const members = raw.members.map((member, idx) => {
     if (!member || typeof member !== "object") throw new Error(`member ${idx + 1} must be an object`);
     const m = member as Record<string, unknown>;
+    for (const [key] of Object.entries(m)) {
+      if (!KNOWN_MEMBER_KEYS.has(key)) {
+        const memberRole = typeof m.role === "string" && m.role.trim() ? m.role.trim() : `#${idx + 1}`;
+        warnings.push(`member '${memberRole}' has unsupported key: ${key}`);
+      }
+    }
     if (typeof m.role !== "string" || !m.role.trim()) throw new Error(`member ${idx + 1} requires role`);
+
     return {
       role: m.role.trim(),
       ...(typeof m.name === "string" && m.name.trim() ? { name: m.name.trim() } : {}),
@@ -244,6 +263,7 @@ function normalizeCharter(value: unknown): TeamCharter {
     ...(typeof raw.goal === "string" && raw.goal.trim() ? { goal: raw.goal.trim() } : {}),
     ...(typeof raw.session === "string" && raw.session.trim() ? { session: raw.session.trim() } : {}),
     members,
+    ...(warnings.length ? { warnings } : {}),
     ...(raw.lifecycle && typeof raw.lifecycle === "object" && !Array.isArray(raw.lifecycle) ? { lifecycle: raw.lifecycle as Record<string, unknown> } : {}),
     ...(raw.governance && typeof raw.governance === "object" && !Array.isArray(raw.governance) ? { governance: raw.governance as Record<string, unknown> } : {}),
   };
@@ -315,6 +335,9 @@ export function formatTeamCharterPlan(plan: TeamCharterPlan): string {
   ].filter((line): line is string => line !== undefined);
   if (plan.warnings.length) {
     lines.push("", "warnings:", ...plan.warnings.map((warning) => `  - ${warning}`));
+  }
+  if (charter.warnings?.length) {
+    lines.push("", "parser warnings:", ...charter.warnings.map((warning) => `  - ${warning}`));
   }
   return lines.join("\n");
 }
@@ -416,6 +439,11 @@ function addPreflightCheck(
 
 export function preflightTeamCharter(charter: TeamCharter): TeamCharterPreflightResult {
   const checks: TeamCharterPreflightCheck[] = [];
+
+  for (const warning of charter.warnings ?? []) {
+    addPreflightCheck(checks, "warn", "parser", warning);
+  }
+
   try {
     assertValidOracleName(charter.name);
     addPreflightCheck(checks, "ok", "team name", `'${charter.name}' is accepted`);

--- a/src/vendor/mpr-plugins/team/team-down.ts
+++ b/src/vendor/mpr-plugins/team/team-down.ts
@@ -47,7 +47,7 @@ export interface TeamDownDeps {
 }
 
 function isLead(member: TeamCharterMember): boolean {
-  return member.role === "lead" || member.worktree === false;
+  return member.role === "lead" || member.role === "bridge";
 }
 
 function renderRoster(team: string, session: string, roster: ClassifiedTeamMember[], actions: TeamDownAction[], tail?: string): string {

--- a/test/isolated/team-charter-plan.test.ts
+++ b/test/isolated/team-charter-plan.test.ts
@@ -114,6 +114,39 @@ governance:
     expect(charter.governance?.requires_human_approval).toBe(false);
   });
 
+  test("warns and ignores unknown top-level and member keys", () => {
+    const charter = parseTeamCharterText(`
+name: warn-team
+description: old-format charter
+legacy: true
+members:
+  - role: builder
+    target: auto
+    unknown: deprecated
+    model: opus
+`);
+
+    expect(charter.warnings).toMatchObject([
+      "team charter has unsupported top-level key: legacy",
+      "member 'builder' has unsupported key: unknown",
+    ]);
+
+    expect(charter).toMatchObject({
+      name: "warn-team",
+      members: [{ role: "builder", target: "auto", model: "opus" }],
+    });
+
+    const preflight = preflightTeamCharter(charter);
+    const planOutput = formatTeamCharterPlan(planTeamCharter(charter));
+    const preflightOutput = formatTeamCharterPreflight(preflight);
+
+    expect(planOutput).toContain("parser warnings:");
+    expect(planOutput).toContain("team charter has unsupported top-level key: legacy");
+    expect(planOutput).toContain("member 'builder' has unsupported key: unknown");
+    expect(preflightOutput).toContain("parser: team charter has unsupported top-level key: legacy");
+    expect(preflightOutput).toContain("parser: member 'builder' has unsupported key: unknown");
+  });
+
   test("team handler plan subcommand is read-only and prints planned artifacts", async () => {
     const file = tmpFile("team.yaml", `
 name: safe-plan

--- a/test/isolated/team-up-coverage.test.ts
+++ b/test/isolated/team-up-coverage.test.ts
@@ -368,6 +368,55 @@ members:
     expect(doneCalls).toHaveLength(0);
   });
 
+  test("default down keeps role bridge members in-session", async () => {
+    const root = tempRepo();
+    writeFileSync(join(root, ".maw", "teams", "down.yaml"), `
+name: down
+session: charter-session
+members:
+  - role: lead
+    name: mawjs-oracle
+    engine: claude
+    worktree: false
+  - role: implementer
+    name: codex
+    engine: omx
+    worktree: true
+  - role: reviewer
+    name: coder-1
+    engine: claude48
+    worktree: true
+  - role: bridge
+    name: bridge-oracle
+    engine: claude
+    worktree: true
+`, "utf-8");
+    const { tmux } = fakeTmux([
+      "charter-session|mawjs-oracle|claude|/repo|%1",
+      "charter-session|mawjs-codex|codex|/wt/codex|%2",
+      "charter-session|mawjs-coder-1|claude|/wt/coder-1|%3",
+      "charter-session|mawjs-bridge-oracle|claude|/wt/bridge-oracle|%4",
+    ]);
+    const doneCalls: any[] = [];
+
+    await cmdTeamDown("down", {}, {
+      cwd: root,
+      tmux,
+      loadConfigFn: () => ({ ...config, node: "m5" }),
+      cmdDoneFn: async (...a: any[]) => { doneCalls.push(a); },
+      logger: () => {},
+    });
+
+    expect(doneCalls).toEqual([[
+      "mawjs-codex",
+      { sessionName: "charter-session" },
+    ], [
+      "mawjs-coder-1",
+      { sessionName: "charter-session" },
+    ]]);
+
+  });
+
   test("down executes done for selected live workers, supports --keep and --all", async () => {
     const root = tempRepo();
     writeFileSync(join(root, ".maw", "teams", "down.yaml"), `


### PR DESCRIPTION
## Summary
- Keep `role: bridge` members during default `maw team down` teardown
- Warn and ignore unknown team charter top-level/member keys for forward compatibility
- Surface parser warnings in plan/preflight output

Closes #2004
Closes #1994

## Verification
- `bun test test/isolated/team-up-coverage.test.ts test/isolated/team-charter-plan.test.ts`
- `git diff --check`
- `bun run build`

## Notes
Target branch: alpha