### PR TITLE
Extract serve WebSocket routes to plugin

### DIFF
--- a/src/core/serve-ws-registry.ts
+++ b/src/core/serve-ws-registry.ts
@@ -1,0 +1,76 @@
+import type { ServerWebSocket } from "bun";
+import type { WSData } from "./types";
+
+export type ServeWsData = WSData & { __serveWsRoute?: string };
+export type ServeWsSocket = ServerWebSocket<ServeWsData>;
+
+export type ServeWsDataFactory = (request: Request) => WSData;
+export type ServeWsHandler = (ws: ServeWsSocket, message?: unknown) => void | Promise<void>;
+
+export interface ServeWsRouteHandlers {
+  open?: (ws: ServeWsSocket) => void | Promise<void>;
+  message?: (ws: ServeWsSocket, message: unknown) => void | Promise<void>;
+  close?: (ws: ServeWsSocket) => void | Promise<void>;
+}
+
+export interface ServeWsRouteRegistrar {
+  route(path: string, data: ServeWsDataFactory, handlers: ServeWsRouteHandlers): void;
+}
+
+export type ServeWsUpgradeResult = {
+  matched: boolean;
+  response?: Response;
+};
+
+function assertAbsolutePath(path: string): void {
+  if (!path.startsWith("/")) throw new Error(`serve ws route path must start with '/': ${path}`);
+}
+
+type RegisteredServeWsRoute = {
+  path: string;
+  data: ServeWsDataFactory;
+  handlers: ServeWsRouteHandlers;
+};
+
+export class ServeWsRegistry implements ServeWsRouteRegistrar {
+  private readonly routes = new Map<string, RegisteredServeWsRoute>();
+
+  readonly handlers = {
+    open: (ws: ServeWsSocket) => this.dispatch("open", ws),
+    message: (ws: ServeWsSocket, message: unknown) => this.dispatch("message", ws, message),
+    close: (ws: ServeWsSocket) => this.dispatch("close", ws),
+  };
+
+  route(path: string, data: ServeWsDataFactory, handlers: ServeWsRouteHandlers): void {
+    assertAbsolutePath(path);
+    if (this.routes.has(path)) throw new Error(`serve ws route already registered: ${path}`);
+    this.routes.set(path, { path, data, handlers });
+  }
+
+  handleUpgrade(req: Request, server: { upgrade: (request: Request, options: { data: ServeWsData }) => boolean }): ServeWsUpgradeResult {
+    const url = new URL(req.url);
+    const route = this.routes.get(url.pathname);
+    if (!route) return { matched: false };
+
+    const data = { ...route.data(req), __serveWsRoute: route.path } as ServeWsData;
+    if (server.upgrade(req, { data })) return { matched: true };
+    return { matched: true, response: new Response("WebSocket upgrade failed", { status: 400 }) };
+  }
+
+  snapshot(): string[] {
+    return [...this.routes.keys()];
+  }
+
+  private dispatch(kind: keyof ServeWsRouteHandlers, ws: ServeWsSocket, message?: unknown): void | Promise<void> {
+    const routeId = ws.data.__serveWsRoute ?? (ws.data.mode === "pty"
+      ? "/ws/pty"
+      : ws.data.mode === "tmux-stream"
+        ? "/ws/tmux"
+        : "/ws");
+    const route = this.routes.get(routeId);
+    const handler = route?.handlers[kind];
+    if (!handler) return;
+    if (kind === "message") return (handler as NonNullable<ServeWsRouteHandlers["message"]>)(ws, message);
+    return (handler as NonNullable<ServeWsRouteHandlers["open"]>)(ws);
+  }
+}

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -1,5 +1,4 @@
 import { MawEngine } from "../engine";
-import type { WSData } from "./types";
 import { loadConfig, cfgInterval, cfgTimeout } from "../config";
 import { existsSync, readFileSync } from "fs";
 import { api } from "../api";
@@ -8,8 +7,7 @@ import { setupTriggerListener } from "./runtime/trigger-listener";
 import { createTransportRouter } from "../transports";
 import { listSessions } from "./transport/ssh";
 import { Tmux } from "./transport/tmux";
