### PR TITLE
test: standalone coverage for consent plugin

### DIFF
--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -30,6 +30,14 @@ export type { EngineDef } from "../config/engine-def";
 export type { EngineRegistry } from "../config/engine-registry";
 export type { MawConfig } from "../config";
 
+// ─── Consent ────────────────────────────────────────────────────────────────
+
+export {
+  listPending, listTrust, recordTrust, removeTrust,
+  approveConsent, rejectConsent,
+} from "../core/consent";
+export type { ConsentAction } from "../core/consent";
+
 // ─── Transport ───────────────────────────────────────────────────────────────
 
 export {

--- a/src/vendor/mpr-plugins/consent/index.ts
+++ b/src/vendor/mpr-plugins/consent/index.ts
@@ -9,12 +9,10 @@
  *   maw consent untrust <peer> [action]  revoke trust entry
  *   maw consent list-trust               show all trust entries
  */
-import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import {
-  listPending, listTrust, recordTrust, removeTrust,
-  approveConsent, rejectConsent, type ConsentAction,
-} from "maw-js/core/consent";
-import { loadConfig } from "maw-js/config";
+  approveConsent, listPending, listTrust, loadConfig, recordTrust, rejectConsent, removeTrust,
+  type ConsentAction, type InvokeContext, type InvokeResult,
+} from "maw-js/sdk";
 
 const VALID_ACTIONS: ConsentAction[] = ["hey", "team-invite", "plugin-install"];
 

--- a/test/isolated/plugin-consent-standalone.test.ts
+++ b/test/isolated/plugin-consent-standalone.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+type ConsentAction = "hey" | "team-invite" | "plugin-install";
+type Pending = { id: string; from: string; to: string; action: ConsentAction; summary: string; status: string };
+type Trust = { from: string; to: string; action: ConsentAction; approvedAt: string };
+
+const root = join(import.meta.dir, "../..");
+let pendingRows: Pending[] = [];
+let trustRows: Trust[] = [];
+let config: Record<string, unknown> = { node: "m5" };
+const recordedTrust: unknown[] = [];
+const removeCalls: Array<{ from: string; to: string; action: ConsentAction }> = [];
+let approveResult: { ok: boolean; error?: string; entry?: { from: string; to: string; action: ConsentAction } } = {
+  ok: true,
+  entry: { from: "m5", to: "oracle", action: "hey" },
+};
+let rejectResult: { ok: boolean; error?: string } = { ok: true };
+let removeResult = true;
+
+const sdkMock = {
+  listPending: () => pendingRows,
+  listTrust: () => trustRows,
+  recordTrust: (entry: unknown) => recordedTrust.push(entry),
+  removeTrust: (from: string, to: string, action: ConsentAction) => {
+    removeCalls.push({ from, to, action });
+    return removeResult;
+  },
+  approveConsent: async () => approveResult,
+  rejectConsent: () => rejectResult,
+  loadConfig: () => config,
+};
+
+mock.module("maw-js/sdk", () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
+
+const { default: consentHandler, command } = await import("../../src/vendor/mpr-plugins/consent/index.ts");
+
+beforeEach(() => {
+  pendingRows = [];
+  trustRows = [];
+  config = { node: "m5" };
+  recordedTrust.length = 0;
+  removeCalls.length = 0;
+  approveResult = { ok: true, entry: { from: "m5", to: "oracle", action: "hey" } };
+  rejectResult = { ok: true };
+  removeResult = true;
+});
+
+describe("consent plugin standalone boundary (#2250)", () => {
+  test("imports consent helpers only through the SDK boundary", () => {
+    const source = readFileSync(join(root, "src/vendor/mpr-plugins/consent/index.ts"), "utf8");
+    expect(command).toMatchObject({ name: "consent" });
+    expect(source).toContain('from "maw-js/sdk"');
+    expect(source).not.toMatch(/maw-js\/(?:core|commands\/shared|cli|config|lib|plugin)(?:\/|")/);
+    expect(source).not.toMatch(/from\s+["'](?:\.\.\/)+(?:core|commands|cli|config|lib|src)\//);
+
+    const sdkSource = readFileSync(join(root, "src/sdk/index.ts"), "utf8");
+    expect(sdkSource).toContain("../core/consent");
+  });
+
+  test("lists pending requests through SDK helpers", async () => {
+    pendingRows = [{
+      id: "req-1",
+      from: "neo",
+      to: "m5",
+      action: "hey",
+      status: "pending",
+      summary: "approve cross-oracle hey",
+    }];
+
+    const result = await consentHandler({ source: "cli", args: ["list"] } as any);
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("req-1");
+    expect(result.output).toContain("neo → m5");
+    expect(result.output).toContain("approve cross-oracle hey");
+  });
+
+  test("trust writes use loadConfig node and recordTrust from SDK", async () => {
+    config = { node: "codex-5" };
+
+    const result = await consentHandler({ source: "cli", args: ["trust", "oracle", "team-invite"] } as any);
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("codex-5 → oracle:team-invite");
+    expect(recordedTrust).toEqual([{
+      from: "codex-5",
+      to: "oracle",
+      action: "team-invite",
+      approvedAt: expect.any(String),
+      approvedBy: "human",
+      requestId: null,
+    }]);
+  });
+
+  test("approve, reject, and untrust route through SDK results", async () => {
+    const approved = await consentHandler({ source: "cli", args: ["approve", "req-1", "123456"] } as any);
+    expect(approved.ok).toBe(true);
+    expect(approved.output).toContain("approved req-1");
+
+    rejectResult = { ok: false, error: "already rejected" };
+    const rejected = await consentHandler({ source: "cli", args: ["reject", "req-1"] } as any);
+    expect(rejected).toEqual({ ok: false, error: "already rejected" });
+
+    const untrusted = await consentHandler({ source: "cli", args: ["untrust", "oracle"] } as any);
+    expect(untrusted.ok).toBe(true);
+    expect(removeCalls).toEqual([{ from: "m5", to: "oracle", action: "hey" }]);
+  });
+
+  test("invalid subcommands and actions stay local validation errors", async () => {
+    const badAction = await consentHandler({ source: "cli", args: ["trust", "oracle", "dance"] } as any);
+    expect(badAction.ok).toBe(false);
+    expect(badAction.error).toContain("unknown action 'dance'");
+
+    const badSub = await consentHandler({ source: "cli", args: ["wat"] } as any);
+    expect(badSub.ok).toBe(false);
+    expect(badSub.error).toContain("unknown subcommand: wat");
+    expect(badSub.error).toContain("usage:");
+  });
+});


### PR DESCRIPTION
Closes #2250.

Summary:
- move consent plugin private core/config/plugin imports to maw-js/sdk
- export consent helpers/types from src/sdk/index.ts
- add isolated standalone coverage for boundary imports, list, trust, approve/reject/untrust, and validation errors

Verification:
- bun build test/isolated/plugin-consent-standalone.test.ts --outfile /tmp/plugin-consent-standalone.js --target=bun --external maw-js/sdk
- rg private import boundary check
- git diff --check
- bun run build

Known local gap:
- bun test test/isolated/plugin-consent-standalone.test.ts hits the known Bun canary 1.4.0 index-out-of-bounds panic before assertions.