### PR TITLE
🧹 Orphan-PTY reaper P2+P3 — recut onto main (SET w/ #2409, merge first, do not merge alone)

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -24,6 +24,8 @@ export interface MawIntervals {
   preview?: number;
   peerFetch?: number;
   crashCheck?: number;
+  /** Periodic orphan-PTY sweep cadence (ms). See pty.ts sweepOrphanPtySessions (#P2). */
+  ptySweep?: number;
 }
 
 export interface MawTimeouts {
@@ -186,7 +188,7 @@ export interface MawConfig {
 
 /** Typed defaults for intervals, timeouts, limits (#172) */
 export const D = {
-  intervals: { capture: 50, sessions: 5000, status: 3000, teams: 3000, preview: 2000, peerFetch: 10000, crashCheck: 30000 } as const,
+  intervals: { capture: 50, sessions: 5000, status: 3000, teams: 3000, preview: 2000, peerFetch: 10000, crashCheck: 30000, ptySweep: 300000 } as const,
   timeouts: { http: 5000, health: 3000, ping: 5000, pty: 5000, workspace: 5000, shellInit: 3000, wakeRetry: 500, wakeVerify: 3000 } as const,
   limits: { feedMax: 500, feedDefault: 50, feedHistory: 50, logsMax: 500, logsDefault: 50, logsTruncate: 500, messageTruncate: 100, ptyCols: 500, ptyRows: 200, maxConcurrentAgents: 0 } as const,
   hmacWindowSeconds: 300,

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { MawEngine } from "../engine";
 import type { WSData } from "./types";
-import { loadConfig } from "../config";
+import { loadConfig, cfgInterval } from "../config";
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { serveStatic } from "hono/bun";
@@ -12,7 +12,7 @@ import { setupTriggerListener } from "./runtime/trigger-listener";
 import { createTransportRouter } from "../transports";
 import { listSessions } from "./transport/ssh";
 import { Tmux } from "./transport/tmux";
-import { handlePtyMessage, handlePtyClose } from "./transport/pty";
+import { handlePtyMessage, handlePtyClose, sweepOrphanPtySessions } from "./transport/pty";
 import { setBunServer } from "../lib/elysia-auth";
 import { runServeLifecycleHooks } from "../plugin/lifecycle";
 import {
@@ -303,6 +303,21 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
   }
   setBunServer(server);
   startEnginePluginHealthPolling();
+
+  // #P2 — periodic orphan-PTY sweep. The boot reaper above (#300) clears the
+  // server-restart class once at startup; this catches in-memory/tmux drift on
+  // a long-lived process. unref() so it never holds the event loop open.
+  const ptySweepTimer = setInterval(() => {
+    sweepOrphanPtySessions()
+      .then(({ killed, checked }) => {
+        if (killed.length > 0) {
+          console.log(`[pty-sweep] killed ${killed.length} orphan(s): ${killed.join(", ")} (checked ${checked})`);
+        }
+      })
+      .catch((err) => console.error("[pty-sweep] failed:", err));
+  }, cfgInterval("ptySweep"));
+  (ptySweepTimer as { unref?: () => void }).unref?.();
+
   const bindNote = reason ? ` (${reason})` : "";
   console.log(`maw ${VERSION} serve → ${HTTP_URL} (${WS_URL}) [${hostname}]${bindNote}`);
 

--- a/src/core/transport/pty.ts
+++ b/src/core/transport/pty.ts
@@ -18,11 +18,12 @@ const PINNED_ROWS = 50;
 type PtyProc = ReturnType<typeof Bun.spawn>;
 type PtySpawn = typeof Bun.spawn;
 type PtySpawnSync = typeof Bun.spawnSync;
-// resizeWindow is optional: production always has it (real `tmux` is spread
-// into ptyDeps), but injected test mocks may omit it — in which case the
-// row-reflow (fitWindowRows) no-ops rather than throw.
+// resizeWindow and listSessionGroups are optional: production always has them
+// (real `tmux` is spread into ptyDeps), but injected test mocks may omit either.
+// Missing resizeWindow makes ROWS reflow no-op; missing listSessionGroups makes
+// the orphan sweep (#P2) and attach-time grouped-orphan kill (#P3) no-op.
 type PtyTmux = Pick<typeof tmux, "newGroupedSession" | "setOption" | "killSession">
-  & Partial<Pick<typeof tmux, "resizeWindow">>;
+  & Partial<Pick<typeof tmux, "resizeWindow" | "listSessionGroups">>;
 
 export interface PtyDeps {
   tmux: PtyTmux;
@@ -68,6 +69,8 @@ interface PtySession {
 interface PtyHandlers {
   handlePtyMessage: (ws: MawWS, msg: string | Buffer) => void;
   handlePtyClose: (ws: MawWS) => void;
+  /** #P2 — kill maw-pty-* tmux sessions no longer tracked in-memory. */
+  sweepOrphanPtySessions: () => Promise<{ killed: string[]; checked: number }>;
 }
 
 function replayLinesFromControl(value: unknown): number {
@@ -93,6 +96,11 @@ export function createPtyHandlers(overrides: Partial<PtyDeps> = {}): PtyHandlers
   let nextPtyId = 0;
   const sessions = new Map<string, PtySession>();
   const attaching = new Set<string>();
+  // PTY session names generated but not yet committed to `sessions` (the
+  // newGroupedSession→setOption→spawn window). The sweep/attach-kill must treat
+  // these as live so a sweep landing mid-create can't reap a session we're
+  // about to track and disconnect the Oracle that just attached.
+  const creatingPtyNames = new Set<string>();
 
 function isLocalHost(): boolean {
   // #713: with bind/host split, config.host is never a bind address (0.0.0.0 etc.)
@@ -120,6 +128,53 @@ async function fitWindowRows(target: string, rows: number): Promise<void> {
   if (!io.tmux.resizeWindow) return;
   const r = Math.max(1, Math.min(io.cfgLimit("ptyRows"), Math.floor(rows)));
   await io.tmux.resizeWindow(target, PINNED_COLS, r).catch(() => { /* expected: target may be gone */ });
+}
+
+// True when a maw-pty-* tmux session is one we own — either committed to
+// `sessions` or mid-create. Neither must ever be reaped.
+function isTrackedPtyName(ptyName: string): boolean {
+  if (creatingPtyNames.has(ptyName)) return true;
+  for (const s of sessions.values()) {
+    if (s.ptySessionName === ptyName) return true;
+  }
+  return false;
+}
+
+// #P2 — periodic orphan sweep. Kills maw-pty-* tmux sessions that exist
+// server-side but are no longer tracked in-memory (in-memory/tmux drift WITHIN
+// a single server lifecycle — e.g. a kill that raced cleanup, or a future
+// dead-client miss). The boot-time reaper (server.ts #300) already clears the
+// server-RESTART class on startup; this handles runtime drift on a long-lived
+// process. Tracked/attached sessions are always skipped, so a live Oracle
+// terminal is never touched.
+async function sweepOrphanPtySessions(): Promise<{ killed: string[]; checked: number }> {
+  if (!io.tmux.listSessionGroups) return { killed: [], checked: 0 };
+  const all = await io.tmux.listSessionGroups();
+  const killed: string[] = [];
+  for (const { name } of all) {
+    if (!name.startsWith("maw-pty-")) continue;
+    if (isTrackedPtyName(name)) continue;
+    await io.tmux.killSession(name); // best-effort; killSession swallows errors
+    killed.push(name);
+  }
+  return { killed, checked: all.length };
+}
+
+// #P3 — at attach time, remove any pre-existing maw-pty-* sessions grouped to
+// the SAME parent that we don't track. Grouped sessions share the parent's
+// window size, so a stale grouped client (e.g. a frozen 45x30 tab) shrinks the
+// real window — the "size-hijack" vector. Group name == parent session name
+// (verified on live tmux). Untracked-only + group-scoped → never kills a live
+// terminal on this or any other Oracle.
+async function killStaleGroupedSessions(parent: string): Promise<void> {
+  if (!io.tmux.listSessionGroups) return;
+  const all = await io.tmux.listSessionGroups();
+  for (const { name, group } of all) {
+    if (!name.startsWith("maw-pty-")) continue;
+    if (group !== parent) continue;
+    if (isTrackedPtyName(name)) continue;
+    await io.tmux.killSession(name);
+  }
 }
 
 function handlePtyMessage(ws: MawWS, msg: string | Buffer) {
@@ -182,6 +237,16 @@ async function attach(ws: MawWS, target: string, cols: number, rows: number, rep
   // Create a grouped session — shares windows but has independent client sizing.
   // This prevents the web terminal from shrinking the real terminal.
   const ptySessionName = `maw-pty-${io.now()}-${++nextPtyId}`;
+  creatingPtyNames.add(ptySessionName);
+
+  // #P3 — clear any stale grouped orphan on this parent so a leftover frozen
+  // client can't shrink the shared window. Fire-and-forget: it runs alongside
+  // session creation (killSession is idempotent and tmux resizes the window
+  // after a client leaves regardless of order), and the new ptySessionName is
+  // already in creatingPtyNames so the kill can never reap the session we are
+  // about to track. Keeps attach latency off the tmux-list round-trip.
+  void killStaleGroupedSessions(sessionName).catch(() => { /* expected: tmux listing may transiently fail */ });
+
   try {
     await io.tmux.newGroupedSession(sessionName, ptySessionName, {
       cols: c, rows: r, window: windowPart || undefined,
@@ -193,6 +258,7 @@ async function attach(ws: MawWS, target: string, cols: number, rows: number, rep
     // otherwise keep the web view at 200x50. Width stays pinned (bake guard).
     await fitWindowRows(ptySessionName, r);
   } catch {
+    creatingPtyNames.delete(ptySessionName);
     attaching.delete(safe);
     ws.send(JSON.stringify({ type: "error", message: "Failed to create PTY session" }));
     return;
@@ -246,6 +312,7 @@ async function attach(ws: MawWS, target: string, cols: number, rows: number, rep
 
   session = { proc, target: safe, ptySessionName, viewers: new Set([ws]), cleanupTimer: null };
   sessions.set(safe, session);
+  creatingPtyNames.delete(ptySessionName); // now tracked via `sessions`
   attaching.delete(safe);
 
   // Stream PTY stdout → all viewers as binary frames
@@ -312,10 +379,11 @@ function detach(ws: MawWS) {
   }
 }
 
-  return { handlePtyMessage, handlePtyClose };
+  return { handlePtyMessage, handlePtyClose, sweepOrphanPtySessions };
 }
 
 const defaultPtyHandlers = createPtyHandlers();
 
 export const handlePtyMessage = defaultPtyHandlers.handlePtyMessage;
 export const handlePtyClose = defaultPtyHandlers.handlePtyClose;
+export const sweepOrphanPtySessions = defaultPtyHandlers.sweepOrphanPtySessions;

--- a/src/core/transport/tmux-class.ts
+++ b/src/core/transport/tmux-class.ts
@@ -96,6 +96,27 @@ export class Tmux {
     }
   }
 
+  /**
+   * List every session with its group name in a single tmux call.
+   * `#{session_group}` is empty for ungrouped sessions and equals the parent
+   * session name for grouped ones (verified on live tmux: a maw-pty-* grouped
+   * to `01-labubu` reports group `01-labubu`). Used by the orphan-PTY reaper
+   * (#P2 sweep) and attach-time grouped-orphan kill (#P3).
+   */
+  async listSessionGroups(): Promise<Array<{ name: string; group: string }>> {
+    try {
+      const raw = await this.run("list-sessions", "-F", "#{session_name}|||#{session_group}");
+      return raw.split("\n").filter(Boolean).map(line => {
+        const [name, group = ""] = line.split("|||");
+        return { name, group };
+      });
+    } catch (error) {
+      if (isTmuxBinaryMissingError(error)) throw error;
+      if (isTmuxNoServerError(error)) return [];
+      return [];
+    }
+  }
+
   async hasSession(name: string): Promise<boolean> {
     try {
       await this.run("has-session", "-t", name);

--- a/test/isolated/core-server-coverage.test.ts
+++ b/test/isolated/core-server-coverage.test.ts
@@ -100,6 +100,7 @@ mock.module(import.meta.resolve("../../src/core/transport/tmux"), () => ({
 mock.module(import.meta.resolve("../../src/core/transport/pty"), () => ({
   handlePtyMessage: (...args: unknown[]) => { ptyMessages.push(args); },
   handlePtyClose: (ws: unknown) => { ptyCloses.push(ws); },
+  sweepOrphanPtySessions: async () => ({ killed: [], checked: 0 }),
 }));
 mock.module(import.meta.resolve("../../src/lib/elysia-auth"), () => ({ setBunServer: (server: unknown) => setServerCalls.push(server) }));
 mock.module(import.meta.resolve("../../src/plugin/lifecycle"), () => ({

--- a/test/isolated/core-server-more-coverage-2.test.ts
+++ b/test/isolated/core-server-more-coverage-2.test.ts
@@ -74,6 +74,7 @@ mock.module(import.meta.resolve("../../src/core/transport/tmux"), () => ({
 mock.module(import.meta.resolve("../../src/core/transport/pty"), () => ({
   handlePtyMessage: () => {},
   handlePtyClose: () => {},
+  sweepOrphanPtySessions: async () => ({ killed: [], checked: 0 }),
 }));
 mock.module(import.meta.resolve("../../src/lib/elysia-auth"), () => ({ setBunServer: () => {} }));
 mock.module(import.meta.resolve("../../src/plugin/lifecycle"), () => ({

--- a/test/isolated/coverage-core-shared-server.test.ts
+++ b/test/isolated/coverage-core-shared-server.test.ts
@@ -48,6 +48,7 @@ mock.module(import.meta.resolve("../../src/core/transport/tmux"), () => ({
 mock.module(import.meta.resolve("../../src/core/transport/pty"), () => ({
   handlePtyMessage: (...args: unknown[]) => { ptyMessages.push(args); },
   handlePtyClose: (...args: unknown[]) => { ptyCloses.push(args); },
+  sweepOrphanPtySessions: async () => ({ killed: [], checked: 0 }),
 }));
 mock.module(import.meta.resolve("../../src/lib/elysia-auth"), () => ({ setBunServer: () => {} }));
 mock.module(import.meta.resolve("../../src/plugin/lifecycle"), () => ({

--- a/test/isolated/coverage-next-core-instance-server.test.ts
+++ b/test/isolated/coverage-next-core-instance-server.test.ts
@@ -50,7 +50,7 @@ mock.module(import.meta.resolve("../../src/core/transport/tmux"), () => ({
     async run() { return ""; }
   },
 }));
-mock.module(import.meta.resolve("../../src/core/transport/pty"), () => ({ handlePtyMessage: () => {}, handlePtyClose: () => {} }));
+mock.module(import.meta.resolve("../../src/core/transport/pty"), () => ({ handlePtyMessage: () => {}, handlePtyClose: () => {}, sweepOrphanPtySessions: async () => ({ killed: [], checked: 0 }) }));
 mock.module(import.meta.resolve("../../src/lib/elysia-auth"), () => ({ setBunServer: () => {} }));
 mock.module(import.meta.resolve("../../src/plugin/lifecycle"), () => ({
   runServeLifecycleHooks: async () => {},

--- a/test/pty-transport-default.test.ts
+++ b/test/pty-transport-default.test.ts
@@ -55,6 +55,7 @@ function makeHarness(options: {
   spawnSync?: (args: string[]) => { stdout?: Uint8Array };
   groupedImpl?: (sessionName: string, ptySessionName: string, opts: unknown) => Promise<void>;
   setOptionImpl?: (session: string, option: string, value: string) => Promise<void>;
+  listSessionGroupsImpl?: () => Promise<Array<{ name: string; group: string }>>;
 } = {}) {
   const spawnPlans = [...(options.spawnPlans ?? [])];
   const readers: ControlledReader[] = [];
@@ -107,6 +108,9 @@ function makeHarness(options: {
         await options.setOptionImpl?.(session, option, value);
       },
       killSession: async (session: string) => { killSessionCalls.push(session); },
+      // Only present when the test opts in — mirrors production where the real
+      // tmux always has it but injected mocks may omit it (sweep/#P3 no-op).
+      ...(options.listSessionGroupsImpl ? { listSessionGroups: options.listSessionGroupsImpl } : {}),
     },
     setTimeout: ((fn: () => void, _ms?: number) => {
       const timer = { active: true, fn };
@@ -370,5 +374,53 @@ describe("createPtyHandlers", () => {
     await eventually(() => bounded.spawnCalls.length === 1, "bounded replay spawn");
 
     expect(bounded.spawnSyncCalls[0]).toEqual(["tmux", "capture-pane", "-t", "follow:1", "-p", "-e", "-J", "-S", "-12"]);
+  });
+
+  test("#P2 sweep kills untracked maw-pty-* sessions, sparing tracked and non-maw sessions", async () => {
+    const groups = [
+      { name: "01-labubu", group: "01-labubu" },        // parent — not maw-pty
+      { name: "maw-pty-orphan-1", group: "01-labubu" },  // orphan
+      { name: "maw-pty-orphan-2", group: "" },           // ungrouped orphan
+      { name: "some-view", group: "" },                  // not maw-pty
+    ];
+    const h = makeHarness({ listSessionGroupsImpl: async () => groups, spawnPlans: [{ chunks: ["x"], autoEnd: false }] });
+
+    // Attach so one maw-pty session becomes tracked in-memory.
+    const ws = makeWs();
+    h.handlePtyMessage(ws as any, JSON.stringify({ type: "attach", target: "tracked:0" }));
+    await eventually(() => h.groupedCalls.length === 1, "tracked attach");
+    const trackedName = h.groupedCalls[0].ptySessionName;
+    groups.push({ name: trackedName, group: "tracked" });
+
+    const result = await h.sweepOrphanPtySessions();
+    expect(result.killed.sort()).toEqual(["maw-pty-orphan-1", "maw-pty-orphan-2"]);
+    expect(result.checked).toBe(5);
+    expect(result.killed).not.toContain(trackedName);
+    expect(h.killSessionCalls).toContain("maw-pty-orphan-1");
+    expect(h.killSessionCalls).not.toContain(trackedName);
+    await h.finishReaders();
+  });
+
+  test("#P2 sweep no-ops when tmux lacks listSessionGroups (injected mock)", async () => {
+    const h = makeHarness(); // no listSessionGroupsImpl → method absent
+    const result = await h.sweepOrphanPtySessions();
+    expect(result).toEqual({ killed: [], checked: 0 });
+    expect(h.killSessionCalls).toEqual([]);
+  });
+
+  test("#P3 attach kills a pre-existing untracked grouped orphan on the same parent only", async () => {
+    const groups = [
+      { name: "01-labubu", group: "01-labubu" },
+      { name: "maw-pty-stale", group: "01-labubu" },  // same parent, untracked → kill
+      { name: "maw-pty-other", group: "02-neo" },      // different parent → spare
+    ];
+    const h = makeHarness({ listSessionGroupsImpl: async () => groups, spawnPlans: [{ autoEnd: true }] });
+    const ws = makeWs();
+
+    h.handlePtyMessage(ws as any, JSON.stringify({ type: "attach", target: "01-labubu:0" }));
+    // P3 is fire-and-forget alongside session creation — poll for the kill.
+    await eventually(() => h.killSessionCalls.includes("maw-pty-stale"), "P3 stale-orphan kill");
+    expect(h.killSessionCalls).not.toContain("maw-pty-other");
+    await h.finishReaders();
   });
 });


### PR DESCRIPTION
## 🧹 Orphan-PTY reaper P2+P3 — recut onto `main`

Recut of `cd9e5647` (originally on the `alpha` line, ex-PR #1978 CLOSED) onto current `main`. Brings the periodic + attach-time orphan-PTY cleanup that is **running in production today** into `main`, so `deploy-from-main` no longer regresses it.

### What it does
- **P2 — periodic orphan sweep** (`pty.ts` + `server.ts`): `setInterval(cfgInterval("ptySweep"), default 300_000ms)` kills any `maw-pty-*` tmux session no longer tracked in-memory. Tracked/attached sessions always skipped → a live Oracle terminal is never touched. Timer `.unref()`'d.
- **P3 — attach-time grouped-orphan kill** (`pty.ts` `attach()`): before a new client renders, fire-and-forget removal of pre-existing untracked `maw-pty-*` sessions grouped to the SAME parent (the "size-hijack" vector — a stale grouped client shrinks the real window).
- **Supporting**: `Tmux.listSessionGroups()` (single `list-sessions` call serving P2+P3); `PtyTmux` widens it OPTIONAL so test mocks that omit it no-op rather than throw; `creatingPtyNames` guard prevents a sweep mid-create from reaping a session about to be tracked; `intervals.ptySweep` default + `MawIntervals` type.

### Recut fidelity
- `git cherry-pick -x cd9e5647` onto `main` (`9efccce1`, which already carries the #2368 image fix).
- **One** conflict, in `src/config/types.ts`: resolved minimally — kept `main`'s `D.intervals` line + appended **only** `ptySweep: 300000`. The `peerRetryBackoff: 300` that appears on the alpha-side of the conflict is **alpha-line drift, not part of this commit** (verified against `cd9e5647`'s own diff) and was deliberately **excluded** — no unrelated scope imported.
- Resulting change: **9 files, +171/-6 — byte-identical surface to the original `cd9e5647`.**

### Verification (bun-native repo — no `tsc`/`tsconfig`; gate is `bun test`)
| Check | Result |
|---|---|
| `test/pty-transport-default.test.ts` | **12/12 pass** (incl. the 3 new reaper tests: sweep-kills-untracked-only / sweep-no-ops-without-listSessionGroups / P3-kills-same-parent-orphan-only) |
| `bun run test:default:safe` | **green** |
| `bun run test:isolated` | 545/546 — the single fail (`coverage-100b-vendor-c-core`, a `tokenScan` test) **fails identically on clean `main` (9efccce1)**, i.e. pre-existing baseline, unrelated to this change. |

---

## ⚠️ MERGE AS A SET — DO NOT MERGE EITHER PR ALONE

This PR is the **base** of a 2-PR set re-landing the web-terminal-stability line into `main` (target: `main == production` so `deploy-from-main` is safe):

1. **THIS PR (reaper)** — merge **first**.
2. **#2409 (ROWS reflow)** — stacks on the reaper; merge **after**, or both together.

**Why the gate**: `main` currently lacks both reaper and ROWS. If #2409 (ROWS) merged alone, a later `deploy-from-main` would drop the P2/P3 orphan cleanup running in prod today = regression trap. The running tree is **pinned** to the fork deploy branch until both land.

Requires **Boss approval** before any merge (Soul-Brews-Studio golden rule). 🤖 Echo 📚 (AI)