-import { handlePtyMessage, handlePtyClose, sweepOrphanPtySessions } from "./transport/pty";
-import { handleTmuxStreamClose, handleTmuxStreamMessage, handleTmuxStreamOpen } from "../api/tmux-stream";
+import { sweepOrphanPtySessions } from "./transport/pty";
 import { isProtected, setBunServer } from "../lib/elysia-auth";
 import { runServeLifecycleHooks } from "../plugin/lifecycle";
 import { discoverLocalPluginDirs } from "../plugin/registry-helpers";
@@ -29,6 +27,7 @@ import { requestReplyStore } from "./request-reply";
 import { agentStatusStore } from "./agent-status";
 import { getRuntimeVersionLabel } from "./runtime/build-info";
 import { ServeRouteRegistry } from "./serve-route-registry";
+import { ServeWsRegistry } from "./serve-ws-registry";
 
 // --- Version info (computed once at startup) ---
 
@@ -92,6 +91,9 @@ const registerServeViews = serveViewsPlugin.serve;
 export const createViews = serveViewsPlugin.createViews;
 export const views = serveViewsPlugin.createViews();
 
+const serveWsPlugin = await import(`../vendor/mpr-plugins/serve-ws/index.ts?server=${encodeURIComponent(import.meta.url)}`);
+const registerServeWs = serveWsPlugin.serve;
+
 const startupPeerWarningsLogged = new Set<string>();
 
 function warnMissingFederationTokenOnce(port: number, log = createServeLogger(1)): void {
@@ -110,11 +112,17 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
   const log = createServeLogger(verbosity);
   const engine = new MawEngine({ feedBuffer, feedListeners });
   const serveRoutes = new ServeRouteRegistry();
+  const serveWs = new ServeWsRegistry();
   const serveViews = createViews();
   await registerServeViews({
     http: serveRoutes,
     plugin: { name: "serve-views" },
   }, { views: serveViews });
+  registerServeWs({
+    ws: serveWs,
+    engine,
+    plugin: { name: "serve-ws" },
+  });
 
   const HTTP_URL = `http://localhost:${port}`;
   const WS_URL = `ws://localhost:${port}/ws`;
@@ -217,24 +225,6 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
     log.error("[plugins] failed to init:", err);
   }
 
