### PR TITLE
test: align config standalone output expectation

### DIFF
--- a/test/isolated/plugin-config-standalone.test.ts
+++ b/test/isolated/plugin-config-standalone.test.ts
@@ -101,7 +101,7 @@ describe("src/commands/plugins/config/index.ts", () => {
     const result = await run(["show"], (...parts) => logs.push(parts.map(String).join(" ")));
 
     const parsed = JSON.parse(logs.join("\n"));
-    expect(result).toEqual({ ok: true, output: logs.join("\n") });
+    expect(result).toEqual({ ok: true, output: undefined });
     expect(loadCallCount).toBe(1);
     expect(parsed).toMatchObject(loadedConfig.config);
     expect(lastLoadOptions).toEqual({ cwd: process.cwd() });


### PR DESCRIPTION
## Summary
- fixes one #2206 isolated failure in `plugin-config-standalone`
- updates the writer-path expectation to match current plugin behavior: output is captured by `ctx.writer`, while `InvokeResult.output` remains undefined

Closes part of #2206.

## Tests
- `bun test test/isolated/plugin-config-standalone.test.ts`
- post-commit build hook (`bash $(git rev-parse --git-path hooks/post-commit)`)

No version bump.
