### PR TITLE
test: lock demo plugin standalone boundary

### DIFF
--- a/src/vendor/mpr-plugins/demo/impl.ts
+++ b/src/vendor/mpr-plugins/demo/impl.ts
@@ -1,4 +1,4 @@
-import { hostExec } from "maw-js/core/transport/ssh";
+import { hostExec } from "maw-js/sdk";
 
 // ---------------------------------------------------------------------------
 // Types

--- a/src/vendor/mpr-plugins/demo/index.ts
+++ b/src/vendor/mpr-plugins/demo/index.ts
@@ -1,6 +1,6 @@
-import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import type { InvokeContext, InvokeResult } from "@maw-js/sdk/plugin";
 import { cmdDemo } from "./impl";
-import { parseFlags } from "maw-js/cli/parse-args";
+import { parseFlags } from "maw-js/sdk";
 
 export const command = {
   name: "demo",

--- a/test/isolated/coverage-100b-vendor-a-branches.test.ts
+++ b/test/isolated/coverage-100b-vendor-a-branches.test.ts
@@ -74,6 +74,9 @@ mock.module("child_process", () => ({
 mock.module("maw-js/sdk", () => ({
   hostExec: async (cmd: string) => hostExecImpl(cmd),
   FLEET_DIR: join(tmpRoot || tmpdir(), "fleet"),
+  getGhqRoot: () => ghqRoot,
+  loadFleetCore: () => [],
+  loadFleetEntries: () => fleetEntries,
 }));
 mock.module("maw-js/config/ghq-root", () => ({ getGhqRoot: () => ghqRoot }));
 mock.module("maw-js/commands/shared/wake", () => ({

--- a/test/isolated/coverage-vendor-dream-bud-dream-default.test.ts
+++ b/test/isolated/coverage-vendor-dream-bud-dream-default.test.ts
@@ -20,6 +20,8 @@ mock.module("maw-js/sdk", () => ({
     if (command === "ghq list -p 2>/dev/null") return "";
     throw new Error(`unexpected hostExec command: ${command}`);
   },
+  getGhqRoot: () => ghqRoot,
+  loadFleetCore: () => [],
 }));
 
 mock.module("maw-js/config/ghq-root", () => ({

--- a/test/isolated/demo-impl-default-exec-coverage.test.ts
+++ b/test/isolated/demo-impl-default-exec-coverage.test.ts
@@ -5,7 +5,7 @@ let paneSnapshots: string[] = [];
 let rejectCleanup = false;
 let rejectListPanes = false;
 
-mock.module("maw-js/core/transport/ssh", () => ({
+mock.module("maw-js/sdk", () => ({
   hostExec: async (cmd: string) => {
     execCalls.push(cmd);
     if (cmd === "tmux list-panes -a -F #{pane_id}") {
@@ -16,6 +16,18 @@ mock.module("maw-js/core/transport/ssh", () => ({
       throw new Error("cleanup failed");
     }
     return "";
+  },
+  parseFlags: (args: string[], spec: Record<string, unknown>) => {
+    const out: Record<string, any> = { _: [] };
+    for (let i = 0; i < args.length; i += 1) {
+      const arg = args[i]!;
+      const parser = spec[arg];
+      if (!parser) out._.push(arg);
+      else if (parser === Boolean) out[arg] = true;
+      else if (typeof parser === "string") out[parser] = true;
+      else out[arg] = args[++i];
+    }
+    return out;
   },
 }));
 

--- a/test/isolated/dream-impl-command-base-coverage.test.ts
+++ b/test/isolated/dream-impl-command-base-coverage.test.ts
@@ -20,6 +20,16 @@ const original = {
 
 mock.module("maw-js/sdk", () => ({
   hostExec: async (cmd: string) => fakeHostExec(cmd),
+  getGhqRoot: () => ghqRoot,
+  loadFleetCore: () => [
+    {
+      name: "base-command-session",
+      windows: [
+        { name: "alpha", repo: "Soul-Brews-Studio/alpha-oracle" },
+        { name: "beta", repo: "Soul-Brews-Studio/beta-oracle" },
+      ],
+    },
+  ],
 }));
 
 mock.module("maw-js/config/ghq-root", () => ({

--- a/test/isolated/dream-impl-focused-coverage.test.ts
+++ b/test/isolated/dream-impl-focused-coverage.test.ts
@@ -23,6 +23,16 @@ const original = {
 
 mock.module("maw-js/sdk", () => ({
   hostExec: async (cmd: string) => fakeHostExec(cmd),
+  getGhqRoot: () => ghqRoot,
+  loadFleetCore: () => [
+    {
+      name: "focused-session",
+      windows: [
+        { name: "main", repo: "Soul-Brews-Studio/focus-oracle" },
+        { name: "missing", repo: "Soul-Brews-Studio/missing-oracle" },
+      ],
+    },
+  ],
 }));
 
 mock.module("maw-js/config/ghq-root", () => ({

--- a/test/isolated/plugin-demo-standalone.test.ts
+++ b/test/isolated/plugin-demo-standalone.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const root = join(import.meta.dir, "../..");
+
+function parseFlags(args: string[], spec: Record<string, unknown>) {
+  const out: Record<string, any> = { _: [] };
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i]!;
+    const parser = spec[arg];
+    if (!parser) out._.push(arg);
+    else if (parser === Boolean) out[arg] = true;
+    else if (typeof parser === "string") out[parser] = true;
+    else out[arg] = args[++i];
+  }
+  return out;
+}
+
+mock.module("maw-js/sdk", () => ({
+  hostExec: async () => "",
+  parseFlags,
+}));
+
+const { command, default: demoHandler } = await import("../../src/vendor/mpr-plugins/demo/index.ts?plugin-demo-standalone");
+const { cmdDemo } = await import("../../src/vendor/mpr-plugins/demo/impl.ts?plugin-demo-standalone");
+
+const originalTmux = process.env.TMUX;
+const originalTmuxPane = process.env.TMUX_PANE;
+const originalWrite = process.stdout.write;
+
+beforeEach(() => {
+  delete process.env.TMUX;
+  delete process.env.TMUX_PANE;
+});
+
+afterEach(() => {
+  if (originalTmux === undefined) delete process.env.TMUX;
+  else process.env.TMUX = originalTmux;
+  if (originalTmuxPane === undefined) delete process.env.TMUX_PANE;
+  else process.env.TMUX_PANE = originalTmuxPane;
+  process.stdout.write = originalWrite;
+});
+
+describe("demo plugin standalone boundary (#2113)", () => {
+  test("uses SDK/plugin imports and no maw core imports", () => {
+    const files = ["index.ts", "impl.ts"].map((file) =>
+      readFileSync(join(root, "src/vendor/mpr-plugins/demo", file), "utf8"),
+    );
+
+    for (const source of files) {
+      expect(source).not.toMatch(/maw-js\/(?:core|commands\/shared|cli|config|lib|plugin)(?:\/|")/);
+      expect(source).not.toMatch(/from\s+["'](?:\.\.\/)+/);
+    }
+    const combined = files.join("\n");
+    expect(combined).toContain('from "maw-js/sdk"');
+    expect(combined).toContain('from "@maw-js/sdk/plugin"');
+  });
+
+  test("exports command metadata and help", async () => {
+    expect(command).toMatchObject({
+      name: "demo",
+      description: expect.stringContaining("simulated multi-agent"),
+    });
+
+    const result = await demoHandler({ source: "cli", args: ["--help"] } as any);
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("Usage: maw demo [--fast]");
+    expect(result.output).toContain("No API key required");
+  });
+
+  test("runs the fast tmux demo through injected SDK-like exec", async () => {
+    process.env.TMUX = "/tmp/tmux.sock";
+    process.env.TMUX_PANE = "%caller";
+    const commands: string[] = [];
+    const paneSnapshots = ["%caller", "%caller\n%agent1", "%caller\n%agent1", "%caller\n%agent1\n%agent2"];
+    const writes: string[] = [];
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      writes.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+
+    await cmdDemo({
+      fast: true,
+      sleep: async () => undefined,
+      exec: async (command: string) => {
+        commands.push(command);
+        if (command.startsWith("tmux list-panes")) return paneSnapshots.shift() ?? "%caller\n%agent1\n%agent2";
+        return "";
+      },
+    });
+
+    expect(commands.some((command) => command.startsWith("chmod +x '/tmp/maw-demo-"))).toBe(true);
+    expect(commands).toContainEqual(expect.stringContaining("tmux split-window -t '%caller' -h -l 50%"));
+    expect(commands).toContainEqual(expect.stringContaining("tmux split-window -t '%agent1' -v -l 50%"));
+    expect(commands).toContain("tmux kill-pane -t '%agent2'");
+    expect(commands).toContain("tmux kill-pane -t '%agent1'");
+    expect(commands.filter((command) => command.startsWith("rm -f '/tmp/maw-demo-"))).toHaveLength(2);
+    expect(writes.join("")).toContain("COST REPORT — demo session");
+    expect(writes.join("")).toContain("demo complete");
+  });
+});


### PR DESCRIPTION
Closes #2113 slice.\n\n## Summary\n- move demo plugin imports to @maw-js/sdk/plugin and maw-js/sdk\n- add isolated standalone boundary test for demo metadata/help\n- verify the fast tmux flow through injected exec/sleep without real tmux work\n\n## Verification\n- bun test test/isolated/plugin-demo-standalone.test.ts\n\n## Notes\n- no version bump\n- local post-commit build hook cannot run in this temp worktree because dependencies are not installed (missing arg/hono/elysia), but the targeted test passes after rebasing onto latest alpha.