### PR TITLE
test: standalone coverage for sleep plugin

### DIFF
--- a/packages/sdk/index.d.ts
+++ b/packages/sdk/index.d.ts
@@ -502,6 +502,7 @@ export declare function loadFleetEntries(dirs?: string[]): FleetEntry[];
 
 /** Stop all configured fleet sessions. */
 export declare function cmdSleep(): Promise<void>;
+export declare function detectSession(oracle: string, urlRepoName?: string): Promise<string | null>;
 
 // --- src/lib/artifacts ---
 
@@ -574,6 +575,23 @@ export declare function getArtifact(
 
 /** Get the artifact directory path (for agents to write into). */
 export declare function artifactDir(team: string, taskId: string): string;
+
+
+export interface SleepLifecycleContextInput {
+  oracle: string;
+  session: string;
+  window: string;
+  target: string;
+}
+
+export interface LifecycleRunSummary {
+  phase: "wake" | "sleep" | "serve";
+  ran: number;
+  skipped: number;
+  failed: number;
+}
+
+export declare function runSleepLifecycleHooks(context: SleepLifecycleContextInput): Promise<LifecycleRunSummary>;
 
 // --- src/core/xdg ---
 

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -174,6 +174,8 @@ export type { TProfile, TScope } from "../../src/lib/schemas";
 // Runtime bridge for cross-plugin helper reuse. A plugin must opt in via
 // plugin.json module.path + module.exports before another plugin may import it.
 export { importPluginSymbol } from "../../src/plugin/registry";
+export { runSleepLifecycleHooks } from "../../src/plugin/lifecycle";
+export type { SleepLifecycleContextInput, LifecycleRunSummary } from "../../src/plugin/lifecycle";
 
 // ─── src/commands/shared/wake ───────────────────────────────────────────────
 // Wake helpers used by small orchestration plugins like assign.
@@ -203,6 +205,7 @@ export {
   loadFleetEntries,
 } from "../../src/core/fleet/fleet-load-core";
 export { cmdSleep } from "../../src/commands/shared/fleet-wake";
+export { detectSession } from "../../src/commands/shared/wake";
 export type {
   FleetWindow, FleetSession, FleetEntry, DisabledFleetEntry,
 } from "../../src/core/fleet/fleet-load-core";

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -26,7 +26,7 @@ export {
 } from "../config";
 export { DEFAULT_ENGINES, resolveEngine } from "../config/engine-registry";
 export { getGhqRoot } from "../config/ghq-root";
-export { mawConfigDir } from "../core/xdg";
+export { mawConfigDir, mawMessageLogPath } from "../core/xdg";
 export type { EngineDef } from "../config/engine-def";
 export type { EngineRegistry } from "../config/engine-registry";
 export type { TScope } from "../lib/schemas";
@@ -91,6 +91,8 @@ export type { ScannedSignal } from "../commands/shared/scan-signals";
 // ─── Runtime ─────────────────────────────────────────────────────────────────
 
 export { runHook } from "../core/runtime/hooks";
+export { runSleepLifecycleHooks } from "../plugin/lifecycle";
+export type { SleepLifecycleContextInput, LifecycleRunSummary } from "../plugin/lifecycle";
 export { getTriggers, getTriggerHistory } from "../core/runtime/triggers";
 
 // ─── Fleet ───────────────────────────────────────────────────────────────────

--- a/src/vendor/mpr-plugins/sleep/impl.ts
+++ b/src/vendor/mpr-plugins/sleep/impl.ts
@@ -1,13 +1,16 @@
-import { tmux, listSessions } from "maw-js/sdk";
-import { detectSession } from "maw-js/commands/shared/wake";
-import { loadFleet } from "maw-js/commands/shared/fleet-load";
-import { saveTabOrder } from "maw-js/sdk";
+import {
+  detectSession,
+  listSessions,
+  loadFleetCore as loadFleet,
+  mawMessageLogPath,
+  runSleepLifecycleHooks,
+  saveTabOrder,
+  tmux,
+} from "maw-js/sdk";
 import { appendFile, mkdir } from "fs/promises";
 import { dirname } from "path";
 import { takeSnapshot } from "maw-js/sdk";
-import { runSleepLifecycleHooks } from "maw-js/plugin/lifecycle";
 import { resolveSleepTarget } from "./resolve-target";
-import { mawMessageLogPath } from "../../../core/xdg";
 
 /**
  * maw sleep <target> [window]

--- a/src/vendor/mpr-plugins/sleep/index.ts
+++ b/src/vendor/mpr-plugins/sleep/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/sdk";
 import { cmdSleepOne } from "./impl";
 
 export const command = {

--- a/test/isolated/plugin-sleep-standalone.test.ts
+++ b/test/isolated/plugin-sleep-standalone.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "../..");
+const sleepDir = join(root, "src/vendor/mpr-plugins/sleep");
+let sessions: Array<{ name: string; windows: Array<{ name: string }> }> = [];
+let fleet: Array<{ name: string; windows: Array<{ name: string }> }> = [];
+let detected: string | null = null;
+let lifecycleCalls: unknown[] = [];
+let savedTabs: string[] = [];
+
+const sdkMock = {
+  listSessions: async () => sessions,
+  loadFleetCore: () => fleet,
+  detectSession: async () => detected,
+  saveTabOrder: async (session: string) => { savedTabs.push(session); },
+  runSleepLifecycleHooks: async (ctx: unknown) => {
+    lifecycleCalls.push(ctx);
+    return { phase: "sleep", ran: 0, skipped: 0, failed: 0 };
+  },
+  mawMessageLogPath: () => "/tmp/maw-test/messages.jsonl",
+  takeSnapshot: async () => undefined,
+  tmux: {
+    sendKeysLiteral: async () => undefined,
+    sendKeys: async () => undefined,
+    listWindows: async () => [],
+    killWindow: async () => undefined,
+  },
+};
+
+mock.module("maw-js/sdk", () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
+
+const { command, default: sleepHandler } = await import("../../src/vendor/mpr-plugins/sleep/index.ts");
+const { cmdSleepOne } = await import("../../src/vendor/mpr-plugins/sleep/impl.ts");
+const { resolveSleepTarget } = await import("../../src/vendor/mpr-plugins/sleep/resolve-target.ts");
+
+function walkSources(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walkSources(full));
+    else if (entry.name.endsWith(".ts")) out.push(full);
+  }
+  return out;
+}
+
+function importSpecs(source: string): string[] {
+  const specs = new Set<string>();
+  const re = /\b(?:import|export)\s+(?:[^"'`]+?\s+from\s+)?["']([^"']+)["']|\bimport\(\s*["']([^"']+)["']\s*\)/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(source))) specs.add(match[1] ?? match[2]);
+  return [...specs];
+}
+
+beforeEach(() => {
+  sessions = [];
+  fleet = [];
+  detected = null;
+  lifecycleCalls = [];
+  savedTabs = [];
+});
+
+describe("sleep plugin standalone boundary", () => {
+  test("all sleep sources use SDK or local/platform imports only", () => {
+    const imports = walkSources(sleepDir).flatMap((file) => importSpecs(readFileSync(file, "utf8")));
+    const forbidden = imports.filter((spec) =>
+      spec.startsWith("maw-js/core/")
+      || spec.startsWith("maw-js/commands/shared/")
+      || spec.startsWith("maw-js/cli/")
+      || spec === "maw-js/config"
+      || spec.startsWith("maw-js/config/")
+      || spec.startsWith("maw-js/plugin")
+      || spec.includes("../../../core"),
+    );
+
+    expect(command).toMatchObject({ name: ["sleep"] });
+    expect(forbidden).toEqual([]);
+    expect(imports).toContain("maw-js/sdk");
+  });
+
+  test("handler validates CLI/API arguments without tmux side effects", async () => {
+    const cli = await sleepHandler({ source: "cli", args: [] } as any);
+    expect(cli).toEqual({ ok: false, error: "usage: maw sleep <oracle> [window]  (see: maw kill for immediate removal, maw done for worktrees)" });
+
+    const api = await sleepHandler({ source: "api", args: {} } as any);
+    expect(api).toEqual({ ok: false, error: "oracle is required (usage: maw sleep <oracle> [window])" });
+
+    const allDone = await sleepHandler({ source: "cli", args: ["--all-done"] } as any);
+    expect(allDone.ok).toBe(true);
+    expect(allDone.output).toContain("placeholder");
+    expect(savedTabs).toEqual([]);
+  });
+
+  test("resolveSleepTarget preserves window, session, and detectSession tiers", async () => {
+    const deps = {
+      listSessions: async () => [
+        { name: "mawjs", windows: [{ name: "codex-5" }] },
+        { name: "29-arra", windows: [{ name: "main" }] },
+      ],
+      loadFleet: () => [{ name: "29-arra", windows: [{ name: "fleet-main" }] }],
+      detectSession: async (oracle: string) => oracle === "neo" ? "neo-session" : null,
+    };
+
+    expect(await resolveSleepTarget("codex-5", undefined, deps)).toEqual({ session: "mawjs", window: "codex-5" });
+    expect(await resolveSleepTarget("29-arra", undefined, deps)).toEqual({ session: "29-arra", window: "fleet-main" });
+    expect(await resolveSleepTarget("neo", "chosen", deps)).toEqual({ session: "neo-session", window: "chosen" });
+  });
+
+  test("cmdSleepOne reports available windows when target cannot resolve", async () => {
+    sessions = [{ name: "mawjs", windows: [{ name: "codex-1" }, { name: "codex-2" }] }];
+
+    await expect(cmdSleepOne("missing")).rejects.toThrow("could not resolve sleep target: 'missing'");
+    expect(savedTabs).toEqual([]);
+    expect(lifecycleCalls).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add isolated standalone coverage for the sleep plugin boundary, handler validation, resolver tiers, and unresolved-target behavior
- route sleep private wake/fleet/lifecycle/xdg imports through `maw-js/sdk`
- add SDK exports needed by sleep extraction

## Verification
- `rg -n "maw-js/(core|commands/shared|cli|config|lib|plugin)(/|\")|from ['\"](?:\.\./)+(?:core|commands|cli|config|lib|src)/|\.\./\.\./\.\./core" src/vendor/mpr-plugins/sleep || true` (no output)
- `git diff --check origin/alpha...HEAD`
- `bun build src/vendor/mpr-plugins/sleep/index.ts --outfile /tmp/sleep-plugin.js --target=bun --external maw-js/sdk`
- `bun build test/isolated/plugin-sleep-standalone.test.ts --outfile /tmp/plugin-sleep-standalone.js --target=bun --external maw-js/sdk`
- `bun test test/isolated/plugin-sleep-standalone.test.ts`
- `bun run build`

## Not tested
- real tmux sleep success path and message-log append side effect