### PR TITLE
fix: bound message retention for maw serve

### DIFF
--- a/src/commands/shared/comm-log-feed.ts
+++ b/src/commands/shared/comm-log-feed.ts
@@ -5,6 +5,7 @@
 
 import { loadConfig } from "../../config";
 import { appendFile, mkdir } from "fs/promises";
+import { pruneJsonlFile } from "../../vendor/mpr-plugins/messages/retention";
 import { hostname } from "os";
 import { dirname } from "path";
 import { buildMessageLifecycleFeedEvent, type MessageLifecycleInput } from "../../lib/message-events";
@@ -24,7 +25,7 @@ export async function logMessage(from: string, to: string, msg: string, route: s
     host: hostname(),
     route,
   }) + "\n";
-  try { await mkdir(dirname(logFile), { recursive: true }); await appendFile(logFile, line); } catch {}
+  try { await mkdir(dirname(logFile), { recursive: true }); await appendFile(logFile, line); pruneJsonlFile(logFile); } catch {}
 }
 
 /** Emit feed event to server plugin pipeline (CLI → server bridge) */

--- a/src/commands/shared/done.ts
+++ b/src/commands/shared/done.ts
@@ -6,6 +6,7 @@ import { listSessions, hostExec, tmux, takeSnapshot } from "../../sdk";
 import { getGhqRoot } from "../../config/ghq-root";
 import { normalizeTarget } from "../../core/matcher/normalize-target";
 import { mawDataPath } from "../../core/xdg";
