### PR TITLE
Fix agent status active-entry pruning

### DIFF
--- a/src/core/agent-status.ts
+++ b/src/core/agent-status.ts
@@ -13,6 +13,7 @@ export interface AgentStatusEntry {
 }
 
 const IDLE_TTL = 120_000; // 120s — no activity → idle
+const ACTIVE_STATUS_MAX_AGE = 48 * 60 * 60_000; // 48h — even busy/ready entries eventually expire
 
 /**
  * In-memory agent status store.
@@ -94,13 +95,16 @@ export class AgentStatusStore {
     this.store.delete(oracle);
   }
 
-  /** Prune terminal/stale statuses so long-lived maw serve processes do not retain old oracle names forever. */
+  /** Prune stale statuses so long-lived maw serve processes do not retain old oracle names forever. */
   prune(maxAge = 24 * 60 * 60_000): number {
-    const cutoff = Date.now() - maxAge;
+    const now = Date.now();
+    const cutoff = now - maxAge;
+    const activeCutoff = now - ACTIVE_STATUS_MAX_AGE;
     let removed = 0;
     for (const [oracle, entry] of this.store) {
-      if (entry.updatedAt >= cutoff) continue;
-      if (entry.status === "busy" || entry.status === "ready") continue;
+      const isActiveStatus = entry.status === "busy" || entry.status === "ready";
+      const expiresAt = isActiveStatus ? activeCutoff : cutoff;
+      if (entry.updatedAt >= expiresAt) continue;
       this.remove(oracle);
       removed++;
     }

--- a/test/isolated/agent-status-store.test.ts
+++ b/test/isolated/agent-status-store.test.ts
@@ -99,4 +99,23 @@ describe("AgentStatusStore", () => {
     store.handleFeedEvent(makeFeedEvent({ event: "SessionEnd" }));
     expect(store.get("neo")!.status).toBe("idle");
   });
+
+  test("prune() evicts busy/ready entries after active max age", () => {
+    const now = Date.now();
+    store.report("old-busy", "busy");
+    store.report("old-ready", "ready");
+    store.report("fresh-busy", "busy");
+    store.report("old-idle", "idle");
+
+    store.get("old-busy")!.updatedAt = now - (49 * 60 * 60_000);
+    store.get("old-ready")!.updatedAt = now - (49 * 60 * 60_000);
+    store.get("fresh-busy")!.updatedAt = now - (47 * 60 * 60_000);
+    store.get("old-idle")!.updatedAt = now - (25 * 60 * 60_000);
+
+    expect(store.prune()).toBe(3);
+    expect(store.get("old-busy")).toBeUndefined();
+    expect(store.get("old-ready")).toBeUndefined();
+    expect(store.get("old-idle")).toBeUndefined();
+    expect(store.get("fresh-busy")!.status).toBe("busy");
+  });
 });


### PR DESCRIPTION
## Summary
- Add a 48h max-age for busy/ready AgentStatusStore entries during prune
- Keep existing stale pruning for non-active statuses
- Add regression coverage for old busy/ready entries being evicted while fresher active entries remain

Closes #2385

## Tests
- MAW_TEST_MODE=1 bun test test/isolated/agent-status-store.test.ts --path-ignore-patterns '**/agents/**'\n- bun run build