### PR TITLE
feat(sdk): export messages plugin helpers

### DIFF
--- a/packages/sdk/index.d.ts
+++ b/packages/sdk/index.d.ts
@@ -52,11 +52,35 @@ export interface FeedEvent {
   timestamp: string;
   oracle: string;
   host: string;
-  event: string;
+  event: FeedEventType;
   project: string;
   sessionId: string;
   message: string;
+  ts: number;
+  data?: unknown;
 }
+
+export type FeedEventType =
+  | "PreToolUse"
+  | "PostToolUse"
+  | "PostToolUseFailure"
+  | "UserPromptSubmit"
+  | "SubagentStart"
+  | "SubagentStop"
+  | "TaskCompleted"
+  | "SessionEnd"
+  | "SessionStart"
+  | "Stop"
+  | "Notification"
+  | "MessageSend"
+  | "MessageDeliver"
+  | "MessageFail"
+  | "WormholeRequest"
+  | "WormholeFail"
+  | "PluginHook"
+  | "PluginFilter"
+  | "PluginLoad"
+  | "PluginError";
 
 export interface PluginInfo {
   name: string;
@@ -441,3 +465,55 @@ export declare function getArtifact(
 
 /** Get the artifact directory path (for agents to write into). */
 export declare function artifactDir(team: string, taskId: string): string;
+
+// --- src/core/xdg ---
+
+export declare function legacyMawPath(...parts: string[]): string;
+export declare function isMawXdgEnabled(): boolean;
+export declare function mawConfigDir(): string;
+export declare function mawRuntimeHomeDir(): string;
+export declare function mawDataDir(): string;
+export declare function mawStateDir(): string;
+export declare function mawCacheDir(): string;
+export declare function mawConfigPath(...parts: string[]): string;
+export declare function mawDataPath(...parts: string[]): string;
+export declare function mawMessageLogPath(): string;
+export declare function legacyOracleMessageLogPath(): string;
+export declare function mawMessageLogCandidatePaths(): string[];
+export declare function legacyOracleHookConfigPath(): string;
+export declare function mawHookConfigCandidatePaths(): string[];
+export declare function mawStatePath(...parts: string[]): string;
+export declare function mawCachePath(...parts: string[]): string;
+
+// --- src/lib/message-events ---
+
+export type MessageDirection = "outbound" | "inbound" | "forwarded";
+export type MessageState = "queued" | "delivered" | "failed";
+export type MessageChannel = "hey" | "send" | "api-send" | "plugin";
+export type MessageRoute = "local" | "peer" | "discovery" | "self-node" | "team" | string;
+
+export interface MessageLifecycleData {
+  id: string;
+  ts: string;
+  direction: MessageDirection;
+  state: MessageState;
+  channel: MessageChannel;
+  route: MessageRoute;
+  from: string;
+  to: string;
+  target?: string;
+  peerUrl?: string;
+  text: string;
+  error?: string;
+  lastLine?: string;
+  signed?: boolean;
+}
+
+export type MessageLifecycleInput = Omit<MessageLifecycleData, "id" | "ts"> & {
+  id?: string;
+  ts?: string | number | Date;
+};
+
+export declare function buildMessageLifecycleData(input: MessageLifecycleInput): MessageLifecycleData;
+export declare function buildMessageLifecycleFeedEvent(input: MessageLifecycleInput): FeedEvent;
+export declare function isMessageLifecycleData(value: unknown): value is MessageLifecycleData;

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -27,7 +27,6 @@ export type {
   Peer,
   FederationStatus,
   Session,
-  FeedEvent,
   PluginInfo,
 } from "../../src/core/runtime/sdk";
 
@@ -106,6 +105,45 @@ export type { ConsentAction } from "../../src/core/consent";
 // Hyperlink helper for OSC-8-capable terminals.
 //   tlink — check
 export { tlink } from "../../src/core/util/terminal";
+
+// ─── src/core/xdg ───────────────────────────────────────────────────────────
+// XDG-aware maw path helpers. Used by messages extraction and other plugins
+// that need stable state/data/config/cache paths without reaching into core.
+export {
+  legacyMawPath,
+  isMawXdgEnabled,
+  mawConfigDir,
+  mawRuntimeHomeDir,
+  mawDataDir,
+  mawStateDir,
+  mawCacheDir,
+  mawConfigPath,
+  mawDataPath,
+  mawMessageLogPath,
+  legacyOracleMessageLogPath,
+  mawMessageLogCandidatePaths,
+  legacyOracleHookConfigPath,
+  mawHookConfigCandidatePaths,
+  mawStatePath,
+  mawCachePath,
+} from "../../src/core/xdg";
+
+// ─── src/lib/message-events ─────────────────────────────────────────────────
+// Message lifecycle helpers + types used by the messages plugin ledger.
+export type { FeedEvent, FeedEventType } from "../../src/lib/feed";
+export {
+  buildMessageLifecycleData,
+  buildMessageLifecycleFeedEvent,
+  isMessageLifecycleData,
+} from "../../src/lib/message-events";
+export type {
+  MessageChannel,
+  MessageDirection,
+  MessageLifecycleData,
+  MessageLifecycleInput,
+  MessageRoute,
+  MessageState,
+} from "../../src/lib/message-events";
 
 // ─── src/lib/profile-loader ──────────────────────────────────────────────────
 // Active-profile pointer + JSON profile read/write. Used by `profile` plugin.

--- a/src/vendor/mpr-plugins/messages/index.ts
+++ b/src/vendor/mpr-plugins/messages/index.ts
@@ -1,8 +1,6 @@
-import type { FeedEvent } from "maw-js/lib/feed";
-import { isMessageLifecycleData, type MessageDirection, type MessageState } from "maw-js/lib/message-events";
+import { isMessageLifecycleData, mawStatePath, type FeedEvent, type MessageDirection, type MessageState } from "@maw-js/sdk";
 import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { listMessageLedgerEvents, messageLedgerDbPath, recordMessageLedgerEvent, type MessageLedgerQuery } from "./ledger";
-import { mawStatePath } from "../../../core/xdg";
 import { spawn } from "child_process";
 import { closeSync, existsSync, mkdirSync, openSync, readFileSync, unlinkSync, writeFileSync } from "fs";
 import { join } from "path";

--- a/src/vendor/mpr-plugins/messages/ledger.ts
+++ b/src/vendor/mpr-plugins/messages/ledger.ts
@@ -1,8 +1,7 @@
 import { Database } from "bun:sqlite";
 import { copyFileSync, existsSync, mkdirSync } from "fs";
 import { dirname } from "path";
-import type { MessageDirection, MessageLifecycleData, MessageState } from "maw-js/lib/message-events";
-import { mawConfigPath, mawDataPath } from "../../../core/xdg";
+import { mawConfigPath, mawDataPath, type MessageDirection, type MessageLifecycleData, type MessageState } from "@maw-js/sdk";
 
 export interface MessageLedgerQuery {
   limit?: number;

--- a/test/isolated/sdk-messages-export.test.ts
+++ b/test/isolated/sdk-messages-export.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const sdkPath = join(import.meta.dir, "../../packages/sdk/index.ts");
+const dtsPath = join(import.meta.dir, "../../packages/sdk/index.d.ts");
+
+describe("sdk messages helper exports (#2157)", () => {
+  test("runtime SDK exports xdg path helpers and message lifecycle helpers", async () => {
+    const sdk = await import("../../packages/sdk/index");
+
+    expect(typeof sdk.mawStatePath).toBe("function");
+    expect(typeof sdk.mawConfigPath).toBe("function");
+    expect(typeof sdk.mawDataPath).toBe("function");
+    expect(typeof sdk.buildMessageLifecycleData).toBe("function");
+    expect(typeof sdk.buildMessageLifecycleFeedEvent).toBe("function");
+    expect(typeof sdk.isMessageLifecycleData).toBe("function");
+
+    const data = sdk.buildMessageLifecycleData({
+      id: "msg-1",
+      ts: "2026-06-06T00:00:00.000Z",
+      direction: "outbound",
+      state: "delivered",
+      channel: "hey",
+      route: "local",
+      from: "m5:mawjs",
+      to: "m5:oracle",
+      text: "hello",
+    });
+
+    expect(sdk.isMessageLifecycleData(data)).toBe(true);
+    expect(data.id).toBe("msg-1");
+  });
+
+  test("sdk declarations include xdg helpers and message lifecycle types", () => {
+    const source = readFileSync(sdkPath, "utf8");
+    const dts = readFileSync(dtsPath, "utf8");
+
+    for (const symbol of [
+      "mawStatePath",
+      "mawConfigPath",
+      "mawDataPath",
+      "buildMessageLifecycleData",
+      "buildMessageLifecycleFeedEvent",
+      "isMessageLifecycleData",
+      "MessageLifecycleData",
+      "MessageLifecycleInput",
+      "MessageDirection",
+      "MessageState",
+    ]) {
+      expect(source + dts).toContain(symbol);
+    }
+  });
+});


### PR DESCRIPTION
Closes #2157

## Summary
- export XDG path helpers through both `maw-js/sdk` and `@maw-js/sdk` package surfaces
- export message lifecycle helpers/types and `FeedEvent` for messages plugin extraction
- update `messages` plugin imports to consume the SDK facade instead of core/lib paths
- add isolated SDK export coverage

## Validation
- `git diff --check`
- `bun -e` direct import smoke for `maw-js/sdk` and `packages/sdk/index.ts`
- `bun build src/cli.ts --outfile /tmp/maw-build-check --target=bun --minify --external @eclipse-zenoh/zenoh-ts`

Note: full Bun test runs are still blocked locally by the known Bun `index out of bounds: the len is 4095 but the index is 4095` panic.