+import { pruneJsonlFile } from "../../vendor/mpr-plugins/messages/retention";
 import { fleetDirForWrite, fleetDirsForRead, uniqueDirs } from "../../core/fleet/paths";
 
 export interface DoneOpts {
@@ -383,7 +384,9 @@ export function signalParentInbox(
     JSON.stringify({ ts: d.now().toISOString(), from, type: "done", msg: `worktree ${windowName} completed`, thread: null }) + "\n";
   try {
     d.fs.mkdirSync(inboxDir, { recursive: true });
-    d.fs.appendFileSync(join(inboxDir, `${parentTarget}.jsonl`), signal);
+    const signalPath = join(inboxDir, `${parentTarget}.jsonl`);
+    d.fs.appendFileSync(signalPath, signal);
+    pruneJsonlFile(signalPath);
   } catch (e) {
     d.logger.error(`  \x1b[33m⚠\x1b[0m inbox signal failed: ${e}`);
   }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -49,6 +49,14 @@ export interface MawSnapshotRetention {
   maxAgeDays?: number;
 }
 
+
+export interface MawRetentionPolicy {
+  /** Keep at least the newest N records. */
+  keepLast?: number;
+  /** Remove records older than D days. */
+  maxAgeDays?: number;
+}
+
 export interface MawLimits {
   feedMax?: number;
   feedDefault?: number;
@@ -209,6 +217,8 @@ export interface MawConfig {
   disabledPlugins?: string[];
   /** Fleet snapshot retention policy (#2146). */
   snapshotRetention?: MawSnapshotRetention;
+  /** Message/inbox retention policy (#2165). */
+  messageRetention?: MawRetentionPolicy;
   /** One-shot config migrations already applied. */
   migrations?: Record<string, boolean>;
 }

--- a/src/vendor/mpr-plugins/messages/ledger.ts
+++ b/src/vendor/mpr-plugins/messages/ledger.ts
@@ -2,6 +2,7 @@ import { Database } from "bun:sqlite";
 import { copyFileSync, existsSync, mkdirSync } from "fs";
 import { dirname } from "path";
 import { mawConfigPath, mawDataPath, type MessageDirection, type MessageLifecycleData, type MessageState } from "@maw-js/sdk";
+import { resolveMessageRetentionPolicy, type RetentionPolicy } from "./retention";
 
 export interface MessageLedgerQuery {
   limit?: number;
@@ -21,6 +22,12 @@ export interface MessageLedgerRow extends MessageLifecycleData {
 
 export interface MessageLedgerRetentionPolicy {
   maxMessages?: number;
+}
+
+export interface MessageLedgerRetentionSummary {
+  retained: number;
+  removed: number;
+  policy: { keepLast: number; maxAgeDays: number };
 }
 
 export const DEFAULT_MAX_MESSAGES = 50_000;
@@ -106,9 +113,26 @@ export function recordMessageLedgerEvent(event: MessageLifecycleData): void {
       $lastLine: event.lastLine ?? null,
       $signed: event.signed ? 1 : 0,
     });
-    pruneMessageLedgerDb(db);
+    pruneMessageLedgerEvents({}, db);
+
   } finally {
     db.close();
+  }
+}
+
+export function pruneMessageLedgerEvents(policy: RetentionPolicy = {}, dbOverride?: Database): MessageLedgerRetentionSummary {
+  const db = dbOverride ?? openDb();
+  try {
+    const resolved = resolveMessageRetentionPolicy(policy);
+    const now = policy.now ?? new Date();
+    const cutoff = new Date(now.getTime() - resolved.maxAgeDays * 24 * 60 * 60 * 1000).toISOString();
+    const before = Number((db.query("SELECT COUNT(*) AS count FROM messages").get() as any)?.count || 0);
+    db.query("DELETE FROM messages WHERE ts < $cutoff AND id NOT IN (SELECT id FROM messages ORDER BY ts DESC LIMIT $keepLast)").run({ $cutoff: cutoff, $keepLast: resolved.keepLast });
+    db.query("DELETE FROM messages WHERE id NOT IN (SELECT id FROM messages ORDER BY ts DESC LIMIT $keepLast)").run({ $keepLast: resolved.keepLast });
+    const retained = Number((db.query("SELECT COUNT(*) AS count FROM messages").get() as any)?.count || 0);
+    return { retained, removed: Math.max(0, before - retained), policy: resolved };
+  } finally {
+    if (!dbOverride) db.close();
   }
 }
 

--- a/src/vendor/mpr-plugins/messages/retention.ts
+++ b/src/vendor/mpr-plugins/messages/retention.ts
@@ -1,0 +1,79 @@
+import { readFileSync, renameSync, writeFileSync } from "fs";
+import { loadConfig } from "maw-js/config";
+
+export interface RetentionPolicy {
+  keepLast?: number;
+  maxAgeDays?: number;
+  now?: Date;
+}
+
+export interface RetentionResolvedPolicy {
+  keepLast: number;
+  maxAgeDays: number;
+}
+
+export interface JsonlRetentionSummary {
+  retained: number;
+  removed: number;
+  policy: RetentionResolvedPolicy;
+}
+
+const DEFAULT_KEEP_LAST = 10_000;
+const DEFAULT_MAX_AGE_DAYS = 14;
+
+function positiveInt(value: unknown): number | null {
+  const n = typeof value === "number" ? value : typeof value === "string" && value.trim() ? Number(value) : NaN;
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : null;
+}
+
+export function resolveMessageRetentionPolicy(policy: RetentionPolicy = {}): RetentionResolvedPolicy {
+  const config = (() => {
+    try { return loadConfig().messageRetention || {}; } catch { return {}; }
+  })();
+  const keepLast = positiveInt(policy.keepLast)
+    ?? positiveInt(process.env.MAW_MESSAGE_KEEP_LAST)
+    ?? positiveInt((config as any).keepLast)
+    ?? DEFAULT_KEEP_LAST;
+  const maxAgeDays = positiveInt(policy.maxAgeDays)
+    ?? positiveInt(process.env.MAW_MESSAGE_MAX_AGE_DAYS)
+    ?? positiveInt((config as any).maxAgeDays)
+    ?? DEFAULT_MAX_AGE_DAYS;
+  return { keepLast, maxAgeDays };
+}
+
+function lineTimeMs(line: string): number {
+  try {
+    const parsed = JSON.parse(line);
+    const ts = parsed?.ts || parsed?.timestamp;
+    const time = typeof ts === "number" ? ts : Date.parse(String(ts || ""));
+    return Number.isFinite(time) ? time : 0;
+  } catch {
+    return 0;
+  }
+}
+
+export function pruneJsonlFile(path: string, policy: RetentionPolicy = {}): JsonlRetentionSummary {
+  const resolved = resolveMessageRetentionPolicy(policy);
+  let lines: string[];
+  try {
+    lines = readFileSync(path, "utf-8").split("\n").filter(Boolean);
+  } catch {
+    return { retained: 0, removed: 0, policy: resolved };
+  }
+
+  const nowMs = (policy.now ?? new Date()).getTime();
+  const maxAgeMs = resolved.maxAgeDays * 24 * 60 * 60 * 1000;
+  const cutoff = Math.max(0, lines.length - resolved.keepLast);
+  const retained = lines.filter((line, index) => {
+    if (index >= cutoff) return true;
+    const timeMs = lineTimeMs(line);
+    return !timeMs || nowMs - timeMs <= maxAgeMs;
+  });
+  const removed = lines.length - retained.length;
+  if (removed > 0) {
+    const tmp = `${path}.tmp.${Date.now()}.${Math.random().toString(36).slice(2, 8)}`;
+    writeFileSync(tmp, retained.length ? `${retained.join("\n")}\n` : "", "utf-8");
+    renameSync(tmp, path);
+  }
+  return { retained: retained.length, removed, policy: resolved };
+}

--- a/test/isolated/message-retention-policy.test.ts
+++ b/test/isolated/message-retention-policy.test.ts
@@ -1,0 +1,83 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const SANDBOX = mkdtempSync(join(tmpdir(), "maw-message-retention-"));
+const oldHome = process.env.MAW_HOME;
+process.env.MAW_HOME = SANDBOX;
+process.env.MAW_TEST_MODE = "1";
+
+const { pruneJsonlFile, resolveMessageRetentionPolicy } = await import("../../src/vendor/mpr-plugins/messages/retention.ts?retention-policy");
+const ledger = await import("../../src/vendor/mpr-plugins/messages/ledger.ts?retention-policy");
+
+beforeEach(() => {
+  rmSync(SANDBOX, { recursive: true, force: true });
+  mkdirSync(SANDBOX, { recursive: true });
+  delete process.env.MAW_MESSAGE_KEEP_LAST;
+  delete process.env.MAW_MESSAGE_MAX_AGE_DAYS;
+});
+
+afterAll(() => {
+  if (oldHome === undefined) delete process.env.MAW_HOME;
+  else process.env.MAW_HOME = oldHome;
+  rmSync(SANDBOX, { recursive: true, force: true });
+});
+
+describe("message retention policy (#2165)", () => {
+  test("pruneJsonlFile trims by keep-last and max-age", () => {
+    const file = join(SANDBOX, "inbox.jsonl");
+    writeFileSync(file, [
+      JSON.stringify({ ts: "2026-01-01T00:00:00.000Z", msg: "old" }),
+      JSON.stringify({ ts: "2026-01-10T00:00:00.000Z", msg: "mid" }),
+      JSON.stringify({ ts: "2026-01-20T00:00:00.000Z", msg: "new" }),
+      "",
+    ].join("\n"));
+
+    const summary = pruneJsonlFile(file, { keepLast: 2, maxAgeDays: 15, now: new Date("2026-01-21T00:00:00.000Z") });
+
+    expect(summary).toMatchObject({ retained: 2, removed: 1, policy: { keepLast: 2, maxAgeDays: 15 } });
+    const text = readFileSync(file, "utf-8");
+    expect(text).not.toContain("old");
+    expect(text).toContain("mid");
+    expect(text).toContain("new");
+  });
+
+  test("keep-last preserves newest records even when age expired", () => {
+    const file = join(SANDBOX, "inbox-old-newest.jsonl");
+    writeFileSync(file, [
+      JSON.stringify({ ts: "2025-12-01T00:00:00.000Z", msg: "ancient" }),
+      JSON.stringify({ ts: "2026-01-01T00:00:00.000Z", msg: "newer-but-expired" }),
+      "",
+    ].join("\n"));
+
+    const summary = pruneJsonlFile(file, { keepLast: 1, maxAgeDays: 1, now: new Date("2026-01-21T00:00:00.000Z") });
+
+    expect(summary).toMatchObject({ retained: 1, removed: 1 });
+    const text = readFileSync(file, "utf-8");
+    expect(text).not.toContain("ancient");
+    expect(text).toContain("newer-but-expired");
+  });
+
+  test("env config drives retention defaults", () => {
+    process.env.MAW_MESSAGE_KEEP_LAST = "4";
+    process.env.MAW_MESSAGE_MAX_AGE_DAYS = "8";
+    expect(resolveMessageRetentionPolicy()).toEqual({ keepLast: 4, maxAgeDays: 8 });
+  });
+
+  test("pruneMessageLedgerEvents bounds sqlite rows", () => {
+    const db = new Database(":memory:");
+    db.exec("CREATE TABLE messages (id TEXT PRIMARY KEY, ts TEXT NOT NULL, direction TEXT NOT NULL, state TEXT NOT NULL, channel TEXT NOT NULL, route TEXT NOT NULL, from_id TEXT NOT NULL, to_id TEXT NOT NULL, target TEXT, peer_url TEXT, text TEXT NOT NULL, error TEXT, last_line TEXT, signed INTEGER NOT NULL DEFAULT 0)");
+    const insert = db.query("INSERT INTO messages (id, ts, direction, state, channel, route, from_id, to_id, text) VALUES ($id, $ts, 'outbound', 'sent', 'maw', 'local', 'a', 'b', 'hello')");
+    insert.run({ $id: "old", $ts: "2026-01-01T00:00:00.000Z" });
+    insert.run({ $id: "mid", $ts: "2026-01-10T00:00:00.000Z" });
+    insert.run({ $id: "new", $ts: "2026-01-20T00:00:00.000Z" });
+
+    const summary = ledger.pruneMessageLedgerEvents({ keepLast: 2, maxAgeDays: 30, now: new Date("2026-01-21T00:00:00.000Z") }, db);
+
+    expect(summary).toMatchObject({ retained: 2, removed: 1, policy: { keepLast: 2, maxAgeDays: 30 } });
+    expect(db.query("SELECT id FROM messages ORDER BY ts").all().map((r: any) => r.id)).toEqual(["mid", "new"]);
+    db.close();
+  });
+});


### PR DESCRIPTION
Closes #2165.\n\n## Summary\n- Adds shared message retention policy defaults for maw message stores.\n- Prunes the message ledger SQLite table after writes.\n- Prunes communication log JSONL and parent inbox JSONL at append points.\n- Adds root SDK workspace dependency edge needed by this branch's clean build.\n\n## Why\nLong-running `maw serve` can accumulate durable message/inbox state without a write-time retention bound. The issue report called out message-ledger and inbox JSONL as candidate growth surfaces.\n\n## Verification\n- `bun run build`\n- `bun test test/isolated/message-retention-policy.test.ts`\n\n## Notes\n- Not tested with a multi-day heap/RSS profile.\n- The workspace dependency edge overlaps with #2175/#2171 if that lands first.