### PR TITLE
release: v26.6.6-alpha.1058

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.6.6-alpha.839",
+  "version": "26.6.6-alpha.1059",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
## Sprint 3 Release — tmux-viewer backend integration

Cuts v26.6.6-alpha.1058 on merge via calver-release.yml.

### Sprint 3 (tmux-viewer integration)
- #2050 feat(ls): spatial fields in maw ls --json (top/left/w/h/paneIdx/winIdx/active)
- #2049 feat(api): batch capture endpoint GET /api/captures
- #2051 feat(api): WebSocket stream /ws/tmux (layout + capture broadcast)

### Sprint 2 (RFC + team lifecycle)
- #2044 RFC #2009: node-local maw team yaml loader
- #2043 fix: atomic config writes + wake command-map override (#2012, #1981)
- #2042 fix: team down bridge + charter forward-compat (#2004, #1994)
- #2040 fix: ambiguous oracle short-name warning (#1972)
- #2039 feat: gather on team bring (#1973)
- #2038 test: CI fix comm-send mock (#2037)
- #2035 feat: team bring respects charter (#1971)
- #2034 test: plugin discovery (#1984)
- #2033 fix: inbox unread + safe-drain (#2007)
- #2045 fix: migration guard atomic persistence

### Today total: 3 sprints, 33 issues, 28 PRs