### PR TITLE
test: standalone coverage for inbox plugin

### DIFF
--- a/packages/sdk/index.d.ts
+++ b/packages/sdk/index.d.ts
@@ -240,6 +240,25 @@ export declare function cmdPeek(query?: string): Promise<void>;
 /** Send a message to an oracle/window target. */
 export declare function cmdSend(target: string, message: string, force?: boolean): Promise<void>;
 export declare function resolveOraclePane(target: string): Promise<string>;
+
+export interface PendingMessage {
+  id: string;
+  sender: string;
+  target: string;
+  message: string;
+  sentAt: string;
+  status: "pending" | "approved" | "rejected";
+  query?: string;
+}
+export declare const TTL_MS: number;
+export declare function pendingDir(): string;
+export declare function pendingPath(id: string): string;
+export declare function isExpired(msg: PendingMessage, now?: Date): boolean;
+export declare function savePending(input: { sender: string; target: string; message: string; query?: string }): PendingMessage;
+export declare function loadPending(): PendingMessage[];
+export declare function loadPendingById(id: string): PendingMessage | null;
+export declare function updatePending(id: string, patch: Partial<PendingMessage>): PendingMessage;
+export declare function deletePending(id: string): boolean;
 export declare function cmdSplit(target: string, opts?: Record<string, unknown>): Promise<void>;
 
 // --- src/config ---

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -59,6 +59,18 @@ export { sparkline } from "../../src/lib/sparkline";
 // Federation-aware communication helpers used by small command plugins.
 export { cmdPeek, cmdSend } from "../../src/commands/shared/comm";
 export { resolveOraclePane } from "../../src/commands/shared/comm-send";
+export {
+  deletePending,
+  isExpired,
+  loadPending,
+  loadPendingById,
+  pendingDir,
+  pendingPath,
+  savePending,
+  TTL_MS,
+  updatePending,
+} from "../../src/commands/shared/queue-store";
+export type { PendingMessage } from "../../src/commands/shared/queue-store";
 export { cmdSplit } from "../../src/commands/plugins/split/impl";
 
 // ─── src/config ──────────────────────────────────────────────────────────────

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -87,6 +87,18 @@ export {
 export type { ChannelPlugin, OracleChannelConfig } from "../commands/shared/channel-loader";
 export { scanSignals } from "../commands/shared/scan-signals";
 export { resolveOraclePane } from "../commands/shared/comm-send";
+export {
+  deletePending,
+  isExpired,
+  loadPending,
+  loadPendingById,
+  pendingDir,
+  pendingPath,
+  savePending,
+  TTL_MS,
+  updatePending,
+} from "../commands/shared/queue-store";
+export type { PendingMessage } from "../commands/shared/queue-store";
 export type { ScannedSignal } from "../commands/shared/scan-signals";
 
 // ─── Runtime ─────────────────────────────────────────────────────────────────

--- a/src/vendor/mpr-plugins/inbox/impl.ts
+++ b/src/vendor/mpr-plugins/inbox/impl.ts
@@ -1,16 +1,16 @@
 import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, statSync, utimesSync, writeFileSync } from "fs";
 import { homedir } from "os";
 import { basename, dirname, join } from "path";
-import { loadConfig } from "maw-js/config";
-import { ghqFind } from "maw-js/core/ghq";
-import { loadFleetEntries } from "maw-js/commands/shared/fleet-load";
 import {
   deletePending,
+  ghqFind,
+  loadConfig,
+  loadFleetEntries,
   loadPending,
   loadPendingById,
   updatePending,
   type PendingMessage,
-} from "maw-js/commands/shared/queue-store";
+} from "maw-js/sdk";
 
 // Re-export queue-store helpers so callers can import from one place.
 export {
@@ -23,8 +23,8 @@ export {
   pendingPath,
   isExpired,
   TTL_MS,
-} from "maw-js/commands/shared/queue-store";
-export type { PendingMessage } from "maw-js/commands/shared/queue-store";
+} from "maw-js/sdk";
+export type { PendingMessage } from "maw-js/sdk";
 
 // File naming: YYYY-MM-DD_HH-MM_<from>_<slug>.md
 // Frontmatter: from / to / timestamp / read
