### PR TITLE
fix(test): add missing tmuxCmd mock export in focused-gaps

### DIFF
--- a/test/comm-send-focused-gaps.test.ts
+++ b/test/comm-send-focused-gaps.test.ts
@@ -45,7 +45,7 @@ mock.module(join(srcRoot, "src/core/transport/tmux"), () => {
     async run() { return "0 claude\n"; }
     async tryRun() { return "0 claude\n"; }
   }
-  return { Tmux: MockTmux, tmux: new MockTmux() };
+  return { Tmux: MockTmux, tmux: new MockTmux(), tmuxCmd: () => "tmux", resolveSocket: () => undefined };
 });
 
 mock.module(join(srcRoot, "src/sdk"), () => ({


### PR DESCRIPTION
## Summary
transport/tmux re-exports `tmuxCmd` and `resolveSocket` from tmux-types. Mock must provide them or bun throws SyntaxError on import resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)