### PR TITLE
🖥️ Web terminal: reflow grouped-session window ROWS to client (fix off-screen prompt)

### DIFF
--- a/src/core/transport/pty.ts
+++ b/src/core/transport/pty.ts
@@ -2,10 +2,27 @@ import { tmux, tmuxCmd } from "./tmux";
 import { loadConfig, cfgTimeout, cfgLimit } from "../../config";
 import type { MawWS } from "../types";
 
+// Pinned Oracle canvas — mirror of CLAUDE_COLS/CLAUDE_ROWS in
+// commands/shared/wake-pane-size.ts (pinSessionWide). Kept local to avoid
+// pulling the sdk graph into the transport layer; the values are stable.
+//
+// The web client may drive the shared window's ROW count (so the latest output
+// + input prompt land on-screen in a short xterm viewport) but the WIDTH must
+// stay pinned: narrow scrollback bakes permanently into pane history (the
+// 2026-04-29 "mobile-width after cron-wake" regression that pinSessionWide
+// fixes). Rows do not bake, so a temporary row shrink is safe and is restored
+// to the pinned canvas when the last viewer detaches.
+const PINNED_COLS = 200;
+const PINNED_ROWS = 50;
+
 type PtyProc = ReturnType<typeof Bun.spawn>;
 type PtySpawn = typeof Bun.spawn;
 type PtySpawnSync = typeof Bun.spawnSync;
-type PtyTmux = Pick<typeof tmux, "newGroupedSession" | "setOption" | "killSession">;
+// resizeWindow is optional: production always has it (real `tmux` is spread
+// into ptyDeps), but injected test mocks may omit it — in which case the
+// row-reflow (fitWindowRows) no-ops rather than throw.
+type PtyTmux = Pick<typeof tmux, "newGroupedSession" | "setOption" | "killSession">
+  & Partial<Pick<typeof tmux, "resizeWindow">>;
 
 export interface PtyDeps {
   tmux: PtyTmux;
@@ -89,6 +106,22 @@ function findSession(ws: MawWS): PtySession | undefined {
   }
 }
 
+// Drive the (shared) window's ROW count to the web client's viewport while
+// pinning width. tmux gives a window exactly one size shared by the grouped web
+// session AND the real Oracle session — there is no per-client window size — so
+// without this the window stays at the manual-pinned 200x50 (pinSessionWide) and
+// a short xterm shows only the top ~26 rows, hiding the latest output + the
+// input prompt. resize-window reflows the live TUI repaint to the visible rows.
+// Width is deliberately NOT taken from the client (bake guard, see PINNED_COLS).
+// This also reflows the Oracle's own view; acceptable because rows don't bake and
+// detach() restores the pinned canvas once the last viewer leaves. No-op when
+// the injected tmux mock omits the optional resizeWindow dep.
+async function fitWindowRows(target: string, rows: number): Promise<void> {
+  if (!io.tmux.resizeWindow) return;
+  const r = Math.max(1, Math.min(io.cfgLimit("ptyRows"), Math.floor(rows)));
+  await io.tmux.resizeWindow(target, PINNED_COLS, r).catch(() => { /* expected: target may be gone */ });
+}
+
 function handlePtyMessage(ws: MawWS, msg: string | Buffer) {
   if (typeof msg !== "string") {
     // Binary → keystroke to PTY stdin
@@ -155,6 +188,10 @@ async function attach(ws: MawWS, target: string, cols: number, rows: number, rep
     });
     // Hide status bar in PTY sessions so it doesn't appear in terminal output
     await io.tmux.setOption(ptySessionName, "status", "off").catch(() => { /* expected: option may not apply */ });
+    // Reflow the shared window to the client's rows so the prompt/latest output
+    // are on-screen from the first paint; the manual-pinned parent window would
+    // otherwise keep the web view at 200x50. Width stays pinned (bake guard).
+    await fitWindowRows(ptySessionName, r);
   } catch {
     attaching.delete(safe);
     ws.send(JSON.stringify({ type: "error", message: "Failed to create PTY session" }));
@@ -235,16 +272,23 @@ async function attach(ws: MawWS, target: string, cols: number, rows: number, rep
     // PTY process ended — clean up grouped session
     sessions.delete(safe);
     io.tmux.killSession(s.ptySessionName);
+    // Restore the shared window's rows in case the wrapper died while shrunk
+    // (symmetry with detach()'s grace-timer restore).
+    void io.tmux.resizeWindow?.(safe.split(":")[0], PINNED_COLS, PINNED_ROWS).catch(() => { /* expected: parent may be gone */ });
     for (const v of s.viewers) {
       try { v.send(JSON.stringify({ type: "detached", target: safe })); } catch { /* expected: viewer may have disconnected */ }
     }
   })();
 }
 
