### PR TITLE
Fix trigger idle state sweep

### DIFF
--- a/src/core/runtime/trigger-listener.ts
+++ b/src/core/runtime/trigger-listener.ts
@@ -6,8 +6,12 @@
  */
 
 import type { FeedEvent } from "../../lib/feed";
-import { fire, markAgentActive, checkIdleTriggers, getTriggers } from "./triggers";
+import { fire, markAgentActive, checkIdleTriggers, getTriggers, sweepStaleAgentState } from "./triggers";
 import { agentStatusStore } from "../agent-status";
+
+function unrefInterval(timer: ReturnType<typeof setInterval>): void {
+  (timer as { unref?: () => void }).unref?.();
+}
 
 /**
  * Register a feed listener that maps feed events → trigger events.
@@ -40,11 +44,16 @@ export function setupTriggerListener(feedListeners: Set<(event: FeedEvent) => vo
     }
   });
 
+  // Periodic stale-state sweep: prune agents absent from feed events for >1h (#2386).
+  unrefInterval(setInterval(() => {
+    sweepStaleAgentState();
+  }, 15 * 60 * 1000));
+
   // Periodic idle check (every 15s)
   const idleTriggers = getTriggers().filter(t => t.on === "agent-idle");
   if (idleTriggers.length > 0) {
-    setInterval(() => {
+    unrefInterval(setInterval(() => {
       checkIdleTriggers();
-    }, 15_000);
+    }, 15_000));
   }
 }

--- a/src/core/runtime/triggers-engine.ts
+++ b/src/core/runtime/triggers-engine.ts
@@ -28,11 +28,43 @@ export interface TriggerFireResult {
 /** Last-fired timestamp per trigger (index in config array → result) */
 const lastFired = new Map<number, TriggerFireResult>();
 
-/** Idle tracking: agent → last activity timestamp (ms) */
+/** Idle tracking: agent → last feed activity timestamp (ms) */
 export const idleTimers = new Map<string, number>();
 
 /** Track busy→idle transition: only fire agent-idle when agent WAS busy (#149) */
 export const agentPrevState = new Map<string, "busy" | "idle">();
+
+/** Remove trigger state for agents absent from feed events for this long (#2386). */
+export const STALE_AGENT_STATE_MS = 60 * 60 * 1000;
+
+/**
+ * Sweep idle/transition state for agents not seen in feed events recently.
+ *
+ * `idleTimers` is the source of truth for last feed activity. Keeping idle
+ * agents there until this sweep lets `agentPrevState` be pruned by age too,
+ * instead of accumulating idle entries indefinitely.
+ */
+export function sweepStaleAgentState(now = Date.now(), maxAgeMs = STALE_AGENT_STATE_MS): string[] {
+  const removed: string[] = [];
+
+  for (const [agent, lastSeen] of idleTimers) {
+    if (now - lastSeen > maxAgeMs) {
+      idleTimers.delete(agent);
+      agentPrevState.delete(agent);
+      removed.push(agent);
+    }
+  }
+
+  // Defensive cleanup for any transition state left without a feed timestamp.
+  for (const agent of agentPrevState.keys()) {
+    if (!idleTimers.has(agent)) {
+      agentPrevState.delete(agent);
+      removed.push(agent);
+    }
+  }
+
+  return removed;
+}
 
 /**
  * Expand template variables in an action string.

--- a/src/core/runtime/triggers-idle.ts
+++ b/src/core/runtime/triggers-idle.ts
@@ -38,7 +38,6 @@ export async function checkIdleTriggers(): Promise<string[]> {
         if (results.some((r) => r.ok)) {
           fired.push(agent);
           agentPrevState.set(agent, "idle");
-          idleTimers.delete(agent);
         }
       }
     }

--- a/src/core/runtime/triggers.ts
+++ b/src/core/runtime/triggers.ts
@@ -7,6 +7,6 @@
  */
 
 export type { TriggerContext, TriggerFireResult } from "./triggers-engine";
