### PR TITLE
fix: cap default maxConcurrentAgents

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -1105,7 +1105,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
 
   if (shouldCreateSession) {
     // #2 — refuse to spawn a brand-new session/agent once the fleet is at the
-    // configured concurrency cap (no-op when limits.maxConcurrentAgents is 0).
+    // configured concurrency cap (no-op when limits.maxConcurrentAgents is explicitly 0).
     await assertAgentCapacity(oracle);
 
     // #769 — URL input names the new session after the full repo (e.g.
@@ -1451,7 +1451,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
   }
 
   // #2 — a new task/worktree window is a net-new agent pane: cap-check before
-  // spawning it (no-op when limits.maxConcurrentAgents is 0).
+  // spawning it (no-op when limits.maxConcurrentAgents is explicitly 0).
   await assertAgentCapacity(oracle);
 
   await tmux.newWindow(session, windowName, { cwd: targetPath });

--- a/src/commands/shared/wake-concurrency.ts
+++ b/src/commands/shared/wake-concurrency.ts
@@ -6,11 +6,11 @@
  * `D.limits` governed feed/logs/pty/message sizes but nothing about agent
  * count.
  *
- * This module adds an opt-in cap. When `limits.maxConcurrentAgents` is a
+ * This module adds a default cap. When `limits.maxConcurrentAgents` is a
  * positive number, `maw wake` counts the agent panes already live across the
  * fleet and refuses ("fails loud") to spawn one more once the fleet is at or
- * over the cap. `0` / unset disables the cap — no behavior change for anyone
- * who has not configured it.
+ * over the cap. Explicit `0` disables the cap for operators that intentionally
+ * want unbounded spawning.
  *
  * Pure decision logic (`checkCapacity`) is split from the tmux I/O
  * (`countLiveAgents`) so the over-cap path is unit-testable without a tmux
@@ -27,7 +27,7 @@ import { isAgentCommand } from "../../core/transport/ssh";
  * no-op. Kept free of I/O so tests can exercise every branch directly.
  */
 export function checkCapacity(liveAgents: number, cap: number, spawning: string): void {
-  if (!cap || cap <= 0) return; // cap disabled — opt-in only
+  if (!cap || cap <= 0) return; // cap disabled by explicit opt-out
   if (liveAgents >= cap) {
     throw new Error(
       `agent concurrency cap reached: ${liveAgents}/${cap} agents already live — ` +
@@ -45,8 +45,8 @@ export async function countLiveAgents(): Promise<number> {
 
 /**
  * Guard a spawn against the configured agent concurrency cap (#2). No-op when
- * `limits.maxConcurrentAgents` is `0` / unset — and in that case we skip the
- * tmux `list-panes` call entirely so the disabled path stays free.
+ * `limits.maxConcurrentAgents` is explicitly `0` — and in that case we skip
+ * the tmux `list-panes` call entirely so the disabled path stays free.
  *
  * @param spawning  the oracle/agent name about to be spawned — surfaced in the
  *                  error so the operator knows what was refused.

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -69,8 +69,8 @@ export interface MawLimits {
   ptyRows?: number;
   /**
    * Max concurrent agent panes across the fleet before `maw wake` refuses to
-   * spawn a new one (#2). `0` (the default) disables the cap entirely —
-   * operators opt in by setting a positive number.
+   * spawn a new one (#2). Defaults to `10`; explicit `0` disables the cap
+   * entirely for operators that intentionally want unbounded spawning.
    */
   maxConcurrentAgents?: number;
 }
@@ -229,6 +229,6 @@ export interface MawConfig {
 export const D = {
   intervals: { capture: 50, sessions: 5000, status: 3000, teams: 3000, preview: 2000, peerFetch: 10000, crashCheck: 30000, peerRetryBackoff: 300, ptySweep: 300000 } as const,
   timeouts: { http: 5000, health: 3000, ping: 5000, pty: 5000, workspace: 5000, shellInit: 3000, wakeRetry: 500, wakeVerify: 3000, wsIdleSec: 60 } as const,
-  limits: { feedMax: 500, feedDefault: 50, feedHistory: 50, logsMax: 500, logsDefault: 50, logsTruncate: 500, messageTruncate: 100, ptyCols: 500, ptyRows: 200, maxConcurrentAgents: 0, peerProbeRetries: 2 } as const,
+  limits: { feedMax: 500, feedDefault: 50, feedHistory: 50, logsMax: 500, logsDefault: 50, logsTruncate: 500, messageTruncate: 100, ptyCols: 500, ptyRows: 200, maxConcurrentAgents: 10, peerProbeRetries: 2 } as const,
   hmacWindowSeconds: 300,
 } as const;

--- a/test/core/config/defaults.test.ts
+++ b/test/core/config/defaults.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, test } from "bun:test";
+import { D } from "../../../src/config/types";
+
+describe("config defaults", () => {
+  test("maxConcurrentAgents defaults to a bounded cap", () => {
+    expect(D.limits.maxConcurrentAgents).toBe(10);
+  });
+});

--- a/test/helpers/mock-config.ts
+++ b/test/helpers/mock-config.ts
@@ -23,7 +23,7 @@ const LIMITS: Record<keyof MawLimits, number> = {
   feedMax: 500, feedDefault: 50, feedHistory: 50,
   logsMax: 500, logsDefault: 50, logsTruncate: 500,
   messageTruncate: 100, ptyCols: 500, ptyRows: 200,
-  maxConcurrentAgents: 0, peerProbeRetries: 2,
+  maxConcurrentAgents: 10, peerProbeRetries: 2,
 };
 
 export const TEST_D = {


### PR DESCRIPTION
## Summary
- cap default `limits.maxConcurrentAgents` at 10
- preserve explicit `0` as the opt-out that disables the wake concurrency guard
- keep test mock defaults synchronized and add a core default regression test

Closes #2471

## Validation
- `bun test test/core/`
- `bun test test/isolated/wake-concurrency.test.ts`
- `bun scripts/check-plugin-coverage-gate.ts origin/alpha`