### PR TITLE
Extract tmux stream websocket route into vendor plugin

### DIFF
--- a/src/vendor-plugins/serve-tmux-stream-ws/index.ts
+++ b/src/vendor-plugins/serve-tmux-stream-ws/index.ts
@@ -1,0 +1,43 @@
+import type { WSData } from "../../core/types";
+import type { ServeWsRouteRegistrar } from "../../core/serve-ws-registry";
+import type { handleTmuxStreamClose, handleTmuxStreamMessage, handleTmuxStreamOpen } from "../../api/tmux-stream";
+
+type TmuxStreamWsDeps = {
+  handleTmuxStreamOpen: typeof handleTmuxStreamOpen;
+  handleTmuxStreamMessage: typeof handleTmuxStreamMessage;
+  handleTmuxStreamClose: typeof handleTmuxStreamClose;
+};
+
+type ServeTmuxStreamWsContext = {
+  ws?: ServeWsRouteRegistrar;
+};
+
+function defaultDeps(): TmuxStreamWsDeps {
+  const tmux = require("../../api/tmux-stream");
+  return {
+    handleTmuxStreamOpen: tmux.handleTmuxStreamOpen,
+    handleTmuxStreamMessage: tmux.handleTmuxStreamMessage,
+    handleTmuxStreamClose: tmux.handleTmuxStreamClose,
+  };
+}
+
+function tmuxStreamWsData(): WSData {
+  return { target: null, previewTargets: new Set(), mode: "tmux-stream" };
+}
+
+export function registerServeTmuxStreamWsRoute(ctx: ServeTmuxStreamWsContext, deps: TmuxStreamWsDeps = defaultDeps()): void {
+  if (!ctx.ws) throw new Error("serve-tmux-stream-ws requires serve ws route registration");
+
+  ctx.ws.route("/ws/tmux", () => tmuxStreamWsData(), {
+    open: (ws) => deps.handleTmuxStreamOpen(ws),
+    message: (ws, msg) => deps.handleTmuxStreamMessage(ws, msg),
+    close: (ws) => deps.handleTmuxStreamClose(ws),
+  });
+}
+
+export function serve(ctx: ServeTmuxStreamWsContext, deps?: TmuxStreamWsDeps): { ok: true; routes: string[] } {
+  registerServeTmuxStreamWsRoute(ctx, deps);
+  return { ok: true, routes: ["/ws/tmux"] };
+}
+
+export default serve;

