### PR TITLE
Notify live receivers about queued inbox writes

### DIFF
--- a/src/api/sessions.ts
+++ b/src/api/sessions.ts
@@ -137,6 +137,42 @@ export function sessionTargetExists(sessions: Session[], target: string): boolea
   return session.windows.some(w => String(w.index) === windowName || w.name === windowName);
 }
 
+function normalizeInboxTargetName(value: string | undefined): string {
+  return (value ?? "")
+    .trim()
+    .replace(/\.[0-9]+$/, "")
+    .replace(/^\d+-/, "")
+    .replace(/-oracle$/i, "")
+    .toLowerCase();
+}
+
+function windowTarget(session: Session, window: Session["windows"][number] | undefined): string {
+  if (!window) return session.name;
+  return `${session.name}:${window.name || window.index}`;
+}
+
+/** @internal exported for tests. Resolve an inbox oracle to a live tmux target. */
+export function resolveLiveInboxNotificationTarget(oracle: string, sessions: Session[]): string | null {
+  const wanted = normalizeInboxTargetName(oracle);
+  if (!wanted) return null;
+
+  for (const session of sessions) {
+    if (normalizeInboxTargetName(session.name) === wanted) {
+      return windowTarget(session, session.windows.find(w => w.active) ?? session.windows[0]);
+    }
+
+    const win = session.windows.find(w => normalizeInboxTargetName(w.name) === wanted);
+    if (win) return windowTarget(session, win);
+  }
+
+  return null;
+}
+
+/** @internal exported for tests. */
+export function formatInboxNotification(inbox: Extract<ReceiverInboxResult, { ok: true }>, from: string): string {
+  return `📬 maw inbox: new message from ${from} in ψ/inbox/${inbox.filename}. Run \`maw inbox\` to read.`;
+}
+
 export function emitMessageLifecycle(input: MessageLifecycleInput, deps: SessionsApiDeps = {}) {
   try {
     const build = deps.buildMessageLifecycleFeedEvent ?? buildMessageLifecycleFeedEvent;
@@ -371,8 +407,19 @@ export function createSessionsApi(deps: SessionsApiDeps = {}) {
           receipt: queuedReceipt(reason),
         };
       };
+      const notifyLiveInboxReceiver = async (inbox: ReceiverInboxResult) => {
+        if (!inbox.ok) return;
+        try {
+          const liveTarget = resolveLiveInboxNotificationTarget(inbox.oracle, await d.listSessions());
+          if (liveTarget) await d.sendKeys(liveTarget, formatInboxNotification(inbox, messageFrom));
+        } catch {
+          // Inbox persistence is the durable path. Live notification is only a
+          // best-effort nudge for already-running receiver sessions (#2057).
+        }
+      };
       const queueOrFail = async (tmuxTarget: string, reason: string, status = 502) => {
         const inbox = await writeInboundInbox(tmuxTarget);
+        if (inbox?.ok) await notifyLiveInboxReceiver(inbox);
         const queued = inbox ? queuedInboxResponse(inbox, tmuxTarget, reason) : null;
         if (queued) return queued;
         set.status = status;
@@ -614,6 +661,7 @@ export function createSessionsApi(deps: SessionsApiDeps = {}) {
 
       const errDetail = resolved?.type === "error" ? { reason: resolved.reason, detail: resolved.detail, hint: resolved.hint } : {};
       const inbox = await writeInboundInbox(target);
+      if (inbox?.ok) await notifyLiveInboxReceiver(inbox);
       const queued = inbox ? queuedInboxResponse(inbox, target, errDetail.detail || "target not live; persisted for receiver inbox polling") : null;
       if (queued) return queued;
       emitLifecycle({

--- a/src/api/sessions.ts
+++ b/src/api/sessions.ts
@@ -151,18 +151,22 @@ function windowTarget(session: Session, window: Session["windows"][number] | und
   return `${session.name}:${window.name || window.index}`;
 }
 
+function receiverNamedWindow(session: Session, wanted: string): Session["windows"][number] | undefined {
+  return session.windows.find((window) => normalizeInboxTargetName(window.name) === wanted);
+}
+
 /** @internal exported for tests. Resolve an inbox oracle to a live tmux target. */
 export function resolveLiveInboxNotificationTarget(oracle: string, sessions: Session[]): string | null {
   const wanted = normalizeInboxTargetName(oracle);
   if (!wanted) return null;
 
   for (const session of sessions) {
+    const namedWindow = receiverNamedWindow(session, wanted);
+    if (namedWindow) return windowTarget(session, namedWindow);
+
     if (normalizeInboxTargetName(session.name) === wanted) {
       return windowTarget(session, session.windows.find(w => w.active) ?? session.windows[0]);
     }
-
-    const win = session.windows.find(w => normalizeInboxTargetName(w.name) === wanted);
-    if (win) return windowTarget(session, win);
   }
 
   return null;

--- a/test/api-send-inbox-notify-2057.test.ts
+++ b/test/api-send-inbox-notify-2057.test.ts
@@ -67,10 +67,15 @@ describe("/api/send queued inbox live notification (#2057)", () => {
     const sessions = [
       session("50-atlas", [{ index: 1, name: "atlas-oracle", active: true }]),
       session("77-mawjs", [{ index: 0, name: "mawjs", active: true }]),
+      session("05-volt", [
+        { index: 0, name: "volt-oracle", active: false },
+        { index: 1, name: "volt-coder-3", active: true },
+      ]),
     ];
 
     expect(resolveLiveInboxNotificationTarget("atlas", sessions)).toBe("50-atlas:atlas-oracle");
     expect(resolveLiveInboxNotificationTarget("mawjs-oracle", sessions)).toBe("77-mawjs:mawjs");
+    expect(resolveLiveInboxNotificationTarget("volt", sessions)).toBe("05-volt:volt-oracle");
     expect(resolveLiveInboxNotificationTarget("ghost", sessions)).toBeNull();
   });
 

--- a/test/api-send-inbox-notify-2057.test.ts
+++ b/test/api-send-inbox-notify-2057.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test";
+import { Elysia } from "elysia";
+import {
+  createSessionsApi,
+  formatInboxNotification,
+  resolveLiveInboxNotificationTarget,
+  type SessionsApiDeps,
+} from "../src/api/sessions";
+
+function session(name: string, windows: any[]) {
+  return { name, windows } as any;
+}
+
+function postSend(body: unknown, headers: Record<string, string> = {}) {
+  return new Request("http://local/send", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+async function json(res: Response) {
+  return await res.json() as any;
+}
+
+function harness(overrides: Partial<SessionsApiDeps> = {}) {
+  const calls: any[] = [];
+  const sessions = [
+    session("50-atlas", [{ index: 0, name: "atlas-oracle", active: true }]),
+  ];
+  const deps: SessionsApiDeps = {
+    listSessions: async () => sessions,
+    capture: async () => "",
+    sendKeys: async (target: string, text: string) => calls.push(["sendKeys", target, text]),
+    selectWindow: async () => undefined,
+    checkPaneIdle: async () => ({ idle: true, lastInput: "" }) as any,
+    findWindow: (() => null) as any,
+    getAggregatedSessions: async (local: any[]) => local,
+    findPeerForTarget: async () => null,
+    sendKeysToPeer: async () => false,
+    sendKeysToPeerDetailed: async () => ({ ok: false, state: "failed" }) as any,
+    loadConfig: (() => ({ node: "m5", oracle: "mawjs", sessions: {} })) as any,
+    curlFetch: async () => ({ ok: false, status: 0, data: null }) as any,
+    resolveTarget: (() => ({ type: "error", reason: "missing", detail: "not live", hint: "wake" })) as any,
+    processMirror: ((raw: string) => raw) as any,
+    resolveFleetSession: () => null,
+    createTmux: () => ({ sendKeysLiteral: async () => undefined, sendKeys: async () => undefined, listPanes: async () => [], capture: async () => "" }) as any,
+    emitMessageLifecycle: () => undefined,
+    writeReceiverInbox: () => ({
+      ok: true,
+      oracle: "atlas",
+      inboxDir: "/repo/ψ/inbox",
+      path: "/repo/ψ/inbox/msg.md",
+      filename: "msg.md",
+    }),
+    sleep: async () => undefined,
+    shouldAutoWake: () => ({ wake: false, reason: "policy" }),
+    cmdWake: async () => undefined,
+    cmdSleepOne: async () => undefined,
+    ...overrides,
+  };
+  return { app: new Elysia().use(createSessionsApi(deps)), calls };
+}
+
+describe("/api/send queued inbox live notification (#2057)", () => {
+  test("resolves receiver oracle names to live session windows", () => {
+    const sessions = [
+      session("50-atlas", [{ index: 1, name: "atlas-oracle", active: true }]),
+      session("77-mawjs", [{ index: 0, name: "mawjs", active: true }]),
+    ];
+
+    expect(resolveLiveInboxNotificationTarget("atlas", sessions)).toBe("50-atlas:atlas-oracle");
+    expect(resolveLiveInboxNotificationTarget("mawjs-oracle", sessions)).toBe("77-mawjs:mawjs");
+    expect(resolveLiveInboxNotificationTarget("ghost", sessions)).toBeNull();
+  });
+
+  test("injects a notification after queueing inbox when receiver is live", async () => {
+    const h = harness();
+
+    const res = await h.app.handle(postSend(
+      { target: "atlas", text: "reply body" },
+      { "x-maw-from": "mawjs:m5" },
+    ));
+
+    expect(await json(res)).toMatchObject({ ok: true, source: "inbox", state: "queued" });
+    expect(h.calls).toEqual([[
+      "sendKeys",
+      "50-atlas:atlas-oracle",
+      "📬 maw inbox: new message from m5:mawjs in ψ/inbox/msg.md. Run `maw inbox` to read.",
+    ]]);
+  });
+
+  test("keeps inbox-only fallback when receiver has no live session", async () => {
+    const h = harness({ listSessions: async () => [] });
+
+    expect(await json(await h.app.handle(postSend({ target: "atlas", text: "reply body" })))).toMatchObject({
+      ok: true,
+      source: "inbox",
+      state: "queued",
+    });
+    expect(h.calls).toEqual([]);
+  });
+
+  test("formats concise inbox notification text", () => {
+    expect(formatInboxNotification({ ok: true, oracle: "atlas", inboxDir: "/x", path: "/x/msg.md", filename: "msg.md" }, "m5:mawjs"))
+      .toBe("📬 maw inbox: new message from m5:mawjs in ψ/inbox/msg.md. Run `maw inbox` to read.");
+  });
+});


### PR DESCRIPTION
## Summary
- notify a live receiver tmux pane after `/api/send` successfully queues a new receiver inbox file
- keep offline behavior as inbox-only for next wake/drain
- avoid daemon/watchers and do not mutate inbox read state
- leave `comm-send.ts` untouched to avoid conflict with #2056 work

## Tests
- `wc -l test/api-send-inbox-notify-2057.test.ts` → 108 lines
- `git diff --check`
- `bun test test/api-send-inbox-notify-2057.test.ts --path-ignore-patterns '**/agents/**'`
- `bun test test/comm-send-durable-inbox.test.ts --path-ignore-patterns '**/agents/**'`
- `bun test test/comm-send-cmdsend-coverage.test.ts --path-ignore-patterns '**/agents/**'`
- `bun test test/sessions-api-default.test.ts --path-ignore-patterns '**/agents/**'`

Closes #2057
