### PR TITLE
feat(sdk): export channel-loader for channel extraction

### DIFF
--- a/packages/sdk/index.d.ts
+++ b/packages/sdk/index.d.ts
@@ -517,3 +517,27 @@ export type MessageLifecycleInput = Omit<MessageLifecycleData, "id" | "ts"> & {
 export declare function buildMessageLifecycleData(input: MessageLifecycleInput): MessageLifecycleData;
 export declare function buildMessageLifecycleFeedEvent(input: MessageLifecycleInput): FeedEvent;
 export declare function isMessageLifecycleData(value: unknown): value is MessageLifecycleData;
+
+// --- src/commands/shared/channel-loader ---
+
+export interface ChannelPlugin {
+  id: string;
+  env?: Record<string, string>;
+}
+
+export interface OracleChannelConfig {
+  plugins: ChannelPlugin[];
+  token_source?: string;
+  permissionMode?: "skip" | "relay";
+}
+
+export declare function loadOracleChannels(oracleStem: string): OracleChannelConfig | null;
+export declare function saveOracleChannels(oracleStem: string, config: OracleChannelConfig): void;
+export declare function listAllOracleChannels(): Array<{ oracle: string; plugins: ChannelPlugin[] }>;
+export declare function loadRepoChannels(repoPath: string): OracleChannelConfig | null;
+export declare function saveRepoChannels(repoPath: string, config: OracleChannelConfig): void;
+export declare function getChannelEnv(
+  oracleStem: string,
+  fleetEnvOverride?: Record<string, string>,
+  repoPath?: string,
+): Record<string, string>;

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -175,3 +175,16 @@ export {
   artifactDir,
 } from "../../src/lib/artifacts";
 export type { ArtifactMeta, ArtifactSummary } from "../../src/lib/artifacts";
+
+// ─── src/commands/shared/channel-loader ─────────────────────────────────────
+// Channel config loader API for extracted channel plugins. Wake/build-command
+// still import the source module directly; this is a pure SDK barrel export.
+export {
+  loadOracleChannels,
+  saveOracleChannels,
+  listAllOracleChannels,
+  loadRepoChannels,
+  saveRepoChannels,
+  getChannelEnv,
+} from "../../src/commands/shared/channel-loader";
+export type { ChannelPlugin, OracleChannelConfig } from "../../src/commands/shared/channel-loader";

--- a/src/commands/plugins/channel/index.ts
+++ b/src/commands/plugins/channel/index.ts
@@ -3,7 +3,7 @@ import {
   loadOracleChannels, saveOracleChannels, listAllOracleChannels,
   loadRepoChannels, saveRepoChannels,
   type OracleChannelConfig, type ChannelPlugin,
-} from "../../shared/channel-loader";
+} from "../../../sdk";
 import { resolve } from "path";
 
 interface GitChannelPlugin extends ChannelPlugin {
@@ -254,7 +254,7 @@ github: prefix → delegates to setup wizard`,
         return { ok: false, error: "no channels" };
       }
       console.log(`  \x1b[36;1mChannel Test: ${target}\x1b[0m\n`);
-      const { getChannelEnv } = await import("../../shared/channel-loader");
+      const { getChannelEnv } = await import("../../../sdk");
       const env = getChannelEnv(target);
       for (const p of config.plugins) {
         const checks: string[] = [];

--- a/src/commands/plugins/channel/setup.ts
+++ b/src/commands/plugins/channel/setup.ts
@@ -5,7 +5,7 @@ import { execSync } from "child_process";
 import {
   loadOracleChannels, saveOracleChannels,
   type ChannelPlugin,
-} from "../../shared/channel-loader";
+} from "../../../sdk";
 
 const CHANNELS_BASE = join(homedir(), ".claude", "channels");
 const PLUGINS_CACHE = join(homedir(), ".claude/plugins/cache/claude-plugins-official");

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -63,6 +63,15 @@ export type {
 } from "../core/resolve";
 export { findWindow } from "../core/runtime/find-window";
 export type { Session, Window } from "../core/runtime/find-window";
+export {
+  loadOracleChannels,
+  saveOracleChannels,
+  listAllOracleChannels,
+  loadRepoChannels,
+  saveRepoChannels,
+  getChannelEnv,
+} from "../commands/shared/channel-loader";
+export type { ChannelPlugin, OracleChannelConfig } from "../commands/shared/channel-loader";
 
 // ─── Runtime ─────────────────────────────────────────────────────────────────
 

--- a/test/sdk-phase2-exports.test.ts
+++ b/test/sdk-phase2-exports.test.ts
@@ -71,6 +71,15 @@ describe("@maw-js/sdk Phase 2 widening", () => {
     expect(typeof sdk.artifactDir).toBe("function");
   });
 
+  test("re-exports channel-loader helpers", () => {
+    expect(typeof sdk.loadOracleChannels).toBe("function");
+    expect(typeof sdk.saveOracleChannels).toBe("function");
+    expect(typeof sdk.listAllOracleChannels).toBe("function");
+    expect(typeof sdk.loadRepoChannels).toBe("function");
+    expect(typeof sdk.saveRepoChannels).toBe("function");
+    expect(typeof sdk.getChannelEnv).toBe("function");
+  });
+
   // Behavior smoke: pure functions are safe to invoke without filesystem state.
   test("normalizeTarget strips trailing /.git/", () => {
     expect(sdk.normalizeTarget("foo/.git/")).toBe("foo");


### PR DESCRIPTION
Closes #2158

Exports channel-loader helpers through the SDK surfaces for channel plugin extraction:
- loadOracleChannels / saveOracleChannels / listAllOracleChannels
- loadRepoChannels / saveRepoChannels
- getChannelEnv
- ChannelPlugin / OracleChannelConfig types

Also updates channel plugin imports to use the SDK barrel while leaving wake/build-command source imports untouched.

Validation:
- bun test test/sdk-phase2-exports.test.ts test/isolated/sdk-config-export.test.ts
- bun build src/commands/plugins/channel/index.ts --target=bun --external @eclipse-zenoh/zenoh-ts