### PR TITLE
feat: add fleet snapshot rotation policy

### DIFF
--- a/src/commands/plugins/fleet/index.ts
+++ b/src/commands/plugins/fleet/index.ts
@@ -155,10 +155,23 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         }
       }
     } else if (sub === "snapshot") {
-      const { takeSnapshot } = await import("../../../core/fleet/snapshot");
-      const trigger = args[1] || "manual";
-      const path = await takeSnapshot(trigger);
-      console.log(`\x1b[32m📸\x1b[0m snapshot saved: ${path} (trigger: ${trigger})`);
+      const { takeSnapshot, pruneSnapshots } = await import("../../../core/fleet/snapshot");
+      const keepIdx = args.indexOf("--keep-last");
+      const ageIdx = args.indexOf("--max-age");
+      const dryRun = args.includes("--dry-run");
+      const retention = {
+        keepLast: keepIdx >= 0 ? Number(args[keepIdx + 1]) : undefined,
+        maxAgeDays: ageIdx >= 0 ? Number(args[ageIdx + 1]) : undefined,
+        dryRun,
+      };
+      const trigger = args.slice(1).find((arg, idx, arr) => !arg.startsWith("-") && arr[idx - 1] !== "--keep-last" && arr[idx - 1] !== "--max-age") || "manual";
+      if (dryRun) {
+        const summary = pruneSnapshots(retention);
+        console.log(`[36m📸[0m snapshot retention dry-run: would remove ${summary.wouldRemove}, retain ${summary.retained} (keep-last ${summary.policy.keepLast}, max-age ${summary.policy.maxAgeDays}d)`);
+      } else {
+        const path = await takeSnapshot(trigger, retention);
+        console.log(`[32m📸[0m snapshot saved: ${path} (trigger: ${trigger})`);
+      }
     } else if (!sub) {
       const { cmdFleetLs } = await import("../../shared/fleet");
       await cmdFleetLs();

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -303,9 +303,9 @@ function formatWorktreeSessionSummary(summary: WorktreeSessionSummary | undefine
   return `  \x1b[90m${summary.status} · ${messages} · last ${relativeAge(summary.lastActivityAt)}\x1b[0m`;
 }
 
-async function recordWakeSnapshot(): Promise<void> {
+async function recordWakeSnapshot(opts: Pick<WakeOptions, "snapshotRetention"> = {}): Promise<void> {
   try {
-    await takeSnapshot("wake");
+    await takeSnapshot("wake", opts.snapshotRetention);
   } catch {
     // Snapshotting is recovery metadata. A transient tmux/config read failure
     // must not turn an otherwise-successful wake into a failed wake.
@@ -363,6 +363,8 @@ export interface WakeOptions {
   engine?: string;
   /** Parent session to expose to newly spawned agents (#1925). */
   parentSessionId?: string;
+  /** Fleet snapshot retention override for this wake invocation (#2146). */
+  snapshotRetention?: { keepLast?: number; maxAgeDays?: number };
   /** Deterministic child session id to expose to newly spawned agents (#1925). */
   sessionId?: string;
   fromSnapshot?: boolean;
@@ -820,7 +822,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
     if (liveAttachSession) {
       console.log(`\x1b[36m→\x1b[0m live tmux session: ${liveAttachSession}`);
       await wakeSession.attachToSession(liveAttachSession);
-      await recordWakeSnapshot();
+      await recordWakeSnapshot(opts);
       const attachWindow = preResolvedFleetSession?.windowName || `${oracle}-oracle`;
       return `${liveAttachSession}:${attachWindow}`;
     }
@@ -835,7 +837,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
     }
     await maybeSplit(existingSessionBringTarget, opts);
     await maybeOpenWindow(existingSessionBringTarget, opts);
-    await recordWakeSnapshot();
+    await recordWakeSnapshot(opts);
     return existingSessionBringTarget;
   }
 
@@ -847,7 +849,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
       return existingWindowBringTarget;
     }
     await maybeSplit(existingWindowBringTarget, opts);
-    await recordWakeSnapshot();
+    await recordWakeSnapshot(opts);
     return existingWindowBringTarget;
   }
 
@@ -1290,7 +1292,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
         if (opts.attach) await wakeSession.attachToSession(session);
         await maybeSplit(target, opts);
         await maybeOpenWindow(target, opts);
-        await recordWakeSnapshot();
+        await recordWakeSnapshot(opts);
         return target;
       }
       // Check if agent is actually alive in the pane
