### PR TITLE
Extract trigger mutating routes to serve plugin

### DIFF
--- a/src/api/triggers.ts
+++ b/src/api/triggers.ts
@@ -1,40 +1,7 @@
 import { Elysia } from "elysia";
-import { fire, type TriggerContext } from "../core/runtime/triggers";
-import type { TriggerEvent } from "../config";
-import { TriggerFireBody, type TTriggerFireBody } from "../lib/schemas";
 
-export interface TriggersApiDeps {
-  fire: typeof fire;
-}
-
-export function createTriggersApi(deps: TriggersApiDeps = {
-  fire,
-}) {
-  const api = new Elysia();
-
-  /** POST /triggers/fire — manually fire a trigger event */
-  api.post("/triggers/fire", async ({ body }) => {
-    const typedBody = body as TTriggerFireBody;
-    const event = typedBody.event as TriggerEvent;
-    const ctx: TriggerContext = typedBody.context || {};
-
-    const results = await deps.fire(event, ctx);
-    return {
-      ok: true,
-      event,
-      fired: results.length,
-      results: results.map(r => ({
-        action: r.action,
-        ok: r.ok,
-        output: r.output || null,
-        error: r.error || null,
-      })),
-    };
-  }, {
-    body: TriggerFireBody,
-  });
-
-  return api;
+export function createTriggersApi() {
+  return new Elysia();
 }
 
 export const triggersApi = createTriggersApi();

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -10,7 +10,7 @@ import { listSessions } from "./transport/ssh";
 import { Tmux } from "./transport/tmux";
 import { handlePtyMessage, handlePtyClose, sweepOrphanPtySessions } from "./transport/pty";
 import { handleTmuxStreamClose, handleTmuxStreamMessage, handleTmuxStreamOpen } from "../api/tmux-stream";
-import { setBunServer } from "../lib/elysia-auth";
+import { isProtected, setBunServer } from "../lib/elysia-auth";
 import { runServeLifecycleHooks } from "../plugin/lifecycle";
 import { discoverLocalPluginDirs } from "../plugin/registry-helpers";
 import {
@@ -247,6 +247,7 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
 
   const fetchHandler = async (req: Request, server: any) => {
     const url = new URL(req.url);
+    const apiPath = url.pathname.replace(/^\/api/, "");
 
     // CORS preflight for all routes
     if (req.method === "OPTIONS") {
@@ -268,6 +269,10 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
     if (url.pathname.startsWith("/api")) {
       const enginePlugin = findEnginePluginRegistration(url.pathname);
       if (enginePlugin) return proxyEnginePluginRequest(req, enginePlugin);
+      if (isProtected(apiPath, req.method)) {
+        const authOrLegacyRoute = await api.handle(req.clone());
+        if (authOrLegacyRoute.status !== 404) return authOrLegacyRoute;
+      }
       const servedByPlugin = await serveRoutes.handle(req);
       if (servedByPlugin) return servedByPlugin;
       return api.handle(req);

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -119,7 +119,7 @@ export type { ScannedSignal } from "../commands/shared/scan-signals";
 export { runHook } from "../core/runtime/hooks";
 export { runSleepLifecycleHooks } from "../plugin/lifecycle";
 export type { SleepLifecycleContextInput, LifecycleRunSummary } from "../plugin/lifecycle";
-export { getTriggers, getTriggerHistory } from "../core/runtime/triggers";
+export { getTriggers, getTriggerHistory, fire } from "../core/runtime/triggers";
 
 // ─── Fleet ───────────────────────────────────────────────────────────────────
 

--- a/src/vendor/mpr-plugins/serve-triggers-mutate/index.ts
+++ b/src/vendor/mpr-plugins/serve-triggers-mutate/index.ts
@@ -1,0 +1,75 @@
+import { fire } from "maw-js/sdk";
+import type { ServeHttpRouteRegistrar } from "maw-js/plugin/types";
+
+type TriggerFireDeps = {
+  fire: typeof fire;
+};
+
+type ServeTriggersMutateContext = {
+  http?: ServeHttpRouteRegistrar;
+};
+
+type TriggerFireBody = {
+  event?: unknown;
+  context?: unknown;
+};
+
+type TriggerContext = Record<string, string | undefined>;
+
+const defaultDeps: TriggerFireDeps = { fire };
+
+function isTriggerContext(value: unknown): value is TriggerContext {
+  if (value === undefined) return true;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  return Object.values(value as Record<string, unknown>)
+    .every((entry) => entry === undefined || typeof entry === "string");
+}
+
+async function readJsonBody(request: Request): Promise<TriggerFireBody | undefined> {
+  try {
+    return await request.json() as TriggerFireBody;
+  } catch {
+    return undefined;
+  }
+}
+
+export function createTriggerMutateRouteHandlers(deps: TriggerFireDeps = defaultDeps) {
+  return {
+    fire: async (request: Request) => {
+      const body = await readJsonBody(request);
+      if (typeof body?.event !== "string") {
+        return Response.json({ error: "event is required" }, { status: 400 });
+      }
+      if (!isTriggerContext(body.context)) {
+        return Response.json({ error: "context must be an object of string values" }, { status: 400 });
+      }
+
+      const event = body.event as Parameters<typeof deps.fire>[0];
+      const ctx = (body.context || {}) as Parameters<typeof deps.fire>[1];
+      const results = await deps.fire(event, ctx);
+      return Response.json({
+        ok: true,
+        event,
+        fired: results.length,
+        results: results.map(r => ({
+          action: r.action,
+          ok: r.ok,
+          output: r.output || null,
+          error: r.error || null,
+        })),
+      });
+    },
+  };
+}
+
+export function registerTriggerMutateRoutes(http: ServeHttpRouteRegistrar, deps?: TriggerFireDeps): void {
+  const handlers = createTriggerMutateRouteHandlers(deps);
+  http.route("POST", "/api/triggers/fire", handlers.fire);
+}
+
+export function serve(ctx: ServeTriggersMutateContext): void {
+  if (!ctx.http) throw new Error("serve-triggers-mutate requires serve http route registration");
+  registerTriggerMutateRoutes(ctx.http);
+}
+
+export default serve;

--- a/src/vendor/mpr-plugins/serve-triggers-mutate/plugin.json
+++ b/src/vendor/mpr-plugins/serve-triggers-mutate/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "serve-triggers-mutate",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Registers maw serve trigger mutation API routes.",
+  "author": "Soul-Brews-Studio",
+  "hooks": {
+    "serve": {
+      "script": "./index.ts",
+      "handler": "serve",
+      "policy": "fail-fast"
+    }
+  },
+  "weight": 0,
+  "license": "MIT",
+  "schemaVersion": 1
+}

--- a/test/api-runtime-default.test.ts
+++ b/test/api-runtime-default.test.ts
@@ -170,54 +170,6 @@ describe("runtime API routers default-suite coverage", () => {
     expect(Number.isNaN(Date.parse(body.timestamp))).toBe(false);
   });
 
-  test("triggers API awaits fire results and normalizes optional output/error", async () => {
-    const calls: any[] = [];
-    const app = apiWith(createTriggersApi({
-      fire: async (event, ctx) => {
-        calls.push({ event, ctx });
-        return [
-          {
-            trigger: { on: "issue-close", action: "ok" },
-            action: "ok",
-            ok: true,
-            output: "done",
-            ts: 1,
-          },
-          {
-            trigger: { on: "issue-close", action: "bad" },
-            action: "bad",
-            ok: false,
-            error: "boom",
-            ts: 2,
-          },
-        ];
-      },
-    }));
-
-    const res = await app.handle(new Request("http://local/api/triggers/fire", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        event: "issue-close",
-        context: { repo: "Soul-Brews-Studio/maw-js", issue: "1709" },
-      }),
-    }));
-    expect(res.status).toBe(200);
-    expect(await json(res)).toEqual({
-      ok: true,
-      event: "issue-close",
-      fired: 2,
-      results: [
-        { action: "ok", ok: true, output: "done", error: null },
-        { action: "bad", ok: false, output: null, error: "boom" },
-      ],
-    });
-    expect(calls).toEqual([{
-      event: "issue-close",
-      ctx: { repo: "Soul-Brews-Studio/maw-js", issue: "1709" },
-    }]);
-  });
-
   test("claude fleet API returns session count and discovery failures", async () => {
     const session = {
       sessionId: "abc",

--- a/test/isolated/core-server-more-coverage-2.test.ts
+++ b/test/isolated/core-server-more-coverage-2.test.ts
@@ -103,7 +103,10 @@ mock.module(import.meta.resolve("../../src/core/transport/pty"), () => ({
   handlePtyClose: () => {},
   sweepOrphanPtySessions: async () => ({ killed: [], checked: 0 }),
 }));
-mock.module(import.meta.resolve("../../src/lib/elysia-auth"), () => ({ setBunServer: () => {} }));
+mock.module(import.meta.resolve("../../src/lib/elysia-auth"), () => ({
+  isProtected: () => false,
+  setBunServer: () => {},
+}));
 mock.module(import.meta.resolve("../../src/plugin/lifecycle"), () => ({
   runServeLifecycleHooks: async () => {
     if (lifecycleShouldThrow) throw new Error("lifecycle failed");

--- a/test/isolated/coverage-core-shared-server.test.ts
+++ b/test/isolated/coverage-core-shared-server.test.ts
@@ -31,7 +31,12 @@ class FakeEngine {
 mock.module(import.meta.resolve("../../src/engine"), () => ({ MawEngine: FakeEngine }));
 mock.module(import.meta.resolve("../../src/config"), () => mockConfigModule(() => config));
 mock.module(import.meta.resolve("../../src/api"), () => ({
-  api: { handle: (req: Request) => { apiPaths.push(new URL(req.url).pathname); return new Response("api"); } },
+  api: { handle: (req: Request) => {
+    const pathname = new URL(req.url).pathname;
+    apiPaths.push(pathname);
+    if (pathname === "/api/triggers/fire") return new Response("not found", { status: 404 });
+    return new Response("api");
+  } },
 }));
 mock.module(import.meta.resolve("../../src/api/feed"), () => ({
   feedBuffer: [],
@@ -79,11 +84,15 @@ mock.module(import.meta.resolve("../../src/api/tmux-stream"), () => ({
   handleTmuxStreamMessage: () => { tmuxStreamEvents.push("message"); },
   handleTmuxStreamClose: () => { tmuxStreamEvents.push("close"); },
 }));
-mock.module(import.meta.resolve("../../src/lib/elysia-auth"), () => ({ setBunServer: () => {} }));
+mock.module(import.meta.resolve("../../src/lib/elysia-auth"), () => ({
+  isProtected: (path: string, method: string) => method === "POST" && path === "/triggers/fire",
+  setBunServer: () => {},
+}));
 mock.module(import.meta.resolve("../../src/plugin/lifecycle"), () => ({
   runServeLifecycleHooks: async (payload: any) => {
     lifecyclePayloads.push(payload);
     payload.http?.route("GET", "/api/triggers", () => new Response("plugin triggers"));
+    payload.http?.route("POST", "/api/triggers/fire", () => new Response("plugin trigger fire"));
   },
 }));
 mock.module(import.meta.resolve("../../src/core/engine-plugin-registry"), () => ({
@@ -248,8 +257,9 @@ describe("coverage core shared server", () => {
     expect(await (await fetch(new Request("http://local/api/engine"), upgradeServer(true))).text()).toBe("proxied");
     expect(proxiedPaths).toEqual(["/api/engine"]);
     expect(await (await fetch(new Request("http://local/api/triggers"), upgradeServer(true))).text()).toBe("plugin triggers");
+    expect(await (await fetch(new Request("http://local/api/triggers/fire", { method: "POST" }), upgradeServer(true))).text()).toBe("plugin trigger fire");
     expect(await (await fetch(new Request("http://local/api/ordinary"), upgradeServer(true))).text()).toBe("api");
-    expect(apiPaths).toEqual(["/api/ordinary"]);
+    expect(apiPaths).toEqual(["/api/triggers/fire", "/api/ordinary"]);
 
     const ptyUpgrade = upgradeServer(true);
     expect(await fetch(new Request("http://local/ws/pty"), ptyUpgrade)).toBeUndefined();

--- a/test/isolated/plugin-serve-triggers-mutate-standalone.test.ts
+++ b/test/isolated/plugin-serve-triggers-mutate-standalone.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, mock, test } from "bun:test";
+import { join } from "node:path";
+import { readFileSync } from "node:fs";
+import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
+
+const root = join(import.meta.dir, "../..");
+const fireCalls: Array<{ event: string; ctx: Record<string, unknown> }> = [];
+
+mock.module("maw-js/sdk", () => ({
+  fire: async (event: string, ctx: Record<string, unknown>) => {
+    fireCalls.push({ event, ctx });
+    return [
+      {
+        trigger: { on: event, action: "ok" },
+        action: "ok",
+        ok: true,
+        output: "done",
+        ts: 1,
+      },
+      {
+        trigger: { on: event, action: "bad" },
+        action: "bad",
+        ok: false,
+        error: "boom",
+        ts: 2,
+      },
+    ];
+  },
+}));
+
+const plugin = await import("../../src/vendor/mpr-plugins/serve-triggers-mutate/index.ts?plugin-serve-triggers-mutate-standalone");
+
+describe("serve-triggers-mutate plugin standalone boundary", () => {
+  test("imports runtime mutation through the SDK and serve route types only", () => {
+    const source = readFileSync(join(root, "src/vendor/mpr-plugins/serve-triggers-mutate/index.ts"), "utf8");
+    expect(source).toContain('from "maw-js/sdk"');
+    expect(source).toContain('from "maw-js/plugin/types"');
+    expectStandalonePluginBoundary({ plugin: "serve-triggers-mutate" });
+  });
+
+  test("POST /api/triggers/fire awaits fire results and preserves response shape", async () => {
+    fireCalls.length = 0;
+    const handlers = plugin.createTriggerMutateRouteHandlers();
+    const res = await handlers.fire(new Request("http://local/api/triggers/fire", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        event: "issue-close",
+        context: { repo: "Soul-Brews-Studio/maw-js", issue: "2443" },
+      }),
+    }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      ok: true,
+      event: "issue-close",
+      fired: 2,
+      results: [
+        { action: "ok", ok: true, output: "done", error: null },
+        { action: "bad", ok: false, output: null, error: "boom" },
+      ],
+    });
+    expect(fireCalls).toEqual([{
+      event: "issue-close",
+      ctx: { repo: "Soul-Brews-Studio/maw-js", issue: "2443" },
+    }]);
+  });
+
+  test("validates JSON body before firing", async () => {
+    fireCalls.length = 0;
+    const handlers = plugin.createTriggerMutateRouteHandlers();
+
+    const missingEvent = await handlers.fire(new Request("http://local/api/triggers/fire", {
+      method: "POST",
+      body: JSON.stringify({ context: {} }),
+    }));
+    expect(missingEvent.status).toBe(400);
+    expect(await missingEvent.json()).toEqual({ error: "event is required" });
+
+    const invalidContext = await handlers.fire(new Request("http://local/api/triggers/fire", {
+      method: "POST",
+      body: JSON.stringify({ event: "issue-close", context: { issue: 2443 } }),
+    }));
+    expect(invalidContext.status).toBe(400);
+    expect(await invalidContext.json()).toEqual({ error: "context must be an object of string values" });
+    expect(fireCalls).toEqual([]);
+  });
+
+  test("serve hook registers POST /api/triggers/fire", async () => {
+    const routes: Array<{ method: string; path: string; handler: (request: Request) => Response | Promise<Response> }> = [];
+    plugin.serve({
+      http: {
+        route: (method, path, handler) => routes.push({ method, path, handler }),
+      },
+    });
+
+    expect(routes.map(({ method, path }) => `${method} ${path}`)).toEqual(["POST /api/triggers/fire"]);
+  });
+
+  test("serve hook fails clearly without route registration context", () => {
+    expect(() => plugin.serve({})).toThrow("serve-triggers-mutate requires serve http route registration");
+  });
+});

--- a/test/isolated/plugin-serve-triggers-standalone.test.ts
+++ b/test/isolated/plugin-serve-triggers-standalone.test.ts
@@ -10,6 +10,7 @@ let history: any[] = [];
 mock.module("maw-js/sdk", () => ({
   getTriggers: () => triggers,
   getTriggerHistory: () => history,
+  fire: async () => [],
 }));
 
 const plugin = await import("../../src/vendor/mpr-plugins/serve-triggers/index.ts?plugin-serve-triggers-standalone");

--- a/test/isolated/serve-route-registry.test.ts
+++ b/test/isolated/serve-route-registry.test.ts
@@ -6,6 +6,7 @@ describe("ServeRouteRegistry", () => {
     const registry = new ServeRouteRegistry();
     registry.route("GET", "/api/worktrees", () => Response.json({ ok: true, route: "worktrees" }));
     registry.route("GET", "/api/triggers", () => Response.json({ ok: true, route: "triggers" }));
+    registry.route("POST", "/api/triggers/fire", () => Response.json({ ok: true, route: "triggers-fire" }));
 
     const worktrees = await registry.handle(new Request("http://local/api/worktrees?ignored=1"));
     expect(worktrees?.status).toBe(200);
@@ -15,12 +16,17 @@ describe("ServeRouteRegistry", () => {
     expect(triggers?.status).toBe(200);
     expect(await triggers!.json()).toEqual({ ok: true, route: "triggers" });
 
+    const fire = await registry.handle(new Request("http://local/api/triggers/fire", { method: "POST" }));
+    expect(fire?.status).toBe(200);
+    expect(await fire!.json()).toEqual({ ok: true, route: "triggers-fire" });
+
     expect(await registry.handle(new Request("http://local/api/worktrees", { method: "POST" }))).toBeUndefined();
     expect(await registry.handle(new Request("http://local/api/triggers/extra"))).toBeUndefined();
     expect(await registry.handle(new Request("http://local/api/other"))).toBeUndefined();
     expect(registry.snapshot()).toEqual([
       { method: "GET", path: "/api/worktrees" },
       { method: "GET", path: "/api/triggers" },
+      { method: "POST", path: "/api/triggers/fire" },
     ]);
   });
 


### PR DESCRIPTION
## Summary
- move POST /api/triggers/fire into new vendored serve-triggers-mutate serve-hook plugin
- expose trigger fire through the SDK boundary for the plugin
- preserve protected-route auth by preflighting moved mutating /api routes through the existing Elysia auth stack before serve-hook dispatch
- no PUT/DELETE trigger routes currently exist on alpha, so only POST /api/triggers/fire is extracted

## Issue
- #2443

## Verification
- bun scripts/check-plugin-coverage-gate.ts origin/alpha
- bun test test/isolated/plugin-serve-triggers-mutate-standalone.test.ts test/isolated/plugin-serve-triggers-standalone.test.ts test/isolated/serve-route-registry.test.ts test/api-runtime-default.test.ts test/isolated/coverage-core-shared-server.test.ts
- bun test test/isolated/federation-auth.test.ts test/proxy.test.ts test/isolated/plugin-lifecycle.test.ts test/plugin-lifecycle.test.ts
- bun run build

Closes #2443