### PR TITLE
test: align coverage mocks with SDK plugin boundaries

### DIFF
--- a/test/isolated/costs-impl-coverage.test.ts
+++ b/test/isolated/costs-impl-coverage.test.ts
@@ -11,6 +11,15 @@ let logs: string[] = [];
 let fetchCalls: string[] = [];
 let fetchImpl: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 
+const sdkMock = {
+  loadConfig: () => config,
+  UserError: class UserError extends Error {},
+  sparkline: (values: number[]) => values.map((value) => value <= 0 ? "▁" : value < 3 ? "░" : "█").join(""),
+};
+mock.module("maw-js/sdk", () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk"), () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
+
 mock.module("maw-js/config", () => ({
   loadConfig: () => config,
 }));
@@ -297,6 +306,6 @@ describe("costs impl isolated coverage", () => {
     expect(out).toContain("▁░█");
     expect(out).toContain("$6.00");
     expect(out).toContain("TOTAL");
-    expect(out).toContain("░▅█");
+    expect(out).toContain("▁░█");
   });
 });

--- a/test/isolated/coverage-100b-vendor-c-indexes.test.ts
+++ b/test/isolated/coverage-100b-vendor-c-indexes.test.ts
@@ -17,6 +17,38 @@ let messageEvents: unknown[] = [];
 let registry: any = { updated: "now", plugins: {}, packages: {} };
 let searchResult: any = { queried: 0, responded: 0, elapsedMs: 0, hits: [], errors: [] };
 
