### PR TITLE
test: align isolated writer and wake expectations

### DIFF
--- a/test/isolated/plugin-config-standalone.test.ts
+++ b/test/isolated/plugin-config-standalone.test.ts
@@ -101,7 +101,7 @@ describe("src/commands/plugins/config/index.ts", () => {
     const result = await run(["show"], (...parts) => logs.push(parts.map(String).join(" ")));
 
     const parsed = JSON.parse(logs.join("\n"));
-    expect(result).toEqual({ ok: true, output: logs.join("\n") });
+    expect(result).toEqual({ ok: true, output: undefined });
     expect(loadCallCount).toBe(1);
     expect(parsed).toMatchObject(loadedConfig.config);
     expect(lastLoadOptions).toEqual({ cwd: process.cwd() });

--- a/test/isolated/wake-cmd-thirteenth-pass-coverage.test.ts
+++ b/test/isolated/wake-cmd-thirteenth-pass-coverage.test.ts
@@ -515,7 +515,7 @@ describe("wake-cmd thirteenth-pass isolated coverage", () => {
 
     expect(result).toBe("54-neo:neo-oracle");
     expect(plain()).toContain("would respawn: neo-docs");
-    expect(plain()).toContain("/tmp/neo-oracle.wt-5-docs");
+    expect(plain()).toContain("from worktree/neo-oracle.wt-5-docs");
   });
 
   test("invalid bud flag combinations and missing snapshots fail before tmux mutation", async () => {


### PR DESCRIPTION
Closes #2206 (partial).\n\n## Summary\n- Updates config standalone coverage to match the current writer contract: output goes through the provided writer and `InvokeResult.output` remains undefined.\n- Updates wake thirteenth-pass dry-run expectation to match the current concrete rehydrate output, which reports relative `worktree/...` labels.\n\n## Verification\n- `bash scripts/test-isolated.sh test/isolated/plugin-config-standalone.test.ts test/isolated/wake-cmd-thirteenth-pass-coverage.test.ts test/isolated/plugin-completions-standalone.test.ts test/isolated/plugin-activity-standalone.test.ts`\n- `bun run build`