### PR TITLE
Fix wake task window name collisions

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -789,11 +789,28 @@ export async function chooseWakeSessionName(oracle: string, urlRepoName?: string
   return `${String(maxNum + 1).padStart(2, "0")}-${baseName}`;
 }
 
+type WakeWindowLookupEntry = { name: string; cwd?: string };
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function findExistingWakeWindowEntry<T extends WakeWindowLookupEntry>(
+  windows: Iterable<T>,
+  oracle: string,
+  windowName: string,
+): T | undefined {
+  const entries = [...windows];
+  const nameSuffix = windowName.startsWith(`${oracle}-`)
+    ? windowName.slice(`${oracle}-`.length)
+    : windowName;
+  const numberedPattern = new RegExp(`^${escapeRegExp(oracle)}-\\d+-${escapeRegExp(nameSuffix)}$`);
+  return entries.find(w => w.name === windowName)
+    || entries.find(w => numberedPattern.test(w.name));
+}
+
 function findExistingWakeWindow(windowNames: Iterable<string>, oracle: string, windowName: string): string | undefined {
-  const names = [...windowNames];
-  const nameSuffix = windowName.replace(`${oracle}-`, "");
-  return names.find(w => w === windowName)
-    || names.find(w => new RegExp(`^${oracle}-\\d+-${nameSuffix}$`).test(w));
+  return findExistingWakeWindowEntry([...windowNames].map(name => ({ name })), oracle, windowName)?.name;
 }
 
 export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string> {
@@ -1067,6 +1084,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
   }
 
   let knownWindows = new Set<string>();
+  let knownWindowEntries: WakeWindowLookupEntry[] = [];
   let knownWindowsReliable = true;
 
   if (shouldCreateSession) {
@@ -1117,7 +1135,8 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
 
     await runWakeLifecycleHooks({ oracle, session, repoPath, repoName });
 
-    let existingWindows = new Set((await tmux.listWindows(session).catch(() => [] as { name: string }[])).map(w => w.name));
+    const initialWindows = await tmux.listWindows(session).catch(() => [] as WakeWindowLookupEntry[]);
+    let existingWindows = new Set(initialWindows.map(w => w.name));
     existingWindows.add(mainWindowName);
     if (requestedSnapshotSession) {
       const allWt = await findWorktrees(parentDir, repoName);
@@ -1151,12 +1170,15 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
       }
     }
     knownWindows = existingWindows;
+    knownWindowEntries = [...initialWindows, { name: mainWindowName, cwd: repoPath }];
   } else {
     await setSessionEnv(session);
     await runWakeLifecycleHooks({ oracle, session, repoPath, repoName });
+    let preExistingWindowEntries: WakeWindowLookupEntry[] = [];
     let preExistingWindows = new Set<string>();
     try {
-      preExistingWindows = new Set((await tmux.listWindows(session)).map(w => w.name));
+      preExistingWindowEntries = await tmux.listWindows(session);
+      preExistingWindows = new Set(preExistingWindowEntries.map(w => w.name));
     } catch {
       knownWindowsReliable = false;
     }
@@ -1191,6 +1213,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
           await new Promise(r => setTimeout(r, 300));
           await tmux.sendText(`${session}:${wt.windowName}`, buildWakeCommand(wt.windowName, wt.path, opts));
           preExistingWindows.add(wt.windowName);
+          preExistingWindowEntries.push({ name: wt.windowName, cwd: wt.path });
           console.log(`\x1b[32m↻\x1b[0m respawned: ${wt.windowName}  \x1b[90m(from ${formatWorktreeSource(wt.path)})\x1b[0m`);
         }
       } else {
@@ -1202,6 +1225,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
     const retried = await wakeSession.ensureSessionRunning(session, preExistingWindows);
     if (retried > 0) console.log(`\x1b[33m${retried} window(s) retried.\x1b[0m`);
     knownWindows = preExistingWindows;
+    knownWindowEntries = preExistingWindowEntries;
   }
 
   const reordered = foreignSession ? 0 : await restoreTabOrder(session);
