### PR TITLE
fix(done): allow --all to target oracle

### DIFF
--- a/src/vendor/mpr-plugins/done/impl.ts
+++ b/src/vendor/mpr-plugins/done/impl.ts
@@ -28,14 +28,31 @@ export interface DoneAllSummary {
   skipped: string[];
 }
 
+function doneAllSessionStem(name: string): string {
+  return name.toLowerCase().replace(/^\d+-/, "").replace(/-oracle$/i, "");
+}
+
+function doneAllCompactStem(name: string): string {
+  return doneAllSessionStem(name).replace(/[^a-z0-9]/g, "");
+}
+
 async function currentSessionName(sessions: DoneSession[], oracle?: string): Promise<string | null> {
   if (oracle) {
     const candidate = oracle.replace(/-oracle$/i, "").trim();
     if (candidate) {
-      for (const session of sessions) {
-        const stem = session.name.toLowerCase().replace(/^\d+-/, "").replace(/-oracle$/i, "");
-        if (stem === candidate.toLowerCase()) return session.name;
-      }
+      const wanted = candidate.toLowerCase();
+      const exact = sessions.find(session => doneAllSessionStem(session.name) === wanted);
+      if (exact) return exact.name;
+
+      // `maw wake` accepts fuzzy oracle names via resolveOracle. Once that
+      // resolver has produced the canonical repo name, accept the same common
+      // fleet-session spelling variants here (e.g. v3 → arra-oracle-v3-oracle
+      // may have a live session named 33-arraoraclev3). Keep it unique because
+      // done --all is destructive.
+      const compactWanted = wanted.replace(/[^a-z0-9]/g, "");
+      const compactMatches = sessions.filter(session => doneAllCompactStem(session.name) === compactWanted);
+      if (compactMatches.length === 1) return compactMatches[0]!.name;
+      if (compactMatches.length > 1) return null;
     }
   }
 

--- a/src/vendor/mpr-plugins/done/index.ts
+++ b/src/vendor/mpr-plugins/done/index.ts
@@ -33,8 +33,9 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       dryRun = args.includes("--dry-run");
       all = args.includes("--all");
       cleanBranch = args.includes("--clean-branch");
-      if (all && positional.length > 0) {
-        return { ok: false, error: `unexpected positional arg(s) with maw done --all: ${positional.join(" ")}\n  usage: maw done --all [<oracle>] [--force] [--dry-run] [--clean-branch]` };
+      if (all && positional.length > 1) {
+        const ignored = positional.slice(1).join(" ");
+        return { ok: false, error: `unexpected extra positional arg(s) for maw done --all: ${ignored}\n  usage: maw done --all [<oracle>] [--force] [--dry-run] [--clean-branch]` };
       }
       if (!all && positional.length > 1) {
         const ignored = positional.slice(1).join(" ");
@@ -55,7 +56,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     }
 
     if (all) {
-      await cmdDoneAll({ force, dryRun, cleanBranch, oracle: name, cwd: process.cwd() });
+      await cmdDoneAll({ force: Boolean(force), dryRun: Boolean(dryRun), cleanBranch: Boolean(cleanBranch), oracle: name, cwd: process.cwd() });
       return { ok: true, output: logs.join("\n") || undefined };
     }
 
@@ -63,7 +64,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       return { ok: false, error: "usage: maw done <window-name> [--force] [--dry-run] [--clean-branch] or maw done --all [<oracle>] [--force] [--dry-run] [--clean-branch]  (see: maw sleep/kill for non-worktree shutdown)" };
     }
 
-    await cmdDone(name, { force, dryRun, cleanBranch, cwd: process.cwd() });
+    await cmdDone(name, { force: Boolean(force), dryRun: Boolean(dryRun), cleanBranch: Boolean(cleanBranch), cwd: process.cwd() });
     return { ok: true, output: logs.join("\n") || undefined };
   } catch (e: any) {
     return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };

--- a/test/isolated/done-all.test.ts
+++ b/test/isolated/done-all.test.ts
@@ -269,6 +269,40 @@ describe("cmdDoneAll", () => {
     expect(output.join("\n")).toContain("would process 2 non-lead window(s) in work");
   });
 
+
+  test("cmdDoneAll({ oracle }) accepts wake-style fuzzy resolver results for compact fleet sessions", async () => {
+    const workTree = mkdtempSync(join(tmpdir(), "maw-done-all-fuzzy-"));
+    sessions = [
+      {
+        name: "33-arraoraclev3",
+        windows: [
+          { index: 0, name: "lead", active: true },
+          { index: 2, name: "worker", active: false },
+        ],
+      },
+      {
+        name: "other",
+        windows: [
+          { index: 0, name: "lead", active: true },
+          { index: 1, name: "other-worker", active: false },
+        ],
+      },
+    ];
+    tmuxRunFails = true;
+    resolveOracleResult = {
+      repoPath: workTree,
+      repoName: "arra-oracle-v3-oracle",
+      parentDir: join(workTree, ".."),
+    };
+
+    const summary = await cmdDoneAll({ oracle: "v3", force: true });
+
+    expect(summary).toEqual({ sessionName: "33-arraoraclev3", processed: ["worker"], skipped: [] });
+    expect(resolveOracleCalls).toEqual(["v3"]);
+    expect(tmuxCommands).toContain("kill 33-arraoraclev3:worker");
+    expect(tmuxCommands).not.toContain("kill other:other-worker");
+    rmSync(workTree, { recursive: true, force: true });
+  });
   test("cmdDoneAll({ oracle }) resolves oracle, cds internally, and processes that oracle session", async () => {
     const workTree = mkdtempSync(join(tmpdir(), "maw-done-all-oracle-"));
     const previousCwd = process.cwd();

--- a/test/isolated/done-index-coverage.test.ts
+++ b/test/isolated/done-index-coverage.test.ts
@@ -107,9 +107,10 @@ describe("done plugin index wrapper", () => {
     expect(typo.error).toContain("33-arraoraclev3");
     expect(typo.error).toContain("did you mean `maw done --all`");
 
-    const allWithTarget = await donePlugin.default({ source: "cli", args: ["--all", "33-arraoraclev3"] } as InvokeCtx);
-    expect(allWithTarget.ok).toBe(false);
-    expect(allWithTarget.error).toContain("unexpected positional arg(s) with maw done --all");
+    const allWithTooManyTargets = await donePlugin.default({ source: "cli", args: ["--all", "33-arraoraclev3", "extra"] } as InvokeCtx);
+    expect(allWithTooManyTargets.ok).toBe(false);
+    expect(allWithTooManyTargets.error).toContain("unexpected extra positional arg(s) for maw done --all");
+    expect(allWithTooManyTargets.error).toContain("extra");
     expect(doneCalls).toEqual([]);
     expect(doneAllCalls).toEqual([]);
   });


### PR DESCRIPTION
Closes #2147

## Summary
- allow `maw done --all <oracle>` to pass the positional oracle into done-all
- reuse the existing wake resolver path already imported by done-all
- match compact numeric fleet-session spellings only when unique for fuzzy-resolved oracle repos

## Tests
- `bash scripts/test-isolated.sh test/isolated/done-index-coverage.test.ts test/isolated/done-all.test.ts`