### PR TITLE
test: align absorb and dream coverage mocks

### DIFF
--- a/test/isolated/absorb-coverage.test.ts
+++ b/test/isolated/absorb-coverage.test.ts
@@ -6,6 +6,7 @@ import { join } from "path";
 const tmpRoot = mkdtempSync(join(tmpdir(), "maw-absorb-coverage-"));
 const fleetDir = join(tmpRoot, "fleet");
 const archiveSoulSyncPath = import.meta.resolve("../../src/vendor/mpr-plugins/archive/internal/soul-sync-impl.ts");
+const sdkPath = import.meta.resolve("../../src/sdk/index.ts");
 
 let ghqRoot = join(tmpRoot, "ghq");
 let fleetEntries: any[] = [];
@@ -22,7 +23,7 @@ const originalLog = console.log;
 const originalError = console.error;
 const originalTmux = process.env.TMUX;
 
-mock.module("maw-js/sdk", () => ({
+const sdkMock = () => ({
   FLEET_DIR: fleetDir,
   hostExec: async (cmd: string) => {
     hostExecCalls.push(cmd);
@@ -31,7 +32,18 @@ mock.module("maw-js/sdk", () => ({
     }
     return "";
   },
-}));
+  getGhqRoot: () => ghqRoot,
+  ghqFind: async (pattern: string) => {
+    ghqFindCalls.push(pattern);
+    return ghqFindResults.get(pattern) ?? null;
+  },
+  fleetLoadDirForWrite: () => fleetDir,
+  loadFleetEntries: () => fleetEntries,
+  loadFleetCore: () => fleetEntries.map(entry => entry.session),
+});
+
+mock.module("maw-js/sdk", sdkMock);
+mock.module(sdkPath, sdkMock);
 
 mock.module("maw-js/config/ghq-root", () => ({
   getGhqRoot: () => ghqRoot,

--- a/test/isolated/dream-impl-fifth-pass-coverage.test.ts
+++ b/test/isolated/dream-impl-fifth-pass-coverage.test.ts
@@ -18,10 +18,25 @@ const original = {
   fetch: globalThis.fetch,
   dateNow: Date.now,
 };
+const sdkPath = import.meta.resolve("../../src/sdk/index.ts");
 
-mock.module("maw-js/sdk", () => ({
+const sdkMock = () => ({
   hostExec: async (cmd: string) => fakeHostExec(cmd),
-}));
+  getGhqRoot: () => ghqRoot,
+  loadFleetCore: () => [
+    {
+      name: "maze-session",
+      windows: [{ name: "main", repo: "Soul-Brews-Studio/maze-oracle" }],
+    },
+    {
+      name: "quiet-session",
+      windows: [{ name: "quiet", repo: "Soul-Brews-Studio/quiet-oracle" }],
+    },
+  ],
+});
+
+mock.module("maw-js/sdk", sdkMock);
+mock.module(sdkPath, sdkMock);
 
 mock.module("maw-js/config/ghq-root", () => ({
   getGhqRoot: () => ghqRoot,

--- a/test/isolated/dream-impl-more-coverage.test.ts
+++ b/test/isolated/dream-impl-more-coverage.test.ts
@@ -17,10 +17,24 @@ const original = {
   fetch: globalThis.fetch,
   dateNow: Date.now,
 };
+const sdkPath = import.meta.resolve("../../src/sdk/index.ts");
 
-mock.module("maw-js/sdk", () => ({
+const sdkMock = () => ({
   hostExec: async (cmd: string) => fakeHostExec(cmd),
-}));
+  getGhqRoot: () => ghqRoot,
+  loadFleetCore: () => [
+    {
+      name: "dream-more-session",
+      windows: [
+        { name: "focus", repo: "Soul-Brews-Studio/focus-oracle" },
+        { name: "duplicate-focus", repo: "Soul-Brews-Studio/focus-oracle" },
+      ],
+    },
+  ],
+});
+
+mock.module("maw-js/sdk", sdkMock);
+mock.module(sdkPath, sdkMock);
 
 mock.module("maw-js/config/ghq-root", () => ({
   getGhqRoot: () => ghqRoot,


### PR DESCRIPTION
Summary:
- align absorb coverage mocks with current SDK fleet/ghq exports used by archive/standalone paths
- align dream fifth-pass and more coverage mocks with current SDK getGhqRoot/loadFleetCore imports
- keep behavior unchanged; only stale test seams updated

Verification:
- bun test test/isolated/dream-impl-fifth-pass-coverage.test.ts (3 pass)
- bun test test/isolated/dream-impl-more-coverage.test.ts (4 pass)
- bun test test/isolated/absorb-coverage.test.ts (11 pass)
- git diff --check
- bun run build