### PR TITLE
fix: bound message ledger retention

### DIFF
--- a/src/vendor/mpr-plugins/messages/ledger.ts
+++ b/src/vendor/mpr-plugins/messages/ledger.ts
@@ -19,6 +19,12 @@ export interface MessageLedgerRow extends MessageLifecycleData {
   signed?: boolean;
 }
 
+export interface MessageLedgerRetentionPolicy {
+  maxMessages?: number;
+}
+
+export const DEFAULT_MAX_MESSAGES = 50_000;
+
 export function messageLedgerDbPath(): string {
   return mawDataPath("message-ledger.sqlite");
 }
@@ -44,6 +50,43 @@ function openDb(): Database {
   return db;
 }
 
+function positiveInt(value: unknown): number | null {
+  const n = typeof value === "number" ? value : typeof value === "string" && value.trim() ? Number(value) : NaN;
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : null;
+}
+
+export function resolveMessageLedgerRetentionPolicy(policy: MessageLedgerRetentionPolicy = {}): { maxMessages: number } {
+  return {
+    maxMessages: positiveInt(policy.maxMessages)
+      ?? positiveInt(process.env.MAW_MESSAGE_LEDGER_MAX_MESSAGES)
+      ?? DEFAULT_MAX_MESSAGES,
+  };
+}
+
+function messageCount(db: Database): number {
+  const row = db.query("SELECT COUNT(*) AS count FROM messages").get() as { count?: number | bigint } | null;
+  return Number(row?.count ?? 0);
+}
+
+function pruneMessageLedgerDb(db: Database, policy: MessageLedgerRetentionPolicy = {}): number {
+  const { maxMessages } = resolveMessageLedgerRetentionPolicy(policy);
+  const before = messageCount(db);
+  if (before <= maxMessages) return 0;
+  db.query("DELETE FROM messages WHERE rowid NOT IN (SELECT rowid FROM messages ORDER BY ts DESC, rowid DESC LIMIT $limit)").run({
+    $limit: maxMessages,
+  });
+  return before - messageCount(db);
+}
+
+export function pruneMessageLedger(policy: MessageLedgerRetentionPolicy = {}): number {
+  const db = openDb();
+  try {
+    return pruneMessageLedgerDb(db, policy);
+  } finally {
+    db.close();
+  }
+}
+
 export function recordMessageLedgerEvent(event: MessageLifecycleData): void {
   const db = openDb();
   try {
@@ -63,6 +106,7 @@ export function recordMessageLedgerEvent(event: MessageLifecycleData): void {
       $lastLine: event.lastLine ?? null,
       $signed: event.signed ? 1 : 0,
     });
+    pruneMessageLedgerDb(db);
   } finally {
     db.close();
   }

--- a/test/isolated/message-ledger.test.ts
+++ b/test/isolated/message-ledger.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { buildMessageLifecycleFeedEvent } from "../../src/lib/message-events";
-import { listMessageLedgerEvents, messageLedgerDbPath, recordMessageLedgerEvent } from "../../src/vendor/mpr-plugins/messages/ledger";
+import { listMessageLedgerEvents, messageLedgerDbPath, pruneMessageLedger, recordMessageLedgerEvent } from "../../src/vendor/mpr-plugins/messages/ledger";
 import messagesHandler, { messagesEngineFetch, onEvent } from "../../src/vendor/mpr-plugins/messages/index";
 import { messagesHtml, messagesView } from "../../src/views/messages";
 import type { FeedEvent } from "../../src/lib/feed";
@@ -14,12 +14,14 @@ let dataDir: string;
 const prevConfig = process.env.MAW_CONFIG_DIR;
 const prevData = process.env.MAW_DATA_DIR;
 const prevHome = process.env.MAW_HOME;
+const prevMaxMessages = process.env.MAW_MESSAGE_LEDGER_MAX_MESSAGES;
 
 beforeEach(() => {
   tmp = mkdtempSync(join(tmpdir(), "maw-message-ledger-"));
   configDir = join(tmp, "config");
   dataDir = join(tmp, "data");
   delete process.env.MAW_HOME;
+  delete process.env.MAW_MESSAGE_LEDGER_MAX_MESSAGES;
   process.env.MAW_CONFIG_DIR = configDir;
   process.env.MAW_DATA_DIR = dataDir;
 });
@@ -31,6 +33,8 @@ afterEach(() => {
   else process.env.MAW_DATA_DIR = prevData;
   if (prevHome === undefined) delete process.env.MAW_HOME;
   else process.env.MAW_HOME = prevHome;
+  if (prevMaxMessages === undefined) delete process.env.MAW_MESSAGE_LEDGER_MAX_MESSAGES;
+  else process.env.MAW_MESSAGE_LEDGER_MAX_MESSAGES = prevMaxMessages;
   rmSync(tmp, { recursive: true, force: true });
 });
 
@@ -112,6 +116,37 @@ describe("messages plugin ledger", () => {
 
     expect(listMessageLedgerEvents({ direction: "inbound" })).toMatchObject([
       { id: "m3", state: "delivered", lastLine: "received" },
+    ]);
+  });
+
+  test("prunes oldest rows when message retention is exceeded", () => {
+    process.env.MAW_MESSAGE_LEDGER_MAX_MESSAGES = "3";
+
+    for (let i = 1; i <= 5; i += 1) {
+      recordMessageLedgerEvent({
+        id: `retention-${i}`,
+        ts: `2026-05-16T01:0${i}:00.000Z`,
+        direction: "outbound",
+        state: "delivered",
+        channel: "hey",
+        route: "local",
+        from: "m5:mawjs-codex",
+        to: "m5:mawjs-oracle",
+        text: `retention ${i}`,
+      });
+    }
+
+    expect(listMessageLedgerEvents({ limit: 10 }).map(row => row.id)).toEqual([
+      "retention-5",
+      "retention-4",
+      "retention-3",
+    ]);
+
+    process.env.MAW_MESSAGE_LEDGER_MAX_MESSAGES = "2";
+    expect(pruneMessageLedger()).toBe(1);
+    expect(listMessageLedgerEvents({ limit: 10 }).map(row => row.id)).toEqual([
+      "retention-5",
+      "retention-4",
     ]);
   });
 });


### PR DESCRIPTION
Closes #2165.\n\n## Summary\n- Add a default SQLite message-ledger retention cap (50,000 rows).\n- Prune oldest rows after each ledger write, keeping newest rows by timestamp.\n- Add explicit prune helper and regression coverage for env override/manual prune.\n\n## Verification\n- Direct Bun SQLite smoke: max=3 retained m5,m4,m3; manual prune to max=2 retained m5,m4.\n- `git diff --check`\n- `bun run build`\n\n## Notes\n- `bun test test/isolated/message-ledger.test.ts` crashes locally before assertions with known Bun canary panic: `index out of bounds: the len is 4095 but the index is 4095`.