### PR TITLE
Fix wake inbox prompt size for unread messages

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -978,16 +978,12 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
     return `${oracle}:list`;
   }
 
-  const drainedInbox = drainWakeInbox(repoPath, { markRead: !opts.dryRun, engine: opts.engine });
+  const drainedInbox = drainWakeInbox(repoPath, { markRead: false, engine: opts.engine });
   if (drainedInbox.prompt.trim()) {
     opts = { ...opts, prompt: mergeWakeInboxPrompt(opts.prompt, drainedInbox.prompt) };
   }
-  if (drainedInbox.count > 0 || drainedInbox.omittedCount > 0) {
-    const dryRunSuffix = opts.dryRun ? " (dry-run; left unread)" : "";
-    const omittedSuffix = drainedInbox.omittedCount > 0
-      ? `; omitted ${drainedInbox.omittedCount} over ${drainedInbox.byteBudget} byte budget`
-      : "";
-    console.log(`\x1b[36m📬\x1b[0m drained ${drainedInbox.count} unread ψ/inbox message${drainedInbox.count === 1 ? "" : "s"} into wake prompt${omittedSuffix}${dryRunSuffix}`);
+  if (drainedInbox.count > 0) {
+    console.log(`\x1b[36m📬\x1b[0m ${drainedInbox.count} unread ψ/inbox message${drainedInbox.count === 1 ? "" : "s"}; left unread for maw inbox --unread`);
   }
 
   const foreignSession = requestedForeignSession;

--- a/src/commands/shared/wake-inbox-drain.ts
+++ b/src/commands/shared/wake-inbox-drain.ts
@@ -32,10 +32,6 @@ export interface WakeInboxDrainDeps {
 
 export const DEFAULT_WAKE_INBOX_BYTE_BUDGET = 64 * 1024;
 
-function utf8Bytes(value: string): number {
-  return Buffer.byteLength(value, "utf-8");
-}
-
 function parseFrontmatter(raw: string): { meta: Record<string, string>; body: string; frontmatter: string | null } {
   if (!raw.startsWith("---\n")) return { meta: {}, body: raw.trim(), frontmatter: null };
   const end = raw.indexOf("\n---", 4);
@@ -66,31 +62,10 @@ function markFrontmatterRead(raw: string, timestamp: string): string {
   return fm + raw.slice(end + "\n---".length);
 }
 
-function formatWakeInboxOmittedNotice(omittedCount: number): string {
-  if (omittedCount <= 0) return "";
-  return [
-    "## Unread ψ/inbox messages omitted",
-    `${omittedCount} unread ψ/inbox message${omittedCount === 1 ? "" : "s"} exceeded the wake prompt byte budget and remain unread.`,
-    "Run `maw inbox --unread` after wake to review the remaining messages.",
-  ].join("\n");
-}
-
-export function formatWakeInboxPrompt(messages: WakeInboxMessage[], omittedCount = 0): string {
-  if (!messages.length) return formatWakeInboxOmittedNotice(omittedCount);
-  const sections = messages.map((msg, index) => [
-    `### ${index + 1}. ${msg.filename}`,
-    `from: ${msg.from || "unknown"}`,
-    msg.timestamp ? `timestamp: ${msg.timestamp}` : "",
-    "",
-    msg.body,
-  ].filter(Boolean).join("\n"));
-  return [
-    "## Unread ψ/inbox messages",
-    "These messages were mechanically drained by `maw wake`; acknowledge or act on them before continuing.",
-    "",
-    ...sections,
-    formatWakeInboxOmittedNotice(omittedCount),
-  ].filter(Boolean).join("\n\n");
+export function formatWakeInboxPrompt(countOrMessages: number | WakeInboxMessage[]): string {
+  const count = Array.isArray(countOrMessages) ? countOrMessages.length : countOrMessages;
+  if (count <= 0) return "";
+  return `You have ${count} unread messages in inbox. Run maw inbox --unread to review.`;
 }
 
 export function mergeWakeInboxPrompt(existingPrompt: string | undefined, inboxPrompt: string): string | undefined {
@@ -104,7 +79,7 @@ export function drainWakeInbox(repoPath: string, deps: WakeInboxDrainDeps = {}):
   const fsReadDir = deps.readdirSync ?? readdirSync;
   const fsReadFile = deps.readFileSync ?? readFileSync;
   const fsWriteFile = deps.writeFileSync ?? writeFileSync;
-  const markRead = deps.markRead ?? true;
+  const markRead = deps.markRead ?? false;
   const byteBudget = Math.max(0, Math.floor(deps.byteBudget ?? DEFAULT_WAKE_INBOX_BYTE_BUDGET));
   const engine = deps.engine;
   if (engine !== undefined && !isClaudeLikeEngine(engine, deps.config ?? {})) {
@@ -115,7 +90,6 @@ export function drainWakeInbox(repoPath: string, deps: WakeInboxDrainDeps = {}):
   if (!fsExists(inboxDir)) return { count: 0, prompt: "", messages: [], omittedCount: 0, byteBudget };
 
   const messages: WakeInboxMessage[] = [];
-  let omittedCount = 0;
   for (const filename of fsReadDir(inboxDir).filter((name) => name.endsWith(".md")).sort()) {
     const path = join(inboxDir, filename);
     let raw: string;
@@ -126,19 +100,13 @@ export function drainWakeInbox(repoPath: string, deps: WakeInboxDrainDeps = {}):
     }
     const parsed = parseFrontmatter(raw);
     if (!isUnread(parsed.meta)) continue;
-    const message = {
+    messages.push({
       path,
       filename,
       from: parsed.meta.from ?? "",
       timestamp: parsed.meta.timestamp ?? "",
-      body: parsed.body,
-    };
-    const nextPrompt = formatWakeInboxPrompt([...messages, message], omittedCount);
-    if (utf8Bytes(nextPrompt) > byteBudget) {
-      omittedCount++;
-      continue;
-    }
-    messages.push(message);
+      body: "",
+    });
     if (markRead) {
       try {
         fsWriteFile(path, markFrontmatterRead(raw, new Date().toISOString()));
@@ -148,8 +116,11 @@ export function drainWakeInbox(repoPath: string, deps: WakeInboxDrainDeps = {}):
     }
   }
 
-  let prompt = formatWakeInboxPrompt(messages, omittedCount);
-  if (utf8Bytes(prompt) > byteBudget) prompt = formatWakeInboxPrompt(messages, 0);
-  if (utf8Bytes(prompt) > byteBudget) prompt = "";
-  return { count: messages.length, messages, omittedCount, byteBudget, prompt };
+  return {
+    count: messages.length,
+    messages,
+    omittedCount: 0,
+    byteBudget,
+    prompt: formatWakeInboxPrompt(messages.length),
+  };
 }

--- a/test/isolated/wake-inbox-drain-2013.test.ts
+++ b/test/isolated/wake-inbox-drain-2013.test.ts
@@ -5,7 +5,7 @@ import { join } from "path";
 import { drainWakeInbox, mergeWakeInboxPrompt } from "../../src/commands/shared/wake-inbox-drain";
 
 describe("wake inbox drain (#2013)", () => {
-  test("drains unread ψ/inbox markdown into a priming prompt and marks read", () => {
+  test("reports unread ψ/inbox count without injecting bodies or marking read", () => {
     const repo = mkdtempSync(join(tmpdir(), "maw-wake-drain-"));
     const inbox = join(repo, "ψ", "inbox");
     mkdirSync(inbox, { recursive: true });
@@ -27,17 +27,18 @@ describe("wake inbox drain (#2013)", () => {
     const result = drainWakeInbox(repo);
 
     expect(result.count).toBe(1);
-    expect(result.prompt).toContain("Unread ψ/inbox messages");
-    expect(result.prompt).toContain("please review #2013");
+    expect(result.prompt).toBe("You have 1 unread messages in inbox. Run maw inbox --unread to review.");
+    expect(result.prompt).not.toContain("please review #2013");
     expect(result.prompt).not.toContain("old");
     const updated = readFileSync(unread, "utf-8");
-    expect(updated).toContain("read: true");
-    expect(updated).toContain("readAt:");
+    expect(updated).toContain("read: false");
+    expect(updated).not.toContain("readAt:");
   });
 
   test("merges drained inbox after an explicit wake prompt", () => {
-    expect(mergeWakeInboxPrompt("continue task", "## Unread ψ/inbox messages\nhello"))
-      .toBe("continue task\n\n## Unread ψ/inbox messages\nhello");
+    const notification = "You have 2 unread messages in inbox. Run maw inbox --unread to review.";
+    expect(mergeWakeInboxPrompt("continue task", notification))
+      .toBe(`continue task\n\n${notification}`);
   });
 
   test("skips draining inbox for non-Claude engines", () => {
@@ -79,15 +80,17 @@ test("caps wake inbox prompt bytes and leaves omitted messages unread", () => {
   const result = drainWakeInbox(repo, { byteBudget: 400 });
 
   expect(Buffer.byteLength(result.prompt, "utf-8")).toBeLessThanOrEqual(400);
-  expect(result.count).toBe(1);
-  expect(result.omittedCount).toBe(1);
-  expect(result.prompt).toContain("small body");
-  expect(readFileSync(small, "utf-8")).toContain("read: true");
+  expect(result.count).toBe(2);
+  expect(result.omittedCount).toBe(0);
+  expect(result.prompt).toBe("You have 2 unread messages in inbox. Run maw inbox --unread to review.");
+  expect(result.prompt).not.toContain("small body");
+  expect(result.prompt).not.toContain("x".repeat(100));
+  expect(readFileSync(small, "utf-8")).toContain("read: false");
   expect(readFileSync(huge, "utf-8")).toContain("read: false");
 });
 
 
-test("returns an omitted notice prompt when every unread message exceeds the byte budget", () => {
+test("returns a count notification even when unread message bodies are huge", () => {
   const repo = mkdtempSync(join(tmpdir(), "maw-wake-drain-all-omitted-"));
   const inbox = join(repo, "ψ", "inbox");
   mkdirSync(inbox, { recursive: true });
@@ -96,9 +99,9 @@ test("returns an omitted notice prompt when every unread message exceeds the byt
 
   const result = drainWakeInbox(repo, { byteBudget: 400 });
 
-  expect(result.count).toBe(0);
-  expect(result.omittedCount).toBe(1);
-  expect(result.prompt).toContain("Unread ψ/inbox messages omitted");
-  expect(result.prompt).toContain("remain unread");
+  expect(result.count).toBe(1);
+  expect(result.omittedCount).toBe(0);
+  expect(result.prompt).toBe("You have 1 unread messages in inbox. Run maw inbox --unread to review.");
+  expect(result.prompt).not.toContain("x".repeat(100));
   expect(readFileSync(huge, "utf-8")).toContain("read: false");
 });


### PR DESCRIPTION
## Summary
- replace wake inbox body injection with a one-line unread count notification
- keep wake inbox messages unread so agents can review with `maw inbox --unread`
- update wake inbox regression tests for huge message bodies

Closes #2390

## Validation
- `bun test test/isolated/wake-inbox-drain-2013.test.ts`
- `bun run build`
- `git diff --check`

## Notes
- Full `bun run test:isolated` was attempted in the sandbox and reached 603/620 passing; remaining failures were unrelated environment issues (EPERM writing under `/Users/nat`, Bun.serve port 0/listen restrictions).
