### PR TITLE
refactor(find): prepare standalone plugin extraction

### DIFF
--- a/packages/sdk/index.d.ts
+++ b/packages/sdk/index.d.ts
@@ -270,6 +270,9 @@ export declare function buildCommand(agentName: string): string;
 /** Build the agent command line, anchored to a specific cwd. */
 export declare function buildCommandInDir(agentName: string, cwd: string): string;
 
+/** Resolve the bare ghq root without the github.com host suffix. */
+export declare function getGhqRoot(): string;
+
 // --- src/core/matcher/resolve-target ---
 
 /** Discriminated-union result of a bare-name resolution attempt. */

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -66,6 +66,7 @@ export {
   buildCommand,
   buildCommandInDir,
 } from "../../src/config";
+export { getGhqRoot } from "../../src/config/ghq-root";
 
 // ─── src/core/matcher/resolve-target ─────────────────────────────────────────
 // Bare-name → ResolveResult cascade (exact / suffix / prefix / hint).

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -25,6 +25,7 @@ export {
   resetConfig,
 } from "../config";
 export { DEFAULT_ENGINES, resolveEngine } from "../config/engine-registry";
+export { getGhqRoot } from "../config/ghq-root";
 export type { EngineDef } from "../config/engine-def";
 export type { EngineRegistry } from "../config/engine-registry";
 export type { MawConfig } from "../config";

--- a/src/vendor/mpr-plugins/find/impl.ts
+++ b/src/vendor/mpr-plugins/find/impl.ts
@@ -1,6 +1,4 @@
-import { hostExec } from "maw-js/sdk";
-import { getGhqRoot } from "maw-js/config/ghq-root";
-import { loadFleet } from "maw-js/commands/shared/fleet-load";
+import { hostExec, getGhqRoot, loadFleetCore as loadFleet } from "maw-js/sdk";
 import { join } from "path";
 import { existsSync, readdirSync } from "fs";
 

--- a/test/isolated/plugin-find-standalone.test.ts
+++ b/test/isolated/plugin-find-standalone.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync, readFileSync } from "fs";
+import { join } from "path";
+
+const root = join(import.meta.dir, "../..");
+const sandbox = join(import.meta.dir, ".tmp-find-standalone");
+const ghqRoot = join(sandbox, "ghq");
+const hostExecCalls: string[] = [];
+let fleet: Array<{
+  name: string;
+  windows: Array<{ name: string; repo?: string }>;
+  sync_peers?: string[];
+  project_repos?: string[];
+}> = [];
+let hostResponses: Record<string, string> = {};
+
+mock.module("maw-js/sdk", () => ({
+  getGhqRoot: () => ghqRoot,
+  loadFleetCore: () => fleet,
+  hostExec: async (cmd: string) => {
+    hostExecCalls.push(cmd);
+    return hostResponses[cmd] ?? "";
+  },
+}));
+
+const { default: findHandler } = await import("../../src/vendor/mpr-plugins/find/index.ts?plugin-find-standalone");
+
+function stripAnsi(value: string | undefined) {
+  return String(value ?? "").replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "");
+}
+
+beforeEach(() => {
+  rmSync(sandbox, { recursive: true, force: true });
+  mkdirSync(join(ghqRoot, "github.com", "Soul-Brews-Studio", "neo-oracle"), { recursive: true });
+  mkdirSync(join(ghqRoot, "github.com", "Soul-Brews-Studio", "ghost"), { recursive: true });
+  hostExecCalls.length = 0;
+  hostResponses = {};
+  fleet = [
+    {
+      name: "1-neo",
+      windows: [{ name: "main", repo: "Soul-Brews-Studio/neo-oracle" }],
+      sync_peers: ["white:neo"],
+      project_repos: ["Soul-Brews-Studio/maw-js"],
+    },
+    { name: "2-ghost", windows: [{ name: "quiet", repo: "Soul-Brews-Studio/ghost" }] },
+  ];
+});
+
+describe("find plugin standalone boundary (#2113)", () => {
+  test("imports runtime dependencies from the SDK boundary", () => {
+    const files = ["index.ts", "impl.ts"].map((file) =>
+      readFileSync(join(root, "src/vendor/mpr-plugins/find", file), "utf8"),
+    );
+    for (const source of files) {
+      expect(source).not.toMatch(/maw-js\/(?:core|commands\/shared|lib|config)(?:\/|")/);
+      expect(source).not.toMatch(/from\s+["'](?:\.\.\/)+/);
+    }
+    const combined = files.join("\n");
+    expect(combined).toContain('from "maw-js/sdk"');
+    expect(combined).toContain("getGhqRoot");
+    expect(combined).toContain("loadFleetCore");
+    expect(combined).toContain("hostExec");
+  });
+
+  test("finds oracle and fleet matches with only SDK mocked", async () => {
+    const result = await findHandler({ source: "cli", args: ["neo"] } as any);
+
+    expect(result.ok).toBe(true);
+    const output = stripAnsi(result.output);
+    expect(output).toContain('Searching — "neo"');
+    expect(output).toContain("Oracles");
+    expect(output).toContain("neo (Soul-Brews-Studio/neo-oracle)");
+    expect(output).toContain("Fleet");
+    expect(output).toContain("session 1-neo");
+    expect(output).toContain("sync_peer white:neo");
+  });
+
+  test("searches psi memory via SDK hostExec and supports --oracle filter", async () => {
+    const psiPath = join(ghqRoot, "github.com", "Soul-Brews-Studio", "neo-oracle", "ψ", "memory");
+    mkdirSync(psiPath, { recursive: true });
+    writeFileSync(join(psiPath, "note.md"), "needle appears here\n");
+    const findCmd = `grep -ril 'needle' '${psiPath}' 2>/dev/null || true`;
+    const matchCmd = `grep -m1 -i 'needle' '${join(psiPath, "note.md")}' 2>/dev/null || true`;
+    hostResponses[findCmd] = `${join(psiPath, "note.md")}\n`;
+    hostResponses[matchCmd] = "needle appears here\n";
+
+    const result = await findHandler({ source: "cli", args: ["needle", "--oracle", "neo"] } as any);
+
+    expect(result.ok).toBe(true);
+    expect(hostExecCalls).toEqual([findCmd, matchCmd]);
+    const output = stripAnsi(result.output);
+    expect(output).toContain("Code");
+    expect(output).toContain("neo (1 match)");
+    expect(output).toContain("note.md");
+    expect(output).toContain("needle appears here");
+  });
+
+  test("returns usage error when keyword is missing", async () => {
+    const result = await findHandler({ source: "cli", args: [] } as any);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("usage: maw find <keyword>");
+  });
+});


### PR DESCRIPTION
## Summary
- moves `find` runtime dependencies to the SDK boundary
- exports `getGhqRoot` from the runtime/public SDK and uses existing `loadFleetCore` instead of shared fleet-load
- adds a standalone-style `find` plugin test that mocks only `maw-js/sdk`

## Verification
- `bun test test/isolated/plugin-find-standalone.test.ts`

RFC #2113 extraction prep.
