### PR TITLE
Fix fleet registration storing worktree path as repo

### DIFF
--- a/src/commands/shared/fleet-ensure.test.ts
+++ b/src/commands/shared/fleet-ensure.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "bun:test";
+import { _test, ensureFleetSessionEntry } from "./fleet-ensure";
+
+const { repoFromCwd } = _test;
+
+describe("repoFromCwd", () => {
+  const ghqRoot = "/opt/Code";
+
+  it("extracts org/repo from a normal github repo path", () => {
+    expect(repoFromCwd("/opt/Code/github.com/Soul-Brews-Studio/maw-js", ghqRoot))
+      .toBe("github.com/Soul-Brews-Studio/maw-js");
+  });
+
+  it("extracts org/repo from github.com candidate (2-segment)", () => {
+    expect(repoFromCwd("/opt/Code/github.com/acme/repo", ghqRoot))
+      .toBe("github.com/acme/repo");
+  });
+
+  it("strips worktree suffix under agents/", () => {
+    expect(repoFromCwd("/opt/Code/github.com/Soul-Brews-Studio/maw-js/agents/1-codex-issue", ghqRoot))
+      .toBe("github.com/Soul-Brews-Studio/maw-js");
+  });
+
+  it("strips deep worktree paths", () => {
+    expect(repoFromCwd("/opt/Code/github.com/acme/repo/agents/3-codex-perf/src/lib", ghqRoot))
+      .toBe("github.com/acme/repo");
+  });
+
+  it("returns null for paths outside ghq root", () => {
+    expect(repoFromCwd("/home/user/projects/foo", ghqRoot)).toBeNull();
+  });
+
+  it("returns null for undefined cwd", () => {
+    expect(repoFromCwd(undefined, ghqRoot)).toBeNull();
+  });
+
+  it("returns null for too-shallow paths", () => {
+    expect(repoFromCwd("/opt/Code/github.com", ghqRoot)).toBeNull();
+    expect(repoFromCwd("/opt/Code/github.com/acme", ghqRoot)).toBeNull();
+  });
+});
+
+describe("ensureFleetSessionEntry worktree repo", () => {
+  it("stores parent repo, not worktree path, in fleet window", () => {
+    let written = "";
+    const result = ensureFleetSessionEntry(
+      { session: "test-wt", window: "codex-issue", cwd: "/opt/Code/github.com/acme/repo/agents/1-codex-issue", createdBy: "maw wake" },
+      {
+        fleetDirsForRead: () => ["/tmp/fleet-test-empty"],
+        loadFleetEntries: () => [],
+        getGhqRoot: () => "/opt/Code",
+        existsSync: () => false,
+        mkdirSync: () => undefined,
+        writeFileSync: (_p: any, data: any) => { written = data; },
+        fleetDirForWrite: () => "/tmp/fleet-test",
+        now: () => new Date("2026-01-01"),
+      },
+    );
+    expect(result.status).toBe("created");
+    const parsed = JSON.parse(written);
+    expect(parsed.windows[0].repo).toBe("github.com/acme/repo");
+  });
+});

--- a/src/commands/shared/fleet-ensure.ts
+++ b/src/commands/shared/fleet-ensure.ts
@@ -42,12 +42,15 @@ function isInside(parent: string, child: string): boolean {
 function repoFromCwd(cwd: string | undefined, ghqRoot: string): string | null {
   if (!cwd) return null;
   const resolvedCwd = resolve(cwd);
-  const candidates = [resolve(ghqRoot), resolve(ghqRoot, "github.com")];
-  for (const root of candidates) {
+  const candidates: Array<{ root: string; segments: number }> = [
+    { root: resolve(ghqRoot), segments: 3 },
+    { root: resolve(ghqRoot, "github.com"), segments: 2 },
+  ];
+  for (const { root, segments } of candidates) {
     if (!isInside(root, resolvedCwd)) continue;
-    const rel = relative(root, resolvedCwd).split(sep).join("/");
-    if (!rel || rel.startsWith("..") || rel.split("/").length < 2) continue;
-    return rel;
+    const parts = relative(root, resolvedCwd).split(sep);
+    if (parts.length < segments || parts[0] === "..") continue;
+    return parts.slice(0, segments).join("/");
   }
   return null;
 }


### PR DESCRIPTION
## Summary
- `repoFromCwd` returned the full relative path including worktree suffixes (e.g. `Soul-Brews-Studio/maw-js/agents/1-codex-issue`) instead of truncating to `github.com/Soul-Brews-Studio/maw-js`
- On re-wake, `resolveWakeFleetSessionRepo` tried to ghq-clone this non-existent repo → `maw attach` fails after `team up`
- Fix: truncate to canonical segment count (3 from ghq root, 2 from github.com root) so worktree subdirectories resolve to their parent repository

## Test plan
- [x] Unit tests for `repoFromCwd` — normal paths, worktree paths, edge cases
- [x] Integration test for `ensureFleetSessionEntry` — verifies worktree cwd stores parent repo
- [x] All 8 new tests pass, full suite green

Closes #2074

🤖 Generated with [Claude Code](https://claude.com/claude-code)