### PR TITLE
fix(engine): consolidate claude-like detection into shared helper (#2099)

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -13,6 +13,7 @@ import * as wakeSession from "./wake-session";
 import { maybeOpenWindow, maybeSplit } from "./wake-maybe-split";
 import { runWakeLifecycleHooks } from "../../plugin/lifecycle";
 import { ensureFleetSessionEntry } from "./fleet-ensure";
+import { isClaudeLikeEngine } from "../../core/engine/is-claude-like";
 import { parseWakeTarget, ensureCloned } from "./wake-target";
 import { assertAgentCapacity } from "./wake-concurrency";
 import { latestSnapshot, loadSnapshot, type Snapshot, type SnapshotSession } from "../../core/fleet/snapshot";
@@ -450,7 +451,13 @@ async function currentTmuxSessionFromPane(): Promise<string | null> {
 }
 
 function isClaudeEngine(engine: string | undefined): boolean {
-  return engine?.trim().toLowerCase() === "claude";
+  let config: Partial<import("../../config/types").MawConfig> = {};
+  try {
+    config = loadConfig();
+  } catch {
+    // fall back to registry defaults when config is unreadable
+  }
+  return isClaudeLikeEngine(engine, config);
 }
 
 async function sendPromptViaTmux(target: string, prompt: string): Promise<void> {

--- a/src/commands/shared/wake-inbox-drain.ts
+++ b/src/commands/shared/wake-inbox-drain.ts
@@ -1,5 +1,7 @@
 import { existsSync, readdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
+import type { MawConfig } from "../../config/types";
+import { isClaudeLikeEngine } from "../../core/engine/is-claude-like";
 
 export interface WakeInboxMessage {
   path: string;
@@ -25,13 +27,10 @@ export interface WakeInboxDrainDeps {
   markRead?: boolean;
   byteBudget?: number;
   engine?: string;
+  config?: Partial<MawConfig>;
 }
 
 export const DEFAULT_WAKE_INBOX_BYTE_BUDGET = 64 * 1024;
-
-function isClaudeEngine(engine?: string): boolean {
-  return engine?.trim().toLowerCase() === "claude";
-}
 
 function utf8Bytes(value: string): number {
   return Buffer.byteLength(value, "utf-8");
@@ -108,7 +107,7 @@ export function drainWakeInbox(repoPath: string, deps: WakeInboxDrainDeps = {}):
   const markRead = deps.markRead ?? true;
   const byteBudget = Math.max(0, Math.floor(deps.byteBudget ?? DEFAULT_WAKE_INBOX_BYTE_BUDGET));
   const engine = deps.engine;
-  if (engine !== undefined && !isClaudeEngine(engine)) {
+  if (engine !== undefined && !isClaudeLikeEngine(engine, deps.config ?? {})) {
     return { count: 0, prompt: "", messages: [], omittedCount: 0, byteBudget };
   }
 

--- a/src/core/engine/is-claude-like.test.ts
+++ b/src/core/engine/is-claude-like.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "bun:test";
+import { isClaudeLikeEngine } from "./is-claude-like";
+import type { MawConfig } from "../../config/types";
+
+describe("isClaudeLikeEngine", () => {
+  it("returns false for empty / undefined engine", () => {
+    expect(isClaudeLikeEngine(undefined)).toBe(false);
+    expect(isClaudeLikeEngine("")).toBe(false);
+    expect(isClaudeLikeEngine("   ")).toBe(false);
+  });
+
+  it("matches the literal claude name case-insensitively", () => {
+    expect(isClaudeLikeEngine("claude")).toBe(true);
+    expect(isClaudeLikeEngine("Claude")).toBe(true);
+    expect(isClaudeLikeEngine("  CLAUDE  ")).toBe(true);
+  });
+
+  it("treats non-claude built-in engines as not claude-like", () => {
+    expect(isClaudeLikeEngine("codex")).toBe(false);
+    expect(isClaudeLikeEngine("opencode")).toBe(false);
+    expect(isClaudeLikeEngine("aider")).toBe(false);
+  });
+
+  it("resolves a config alias whose command is claude-like", () => {
+    const config: Partial<MawConfig> = {
+      engines: { fast: { name: "fast", cmd: "claude --model opus" } },
+    };
+    expect(isClaudeLikeEngine("fast", config)).toBe(true);
+  });
+
+  it("resolves a legacy commands alias whose command is claude-like", () => {
+    const config: Partial<MawConfig> = {
+      commands: { beta: "claudeBeta --foo" },
+    };
+    expect(isClaudeLikeEngine("beta", config)).toBe(true);
+  });
+
+  it("treats a config alias with a non-claude command as not claude-like", () => {
+    const config: Partial<MawConfig> = {
+      engines: { custom: { name: "custom", cmd: "codex exec" } },
+    };
+    expect(isClaudeLikeEngine("custom", config)).toBe(false);
+  });
+
+  it("matches an engine that declares the system-prompt-file capability", () => {
+    const config: Partial<MawConfig> = {
+      engines: {
+        wrapped: { name: "wrapped", cmd: "my-wrapper", capabilities: ["system-prompt-file"] },
+      },
+    };
+    expect(isClaudeLikeEngine("wrapped", config)).toBe(true);
+  });
+
+  it("does not match a raw command merely named like an unknown engine", () => {
+    expect(isClaudeLikeEngine("mystery")).toBe(false);
+  });
+});

--- a/src/core/engine/is-claude-like.ts
+++ b/src/core/engine/is-claude-like.ts
@@ -1,0 +1,36 @@
+import type { MawConfig } from "../../config/types";
+import { resolveEngine } from "../../config/engine-registry";
+
+/**
+ * Shared claude-like engine detector (#2099).
+ *
+ * Consolidates the duplicated `engine?.toLowerCase() === "claude"` checks that
+ * lived in wake-cmd, wake-inbox-drain, and friends. Those copies only matched
+ * the literal name "claude" and silently misclassified aliases — a config
+ * `engines.fast = { cmd: "claude --model opus" }` or a raw `claudeBeta`
+ * command was treated as non-claude, so claude-only behavior (the `-p` prompt
+ * form, inbox drain) was skipped.
+ *
+ * Resolving the name through the engine registry first means aliases inherit
+ * the detection: an engine counts as claude-like when its launch command looks
+ * claude-like, or it declares the claude-only `system-prompt-file` capability.
+ */
+
+/** Matches a launch command whose executable is claude (or claude-prefixed). */
+const CLAUDE_LIKE_CMD = /(^|\s)(?:command\s+)?claude[A-Za-z0-9_-]*(?:\s|$)/;
+
+/** Capability only claude-like engines declare (the `-p`/system-prompt form). */
+const CLAUDE_LIKE_CAPABILITY = "system-prompt-file";
+
+export function isClaudeLikeEngine(
+  engine: string | undefined,
+  config: Partial<MawConfig> = {},
+): boolean {
+  const name = engine?.trim();
+  if (!name) return false;
+  if (name.toLowerCase() === "claude") return true;
+
+  const def = resolveEngine(name, config);
+  if (CLAUDE_LIKE_CMD.test(def.cmd)) return true;
+  return def.capabilities?.includes(CLAUDE_LIKE_CAPABILITY) ?? false;
+}


### PR DESCRIPTION
## What

Closes #2099

Consolidates the duplicated claude-like engine detectors into one shared helper.

`wake-cmd.ts` and `wake-inbox-drain.ts` each carried a local
`isClaudeEngine()` doing `engine?.toLowerCase() === "claude"`. That only
matched the literal name `claude`, so an **aliased** engine was silently
misclassified as non-claude and skipped claude-only behavior (the `-p`
prompt form in wake, the inbox drain). Examples that broke:

- `engines.fast = { name: "fast", cmd: "claude --model opus" }`
- legacy `commands.beta = "claudeBeta --foo"`

## Change

- **New** `src/core/engine/is-claude-like.ts` — `isClaudeLikeEngine(engine, config)`
  resolves the name through the registry (`resolveEngine`) first, then
  matches on the launch command or the claude-only `system-prompt-file`
  capability. Aliases now inherit detection.
- `wake-cmd.ts` + `wake-inbox-drain.ts` import the shared helper; local
  copies removed. `wake-inbox-drain` gains an optional `config` dep so it
  can resolve aliases too.

## Tests

`src/core/engine/is-claude-like.test.ts` (60 lines) — literal name,
case-insensitivity, non-claude built-ins, config/legacy aliases, capability
match, and the negative cases.

- `bun test src/core/engine/is-claude-like.test.ts` → 8 pass
- `bun test src/commands/shared/` → 512 pass, 0 fail
- `bunx tsc --noEmit` → clean

No `package.json` bump — code-only, per release-separation convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)