### PR TITLE
test(doctor): lock standalone boundary

### DIFF
--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -26,7 +26,17 @@ export {
 } from "../config";
 export { DEFAULT_ENGINES, resolveEngine } from "../config/engine-registry";
 export { getGhqRoot } from "../config/ghq-root";
-export { mawConfigDir, mawDataPath, mawMessageLogPath } from "../core/xdg";
+export {
+  isMawXdgEnabled,
+  legacyMawPath,
+  mawCacheDir,
+  mawConfigDir,
+  mawDataDir,
+  mawDataPath,
+  mawMessageLogPath,
+  mawStateDir,
+  mawStatePath,
+} from "../core/xdg";
 export type { EngineDef } from "../config/engine-def";
 export type { EngineRegistry } from "../config/engine-registry";
 export type { TScope } from "../lib/schemas";
@@ -178,6 +188,7 @@ export { registerCommand, matchCommand, listCommands } from "../cli/command-regi
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
+export { C } from "../commands/shared/fleet-doctor-fixer";
 export { parseFlags } from "../cli/parse-args";
 export {
   cmdWorkspaceCreate,
@@ -197,7 +208,6 @@ export { writeSignal } from "../core/fleet/leaf";
 export { validateNickname, writeNickname, setCachedNickname } from "../core/fleet/nicknames";
 export { sparkline } from "../lib/sparkline";
 export { tlink } from "../core/util/terminal";
-export { legacyMawPath, mawStatePath } from "../core/xdg";
 
 // Plugin extraction helpers for tab-like command surfaces.
 export { cmdPeek, cmdSend } from "../commands/shared/comm";

--- a/src/vendor/mpr-plugins/doctor/cross-source-detect.ts
+++ b/src/vendor/mpr-plugins/doctor/cross-source-detect.ts
@@ -30,7 +30,7 @@
  * `--allow-drift` for normal mid-migration states, defeating the purpose.
  */
 
-import type { OracleManifestEntry } from "maw-js/lib/oracle-manifest";
+import type { OracleManifestEntry } from "maw-js/sdk";
 
 /** One inconsistency flagged across the 5 registries for a single oracle. */
 export interface CrossSourceGap {

--- a/src/vendor/mpr-plugins/doctor/impl.ts
+++ b/src/vendor/mpr-plugins/doctor/impl.ts
@@ -4,18 +4,19 @@ import { homedir } from "os";
 import { join, dirname, resolve } from "path";
 import { loadPeers } from "./internal/peers-store";
 import { findDuplicateIdentities, formatDuplicate } from "./internal/duplicate-detect";
-import { loadConfig } from "maw-js/config";
-import { C } from "maw-js/commands/shared/fleet-doctor-fixer";
 import {
+  C,
+  invalidateManifest,
   isMawXdgEnabled,
+  legacyMawPath,
+  loadConfig,
+  loadManifestCached,
   mawCacheDir,
   mawConfigDir,
   mawDataDir,
   mawDataPath,
   mawStateDir,
-  legacyMawPath,
-} from "../../../core/xdg";
-import { loadManifestCached, invalidateManifest } from "maw-js/lib/oracle-manifest";
+} from "maw-js/sdk";
 import { findGaps, summarizeGaps } from "./cross-source-detect";
 import { checkMawJsBranch } from "./internal/maw-js-branch-check";
 import { checkStillbornWorktrees } from "./internal/stillborn-worktrees";

--- a/src/vendor/mpr-plugins/doctor/index.ts
+++ b/src/vendor/mpr-plugins/doctor/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/sdk";
 import { cmdDoctor } from "./impl";
 
 export const command = {

--- a/src/vendor/mpr-plugins/doctor/internal/peers-store.ts
+++ b/src/vendor/mpr-plugins/doctor/internal/peers-store.ts
@@ -30,7 +30,7 @@
  */
 import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync, unlinkSync } from "fs";
 import { dirname } from "path";
-import { legacyMawPath, mawStatePath } from "../../../../core/xdg";
+import { legacyMawPath, mawStatePath } from "maw-js/sdk";
 import { withPeersLock } from "./lock";
 
 /**

--- a/src/vendor/mpr-plugins/doctor/internal/stale-peers.ts
+++ b/src/vendor/mpr-plugins/doctor/internal/stale-peers.ts
@@ -24,7 +24,7 @@
  * exclude. (Contrast with `cleanup --zombie-agents`, which had to
  * exclude the operator's live primary pane.)
  */
-import { C } from "maw-js/commands/shared/fleet-doctor-fixer";
+import { C } from "maw-js/sdk";
 import {
   loadPeers,
   mutatePeers,

--- a/test/isolated/plugin-doctor-standalone.test.ts
+++ b/test/isolated/plugin-doctor-standalone.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const root = join(import.meta.dir, "../..");
+const doctorDir = join(root, "src/vendor/mpr-plugins/doctor");
+
+let tmpRoot = "";
+let config: Record<string, unknown> = {};
+let manifestEntries: unknown[] = [];
+let invalidated = 0;
+
+const C = {
+  green: "",
+  yellow: "",
+  red: "",
+  gray: "",
+  reset: "",
+};
+
+function tmpPath(...parts: string[]) {
+  return join(tmpRoot || tmpdir(), ...parts);
+}
+
+const sdkMock = {
+  C,
+  loadConfig: () => config,
+  invalidateManifest: () => { invalidated += 1; },
+  loadManifestCached: () => manifestEntries,
+  isMawXdgEnabled: () => true,
+  legacyMawPath: (...parts: string[]) => tmpPath("legacy-maw", ...parts),
+  mawCacheDir: () => tmpPath("cache"),
+  mawConfigDir: () => tmpPath("config"),
+  mawDataDir: () => tmpPath("data"),
+  mawDataPath: (...parts: string[]) => tmpPath("data", ...parts),
+  mawStateDir: () => tmpPath("state"),
+  mawStatePath: (...parts: string[]) => tmpPath("state", ...parts),
+};
+
+mock.module("maw-js/sdk", () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
+mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/doctor/internal/maw-js-branch-check.ts"), () => ({
+  checkMawJsBranch: async () => ({ name: "maw-js:branch", ok: true, message: "mock branch ok" }),
+}));
+mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/doctor/internal/stillborn-worktrees.ts"), () => ({
+  checkStillbornWorktrees: () => ({ name: "worktrees:stillborn", ok: true, message: "mock worktrees ok" }),
+}));
+mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/doctor/internal/bun-link-detect.ts"), () => ({
+  detectBunLinkedCheckout: () => null,
+}));
+
+const { command, default: doctorHandler } = await import("../../src/vendor/mpr-plugins/doctor/index.ts?plugin-doctor-standalone");
+const peersStore = await import("../../src/vendor/mpr-plugins/doctor/internal/peers-store.ts?plugin-doctor-standalone");
+
+function walkSources(dir: string): string[] {
+  const { readdirSync } = require("node:fs");
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walkSources(full));
+    else if (entry.name.endsWith(".ts")) out.push(full);
+  }
+  return out;
+}
+
+function importSpecs(source: string): string[] {
+  const specs = new Set<string>();
+  const re = /\b(?:import|export)\s+(?:[^"'`]+?\s+from\s+)?["']([^"']+)["']|\bimport\(\s*["']([^"']+)["']\s*\)/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(source))) specs.add(match[1] ?? match[2]);
+  return [...specs];
+}
+
+function stripAnsi(value: string | undefined) {
+  return String(value ?? "").replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "");
+}
+
+beforeEach(() => {
+  tmpRoot = join(tmpdir(), `maw-doctor-standalone-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  mkdirSync(tmpPath("state"), { recursive: true });
+  config = { oracle: "local", node: "home" };
+  manifestEntries = [];
+  invalidated = 0;
+  process.env.PEERS_FILE = tmpPath("state", "peers.json");
+  process.env.MAW_TEST_MODE = "1";
+  process.env.MAW_PEER_STALE_TTL_MS = String(24 * 60 * 60 * 1000);
+});
+
+afterEach(() => {
+  delete process.env.PEERS_FILE;
+  delete process.env.MAW_TEST_MODE;
+  delete process.env.MAW_PEER_STALE_TTL_MS;
+  if (tmpRoot) rmSync(tmpRoot, { recursive: true, force: true });
+  tmpRoot = "";
+});
+
+describe("doctor plugin standalone boundary (#2328)", () => {
+  test("all doctor sources use SDK or local/platform imports only", () => {
+    const imports = walkSources(doctorDir).flatMap((file) => importSpecs(readFileSync(file, "utf8")));
+    const forbidden = imports.filter((spec) =>
+      spec.startsWith("maw-js/core/")
+      || spec.startsWith("maw-js/commands/shared/")
+      || spec.startsWith("maw-js/lib/")
+      || spec.startsWith("maw-js/config")
+      || spec.startsWith("maw-js/plugin")
+      || spec.includes("../../../core")
+      || spec.includes("../../../../core"),
+    );
+
+    expect(command).toMatchObject({ name: "doctor" });
+    expect(forbidden).toEqual([]);
+    expect(imports).toContain("maw-js/sdk");
+
+    const sdk = readFileSync(join(root, "src/sdk/index.ts"), "utf8");
+    for (const symbol of ["C", "loadConfig", "loadManifestCached", "invalidateManifest", "mawStatePath", "isMawXdgEnabled", "mawCacheDir"]) {
+      expect(sdk).toContain(symbol);
+    }
+  });
+
+  test("API peers check runs through SDK-backed config and peer store", async () => {
+    peersStore.savePeers({
+      version: 1,
+      peers: {
+        alpha: {
+          url: "http://alpha.local",
+          node: "alpha-node",
+          addedAt: new Date().toISOString(),
+          lastSeen: new Date().toISOString(),
+          identity: { oracle: "remote", node: "alpha" },
+        },
+      },
+    });
+
+    const result = await doctorHandler({ source: "api", args: { check: "peers" } } as any);
+
+    expect(result.ok).toBe(true);
+    const output = stripAnsi(result.output);
+    expect(output).toContain("peers:duplicates: no <oracle>:<node> collisions across 1 peer");
+    expect(output).toContain("peers:stale: no stale peers");
+  });
+
+  test("CLI --fix-stale removes stale peers through the plugin-local store", async () => {
+    const now = Date.now();
+    peersStore.savePeers({
+      version: 1,
+      peers: {
+        stale: {
+          url: "http://stale.local",
+          node: "stale-node",
+          addedAt: new Date(now - 3 * 24 * 60 * 60 * 1000).toISOString(),
+          lastSeen: null,
+        },
+        fresh: {
+          url: "http://fresh.local",
+          node: "fresh-node",
+          addedAt: new Date(now).toISOString(),
+          lastSeen: new Date(now).toISOString(),
+        },
+      },
+    });
+
+    const result = await doctorHandler({ source: "cli", args: ["--fix-stale"] } as any);
+
+    expect(result.ok).toBe(true);
+    expect(stripAnsi(result.output)).toContain("peers:fix-stale: removed 1 stale peer");
+    expect(Object.keys(peersStore.loadPeers().peers)).toEqual(["fresh"]);
+  });
+
+  test("manifest check uses SDK manifest helpers", async () => {
+    const result = await doctorHandler({ source: "cli", args: ["manifest"] } as any);
+
+    expect(result.ok).toBe(true);
+    expect(invalidated).toBe(1);
+    expect(stripAnsi(result.output)).toContain("manifest:cross-source");
+  });
+});


### PR DESCRIPTION
## Summary
- add `plugin-doctor-standalone` isolated boundary coverage for #2328
- route doctor plugin imports for config, XDG paths, manifest helpers, and color constants through `maw-js/sdk`
- exercise peers, stale-peer cleanup, and manifest paths through SDK mocks

## Verification
- `BUN_INSTALL=/Users/nat/.bun PATH=/Users/nat/.bun/install/cache/@oven/bun-darwin-aarch64@1.3.13@@@1/bin:$PATH bash scripts/test-isolated.sh test/isolated/plugin-doctor-standalone.test.ts test/isolated/doctor-impl-second-pass-coverage.test.ts test/isolated/vendor-doctor-peers-store-coverage.test.ts test/isolated/stale-peers-coverage.test.ts`
- `BUN_INSTALL=/Users/nat/.bun PATH=/Users/nat/.bun/install/cache/@oven/bun-darwin-aarch64@1.3.13@@@1/bin:$PATH bun --check src/vendor/mpr-plugins/doctor/index.ts src/vendor/mpr-plugins/doctor/impl.ts src/vendor/mpr-plugins/doctor/cross-source-detect.ts src/vendor/mpr-plugins/doctor/internal/peers-store.ts src/vendor/mpr-plugins/doctor/internal/stale-peers.ts src/sdk/index.ts`

Closes #2328.
