### PR TITLE
Fix stale HubTransport remote agents

### DIFF
--- a/src/transports/hub-agent-registry.ts
+++ b/src/transports/hub-agent-registry.ts
@@ -1,0 +1,55 @@
+import type { HubConnection } from "./hub-connection";
+
+export const REMOTE_AGENT_STALE_MS = 60 * 60 * 1000;
+
+function lastSeen(conn: HubConnection): Map<string, number> {
+  return conn.remoteAgentLastSeen ??= new Map();
+}
+
+function owners(conn: HubConnection): Map<string, string> {
+  return conn.remoteAgentOwners ??= new Map();
+}
+
+export function rememberRemoteAgent(conn: HubConnection, name: string, seenAt = Date.now(), owner?: string): void {
+  if (!name) return;
+  conn.remoteAgents.add(name);
+  lastSeen(conn).set(name, seenAt);
+  if (owner) owners(conn).set(name, owner);
+}
+
+export function forgetRemoteAgent(conn: HubConnection, name: string): void {
+  conn.remoteAgents.delete(name);
+  conn.remoteAgentLastSeen?.delete(name);
+  conn.remoteAgentOwners?.delete(name);
+}
+
+export function forgetRemoteAgentsForNode(conn: HubConnection, nodeId: string): string[] {
+  const removed: string[] = [];
+  for (const [agent, owner] of conn.remoteAgentOwners ?? []) {
+    if (owner !== nodeId) continue;
+    forgetRemoteAgent(conn, agent);
+    removed.push(agent);
+  }
+  return removed;
+}
+
+export function clearRemoteAgents(conn: HubConnection): void {
+  conn.remoteAgents.clear();
+  conn.remoteAgentLastSeen?.clear();
+  conn.remoteAgentOwners?.clear();
+}
+
+export function pruneStaleRemoteAgents(
+  conn: HubConnection,
+  now = Date.now(),
+  maxAgeMs = REMOTE_AGENT_STALE_MS,
+): string[] {
+  const removed: string[] = [];
+  for (const agent of Array.from(conn.remoteAgents)) {
+    const seenAt = conn.remoteAgentLastSeen?.get(agent);
+    if (seenAt === undefined || now - seenAt <= maxAgeMs) continue;
+    forgetRemoteAgent(conn, agent);
+    removed.push(agent);
+  }
+  return removed;
+}

--- a/src/transports/hub-connection.ts
+++ b/src/transports/hub-connection.ts
@@ -10,6 +10,12 @@ import { trySilent } from "../core/util/try-silent";
 import { sanitizeLogField } from "../core/util/sanitize-log";
 import { HEARTBEAT_MS, RECONNECT_BASE_MS, RECONNECT_MAX_MS } from "./hub-config";
 import type { WorkspaceConfig } from "./hub-config";
