### PR TITLE
Extract serve static views into plugin

### DIFF
--- a/src/core/serve-route-registry.ts
+++ b/src/core/serve-route-registry.ts
@@ -2,6 +2,23 @@ import type { ServeHttpRouteRegistrar, ServeRouteHandler, ServeRouteMethod } fro
 
 export type { ServeHttpRouteRegistrar, ServeRouteHandler, ServeRouteMethod } from "../plugin/types";
 
+export type ServeRouteEnv = Record<string, unknown>;
+
+export type ServeFallbackHandler = (
+  req: Request,
+  env?: ServeRouteEnv,
+) => Response | Promise<Response>;
+
+export interface ServeFallbackRegistrar {
+  /** Register the public fallback surface used after core /ws and /api routing. */
+  fallback(id: string, handler: ServeFallbackHandler): void;
+}
+
+export interface ServeHookContext {
+  http: ServeHttpRouteRegistrar & ServeFallbackRegistrar;
+  plugin?: { name: string; dir?: string };
+}
+
 type RegisteredServeRoute = {
   method: ServeRouteMethod;
   path: string;
@@ -16,8 +33,9 @@ function assertAbsolutePath(path: string): void {
   if (!path.startsWith("/")) throw new Error(`serve route path must start with '/': ${path}`);
 }
 
-export class ServeRouteRegistry implements ServeHttpRouteRegistrar {
+export class ServeRouteRegistry implements ServeHttpRouteRegistrar, ServeFallbackRegistrar {
   private readonly routes = new Map<string, RegisteredServeRoute>();
+  private readonly fallbackHandlers: Array<{ id: string; handler: ServeFallbackHandler }> = [];
 
   route(method: ServeRouteMethod, path: string, handler: ServeRouteHandler): void {
     assertAbsolutePath(path);
@@ -27,6 +45,15 @@ export class ServeRouteRegistry implements ServeHttpRouteRegistrar {
     this.routes.set(key, { method: normalizedMethod, path, handler });
   }
 
+  fallback(id: string, handler: ServeFallbackHandler): void {
+    if (!id.trim()) throw new Error("serve fallback id is required");
+    if (typeof handler !== "function") throw new Error(`serve fallback ${id} handler must be a function`);
+    if (this.fallbackHandlers.some((entry) => entry.id === id)) {
+      throw new Error(`serve fallback already registered: ${id}`);
+    }
+    this.fallbackHandlers.push({ id, handler });
+  }
+
   async handle(request: Request): Promise<Response | undefined> {
     const url = new URL(request.url);
     const route = this.routes.get(`${request.method.toUpperCase()} ${url.pathname}`);
@@ -34,7 +61,17 @@ export class ServeRouteRegistry implements ServeHttpRouteRegistrar {
     return route.handler(request);
   }
 
+  handleFallback(req: Request, env?: ServeRouteEnv): Response | Promise<Response> {
+    const entry = this.fallbackHandlers[0];
+    if (!entry) return new Response("Not Found", { status: 404 });
+    return entry.handler(req, env);
+  }
+
   snapshot(): Array<{ method: ServeRouteMethod; path: string }> {
     return [...this.routes.values()].map(({ method, path }) => ({ method, path }));
+  }
+
+  listFallbacks(): string[] {
+    return this.fallbackHandlers.map((entry) => entry.id);
   }
 }

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -1,13 +1,9 @@
-import { Hono } from "hono";
 import { MawEngine } from "../engine";
 import type { WSData } from "./types";
 import { loadConfig, cfgInterval, cfgTimeout } from "../config";
 import { existsSync, readFileSync } from "fs";
-import { join } from "path";
-import { serveStatic } from "hono/bun";
 import { api } from "../api";
 import { feedBuffer, feedListeners } from "../api/feed";
-import { mountViews } from "../views/index";
 import { setupTriggerListener } from "./runtime/trigger-listener";
 import { createTransportRouter } from "../transports";
 import { listSessions } from "./transport/ssh";
@@ -63,49 +59,10 @@ export function servePortInUseInstructions(port: number, hostname: string): stri
 // pulling in server.ts's module-level auto-start side effects.
 import { resolveBindHost } from "./bind-host";
 
-// --- Views + static (Hono keeps these) ---
-
-export function createViews(
-  mawUiDir = process.env.MAW_UI_DIR || mawDataPath("ui", "dist"),
-  doorHtmlPath = join(import.meta.dir, "static", "door.html"),
-) {
-  const views = new Hono();
-
-  // Fleet topology visualization
-  views.get("/topology", async (c) => {
-    const path = require("path").resolve(process.cwd(), "ψ/outbox/fleet-topology.html");
-    try {
-      const html = require("fs").readFileSync(path, "utf-8");
-      return c.html(html);
-    } catch { return c.text("fleet-topology.html not found", 404); }
-  });
-
-  mountViews(views);
-
-  // Serve packed maw-ui dist (Shape A — single port, single process)
-  if (existsSync(mawUiDir)) {
-    views.use("/*", serveStatic({ root: mawUiDir }));
-  } else {
-    // The Door — minimal landing page when no packed maw-ui is installed.
-    // Lets users connect to any federation by pasting an address.
-    let doorHtml: string;
-    try {
-      doorHtml = readFileSync(doorHtmlPath, "utf-8");
-    } catch {
-      // door.html missing (e.g. fresh clone without assets) — serve inline stub
-      process.stderr.write("→ maw-ui not found. Run `maw ui build` or install maw-ui.\n");
-      doorHtml = `<!DOCTYPE html><html><head><meta charset="UTF-8"><title>maw</title></head><body style="font-family:monospace;background:#0d0d0d;color:#ccc;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0"><div style="text-align:center"><h1 style="color:#fff">maw</h1><p>maw-ui not installed. Run <code style="color:#7dd3fc">maw ui build</code> or install maw-ui.</p></div></body></html>`;
-    }
-    views.get("/", (c) => c.html(doorHtml));
-  }
-
-  views.onError((err, c) => c.json({ error: err.message }, 500));
-
-  return views;
-}
-
-const views = createViews();
-export { views };
+const serveViewsPlugin = await import(`../vendor/mpr-plugins/serve-views/index.ts?server=${encodeURIComponent(import.meta.url)}`);
+const registerServeViews = serveViewsPlugin.serve;
+export const createViews = serveViewsPlugin.createViews;
+export const views = serveViewsPlugin.createViews();
 
 const startupPeerWarningsLogged = new Set<string>();
 
@@ -123,6 +80,11 @@ function warnMissingFederationTokenOnce(port: number): void {
 export async function startServer(port = +(process.env.MAW_PORT || loadConfig().port || 3456)) {
   const engine = new MawEngine({ feedBuffer, feedListeners });
   const serveRoutes = new ServeRouteRegistry();
+  const serveViews = createViews();
+  await registerServeViews({
+    http: serveRoutes,
+    plugin: { name: "serve-views" },
+  }, { views: serveViews });
 
   const HTTP_URL = `http://localhost:${port}`;
   const WS_URL = `ws://localhost:${port}/ws`;
@@ -213,13 +175,13 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
     feedListeners.add((event) => plugins.emit(event));
 
     // Plugin debug API + page (still on Hono views — will move to Elysia in #312)
-    views.get("/api/plugins", (c) => c.json(plugins.stats()));
-    views.post("/api/plugins/reload", async (c) => {
+    serveViews.get("/api/plugins", (c) => c.json(plugins.stats()));
+    serveViews.post("/api/plugins/reload", async (c) => {
       await reloadUserPlugins(plugins, userPluginsDir);
       return c.json({ ok: true, ...plugins.stats() });
     });
     const { pluginsView } = require("../views/plugins");
-    views.route("/plugins", pluginsView(plugins));
+    serveViews.route("/plugins", pluginsView(plugins));
   } catch (err) {
     console.error("[plugins] failed to init:", err);
   }
@@ -280,7 +242,7 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
       if (servedByPlugin) return servedByPlugin;
       return api.handle(req);
     }
-    // Hono handles views + static — clone response with CORS headers
+    // Plugin-registered fallbacks handle views + static — clone response with CORS headers
     const addCors = (r: Response) => {
       const h = corsHeaders(req);
       return new Response(r.body, {
@@ -289,7 +251,7 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
         headers: { ...Object.fromEntries(r.headers.entries()), ...h },
       });
     };
-    const res = views.fetch(req, { server });
+    const res = serveRoutes.handleFallback(req, { server });
     if (res instanceof Promise) return res.then(addCors);
     return addCors(res as Response);
   };

--- a/src/vendor/mpr-plugins/serve-views/index.ts
+++ b/src/vendor/mpr-plugins/serve-views/index.ts
@@ -1,0 +1,58 @@
+import { Hono } from "hono";
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+import { serveStatic } from "hono/bun";
+import { mountViews } from "../../../views/index";
+import { mawDataPath } from "../../../core/xdg";
+import type { ServeHookContext } from "../../../core/serve-route-registry";
+
+export function createViews(
+  mawUiDir = process.env.MAW_UI_DIR || mawDataPath("ui", "dist"),
+  doorHtmlPath = join(import.meta.dir, "../../../core/static/door.html"),
+) {
+  const views = new Hono();
+
+  // Fleet topology visualization
+  views.get("/topology", async (c) => {
+    const path = require("path").resolve(process.cwd(), "ψ/outbox/fleet-topology.html");
+    try {
+      const html = require("fs").readFileSync(path, "utf-8");
+      return c.html(html);
+    } catch { return c.text("fleet-topology.html not found", 404); }
+  });
+
+  mountViews(views);
+
+  // Serve packed maw-ui dist (Shape A — single port, single process)
+  if (existsSync(mawUiDir)) {
+    views.use("/*", serveStatic({ root: mawUiDir }));
+  } else {
+    // The Door — minimal landing page when no packed maw-ui is installed.
+    // Lets users connect to any federation by pasting an address.
+    let doorHtml: string;
+    try {
+      doorHtml = readFileSync(doorHtmlPath, "utf-8");
+    } catch {
+      // door.html missing (e.g. fresh clone without assets) — serve inline stub
+      process.stderr.write("→ maw-ui not found. Run `maw ui build` or install maw-ui.\n");
+      doorHtml = `<!DOCTYPE html><html><head><meta charset="UTF-8"><title>maw</title></head><body style="font-family:monospace;background:#0d0d0d;color:#ccc;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0"><div style="text-align:center"><h1 style="color:#fff">maw</h1><p>maw-ui not installed. Run <code style="color:#7dd3fc">maw ui build</code> or install maw-ui.</p></div></body></html>`;
+    }
+    views.get("/", (c) => c.html(doorHtml));
+  }
+
+  views.onError((err, c) => c.json({ error: err.message }, 500));
+
+  return views;
+}
+
+export const views = createViews();
+
+export async function serve(
+  ctx: ServeHookContext,
+  options: { views?: Hono } = {},
+): Promise<{ ok: true }> {
+  if (!ctx.http?.fallback) return { ok: true };
+  const honoViews = options.views ?? createViews();
+  ctx.http.fallback("serve-views", (req, env) => honoViews.fetch(req, env));
+  return { ok: true };
+}

--- a/src/vendor/mpr-plugins/serve-views/plugin.json
+++ b/src/vendor/mpr-plugins/serve-views/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "serve-views",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Register maw serve static and bundled view routes.",
+  "hooks": {
+    "serve": {
+      "script": "index.ts",
+      "handler": "serve",
+      "policy": "fail-fast"
+    }
+  },
+  "weight": 10,
+  "license": "MIT",
+  "schemaVersion": 1
+}

--- a/test/isolated/plugin-serve-views-standalone.test.ts
+++ b/test/isolated/plugin-serve-views-standalone.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
+import { ServeRouteRegistry } from "../../src/core/serve-route-registry";
+
+describe("serve-views plugin", () => {
+  test("keeps a declared standalone boundary", () => {
+    expectStandalonePluginBoundary({
+      plugin: "serve-views",
+      requireSdk: false,
+      allowRelative: [/^\.\.\/\.\.\/\.\.\/core\/xdg$/, /^\.\.\/\.\.\/\.\.\/core\/serve-route-registry$/],
+    });
+  });
+
+  test("registers the Hono views fallback through the serve hook", async () => {
+    const { serve } = await import("../../src/vendor/mpr-plugins/serve-views/index.ts?standalone-register");
+    const registry = new ServeRouteRegistry();
+
+    await serve({ http: registry, plugin: { name: "serve-views" } });
+
+    expect(registry.listFallbacks()).toEqual(["serve-views"]);
+    const response = await registry.handleFallback(new Request("http://local/"));
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain("maw");
+  });
+
+  test("createViews preserves topology and door fallback behavior", async () => {
+    const { createViews } = await import("../../src/vendor/mpr-plugins/serve-views/index.ts?standalone-create");
+    const tmp = mkdtempSync(join(tmpdir(), "maw-serve-views-"));
+    const previousCwd = process.cwd();
+    const previousWrite = process.stderr.write;
+    process.stderr.write = (() => true) as typeof process.stderr.write;
+    try {
+      mkdirSync(join(tmp, "ψ", "outbox"), { recursive: true });
+      writeFileSync(join(tmp, "ψ", "outbox", "fleet-topology.html"), "<h1>topology</h1>");
+      process.chdir(tmp);
+
+      const views = createViews(join(tmp, "missing-ui"), join(tmp, "missing-door.html"));
+
+      expect(await (await views.request("http://local/topology")).text()).toContain("topology");
+      rmSync(join(tmp, "ψ"), { recursive: true, force: true });
+      expect((await views.request("http://local/topology")).status).toBe(404);
+      expect(await (await views.request("http://local/")).text()).toContain("maw-ui not installed");
+    } finally {
+      process.chdir(previousCwd);
+      process.stderr.write = previousWrite;
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/isolated/serve-route-registry.test.ts
+++ b/test/isolated/serve-route-registry.test.ts
@@ -32,4 +32,29 @@ describe("ServeRouteRegistry", () => {
     registry.route("GET", "/api/triggers", () => new Response());
     expect(() => registry.route("GET", "/api/triggers", () => new Response())).toThrow("serve route already registered: GET /api/triggers");
   });
+
+  test("dispatches the registered fallback in registration order", async () => {
+    const registry = new ServeRouteRegistry();
+    registry.fallback("first", () => new Response("first"));
+    registry.fallback("second", () => new Response("second"));
+
+    expect(registry.listFallbacks()).toEqual(["first", "second"]);
+    expect(await (await registry.handleFallback(new Request("http://local/path"))).text()).toBe("first");
+  });
+
+  test("rejects invalid or duplicate fallback registrations", () => {
+    const registry = new ServeRouteRegistry();
+    expect(() => registry.fallback("", () => new Response())).toThrow("serve fallback id is required");
+    registry.fallback("views", () => new Response("ok"));
+    expect(() => registry.fallback("views", () => new Response("again"))).toThrow("serve fallback already registered: views");
+    expect(() => registry.fallback("bad", undefined as never)).toThrow("serve fallback bad handler must be a function");
+  });
+
+  test("returns a core 404 when no fallback is registered", async () => {
+    const registry = new ServeRouteRegistry();
+    const response = await registry.handleFallback(new Request("http://local/missing"));
+
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe("Not Found");
+  });
 });


### PR DESCRIPTION
## Summary\n- extract maw serve static/view Hono routes into the internal serve-views MPR plugin\n- add a minimal serve route registry/fallback hook used by the host before /api and websocket fallback handling\n- keep /api and websocket precedence in core while preserving server exports for existing tests/imports\n\n## Verification\n- bun scripts/check-plugin-coverage-gate.ts origin/alpha\n- MAW_TEST_MODE=1 bun test test/isolated/plugin-serve-views-standalone.test.ts test/isolated/serve-route-registry.test.ts test/isolated/coverage-core-shared-server.test.ts test/isolated/core-server-more-coverage-2.test.ts test/plugin-manifest.test.ts test/plugin-manifest-validate-edges.test.ts --path-ignore-patterns '**/agents/**'\n- bun run build\n- bun run test:isolated (622/622 files passed)\n\nCloses #2437