### PR TITLE
Fix plugin loading correctness phase 1

### DIFF
--- a/src/plugin/registry-helpers.ts
+++ b/src/plugin/registry-helpers.ts
@@ -22,6 +22,7 @@ export function discoverLocalPluginDirs(cwd = process.cwd()): string[] {
   for (let i = 0; i < 32; i += 1) {
     const pluginsDir = join(dir, ".maw", "plugins");
     if (existsSync(pluginsDir)) dirs.push(pluginsDir);
+    if (existsSync(join(dir, ".maw-root"))) break;
     const parent = dirname(dir);
     if (parent === dir) break;
     dir = parent;

--- a/src/plugin/registry.ts
+++ b/src/plugin/registry.ts
@@ -24,7 +24,7 @@ import { join, resolve, sep } from "path";
 import { pathToFileURL } from "url";
 import { loadManifestFromDir } from "./manifest";
 import { loadConfig } from "../config";
-import { verbose, info } from "../cli/verbosity";
+import { verbose, info, warn } from "../cli/verbosity";
 import type { MawConfig } from "../config/types";
 import type { LoadedPlugin } from "./types";
 import { satisfies, formatSdkMismatchError } from "./registry-semver";
@@ -159,7 +159,7 @@ export function discoverPackages(deps: DiscoverPackagesDeps = {}): LoadedPlugin[
   // invariant (#343), but the right grain is SUMMARY, not per-entry.
   const modeCounts = { symlink: 0, artifact: 0, unbuilt: 0, legacy: 0 };
 
-  const seenPluginNames = new Set<string>();
+  const seenPluginNames = new Map<string, LoadedPlugin>();
 
   for (const baseDir of pluginDirs) {
     if (!existsSync(baseDir)) continue;
@@ -184,7 +184,11 @@ export function discoverPackages(deps: DiscoverPackagesDeps = {}): LoadedPlugin[
       if (!loaded) continue;
 
       const m = loaded.manifest;
-      if (seenPluginNames.has(m.name)) continue;
+      const winner = seenPluginNames.get(m.name);
+      if (winner) {
+        warn(`plugin '${m.name}' shadowed: using ${winner.dir}, ignoring ${pkgDir}`);
+        continue;
+      }
 
       // Gate 1: SDK semver. Mismatch → refuse with actionable error.
       if (!satisfies(runtimeVer, m.sdk)) {
@@ -228,7 +232,7 @@ export function discoverPackages(deps: DiscoverPackagesDeps = {}): LoadedPlugin[
         legacyCount++;
       }
 
-      seenPluginNames.add(m.name);
+      seenPluginNames.set(m.name, loaded);
 
       if (disabled.includes(m.name)) {
         loaded.disabled = true;
@@ -261,9 +265,8 @@ export function discoverPackages(deps: DiscoverPackagesDeps = {}): LoadedPlugin[
 
   // #404 — apply weight overrides so category survives `install --link` replaces
   // where the new plugin.json omitted `weight`.
-  const primaryPluginDir = pluginDirs[0];
-  if (primaryPluginDir) {
-    const overridesPath = join(primaryPluginDir, ".overrides.json");
+  for (const pluginDir of pluginDirs) {
+    const overridesPath = join(pluginDir, ".overrides.json");
     try {
       const overrides = JSON.parse(readFileSync(overridesPath, "utf8")) as Record<string, number>;
       for (const p of plugins) {

--- a/test/isolated/plugin-import-symbol-coverage.test.ts
+++ b/test/isolated/plugin-import-symbol-coverage.test.ts
@@ -151,4 +151,33 @@ describe("importPluginSymbol", () => {
     expect(second).toBe(first);
     expect(discoverCalls).toBe(2);
   });
+
+  test("resetDiscoverCache clears cached symbols so changed module surfaces can load", async () => {
+    const dir = join(root, "helper");
+    mkdirSync(dir);
+    writeFileSync(join(dir, "old.ts"), "export const stamp = 1;\n");
+    writeFileSync(join(dir, "new.ts"), "export const stamp = 2;\n");
+
+    const oldPlugin = makePlugin(dir, {
+      module: { path: "./old.ts", exports: ["stamp"] },
+    });
+    const newPlugin = makePlugin(dir, {
+      module: { path: "./new.ts", exports: ["stamp"] },
+    });
+
+    const first = await importPluginSymbol<number>("helper", "stamp", {
+      discoverPackages: () => [oldPlugin],
+    });
+    const staleWithoutReset = await importPluginSymbol<number>("helper", "stamp", {
+      discoverPackages: () => [newPlugin],
+    });
+    resetDiscoverCache();
+    const refreshed = await importPluginSymbol<number>("helper", "stamp", {
+      discoverPackages: () => [newPlugin],
+    });
+
+    expect(first).toBe(1);
+    expect(staleWithoutReset).toBe(1);
+    expect(refreshed).toBe(2);
+  });
 });

--- a/test/isolated/plugin-registry-runtime-coverage.test.ts
+++ b/test/isolated/plugin-registry-runtime-coverage.test.ts
@@ -31,6 +31,7 @@ mock.module(import.meta.resolve("../../src/config"), () => ({
 mock.module(import.meta.resolve("../../src/cli/verbosity"), () => ({
   verbose: (fn: () => void) => fn(),
   info: (line: string) => { infos.push(line); },
+  warn: (line: string) => { warns.push(line); },
 }));
 
 mock.module(import.meta.resolve("../../src/lib/profile-loader"), () => ({

--- a/test/plugin-registry-default.test.ts
+++ b/test/plugin-registry-default.test.ts
@@ -165,6 +165,38 @@ describe("discoverPackages default-suite coverage", () => {
     expect(discovered?.manifest.weight).toBe(10);
   });
 
+  test("warns when a later scanned plugin shadows an already loaded name", () => {
+    const project = join(testRoot, "workspace", "pkg");
+    const localPlugins = join(project, ".maw", "plugins");
+    const cwd = join(project, "src");
+    mkdirSync(cwd, { recursive: true });
+
+    const winnerDir = writeEntryPlugin(pluginsDir, "shadowed-plugin", { weight: 10 });
+    const ignoredDir = writeEntryPlugin(localPlugins, "shadowed-plugin", { weight: 1 });
+
+    process.chdir(cwd);
+    resetDiscoverCache();
+
+    const stderr: string[] = [];
+    const originalWrite = process.stderr.write;
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      stderr.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      const discovered = discoverPackages().filter((p) => p.manifest.name === "shadowed-plugin");
+      expect(discovered).toHaveLength(1);
+      expect(discovered[0].dir).toBe(winnerDir);
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+
+    const warning = stderr.join("");
+    expect(warning).toContain(`plugin 'shadowed-plugin' shadowed: using ${winnerDir}, ignoring `);
+    expect(warning).toContain("workspace/pkg/.maw/plugins/shadowed-plugin");
+    expect(warning).toContain(ignoredDir.split(`${testRoot}/`)[1]);
+  });
+
   test("memoizes default discovery until resetDiscoverCache is called", () => {
     writeEntryPlugin(pluginsDir, "registry-cache-a");
 
@@ -240,6 +272,29 @@ describe("discoverPackages default-suite coverage", () => {
     expect(warningText).toContain("plugin 'registry-unbuilt' is unbuilt");
     expect(warningText).toContain("plugin 'registry-missing-artifact' artifact missing");
     expect(warningText).toContain("plugin 'registry-hash-mismatch' artifact hash mismatch");
+  });
+
+  test("applies .overrides.json from every scanned plugin directory", () => {
+    const localPlugins = join(testRoot, "local-plugins");
+    writeEntryPlugin(pluginsDir, "global-weighted", { weight: 40 });
+    writeEntryPlugin(localPlugins, "local-weighted", { weight: 50 });
+
+    writeFileSync(join(pluginsDir, ".overrides.json"), JSON.stringify({
+      "global-weighted": 30,
+    }));
+    writeFileSync(join(localPlugins, ".overrides.json"), JSON.stringify({
+      "local-weighted": 1,
+    }));
+
+    const discovered = discoverPackages({
+      scanDirs: () => [pluginsDir, localPlugins],
+      loadConfig: () => ({ disabledPlugins: [] }),
+    }).map((p) => [p.manifest.name, p.manifest.weight] as const);
+
+    expect(discovered).toEqual([
+      ["local-weighted", 1],
+      ["global-weighted", 30],
+    ]);
   });
 
   test("applies injected active profile filters after defaulting missing tiers to core", () => {

--- a/test/registry-helpers.test.ts
+++ b/test/registry-helpers.test.ts
@@ -58,6 +58,22 @@ describe("plugin registry runtime helpers", () => {
     expect(scanDirs(cwd)).toEqual(["/tmp/maw-test-plugins", packagePlugins, projectPlugins]);
   });
 
+  test("discoverLocalPluginDirs stops walking at a .maw-root marker", () => {
+    const root = tempDir("maw-root-marker-");
+    const parentPlugins = join(root, ".maw", "plugins");
+    const project = join(root, "workspace");
+    const projectPlugins = join(project, ".maw", "plugins");
+    const packagePlugins = join(project, "packages", "app", ".maw", "plugins");
+    const cwd = join(project, "packages", "app", "src");
+    mkdirSync(parentPlugins, { recursive: true });
+    mkdirSync(projectPlugins, { recursive: true });
+    mkdirSync(packagePlugins, { recursive: true });
+    mkdirSync(cwd, { recursive: true });
+    writeFileSync(join(project, ".maw-root"), "");
+
+    expect(discoverLocalPluginDirs(cwd)).toEqual([packagePlugins, projectPlugins]);
+  });
+
   test("runtimeSdkVersion resolves and caches the bundled SDK package version", () => {
     __resetDiscoverStateForTests();
     const version = runtimeSdkVersion();


### PR DESCRIPTION
## Summary
- clear cached plugin module symbols when discovery cache resets
- warn when a later scanned plugin name is shadowed by an earlier winner
- stop repo-local plugin-dir discovery at `.maw-root`
- apply `.overrides.json` files from every scanned plugin directory

Closes #2424

## Tests
- `MAW_TEST_MODE=1 bun test test/plugin-registry-default.test.ts test/registry-helpers.test.ts test/isolated/plugin-import-symbol-coverage.test.ts --path-ignore-patterns '**/agents/**'`
