### PR TITLE
Fix wake orphan agents dir rehydration

### DIFF
--- a/src/commands/shared/wake-cmd-helpers.ts
+++ b/src/commands/shared/wake-cmd-helpers.ts
@@ -239,8 +239,10 @@ export function planRehydrateWorktreeWindows(
 ): RehydrateWorktreePlan[] {
   const usedNames = new Set(existingWindows);
   const planned: RehydrateWorktreePlan[] = [];
+  const oracleBase = oracle.replace(/^\d+-/, "").toLowerCase();
   for (const wt of worktrees) {
     const taskPart = wt.name.replace(/^\d+-/, "");
+    if (taskPart.toLowerCase() === oracleBase) continue;
     if (liveTileRoles.has(taskPart)) continue;
     let wtWindowName = `${oracle}-${taskPart}`;
     if (usedNames.has(wtWindowName)) {

--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -354,14 +354,16 @@ export async function findWorktrees(
   const safe = (s: string) => s.replace(/'/g, "'\\''");
   const repoPath = `${parentDir}/${repoName}`;
   const outs: string[] = [];
-  const legacyOut = await hostExec(`ls -d '${safe(parentDir)}'/'${safe(repoName)}'.wt-* 2>/dev/null || true`);
+  const gitLinkedFind = (root: string, predicates: string) =>
+    `find ${root} ${predicates} -exec sh -c 'for dir do [ -e "$dir/.git" ] && printf "%s\n" "$dir"; done' sh {} + 2>/dev/null || true`;
+  const legacyOut = await hostExec(gitLinkedFind(`'${safe(parentDir)}'`, `-maxdepth 1 -type d -name '${safe(repoName)}.wt-*'`));
   outs.push(legacyOut);
-  const nestedOut = await hostExec(`find '${safe(repoPath)}/agents' -mindepth 1 -maxdepth 1 -type d 2>/dev/null || true`);
+  const nestedOut = await hostExec(gitLinkedFind(`'${safe(repoPath)}/agents'`, "-mindepth 1 -maxdepth 1 -type d"));
   outs.push(nestedOut);
 
   if (!outs.join("\n").trim() && taskSlug && scopeStem) {
     outs.push(await hostExec(
-      `find '${safe(parentDir)}' -maxdepth 1 -type d -name '${safe(scopeStem)}.wt-*-${safe(taskSlug)}' 2>/dev/null || true`,
+      gitLinkedFind(`'${safe(parentDir)}'`, `-maxdepth 1 -type d -name '${safe(scopeStem)}.wt-*-${safe(taskSlug)}'`),
     ));
   }
 

--- a/test/isolated/tile.test.ts
+++ b/test/isolated/tile.test.ts
@@ -7,7 +7,7 @@
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { join } from "path";
-import { mkdirSync, rmSync } from "fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
 
 let commands: string[] = [];
 let nextPane = 1;
@@ -32,6 +32,14 @@ function paneIdsFromPaneList(): string[] {
     .filter(Boolean);
 }
 
+function linkedWorktreeGlobList(): string {
+  return worktreeGlobList
+    .split("\n")
+    .filter(Boolean)
+    .filter(path => existsSync(join(path, ".git")))
+    .join("\n") + (worktreeGlobList.trim() ? "\n" : "");
+}
+
 mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
   FLEET_DIR: "/tmp/fleet",
   curlFetch: async () => ({ ok: false, status: 404, text: async () => "" }),
@@ -52,6 +60,7 @@ mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
     }
     if (cmd.includes("rev-parse --git-common-dir")) return gitCommonDir;
     if (cmd.includes("git rev-parse --show-toplevel")) return "/tmp/maw-js\n";
+    if (cmd.includes("find") && cmd.includes(".wt-*") && cmd.includes('[ -e \"$dir/.git\" ]')) return linkedWorktreeGlobList();
     if (cmd.includes("ls -d") && cmd.includes(".wt-*")) return worktreeGlobList;
     if (cmd.includes("git -C '/tmp/maw-js' worktree list")) return worktreeList;
     if (cmd.includes("show-ref --verify")) throw new Error("missing branch");
@@ -222,6 +231,7 @@ describe("tile plugin spawn metadata", () => {
 
   test("reuses named --wt worktrees and resolves --path relative to that worktree", async () => {
     mkdirSync("/tmp/maw-js.wt-explore-1234/src", { recursive: true });
+    writeFileSync("/tmp/maw-js.wt-explore-1234/.git", "gitdir: /tmp/maw-js/.git/worktrees/explore-1234\n");
     worktreeGlobList = "/tmp/maw-js.wt-explore-1234\n";
 
     await cmdTile(2, { wt: "explore-1234", path: "src" });

--- a/test/isolated/wake-rehydrate-plan.test.ts
+++ b/test/isolated/wake-rehydrate-plan.test.ts
@@ -22,4 +22,14 @@ describe("planRehydrateWorktreeWindows (#1563)", () => {
     );
     expect(planned.map(p => p.windowName)).toEqual([]);
   });
+
+  test("skips same-name orphan-style worktree names instead of planning oracle-oracle ghosts (#2375)", () => {
+    const planned = planRehydrateWorktreeWindows("athena", [
+      { name: "athena", path: "/repo/agents/athena" },
+      { name: "1-athena", path: "/repo/agents/1-athena" },
+      { name: "2-fix", path: "/repo/agents/2-fix" },
+    ]);
+
+    expect(planned.map(p => p.windowName)).toEqual(["athena-fix"]);
+  });
 });

--- a/test/wake-resolve-impl-runtime-coverage.test.ts
+++ b/test/wake-resolve-impl-runtime-coverage.test.ts
@@ -421,10 +421,10 @@ describe("findWorktrees and detectSession runtime paths", () => {
     const calls: string[] = [];
     hostExecImpl = async (cmd) => {
       calls.push(cmd);
-      if (cmd === "ls -d '/repos'/'mawjs-oracle'.wt-* 2>/dev/null || true") {
+      if (cmd.includes("-name 'mawjs-oracle.wt-*'") && cmd.includes('[ -e "$dir/.git" ]')) {
         return "/repos/mawjs-oracle.wt-feature\n/repos/mawjs-oracle.wt-2-bug\n";
       }
-      if (cmd === "find '/repos/mawjs-oracle/agents' -mindepth 1 -maxdepth 1 -type d 2>/dev/null || true") {
+      if (cmd.includes("find '/repos/mawjs-oracle/agents' -mindepth 1 -maxdepth 1 -type d") && cmd.includes('[ -e "$dir/.git" ]')) {
         return "/repos/mawjs-oracle/agents/3-nested\n";
       }
       throw new Error(`unexpected command: ${cmd}`);
@@ -435,10 +435,10 @@ describe("findWorktrees and detectSession runtime paths", () => {
       { path: "/repos/mawjs-oracle.wt-2-bug", name: "2-bug" },
       { path: "/repos/mawjs-oracle/agents/3-nested", name: "3-nested" },
     ]);
-    expect(calls).toEqual([
-      "ls -d '/repos'/'mawjs-oracle'.wt-* 2>/dev/null || true",
-      "find '/repos/mawjs-oracle/agents' -mindepth 1 -maxdepth 1 -type d 2>/dev/null || true",
-    ]);
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toContain("-name 'mawjs-oracle.wt-*'");
+    expect(calls[1]).toContain("find '/repos/mawjs-oracle/agents' -mindepth 1 -maxdepth 1 -type d");
+    expect(calls.every(cmd => cmd.includes('[ -e "$dir/.git" ]'))).toBe(true);
   });
 
   test("findReusableWorktreeBySlug finds matching slug only within the requested oracle scope", () => {


### PR DESCRIPTION
## Summary\n- make `findWorktrees()` only return legacy/nested candidates with a `.git` linkage\n- skip same-name task parts in wake rehydration planning to avoid `athena-athena` ghost windows\n- add focused regression coverage for both the finder command and planner guard\n\nCloses #2375\n\n## Tests\n- `bun test test/isolated/wake-rehydrate-plan.test.ts --path-ignore-patterns '**/agents/**'`\n- `bun test test/wake-resolve-impl-runtime-coverage.test.ts --path-ignore-patterns '**/agents/**'`\n- `bun test src/commands/shared/wake-resolve-impl.test.ts --path-ignore-patterns '**/agents/**'`\n- temp-dir `findWorktrees` smoke: orphan `agents/athena` without `.git` omitted, linked worktrees retained\n- `bun run build`