### PR TITLE
Fix #2424 Phase 2 serve local plugin discovery

### DIFF
--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -16,6 +16,7 @@ import { handlePtyMessage, handlePtyClose, sweepOrphanPtySessions } from "./tran
 import { handleTmuxStreamClose, handleTmuxStreamMessage, handleTmuxStreamOpen } from "../api/tmux-stream";
 import { setBunServer } from "../lib/elysia-auth";
 import { runServeLifecycleHooks } from "../plugin/lifecycle";
+import { discoverLocalPluginDirs } from "../plugin/registry-helpers";
 import {
   dispatchEnginePluginEvent,
   findEnginePluginRegistration,
@@ -181,16 +182,34 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
     const userPluginsDir = process.env.MAW_PLUGINS_DIR || mawDataPath("plugins");
     await loadPlugins(plugins, userPluginsDir, "user");
 
+    // Project-local plugins (.maw/plugins in cwd ancestors) are loaded after
+    // user plugins so repository-specific hooks can participate in serve.
+    const projectPluginDirs = discoverLocalPluginDirs(process.cwd());
+    for (const dir of projectPluginDirs) {
+      await loadPlugins(plugins, dir, "project");
+    }
+
     // Package plugin hooks (manifest.hooks) — lets bundled/MPR plugins
     // subscribe to feed events without direct core imports (#1566).
     await registerManifestHooks(plugins);
 
-    // Hot-reload: watch the user plugins dir and re-import on .ts/.js/.wasm
-    // change. Builtin plugins are not touched. Opt out with MAW_HOT_RELOAD=0.
+    // Hot-reload: watch user and project-local plugin dirs and re-import on
+    // .ts/.js/.wasm change. Builtin plugins are not touched. Opt out with
+    // MAW_HOT_RELOAD=0.
     watchUserPlugins(userPluginsDir, async (changedFile: string) => {
       console.log(`[plugin] reloading user plugins (${changedFile} changed)`);
       await reloadUserPlugins(plugins, userPluginsDir);
     });
+    for (const dir of projectPluginDirs) {
+      watchUserPlugins(dir, async (changedFile: string) => {
+        console.log(`[plugin] reloading project plugins (${changedFile} changed)`);
+        plugins.unloadScope("project");
+        for (const projectDir of projectPluginDirs) {
+          await loadPlugins(plugins, projectDir, "project", true);
+        }
+        plugins._markReloaded?.();
+      });
+    }
 
     // Single feedListener wires everything through the plugin pipeline
     feedListeners.add((event) => plugins.emit(event));

--- a/src/plugins/00_types.ts
+++ b/src/plugins/00_types.ts
@@ -9,7 +9,7 @@ export type Filter = (event: FeedEvent) => FeedEvent;
 export type Handler = (event: Readonly<FeedEvent>) => void | Promise<void>;
 export type Late = (event: Readonly<FeedEvent>) => void;
 export type MawPlugin = (hooks: MawHooks) => void | (() => void);
-export type PluginScope = "builtin" | "user";
+export type PluginScope = "builtin" | "user" | "project";
 
 export interface Scoped<T> { fn: T; scope: PluginScope; name?: string; }
 

--- a/test/isolated/core-server-more-coverage-2.test.ts
+++ b/test/isolated/core-server-more-coverage-2.test.ts
@@ -19,6 +19,10 @@ let pluginLoadShouldThrow = false;
 let peersShouldThrow: unknown = false;
 let watchCallbacks: Array<(changedFile: string) => unknown> = [];
 let pluginReloads: unknown[][] = [];
+let pluginLoads: unknown[][] = [];
+let projectPluginDirs: string[] = [];
+let unloadedScopes: string[] = [];
+let reloadMarks = 0;
 let skipDecisions: boolean[] = [];
 let logs: string[] = [];
 let warns: string[] = [];
@@ -43,6 +47,8 @@ class FakePluginSystem {
   }
   emit(_event: unknown) {}
   stats() { return { loaded: 1 }; }
+  unloadScope(scope: string) { unloadedScopes.push(scope); }
+  _markReloaded() { reloadMarks += 1; }
 }
 
 mock.module(import.meta.resolve("../../src/engine"), () => ({ MawEngine: FakeEngine }));
