### PR TITLE
Implement node-local maw team yaml

### DIFF
--- a/src/vendor/mpr-plugins/team/team-charter.ts
+++ b/src/vendor/mpr-plugins/team/team-charter.ts
@@ -16,6 +16,8 @@ export interface TeamCharterMember {
   queue?: string[];
   node?: string;
   channels?: boolean;
+  /** New-style per-member channel override (`false` disables top-level `discord`). */
+  discord?: false;
 }
 
 export interface TeamCharter {
@@ -23,7 +25,13 @@ export interface TeamCharter {
   description?: string;
   goal?: string;
   session?: string;
+  /** Optional top-level project slug for generated wake targets (`owner/repo`). */
+  project?: string;
+  /** Optional top-level discord bridge toggle. `false` disables, string enables. */
+  discord?: string | false;
   members: TeamCharterMember[];
+  /** New-style agent map (`agents: { codex: { engine: omx, ... } }`). */
+  agents?: Record<string, Record<string, unknown>>;
   lifecycle?: Record<string, unknown>;
   governance?: Record<string, unknown>;
   warnings?: string[];
@@ -114,6 +122,66 @@ function readBlock(lines: string[], start: number, parentIndent: number): { valu
   };
 }
 
+function parseYamlMapBlock(lines: string[], start: number, parentIndent: number): { value: Record<string, Record<string, unknown>>; next: number } {
+  const out: Record<string, Record<string, unknown>> = {};
+  let i = start;
+  for (; i < lines.length; i++) {
+    const raw = lines[i]!;
+    if (!raw.trim()) continue;
+    const indent = lineIndent(raw);
+    if (indent <= parentIndent) break;
+
+    const header = raw.match(/^ {2}([A-Za-z_][\w-]*):(?:\s*(.*))?$/);
+    if (!header) throw new Error(`unsupported map entry near line ${i + 1}: ${raw.trim()}`);
+    const key = header[1]!;
+    const keyValue = header[2] ?? "";
+    if (keyValue.trim()) throw new Error(`unsupported map value near line ${i + 1}: ${raw.trim()}`);
+
+    const record: Record<string, unknown> = {};
+    i++;
+    while (i < lines.length) {
+      const child = lines[i]!;
+      if (!child.trim()) {
+        i++;
+        continue;
+      }
+      if (lineIndent(child) <= 2) break;
+      const field = child.match(/^ {4}([A-Za-z_][\w-]*):(?:\s*(.*))?$/);
+      if (!field) throw new Error(`unsupported map field near line ${i + 1}: ${child.trim()}`);
+      const fieldKey = field[1]!;
+      const fieldRaw = field[2] ?? "";
+      if (fieldRaw === "|") {
+        const block = readBlock(lines, i + 1, 4);
+        record[fieldKey] = block.value;
+        i = block.next;
+      } else if (fieldRaw === "") {
+        const items: unknown[] = [];
+        let j = i + 1;
+        while (j < lines.length) {
+          const itemLine = lines[j]!;
+          if (!itemLine.trim()) {
+            j++;
+            continue;
+          }
+          if (lineIndent(itemLine) <= 4) break;
+          const item = itemLine.match(/^ {6}-\s*(.*)$/);
+          if (!item) throw new Error(`unsupported map field near line ${j + 1}: ${itemLine.trim()}`);
+          items.push(scalar(item[1] ?? ""));
+          j++;
+        }
+        record[fieldKey] = items;
+        i = j;
+      } else {
+        record[fieldKey] = scalar(fieldRaw);
+        i++;
+      }
+    }
+    out[key] = record;
+    if (i < lines.length && lines[i]?.trim() && lineIndent(lines[i]!) > parentIndent) i--;
+  }
+  return { value: out, next: i };
+}
+
 function parseYamlSubset(text: string): TeamCharter {
   const lines = text.split(/\r?\n/).map(stripComment);
   const root: Record<string, unknown> = { members: [] };
@@ -190,6 +258,12 @@ function parseYamlSubset(text: string): TeamCharter {
       root.members = members;
       continue;
     }
+    if (key === "agents" && raw === "") {
+      const block = parseYamlMapBlock(lines, i + 1, 0);
+      i = block.next;
+      root.agents = block.value;
+      continue;
+    }
     if ((key === "lifecycle" || key === "governance") && raw === "") {
       const map: Record<string, unknown> = {};
       i++;
@@ -214,8 +288,29 @@ function parseYamlSubset(text: string): TeamCharter {
   return normalizeCharter(root);
 }
 
-const KNOWN_TOP_LEVEL_KEYS = new Set(["name", "description", "goal", "session", "members", "lifecycle", "governance"]);
-const KNOWN_MEMBER_KEYS = new Set(["role", "name", "target", "model", "cwd", "prompt", "engine", "worktree", "queue", "node", "channels"]);
+const KNOWN_TOP_LEVEL_KEYS = new Set(["name", "description", "goal", "session", "project", "discord", "members", "agents", "lifecycle", "governance"]);
+const KNOWN_MEMBER_KEYS = new Set(["role", "name", "target", "model", "cwd", "prompt", "engine", "worktree", "queue", "node", "channels", "discord"]);
+
+function normalizeTeamMember(roleRaw: string, m: Record<string, unknown>): TeamCharterMember {
+  const role = roleRaw.trim();
+  if (!role) throw new Error("agent key must be non-empty");
+  return {
+    role,
+    ...(typeof m.name === "string" && m.name.trim() ? { name: m.name.trim() } : {}),
+    ...(typeof m.target === "string" && m.target.trim() ? { target: m.target.trim() } : {}),
+    ...(typeof m.model === "string" && m.model.trim() ? { model: m.model.trim() } : {}),
+    ...(typeof m.cwd === "string" && m.cwd.trim() ? { cwd: m.cwd.trim() } : {}),
+    ...(typeof m.prompt === "string" && m.prompt.trim() ? { prompt: m.prompt.trim() } : {}),
+    ...(typeof m.engine === "string" && m.engine.trim() ? { engine: m.engine.trim() } : {}),
+    ...(typeof m.worktree === "boolean" ? { worktree: m.worktree } : {}),
+    ...(typeof m.worktree === "string" && m.worktree.trim() ? { worktree: m.worktree.trim() } : {}),
+    ...(Array.isArray(m.queue) ? { queue: m.queue.filter((item): item is string => typeof item === "string" && item.trim()).map((item) => item.trim()) } : {}),
+    ...(typeof m.queue === "string" && m.queue.trim() ? { queue: [m.queue.trim()] } : {}),
+    ...(typeof m.node === "string" && m.node.trim() ? { node: m.node.trim() } : {}),
+    ...(typeof m.channels === "boolean" ? { channels: m.channels } : {}),
+    ...(typeof m.discord === "boolean" && m.discord === false ? { discord: false } : {}),
+  };
+}
 
 function normalizeCharter(value: unknown): TeamCharter {
   if (!value || typeof value !== "object") throw new Error("team charter must be an object");
@@ -229,8 +324,7 @@ function normalizeCharter(value: unknown): TeamCharter {
   }
 
   if (typeof raw.name !== "string" || !raw.name.trim()) throw new Error("team charter requires name");
-  if (!Array.isArray(raw.members) || raw.members.length === 0) throw new Error("team charter requires at least one member");
-  const members = raw.members.map((member, idx) => {
+  const membersFromList = Array.isArray(raw.members) ? raw.members.map((member, idx) => {
     if (!member || typeof member !== "object") throw new Error(`member ${idx + 1} must be an object`);
     const m = member as Record<string, unknown>;
     for (const [key] of Object.entries(m)) {
@@ -241,28 +335,31 @@ function normalizeCharter(value: unknown): TeamCharter {
     }
     if (typeof m.role !== "string" || !m.role.trim()) throw new Error(`member ${idx + 1} requires role`);
 
-    return {
-      role: m.role.trim(),
-      ...(typeof m.name === "string" && m.name.trim() ? { name: m.name.trim() } : {}),
-      ...(typeof m.target === "string" && m.target.trim() ? { target: m.target.trim() } : {}),
-      ...(typeof m.model === "string" && m.model.trim() ? { model: m.model.trim() } : {}),
-      ...(typeof m.cwd === "string" && m.cwd.trim() ? { cwd: m.cwd.trim() } : {}),
-      ...(typeof m.prompt === "string" && m.prompt.trim() ? { prompt: m.prompt.trim() } : {}),
-      ...(typeof m.engine === "string" && m.engine.trim() ? { engine: m.engine.trim() } : {}),
-      ...(typeof m.worktree === "boolean" ? { worktree: m.worktree } : {}),
-      ...(typeof m.worktree === "string" && m.worktree.trim() ? { worktree: m.worktree.trim() } : {}),
-      ...(Array.isArray(m.queue) ? { queue: m.queue.filter((item): item is string => typeof item === "string" && item.trim()).map((item) => item.trim()) } : {}),
-      ...(typeof m.queue === "string" && m.queue.trim() ? { queue: [m.queue.trim()] } : {}),
-      ...(typeof m.node === "string" && m.node.trim() ? { node: m.node.trim() } : {}),
-      ...(typeof m.channels === "boolean" ? { channels: m.channels } : {}),
-    };
-  });
+    return normalizeTeamMember(m.role.trim(), m);
+  }) : [];
+  const membersFromAgents = (raw.agents && typeof raw.agents === "object" && !Array.isArray(raw.agents))
+    ? Object.entries(raw.agents).map(([agentKey, agentValue], idx) => {
+      if (!agentValue || typeof agentValue !== "object" || Array.isArray(agentValue)) {
+        throw new Error(`agent ${idx + 1} ('${agentKey}') must be a map`);
+      }
+      const m = agentValue as Record<string, unknown>;
+      for (const [key] of Object.entries(m)) {
+        if (!KNOWN_MEMBER_KEYS.has(key)) warnings.push(`member '${agentKey}' has unsupported key: ${key}`);
+      }
+      return normalizeTeamMember(agentKey, m);
+    })
+    : [];
+  const members = [...membersFromList, ...membersFromAgents];
+  if (members.length === 0) throw new Error("team charter requires at least one member");
   return {
     name: raw.name.trim(),
     ...(typeof raw.description === "string" && raw.description.trim() ? { description: raw.description.trim() } : {}),
     ...(typeof raw.goal === "string" && raw.goal.trim() ? { goal: raw.goal.trim() } : {}),
+    ...(typeof raw.project === "string" && raw.project.trim() ? { project: raw.project.trim() } : {}),
+    ...(raw.discord === false ? { discord: false } : typeof raw.discord === "string" ? { discord: raw.discord.trim() } : {}),
     ...(typeof raw.session === "string" && raw.session.trim() ? { session: raw.session.trim() } : {}),
     members,
+    ...(raw.agents && typeof raw.agents === "object" && !Array.isArray(raw.agents) ? { agents: raw.agents as Record<string, Record<string, unknown>> } : {}),
     ...(warnings.length ? { warnings } : {}),
     ...(raw.lifecycle && typeof raw.lifecycle === "object" && !Array.isArray(raw.lifecycle) ? { lifecycle: raw.lifecycle as Record<string, unknown> } : {}),
     ...(raw.governance && typeof raw.governance === "object" && !Array.isArray(raw.governance) ? { governance: raw.governance as Record<string, unknown> } : {}),

--- a/src/vendor/mpr-plugins/team/team-liveness.ts
+++ b/src/vendor/mpr-plugins/team/team-liveness.ts
@@ -55,12 +55,16 @@ export function memberWakeTarget(repoSlug: string, member: TeamCharterMember): s
   return repoSlug;
 }
 
-export function memberWakeOptions(member: TeamCharterMember, opts: WakeOptions & { engine: string; session: string; repoPath: string }): WakeOptions {
+export function memberWakeOptions(
+  member: TeamCharterMember,
+  opts: WakeOptions & { engine: string; session: string; repoPath: string },
+): WakeOptions {
+  const channels = opts.channels === undefined ? (member.channels === true) : opts.channels;
   const base: WakeOptions = {
     engine: opts.engine,
     session: opts.session,
     repoPath: opts.repoPath,
-    ...(member.channels === true ? { channels: true } : {}),
+    ...(channels ? { channels: true } : {}),
   };
   if (member.worktree === false) return base;
   return { ...base, wt: memberWorktree(member) };
@@ -103,12 +107,14 @@ export function findRepoRoot(cwd = process.cwd()): string {
   }
 }
 
-export function resolveCharterPath(team: string, cwd = process.cwd()): string | null {
+export function resolveCharterPath(team: string, cwd = process.cwd(), configNode?: string): string | null {
   const root = findRepoRoot(cwd);
   const local = join(root, ".maw", "teams", `${team}.yaml`);
   if (existsSync(local)) return local;
   const psi = join(root, "ψ", "teams", `${team}.yaml`);
   if (existsSync(psi)) return psi;
+  const nodeCandidate = configNode ? join(root, ".maw", `${configNode}.yaml`) : "";
+  if (configNode && existsSync(nodeCandidate)) return nodeCandidate;
   return null;
 }
 

--- a/src/vendor/mpr-plugins/team/team-up.ts
+++ b/src/vendor/mpr-plugins/team/team-up.ts
@@ -2,11 +2,14 @@
 // (~/.maw/plugins/team → src/vendor/mpr-plugins/team), not src/commands/plugins/team.
 // Paths differ from the core copy: charter is a sibling here, and commands/shared
 // is three levels up (vendored dir is src/vendor/mpr-plugins/team).
+import { existsSync, readFileSync } from "fs";
+import { resolve } from "path";
 import { readTeamCharter, type TeamCharter } from "./team-charter";
 import { loadConfig } from "../../../config/load";
 import type { MawConfig } from "../../../config/types";
 import { Tmux } from "../../../core/transport/tmux";
 import { cmdWake } from "../../../commands/shared/wake-cmd";
+import { cmdSend } from "../../../commands/shared/comm-send";
 import { TEAM_LIFECYCLE_GUARD_WINDOW } from "./team-down";
 import {
   classifyMember,
@@ -17,6 +20,7 @@ import {
   repoSlugFromRoot,
   resolveCharterPath,
   memberWakeTarget,
+  memberWindowIdentity,
   wakeMember,
   type ClassifiedTeamMember,
 } from "./team-liveness";
@@ -54,6 +58,7 @@ export interface TeamUpDeps {
   readTeamCharterFn?: typeof readTeamCharter;
   loadConfigFn?: typeof loadConfig;
   cmdWakeFn?: typeof cmdWake;
+  cmdSendFn?: typeof cmdSend;
   sleep?: (ms: number) => Promise<void>;
   repoRoot?: string;
   repoSlug?: string;
@@ -100,31 +105,67 @@ function warnOnPathCollisions(roster: ClassifiedTeamMember[], warnings: string[]
   }
 }
 
-function wakePlan(item: ClassifiedTeamMember, repoSlug: string, session: string): string {
-  if (item.member.worktree === false) {
-    return `wakeable ${memberWakeTarget(repoSlug, item.member)} -e ${item.engine} --session ${session}${item.member.channels ? " --channels" : ""}`;
-  }
-  return `wakeable --wt ${item.worktree} -e ${item.engine} --session ${session}${item.member.channels ? " --channels" : ""}`;
+function memberChannels(charter: TeamCharter, member: TeamCharter["members"][number]): boolean {
+  if (member.discord === false) return false;
+  if (charter.discord && charter.discord !== false) return true;
+  return member.channels === true;
 }
 
-function freshWakePlan(item: ClassifiedTeamMember, repoSlug: string, session: string, prefix = "would fresh wake"): string {
+function channelFlag(channels: boolean): string {
+  return channels ? " --channels" : "";
+}
+
+function wakePlan(item: ClassifiedTeamMember, repoSlug: string, session: string, channels = false): string {
   if (item.member.worktree === false) {
-    return `${prefix} ${memberWakeTarget(repoSlug, item.member)} -e ${item.engine} --session ${session}${item.member.channels ? " --channels" : ""}`;
+    return `wakeable ${memberWakeTarget(repoSlug, item.member)} -e ${item.engine} --session ${session}${channelFlag(channels)}`;
   }
-  return `${prefix} --wt ${item.worktree} -e ${item.engine} --session ${session}${item.member.channels ? " --channels" : ""}`;
+  return `wakeable --wt ${item.worktree} -e ${item.engine} --session ${session}${channelFlag(channels)}`;
+}
+
+function freshWakePlan(item: ClassifiedTeamMember, repoSlug: string, session: string, channels = false, prefix = "would fresh wake"): string {
+  if (item.member.worktree === false) {
+    return `${prefix} ${memberWakeTarget(repoSlug, item.member)} -e ${item.engine} --session ${session}${channelFlag(channels)}`;
+  }
+  return `${prefix} --wt ${item.worktree} -e ${item.engine} --session ${session}${channelFlag(channels)}`;
+}
+
+function resolvePrimingPrompt(member: TeamCharter["members"][number], repoRoot: string): string | undefined {
+  const prompt = member.prompt?.trim();
+  if (!prompt) return undefined;
+  if (!prompt.startsWith("./")) return prompt;
+  const path = resolve(repoRoot, prompt);
+  if (!existsSync(path)) throw new Error(`prompt file not found for ${member.role}: ${prompt}`);
+  return readFileSync(path, "utf-8").trim();
+}
+
+async function primeMember(
+  member: TeamCharter["members"][number],
+  repoRoot: string,
+  deps: Pick<TeamUpDeps, "cmdSendFn">,
+  warnings: string[],
+): Promise<void> {
+  const prompt = resolvePrimingPrompt(member, repoRoot);
+  if (!prompt) return;
+  const send = deps.cmdSendFn ?? cmdSend;
+  try {
+    await send(memberWindowIdentity(member), prompt, false);
+  } catch (error) {
+    warnings.push(`prompt prime failed for ${member.role}: ${error instanceof Error ? error.message : String(error)}`);
+  }
 }
 
 export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: TeamUpDeps = {}): Promise<TeamUpResult> {
   const cwd = deps.cwd ?? process.cwd();
-  const charterPath = deps.charterPath !== undefined ? deps.charterPath : resolveCharterPath(team, cwd);
-  if (!charterPath) throw new Error(`charter not found: ${team}`);
+  const config: MawConfig = (deps.loadConfigFn ?? loadConfig)();
+  const charterPath = deps.charterPath !== undefined ? deps.charterPath : resolveCharterPath(team, cwd, config.node);
+  if (!charterPath) throw new Error(config.node ? `charter not found: ${team} (no team file for node '${config.node}')` : `charter not found: ${team}`);
 
   const read = deps.readTeamCharterFn ?? readTeamCharter;
   const charter: TeamCharter = read(charterPath);
   const tmux = deps.tmux ?? new Tmux();
-  const config: MawConfig = (deps.loadConfigFn ?? loadConfig)();
   const repoRoot = deps.repoRoot ?? findRepoRoot(cwd);
   const repoSlug = deps.repoSlug ?? repoSlugFromRoot(repoRoot);
+  const targetRepoSlug = charter.project ?? repoSlug;
   const currentSession = await currentTmuxSession(tmux).catch(() => "");
   const session = opts.session?.trim() || charter.session || currentSession;
   if (!session) throw new Error(`session required: pass --session <name> when running team up outside tmux and charter.session is omitted`);
@@ -137,13 +178,13 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
 
   const panes = await listPaneSnapshots(tmux);
   const only = opts.only?.length ? new Set(opts.only.map((item) => item.trim()).filter(Boolean)) : undefined;
-  const roster = charter.members.map((member) => classifyMember(member, panes, session, { engine: opts.engine, currentNode: config.node, only, repoSlug }));
+  const roster = charter.members.map((member) => classifyMember(member, panes, session, { engine: opts.engine, currentNode: config.node, only, repoSlug: targetRepoSlug }));
   const actions: TeamUpAction[] = [];
 
   if (opts.status) {
     for (const item of roster) {
       if (item.state === "skipped") actions.push({ role: item.role, state: item.state, action: `skip (${item.skipReason ?? "guard"})` });
-      else if (item.state === "missing") actions.push({ role: item.role, state: item.state, action: wakePlan(item, repoSlug, session) });
+      else if (item.state === "missing") actions.push({ role: item.role, state: item.state, action: wakePlan(item, targetRepoSlug, session, memberChannels(charter, item.member)) });
       else if (item.state === "dead") actions.push({ role: item.role, state: item.state, action: "wakeable resume in place" });
       else actions.push({ role: item.role, state: item.state, action: "skip live" });
     }
@@ -159,7 +200,7 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
         actions.push({ role: item.role, state: item.state, action: `skip (${item.skipReason ?? "guard"})` });
       } else if (opts.force) {
         const command = engineCommand(item.engine, { resume: false }, config);
-        actions.push({ role: item.role, state: item.state, action: freshWakePlan(item, repoSlug, session, "would force fresh wake"), command });
+        actions.push({ role: item.role, state: item.state, action: freshWakePlan(item, targetRepoSlug, session, memberChannels(charter, item.member), "would force fresh wake"), command });
       } else if (item.state === "live") {
         actions.push({ role: item.role, state: item.state, action: "skip live" });
       } else if (item.state === "dead") {
@@ -167,7 +208,7 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
         actions.push({ role: item.role, state: item.state, action: "would relaunch in place with resume", command });
       } else {
         const command = engineCommand(item.engine, { resume: false }, config);
-        actions.push({ role: item.role, state: item.state, action: freshWakePlan(item, repoSlug, session), command });
+        actions.push({ role: item.role, state: item.state, action: freshWakePlan(item, targetRepoSlug, session, memberChannels(charter, item.member)), command });
       }
     }
     warnOnPathCollisions(roster, warnings);
@@ -183,26 +224,29 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
     } else if (opts.force) {
       if (item.pane) await tmux.run("kill-window", "-t", `${item.pane.sessionName ?? session}:${item.pane.windowName}`);
       const command = engineCommand(item.engine, { resume: false }, config);
-      await wakeMember(repoSlug, item.member, { engine: item.engine, session, repoPath: repoRoot }, { cmdWakeFn: deps.cmdWakeFn });
+      await wakeMember(targetRepoSlug, item.member, { engine: item.engine, session, repoPath: repoRoot, channels: memberChannels(charter, item.member) }, { cmdWakeFn: deps.cmdWakeFn });
       actions.push({ role: item.role, state: item.state, action: "force fresh wake", command });
-      await waitForNonShell(item.member, session, tmux, sleep, repoSlug);
+      await waitForNonShell(item.member, session, tmux, sleep, targetRepoSlug);
+      await primeMember(item.member, repoRoot, deps, warnings);
     } else if (item.state === "live") {
       actions.push({ role: item.role, state: item.state, action: "skip live" });
     } else if (item.state === "dead") {
       const command = engineCommand(item.engine, { resume: true }, config);
       await tmux.run("send-keys", "-t", item.pane!.paneId, command, "Enter");
       actions.push({ role: item.role, state: item.state, action: "resume in place", command });
-      await waitForNonShell(item.member, session, tmux, sleep, repoSlug);
+      await waitForNonShell(item.member, session, tmux, sleep, targetRepoSlug);
+      await primeMember(item.member, repoRoot, deps, warnings);
     } else {
       const command = engineCommand(item.engine, { resume: false }, config);
-      await wakeMember(repoSlug, item.member, { engine: item.engine, session, repoPath: repoRoot }, { cmdWakeFn: deps.cmdWakeFn });
+      await wakeMember(targetRepoSlug, item.member, { engine: item.engine, session, repoPath: repoRoot, channels: memberChannels(charter, item.member) }, { cmdWakeFn: deps.cmdWakeFn });
       actions.push({ role: item.role, state: item.state, action: "fresh wake", command });
-      await waitForNonShell(item.member, session, tmux, sleep, repoSlug);
+      await waitForNonShell(item.member, session, tmux, sleep, targetRepoSlug);
+      await primeMember(item.member, repoRoot, deps, warnings);
     }
   }
 
   const finalPanes = await listPaneSnapshots(tmux).catch(() => panes);
-  const finalRoster = charter.members.map((member) => classifyMember(member, finalPanes, session, { engine: opts.engine, currentNode: config.node, only, repoSlug }));
+  const finalRoster = charter.members.map((member) => classifyMember(member, finalPanes, session, { engine: opts.engine, currentNode: config.node, only, repoSlug: targetRepoSlug }));
   warnOnPathCollisions(finalRoster, warnings);
 
   if (opts.gather) {

--- a/test/isolated/team-charter-plan.test.ts
+++ b/test/isolated/team-charter-plan.test.ts
@@ -114,6 +114,33 @@ governance:
     expect(charter.governance?.requires_human_approval).toBe(false);
   });
 
+
+
+  test("parses node yaml project, discord, and agents map", () => {
+    const charter = parseTeamCharterText(`
+name: m5-team
+project: soul-brews-studio/maw-js
+discord: mawjs
+agents:
+  codex:
+    engine: omx
+    prompt: |
+      inline prompt
+  oss-world:
+    engine: claude
+    discord: false
+    prompt: ./prompts/bridge.md
+`);
+
+    expect(charter.project).toBe("soul-brews-studio/maw-js");
+    expect(charter.discord).toBe("mawjs");
+    expect(charter.warnings).toBeUndefined();
+    expect(charter.members).toEqual([
+      { role: "codex", engine: "omx", prompt: "inline prompt" },
+      { role: "oss-world", engine: "claude", discord: false, prompt: "./prompts/bridge.md" },
+    ]);
+  });
+
   test("warns and ignores unknown top-level and member keys", () => {
     const charter = parseTeamCharterText(`
 name: warn-team

--- a/test/isolated/team-up-coverage.test.ts
+++ b/test/isolated/team-up-coverage.test.ts
@@ -8,7 +8,7 @@ import { tmpdir } from "os";
 // (core), which is tested but NOT dispatched, so `maw team up` was unreachable
 // despite green tests. Guard the copy that actually ships.
 import { parseTeamCharterText } from "../../src/vendor/mpr-plugins/team/team-charter";
-import { classifyMember, engineCommand, memberWakeOptions, memberWakeTarget } from "../../src/vendor/mpr-plugins/team/team-liveness";
+import { classifyMember, engineCommand, memberWakeOptions, memberWakeTarget, resolveCharterPath } from "../../src/vendor/mpr-plugins/team/team-liveness";
 import { cmdTeamUp } from "../../src/vendor/mpr-plugins/team/team-up";
 import { cmdTeamDown, TEAM_LIFECYCLE_GUARD_WINDOW } from "../../src/vendor/mpr-plugins/team/team-down";
 
@@ -172,6 +172,89 @@ members:
     expect(wakes).toEqual([[expect.any(String), { wt: "mawjs-oss-world", engine: "claude", session: "charter-session", repoPath: root, channels: true }]]);
   });
 
+
+
+
+  test("node yaml charter is resolved from config.node and new agents map defaults to worktrees", async () => {
+    const root = mkdtempSync(join(tmpdir(), "maw-node-yaml-"));
+    dirs.push(root);
+    mkdirSync(join(root, ".git"));
+    mkdirSync(join(root, ".maw"), { recursive: true });
+    writeFileSync(join(root, ".maw", "m5.yaml"), `
+name: m5-team
+project: soul-brews-studio/maw-js
+discord: mawjs
+agents:
+  codex:
+    engine: omx
+    prompt: inline hello
+  oss-world:
+    engine: claude
+    discord: false
+`, "utf-8");
+    const { tmux } = fakeTmux([]);
+
+    expect(resolveCharterPath("missing-team", root, "m5")).toBe(join(root, ".maw", "m5.yaml"));
+
+    const status = await cmdTeamUp("missing-team", { status: true, session: "charter-session" }, {
+      cwd: root,
+      tmux,
+      loadConfigFn: () => ({ ...config, node: "m5" }),
+      logger: () => {},
+    });
+
+    expect(status.roster.map((m) => [m.role, m.engine, m.worktree, m.state])).toEqual([
+      ["codex", "omx", "codex", "missing"],
+      ["oss-world", "claude", "oss-world", "missing"],
+    ]);
+    expect(status.output).toContain("codex\tomx\tmissing\twakeable --wt codex -e omx --session charter-session --channels");
+    expect(status.output).toContain("oss-world\tclaude\tmissing\twakeable --wt oss-world -e claude --session charter-session");
+    expect(status.output).not.toContain("oss-world\tclaude\tmissing\twakeable --wt oss-world -e claude --session charter-session --channels");
+  });
+
+  test("team up wakes charter.project and primes inline plus file-ref prompts", async () => {
+    const root = mkdtempSync(join(tmpdir(), "maw-node-prompt-"));
+    dirs.push(root);
+    mkdirSync(join(root, ".git"));
+    mkdirSync(join(root, ".maw"), { recursive: true });
+    mkdirSync(join(root, "prompts"), { recursive: true });
+    writeFileSync(join(root, "prompts", "claude48.md"), "file prompt\n", "utf-8");
+    writeFileSync(join(root, ".maw", "m5.yaml"), `
+name: m5-team
+project: soul-brews-studio/maw-js
+discord: mawjs
+agents:
+  codex:
+    engine: omx
+    prompt: |
+      inline prompt
+  claude48:
+    engine: claude48
+    prompt: ./prompts/claude48.md
+`, "utf-8");
+    const { tmux } = fakeTmux([]);
+    const wakes: any[] = [];
+    const sends: any[] = [];
+
+    await cmdTeamUp("any", { session: "charter-session" }, {
+      cwd: root,
+      tmux,
+      loadConfigFn: () => ({ ...config, node: "m5" }),
+      cmdWakeFn: async (...a: any[]) => { wakes.push(a); return "woke"; },
+      cmdSendFn: async (...a: any[]) => { sends.push(a); },
+      sleep: async () => {},
+      logger: () => {},
+    });
+
+    expect(wakes).toEqual([
+      ["soul-brews-studio/maw-js", { wt: "codex", engine: "omx", session: "charter-session", repoPath: root, channels: true }],
+      ["soul-brews-studio/maw-js", { wt: "claude48", engine: "claude48", session: "charter-session", repoPath: root, channels: true }],
+    ]);
+    expect(sends).toEqual([
+      ["codex", "inline prompt", false],
+      ["claude48", "file prompt", false],
+    ]);
+  });
 
   test("semantic role adopts live window by charter member name", async () => {
     const root = tempRepo();


### PR DESCRIPTION
## Summary
- resolve `maw team up` charters from `.maw/<config.node>.yaml` after legacy team paths
- parse `project`, `discord`, and `agents:` maps into wakeable team members
- inject channels from top-level/per-agent discord settings, wake `charter.project`, and prime agents from inline/file-ref prompts

Closes #2009

## Tested
- `bun test test/isolated/team-up-coverage.test.ts test/isolated/team-charter-plan.test.ts`
- `bun run build`