### PR TITLE
Bound maw serve memory retention

### DIFF
--- a/src/core/agent-status.ts
+++ b/src/core/agent-status.ts
@@ -94,6 +94,19 @@ export class AgentStatusStore {
     this.store.delete(oracle);
   }
 
+  /** Prune terminal/stale statuses so long-lived maw serve processes do not retain old oracle names forever. */
+  prune(maxAge = 24 * 60 * 60_000): number {
+    const cutoff = Date.now() - maxAge;
+    let removed = 0;
+    for (const [oracle, entry] of this.store) {
+      if (entry.updatedAt >= cutoff) continue;
+      if (entry.status === "busy" || entry.status === "ready") continue;
+      this.remove(oracle);
+      removed++;
+    }
+    return removed;
+  }
+
   private clearTimer(oracle: string) {
     const t = this.timers.get(oracle);
     if (t) { clearTimeout(t); this.timers.delete(oracle); }

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -27,6 +27,9 @@ import { mawDataPath } from "./xdg";
 import { UserError } from "./util/user-error";
 import { startDispatchEngine } from "./dispatch-engine";
 import { sendKeys } from "./transport/ssh";
+import { messageQueue } from "./message-queue";
+import { requestReplyStore } from "./request-reply";
+import { agentStatusStore } from "./agent-status";
 
 // --- Version info (computed once at startup) ---
 
@@ -337,6 +340,19 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
       .catch((err) => console.error("[pty-sweep] failed:", err));
   }, cfgInterval("ptySweep"));
   (ptySweepTimer as { unref?: () => void }).unref?.();
+
+  // #2165: maw serve is a multi-day process; keep in-memory queues/request
+  // reply records/status cache bounded. The stores already expose pruning for
+  // completed messages and expired request/reply entries, but serve never
+  // called them, so active federation traffic could retain old objects until
+  // process restart. Pending queues are preserved; only completed/expired/stale
+  // terminal state is removed.
+  const memoryMaintenanceTimer = setInterval(() => {
+    try { messageQueue.prune(); } catch { /* best effort */ }
+    try { requestReplyStore.prune(); } catch { /* best effort */ }
+    try { agentStatusStore.prune(); } catch { /* best effort */ }
+  }, 60_000);
+  (memoryMaintenanceTimer as { unref?: () => void }).unref?.();
 
   const bindNote = reason ? ` (${reason})` : "";
   console.log(`maw ${VERSION} serve → ${HTTP_URL} (${WS_URL}) [${hostname}]${bindNote}`);

--- a/test/isolated/serve-memory-retention-2165.test.ts
+++ b/test/isolated/serve-memory-retention-2165.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+
+import { AgentStatusStore } from "../../src/core/agent-status";
+import { MessageQueue } from "../../src/core/message-queue";
+import { RequestReplyStore } from "../../src/core/request-reply";
+
+describe("serve memory retention pruning (#2165)", () => {
+  test("message queue prune removes completed entries while preserving pending", () => {
+    const queue = new MessageQueue();
+    const delivered = queue.enqueue({ from: "a", to: "b", target: "sess:1", message: "done" });
+    const pending = queue.enqueue({ from: "a", to: "b", target: "sess:1", message: "wait" });
+    queue.markDelivered(delivered.id);
+
+    queue.prune(0);
+
+    expect(queue.getAll().map((m) => m.id)).toEqual([pending.id]);
+  });
+
+  test("request/reply prune drops entries older than two ttl windows", () => {
+    const store = new RequestReplyStore();
+    const entry = store.create({ from: "a", to: "b", target: "b", message: "question" });
+    entry.createdAt = Date.now() - 10_000;
+
+    store.prune(1_000);
+
+    expect(store.get(entry.correlationId)).toBeUndefined();
+  });
+
+  test("agent status prune evicts stale idle/offline entries but keeps live busy entries", () => {
+    const store = new AgentStatusStore();
+    store.report("old-idle", "idle");
+    store.report("live-busy", "busy");
+    const oldIdle = store.get("old-idle")!;
+    const busy = store.get("live-busy")!;
+    oldIdle.updatedAt = Date.now() - 10_000;
+    busy.updatedAt = Date.now() - 10_000;
+
+    expect(store.prune(1_000)).toBe(1);
+
+    expect(store.get("old-idle")).toBeUndefined();
+    expect(store.get("live-busy")?.status).toBe("busy");
+    store.remove("live-busy");
+  });
+});


### PR DESCRIPTION
Closes #2165.

## Summary
- add a `maw serve` maintenance sweep that calls existing `messageQueue.prune()` and `requestReplyStore.prune()` once per minute
- add `AgentStatusStore.prune()` for stale terminal statuses so old oracle names do not remain forever in long-lived servers
- preserve pending/active state: pending dispatch messages and busy/ready statuses are not pruned

## Findings
- `src/core/server.ts` WS close paths clean normal engine, PTY, and tmux-stream connections; tmux-stream clears per-connection intervals in `handleTmuxStreamClose`.
- `src/api/feed.ts` feed buffer is bounded by `cfgLimit("feedMax")`.
- `src/vendor/mpr-plugins/messages/ledger.ts` opens/closes SQLite per query/event; likely disk growth, not RSS retention.
- `src/commands/shared/comm-log-feed.ts` appends `maw-log.jsonl` without rotation; disk-growth candidate, not a direct RSS leak.
- Concrete RSS candidate: in-memory stores had prune APIs but `maw serve` never called `messageQueue.prune()` or `requestReplyStore.prune()`, and agent status entries idled but never evicted.

## Tests
- `bun test test/isolated/serve-memory-retention-2165.test.ts test/isolated/api-request-reply.test.ts test/isolated/api-status.test.ts test/isolated/core-server-coverage.test.ts`

## Not tested
- Multi-day heap profile under production federation traffic.
- Build hook currently fails on pre-existing `@maw-js/sdk` resolution in `src/vendor/mpr-plugins/messages/ledger.ts`.