### PR TITLE
Guard maw done against lead-window mistakes

### DIFF
--- a/src/commands/shared/done.ts
+++ b/src/commands/shared/done.ts
@@ -31,6 +31,7 @@ export interface DoneDeps {
   listSessions?: () => Promise<SessionInfo[]>;
   hostExec?: (command: string) => Promise<string>;
   tmux?: {
+    run?: (subcommand: string, ...args: (string | number)[]) => Promise<string>;
     killWindow?: (target: string) => Promise<unknown>;
     sendText?: (target: string, text: string) => Promise<unknown>;
   };
@@ -53,6 +54,7 @@ function doneDeps(deps: DoneDeps = {}) {
     listSessions: deps.listSessions ?? (listSessions as () => Promise<SessionInfo[]>),
     hostExec: deps.hostExec ?? hostExec,
     tmux: {
+      run: deps.tmux?.run ?? tmux.run.bind(tmux),
       killWindow: deps.tmux?.killWindow ?? tmux.killWindow,
       sendText: deps.tmux?.sendText ?? tmux.sendText,
     },
@@ -229,6 +231,42 @@ function failMissingDoneTarget(windowName: string, d: ResolvedDoneDeps): never {
   throw new Error(message);
 }
 
+function leadWindow(session: SessionInfo): SessionInfo["windows"][number] | null {
+  if (session.windows.length === 0) return null;
+  const leadIndex = Math.min(...session.windows.map(w => w.index));
+  return session.windows.find(w => w.index === leadIndex) ?? null;
+}
+
+async function currentTmuxIdentity(d: ResolvedDoneDeps): Promise<{ sessionName: string; windowIndex: number } | null> {
+  try {
+    const raw = (await d.tmux.run("display-message", "-p", "#{session_name}\t#{window_index}")).trim();
+    const [sessionName, indexRaw] = raw.split("\t");
+    const windowIndex = Number(indexRaw);
+    if (sessionName && Number.isInteger(windowIndex)) return { sessionName, windowIndex };
+  } catch {
+    // Outside tmux or tmux unavailable. Treat as non-lead for the guard.
+  }
+  return null;
+}
+
+async function assertDoneMayTargetWindow(
+  session: SessionInfo,
+  windowIndex: number,
+  windowName: string,
+  d: ResolvedDoneDeps,
+): Promise<void> {
+  const lead = leadWindow(session);
+  if (!lead || lead.index !== windowIndex) return;
+
+  const current = await currentTmuxIdentity(d);
+  if (current?.sessionName === session.name && current.windowIndex === lead.index) return;
+
+  const message = `refusing to done lead window '${windowName}' in session '${session.name}' from a non-lead context`;
+  d.logger.error(`  \x1b[31m✗\x1b[0m ${message}`);
+  d.logger.error(`  \x1b[90m  run from the lead window, or target a non-lead agent window\x1b[0m`);
+  throw new Error(message);
+}
+
 function activeFleetConfigFiles(d: ResolvedDoneDeps): Array<{ file: string; path: string }> {
   const filesByName = new Map<string, { file: string; path: string }>();
   const dirs = uniqueDirs(d.fleetDirs?.length ? d.fleetDirs : [d.fleetDir]);
@@ -262,10 +300,15 @@ export async function cmdDone(windowName_: string, opts: DoneOpts = {}, deps: Do
 
   const windowNameLower = windowName.toLowerCase();
   let sessionName: string | null = null;
+  let matchedSession: SessionInfo | null = null;
   let windowIndex: number | null = null;
   for (const s of sessions) {
     const w = s.windows.find(w => w.name.toLowerCase() === windowNameLower);
-    if (w) { sessionName = s.name; windowIndex = w.index; windowName = w.name; break; }
+    if (w) { sessionName = s.name; matchedSession = s; windowIndex = w.index; windowName = w.name; break; }
+  }
+
+  if (matchedSession && windowIndex !== null) {
+    await assertDoneMayTargetWindow(matchedSession, windowIndex, windowName, d);
   }
 
   if (sessionName) {

--- a/src/vendor/mpr-plugins/done/impl.ts
+++ b/src/vendor/mpr-plugins/done/impl.ts
@@ -57,6 +57,41 @@ function failMissingDoneTarget(windowName: string): never {
   throw new Error(message);
 }
 
+function leadWindow(session: DoneSession): DoneWindow | null {
+  if (session.windows.length === 0) return null;
+  const leadIndex = Math.min(...session.windows.map(w => w.index));
+  return session.windows.find(w => w.index === leadIndex) ?? null;
+}
+
+async function currentTmuxIdentity(): Promise<{ sessionName: string; windowIndex: number } | null> {
+  try {
+    const raw = (await tmux.run("display-message", "-p", "#{session_name}\t#{window_index}")).trim();
+    const [sessionName, indexRaw] = raw.split("\t");
+    const windowIndex = Number(indexRaw);
+    if (sessionName && Number.isInteger(windowIndex)) return { sessionName, windowIndex };
+  } catch {
+    // Outside tmux or tmux unavailable. Treat as non-lead for the guard.
+  }
+  return null;
+}
+
+async function assertDoneMayTargetWindow(
+  session: DoneSession,
+  windowIndex: number,
+  windowName: string,
+): Promise<void> {
+  const lead = leadWindow(session);
+  if (!lead || lead.index !== windowIndex) return;
+
+  const current = await currentTmuxIdentity();
+  if (current?.sessionName === session.name && current.windowIndex === lead.index) return;
+
+  const message = `refusing to done lead window '${windowName}' in session '${session.name}' from a non-lead context`;
+  console.error(`  \x1b[31m✗\x1b[0m ${message}`);
+  console.error(`  \x1b[90m  run from the lead window, or target a non-lead agent window\x1b[0m`);
+  throw new Error(message);
+}
+
 /**
  * maw done <window-name> [--force] [--dry-run] [--clean-branch]
  *
@@ -73,13 +108,18 @@ export async function cmdDone(windowName_: string, opts: DoneOpts = {}) {
 
   const windowNameLower = windowName.toLowerCase();
   let sessionName: string | null = null;
+  let matchedSession: DoneSession | null = null;
   let windowIndex: number | null = null;
   const searchSessions = opts.sessionName
     ? sessions.filter(s => s.name === opts.sessionName)
     : sessions;
   for (const s of searchSessions) {
     const w = s.windows.find(w => w.name.toLowerCase() === windowNameLower);
-    if (w) { sessionName = s.name; windowIndex = w.index; windowName = w.name; break; }
+    if (w) { sessionName = s.name; matchedSession = s; windowIndex = w.index; windowName = w.name; break; }
+  }
+
+  if (matchedSession && windowIndex !== null) {
+    await assertDoneMayTargetWindow(matchedSession, windowIndex, windowName);
   }
 
   // 0. Signal parent inbox (#81) — write before kill so parent knows

--- a/test/done-lead-guard.test.ts
+++ b/test/done-lead-guard.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import { cmdDone, type DoneDeps } from "../src/commands/shared/done";
+
+type WindowInfo = { index: number; name: string; active: boolean };
+
+function depsFor(options: {
+  current?: string;
+  kills?: string[];
+  errors?: string[];
+} = {}): DoneDeps {
+  const kills = options.kills ?? [];
+  const errors = options.errors ?? [];
+  return {
+    listSessions: async () => [
+      {
+        name: "mawjs",
+        windows: [
+          { index: 0, name: "mawjs-oracle", active: false },
+          { index: 1, name: "codex-pr", active: true },
+        ] satisfies WindowInfo[],
+      },
+    ],
+    ghqRoot: "/repos",
+    fleetDir: "/fleet",
+    fs: {
+      readdirSync: () => [],
+      mkdirSync: () => undefined,
+      appendFileSync: () => undefined,
+      readFileSync: () => "",
+      writeFileSync: () => undefined,
+    },
+    hostExec: async (command) => {
+      if (command.startsWith("find ")) return "";
+      throw new Error(`unexpected host command: ${command}`);
+    },
+    tmux: {
+      run: async () => {
+        if (options.current === undefined) throw new Error("not in tmux");
+        return options.current;
+      },
+      killWindow: async (target) => {
+        kills.push(target);
+      },
+      sendText: async () => undefined,
+    },
+    takeSnapshot: async () => undefined,
+    logger: {
+      log: () => undefined,
+      error: (...args) => errors.push(args.map(String).join(" ")),
+    },
+  };
+}
+
+describe("done lead guard", () => {
+  test("refuses to done the lead window from a non-lead context", async () => {
+    const kills: string[] = [];
+    const errors: string[] = [];
+
+    await expect(cmdDone("mawjs-oracle", { force: true }, depsFor({
+      current: "mawjs\t1",
+      kills,
+      errors,
+    }))).rejects.toThrow("refusing to done lead window");
+
+    expect(kills).toEqual([]);
+    expect(errors.join("\n")).toContain("target a non-lead agent window");
+  });
+
+  test("allows the lead window to done a non-lead agent", async () => {
+    const kills: string[] = [];
+
+    await cmdDone("codex-pr", { force: true }, depsFor({
+      current: "mawjs\t0",
+      kills,
+    }));
+
+    expect(kills).toEqual(["mawjs:codex-pr"]);
+  });
+});


### PR DESCRIPTION
## Summary
- refuse `maw done <lead-window>` unless the caller is currently in that lead window
- run the guard before inbox signaling, autosave, tmux kill, worktree cleanup, or fleet config mutation
- add a focused 79-line regression test for the non-lead lead-window refusal and non-lead cleanup path

Closes #2053

## Tests
- `MAW_TEST_MODE=1 bun test test/done-lead-guard.test.ts test/done-command.test.ts --path-ignore-patterns '**/agents/**'`\n- `bun run build`\n\n## Notes\n- `bun run test` was attempted, but the repo script traversed archived `agents/*` test copies and timed out in `agents/1-sprint-codex-1/test/cleanup-worktrees-handler.test.ts`, outside this change. Root targeted tests and build are green.