@@ -1276,13 +1300,23 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
       targetPath = match.path;
       windowName = `${oracle}-${name}`;
     } else {
-      const result = await wakeSession.createWorktree(repoPath, parentDir, repoName, oracle, name, worktrees, {
-        fresh: !!opts.fresh,
-        named: Boolean(stableName && !opts.fresh),
-        layout: worktreeLayout,
-      });
-      targetPath = result.wtPath;
-      windowName = result.windowName;
+      const existingTaskWindow = opts.fresh
+        ? undefined
+        : findExistingWakeWindowEntry(knownWindowEntries, oracle, `${oracle}-${name}`);
+      if (existingTaskWindow) {
+        console.log(`\x1b[33m⚡\x1b[0m reusing live window: ${session}:${existingTaskWindow.name}`);
+        targetPath = existingTaskWindow.cwd || repoPath;
+        windowName = existingTaskWindow.name;
+      } else {
+        const result = await wakeSession.createWorktree(repoPath, parentDir, repoName, oracle, name, worktrees, {
+          fresh: !!opts.fresh,
+          named: Boolean(stableName && !opts.fresh),
+          layout: worktreeLayout,
+          existingWindowNames: knownWindows,
+        });
+        targetPath = result.wtPath;
+        windowName = result.windowName;
+      }
     }
 
     if (opts.bud) {

--- a/src/commands/shared/wake-session.ts
+++ b/src/commands/shared/wake-session.ts
@@ -20,6 +20,8 @@ export interface WakeSessionDeps {
   named: boolean;
   /** Filesystem layout for newly-created worktrees (#1850). Defaults to nested repo/agents/<name>. */
   layout: WorktreeLayout;
+  /** Existing tmux window names in the target session; used to avoid duplicate wake --task windows. */
+  existingWindowNames: Iterable<string>;
 }
 
 export function wakeSessionDeps(overrides: Partial<WakeSessionDeps> = {}): WakeSessionDeps {
@@ -35,6 +37,7 @@ export function wakeSessionDeps(overrides: Partial<WakeSessionDeps> = {}): WakeS
     fresh: false,
     named: false,
     layout: "nested",
+    existingWindowNames: [],
     ...overrides,
   };
 }
@@ -224,15 +227,26 @@ export async function createWorktree(
   }
 
   const layout = normalizeWorktreeLayout(d.layout);
+  const existingWindowNames = new Set([...d.existingWindowNames].filter(Boolean));
+  const preferredWindowName = `${oracle}-${name}`;
+  const windowNameForWorktree = (wtName: string): string => {
+    if (d.named) return preferredWindowName;
+    return existingWindowNames.has(preferredWindowName) ? `${oracle}-${wtName}` : preferredWindowName;
+  };
   let wtName = "";
   let wtPath = "";
   let branch = "";
