### PR TITLE
feat(wake): announce rehydration sources

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -438,6 +438,37 @@ function formatWorktreeSource(path: string): string {
   return `worktree/${base}`;
 }
 
+function rehydrationWindowLabel(count: number): string {
+  return `${count} window${count === 1 ? "" : "s"}`;
+}
+
+function agentsRehydrationSource(worktrees: { path: string }[]): string {
+  const agentsPath = worktrees
+    .map(wt => wt.path)
+    .find(path => path.includes("/agents/"));
+  if (agentsPath) {
+    return agentsPath.slice(0, agentsPath.indexOf("/agents/") + "/agents".length);
+  }
+  return worktrees.length > 0 ? "worktree folders" : "agents/ folder";
+}
+
+function logSnapshotRehydrationSource(count: number, snapshotFile: string): void {
+  if (count > 0) {
+    console.log(`\x1b[36m↻\x1b[0m Rehydrating ${rehydrationWindowLabel(count)} from snapshot ${snapshotFile}`);
+    return;
+  }
+  console.log(`\x1b[90m↻ snapshot rehydrate: none from snapshot ${snapshotFile}\x1b[0m`);
+}
+
+function logAgentsRehydrationSource(count: number, worktrees: { path: string }[]): void {
+  const source = agentsRehydrationSource(worktrees);
+  if (count > 0) {
+    console.log(`\x1b[36m↻\x1b[0m Rehydrating ${rehydrationWindowLabel(count)} from agents/ state at ${source}`);
+    return;
+  }
+  console.log(`\x1b[90m↻ agents/ rehydrate: none from ${source}\x1b[0m`);
+}
+
 async function restoreSnapshotWindows(
   oracle: string,
   session: string,
@@ -449,6 +480,7 @@ async function restoreSnapshotWindows(
   engine?: string,
 ): Promise<number> {
   const planned = planSnapshotRestoreWindows(oracle, snapshotSession, existingWindows, worktrees, repoPath);
+  logSnapshotRehydrationSource(planned.length, snapshotFile);
   if (planned.length > 0) {
     console.log(`\x1b[36m↻\x1b[0m rehydrating from snapshot ${snapshotFile}:`);
   }
@@ -1001,7 +1033,9 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
       const planned = planSnapshotRestoreWindows(oracle, requestedSnapshotSession, existingWindows, allWt, repoPath);
       if (planned.length === 0) {
         console.log(`\x1b[90m↻ would restore snapshot windows: none\x1b[0m`);
+        logSnapshotRehydrationSource(0, requestedSnapshotFile || "snapshot");
       } else {
+        logSnapshotRehydrationSource(planned.length, requestedSnapshotFile || "snapshot");
         if (requestedSnapshotFile) {
           console.log(`\x1b[36m↻\x1b[0m rehydrating from snapshot ${requestedSnapshotFile}:`);
         }
@@ -1021,7 +1055,9 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
     const planned = planRehydrateWorktreeWindows(oracle, allWt, existingWindows, liveTileRoles);
     if (planned.length === 0) {
       console.log(`\x1b[90m↻ would respawn: none\x1b[0m`);
+      logAgentsRehydrationSource(0, allWt);
     } else {
+      logAgentsRehydrationSource(planned.length, allWt);
       console.log(`\x1b[36m↻\x1b[0m rehydrating from agents/ folder:`);
       for (const wt of planned) {
         console.log(`\x1b[32m↻\x1b[0m would respawn: ${wt.windowName}  \x1b[90m(from ${formatWorktreeSource(wt.path)})\x1b[0m`);
@@ -1101,6 +1137,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
     if (!foreignSession && !opts.task && !opts.wt && !opts.noRehydrate) {
       const allWt = await findWorktrees(parentDir, repoName);
       const plan = planRehydrateWorktreeWindows(oracle, allWt, [...existingWindows]);
+      logAgentsRehydrationSource(plan.length, allWt);
       if (plan.length > 0) {
         console.log(`\x1b[36m↻\x1b[0m rehydrating from agents/ folder:`);
       }
@@ -1145,6 +1182,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
         const existingWindows = [...preExistingWindows];
         const liveTileRoles = await getLiveTileRoles(session);
         const plan = planRehydrateWorktreeWindows(oracle, allWt, existingWindows, liveTileRoles);
+        logAgentsRehydrationSource(plan.length, allWt);
         if (plan.length > 0) {
           console.log(`\x1b[36m↻\x1b[0m rehydrating from agents/ folder:`);
         }
@@ -1155,7 +1193,9 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
           preExistingWindows.add(wt.windowName);
           console.log(`\x1b[32m↻\x1b[0m respawned: ${wt.windowName}  \x1b[90m(from ${formatWorktreeSource(wt.path)})\x1b[0m`);
         }
-        }
+      } else {
+        logAgentsRehydrationSource(0, allWt);
+      }
     }
 
     await new Promise(r => setTimeout(r, cfgTimeout("wakeVerify")));

--- a/test/isolated/wake-cmd-thirteenth-pass-coverage.test.ts
+++ b/test/isolated/wake-cmd-thirteenth-pass-coverage.test.ts
@@ -495,11 +495,13 @@ describe("wake-cmd thirteenth-pass isolated coverage", () => {
     let result = await captureLogs(() => cmdWake("neo", { repoPath, fromSnapshot: true, dryRun: true }));
     expect(result).toBe("54-neo:neo-oracle");
     expect(plain()).toContain("would restore snapshot windows: none");
+    expect(plain()).toContain("snapshot rehydrate: none from snapshot latest.json");
 
     logs = [];
     plannedSnapshotWindows = [{ windowName: "neo-alpha", cwd: "/tmp/neo-oracle.wt-1-alpha", source: "worktree" }];
     result = await captureLogs(() => cmdWake("neo", { repoPath, fromSnapshot: true, dryRun: true }));
     expect(result).toBe("54-neo:neo-oracle");
+    expect(plain()).toContain("Rehydrating 1 window from snapshot latest.json");
     expect(plain()).toContain("would restore snapshot window: neo-alpha");
 
     snapshotSessionReturn = null;
@@ -508,14 +510,15 @@ describe("wake-cmd thirteenth-pass isolated coverage", () => {
   });
 
   test("dry-run reports concrete worktree rehydrate plans", async () => {
-    findWorktreesReturn = [{ name: "5-docs", path: "/tmp/neo-oracle.wt-5-docs" }];
-    plannedRehydrateWindows = [{ windowName: "neo-docs", path: "/tmp/neo-oracle.wt-5-docs" }];
+    findWorktreesReturn = [{ name: "5-docs", path: `${repoPath}/agents/5-docs` }];
+    plannedRehydrateWindows = [{ windowName: "neo-docs", path: `${repoPath}/agents/5-docs` }];
 
     const result = await captureLogs(() => cmdWake("neo", { repoPath, dryRun: true }));
 
     expect(result).toBe("54-neo:neo-oracle");
+    expect(plain()).toContain("Rehydrating 1 window from agents/ state at /tmp/ghq/github.com/Soul-Brews-Studio/neo-oracle/agents");
     expect(plain()).toContain("would respawn: neo-docs");
-    expect(plain()).toMatch(/(?:from worktree\/neo-oracle\.wt-5-docs|\/tmp\/neo-oracle\.wt-5-docs)/);
+    expect(plain()).toContain("from agents/5-docs");
   });
 
   test("invalid bud flag combinations and missing snapshots fail before tmux mutation", async () => {
@@ -563,12 +566,13 @@ describe("wake-cmd thirteenth-pass isolated coverage", () => {
 
   test("dry-run treats window listing failures as empty when planning rehydrate", async () => {
     listWindowsThrows = true;
-    findWorktreesReturn = [{ name: "5-docs", path: "/tmp/neo-oracle.wt-5-docs" }];
-    plannedRehydrateWindows = [{ windowName: "neo-docs", path: "/tmp/neo-oracle.wt-5-docs" }];
+    findWorktreesReturn = [{ name: "5-docs", path: `${repoPath}/agents/5-docs` }];
+    plannedRehydrateWindows = [{ windowName: "neo-docs", path: `${repoPath}/agents/5-docs` }];
 
     const result = await captureLogs(() => cmdWake("neo", { repoPath, dryRun: true }));
 
     expect(result).toBe("54-neo:neo-oracle");
+    expect(plain()).toContain("Rehydrating 1 window from agents/ state at /tmp/ghq/github.com/Soul-Brews-Studio/neo-oracle/agents");
     expect(plain()).toContain("would respawn: neo-docs");
   });
 
@@ -624,6 +628,8 @@ describe("wake-cmd thirteenth-pass isolated coverage", () => {
       target: "54-neo:neo-review",
       text: "cd /tmp/neo-oracle.wt-3-review && codex --agent neo-review",
     });
+    expect(plain()).toContain("Rehydrating 1 window from snapshot latest.json");
+    expect(plain()).toContain("Rehydrating 1 window from agents/ state at worktree folders");
     expect(plain()).toContain("snapshot restore: 1 window");
     expect(plain()).toContain("2 window(s) retried.");
   });
@@ -665,6 +671,8 @@ describe("wake-cmd thirteenth-pass isolated coverage", () => {
       text: "cd /tmp/neo-oracle.wt-2-beta && claude --agent neo-beta",
     });
     expect(snapshots).toEqual(["wake"]);
+    expect(plain()).toContain("Rehydrating 1 window from snapshot latest.json");
+    expect(plain()).toContain("Rehydrating 1 window from agents/ state at worktree folders");
     expect(plain()).toContain("snapshot window: neo-restored");
     expect(plain()).toContain("1 window(s) reordered");
   });


### PR DESCRIPTION
## Summary
- announce snapshot rehydration source/count before restoring snapshot windows
- announce agents/worktree rehydration source/count before respawning agent windows
- explicitly report `none` when snapshot or agents rehydration plans are empty

## Verification
- `BUN_INSTALL=/Users/nat/.bun PATH=/Users/nat/.bun/install/cache/@oven/bun-darwin-aarch64@1.3.13@@@1/bin:$PATH bun test test/wake-cmd-default.test.ts test/wake-flags.test.ts --path-ignore-patterns '**/agents/**'`
- `BUN_INSTALL=/Users/nat/.bun PATH=/Users/nat/.bun/install/cache/@oven/bun-darwin-aarch64@1.3.13@@@1/bin:$PATH bash scripts/test-isolated.sh test/isolated/wake-cmd-thirteenth-pass-coverage.test.ts test/isolated/wake-cmd-twelfth-pass-coverage.test.ts test/isolated/wake-cmd-dryrun-coverage.test.ts test/isolated/wake-cmd-extra-coverage.test.ts`
- `BUN_INSTALL=/Users/nat/.bun PATH=/Users/nat/.bun/install/cache/@oven/bun-darwin-aarch64@1.3.13@@@1/bin:$PATH bun --check src/commands/shared/wake-cmd.ts test/isolated/wake-cmd-thirteenth-pass-coverage.test.ts`
- `git diff --check`

## Full-suite note
A prior repo-wide bare `bun test` attempt was killed after unrelated failures/hang already appeared:
- `test/comm-send-durable-inbox.test.ts` timed out
- `test/fleet-wake-ssh-failsoft.test.ts` failed due cross-file mock pollution from fleet wake default mocks
- `test/api-plugin-oracle-default.test.ts` hit a config export error

Do not merge until CI/required release gates are green.

Closes #2145.
