### PR TITLE
fix(done): skip retro for codex/aider/opencode instead of sending $rrr (#2099)

### DIFF
--- a/src/vendor/mpr-plugins/done/done-autosave.ts
+++ b/src/vendor/mpr-plugins/done/done-autosave.ts
@@ -11,10 +11,21 @@ type SessionInfo = { name: string; windows: { index: number; name: string; activ
 
 type RetrospectiveCommand = "/rrr" | "$rrr";
 
-const NON_CLAUDE_ENGINES = /\b(omx|codex|aider|opencode|oh-my-codex)\b/i;
+/** Engines that support the `$rrr` retrospective command (oh-my-codex wrapper). */
+const DOLLAR_RRR_ENGINES = /\b(omx|oh-my-codex)\b/i;
+/** Engines with no retrospective command — skip the retro step entirely. */
+const NO_RETRO_ENGINES = /\b(codex|aider|opencode)\b/i;
 
-function inferRetrospectiveCommand(paneCurrentCommand: string): RetrospectiveCommand {
-  return NON_CLAUDE_ENGINES.test(paneCurrentCommand || "") ? "$rrr" : "/rrr";
+/**
+ * Choose the retrospective command for a pane's engine.
+ * Returns `null` to skip the retro entirely (engines that have no equivalent),
+ * `$rrr` for the oh-my-codex wrapper, and `/rrr` for claude (the default).
+ */
+function inferRetrospectiveCommand(paneCurrentCommand: string): RetrospectiveCommand | null {
+  const command = paneCurrentCommand || "";
+  if (DOLLAR_RRR_ENGINES.test(command)) return "$rrr";
+  if (NO_RETRO_ENGINES.test(command)) return null;
+  return "/rrr";
 }
 
 /** Signal parent oracle inbox that a worktree window is done (#81). */
@@ -58,7 +69,11 @@ export async function autoSave(
   const retrospectiveCommand = inferRetrospectiveCommand(paneCurrentCommand);
 
   if (opts.dryRun) {
-    console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would send ${retrospectiveCommand} to ${target} and wait 10s`);
+    if (retrospectiveCommand) {
+      console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would send ${retrospectiveCommand} to ${target} and wait 10s`);
+    } else {
+      console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would skip retro (no retrospective command for this engine)`);
+    }
     if (paneCwd) {
       console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would git add + commit + push in ${paneCwd}`);
     }
@@ -68,14 +83,19 @@ export async function autoSave(
     return;
   }
 
-  // Send a retrospective command aligned with the panel's engine.
-  console.log(`  \x1b[36m⏳\x1b[0m sending ${retrospectiveCommand} to ${target}...`);
-  try {
-    await tmux.sendText(target, retrospectiveCommand);
-    await new Promise(r => setTimeout(r, 10_000));
-    console.log(`  \x1b[32m✓\x1b[0m ${retrospectiveCommand} sent (waited 10s)`);
-  } catch {
-    console.log(`  \x1b[33m⚠\x1b[0m could not send ${retrospectiveCommand} (agent may not be running)`);
+  // Send a retrospective command aligned with the panel's engine; skip when the
+  // engine has no retrospective command (codex/aider/opencode).
+  if (retrospectiveCommand) {
+    console.log(`  \x1b[36m⏳\x1b[0m sending ${retrospectiveCommand} to ${target}...`);
+    try {
+      await tmux.sendText(target, retrospectiveCommand);
+      await new Promise(r => setTimeout(r, 10_000));
+      console.log(`  \x1b[32m✓\x1b[0m ${retrospectiveCommand} sent (waited 10s)`);
+    } catch {
+      console.log(`  \x1b[33m⚠\x1b[0m could not send ${retrospectiveCommand} (agent may not be running)`);
+    }
+  } else {
+    console.log(`  \x1b[90m○\x1b[0m no retrospective command for this engine — skipping retro`);
   }
 
   // Git auto-save in pane's cwd

--- a/test/isolated/done-autosave-engine-retro.test.ts
+++ b/test/isolated/done-autosave-engine-retro.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Engine-aware retrospective selection for done-autosave's autoSave (#2099 follow-up).
+ *
+ * Verifies inferRetrospectiveCommand's three outcomes, observed through autoSave:
+ *   - claude (default)      -> sends "/rrr"
+ *   - omx / oh-my-codex     -> sends "$rrr"
+ *   - codex / aider / opencode -> skips the retro entirely (no tmux send, no 10s wait)
+ *
+ * Mocks are registered before importing the target module (it captures SDK,
+ * reunion, and soul-sync imports at load time).
+ */
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { mock } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "node:os";
+import { join } from "path";
+
+const SANDBOX = mkdtempSync(join(tmpdir(), "maw-done-engine-retro-"));
+
+let hostExecHandler: (command: string) => string | Promise<string> = () => "";
+let sentTexts: Array<{ target: string; text: string }> = [];
+
+mock.module("os", () => ({ homedir: () => join(SANDBOX, "home") }));
+
+mock.module("maw-js/sdk", () => ({
+  hostExec: async (command: string) => await hostExecHandler(command),
+  tmux: {
+    sendText: async (target: string, text: string) => {
+      sentTexts.push({ target, text });
+    },
+  },
+}));
+
+mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/done/internal/reunion-impl"), () => ({
+  cmdReunion: async () => {},
+}));
+
+mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/done/internal/soul-sync-impl"), () => ({
+  cmdSoulSync: async () => [],
+}));
+
+const { autoSave } = await import("../../src/vendor/mpr-plugins/done/done-autosave.ts?engine-retro");
+
+beforeEach(() => {
+  sentTexts = [];
+});
+
+afterAll(() => {
+  rmSync(SANDBOX, { recursive: true, force: true });
+});
+
+function paneRunning(engine: string): void {
+  hostExecHandler = (command) =>
+    command.includes("pane_current_path") ? `${engine}\t/repo/worktree\n` : "";
+}
+
+async function captureConsole(fn: () => Promise<void>): Promise<string> {
+  const originalLog = console.log;
+  const lines: string[] = [];
+  console.log = (...parts: unknown[]) => { lines.push(parts.map(String).join(" ")); };
+  try {
+    await fn();
+  } finally {
+    console.log = originalLog;
+  }
+  return lines.join("\n").replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+async function withImmediateTimers(fn: () => Promise<void>): Promise<number[]> {
+  const original = globalThis.setTimeout;
+  const delays: number[] = [];
+  globalThis.setTimeout = ((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
+    delays.push(timeout ?? 0);
+    if (typeof handler === "function") handler(...args);
+    return 0 as unknown as ReturnType<typeof setTimeout>;
+  }) as typeof setTimeout;
+  try {
+    await fn();
+    return delays;
+  } finally {
+    globalThis.setTimeout = original;
+  }
+}
+
+describe("done autosave engine-aware retro", () => {
+  for (const engine of ["claude", "node"]) {
+    test(`${engine} pane sends /rrr`, async () => {
+      paneRunning(engine);
+      let delays: number[] = [];
+      const output = await captureConsole(async () => {
+        delays = await withImmediateTimers(() => autoSave("tile-1", "work", {}));
+      });
+      expect(sentTexts).toEqual([{ target: "work:tile-1", text: "/rrr" }]);
+      expect(delays).toEqual([10_000]);
+      expect(output).toContain("/rrr sent (waited 10s)");
+    });
+  }
+
+  for (const engine of ["omx", "oh-my-codex"]) {
+    test(`${engine} pane sends $rrr`, async () => {
+      paneRunning(engine);
+      let delays: number[] = [];
+      const output = await captureConsole(async () => {
+        delays = await withImmediateTimers(() => autoSave("tile-1", "work", {}));
+      });
+      expect(sentTexts).toEqual([{ target: "work:tile-1", text: "$rrr" }]);
+      expect(delays).toEqual([10_000]);
+      expect(output).toContain("$rrr sent (waited 10s)");
+    });
+  }
+
+  for (const engine of ["codex", "aider", "opencode"]) {
+    test(`${engine} pane skips the retro entirely`, async () => {
+      paneRunning(engine);
+      let delays: number[] = [];
+      const output = await captureConsole(async () => {
+        delays = await withImmediateTimers(() => autoSave("tile-1", "work", {}));
+      });
+      // No retro command sent and no 10s wait incurred.
+      expect(sentTexts).toEqual([]);
+      expect(delays).toEqual([]);
+      expect(output).toContain("no retrospective command for this engine");
+      // Git auto-save still runs for skipped engines.
+      expect(output).toContain("committed changes");
+    });
+
+    test(`${engine} dry-run announces the skip without sending`, async () => {
+      paneRunning(engine);
+      const output = await captureConsole(() => autoSave("tile-1", "work", { dryRun: true }));
+      expect(sentTexts).toEqual([]);
+      expect(output).toContain("would skip retro");
+      expect(output).not.toContain("would send");
+    });
+  }
+});


### PR DESCRIPTION
## What

Follow-up to #2102 per Design Partner recommendation. Instead of sending `$rrr` to non-claude engines that have no retrospective command, `inferRetrospectiveCommand` now returns `"/rrr" | "$rrr" | null`, where `null` means **skip the retro entirely**.

| Engine | Retro command |
|---|---|
| `claude` (default) | `/rrr` |
| `omx` / `oh-my-codex` | `$rrr` (oh-my-codex wrapper supports it) |
| `codex` / `aider` / `opencode` | _skip_ (no retro command) |

## Why

#2102 widened the non-claude regex so codex/aider/opencode also received `$rrr`. But those engines have no `$rrr` retrospective — sending it was a no-op at best and stray keystrokes at worst, plus an unnecessary 10s wait. The Design Partner's call: skip the retro step for them rather than send a command they don't understand.

## Changes

- `done-autosave.ts`: split engine detection into `DOLLAR_RRR_ENGINES` (omx/oh-my-codex) and `NO_RETRO_ENGINES` (codex/aider/opencode); `inferRetrospectiveCommand` returns `null` to skip.
- `autoSave` guards the tmux send + 10s wait on a non-null command. Git auto-save, reunion, and soul-sync are unaffected. Dry-run announces the skip instead of a phantom send.
- New isolated test `done-autosave-engine-retro.test.ts` (135 lines) covers all three outcomes + the dry-run skip path, one process per file (no mock leakage).

## Test

```
bash scripts/test-isolated.sh test/isolated/done-all.test.ts test/isolated/done-autosave-coverage.test.ts test/isolated/done-autosave-engine-retro.test.ts
=== summary: 3/3 files passed, 0 failed ===
```

> Note: `package.json` on `alpha` currently carries an unresolved git conflict marker (`<<<<<<< HEAD` around the version field). Not touched here — flagging for a separate release/version fix.

Closes #2099 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)