### PR TITLE
Fix wake rehydrate double-prefix window names

### DIFF
--- a/src/commands/shared/wake-cmd-helpers.ts
+++ b/src/commands/shared/wake-cmd-helpers.ts
@@ -239,18 +239,21 @@ export function planRehydrateWorktreeWindows(
 ): RehydrateWorktreePlan[] {
   const usedNames = new Set(existingWindows);
   const planned: RehydrateWorktreePlan[] = [];
-  const oracleBase = oracle.replace(/^\d+-/, "").toLowerCase();
+  const oracleBase = oracle.replace(/^\d+-/, "");
+  const oracleBaseLower = oracleBase.toLowerCase();
   for (const wt of worktrees) {
     const taskPart = wt.name.replace(/^\d+-/, "");
-    const cleanTask = taskPart.toLowerCase().startsWith(`${oracleBase}-`)
+    if (taskPart.toLowerCase() === oracleBaseLower) continue;
+    const cleanTask = taskPart.toLowerCase().startsWith(`${oracleBaseLower}-`)
       ? taskPart.slice(oracleBase.length + 1)
       : taskPart;
-    if (cleanTask.toLowerCase() === oracleBase) continue;
+    if (!cleanTask) continue;
     if (liveTileRoles.has(taskPart) || liveTileRoles.has(cleanTask)) continue;
     let wtWindowName = `${oracle}-${cleanTask}`;
     if (usedNames.has(wtWindowName)) {
       if (existingWindows.includes(wtWindowName)) continue;
-      wtWindowName = `${oracle}-${wt.name}`;
+      const numberPrefix = wt.name.match(/^(\d+)-/)?.[1];
+      wtWindowName = `${oracle}-${numberPrefix ? `${numberPrefix}-` : ""}${cleanTask}`;
     }
     const altName = `${oracle}-${wt.name}`;
     if (existingWindows.includes(wtWindowName) || existingWindows.includes(altName)) continue;

--- a/test/isolated/wake-rehydrate-plan.test.ts
+++ b/test/isolated/wake-rehydrate-plan.test.ts
@@ -33,18 +33,14 @@ describe("planRehydrateWorktreeWindows (#1563)", () => {
     expect(planned.map(p => p.windowName)).toEqual(["athena-fix"]);
   });
 
-  test("strips an existing oracle prefix before naming rehydrated agent windows (#2375)", () => {
+  test("strips oracle-prefixed worktree task names before composing wake window names (#2375)", () => {
     const planned = planRehydrateWorktreeWindows("athena", [
       { name: "1-athena-codex-1", path: "/repo/agents/1-athena-codex-1" },
+      { name: "2-athena-codex-1", path: "/repo/agents/2-athena-codex-1" },
+      { name: "3-athena-review", path: "/repo/agents/3-athena-review" },
     ]);
 
-    expect(planned).toEqual([
-      {
-        worktreeName: "1-athena-codex-1",
-        windowName: "athena-codex-1",
-        path: "/repo/agents/1-athena-codex-1",
-      },
-    ]);
-    expect(planned.map(p => p.windowName)).not.toContain("athena-athena-codex-1");
+    expect(planned.map(p => p.windowName)).toEqual(["athena-codex-1", "athena-2-codex-1", "athena-review"]);
   });
+
 });


### PR DESCRIPTION
## Summary\n- strip an existing oracle prefix from numbered worktree task slugs before composing rehydrate window names\n- keep numeric prefixes only for collision fallback, e.g. duplicate codex tasks become `athena-codex-1` then `athena-2-codex-1`\n- add regression coverage for `agents/1-athena-codex-1` so it cannot plan `athena-athena-codex-1`\n\nCloses #2375\n\n## Tests\n- `bun test test/isolated/wake-rehydrate-plan.test.ts --path-ignore-patterns '**/agents/**'`\n- `bun run build`