### PR TITLE
Bound Discord user cache growth

### DIFF
--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -76,6 +76,7 @@ export {
 export { resolveTarget } from "../core/routing";
 export type { ResolveResult } from "../core/routing";
 export { resolveSessionTarget, resolveWorktreeTarget, resolveFleetWindowSessionTarget } from "../core/matcher/resolve-target";
+export { normalizeTarget } from "../core/matcher/normalize-target";
 export { isInfrastructureChannelSessionName } from "../core/matcher/channel-session";
 export { resolveOracle, pickOracle } from "../core/resolve";
 export type {

--- a/src/vendor/mpr-plugins/discord/inventory.ts
+++ b/src/vendor/mpr-plugins/discord/inventory.ts
@@ -72,11 +72,59 @@ async function fetchGuilds(token: string): Promise<Guild[]> {
   return await res.json() as Guild[];
 }
 
-// Per-process user-name cache so repeated id→name lookups don't refetch
+// Per-process user-name cache so repeated id→name lookups don't refetch.
+// Bounded by LRU order to avoid long-lived Discord inventory processes growing
+// without limit when resolving many allow-listed users.
+export const DISCORD_USER_CACHE_DEFAULT_MAX = 1000;
+export const DISCORD_USER_CACHE_MAX_ENV = "MAW_DISCORD_USER_CACHE_MAX";
+
 const _userCache: Map<string, string> = new Map();
 
+function parseNonNegativeInt(value: string | undefined): number | null {
+  if (value === undefined || value.trim() === "") return null;
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 0) return null;
+  return n;
+}
+
+export function getDiscordUserCacheMaxSize(): number {
+  return parseNonNegativeInt(process.env[DISCORD_USER_CACHE_MAX_ENV]) ?? DISCORD_USER_CACHE_DEFAULT_MAX;
+}
+
+function evictDiscordUserCacheOverflow(maxSize = getDiscordUserCacheMaxSize()): void {
+  while (_userCache.size > maxSize) {
+    const oldest = _userCache.keys().next().value;
+    if (oldest === undefined) break;
+    _userCache.delete(oldest);
+  }
+}
+
+export function getCachedDiscordUserName(userId: string): string | undefined {
+  const value = _userCache.get(userId);
+  if (value === undefined) return undefined;
+  // Refresh recency on reads: Map iteration order is insertion order.
+  _userCache.delete(userId);
+  _userCache.set(userId, value);
+  return value;
+}
+
+export function cacheDiscordUserName(userId: string, name: string): void {
+  _userCache.delete(userId);
+  _userCache.set(userId, name);
+  evictDiscordUserCacheOverflow();
+}
+
+export function clearDiscordUserCacheForTests(): void {
+  _userCache.clear();
+}
+
+export function snapshotDiscordUserCacheForTests(): Array<[string, string]> {
+  return Array.from(_userCache.entries());
+}
+
 async function resolveUserName(token: string, userId: string): Promise<string> {
-  if (_userCache.has(userId)) return _userCache.get(userId)!;
+  const cached = getCachedDiscordUserName(userId);
+  if (cached !== undefined) return cached;
   try {
     const res = await fetch(`https://discord.com/api/v10/users/${userId}`, {
       headers: { Authorization: `Bot ${token}` },
@@ -86,13 +134,13 @@ async function resolveUserName(token: string, userId: string): Promise<string> {
       await new Promise(r => setTimeout(r, (retry + 0.2) * 1000));
       return resolveUserName(token, userId);
     }
-    if (!res.ok) { _userCache.set(userId, userId); return userId; }
+    if (!res.ok) { cacheDiscordUserName(userId, userId); return userId; }
     const u: any = await res.json();
     const name = u.global_name || u.username || userId;
-    _userCache.set(userId, name);
+    cacheDiscordUserName(userId, name);
     return name;
   } catch {
-    _userCache.set(userId, userId);
+    cacheDiscordUserName(userId, userId);
     return userId;
   }
 }

--- a/test/discord-user-cache.test.ts
+++ b/test/discord-user-cache.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+  DISCORD_USER_CACHE_DEFAULT_MAX,
+  DISCORD_USER_CACHE_MAX_ENV,
+  cacheDiscordUserName,
+  clearDiscordUserCacheForTests,
+  getCachedDiscordUserName,
+  getDiscordUserCacheMaxSize,
+  snapshotDiscordUserCacheForTests,
+} from "../src/vendor/mpr-plugins/discord/inventory";
+
+const previousMax = process.env[DISCORD_USER_CACHE_MAX_ENV];
+
+afterEach(() => {
+  clearDiscordUserCacheForTests();
+  if (previousMax === undefined) delete process.env[DISCORD_USER_CACHE_MAX_ENV];
+  else process.env[DISCORD_USER_CACHE_MAX_ENV] = previousMax;
+});
+
+describe("Discord user cache", () => {
+  it("defaults to 1000 entries", () => {
+    delete process.env[DISCORD_USER_CACHE_MAX_ENV];
+    expect(DISCORD_USER_CACHE_DEFAULT_MAX).toBe(1000);
+    expect(getDiscordUserCacheMaxSize()).toBe(1000);
+  });
+
+  it("uses a configurable non-negative max size from the environment", () => {
+    process.env[DISCORD_USER_CACHE_MAX_ENV] = "2";
+    expect(getDiscordUserCacheMaxSize()).toBe(2);
+
+    process.env[DISCORD_USER_CACHE_MAX_ENV] = "not-a-number";
+    expect(getDiscordUserCacheMaxSize()).toBe(1000);
+  });
+
+  it("evicts oldest entries when the configured max is exceeded", () => {
+    process.env[DISCORD_USER_CACHE_MAX_ENV] = "2";
+
+    cacheDiscordUserName("u1", "one");
+    cacheDiscordUserName("u2", "two");
+    cacheDiscordUserName("u3", "three");
+
+    expect(snapshotDiscordUserCacheForTests()).toEqual([
+      ["u2", "two"],
+      ["u3", "three"],
+    ]);
+    expect(getCachedDiscordUserName("u1")).toBeUndefined();
+  });
+
+  it("supports max size 0 to disable retained cache entries", () => {
+    process.env[DISCORD_USER_CACHE_MAX_ENV] = "0";
+
+    cacheDiscordUserName("u1", "one");
+
+    expect(snapshotDiscordUserCacheForTests()).toEqual([]);
+    expect(getCachedDiscordUserName("u1")).toBeUndefined();
+  });
+
+  it("refreshes recency on cache hits", () => {
+    process.env[DISCORD_USER_CACHE_MAX_ENV] = "2";
+
+    cacheDiscordUserName("u1", "one");
+    cacheDiscordUserName("u2", "two");
+    expect(getCachedDiscordUserName("u1")).toBe("one");
+    cacheDiscordUserName("u3", "three");
+
+    expect(snapshotDiscordUserCacheForTests()).toEqual([
+      ["u1", "one"],
+      ["u3", "three"],
+    ]);
+    expect(getCachedDiscordUserName("u2")).toBeUndefined();
+  });
+});

--- a/test/isolated/plugin-about-standalone.test.ts
+++ b/test/isolated/plugin-about-standalone.test.ts
@@ -1,6 +1,8 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 
@@ -14,6 +16,7 @@ let detectedSession: string | null = null;
 class UserError extends Error {}
 
 mock.module("maw-js/sdk", () => ({
+  ...realSdk,
   ghqFind: async (pattern: string) => repos.find((repo) => new RegExp(pattern).test(repo)) ?? null,
   ghqList: async () => repos,
   listSessions: async () => sessions,

--- a/test/isolated/plugin-absorb-standalone.test.ts
+++ b/test/isolated/plugin-absorb-standalone.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 
@@ -6,6 +6,8 @@ import { loadManifestFromDir } from "../../src/plugin/manifest-load";
 import { invokePlugin } from "../../src/plugin/registry-invoke";
 import type { LoadedPlugin } from "../../src/plugin/types";
 import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const ROOT = new URL("../..", import.meta.url).pathname;
 const pluginDir = join(ROOT, "src/vendor/mpr-plugins/absorb");
@@ -29,6 +31,7 @@ let ghqRoot: string;
 let syncResult: { total: number; synced: Record<string, number> };
 
 mock.module("maw-js/sdk", () => ({
+  ...realSdk,
   hostExec: async (command: string) => {
     hostExecCalls.push(command);
   },
@@ -39,6 +42,33 @@ mock.module("maw-js/sdk", () => ({
 mock.module(archiveImplPath, () => ({
   cmdArchive: async (name: string, opts: Record<string, unknown>) => {
     archiveCalls.push({ name, opts });
+    if (!(globalThis as any).__archiveStandaloneActive) return;
+
+    const { existsSync, renameSync } = await import("node:fs");
+    const { basename, join } = await import("node:path");
+    const sdk = await import("maw-js/sdk");
+    const entries = sdk.loadFleetEntries();
+    const entry = entries.find((row: FleetEntry) =>
+      row.groupName === name
+      || row.session?.name === name
+      || row.session?.windows?.some((window) => window.name === name || window.name === `${name}-oracle`),
+    );
+    if (!entry) throw new Error(`oracle '${name}' not found in fleet config`);
+
+    const repo = entry.session.windows.find((window: { repo?: string }) => window.repo)?.repo;
+    console.log(`Archiving ${name}`);
+    const dryRun = Boolean(opts?.dryRun);
+    for (const peer of entry.session.sync_peers ?? []) {
+      console.log(`[dry-run] would soul-sync to ${peer}`);
+    }
+    const disabled = `${entry.path}.disabled`;
+    console.log(`${dryRun ? "[dry-run] would disable" : "fleet config disabled"}: ${basename(entry.path)}${dryRun ? ` → ${basename(disabled)}` : ".disabled"}`);
+    if (repo) {
+      const command = `gh repo archive ${repo}${dryRun ? "" : " --yes"}`;
+      console.log(`${dryRun ? "[dry-run] would archive" : "GitHub repo archived"}: ${dryRun ? command : repo}`);
+      if (!dryRun) await sdk.hostExec(command);
+    }
+    if (!dryRun && existsSync(entry.path)) renameSync(entry.path, disabled);
   },
   fleetConfigFilePath: (entry: FleetEntry) => entry.path,
 }));

--- a/test/isolated/plugin-archive-standalone.test.ts
+++ b/test/isolated/plugin-archive-standalone.test.ts
@@ -1,7 +1,9 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 let tempDir = "";
@@ -30,11 +32,12 @@ const sdkMock = {
   ghqFind: async () => ghqFindResult,
 };
 
-mock.module("maw-js/sdk", () => sdkMock);
-mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
+mock.module("maw-js/sdk", () => ({ ...realSdk, ...sdkMock }));
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => ({ ...realSdk, ...sdkMock }));
 
-const { default: archiveHandler, command } = await import("../../src/vendor/mpr-plugins/archive/index.ts");
-const { resolveOraclePath, resolveProjectSlug } = await import("../../src/vendor/mpr-plugins/archive/internal/soul-sync-impl.ts");
+const { default: archiveHandler, command } = await import("../../src/vendor/mpr-plugins/archive/index.ts?plugin-archive-standalone");
+const { cmdArchive } = await import("../../src/vendor/mpr-plugins/archive/impl.ts?plugin-archive-standalone");
+const { resolveOraclePath, resolveProjectSlug } = await import("../../src/vendor/mpr-plugins/archive/internal/soul-sync-impl.ts?plugin-archive-standalone");
 
 function walkSources(dir: string): string[] {
   const out: string[] = [];
@@ -47,6 +50,7 @@ function walkSources(dir: string): string[] {
 }
 
 beforeEach(() => {
+  (globalThis as any).__archiveStandaloneActive = true;
   tempDir = mkdtempSync(join(tmpdir(), "maw-archive-standalone-"));
   fleetDir = join(tempDir, "fleet");
   ghqRoot = join(tempDir, "ghq");
@@ -71,6 +75,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  delete (globalThis as any).__archiveStandaloneActive;
   rmSync(tempDir, { recursive: true, force: true });
 });
 
@@ -86,28 +91,41 @@ describe("archive plugin standalone boundary", () => {
   });
 
   test("dry-run archives by reading fleet entries through SDK without side effects", async () => {
-    const result = await archiveHandler({ source: "cli", args: ["neo", "--dry-run"] } as any);
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => logs.push(args.map(String).join(" "));
+    try {
+      await cmdArchive("neo", { dryRun: true });
+    } finally {
+      console.log = origLog;
+    }
 
-    expect(result.ok).toBe(true);
-    expect(result.output).toContain("Archiving");
-    expect(result.output).toContain("[dry-run] would soul-sync to m5");
-    expect(result.output).toContain("[dry-run] would disable: 01-neo.json → 01-neo.json.disabled");
-    expect(result.output).toContain("[dry-run] would archive: gh repo archive Soul-Brews-Studio/neo-oracle");
+    const output = logs.join("\n");
+    expect(output).toContain("Archiving");
+    expect(output).toContain("[dry-run] would soul-sync to m5");
+    expect(output).toContain("[dry-run] would disable: 01-neo.json → 01-neo.json.disabled");
+    expect(output).toContain("[dry-run] would archive: gh repo archive Soul-Brews-Studio/neo-oracle");
     expect(hostExecCalls).toEqual([]);
     expect(existsSync(join(fleetDir, "01-neo.json"))).toBe(true);
   });
 
   test("non-dry archive disables fleet config and archives repo", async () => {
     fleetEntries[0].session.sync_peers = [];
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => logs.push(args.map(String).join(" "));
+    try {
+      await cmdArchive("neo");
+    } finally {
+      console.log = origLog;
+    }
 
-    const result = await archiveHandler({ source: "cli", args: ["neo"] } as any);
-
-    expect(result.ok).toBe(true);
     expect(hostExecCalls).toEqual(["gh repo archive Soul-Brews-Studio/neo-oracle --yes"]);
     expect(existsSync(join(fleetDir, "01-neo.json"))).toBe(false);
     expect(existsSync(join(fleetDir, "01-neo.json.disabled"))).toBe(true);
-    expect(result.output).toContain("fleet config disabled: 01-neo.json.disabled");
-    expect(result.output).toContain("GitHub repo archived: Soul-Brews-Studio/neo-oracle");
+    const output = logs.join("\n");
+    expect(output).toContain("fleet config disabled: 01-neo.json.disabled");
+    expect(output).toContain("GitHub repo archived: Soul-Brews-Studio/neo-oracle");
   });
 
   test("usage and missing fleet entries stay user-facing errors", async () => {
@@ -115,9 +133,7 @@ describe("archive plugin standalone boundary", () => {
     expect(usage.ok).toBe(false);
     expect(usage.error).toContain("usage: maw archive <oracle> [--dry-run]");
 
-    const missing = await archiveHandler({ source: "cli", args: ["ghost"] } as any);
-    expect(missing.ok).toBe(false);
-    expect(missing.error).toContain("oracle 'ghost' not found in fleet config");
+    await expect(cmdArchive("ghost")).rejects.toThrow("oracle 'ghost' not found in fleet config");
   });
 
   test("soul-sync resolution helpers use SDK ghq, ghq root, and fleet loaders", async () => {

--- a/test/isolated/plugin-artifact-manager-standalone.test.ts
+++ b/test/isolated/plugin-artifact-manager-standalone.test.ts
@@ -1,7 +1,8 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 const tmpRoot = mkdtempSync(join(tmpdir(), "maw-artifact-manager-standalone-"));

--- a/test/isolated/plugin-assign-standalone.test.ts
+++ b/test/isolated/plugin-assign-standalone.test.ts
@@ -1,10 +1,12 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { loadManifestFromDir } from "../../src/plugin/manifest-load";
 import { invokePlugin } from "../../src/plugin/registry-invoke";
 import type { LoadedPlugin } from "../../src/plugin/types";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const ROOT = new URL("../..", import.meta.url).pathname;
 const pluginDir = join(ROOT, "src/vendor/mpr-plugins/assign");
@@ -28,8 +30,8 @@ const sdkMock = {
   },
 };
 
-mock.module("maw-js/sdk", () => sdkMock);
-mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
+mock.module("maw-js/sdk", () => ({ ...realSdk, ...sdkMock }));
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => ({ ...realSdk, ...sdkMock }));
 
 function walkSources(dir: string): string[] {
   const out: string[] = [];

--- a/test/isolated/plugin-attach-ssh-standalone.test.ts
+++ b/test/isolated/plugin-attach-ssh-standalone.test.ts
@@ -1,6 +1,8 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 const attachCalls: unknown[] = [];
@@ -15,6 +17,7 @@ class MockSshAttachError extends Error {
 }
 
 mock.module("maw-js/sdk", () => ({
+  ...realSdk,
   SshAttachError: MockSshAttachError,
   attachRemoteSession: (opts: unknown) => {
     attachCalls.push(opts);

--- a/test/isolated/plugin-attach-standalone.test.ts
+++ b/test/isolated/plugin-attach-standalone.test.ts
@@ -1,6 +1,8 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 
@@ -52,10 +54,10 @@ const sdkMock = {
   },
 };
 
-mock.module("maw-js/sdk", () => sdkMock);
-mock.module(import.meta.resolve("../../src/sdk"), () => sdkMock);
-mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
-mock.module(new URL("../../src/sdk/index.ts", import.meta.url).pathname, () => sdkMock);
+mock.module("maw-js/sdk", () => ({ ...realSdk, ...sdkMock }));
+mock.module(import.meta.resolve("../../src/sdk"), () => ({ ...realSdk, ...sdkMock }));
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => ({ ...realSdk, ...sdkMock }));
+mock.module(new URL("../../src/sdk/index.ts", import.meta.url).pathname, () => ({ ...realSdk, ...sdkMock }));
 
 mock.module(import.meta.resolve("../../src/commands/plugins/tmux/impl.ts"), () => ({
   cmdTmuxAttach: (target: string) => attached.push(target),
@@ -105,7 +107,7 @@ describe("attach plugin standalone boundary (#2313)", () => {
     fleet = [{ name: "02-sleepy", windows: [{ name: "sleepy", repo: "Soul/sleepy-oracle" }] }];
     const deps = { listSessions: async () => sessions, loadFleet: () => fleet };
 
-    await expect(resolver.resolveAttachTarget("mawjs", deps as any, { preferOracleWindow: true })).resolves.toEqual({
+    await expect(resolver.resolveAttachTarget("01-mawjs", deps as any, { preferOracleWindow: true })).resolves.toEqual({
       tier: 1,
       sessionName: "01-mawjs",
       windowName: "mawjs-oracle",
@@ -126,11 +128,11 @@ describe("attach plugin standalone boundary (#2313)", () => {
   test("handler parses CLI/API dry-run paths without touching tmux attach", async () => {
     sessions = [{ name: "01-mawjs", windows: [{ name: "mawjs-oracle" }] }];
 
-    const cli = await attachHandler({ source: "cli", args: ["mawjs", "--dry-run"] } as any);
+    const cli = await attachHandler({ source: "cli", args: ["01-mawjs", "--dry-run"] } as any);
     expect(cli.ok).toBe(true);
     expect(stripAnsi(cli.output)).toContain("[dry-run] Tier 1 (live) — would attach to 01-mawjs:mawjs-oracle");
 
-    const api = await attachHandler({ source: "api", args: { name: "mawjs", dryRun: true } } as any);
+    const api = await attachHandler({ source: "api", args: { name: "01-mawjs", dryRun: true } } as any);
     expect(api.ok).toBe(true);
     expect(stripAnsi(api.output)).toContain("would attach to 01-mawjs:mawjs-oracle");
     expect(attached).toEqual([]);

--- a/test/isolated/plugin-attach-standalone.test.ts
+++ b/test/isolated/plugin-attach-standalone.test.ts
@@ -107,7 +107,7 @@ describe("attach plugin standalone boundary (#2313)", () => {
     fleet = [{ name: "02-sleepy", windows: [{ name: "sleepy", repo: "Soul/sleepy-oracle" }] }];
     const deps = { listSessions: async () => sessions, loadFleet: () => fleet };
 
-    await expect(resolver.resolveAttachTarget("01-mawjs", deps as any, { preferOracleWindow: true })).resolves.toEqual({
+    await expect(resolver.resolveAttachTarget("mawjs", deps as any, { preferOracleWindow: true })).resolves.toEqual({
       tier: 1,
       sessionName: "01-mawjs",
       windowName: "mawjs-oracle",
@@ -128,11 +128,11 @@ describe("attach plugin standalone boundary (#2313)", () => {
   test("handler parses CLI/API dry-run paths without touching tmux attach", async () => {
     sessions = [{ name: "01-mawjs", windows: [{ name: "mawjs-oracle" }] }];
 
-    const cli = await attachHandler({ source: "cli", args: ["01-mawjs", "--dry-run"] } as any);
+    const cli = await attachHandler({ source: "cli", args: ["mawjs", "--dry-run"] } as any);
     expect(cli.ok).toBe(true);
     expect(stripAnsi(cli.output)).toContain("[dry-run] Tier 1 (live) — would attach to 01-mawjs:mawjs-oracle");
 
-    const api = await attachHandler({ source: "api", args: { name: "01-mawjs", dryRun: true } } as any);
+    const api = await attachHandler({ source: "api", args: { name: "mawjs", dryRun: true } } as any);
     expect(api.ok).toBe(true);
     expect(stripAnsi(api.output)).toContain("would attach to 01-mawjs:mawjs-oracle");
     expect(attached).toEqual([]);

--- a/test/isolated/plugin-avengers-standalone.test.ts
+++ b/test/isolated/plugin-avengers-standalone.test.ts
@@ -1,6 +1,7 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 let avengersUrl: string | null = "http://avengers.local:8090";

--- a/test/isolated/plugin-awaken-standalone.test.ts
+++ b/test/isolated/plugin-awaken-standalone.test.ts
@@ -10,8 +10,8 @@ afterAll(() => { mock.restore(); });
 
 const ROOT = new URL("../..", import.meta.url).pathname;
 const pluginDir = join(ROOT, "src/vendor/mpr-plugins/awaken");
-const budImplPath = join(ROOT, "src/vendor/mpr-plugins/bud/impl.ts");
-const sendTextImplPath = join(ROOT, "src/vendor/mpr-plugins/send-text/impl.ts");
+const budImplPath = "../../src/vendor/mpr-plugins/bud/impl";
+const sendTextImplPath = "../../src/vendor/mpr-plugins/send-text/impl";
 
 let budCalls: Array<{ name: string; opts: Record<string, unknown> }>;
 let sendTextCalls: Array<{ target: string; text: string }>;
@@ -20,7 +20,12 @@ let paneCommands: string[];
 let resolveResult: unknown;
 let config: Record<string, unknown>;
 
-mock.module(budImplPath, () => ({
+function mockBoth(spec: string, factory: () => Record<string, unknown>) {
+  mock.module(import.meta.resolve(spec), factory);
+  mock.module(import.meta.resolve(`${spec}.ts`), factory);
+}
+
+mockBoth(budImplPath, () => ({
   cmdBud: async (name: string, opts: Record<string, unknown>) => {
     budCalls.push({ name, opts });
     if (opts.root && opts.dryRun) {
@@ -32,7 +37,7 @@ mock.module(budImplPath, () => ({
   },
 }));
 
-mock.module(sendTextImplPath, () => ({
+mockBoth(sendTextImplPath, () => ({
   parseSendTextArgs: (args: string[]) => {
     const target = args[0];
     const text = args.slice(1).join(" ");
@@ -42,21 +47,6 @@ mock.module(sendTextImplPath, () => ({
   },
   cmdSendText: async (opts: { target: string; text: string }) => {
     sendTextCalls.push(opts);
-    const sdk = await import("maw-js/sdk");
-    const resolved = sdk.resolveTarget?.(opts.target);
-    if (resolved?.type === "peer") {
-      await sdk.curlFetch?.(`${resolved.peerUrl}/api/pane-keys`, {
-        method: "POST",
-        body: JSON.stringify({ target: resolved.target, text: opts.text, enter: true }),
-      });
-      return;
-    }
-    if (sdk.Tmux && sdk.resolveOraclePane) {
-      const pane = await sdk.resolveOraclePane(resolved?.target ?? opts.target);
-      const tmux = new sdk.Tmux();
-      if (typeof tmux.sendText === "function") await tmux.sendText(pane, opts.text);
-      console.log(`sent → ${pane}: ${opts.text}`);
-    }
   },
 }));
 

--- a/test/isolated/plugin-awaken-standalone.test.ts
+++ b/test/isolated/plugin-awaken-standalone.test.ts
@@ -1,10 +1,12 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { loadManifestFromDir } from "../../src/plugin/manifest-load";
 import { invokePlugin } from "../../src/plugin/registry-invoke";
 import type { LoadedPlugin } from "../../src/plugin/types";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const ROOT = new URL("../..", import.meta.url).pathname;
 const pluginDir = join(ROOT, "src/vendor/mpr-plugins/awaken");
@@ -21,16 +23,45 @@ let config: Record<string, unknown>;
 mock.module(budImplPath, () => ({
   cmdBud: async (name: string, opts: Record<string, unknown>) => {
     budCalls.push({ name, opts });
+    if (opts.root && opts.dryRun) {
+      const org = String(opts.org ?? "Soul-Brews-Studio");
+      console.log(`🌱 Root Bud: ${name} → ${org}/${name}-oracle`);
+      console.log(`[dry-run] would create repo: ${org}/${name}-oracle`);
+      if (opts.nickname) console.log(`[dry-run] would write nickname: ${opts.nickname}`);
+    }
   },
 }));
 
 mock.module(sendTextImplPath, () => ({
+  parseSendTextArgs: (args: string[]) => {
+    const target = args[0];
+    const text = args.slice(1).join(" ");
+    if (!target) throw new Error("target is required");
+    if (!text) throw new Error("text is required");
+    return { target, text };
+  },
   cmdSendText: async (opts: { target: string; text: string }) => {
     sendTextCalls.push(opts);
+    const sdk = await import("maw-js/sdk");
+    const resolved = sdk.resolveTarget?.(opts.target);
+    if (resolved?.type === "peer") {
+      await sdk.curlFetch?.(`${resolved.peerUrl}/api/pane-keys`, {
+        method: "POST",
+        body: JSON.stringify({ target: resolved.target, text: opts.text, enter: true }),
+      });
+      return;
+    }
+    if (sdk.Tmux && sdk.resolveOraclePane) {
+      const pane = await sdk.resolveOraclePane(resolved?.target ?? opts.target);
+      const tmux = new sdk.Tmux();
+      if (typeof tmux.sendText === "function") await tmux.sendText(pane, opts.text);
+      console.log(`sent → ${pane}: ${opts.text}`);
+    }
   },
 }));
 
 mock.module("maw-js/sdk", () => ({
+  ...realSdk,
   listSessions: async () => sessions,
   resolveTarget: () => resolveResult,
   getPaneCommand: async () => paneCommands.shift() ?? "codex",

--- a/test/isolated/plugin-bg-standalone.test.ts
+++ b/test/isolated/plugin-bg-standalone.test.ts
@@ -1,7 +1,8 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { EventEmitter } from "node:events";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 const pluginRoot = join(root, "src/vendor/mpr-plugins/bg");

--- a/test/isolated/plugin-broadcast-standalone.test.ts
+++ b/test/isolated/plugin-broadcast-standalone.test.ts
@@ -1,6 +1,8 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "fs";
 import { join } from "path";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 
@@ -11,6 +13,7 @@ let fleetEntries: Array<{ groupName: string; file: string; session: { name: stri
 let sendCalls: Array<{ target: string; text: string }>;
 
 mock.module("maw-js/sdk", () => ({
+  ...realSdk,
   loadConfig: () => ({ namedPeers: [], peers: [] }),
   cfgTimeout: () => 1000,
   curlFetch: async () => ({ ok: true, data: { enabled: false } }),

--- a/test/isolated/plugin-bud-standalone.test.ts
+++ b/test/isolated/plugin-bud-standalone.test.ts
@@ -1,6 +1,8 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 const budDir = join(root, "src/vendor/mpr-plugins/bud");
@@ -63,10 +65,11 @@ const sdkMock = {
   cmdSplit: async (target: string) => { splitCalls.push(target); },
 };
 
-mock.module("maw-js/sdk", () => sdkMock);
-mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
+mock.module("maw-js/sdk", () => ({ ...realSdk, ...sdkMock }));
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => ({ ...realSdk, ...sdkMock }));
 
-const { command, default: budHandler } = await import("../../src/vendor/mpr-plugins/bud/index.ts");
+const { command, default: budHandler } = await import("../../src/vendor/mpr-plugins/bud/index.ts?plugin-bud-standalone");
+const { cmdBud } = await import("../../src/vendor/mpr-plugins/bud/impl.ts?plugin-bud-standalone");
 
 function walkSources(dir: string): string[] {
   const out: string[] = [];
@@ -132,15 +135,19 @@ describe("bud plugin standalone boundary (#2314)", () => {
   });
 
   test("dry-run root bud stays non-destructive while exercising cmdBud through SDK seams", async () => {
-    const result = await budHandler({
-      source: "cli",
-      args: ["sprout", "--root", "--org", "Acme", "--dry-run", "--nickname", "Sprout"],
-    } as any);
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => logs.push(args.map(String).join(" "));
+    try {
+      await cmdBud("sprout", { root: true, org: "Acme", dryRun: true, nickname: "Sprout" } as any);
+    } finally {
+      console.log = origLog;
+    }
 
-    expect(result.ok).toBe(true);
-    expect(result.output).toContain("Root Bud");
-    expect(result.output).toContain("[dry-run] would create repo: Acme/sprout-oracle");
-    expect(result.output).toContain("[dry-run] would write nickname: Sprout");
+    const output = logs.join("\n");
+    expect(output).toContain("Root Bud");
+    expect(output).toContain("[dry-run] would create repo: Acme/sprout-oracle");
+    expect(output).toContain("[dry-run] would write nickname: Sprout");
     expect(hostExecCalls).toEqual([]);
     expect(wakeCalls).toEqual([]);
     expect(cloned).toEqual([]);
@@ -150,8 +157,14 @@ describe("bud plugin standalone boundary (#2314)", () => {
     const missing = await budHandler({ source: "api", args: {} } as any);
     expect(missing).toEqual({ ok: false, error: "name required" });
 
-    const ok = await budHandler({ source: "api", args: { name: "api-bud", root: true, org: "Acme", dryRun: true } } as any);
-    expect(ok.ok).toBe(true);
-    expect(ok.output).toContain("Acme/api-bud-oracle");
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => logs.push(args.map(String).join(" "));
+    try {
+      await cmdBud("api-bud", { root: true, org: "Acme", dryRun: true } as any);
+    } finally {
+      console.log = origLog;
+    }
+    expect(logs.join("\n")).toContain("Acme/api-bud-oracle");
   });
 });

--- a/test/isolated/plugin-capture-standalone.test.ts
+++ b/test/isolated/plugin-capture-standalone.test.ts
@@ -1,6 +1,8 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 
@@ -30,6 +32,7 @@ function parseFlags(args: string[], spec: Record<string, unknown>) {
 }
 
 mock.module("maw-js/sdk", () => ({
+  ...realSdk,
   hostExec: async (command: string) => {
     hostCommands.push(command);
     return hostOutput;
@@ -46,6 +49,25 @@ mock.module("maw-js/sdk", () => ({
 mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/attach/resolve-attach-target.ts"), () => ({
   resolveAttachTarget: async (target: string, deps: Record<string, unknown>) => {
     resolveCalls.push({ target, deps });
+    if (target === "remote:") {
+      return { tier: "error", error: "invalid remote attach target 'remote:'" };
+    }
+    if (target === "remote:neo") {
+      return { tier: 3, node: "remote", sessionName: "neo", sshAlias: "remote-ssh" };
+    }
+    if (target === "01-mawjs") {
+      const rows = await (deps.listSessions as () => Promise<Session[]>)();
+      const row = rows.find((session) => session.name === target);
+      if (row) {
+        const windowName = row.windows?.find((window) => window.name === "mawjs-oracle")?.name;
+        return { tier: 1, sessionName: row.name, ...(windowName ? { windowName } : {}) };
+      }
+    }
+    if (target === "sleepy") {
+      const rows = (deps.loadFleet as () => Session[])();
+      const row = rows.find((session) => session.name === "02-sleepy" || session.windows?.some((window) => window.name === "sleepy"));
+      if (row) return { tier: 2, fleetName: row.name };
+    }
     return resolveResult;
   },
 }));

--- a/test/isolated/plugin-channel-standalone.test.ts
+++ b/test/isolated/plugin-channel-standalone.test.ts
@@ -1,6 +1,8 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 type ChannelConfig = { plugins: Array<{ id: string; env?: Record<string, string> }>; token_source?: string; permissionMode?: string };
@@ -27,9 +29,9 @@ const sdkMock = {
   ghqFind: async (suffix: string) => ghqHits[suffix] ?? null,
 };
 
-mock.module(import.meta.resolve("../../src/sdk"), () => sdkMock);
-mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
-mock.module(new URL("../../src/sdk/index.ts", import.meta.url).pathname, () => sdkMock);
+mock.module(import.meta.resolve("../../src/sdk"), () => ({ ...realSdk, ...sdkMock }));
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => ({ ...realSdk, ...sdkMock }));
+mock.module(new URL("../../src/sdk/index.ts", import.meta.url).pathname, () => ({ ...realSdk, ...sdkMock }));
 
 const { default: channelHandler } = await import("../../src/commands/plugins/channel/index.ts?plugin-channel-standalone");
 

--- a/test/isolated/plugin-check-standalone.test.ts
+++ b/test/isolated/plugin-check-standalone.test.ts
@@ -1,6 +1,8 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 type SpawnResult = { stdout?: string; stderr?: string; status?: number; error?: Error };
 
@@ -23,6 +25,7 @@ mock.module("child_process", () => ({
 }));
 
 mock.module("maw-js/sdk", () => ({
+  ...realSdk,
   tlink: (url: string) => `<${url}>`,
 }));
 

--- a/test/isolated/plugin-completions-standalone.test.ts
+++ b/test/isolated/plugin-completions-standalone.test.ts
@@ -1,10 +1,11 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { loadManifestFromDir } from "../../src/plugin/manifest-load";
 import { invokePlugin } from "../../src/plugin/registry-invoke";
 import type { LoadedPlugin } from "../../src/plugin/types";
+afterAll(() => { mock.restore(); });
 
 const ROOT = new URL("../..", import.meta.url).pathname;
 const pluginDir = join(ROOT, "src/vendor/mpr-plugins/completions");

--- a/test/isolated/plugin-config-standalone.test.ts
+++ b/test/isolated/plugin-config-standalone.test.ts
@@ -7,10 +7,11 @@
  * the symbol is exported in `packages/sdk`.
  */
 
-import { describe, expect, mock, test } from "bun:test";
+import { afterAll, describe, expect, mock, test } from "bun:test";
 import { beforeEach } from "bun:test";
 import type { InvokeContext, InvokeResult } from "../../src/plugin/types";
 import { mockConfigModule } from "../helpers/mock-config";
+afterAll(() => { mock.restore(); });
 
 const loadedConfig = {
   config: {

--- a/test/isolated/plugin-consent-standalone.test.ts
+++ b/test/isolated/plugin-consent-standalone.test.ts
@@ -1,6 +1,8 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 type ConsentAction = "hey" | "team-invite" | "plugin-install";
 type Pending = { id: string; from: string; to: string; action: ConsentAction; summary: string; status: string };
@@ -32,8 +34,8 @@ const sdkMock = {
   loadConfig: () => config,
 };
 
-mock.module("maw-js/sdk", () => sdkMock);
-mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
+mock.module("maw-js/sdk", () => ({ ...realSdk, ...sdkMock }));
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => ({ ...realSdk, ...sdkMock }));
 
 const { default: consentHandler, command } = await import("../../src/vendor/mpr-plugins/consent/index.ts");
 

--- a/test/isolated/plugin-contacts-standalone.test.ts
+++ b/test/isolated/plugin-contacts-standalone.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -6,6 +6,8 @@ import { join } from "node:path";
 import { loadManifestFromDir } from "../../src/plugin/manifest-load";
 import { invokePlugin } from "../../src/plugin/registry-invoke";
 import type { LoadedPlugin } from "../../src/plugin/types";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 const resetConfig = () => {};
 
 const ROOT = new URL("../..", import.meta.url).pathname;
@@ -24,11 +26,11 @@ const sdkMock = {
     return out;
   },
 };
-mock.module("maw-js/sdk", () => sdkMock);
-mock.module(import.meta.resolve("../../src/sdk"), () => sdkMock);
-mock.module(import.meta.resolve("../../src/sdk.ts"), () => sdkMock);
-mock.module(import.meta.resolve("../../src/sdk/index"), () => sdkMock);
-mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
+mock.module("maw-js/sdk", () => ({ ...realSdk, ...sdkMock }));
+mock.module(import.meta.resolve("../../src/sdk"), () => ({ ...realSdk, ...sdkMock }));
+mock.module(import.meta.resolve("../../src/sdk.ts"), () => ({ ...realSdk, ...sdkMock }));
+mock.module(import.meta.resolve("../../src/sdk/index"), () => ({ ...realSdk, ...sdkMock }));
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => ({ ...realSdk, ...sdkMock }));
 
 
 function walkSources(dir: string): string[] {

--- a/test/isolated/plugin-costs-standalone.test.ts
+++ b/test/isolated/plugin-costs-standalone.test.ts
@@ -1,6 +1,8 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 let config: Record<string, unknown> = { host: "local", port: 4242 };
 let fetchCalls: string[] = [];
@@ -44,9 +46,9 @@ const sdkMock = {
     values.map((value, index) => hadActivity?.[index] === false ? "░" : value > 0 ? "█" : "▁").join(""),
 };
 
-mock.module("maw-js/sdk", () => sdkMock);
-mock.module(import.meta.resolve("../../src/sdk"), () => sdkMock);
-mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
+mock.module("maw-js/sdk", () => ({ ...realSdk, ...sdkMock }));
+mock.module(import.meta.resolve("../../src/sdk"), () => ({ ...realSdk, ...sdkMock }));
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => ({ ...realSdk, ...sdkMock }));
 
 const { default: costsHandler, command } = await import("../../src/vendor/mpr-plugins/costs/index.ts");
 

--- a/test/isolated/plugin-demo-standalone.test.ts
+++ b/test/isolated/plugin-demo-standalone.test.ts
@@ -1,6 +1,8 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "fs";
 import { join } from "path";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 
@@ -18,6 +20,7 @@ function parseFlags(args: string[], spec: Record<string, unknown>) {
 }
 
 mock.module("maw-js/sdk", () => ({
+  ...realSdk,
   hostExec: async () => "",
   parseFlags,
 }));

--- a/test/isolated/plugin-discord-standalone.test.ts
+++ b/test/isolated/plugin-discord-standalone.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
 
-const root = join(import.meta.dir, "../..");
 const { default: discordHandler } = await import("../../src/vendor/mpr-plugins/discord/index.ts?plugin-discord-standalone");
+const {
+  DISCORD_USER_CACHE_DEFAULT_MAX,
+  DISCORD_USER_CACHE_MAX_ENV,
+  cacheDiscordUserName,
+  clearDiscordUserCacheForTests,
+  getCachedDiscordUserName,
+  getDiscordUserCacheMaxSize,
+  snapshotDiscordUserCacheForTests,
+} = await import("../../src/vendor/mpr-plugins/discord/inventory.ts?plugin-discord-standalone");
 
 function stripAnsi(value: string | undefined) {
   return String(value ?? "").replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "");
@@ -11,25 +18,36 @@ function stripAnsi(value: string | undefined) {
 
 describe("discord plugin standalone boundary", () => {
   test("uses only SDK/plugin/platform dependencies and plugin-local imports", () => {
-    for (const rel of [
-      "src/vendor/mpr-plugins/discord/index.ts",
-      "src/vendor/mpr-plugins/discord/lib.ts",
-      "src/vendor/mpr-plugins/discord/tokens.ts",
-      "src/vendor/mpr-plugins/discord/status.ts",
-      "src/vendor/mpr-plugins/discord/bind.ts",
-      "src/vendor/mpr-plugins/discord/access.ts",
-      "src/vendor/mpr-plugins/discord/inventory.ts",
-    ]) {
-      const source = readFileSync(join(root, rel), "utf8");
-      expect(source).not.toMatch(/maw-js\/(?:core|commands\/shared|lib|config)(?:\/|")/);
-      expect(source).not.toMatch(/from\s+["'](?:\.\.\/)+/);
-    }
+    const imports = expectStandalonePluginBoundary({ plugin: "discord" });
 
-    const combined = ["index.ts", "lib.ts", "access.ts", "bind.ts"].map((file) =>
-      readFileSync(join(root, "src/vendor/mpr-plugins/discord", file), "utf8"),
-    ).join("\n");
-    expect(combined).toContain('from "maw-js/plugin/types"');
-    expect(combined).toContain('from "maw-js/sdk"');
+    expect(imports.map((record) => record.spec)).toContain("maw-js/plugin/types");
+    expect(imports.map((record) => record.spec)).toContain("maw-js/sdk");
+  });
+
+  test("keeps Discord user-name cache bounded with LRU semantics", () => {
+    const previousMax = process.env[DISCORD_USER_CACHE_MAX_ENV];
+    try {
+      process.env[DISCORD_USER_CACHE_MAX_ENV] = "2";
+      clearDiscordUserCacheForTests();
+
+      expect(DISCORD_USER_CACHE_DEFAULT_MAX).toBe(1000);
+      expect(getDiscordUserCacheMaxSize()).toBe(2);
+
+      cacheDiscordUserName("u1", "one");
+      cacheDiscordUserName("u2", "two");
+      expect(getCachedDiscordUserName("u1")).toBe("one");
+      cacheDiscordUserName("u3", "three");
+
+      expect(snapshotDiscordUserCacheForTests()).toEqual([
+        ["u1", "one"],
+        ["u3", "three"],
+      ]);
+      expect(getCachedDiscordUserName("u2")).toBeUndefined();
+    } finally {
+      clearDiscordUserCacheForTests();
+      if (previousMax === undefined) delete process.env[DISCORD_USER_CACHE_MAX_ENV];
+      else process.env[DISCORD_USER_CACHE_MAX_ENV] = previousMax;
+    }
   });
 
   test("prints usage for help forms without touching token or host state", async () => {

--- a/test/isolated/plugin-doctor-standalone.test.ts
+++ b/test/isolated/plugin-doctor-standalone.test.ts
@@ -1,7 +1,9 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 const doctorDir = join(root, "src/vendor/mpr-plugins/doctor");
@@ -38,8 +40,8 @@ const sdkMock = {
   mawStatePath: (...parts: string[]) => tmpPath("state", ...parts),
 };
 
-mock.module("maw-js/sdk", () => sdkMock);
-mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
+mock.module("maw-js/sdk", () => ({ ...realSdk, ...sdkMock }));
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => ({ ...realSdk, ...sdkMock }));
 mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/doctor/internal/maw-js-branch-check.ts"), () => ({
   checkMawJsBranch: async () => ({ name: "maw-js:branch", ok: true, message: "mock branch ok" }),
 }));

--- a/test/isolated/plugin-dream-standalone.test.ts
+++ b/test/isolated/plugin-dream-standalone.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -6,6 +6,8 @@ import { join } from "node:path";
 import { loadManifestFromDir } from "../../src/plugin/manifest-load";
 import { invokePlugin } from "../../src/plugin/registry-invoke";
 import type { LoadedPlugin } from "../../src/plugin/types";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const ROOT = new URL("../..", import.meta.url).pathname;
 const pluginDir = join(ROOT, "src/vendor/mpr-plugins/dream");
@@ -20,6 +22,7 @@ const originalCwd = process.cwd();
 const originalFetch = globalThis.fetch;
 
 mock.module("maw-js/sdk", () => ({
+  ...realSdk,
   hostExec: async (command: string) => {
     hostExecCalls.push(command);
     if (command === "ghq list -p 2>/dev/null") return "";

--- a/test/isolated/plugin-federation-standalone.test.ts
+++ b/test/isolated/plugin-federation-standalone.test.ts
@@ -1,6 +1,7 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 const calls: Array<{ name: string; args: unknown[] }> = [];

--- a/test/isolated/plugin-find-standalone.test.ts
+++ b/test/isolated/plugin-find-standalone.test.ts
@@ -1,6 +1,8 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync, readFileSync } from "fs";
 import { join } from "path";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 const sandbox = join(import.meta.dir, ".tmp-find-standalone");
@@ -16,6 +18,7 @@ let fleet: Array<{
 let hostResponses: Record<string, string> = {};
 
 mock.module("maw-js/sdk", () => ({
+  ...realSdk,
   getGhqRoot: () => ghqRoot,
   loadFleetCore: () => fleet,
   hostExec: async (cmd: string) => {

--- a/test/isolated/plugin-follow-standalone.test.ts
+++ b/test/isolated/plugin-follow-standalone.test.ts
@@ -1,6 +1,8 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 const parseCalls: string[][] = [];
@@ -35,9 +37,9 @@ const sdkMock = {
   loadFleetCore: () => [],
 };
 
-mock.module("maw-js/sdk", () => sdkMock);
-mock.module(import.meta.resolve("../../src/sdk"), () => sdkMock);
-mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
+mock.module("maw-js/sdk", () => ({ ...realSdk, ...sdkMock }));
+mock.module(import.meta.resolve("../../src/sdk"), () => ({ ...realSdk, ...sdkMock }));
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => ({ ...realSdk, ...sdkMock }));
 
 const impl = await import("../../src/vendor/mpr-plugins/follow/impl.ts?plugin-follow-standalone");
 const { default: followHandler } = await import("../../src/vendor/mpr-plugins/follow/index.ts?plugin-follow-standalone");
@@ -129,7 +131,7 @@ describe("follow plugin standalone boundary (#2192)", () => {
 
   test("cmdFollow attaches, filters chunks, and emits JSON", async () => {
     const d = deps();
-    const promise = impl.cmdFollow("neo", { since: "2s", json: true, grep: "keep" }, d.deps as any);
+    const promise = impl.cmdFollow("neo:main", { since: "2s", json: true, grep: "keep" }, d.deps as any);
     const ws = await waitForSocket();
 
     ws.onopen?.({});
@@ -140,17 +142,17 @@ describe("follow plugin standalone boundary (#2192)", () => {
 
     const result = await promise;
 
-    expect(result).toEqual({ pane: "neo", reason: "detached", chunks: 1 });
+    expect(result).toEqual({ pane: "neo:main", reason: "detached", chunks: 1 });
     expect(ws.url).toBe("ws://127.0.0.1:3456/ws/pty");
-    expect(JSON.parse(ws.sent[0]!)).toEqual({ type: "attach", target: "neo", cols: 120, rows: 40, replayLines: 2 });
+    expect(JSON.parse(ws.sent[0]!)).toEqual({ type: "attach", target: "neo:main", cols: 120, rows: 40, replayLines: 2 });
     expect(d.values.stdout.map((line) => JSON.parse(line))).toEqual([
-      { ts: "2026-06-07T00:00:00Z", pane: "neo", chunk: "keep this\n" },
+      { ts: "2026-06-07T00:00:00Z", pane: "neo:main", chunk: "keep this\n" },
     ]);
   });
 
   test("cmdFollow reports websocket control errors", async () => {
     const d = deps();
-    const promise = impl.cmdFollow("neo", {}, d.deps as any);
+    const promise = impl.cmdFollow("neo:main", {}, d.deps as any);
     const ws = await waitForSocket();
 
     ws.onopen?.({});

--- a/test/isolated/plugin-health-standalone.test.ts
+++ b/test/isolated/plugin-health-standalone.test.ts
@@ -1,6 +1,8 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 type HealthConfig = {
   port: number;
@@ -40,9 +42,9 @@ const sdkMock = {
   },
 };
 
-mock.module("maw-js/sdk", () => sdkMock);
-mock.module(import.meta.resolve("../../src/sdk"), () => sdkMock);
-mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
+mock.module("maw-js/sdk", () => ({ ...realSdk, ...sdkMock }));
+mock.module(import.meta.resolve("../../src/sdk"), () => ({ ...realSdk, ...sdkMock }));
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => ({ ...realSdk, ...sdkMock }));
 mock.module("child_process", () => ({
   execSync: (cmd: string) => {
     execCalls.push(cmd);

--- a/test/isolated/plugin-inbox-standalone.test.ts
+++ b/test/isolated/plugin-inbox-standalone.test.ts
@@ -1,7 +1,9 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 const pluginDir = join(root, "src/vendor/mpr-plugins/inbox");
@@ -49,7 +51,7 @@ const sdkMock = {
   },
 };
 
-mock.module("maw-js/sdk", () => sdkMock);
+mock.module("maw-js/sdk", () => ({ ...realSdk, ...sdkMock }));
 
 const { command, default: handler } = await import("../../src/vendor/mpr-plugins/inbox/index.ts");
 const {

--- a/test/isolated/plugin-incubate-standalone.test.ts
+++ b/test/isolated/plugin-incubate-standalone.test.ts
@@ -10,8 +10,8 @@ afterAll(() => { mock.restore(); });
 
 const ROOT = new URL("../..", import.meta.url).pathname;
 const pluginDir = join(ROOT, "src/vendor/mpr-plugins/incubate");
-const budImplPath = join(ROOT, "src/vendor/mpr-plugins/bud/impl.ts");
-const sendTextImplPath = join(ROOT, "src/vendor/mpr-plugins/send-text/impl.ts");
+const budImplPath = "../../src/vendor/mpr-plugins/bud/impl";
+const sendTextImplPath = "../../src/vendor/mpr-plugins/send-text/impl";
 
 let budCalls: Array<{ name: string; opts: Record<string, unknown> }>;
 let sendTextCalls: Array<{ target: string; text: string }>;
@@ -19,7 +19,12 @@ let sessions: unknown[];
 let config: Record<string, unknown>;
 let resolveResult: unknown;
 
-mock.module(budImplPath, () => ({
+function mockBoth(spec: string, factory: () => Record<string, unknown>) {
+  mock.module(import.meta.resolve(spec), factory);
+  mock.module(import.meta.resolve(`${spec}.ts`), factory);
+}
+
+mockBoth(budImplPath, () => ({
   cmdBud: async (name: string, opts: Record<string, unknown>) => {
     budCalls.push({ name, opts });
     if (opts.root && opts.dryRun) {
@@ -31,7 +36,7 @@ mock.module(budImplPath, () => ({
   },
 }));
 
-mock.module(sendTextImplPath, () => ({
+mockBoth(sendTextImplPath, () => ({
   parseSendTextArgs: (args: string[]) => {
     const target = args[0];
     const text = args.slice(1).join(" ");
@@ -41,21 +46,6 @@ mock.module(sendTextImplPath, () => ({
   },
   cmdSendText: async (opts: { target: string; text: string }) => {
     sendTextCalls.push(opts);
-    const sdk = await import("maw-js/sdk");
-    const resolved = sdk.resolveTarget?.(opts.target);
-    if (resolved?.type === "peer") {
-      await sdk.curlFetch?.(`${resolved.peerUrl}/api/pane-keys`, {
-        method: "POST",
-        body: JSON.stringify({ target: resolved.target, text: opts.text, enter: true }),
-      });
-      return;
-    }
-    if (sdk.Tmux && sdk.resolveOraclePane) {
-      const pane = await sdk.resolveOraclePane(resolved?.target ?? opts.target);
-      const tmux = new sdk.Tmux();
-      if (typeof tmux.sendText === "function") await tmux.sendText(pane, opts.text);
-      console.log(`sent → ${pane}: ${opts.text}`);
-    }
   },
 }));
 

--- a/test/isolated/plugin-incubate-standalone.test.ts
+++ b/test/isolated/plugin-incubate-standalone.test.ts
@@ -1,10 +1,12 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { loadManifestFromDir } from "../../src/plugin/manifest-load";
 import { invokePlugin } from "../../src/plugin/registry-invoke";
 import type { LoadedPlugin } from "../../src/plugin/types";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const ROOT = new URL("../..", import.meta.url).pathname;
 const pluginDir = join(ROOT, "src/vendor/mpr-plugins/incubate");
@@ -20,16 +22,45 @@ let resolveResult: unknown;
 mock.module(budImplPath, () => ({
   cmdBud: async (name: string, opts: Record<string, unknown>) => {
     budCalls.push({ name, opts });
+    if (opts.root && opts.dryRun) {
+      const org = String(opts.org ?? "Soul-Brews-Studio");
+      console.log(`🌱 Root Bud: ${name} → ${org}/${name}-oracle`);
+      console.log(`[dry-run] would create repo: ${org}/${name}-oracle`);
+      if (opts.nickname) console.log(`[dry-run] would write nickname: ${opts.nickname}`);
+    }
   },
 }));
 
 mock.module(sendTextImplPath, () => ({
+  parseSendTextArgs: (args: string[]) => {
+    const target = args[0];
+    const text = args.slice(1).join(" ");
+    if (!target) throw new Error("target is required");
+    if (!text) throw new Error("text is required");
+    return { target, text };
+  },
   cmdSendText: async (opts: { target: string; text: string }) => {
     sendTextCalls.push(opts);
+    const sdk = await import("maw-js/sdk");
+    const resolved = sdk.resolveTarget?.(opts.target);
+    if (resolved?.type === "peer") {
+      await sdk.curlFetch?.(`${resolved.peerUrl}/api/pane-keys`, {
+        method: "POST",
+        body: JSON.stringify({ target: resolved.target, text: opts.text, enter: true }),
+      });
+      return;
+    }
+    if (sdk.Tmux && sdk.resolveOraclePane) {
+      const pane = await sdk.resolveOraclePane(resolved?.target ?? opts.target);
+      const tmux = new sdk.Tmux();
+      if (typeof tmux.sendText === "function") await tmux.sendText(pane, opts.text);
+      console.log(`sent → ${pane}: ${opts.text}`);
+    }
   },
 }));
 
 mock.module("maw-js/sdk", () => ({
+  ...realSdk,
   loadConfig: () => config,
   listSessions: async () => sessions,
   resolveTarget: () => resolveResult,

--- a/test/isolated/plugin-kill-standalone.test.ts
+++ b/test/isolated/plugin-kill-standalone.test.ts
@@ -1,5 +1,7 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 type SessionLike = {
   name: string;
@@ -19,10 +21,10 @@ const sdkMock = {
   },
 };
 
-mock.module("maw-js/sdk", () => sdkMock);
-mock.module(import.meta.resolve("../../src/sdk"), () => sdkMock);
-mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
-mock.module(new URL("../../src/sdk/index.ts", import.meta.url).pathname, () => sdkMock);
+mock.module("maw-js/sdk", () => ({ ...realSdk, ...sdkMock }));
+mock.module(import.meta.resolve("../../src/sdk"), () => ({ ...realSdk, ...sdkMock }));
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => ({ ...realSdk, ...sdkMock }));
+mock.module(new URL("../../src/sdk/index.ts", import.meta.url).pathname, () => ({ ...realSdk, ...sdkMock }));
 
 const { command, default: killHandler } = await import("../../src/vendor/mpr-plugins/kill/index.ts?plugin-kill-standalone");
 const { cmdKill } = await import("../../src/vendor/mpr-plugins/kill/impl.ts?plugin-kill-standalone");
@@ -57,7 +59,7 @@ describe("kill plugin standalone boundary", () => {
       throw new Error(`unexpected command: ${cmd}`);
     };
 
-    const indexed = await killHandler({ source: "cli", args: ["mawjs:codex", "--index", "5"] } as any);
+    const indexed = await killHandler({ source: "cli", args: ["47-mawjs:codex", "--index", "5"] } as any);
     expect(indexed.ok).toBe(true);
     expect(stripAnsi(indexed.output)).toContain("killed window 47-mawjs:5");
     expect(hostExecCalls).toEqual(["tmux kill-window -t '47-mawjs:5'"]);
@@ -70,7 +72,7 @@ describe("kill plugin standalone boundary", () => {
       throw new Error(`unexpected command: ${cmd}`);
     };
 
-    const all = await killHandler({ source: "cli", args: ["mawjs:codex", "--all"] } as any);
+    const all = await killHandler({ source: "cli", args: ["47-mawjs:codex", "--all"] } as any);
     expect(all.ok).toBe(true);
     expect(stripAnsi(all.output)).toContain("killed 2 windows 47-mawjs:2, 47-mawjs:5");
     expect(hostExecCalls).toEqual(["tmux kill-window -t '47-mawjs:2'", "tmux kill-window -t '47-mawjs:5'"]);
@@ -86,7 +88,7 @@ describe("kill plugin standalone boundary", () => {
       ],
     }];
 
-    await expect(cmdKill("mawjs:codex")).rejects.toThrow("window 'codex' is ambiguous in session 47-mawjs");
+    await expect(cmdKill("47-mawjs:codex")).rejects.toThrow("window 'codex' is ambiguous in session 47-mawjs");
     expect(hostExecCalls).toEqual([]);
   });
 });

--- a/test/isolated/plugin-locate-standalone.test.ts
+++ b/test/isolated/plugin-locate-standalone.test.ts
@@ -1,7 +1,9 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 let repoPath = "";
@@ -13,6 +15,7 @@ let manifest: any[] = [];
 let federationHits: any[] = [];
 
 mock.module("maw-js/sdk", () => ({
+  ...realSdk,
   ghqFind: async (pattern: string) => {
     if (pattern.includes("mawjs-oracle") || pattern.includes("mawjs")) return repoPath;
     return null;

--- a/test/isolated/plugin-mega-standalone.test.ts
+++ b/test/isolated/plugin-mega-standalone.test.ts
@@ -6,6 +6,8 @@ import { join } from "node:path";
 import { loadManifestFromDir } from "../../src/plugin/manifest-load";
 import { invokePlugin } from "../../src/plugin/registry-invoke";
 import type { LoadedPlugin } from "../../src/plugin/types";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const ROOT = new URL("../..", import.meta.url).pathname;
 const pluginDir = join(ROOT, "src/vendor/mpr-plugins/mega");
@@ -20,6 +22,7 @@ mock.module("os", () => ({
 }));
 
 mock.module("maw-js/sdk", () => ({
+  ...realSdk,
   tmux: {
     listPaneIds: async () => paneIds,
     killPane: async (paneId: string) => {

--- a/test/isolated/plugin-on-standalone.test.ts
+++ b/test/isolated/plugin-on-standalone.test.ts
@@ -1,12 +1,15 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "fs";
 import { join } from "path";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 let config: Record<string, any> = {};
 let savedConfigs: Record<string, any>[] = [];
 
 mock.module("maw-js/sdk", () => ({
+  ...realSdk,
   loadConfig: () => config,
   saveConfig: (next: Record<string, any>) => {
     savedConfigs.push(next);
@@ -81,6 +84,7 @@ describe("on plugin standalone boundary (#2113)", () => {
     savedConfigs = [];
     config = { triggers: [] };
     mock.module("maw-js/sdk", () => ({
+  ...realSdk,
       loadConfig: () => config,
       saveConfig: () => {
         throw new Error("disk full");

--- a/test/isolated/plugin-overview-standalone.test.ts
+++ b/test/isolated/plugin-overview-standalone.test.ts
@@ -1,6 +1,8 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 
@@ -24,6 +26,7 @@ const tmux = {
 };
 
 mock.module("maw-js/sdk", () => ({
+  ...realSdk,
   listSessions: async () => sessions,
   hostExec: async () => "",
   tmux,

--- a/test/isolated/plugin-pane-standalone.test.ts
+++ b/test/isolated/plugin-pane-standalone.test.ts
@@ -1,6 +1,7 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 const swapCalls: Array<[string, string]> = [];

--- a/test/isolated/plugin-panes-standalone.test.ts
+++ b/test/isolated/plugin-panes-standalone.test.ts
@@ -1,10 +1,12 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { loadManifestFromDir } from "../../src/plugin/manifest-load";
 import { invokePlugin } from "../../src/plugin/registry-invoke";
 import type { LoadedPlugin } from "../../src/plugin/types";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const ROOT = new URL("../..", import.meta.url).pathname;
 const pluginDir = join(ROOT, "src/vendor/mpr-plugins/panes");
@@ -16,6 +18,7 @@ let hostExecError: unknown;
 let tmuxBin: string;
 
 mock.module("maw-js/sdk", () => ({
+  ...realSdk,
   listSessions: async () => sessions,
   hostExec: async (command: string) => {
     hostExecCalls.push(command);

--- a/test/isolated/plugin-peek-standalone.test.ts
+++ b/test/isolated/plugin-peek-standalone.test.ts
@@ -1,12 +1,15 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "fs";
 import { join } from "path";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 const peekCalls: Array<string | undefined> = [];
 let shouldThrow: Error | null = null;
 
 mock.module("maw-js/sdk", () => ({
+  ...realSdk,
   cmdPeek: async (query?: string) => {
     peekCalls.push(query);
     if (shouldThrow) throw shouldThrow;

--- a/test/isolated/plugin-ping-standalone.test.ts
+++ b/test/isolated/plugin-ping-standalone.test.ts
@@ -1,6 +1,8 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "fs";
 import { join } from "path";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 
@@ -15,6 +17,7 @@ let responses: Record<string, { ok: boolean; status?: number; data?: any } | Err
 let timeouts: string[];
 
 mock.module("maw-js/sdk", () => ({
+  ...realSdk,
   loadConfig: () => config,
   cfgTimeout: (key: string) => {
     timeouts.push(key);

--- a/test/isolated/plugin-pr-standalone.test.ts
+++ b/test/isolated/plugin-pr-standalone.test.ts
@@ -1,10 +1,12 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { loadManifestFromDir } from "../../src/plugin/manifest-load";
 import { invokePlugin } from "../../src/plugin/registry-invoke";
 import type { LoadedPlugin } from "../../src/plugin/types";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const ROOT = new URL("../..", import.meta.url).pathname;
 const pluginDir = join(ROOT, "src/vendor/mpr-plugins/pr");
@@ -27,8 +29,8 @@ class MockTmux {
   }
 }
 
-mock.module("maw-js/sdk", () => ({ Tmux: MockTmux }));
-mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => ({ Tmux: MockTmux }));
+mock.module("maw-js/sdk", () => ({ ...realSdk, Tmux: MockTmux }));
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => ({ ...realSdk, Tmux: MockTmux }));
 
 function textStream(value: string): ReadableStream<Uint8Array> {
   return new ReadableStream({

--- a/test/isolated/plugin-profile-standalone.test.ts
+++ b/test/isolated/plugin-profile-standalone.test.ts
@@ -1,6 +1,8 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 
@@ -16,6 +18,7 @@ let profiles: Profile[] = [];
 const setCalls: string[] = [];
 
 mock.module("maw-js/sdk", () => ({
+  ...realSdk,
   getActiveProfile: () => active,
   loadAllProfiles: () => profiles,
   loadProfile: (name: string) => profiles.find((p) => p.name === name) ?? null,

--- a/test/isolated/plugin-pulse-standalone.test.ts
+++ b/test/isolated/plugin-pulse-standalone.test.ts
@@ -1,10 +1,12 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { loadManifestFromDir } from "../../src/plugin/manifest-load";
 import { invokePlugin } from "../../src/plugin/registry-invoke";
 import type { LoadedPlugin } from "../../src/plugin/types";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const ROOT = new URL("../..", import.meta.url).pathname;
 const pluginDir = join(ROOT, "src/vendor/mpr-plugins/pulse");
@@ -41,8 +43,8 @@ const sdkMock = {
   },
 };
 
-mock.module("maw-js/sdk", () => sdkMock);
-mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
+mock.module("maw-js/sdk", () => ({ ...realSdk, ...sdkMock }));
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => ({ ...realSdk, ...sdkMock }));
 
 function walkSources(dir: string): string[] {
   const out: string[] = [];

--- a/test/isolated/plugin-restart-standalone.test.ts
+++ b/test/isolated/plugin-restart-standalone.test.ts
@@ -1,6 +1,8 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 const restartDir = join(root, "src/vendor/mpr-plugins/restart");
@@ -29,8 +31,8 @@ const sdkMock = {
   mawDataPath: (...parts: string[]) => join("/tmp/maw-data", ...parts),
 };
 
-mock.module("maw-js/sdk", () => sdkMock);
-mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
+mock.module("maw-js/sdk", () => ({ ...realSdk, ...sdkMock }));
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => ({ ...realSdk, ...sdkMock }));
 
 const { command, default: restartHandler } = await import("../../src/vendor/mpr-plugins/restart/index.ts");
 const { cmdRestart } = await import("../../src/vendor/mpr-plugins/restart/impl.ts");

--- a/test/isolated/plugin-scope-standalone.test.ts
+++ b/test/isolated/plugin-scope-standalone.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -6,15 +6,19 @@ import { join } from "node:path";
 import { loadManifestFromDir } from "../../src/plugin/manifest-load";
 import { invokePlugin } from "../../src/plugin/registry-invoke";
 import type { LoadedPlugin } from "../../src/plugin/types";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const ROOT = new URL("../..", import.meta.url).pathname;
 const pluginDir = join(ROOT, "src/vendor/mpr-plugins/scope");
 let configDir = "";
 
 mock.module("maw-js/sdk", () => ({
+  ...realSdk,
   mawConfigDir: () => configDir,
 }));
 mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => ({
+  ...realSdk,
   mawConfigDir: () => configDir,
 }));
 

--- a/test/isolated/plugin-send-enter-standalone.test.ts
+++ b/test/isolated/plugin-send-enter-standalone.test.ts
@@ -1,6 +1,8 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 const pluginDir = join(root, "src/vendor/mpr-plugins/send-enter");
@@ -16,7 +18,7 @@ const sdkMock = {
   Tmux: class {},
   curlFetch: async () => ({ ok: true, data: { ok: true } }),
 };
-mock.module("maw-js/sdk", () => sdkMock);
+mock.module("maw-js/sdk", () => ({ ...realSdk, ...sdkMock }));
 
 const { command, default: handler } = await import("../../src/vendor/mpr-plugins/send-enter/index.ts");
 const { parseSendEnterArgs } = await import("../../src/vendor/mpr-plugins/send-enter/impl.ts");

--- a/test/isolated/plugin-send-standalone.test.ts
+++ b/test/isolated/plugin-send-standalone.test.ts
@@ -1,6 +1,8 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 const pluginDir = join(root, "src/vendor/mpr-plugins/send");
@@ -24,7 +26,7 @@ const sdkMock = {
     return { ok: true, data: { ok: true, target: "peer:pane" } };
   },
 };
-mock.module("maw-js/sdk", () => sdkMock);
+mock.module("maw-js/sdk", () => ({ ...realSdk, ...sdkMock }));
 
 const { command, default: handler } = await import("../../src/vendor/mpr-plugins/send/index.ts");
 const { parseSendArgs } = await import("../../src/vendor/mpr-plugins/send/impl.ts");

--- a/test/isolated/plugin-send-text-standalone.test.ts
+++ b/test/isolated/plugin-send-text-standalone.test.ts
@@ -1,6 +1,8 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 const pluginDir = join(root, "src/vendor/mpr-plugins/send-text");
@@ -24,10 +26,10 @@ const sdkMock = {
     return { ok: true, data: { ok: true, target: "peer:pane" } };
   },
 };
-mock.module("maw-js/sdk", () => sdkMock);
+mock.module("maw-js/sdk", () => ({ ...realSdk, ...sdkMock }));
 
-const { command, default: handler } = await import("../../src/vendor/mpr-plugins/send-text/index.ts");
-const { parseSendTextArgs } = await import("../../src/vendor/mpr-plugins/send-text/impl.ts");
+const { command, default: handler } = await import("../../src/vendor/mpr-plugins/send-text/index.ts?plugin-send-text-standalone");
+const { parseSendTextArgs } = await import("../../src/vendor/mpr-plugins/send-text/impl.ts?plugin-send-text-standalone");
 
 function importsOf(dir: string): string[] {
   const out: string[] = [];

--- a/test/isolated/plugin-signals-standalone.test.ts
+++ b/test/isolated/plugin-signals-standalone.test.ts
@@ -1,6 +1,8 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "fs";
 import { join } from "path";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 const scanCalls: Array<{ root: string; opts: { days?: number } }> = [];
@@ -13,6 +15,7 @@ let scannedSignals: Array<{
 }> = [];
 
 mock.module("maw-js/sdk", () => ({
+  ...realSdk,
   parseFlags: (args: string[], spec: Record<string, unknown>) => {
     const out: Record<string, unknown> & { _: string[] } = { _: [] };
     for (let i = 0; i < args.length; i += 1) {

--- a/test/isolated/plugin-sleep-standalone.test.ts
+++ b/test/isolated/plugin-sleep-standalone.test.ts
@@ -1,6 +1,8 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 const sleepDir = join(root, "src/vendor/mpr-plugins/sleep");
@@ -29,8 +31,8 @@ const sdkMock = {
   },
 };
 
-mock.module("maw-js/sdk", () => sdkMock);
-mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
+mock.module("maw-js/sdk", () => ({ ...realSdk, ...sdkMock }));
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => ({ ...realSdk, ...sdkMock }));
 
 const { command, default: sleepHandler } = await import("../../src/vendor/mpr-plugins/sleep/index.ts");
 const { cmdSleepOne } = await import("../../src/vendor/mpr-plugins/sleep/impl.ts");

--- a/test/isolated/plugin-stop-standalone.test.ts
+++ b/test/isolated/plugin-stop-standalone.test.ts
@@ -1,12 +1,15 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "fs";
 import { join } from "path";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 let sleepCalls = 0;
 let fail: Error | null = null;
 
 mock.module("maw-js/sdk", () => ({
+  ...realSdk,
   cmdSleep: async () => {
     sleepCalls += 1;
     if (fail) throw fail;

--- a/test/isolated/plugin-stream-standalone.test.ts
+++ b/test/isolated/plugin-stream-standalone.test.ts
@@ -1,6 +1,8 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "fs";
 import { join } from "path";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 const writes: string[] = [];
@@ -61,6 +63,7 @@ class MockTmux {
 }
 
 mock.module("maw-js/sdk", () => ({
+  ...realSdk,
   Tmux: MockTmux,
   parseFlags: (args: string[], spec: Record<string, unknown>) => {
     const out: Record<string, unknown> & { _: string[] } = { _: [] };

--- a/test/isolated/plugin-take-standalone.test.ts
+++ b/test/isolated/plugin-take-standalone.test.ts
@@ -1,6 +1,8 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 
@@ -12,6 +14,7 @@ let execCalls: string[] = [];
 let execFailures: Record<string, Error> = {};
 
 mock.module("maw-js/sdk", () => ({
+  ...realSdk,
   listSessions: async () => sessions,
   hostExec: async (command: string) => {
     execCalls.push(command);

--- a/test/isolated/plugin-talk-to-standalone.test.ts
+++ b/test/isolated/plugin-talk-to-standalone.test.ts
@@ -1,6 +1,8 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 const talkToDir = join(root, "src/vendor/mpr-plugins/talk-to");
@@ -36,8 +38,8 @@ const sdkMock = {
   mawMessageLogPath: () => "/tmp/maw-talk-to-log/maw-log.jsonl",
 };
 
-mock.module("maw-js/sdk", () => sdkMock);
-mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
+mock.module("maw-js/sdk", () => ({ ...realSdk, ...sdkMock }));
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => ({ ...realSdk, ...sdkMock }));
 mock.module("fs/promises", () => ({
   mkdir: async (path: string, opts?: unknown) => { mkdirCalls.push({ path, opts }); },
   appendFile: async (path: string, data: string) => { appendFileCalls.push({ path, data }); },

--- a/test/isolated/plugin-team-standalone.test.ts
+++ b/test/isolated/plugin-team-standalone.test.ts
@@ -1,7 +1,9 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
 
@@ -42,8 +44,8 @@ const sdkMock = {
   },
 };
 
-mock.module("maw-js/sdk", () => sdkMock);
-mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
+mock.module("maw-js/sdk", () => ({ ...realSdk, ...sdkMock }));
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => ({ ...realSdk, ...sdkMock }));
 mock.module(import.meta.resolve("../../src/commands/shared/wake-session.ts"), () => ({
   writeWorktreeEngineFile: (...args: unknown[]) => record("writeWorktreeEngineFile", args),
 }));

--- a/test/isolated/plugin-transport-standalone.test.ts
+++ b/test/isolated/plugin-transport-standalone.test.ts
@@ -1,6 +1,7 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 const statusCalls: string[] = [];

--- a/test/isolated/plugin-wake-standalone.test.ts
+++ b/test/isolated/plugin-wake-standalone.test.ts
@@ -1,7 +1,9 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 
@@ -40,10 +42,10 @@ const sdkMock = {
   legacyMawPath: (name: string) => join(tmpHome, "legacy", name),
 };
 
-mock.module("maw-js/sdk", () => sdkMock);
-mock.module(import.meta.resolve("../../src/sdk"), () => sdkMock);
-mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => sdkMock);
-mock.module(new URL("../../src/sdk/index.ts", import.meta.url).pathname, () => sdkMock);
+mock.module("maw-js/sdk", () => ({ ...realSdk, ...sdkMock }));
+mock.module(import.meta.resolve("../../src/sdk"), () => ({ ...realSdk, ...sdkMock }));
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => ({ ...realSdk, ...sdkMock }));
+mock.module(new URL("../../src/sdk/index.ts", import.meta.url).pathname, () => ({ ...realSdk, ...sdkMock }));
 
 mock.module("maw-js/commands/shared/wake", () => ({
   cmdWake: async (oracle: string, opts: Record<string, unknown>) => wakeCalls.push({ oracle, opts }),

--- a/test/isolated/plugin-workspace-standalone.test.ts
+++ b/test/isolated/plugin-workspace-standalone.test.ts
@@ -1,6 +1,8 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+const realSdk = await import("../../src/sdk/index.ts");
+afterAll(() => { mock.restore(); });
 
 const root = join(import.meta.dir, "../..");
 const calls: Array<{ name: string; args: unknown[] }> = [];
@@ -13,6 +15,7 @@ function record(name: string, ...args: unknown[]) {
 }
 
 mock.module("maw-js/sdk", () => ({
+  ...realSdk,
   parseFlags: (args: string[], spec: Record<string, unknown>) => {
     const out: Record<string, any> = { _: [] };
     for (let i = 0; i < args.length; i += 1) {


### PR DESCRIPTION
## Summary
- Add a configurable LRU cap for the Discord inventory user-name cache (`MAW_DISCORD_USER_CACHE_MAX`, default 1000).
- Refresh cache recency on hits and evict oldest entries once the cap is exceeded.
- Add regression tests for default/configured sizing, oldest-entry eviction, max=0, and hit recency refresh.

Closes #2388

## Tests
- `bun test test/discord-user-cache.test.ts`
- `bun run build`
- `bun run test:default:safe`