### PR TITLE
test: standalone coverage for capture plugin

### DIFF
--- a/src/vendor/mpr-plugins/capture/impl.ts
+++ b/src/vendor/mpr-plugins/capture/impl.ts
@@ -1,5 +1,4 @@
-import { hostExec, listSessions, tmuxCmd } from "maw-js/sdk";
-import { loadFleet } from "maw-js/commands/shared/fleet-load";
+import { hostExec, listSessions, loadFleetCore as loadFleet, tmuxCmd } from "maw-js/sdk";
 import { resolveAttachTarget } from "../attach/resolve-attach-target";
 
 export interface CaptureOpts {

--- a/src/vendor/mpr-plugins/capture/index.ts
+++ b/src/vendor/mpr-plugins/capture/index.ts
@@ -1,6 +1,5 @@
-import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import { parseFlags, type InvokeContext, type InvokeResult } from "maw-js/sdk";
 import { cmdCapture } from "./impl";
-import { parseFlags } from "maw-js/cli/parse-args";
 
 export const command = {
   name: "capture",

--- a/test/isolated/plugin-capture-standalone.test.ts
+++ b/test/isolated/plugin-capture-standalone.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "../..");
+
+type Session = { name: string; windows?: Array<{ index?: number; name?: string }> };
+
+let sessions: Session[] = [];
+let hostCommands: string[] = [];
+let hostOutput = "captured output";
+let resolveResult: unknown = { tier: 1, sessionName: "54-mawjs" };
+let loadFleetCalls = 0;
+let resolveCalls: Array<{ target: string; deps: Record<string, unknown> }> = [];
+
+function parseFlags(args: string[], spec: Record<string, unknown>) {
+  const out: Record<string, any> = { _: [] };
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg in spec) {
+      const kind = spec[arg];
+      if (kind === Boolean) out[arg] = true;
+      else if (kind === Number) out[arg] = Number(args[++i]);
+      else out[arg] = args[++i];
+    } else {
+      out._.push(arg);
+    }
+  }
+  return out;
+}
+
+mock.module("maw-js/sdk", () => ({
+  hostExec: async (command: string) => {
+    hostCommands.push(command);
+    return hostOutput;
+  },
+  listSessions: async () => sessions,
+  loadFleetCore: () => {
+    loadFleetCalls += 1;
+    return [{ name: "54-mawjs", windows: [{ name: "mawjs-oracle" }] }];
+  },
+  parseFlags,
+  tmuxCmd: () => "tmux -L test",
+}));
+
+mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/attach/resolve-attach-target.ts"), () => ({
+  resolveAttachTarget: async (target: string, deps: Record<string, unknown>) => {
+    resolveCalls.push({ target, deps });
+    return resolveResult;
+  },
+}));
+
+const { command, default: captureHandler } = await import("../../src/vendor/mpr-plugins/capture/index.ts");
+
+function stripAnsi(value: string | undefined) {
+  return String(value ?? "").replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "");
+}
+
+beforeEach(() => {
+  sessions = [{ name: "54-mawjs", windows: [{ index: 7, name: "mawjs-oracle" }] }];
+  hostCommands = [];
+  hostOutput = "captured output";
+  resolveResult = { tier: 1, sessionName: "54-mawjs" };
+  loadFleetCalls = 0;
+  resolveCalls = [];
+});
+
+describe("capture plugin standalone boundary (#2191)", () => {
+  test("uses SDK imports for shared helpers and has no core imports", () => {
+    const sources = ["index.ts", "impl.ts"].map((file) =>
+      readFileSync(join(root, "src/vendor/mpr-plugins/capture", file), "utf8"),
+    );
+
+    for (const source of sources) {
+      expect(source).not.toMatch(/maw-js\/(?:core|commands\/shared|cli|config|lib)(?:\/|")/);
+      expect(source).not.toMatch(/from\s+["'](?:\.\.\/)+(?:core|commands|cli|config|lib)\//);
+    }
+    expect(sources.join("\n")).toContain('from "maw-js/sdk"');
+  });
+
+  test("exports command metadata", () => {
+    expect(command).toMatchObject({
+      name: "capture",
+      description: expect.stringContaining("Capture visible pane output"),
+    });
+  });
+
+  test("CLI target and flags capture the requested pane tail", async () => {
+    const result = await captureHandler({ source: "cli", args: ["mawjs", "--pane", "2", "--lines", "12"] } as any);
+
+    expect(result).toEqual({ ok: true, output: "captured output" });
+    expect(resolveCalls.map((call) => call.target)).toEqual(["mawjs"]);
+    expect(loadFleetCalls).toBe(0);
+    expect(hostCommands).toEqual(["tmux -L test capture-pane -t '54-mawjs:7.2' -p -S -12"]);
+  });
+
+  test("API target supports explicit window suffix and full scrollback", async () => {
+    const result = await captureHandler({ source: "api", args: { target: "mawjs:3", full: true } } as any);
+
+    expect(result.ok).toBe(true);
+    expect(hostCommands).toEqual(["tmux -L test capture-pane -t '54-mawjs:3' -p -S -"]);
+  });
+
+  test("missing target and unresolved sessions return InvokeResult errors", async () => {
+    await expect(captureHandler({ source: "api", args: {} } as any)).resolves.toMatchObject({ ok: false, error: "target is required" });
+
+    resolveResult = null;
+    const missing = await captureHandler({ source: "cli", args: ["ghost"] } as any);
+    expect(missing.ok).toBe(false);
+    expect(stripAnsi(missing.error)).toContain("try: maw ls");
+    expect(stripAnsi(missing.output)).toContain("try: maw ls");
+  });
+});


### PR DESCRIPTION
Closes #2191.\n\n## Summary\n- Switch capture plugin shared imports to the SDK barrel.\n- Add isolated standalone coverage for capture plugin metadata, CLI/API option handling, capture command construction, and error capture.\n- Assert capture stays free of private core/shared/cli/config/lib imports.\n\n## Verification\n- No-core/shared/cli/config/lib import grep for `src/vendor/mpr-plugins/capture`.\n- `bun build test/isolated/plugin-capture-standalone.test.ts --outfile /tmp/plugin-capture-standalone.js --target=bun --external maw-js/sdk`\n- `git diff --check`\n- `bun run build`\n\n## Known local gap\n- `bun test test/isolated/plugin-capture-standalone.test.ts` crashes locally before assertions with the known Bun canary panic: `index out of bounds: the len is 4095 but the index is 4095`.