### PR TITLE
fix(test): move view-grouped-session to isolated/ — tmux mock leak

### DIFF
--- a/test/isolated/view-grouped-session.test.ts
+++ b/test/isolated/view-grouped-session.test.ts
@@ -21,7 +21,7 @@
  * that guarded flow.
  */
 import { describe, test, expect } from "bun:test";
-import { Tmux } from "../src/core/transport/tmux-class";
+import { Tmux } from "../../src/core/transport/tmux-class";
 
 type Call = { subcommand: string; args: (string | number)[] };
 type OptCall = { target: string; option: string; value: string };


### PR DESCRIPTION
## Summary
Default suite files that `mock.module(tmux)` pollute the shared Bun process, causing `CapturingTmux.run()` to never fire in `view-grouped-session.test.ts`. Moving to `test/isolated/` gives it its own process.

Fixes CalVer Release 8-test failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)