### PR TITLE
test: align isolated mocks with SDK export boundary

### DIFF
--- a/test/isolated/bud-scaffold-only.test.ts
+++ b/test/isolated/bud-scaffold-only.test.ts
@@ -29,9 +29,20 @@ mock.module("maw-js/core/fleet/validate", () => ({
 
 mock.module("maw-js/sdk", () => ({
   FLEET_DIR: "/fleet",
+  loadConfig: () => ({ githubOrg: "TestOrg" }),
   hostExec: async (cmd: string) => {
     calls.push(`hostExec:${cmd}`);
     throw new Error(`hostExec should not be needed in this test: ${cmd}`);
+  },
+  writeSignal: () => {
+    calls.push("writeSignal");
+  },
+  validateNickname: (value: string) => ({ ok: true, value }),
+  writeNickname: () => {
+    calls.push("writeNickname");
+  },
+  setCachedNickname: () => {
+    calls.push("setCachedNickname");
   },
 }));
 

--- a/test/isolated/bud-seed-team-extra-coverage.test.ts
+++ b/test/isolated/bud-seed-team-extra-coverage.test.ts
@@ -12,6 +12,8 @@ let spawnCalls: Array<{ team: string; member: string; opts: unknown }> = [];
 
 mock.module("maw-js/config", () => ({
   loadConfig: () => config,
+  cfgLimit: () => 100,
+  cfgTimeout: () => 100,
 }));
 
 mock.module("maw-js/config/ghq-root", () => ({

--- a/test/isolated/core-server-more-coverage-2.test.ts
+++ b/test/isolated/core-server-more-coverage-2.test.ts
@@ -104,6 +104,7 @@ mock.module(import.meta.resolve("../../src/plugin/lifecycle"), () => ({
     if (lifecycleShouldThrow) throw new Error("lifecycle failed");
   },
   runWakeLifecycleHooks: async () => {},
+  runSleepLifecycleHooks: async () => {},
 }));
 mock.module(import.meta.resolve("../../src/core/engine-plugin-registry"), () => ({
   dispatchEnginePluginEvent: async () => { throw new Error("dispatch rejected"); },

--- a/test/isolated/coverage-100-last-five.test.ts
+++ b/test/isolated/coverage-100-last-five.test.ts
@@ -27,6 +27,11 @@ mock.module("maw-js/config", () => ({
 
 mock.module("maw-js/sdk", () => ({
   listSessions: async () => [],
+  loadConfig: () => ({}),
+  cmdSleep: async () => undefined,
+  cmdWakeAll: async () => undefined,
+  ghqFindSync: () => ghqDir,
+  mawDataPath: (...parts: string[]) => join(homeDir, ".maw", ...parts),
   resolveTarget: () => sdkResolveTarget,
   curlFetch: async () => sdkCurlFetch,
   hostExec: async () => "",
@@ -38,6 +43,7 @@ mock.module("maw-js/sdk", () => ({
   getPaneCommands: async () => [],
   getPaneInfos: async () => [],
   isAgentCommand: () => false,
+  resolveOraclePane: async (target: string) => target,
   withPaneLock: async (fn: () => Promise<unknown>) => fn(),
   splitWindowLocked: async () => "%1",
   tagPane: async () => undefined,

--- a/test/isolated/coverage-100b-vendor-a-branches.test.ts
+++ b/test/isolated/coverage-100b-vendor-a-branches.test.ts
@@ -73,10 +73,13 @@ mock.module("child_process", () => ({
 
 mock.module("maw-js/sdk", () => ({
   hostExec: async (cmd: string) => hostExecImpl(cmd),
+  ghqFind: async (_query: string) => "",
   FLEET_DIR: join(tmpRoot || tmpdir(), "fleet"),
   getGhqRoot: () => ghqRoot,
   loadFleetCore: () => [],
+  fleetLoadDirForWrite: () => join(tmpRoot || tmpdir(), "fleet"),
   loadFleetEntries: () => fleetEntries,
+  shouldAutoWake: (name: string, ctx: unknown) => ({ wake: shouldWake, reason: `skip ${name} ${JSON.stringify(ctx)}` }),
 }));
 mock.module("maw-js/config/ghq-root", () => ({ getGhqRoot: () => ghqRoot }));
 mock.module("maw-js/commands/shared/wake", () => ({

--- a/test/isolated/coverage-next-vendor-b-core.test.ts
+++ b/test/isolated/coverage-next-vendor-b-core.test.ts
@@ -50,7 +50,11 @@ const sdkMock = {
     calls.push(`snapshot:${trigger}`);
     throw new Error("snapshot unavailable");
   },
+  runSleepLifecycleHooks: async (ctx: { oracle: string; session: string; window: string }) => {
+    calls.push(`hook:${ctx.oracle}:${ctx.session}:${ctx.window}`);
+  },
   FLEET_DIR: "/tmp/maw-coverage-next-vendor-b-fleet",
+  mawMessageLogPath: (...parts: string[]) => ["/tmp/maw-coverage-next-vendor-b-home", ".maw", "messages", ...parts].join("/"),
   tmux: {
     run: async (...args: string[]) => {
       calls.push(`run:${args.join(" ")}`);

--- a/test/isolated/dream-impl-third-pass-coverage.test.ts
+++ b/test/isolated/dream-impl-third-pass-coverage.test.ts
@@ -20,6 +20,16 @@ const original = {
 
 mock.module("maw-js/sdk", () => ({
   hostExec: async (cmd: string) => fakeHostExec(cmd),
+  getGhqRoot: () => ghqRoot,
+  loadFleetCore: () => [
+    {
+      name: "active-session",
+      windows: [
+        { name: "main", repo: "Soul-Brews-Studio/active-oracle" },
+        { name: "missing", repo: "Soul-Brews-Studio/missing-oracle" },
+      ],
+    },
+  ],
 }));
 
 mock.module("maw-js/config/ghq-root", () => ({

--- a/test/isolated/oracle-scan-costs-coverage.test.ts
+++ b/test/isolated/oracle-scan-costs-coverage.test.ts
@@ -64,6 +64,10 @@ mock.module(implListPath, () => ({
 
 mock.module(verbosityPath, () => ({
   isQuiet: () => quietMode,
+  info: (msg: string) => { if (!quietMode) console.error(msg); },
+  warn: (msg: string) => { if (!quietMode) console.error(`⚠ ${msg}`); },
+  error: (msg: string) => { console.error(msg); },
+  verbose: (fn: () => void) => { if (!quietMode) fn(); },
 }));
 
 mock.module(registryTypesPath, () => ({

--- a/test/isolated/restart-impl-link-coverage.test.ts
+++ b/test/isolated/restart-impl-link-coverage.test.ts
@@ -23,6 +23,10 @@ class MockTmux {
 
 mock.module("maw-js/sdk", () => ({
   listSessions: async () => [],
+  cmdSleep: async () => { sleepCalls += 1; },
+  cmdWakeAll: async () => { wakeCalls += 1; },
+  ghqFindSync: () => "/tmp/maw-js-checkout",
+  mawDataPath: (...parts: string[]) => join(homeDir, ".maw", ...parts),
   Tmux: MockTmux,
 }));
 

--- a/test/isolated/soul-sync-family-coverage.test.ts
+++ b/test/isolated/soul-sync-family-coverage.test.ts
@@ -51,6 +51,17 @@ mock.module("maw-js/core/ghq", () => ({
 }));
 
 mock.module("maw-js/sdk", () => ({
+  ghqFind: async (query: string) => {
+    ghqFindCalls.push(query);
+    const match = query.match(/^\/(.+)-oracle\$$/);
+    if (!match) return "";
+    const stem = match[1]!;
+    if (ghqFindMisses.has(stem)) return "";
+    const candidate = join(reposRoot, "Org", `${stem}-oracle`);
+    return existsSync(candidate) ? candidate : "";
+  },
+  getGhqRoot: () => ghqRoot,
+  loadFleetCore: () => fleet,
   hostExec: async (cmd: string) => {
     hostExecCalls.push(cmd);
     if (cmd.includes("tmux display-message")) {

--- a/test/isolated/vendor-attach-impl-next-coverage.test.ts
+++ b/test/isolated/vendor-attach-impl-next-coverage.test.ts
@@ -30,6 +30,9 @@ const original = {
 
 mock.module("maw-js/sdk", () => ({
   listSessions: async () => [],
+  getGhqRoot: () => "/tmp/ghq",
+  loadFleetCore: () => [],
+  UserError: class UserError extends Error {},
 }));
 
 mock.module("maw-js/commands/shared/fleet-load", () => ({

--- a/test/isolated/vendor-doctor-pair-extra-coverage.test.ts
+++ b/test/isolated/vendor-doctor-pair-extra-coverage.test.ts
@@ -76,6 +76,10 @@ mock.module("maw-js/config", () => ({
     if (configError) throw configError;
     return configValue;
   },
+  cfgLimit: (_key: string, fallback: number = 0) => fallback,
+  cfgTimeout: (_key: string, fallback: number = 0) => fallback,
+  cfgInterval: (_key: string, fallback: number = 0) => fallback,
+  cfg: (_key: string, fallback: unknown = undefined) => fallback,
 }));
 
 mock.module("maw-js/commands/shared/fleet-doctor-fixer", () => ({ C }));

--- a/test/isolated/wake-index-peer-extra-coverage.test.ts
+++ b/test/isolated/wake-index-peer-extra-coverage.test.ts
@@ -12,6 +12,7 @@ const peerCalls: Array<{ url: string; body: Record<string, unknown> }> = [];
 let wakeThrow: Error | null = null;
 
 mock.module("maw-js/commands/shared/wake", () => ({
+  fetchIssuePrompt: async (num: number, repo?: string) => `issue-${num}-${repo ?? ""}-prompt`,
   cmdWake: async (oracle: string, opts: Record<string, unknown>) => {
     wakeCalls.push({ oracle, opts });
     console.log(`wake ${oracle}`);
@@ -29,6 +30,7 @@ mock.module("maw-js/commands/shared/wake-target", () => ({
 }));
 
 mock.module("maw-js/commands/shared/wake-resolve", () => ({
+  fetchIssuePrompt: async (num: number, repo?: string) => `issue-${num}-${repo ?? ""}-prompt`,
   fetchGitHubPrompt: async (kind: string, num: number, repo?: string) => {
     fetchPromptCalls.push({ kind, num, repo });
     return `${kind}-${num}-prompt`;


### PR DESCRIPTION
## Summary
- Align stale isolated test mocks with current static imports from `maw-js/sdk`, config, lifecycle, and wake helpers.
- Targets the CI pattern where Bun reports named SDK exports (e.g. `ghqFindSync`/related extracted-plugin exports) missing before tests run because the local mock shadowed the real SDK.

## Validation
- Reproduced with `bun run test:isolated -- --shard 1/4` (11 stale mock failures).
- Passed: `MAW_TEST_MODE=1 bun test test/isolated/coverage-100-last-five.test.ts --path-ignore-patterns **/agents/**`.
- Not fully verified: full shard still needs follow-up; PR opened urgently per release instruction.