-  const wsHandler = {
-    open: (ws: any) => {
-      if (ws.data.mode === "pty") return;
-      if (ws.data.mode === "tmux-stream") { handleTmuxStreamOpen(ws); return; }
-      engine.handleOpen(ws);
-    },
-    message: (ws: any, msg: any) => {
-      if (ws.data.mode === "pty") { handlePtyMessage(ws, msg); return; }
-      if (ws.data.mode === "tmux-stream") { handleTmuxStreamMessage(ws, msg); return; }
-      engine.handleMessage(ws, msg);
-    },
-    close: (ws: any) => {
-      if (ws.data.mode === "pty") { handlePtyClose(ws); return; }
-      if (ws.data.mode === "tmux-stream") { handleTmuxStreamClose(ws); return; }
-      engine.handleClose(ws);
-    },
-  };
-
   const corsHeaders = (req: Request) => {
     const origin = req.headers.get("origin") ?? "*";
     return {
@@ -253,18 +243,8 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
     if (req.method === "OPTIONS") {
       return new Response(null, { status: 204, headers: corsHeaders(req) });
     }
-    if (url.pathname === "/ws/pty") {
-      if (server.upgrade(req, { data: { target: null, previewTargets: new Set(), mode: "pty" } as WSData })) return;
-      return new Response("WebSocket upgrade failed", { status: 400 });
-    }
-    if (url.pathname === "/ws/tmux") {
-      if (server.upgrade(req, { data: { target: null, previewTargets: new Set(), mode: "tmux-stream" } as WSData })) return;
-      return new Response("WebSocket upgrade failed", { status: 400 });
-    }
-    if (url.pathname === "/ws") {
-      if (server.upgrade(req, { data: { target: null, previewTargets: new Set() } as WSData })) return;
-      return new Response("WebSocket upgrade failed", { status: 400 });
-    }
+    const wsUpgrade = serveWs.handleUpgrade(req, server);
+    if (wsUpgrade.matched) return wsUpgrade.response;
     // Elysia handles all /api/* routes (has its own CORS)
     if (url.pathname.startsWith("/api")) {
       const enginePlugin = findEnginePluginRegistration(url.pathname);
@@ -331,7 +311,7 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
   // fires → handlePtyClose → detach → grace-timer reaps the maw-pty- tmux session.
   // sendPings: true is Bun's default but pinned for explicitness. Shared across
   // the HTTP + TLS Bun.serve calls below so both ws surfaces get the heartbeat.
-  const wsConfig = { ...wsHandler, idleTimeout: cfgTimeout("wsIdleSec"), sendPings: true };
+  const wsConfig = { ...serveWs.handlers, idleTimeout: cfgTimeout("wsIdleSec"), sendPings: true };
 
   let server: ReturnType<typeof Bun.serve>;
   try {
@@ -384,6 +364,8 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
       wsUrl: WS_URL,
       hostname,
       http: serveRoutes,
+      ws: serveWs,
+      engine,
       plugins: serveLifecyclePlugins,
       reloadPlugins: serveLifecycleReloadPlugins,
     }, undefined, {

--- a/src/plugin/lifecycle.ts
+++ b/src/plugin/lifecycle.ts
@@ -10,6 +10,8 @@ import { existsSync, realpathSync } from "fs";
 import { resolve, sep } from "path";
 import { pathToFileURL } from "url";
 import { discoverPackages } from "./registry";
+import type { MawEngine } from "../engine";
+import type { ServeWsRouteRegistrar } from "../core/serve-ws-registry";
 import type { LoadedPlugin, PluginLifecycleHook, ServeHttpRouteRegistrar } from "./types";
 
 export type LifecyclePhase = "wake" | "sleep" | "serve";
@@ -28,6 +30,8 @@ export interface PluginLifecycleContext {
   wsUrl?: string;
   hostname?: string;
   http?: ServeHttpRouteRegistrar;
+  ws?: ServeWsRouteRegistrar;
+  engine?: MawEngine;
   ensures?: string[];
 }
 
@@ -51,6 +55,8 @@ export interface ServeLifecycleContextInput {
   wsUrl: string;
   hostname: string;
   http?: ServeHttpRouteRegistrar;
+  ws?: ServeWsRouteRegistrar;
+  engine?: MawEngine;
   /** In-memory feed plugin system, exposed for serve diagnostics/debug plugins. */
   plugins?: unknown;
   /** Reload user plugins and return the current plugin stats/debug payload. */

--- a/src/vendor/mpr-plugins/serve-ws/index.ts
+++ b/src/vendor/mpr-plugins/serve-ws/index.ts
@@ -1,0 +1,63 @@
+import type { MawEngine } from "../../../engine";
+import type { WSData } from "../../../core/types";
+import type { ServeWsRouteRegistrar, ServeWsSocket } from "../../../core/serve-ws-registry";
+import type { handlePtyClose, handlePtyMessage } from "../../../core/transport/pty";
+import type { handleTmuxStreamClose, handleTmuxStreamMessage, handleTmuxStreamOpen } from "../../../api/tmux-stream";
+
+type WsDeps = {
+  handlePtyMessage: typeof handlePtyMessage;
+  handlePtyClose: typeof handlePtyClose;
+  handleTmuxStreamOpen: typeof handleTmuxStreamOpen;
+  handleTmuxStreamMessage: typeof handleTmuxStreamMessage;
+  handleTmuxStreamClose: typeof handleTmuxStreamClose;
+};
+
+type ServeWsContext = {
+  ws?: ServeWsRouteRegistrar;
+  engine?: MawEngine;
+};
+
+function defaultDeps(): WsDeps {
+  const pty = require("../../../core/transport/pty");
+  const tmux = require("../../../api/tmux-stream");
+  return {
+    handlePtyMessage: pty.handlePtyMessage,
+    handlePtyClose: pty.handlePtyClose,
+    handleTmuxStreamOpen: tmux.handleTmuxStreamOpen,
+    handleTmuxStreamMessage: tmux.handleTmuxStreamMessage,
+    handleTmuxStreamClose: tmux.handleTmuxStreamClose,
+  };
+}
+
+function defaultWsData(mode?: WSData["mode"]): WSData {
+  return { target: null, previewTargets: new Set(), ...(mode ? { mode } : {}) };
+}
+
+export function registerServeWsRoutes(ctx: ServeWsContext, deps: WsDeps = defaultDeps()): void {
+  if (!ctx.ws) throw new Error("serve-ws requires serve ws route registration");
+  if (!ctx.engine) throw new Error("serve-ws requires MawEngine in serve context");
+
+  ctx.ws.route("/ws/pty", () => defaultWsData("pty"), {
+    message: (ws, msg) => deps.handlePtyMessage(ws, msg as string | Buffer),
+    close: (ws) => deps.handlePtyClose(ws),
+  });
+
+  ctx.ws.route("/ws/tmux", () => defaultWsData("tmux-stream"), {
+    open: (ws) => deps.handleTmuxStreamOpen(ws),
+    message: (ws, msg) => deps.handleTmuxStreamMessage(ws, msg),
+    close: (ws) => deps.handleTmuxStreamClose(ws),
+  });
+
+  ctx.ws.route("/ws", () => defaultWsData(), {
+    open: (ws: ServeWsSocket) => ctx.engine!.handleOpen(ws as never),
+    message: (ws: ServeWsSocket, msg: unknown) => ctx.engine!.handleMessage(ws as never, msg as never),
+    close: (ws: ServeWsSocket) => ctx.engine!.handleClose(ws as never),
+  });
+}
+
+export function serve(ctx: ServeWsContext, deps?: WsDeps): { ok: true; routes: string[] } {
+  registerServeWsRoutes(ctx, deps);
+  return { ok: true, routes: ["/ws/pty", "/ws/tmux", "/ws"] };
+}
+
+export default serve;

--- a/src/vendor/mpr-plugins/serve-ws/plugin.json
+++ b/src/vendor/mpr-plugins/serve-ws/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "serve-ws",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "tier": "core",
+  "description": "Registers maw serve WebSocket upgrade routes and handlers.",
+  "author": "Soul-Brews-Studio",
+  "hooks": {
+    "serve": {
+      "script": "./index.ts",
+      "handler": "serve",
+      "ensures": ["ws:route:/ws", "ws:route:/ws/pty", "ws:route:/ws/tmux"],
+      "policy": "fail-fast"
+    }
+  },
+  "module": {
+    "path": "./index.ts",
+    "exports": ["serve", "registerServeWsRoutes"]
+  },
+  "capabilities": ["serve:ws-route"],
+  "weight": 0,
+  "license": "MIT",
+  "schemaVersion": 1,
+  "capabilityNamespaces": ["serve"]
+}

--- a/test/isolated/plugin-serve-ws-standalone.test.ts
+++ b/test/isolated/plugin-serve-ws-standalone.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
+import { ServeWsRegistry, type ServeWsSocket } from "../../src/core/serve-ws-registry";
+import { serve } from "../../src/vendor/mpr-plugins/serve-ws/index";
+
+const root = join(import.meta.dir, "../..");
+
+type WsCall = { kind: string; msg?: unknown };
+
+function makeSocket(path: string): ServeWsSocket {
+  return { data: { target: null, previewTargets: new Set(), __serveWsRoute: path }, send: () => undefined } as unknown as ServeWsSocket;
+}
+
+describe("serve-ws plugin", () => {
+  test("declares the serve hook and keeps the standalone boundary explicit", () => {
+    const manifest = JSON.parse(readFileSync(join(root, "src/vendor/mpr-plugins/serve-ws/plugin.json"), "utf8"));
+    expect(manifest.hooks.serve).toMatchObject({ script: "./index.ts", handler: "serve", policy: "fail-fast" });
+    expect(manifest.hooks.serve.ensures).toEqual(["ws:route:/ws", "ws:route:/ws/pty", "ws:route:/ws/tmux"]);
+
+    expectStandalonePluginBoundary({
+      plugin: "serve-ws",
+      requireSdk: false,
+      allowRelative: [
+        /^\.\.\/\.\.\/\.\.\/api\/tmux-stream$/,
+        /^\.\.\/\.\.\/\.\.\/core\/serve-ws-registry$/,
+        /^\.\.\/\.\.\/\.\.\/core\/transport\/pty$/,
+        /^\.\.\/\.\.\/\.\.\/core\/types$/,
+      ],
+    });
+  });
+
+  test("registers /ws, /ws/pty, and /ws/tmux through the serve hook", () => {
+    const registry = new ServeWsRegistry();
+    const calls: WsCall[] = [];
+    const engine = {
+      handleOpen: () => calls.push({ kind: "engine:open" }),
+      handleMessage: (_ws: unknown, msg: unknown) => calls.push({ kind: "engine:message", msg }),
+      handleClose: () => calls.push({ kind: "engine:close" }),
+    };
+    const deps = {
+      handlePtyMessage: (_ws: unknown, msg: string | Buffer) => calls.push({ kind: "pty:message", msg }),
+      handlePtyClose: () => calls.push({ kind: "pty:close" }),
+      handleTmuxStreamOpen: () => calls.push({ kind: "tmux:open" }),
+      handleTmuxStreamMessage: (_ws: unknown, msg: unknown) => calls.push({ kind: "tmux:message", msg }),
+      handleTmuxStreamClose: () => calls.push({ kind: "tmux:close" }),
+    } as any;
+
+    expect(serve({ ws: registry, engine: engine as any }, deps)).toEqual({ ok: true, routes: ["/ws/pty", "/ws/tmux", "/ws"] });
+    expect(registry.snapshot()).toEqual(["/ws/pty", "/ws/tmux", "/ws"]);
+
+    registry.handlers.open(makeSocket("/ws"));
+    registry.handlers.message(makeSocket("/ws"), "hello");
+    registry.handlers.close(makeSocket("/ws"));
+    registry.handlers.message(makeSocket("/ws/pty"), "attach");
+    registry.handlers.close(makeSocket("/ws/pty"));
+    registry.handlers.open(makeSocket("/ws/tmux"));
+    registry.handlers.message(makeSocket("/ws/tmux"), "refresh");
+    registry.handlers.close(makeSocket("/ws/tmux"));
+
+    expect(calls).toEqual([
+      { kind: "engine:open" },
+      { kind: "engine:message", msg: "hello" },
+      { kind: "engine:close" },
+      { kind: "pty:message", msg: "attach" },
+      { kind: "pty:close" },
+      { kind: "tmux:open" },
+      { kind: "tmux:message", msg: "refresh" },
+      { kind: "tmux:close" },
+    ]);
+  });
+
+  test("upgrades matching paths with preserved WSData modes", () => {
+    const registry = new ServeWsRegistry();
+    serve({
+      ws: registry,
+      engine: { handleOpen() {}, handleMessage() {}, handleClose() {} } as any,
+    }, {
+      handlePtyMessage() {},
+      handlePtyClose() {},
+      handleTmuxStreamOpen() {},
+      handleTmuxStreamMessage() {},
+      handleTmuxStreamClose() {},
+    } as any);
+
+    const upgrades: unknown[] = [];
+    const okServer = { upgrade: (_req: Request, opts: unknown) => { upgrades.push(opts); return true; } };
+    expect(registry.handleUpgrade(new Request("http://local/ws/pty"), okServer).matched).toBe(true);
+    expect(registry.handleUpgrade(new Request("http://local/ws/tmux"), okServer).matched).toBe(true);
+    expect(registry.handleUpgrade(new Request("http://local/ws"), okServer).matched).toBe(true);
+    expect(registry.handleUpgrade(new Request("http://local/not-ws"), okServer)).toEqual({ matched: false });
+
+    expect(upgrades).toMatchObject([
+      { data: { target: null, mode: "pty", __serveWsRoute: "/ws/pty" } },
+      { data: { target: null, mode: "tmux-stream", __serveWsRoute: "/ws/tmux" } },
+      { data: { target: null, __serveWsRoute: "/ws" } },
+    ]);
+    for (const upgrade of upgrades as Array<{ data: { previewTargets: unknown } }>) {
+      expect(upgrade.data.previewTargets).toBeInstanceOf(Set);
+    }
+
+    const failed = registry.handleUpgrade(new Request("http://local/ws"), { upgrade: () => false });
+    expect(failed.matched).toBe(true);
+    expect(failed.response?.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- add a core ServeWsRegistry for Bun upgrade dispatch while keeping heartbeat/upgrade ownership in maw serve
- move /ws, /ws/pty, and /ws/tmux handler registration into src/vendor/mpr-plugins/serve-ws
- expose ws + engine on serve lifecycle context and cover the plugin boundary/contract

Closes #2448
References #2408

## Validation
- bun test test/isolated/plugin-serve-ws-standalone.test.ts test/isolated/core-server-more-coverage-2.test.ts test/isolated/core-server-engine-crash-more-coverage.test.ts test/isolated/coverage-core-shared-server.test.ts test/isolated/install-server-intervals-extra-coverage.test.ts
- bun scripts/check-plugin-coverage-gate.ts origin/alpha
- git diff --check
- bun run build