### PR TITLE
Fix wake orphan worktree rehydrate

### DIFF
--- a/src/commands/shared/wake-cmd-helpers.ts
+++ b/src/commands/shared/wake-cmd-helpers.ts
@@ -190,6 +190,7 @@ export function planRehydrateWorktreeWindows(
   const planned: RehydrateWorktreePlan[] = [];
   for (const wt of worktrees) {
     const taskPart = wt.name.replace(/^\d+-/, "");
+    if (taskPart === oracle) continue;
     if (liveTileRoles.has(taskPart)) continue;
     let wtWindowName = `${oracle}-${taskPart}`;
     if (usedNames.has(wtWindowName)) {

--- a/src/commands/shared/wake-resolve-impl.test.ts
+++ b/src/commands/shared/wake-resolve-impl.test.ts
@@ -8,6 +8,8 @@
  * session — and return null otherwise so the caller can auto-create.
  */
 import { afterEach, beforeEach, describe, it, expect, mock } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
 import { join } from "path";
 
 const root = join(import.meta.dir, "../..");
@@ -311,10 +313,20 @@ describe("resolveLocalOracleRepoName (#1469) — exact local oracle wins before 
 
 describe("findWorktrees (#1775) — cross-repo slug fallback", () => {
   it("reuses a matching slug even when the repo stem changed", async () => {
-    hostExecOut = "/ghq/github.com/laris-co/homekeeper-oracle.wt-2-white";
-    await expect(findWorktrees("/ghq/github.com/laris-co", "homelab", "white", "homekeeper-oracle")).resolves.toEqual([
-      { path: "/ghq/github.com/laris-co/homekeeper-oracle.wt-2-white", name: "2-white" },
-    ]);
+    const parentDir = mkdtempSync(join(tmpdir(), "maw-find-worktrees-source-"));
+    const wtPath = join(parentDir, "homekeeper-oracle.wt-2-white");
+    const orphanPath = join(parentDir, "homekeeper-oracle.wt-3-white");
+    try {
+      mkdirSync(wtPath, { recursive: true });
+      mkdirSync(orphanPath, { recursive: true });
+      writeFileSync(join(wtPath, ".git"), "gitdir: homelab/.git/worktrees/2-white\n");
+      hostExecOut = `${wtPath}\n${orphanPath}\n`;
+      await expect(findWorktrees(parentDir, "homelab", "white", "homekeeper-oracle")).resolves.toEqual([
+        { path: wtPath, name: "2-white" },
+      ]);
+    } finally {
+      rmSync(parentDir, { recursive: true, force: true });
+    }
   });
 
   it("does not reuse a matching slug from another oracle", () => {

--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -352,6 +352,13 @@ export async function findWorktrees(
   scopeStem?: string,
 ): Promise<{ path: string; name: string }[]> {
   const safe = (s: string) => s.replace(/'/g, "'\\''");
+  const isLinkedWorktree = (path: string): boolean => {
+    try {
+      return statSync(join(path, ".git")).isFile();
+    } catch {
+      return false;
+    }
+  };
   const repoPath = `${parentDir}/${repoName}`;
   const outs: string[] = [];
   const legacyOut = await hostExec(`ls -d '${safe(parentDir)}'/'${safe(repoName)}'.wt-* 2>/dev/null || true`);
@@ -373,7 +380,7 @@ export async function findWorktrees(
     .filter(path => {
       if (seen.has(path)) return false;
       seen.add(path);
-      return true;
+      return isLinkedWorktree(path);
     })
     .map(path => ({ path, name: worktreeNameFromPath(path) ?? path.split("/").pop()! }));
 }

--- a/test/isolated/wake-rehydrate-plan.test.ts
+++ b/test/isolated/wake-rehydrate-plan.test.ts
@@ -6,6 +6,7 @@ describe("planRehydrateWorktreeWindows (#1563)", () => {
     { name: "1-alpha", path: "/repo.wt-1-alpha" },
     { name: "2-alpha", path: "/repo.wt-2-alpha" },
     { name: "3-beta", path: "/repo.wt-3-beta" },
+    { name: "4-mawjs", path: "/repo.wt-4-mawjs" },
   ];
 
   test("plans stable de-numbered window names and numbered fallback for true collisions", () => {

--- a/test/wake-cmd-default.test.ts
+++ b/test/wake-cmd-default.test.ts
@@ -304,6 +304,7 @@ describe("wake worktree rehydrate planning — default coverage", () => {
         { name: "2-tile-1", path: "/repo/mawjs-oracle.wt-2-tile-1" },
         { name: "feature-a", path: "/repo/mawjs-oracle.wt-feature-a" },
         { name: "3-feature-c", path: "/repo/mawjs-oracle.wt-3-feature-c" },
+        { name: "4-mawjs", path: "/repo/mawjs-oracle.wt-4-mawjs" },
       ],
       ["mawjs-oracle", "mawjs-feature-a"],
       new Set(["tile-1"]),
@@ -322,6 +323,7 @@ describe("wake worktree rehydrate planning — default coverage", () => {
     const planned = planRehydrateWorktreeWindows("mawjs", [
       { name: "feature-a", path: "/repo/wt-feature-a" },
       { name: "2-feature-a", path: "/repo/wt-2-feature-a" },
+      { name: "3-mawjs", path: "/repo/wt-3-mawjs" },
     ]);
 
     expect(planned).toEqual([

--- a/test/wake-resolve-impl-runtime-coverage.test.ts
+++ b/test/wake-resolve-impl-runtime-coverage.test.ts
@@ -419,26 +419,39 @@ describe("resolveOracle runtime paths", () => {
 describe("findWorktrees and detectSession runtime paths", () => {
   test("findWorktrees maps legacy and nested shell output into wake worktree records", async () => {
     const calls: string[] = [];
+    const root = mkdtempSync(join(tmpdir(), "maw-find-worktrees-"));
+    const legacyFeature = join(root, "mawjs-oracle.wt-feature");
+    const legacyBug = join(root, "mawjs-oracle.wt-2-bug");
+    const orphan = join(root, "mawjs-oracle.wt-orphan");
+    const nested = join(root, "mawjs-oracle", "agents", "3-nested");
+    mkdirSync(legacyFeature, { recursive: true });
+    mkdirSync(legacyBug, { recursive: true });
+    mkdirSync(orphan, { recursive: true });
+    mkdirSync(nested, { recursive: true });
+    writeFileSync(join(legacyFeature, ".git"), "gitdir: ../mawjs-oracle/.git/worktrees/feature\n");
+    writeFileSync(join(legacyBug, ".git"), "gitdir: ../mawjs-oracle/.git/worktrees/2-bug\n");
+    writeFileSync(join(nested, ".git"), "gitdir: ../../.git/worktrees/3-nested\n");
     hostExecImpl = async (cmd) => {
       calls.push(cmd);
-      if (cmd === "ls -d '/repos'/'mawjs-oracle'.wt-* 2>/dev/null || true") {
-        return "/repos/mawjs-oracle.wt-feature\n/repos/mawjs-oracle.wt-2-bug\n";
+      if (cmd === `ls -d '${root}'/'mawjs-oracle'.wt-* 2>/dev/null || true`) {
+        return `${legacyFeature}\n${legacyBug}\n${orphan}\n`;
       }
-      if (cmd === "find '/repos/mawjs-oracle/agents' -mindepth 1 -maxdepth 1 -type d 2>/dev/null || true") {
-        return "/repos/mawjs-oracle/agents/3-nested\n";
+      if (cmd === `find '${root}/mawjs-oracle/agents' -mindepth 1 -maxdepth 1 -type d 2>/dev/null || true`) {
+        return `${nested}\n`;
       }
       throw new Error(`unexpected command: ${cmd}`);
     };
 
-    await expect(findWorktrees("/repos", "mawjs-oracle")).resolves.toEqual([
-      { path: "/repos/mawjs-oracle.wt-feature", name: "feature" },
-      { path: "/repos/mawjs-oracle.wt-2-bug", name: "2-bug" },
-      { path: "/repos/mawjs-oracle/agents/3-nested", name: "3-nested" },
+    await expect(findWorktrees(root, "mawjs-oracle")).resolves.toEqual([
+      { path: legacyFeature, name: "feature" },
+      { path: legacyBug, name: "2-bug" },
+      { path: nested, name: "3-nested" },
     ]);
     expect(calls).toEqual([
-      "ls -d '/repos'/'mawjs-oracle'.wt-* 2>/dev/null || true",
-      "find '/repos/mawjs-oracle/agents' -mindepth 1 -maxdepth 1 -type d 2>/dev/null || true",
+      `ls -d '${root}'/'mawjs-oracle'.wt-* 2>/dev/null || true`,
+      `find '${root}/mawjs-oracle/agents' -mindepth 1 -maxdepth 1 -type d 2>/dev/null || true`,
     ]);
+    rmSync(root, { recursive: true, force: true });
   });
 
   test("findReusableWorktreeBySlug finds matching slug only within the requested oracle scope", () => {


### PR DESCRIPTION
Closes #2375.

## Summary
- skip rehydrating worktrees whose stripped task name equals the oracle name (prevents windows like athena-athena)
- require discovered worktree directories to have a linked `.git` file before wake treats them as worktrees
- add regression coverage for same-name rehydrate skips and orphan directory filtering

## Tests
- bun test test/wake-cmd-default.test.ts test/isolated/wake-rehydrate-plan.test.ts test/isolated/wake-cmd-helper-coverage.test.ts test/wake-resolve-impl-runtime-coverage.test.ts src/commands/shared/wake-resolve-impl.test.ts
- bun run build