### PR TITLE
Extract serve agent listing routes into plugin

### DIFF
--- a/packages/sdk/index.d.ts
+++ b/packages/sdk/index.d.ts
@@ -260,6 +260,20 @@ export declare function loadPendingById(id: string): PendingMessage | null;
 export declare function updatePending(id: string, patch: Partial<PendingMessage>): PendingMessage;
 export declare function deletePending(id: string): boolean;
 export declare function cmdSplit(target: string, opts?: Record<string, unknown>): Promise<void>;
+export interface AgentRow {
+  node: string;
+  session: string;
+  window: string;
+  oracle: string;
+  state: "active" | "idle";
+  pid: number | null;
+}
+export declare function buildAgentRows(
+  panes: Array<{ command: string; target: string; pid?: number }>,
+  windowNames: Map<string, string>,
+  nodeName: string,
+  opts?: { all?: boolean },
+): AgentRow[];
 
 // --- src/config ---
 

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -72,6 +72,8 @@ export {
 } from "../../src/commands/shared/queue-store";
 export type { PendingMessage } from "../../src/commands/shared/queue-store";
 export { cmdSplit } from "../../src/commands/plugins/split/impl";
+export { buildAgentRows } from "../../src/commands/shared/agents";
+export type { AgentRow } from "../../src/commands/shared/agents";
 
 // ─── src/config ──────────────────────────────────────────────────────────────
 // Operator config loader + key-typed accessors. Used by:

--- a/src/commands/shared/agents.ts
+++ b/src/commands/shared/agents.ts
@@ -1,4 +1,4 @@
-import { tmux } from "../../sdk";
+import { tmux } from "../../core/transport/tmux";
 import { loadConfig } from "../../config";
 
 /** @internal — exported for tests only. */

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -215,6 +215,8 @@ export { tlink } from "../core/util/terminal";
 // Plugin extraction helpers for tab-like command surfaces.
 export { cmdPeek, cmdSend } from "../commands/shared/comm";
 export { cmdSplit } from "../commands/plugins/split/impl";
+export { buildAgentRows } from "../commands/shared/agents";
+export type { AgentRow } from "../commands/shared/agents";
 
 // ─── Transport Router ────────────────────────────────────────────────────────
 

--- a/src/vendor/mpr-plugins/serve-agents/index.ts
+++ b/src/vendor/mpr-plugins/serve-agents/index.ts
@@ -1,0 +1,69 @@
+import { buildAgentRows, loadConfig, tmux } from "maw-js/sdk";
+import type { ServeHttpRouteRegistrar } from "maw-js/plugin/types";
+
+type AgentsDeps = {
+  tmux: Pick<typeof tmux, "listAll" | "listPanes">;
+  loadConfig: typeof loadConfig;
+  buildAgentRows: typeof buildAgentRows;
+};
+
+type ServeAgentsContext = {
+  http?: ServeHttpRouteRegistrar;
+};
+
+const defaultDeps: AgentsDeps = {
+  tmux,
+  loadConfig,
+  buildAgentRows,
+};
+
+function wantsAll(searchParams: URLSearchParams): boolean {
+  const all = searchParams.get("all");
+  return all === "1" || all === "true";
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function buildAgentsReadResponse(
+  request: Request,
+  deps: AgentsDeps = defaultDeps,
+): Promise<Response> {
+  try {
+    const url = new URL(request.url);
+    const all = wantsAll(url.searchParams);
+    const config = deps.loadConfig();
+    const nodeName = config.node || "local";
+
+    const [sessions, panes] = await Promise.all([
+      deps.tmux.listAll(),
+      deps.tmux.listPanes(),
+    ]);
+
+    const windowNames = new Map<string, string>();
+    for (const session of sessions) {
+      for (const window of session.windows) {
+        windowNames.set(`${session.name}:${window.index}`, window.name);
+      }
+    }
+
+    const rows = deps.buildAgentRows(panes, windowNames, nodeName, { all });
+    return Response.json({ agents: rows, count: rows.length, node: nodeName });
+  } catch (error) {
+    return Response.json({ error: errorMessage(error) }, { status: 500 });
+  }
+}
+
+export function registerAgentsRoutes(http: ServeHttpRouteRegistrar, deps?: AgentsDeps): void {
+  const handler = (request: Request) => buildAgentsReadResponse(request, deps);
+  http.route("GET", "/api/agents", handler);
+  http.route("GET", "/api/agent", handler);
+}
+
+export function serve(ctx: ServeAgentsContext): void {
+  if (!ctx.http) throw new Error("serve-agents requires serve http route registration");
+  registerAgentsRoutes(ctx.http);
+}
+
+export default serve;

--- a/src/vendor/mpr-plugins/serve-agents/plugin.json
+++ b/src/vendor/mpr-plugins/serve-agents/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "serve-agents",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Registers the maw serve agent listing API routes.",
+  "author": "Soul-Brews-Studio",
+  "hooks": {
+    "serve": {
+      "script": "./index.ts",
+      "handler": "serve",
+      "policy": "fail-fast"
+    }
+  },
+  "weight": 0,
+  "license": "MIT",
+  "schemaVersion": 1
+}

