### PR TITLE
refactor(tab): prepare standalone plugin extraction

### DIFF
--- a/packages/sdk/index.d.ts
+++ b/packages/sdk/index.d.ts
@@ -216,6 +216,14 @@ export declare function parseFlags<T extends Record<string, unknown>>(
   skip?: number,
 ): { [key: string]: unknown; _: string[] };
 
+// --- src/commands/shared/comm ---
+
+/** Peek/capture a target session or window and print the result. */
+export declare function cmdPeek(target: string): Promise<void>;
+
+/** Send a message to an oracle/window target. */
+export declare function cmdSend(target: string, message: string, force?: boolean): Promise<void>;
+
 // --- src/config ---
 
 /** Loaded operator config — opaque to plugins; consume via `cfg*` accessors. */

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -52,6 +52,9 @@ export type {
 // NOTE: also re-exported from "@maw-js/sdk/plugin" for ergonomics — both work.
 export { parseFlags } from "../../src/cli/parse-args";
 
+// Plugin extraction helpers for tab-like command surfaces.
+export { cmdPeek, cmdSend } from "../../src/commands/shared/comm";
+
 // ─── src/config ──────────────────────────────────────────────────────────────
 // Operator config loader + key-typed accessors. Used by:
 //   loadConfig    — consent, ping, health, send, run, send-enter, contacts,

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -136,6 +136,9 @@ export { registerCommand, matchCommand, listCommands } from "../cli/command-regi
 
 export { parseFlags } from "../cli/parse-args";
 
+// Plugin extraction helpers for tab-like command surfaces.
+export { cmdPeek, cmdSend } from "../commands/shared/comm";
+
 // ─── Transport Router ────────────────────────────────────────────────────────
 
 export {

--- a/src/vendor/mpr-plugins/tab/impl.ts
+++ b/src/vendor/mpr-plugins/tab/impl.ts
@@ -1,6 +1,4 @@
-import { hostExec } from "maw-js/sdk";
-import { tmux, tmuxCmd } from "maw-js/sdk";
-import { cmdPeek, cmdSend } from "maw-js/commands/shared/comm";
+import { hostExec, tmux, tmuxCmd, cmdPeek, cmdSend } from "maw-js/sdk";
 import { cmdTalkTo } from "./internal/talk-to-impl";
 
 /**

--- a/test/isolated/tab-standalone-extraction.test.ts
+++ b/test/isolated/tab-standalone-extraction.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const root = join(import.meta.dir, "../..");
+const peekCalls: string[] = [];
+const sendCalls: Array<{ target: string; message: string; force: boolean }> = [];
+const talkToCalls: Array<{ target: string; message: string; force: boolean }> = [];
+const talkToPath = import.meta.resolve("../../src/vendor/mpr-plugins/tab/internal/talk-to-impl.ts");
+
+mock.module("maw-js/sdk", () => ({
+  tmux: {
+    run: async (subcommand: string) => subcommand === "display-message" ? "01-neo\n" : "",
+  },
+  tmuxCmd: () => "tmux",
+  hostExec: async () => "0:main:1\n1:logs:0\n",
+  cmdPeek: async (target: string) => { peekCalls.push(target); },
+  cmdSend: async (target: string, message: string, force = false) => { sendCalls.push({ target, message, force }); },
+}));
+
+mock.module(talkToPath, () => ({
+  cmdTalkTo: async (target: string, message: string, force = false) => {
+    talkToCalls.push({ target, message, force });
+  },
+}));
+
+describe("tab standalone extraction prep (#2113)", () => {
+  test("tab impl routes peek/send through SDK instead of shared comm", () => {
+    const impl = readFileSync(join(root, "src/vendor/mpr-plugins/tab/impl.ts"), "utf8");
+    expect(impl).toContain('from "maw-js/sdk"');
+    expect(impl).not.toContain("maw-js/commands/shared/comm");
+  });
+
+  test("handler can peek and send with only SDK mocked", async () => {
+    peekCalls.length = 0;
+    sendCalls.length = 0;
+    talkToCalls.length = 0;
+    const handler = (await import("../../src/vendor/mpr-plugins/tab/index.ts?tab-standalone-extraction")).default;
+    expect(await handler({ source: "cli", args: ["1"] })).toMatchObject({ ok: true });
+    expect(await handler({ source: "cli", args: ["1", "hello", "there", "--force"] })).toMatchObject({ ok: true });
+    expect(peekCalls).toEqual(["logs"]);
+    expect(sendCalls).toEqual([{ target: "logs", message: "hello there", force: true }]);
+  });
+});


### PR DESCRIPTION
## Summary
- moves tab peek/send dependencies to the SDK boundary
- exports cmdPeek/cmdSend from runtime and public SDK surfaces
- adds a standalone-style tab test that runs with only maw-js/sdk and internal talk-to mocked

## Verification
- `bun test test/isolated/tab-standalone-extraction.test.ts`

## Follow-up
- tab talk-to internals still need their own SDK-safe extraction slice.

RFC #2113 extraction prep.
