### PR TITLE
test: standalone coverage for send plugins

### DIFF
--- a/packages/sdk/index.d.ts
+++ b/packages/sdk/index.d.ts
@@ -239,6 +239,7 @@ export declare function cmdPeek(query?: string): Promise<void>;
 
 /** Send a message to an oracle/window target. */
 export declare function cmdSend(target: string, message: string, force?: boolean): Promise<void>;
+export declare function resolveOraclePane(target: string): Promise<string>;
 export declare function cmdSplit(target: string, opts?: Record<string, unknown>): Promise<void>;
 
 // --- src/config ---

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -58,6 +58,7 @@ export { sparkline } from "../../src/lib/sparkline";
 // ─── src/commands/shared/comm ────────────────────────────────────────────────
 // Federation-aware communication helpers used by small command plugins.
 export { cmdPeek, cmdSend } from "../../src/commands/shared/comm";
+export { resolveOraclePane } from "../../src/commands/shared/comm-send";
 export { cmdSplit } from "../../src/commands/plugins/split/impl";
 
 // ─── src/config ──────────────────────────────────────────────────────────────

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -86,6 +86,7 @@ export {
 } from "../commands/shared/channel-loader";
 export type { ChannelPlugin, OracleChannelConfig } from "../commands/shared/channel-loader";
 export { scanSignals } from "../commands/shared/scan-signals";
+export { resolveOraclePane } from "../commands/shared/comm-send";
 export type { ScannedSignal } from "../commands/shared/scan-signals";
 
 // ─── Runtime ─────────────────────────────────────────────────────────────────

--- a/src/vendor/mpr-plugins/send-enter/impl.ts
+++ b/src/vendor/mpr-plugins/send-enter/impl.ts
@@ -12,9 +12,7 @@
  *   maw send-enter <target> --N 3    # send N Enters
  */
 
