### PR TITLE
Fix team up member subset filter

### DIFF
--- a/src/commands/plugins/team/index.ts
+++ b/src/commands/plugins/team/index.ts
@@ -147,7 +147,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       await cmdTeamPrune();
     } else if (sub === "up") {
       if (!args[1]) {
-        logs.push("usage: maw team up <team> [--dry-run] [--status] [--force] [--gather] [-e <engine>]");
+        logs.push("usage: maw team up <team> [--members <roles>] [--dry-run] [--status] [--force] [--gather] [-e <engine>]");
         return { ok: false, error: "team required", output: logs.join("\n") };
       }
       const { cmdTeamUp } = await import("../../../vendor/mpr-plugins/team/team-up");
@@ -158,6 +158,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         "--gather": Boolean,
         "--engine": String,
         "-e": "--engine",
+        "--members": String,
       }, 2);
       await cmdTeamUp(args[1], {
         dryRun: Boolean(flags["--dry-run"]),
@@ -165,6 +166,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         force: Boolean(flags["--force"]),
         gather: Boolean(flags["--gather"]),
         engine: flags["--engine"] as string | undefined,
+        members: String(flags["--members"] || "").split(",").map((s) => s.trim()).filter(Boolean),
       });
     } else if (sub === "list" || sub === "ls" || !sub) {
       if (args.includes("--all")) await cmdTeamList({ all: true });

--- a/src/vendor/mpr-plugins/team/index.ts
+++ b/src/vendor/mpr-plugins/team/index.ts
@@ -409,7 +409,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       // #1976 — charter-driven team wake: reconcile the charter against live
       // panes (skip live, resume dead in place, fresh-wake missing).
       if (!args[1]) {
-        logs.push("usage: maw team up <team> [--session <name>] [--only <a,b>] [--dry-run] [--status] [--force] [--gather] [-e <engine>]");
+        logs.push("usage: maw team up <team> [--session <name>] [--members <roles>] [--only <a,b>] [--dry-run] [--status] [--force] [--gather] [-e <engine>]");
         return { ok: false, error: "team required", output: logs.join("\n") };
       }
       const { cmdTeamUp } = await import("./team-up");
@@ -421,6 +421,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         "--engine": String,
         "-e": "--engine",
         "--only": String,
+        "--members": String,
         "--session": String,
       }, 2);
       await cmdTeamUp(args[1], {
@@ -430,6 +431,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         gather: Boolean(flags["--gather"]),
         engine: flags["--engine"] as string | undefined,
         only: String(flags["--only"] || "").split(",").map((s) => s.trim()).filter(Boolean),
+        members: String(flags["--members"] || "").split(",").map((s) => s.trim()).filter(Boolean),
         session: flags["--session"] as string | undefined,
       });
 

--- a/src/vendor/mpr-plugins/team/team-liveness.ts
+++ b/src/vendor/mpr-plugins/team/team-liveness.ts
@@ -41,6 +41,7 @@ export interface ClassifyMemberOptions {
   engine?: string;
   currentNode?: string;
   only?: Set<string>;
+  members?: Set<string>;
   repoSlug?: string;
 }
 
@@ -169,6 +170,9 @@ export function classifyMember(
   }
   if (opts.only && ![member.role, windowIdentity, worktree].some((value) => opts.only!.has(value))) {
     return { member, role, engine, worktree, windowIdentity, state: "skipped", skipReason: "outside --only" };
+  }
+  if (opts.members && !opts.members.has(member.role)) {
+    return { member, role, engine, worktree, windowIdentity, state: "skipped", skipReason: "outside --members" };
   }
 
   const candidates = memberWindowCandidates(member, opts.repoSlug);

--- a/src/vendor/mpr-plugins/team/team-up.ts
+++ b/src/vendor/mpr-plugins/team/team-up.ts
@@ -32,6 +32,7 @@ export interface TeamUpOptions {
   gather?: boolean;
   engine?: string;
   only?: string[];
+  members?: string[];
   session?: string;
 }
 
@@ -194,8 +195,17 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
   }
 
   const panes = await listPaneSnapshots(tmux);
