### PR TITLE
fix(test): update comm-send mocks for isClaudeLikeEngine refactor

### DIFF
--- a/test/isolated/comm-send-deep-branches-coverage.test.ts
+++ b/test/isolated/comm-send-deep-branches-coverage.test.ts
@@ -22,7 +22,7 @@ type ReceiverInboxResult =
   | { ok: false; reason: string }
   | null;
 
-let config: any;
+let config: any = { node: "test-node", oracle: "sender", host: "local", port: 3456, namedPeers: [] };
 let listSessionsReturn: any[];
 let listSessionsCalls: number;
 let resolveTargetReturn: ResolvedTarget;
@@ -60,10 +60,10 @@ mock.module(join(srcRoot, "src/core/transport/tmux"), () => {
     async run() { return tmuxPaneList; }
     async tryRun() { return tmuxPaneList; }
   }
-  return { Tmux: MockTmux, tmux: new MockTmux() };
+  return { Tmux: MockTmux, tmux: new MockTmux(), tmuxCmd: () => "tmux", resolveSocket: () => undefined };
 });
 
-mock.module(join(srcRoot, "src/sdk"), () => ({
+mock.module(join(srcRoot, "src/sdk/index.ts"), () => ({
   listSessions: async () => {
     listSessionsCalls += 1;
     return listSessionsReturn;

--- a/test/isolated/comm-send-failure-branches.test.ts
+++ b/test/isolated/comm-send-failure-branches.test.ts
@@ -16,7 +16,7 @@ type ResolvedTarget =
 
 type CurlResult = { ok: boolean; status?: number; data?: any };
 
-let config: any;
+let config: any = { node: "test-node", oracle: "sender", host: "local", port: 3456, namedPeers: [] };
 let listSessionsReturn: any[];
 let resolveTargetReturn: ResolvedTarget;
 let findPeerUrl: string | null;
@@ -35,10 +35,10 @@ mock.module(join(srcRoot, "src/core/transport/tmux"), () => {
     async run() { return "0 claude\n"; }
     async tryRun() { return "0 claude\n"; }
   }
-  return { Tmux: MockTmux, tmux: new MockTmux() };
+  return { Tmux: MockTmux, tmux: new MockTmux(), tmuxCmd: () => "tmux", resolveSocket: () => undefined };
 });
 
-mock.module(join(srcRoot, "src/sdk"), () => ({
+mock.module(join(srcRoot, "src/sdk/index.ts"), () => ({
   listSessions: async () => listSessionsReturn,
   capture: async () => "accepted",
   sendKeys: async () => {},
@@ -166,20 +166,23 @@ afterAll(() => {
 });
 
 describe("cmdSend failure and forgiving branches", () => {
-  test("cross-node auto-wake failure exits before peer send", async () => {
+  test("cross-node auto-wake failure falls through to peer send", async () => {
     config.namedPeers = [{ name: "remote", url: "http://remote:3456" }];
     shouldWake = true;
     resolveTargetReturn = { type: "peer", target: "oracle", node: "remote", peerUrl: "http://remote:3456" };
-    curlFetchHandler = () => ({ ok: false, status: 503, data: { error: "wake offline" } });
+    curlFetchHandler = (url) => url.endsWith("/api/wake")
+      ? { ok: false, status: 503, data: { error: "wake offline" } }
+      : { ok: true, status: 200, data: { ok: true, target: "oracle.0", lastLine: "ack", state: "delivered" } };
 
     await runCmd(() => cmdSend("remote:oracle", "hello", false, { receiverInbox: false }));
 
-    expect(exitCode).toBe(1);
-    expect(curlFetchCalls).toHaveLength(1);
+    expect(exitCode).toBeUndefined();
+    expect(curlFetchCalls).toHaveLength(2);
     expect(curlFetchCalls[0].url).toBe("http://remote:3456/api/wake");
     expect(JSON.parse(curlFetchCalls[0].options.body)).toEqual({ target: "oracle" });
-    expect(errs.join("\n")).toContain("cross-node wake failed for oracle: wake offline");
-    expect(runHookCalls).toEqual([]);
+    expect(curlFetchCalls[1].url).toBe("http://remote:3456/api/send");
+    expect(JSON.parse(curlFetchCalls[1].options.body)).toEqual({ target: "oracle", text: "[test-node:sender] hello" });
+    expect(runHookCalls).toEqual([{ name: "after_send", payload: { to: "remote:oracle", message: "[test-node:sender] hello" } }]);
   });
 
   test("peer send failure emits failed lifecycle and exits with remote hint", async () => {

--- a/test/isolated/comm-send-final-hotspots-coverage.test.ts
+++ b/test/isolated/comm-send-final-hotspots-coverage.test.ts
@@ -30,7 +30,7 @@ type ReceiverInboxResult =
   | { ok: true; oracle: string; inboxDir: string; path: string; filename: string }
   | { ok: false; reason: string };
 
-let config: any;
+let config: any = { node: "test-node", oracle: "sender", host: "local", port: 3456, namedPeers: [] };
 let listSessionsReturn: any[];
 let resolveTargetReturn: ResolvedTarget;
 let findPeerUrl: string | null;
@@ -56,10 +56,10 @@ mock.module(join(srcRoot, "src/core/transport/tmux"), () => {
     async run() { return "0 claude\n"; }
     async tryRun() { return "0 claude\n"; }
   }
-  return { Tmux: MockTmux, tmux: new MockTmux() };
+  return { Tmux: MockTmux, tmux: new MockTmux(), tmuxCmd: () => "tmux", resolveSocket: () => undefined };
 });
 
-mock.module(join(srcRoot, "src/sdk"), () => ({
+mock.module(join(srcRoot, "src/sdk/index.ts"), () => ({
   listSessions: async () => listSessionsReturn,
   capture: async () => captureResponses.shift() ?? "",
   sendKeys: async (target: string, text: string) => {

--- a/test/isolated/comm-send-fourteenth-pass-coverage.test.ts
+++ b/test/isolated/comm-send-fourteenth-pass-coverage.test.ts
@@ -15,7 +15,7 @@ type ResolvedTarget =
   | { type: "error"; detail: string; hint?: string }
   | null;
 
-let config: any;
+let config: any = { node: "test-node", oracle: "sender", host: "local", port: 3456, namedPeers: [] };
 let listSessionsReturn: any[];
 let resolveTargetReturn: ResolvedTarget;
 let captureResponses: string[];
@@ -31,10 +31,10 @@ mock.module(join(srcRoot, "src/core/transport/tmux"), () => {
     async run() { return "0 claude\n"; }
     async tryRun() { return "0 claude\n"; }
   }
-  return { Tmux: MockTmux, tmux: new MockTmux() };
+  return { Tmux: MockTmux, tmux: new MockTmux(), tmuxCmd: () => "tmux", resolveSocket: () => undefined };
 });
 
-mock.module(join(srcRoot, "src/sdk"), () => ({
+mock.module(join(srcRoot, "src/sdk/index.ts"), () => ({
   listSessions: async () => listSessionsReturn,
   capture: async () => captureResponses.shift() ?? "",
   sendKeys: async (target: string, text: string) => {
@@ -159,7 +159,7 @@ describe("comm-send fourteenth-pass uncovered branches", () => {
     await runCmd(() => cmdSend("local:session:oracle", "wait for idle", false, { receiverInbox: false }));
 
     expect(exitCode).toBeUndefined();
-    expect(sleepCalls).toEqual([150]);
+    expect(sleepCalls).toEqual([800, 150]);
     expect(defaultInboxCalls).toEqual([]);
     expect(sendKeysCalls).toEqual([{ target: "session:oracle.0", text: "[test-node:sender] wait for idle" }]);
     expect(runHookCalls).toEqual([{ name: "after_send", payload: { to: "local:session:oracle", message: "[test-node:sender] wait for idle" } }]);

--- a/test/isolated/comm-send-helper-coverage.test.ts
+++ b/test/isolated/comm-send-helper-coverage.test.ts
@@ -30,7 +30,7 @@ type ReceiverInboxResult =
   | { ok: true; oracle: string; inboxDir: string; path: string; filename: string }
   | { ok: false; reason: string };
 
-let config: any;
+let config: any = { node: "test-node", oracle: "sender", host: "local", port: 3456, namedPeers: [] };
 let listSessionsReturn: any[];
 let resolveTargetReturn: ResolvedTarget;
 let findPeerUrl: string | null;
@@ -65,10 +65,10 @@ mock.module(join(srcRoot, "src/core/transport/tmux"), () => {
     async run() { return "0 claude\n"; }
     async tryRun() { return "0 claude\n"; }
   }
-  return { Tmux: MockTmux, tmux: new MockTmux() };
+  return { Tmux: MockTmux, tmux: new MockTmux(), tmuxCmd: () => "tmux", resolveSocket: () => undefined };
 });
 
-mock.module(join(srcRoot, "src/sdk"), () => ({
+mock.module(join(srcRoot, "src/sdk/index.ts"), () => ({
   listSessions: async () => listSessionsReturn,
   capture: async () => {
     const next = captureResponses.shift();

--- a/test/isolated/comm-send-more-coverage.test.ts
+++ b/test/isolated/comm-send-more-coverage.test.ts
@@ -26,7 +26,7 @@ type ReceiverInboxInput = {
   config: any;
 };
 
-let config: any;
+let config: any = { node: "test-node", oracle: "sender", host: "local", port: 3456, namedPeers: [] };
 let listSessionsQueue: any[][];
 let resolveTargetReturn: ResolvedTarget;
 let findPeerUrl: string | null;
@@ -51,10 +51,10 @@ mock.module(join(srcRoot, "src/core/transport/tmux"), () => {
     async run() { return "0 claude\n"; }
     async tryRun() { return "0 claude\n"; }
   }
-  return { Tmux: MockTmux, tmux: new MockTmux() };
+  return { Tmux: MockTmux, tmux: new MockTmux(), tmuxCmd: () => "tmux", resolveSocket: () => undefined };
 });
 
-mock.module(join(srcRoot, "src/sdk"), () => ({
+mock.module(join(srcRoot, "src/sdk/index.ts"), () => ({
   listSessions: async () => listSessionsQueue.length > 1 ? listSessionsQueue.shift()! : listSessionsQueue[0],
   capture: async (target: string, lines: number, host?: string) => {
     captureCalls.push({ target, lines, host });

--- a/test/isolated/comm-send-runtime-coverage.test.ts
+++ b/test/isolated/comm-send-runtime-coverage.test.ts
@@ -52,10 +52,10 @@ mock.module(join(srcRoot, "src/core/transport/tmux"), () => {
     async run() { return "0 claude\n"; }
     async tryRun() { return "0 claude\n"; }
   }
-  return { Tmux: MockTmux, tmux: new MockTmux() };
+  return { Tmux: MockTmux, tmux: new MockTmux(), tmuxCmd: () => "tmux", resolveSocket: () => undefined };
 });
 
-mock.module(join(srcRoot, "src/sdk"), () => ({
+mock.module(join(srcRoot, "src/sdk/index.ts"), () => ({
   listSessions: async () => listSessionsReturn,
   capture: async (target: string, lines: number, host?: string) => {
     captureCalls.push({ target, lines, host });

--- a/test/isolated/comm-send-thirteenth-pass-coverage.test.ts
+++ b/test/isolated/comm-send-thirteenth-pass-coverage.test.ts
@@ -29,7 +29,7 @@ type ReceiverInboxResult =
   | { ok: false; reason: string }
   | null;
 
-let config: any;
+let config: any = { node: "test-node", oracle: "sender", host: "local", port: 3456, namedPeers: [] };
 let listSessionsReturn: any[];
 let resolveTargetReturn: ResolvedTarget;
 let findPeerUrl: string | null;
@@ -58,10 +58,10 @@ mock.module(join(srcRoot, "src/core/transport/tmux"), () => {
     async run() { return tmuxPaneList; }
     async tryRun() { return tmuxPaneList; }
   }
-  return { Tmux: MockTmux, tmux: new MockTmux() };
+  return { Tmux: MockTmux, tmux: new MockTmux(), tmuxCmd: () => "tmux", resolveSocket: () => undefined };
 });
 
-mock.module(join(srcRoot, "src/sdk"), () => ({
+mock.module(join(srcRoot, "src/sdk/index.ts"), () => ({
   listSessions: async () => listSessionsReturn,
   capture: async () => {
     const next = captureResponses.shift();
@@ -350,7 +350,7 @@ describe("comm-send thirteenth-pass cmdSend branches", () => {
     resolveTargetReturn = { type: "self-node", target: "session:oracle" };
     tmuxPaneList = "0 bash\n3 node\n1 codex\n";
     getPaneCommandReturn = "vim";
-    captureResponses = ["final line after send"];
+    captureResponses = ["submitted", "final line after send"];
     defaultInboxResult = { ok: true, oracle: "oracle", inboxDir: "/tmp/inbox", path: "/tmp/inbox/msg.md", filename: "msg.md" };
 
     await runCmd(() => cmdSend("test-node:session:oracle", "forced", true));
@@ -358,7 +358,7 @@ describe("comm-send thirteenth-pass cmdSend branches", () => {
     expect(exitCode).toBeUndefined();
     expect(sendKeysCalls).toEqual([{ target: "session:oracle.1", text: "[test-node:sender] forced" }]);
     expect(defaultInboxCalls[0]).toMatchObject({ target: "session:oracle.1", from: "test-node:sender" });
-    expect(sleepCalls).toEqual([150]);
+    expect(sleepCalls).toEqual([800, 150]);
     expect(logMessageCalls[0]).toMatchObject({ route: "local" });
     expect(logs.join("\n")).toContain("final line after send");
   });


### PR DESCRIPTION
Closes #2107 (partial).

## Summary
- update the eight failing comm-send isolated coverage harnesses to mock the resolved SDK index and full tmux barrel runtime exports
- initialize mocked config before import-time SDK transport setup
- align stale assertions with current alpha submit verification and non-fatal cross-node wake fallback behavior

## Tests
- bun test test/isolated/comm-send-deep-branches-coverage.test.ts test/isolated/comm-send-fourteenth-pass-coverage.test.ts test/isolated/comm-send-runtime-coverage.test.ts test/isolated/comm-send-helper-coverage.test.ts test/isolated/comm-send-thirteenth-pass-coverage.test.ts test/isolated/comm-send-failure-branches.test.ts test/isolated/comm-send-more-coverage.test.ts test/isolated/comm-send-final-hotspots-coverage.test.ts