@@ -780,7 +780,7 @@ export async function cmdApprove(idOrPrefix: string): Promise<PendingMessage> {
   // Re-issue the send. Use the original query string when present (preserves
   // node prefix routing); fall back to target name otherwise.
   const query = updated.query ?? updated.target;
-  const { cmdSend } = await import("maw-js/commands/shared/comm-send");
+  const { cmdSend } = await import("maw-js/sdk");
   // Pass `force=true` plus a sentinel to bypass ACL on the second pass:
   // the human approval IS the gate — re-checking here would loop forever.
   process.env.MAW_ACL_BYPASS = "1";

--- a/src/vendor/mpr-plugins/inbox/index.ts
+++ b/src/vendor/mpr-plugins/inbox/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/sdk";
 import {
   cmdInboxLs,
   cmdInboxDrain,

--- a/test/isolated/plugin-inbox-standalone.test.ts
+++ b/test/isolated/plugin-inbox-standalone.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "../..");
+const pluginDir = join(root, "src/vendor/mpr-plugins/inbox");
+const tmpRoot = join(tmpdir(), `maw-inbox-standalone-${process.pid}`);
+const psiPath = join(tmpRoot, "psi");
+
+let pending: any[] = [];
+let deleted: string[] = [];
+let updated: Array<{ id: string; patch: any }> = [];
+let sent: Array<{ target: string; message: string; force?: boolean }> = [];
+let ghqCalls: string[] = [];
+
+const sdkMock = {
+  loadConfig: () => ({ psiPath, node: "codex-5", oracle: "codex-5" }),
+  ghqFind: async (pattern: string) => {
+    ghqCalls.push(pattern);
+    return null;
+  },
+  loadFleetEntries: () => [],
+  loadPending: () => pending,
+  loadPendingById: (id: string) => pending.find((msg) => msg.id === id) ?? null,
+  updatePending: (id: string, patch: any) => {
+    updated.push({ id, patch });
+    const msg = pending.find((item) => item.id === id);
+    if (!msg) throw new Error(`pending message not found: ${id}`);
+    Object.assign(msg, patch);
+    return msg;
+  },
+  deletePending: (id: string) => {
+    deleted.push(id);
+    pending = pending.filter((msg) => msg.id !== id);
+    return true;
+  },
+  savePending: (input: any) => {
+    const msg = { id: `p${pending.length + 1}`, sentAt: new Date(0).toISOString(), status: "pending", ...input };
+    pending.push(msg);
+    return msg;
+  },
+  pendingDir: () => join(tmpRoot, "state", "pending"),
+  pendingPath: (id: string) => join(tmpRoot, "state", "pending", `${id}.json`),
+  isExpired: () => false,
+  TTL_MS: 30 * 24 * 60 * 60 * 1000,
+  cmdSend: async (target: string, message: string, force?: boolean) => {
+    sent.push({ target, message, force });
+  },
+};
+
+mock.module("maw-js/sdk", () => sdkMock);
+
+const { command, default: handler } = await import("../../src/vendor/mpr-plugins/inbox/index.ts");
+const {
+  cmdInboxWrite,
+  cmdQueueList,
+  formatQueueDetail,
+  formatQueueList,
+  relativeTime,
+  resolvePendingId,
+} = await import("../../src/vendor/mpr-plugins/inbox/impl.ts");
+
+function importsOf(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...importsOf(full));
+    else if (entry.name.endsWith(".ts")) {
+      const source = readFileSync(full, "utf8");
+      const re = /\b(?:import|export)\s+(?:[^"'`]+?\s+from\s+)?["']([^"']+)["']|\bimport\(\s*["']([^"']+)["']\s*\)/g;
+      let match: RegExpExecArray | null;
+      while ((match = re.exec(source))) out.push(match[1] ?? match[2]);
+    }
+  }
+  return out;
+}
+
+beforeEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+  mkdirSync(join(psiPath, "inbox"), { recursive: true });
+  pending = [
+    { id: "abc123", sender: "m1", target: "codex-5", message: "hello from queue", sentAt: "2026-06-06T00:00:00.000Z", status: "pending", query: "codex-5" },
+    { id: "old999", sender: "m2", target: "codex-4", message: "already approved", sentAt: "2026-06-05T00:00:00.000Z", status: "approved" },
+  ];
+  deleted = [];
+  updated = [];
+  sent = [];
+  ghqCalls = [];
+});
+
+describe("inbox plugin standalone boundary (#2329)", () => {
+  test("uses SDK or local/platform imports only", () => {
+    const imports = importsOf(pluginDir);
+    const forbidden = imports.filter((spec) =>
+      spec.startsWith("maw-js/core/")
+      || spec.startsWith("maw-js/commands/shared/")
+      || spec.startsWith("maw-js/plugin")
+      || spec.startsWith("maw-js/config"),
+    );
+
+    expect(command).toMatchObject({ name: "inbox" });
+    expect(imports).toContain("maw-js/sdk");
+    expect(forbidden).toEqual([]);
+  });
+
+  test("queue helpers list pending rows and resolve exact or prefix ids", () => {
+    expect(cmdQueueList().map((msg: any) => msg.id)).toEqual(["abc123"]);
+    expect(resolvePendingId("abc123")?.message).toBe("hello from queue");
+    expect(resolvePendingId("abc")?.id).toBe("abc123");
+    expect(formatQueueList(cmdQueueList())).toContain("hello from queue");
+    expect(formatQueueDetail(pending[0])).toContain("query:   codex-5");
+  });
+
+  test("handler pending/show/reject paths stay inside SDK queue seams", async () => {
+    const listed = await handler({ source: "cli", args: ["pending"] } as any);
+    expect(listed.ok).toBe(true);
+    expect(listed.output).toContain("abc123");
+
+    const shown = await handler({ source: "cli", args: ["show-pending", "abc"] } as any);
+    expect(shown.ok).toBe(true);
+    expect(shown.output).toContain("message:");
+
+    const rejected = await handler({ source: "cli", args: ["reject", "abc"] } as any);
+    expect(rejected.ok).toBe(true);
+    expect(updated).toEqual([{ id: "abc123", patch: { status: "rejected" } }]);
+    expect(deleted).toEqual(["abc123"]);
+  });
+
+  test("approve marks approved, sends through SDK cmdSend, then deletes", async () => {
+    const approved = await handler({ source: "cli", args: ["approve", "abc"] } as any);
+
+    expect(approved.ok).toBe(true);
+    expect(updated).toEqual([{ id: "abc123", patch: { status: "approved" } }]);
+    expect(sent).toEqual([{ target: "codex-5", message: "hello from queue", force: undefined }]);
+    expect(deleted).toEqual(["abc123"]);
+  });
+
+  test("local inbox write and relative time are non-destructive and deterministic", async () => {
+    await cmdInboxWrite("standalone note");
+    const files = readdirSync(join(psiPath, "inbox")).filter((name) => name.endsWith(".md"));
+    expect(files).toHaveLength(1);
+    expect(readFileSync(join(psiPath, "inbox", files[0]), "utf8")).toContain("standalone note");
+    expect(relativeTime(new Date(0))).toBe("—");
+    expect(relativeTime(new Date(Date.now() + 1000))).toBe("future");
+  });
+});


### PR DESCRIPTION
Closes #2329

## Summary
- add isolated standalone coverage for inbox plugin boundary, queue helpers, pending handler paths, approve path, and local inbox write
- route inbox private config/ghq/fleet-load/queue-store/plugin-type imports through `maw-js/sdk`
- export queue-store helpers/types through SDK barrels/declarations

## Verification
- `rg -n "maw-js/(core|commands/shared|cli|config|lib|plugin)(/|\")|from ['\"](?:\.\./)+(?:core|commands|cli|config|lib|src)/|\.\./\.\./\.\./core" src/vendor/mpr-plugins/inbox || true` (no output)
- `git diff --check origin/alpha...HEAD`
- `bun build src/vendor/mpr-plugins/inbox/index.ts --outfile /tmp/inbox-plugin.js --target=bun --external maw-js/sdk`
- `bun build test/isolated/plugin-inbox-standalone.test.ts --outfile /tmp/plugin-inbox-standalone.js --target=bun --external maw-js/sdk`
- `bun test test/isolated/plugin-inbox-standalone.test.ts`
- `bun run build`

## Not tested
- live cross-node approval delivery, fleet-wide status scans, or real operator queue files