### PR TITLE
fix(workspace): add @maw-js/sdk dependency edge

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@eclipse-zenoh/zenoh-ts": "^1.9.0",
         "@elysiajs/cors": "^1.4.1",
         "@elysiajs/swagger": "^1.3.1",
+        "@maw-js/sdk": "workspace:*",
         "@monaco-editor/react": "^4.7.0",
         "@sinclair/typebox": "^0.34.49",
         "@xterm/addon-fit": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "description": "maw.js — Multi-Agent Workflow in Bun/TS. Remote tmux orchestra control. CLI + Web UI.",
   "dependencies": {
+    "@maw-js/sdk": "workspace:*",
     "@eclipse-zenoh/zenoh-ts": "^1.9.0",
     "@elysiajs/cors": "^1.4.1",
     "@elysiajs/swagger": "^1.3.1",


### PR DESCRIPTION
Closes #2171.\n\n## Summary\n- Adds the root dependency edge for the local SDK workspace package: `@maw-js/sdk`: `workspace:*`.\n- Regenerates `bun.lock` so clean installs create `node_modules/@maw-js/sdk -> ../../packages/sdk`.\n\n## Why\nVendor plugin source imports `@maw-js/sdk` / `@maw-js/sdk/plugin`; without an explicit root dependency, clean CI installs can omit that workspace link and fail during tests/build.\n\n## Verification\n- `bun install --frozen-lockfile`\n- `ls node_modules/@maw-js` showed `sdk -> ../../packages/sdk`\n- `bun run build`