### PR TITLE
Fix maw done orphan worktree cleanup

### DIFF
--- a/src/commands/shared/done.ts
+++ b/src/commands/shared/done.ts
@@ -1,4 +1,4 @@
-import { basename, dirname, join } from "path";
+import { basename, join } from "path";
 import { parseWorktreePath } from "../../core/fleet/worktree-layout";
 import { appendFileSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "fs";
 import { homedir } from "os";
@@ -87,15 +87,11 @@ function shellArg(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
-function isNotWorkingTreeError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return /not a working tree/i.test(message);
-}
-
-function archivePathFor(wtPath: string, d: ResolvedDoneDeps): string {
-  const stamp = d.now().toISOString().replace(/[^0-9A-Za-z_.-]/g, "-");
-  const safeBase = basename(wtPath).replace(/[^0-9A-Za-z_.-]/g, "-");
-  return `/tmp/maw-done-orphan-worktrees/${safeBase}-${stamp}`;
+class DirtyWorktreeRemovalError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DirtyWorktreeRemovalError";
+  }
 }
 
 async function dirExists(path: string, d: ResolvedDoneDeps): Promise<boolean> {
@@ -107,17 +103,48 @@ async function dirExists(path: string, d: ResolvedDoneDeps): Promise<boolean> {
   }
 }
 
-async function movePrunedWorktreeDir(wtPath: string, mainPath: string, d: ResolvedDoneDeps): Promise<boolean> {
+async function removeFailedWorktreeDir(
+  wtPath: string,
+  mainPath: string,
+  originalError: unknown,
+  opts: DoneOpts,
+  d: ResolvedDoneDeps,
+): Promise<boolean> {
   if (!(await dirExists(wtPath, d))) return false;
-  const archived = archivePathFor(wtPath, d);
+
+  let status = "";
+  let statusKnown = false;
   try {
-    await d.hostExec(`mkdir -p ${shellArg(dirname(archived))}`);
-    await d.hostExec(`mv ${shellArg(wtPath)} ${shellArg(archived)}`);
+    status = await d.hostExec(`git -C ${shellArg(wtPath)} status --porcelain --untracked-files=all`);
+    statusKnown = true;
+  } catch (e: any) {
+    if (!opts.force) {
+      throw new DirtyWorktreeRemovalError(
+        `worktree remove failed and ${wtPath} could not be checked for local changes (${e?.message || e}); rerun with --force to delete it`,
+      );
+    }
+    d.logger.log(`  \x1b[33m⚠\x1b[0m deleting ${basename(wtPath)} with --force after status check failed: ${e?.message || e}`);
+  }
+
+  const dirty = status.trim().length > 0;
+  if (dirty && !opts.force) {
+    throw new DirtyWorktreeRemovalError(
+      `worktree remove failed and ${wtPath} has uncommitted changes; rerun maw done --force to delete it`,
+    );
+  }
+
+  try {
+    await d.hostExec(`rm -rf ${shellArg(wtPath)}`);
     await d.hostExec(`git -C ${shellArg(mainPath)} worktree prune`);
-    d.logger.log(`  \x1b[32m✓\x1b[0m moved orphan directory ${basename(wtPath)} to ${archived}`);
+    const suffix = dirty
+      ? " with --force despite uncommitted changes"
+      : statusKnown
+        ? " after verifying it was clean"
+        : " with --force after status check failed";
+    d.logger.log(`  \x1b[32m✓\x1b[0m removed orphan directory ${basename(wtPath)}${suffix}`);
     return true;
   } catch (e: any) {
-    d.logger.log(`  \x1b[33m⚠\x1b[0m orphan directory move failed: ${e?.message || e}`);
+    d.logger.log(`  \x1b[33m⚠\x1b[0m orphan directory removal failed after worktree remove failed (${e?.message || e}); original error: ${originalError instanceof Error ? originalError.message : originalError}`);
     return false;
   }
 }
@@ -486,14 +513,17 @@ export async function removeWorktreeViaConfig(
         }
         return true;
       } catch (e: any) {
-        if (isNotWorkingTreeError(e) && await movePrunedWorktreeDir(fullPath, mainPath, d)) {
+        if (await removeFailedWorktreeDir(fullPath, mainPath, e, opts, d)) {
           return true;
         }
         d.logger.log(`  \x1b[33m⚠\x1b[0m worktree remove failed: ${e.message || e}`);
       }
       break;
     }
-  } catch (e) { d.logger.error(`  \x1b[33m⚠\x1b[0m fleet scan failed: ${e}`); }
+  } catch (e) {
+    if (e instanceof DirtyWorktreeRemovalError) throw e;
+    d.logger.error(`  \x1b[33m⚠\x1b[0m fleet scan failed: ${e}`);
+  }
   return false;
 }
 
@@ -547,14 +577,17 @@ export async function removeWorktreeByGhqScan(
           await cleanupDoneBranch(mainPath, branch, opts, deps);
         }
       } catch (e) {
-        if (isNotWorkingTreeError(e) && await movePrunedWorktreeDir(wtPath, mainPath, d)) {
+        if (await removeFailedWorktreeDir(wtPath, mainPath, e, opts, d)) {
           removed = true;
           continue;
         }
         d.logger.error(`  \x1b[33m⚠\x1b[0m worktree remove failed: ${e}`);
       }
     }
-  } catch (e) { d.logger.error(`  \x1b[33m⚠\x1b[0m worktree scan failed: ${e}`); }
+  } catch (e) {
+    if (e instanceof DirtyWorktreeRemovalError) throw e;
+    d.logger.error(`  \x1b[33m⚠\x1b[0m worktree scan failed: ${e}`);
+  }
   return removed;
 }
 

