### PR TITLE
test(demo): align SDK mocks after standalone extraction

### DIFF
--- a/test/isolated/assign-locks-extra-coverage.test.ts
+++ b/test/isolated/assign-locks-extra-coverage.test.ts
@@ -118,6 +118,16 @@ await mock.module("maw-js/sdk", () => ({
     hostExecCalls.push(cmd);
     return hostExecImpl(cmd);
   },
+  fetchIssuePrompt: async (issueNum: number, slug: string) => {
+    fetchIssueCalls.push([issueNum, slug]);
+    return fetchIssuePromptImpl(issueNum, slug);
+  },
+  cmdWake: async (
+    oracle: string,
+    opts: { incubate: string; task: string; prompt: string },
+  ) => {
+    wakeCalls.push([oracle, opts]);
+  },
 }));
 
 await mock.module("maw-js/commands/shared/wake", () => ({

--- a/test/isolated/dream-impl-edge-coverage.test.ts
+++ b/test/isolated/dream-impl-edge-coverage.test.ts
@@ -20,6 +20,16 @@ const original = {
 
 mock.module("maw-js/sdk", () => ({
   hostExec: async (cmd: string) => fakeHostExec(cmd),
+  getGhqRoot: () => ghqRoot,
+  loadFleetCore: () => {
+    if (scenario === "offline-all") {
+      return [{ name: "edge", windows: [{ name: "edge", repo: "Soul-Brews-Studio/edge-oracle" }] }];
+    }
+    if (scenario === "empty-scan") {
+      return [{ name: "empty", windows: [{ name: "missing", repo: "Soul-Brews-Studio/missing-oracle" }] }];
+    }
+    return [{ name: "many", windows: [{ name: "dupe", repo: "Soul-Brews-Studio/repo-00-oracle" }] }];
+  },
 }));
 
 mock.module("maw-js/config/ghq-root", () => ({

--- a/test/isolated/dream-impl-fourth-pass-coverage.test.ts
+++ b/test/isolated/dream-impl-fourth-pass-coverage.test.ts
@@ -21,6 +21,13 @@ const original = {
 
 mock.module("maw-js/sdk", () => ({
   hostExec: async (cmd: string) => fakeHostExec(cmd),
+  getGhqRoot: () => ghqRoot,
+  loadFleetCore: () => [
+    {
+      name: "fourth-pass-session",
+      windows: [{ name: "main", repo: "Soul-Brews-Studio/fourth-oracle" }],
+    },
+  ],
 }));
 
 mock.module("maw-js/config/ghq-root", () => ({

--- a/test/isolated/dream-impl-second-pass-coverage.test.ts
+++ b/test/isolated/dream-impl-second-pass-coverage.test.ts
@@ -19,6 +19,10 @@ const original = {
 
 mock.module("maw-js/sdk", () => ({
   hostExec: async (cmd: string) => fakeHostExec(cmd),
+  getGhqRoot: () => ghqRoot,
+  loadFleetCore: () => [
+    { name: "active", windows: [{ name: "main", repo: "Soul-Brews-Studio/active-oracle" }] },
+  ],
 }));
 
 mock.module("maw-js/config/ghq-root", () => ({

--- a/test/isolated/dream-team-index-extra-coverage.test.ts
+++ b/test/isolated/dream-team-index-extra-coverage.test.ts
@@ -52,6 +52,8 @@ mock.module("maw-js/commands/shared/fleet-load", () => ({
 }));
 mock.module("maw-js/sdk", () => ({
   hostExec: async (cmd: string) => fakeHostExec(cmd),
+  getGhqRoot: () => ghqRoot,
+  loadFleetCore: () => [{ name: "dream-team-extra", windows: [{ name: "alpha", repo: "Soul-Brews-Studio/alpha-oracle" }] }],
 }));
 mock.module("maw-js/cli/parse-args", () => ({ parseFlags: parseTestFlags }));
 
@@ -131,6 +133,8 @@ mock.module(at("../../src/sdk"), () => ({
     if (next instanceof Error) throw next;
     return next ?? "";
   },
+  getGhqRoot: () => ghqRoot,
+  loadFleetCore: () => [{ name: "dream-team-extra", windows: [{ name: "alpha", repo: "Soul-Brews-Studio/alpha-oracle" }] }],
   withPaneLock: async (fn: () => Promise<void>) => fn(),
 }));
 mock.module(at("../../src/commands/plugins/tmux/layout-manager"), () => ({


### PR DESCRIPTION
## Summary
- align stale isolated mocks with the SDK exports used after the demo standalone extraction
- add missing SDK mock exports for assign/dream follow-on failures

Follows #2264.

## Tests
- bun test test/isolated/assign-locks-extra-coverage.test.ts
- bun test test/isolated/dream-impl-edge-coverage.test.ts
- bun test test/isolated/dream-impl-fourth-pass-coverage.test.ts
- bun test test/isolated/dream-impl-second-pass-coverage.test.ts
- bun test test/isolated/dream-team-index-extra-coverage.test.ts
- bun test test/isolated/plugin-demo-standalone.test.ts

## Notes
- local post-commit dist build is blocked by missing deps arg/hono/elysia in this worktree