### PR TITLE
test: standalone coverage for restart plugin

### DIFF
--- a/packages/sdk/index.d.ts
+++ b/packages/sdk/index.d.ts
@@ -502,6 +502,8 @@ export declare function loadFleetEntries(dirs?: string[]): FleetEntry[];
 
 /** Stop all configured fleet sessions. */
 export declare function cmdSleep(): Promise<void>;
+/** Wake all configured fleet sessions. */
+export declare function cmdWakeAll(opts?: { kill?: boolean; all?: boolean; resume?: boolean }): Promise<void>;
 export declare function detectSession(oracle: string, urlRepoName?: string): Promise<string | null>;
 
 // --- src/lib/artifacts ---

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -204,7 +204,7 @@ export {
   loadDisabledFleetEntries as loadDisabledFleetEntriesCore,
   loadFleetEntries,
 } from "../../src/core/fleet/fleet-load-core";
-export { cmdSleep } from "../../src/commands/shared/fleet-wake";
+export { cmdSleep, cmdWakeAll } from "../../src/commands/shared/fleet-wake";
 export { detectSession } from "../../src/commands/shared/wake";
 export type {
   FleetWindow, FleetSession, FleetEntry, DisabledFleetEntry,

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -26,7 +26,7 @@ export {
 } from "../config";
 export { DEFAULT_ENGINES, resolveEngine } from "../config/engine-registry";
 export { getGhqRoot } from "../config/ghq-root";
-export { mawConfigDir, mawMessageLogPath } from "../core/xdg";
+export { mawConfigDir, mawDataPath, mawMessageLogPath } from "../core/xdg";
 export type { EngineDef } from "../config/engine-def";
 export type { EngineRegistry } from "../config/engine-registry";
 export type { TScope } from "../lib/schemas";
@@ -115,7 +115,7 @@ export {
   loadDisabledFleetEntries as loadDisabledFleetEntriesCore,
   loadFleetEntries,
 } from "../core/fleet/fleet-load-core";
-export { cmdSleep } from "../commands/shared/fleet-wake";
+export { cmdSleep, cmdWakeAll } from "../commands/shared/fleet-wake";
 export { cmdPulseAdd, cmdPulseLs } from "../commands/shared/pulse";
 export { cmdWake, fetchIssuePrompt, findWorktrees, detectSession } from "../commands/shared/wake";
 export { parseWakeTarget, ensureCloned } from "../commands/shared/wake-target";

--- a/src/vendor/mpr-plugins/restart/impl.ts
+++ b/src/vendor/mpr-plugins/restart/impl.ts
@@ -10,13 +10,9 @@
  *   4. Wake fleet (maw wake all)
  */
 
-import { listSessions } from "maw-js/sdk";
-import { Tmux } from "maw-js/sdk";
-import { cmdSleep, cmdWakeAll } from "maw-js/commands/shared/fleet";
+import { cmdSleep, cmdWakeAll, ghqFindSync, listSessions, mawDataPath, Tmux } from "maw-js/sdk";
 import { execSync } from "child_process";
 import { existsSync, mkdirSync, writeFileSync } from "fs";
-import { ghqFindSync } from "maw-js/core/ghq";
-import { mawDataPath } from "../../../core/xdg";
 
 const HELP_TEXT = [
   "usage: maw restart [--no-update] [--ref <git-ref>]",

--- a/src/vendor/mpr-plugins/restart/index.ts
+++ b/src/vendor/mpr-plugins/restart/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/sdk";
 import { cmdRestart } from "./impl";
 
 /** Dual-dispatcher ctx: old plugin/registry.ts passes InvokeContext;

--- a/test/isolated/plugin-restart-standalone.test.ts
+++ b/test/isolated/plugin-restart-standalone.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "../..");
+const restartDir = join(root, "src/vendor/mpr-plugins/restart");
+let sessions: Array<{ name: string; windows: Array<{ name: string }> }> = [];
+let killed: string[] = [];
+let slept = 0;
+let woke = 0;
+
+async function silenceConsole<T>(fn: () => Promise<T>): Promise<T> {
+  const orig = console.log;
+  console.log = () => {};
+  try { return await fn(); }
+  finally { console.log = orig; }
+}
+
+class MockTmux {
+  async killSession(name: string) { killed.push(name); }
+}
+
+const sdkMock = {
+  listSessions: async () => sessions,
+  Tmux: MockTmux,
+  cmdSleep: async () => { slept++; },
+  cmdWakeAll: async () => { woke++; },
+  ghqFindSync: () => null,
+  mawDataPath: (...parts: string[]) => join("/tmp/maw-data", ...parts),
+};
+
+mock.module("maw-js/sdk", () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
+
+const { command, default: restartHandler } = await import("../../src/vendor/mpr-plugins/restart/index.ts");
+const { cmdRestart } = await import("../../src/vendor/mpr-plugins/restart/impl.ts");
+
+function walkSources(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walkSources(full));
+    else if (entry.name.endsWith(".ts")) out.push(full);
+  }
+  return out;
+}
+
+function importSpecs(source: string): string[] {
+  const specs = new Set<string>();
+  const re = /\b(?:import|export)\s+(?:[^"'`]+?\s+from\s+)?["']([^"']+)["']|\bimport\(\s*["']([^"']+)["']\s*\)/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(source))) specs.add(match[1] ?? match[2]);
+  return [...specs];
+}
+
+beforeEach(() => {
+  sessions = [];
+  killed = [];
+  slept = 0;
+  woke = 0;
+});
+
+describe("restart plugin standalone boundary", () => {
+  test("all restart sources use SDK or platform/local imports only", () => {
+    const imports = walkSources(restartDir).flatMap((file) => importSpecs(readFileSync(file, "utf8")));
+    const forbidden = imports.filter((spec) =>
+      spec.startsWith("maw-js/core/")
+      || spec.startsWith("maw-js/commands/shared/")
+      || spec.startsWith("maw-js/cli/")
+      || spec === "maw-js/config"
+      || spec.startsWith("maw-js/config/")
+      || spec.startsWith("maw-js/plugin")
+      || spec.includes("../../../core"),
+    );
+
+    expect(command).toMatchObject({ name: "restart" });
+    expect(forbidden).toEqual([]);
+    expect(imports).toContain("maw-js/sdk");
+  });
+
+  test("help short-circuits before destructive restart work", async () => {
+    const cli = await silenceConsole(() => restartHandler({ source: "cli", args: ["--help"] } as any));
+    expect(cli).toMatchObject({ ok: true });
+    expect(cli?.output).toContain("usage: maw restart");
+
+    const newer = await silenceConsole(() => restartHandler(["-h"] as any));
+    expect(newer).toMatchObject({ ok: true });
+    expect(killed).toEqual([]);
+    expect(slept).toBe(0);
+    expect(woke).toBe(0);
+  });
+
+  test("--no-update path cleans stale sessions then sleeps and wakes fleet via SDK seams", async () => {
+    sessions = [
+      { name: "mawjs-view", windows: [{ name: "codex" }] },
+      { name: "maw-pty-123", windows: [{ name: "bash" }] },
+      { name: "all-bash", windows: [{ name: "bash" }, { name: "bash" }] },
+      { name: "healthy", windows: [{ name: "codex-5" }] },
+    ];
+
+    const result = await restartHandler({ source: "cli", args: ["--no-update"] } as any);
+
+    expect(result).toMatchObject({ ok: true });
+    expect(killed).toEqual(["mawjs-view", "maw-pty-123", "all-bash"]);
+    expect(slept).toBe(1);
+    expect(woke).toBe(1);
+    expect(result?.output).toContain("Update skipped");
+    expect(result?.output).toContain("restart complete");
+  });
+
+  test("cmdRestart help option is defensive and side-effect free", async () => {
+    await silenceConsole(() => cmdRestart({ help: true }));
+
+    expect(killed).toEqual([]);
+    expect(slept).toBe(0);
+    expect(woke).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add isolated standalone coverage for the restart plugin boundary and non-destructive help/no-update behavior
- route restart private fleet/ghq/xdg/plugin-type imports through `maw-js/sdk`
- add SDK exports needed by restart extraction (`cmdWakeAll`, source `mawDataPath`)

## Verification
- `rg -n "maw-js/(core|commands/shared|cli|config|lib|plugin)(/|\")|from ['\"](?:\.\./)+(?:core|commands|cli|config|lib|src)/|\.\./\.\./\.\./core" src/vendor/mpr-plugins/restart || true` (no output)
- `git diff --check origin/alpha...HEAD`
- `bun build src/vendor/mpr-plugins/restart/index.ts --outfile /tmp/restart-plugin.js --target=bun --external maw-js/sdk`
- `bun build test/isolated/plugin-restart-standalone.test.ts --outfile /tmp/plugin-restart-standalone.js --target=bun --external maw-js/sdk`
- `bun test test/isolated/plugin-restart-standalone.test.ts`
- `bun run build`

## Not tested
- real tmux restart, global bun update, SDK relink, or fleet sleep/wake side effects