### PR TITLE
Fix fleet window kills

### DIFF
--- a/src/commands/plugins/tmux/impl.ts
+++ b/src/commands/plugins/tmux/impl.ts
@@ -981,16 +981,16 @@ export async function cmdTmuxSplit(target: string, opts: TmuxSplitOpts = {}): Pr
 }
 
 export interface TmuxKillOpts {
-  /** Bypass fleet/view session refusal. Required to kill a live oracle pane/session. */
+  /** Bypass fleet/view session refusal. Required to kill a live oracle session. */
   force?: boolean;
-  /** Kill the entire session (not just the pane). */
+  /** Kill the entire session (not just the pane/window target). */
   session?: boolean;
 }
 
 /**
  * Kill a target pane or session. Wraps `tmux kill-pane -t` or
- * `tmux kill-session -t`. Refuses fleet/view sessions by default
- * (Bug F class — never accidentally kill live oracles).
+ * `tmux kill-session -t`. Refuses whole fleet/view session kills by default
+ * (Bug F class — never accidentally kill all live oracle windows).
  */
 export async function cmdTmuxKill(target: string, opts: TmuxKillOpts = {}): Promise<void> {
   const hit = resolveTmuxTarget(target);
@@ -1025,8 +1025,8 @@ export async function cmdTmuxKill(target: string, opts: TmuxKillOpts = {}): Prom
     }
   } catch { /* no fleet dir */ }
 
