### PR TITLE
refactor(zoom): prepare standalone plugin extraction

### DIFF
--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -53,6 +53,7 @@ export {
 } from "../core/transport/peers";
 export { resolveTarget } from "../core/routing";
 export type { ResolveResult } from "../core/routing";
+export { resolveSessionTarget, resolveWorktreeTarget } from "../core/matcher/resolve-target";
 export { resolveOracle, pickOracle } from "../core/resolve";
 export type {
   OracleRef,

--- a/src/vendor/mpr-plugins/zoom/impl.ts
+++ b/src/vendor/mpr-plugins/zoom/impl.ts
@@ -1,5 +1,4 @@
-import { listSessions, hostExec, tmuxCmd } from "maw-js/sdk";
-import { resolveSessionTarget } from "maw-js/core/matcher/resolve-target";
+import { listSessions, hostExec, tmuxCmd, resolveSessionTarget } from "maw-js/sdk";
 
 export interface ZoomOpts {
   /** Pane index within the resolved window. Default: current/first. */

--- a/src/vendor/mpr-plugins/zoom/index.ts
+++ b/src/vendor/mpr-plugins/zoom/index.ts
@@ -1,6 +1,6 @@
 import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdZoom } from "./impl";
-import { parseFlags } from "maw-js/cli/parse-args";
+import { parseFlags } from "maw-js/sdk";
 
 export const command = {
   name: "zoom",

--- a/test/isolated/vendor-actions-extra-coverage.test.ts
+++ b/test/isolated/vendor-actions-extra-coverage.test.ts
@@ -85,6 +85,10 @@ mock.module("maw-js/sdk", () => ({
     return "";
   },
   tmuxCmd: () => "tmux-mock",
+  resolveSessionTarget: (target: string, seenSessions: Session[]) => {
+    resolveCalls.push({ target, sessions: seenSessions });
+    return resolveResults.get(target) ?? { kind: "none", hints: [] };
+  },
 }));
 
 mock.module("maw-js/core/matcher/resolve-target", () => ({

--- a/test/isolated/vendor-pane-actions-extra-coverage.test.ts
+++ b/test/isolated/vendor-pane-actions-extra-coverage.test.ts
@@ -74,6 +74,28 @@ mock.module("maw-js/sdk", () => ({
     return next ?? "";
   },
   tmuxCmd: () => "tmux-test",
+  loadConfig: () => configState,
+  cfgTimeout: (name: string) => {
+    cfgTimeoutCalls.push(name);
+    return 1234;
+  },
+  buildCommandInDir: (dir: string, cmd: string) => `cd ${dir} && ${cmd}`,
+  resolveSessionTarget: (target: string, seenSessions: Session[]) => {
+    resolveCalls.push({ target, sessions: seenSessions });
+    return resolveResults.get(target) ?? { kind: "none", hints: [] };
+  },
+  parseFlags: (args: string[]) => {
+    const out: Record<string, unknown> & { _: string[] } = { _: [] };
+    for (let i = 0; i < args.length; i += 1) {
+      const arg = args[i]!;
+      if (arg === "--pane") {
+        const value = args[++i];
+        if (value === undefined || value.startsWith("--")) throw new Error("option requires argument: --pane");
+        out["--pane"] = Number(value);
+      } else out._.push(arg);
+    }
+    return out;
+  },
   tmux: {
     run: async (...args: string[]) => {
       tmuxRunCalls.push(args);

--- a/test/isolated/zoom-standalone-extraction.test.ts
+++ b/test/isolated/zoom-standalone-extraction.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const root = join(import.meta.dir, "../..");
+const hostExecCalls: string[] = [];
+
+mock.module("maw-js/sdk", () => ({
+  listSessions: async () => [
+    { name: "Neo", windows: [{ index: 5, name: "main", active: true }] },
+  ],
+  tmuxCmd: () => "tmux",
+  loadConfig: () => ({ peers: [] }),
+  cfgTimeout: () => 1234,
+  buildCommandInDir: (dir: string, cmd: string) => `cd ${dir} && ${cmd}`,
+  curlFetch: async () => ({ ok: true, data: {} }),
+  tmux: {
+    run: async () => "",
+  },
+  hostExec: async (cmd: string) => {
+    hostExecCalls.push(cmd);
+    return "";
+  },
+  parseFlags: (args: string[]) => {
+    const out: Record<string, unknown> & { _: string[] } = { _: [] };
+    for (let i = 0; i < args.length; i += 1) {
+      const arg = args[i]!;
+      if (arg === "--pane") {
+        const value = args[++i];
+        if (value === undefined || value.startsWith("--")) throw new Error("option requires argument: --pane");
+        out["--pane"] = Number(value);
+      } else out._.push(arg);
+    }
+    return out;
+  },
+  resolveSessionTarget: (target: string, sessions: Array<{ name: string; windows: unknown[] }>) => {
+    const match = sessions.find((s) => s.name.toLowerCase() === target.toLowerCase());
+    return match ? { kind: "exact", match } : { kind: "none", hints: [] };
+  },
+}));
+
+describe("zoom standalone extraction prep (#2113)", () => {
+  test("runtime imports stay on the SDK boundary", () => {
+    const impl = readFileSync(join(root, "src/vendor/mpr-plugins/zoom/impl.ts"), "utf8");
+    const index = readFileSync(join(root, "src/vendor/mpr-plugins/zoom/index.ts"), "utf8");
+    expect(impl).toContain('from "maw-js/sdk"');
+    expect(index).toContain('from "maw-js/sdk"');
+    expect(impl).not.toContain("maw-js/core/");
+    expect(index).not.toContain("maw-js/cli/");
+  });
+
+  test("handler runs with only maw-js/sdk mocked", async () => {
+    hostExecCalls.length = 0;
+    const handler = (await import("../../src/vendor/mpr-plugins/zoom/index.ts?standalone-extraction")).default;
+    const result = await handler({ source: "cli", args: ["neo", "--pane", "2"] });
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("toggled zoom on Neo:5.2");
+    expect(hostExecCalls).toEqual(["tmux resize-pane -Z -t 'Neo:5.2'"]);
+  });
+});


### PR DESCRIPTION
## Summary
- moves zoom runtime imports to the SDK boundary
- exports session target resolution from the runtime SDK barrel
- adds a standalone-style zoom test that runs with only `maw-js/sdk` mocked

## Verification
- `bun test test/isolated/zoom-standalone-extraction.test.ts test/isolated/vendor-pane-actions-extra-coverage.test.ts test/isolated/vendor-actions-extra-coverage.test.ts`

RFC #2113 extraction prep.
