### PR TITLE
docs: update READMEs for Jun 2026 state

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -16,7 +16,7 @@ Soft-warning hooks for the size discipline documented in [CONTRIBUTING.md](../CO
 Claude Code auto-loads `.claude/settings.json` when invoked in this repo and runs the registered hooks at the lifecycle points:
 
 - **PostToolUse on Write/Edit**: each file write triggers a line-count check on the touched file; emits an `additionalContext` JSON line if > 200 LOC. The notification surfaces back to the agent's next turn.
-- **Stop**: at the end of each AI turn, sums production-code additions vs `origin/main`; warns to stderr if > 300 LOC.
+- **Stop**: at the end of each AI turn, sums production-code additions vs `origin/alpha`; warns to stderr if > 300 LOC.
 
 Both are **soft warnings — non-blocking** (exit 0 always). They surface drift early but never prevent shipping.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # maw
 
-[![CI](https://github.com/Soul-Brews-Studio/maw-js/actions/workflows/ci.yml/badge.svg?branch=alpha)](https://github.com/Soul-Brews-Studio/maw-js/actions/workflows/ci.yml?query=branch%3Aalpha) [![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnazt%2Fb00c729c7f40d4804f82011167bfd9d8%2Fraw%2Fmaw-js-coverage.json&cacheSeconds=300)](docs/testing/coverage-gap-analysis.md) [![License](https://img.shields.io/badge/license-BUSL--1.1-blue)](./LICENSE) [![CalVer](https://img.shields.io/github/v/release/Soul-Brews-Studio/maw-js?include_prereleases&label=calver)](https://github.com/Soul-Brews-Studio/maw-js/releases) [![Bun](https://img.shields.io/badge/runtime-Bun%201.3%2B-f9f1e1)](https://bun.sh) [![Test files](https://img.shields.io/badge/test_files-750%2B-brightgreen)](./test)
+[![CI](https://github.com/Soul-Brews-Studio/maw-js/actions/workflows/ci.yml/badge.svg?branch=alpha)](https://github.com/Soul-Brews-Studio/maw-js/actions/workflows/ci.yml?query=branch%3Aalpha) [![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnazt%2Fb00c729c7f40d4804f82011167bfd9d8%2Fraw%2Fmaw-js-coverage.json&cacheSeconds=300)](docs/testing/coverage-gap-analysis.md) [![License](https://img.shields.io/badge/license-BUSL--1.1-blue)](./LICENSE) [![CalVer](https://img.shields.io/github/v/release/Soul-Brews-Studio/maw-js?include_prereleases&label=calver)](https://github.com/Soul-Brews-Studio/maw-js/releases) [![Bun](https://img.shields.io/badge/runtime-Bun%201.3%2B-f9f1e1)](https://bun.sh) [![Test files](https://img.shields.io/badge/test_files-800%2B-brightgreen)](./test)
 
 > Multi-Agent Workflow — wake agents, talk across machines, see the mesh.
 
@@ -202,16 +202,25 @@ promoting every experiment into core.
 
 ## Team Workspaces
 
-Use `maw new` to create a shared tmux workspace, then bring a team of
-oracles into it. This is the dynamic version of a static MAWK profile:
-one lead shell plus one window per specialist.
+Charter-driven multi-agent teams with worktree isolation:
 
 ```bash
+# Charter-based (recommended)
+maw team up my-team --dry-run       # preview spawn plan
+maw team up my-team                 # spawn from .maw/teams/my-team.yaml
+maw team down my-team               # graceful shutdown
+maw team reassign codex-1 "#999"    # kill + fresh wake + re-dispatch
+
+# Ad-hoc
 maw new project-room --no-attach
 maw team create project-room
 maw team oracle-invite mawjs-issuer --team project-room
 maw team bring project-room
 ```
+
+Charter YAML declares members, engines, worktrees, and prompts. Workers
+get isolated git worktrees; prompts are delivered via `send-keys` (works
+with any engine — Claude Code, Codex, Aider, OpenCode).
 
 ## Wake Lifecycle
 
@@ -246,8 +255,8 @@ maw-js (backend + CLI)              maw-ui (frontend)
 ├── src/api/       (engine + plugin APIs)   ├── src/hooks/
 ├── src/engine/    (WebSocket + serve proxy)├── src/lib/
 ├── src/transports/ (HTTP/tmux/hub)         └── 16 HTML entry points
-├── plugins        (89 installed plugin surfaces)
-├── test/          (750+ test files)
+├── plugins        (89 vendor plugin surfaces)
+├── test/          (800+ test files)
 └── install.sh
 ```
 
@@ -261,8 +270,12 @@ Apr 2026   v2.0.0-alpha.66        Plugin OS foundation, Bun runtime,
                                    federation API + maw-ui split
 May 2026   v26.5.20-alpha.2203    Plugin engine, lifecycle hooks,
                                    team workspaces, 89 plugins,
-                                   750+ test files, near-100% coverage,
+                                   800+ test files, near-100% coverage,
                                    portable Rust spec fixtures
+Jun 2026   v26.6.6-alpha.1830     Charter-driven teams, engine-aware
+                                   wake/done, cross-node federation,
+                                   lean-core extraction (RFC #2113),
+                                   shared isClaudeLikeEngine helper
 ```
 
 ## Federation testing

--- a/src/vendor/mpr-plugins/README.md
+++ b/src/vendor/mpr-plugins/README.md
@@ -1,8 +1,26 @@
 # Vendored maw-plugin-registry plugins
 
-Runtime copies of maw-plugin-registry plugins used to bootstrap fresh maw-js
-installs without a first-run network fetch. Tests are intentionally excluded;
-source of truth remains Soul-Brews-Studio/maw-plugin-registry.
+89 runtime copies of maw-plugin-registry plugins bundled with maw-js.
+Bootstraps fresh installs without a first-run network fetch.
 
-Update by copying plugin runtime files from `maw-plugin-registry/plugins/*`
+Tests are intentionally excluded; source of truth remains
+Soul-Brews-Studio/maw-plugin-registry.
+
+## Extraction status
+
+Per RFC #2113, 73 of these 89 plugins are mapped for extraction:
+
+| Tier | Count | Status |
+|------|-------|--------|
+| Easy | 23 | Minimal core deps, ready to extract |
+| Medium | 27 | Need SDK 1.0 exports |
+| Hard | 13 | Need fleet/lifecycle refactoring |
+| True core | ~10 | Stay bundled |
+
+See [#2113](https://github.com/Soul-Brews-Studio/maw-js/issues/2113)
+for the full extraction map.
+
+## Updating
+
+Copy plugin runtime files from `maw-plugin-registry/plugins/*`
 while excluding `*.test.ts`.

--- a/test/README.md
+++ b/test/README.md
@@ -1,9 +1,12 @@
 # test/
 
+800+ test files covering 89 vendor plugins, core transport, federation,
+fleet management, and CLI commands.
+
 ## Canonical suite
 
-Use `bun run test:all`. This is the ship gate — the alpha release script
-(`scripts/ship-alpha.sh`) refuses to tag if it fails.
+Use `bun run test:all`. This is the ship gate — CI runs it on every PR
+to `alpha` via 4-shard parallelism.
 
 `test:all` runs four disjoint invocations so mocks don't cross-pollute:
 


### PR DESCRIPTION
## Summary
- Root README: 800+ test badge, charter-driven team section, Jun 2026 evolution
- Vendor plugins README: extraction status table (RFC #2113)
- Test README: 800+ count, CI shard mention
- .claude README: alpha is now default branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)