### PR TITLE
feat(broadcast): scope filter

### DIFF
--- a/src/vendor/mpr-plugins/broadcast/impl.ts
+++ b/src/vendor/mpr-plugins/broadcast/impl.ts
@@ -1,8 +1,152 @@
+import { existsSync, readFileSync } from "fs";
+import { homedir } from "os";
+import { dirname, join } from "path";
 import { tmux } from "maw-js/sdk";
 import { isAgentCommand } from "../../../core/agent-detect";
+import { loadOracleRegistry } from "../../../lib/oracle-members";
+import { loadFleetEntries } from "../../../commands/shared/fleet-load";
+
+export interface BroadcastScopeOptions {
+  session?: string;
+  team?: string;
+  fleet?: string;
+}
+
+export interface BroadcastCommand {
+  message: string;
+  scope: BroadcastScopeOptions;
+}
+
+function usage(): string {
+  return "usage: maw broadcast <message> [--session <name>] [--team <name>] [--fleet <name>]";
+}
+
+export function parseBroadcastArgs(args: string[]): BroadcastCommand {
+  const scope: BroadcastScopeOptions = {};
+  const messageParts: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
+    if (arg === "--session" || arg === "--team" || arg === "--fleet") {
+      const value = args[++i];
+      if (!value || value.startsWith("--")) throw new Error(`${arg} requires a value\n${usage()}`);
+      if (arg === "--session") scope.session = value;
+      else if (arg === "--team") scope.team = value;
+      else scope.fleet = value;
+      continue;
+    }
+    messageParts.push(arg);
+  }
+
+  const message = messageParts.join(" ").trim();
+  if (!message) throw new Error(usage());
+  return { message, scope };
+}
+
+function stripNumericPrefix(value: string): string {
+  return value.replace(/^\d+-/, "");
+}
+
+function stripOracleSuffix(value: string): string {
+  return value.replace(/-oracle$/i, "");
+}
+
+function normalizedNames(value: string): string[] {
+  const trimmed = value.trim();
+  if (!trimmed) return [];
+  const strippedPrefix = stripNumericPrefix(trimmed);
+  return [...new Set([
+    trimmed,
+    strippedPrefix,
+    stripOracleSuffix(trimmed),
+    stripOracleSuffix(strippedPrefix),
+    `${strippedPrefix}-oracle`,
+  ].filter(Boolean))];
+}
+
+function readJson(path: string): any | null {
+  if (!existsSync(path)) return null;
+  try { return JSON.parse(readFileSync(path, "utf-8")); }
+  catch { return null; }
+}
+
+function teamConfigMemberNames(teamName: string): string[] {
+  const cfg = readJson(join(homedir(), ".claude", "teams", teamName, "config.json"));
+  if (!cfg || !Array.isArray(cfg.members)) return [];
+  return cfg.members
+    .filter((m: any) => m?.agentType !== "team-lead" && m?.role !== "lead" && m?.name !== "team-lead")
+    .map((m: any) => typeof m?.name === "string" ? m.name : "")
+    .filter(Boolean);
+}
+
+function resolvePsi(): string {
+  let dir = process.cwd();
+  while (true) {
+    const psi = join(dir, "ψ");
+    if (existsSync(psi) && existsSync(join(dir, "CLAUDE.md"))) return psi;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return join(process.cwd(), "ψ");
+}
+
+function teamManifestMemberNames(teamName: string): string[] {
+  const manifest = readJson(join(resolvePsi(), "memory", "mailbox", "teams", teamName, "manifest.json"));
+  if (!manifest) return [];
+  const out: string[] = [];
+  for (const entry of Array.isArray(manifest.members) ? manifest.members : []) {
+    if (typeof entry === "string") out.push(entry);
+    else if (entry && typeof entry.name === "string") out.push(entry.name);
+  }
+  for (const entry of Array.isArray(manifest.charter?.members) ? manifest.charter.members : []) {
+    if (entry && typeof entry.name === "string") out.push(entry.name);
+    else if (entry && typeof entry.role === "string") out.push(entry.role);
+  }
+  return out;
+}
+
+export function teamScopeMemberNames(teamName: string): string[] {
+  const registry = loadOracleRegistry(teamName);
+  const registryMembers = registry?.members.map(m => m.oracle).filter(Boolean) ?? [];
+  return [...new Set([
+    ...registryMembers,
+    ...teamConfigMemberNames(teamName),
+    ...teamManifestMemberNames(teamName),
+  ])];
+}
+
+export function fleetScopeSessionNames(fleetName: string): Set<string> {
+  const wanted = new Set(normalizedNames(fleetName));
+  const sessions = new Set<string>();
+  for (const entry of loadFleetEntries()) {
+    const candidates = [
+      entry.groupName,
+      entry.file.replace(/\.json$/i, ""),
+      entry.session.name,
+      stripNumericPrefix(entry.session.name),
+    ];
+    if (candidates.some(c => wanted.has(c))) sessions.add(entry.session.name);
+  }
+  return sessions;
+}
+
+function windowMatchesTeamMember(sessionName: string, windowName: string, teamMembers: Set<string>): boolean {
+  return [...normalizedNames(sessionName), ...normalizedNames(windowName)].some(name => teamMembers.has(name));
+}
+
+function scopeDescription(scope: BroadcastScopeOptions): string {
+  const parts = [
+    scope.session ? `session=${scope.session}` : "",
+    scope.team ? `team=${scope.team}` : "",
+    scope.fleet ? `fleet=${scope.fleet}` : "",
+  ].filter(Boolean);
+  return parts.length ? parts.join(", ") : "all agents";
+}
 
 /**
- * maw broadcast <message> — send to ALL agent windows across ALL sessions
+ * maw broadcast <message> — send to agent windows, optionally scoped by
+ * --session, --team charter members, and/or --fleet tagged session.
  * Always prefixes with sender identity so receivers know who broadcasted.
  *
  * #1881 — uses shared isAgentCommand (not hardcoded "claude" substring) so
@@ -10,9 +154,9 @@ import { isAgentCommand } from "../../../core/agent-detect";
  * skip-reason breakdown when at least one window is skipped, so 0-windows
  * surprises become diagnosable.
  */
-export async function cmdBroadcast(message: string) {
+export async function cmdBroadcast(message: string, scope: BroadcastScopeOptions = {}) {
   if (!message) {
-    throw new Error("usage: maw broadcast <message>");
+    throw new Error(usage());
   }
 
   // Detect sender from current tmux window
@@ -26,6 +170,8 @@ export async function cmdBroadcast(message: string) {
   message = `[broadcast from ${sender}] ${message}`;
 
   const sessions = await tmux.listAll();
+  const teamMembers = scope.team ? new Set(teamScopeMemberNames(scope.team).flatMap(normalizedNames)) : null;
+  const fleetSessions = scope.fleet ? fleetScopeSessionNames(scope.fleet) : null;
   let sent = 0;
   let skipped = 0;
   const skipReasons = new Map<string, number>();
@@ -34,8 +180,11 @@ export async function cmdBroadcast(message: string) {
     // Skip overview/scratch/view sessions
     if (s.name === "99-overview" || s.name === "scratch") continue;
     if (s.name.endsWith("-view")) continue;
+    if (scope.session && s.name !== scope.session) continue;
+    if (fleetSessions && !fleetSessions.has(s.name)) continue;
 
     for (const w of s.windows) {
+      if (teamMembers && !windowMatchesTeamMember(s.name, w.name, teamMembers)) continue;
       const target = `${s.name}:${w.index}`;
       try {
         // Check if window is running an agent (shared with ssh.ts post-#1906)
@@ -55,7 +204,7 @@ export async function cmdBroadcast(message: string) {
     }
   }
 
-  console.log(`\n\x1b[32m✓\x1b[0m Broadcast to ${sent} windows (${skipped} skipped)`);
+  console.log(`\n\x1b[32m✓\x1b[0m Broadcast to ${sent} windows (${skipped} skipped) [scope: ${scopeDescription(scope)}]`);
   if (skipped > 0) {
     console.log(`  \x1b[90mskipped breakdown:\x1b[0m`);
     for (const [reason, count] of skipReasons) {

--- a/src/vendor/mpr-plugins/broadcast/index.ts
+++ b/src/vendor/mpr-plugins/broadcast/index.ts
@@ -1,5 +1,5 @@
 import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
-import { cmdBroadcast } from "./impl";
+import { cmdBroadcast, parseBroadcastArgs } from "./impl";
 
 export const command = { name: "broadcast", description: "Broadcast a message to all agents." };
 
@@ -17,7 +17,8 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
   };
   try {
     const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
-    await cmdBroadcast(args.join(" "));
+    const { message, scope } = parseBroadcastArgs(args);
+    await cmdBroadcast(message, scope);
     return { ok: true, output: logs.join("\n") || undefined };
   } catch (e: any) {
     return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };

--- a/test/isolated/broadcast-agent-detect.test.ts
+++ b/test/isolated/broadcast-agent-detect.test.ts
@@ -2,15 +2,21 @@
  * #1881 — broadcast must use isAgentCommand (not hardcoded "claude" substring)
  * so panes running thclaws / codex / configured engines are reached.
  */
-import { describe, test, expect, beforeEach, mock } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
 import { join } from "path";
 
 let paneCommands = new Map<string, string>();
+let sessions: Array<{ name: string; windows: Array<{ index: number; name: string }> }> = [];
+let teamMembers: string[] = [];
+let fleetEntries: Array<{ groupName: string; file: string; session: { name: string } }> = [];
 let sendCalls: Array<{ target: string; text: string }> = [];
 let logs: string[] = [];
 let originalLog: typeof console.log;
 
-mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
+mock.module("maw-js/sdk", () => ({
+  hostExec: async () => "",
+  listSessions: async () => [],
+  tmuxCmd: () => "tmux",
   tmux: {
     run: async (subcommand: string, ...args: string[]) => {
       if (subcommand === "display-message") {
@@ -24,30 +30,103 @@ mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
       }
       return "";
     },
-    listAll: async () => [
-      {
-        name: "77-mawjs",
-        windows: [
-          { index: 0, name: "claude-pane" },
-          { index: 1, name: "thclaws-pane" },
-          { index: 2, name: "zsh-pane" },
-        ],
-      },
-    ],
+    listAll: async () => sessions,
     sendText: async (target: string, text: string) => {
       sendCalls.push({ target, text });
     },
   },
 }));
 
-const { cmdBroadcast } = await import("../../src/vendor/mpr-plugins/broadcast/impl");
+
+mock.module(join(import.meta.dir, "../../src/lib/oracle-members"), () => ({
+  loadOracleRegistry: (teamName: string) => teamMembers.length
+    ? { name: teamName, members: teamMembers.map(oracle => ({ oracle, role: "member", addedAt: "2026-06-06T00:00:00.000Z" })), createdAt: "2026-06-06T00:00:00.000Z" }
+    : null,
+}));
+
+mock.module(join(import.meta.dir, "../../src/commands/shared/fleet-load"), () => ({
+  loadFleetEntries: () => fleetEntries,
+}));
+
+const { cmdBroadcast, parseBroadcastArgs } = await import("../../src/vendor/mpr-plugins/broadcast/impl");
 
 beforeEach(() => {
   paneCommands = new Map();
+  sessions = [
+    {
+      name: "77-mawjs",
+      windows: [
+        { index: 0, name: "claude-pane" },
+        { index: 1, name: "thclaws-pane" },
+        { index: 2, name: "zsh-pane" },
+      ],
+    },
+  ];
+  teamMembers = [];
+  fleetEntries = [];
   sendCalls = [];
   logs = [];
   originalLog = console.log;
   console.log = (...args: any[]) => logs.push(args.map(String).join(" "));
+
+});
+
+afterEach(() => {
+  console.log = originalLog;
+});
+
+test("parses scope flags and preserves unquoted message", () => {
+  expect(parseBroadcastArgs(["--session", "77-mawjs", "--team", "builders", "--fleet", "mawjs", "hello", "team"])).toEqual({
+    message: "hello team",
+    scope: { session: "77-mawjs", team: "builders", fleet: "mawjs" },
+  });
+});
+
+test("--session limits broadcast to panes in that session", async () => {
+  sessions = [
+    { name: "77-mawjs", windows: [{ index: 0, name: "neo" }] },
+    { name: "88-other", windows: [{ index: 0, name: "trinity" }] },
+  ];
+  paneCommands.set("77-mawjs:0", "claude");
+  paneCommands.set("88-other:0", "claude");
+
+  await cmdBroadcast("hello", { session: "77-mawjs" });
+  console.log = originalLog;
+
+  expect(sendCalls.map(c => c.target)).toEqual(["77-mawjs:0"]);
+  expect(logs.some(l => l.includes("scope: session=77-mawjs"))).toBe(true);
+});
+
+test("--team limits broadcast to charter/member windows", async () => {
+  sessions = [
+    { name: "77-mawjs", windows: [{ index: 0, name: "builder" }, { index: 1, name: "reviewer-oracle" }, { index: 2, name: "bystander" }] },
+  ];
+  teamMembers = ["builder-oracle", "reviewer"];
+  paneCommands.set("77-mawjs:0", "claude");
+  paneCommands.set("77-mawjs:1", "codex");
+  paneCommands.set("77-mawjs:2", "claude");
+
+  await cmdBroadcast("standup", { team: "alpha" });
+  console.log = originalLog;
+
+  expect(sendCalls.map(c => c.target)).toEqual(["77-mawjs:0", "77-mawjs:1"]);
+  expect(logs.some(l => l.includes("scope: team=alpha"))).toBe(true);
+});
+
+test("--fleet limits broadcast to fleet-tagged session", async () => {
+  sessions = [
+    { name: "01-neo", windows: [{ index: 0, name: "neo" }] },
+    { name: "02-trinity", windows: [{ index: 0, name: "trinity" }] },
+  ];
+  fleetEntries = [{ groupName: "neo", file: "01-neo.json", session: { name: "01-neo" } }];
+  paneCommands.set("01-neo:0", "claude");
+  paneCommands.set("02-trinity:0", "claude");
+
+  await cmdBroadcast("ping", { fleet: "neo" });
+  console.log = originalLog;
+
+  expect(sendCalls.map(c => c.target)).toEqual(["01-neo:0"]);
+  expect(logs.some(l => l.includes("scope: fleet=neo"))).toBe(true);
 });
 
 describe("broadcast agent detection (#1881)", () => {


### PR DESCRIPTION
Closes #2041

## Summary
- add `maw broadcast` parsing for `--session <name>`, `--team <name>`, and `--fleet <name>`
- filter target windows by exact tmux session, team charter/member names, or registered fleet session
- keep unscoped broadcast behavior unchanged and include scope in the summary output

## Verification
- `bun test test/isolated/broadcast-agent-detect.test.ts test/isolated/vendor-bud-init-broadcast-rename-extra-coverage.test.ts --path-ignore-patterns '**/agents/**'`\n- `bun run build`\n- `git diff --check`\n