+import {
+  clearRemoteAgents,
+  forgetRemoteAgent,
+  forgetRemoteAgentsForNode,
+  rememberRemoteAgent,
+} from "./hub-agent-registry";
 
 /** Live connection to a single workspace hub */
 export interface HubConnection {
@@ -21,6 +27,10 @@ export interface HubConnection {
   reconnectAttempt: number;
   /** Remote agents visible through this workspace (from auth-ok + presence) */
   remoteAgents: Set<string>;
+  /** Last time each remote agent was observed in auth/presence traffic. */
+  remoteAgentLastSeen?: Map<string, number>;
+  /** Best-effort owner node for each remote agent, learned from presence. */
+  remoteAgentOwners?: Map<string, string>;
 }
 
 export function sendAuth(conn: HubConnection, nodeId: string, federationToken: string | undefined): void {
@@ -56,7 +66,10 @@ export function handleMessage(
         // Sanitize before logging to close CodeQL js/log-injection (#474, #486).
         // lgtm[js/log-injection] — sanitizeLogField strips control chars + ANSI, see docs/security/codeql-sanitizer-model.md
         console.log(`[hub] workspace ${conn.config.id}: authenticated (workspace=${sanitizeLogField(msg.workspaceId)})`);
-        if (Array.isArray(msg.agents)) conn.remoteAgents = new Set(msg.agents);
+        if (Array.isArray(msg.agents)) {
+          clearRemoteAgents(conn);
+          for (const agent of msg.agents) rememberRemoteAgent(conn, agent);
+        }
         break;
       case "message": {
         const transportMsg: TransportMessage = {
@@ -72,7 +85,10 @@ export function handleMessage(
       case "presence":
         if (Array.isArray(msg.agents)) {
           for (const agent of msg.agents) {
-            if (agent.name) conn.remoteAgents.add(agent.name);
+            const name = agent.name || "";
+            const owner = agent.host || agent.nodeId;
+            if (name && agent.status === "offline") forgetRemoteAgent(conn, name);
+            else rememberRemoteAgent(conn, name, msg.timestamp || Date.now(), owner);
             const presence: TransportPresence = {
               oracle: agent.name || "unknown",
               host: agent.host || agent.nodeId || "remote",
@@ -93,7 +109,9 @@ export function handleMessage(
         // lgtm[js/log-injection] — sanitizeLogField, see docs/security/codeql-sanitizer-model.md
         console.log(`[hub] workspace ${conn.config.id}: node left — ${sanitizeLogField(msg.nodeId)}`);
         if (msg.agents && Array.isArray(msg.agents)) {
-          for (const agent of msg.agents) conn.remoteAgents.delete(agent);
+          for (const agent of msg.agents) forgetRemoteAgent(conn, agent);
+        } else if (msg.nodeId) {
+          forgetRemoteAgentsForNode(conn, msg.nodeId);
         }
         break;
       case "feed":
@@ -157,6 +175,7 @@ export function cleanupConnection(conn: HubConnection): void {
     conn.ws = null;
   }
   conn.connected = false;
+  clearRemoteAgents(conn);
 }
 
 export function openWebSocket(
@@ -193,6 +212,7 @@ export function openWebSocket(
     ws.addEventListener("close", (event) => {
       console.log(`[hub] workspace ${conn.config.id}: disconnected (code=${event.code}, reason=${event.reason})`);
       conn.connected = false;
+      clearRemoteAgents(conn);
       stopHeartbeat(conn);
       onUpdateState();
       scheduleReconnect(conn, reopen);
@@ -204,6 +224,7 @@ export function openWebSocket(
     });
   } catch (err) {
     console.error(`[hub] workspace ${conn.config.id}: failed to create WebSocket:`, err);
+    clearRemoteAgents(conn);
     scheduleReconnect(conn, reopen);
   }
 }

--- a/src/transports/hub-transport.ts
+++ b/src/transports/hub-transport.ts
@@ -8,7 +8,8 @@ import type { FeedEvent } from "../lib/feed";
 import { loadConfig } from "../config";
 import { trySilent } from "../core/util/try-silent";
 import type { HubConnection } from "./hub-connection";
-import { openWebSocket, cleanupConnection } from "./hub-connection";
+import { cleanupConnection, openWebSocket } from "./hub-connection";
+import { REMOTE_AGENT_STALE_MS, pruneStaleRemoteAgents } from "./hub-agent-registry";
 import { loadWorkspaceConfigs } from "./hub-config";
 import type { WorkspaceConfig } from "./hub-config";
 
@@ -19,6 +20,10 @@ interface HubTransportDeps {
   cleanup?: typeof cleanupConnection;
   setConnectTimeout?: typeof setTimeout;
   clearConnectTimeout?: typeof clearTimeout;
+  setReconcileInterval?: typeof setInterval;
+  clearReconcileInterval?: typeof clearInterval;
+  now?: () => number;
+  remoteAgentStaleMs?: number;
 }
 
 export class HubTransport implements Transport {
@@ -31,6 +36,7 @@ export class HubTransport implements Transport {
   private msgHandlers = new Set<(msg: TransportMessage) => void>();
   private presenceHandlers = new Set<(p: TransportPresence) => void>();
   private feedHandlers = new Set<(e: FeedEvent) => void>();
+  private reconcileTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(
     nodeId?: string,
@@ -61,9 +67,11 @@ export class HubTransport implements Transport {
       (r) => r.status === "fulfilled" && r.value === true,
     );
     this._connected = anyConnected;
+    if (anyConnected) this.startRemoteAgentReconciliation();
   }
 
   async disconnect(): Promise<void> {
+    this.stopRemoteAgentReconciliation();
     for (const conn of this.connections.values()) {
       (this.deps.cleanup ?? cleanupConnection)(conn);
     }
@@ -192,7 +200,10 @@ export class HubTransport implements Transport {
         this.msgHandlers,
         this.presenceHandlers,
         this.feedHandlers,
-        () => { this._connected = true; },
+        () => {
+          this._connected = true;
+          this.startRemoteAgentReconciliation();
+        },
         () => this.updateConnectedState(),
         () => { (this.deps.clearConnectTimeout ?? clearTimeout)(timeout); resolve(true); },
       );
@@ -201,5 +212,31 @@ export class HubTransport implements Transport {
 
   private updateConnectedState() {
     this._connected = Array.from(this.connections.values()).some((c) => c.connected);
+    if (this._connected) this.startRemoteAgentReconciliation();
+    else this.stopRemoteAgentReconciliation();
+  }
+
+  private startRemoteAgentReconciliation() {
+    if (this.reconcileTimer) return;
+    const setTimer = this.deps.setReconcileInterval ?? setInterval;
+    this.reconcileTimer = setTimer(() => this.pruneStaleRemoteAgents(), 5 * 60 * 1000);
+    (this.reconcileTimer as any)?.unref?.();
+  }
+
+  private stopRemoteAgentReconciliation() {
+    if (!this.reconcileTimer) return;
+    (this.deps.clearReconcileInterval ?? clearInterval)(this.reconcileTimer);
+    this.reconcileTimer = null;
+  }
+
+  private pruneStaleRemoteAgents() {
+    const now = (this.deps.now ?? Date.now)();
+    const staleMs = this.deps.remoteAgentStaleMs ?? REMOTE_AGENT_STALE_MS;
+    for (const conn of this.connections.values()) {
+      const removed = pruneStaleRemoteAgents(conn, now, staleMs);
+      if (removed.length > 0) {
+        console.log(`[hub] workspace ${conn.config.id}: pruned stale remote agent(s): ${removed.join(", ")}`);
+      }
+    }
   }
 }

--- a/test/hub-connection.test.ts
+++ b/test/hub-connection.test.ts
@@ -11,6 +11,11 @@ import {
   startHeartbeat,
   stopHeartbeat,
 } from "../src/transports/hub-connection";
+import {
+  forgetRemoteAgentsForNode,
+  pruneStaleRemoteAgents,
+  rememberRemoteAgent,
+} from "../src/transports/hub-agent-registry";
 
 function makeConn(id = "ws-test"): HubConnection {
   return {
@@ -107,6 +112,41 @@ describe("hub connection lifecycle helpers", () => {
     expect(feeds[0].oracle).toBe("pulse");
   });
 
+  test("remote agent cleanup handles offline presence, node-left owners, and stale reconciliation", () => {
+    const conn = makeConn();
+    const presenceHandlers = new Set<(p: TransportPresence) => void>();
+
+    handleMessage(conn, JSON.stringify({
+      type: "presence",
+      timestamp: 1_000,
+      agents: [
+        { name: "neo", host: "m5", status: "ready" },
+        { name: "pulse", nodeId: "m6", status: "ready" },
+      ],
+    }), new Set(), presenceHandlers, new Set());
+
+    expect(conn.remoteAgents.has("neo")).toBe(true);
+    expect(conn.remoteAgents.has("pulse")).toBe(true);
+    expect(conn.remoteAgentOwners?.get("neo")).toBe("m5");
+    expect(conn.remoteAgentLastSeen?.get("pulse")).toBe(1_000);
+
+    handleMessage(conn, JSON.stringify({
+      type: "presence",
+      timestamp: 2_000,
+      agents: [{ name: "neo", host: "m5", status: "offline" }],
+    }), new Set(), presenceHandlers, new Set());
+    expect(conn.remoteAgents.has("neo")).toBe(false);
+
+    expect(forgetRemoteAgentsForNode(conn, "m6")).toEqual(["pulse"]);
+    expect(conn.remoteAgents.has("pulse")).toBe(false);
+
+    rememberRemoteAgent(conn, "fresh", 10_000, "m7");
+    rememberRemoteAgent(conn, "stale", 1_000, "m8");
+    expect(pruneStaleRemoteAgents(conn, 11_000, 5_000)).toEqual(["stale"]);
+    expect(conn.remoteAgents.has("fresh")).toBe(true);
+    expect(conn.remoteAgents.has("stale")).toBe(false);
+  });
+
   test("heartbeat, reconnect, and cleanup manage timers and sockets", () => {
     const originalSetInterval = globalThis.setInterval;
     const originalClearInterval = globalThis.clearInterval;
@@ -137,6 +177,7 @@ describe("hub connection lifecycle helpers", () => {
         send: (payload: string) => sent.push(payload),
         close: (_code?: number, reason?: string) => closed.push(reason ?? ""),
       } as unknown as WebSocket;
+      rememberRemoteAgent(conn, "stale-on-cleanup", 1);
 
       startHeartbeat(conn, "m5");
       expect(intervals).toEqual([30_000]);
@@ -159,6 +200,7 @@ describe("hub connection lifecycle helpers", () => {
       expect(conn.connected).toBe(false);
       expect(conn.ws).toBeNull();
       expect(conn.reconnectTimer).toBeNull();
+      expect(conn.remoteAgents.size).toBe(0);
 
       const timerOnly = makeConn();
       timerOnly.reconnectTimer = { kind: "pending-timeout" } as ReturnType<typeof setTimeout>;
@@ -235,11 +277,14 @@ describe("hub connection lifecycle helpers", () => {
         expect(JSON.parse(ws.sent[0])).toMatchObject({ type: "auth", nodeId: "m5" });
 
         ws.emit("message", { data: JSON.stringify({ type: "message", from: "pulse", to: "mawjs", body: "hi", timestamp: 7 }) });
+        ws.emit("message", { data: JSON.stringify({ type: "presence", agents: [{ name: "neo", host: "m5" }] }) });
+        expect(conn.remoteAgents.has("neo")).toBe(true);
         ws.emit("error", { message: "network broke" });
         ws.emit("close", { code: 1006, reason: "lost" });
       });
       expect(messages).toEqual([{ from: "pulse", to: "mawjs", body: "hi", timestamp: 7, transport: "hub" }]);
       expect(conn.connected).toBe(false);
+      expect(conn.remoteAgents.size).toBe(0);
       expect(updateState).toBe(1);
       cleanupConnection(conn);
 

--- a/test/hub-transport.test.ts
+++ b/test/hub-transport.test.ts
@@ -112,6 +112,53 @@ describe("HubTransport", () => {
     }
   });
 
+  test("periodic reconciliation prunes stale remote agents from connected workspaces", async () => {
+    const ws = workspace("ws-prune");
+    const intervals: Array<() => void> = [];
+    const cleared: unknown[] = [];
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => logs.push(args.map(String).join(" "));
+    try {
+      const transport = new HubTransport("m5", {
+        loadConfig: () => ({} as any),
+        loadWorkspaces: () => [ws],
+        now: () => 10_000,
+        remoteAgentStaleMs: 5_000,
+        setConnectTimeout: (() => ({ kind: "connect-timeout" })) as typeof setTimeout,
+        clearConnectTimeout: (() => {}) as typeof clearTimeout,
+        setReconcileInterval: ((cb: () => void) => {
+          intervals.push(cb);
+          return { kind: "reconcile-timer" } as any;
+        }) as typeof setInterval,
+        clearReconcileInterval: ((timer: unknown) => { cleared.push(timer); }) as typeof clearInterval,
+        openSocket: (connection, _nodeId, _token, _msg, _presence, _feed, onSetConnected, _onUpdateState, onFirstConnect) => {
+          connection.connected = true;
+          connection.remoteAgents = new Set(["fresh", "stale"]);
+          connection.remoteAgentLastSeen = new Map([
+            ["fresh", 8_000],
+            ["stale", 1_000],
+          ]);
+          onSetConnected();
+          onFirstConnect?.();
+        },
+      });
+
+      await transport.connect();
+      expect(intervals).toHaveLength(1);
+      expect(transport.workspaceStatus()[0]?.remoteAgents).toEqual(["fresh", "stale"]);
+
+      intervals[0]!();
+      expect(transport.workspaceStatus()[0]?.remoteAgents).toEqual(["fresh"]);
+      expect(logs.join("\n")).toContain("pruned stale remote agent(s): stale");
+
+      await transport.disconnect();
+      expect(cleared).toHaveLength(1);
+    } finally {
+      console.log = originalLog;
+    }
+  });
+
   test("routes sends, publishes best-effort events, reports status, and disconnects", async () => {
     const cleanups: string[] = [];
     const warnLogs: string[] = [];


### PR DESCRIPTION
## Summary
- Track per-agent last-seen and best-effort owner metadata for HubTransport remote agents.
- Remove remote agents on offline presence, node-left, local hub disconnect/cleanup, and periodic stale reconciliation.
- Add regression coverage for stale pruning and disconnect cleanup.

Closes #2387

## Tests
- `bun test test/hub-connection.test.ts test/hub-transport.test.ts --path-ignore-patterns '**/agents/**'`
- `bun run build`
- `bun run test:default:safe`
