### PR TITLE
test: standalone coverage for health plugin

### DIFF
--- a/test/isolated/plugin-health-standalone.test.ts
+++ b/test/isolated/plugin-health-standalone.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+type HealthConfig = {
+  port: number;
+  peers?: string[];
+  namedPeers?: Array<{ name: string; url: string }>;
+};
+
+const root = join(import.meta.dir, "../..");
+let config: HealthConfig = { port: 4242 };
+let sessions: unknown[] = [];
+let tmuxError: Error | null = null;
+let fetchResult: { ok: boolean; status: number; json?: () => Promise<unknown> } | Error = {
+  ok: true,
+  status: 200,
+  json: async () => ({ sessions: 1 }),
+};
+let curlResults = new Map<string, { ok: boolean; status: number } | Error>();
+let execCalls: string[] = [];
+let curlCalls: Array<{ url: string; method?: string; body?: string; from?: string; timeout?: number }> = [];
+let execHandler: (cmd: string) => string = () => "";
+
+const sdkMock = {
+  loadConfig: () => config,
+  cfgTimeout: (name: string) => name === "health" ? 3210 : 1,
+  tmux: {
+    listSessions: async () => {
+      if (tmuxError) throw tmuxError;
+      return sessions;
+    },
+  },
+  curlFetch: async (url: string, opts: { method?: string; body?: string; from?: string; timeout?: number }) => {
+    curlCalls.push({ url, ...opts });
+    const result = curlResults.get(url);
+    if (result instanceof Error) throw result;
+    if (!result) throw new Error(`unexpected curlFetch: ${url}`);
+    return result;
+  },
+};
+
+mock.module("maw-js/sdk", () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
+mock.module("child_process", () => ({
+  execSync: (cmd: string) => {
+    execCalls.push(cmd);
+    return execHandler(cmd);
+  },
+}));
+
+const { default: healthHandler, command } = await import("../../src/vendor/mpr-plugins/health/index.ts");
+
+const originalFetch = globalThis.fetch;
+const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+
+function setPlatform(platform: NodeJS.Platform) {
+  Object.defineProperty(process, "platform", { value: platform, configurable: true });
+}
+
+beforeEach(() => {
+  config = { port: 4242 };
+  sessions = [{ name: "m5" }, { name: "oracle" }];
+  tmuxError = null;
+  fetchResult = { ok: true, status: 200, json: async () => ({ sessions: 2 }) };
+  curlResults = new Map();
+  execCalls = [];
+  curlCalls = [];
+  execHandler = (cmd: string) => {
+    if (cmd === "df -h /tmp | tail -1") return "/dev/disk 100G 25G 75G 25% /tmp";
+    if (cmd === "free -m | grep Mem") return "Mem: 16000 1000 2000 0 0 12000";
+    if (cmd === "pm2 jlist 2>/dev/null") return JSON.stringify([{ name: "maw", pid: 123, pm2_env: { status: "online" } }]);
+    throw new Error(`unexpected execSync: ${cmd}`);
+  };
+  setPlatform("linux");
+  globalThis.fetch = (async () => {
+    if (fetchResult instanceof Error) throw fetchResult;
+    return fetchResult as Response;
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalPlatform) Object.defineProperty(process, "platform", originalPlatform);
+});
+
+describe("health plugin standalone boundary", () => {
+  test("imports runtime helpers only through the SDK boundary", () => {
+    const indexSource = readFileSync(join(root, "src/vendor/mpr-plugins/health/index.ts"), "utf8");
+    const implSource = readFileSync(join(root, "src/vendor/mpr-plugins/health/impl.ts"), "utf8");
+    const combined = `${indexSource}\n${implSource}`;
+
+    expect(command).toMatchObject({ name: "health" });
+    expect(combined).toContain('from "maw-js/sdk"');
+    expect(combined).not.toMatch(/maw-js\/(?:core|commands\/shared|cli|config|lib|plugin)(?:\/|")/);
+    expect(combined).not.toMatch(/from\s+["'](?:\.\.\/)+(?:core|commands|cli|config|lib|src)\//);
+  });
+
+  test("handler renders healthy local checks and delivery-faithful peer probes", async () => {
+    config = {
+      port: 5151,
+      peers: ["http://peer-a"],
+      namedPeers: [{ name: "beta", url: "http://peer-b" }],
+    };
+    curlResults.set("http://peer-a/api/probe", { ok: true, status: 200 });
+    curlResults.set("http://peer-b/api/probe", { ok: false, status: 503 });
+
+    const result = await healthHandler({ source: "cli", args: [] } as any);
+
+    expect(result.ok).toBe(true);
+    expect(globalThis.fetch).toHaveBeenCalledWith("http://localhost:5151/api/probe", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+      signal: expect.any(AbortSignal),
+    });
+    expect(execCalls).toEqual(["df -h /tmp | tail -1", "free -m | grep Mem", "pm2 jlist 2>/dev/null"]);
+    expect(curlCalls).toEqual([
+      { url: "http://peer-a/api/probe", method: "POST", body: "{}", from: "auto", timeout: 3210 },
+      { url: "http://peer-b/api/probe", method: "POST", body: "{}", from: "auto", timeout: 3210 },
+    ]);
+    expect(result.output).toContain("maw health");
+    expect(result.output).toContain("tmux server        running (2 sessions)");
+    expect(result.output).toContain("maw server         online (:5151, 2 sessions, probe ok)");
+    expect(result.output).toContain("peer http://peer-a online (delivery ok)");
+    expect(result.output).toContain("peer beta (http://peer-b) HTTP 503 (probe)");
+  });
+
+  test("handler reports warning/failure fallbacks without throwing", async () => {
+    tmuxError = new Error("tmux down");
+    fetchResult = new Error("server down");
+    config = { port: 6161, peers: ["http://offline"] };
+    curlResults.set("http://offline/api/probe", new Error("offline"));
+    execHandler = (cmd: string) => {
+      if (cmd === "df -h /tmp | tail -1") return "/dev/disk 100G 95G 4G 97% /tmp";
+      if (cmd === "free -m | grep Mem") throw new Error("free missing");
+      if (cmd === "pm2 jlist 2>/dev/null") return "not json";
+      throw new Error(`unexpected execSync: ${cmd}`);
+    };
+
+    const result = await healthHandler({ source: "cli", args: [] } as any);
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("tmux server        not running");
+    expect(result.output).toContain("maw server         offline");
+    expect(result.output).toContain("disk /tmp          4G free");
+    expect(result.output).toContain("memory             unknown");
+    expect(result.output).toContain("peer http://offline unreachable");
+    expect(result.output).not.toContain("pm2 maw");
+  });
+
+  test("macOS memory and no-peer path stay standalone", async () => {
+    setPlatform("darwin");
+    fetchResult = { ok: true, status: 200, json: async () => ({ sessions: "unknown" }) };
+    execHandler = (cmd: string) => {
+      if (cmd === "df -h /tmp | tail -1") throw new Error("df unavailable");
+      if (cmd === "vm_stat") return "Pages free: 10.\nPages inactive: 22.";
+      if (cmd === "sysctl -n hw.pagesize") return "4096\n";
+      if (cmd === "pm2 jlist 2>/dev/null") return JSON.stringify([{ name: "other", pid: 9, pm2_env: { status: "online" } }]);
+      throw new Error(`unexpected execSync: ${cmd}`);
+    };
+
+    const result = await healthHandler({ source: "api", args: {} } as any);
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("maw server         online (:4242, ? sessions, probe ok)");
+    expect(result.output).toContain("disk /tmp          unknown");
+    expect(result.output).toContain("memory             0MB available");
+    expect(result.output).toContain("peers              none configured");
+  });
+});


### PR DESCRIPTION
Summary:
- add isolated standalone coverage for the health plugin boundary
- verify health imports stay on maw-js/sdk/local files only
- mock SDK/platform edges for local health, peer probe, failure fallback, and macOS/no-peer paths

Verification:
- bun build test/isolated/plugin-health-standalone.test.ts --outfile /tmp/plugin-health-standalone.js --target=bun --external maw-js/sdk
- rg private import boundary check
- git diff --check
- bun run build

Known local gap:
- bun test test/isolated/plugin-health-standalone.test.ts hits the known Bun canary 1.4.0 index-out-of-bounds panic before assertions.