### PR TITLE
Warn when hey queues for an offline node

### DIFF
--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -849,6 +849,9 @@ export async function cmdSend(
     console.log(`\x1b[90m  ⤷ ${reason}\x1b[0m`);
     return true;
   };
+  const warnOfflineInboxOnly = (): void => {
+    console.warn(`\x1b[33m⚠ target node offline — message written to inbox only, will not be seen until node wakes\x1b[0m`);
+  };
 
   // Local target (or self-node) → send via tmux.
   // Resolve to a specific pane first: when the oracle window has multiple
@@ -1030,7 +1033,10 @@ export async function cmdSend(
   // Try receiver inbox queue before surfacing a local-only resolver miss.
   if (bareResolution.locate?.repoPath) {
     const reason = `${query} found at ${bareResolution.locate.repoPath} but no active session — written to inbox only`;
-    if (logQueuedInbox(await writeReceiverInbox(bareResolution.locate.repoPath), query, reason)) return;
+    if (logQueuedInbox(await writeReceiverInbox(bareResolution.locate.repoPath), query, reason)) {
+      warnOfflineInboxOnly();
+      return;
+    }
     console.warn(`\x1b[33mwarn\x1b[0m: ${reason}`);
   } else if (logQueuedInbox(await writeReceiverInbox(), query, "target not live; persisted for receiver inbox polling")) return;
 

--- a/test/comm-send-cmdsend-coverage.test.ts
+++ b/test/comm-send-cmdsend-coverage.test.ts
@@ -742,6 +742,7 @@ describe("cmdSend — bare-name, wake, and safety gates", () => {
     expect(receiverWrites).toHaveLength(1);
     expect(receiverWrites[0].target).toBe("/tmp/renamed-oracle");
     expect(logs.join("\n")).toContain("renamed found at /tmp/renamed-oracle but no active session — written to inbox only");
+    expect(warns.join("\n")).toContain("⚠ target node offline — message written to inbox only, will not be seen until node wakes");
   });
 
   test("bare located repo resolves to active local session by cwd before inbox fallback (#2056)", async () => {


### PR DESCRIPTION
## Summary
- Print an explicit warning when `maw hey` resolves a target repo but finds no active tmux session and queues to receiver `ψ/inbox` only.
- Preserve the successful queue exit path while making delayed visibility clear to the sender.
- Add regression coverage for the offline inbox-only fallback warning.

Closes #2407

## Tests
- `MAW_TEST_MODE=1 bun test test/comm-send-cmdsend-coverage.test.ts --path-ignore-patterns '**/agents/**'`\n- `bun run test:default:safe`