### PR TITLE
test: align contacts and tab isolated mocks

### DIFF
--- a/test/isolated/plugin-contacts-standalone.test.ts
+++ b/test/isolated/plugin-contacts-standalone.test.ts
@@ -6,9 +6,30 @@ import { join } from "node:path";
 import { loadManifestFromDir } from "../../src/plugin/manifest-load";
 import { invokePlugin } from "../../src/plugin/registry-invoke";
 import type { LoadedPlugin } from "../../src/plugin/types";
-import { resetConfig } from "maw-js/sdk";
+const resetConfig = () => {};
 
 const ROOT = new URL("../..", import.meta.url).pathname;
+
+const sdkMock = {
+  loadConfig: () => ({}),
+  parseFlags: (args: string[], spec: Record<string, unknown>, skip = 0) => {
+    const out: Record<string, any> = { _: [] };
+    const tokens = args.slice(skip);
+    for (let i = 0; i < tokens.length; i += 1) {
+      const token = tokens[i]!;
+      if (token.startsWith("--")) {
+        out[token] = spec[token] === String ? tokens[++i] : true;
+      } else out._.push(token);
+    }
+    return out;
+  },
+};
+mock.module("maw-js/sdk", () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk"), () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk.ts"), () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk/index"), () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
+
 
 function walkSources(dir: string): string[] {
   const out: string[] = [];

--- a/test/isolated/vendor-pane-actions-extra-coverage.test.ts
+++ b/test/isolated/vendor-pane-actions-extra-coverage.test.ts
@@ -84,14 +84,22 @@ const sdkMock = {
     resolveCalls.push({ target, sessions: seenSessions });
     return resolveResults.get(target) ?? { kind: "none", hints: [] };
   },
+  cmdPeek: async (target: string) => {
+    peekCalls.push(target);
+  },
+  cmdSend: async (target: string, message: string, force = false) => {
+    sendCalls.push({ target, message, force });
+  },
   parseFlags: (args: string[]) => {
     const out: Record<string, unknown> & { _: string[] } = { _: [] };
     for (let i = 0; i < args.length; i += 1) {
       const arg = args[i]!;
-      if (arg === "--pane") {
+      if (arg === "--pane" || arg === "--lines") {
         const value = args[++i];
-        if (value === undefined || value.startsWith("--")) throw new Error("option requires argument: --pane");
-        out["--pane"] = Number(value);
+        if (value === undefined || value.startsWith("--")) throw new Error(`option requires argument: ${arg}`);
+        out[arg] = Number(value);
+      } else if (["--full", "--dry-run", "--shell", "--split", "--no-split", "--yes", "-y"].includes(arg)) {
+        out[arg === "-y" ? "--yes" : arg] = true;
       } else out._.push(arg);
     }
     return out;
@@ -112,7 +120,12 @@ const sdkMock = {
   },
 };
 mock.module("maw-js/sdk", () => sdkMock);
+mock.module("maw-js/cli/parse-args", () => ({ parseFlags: sdkMock.parseFlags }));
+mock.module(import.meta.resolve("../../src/cli/parse-args"), () => ({ parseFlags: sdkMock.parseFlags }));
+mock.module(import.meta.resolve("../../src/cli/parse-args.ts"), () => ({ parseFlags: sdkMock.parseFlags }));
 mock.module(import.meta.resolve("../../src/sdk"), () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk.ts"), () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk/index"), () => sdkMock);
 mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
 
 mock.module("maw-js/config", () => ({


### PR DESCRIPTION
## Summary
- Keep contacts standalone coverage from importing the full SDK barrel during test setup.
- Align tab/vendor pane coverage mocks with current SDK and parser extraction paths.
- Add SDK aliases for `cmdPeek`/`cmdSend` and parse-args so the tests stay hermetic.

## Tests
- bun test test/isolated/plugin-contacts-standalone.test.ts test/isolated/vendor-pane-actions-extra-coverage.test.ts

## Notes
- No version bump.
- Local post-commit dist build could not run because this worktree lacks installed deps (`arg`, `hono`, `elysia`).