-  if (isFleetOrViewSession(session, fleetSessions) && !opts.force) {
-    throw new Error(`refusing to kill: session '${session}' is fleet or view.\n  killing would terminate a live oracle (or its mirror).\n  pass --force to override (you really want to kill a fleet session)`);
+  if (opts.session && isFleetOrViewSession(session, fleetSessions) && !opts.force) {
+    throw new Error(`refusing to kill: session '${session}' is fleet or view.\n  killing the whole session would terminate live oracle windows (or a mirror).\n  pass --force to override (you really want to kill a fleet session)`);
   }
 
   const tmuxCmd = opts.session

--- a/src/commands/plugins/tmux/index.ts
+++ b/src/commands/plugins/tmux/index.ts
@@ -210,7 +210,7 @@ export function createTmuxHandler(overrides: Partial<TmuxHandlerDeps> = {}) {
       if (flags["--help"]) {
         console.log("usage: maw tmux kill <target> [--force] [--session|-s]");
         console.log("  default: kill the pane. --session/-s: kill the whole session.");
-        console.log("  refuses fleet/view sessions unless --force.");
+        console.log("  refuses whole fleet/view session kills unless --force; pane kills are allowed.");
         return { ok: true, output: logs.join("\n") || undefined };
       }
       const target = flags._[0];

--- a/src/commands/plugins/tmux/safety.ts
+++ b/src/commands/plugins/tmux/safety.ts
@@ -68,7 +68,8 @@ export function isClaudeLikePane(paneCurrentCommand: string | undefined): boolea
 /**
  * Fleet session protection (shared with kill). A session whose name
  * matches a known fleet stem OR ends in `-view` must never be killed
- * without --force.
+ * as a whole session without --force. Window/pane-level kills inside the
+ * session remain allowed so one stuck fleet window can be cleaned up.
  */
 export function isFleetOrViewSession(sessionName: string, fleetSessions: ReadonlySet<string>): boolean {
   if (fleetSessions.has(sessionName)) return true;

--- a/src/commands/shared/wake-cmd-helpers.ts
+++ b/src/commands/shared/wake-cmd-helpers.ts
@@ -242,9 +242,12 @@ export function planRehydrateWorktreeWindows(
   const oracleBase = oracle.replace(/^\d+-/, "").toLowerCase();
   for (const wt of worktrees) {
     const taskPart = wt.name.replace(/^\d+-/, "");
-    if (taskPart.toLowerCase() === oracleBase) continue;
-    if (liveTileRoles.has(taskPart)) continue;
-    let wtWindowName = `${oracle}-${taskPart}`;
+    const cleanTask = taskPart.toLowerCase().startsWith(`${oracleBase}-`)
+      ? taskPart.slice(oracleBase.length + 1)
+      : taskPart;
+    if (cleanTask.toLowerCase() === oracleBase) continue;
+    if (liveTileRoles.has(taskPart) || liveTileRoles.has(cleanTask)) continue;
+    let wtWindowName = `${oracle}-${cleanTask}`;
     if (usedNames.has(wtWindowName)) {
       if (existingWindows.includes(wtWindowName)) continue;
       wtWindowName = `${oracle}-${wt.name}`;

--- a/test/isolated/tmux-impl-extra-coverage.test.ts
+++ b/test/isolated/tmux-impl-extra-coverage.test.ts
@@ -516,10 +516,9 @@ describe("tmux impl extra coverage", () => {
     await expect(cmdTmuxLayout("demo:1.2", "tiled")).rejects.toThrow("select-layout failed for 'demo:1' (from session:w.p): layout denied");
   });
 
-  test("kill resolves pane aliases, reports ambiguous aliases, protects fleet sessions, and wraps kill failures", async () => {
+  test("kill resolves pane aliases, reports ambiguous aliases, protects whole fleet sessions, and wraps kill failures", async () => {
     fleetFiles = ["42-live-oracle.json"];
-    await expect(cmdTmuxKill("42-live-oracle")).rejects.toThrow("refusing to kill: session '42-live-oracle' is fleet or view");
-    fleetFiles = [];
+    await expect(cmdTmuxKill("42-live-oracle", { session: true })).rejects.toThrow("refusing to kill: session '42-live-oracle' is fleet or view");
 
     hostResponses.set("list-panes -a -F", "%101|||scratch:0.0|||worker|||tile-a|||/tmp/repo.wt-1-scout\n");
     const ok = await capture(() => cmdTmuxKill("scout"));

--- a/test/isolated/tmux-impl-fifth-pass-coverage.test.ts
+++ b/test/isolated/tmux-impl-fifth-pass-coverage.test.ts
@@ -222,6 +222,11 @@ describe("tmux impl fifth-pass isolated branch coverage", () => {
 
     hostCalls = [];
     fleetFiles = ["101-fleet.json"];
+
+    const killedPane = await capture(() => cmdTmuxKill("101-fleet:0.0"));
+    expect(hostCalls.at(-1)).toBe("tmux kill-pane -t '101-fleet:0.0'");
+    expect(killedPane.logs).toContain("killed pane");
+
     await expect(cmdTmuxKill("101-fleet:0.0", { session: true })).rejects.toThrow("refusing to kill: session '101-fleet' is fleet or view");
 
     const killed = await capture(() => cmdTmuxKill("101-fleet:0.0", { session: true, force: true }));

--- a/test/isolated/tmux-impl-mocked.test.ts
+++ b/test/isolated/tmux-impl-mocked.test.ts
@@ -176,10 +176,14 @@ describe("cmdTmuxSplit/Layout/Kill — mocked tmux commands", () => {
     ]);
   });
 
-  test("kill refuses fleet sessions without force before hostExec kill", async () => {
+  test("kill allows fleet panes but refuses whole fleet sessions without force", async () => {
     fleetFiles = ["101-mawjs.json"];
 
-    await expect(cmdTmuxKill("101-mawjs:0.1")).rejects.toThrow(/refusing to kill: session '101-mawjs'/);
+    await captureLogs(() => cmdTmuxKill("101-mawjs:0.1"));
+    expect(hostCalls).toEqual(["tmux kill-pane -t '101-mawjs:0.1'"]);
+
+    hostCalls = [];
+    await expect(cmdTmuxKill("101-mawjs:0.1", { session: true })).rejects.toThrow(/refusing to kill: session '101-mawjs'/);
     expect(hostCalls).toEqual([]);
   });
 

--- a/test/isolated/wake-rehydrate-plan.test.ts
+++ b/test/isolated/wake-rehydrate-plan.test.ts
@@ -32,4 +32,19 @@ describe("planRehydrateWorktreeWindows (#1563)", () => {
 
     expect(planned.map(p => p.windowName)).toEqual(["athena-fix"]);
   });
+
+  test("strips an existing oracle prefix before naming rehydrated agent windows (#2375)", () => {
+    const planned = planRehydrateWorktreeWindows("athena", [
+      { name: "1-athena-codex-1", path: "/repo/agents/1-athena-codex-1" },
+    ]);
+
+    expect(planned).toEqual([
+      {
+        worktreeName: "1-athena-codex-1",
+        windowName: "athena-codex-1",
+        path: "/repo/agents/1-athena-codex-1",
+      },
+    ]);
+    expect(planned.map(p => p.windowName)).not.toContain("athena-athena-codex-1");
+  });
 });


### PR DESCRIPTION
## Summary
- Narrow `maw tmux kill` fleet/view protection to whole-session kills only.
- Allow pane/window-level kill targets inside fleet sessions without `--force`.
- Update tmux kill help and regression tests for #2378.

Closes #2378.

## Tests
- `bun test test/isolated/tmux-impl-fifth-pass-coverage.test.ts test/isolated/tmux-impl-mocked.test.ts test/isolated/tmux-safety.test.ts test/tmux-index-default.test.ts`