### PR TITLE
RFC #2400 Phase 2: use configured default engine fallbacks

### DIFF
--- a/src/commands/plugins/team/team-lifecycle.ts
+++ b/src/commands/plugins/team/team-lifecycle.ts
@@ -5,6 +5,8 @@ import { tmux } from "../../../sdk";
 import { assertValidOracleName } from "../../../core/fleet/validate";
 import { prefixCommandWithSpawnSessionEnv } from "../../../core/fleet/parent-session";
 import { buildCommand, buildCommandInDir } from "../../../config/command";
+import { loadConfig } from "../../../config/load";
+import { resolveEngine } from "../../../config/engine-registry";
 import { TEAMS_DIR, loadTeam, resolvePsi, writeShutdownRequest, cleanupTeamDir, type TeamConfig, type TeamMember } from "./team-helpers";
 
 const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
@@ -241,8 +243,10 @@ export async function cmdTeamSpawn(
   }
 
   // Build spawn prompt
-  const engine = opts.engine || "claude";
-  const model = opts.model || (engine === "claude" ? "sonnet" : undefined);
+  const config = loadConfig();
+  const engine = opts.engine || config.defaultEngine || "claude";
+  const resolvedEngine = resolveEngine(engine, config);
+  const model = opts.model || resolvedEngine.model?.default;
   const shellQuote = (s: string) => `'${s.replace(/'/g, "'\\''")}'`;
   const cwdPrefix = opts.cwd ? `cd ${shellQuote(opts.cwd)} && ` : "";
   const parts: string[] = [];

