### PR TITLE
Fix maw serve hub fixture warning noise

### DIFF
--- a/src/transports/hub-config.ts
+++ b/src/transports/hub-config.ts
@@ -31,6 +31,16 @@ function workspaceDirsForRead(): string[] {
   return primary === legacy ? [primary] : [primary, legacy];
 }
 
+function shouldWarnOnInvalidWorkspaceConfig(): boolean {
+  return process.env.MAW_HUB_CONFIG_WARNINGS === "1" || process.env.MAW_VERBOSE === "1";
+}
+
+function warnInvalidWorkspaceConfig(message: string, error?: unknown): void {
+  if (!shouldWarnOnInvalidWorkspaceConfig()) return;
+  if (error === undefined) console.warn(message);
+  else console.warn(message, error);
+}
+
 /** Load all workspace configs from the data dir, with legacy config fallback. */
 export function loadWorkspaceConfigs(): WorkspaceConfig[] {
   const primary = workspaceDir();
@@ -52,10 +62,10 @@ export function loadWorkspaceConfigs(): WorkspaceConfig[] {
         if (validation.ok) {
           byId.set((raw as WorkspaceConfig).id, raw as WorkspaceConfig);
         } else {
-          console.warn(`[hub] invalid workspace config: ${file} (${validation.reason})`);
+          warnInvalidWorkspaceConfig(`[hub] invalid workspace config: ${file} (${validation.reason})`);
         }
       } catch (err) {
-        console.warn(`[hub] failed to parse workspace config: ${file}`, err);
+        warnInvalidWorkspaceConfig(`[hub] failed to parse workspace config: ${file}`, err);
       }
     }
   }

--- a/test/isolated/coverage-100b-config-transport-hooks-hub.test.ts
+++ b/test/isolated/coverage-100b-config-transport-hooks-hub.test.ts
@@ -187,8 +187,15 @@ describe("coverage 100b hub config and connection", () => {
       writeFileSync(join(workspacesDir, "skip.txt"), "not json");
 
       const warnings: string[] = [];
+      const originalFlag = process.env.MAW_HUB_CONFIG_WARNINGS;
+      process.env.MAW_HUB_CONFIG_WARNINGS = "1";
       console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(" "));
-      expect(first.loadWorkspaceConfigs()).toEqual([{ id: "good", hubUrl: "wss://hub.example.test", token: "tok", sharedAgents: ["neo"] }]);
+      try {
+        expect(first.loadWorkspaceConfigs()).toEqual([{ id: "good", hubUrl: "wss://hub.example.test", token: "tok", sharedAgents: ["neo"] }]);
+      } finally {
+        if (originalFlag === undefined) delete process.env.MAW_HUB_CONFIG_WARNINGS;
+        else process.env.MAW_HUB_CONFIG_WARNINGS = originalFlag;
+      }
       expect(warnings.join("\n")).toContain("[hub] failed to parse workspace config: bad.json");
     } finally {
       // Keep the mocked CONFIG_FILE root alive for later config/load tests in this file.

--- a/test/isolated/coverage-100c-executable-gaps.test.ts
+++ b/test/isolated/coverage-100c-executable-gaps.test.ts
@@ -96,8 +96,7 @@ describe("coverage 100c executable gap tests", () => {
     console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(" "));
 
     expect(hub.loadWorkspaceConfigs()).toEqual([{ id: "alpha", hubUrl: "wss://hub.example.test", token: "secret", sharedAgents: ["mawjs"] }]);
-    expect(warnings.join("\n")).toContain("invalid workspace config: invalid.json");
-    expect(warnings.join("\n")).toContain("failed to parse workspace config: broken.json");
+    expect(warnings).toEqual([]);
   });
 
   test("plugin install extraction rejects traversal, oversized bodies, and missing source entries", async () => {

--- a/test/isolated/hub-config.test.ts
+++ b/test/isolated/hub-config.test.ts
@@ -25,16 +25,38 @@ describe("hub workspace config validation (#1521)", () => {
     expect(validateWorkspaceConfig({ id: "ws", hubUrl: "wss://hub", token: "t", sharedAgents: ["agent"] })).toEqual({ ok: true });
   });
 
-  test("warning includes the invalid filename and reason", () => {
+  test("skips invalid workspace configs silently by default", () => {
     mkdirSync(WORKSPACES_DIR, { recursive: true });
     writeFileSync(join(WORKSPACES_DIR, "bad.json"), JSON.stringify({ id: "ws-bad", hubUrl: "http://hub", token: "t", sharedAgents: [] }));
     const warnings: string[] = [];
     const originalWarn = console.warn;
+    const originalFlag = process.env.MAW_HUB_CONFIG_WARNINGS;
+    delete process.env.MAW_HUB_CONFIG_WARNINGS;
     console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(" "));
     try {
       expect(loadWorkspaceConfigs()).toEqual([]);
     } finally {
       console.warn = originalWarn;
+      if (originalFlag === undefined) delete process.env.MAW_HUB_CONFIG_WARNINGS;
+      else process.env.MAW_HUB_CONFIG_WARNINGS = originalFlag;
+    }
+    expect(warnings).toEqual([]);
+  });
+
+  test("opt-in diagnostics include the invalid filename and reason", () => {
+    mkdirSync(WORKSPACES_DIR, { recursive: true });
+    writeFileSync(join(WORKSPACES_DIR, "bad.json"), JSON.stringify({ id: "ws-bad", hubUrl: "http://hub", token: "t", sharedAgents: [] }));
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    const originalFlag = process.env.MAW_HUB_CONFIG_WARNINGS;
+    process.env.MAW_HUB_CONFIG_WARNINGS = "1";
+    console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(" "));
+    try {
+      expect(loadWorkspaceConfigs()).toEqual([]);
+    } finally {
+      console.warn = originalWarn;
+      if (originalFlag === undefined) delete process.env.MAW_HUB_CONFIG_WARNINGS;
+      else process.env.MAW_HUB_CONFIG_WARNINGS = originalFlag;
     }
     expect(warnings.join("\n")).toContain("[hub] invalid workspace config: bad.json (hubUrl must be ws:|wss: (got http:))");
   });


### PR DESCRIPTION
## Summary
- suppress invalid/malformed hub workspace config warnings by default so fixture JSON does not pollute `maw serve` startup
- keep opt-in diagnostics via `MAW_HUB_CONFIG_WARNINGS=1` or `MAW_VERBOSE=1`
- update hub config tests for quiet default plus diagnostic opt-in

Fixes #2410

## Tested
- `bun test test/isolated/hub-config.test.ts --path-ignore-patterns '**/agents/**'`\n- `bun test test/isolated/coverage-100c-executable-gaps.test.ts test/isolated/coverage-100b-config-transport-hooks-hub.test.ts --path-ignore-patterns '**/agents/**'`\n- `bun test test/transports-index-default.test.ts test/hub-transport.test.ts --path-ignore-patterns '**/agents/**'`\n- `bun run build`