### PR TITLE
fix(test): initialize config before module-level ssh init

### DIFF
--- a/test/comm-send-focused-gaps.test.ts
+++ b/test/comm-send-focused-gaps.test.ts
@@ -17,7 +17,7 @@ type ResolvedTarget =
   | { type: "error"; detail: string; hint?: string }
   | null;
 
-let config: any;
+let config: any = { node: "test-node", oracle: "sender", host: "local", port: 3456, namedPeers: [] };
 let listSessionsReturn: any[];
 let listSessionsCalls: number;
 let resolveTargetReturn: ResolvedTarget;


### PR DESCRIPTION
## Summary
ssh.ts calls `createSshTransport()` at module-init time, reading `loadConfig().host`. Mock returns the `config` variable which was `undefined` before `beforeEach()`. Give it a default value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)