### PR TITLE
Align migration guard with atomic persistence

### DIFF
--- a/test/isolated/migration-persist-913.test.ts
+++ b/test/isolated/migration-persist-913.test.ts
@@ -333,13 +333,14 @@ describe("#913 — hostExec sees migrated host on next process boot", () => {
 
 // ─── (5) Source-level guard — the persist branch lives inside loadConfig ─────
 
-test("#913 — load.ts contains a writeFileSync inside the host=node migration block", () => {
+test("#913 — load.ts persists the host=node migration through the config writer", () => {
   const src = readFileSync(join(REPO_ROOT, "src/config/load.ts"), "utf-8");
-  // The fix must call writeFileSync after setting cached.host = "local"
-  // in the host=node branch. We check the structural pattern rather
-  // than exact whitespace so a future refactor can rearrange comments.
+  // The fix must persist after setting cached.host = "local" in the host=node
+  // branch. We check the structural pattern rather than exact whitespace so a
+  // future refactor can rearrange comments or swap direct writes for the atomic
+  // config writer used by #2012.
   expect(src).toMatch(/cached\.host = "local";[\s\S]*persistLoadedConfig\("config\.host migration"\)/);
-  expect(src).toMatch(/function persistLoadedConfig[\s\S]*writeFileSync\(CONFIG_FILE/);
+  expect(src).toMatch(/function persistLoadedConfig[\s\S]*persistConfigFile\(CONFIG_FILE/);
   // The #820-style guard must wrap the persist.
   expect(src).toMatch(/MAW_TEST_MODE.*REAL_HOME_CONFIG/);
 });


### PR DESCRIPTION
## Summary
- update the #913 source-level guard to accept the atomic config persistence helper introduced by #2012
- keeps the guard focused on persisted host=node healing without requiring direct visible-path writes

Follow-up for #2012 / PR #2043.

## Verification
- MAW_TEST_MODE=1 bun test ./test/isolated/migration-persist-913.test.ts --path-ignore-patterns '**/agents/**'\n