-function resize(_ws: MawWS, _cols: number, _rows: number) {
-  // No-op: with grouped sessions, resize-pane would affect the shared pane
-  // (shrinking the real terminal). The web terminal works at its initial size.
-  // TODO: proper PTY resize via node-pty or ioctl
+function resize(ws: MawWS, _cols: number, rows: number) {
+  // Honor row changes from the client (xterm FitAddon / ResizeObserver) so the
+  // prompt stays on-screen as the viewport changes (rotation, soft keyboard,
+  // window resize). Width is intentionally ignored — it stays pinned to avoid
+  // permanent narrow-scrollback bake. Fire-and-forget; the WS handler is sync.
+  const session = findSession(ws);
+  if (!session) return;
+  void fitWindowRows(session.ptySessionName, rows);
 }
 
 function detach(ws: MawWS) {
@@ -256,6 +300,12 @@ function detach(ws: MawWS) {
       session.cleanupTimer = io.setTimeout(() => {
         try { session.proc.kill(); } catch { /* expected: process may already be dead */ }
         io.tmux.killSession(session.ptySessionName);
+        // Restore the shared Oracle window to its pinned canvas — fitWindowRows
+        // may have shrunk its rows to the web viewport; with no viewer left the
+        // headless Oracle should regain its full working area (re-asserts the
+        // pinSessionWide pin; rows don't bake so this is purely cosmetic restore).
+        const parent = target.split(":")[0];
+        void io.tmux.resizeWindow?.(parent, PINNED_COLS, PINNED_ROWS).catch(() => { /* expected: parent may be gone */ });
         sessions.delete(target);
       }, io.cfgTimeout("pty"));
     }

--- a/test/isolated/pty-transport-coverage.test.ts
+++ b/test/isolated/pty-transport-coverage.test.ts
@@ -57,6 +57,7 @@ let groupedImpl: (sessionName: string, ptySessionName: string, opts: any) => Pro
 let setOptionCalls: Array<{ session: string; option: string; value: string }> = [];
 let setOptionImpl: (session: string, option: string, value: string) => Promise<void> = async () => {};
 let killSessionCalls: string[] = [];
+let resizeWindowCalls: Array<{ target: string; cols: number; rows: number }> = [];
 
 const originalSpawn = Bun.spawn;
 const originalSpawnSync = Bun.spawnSync;
@@ -95,6 +96,10 @@ mock.module(import.meta.resolve("../../src/core/transport/tmux"), () => ({
     killSession: async (session: string) => {
       if (!mockActive) return realTmux.tmux.killSession(session);
       killSessionCalls.push(session);
+    },
+    resizeWindow: async (target: string, cols: number, rows: number) => {
+      if (!mockActive) return realTmux.tmux.resizeWindow(target, cols, rows);
+      resizeWindowCalls.push({ target, cols, rows });
     },
   },
 }));
@@ -167,6 +172,7 @@ beforeEach(() => {
   setOptionCalls = [];
   setOptionImpl = async () => {};
   killSessionCalls = [];
+  resizeWindowCalls = [];
   if (originalHost === undefined) delete process.env.MAW_HOST;
   else process.env.MAW_HOST = originalHost;
   installSpawnMocks();
@@ -308,5 +314,30 @@ describe("PTY websocket bridge", () => {
     expect(failed.sent.map(decode)).toEqual([
       JSON.stringify({ type: "error", message: "Failed to create PTY session" }),
     ]);
+  });
+
+  test("reflows window rows to the client on attach + resize (width pinned 200) and restores the pinned canvas on detach", async () => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+    const ws = makeWs();
+    spawnPlans = [{ chunks: ["x"], autoEnd: false }];
+
+    handlePtyMessage(ws as any, JSON.stringify({ type: "attach", target: "demo:oracle", cols: 70, rows: 30 }));
+    await eventually(() => ws.sent.map(decode).includes("x"), "pty output");
+    const ptyName = groupedCalls[0].ptySessionName;
+
+    // attach-time: rows from client, WIDTH PINNED to 200 (bake guard, not client cols)
+    expect(resizeWindowCalls).toContainEqual({ target: ptyName, cols: 200, rows: 30 });
+
+    // resize message: honor new rows, width still pinned, ignore client cols (45)
+    handlePtyMessage(ws as any, JSON.stringify({ type: "resize", cols: 45, rows: 26 }));
+    await eventually(() => resizeWindowCalls.some(c => c.target === ptyName && c.rows === 26), "row resize honored");
+    expect(resizeWindowCalls).toContainEqual({ target: ptyName, cols: 200, rows: 26 });
+    expect(resizeWindowCalls.every(c => c.cols === 200)).toBe(true); // width never follows client
+
+    // detach: restore the shared parent window to the pinned 200x50 canvas
+    handlePtyClose(ws as any);
+    await eventually(() => resizeWindowCalls.some(c => c.target === "demo" && c.rows === 50), "pinned-canvas restore on detach");
+    expect(resizeWindowCalls).toContainEqual({ target: "demo", cols: 200, rows: 50 });
+    await finishReaders();
   });
 });