-export { getTriggers, getTriggerHistory, fire } from "./triggers-engine";
+export { getTriggers, getTriggerHistory, fire, sweepStaleAgentState, STALE_AGENT_STATE_MS } from "./triggers-engine";
 export { parseCronField, wouldFireAt } from "./triggers-cron";
 export { markAgentActive, checkIdleTriggers } from "./triggers-idle";

--- a/test/isolated/peers-store-triggers-idle-more-coverage.test.ts
+++ b/test/isolated/peers-store-triggers-idle-more-coverage.test.ts
@@ -208,7 +208,7 @@ describe("src/core/runtime/triggers-idle focused branches", () => {
     expect(agentPrevState.get("too-young")).toBe("busy");
   });
 
-  test("checkIdleTriggers records a fired idle transition and clears its timer after a successful fire", async () => {
+  test("checkIdleTriggers records a fired idle transition and keeps last-seen state for sweeping", async () => {
     const now = 1_779_000_200_000;
     Date.now = () => now;
     triggers = [{ on: "agent-idle", action: "echo idle", timeout: 5 }];
@@ -219,7 +219,7 @@ describe("src/core/runtime/triggers-idle focused branches", () => {
     expect(await checkIdleTriggers()).toEqual(["done-agent"]);
     expect(fireCalls).toEqual([{ event: "agent-idle", ctx: { agent: "done-agent" } }]);
     expect(agentPrevState.get("done-agent")).toBe("idle");
-    expect(idleTimers.has("done-agent")).toBe(false);
+    expect(idleTimers.get("done-agent")).toBe(now - 6_000);
   });
 
   test("checkIdleTriggers leaves busy state and timer intact when fire returns no successful result", async () => {

--- a/test/isolated/runtime-triggers-extra-coverage.test.ts
+++ b/test/isolated/runtime-triggers-extra-coverage.test.ts
@@ -29,7 +29,7 @@ const originalSpawn = Bun.spawn;
 let spawnQueue: Array<{ stdout?: string; code?: number } | Error> = [];
 
 const engine = await import("../../src/core/runtime/triggers-engine.ts?runtime-triggers-extra");
-const { fire, getTriggers, getTriggerHistory, idleTimers, agentPrevState } = engine;
+const { fire, getTriggers, getTriggerHistory, idleTimers, agentPrevState, sweepStaleAgentState, STALE_AGENT_STATE_MS } = engine;
 
 function mockSpawn() {
   Bun.spawn = ((cmd: string[]) => {
@@ -64,6 +64,23 @@ describe("runtime trigger engine", () => {
     expect(getTriggers()).toEqual(triggers);
     expect(idleTimers.get("oracle")).toBe(123);
     expect(agentPrevState.get("oracle")).toBe("busy");
+  });
+
+
+  test("sweepStaleAgentState prunes agents absent from feed events for over one hour", () => {
+    const now = 1_779_100_000_000;
+    idleTimers.set("stale-busy", now - STALE_AGENT_STATE_MS - 1);
+    agentPrevState.set("stale-busy", "busy");
+    idleTimers.set("fresh-idle", now - STALE_AGENT_STATE_MS);
+    agentPrevState.set("fresh-idle", "idle");
+    agentPrevState.set("orphan-state", "idle");
+
+    expect(sweepStaleAgentState(now)).toEqual(["stale-busy", "orphan-state"]);
+    expect(idleTimers.has("stale-busy")).toBe(false);
+    expect(agentPrevState.has("stale-busy")).toBe(false);
+    expect(idleTimers.has("fresh-idle")).toBe(true);
+    expect(agentPrevState.get("fresh-idle")).toBe("idle");
+    expect(agentPrevState.has("orphan-state")).toBe(false);
   });
 
   test("fires matching triggers with template expansion, audit history, and once removal", async () => {

--- a/test/isolated/trigger-listener-more-coverage.test.ts
+++ b/test/isolated/trigger-listener-more-coverage.test.ts
@@ -10,6 +10,7 @@ let triggers: Trigger[] = [];
 let fireCalls: FireCall[] = [];
 let activeAgents: string[] = [];
 let idleChecks = 0;
+let sweepChecks = 0;
 
 mock.module(import.meta.resolve("../../src/core/runtime/triggers.ts"), () => ({
   fire: (event: string, ctx: Record<string, unknown>) => {
@@ -22,6 +23,9 @@ mock.module(import.meta.resolve("../../src/core/runtime/triggers.ts"), () => ({
     idleChecks += 1;
   },
   getTriggers: () => triggers,
+  sweepStaleAgentState: () => {
+    sweepChecks += 1;
+  },
 }));
 
 const { setupTriggerListener } = await import("../../src/core/runtime/trigger-listener.ts?trigger-listener-more-coverage");
@@ -38,6 +42,7 @@ beforeEach(() => {
   fireCalls = [];
   activeAgents = [];
   idleChecks = 0;
+  sweepChecks = 0;
   intervalCalls = [];
   globalThis.setInterval = ((callback: () => void, delay?: number) => {
     intervalCalls.push({ callback, delay: delay ?? 0 });
@@ -50,13 +55,16 @@ afterEach(() => {
 });
 
 describe("setupTriggerListener", () => {
-  test("registers a listener without scheduling idle checks when no idle triggers are configured", () => {
+  test("registers a listener and schedules stale-state sweep even without idle triggers", () => {
     const listeners = new Set<(event: FeedEvent) => void>();
 
     setupTriggerListener(listeners);
 
     expect(listeners.size).toBe(1);
-    expect(intervalCalls).toEqual([]);
+    expect(intervalCalls).toHaveLength(1);
+    expect(intervalCalls[0]?.delay).toBe(15 * 60 * 1000);
+
+    intervalCalls[0]?.callback();
 
     const [listener] = listeners;
     listener(feed({ event: "Message" }));
@@ -64,6 +72,7 @@ describe("setupTriggerListener", () => {
     expect(activeAgents).toEqual([]);
     expect(fireCalls).toEqual([]);
     expect(idleChecks).toBe(0);
+    expect(sweepChecks).toBe(1);
   });
 
   test("marks agent activity and maps SessionStart to agent-wake", () => {
@@ -102,10 +111,11 @@ describe("setupTriggerListener", () => {
 
     setupTriggerListener(listeners);
 
-    expect(intervalCalls).toHaveLength(1);
-    expect(intervalCalls[0]?.delay).toBe(15_000);
+    expect(intervalCalls).toHaveLength(2);
+    expect(intervalCalls[0]?.delay).toBe(15 * 60 * 1000);
+    expect(intervalCalls[1]?.delay).toBe(15_000);
 
-    intervalCalls[0]?.callback();
+    intervalCalls[1]?.callback();
 
     expect(idleChecks).toBe(1);
   });


### PR DESCRIPTION
Closes #2386

## Summary
- keep idleTimers as last feed-seen state after idle transitions
- add a >1h stale-agent sweep that prunes idleTimers and agentPrevState
- schedule the sweep from the trigger listener with unref'd intervals

## Verification
- bun install --frozen-lockfile
- git diff --check
- MAW_TEST_MODE=1 bun test test/isolated/runtime-triggers-extra-coverage.test.ts test/isolated/trigger-listener-more-coverage.test.ts test/isolated/peers-store-triggers-idle-more-coverage.test.ts --path-ignore-patterns "**/agents/**"
- bun run build
- bun run test:isolated (620/620 files)

## Notes
- bun run test:default:safe remains red in shared-sweep mode on 16 tmux wrapper/sendText cases; those tmux files pass when run directly and are unrelated to trigger state.