### PR TITLE
feat: add maw forget oracle cleanup

### DIFF
--- a/src/vendor/mpr-plugins/forget/impl.ts
+++ b/src/vendor/mpr-plugins/forget/impl.ts
@@ -1,0 +1,86 @@
+import { existsSync, readdirSync, readFileSync, unlinkSync } from "fs";
+import { join } from "path";
+import { tmux, listSessions } from "maw-js/sdk";
+import { findWorktrees, resolveOracle } from "maw-js/commands/shared/wake-resolve";
+import { loadFleetEntries, type FleetEntry } from "maw-js/commands/shared/fleet-load";
+import { cmdDone, cmdDoneAll } from "../done/impl";
+import { mawConfigPath, mawStatePath } from "../../../core/xdg";
+
+export interface ForgetOpts { dryRun?: boolean; yes?: boolean; json?: boolean }
+export interface ForgetAction { layer: "worktrees"|"tmux"|"fleet"|"snapshots"|"confirm"; target: string; status: "planned"|"removed"|"skipped"|"failed"; detail?: string }
+export interface ForgetResult { oracle: string; resolved: { repoPath: string; repoName: string; sessionName: string | null }; dryRun: boolean; confirmed: boolean; actions: ForgetAction[] }
+
+const stripOracleSuffix = (name: string) => name.replace(/-oracle$/i, "");
+const stripNumericPrefix = (name: string) => name.replace(/^\d+-/, "");
+function aliasesFor(input: string, repoName: string): Set<string> {
+  const raw = input.trim().toLowerCase(), repo = repoName.trim().toLowerCase(), bare = stripOracleSuffix(repo);
+  return new Set([raw, stripOracleSuffix(raw), repo, bare].filter(Boolean));
+}
+function entryMatches(entry: FleetEntry, aliases: Set<string>): boolean {
+  const candidates = [entry.session.name, stripNumericPrefix(entry.session.name), entry.groupName];
+  for (const win of entry.session.windows || []) {
+    candidates.push(win.name, stripOracleSuffix(win.name));
+    if (win.repo) { const base = win.repo.split("/").pop() || win.repo; candidates.push(base, stripOracleSuffix(base)); }
+  }
+  return candidates.some(c => aliases.has(c.toLowerCase()));
+}
+function resolveFleetEntry(oracle: string, repoName: string): FleetEntry | null {
+  const aliases = aliasesFor(oracle, repoName);
+  const matches = loadFleetEntries().filter(e => entryMatches(e, aliases));
+  if (matches.length > 1) throw new Error(`forget '${oracle}' is ambiguous in fleet: ${matches.map(m => m.session.name).join(", ")}`);
+  return matches[0] ?? null;
+}
+async function resolveSessionName(oracle: string, repoName: string, fleetEntry: FleetEntry | null): Promise<string | null> {
+  const aliases = aliasesFor(oracle, repoName); if (fleetEntry) aliases.add(fleetEntry.session.name.toLowerCase());
+  const sessions = await listSessions().catch(() => [] as any[]);
+  const matches = sessions.filter(s => aliases.has(s.name.toLowerCase()) || aliases.has(stripNumericPrefix(s.name).toLowerCase()));
+  if (matches.length > 1) throw new Error(`forget '${oracle}' is ambiguous in tmux: ${matches.map(s => s.name).join(", ")}`);
+  return matches[0]?.name ?? fleetEntry?.session.name ?? null;
+}
+function snapshotMatches(path: string, aliases: Set<string>, sessionName: string | null): boolean {
+  try { const snap = JSON.parse(readFileSync(path, "utf-8")); return (snap.sessions || []).some((s: any) => {
+    const session = String(s.name || "").toLowerCase();
+    if ((sessionName && session === sessionName.toLowerCase()) || aliases.has(session) || aliases.has(stripNumericPrefix(session))) return true;
+    return (s.windows || []).some((w: any) => { const win = String(w.name || "").toLowerCase(); return aliases.has(win) || aliases.has(stripOracleSuffix(win)); });
+  }); } catch { return false; }
+}
+function matchingSnapshotFiles(oracle: string, repoName: string, sessionName: string | null): string[] {
+  const aliases = aliasesFor(oracle, repoName), out: string[] = [];
+  for (const dir of [...new Set([mawStatePath("snapshots"), mawConfigPath("snapshots")])]) {
+    let files: string[] = []; try { files = readdirSync(dir).filter(f => f.endsWith(".json")); } catch { continue; }
+    for (const file of files) { const path = join(dir, file); if (snapshotMatches(path, aliases, sessionName)) out.push(path); }
+  }
+  return [...new Set(out)].sort();
+}
+async function confirmForget(oracle: string, count: number): Promise<boolean> {
+  if (!process.stdin.isTTY) return false;
+  process.stdout.write(`\nForget ${oracle} and remove ${count} local state item(s)? [y/N] `);
+  return await new Promise<boolean>(resolve => { let buf = ""; const onData = (chunk: Buffer) => { buf += chunk.toString(); if (!buf.includes("\n")) return; process.stdin.removeListener("data", onData); process.stdin.pause(); resolve(buf.split("\n")[0]!.trim().toLowerCase() === "y"); }; process.stdin.resume(); process.stdin.on("data", onData); process.stdin.once("error", () => resolve(false)); process.stdin.once("end", () => resolve(false)); });
+}
+function printPlan(result: ForgetResult): void {
+  console.log(`\x1b[36mforget\x1b[0m ${result.oracle} → ${result.resolved.repoName}`);
+  for (const a of result.actions) console.log(`  \x1b[36m⬡\x1b[0m ${result.dryRun ? "[dry-run] would" : a.status} ${a.layer}: ${a.target}${a.detail ? ` (${a.detail})` : ""}`);
+}
+
+export async function cmdForget(oracle: string, opts: ForgetOpts = {}): Promise<ForgetResult> {
+  const resolved = await resolveOracle(oracle, { quietWorktreeScan: true });
+  const fleetEntry = resolveFleetEntry(oracle, resolved.repoName);
+  const sessionName = await resolveSessionName(oracle, resolved.repoName, fleetEntry);
+  const snapshotFiles = matchingSnapshotFiles(oracle, resolved.repoName, sessionName);
+  const actions: ForgetAction[] = [{ layer: "worktrees", target: resolved.repoPath, status: "planned", detail: "maw done --all + linked worktree sweep" }];
+  if (sessionName) actions.push({ layer: "tmux", target: sessionName, status: "planned", detail: "kill-session" });
+  if (fleetEntry?.path) actions.push({ layer: "fleet", target: fleetEntry.path, status: "planned" });
+  for (const path of snapshotFiles) actions.push({ layer: "snapshots", target: path, status: "planned" });
+  let confirmed = !!opts.yes && !opts.dryRun;
+  const result: ForgetResult = { oracle, resolved: { repoPath: resolved.repoPath, repoName: resolved.repoName, sessionName }, dryRun: !!opts.dryRun || !confirmed, confirmed, actions };
+  if (!opts.json) printPlan(result);
+  if (opts.dryRun) return result;
+  if (!confirmed) { confirmed = await confirmForget(oracle, actions.length); result.confirmed = confirmed; result.dryRun = !confirmed; if (!confirmed) { actions.push({ layer: "confirm", target: oracle, status: "skipped", detail: "not confirmed; no changes made" }); if (!opts.json) console.log("  \x1b[90m○\x1b[0m not confirmed; no changes made"); return result; } }
+  const mark = (layer: ForgetAction["layer"], target: string, status: ForgetAction["status"], detail?: string) => { const a = actions.find(x => x.layer === layer && x.target === target); if (a) { a.status = status; a.detail = detail ?? a.detail; } };
+  try { const originalCwd = process.cwd(); try { process.chdir(resolved.repoPath); const summary = await cmdDoneAll({ oracle, force: true, cleanBranch: true, cwd: resolved.repoPath }); const remaining = await findWorktrees(resolved.parentDir, resolved.repoName); let swept = 0; for (const wt of remaining) { try { await cmdDone(wt.name, { force: true, cleanBranch: true, cwd: resolved.repoPath }); swept++; } catch { /* stale/non-maw worktree: keep going */ } } mark("worktrees", resolved.repoPath, "removed", `done --all processed ${summary.processed.length}; swept ${swept} linked worktree(s)`); } finally { if (process.cwd() !== originalCwd) process.chdir(originalCwd); } } catch (e: any) { mark("worktrees", resolved.repoPath, "failed", e?.message || String(e)); }
+  if (sessionName) { try { await tmux.killSession(sessionName); mark("tmux", sessionName, "removed"); } catch (e: any) { mark("tmux", sessionName, "failed", e?.message || String(e)); } }
+  if (fleetEntry?.path) { try { if (existsSync(fleetEntry.path)) unlinkSync(fleetEntry.path); mark("fleet", fleetEntry.path, "removed"); } catch (e: any) { mark("fleet", fleetEntry.path, "failed", e?.message || String(e)); } }
+  for (const path of snapshotFiles) { try { if (existsSync(path)) unlinkSync(path); mark("snapshots", path, "removed"); } catch (e: any) { mark("snapshots", path, "failed", e?.message || String(e)); } }
+  if (!opts.json) console.log(`  \x1b[32m✓\x1b[0m forget removed ${actions.filter(a => a.status === "removed").length} item(s)${actions.some(a => a.status === "failed") ? ", failures present" : ""}`);
+  return result;
+}

