### PR TITLE
test: align remaining isolated mocks with SDK exports

### DIFF
--- a/test/isolated/coverage-100b-vendor-c-indexes.test.ts
+++ b/test/isolated/coverage-100b-vendor-c-indexes.test.ts
@@ -23,7 +23,7 @@ function record(name: string, ...args: unknown[]) {
   if (workspaceThrow) throw new Error(`${name} failed`);
 }
 
-mock.module("maw-js/sdk", () => ({
+const sdkMock = {
   resolveSessionTarget: (target: string, rows: any[]) => {
     const match = rows.find(row => row.name === target) ?? rows[0];
     return match ? { kind: "exact", match } : { kind: "none", hints: [] };
@@ -38,7 +38,15 @@ mock.module("maw-js/sdk", () => ({
   resolveTarget: () => resolveTargetResult,
   curlFetch: async () => ({ ok: true, data: { ok: true, target: "remote:1" } }),
   Tmux: class { async sendKeysLiteral(target: string, text: string) { sendKeysLiteralCalls.push([target, text]); } },
-}));
+  loadFleetCore: () => [],
+  loadFleetEntries: () => [],
+  countDisabledFleetFilesCore: () => 0,
+  loadDisabledFleetEntriesCore: () => [],
+  parseFlags: (args: string[]) => ({ _: args.filter((a) => !String(a).startsWith("--")) }),
+};
+mock.module("maw-js/sdk", () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk"), () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
 mock.module("maw-js/config", () => ({ loadConfig: () => ({ host: "local", disabledPlugins: [] }) }));
 mock.module("maw-js/commands/shared/comm-send", () => ({ resolveOraclePane: async (target: string) => `pane:${target}` }));
 mock.module("maw-js/commands/shared/fleet-load", () => ({ loadFleet: () => [] }));
@@ -46,11 +54,6 @@ mock.module("maw-js/core/transport/tmux", () => ({
   Tmux: class { async run(...args: string[]) { return await tmuxRunImpl(...args); } },
 }));
 
-mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/contacts/impl.ts"), () => ({
-  cmdContactsLs: async () => record("contacts-ls"),
-  cmdContactsAdd: async (name: string, args: string[]) => record("contacts-add", name, args),
-  cmdContactsRm: async (name: string) => record("contacts-rm", name),
-}));
 mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/kill/impl.ts"), () => ({ cmdKill: async (target: string, opts: unknown) => record("kill", target, opts) }));
 mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/kill/internal/peer-resolve.ts"), () => ({
   resolvePeer: (alias: string) => peerMode === "missing" ? null : ({ url: `http://${alias}.invalid` }),

--- a/test/isolated/coverage-next-vendor-b-core.test.ts
+++ b/test/isolated/coverage-next-vendor-b-core.test.ts
@@ -35,7 +35,7 @@ mock.module(pairPeersImplPath, () => ({
   cmdAdd: async () => undefined,
 }));
 
-mock.module("maw-js/sdk", () => ({
+const sdkMock = {
   listSessions: async () => sessions,
   hostExec: async (cmd: string) => {
     calls.push(`host:${cmd}`);
@@ -70,7 +70,10 @@ mock.module("maw-js/sdk", () => ({
       calls.push(`kill:${target}`);
     },
   },
-}));
+};
+mock.module("maw-js/sdk", () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk"), () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
 
 mock.module("maw-js/core/matcher/resolve-target", () => ({
   resolveSessionTarget: (target: string, inputSessions: typeof sessions) => {

--- a/test/isolated/find-impl-coverage.test.ts
+++ b/test/isolated/find-impl-coverage.test.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { join, resolve } from "path";
 
 const realFs = await import("fs");
-const realSdk = await import("../../src/sdk");
 
 const repoRoot = process.cwd();
 const ghqRoot = resolve(repoRoot, "../../../..");
@@ -54,8 +53,7 @@ await mock.module("maw-js/commands/shared/fleet-load", () => ({
   loadFleet: () => mockedFleet,
 }));
 
-await mock.module("maw-js/sdk", () => ({
-  ...realSdk,
+const sdkMock = {
   hostExec: async (command: string) => {
     hostExecCalls.push(command);
 
@@ -75,7 +73,12 @@ await mock.module("maw-js/sdk", () => ({
 
     throw new Error(`unexpected hostExec command: ${command}`);
   },
-}));
+  loadFleetCore: () => mockedFleet,
+  loadFleetEntries: () => [],
+};
+await mock.module("maw-js/sdk", () => sdkMock);
+await mock.module(import.meta.resolve("../../src/sdk"), () => sdkMock);
+await mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
 
 const { cmdFind } = await import("../../src/vendor/mpr-plugins/find/impl.ts?find-impl-coverage");
 

--- a/test/isolated/vendor-command-plugins-coverage.test.ts
+++ b/test/isolated/vendor-command-plugins-coverage.test.ts
@@ -68,18 +68,24 @@ mock.module("maw-js/core/transport/tmux", () => ({
   },
 }));
 
-mock.module("maw-js/sdk", () => ({
+const sdkMock = {
   parseFlags: (args: string[], spec: Record<string, unknown>, skip = 0) => {
     const out: Record<string, any> = { _: [] };
     const aliases: Record<string, string> = {};
     for (const [key, value] of Object.entries(spec)) if (typeof value === "string") aliases[key] = value;
-    for (const tok of args.slice(skip)) {
+    const sliced = args.slice(skip);
+    for (let i = 0; i < sliced.length; i += 1) {
+      const tok = sliced[i]!;
       const key = aliases[tok] ?? tok;
-      if (key.startsWith("-")) out[key] = true;
-      else out._.push(tok);
+      if (key.startsWith("-")) {
+        const type = spec[key] ?? spec[tok];
+        if (type === String) out[key] = sliced[++i];
+        else out[key] = true;
+      } else out._.push(tok);
     }
     return out;
   },
+  loadConfig: () => configState,
   listSessions: async () => sessions,
   resolveTarget: (query: string, config: Record<string, any>, listedSessions: any[]) => {
     resolveTargetCalls.push({ query, config, sessions: listedSessions });
@@ -90,7 +96,10 @@ mock.module("maw-js/sdk", () => ({
       sendKeyCalls.push({ target, key });
     },
   },
-}));
+};
+mock.module("maw-js/sdk", () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk"), () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
 
 mock.module("maw-js/commands/shared/comm-send", () => ({
   resolveOraclePane: async (target: string) => {

--- a/test/isolated/vendor-pane-actions-extra-coverage.test.ts
+++ b/test/isolated/vendor-pane-actions-extra-coverage.test.ts
@@ -62,7 +62,7 @@ let errors: string[] = [];
 const originalLog = console.log;
 const originalError = console.error;
 
-mock.module("maw-js/sdk", () => ({
+const sdkMock = {
   listSessions: async () => {
     listSessionsCalls += 1;
     return sessions;
@@ -110,7 +110,10 @@ mock.module("maw-js/sdk", () => ({
     if (next instanceof Error) throw next;
     return next ?? { ok: true, data: {} };
   },
-}));
+};
+mock.module("maw-js/sdk", () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk"), () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
 
 mock.module("maw-js/config", () => ({
   loadConfig: () => configState,


### PR DESCRIPTION
## Summary
- Replacement for closed #2208; wake-only fix was superseded by #2207.
- Starts aligning remaining stale isolated mocks with current SDK/export surfaces.
- Current WIP touches the requested remaining files; more fixes needed for green.

Closes #2206

## Current local status
- `bun test test/isolated/find-impl-coverage.test.ts test/isolated/vendor-command-plugins-coverage.test.ts` still fails on repo-SDK mock exports (`getGhqRoot`, `loadConfig`).

## Notes
- No version bump.
- Local post-commit dist build could not run because this worktree lacks installed deps (`arg`, `hono`, `elysia`).