### PR TITLE
Add resolver sprint regression tests

### DIFF
--- a/test/isolated/done-orphan-worktree.test.ts
+++ b/test/isolated/done-orphan-worktree.test.ts
@@ -58,6 +58,26 @@ describe("maw done orphan worktree cleanup", () => {
     expect(h.commands).toContain(`rm -rf '${primary}'`);
   });
 
+  test("removes a clean worktree directory when git worktree remove leaves it behind (#2369)", async () => {
+    const h = harness((command) => {
+      if (command.includes("rev-parse --abbrev-ref")) return "feature/clean\n";
+      if (command.includes("worktree remove")) throw new Error("fatal: Directory not empty");
+      if (command.startsWith("test -d")) return "";
+      if (command.includes("status --porcelain")) return "";
+      if (command.startsWith("rm -rf")) return "";
+      if (command.includes("worktree prune")) return "";
+      if (command.startsWith("find ")) return "";
+      return "";
+    });
+
+    await cmdDone("mawjs-codex", { cwd: main }, h.deps);
+
+    expect(h.commands).toContain(`git -C '${primary}' status --porcelain --untracked-files=all`);
+    expect(h.commands).toContain(`rm -rf '${primary}'`);
+    expect(h.commands).toContain(`git -C '${main}' worktree prune`);
+    expect(h.logs.join("\n")).toContain("removed orphan directory 1-codex after verifying it was clean");
+  });
+
   test("refuses to remove a dirty orphan directory without force", async () => {
     const h = harness((command) => {
       if (command.includes("rev-parse --abbrev-ref")) return "feature\n";

--- a/test/isolated/vendor-shellenv-token-kill-extra-coverage.test.ts
+++ b/test/isolated/vendor-shellenv-token-kill-extra-coverage.test.ts
@@ -206,7 +206,9 @@ describe("vendor kill implementation branch coverage", () => {
       throw new Error(`unexpected command: ${cmd}`);
     };
 
-    await expect(cmdKill("mawjs:codex")).rejects.toThrow("window 'codex' is ambiguous in session 47-mawjs");
+    await expect(cmdKill("mawjs:codex")).rejects.toThrow(
+      "use --index N to kill one, or --all to kill all matching windows",
+    );
     expect(hostExecCalls).toEqual([]);
 
     await expect(captureConsole(() => cmdKill("mawjs:codex", { index: 5 }))).resolves.toMatchObject({


### PR DESCRIPTION
## Summary\n- Add a #2369 regression proving clean orphan worktree directories left behind by git removal errors are status-checked, removed, and pruned.\n- Strengthen the #2367 duplicate kill-window test to assert the actionable disambiguation guidance is preserved.\n- Leave existing alpha coverage for #2366, #2370, and #2375 in place after their fix PRs landed.\n\n## Tests\n- `MAW_TEST_MODE=1 bun test test/isolated/done-orphan-worktree.test.ts test/isolated/vendor-shellenv-token-kill-extra-coverage.test.ts test/isolated/wake-rehydrate-plan.test.ts test/wake-cmd-cmdwake-coverage.test.ts test/wake-cmd-default.test.ts`\n- `bun run build`