### PR TITLE
fix: reuse hyphen-equivalent wake sessions

### DIFF
--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -84,6 +84,40 @@ function stripNumericFleetPrefix(name: string): string {
   return name.replace(/^\d+-/, "");
 }
 
+function hyphenInsensitiveSessionKey(name: string): string {
+  return stripOracleSuffix(stripNumericFleetPrefix(name.trim().toLowerCase())).replace(/-/g, "");
+}
+
+function findHyphenInsensitiveSessions<T extends { name: string }>(
+  sessions: readonly T[],
+  targets: readonly string[],
+): T[] {
+  const targetKeys = new Set(
+    targets
+      .map(hyphenInsensitiveSessionKey)
+      .filter(Boolean),
+  );
+  if (targetKeys.size === 0) return [];
+
+  return sessions.filter(session => targetKeys.has(hyphenInsensitiveSessionKey(session.name)));
+}
+
+function resolveHyphenInsensitiveSession<T extends { name: string }>(
+  label: string,
+  sessions: readonly T[],
+  targets: readonly string[],
+): T | null {
+  const matches = findHyphenInsensitiveSessions(sessions, targets);
+  if (matches.length === 1) return matches[0]!;
+  if (matches.length > 1) {
+    console.error(`\x1b[31merror\x1b[0m: '${label}' is ambiguous — matches ${matches.length} hyphen-equivalent sessions:`);
+    for (const s of matches) console.error(`\x1b[90m    • ${s.name}\x1b[0m`);
+    console.error(`\x1b[90m  use the full name: maw wake <exact-session>\x1b[0m`);
+    process.exit(1);
+  }
+  return null;
+}
+
 function localOracleIntentNames(oracle: string): string[] {
   const raw = oracle.trim().toLowerCase();
   const withoutNumeric = stripNumericFleetPrefix(raw);
@@ -466,6 +500,13 @@ export async function detectSession(oracle: string, urlRepoName?: string): Promi
       resolveFleetSession(oracle);
     if (fleetSession && sessions.find(s => s.name === fleetSession)) return fleetSession;
 
+    // #2461 — session stems may be registered/generated with or without
+    // human-readable hyphens. A URL/repo target like `maw-js-oracle` should
+    // still join the live numbered session `139-mawjs` instead of creating a
+    // duplicate `NN-maw-js`.
+    const hyphenInsensitive = resolveHyphenInsensitiveSession(urlRepoName, scopedSessions, [urlRepoName, oracle]);
+    if (hyphenInsensitive) return hyphenInsensitive.name;
+
     const numbered = scopedSessions.filter(s => /^\d+-/.test(s.name) && s.name.endsWith(`-${urlRepoName}`));
     if (numbered.length === 1) return numbered[0]!.name;
     if (numbered.length > 1) {
@@ -497,6 +538,11 @@ export async function detectSession(oracle: string, urlRepoName?: string): Promi
     console.error(`\x1b[90m  use the full name: maw wake <exact-session>\x1b[0m`);
     process.exit(1);
   }
+
+  // #2461 — allow `maw wake maw-js` to find `139-mawjs` (and vice versa)
+  // while preserving ambiguity reporting if both spellings are live.
+  const hyphenInsensitive = resolveHyphenInsensitiveSession(oracle, scopedSessions, [oracle]);
+  if (hyphenInsensitive) return hyphenInsensitive.name;
 
   const numeric = numericSessions.filter(s => s.name.endsWith(`-${oracle}`));
   if (numeric.length === 1) return numeric[0]!.name;

--- a/test/isolated/wake-resolve-impl-fifteenth-pass-coverage.test.ts
+++ b/test/isolated/wake-resolve-impl-fifteenth-pass-coverage.test.ts
@@ -359,6 +359,14 @@ describe("resolveOracle fallback branches", () => {
 });
 
 describe("detectSession and setSessionEnv uncovered function paths", () => {
+  test("detectSession joins hyphen-equivalent existing sessions instead of creating duplicates", async () => {
+    sessions = [{ name: "139-mawjs" }];
+    await expect(detectSession("maw-js")).resolves.toBe("139-mawjs");
+
+    sessions = [{ name: "139-mawjs" }];
+    await expect(detectSession("maw-js", "maw-js-oracle")).resolves.toBe("139-mawjs");
+  });
+
   test("detectSession covers URL-numbered, numeric, prefix, and generic ambiguities", async () => {
     sessions = [{ name: "77-wireboy-oracle" }];
     await expect(detectSession("wireboy", "wireboy-oracle")).resolves.toBe("77-wireboy-oracle");


### PR DESCRIPTION
Closes #2461

## Summary
- add wake-scoped hyphen-insensitive session matching
- keep canonical session naming unchanged, preserving internal hyphens
- make `maw wake maw-js` join existing sessions like `139-mawjs` instead of creating `NN-maw-js`

## Validation
- `bun test test/isolated/wake-resolve-impl-fifteenth-pass-coverage.test.ts test/wake-resolve-impl-default.test.ts test/wake-resolve.test.ts`
- `bun scripts/check-plugin-coverage-gate.ts origin/alpha`

## Note
Exact `bun test` was attempted but remains blocked by pre-existing full-suite mock isolation failures unrelated to this PR (comm-send SDK mock leakage into routing tests, then scout integration hang). The #2461 wake resolver regression tests pass.