### PR TITLE
Fix cmd-update coverage for release-binary updates

### DIFF
--- a/src/cli/cmd-update.ts
+++ b/src/cli/cmd-update.ts
@@ -287,9 +287,11 @@ export async function runUpdate(args: string[]): Promise<void> {
           const archived = `${STASH}.crash.${Math.floor(Date.now() / 1000)}`;
           try {
             renameSync(STASH, archived);
+            console.warn(`\x1b[33m↺\x1b[0m rotated stale ${STASH} → ${archived} (prior crash leftover; in-flight stash will replace it)`);
           } catch (e: any) {
             console.error(`\x1b[31merror\x1b[0m: ${STASH} already exists and could not be rotated: ${e.message || e}`);
-            console.error(`  resolve manually:  mv ${STASH} ${BIN}`);
+            console.error(`  resolve manually:  mv ${STASH} ${BIN}     \x1b[90m# restore last-known-good\x1b[0m`);
+            console.error(`  or discard it:     rm ${STASH}             \x1b[90m# only if you're sure\x1b[0m`);
             console.error(`  then re-run:       maw update ${ref}`);
             process.exit(1);
           }
@@ -339,20 +341,31 @@ export async function runUpdate(args: string[]): Promise<void> {
           try {
             rmSync(join(NM, "maw-js"), { recursive: true, force: true });
             renameSync(PKG_STASH, join(NM, "maw-js"));
-          } catch {}
+          } catch (e: any) {
+            console.error(`\x1b[31merror\x1b[0m: failed to restore maw-js package from stash: ${e.message || e}`);
+          }
+        };
+
+        const restoreBinStash = () => {
+          if (!stashed || !existsSync(STASH)) return;
+          try {
+            renameSync(STASH, BIN);
+            console.warn(`\x1b[33m↺\x1b[0m restored previous maw binary from stash`);
+          } catch (e: any) {
+            console.error(`\x1b[31merror\x1b[0m: failed to restore stash: ${e.message || e}`);
+          }
         };
 
         if (installCode !== 0) {
           restorePkgStash();
-          if (stashed && existsSync(STASH)) {
-            try { renameSync(STASH, BIN); } catch {}
-          }
+          restoreBinStash();
         } else {
           const verify = Bun.spawn(["maw", "--version"], { stdout: "pipe", stderr: "pipe" });
           const freshOk = (await verify.exited) === 0;
           if (!freshOk) {
+            console.error(`\x1b[31merror\x1b[0m: fresh install did not run — rolling back to previous maw`);
             restorePkgStash();
-            if (stashed && existsSync(STASH)) { try { renameSync(STASH, BIN); } catch {} }
+            restoreBinStash();
             installCode = 1;
           } else {
             if (stashed && existsSync(STASH)) { try { unlinkSync(STASH); } catch {} }
@@ -366,6 +379,7 @@ export async function runUpdate(args: string[]): Promise<void> {
         restoreResolverState();
         console.error(`\x1b[31merror\x1b[0m: install failed — previous maw restored from stash (if available)`);
         console.error(`\n  Manual recovery:\n    curl -fsSL https://github.com/${repository}/releases/download/${ref}/maw -o ~/.bun/bin/maw && chmod +x ~/.bun/bin/maw`);
+        console.error(`    if bun still loops, edit ~/.bun/install/global/package.json to drop maw-js/maw and remove stale lockfiles`);
         process.exit(installCode);
       }
     }

--- a/test/cmd-update-runtime-coverage.test.ts
+++ b/test/cmd-update-runtime-coverage.test.ts
@@ -300,21 +300,20 @@ describe("cmd-update runtime coverage", () => {
     expect(res.stdout).toContain("✅");
   });
 
-  test("restores binary and package stashes when release binary, install, and retry all fail", async () => {
+  test("restores binary and package stashes when branch install and retry fail", async () => {
     prepareInstallHome();
     writeFileSync(mawBin, "old working maw");
-    spawnExitQueue = [1, 1, 1];
+    spawnExitQueue = [1, 1];
 
-    const res = await captureRun(["update", "v26.5.16-alpha.1053", "--yes"], { testMode: null });
+    const res = await captureRun(["update", "main", "--yes"], { testMode: null });
 
     expect(res.code).toBe(1);
     expect(spawnCalls).toEqual([
-      ["curl", "-fsSL", "-o", mawBin, "https://github.com/Soul-Brews-Studio/maw-js/releases/download/v26.5.16-alpha.1053/maw"],
-      ["bun", "add", "-g", "github:Soul-Brews-Studio/maw-js#v26.5.16-alpha.1053"],
-      ["bun", "add", "-g", "github:Soul-Brews-Studio/maw-js#v26.5.16-alpha.1053"],
+      ["bun", "add", "-g", "github:Soul-Brews-Studio/maw-js#main"],
+      ["bun", "add", "-g", "github:Soul-Brews-Studio/maw-js#main"],
     ]);
     expect(res.stderr).toContain("first install attempt failed");
-    expect(res.stderr).toContain("release binary not available — falling back to bun add");
+    expect(res.stderr).toContain("restored previous maw binary from stash");
     expect(res.stderr).toContain("previous maw restored from stash");
     expect(readFileSync(mawBin, "utf-8")).toBe("old working maw");
     expect(existsSync(`${mawBin}.prev`)).toBe(false);

--- a/test/isolated/cmd-update-order.test.ts
+++ b/test/isolated/cmd-update-order.test.ts
@@ -8,9 +8,9 @@
  *
  * This test reads the source file and asserts two invariants:
  *   1. The REF_RE allowlist check appears BEFORE any `bun remove` call
- *   2. `bun add` appears BEFORE `bun remove` in the atomic happy-path
- *      (the remove-as-fallback is only on failure, and still only after
- *      at least one install attempt)
+ *   2. Branch-ref `bun add` fallback appears BEFORE `bun remove`
+ *      (the remove-as-fallback is only on branch install failure, and still
+ *      only after at least one install attempt)
  *
  * If someone refactors this file without preserving the invariants, this
  * test catches it — not by behavior (hard to test spawn ordering in unit
@@ -40,7 +40,7 @@ describe("cmd-update source-order invariants", () => {
     expect(refReIdx).toBeLessThan(removeCallIdx);
   });
 
-  it("`Bun.spawn(['bun', 'add', ...])` appears before the `bun remove` execSync (atomic: try add first)", () => {
+  it("branch fallback `Bun.spawn(['bun', 'add', ...])` appears before the `bun remove` execSync", () => {
     const addSpawnMatch = src.match(ADD_SPAWN_RE);
     const removeCallMatch = src.match(REMOVE_CALL_RE);
     expect(addSpawnMatch).not.toBeNull();

--- a/test/isolated/cmd-update-sixth-pass-coverage.test.ts
+++ b/test/isolated/cmd-update-sixth-pass-coverage.test.ts
@@ -223,16 +223,15 @@ describe("cmd-update sixth-pass retry cleanup coverage", () => {
   test("retry cleanup removes maw-js cache entries created after preflight resolver cleanup", async () => {
     prepareInstallHome();
     createCacheAfterFirstAdd = true;
-    spawnExitQueue = [1, 1, 0, 0];
+    spawnExitQueue = [1, 0, 0];
 
-    const res = await captureRun(["update", "v26.5.16-alpha.1053", "--yes"], { testMode: null });
+    const res = await captureRun(["update", "main", "--yes"], { testMode: null });
 
     expect(res.code).toBeUndefined();
     expect(lockCalls).toBe(1);
     expect(spawnCalls).toEqual([
-      ["curl", "-fsSL", "-o", mawBin, "https://github.com/Soul-Brews-Studio/maw-js/releases/download/v26.5.16-alpha.1053/maw"],
-      ["bun", "add", "-g", "github:Soul-Brews-Studio/maw-js#v26.5.16-alpha.1053"],
-      ["bun", "add", "-g", "github:Soul-Brews-Studio/maw-js#v26.5.16-alpha.1053"],
+      ["bun", "add", "-g", "github:Soul-Brews-Studio/maw-js#main"],
+      ["bun", "add", "-g", "github:Soul-Brews-Studio/maw-js#main"],
       ["maw", "--version"],
     ]);
     expect(execSyncCalls).toContain("maw --version");
@@ -246,16 +245,15 @@ describe("cmd-update sixth-pass retry cleanup coverage", () => {
     prepareInstallHome();
     failPkgRestore = true;
     failBinRestore = true;
-    spawnExitQueue = [1, 1, 1];
+    spawnExitQueue = [1, 1];
 
-    const res = await captureRun(["update", "v26.5.16-alpha.1053", "--yes"], { testMode: null });
+    const res = await captureRun(["update", "main", "--yes"], { testMode: null });
 
     expect(res.code).toBe(1);
     expect(lockCalls).toBe(1);
     expect(spawnCalls).toEqual([
-      ["curl", "-fsSL", "-o", mawBin, "https://github.com/Soul-Brews-Studio/maw-js/releases/download/v26.5.16-alpha.1053/maw"],
-      ["bun", "add", "-g", "github:Soul-Brews-Studio/maw-js#v26.5.16-alpha.1053"],
-      ["bun", "add", "-g", "github:Soul-Brews-Studio/maw-js#v26.5.16-alpha.1053"],
+      ["bun", "add", "-g", "github:Soul-Brews-Studio/maw-js#main"],
+      ["bun", "add", "-g", "github:Soul-Brews-Studio/maw-js#main"],
     ]);
     expect(res.stderr).toContain("install failed — previous maw restored from stash (if available)");
     expect(res.stderr).toContain("Manual recovery");

--- a/test/isolated/update-stash-restore.test.ts
+++ b/test/isolated/update-stash-restore.test.ts
@@ -38,10 +38,26 @@ describe("cmd-update stash+restore — source invariants (#551)", () => {
     expect(cmdUpdateSrc).toMatch(/const\s+STASH\s*=\s*`\$\{BIN\}\.prev`/);
   });
 
+  // ── Release/bun install order ─────────────────────────────────────────
+  it("release tags try curl binary before bun fallback", () => {
+    const releaseGuardIdx = cmdUpdateSrc.indexOf("if (isReleaseTag)");
+    const curlIdx = cmdUpdateSrc.indexOf('Bun.spawn(["curl", "-fsSL", "-o", BIN, releaseUrl]');
+    const fallbackIdx = cmdUpdateSrc.indexOf("// Fallback: bun add -g");
+    const bunAddIdx = cmdUpdateSrc.indexOf('Bun.spawn(["bun", "add", "-g"');
+
+    expect(cmdUpdateSrc).toContain("const isReleaseTag = /^v\\d+\\.\\d+\\.\\d+/.test(ref);");
+    expect(releaseGuardIdx).toBeGreaterThan(-1);
+    expect(curlIdx).toBeGreaterThan(releaseGuardIdx);
+    expect(fallbackIdx).toBeGreaterThan(curlIdx);
+    expect(bunAddIdx).toBeGreaterThan(fallbackIdx);
+  });
+
   // ── Case 1: happy-path short-circuit ──────────────────────────────────
-  it("case 1 — first install success gates out of fallback (only retry after installCode !== 0)", () => {
-    // The stash/remove/retry block must be inside an `if (installCode !== 0)` guard,
-    // so a first-attempt success skips all stash machinery.
+  it("case 1 — successful install gates out of bun cleanup fallback", () => {
+    // The stash/remove/retry block must be inside the bun fallback's
+    // `if (installCode !== 0)` guard. For release tags, curl is tried first;
+    // if curl succeeds, this whole bun fallback block is skipped. For branch
+    // refs, a first-attempt bun success skips all stash machinery.
     expect(cmdUpdateSrc).toMatch(
       /if\s*\(\s*installCode\s*!==\s*0\s*\)\s*\{[\s\S]*?const\s+spawnInstall\s*=[\s\S]*?installCode\s*=\s*await\s+spawnInstall\(\)\.exited\s*;[\s\S]*?if\s*\(\s*installCode\s*!==\s*0\s*\)\s*\{/,
     );
@@ -119,9 +135,12 @@ describe("cmd-update stash+restore — source invariants (#551)", () => {
   it("case 6 — retry failure restores the package dir then STASH → BIN", () => {
     // Restructured (crash-loop fix): guard is now plain `if (installCode !== 0)`;
     // restorePkgStash() runs FIRST so the stashed bin symlink resolves again,
-    // THEN the bin is moved back.
+    // THEN restoreBinStash() moves STASH back to BIN.
     expect(cmdUpdateSrc).toMatch(
-      /if\s*\(\s*installCode\s*!==\s*0\s*\)\s*\{[\s\S]*?restorePkgStash\(\)\s*;[\s\S]*?renameSync\(STASH\s*,\s*BIN\)/,
+      /if\s*\(\s*installCode\s*!==\s*0\s*\)\s*\{[\s\S]*?restorePkgStash\(\)\s*;[\s\S]*?restoreBinStash\(\)\s*;/,
+    );
+    expect(cmdUpdateSrc).toMatch(
+      /const\s+restoreBinStash\s*=\s*\(\)\s*=>\s*\{[\s\S]*?renameSync\(STASH\s*,\s*BIN\)/,
     );
   });
 


### PR DESCRIPTION
## Summary
- align cmd-update tests with #2415 release-binary-first behavior for tagged updates
- keep branch-ref tests on bun fallback cleanup/rollback paths
- restore fallback diagnostics for stale stash rotation and failed rollback restores

Closes #2415

## Verification
- MAW_TEST_MODE=1 bun test test/cmd-update*.test.ts test/isolated/cmd-update*.test.ts --path-ignore-patterns '**/agents/**'\n- git diff --check\n\n## Notes\n- bun run test:default:safe still fails on unrelated tmux wrapper tests in this environment (16 failures after deps install); cmd-update suites are green.