### PR TITLE
test: standalone coverage for scope plugin

### DIFF
--- a/packages/sdk/index.d.ts
+++ b/packages/sdk/index.d.ts
@@ -386,6 +386,15 @@ export declare function tlink(url: string, text?: string): string;
 // --- src/lib/profile-loader ---
 
 /** Profile shape (mirrors src/lib/schemas.ts Profile/TProfile). */
+
+export interface TScope {
+  name: string;
+  members: string[];
+  created: string;
+  ttl: string | null;
+  lead?: string;
+}
+
 export interface TProfile {
   name: string;
   plugins?: string[];

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -163,7 +163,7 @@ export {
 
 // ─── src/lib/schemas ─────────────────────────────────────────────────────────
 // Profile shape (TypeBox-derived). Used by `profile` plugin.
-export type { TProfile } from "../../src/lib/schemas";
+export type { TProfile, TScope } from "../../src/lib/schemas";
 
 // ─── src/plugin/registry ─────────────────────────────────────────────────────
 // Runtime bridge for cross-plugin helper reuse. A plugin must opt in via

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -26,8 +26,10 @@ export {
 } from "../config";
 export { DEFAULT_ENGINES, resolveEngine } from "../config/engine-registry";
 export { getGhqRoot } from "../config/ghq-root";
+export { mawConfigDir } from "../core/xdg";
 export type { EngineDef } from "../config/engine-def";
 export type { EngineRegistry } from "../config/engine-registry";
+export type { TScope } from "../lib/schemas";
 export type { MawConfig } from "../config";
 
 // ─── Consent ────────────────────────────────────────────────────────────────

--- a/src/vendor/mpr-plugins/scope/impl.ts
+++ b/src/vendor/mpr-plugins/scope/impl.ts
@@ -21,8 +21,7 @@
  */
 import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, unlinkSync, writeFileSync } from "fs";
 import { join } from "path";
-import { mawConfigDir } from "../../../core/xdg";
-import type { TScope } from "maw-js/lib/schemas";
+import { mawConfigDir, type TScope } from "maw-js/sdk";
 
 // Scope name validation — same alphabet as peers aliases. Slug-safe so the
 // name can double as a filename without escaping.

--- a/src/vendor/mpr-plugins/scope/index.ts
+++ b/src/vendor/mpr-plugins/scope/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/sdk";
 
 export const command = {
   name: "scope",

--- a/test/isolated/plugin-scope-standalone.test.ts
+++ b/test/isolated/plugin-scope-standalone.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { loadManifestFromDir } from "../../src/plugin/manifest-load";
+import { invokePlugin } from "../../src/plugin/registry-invoke";
+import type { LoadedPlugin } from "../../src/plugin/types";
+
+const ROOT = new URL("../..", import.meta.url).pathname;
+const pluginDir = join(ROOT, "src/vendor/mpr-plugins/scope");
+let configDir = "";
+
+mock.module("maw-js/sdk", () => ({
+  mawConfigDir: () => configDir,
+}));
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => ({
+  mawConfigDir: () => configDir,
+}));
+
+function walkSources(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "dist" || entry.name.startsWith(".")) continue;
+      out.push(...walkSources(full));
+    } else if (entry.name.endsWith(".ts") || entry.name.endsWith(".js")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function parseImportSpecs(source: string): string[] {
+  const specs = new Set<string>();
+  const importFrom = /\b(?:import|export)\s+(?:[^"'`]+?\s+from\s+)?["']([^"']+)["']/g;
+  const importFn = /\bimport\(\s*["']([^"']+)["']\s*\)/g;
+  const requireFn = /\brequire\(\s*["']([^"']+)["']\s*\)/g;
+
+  for (const re of [importFrom, importFn, requireFn]) {
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(source)) !== null) specs.add(m[1]);
+  }
+
+  return [...specs];
+}
+
+function stripAnsi(value: string | undefined) {
+  return String(value ?? "").replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "");
+}
+
+function loadScopePlugin(): LoadedPlugin {
+  const loaded = loadManifestFromDir(pluginDir);
+  expect(loaded).not.toBeNull();
+  return loaded as LoadedPlugin;
+}
+
+beforeEach(() => {
+  if (configDir) rmSync(configDir, { recursive: true, force: true });
+  configDir = mkdtempSync(join(tmpdir(), "maw-scope-standalone-"));
+});
+
+describe("scope plugin standalone boundary", () => {
+  test("imports runtime dependencies only through the SDK boundary", () => {
+    const imports = walkSources(pluginDir).flatMap((file) => parseImportSpecs(readFileSync(file, "utf8")));
+
+    const disallowed = imports.filter((spec) => {
+      if (spec.startsWith(".")) return false;
+      if (["fs", "path"].includes(spec)) return false;
+      return spec !== "maw-js/sdk";
+    });
+
+    expect(disallowed).toEqual([]);
+    expect(imports).toContain("maw-js/sdk");
+  });
+
+  test("plugin loads and help returns InvokeResult", async () => {
+    const plugin = loadScopePlugin();
+
+    const result = await invokePlugin(plugin, { source: "cli", args: [] });
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("usage: maw scope");
+  });
+
+  test("create, list, show, and delete run with only SDK path mocked", async () => {
+    const plugin = loadScopePlugin();
+
+    const out: string[] = [];
+    const writer = (...args: unknown[]) => out.push(args.map(String).join(" "));
+
+    const created = await invokePlugin(plugin, {
+      source: "cli",
+      args: ["create", "alpha", "--members", "neo,trinity", "--lead", "neo", "--ttl", "2026-06-08T00:00:00.000Z"],
+      writer,
+    });
+    expect(created.ok).toBe(true);
+    expect(stripAnsi(`${created.output ?? ""}\n${out.join("\n")}`)).toContain('created scope "alpha"');
+
+    out.length = 0;
+    const listed = await invokePlugin(plugin, { source: "cli", args: ["list"], writer });
+    expect(listed.ok).toBe(true);
+    const listOutput = stripAnsi(`${listed.output ?? ""}\n${out.join("\n")}`);
+    expect(listOutput).toContain("alpha");
+    expect(listOutput).toContain("neo,trinity");
+
+    out.length = 0;
+    const shown = await invokePlugin(plugin, { source: "cli", args: ["show", "alpha"], writer });
+    expect(shown.ok).toBe(true);
+    const parsed = JSON.parse(out.join("\n") || String(shown.output));
+    expect(parsed).toMatchObject({
+      name: "alpha",
+      members: ["neo", "trinity"],
+      lead: "neo",
+      ttl: "2026-06-08T00:00:00.000Z",
+    });
+
+    const refused = await invokePlugin(plugin, { source: "cli", args: ["delete", "alpha"], writer });
+    expect(refused.ok).toBe(false);
+    expect(refused.error).toContain("delete requires --yes");
+
+    out.length = 0;
+    const deleted = await invokePlugin(plugin, { source: "cli", args: ["delete", "alpha", "--yes"], writer });
+    expect(deleted.ok).toBe(true);
+    expect(stripAnsi(`${deleted.output ?? ""}\n${out.join("\n")}`)).toContain('deleted scope "alpha"');
+  });
+});


### PR DESCRIPTION
Adds isolated standalone coverage for scope and moves its runtime/type imports behind the SDK boundary.

Validation:
- bash scripts/test-isolated.sh test/isolated/plugin-scope-standalone.test.ts