### PR TITLE
Add daemon tmux WebSocket stream

### DIFF
--- a/src/api/tmux-stream.ts
+++ b/src/api/tmux-stream.ts
@@ -1,0 +1,141 @@
+import type { ServerWebSocket } from "bun";
+import { tmuxLsJsonRows } from "../commands/plugins/tmux/impl";
+import { Tmux } from "../core/transport/tmux";
+import type { WSData } from "../core/types";
+
+export const TMUX_STREAM_INTERVAL_MS = 200;
+export const TMUX_STREAM_CAPTURE_LINES = 200;
+
+type TimerHandle = ReturnType<typeof setInterval>;
+type StreamWebSocket = Pick<ServerWebSocket<WSData>, "send">;
+
+type PaneRef = { id?: string };
+
+export interface TmuxStreamDeps {
+  intervalMs?: number;
+  captureLines?: number;
+  layoutRows?: () => Promise<unknown[]>;
+  listPanes?: () => Promise<PaneRef[]>;
+  capturePane?: (paneId: string, lines: number) => Promise<string>;
+  setIntervalFn?: typeof setInterval;
+  clearIntervalFn?: typeof clearInterval;
+  startTimers?: boolean;
+  onError?: (message: string, error: unknown) => void;
+}
+
+export interface TmuxStreamConnection {
+  sendLayout: () => Promise<void>;
+  sendCapture: (opts?: { force?: boolean }) => Promise<void>;
+  close: () => void;
+}
+
+function safeSend(ws: StreamWebSocket, payload: string): void {
+  try { ws.send(payload); } catch { /* client may close between ticks */ }
+}
+
+function logStreamError(deps: TmuxStreamDeps, message: string, error: unknown): void {
+  if (deps.onError) deps.onError(message, error);
+  else console.warn(`[tmux-stream] ${message}: ${error instanceof Error ? error.message : String(error)}`);
+}
+
+export function layoutPayload(rows: unknown[]): string {
+  return JSON.stringify({ type: "layout", panes: rows });
+}
+
+export function capturePayload(captures: Record<string, string>): string {
+  return JSON.stringify({ type: "capture", captures });
+}
+
+export function createTmuxStreamConnection(ws: StreamWebSocket, deps: TmuxStreamDeps = {}): TmuxStreamConnection {
+  const tmux = deps.listPanes && deps.capturePane ? null : new Tmux();
+  const intervalMs = deps.intervalMs ?? TMUX_STREAM_INTERVAL_MS;
+  const captureLines = deps.captureLines ?? TMUX_STREAM_CAPTURE_LINES;
+  const layoutRows = deps.layoutRows ?? (() => tmuxLsJsonRows({ all: true, compact: true, teams: true, channels: true }));
+  const listPanes = deps.listPanes ?? (() => tmux!.listPanes());
+  const capturePane = deps.capturePane ?? ((paneId: string, lines: number) => tmux!.capture(paneId, lines));
+  const setIntervalFn = deps.setIntervalFn ?? setInterval;
+  const clearIntervalFn = deps.clearIntervalFn ?? clearInterval;
+  const captures: Record<string, string> = {};
+  let captureRunning = false;
+  let closed = false;
+  let layoutTimer: TimerHandle | undefined;
+  let captureTimer: TimerHandle | undefined;
+
+  async function sendLayout(): Promise<void> {
+    if (closed) return;
+    try {
+      safeSend(ws, layoutPayload(await layoutRows()));
+    } catch (error) {
+      logStreamError(deps, "layout refresh failed", error);
+    }
+  }
+
+  async function sendCapture(opts: { force?: boolean } = {}): Promise<void> {
+    if (closed || captureRunning) return;
+    captureRunning = true;
+    try {
+      const panes = (await listPanes()).filter((pane): pane is { id: string } => typeof pane.id === "string" && pane.id.length > 0);
+      const liveIds = new Set(panes.map(pane => pane.id));
+      let changed = false;
+      const entries = await Promise.all(panes.map(async pane => {
+        try {
+          return [pane.id, await capturePane(pane.id, captureLines)] as const;
+        } catch {
+          return [pane.id, ""] as const;
+        }
+      }));
+      for (const [id, text] of entries) {
+        if (captures[id] !== text) {
+          captures[id] = text;
+          changed = true;
+        }
+      }
+      for (const id of Object.keys(captures)) {
+        if (!liveIds.has(id)) {
+          delete captures[id];
+          changed = true;
+        }
+      }
+      if (opts.force || changed) safeSend(ws, capturePayload(captures));
+    } catch (error) {
+      logStreamError(deps, "capture refresh failed", error);
+    } finally {
+      captureRunning = false;
+    }
+  }
+
+  function close(): void {
+    closed = true;
+    if (layoutTimer) clearIntervalFn(layoutTimer);
+    if (captureTimer) clearIntervalFn(captureTimer);
+  }
+
+  if (deps.startTimers !== false) {
+    void sendLayout();
+    void sendCapture({ force: true });
+    layoutTimer = setIntervalFn(() => { void sendLayout(); }, intervalMs);
+    captureTimer = setIntervalFn(() => { void sendCapture(); }, intervalMs);
+  }
+
+  return { sendLayout, sendCapture, close };
+}
+
+const connections = new WeakMap<ServerWebSocket<WSData>, TmuxStreamConnection>();
+
+export function handleTmuxStreamOpen(ws: ServerWebSocket<WSData>): void {
+  connections.set(ws, createTmuxStreamConnection(ws));
+}
+
+export function handleTmuxStreamMessage(ws: ServerWebSocket<WSData>, msg: unknown): void {
+  const connection = connections.get(ws);
+  if (!connection) return;
+  if (msg === "refresh") {
+    void connection.sendLayout();
+    void connection.sendCapture({ force: true });
+  }
+}
+
+export function handleTmuxStreamClose(ws: ServerWebSocket<WSData>): void {
+  connections.get(ws)?.close();
+  connections.delete(ws);
+}