+  let windowName = "";
   let branchExists = false;
   let allocated = false;
   if (d.named) {
     wtName = name;
     wtPath = worktreePathForLayout({ repoPath, parentDir, repoName, wtName, layout });
     branch = `agents/${wtName}`;
+    windowName = windowNameForWorktree(wtName);
+    if (existingWindowNames.has(windowName)) {
+      throw new Error(`tmux window '${windowName}' already exists`);
+    }
     const knownWorktree = existingWorktrees.some(w => w.name === wtName || w.path === wtPath);
     if (!knownWorktree) {
       try {
@@ -248,8 +262,9 @@ export async function createWorktree(
       wtName = `${nextNum}-${name}`;
       wtPath = worktreePathForLayout({ repoPath, parentDir, repoName, wtName, layout });
       branch = `agents/${wtName}`;
+      windowName = windowNameForWorktree(wtName);
       const knownWorktree = existingWorktrees.some(w => w.name === wtName || w.path === wtPath);
-      if (knownWorktree) {
+      if (knownWorktree || existingWindowNames.has(windowName)) {
         nextNum++;
         continue;
       }
@@ -268,7 +283,7 @@ export async function createWorktree(
     }
   }
 
-  if (!allocated || !wtName || !wtPath || !branch) {
+  if (!allocated || !wtName || !wtPath || !branch || !windowName) {
     throw new Error(`could not allocate worktree for ${name}`);
   }
 
@@ -281,5 +296,5 @@ export async function createWorktree(
   await d.hostExec(`git -C '${safe(repoPath)}' worktree add ${addArgs}`);
   await reconcileParentClaudeDir(repoPath, wtPath, d.log);
   d.log(`\x1b[32m+\x1b[0m worktree: ${wtPath} (${branch}${branchExists ? ", reused branch" : ""})`);
-  return { wtPath, windowName: `${oracle}-${name}` };
+  return { wtPath, windowName };
 }

--- a/test/wake-cmd-cmdwake-coverage.test.ts
+++ b/test/wake-cmd-cmdwake-coverage.test.ts
@@ -432,11 +432,23 @@ mock.module(
         name,
         deps,
       });
+      const existingWindowNames = new Set([...(deps?.existingWindowNames ?? [])].filter(Boolean));
+      const preferredWindowName = `${oracleArg}-${name}`;
+      let wtName = name;
+      let windowName = preferredWindowName;
+      if (!deps?.named && existingWindowNames.has(preferredWindowName)) {
+        let nextNum = 1;
+        do {
+          wtName = `${nextNum}-${name}`;
+          windowName = `${oracleArg}-${wtName}`;
+          nextNum++;
+        } while (existingWindowNames.has(windowName));
+      }
       const wtPath = deps?.layout === "legacy"
-        ? join(parentDirArg, `${repoNameArg}.wt-${name}`)
-        : join(repoPathArg, "agents", name);
+        ? join(parentDirArg, `${repoNameArg}.wt-${wtName}`)
+        : join(repoPathArg, "agents", wtName);
       mkdirSync(wtPath, { recursive: true });
-      return { wtPath, windowName: `${oracleArg}-${name}` };
+      return { wtPath, windowName };
     },
   }),
 );
@@ -1251,7 +1263,14 @@ describe("cmdWake main-suite coverage", () => {
     expect(result).toBe("12-seed:seed-newtool");
     expect(hostExecCalls).toContain("ghq get -u github.com/Soul-Brews-Studio/new-tool");
     expect(createdWorktrees).toEqual([
-      { repoPath, parentDir, repoName, oracle: "seed", name: "newtool", deps: { fresh: false, named: false, layout: "nested" } },
+      expect.objectContaining({
+        repoPath,
+        parentDir,
+        repoName,
+        oracle: "seed",
+        name: "newtool",
+        deps: expect.objectContaining({ fresh: false, named: false, layout: "nested" }),
+      }),
     ]);
   });
 
@@ -1576,6 +1595,19 @@ describe("cmdWake main-suite coverage", () => {
     expect(logs.join("\n")).toContain("reusing worktree");
   });
 
