### PR TITLE
fix(test): update server/coverage/misc mocks for recent refactors

### DIFF
--- a/test/fleet-ensure-entry.test.ts
+++ b/test/fleet-ensure-entry.test.ts
@@ -63,7 +63,7 @@ describe("ensureFleetSessionEntry", () => {
     expect(h.writes.map(([path]) => path)).toEqual(["/legacy/fleet/77-mawjs.json"]);
     expect(JSON.parse(h.files.get("/legacy/fleet/77-mawjs.json")!).windows).toEqual([
       { name: "lead", repo: "github.com/Soul-Brews-Studio/maw-js" },
-      { name: "worker", repo: "github.com/Soul-Brews-Studio/maw-js/agents/1-worker" },
+      { name: "worker", repo: "github.com/Soul-Brews-Studio/maw-js" },
     ]);
   });
 
@@ -74,8 +74,8 @@ describe("ensureFleetSessionEntry", () => {
     expect(h.writes).toEqual([]);
   });
 
-  test("repo derivation works whether ghq root includes github.com or not", () => {
+  test("repo derivation uses the configured ghq root and rejects too-shallow alternate roots", () => {
     expect(_test.repoFromCwd("/ghq/github.com/Soul-Brews-Studio/maw-js", "/ghq")).toBe("github.com/Soul-Brews-Studio/maw-js");
-    expect(_test.repoFromCwd("/ghq/github.com/Soul-Brews-Studio/maw-js", "/ghq/github.com")).toBe("Soul-Brews-Studio/maw-js");
+    expect(_test.repoFromCwd("/ghq/github.com/Soul-Brews-Studio/maw-js", "/ghq/github.com")).toBeNull();
   });
 });

