### PR TITLE
test: align contacts profile and message ledger coverage

### DIFF
--- a/test/isolated/message-ledger.test.ts
+++ b/test/isolated/message-ledger.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { buildMessageLifecycleFeedEvent } from "../../src/lib/message-events";
-import { listMessageLedgerEvents, messageLedgerDbPath, pruneMessageLedger, recordMessageLedgerEvent } from "../../src/vendor/mpr-plugins/messages/ledger";
+import { listMessageLedgerEvents, messageLedgerDbPath, pruneMessageLedgerEvents, recordMessageLedgerEvent } from "../../src/vendor/mpr-plugins/messages/ledger";
 import messagesHandler, { messagesEngineFetch, onEvent } from "../../src/vendor/mpr-plugins/messages/index";
 import { messagesHtml, messagesView } from "../../src/views/messages";
 import type { FeedEvent } from "../../src/lib/feed";
@@ -15,6 +15,7 @@ const prevConfig = process.env.MAW_CONFIG_DIR;
 const prevData = process.env.MAW_DATA_DIR;
 const prevHome = process.env.MAW_HOME;
 const prevMaxMessages = process.env.MAW_MESSAGE_LEDGER_MAX_MESSAGES;
+const prevKeepLast = process.env.MAW_MESSAGE_KEEP_LAST;
 
 beforeEach(() => {
   tmp = mkdtempSync(join(tmpdir(), "maw-message-ledger-"));
@@ -22,6 +23,7 @@ beforeEach(() => {
   dataDir = join(tmp, "data");
   delete process.env.MAW_HOME;
   delete process.env.MAW_MESSAGE_LEDGER_MAX_MESSAGES;
+  delete process.env.MAW_MESSAGE_KEEP_LAST;
   process.env.MAW_CONFIG_DIR = configDir;
   process.env.MAW_DATA_DIR = dataDir;
 });
@@ -35,6 +37,8 @@ afterEach(() => {
   else process.env.MAW_HOME = prevHome;
   if (prevMaxMessages === undefined) delete process.env.MAW_MESSAGE_LEDGER_MAX_MESSAGES;
   else process.env.MAW_MESSAGE_LEDGER_MAX_MESSAGES = prevMaxMessages;
+  if (prevKeepLast === undefined) delete process.env.MAW_MESSAGE_KEEP_LAST;
+  else process.env.MAW_MESSAGE_KEEP_LAST = prevKeepLast;
   rmSync(tmp, { recursive: true, force: true });
 });
 
@@ -120,7 +124,7 @@ describe("messages plugin ledger", () => {
   });
 
   test("prunes oldest rows when message retention is exceeded", () => {
-    process.env.MAW_MESSAGE_LEDGER_MAX_MESSAGES = "3";
+    process.env.MAW_MESSAGE_KEEP_LAST = "3";
 
     for (let i = 1; i <= 5; i += 1) {
       recordMessageLedgerEvent({
@@ -142,8 +146,8 @@ describe("messages plugin ledger", () => {
       "retention-3",
     ]);
 
-    process.env.MAW_MESSAGE_LEDGER_MAX_MESSAGES = "2";
-    expect(pruneMessageLedger()).toBe(1);
+    process.env.MAW_MESSAGE_KEEP_LAST = "2";
+    expect(pruneMessageLedgerEvents().removed).toBe(1);
     expect(listMessageLedgerEvents({ limit: 10 }).map(row => row.id)).toEqual([
       "retention-5",
       "retention-4",


### PR DESCRIPTION
## Summary
- aligns `message-ledger` retention coverage with the current `pruneMessageLedgerEvents` / `MAW_MESSAGE_KEEP_LAST` path
- verifies `plugin-contacts-standalone` and `profile-plugin-coverage` against current code
- no runtime changes

## Verification
- `bun test test/isolated/plugin-contacts-standalone.test.ts test/isolated/profile-plugin-coverage.test.ts test/isolated/message-ledger.test.ts`
