### PR TITLE
Extract identity route to serve plugin

### DIFF
--- a/src/api/federation.ts
+++ b/src/api/federation.ts
@@ -2,35 +2,11 @@ import { Elysia, t } from "elysia";
 import { getFederationStatus } from "../core/transport/peers";
 import { loadConfig } from "../config";
 import { listSnapshots, loadSnapshot } from "../core/fleet/snapshot";
-import { hostedAgents as defaultHostedAgents } from "../commands/shared/federation-sync";
 import { readFileSync, readdirSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
-import { getPeerKey } from "../lib/peer-key";
-import { resolveNodeIdentity } from "../core/fleet/node-identity";
 import { mawMessageLogCandidatePaths } from "../core/xdg";
 import { fleetDirsForRead, uniqueDirs } from "../core/fleet/paths";
-
-/**
- * Endpoints advertised by /api/identity (#804 Step 1).
- *
- * Lets peers discover supported API surfaces in one round-trip instead of
- * probing each path individually. Keep alphabetised + in sync with the actual
- * mounted routes — this is a contract, not documentation.
- */
-const ADVERTISED_ENDPOINTS: string[] = [
-  "/api/identity",
-  "/api/messages",
-  "/api/pane-keys",
-  "/api/probe",
-  "/api/send",
-  "/api/sleep",
-  "/api/wake",
-];
-
-// Re-export so existing importers (and any future code) can still reach
-// hostedAgents via the API module. The canonical home is federation-sync.ts.
-export { defaultHostedAgents as hostedAgents };
 
 type LedgerModule = {
   listMessageLedgerEvents: (query: {
@@ -49,10 +25,6 @@ export interface FederationApiDeps {
   listSnapshots?: typeof listSnapshots;
   loadSnapshot?: typeof loadSnapshot;
   loadConfig?: typeof loadConfig;
-  hostedAgents?: typeof defaultHostedAgents;
-  getPeerKey?: typeof getPeerKey;
-  packageVersion?: string;
-  uptime?: () => number;
   nowIso?: () => string;
   loadLedger?: () => Promise<LedgerModule>;
   readFileSync?: typeof readFileSync;
@@ -69,10 +41,6 @@ export function createFederationApi(deps: FederationApiDeps = {}) {
   const snapshots = deps.listSnapshots ?? listSnapshots;
   const snapshot = deps.loadSnapshot ?? loadSnapshot;
   const load = deps.loadConfig ?? loadConfig;
-  const agentsForHost = deps.hostedAgents ?? defaultHostedAgents;
-  const peerKey = deps.getPeerKey ?? getPeerKey;
-  const version = deps.packageVersion ?? require("../../package.json").version;
-  const uptime = deps.uptime ?? (() => process.uptime());
   const nowIso = deps.nowIso ?? (() => new Date().toISOString());
   const readFile = deps.readFileSync ?? readFileSync;
   const readDir = deps.readdirSync ?? readdirSync;
@@ -104,43 +72,6 @@ export function createFederationApi(deps: FederationApiDeps = {}) {
     const snap = snapshot(params.id);
     if (!snap) { set.status = 404; return { error: "snapshot not found" }; }
     return snap;
-  });
-
-  /**
-   * Node identity — public endpoint for federation dedup (#192) + clock health (#268).
-   *
-   * #804 Step 1 (ADR docs/federation/0001-peer-identity.md): also advertises
-   *   - `endpoints`: supported API paths so peers can discover capabilities
-   *     in one round-trip (closes the version-skew pressure).
-   *   - `pubkey`: per-peer identity for TOFU pinning + Step 4 signing. Persisted
-   *     at <CONFIG_DIR>/peer-key (SSH host-key model).
-   */
-  federationApi.get("/identity", async () => {
-    const config = load();
-    const identity = resolveNodeIdentity(config, {
-      fallbackHost: "local",
-      user: process.env.USER || process.env.LOGNAME,
-    });
-    const node = identity.node;
-    const host = identity.host;
-    const oracle = config.oracle ?? "mawjs";
-    const agents = [...new Set([
-      ...agentsForHost(config.agents || {}, node),
-      ...(host !== node ? agentsForHost(config.agents || {}, host) : []),
-    ])];
-    return {
-      node,
-      host,
-      ...(identity.user ? { user: identity.user } : {}),
-      ...(identity.port !== undefined ? { port: identity.port } : {}),
-      oracle,
-      version,
-      agents,
-      uptime: Math.floor(uptime()),
-      clockUtc: nowIso(),
-      endpoints: ADVERTISED_ENDPOINTS,
-      pubkey: peerKey(),
-    };
   });
 
   /** Message log — query SQLite message ledger, falling back to legacy maw-log.jsonl. */

--- a/src/vendor/mpr-plugins/serve-identity/impl.ts
+++ b/src/vendor/mpr-plugins/serve-identity/impl.ts
@@ -1,0 +1,81 @@
+import { Elysia } from "elysia";
+import { loadConfig } from "../../../config";
+import { hostedAgents as defaultHostedAgents } from "../../../commands/shared/federation-sync";
+import { getPeerKey } from "../../../lib/peer-key";
+import { resolveNodeIdentity } from "../../../core/fleet/node-identity";
+
+/**
+ * Endpoints advertised by /api/identity (#804 Step 1).
+ *
+ * Lets peers discover supported API surfaces in one round-trip instead of
+ * probing each path individually. Keep alphabetised + in sync with the actual
+ * mounted routes — this is a contract, not documentation.
+ */
+export const ADVERTISED_ENDPOINTS: string[] = [
+  "/api/identity",
+  "/api/messages",
+  "/api/pane-keys",
+  "/api/probe",
+  "/api/send",
+  "/api/sleep",
+  "/api/wake",
+];
+
+export interface IdentityApiDeps {
+  loadConfig?: typeof loadConfig;
+  hostedAgents?: typeof defaultHostedAgents;
+  getPeerKey?: typeof getPeerKey;
+  packageVersion?: string;
+  uptime?: () => number;
+  nowIso?: () => string;
+}
+
+export function createIdentityApi(deps: IdentityApiDeps = {}) {
+  const load = deps.loadConfig ?? loadConfig;
+  const agentsForHost = deps.hostedAgents ?? defaultHostedAgents;
+  const peerKey = deps.getPeerKey ?? getPeerKey;
+  const version = deps.packageVersion ?? require("../../../../package.json").version;
+  const uptime = deps.uptime ?? (() => process.uptime());
+  const nowIso = deps.nowIso ?? (() => new Date().toISOString());
+
+  const identityApi = new Elysia();
+
+  /**
+   * Node identity — public endpoint for federation dedup (#192) + clock health (#268).
+   *
+   * #804 Step 1 (ADR docs/federation/0001-peer-identity.md): also advertises
+   *   - `endpoints`: supported API paths so peers can discover capabilities
+   *     in one round-trip (closes the version-skew pressure).
+   *   - `pubkey`: per-peer identity for TOFU pinning + Step 4 signing. Persisted
+   *     at <CONFIG_DIR>/peer-key (SSH host-key model).
+   */
+  identityApi.get("/identity", async () => {
+    const config = load();
+    const identity = resolveNodeIdentity(config, {
+      fallbackHost: "local",
+      user: process.env.USER || process.env.LOGNAME,
+    });
+    const node = identity.node;
+    const host = identity.host;
+    const oracle = config.oracle ?? "mawjs";
+    const agents = [...new Set([
+      ...agentsForHost(config.agents || {}, node),
+      ...(host !== node ? agentsForHost(config.agents || {}, host) : []),
+    ])];
+    return {
+      node,
+      host,
+      ...(identity.user ? { user: identity.user } : {}),
+      ...(identity.port !== undefined ? { port: identity.port } : {}),
+      oracle,
+      version,
+      agents,
+      uptime: Math.floor(uptime()),
+      clockUtc: nowIso(),
+      endpoints: ADVERTISED_ENDPOINTS,
+      pubkey: peerKey(),
+    };
+  });
+
+  return identityApi;
+}

--- a/src/vendor/mpr-plugins/serve-identity/index.ts
+++ b/src/vendor/mpr-plugins/serve-identity/index.ts
@@ -1,0 +1,25 @@
+import { api } from "../../../api";
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { createIdentityApi } from "./impl";
+
+let registered = false;
+
+/** Register GET /api/identity during maw serve startup. */
+export async function serve(): Promise<{ ok: true; registered: boolean }> {
+  if (!registered) {
+    api.use(createIdentityApi());
+    registered = true;
+  }
+  return { ok: true, registered };
+}
+
+export async function registerIdentityRouteForTests(targetApi: { use: (plugin: ReturnType<typeof createIdentityApi>) => unknown }): Promise<void> {
+  targetApi.use(createIdentityApi());
+}
+
+export default async function handler(_ctx: InvokeContext): Promise<InvokeResult> {
+  return { ok: true, output: "serve-identity registers GET /api/identity from the maw serve lifecycle hook" };
+}
+
+export { ADVERTISED_ENDPOINTS, createIdentityApi } from "./impl";
+export type { IdentityApiDeps } from "./impl";

--- a/src/vendor/mpr-plugins/serve-identity/plugin.json
+++ b/src/vendor/mpr-plugins/serve-identity/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "serve-identity",
+  "version": "0.1.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "tier": "core",
+  "description": "Registers the public /api/identity route during maw serve startup.",
+  "author": "Soul-Brews-Studio",
+  "hooks": {
+    "serve": {
+      "script": "./index.ts",
+      "handler": "serve",
+      "ensures": ["http:route:/api/identity"],
+      "policy": "fail-fast"
+    }
+  },
+  "module": {
+    "path": "./index.ts",
+    "exports": ["createIdentityApi", "ADVERTISED_ENDPOINTS"]
+  },
+  "capabilities": ["serve:http-route", "identity:read"],
+  "weight": 10,
+  "license": "MIT",
+  "schemaVersion": 1,
+  "capabilityNamespaces": ["serve", "identity"]
+}

--- a/test/federation-api-default.test.ts
+++ b/test/federation-api-default.test.ts
@@ -4,9 +4,14 @@ import { mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { createFederationApi, type FederationApiDeps } from "../src/api/federation";
+import { createIdentityApi, type IdentityApiDeps } from "../src/vendor/mpr-plugins/serve-identity/impl";
 
 function makeApp(deps: FederationApiDeps = {}) {
   return new Elysia().use(createFederationApi(deps));
+}
+
+function makeIdentityApp(deps: IdentityApiDeps = {}) {
+  return new Elysia().use(createIdentityApi(deps));
 }
 
 async function readJson(res: Response) {
@@ -14,7 +19,7 @@ async function readJson(res: Response) {
 }
 
 describe("federation API identity/status/snapshot routes", () => {
-  test("serves federation status, snapshots, identity, and auth status", async () => {
+  test("serves federation status, snapshots, and auth status", async () => {
     const app = makeApp({
       getFederationStatus: async () => ({ peers: [{ name: "m5" }] }) as any,
       listSnapshots: () => [{ id: "s1" }] as any,
@@ -27,12 +32,6 @@ describe("federation API identity/status/snapshot routes", () => {
         agents: { codex: "m5", buddy: "codex@m5" },
         federationToken: "abcd-secret",
       })) as any,
-      hostedAgents: ((agents: any, node: string) => Object.entries(agents)
-        .filter(([, n]) => n === node)
-        .map(([name]) => ({ node, name }))) as any,
-      getPeerKey: () => "peer-public-key",
-      packageVersion: "v.test",
-      uptime: () => 42.9,
       nowIso: () => "2026-05-17T00:00:00.000Z",
     });
 
@@ -43,6 +42,54 @@ describe("federation API identity/status/snapshot routes", () => {
     const missing = await app.handle(new Request("http://localhost/snapshots/missing"));
     expect(missing.status).toBe(404);
     expect(await readJson(missing)).toEqual({ error: "snapshot not found" });
+
+
+    expect(await readJson(await app.handle(new Request("http://localhost/auth/status")))).toEqual({
+      enabled: true,
+      tokenConfigured: true,
+      tokenPreview: "abcd****",
+      method: "HMAC-SHA256",
+      clockUtc: "2026-05-17T00:00:00.000Z",
+      node: "m5",
+    });
+  });
+
+  test("identity and auth status default missing config fields", async () => {
+    const app = makeApp({
+      loadConfig: (() => ({})) as any,
+      nowIso: () => "now",
+    });
+
+    expect(await readJson(await app.handle(new Request("http://localhost/auth/status")))).toEqual({
+      enabled: false,
+      tokenConfigured: false,
+      tokenPreview: null,
+      method: "none",
+      clockUtc: "now",
+      node: "local",
+    });
+  });
+
+});
+
+describe("serve-identity plugin API", () => {
+  test("serves the existing identity contract", async () => {
+    const app = makeIdentityApp({
+      loadConfig: (() => ({
+        node: "m5",
+        nodeUser: "codex",
+        port: 4567,
+        oracle: "mawjs-oracle",
+        agents: { codex: "m5", buddy: "codex@m5" },
+      })) as any,
+      hostedAgents: ((agents: any, node: string) => Object.entries(agents)
+        .filter(([, n]) => n === node)
+        .map(([name]) => ({ node, name }))) as any,
+      getPeerKey: () => "peer-public-key",
+      packageVersion: "v.test",
+      uptime: () => 42.9,
+      nowIso: () => "2026-05-17T00:00:00.000Z",
+    });
 
     expect(await readJson(await app.handle(new Request("http://localhost/identity")))).toEqual({
       node: "codex@m5",
@@ -65,40 +112,10 @@ describe("federation API identity/status/snapshot routes", () => {
       ],
       pubkey: "peer-public-key",
     });
-
-    expect(await readJson(await app.handle(new Request("http://localhost/auth/status")))).toEqual({
-      enabled: true,
-      tokenConfigured: true,
-      tokenPreview: "abcd****",
-      method: "HMAC-SHA256",
-      clockUtc: "2026-05-17T00:00:00.000Z",
-      node: "m5",
-    });
   });
 
-  test("identity and auth status default missing config fields", async () => {
-    const app = makeApp({
-      loadConfig: (() => ({})) as any,
-      hostedAgents: (() => []) as any,
-      getPeerKey: () => "pub",
-      packageVersion: "v.test",
-      uptime: () => 1,
-      nowIso: () => "now",
-    });
-
-    expect((await readJson(await app.handle(new Request("http://localhost/identity")))).node).toBe("local");
-    expect(await readJson(await app.handle(new Request("http://localhost/auth/status")))).toEqual({
-      enabled: false,
-      tokenConfigured: false,
-      tokenPreview: null,
-      method: "none",
-      clockUtc: "now",
-      node: "local",
-    });
-  });
-
-  test("production default callbacks remain callable without writing peer keys", async () => {
-    const tmp = mkdtempSync(join(tmpdir(), "maw-federation-api-"));
+  test("defaults missing config fields and production callbacks remain callable", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "maw-identity-plugin-"));
     const savedPeerKey = process.env.MAW_PEER_KEY;
     const savedConfigDir = process.env.MAW_CONFIG_DIR;
     const savedDataDir = process.env.MAW_DATA_DIR;
@@ -106,18 +123,12 @@ describe("federation API identity/status/snapshot routes", () => {
     process.env.MAW_CONFIG_DIR = tmp;
     process.env.MAW_DATA_DIR = join(tmp, "data");
     try {
-      const app = makeApp({
-        homedir: () => tmp,
-        readFileSync: (() => { throw new Error("no legacy log"); }) as any,
-      });
-
+      const app = makeIdentityApp({ loadConfig: (() => ({})) as any });
       const identity = await readJson(await app.handle(new Request("http://localhost/identity")));
+      expect(identity.node).toBe("local");
       expect(identity.pubkey).toBe("test-peer-key");
       expect(typeof identity.uptime).toBe("number");
       expect(typeof identity.clockUtc).toBe("string");
-
-      const messages = await readJson(await app.handle(new Request("http://localhost/messages?limit=1")));
-      expect(messages).toEqual({ messages: [], total: 0 });
     } finally {
       if (savedPeerKey === undefined) delete process.env.MAW_PEER_KEY;
       else process.env.MAW_PEER_KEY = savedPeerKey;
@@ -129,6 +140,7 @@ describe("federation API identity/status/snapshot routes", () => {
     }
   });
 });
+
 
 describe("federation API messages route", () => {
   test("returns sqlite ledger messages with bounded query options", async () => {

--- a/test/isolated/api-identity-fields.test.ts
+++ b/test/isolated/api-identity-fields.test.ts
@@ -24,8 +24,8 @@ delete process.env.MAW_JWT_SECRET;
 let app: Elysia;
 
 beforeAll(async () => {
-  const { federationApi } = await import("../../src/api/federation");
-  app = new Elysia().use(federationApi);
+  const { createIdentityApi } = await import("../../src/vendor/mpr-plugins/serve-identity/impl");
+  app = new Elysia().use(createIdentityApi());
 });
 
 afterAll(() => {

--- a/test/isolated/plugin-serve-identity-standalone.test.ts
+++ b/test/isolated/plugin-serve-identity-standalone.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { Elysia } from "elysia";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
+import { createIdentityApi } from "../../src/vendor/mpr-plugins/serve-identity/impl";
+
+const root = join(import.meta.dir, "../..");
+
+describe("serve-identity plugin standalone boundary", () => {
+  test("declares the serve hook and keeps route registration out of federationApi", () => {
+    const manifest = JSON.parse(readFileSync(join(root, "src/vendor/mpr-plugins/serve-identity/plugin.json"), "utf8"));
+    expect(manifest.hooks.serve).toMatchObject({ script: "./index.ts", handler: "serve", policy: "fail-fast" });
+    expect(manifest.api).toBeUndefined();
+    expect(readFileSync(join(root, "src/api/federation.ts"), "utf8")).not.toContain('get("/identity"');
+  });
+
+  test("boundary drift is explicit for this core serve route plugin", () => {
+    expectStandalonePluginBoundary({
+      plugin: "serve-identity",
+      requireSdk: false,
+      allowRelative: [
+        /^\.\.\/\.\.\/\.\.\/api$/,
+        /^\.\.\/\.\.\/\.\.\/config$/,
+        /^\.\.\/\.\.\/\.\.\/commands\/shared\/federation-sync$/,
+        /^\.\.\/\.\.\/\.\.\/lib\/peer-key$/,
+        /^\.\.\/\.\.\/\.\.\/core\/fleet\/node-identity$/,
+        /^\.\.\/\.\.\/\.\.\/plugin\/types$/,
+      ],
+    });
+  });
+
+  test("serve hook mounts /api/identity on the shared API app", async () => {
+    const savedPeerKey = process.env.MAW_PEER_KEY;
+    process.env.MAW_PEER_KEY = "hook-peer-key";
+    try {
+      const { api } = await import("../../src/api");
+      const { serve } = await import("../../src/vendor/mpr-plugins/serve-identity/index.ts?serve-hook-test");
+      await serve();
+
+      const after = await api.handle(new Request("http://localhost/api/identity"));
+      expect(after.status).toBe(200);
+      const body = await after.json() as Record<string, unknown>;
+      expect(body.pubkey).toBe("hook-peer-key");
+      expect(body.endpoints).toEqual(expect.arrayContaining(["/api/identity", "/api/send"]));
+    } finally {
+      if (savedPeerKey === undefined) delete process.env.MAW_PEER_KEY;
+      else process.env.MAW_PEER_KEY = savedPeerKey;
+    }
+  });
+
+  test("serves the unchanged identity response shape", async () => {
+    const app = new Elysia().use(createIdentityApi({
+      loadConfig: (() => ({ node: "m5", nodeUser: "codex", port: 3456, oracle: "mawjs", agents: { neo: "codex@m5" } })) as any,
+      hostedAgents: ((agents: any, node: string) => Object.entries(agents)
+        .filter(([, value]) => value === node)
+        .map(([name]) => ({ node, name }))) as any,
+      getPeerKey: () => "pub",
+      packageVersion: "v.test",
+      uptime: () => 2.9,
+      nowIso: () => "2026-06-07T00:00:00.000Z",
+    }));
+
+    const res = await app.handle(new Request("http://localhost/identity"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      node: "codex@m5",
+      host: "m5",
+      user: "codex",
+      port: 3456,
+      oracle: "mawjs",
+      version: "v.test",
+      agents: [{ node: "codex@m5", name: "neo" }],
+      uptime: 2,
+      clockUtc: "2026-06-07T00:00:00.000Z",
+      endpoints: ["/api/identity", "/api/messages", "/api/pane-keys", "/api/probe", "/api/send", "/api/sleep", "/api/wake"],
+      pubkey: "pub",
+    });
+  });
+});


### PR DESCRIPTION
Closes #2433

## Summary
- moved the /api/identity handler into bundled MPR plugin src/vendor/mpr-plugins/serve-identity
- registered the route from the plugin lifecycle serve hook instead of the federation API pack
- preserved the identity response contract and endpoint advertisement

## Verification
- bun scripts/check-plugin-coverage-gate.ts origin/alpha
- bun test test/federation-api-default.test.ts test/isolated/api-identity-fields.test.ts test/isolated/plugin-serve-identity-standalone.test.ts test/plugin-manifest.test.ts --path-ignore-patterns '**/agents/**'\n- bun run build