### PR TITLE
test: gate plugin extraction coverage drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,25 @@ on:
     branches: [alpha, main]
 
 jobs:
+  plugin-coverage-gate:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
+
+      - name: Require plugin extraction boundary tests
+        run: bun scripts/check-plugin-coverage-gate.ts origin/${{ github.base_ref }}
+
   test:
     runs-on: ubuntu-latest
+    needs: plugin-coverage-gate
+    if: always() && (needs.plugin-coverage-gate.result == 'success' || needs.plugin-coverage-gate.result == 'skipped')
     strategy:
       fail-fast: false
       matrix:

--- a/scripts/check-plugin-coverage-gate.ts
+++ b/scripts/check-plugin-coverage-gate.ts
@@ -1,0 +1,143 @@
+#!/usr/bin/env bun
+/**
+ * check-plugin-coverage-gate.ts — PR guardrail for #2316.
+ *
+ * Problem: vendor plugin extractions repeatedly move runtime imports from
+ * core/shared/config internals to the SDK boundary, then old implementation
+ * coverage tests break until their mocks are realigned. This gate makes that
+ * coupling explicit: when a PR changes a vendor plugin or the SDK boundary, it
+ * must also update the matching standalone-boundary tests/pattern.
+ *
+ * Usage:
+ *   bun scripts/check-plugin-coverage-gate.ts origin/alpha
+ *   bun scripts/check-plugin-coverage-gate.ts --files <changed-file>...
+ */
+
+import { existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+
+const STANDALONE_TEST_RE = /^test\/isolated\/plugin-[^/]+-standalone\.test\.ts$/;
+const BOUNDARY_PATTERN_FILES = new Set([
+  "test/isolated/helpers/plugin-standalone-boundary.ts",
+  "scripts/check-plugin-coverage-gate.ts",
+]);
+
+type GateResult = {
+  ok: boolean;
+  pluginChanges: Map<string, string[]>;
+  sdkChanges: string[];
+  testChanges: string[];
+  failures: string[];
+};
+
+function runGit(args: string[]): string {
+  const proc = spawnSync("git", args, { encoding: "utf8" });
+  if (proc.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${proc.stderr || proc.stdout}`.trim());
+  }
+  return proc.stdout.trim();
+}
+
+function changedFilesFromGit(baseRef?: string): string[] {
+  const base = baseRef || process.env.GITHUB_BASE_REF && `origin/${process.env.GITHUB_BASE_REF}` || "origin/alpha";
+  const mergeBase = runGit(["merge-base", base, "HEAD"]);
+  const committed = runGit(["diff", "--name-only", `${mergeBase}...HEAD`]);
+  const unstaged = runGit(["diff", "--name-only"]);
+  const staged = runGit(["diff", "--cached", "--name-only"]);
+  const untracked = runGit(["ls-files", "--others", "--exclude-standard"]);
+  return [...new Set([committed, staged, unstaged, untracked]
+    .flatMap((output) => output.split(/\r?\n/))
+    .map((line) => line.trim())
+    .filter(Boolean))];
+}
+
+function isRuntimeSource(path: string): boolean {
+  return /\.(?:ts|tsx|js|json)$/.test(path) && !path.endsWith(".d.ts");
+}
+
+function standaloneTestFor(plugin: string): string {
+  return `test/isolated/plugin-${plugin}-standalone.test.ts`;
+}
+
+function analyzeChangedFiles(files: string[]): GateResult {
+  const pluginChanges = new Map<string, string[]>();
+  const sdkChanges: string[] = [];
+  const testChanges = files.filter((file) => STANDALONE_TEST_RE.test(file) || BOUNDARY_PATTERN_FILES.has(file));
+  const failures: string[] = [];
+
+  for (const file of files) {
+    if (!isRuntimeSource(file)) continue;
+
+    const pluginMatch = file.match(/^src\/vendor\/mpr-plugins\/([^/]+)\//);
+    if (pluginMatch) {
+      const plugin = pluginMatch[1];
+      if (!pluginChanges.has(plugin)) pluginChanges.set(plugin, []);
+      pluginChanges.get(plugin)!.push(file);
+      continue;
+    }
+
+    if (file.startsWith("src/sdk/") || file === "src/sdk.ts") {
+      sdkChanges.push(file);
+    }
+  }
+
+  for (const [plugin, changed] of pluginChanges) {
+    const test = standaloneTestFor(plugin);
+    if (!existsSync(test)) {
+      failures.push(
+        `${plugin}: changed ${changed.length} vendor file(s) but ${test} does not exist. ` +
+        `Add the standalone boundary test instead of relying on brittle implementation coverage mocks.`,
+      );
+      continue;
+    }
+    if (!files.includes(test) && !testChanges.some((file) => BOUNDARY_PATTERN_FILES.has(file))) {
+      failures.push(
+        `${plugin}: changed ${changed.length} vendor file(s) without updating ${test}. ` +
+        `If behavior is unchanged, refresh the boundary assertion/import mocks so extraction drift is explicit.`,
+      );
+    }
+  }
+
+  if (sdkChanges.length > 0 && testChanges.length === 0) {
+    failures.push(
+      `SDK boundary changed (${sdkChanges.join(", ")}) without any plugin standalone-boundary test or helper update. ` +
+      `Update at least one test/isolated/plugin-*-standalone.test.ts or the boundary helper so SDK mock drift is covered.`,
+    );
+  }
+
+  return { ok: failures.length === 0, pluginChanges, sdkChanges, testChanges, failures };
+}
+
+function printSummary(result: GateResult, files: string[]): void {
+  console.log(`plugin coverage gate: ${files.length} changed file(s)`);
+  if (result.pluginChanges.size > 0) {
+    console.log(`vendor plugins touched: ${[...result.pluginChanges.keys()].sort().join(", ")}`);
+  }
+  if (result.sdkChanges.length > 0) {
+    console.log(`sdk boundary files touched: ${result.sdkChanges.join(", ")}`);
+  }
+  if (result.testChanges.length > 0) {
+    console.log(`boundary tests/helpers touched: ${result.testChanges.join(", ")}`);
+  }
+}
+
+function parseArgs(argv: string[]): { files?: string[]; base?: string } {
+  if (argv[0] === "--files") return { files: argv.slice(1) };
+  return { base: argv[0] };
+}
+
+if (import.meta.main) {
+  const { files: explicitFiles, base } = parseArgs(process.argv.slice(2));
+  const files = explicitFiles ?? changedFilesFromGit(base);
+  const result = analyzeChangedFiles(files);
+  printSummary(result, files);
+  if (!result.ok) {
+    console.error("\n✗ plugin coverage gate failed (#2316):");
+    for (const failure of result.failures) console.error(`  - ${failure}`);
+    console.error("\nFix: update/create the matching plugin-*-standalone.test.ts and use test/isolated/helpers/plugin-standalone-boundary.ts for import-boundary assertions.");
+    process.exit(1);
+  }
+  console.log("✓ plugin coverage gate passed");
+}
+
+export { analyzeChangedFiles, changedFilesFromGit, standaloneTestFor };

--- a/test/isolated/helpers/plugin-standalone-boundary.ts
+++ b/test/isolated/helpers/plugin-standalone-boundary.ts
@@ -1,0 +1,101 @@
+import { expect } from "bun:test";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+type ImportRecord = {
+  spec: string;
+  typeOnly: boolean;
+};
+
+type BoundaryOptions = {
+  plugin: string;
+  root?: string;
+  files?: string[];
+  requireSdk?: boolean;
+  allowMawJs?: Array<string | RegExp>;
+  allowRelative?: Array<string | RegExp>;
+};
+
+const DEFAULT_ALLOWED_MAW_JS: Array<string | RegExp> = [
+  "maw-js/sdk",
+  /^maw-js\/plugin\/types$/,
+  /^maw-js\/cli\/parse-args$/,
+];
+
+function repoRootFromTest(): string {
+  return join(import.meta.dir, "../../..");
+}
+
+function walkTsFiles(dir: string, out: string[] = []): string[] {
+  if (!existsSync(dir)) return out;
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      walkTsFiles(full, out);
+    } else if (/\.tsx?$/.test(name) && !name.endsWith(".d.ts")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function pluginSourceFiles(plugin: string, root = repoRootFromTest(), files?: string[]): string[] {
+  const dir = join(root, "src/vendor/mpr-plugins", plugin);
+  return files?.map((file) => join(dir, file)) ?? walkTsFiles(dir).sort();
+}
+
+function parseImportRecords(source: string): ImportRecord[] {
+  const records: ImportRecord[] = [];
+  const staticImport = /\b(import|export)\s+(type\s+)?(?:[^"'`]+?\s+from\s+)?["']([^"']+)["']/g;
+  const importFn = /\bimport\(\s*["']([^"']+)["']\s*\)/g;
+  const requireFn = /\brequire\(\s*["']([^"']+)["']\s*\)/g;
+
+  let match: RegExpExecArray | null;
+  while ((match = staticImport.exec(source)) !== null) {
+    records.push({ spec: match[3], typeOnly: Boolean(match[2]) });
+  }
+  while ((match = importFn.exec(source)) !== null) records.push({ spec: match[1], typeOnly: false });
+  while ((match = requireFn.exec(source)) !== null) records.push({ spec: match[1], typeOnly: false });
+  return records;
+}
+
+function matchesAny(value: string, patterns: Array<string | RegExp>): boolean {
+  return patterns.some((pattern) => typeof pattern === "string" ? value === pattern : pattern.test(value));
+}
+
+function collectPluginImports(options: BoundaryOptions): ImportRecord[] {
+  return pluginSourceFiles(options.plugin, options.root, options.files)
+    .flatMap((file) => parseImportRecords(readFileSync(file, "utf8")));
+}
+
+function expectStandalonePluginBoundary(options: BoundaryOptions): ImportRecord[] {
+  const imports = collectPluginImports(options);
+  const allowMawJs = [...DEFAULT_ALLOWED_MAW_JS, ...(options.allowMawJs ?? [])];
+  const allowRelative = options.allowRelative ?? [];
+
+  const forbiddenMawJs = imports
+    .filter((record) => record.spec.startsWith("maw-js/"))
+    .filter((record) => !record.typeOnly)
+    .filter((record) => !matchesAny(record.spec, allowMawJs))
+    .map((record) => record.spec);
+
+  const forbiddenRelative = imports
+    .filter((record) => /^(?:\.\.\/)+(?:core|commands|cli|config|lib|plugin|src)(?:\/|$)/.test(record.spec))
+    .filter((record) => !matchesAny(record.spec, allowRelative))
+    .map((record) => record.spec);
+
+  expect(forbiddenMawJs).toEqual([]);
+  expect(forbiddenRelative).toEqual([]);
+  if (options.requireSdk ?? true) {
+    expect(imports.map((record) => record.spec)).toContain("maw-js/sdk");
+  }
+  return imports;
+}
+
+export {
+  collectPluginImports,
+  expectStandalonePluginBoundary,
+  parseImportRecords,
+  pluginSourceFiles,
+};

