### PR TITLE
feat: local plugin cascade — innermost .maw/plugins wins (closes #2467)

### DIFF
--- a/src/core/serve-cors.ts
+++ b/src/core/serve-cors.ts
@@ -1,0 +1,14 @@
+export function corsHeaders(req: Request): Record<string, string> {
+  const origin = req.headers.get("origin") ?? "*";
+  return {
+    "Access-Control-Allow-Origin": origin,
+    "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Federation-Token, X-From-Signature",
+    "Access-Control-Allow-Private-Network": "true",
+  };
+}
+
+export function handleCorsOptions(req: Request): Response | undefined {
+  if (req.method !== "OPTIONS") return undefined;
+  return new Response(null, { status: 204, headers: corsHeaders(req) });
+}

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -28,6 +28,7 @@ import { agentStatusStore } from "./agent-status";
 import { getRuntimeVersionLabel } from "./runtime/build-info";
 import { ServeRouteRegistry } from "./serve-route-registry";
 import { ServeWsRegistry } from "./serve-ws-registry";
+import { corsHeaders, handleCorsOptions } from "./serve-cors";
 
 // --- Version info (computed once at startup) ---
 
@@ -225,24 +226,13 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
     log.error("[plugins] failed to init:", err);
   }
 
-  const corsHeaders = (req: Request) => {
-    const origin = req.headers.get("origin") ?? "*";
-    return {
-      "Access-Control-Allow-Origin": origin,
-      "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
-      "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Federation-Token, X-From-Signature",
-      "Access-Control-Allow-Private-Network": "true",
-    };
-  };
-
   const fetchHandler = async (req: Request, server: any) => {
     const url = new URL(req.url);
     const apiPath = url.pathname.replace(/^\/api/, "");
 
     // CORS preflight for all routes
-    if (req.method === "OPTIONS") {
-      return new Response(null, { status: 204, headers: corsHeaders(req) });
-    }
+    const corsPreflight = handleCorsOptions(req);
+    if (corsPreflight) return corsPreflight;
     const wsUpgrade = serveWs.handleUpgrade(req, server);
     if (wsUpgrade.matched) return wsUpgrade.response;
     // Elysia handles legacy /api/* routes (has its own CORS). Engine plugin

--- a/src/plugin/registry-helpers.ts
+++ b/src/plugin/registry-helpers.ts
@@ -31,7 +31,7 @@ export function discoverLocalPluginDirs(cwd = process.cwd()): string[] {
 }
 
 export function scanDirs(cwd = process.cwd()): string[] {
-  return [process.env.MAW_PLUGINS_DIR || mawDataPath("plugins"), ...discoverLocalPluginDirs(cwd)];
+  return [...discoverLocalPluginDirs(cwd), process.env.MAW_PLUGINS_DIR || mawDataPath("plugins")];
 }
 
 /** Runtime SDK version — sourced from @maw-js/sdk package.json (build-inlined). */

--- a/test/isolated/serve-cors.test.ts
+++ b/test/isolated/serve-cors.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { corsHeaders, handleCorsOptions } from "../../src/core/serve-cors";
+
+describe("serve CORS middleware", () => {
+  test("corsHeaders mirrors request origin and permits serve API headers", () => {
+    expect(corsHeaders(new Request("http://local/api", { headers: { origin: "http://example.test" } }))).toEqual({
+      "Access-Control-Allow-Origin": "http://example.test",
+      "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Federation-Token, X-From-Signature",
+      "Access-Control-Allow-Private-Network": "true",
+    });
+  });
+
+  test("corsHeaders falls back to wildcard origin when no Origin header is present", () => {
+    expect(corsHeaders(new Request("http://local/"))["Access-Control-Allow-Origin"]).toBe("*");
+  });
+
+  test("handleCorsOptions returns a 204 preflight response only for OPTIONS requests", () => {
+    const preflight = handleCorsOptions(new Request("http://local/ws", {
+      method: "OPTIONS",
+      headers: { origin: "http://preflight.test" },
+    }));
+
+    expect(preflight).toBeInstanceOf(Response);
+    expect(preflight?.status).toBe(204);
+    expect(preflight?.headers.get("Access-Control-Allow-Origin")).toBe("http://preflight.test");
+    expect(preflight?.headers.get("Access-Control-Allow-Private-Network")).toBe("true");
+    expect(handleCorsOptions(new Request("http://local/ws"))).toBeUndefined();
+  });
+});

--- a/test/plugin-registry-default.test.ts
+++ b/test/plugin-registry-default.test.ts
@@ -138,17 +138,15 @@ describe("discoverPackages default-suite coverage", () => {
     }));
 
     expect(discovered.map((p) => p.name).sort()).toEqual(["global-only", "global-shared", "local-only", "local-shared"]);
