### PR TITLE
test: standalone coverage for peek plugin

### DIFF
--- a/test/isolated/plugin-peek-standalone.test.ts
+++ b/test/isolated/plugin-peek-standalone.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "../..");
+
+let peekCalls: Array<string | undefined> = [];
+let shouldThrow = false;
+
+mock.module("maw-js/commands/shared/comm", () => ({
+  cmdPeek: async (target?: string) => {
+    peekCalls.push(target);
+    console.log(`peeked:${target ?? "default"}`);
+    if (shouldThrow) throw new Error("peek failed");
+  },
+}));
+
+const { command, default: peekHandler } = await import("../../src/vendor/mpr-plugins/peek/index.ts");
+
+beforeEach(() => {
+  peekCalls = [];
+  shouldThrow = false;
+});
+
+describe("peek plugin standalone coverage (#2185)", () => {
+  test("has no direct core imports", () => {
+    const source = readFileSync(join(root, "src/vendor/mpr-plugins/peek/index.ts"), "utf8");
+
+    expect(source).not.toMatch(/maw-js\/core(?:\/|")/);
+    expect(source).not.toMatch(/from\s+["'](?:\.\.\/)+core\//);
+    expect(source).not.toMatch(/from\s+["'](?:\.\.\/)+src\/core\//);
+  });
+
+  test("exports command metadata", () => {
+    expect(command).toMatchObject({
+      name: "peek",
+      description: expect.stringContaining("Peek at the latest output"),
+    });
+  });
+
+  test("CLI args call cmdPeek and capture console output without writer", async () => {
+    const result = await peekHandler({ source: "cli", args: ["mawjs-codex-1"] } as any);
+
+    expect(peekCalls).toEqual(["mawjs-codex-1"]);
+    expect(result).toEqual({ ok: true, output: "peeked:mawjs-codex-1" });
+  });
+
+  test("writer receives output and API source uses default target", async () => {
+    const written: string[] = [];
+    const result = await peekHandler({
+      source: "api",
+      args: { target: "ignored-by-wrapper" },
+      writer: (...parts: unknown[]) => written.push(parts.map(String).join(" ")),
+    } as any);
+
+    expect(peekCalls).toEqual([undefined]);
+    expect(written).toEqual(["peeked:default"]);
+    expect(result).toEqual({ ok: true, output: undefined });
+  });
+
+  test("returns captured output as error when cmdPeek fails", async () => {
+    shouldThrow = true;
+
+    const result = await peekHandler({ source: "cli", args: ["broken"] } as any);
+
+    expect(peekCalls).toEqual(["broken"]);
+    expect(result).toEqual({ ok: false, error: "peeked:broken", output: "peeked:broken" });
+  });
+});


### PR DESCRIPTION
Closes #2185.\n\n## Summary\n- Add isolated standalone coverage for the tiny peek plugin.\n- Verify the plugin source has no direct core imports.\n- Cover metadata, CLI target forwarding, writer behavior, API default target behavior, and failure output capture.\n\n## Verification\n- Import-boundary grep: no peek core imports.\n- `bun build test/isolated/plugin-peek-standalone.test.ts --outfile /tmp/plugin-peek-standalone.js --target=bun --external maw-js/commands/shared/comm`\n- `git diff --check`\n- `bun run build`\n\n## Known local gap\n- `bun test test/isolated/plugin-peek-standalone.test.ts` crashes locally before assertions with the known Bun canary panic: `index out of bounds: the len is 4095 but the index is 4095`.