### PR TITLE
release: v26.6.6-alpha.1545

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.6.6-alpha.1432",
+  "version": "26.6.6-alpha.1548",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/vendor/mpr-plugins/done/done-worktree.ts
+++ b/src/vendor/mpr-plugins/done/done-worktree.ts
@@ -190,8 +190,13 @@ export async function removeWorktreeViaConfig(
         }
         let branch = "";
         try { branch = (await hostExec(`git -C '${fullPath}' rev-parse --abbrev-ref HEAD`)).trim(); } catch { /* expected */ }
-        // #1968: force removes ignored engine scratch (for example .omx/) left in finished worktrees.
-        await hostExec(`git -C ${shellArg(mainPath)} worktree remove ${shellArg(fullPath)} --force`);
+        // Try without --force first; fall back to --force if dirty (#2065).
+        try {
+          await hostExec(`git -C ${shellArg(mainPath)} worktree remove ${shellArg(fullPath)}`);
+        } catch {
+          console.log(`  \x1b[33m⚠\x1b[0m non-force remove failed, retrying with --force`);
+          await hostExec(`git -C ${shellArg(mainPath)} worktree remove ${shellArg(fullPath)} --force`);
+        }
         await hostExec(`git -C ${shellArg(mainPath)} worktree prune`);
         console.log(`  \x1b[32m✓\x1b[0m removed worktree ${win.repo}`);
         await cleanupDoneBranch(mainPath, branch, opts);
@@ -252,8 +257,13 @@ export async function removeWorktreeByGhqScan(
         }
         let branch = "";
         try { branch = (await hostExec(`git -C '${wtPath}' rev-parse --abbrev-ref HEAD`)).trim(); } catch { /* expected */ }
-        // #1968: force removes ignored engine scratch (for example .omx/) left in finished worktrees.
-        await hostExec(`git -C ${shellArg(mainPath)} worktree remove ${shellArg(wtPath)} --force`);
+        // Try without --force first; fall back to --force if dirty (#2065).
+        try {
+          await hostExec(`git -C ${shellArg(mainPath)} worktree remove ${shellArg(wtPath)}`);
+        } catch {
+          console.log(`  \x1b[33m⚠\x1b[0m non-force remove failed, retrying with --force`);
+          await hostExec(`git -C ${shellArg(mainPath)} worktree remove ${shellArg(wtPath)} --force`);
+        }
         await hostExec(`git -C ${shellArg(mainPath)} worktree prune`);
         console.log(`  \x1b[32m✓\x1b[0m removed worktree ${base}`);
         removed = true;


### PR DESCRIPTION
Cuts v26.6.6-alpha.1545 on merge via calver-release.yml.

## Sprint ships (9 PRs)
- #2075 fix: fleet pin worktree path
- #2076 fix: wake inbox 64KB byte budget
- #2077 fix: resume clear pending input
- #2078 fix: fleet rename migrate peer refs
- #2079 fix: done engine-aware /rrr skip
- #2080 feat: cleanup --repo/--scope
- #2081 chore: remove dead team-up copy
- #2083 fix: wake-cmd engine-aware prompt
- #2085 fix: done no-force fallback