### PR TITLE
release: v26.6.6-alpha.1652

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,6 @@
 {
   "name": "maw-js",
-<<<<<<< HEAD
-  "version": "26.6.6-alpha.1615",
-=======
-  "version": "26.6.6-alpha.1615",
->>>>>>> e3609b00 (bump: v26.6.6-alpha.1615)
+  "version": "26.6.6-alpha.1652",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts v26.6.6-alpha.1652 on merge via calver-release.yml.\n\nNotes:\n- Branch created from origin/alpha.\n- package.json conflict markers inherited from alpha were resolved before applying CalVer.\n- No force push used.