### PR TITLE
Fix #2416 team up prompt delay

### DIFF
--- a/src/vendor/mpr-plugins/team/team-up.ts
+++ b/src/vendor/mpr-plugins/team/team-up.ts
@@ -149,6 +149,11 @@ function memberPrimingTarget(session: string, member: TeamCharter["members"][num
   return `${session}:${identity}`;
 }
 
+function promptDelayMs(charter: TeamCharter): number {
+  const configured = charter.lifecycle?.prompt_delay;
+  return typeof configured === "number" ? configured : 3000;
+}
+
 async function primeMember(
   member: TeamCharter["members"][number],
   session: string,
@@ -242,6 +247,7 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
       await wakeMember(targetRepoSlug, item.member, { engine: item.engine, session, repoPath: repoRoot, channels: memberChannels(charter, item.member) }, { cmdWakeFn: deps.cmdWakeFn });
       actions.push({ role: item.role, memberKey, state: item.state, action: "force fresh wake", command });
       await waitForNonShell(item.member, session, tmux, sleep, targetRepoSlug);
+      await sleep(promptDelayMs(charter));
       await primeMember(item.member, session, repoRoot, deps, warnings);
     } else if (item.state === "live") {
       actions.push({ role: item.role, memberKey, state: item.state, action: "skip live" });
@@ -251,12 +257,14 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
       await tmux.run("send-keys", "-t", item.pane!.paneId, command, "Enter");
       actions.push({ role: item.role, memberKey, state: item.state, action: "resume in place", command });
       await waitForNonShell(item.member, session, tmux, sleep, targetRepoSlug);
+      await sleep(promptDelayMs(charter));
       await primeMember(item.member, session, repoRoot, deps, warnings);
     } else {
       const command = engineCommand(item.engine, { resume: false }, config);
       await wakeMember(targetRepoSlug, item.member, { engine: item.engine, session, repoPath: repoRoot, channels: memberChannels(charter, item.member) }, { cmdWakeFn: deps.cmdWakeFn });
       actions.push({ role: item.role, memberKey, state: item.state, action: "fresh wake", command });
       await waitForNonShell(item.member, session, tmux, sleep, targetRepoSlug);
+      await sleep(promptDelayMs(charter));
       await primeMember(item.member, session, repoRoot, deps, warnings);
     }
   }

--- a/test/isolated/plugin-team-standalone.test.ts
+++ b/test/isolated/plugin-team-standalone.test.ts
@@ -3,6 +3,8 @@ import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
+
 const root = join(import.meta.dir, "../..");
 
 let calls: Array<{ name: string; args: unknown[] }> = [];
@@ -85,6 +87,25 @@ beforeEach(() => {
 });
 
 describe("team command plugin standalone boundary (#2336)", () => {
+  test("team-up vendor boundary explicitly tracks prompt priming seams", () => {
+    const imports = expectStandalonePluginBoundary({
+      plugin: "team",
+      files: ["team-up.ts"],
+      requireSdk: false,
+      allowRelative: [
+        "../../../commands/shared/comm-send",
+        "../../../commands/shared/wake-cmd",
+        "../../../config/load",
+        "../../../config/types",
+        "../../../core/transport/tmux",
+      ],
+    }).map((record) => record.spec);
+
+    expect(imports).toContain("./team-charter");
+    expect(imports).toContain("./team-liveness");
+    expect(imports).toContain("../../../commands/shared/comm-send");
+  });
+
   test("entrypoint uses SDK rather than direct plugin/cli/core imports", () => {
     const source = readFileSync(join(root, "src/vendor/mpr-plugins/team/index.ts"), "utf8");
     const specs = [...source.matchAll(/\b(?:import|export)\s+(?:[^"'`]+?\s+from\s+)?["']([^"']+)["']/g)].map((m) => m[1]);

--- a/test/isolated/team-up-coverage.test.ts
+++ b/test/isolated/team-up-coverage.test.ts
@@ -76,8 +76,11 @@ members:
     channels: true
     queue:
       - next
+lifecycle:
+  prompt_delay: 250
 `);
     expect(charter.session).toBe("named-session");
+    expect(charter.lifecycle?.prompt_delay).toBe(250);
     expect(charter.members[0]).toMatchObject({ role: "coder", name: "mawjs-codex", engine: "omx", worktree: true, node: "m5", channels: true, queue: ["next"] });
   });
 
@@ -210,6 +213,53 @@ agents:
     expect(status.output).toContain("codex\tomx\tmissing\twakeable --wt codex -e omx --session charter-session --channels");
     expect(status.output).toContain("oss-world\tclaude\tmissing\twakeable --wt oss-world -e claude --session charter-session");
     expect(status.output).not.toContain("oss-world\tclaude\tmissing\twakeable --wt oss-world -e claude --session charter-session --channels");
+  });
+
+  test("team up delays by lifecycle.prompt_delay after wake readiness before priming prompts", async () => {
+    const root = mkdtempSync(join(tmpdir(), "maw-node-prompt-delay-"));
+    dirs.push(root);
+    mkdirSync(join(root, ".git"));
+    mkdirSync(join(root, ".maw"), { recursive: true });
+    writeFileSync(join(root, ".maw", "m5.yaml"), `
+name: m5-team
+session: charter-session
+lifecycle:
+  prompt_delay: 42
+agents:
+  codex:
+    engine: omx
+    prompt: delayed hello
+`, "utf-8");
+
+    let listCalls = 0;
+    const events: string[] = [];
+    const tmux = {
+      run: async (...args: string[]) => {
+        events.push(`tmux:${args[0]}`);
+        if (args[0] === "display-message") return "lead-session\n";
+        if (args[0] === "list-panes") {
+          listCalls++;
+          if (listCalls === 1) return "";
+          if (listCalls === 2) return "charter-session|codex|zsh|/wt/codex|%1";
+          return "charter-session|codex|codex|/wt/codex|%1";
+        }
+        return "";
+      },
+    };
+
+    await cmdTeamUp("any", { session: "charter-session" }, {
+      cwd: root,
+      tmux,
+      loadConfigFn: () => ({ ...config, node: "m5" }),
+      cmdWakeFn: async () => { events.push("wake"); return "woke"; },
+      cmdSendFn: async () => { events.push("send"); },
+      sleep: async (ms: number) => { events.push(`sleep:${ms}`); },
+      logger: () => {},
+    });
+
+    expect(events).toContain("sleep:42");
+    expect(events.indexOf("sleep:1000")).toBeLessThan(events.indexOf("sleep:42"));
+    expect(events.indexOf("sleep:42")).toBeLessThan(events.indexOf("send"));
   });
 
   test("team up wakes charter.project and primes inline plus file-ref prompts", async () => {


### PR DESCRIPTION
## Summary
- add a configurable lifecycle.prompt_delay wait between team wake readiness and prompt priming
- default the delay to 3000ms when lifecycle.prompt_delay is omitted
- cover charter parsing and prompt-delay ordering in vendored team-up tests

Closes #2416

## Verification
- bun test test/isolated/team-up-coverage.test.ts --path-ignore-patterns '**/agents/**'
- bun run build