--- a/src/vendor-plugins/serve-tmux-stream-ws/plugin.json
+++ b/src/vendor-plugins/serve-tmux-stream-ws/plugin.json
@@ -1,25 +1,25 @@
 {
-  "name": "serve-ws",
+  "name": "serve-tmux-stream-ws",
   "version": "1.0.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
   "tier": "core",
-  "description": "Registers maw serve WebSocket upgrade routes and handlers.",
+  "description": "Registers the maw serve tmux stream WebSocket upgrade route.",
   "author": "Soul-Brews-Studio",
   "hooks": {
     "serve": {
       "script": "./index.ts",
       "handler": "serve",
-      "ensures": ["ws:route:/ws", "ws:route:/ws/pty"],
+      "ensures": ["ws:route:/ws/tmux"],
       "policy": "fail-fast"
     }
   },
   "module": {
     "path": "./index.ts",
-    "exports": ["serve", "registerServeWsRoutes"]
+    "exports": ["serve", "registerServeTmuxStreamWsRoute"]
   },
   "capabilities": ["serve:ws-route"],
-  "weight": 0,
+  "weight": 1,
   "license": "MIT",
   "schemaVersion": 1,
   "capabilityNamespaces": ["serve"]

--- a/src/vendor/mpr-plugins/serve-ws/index.ts
+++ b/src/vendor/mpr-plugins/serve-ws/index.ts
@@ -2,14 +2,10 @@ import type { MawEngine } from "../../../engine";
 import type { WSData } from "../../../core/types";
 import type { ServeWsRouteRegistrar, ServeWsSocket } from "../../../core/serve-ws-registry";
 import type { handlePtyClose, handlePtyMessage } from "../../../core/transport/pty";
-import type { handleTmuxStreamClose, handleTmuxStreamMessage, handleTmuxStreamOpen } from "../../../api/tmux-stream";
 
 type WsDeps = {
   handlePtyMessage: typeof handlePtyMessage;
   handlePtyClose: typeof handlePtyClose;
-  handleTmuxStreamOpen: typeof handleTmuxStreamOpen;
-  handleTmuxStreamMessage: typeof handleTmuxStreamMessage;
-  handleTmuxStreamClose: typeof handleTmuxStreamClose;
 };
 
 type ServeWsContext = {
@@ -19,13 +15,9 @@ type ServeWsContext = {
 
 function defaultDeps(): WsDeps {
   const pty = require("../../../core/transport/pty");
-  const tmux = require("../../../api/tmux-stream");
   return {
     handlePtyMessage: pty.handlePtyMessage,
     handlePtyClose: pty.handlePtyClose,
-    handleTmuxStreamOpen: tmux.handleTmuxStreamOpen,
-    handleTmuxStreamMessage: tmux.handleTmuxStreamMessage,
-    handleTmuxStreamClose: tmux.handleTmuxStreamClose,
   };
 }
 
@@ -42,12 +34,6 @@ export function registerServeWsRoutes(ctx: ServeWsContext, deps: WsDeps = defaul
     close: (ws) => deps.handlePtyClose(ws),
   });
 
-  ctx.ws.route("/ws/tmux", () => defaultWsData("tmux-stream"), {
-    open: (ws) => deps.handleTmuxStreamOpen(ws),
-    message: (ws, msg) => deps.handleTmuxStreamMessage(ws, msg),
-    close: (ws) => deps.handleTmuxStreamClose(ws),
-  });
-
   ctx.ws.route("/ws", () => defaultWsData(), {
     open: (ws: ServeWsSocket) => ctx.engine!.handleOpen(ws as never),
     message: (ws: ServeWsSocket, msg: unknown) => ctx.engine!.handleMessage(ws as never, msg as never),
@@ -57,7 +43,7 @@ export function registerServeWsRoutes(ctx: ServeWsContext, deps: WsDeps = defaul
 
 export function serve(ctx: ServeWsContext, deps?: WsDeps): { ok: true; routes: string[] } {
   registerServeWsRoutes(ctx, deps);
-  return { ok: true, routes: ["/ws/pty", "/ws/tmux", "/ws"] };
+  return { ok: true, routes: ["/ws/pty", "/ws"] };
 }
 
 export default serve;

--- a/test/isolated/coverage-core-shared-server.test.ts
+++ b/test/isolated/coverage-core-shared-server.test.ts
@@ -99,6 +99,11 @@ mock.module(import.meta.resolve("../../src/plugin/lifecycle"), () => ({
     payload.http?.route("POST", "/api/triggers/fire", () => new Response("plugin trigger fire"));
     payload.http?.route("POST", "/api/worktrees/cleanup", () => new Response("plugin cleanup"));
     payload.http?.route("POST", "/api/protected-auth-fail", () => new Response("should not bypass auth"));
+    payload.ws?.route("/ws/tmux", () => ({ target: null, previewTargets: new Set(), mode: "tmux-stream" }), {
+      open: () => { tmuxStreamEvents.push("open"); },
+      message: () => { tmuxStreamEvents.push("message"); },
+      close: () => { tmuxStreamEvents.push("close"); },
+    });
   },
 }));
 mock.module(import.meta.resolve("../../src/core/engine-plugin-registry"), () => ({

--- a/test/isolated/plugin-serve-tmux-stream-ws-standalone.test.ts
+++ b/test/isolated/plugin-serve-tmux-stream-ws-standalone.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
+import { ServeWsRegistry, type ServeWsSocket } from "../../src/core/serve-ws-registry";
+import {
+  registerServeTmuxStreamWsRoute,
+  serve,
+} from "../../src/vendor-plugins/serve-tmux-stream-ws/index.ts?plugin-serve-tmux-stream-ws-standalone";
+
+const root = join(import.meta.dir, "../..");
+
+type WsCall = { kind: string; msg?: unknown };
+
+function makeSocket(path: string): ServeWsSocket {
+  return { data: { target: null, previewTargets: new Set(), __serveWsRoute: path }, send: () => undefined } as unknown as ServeWsSocket;
+}
+
+describe("serve-tmux-stream-ws plugin standalone boundary", () => {
+  test("declares the serve hook and keeps the standalone boundary explicit", () => {
+    const manifest = JSON.parse(readFileSync(join(root, "src/vendor-plugins/serve-tmux-stream-ws/plugin.json"), "utf8"));
+    expect(manifest.hooks.serve).toMatchObject({ script: "./index.ts", handler: "serve", policy: "fail-fast" });
+    expect(manifest.hooks.serve.ensures).toEqual(["ws:route:/ws/tmux"]);
+    expect(manifest.module.exports).toContain("registerServeTmuxStreamWsRoute");
+
+    expectStandalonePluginBoundary({
+      plugin: "serve-tmux-stream-ws",
+      pluginDir: "src/vendor-plugins/serve-tmux-stream-ws",
+      requireSdk: false,
+      allowRelative: [
+        /^\.\.\/\.\.\/api\/tmux-stream$/,
+        /^\.\.\/\.\.\/core\/serve-ws-registry$/,
+        /^\.\.\/\.\.\/core\/types$/,
+      ],
+    });
+  });
+
+  test("registers only the tmux stream websocket route through the serve hook", () => {
+    const registry = new ServeWsRegistry();
+    const calls: WsCall[] = [];
+    const deps = {
+      handleTmuxStreamOpen: () => calls.push({ kind: "tmux:open" }),
+      handleTmuxStreamMessage: (_ws: unknown, msg: unknown) => calls.push({ kind: "tmux:message", msg }),
+      handleTmuxStreamClose: () => calls.push({ kind: "tmux:close" }),
+    } as any;
+
+    expect(serve({ ws: registry }, deps)).toEqual({ ok: true, routes: ["/ws/tmux"] });
+    expect(registry.snapshot()).toEqual(["/ws/tmux"]);
+
+    registry.handlers.open(makeSocket("/ws/tmux"));
+    registry.handlers.message(makeSocket("/ws/tmux"), "refresh");
+    registry.handlers.close(makeSocket("/ws/tmux"));
+
+    expect(calls).toEqual([
+      { kind: "tmux:open" },
+      { kind: "tmux:message", msg: "refresh" },
+      { kind: "tmux:close" },
+    ]);
+  });
+
+  test("upgrades /ws/tmux with tmux-stream WSData mode", () => {
+    const registry = new ServeWsRegistry();
+    registerServeTmuxStreamWsRoute({ ws: registry }, {
+      handleTmuxStreamOpen() {},
+      handleTmuxStreamMessage() {},
+      handleTmuxStreamClose() {},
+    } as any);
+
+    const upgrades: unknown[] = [];
+    const okServer = { upgrade: (_req: Request, opts: unknown) => { upgrades.push(opts); return true; } };
+    expect(registry.handleUpgrade(new Request("http://local/ws/tmux"), okServer).matched).toBe(true);
+    expect(registry.handleUpgrade(new Request("http://local/ws"), okServer)).toEqual({ matched: false });
+
+    expect(upgrades).toMatchObject([
+      { data: { target: null, mode: "tmux-stream", __serveWsRoute: "/ws/tmux" } },
+    ]);
+    expect((upgrades[0] as { data: { previewTargets: unknown } }).data.previewTargets).toBeInstanceOf(Set);
+
+    const failed = registry.handleUpgrade(new Request("http://local/ws/tmux"), { upgrade: () => false });
+    expect(failed.matched).toBe(true);
+    expect(failed.response?.status).toBe(400);
+  });
+
+  test("serve hook fails clearly without ws route registration context", () => {
+    expect(() => serve({})).toThrow("serve-tmux-stream-ws requires serve ws route registration");
+  });
+});

--- a/test/isolated/plugin-serve-ws-standalone.test.ts
+++ b/test/isolated/plugin-serve-ws-standalone.test.ts
@@ -17,13 +17,12 @@ describe("serve-ws plugin", () => {
   test("declares the serve hook and keeps the standalone boundary explicit", () => {
     const manifest = JSON.parse(readFileSync(join(root, "src/vendor/mpr-plugins/serve-ws/plugin.json"), "utf8"));
     expect(manifest.hooks.serve).toMatchObject({ script: "./index.ts", handler: "serve", policy: "fail-fast" });
-    expect(manifest.hooks.serve.ensures).toEqual(["ws:route:/ws", "ws:route:/ws/pty", "ws:route:/ws/tmux"]);
+    expect(manifest.hooks.serve.ensures).toEqual(["ws:route:/ws", "ws:route:/ws/pty"]);
 
     expectStandalonePluginBoundary({
       plugin: "serve-ws",
       requireSdk: false,
       allowRelative: [
-        /^\.\.\/\.\.\/\.\.\/api\/tmux-stream$/,
         /^\.\.\/\.\.\/\.\.\/core\/serve-ws-registry$/,
         /^\.\.\/\.\.\/\.\.\/core\/transport\/pty$/,
         /^\.\.\/\.\.\/\.\.\/core\/types$/,
@@ -31,7 +30,7 @@ describe("serve-ws plugin", () => {
     });
   });
 
-  test("registers /ws, /ws/pty, and /ws/tmux through the serve hook", () => {
+  test("registers /ws and /ws/pty through the serve hook", () => {
     const registry = new ServeWsRegistry();
     const calls: WsCall[] = [];
     const engine = {
@@ -42,32 +41,22 @@ describe("serve-ws plugin", () => {
     const deps = {
       handlePtyMessage: (_ws: unknown, msg: string | Buffer) => calls.push({ kind: "pty:message", msg }),
       handlePtyClose: () => calls.push({ kind: "pty:close" }),
-      handleTmuxStreamOpen: () => calls.push({ kind: "tmux:open" }),
-      handleTmuxStreamMessage: (_ws: unknown, msg: unknown) => calls.push({ kind: "tmux:message", msg }),
-      handleTmuxStreamClose: () => calls.push({ kind: "tmux:close" }),
     } as any;
 
-    expect(serve({ ws: registry, engine: engine as any }, deps)).toEqual({ ok: true, routes: ["/ws/pty", "/ws/tmux", "/ws"] });
-    expect(registry.snapshot()).toEqual(["/ws/pty", "/ws/tmux", "/ws"]);
+    expect(serve({ ws: registry, engine: engine as any }, deps)).toEqual({ ok: true, routes: ["/ws/pty", "/ws"] });
+    expect(registry.snapshot()).toEqual(["/ws/pty", "/ws"]);
 
     registry.handlers.open(makeSocket("/ws"));
     registry.handlers.message(makeSocket("/ws"), "hello");
     registry.handlers.close(makeSocket("/ws"));
     registry.handlers.message(makeSocket("/ws/pty"), "attach");
     registry.handlers.close(makeSocket("/ws/pty"));
-    registry.handlers.open(makeSocket("/ws/tmux"));
-    registry.handlers.message(makeSocket("/ws/tmux"), "refresh");
-    registry.handlers.close(makeSocket("/ws/tmux"));
-
     expect(calls).toEqual([
       { kind: "engine:open" },
       { kind: "engine:message", msg: "hello" },
       { kind: "engine:close" },
       { kind: "pty:message", msg: "attach" },
       { kind: "pty:close" },
-      { kind: "tmux:open" },
-      { kind: "tmux:message", msg: "refresh" },
-      { kind: "tmux:close" },
     ]);
   });
 
@@ -79,21 +68,16 @@ describe("serve-ws plugin", () => {
     }, {
       handlePtyMessage() {},
       handlePtyClose() {},
-      handleTmuxStreamOpen() {},
-      handleTmuxStreamMessage() {},
-      handleTmuxStreamClose() {},
     } as any);
 
     const upgrades: unknown[] = [];
     const okServer = { upgrade: (_req: Request, opts: unknown) => { upgrades.push(opts); return true; } };
     expect(registry.handleUpgrade(new Request("http://local/ws/pty"), okServer).matched).toBe(true);
-    expect(registry.handleUpgrade(new Request("http://local/ws/tmux"), okServer).matched).toBe(true);
     expect(registry.handleUpgrade(new Request("http://local/ws"), okServer).matched).toBe(true);
     expect(registry.handleUpgrade(new Request("http://local/not-ws"), okServer)).toEqual({ matched: false });
 
     expect(upgrades).toMatchObject([
       { data: { target: null, mode: "pty", __serveWsRoute: "/ws/pty" } },
-      { data: { target: null, mode: "tmux-stream", __serveWsRoute: "/ws/tmux" } },
       { data: { target: null, __serveWsRoute: "/ws" } },
     ]);
     for (const upgrade of upgrades as Array<{ data: { previewTargets: unknown } }>) {


### PR DESCRIPTION
## Summary
- Add `src/vendor-plugins/serve-tmux-stream-ws` to own `/ws/tmux` registration
- Remove tmux-stream handler coupling from the generic `serve-ws` plugin
- Add standalone coverage for the new plugin and update server/serve-ws route ownership tests

Closes #2453

## Verification
- `MAW_TEST_MODE=1 bun test test/isolated/plugin-serve-tmux-stream-ws-standalone.test.ts test/isolated/plugin-serve-ws-standalone.test.ts test/isolated/coverage-core-shared-server.test.ts --path-ignore-patterns '**/agents/**'`\n- `bun scripts/check-plugin-coverage-gate.ts origin/alpha`\n- `bun run test:default:safe`