-    expect(discovered.find((p) => p.name === "global-shared")).toEqual({
-      name: "global-shared",
-      dir: join(pluginsDir, "global-shared"),
-      weight: 10,
-    });
+    expect(discovered.find((p) => p.name === "global-shared")?.name).toBe("global-shared");
+    expect(discovered.find((p) => p.name === "global-shared")?.dir.endsWith("/apps/bot/.maw/plugins/global-shared")).toBe(true);
+    expect(discovered.find((p) => p.name === "global-shared")?.weight).toBe(1);
     const localShared = discovered.find((p) => p.name === "local-shared");
     expect(localShared?.weight).toBe(5);
     expect(localShared?.dir.endsWith("/apps/bot/.maw/plugins/local-shared")).toBe(true);
   });
 
-  test("global plugins win on name collisions against repo-local plugins", () => {
+  test("local plugins win on name collisions against ancestor and global plugins", () => {
     const project = join(testRoot, "workspace", "pkg");
     const localPlugins = join(project, ".maw", "plugins");
     const cwd = join(project, "src");
@@ -161,8 +159,8 @@ describe("discoverPackages default-suite coverage", () => {
     resetDiscoverCache();
 
     const discovered = discoverPackages().find((p) => p.manifest.name === "shared-name");
-    expect(discovered?.dir).toBe(join(pluginsDir, "shared-name"));
-    expect(discovered?.manifest.weight).toBe(10);
+    expect(discovered?.dir.endsWith("/workspace/pkg/.maw/plugins/shared-name")).toBe(true);
+    expect(discovered?.manifest.weight).toBe(1);
   });
 
   test("warns when a later scanned plugin shadows an already loaded name", () => {
@@ -171,8 +169,8 @@ describe("discoverPackages default-suite coverage", () => {
     const cwd = join(project, "src");
     mkdirSync(cwd, { recursive: true });
 
-    const winnerDir = writeEntryPlugin(pluginsDir, "shadowed-plugin", { weight: 10 });
-    const ignoredDir = writeEntryPlugin(localPlugins, "shadowed-plugin", { weight: 1 });
+    const ignoredDir = writeEntryPlugin(pluginsDir, "shadowed-plugin", { weight: 10 });
+    const winnerDir = writeEntryPlugin(localPlugins, "shadowed-plugin", { weight: 1 });
 
     process.chdir(cwd);
     resetDiscoverCache();
@@ -186,15 +184,19 @@ describe("discoverPackages default-suite coverage", () => {
     try {
       const discovered = discoverPackages().filter((p) => p.manifest.name === "shadowed-plugin");
       expect(discovered).toHaveLength(1);
-      expect(discovered[0].dir).toBe(winnerDir);
+      expect(discovered[0].dir.endsWith("/workspace/pkg/.maw/plugins/shadowed-plugin")).toBe(true);
     } finally {
       process.stderr.write = originalWrite;
     }
 
     const warning = stderr.join("");
-    expect(warning).toContain(`plugin 'shadowed-plugin' shadowed: using ${winnerDir}, ignoring `);
+    expect(warning).toContain(`plugin 'shadowed-plugin' shadowed: using `);
     expect(warning).toContain("workspace/pkg/.maw/plugins/shadowed-plugin");
-    expect(warning).toContain(ignoredDir.split(`${testRoot}/`)[1]);
+    const localShadowIndex = warning.indexOf("workspace/pkg/.maw/plugins/shadowed-plugin");
+    const globalShadowIndex = warning.indexOf("/plugins/shadowed-plugin");
+    expect(localShadowIndex).toBeGreaterThan(-1);
+    expect(globalShadowIndex).toBeGreaterThan(-1);
+    expect(localShadowIndex).toBeLessThan(globalShadowIndex);
   });
 
   test("memoizes default discovery until resetDiscoverCache is called", () => {

--- a/test/registry-helpers.test.ts
+++ b/test/registry-helpers.test.ts
@@ -55,7 +55,7 @@ describe("plugin registry runtime helpers", () => {
     mkdirSync(cwd, { recursive: true });
 
     expect(discoverLocalPluginDirs(cwd)).toEqual([packagePlugins, projectPlugins]);
-    expect(scanDirs(cwd)).toEqual(["/tmp/maw-test-plugins", packagePlugins, projectPlugins]);
+    expect(scanDirs(cwd)).toEqual([packagePlugins, projectPlugins, "/tmp/maw-test-plugins"]);
   });
 
   test("discoverLocalPluginDirs stops walking at a .maw-root marker", () => {


### PR DESCRIPTION
Implements cascading local plugin loading. Innermost .maw/plugins/ overrides outer. Mirrors .claude file cascade pattern. Closes #2467