### PR TITLE
test: align vendor coverage SDK mocks

### DIFF
--- a/test/isolated/team-vendor-handler-coverage.test.ts
+++ b/test/isolated/team-vendor-handler-coverage.test.ts
@@ -23,6 +23,10 @@ const calls: Record<string, unknown[]> = {
 let parseFlagsReturn: Record<string, unknown> = {};
 
 mock.module("maw-js/sdk", () => ({
+  parseFlags: (_args: string[], _schema: Record<string, unknown>, _start = 0) => ({
+    _: [],
+    ...(parseFlagsReturn || {}),
+  }),
   hostExec: async () => "",
   tmux: {
     listPaneIds: async () => new Set<string>(),

--- a/test/isolated/vendor-about-bud-sleep-run-send-extra-coverage.test.ts
+++ b/test/isolated/vendor-about-bud-sleep-run-send-extra-coverage.test.ts
@@ -70,6 +70,12 @@ mock.module("maw-js/sdk", () => ({
   },
   ghqList: async () => ghqListResult,
   loadFleetEntries: loadTestFleetEntries,
+  loadConfig: () => configState,
+  resolveOraclePane: async (target: string) => {
+    paneCalls.push(target);
+    if (paneError) throw paneError;
+    return paneResult;
+  },
   UserError: class UserError extends Error {},
   listSessions: async () => {
     if (listSessionsError) throw listSessionsError;

--- a/test/isolated/vendor-attach-impl-more-coverage.test.ts
+++ b/test/isolated/vendor-attach-impl-more-coverage.test.ts
@@ -11,6 +11,12 @@ mock.module("maw-js/sdk", () => ({
     listSessionsCalls.push([]);
     return [];
   },
+  getGhqRoot: () => "/tmp/ghq",
+  loadFleetCore: async () => {
+    loadFleetCalls.push([]);
+    return [];
+  },
+  UserError: class UserError extends Error {},
 }));
 
 mock.module("maw-js/commands/shared/fleet-load", () => ({

--- a/test/isolated/vendor-bud-init-broadcast-rename-extra-coverage.test.ts
+++ b/test/isolated/vendor-bud-init-broadcast-rename-extra-coverage.test.ts
@@ -87,6 +87,18 @@ mock.module("maw-js/sdk", () => ({
     if (hostExecError) throw hostExecError;
     return hostExecResult;
   },
+  getGhqRoot: () => ghqRoot,
+  loadConfig: () => config,
+  normalizeTarget: () => normalizedTarget,
+  assertValidOracleName: () => {
+    if (validateOracleError) throw validateOracleError;
+  },
+  parseWakeTarget: () => parseWakeTargetResult,
+  ensureCloned: async (slug: string) => { ensureClonedCalls.push(slug); },
+  validateNickname: (value: string) => { validateNicknameCalls.push(value); return validateNicknameResult; },
+  writeNickname: (...args: any[]) => { writeNicknameCalls.push(args); },
+  setCachedNickname: (...args: any[]) => { setCachedNicknameCalls.push(args); },
+  writeSignal: (...args: any[]) => { writeSignalCalls.push(args); },
   isAgentCommand: (cmd: string | null | undefined) => /claude|codex|thclaws|thclaude/i.test((cmd ?? "").trim()) || /^node$/i.test((cmd ?? "").trim()) || /^\d+\.\d+\.\d+$/.test((cmd ?? "").trim()),
   loadOracleRegistry: () => null,
   loadFleetEntries: () => [{ groupName: "neo", file: "01-neo.json", session: { name: "01-neo" } }],

--- a/test/isolated/vendor-command-plugins-coverage.test.ts
+++ b/test/isolated/vendor-command-plugins-coverage.test.ts
@@ -87,9 +87,19 @@ const sdkMock = {
   },
   loadConfig: () => configState,
   listSessions: async () => sessions,
+  Tmux: class {
+    async run(...args: string[]) {
+      tmuxRunCalls.push(args);
+      return tmuxResponses.shift() ?? "";
+    }
+  },
   resolveTarget: (query: string, config: Record<string, any>, listedSessions: any[]) => {
     resolveTargetCalls.push({ query, config, sessions: listedSessions });
     return resolvedTarget;
+  },
+  resolveOraclePane: async (target: string) => {
+    paneCalls.push(target);
+    return paneTarget;
   },
   tmux: {
     sendKeys: async (target: string, key: string) => {

--- a/test/isolated/vendor-sleep-impl-extra-coverage.test.ts
+++ b/test/isolated/vendor-sleep-impl-extra-coverage.test.ts
@@ -13,6 +13,9 @@ mock.module("maw-js/sdk", () => ({
   listSessions: async () => sessions,
   saveTabOrder: async (session: string) => { calls.push(`save:${session}`); },
   takeSnapshot: async (trigger: string) => { calls.push(`snapshot:${trigger}`); },
+  runSleepLifecycleHooks: async (ctx: { oracle: string; session: string; window: string }) => {
+    calls.push(`hook:${ctx.oracle}:${ctx.session}:${ctx.window}`);
+  },
   tmux: {
     sendKeysLiteral: async (target: string, ch: string) => { calls.push(`literal:${target}:${ch}`); },
     sendKeys: async (target: string, key: string) => { calls.push(`key:${target}:${key}`); },


### PR DESCRIPTION
## Summary
- Aligns sparse mocks in assigned vendor/team isolated coverage files with the SDK exports those modules now statically import.
- Covers vendor about/bud/sleep/run/send, attach-more, bud init/broadcast/rename, command plugins, sleep impl, and team vendor handler fixtures.

## Validation
- Reproduced assigned sparse-mock failures before patch.
- Not fully shard-verified: pushed partial by urgent request.
