### PR TITLE
Extract serve config health routes into vendor plugin

### DIFF
--- a/scripts/check-plugin-coverage-gate.ts
+++ b/scripts/check-plugin-coverage-gate.ts
@@ -68,7 +68,7 @@ function analyzeChangedFiles(files: string[]): GateResult {
   for (const file of files) {
     if (!isRuntimeSource(file)) continue;
 
-    const pluginMatch = file.match(/^src\/vendor\/mpr-plugins\/([^/]+)\//);
+    const pluginMatch = file.match(/^src\/(?:vendor\/mpr-plugins|vendor-plugins)\/([^/]+)\//);
     if (pluginMatch) {
       const plugin = pluginMatch[1];
       if (!pluginChanges.has(plugin)) pluginChanges.set(plugin, []);

--- a/scripts/test-default-safe.sh
+++ b/scripts/test-default-safe.sh
@@ -233,9 +233,16 @@ for f in "${MOCK_FILES[@]}"; do
   mock_index=$((mock_index + 1))
   run_cwd="$REPO_ROOT"
   test_path="$f"
+  path_ignore_args=(--path-ignore-patterns '**/agents/**')
   if grep -q '@maw-test-isolate-cwd-neutral' "$f"; then
     run_cwd="${TMPDIR:-/tmp}"
     test_path="$REPO_ROOT/$f"
+    # This subprocess intentionally runs outside the repo. In worktrees whose
+    # absolute path contains "/agents/" (for example OMX agent worktrees),
+    # applying the repo-wide agents ignore to the absolute test filter hides the
+    # exact file we are trying to run. The exact file path is already bounded, so
+    # no recursive agents ignore is needed here.
+    path_ignore_args=()
   fi
-  run_bun_case "mock-$mock_index" "$run_cwd" "$test_path" --path-ignore-patterns '**/agents/**'
+  run_bun_case "mock-$mock_index" "$run_cwd" "$test_path" "${path_ignore_args[@]}"
 done

--- a/src/cli/cmd-update.ts
+++ b/src/cli/cmd-update.ts
@@ -417,14 +417,16 @@ export async function runUpdate(args: string[]): Promise<void> {
       const bundledRoots = [
         join(mawSrc, "commands", "plugins"),
         join(mawSrc, "vendor", "mpr-plugins"),
+        join(mawSrc, "vendor-plugins"),
       ];
       if (bundledRoots.some((root) => existsSync(root))) {
         const healed = healBrokenPluginSymlinks(pluginDir, bundledRoots);
         const refreshed = linkBundledPluginRoots(pluginDir, bundledRoots);
         if (refreshed > 0) console.log(`\n  🔗 ${refreshed} bundled plugins re-linked`);
 
-        // #1449 — silently heal broken symlinks when the same plugin is now
-        // bundled under src/vendor/mpr-plugins. Warn only for genuine losses.
+        // #1449/#2449 — silently heal broken symlinks when the same plugin is
+        // now bundled under one of the source plugin roots. Warn only for
+        // genuine losses.
         if (healed.pruned > 0) {
           console.log(`\n  \x1b[33m⚠\x1b[0m removed ${healed.pruned} broken plugin symlink${healed.pruned === 1 ? "" : "s"} (targets no longer exist)`);
         }

--- a/src/cli/plugin-bootstrap.test.ts
+++ b/src/cli/plugin-bootstrap.test.ts
@@ -31,6 +31,7 @@ describe("runBootstrap — #817 idempotent bundled-plugin symlinks", () => {
   let pluginDir: string;
   let bundledDir: string;
   let vendoredDir: string;
+  let vendorPluginsDir: string;
 
   beforeEach(() => {
     // mkdtempSync is atomic — appends 6 random chars + creates the dir in one
@@ -41,6 +42,7 @@ describe("runBootstrap — #817 idempotent bundled-plugin symlinks", () => {
     pluginDir = join(workDir, "plugins");
     bundledDir = join(srcDir, "commands", "plugins");
     vendoredDir = join(srcDir, "vendor", "mpr-plugins");
+    vendorPluginsDir = join(srcDir, "vendor-plugins");
     mkdirSync(bundledDir, { recursive: true });
   });
 
@@ -63,6 +65,15 @@ describe("runBootstrap — #817 idempotent bundled-plugin symlinks", () => {
   /** Helper: create a vendored mpr plugin dir recognized by runBootstrap. */
   function makeVendoredPlugin(name: string) {
     const dir = join(vendoredDir, name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "plugin.json"), JSON.stringify({ name }));
+    writeFileSync(join(dir, "index.ts"), `export default async () => ({ ok: true });\n`);
+    return dir;
+  }
+
+  /** Helper: create a top-level vendor plugin dir recognized by runBootstrap. */
+  function makeVendorPlugin(name: string) {
+    const dir = join(vendorPluginsDir, name);
     mkdirSync(dir, { recursive: true });
     writeFileSync(join(dir, "plugin.json"), JSON.stringify({ name }));
     writeFileSync(join(dir, "index.ts"), `export default async () => ({ ok: true });\n`);
@@ -111,17 +122,19 @@ describe("runBootstrap — #817 idempotent bundled-plugin symlinks", () => {
     }
   });
 
-  it("#1339 — empty pluginDir also symlinks vendored maw-plugin-registry plugins", async () => {
+  it("#1339/#2449 — empty pluginDir also symlinks vendored and top-level vendor plugins", async () => {
     makeBundledPlugin("tile");
     makeVendoredPlugin("wake");
     makeVendoredPlugin("attach");
+    makeVendorPlugin("serve-config-health");
 
     await runBootstrap(pluginDir, srcDir);
 
-    expect(readdirSync(pluginDir).sort()).toEqual(["attach", "tile", "wake"]);
+    expect(readdirSync(pluginDir).sort()).toEqual(["attach", "serve-config-health", "tile", "wake"]);
     expect(readlinkSync(join(pluginDir, "tile"))).toBe(join(bundledDir, "tile"));
     expect(readlinkSync(join(pluginDir, "wake"))).toBe(join(vendoredDir, "wake"));
     expect(readlinkSync(join(pluginDir, "attach"))).toBe(join(vendoredDir, "attach"));
+    expect(readlinkSync(join(pluginDir, "serve-config-health"))).toBe(join(vendorPluginsDir, "serve-config-health"));
   });
 
   it("#1484 — incomplete in-tree plugin dir does not block vendored manifest plugin", async () => {

--- a/src/cli/plugin-bootstrap.ts
+++ b/src/cli/plugin-bootstrap.ts
@@ -34,6 +34,7 @@ function bundledMawJsRoot(target: string, entry: string): string | undefined {
   const suffixes = [
     `/src/commands/plugins/${entry}`,
     `/src/vendor/mpr-plugins/${entry}`,
+    `/src/vendor-plugins/${entry}`,
   ];
   for (const suffix of suffixes) {
     if (!normalized.endsWith(suffix)) continue;
@@ -144,6 +145,7 @@ export async function runBootstrap(pluginDir: string, srcDir: string): Promise<v
   const bundledRoots = [
     join(srcDir, "commands", "plugins"),
     join(srcDir, "vendor", "mpr-plugins"),
+    join(srcDir, "vendor-plugins"),
   ];
   const { pruned } = healOrPruneBrokenSymlinks(pluginDir, bundledRoots);
   if (pruned > 0) {
@@ -161,6 +163,11 @@ export async function runBootstrap(pluginDir: string, srcDir: string): Promise<v
   // source-only and intentionally uses the same pluginDir symlink mechanism as
   // in-tree plugins so user-installed plugins keep precedence.
   linkBundledPlugins(pluginDir, bundledRoots[1]);
+
+  // Core serve-route extractions live in the top-level vendor-plugins tree.
+  // Keep them on the same bundled symlink path so lifecycle hooks discover
+  // them like the older src/vendor/mpr-plugins packages.
+  linkBundledPlugins(pluginDir, bundledRoots[2]);
 
   // 2. Install from pluginSources URLs — first-install only (network calls,
   //    should not retry every boot).

--- a/src/vendor-plugins/serve-config-health/index.ts
+++ b/src/vendor-plugins/serve-config-health/index.ts
@@ -1,8 +1,8 @@
 import { loadConfig, saveConfig, configForDisplay, resetConfig, type MawConfig } from "maw-js/config";
 import type { ServeHttpRouteRegistrar } from "maw-js/plugin/types";
-import healthHandler from "../health/index";
-import { agentStatusStore as defaultAgentStatusStore, type AgentStatus } from "../../../core/agent-status";
-import { messageQueue as defaultMessageQueue } from "../../../core/message-queue";
+import healthHandler from "../../vendor/mpr-plugins/health/index";
+import { agentStatusStore as defaultAgentStatusStore, type AgentStatus } from "../../core/agent-status";
+import { messageQueue as defaultMessageQueue } from "../../core/message-queue";
 
 const VALID_STATUSES = new Set<AgentStatus>(["busy", "ready", "idle", "crashed", "offline"]);
 
@@ -144,7 +144,7 @@ export function registerServeHealthRoutes(http: ServeHttpRouteRegistrar, deps?: 
 }
 
 export function serve(ctx: ServeHealthContext): void {
-  if (!ctx.http) throw new Error("serve-health requires serve http route registration");
+  if (!ctx.http) throw new Error("serve-config-health requires serve http route registration");
   registerServeHealthRoutes(ctx.http);
 }
 

--- a/src/vendor-plugins/serve-config-health/plugin.json
+++ b/src/vendor-plugins/serve-config-health/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "serve-health",
+  "name": "serve-config-health",
   "version": "1.0.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",

--- a/test/isolated/api-status.test.ts
+++ b/test/isolated/api-status.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, beforeEach } from "bun:test";
 import { ServeRouteRegistry } from "../../src/core/serve-route-registry";
-import { registerServeHealthRoutes } from "../../src/vendor/mpr-plugins/serve-health/index";
+import { registerServeHealthRoutes } from "../../src/vendor-plugins/serve-config-health/index";
 import { agentStatusStore } from "../../src/core/agent-status";
 
 describe("Status API", () => {

--- a/test/isolated/helpers/plugin-standalone-boundary.ts
+++ b/test/isolated/helpers/plugin-standalone-boundary.ts
@@ -10,6 +10,7 @@ type ImportRecord = {
 type BoundaryOptions = {
   plugin: string;
   root?: string;
+  pluginDir?: string;
   files?: string[];
   requireSdk?: boolean;
   allowMawJs?: Array<string | RegExp>;
@@ -45,6 +46,14 @@ function pluginSourceFiles(plugin: string, root = repoRootFromTest(), files?: st
   return files?.map((file) => join(dir, file)) ?? walkTsFiles(dir).sort();
 }
 
+function pluginSourceFilesFromOptions(options: BoundaryOptions): string[] {
+  const root = options.root ?? repoRootFromTest();
+  const dir = options.pluginDir
+    ? join(root, options.pluginDir)
+    : join(root, "src/vendor/mpr-plugins", options.plugin);
+  return options.files?.map((file) => join(dir, file)) ?? walkTsFiles(dir).sort();
+}
+
 function parseImportRecords(source: string): ImportRecord[] {
   const records: ImportRecord[] = [];
   const staticImport = /\b(import|export)\s+(type\s+)?(?:[^"'`]+?\s+from\s+)?["']([^"']+)["']/g;
@@ -65,7 +74,7 @@ function matchesAny(value: string, patterns: Array<string | RegExp>): boolean {
 }
 
 function collectPluginImports(options: BoundaryOptions): ImportRecord[] {
-  return pluginSourceFiles(options.plugin, options.root, options.files)
+  return pluginSourceFilesFromOptions(options)
     .flatMap((file) => parseImportRecords(readFileSync(file, "utf8")));
 }
 

--- a/test/isolated/plugin-serve-config-health-standalone.test.ts
+++ b/test/isolated/plugin-serve-config-health-standalone.test.ts
@@ -7,7 +7,7 @@ import {
   createServeHealthRouteHandlers,
   registerServeHealthRoutes,
   serve,
-} from "../../src/vendor/mpr-plugins/serve-health/index.ts?plugin-serve-health-standalone";
+} from "../../src/vendor-plugins/serve-config-health/index.ts?plugin-serve-config-health-standalone";
 
 const root = join(import.meta.dir, "../..");
 
@@ -23,9 +23,9 @@ async function readJson(res: Response) {
   return await res.json() as any;
 }
 
-describe("serve-health plugin standalone boundary", () => {
+describe("serve-config-health plugin standalone boundary", () => {
   test("declares serve hook routes and removes old health API auto-mount", () => {
-    const manifest = JSON.parse(readFileSync(join(root, "src/vendor/mpr-plugins/serve-health/plugin.json"), "utf8"));
+    const manifest = JSON.parse(readFileSync(join(root, "src/vendor-plugins/serve-config-health/plugin.json"), "utf8"));
     expect(manifest.hooks.serve).toMatchObject({ script: "./index.ts", handler: "serve", policy: "fail-fast" });
     expect(manifest.api).toBeUndefined();
 
@@ -35,13 +35,14 @@ describe("serve-health plugin standalone boundary", () => {
 
   test("boundary drift is explicit for this core serve route plugin", () => {
     expectStandalonePluginBoundary({
-      plugin: "serve-health",
+      plugin: "serve-config-health",
+      pluginDir: "src/vendor-plugins/serve-config-health",
       requireSdk: false,
       allowMawJs: ["maw-js/config"],
       allowRelative: [
-        /^\.\.\/health\/index$/,
-        /^\.\.\/\.\.\/\.\.\/core\/agent-status$/,
-        /^\.\.\/\.\.\/\.\.\/core\/message-queue$/,
+        /^\.\.\/\.\.\/vendor\/mpr-plugins\/health\/index$/,
+        /^\.\.\/\.\.\/core\/agent-status$/,
+        /^\.\.\/\.\.\/core\/message-queue$/,
       ],
     });
   });
@@ -154,6 +155,6 @@ describe("serve-health plugin standalone boundary", () => {
   });
 
   test("serve hook fails clearly without route registration context", () => {
-    expect(() => serve({})).toThrow("serve-health requires serve http route registration");
+    expect(() => serve({})).toThrow("serve-config-health requires serve http route registration");
   });
 });


### PR DESCRIPTION
## Summary
- Move the serve config/health/status route package into `src/vendor-plugins/serve-config-health`
- Teach bootstrap/update and plugin coverage gate about the top-level vendor plugin root
- Add/update standalone coverage for the serve-config-health plugin and preserve route behavior

Closes #2449

## Verification
- `MAW_TEST_MODE=1 bun test test/isolated/plugin-serve-config-health-standalone.test.ts test/isolated/api-status.test.ts src/cli/plugin-bootstrap.test.ts --path-ignore-patterns '**/agents/**'`\n- `bun scripts/check-plugin-coverage-gate.ts origin/alpha`\n- `bun run test:default:safe`