### PR TITLE
release: v26.6.6-alpha.1854

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.6.6-alpha.1849",
+  "version": "26.6.6-alpha.1854",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts v26.6.6-alpha.1854. Includes import path fix (#2128).