### PR TITLE
test: standalone coverage for assign plugin

### DIFF
--- a/packages/sdk/index.d.ts
+++ b/packages/sdk/index.d.ts
@@ -642,3 +642,8 @@ export interface ScannedSignal extends Signal {
 }
 
 export declare function scanSignals(root: string, opts?: { days?: number }): ScannedSignal[];
+
+// --- src/commands/shared/wake ---
+
+export declare function fetchIssuePrompt(num: number, repo?: string): Promise<string>;
+export declare function cmdWake(oracle: string, opts: Record<string, unknown>): Promise<string>;

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -168,6 +168,10 @@ export type { TProfile } from "../../src/lib/schemas";
 // plugin.json module.path + module.exports before another plugin may import it.
 export { importPluginSymbol } from "../../src/plugin/registry";
 
+// ─── src/commands/shared/wake ───────────────────────────────────────────────
+// Wake helpers used by small orchestration plugins like assign.
+export { cmdWake, fetchIssuePrompt } from "../../src/commands/shared/wake";
+
 
 // ─── src/core/agent-detect ──────────────────────────────────────────────────
 // Lightweight agent-pane detection used by broadcast and send helpers.

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -103,6 +103,7 @@ export {
   loadFleetEntries,
 } from "../core/fleet/fleet-load-core";
 export { cmdSleep } from "../commands/shared/fleet-wake";
+export { cmdWake, fetchIssuePrompt } from "../commands/shared/wake";
 export type {
   FleetWindow, FleetSession, FleetEntry, DisabledFleetEntry,
 } from "../core/fleet/fleet-load-core";

--- a/src/vendor/mpr-plugins/assign/impl.ts
+++ b/src/vendor/mpr-plugins/assign/impl.ts
@@ -1,5 +1,4 @@
-import { hostExec } from "maw-js/sdk";
-import { cmdWake, fetchIssuePrompt } from "maw-js/commands/shared/wake";
+import { cmdWake, fetchIssuePrompt, hostExec } from "maw-js/sdk";
 
 function parseIssueUrl(url: string): { org: string; repo: string; issueNum: number } {
   const m = url.match(/github\.com[:/]([^/]+)\/([^/]+)\/issues\/(\d+)/);

--- a/src/vendor/mpr-plugins/assign/index.ts
+++ b/src/vendor/mpr-plugins/assign/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/sdk";
 import { cmdAssign } from "./impl";
 
 export const command = {

--- a/test/isolated/plugin-assign-standalone.test.ts
+++ b/test/isolated/plugin-assign-standalone.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { loadManifestFromDir } from "../../src/plugin/manifest-load";
+import { invokePlugin } from "../../src/plugin/registry-invoke";
+import type { LoadedPlugin } from "../../src/plugin/types";
+
+const ROOT = new URL("../..", import.meta.url).pathname;
+const pluginDir = join(ROOT, "src/vendor/mpr-plugins/assign");
+
+let hostExecCalls: string[] = [];
+let wakeCalls: Array<{ oracle: string; opts: Record<string, unknown> }> = [];
+let fetchedIssues: Array<{ num: number; repo?: string }> = [];
+
+const sdkMock = {
+  hostExec: async (cmd: string) => {
+    hostExecCalls.push(cmd);
+    return "neo-oracle\n";
+  },
+  fetchIssuePrompt: async (num: number, repo?: string) => {
+    fetchedIssues.push({ num, repo });
+    return `issue ${num} prompt for ${repo}`;
+  },
+  cmdWake: async (oracle: string, opts: Record<string, unknown>) => {
+    wakeCalls.push({ oracle, opts });
+    return "woke";
+  },
+};
+
+mock.module("maw-js/sdk", () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
+
+function walkSources(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "dist" || entry.name.startsWith(".")) continue;
+      out.push(...walkSources(full));
+    } else if (entry.name.endsWith(".ts") || entry.name.endsWith(".js")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function parseImportSpecs(source: string): string[] {
+  const specs = new Set<string>();
+  const importFrom = /\b(?:import|export)\s+(?:[^"'`]+?\s+from\s+)?["']([^"']+)["']/g;
+  const importFn = /\bimport\(\s*["']([^"']+)["']\s*\)/g;
+  const requireFn = /\brequire\(\s*["']([^"']+)["']\s*\)/g;
+
+  for (const re of [importFrom, importFn, requireFn]) {
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(source)) !== null) specs.add(m[1]);
+  }
+
+  return [...specs];
+}
+
+function loadAssignPlugin(): LoadedPlugin {
+  const loaded = loadManifestFromDir(pluginDir);
+  expect(loaded).not.toBeNull();
+  return loaded as LoadedPlugin;
+}
+
+beforeEach(() => {
+  hostExecCalls = [];
+  wakeCalls = [];
+  fetchedIssues = [];
+  delete process.env.TMUX;
+});
+
+describe("assign plugin standalone boundary (#2251)", () => {
+  test("imports runtime dependencies only through the SDK boundary", () => {
+    const imports = walkSources(pluginDir).flatMap((file) => parseImportSpecs(readFileSync(file, "utf8")));
+
+    const disallowed = imports.filter((spec) => {
+      if (spec.startsWith(".")) return false;
+      if (spec.startsWith("node:")) return false;
+      return spec !== "maw-js/sdk";
+    });
+
+    expect(disallowed).toEqual([]);
+    expect(imports).toContain("maw-js/sdk");
+  });
+
+  test("plugin loads and missing issue URL returns InvokeResult error", async () => {
+    const plugin = loadAssignPlugin();
+
+    const result = await invokePlugin(plugin, { source: "cli", args: [] });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("usage: maw assign <issue-url>");
+  });
+
+  test("CLI --oracle fetches issue prompt and wakes requested oracle", async () => {
+    const plugin = loadAssignPlugin();
+    const out: string[] = [];
+
+    const result = await invokePlugin(plugin, {
+      source: "cli",
+      args: ["https://github.com/Soul-Brews-Studio/maw-js/issues/2251", "--oracle", "neo"],
+      writer: (...args: unknown[]) => out.push(args.map(String).join(" ")),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(fetchedIssues).toEqual([{ num: 2251, repo: "Soul-Brews-Studio/maw-js" }]);
+    expect(wakeCalls).toEqual([
+      {
+        oracle: "neo",
+        opts: {
+          incubate: "Soul-Brews-Studio/maw-js",
+          task: "issue-2251",
+          prompt: "issue 2251 prompt for Soul-Brews-Studio/maw-js",
+        },
+      },
+    ]);
+    expect(hostExecCalls).toEqual([]);
+    expect(out.join("\n")).toContain("fetching issue #2251");
+  });
+
+  test("CLI can detect oracle from tmux window through SDK hostExec", async () => {
+    process.env.TMUX = "/tmp/tmux.sock";
+    const plugin = loadAssignPlugin();
+
+    const result = await invokePlugin(plugin, {
+      source: "cli",
+      args: ["https://github.com/Soul-Brews-Studio/maw-js/issues/2251"],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(hostExecCalls).toEqual(["tmux display-message -p '#{window_name}'"]);
+    expect(wakeCalls[0]?.oracle).toBe("neo");
+  });
+});


### PR DESCRIPTION
Closes #2251.

Adds isolated standalone coverage for the assign plugin and moves its runtime wake helper imports behind the SDK boundary.

Validation:
- bash scripts/test-isolated.sh test/isolated/plugin-assign-standalone.test.ts