### PR TITLE
Fix atomic config writes and wake override resolution

### DIFF
--- a/src/commands/shared/target-cwd.ts
+++ b/src/commands/shared/target-cwd.ts
@@ -3,15 +3,33 @@ import { loadFleet } from "./fleet-load";
 import { getGhqRoot } from "../../config/ghq-root";
 
 /**
- * Extract oracle name from a tmux target. Sessions are conventionally
- * `NN-<oracle>` (e.g. `05-nari` → `nari`). The previous extraction
- * (`target.split(":").pop()`) returned the window index/name, which
- * `buildCommand` could not match — falling back to the default command
- * regardless of which oracle was being woken.
+ * Extract oracle name from a tmux target.
+ *
+ * Prefer the window segment when present so command-map overrides keyed by
+ * window names still apply on wake/resume. Fall back to session slug when
+ * window is numeric/absent or when target is session-only.
  */
 export function extractOracleName(target: string): string {
-  const session = target?.split(":")[0] || "";
-  return session.replace(/^\d+-/, "");
+  const clean = stripPaneSuffix(target);
+  if (!clean) return "";
+  const parts = clean.split(":");
+
+  const hasNodePrefix = parts.length >= 3;
+  const sessionPart = hasNodePrefix ? parts[1] : parts[0] || "";
+  const windowPart = hasNodePrefix ? parts[2] : parts[1];
+
+  if (windowPart && !/^[0-9]+$/.test(windowPart)) {
+    return windowPart.replace(/^\d+-/, "");
+  }
+  return sessionPart.replace(/^\d+-/, "");
+}
+
+/**
+ * Strip pane suffixes like `target.0` while preserving dots in window names
+ * (e.g. `mawjs-v2`).
+ */
+function stripPaneSuffix(target: string): string {
+  return target.replace(/\.[0-9]+$/, "");
 }
 
 /**
@@ -26,7 +44,12 @@ export function extractOracleName(target: string): string {
  */
 export function resolveTargetCwd(target: string): string | null {
   if (!target) return null;
-  const [session, winRef] = target.split(":");
+  const clean = stripPaneSuffix(target);
+  const parts = clean.split(":");
+  const hasNodePrefix = parts.length >= 3;
+
+  const session = hasNodePrefix ? parts[1] : parts[0] || "";
+  const winRef = hasNodePrefix ? parts[2] : parts[1];
   if (!session) return null;
 
   let fleets;

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -1,6 +1,6 @@
-import { existsSync, readFileSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "fs";
 import { homedir } from "os";
-import { join } from "path";
+import { dirname, join } from "path";
 import { CONFIG_FILE, CONFIG_WEIGHTED_FILE, discoverConfigs, type DiscoveredConfig } from "../core/paths";
 import { refreshContext } from "../lib/context";
 import { verbose, info } from "../cli/verbosity";
@@ -79,6 +79,30 @@ const BIND_ADDRESSES = new Set(["0.0.0.0", "::", "", "127.0.0.1", "localhost"]);
  */
 const REAL_HOME_CONFIG = join(homedir(), ".config", "maw", "maw.config.json");
 
+function generateTmpPath(filePath: string): string {
+  return `${filePath}.tmp.${Date.now()}.${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function writeFileAtomic(filePath: string, body: string): void {
+  const tmpPath = generateTmpPath(filePath);
+  try {
+    writeFileSync(tmpPath, body, "utf-8");
+    renameSync(tmpPath, filePath);
+  } catch (e) {
+    try {
+      rmSync(tmpPath, { force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+    throw e;
+  }
+}
+
+function persistConfigFile(filePath: string, body: string): void {
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileAtomic(filePath, body);
+}
+
 function canPersistConfigMigration(): boolean {
   return !(process.env.MAW_TEST_MODE === "1" && CONFIG_FILE === REAL_HOME_CONFIG);
 }
@@ -89,7 +113,7 @@ function maybeMigrateLegacyConfigFile(): void {
   if (!existsSync(CONFIG_FILE) || existsSync(CONFIG_WEIGHTED_FILE)) return;
   try {
     const body = readFileSync(CONFIG_FILE, "utf-8");
-    writeFileSync(CONFIG_WEIGHTED_FILE, body.endsWith("\n") ? body : `${body}\n`, "utf-8");
+    persistConfigFile(CONFIG_WEIGHTED_FILE, body.endsWith("\n") ? body : `${body}\n`);
     process.stderr.write(
       `[maw] migrating ${CONFIG_FILE} → ${CONFIG_WEIGHTED_FILE} ` +
       `(legacy file kept for compatibility)\n`,
@@ -106,8 +130,8 @@ function persistLoadedConfig(label: string): void {
   if (!canPersistConfigMigration()) return;
   try {
     const body = JSON.stringify(cached, null, 2) + "\n";
-    writeFileSync(CONFIG_FILE, body, "utf-8");
-    if (existsSync(CONFIG_WEIGHTED_FILE)) writeFileSync(CONFIG_WEIGHTED_FILE, body, "utf-8");
+    persistConfigFile(CONFIG_FILE, body);
+    if (existsSync(CONFIG_WEIGHTED_FILE)) persistConfigFile(CONFIG_WEIGHTED_FILE, body);
   } catch (e) {
     process.stderr.write(
       `[maw] ${label}: in-memory heal applied but disk persist failed: ` +
@@ -504,7 +528,7 @@ export function saveConfig(update: Partial<MawConfig>) {
     current = {};
   }
   const merged = { ...current, ...update };
-  writeFileSync(target, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  persistConfigFile(target, JSON.stringify(merged, null, 2) + "\n");
   resetConfig(); // clear cache so next loadConfig() reads fresh
   refreshContext(); // clear DI cache so middleware picks up new config
   return loadConfig();

--- a/src/vendor/mpr-plugins/init/write-config.ts
+++ b/src/vendor/mpr-plugins/init/write-config.ts
@@ -1,17 +1,55 @@
-import { copyFileSync, existsSync, mkdirSync, writeFileSync } from "fs";
+import { copyFileSync, existsSync, linkSync, mkdirSync, renameSync, rmSync, writeFileSync } from "fs";
 import { dirname } from "path";
 import type { MawConfig } from "maw-js/config/types";
+
+function generateTmpPath(filePath: string): string {
+  return `${filePath}.tmp.${Date.now()}.${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function writeFileAtomic(filePath: string, body: string): void {
+  const tmpPath = generateTmpPath(filePath);
+  try {
+    writeFileSync(tmpPath, body, "utf-8");
+    renameSync(tmpPath, filePath);
+  } catch (e) {
+    try {
+      rmSync(tmpPath, { force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+    throw e;
+  }
+}
 
 /** Atomically write JSON config; throws EEXIST if `wx` flag and file exists. */
 export function writeConfigAtomic(filePath: string, config: Partial<MawConfig>, overwrite: boolean): void {
   mkdirSync(dirname(filePath), { recursive: true });
   const body = JSON.stringify(config, null, 2) + "\n";
   if (overwrite) {
-    writeFileSync(filePath, body, "utf-8");
+    writeFileAtomic(filePath, body);
     return;
   }
-  // wx mode: fail if exists
-  writeFileSync(filePath, body, { encoding: "utf-8", flag: "wx" });
+
+  const tmpPath = generateTmpPath(filePath);
+  try {
+    writeFileSync(tmpPath, body, { encoding: "utf-8", flag: "wx" });
+    // Atomic no-overwrite install: hard-link fails with EEXIST if the visible
+    // config path already exists, so disk-full temp writes never truncate it.
+    linkSync(tmpPath, filePath);
+  } catch (e) {
+    try {
+      rmSync(tmpPath, { force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+    throw e;
+  } finally {
+    try {
+      rmSync(tmpPath, { force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  }
 }
 
 export function backupConfig(filePath: string): string {

--- a/test/isolated/config-load-second-pass-coverage.test.ts
+++ b/test/isolated/config-load-second-pass-coverage.test.ts
@@ -4,6 +4,7 @@ const realFs = await import("fs");
 const realPaths = await import("../../src/core/paths");
 
 const MOCK_CONFIG_FILE = "/tmp/maw-config-second-pass-coverage/maw.config.json";
+const mockedConfigFileWrites: Record<string, string> = {};
 
 let rawConfigText = "{}";
 let readError: Error | null = null;
@@ -22,7 +23,8 @@ await mock.module("fs", () => ({
   ...realFs,
   readFileSync: ((path: string | Buffer | URL, ...args: unknown[]) => {
     const pathText = String(path);
-    if (pathText === MOCK_CONFIG_FILE) {
+    if (pathText.startsWith(MOCK_CONFIG_FILE)) {
+      if (pathText in mockedConfigFileWrites) return mockedConfigFileWrites[pathText];
       if (readError) throw readError;
       return rawConfigText;
     }
@@ -30,13 +32,34 @@ await mock.module("fs", () => ({
   }) as typeof realFs.readFileSync,
   writeFileSync: ((path: string | Buffer | URL, data: string | ArrayBufferView, ...args: unknown[]) => {
     const pathText = String(path);
-    if (pathText === MOCK_CONFIG_FILE) {
+    if (pathText.startsWith(MOCK_CONFIG_FILE)) {
       writeCalls.push({ path: pathText, data: String(data) });
+      mockedConfigFileWrites[pathText] = String(data);
       if (writeError) throw writeError;
       return;
     }
     return (realFs.writeFileSync as any)(path, data, ...args);
   }) as typeof realFs.writeFileSync,
+  renameSync: ((oldPath: string | URL, newPath: string | URL) => {
+    const oldPathText = String(oldPath);
+    const newPathText = String(newPath);
+    if (oldPathText.startsWith(MOCK_CONFIG_FILE)) {
+      if (oldPathText in mockedConfigFileWrites) {
+        mockedConfigFileWrites[newPathText] = mockedConfigFileWrites[oldPathText];
+        delete mockedConfigFileWrites[oldPathText];
+      }
+      return;
+    }
+    return realFs.renameSync(oldPath as any, newPath as any);
+  }) as typeof realFs.renameSync,
+  rmSync: ((path: string | URL, ...args: unknown[]) => {
+    const pathText = String(path);
+    if (pathText.startsWith(MOCK_CONFIG_FILE)) {
+      delete mockedConfigFileWrites[pathText];
+      return;
+    }
+    return realFs.rmSync(path as any, ...args);
+  }) as typeof realFs.rmSync,
 }));
 
 await mock.module(import.meta.resolve("../../src/core/paths"), () => ({
@@ -83,6 +106,7 @@ beforeEach(() => {
   readError = null;
   writeError = null;
   writeCalls = [];
+  for (const key of Object.keys(mockedConfigFileWrites)) delete mockedConfigFileWrites[key];
   validatedConfig = {};
   validateError = null;
   loadFleetResult = {};
@@ -125,7 +149,7 @@ describe("config load second pass coverage", () => {
       defaultActivePlugins1531: true,
     });
     expect(writeCalls).toHaveLength(5);
-    expect(writeCalls.every((call) => call.path === MOCK_CONFIG_FILE)).toBe(true);
+    expect(writeCalls.every((call) => call.path.startsWith(MOCK_CONFIG_FILE))).toBe(true);
     expect(JSON.parse(writeCalls.at(-1)!.data).disabledPlugins).toEqual(loaded.disabledPlugins);
     expect(stderrWrites.join("")).toContain("config.disabledPlugins migration (#1500)");
     expect(stderrWrites.join("")).toContain("config.disabledPlugins migration (#1514)");

--- a/test/isolated/config-load-second-pass.test.ts
+++ b/test/isolated/config-load-second-pass.test.ts
@@ -30,7 +30,7 @@ await mock.module("fs", () => ({
   ...realFs,
   readFileSync: ((path: string | Buffer | URL, ...args: unknown[]) => {
     const pathText = String(path);
-    if (pathText === MOCK_CONFIG_FILE) {
+    if (pathText.startsWith(MOCK_CONFIG_FILE)) {
       readCalls.push(pathText);
       if (readError) throw readError;
       return rawConfigText;
@@ -39,7 +39,7 @@ await mock.module("fs", () => ({
   }) as typeof realFs.readFileSync,
   writeFileSync: ((path: string | Buffer | URL, data: string | ArrayBufferView, ...args: unknown[]) => {
     const pathText = String(path);
-    if (pathText === MOCK_CONFIG_FILE) {
+    if (pathText.startsWith(MOCK_CONFIG_FILE)) {
       writeCalls.push({ path: pathText, data: String(data) });
       if (writeError) throw writeError;
       return;
@@ -211,7 +211,7 @@ describe("config load second pass coverage", () => {
     expect(loaded.host).toBe("local");
     expect(loaded.node).toBe("m5");
     expect(writeCalls).toHaveLength(1);
-    expect(writeCalls[0]?.path).toBe(MOCK_CONFIG_FILE);
+    expect(writeCalls[0]?.path.startsWith(MOCK_CONFIG_FILE)).toBe(true);
     expect(stderrWrites.some((line) => line.includes("legacy init bug (#906)"))).toBe(true);
     expect(
       stderrWrites.some((line) =>

--- a/test/isolated/vendor-bud-init-broadcast-rename-extra-coverage.test.ts
+++ b/test/isolated/vendor-bud-init-broadcast-rename-extra-coverage.test.ts
@@ -368,6 +368,7 @@ describe("init write-config extra isolated coverage", () => {
       expect(configExists(file)).toBe(true);
 
       expect(() => writeConfigAtomic(file, { node: "mba" } as any, false)).toThrow();
+      expect(JSON.parse(readFileSync(file, "utf-8"))).toEqual({ node: "white" });
       writeConfigAtomic(file, { node: "mba" } as any, true);
       expect(JSON.parse(readFileSync(file, "utf-8"))).toEqual({ node: "mba" });
 

--- a/test/wake-handler-cwd.test.ts
+++ b/test/wake-handler-cwd.test.ts
@@ -38,8 +38,13 @@ const { extractOracleName, resolveTargetCwd, shellQuote } = await import("../src
 describe("extractOracleName", () => {
   test("strips numeric prefix from session — 05-acme → acme", () => {
     expect(extractOracleName("05-acme:0")).toBe("acme");
-    expect(extractOracleName("05-acme:acme-oracle")).toBe("acme");
+    expect(extractOracleName("05-acme:acme-oracle")).toBe("acme-oracle");
     expect(extractOracleName("05-acme")).toBe("acme");
+  });
+
+  test("resolves by window name when target is node:session:window", () => {
+    expect(extractOracleName("m5:05-acme:acme-oracle")).toBe("acme-oracle");
+    expect(extractOracleName("m5:05-acme:0")).toBe("acme");
   });
 
   test("session without numeric prefix is passed through", () => {


### PR DESCRIPTION
## Summary
- make maw config persistence use same-directory temp writes with atomic rename for migrations/saveConfig
- make init config writes atomic, including no-overwrite create preserving existing config on EEXIST
- make wake respawn resolve command-map names from named window targets, with numeric window/session fallback

Closes #2012
Closes #1981

## Verification
- MAW_TEST_MODE=1 bun test ./test/wake-handler-cwd.test.ts ./test/isolated/config-load-second-pass.test.ts ./test/isolated/config-load-second-pass-coverage.test.ts --path-ignore-patterns '**/agents/**'\n- MAW_TEST_MODE=1 bun test ./test/isolated/vendor-bud-init-broadcast-rename-extra-coverage.test.ts -t 'writeConfigAtomic creates parent dirs' --path-ignore-patterns '**/agents/**' --timeout 5000\n- bun run build\n\n## Notes\n- Full suite not run because duplicate tests under agents/ worktrees make unscoped bun test scan noisy/hanging.\n