### PR TITLE
test: align ui capture helper coverage mock

### DIFF
--- a/test/isolated/ui-capture-helpers-coverage.test.ts
+++ b/test/isolated/ui-capture-helpers-coverage.test.ts
@@ -54,6 +54,7 @@ mock.module("maw-js/core/ghq", () => ({
 }));
 
 mock.module("maw-js/sdk", () => ({
+  loadConfig: () => (configValue === undefined ? { namedPeers } : configValue),
   listSessions: async () => sessions,
   loadFleetCore: () => [],
   hostExec: async (cmd: string) => {


### PR DESCRIPTION
## Summary
- align the ui/capture isolated SDK mock with the current extracted-plugin SDK surface by exposing loadConfig
- keep the test hermetic instead of spreading the real SDK into the mock
- no version bump

## Verification
- bash scripts/test-isolated.sh test/isolated/ui-capture-helpers-coverage.test.ts
- bun run build
