### PR TITLE
test: align vendor coverage SDK mock

### DIFF
--- a/test/isolated/coverage-next-vendor-a-1.test.ts
+++ b/test/isolated/coverage-next-vendor-a-1.test.ts
@@ -21,6 +21,8 @@ let ghqExactQueue: string[] = [];
 let resolveAttachResult: any = null;
 let fetchOk = false;
 
+const realSdk = await import("../../src/sdk");
+
 const original = {
   cwd: process.cwd(),
   log: console.log,
@@ -43,6 +45,7 @@ function makeDreamRepo() {
 }
 
 mock.module("maw-js/sdk", () => ({
+  ...realSdk,
   listSessions: async () => sessions,
   tmuxCmd: () => "tmux",
   hostExec: async (command: string) => {


### PR DESCRIPTION
## Summary
- spread the real SDK into the coverage-next vendor A maw-js/sdk mock before overriding test hooks
- keeps profile loader exports available when profile show coverage imports the vendor implementation
- no version bump

## Verification
- bash scripts/test-isolated.sh test/isolated/profile-plugin-coverage.test.ts test/isolated/coverage-next-vendor-a-1.test.ts
- bun run build

Addresses CalVer #6 profile/coverage-next blocker.