### PR TITLE
test: align UI capture and vendor wrapper mocks

### DIFF
--- a/test/isolated/ui-capture-helpers-coverage.test.ts
+++ b/test/isolated/ui-capture-helpers-coverage.test.ts
@@ -55,6 +55,7 @@ mock.module("maw-js/core/ghq", () => ({
 
 mock.module("maw-js/sdk", () => ({
   listSessions: async () => sessions,
+  loadFleetCore: () => [],
   hostExec: async (cmd: string) => {
     hostExecCalls.push(cmd);
     if (hostExecError) throw hostExecError;

--- a/test/isolated/vendor-more-indexes-extra-coverage.test.ts
+++ b/test/isolated/vendor-more-indexes-extra-coverage.test.ts
@@ -63,6 +63,11 @@ mock.module("maw-js/commands/shared/comm", () => ({
   cmdPeek: async (target?: string) => record("peek", target),
 }));
 
+mock.module("maw-js/sdk", () => ({
+  cmdPeek: async (target?: string) => record("peek", target),
+  cmdSleep: async () => record("stop", undefined),
+}));
+
 mock.module(prImplPath, () => ({
   cmdPr: async (window?: string) => record("pr", window),
 }));


### PR DESCRIPTION
## Summary
- align `ui-capture-helpers` SDK mock with current capture dependencies (`loadFleetCore`)
- align `vendor-more-indexes` wrapper mocks with current SDK-backed `stop`/future wrapper imports

## Tests
- `bun test test/isolated/ui-capture-helpers-coverage.test.ts`
- `bun test test/isolated/vendor-more-indexes-extra-coverage.test.ts`
- post-commit build hook

No version bump.
