### PR TITLE
test: standalone coverage for pulse plugin

### DIFF
--- a/packages/sdk/index.d.ts
+++ b/packages/sdk/index.d.ts
@@ -658,3 +658,8 @@ export declare function scanSignals(root: string, opts?: { days?: number }): Sca
 
 export declare function fetchIssuePrompt(num: number, repo?: string): Promise<string>;
 export declare function cmdWake(oracle: string, opts: Record<string, unknown>): Promise<string>;
+
+// --- src/commands/shared/pulse ---
+
+export declare function cmdPulseAdd(title: string, opts: { oracle?: string; priority?: string; wt?: string }): Promise<void>;
+export declare function cmdPulseLs(opts?: { sync?: boolean }): Promise<void>;

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -51,6 +51,7 @@ export type {
 // kill, capture, panes, split, contacts, tag, locate.
 // NOTE: also re-exported from "@maw-js/sdk/plugin" for ergonomics — both work.
 export { parseFlags } from "../../src/cli/parse-args";
+export { cmdPulseAdd, cmdPulseLs } from "../../src/commands/shared/pulse";
 export { UserError, isUserError } from "../../src/core/util/user-error";
 export { sparkline } from "../../src/lib/sparkline";
 

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -111,6 +111,7 @@ export {
   loadFleetEntries,
 } from "../core/fleet/fleet-load-core";
 export { cmdSleep } from "../commands/shared/fleet-wake";
+export { cmdPulseAdd, cmdPulseLs } from "../commands/shared/pulse";
 export { cmdWake, fetchIssuePrompt, findWorktrees, detectSession } from "../commands/shared/wake";
 export type {
   FleetWindow, FleetSession, FleetEntry, DisabledFleetEntry,

--- a/src/vendor/mpr-plugins/pulse/index.ts
+++ b/src/vendor/mpr-plugins/pulse/index.ts
@@ -1,5 +1,4 @@
-import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
-import { parseFlags } from "maw-js/cli/parse-args";
+import { parseFlags, type InvokeContext, type InvokeResult } from "maw-js/sdk";
 
 export const command = {
   name: "pulse",
@@ -42,14 +41,14 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
           error: 'usage: maw pulse add "task title" --oracle <name> [--wt <repo>]',
         };
       }
-      const { cmdPulseAdd } = await import("maw-js/commands/shared/pulse");
+      const { cmdPulseAdd } = await import("maw-js/sdk");
       await cmdPulseAdd(title, pulseOpts);
     } else if (subcmd === "ls" || subcmd === "list") {
       const sync = args.includes("--sync");
-      const { cmdPulseLs } = await import("maw-js/commands/shared/pulse");
+      const { cmdPulseLs } = await import("maw-js/sdk");
       await cmdPulseLs({ sync });
     } else if (subcmd === "cleanup" || subcmd === "clean") {
-      const { scanWorktrees, cleanupWorktree } = await import("maw-js/worktrees");
+      const { scanWorktrees, cleanupWorktree } = await import("maw-js/sdk");
       const worktrees = await scanWorktrees();
       const stale = worktrees.filter(wt => wt.status !== "active");
       if (!stale.length) {

--- a/test/isolated/plugin-pulse-standalone.test.ts
+++ b/test/isolated/plugin-pulse-standalone.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { loadManifestFromDir } from "../../src/plugin/manifest-load";
+import { invokePlugin } from "../../src/plugin/registry-invoke";
+import type { LoadedPlugin } from "../../src/plugin/types";
+
+const ROOT = new URL("../..", import.meta.url).pathname;
+const pluginDir = join(ROOT, "src/vendor/mpr-plugins/pulse");
+
+let calls: Array<[string, ...unknown[]]> = [];
+let worktrees: Array<{ status: string; name: string; mainRepo: string; branch: string; path: string }> = [];
+
+function parseFlags(args: string[], spec: Record<string, unknown>) {
+  const out: Record<string, any> = { _: [] };
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i]!;
+    const alias = spec[arg];
+    if (alias && typeof alias === "string" && alias.startsWith("--")) {
+      out[alias] = args[i + 1];
+      i += 1;
+    } else if (arg.startsWith("--")) {
+      out[arg] = args[i + 1];
+      i += 1;
+    } else {
+      out._.push(arg);
+    }
+  }
+  return out;
+}
+
+const sdkMock = {
+  parseFlags,
+  cmdPulseAdd: async (title: string, opts: unknown) => calls.push(["add", title, opts]),
+  cmdPulseLs: async (opts: unknown) => calls.push(["ls", opts]),
+  scanWorktrees: async () => worktrees,
+  cleanupWorktree: async (path: string) => {
+    calls.push(["cleanup", path]);
+    return [`removed ${path}`];
+  },
+};
+
+mock.module("maw-js/sdk", () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
+
+function walkSources(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "dist" || entry.name.startsWith(".")) continue;
+      out.push(...walkSources(full));
+    } else if (entry.name.endsWith(".ts") || entry.name.endsWith(".js")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function parseImportSpecs(source: string): string[] {
+  const specs = new Set<string>();
+  const importFrom = /\b(?:import|export)\s+(?:[^"'`]+?\s+from\s+)?["']([^"']+)["']/g;
+  const importFn = /\bimport\(\s*["']([^"']+)["']\s*\)/g;
+  const requireFn = /\brequire\(\s*["']([^"']+)["']\s*\)/g;
+
+  for (const re of [importFrom, importFn, requireFn]) {
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(source)) !== null) specs.add(m[1]);
+  }
+
+  return [...specs];
+}
+
+function loadPulsePlugin(): LoadedPlugin {
+  const loaded = loadManifestFromDir(pluginDir);
+  expect(loaded).not.toBeNull();
+  return loaded as LoadedPlugin;
+}
+
+beforeEach(() => {
+  calls = [];
+  worktrees = [];
+});
+
+describe("pulse plugin standalone boundary (#2283)", () => {
+  test("imports runtime dependencies only through the SDK boundary", () => {
+    const imports = walkSources(pluginDir).flatMap((file) => parseImportSpecs(readFileSync(file, "utf8")));
+
+    const disallowed = imports.filter((spec) => {
+      if (spec.startsWith(".")) return false;
+      return spec !== "maw-js/sdk";
+    });
+
+    expect(disallowed).toEqual([]);
+    expect(imports).toContain("maw-js/sdk");
+  });
+
+  test("plugin loads and missing subcommand returns InvokeResult error", async () => {
+    const plugin = loadPulsePlugin();
+
+    const result = await invokePlugin(plugin, { source: "cli", args: [] });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("usage: maw pulse <add|ls|cleanup>");
+  });
+
+  test("CLI add and ls delegate through SDK helpers", async () => {
+    const plugin = loadPulsePlugin();
+
+    await expect(invokePlugin(plugin, {
+      source: "cli",
+      args: ["add", "ship", "--oracle", "neo", "--priority", "p1", "--worktree", "maw-js"],
+    })).resolves.toMatchObject({ ok: true });
+    await expect(invokePlugin(plugin, { source: "cli", args: ["ls", "--sync"] })).resolves.toMatchObject({ ok: true });
+
+    expect(calls).toEqual([
+      ["add", "ship", { oracle: "neo", priority: "p1", wt: "maw-js" }],
+      ["ls", { sync: true }],
+    ]);
+  });
+
+  test("CLI cleanup uses SDK worktree helpers and supports dry-run", async () => {
+    const plugin = loadPulsePlugin();
+    worktrees = [
+      { status: "active", name: "main", mainRepo: "maw-js", branch: "alpha", path: "/tmp/main" },
+      { status: "stale", name: "old", mainRepo: "maw-js", branch: "old", path: "/tmp/old" },
+    ];
+
+    const dryRun = await invokePlugin(plugin, { source: "cli", args: ["cleanup", "--dry-run"] });
+    expect(dryRun).toMatchObject({ ok: true });
+    expect(calls).toEqual([]);
+
+    const clean = await invokePlugin(plugin, { source: "cli", args: ["cleanup"] });
+    expect(clean).toMatchObject({ ok: true });
+    expect(calls).toEqual([["cleanup", "/tmp/old"]]);
+  });
+});


### PR DESCRIPTION
Closes #2283.

Adds isolated standalone coverage for pulse and moves runtime helper imports behind the SDK boundary.

Validation:
- bash scripts/test-isolated.sh test/isolated/plugin-pulse-standalone.test.ts