### PR TITLE
Extract serve health routes into plugin

### DIFF
--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -1,7 +1,7 @@
 import { Elysia, t } from "elysia";
 import { readdirSync, readFileSync, writeFileSync, renameSync, unlinkSync, existsSync } from "fs";
 import { join, basename } from "path";
-import { type MawConfig, loadConfig, saveConfig, configForDisplay } from "../config";
+import { loadConfig, saveConfig, configForDisplay } from "../config";
 import { CONFIG_FILE } from "../core/paths";
 import { fleetDirForWrite, fleetDirsForRead, uniqueDirs } from "../core/fleet/paths";
 
@@ -245,36 +245,6 @@ export function createConfigApi(deps: ConfigApiDeps = {}) {
     return { ok };
   }, {
     body: t.Object({ pin: t.Optional(t.String()) }),
-  });
-
-  // PUBLIC FEDERATION API (v1) — no auth. Shape is load-bearing for lens
-  // clients (e.g. maw-ui#8). See docs/federation.md before changing fields.
-  configApi.get("/config", ({ query }) => {
-    if (query.raw === "1") return load();
-    return displayConfig();
-  }, {
-    query: t.Object({ raw: t.Optional(t.String()) }),
-  });
-
-  configApi.post("/config", async ({ body, set }) => {
-    try {
-      const data = body as Partial<MawConfig>;
-      // If env has masked values (bullet chars), keep originals for those keys
-      if (data.env && typeof data.env === "object") {
-        const current = load();
-        const merged: Record<string, string> = {};
-        for (const [k, v] of Object.entries(data.env as Record<string, string>)) {
-          merged[k] = /\u2022/.test(v) ? (current.env[k] || v) : v;
-        }
-        data.env = merged;
-      }
-      save(data);
-      return { ok: true };
-    } catch (e: unknown) {
-      set.status = 400; return { error: e instanceof Error ? e.message : String(e) };
-    }
-  }, {
-    body: t.Unknown(),
   });
 
   return configApi;

--- a/src/api/status.ts
+++ b/src/api/status.ts
@@ -1,49 +1,7 @@
 import { Elysia, t } from "elysia";
-import { agentStatusStore, type AgentStatus } from "../core/agent-status";
 import { messageQueue } from "../core/message-queue";
-import { resetConfig } from "../config/load";
-
-const VALID_STATUSES = new Set<AgentStatus>(["busy", "ready", "idle", "crashed", "offline"]);
 
 export const statusApi = new Elysia()