--- a/src/vendor/mpr-plugins/serve-identity/impl.ts
+++ b/src/vendor/mpr-plugins/serve-identity/impl.ts
@@ -12,6 +12,7 @@ import { resolveNodeIdentity } from "../../../core/fleet/node-identity";
  * mounted routes — this is a contract, not documentation.
  */
 export const ADVERTISED_ENDPOINTS: string[] = [
+  "/api/agents",
   "/api/identity",
   "/api/messages",
   "/api/pane-keys",

--- a/test/federation-api-default.test.ts
+++ b/test/federation-api-default.test.ts
@@ -107,6 +107,7 @@ describe("serve-identity plugin API", () => {
       uptime: 42,
       clockUtc: "2026-05-17T00:00:00.000Z",
       endpoints: [
+        "/api/agents",
         "/api/identity",
         "/api/messages",
         "/api/pane-keys",

--- a/test/isolated/plugin-serve-agents-standalone.test.ts
+++ b/test/isolated/plugin-serve-agents-standalone.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
+
+const root = join(import.meta.dir, "../..");
+let listAllError: Error | undefined;
+let listPanesError: Error | undefined;
+
+function buildRows(
+  panes: Array<{ command: string; target: string; pid?: number }>,
+  windowNames: Map<string, string>,
+  node: string,
+  opts: { all?: boolean } = {},
+) {
+  return panes.flatMap((pane) => {
+    const match = pane.target.match(/^(.+):(.+)\.\d+$/);
+    if (!match) return [];
+    const [, session, winPart] = match;
+    const window = /^\d+$/.test(winPart) ? windowNames.get(`${session}:${winPart}`) ?? "" : winPart;
+    const oracle = window.endsWith("-oracle") ? window.slice(0, -"-oracle".length) : "";
+    if (!opts.all && !oracle) return [];
+    return [{
+      node,
+      session,
+      window,
+      oracle,
+      state: ["zsh", "bash", "sh", "fish", "dash"].includes(pane.command.toLowerCase()) ? "idle" : "active",
+      pid: pane.pid ?? null,
+    }];
+  });
+}
+
+mock.module("maw-js/sdk", () => ({
+  loadConfig: () => ({ node: "test-node" }),
+  tmux: {
+    listAll: async () => {
+      if (listAllError) throw listAllError;
+      return [
+        { name: "01-mawjs", windows: [{ index: "0", name: "mawjs-oracle" }] },
+        { name: "02-neo", windows: [{ index: "0", name: "neo-oracle" }, { index: "1", name: "shell" }] },
+      ];
+    },
+    listPanes: async () => {
+      if (listPanesError) throw listPanesError;
+      return [
+        { command: "claude", target: "01-mawjs:0.0", pid: 1001 },
+        { command: "claude", target: "02-neo:0.0", pid: 1002 },
+        { command: "zsh", target: "02-neo:1.0", pid: 1003 },
+      ];
+    },
+  },
+  buildAgentRows: buildRows,
+}));
+
+const plugin = await import("../../src/vendor/mpr-plugins/serve-agents/index.ts?plugin-serve-agents-standalone");
+
+async function json(response: Response): Promise<any> {
+  return await response.json();
+}
+
+describe("serve-agents plugin standalone boundary (#2447)", () => {
+  test("imports agent listing dependencies only through the SDK and serve types", () => {
+    expectStandalonePluginBoundary({ plugin: "serve-agents" });
+    const source = readFileSync(join(root, "src/vendor/mpr-plugins/serve-agents/index.ts"), "utf8");
+    expect(source).toContain('from "maw-js/sdk"');
+    expect(source).toContain('from "maw-js/plugin/types"');
+  });
+
+  test("serve hook registers the legacy /api/agents routes", async () => {
+    const routes = new Map<string, (request: Request) => Response | Promise<Response>>();
+
+    plugin.serve({
+      http: {
+        route(method, path, handler) {
+          routes.set(`${method} ${path}`, handler);
+        },
+      },
+    });
+
+    expect([...routes.keys()].sort()).toEqual([
+      "GET /api/agent",
+      "GET /api/agents",
+    ]);
+
+    const res = await routes.get("GET /api/agents")!(new Request("http://local/api/agents"));
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    expect(body).toMatchObject({ count: 2, node: "test-node" });
+    expect(body.agents.map((agent: any) => agent.oracle).sort()).toEqual(["mawjs", "neo"]);
+    expect(body.agents.every((agent: any) => agent.window.endsWith("-oracle"))).toBe(true);
+
+    const alias = await routes.get("GET /api/agent")!(new Request("http://local/api/agent"));
+    expect(await json(alias)).toEqual(body);
+  });
+
+  test("preserves all-pane query handling and row shape", async () => {
+    listAllError = undefined;
+    listPanesError = undefined;
+    const res = await plugin.buildAgentsReadResponse(new Request("http://local/api/agents?all=true"));
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    expect(body.count).toBe(3);
+    expect(body.agents.find((agent: any) => agent.window === "shell")).toBeDefined();
+    expect(body.agents[0]).toEqual(expect.objectContaining({
+      node: expect.any(String),
+      session: expect.any(String),
+      window: expect.any(String),
+      oracle: expect.any(String),
+      state: expect.any(String),
+      pid: expect.any(Number),
+    }));
+
+    const one = await plugin.buildAgentsReadResponse(new Request("http://local/api/agents?all=1"));
+    expect((await json(one)).count).toBe(3);
+  });
+
+  test("reports tmux failures as route errors without throwing", async () => {
+    listAllError = new Error("tmux offline");
+    try {
+      const res = await plugin.buildAgentsReadResponse(new Request("http://local/api/agents"));
+      expect(res.status).toBe(500);
+      expect(await json(res)).toEqual({ error: "tmux offline" });
+    } finally {
+      listAllError = undefined;
+      listPanesError = undefined;
+    }
+  });
+
+  test("serve hook fails clearly without route registration context", () => {
+    expect(() => plugin.serve({})).toThrow("serve-agents requires serve http route registration");
+  });
+});

--- a/test/isolated/plugin-serve-identity-standalone.test.ts
+++ b/test/isolated/plugin-serve-identity-standalone.test.ts
@@ -73,7 +73,7 @@ describe("serve-identity plugin standalone boundary", () => {
       agents: [{ node: "codex@m5", name: "neo" }],
       uptime: 2,
       clockUtc: "2026-06-07T00:00:00.000Z",
-      endpoints: ["/api/identity", "/api/messages", "/api/pane-keys", "/api/probe", "/api/send", "/api/sleep", "/api/wake"],
+      endpoints: ["/api/agents", "/api/identity", "/api/messages", "/api/pane-keys", "/api/probe", "/api/send", "/api/sleep", "/api/wake"],
       pubkey: "pub",
     });
   });


### PR DESCRIPTION
## Summary
- adds bundled `serve-agents` plugin with a manifest serve hook
- registers the legacy `GET /api/agents` and `GET /api/agent` listing routes through `ServeRouteRegistry`
- mirrors `buildAgentRows` through internal and package SDK surfaces so the plugin preserves the `maw agents --json` row contract
- advertises `/api/agents` from the identity endpoint list

Closes #2447.

## Validation
- `bun scripts/check-plugin-coverage-gate.ts origin/alpha`
- `MAW_TEST_MODE=1 bun test test/isolated/plugin-serve-agents-standalone.test.ts test/isolated/plugin-serve-identity-standalone.test.ts test/isolated/plugin-lifecycle.test.ts test/isolated/plugin-serve-worktrees-standalone.test.ts test/isolated/plugin-serve-triggers-standalone.test.ts test/isolated/plugin-serve-debug-standalone.test.ts test/isolated/plugin-serve-views-standalone.test.ts test/agents.test.ts test/isolated/sdk-plugin-exports.test.ts test/isolated/sdk-config-export.test.ts test/isolated/sdk-tmux-export.test.ts --path-ignore-patterns '**/agents/**'`