### PR TITLE
test: lock on plugin standalone boundary

### DIFF
--- a/src/vendor/mpr-plugins/on/index.ts
+++ b/src/vendor/mpr-plugins/on/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import type { InvokeContext, InvokeResult } from "@maw-js/sdk/plugin";
 
 export const command = {
   name: "on",
@@ -6,7 +6,7 @@ export const command = {
 };
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
-  const { loadConfig, saveConfig } = await import("maw-js/config");
+  const { loadConfig, saveConfig } = await import("maw-js/sdk");
 
   const logs: string[] = [];
   const origLog = console.log;

--- a/test/isolated/plugin-on-standalone.test.ts
+++ b/test/isolated/plugin-on-standalone.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const root = join(import.meta.dir, "../..");
+let config: Record<string, any> = {};
+let savedConfigs: Record<string, any>[] = [];
+
+mock.module("maw-js/sdk", () => ({
+  loadConfig: () => config,
+  saveConfig: (next: Record<string, any>) => {
+    savedConfigs.push(next);
+    config = { ...config, ...next };
+  },
+}));
+
+const { command, default: onHandler } = await import("../../src/vendor/mpr-plugins/on/index.ts?plugin-on-standalone");
+
+function stripAnsi(value: string | undefined) {
+  return String(value ?? "").replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "");
+}
+
+beforeEach(() => {
+  config = {};
+  savedConfigs = [];
+});
+
+describe("on plugin standalone boundary (#2113)", () => {
+  test("uses SDK/plugin imports and no maw private imports", () => {
+    const source = readFileSync(join(root, "src/vendor/mpr-plugins/on/index.ts"), "utf8");
+
+    expect(source).toContain('from "@maw-js/sdk/plugin"');
+    expect(source).toContain('import("maw-js/sdk")');
+    expect(source).not.toMatch(/maw-js\/(?:core|commands\/shared|cli|config|lib|plugin)(?:\/|")/);
+    expect(source).not.toMatch(/from\s+["'](?:\.\.\/)+/);
+  });
+
+  test("exports command metadata and usage output", async () => {
+    expect(command).toMatchObject({
+      name: "on",
+      description: expect.stringContaining("event triggers"),
+    });
+
+    const result = await onHandler({ source: "cli", args: [] } as any);
+
+    expect(result.ok).toBe(true);
+    const output = stripAnsi(result.output);
+    expect(output).toContain('Usage: maw on <oracle> <event> [--once] [--timeout N] "<action>"');
+    expect(output).toContain("agent-idle, agent-wake, agent-crash");
+    expect(savedConfigs).toEqual([]);
+  });
+
+  test("adds a trigger using only SDK config helpers", async () => {
+    config = { triggers: [{ name: "existing", on: "agent-idle", repo: "old", timeout: 5, action: "noop" }] };
+
+    const result = await onHandler({
+      source: "cli",
+      args: ["neo", "idle", "--once", "--timeout", "9", "maw", "hey", "homekeeper", "neo done"],
+    } as any);
+
+    expect(result.ok).toBe(true);
+    expect(savedConfigs).toEqual([
+      {
+        triggers: [
+          { name: "existing", on: "agent-idle", repo: "old", timeout: 5, action: "noop" },
+          {
+            on: "agent-idle",
+            repo: "neo",
+            timeout: 9,
+            action: "maw hey homekeeper neo done",
+            name: "on-neo-idle",
+            once: true,
+          },
+        ],
+      },
+    ]);
+    expect(stripAnsi(result.output)).toContain("trigger added: on neo idle [once] → maw hey homekeeper neo done");
+  });
+
+  test("returns save errors as InvokeResult failures", async () => {
+    savedConfigs = [];
+    config = { triggers: [] };
+    mock.module("maw-js/sdk", () => ({
+      loadConfig: () => config,
+      saveConfig: () => {
+        throw new Error("disk full");
+      },
+    }));
+    const { default: failingHandler } = await import("../../src/vendor/mpr-plugins/on/index.ts?plugin-on-standalone-fail");
+
+    const result = await failingHandler({ source: "cli", args: ["neo", "wake", "maw", "peek", "neo"] } as any);
+
+    expect(result).toMatchObject({ ok: false, error: "disk full" });
+  });
+});


### PR DESCRIPTION
Closes #2113 slice.\n\n## Summary\n- move on plugin private type/config imports to @maw-js/sdk/plugin and maw-js/sdk\n- add isolated standalone boundary coverage for metadata, usage, trigger persistence, and save errors\n\n## Verification\n- bun test test/isolated/plugin-on-standalone.test.ts\n\n## Notes\n- no version bump\n- local post-commit build hook cannot run in this temp worktree because dependencies are not installed (missing arg/hono/elysia), but the targeted test passes after rebasing onto latest alpha.