+  test("reuses a live task window instead of creating a duplicate (#2366)", async () => {
+    addWindow("54-mawjs", "mawjs-fix-2366");
+
+    const { result } = await captureLogs(() =>
+      cmdWake("mawjs", { task: "fix-2366" }),
+    );
+
+    expect(result).toBe("54-mawjs:mawjs-fix-2366");
+    expect(createdWorktrees).toEqual([]);
+    expect(newWindowCalls).toEqual([]);
+    expect(newWindowCalls.some(call => call.name === "mawjs-fix-2366")).toBe(false);
+  });
+
   test("registers split worktree windows before they can be joined away (#1956)", async () => {
     repoName = "homelab";
     repoPath = join(parentDir, repoName);
@@ -1635,7 +1667,14 @@ describe("cmdWake main-suite coverage", () => {
       scopeStem: "homekeeper-oracle",
     });
     expect(createdWorktrees).toEqual([
-      { repoPath, parentDir, repoName: "homelab", oracle: "homekeeper", name: "osmosis-white", deps: { fresh: false, named: true, layout: "nested" } },
+      expect.objectContaining({
+        repoPath,
+        parentDir,
+        repoName: "homelab",
+        oracle: "homekeeper",
+        name: "osmosis-white",
+        deps: expect.objectContaining({ fresh: false, named: true, layout: "nested" }),
+      }),
     ]);
     expect(newWindowCalls).toContainEqual({
       session: "04-homekeeper",
@@ -1686,7 +1725,14 @@ describe("cmdWake main-suite coverage", () => {
     const wtPath = join(repoPath, "agents", "fix-a");
     expect(result).toBe("54-mawjs:mawjs-fix-a");
     expect(createdWorktrees).toEqual([
-      { repoPath, parentDir, repoName, oracle: "mawjs", name: "fix-a", deps: { fresh: false, named: false, layout: "nested" } },
+      expect.objectContaining({
+        repoPath,
+        parentDir,
+        repoName,
+        oracle: "mawjs",
+        name: "fix-a",
+        deps: expect.objectContaining({ fresh: false, named: false, layout: "nested" }),
+      }),
     ]);
     expect(newWindowCalls).toContainEqual({
       session: "54-mawjs",

--- a/test/wake-session-default.test.ts
+++ b/test/wake-session-default.test.ts
@@ -208,6 +208,56 @@ describe("createWorktree", () => {
     expect(commands).toContain("git -C '/repo' worktree add '/repo/agents/1-white' -b 'agents/1-white'");
   });
 
+  test("skips a candidate when its tmux window name already exists", async () => {
+    const commands: string[] = [];
+    const result = await createWorktree(
+      "/repo",
+      "/tmp",
+      "repo",
+      "oracle",
+      "white",
+      [],
+      {
+        existingWindowNames: ["oracle-white"],
+        hostExec: async (cmd: string) => {
+          commands.push(cmd);
+          if (cmd.includes("rev-parse HEAD")) return "abc\n";
+          if (cmd.includes("show-ref")) throw new Error("missing branch");
+          return "";
+        },
+        log: () => {},
+      },
+    );
+
+    expect(result).toEqual({ wtPath: "/repo/agents/1-white", windowName: "oracle-1-white" });
+    expect(commands).toContain("git -C '/repo' worktree add '/repo/agents/1-white' -b 'agents/1-white'");
+  });
+
+  test("keeps allocating when the numbered fallback window also exists", async () => {
+    const commands: string[] = [];
+    const result = await createWorktree(
+      "/repo",
+      "/tmp",
+      "repo",
+      "oracle",
+      "white",
+      [],
+      {
+        existingWindowNames: ["oracle-white", "oracle-1-white"],
+        hostExec: async (cmd: string) => {
+          commands.push(cmd);
+          if (cmd.includes("rev-parse HEAD")) return "abc\n";
+          if (cmd.includes("show-ref")) throw new Error("missing branch");
+          return "";
+        },
+        log: () => {},
+      },
+    );
+
+    expect(result).toEqual({ wtPath: "/repo/agents/2-white", windowName: "oracle-2-white" });
+    expect(commands).toContain("git -C '/repo' worktree add '/repo/agents/2-white' -b 'agents/2-white'");
+  });
+
   test("reattaches an existing branch for the stable slot when the worktree dir is gone", async () => {
     const commands: string[] = [];
     const logs: string[] = [];


### PR DESCRIPTION
Closes #2366.

## Summary
- reuse an existing live wake task window before creating a worktree/window
- pass known tmux window names into wake worktree allocation
- make createWorktree skip colliding task window names and fall back to numbered window names
- add regression coverage for live-window reuse and allocator fallback

## Tests
- bun test test/wake-session-default.test.ts test/wake-cmd-cmdwake-coverage.test.ts
- bun run build