### PR TITLE
Fix hey locate resolution and wake inbox drain

### DIFF
--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -17,6 +17,10 @@ import {
   type ReceiverInboxResult,
   type ReceiverInboxWriter,
 } from "./receiver-inbox";
+import {
+  resolveBareHeyByLocatePath,
+  type HeyLocateResolution,
+} from "./hey-locate-resolution";
 
 /**
  * Resolve a `session:window` target to a specific pane running an agent
@@ -371,22 +375,26 @@ function isConfiguredPeerAlias(query: string, config: ReturnType<typeof loadConf
   }
 }
 
-function assertBareLocalTarget(
+async function resolveBareLocalTarget(
   query: string,
   config: ReturnType<typeof loadConfig>,
   sessions: Awaited<ReturnType<typeof listSessions>>,
-): ReturnType<typeof resolveTarget> | null {
-  if (!isBareLocalHeyTarget(query)) return null;
+): Promise<{ result: ReturnType<typeof resolveTarget> | null; locate: HeyLocateResolution | null }> {
+  if (!isBareLocalHeyTarget(query)) return { result: null, locate: null };
 
   try {
     const localResult = normalizeBareLocalResult(query, resolveTarget(query, config, sessions), config);
-    if (localResult) return localResult;
+    if (localResult) return { result: localResult, locate: null };
   } catch (e) {
     if (e instanceof AmbiguousMatchError) {
       rejectBareAmbiguous(query, e.candidates);
     }
     throw e;
   }
+
+  const locate = await resolveBareHeyByLocatePath(query, config, sessions);
+  if (locate.result) return { result: locate.result, locate };
+  if (locate.repoPath) return { result: null, locate };
 
   rejectBareMiss(query);
 }
@@ -577,7 +585,7 @@ export async function cmdSend(
   }
 
   let sessions = await listSessions();
-  const bareLocalResult = assertBareLocalTarget(query, config, sessions);
+  let bareResolution = await resolveBareLocalTarget(query, config, sessions);
 
   // --- #736 Phase 1.2 + #791: auto-wake fleet-known targets (parity with maw view) ---
   // Mirrors view/impl.ts:107 — if the user's hey target is fleet-known but
@@ -629,6 +637,7 @@ export async function cmdSend(
           await cmdWake(bareAgent, {});
           // Refresh after wake — resolver needs the new tmux session visible.
           sessions = await listSessions();
+          bareResolution = await resolveBareLocalTarget(query, config, sessions);
         }
       } catch { /* fleet/wake best-effort — fall through to existing error path */ }
     } else if (targetNode && bareAgent && !isCanonical) {
@@ -681,7 +690,11 @@ export async function cmdSend(
   }
 
   // --- Unified resolution via resolveTarget (#201) ---
-  const result = bareLocalResult ?? resolveTarget(query, config, sessions);
+  const result = bareResolution.result ?? (
+    isBareLocalHeyTarget(query)
+      ? { type: "error" as const, reason: "not_live", detail: `'${query}' found but no active session`, hint: `maw wake ${query}` }
+      : resolveTarget(query, config, sessions)
+  );
 
   // --- #842 Sub-C — cross-oracle ACL gate (Phase 2 of #642) ---
   //
@@ -938,7 +951,7 @@ export async function cmdSend(
   // Fallback: async peer discovery (network scan — slow path).
   // Only reached when resolveTarget found no local session AND no config-mapped peer.
   // Local sessions were already checked above — if we reach here, local genuinely missed.
-  const peerUrl = await findPeerForTarget(query, sessions);
+  const peerUrl = isBareLocalHeyTarget(query) ? null : await findPeerForTarget(query, sessions);
   if (peerUrl) {
     const res = await curlFetch(`${peerUrl}/api/send`, {
       method: "POST",
@@ -989,7 +1002,11 @@ export async function cmdSend(
   }
 
   // Try receiver inbox queue before surfacing a local-only resolver miss.
-  if (logQueuedInbox(await writeReceiverInbox(), query, "target not live; persisted for receiver inbox polling")) return;
+  if (bareResolution.locate?.repoPath) {
+    const reason = `${query} found at ${bareResolution.locate.repoPath} but no active session — written to inbox only`;
+    if (logQueuedInbox(await writeReceiverInbox(bareResolution.locate.repoPath), query, reason)) return;
+    console.warn(`\x1b[33mwarn\x1b[0m: ${reason}`);
+  } else if (logQueuedInbox(await writeReceiverInbox(), query, "target not live; persisted for receiver inbox polling")) return;
 
   // Local-only miss — no network was attempted (#411). Show resolver's own detail.
   if (result?.type === "error") {

--- a/src/commands/shared/hey-locate-resolution.ts
+++ b/src/commands/shared/hey-locate-resolution.ts
@@ -1,0 +1,172 @@
+import { existsSync } from "fs";
+import { isAbsolute, join, resolve, sep } from "path";
+import type { MawConfig } from "../../config";
+import { getGhqRoot } from "../../config/ghq-root";
+import { ghqFind } from "../../core/ghq";
+import type { Session } from "../../core/runtime/find-window";
+import { loadManifestCached, type OracleManifestEntry } from "../../lib/oracle-manifest";
+import { loadFleetEntries, type FleetEntry } from "./fleet-load";
+
+type LocalResolveResult = { type: "local" | "self-node"; target: string } | null;
+
+export interface HeyLocateResolution {
+  result: LocalResolveResult;
+  repoPath: string | null;
+  crossNodeBlocked: boolean;
+}
+
+export interface HeyLocateResolutionDeps {
+  ghqFind?: typeof ghqFind;
+  loadManifest?: () => OracleManifestEntry[];
+  loadFleetEntries?: () => FleetEntry[];
+  getGhqRoot?: typeof getGhqRoot;
+  existsSync?: typeof existsSync;
+}
+
+type SessionWithCwd = Session & { windows: Array<Session["windows"][number] & { cwd?: string }> };
+
+function normalizeOracleName(raw: string | undefined): string {
+  return (raw ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/^\d+-/, "")
+    .replace(/-oracle$/, "");
+}
+
+function unique(values: Array<string | null | undefined>): string[] {
+  return [...new Set(values.filter((value): value is string => Boolean(value && value.trim())))];
+}
+
+function repoFromFleetValue(value: string, ghqRoot: string): string[] {
+  const trimmed = value.trim();
+  if (!trimmed) return [];
+  if (isAbsolute(trimmed)) return [trimmed];
+  if (trimmed.startsWith("github.com/")) return [join(ghqRoot, trimmed)];
+  if (/^[^/]+\/[^/]+(?:\/.*)?$/.test(trimmed)) return [join(ghqRoot, "github.com", trimmed), join(ghqRoot, trimmed)];
+  return [join(ghqRoot, trimmed)];
+}
+
+function entryNameMatches(query: string, entry: OracleManifestEntry): boolean {
+  const wanted = normalizeOracleName(query);
+  return [entry.name, entry.window, entry.session]
+    .filter(Boolean)
+    .some((name) => normalizeOracleName(name) === wanted);
+}
+
+function fleetEntryMatches(query: string, entry: FleetEntry): boolean {
+  const wanted = normalizeOracleName(query);
+  const names = [
+    entry.file.replace(/\.json$/, ""),
+    entry.groupName,
+    entry.session?.name,
+    ...(entry.session?.windows ?? []).map((w) => w.name),
+  ];
+  return names.some((name) => normalizeOracleName(name) === wanted);
+}
+
+function resolveLocalPathCandidates(candidates: string[], exists: typeof existsSync): string[] {
+  return unique(candidates).filter((candidate) => {
+    try {
+      // Keep manifest-provided absolute paths even when the repo is currently
+      // absent: the caller still needs the exact path for the no-live warning,
+      // and receiver inbox persistence will report its own availability.
+      return isAbsolute(candidate) || exists(candidate);
+    } catch {
+      return isAbsolute(candidate);
+    }
+  });
+}
+
+export async function locateRepoPathsForBareHey(
+  query: string,
+  deps: HeyLocateResolutionDeps = {},
+): Promise<string[]> {
+  const find = deps.ghqFind ?? ghqFind;
+  const loadManifest = deps.loadManifest ?? loadManifestCached;
+  const loadFleet = deps.loadFleetEntries ?? loadFleetEntries;
+  const root = (deps.getGhqRoot ?? getGhqRoot)();
+  const exists = deps.existsSync ?? existsSync;
+  const paths: string[] = [];
+
+  try {
+    paths.push(await find(`/${query}-oracle`) ?? "");
+    paths.push(await find(`/${query}`) ?? "");
+  } catch {
+    // Best effort; manifest/fleet may still know the path.
+  }
+
+  try {
+    const entry = loadManifest().find((candidate) => entryNameMatches(query, candidate));
+    if (entry?.localPath) paths.push(entry.localPath);
+    if (entry?.repo) paths.push(join(root, "github.com", entry.repo), join(root, entry.repo));
+  } catch {
+    // Manifest lookup must not break hey delivery.
+  }
+
+  try {
+    for (const entry of loadFleet()) {
+      if (!fleetEntryMatches(query, entry)) continue;
+      for (const win of entry.session?.windows ?? []) {
+        paths.push(...repoFromFleetValue(win.repo, root));
+      }
+    }
+  } catch {
+    // Fleet lookup is advisory for locate-style resolution.
+  }
+
+  return resolveLocalPathCandidates(paths, exists);
+}
+
+function sameOrInside(candidate: string, repoPath: string): boolean {
+  const cwd = resolve(candidate);
+  const repo = resolve(repoPath);
+  return cwd === repo || cwd.startsWith(`${repo}${sep}`);
+}
+
+function targetForWindow(session: SessionWithCwd, window: SessionWithCwd["windows"][number]): string {
+  return `${session.name}:${window.name || window.index}`;
+}
+
+export function resolveLiveSessionByRepoPath(
+  repoPath: string,
+  sessions: Session[],
+): LocalResolveResult {
+  for (const session of sessions as SessionWithCwd[]) {
+    for (const window of session.windows ?? []) {
+      if (window.cwd && sameOrInside(window.cwd, repoPath)) {
+        return { type: "local", target: targetForWindow(session, window) };
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * `maw hey <bare>` locate-style resolver for #2056.
+ *
+ * Bare names stay local-only: a manifest/config remote node hit never becomes a
+ * peer route here. We only use locate-style sources to find a local repo path,
+ * then map that path to an active local tmux window or queue inbox-only.
+ */
+export async function resolveBareHeyByLocatePath(
+  query: string,
+  config: Pick<MawConfig, "node">,
+  sessions: Session[],
+  deps: HeyLocateResolutionDeps = {},
+): Promise<HeyLocateResolution> {
+  const repoPaths = await locateRepoPathsForBareHey(query, deps);
+  const repoPath = repoPaths[0] ?? null;
+  if (!repoPath) return { result: null, repoPath: null, crossNodeBlocked: false };
+
+  const result = resolveLiveSessionByRepoPath(repoPath, sessions);
+  const selfNode = config.node ?? "local";
+  let crossNodeBlocked = false;
+  try {
+    const manifestEntry = (deps.loadManifest ?? loadManifestCached)().find((entry) => entryNameMatches(query, entry));
+    crossNodeBlocked = Boolean(manifestEntry?.node && manifestEntry.node !== selfNode && manifestEntry.node !== "local");
+  } catch {
+    crossNodeBlocked = false;
+  }
+
+  return { result, repoPath, crossNodeBlocked };
+}

--- a/src/commands/shared/receiver-inbox.ts
+++ b/src/commands/shared/receiver-inbox.ts
@@ -1,5 +1,5 @@
 import { existsSync as fsExistsSync, mkdirSync as fsMkdirSync, writeFileSync as fsWriteFileSync } from "fs";
-import { basename, join } from "path";
+import { basename, isAbsolute, join } from "path";
 import { getGhqRoot as defaultGetGhqRoot } from "../../config/ghq-root";
 import { ghqFindSync as defaultGhqFindSync } from "../../core/ghq";
 import { loadManifestCached, type OracleManifestEntry } from "../../lib/oracle-manifest";
@@ -111,7 +111,9 @@ function repoPathCandidates(
 
   if (input.target) {
     try {
-      const cwd = deps.resolveTargetCwd(stripPaneSuffix(input.target));
+      const strippedTarget = stripPaneSuffix(input.target);
+      if (isAbsolute(strippedTarget)) candidates.push(strippedTarget);
+      const cwd = deps.resolveTargetCwd(strippedTarget);
       if (cwd) candidates.push(cwd);
     } catch {
       // Best effort: inbox persistence must never break message delivery.

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -30,6 +30,7 @@ import {
   writeWakeBudBirthSignal,
   writeWakeBudLineage,
 } from "./wake-cmd-helpers";
+import { drainWakeInbox, mergeWakeInboxPrompt } from "./wake-inbox-drain";
 export {
   type RehydrateWorktreePlan,
   type SnapshotRestorePlan,
@@ -843,6 +844,13 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
     : repoName;
   console.log(`\x1b[36m→\x1b[0m found \x1b[1m${ghSlug}\x1b[0m (${repoPath})`);
 
+  const drainedInbox = drainWakeInbox(repoPath, { markRead: !opts.dryRun });
+  if (drainedInbox.count > 0) {
+    opts = { ...opts, prompt: mergeWakeInboxPrompt(opts.prompt, drainedInbox.prompt) };
+    const dryRunSuffix = opts.dryRun ? " (dry-run; left unread)" : "";
+    console.log(`\x1b[36m📬\x1b[0m drained ${drainedInbox.count} unread ψ/inbox message${drainedInbox.count === 1 ? "" : "s"} into wake prompt${dryRunSuffix}`);
+  }
+
   // #1563 — `maw wake <oracle> --list` is a preview/read-only query.
   // Keep it before detectSession/newSession/respawn so it never creates or
   // rehydrates tmux windows just to show worktrees.
@@ -959,9 +967,12 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
       hasSession: tmux.hasSession,
     });
     await new Promise(r => setTimeout(r, 300));
-    await retryFreshSessionTmuxStep(session, "launch main window", () =>
-      tmux.sendText(`${session}:${mainWindowName}`, buildWakeCommand(mainWindowName, repoPath, opts))
-    , {
+    await retryFreshSessionTmuxStep(session, "launch main window", () => {
+      const command = buildWakeCommand(mainWindowName, repoPath, opts);
+      if (!opts.prompt) return tmux.sendText(`${session}:${mainWindowName}`, command);
+      const escaped = opts.prompt.replace(/'/g, "'\\''");
+      return tmux.sendText(`${session}:${mainWindowName}`, `${command} -p '${escaped}'`);
+    }, {
       hasSession: tmux.hasSession,
     });
     await wakeSession.waitForEngine(`${session}:${mainWindowName}`, getPaneInfos, isAgentCommand);

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -844,13 +844,6 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
     : repoName;
   console.log(`\x1b[36m→\x1b[0m found \x1b[1m${ghSlug}\x1b[0m (${repoPath})`);
 
-  const drainedInbox = drainWakeInbox(repoPath, { markRead: !opts.dryRun });
-  if (drainedInbox.count > 0) {
-    opts = { ...opts, prompt: mergeWakeInboxPrompt(opts.prompt, drainedInbox.prompt) };
-    const dryRunSuffix = opts.dryRun ? " (dry-run; left unread)" : "";
-    console.log(`\x1b[36m📬\x1b[0m drained ${drainedInbox.count} unread ψ/inbox message${drainedInbox.count === 1 ? "" : "s"} into wake prompt${dryRunSuffix}`);
-  }
-
   // #1563 — `maw wake <oracle> --list` is a preview/read-only query.
   // Keep it before detectSession/newSession/respawn so it never creates or
   // rehydrates tmux windows just to show worktrees.
@@ -866,6 +859,13 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
       }
     }
     return `${oracle}:list`;
+  }
+
+  const drainedInbox = drainWakeInbox(repoPath, { markRead: !opts.dryRun });
+  if (drainedInbox.count > 0) {
+    opts = { ...opts, prompt: mergeWakeInboxPrompt(opts.prompt, drainedInbox.prompt) };
+    const dryRunSuffix = opts.dryRun ? " (dry-run; left unread)" : "";
+    console.log(`\x1b[36m📬\x1b[0m drained ${drainedInbox.count} unread ψ/inbox message${drainedInbox.count === 1 ? "" : "s"} into wake prompt${dryRunSuffix}`);
   }
 
   const foreignSession = requestedForeignSession;

--- a/src/commands/shared/wake-inbox-drain.ts
+++ b/src/commands/shared/wake-inbox-drain.ts
@@ -1,0 +1,116 @@
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+
+export interface WakeInboxMessage {
+  path: string;
+  filename: string;
+  from: string;
+  timestamp: string;
+  body: string;
+}
+
+export interface WakeInboxDrainResult {
+  count: number;
+  prompt: string;
+  messages: WakeInboxMessage[];
+}
+
+export interface WakeInboxDrainDeps {
+  existsSync?: typeof existsSync;
+  readdirSync?: typeof readdirSync;
+  readFileSync?: typeof readFileSync;
+  writeFileSync?: typeof writeFileSync;
+  markRead?: boolean;
+}
+
+function parseFrontmatter(raw: string): { meta: Record<string, string>; body: string; frontmatter: string | null } {
+  if (!raw.startsWith("---\n")) return { meta: {}, body: raw.trim(), frontmatter: null };
+  const end = raw.indexOf("\n---", 4);
+  if (end < 0) return { meta: {}, body: raw.trim(), frontmatter: null };
+  const frontmatter = raw.slice(0, end + "\n---".length);
+  const body = raw.slice(end + "\n---".length).replace(/^\s*\n/, "").trim();
+  const meta: Record<string, string> = {};
+  for (const line of frontmatter.slice(4, -4).split("\n")) {
+    const idx = line.indexOf(":");
+    if (idx < 0) continue;
+    meta[line.slice(0, idx).trim()] = line.slice(idx + 1).trim().replace(/^['\"]|['\"]$/g, "");
+  }
+  return { meta, body, frontmatter };
+}
+
+function isUnread(meta: Record<string, string>): boolean {
+  return (meta.read ?? "false").trim().toLowerCase() === "false";
+}
+
+function markFrontmatterRead(raw: string, timestamp: string): string {
+  if (!raw.startsWith("---\n")) return raw;
+  const end = raw.indexOf("\n---", 4);
+  if (end < 0) return raw;
+  let fm = raw.slice(0, end + "\n---".length);
+  if (/^read:\s*false\s*$/im.test(fm)) fm = fm.replace(/^read:\s*false\s*$/im, "read: true");
+  else if (!/^read:/im.test(fm)) fm = fm.replace(/\n---$/, "\nread: true\n---");
+  if (!/^readAt:/im.test(fm)) fm = fm.replace(/\n---$/, `\nreadAt: ${timestamp}\n---`);
+  return fm + raw.slice(end + "\n---".length);
+}
+
+export function formatWakeInboxPrompt(messages: WakeInboxMessage[]): string {
+  if (!messages.length) return "";
+  const sections = messages.map((msg, index) => [
+    `### ${index + 1}. ${msg.filename}`,
+    `from: ${msg.from || "unknown"}`,
+    msg.timestamp ? `timestamp: ${msg.timestamp}` : "",
+    "",
+    msg.body,
+  ].filter(Boolean).join("\n"));
+  return [
+    "## Unread ψ/inbox messages",
+    "These messages were mechanically drained by `maw wake`; acknowledge or act on them before continuing.",
+    "",
+    ...sections,
+  ].join("\n\n");
+}
+
+export function mergeWakeInboxPrompt(existingPrompt: string | undefined, inboxPrompt: string): string | undefined {
+  if (!inboxPrompt.trim()) return existingPrompt;
+  if (!existingPrompt?.trim()) return inboxPrompt;
+  return `${existingPrompt.trim()}\n\n${inboxPrompt}`;
+}
+
+export function drainWakeInbox(repoPath: string, deps: WakeInboxDrainDeps = {}): WakeInboxDrainResult {
+  const fsExists = deps.existsSync ?? existsSync;
+  const fsReadDir = deps.readdirSync ?? readdirSync;
+  const fsReadFile = deps.readFileSync ?? readFileSync;
+  const fsWriteFile = deps.writeFileSync ?? writeFileSync;
+  const markRead = deps.markRead ?? true;
+  const inboxDir = join(repoPath, "ψ", "inbox");
+  if (!fsExists(inboxDir)) return { count: 0, prompt: "", messages: [] };
+
+  const messages: WakeInboxMessage[] = [];
+  for (const filename of fsReadDir(inboxDir).filter((name) => name.endsWith(".md")).sort()) {
+    const path = join(inboxDir, filename);
+    let raw: string;
+    try {
+      raw = fsReadFile(path, "utf-8");
+    } catch {
+      continue;
+    }
+    const parsed = parseFrontmatter(raw);
+    if (!isUnread(parsed.meta)) continue;
+    messages.push({
+      path,
+      filename,
+      from: parsed.meta.from ?? "",
+      timestamp: parsed.meta.timestamp ?? "",
+      body: parsed.body,
+    });
+    if (markRead) {
+      try {
+        fsWriteFile(path, markFrontmatterRead(raw, new Date().toISOString()));
+      } catch {
+        // Draining is best-effort: a read-only inbox should not prevent wake.
+      }
+    }
+  }
+
+  return { count: messages.length, messages, prompt: formatWakeInboxPrompt(messages) };
+}

--- a/test/comm-send-cmdsend-coverage.test.ts
+++ b/test/comm-send-cmdsend-coverage.test.ts
@@ -37,7 +37,7 @@ const realConfig = { loadConfig: _rConfig.loadConfig, cfgLimit: _rConfig.cfgLimi
 const realFeed = { logMessage: _rFeed.logMessage, emitFeed: _rFeed.emitFeed };
 const realRegistry = { discoverPackages: _rRegistry.discoverPackages, invokePlugin: _rRegistry.invokePlugin };
 const realOracleMembers = { getOracleMembers: _rOracleMembers.getOracleMembers, loadOracleRegistry: _rOracleMembers.loadOracleRegistry };
-const realOracleManifest = { findOracle: _rOracleManifest.findOracle };
+const realOracleManifest = { findOracle: _rOracleManifest.findOracle, loadManifestCached: _rOracleManifest.loadManifestCached };
 const realWakeCmd = { cmdWake: _rWakeCmd.cmdWake };
 const realScopeAcl = { loadAllScopes: _rScopeAcl.loadAllScopes, evaluateAclFromDisk: _rScopeAcl.evaluateAclFromDisk };
 const realQueueStore = { savePending: _rQueueStore.savePending };
@@ -77,6 +77,7 @@ let invokePluginResult: { ok: boolean; output?: string; error?: string };
 let oracleMembers: string[];
 let oracleRegistry: { members: string[] } | null;
 let findOracleResult: any;
+let manifestEntries: any[];
 let cmdWakeCalls: Array<{ oracle: string; opts: any }>;
 let scopes: any[];
 let aclError: Error | null;
@@ -155,6 +156,7 @@ mock.module(join(import.meta.dir, "../src/lib/oracle-members"), () => ({
 mock.module(join(import.meta.dir, "../src/lib/oracle-manifest"), () => ({
   ..._rOracleManifest,
   findOracle: (name: string) => mockActive ? findOracleResult : realOracleManifest.findOracle(name),
+  loadManifestCached: () => mockActive ? manifestEntries : realOracleManifest.loadManifestCached(),
 }));
 
 mock.module(join(import.meta.dir, "../src/commands/shared/wake-cmd"), () => ({
@@ -276,6 +278,7 @@ beforeEach(() => {
   oracleMembers = [];
   oracleRegistry = null;
   findOracleResult = undefined;
+  manifestEntries = [];
   cmdWakeCalls = [];
   scopes = [];
   aclError = null;
@@ -703,6 +706,54 @@ describe("cmdSend — bare-name, wake, and safety gates", () => {
     expect(exitCode).toBe(1);
     expect(curlFetchCalls).toEqual([]);
     expect(errs.join("\n")).toContain("not found locally");
+  });
+
+
+
+  test("bare located repo with no live session queues inbox-only with clear warning (#2056)", async () => {
+    const receiverWrites: any[] = [];
+    listSessionsReturn = [];
+    resolveTargetReturn = { type: "peer", target: "renamed", node: "remote", peerUrl: "http://remote:3456" };
+    manifestEntries = [{ name: "renamed", localPath: "/tmp/renamed-oracle", node: "test-node", sources: ["oracles.json"] }];
+
+    await runCmd(() => cmdSend("renamed", "hello", false, {
+      receiverInbox: async (input: any) => {
+        receiverWrites.push(input);
+        return { ok: true, oracle: "renamed", inboxDir: "/tmp/renamed-oracle/ψ/inbox", path: "/tmp/renamed-oracle/ψ/inbox/msg.md", filename: "msg.md" };
+      },
+    }));
+
+    expect(exitCode).toBeUndefined();
+    expect(curlFetchCalls).toEqual([]);
+    expect(receiverWrites).toHaveLength(1);
+    expect(receiverWrites[0].target).toBe("/tmp/renamed-oracle");
+    expect(logs.join("\n")).toContain("renamed found at /tmp/renamed-oracle but no active session — written to inbox only");
+  });
+
+  test("bare located repo resolves to active local session by cwd before inbox fallback (#2056)", async () => {
+    listSessionsReturn = [{ name: "77-renamed", windows: [{ index: 0, name: "renamed-oracle", active: true, cwd: "/tmp/renamed-oracle" } as any] }];
+    resolveTargetReturn = { type: "peer", target: "renamed", node: "remote", peerUrl: "http://remote:3456" };
+    manifestEntries = [{ name: "renamed", localPath: "/tmp/renamed-oracle", node: "test-node", sources: ["oracles.json"] }];
+
+    await runCmd(() => cmdSend("renamed", "hello", false, { receiverInbox: false }));
+
+    expect(exitCode).toBeUndefined();
+    expect(curlFetchCalls).toEqual([]);
+    expect(sendKeysCalls).toEqual([{ target: "77-renamed:renamed-oracle", text: "[test-node:sender] hello" }]);
+  });
+
+  test("bare manifest cross-node hit does not silently route to peer (#2056)", async () => {
+    config.namedPeers = [{ name: "remote", url: "http://remote:3456" }];
+    listSessionsReturn = [];
+    resolveTargetReturn = { type: "peer", target: "renamed", node: "remote", peerUrl: "http://remote:3456" };
+    manifestEntries = [{ name: "renamed", localPath: "/tmp/renamed-oracle", node: "remote", sources: ["oracles.json"] }];
+
+    await runCmd(() => cmdSend("renamed", "hello", false, { receiverInbox: false }));
+
+    expect(exitCode).toBe(1);
+    expect(curlFetchCalls).toEqual([]);
+    expect(warns.join("\n")).toContain("renamed found at /tmp/renamed-oracle but no active session — written to inbox only");
+    expect(errs.join("\n")).toContain("found but no active session");
   });
 
   test("bare peer aliases are allowed as explicit federation targets (#1940)", async () => {

--- a/test/receiver-inbox-default.test.ts
+++ b/test/receiver-inbox-default.test.ts
@@ -68,6 +68,30 @@ describe("receiver inbox auto-write helpers", () => {
     expect(readFileSync(result.path, "utf-8")).toContain("[m5:sender] ralph-dig: oracle-status-tray");
   });
 
+  test("accepts an absolute repo path target for locate-resolved no-live queues (#2056)", () => {
+    const root = mkdtempSync(join(tmpdir(), "maw-receiver-inbox-absolute-"));
+    const repo = join(root, "renamed-oracle");
+    mkdirSync(repo, { recursive: true });
+
+    const result = persistReceiverInbox({
+      query: "renamed",
+      target: repo,
+      from: "m5:sender",
+      message: "queued via locate path",
+    }, {
+      resolveTargetCwd: () => null,
+      loadManifest: () => [],
+      getGhqRoot: () => root,
+      ghqFindSync: () => null,
+      now: () => new Date("2026-06-06T07:00:00.000Z"),
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.reason);
+    expect(result.inboxDir).toBe(join(repo, "ψ", "inbox"));
+    expect(readFileSync(result.path, "utf-8")).toContain("queued via locate path");
+  });
+
   test("falls back to manifest repo path and reports misses without throwing", () => {
     const root = mkdtempSync(join(tmpdir(), "maw-receiver-inbox-manifest-"));
     const repo = join(root, "github.com", "Soul-Brews-Studio", "digger-oracle");

--- a/test/wake-cmd-cmdwake-coverage.test.ts
+++ b/test/wake-cmd-cmdwake-coverage.test.ts
@@ -5,7 +5,7 @@
  * to avoid cross-file pollution.
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync, mkdirSync } from "fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, mkdirSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 
@@ -664,6 +664,34 @@ describe("cmdWake main-suite coverage", () => {
 
     _wtPicker.readChoice = () => "1";
     expect(promptAmbiguousBringPick("features", [candidate])).toEqual(candidate);
+  });
+
+  test("--list is read-only and does not drain unread ψ/inbox messages (#2056)", async () => {
+    const inboxDir = join(repoPath, "ψ", "inbox");
+    mkdirSync(inboxDir, { recursive: true });
+    const unreadPath = join(inboxDir, "001.md");
+    writeFileSync(unreadPath, [
+      "---",
+      "from: m5:sender",
+      "to: mawjs",
+      "timestamp: 2026-06-06T07:30:00.000Z",
+      "read: false",
+      "---",
+      "",
+      "do not drain during preview",
+      "",
+    ].join("\n"));
+
+    const { result, logs } = await captureLogs(() =>
+      cmdWake("mawjs", { listWt: true }),
+    );
+
+    expect(result).toBe("mawjs:list");
+    expect(readFileSync(unreadPath, "utf-8")).toContain("read: false");
+    expect(readFileSync(unreadPath, "utf-8")).not.toContain("readAt:");
+    expect(logs.join("\n")).not.toContain("drained");
+    expect(detectSessionCalls).toHaveLength(0);
+    expect(sendTextCalls).toHaveLength(0);
   });
 
   test("lists worktrees without detecting or mutating tmux", async () => {

--- a/test/wake-inbox-drain-2056.test.ts
+++ b/test/wake-inbox-drain-2056.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { drainWakeInbox, mergeWakeInboxPrompt } from "../src/commands/shared/wake-inbox-drain";
+
+describe("wake inbox drain (#2056)", () => {
+  test("drains unread ψ/inbox markdown into a priming prompt and marks read", () => {
+    const repo = mkdtempSync(join(tmpdir(), "maw-wake-drain-"));
+    const inbox = join(repo, "ψ", "inbox");
+    mkdirSync(inbox, { recursive: true });
+    const unread = join(inbox, "001.md");
+    const read = join(inbox, "002.md");
+    writeFileSync(unread, [
+      "---",
+      "from: alpha:sender",
+      "to: renamed",
+      "timestamp: 2026-06-06T00:00:00.000Z",
+      "read: false",
+      "---",
+      "",
+      "please review #2056",
+      "",
+    ].join("\n"));
+    writeFileSync(read, ["---", "from: old", "read: true", "---", "", "old"].join("\n"));
+
+    const result = drainWakeInbox(repo);
+
+    expect(result.count).toBe(1);
+    expect(result.prompt).toContain("Unread ψ/inbox messages");
+    expect(result.prompt).toContain("please review #2056");
+    expect(result.prompt).not.toContain("old");
+    const updated = readFileSync(unread, "utf-8");
+    expect(updated).toContain("read: true");
+    expect(updated).toContain("readAt:");
+  });
+
+  test("merges drained inbox after an explicit wake prompt", () => {
+    expect(mergeWakeInboxPrompt("continue task", "## Unread ψ/inbox messages\nhello"))
+      .toBe("continue task\n\n## Unread ψ/inbox messages\nhello");
+  });
+});


### PR DESCRIPTION
Closes #2056.

## Summary
- make bare `maw hey <name>` use locate-style local repo discovery before failing
- keep bare names local-only: manifest/agents remote hits do not silently route cross-node without explicit `<node>:`
- queue no-live located targets to receiver `ψ/inbox` with `X found at /path but no active session — written to inbox only`
- drain unread `ψ/inbox/*.md` into `maw wake` priming prompts and mark them read

## Tests
- `bun test test/comm-send-cmdsend-coverage.test.ts test/receiver-inbox-default.test.ts test/wake-inbox-drain-2056.test.ts`
- `bash scripts/test-default-safe.sh test/comm-send-cmdsend-coverage.test.ts test/receiver-inbox-default.test.ts test/wake-inbox-drain-2056.test.ts`
- `bun run build`
- `git diff --check`

## Note
A broad `bun run test:default:safe` attempt failed outside this change because the script also scanned top-level `agents/` worktree copies and timed out duplicated `cleanup --worktrees handler` cases; scoped changed-file gates above are green.