### PR TITLE
fix(test): repair standalone+index mock completeness

### DIFF
--- a/test/isolated/plugin-follow-standalone.test.ts
+++ b/test/isolated/plugin-follow-standalone.test.ts
@@ -26,11 +26,18 @@ mock.module("maw-js/cli/parse-args", () => ({
   },
 }));
 
-mock.module("maw-js/sdk", () => ({
+const sdkMock = {
+  isInfrastructureChannelSessionName: () => false,
+  resolveFleetWindowSessionTarget: () => null,
+  resolveSessionTarget: () => null,
   listSessions: async () => [{ name: "neo", windows: [{ index: 0, name: "main", active: true }] }],
   loadConfig: () => ({ port: 3456 }),
   loadFleetCore: () => [],
-}));
+};
+
+mock.module("maw-js/sdk", () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk"), () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
 
 const impl = await import("../../src/vendor/mpr-plugins/follow/impl.ts?plugin-follow-standalone");
 const { default: followHandler } = await import("../../src/vendor/mpr-plugins/follow/index.ts?plugin-follow-standalone");

--- a/test/isolated/plugin-health-standalone.test.ts
+++ b/test/isolated/plugin-health-standalone.test.ts
@@ -41,6 +41,7 @@ const sdkMock = {
 };
 
 mock.module("maw-js/sdk", () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk"), () => sdkMock);
 mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
 mock.module("child_process", () => ({
   execSync: (cmd: string) => {
@@ -73,10 +74,10 @@ beforeEach(() => {
     throw new Error(`unexpected execSync: ${cmd}`);
   };
   setPlatform("linux");
-  globalThis.fetch = (async () => {
+  globalThis.fetch = mock(async () => {
     if (fetchResult instanceof Error) throw fetchResult;
     return fetchResult as Response;
-  }) as typeof fetch;
+  }) as unknown as typeof fetch;
 });
 
 afterEach(() => {

--- a/test/isolated/sleep-lifecycle.test.ts
+++ b/test/isolated/sleep-lifecycle.test.ts
@@ -16,6 +16,20 @@ const tempDirs: string[] = [];
 const session = { name: "54-mawjs", windows: [{ name: "mawjs-oracle" }] };
 
 const sdkMock = () => ({
+  detectSession: async (target: string) => {
+    calls.push(`detect:${target}`);
+    return session.name;
+  },
+  loadFleetCore: () => {
+    calls.push("loadFleet");
+    return [session];
+  },
+  mawMessageLogPath: () => join(tmpdir(), "maw-sleep-life.log"),
+  runSleepLifecycleHooks: async (ctx: { oracle: string; target: string; session: string; window: string }) => {
+    calls.push(`hook:${ctx.oracle}:${ctx.target}:${ctx.session}:${ctx.window}`);
+    if ((globalThis as any).__mawSleepLifecycleThrow) throw new Error("plugin lifecycle sleep failed for sleep-ledger: fatal sleep hook");
+    return { ok: true, results: [] };
+  },
   listSessions: async () => {
     calls.push("listSessions");
     return [session];
@@ -63,6 +77,7 @@ mock.module("maw-js/commands/shared/wake", wakeMock);
 mock.module("maw-js/commands/shared/fleet-load", fleetMock);
 
 mock.module(join(import.meta.dir, "../../src/sdk"), sdkMock);
+mock.module(join(import.meta.dir, "../../src/sdk/index.ts"), sdkMock);
 mock.module(join(import.meta.dir, "../../src/commands/shared/wake"), wakeMock);
 mock.module(join(import.meta.dir, "../../src/plugin/registry"), () => ({
   discoverPackages: () => plugins,

--- a/test/isolated/wake-index-coverage.test.ts
+++ b/test/isolated/wake-index-coverage.test.ts
@@ -1,5 +1,24 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+function parseFlags(args: string[], spec: Record<string, unknown>, start = 0) {
+  const out: Record<string, any> & { _: string[] } = { _: [] };
+  for (let i = start; i < args.length; i += 1) {
+    const arg = args[i]!;
+    const parser = spec[arg];
+    if (!parser) out._.push(arg);
+    else if (typeof parser === "string") out[parser] = true;
+    else if (parser === Boolean) out[arg] = true;
+    else if (parser === Number) out[arg] = Number(args[++i]);
+    else if (parser === String) out[arg] = args[++i];
+  }
+  return out;
+}
+
+const sdkMock = { parseFlags };
+mock.module("maw-js/sdk", () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk"), () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
+
 const wakeCalls: Array<{ oracle: string; opts: Record<string, unknown> }> = [];
 const wakeAllCalls: Array<Record<string, unknown>> = [];
 const parseTargetCalls: string[] = [];
@@ -15,21 +34,25 @@ let peersByAlias = new Map<string, { url: string }>();
 let peerWakeResult: { ok: boolean; status?: number; data?: any } = { ok: true, data: {} };
 let peerWakeError: Error | null = null;
 
-mock.module("maw-js/commands/shared/wake", () => ({
+const wakeSharedMock = () => ({
   cmdWake: async (oracle: string, opts: Record<string, unknown>) => {
     wakeCalls.push({ oracle, opts });
     console.log(`wake ${oracle}`);
   },
-}));
+} as const);
+mock.module("maw-js/commands/shared/wake", wakeSharedMock);
+mock.module(import.meta.resolve("../../src/commands/shared/wake.ts"), wakeSharedMock);
 
-mock.module("maw-js/commands/shared/fleet", () => ({
+const fleetSharedMock = () => ({
   cmdWakeAll: async (opts: Record<string, unknown>) => {
     wakeAllCalls.push(opts);
     console.log("wake all invoked");
   },
-}));
+} as const);
+mock.module("maw-js/commands/shared/fleet", fleetSharedMock);
+mock.module(import.meta.resolve("../../src/commands/shared/fleet.ts"), fleetSharedMock);
 
-mock.module("maw-js/commands/shared/wake-target", () => ({
+const wakeTargetMock = () => ({
   parseWakeTarget: (target: string) => {
     parseTargetCalls.push(target);
     return parsedTarget;
@@ -37,14 +60,18 @@ mock.module("maw-js/commands/shared/wake-target", () => ({
   ensureCloned: async (slug: string) => {
     ensureClonedCalls.push(slug);
   },
-}));
+} as const);
+mock.module("maw-js/commands/shared/wake-target", wakeTargetMock);
+mock.module(import.meta.resolve("../../src/commands/shared/wake-target.ts"), wakeTargetMock);
 
-mock.module("maw-js/commands/shared/wake-resolve", () => ({
+const wakeResolveMock = () => ({
   fetchGitHubPrompt: async (kind: string, num: number, repo?: string) => {
     fetchPromptCalls.push({ kind, num, repo });
     return fetchedPrompt;
   },
-}));
+} as const);
+mock.module("maw-js/commands/shared/wake-resolve", wakeResolveMock);
+mock.module(import.meta.resolve("../../src/commands/shared/wake-resolve.ts"), wakeResolveMock);
 
 mock.module(peerResolvePath, () => ({
   resolvePeer: (alias: string) => peersByAlias.get(alias) ?? null,


### PR DESCRIPTION
## Summary
- complete SDK mocks for standalone follow/health/wake and sleep lifecycle tests
- align wake/index coverage mocks with current SDK boundary imports
- keep the standalone/index tests as blocking coverage pattern

## Validation
- bash scripts/test-isolated.sh test/isolated/plugin-follow-standalone.test.ts test/isolated/plugin-health-standalone.test.ts test/isolated/plugin-wake-standalone.test.ts test/isolated/sleep-lifecycle.test.ts test/isolated/wake-index-coverage.test.ts test/isolated/wake-index-peer-extra-coverage.test.ts