### PR TITLE
test(attach): lock standalone boundary

### DIFF
--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -64,7 +64,8 @@ export {
 } from "../core/transport/peers";
 export { resolveTarget } from "../core/routing";
 export type { ResolveResult } from "../core/routing";
-export { resolveSessionTarget, resolveWorktreeTarget } from "../core/matcher/resolve-target";
+export { resolveSessionTarget, resolveWorktreeTarget, resolveFleetWindowSessionTarget } from "../core/matcher/resolve-target";
+export { isInfrastructureChannelSessionName } from "../core/matcher/channel-session";
 export { resolveOracle, pickOracle } from "../core/resolve";
 export type {
   OracleRef,

--- a/src/vendor/mpr-plugins/attach/impl.ts
+++ b/src/vendor/mpr-plugins/attach/impl.ts
@@ -10,12 +10,9 @@
  *   - implicit bounded federation precheck after local misses, before wake/scan (#1878)
  * Both hand off to attach-ssh.
  */
-import { listSessions } from "maw-js/sdk";
-import { loadFleet } from "maw-js/commands/shared/fleet-load";
-import { getGhqRoot } from "maw-js/config/ghq-root";
+import { getGhqRoot, listSessions, loadFleetCore as loadFleet, UserError } from "maw-js/sdk";
 import { cmdTmuxAttach } from "../../../commands/plugins/tmux/impl";
 import { isClaudeLikePane } from "../../../commands/plugins/tmux/safety";
-import { UserError } from "../../../core/util/user-error";
 import { join } from "path";
 import {
   resolveAttachTarget,
@@ -238,7 +235,7 @@ async function openShellForSession(
 ): Promise<void> {
   // #1916 MED-4 — pass a real readSessionOption so workspace sessions
   // (no fleet entry) can fall back to their @maw_new_cwd.
-  const { hostExec } = await import("../../../sdk");
+  const { hostExec } = await import("maw-js/sdk");
   const readSessionOption = (session: string, option: string): string | undefined => {
     try {
       // hostExec is async but resolveSessionOptionSync isn't available; do a

--- a/src/vendor/mpr-plugins/attach/index.ts
+++ b/src/vendor/mpr-plugins/attach/index.ts
@@ -1,5 +1,5 @@
 import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
-import { parseFlags } from "maw-js/cli/parse-args";
+import { parseFlags } from "maw-js/sdk";
 import { cmdAttach } from "./impl";
 
 export const command = {

--- a/src/vendor/mpr-plugins/attach/resolve-attach-target.ts
+++ b/src/vendor/mpr-plugins/attach/resolve-attach-target.ts
@@ -1,5 +1,4 @@
-import { isInfrastructureChannelSessionName } from "../../../core/matcher/channel-session";
-import { resolveFleetWindowSessionTarget } from "../../../core/matcher/resolve-target";
+import { isInfrastructureChannelSessionName, resolveFleetWindowSessionTarget } from "maw-js/sdk";
 import { resolvePeer as resolveConfiguredPeer } from "../ls/internal/peer-resolve";
 import { existsSync, readFileSync } from "fs";
 import { homedir } from "os";

--- a/test/isolated/plugin-attach-standalone.test.ts
+++ b/test/isolated/plugin-attach-standalone.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "../..");
+
+type Session = { name: string; windows: Array<{ name: string; repo?: string; index?: number }> };
+
+let sessions: Session[] = [];
+let fleet: Session[] = [];
+const attached: string[] = [];
+
+function simpleParseFlags(args: string[], spec: Record<string, unknown>) {
+  const out: Record<string, any> & { _: string[] } = { _: [] };
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i]!;
+    const parser = spec[arg];
+    if (!parser) {
+      out._.push(arg);
+    } else if (typeof parser === "string") {
+      out[parser] = true;
+    } else if (parser === Boolean) {
+      out[arg] = true;
+    } else if (parser === String || parser === Number) {
+      out[arg] = args[++i];
+    }
+  }
+  return out;
+}
+
+function nameMatches(name: string, target: string) {
+  const n = name.toLowerCase().replace(/^\d+-/, "").replace(/-oracle$/, "");
+  const t = target.toLowerCase().replace(/^\d+-/, "").replace(/-oracle$/, "");
+  return n === t || name.toLowerCase() === target.toLowerCase() || name.toLowerCase().endsWith(`-${t}`);
+}
+
+const sdkMock = {
+  parseFlags: simpleParseFlags,
+  getGhqRoot: () => "/ghq/github.com",
+  listSessions: async () => sessions,
+  loadFleetCore: () => fleet,
+  hostExec: async () => "",
+  UserError: class UserError extends Error { readonly isUserError = true; },
+  isInfrastructureChannelSessionName: (sessionName: string) => sessionName === "0-overview" || sessionName.includes("channel"),
+  resolveFleetWindowSessionTarget: (target: string, rows: Session[]) => {
+    const matches = rows.filter((row) =>
+      row.windows.some((window) => window.name === target || window.repo?.endsWith(`/${target}-oracle`)),
+    );
+    if (matches.length === 1) return { kind: "fuzzy", match: matches[0] };
+    if (matches.length > 1) return { kind: "ambiguous", candidates: matches };
+    return { kind: "none", hints: [] };
+  },
+};
+
+mock.module("maw-js/sdk", () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk"), () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
+mock.module(new URL("../../src/sdk/index.ts", import.meta.url).pathname, () => sdkMock);
+
+mock.module(import.meta.resolve("../../src/commands/plugins/tmux/impl.ts"), () => ({
+  cmdTmuxAttach: (target: string) => attached.push(target),
+}));
+mock.module(import.meta.resolve("../../src/commands/plugins/tmux/safety.ts"), () => ({
+  isClaudeLikePane: (command?: string) => command === "claude" || command === "codex",
+}));
+mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/ls/internal/peer-resolve.ts"), () => ({
+  resolvePeer: (alias: string) => alias === "remote" ? { alias, node: alias, url: "https://remote.invalid", sshAlias: "remote-ssh" } : null,
+  resolveAllPeers: () => [],
+}));
+
+const { default: attachHandler } = await import("../../src/vendor/mpr-plugins/attach/index.ts?plugin-attach-standalone");
+const attachImpl = await import("../../src/vendor/mpr-plugins/attach/impl.ts?plugin-attach-standalone");
+const resolver = await import("../../src/vendor/mpr-plugins/attach/resolve-attach-target.ts?plugin-attach-standalone");
+
+function stripAnsi(value: string | undefined) {
+  return String(value ?? "").replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "");
+}
+
+beforeEach(() => {
+  sessions = [];
+  fleet = [];
+  attached.length = 0;
+});
+
+describe("attach plugin standalone boundary (#2313)", () => {
+  test("uses SDK for former core/shared/config dependencies", () => {
+    for (const rel of [
+      "src/vendor/mpr-plugins/attach/index.ts",
+      "src/vendor/mpr-plugins/attach/impl.ts",
+      "src/vendor/mpr-plugins/attach/resolve-attach-target.ts",
+    ]) {
+      const source = readFileSync(join(root, rel), "utf8");
+      expect(source).not.toMatch(/maw-js\/(?:core|commands\/shared|config|cli)(?:\/|")/);
+      expect(source).not.toMatch(/from\s+["']\.\.\/\.\.\/\.\.\/(?:core|commands\/shared|sdk|config|cli)/);
+    }
+
+    expect(readFileSync(join(root, "src/vendor/mpr-plugins/attach/impl.ts"), "utf8")).toContain('from "maw-js/sdk"');
+    expect(readFileSync(join(root, "src/vendor/mpr-plugins/attach/resolve-attach-target.ts"), "utf8")).toContain('from "maw-js/sdk"');
+    expect(readFileSync(join(root, "src/sdk/index.ts"), "utf8")).toContain("resolveFleetWindowSessionTarget");
+    expect(readFileSync(join(root, "src/sdk/index.ts"), "utf8")).toContain("isInfrastructureChannelSessionName");
+  });
+
+  test("resolver returns live, sleeping, remote, and invalid remote tiers", async () => {
+    sessions = [{ name: "01-mawjs", windows: [{ name: "mawjs-oracle", repo: "Soul-Brews-Studio/mawjs-oracle" }] }];
+    fleet = [{ name: "02-sleepy", windows: [{ name: "sleepy", repo: "Soul/sleepy-oracle" }] }];
+    const deps = { listSessions: async () => sessions, loadFleet: () => fleet };
+
+    await expect(resolver.resolveAttachTarget("mawjs", deps as any, { preferOracleWindow: true })).resolves.toEqual({
+      tier: 1,
+      sessionName: "01-mawjs",
+      windowName: "mawjs-oracle",
+    });
+    await expect(resolver.resolveAttachTarget("sleepy", deps as any)).resolves.toEqual({ tier: 2, fleetName: "02-sleepy" });
+    await expect(resolver.resolveAttachTarget("remote:neo", deps as any)).resolves.toMatchObject({
+      tier: 3,
+      node: "remote",
+      sessionName: "neo",
+      sshAlias: "remote-ssh",
+    });
+    await expect(resolver.resolveAttachTarget("remote:", deps as any)).resolves.toMatchObject({
+      tier: "error",
+      error: "invalid remote attach target 'remote:'",
+    });
+  });
+
+  test("handler parses CLI/API dry-run paths without touching tmux attach", async () => {
+    sessions = [{ name: "01-mawjs", windows: [{ name: "mawjs-oracle" }] }];
+
+    const cli = await attachHandler({ source: "cli", args: ["mawjs", "--dry-run"] } as any);
+    expect(cli.ok).toBe(true);
+    expect(stripAnsi(cli.output)).toContain("[dry-run] Tier 1 (live) — would attach to 01-mawjs:mawjs-oracle");
+
+    const api = await attachHandler({ source: "api", args: { name: "mawjs", dryRun: true } } as any);
+    expect(api.ok).toBe(true);
+    expect(stripAnsi(api.output)).toContain("would attach to 01-mawjs:mawjs-oracle");
+    expect(attached).toEqual([]);
+  });
+
+  test("handler validates missing names and flag-looking targets", async () => {
+    await expect(attachHandler({ source: "cli", args: [] } as any)).resolves.toEqual({
+      ok: false,
+      error: "usage: maw attach <name> [--shell [--split|--no-split]] [--dry-run] [-y|--yes]",
+    });
+    await expect(attachHandler({ source: "api", args: {} } as any)).resolves.toEqual({ ok: false, error: "name required" });
+    await expect(attachHandler({ source: "cli", args: ["--bogus"] } as any)).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining("looks like a flag"),
+    });
+  });
+
+  test("buildAttachShellPlan resolves fleet repo and workspace cwd fallbacks", () => {
+    const repoPlan = attachImpl.buildAttachShellPlan("mawjs", "01-mawjs", [
+      { name: "01-mawjs", windows: [{ name: "mawjs", repo: "Soul-Brews-Studio/mawjs-oracle" }] },
+    ]);
+    expect(repoPlan).toMatchObject({
+      sessionName: "01-mawjs",
+      targetWindow: "01-mawjs:mawjs",
+      windowName: "mawjs-shell",
+      cwd: "/ghq/github.com/Soul-Brews-Studio/mawjs-oracle",
+    });
+    expect(repoPlan.command).toContain("cd '/ghq/github.com/Soul-Brews-Studio/mawjs-oracle'");
+
+    const workspacePlan = attachImpl.buildAttachShellPlan("scratch", "scratch", [], {
+      readSessionOption: () => "/tmp/scratch space",
+    });
+    expect(workspacePlan.cwd).toBe("/tmp/scratch space");
+    expect(workspacePlan.command).toContain("cd '/tmp/scratch space'");
+
+    expect(() => attachImpl.buildAttachShellPlan("missing", "missing", [])).toThrow("cannot resolve repo path");
+  });
+});


### PR DESCRIPTION
## Summary
- adds isolated standalone boundary coverage for the attach plugin
- routes attach matcher/UserError/fleet/config/flag parsing dependencies through the SDK surface
- covers resolver live/sleeping/remote/error tiers, handler parsing, and shell-plan behavior

## Verification
- `git diff --check`
- `bun --check src/vendor/mpr-plugins/attach/impl.ts`
- `bun --check src/vendor/mpr-plugins/attach/resolve-attach-target.ts`
- `bun --check src/vendor/mpr-plugins/attach/index.ts`

## Local runner note
- `bun test test/isolated/plugin-attach-standalone.test.ts` is blocked in this checkout by a Bun Canary index-out-of-bounds panic before assertions; the same crash has occurred for one-line tests locally.

Closes #2313.
