### PR TITLE
test: standalone coverage for costs plugin

### DIFF
--- a/packages/sdk/index.d.ts
+++ b/packages/sdk/index.d.ts
@@ -216,6 +216,17 @@ export declare function parseFlags<T extends Record<string, unknown>>(
   skip?: number,
 ): { [key: string]: unknown; _: string[] };
 
+/** User-facing command error marker. */
+export declare class UserError extends Error {
+  readonly isUserError: true;
+}
+
+/** True when an error was raised for user-facing command feedback. */
+export declare function isUserError(e: unknown): e is UserError;
+
+/** Render numeric buckets as a compact Unicode sparkline. */
+export declare function sparkline(values: number[], hadActivity?: boolean[]): string;
+
 // --- src/commands/shared/comm ---
 
 /** Peek/capture a target session or window and print the result. */

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -51,6 +51,8 @@ export type {
 // kill, capture, panes, split, contacts, tag, locate.
 // NOTE: also re-exported from "@maw-js/sdk/plugin" for ergonomics — both work.
 export { parseFlags } from "../../src/cli/parse-args";
+export { UserError, isUserError } from "../../src/core/util/user-error";
+export { sparkline } from "../../src/lib/sparkline";
 
 // ─── src/commands/shared/comm ────────────────────────────────────────────────
 // Federation-aware communication helpers used by small command plugins.

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -158,6 +158,8 @@ export { registerCommand, matchCommand, listCommands } from "../cli/command-regi
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 export { parseFlags } from "../cli/parse-args";
+export { UserError, isUserError } from "../core/util/user-error";
+export { sparkline } from "../lib/sparkline";
 export { tlink } from "../core/util/terminal";
 
 // Plugin extraction helpers for tab-like command surfaces.

--- a/src/vendor/mpr-plugins/costs/impl.ts
+++ b/src/vendor/mpr-plugins/costs/impl.ts
@@ -1,6 +1,4 @@
-import { loadConfig } from "maw-js/config";
-import { UserError } from "maw-js/core/util/user-error";
-import { sparkline } from "maw-js/lib/sparkline";
+import { loadConfig, sparkline, UserError } from "maw-js/sdk";
 
 type CostAgent = {
   name: string;

--- a/src/vendor/mpr-plugins/costs/index.ts
+++ b/src/vendor/mpr-plugins/costs/index.ts
@@ -1,5 +1,4 @@
-import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
-import { parseFlags } from "maw-js/cli/parse-args";
+import { parseFlags, type InvokeContext, type InvokeResult } from "maw-js/sdk";
 import { cmdCosts, cmdCostsDaily } from "./impl";
 
 export const command = {

--- a/test/isolated/plugin-costs-standalone.test.ts
+++ b/test/isolated/plugin-costs-standalone.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "../..");
+let config: Record<string, unknown> = { host: "local", port: 4242 };
+let fetchCalls: string[] = [];
+let responseBody = "";
+let responseOk = true;
+let responseStatus = 200;
+let responseStatusText = "OK";
+let fetchError: Error | null = null;
+
+class MockUserError extends Error {
+  readonly isUserError = true;
+  constructor(message: string) {
+    super(message);
+    this.name = "UserError";
+  }
+}
+
+function parseFlags(args: string[], spec: Record<string, unknown>) {
+  const out: Record<string, unknown> & { _: string[] } = { _: [] };
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "-j") {
+      out["--json"] = true;
+    } else if (arg === "--json") {
+      out["--json"] = true;
+    } else if (arg === "--daily") {
+      const raw = args[++i];
+      out["--daily"] = spec["--daily"] === Number ? Number(raw) : raw;
+    } else {
+      out._.push(arg);
+    }
+  }
+  return out;
+}
+
+const sdkMock = {
+  loadConfig: () => config,
+  parseFlags,
+  UserError: MockUserError,
+  sparkline: (values: number[], hadActivity?: boolean[]) =>
+    values.map((value, index) => hadActivity?.[index] === false ? "░" : value > 0 ? "█" : "▁").join(""),
+};
+
+mock.module("maw-js/sdk", () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
+
+const { default: costsHandler, command } = await import("../../src/vendor/mpr-plugins/costs/index.ts");
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  config = { host: "local", port: 4242 };
+  fetchCalls = [];
+  responseBody = JSON.stringify({ agents: [], total: { agents: 0, sessions: 0, tokens: 0, cost: 0 } });
+  responseOk = true;
+  responseStatus = 200;
+  responseStatusText = "OK";
+  fetchError = null;
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    fetchCalls.push(url);
+    if (fetchError) throw fetchError;
+    return {
+      ok: responseOk,
+      status: responseStatus,
+      statusText: responseStatusText,
+      text: async () => responseBody,
+    } as Response;
+  }) as typeof fetch;
+});
+
+describe("costs plugin standalone boundary", () => {
+  test("imports runtime helpers only through the SDK boundary", () => {
+    const indexSource = readFileSync(join(root, "src/vendor/mpr-plugins/costs/index.ts"), "utf8");
+    const implSource = readFileSync(join(root, "src/vendor/mpr-plugins/costs/impl.ts"), "utf8");
+    const combined = `${indexSource}\n${implSource}`;
+
+    expect(command).toMatchObject({ name: "costs" });
+    expect(combined).toContain('from "maw-js/sdk"');
+    expect(combined).not.toMatch(/maw-js\/(?:core|commands\/shared|cli|config|lib|plugin)(?:\/|")/);
+    expect(combined).not.toMatch(/from\s+["'](?:\.\.\/)+(?:core|commands|cli|config|lib|src)\//);
+
+    const sdkSource = readFileSync(join(root, "src/sdk/index.ts"), "utf8");
+    expect(sdkSource).toContain("../core/util/user-error");
+    expect(sdkSource).toContain("../lib/sparkline");
+  });
+
+  test("default CLI view fetches aggregate costs from the configured maw server", async () => {
+    responseBody = JSON.stringify({
+      agents: [{ name: "codex-5", totalTokens: 1234, estimatedCost: 1.23, sessions: 2, turns: 9, lastActive: "2026-06-07T00:00:00Z" }],
+      total: { agents: 1, sessions: 2, tokens: 1234, cost: 1.23 },
+    });
+
+    const result = await costsHandler({ source: "cli", args: [] } as any);
+
+    expect(result.ok).toBe(true);
+    expect(fetchCalls).toEqual(["http://localhost:4242/api/costs"]);
+    expect(result.output).toContain("COST TRACKING");
+    expect(result.output).toContain("codex-5");
+    expect(result.output).toContain("$1.23");
+  });
+
+  test("bare --daily injects the default 7 day window and can render JSON", async () => {
+    responseBody = JSON.stringify({
+      window: 7,
+      buckets: ["2026-06-07"],
+      agents: [],
+      total: { cost: 0, agents: 0 },
+    });
+
+    const result = await costsHandler({ source: "cli", args: ["--daily", "--json"] } as any);
+
+    expect(result.ok).toBe(true);
+    expect(fetchCalls).toEqual(["http://localhost:4242/api/costs/daily?days=7"]);
+    expect(result.output).toContain('"window": 7');
+  });
+
+  test("API daily args use numeric days and text daily output uses SDK sparkline", async () => {
+    config = { host: "maw.local", port: 5151 };
+    responseBody = JSON.stringify({
+      window: 3,
+      buckets: ["2026-06-05", "2026-06-06", "2026-06-07"],
+      agents: [{ name: "oracle", dailyCosts: [0, 0.5, 1], totalCost: 1.5, hadActivity: [false, true, true] }],
+      total: { cost: 1.5, agents: 1 },
+    });
+
+    const result = await costsHandler({ source: "api", args: { daily: true, days: "3" } } as any);
+
+    expect(result.ok).toBe(true);
+    expect(fetchCalls).toEqual(["http://maw.local:5151/api/costs/daily?days=3"]);
+    expect(result.output).toContain("DAILY COSTS");
+    expect(result.output).toContain("░██");
+  });
+
+  test("network failures return user-facing serve guidance", async () => {
+    fetchError = new Error("ECONNREFUSED");
+
+    const result = await costsHandler({ source: "cli", args: [] } as any);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("cannot reach maw server");
+  });
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});


### PR DESCRIPTION
Summary:
- move costs plugin private CLI/config/core/lib imports to maw-js/sdk
- export UserError and sparkline from the SDK barrels/types
- add isolated standalone coverage for boundary imports, aggregate costs, daily JSON/default window, API daily output, and network errors

Verification:
- bun build test/isolated/plugin-costs-standalone.test.ts --outfile /tmp/plugin-costs-standalone.js --target=bun --external maw-js/sdk
- rg private import boundary check
- git diff --check
- bun run build

Known local gap:
- bun test test/isolated/plugin-costs-standalone.test.ts hits the known Bun canary 1.4.0 index-out-of-bounds panic before assertions.