### PR TITLE
Fix duplicate serve peer warnings

### DIFF
--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -106,6 +106,17 @@ export function createViews(
 const views = createViews();
 export { views };
 
+const startupPeerWarningsLogged = new Set<string>();
+
+function warnMissingFederationTokenOnce(port: number): void {
+  const key = "missing-federation-token";
+  if (startupPeerWarningsLogged.has(key)) return;
+  startupPeerWarningsLogged.add(key);
+  console.warn(`\x1b[31m⚠ WARNING: peers configured but no federationToken set!\x1b[0m`);
+  console.warn(`\x1b[31m  Port ${port} is exposed to network WITHOUT authentication.\x1b[0m`);
+  console.warn(`\x1b[31m  Add "federationToken" (min 16 chars) to maw.config.json\x1b[0m`);
+}
+
 // --- Server ---
 
 export async function startServer(port = +(process.env.MAW_PORT || loadConfig().port || 3456)) {
@@ -291,9 +302,7 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
   const hasPeers = heuristic.reason !== null;
 
   if (hasPeers && !config.federationToken) {
-    console.warn(`\x1b[31m⚠ WARNING: peers configured but no federationToken set!\x1b[0m`);
-    console.warn(`\x1b[31m  Port ${port} is exposed to network WITHOUT authentication.\x1b[0m`);
-    console.warn(`\x1b[31m  Add "federationToken" (min 16 chars) to maw.config.json\x1b[0m`);
+    warnMissingFederationTokenOnce(port);
   }
 
   // Duplicate <oracle>:<node> warn (#804 Step 3, ADR docs/federation/0001-peer-identity.md).

--- a/src/lib/peers/duplicate-detect.ts
+++ b/src/lib/peers/duplicate-detect.ts
@@ -21,6 +21,8 @@
  */
 import type { Peer } from "./store";
 
+const bootWarningMessagesLogged = new Set<string>();
+
 /** A single collision: two-or-more peers (or local + peers) sharing one key. */
 export interface DuplicateClaim {
   /** Canonical `<oracle>:<node>` key the peers collide on. */
@@ -84,8 +86,8 @@ export function formatDuplicate(d: DuplicateClaim): string {
 
 /**
  * Boot-time hook used by `startServer()`. Loads the peer cache + the
- * caller-supplied local identity, then writes a YELLOW warning per
- * collision via `console.warn`. Never throws — boot must continue per ADR.
+ * caller-supplied local identity, then writes a YELLOW warning once per
+ * unique collision via `console.warn`. Never throws — boot must continue per ADR.
  *
  * Returns the duplicates list so tests / callers can assert on it.
  */
@@ -97,7 +99,10 @@ export function warnDuplicatesAtBoot(args: {
   const log = args.log ?? ((m: string) => console.warn(m));
   const dups = findDuplicateIdentities(args.peers, args.local);
   for (const d of dups) {
-    log(`\x1b[33m⚠ ${formatDuplicate(d)}\x1b[0m`);
+    const warning = formatDuplicate(d);
+    if (bootWarningMessagesLogged.has(warning)) continue;
+    bootWarningMessagesLogged.add(warning);
+    log(`\x1b[33m⚠ ${warning}\x1b[0m`);
     log(`\x1b[33m  investigate with \`maw peers list\` and \`maw peers remove <alias>\` if stale.\x1b[0m`);
   }
   return dups;

--- a/src/vendor/mpr-plugins/peers/duplicate-detect.ts
+++ b/src/vendor/mpr-plugins/peers/duplicate-detect.ts
@@ -21,6 +21,8 @@
  */
 import type { Peer } from "./store";
 
+const bootWarningMessagesLogged = new Set<string>();
+
 /** A single collision: two-or-more peers (or local + peers) sharing one key. */
 export interface DuplicateClaim {
   /** Canonical `<oracle>:<node>` key the peers collide on. */
@@ -84,8 +86,8 @@ export function formatDuplicate(d: DuplicateClaim): string {
 
 /**
  * Boot-time hook used by `startServer()`. Loads the peer cache + the
- * caller-supplied local identity, then writes a YELLOW warning per
- * collision via `console.warn`. Never throws — boot must continue per ADR.
+ * caller-supplied local identity, then writes a YELLOW warning once per
+ * unique collision via `console.warn`. Never throws — boot must continue per ADR.
  *
  * Returns the duplicates list so tests / callers can assert on it.
  */
@@ -97,7 +99,10 @@ export function warnDuplicatesAtBoot(args: {
   const log = args.log ?? ((m: string) => console.warn(m));
   const dups = findDuplicateIdentities(args.peers, args.local);
   for (const d of dups) {
-    log(`\x1b[33m⚠ ${formatDuplicate(d)}\x1b[0m`);
+    const warning = formatDuplicate(d);
+    if (bootWarningMessagesLogged.has(warning)) continue;
+    bootWarningMessagesLogged.add(warning);
+    log(`\x1b[33m⚠ ${warning}\x1b[0m`);
     log(`\x1b[33m  investigate with \`maw peers list\` and \`maw peers remove <alias>\` if stale.\x1b[0m`);
   }
   return dups;

--- a/test/isolated/core-server-more-coverage-2.test.ts
+++ b/test/isolated/core-server-more-coverage-2.test.ts
@@ -243,6 +243,17 @@ describe("core server remaining isolated coverage", () => {
     expect(warns.join("\n")).toContain("event dispatch failed: dispatch rejected");
   });
 
+  test("deduplicates missing federation token startup warning across repeated serve starts", async () => {
+    config = { peers: ["http://peer.local:3456"] };
+
+    await startServer(4792);
+    await startServer(4793);
+
+    const joined = warns.join("\n");
+    expect(joined.match(/peers configured but no federationToken set/g)?.length).toBe(1);
+    expect(joined.match(/exposed to network WITHOUT authentication/g)?.length).toBe(1);
+  });
+
   test("plugin reload watcher callback reloads user plugins", async () => {
     await startServer(4790);
 

--- a/test/isolated/peers-duplicate-discovery-extra-coverage.test.ts
+++ b/test/isolated/peers-duplicate-discovery-extra-coverage.test.ts
@@ -88,6 +88,22 @@ describe.each(duplicateModules)("%s peers duplicate detection exports", (_label,
     expect(logs[1]).toContain("maw peers remove <alias>");
   });
 
+  test("deduplicates repeated boot warnings for the same peer collision", () => {
+    const logs: string[] = [];
+    const peers = {
+      repeatOne: peer({ url: "http://repeat-1", identity: { oracle: "repeat", node: "node" } }),
+      repeatTwo: peer({ url: "http://repeat-2", identity: { oracle: "repeat", node: "node" } }),
+    };
+
+    const first = mod.warnDuplicatesAtBoot({ peers, log: (msg) => logs.push(msg) });
+    const second = mod.warnDuplicatesAtBoot({ peers, log: (msg) => logs.push(msg) });
+
+    expect(first).toHaveLength(1);
+    expect(second).toHaveLength(1);
+    expect(logs).toHaveLength(2);
+    expect(logs[0]).toContain('duplicate <oracle>:<node> claim "repeat:node"');
+  });
+
   test("sorts multiple duplicate groups and uses the default boot logger", () => {
     const originalWarn = console.warn;
     const warnings: string[] = [];

--- a/test/isolated/plugin-peers-standalone.test.ts
+++ b/test/isolated/plugin-peers-standalone.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
+
+const duplicateDetect = await import("../../src/vendor/mpr-plugins/peers/duplicate-detect.ts?plugin-peers-standalone");
+
+type Peer = {
+  url: string;
+  node: string | null;
+  addedAt: string;
+  lastSeen: string | null;
+  identity?: { oracle: string; node: string };
+};
+
+function peer(url: string, identity?: { oracle: string; node: string }): Peer {
+  return {
+    url,
+    node: identity?.node ?? null,
+    addedAt: "2026-06-07T00:00:00.000Z",
+    lastSeen: null,
+    ...(identity ? { identity } : {}),
+  };
+}
+
+function stripAnsi(value: string) {
+  return value.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "");
+}
+
+describe("peers plugin standalone boundary (#2413)", () => {
+  test("documents current import boundary while peers finishes SDK extraction", () => {
+    const imports = expectStandalonePluginBoundary({
+      plugin: "peers",
+      requireSdk: false,
+      allowMawJs: ["maw-js/commands/shared/discovered-peers-client"],
+      allowRelative: ["../../../core/xdg"],
+    });
+
+    expect(imports.map((record) => record.spec)).toContain("../../../core/xdg");
+    expect(typeof duplicateDetect.findDuplicateIdentities).toBe("function");
+  });
+
+  test("finds stable duplicate identity claims and skips legacy peers", () => {
+    const dups = duplicateDetect.findDuplicateIdentities({
+      legacy: peer("http://legacy.local"),
+      beta: peer("http://beta.local", { oracle: "mawjs", node: "m5" }),
+      alpha: peer("http://alpha.local", { oracle: "mawjs", node: "m5" }),
+      otherOracle: peer("http://other.local", { oracle: "oracle", node: "m5" }),
+    });
+
+    expect(dups).toEqual([
+      {
+        key: "mawjs:m5",
+        claimants: [
+          { alias: "beta", url: "http://beta.local" },
+          { alias: "alpha", url: "http://alpha.local" },
+        ],
+      },
+    ]);
+    expect(duplicateDetect.formatDuplicate(dups[0])).toBe(
+      'duplicate <oracle>:<node> claim "mawjs:m5" — beta (http://beta.local), alpha (http://alpha.local)',
+    );
+  });
+
+  test("warnDuplicatesAtBoot warns once per unique collision and includes local identity", () => {
+    const logs: string[] = [];
+    const args = {
+      peers: {
+        selfAlias: peer("http://self.local", { oracle: "mawjs", node: "local" }),
+        remote: peer("http://remote.local", { oracle: "mawjs", node: "remote" }),
+      },
+      local: { oracle: "mawjs", node: "local" },
+      log: (msg: string) => logs.push(stripAnsi(msg)),
+    };
+
+    const first = duplicateDetect.warnDuplicatesAtBoot(args);
+    const second = duplicateDetect.warnDuplicatesAtBoot(args);
+
+    expect(first).toEqual([
+      {
+        key: "mawjs:local",
+        claimants: [
+          { alias: "<local>" },
+          { alias: "selfAlias", url: "http://self.local" },
+        ],
+      },
+    ]);
+    expect(second).toEqual(first);
+    expect(logs).toEqual([
+      '⚠ duplicate <oracle>:<node> claim "mawjs:local" — <local>, selfAlias (http://self.local)',
+      "  investigate with `maw peers list` and `maw peers remove <alias>` if stale.",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Deduplicate `maw serve` missing-token peer warnings across repeated startup/reload paths.
- Deduplicate duplicate peer identity boot warnings per exact warning while preserving duplicate scan return data.
- Add regression coverage for repeated serve starts and repeated duplicate peer collision scans.

Closes #2413

## Tests
- `bun test test/isolated/peers-duplicate-discovery-extra-coverage.test.ts test/isolated/core-server-more-coverage-2.test.ts --path-ignore-patterns '**/agents/**'`
- `bun run build`
- `bun run test:default:safe`
