### PR TITLE
release: v26.6.7-alpha.2328

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.6.7-alpha.2322",
+  "version": "26.6.7-alpha.2328",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts v26.6.7-alpha.2328 on merge via calver-release.yml.\n\nRebased on current alpha after #2175; release branch contains only the package.json CalVer bump.