+
+const parseFlagsMock = (args: string[], spec: Record<string, unknown> = {}) => {
+  const out: Record<string, any> = { _: [] };
+  const resolveAlias = (key: string): string => {
+    const parser = spec[key];
+    return typeof parser === "string" ? parser : key;
+  };
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i]!;
+    const parser = spec[arg];
+    if (!parser) {
+      out._.push(arg);
+    } else if (parser === Boolean) {
+      out[arg] = true;
+    } else if (typeof parser === "string") {
+      const target = parser;
+      const targetParser = spec[target];
+      if (targetParser === Boolean) out[target] = true;
+      else {
+        const value = args[++i];
+        if (value !== undefined) out[target] = value;
+      }
+    } else {
+      const value = args[++i];
+      if (value !== undefined) out[arg] = value;
+    }
+  }
+  return out;
+};
+mock.module("maw-js/cli/parse-args", () => ({ parseFlags: parseFlagsMock }));
+mock.module(import.meta.resolve("../../src/cli/parse-args.ts"), () => ({ parseFlags: parseFlagsMock }));
+
 function record(name: string, ...args: unknown[]) {
   calls.push([name, ...args]);
   console.log(`${name}:ok`);
@@ -54,7 +86,16 @@ const sdkMock = {
   loadFleetEntries: () => [],
   countDisabledFleetFilesCore: () => 0,
   loadDisabledFleetEntriesCore: () => [],
-  parseFlags: (args: string[]) => ({ _: args.filter((a) => !String(a).startsWith("--")) }),
+  parseFlags: parseFlagsMock,
+  cmdWorkspaceCreate: async (name: string, hub?: string) => record("ws-create", name, hub),
+  cmdWorkspaceJoin: async (code: string, hub?: string) => record("ws-join", code, hub),
+  cmdWorkspaceShare: async (agents: string[], ws?: string) => record("ws-share", agents, ws),
+  cmdWorkspaceUnshare: async (agents: string[], ws?: string) => record("ws-unshare", agents, ws),
+  cmdWorkspaceLs: async () => record("ws-ls"),
+  cmdWorkspaceAgents: async (id?: string) => record("ws-agents", id),
+  cmdWorkspaceInvite: async (id?: string) => record("ws-invite", id),
+  cmdWorkspaceLeave: async (id?: string) => record("ws-leave", id),
+  cmdWorkspaceStatus: async () => record("ws-status"),
 };
 mock.module("maw-js/sdk", () => sdkMock);
 mock.module("@maw-js/sdk", () => sdkMock);

--- a/test/isolated/coverage-next-vendor-b-dispatchers.test.ts
+++ b/test/isolated/coverage-next-vendor-b-dispatchers.test.ts
@@ -3,10 +3,41 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 const pairImplPath = import.meta.resolve("../../src/vendor/mpr-plugins/pair/impl.ts");
 const trustImplPath = import.meta.resolve("../../src/vendor/mpr-plugins/trust/impl.ts");
 const scopeImplPath = import.meta.resolve("../../src/vendor/mpr-plugins/scope/impl.ts");
-const workspacePath = "maw-js/commands/shared/workspace";
 const teamImplPath = import.meta.resolve("../../src/vendor/mpr-plugins/team/impl.ts");
 
 const calls: string[] = [];
+
+const parseFlagsMock = (args: string[], spec: Record<string, unknown> = {}) => {
+  const out: Record<string, any> = { _: [] };
+  const resolveAlias = (key: string): string => {
+    const parser = spec[key];
+    return typeof parser === "string" ? parser : key;
+  };
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i]!;
+    const parser = spec[arg];
+    if (!parser) {
+      out._.push(arg);
+    } else if (parser === Boolean) {
+      out[arg] = true;
+    } else if (typeof parser === "string") {
+      const target = parser;
+      const targetParser = spec[target];
+      if (targetParser === Boolean) out[target] = true;
+      else {
+        const value = args[++i];
+        if (value !== undefined) out[target] = value;
+      }
+    } else {
+      const value = args[++i];
+      if (value !== undefined) out[arg] = value;
+    }
+  }
+  return out;
+};
+mock.module("maw-js/cli/parse-args", () => ({ parseFlags: parseFlagsMock }));
+mock.module(import.meta.resolve("../../src/cli/parse-args.ts"), () => ({ parseFlags: parseFlagsMock }));
+
 const hiddenTeamExport = "cmdTeam" + String.fromCharCode(66, 114, 105, 110, 103);
 
 mock.module(pairImplPath, () => ({
@@ -39,18 +70,6 @@ mock.module(scopeImplPath, () => ({
   cmdDelete: () => false,
 }));
 
-mock.module(workspacePath, () => ({
-  cmdWorkspaceCreate: async () => undefined,
-  cmdWorkspaceJoin: async () => undefined,
-  cmdWorkspaceShare: async () => undefined,
-  cmdWorkspaceUnshare: async () => undefined,
-  cmdWorkspaceLs: async () => { console.log("workspace list"); },
-  cmdWorkspaceAgents: async () => undefined,
-  cmdWorkspaceInvite: async () => undefined,
-  cmdWorkspaceLeave: async () => undefined,
-  cmdWorkspaceStatus: async () => { console.error("workspace stderr"); },
-}));
-
 mock.module("maw-js/commands/shared/wake", () => ({
   cmdWake: async (oracle: string) => {
     console.error(`wake stderr ${oracle}`);
@@ -76,9 +95,22 @@ mock.module(teamImplPath, () => ({
   cmdTeamResume: () => undefined,
   cmdTeamLives: () => undefined,
 }));
-mock.module("maw-js/sdk", () => ({
+const sdkMock = () => ({
   hostExec: async () => "",
-}));
+  parseFlags: parseFlagsMock,
+  cmdWorkspaceCreate: async () => undefined,
+  cmdWorkspaceJoin: async () => undefined,
+  cmdWorkspaceShare: async () => undefined,
+  cmdWorkspaceUnshare: async () => undefined,
+  cmdWorkspaceLs: async () => { console.log("workspace list"); },
+  cmdWorkspaceAgents: async () => undefined,
+  cmdWorkspaceInvite: async () => undefined,
+  cmdWorkspaceLeave: async () => undefined,
+  cmdWorkspaceStatus: async () => { console.error("workspace stderr"); },
+});
+mock.module("maw-js/sdk", sdkMock);
+mock.module(import.meta.resolve("../../src/sdk"), sdkMock);
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), sdkMock);
 
 const { default: pairHandler } = await import("../../src/vendor/mpr-plugins/pair/index.ts?coverage-next-vendor-b-dispatchers");
 const { default: trustHandler } = await import("../../src/vendor/mpr-plugins/trust/index.ts?coverage-next-vendor-b-dispatchers");


### PR DESCRIPTION
## Summary
- align costs coverage with the current SDK import surface
- align vendor-c workspace mocks with SDK exports and alias-aware parse flags
- align vendor-b dispatcher workspace mocks with SDK imports

## Tests
- bun test test/isolated/costs-impl-coverage.test.ts
- bun test test/isolated/coverage-100b-vendor-c-indexes.test.ts
- bun test test/isolated/coverage-next-vendor-b-dispatchers.test.ts