@@ -115,7 +121,8 @@ mock.module(import.meta.resolve("../../src/core/engine-plugin-registry"), () => 
 }));
 mock.module(import.meta.resolve("../../src/plugins/index"), () => ({
   PluginSystem: FakePluginSystem,
-  loadPlugins: async () => {
+  loadPlugins: async (...args: unknown[]) => {
+    pluginLoads.push(args);
     if (pluginLoadShouldThrow) throw new Error("plugin load failed");
   },
   reloadUserPlugins: async (...args: unknown[]) => { pluginReloads.push(args); },
@@ -178,6 +185,10 @@ describe("core server remaining isolated coverage", () => {
     peersShouldThrow = false;
     watchCallbacks = [];
     pluginReloads = [];
+    pluginLoads = [];
+    projectPluginDirs = [];
+    unloadedScopes = [];
+    reloadMarks = 0;
     skipDecisions = [];
     logs = [];
     warns = [];
@@ -241,6 +252,37 @@ describe("core server remaining isolated coverage", () => {
 
     expect(logs.join("\n")).toContain("changed-plugin.ts changed");
     expect(pluginReloads).toHaveLength(1);
+  });
+
+  test("server loads and watches project-local plugin directories", async () => {
+    projectPluginDirs = [join(tmp, "packages", "app", ".maw", "plugins"), join(tmp, ".maw", "plugins")];
+    const cwd = join(tmp, "packages", "app", "src");
+    for (const dir of projectPluginDirs) mkdirSync(dir, { recursive: true });
+    mkdirSync(cwd, { recursive: true });
+    process.chdir(cwd);
+
+    await startServer(4792);
+
+    const initialLoads = pluginLoads.map((args) => args.slice(1));
+    expect(String(initialLoads[0][0])).toContain("plugins/builtin");
+    expect(initialLoads[0][1]).toBe("builtin");
+    expect(String(initialLoads[1][0])).toContain("plugins");
+    expect(initialLoads[1][1]).toBe("user");
+    expect(initialLoads.slice(2).map((args) => args[1])).toEqual(["project", "project"]);
+    expect(String(initialLoads[2][0])).toContain("packages/app/.maw/plugins");
+    expect(String(initialLoads[3][0])).toContain(".maw/plugins");
+    expect(watchCallbacks).toHaveLength(3);
+
+    await watchCallbacks[1]("local-plugin.ts");
+
+    expect(logs.join("\n")).toContain("reloading project plugins (local-plugin.ts changed)");
+    expect(unloadedScopes).toEqual(["project"]);
+    const reloadedProjectLoads = pluginLoads.slice(-2).map((args) => args.slice(1));
+    expect(reloadedProjectLoads.map((args) => args[1])).toEqual(["project", "project"]);
+    expect(reloadedProjectLoads.map((args) => args[2])).toEqual([true, true]);
+    expect(String(reloadedProjectLoads[0][0])).toContain("packages/app/.maw/plugins");
+    expect(String(reloadedProjectLoads[1][0])).toContain(".maw/plugins");
+    expect(reloadMarks).toBe(1);
   });
 
   test("lifecycle failure rethrows even when server stop also fails", async () => {


### PR DESCRIPTION
## Summary
- Fix #2424 Phase 2: load repo-local `.maw/plugins` during `maw serve` after user plugins under a new `project` plugin scope.
- Watch discovered local plugin directories for hot reload alongside the user plugin directory.
- Add isolated server coverage for project-local plugin load and reload behavior.

## Tests
- `MAW_TEST_MODE=1 bun test test/isolated/core-server-more-coverage-2.test.ts test/plugin-watcher.test.ts test/plugins.test.ts --path-ignore-patterns '**/agents/**'`\n\n## Notes\n- PR target: `alpha`.\n- References #2424 Phase 2.