--- a/test/isolated/plugin-absorb-standalone.test.ts
+++ b/test/isolated/plugin-absorb-standalone.test.ts
@@ -1,10 +1,11 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
-import { mkdirSync, readFileSync } from "node:fs";
+import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { loadManifestFromDir } from "../../src/plugin/manifest-load";
 import { invokePlugin } from "../../src/plugin/registry-invoke";
 import type { LoadedPlugin } from "../../src/plugin/types";
+import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
 
 const ROOT = new URL("../..", import.meta.url).pathname;
 const pluginDir = join(ROOT, "src/vendor/mpr-plugins/absorb");
@@ -54,18 +55,6 @@ mock.module(syncHelpersPath, () => ({
 }));
 
 
-function parseImportSpecs(source: string): string[] {
-  const specs = new Set<string>();
-  const importFrom = /\b(?:import|export)\s+(?:[^"'`]+?\s+from\s+)?["']([^"']+)["']/g;
-  const importFn = /\bimport\(\s*["']([^"']+)["']\s*\)/g;
-  const requireFn = /\brequire\(\s*["']([^"']+)["']\s*\)/g;
-  for (const re of [importFrom, importFn, requireFn]) {
-    let m: RegExpExecArray | null;
-    while ((m = re.exec(source)) !== null) specs.add(m[1]);
-  }
-  return [...specs];
-}
-
 function entry(name: string, repo?: string): FleetEntry {
   return {
     file: `${name}.json`,
@@ -106,10 +95,12 @@ beforeEach(() => {
 
 describe("absorb plugin standalone boundary (#2221)", () => {
   test("plugin sources stay off direct core/shared/lib/config imports", () => {
-    const files = ["index.ts", "impl.ts"].map((file) => readFileSync(join(pluginDir, file), "utf8"));
-    const imports = files.flatMap(parseImportSpecs);
+    const imports = expectStandalonePluginBoundary({
+      plugin: "absorb",
+      files: ["index.ts", "impl.ts"],
+      allowRelative: ["../archive/impl", "../soul-sync/resolve", "../soul-sync/sync-helpers"],
+    }).map((record) => record.spec);
 
-    expect(imports.filter((spec) => spec.startsWith("maw-js/core/") || spec.startsWith("maw-js/commands/shared/") || spec.startsWith("maw-js/lib/") || spec === "maw-js/config" || spec.startsWith("maw-js/config/"))).toEqual([]);
     expect(imports).toEqual(expect.arrayContaining(["maw-js/plugin/types", "maw-js/sdk", "../archive/impl", "../soul-sync/resolve", "../soul-sync/sync-helpers"]));
   });
 

--- a/test/isolated/plugin-costs-standalone.test.ts
+++ b/test/isolated/plugin-costs-standalone.test.ts
@@ -1,8 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
 
-const root = join(import.meta.dir, "../..");
+import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
+
 let config: Record<string, unknown> = { host: "local", port: 4242 };
 let fetchCalls: string[] = [];
 let responseBody = "";
@@ -46,6 +45,7 @@ const sdkMock = {
 };
 
 mock.module("maw-js/sdk", () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk"), () => sdkMock);
 mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
 
 const { default: costsHandler, command } = await import("../../src/vendor/mpr-plugins/costs/index.ts");
@@ -75,18 +75,10 @@ beforeEach(() => {
 
 describe("costs plugin standalone boundary", () => {
   test("imports runtime helpers only through the SDK boundary", () => {
-    const indexSource = readFileSync(join(root, "src/vendor/mpr-plugins/costs/index.ts"), "utf8");
-    const implSource = readFileSync(join(root, "src/vendor/mpr-plugins/costs/impl.ts"), "utf8");
-    const combined = `${indexSource}\n${implSource}`;
+    const imports = expectStandalonePluginBoundary({ plugin: "costs", files: ["index.ts", "impl.ts"] });
 
     expect(command).toMatchObject({ name: "costs" });
-    expect(combined).toContain('from "maw-js/sdk"');
-    expect(combined).not.toMatch(/maw-js\/(?:core|commands\/shared|cli|config|lib|plugin)(?:\/|")/);
-    expect(combined).not.toMatch(/from\s+["'](?:\.\.\/)+(?:core|commands|cli|config|lib|src)\//);
-
-    const sdkSource = readFileSync(join(root, "src/sdk/index.ts"), "utf8");
-    expect(sdkSource).toContain("../core/util/user-error");
-    expect(sdkSource).toContain("../lib/sparkline");
+    expect(imports.map((record) => record.spec)).toEqual(expect.arrayContaining(["maw-js/sdk"]));
   });
 
   test("default CLI view fetches aggregate costs from the configured maw server", async () => {

--- a/test/isolated/plugin-coverage-gate.test.ts
+++ b/test/isolated/plugin-coverage-gate.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+
+import { analyzeChangedFiles } from "../../scripts/check-plugin-coverage-gate";
+
+describe("plugin coverage gate (#2316)", () => {
+  test("requires matching standalone test when a vendor plugin changes", () => {
+    const result = analyzeChangedFiles(["src/vendor/mpr-plugins/costs/impl.ts"]);
+
+    expect(result.ok).toBe(false);
+    expect(result.failures.join("\n")).toContain("plugin-costs-standalone.test.ts");
+  });
+
+  test("accepts plugin changes when the matching standalone test changes too", () => {
+    const result = analyzeChangedFiles([
+      "src/vendor/mpr-plugins/costs/impl.ts",
+      "test/isolated/plugin-costs-standalone.test.ts",
+    ]);
+
+    expect(result.ok).toBe(true);
+  });
+
+  test("requires SDK boundary changes to update a standalone test or helper", () => {
+    const stale = analyzeChangedFiles(["src/sdk/index.ts"]);
+    const covered = analyzeChangedFiles(["src/sdk/index.ts", "test/isolated/helpers/plugin-standalone-boundary.ts"]);
+
+    expect(stale.ok).toBe(false);
+    expect(stale.failures.join("\n")).toContain("SDK boundary changed");
+    expect(covered.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a blocking PR CI job for #2316 that fails when vendor plugin or SDK-boundary changes do not update the matching standalone-boundary test/helper.
- Add `test/isolated/helpers/plugin-standalone-boundary.ts` so extracted plugin tests share one import-boundary assertion instead of ad-hoc regex/mocks.
- Convert representative `absorb` and `costs` standalone tests onto the helper.

Closes #2316

## Validation
- `bun scripts/check-plugin-coverage-gate.ts origin/alpha`
- `bash scripts/test-isolated.sh test/isolated/plugin-costs-standalone.test.ts test/isolated/plugin-absorb-standalone.test.ts test/isolated/plugin-coverage-gate.test.ts`
- `bun run build`

## Notes
- Local `bun run test:default:safe` still shows unrelated shared-process tmux mock-pollution failures; the failing tmux tests pass when run directly/isolated, so this PR relies on CI shards for the full merge gate.
