### PR TITLE
Fix maw wake skipping merged worktrees

### DIFF
--- a/src/commands/shared/wake-cmd-helpers.ts
+++ b/src/commands/shared/wake-cmd-helpers.ts
@@ -164,6 +164,57 @@ export async function retryFreshSessionTmuxStep<T>(
   throw new Error(`unreachable: fresh tmux session setup step '${label}' exhausted without throwing`);
 }
 
+
+export type RehydrateWorktree = { name: string; path: string };
+
+export type RehydrateMergeCheckDeps = {
+  hostExec: (command: string) => Promise<string>;
+  baseBranch?: string;
+};
+
+function shellArg(value: string): string {
+  return "'" + value.replace(/'/g, "'\\''") + "'";
+}
+
+function parseMergedBranches(output: string): Set<string> {
+  return new Set(
+    output
+      .split("\n")
+      .map(line => line.replace(/^\*?\s*/, "").trim())
+      .filter(Boolean),
+  );
+}
+
+export async function isWorktreeBranchMergedToBase(
+  worktree: RehydrateWorktree,
+  deps: RehydrateMergeCheckDeps,
+): Promise<boolean> {
+  const baseBranch = deps.baseBranch ?? "alpha";
+  const cwd = shellArg(worktree.path);
+  try {
+    const branch = (await deps.hostExec(`git -C ${cwd} branch --show-current`)).trim();
+    if (!branch) return false;
+    const merged = await deps.hostExec(`git -C ${cwd} branch --merged ${shellArg(baseBranch)}`);
+    return parseMergedBranches(merged).has(branch);
+  } catch {
+    // Rehydrate conservatively if Git cannot answer. A stale or missing local
+    // alpha ref should not hide a still-active worktree.
+    return false;
+  }
+}
+
+export async function filterMergedWorktreesForRehydrate(
+  worktrees: RehydrateWorktree[],
+  deps: RehydrateMergeCheckDeps,
+): Promise<RehydrateWorktree[]> {
+  const kept: RehydrateWorktree[] = [];
+  for (const wt of worktrees) {
+    if (await isWorktreeBranchMergedToBase(wt, deps)) continue;
+    kept.push(wt);
+  }
+  return kept;
+}
+
 export type RehydrateWorktreePlan = {
   worktreeName: string;
   windowName: string;

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -29,6 +29,7 @@ import { UserError } from "../../core/util/user-error";
 import {
   type RehydrateWorktreePlan,
   type SnapshotRestorePlan,
+  filterMergedWorktreesForRehydrate,
   findWakeSnapshotSession,
   planRehydrateWorktreeWindows,
   planSnapshotRestoreWindows,
@@ -43,6 +44,7 @@ export {
   type SnapshotRestorePlan,
   type WakeBudLineageInput,
   buildWakeBudLineage,
+  filterMergedWorktreesForRehydrate,
   findWakeSnapshotSession,
   planRehydrateWorktreeWindows,
   planSnapshotRestoreWindows,
@@ -1052,7 +1054,8 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
     }
 
     const liveTileRoles = session ? await getLiveTileRoles(session) : new Set<string>();
-    const planned = planRehydrateWorktreeWindows(oracle, allWt, existingWindows, liveTileRoles);
+    const rehydratableWt = await filterMergedWorktreesForRehydrate(allWt, { hostExec, baseBranch: "alpha" });
+    const planned = planRehydrateWorktreeWindows(oracle, rehydratableWt, existingWindows, liveTileRoles);
     if (planned.length === 0) {
       console.log(`\x1b[90m↻ would respawn: none\x1b[0m`);
       logAgentsRehydrationSource(0, allWt);
@@ -1136,7 +1139,8 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
 
     if (!foreignSession && !opts.task && !opts.wt && !opts.noRehydrate) {
       const allWt = await findWorktrees(parentDir, repoName);
-      const plan = planRehydrateWorktreeWindows(oracle, allWt, [...existingWindows]);
+      const rehydratableWt = await filterMergedWorktreesForRehydrate(allWt, { hostExec, baseBranch: "alpha" });
+      const plan = planRehydrateWorktreeWindows(oracle, rehydratableWt, [...existingWindows]);
       logAgentsRehydrationSource(plan.length, allWt);
       if (plan.length > 0) {
         console.log(`\x1b[36m↻\x1b[0m rehydrating from agents/ folder:`);
@@ -1181,7 +1185,8 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
       if (allWt.length > 0) {
         const existingWindows = [...preExistingWindows];
         const liveTileRoles = await getLiveTileRoles(session);
-        const plan = planRehydrateWorktreeWindows(oracle, allWt, existingWindows, liveTileRoles);
+        const rehydratableWt = await filterMergedWorktreesForRehydrate(allWt, { hostExec, baseBranch: "alpha" });
+        const plan = planRehydrateWorktreeWindows(oracle, rehydratableWt, existingWindows, liveTileRoles);
         logAgentsRehydrationSource(plan.length, allWt);
         if (plan.length > 0) {
           console.log(`\x1b[36m↻\x1b[0m rehydrating from agents/ folder:`);

--- a/test/isolated/wake-cmd-dryrun-coverage.test.ts
+++ b/test/isolated/wake-cmd-dryrun-coverage.test.ts
@@ -171,6 +171,7 @@ mock.module(import.meta.resolve("../../src/core/fleet/snapshot"), () => ({
 mock.module(import.meta.resolve("../../src/commands/shared/wake-cmd-helpers"), () => ({
   ...realWakeHelpers,
   findWakeSnapshotSession: () => findWakeSnapshotSessionReturn,
+  filterMergedWorktreesForRehydrate: async (worktrees: any[]) => worktrees,
   planRehydrateWorktreeWindows: () => planRehydrateReturn,
   planSnapshotRestoreWindows: () => planSnapshotRestoreReturn,
   retryFreshSessionTmuxStep: async (_session: string, _label: string, fn: () => unknown) => await fn(),

--- a/test/isolated/wake-cmd-extra-coverage.test.ts
+++ b/test/isolated/wake-cmd-extra-coverage.test.ts
@@ -161,6 +161,7 @@ mock.module(import.meta.resolve("../../src/core/fleet/snapshot"), () => ({
 mock.module(import.meta.resolve("../../src/commands/shared/wake-cmd-helpers"), () => ({
   buildWakeBudLineage: () => "",
   findWakeSnapshotSession: () => snapshotSessionReturn,
+  filterMergedWorktreesForRehydrate: async (worktrees: any[]) => worktrees,
   planRehydrateWorktreeWindows: () => [],
   planSnapshotRestoreWindows: () => plannedSnapshotWindows,
   retryFreshSessionTmuxStep: async (_session: string, _label: string, fn: () => unknown) => await fn(),

--- a/test/isolated/wake-cmd-thirteenth-pass-coverage.test.ts
+++ b/test/isolated/wake-cmd-thirteenth-pass-coverage.test.ts
@@ -268,6 +268,7 @@ mock.module(import.meta.resolve("../../src/core/fleet/snapshot"), () => ({
 mock.module(import.meta.resolve("../../src/commands/shared/wake-cmd-helpers"), () => ({
   buildWakeBudLineage: () => "",
   findWakeSnapshotSession: () => snapshotSessionReturn,
+  filterMergedWorktreesForRehydrate: async (worktrees: any[]) => worktrees,
   planRehydrateWorktreeWindows: () => plannedRehydrateWindows,
   planSnapshotRestoreWindows: () => plannedSnapshotWindows,
   retryFreshSessionTmuxStep: async (_session: string, _label: string, fn: () => unknown) => await fn(),

--- a/test/wake-cmd-default.test.ts
+++ b/test/wake-cmd-default.test.ts
@@ -4,6 +4,7 @@ import { join } from "path";
 import { tmpdir } from "os";
 import {
   buildWakeBudLineage,
+  filterMergedWorktreesForRehydrate,
   findWakeSnapshotSession,
   getLiveTileRoles,
   promptAmbiguousWorktreePick,
@@ -327,6 +328,33 @@ describe("wake worktree rehydrate planning — default coverage", () => {
     expect(planned).toEqual([
       { worktreeName: "feature-a", windowName: "mawjs-feature-a", path: "/repo/wt-feature-a" },
       { worktreeName: "2-feature-a", windowName: "mawjs-2-feature-a", path: "/repo/wt-2-feature-a" },
+    ]);
+  });
+
+  it("filters worktrees whose current branch is already merged to alpha before planning", async () => {
+    const commands: string[] = [];
+    const worktrees = [
+      { name: "2370-done", path: "/repo/agents/2370-done" },
+      { name: "2370-open", path: "/repo/agents/2370-open" },
+    ];
+
+    const filtered = await filterMergedWorktreesForRehydrate(worktrees, {
+      hostExec: async (command: string) => {
+        commands.push(command);
+        if (command.includes("2370-done") && command.includes("branch --show-current")) return "feature/done\n";
+        if (command.includes("2370-done") && command.includes("branch --merged")) return "  alpha\n* feature/done\n";
+        if (command.includes("2370-open") && command.includes("branch --show-current")) return "feature/open\n";
+        if (command.includes("2370-open") && command.includes("branch --merged")) return "  alpha\n";
+        throw new Error(`unexpected command: ${command}`);
+      },
+    });
+
+    expect(filtered).toEqual([{ name: "2370-open", path: "/repo/agents/2370-open" }]);
+    expect(commands).toEqual([
+      "git -C '/repo/agents/2370-done' branch --show-current",
+      "git -C '/repo/agents/2370-done' branch --merged 'alpha'",
+      "git -C '/repo/agents/2370-open' branch --show-current",
+      "git -C '/repo/agents/2370-open' branch --merged 'alpha'",
     ]);
   });
 });


### PR DESCRIPTION
## Summary
- Filter discovered rehydrate worktrees through `git branch --merged alpha` before planning tmux windows
- Skip branches already merged to alpha while keeping conservative behavior when Git cannot answer
- Add regression coverage for merged-vs-open worktrees

Closes #2370

## Tests
- `bun test test/wake-cmd-default.test.ts`
- `bun test test/isolated/wake-rehydrate-plan.test.ts test/isolated/wake-cmd-helper-coverage.test.ts`
- `bun run build`