-import { listSessions, resolveTarget, tmux } from "maw-js/sdk";
-import { loadConfig } from "maw-js/config";
-import { resolveOraclePane } from "maw-js/commands/shared/comm-send";
+import { listSessions, loadConfig, resolveOraclePane, resolveTarget, tmux } from "maw-js/sdk";
 
 export interface SendEnterOpts {
   target: string;

--- a/src/vendor/mpr-plugins/send-enter/index.ts
+++ b/src/vendor/mpr-plugins/send-enter/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/sdk";
 import { cmdSendEnter, parseSendEnterArgs } from "./impl";
 
 export const command = {

--- a/src/vendor/mpr-plugins/send-text/impl.ts
+++ b/src/vendor/mpr-plugins/send-text/impl.ts
@@ -15,9 +15,7 @@
  *
  *   maw send-text <target> "<text>"
  */
-import { listSessions, resolveTarget, Tmux, curlFetch } from "maw-js/sdk";
-import { loadConfig } from "maw-js/config";
-import { resolveOraclePane } from "maw-js/commands/shared/comm-send";
+import { curlFetch, listSessions, loadConfig, resolveOraclePane, resolveTarget, Tmux } from "maw-js/sdk";
 
 export interface SendTextOpts {
   target: string;

--- a/src/vendor/mpr-plugins/send-text/index.ts
+++ b/src/vendor/mpr-plugins/send-text/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/sdk";
 import { cmdSendText, parseSendTextArgs } from "./impl";
 
 export const command = {

--- a/src/vendor/mpr-plugins/send/impl.ts
+++ b/src/vendor/mpr-plugins/send/impl.ts
@@ -13,9 +13,7 @@
  *   maw send <target> "<text>"
  */
 
-import { listSessions, resolveTarget, Tmux, curlFetch } from "maw-js/sdk";
-import { loadConfig } from "maw-js/config";
-import { resolveOraclePane } from "maw-js/commands/shared/comm-send";
+import { curlFetch, listSessions, loadConfig, resolveOraclePane, resolveTarget, Tmux } from "maw-js/sdk";
 
 export interface SendOpts {
   target: string;

--- a/src/vendor/mpr-plugins/send/index.ts
+++ b/src/vendor/mpr-plugins/send/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/sdk";
 import { cmdSend, parseSendArgs } from "./impl";
 
 export const command = {

--- a/test/isolated/plugin-send-enter-standalone.test.ts
+++ b/test/isolated/plugin-send-enter-standalone.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "../..");
+const pluginDir = join(root, "src/vendor/mpr-plugins/send-enter");
+let enterCalls: Array<{ target: string; key: string }> = [];
+let result: any = { type: "local", target: "mawjs:codex-5" };
+
+const sdkMock = {
+  loadConfig: () => ({}),
+  listSessions: async () => [{ name: "mawjs", windows: [{ name: "codex-5" }] }],
+  resolveTarget: () => result,
+  resolveOraclePane: async (target: string) => `${target}.pane`,
+  tmux: { sendKeys: async (target: string, key: string) => { enterCalls.push({ target, key }); } },
+  Tmux: class {},
+  curlFetch: async () => ({ ok: true, data: { ok: true } }),
+};
+mock.module("maw-js/sdk", () => sdkMock);
+
+const { command, default: handler } = await import("../../src/vendor/mpr-plugins/send-enter/index.ts");
+const { parseSendEnterArgs } = await import("../../src/vendor/mpr-plugins/send-enter/impl.ts");
+
+function importsOf(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...importsOf(full));
+    else if (entry.name.endsWith(".ts")) {
+      const source = readFileSync(full, "utf8");
+      const re = /\b(?:import|export)\s+(?:[^"'`]+?\s+from\s+)?["']([^"']+)["']|\bimport\(\s*["']([^"']+)["']\s*\)/g;
+      let match: RegExpExecArray | null;
+      while ((match = re.exec(source))) out.push(match[1] ?? match[2]);
+    }
+  }
+  return out;
+}
+
+beforeEach(() => {
+  enterCalls = [];
+  result = { type: "local", target: "mawjs:codex-5" };
+});
+
+describe("send-enter plugin standalone boundary", () => {
+  test("uses SDK or local/platform imports only", () => {
+    const imports = importsOf(pluginDir);
+    expect(command).toMatchObject({ name: "send-enter" });
+    expect(imports).toContain("maw-js/sdk");
+    expect(imports.filter((spec) =>
+      spec.startsWith("maw-js/core/") || spec.startsWith("maw-js/commands/shared/") || spec.startsWith("maw-js/plugin") || spec.startsWith("maw-js/config"),
+    )).toEqual([]);
+  });
+
+  test("parses target and count forms", () => {
+    expect(parseSendEnterArgs(["pane"])).toEqual({ target: "pane", count: 1 });
+    expect(parseSendEnterArgs(["--N", "3", "pane"])).toEqual({ target: "pane", count: 3 });
+    expect(parseSendEnterArgs(["pane", "--N=2"])).toEqual({ target: "pane", count: 2 });
+  });
+
+  test("local API invocation sends N enters through tmux", async () => {
+    const r = await handler({ source: "api", args: { target: "codex-5", count: 2 } } as any);
+    expect(r.ok).toBe(true);
+    expect(enterCalls).toEqual([
+      { target: "mawjs:codex-5.pane", key: "Enter" },
+      { target: "mawjs:codex-5.pane", key: "Enter" },
+    ]);
+    expect(r.output).toContain("2 Enters");
+  });
+
+  test("peer targets remain explicitly unsupported", async () => {
+    result = { type: "peer", node: "remote", target: "sess:win" };
+    const r = await handler({ source: "cli", args: ["remote"] } as any);
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain("cross-node target");
+    expect(enterCalls).toEqual([]);
+  });
+});

--- a/test/isolated/plugin-send-standalone.test.ts
+++ b/test/isolated/plugin-send-standalone.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "../..");
+const pluginDir = join(root, "src/vendor/mpr-plugins/send");
+let sentLiteral: Array<{ target: string; text: string }> = [];
+let fetchCalls: Array<{ url: string; opts: any }> = [];
+let result: any = { type: "local", target: "mawjs:codex-5" };
+
+class MockTmux {
+  async sendKeysLiteral(target: string, text: string) { sentLiteral.push({ target, text }); }
+}
+
+const sdkMock = {
+  loadConfig: () => ({ node: { name: "local" } }),
+  listSessions: async () => [{ name: "mawjs", windows: [{ name: "codex-5" }] }],
+  resolveTarget: () => result,
+  resolveOraclePane: async (target: string) => `${target}.pane`,
+  Tmux: MockTmux,
+  tmux: { sendKeys: async () => undefined },
+  curlFetch: async (url: string, opts: any) => {
+    fetchCalls.push({ url, opts });
+    return { ok: true, data: { ok: true, target: "peer:pane" } };
+  },
+};
+mock.module("maw-js/sdk", () => sdkMock);
+
+const { command, default: handler } = await import("../../src/vendor/mpr-plugins/send/index.ts");
+const { parseSendArgs } = await import("../../src/vendor/mpr-plugins/send/impl.ts");
+
+function importsOf(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...importsOf(full));
+    else if (entry.name.endsWith(".ts")) {
+      const source = readFileSync(full, "utf8");
+      const re = /\b(?:import|export)\s+(?:[^"'`]+?\s+from\s+)?["']([^"']+)["']|\bimport\(\s*["']([^"']+)["']\s*\)/g;
+      let match: RegExpExecArray | null;
+      while ((match = re.exec(source))) out.push(match[1] ?? match[2]);
+    }
+  }
+  return out;
+}
+
+beforeEach(() => {
+  sentLiteral = [];
+  fetchCalls = [];
+  result = { type: "local", target: "mawjs:codex-5" };
+});
+
+describe("send plugin standalone boundary", () => {
+  test("uses SDK or local/platform imports only", () => {
+    const imports = importsOf(pluginDir);
+    expect(command).toMatchObject({ name: "send" });
+    expect(imports).toContain("maw-js/sdk");
+    expect(imports.filter((spec) =>
+      spec.startsWith("maw-js/core/") || spec.startsWith("maw-js/commands/shared/") || spec.startsWith("maw-js/plugin") || spec.startsWith("maw-js/config"),
+    )).toEqual([]);
+  });
+
+  test("parses target plus raw text including dash args", () => {
+    expect(parseSendArgs(["pane", "ls", "-la", "/tmp"])).toEqual({ target: "pane", text: "ls -la /tmp" });
+    expect(() => parseSendArgs(["--flag"])).toThrow("usage: maw send");
+  });
+
+  test("local CLI invocation sends literal text without Enter", async () => {
+    const r = await handler({ source: "cli", args: ["codex-5", "hello", "world"] } as any);
+    expect(r.ok).toBe(true);
+    expect(sentLiteral).toEqual([{ target: "mawjs:codex-5.pane", text: "hello world" }]);
+    expect(r.output).toContain("typed");
+  });
+
+  test("peer target posts pane-keys without Enter", async () => {
+    result = { type: "peer", node: "remote", peerUrl: "http://remote", target: "sess:win" };
+    const r = await handler({ source: "api", args: { target: "remote", text: "hi" } } as any);
+    expect(r.ok).toBe(true);
+    expect(fetchCalls[0].url).toBe("http://remote/api/pane-keys");
+    expect(JSON.parse(fetchCalls[0].opts.body)).toEqual({ target: "sess:win", text: "hi", enter: false });
+  });
+});

