### PR TITLE
Fix team-up priming target resolution

### DIFF
--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -426,12 +426,15 @@ async function resolveBareLocalTarget(
  *   into the live pane. Normal sends now always inject by default.
  * - `from` (#1889): explicit user-facing sender override, `<node>:<oracle>`,
  *   used for SSH relays where auto local identity would impersonate the host.
+ * - `currentSession` (#2134): caller-known tmux session used to scope bare
+ *   target resolution before cross-session matching.
  */
 export interface CmdSendOptions {
   approve?: boolean;
   trust?: boolean;
   inboxOnly?: boolean;
   from?: string;
+  currentSession?: string;
   receiverInbox?: ReceiverInboxWriter | false;
   /**
    * #1907 — opt out of post-send verify-submit retry. Default behaviour
@@ -597,7 +600,7 @@ export async function cmdSend(
   }
 
   let sessions = await listSessions();
-  const currentSession = await currentTmuxSessionName();
+  const currentSession = opts.currentSession?.trim() || await currentTmuxSessionName();
   let bareResolution = await resolveBareLocalTarget(query, config, sessions, currentSession);
 
   // --- #736 Phase 1.2 + #791: auto-wake fleet-known targets (parity with maw view) ---

--- a/src/vendor/mpr-plugins/team/team-up.ts
+++ b/src/vendor/mpr-plugins/team/team-up.ts
@@ -143,8 +143,15 @@ function resolvePrimingPrompt(member: TeamCharter["members"][number], repoRoot: 
   return readFileSync(path, "utf-8").trim();
 }
 
+function memberPrimingTarget(session: string, member: TeamCharter["members"][number]): string {
+  const identity = memberWindowIdentity(member);
+  if (identity.includes(":")) return identity;
+  return `${session}:${identity}`;
+}
+
 async function primeMember(
   member: TeamCharter["members"][number],
+  session: string,
   repoRoot: string,
   deps: Pick<TeamUpDeps, "cmdSendFn">,
   warnings: string[],
@@ -153,7 +160,7 @@ async function primeMember(
   if (!prompt) return;
   const send = deps.cmdSendFn ?? cmdSend;
   try {
-    await send(memberWindowIdentity(member), prompt, false);
+    await send(memberPrimingTarget(session, member), prompt, false, { currentSession: session });
   } catch (error) {
     warnings.push(`prompt prime failed for ${member.role}: ${error instanceof Error ? error.message : String(error)}`);
   }
@@ -235,7 +242,7 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
       await wakeMember(targetRepoSlug, item.member, { engine: item.engine, session, repoPath: repoRoot, channels: memberChannels(charter, item.member) }, { cmdWakeFn: deps.cmdWakeFn });
       actions.push({ role: item.role, memberKey, state: item.state, action: "force fresh wake", command });
       await waitForNonShell(item.member, session, tmux, sleep, targetRepoSlug);
-      await primeMember(item.member, repoRoot, deps, warnings);
+      await primeMember(item.member, session, repoRoot, deps, warnings);
     } else if (item.state === "live") {
       actions.push({ role: item.role, memberKey, state: item.state, action: "skip live" });
     } else if (item.state === "dead") {
@@ -244,13 +251,13 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
       await tmux.run("send-keys", "-t", item.pane!.paneId, command, "Enter");
       actions.push({ role: item.role, memberKey, state: item.state, action: "resume in place", command });
       await waitForNonShell(item.member, session, tmux, sleep, targetRepoSlug);
-      await primeMember(item.member, repoRoot, deps, warnings);
+      await primeMember(item.member, session, repoRoot, deps, warnings);
     } else {
       const command = engineCommand(item.engine, { resume: false }, config);
       await wakeMember(targetRepoSlug, item.member, { engine: item.engine, session, repoPath: repoRoot, channels: memberChannels(charter, item.member) }, { cmdWakeFn: deps.cmdWakeFn });
       actions.push({ role: item.role, memberKey, state: item.state, action: "fresh wake", command });
       await waitForNonShell(item.member, session, tmux, sleep, targetRepoSlug);
-      await primeMember(item.member, repoRoot, deps, warnings);
+      await primeMember(item.member, session, repoRoot, deps, warnings);
     }
   }
 

--- a/test/comm-send-cmdsend-coverage.test.ts
+++ b/test/comm-send-cmdsend-coverage.test.ts
@@ -60,6 +60,7 @@ let listSessionsReturn: Session[];
 let resolveTargetReturn: ResolvedTarget;
 let resolveTargetError: Error | null;
 let resolveTargetCalls: string[];
+let resolveTargetArgCalls: Parameters<typeof _rSdk.resolveTarget>[];
 let resolveTargetHandler: ((query: string) => ResolvedTarget) | null;
 let findPeerUrl: string | null;
 let getPaneCommandReturn: string;
@@ -108,6 +109,7 @@ mock.module(join(import.meta.dir, "../src/sdk"), () => ({
   resolveTarget: (...args: Parameters<typeof _rSdk.resolveTarget>) => {
     if (!mockActive) return realSdk.resolveTarget(...args);
     resolveTargetCalls.push(args[0]);
+    resolveTargetArgCalls.push(args);
     if (resolveTargetError) throw resolveTargetError;
     if (resolveTargetHandler) return resolveTargetHandler(args[0]);
     return resolveTargetReturn as ReturnType<typeof _rSdk.resolveTarget>;
@@ -261,6 +263,7 @@ beforeEach(() => {
   resolveTargetReturn = { type: "local", target: "session:oracle.0" };
   resolveTargetError = null;
   resolveTargetCalls = [];
+  resolveTargetArgCalls = [];
   resolveTargetHandler = null;
   findPeerUrl = null;
   getPaneCommandReturn = "claude";
@@ -327,6 +330,17 @@ afterAll(() => {
 });
 
 describe("cmdSend — delivery branch coverage", () => {
+  test("caller-supplied currentSession scopes target resolution", async () => {
+    captureResponses = ["accepted"];
+
+    await runCmd(() => cmdSend("codex-1", "hello", false, { currentSession: "89-mawjs", receiverInbox: false }));
+
+    expect(exitCode).toBeUndefined();
+    expect(resolveTargetArgCalls[0]?.[0]).toBe("codex-1");
+    expect(resolveTargetArgCalls[0]?.[3]).toBe("89-mawjs");
+    expect(sendKeysCalls).toEqual([{ target: "session:oracle.0", text: "[test-node:sender] hello" }]);
+  });
+
   test("local delivery signs, sends, logs, hooks, captures last line, and emits feed", async () => {
     captureResponses = ["accepted"];
     await runCmd(() => cmdSend("local:session:oracle", "hello"));

--- a/test/isolated/team-up-coverage.test.ts
+++ b/test/isolated/team-up-coverage.test.ts
@@ -251,8 +251,8 @@ agents:
       ["soul-brews-studio/maw-js", { wt: "claude48", engine: "claude48", session: "charter-session", repoPath: root, channels: true }],
     ]);
     expect(sends).toEqual([
-      ["codex", "inline prompt", false],
-      ["claude48", "file prompt", false],
+      ["charter-session:codex", "inline prompt", false, { currentSession: "charter-session" }],
+      ["charter-session:claude48", "file prompt", false, { currentSession: "charter-session" }],
     ]);
   });
 


### PR DESCRIPTION
Closes #2134.

## Summary
- Prime team members with session-qualified `session:member` targets instead of bare member names.
- Allow `cmdSend` callers to pass a known `currentSession` so resolver scoping reaches `findWindow`.
- Update regressions for team-up priming and cmdSend current-session forwarding.

## Verification
- `npm exec --yes --package bun@1.2.21 -- bun test /opt/Code/github.com/Soul-Brews-Studio/maw-js/maw-js-2134-session-target/test/isolated/team-up-coverage.test.ts /opt/Code/github.com/Soul-Brews-Studio/maw-js/maw-js-2134-session-target/test/isolated/find-window-current-session.test.ts /opt/Code/github.com/Soul-Brews-Studio/maw-js/maw-js-2134-session-target/test/comm-send-cmdsend-coverage.test.ts`
- `npm exec --yes --package bun@1.2.21 -- bun run build`
- `bun run build`
- `git diff --check`

Note: local installed Bun 1.4.0-canary crashes on any `bun test` invocation here, so targeted tests were run with stable Bun 1.2.21 via `npm exec`.