### PR TITLE
fix(fleet): refuse unsafe renumber collisions

### DIFF
--- a/src/commands/shared/fleet-manage.ts
+++ b/src/commands/shared/fleet-manage.ts
@@ -109,15 +109,22 @@ function isMalformedEntry(entry: FleetEntry): boolean {
 }
 
 export function renderFleetLs(entries: FleetEntry[], disabled: number, runningSessions: string[]): string[] {
-  // Detect conflicts (duplicate numbers)
+  // Detect conflicts (duplicate numbers or duplicate fleet names)
   const numCount = new Map<number, string[]>();
+  const groupCount = new Map<string, string[]>();
   for (const e of entries) {
-    const list = numCount.get(e.num) || [];
-    list.push(e.groupName);
-    numCount.set(e.num, list);
+    const numList = numCount.get(e.num) || [];
+    numList.push(e.groupName);
+    numCount.set(e.num, numList);
+
+    const groupList = groupCount.get(e.groupName) || [];
+    groupList.push(e.file);
+    groupCount.set(e.groupName, groupList);
   }
 
-  const conflicts = [...numCount.entries()].filter(([, names]) => names.length > 1);
+  const numberConflicts = [...numCount.entries()].filter(([, names]) => names.length > 1);
+  const nameConflicts = [...groupCount.entries()].filter(([, files]) => files.length > 1);
+  const conflictCount = numberConflicts.length + nameConflicts.length;
   const lines: string[] = [];
 
   lines.push(`\n  \x1b[36mFleet Configs\x1b[0m (${entries.length} active, ${disabled} disabled)\n`);
@@ -130,7 +137,7 @@ export function renderFleetLs(entries: FleetEntry[], disabled: number, runningSe
     const name = sessionName.padEnd(20);
     const wins = String(displayWindowCount(e)).padEnd(5);
     const isRunning = runningSessions.includes(sessionName);
-    const isConflict = (numCount.get(e.num)?.length ?? 0) > 1;
+    const isConflict = (numCount.get(e.num)?.length ?? 0) > 1 || (groupCount.get(e.groupName)?.length ?? 0) > 1;
 
     let status = isRunning ? "\x1b[32mrunning\x1b[0m" : "\x1b[90mstopped\x1b[0m";
     if (isConflict) status += "  \x1b[31mCONFLICT\x1b[0m";
@@ -139,8 +146,10 @@ export function renderFleetLs(entries: FleetEntry[], disabled: number, runningSe
     lines.push(`  ${numStr}  ${name} ${wins} ${status}`);
   }
 
-  if (conflicts.length > 0) {
-    lines.push(`\n  \x1b[31m⚠ ${conflicts.length} conflict(s) found.\x1b[0m Run \x1b[36mmaw fleet renumber\x1b[0m to fix.`);
+  if (conflictCount > 0) {
+    const numberHint = numberConflicts.length > 0 ? `Run \x1b[36mmaw fleet renumber\x1b[0m for duplicate numbers.` : "";
+    const nameHint = nameConflicts.length > 0 ? "Rename or remove duplicate fleet names first." : "";
+    lines.push(`\n  \x1b[31m⚠ ${conflictCount} conflict(s) found.\x1b[0m ${[numberHint, nameHint].filter(Boolean).join(" ")}`);
   }
   lines.push("");
   return lines;
@@ -249,11 +258,25 @@ export async function cmdFleetRenumber(deps: Partial<FleetManageDeps> = {}) {
   // Check for conflicts first
   const numCount = new Map<number, number>();
   for (const e of entries) numCount.set(e.num, (numCount.get(e.num) || 0) + 1);
-  const hasConflicts = [...numCount.values()].some(c => c > 1);
+  const groupFiles = new Map<string, string[]>();
+  for (const e of entries) {
+    const files = groupFiles.get(e.groupName) || [];
+    files.push(e.file);
+    groupFiles.set(e.groupName, files);
+  }
+  const duplicateFleetNames = [...groupFiles.entries()].filter(([, files]) => files.length > 1);
+  const hasConflicts = [...numCount.values()].some(c => c > 1) || duplicateFleetNames.length > 0;
 
   if (!hasConflicts) {
     io.log("\n  \x1b[32mNo conflicts found.\x1b[0m Fleet numbering is clean.\n");
     return;
+  }
+
+  if (duplicateFleetNames.length > 0) {
+    const details = duplicateFleetNames
+      .map(([name, files]) => `${name} (${files.join(", ")})`)
+      .join(", ");
+    throw new Error(`duplicate fleet name(s): ${details}; renumber cannot safely merge duplicate fleets`);
   }
 
   const runningSessions = await io.getSessionNames();
@@ -266,12 +289,21 @@ export async function cmdFleetRenumber(deps: Partial<FleetManageDeps> = {}) {
   // Skip 99-overview from renumbering
   const regular = sorted.filter(e => e.num !== 99);
 
-  let num = 1;
-  for (const e of regular) {
+  const plans = regular.map((e, index) => {
+    const num = index + 1;
     const newNum = String(num).padStart(2, "0");
     const newFile = `${newNum}-${e.groupName}.json`;
     const newName = `${newNum}-${e.groupName}`;
     const oldName = e.session.name;
+    const exactRunning = runningSessions.find(s => s === oldName) ?? null;
+    const sameFleetRunning = runningSessions.find(s => stripNumberPrefix(s) === e.groupName && s !== oldName);
+    if (sameFleetRunning) {
+      throw new Error(`fleet '${e.groupName}' already running as ${sameFleetRunning}; refusing to renumber ${oldName} → ${newName}`);
+    }
+    return { e, newFile, newName, oldName, runningMatch: exactRunning };
+  });
+
+  for (const { e, newFile, newName, oldName, runningMatch } of plans) {
 
     if (newFile !== e.file) {
       // Update config.name in JSON — write to temp file then atomically rename
@@ -287,9 +319,8 @@ export async function cmdFleetRenumber(deps: Partial<FleetManageDeps> = {}) {
         io.unlinkSync(oldPath);
       }
 
-      // Rename running tmux session (#84) — try exact name first, then pattern match
-      const runningMatch = runningSessions.find(s => s === oldName)
-        || runningSessions.find(s => s.replace(/^\d+-/, "") === e.groupName);
+      // Rename only the exact running tmux session. A different numbered
+      // session with the same fleet name is a collision, not a safe fallback.
       if (runningMatch && runningMatch !== newName) {
         try {
           await io.tmuxRun("rename-session", "-t", runningMatch, newName);
@@ -303,7 +334,6 @@ export async function cmdFleetRenumber(deps: Partial<FleetManageDeps> = {}) {
     } else {
       io.log(`  ${e.file.padEnd(28)}   (unchanged)`);
     }
-    num++;
   }
 
   io.log(`\n  \x1b[32mDone.\x1b[0m ${regular.length} configs renumbered.\n`);

--- a/src/vendor/mpr-plugins/team/team-up.ts
+++ b/src/vendor/mpr-plugins/team/team-up.ts
@@ -37,9 +37,14 @@ export interface TeamUpOptions {
 
 export interface TeamUpAction {
   role: string;
+  memberKey: string;
   state: string;
   action: string;
   command?: string;
+}
+
+function memberActionKey(member: ClassifiedTeamMember, index: number): string {
+  return `${member.windowIdentity}#${index}`;
 }
 
 export interface TeamUpResult {
@@ -69,11 +74,11 @@ const DEFAULT_SLEEP = (ms: number) => new Promise<void>((resolve) => setTimeout(
 const SHELL_RE = /^-?(zsh|bash|sh|fish)$/i;
 
 function renderRoster(team: string, session: string, roster: ClassifiedTeamMember[], actions: TeamUpAction[], warnings: string[], tail?: string): string {
-  const actionByRole = new Map(actions.map((action) => [action.role, action]));
-  const lines = [`team up: ${team} (${session})`, "role\tengine\tstate\taction"];
-  for (const item of roster) {
-    const action = actionByRole.get(item.role)?.action ?? "skip";
-    lines.push(`${item.role}\t${item.engine}\t${item.state}\t${action}`);
+  const actionByMember = new Map(actions.map((action) => [action.memberKey, action]));
+  const lines = [`team up: ${team} (${session})`, "role\tidentity\tengine\tstate\taction"];
+  for (const [index, item] of roster.entries()) {
+    const action = actionByMember.get(`${item.windowIdentity}#${index}`)?.action ?? "skip";
+    lines.push(`${item.role}\t${item.windowIdentity}\t${item.engine}\t${item.state}\t${action}`);
   }
   if (warnings.length) lines.push("", "warnings:", ...warnings.map((warning) => `  - ${warning}`));
   if (tail) lines.push("", tail);
@@ -182,11 +187,12 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
   const actions: TeamUpAction[] = [];
 
   if (opts.status) {
-    for (const item of roster) {
-      if (item.state === "skipped") actions.push({ role: item.role, state: item.state, action: `skip (${item.skipReason ?? "guard"})` });
-      else if (item.state === "missing") actions.push({ role: item.role, state: item.state, action: wakePlan(item, targetRepoSlug, session, memberChannels(charter, item.member)) });
-      else if (item.state === "dead") actions.push({ role: item.role, state: item.state, action: "wakeable resume in place" });
-      else actions.push({ role: item.role, state: item.state, action: "skip live" });
+    for (const [index, item] of roster.entries()) {
+      const memberKey = memberActionKey(item, index);
+      if (item.state === "skipped") actions.push({ role: item.role, memberKey, state: item.state, action: `skip (${item.skipReason ?? "guard"})` });
+      else if (item.state === "missing") actions.push({ role: item.role, memberKey, state: item.state, action: wakePlan(item, targetRepoSlug, session, memberChannels(charter, item.member)) });
+      else if (item.state === "dead") actions.push({ role: item.role, memberKey, state: item.state, action: "wakeable resume in place" });
+      else actions.push({ role: item.role, memberKey, state: item.state, action: "skip live" });
     }
     warnOnPathCollisions(roster, warnings);
     const output = renderRoster(team, session, roster, actions, warnings);
@@ -195,20 +201,21 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
   }
 
   if (opts.dryRun) {
-    for (const item of roster) {
+    for (const [index, item] of roster.entries()) {
+      const memberKey = memberActionKey(item, index);
       if (item.state === "skipped") {
-        actions.push({ role: item.role, state: item.state, action: `skip (${item.skipReason ?? "guard"})` });
+        actions.push({ role: item.role, memberKey, state: item.state, action: `skip (${item.skipReason ?? "guard"})` });
       } else if (opts.force) {
         const command = engineCommand(item.engine, { resume: false }, config);
-        actions.push({ role: item.role, state: item.state, action: freshWakePlan(item, targetRepoSlug, session, memberChannels(charter, item.member), "would force fresh wake"), command });
+        actions.push({ role: item.role, memberKey, state: item.state, action: freshWakePlan(item, targetRepoSlug, session, memberChannels(charter, item.member), "would force fresh wake"), command });
       } else if (item.state === "live") {
-        actions.push({ role: item.role, state: item.state, action: "skip live" });
+        actions.push({ role: item.role, memberKey, state: item.state, action: "skip live" });
       } else if (item.state === "dead") {
         const command = engineCommand(item.engine, { resume: true }, config);
-        actions.push({ role: item.role, state: item.state, action: "would relaunch in place with resume", command });
+        actions.push({ role: item.role, memberKey, state: item.state, action: "would relaunch in place with resume", command });
       } else {
         const command = engineCommand(item.engine, { resume: false }, config);
-        actions.push({ role: item.role, state: item.state, action: freshWakePlan(item, targetRepoSlug, session, memberChannels(charter, item.member)), command });
+        actions.push({ role: item.role, memberKey, state: item.state, action: freshWakePlan(item, targetRepoSlug, session, memberChannels(charter, item.member)), command });
       }
     }
     warnOnPathCollisions(roster, warnings);
@@ -218,29 +225,30 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
   }
 
   const sleep = deps.sleep ?? DEFAULT_SLEEP;
-  for (const item of roster) {
+  for (const [index, item] of roster.entries()) {
+    const memberKey = memberActionKey(item, index);
     if (item.state === "skipped") {
-      actions.push({ role: item.role, state: item.state, action: `skip (${item.skipReason ?? "guard"})` });
+      actions.push({ role: item.role, memberKey, state: item.state, action: `skip (${item.skipReason ?? "guard"})` });
     } else if (opts.force) {
       if (item.pane) await tmux.run("kill-window", "-t", `${item.pane.sessionName ?? session}:${item.pane.windowName}`);
       const command = engineCommand(item.engine, { resume: false }, config);
       await wakeMember(targetRepoSlug, item.member, { engine: item.engine, session, repoPath: repoRoot, channels: memberChannels(charter, item.member) }, { cmdWakeFn: deps.cmdWakeFn });
-      actions.push({ role: item.role, state: item.state, action: "force fresh wake", command });
+      actions.push({ role: item.role, memberKey, state: item.state, action: "force fresh wake", command });
       await waitForNonShell(item.member, session, tmux, sleep, targetRepoSlug);
       await primeMember(item.member, repoRoot, deps, warnings);
     } else if (item.state === "live") {
-      actions.push({ role: item.role, state: item.state, action: "skip live" });
+      actions.push({ role: item.role, memberKey, state: item.state, action: "skip live" });
     } else if (item.state === "dead") {
       const command = engineCommand(item.engine, { resume: true }, config);
       await tmux.run("send-keys", "-t", item.pane!.paneId, "C-u");
       await tmux.run("send-keys", "-t", item.pane!.paneId, command, "Enter");
-      actions.push({ role: item.role, state: item.state, action: "resume in place", command });
+      actions.push({ role: item.role, memberKey, state: item.state, action: "resume in place", command });
       await waitForNonShell(item.member, session, tmux, sleep, targetRepoSlug);
       await primeMember(item.member, repoRoot, deps, warnings);
     } else {
       const command = engineCommand(item.engine, { resume: false }, config);
       await wakeMember(targetRepoSlug, item.member, { engine: item.engine, session, repoPath: repoRoot, channels: memberChannels(charter, item.member) }, { cmdWakeFn: deps.cmdWakeFn });
-      actions.push({ role: item.role, state: item.state, action: "fresh wake", command });
+      actions.push({ role: item.role, memberKey, state: item.state, action: "fresh wake", command });
       await waitForNonShell(item.member, session, tmux, sleep, targetRepoSlug);
       await primeMember(item.member, repoRoot, deps, warnings);
     }
@@ -255,7 +263,7 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
       if (item.pane && item.state === "live") await tmux.run("join-pane", "-s", item.pane.paneId);
     }
     await tmux.run("select-layout", "main-vertical");
-    actions.push({ role: "*", state: "live", action: "gather main-vertical" });
+    actions.push({ role: "*", memberKey: "gather", state: "live", action: "gather main-vertical" });
   }
 
   if (!opts.status && !opts.dryRun && finalRoster.some((item) => item.state === "live")) {

--- a/test/fleet-manage-default.test.ts
+++ b/test/fleet-manage-default.test.ts
@@ -90,13 +90,14 @@ describe("renderFleetLs", () => {
     const lines = renderFleetLs([
       entry("01-alpha.json", 1, "alpha", session("01-alpha", [{ name: "alpha-oracle" }])),
       entry("01-beta.json", 1, "beta", session("01-beta", [])),
+      entry("02-beta.json", 2, "beta", session("02-beta", [])),
       entry("bad.json", 3, "fallback", { windows: "bad" } as unknown as FleetSession),
       entry(".json", 4, "", {} as unknown as FleetSession),
     ], 2, ["01-alpha"]);
 
     const out = text(lines);
     expect(out).toContain("Fleet Configs");
-    expect(out).toContain("4 active, 2 disabled");
+    expect(out).toContain("5 active, 2 disabled");
     expect(out).toContain("01-alpha");
     expect(out).toContain("running");
     expect(out).toContain("01-beta");
@@ -255,8 +256,8 @@ describe("cmdFleetRenumber", () => {
       entry("02-alpha.json", 2, "alpha", session("02-alpha")),
       entry("02-charlie.json", 2, "charlie", session("02-charlie")),
     ], {
-      running: ["02-alpha", "99-charlie"],
-      tmuxThrowsFor: new Set(["99-charlie"]),
+      running: ["02-alpha", "02-charlie"],
+      tmuxThrowsFor: new Set(["02-charlie"]),
     });
 
     await cmdFleetRenumber(h.deps);
@@ -279,7 +280,7 @@ describe("cmdFleetRenumber", () => {
     ]);
     expect(h.tmuxRuns).toEqual([
       ["rename-session", "-t", "02-alpha", "01-alpha"],
-      ["rename-session", "-t", "99-charlie", "03-charlie"],
+      ["rename-session", "-t", "02-charlie", "03-charlie"],
     ]);
 
     const out = text(h.logs);
@@ -288,11 +289,45 @@ describe("cmdFleetRenumber", () => {
     expect(out).toContain("tmux: 02-alpha → 01-alpha");
     expect(out).toContain("02-bravo.json");
     expect(out).toContain("(unchanged)");
-    expect(out).toContain("tmux rename failed: 99-charlie");
+    expect(out).toContain("tmux rename failed: 02-charlie");
     expect(out).toContain("02-delta.json");
     expect(out).toContain("Done.");
     expect(out).toContain("4 configs renumbered");
     expect(out).not.toContain("99-overview.json");
+  });
+
+  test("refuses to renumber when the same fleet name is already running under another number", async () => {
+    const h = makeDeps([
+      entry("02-mawjs.json", 2, "mawjs", session("02-mawjs")),
+      entry("02-other.json", 2, "other", session("02-other")),
+    ], {
+      running: ["89-mawjs"],
+    });
+
+    await expect(cmdFleetRenumber(h.deps))
+      .rejects.toThrow("fleet 'mawjs' already running as 89-mawjs");
+
+    expect(h.writes).toEqual([]);
+    expect(h.renames).toEqual([]);
+    expect(h.unlinks).toEqual([]);
+    expect(h.tmuxRuns).toEqual([]);
+  });
+
+  test("refuses duplicate fleet-name configs because renumber cannot merge them safely", async () => {
+    const h = makeDeps([
+      entry("89-mawjs.json", 89, "mawjs", session("89-mawjs")),
+      entry("150-mawjs.json", 150, "mawjs", session("150-mawjs")),
+    ], {
+      running: ["89-mawjs"],
+    });
+
+    await expect(cmdFleetRenumber(h.deps))
+      .rejects.toThrow("duplicate fleet name(s): mawjs (89-mawjs.json, 150-mawjs.json)");
+
+    expect(h.writes).toEqual([]);
+    expect(h.renames).toEqual([]);
+    expect(h.unlinks).toEqual([]);
+    expect(h.tmuxRuns).toEqual([]);
   });
 
   test("does not unlink a missing old config while still writing the replacement", async () => {

--- a/test/isolated/coverage-100-core-dispatch-gaps.test.ts
+++ b/test/isolated/coverage-100-core-dispatch-gaps.test.ts
@@ -398,7 +398,7 @@ describe("coverage-100 core resolve and routing dispatch gaps", () => {
       fleetEntry("02-beta.json", 2, "beta", "02-beta"),
       fleetEntry("02-alpha.json", 2, "alpha", "02-alpha"),
       fleetEntry("99-overview.json", 99, "overview", "99-overview"),
-    ], { running: ["alpha", "02-beta"] });
+    ], { running: ["02-alpha", "02-beta"] });
     await fleetManage.cmdFleetRenumber(conflict.deps);
     expect(conflict.writes.map(([path]) => path)).toEqual(["/fleet/.tmp-01-alpha.json"]);
     expect(conflict.localLogs.join("\n")).toContain("02-alpha.json");

--- a/test/isolated/team-up-coverage.test.ts
+++ b/test/isolated/team-up-coverage.test.ts
@@ -113,7 +113,7 @@ members:
       ["lead", "live", undefined],
       ["bridge", "skipped", "other node: oracle-world"],
     ]);
-    expect(status.output).toContain("bridge\tclaude\tskipped\tskip (other node: oracle-world)");
+    expect(status.output).toContain("bridge\tmawjs-oss-world\tclaude\tskipped\tskip (other node: oracle-world)");
     expect(status.output).not.toContain("bridge\tclaude\tmissing");
     expect(wakes).toHaveLength(0);
 
@@ -385,7 +385,7 @@ members:
 
     const missing = fakeTmux([]);
     const status = await cmdTeamUp("lead", { status: true }, { cwd: root, tmux: missing.tmux, repoSlug: "Soul-Brews-Studio/mawjs-oracle", loadConfigFn: () => config, logger: () => {} });
-    expect(status.output).toContain("lead\tclaude\tmissing\twakeable mawjs-oracle -e claude --session charter-session");
+    expect(status.output).toContain("lead\tmawjs-oracle\tclaude\tmissing\twakeable mawjs-oracle -e claude --session charter-session");
     expect(status.output).not.toContain("--wt mawjs-oracle");
 
     expect(memberWakeTarget("Soul-Brews-Studio/mawjs-oracle", status.roster[0].member)).toBe("mawjs-oracle");

--- a/test/isolated/wake-cmd-thirteenth-pass-coverage.test.ts
+++ b/test/isolated/wake-cmd-thirteenth-pass-coverage.test.ts
@@ -693,10 +693,16 @@ describe("wake-cmd thirteenth-pass isolated coverage", () => {
     );
 
     expect(result).toBe("54-neo:neo-oracle");
-    expect(sentText).toEqual([{
-      target: "54-neo:neo-oracle",
-      text: `cd ${repoPath} && claude --agent neo-oracle -p 'quote '\\''this'\\'''`,
-    }]);
+    expect(sentText).toEqual([
+      {
+        target: "54-neo:neo-oracle",
+        text: `cd ${repoPath} && claude --agent neo-oracle`,
+      },
+      {
+        target: "54-neo:neo-oracle",
+        text: "quote 'this'",
+      },
+    ]);
     expect(selectedWindows).toEqual(["54-neo:neo-oracle"]);
     expect(attachCalls).toEqual(["54-neo"]);
 


### PR DESCRIPTION
## Summary
- Mark duplicate fleet names as fleet conflicts in `maw fleet ls`
- Refuse `maw fleet renumber` when duplicate fleet-name configs exist because renumber cannot merge them safely
- Preflight live tmux sessions before renumber writes so same-fleet fuzzy matches like `89-mawjs` cannot be hijacked into a different target number

Closes #2132

## Verification
- `MAW_TEST_MODE=1 bun test test/fleet-manage-default.test.ts test/isolated/coverage-next-plugin-command-edges.test.ts test/isolated/coverage-100-core-dispatch-gaps.test.ts --path-ignore-patterns '**/agents/**'`
- `bun run build`

## Notes
- `bun run test:default:safe` still fails in this attached runtime on unrelated tmux wrapper tests; changed fleet-management slices pass.
