### PR TITLE
Fix bare target resolution in current tmux session

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.6.6-alpha.1854",
+  "version": "26.6.7-alpha.2028",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",

--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -87,6 +87,16 @@ export function resolveMyName(config: ReturnType<typeof loadConfig>): string {
   return config.node || "cli";
 }
 
+async function currentTmuxSessionName(): Promise<string | undefined> {
+  if (!process.env.TMUX) return undefined;
+  try {
+    const session = (await new Tmux().run("display-message", "-p", "#S")).trim();
+    return session || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export interface SenderIdentity {
   /** Human-facing node name used in visible `[node:oracle]` message prefixes. */
   node: string;
@@ -380,11 +390,12 @@ async function resolveBareLocalTarget(
   query: string,
   config: ReturnType<typeof loadConfig>,
   sessions: Awaited<ReturnType<typeof listSessions>>,
+  currentSession?: string,
 ): Promise<{ result: ReturnType<typeof resolveTarget> | null; locate: HeyLocateResolution | null }> {
   if (!isBareLocalHeyTarget(query)) return { result: null, locate: null };
 
   try {
-    const localResult = normalizeBareLocalResult(query, resolveTarget(query, config, sessions), config);
+    const localResult = normalizeBareLocalResult(query, resolveTarget(query, config, sessions, currentSession), config);
     if (localResult) return { result: localResult, locate: null };
   } catch (e) {
     if (e instanceof AmbiguousMatchError) {
@@ -586,7 +597,8 @@ export async function cmdSend(
   }
 
   let sessions = await listSessions();
-  let bareResolution = await resolveBareLocalTarget(query, config, sessions);
+  const currentSession = await currentTmuxSessionName();
+  let bareResolution = await resolveBareLocalTarget(query, config, sessions, currentSession);
 
   // --- #736 Phase 1.2 + #791: auto-wake fleet-known targets (parity with maw view) ---
   // Mirrors view/impl.ts:107 — if the user's hey target is fleet-known but
@@ -638,7 +650,7 @@ export async function cmdSend(
           await cmdWake(bareAgent, {});
           // Refresh after wake — resolver needs the new tmux session visible.
           sessions = await listSessions();
-          bareResolution = await resolveBareLocalTarget(query, config, sessions);
+          bareResolution = await resolveBareLocalTarget(query, config, sessions, currentSession);
         }
       } catch { /* fleet/wake best-effort — fall through to existing error path */ }
     } else if (targetNode && bareAgent && !isCanonical) {
@@ -694,7 +706,7 @@ export async function cmdSend(
   const result = bareResolution.result ?? (
     isBareLocalHeyTarget(query)
       ? { type: "error" as const, reason: "not_live", detail: `'${query}' found but no active session`, hint: `maw wake ${query}` }
-      : resolveTarget(query, config, sessions)
+      : resolveTarget(query, config, sessions, currentSession)
   );
 
   // --- #842 Sub-C — cross-oracle ACL gate (Phase 2 of #642) ---

--- a/src/core/routing.ts
+++ b/src/core/routing.ts
@@ -63,6 +63,7 @@ export function resolveTarget(
   query: string,
   config: MawConfig,
   sessions: (Session & { source?: string })[],
+  currentSession?: string,
 ): ResolveResult {
   if (!query) return { type: "error", reason: "empty_query", detail: "no target specified", hint: "usage: maw hey <agent> <message>" };
 
@@ -99,7 +100,7 @@ export function resolveTarget(
   }
 
   // --- Step 1: Local findWindow ---
-  const localTarget = findWindow(writable, query);
+  const localTarget = findWindow(writable, query, currentSession);
   if (localTarget) {
     return { type: "local", target: localTarget };
   }
@@ -131,7 +132,7 @@ export function resolveTarget(
       if (sessionAliasResult) return sessionAliasResult;
       const sessionWindowAliasResult = resolveSessionWindowAliasTarget(agentName, writable, "self-node");
       if (sessionWindowAliasResult) return sessionWindowAliasResult;
-      const selfTarget = findWindow(writable, agentName);
+      const selfTarget = findWindow(writable, agentName, currentSession);
       if (selfTarget) return { type: "self-node", target: selfTarget };
       return { type: "error", reason: "self_not_running", detail: `'${agentName}' not found in local sessions on ${selfNode}`, hint: `maw wake ${agentName}` };
     }

--- a/src/core/runtime/find-window.ts
+++ b/src/core/runtime/find-window.ts
@@ -58,7 +58,7 @@ function matchSession(sessions: Session[], part: string, strict = false): Sessio
   return null;
 }
 
-export function findWindow(sessions: Session[], query: string): string | null {
+export function findWindow(sessions: Session[], query: string, currentSession?: string): string | null {
   const q = query.toLowerCase();
 
   // session:window syntax — strict session match to prevent node:agent collision (#186)
@@ -87,8 +87,10 @@ export function findWindow(sessions: Session[], query: string): string | null {
   //   window-name matches because a stale session may still have a window named
   //   `<name>-oracle` while the live session itself is named `NN-<name>-oracle`
   //   (#1752). Pass 1b collects exact window matches only when no exact session
-  //   match exists. Pass 2 collects substring matches only if Pass 1 was empty.
-  //   Multi-candidate inside any pass → AmbiguousMatchError.
+  //   match exists. Pass 1c scopes substring matching to the caller-supplied
+  //   current tmux session before falling back to Pass 2's cross-session
+  //   substring search (#2134). Multi-candidate inside any pass →
+  //   AmbiguousMatchError.
   const exactSessions = new Set<string>();
   for (const s of sessions) {
     if (s.windows.length > 0) {
@@ -109,6 +111,21 @@ export function findWindow(sessions: Session[], query: string): string | null {
   }
   if (exact.size === 1) return [...exact][0];
   if (exact.size > 1) throw new AmbiguousMatchError(query, [...exact]);
+
+  const current = currentSession
+    ? sessions.find((s) => s.name.toLowerCase() === currentSession.toLowerCase())
+    : undefined;
+  if (current) {
+    const scopedSub = new Set<string>();
+    for (const w of current.windows) {
+      if (w.name.toLowerCase().includes(q)) scopedSub.add(`${current.name}:${w.index}`);
+    }
+    if (current.name.toLowerCase().includes(q) && current.windows.length > 0) {
+      scopedSub.add(`${current.name}:${current.windows[0].index}`);
+    }
+    if (scopedSub.size === 1) return [...scopedSub][0];
+    if (scopedSub.size > 1) throw new AmbiguousMatchError(query, [...scopedSub]);
+  }
 
   const sub = new Set<string>();
   for (const s of sessions) {

--- a/test/isolated/find-window-current-session.test.ts
+++ b/test/isolated/find-window-current-session.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { AmbiguousMatchError, findWindow, type Session } from "../../src/core/runtime/find-window";
+
+const SESSIONS: Session[] = [
+  {
+    name: "89-mawjs",
+    windows: [
+      { index: 1, name: "mawjs-oracle", active: true },
+      { index: 2, name: "mawjs-codex-1", active: false },
+    ],
+  },
+  {
+    name: "46-atlas",
+    windows: [
+      { index: 1, name: "atlas-oracle", active: true },
+      { index: 2, name: "atlas-codex-1", active: false },
+    ],
+  },
+  {
+    name: "12-sidecar",
+    windows: [
+      { index: 1, name: "sidecar-codex-2", active: true },
+    ],
+  },
+];
+
+describe("findWindow current-session scoped substring pass (#2134)", () => {
+  test("bare name matching one window in current session resolves without cross-session ambiguity", () => {
+    expect(findWindow(SESSIONS, "codex-1", "89-mawjs")).toBe("89-mawjs:2");
+  });
+
+  test("bare name matching zero windows in current session falls through to one cross-session match", () => {
+    expect(findWindow(SESSIONS, "codex-2", "89-mawjs")).toBe("12-sidecar:1");
+  });
+
+  test("bare name matching multiple windows in current session is ambiguous within current session", () => {
+    const sessions: Session[] = [
+      {
+        name: "89-mawjs",
+        windows: [
+          { index: 1, name: "mawjs-codex-1", active: true },
+          { index: 2, name: "mawjs-helper-codex-1", active: false },
+        ],
+      },
+      {
+        name: "46-atlas",
+        windows: [
+          { index: 1, name: "atlas-codex-1", active: true },
+        ],
+      },
+    ];
+
+    expect(() => findWindow(sessions, "codex-1", "89-mawjs")).toThrow(AmbiguousMatchError);
+    try {
+      findWindow(sessions, "codex-1", "89-mawjs");
+    } catch (error) {
+      const err = error as AmbiguousMatchError;
+      expect(err.candidates).toEqual(["89-mawjs:1", "89-mawjs:2"]);
+    }
+  });
+
+  test("without currentSession preserves existing cross-session ambiguity behavior", () => {
+    expect(() => findWindow(SESSIONS, "codex-1")).toThrow(AmbiguousMatchError);
+  });
+});


### PR DESCRIPTION
## Summary
- add optional current-session context to pure `findWindow` resolution
- prefer substring matches within the caller's current tmux session before global substring matching
- pass current tmux session from `maw hey` caller resolution
- add isolated regressions for #2134

Closes #2134

## Verification
- `bash scripts/test-isolated.sh test/isolated/find-window-current-session.test.ts`
- `bun test test/isolated/find-window-current-session.test.ts test/00-ssh.test.ts test/routing.test.ts test/00-routing-default.test.ts test/comm-send-cmdsend-coverage.test.ts --path-ignore-patterns '**/agents/**'`\n- `bun run build`\n\n## Notes\n- `bunx tsc --noEmit` was attempted, but the repo has no `tsconfig.json`; TypeScript printed compiler help instead of checking the project.