### PR TITLE
test(wake): keep requested snapshot fixture discoverable

### DIFF
--- a/test/wake-cmd-cmdwake-coverage.test.ts
+++ b/test/wake-cmd-cmdwake-coverage.test.ts
@@ -507,8 +507,20 @@ mock.module(join(import.meta.dir, "../src/core/fleet/snapshot"), () => ({
   ..._rSnapshot,
   latestSnapshot: () =>
     mockActive ? snapshotReturn : realSnapshot.latestSnapshot(),
+  listSnapshots: () => {
+    if (!mockActive) return _rSnapshot.listSnapshots();
+    return snapshotReturn
+      ? [{
+          file: "snap-1.json",
+          timestamp: snapshotReturn.timestamp,
+          trigger: snapshotReturn.trigger,
+          sessionCount: snapshotReturn.sessions.length,
+          windowCount: snapshotReturn.sessions.reduce((sum, session) => sum + session.windows.length, 0),
+        }]
+      : [];
+  },
   loadSnapshot: (id: string) =>
-    mockActive ? snapshotReturn : realSnapshot.loadSnapshot(id),
+    mockActive ? (id === "snap-1" || id === "snap-1.json" ? snapshotReturn : null) : realSnapshot.loadSnapshot(id),
 }));
 
 mock.module(join(import.meta.dir, "../src/core/fleet/claude-sessions"), () => ({


### PR DESCRIPTION
Closes #2199.\n\n## Summary\n- Updates the wake-cmd snapshot mock to expose `snap-1.json` via `listSnapshots()` whenever the test fixture has a snapshot.\n- Keeps `loadSnapshot("snap-1")` tied to the same fixture and unknown ids returning null.\n- Preserves the no-snapshot failure case by returning an empty snapshot list.\n\n## Why\nWake now lists snapshots before loading a requested id. The old fixture mocked `loadSnapshot` only, so `snap-1` was rejected before the mocked load path could run.\n\n## Verification\n- `bun test test/wake-cmd-cmdwake-coverage.test.ts`\n- `bun run build`