### PR TITLE
feat: audit user setup prune candidates

### DIFF
--- a/src/vendor/mpr-plugins/user-setup/impl.ts
+++ b/src/vendor/mpr-plugins/user-setup/impl.ts
@@ -4,6 +4,7 @@ import { basename, dirname, join, resolve, sep } from "path";
 import { execSync } from "child_process";
 
 export const USER_SETUP_AUDIT_USAGE = "usage: maw user-setup projects audit --json";
+export const USER_SETUP_USAGE = "usage: maw user-setup [--dry-run] or maw user-setup projects audit --json";
 
 export type PathConfidence = "exact" | "probable" | "ambiguous" | "unknown";
 
@@ -52,6 +53,31 @@ export interface UserSetupAuditResult {
   totalSizeBytes: number;
   entries: UserSetupAuditEntry[];
   warnings: string[];
+}
+
+export interface DuplicatePathFinding {
+  inferred: string;
+  encoded: string[];
+}
+
+export interface UserSetupPrunePlan {
+  root: string;
+  generatedAt: string;
+  dryRun: boolean;
+  staleProjectDirs: UserSetupAuditEntry[];
+  orphanSessionFiles: FileFinding[];
+  duplicateEncodedPaths: DuplicatePathFinding[];
+  warnings: string[];
+}
+
+function isWorktreeDerivedProject(encoded: string): boolean {
+  return encoded.includes("-wt-") || encoded.includes("-agents-");
+}
+
+function isSafePruneCandidate(entry: UserSetupAuditEntry): boolean {
+  return isWorktreeDerivedProject(entry.encoded)
+    && entry.sessionCount === 0
+    && entry.sourceExists === false;
 }
 
 type DirentLike = { name: string; isDirectory(): boolean; isFile(): boolean; isSymbolicLink?(): boolean };
@@ -303,7 +329,7 @@ export async function auditClaudeProjects(deps: UserSetupAuditDeps = {}): Promis
     if (scan.sessionCount === 0) warningsForEntry.push("no JSONL sessions found");
 
     let sourceExists: boolean | undefined;
-    if (path.inferred && (path.confidence === "exact" || path.confidence === "probable")) {
+    if (path.inferred) {
       try { sourceExists = d.existsSync(path.inferred); } catch { sourceExists = false; }
     }
 
@@ -332,4 +358,100 @@ export async function auditClaudeProjects(deps: UserSetupAuditDeps = {}): Promis
     entries,
     warnings,
   };
