### PR TITLE
fix(wake): remove -p flag — send prompt via send-keys instead

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -469,20 +469,11 @@ async function sendPromptViaTmux(target: string, prompt: string): Promise<void> 
   await tmux.sendText(target, prompt);
 }
 
-async function sendWakeCommandAndPrompt(target: string, prompt: string | undefined, command: string, engine?: string): Promise<void> {
-  if (!prompt) {
-    await tmux.sendText(target, command);
-    return;
-  }
-
-  if (isClaudeEngine(engine)) {
-    const escaped = prompt.replace(/'/g, "'\\''");
-    await tmux.sendText(target, `${command} -p '${escaped}'`);
-    return;
-  }
-
+async function sendWakeCommandAndPrompt(target: string, prompt: string | undefined, command: string, _engine?: string): Promise<void> {
   await tmux.sendText(target, command);
-  await sendPromptViaTmux(target, prompt);
+  if (prompt) {
+    await sendPromptViaTmux(target, prompt);
+  }
 }
 
 async function findLiveWindowsByName(windowName: string): Promise<LiveWindowMatch[]> {


### PR DESCRIPTION
## Summary
Remove `-p` flag path from `sendWakeCommandAndPrompt()`. All engines now use two-step: send command → send prompt separately via `sendPromptViaTmux()`.

Fixes #2130 — 64KB inbox prompt inlined into single tmux arg exceeded OS limits.

## Test plan
- [ ] `maw wake` with inbox messages doesn't crash
- [ ] Prompt still delivered to Claude Code after boot
- [ ] Non-claude engines unaffected (already used this path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)