### PR TITLE
Add batch pane capture API

### DIFF
--- a/src/api/sessions.ts
+++ b/src/api/sessions.ts
@@ -19,7 +19,7 @@ import type { Session } from "../core/transport/ssh";
 
 type Config = ReturnType<typeof loadConfig>;
 type IdleCheck = Awaited<ReturnType<typeof checkPaneIdle>>;
-type TmuxLike = Pick<Tmux, "sendKeysLiteral" | "sendKeys">;
+type TmuxLike = Pick<Tmux, "sendKeysLiteral" | "sendKeys" | "listPanes" | "capture">;
 
 type AutoWakeDecision = Awaited<ReturnType<typeof defaultShouldAutoWake>>;
 type AutoWakeOpts = Parameters<typeof defaultShouldAutoWake>[1];
@@ -234,6 +234,25 @@ export function createSessionsApi(deps: SessionsApiDeps = {}) {
     query: t.Object({
       local: t.Optional(t.String()),
     }),
+  });
+
+  api.get("/captures", async ({ set }) => {
+    try {
+      const tmux = d.createTmux();
+      const panes = await tmux.listPanes();
+      const entries = await Promise.all(panes.map(async pane => {
+        try {
+          return [pane.id, await tmux.capture(pane.id, 200)] as const;
+        } catch {
+          // Pane may close between list-panes and capture-pane; keep response total.
+          return [pane.id, ""] as const;
+        }
+      }));
+      return { captures: Object.fromEntries(entries) };
+    } catch (error) {
+      set.status = 503;
+      return sessionsUnavailablePayload(error);
+    }
   });
 
   api.get("/capture", async ({ query, set }) => {

--- a/test/sessions-api-default.test.ts
+++ b/test/sessions-api-default.test.ts
@@ -59,6 +59,8 @@ function makeHarness(overrides: SessionsApiDeps = {}) {
     createTmux: () => ({
       sendKeysLiteral: async (target: string, text: string) => { calls.push(["literal", target, text]); },
       sendKeys: async (target: string, key: string) => { calls.push(["tmuxKeys", target, key]); },
+      listPanes: async () => [],
+      capture: async (target: string, lines?: number) => { calls.push(["tmuxCapture", target, lines]); return ""; },
     } as any),
     emitMessageLifecycle: (input) => { lifecycle.push(input); },
     writeReceiverInbox: null,
@@ -167,6 +169,57 @@ describe("sessions, capture, and mirror routes", () => {
 
     const err = makeHarness({ capture: async () => { throw new Error("capture boom"); } });
     expect(await readJson(await err.app.handle(new Request("http://local/capture?target=neo")))).toEqual({ content: "", error: "capture boom" });
+  });
+
+  test("GET /captures returns ANSI captures for every tmux pane using 200 lines", async () => {
+    const captureCalls: any[] = [];
+    const h = makeHarness({
+      createTmux: () => ({
+        sendKeysLiteral: async () => {},
+        sendKeys: async () => {},
+        listPanes: async () => [
+          { id: "%1", command: "zsh", target: "maw:main.0", title: "one", pid: 101, cwd: "/tmp" },
+          { id: "%2", command: "bun", target: "maw:api.0", title: "two", pid: 102, cwd: "/repo" },
+        ],
+        capture: async (target: string, lines?: number) => {
+          captureCalls.push([target, lines]);
+          return target === "%1" ? "\x1b[31mred\x1b[0m" : "second pane";
+        },
+      } as any),
+    });
+
+    const res = await h.app.handle(new Request("http://local/captures"));
+
+    expect(res.status).toBe(200);
+    expect(await readJson(res)).toEqual({
+      captures: {
+        "%1": "\x1b[31mred\x1b[0m",
+        "%2": "second pane",
+      },
+    });
+    expect(captureCalls).toEqual([["%1", 200], ["%2", 200]]);
+  });
+
+  test("GET /captures keeps pane keys when a pane closes during capture", async () => {
+    const h = makeHarness({
+      createTmux: () => ({
+        sendKeysLiteral: async () => {},
+        sendKeys: async () => {},
+        listPanes: async () => [
+          { id: "%1", command: "zsh", target: "maw:main.0", title: "one", pid: 101, cwd: "/tmp" },
+          { id: "%2", command: "bun", target: "maw:api.0", title: "two", pid: 102, cwd: "/repo" },
+        ],
+        capture: async (target: string) => {
+          if (target === "%2") throw new Error("pane gone");
+          return "still here";
+        },
+      } as any),
+    });
+
+    const res = await h.app.handle(new Request("http://local/captures"));
+
+    expect(res.status).toBe(200);
+    expect(await readJson(res)).toEqual({ captures: { "%1": "still here", "%2": "" } });
   });
 
   test("GET /mirror validates target and processes captured output", async () => {


### PR DESCRIPTION
## Summary
- add GET /api/captures to return all tmux panes as `{ captures: Record<paneId, string> }`
- capture each pane concurrently via existing tmux capture helper with 200 ANSI-preserving lines
- keep batch response resilient if a pane disappears after list-panes

Closes #2047

## Tests
- MAW_TEST_MODE=1 bun test ./test/sessions-api-default.test.ts --path-ignore-patterns **/agents/**
- bun run build

## Not tested
- Live HTTP smoke against a running maw daemon with real tmux panes