--- a/test/done-command.test.ts
+++ b/test/done-command.test.ts
@@ -521,6 +521,7 @@ describe("done worktree cleanup helpers", () => {
       },
       hostExec: (command) => {
         if (command.includes("worktree remove")) throw new Error("busy");
+        if (command.startsWith("test -d")) throw new Error("missing");
         return "feature\n";
       },
     });
@@ -630,6 +631,7 @@ describe("done worktree cleanup helpers", () => {
       hostExec: (command) => {
         if (command.startsWith("find ")) return "/repos/github.com/Soul-Brews-Studio/maw-js.wt-tile-1\n";
         if (command.includes("worktree remove")) throw new Error("busy");
+        if (command.startsWith("test -d")) throw new Error("missing");
         return "";
       },
     });

--- a/test/isolated/done-orphan-worktree.test.ts
+++ b/test/isolated/done-orphan-worktree.test.ts
@@ -38,24 +38,62 @@ function harness(hostExec: (command: string) => string | Promise<string>) {
 }
 
 describe("maw done orphan worktree cleanup", () => {
-  test("moves an already-pruned configured directory instead of reporting no worktree", async () => {
+  test("removes a clean configured orphan directory instead of reporting no worktree", async () => {
     const h = harness((command) => {
       if (command.includes("rev-parse --abbrev-ref")) throw new Error("not git");
       if (command.includes("worktree remove")) throw new Error(`fatal: '${primary}' is not a working tree`);
       if (command.startsWith("test -d")) return "";
-      if (command.startsWith("mkdir -p") || command.startsWith("mv ")) return "";
+      if (command.includes("status --porcelain")) return "";
+      if (command.startsWith("rm -rf")) return "";
       if (command.includes("worktree prune")) return "";
+      if (command.startsWith("find ")) return "";
+      return "";
+    });
+
+    await cmdDone("mawjs-codex", { cwd: main }, h.deps);
+
+    expect(h.logs.join("\n")).toContain("removed orphan directory 1-codex after verifying it was clean");
+    expect(h.logs.join("\n")).not.toContain("no worktree to remove");
+    expect(h.commands).toContain(`git -C '${primary}' status --porcelain --untracked-files=all`);
+    expect(h.commands).toContain(`rm -rf '${primary}'`);
+  });
+
+  test("refuses to remove a dirty orphan directory without force", async () => {
+    const h = harness((command) => {
+      if (command.includes("rev-parse --abbrev-ref")) return "feature\n";
+      if (command.includes("worktree remove")) throw new Error("busy");
+      if (command.startsWith("test -d")) return "";
+      if (command.includes("status --porcelain")) return " M src/file.ts\n";
+      if (command.startsWith("rm -rf")) throw new Error("dirty directory should not be removed");
+      if (command.startsWith("find ")) return "";
+      return "";
+    });
+
+    await expect(cmdDone("mawjs-codex", { cwd: main }, h.deps)).rejects.toThrow("has uncommitted changes");
+
+    expect(h.commands).toContain(`git -C '${primary}' status --porcelain --untracked-files=all`);
+    expect(h.commands.some(command => command.startsWith("rm -rf"))).toBe(false);
+    expect(JSON.parse(h.files.get("/fleet/team.json")!).windows).toHaveLength(1);
+  });
+
+  test("force-removes a dirty orphan directory", async () => {
+    const h = harness((command) => {
+      if (command.includes("rev-parse --abbrev-ref")) return "feature\n";
+      if (command.includes("worktree remove")) throw new Error("busy");
+      if (command.startsWith("test -d")) return "";
+      if (command.includes("status --porcelain")) return "?? scratch.txt\n";
+      if (command.startsWith("rm -rf")) return "";
+      if (command.includes("worktree prune")) return "";
+      if (command.includes("merge-base --is-ancestor")) return "";
       if (command.startsWith("find ")) return "";
       return "";
     });
 
     await cmdDone("mawjs-codex", { force: true, cwd: main }, h.deps);
 
-    expect(h.logs.join("\n")).toContain("moved orphan directory 1-codex to /tmp/maw-done-orphan-worktrees");
-    expect(h.logs.join("\n")).not.toContain("no worktree to remove");
-    expect(h.commands).toContain(
-      `mv '${primary}' '/tmp/maw-done-orphan-worktrees/1-codex-2026-06-06T01-02-03.004Z'`,
-    );
+    expect(h.logs.join("\n")).toContain("removed orphan directory 1-codex with --force despite uncommitted changes");
+    expect(h.commands).toContain(`rm -rf '${primary}'`);
+    expect(JSON.parse(h.files.get("/fleet/team.json")!).windows).toEqual([]);
   });
 
   test("surfaces same-member worktrees that remain in other repos", async () => {


### PR DESCRIPTION
## Summary
- Handle failed `git worktree remove` in `maw done` by checking the target directory status before fallback deletion.
- Remove and prune clean orphan directories instead of silently continuing.
- Refuse dirty/unverifiable directories unless `--force` is used, preserving fleet config when aborting.

Closes #2369.

## Tests
- `bun test test/isolated/done-orphan-worktree.test.ts test/done-command.test.ts`
- `bun test test/isolated/done-orphan-worktree.test.ts test/done-command.test.ts test/isolated/done-worktree-coverage.test.ts test/isolated/done-worktree-force-real.test.ts test/isolated/worktrees-cleanup-coverage.test.ts`

## Notes
- `bunx tsc --noEmit` is not usable in this repo as invoked because no tsconfig/input set is discovered.
- `bun run test:default:safe` currently fails in unrelated tmux wrapper tests; the done-command tests in that sweep pass.