-  const only = opts.only?.length ? new Set(opts.only.map((item) => item.trim()).filter(Boolean)) : undefined;
-  const roster = charter.members.map((member) => classifyMember(member, panes, session, { engine: opts.engine, currentNode: config.node, only, repoSlug: targetRepoSlug }));
+  const onlyItems = opts.only?.map((item) => item.trim()).filter(Boolean) ?? [];
+  const only = onlyItems.length ? new Set(onlyItems) : undefined;
+  const requestedMemberItems = opts.members?.map((item) => item.trim()).filter(Boolean) ?? [];
+  const requestedMembers = requestedMemberItems.length ? new Set(requestedMemberItems) : undefined;
+  if (requestedMembers) {
+    const charterRoles = new Set(charter.members.map((member) => member.role));
+    for (const role of requestedMembers) {
+      if (!charterRoles.has(role)) warnings.push(`--members role not found in charter: ${role}`);
+    }
+  }
+  const roster = charter.members.map((member) => classifyMember(member, panes, session, { engine: opts.engine, currentNode: config.node, only, members: requestedMembers, repoSlug: targetRepoSlug }));
   const actions: TeamUpAction[] = [];
 
   if (opts.status) {
@@ -270,7 +280,7 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
   }
 
   const finalPanes = await listPaneSnapshots(tmux).catch(() => panes);
-  const finalRoster = charter.members.map((member) => classifyMember(member, finalPanes, session, { engine: opts.engine, currentNode: config.node, only, repoSlug: targetRepoSlug }));
+  const finalRoster = charter.members.map((member) => classifyMember(member, finalPanes, session, { engine: opts.engine, currentNode: config.node, only, members: requestedMembers, repoSlug: targetRepoSlug }));
   warnOnPathCollisions(finalRoster, warnings);
 
   if (opts.gather) {

--- a/test/isolated/plugin-team-standalone.test.ts
+++ b/test/isolated/plugin-team-standalone.test.ts
@@ -66,6 +66,9 @@ mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/team/team-comms.ts
     return { mode: "broadcast", message: args.join(" ") };
   },
 }));
+mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/team/team-up.ts"), () => ({
+  cmdTeamUp: async (...args: unknown[]) => calls.push({ name: "up", args }),
+}));
 mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/team/task-ops.ts"), () => ({
   cmdTeamTaskAdd: (...args: unknown[]) => calls.push({ name: "task-add", args }),
   cmdTeamTaskList: (...args: unknown[]) => calls.push({ name: "task-list", args }),
