### PR TITLE
Improve plugin install UX for local dev

### DIFF
--- a/src/cli/route-tools.ts
+++ b/src/cli/route-tools.ts
@@ -177,6 +177,8 @@ export async function routeToolsWithDeps(cmd: string, args: string[], deps: Rout
     const flags = parseFlags(args, {
       "--json": Boolean,
       "--force": Boolean,
+      "--local": Boolean,
+      "--symlink": Boolean,
       "--all": Boolean,
       "--verbose": Boolean,
       "-v": Boolean,

--- a/src/commands/plugins/plugin/install-impl.ts
+++ b/src/commands/plugins/plugin/install-impl.ts
@@ -25,7 +25,7 @@ import { parseFlags } from "../../../cli/parse-args";
 import { detectMode, ensureInstallRoot } from "./install-source-detect";
 import { installFromDir, installFromTarball, installFromUrl, installFromMonorepo, installFromGithub } from "./install-handlers";
 import { resolvePeerInstall } from "./install-peer-resolver";
-import { basename } from "path";
+import { basename, join } from "path";
 
 export { installRoot, detectMode, parsePeerSpec, parseMonorepoRef, parseGithubRef, ensureInstallRoot, removeExisting } from "./install-source-detect";
 export type { GithubRef } from "./install-source-detect";
@@ -51,78 +51,95 @@ const CATEGORY_WEIGHT: Record<string, number> = { core: 5, standard: 30, extra: 
 export async function cmdPluginInstall(args: string[]): Promise<void> {
   const flags = parseFlags(
     args,
-    { "--link": Boolean, "--force": Boolean, "--category": String, "--pin": Boolean },
+    { "--link": Boolean, "--force": Boolean, "--category": String, "--pin": Boolean, "--local": Boolean, "--symlink": Boolean },
     0,
   );
   const src = flags._[0];
 
   if (!src || src === "--help" || src === "-h") {
-    throw new Error("usage: maw plugin install <dir | .tgz | URL | name@peer | monorepo:plugins/<name>@<tag> | owner/repo[/name][@ref]> [--link] [--force] [--pin] [--category core|standard|extra]");
+    throw new Error("usage: maw plugin install <dir | .tgz | URL | name@peer | monorepo:plugins/<name>@<tag> | owner/repo[/name][@ref]> [--link|--symlink] [--local] [--force] [--pin] [--category core|standard|extra]");
   }
 
-  ensureInstallRoot();
-  const mode = detectMode(src);
-  const force = !!flags["--force"];
-  const pin = !!flags["--pin"];
-  const cat = flags["--category"] as string | undefined;
-  if (cat !== undefined && !(cat in CATEGORY_WEIGHT)) {
-    throw new Error(`--category must be one of: core, standard, extra (got ${JSON.stringify(cat)})`);
+  const originalPluginsDir = process.env.MAW_PLUGINS_DIR;
+  if (flags["--local"]) {
+    process.env.MAW_PLUGINS_DIR = join(process.cwd(), ".maw", "plugins");
   }
-  const weight = cat !== undefined ? CATEGORY_WEIGHT[cat] : undefined;
 
-  // Dispatch on source type. --pin only meaningful for tarball/URL installs
-  // (dev `--link` is a symlink, not a supply-chain surface).
-  if (mode.kind === "dir") {
-    await installFromDir(mode.src, { force, weight });
-  } else if (mode.kind === "tarball") {
-    await installFromTarball(mode.src, { source: `./${basename(mode.src)}`, force, weight, pin });
-  } else if (mode.kind === "monorepo") {
-    await installFromMonorepo(mode.subpath, mode.tag, { force, weight, pin });
-  } else if (mode.kind === "github") {
-    // #939 — Vercel-style `owner/repo[/name][@ref]`.
-    await installFromGithub(
-      {
-        owner: mode.owner,
-        repo: mode.repo,
-        ...(mode.subpath ? { subpath: mode.subpath } : {}),
-        ...(mode.ref ? { ref: mode.ref } : {}),
-      },
-      { force, weight, pin },
-    );
-  } else if (mode.kind === "peer") {
-    const resolved = await resolvePeerInstall(mode.name, mode.peer);
-    console.log(
-      `→ ${resolved.peerName}${resolved.peerNode ? ` (${resolved.peerNode})` : ""} advertises: ` +
-      `${mode.name}@${resolved.version}` +
-      (resolved.peerSha256 ? ` (sha256: ${resolved.peerSha256.slice(0, 12)}…)` : ""),
-    );
+  try {
+    ensureInstallRoot();
+    const mode = detectMode(src);
+    const force = !!flags["--force"];
+    const pin = !!flags["--pin"];
+    const symlink = !!flags["--symlink"];
+    const cat = flags["--category"] as string | undefined;
+    if (cat !== undefined && !(cat in CATEGORY_WEIGHT)) {
+      throw new Error(`--category must be one of: core, standard, extra (got ${JSON.stringify(cat)})`);
+    }
+    const weight = cat !== undefined ? CATEGORY_WEIGHT[cat] : undefined;
 
-    // #644 Phase 3 — PIN consent before we touch the network for the artifact.
-    // Default OFF; opt in via MAW_CONSENT=1. Gate lives here (not in resolver)
-    // so the operator sees what the peer advertised BEFORE being asked to
-    // approve — the decision context is on-screen.
-    if (process.env.MAW_CONSENT === "1") {
-      const { maybeGatePluginInstall } = await import("../../../core/consent/gate-plugin-install");
-      const { loadConfig } = await import("../../../config");
-      const myNode = loadConfig().node ?? "local";
-      const decision = await maybeGatePluginInstall({
-        myNode,
-        peerName: resolved.peerName,
-        peerNode: resolved.peerNode,
-        peerUrl: resolved.peerUrl,
-        pluginName: mode.name,
-        pluginVersion: resolved.version,
-        pluginSha256: resolved.peerSha256,
-      });
-      if (!decision.allow) {
-        if (decision.message) console.error(decision.message);
-        process.exit(decision.exitCode ?? 1);
-      }
+    // Dispatch on source type. --pin only meaningful for tarball/URL installs
+    // (dev `--link`/`--symlink` is a symlink, not a supply-chain surface).
+    if (symlink && mode.kind !== "dir") {
+      throw new Error("--symlink is only supported for local directory plugin installs");
     }
 
-    console.log(`→ downloading ${resolved.downloadUrl}…`);
-    await installFromUrl(resolved.downloadUrl, { force, weight, pin });
-  } else {
-    await installFromUrl(mode.src, { force, weight, pin });
+    if (mode.kind === "dir") {
+      await installFromDir(mode.src, { force, weight });
+    } else if (mode.kind === "tarball") {
+      await installFromTarball(mode.src, { source: `./${basename(mode.src)}`, force, weight, pin });
+    } else if (mode.kind === "monorepo") {
+      await installFromMonorepo(mode.subpath, mode.tag, { force, weight, pin });
+    } else if (mode.kind === "github") {
+      // #939 — Vercel-style `owner/repo[/name][@ref]`.
+      await installFromGithub(
+        {
+          owner: mode.owner,
+          repo: mode.repo,
+          ...(mode.subpath ? { subpath: mode.subpath } : {}),
+          ...(mode.ref ? { ref: mode.ref } : {}),
+        },
+        { force, weight, pin },
+      );
+    } else if (mode.kind === "peer") {
+      const resolved = await resolvePeerInstall(mode.name, mode.peer);
+      console.log(
+        `→ ${resolved.peerName}${resolved.peerNode ? ` (${resolved.peerNode})` : ""} advertises: ` +
+        `${mode.name}@${resolved.version}` +
+        (resolved.peerSha256 ? ` (sha256: ${resolved.peerSha256.slice(0, 12)}…)` : ""),
+      );
+
+      // #644 Phase 3 — PIN consent before we touch the network for the artifact.
+      // Default OFF; opt in via MAW_CONSENT=1. Gate lives here (not in resolver)
+      // so the operator sees what the peer advertised BEFORE being asked to
+      // approve — the decision context is on-screen.
+      if (process.env.MAW_CONSENT === "1") {
+        const { maybeGatePluginInstall } = await import("../../../core/consent/gate-plugin-install");
+        const { loadConfig } = await import("../../../config");
+        const myNode = loadConfig().node ?? "local";
+        const decision = await maybeGatePluginInstall({
+          myNode,
+          peerName: resolved.peerName,
+          peerNode: resolved.peerNode,
+          peerUrl: resolved.peerUrl,
+          pluginName: mode.name,
+          pluginVersion: resolved.version,
+          pluginSha256: resolved.peerSha256,
+        });
+        if (!decision.allow) {
+          if (decision.message) console.error(decision.message);
+          process.exit(decision.exitCode ?? 1);
+        }
+      }
+
+      console.log(`→ downloading ${resolved.downloadUrl}…`);
+      await installFromUrl(resolved.downloadUrl, { force, weight, pin });
+    } else {
+      await installFromUrl(mode.src, { force, weight, pin });
+    }
+  } finally {
+    if (flags["--local"]) {
+      if (originalPluginsDir === undefined) delete process.env.MAW_PLUGINS_DIR;
+      else process.env.MAW_PLUGINS_DIR = originalPluginsDir;
+    }
   }
 }

--- a/src/commands/shared/plugins-install.ts
+++ b/src/commands/shared/plugins-install.ts
@@ -3,7 +3,7 @@
  */
 
 import type { LoadedPlugin } from "../../plugin/types";
-import { existsSync, mkdirSync, cpSync, readFileSync } from "fs";
+import { existsSync, mkdirSync, cpSync, readFileSync, symlinkSync } from "fs";
 import { join, resolve } from "path";
 import { parseManifest } from "../../plugin/manifest";
 import { archiveToTmp } from "./plugins-ui";
@@ -12,11 +12,23 @@ import { mawDataPath } from "../../core/xdg";
 /** Allowlist: only http/https URLs permitted as plugin sources */
 const URL_SCHEME_RE = /^https?:\/\//;
 
-function getPluginHome(): string {
+export type PluginInstallOptions = {
+  /** Install into the cwd-local .maw/plugins tree instead of the global plugin home. */
+  local?: boolean;
+  /** Symlink the source directory into place for development instead of copying it. */
+  symlink?: boolean;
+};
+
+function getPluginHome(options: PluginInstallOptions = {}): string {
+  if (options.local) return join(process.cwd(), ".maw", "plugins");
   return process.env.MAW_PLUGIN_HOME ?? mawDataPath("plugins");
 }
 
-export async function doInstall(srcPath: string, force: boolean): Promise<void> {
+export async function doInstall(
+  srcPath: string,
+  force: boolean,
+  options: PluginInstallOptions = {},
+): Promise<void> {
   let src: string;
 
   // GitHub URL → clone via ghq, then install from local path
@@ -84,7 +96,8 @@ export async function doInstall(srcPath: string, force: boolean): Promise<void> 
     process.exit(1);
   }
 
-  const dest = join(getPluginHome(), manifest.name);
+  const pluginHome = getPluginHome(options);
+  const dest = join(pluginHome, manifest.name);
   if (existsSync(dest)) {
     if (!force) {
       console.error(
@@ -96,8 +109,12 @@ export async function doInstall(srcPath: string, force: boolean): Promise<void> 
     archiveToTmp(manifest.name, dest);
   }
 
-  mkdirSync(dest, { recursive: true });
-  cpSync(src, dest, { recursive: true });
+  mkdirSync(pluginHome, { recursive: true });
+  if (options.symlink) {
+    symlinkSync(resolve(src), dest, "dir");
+  } else {
+    cpSync(src, dest, { recursive: true });
+  }
   console.log(
     `\x1b[32m✓\x1b[0m installed ${manifest.name}@${manifest.version} → ${dest}`,
   );

--- a/src/commands/shared/plugins.ts
+++ b/src/commands/shared/plugins.ts
@@ -28,6 +28,8 @@ type Flags = {
   _: string[];
   "--json"?: boolean;
   "--force"?: boolean;
+  "--local"?: boolean;
+  "--symlink"?: boolean;
   "--all"?: boolean;
   "--verbose"?: boolean;
   "-v"?: boolean;
@@ -73,10 +75,13 @@ export async function cmdPlugins(
       return doInfo(name, discover);
     case "install":
       if (!name) {
-        console.error("usage: maw plugins install <path> [--force]");
+        console.error("usage: maw plugins install <path> [--force] [--local] [--symlink]");
         process.exit(1);
       }
-      return doInstall(name, flags["--force"] ?? false);
+      return doInstall(name, flags["--force"] ?? false, {
+        local: flags["--local"] ?? false,
+        symlink: flags["--symlink"] ?? false,
+      });
     case "remove":
     case "uninstall":
     case "rm":

--- a/test/isolated/instance-preset-token-load-extra-coverage.test.ts
+++ b/test/isolated/instance-preset-token-load-extra-coverage.test.ts
@@ -309,11 +309,18 @@ describe("cmdPlugins isolated branch dispatcher", () => {
     const discover = () => [] as any[];
 
     await cmdPlugins("install", [], { _: ["/tmp/plugin"], "--force": true }, discover as any);
+    await cmdPlugins(
+      "install",
+      [],
+      { _: ["/tmp/local-plugin"], "--local": true, "--symlink": true },
+      discover as any,
+    );
     await cmdPlugins("uninstall", [], { _: ["old-plugin"] }, discover as any);
     await cmdPlugins("rm", [], { _: ["older-plugin"] }, discover as any);
 
     expect(pluginCalls).toEqual([
-      { fn: "doInstall", args: ["/tmp/plugin", true] },
+      { fn: "doInstall", args: ["/tmp/plugin", true, { local: false, symlink: false }] },
+      { fn: "doInstall", args: ["/tmp/local-plugin", false, { local: true, symlink: true }] },
       { fn: "doRemove", args: ["old-plugin", discover] },
       { fn: "doRemove", args: ["older-plugin", discover] },
     ]);
@@ -328,7 +335,7 @@ describe("cmdPlugins isolated branch dispatcher", () => {
 
     expect(exitCodes).toEqual([1, 1, 1, 1, 1]);
     expect(errorSpy).toHaveBeenCalledWith("usage: maw plugins info <name>");
-    expect(errorSpy).toHaveBeenCalledWith("usage: maw plugins install <path> [--force]");
+    expect(errorSpy).toHaveBeenCalledWith("usage: maw plugins install <path> [--force] [--local] [--symlink]");
     expect(errorSpy).toHaveBeenCalledWith("usage: maw plugins remove <name>");
     expect(errorSpy).toHaveBeenCalledWith("usage: maw plugin enable <name> [more...]");
     expect(errorSpy).toHaveBeenCalledWith("usage: maw plugin disable <name>");

--- a/test/isolated/plugin-install-impl-more-coverage.test.ts
+++ b/test/isolated/plugin-install-impl-more-coverage.test.ts
@@ -55,6 +55,7 @@ let exitCode: number | undefined;
 
 const originalEnv = {
   consent: process.env.MAW_CONSENT,
+  pluginsDir: process.env.MAW_PLUGINS_DIR,
 };
 const originalLog = console.log;
 const originalError = console.error;
@@ -147,6 +148,7 @@ beforeEach(() => {
   stderr = [];
   exitCode = undefined;
   delete process.env.MAW_CONSENT;
+  delete process.env.MAW_PLUGINS_DIR;
   console.log = (...args: unknown[]) => stdout.push(args.map(String).join(" "));
   console.error = (...args: unknown[]) => stderr.push(args.map(String).join(" "));
   (process as any).exit = (code?: number): never => {
@@ -158,6 +160,8 @@ beforeEach(() => {
 afterEach(() => {
   if (originalEnv.consent === undefined) delete process.env.MAW_CONSENT;
   else process.env.MAW_CONSENT = originalEnv.consent;
+  if (originalEnv.pluginsDir === undefined) delete process.env.MAW_PLUGINS_DIR;
+  else process.env.MAW_PLUGINS_DIR = originalEnv.pluginsDir;
   console.log = originalLog;
   console.error = originalError;
   (process as any).exit = originalExit;
@@ -196,6 +200,27 @@ describe("cmdPluginInstall source dispatch", () => {
     expect(handlerCalls).toEqual([
       { fn: "dir", args: ["/tmp/dev-plugin", { force: true, weight: 5 }] },
     ]);
+  });
+
+  test("accepts --local and --symlink for directory installs without leaking MAW_PLUGINS_DIR", async () => {
+    plannedMode = { kind: "dir", src: "/tmp/dev-plugin" };
+
+    await cmdPluginInstall(["/tmp/dev-plugin", "--local", "--symlink", "--force"]);
+
+    expect(process.env.MAW_PLUGINS_DIR).toBeUndefined();
+    expect(handlerCalls).toEqual([
+      { fn: "dir", args: ["/tmp/dev-plugin", { force: true, weight: undefined }] },
+    ]);
+  });
+
+  test("rejects --symlink for sealed artifact installs", async () => {
+    plannedMode = { kind: "tarball", src: "/tmp/builds/demo-1.2.3.tgz" };
+
+    await expect(cmdPluginInstall(["/tmp/builds/demo-1.2.3.tgz", "--symlink"])).rejects.toThrow(
+      /--symlink is only supported for local directory plugin installs/,
+    );
+
+    expect(handlerCalls).toEqual([]);
   });
 
   test("normalizes tarball source labels and forwards pin/weight options", async () => {

--- a/test/isolated/plugins-install-github-extra-coverage.test.ts
+++ b/test/isolated/plugins-install-github-extra-coverage.test.ts
@@ -9,10 +9,12 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readdirSync,
   readFileSync,
+  readlinkSync,
   rmSync,
   writeFileSync,
 } from "fs";
@@ -176,6 +178,39 @@ describe("doInstall local source", () => {
     expect(result.stdout).toContain("installed local-extra@1.2.3");
     expect(existsSync(join(dest, "plugin.json"))).toBe(true);
     expect(readFileSync(join(dest, "index.js"), "utf8")).toContain("marker");
+  });
+
+
+  test("installs into cwd-local .maw/plugins when --local is set", async () => {
+    const cwd = tmpDir("maw-local-install-cwd-");
+    const src = buildPlugin("local-flag", "1.0.1", "export const marker = 'local';\n");
+    const originalCwd = process.cwd();
+
+    try {
+      process.chdir(cwd);
+      const result = await capture(() => doInstall(src, false, { local: true }));
+
+      const localDest = join(cwd, ".maw", "plugins", "local-flag");
+      expect(result.exitCode).toBeUndefined();
+      expect(result.stdout).toContain("installed local-flag@1.0.1");
+      expect(result.stdout).toContain(join(".maw", "plugins", "local-flag"));
+      expect(existsSync(join(localDest, "plugin.json"))).toBe(true);
+      expect(existsSync(join(pluginHome(), "local-flag"))).toBe(false);
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  test("symlinks a local plugin when --symlink is set", async () => {
+    const src = buildPlugin("symlink-flag", "2.0.1", "export const marker = 'symlink';\n");
+
+    const result = await capture(() => doInstall(src, false, { symlink: true }));
+
+    const dest = join(pluginHome(), "symlink-flag");
+    expect(result.exitCode).toBeUndefined();
+    expect(result.stdout).toContain("installed symlink-flag@2.0.1");
+    expect(lstatSync(dest).isSymbolicLink()).toBe(true);
+    expect(resolve(pluginHome(), readlinkSync(dest))).toBe(resolve(src));
   });
 
   test("exits when the local source path is missing", async () => {

--- a/test/route-tools-default.test.ts
+++ b/test/route-tools-default.test.ts
@@ -191,11 +191,18 @@ describe("routeTools default-suite seams", () => {
   test("routes plugins, artifacts, agents, and audit through injected handlers", async () => {
     const h = harness();
 
+    expect(await routeToolsWithDeps("plugins", ["plugins", "install", "./demo", "--local", "--symlink", "--force"], h.deps)).toBe(true);
+    expect(h.calls.plugins[0]).toMatchObject({
+      sub: "install",
+      args: ["./demo", "--local", "--symlink", "--force"],
+      flags: { "--local": true, "--symlink": true, "--force": true },
+    });
+
     expect(await routeToolsWithDeps("plugins", ["plugins", "info", "about", "--json"], h.deps)).toBe(true);
-    expect(h.calls.plugins[0]).toMatchObject({ sub: "info", args: ["about", "--json"], flags: { "--json": true } });
+    expect(h.calls.plugins[1]).toMatchObject({ sub: "info", args: ["about", "--json"], flags: { "--json": true } });
 
     expect(await routeToolsWithDeps("plugin", ["plugin", "ls", "--all", "-v", "--api"], h.deps)).toBe(true);
-    expect(h.calls.plugins[1]).toMatchObject({
+    expect(h.calls.plugins[2]).toMatchObject({
       sub: "ls",
       args: ["--all", "-v", "--api"],
       flags: { "--all": true, "-v": true, "--api": true },


### PR DESCRIPTION
## Summary
- add `--local` install mode for cwd-local `.maw/plugins` installs
- add `--symlink` dev install mode for shared installer copies and lifecycle directory installs
- wire parser coverage for the new install flags

## Issue
References #2424 Phase 3.

## Verification
- `MAW_TEST_MODE=1 bun test test/isolated/plugins-install-github-extra-coverage.test.ts test/route-tools-default.test.ts test/isolated/plugin-install-impl-more-coverage.test.ts --path-ignore-patterns '**/agents/**'`
- `bun run build`
- `bun run test:default:safe`
