### PR TITLE
refactor(stop): prepare standalone plugin extraction

### DIFF
--- a/packages/sdk/index.d.ts
+++ b/packages/sdk/index.d.ts
@@ -474,6 +474,9 @@ export declare function countDisabledFleetFilesCore(dirs?: string[]): number;
 export declare function loadDisabledFleetEntriesCore(dirs?: string[]): DisabledFleetEntry[];
 export declare function loadFleetEntries(dirs?: string[]): FleetEntry[];
 
+/** Stop all configured fleet sessions. */
+export declare function cmdSleep(): Promise<void>;
+
 // --- src/lib/artifacts ---
 
 export interface ArtifactMeta {

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -188,6 +188,7 @@ export {
   loadDisabledFleetEntries as loadDisabledFleetEntriesCore,
   loadFleetEntries,
 } from "../../src/core/fleet/fleet-load-core";
+export { cmdSleep } from "../../src/commands/shared/fleet-wake";
 export type {
   FleetWindow, FleetSession, FleetEntry, DisabledFleetEntry,
 } from "../../src/core/fleet/fleet-load-core";

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -100,6 +100,7 @@ export {
   loadDisabledFleetEntries as loadDisabledFleetEntriesCore,
   loadFleetEntries,
 } from "../core/fleet/fleet-load-core";
+export { cmdSleep } from "../commands/shared/fleet-wake";
 export type {
   FleetWindow, FleetSession, FleetEntry, DisabledFleetEntry,
 } from "../core/fleet/fleet-load-core";

--- a/src/vendor/mpr-plugins/stop/index.ts
+++ b/src/vendor/mpr-plugins/stop/index.ts
@@ -1,5 +1,5 @@
 import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
-import { cmdSleep } from "maw-js/commands/shared/fleet";
+import { cmdSleep } from "maw-js/sdk";
 
 export const command = {
   name: ["stop", "rest"],

--- a/test/isolated/plugin-stop-standalone.test.ts
+++ b/test/isolated/plugin-stop-standalone.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const root = join(import.meta.dir, "../..");
+let sleepCalls = 0;
+let fail: Error | null = null;
+
+mock.module("maw-js/sdk", () => ({
+  cmdSleep: async () => {
+    sleepCalls += 1;
+    if (fail) throw fail;
+    console.log("fleet slept");
+  },
+}));
+
+const { default: stopHandler } = await import("../../src/vendor/mpr-plugins/stop/index.ts?plugin-stop-standalone");
+
+beforeEach(() => {
+  sleepCalls = 0;
+  fail = null;
+});
+
+describe("stop plugin standalone boundary (#2113)", () => {
+  test("imports runtime behavior from the SDK boundary", () => {
+    const source = readFileSync(join(root, "src/vendor/mpr-plugins/stop/index.ts"), "utf8");
+    expect(source).toContain('from "maw-js/sdk"');
+    expect(source).not.toMatch(/maw-js\/(?:core|commands\/shared|cli|lib|config)(?:\/|")/);
+    expect(source).not.toMatch(/from\s+["'](?:\.\.\/)+/);
+  });
+
+  test("handler stops the fleet through SDK cmdSleep", async () => {
+    const result = await stopHandler({ source: "cli", args: [] } as any);
+
+    expect(result.ok).toBe(true);
+    expect(sleepCalls).toBe(1);
+    expect(result.output).toContain("fleet slept");
+  });
+
+  test("handler returns SDK errors and captured output", async () => {
+    fail = new Error("tmux unavailable");
+
+    const result = await stopHandler({ source: "api", args: {} } as any);
+
+    expect(result.ok).toBe(false);
+    expect(sleepCalls).toBe(1);
+    expect(result.error).toBe("tmux unavailable");
+  });
+});


### PR DESCRIPTION
## Summary
- moves the stop plugin runtime import from shared fleet internals to `maw-js/sdk`
- exports `cmdSleep` through the runtime and public SDK surfaces
- adds a standalone-style stop plugin test that mocks only `maw-js/sdk`

## Verification
- `bun test test/isolated/plugin-stop-standalone.test.ts`

RFC #2113 extraction prep.
