### PR TITLE
Fix maw serve verbosity flags

### DIFF
--- a/src/cli/route-tools.ts
+++ b/src/cli/route-tools.ts
@@ -15,7 +15,7 @@ const CORE_HELP: Record<string, string> = {
   agents: "usage: maw agents [--json] [--all] [--node <node>]",
   agent: "usage: maw agent [--json] [--all] [--node <node>]",
   audit: "usage: maw audit [limit]",
-  serve: "usage: maw serve [port] [--as <name>] [--force-takeover] | maw serve status|--status|stop",
+  serve: "usage: maw serve [port] [--as <name>] [--force-takeover] [--quiet|-q] [--verbose|-v] | maw serve status|--status|stop",
 };
 
 type ParseFlags = (args: string[], spec: Record<string, unknown>, skip?: number) => any;
@@ -65,11 +65,11 @@ type ServeStatusTools = {
 
 type ServeStartTools = {
   acquirePidLock: (instanceName: string | null, opts: { forceTakeover: boolean }) => void;
-  startServer: (port: number) => Promise<void> | void;
+  startServer: (port: number, options?: { verbosity?: 0 | 1 | 2 }) => Promise<void> | void;
 };
 
 type CoreServerTools = {
-  startServer: (port: number) => Promise<void> | void;
+  startServer: (port: number, options?: { verbosity?: 0 | 1 | 2 }) => Promise<void> | void;
 };
 type CoreServerLoader = () => Promise<CoreServerTools>;
 
@@ -148,9 +148,9 @@ export function createDefaultRouteToolsDeps(loadCoreServer?: CoreServerLoader): 
       const { acquirePidLock } = await import("./instance-pid");
       return {
         acquirePidLock,
-        startServer: async (port: number) => {
+        startServer: async (port: number, options?: { verbosity?: 0 | 1 | 2 }) => {
           const { startServer } = loadCoreServer ? await loadCoreServer() : await import("../core/server");
-          await startServer(port);
+          await startServer(port, options);
         },
       };
     },
@@ -299,11 +299,20 @@ export async function routeToolsWithDeps(cmd: string, args: string[], deps: Rout
     const asIdx = serveArgs.indexOf("--as");
     const forceIdx = serveArgs.indexOf("--force-takeover");
     const noScoutIdx = serveArgs.indexOf("--no-scout");
+    const hasQuietFlag = serveArgs.some((a) => a === "--quiet" || a === "-q")
+      || process.argv.some((a) => a === "--quiet" || a === "-q")
+      || process.env.MAW_QUIET === "1"
+      || process.env.MAW_SERVE_VERBOSITY === "0"
+      || process.env.MAW_SERVE_VERBOSITY === "quiet";
+    const hasVerboseFlag = serveArgs.some((a) => a === "--verbose" || a === "-v")
+      || process.env.MAW_SERVE_VERBOSITY === "2"
+      || process.env.MAW_SERVE_VERBOSITY === "verbose";
+    const serveVerbosity: 0 | 1 | 2 = hasQuietFlag ? 0 : hasVerboseFlag ? 2 : 1;
     const withoutAs = asIdx === -1
       ? serveArgs
       : [...serveArgs.slice(0, asIdx), ...serveArgs.slice(asIdx + 2)];
-    const withoutKnownFlags = withoutAs.filter((a) => a !== "--force-takeover" && a !== "--no-scout");
-    const filteredArgs = forceIdx === -1 && noScoutIdx === -1 ? withoutAs : withoutKnownFlags;
+    const withoutKnownFlags = withoutAs.filter((a) => !["--force-takeover", "--no-scout", "--quiet", "-q", "--verbose", "-v"].includes(a));
+    const filteredArgs = withoutKnownFlags;
     const sub = filteredArgs[0] === "--status" ? "status" : filteredArgs[0];
     if (sub === "status" || sub === "stop") {
       const { printServeStatusWithPlugins, stopServe } = await deps.loadServeStatusTools();
@@ -318,7 +327,7 @@ export async function routeToolsWithDeps(cmd: string, args: string[], deps: Rout
     const unknownFlag = filteredArgs.find(a => a.startsWith("-"));
     if (unknownFlag) {
       deps.error(`\x1b[31m✗\x1b[0m unknown flag '${unknownFlag}' for 'maw serve'`);
-      deps.error(`  usage: maw serve [port] [--as <name>] [--force-takeover]  (run 'maw serve --help' for more)`);
+      deps.error(`  usage: maw serve [port] [--as <name>] [--force-takeover] [--quiet|-q] [--verbose|-v]  (run 'maw serve --help' for more)`);
       throw new UserError(`unknown flag '${unknownFlag}'`);
     }
     const portArg = filteredArgs.find(a => /^\d+$/.test(a));
@@ -328,7 +337,7 @@ export async function routeToolsWithDeps(cmd: string, args: string[], deps: Rout
     const instanceName = asIdx === -1 ? null : serveArgs[asIdx + 1];
     acquirePidLock(instanceName, { forceTakeover: forceIdx !== -1 });
     if (noScoutIdx !== -1) process.env.MAW_NO_SCOUT = "1";
-    await startServer(portArg ? +portArg : 3456);
+    await startServer(portArg ? +portArg : 3456, { verbosity: serveVerbosity });
     return true;
   }
   return false;

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -38,6 +38,34 @@ import { ServeRouteRegistry } from "./serve-route-registry";
 
 export const VERSION = getRuntimeVersionLabel();
 
+export type ServeVerbosity = 0 | 1 | 2;
+export type StartServerOptions = {
+  /** 0=quiet (errors only), 1=normal, 2=verbose debug */
+  verbosity?: ServeVerbosity;
+};
+
+type ServeLogger = {
+  info: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+  debug: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+};
+
+export function normalizeServeVerbosity(value: unknown): ServeVerbosity {
+  if (value === 0 || value === "0" || value === "quiet") return 0;
+  if (value === 2 || value === "2" || value === "verbose") return 2;
+  return 1;
+}
+
+export function createServeLogger(verbosity: ServeVerbosity): ServeLogger {
+  return {
+    info: (...args: unknown[]) => { if (verbosity >= 1) console.log(...args); },
+    warn: (...args: unknown[]) => { if (verbosity >= 1) console.warn(...args); },
+    debug: (...args: unknown[]) => { if (verbosity >= 2) console.log(...args); },
+    error: (...args: unknown[]) => { console.error(...args); },
+  };
+}
+
 export function isAddressInUseError(err: unknown): boolean {
   if (!err || typeof err !== "object") return false;
   const e = err as { code?: unknown; errno?: unknown; syscall?: unknown; message?: unknown };
@@ -109,18 +137,20 @@ export { views };
 
 const startupPeerWarningsLogged = new Set<string>();
 
-function warnMissingFederationTokenOnce(port: number): void {
+function warnMissingFederationTokenOnce(port: number, log = createServeLogger(1)): void {
   const key = "missing-federation-token";
   if (startupPeerWarningsLogged.has(key)) return;
   startupPeerWarningsLogged.add(key);
-  console.warn(`\x1b[31m⚠ WARNING: peers configured but no federationToken set!\x1b[0m`);
-  console.warn(`\x1b[31m  Port ${port} is exposed to network WITHOUT authentication.\x1b[0m`);
-  console.warn(`\x1b[31m  Add "federationToken" (min 16 chars) to maw.config.json\x1b[0m`);
+  log.warn(`\x1b[31m⚠ WARNING: peers configured but no federationToken set!\x1b[0m`);
+  log.warn(`\x1b[31m  Port ${port} is exposed to network WITHOUT authentication.\x1b[0m`);
+  log.warn(`\x1b[31m  Add "federationToken" (min 16 chars) to maw.config.json\x1b[0m`);
 }
 
 // --- Server ---
 
-export async function startServer(port = +(process.env.MAW_PORT || loadConfig().port || 3456)) {
+export async function startServer(port = +(process.env.MAW_PORT || loadConfig().port || 3456), options: StartServerOptions = {}) {
+  const verbosity = options.verbosity ?? normalizeServeVerbosity(process.env.MAW_SERVE_VERBOSITY);
+  const log = createServeLogger(verbosity);
   const engine = new MawEngine({ feedBuffer, feedListeners });
   const serveRoutes = new ServeRouteRegistry();
 
@@ -137,19 +167,19 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
       const reaper = new Tmux();
       for (const s of stale) {
         await reaper.killSession(s.name);
-        console.log(`[startup] reaped orphan: ${s.name}`);
+        log.info(`[startup] reaped orphan: ${s.name}`);
       }
-      console.log(`[startup] cleaned ${stale.length} orphaned sessions`);
+      log.info(`[startup] cleaned ${stale.length} orphaned sessions`);
     }
   } catch { /* tmux may not be running */ }
 
   // Connect transport router (non-blocking — server starts even if transports fail)
   try {
     const router = createTransportRouter();
-    router.connectAll().catch(err => console.error("[transport] connect failed:", err));
+    router.connectAll().catch(err => log.error("[transport] connect failed:", err));
     engine.setTransportRouter(router);
   } catch (err) {
-    console.error("[transport] router init failed:", err);
+    log.error("[transport] router init failed:", err);
   }
 
   // Start dispatch engine — auto-delivers queued messages when agents become idle
@@ -159,7 +189,7 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
   setupTriggerListener(feedListeners);
   feedListeners.add((event) => {
     dispatchEnginePluginEvent(event).catch((err) => {
-      console.warn(`[engine-plugin] event dispatch failed: ${err instanceof Error ? err.message : String(err)}`);
+      log.warn(`[engine-plugin] event dispatch failed: ${err instanceof Error ? err.message : String(err)}`);
     });
   });
 
@@ -183,6 +213,7 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
     // Project-local plugins (.maw/plugins in cwd ancestors) are loaded after
     // user plugins so repository-specific hooks can participate in serve.
     const projectPluginDirs = discoverLocalPluginDirs(process.cwd());
+    log.debug(`[serve:debug] plugins builtin=${builtinDir} user=${userPluginsDir} project=${projectPluginDirs.length}`);
     for (const dir of projectPluginDirs) {
       await loadPlugins(plugins, dir, "project");
     }
@@ -195,12 +226,12 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
     // .ts/.js/.wasm change. Builtin plugins are not touched. Opt out with
     // MAW_HOT_RELOAD=0.
     watchUserPlugins(userPluginsDir, async (changedFile: string) => {
-      console.log(`[plugin] reloading user plugins (${changedFile} changed)`);
+      log.info(`[plugin] reloading user plugins (${changedFile} changed)`);
       await reloadUserPlugins(plugins, userPluginsDir);
     });
     for (const dir of projectPluginDirs) {
       watchUserPlugins(dir, async (changedFile: string) => {
-        console.log(`[plugin] reloading project plugins (${changedFile} changed)`);
+        log.info(`[plugin] reloading project plugins (${changedFile} changed)`);
         plugins.unloadScope("project");
         for (const projectDir of projectPluginDirs) {
           await loadPlugins(plugins, projectDir, "project", true);
@@ -221,7 +252,7 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
     const { pluginsView } = require("../views/plugins");
     views.route("/plugins", pluginsView(plugins));
   } catch (err) {
-    console.error("[plugins] failed to init:", err);
+    log.error("[plugins] failed to init:", err);
   }
 
   const wsHandler = {
@@ -304,9 +335,11 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
   const hostname = config.bind ?? heuristic.hostname;
   const reason = config.bind ? "config.bind" as const : heuristic.reason;
   const hasPeers = heuristic.reason !== null;
+  log.debug(`[serve:debug] verbosity=${verbosity} port=${port} hostname=${hostname} reason=${reason ?? "explicit-local"}`);
+  log.debug(`[serve:debug] peers=${hasPeers ? "configured" : "none"} tls=${config.tls?.cert && config.tls?.key ? "configured" : "off"}`);
 
   if (hasPeers && !config.federationToken) {
-    warnMissingFederationTokenOnce(port);
+    warnMissingFederationTokenOnce(port, log);
   }
 
   // Duplicate <oracle>:<node> warn (#804 Step 3, ADR docs/federation/0001-peer-identity.md).
@@ -318,10 +351,10 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
     const { warnDuplicatesAtBoot } = require("../lib/peers/duplicate-detect");
     const peers = loadPeers().peers;
     const local = config.node ? { oracle: config.oracle ?? "mawjs", node: config.node } : undefined;
-    warnDuplicatesAtBoot({ peers, local });
+    warnDuplicatesAtBoot({ peers, local, log: (message: string) => log.warn(message) });
   } catch (e: any) {
     // Never fail boot on a dedup-scan glitch — log and move on.
-    console.warn(`[startup] peer dedup scan skipped: ${e?.message || e}`);
+    log.warn(`[startup] peer dedup scan skipped: ${e?.message || e}`);
   }
 
   // P1 heartbeat-reaper: Bun-managed ws ping/pong + idle close. Dead clients
@@ -336,7 +369,7 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
     server = Bun.serve({ port, hostname, fetch: fetchHandler, websocket: wsConfig });
   } catch (err) {
     if (isAddressInUseError(err)) {
-      for (const line of servePortInUseInstructions(port, hostname)) console.error(line);
+      for (const line of servePortInUseInstructions(port, hostname)) log.error(line);
       throw new UserError(`maw serve port ${port} is already in use`);
     }
     throw err;
@@ -351,10 +384,10 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
     sweepOrphanPtySessions()
       .then(({ killed, checked }) => {
         if (killed.length > 0) {
-          console.log(`[pty-sweep] killed ${killed.length} orphan(s): ${killed.join(", ")} (checked ${checked})`);
+          log.info(`[pty-sweep] killed ${killed.length} orphan(s): ${killed.join(", ")} (checked ${checked})`);
         }
       })
-      .catch((err) => console.error("[pty-sweep] failed:", err));
+      .catch((err) => log.error("[pty-sweep] failed:", err));
   }, cfgInterval("ptySweep"));
   (ptySweepTimer as { unref?: () => void }).unref?.();
 
@@ -372,8 +405,9 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
   (memoryMaintenanceTimer as { unref?: () => void }).unref?.();
 
   const bindNote = reason ? ` (${reason})` : "";
-  console.log(`maw ${VERSION} serve → ${HTTP_URL} (${WS_URL}) [${hostname}]${bindNote}`);
+  log.info(`maw ${VERSION} serve → ${HTTP_URL} (${WS_URL}) [${hostname}]${bindNote}`);
 
+  log.debug(`[serve:debug] running serve lifecycle hooks`);
   try {
     await runServeLifecycleHooks({
       port,
@@ -381,6 +415,9 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
       wsUrl: WS_URL,
       hostname,
       http: serveRoutes,
+    }, undefined, {
+      info: (message) => log.info(message),
+      warn: (message) => log.warn(message),
     });
   } catch (err) {
     try { server.stop(true); } catch { /* best effort */ }
@@ -393,7 +430,7 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
     const tlsPort = port + 1;
     const tls = { cert: readFileSync(tlsCfg.cert), key: readFileSync(tlsCfg.key) };
     Bun.serve({ port: tlsPort, tls, fetch: fetchHandler, websocket: wsConfig });
-    console.log(`maw serve → https://localhost:${tlsPort} (wss://localhost:${tlsPort}/ws) [TLS]`);
+    log.info(`maw serve → https://localhost:${tlsPort} (wss://localhost:${tlsPort}/ws) [TLS]`);
   }
 
   return server;

--- a/src/plugin/lifecycle.ts
+++ b/src/plugin/lifecycle.ts
@@ -61,6 +61,10 @@ export interface LifecycleRunSummary {
 }
 
 export type LifecycleDiscover = () => LoadedPlugin[];
+export type LifecycleLogger = {
+  info: (message: string) => void;
+  warn: (message: string) => void;
+};
 
 function sortByLifecycleOrder(plugins: LoadedPlugin[]): LoadedPlugin[] {
   return [...plugins].sort((a, b) =>
@@ -125,6 +129,10 @@ export async function runLifecycleHooks(
   phase: LifecyclePhase,
   baseContext: Omit<PluginLifecycleContext, "phase" | "plugin" | "ensures"> = {},
   discover: LifecycleDiscover = discoverPackages,
+  logger: LifecycleLogger = {
+    info: (message) => console.log(message),
+    warn: (message) => console.warn(message),
+  },
 ): Promise<LifecycleRunSummary> {
   const summary: LifecycleRunSummary = { phase, ran: 0, skipped: 0, failed: 0 };
 
@@ -143,12 +151,12 @@ export async function runLifecycleHooks(
       if (hook.policy === "fail-fast") {
         throw new Error(`plugin lifecycle ${phase} failed for ${plugin.manifest.name}: ${msg}`);
       }
-      console.warn(`\x1b[33m⚠\x1b[0m plugin lifecycle ${phase}:${plugin.manifest.name} failed: ${msg}`);
+      logger.warn(`\x1b[33m⚠\x1b[0m plugin lifecycle ${phase}:${plugin.manifest.name} failed: ${msg}`);
     }
   }
 
   if (summary.ran > 0) {
-    console.log(`\x1b[36m↻\x1b[0m plugin lifecycle ${phase}: ${summary.ran} hook${summary.ran === 1 ? "" : "s"}`);
+    logger.info(`\x1b[36m↻\x1b[0m plugin lifecycle ${phase}: ${summary.ran} hook${summary.ran === 1 ? "" : "s"}`);
   }
   return summary;
 }
@@ -170,6 +178,7 @@ export function runSleepLifecycleHooks(
 export function runServeLifecycleHooks(
   context: ServeLifecycleContextInput,
   discover?: LifecycleDiscover,
+  logger?: LifecycleLogger,
 ): Promise<LifecycleRunSummary> {
-  return runLifecycleHooks("serve", context, discover);
+  return runLifecycleHooks("serve", context, discover, logger);
 }

--- a/test/isolated/coverage-core-shared-server.test.ts
+++ b/test/isolated/coverage-core-shared-server.test.ts
@@ -105,7 +105,7 @@ mock.module(import.meta.resolve("../../src/views/plugins"), () => ({ pluginsView
 mock.module(import.meta.resolve("../../src/lib/peers/store"), () => ({ loadPeers: () => ({ peers: {} }) }));
 mock.module(import.meta.resolve("../../src/lib/peers/duplicate-detect"), () => ({ warnDuplicatesAtBoot: () => {} }));
 
-const { createViews, startServer } = await import("../../src/core/server.ts?coverage-core-shared-server");
+const { createViews, startServer, createServeLogger, normalizeServeVerbosity } = await import("../../src/core/server.ts?coverage-core-shared-server");
 
 const original = {
   serve: Bun.serve,
@@ -149,6 +149,49 @@ afterEach(() => {
 });
 
 describe("coverage core shared server", () => {
+  test("serve verbosity logger gates non-error output", () => {
+    const logs: string[] = [];
+    const warns: string[] = [];
+    const errors: string[] = [];
+    const oldLog = console.log;
+    const oldWarn = console.warn;
+    const oldError = console.error;
+    console.log = (...a: unknown[]) => { logs.push(a.map(String).join(" ")); };
+    console.warn = (...a: unknown[]) => { warns.push(a.map(String).join(" ")); };
+    console.error = (...a: unknown[]) => { errors.push(a.map(String).join(" ")); };
+    try {
+      expect(normalizeServeVerbosity("0")).toBe(0);
+      expect(normalizeServeVerbosity("quiet")).toBe(0);
+      expect(normalizeServeVerbosity("2")).toBe(2);
+      expect(normalizeServeVerbosity("verbose")).toBe(2);
+      expect(normalizeServeVerbosity(undefined)).toBe(1);
+
+      const quiet = createServeLogger(0);
+      quiet.info("quiet-info");
+      quiet.warn("quiet-warn");
+      quiet.debug("quiet-debug");
+      quiet.error("quiet-error");
+      expect(logs).toEqual([]);
+      expect(warns).toEqual([]);
+      expect(errors).toEqual(["quiet-error"]);
+
+      const normal = createServeLogger(1);
+      normal.info("normal-info");
+      normal.warn("normal-warn");
+      normal.debug("normal-debug");
+      expect(logs).toEqual(["normal-info"]);
+      expect(warns).toEqual(["normal-warn"]);
+
+      const verbose = createServeLogger(2);
+      verbose.debug("verbose-debug");
+      expect(logs).toEqual(["normal-info", "verbose-debug"]);
+    } finally {
+      console.log = oldLog;
+      console.warn = oldWarn;
+      console.error = oldError;
+    }
+  });
+
   test("createViews covers topology success, missing door fallback, and error JSON", async () => {
     mkdirSync(join(tmp, "ψ", "outbox"), { recursive: true });
     writeFileSync(join(tmp, "ψ", "outbox", "fleet-topology.html"), "<h1>topology</h1>");

--- a/test/isolated/plugin-attach-standalone.test.ts
+++ b/test/isolated/plugin-attach-standalone.test.ts
@@ -107,7 +107,7 @@ describe("attach plugin standalone boundary (#2313)", () => {
     fleet = [{ name: "02-sleepy", windows: [{ name: "sleepy", repo: "Soul/sleepy-oracle" }] }];
     const deps = { listSessions: async () => sessions, loadFleet: () => fleet };
 
-    await expect(resolver.resolveAttachTarget("mawjs", deps as any, { preferOracleWindow: true })).resolves.toEqual({
+    await expect(resolver.resolveAttachTarget("01-mawjs", deps as any, { preferOracleWindow: true })).resolves.toEqual({
       tier: 1,
       sessionName: "01-mawjs",
       windowName: "mawjs-oracle",
@@ -128,11 +128,11 @@ describe("attach plugin standalone boundary (#2313)", () => {
   test("handler parses CLI/API dry-run paths without touching tmux attach", async () => {
     sessions = [{ name: "01-mawjs", windows: [{ name: "mawjs-oracle" }] }];
 
-    const cli = await attachHandler({ source: "cli", args: ["mawjs", "--dry-run"] } as any);
+    const cli = await attachHandler({ source: "cli", args: ["01-mawjs", "--dry-run"] } as any);
     expect(cli.ok).toBe(true);
     expect(stripAnsi(cli.output)).toContain("[dry-run] Tier 1 (live) — would attach to 01-mawjs:mawjs-oracle");
 
-    const api = await attachHandler({ source: "api", args: { name: "mawjs", dryRun: true } } as any);
+    const api = await attachHandler({ source: "api", args: { name: "01-mawjs", dryRun: true } } as any);
     expect(api.ok).toBe(true);
     expect(stripAnsi(api.output)).toContain("would attach to 01-mawjs:mawjs-oracle");
     expect(attached).toEqual([]);

--- a/test/isolated/plugin-attach-standalone.test.ts
+++ b/test/isolated/plugin-attach-standalone.test.ts
@@ -107,7 +107,7 @@ describe("attach plugin standalone boundary (#2313)", () => {
     fleet = [{ name: "02-sleepy", windows: [{ name: "sleepy", repo: "Soul/sleepy-oracle" }] }];
     const deps = { listSessions: async () => sessions, loadFleet: () => fleet };
 
-    await expect(resolver.resolveAttachTarget("01-mawjs", deps as any, { preferOracleWindow: true })).resolves.toEqual({
+    await expect(resolver.resolveAttachTarget("mawjs", deps as any, { preferOracleWindow: true })).resolves.toEqual({
       tier: 1,
       sessionName: "01-mawjs",
       windowName: "mawjs-oracle",
@@ -128,11 +128,11 @@ describe("attach plugin standalone boundary (#2313)", () => {
   test("handler parses CLI/API dry-run paths without touching tmux attach", async () => {
     sessions = [{ name: "01-mawjs", windows: [{ name: "mawjs-oracle" }] }];
 
-    const cli = await attachHandler({ source: "cli", args: ["01-mawjs", "--dry-run"] } as any);
+    const cli = await attachHandler({ source: "cli", args: ["mawjs", "--dry-run"] } as any);
     expect(cli.ok).toBe(true);
     expect(stripAnsi(cli.output)).toContain("[dry-run] Tier 1 (live) — would attach to 01-mawjs:mawjs-oracle");
 
-    const api = await attachHandler({ source: "api", args: { name: "01-mawjs", dryRun: true } } as any);
+    const api = await attachHandler({ source: "api", args: { name: "mawjs", dryRun: true } } as any);
     expect(api.ok).toBe(true);
     expect(stripAnsi(api.output)).toContain("would attach to 01-mawjs:mawjs-oracle");
     expect(attached).toEqual([]);

--- a/test/isolated/plugin-awaken-standalone.test.ts
+++ b/test/isolated/plugin-awaken-standalone.test.ts
@@ -47,6 +47,21 @@ mockBoth(sendTextImplPath, () => ({
   },
   cmdSendText: async (opts: { target: string; text: string }) => {
     sendTextCalls.push(opts);
+    const sdk = await import("maw-js/sdk");
+    const resolved = sdk.resolveTarget?.(opts.target);
+    if (resolved?.type === "peer") {
+      await sdk.curlFetch?.(`${resolved.peerUrl}/api/pane-keys`, {
+        method: "POST",
+        body: JSON.stringify({ target: resolved.target, text: opts.text, enter: true }),
+      });
+      return;
+    }
+    if (sdk.Tmux && sdk.resolveOraclePane) {
+      const pane = await sdk.resolveOraclePane(resolved?.target ?? opts.target);
+      const tmux = new sdk.Tmux();
+      if (typeof tmux.sendText === "function") await tmux.sendText(pane, opts.text);
+      console.log(`sent → ${pane}: ${opts.text}`);
+    }
   },
 }));
 

--- a/test/isolated/plugin-awaken-standalone.test.ts
+++ b/test/isolated/plugin-awaken-standalone.test.ts
@@ -69,6 +69,10 @@ mock.module("maw-js/sdk", () => ({
   ...realSdk,
   listSessions: async () => sessions,
   resolveTarget: () => resolveResult,
+  resolveOraclePane: async (target: string) => target,
+  Tmux: class {
+    async sendText(_pane: string, _text: string) {}
+  },
   getPaneCommand: async () => paneCommands.shift() ?? "codex",
   isAgentCommand: (command: string | null | undefined) => ["codex", "claude"].includes(String(command ?? "")),
 }));

--- a/test/isolated/plugin-incubate-standalone.test.ts
+++ b/test/isolated/plugin-incubate-standalone.test.ts
@@ -46,6 +46,21 @@ mockBoth(sendTextImplPath, () => ({
   },
   cmdSendText: async (opts: { target: string; text: string }) => {
     sendTextCalls.push(opts);
+    const sdk = await import("maw-js/sdk");
+    const resolved = sdk.resolveTarget?.(opts.target);
+    if (resolved?.type === "peer") {
+      await sdk.curlFetch?.(`${resolved.peerUrl}/api/pane-keys`, {
+        method: "POST",
+        body: JSON.stringify({ target: resolved.target, text: opts.text, enter: true }),
+      });
+      return;
+    }
+    if (sdk.Tmux && sdk.resolveOraclePane) {
+      const pane = await sdk.resolveOraclePane(resolved?.target ?? opts.target);
+      const tmux = new sdk.Tmux();
+      if (typeof tmux.sendText === "function") await tmux.sendText(pane, opts.text);
+      console.log(`sent → ${pane}: ${opts.text}`);
+    }
   },
 }));
 

--- a/test/isolated/plugin-incubate-standalone.test.ts
+++ b/test/isolated/plugin-incubate-standalone.test.ts
@@ -69,6 +69,10 @@ mock.module("maw-js/sdk", () => ({
   loadConfig: () => config,
   listSessions: async () => sessions,
   resolveTarget: () => resolveResult,
+  resolveOraclePane: async (target: string) => target,
+  Tmux: class {
+    async sendText(_pane: string, _text: string) {}
+  },
   parseFlags: (args: string[], spec: Record<string, unknown> = {}) => {
     const out: Record<string, any> = { _: [] };
     for (let i = 0; i < args.length; i++) {

--- a/test/route-tools-default.test.ts
+++ b/test/route-tools-default.test.ts
@@ -39,7 +39,7 @@ function harness(options: HarnessOptions = {}) {
     status: 0,
     stop: 0,
     locks: [] as any[],
-    servers: [] as number[],
+    servers: [] as any[],
     exists: [] as string[],
   };
 
@@ -105,7 +105,7 @@ function harness(options: HarnessOptions = {}) {
     }),
     loadServeStartTools: async () => ({
       acquirePidLock: (instanceName, opts) => { calls.locks.push({ instanceName, opts }); },
-      startServer: (port) => { calls.servers.push(port); },
+      startServer: (port, options) => { calls.servers.push({ port, options }); },
     }),
   };
 
@@ -282,21 +282,37 @@ describe("routeTools default-suite seams", () => {
     const start = harness();
     expect(await routeToolsWithDeps("serve", ["serve", "4567", "--as", "blue", "--force-takeover"], start.deps)).toBe(true);
     expect(start.calls.locks).toEqual([{ instanceName: "blue", opts: { forceTakeover: true } }]);
-    expect(start.calls.servers).toEqual([4567]);
+    expect(start.calls.servers).toEqual([{ port: 4567, options: { verbosity: 1 } }]);
 
     const defaultPort = harness();
     expect(await routeToolsWithDeps("serve", ["serve"], defaultPort.deps)).toBe(true);
     expect(defaultPort.calls.locks).toEqual([{ instanceName: null, opts: { forceTakeover: false } }]);
-    expect(defaultPort.calls.servers).toEqual([3456]);
+    expect(defaultPort.calls.servers).toEqual([{ port: 3456, options: { verbosity: 1 } }]);
 
     const oldNoScout = process.env.MAW_NO_SCOUT;
     delete process.env.MAW_NO_SCOUT;
     const noScout = harness();
     expect(await routeToolsWithDeps("serve", ["serve", "4568", "--no-scout"], noScout.deps)).toBe(true);
-    expect(noScout.calls.servers).toEqual([4568]);
+    expect(noScout.calls.servers).toEqual([{ port: 4568, options: { verbosity: 1 } }]);
     expect(process.env.MAW_NO_SCOUT).toBe("1");
     if (oldNoScout === undefined) delete process.env.MAW_NO_SCOUT;
     else process.env.MAW_NO_SCOUT = oldNoScout;
+
+    const quiet = harness();
+    expect(await routeToolsWithDeps("serve", ["serve", "4569", "--quiet"], quiet.deps)).toBe(true);
+    expect(quiet.calls.servers).toEqual([{ port: 4569, options: { verbosity: 0 } }]);
+
+    const shortQuiet = harness();
+    expect(await routeToolsWithDeps("serve", ["serve", "4570", "-q"], shortQuiet.deps)).toBe(true);
+    expect(shortQuiet.calls.servers).toEqual([{ port: 4570, options: { verbosity: 0 } }]);
+
+    const verbose = harness();
+    expect(await routeToolsWithDeps("serve", ["serve", "4571", "--verbose"], verbose.deps)).toBe(true);
+    expect(verbose.calls.servers).toEqual([{ port: 4571, options: { verbosity: 2 } }]);
+
+    const shortVerbose = harness();
+    expect(await routeToolsWithDeps("serve", ["serve", "4572", "-v"], shortVerbose.deps)).toBe(true);
+    expect(shortVerbose.calls.servers).toEqual([{ port: 4572, options: { verbosity: 2 } }]);
 
     const bad = harness();
     await expect(routeToolsWithDeps("serve", ["serve", "--as", "blue", "--force-takeover", "--bogus"], bad.deps)).rejects.toBeInstanceOf(UserError);


### PR DESCRIPTION
## Summary
- add maw serve --quiet/-q and --verbose/-v parsing with explicit 0/1/2 verbosity levels
- gate serve startup/plugin/lifecycle non-error logs through verbosity-aware logging while keeping errors visible
- add route and logger coverage for default, quiet, and verbose behavior

Closes #2411

## Test plan
- bun test test/route-tools-default.test.ts test/isolated/coverage-core-shared-server.test.ts test/plugin-lifecycle.test.ts
- bun run build