### PR TITLE
Fix maw hey pending detection for Codex panes

### DIFF
--- a/src/core/transport/tmux-class.ts
+++ b/src/core/transport/tmux-class.ts
@@ -24,6 +24,24 @@ const MAX_SUBMIT_ATTEMPTS = 4;
 /** ANSI escape stripper — matches checkPaneIdle in comm-send.ts (#405). */
 const ANSI_RE = /\x1b\[[0-9;]*[mGKHFJA-Z]/g;
 
+function pendingInputNeedles(sentText: string): string[] {
+  const normalized = sentText.replace(/\r/g, "").trim();
+  if (!normalized) return [];
+
+  const needles = new Set<string>();
+  const compact = normalized.replace(/\s+/g, " ").trim();
+  if (compact) needles.add(compact.slice(0, 40));
+
+  const lastLine = normalized
+    .split("\n")
+    .map(line => line.trim())
+    .filter(Boolean)
+    .at(-1);
+  if (lastLine) needles.add(lastLine.slice(0, 40));
+
+  return [...needles].filter(Boolean);
+}
+
 function isTmuxNoServerError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return /no server/i.test(message) || /failed to connect to server/i.test(message);
@@ -491,7 +509,7 @@ export class Tmux {
       await this.sendKeysLiteral(target, text);
     }
     await new Promise(r => setTimeout(r, SEND_SETTLE_MS));
-    await this.submitWithConfirm(target);
+    await this.submitWithConfirm(target, text);
   }
 
   /**
@@ -499,11 +517,11 @@ export class Tmux {
    * the Enter while input is still pending — see sendText for the #6 race.
    * @internal — exported behavior is exercised via sendText in tests.
    */
-  private async submitWithConfirm(target: string): Promise<void> {
+  private async submitWithConfirm(target: string, sentText: string): Promise<void> {
     for (let attempt = 1; attempt <= MAX_SUBMIT_ATTEMPTS; attempt++) {
       await this.sendKeys(target, "Enter");
       await new Promise(r => setTimeout(r, SUBMIT_CONFIRM_MS));
-      if (!(await this.paneInputPending(target))) return; // submitted — done
+      if (!(await this.paneInputPending(target, sentText))) return; // submitted — done
     }
     // Exhausted every retry and the input line still looks non-empty. The
     // caller has no visibility into tmux pane state, so warn loudly — a
@@ -514,20 +532,25 @@ export class Tmux {
   }
 
   /**
-   * True when the pane's prompt line still holds un-submitted input.
-   * Mirrors checkPaneIdle (comm-send.ts #405) but inlined here to avoid a
-   * circular import — comm-send.ts already imports Tmux. A read failure
-   * returns false (assume submitted) so a flaky capture can't spin the retry
-   * loop.
+   * True when the pane's input line still holds the text we just sent. Prefer
+   * sent-text visibility over prompt markers so submit confirmation works for
+   * any engine prompt. A prompt-marker fallback, including Codex's U+203A `›`,
+   * keeps legacy detection working when panes transform or truncate the text.
+   * A read failure returns false (assume submitted) so a flaky capture can't
+   * spin the retry loop.
    */
-  private async paneInputPending(target: string): Promise<boolean> {
+  private async paneInputPending(target: string, sentText: string): Promise<boolean> {
     try {
       const content = await this.capture(target, 5);
       const lines = content.split("\n").filter(l => l.trim());
       const last = (lines.at(-1) ?? "").replace(ANSI_RE, "").replace(/\r/g, "");
-      // Prompt marker followed by non-whitespace → user/command text still
-      // sitting on the input line, i.e. Enter has not submitted it yet.
-      return /[#$%>❯»]\s+\S/.test(last);
+      const sentNeedles = pendingInputNeedles(sentText);
+      if (sentNeedles.some(needle => last.includes(needle))) return true;
+
+      // Fallback: prompt marker followed by non-whitespace → user/command text
+      // still sitting on the input line. Includes Codex `›` for immediate #2380
+      // relief while sent-text detection handles unknown future engines.
+      return /[#$%>❯»›]\s+\S/.test(last);
     } catch {
       return false;
     }

--- a/test/isolated/tmux-class-sixth-pass-coverage.test.ts
+++ b/test/isolated/tmux-class-sixth-pass-coverage.test.ts
@@ -226,7 +226,7 @@ describe("tmux-class sixth-pass isolated coverage", () => {
     ]);
 
     const noWhitespace = new SubmitProbeTmux();
-    noWhitespace.captureScript = ["agent%make test"];
+    noWhitespace.captureScript = ["agent%unrelated text"];
 
     await noWhitespace.sendText("alpha:0.0", "make test");
 

--- a/test/tmux-sendtext-submit.test.ts
+++ b/test/tmux-sendtext-submit.test.ts
@@ -83,6 +83,33 @@ describe("Tmux.sendText — confirmed submit (#6)", () => {
     15_000,
   );
 
+
+  test(
+    "recognizes Codex U+203A prompts as pending via prompt fallback",
+    async () => {
+      const t = new FakeTmux();
+      t.captureScript = ["› [m5:mawjs] codex-1: unrelated pending input", "› "];
+      await t.sendText("sess:codex", "hello");
+
+      expect(enterCount(t.calls)).toBe(2);
+      expect(t.calls.at(-1)).toBe("capture");
+    },
+    15_000,
+  );
+
+  test(
+    "detects pending input from the sent text without known prompt markers",
+    async () => {
+      const t = new FakeTmux();
+      t.captureScript = ["ENGINE_PROMPT please handle this", "ENGINE_PROMPT "];
+      await t.sendText("sess:any-engine", "please handle this");
+
+      expect(enterCount(t.calls)).toBe(2);
+      expect(t.calls.at(-1)).toBe("capture");
+    },
+    15_000,
+  );
+
   test(
     "stops after MAX_SUBMIT_ATTEMPTS and warns when the pane never clears",
     async () => {


### PR DESCRIPTION
## Summary
- Confirm tmux sendText submission by checking whether the sent text is still visible on the final captured pane line
- Add Codex U+203A `›` to the prompt-marker fallback for immediate compatibility
- Cover Codex fallback and unknown-engine sent-text pending detection

Closes #2380

## Tests
- `bun test test/tmux-sendtext-submit.test.ts`
- `MAW_SKIP_FLAKY=1 bash scripts/test-isolated.sh test/isolated/tmux-class-sixth-pass-coverage.test.ts`
- `bun test test/isolated/tmux-class-coverage.test.ts test/isolated/tmux-class-fourth-pass-coverage.test.ts test/isolated/tmux-class-fifth-pass-coverage.test.ts test/isolated/tmux-class-sixth-pass-coverage.test.ts test/isolated/tmux-class-seventh-pass-coverage.test.ts test/isolated/tmux-class-tenth-pass-coverage.test.ts test/isolated/tmux-class-thirteenth-pass-coverage.test.ts test/isolated/tmux-class-fourteenth-pass-coverage.test.ts`
- `bun run build`