### PR TITLE
test(locate): cover standalone plugin boundary

### DIFF
--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -158,6 +158,7 @@ export { registerCommand, matchCommand, listCommands } from "../cli/command-regi
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 export { parseFlags } from "../cli/parse-args";
+export { ghqFind, ghqList, ghqFindSync, ghqListSync } from "../core/ghq";
 export { UserError, isUserError } from "../core/util/user-error";
 export { sparkline } from "../lib/sparkline";
 export { tlink } from "../core/util/terminal";

--- a/src/vendor/mpr-plugins/locate/impl.ts
+++ b/src/vendor/mpr-plugins/locate/impl.ts
@@ -13,13 +13,17 @@
 
 import { existsSync } from "fs";
 import { join } from "path";
-import { ghqFind } from "maw-js/core/ghq";
-import { listSessions } from "maw-js/sdk";
-import { loadFleetEntries, type FleetEntry } from "maw-js/commands/shared/fleet-load";
-import { loadConfig } from "maw-js/config";
-import { resolveSessionTarget } from "maw-js/core/matcher/resolve-target";
-import { UserError } from "maw-js/core/util/user-error";
-import { loadManifestCached, type OracleManifestEntry } from "maw-js/lib/oracle-manifest";
+import {
+  ghqFind,
+  listSessions,
+  loadConfig,
+  loadFleetEntries,
+  loadManifestCached,
+  resolveSessionTarget,
+  UserError,
+  type FleetEntry,
+  type OracleManifestEntry,
+} from "maw-js/sdk";
 import { fetchPeerPayload, type PeerSession } from "../ls/internal/peer-call";
 import { resolveAllPeers } from "../ls/internal/peer-resolve";
 

--- a/src/vendor/mpr-plugins/locate/index.ts
+++ b/src/vendor/mpr-plugins/locate/index.ts
@@ -1,6 +1,5 @@
-import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import { parseFlags, type InvokeContext, type InvokeResult } from "maw-js/sdk";
 import { cmdLocate } from "./impl";