### PR DESCRIPTION
> ## 🚫 DO NOT MERGE ALONE — MERGE AS A SET WITH #2414
> This PR (ROWS-only) and **#2414 (P2/P3 orphan-PTY reaper)** must land together.
> **Merge order:** merge **#2414 first** → then click **"Update branch"** here (merge `main` in — no force-push) → then merge this. Both green + Boss-approved as one set.
> **Why:** if ROWS lands on `main` alone and anyone deploys maw-from-main, the P2/P3 reaper currently live in prod (`62cc5156`) silently drops = regression trap.

## What

Recut of the web-terminal **ROWS reflow** fix onto current `main` (`9efccce1`). Drives the shared grouped-session tmux window's **row count** to the web client's xterm viewport so the latest output + input prompt land on-screen from first paint, while keeping **width pinned at 200** (bake guard).

## Why a recut (not reopen #2055)

- The original commit `00f59a78` lived on closed **PR #2055**, which fell **~40 commits behind main**.
- `00f59a78` was *stacked on* the P2/P3 orphan-reaper (`cd9e5647`, PR #1978) which is **not in main** — a raw cherry-pick drags P2/P3 in.
- This recut takes **only the genuine ROWS delta** and adapts `PtyTmux` to add the optional `resizeWindow` dep alone (no `listSessionGroups` — that belongs to P2/P3).

## Scope

`src/core/transport/pty.ts` (+ test). Width never follows the client (narrow scrollback bakes permanently into pane history — the 2026-04-29 mobile-width regression `pinSessionWide` guards). `attach`/`resize` reflow rows; `detach` + EOF cleanup restore the pinned 200x50 canvas when the last viewer leaves. Frontend (`maw-ui` XTerminal) already sends `{type:resize,cols,rows}` — no frontend change.

## Verify

- `bun test test/isolated/pty-transport-coverage.test.ts` → **7/7 pass** (27 expect), incl. new attach/resize/detach reflow coverage
- `bunx tsc --noEmit` → **0 errors**

## ⚠️ Deploy note for reviewer (Boss)

Production maw currently runs `deploy/image-stall-on-rows-2026-06-07` (`62cc5156`) which carries **image-stub + ROWS + P2/P3 reaper**. Image stub already merged via #2368. Once this ROWS PR merges, `main` has image+ROWS — **but not P2/P3**. Deploying maw from canonical `main` afterward would drop the P2/P3 orphan-reaper currently running. **Resolved:** P2/P3 is recut as **#2414** — merge it first (see set-banner above), so `main` carries image+ROWS+P2/P3 before the deploy-from-main cutover. Running tree stays **pinned** at the fork deploy-branch until both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
