### PR TITLE
test: standalone coverage for avengers plugin

### DIFF
--- a/src/vendor/mpr-plugins/avengers/impl.ts
+++ b/src/vendor/mpr-plugins/avengers/impl.ts
@@ -2,7 +2,7 @@
  * maw avengers — rate limit monitor integration with ARRA-01/avengers.
  */
 
-import { loadConfig } from "maw-js/config";
+import { loadConfig } from "maw-js/sdk";
 
 function getAvengersUrl(): string | null {
   return (loadConfig() as any).avengers || null;

--- a/src/vendor/mpr-plugins/avengers/index.ts
+++ b/src/vendor/mpr-plugins/avengers/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/sdk";
 
 export const command = {
   name: "avengers",

--- a/test/isolated/plugin-avengers-standalone.test.ts
+++ b/test/isolated/plugin-avengers-standalone.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "../..");
+let config: Record<string, unknown> = {};
+let fetchCalls: string[] = [];
+let fetchPayload: unknown = [];
+let fetchError: Error | null = null;
+
+mock.module("maw-js/sdk", () => ({
+  loadConfig: () => config,
+}));
+
+const { default: avengersHandler, command } = await import(
+  "../../src/vendor/mpr-plugins/avengers/index.ts"
+);
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  config = {};
+  fetchCalls = [];
+  fetchPayload = [];
+  fetchError = null;
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    fetchCalls.push(url);
+    if (fetchError) throw fetchError;
+    return { json: async () => fetchPayload } as Response;
+  }) as typeof fetch;
+});
+
+describe("avengers plugin standalone boundary (#2247)", () => {
+  test("imports runtime behavior from the SDK boundary", () => {
+    const indexSource = readFileSync(join(root, "src/vendor/mpr-plugins/avengers/index.ts"), "utf8");
+    const implSource = readFileSync(join(root, "src/vendor/mpr-plugins/avengers/impl.ts"), "utf8");
+    const combined = `${indexSource}\n${implSource}`;
+
+    expect(command).toMatchObject({
+      name: "avengers",
+      description: "Manage the Avengers multi-agent team.",
+    });
+    expect(combined).toContain('from "maw-js/sdk"');
+    expect(combined).not.toMatch(/maw-js\/(?:core|commands\/shared|cli|config|lib|plugin)(?:\/|")/);
+    expect(combined).not.toMatch(/from\s+["'](?:\.\.\/)+(?:core|commands|cli|config|lib|src)\//);
+  });
+
+  test("help renders without loading the implementation", async () => {
+    const output: string[] = [];
+    const result = await avengersHandler({
+      source: "cli",
+      args: ["--help"],
+      writer: (...parts: unknown[]) => output.push(parts.map(String).join(" ")),
+    } as any);
+
+    expect(result).toEqual({ ok: true });
+    expect(output.join("\n")).toContain("usage: maw avengers");
+    expect(output.join("\n")).toContain("maw avengers status");
+    expect(fetchCalls).toEqual([]);
+  });
+
+  test("reports missing avengers config through the handler boundary", async () => {
+    const result = await avengersHandler({ source: "cli", args: ["status"] } as any);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("Avengers not configured");
+    expect(fetchCalls).toEqual([]);
+  });
+
+  test("status uses configured base URL and prints account limits", async () => {
+    config = { avengers: "http://avengers.local" };
+    fetchPayload = [{ name: "alpha", remaining: 75, limit: 100 }];
+
+    const result = await avengersHandler({ source: "cli", args: ["status"] } as any);
+
+    expect(result.ok).toBe(true);
+    expect(fetchCalls).toEqual(["http://avengers.local/all"]);
+    expect(result.output).toContain("Avengers Status");
+    expect(result.output).toContain("alpha");
+    expect(result.output).toContain("75/100 (75%)");
+  });
+
+  test("fetch failures stay user-visible without failing the command", async () => {
+    config = { avengers: "http://avengers.local" };
+    fetchError = new Error("connection refused");
+
+    const result = await avengersHandler({ source: "cli", args: ["status"] } as any);
+
+    expect(result.ok).toBe(true);
+    expect(fetchCalls).toEqual(["http://avengers.local/all"]);
+    expect(result.output).toContain("avengers unreachable at http://avengers.local");
+    expect(result.output).toContain("connection refused");
+  });
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});


### PR DESCRIPTION
Closes #2247.

Summary:
- move avengers plugin imports to the SDK boundary
- add isolated standalone coverage for avengers command metadata, help, config errors, status output, and fetch failures
- assert no private core/shared/config/plugin imports remain

Verification:
- bun build test/isolated/plugin-avengers-standalone.test.ts --outfile /tmp/plugin-avengers-standalone.js --target=bun --external maw-js/sdk
- rg private import boundary check
- git diff --check
- bun run build

Known local gap:
- bun test test/isolated/plugin-avengers-standalone.test.ts hits the known Bun canary 1.4.0 index-out-of-bounds panic before assertions.