### PR TITLE
test(plugins): lock standalone-ready lean-core boundaries

### DIFF
--- a/src/vendor/mpr-plugins/broadcast/index.ts
+++ b/src/vendor/mpr-plugins/broadcast/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/sdk";
 import { cmdBroadcast, parseBroadcastArgs } from "./impl";
 
 export const command = { name: "broadcast", description: "Broadcast a message to all agents." };

--- a/src/vendor/mpr-plugins/learn/index.ts
+++ b/src/vendor/mpr-plugins/learn/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/sdk";
 
 export const command = {
   name: "learn",

--- a/test/isolated/plugin-broadcast-standalone.test.ts
+++ b/test/isolated/plugin-broadcast-standalone.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const root = join(import.meta.dir, "../..");
+
+let paneCommands: Map<string, string>;
+let sessions: Array<{ name: string; windows: Array<{ index: number; name: string }> }>;
+let teamMembers: string[];
+let fleetEntries: Array<{ groupName: string; file: string; session: { name: string } }>;
+let sendCalls: Array<{ target: string; text: string }>;
+
+mock.module("maw-js/sdk", () => ({
+  loadConfig: () => ({ namedPeers: [], peers: [] }),
+  cfgTimeout: () => 1000,
+  curlFetch: async () => ({ ok: true, data: { enabled: false } }),
+  isAgentCommand: (cmd: string | null | undefined) => ["claude", "codex", "node"].includes(String(cmd ?? "").trim()),
+  loadOracleRegistry: (teamName: string) => teamMembers.length
+    ? { name: teamName, members: teamMembers.map(oracle => ({ oracle, role: "member", addedAt: "2026-06-06T00:00:00.000Z" })), createdAt: "2026-06-06T00:00:00.000Z" }
+    : null,
+  loadFleetEntries: () => fleetEntries,
+  tmux: {
+    run: async (subcommand: string, ...args: string[]) => {
+      if (subcommand !== "display-message") return "";
+      if (args[0] === "-p" && args[1] === "#{window_name}") return "sender\n";
+      const targetIndex = args.indexOf("-t");
+      if (targetIndex >= 0) return `${paneCommands.get(args[targetIndex + 1]!) ?? "zsh"}\n`;
+      return "";
+    },
+    listAll: async () => sessions,
+    sendText: async (target: string, text: string) => { sendCalls.push({ target, text }); },
+  },
+}));
+
+const { default: broadcastHandler } = await import("../../src/vendor/mpr-plugins/broadcast/index.ts?plugin-broadcast-standalone");
+const { parseBroadcastArgs, fleetScopeSessionNames } = await import("../../src/vendor/mpr-plugins/broadcast/impl.ts?plugin-broadcast-standalone");
+
+function stripAnsi(value: string | undefined) {
+  return String(value ?? "").replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "");
+}
+
+beforeEach(() => {
+  paneCommands = new Map();
+  sessions = [];
+  teamMembers = [];
+  fleetEntries = [];
+  sendCalls = [];
+});
+
+describe("broadcast plugin standalone boundary (#2113)", () => {
+  test("imports plugin contracts and runtime helpers only through the SDK boundary", () => {
+    const index = readFileSync(join(root, "src/vendor/mpr-plugins/broadcast/index.ts"), "utf8");
+    const impl = readFileSync(join(root, "src/vendor/mpr-plugins/broadcast/impl.ts"), "utf8");
+    for (const source of [index, impl]) {
+      expect(source).not.toMatch(/maw-js\/(?:core|commands\/shared|lib|plugin)(?:\/|\")/);
+      expect(source).not.toMatch(/from\s+["'](?:\.\.\/)+/);
+    }
+    expect(index).toContain('from "maw-js/sdk"');
+    expect(impl).toContain('from "maw-js/sdk"');
+  });
+
+  test("parses scopes and broadcasts only to agent panes", async () => {
+    expect(parseBroadcastArgs(["--session", "77-mawjs", "hello", "team"])).toEqual({
+      message: "hello team",
+      scope: { session: "77-mawjs" },
+    });
+    sessions = [{ name: "77-mawjs", windows: [{ index: 0, name: "agent" }, { index: 1, name: "shell" }] }];
+    paneCommands.set("77-mawjs:0", "codex");
+    paneCommands.set("77-mawjs:1", "zsh");
+
+    const result = await broadcastHandler({ source: "cli", args: ["--session", "77-mawjs", "hello", "team"] } as any);
+
+    expect(result.ok).toBe(true);
+    expect(sendCalls).toEqual([{ target: "77-mawjs:0", text: "[broadcast from sender] hello team" }]);
+    expect(stripAnsi(result.output)).toContain("Broadcast to 1 windows (1 skipped) [scope: session=77-mawjs]");
+  });
+
+  test("fleet scope resolves through SDK fleet entries", () => {
+    fleetEntries = [{ groupName: "mawjs", file: "077-mawjs.json", session: { name: "77-mawjs" } }];
+
+    expect([...fleetScopeSessionNames("mawjs")]).toEqual(["77-mawjs"]);
+    expect([...fleetScopeSessionNames("mawjs-oracle")]).toEqual(["77-mawjs"]);
+  });
+});

--- a/test/isolated/plugin-learn-standalone.test.ts
+++ b/test/isolated/plugin-learn-standalone.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const root = join(import.meta.dir, "../..");
+const { default: learnHandler } = await import("../../src/vendor/mpr-plugins/learn/index.ts?plugin-learn-standalone");
+const { resolveMode } = await import("../../src/vendor/mpr-plugins/learn/impl.ts?plugin-learn-standalone");
+
+describe("learn plugin standalone boundary (#2113)", () => {
+  test("has no direct core/shared/lib/plugin imports", () => {
+    const files = ["index.ts", "impl.ts"].map((file) =>
+      readFileSync(join(root, "src/vendor/mpr-plugins/learn", file), "utf8"),
+    );
+    for (const source of files) {
+      expect(source).not.toMatch(/maw-js\/(?:core|commands\/shared|lib|plugin)(?:\/|\")/);
+      expect(source).not.toMatch(/from\s+["'](?:\.\.\/)+/);
+    }
+    expect(files.join("\n")).toContain('from "maw-js/sdk"');
+  });
+
+  test("validates flags and returns standalone scaffold output", async () => {
+    expect(resolveMode(false, false)).toBe("default");
+    expect(resolveMode(true, false)).toBe("fast");
+    expect(() => resolveMode(true, true)).toThrow("mutually exclusive");
+
+    const ok = await learnHandler({ source: "cli", args: ["Soul-Brews-Studio/maw-js", "--deep"] } as any);
+    expect(ok.ok).toBe(true);
+    expect(ok.output).toContain('learn: deep mode on "Soul-Brews-Studio/maw-js"');
+
+    await expect(learnHandler({ source: "cli", args: ["repo", "--fast", "--deep"] } as any)).resolves.toMatchObject({
+      ok: false,
+      error: "maw learn: --fast and --deep are mutually exclusive",
+    });
+    await expect(learnHandler({ source: "cli", args: [] } as any)).resolves.toMatchObject({
+      ok: false,
+      error: "usage: maw learn <repo> [--fast|--deep]",
+    });
+  });
+});

--- a/test/isolated/plugin-ping-standalone.test.ts
+++ b/test/isolated/plugin-ping-standalone.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const root = join(import.meta.dir, "../..");
+
+type PeerConfig = {
+  namedPeers?: Array<{ name: string; url: string }>;
+  peers?: string[];
+};
+
+let config: PeerConfig;
+let fetchCalls: Array<{ url: string; options: unknown }>;
+let responses: Record<string, { ok: boolean; status?: number; data?: any } | Error>;
+let timeouts: string[];
+
+mock.module("maw-js/sdk", () => ({
+  loadConfig: () => config,
+  cfgTimeout: (key: string) => {
+    timeouts.push(key);
+    return 1234;
+  },
+  curlFetch: async (url: string, options: unknown) => {
+    fetchCalls.push({ url, options });
+    const response = responses[url];
+    if (response instanceof Error) throw response;
+    return response ?? { ok: true, data: { enabled: false } };
+  },
+}));
+
+const { default: pingHandler } = await import("../../src/vendor/mpr-plugins/ping/index.ts?plugin-ping-standalone");
+
+function stripAnsi(value: string | undefined) {
+  return String(value ?? "").replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "");
+}
+
+beforeEach(() => {
+  config = { namedPeers: [], peers: [] };
+  fetchCalls = [];
+  responses = {};
+  timeouts = [];
+});
+
+describe("ping plugin standalone boundary (#2113)", () => {
+  test("has no direct core/shared/lib/config imports", () => {
+    const files = ["index.ts", "impl.ts"].map((file) =>
+      readFileSync(join(root, "src/vendor/mpr-plugins/ping", file), "utf8"),
+    );
+    for (const source of files) {
+      expect(source).not.toMatch(/maw-js\/(?:core|commands\/shared|lib|config)(?:\/|\")/);
+      expect(source).not.toMatch(/from\s+["'](?:\.\.\/)+/);
+    }
+    expect(files.join("\n")).toContain('from "maw-js/sdk"');
+  });
+
+  test("pings named and legacy peers through SDK helpers", async () => {
+    config = {
+      namedPeers: [{ name: "alpha", url: "http://alpha.local" }],
+      peers: ["http://alpha.local", "http://legacy.local"],
+    };
+    responses["http://alpha.local/api/auth/status"] = {
+      ok: true,
+      data: { enabled: true, tokenPreview: "tok…" },
+    };
+    responses["http://legacy.local/api/auth/status"] = { ok: false, status: 503 };
+
+    const result = await pingHandler({ source: "cli", args: [] } as any);
+
+    expect(result.ok).toBe(true);
+    expect(fetchCalls.map((call) => call.url)).toEqual([
+      "http://alpha.local/api/auth/status",
+      "http://legacy.local/api/auth/status",
+    ]);
+    expect(fetchCalls.map((call) => call.options)).toEqual([{ timeout: 1234 }, { timeout: 1234 }]);
+    expect(timeouts).toEqual(["ping", "ping"]);
+    const output = stripAnsi(result.output);
+    expect(output).toContain("alpha (http://alpha.local)");
+    expect(output).toContain("auth: ok (tok…)");
+    expect(output).toContain("http://legacy.local (http://legacy.local)");
+    expect(output).toContain("503");
+  });
+
+  test("supports API positional node lookup and reports unknown nodes without fetching", async () => {
+    config = { namedPeers: [{ name: "alpha", url: "http://alpha.local" }] };
+
+    const ok = await pingHandler({ source: "api", args: { node: "alpha" } } as any);
+    expect(ok.ok).toBe(true);
+    expect(fetchCalls.map((call) => call.url)).toEqual(["http://alpha.local/api/auth/status"]);
+
+    fetchCalls = [];
+    const missing = await pingHandler({ source: "api", args: { node: "ghost" } } as any);
+    expect(missing.ok).toBe(false);
+    expect(stripAnsi(missing.error)).toContain("known: alpha");
+    expect(fetchCalls).toEqual([]);
+  });
+
+  test("no configured peers is a successful no-op", async () => {
+    const result = await pingHandler({ source: "cli", args: [] } as any);
+
+    expect(result.ok).toBe(true);
+    expect(stripAnsi(result.output)).toContain("no peers configured");
+    expect(fetchCalls).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add standalone boundary tests for ping, broadcast, and learn plugins.
- Move broadcast/learn plugin context type imports onto the SDK barrel.
- Verify the selected plugins avoid direct maw-js core/shared/lib/plugin imports for RFC #2113 lean-core extraction prep.

Refs #2113

## Validation
- bun test test/isolated/plugin-ping-standalone.test.ts test/isolated/plugin-broadcast-standalone.test.ts test/isolated/plugin-learn-standalone.test.ts
- rg verified no chosen-plugin maw-js/core, maw-js/commands/shared, maw-js/lib, or maw-js/plugin imports

## Notes
- Post-commit auto-build did not run because this clean /tmp worktree has no installed dependencies (missing hono/arg/elysia); source changes are tests/type-import boundary only.