### PR TITLE
release: v26.6.8-alpha.120

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.6.8-alpha.116",
+  "version": "26.6.8-alpha.120",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
## Release

Bumps to v26.6.8-alpha.120.

36+ PRs merged since v26.6.8-alpha.31:
- 25+ plugin standalone tests
- SDK exports (multiple batches)
- Test stabilizations
- zenoh-scout untangle
- maw forget command
- snapshot rotation
- memory leak bounded

Cut from oracle (codex-4 was overloaded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)