### PR TITLE
test: fix stale isolated mocks after plugin cascade

### DIFF
--- a/test/isolated/plugin-config-standalone.test.ts
+++ b/test/isolated/plugin-config-standalone.test.ts
@@ -10,6 +10,7 @@
 import { describe, expect, mock, test } from "bun:test";
 import { beforeEach } from "bun:test";
 import type { InvokeContext, InvokeResult } from "../../src/plugin/types";
+import { mockConfigModule } from "../helpers/mock-config";
 
 const loadedConfig = {
   config: {
@@ -66,6 +67,7 @@ let loadCallCount = 0;
 let lastLoadOptions: unknown;
 
 mock.module(import.meta.resolve("../../src/config.ts"), () => ({
+  ...mockConfigModule(() => loadedConfig.config as any),
   loadConfigWithProvenance: (opts?: unknown) => {
     loadCallCount += 1;
     lastLoadOptions = opts;

--- a/test/isolated/plugin-contacts-standalone.test.ts
+++ b/test/isolated/plugin-contacts-standalone.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -12,9 +12,9 @@ const ROOT = new URL("../..", import.meta.url).pathname;
 
 function walkSources(dir: string): string[] {
   const out: string[] = [];
-  const root = Bun.file(join(dir, "index.ts")).existsSync() ? join(dir, "index.ts") : null;
+  const root = existsSync(join(dir, "index.ts")) ? join(dir, "index.ts") : null;
   if (root) out.push(root);
-  const impl = Bun.file(join(dir, "impl.ts")).existsSync() ? join(dir, "impl.ts") : null;
+  const impl = existsSync(join(dir, "impl.ts")) ? join(dir, "impl.ts") : null;
   if (impl) out.push(impl);
   return out;
 }

--- a/test/isolated/wake-cmd-dryrun-coverage.test.ts
+++ b/test/isolated/wake-cmd-dryrun-coverage.test.ts
@@ -322,6 +322,11 @@ describe("wake-cmd dry-run and early branch coverage", () => {
     }];
     fleetSessionReturn = "199-zzcodex";
     ghqFindReturn = "/tmp/ghq/github.com/Soul-Brews-Studio/mawjs-codex-oracle";
+    resolveOracleReturn = {
+      repoPath: "/tmp/ghq/github.com/Soul-Brews-Studio/mawjs-codex-oracle",
+      repoName: "mawjs-codex-oracle",
+      parentDir: "/tmp/ghq/github.com/Soul-Brews-Studio",
+    };
     shouldAutoWakeReturn = { wake: true, reason: "missing" };
 
     const { logs } = await captureLogs(() =>
@@ -360,6 +365,7 @@ describe("wake-cmd dry-run and early branch coverage", () => {
     );
 
     latestSnapshotReturn = { timestamp: "2026-05-18T00:00:00.000Z", sessions: [] };
+    loadSnapshotReturn = latestSnapshotReturn;
     await expect(cmdWake("neo", { fromSnapshot: true, dryRun: true })).rejects.toThrow(
       "has no session for neo",
     );


### PR DESCRIPTION
## Summary
- fixes `plugin-config-standalone` by mocking the full config barrel to avoid cross-file mock pollution
- fixes `plugin-contacts-standalone` by replacing removed `Bun.file().existsSync()` usage with `fs.existsSync`
- fixes `wake-cmd-dryrun-coverage` stale syntax/mock expectations for current resolver and snapshot loading paths

## Verification
- `bun test test/isolated/plugin-config-standalone.test.ts test/isolated/wake-cmd-dryrun-coverage.test.ts test/isolated/plugin-contacts-standalone.test.ts`

Partial #2206 fix: 3 failing isolated files addressed.
