### PR TITLE
release: v26.6.6-alpha.1849

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.6.6-alpha.1846",
+  "version": "26.6.6-alpha.1849",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts v26.6.6-alpha.1849. Includes mock-leak fixes (#2124, #2126).