### PR TITLE
fix(ci): align coverage mocks with SDK exports

### DIFF
--- a/test/isolated/coverage-100b-vendor-a-branches.test.ts
+++ b/test/isolated/coverage-100b-vendor-a-branches.test.ts
@@ -73,8 +73,13 @@ mock.module("child_process", () => ({
 
 mock.module("maw-js/sdk", () => ({
   hostExec: async (cmd: string) => hostExecImpl(cmd),
+  ghqFind: async () => ghqPath,
   FLEET_DIR: join(tmpRoot || tmpdir(), "fleet"),
   getGhqRoot: () => ghqRoot,
+  fleetLoadDirForWrite: () => join(tmpRoot || tmpdir(), "fleet"),
+  ensureCloned: async (slug: string) => { hostExecCalls.push(`ensureCloned:${slug}`); },
+  parseWakeTarget: (value: string) => value.includes("/") ? { oracle: value.split("/").pop()?.replace(/-oracle$/, "") ?? value, slug: value } : null,
+  shouldAutoWake: (name: string, ctx: unknown) => ({ wake: shouldWake, reason: `skip ${name} ${JSON.stringify(ctx)}` }),
   loadFleetCore: () => [],
   loadFleetEntries: () => fleetEntries,
   fleetLoadDirForWrite: () => join(tmpRoot || tmpdir(), "fleet"),

--- a/test/isolated/coverage-100b-vendor-b-team.test.ts
+++ b/test/isolated/coverage-100b-vendor-b-team.test.ts
@@ -55,6 +55,14 @@ mock.module("maw-js/sdk", () => ({
   resolveTarget: () => null,
   Tmux: class {},
   FLEET_DIR: join(psi, "fleet"),
+  parseFlags: (args: string[]) => {
+    const flags: Record<string, unknown> = { _: [] as string[] };
+    for (const arg of args) {
+      if (arg.startsWith("--")) flags[arg.slice(2)] = true;
+      else (flags._ as string[]).push(arg);
+    }
+    return flags;
+  },
 }));
 mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/team/oracle-members"), () => ({
   loadOracleRegistry: () => ({ members: [{ oracle: "neo" }] }),


### PR DESCRIPTION
Partial CI fix for assigned coverage-100/coverage-next sparse SDK mocks. Includes known passing local fixes for coverage-100-last-five, coverage-100b-vendor-a-branches, and coverage-100b-vendor-b-team.