### PR TITLE
release: v26.6.8-alpha.144

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.6.8-alpha.129",
+  "version": "26.6.8-alpha.144",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts v26.6.8-alpha.144 on merge via calver-release.yml.

Verification:
- `TZ=Asia/Bangkok bun scripts/calver.ts --check`
- `TZ=Asia/Bangkok bun scripts/calver.ts`