@@ -1308,7 +1310,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
         }
         await maybeSplit(target, opts);
         await maybeOpenWindow(target, opts);
-        await recordWakeSnapshot();
+        await recordWakeSnapshot(opts);
         return target;
       }
 
@@ -1324,7 +1326,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
         }
         await maybeSplit(target, opts);
         await maybeOpenWindow(target, opts);
-        await recordWakeSnapshot();
+        await recordWakeSnapshot(opts);
         return target;
       }
 
@@ -1347,7 +1349,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
       }
       await maybeSplit(target, opts);
       await maybeOpenWindow(target, opts);
-      await recordWakeSnapshot();
+      await recordWakeSnapshot(opts);
       return target;
     }
 
@@ -1375,6 +1377,6 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
   await maybeSplit(`${session}:${windowName}`, opts);
   await maybeOpenWindow(`${session}:${windowName}`, opts);
 
-  await recordWakeSnapshot();
+  await recordWakeSnapshot(opts);
   return `${session}:${windowName}`;
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -41,6 +41,14 @@ export interface MawTimeouts {
   wsIdleSec?: number;
 }
 
+
+export interface MawSnapshotRetention {
+  /** Keep at least the newest N snapshot files. */
+  keepLast?: number;
+  /** Remove snapshots older than D days. */
+  maxAgeDays?: number;
+}
+
 export interface MawLimits {
   feedMax?: number;
   feedDefault?: number;
@@ -199,6 +207,8 @@ export interface MawConfig {
   pluginSources?: string[];
   /** Plugin names to disable (skip during scanning and execution) */
   disabledPlugins?: string[];
+  /** Fleet snapshot retention policy (#2146). */
+  snapshotRetention?: MawSnapshotRetention;
   /** One-shot config migrations already applied. */
   migrations?: Record<string, boolean>;
 }

--- a/src/core/fleet/snapshot.ts
+++ b/src/core/fleet/snapshot.ts
@@ -15,10 +15,10 @@
  *   maw fleet restore            — show latest snapshot
  *   maw fleet restore <timestamp> — show specific snapshot
  *
- * Keeps last 48 snapshots (prunes oldest on write).
+ * Applies retention on write: keep newest snapshots and prune old files.
  */
 
-import { mkdirSync, readdirSync, readFileSync, writeFileSync, unlinkSync } from "fs";
+import { mkdirSync, readdirSync, readFileSync, writeFileSync, unlinkSync, statSync } from "fs";
 import { join } from "path";
 import { mawConfigPath, mawStatePath } from "../xdg";
 import { listSessions } from "../transport/ssh";
@@ -41,7 +41,8 @@ function candidateSnapshotDirs(): string[] {
 export const SNAPSHOT_DIR = snapshotDir();
 mkdirSync(SNAPSHOT_DIR, { recursive: true });
 
-const MAX_SNAPSHOTS = 720; // ~1 month at 1 snapshot/hour
+const DEFAULT_KEEP_LAST = 240;
+const DEFAULT_MAX_AGE_DAYS = 14;
 
 export interface SnapshotWindow {
   name: string;
@@ -60,8 +61,43 @@ export interface Snapshot {
   sessions: SnapshotSession[];
 }
 
+export interface SnapshotRetentionPolicy {
+  keepLast?: number;
+  maxAgeDays?: number;
+  dryRun?: boolean;
+  now?: Date;
+}
+
+export interface SnapshotRetentionSummary {
+  retained: number;
+  removed: number;
+  wouldRemove: number;
+  policy: { keepLast: number; maxAgeDays: number };
+  removedFiles: string[];
+}
+
+function positiveInt(value: unknown): number | null {
+  const n = typeof value === "number" ? value : typeof value === "string" && value.trim() ? Number(value) : NaN;
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : null;
+}
+
+export function resolveSnapshotRetentionPolicy(policy: SnapshotRetentionPolicy = {}): { keepLast: number; maxAgeDays: number } {
+  const config = (() => {
+    try { return loadConfig().snapshotRetention || {}; } catch { return {}; }
+  })();
+  const keepLast = positiveInt(policy.keepLast)
+    ?? positiveInt(process.env.MAW_SNAPSHOT_KEEP_LAST)
+    ?? positiveInt((config as any).keepLast)
+    ?? DEFAULT_KEEP_LAST;
+  const maxAgeDays = positiveInt(policy.maxAgeDays)
+    ?? positiveInt(process.env.MAW_SNAPSHOT_MAX_AGE_DAYS)
+    ?? positiveInt((config as any).maxAgeDays)
+    ?? DEFAULT_MAX_AGE_DAYS;
+  return { keepLast, maxAgeDays };
+}
+
 /** Take a snapshot of all current tmux sessions */
-export async function takeSnapshot(trigger: string): Promise<string> {
+export async function takeSnapshot(trigger: string, retentionPolicy: SnapshotRetentionPolicy = {}): Promise<string> {
   const sessions = await listSessions();
 
   const config = loadConfig();
@@ -87,7 +123,7 @@ export async function takeSnapshot(trigger: string): Promise<string> {
   writeFileSync(filepath, JSON.stringify(snapshot, null, 2) + "\n");
 
   // Prune old snapshots
-  pruneSnapshots();
+  pruneSnapshots(retentionPolicy);
 
   return filepath;
 }
@@ -156,14 +192,49 @@ export function latestSnapshot(): Snapshot | null {
   }
 }
 
-/** Prune old snapshots, keep MAX_SNAPSHOTS newest */
-function pruneSnapshots() {
+function snapshotTimeMs(dir: string, file: string): number {
+  try {
+    const data: Snapshot = JSON.parse(readFileSync(join(dir, file), "utf-8"));
+    const parsed = Date.parse(data.timestamp);
+    if (Number.isFinite(parsed)) return parsed;
+  } catch { /* fall back to filename/stat */ }
+
+  const match = file.match(/^(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})/);
+  if (match) {
+    const [, y, mo, d, h, mi, se] = match;
+    const parsed = new Date(Number(y), Number(mo) - 1, Number(d), Number(h), Number(mi), Number(se)).getTime();
+    if (Number.isFinite(parsed)) return parsed;
+  }
+
+  try { return statSync(join(dir, file)).mtimeMs; } catch { return 0; }
+}
+
+/** Prune snapshots by count and age. Defaults prevent unbounded growth (#2146). */
+export function pruneSnapshots(policy: SnapshotRetentionPolicy = {}): SnapshotRetentionSummary {
+  const resolved = resolveSnapshotRetentionPolicy(policy);
+  const nowMs = (policy.now ?? new Date()).getTime();
+  const maxAgeMs = resolved.maxAgeDays * 24 * 60 * 60 * 1000;
   const files = readdirSync(SNAPSHOT_DIR)
     .filter(f => f.endsWith(".json"))
-    .sort();
+    .map(file => ({ file, timeMs: snapshotTimeMs(SNAPSHOT_DIR, file) }))
+    .sort((a, b) => b.timeMs - a.timeMs || b.file.localeCompare(a.file));
 
-  while (files.length > MAX_SNAPSHOTS) {
-    const oldest = files.shift()!;
-    try { unlinkSync(join(SNAPSHOT_DIR, oldest)); } catch {}
+  const toRemove = files.filter((entry, index) => {
+    if (index >= resolved.keepLast) return true;
+    return Number.isFinite(entry.timeMs) && nowMs - entry.timeMs > maxAgeMs;
+  });
+
+  if (!policy.dryRun) {
+    for (const { file } of toRemove) {
+      try { unlinkSync(join(SNAPSHOT_DIR, file)); } catch {}
+    }
   }
+
+  return {
+    retained: files.length - toRemove.length,
+    removed: policy.dryRun ? 0 : toRemove.length,
+    wouldRemove: policy.dryRun ? toRemove.length : 0,
+    policy: resolved,
+    removedFiles: toRemove.map(f => f.file),
+  };
 }

--- a/src/vendor/mpr-plugins/wake/index.ts
+++ b/src/vendor/mpr-plugins/wake/index.ts
@@ -32,7 +32,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       if (!args[0]) {
         return {
           ok: false,
-          error: "usage: maw wake <oracle|org/repo|URL> [task] [--task \"<prompt>\"] [--wt <name>] [--layout nested|legacy] [--fresh|--new] [--pick] [--name <s>] [--attach] [--issue N] [--pr N] [--repo org/name] [--list] [--dry-run] [--from-snapshot|--snapshot <id>] [--main|--solo|--no-rehydrate] [--all-local] [--peer <alias>]\n       maw wake all [--kill]\n       --layout selects new worktree layout: nested (default repo/agents/N-X) or legacy (.wt-N-X)\n       --list previews worktrees only; no tmux session/window changes\n       --dry-run previews session/worktree rehydrate actions; --from-snapshot previews/restores missing snapshot windows; --main skips worktree rehydrate\n       --new is an alias for --fresh: force a new numbered worktree slot; --pick opens the reusable picker; --name creates/reuses a stable named worktree",
+          error: "usage: maw wake <oracle|org/repo|URL> [task] [--task \"<prompt>\"] [--wt <name>] [--layout nested|legacy] [--fresh|--new] [--pick] [--name <s>] [--attach] [--issue N] [--pr N] [--repo org/name] [--list] [--dry-run] [--from-snapshot|--snapshot <id>] [--keep-last N] [--max-age D] [--main|--solo|--no-rehydrate] [--all-local] [--peer <alias>]\n       maw wake all [--kill]\n       --layout selects new worktree layout: nested (default repo/agents/N-X) or legacy (.wt-N-X)\n       --list previews worktrees only; no tmux session/window changes\n       --dry-run previews session/worktree rehydrate actions; --from-snapshot previews/restores missing snapshot windows; --main skips worktree rehydrate\n       --new is an alias for --fresh: force a new numbered worktree slot; --pick opens the reusable picker; --name creates/reuses a stable named worktree",
         };
       }
 
@@ -53,6 +53,8 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         "--dry-run": Boolean,
         "--from-snapshot": Boolean,
         "--snapshot": String,
+        "--keep-last": Number,
+        "--max-age": Number,
         "--main": Boolean, "--solo": "--main", "--no-rehydrate": "--main",
         "--split": Boolean,
         "--all-local": Boolean,
@@ -72,6 +74,8 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         dryRun?: boolean; noRehydrate?: boolean;
         split?: boolean; urlRepoName?: string; allLocal?: boolean;
         fromSnapshot?: boolean; snapshotId?: string;
+      snapshotRetention?: { keepLast?: number; maxAgeDays?: number };
+        snapshotRetention?: { keepLast?: number; maxAgeDays?: number };
         layout?: "nested" | "legacy";
         parentSessionId?: string; sessionId?: string;
       } = {};
@@ -107,6 +111,11 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       if (flags["--snapshot"]) {
         wakeOpts.snapshotId = flags["--snapshot"];
         wakeOpts.fromSnapshot = true;
+      }
+      if (flags["--keep-last"] || flags["--max-age"]) {
+        wakeOpts.snapshotRetention = {};
+        if (flags["--keep-last"]) wakeOpts.snapshotRetention.keepLast = flags["--keep-last"];
+        if (flags["--max-age"]) wakeOpts.snapshotRetention.maxAgeDays = flags["--max-age"];
       }
       if (flags["--main"]) wakeOpts.noRehydrate = true;
       if (flags["--split"]) wakeOpts.split = true;
@@ -173,6 +182,12 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     if (typeof body.snapshot === "string") {
       wakeOpts.snapshotId = body.snapshot;
       wakeOpts.fromSnapshot = true;
+    }
+    if (typeof body.keepLast === "number" || typeof body.maxAge === "number" || typeof body.maxAgeDays === "number") {
+      wakeOpts.snapshotRetention = {};
+      if (typeof body.keepLast === "number") wakeOpts.snapshotRetention.keepLast = body.keepLast;
+      const maxAge = typeof body.maxAgeDays === "number" ? body.maxAgeDays : body.maxAge;
+      if (typeof maxAge === "number") wakeOpts.snapshotRetention.maxAgeDays = maxAge;
     }
     if (typeof body.parentSessionId === "string") wakeOpts.parentSessionId = body.parentSessionId;
     if (typeof body.parent === "string") wakeOpts.parentSessionId = body.parent;

--- a/test/isolated/snapshot-rotation-policy.test.ts
+++ b/test/isolated/snapshot-rotation-policy.test.ts
@@ -1,0 +1,65 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const SANDBOX = mkdtempSync(join(tmpdir(), "maw-snapshot-rotation-"));
+const OLD_MAW_HOME = process.env.MAW_HOME;
+process.env.MAW_HOME = SANDBOX;
+process.env.MAW_TEST_MODE = "1";
+
+const snapshot = await import("../../src/core/fleet/snapshot.ts?snapshot-rotation-policy");
+const SNAP_DIR = snapshot.SNAPSHOT_DIR;
+
+function resetSnapshots() {
+  rmSync(SNAP_DIR, { recursive: true, force: true });
+  mkdirSync(SNAP_DIR, { recursive: true });
+  delete process.env.MAW_SNAPSHOT_KEEP_LAST;
+  delete process.env.MAW_SNAPSHOT_MAX_AGE_DAYS;
+}
+
+function writeSnapshot(file: string, timestamp: string) {
+  writeFileSync(join(SNAP_DIR, file), JSON.stringify({ timestamp, trigger: "manual", sessions: [] }, null, 2));
+}
+
+function files() {
+  return readdirSync(SNAP_DIR).filter(f => f.endsWith(".json")).sort();
+}
+
+beforeEach(resetSnapshots);
+
+afterAll(() => {
+  if (OLD_MAW_HOME === undefined) delete process.env.MAW_HOME;
+  else process.env.MAW_HOME = OLD_MAW_HOME;
+  rmSync(SANDBOX, { recursive: true, force: true });
+});
+
+describe("snapshot rotation policy (#2146)", () => {
+  test("pruneSnapshots applies --keep-last style retention", () => {
+    writeSnapshot("20260101-000000.json", "2026-01-01T00:00:00.000Z");
+    writeSnapshot("20260102-000000.json", "2026-01-02T00:00:00.000Z");
+    writeSnapshot("20260103-000000.json", "2026-01-03T00:00:00.000Z");
+
+    const summary = snapshot.pruneSnapshots({ keepLast: 2, maxAgeDays: 3650, now: new Date("2026-01-04T00:00:00.000Z") });
+
+    expect(summary).toMatchObject({ removed: 1, wouldRemove: 0, retained: 2, policy: { keepLast: 2, maxAgeDays: 3650 } });
+    expect(files()).toEqual(["20260102-000000.json", "20260103-000000.json"]);
+  });
+
+  test("pruneSnapshots supports dry-run and max-age without deleting files", () => {
+    writeSnapshot("20260101-000000.json", "2026-01-01T00:00:00.000Z");
+    writeSnapshot("20260110-000000.json", "2026-01-10T00:00:00.000Z");
+
+    const summary = snapshot.pruneSnapshots({ keepLast: 10, maxAgeDays: 5, dryRun: true, now: new Date("2026-01-20T00:00:00.000Z") });
+
+    expect(summary).toMatchObject({ removed: 0, wouldRemove: 2, retained: 0, policy: { keepLast: 10, maxAgeDays: 5 } });
+    expect(files()).toEqual(["20260101-000000.json", "20260110-000000.json"]);
+  });
+
+  test("env provides central defaults and explicit flags win", () => {
+    process.env.MAW_SNAPSHOT_KEEP_LAST = "5";
+    process.env.MAW_SNAPSHOT_MAX_AGE_DAYS = "6";
+    expect(snapshot.resolveSnapshotRetentionPolicy()).toEqual({ keepLast: 5, maxAgeDays: 6 });
+    expect(snapshot.resolveSnapshotRetentionPolicy({ keepLast: 2, maxAgeDays: 3 })).toEqual({ keepLast: 2, maxAgeDays: 3 });
+  });
+});


### PR DESCRIPTION
Closes #2146\n\n## Summary\n- adds bounded snapshot retention defaults (keep-last + max-age) in snapshot save path\n- wires wake CLI/API overrides: --keep-last N / --max-age D\n- adds manual snapshot retention dry-run via fleet snapshot --dry-run\n- adds isolated retention tests\n\n## Verification\n- bun run build\n- bun test test/isolated/snapshot-rotation-policy.test.ts