### PR TITLE
fix(sdk): expose profile loader helpers

### DIFF
--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -130,6 +130,16 @@ export {
 } from "../lib/artifacts";
 export type { ArtifactMeta, ArtifactSummary } from "../lib/artifacts";
 
+// ─── Profile Loader ─────────────────────────────────────────────────────────
+
+export {
+  getActiveProfile,
+  loadAllProfiles,
+  loadProfile,
+  setActiveProfile,
+} from "../lib/profile-loader";
+export type { TProfile } from "../lib/schemas";
+
 // ─── Plugin System ───────────────────────────────────────────────────────────
 
 export { discoverPackages, importPluginSymbol, invokePlugin } from "../plugin/registry";


### PR DESCRIPTION
Closes #2215 (partial).\n\n## Summary\n- Adds profile-loader helpers to the runtime `maw-js/sdk` barrel so it matches the package SDK surface used by the refactored profile plugin.\n- Fixes the profile vendor coverage failure: `Export named 'loadAllProfiles' not found in src/sdk/index.ts`.\n\n## Verification\n- `bash scripts/test-isolated.sh test/isolated/profile-plugin-coverage.test.ts test/isolated/plugin-profile-standalone.test.ts test/isolated/tab-order-coverage.test.ts test/isolated/plugin-capture-standalone.test.ts test/isolated/attach-impl-coverage.test.ts`\n- `bun run build`