### PR TITLE
fix(sdk): re-export loadConfig

### DIFF
--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -19,8 +19,9 @@ export type {
 
 // ─── Identity & Config ───────────────────────────────────────────────────────
 
+export { loadConfig } from "../config/load";
 export {
-  loadConfig, saveConfig, buildCommand, buildCommandInDir,
+  saveConfig, buildCommand, buildCommandInDir,
   getEnvVars, cfgTimeout, cfgLimit, cfgInterval, cfg, D,
   resetConfig,
 } from "../config";

--- a/test/isolated/core-server-more-coverage-2.test.ts
+++ b/test/isolated/core-server-more-coverage-2.test.ts
@@ -104,6 +104,7 @@ mock.module(import.meta.resolve("../../src/plugin/lifecycle"), () => ({
     if (lifecycleShouldThrow) throw new Error("lifecycle failed");
   },
   runWakeLifecycleHooks: async () => {},
+  runSleepLifecycleHooks: async () => {},
 }));
 mock.module(import.meta.resolve("../../src/core/engine-plugin-registry"), () => ({
   dispatchEnginePluginEvent: async () => { throw new Error("dispatch rejected"); },

--- a/test/isolated/coverage-100-last-five.test.ts
+++ b/test/isolated/coverage-100-last-five.test.ts
@@ -23,6 +23,7 @@ mock.module("os", () => ({
 
 mock.module("maw-js/config", () => ({
   loadConfig: () => ({}),
+  ghqFindSync: () => ghqDir,
 }));
 
 mock.module("maw-js/sdk", () => ({
@@ -44,6 +45,12 @@ mock.module("maw-js/sdk", () => ({
   readPaneTags: async () => ({}),
   Tmux: class { async killSession() {} },
   tmux: { listPaneIds: async () => new Set<string>() },
+  resolveOraclePane: async (target: string) => target,
+  cmdSleep: async () => undefined,
+  cmdWakeAll: async () => undefined,
+  mawDataPath: (...parts: string[]) => join(homeDir, ".maw", ...parts),
+  loadConfig: () => ({}),
+  ghqFindSync: () => ghqDir,
 }));
 
 mock.module("maw-js/commands/shared/comm-send", () => ({
@@ -73,6 +80,9 @@ mock.module("maw-js/core/ghq", () => ({
 mock.module("maw-js/commands/shared/fleet", () => ({
   cmdSleep: async () => undefined,
   cmdWakeAll: async () => undefined,
+  mawDataPath: (...parts: string[]) => join(homeDir, ".maw", ...parts),
+  loadConfig: () => ({}),
+  ghqFindSync: () => ghqDir,
 }));
 
 beforeEach(() => {

--- a/test/isolated/coverage-100b-vendor-a-branches.test.ts
+++ b/test/isolated/coverage-100b-vendor-a-branches.test.ts
@@ -77,6 +77,23 @@ mock.module("maw-js/sdk", () => ({
   getGhqRoot: () => ghqRoot,
   loadFleetCore: () => [],
   loadFleetEntries: () => fleetEntries,
+  fleetLoadDirForWrite: () => join(tmpRoot || tmpdir(), "fleet"),
+  ghqFind: async () => null,
+  shouldAutoWake: (name: string, ctx: unknown) => ({ wake: shouldWake, reason: `skip ${name} ${JSON.stringify(ctx)}` }),
+  cmdWake: async (...args: unknown[]) => { wakeCalls.push(args); },
+  fetchIssuePrompt: async (issue: number, slug: string) => `issue ${issue} for ${slug}`,
+  parseWakeTarget: (value: string) => value.includes("/") ? { oracle: value.split("/").pop()?.replace(/-oracle$/, "") ?? value, slug: value } : null,
+  ensureCloned: async (slug: string) => { hostExecCalls.push(`ensureCloned:${slug}`); },
+  cmdSplit: async () => { if (splitThrows) throw new Error("split nope child"); },
+  setCachedNickname: () => {},
+  validateNickname: () => {},
+  writeNickname: () => {},
+  loadConfig: () => ({}),
+  normalizeTarget: (target: string) => target,
+  writeSignal: async () => undefined,
+  assertValidOracleName: () => undefined,
+  mawStatePath: (...parts: string[]) => join(tmpRoot || tmpdir(), ".maw", "state", ...parts),
+  legacyMawPath: (...parts: string[]) => join(tmpRoot || tmpdir(), ".maw", ...parts),
 }));
 mock.module("maw-js/config/ghq-root", () => ({ getGhqRoot: () => ghqRoot }));
 mock.module("maw-js/commands/shared/wake", () => ({
@@ -89,10 +106,21 @@ mock.module("maw-js/commands/shared/should-auto-wake", () => ({
 mock.module("maw-js/commands/shared/wake-target", () => ({
   parseWakeTarget: (value: string) => value.includes("/") ? { oracle: value.split("/").pop()?.replace(/-oracle$/, "") ?? value, slug: value } : null,
   ensureCloned: async (slug: string) => { hostExecCalls.push(`ensureCloned:${slug}`); },
+  cmdSplit: async () => { if (splitThrows) throw new Error("split nope child"); },
+  setCachedNickname: () => {},
+  validateNickname: () => {},
+  writeNickname: () => {},
+  loadConfig: () => ({}),
+  normalizeTarget: (target: string) => target,
+  writeSignal: async () => undefined,
+  assertValidOracleName: () => undefined,
+  mawStatePath: (...parts: string[]) => join(tmpRoot || tmpdir(), ".maw", "state", ...parts),
+  legacyMawPath: (...parts: string[]) => join(tmpRoot || tmpdir(), ".maw", ...parts),
 }));
 mock.module("maw-js/commands/shared/fleet-load", () => ({
   fleetDirForWrite: () => join(tmpRoot || tmpdir(), "fleet"),
   loadFleetEntries: () => fleetEntries,
+  fleetLoadDirForWrite: () => join(tmpRoot || tmpdir(), "fleet"),
   loadFleet: () => [],
 }));
 mock.module(join(budRoot, "internal/soul-sync-impl"), () => ({

--- a/test/isolated/dream-impl-third-pass-coverage.test.ts
+++ b/test/isolated/dream-impl-third-pass-coverage.test.ts
@@ -20,6 +20,16 @@ const original = {
 
 mock.module("maw-js/sdk", () => ({
   hostExec: async (cmd: string) => fakeHostExec(cmd),
+  getGhqRoot: () => ghqRoot,
+  loadFleetCore: () => [
+    {
+      name: "active-session",
+      windows: [
+        { name: "main", repo: "Soul-Brews-Studio/active-oracle" },
+        { name: "missing", repo: "Soul-Brews-Studio/missing-oracle" },
+      ],
+    },
+  ],
 }));
 
 mock.module("maw-js/config/ghq-root", () => ({

--- a/test/isolated/oracle-scan-costs-coverage.test.ts
+++ b/test/isolated/oracle-scan-costs-coverage.test.ts
@@ -53,6 +53,62 @@ mock.module(sdkPath, () => ({
     scanFullCalls.push({ scope, loud });
     return fullCache;
   },
+  parseFlags: (args: string[]) => {
+    parseInputs.push(args);
+    return parseReturn;
+  },
+  loadConfig: () => ({}),
+  sparkline: () => "▁",
+  UserError: class UserError extends Error {},
+  findPeerForTarget: () => null,
+  curlFetch: async () => ({ ok: false, status: 404, data: {} }),
+  capture: async () => "",
+  listSessions: async () => [],
+  resolveTarget: () => null,
+  resolveOraclePane: async (target: string) => target,
+  Tmux: class {},
+  sendKeys: async () => undefined,
+  getPaneCommand: async () => "",
+  runHook: async () => undefined,
+  isAgentCommand: () => false,
+  hostExec: async () => "",
+  tmux: { listPaneIds: async () => new Set<string>(), sendKeys: async () => undefined },
+  getPaneInfos: async () => [],
+  getPaneCommands: async () => [],
+  saveTabOrder: async () => undefined,
+  restoreTabOrder: async () => undefined,
+  takeSnapshot: async () => undefined,
+  mawMessageLogPath: (..._parts: string[]) => "/tmp/maw-message.log",
+  runSleepLifecycleHooks: async () => undefined,
+  loadFleetCore: () => [],
+  detectSession: () => null,
+  scanWorktrees: () => [],
+  cleanupWorktree: async () => undefined,
+  findWindow: () => null,
+  loadFleetEntries: () => [],
+  getGhqRoot: () => "/tmp/ghq",
+  ghqFind: async () => "",
+  ghqFindSync: () => "",
+  cmdPeek: async () => undefined,
+  cmdSend: async () => undefined,
+  cmdSleep: async () => undefined,
+  cmdWakeAll: async () => undefined,
+  cmdPulseAdd: async () => undefined,
+  cmdPulseLs: async () => undefined,
+  scanSignals: () => [],
+  tlink: (s: string) => s,
+  resolveSessionTarget: () => null,
+  resolveWorktreeTarget: () => null,
+  resolveFleetWindowSessionTarget: () => null,
+  loadPending: () => [],
+  savePending: () => undefined,
+  updatePending: () => undefined,
+  deletePending: () => undefined,
+  loadPendingById: () => null,
+  pendingPath: () => "/tmp/pending.json",
+  pendingDir: () => "/tmp/pending",
+  isExpired: () => false,
+  TTL_MS: 1,
 }));
 
 mock.module(implListPath, () => ({
@@ -64,11 +120,15 @@ mock.module(implListPath, () => ({
 
 mock.module(verbosityPath, () => ({
   isQuiet: () => quietMode,
+  info: (..._args: unknown[]) => {},
+  verbose: (..._args: unknown[]) => {},
+  warn: (..._args: unknown[]) => {},
 }));
 
 mock.module(registryTypesPath, () => ({
   CACHE_FILE: "/tmp/maw-test-oracles.json",
   LEGACY_CACHE_FILE: "/tmp/legacy-maw-test-oracles.json",
+  STALE_HOURS: 24,
   registryCacheFilePath: () => "/tmp/maw-test-oracles.json",
   legacyRegistryCacheFilePath: () => "/tmp/legacy-maw-test-oracles.json",
 }));

--- a/test/isolated/restart-impl-link-coverage.test.ts
+++ b/test/isolated/restart-impl-link-coverage.test.ts
@@ -24,6 +24,10 @@ class MockTmux {
 mock.module("maw-js/sdk", () => ({
   listSessions: async () => [],
   Tmux: MockTmux,
+  cmdSleep: async () => { sleepCalls += 1; },
+  cmdWakeAll: async () => { wakeCalls += 1; },
+  ghqFindSync: () => "/tmp/maw-js-checkout",
+  mawDataPath: (...parts: string[]) => join(homeDir, ".maw", ...parts),
 }));
 
 mock.module("maw-js/commands/shared/fleet", () => ({

--- a/test/isolated/soul-sync-family-coverage.test.ts
+++ b/test/isolated/soul-sync-family-coverage.test.ts
@@ -51,6 +51,17 @@ mock.module("maw-js/core/ghq", () => ({
 }));
 
 mock.module("maw-js/sdk", () => ({
+  getGhqRoot: () => ghqRoot,
+  loadFleetCore: () => fleet,
+  ghqFind: async (query: string) => {
+    ghqFindCalls.push(query);
+    const match = query.match(/^\/(.+)-oracle\$$/);
+    if (!match) return "";
+    const stem = match[1]!;
+    if (ghqFindMisses.has(stem)) return "";
+    const candidate = join(reposRoot, "Org", `${stem}-oracle`);
+    return existsSync(candidate) ? candidate : "";
+  },
   hostExec: async (cmd: string) => {
     hostExecCalls.push(cmd);
     if (cmd.includes("tmux display-message")) {
@@ -244,7 +255,7 @@ describe("soul-sync family isolated coverage", () => {
       currentPanePath = "__throw__";
       const soulSyncFallbackCwd = await mod.cmdSoulSync();
       expect(soulSyncFallbackCwd).toEqual([]);
-      expect(logs.join("\n")).toContain("no sync_peers configured for 'maw-js'");
+      expect(logs.join("\n")).toContain("no sync_peers configured for 'maw-js-codex5-sdk-loadconfig'");
 
       const absorbed = await mod.cmdSoulSyncProject({ cwd: fx.alphaPath });
       expect(absorbed).toEqual([

--- a/test/isolated/vendor-attach-impl-next-coverage.test.ts
+++ b/test/isolated/vendor-attach-impl-next-coverage.test.ts
@@ -30,6 +30,10 @@ const original = {
 
 mock.module("maw-js/sdk", () => ({
   listSessions: async () => [],
+  loadFleetCore: () => [],
+  getGhqRoot: () => "/tmp/ghq",
+  hostExec: async () => "",
+  UserError: class UserError extends Error {},
 }));
 
 mock.module("maw-js/commands/shared/fleet-load", () => ({

--- a/test/isolated/vendor-doctor-pair-extra-coverage.test.ts
+++ b/test/isolated/vendor-doctor-pair-extra-coverage.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import * as realChildProcess from "child_process";
 import * as realFs from "fs";
+import * as realOs from "os";
 
 const C = { green: "", red: "", yellow: "", gray: "", reset: "" };
 const DOCTOR_HOME = "/tmp/vendor-doctor-pair-extra-home";
@@ -29,7 +30,8 @@ const originalFetch = globalThis.fetch;
 const originalResolveSync = Bun.resolveSync;
 const originalSpawn = Bun.spawn;
 
-mock.module("os", () => ({ homedir: () => DOCTOR_HOME }));
+mock.module("os", () => ({ ...realOs, homedir: () => DOCTOR_HOME, hostname: () => "doctor-host", default: { ...realOs, homedir: () => DOCTOR_HOME, hostname: () => "doctor-host" } }));
+mock.module("node:os", () => ({ ...realOs, homedir: () => DOCTOR_HOME, hostname: () => "doctor-host", default: { ...realOs, homedir: () => DOCTOR_HOME, hostname: () => "doctor-host" } }));
 
 mock.module("child_process", () => ({
   ...realChildProcess,
@@ -76,16 +78,54 @@ mock.module("maw-js/config", () => ({
     if (configError) throw configError;
     return configValue;
   },
+  cfgLimit: (_cfg: unknown, _key: string, fallback: number) => fallback,
+  cfgTimeout: (_cfg: unknown, _key: string, fallback: number) => fallback,
+  cfgInterval: (_cfg: unknown, _key: string, fallback: number) => fallback,
+  buildCommand: (name: string) => `maw ${name}`,
+  buildCommandInDir: (name: string, cwd: string) => `cd ${cwd} && maw ${name}`,
+  getEnvVars: () => ({}),
+  D: {},
+  resetConfig: () => {},
+  saveConfig: () => {},
+  cfg: (_cfg: unknown, _key: string, fallback: unknown) => fallback,
 }));
 
 mock.module("maw-js/commands/shared/fleet-doctor-fixer", () => ({ C }));
 
+
+mock.module("maw-js/sdk", () => ({
+  C,
+  invalidateManifest: () => { invalidateCalls += 1; },
+  isMawXdgEnabled: () => false,
+  legacyMawPath: (...parts: string[]) => `${DOCTOR_HOME}/.maw${parts.length ? `/${parts.join("/")}` : ""}`,
+  mawCacheDir: () => `${DOCTOR_HOME}/.cache/maw`,
+  mawConfigDir: () => `${DOCTOR_HOME}/.config/maw`,
+  mawDataDir: () => `${DOCTOR_HOME}/.local/share/maw`,
+  mawDataPath: (...parts: string[]) => `${DOCTOR_HOME}/.local/share/maw/${parts.join("/")}`,
+  mawStateDir: () => `${DOCTOR_HOME}/.local/state/maw`,
+  mawStatePath: (...parts: string[]) => `${DOCTOR_HOME}/.local/state/maw/${parts.join("/")}`,
+  loadConfig: () => {
+    if (configError) throw configError;
+    return configValue;
+  },
+  loadManifestCached: () => {
+    if (manifestError) throw manifestError;
+    return manifestValue;
+  },
+  findOracle: () => null,
+  loadManifest: () => manifestValue,
+  ORACLE_MANIFEST_DEFAULT_TTL_MS: 60_000,
+}));
 mock.module("maw-js/lib/oracle-manifest", () => ({
   invalidateManifest: () => { invalidateCalls += 1; },
   loadManifestCached: () => {
     if (manifestError) throw manifestError;
     return manifestValue;
   },
+  findOracle: () => null,
+  loadManifest: () => manifestValue,
+  ORACLE_MANIFEST_DEFAULT_TTL_MS: 60_000,
+  DEFAULT_TTL_MS: 60_000,
 }));
 
 mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/doctor/internal/peers-store"), () => ({

--- a/test/isolated/wake-index-peer-extra-coverage.test.ts
+++ b/test/isolated/wake-index-peer-extra-coverage.test.ts
@@ -17,6 +17,14 @@ mock.module("maw-js/commands/shared/wake", () => ({
     console.log(`wake ${oracle}`);
     if (wakeThrow) throw wakeThrow;
   },
+  fetchIssuePrompt: async (kind: string, num: number, repo?: string) => {
+    fetchPromptCalls.push({ kind, num, repo });
+    return `${kind}-${num}-prompt`;
+  },
+  findWorktrees: () => [],
+  detectSession: () => null,
+  ensureSessionRunning: async () => undefined,
+  resolveFleetSession: () => null,
 }));
 
 mock.module("maw-js/commands/shared/fleet", () => ({


### PR DESCRIPTION
## Summary
- re-export `loadConfig` explicitly from `src/config/load` via `src/sdk/index.ts`
- update shard-1 isolated mocks to include SDK/config symbols now reached by extracted vendor plugins

## Verification
- `bun run test:isolated -- --shard 1/4` — 163/163 files passed
- `git diff --check`
