### PR TITLE
Fix maw kill duplicate window disambiguation

### DIFF
--- a/src/vendor/mpr-plugins/kill/impl.ts
+++ b/src/vendor/mpr-plugins/kill/impl.ts
@@ -8,10 +8,82 @@ import {
 export interface KillOpts {
   /** Pane index — narrows kill to a specific pane of the resolved window. */
   pane?: number;
+  /** Window index — disambiguates duplicate window names. */
+  index?: number;
+  /** Kill every window whose name matches the requested window. */
+  all?: boolean;
+}
+
+type KillWindowInfo = { index?: number; name?: string };
+
+function windowLabel(w: KillWindowInfo): string {
+  const index = Number.isInteger(w.index) ? String(w.index) : "?";
+  const name = w.name || "(unnamed)";
+  return `${index}:${name}`;
+}
+
+function parseWindowIndex(value: unknown): number | undefined {
+  if (value === undefined || value === null || value === "") return undefined;
+  if (typeof value === "number") return Number.isInteger(value) && value >= 0 ? value : undefined;
+  const text = String(value).trim();
+  if (!/^\d+$/.test(text)) return undefined;
+  const n = Number.parseInt(text, 10);
+  return Number.isInteger(n) && n >= 0 ? n : undefined;
+}
+
+function matchingWindowIndexes(
+  sessionName: string,
+  windows: KillWindowInfo[],
+  rawWindow: string,
+  opts: KillOpts,
+): number[] {
+  const optIndex = parseWindowIndex(opts.index);
+  if (opts.index !== undefined && optIndex === undefined) throw new Error(`--index must be a non-negative integer (got ${String(opts.index)})`);
+  if (opts.all && optIndex !== undefined) throw new Error("cannot combine --all and --index");
+  if (opts.all && opts.pane !== undefined) throw new Error("cannot combine --all and --pane");
+
+  if (optIndex !== undefined) {
+    const hit = windows.find(w => w.index === optIndex);
+    if (!hit) {
+      const valid = windows.map(windowLabel).join(", ") || "(none)";
+      throw new Error(`window index ${optIndex} does not exist in session ${sessionName} (valid: ${valid})`);
+    }
+    return [optIndex];
+  }
+
+  if (!rawWindow) return [];
+
+  // Preserve long-standing shorthand: session:2 means window index 2.
+  if (/^\d+$/.test(rawWindow)) {
+    const index = Number.parseInt(rawWindow, 10);
+    const hit = windows.find(w => w.index === index);
+    if (!hit) {
+      const valid = windows.map(windowLabel).join(", ") || "(none)";
+      throw new Error(`window index ${index} does not exist in session ${sessionName} (valid: ${valid})`);
+    }
+    return [index];
+  }
+
+  const requested = rawWindow.toLowerCase();
+  const matches = windows.filter(w => (w.name || "").toLowerCase() === requested);
+  if (matches.length === 0) {
+    const valid = windows.map(windowLabel).join(", ") || "(none)";
+    throw new Error(`window '${rawWindow}' not found in session ${sessionName} (valid: ${valid})`);
+  }
+  if (matches.length > 1 && !opts.all) {
+    const lines = matches.map(w => `    • ${windowLabel(w)}`).join("\n");
+    throw new Error(
+      `window '${rawWindow}' is ambiguous in session ${sessionName} — matches ${matches.length} windows:\n` +
+      `${lines}\n  use --index N to kill one, or --all to kill all matching windows`,
+    );
+  }
+  return matches
+    .map(w => w.index)
+    .filter((index): index is number => Number.isInteger(index));
 }
 
 /**
- * maw kill <target>[:window] [--pane N]
+ * maw kill <target>[:window] [--pane N] [--index N|--all]
  *
  * Trust the user — if they typed it, they meant it. No --force gate.
  *
@@ -25,11 +97,11 @@ export interface KillOpts {
  */
 export async function cmdKill(target: string, opts: KillOpts = {}) {
   if (!target) {
-    console.error("usage: maw kill <target>[:window] [--pane N]");
+    console.error("usage: maw kill <target>[:window] [--pane N] [--index N|--all]");
     console.error("  e.g. maw kill mawjs");
     console.error("       maw kill mawjs:0");
     console.error("       maw kill mawjs --pane 1");
-    throw new Error("usage: maw kill <target>[:window] [--pane N]");
+    throw new Error("usage: maw kill <target>[:window] [--pane N] [--index N|--all]");
   }
 
   const [rawSession, rawWindow] = target.includes(":")
@@ -88,10 +160,12 @@ export async function cmdKill(target: string, opts: KillOpts = {}) {
   const session = r.match.name;
   const tmux = tmuxCmd();
 
+  const windowIndexes = matchingWindowIndexes(session, r.match.windows ?? [], rawWindow, opts);
+
   // --pane requires a window, bare session kill does not
   if (opts.pane !== undefined) {
-    // Default to window 0 if no window given
-    const win = rawWindow || String(r.match.windows[0]?.index ?? 0);
+    // Default to the first window if no window/index given.
+    const win = windowIndexes[0] ?? r.match.windows[0]?.index ?? 0;
     const winTarget = `${session}:${win}`;
     const paneIndexesRaw = await hostExec(
       `${tmux} list-panes -t '${winTarget}' -F '#{pane_index}'`,
@@ -122,13 +196,24 @@ export async function cmdKill(target: string, opts: KillOpts = {}) {
     return;
   }
 
-  if (rawWindow) {
-    const win = `${session}:${rawWindow}`;
-    try {
-      await hostExec(`${tmux} kill-window -t '${win}'`);
-      console.log(`  \x1b[32m✓\x1b[0m killed window ${win}`);
-    } catch (e: any) {
-      throw new Error(`kill-window failed: ${e.message || e}`);
+  if (rawWindow || opts.index !== undefined || opts.all) {
+    if (windowIndexes.length === 0) {
+      throw new Error(opts.all ? "--all requires a window name target (session:window)" : "window target required");
+    }
+    const killed: string[] = [];
+    for (const index of windowIndexes) {
+      const win = `${session}:${index}`;
+      try {
+        await hostExec(`${tmux} kill-window -t '${win}'`);
+        killed.push(win);
+      } catch (e: any) {
+        throw new Error(`kill-window failed: ${e.message || e}`);
+      }
+    }
+    if (killed.length === 1) {
+      console.log(`  \x1b[32m✓\x1b[0m killed window ${killed[0]}`);
+    } else {
+      console.log(`  \x1b[32m✓\x1b[0m killed ${killed.length} windows ${killed.join(", ")}`);
     }
     return;
   }

--- a/src/vendor/mpr-plugins/kill/index.ts
+++ b/src/vendor/mpr-plugins/kill/index.ts
@@ -21,15 +21,15 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
   };
   try {
     let target: string;
-    let opts: { pane?: number } = {};
+    let opts: { pane?: number; index?: number; all?: boolean } = {};
 
     if (ctx.source === "cli") {
       const args = ctx.args as string[];
-      const flags = parseFlags(args, { "--pane": Number, "--peer": String }, 0);
+      const flags = parseFlags(args, { "--pane": Number, "--index": Number, "--all": Boolean, "--peer": String }, 0);
 
       target = flags._[0];
       if (!target || target === "--help" || target === "-h") {
-        return { ok: false, error: "usage: maw kill <target>[:window] [--pane N] [--peer <alias>]  (see: maw sleep for graceful stop, maw done for worktrees)" };
+        return { ok: false, error: "usage: maw kill <target>[:window] [--pane N] [--index N|--all] [--peer <alias>]  (see: maw sleep for graceful stop, maw done for worktrees)" };
       }
       if (target.startsWith("-")) {
         return { ok: false, error: `"${target}" looks like a flag, not a target.\n  usage: maw kill <target>  (see: maw sleep for graceful stop, maw done for worktrees)` };
@@ -39,12 +39,12 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         return await forwardToPeer(flags["--peer"], target, flags);
       }
 
-      opts = { pane: flags["--pane"] };
+      opts = { pane: flags["--pane"], index: flags["--index"], all: !!flags["--all"] };
     } else {
       const body = ctx.args as Record<string, unknown>;
       if (!body.target) return { ok: false, error: "target is required" };
       target = body.target as string;
-      opts = { pane: body.pane as number | undefined };
+      opts = { pane: body.pane as number | undefined, index: body.index as number | undefined, all: body.all as boolean | undefined };
     }
 
     await cmdKill(target, opts);
@@ -81,6 +81,8 @@ async function forwardToPeer(
 
   const body: Record<string, unknown> = { target };
   if (typeof flags["--pane"] === "number") body.pane = flags["--pane"];
+  if (typeof flags["--index"] === "number") body.index = flags["--index"];
+  if (flags["--all"]) body.all = true;
 
   const { callPeerKill } = await import("./internal/peer-call");
   let res: { ok: boolean; status?: number; data?: any };

--- a/src/vendor/mpr-plugins/kill/plugin.json
+++ b/src/vendor/mpr-plugins/kill/plugin.json
@@ -6,10 +6,12 @@
   "description": "Immediately kill a tmux session, window, or pane; use sleep for graceful single-agent shutdown or done for finished worktrees.",
   "cli": {
     "command": "kill",
-    "help": "maw kill <target>[:window] [--pane N] [--peer <alias>] — immediate tmux kill; see maw sleep for graceful stop and maw done for worktree cleanup",
+    "help": "maw kill <target>[:window] [--pane N] [--index N|--all] [--peer <alias>] \u2014 immediate tmux kill; see maw sleep for graceful stop and maw done for worktree cleanup",
     "flags": {
       "--pane": "number",
-      "--peer": "string"
+      "--peer": "string",
+      "--index": "number",
+      "--all": "boolean"
     }
   },
   "api": {

--- a/test/isolated/plugin-kill-standalone.test.ts
+++ b/test/isolated/plugin-kill-standalone.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
+
+type SessionLike = {
+  name: string;
+  windows?: Array<{ index?: number; name?: string }>;
+};
+
+let sessions: SessionLike[] = [];
+let hostExecCalls: string[] = [];
+let hostExecImpl: (cmd: string) => string | Promise<string> = () => "";
+
+const sdkMock = {
+  listSessions: async () => sessions,
+  tmuxCmd: () => "tmux",
+  hostExec: async (cmd: string) => {
+    hostExecCalls.push(cmd);
+    return await hostExecImpl(cmd);
+  },
+};
+
+mock.module("maw-js/sdk", () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk"), () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
+mock.module(new URL("../../src/sdk/index.ts", import.meta.url).pathname, () => sdkMock);
+
+const { command, default: killHandler } = await import("../../src/vendor/mpr-plugins/kill/index.ts?plugin-kill-standalone");
+const { cmdKill } = await import("../../src/vendor/mpr-plugins/kill/impl.ts?plugin-kill-standalone");
+
+function stripAnsi(value: string | undefined) {
+  return String(value ?? "").replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "");
+}
+
+beforeEach(() => {
+  sessions = [];
+  hostExecCalls = [];
+  hostExecImpl = () => "";
+});
+
+describe("kill plugin standalone boundary", () => {
+  test("uses the SDK/plugin boundary with an explicit shared pane resolver exception", () => {
+    const imports = expectStandalonePluginBoundary({
+      plugin: "kill",
+      allowMawJs: [/^maw-js\/core\/matcher\/resolve-target$/],
+      allowRelative: [/commands\/shared\/pane-target-resolver$/, /core\/xdg$/],
+    });
+
+    expect(command).toMatchObject({ name: "kill" });
+    expect(imports.map((record) => record.spec)).toContain("maw-js/sdk");
+    expect(imports.map((record) => record.spec)).toContain("maw-js/cli/parse-args");
+  });
+
+  test("handler parses --index and --all for local CLI and peer forwarding", async () => {
+    sessions = [{ name: "47-mawjs", windows: [{ index: 0, name: "lead" }, { index: 5, name: "codex" }] }];
+    hostExecImpl = (cmd) => {
+      if (cmd.includes("kill-window -t '47-mawjs:5'")) return "";
+      throw new Error(`unexpected command: ${cmd}`);
+    };
+
+    const indexed = await killHandler({ source: "cli", args: ["mawjs:codex", "--index", "5"] } as any);
+    expect(indexed.ok).toBe(true);
+    expect(stripAnsi(indexed.output)).toContain("killed window 47-mawjs:5");
+    expect(hostExecCalls).toEqual(["tmux kill-window -t '47-mawjs:5'"]);
+
+    hostExecCalls = [];
+    sessions = [{ name: "47-mawjs", windows: [{ index: 2, name: "codex" }, { index: 5, name: "codex" }] }];
+    hostExecImpl = (cmd) => {
+      if (cmd.includes("kill-window -t '47-mawjs:2'")) return "";
+      if (cmd.includes("kill-window -t '47-mawjs:5'")) return "";
+      throw new Error(`unexpected command: ${cmd}`);
+    };
+
+    const all = await killHandler({ source: "cli", args: ["mawjs:codex", "--all"] } as any);
+    expect(all.ok).toBe(true);
+    expect(stripAnsi(all.output)).toContain("killed 2 windows 47-mawjs:2, 47-mawjs:5");
+    expect(hostExecCalls).toEqual(["tmux kill-window -t '47-mawjs:2'", "tmux kill-window -t '47-mawjs:5'"]);
+  });
+
+  test("cmdKill refuses duplicate window names with actionable diagnostics", async () => {
+    sessions = [{
+      name: "47-mawjs",
+      windows: [
+        { index: 0, name: "lead" },
+        { index: 2, name: "codex" },
+        { index: 5, name: "codex" },
+      ],
+    }];
+
+    await expect(cmdKill("mawjs:codex")).rejects.toThrow("window 'codex' is ambiguous in session 47-mawjs");
+    expect(hostExecCalls).toEqual([]);
+  });
+});

--- a/test/isolated/vendor-shellenv-token-kill-extra-coverage.test.ts
+++ b/test/isolated/vendor-shellenv-token-kill-extra-coverage.test.ts
@@ -83,10 +83,10 @@ afterAll(() => {
 describe("vendor kill implementation branch coverage", () => {
   test("rejects a missing target before querying tmux", async () => {
     const { errors } = await captureConsole(async () => {
-      await expect(cmdKill("")).rejects.toThrow("usage: maw kill <target>[:window] [--pane N]");
+      await expect(cmdKill("")).rejects.toThrow("usage: maw kill <target>[:window] [--pane N] [--index N|--all]");
     });
 
-    expect(errors.join("\n")).toContain("usage: maw kill <target>[:window] [--pane N]");
+    expect(errors.join("\n")).toContain("usage: maw kill <target>[:window] [--pane N] [--index N|--all]");
     expect(hostExecCalls).toEqual([]);
   });
 
@@ -189,6 +189,38 @@ describe("vendor kill implementation branch coverage", () => {
       throw new Error(`unexpected command: ${cmd}`);
     };
     await expect(cmdKill("mawjs", { pane: 4 })).rejects.toThrow("kill-pane failed: permission denied");
+  });
+
+  test("refuses duplicate window names unless --index or --all disambiguates", async () => {
+    sessions = [{
+      name: "47-mawjs",
+      windows: [
+        { index: 0, name: "lead" },
+        { index: 2, name: "codex" },
+        { index: 5, name: "codex" },
+      ],
+    }];
+    hostExecImpl = (cmd) => {
+      if (cmd.includes("kill-window -t '47-mawjs:2'")) return "";
+      if (cmd.includes("kill-window -t '47-mawjs:5'")) return "";
+      throw new Error(`unexpected command: ${cmd}`);
+    };
+
+    await expect(cmdKill("mawjs:codex")).rejects.toThrow("window 'codex' is ambiguous in session 47-mawjs");
+    expect(hostExecCalls).toEqual([]);
+
+    await expect(captureConsole(() => cmdKill("mawjs:codex", { index: 5 }))).resolves.toMatchObject({
+      logs: [expect.stringContaining("killed window 47-mawjs:5")],
+    });
+
+    hostExecCalls = [];
+    await expect(captureConsole(() => cmdKill("mawjs:codex", { all: true }))).resolves.toMatchObject({
+      logs: [expect.stringContaining("killed 2 windows 47-mawjs:2, 47-mawjs:5")],
+    });
+    expect(hostExecCalls).toEqual([
+      "tmux kill-window -t '47-mawjs:2'",
+      "tmux kill-window -t '47-mawjs:5'",
+    ]);
   });
 
   test("kills windows and sessions, wrapping tmux failures with action-specific messages", async () => {

--- a/test/isolated/vendor-simple-plugins-coverage.test.ts
+++ b/test/isolated/vendor-simple-plugins-coverage.test.ts
@@ -471,7 +471,7 @@ describe("vendor kill/index handler coverage", () => {
 
     await expect(killHandler(makeCtx("cli", ["--help"]))).resolves.toEqual({
       ok: false,
-      error: "usage: maw kill <target>[:window] [--pane N] [--peer <alias>]  (see: maw sleep for graceful stop, maw done for worktrees)",
+      error: "usage: maw kill <target>[:window] [--pane N] [--index N|--all] [--peer <alias>]  (see: maw sleep for graceful stop, maw done for worktrees)",
     });
 
     await expect(killHandler(makeCtx("cli", ["--pane"]))).resolves.toEqual({
@@ -493,13 +493,25 @@ describe("vendor kill/index handler coverage", () => {
       ok: true,
       output: "killed mawjs:1 pane 2",
     });
-    expect(killCalls.at(-1)).toEqual({ target: "mawjs:1", opts: { pane: 2 } });
+    expect(killCalls.at(-1)).toEqual({ target: "mawjs:1", opts: { pane: 2, index: undefined, all: false } });
+
+    await expect(killHandler(makeCtx("cli", ["mawjs:codex", "--index", "5"]))).resolves.toEqual({
+      ok: true,
+      output: "killed mawjs:codex",
+    });
+    expect(killCalls.at(-1)).toEqual({ target: "mawjs:codex", opts: { pane: undefined, index: 5, all: false } });
+
+    await expect(killHandler(makeCtx("cli", ["mawjs:codex", "--all"]))).resolves.toEqual({
+      ok: true,
+      output: "killed mawjs:codex",
+    });
+    expect(killCalls.at(-1)).toEqual({ target: "mawjs:codex", opts: { pane: undefined, index: undefined, all: true } });
 
     await expect(killHandler(makeCtx("api", { target: "tile", pane: 1 }))).resolves.toEqual({
       ok: true,
       output: "killed tile pane 1",
     });
-    expect(killCalls.at(-1)).toEqual({ target: "tile", opts: { pane: 1 } });
+    expect(killCalls.at(-1)).toEqual({ target: "tile", opts: { pane: 1, index: undefined, all: undefined } });
 
     await expect(killHandler(makeCtx("api", {}))).resolves.toEqual({
       ok: false,


### PR DESCRIPTION
## Summary\n- add `maw kill --index N` and `--all` for duplicate window-name targets\n- resolve window-name kills through the live session window list and kill by index\n- fail loudly with candidate diagnostics when a window name is ambiguous\n- forward new kill flags through CLI/API/peer handling and update plugin help\n\nCloses #2367\n\n## Tests\n- `bun test test/isolated/vendor-shellenv-token-kill-extra-coverage.test.ts --path-ignore-patterns '**/agents/**'`\n- `bun test test/isolated/vendor-simple-plugins-coverage.test.ts --path-ignore-patterns '**/agents/**'`\n- `bun test test/done-command.test.ts --path-ignore-patterns '**/agents/**'`\n- `bun run build`\n\nNote: running the two isolated vendor coverage files in one Bun process still hits an existing module-mock collision around `loadFleetEntries`; each file passes independently.