--- a/test/isolated/api-index-plugin-mount-coverage.test.ts
+++ b/test/isolated/api-index-plugin-mount-coverage.test.ts
@@ -82,6 +82,8 @@ const moduleExports: Record<string, unknown> = {
   claudeFleetApi: inertPlugin,
   peerDiscoveriesApi: inertPlugin,
   engineApi: inertPlugin,
+  statusApi: inertPlugin,
+  requestReplyApi: inertPlugin,
 };
 
 const apiModules: Array<[string, string]> = [
@@ -113,6 +115,8 @@ const apiModules: Array<[string, string]> = [
   ["claude-fleet", "claudeFleetApi"],
   ["peers-discoveries", "peerDiscoveriesApi"],
   ["engine", "engineApi"],
+  ["status", "statusApi"],
+  ["request-reply", "requestReplyApi"],
 ];
 
 for (const [moduleName, exportName] of apiModules) {

--- a/test/isolated/bud-scaffold-only.test.ts
+++ b/test/isolated/bud-scaffold-only.test.ts
@@ -68,6 +68,9 @@ mock.module(join(root, "vendor/mpr-plugins/bud/bud-init"), () => ({
     calls.push("initVault");
     return "/tmp/testscaffold-oracle/ψ";
   },
+  generateClaudeSettings: () => {
+    calls.push("generateClaudeSettings");
+  },
   generateClaudeMd: () => {
     calls.push("generateClaudeMd");
   },

--- a/test/isolated/core-server-coverage.test.ts
+++ b/test/isolated/core-server-coverage.test.ts
@@ -73,7 +73,12 @@ mock.module(import.meta.resolve("../../src/config"), () => mockConfigModule(() =
 mock.module(import.meta.resolve("../../src/api"), () => ({
   api: { handle: (req: Request) => { apiCalls.push(new URL(req.url).pathname); return new Response("api"); } },
 }));
-mock.module(import.meta.resolve("../../src/api/feed"), () => ({ feedBuffer, feedListeners }));
+mock.module(import.meta.resolve("../../src/api/feed"), () => ({
+  feedBuffer,
+  feedListeners,
+  pushFeedEvent: (event: unknown) => { feedBuffer.push(event); for (const listener of feedListeners) listener(event); },
+  pushFeedEventWithDeps: (event: unknown) => { feedBuffer.push(event); for (const listener of feedListeners) listener(event); },
+}));
 mock.module(import.meta.resolve("../../src/views/index"), () => ({
   mountViews: (views: Hono) => { views.get("/mounted", c => c.text("mounted view")); },
 }));
@@ -90,11 +95,28 @@ mock.module(import.meta.resolve("../../src/transports"), () => ({
       },
     };
   },
+  getTransportRouter: () => null,
+  resetTransportRouter: () => {},
 }));
-mock.module(import.meta.resolve("../../src/core/transport/ssh"), () => mockSshModule({
-  listSessions: async () => sessions,
+mock.module(import.meta.resolve("../../src/core/transport/ssh"), () => ({
+  ...mockSshModule({ listSessions: async () => sessions }),
+  hostExec: async () => "",
+  HostExecError: class HostExecError extends Error {},
+  capture: async () => "",
+  sendKeys: async () => {},
+  getPaneCommand: async () => "",
+  getPaneCommands: async () => [],
+  getPaneInfos: async () => [],
+  isAgentCommand: () => false,
 }));
 mock.module(import.meta.resolve("../../src/core/transport/tmux"), () => ({
+  tmuxCmd: () => "tmux-test",
+  resolveSocket: () => [],
+  tmux: { run: async () => "", listSessions: async () => [] },
+  withPaneLock: async (fn: () => unknown) => await fn(),
+  splitWindowLocked: async () => undefined,
+  tagPane: async () => undefined,
+  readPaneTags: async () => ({}),
   Tmux: class { async killSession(name: string) { killed.push(name); } },
 }));
 mock.module(import.meta.resolve("../../src/core/transport/pty"), () => ({
@@ -108,6 +130,7 @@ mock.module(import.meta.resolve("../../src/plugin/lifecycle"), () => ({
     lifecycleCalls.push(payload);
     if (lifecycleShouldThrow) throw new Error("lifecycle boom");
   },
+  runWakeLifecycleHooks: async () => {},
 }));
 mock.module(import.meta.resolve("../../src/core/engine-plugin-registry"), () => ({
   dispatchEnginePluginEvent: async (event: unknown) => {

--- a/test/isolated/core-server-more-coverage-2.test.ts
+++ b/test/isolated/core-server-more-coverage-2.test.ts
@@ -50,7 +50,12 @@ mock.module(import.meta.resolve("../../src/config"), () => mockConfigModule(() =
 mock.module(import.meta.resolve("../../src/api"), () => ({
   api: { handle: () => new Response("api") },
 }));
-mock.module(import.meta.resolve("../../src/api/feed"), () => ({ feedBuffer, feedListeners }));
+mock.module(import.meta.resolve("../../src/api/feed"), () => ({
+  feedBuffer,
+  feedListeners,
+  pushFeedEvent: (event: unknown) => { feedBuffer.push(event); for (const listener of feedListeners) listener(event); },
+  pushFeedEventWithDeps: (event: unknown) => { feedBuffer.push(event); for (const listener of feedListeners) listener(event); },
+}));
 mock.module(import.meta.resolve("../../src/views/index"), () => ({
   mountViews: (views: Hono) => { views.get("/boom", () => { throw new Error("view exploded"); }); },
 }));
@@ -61,14 +66,31 @@ mock.module(import.meta.resolve("../../src/transports"), () => ({
   createTransportRouter: () => ({
     connectAll: () => connectShouldReject ? Promise.reject(new Error("connect rejected")) : Promise.resolve(),
   }),
+  getTransportRouter: () => null,
+  resetTransportRouter: () => {},
 }));
 mock.module(import.meta.resolve("../../src/core/transport/ssh"), () => ({
+  hostExec: async () => "",
+  HostExecError: class HostExecError extends Error {},
+  capture: async () => "",
+  sendKeys: async () => {},
+  getPaneCommands: async () => [],
+  getPaneInfos: async () => [],
+  getPaneCommand: async () => "",
+  isAgentCommand: () => false,
   listSessions: async () => {
     if (sessionsShouldThrow) throw new Error("tmux unavailable");
     return [];
   },
 }));
 mock.module(import.meta.resolve("../../src/core/transport/tmux"), () => ({
+  tmuxCmd: () => "tmux-test",
+  resolveSocket: () => [],
+  tmux: { run: async () => "", listSessions: async () => [] },
+  withPaneLock: async (fn: () => unknown) => await fn(),
+  splitWindowLocked: async () => undefined,
+  tagPane: async () => undefined,
+  readPaneTags: async () => ({}),
   Tmux: class { async killSession(_name: string) {} },
 }));
 mock.module(import.meta.resolve("../../src/core/transport/pty"), () => ({
@@ -81,6 +103,7 @@ mock.module(import.meta.resolve("../../src/plugin/lifecycle"), () => ({
   runServeLifecycleHooks: async () => {
     if (lifecycleShouldThrow) throw new Error("lifecycle failed");
   },
+  runWakeLifecycleHooks: async () => {},
 }));
 mock.module(import.meta.resolve("../../src/core/engine-plugin-registry"), () => ({
   dispatchEnginePluginEvent: async () => { throw new Error("dispatch rejected"); },

--- a/test/isolated/coverage-100b-vendor-a-branches.test.ts
+++ b/test/isolated/coverage-100b-vendor-a-branches.test.ts
@@ -130,6 +130,7 @@ mock.module(join(budRoot, "smart-default-org"), () => ({
 mock.module(join(budRoot, "bud-repo"), () => ({ ensureBudRepo: async (_slug: string, predicted: string) => predicted }));
 mock.module(join(budRoot, "bud-init"), () => ({
   initVault: (repoPath: string) => { const psi = join(repoPath, "ψ"); mkdirSync(psi, { recursive: true }); return psi; },
+  generateClaudeSettings: (...args: unknown[]) => { hostExecCalls?.push?.(`generateClaudeSettings:${JSON.stringify(args)}`); },
   generateClaudeMd: (...args: unknown[]) => { hostExecCalls.push(`generateClaudeMd:${JSON.stringify(args)}`); },
   configureFleet: (name: string) => join(tmpRoot, `${name}.json`),
   writeBirthNote: (...args: unknown[]) => { hostExecCalls.push(`writeBirthNote:${JSON.stringify(args)}`); },

--- a/test/isolated/coverage-core-shared-server.test.ts
+++ b/test/isolated/coverage-core-shared-server.test.ts
@@ -34,16 +34,40 @@ mock.module(import.meta.resolve("../../src/config"), () => mockConfigModule(() =
 mock.module(import.meta.resolve("../../src/api"), () => ({
   api: { handle: (req: Request) => { apiPaths.push(new URL(req.url).pathname); return new Response("api"); } },
 }));
-mock.module(import.meta.resolve("../../src/api/feed"), () => ({ feedBuffer: [], feedListeners: new Set() }));
+mock.module(import.meta.resolve("../../src/api/feed"), () => ({
+  feedBuffer: [],
+  feedListeners: new Set(),
+  pushFeedEvent: () => {},
+  pushFeedEventWithDeps: () => {},
+}));
 mock.module(import.meta.resolve("../../src/views/index"), () => ({
   mountViews: (views: Hono) => { views.get("/throws", () => { throw new Error("view failed"); }); },
 }));
 mock.module(import.meta.resolve("../../src/core/runtime/trigger-listener"), () => ({ setupTriggerListener: () => {} }));
 mock.module(import.meta.resolve("../../src/transports"), () => ({
   createTransportRouter: () => ({ connectAll: () => Promise.resolve() }),
+  getTransportRouter: () => null,
+  resetTransportRouter: () => {},
 }));
-mock.module(import.meta.resolve("../../src/core/transport/ssh"), () => ({ listSessions: async () => sessions }));
+mock.module(import.meta.resolve("../../src/core/transport/ssh"), () => ({
+  hostExec: async () => "",
+  capture: async () => "",
+  sendKeys: async () => {},
+  getPaneCommand: async () => "",
+  getPaneCommands: async () => [],
+  getPaneInfos: async () => [],
+  isAgentCommand: () => false,
+  HostExecError: class HostExecError extends Error {},
+  listSessions: async () => sessions,
+}));
 mock.module(import.meta.resolve("../../src/core/transport/tmux"), () => ({
+  tmuxCmd: () => "tmux-test",
+  resolveSocket: () => [],
+  tmux: { run: async () => "", listSessions: async () => [] },
+  withPaneLock: async (fn: () => unknown) => await fn(),
+  splitWindowLocked: async () => undefined,
+  tagPane: async () => undefined,
+  readPaneTags: async () => ({}),
   Tmux: class { async killSession(name: string) { killed.push(name); } },
 }));
 mock.module(import.meta.resolve("../../src/core/transport/pty"), () => ({

--- a/test/isolated/coverage-next-core-instance-server.test.ts
+++ b/test/isolated/coverage-next-core-instance-server.test.ts
@@ -21,15 +21,26 @@ mock.module(import.meta.resolve("../../src/engine"), () => ({
   },
 }));
 mock.module(import.meta.resolve("../../src/api"), () => ({ api: { handle: () => new Response("api") } }));
-mock.module(import.meta.resolve("../../src/api/feed"), () => ({ feedBuffer: [], feedListeners }));
+mock.module(import.meta.resolve("../../src/api/feed"), () => ({
+  feedBuffer: [],
+  feedListeners,
+  pushFeedEvent: (event: unknown) => { feedListeners.forEach(listener => listener(event)); },
+  pushFeedEventWithDeps: (event: unknown) => { feedListeners.forEach(listener => listener(event)); },
+}));
 mock.module(import.meta.resolve("../../src/views/index"), () => ({
   mountViews: (views: any) => { views.get("/mounted-next", (c: any) => c.text("mounted-next")); },
 }));
 mock.module(import.meta.resolve("../../src/core/runtime/trigger-listener"), () => ({ setupTriggerListener: () => {} }));
-mock.module(import.meta.resolve("../../src/transports"), () => ({ createTransportRouter: () => ({ connectAll: () => Promise.resolve() }) }));
+mock.module(import.meta.resolve("../../src/transports"), () => ({
+  createTransportRouter: () => ({ connectAll: () => Promise.resolve() }),
+  getTransportRouter: () => null,
+  resetTransportRouter: () => {},
+}));
 mock.module(import.meta.resolve("../../src/core/transport/ssh"), () => ({
   HostExecError: class HostExecError extends Error {},
   capture: async () => "",
+  getPaneCommands: async () => [],
+  getPaneInfos: async () => [],
   getPaneCommand: async () => "claude",
   hostExec: async () => "",
   isAgentCommand: (cmd: string) => ["claude", "codex", "node"].includes(cmd),
@@ -39,12 +50,17 @@ mock.module(import.meta.resolve("../../src/core/transport/ssh"), () => ({
 }));
 mock.module(import.meta.resolve("../../src/core/transport/tmux"), () => ({
   tmuxCmd: (...args: Array<string | number>) => `tmux ${args.join(" ")}`,
+  resolveSocket: () => [],
+  splitWindowLocked: async () => undefined,
+  tagPane: async () => undefined,
+  readPaneTags: async () => ({}),
   tmux: {
     listSessions: async () => [],
     setEnvironment: async () => {},
     hasSession: async () => true,
     run: async () => "",
   },
+  withPaneLock: async (fn: () => unknown) => await fn(),
   Tmux: class {
     async killSession() {}
     async run() { return ""; }

--- a/test/isolated/coverage-next-vendor-b-core.test.ts
+++ b/test/isolated/coverage-next-vendor-b-core.test.ts
@@ -104,6 +104,7 @@ mock.module(doneWorktreePath, () => ({
   removeWorktreeViaConfig: async () => false,
   removeWorktreeByGhqScan: async () => false,
   removeFromFleetConfig: () => false,
+  warnRemainingWorktrees: async () => [],
 }));
 
 const { postHandshake } = await import("../../src/vendor/mpr-plugins/pair/handshake.ts?coverage-next-vendor-b-core");

--- a/test/isolated/done-worktree-coverage.test.ts
+++ b/test/isolated/done-worktree-coverage.test.ts
@@ -178,7 +178,7 @@ describe("removeWorktreeViaConfig", () => {
     const mainPath = join(REPOS_ROOT, "Soul-Brews-Studio", "maw-js");
     expect(hostExecCalls).toEqual([
       `git -C '${fullPath}' rev-parse --abbrev-ref HEAD`,
-      `git -C '${mainPath}' worktree remove '${fullPath}' --force`,
+      `git -C '${mainPath}' worktree remove '${fullPath}'`,
       `git -C '${mainPath}' worktree prune`,
       `git -C '${mainPath}' merge-base --is-ancestor 'feature/done-cleanup' 'alpha'`,
       `git -C '${mainPath}' branch -d 'feature/done-cleanup'`,
@@ -264,7 +264,7 @@ describe("removeWorktreeByGhqScan", () => {
     expect(hostExecCalls).toEqual([
       `find '${REPOS_ROOT}' -maxdepth 4 -type d \\( -name '*.wt-*' -o -path '*/agents/*' \\) 2>/dev/null`,
       `git -C '${exact}' rev-parse --abbrev-ref HEAD`,
-      `git -C '${mainPath}' worktree remove '${exact}' --force`,
+      `git -C '${mainPath}' worktree remove '${exact}'`,
       `git -C '${mainPath}' worktree prune`,
       `git -C '${mainPath}' merge-base --is-ancestor 'feature/done' 'main'`,
       "gh pr list --head 'feature/done' --state merged --json number --limit 1",
@@ -311,7 +311,7 @@ describe("removeWorktreeByGhqScan", () => {
     });
 
     expect(output).toContain("scoped ambiguous worktree 'trio-coder'");
-    expect(hostExecCalls).toContain(`git -C '${join(REPOS_ROOT, "github.com", "Soul-Brews-Studio", "mawjs-oracle")}' worktree remove '${two}' --force`);
+    expect(hostExecCalls).toContain(`git -C '${join(REPOS_ROOT, "github.com", "Soul-Brews-Studio", "mawjs-oracle")}' worktree remove '${two}'`);
     expect(hostExecCalls.join("\n")).not.toContain("ccc-oracle.wt-trio-coder' --force");
 
     hostExecCalls = [];

--- a/test/isolated/hey-cross-node-auto-wake.test.ts
+++ b/test/isolated/hey-cross-node-auto-wake.test.ts
@@ -184,21 +184,19 @@ describe("cmdSend — cross-node auto-wake (#791)", () => {
     expect(wakeCalls.length).toBe(0);
   });
 
-  test("wake error surfaces and exits — does NOT proceed to /api/send", async () => {
+  test("wake error warns and falls back to direct /api/send", async () => {
     mockNamedPeers = [{ name: "phaith", url: "http://phaith:3456" }];
     curlFetchHandler = (url: string) => {
       if (url.includes("/api/wake")) return { ok: false, status: 503, data: { error: "peer unreachable" } };
-      // /api/send mock would succeed, but should not be reached
       if (url.includes("/api/send")) return { ok: true, status: 200, data: { ok: true } };
       return { ok: false, status: 500, data: {} };
     };
 
     await run(() => cmdSend("phaith:hojo", "ping"));
 
-    expect(exitCode).toBe(1);
+    expect(exitCode).toBeUndefined();
     const sendCalls = curlFetchCalls.filter(c => c.url.includes("/api/send"));
-    expect(sendCalls.length).toBe(0);
-    const allErr = errs.join("\n");
-    expect(allErr).toMatch(/cross-node wake failed/);
+    expect(sendCalls.length).toBe(1);
+    expect(curlFetchCalls.map(c => c.url).join("\n")).toContain("/api/wake");
   });
 });

--- a/test/isolated/team-vendor-handler-coverage.test.ts
+++ b/test/isolated/team-vendor-handler-coverage.test.ts
@@ -172,6 +172,7 @@ describe("vendor team handler coverage slice", () => {
       engine: "codex",
       dryRun: true,
       split: true,
+      gather: false,
     }]]);
   });
 

--- a/test/isolated/team-workspace-next-coverage.test.ts
+++ b/test/isolated/team-workspace-next-coverage.test.ts
@@ -19,6 +19,14 @@ const originalTmux = process.env.TMUX;
 const originalWarn = console.warn;
 
 mock.module("maw-js/sdk", () => ({
+  hostExec: async () => "",
+  curlFetch: async () => ({ ok: false, status: 503, data: {} }),
+  isAgentCommand: () => true,
+  getPaneInfos: async () => [],
+  getPaneCommands: async () => [],
+  getPaneCommand: async () => "claude",
+  listSessions: async () => [],
+  tmuxCmd: () => "tmux-test",
   tmux: {
     hasSession: async (name: string) => sessionExists.has(name),
     run: async () => {
@@ -49,6 +57,13 @@ mock.module("maw-js/commands/shared/context-limit", () => ({
 
 mock.module("../../src/vendor/mpr-plugins/team/oracle-members", () => ({
   loadOracleRegistry: () => registry,
+}));
+
+mock.module("../../src/vendor/mpr-plugins/team/team-liveness", () => ({
+  listPaneSnapshots: async () => [],
+}));
+mock.module("../../src/vendor/mpr-plugins/team/team-liveness.ts", () => ({
+  listPaneSnapshots: async () => [],
 }));
 
 const {

--- a/test/isolated/vendor-bud-init-broadcast-rename-extra-coverage.test.ts
+++ b/test/isolated/vendor-bud-init-broadcast-rename-extra-coverage.test.ts
@@ -117,6 +117,7 @@ mock.module(join(srcRoot, "vendor/mpr-plugins/bud/bud-init"), () => ({
     initVaultCalls.push(repoPath);
     return initVaultResult;
   },
+  generateClaudeSettings: (...args: unknown[]) => { hostExecCalls?.push?.(`generateClaudeSettings:${JSON.stringify(args)}`); },
   generateClaudeMd: (...args: any[]) => {
     generateClaudeMdCalls.push(args);
   },

--- a/test/isolated/vendor-owned-wrapper-stderr-coverage.test.ts
+++ b/test/isolated/vendor-owned-wrapper-stderr-coverage.test.ts
@@ -14,7 +14,10 @@ function mockBoth(spec: string, factory: () => Record<string, unknown>) {
   mock.module(import.meta.resolve(`${spec}.ts`), factory);
 }
 
-mockBoth("../../src/vendor/mpr-plugins/broadcast/impl", () => ({ cmdBroadcast: async (m: string) => emit("broadcast", m) }));
+mockBoth("../../src/vendor/mpr-plugins/broadcast/impl", () => ({
+  parseBroadcastArgs: (args: string[]) => ({ message: args.join(" "), scope: {} }),
+  cmdBroadcast: async (m: string) => emit("broadcast", m),
+}));
 mockBoth("../../src/vendor/mpr-plugins/completions/impl", () => ({ cmdCompletions: async (s?: string) => emit("completions", s ?? "") }));
 mockBoth("../../src/vendor/mpr-plugins/find/impl", () => ({ cmdFind: async (q: string, o: unknown) => emit("find", q, JSON.stringify(o)) }));
 mockBoth("../../src/vendor/mpr-plugins/locate/impl", () => ({ cmdLocate: async (o: string, opts: unknown) => emit("locate", o, JSON.stringify(opts)) }));

--- a/test/isolated/vendor-small-indexes-extra-coverage.test.ts
+++ b/test/isolated/vendor-small-indexes-extra-coverage.test.ts
@@ -68,6 +68,11 @@ mock.module(checkImplPath, () => ({
 }));
 
 mock.module(broadcastImplPath, () => ({
+  parseBroadcastArgs: (args: string[]) => {
+    const message = args.join(" ").trim();
+    if (!message) throw new Error("usage: maw broadcast <message> [--session <name>] [--team <name>] [--fleet <name>]");
+    return { message, scope: {} };
+  },
   cmdBroadcast: async (message: string) => {
     calls.broadcast.push(message);
     console.log(`broadcast:${message || "<empty>"}`);
@@ -162,7 +167,11 @@ describe("extra isolated coverage for small vendor command indexes", () => {
       output: undefined,
     });
     await expect(checkPlugin.default(ctx("api", { sub: "ignored" }))).resolves.toMatchObject({ ok: true });
-    await expect(broadcastPlugin.default(ctx("api", { message: "ignored" }))).resolves.toMatchObject({ ok: true });
+    await expect(broadcastPlugin.default(ctx("api", { message: "ignored" }))).resolves.toEqual({
+      ok: false,
+      error: "usage: maw broadcast <message> [--session <name>] [--team <name>] [--fleet <name>]",
+      output: undefined,
+    });
     await expect(completionsPlugin.default(ctx("api", { shell: "fish" }))).resolves.toMatchObject({ ok: true });
     await expect(overviewPlugin.default(ctx("api", { args: ["ignored"] }))).resolves.toMatchObject({ ok: true });
 
@@ -170,7 +179,7 @@ describe("extra isolated coverage for small vendor command indexes", () => {
       talkTo: [],
       find: [],
       check: [{ sub: "tools", args: [] }],
-      broadcast: [""],
+      broadcast: [],
       completions: [undefined],
       overview: [[]],
     });

--- a/test/isolated/wake-cmd-branch-coverage.test.ts
+++ b/test/isolated/wake-cmd-branch-coverage.test.ts
@@ -359,10 +359,11 @@ describe("wake-cmd isolated executable branch coverage", () => {
 
     expect(result).toBe("54-mawjs:mawjs-oracle");
     expect(selectWindowCalls).toEqual(["54-mawjs:mawjs-oracle"]);
-    expect(sendTextCalls).toHaveLength(1);
+    expect(sendTextCalls).toHaveLength(2);
     expect(sendTextCalls[0]!.target).toBe("54-mawjs:mawjs-oracle");
-    expect(sendTextCalls[0]!.text).toContain(`cd ${repoPath} && codex --agent mawjs-oracle -p `);
-    expect(sendTextCalls[0]!.text).toMatch(/say .*hi/);
+    expect(sendTextCalls[0]!.text).toContain(`cd ${repoPath}`);
+    expect(sendTextCalls[1]!.target).toBe("54-mawjs:mawjs-oracle");
+    expect(sendTextCalls[1]!.text).toMatch(/say .*hi/);
     expect(attachCalls).toEqual(["54-mawjs"]);
     expect(splitCalls).toEqual(["54-mawjs:mawjs-oracle"]);
     expect(openWindowCalls).toEqual(["54-mawjs:mawjs-oracle"]);


### PR DESCRIPTION
Closes #2107 (partial).

## Summary
- refresh isolated server/API/vendor mocks for current SDK and server exports
- update stale expectations for worktree cleanup, cross-node wake fallback, team bring gather defaults, broadcast validation, wake prompt sends, and fleet repo derivation

## Tests
- MAW_TEST_MODE=1 bun test each requested isolated test file
- MAW_TEST_MODE=1 bun test test/fleet-ensure-entry.test.ts src/commands/shared/fleet-ensure.test.ts