### PR TITLE
Extract serve CORS preflight middleware

### DIFF
--- a/src/core/serve-cors.ts
+++ b/src/core/serve-cors.ts
@@ -1,0 +1,14 @@
+export function corsHeaders(req: Request): Record<string, string> {
+  const origin = req.headers.get("origin") ?? "*";
+  return {
+    "Access-Control-Allow-Origin": origin,
+    "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Federation-Token, X-From-Signature",
+    "Access-Control-Allow-Private-Network": "true",
+  };
+}
+
+export function handleCorsOptions(req: Request): Response | undefined {
+  if (req.method !== "OPTIONS") return undefined;
+  return new Response(null, { status: 204, headers: corsHeaders(req) });
+}

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -28,6 +28,7 @@ import { agentStatusStore } from "./agent-status";
 import { getRuntimeVersionLabel } from "./runtime/build-info";
 import { ServeRouteRegistry } from "./serve-route-registry";
 import { ServeWsRegistry } from "./serve-ws-registry";
+import { corsHeaders, handleCorsOptions } from "./serve-cors";
 
 // --- Version info (computed once at startup) ---
 
@@ -225,24 +226,13 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
     log.error("[plugins] failed to init:", err);
   }
 
-  const corsHeaders = (req: Request) => {
-    const origin = req.headers.get("origin") ?? "*";
-    return {
-      "Access-Control-Allow-Origin": origin,
-      "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
-      "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Federation-Token, X-From-Signature",
-      "Access-Control-Allow-Private-Network": "true",
-    };
-  };
-
   const fetchHandler = async (req: Request, server: any) => {
     const url = new URL(req.url);
     const apiPath = url.pathname.replace(/^\/api/, "");
 
     // CORS preflight for all routes
-    if (req.method === "OPTIONS") {
-      return new Response(null, { status: 204, headers: corsHeaders(req) });
-    }
+    const corsPreflight = handleCorsOptions(req);
+    if (corsPreflight) return corsPreflight;
     const wsUpgrade = serveWs.handleUpgrade(req, server);
     if (wsUpgrade.matched) return wsUpgrade.response;
     // Elysia handles legacy /api/* routes (has its own CORS). Engine plugin

--- a/test/isolated/serve-cors.test.ts
+++ b/test/isolated/serve-cors.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { corsHeaders, handleCorsOptions } from "../../src/core/serve-cors";
+
+describe("serve CORS middleware", () => {
+  test("corsHeaders mirrors request origin and permits serve API headers", () => {
+    expect(corsHeaders(new Request("http://local/api", { headers: { origin: "http://example.test" } }))).toEqual({
+      "Access-Control-Allow-Origin": "http://example.test",
+      "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Federation-Token, X-From-Signature",
+      "Access-Control-Allow-Private-Network": "true",
+    });
+  });
+
+  test("corsHeaders falls back to wildcard origin when no Origin header is present", () => {
+    expect(corsHeaders(new Request("http://local/"))["Access-Control-Allow-Origin"]).toBe("*");
+  });
+
+  test("handleCorsOptions returns a 204 preflight response only for OPTIONS requests", () => {
+    const preflight = handleCorsOptions(new Request("http://local/ws", {
+      method: "OPTIONS",
+      headers: { origin: "http://preflight.test" },
+    }));
+
+    expect(preflight).toBeInstanceOf(Response);
+    expect(preflight?.status).toBe(204);
+    expect(preflight?.headers.get("Access-Control-Allow-Origin")).toBe("http://preflight.test");
+    expect(preflight?.headers.get("Access-Control-Allow-Private-Network")).toBe("true");
+    expect(handleCorsOptions(new Request("http://local/ws"))).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #2455

## Summary
- moved maw serve CORS header construction and OPTIONS handling into src/core/serve-cors.ts
- kept server.ts using the shared host middleware for preflight and fallback response CORS cloning
- added isolated coverage for CORS headers and OPTIONS handling

## Verification
- bun scripts/check-plugin-coverage-gate.ts origin/alpha
- MAW_TEST_MODE=1 bun test test/isolated/serve-cors.test.ts test/isolated/coverage-core-shared-server.test.ts test/isolated/core-server-more-coverage-2.test.ts --path-ignore-patterns '**/agents/**'