-  .get("/status", () => {
-    const agents = agentStatusStore.getAll();
-    const summary: Record<string, number> = {};
-    for (const a of agents) summary[a.status] = (summary[a.status] || 0) + 1;
-    return { agents, summary, total: agents.length };
-  })
-
-  .get("/status/:oracle", ({ params }) => {
-    const entry = agentStatusStore.get(params.oracle);
-    if (!entry) return { error: "not found", oracle: params.oracle };
-    const pending = messageQueue.pending(params.oracle);
-    return { ...entry, pendingMessages: pending.length };
-  })
-
-  .post("/status", ({ body }) => {
-    const { oracle, status, sessionId, project, event } = body as {
-      oracle: string;
-      status: string;
-      sessionId?: string;
-      project?: string;
-      event?: string;
-    };
-    if (!oracle || !status) return { error: "oracle and status required" };
-    if (!VALID_STATUSES.has(status as AgentStatus)) {
-      return { error: `invalid status: ${status}`, valid: [...VALID_STATUSES] };
-    }
-    agentStatusStore.report(oracle, status as AgentStatus, { sessionId, project, event });
-    return { ok: true, oracle, status };
-  }, {
-    body: t.Object({
-      oracle: t.String(),
-      status: t.String(),
-      sessionId: t.Optional(t.String()),
-      project: t.Optional(t.String()),
-      event: t.Optional(t.String()),
-    }),
-  })
-
   .get("/queue", () => {
     const all = messageQueue.getAll();
     return {
@@ -57,12 +15,6 @@ export const statusApi = new Elysia()
     const pending = messageQueue.pending(params.oracle);
     return { oracle: params.oracle, pending, count: pending.length };
   })
-
-  .post("/config/reload", () => {
-    resetConfig();
-    return { ok: true };
-  })
-
   .post("/queue", ({ body }) => {
     const { from, to, target, message } = body as {
       from: string; to: string; target: string; message: string;

--- a/src/core/serve-route-registry.ts
+++ b/src/core/serve-route-registry.ts
@@ -33,6 +33,15 @@ function assertAbsolutePath(path: string): void {
   if (!path.startsWith("/")) throw new Error(`serve route path must start with '/': ${path}`);
 }
 
+function routePathMatches(pattern: string, pathname: string): boolean {
+  if (pattern === pathname) return true;
+  if (!pattern.includes(":")) return false;
+  const patternParts = pattern.split("/").filter(Boolean);
+  const pathParts = pathname.split("/").filter(Boolean);
+  if (patternParts.length !== pathParts.length) return false;
+  return patternParts.every((part, index) => part.startsWith(":") || part === pathParts[index]);
+}
+
 export class ServeRouteRegistry implements ServeHttpRouteRegistrar, ServeFallbackRegistrar {
   private readonly routes = new Map<string, RegisteredServeRoute>();
   private readonly fallbackHandlers: Array<{ id: string; handler: ServeFallbackHandler }> = [];
@@ -56,7 +65,12 @@ export class ServeRouteRegistry implements ServeHttpRouteRegistrar, ServeFallbac
 
   async handle(request: Request): Promise<Response | undefined> {
     const url = new URL(request.url);
-    const route = this.routes.get(`${request.method.toUpperCase()} ${url.pathname}`);
+    const method = request.method.toUpperCase() as ServeRouteMethod;
+    const exact = this.routes.get(`${method} ${url.pathname}`);
+    if (exact) return exact.handler(request);
+    const route = [...this.routes.values()].find((candidate) =>
+      candidate.method === method && routePathMatches(candidate.path, url.pathname),
+    );
     if (!route) return undefined;
     return route.handler(request);
   }

--- a/src/vendor/mpr-plugins/health/plugin.json
+++ b/src/vendor/mpr-plugins/health/plugin.json
@@ -9,12 +9,6 @@
     "command": "health",
     "help": "maw health — check system health (tmux, server, disk, memory, pm2, peers)"
   },
-  "api": {
-    "path": "/api/health",
-    "methods": [
-      "GET"
-    ]
-  },
   "weight": 0,
   "license": "MIT",
   "schemaVersion": 1

--- a/src/vendor/mpr-plugins/serve-health/index.ts
+++ b/src/vendor/mpr-plugins/serve-health/index.ts
@@ -1,0 +1,151 @@
+import { loadConfig, saveConfig, configForDisplay, resetConfig, type MawConfig } from "maw-js/config";
+import type { ServeHttpRouteRegistrar } from "maw-js/plugin/types";
+import healthHandler from "../health/index";
+import { agentStatusStore as defaultAgentStatusStore, type AgentStatus } from "../../../core/agent-status";
+import { messageQueue as defaultMessageQueue } from "../../../core/message-queue";
+
+const VALID_STATUSES = new Set<AgentStatus>(["busy", "ready", "idle", "crashed", "offline"]);
+
+type AgentStatusStore = Pick<typeof defaultAgentStatusStore, "getAll" | "get" | "report">;
+type MessageQueue = Pick<typeof defaultMessageQueue, "pending">;
+
+type ServeHealthDeps = {
+  loadConfig: typeof loadConfig;
+  saveConfig: typeof saveConfig;
+  configForDisplay: typeof configForDisplay;
+  resetConfig: typeof resetConfig;
+  agentStatusStore: AgentStatusStore;
+  messageQueue: MessageQueue;
+  healthHandler: typeof healthHandler;
+};
+
+type ServeHealthContext = {
+  http?: ServeHttpRouteRegistrar;
+};
+
+const defaultDeps: ServeHealthDeps = {
+  loadConfig,
+  saveConfig,
+  configForDisplay,
+  resetConfig,
+  agentStatusStore: defaultAgentStatusStore,
+  messageQueue: defaultMessageQueue,
+  healthHandler,
+};
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function readJsonBody(request: Request): Promise<unknown> {
+  try {
+    return await request.json();
+  } catch {
+    return undefined;
+  }
+}
+
+function hasMaskedEnvValue(value: unknown): boolean {
+  return typeof value === "string" && /\u2022/.test(value);
+}
+
+function mergeMaskedEnv(data: Partial<MawConfig>, load: typeof loadConfig): Partial<MawConfig> {
+  if (!data.env || typeof data.env !== "object") return data;
+  const current = load();
+  const merged: Record<string, string> = {};
+  for (const [key, value] of Object.entries(data.env as Record<string, string>)) {
+    merged[key] = hasMaskedEnvValue(value) ? (current.env[key] || value) : value;
+  }
+  return { ...data, env: merged };
+}
+
+export function createServeHealthRouteHandlers(deps: Partial<ServeHealthDeps> = {}) {
+  const d = { ...defaultDeps, ...deps };
+
+  return {
+    getConfig: (request: Request) => {
+      const url = new URL(request.url);
+      if (url.searchParams.get("raw") === "1") return Response.json(d.loadConfig());
+      return Response.json(d.configForDisplay());
+    },
+
+    postConfig: async (request: Request) => {
+      try {
+        const body = await readJsonBody(request) as Partial<MawConfig>;
+        d.saveConfig(mergeMaskedEnv(body ?? {}, d.loadConfig));
+        return Response.json({ ok: true });
+      } catch (error) {
+        return Response.json({ error: errorMessage(error) }, { status: 400 });
+      }
+    },
+
+    reloadConfig: () => {
+      d.resetConfig();
+      return Response.json({ ok: true });
+    },
+
+    health: async (request: Request) => {
+      const url = new URL(request.url);
+      const args = Object.fromEntries(url.searchParams.entries());
+      const result = await d.healthHandler({ source: "api", args });
+      return Response.json(result);
+    },
+
+    getStatus: () => {
+      const agents = d.agentStatusStore.getAll();
+      const summary: Record<string, number> = {};
+      for (const a of agents) summary[a.status] = (summary[a.status] || 0) + 1;
+      return Response.json({ agents, summary, total: agents.length });
+    },
+
+    getOracleStatus: (_request: Request, oracle: string) => {
+      const entry = d.agentStatusStore.get(oracle);
+      if (!entry) return Response.json({ error: "not found", oracle });
+      const pending = d.messageQueue.pending(oracle);
+      return Response.json({ ...entry, pendingMessages: pending.length });
+    },
+
+    postStatus: async (request: Request) => {
+      const body = await readJsonBody(request) as {
+        oracle?: string;
+        status?: string;
+        sessionId?: string;
+        project?: string;
+        event?: string;
+      } | undefined;
+      const oracle = body?.oracle;
+      const status = body?.status;
+      if (!oracle || !status) return Response.json({ error: "oracle and status required" });
+      if (!VALID_STATUSES.has(status as AgentStatus)) {
+        return Response.json({ error: `invalid status: ${status}`, valid: [...VALID_STATUSES] });
+      }
+      d.agentStatusStore.report(oracle, status as AgentStatus, {
+        sessionId: body?.sessionId,
+        project: body?.project,
+        event: body?.event,
+      });
+      return Response.json({ ok: true, oracle, status });
+    },
+  };
+}
+
+export function registerServeHealthRoutes(http: ServeHttpRouteRegistrar, deps?: Partial<ServeHealthDeps>): void {
+  const handlers = createServeHealthRouteHandlers(deps);
+  http.route("GET", "/api/config", handlers.getConfig);
+  http.route("POST", "/api/config", handlers.postConfig);
+  http.route("POST", "/api/config/reload", handlers.reloadConfig);
+  http.route("GET", "/api/health", handlers.health);
+  http.route("GET", "/api/status", handlers.getStatus);
+  http.route("POST", "/api/status", handlers.postStatus);
+  http.route("GET", "/api/status/:oracle", (request) => {
+    const oracle = decodeURIComponent(new URL(request.url).pathname.split("/").pop() ?? "");
+    return handlers.getOracleStatus(request, oracle);
+  });
+}
+
+export function serve(ctx: ServeHealthContext): void {
+  if (!ctx.http) throw new Error("serve-health requires serve http route registration");
+  registerServeHealthRoutes(ctx.http);
+}
+
+export default serve;

--- a/src/vendor/mpr-plugins/serve-health/plugin.json
+++ b/src/vendor/mpr-plugins/serve-health/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "serve-health",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "tier": "core",
+  "description": "Registers maw serve config, health, and agent status API routes.",
+  "author": "Soul-Brews-Studio",
+  "hooks": {
+    "serve": {
+      "script": "./index.ts",
+      "handler": "serve",
+      "ensures": [
+        "http:route:/api/config",
+        "http:route:/api/config/reload",
+        "http:route:/api/health",
+        "http:route:/api/status"
+      ],
+      "policy": "fail-fast"
+    }
+  },
+  "capabilities": [
+    "serve:http-route",
+    "config:read",
+    "config:write",
+    "health:read",
+    "status:read",
+    "status:write"
+  ],
+  "capabilityNamespaces": ["serve", "config", "health", "status"],
+  "weight": 0,
+  "license": "MIT",
+  "schemaVersion": 1
+}

--- a/test/config-api-default.test.ts
+++ b/test/config-api-default.test.ts
@@ -227,7 +227,7 @@ describe("config API file routes", () => {
   });
 });
 
-describe("config API pin and public config routes", () => {
+describe("config API pin routes", () => {
   test("pin info, set, verify, reset, and rate-limit branches", async () => {
     const saves: any[] = [];
     const attempts = new Map<string, { count: number; resetAt: number }>();
@@ -292,24 +292,4 @@ describe("config API pin and public config routes", () => {
     }
   });
 
-  test("GET and POST /config preserve masked env values and report save errors", async () => {
-    const saves: any[] = [];
-    const app = makeApp({
-      loadConfig: (() => ({ raw: true, env: { SECRET: "raw-secret" } })) as any,
-      configForDisplay: (() => ({ display: true, envMasked: { SECRET: "••••" } })) as any,
-      saveConfig: ((data: any) => { saves.push(data); }) as any,
-    });
-
-    expect(await readJson(await app.handle(new Request("http://localhost/config?raw=1")))).toEqual({ raw: true, env: { SECRET: "raw-secret" } });
-    expect(await readJson(await app.handle(new Request("http://localhost/config")))).toEqual({ display: true, envMasked: { SECRET: "••••" } });
-
-    const save = await app.handle(jsonRequest("/config", "POST", { env: { SECRET: "••••", PLAIN: "ok" } }));
-    expect(save.status).toBe(200);
-    expect(saves).toEqual([{ env: { SECRET: "raw-secret", PLAIN: "ok" } }]);
-
-    const failing = makeApp({ saveConfig: (() => { throw new Error("config save boom"); }) as any });
-    const error = await failing.handle(jsonRequest("/config", "POST", { host: "local" }));
-    expect(error.status).toBe(400);
-    expect((await readJson(error)).error).toBe("config save boom");
-  });
 });

--- a/test/isolated/api-status.test.ts
+++ b/test/isolated/api-status.test.ts
@@ -1,26 +1,27 @@
 import { describe, test, expect, beforeEach } from "bun:test";
-import { Elysia } from "elysia";
-import { statusApi } from "../../src/api/status";
+import { ServeRouteRegistry } from "../../src/core/serve-route-registry";
+import { registerServeHealthRoutes } from "../../src/vendor/mpr-plugins/serve-health/index";
 import { agentStatusStore } from "../../src/core/agent-status";
 
 describe("Status API", () => {
-  let app: Elysia;
+  let app: ServeRouteRegistry;
 
   beforeEach(() => {
-    app = new Elysia().use(statusApi);
+    app = new ServeRouteRegistry();
+    registerServeHealthRoutes(app);
     // Clear store between tests — access internal map via report/remove
     for (const e of agentStatusStore.getAll()) agentStatusStore.remove(e.oracle);
   });
 
   test("GET /status returns empty list initially", async () => {
-    const res = await app.handle(new Request("http://localhost/status"));
+    const res = await app.handle(new Request("http://localhost/api/status"));
     const body = await res.json() as { agents: unknown[]; summary: Record<string, number>; total: number };
     expect(body.agents).toEqual([]);
     expect(body.total).toBe(0);
   });
 
   test("POST /status reports agent status", async () => {
-    const res = await app.handle(new Request("http://localhost/status", {
+    const res = await app.handle(new Request("http://localhost/api/status", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ oracle: "neo", status: "busy", sessionId: "s1" }),
@@ -28,14 +29,14 @@ describe("Status API", () => {
     const body = await res.json() as { ok: boolean };
     expect(body.ok).toBe(true);
 
-    const getRes = await app.handle(new Request("http://localhost/status/neo"));
+    const getRes = await app.handle(new Request("http://localhost/api/status/neo"));
     const entry = await getRes.json() as { oracle: string; status: string };
     expect(entry.oracle).toBe("neo");
     expect(entry.status).toBe("busy");
   });
 
   test("POST /status rejects invalid status", async () => {
-    const res = await app.handle(new Request("http://localhost/status", {
+    const res = await app.handle(new Request("http://localhost/api/status", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ oracle: "neo", status: "invalid" }),
@@ -45,7 +46,7 @@ describe("Status API", () => {
   });
 
   test("GET /status/:oracle returns 'not found' for unknown", async () => {
-    const res = await app.handle(new Request("http://localhost/status/unknown"));
+    const res = await app.handle(new Request("http://localhost/api/status/unknown"));
     const body = await res.json() as { error: string };
     expect(body.error).toBe("not found");
   });
@@ -55,7 +56,7 @@ describe("Status API", () => {
     agentStatusStore.report("morpheus", "busy");
     agentStatusStore.report("trinity", "ready");
 
-    const res = await app.handle(new Request("http://localhost/status"));
+    const res = await app.handle(new Request("http://localhost/api/status"));
     const body = await res.json() as { summary: Record<string, number>; total: number };
     expect(body.summary.busy).toBe(2);
     expect(body.summary.ready).toBe(1);

--- a/test/isolated/plugin-health-standalone.test.ts
+++ b/test/isolated/plugin-health-standalone.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
 const realSdk = await import("../../src/sdk/index.ts");
 afterAll(() => { mock.restore(); });
 
@@ -93,8 +94,12 @@ describe("health plugin standalone boundary", () => {
     const implSource = readFileSync(join(root, "src/vendor/mpr-plugins/health/impl.ts"), "utf8");
     const combined = `${indexSource}\n${implSource}`;
 
+    const manifest = JSON.parse(readFileSync(join(root, "src/vendor/mpr-plugins/health/plugin.json"), "utf8"));
+
     expect(command).toMatchObject({ name: "health" });
+    expect(manifest.api).toBeUndefined();
     expect(combined).toContain('from "maw-js/sdk"');
+    expectStandalonePluginBoundary({ plugin: "health" });
     expect(combined).not.toMatch(/maw-js\/(?:core|commands\/shared|cli|config|lib|plugin)(?:\/|")/);
     expect(combined).not.toMatch(/from\s+["'](?:\.\.\/)+(?:core|commands|cli|config|lib|src)\//);
   });

--- a/test/isolated/plugin-serve-health-standalone.test.ts
+++ b/test/isolated/plugin-serve-health-standalone.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { ServeRouteRegistry } from "../../src/core/serve-route-registry";
+import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
+import {
+  createServeHealthRouteHandlers,
+  registerServeHealthRoutes,
+  serve,
+} from "../../src/vendor/mpr-plugins/serve-health/index.ts?plugin-serve-health-standalone";
+
+const root = join(import.meta.dir, "../..");
+
+function jsonRequest(path: string, method: string, body?: unknown) {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers: { "content-type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+async function readJson(res: Response) {
+  return await res.json() as any;
+}
+
+describe("serve-health plugin standalone boundary", () => {
+  test("declares serve hook routes and removes old health API auto-mount", () => {
+    const manifest = JSON.parse(readFileSync(join(root, "src/vendor/mpr-plugins/serve-health/plugin.json"), "utf8"));
+    expect(manifest.hooks.serve).toMatchObject({ script: "./index.ts", handler: "serve", policy: "fail-fast" });
+    expect(manifest.api).toBeUndefined();
+
+    const oldHealth = JSON.parse(readFileSync(join(root, "src/vendor/mpr-plugins/health/plugin.json"), "utf8"));
+    expect(oldHealth.api).toBeUndefined();
+  });
+
+  test("boundary drift is explicit for this core serve route plugin", () => {
+    expectStandalonePluginBoundary({
+      plugin: "serve-health",
+      requireSdk: false,
+      allowMawJs: ["maw-js/config"],
+      allowRelative: [
+        /^\.\.\/health\/index$/,
+        /^\.\.\/\.\.\/\.\.\/core\/agent-status$/,
+        /^\.\.\/\.\.\/\.\.\/core\/message-queue$/,
+      ],
+    });
+  });
+
+  test("registers config, health, and status routes through serve hook", async () => {
+    const routes = new Map<string, (request: Request) => Response | Promise<Response>>();
+
+    serve({
+      http: {
+        route(method, path, handler) {
+          routes.set(`${method} ${path}`, handler);
+        },
+      },
+    });
+
+    expect([...routes.keys()].sort()).toEqual([
+      "GET /api/config",
+      "GET /api/health",
+      "GET /api/status",
+      "GET /api/status/:oracle",
+      "POST /api/config",
+      "POST /api/config/reload",
+      "POST /api/status",
+    ]);
+  });
+
+  test("preserves GET and POST /api/config response shapes", async () => {
+    const saves: any[] = [];
+    const handlers = createServeHealthRouteHandlers({
+      loadConfig: (() => ({ raw: true, env: { SECRET: "raw-secret" } })) as any,
+      configForDisplay: (() => ({ display: true, envMasked: { SECRET: "••••" } })) as any,
+      saveConfig: ((data: any) => { saves.push(data); }) as any,
+    });
+
+    expect(await readJson(await handlers.getConfig(new Request("http://localhost/api/config?raw=1")))).toEqual({ raw: true, env: { SECRET: "raw-secret" } });
+    expect(await readJson(await handlers.getConfig(new Request("http://localhost/api/config")))).toEqual({ display: true, envMasked: { SECRET: "••••" } });
+
+    const save = await handlers.postConfig(jsonRequest("/api/config", "POST", { env: { SECRET: "••••", PLAIN: "ok" } }));
+    expect(save.status).toBe(200);
+    expect(saves).toEqual([{ env: { SECRET: "raw-secret", PLAIN: "ok" } }]);
+
+    const failing = createServeHealthRouteHandlers({ saveConfig: (() => { throw new Error("config save boom"); }) as any });
+    const error = await failing.postConfig(jsonRequest("/api/config", "POST", { host: "local" }));
+    expect(error.status).toBe(400);
+    expect((await readJson(error)).error).toBe("config save boom");
+  });
+
+  test("preserves status summaries, per-oracle pending counts, validation, and config reload", async () => {
+    const reports: any[] = [];
+    let reloaded = 0;
+    const entries = [
+      { oracle: "neo", status: "busy" },
+      { oracle: "trinity", status: "ready" },
+      { oracle: "morpheus", status: "busy" },
+    ];
+    const handlers = createServeHealthRouteHandlers({
+      resetConfig: (() => { reloaded += 1; }) as any,
+      agentStatusStore: {
+        getAll: () => entries,
+        get: (oracle: string) => entries.find((entry) => entry.oracle === oracle),
+        report: (...args: any[]) => { reports.push(args); },
+      } as any,
+      messageQueue: { pending: (oracle: string) => oracle === "neo" ? [{ id: "m1" }, { id: "m2" }] : [] } as any,
+    });
+
+    expect(await readJson(await handlers.getStatus(new Request("http://localhost/api/status")))).toEqual({
+      agents: entries,
+      summary: { busy: 2, ready: 1 },
+      total: 3,
+    });
+    expect(await readJson(await handlers.getOracleStatus(new Request("http://localhost/api/status/neo"), "neo"))).toEqual({
+      oracle: "neo",
+      status: "busy",
+      pendingMessages: 2,
+    });
+    expect(await readJson(await handlers.getOracleStatus(new Request("http://localhost/api/status/unknown"), "unknown"))).toEqual({ error: "not found", oracle: "unknown" });
+
+    expect(await readJson(await handlers.postStatus(jsonRequest("/api/status", "POST", { oracle: "neo", status: "invalid" })))).toMatchObject({ error: "invalid status: invalid" });
+    expect(await readJson(await handlers.postStatus(jsonRequest("/api/status", "POST", { oracle: "neo", status: "busy", sessionId: "s1" })))).toEqual({ ok: true, oracle: "neo", status: "busy" });
+    expect(reports).toEqual([["neo", "busy", { sessionId: "s1", project: undefined, event: undefined }]]);
+
+    expect(await readJson(await handlers.reloadConfig(new Request("http://localhost/api/config/reload", { method: "POST" })))).toEqual({ ok: true });
+    expect(reloaded).toBe(1);
+  });
+
+  test("preserves /api/health invoke-result shape and auto-mounted status semantics", async () => {
+    const handlers = createServeHealthRouteHandlers({
+      healthHandler: (async (ctx: any) => ({ ok: false, error: `source=${ctx.source} args=${JSON.stringify(ctx.args)}` })) as any,
+    });
+
+    const response = await handlers.health(new Request("http://localhost/api/health?verbose=1"));
+    expect(response.status).toBe(200);
+    expect(await readJson(response)).toEqual({ ok: false, error: 'source=api args={"verbose":"1"}' });
+  });
+
+  test("registered param route works through ServeRouteRegistry", async () => {
+    const registry = new ServeRouteRegistry();
+    registerServeHealthRoutes(registry, {
+      agentStatusStore: {
+        getAll: () => [],
+        get: (oracle: string) => ({ oracle, status: "ready" }),
+        report: () => {},
+      } as any,
+      messageQueue: { pending: () => [{ id: "queued" }] } as any,
+    });
+
+    const response = await registry.handle(new Request("http://localhost/api/status/neo"));
+    expect(response?.status).toBe(200);
+    expect(await response!.json()).toEqual({ oracle: "neo", status: "ready", pendingMessages: 1 });
+  });
+
+  test("serve hook fails clearly without route registration context", () => {
+    expect(() => serve({})).toThrow("serve-health requires serve http route registration");
+  });
+});

--- a/test/isolated/serve-route-registry.test.ts
+++ b/test/isolated/serve-route-registry.test.ts
@@ -24,6 +24,23 @@ describe("ServeRouteRegistry", () => {
     ]);
   });
 
+  test("dispatches colon parameter routes after exact routes", async () => {
+    const registry = new ServeRouteRegistry();
+    registry.route("GET", "/api/status", () => Response.json({ route: "summary" }));
+    registry.route("GET", "/api/status/:oracle", (request) => {
+      const oracle = new URL(request.url).pathname.split("/").pop();
+      return Response.json({ route: "oracle", oracle });
+    });
+
+    const exact = await registry.handle(new Request("http://local/api/status"));
+    expect(await exact!.json()).toEqual({ route: "summary" });
+
+    const param = await registry.handle(new Request("http://local/api/status/neo"));
+    expect(await param!.json()).toEqual({ route: "oracle", oracle: "neo" });
+
+    expect(await registry.handle(new Request("http://local/api/status/neo/extra"))).toBeUndefined();
+  });
+
   test("rejects non-absolute paths and duplicate routes", () => {
     const registry = new ServeRouteRegistry();
     expect(() => registry.route("GET", "api/worktrees", () => new Response())).toThrow("serve route path must start");


### PR DESCRIPTION
## Summary\n- add bundled serve-health plugin that registers /api/config, /api/config/reload, /api/health, and /api/status* through the serve lifecycle hook\n- remove those direct route owners from core config/status APIs and remove the old health plugin manifest API auto-mount\n- teach ServeRouteRegistry to dispatch colon-parameter paths for /api/status/:oracle\n\nCloses #2449\n\n## Verification\n- bun scripts/check-plugin-coverage-gate.ts origin/alpha\n- bun test test/isolated/plugin-serve-health-standalone.test.ts test/isolated/plugin-health-standalone.test.ts test/isolated/serve-route-registry.test.ts test/isolated/api-status.test.ts test/config-api-default.test.ts test/plugin-manifest.test.ts test/plugin-lifecycle.test.ts test/isolated/coverage-core-shared-server.test.ts test/isolated/core-server-more-coverage-2.test.ts