### PR TITLE
fix(new): make split directions use window edges

### DIFF
--- a/src/cli/cmd-new.ts
+++ b/src/cli/cmd-new.ts
@@ -84,9 +84,9 @@ function printUsage(write: (line: string) => void = console.log): void {
   write("  --cmd, -c    Run <cmd> after the shell starts; keep the shell open afterward.");
   write("  --shell      Explicit shell mode (default today; accepted for future symmetry).");
   write("  --claude     Shortcut for Claude Code with maw team env enabled.");
-  write("  --split      Open as a split in the current tmux window instead of a new session.");
-  write("  --right, --horizontal  With --split, create the pane to the right (tmux -h).");
-  write("  --bottom, --vertical   With --split, create the pane below (tmux -v; default).");
+  write("  --split      Open as a full-window split in the current tmux window instead of a new session.");
+  write("  --right, --horizontal  With --split, create a full-height pane at the right edge (tmux -f -h).");
+  write("  --bottom, --vertical   With --split, create a full-width pane at the bottom edge (tmux -f -v; default).");
   write("  --print      Print a JSON payload with session/window/pane_id for scripts.");
   write("  --json       Alias for --print.");
   write("  --dry-run    Show what WOULD happen without creating any tmux state. (#1913)");
@@ -344,7 +344,8 @@ export async function cmdNew(argv: string[]): Promise<void> {
     if (!dryRun) {
       const rawPaneId = await tmux.splitWindow(undefined, {
         cwd,
-        ...(splitDirection ? { direction: splitDirection } : {}),
+        direction: splitDirection ?? "vertical",
+        fullWindow: true,
         ...(tmuxCommand ? { command: tmuxCommand } : {}),
         printFormat: "#{pane_id}",
       });
@@ -365,7 +366,8 @@ export async function cmdNew(argv: string[]): Promise<void> {
     } else {
       const mode = startupCommand ? "split shell + command" : "split shell";
       const verb = dryRun ? `\x1b[36m·\x1b[0m [dry-run] would create` : `\x1b[32m✓\x1b[0m created`;
-      console.log(`${verb} ${mode} '${name}' in ${session}:${window}`);
+      const edge = (splitDirection ?? "vertical") === "horizontal" ? "right edge" : "bottom edge";
+      console.log(`${verb} ${mode} '${name}' at ${edge} in ${session}:${window}`);
     }
     if (dryRun && !machineReadable) {
       console.log(`  \x1b[90mno tmux state changed (dry-run). Drop --dry-run to actually create.\x1b[0m`);

--- a/src/core/transport/tmux-class.ts
+++ b/src/core/transport/tmux-class.ts
@@ -354,9 +354,11 @@ export class Tmux {
     command?: string;
     printFormat?: string;
     direction?: "horizontal" | "vertical";
+    fullWindow?: boolean;
   } = {}): Promise<string> {
     const args: (string | number)[] = [];
     if (opts.printFormat) args.push("-P", "-F", opts.printFormat);
+    if (opts.fullWindow) args.push("-f");
     if (opts.direction === "horizontal") args.push("-h");
     if (opts.direction === "vertical") args.push("-v");
     if (target) args.push("-t", target);

--- a/test/isolated/cmd-new-workspace.test.ts
+++ b/test/isolated/cmd-new-workspace.test.ts
@@ -430,6 +430,8 @@ describe("cmdNew workspace session factory", () => {
           target: undefined,
           opts: {
             cwd: dir,
+            direction: "vertical",
+            fullWindow: true,
             command: `bun dev; exec ${process.env.SHELL || "zsh"}`,
             printFormat: "#{pane_id}",
           },
@@ -465,12 +467,14 @@ describe("cmdNew workspace session factory", () => {
           target: undefined,
           opts: {
             cwd: dir,
+            direction: "vertical",
+            fullWindow: true,
             command: `bun dev; exec ${process.env.SHELL || "zsh"}`,
             printFormat: "#{pane_id}",
           },
         },
       ]);
-      expect(lines.join("\n")).toContain("created split shell + command 'agent-log' in work:main");
+      expect(lines.join("\n")).toContain("created split shell + command 'agent-log' at bottom edge in work:main");
     } finally {
       logSpy.mockRestore();
       rmSync(dir, { recursive: true, force: true });
@@ -483,7 +487,13 @@ describe("cmdNew workspace session factory", () => {
       await cmdNew(["righty", "-p", dir, "--split", "--right", "--no-attach"]);
       await cmdNew(["bottomy", "-p", dir, "--split", "--bottom", "--no-attach"]);
 
-      expect(splitWindowCalls.map(call => call.opts.direction)).toEqual(["horizontal", "vertical"]);
+      expect(splitWindowCalls.map(call => ({
+        direction: call.opts.direction,
+        fullWindow: call.opts.fullWindow,
+      }))).toEqual([
+        { direction: "horizontal", fullWindow: true },
+        { direction: "vertical", fullWindow: true },
+      ]);
       await expect(cmdNew(["conflict", "-p", dir, "--split", "--right", "--vertical", "--no-attach"]))
         .rejects.toThrow("choose only one split direction");
       await expect(cmdNew(["no-split", "-p", dir, "--right", "--no-attach"]))

--- a/test/isolated/tmux.test.ts
+++ b/test/isolated/tmux.test.ts
@@ -267,6 +267,15 @@ describe("Tmux", () => {
       });
       expect(commands[0]).toBe("tmux split-window -P -F '#{pane_id}' -h -c /tmp/work zsh");
     });
+
+    test("can split the full window before applying direction", async () => {
+      await t.splitWindow(undefined, {
+        fullWindow: true,
+        direction: "horizontal",
+        printFormat: "#{pane_id}",
+      });
+      expect(commands[0]).toBe("tmux split-window -P -F '#{pane_id}' -f -h");
+    });
   });
 
   describe("selectPane", () => {

--- a/test/isolated/wake-cmd-thirteenth-pass-coverage.test.ts
+++ b/test/isolated/wake-cmd-thirteenth-pass-coverage.test.ts
@@ -693,10 +693,16 @@ describe("wake-cmd thirteenth-pass isolated coverage", () => {
     );
 
     expect(result).toBe("54-neo:neo-oracle");
-    expect(sentText).toEqual([{
-      target: "54-neo:neo-oracle",
-      text: `cd ${repoPath} && claude --agent neo-oracle -p 'quote '\\''this'\\'''`,
-    }]);
+    expect(sentText).toEqual([
+      {
+        target: "54-neo:neo-oracle",
+        text: `cd ${repoPath} && claude --agent neo-oracle`,
+      },
+      {
+        target: "54-neo:neo-oracle",
+        text: "quote 'this'",
+      },
+    ]);
     expect(selectedWindows).toEqual(["54-neo:neo-oracle"]);
     expect(attachCalls).toEqual(["54-neo"]);
 


### PR DESCRIPTION
## Summary
- Make `maw new --split` create full-window tmux splits (`-f`) instead of splitting the focused pane.
- Keep `--right/--horizontal` as right-edge full-height panes and default/`--bottom` as bottom-edge full-width panes.
- Update usage text and confirmation output to name the resulting edge.
- Refresh one stale alpha test expectation for the current launch-then-send prompt fallback path so CI stays green.

Closes #29
Closes Soul-Brews-Studio/mawjs-oracle#29

## Verification
- `bun build`
- `MAW_TEST_MODE=1 bun test test/isolated/cmd-new-workspace.test.ts test/isolated/tmux.test.ts test/isolated/wake-cmd-thirteenth-pass-coverage.test.ts --path-ignore-patterns '**/agents/**'`
- `MAW_TEST_MODE=1 bun test test/tmux-class-command-builders.test.ts --path-ignore-patterns '**/agents/**'`
- `MAW_TEST_MODE=1 bun test test/tmux-sendtext-submit.test.ts --path-ignore-patterns '**/agents/**'`
- `bun run test:default:safe --isolate`

## Notes
- `bun run test:default:safe` without `--isolate` still fails in shared-process tmux/mock tests; the named failing files pass in isolation and under the isolated broad gate.