@@ -87,39 +90,24 @@ beforeEach(() => {
 });
 
 describe("team command plugin standalone boundary (#2336)", () => {
-  test("team-up vendor boundary explicitly tracks prompt priming seams", () => {
+  test("entrypoint and touched team-up files keep explicit standalone import boundaries", () => {
     const imports = expectStandalonePluginBoundary({
       plugin: "team",
-      files: ["team-up.ts"],
-      requireSdk: false,
+      files: ["index.ts", "team-liveness.ts", "team-up.ts"],
       allowRelative: [
-        "../../../commands/shared/comm-send",
-        "../../../commands/shared/wake-cmd",
+        "../../../core/transport/tmux",
+        "../../../core/agent-detect",
         "../../../config/load",
         "../../../config/types",
-        "../../../core/transport/tmux",
+        "../../../commands/shared/wake-cmd",
+        "../../../commands/shared/comm-send",
       ],
     }).map((record) => record.spec);
 
-    expect(imports).toContain("./team-charter");
-    expect(imports).toContain("./team-liveness");
-    expect(imports).toContain("../../../commands/shared/comm-send");
-  });
-
-  test("entrypoint uses SDK rather than direct plugin/cli/core imports", () => {
-    const source = readFileSync(join(root, "src/vendor/mpr-plugins/team/index.ts"), "utf8");
-    const specs = [...source.matchAll(/\b(?:import|export)\s+(?:[^"'`]+?\s+from\s+)?["']([^"']+)["']/g)].map((m) => m[1]);
-    const forbidden = specs.filter((spec) =>
-      spec?.startsWith("maw-js/plugin")
-      || spec?.startsWith("maw-js/cli/")
-      || spec?.startsWith("maw-js/core/")
-      || spec?.startsWith("maw-js/commands/shared/")
-      || spec === "maw-js/config",
-    );
 
     expect(command).toMatchObject({ name: "team" });
-    expect(forbidden).toEqual([]);
-    expect(specs).toContain("maw-js/sdk");
+    expect(imports).toContain("maw-js/sdk");
+    expect(imports).toEqual(expect.arrayContaining(["./team-up", "../../../commands/shared/wake-cmd"]));
     const sdk = readFileSync(join(root, "src/sdk/index.ts"), "utf8");
     expect(sdk).toContain("parseFlags");
     expect(sdk).toContain("hostExec");
@@ -143,6 +131,21 @@ describe("team command plugin standalone boundary (#2336)", () => {
     targets = ["neo"];
     await teamHandler({ source: "cli", args: ["send", "avengers", "hello", "all"] } as any);
     expect(calls.pop()).toEqual({ name: "broadcast", args: ["avengers", "hello all"] });
+
+    await teamHandler({ source: "cli", args: ["up", "avengers", "--members", "coder-1, oracle", "--session", "alpha", "--dry-run"] } as any);
+    expect(calls.pop()).toEqual({
+      name: "up",
+      args: ["avengers", {
+        dryRun: true,
+        status: false,
+        force: false,
+        gather: false,
+        engine: undefined,
+        only: [],
+        members: ["coder-1", "oracle"],
+        session: "alpha",
+      }],
+    });
   });
 
   test("validation paths return InvokeResult errors without side effects", async () => {

--- a/test/isolated/team-up-coverage.test.ts
+++ b/test/isolated/team-up-coverage.test.ts
@@ -388,6 +388,37 @@ members:
   });
 
 
+  test("--members filters by charter role, warns unknown roles, and wakes only selected members", async () => {
+    const root = tempRepo();
+    const { tmux } = fakeTmux([]);
+    const wakes: any[] = [];
+
+    const status = await cmdTeamUp("alpha", { status: true, members: ["coder-1", "mawjs-oracle", "missing-role"] }, {
+      cwd: root,
+      tmux,
+      loadConfigFn: () => config,
+      logger: () => {},
+    });
+    expect(status.roster.map((m) => [m.role, m.state, m.skipReason])).toEqual([
+      ["coder-1", "missing", undefined],
+      ["coder-10", "skipped", "outside --members"],
+      ["oracle", "skipped", "outside --members"],
+    ]);
+    expect(status.warnings).toContain("--members role not found in charter: mawjs-oracle");
+    expect(status.warnings).toContain("--members role not found in charter: missing-role");
+
+    await cmdTeamUp("alpha", { members: ["coder-1"] }, {
+      cwd: root,
+      tmux,
+      loadConfigFn: () => config,
+      cmdWakeFn: async (...a: any[]) => { wakes.push(a); return "woke"; },
+      sleep: async () => {},
+      logger: () => {},
+    });
+    expect(wakes.map((w) => w[1].wt)).toEqual(["coder-1"]);
+  });
+
+
   test("--only skips members outside the selected role/name/worktree set", async () => {
     const root = tempRepo();
     const { tmux } = fakeTmux([]);
@@ -620,6 +651,7 @@ describe("vendored team plugin routes `up` (#1976 integration)", () => {
     const { res } = await dispatch(["up"]);
     expect(res.error).not.toContain("unknown subcommand");
     expect(res.error).toBe("team required");
+    expect(res.output).toContain("--members <roles>");
   });
 
   test("`team down` is a known subcommand", async () => {


### PR DESCRIPTION
Closes #2399

## Summary
- add `maw team up --members` parsing in the vendored runtime plugin and core shim
- filter charter reconciliation to selected role names only
- warn when requested role names are absent from the charter

## Tests
- `MAW_TEST_MODE=1 bun test test/isolated/team-up-coverage.test.ts --path-ignore-patterns '**/agents/**'`\n- `bun run build`