### PR TITLE
Fix wake rehydrate after reboot without stale continue

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -402,11 +402,28 @@ function isAttachOnlyWake(opts: WakeOptions): boolean {
     && !opts.snapshotId;
 }
 
-function buildWakeCommand(windowName: string, cwd: string, opts: Pick<WakeOptions, "engine" | "parentSessionId" | "sessionId" | "channels">): string {
+type WakeCommandOptions = Pick<WakeOptions, "engine" | "parentSessionId" | "sessionId" | "channels"> & {
+  /** Strip engine resume/continue placeholders for reboot-rehydrated dead panes (#2391). */
+  freshLaunch?: boolean;
+};
+
+function buildWakeCommand(windowName: string, cwd: string, opts: WakeCommandOptions): string {
+  const commandOpts = opts.channels
+    ? { engine: opts.engine, channels: ["plugin:discord@claude-plugins-official"], fresh: opts.freshLaunch }
+    : opts.freshLaunch
+      ? { engine: opts.engine, fresh: true }
+      : opts.engine;
   return prefixCommandWithSpawnSessionEnv(
-    buildCommandInDir(windowName, cwd, opts.channels ? { engine: opts.engine, channels: ["plugin:discord@claude-plugins-official"] } : opts.engine),
+    buildCommandInDir(windowName, cwd, commandOpts),
     { explicit: opts.parentSessionId, sessionId: opts.sessionId, cwd },
   );
+}
+
+async function buildWakeCommandForPane(windowName: string, cwd: string, opts: WakeCommandOptions, target: string): Promise<string> {
+  const infos = await getPaneInfos([target]).catch(() => ({} as Awaited<ReturnType<typeof getPaneInfos>>));
+  const command = infos[target]?.command;
+  const freshLaunch = !isAgentCommand(command);
+  return buildWakeCommand(windowName, cwd, freshLaunch ? { ...opts, freshLaunch: true } : opts);
 }
 
 function loadRequestedSnapshot(snapshotId?: string): Snapshot | null {
@@ -1167,8 +1184,9 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
       for (const wt of plan) {
         await tmux.newWindow(session, wt.windowName, { cwd: wt.path });
         await new Promise(r => setTimeout(r, 300));
-        await tmux.sendText(`${session}:${wt.windowName}`, buildWakeCommand(wt.windowName, wt.path, opts));
-        await wakeSession.waitForEngine(`${session}:${wt.windowName}`, getPaneInfos, isAgentCommand);
+        const target = `${session}:${wt.windowName}`;
+        await tmux.sendText(target, await buildWakeCommandForPane(wt.windowName, wt.path, opts, target));
+        await wakeSession.waitForEngine(target, getPaneInfos, isAgentCommand);
         existingWindows.add(wt.windowName);
         console.log(`\x1b[32m+\x1b[0m window: ${wt.windowName}  \x1b[90m(from ${formatWorktreeSource(wt.path)})\x1b[0m`);
       }
@@ -1216,7 +1234,8 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
         for (const wt of plan) {
           await tmux.newWindow(session, wt.windowName, { cwd: wt.path });
           await new Promise(r => setTimeout(r, 300));
-          await tmux.sendText(`${session}:${wt.windowName}`, buildWakeCommand(wt.windowName, wt.path, opts));
+          const target = `${session}:${wt.windowName}`;
+          await tmux.sendText(target, await buildWakeCommandForPane(wt.windowName, wt.path, opts, target));
           preExistingWindows.add(wt.windowName);
           preExistingWindowEntries.push({ name: wt.windowName, cwd: wt.path });
           console.log(`\x1b[32m↻\x1b[0m respawned: ${wt.windowName}  \x1b[90m(from ${formatWorktreeSource(wt.path)})\x1b[0m`);
@@ -1380,8 +1399,8 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
       const agentAlive = info && isAgentCommand(info.command);
 
       if (!agentAlive) {
-        console.log(`\x1b[33m⚡\x1b[0m '${existingWindow}' in ${session} — agent dead, re-launching...`);
-        await tmux.sendText(target, buildWakeCommand(existingWindow, targetPath, opts));
+        console.log(`\x1b[33m⚡\x1b[0m '${existingWindow}' in ${session} — agent dead, re-launching fresh...`);
+        await tmux.sendText(target, buildWakeCommand(existingWindow, targetPath, { ...opts, freshLaunch: true }));
         await wakeSession.waitForEngine(target, getPaneInfos, isAgentCommand);
         if (opts.attach) {
           await tmux.selectWindow(target);

--- a/src/config/command-logic.ts
+++ b/src/config/command-logic.ts
@@ -241,7 +241,7 @@ export function buildCommandFromConfig(
   const sessionIds: Record<string, string> = config.sessionIds || {};
   const sessionId = commandMatchNames(agentName).map((name) => sessionIds[name]).find(Boolean)
     || Object.entries(sessionIds).find(([p]) => p !== "default" && matchesAgentPattern(p, agentName))?.[1];
-  if (sessionId) {
+  if (sessionId && !opts.fresh) {
     cmd = applyResumeFlag(cmd, engine, sessionId, genericRenderer);
   }
 

--- a/test/command-simplified.test.ts
+++ b/test/command-simplified.test.ts
@@ -33,6 +33,10 @@ function buildCommandInDir(agentName: string, cwd: string, engine?: string): str
   return buildCommandInDirFromConfig(testConfig(), agentName, cwd, engine);
 }
 
+function buildFreshCommand(agentName: string): string {
+  return buildCommandFromConfig(testConfig(), agentName, { fresh: true });
+}
+
 // buildCommand strips --dangerously-skip-permissions when process.getuid() === 0
 // (root-stripping from #181). Pin the uid to a non-root value regardless of the
 // host user so command-string assertions stay stable.
@@ -122,6 +126,17 @@ describe("buildCommand — post-#541 contract", () => {
     expect(out).toBe('claude --resume "uuid-2"');
     expect(out).not.toContain("||");
     expect(out).not.toContain("--session-id");
+  });
+
+  test("fresh launch strips continue placeholders and suppresses sessionId resume injection", () => {
+    fakeConfig.commands = { default: "claude --continue" };
+    fakeSessionIds = { foo: "uuid-fresh" };
+
+    const out = buildFreshCommand("foo");
+
+    expect(out).toBe("claude");
+    expect(out).not.toContain("--continue");
+    expect(out).not.toContain("--resume");
   });
 
   test("sessionId supports glob fallback when there is no exact agent key", () => {

--- a/test/isolated/wake-cmd-thirteenth-pass-coverage.test.ts
+++ b/test/isolated/wake-cmd-thirteenth-pass-coverage.test.ts
@@ -54,6 +54,7 @@ let lineageWrites: any[] = [];
 let birthSignalWrites: any[] = [];
 let parseWakeTargetReturn: null | { slug: string; oracle: string } = null;
 let ghqFindReturn: string | null = null;
+let commandTemplateContinues = false;
 
 function resetState(): void {
   logs = [];
@@ -103,6 +104,7 @@ function resetState(): void {
   birthSignalWrites = [];
   parseWakeTargetReturn = null;
   ghqFindReturn = null;
+  commandTemplateContinues = false;
 }
 
 async function captureLogs<T>(fn: () => Promise<T> | T): Promise<T> {
@@ -180,8 +182,12 @@ mock.module(import.meta.resolve("../../src/core/ghq"), () => ({
 }));
 
 mock.module(import.meta.resolve("../../src/config"), () => ({
-  buildCommandInDir: (windowName: string, cwd: string, engine?: string) =>
-    `cd ${cwd} && ${engine ?? "codex"} --agent ${windowName}`,
+  buildCommandInDir: (windowName: string, cwd: string, optsOrEngine?: string | { engine?: string; fresh?: boolean }) => {
+    const engine = typeof optsOrEngine === "string" ? optsOrEngine : optsOrEngine?.engine;
+    const fresh = typeof optsOrEngine === "object" && Boolean(optsOrEngine.fresh);
+    const resume = commandTemplateContinues && !fresh ? " --continue" : "";
+    return `cd ${cwd} && ${engine ?? "codex"} --agent ${windowName}${resume}`;
+  },
   cfgTimeout: () => 0,
   loadConfig: () => ({ node: "m5", agents: configAgents }),
   saveConfig: (patch: any) => {
@@ -676,6 +682,30 @@ describe("wake-cmd thirteenth-pass isolated coverage", () => {
     expect(plain()).toContain("Rehydrating 1 window from agents/ state at worktree folders");
     expect(plain()).toContain("snapshot window: neo-restored");
     expect(plain()).toContain("1 window(s) reordered");
+  });
+
+  test("dead rehydrated worktree panes launch fresh without engine continue placeholders", async () => {
+    detectSessionReturn = null;
+    shouldWake = true;
+    listSessionsReturn = [{ name: "03-old" }];
+    listWindowsReturn = [];
+    findWorktreesReturn = [{ name: "2-beta", path: "/tmp/neo-oracle.wt-2-beta" }];
+    plannedRehydrateWindows = [{ windowName: "neo-beta", path: "/tmp/neo-oracle.wt-2-beta" }];
+    paneCommand = "zsh";
+    commandTemplateContinues = true;
+
+    const result = await captureLogs(() => cmdWake("neo", { repoPath, engine: "claude" }));
+
+    expect(result).toBe("04-neo:neo-oracle");
+    expect(sentText).toContainEqual({
+      target: "04-neo:neo-oracle",
+      text: `cd ${repoPath} && claude --agent neo-oracle --continue`,
+    });
+    expect(sentText).toContainEqual({
+      target: "04-neo:neo-beta",
+      text: "cd /tmp/neo-oracle.wt-2-beta && claude --agent neo-beta",
+    });
+    expect(sentText.find((call) => call.target === "04-neo:neo-beta")?.text).not.toContain("--continue");
   });
 
   test("existing live windows can switch engine through tmux respawn-pane", async () => {

--- a/test/isolated/wake-cmd-twelfth-pass-coverage.test.ts
+++ b/test/isolated/wake-cmd-twelfth-pass-coverage.test.ts
@@ -98,8 +98,10 @@ mock.module(import.meta.resolve("../../src/core/ghq"), () => ({
 }));
 
 mock.module(import.meta.resolve("../../src/config"), () => ({
-  buildCommandInDir: (windowName: string, cwd: string, engine?: string) =>
-    `cd ${cwd} && ${engine ?? "codex"} --agent ${windowName}`,
+  buildCommandInDir: (windowName: string, cwd: string, optsOrEngine?: string | { engine?: string }) => {
+    const engine = typeof optsOrEngine === "string" ? optsOrEngine : optsOrEngine?.engine;
+    return `cd ${cwd} && ${engine ?? "codex"} --agent ${windowName}`;
+  },
   cfgTimeout: () => 0,
   loadConfig: () => ({ node: "m5", agents: { neo: "m5" } }),
   saveConfig: () => {},

--- a/test/wake-cmd-cmdwake-coverage.test.ts
+++ b/test/wake-cmd-cmdwake-coverage.test.ts
@@ -328,9 +328,10 @@ mock.module(join(import.meta.dir, "../src/core/ghq"), () => ({
 
 mock.module(join(import.meta.dir, "../src/config"), () => ({
   ..._rConfig,
-  buildCommandInDir: (windowName: string, cwd: string, engine?: string) => {
+  buildCommandInDir: (windowName: string, cwd: string, optsOrEngine?: string | { engine?: string }) => {
     if (!mockActive)
-      return realConfig.buildCommandInDir(windowName, cwd, engine);
+      return realConfig.buildCommandInDir(windowName, cwd, optsOrEngine);
+    const engine = typeof optsOrEngine === "string" ? optsOrEngine : optsOrEngine?.engine;
     return `cd ${cwd} && ${engine ?? "codex"} --agent ${windowName}`;
   },
   cfgTimeout: (key: Parameters<typeof _rConfig.cfgTimeout>[0]) =>


### PR DESCRIPTION
## Summary
- detect dead/non-agent panes during wake worktree rehydrate and render fresh launch commands
- suppress continue/resume launch forms for fresh dead-pane relaunches
- add regressions for dead rehydrate panes and fresh command rendering

Closes #2391

## Tests
- MAW_TEST_MODE=1 bun test test/command-simplified.test.ts
- MAW_TEST_MODE=1 bun test test/isolated/wake-cmd-thirteenth-pass-coverage.test.ts
- MAW_TEST_MODE=1 bun test test/command-golden-master.test.ts
- bun run build