-import { parseFlags } from "maw-js/cli/parse-args";
 
 export const command = {
   name: "locate",

--- a/test/isolated/locate-impl-coverage.test.ts
+++ b/test/isolated/locate-impl-coverage.test.ts
@@ -21,14 +21,32 @@ mock.module("maw-js/core/ghq", () => ({
 }));
 mock.module("maw-js/sdk", () => ({
   FLEET_DIR: fleetDir,
+  ghqFind: async () => ghqResults.shift() ?? null,
   listSessions: async () => {
     if (listSessionsThrows) throw new Error("tmux unavailable");
     return sessions;
   },
+  loadFleetEntries: () => readdirSync(fleetDir)
+    .filter(file => file.endsWith(".json") && !file.endsWith(".disabled"))
+    .sort()
+    .map(file => {
+      const match = file.match(/^(\d+)-(.+)\.json$/);
+      return {
+        file,
+        path: join(fleetDir, file),
+        num: match ? Number.parseInt(match[1], 10) : 0,
+        groupName: match ? match[2] : file.replace(/\.json$/, ""),
+        session: JSON.parse(readFileSync(join(fleetDir, file), "utf-8") || "{}"),
+      };
+    }),
+  loadConfig: () => config,
+  resolveSessionTarget: () => resolved,
+  loadManifestCached: () => manifestEntries,
   curlFetch: async (url: string, options: any) => {
     curlFetchCalls.push({ url, options });
     return curlFetchQueue.shift() ?? { ok: true, status: 200, data: { sessions: [] } };
   },
+  UserError: class UserError extends Error {},
 }));
 mock.module("maw-js/commands/shared/fleet-load", () => ({
   loadFleetEntries: () => readdirSync(fleetDir)

--- a/test/isolated/plugin-locate-standalone.test.ts
+++ b/test/isolated/plugin-locate-standalone.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "../..");
+let repoPath = "";
+let psiExists = true;
+let sessions: Array<{ name: string; windows: Array<{ index: number; name: string }> }> = [];
+let fleetEntries: any[] = [];
+let config: any = {};
+let manifest: any[] = [];
+let federationHits: any[] = [];
+
+mock.module("maw-js/sdk", () => ({
+  ghqFind: async (pattern: string) => {
+    if (pattern.includes("mawjs-oracle") || pattern.includes("mawjs")) return repoPath;
+    return null;
+  },
+  listSessions: async () => sessions,
+  loadFleetEntries: () => fleetEntries,
+  loadConfig: () => config,
+  loadManifestCached: () => manifest,
+  resolveSessionTarget: (oracle: string, available: typeof sessions) => {
+    const match = available.find((session) => session.name === `139-${oracle}` || session.name === oracle);
+    return match ? { kind: "exact", match } : { kind: "none" };
+  },
+  parseFlags: (args: string[], spec: Record<string, unknown>) => {
+    const out: Record<string, any> = { _: [] };
+    for (let i = 0; i < args.length; i += 1) {
+      const arg = args[i]!;
+      const parser = spec[arg];
+      if (!parser) out._.push(arg);
+      else if (parser === Boolean) out[arg] = true;
+      else if (typeof parser === "string") out[parser] = true;
+      else out[arg] = args[++i];
+    }
+    return out;
+  },
+  UserError: class UserError extends Error {},
+}));
+
+mock.module("../../src/vendor/mpr-plugins/ls/internal/peer-resolve.ts", () => ({
+  resolveAllPeers: () => federationHits.map((hit) => ({ alias: hit.alias, url: hit.url, node: hit.node ?? null })),
+}));
+
+mock.module("../../src/vendor/mpr-plugins/ls/internal/peer-call.ts", () => ({
+  fetchPeerPayload: async (peer: any) => federationHits.find((hit) => hit.alias === peer.alias)?.payload ?? { sessions: [] },
+}));
+
+const { default: locateHandler } = await import("../../src/vendor/mpr-plugins/locate/index.ts?plugin-locate-standalone");
+const { cmdLocate } = await import("../../src/vendor/mpr-plugins/locate/impl.ts?plugin-locate-standalone");
+
+beforeEach(() => {
+  repoPath = join(tmpdir(), `maw-locate-${Date.now()}-${Math.random().toString(36).slice(2)}`, "mawjs-oracle");
+  rmSync(repoPath.replace(/\/mawjs-oracle$/, ""), { recursive: true, force: true });
+  mkdirSync(join(repoPath, "ψ"), { recursive: true });
+  psiExists = true;
+  sessions = [{ name: "139-mawjs", windows: [{ index: 1, name: "mawjs-oracle" }, { index: 2, name: "work" }] }];
+  fleetEntries = [{ file: "139-mawjs.json", path: "/fleet/139-mawjs.json", session: { name: "139-mawjs" }, groupName: "mawjs" }];
+  config = { node: "local-node", agents: { mawjs: "remote-node" } };
+  manifest = [{ name: "mawjs", localPath: repoPath, hasPsi: true, sources: ["registry"], node: "manifest-node" }];
+  federationHits = [{
+    alias: "white",
+    node: "white-node",
+    url: "http://white.local",
+    payload: { alias: "white", node: "white-node", url: "http://white.local", sessions: [{ name: "mawjs", windows: [{ name: "mawjs-oracle" }] }] },
+  }];
+});
+
+describe("locate plugin standalone boundary (#2113)", () => {
+  test("imports runtime dependencies through SDK plus plugin-local ls helpers", () => {
+    for (const rel of ["index.ts", "impl.ts"]) {
+      const source = readFileSync(join(root, "src/vendor/mpr-plugins/locate", rel), "utf8");
+      expect(source).not.toMatch(/maw-js\/(?:core|commands\/shared|cli|config|lib|plugin)(?:\/|")/);
+    }
+    const impl = readFileSync(join(root, "src/vendor/mpr-plugins/locate/impl.ts"), "utf8");
+    expect(impl).toContain('from "maw-js/sdk"');
+    expect(impl).toContain('from "../ls/internal/peer-call"');
+    expect(impl).toContain('from "../ls/internal/peer-resolve"');
+  });
+
+  test("handler renders locate summary from SDK data and peer helpers", async () => {
+    const result = await locateHandler({ source: "cli", args: ["mawjs"] } as any);
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("📍 mawjs");
+    expect(result.output).toContain(`repo:     ${repoPath}`);
+    expect(result.output).toContain("ψ/:       present");
+    expect(result.output).toContain("session:  139-mawjs (2 windows)");
+    expect(result.output).toContain("fleet:    /fleet/139-mawjs.json");
+    expect(result.output).toContain("node:     remote-node (from config.agents)");
+    expect(result.output).toContain("remote:   white-node:mawjs (http://white.local) (1 window)");
+  });
+
+  test("path and json modes stay shell/API friendly", async () => {
+    const pathResult = await locateHandler({ source: "cli", args: ["mawjs", "--path"] } as any);
+    expect(pathResult).toEqual({ ok: true, output: repoPath });
+
+    const jsonResult = await locateHandler({ source: "cli", args: ["mawjs", "--json"] } as any);
+    expect(jsonResult.ok).toBe(true);
+    expect(JSON.parse(jsonResult.output!)).toMatchObject({
+      name: "mawjs",
+      repoPath,
+      hasPsi: true,
+      sessionName: "139-mawjs",
+      windowCount: 2,
+    });
+  });
+
+  test("reports missing oracle and missing repo path through UserError messages", async () => {
+    repoPath = "";
+    sessions = [];
+    fleetEntries = [];
+    manifest = [];
+    federationHits = [];
+    const missing = await locateHandler({ source: "cli", args: ["ghost"] } as any);
+    expect(missing.ok).toBe(false);
+    expect(missing.error).toContain("no oracle named 'ghost'");
+
+    sessions = [{ name: "ghost", windows: [] }];
+    const noPathLogs: string[] = [];
+    const orig = console.log;
+    console.log = (...args: any[]) => noPathLogs.push(args.map(String).join(" "));
+    try {
+      await expect(cmdLocate("ghost", { path: true })).rejects.toThrow("no repo path for 'ghost'");
+    } finally {
+      console.log = orig;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add standalone boundary coverage for the locate plugin
- move locate runtime imports to maw-js/sdk
- export ghq helpers through the SDK for plugin use
- align existing locate coverage mocks with the SDK boundary

Contributes to #2113.

## Tests
- bun test test/isolated/plugin-locate-standalone.test.ts
- bun test test/isolated/locate-impl-coverage.test.ts

## Notes
- local post-commit dist build is blocked by missing deps arg/hono/elysia in this worktree