### PR TITLE
Fix exact tmux pane routing before alias ambiguity

### DIFF
--- a/src/core/routing.ts
+++ b/src/core/routing.ts
@@ -78,6 +78,13 @@ export function resolveTarget(
 
   const selfNode = config.node ?? "local";
 
+  // #1450 release blocker: a concrete tmux pane address already names the
+  // exact local session/window/pane. Do not run session-alias suffix matching
+  // on this shape, or `47-mawjs:1.0` can be misread as alias `mawjs` and become
+  // ambiguous with `08-mawjs`.
+  const exactTmuxAddress = resolveExactTmuxPaneAddress(query, writable, "local");
+  if (exactTmuxAddress) return exactTmuxAddress;
+
   // Fleet config: oracle name → session name → findWindow (#281)
   //
   // #1565: fleet-known oracle names must not silently inherit findWindow's
@@ -339,6 +346,32 @@ function resolveSessionWindowAliasTarget(
     type: routeType,
     target: `${session.name}:${window.index}${paneIndex ? `.${paneIndex}` : ""}`,
   };
+}
+
+function resolveExactTmuxPaneAddress(
+  query: string,
+  writable: Session[],
+  routeType: FleetRouteType,
+): FleetWindowResult | null {
+  const match = query.trim().match(/^([^:]+):(\d+)\.(\d+)$/);
+  if (!match) return null;
+
+  const [, sessionName, rawWindowIndex, paneIndex] = match;
+  const session = writable.find((s) => s.name === sessionName);
+  if (!session) return null;
+
+  const windowIndex = Number(rawWindowIndex);
+  const window = session.windows.find((w) => w.index === windowIndex);
+  if (!window) {
+    return {
+      type: "error",
+      reason: "session_window_index_not_found",
+      detail: `'${sessionName}' matched local session '${session.name}', but window ${rawWindowIndex} was not found`,
+      hint: `candidates: ${session.windows.map((w) => `${session.name}:${w.index} (${w.name})`).join(", ") || "none"}`,
+    };
+  }
+
+  return { type: routeType, target: `${session.name}:${window.index}.${paneIndex}` };
 }
 
 function resolveSessionAliasWindowTarget(


### PR DESCRIPTION
## Summary\n- short-circuit fully-qualified tmux pane addresses like  before session alias suffix matching\n- require exact local session-name match for the  form\n- avoid false  errors for concrete tmux addresses\n\nCloses #2180.\n\n## Tests\n- bun test v1.4.0-canary.1 (b96cc3fa1)\n- === test-default-safe.sh: shared default sweep ===
bun test v1.4.0-canary.1 (b96cc3fa1)
[commands] overriding "test-override" (was: user, now: builtin)
[commands] loaded wasm: greet.wasm (memory: 1/256 pages)
[commands] skipped wasm: noop.wasm (no handle+memory exports)
→ scanning laris-co/wireboy-oracle ... not found
→ scanning Soul-Brews-Studio/wireboy-oracle ... FOUND  https://github.com/Soul-Brews-Studio/wireboy-oracle
→ scanning org-a/ghost-oracle ... not found
→ scanning org-b/ghost-oracle ... not found
→ scanning my-org/wireboy-oracle ... not found

[36m🔍 Scan for testoracle-oracle?[0m

Provider: github.com (scope: all local (org-fetch failed))
Orgs (1, sorted):
  Soul-Brews-Studio        (local)

Will check: gh repo view <org>/testoracle-oracle  (1 request)

[90m(non-interactive — cannot prompt)[0m
[90mManually: gh repo view <org>/testoracle-oracle  then: ghq get -u <url>  then re-run maw wake testoracle[0m

[36m🔍 Scan for notexistsoracle-oracle?[0m

Provider: github.com (scope: all local (org-fetch failed))
Orgs (1, sorted):
  my-org                   (local)

Will check: gh repo view <org>/notexistsoracle-oracle  (1 request)

→ scanning my-org/notexistsoracle-oracle ... not found

[36m🔍 Scan for liquid-oracle?[0m

Provider: github.com (scope: owned + member orgs only)
Orgs (3, sorted):
  laris-co                 (local)
  nazt                     (local)
  Soul-Brews-Studio        (local)

Will check: gh repo view <org>/liquid-oracle  (3 requests)

→ scanning laris-co/liquid-oracle ... not found
→ scanning nazt/liquid-oracle ... not found
→ scanning Soul-Brews-Studio/liquid-oracle ... not found

[36m🔍 Scan for liquid-oracle?[0m

Provider: github.com (scope: --all-local (no filter))
Orgs (2, sorted):
  anthropics               (local)
  Soul-Brews-Studio        (local)

Will check: gh repo view <org>/liquid-oracle  (2 requests)

→ scanning anthropics/liquid-oracle ... not found
→ scanning Soul-Brews-Studio/liquid-oracle ... not found

[36m🔍 Scan for liquid-oracle?[0m

Provider: github.com (scope: all local (org-fetch failed))
Orgs (2, sorted):
  anthropics               (local)
  Soul-Brews-Studio        (local)

Will check: gh repo view <org>/liquid-oracle  (2 requests)

→ scanning anthropics/liquid-oracle ... not found
→ scanning Soul-Brews-Studio/liquid-oracle ... not found

[36m🔍 Scan for solo-oracle?[0m

Provider: github.com (scope: owned + member orgs only)
Orgs (1, sorted):
  Soul-Brews-Studio        (local)

Will check: gh repo view <org>/solo-oracle  (1 request)

→ scanning Soul-Brews-Studio/solo-oracle ... FOUND  https://github.com/Soul-Brews-Studio/solo-oracle

[36m⚡ ghq get -u https://github.com/Soul-Brews-Studio/solo-oracle[0m
[32m✓ cloned to /opt/Code/github.com/Soul-Brews-Studio/solo-oracle[0m

continuing wake...

[36m🔍 Scan for solo-oracle?[0m

Provider: github.com (scope: owned + member orgs only)
Orgs (1, sorted):
  Soul-Brews-Studio        (local)

Will check: gh repo view <org>/solo-oracle  (1 request)

→ scanning Soul-Brews-Studio/solo-oracle ... FOUND  https://github.com/Soul-Brews-Studio/solo-oracle

[36m⚡ ghq get -u https://github.com/Soul-Brews-Studio/solo-oracle[0m

[36m🔍 Scan for solo-oracle?[0m

Provider: github.com (scope: owned + member orgs only)
Orgs (1, sorted):
  Soul-Brews-Studio        (local)

Will check: gh repo view <org>/solo-oracle  (1 request)

[90maborted. Manually: ghq get -u <url>  then re-run maw wake solo[0m
[hub] connecting to 1 workspace(s)...
[hub] connecting to 1 workspace(s)...
[hub] connecting to 1 workspace(s)...

  'white' matches 2 worktrees — wake which?
  [36m1[0m) 1-white  [90m/repos/homelab.wt-1-white[0m
  [36m2[0m) 2-white  [90m/repos/homelab.wt-2-white[0m

  Select [1-2]: 
  'white' matches 2 worktrees — wake which?
  [36m1[0m) 1-white  [90m/repos/homelab.wt-1-white[0m
  [36m2[0m) 2-white  [90m/repos/homelab.wt-2-white[0m

  Select [1-2]: 
  'white' matches 2 worktrees — wake which?
  [36m1[0m) 1-white  [90m/repos/homelab.wt-1-white[0m
  [36m2[0m) 2-white  [90m/repos/homelab.wt-2-white[0m

  Select [1-2]: 
  'white' matches 2 worktrees — wake which?
  [36m1[0m) 1-white  [90m/repos/homelab.wt-1-white[0m
  [36m2[0m) 2-white  [90m/repos/homelab.wt-2-white[0m

  Select [1-2]: 
  'white' matches 2 worktrees — wake which?
  [36m1[0m) 1-white  [90m/repos/homelab.wt-1-white[0m
  [36m2[0m) 2-white  [90m/repos/homelab.wt-2-white[0m

  Select [1-2]: 
  'white' matches 2 worktrees — wake which?
  [36m1[0m) 1-white  [90m/repos/homelab.wt-1-white[0m
  [36m2[0m) 2-white  [90m/repos/homelab.wt-2-white[0m

  Select [1-2]: 
  'white' matches 2 worktrees — wake which?
  [36m1[0m) 1-white  [90m/repos/homelab.wt-1-white[0m
  [36m2[0m) 2-white  [90m/repos/homelab.wt-2-white[0m

  Select [1-2]: [36m↻[0m plugin lifecycle wake: 3 hooks
[36m↻[0m plugin lifecycle wake: 1 hook
[36m↻[0m plugin lifecycle sleep: 1 hook
[36m↻[0m plugin lifecycle serve: 1 hook
[36m↻[0m plugin lifecycle wake: 1 hook
[36mmaw cleanup --worktrees[0m — orphan worktree survey
  SKIP  4-other                  -                        owned by uid 999
        [90m/repos/github.com/org/repo.wt-4-other[0m
  KEEP  1-live                   -                        live pane cwd is inside worktree live=team:live.0
        [90m/repos/github.com/org/repo/agents/1-live[0m
  CLEAN 2-clean                  feature/clean            no live pane, clean git state
        [90m/repos/github.com/org/repo/agents/2-clean[0m
  ASK   3-dirty                  feature/dirty            uncommitted changes
        [90m/repos/github.com/org/repo/agents/3-dirty[0m
  [32m✓[0m removed org/repo/agents/2-clean
[transport] mqtt: timeout (retryable) — trying next
[transport] peer: auth — trying next
[transport] rejecting: send failed for neo, trying next
[32m✓[0m integ-ping@1.0.0 installed from http://127.0.0.1:60253/api/plugin/download/integ-ping
  sdk: 1.0.0-alpha.1 ✓ (maw 1.0.0-alpha.1)
  capabilities: (none)
  mode: installed (sha256:72961e5…)
  dir: /var/folders/lf/s98q6y892sl__0brv1tyn0ch0000gn/T/maw-atpeer-AMIoVy/client-plugins/integ-ping
try: maw integ-ping
[32m✓[0m integ-consent-ping@1.0.0 installed from http://127.0.0.1:60263/api/plugin/download/integ-consent-ping
  sdk: 1.0.0-alpha.1 ✓ (maw 1.0.0-alpha.1)
  capabilities: (none)
  mode: installed (sha256:7ed9b5c…)
  dir: /var/folders/lf/s98q6y892sl__0brv1tyn0ch0000gn/T/maw-consent-install-18Rf5r/client-plugins/integ-consent-ping
try: maw integ-consent-ping (local run reached 2327 tests; routing fix included, but 14 existing tmux wrapper tests failed in this environment)\n\nNo version bump.