--- a/test/isolated/plugin-send-text-standalone.test.ts
+++ b/test/isolated/plugin-send-text-standalone.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "../..");
+const pluginDir = join(root, "src/vendor/mpr-plugins/send-text");
+let sentText: Array<{ target: string; text: string }> = [];
+let fetchCalls: Array<{ url: string; opts: any }> = [];
+let result: any = { type: "local", target: "mawjs:codex-5" };
+
+class MockTmux {
+  async sendText(target: string, text: string) { sentText.push({ target, text }); }
+}
+
+const sdkMock = {
+  loadConfig: () => ({}),
+  listSessions: async () => [{ name: "mawjs", windows: [{ name: "codex-5" }] }],
+  resolveTarget: () => result,
+  resolveOraclePane: async (target: string) => `${target}.pane`,
+  Tmux: MockTmux,
+  tmux: { sendKeys: async () => undefined },
+  curlFetch: async (url: string, opts: any) => {
+    fetchCalls.push({ url, opts });
+    return { ok: true, data: { ok: true, target: "peer:pane" } };
+  },
+};
+mock.module("maw-js/sdk", () => sdkMock);
+
+const { command, default: handler } = await import("../../src/vendor/mpr-plugins/send-text/index.ts");
+const { parseSendTextArgs } = await import("../../src/vendor/mpr-plugins/send-text/impl.ts");
+
+function importsOf(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...importsOf(full));
+    else if (entry.name.endsWith(".ts")) {
+      const source = readFileSync(full, "utf8");
+      const re = /\b(?:import|export)\s+(?:[^"'`]+?\s+from\s+)?["']([^"']+)["']|\bimport\(\s*["']([^"']+)["']\s*\)/g;
+      let match: RegExpExecArray | null;
+      while ((match = re.exec(source))) out.push(match[1] ?? match[2]);
+    }
+  }
+  return out;
+}
+
+beforeEach(() => {
+  sentText = [];
+  fetchCalls = [];
+  result = { type: "local", target: "mawjs:codex-5" };
+});
+
+describe("send-text plugin standalone boundary", () => {
+  test("uses SDK or local/platform imports only", () => {
+    const imports = importsOf(pluginDir);
+    expect(command).toMatchObject({ name: "send-text" });
+    expect(imports).toContain("maw-js/sdk");
+    expect(imports.filter((spec) =>
+      spec.startsWith("maw-js/core/") || spec.startsWith("maw-js/commands/shared/") || spec.startsWith("maw-js/plugin") || spec.startsWith("maw-js/config"),
+    )).toEqual([]);
+  });
+
+  test("parses target plus text and rejects missing text", () => {
+    expect(parseSendTextArgs(["pane", "/awaken"])).toEqual({ target: "pane", text: "/awaken" });
+    expect(() => parseSendTextArgs(["pane"])).toThrow("text is required");
+  });
+
+  test("local CLI invocation sends text plus Enter through Tmux.sendText", async () => {
+    const r = await handler({ source: "cli", args: ["codex-5", "hello"] } as any);
+    expect(r.ok).toBe(true);
+    expect(sentText).toEqual([{ target: "mawjs:codex-5.pane", text: "hello" }]);
+    expect(r.output).toContain("sent");
+  });
+
+  test("peer target posts pane-keys with Enter", async () => {
+    result = { type: "peer", node: "remote", peerUrl: "http://remote", target: "sess:win" };
+    const r = await handler({ source: "api", args: { target: "remote", text: "hi" } } as any);
+    expect(r.ok).toBe(true);
+    expect(JSON.parse(fetchCalls[0].opts.body)).toEqual({ target: "sess:win", text: "hi", enter: true });
+  });
+});


