### PR TITLE
release: v26.6.8-alpha.505

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.6.8-alpha.242",
+  "version": "26.6.8-alpha.505",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts v26.6.8-alpha.505 on merge via calver-release.yml.