### PR TITLE
test(wake): isolate resolver env

### DIFF
--- a/src/commands/shared/wake-resolve-impl.test.ts
+++ b/src/commands/shared/wake-resolve-impl.test.ts
@@ -7,11 +7,43 @@
  * full repo name, the stripped form (exact), or a `NN-<full>` numbered
  * session — and return null otherwise so the caller can auto-create.
  */
-import { describe, it, expect, mock } from "bun:test";
+import { afterEach, beforeEach, describe, it, expect, mock } from "bun:test";
 import { join } from "path";
 
 const root = join(import.meta.dir, "../..");
 const { mockConfigModule } = await import("../../../test/helpers/mock-config");
+
+
+const envKeys = [
+  "MAW_HOME",
+  "MAW_DATA_DIR",
+  "MAW_STATE_DIR",
+  "MAW_CACHE_DIR",
+  "MAW_CONFIG_DIR",
+  "MAW_XDG",
+  "MAW_HOST",
+  "MAW_PORT",
+  "MAW_QUIET",
+  "TMUX",
+  "XDG_CONFIG_HOME",
+  "XDG_DATA_HOME",
+  "XDG_STATE_HOME",
+  "XDG_CACHE_HOME",
+  "NODE_ENV",
+] as const;
+const originalEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]));
+
+function resetResolverEnv(): void {
+  for (const key of envKeys) delete process.env[key];
+}
+
+function restoreResolverEnv(): void {
+  for (const key of envKeys) {
+    const value = originalEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
 
 let tmuxSessions: Array<{ name: string }> = [];
 let hostExecOut = "";
@@ -41,6 +73,16 @@ const {
   setSessionEnv,
 } = await import("./wake-resolve-impl");
 
+
+beforeEach(() => {
+  resetResolverEnv();
+  tmuxSessions = [];
+  hostExecOut = "";
+});
+
+afterEach(() => {
+  restoreResolverEnv();
+});
 
 describe("resolveFromWorktrees — injected helper coverage", () => {
   it("resolves a main repo from a matching linked worktree", async () => {

--- a/test/isolated/wake-resolve-impl-fifteenth-pass-coverage.test.ts
+++ b/test/isolated/wake-resolve-impl-fifteenth-pass-coverage.test.ts
@@ -42,6 +42,37 @@ let spawnSpy: ReturnType<typeof spyOn> | null;
 const originalExit = process.exit;
 const originalLog = console.log;
 const originalError = console.error;
+const envKeys = [
+  "MAW_HOME",
+  "MAW_DATA_DIR",
+  "MAW_STATE_DIR",
+  "MAW_CACHE_DIR",
+  "MAW_CONFIG_DIR",
+  "MAW_XDG",
+  "MAW_HOST",
+  "MAW_PORT",
+  "MAW_QUIET",
+  "TMUX",
+  "XDG_CONFIG_HOME",
+  "XDG_DATA_HOME",
+  "XDG_STATE_HOME",
+  "XDG_CACHE_HOME",
+  "NODE_ENV",
+] as const;
+const originalEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]));
+
+function resetResolverEnv(): void {
+  for (const key of envKeys) delete process.env[key];
+}
+
+function restoreResolverEnv(): void {
+  for (const key of envKeys) {
+    const value = originalEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
 
 function resetFleetDir(): void {
   rmSync(fleetRoot, { recursive: true, force: true });
@@ -110,6 +141,7 @@ const {
 } = await import("../../src/commands/shared/wake-resolve-impl");
 
 beforeEach(() => {
+  resetResolverEnv();
   resetFleetDir();
   config = { githubOrg: "FallbackOrg", githubOrgs: undefined, peers: [], sessions: {} };
   envVars = {};
@@ -141,6 +173,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  restoreResolverEnv();
   spawnSpy?.mockRestore();
   process.exit = originalExit;
   console.log = originalLog;


### PR DESCRIPTION
## Summary
- Add explicit env reset/restore around wake resolver tests for MAW_*, TMUX, XDG, and NODE_ENV variables
- Harden current wake-resolve coverage that replaces the old sparse fourteenth/sixteenth files mentioned in #2357

Closes #2357

## Verification
- `CI=true bun test src/commands/shared/wake-resolve-impl.test.ts test/isolated/wake-resolve-impl-fifteenth-pass-coverage.test.ts`
- `CI=true bun run test:isolated -- --shard 4/4`
- `git diff --check`

Note: release/alpha-25 CI is now green, but this keeps the cross-machine env-leak rule encoded in the tests.
