### PR TITLE
Add tmux spatial fields to ls json

### DIFF
--- a/src/commands/plugins/tmux/impl.ts
+++ b/src/commands/plugins/tmux/impl.ts
@@ -254,6 +254,20 @@ interface AnnotatedPane {
   sessionActivity?: number;
   source?: string;
   cwd?: string;
+  top?: number;
+  left?: number;
+  w?: number;
+  h?: number;
+  paneIdx?: number;
+  winIdx?: number;
+  winName?: string;
+  active?: boolean;
+  window?: {
+    w?: number;
+    h?: number;
+    active?: boolean;
+  };
+  attached?: boolean;
 }
 
 export function classifyLsPaneActivity(status: PaneStatus): PaneActivity {
@@ -568,6 +582,16 @@ export async function cmdTmuxLs(opts: TmuxLsOpts = {}): Promise<void> {
       sessionActivity: activityBySession.get(session),
       source: (p as { source?: string; node?: string }).source ?? (p as { node?: string }).node,
       cwd: p.cwd,
+      top: p.top,
+      left: p.left,
+      w: p.w,
+      h: p.h,
+      paneIdx: p.paneIdx,
+      winIdx: p.winIdx,
+      winName: p.winName,
+      active: p.active,
+      window: p.window,
+      attached: p.attached,
     };
   });
 

--- a/src/core/transport/tmux-class.ts
+++ b/src/core/transport/tmux-class.ts
@@ -233,10 +233,33 @@ export class Tmux {
   async listPanes(): Promise<TmuxPane[]> {
     try {
       const raw = await this.run("list-panes", "-a", "-F",
-        "#{pane_id}|||#{pane_current_command}|||#{session_name}:#{window_name}.#{pane_index}|||#{pane_title}|||#{pane_pid}|||#{pane_current_path}|||#{window_activity}");
+        "#{pane_id}|||#{pane_current_command}|||#{session_name}:#{window_name}.#{pane_index}|||#{pane_title}|||#{pane_pid}|||#{pane_current_path}|||#{window_activity}|||#{pane_top}|||#{pane_left}|||#{pane_width}|||#{pane_height}|||#{pane_index}|||#{window_index}|||#{window_name}|||#{pane_active}|||#{window_width}|||#{window_height}|||#{window_active}|||#{session_attached}");
+      const num = (value: string | undefined) => {
+        const n = Number(value);
+        return Number.isFinite(n) ? n : undefined;
+      };
+      const bool = (value: string | undefined) => value === "1" || value === "true";
       return raw.split("\n").filter(Boolean).map(line => {
-        const [id, command, target, title, pid, cwd, winAct] = line.split("|||");
-        return { id, command, target, title, pid: pid ? Number(pid) : undefined, cwd: cwd || undefined, lastActivity: winAct ? Number(winAct) : undefined };
+        const [id, command, target, title, pid, cwd, winAct, top, left, paneW, paneH, paneIdx, winIdx, winName, paneActive, winW, winH, winActive, attached] = line.split("|||");
+        return {
+          id,
+          command,
+          target,
+          title,
+          pid: pid ? Number(pid) : undefined,
+          cwd: cwd || undefined,
+          lastActivity: winAct ? Number(winAct) : undefined,
+          top: num(top),
+          left: num(left),
+          w: num(paneW),
+          h: num(paneH),
+          paneIdx: num(paneIdx),
+          winIdx: num(winIdx),
+          winName: winName || undefined,
+          active: bool(paneActive),
+          window: { w: num(winW), h: num(winH), active: bool(winActive) },
+          attached: bool(attached),
+        };
       });
     } catch { return []; }
   }

--- a/src/core/transport/tmux-types.ts
+++ b/src/core/transport/tmux-types.ts
@@ -19,6 +19,20 @@ export interface TmuxPane {
   pid?: number;
   cwd?: string;
   lastActivity?: number;
+  top?: number;
+  left?: number;
+  w?: number;
+  h?: number;
+  paneIdx?: number;
+  winIdx?: number;
+  winName?: string;
+  active?: boolean;
+  window?: {
+    w?: number;
+    h?: number;
+    active?: boolean;
+  };
+  attached?: boolean;
 }
 
 export interface TmuxWindow {

--- a/test/isolated/tmux-class-tenth-pass-coverage.test.ts
+++ b/test/isolated/tmux-class-tenth-pass-coverage.test.ts
@@ -144,10 +144,37 @@ describe("tmux-class tenth-pass isolated coverage", () => {
         args: [
           "-a",
           "-F",
-          "#{pane_id}|||#{pane_current_command}|||#{session_name}:#{window_name}.#{pane_index}|||#{pane_title}|||#{pane_pid}|||#{pane_current_path}|||#{window_activity}",
+          "#{pane_id}|||#{pane_current_command}|||#{session_name}:#{window_name}.#{pane_index}|||#{pane_title}|||#{pane_pid}|||#{pane_current_path}|||#{window_activity}|||#{pane_top}|||#{pane_left}|||#{pane_width}|||#{pane_height}|||#{pane_index}|||#{window_index}|||#{window_name}|||#{pane_active}|||#{window_width}|||#{window_height}|||#{window_active}|||#{session_attached}",
         ],
       },
     ]);
