### PR TITLE
Fix serve startup version fallback

### DIFF
--- a/src/core/runtime/build-info.ts
+++ b/src/core/runtime/build-info.ts
@@ -1,20 +1,38 @@
 import { execSync } from "child_process";
 
 let cachedVersionString: string | undefined;
+let cachedVersionLabel: string | undefined;
 
-export function getRuntimeVersionString(): string {
-  if (cachedVersionString !== undefined) return cachedVersionString;
+export function normalizeRuntimeVersion(version: unknown): string {
+  return typeof version === "string" && version.trim() ? version.trim() : "dev";
+}
 
-  const pkg = require("../../../package.json");
-  let hash = "";
+export function formatRuntimeVersionLabel(version: unknown, hash = "", buildDate = ""): string {
+  const normalized = normalizeRuntimeVersion(version);
+  return `v${normalized}${hash ? ` (${hash})` : ""}${buildDate ? ` built ${buildDate}` : ""}`;
+}
+
+function readPackageVersion(): string {
   try {
-    hash = execSync("git rev-parse --short HEAD", {
+    const pkg = require("../../../package.json");
+    return normalizeRuntimeVersion(pkg?.version);
+  } catch {
+    return "dev";
+  }
+}
+
+function readGitHash(): string {
+  try {
+    return execSync("git rev-parse --short HEAD", {
       cwd: import.meta.dir,
       stdio: "pipe",
     }).toString().trim();
-  } catch {}
+  } catch {
+    return "";
+  }
+}
 
-  let buildDate = "";
+function readBuildDate(): string {
   try {
     const raw = execSync("git log -1 --format=%ci", {
       cwd: import.meta.dir,
@@ -22,9 +40,22 @@ export function getRuntimeVersionString(): string {
     }).toString().trim();
     const d = new Date(raw);
     const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-    buildDate = `${raw.slice(0, 10)} ${days[d.getDay()]} ${raw.slice(11, 16)}`;
-  } catch {}
+    return `${raw.slice(0, 10)} ${days[d.getDay()]} ${raw.slice(11, 16)}`;
+  } catch {
+    return "";
+  }
+}
 
-  cachedVersionString = `maw v${pkg.version}${hash ? ` (${hash})` : ""}${buildDate ? ` built ${buildDate}` : ""}`;
+export function getRuntimeVersionLabel(): string {
+  if (cachedVersionLabel !== undefined) return cachedVersionLabel;
+
+  cachedVersionLabel = formatRuntimeVersionLabel(readPackageVersion(), readGitHash(), readBuildDate());
+  return cachedVersionLabel;
+}
+
+export function getRuntimeVersionString(): string {
+  if (cachedVersionString !== undefined) return cachedVersionString;
+
+  cachedVersionString = `maw ${getRuntimeVersionLabel()}`;
   return cachedVersionString;
 }

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -30,26 +30,11 @@ import { sendKeys } from "./transport/ssh";
 import { messageQueue } from "./message-queue";
 import { requestReplyStore } from "./request-reply";
 import { agentStatusStore } from "./agent-status";
+import { getRuntimeVersionLabel } from "./runtime/build-info";
 
 // --- Version info (computed once at startup) ---
 
-function getVersionString(): string {
-  try {
-    const rootDir = join(import.meta.dir, "..", "..");
-    const pkg = JSON.parse(readFileSync(join(rootDir, "package.json"), "utf-8"));
-    let hash = ""; try { hash = require("child_process").execSync("git rev-parse --short HEAD", { cwd: rootDir }).toString().trim(); } catch {}
-    let buildDate = "";
-    try {
-      const raw = require("child_process").execSync("git log -1 --format=%ci", { cwd: rootDir }).toString().trim();
-      const d = new Date(raw);
-      const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-      buildDate = `${raw.slice(0, 10)} ${days[d.getDay()]} ${raw.slice(11, 16)}`;
-    } catch {}
-    return `v${pkg.version}${hash ? ` (${hash})` : ""}${buildDate ? ` built ${buildDate}` : ""}`;
-  } catch { return ""; }
-}
-
-export const VERSION = getVersionString();
+export const VERSION = getRuntimeVersionLabel();
 
 export function isAddressInUseError(err: unknown): boolean {
   if (!err || typeof err !== "object") return false;

--- a/test/build-info.test.ts
+++ b/test/build-info.test.ts
@@ -50,4 +50,14 @@ describe("getRuntimeVersionString", () => {
     expect(value).not.toContain(" built ");
     expect(execCalls).toHaveLength(2);
   });
+
+  test("uses dev instead of undefined when package version is missing", async () => {
+    const { formatRuntimeVersionLabel, normalizeRuntimeVersion } = await importBuildInfo("dev-fallback");
+
+    expect(normalizeRuntimeVersion(undefined)).toBe("dev");
+    expect(normalizeRuntimeVersion("")).toBe("dev");
+    expect(formatRuntimeVersionLabel(undefined)).toBe("vdev");
+    expect(formatRuntimeVersionLabel(" 26.6.8-alpha.1250 ", "abc1234", "2026-05-17 Sun 07:31"))
+      .toBe("v26.6.8-alpha.1250 (abc1234) built 2026-05-17 Sun 07:31");
+  });
 });


### PR DESCRIPTION
## Summary
- route `maw serve` startup version output through the shared runtime build-info formatter
- normalize missing/empty package versions to `dev` so startup never prints `vundefined`
- add regression coverage for the missing-version fallback

Closes #2412

## Tests
- `bun test test/build-info.test.ts test/isolated/core-server-more-coverage-2.test.ts`