+}
+
+function rootSessionFiles(root: string, deps: ReturnType<typeof depsWithDefaults>): FileFinding[] {
+  let entries: DirentLike[];
+  try { entries = readDirents(root, deps); }
+  catch { return []; }
+
+  const files: FileFinding[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
+    const full = join(root, entry.name);
+    try {
+      const st = deps.statSync(full);
+      files.push({ name: entry.name, sizeBytes: st.size || 0, lastModified: isoFromMs(st.mtimeMs || null) });
+    } catch {
+      files.push({ name: entry.name, sizeBytes: 0, lastModified: null });
+    }
+  }
+  return files.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function duplicateInferredPaths(entries: UserSetupAuditEntry[]): DuplicatePathFinding[] {
+  const groups = new Map<string, string[]>();
+  for (const entry of entries) {
+    const inferred = entry.path.inferred;
+    if (!inferred) continue;
+    const list = groups.get(inferred) ?? [];
+    list.push(entry.encoded);
+    groups.set(inferred, list);
+  }
+  return [...groups.entries()]
+    .filter(([, encoded]) => encoded.length > 1)
+    .map(([inferred, encoded]) => ({ inferred, encoded: encoded.sort() }))
+    .sort((a, b) => a.inferred.localeCompare(b.inferred));
+}
+
+export async function planUserSetupPrune(
+  opts: { dryRun?: boolean } = {},
+  deps: UserSetupAuditDeps = {},
+): Promise<UserSetupPrunePlan> {
+  const d = depsWithDefaults(deps);
+  const audit = await auditClaudeProjects(deps);
+  // Noah/m5 real-data rule: only prune empty worktree-derived Claude project dirs.
+  // Observed shape: ~370 dirs, ~167 worktree-derived, ~86 empty/prune-able, ~81
+  // with JSONL memory. Never prune main repo dirs or any dir with *.jsonl.
+  const staleProjectDirs = audit.entries
+    .filter(isSafePruneCandidate)
+    .sort((a, b) => a.encoded.localeCompare(b.encoded));
+  const orphanSessionFiles = rootSessionFiles(audit.root, d);
+  const duplicateEncodedPaths = duplicateInferredPaths(audit.entries);
+
+  return {
+    root: audit.root,
+    generatedAt: audit.generatedAt,
+    dryRun: opts.dryRun !== false,
+    staleProjectDirs,
+    orphanSessionFiles,
+    duplicateEncodedPaths,
+    warnings: audit.warnings,
+  };
+}
+
+export function renderUserSetupPlan(plan: UserSetupPrunePlan): string {
+  const lines = [
+    `maw user-setup ${plan.dryRun ? "dry-run " : ""}audit`,
+    `root: ${plan.root}`,
+    `safe prune candidates: ${plan.staleProjectDirs.length}`,
+    `orphan session files: ${plan.orphanSessionFiles.length}`,
+    `duplicate encoded paths: ${plan.duplicateEncodedPaths.length}`,
+  ];
+
+  if (plan.staleProjectDirs.length) {
+    lines.push("", "safe prune candidates:");
+    for (const entry of plan.staleProjectDirs) {
+      lines.push(`  - ${entry.encoded}${entry.path.inferred ? ` -> ${entry.path.inferred}` : ""}`);
+      lines.push("    why: worktree-derived name (-wt-/-agents-), 0 JSONL sessions, decoded path missing");
+    }
+  }
+  if (plan.orphanSessionFiles.length) {
+    lines.push("", "orphan session files:");
+    for (const file of plan.orphanSessionFiles) lines.push(`  - ${file.name} (${file.sizeBytes} bytes)`);
+  }
+  if (plan.duplicateEncodedPaths.length) {
+    lines.push("", "duplicate encoded paths:");
+    for (const group of plan.duplicateEncodedPaths) lines.push(`  - ${group.inferred}: ${group.encoded.join(", ")}`);
+  }
+  if (plan.warnings.length) lines.push("", "warnings:", ...plan.warnings.map(w => `  - ${w}`));
+
+  const pruneCount = plan.staleProjectDirs.length + plan.orphanSessionFiles.length;
+  lines.push(
+    "",
+    pruneCount
+      ? "prune offer: archive candidates are listed above; rerun after review when prune execution is enabled."
+      : "prune offer: nothing to prune.",
+  );
+  return lines.join("\n");
 }

--- a/src/vendor/mpr-plugins/user-setup/index.ts
+++ b/src/vendor/mpr-plugins/user-setup/index.ts
@@ -1,21 +1,33 @@
 import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { parseFlags } from "maw-js/cli/parse-args";
-import { auditClaudeProjects, USER_SETUP_AUDIT_USAGE } from "./impl";
+import {
+  auditClaudeProjects,
+  planUserSetupPrune,
+  renderUserSetupPlan,
+  USER_SETUP_AUDIT_USAGE,
+  USER_SETUP_USAGE,
+} from "./impl";
 
 export const command = {
   name: "user-setup",
-  description: "Read-only user setup inventory tools.",
+  description: "Audit local Claude project logs and report prune candidates.",
 };
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
   const args = ctx.args ?? [];
   const flags = parseFlags(args, {
+    "--dry-run": Boolean,
     "--json": Boolean,
   }, 0);
 
   const [scope, action] = flags._;
+  if (!scope) {
+    const plan = await planUserSetupPrune({ dryRun: true });
+    return { ok: true, output: renderUserSetupPlan(plan) };
+  }
+
   if (scope !== "projects" || action !== "audit") {
-    return { ok: false, error: USER_SETUP_AUDIT_USAGE, output: USER_SETUP_AUDIT_USAGE, exitCode: 2 };
+    return { ok: false, error: USER_SETUP_USAGE, output: USER_SETUP_USAGE, exitCode: 2 };
   }
   if (!flags["--json"]) {
     return {

--- a/src/vendor/mpr-plugins/user-setup/plugin.json
+++ b/src/vendor/mpr-plugins/user-setup/plugin.json
@@ -3,11 +3,12 @@
   "version": "1.0.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "Audit Claude project-log directories before any user-setup organize or prune flow. Read-only.",
+  "description": "Audit Claude project-log directories and report safe prune candidates.",
   "cli": {
     "command": "user-setup",
-    "help": "maw user-setup projects audit --json",
+    "help": "maw user-setup [--dry-run] | maw user-setup projects audit --json",
     "flags": {
+      "--dry-run": "boolean",
       "--json": "boolean"
     }
   },

--- a/test/isolated/user-setup-audit.test.ts
+++ b/test/isolated/user-setup-audit.test.ts
@@ -126,3 +126,36 @@ describe("user-setup projects audit", () => {
     expect(entry.warnings.some(w => w.includes("stat failed") && w.includes("boom"))).toBe(true);
   });
 });
+
+test("top-level user-setup plan only prunes empty missing worktree-derived dirs", async () => {
+  const root = tempRoot();
+  const projects = join(root, "projects");
+  mkdirSync(projects, { recursive: true });
+
+  const pruneMe = "-tmp-repo-wt-1-task";
+  mkdirSync(join(projects, pruneMe), { recursive: true });
+  const keepMain = "-tmp-missing-main";
+  mkdirSync(join(projects, keepMain), { recursive: true });
+  const keepMemory = "-tmp-repo-wt-2-memory";
+  mkdirSync(join(projects, keepMemory), { recursive: true });
+  writeJsonl(join(projects, keepMemory, "session.jsonl"));
+  writeJsonl(join(projects, "orphan.jsonl"));
+
+  const { planUserSetupPrune, renderUserSetupPlan } = await import("../../src/vendor/mpr-plugins/user-setup/impl");
+  const plan = await planUserSetupPrune({ dryRun: true }, {
+    projectsRoot: projects,
+    now: () => new Date("2026-06-06T00:00:00Z"),
+    cwd: () => "/elsewhere",
+  });
+  plan.duplicateEncodedPaths.push({ inferred: "/tmp/dupe", encoded: ["-tmp-dupe-a", "-tmp-dupe-b"] });
+  const output = renderUserSetupPlan(plan);
+
+  expect(plan.staleProjectDirs.map(e => e.encoded)).toEqual([pruneMe]);
+  expect(plan.orphanSessionFiles.map(f => f.name)).toEqual(["orphan.jsonl"]);
+  expect(output).toContain("safe prune candidates: 1");
+  expect(output).toContain("why: worktree-derived name (-wt-/-agents-), 0 JSONL sessions, decoded path missing");
+  expect(output).not.toContain(keepMain);
+  expect(output).not.toContain(keepMemory);
+  expect(output).toContain("duplicate encoded paths: 1");
+  expect(output).toContain("prune offer:");
+});


### PR DESCRIPTION
## Summary
- Add top-level `maw user-setup [--dry-run]` report for Claude project-log hygiene.
- Report safe prune candidates, root-level orphan session files, and duplicate inferred encoded paths.
- Encode Noah/m5 prune guardrail: only dirs with `-wt-`/`-agents-`, zero `*.jsonl`, and missing decoded path are prune candidates; main repo dirs and any JSONL-bearing dirs are kept.

Closes #1934

## Tests
- `MAW_TEST_MODE=1 bun test test/isolated/user-setup-audit.test.ts --path-ignore-patterns '**/agents/**'`\n- Import smoke for `user-setup --dry-run` and `projects audit --json`\n- `git diff --check`\n\n## Notes\n- Full `timeout 120s bun test --path-ignore-patterns '**/agents/**'` was attempted, but existing unrelated default-suite failures appeared in `test/fleet-ensure-entry.test.ts` and `test/routing-fleet-window-default.test.ts`; the run then timed out.