--- a/src/commands/plugins/team/team-liveness.ts
+++ b/src/commands/plugins/team/team-liveness.ts
@@ -80,7 +80,8 @@ export function classifyMember(
   const pane = panes.find((candidate) =>
     candidate.sessionName === session && (candidate.windowName === windowIdentity || suffix.test(candidate.windowName))
   );
-  const engine = opts.engine ?? member.engine ?? member.model ?? "claude";
+  const config = loadConfig();
+  const engine = opts.engine ?? member.engine ?? member.model ?? config.defaultEngine ?? "claude";
   const worktree = typeof member.worktree === "string" && member.worktree.trim() ? member.worktree.trim() : windowIdentity;
   if (!pane) return { member, role, engine, worktree, windowIdentity, state: "missing" };
   if (SHELL_RE.test(pane.command)) return { member, role, engine, worktree, windowIdentity, state: "dead", pane };

--- a/src/config/command-logic.ts
+++ b/src/config/command-logic.ts
@@ -4,7 +4,7 @@ import { join } from "path";
 import type { MawConfig } from "./types";
 import type { EngineDef } from "./engine-def";
 import { getChannelEnv, getChannelPermissionMode, getChannelPluginIds } from "../commands/shared/channel-loader";
-import { DEFAULT_ENGINES, resolveEngine } from "./engine-registry";
+import { DEFAULT_ENGINES, isClaudeLikeCommand, resolveEngine } from "./engine-registry";
 
 const DISCORD_CHANNEL_PLUGIN = "plugin:discord@claude-plugins-official";
 
@@ -28,10 +28,6 @@ export type BuildCommandInput = string | BuildCommandOpts | undefined;
 
 function normalizeBuildCommandOpts(input?: BuildCommandInput): BuildCommandOpts {
   return typeof input === "string" ? { engine: input } : { ...(input || {}) };
-}
-
-function isClaudeLikeCommand(cmd: string): boolean {
-  return /(^|\s)(?:command\s+)?claude[A-Za-z0-9_-]*(?:\s|$)/.test(cmd);
 }
 
 function hasChannelsFlag(cmd: string): boolean {
@@ -125,13 +121,14 @@ function legacyCommandForAgent(
   agentName: string,
   opts: BuildCommandOpts,
 ): string {
-  const commands = config.commands || { default: "claude" };
+  const commands = config.commands || { default: config.defaultEngine ?? "claude" };
+  const defaultEngine = config.defaultEngine ?? "claude";
   let cmd: string;
 
   if (opts.engine && commands[opts.engine]) {
     cmd = commands[opts.engine];
   } else {
-    cmd = commands.default || "claude";
+    cmd = commands.default || defaultEngine;
     for (const [pattern, command] of Object.entries(commands)) {
       if (pattern === "default") continue;
       if (matchesAgentPattern(pattern, agentName)) { cmd = command; break; }
@@ -158,7 +155,7 @@ function selectEngineForAgent(
     return resolveEngine(opts.engine, config);
   }
 
-  let engineName = "default";
+  let engineName = commands.default ? "default" : (config.defaultEngine ?? "default");
   for (const pattern of Object.keys(commands)) {
     if (pattern === "default") continue;
     if (matchesAgentPattern(pattern, agentName)) { engineName = pattern; break; }

--- a/src/config/engine-registry.ts
+++ b/src/config/engine-registry.ts
@@ -19,7 +19,7 @@ export const DEFAULT_ENGINES = {
 
 export type EngineRegistry = Record<string, EngineDef>;
 
-function isClaudeLikeCommand(cmd: string): boolean {
+export function isClaudeLikeCommand(cmd: string): boolean {
   return /(^|\s)(?:command\s+)?claude[A-Za-z0-9_-]*(?:\s|$)/.test(cmd);
 }
 

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -34,6 +34,7 @@ const DEFAULTS: MawConfig = {
   oracleUrl: "http://localhost:47779",
   env: {},
   commands: { default: "claude" },
+  defaultEngine: "claude",
   sessions: {},
 };
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -98,6 +98,8 @@ export interface MawConfig {
   oracleUrl: string;
   env: Record<string, string>;
   commands: Record<string, string>;
+  /** Default engine key/command used when no command-specific fallback is configured (#2400). */
+  defaultEngine?: string;
   /**
    * Generic engine definitions (#1960 P1).
    *

--- a/src/vendor/mpr-plugins/team/team-lifecycle.ts
+++ b/src/vendor/mpr-plugins/team/team-lifecycle.ts
@@ -6,6 +6,8 @@ import { assertValidOracleName } from "maw-js/core/fleet/validate";
 import { prefixCommandWithSpawnSessionEnv } from "../../../core/fleet/parent-session";
 import { buildCommand, buildCommandInDir } from "../../../config/command";
 import { writeWorktreeEngineFile } from "../../../commands/shared/wake-session";
+import { loadConfig } from "../../../config/load";
+import { resolveEngine } from "../../../config/engine-registry";
 import { TEAMS_DIR, loadTeam, resolvePsi, writeShutdownRequest, cleanupTeamDir, currentLeadSessionId, type TeamConfig, type TeamMember } from "./team-helpers";
 
 const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
@@ -233,9 +235,11 @@ export async function cmdTeamSpawn(
   }
 
   // Build spawn prompt
-  const engine = opts.engine || "claude";
+  const config = loadConfig();
+  const engine = opts.engine || config.defaultEngine || "claude";
   if (opts.cwd && existsSync(opts.cwd)) writeWorktreeEngineFile(opts.cwd, engine, console.log.bind(console));
-  const model = opts.model || (engine === "claude" ? "sonnet" : undefined);
+  const resolvedEngine = resolveEngine(engine, config);
+  const model = opts.model || resolvedEngine.model?.default;
   const shellQuote = (s: string) => `'${s.replace(/'/g, "'\\''")}'`;
   const cwdPrefix = opts.cwd ? `cd ${shellQuote(opts.cwd)} && ` : "";
   const parts: string[] = [];

--- a/src/vendor/mpr-plugins/team/team-liveness.ts
+++ b/src/vendor/mpr-plugins/team/team-liveness.ts
@@ -79,8 +79,8 @@ export function memberWorktree(member: TeamCharterMember): string {
   return typeof member.worktree === "string" && member.worktree.trim() ? member.worktree.trim() : identity;
 }
 
-export function memberEngine(member: TeamCharterMember, override?: string): string {
-  return override ?? member.engine ?? member.model ?? "claude";
+export function memberEngine(member: TeamCharterMember, override?: string, config: MawConfig = loadConfig()): string {
+  return override ?? member.engine ?? member.model ?? config.defaultEngine ?? "claude";
 }
 
 export function memberMatchesSelector(member: TeamCharterMember, selector: string): boolean {

--- a/test/command-golden-master.test.ts
+++ b/test/command-golden-master.test.ts
@@ -111,4 +111,21 @@ describe("buildCommandFromConfig golden master (#1960 P0)", () => {
       engines: { codex: { name: "codex", cmd: "codex --typed" } },
     } as any, "codex-agent", "codex")).toBe("codex --typed");
   });
+
+  test("defaultEngine supplies the default fallback when commands.default is absent", () => {
+    delete process.env.MAW_GENERIC_ENGINES;
+
+    expect(buildCommandFromConfig({
+      ...baseConfig,
+      defaultEngine: "codex",
+      commands: {},
+    } as any, "unmapped-agent")).toBe("codex");
+
+    process.env.MAW_GENERIC_ENGINES = "0";
+    expect(buildCommandFromConfig({
+      ...baseConfig,
+      defaultEngine: "opencode",
+      commands: {},
+    } as any, "unmapped-agent")).toBe("opencode");
+  });
 });

--- a/test/engine-registry.test.ts
+++ b/test/engine-registry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-const { DEFAULT_ENGINES, resolveEngine } = await import("../src/config/engine-registry");
+const { DEFAULT_ENGINES, isClaudeLikeCommand, resolveEngine } = await import("../src/config/engine-registry");
 
 describe("generic engine registry (#1960 P1)", () => {
   test("lowers the legacy swarm known agents into dormant EngineDef defaults", () => {
@@ -49,5 +49,10 @@ describe("generic engine registry (#1960 P1)", () => {
       name: "gemini",
       cmd: "gemini",
     });
+  });
+
+  test("exports Claude-like command detection for command rendering", () => {
+    expect(isClaudeLikeCommand("claude --continue")).toBe(true);
+    expect(isClaudeLikeCommand("codex --continue")).toBe(false);
   });
 });

--- a/test/isolated/config-load-second-pass.test.ts
+++ b/test/isolated/config-load-second-pass.test.ts
@@ -233,6 +233,7 @@ describe("config load second pass coverage", () => {
       oracleUrl: "http://localhost:47779",
       env: {},
       commands: { default: "claude" },
+      defaultEngine: "claude",
       sessions: {},
     });
     expect(validateCalls).toBe(0);

--- a/test/isolated/plugin-team-standalone.test.ts
+++ b/test/isolated/plugin-team-standalone.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const root = join(import.meta.dir, "../..");
@@ -33,6 +34,10 @@ function parseFlags(args: string[], spec: Record<string, unknown>, start = 0) {
 const sdkMock = {
   parseFlags,
   hostExec: async (cmd: string) => { hostExecCalls.push(cmd); return ""; },
+  tmux: {
+    listPaneIds: async () => new Set<string>(),
+    killPane: async () => undefined,
+  },
 };
 
 mock.module("maw-js/sdk", () => sdkMock);
@@ -129,6 +134,74 @@ describe("team command plugin standalone boundary (#2336)", () => {
     const unknown = await teamHandler({ source: "cli", args: ["nope"] } as any);
     expect(unknown).toMatchObject({ ok: false, error: "unknown subcommand: nope" });
     expect(calls).toEqual([]);
+  });
+
+
+  test("team spawn honors config.defaultEngine fallback without explicit --engine", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "maw-team-standalone-"));
+    const cwd = join(tmp, "repo");
+    const psi = join(cwd, "ψ");
+    const teamsDir = join(tmp, "teams");
+    const tasksDir = join(tmp, "tasks");
+    mkdirSync(join(psi, "memory", "mailbox", "teams", "avengers"), { recursive: true });
+    mkdirSync(join(teamsDir, "avengers"), { recursive: true });
+    writeFileSync(join(cwd, "CLAUDE.md"), "oracle repo\n");
+    writeFileSync(join(psi, "memory", "mailbox", "teams", "avengers", "manifest.json"), JSON.stringify({ name: "avengers", members: [] }));
+    writeFileSync(join(teamsDir, "avengers", "config.json"), JSON.stringify({ name: "avengers", members: [] }));
+
+    const testConfig = {
+      defaultEngine: "codex",
+      commands: {},
+      engines: {
+        codex: {
+          cmd: "codex",
+          model: { flag: "--model", default: "gpt-5.5" },
+          capabilities: ["model", "system-prompt-file"],
+        },
+      },
+    };
+    mock.module(import.meta.resolve("../../src/config/load.ts"), () => ({
+      loadConfig: () => testConfig,
+      loadConfigWithProvenance: () => ({ config: testConfig, sources: [], provenance: {}, warnings: [] }),
+      resetConfig: () => undefined,
+      saveConfig: () => undefined,
+      configForDisplay: () => testConfig,
+      cfgInterval: () => 1,
+      cfgTimeout: () => 1,
+      cfgLimit: () => 80,
+      cfg: (key: keyof typeof testConfig) => testConfig[key],
+    }));
+
+    const helpers = await import("../../src/vendor/mpr-plugins/team/team-helpers.ts");
+    helpers._setDirs(teamsDir, tasksDir);
+    const lifecycle = await import("../../src/vendor/mpr-plugins/team/team-lifecycle.ts?plugin-team-default-engine");
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(cwd);
+      await lifecycle.cmdTeamSpawn("avengers", "builder");
+    } finally {
+      process.chdir(previousCwd);
+    }
+
+    const toolConfig = JSON.parse(readFileSync(join(teamsDir, "avengers", "config.json"), "utf8"));
+    expect(toolConfig.members).toEqual([{ name: "builder", engine: "codex", model: "gpt-5.5" }]);
+    const prompt = readFileSync(join(psi, "memory", "mailbox", "teams", "avengers", "builder-spawn-prompt.md"), "utf8");
+    expect(prompt).toContain("You are 'builder' on team 'avengers'.");
+
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("memberEngine honors config.defaultEngine before hard-coded claude fallback", async () => {
+    mock.module(import.meta.resolve("../../src/commands/shared/wake-cmd.ts"), () => ({
+      cmdWake: async () => "",
+    }));
+    const { memberEngine } = await import("../../src/vendor/mpr-plugins/team/team-liveness.ts?plugin-team-member-engine");
+
+    expect(memberEngine({ role: "builder" } as any, undefined, { defaultEngine: "codex" } as any)).toBe("codex");
+    expect(memberEngine({ role: "builder", model: "opencode" } as any, undefined, { defaultEngine: "codex" } as any)).toBe("opencode");
+    expect(memberEngine({ role: "builder", engine: "aider" } as any, undefined, { defaultEngine: "codex" } as any)).toBe("aider");
+    expect(memberEngine({ role: "builder", engine: "aider" } as any, "thclaws", { defaultEngine: "codex" } as any)).toBe("thclaws");
+    expect(memberEngine({ role: "builder" } as any, undefined, {} as any)).toBe("claude");
   });
 
   test("enter subcommand sends tmux enter via SDK hostExec", async () => {


### PR DESCRIPTION
RFC #2400 Phase 2. Replaces hardcoded Claude/Sonnet launch fallbacks with MawConfig.defaultEngine and resolveEngine model defaults.