--- a/src/vendor/mpr-plugins/forget/index.ts
+++ b/src/vendor/mpr-plugins/forget/index.ts
@@ -1,0 +1,31 @@
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import { parseFlags } from "maw-js/cli/parse-args";
+import { cmdForget } from "./impl";
+
+export const command = { name: "forget", description: "Exhaustively remove stale local oracle runtime state." };
+const USAGE = "usage: maw forget <oracle> [--dry-run] [--yes|--force] [--json]";
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log, origError = console.error;
+  console.log = (...a: any[]) => ctx.writer ? ctx.writer(...a) : logs.push(a.map(String).join(" "));
+  console.error = (...a: any[]) => ctx.writer ? ctx.writer(...a) : logs.push(a.map(String).join(" "));
+  try {
+    let oracle: string | undefined, dryRun = false, yes = false, json = false;
+    if (ctx.source === "cli") {
+      const flags = parseFlags(ctx.args as string[], { "--dry-run": Boolean, "--yes": Boolean, "-y": "--yes", "--force": Boolean, "--json": Boolean });
+      oracle = flags._[0]; dryRun = !!flags["--dry-run"]; yes = !!(flags["--yes"] || flags["--force"]); json = !!flags["--json"];
+      if (!oracle || oracle === "--help" || oracle === "-h") return { ok: false, error: USAGE };
+      if (flags._.length > 1) return { ok: false, error: `${USAGE}\nunexpected positional args: ${flags._.slice(1).join(" ")}` };
+    } else {
+      const args = ctx.args as Record<string, unknown>;
+      oracle = args.oracle as string | undefined; dryRun = !!(args.dryRun ?? args.dry_run); yes = !!(args.yes ?? args.force); json = !!args.json;
+      if (!oracle) return { ok: false, error: "oracle is required" };
+    }
+    const result = await cmdForget(oracle, { dryRun, yes, json });
+    if (json) console.log(JSON.stringify(result, null, 2));
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally { console.log = origLog; console.error = origError; }
+}

--- a/src/vendor/mpr-plugins/forget/plugin.json
+++ b/src/vendor/mpr-plugins/forget/plugin.json
@@ -1,0 +1,1 @@
+{"name":"forget","version":"0.1.0","entry":"./index.ts","sdk":"^1.0.0","description":"Exhaustively remove stale local oracle runtime state.","author":"Soul-Brews-Studio","cli":{"command":"forget","help":"maw forget <oracle> [--dry-run] [--yes|--force] [--json] — preview or remove tmux, fleet, snapshots, and worktrees"},"weight":50,"license":"MIT","schemaVersion":1}


### PR DESCRIPTION
Closes #2144

Adds a new `maw forget <oracle>` plugin for local exhaustive cleanup:
- previews by default / `--dry-run`
- supports `--yes` / `--force` for non-interactive cleanup
- resolves oracle with wake resolver
- runs `maw done --all` for repo worktrees
- kills matching tmux session
- removes matching fleet JSON
- removes matching snapshot JSON files

Validation:
- `bun build src/vendor/mpr-plugins/forget/index.ts --target=bun --external @eclipse-zenoh/zenoh-ts`

Known gap:
- targeted Bun tests still crash locally with Bun canary panic before assertions in this workspace.