--- a/src/commands/plugins/tmux/impl.ts
+++ b/src/commands/plugins/tmux/impl.ts
@@ -521,12 +521,15 @@ async function sessionActivityTimes(): Promise<Map<string, number>> {
   return parseSessionActivityList(raw);
 }
 
-/**
- * List tmux panes with fleet + team annotations. Supersedes `maw panes`
- * with smarter labeling — if a pane is a fleet oracle or a team agent,
- * say so explicitly so operators don't need to cross-check configs.
- */
-export async function cmdTmuxLs(opts: TmuxLsOpts = {}): Promise<void> {
+interface TmuxLsState {
+  scope: AnnotatedPane[];
+  visibleTeams: ClaudeTeamSummary[];
+  currentSession: string;
+  activeThresholdSec: number;
+  nowEpoch: number;
+}
+
+async function collectTmuxLsState(opts: TmuxLsOpts = {}): Promise<TmuxLsState> {
   const allPanes = await tmux.listPanes();
   const currentSession = process.env.TMUX
     ? (await hostExec("tmux display-message -p '#{session_name}'").catch(() => "")).trim()
@@ -651,23 +654,42 @@ export async function cmdTmuxLs(opts: TmuxLsOpts = {}): Promise<void> {
 
   await markContextLimitedPanes(scope);
 
+  return { scope, visibleTeams, currentSession, activeThresholdSec, nowEpoch };
+}
+
+async function tmuxLsJsonRowsFromState({ scope, visibleTeams }: Pick<TmuxLsState, "scope" | "visibleTeams">): Promise<unknown[]> {
+  const paneRows = await panesForJson(scope);
+  const teamRows = visibleTeams.map(team => ({
+    kind: "team",
+    id: `team:${team.name}`,
+    target: `team:${team.name}`,
+    session: team.name,
+    command: "team",
+    title: `L2 team (${team.memberCount} member${team.memberCount === 1 ? "" : "s"})`,
+    annotation: `team: ${team.memberCount} member${team.memberCount === 1 ? "" : "s"}`,
+    status: "unknown",
+    lastActivitySec: 0,
+    source: "l2-team",
+    members: team.memberCount,
+    configPath: team.configPath,
+  }));
+  return [...paneRows, ...teamRows];
+}
+
+export async function tmuxLsJsonRows(opts: TmuxLsOpts = {}): Promise<unknown[]> {
+  return tmuxLsJsonRowsFromState(await collectTmuxLsState(opts));
+}
+
+/**
+ * List tmux panes with fleet + team annotations. Supersedes `maw panes`
+ * with smarter labeling — if a pane is a fleet oracle or a team agent,
+ * say so explicitly so operators don't need to cross-check configs.
+ */
+export async function cmdTmuxLs(opts: TmuxLsOpts = {}): Promise<void> {
+  const { scope, visibleTeams, currentSession, activeThresholdSec, nowEpoch } = await collectTmuxLsState(opts);
+
   if (opts.json) {
-    const paneRows = await panesForJson(scope);
-    const teamRows = visibleTeams.map(team => ({
-      kind: "team",
-      id: `team:${team.name}`,
-      target: `team:${team.name}`,
-      session: team.name,
-      command: "team",
-      title: `L2 team (${team.memberCount} member${team.memberCount === 1 ? "" : "s"})`,
-      annotation: `team: ${team.memberCount} member${team.memberCount === 1 ? "" : "s"}`,
-      status: "unknown",
-      lastActivitySec: 0,
-      source: "l2-team",
-      members: team.memberCount,
-      configPath: team.configPath,
-    }));
-    console.log(JSON.stringify([...paneRows, ...teamRows], null, 2));
+    console.log(JSON.stringify(await tmuxLsJsonRowsFromState({ scope, visibleTeams }), null, 2));
     return;
   }
 

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -13,6 +13,7 @@ import { createTransportRouter } from "../transports";
 import { listSessions } from "./transport/ssh";
 import { Tmux } from "./transport/tmux";
 import { handlePtyMessage, handlePtyClose } from "./transport/pty";
+import { handleTmuxStreamClose, handleTmuxStreamMessage, handleTmuxStreamOpen } from "../api/tmux-stream";
 import { setBunServer } from "../lib/elysia-auth";
 import { runServeLifecycleHooks } from "../plugin/lifecycle";
 import {
@@ -201,14 +202,17 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
   const wsHandler = {
     open: (ws: any) => {
       if (ws.data.mode === "pty") return;
+      if (ws.data.mode === "tmux-stream") { handleTmuxStreamOpen(ws); return; }
       engine.handleOpen(ws);
     },
     message: (ws: any, msg: any) => {
       if (ws.data.mode === "pty") { handlePtyMessage(ws, msg); return; }
+      if (ws.data.mode === "tmux-stream") { handleTmuxStreamMessage(ws, msg); return; }
       engine.handleMessage(ws, msg);
     },
     close: (ws: any) => {
       if (ws.data.mode === "pty") { handlePtyClose(ws); return; }
+      if (ws.data.mode === "tmux-stream") { handleTmuxStreamClose(ws); return; }
       engine.handleClose(ws);
     },
   };
@@ -233,6 +237,10 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
 
     if (url.pathname === "/ws/pty") {
       if (server.upgrade(req, { data: { target: null, previewTargets: new Set(), mode: "pty" } as WSData })) return;
+      return new Response("WebSocket upgrade failed", { status: 400 });
+    }
+    if (url.pathname === "/ws/tmux") {
+      if (server.upgrade(req, { data: { target: null, previewTargets: new Set(), mode: "tmux-stream" } as WSData })) return;
       return new Response("WebSocket upgrade failed", { status: 400 });
     }
     if (url.pathname === "/ws") {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,6 +1,6 @@
 import type { ServerWebSocket } from "bun";
 
-export type WSData = { target: string | null; previewTargets: Set<string>; mode?: "pty" };
+export type WSData = { target: string | null; previewTargets: Set<string>; mode?: "pty" | "tmux-stream" };
 export type MawWS = ServerWebSocket<WSData>;
 export type Handler = (ws: MawWS, data: any, engine: MawEngine) => void | Promise<void>;
 

--- a/test/isolated/coverage-core-shared-server.test.ts
+++ b/test/isolated/coverage-core-shared-server.test.ts
@@ -15,6 +15,7 @@ let killed: string[] = [];
 let engineCalls: string[] = [];
 let ptyMessages: unknown[] = [];
 let ptyCloses: unknown[] = [];
+let tmuxStreamEvents: string[] = [];
 let apiPaths: string[] = [];
 let proxiedPaths: string[] = [];
 let lifecyclePayloads: unknown[] = [];
@@ -48,6 +49,11 @@ mock.module(import.meta.resolve("../../src/core/transport/tmux"), () => ({
 mock.module(import.meta.resolve("../../src/core/transport/pty"), () => ({
   handlePtyMessage: (...args: unknown[]) => { ptyMessages.push(args); },
   handlePtyClose: (...args: unknown[]) => { ptyCloses.push(args); },
+}));
+mock.module(import.meta.resolve("../../src/api/tmux-stream"), () => ({
+  handleTmuxStreamOpen: () => { tmuxStreamEvents.push("open"); },
+  handleTmuxStreamMessage: () => { tmuxStreamEvents.push("message"); },
+  handleTmuxStreamClose: () => { tmuxStreamEvents.push("close"); },
 }));
 mock.module(import.meta.resolve("../../src/lib/elysia-auth"), () => ({ setBunServer: () => {} }));
 mock.module(import.meta.resolve("../../src/plugin/lifecycle"), () => ({
@@ -91,6 +97,7 @@ beforeEach(() => {
   engineCalls = [];
   ptyMessages = [];
   ptyCloses = [];
+  tmuxStreamEvents = [];
   apiPaths = [];
   proxiedPaths = [];
   lifecyclePayloads = [];
@@ -141,15 +148,20 @@ describe("coverage core shared server", () => {
     const ws = serveCalls[0].websocket;
     const normal = { data: {} };
     const pty = { data: { mode: "pty" } };
+    const tmuxStream = { data: { mode: "tmux-stream" } };
     ws.open(normal);
     ws.open(pty);
+    ws.open(tmuxStream);
     ws.message(normal, "hello");
     ws.message(pty, "resize");
+    ws.message(tmuxStream, "refresh");
     ws.close(normal);
     ws.close(pty);
+    ws.close(tmuxStream);
     expect(engineCalls).toEqual(["router", "open", "message", "close"]);
     expect(ptyMessages).toHaveLength(1);
     expect(ptyCloses).toHaveLength(1);
+    expect(tmuxStreamEvents).toEqual(["open", "message", "close"]);
 
     const fetch = serveCalls[0].fetch;
     const options = await fetch(new Request("http://local/anything", { method: "OPTIONS", headers: { origin: "http://origin.test" } }), upgradeServer(true));
@@ -163,6 +175,9 @@ describe("coverage core shared server", () => {
     const ptyUpgrade = upgradeServer(true);
     expect(await fetch(new Request("http://local/ws/pty"), ptyUpgrade)).toBeUndefined();
     expect(ptyUpgrade.upgrades[0].data.mode).toBe("pty");
+    const tmuxUpgrade = upgradeServer(true);
+    expect(await fetch(new Request("http://local/ws/tmux"), tmuxUpgrade)).toBeUndefined();
+    expect(tmuxUpgrade.upgrades[0].data.mode).toBe("tmux-stream");
     const failedUpgrade = await fetch(new Request("http://local/ws"), upgradeServer(false));
     expect(failedUpgrade.status).toBe(400);
   });

--- a/test/isolated/tmux-stream.test.ts
+++ b/test/isolated/tmux-stream.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+
+import { capturePayload, createTmuxStreamConnection, layoutPayload, TMUX_STREAM_INTERVAL_MS } from "../../src/api/tmux-stream";
+
+describe("tmux websocket stream (#2048)", () => {
+  test("formats layout and capture payloads for tmux-viewer protocol", () => {
+    expect(JSON.parse(layoutPayload([{ id: "%1", top: 1, left: 2 }]))).toEqual({
+      type: "layout",
+      panes: [{ id: "%1", top: 1, left: 2 }],
+    });
+    expect(JSON.parse(capturePayload({ "%1": "hello" }))).toEqual({
+      type: "capture",
+      captures: { "%1": "hello" },
+    });
+  });
+
+  test("sends immediate snapshots, then capture updates only when content changes", async () => {
+    const sent: string[] = [];
+    const callbacks: Array<() => void> = [];
+    let captureText = "first";
+    const ws = { send: (payload: string) => { sent.push(payload); } };
+
+    const connection = createTmuxStreamConnection(ws, {
+      layoutRows: async () => [{ id: "%1", target: "demo:0.0", top: 0, left: 0, w: 80, h: 24 }],
+      listPanes: async () => [{ id: "%1" }],
+      capturePane: async () => captureText,
+      setIntervalFn: ((fn: () => void, ms?: number) => {
+        expect(ms).toBe(TMUX_STREAM_INTERVAL_MS);
+        callbacks.push(fn);
+        return callbacks.length as any;
+      }) as typeof setInterval,
+      clearIntervalFn: (() => {}) as typeof clearInterval,
+    });
+
+    await Bun.sleep(0);
+    expect(sent.map(payload => JSON.parse(payload).type)).toEqual(["layout", "capture"]);
+    expect(JSON.parse(sent[0]!).panes[0]).toMatchObject({ id: "%1", top: 0, left: 0, w: 80, h: 24 });
+    expect(JSON.parse(sent[1]!).captures).toEqual({ "%1": "first" });
+
+    await connection.sendCapture();
+    expect(sent).toHaveLength(2);
+
+    captureText = "second";
+    await connection.sendCapture();
+    expect(JSON.parse(sent.at(-1)!).captures).toEqual({ "%1": "second" });
+
+    connection.close();
+  });
+});

--- a/test/tmux-class-command-builders.test.ts
+++ b/test/tmux-class-command-builders.test.ts
@@ -162,9 +162,9 @@ describe("Tmux command wrapper coverage", () => {
   test("pane list/info helpers parse optional fields and tolerate failures", async () => {
     const t = new FakeTmux(byCommand({
       "list-panes -a -F #{pane_id}": "%1\n%2\n",
-      "list-panes -a -F #{pane_id}|||#{pane_current_command}|||#{session_name}:#{window_name}.#{pane_index}|||#{pane_title}|||#{pane_pid}|||#{pane_current_path}|||#{window_activity}": [
-        "%1|||claude|||s:main.0|||oracle|||123|||/repo|||1715840000",
-        "%2|||zsh|||s:shell.1||||||",
+      "list-panes -a -F #{pane_id}|||#{pane_current_command}|||#{session_name}:#{window_name}.#{pane_index}|||#{pane_title}|||#{pane_pid}|||#{pane_current_path}|||#{window_activity}|||#{pane_top}|||#{pane_left}|||#{pane_width}|||#{pane_height}|||#{pane_index}|||#{window_index}|||#{window_name}|||#{pane_active}|||#{window_width}|||#{window_height}|||#{window_active}|||#{session_attached}": [
+        "%1|||claude|||s:main.0|||oracle|||123|||/repo|||1715840000|||1|||2|||80|||24|||0|||3|||main|||1|||160|||48|||1|||1",
+        "%2|||zsh|||s:shell.1||||||||||||||||||||||||||||||||||||||||||||||||",
       ].join("\n"),
       "list-panes -t s:main.0 -F #{pane_current_command}": "claude\n",
       "list-panes -a -F #{session_name}:#{window_index}|||#{pane_current_command}": "s:0|||claude\ns:1|||zsh\n",
@@ -174,8 +174,8 @@ describe("Tmux command wrapper coverage", () => {
 
     expect(await t.listPaneIds()).toEqual(new Set(["%1", "%2"]));
     expect(await t.listPanes()).toEqual([
-      { id: "%1", command: "claude", target: "s:main.0", title: "oracle", pid: 123, cwd: "/repo", lastActivity: 1715840000 },
-      { id: "%2", command: "zsh", target: "s:shell.1", title: "", pid: undefined, cwd: undefined, lastActivity: undefined },
+      { id: "%1", command: "claude", target: "s:main.0", title: "oracle", pid: 123, cwd: "/repo", lastActivity: 1715840000, top: 1, left: 2, w: 80, h: 24, paneIdx: 0, winIdx: 3, winName: "main", active: true, window: { w: 160, h: 48, active: true }, attached: true },
+      { id: "%2", command: "zsh", target: "s:shell.1", title: "", pid: undefined, cwd: undefined, lastActivity: undefined, top: 0, left: 0, w: 0, h: 0, paneIdx: 0, winIdx: 0, winName: undefined, active: false, window: { w: 0, h: 0, active: false }, attached: false },
     ]);
     expect(await t.getPaneCommand("s:main.0")).toBe("claude");
     expect(await t.getPaneCommands(["s:0", "s:missing"])).toEqual({ "s:0": "claude" });


### PR DESCRIPTION
## Summary
- Add `/ws/tmux` WebSocket route for tmux-viewer-compatible layout/capture streaming
- Stream `{ type: "layout", panes: [...] }` rows from maw tmux layout data every 200ms
- Stream diff-aware `{ type: "capture", captures }` payloads keyed by pane id
- Expose programmatic `tmuxLsJsonRows()` and cover server routing + stream behavior

Closes #2048

## Verification
- `bun test test/isolated/tmux-stream.test.ts`
- `bun test test/isolated/coverage-core-shared-server.test.ts`
- `bun test test/isolated/tmux-impl-plugin-second-pass-coverage.test.ts`
- `bun test test/isolated/tmux-class-tenth-pass-coverage.test.ts`
- `bun test test/tmux-class-command-builders.test.ts --test-name-pattern "pane list/info helpers parse optional fields and tolerate failures"`
- `bun run build`
- `git diff --check`

## Known pre-existing gap
- `bun run test:default:safe` currently stops on a pre-existing stale runner/path issue for `test/claude-sessions-default.test.ts` and was not used as the ship gate for this PR.

## Notes
Target branch: alpha