### PR DESCRIPTION
## Summary
- add isolated standalone coverage for send, send-text, and send-enter plugins
- route send trio private config/comm/plugin-type imports through `maw-js/sdk`
- export `resolveOraclePane` through SDK barrels/declarations for plugin extraction

## Verification
- `rg -n "maw-js/(core|commands/shared|cli|config|lib|plugin)(/|\")|from ['\"](?:\.\./)+(?:core|commands|cli|config|lib|src)/|\.\./\.\./\.\./core" src/vendor/mpr-plugins/send src/vendor/mpr-plugins/send-text src/vendor/mpr-plugins/send-enter || true` (no output)
- `git diff --check origin/alpha...HEAD`
- `bun build src/vendor/mpr-plugins/send/index.ts --outfile /tmp/send-plugin.js --target=bun --external maw-js/sdk`
- `bun build src/vendor/mpr-plugins/send-text/index.ts --outfile /tmp/send-text-plugin.js --target=bun --external maw-js/sdk`
- `bun build src/vendor/mpr-plugins/send-enter/index.ts --outfile /tmp/send-enter-plugin.js --target=bun --external maw-js/sdk`
- `bun build` for all three new isolated test files with `--external maw-js/sdk`
- `bun test test/isolated/plugin-send-standalone.test.ts test/isolated/plugin-send-text-standalone.test.ts test/isolated/plugin-send-enter-standalone.test.ts`
- `bun run build`

## Not tested
- real tmux pane key injection or live cross-node pane-keys API