### PR TITLE
test: standalone coverage for config plugin

### DIFF
--- a/test/isolated/plugin-config-standalone.test.ts
+++ b/test/isolated/plugin-config-standalone.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Standalone coverage for src/commands/plugins/config/index.ts.
+ *
+ * Current state: this plugin still imports `loadConfigWithProvenance` directly from
+ * `src/config` (not yet from `@maw-js/sdk`). The test mocks that local surface so
+ * extraction-ready behavior can be validated now and can switch to SDK import once
+ * the symbol is exported in `packages/sdk`.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import { beforeEach } from "bun:test";
+import type { InvokeContext, InvokeResult } from "../../src/plugin/types";
+
+const loadedConfig = {
+  config: {
+    host: "local",
+    port: 3456,
+    teams: {
+      default: ["a", "b"],
+    },
+  },
+  sources: [
+    {
+      path: "/etc/maw/core.config.json",
+      weight: 10,
+      isLocal: false,
+      scope: "core",
+      scopeRank: 100,
+      depth: 1,
+      mtimeMs: 111,
+    },
+    {
+      path: "/cwd/maw.config.json",
+      weight: 0,
+      isLocal: true,
+      scope: "project",
+      scopeRank: 10,
+      depth: 0,
+      mtimeMs: 222,
+    },
+  ],
+  provenance: {
+    "teams.default": [
+      {
+        path: "/etc/maw/core.config.json",
+        weight: 10,
+        isLocal: false,
+        scope: "core",
+        action: "set",
+        value: ["legacy"],
+      },
+      {
+        path: "/cwd/maw.config.json",
+        weight: 0,
+        isLocal: true,
+        scope: "project",
+        action: "set",
+        value: ["a", "b"],
+      },
+    ],
+  },
+  warnings: ["project-level key overridden"],
+};
+
+let loadCallCount = 0;
+let lastLoadOptions: unknown;
+
+mock.module(import.meta.resolve("../../src/config.ts"), () => ({
+  loadConfigWithProvenance: (opts?: unknown) => {
+    loadCallCount += 1;
+    lastLoadOptions = opts;
+    return loadedConfig;
+  },
+}));
+
+const { command, default: configHandler } = await import("../../src/commands/plugins/config/index.ts");
+
+function run(args: string[], writer: ((...parts: unknown[]) => void) | undefined = undefined): Promise<InvokeResult> {
+  return configHandler({
+    source: "cli",
+    args,
+    writer,
+  } as InvokeContext);
+}
+
+describe("src/commands/plugins/config/index.ts", () => {
+  beforeEach(() => {
+    loadCallCount = 0;
+    lastLoadOptions = undefined;
+  });
+
+  test("exports metadata", () => {
+    expect(command).toEqual({
+      name: "config",
+      description: "Inspect cwd-aware maw config layers and provenance.",
+    });
+  });
+
+  test("show renders merged config JSON", async () => {
+    const logs: string[] = [];
+    const result = await run(["show"], (...parts) => logs.push(parts.map(String).join(" ")));
+
+    const parsed = JSON.parse(logs.join("\n"));
+    expect(result).toEqual({ ok: true, output: logs.join("\n") });
+    expect(loadCallCount).toBe(1);
+    expect(parsed).toMatchObject(loadedConfig.config);
+    expect(lastLoadOptions).toEqual({ cwd: process.cwd() });
+  });
+
+  test("sources with --json returns structured rows + warnings", async () => {
+    const logs: string[] = [];
+    const result = await run(["sources", "--json"], (...parts) => logs.push(parts.map(String).join(" ")));
+
+    const payload = JSON.parse(logs.join("\n"));
+    expect(result.ok).toBe(true);
+    expect(payload).toEqual({
+      sources: [
+        {
+          weight: 10,
+          scope: "core",
+          local: false,
+          file: "/etc/maw/core.config.json",
+        },
+        {
+          weight: 0,
+          scope: "project",
+          local: true,
+          file: "/cwd/maw.config.json",
+        },
+      ],
+      warnings: ["project-level key overridden"],
+    });
+  });
+
+  test("explain returns provenance and final value", async () => {
+    const logs: string[] = [];
+    const result = await run(
+      ["explain", "teams.default", "--json"],
+      (...parts) => logs.push(parts.map(String).join(" ")),
+    );
+
+    const payload = JSON.parse(logs.join("\n"));
+    expect(result.ok).toBe(true);
+    expect(payload).toEqual({
+      key: "teams.default",
+      finalValue: ["a", "b"],
+      entries: loadedConfig.provenance["teams.default"],
+    });
+  });
+
+  test("usage path for missing explain key", async () => {
+    const result = await run(["explain"]);
+
+    expect(result).toEqual({
+      ok: false,
+      error: "usage: maw config explain <key> [--json]",
+    });
+  });
+
+  test("bad subcommand returns usage error", async () => {
+    const result = await run(["unknown"]);
+
+    expect(result).toEqual({
+      ok: false,
+      error: "usage: maw config <show|sources|explain <key>> [--json]",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Added standalone coverage for the config plugin in `test/isolated/plugin-config-standalone.test.ts`.
- Confirmed plugin source remains `src/commands/plugins/config/index.ts`.
- Verified `src/commands/plugins/config/index.ts` imports `loadConfigWithProvenance` from local `src/config` (not from `@maw-js/sdk`).
- SDK export check: `packages/sdk/index.ts` and `packages/sdk/index.d.ts` do not currently export `loadConfigWithProvenance`.

## Verification
- Attempted local run: `bun test test/isolated/plugin-config-standalone.test.ts`.
- Result: Bun test runner crashes in this environment with `index out of bounds: the len is 4095 but the index is 4095` before tests execute (runner/runtime issue).
- Additional sanity check executed via direct `bun -e` invocation of the plugin with local config setup.

## Notes
- No SDK export was added in this patch; test is written against current state and includes a note proposing the export as follow-up.
