### PR TITLE
test: standalone coverage for archive plugin

### DIFF
--- a/src/vendor/mpr-plugins/archive/impl.ts
+++ b/src/vendor/mpr-plugins/archive/impl.ts
@@ -1,12 +1,13 @@
-import { hostExec } from "maw-js/sdk";
-import { getGhqRoot } from "maw-js/config/ghq-root";
-import { fleetDirForWrite, loadFleetEntries, type FleetEntry } from "maw-js/commands/shared/fleet-load";
+import {
+  fleetLoadDirForWrite, getGhqRoot, hostExec, loadFleetEntries,
+  type FleetEntry,
+} from "maw-js/sdk";
 import { cmdSoulSync } from "./internal/soul-sync-impl";
 import { join } from "path";
 import { renameSync } from "fs";
 
 export function fleetConfigFilePath(entry: Pick<FleetEntry, "file" | "path">): string {
-  return entry.path ?? join(fleetDirForWrite(), entry.file);
+  return entry.path ?? join(fleetLoadDirForWrite(), entry.file);
 }
 
 /**

--- a/src/vendor/mpr-plugins/archive/index.ts
+++ b/src/vendor/mpr-plugins/archive/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/sdk";
 import { cmdArchive } from "./impl";
 
 export const command = {

--- a/src/vendor/mpr-plugins/archive/internal/resolve.ts
+++ b/src/vendor/mpr-plugins/archive/internal/resolve.ts
@@ -1,8 +1,6 @@
 import { existsSync } from "fs";
 import { join } from "path";
-import { ghqFind } from "maw-js/core/ghq";
-import { getGhqRoot } from "maw-js/config/ghq-root";
-import { loadFleet } from "maw-js/commands/shared/fleet-load";
+import { ghqFind, getGhqRoot, loadFleetCore as loadFleet } from "maw-js/sdk";
 
 /**
  * Resolve ghq path for an oracle name.

--- a/src/vendor/mpr-plugins/archive/internal/soul-sync-impl.ts
+++ b/src/vendor/mpr-plugins/archive/internal/soul-sync-impl.ts
@@ -1,7 +1,6 @@
 import { existsSync } from "fs";
 import { join, basename } from "path";
-import { hostExec } from "maw-js/sdk";
-import { getGhqRoot } from "maw-js/config/ghq-root";
+import { getGhqRoot, hostExec } from "maw-js/sdk";
 import { findPeers, findProjectsForOracle, syncOracleVaults, syncProjectVault, reportProjectResult, type SoulSyncResult, type ProjectSyncResult } from "./sync-helpers";
 import { resolveOraclePath, resolveProjectSlug, findOracleForProject } from "./resolve";
 

--- a/src/vendor/mpr-plugins/archive/internal/sync-helpers.ts
+++ b/src/vendor/mpr-plugins/archive/internal/sync-helpers.ts
@@ -1,6 +1,6 @@
 import { existsSync, readdirSync, copyFileSync, mkdirSync, appendFileSync } from "fs";
 import { join } from "path";
-import { loadFleet } from "maw-js/commands/shared/fleet-load";
+import { loadFleetCore as loadFleet } from "maw-js/sdk";
 
 const SYNC_DIRS = ["memory/learnings", "memory/retrospectives", "memory/traces", "memory/collaborations"];
 

--- a/test/isolated/plugin-archive-standalone.test.ts
+++ b/test/isolated/plugin-archive-standalone.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "../..");
+let tempDir = "";
+let fleetDir = "";
+let ghqRoot = "";
+let hostExecCalls: string[] = [];
+let fleetEntries: Array<{
+  file: string;
+  path?: string;
+  num: number;
+  groupName: string;
+  session: { name: string; windows: Array<{ name: string; repo?: string }>; sync_peers?: string[]; project_repos?: string[] };
+}> = [];
+let fleetSessions: Array<{ name: string; windows: Array<{ name: string; repo?: string }>; sync_peers?: string[]; project_repos?: string[] }> = [];
+let ghqFindResult: string | null = null;
+
+const sdkMock = {
+  hostExec: async (cmd: string) => {
+    hostExecCalls.push(cmd);
+    return "";
+  },
+  getGhqRoot: () => ghqRoot,
+  fleetLoadDirForWrite: () => fleetDir,
+  loadFleetEntries: () => fleetEntries,
+  loadFleetCore: () => fleetSessions,
+  ghqFind: async () => ghqFindResult,
+};
+
+mock.module("maw-js/sdk", () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
+
+const { default: archiveHandler, command } = await import("../../src/vendor/mpr-plugins/archive/index.ts");
+const { resolveOraclePath, resolveProjectSlug } = await import("../../src/vendor/mpr-plugins/archive/internal/soul-sync-impl.ts");
+
+function walkSources(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walkSources(full));
+    else if (entry.name.endsWith(".ts")) out.push(full);
+  }
+  return out;
+}
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "maw-archive-standalone-"));
+  fleetDir = join(tempDir, "fleet");
+  ghqRoot = join(tempDir, "ghq");
+  mkdirSync(fleetDir, { recursive: true });
+  mkdirSync(join(ghqRoot, "github.com", "Soul-Brews-Studio", "neo-oracle"), { recursive: true });
+  hostExecCalls = [];
+  ghqFindResult = null;
+  fleetEntries = [{
+    file: "01-neo.json",
+    path: join(fleetDir, "01-neo.json"),
+    num: 1,
+    groupName: "neo",
+    session: {
+      name: "01-neo",
+      windows: [{ name: "neo-oracle", repo: "Soul-Brews-Studio/neo-oracle" }],
+      sync_peers: ["m5"],
+      project_repos: ["Soul-Brews-Studio/maw-js"],
+    },
+  }];
+  fleetSessions = fleetEntries.map((entry) => entry.session);
+  writeFileSync(join(fleetDir, "01-neo.json"), JSON.stringify(fleetEntries[0].session), "utf8");
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("archive plugin standalone boundary", () => {
+  test("imports runtime helpers only through the SDK boundary", () => {
+    const pluginDir = join(root, "src/vendor/mpr-plugins/archive");
+    const sources = walkSources(pluginDir).map((file) => readFileSync(file, "utf8")).join("\n");
+
+    expect(command).toMatchObject({ name: "archive" });
+    expect(sources).toContain('from "maw-js/sdk"');
+    expect(sources).not.toMatch(/maw-js\/(?:core|commands\/shared|cli|config|lib|plugin)(?:\/|")/);
+    expect(sources).not.toMatch(/from\s+["'](?:\.\.\/)+(?:core|commands|cli|config|lib|src)\//);
+  });
+
+  test("dry-run archives by reading fleet entries through SDK without side effects", async () => {
+    const result = await archiveHandler({ source: "cli", args: ["neo", "--dry-run"] } as any);
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("Archiving");
+    expect(result.output).toContain("[dry-run] would soul-sync to m5");
+    expect(result.output).toContain("[dry-run] would disable: 01-neo.json → 01-neo.json.disabled");
+    expect(result.output).toContain("[dry-run] would archive: gh repo archive Soul-Brews-Studio/neo-oracle");
+    expect(hostExecCalls).toEqual([]);
+    expect(existsSync(join(fleetDir, "01-neo.json"))).toBe(true);
+  });
+
+  test("non-dry archive disables fleet config and archives repo", async () => {
+    fleetEntries[0].session.sync_peers = [];
+
+    const result = await archiveHandler({ source: "cli", args: ["neo"] } as any);
+
+    expect(result.ok).toBe(true);
+    expect(hostExecCalls).toEqual(["gh repo archive Soul-Brews-Studio/neo-oracle --yes"]);
+    expect(existsSync(join(fleetDir, "01-neo.json"))).toBe(false);
+    expect(existsSync(join(fleetDir, "01-neo.json.disabled"))).toBe(true);
+    expect(result.output).toContain("fleet config disabled: 01-neo.json.disabled");
+    expect(result.output).toContain("GitHub repo archived: Soul-Brews-Studio/neo-oracle");
+  });
+
+  test("usage and missing fleet entries stay user-facing errors", async () => {
+    const usage = await archiveHandler({ source: "cli", args: [] } as any);
+    expect(usage.ok).toBe(false);
+    expect(usage.error).toContain("usage: maw archive <oracle> [--dry-run]");
+
+    const missing = await archiveHandler({ source: "cli", args: ["ghost"] } as any);
+    expect(missing.ok).toBe(false);
+    expect(missing.error).toContain("oracle 'ghost' not found in fleet config");
+  });
+
+  test("soul-sync resolution helpers use SDK ghq, ghq root, and fleet loaders", async () => {
+    ghqFindResult = join(ghqRoot, "github.com", "Soul-Brews-Studio", "neo-oracle");
+    await expect(resolveOraclePath("neo")).resolves.toBe(ghqFindResult);
+
+    ghqFindResult = null;
+    await expect(resolveOraclePath("neo-oracle")).resolves.toBe(join(ghqRoot, "github.com", "Soul-Brews-Studio", "neo-oracle"));
+
+    expect(resolveProjectSlug(join(ghqRoot, "github.com", "Soul-Brews-Studio", "maw-js", "agents", "1-codex"), ghqRoot)).toBe("Soul-Brews-Studio/maw-js");
+  });
+});


### PR DESCRIPTION
Closes #2219.

Summary:
- move archive plugin private core/config/shared imports to maw-js/sdk
- add isolated standalone coverage for archive dry-run, non-dry fleet disable, user-facing errors, and soul-sync resolution helpers
- assert archive sources have no private core/shared/config/plugin imports

Verification:
- bun build test/isolated/plugin-archive-standalone.test.ts --outfile /tmp/plugin-archive-standalone.js --target=bun --external maw-js/sdk
- rg private import boundary check
- git diff --check
- bun run build
- bun test test/isolated/plugin-archive-standalone.test.ts (5 pass)