### PR TITLE
feat(sdk): export broadcast helpers

### DIFF
--- a/packages/sdk/index.d.ts
+++ b/packages/sdk/index.d.ts
@@ -394,6 +394,75 @@ export declare function importPluginSymbol<T = unknown>(
   symbolName: string,
 ): Promise<T>;
 
+
+// --- src/core/agent-detect ---
+
+/** Return true when a tmux pane command appears to be an agent runtime. */
+export declare function isAgentCommand(cmd: string | null | undefined): boolean;
+
+// --- src/lib/oracle-members ---
+
+export interface OracleMember {
+  oracle: string;
+  role: string;
+  addedAt: string;
+}
+
+export interface OracleTeamRegistry {
+  name: string;
+  members: OracleMember[];
+  createdAt: string;
+  excludeSelf?: boolean;
+}
+
+export declare function loadOracleRegistry(teamName: string): OracleTeamRegistry | null;
+export declare function filterMembers(
+  members: OracleMember[],
+  excludeSelf: boolean | undefined,
+  currentOracle?: string,
+): string[];
+export declare function getOracleMembers(teamName: string, currentOracle?: string): string[];
+
+// --- src/core/fleet/fleet-load-core ---
+
+export interface FleetWindow {
+  name: string;
+  repo: string;
+}
+
+export interface FleetSession {
+  name: string;
+  windows: FleetWindow[];
+  skip_command?: boolean;
+  sync_peers?: string[];
+  budded_from?: string;
+  project_repos?: string[];
+}
+
+export interface FleetEntry {
+  file: string;
+  path?: string;
+  num: number;
+  groupName: string;
+  session: FleetSession;
+}
+
+export interface DisabledFleetEntry {
+  file: string;
+  path: string;
+  num: number;
+  groupName: string;
+  session?: FleetSession;
+  error?: unknown;
+}
+
+export declare function fleetLoadDirsForRead(legacyFleetDir?: string): string[];
+export declare function fleetLoadDirForWrite(): string;
+export declare function loadFleetCore(dirs?: string[]): FleetSession[];
+export declare function countDisabledFleetFilesCore(dirs?: string[]): number;
+export declare function loadDisabledFleetEntriesCore(dirs?: string[]): DisabledFleetEntry[];
+export declare function loadFleetEntries(dirs?: string[]): FleetEntry[];
+
 // --- src/lib/artifacts ---
 
 export interface ArtifactMeta {

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -163,6 +163,31 @@ export type { TProfile } from "../../src/lib/schemas";
 // plugin.json module.path + module.exports before another plugin may import it.
 export { importPluginSymbol } from "../../src/plugin/registry";
 
+
+// ─── src/core/agent-detect ──────────────────────────────────────────────────
+// Lightweight agent-pane detection used by broadcast and send helpers.
+export { isAgentCommand } from "../../src/core/agent-detect";
+
+// ─── src/lib/oracle-members ─────────────────────────────────────────────────
+// Team registry readers used by broadcast-style plugins.
+export { loadOracleRegistry, getOracleMembers, filterMembers } from "../../src/lib/oracle-members";
+export type { OracleMember, OracleTeamRegistry } from "../../src/lib/oracle-members";
+
+// ─── src/core/fleet/fleet-load-core ─────────────────────────────────────────
+// Core-only fleet config reads. Avoids src/commands/shared/fleet-load because
+// that module imports the SDK barrel for tmux helpers.
+export {
+  fleetDirsForRead as fleetLoadDirsForRead,
+  fleetDirForWrite as fleetLoadDirForWrite,
+  loadFleet as loadFleetCore,
+  countDisabledFleetFiles as countDisabledFleetFilesCore,
+  loadDisabledFleetEntries as loadDisabledFleetEntriesCore,
+  loadFleetEntries,
+} from "../../src/core/fleet/fleet-load-core";
+export type {
+  FleetWindow, FleetSession, FleetEntry, DisabledFleetEntry,
+} from "../../src/core/fleet/fleet-load-core";
+
 // ─── src/lib/artifacts ───────────────────────────────────────────────────────
 // Artifact dir/spec/meta/result helpers. Used by `artifact-manager` plugin.
 export {

--- a/src/commands/shared/fleet-load.ts
+++ b/src/commands/shared/fleet-load.ts
@@ -1,139 +1,40 @@
-import { join } from "path";
-import { existsSync, readdirSync, readFileSync } from "fs";
 import * as sdk from "../../sdk";
-import { fleetDirForWrite as coreFleetDirForWrite, fleetDirsForRead as coreFleetDirsForRead, uniqueDirs } from "../../core/fleet/paths";
+import {
+  fleetDirForWrite,
+  fleetDirsForRead as coreFleetDirsForRead,
+  loadFleet as loadFleetCore,
+  countDisabledFleetFiles as countDisabledFleetFilesCore,
+  loadDisabledFleetEntries as loadDisabledFleetEntriesCore,
+  loadFleetEntries as loadFleetEntriesCore,
+  type DisabledFleetEntry,
+  type FleetEntry,
+  type FleetSession,
+  type FleetWindow,
+} from "../../core/fleet/fleet-load-core";
 import { resolveFleetWindowSessionTarget } from "../../core/matcher/resolve-target";
 
-export interface FleetWindow {
-  name: string;
-  repo: string;
-}
-
-export interface FleetSession {
-  name: string;
-  windows: FleetWindow[];
-  skip_command?: boolean;
-  /** Peer oracle names for soul-sync (flat, no hierarchy). */
-  sync_peers?: string[];
-  /** Optional parent oracle/fleet name for bud lineage. */
-  budded_from?: string;
-  /** Project repos (org/repo) this oracle absorbs ψ/ from via `maw soul-sync --project`. */
-  project_repos?: string[];
-}
-
-export interface FleetEntry {
-  file: string;
-  /** Absolute path of the config file that supplied this entry. */
-  path?: string;
-  num: number;
-  groupName: string;
-  session: FleetSession;
-}
-
-export interface DisabledFleetEntry {
-  file: string;
-  /** Absolute path of the disabled config file that supplied this entry. */
-  path: string;
-  num: number;
-  groupName: string;
-  session?: FleetSession;
-  error?: unknown;
-}
+export type { DisabledFleetEntry, FleetEntry, FleetSession, FleetWindow };
 
 export function fleetDirsForRead(): string[] {
-  const legacyFleetDir = (sdk as any).FLEET_DIR as string | undefined;
-  return legacyFleetDir ? coreFleetDirsForRead({ legacyFleetDir }) : uniqueDirs([coreFleetDirForWrite()]);
+  return coreFleetDirsForRead((sdk as any).FLEET_DIR as string | undefined);
 }
 
-export function fleetDirForWrite(): string {
-  return coreFleetDirForWrite();
-}
-
-function readFleetFiles(dirs: string[] = fleetDirsForRead()): Array<{ file: string; path: string; session: FleetSession }> {
-  const byName = new Map<string, { file: string; path: string; session: FleetSession }>();
-  for (const dir of uniqueDirs(dirs)) {
-    if (!existsSync(dir)) continue;
-    let files: string[];
-    try {
-      files = readdirSync(dir)
-        .filter(f => f.endsWith(".json") && !f.endsWith(".disabled"))
-        .sort();
-    } catch {
-      continue;
-    }
-    for (const file of files) {
-      if (byName.has(file)) continue;
-      const path = join(dir, file);
-      try {
-        byName.set(file, { file, path, session: JSON.parse(readFileSync(path, "utf-8")) as FleetSession });
-      } catch {
-        // Keep looking in fallback dirs. A malformed state-first fleet file
-        // should not shadow a valid legacy config with the same filename.
-      }
-    }
-  }
-  return [...byName.values()].sort((a, b) => a.file.localeCompare(b.file));
-}
-
-function readDisabledFleetFiles(dirs: string[] = fleetDirsForRead()): Array<{ file: string; path: string }> {
-  const byName = new Map<string, { file: string; path: string }>();
-  for (const dir of uniqueDirs(dirs)) {
-    if (!existsSync(dir)) continue;
-    let files: string[];
-    try {
-      files = readdirSync(dir)
-        .filter(f => f.endsWith(".disabled"))
-        .sort();
-    } catch {
-      continue;
-    }
-    for (const file of files) {
-      if (!byName.has(file)) byName.set(file, { file, path: join(dir, file) });
-    }
-  }
-  return [...byName.values()].sort((a, b) => a.file.localeCompare(b.file));
-}
-
-function parseFleetFileInfo(file: string): { num: number; groupName: string } {
-  const activeName = file.replace(/\.disabled$/i, "");
-  const match = activeName.match(/^(\d+)-(.+)\.json$/);
-  return {
-    num: match ? parseInt(match[1], 10) : 0,
-    groupName: match ? match[2] : activeName.replace(/\.json$/i, ""),
-  };
-}
+export { fleetDirForWrite };
 
 export function loadFleet(dirs: string[] = fleetDirsForRead()): FleetSession[] {
-  return readFleetFiles(dirs).map(({ session }) => session);
+  return loadFleetCore(dirs);
 }
 
-
 export function countDisabledFleetFiles(dirs: string[] = fleetDirsForRead()): number {
-  return readDisabledFleetFiles(dirs).length;
+  return countDisabledFleetFilesCore(dirs);
 }
 
 export function loadDisabledFleetEntries(dirs: string[] = fleetDirsForRead()): DisabledFleetEntry[] {
-  return readDisabledFleetFiles(dirs).map(({ file, path }) => {
-    const { num, groupName } = parseFleetFileInfo(file);
-    try {
-      return { file, path, num, groupName, session: JSON.parse(readFileSync(path, "utf-8")) as FleetSession };
-    } catch (error) {
-      return { file, path, num, groupName, error };
-    }
-  });
+  return loadDisabledFleetEntriesCore(dirs);
 }
 
 export function loadFleetEntries(dirs: string[] = fleetDirsForRead()): FleetEntry[] {
-  return readFleetFiles(dirs).map(({ file, path, session }) => {
-    const { num, groupName } = parseFleetFileInfo(file);
-    return {
-      file,
-      path,
-      num,
-      groupName,
-      session,
-    };
-  });
+  return loadFleetEntriesCore(dirs);
 }
 
 export async function getSessionNames(): Promise<string[]> {

--- a/src/core/fleet/fleet-load-core.ts
+++ b/src/core/fleet/fleet-load-core.ts
@@ -100,15 +100,15 @@ function parseFleetFileInfo(file: string): { num: number; groupName: string } {
   };
 }
 
-export function loadFleet(dirs: string[]): FleetSession[] {
+export function loadFleet(dirs: string[] = fleetDirsForRead()): FleetSession[] {
   return readFleetFiles(dirs).map(({ session }) => session);
 }
 
-export function countDisabledFleetFiles(dirs: string[]): number {
+export function countDisabledFleetFiles(dirs: string[] = fleetDirsForRead()): number {
   return readDisabledFleetFiles(dirs).length;
 }
 
-export function loadDisabledFleetEntries(dirs: string[]): DisabledFleetEntry[] {
+export function loadDisabledFleetEntries(dirs: string[] = fleetDirsForRead()): DisabledFleetEntry[] {
   return readDisabledFleetFiles(dirs).map(({ file, path }) => {
     const { num, groupName } = parseFleetFileInfo(file);
     try {
@@ -119,7 +119,7 @@ export function loadDisabledFleetEntries(dirs: string[]): DisabledFleetEntry[] {
   });
 }
 
-export function loadFleetEntries(dirs: string[]): FleetEntry[] {
+export function loadFleetEntries(dirs: string[] = fleetDirsForRead()): FleetEntry[] {
   return readFleetFiles(dirs).map(({ file, path, session }) => {
     const { num, groupName } = parseFleetFileInfo(file);
     return { file, path, num, groupName, session };

--- a/src/core/fleet/fleet-load-core.ts
+++ b/src/core/fleet/fleet-load-core.ts
@@ -1,0 +1,127 @@
+import { existsSync, readdirSync, readFileSync } from "fs";
+import { join } from "path";
+import { fleetDirForWrite as coreFleetDirForWrite, fleetDirsForRead as coreFleetDirsForRead, uniqueDirs } from "./paths";
+
+export interface FleetWindow {
+  name: string;
+  repo: string;
+}
+
+export interface FleetSession {
+  name: string;
+  windows: FleetWindow[];
+  skip_command?: boolean;
+  /** Peer oracle names for soul-sync (flat, no hierarchy). */
+  sync_peers?: string[];
+  /** Optional parent oracle/fleet name for bud lineage. */
+  budded_from?: string;
+  /** Project repos (org/repo) this oracle absorbs ψ/ from via `maw soul-sync --project`. */
+  project_repos?: string[];
+}
+
+export interface FleetEntry {
+  file: string;
+  /** Absolute path of the config file that supplied this entry. */
+  path?: string;
+  num: number;
+  groupName: string;
+  session: FleetSession;
+}
+
+export interface DisabledFleetEntry {
+  file: string;
+  /** Absolute path of the disabled config file that supplied this entry. */
+  path: string;
+  num: number;
+  groupName: string;
+  session?: FleetSession;
+  error?: unknown;
+}
+
+export function fleetDirsForRead(legacyFleetDir?: string): string[] {
+  return legacyFleetDir ? coreFleetDirsForRead({ legacyFleetDir }) : uniqueDirs([coreFleetDirForWrite()]);
+}
+
+export function fleetDirForWrite(): string {
+  return coreFleetDirForWrite();
+}
+
+function readFleetFiles(dirs: string[]): Array<{ file: string; path: string; session: FleetSession }> {
+  const byName = new Map<string, { file: string; path: string; session: FleetSession }>();
+  for (const dir of uniqueDirs(dirs)) {
+    if (!existsSync(dir)) continue;
+    let files: string[];
+    try {
+      files = readdirSync(dir)
+        .filter(f => f.endsWith(".json") && !f.endsWith(".disabled"))
+        .sort();
+    } catch {
+      continue;
+    }
+    for (const file of files) {
+      if (byName.has(file)) continue;
+      const path = join(dir, file);
+      try {
+        byName.set(file, { file, path, session: JSON.parse(readFileSync(path, "utf-8")) as FleetSession });
+      } catch {
+        // Keep looking in fallback dirs. A malformed state-first fleet file
+        // should not shadow a valid legacy config with the same filename.
+      }
+    }
+  }
+  return [...byName.values()].sort((a, b) => a.file.localeCompare(b.file));
+}
+
+function readDisabledFleetFiles(dirs: string[]): Array<{ file: string; path: string }> {
+  const byName = new Map<string, { file: string; path: string }>();
+  for (const dir of uniqueDirs(dirs)) {
+    if (!existsSync(dir)) continue;
+    let files: string[];
+    try {
+      files = readdirSync(dir)
+        .filter(f => f.endsWith(".disabled"))
+        .sort();
+    } catch {
+      continue;
+    }
+    for (const file of files) {
+      if (!byName.has(file)) byName.set(file, { file, path: join(dir, file) });
+    }
+  }
+  return [...byName.values()].sort((a, b) => a.file.localeCompare(b.file));
+}
+
+function parseFleetFileInfo(file: string): { num: number; groupName: string } {
+  const activeName = file.replace(/\.disabled$/i, "");
+  const match = activeName.match(/^(\d+)-(.+)\.json$/);
+  return {
+    num: match ? parseInt(match[1], 10) : 0,
+    groupName: match ? match[2] : activeName.replace(/\.json$/i, ""),
+  };
+}
+
+export function loadFleet(dirs: string[]): FleetSession[] {
+  return readFleetFiles(dirs).map(({ session }) => session);
+}
+
+export function countDisabledFleetFiles(dirs: string[]): number {
+  return readDisabledFleetFiles(dirs).length;
+}
+
+export function loadDisabledFleetEntries(dirs: string[]): DisabledFleetEntry[] {
+  return readDisabledFleetFiles(dirs).map(({ file, path }) => {
+    const { num, groupName } = parseFleetFileInfo(file);
+    try {
+      return { file, path, num, groupName, session: JSON.parse(readFileSync(path, "utf-8")) as FleetSession };
+    } catch (error) {
+      return { file, path, num, groupName, error };
+    }
+  });
+}
+
+export function loadFleetEntries(dirs: string[]): FleetEntry[] {
+  return readFleetFiles(dirs).map(({ file, path, session }) => {
+    const { num, groupName } = parseFleetFileInfo(file);
+    return { file, path, num, groupName, session };
+  });
+}

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -42,7 +42,6 @@ export type {
 export {
   hostExec, listSessions, capture, sendKeys,
   getPaneCommand, getPaneCommands, getPaneInfos,
-  isAgentCommand,
   HostExecError,
 } from "../core/transport/ssh";
 export type { Session as SshSession, HostExecTransport } from "../core/transport/ssh";
@@ -62,6 +61,7 @@ export type {
   PickOracleOptions,
 } from "../core/resolve";
 export { findWindow } from "../core/runtime/find-window";
+export { isAgentCommand } from "../core/agent-detect";
 export type { Session, Window } from "../core/runtime/find-window";
 export {
   loadOracleChannels,
@@ -90,6 +90,19 @@ export {
   readCache, isCacheStale,
 } from "../core/fleet/oracle-registry";
 export type { OracleEntry, RegistryCache } from "../core/fleet/oracle-registry";
+export {
+  fleetDirsForRead as fleetLoadDirsForRead,
+  fleetDirForWrite as fleetLoadDirForWrite,
+  loadFleet as loadFleetCore,
+  countDisabledFleetFiles as countDisabledFleetFilesCore,
+  loadDisabledFleetEntries as loadDisabledFleetEntriesCore,
+  loadFleetEntries,
+} from "../core/fleet/fleet-load-core";
+export type {
+  FleetWindow, FleetSession, FleetEntry, DisabledFleetEntry,
+} from "../core/fleet/fleet-load-core";
+export { loadOracleRegistry, getOracleMembers, filterMembers } from "../lib/oracle-members";
+export type { OracleMember, OracleTeamRegistry } from "../lib/oracle-members";
 // Sub-issue 2 of #736 Phase 2 / #836 — unified read-only view across the 5
 // oracle registries. Consumer-side rollouts (oracle ls, doctor, resolveTarget)
 // land in follow-up PRs.

--- a/src/vendor/mpr-plugins/broadcast/impl.ts
+++ b/src/vendor/mpr-plugins/broadcast/impl.ts
@@ -1,10 +1,7 @@
 import { existsSync, readFileSync } from "fs";
 import { homedir } from "os";
 import { dirname, join } from "path";
-import { tmux } from "maw-js/sdk";
-import { isAgentCommand } from "../../../core/agent-detect";
-import { loadOracleRegistry } from "../../../lib/oracle-members";
-import { loadFleetEntries } from "../../../commands/shared/fleet-load";
+import { tmux, isAgentCommand, loadOracleRegistry, loadFleetEntries } from "maw-js/sdk";
 
 export interface BroadcastScopeOptions {
   session?: string;

--- a/test/isolated/broadcast-agent-detect.test.ts
+++ b/test/isolated/broadcast-agent-detect.test.ts
@@ -17,6 +17,11 @@ mock.module("maw-js/sdk", () => ({
   hostExec: async () => "",
   listSessions: async () => [],
   tmuxCmd: () => "tmux",
+  isAgentCommand: (cmd: string | null | undefined) => /claude|codex|thclaws|thclaude/i.test((cmd ?? "").trim()) || /^node$/i.test((cmd ?? "").trim()) || /^\d+\.\d+\.\d+$/.test((cmd ?? "").trim()),
+  loadOracleRegistry: (teamName: string) => teamMembers.length
+    ? { name: teamName, members: teamMembers.map(oracle => ({ oracle, role: "member", addedAt: "2026-06-06T00:00:00.000Z" })), createdAt: "2026-06-06T00:00:00.000Z" }
+    : null,
+  loadFleetEntries: () => fleetEntries,
   tmux: {
     run: async (subcommand: string, ...args: string[]) => {
       if (subcommand === "display-message") {
@@ -37,16 +42,6 @@ mock.module("maw-js/sdk", () => ({
   },
 }));
 
-
-mock.module(join(import.meta.dir, "../../src/lib/oracle-members"), () => ({
-  loadOracleRegistry: (teamName: string) => teamMembers.length
-    ? { name: teamName, members: teamMembers.map(oracle => ({ oracle, role: "member", addedAt: "2026-06-06T00:00:00.000Z" })), createdAt: "2026-06-06T00:00:00.000Z" }
-    : null,
-}));
-
-mock.module(join(import.meta.dir, "../../src/commands/shared/fleet-load"), () => ({
-  loadFleetEntries: () => fleetEntries,
-}));
 
 const { cmdBroadcast, parseBroadcastArgs } = await import("../../src/vendor/mpr-plugins/broadcast/impl");
 

--- a/test/isolated/sdk-broadcast-exports.test.ts
+++ b/test/isolated/sdk-broadcast-exports.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const root = join(import.meta.dir, "../..");
+
+describe("sdk broadcast extraction exports (#2156)", () => {
+  test("runtime SDK exposes broadcast helpers", async () => {
+    const sdk = await import("../../src/sdk/index");
+    expect(typeof sdk.isAgentCommand).toBe("function");
+    expect(typeof sdk.loadOracleRegistry).toBe("function");
+    expect(typeof sdk.loadFleetEntries).toBe("function");
+    expect(typeof sdk.loadFleetCore).toBe("function");
+  });
+
+  test("public package SDK and declarations include broadcast helpers", () => {
+    const source = readFileSync(join(root, "packages/sdk/index.ts"), "utf8");
+    const dts = readFileSync(join(root, "packages/sdk/index.d.ts"), "utf8");
+    expect(source).toContain("../../src/core/agent-detect");
+    expect(source).toContain("../../src/lib/oracle-members");
+    expect(source).toContain("../../src/core/fleet/fleet-load-core");
+    expect(dts).toContain("isAgentCommand");
+    expect(dts).toContain("loadOracleRegistry");
+    expect(dts).toContain("loadFleetEntries");
+  });
+
+  test("broadcast plugin imports helpers from SDK boundary", () => {
+    const impl = readFileSync(join(root, "src/vendor/mpr-plugins/broadcast/impl.ts"), "utf8");
+    expect(impl).toContain('from "maw-js/sdk"');
+    expect(impl).not.toContain("../../../core/agent-detect");
+    expect(impl).not.toContain("../../../lib/oracle-members");
+    expect(impl).not.toContain("../../../commands/shared/fleet-load");
+  });
+});

--- a/test/isolated/vendor-bud-init-broadcast-rename-extra-coverage.test.ts
+++ b/test/isolated/vendor-bud-init-broadcast-rename-extra-coverage.test.ts
@@ -81,6 +81,9 @@ mock.module("maw-js/sdk", () => ({
     if (hostExecError) throw hostExecError;
     return hostExecResult;
   },
+  isAgentCommand: (cmd: string | null | undefined) => /claude|codex|thclaws|thclaude/i.test((cmd ?? "").trim()) || /^node$/i.test((cmd ?? "").trim()) || /^\d+\.\d+\.\d+$/.test((cmd ?? "").trim()),
+  loadOracleRegistry: () => null,
+  loadFleetEntries: () => [{ groupName: "neo", file: "01-neo.json", session: { name: "01-neo" } }],
   tmux: {
     run: async (...args: string[]) => {
       tmuxRunCalls.push(args);


### PR DESCRIPTION
## Summary
- adds a core-only fleet-load helper for SDK-safe fleet entry reads
- exports broadcast extraction helpers from both runtime and public SDK surfaces
- updates the broadcast plugin to import agent detection, team registry, and fleet entry helpers through `maw-js/sdk`

## Verification
- `bun test test/isolated/sdk-broadcast-exports.test.ts test/isolated/broadcast-agent-detect.test.ts test/route-tools-default.test.ts test/isolated/team-ensure-config-and-fleet-load-coverage.test.ts test/config-fleet-merge.test.ts`

## Notes
- Local post-commit build hook still fails on the existing `@maw-js/sdk` package-resolution issue in `src/vendor/mpr-plugins/messages/ledger.ts`; targeted tests above pass.

Closes #2156
