### PR TITLE
feat(sdk): export loadConfigWithProvenance for config plugin extraction

### DIFF
--- a/packages/sdk/index.d.ts
+++ b/packages/sdk/index.d.ts
@@ -202,6 +202,41 @@ export interface MawConfig {
 /** Read the merged operator config (file + env overrides). */
 export declare function loadConfig(): MawConfig;
 
+/** Source file discovered while building operator config. */
+export interface ConfigSource {
+  path: string;
+  weight: number;
+  isLocal: boolean;
+  scope: string;
+  scopeRank: number;
+  depth: number;
+  mtimeMs: number;
+}
+
+export interface ConfigProvenanceEntry {
+  path: string;
+  scope: string;
+  weight: number;
+  isLocal: boolean;
+  action: string;
+  value: unknown;
+}
+
+/** Config loaded with provenance details and warnings. */
+export interface LoadedConfigWithProvenance {
+  config: MawConfig;
+  sources: ConfigSource[];
+  provenance: Record<string, ConfigProvenanceEntry[]>;
+  warnings: string[];
+}
+
+export interface LoadConfigOptions {
+  cwd?: string;
+}
+
+/** Read merged config plus merge provenance and warnings. */
+export declare function loadConfigWithProvenance(opts?: LoadConfigOptions): LoadedConfigWithProvenance;
+
 /** Look up a named timeout (ms). Throws on unknown key. */
 export declare function cfgTimeout(key: string): number;
 

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -62,6 +62,7 @@ export { parseFlags } from "../../src/cli/parse-args";
 //   buildCommandInDir   — take
 export {
   loadConfig,
+  loadConfigWithProvenance,
   cfgTimeout,
   buildCommand,
   buildCommandInDir,

--- a/test/isolated/sdk-config-export.test.ts
+++ b/test/isolated/sdk-config-export.test.ts
@@ -1,0 +1,33 @@
+/**
+ * sdk-config-export.test.ts
+ *
+ * Verifies `loadConfigWithProvenance` is exported from @maw-js/sdk after
+ * extraction widening.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { loadConfigWithProvenance } from "../../packages/sdk";
+
+const INDEX_DTS = resolve(__dirname, "..", "..", "packages", "sdk", "index.d.ts");
+
+describe("@maw-js/sdk config export surface", () => {
+  test("loadConfigWithProvenance is importable from the package surface", () => {
+    expect(typeof loadConfigWithProvenance).toBe("function");
+  });
+
+  test("index.d.ts declares loadConfigWithProvenance", () => {
+    const dts = readFileSync(INDEX_DTS, "utf8");
+    expect(dts).toMatch(/export interface LoadedConfigWithProvenance/);
+    expect(dts).toMatch(/export interface ConfigSource/);
+    expect(dts).toMatch(/export interface ConfigProvenanceEntry/);
+    expect(dts).toMatch(/export interface LoadConfigOptions/);
+    expect(dts).toMatch(/export declare function loadConfigWithProvenance/);
+  });
+
+  test("index.d.ts remains self-contained (no parent-relative imports)", () => {
+    const dts = readFileSync(INDEX_DTS, "utf8");
+    expect(dts).not.toMatch(/from ["']\.\.{1,2}\//);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `loadConfigWithProvenance` to `@maw-js/sdk` public surface so config plugin can use a package seam.
- Updates:
  - `packages/sdk/index.ts` exports:
    - `loadConfigWithProvenance` from `src/config`
  - `packages/sdk/index.d.ts` declares:
    - `ConfigSource`
    - `ConfigProvenanceEntry`
    - `LoadedConfigWithProvenance`
    - `LoadConfigOptions`
    - `loadConfigWithProvenance`
- Adds standalone coverage `test/isolated/sdk-config-export.test.ts` to assert runtime + declaration exports are present.

## Motivation
This follows from PR #2143, where config plugin extraction showed `loadConfigWithProvenance` was missing from the SDK.
