### PR TITLE
RFC #2400 Phase 2b: engine processNames agent detection

### DIFF
--- a/src/commands/plugins/tmux/safety.ts
+++ b/src/commands/plugins/tmux/safety.ts
@@ -1,3 +1,4 @@
+import { matchesAgentProcessName } from "../../../core/agent-detect";
 /**
  * Safety gates for maw tmux verbs that mutate pane state (send, kill).
  * Centralized so `send` and `kill` share the same refuse/confirm logic.
@@ -58,10 +59,10 @@ export function checkDestructive(cmd: string): DestructiveCheck {
  */
 export function isClaudeLikePane(paneCurrentCommand: string | undefined): boolean {
   if (!paneCurrentCommand) return false;
-  const cmd = paneCurrentCommand.toLowerCase();
-  if (cmd.includes("claude")) return true;
+  const cmd = paneCurrentCommand.toLowerCase().trim();
+  if (matchesAgentProcessName(cmd)) return true;
   // Claude Code with bun often shows as "2.1.111" etc. — version-y pattern.
-  if (/^\d+\.\d+\.\d+$/.test(cmd.trim())) return true;
+  if (/^\d+\.\d+\.\d+$/.test(cmd)) return true;
   return false;
 }
 

--- a/src/commands/shared/context-limit.ts
+++ b/src/commands/shared/context-limit.ts
@@ -1,3 +1,4 @@
+import { matchesAgentProcessName } from "../../core/agent-detect";
 import { tmux as defaultTmux } from "../../sdk";
 
 export interface ContextLimitProbeDeps {
@@ -43,7 +44,8 @@ export function isLikelyAgentPaneCommand(command: string | undefined): boolean {
   if (!command) return false;
   const cmd = command.toLowerCase().trim();
   if (!cmd) return false;
-  if (/claude|codex|node|bun/.test(cmd)) return true;
+  if (matchesAgentProcessName(cmd)) return true;
+  if (/^(node|bun)$/i.test(cmd)) return true;
   return /^\d+\.\d+\.\d+$/.test(cmd);
 }
 

--- a/src/config/engine-def.ts
+++ b/src/config/engine-def.ts
@@ -11,6 +11,8 @@ export interface EngineDef {
   cmd: string;
   /** Human label for UI surfaces such as swarm/team panes. */
   label?: string;
+  /** Tmux pane_current_command basenames that identify this engine as live. */
+  processNames?: string[];
   /** Arguments for a fresh launch form. Advisory until P2/P3 consumes it. */
   freshArgs?: string[];
   /** Resume form for engines that support session resurrection. */

--- a/src/config/engine-registry.ts
+++ b/src/config/engine-registry.ts
@@ -6,13 +6,15 @@ export const DEFAULT_ENGINES = {
     name: "claude",
     cmd: "claude",
     label: "Claude Code",
+    processNames: ["claude", "claude-code", "thclaude"],
     resume: { flag: "--resume", replaces: "--continue", quoteValue: true },
     model: { flag: "--model", default: "sonnet" },
     capabilities: ["channels", "resume", "model", "system-prompt-file"],
   },
-  codex: { name: "codex", cmd: "codex", label: "Codex CLI" },
-  opencode: { name: "opencode", cmd: "opencode", label: "OpenCode" },
-  aider: { name: "aider", cmd: "aider", label: "Aider" },
+  codex: { name: "codex", cmd: "codex", label: "Codex CLI", processNames: ["codex"] },
+  thclaws: { name: "thclaws", cmd: "thclaws", label: "thClaws", processNames: ["thclaws"] },
+  opencode: { name: "opencode", cmd: "opencode", label: "OpenCode", processNames: ["opencode"] },
+  aider: { name: "aider", cmd: "aider", label: "Aider", processNames: ["aider"] },
 } satisfies Record<string, EngineDef>;
 
 export type EngineRegistry = Record<string, EngineDef>;
@@ -23,7 +25,8 @@ function isClaudeLikeCommand(cmd: string): boolean {
 
 function fromLegacyCommand(name: string, cmd: string): EngineDef {
   const builtIn = DEFAULT_ENGINES[name];
-  const def: EngineDef = { name, cmd, ...(builtIn?.label ? { label: builtIn.label } : {}) };
+  const bin = cmd.trim().split(/\s+/)[0];
+  const def: EngineDef = { name, cmd, ...(builtIn?.label ? { label: builtIn.label } : {}), processNames: bin && bin !== "default" ? [bin] : builtIn?.processNames };
   if (isClaudeLikeCommand(cmd)) {
     def.resume = { flag: "--resume", replaces: "--continue", quoteValue: true };
     def.model = { flag: "--model", default: "sonnet" };

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -91,6 +91,10 @@ export function validateBasicFields(
           warn(`engines.${name}.cmd`, "must be a non-empty string");
           continue;
         }
+        if (def.processNames !== undefined && (!Array.isArray(def.processNames) || def.processNames.some((v) => typeof v !== "string"))) {
+          warn(`engines.${name}.processNames`, "must be a string[]");
+          continue;
+        }
         engines[name] = { ...def, name: typeof def.name === "string" && def.name ? def.name : name };
       }
       if (Object.keys(engines).length > 0) result.engines = engines;
@@ -169,6 +173,9 @@ export function validateConfigShape(config: unknown): string[] {
         const def = v as Record<string, unknown>;
         if (def.name !== undefined && typeof def.name !== "string") errors.push(`engines.${k}.name must be a string`);
         if (typeof def.cmd !== "string" || def.cmd.length === 0) errors.push(`engines.${k}.cmd must be a non-empty string`);
+        if (def.processNames !== undefined && (!Array.isArray(def.processNames) || def.processNames.some((item) => typeof item !== "string"))) {
+          errors.push(`engines.${k}.processNames must be a string[]`);
+        }
       }
     }
   }

--- a/src/core/agent-detect.ts
+++ b/src/core/agent-detect.ts
@@ -1,28 +1,110 @@
+import { DEFAULT_ENGINES } from "../config/engine-registry";
+import type { EngineDef } from "../config/engine-def";
+import type { MawConfig } from "../config/types";
+
+const GENERIC_AGENT_PROCESS_NAMES = ["node"] as const;
+
+function firstCommandToken(cmd: string | undefined): string {
+  return (cmd ?? "").trim().split(/\s+/)[0] ?? "";
+}
+
+function commandBasename(cmd: string): string {
+  return firstCommandToken(cmd).split(/[\\/]/).filter(Boolean).at(-1) ?? "";
+}
+
+function normalizedProcessNames(names: Iterable<string>): string[] {
+  const seen = new Set<string>();
+  for (const name of names) {
+    const normalized = commandBasename(name).trim().toLowerCase();
+    if (normalized && normalized !== "default") seen.add(normalized);
+  }
+  return [...seen];
+}
+
+function processNamesFromEngine(def: EngineDef | undefined): string[] {
+  return normalizedProcessNames(def?.processNames ?? []);
+}
+
+function processNamesFromLegacyCommands(commands: Record<string, string> | undefined): string[] {
+  if (!commands) return [];
+  return normalizedProcessNames(
+    Object.entries(commands)
+      .filter(([name, command]) => name !== "default" && command !== "default")
+      .map(([, command]) => firstCommandToken(command)),
+  );
+}
+
+/** Engine process names from built-ins plus config.engines/processNames and legacy command bins. */
+export function agentProcessNames(config?: Partial<MawConfig> | null): string[] {
+  const names: string[] = [];
+  for (const def of Object.values(DEFAULT_ENGINES)) names.push(...processNamesFromEngine(def));
+  for (const def of Object.values(config?.engines ?? {})) names.push(...processNamesFromEngine(def));
+  names.push(...processNamesFromLegacyCommands(config?.commands));
+  return normalizedProcessNames(names);
+}
+
+function loadConfigLazy(): Partial<MawConfig> | null {
+  try {
+    const { loadConfig } = require("../config/load") as typeof import("../config/load");
+    return loadConfig();
+  } catch {
+    return null;
+  }
+}
+
+function loadConfiguredProcessNames(): string[] {
+  return agentProcessNames(loadConfigLazy());
+}
+
+export function matchesAgentProcessName(cmd: string | null | undefined, processNames: readonly string[] = loadConfiguredProcessNames()): boolean {
+  const raw = (cmd ?? "").trim();
+  if (!raw) return false;
+  const names = normalizedProcessNames(processNames);
+  if (names.length === 0) return false;
+  return raw
+    .split(/\s+/)
+    .map(token => commandBasename(token).toLowerCase())
+    .some(token => token && names.includes(token));
+}
+
+/** Idle prompt strings that engines render while waiting for user input. */
+export function engineIdlePromptPatterns(config?: Partial<MawConfig> | null): RegExp[] {
+  const escaped = agentProcessNames(config)
+    .map(name => name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+  if (escaped.length === 0) return [];
+  return [new RegExp(`ask (?:${escaped.join("|")})\\??\\s*$`, "i")];
+}
+
+function loadEngineIdlePromptPatterns(): RegExp[] {
+  return engineIdlePromptPatterns(loadConfigLazy());
+}
+
+export function matchesEngineIdlePrompt(output: string | null | undefined): boolean {
+  const normalized = (output ?? "").trim();
+  if (!normalized) return false;
+  return loadEngineIdlePromptPatterns().some(pattern => pattern.test(normalized));
+}
+
 /**
  * Decide whether a tmux pane's `pane_current_command` looks like an
- * agent runtime (claude / codex / thclaws / known generic launchers).
- *
- * Standalone (no maw-js imports) so consumers (broadcast, ssh-send)
- * can use it without dragging in tmux transport or config — keeping
- * test mocks for `maw-js/sdk` / `maw-js/config` independent of any
- * other module side effects (#1881 + #1906).
+ * agent runtime.
  *
  * Detection layers (any match → true):
- *  1. Hardcoded fleet engines (claude, codex, thclaws, thclaude).
- *     Substring-friendly because these names don't collide with benign
- *     commands.
- *  2. `node` REPL — agents launched via Bun/Node wrapper.
- *  3. Claude Code 2.1+ shows as a version string (e.g. `2.1.121`).
- *
- * Config-driven engine detection (looking up `commands.*` in maw config)
- * stays in ssh.ts's internal copy so it can use the cached config
- * accessor; that path is only needed for SSH-send today.
+ *  1. Config/default engine `processNames` (claude, claude-code, codex,
+ *     thclaws, thclaude, opencode, aider, plus configured engines).
+ *  2. Legacy `config.commands` executable names, exact basename match.
+ *  3. Generic node wrapper panes.
+ *  4. Claude Code 2.1+ version command strings (e.g. `2.1.121`).
  */
-export function isAgentCommand(cmd: string | null | undefined): boolean {
+export function isAgentCommandForConfig(cmd: string | null | undefined, config?: Partial<MawConfig> | null): boolean {
   const c = (cmd ?? "").trim();
   if (!c) return false;
-  if (/claude|codex|thclaws|thclaude/i.test(c)) return true;
-  if (/^node$/i.test(c)) return true;
-  if (/^\d+\.\d+\.\d+$/.test(c)) return true;
+  if (matchesAgentProcessName(c, agentProcessNames(config))) return true;
+  if (matchesAgentProcessName(c, GENERIC_AGENT_PROCESS_NAMES)) return true;
+  if (/^\d+\.\d+\.\d+$/.test(commandBasename(c))) return true;
   return false;
+}
+
+export function isAgentCommand(cmd: string | null | undefined): boolean {
+  return isAgentCommandForConfig(cmd, loadConfigLazy());
 }

--- a/src/core/transport/ssh.ts
+++ b/src/core/transport/ssh.ts
@@ -1,5 +1,6 @@
 import { loadConfig } from "../../config";
 import { tmuxCmd, Tmux } from "./tmux";
+import { isAgentCommandForConfig } from "../agent-detect";
 
 export type HostExecTransport = "local" | "ssh";
 
@@ -163,30 +164,13 @@ export function createSshTransport(overrides: Partial<SshDeps> = {}): SshTranspo
  *  WHOLE command name — not loose substrings — so non-agent node processes
  *  don't pass. */
   function isAgentCommand(cmd: string | null | undefined): boolean {
-    const c = (cmd ?? "").trim();
-    if (!c) return false;
-    // #1906 — non-claude/codex agents (thclaws, thclaude, …) need the same
-    // detection path so wake doesn't re-send the launch command into their
-    // chat input. Config-driven match below covers exotics; this hardcoded
-    // list covers the common-case fleet engines that ship without explicit
-    // config.commands entries.
-    if (/claude|codex|thclaws|thclaude/i.test(c)) return true;
-    if (/^node$/i.test(c)) return true;
-    if (/^\d+\.\d+\.\d+$/.test(c)) return true;
     try {
       const { loadConfig } = io.requireConfig();
-      const commands: Record<string, string> = loadConfig().commands || {};
-      const lc = c.toLowerCase();
-      for (const v of Object.values(commands)) {
-        const bin = v.split(/\s/)[0];
-        // Exact name match, not substring — a configured `node`-launched agent
-        // must not make every `nodemon`/`node-*` pane look like an agent.
-        if (bin && bin !== "default" && lc === bin.toLowerCase()) return true;
-      }
-    } catch {}
-    return false;
+      return isAgentCommandForConfig(cmd, loadConfig());
+    } catch {
+      return isAgentCommandForConfig(cmd, null);
+    }
   }
-
 /** Batch-check which panes are running what command. */
   async function getPaneCommands(targets: string[], host?: string): Promise<Record<string, string>> {
     const t = io.createTmux(host);

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -85,7 +85,7 @@ export type {
   PickOracleOptions,
 } from "../core/resolve";
 export { findWindow } from "../core/runtime/find-window";
-export { isAgentCommand } from "../core/agent-detect";
+export { agentProcessNames, engineIdlePromptPatterns, isAgentCommand, isAgentCommandForConfig, matchesAgentProcessName, matchesEngineIdlePrompt } from "../core/agent-detect";
 export { checkBusyGuard, extractOracleName } from "../core/agent-status-guard";
 export type { Session, Window } from "../core/runtime/find-window";
 export {

--- a/src/vendor/mpr-plugins/activity/impl.ts
+++ b/src/vendor/mpr-plugins/activity/impl.ts
@@ -1,4 +1,4 @@
-import { capture, findWindow, listSessions, loadConfig, loadFleetCore as loadFleet, loadFleetEntries, type FleetEntry } from "maw-js/sdk";
+import { capture, findWindow, listSessions, loadConfig, loadFleetCore as loadFleet, loadFleetEntries, matchesEngineIdlePrompt, type FleetEntry } from "maw-js/sdk";
 import {
   followUrlFromConfig,
   parseDurationMs,
@@ -257,7 +257,8 @@ export function isStuckSnapshot(input: string): boolean {
   const normalized = normalizeSnapshot(input);
   const lines = normalized.split("\n").map(line => line.trim()).filter(Boolean).slice(-10);
   if (lines.some(line => /^(?:[>$#]|[❯›λ])\s*(?:[▌█_])?$/.test(line))) return true;
-  return /(type a message|send a message|ask codex|ask claude|what can i help with)\??\s*$/i.test(normalized);
+  if (/(type a message|send a message|what can i help with)\??\s*$/i.test(normalized)) return true;
+  return matchesEngineIdlePrompt(normalized);
 }
 
 function confidenceFor(samples: number): ActivityConfidence {

--- a/test/is-agent-command.test.ts
+++ b/test/is-agent-command.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import { isAgentCommand } from "../src/core/transport/ssh";
+import { engineIdlePromptPatterns, isAgentCommandForConfig } from "../src/core/agent-detect";
 
 describe("isAgentCommand", () => {
   test("matches classic agent binary names", () => {
@@ -65,9 +66,29 @@ describe("isAgentCommand", () => {
     expect(isAgentCommand("  node  ")).toBe(true);
   });
 
-  test("claude / codex stay substring-matched (distinctive — no false positives)", () => {
+  test("claude / codex process names remain recognized", () => {
     expect(isAgentCommand("claude")).toBe(true);
     expect(isAgentCommand("claude-code")).toBe(true);
     expect(isAgentCommand("codex")).toBe(true);
   });
+  test("matches configured engine processNames without hardcoded regex updates", () => {
+    const config = {
+      commands: {},
+      engines: { gemini: { name: "gemini", cmd: "gemini", processNames: ["gemini-cli", "/opt/bin/gemini-agent"] } },
+    };
+
+    expect(isAgentCommandForConfig("gemini-cli", config)).toBe(true);
+    expect(isAgentCommandForConfig("/opt/bin/gemini-agent", config)).toBe(true);
+    expect(isAgentCommandForConfig("gemini-agent-helper", config)).toBe(false);
+  });
+
+  test("matches engine idle prompts from configured processNames", () => {
+    const config = {
+      commands: {},
+      engines: { gemini: { name: "gemini", cmd: "gemini", processNames: ["gemini-cli"] } },
+    };
+
+    expect(engineIdlePromptPatterns(config).some((pattern) => pattern.test("Ask gemini-cli?"))).toBe(true);
+  });
+
 });

--- a/test/isolated/plugin-activity-standalone.test.ts
+++ b/test/isolated/plugin-activity-standalone.test.ts
@@ -38,6 +38,7 @@ describe("activity plugin standalone boundary (#2190)", () => {
     const imports = [index, impl].flatMap(parseImportSpecs);
 
     expect(imports).toContain("maw-js/sdk");
+    expect(impl).toContain("matchesEngineIdlePrompt");
     expect(imports).toContain("maw-js/cli/parse-args");
     expect(imports).toContain("maw-js/plugin/types");
     expect(imports).not.toContain("maw-js/commands/shared/fleet-load");

--- a/test/isolated/tmux-impl-eighth-pass-coverage.test.ts
+++ b/test/isolated/tmux-impl-eighth-pass-coverage.test.ts
@@ -23,6 +23,11 @@ mock.module("os", () => ({
 }));
 
 mock.module("fs", () => ({
+  statSync: () => ({ isFile: () => false, isDirectory: () => false }),
+  mkdirSync: () => undefined,
+  renameSync: () => undefined,
+  rmSync: () => undefined,
+  writeFileSync: () => undefined,
   existsSync: () => false,
   readdirSync: () => [],
   readFileSync: () => { throw new Error("unexpected readFileSync"); },

--- a/test/isolated/tmux-impl-fifth-pass-coverage.test.ts
+++ b/test/isolated/tmux-impl-fifth-pass-coverage.test.ts
@@ -25,6 +25,11 @@ mock.module("os", () => ({
 }));
 
 mock.module("fs", () => ({
+  statSync: () => ({ isFile: () => false, isDirectory: () => false }),
+  mkdirSync: () => undefined,
+  renameSync: () => undefined,
+  rmSync: () => undefined,
+  writeFileSync: () => undefined,
   existsSync: () => false,
   readdirSync: () => [],
   readFileSync: () => { throw new Error("unexpected readFileSync"); },

--- a/test/isolated/tmux-impl-seventh-pass-coverage.test.ts
+++ b/test/isolated/tmux-impl-seventh-pass-coverage.test.ts
@@ -27,6 +27,11 @@ let fileContents: Map<string, string> = new Map();
 mock.module("os", () => ({ homedir: () => mockHome }));
 
 mock.module("fs", () => ({
+  statSync: (path: string) => ({ isFile: () => existingPaths.has(path) && path.endsWith(".json"), isDirectory: () => existingPaths.has(path) && !path.endsWith(".json") }),
+  mkdirSync: () => undefined,
+  renameSync: () => undefined,
+  rmSync: () => undefined,
+  writeFileSync: () => undefined,
   existsSync: (path: string) => existingPaths.has(path),
   readdirSync: (path: string) => dirEntries.get(path) ?? [],
   readFileSync: (path: string) => {

--- a/test/isolated/tmux-impl-third-pass-coverage.test.ts
+++ b/test/isolated/tmux-impl-third-pass-coverage.test.ts
@@ -23,6 +23,11 @@ mock.module("os", () => ({
 }));
 
 mock.module("fs", () => ({
+  statSync: (path: string) => ({ isFile: () => existingPaths.has(path) && path.endsWith(".json"), isDirectory: () => !path.endsWith(".json") && (existingPaths.has(path) || path.startsWith(`${teamsRoot}/`)) }),
+  mkdirSync: () => undefined,
+  renameSync: () => undefined,
+  rmSync: () => undefined,
+  writeFileSync: () => undefined,
   existsSync: (path: string) => existingPaths.has(path),
   readdirSync: (path: string) => dirEntries.get(path) ?? [],
   readFileSync: (path: string) => {

--- a/test/ssh-transport-default.test.ts
+++ b/test/ssh-transport-default.test.ts
@@ -215,7 +215,7 @@ describe("createSshTransport", () => {
     expect(h.transport.isAgentCommand("2.1.121")).toBe(true);
     expect(h.transport.isAgentCommand("  ")).toBe(false);
 
-    expect(makeHarness({ requireThrows: true }).transport.isAgentCommand("opencode")).toBe(false);
+    expect(makeHarness({ requireThrows: true }).transport.isAgentCommand("opus-only")).toBe(false);
   });
 
   test("sendKeys maps special keys, handles enter-only input, slash commands, and smart text", async () => {


### PR DESCRIPTION
## Summary
- add EngineDef.processNames and default process names for built-in engines
- route agent pane detection through shared config-driven process name helpers
- replace hardcoded liveness checks in agent-detect, ssh, context-limit, tmux safety, and activity idle prompt matching

Closes #2400

## Tests
- bun test test/engine-registry.test.ts test/config-validate.test.ts test/is-agent-command.test.ts test/ssh-transport-default.test.ts test/isolated/is-agent-command-config.test.ts test/isolated/activity-impl-coverage.test.ts test/isolated/plugin-activity-standalone.test.ts test/isolated/coverage-next-plugin-transport-core.test.ts test/isolated/context-limit.test.ts test/isolated/tmux-safety.test.ts
- bun test test/tmux-class-command-builders.test.ts
- bun test test/tmux-sendtext-submit.test.ts
- bun run build

## Note
- MAW_TEST_MODE=1 bun run test:default:safe was attempted; it failed in tmux wrapper/sendText tests that both pass individually, consistent with existing sweep-order/mock pollution rather than this patch.