### PR TITLE
fix(test): fix import paths in focused-gaps after isolated/ move

### DIFF
--- a/test/isolated/comm-send-focused-gaps.test.ts
+++ b/test/isolated/comm-send-focused-gaps.test.ts
@@ -9,7 +9,7 @@
 import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { join } from "path";
 
-const srcRoot = join(import.meta.dir, "..");
+const srcRoot = join(import.meta.dir, "../..");
 
 type ResolvedTarget =
   | { type: "local" | "self-node"; target: string }
@@ -142,7 +142,7 @@ const origAgentName = process.env.CLAUDE_AGENT_NAME;
   sleepCalls.push(ms);
 };
 
-const { cmdSend, resolveTeamWorkspaceMemberTarget } = await import("../src/commands/shared/comm-send");
+const { cmdSend, resolveTeamWorkspaceMemberTarget } = await import("../../src/commands/shared/comm-send");
 
 let exitCode: number | undefined;
 let errs: string[];


### PR DESCRIPTION
## Summary
`srcRoot` and dynamic import needed `../../` not `../` from `test/isolated/` depth. Fixes CalVer Release failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)