### PR TITLE
Unify serve route registration behind owned registry

### DIFF
--- a/src/core/serve-route-registry.ts
+++ b/src/core/serve-route-registry.ts
@@ -1,28 +1,41 @@
-import type { ServeHttpRouteRegistrar, ServeRouteHandler, ServeRouteMethod } from "../plugin/types";
+import type {
+  ServeFallbackHandler,
+  ServeHttpRouteRegistrar,
+  ServeRouteHandler,
+  ServeRouteMethod,
+  ServeRouteRegistrar,
+} from "../plugin/types";
 
-export type { ServeHttpRouteRegistrar, ServeRouteHandler, ServeRouteMethod } from "../plugin/types";
+export type { ServeFallbackHandler, ServeHttpRouteRegistrar, ServeRouteHandler, ServeRouteMethod, ServeRouteRegistrar } from "../plugin/types";
 
 export type ServeRouteEnv = Record<string, unknown>;
 
-export type ServeFallbackHandler = (
-  req: Request,
-  env?: ServeRouteEnv,
-) => Response | Promise<Response>;
+export type ServeRouteOwner = {
+  name: string;
+  dir?: string;
+};
 
-export interface ServeFallbackRegistrar {
-  /** Register the public fallback surface used after core /ws and /api routing. */
-  fallback(id: string, handler: ServeFallbackHandler): void;
+export interface ServeRouteRegistryContext extends ServeRouteRegistrar {
+  /** Return a plugin-scoped registrar so route ownership is captured centrally. */
+  forPlugin(plugin: ServeRouteOwner): ServeRouteRegistrar;
 }
 
 export interface ServeHookContext {
-  http: ServeHttpRouteRegistrar & ServeFallbackRegistrar;
-  plugin?: { name: string; dir?: string };
+  http: ServeRouteRegistrar;
+  plugin?: ServeRouteOwner;
 }
 
 type RegisteredServeRoute = {
   method: ServeRouteMethod;
   path: string;
   handler: ServeRouteHandler;
+  plugin?: ServeRouteOwner;
+};
+
+type RegisteredServeFallback = {
+  id: string;
+  handler: ServeFallbackHandler;
+  plugin?: ServeRouteOwner;
 };
 
 function normalizeMethod(method: ServeRouteMethod): ServeRouteMethod {
@@ -42,25 +55,56 @@ function routePathMatches(pattern: string, pathname: string): boolean {
   return patternParts.every((part, index) => part.startsWith(":") || part === pathParts[index]);
 }
 
-export class ServeRouteRegistry implements ServeHttpRouteRegistrar, ServeFallbackRegistrar {
+function pluginLabel(plugin?: ServeRouteOwner): string {
+  return plugin?.name ? ` (${plugin.name})` : "";
+}
+
+export class ServeRouteRegistry implements ServeRouteRegistryContext {
   private readonly routes = new Map<string, RegisteredServeRoute>();
-  private readonly fallbackHandlers: Array<{ id: string; handler: ServeFallbackHandler }> = [];
+  private readonly fallbackHandlers: RegisteredServeFallback[] = [];
+
+  forPlugin(plugin: ServeRouteOwner): ServeRouteRegistrar {
+    if (!plugin.name.trim()) throw new Error("serve route plugin name is required");
+    const owner = { name: plugin.name, ...(plugin.dir ? { dir: plugin.dir } : {}) };
+    return {
+      route: (method, path, handler) => this.registerRoute(owner, method, path, handler),
+      fallback: (id, handler) => this.registerFallback(owner, id, handler),
+    };
+  }
 
   route(method: ServeRouteMethod, path: string, handler: ServeRouteHandler): void {
-    assertAbsolutePath(path);
-    const normalizedMethod = normalizeMethod(method);
-    const key = `${normalizedMethod} ${path}`;
-    if (this.routes.has(key)) throw new Error(`serve route already registered: ${key}`);
-    this.routes.set(key, { method: normalizedMethod, path, handler });
+    this.registerRoute(undefined, method, path, handler);
   }
 
   fallback(id: string, handler: ServeFallbackHandler): void {
+    this.registerFallback(undefined, id, handler);
+  }
+
+  private registerRoute(
+    plugin: ServeRouteOwner | undefined,
+    method: ServeRouteMethod,
+    path: string,
+    handler: ServeRouteHandler,
+  ): void {
+    assertAbsolutePath(path);
+    if (typeof handler !== "function") throw new Error(`serve route ${method} ${path} handler must be a function`);
+    const normalizedMethod = normalizeMethod(method);
+    const key = `${normalizedMethod} ${path}`;
+    const existing = this.routes.get(key);
+    if (existing) {
+      throw new Error(`serve route already registered: ${key}${pluginLabel(existing.plugin)}`);
+    }
+    this.routes.set(key, { method: normalizedMethod, path, handler, plugin });
+  }
+
+  private registerFallback(plugin: ServeRouteOwner | undefined, id: string, handler: ServeFallbackHandler): void {
     if (!id.trim()) throw new Error("serve fallback id is required");
     if (typeof handler !== "function") throw new Error(`serve fallback ${id} handler must be a function`);
-    if (this.fallbackHandlers.some((entry) => entry.id === id)) {
-      throw new Error(`serve fallback already registered: ${id}`);
+    const existing = this.fallbackHandlers.find((entry) => entry.id === id);
+    if (existing) {
+      throw new Error(`serve fallback already registered: ${id}${pluginLabel(existing.plugin)}`);
     }
-    this.fallbackHandlers.push({ id, handler });
+    this.fallbackHandlers.push({ id, handler, plugin });
   }
 
   async handle(request: Request): Promise<Response | undefined> {
@@ -81,11 +125,22 @@ export class ServeRouteRegistry implements ServeHttpRouteRegistrar, ServeFallbac
     return entry.handler(req, env);
   }
 
-  snapshot(): Array<{ method: ServeRouteMethod; path: string }> {
-    return [...this.routes.values()].map(({ method, path }) => ({ method, path }));
+  snapshot(): Array<{ method: ServeRouteMethod; path: string; plugin?: string }> {
+    return [...this.routes.values()].map(({ method, path, plugin }) => ({
+      method,
+      path,
+      ...(plugin?.name ? { plugin: plugin.name } : {}),
+    }));
   }
 
   listFallbacks(): string[] {
     return this.fallbackHandlers.map((entry) => entry.id);
+  }
+
+  fallbackSnapshot(): Array<{ id: string; plugin?: string }> {
+    return this.fallbackHandlers.map(({ id, plugin }) => ({
+      id,
+      ...(plugin?.name ? { plugin: plugin.name } : {}),
+    }));
   }
 }

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -115,7 +115,7 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
   const serveWs = new ServeWsRegistry();
   const serveViews = createViews();
   await registerServeViews({
-    http: serveRoutes,
+    http: serveRoutes.forPlugin({ name: "serve-views" }),
     plugin: { name: "serve-views" },
   }, { views: serveViews });
   registerServeWs({
@@ -245,13 +245,18 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
     }
     const wsUpgrade = serveWs.handleUpgrade(req, server);
     if (wsUpgrade.matched) return wsUpgrade.response;
-    // Elysia handles all /api/* routes (has its own CORS)
+    // Elysia handles legacy /api/* routes (has its own CORS). Engine plugin
+    // proxy stays first. For protected routes extracted into serve plugins,
+    // preserve Elysia auth hooks by running legacy api.handle(req.clone())
+    // before the registry and falling through only when legacy returns 404.
     if (url.pathname.startsWith("/api")) {
       const enginePlugin = findEnginePluginRegistration(url.pathname);
       if (enginePlugin) return proxyEnginePluginRequest(req, enginePlugin);
       if (isProtected(apiPath, req.method)) {
         const authOrLegacyRoute = await api.handle(req.clone());
         if (authOrLegacyRoute.status !== 404) return authOrLegacyRoute;
+        const servedByPlugin = await serveRoutes.handle(req);
+        return servedByPlugin ?? authOrLegacyRoute;
       }
       const servedByPlugin = await serveRoutes.handle(req);
       if (servedByPlugin) return servedByPlugin;

--- a/src/plugin/lifecycle.ts
+++ b/src/plugin/lifecycle.ts
@@ -12,7 +12,7 @@ import { pathToFileURL } from "url";
 import { discoverPackages } from "./registry";
 import type { MawEngine } from "../engine";
 import type { ServeWsRouteRegistrar } from "../core/serve-ws-registry";
-import type { LoadedPlugin, PluginLifecycleHook, ServeHttpRouteRegistrar } from "./types";
+import type { LoadedPlugin, PluginLifecycleHook, ServeRouteRegistrar } from "./types";
 
 export type LifecyclePhase = "wake" | "sleep" | "serve";
 
@@ -29,7 +29,7 @@ export interface PluginLifecycleContext {
   httpUrl?: string;
   wsUrl?: string;
   hostname?: string;
-  http?: ServeHttpRouteRegistrar;
+  http?: ServeRouteRegistrar;
   ws?: ServeWsRouteRegistrar;
   engine?: MawEngine;
   ensures?: string[];
@@ -54,7 +54,7 @@ export interface ServeLifecycleContextInput {
   httpUrl: string;
   wsUrl: string;
   hostname: string;
-  http?: ServeHttpRouteRegistrar;
+  http?: ServeRouteRegistrar;
   ws?: ServeWsRouteRegistrar;
   engine?: MawEngine;
   /** In-memory feed plugin system, exposed for serve diagnostics/debug plugins. */
@@ -86,6 +86,23 @@ function sortByLifecycleOrder(plugins: LoadedPlugin[]): LoadedPlugin[] {
 function messageOf(error: unknown): string {
   if (error instanceof Error) return error.message;
   return String(error);
+}
+
+
+type PluginScopedServeRoutes = ServeRouteRegistrar & {
+  forPlugin?: (plugin: { name: string; dir?: string }) => ServeRouteRegistrar;
+};
+
+function scopedServeContext(
+  baseContext: Omit<PluginLifecycleContext, "phase" | "plugin" | "ensures">,
+  plugin: LoadedPlugin,
+): Omit<PluginLifecycleContext, "phase" | "plugin" | "ensures"> {
+  const http = baseContext.http as PluginScopedServeRoutes | undefined;
+  if (!http?.forPlugin) return baseContext;
+  return {
+    ...baseContext,
+    http: http.forPlugin({ name: plugin.manifest.name, dir: plugin.dir }),
+  };
 }
 
 function resolveHookModulePath(plugin: LoadedPlugin, hook: PluginLifecycleHook): string {
@@ -124,7 +141,7 @@ async function runOneLifecycleHook(
   }
 
   const result = await handler({
-    ...baseContext,
+    ...scopedServeContext(baseContext, plugin),
     phase,
     plugin: { name: plugin.manifest.name, dir: plugin.dir },
     ensures: hook.ensures ?? [],

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -34,9 +34,21 @@ export type ServeRouteMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "OP
 
 export type ServeRouteHandler = (request: Request) => Response | Promise<Response>;
 
+export type ServeFallbackHandler = (
+  request: Request,
+  env?: Record<string, unknown>,
+) => Response | Promise<Response>;
+
 export interface ServeHttpRouteRegistrar {
   route(method: ServeRouteMethod, path: string, handler: ServeRouteHandler): void;
 }
+
+export interface ServeFallbackRegistrar {
+  /** Register the public fallback surface used after core /ws and /api routing. */
+  fallback(id: string, handler: ServeFallbackHandler): void;
+}
+
+export interface ServeRouteRegistrar extends ServeHttpRouteRegistrar, ServeFallbackRegistrar {}
 
 export interface PluginLifecycleHook {
   /** Relative script/module path reserved for lifecycle runners (#1576). */

--- a/src/vendor/mpr-plugins/serve-identity/index.ts
+++ b/src/vendor/mpr-plugins/serve-identity/index.ts
@@ -1,16 +1,24 @@
-import { api } from "../../../api";
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
-import { createIdentityApi } from "./impl";
+import type { InvokeContext, InvokeResult, ServeHttpRouteRegistrar } from "../../../plugin/types";
+import { createIdentityApi, type IdentityApiDeps } from "./impl";
 
-let registered = false;
+type ServeIdentityContext = {
+  http?: ServeHttpRouteRegistrar;
+};
+
+export function createIdentityRouteHandler(deps?: IdentityApiDeps) {
+  const identityApi = createIdentityApi(deps);
+  return (request: Request) => {
+    const url = new URL(request.url);
+    url.pathname = "/identity";
+    return identityApi.handle(new Request(url.toString(), request));
+  };
+}
 
 /** Register GET /api/identity during maw serve startup. */
-export async function serve(): Promise<{ ok: true; registered: boolean }> {
-  if (!registered) {
-    api.use(createIdentityApi());
-    registered = true;
-  }
-  return { ok: true, registered };
+export async function serve(ctx: ServeIdentityContext): Promise<{ ok: true; registered: boolean }> {
+  if (!ctx.http) throw new Error("serve-identity requires serve http route registration");
+  ctx.http.route("GET", "/api/identity", createIdentityRouteHandler());
+  return { ok: true, registered: true };
 }
 
 export async function registerIdentityRouteForTests(targetApi: { use: (plugin: ReturnType<typeof createIdentityApi>) => unknown }): Promise<void> {

--- a/test/isolated/coverage-core-shared-server.test.ts
+++ b/test/isolated/coverage-core-shared-server.test.ts
@@ -32,9 +32,11 @@ mock.module(import.meta.resolve("../../src/engine"), () => ({ MawEngine: FakeEng
 mock.module(import.meta.resolve("../../src/config"), () => mockConfigModule(() => config));
 mock.module(import.meta.resolve("../../src/api"), () => ({
   api: { handle: (req: Request) => {
-    const pathname = new URL(req.url).pathname;
-    apiPaths.push(pathname);
-    if (pathname === "/api/triggers/fire") return new Response("not found", { status: 404 });
+    const url = new URL(req.url);
+    apiPaths.push(url.pathname);
+    if (url.pathname === "/api/triggers/fire") return new Response("not found", { status: 404 });
+    if (url.pathname === "/api/worktrees/cleanup") return new Response("legacy missing", { status: 404 });
+    if (url.pathname === "/api/protected-auth-fail") return new Response("auth failed", { status: 401 });
     return new Response("api");
   } },
 }));
@@ -85,14 +87,18 @@ mock.module(import.meta.resolve("../../src/api/tmux-stream"), () => ({
   handleTmuxStreamClose: () => { tmuxStreamEvents.push("close"); },
 }));
 mock.module(import.meta.resolve("../../src/lib/elysia-auth"), () => ({
-  isProtected: (path: string, method: string) => method === "POST" && path === "/triggers/fire",
   setBunServer: () => {},
+  isProtected: (path: string, method: string) => method === "POST" && (
+    path === "/triggers/fire" || path === "/worktrees/cleanup" || path === "/protected-auth-fail"
+  ),
 }));
 mock.module(import.meta.resolve("../../src/plugin/lifecycle"), () => ({
   runServeLifecycleHooks: async (payload: any) => {
     lifecyclePayloads.push(payload);
     payload.http?.route("GET", "/api/triggers", () => new Response("plugin triggers"));
     payload.http?.route("POST", "/api/triggers/fire", () => new Response("plugin trigger fire"));
+    payload.http?.route("POST", "/api/worktrees/cleanup", () => new Response("plugin cleanup"));
+    payload.http?.route("POST", "/api/protected-auth-fail", () => new Response("should not bypass auth"));
   },
 }));
 mock.module(import.meta.resolve("../../src/core/engine-plugin-registry"), () => ({
@@ -258,8 +264,12 @@ describe("coverage core shared server", () => {
     expect(proxiedPaths).toEqual(["/api/engine"]);
     expect(await (await fetch(new Request("http://local/api/triggers"), upgradeServer(true))).text()).toBe("plugin triggers");
     expect(await (await fetch(new Request("http://local/api/triggers/fire", { method: "POST" }), upgradeServer(true))).text()).toBe("plugin trigger fire");
+    expect(await (await fetch(new Request("http://local/api/worktrees/cleanup", { method: "POST", body: JSON.stringify({ path: "/tmp/wt" }) }), upgradeServer(true))).text()).toBe("plugin cleanup");
+    const authFailed = await fetch(new Request("http://local/api/protected-auth-fail", { method: "POST" }), upgradeServer(true));
+    expect(authFailed.status).toBe(401);
+    expect(await authFailed.text()).toBe("auth failed");
     expect(await (await fetch(new Request("http://local/api/ordinary"), upgradeServer(true))).text()).toBe("api");
-    expect(apiPaths).toEqual(["/api/triggers/fire", "/api/ordinary"]);
+    expect(apiPaths).toEqual(["/api/triggers/fire", "/api/worktrees/cleanup", "/api/protected-auth-fail", "/api/ordinary"]);
 
     const ptyUpgrade = upgradeServer(true);
     expect(await fetch(new Request("http://local/ws/pty"), ptyUpgrade)).toBeUndefined();

--- a/test/isolated/plugin-lifecycle.test.ts
+++ b/test/isolated/plugin-lifecycle.test.ts
@@ -135,6 +135,41 @@ describe("plugin lifecycle hooks (#1576)", () => {
     expect(readFileSync(log, "utf8")).toBe("serve|server|4567|http://localhost:4567|ws://localhost:4567/ws|127.0.0.1\n");
   });
 
+
+  test("serve hooks receive plugin-scoped route registrars", async () => {
+    const plugin = makePlugin("route-owner", {
+      hook: { serve: { script: "serve.ts", handler: "onServe" } },
+      files: {
+        "index.ts": "",
+        "serve.ts": `export function onServe(ctx) { ctx.http.route("GET", "/api/owned", () => new Response(ctx.plugin.name)); ctx.http.fallback("owned-fallback", () => new Response(ctx.plugin.name)); }\n`,
+      },
+    });
+    const scoped: Array<{ name: string; dir?: string }> = [];
+    const routes: string[] = [];
+    const fallbacks: string[] = [];
+    const http = {
+      route: () => { throw new Error("unscoped route should not be used"); },
+      fallback: () => { throw new Error("unscoped fallback should not be used"); },
+      forPlugin(owner: { name: string; dir?: string }) {
+        scoped.push(owner);
+        return {
+          route: (method: string, path: string) => routes.push(`${owner.name}:${method} ${path}`),
+          fallback: (id: string) => fallbacks.push(`${owner.name}:${id}`),
+        };
+      },
+    };
+
+    const summary = await runServeLifecycleHooks(
+      { port: 4567, httpUrl: "http://localhost:4567", wsUrl: "ws://localhost:4567/ws", hostname: "127.0.0.1", http: http as any },
+      () => [plugin],
+    );
+
+    expect(summary).toEqual({ phase: "serve", ran: 1, skipped: 0, failed: 0 });
+    expect(scoped).toEqual([{ name: "route-owner", dir: plugin.dir }]);
+    expect(routes).toEqual(["route-owner:GET /api/owned"]);
+    expect(fallbacks).toEqual(["route-owner:owned-fallback"]);
+  });
+
   test("best-effort failures continue, fail-fast failures throw clearly", async () => {
     const log = makeLog();
     const ok = makePlugin("ok", { weight: 2 });

--- a/test/isolated/plugin-serve-debug-standalone.test.ts
+++ b/test/isolated/plugin-serve-debug-standalone.test.ts
@@ -43,6 +43,8 @@ describe("serve-debug plugin standalone boundary (#2436)", () => {
 
     const imports = expectStandalonePluginBoundary({ plugin: "serve-debug", requireSdk: false });
     expect(imports.map((record) => record.spec).filter((spec) => spec.startsWith("../"))).toEqual([]);
+    const source = readFileSync(join(pluginDir, "index.ts"), "utf8");
+    expect(source).toContain("ServeHttpRouteRegistrar");
   });
 
   test("registers plugin debug API and page routes through the serve hook", async () => {

--- a/test/isolated/plugin-serve-identity-standalone.test.ts
+++ b/test/isolated/plugin-serve-identity-standalone.test.ts
@@ -3,6 +3,7 @@ import { Elysia } from "elysia";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
+import { ServeRouteRegistry } from "../../src/core/serve-route-registry";
 import { createIdentityApi } from "../../src/vendor/mpr-plugins/serve-identity/impl";
 
 const root = join(import.meta.dir, "../..");
@@ -20,7 +21,6 @@ describe("serve-identity plugin standalone boundary", () => {
       plugin: "serve-identity",
       requireSdk: false,
       allowRelative: [
-        /^\.\.\/\.\.\/\.\.\/api$/,
         /^\.\.\/\.\.\/\.\.\/config$/,
         /^\.\.\/\.\.\/\.\.\/commands\/shared\/federation-sync$/,
         /^\.\.\/\.\.\/\.\.\/lib\/peer-key$/,
@@ -30,17 +30,18 @@ describe("serve-identity plugin standalone boundary", () => {
     });
   });
 
-  test("serve hook mounts /api/identity on the shared API app", async () => {
+  test("serve hook registers /api/identity on the shared serve route registry", async () => {
     const savedPeerKey = process.env.MAW_PEER_KEY;
     process.env.MAW_PEER_KEY = "hook-peer-key";
     try {
-      const { api } = await import("../../src/api");
       const { serve } = await import("../../src/vendor/mpr-plugins/serve-identity/index.ts?serve-hook-test");
-      await serve();
+      const registry = new ServeRouteRegistry();
+      await serve({ http: registry.forPlugin({ name: "serve-identity" }) });
 
-      const after = await api.handle(new Request("http://localhost/api/identity"));
-      expect(after.status).toBe(200);
-      const body = await after.json() as Record<string, unknown>;
+      expect(registry.snapshot()).toEqual([{ method: "GET", path: "/api/identity", plugin: "serve-identity" }]);
+      const after = await registry.handle(new Request("http://localhost/api/identity"));
+      expect(after?.status).toBe(200);
+      const body = await after!.json() as Record<string, unknown>;
       expect(body.pubkey).toBe("hook-peer-key");
       expect(body.endpoints).toEqual(expect.arrayContaining(["/api/identity", "/api/send"]));
     } finally {

--- a/test/isolated/plugin-serve-triggers-standalone.test.ts
+++ b/test/isolated/plugin-serve-triggers-standalone.test.ts
@@ -20,6 +20,7 @@ describe("serve-triggers plugin standalone boundary", () => {
     const source = readFileSync(join(root, "src/vendor/mpr-plugins/serve-triggers/index.ts"), "utf8");
     expect(source).toContain('from "maw-js/sdk"');
     expect(source).toContain('from "maw-js/plugin/types"');
+    expect(source).toContain("ServeHttpRouteRegistrar");
     expectStandalonePluginBoundary({ plugin: "serve-triggers" });
   });
 

--- a/test/isolated/plugin-serve-worktrees-standalone.test.ts
+++ b/test/isolated/plugin-serve-worktrees-standalone.test.ts
@@ -35,6 +35,7 @@ describe("serve-worktrees plugin standalone boundary (#2434)", () => {
     const source = readFileSync(join(root, "src/vendor/mpr-plugins/serve-worktrees/index.ts"), "utf8");
     expect(source).toContain('from "maw-js/sdk"');
     expect(source).toContain('from "maw-js/plugin/types"');
+    expect(source).toContain("ServeHttpRouteRegistrar");
   });
 
   test("registers identical worktrees list and cleanup routes", async () => {

--- a/test/isolated/serve-route-registry.test.ts
+++ b/test/isolated/serve-route-registry.test.ts
@@ -47,13 +47,34 @@ describe("ServeRouteRegistry", () => {
     expect(await registry.handle(new Request("http://local/api/status/neo/extra"))).toBeUndefined();
   });
 
-  test("rejects non-absolute paths and duplicate routes", () => {
+  test("rejects non-absolute paths, invalid handlers, and duplicate routes", () => {
     const registry = new ServeRouteRegistry();
     expect(() => registry.route("GET", "api/worktrees", () => new Response())).toThrow("serve route path must start");
+    expect(() => registry.route("GET", "/api/bad", undefined as never)).toThrow("serve route GET /api/bad handler must be a function");
     registry.route("GET", "/api/worktrees", () => new Response());
     expect(() => registry.route("get" as any, "/api/worktrees", () => new Response())).toThrow("serve route already registered");
     registry.route("GET", "/api/triggers", () => new Response());
     expect(() => registry.route("GET", "/api/triggers", () => new Response())).toThrow("serve route already registered: GET /api/triggers");
+  });
+
+  test("scopes route and fallback ownership to the registering plugin", async () => {
+    const registry = new ServeRouteRegistry();
+    const identity = registry.forPlugin({ name: "serve-identity", dir: "/plugins/identity" });
+    const views = registry.forPlugin({ name: "serve-views" });
+
+    identity.route("GET", "/api/identity", () => Response.json({ node: "m5" }));
+    views.fallback("serve-views", () => new Response("view"));
+
+    expect(registry.snapshot()).toEqual([{ method: "GET", path: "/api/identity", plugin: "serve-identity" }]);
+    expect(registry.fallbackSnapshot()).toEqual([{ id: "serve-views", plugin: "serve-views" }]);
+    expect(await (await registry.handle(new Request("http://local/api/identity")))!.json()).toEqual({ node: "m5" });
+    expect(await (await registry.handleFallback(new Request("http://local/"))).text()).toBe("view");
+
+    expect(() => registry.forPlugin({ name: "" })).toThrow("serve route plugin name is required");
+    expect(() => registry.forPlugin({ name: "serve-debug" }).route("GET", "/api/identity", () => new Response()))
+      .toThrow("serve route already registered: GET /api/identity (serve-identity)");
+    expect(() => registry.forPlugin({ name: "other-views" }).fallback("serve-views", () => new Response()))
+      .toThrow("serve fallback already registered: serve-views (serve-views)");
   });
 
   test("dispatches the registered fallback in registration order", async () => {

--- a/test/plugin-lifecycle.test.ts
+++ b/test/plugin-lifecycle.test.ts
@@ -135,6 +135,41 @@ describe("plugin lifecycle hooks (#1576)", () => {
     expect(readFileSync(log, "utf8")).toBe("serve|server|4567|http://localhost:4567|ws://localhost:4567/ws|127.0.0.1\n");
   });
 
+
+  test("serve hooks receive plugin-scoped route registrars", async () => {
+    const plugin = makePlugin("route-owner", {
+      hook: { serve: { script: "serve.ts", handler: "onServe" } },
+      files: {
+        "index.ts": "",
+        "serve.ts": `export function onServe(ctx) { ctx.http.route("GET", "/api/owned", () => new Response(ctx.plugin.name)); ctx.http.fallback("owned-fallback", () => new Response(ctx.plugin.name)); }\n`,
+      },
+    });
+    const scoped: Array<{ name: string; dir?: string }> = [];
+    const routes: string[] = [];
+    const fallbacks: string[] = [];
+    const http = {
+      route: () => { throw new Error("unscoped route should not be used"); },
+      fallback: () => { throw new Error("unscoped fallback should not be used"); },
+      forPlugin(owner: { name: string; dir?: string }) {
+        scoped.push(owner);
+        return {
+          route: (method: string, path: string) => routes.push(`${owner.name}:${method} ${path}`),
+          fallback: (id: string) => fallbacks.push(`${owner.name}:${id}`),
+        };
+      },
+    };
+
+    const summary = await runServeLifecycleHooks(
+      { port: 4567, httpUrl: "http://localhost:4567", wsUrl: "ws://localhost:4567/ws", hostname: "127.0.0.1", http: http as any },
+      () => [plugin],
+    );
+
+    expect(summary).toEqual({ phase: "serve", ran: 1, skipped: 0, failed: 0 });
+    expect(scoped).toEqual([{ name: "route-owner", dir: plugin.dir }]);
+    expect(routes).toEqual(["route-owner:GET /api/owned"]);
+    expect(fallbacks).toEqual(["route-owner:owned-fallback"]);
+  });
+
   test("best-effort failures continue, fail-fast failures throw clearly", async () => {
     const log = makeLog();
     const ok = makePlugin("ok", { weight: 2 });


### PR DESCRIPTION
## Summary
- Adds an owned `ServeRouteRegistry`/serve-hook registrar pattern for extraction plugins.
- Scopes serve lifecycle `ctx.http` to the registering plugin so route/fallback ownership is tracked and duplicate diagnostics name the plugin owner.
- Moves `serve-identity` onto the serve-route plugin pattern while preserving the `/api/identity` response shape.
- Preserves protected `/api` auth dispatch by running legacy `api.handle(req.clone())` before plugin serve routes for protected paths, falling through only on 404.

Closes #2445.

## Tests
- `bun scripts/check-plugin-coverage-gate.ts origin/alpha`
- `MAW_TEST_MODE=1 bun test test/isolated/coverage-core-shared-server.test.ts test/isolated/core-server-more-coverage-2.test.ts --path-ignore-patterns '**/agents/**'`
- `bun test test/isolated/serve-route-registry.test.ts test/plugin-lifecycle.test.ts test/isolated/plugin-lifecycle.test.ts --path-ignore-patterns '**/agents/**'`
- `bun test test/isolated/plugin-serve-identity-standalone.test.ts --path-ignore-patterns '**/agents/**'`
- `bun test test/isolated/plugin-serve-debug-standalone.test.ts --path-ignore-patterns '**/agents/**'`
- `bun test test/isolated/plugin-serve-triggers-standalone.test.ts --path-ignore-patterns '**/agents/**'`
- `bun test test/isolated/plugin-serve-worktrees-standalone.test.ts --path-ignore-patterns '**/agents/**'`
- `bun run build`
- `bun run test:default:safe`
