### PR TITLE
release: v26.6.6-alpha.1432

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.6.6-alpha.1059",
+  "version": "26.6.6-alpha.1432",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
## Mini-sprint: inbox notification + broadcast scope

Cuts v26.6.6-alpha.1432 on merge.

### Shipped
- #2058 feat(broadcast): scope filter --session/--team/--fleet (#2041)
- #2059 fix(api): notify live receivers about queued inbox writes (#2057)
- #2060 fix(hey): locate resolution + wake inbox drain (#2056)
- #2054 fix(done): lead-window guard (#2053)

### Context
Solves inbox blind spot found live by atlas-oracle (renamed from discord-oracle). maw hey now resolves renamed oracles, wake drains inbox, live receivers get notified.