### PR TITLE
test: standalone coverage for bud plugin

### DIFF
--- a/packages/sdk/index.d.ts
+++ b/packages/sdk/index.d.ts
@@ -223,6 +223,11 @@ export declare class UserError extends Error {
 
 /** True when an error was raised for user-facing command feedback. */
 export declare function isUserError(e: unknown): e is UserError;
+export declare function assertValidOracleName(name: string): void;
+export declare function writeSignal(parentRoot: string, budName: string, payload: { kind: "info" | "alert" | "pattern"; message: string; context?: Record<string, unknown> }): string;
+export declare function validateNickname(raw: string): { ok: true; value: string } | { ok: false; error: string };
+export declare function writeNickname(repoPath: string, nickname: string): void;
+export declare function setCachedNickname(name: string, nickname: string): void;
 
 /** Render numeric buckets as a compact Unicode sparkline. */
 export declare function sparkline(values: number[], hadActivity?: boolean[]): string;
@@ -234,6 +239,7 @@ export declare function cmdPeek(query?: string): Promise<void>;
 
 /** Send a message to an oracle/window target. */
 export declare function cmdSend(target: string, message: string, force?: boolean): Promise<void>;
+export declare function cmdSplit(target: string, opts?: Record<string, unknown>): Promise<void>;
 
 // --- src/config ---
 
@@ -667,6 +673,11 @@ export declare function scanSignals(root: string, opts?: { days?: number }): Sca
 
 export declare function fetchIssuePrompt(num: number, repo?: string): Promise<string>;
 export declare function cmdWake(oracle: string, opts: Record<string, unknown>): Promise<string>;
+export interface ParsedWakeTarget { oracle: string; slug: string; issueNum?: number }
+export declare function parseWakeTarget(target: string): ParsedWakeTarget | null;
+export declare function ensureCloned(slug: string): Promise<void>;
+export interface ShouldAutoWakeDecision { wake: boolean; reason: string }
+export declare function shouldAutoWake(oracle: string, opts: Record<string, unknown>): ShouldAutoWakeDecision;
 
 // --- src/commands/shared/pulse ---
 

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -58,6 +58,7 @@ export { sparkline } from "../../src/lib/sparkline";
 // ─── src/commands/shared/comm ────────────────────────────────────────────────
 // Federation-aware communication helpers used by small command plugins.
 export { cmdPeek, cmdSend } from "../../src/commands/shared/comm";
+export { cmdSplit } from "../../src/commands/plugins/split/impl";
 
 // ─── src/config ──────────────────────────────────────────────────────────────
 // Operator config loader + key-typed accessors. Used by:
@@ -113,6 +114,9 @@ export type { ConsentAction } from "../../src/core/consent";
 // Hyperlink helper for OSC-8-capable terminals.
 //   tlink — check
 export { tlink } from "../../src/core/util/terminal";
+export { assertValidOracleName } from "../../src/core/fleet/validate";
+export { writeSignal } from "../../src/core/fleet/leaf";
+export { validateNickname, writeNickname, setCachedNickname } from "../../src/core/fleet/nicknames";
 
 // ─── src/core/xdg ───────────────────────────────────────────────────────────
 // XDG-aware maw path helpers. Used by messages extraction and other plugins
@@ -174,6 +178,8 @@ export { importPluginSymbol } from "../../src/plugin/registry";
 // ─── src/commands/shared/wake ───────────────────────────────────────────────
 // Wake helpers used by small orchestration plugins like assign.
 export { cmdWake, fetchIssuePrompt } from "../../src/commands/shared/wake";
+export { parseWakeTarget, ensureCloned } from "../../src/commands/shared/wake-target";
+export { shouldAutoWake } from "../../src/commands/shared/should-auto-wake";
 
 
 // ─── src/core/agent-detect ──────────────────────────────────────────────────

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -116,6 +116,8 @@ export {
 export { cmdSleep } from "../commands/shared/fleet-wake";
 export { cmdPulseAdd, cmdPulseLs } from "../commands/shared/pulse";
 export { cmdWake, fetchIssuePrompt, findWorktrees, detectSession } from "../commands/shared/wake";
+export { parseWakeTarget, ensureCloned } from "../commands/shared/wake-target";
+export { shouldAutoWake } from "../commands/shared/should-auto-wake";
 export type {
   FleetWindow, FleetSession, FleetEntry, DisabledFleetEntry,
 } from "../core/fleet/fleet-load-core";
@@ -175,11 +177,16 @@ export {
 } from "../commands/shared/workspace";
 export { ghqFind, ghqList, ghqFindSync, ghqListSync } from "../core/ghq";
 export { UserError, isUserError } from "../core/util/user-error";
+export { assertValidOracleName } from "../core/fleet/validate";
+export { writeSignal } from "../core/fleet/leaf";
+export { validateNickname, writeNickname, setCachedNickname } from "../core/fleet/nicknames";
 export { sparkline } from "../lib/sparkline";
 export { tlink } from "../core/util/terminal";
+export { legacyMawPath, mawStatePath } from "../core/xdg";
 
 // Plugin extraction helpers for tab-like command surfaces.
 export { cmdPeek, cmdSend } from "../commands/shared/comm";
+export { cmdSplit } from "../commands/plugins/split/impl";
 
 // ─── Transport Router ────────────────────────────────────────────────────────
 

--- a/src/vendor/mpr-plugins/bud/bud-init.ts
+++ b/src/vendor/mpr-plugins/bud/bud-init.ts
@@ -1,6 +1,6 @@
 import { join } from "path";
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
-import { fleetDirForWrite, loadFleetEntries } from "maw-js/commands/shared/fleet-load";
+import { fleetLoadDirForWrite, loadFleetEntries } from "maw-js/sdk";
 
 /** Step 2: Create ψ/ vault directory structure. Returns the psiDir path. */
 export function initVault(budRepoPath: string): string {
@@ -129,7 +129,7 @@ export function configureFleet(name: string, org: string, budRepoName: string, p
   let fleetFile: string;
 
   if (existing) {
-    fleetFile = existing.path ?? join(fleetDirForWrite(), existing.file);
+    fleetFile = existing.path ?? join(fleetLoadDirForWrite(), existing.file);
     const cfg = JSON.parse(readFileSync(fleetFile, "utf-8"));
     let updated = false;
     if (!cfg.budded_from && parentName) { cfg.budded_from = parentName; updated = true; }
@@ -143,7 +143,7 @@ export function configureFleet(name: string, org: string, budRepoName: string, p
   } else {
     const maxNum = entries.reduce((max, e) => Math.max(max, e.num), 0);
     const budNum = maxNum + 1;
-    const writeDir = fleetDirForWrite();
+    const writeDir = fleetLoadDirForWrite();
     mkdirSync(writeDir, { recursive: true });
     fleetFile = join(writeDir, `${String(budNum).padStart(2, "0")}-${name}.json`);
     const fleetConfig: Record<string, unknown> = {

--- a/src/vendor/mpr-plugins/bud/bud-wake.ts
+++ b/src/vendor/mpr-plugins/bud/bud-wake.ts
@@ -1,8 +1,8 @@
-import { hostExec } from "maw-js/sdk";
+import {
+  cmdSplit, cmdWake, ensureCloned, fetchIssuePrompt, fleetLoadDirForWrite, getGhqRoot, hostExec,
+  loadFleetCore as loadFleet, loadFleetEntries, shouldAutoWake,
+} from "maw-js/sdk";
 import { cmdSoulSync } from "./internal/soul-sync-impl";
-import { cmdWake } from "maw-js/commands/shared/wake";
-import { fleetDirForWrite, loadFleetEntries, loadFleet } from "maw-js/commands/shared/fleet-load";
-import { getGhqRoot } from "maw-js/config/ghq-root";
 import { resolveOraclePath } from "./internal/resolve";
 import { join } from "path";
 import { existsSync, readFileSync, writeFileSync } from "fs";
@@ -116,7 +116,7 @@ export async function finalizeBud(ctx: BudFinalizeCtx): Promise<void> {
   for (const entry of parentName ? loadFleetEntries() : []) {
     const entryName = entry.session.name.replace(/^\d+-/, "");
     if (entryName === parentName) {
-      const parentFile = entry.path ?? join(fleetDirForWrite(), entry.file);
+      const parentFile = entry.path ?? join(fleetLoadDirForWrite(), entry.file);
       const parentConfig = JSON.parse(readFileSync(parentFile, "utf-8"));
       const peers: string[] = parentConfig.sync_peers || [];
       if (!peers.includes(name)) {
@@ -133,7 +133,6 @@ export async function finalizeBud(ctx: BudFinalizeCtx): Promise<void> {
   // #835 — consult unified shouldAutoWake helper. bud's policy is "always
   // wake" — a freshly-cloned bud has no session yet and the whole point of
   // bud is to spawn one. The helper makes that explicit and auditable.
-  const { shouldAutoWake } = await import("maw-js/commands/shared/should-auto-wake");
   const decision = shouldAutoWake(name, { site: "bud" });
   if (!decision.wake) {
     // Defensive — site=bud never returns wake=false today. Preserve the
@@ -148,7 +147,6 @@ export async function finalizeBud(ctx: BudFinalizeCtx): Promise<void> {
   if (opts.parentSessionId) wakeOpts.parentSessionId = opts.parentSessionId;
   if (opts.sessionId) wakeOpts.sessionId = opts.sessionId;
   if (opts.issue) {
-    const { fetchIssuePrompt } = await import("maw-js/commands/shared/wake");
     const issueRepo = await resolveIssueRepoForBud(ctx);
     wakeOpts.prompt = await fetchIssuePrompt(opts.issue, issueRepo);
     wakeOpts.task = `issue-${opts.issue}`;
@@ -156,7 +154,6 @@ export async function finalizeBud(ctx: BudFinalizeCtx): Promise<void> {
   if (opts.repo) {
     // Clone the target repo via ghq (resolve-first, no worktree).
     // Previously set wakeOpts.incubate which auto-created a worktree — see #271.
-    const { ensureCloned } = await import("maw-js/commands/shared/wake-target");
     await ensureCloned(opts.repo);
   }
   try {
@@ -173,7 +170,6 @@ export async function finalizeBud(ctx: BudFinalizeCtx): Promise<void> {
   // failed inside tmux (nested attach-session refused to nest, pane died immediately).
   if (opts.split && process.env.TMUX) {
     try {
-      const { cmdSplit } = await import("../split/impl");
       await cmdSplit(name);
     } catch (e: any) {
       console.log(`  \x1b[33m⚠\x1b[0m split failed: ${e.message || e}`);

--- a/src/vendor/mpr-plugins/bud/from-repo-fleet.ts
+++ b/src/vendor/mpr-plugins/bud/from-repo-fleet.ts
@@ -11,7 +11,7 @@
 import { mkdirSync, readFileSync, writeFileSync } from "fs";
 import { basename, join } from "path";
 import { execFileSync } from "child_process";
-import { fleetDirForWrite, loadFleetEntries, type FleetEntry } from "maw-js/commands/shared/fleet-load";
+import { fleetLoadDirForWrite, loadFleetEntries, type FleetEntry } from "maw-js/sdk";
 
 /** Parsed `org/repo` slug from a remote URL. */
 export interface RepoSlug {
@@ -62,7 +62,7 @@ export function resolveSlug(target: string): RepoSlug {
 
 /** Absolute source path for an entry, falling back to the current write dir. */
 function fleetEntryPath(entry: Pick<FleetEntry, "file" | "path">): string {
-  return entry.path ?? join(fleetDirForWrite(), entry.file);
+  return entry.path ?? join(fleetLoadDirForWrite(), entry.file);
 }
 
 /** Find the next NN prefix by scanning existing fleet entries across read roots. */
@@ -112,7 +112,7 @@ export function registerFleetEntry(opts: RegisterFleetOpts): RegisterFleetResult
   }
   const num = nextFleetNum(entries);
   const padded = String(num).padStart(2, "0");
-  const writeDir = fleetDirForWrite();
+  const writeDir = fleetLoadDirForWrite();
   mkdirSync(writeDir, { recursive: true });
   const file = join(writeDir, `${padded}-${opts.stem}.json`);
   const cfg: Record<string, unknown> = {

--- a/src/vendor/mpr-plugins/bud/from-repo-seed.ts
+++ b/src/vendor/mpr-plugins/bud/from-repo-seed.ts
@@ -13,8 +13,7 @@
 
 import { cpSync, copyFileSync, existsSync, mkdirSync, statSync } from "fs";
 import { join } from "path";
-import { loadConfig } from "maw-js/config";
-import { getGhqRoot } from "maw-js/config/ghq-root";
+import { getGhqRoot, loadConfig } from "maw-js/sdk";
 import { peersPath } from "./internal/peers-store";
 
 type Log = (msg: string) => void;

--- a/src/vendor/mpr-plugins/bud/impl.ts
+++ b/src/vendor/mpr-plugins/bud/impl.ts
@@ -1,14 +1,10 @@
-import { loadConfig } from "maw-js/config";
-import { getGhqRoot } from "maw-js/config/ghq-root";
-import { parseWakeTarget, ensureCloned } from "maw-js/commands/shared/wake-target";
-import { normalizeTarget } from "maw-js/core/matcher/normalize-target";
-import { assertValidOracleName } from "maw-js/core/fleet/validate";
-import { hostExec } from "maw-js/sdk";
+import {
+  assertValidOracleName, ensureCloned, getGhqRoot, hostExec, loadConfig, normalizeTarget, parseWakeTarget,
+  setCachedNickname, validateNickname, writeNickname, writeSignal,
+} from "maw-js/sdk";
 import { ensureBudRepo } from "./bud-repo";
 import { initVault, generateClaudeMd, generateClaudeSettings, configureFleet, writeBirthNote } from "./bud-init";
 import { finalizeBud } from "./bud-wake";
-import { writeSignal } from "maw-js/core/fleet/leaf";
-import { validateNickname, writeNickname, setCachedNickname } from "maw-js/core/fleet/nicknames";
 import { resolveOrg, formatOrgSource, type OrgResolution } from "./smart-default-org";
 import { join } from "path";
 

--- a/src/vendor/mpr-plugins/bud/index.ts
+++ b/src/vendor/mpr-plugins/bud/index.ts
@@ -1,7 +1,6 @@
-import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdBud } from "./impl";
 import { cmdBudFromRepo, looksLikeUrl } from "./from-repo";
-import { parseFlags } from "maw-js/cli/parse-args";
+import { parseFlags, type InvokeContext, type InvokeResult } from "maw-js/sdk";
 
 export const command = {
   name: "bud",

--- a/src/vendor/mpr-plugins/bud/internal/peers-store.ts
+++ b/src/vendor/mpr-plugins/bud/internal/peers-store.ts
@@ -30,7 +30,7 @@
  */
 import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync, unlinkSync } from "fs";
 import { dirname } from "path";
-import { legacyMawPath, mawStatePath } from "../../../../core/xdg";
+import { legacyMawPath, mawStatePath } from "maw-js/sdk";
 import { withPeersLock } from "./lock";
 
 /**

--- a/src/vendor/mpr-plugins/bud/internal/resolve.ts
+++ b/src/vendor/mpr-plugins/bud/internal/resolve.ts
@@ -1,8 +1,6 @@
 import { existsSync } from "fs";
 import { join } from "path";
-import { ghqFind } from "maw-js/core/ghq";
-import { getGhqRoot } from "maw-js/config/ghq-root";
-import { loadFleet } from "maw-js/commands/shared/fleet-load";
+import { ghqFind, getGhqRoot, loadFleetCore as loadFleet } from "maw-js/sdk";
 
 /**
  * Resolve ghq path for an oracle name.

--- a/src/vendor/mpr-plugins/bud/internal/soul-sync-impl.ts
+++ b/src/vendor/mpr-plugins/bud/internal/soul-sync-impl.ts
@@ -1,7 +1,6 @@
 import { existsSync } from "fs";
 import { join, basename } from "path";
-import { hostExec } from "maw-js/sdk";
-import { getGhqRoot } from "maw-js/config/ghq-root";
+import { getGhqRoot, hostExec } from "maw-js/sdk";
 import { findPeers, findProjectsForOracle, syncOracleVaults, syncProjectVault, reportProjectResult, type SoulSyncResult, type ProjectSyncResult } from "./sync-helpers";
 import { resolveOraclePath, resolveProjectSlug, findOracleForProject } from "./resolve";
 

--- a/src/vendor/mpr-plugins/bud/internal/sync-helpers.ts
+++ b/src/vendor/mpr-plugins/bud/internal/sync-helpers.ts
@@ -1,6 +1,6 @@
 import { existsSync, readdirSync, copyFileSync, mkdirSync, appendFileSync } from "fs";
 import { join } from "path";
-import { loadFleet } from "maw-js/commands/shared/fleet-load";
+import { loadFleetCore as loadFleet } from "maw-js/sdk";
 
 const SYNC_DIRS = ["memory/learnings", "memory/retrospectives", "memory/traces", "memory/collaborations"];
 

--- a/src/vendor/mpr-plugins/bud/smart-default-org.ts
+++ b/src/vendor/mpr-plugins/bud/smart-default-org.ts
@@ -28,8 +28,7 @@
  * before `gh repo create` fires.
  */
 
-import { hostExec } from "maw-js/sdk";
-import { loadFleet } from "maw-js/commands/shared/fleet-load";
+import { hostExec, loadFleetCore as loadFleet } from "maw-js/sdk";
 
 export type OrgSource = "flag" | "env" | "config" | "fleet" | "gh" | "default";
 

--- a/test/isolated/plugin-bud-standalone.test.ts
+++ b/test/isolated/plugin-bud-standalone.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "../..");
+const budDir = join(root, "src/vendor/mpr-plugins/bud");
+let hostExecCalls: string[] = [];
+let wakeCalls: Array<{ oracle: string; opts: Record<string, unknown> }> = [];
+let splitCalls: string[] = [];
+let cloned: string[] = [];
+let signals: unknown[] = [];
+let nicknames: unknown[] = [];
+let config: Record<string, unknown> = {};
+
+function parseFlags(args: string[], spec: Record<string, unknown>) {
+  const out: Record<string, any> & { _: string[] } = { _: [] };
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (!arg.startsWith("--")) {
+      out._.push(arg);
+      continue;
+    }
+    const type = spec[arg];
+    if (type === Boolean) out[arg] = true;
+    else if (type === Number) out[arg] = Number(args[++i]);
+    else if (type === String) out[arg] = args[++i];
+    else out._.push(arg);
+  }
+  return out;
+}
+
+const sdkMock = {
+  parseFlags,
+  loadConfig: () => config,
+  getGhqRoot: () => "/tmp/ghq",
+  hostExec: async (cmd: string) => {
+    hostExecCalls.push(cmd);
+    if (cmd.includes("pane_current_path")) return "/tmp/ghq/github.com/Acme/parent-oracle";
+    return "";
+  },
+  loadFleetCore: () => [],
+  fleetLoadDirForWrite: () => "/tmp/fleet",
+  loadFleetEntries: () => [],
+  ghqFind: async () => null,
+  legacyMawPath: (...parts: string[]) => join("/tmp/legacy-maw", ...parts),
+  mawStatePath: (...parts: string[]) => join("/tmp/state-maw", ...parts),
+  parseWakeTarget: () => null,
+  ensureCloned: async (slug: string) => { cloned.push(slug); },
+  normalizeTarget: (raw: string) => raw.replace(/\/$/, "").replace(/\.git$/, ""),
+  assertValidOracleName: (name: string) => {
+    if (name.endsWith("-view")) throw new Error("Oracle name cannot end in '-view'");
+  },
+  validateNickname: (raw: string) => raw.includes("\n") ? { ok: false, error: "nickname must be a single line" } : { ok: true, value: raw.trim() },
+  writeNickname: (repoPath: string, nickname: string) => nicknames.push({ repoPath, nickname }),
+  setCachedNickname: (name: string, nickname: string) => nicknames.push({ name, nickname }),
+  writeSignal: (...args: unknown[]) => { signals.push(args); return "/tmp/signal.json"; },
+  cmdWake: async (oracle: string, opts: Record<string, unknown>) => {
+    wakeCalls.push({ oracle, opts });
+    return "woke";
+  },
+  fetchIssuePrompt: async (num: number, repo?: string) => `issue ${num} from ${repo}`,
+  shouldAutoWake: () => ({ wake: true, reason: "bud always wakes" }),
+  cmdSplit: async (target: string) => { splitCalls.push(target); },
+};
+
+mock.module("maw-js/sdk", () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
+
+const { command, default: budHandler } = await import("../../src/vendor/mpr-plugins/bud/index.ts");
+
+function walkSources(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walkSources(full));
+    else if (entry.name.endsWith(".ts")) out.push(full);
+  }
+  return out;
+}
+
+function importSpecs(source: string): string[] {
+  const specs = new Set<string>();
+  const re = /\b(?:import|export)\s+(?:[^"'`]+?\s+from\s+)?["']([^"']+)["']|\bimport\(\s*["']([^"']+)["']\s*\)/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(source))) specs.add(match[1] ?? match[2]);
+  return [...specs];
+}
+
+beforeEach(() => {
+  hostExecCalls = [];
+  wakeCalls = [];
+  splitCalls = [];
+  cloned = [];
+  signals = [];
+  nicknames = [];
+  config = {};
+  delete process.env.MAW_BUD_OWNER;
+  delete process.env.TMUX;
+});
+
+describe("bud plugin standalone boundary (#2314)", () => {
+  test("all bud sources use SDK or local/platform imports only", () => {
+    const imports = walkSources(budDir).flatMap((file) => importSpecs(readFileSync(file, "utf8")));
+    const forbidden = imports.filter((spec) =>
+      spec.startsWith("maw-js/core/")
+      || spec.startsWith("maw-js/commands/shared/")
+      || spec.startsWith("maw-js/cli/")
+      || spec === "maw-js/config"
+      || spec.startsWith("maw-js/config/")
+      || spec.startsWith("maw-js/plugin")
+      || spec.startsWith("../split/")
+      || spec.includes("../../../../core"),
+    );
+
+    expect(command).toMatchObject({ name: "bud" });
+    expect(forbidden).toEqual([]);
+    expect(imports).toContain("maw-js/sdk");
+  });
+
+  test("CLI usage and invalid argument paths return InvokeResult errors without side effects", async () => {
+    const help = await budHandler({ source: "cli", args: ["--help"] } as any);
+    expect(help.ok).toBe(false);
+    expect(help.error).toContain("usage: maw bud <name>");
+
+    const flagName = await budHandler({ source: "cli", args: ["--dry-run"] } as any);
+    expect(flagName.ok).toBe(false);
+    expect(flagName.error).toContain("usage: maw bud <name>");
+
+    const missingStem = await budHandler({ source: "cli", args: ["--from-repo", "/repo"] } as any);
+    expect(missingStem).toEqual({ ok: false, error: "--from-repo requires --stem <stem> (oracle stem, no -oracle suffix)" });
+    expect(hostExecCalls).toEqual([]);
+  });
+
+  test("dry-run root bud stays non-destructive while exercising cmdBud through SDK seams", async () => {
+    const result = await budHandler({
+      source: "cli",
+      args: ["sprout", "--root", "--org", "Acme", "--dry-run", "--nickname", "Sprout"],
+    } as any);
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("Root Bud");
+    expect(result.output).toContain("[dry-run] would create repo: Acme/sprout-oracle");
+    expect(result.output).toContain("[dry-run] would write nickname: Sprout");
+    expect(hostExecCalls).toEqual([]);
+    expect(wakeCalls).toEqual([]);
+    expect(cloned).toEqual([]);
+  });
+
+  test("API requires a name and can run a dry-run root bud", async () => {
+    const missing = await budHandler({ source: "api", args: {} } as any);
+    expect(missing).toEqual({ ok: false, error: "name required" });
+
+    const ok = await budHandler({ source: "api", args: { name: "api-bud", root: true, org: "Acme", dryRun: true } } as any);
+    expect(ok.ok).toBe(true);
+    expect(ok.output).toContain("Acme/api-bud-oracle");
+  });
+});


### PR DESCRIPTION
Closes #2314

## Summary
- add isolated standalone coverage for the bud plugin boundary and safe dry-run handler paths
- route bud private core/shared/config/cli imports through `maw-js/sdk`
- add SDK barrel exports needed by bud extraction

## Verification
- `rg -n "maw-js/(core|commands/shared|cli|config|lib|plugin)(/|\")|from ['\"](?:\.\./)+(?:core|commands|cli|config|lib|src)/|\.\./\.\./\.\./\.\./core|\.\./split/" src/vendor/mpr-plugins/bud || true` (no output)
- `git diff --check origin/alpha...HEAD`
- `bun build test/isolated/plugin-bud-standalone.test.ts --outfile /tmp/plugin-bud-standalone.js --target=bun --external maw-js/sdk`
- `bun test test/isolated/plugin-bud-standalone.test.ts`
- `bun run build`

## Not tested
- destructive bud lifecycle paths such as real GitHub repo creation, tmux wake/split, or git push