+  });
+
+  test("listPanes parses spatial pane, window, and session metadata", async () => {
+    const t = new RecordingTmux().queue(
+      "list-panes",
+      "%7|||claude|||alpha:main.1|||main|||123|||/repo|||1700|||4|||9|||80|||24|||1|||2|||main|||1|||160|||48|||0|||1\n",
+    );
+
+    await expect(t.listPanes()).resolves.toEqual([{
+      id: "%7",
+      command: "claude",
+      target: "alpha:main.1",
+      title: "main",
+      pid: 123,
+      cwd: "/repo",
+      lastActivity: 1700,
+      top: 4,
+      left: 9,
+      w: 80,
+      h: 24,
+      paneIdx: 1,
+      winIdx: 2,
+      winName: "main",
+      active: true,
+      window: { w: 160, h: 48, active: false },
+      attached: true,
+    }]);
   });
 
   test("getPaneCommands fails soft when the batch pane command lookup errors", async () => {

--- a/test/isolated/tmux-impl-plugin-second-pass-coverage.test.ts
+++ b/test/isolated/tmux-impl-plugin-second-pass-coverage.test.ts
@@ -4,7 +4,23 @@ import { join } from "path";
 const srcRoot = join(import.meta.dir, "../..");
 const mockHome = "/mock-home-second-pass";
 
-type Pane = { id: string; target: string; command?: string; title?: string; lastActivity?: number };
+type Pane = {
+  id: string;
+  target: string;
+  command?: string;
+  title?: string;
+  lastActivity?: number;
+  top?: number;
+  left?: number;
+  w?: number;
+  h?: number;
+  paneIdx?: number;
+  winIdx?: number;
+  winName?: string;
+  active?: boolean;
+  window?: { w?: number; h?: number; active?: boolean };
+  attached?: boolean;
+};
 
 let hostCalls: string[] = [];
 let hostResponses = new Map<string, string>();
@@ -178,6 +194,44 @@ describe("tmux impl plugin second-pass isolated coverage", () => {
     expect(compact.logs).toContain("maw-view");
     expect(compact.logs).toContain("scratch");
     expect(compact.logs).toContain("maw ls -v");
+  });
+
+
+  test("ls json includes pane, window, and session spatial metadata", async () => {
+    panes = [
+      {
+        id: "%9",
+        target: "spatial:editor.2",
+        command: "claude",
+        title: "editor",
+        lastActivity: Math.floor(Date.now() / 1000),
+        top: 3,
+        left: 11,
+        w: 80,
+        h: 24,
+        paneIdx: 2,
+        winIdx: 7,
+        winName: "editor",
+        active: true,
+        window: { w: 161, h: 49, active: false },
+        attached: true,
+      },
+    ];
+
+    const json = await capture(() => cmdTmuxLs({ all: true, json: true }));
+    expect(JSON.parse(json.logs)[0]).toMatchObject({
+      id: "%9",
+      top: 3,
+      left: 11,
+      w: 80,
+      h: 24,
+      paneIdx: 2,
+      winIdx: 7,
+      winName: "editor",
+      active: true,
+      window: { w: 161, h: 49, active: false },
+      attached: true,
+    });
   });
 
   test("annotatePane precedence favors team over fleet, then view, then claude-like orphan panes", () => {


### PR DESCRIPTION
## Summary
- add tmux pane geometry/index/active fields to `maw ls --json`
- include window geometry/active and session attached metadata on JSON rows
- extend tmux transport parsing and regression tests

Closes #2046

## Tested
- `bun test test/isolated/tmux-class-tenth-pass-coverage.test.ts`
- `bun test test/isolated/tmux-impl-plugin-second-pass-coverage.test.ts`
- `bun run build`