### PR TITLE
test(wake): align stale coverage mocks

### DIFF
--- a/test/isolated/wake-cmd-thirteenth-pass-coverage.test.ts
+++ b/test/isolated/wake-cmd-thirteenth-pass-coverage.test.ts
@@ -200,6 +200,16 @@ mock.module(import.meta.resolve("../../src/core/fleet/claude-sessions"), () => (
   },
 }));
 
+
+mock.module(import.meta.resolve("../../src/commands/shared/fleet-load"), () => ({
+  fleetDirsForRead: () => ["/tmp/maw-fleet"],
+  fleetDirForWrite: () => "/tmp/maw-fleet",
+  loadFleet: () => [],
+  loadFleetEntries: () => [],
+  countDisabledFleetFiles: () => 0,
+  loadDisabledFleetEntries: () => [],
+}));
+
 mock.module(import.meta.resolve("../../src/commands/shared/wake-resolve"), () => ({
   resolveOracle: async () => ({ repoPath, repoName, parentDir }),
   findWorktrees: async (...args: any[]) => {

--- a/test/isolated/wake-cmd-thirteenth-pass-coverage.test.ts
+++ b/test/isolated/wake-cmd-thirteenth-pass-coverage.test.ts
@@ -525,7 +525,7 @@ describe("wake-cmd thirteenth-pass isolated coverage", () => {
 
     expect(result).toBe("54-neo:neo-oracle");
     expect(plain()).toContain("would respawn: neo-docs");
-    expect(plain()).toContain("/tmp/neo-oracle.wt-5-docs");
+    expect(plain()).toContain("worktree/neo-oracle.wt-5-docs");
   });
 
   test("invalid bud flag combinations and missing snapshots fail before tmux mutation", async () => {


### PR DESCRIPTION
## Summary
- Refresh wake thirteenth-pass coverage mocks for the current fleet-load export surface.
- Align dry-run rehydrate expectation with the post-#2182 relative worktree display.

Part of #2206 mock-alignment cleanup. No version bump.

## Tests
- bun test test/isolated/wake-cmd-thirteenth-pass-coverage.test.ts

## Notes
- Local post-commit dist build could not run because this worktree lacks installed deps (`arg`, `hono`, `elysia`).