### PR TITLE
test: lock oracle-skills standalone boundary

### DIFF
--- a/src/vendor/mpr-plugins/oracle-skills/index.ts
+++ b/src/vendor/mpr-plugins/oracle-skills/index.ts
@@ -9,7 +9,7 @@
  * upstream CLI owns help text, verb routing, and output formatting.
  */
 
-import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import type { InvokeContext, InvokeResult } from "@maw-js/sdk/plugin";
 
 export const command = {
   name: "oracle-skills",
@@ -17,17 +17,17 @@ export const command = {
     "Pass through to arra-oracle-skills to manage Oracle skills across AI coding agents.",
 };
 
-export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
-  const args: string[] = ctx.source === "cli" ? (ctx.args as string[]) : [];
+export type OracleSkillsSpawn = typeof Bun.spawnSync;
 
+export function runOracleSkills(args: string[], spawn: OracleSkillsSpawn = Bun.spawnSync): InvokeResult {
   let proc: ReturnType<typeof Bun.spawnSync>;
   try {
-    proc = Bun.spawnSync(["arra-oracle-skills", ...args], {
+    proc = spawn(["arra-oracle-skills", ...args], {
       stdout: "inherit",
       stderr: "inherit",
       stdin: "inherit",
     });
-  } catch (e: any) {
+  } catch (_e: any) {
     return {
       ok: false,
       error:
@@ -46,4 +46,9 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     error: `arra-oracle-skills exited with code ${proc.exitCode}`,
     output: "",
   };
+}
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const args: string[] = ctx.source === "cli" ? (ctx.args as string[]) : [];
+  return runOracleSkills(args);
 }

--- a/test/isolated/plugin-oracle-skills-standalone.test.ts
+++ b/test/isolated/plugin-oracle-skills-standalone.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const root = join(import.meta.dir, "../..");
+let spawnCalls: unknown[][] = [];
+let spawnImpl: (...args: unknown[]) => { exitCode: number } = () => ({ exitCode: 0 });
+
+const { command, runOracleSkills } = await import("../../src/vendor/mpr-plugins/oracle-skills/index.ts?plugin-oracle-skills-standalone");
+
+beforeEach(() => {
+  spawnCalls = [];
+  spawnImpl = () => ({ exitCode: 0 });
+});
+
+describe("oracle-skills plugin standalone boundary (#2113)", () => {
+  test("uses SDK plugin types and no maw private imports", () => {
+    const source = readFileSync(join(root, "src/vendor/mpr-plugins/oracle-skills/index.ts"), "utf8");
+
+    expect(source).toContain('from "@maw-js/sdk/plugin"');
+    expect(source).not.toMatch(/maw-js\/(?:core|commands\/shared|cli|config|lib|plugin)(?:\/|")/);
+    expect(source).not.toMatch(/from\s+["'](?:\.\.\/)+/);
+  });
+
+  test("exports command metadata", () => {
+    expect(command).toMatchObject({
+      name: "oracle-skills",
+      description: expect.stringContaining("arra-oracle-skills"),
+    });
+  });
+
+  test("passes CLI args through to arra-oracle-skills with inherited stdio", async () => {
+    const result = runOracleSkills(["go", "list", "--json"], ((...args: unknown[]) => {
+      spawnCalls.push(args);
+      return spawnImpl(...args);
+    }) as typeof Bun.spawnSync);
+
+    expect(result).toEqual({ ok: true, output: "" });
+    expect(spawnCalls).toEqual([
+      [["arra-oracle-skills", "go", "list", "--json"], { stdout: "inherit", stderr: "inherit", stdin: "inherit" }],
+    ]);
+  });
+
+  test("surfaces missing binary and non-zero exit as InvokeResult failures", async () => {
+    spawnImpl = () => {
+      throw new Error("ENOENT");
+    };
+    expect(runOracleSkills([], ((...args: unknown[]) => {
+      spawnCalls.push(args);
+      return spawnImpl(...args);
+    }) as typeof Bun.spawnSync)).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("arra-oracle-skills not found"),
+      output: "",
+    });
+
+    spawnImpl = () => ({ exitCode: 42 });
+    expect(runOracleSkills([], ((...args: unknown[]) => {
+      spawnCalls.push(args);
+      return spawnImpl(...args);
+    }) as typeof Bun.spawnSync)).toEqual({
+      ok: false,
+      error: "arra-oracle-skills exited with code 42",
+      output: "",
+    });
+  });
+});
+


### PR DESCRIPTION
Closes #2282.\n\n## Summary\n- move oracle-skills type import to @maw-js/sdk/plugin\n- add a tiny runOracleSkills spawn seam for testing without invoking the external CLI\n- add isolated standalone coverage for metadata, pass-through args, missing binary, and non-zero exit handling\n\n## Verification\n- bun test test/isolated/plugin-oracle-skills-standalone.test.ts\n\n## Notes\n- no version bump\n- local post-commit build hook cannot run in this temp worktree because dependencies are not installed (missing arg/hono/elysia), but the targeted test passes after rebasing onto latest alpha.