### PR TITLE
Fix MessageQueue stuck pending retention

### DIFF
--- a/src/core/message-queue.ts
+++ b/src/core/message-queue.ts
@@ -14,6 +14,9 @@ export interface QueuedMessage {
 
 let nextId = 1;
 
+const DEFAULT_TERMINAL_PRUNE_MAX_AGE_MS = 3_600_000;
+const DEFAULT_ACTIVE_PRUNE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
 export class MessageQueue {
   private queue: QueuedMessage[] = [];
 
@@ -64,12 +67,19 @@ export class MessageQueue {
     return [...this.queue];
   }
 
-  /** Prune delivered/failed messages older than maxAge ms. */
-  prune(maxAge = 3_600_000) {
-    const cutoff = Date.now() - maxAge;
-    this.queue = this.queue.filter(m =>
-      m.status === "pending" || m.status === "delivering" || m.queuedAt > cutoff
-    );
+  /** Prune terminal messages by maxAge and stuck active messages after 24h by default. */
+  prune(maxAge = DEFAULT_TERMINAL_PRUNE_MAX_AGE_MS, activeMaxAge = DEFAULT_ACTIVE_PRUNE_MAX_AGE_MS) {
+    const now = Date.now();
+    const terminalCutoff = now - maxAge;
+    const activeCutoff = now - activeMaxAge;
+
+    this.queue = this.queue.filter(m => {
+      if (m.status === "pending" || m.status === "delivering") {
+        return m.queuedAt > activeCutoff;
+      }
+
+      return m.queuedAt > terminalCutoff;
+    });
   }
 
   get size(): number {

--- a/test/isolated/message-queue.test.ts
+++ b/test/isolated/message-queue.test.ts
@@ -63,6 +63,34 @@ describe("MessageQueue", () => {
     expect(queue.getAll()[0].error).toBeUndefined();
   });
 
+
+  test("prune removes pending and delivering messages stuck longer than active max age", () => {
+    const stalePending = queue.enqueue({ from: "a:s", to: "neo", target: "s:neo", message: "stale pending" });
+    const staleDelivering = queue.enqueue({ from: "a:s", to: "neo", target: "s:neo", message: "stale delivering" });
+    const freshPending = queue.enqueue({ from: "a:s", to: "neo", target: "s:neo", message: "fresh pending" });
+
+    queue.markDelivering(staleDelivering.id);
+    stalePending.queuedAt = Date.now() - 25 * 60 * 60 * 1000;
+    staleDelivering.queuedAt = Date.now() - 25 * 60 * 60 * 1000;
+
+    queue.prune();
+
+    expect(queue.getAll().map(m => m.message)).toEqual(["fresh pending"]);
+  });
+
+  test("prune keeps pending and delivering messages newer than active max age", () => {
+    const pending = queue.enqueue({ from: "a:s", to: "neo", target: "s:neo", message: "pending" });
+    const delivering = queue.enqueue({ from: "a:s", to: "neo", target: "s:neo", message: "delivering" });
+
+    queue.markDelivering(delivering.id);
+    pending.queuedAt = Date.now() - 23 * 60 * 60 * 1000;
+    delivering.queuedAt = Date.now() - 23 * 60 * 60 * 1000;
+
+    queue.prune();
+
+    expect(queue.getAll().map(m => m.message)).toEqual(["pending", "delivering"]);
+  });
+
   test("pendingCount and size", () => {
     queue.enqueue({ from: "a:s", to: "neo", target: "s:neo", message: "m1" });
     const m2 = queue.enqueue({ from: "a:s", to: "neo", target: "s:neo", message: "m2" });


### PR DESCRIPTION
## Summary
- add a 24h max-age for pending/delivering MessageQueue entries
- keep the existing shorter prune window for delivered/failed entries
- add regression coverage for stale and fresh active queue entries

Closes #2384

## Tests
- MAW_TEST_MODE=1 bun test test/isolated/message-queue.test.ts --path-ignore-patterns '**/agents/**'\n\n## Notes\n- post-commit auto-build could not complete in the fresh worktree because dependencies were not installed there (missing arg, hono, elysia).