### PR TITLE
bump: v26.6.6-alpha.1615

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "maw-js",
-  "version": "26.6.6-alpha.1548",
+<<<<<<< HEAD
+  "version": "26.6.6-alpha.1615",
+=======
+  "version": "26.6.6-alpha.1615",
+>>>>>>> e3609b00 (bump: v26.6.6-alpha.1615)
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Closes #1997

Release alpha bump for package.json version to v26.6.6-alpha.1615.

- Bumped version via `bun scripts/calver.ts`
- Prepared version-only release commit for alpha channel
