### PR TITLE
Extract triggers read route to serve plugin

### DIFF
--- a/src/api/triggers.ts
+++ b/src/api/triggers.ts
@@ -1,46 +1,16 @@
 import { Elysia } from "elysia";
-import { getTriggers, getTriggerHistory, fire, type TriggerContext } from "../core/runtime/triggers";
+import { fire, type TriggerContext } from "../core/runtime/triggers";
 import type { TriggerEvent } from "../config";
 import { TriggerFireBody, type TTriggerFireBody } from "../lib/schemas";
 
 export interface TriggersApiDeps {
-  getTriggers: typeof getTriggers;
-  getTriggerHistory: typeof getTriggerHistory;
   fire: typeof fire;
 }
 
 export function createTriggersApi(deps: TriggersApiDeps = {
-  getTriggers,
-  getTriggerHistory,
   fire,
 }) {
   const api = new Elysia();
-
-  /** GET /triggers — list configured triggers + last fired */
-  api.get("/triggers", () => {
-    const triggers = deps.getTriggers();
-    const history = deps.getTriggerHistory();
-
-    const items = triggers.map((t, i) => {
-      const last = history.find(h => h.index === i);
-      return {
-        index: i,
-        on: t.on,
-        repo: t.repo || null,
-        timeout: t.timeout || null,
-        action: t.action,
-        name: t.name || null,
-        lastFired: last ? {
-          ts: last.result.ts,
-          ok: last.result.ok,
-          action: last.result.action,
-          error: last.result.error || null,
-        } : null,
-      };
-    });
-
-    return { triggers: items, total: items.length };
-  });
 
   /** POST /triggers/fire — manually fire a trigger event */
   api.post("/triggers/fire", async ({ body }) => {

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -120,6 +120,7 @@ export interface LoadedPlugin {
   disabled?: boolean;     // true if plugin is in disabledPlugins config list
 }
 
+
 export interface InvokeContext {
   source: "cli" | "api" | "peer";
   args: string[] | Record<string, unknown>;

--- a/src/vendor/mpr-plugins/serve-triggers/index.ts
+++ b/src/vendor/mpr-plugins/serve-triggers/index.ts
@@ -1,0 +1,46 @@
+import { getTriggerHistory, getTriggers } from "maw-js/sdk";
+import type { ServeHttpRouteRegistrar } from "maw-js/plugin/types";
+
+type TriggerReadDeps = {
+  getTriggers: typeof getTriggers;
+  getTriggerHistory: typeof getTriggerHistory;
+};
+
+type ServeTriggersContext = {
+  http?: ServeHttpRouteRegistrar;
+};
+
+export function buildTriggersReadResponse(deps: TriggerReadDeps = {
+  getTriggers,
+  getTriggerHistory,
+}) {
+  const triggers = deps.getTriggers();
+  const history = deps.getTriggerHistory();
+
+  const items = triggers.map((t, i) => {
+    const last = history.find(h => h.index === i);
+    return {
+      index: i,
+      on: t.on,
+      repo: t.repo || null,
+      timeout: t.timeout || null,
+      action: t.action,
+      name: t.name || null,
+      lastFired: last ? {
+        ts: last.result.ts,
+        ok: last.result.ok,
+        action: last.result.action,
+        error: last.result.error || null,
+      } : null,
+    };
+  });
+
+  return { triggers: items, total: items.length };
+}
+
+export function serve(ctx: ServeTriggersContext) {
+  if (!ctx.http) throw new Error("serve-triggers requires serve http route registration");
+  ctx.http.route("GET", "/api/triggers", () => Response.json(buildTriggersReadResponse()));
+}
+
+export default serve;

--- a/src/vendor/mpr-plugins/serve-triggers/plugin.json
+++ b/src/vendor/mpr-plugins/serve-triggers/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "serve-triggers",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Registers the read-only maw serve triggers API route.",
+  "author": "Soul-Brews-Studio",
+  "hooks": {
+    "serve": {
+      "script": "./index.ts",
+      "handler": "serve",
+      "policy": "fail-fast"
+    }
+  },
+  "weight": 0,
+  "license": "MIT",
+  "schemaVersion": 1
+}

--- a/test/api-runtime-default.test.ts
+++ b/test/api-runtime-default.test.ts
@@ -170,57 +170,9 @@ describe("runtime API routers default-suite coverage", () => {
     expect(Number.isNaN(Date.parse(body.timestamp))).toBe(false);
   });
 
-  test("triggers API renders configured triggers with last-fired history", async () => {
-    const app = apiWith(createTriggersApi({
-      getTriggers: () => [
-        { on: "pr-merge", repo: "Soul-Brews-Studio/maw-js", action: "maw hey", name: "notify" },
-        { on: "agent-idle", timeout: 60, action: "maw wake" },
-      ],
-      getTriggerHistory: () => [{
-        index: 0,
-        result: {
-          trigger: { on: "pr-merge", action: "maw hey" },
-          action: "maw hey",
-          ok: true,
-          output: "sent",
-          ts: 123,
-        },
-      }],
-      fire: (async () => []) as any,
-    }));
-
-    const res = await app.handle(new Request("http://local/api/triggers"));
-    expect(res.status).toBe(200);
-    expect(await json(res)).toEqual({
-      total: 2,
-      triggers: [
-        {
-          index: 0,
-          on: "pr-merge",
-          repo: "Soul-Brews-Studio/maw-js",
-          timeout: null,
-          action: "maw hey",
-          name: "notify",
-          lastFired: { ts: 123, ok: true, action: "maw hey", error: null },
-        },
-        {
-          index: 1,
-          on: "agent-idle",
-          repo: null,
-          timeout: 60,
-          action: "maw wake",
-          name: null,
-          lastFired: null,
-        },
-      ],
-    });
-  });
-
   test("triggers API awaits fire results and normalizes optional output/error", async () => {
     const calls: any[] = [];
     const app = apiWith(createTriggersApi({
-      getTriggers: () => [],
-      getTriggerHistory: () => [],
       fire: async (event, ctx) => {
         calls.push({ event, ctx });
         return [

--- a/test/isolated/coverage-core-shared-server.test.ts
+++ b/test/isolated/coverage-core-shared-server.test.ts
@@ -82,7 +82,10 @@ mock.module(import.meta.resolve("../../src/api/tmux-stream"), () => ({
 }));
 mock.module(import.meta.resolve("../../src/lib/elysia-auth"), () => ({ setBunServer: () => {} }));
 mock.module(import.meta.resolve("../../src/plugin/lifecycle"), () => ({
-  runServeLifecycleHooks: async (payload: unknown) => { lifecyclePayloads.push(payload); },
+  runServeLifecycleHooks: async (payload: any) => {
+    lifecyclePayloads.push(payload);
+    payload.http?.route("GET", "/api/triggers", () => new Response("plugin triggers"));
+  },
 }));
 mock.module(import.meta.resolve("../../src/core/engine-plugin-registry"), () => ({
   dispatchEnginePluginEvent: async () => {},
@@ -169,7 +172,7 @@ describe("coverage core shared server", () => {
     expect(engineCalls).toContain("router");
     expect(lifecyclePayloads).toHaveLength(1);
     expect(lifecyclePayloads[0]).toMatchObject({ port: 4910, httpUrl: "http://localhost:4910", wsUrl: "ws://localhost:4910/ws", hostname: "127.0.0.1" });
-    expect((lifecyclePayloads[0] as any).http).toBeDefined();
+    expect((lifecyclePayloads[0] as any).http).toEqual(expect.objectContaining({ route: expect.any(Function) }));
     expect(healthPolls).toBe(1);
 
     const ws = serveCalls[0].websocket;
@@ -196,6 +199,7 @@ describe("coverage core shared server", () => {
     expect(options.headers.get("Access-Control-Allow-Origin")).toBe("http://origin.test");
     expect(await (await fetch(new Request("http://local/api/engine"), upgradeServer(true))).text()).toBe("proxied");
     expect(proxiedPaths).toEqual(["/api/engine"]);
+    expect(await (await fetch(new Request("http://local/api/triggers"), upgradeServer(true))).text()).toBe("plugin triggers");
     expect(await (await fetch(new Request("http://local/api/ordinary"), upgradeServer(true))).text()).toBe("api");
     expect(apiPaths).toEqual(["/api/ordinary"]);
 

--- a/test/isolated/plugin-serve-triggers-standalone.test.ts
+++ b/test/isolated/plugin-serve-triggers-standalone.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, mock, test } from "bun:test";
+import { join } from "node:path";
+import { readFileSync } from "node:fs";
+import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
+
+const root = join(import.meta.dir, "../..");
+let triggers: any[] = [];
+let history: any[] = [];
+
+mock.module("maw-js/sdk", () => ({
+  getTriggers: () => triggers,
+  getTriggerHistory: () => history,
+}));
+
+const plugin = await import("../../src/vendor/mpr-plugins/serve-triggers/index.ts?plugin-serve-triggers-standalone");
+
+describe("serve-triggers plugin standalone boundary", () => {
+  test("imports runtime reads through the SDK and serve route types only", () => {
+    const source = readFileSync(join(root, "src/vendor/mpr-plugins/serve-triggers/index.ts"), "utf8");
+    expect(source).toContain('from "maw-js/sdk"');
+    expect(source).toContain('from "maw-js/plugin/types"');
+    expectStandalonePluginBoundary({ plugin: "serve-triggers" });
+  });
+
+  test("builds the legacy GET /api/triggers response shape", () => {
+    const response = plugin.buildTriggersReadResponse({
+      getTriggers: () => [
+        { on: "pr-merge", repo: "Soul-Brews-Studio/maw-js", action: "maw hey", name: "notify" },
+        { on: "agent-idle", timeout: 60, action: "maw wake" },
+      ],
+      getTriggerHistory: () => [{
+        index: 0,
+        result: {
+          trigger: { on: "pr-merge", action: "maw hey" },
+          action: "maw hey",
+          ok: true,
+          output: "sent",
+          ts: 123,
+        },
+      }],
+    });
+
+    expect(response).toEqual({
+      total: 2,
+      triggers: [
+        {
+          index: 0,
+          on: "pr-merge",
+          repo: "Soul-Brews-Studio/maw-js",
+          timeout: null,
+          action: "maw hey",
+          name: "notify",
+          lastFired: { ts: 123, ok: true, action: "maw hey", error: null },
+        },
+        {
+          index: 1,
+          on: "agent-idle",
+          repo: null,
+          timeout: 60,
+          action: "maw wake",
+          name: null,
+          lastFired: null,
+        },
+      ],
+    });
+  });
+
+  test("serve hook registers GET /api/triggers", async () => {
+    triggers = [{ on: "issue-close", action: "maw done", repo: "repo", name: "done" }];
+    history = [{ index: 0, result: { ts: 456, ok: false, action: "maw done", error: "boom" } }];
+    const routes: Array<{ method: string; path: string; handler: (request: Request) => Response | Promise<Response> }> = [];
+
+    plugin.serve({
+      http: {
+        route: (method, path, handler) => routes.push({ method, path, handler }),
+      },
+    });
+
+    expect(routes.map(({ method, path }) => `${method} ${path}`)).toEqual(["GET /api/triggers"]);
+    const res = await routes[0].handler(new Request("http://local/api/triggers"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      total: 1,
+      triggers: [{
+        index: 0,
+        on: "issue-close",
+        repo: "repo",
+        timeout: null,
+        action: "maw done",
+        name: "done",
+        lastFired: { ts: 456, ok: false, action: "maw done", error: "boom" },
+      }],
+    });
+  });
+
+  test("serve hook fails clearly without route registration context", () => {
+    expect(() => plugin.serve({})).toThrow("serve-triggers requires serve http route registration");
+  });
+});

--- a/test/isolated/serve-route-registry.test.ts
+++ b/test/isolated/serve-route-registry.test.ts
@@ -4,15 +4,24 @@ import { ServeRouteRegistry } from "../../src/core/serve-route-registry";
 describe("ServeRouteRegistry", () => {
   test("dispatches exact registered method/path before returning undefined", async () => {
     const registry = new ServeRouteRegistry();
-    registry.route("GET", "/api/worktrees", () => Response.json({ ok: true }));
+    registry.route("GET", "/api/worktrees", () => Response.json({ ok: true, route: "worktrees" }));
+    registry.route("GET", "/api/triggers", () => Response.json({ ok: true, route: "triggers" }));
 
-    const hit = await registry.handle(new Request("http://local/api/worktrees?ignored=1"));
-    expect(hit?.status).toBe(200);
-    expect(await hit!.json()).toEqual({ ok: true });
+    const worktrees = await registry.handle(new Request("http://local/api/worktrees?ignored=1"));
+    expect(worktrees?.status).toBe(200);
+    expect(await worktrees!.json()).toEqual({ ok: true, route: "worktrees" });
+
+    const triggers = await registry.handle(new Request("http://local/api/triggers?ignored=1"));
+    expect(triggers?.status).toBe(200);
+    expect(await triggers!.json()).toEqual({ ok: true, route: "triggers" });
 
     expect(await registry.handle(new Request("http://local/api/worktrees", { method: "POST" }))).toBeUndefined();
+    expect(await registry.handle(new Request("http://local/api/triggers/extra"))).toBeUndefined();
     expect(await registry.handle(new Request("http://local/api/other"))).toBeUndefined();
-    expect(registry.snapshot()).toEqual([{ method: "GET", path: "/api/worktrees" }]);
+    expect(registry.snapshot()).toEqual([
+      { method: "GET", path: "/api/worktrees" },
+      { method: "GET", path: "/api/triggers" },
+    ]);
   });
 
   test("rejects non-absolute paths and duplicate routes", () => {
@@ -20,5 +29,7 @@ describe("ServeRouteRegistry", () => {
     expect(() => registry.route("GET", "api/worktrees", () => new Response())).toThrow("serve route path must start");
     registry.route("GET", "/api/worktrees", () => new Response());
     expect(() => registry.route("get" as any, "/api/worktrees", () => new Response())).toThrow("serve route already registered");
+    registry.route("GET", "/api/triggers", () => new Response());
+    expect(() => registry.route("GET", "/api/triggers", () => new Response())).toThrow("serve route already registered: GET /api/triggers");
   });
 });


### PR DESCRIPTION
## Summary
- add a minimal serve route registry and pass it to serve lifecycle hooks
- move GET /api/triggers into vendored serve-triggers plugin
- keep POST /api/triggers/fire on the existing triggers API

## Verification
- bun scripts/check-plugin-coverage-gate.ts origin/alpha
- bun test test/isolated/plugin-serve-triggers-standalone.test.ts test/isolated/serve-route-registry.test.ts test/api-runtime-default.test.ts test/isolated/coverage-core-shared-server.test.ts
- bun test test/isolated/plugin-lifecycle.test.ts
- bun test test/plugin-lifecycle.test.ts
- bun run build

Closes #2435