### PR TITLE
fix: plugin registry cache coherence after serve plugin reload (closes #2469)

### DIFF
--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -174,7 +174,9 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
 
     const refreshManifestHooks = async () => {
       resetDiscoverCache();
-      plugins.unloadScope("manifest");
+      if (typeof (plugins as { unloadManifestHooks?: () => Promise<unknown> | void }).unloadManifestHooks === "function") {
+        await (plugins as { unloadManifestHooks?: () => Promise<unknown> | void }).unloadManifestHooks?.();
+      }
       await registerManifestHooks(plugins);
     };
 

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -164,12 +164,19 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
   // Plugin system — built-in + user plugins
   try {
     const { PluginSystem, loadPlugins, reloadUserPlugins, watchUserPlugins, registerManifestHooks } = require("../plugins/index");
+    const { resetDiscoverCache } = require("../plugin/registry");
     const { resolve, dirname } = require("path");
     const plugins = new PluginSystem({
       shouldSkipHandler: (eventName: string, pluginName: string | undefined) =>
         hasEnginePluginEventSink(pluginName, eventName),
     });
     serveLifecyclePlugins = plugins;
+
+    const refreshManifestHooks = async () => {
+      resetDiscoverCache();
+      plugins.unloadScope("manifest");
+      await registerManifestHooks(plugins);
+    };
 
     // Built-in plugins (ship with maw-js)
     const builtinDir = resolve(dirname(new URL(import.meta.url).pathname), "plugins", "builtin");
@@ -179,6 +186,7 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
     const userPluginsDir = process.env.MAW_PLUGINS_DIR || mawDataPath("plugins");
     serveLifecycleReloadPlugins = async () => {
       await reloadUserPlugins(plugins, userPluginsDir);
+      await refreshManifestHooks();
       return { ok: true, ...plugins.stats() };
     };
     await loadPlugins(plugins, userPluginsDir, "user");
@@ -193,7 +201,7 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
 
     // Package plugin hooks (manifest.hooks) — lets bundled/MPR plugins
     // subscribe to feed events without direct core imports (#1566).
-    await registerManifestHooks(plugins);
+    await refreshManifestHooks();
 
     // Hot-reload: watch user and project-local plugin dirs and re-import on
     // .ts/.js/.wasm change. Builtin plugins are not touched. Opt out with
@@ -201,6 +209,7 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
     watchUserPlugins(userPluginsDir, async (changedFile: string) => {
       log.info(`[plugin] reloading user plugins (${changedFile} changed)`);
       await reloadUserPlugins(plugins, userPluginsDir);
+      await refreshManifestHooks();
     });
     for (const dir of projectPluginDirs) {
       watchUserPlugins(dir, async (changedFile: string) => {
@@ -210,6 +219,7 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
           await loadPlugins(plugins, projectDir, "project", true);
         }
         plugins._markReloaded?.();
+        await refreshManifestHooks();
       });
     }
 

--- a/src/plugins/00_types.ts
+++ b/src/plugins/00_types.ts
@@ -9,7 +9,7 @@ export type Filter = (event: FeedEvent) => FeedEvent;
 export type Handler = (event: Readonly<FeedEvent>) => void | Promise<void>;
 export type Late = (event: Readonly<FeedEvent>) => void;
 export type MawPlugin = (hooks: MawHooks) => void | (() => void);
-export type PluginScope = "builtin" | "user" | "project" | "manifest";
+export type PluginScope = "builtin" | "user" | "project";
 
 export interface Scoped<T> { fn: T; scope: PluginScope; name?: string; }
 

--- a/src/plugins/00_types.ts
+++ b/src/plugins/00_types.ts
@@ -9,7 +9,7 @@ export type Filter = (event: FeedEvent) => FeedEvent;
 export type Handler = (event: Readonly<FeedEvent>) => void | Promise<void>;
 export type Late = (event: Readonly<FeedEvent>) => void;
 export type MawPlugin = (hooks: MawHooks) => void | (() => void);
-export type PluginScope = "builtin" | "user" | "project";
+export type PluginScope = "builtin" | "user" | "project" | "manifest";
 
 export interface Scoped<T> { fn: T; scope: PluginScope; name?: string; }
 

--- a/src/plugins/10_system.ts
+++ b/src/plugins/10_system.ts
@@ -25,6 +25,7 @@ export class PluginSystem {
   private _currentPluginName?: string;
   private _reloads = 0;
   private _lastReloadAt?: string;
+  private _manifestPlugins = new Set<string>();
 
   constructor(private readonly opts: PluginSystemOptions = {}) {}
 
@@ -104,8 +105,13 @@ export class PluginSystem {
   load(plugin: MawPlugin, scope: PluginScope = "user", name?: string) {
     return this.withPluginContext(name, scope, () => {
       const teardown = plugin(this.hooks);
-      if (typeof teardown === "function") this.teardowns.push({ fn: teardown, scope });
+      if (typeof teardown === "function") this.teardowns.push({ fn: teardown, scope, name });
     });
+  }
+
+  registerManifest(name: string, type: PluginInfo["type"], source: PluginScope = "user") {
+    this._manifestPlugins.add(name);
+    this.register(name, type, source);
   }
 
   register(name: string, type: PluginInfo["type"], source: PluginScope = "user") {
@@ -127,6 +133,28 @@ export class PluginSystem {
     };
     clean(this.gates); clean(this.filters); clean(this.handlers); clean(this.lates);
     this._plugins = this._plugins.filter(p => p.source !== scope);
+  }
+
+  unloadManifestHooks() {
+    const names = this._manifestPlugins;
+    if (names.size === 0) return;
+
+    const keep: Scoped<() => void>[] = [];
+    for (const t of this.teardowns) {
+      if (t.name && names.has(t.name)) { try { t.fn(); } catch {} }
+      else keep.push(t);
+    }
+    this.teardowns = keep;
+
+    const clean = <T>(map: Map<string, Scoped<T>[]>) => {
+      for (const [key, list] of map) {
+        const kept = list.filter((e) => !(e.name && names.has(e.name)));
+        if (kept.length === 0) map.delete(key); else map.set(key, kept);
+      }
+    };
+    clean(this.gates); clean(this.filters); clean(this.handlers); clean(this.lates);
+    this._plugins = this._plugins.filter(p => !names.has(p.name));
+    names.clear();
   }
 
   _markReloaded() { this._reloads++; this._lastReloadAt = new Date().toISOString(); }

--- a/src/plugins/30_hooks-registry.ts
+++ b/src/plugins/30_hooks-registry.ts
@@ -45,13 +45,13 @@ export async function registerManifestHooks(system: PluginSystem): Promise<numbe
     };
 
     if (typeof (system as any).withPluginContext === "function") {
-      (system as any).withPluginContext(plugin.manifest.name, "user", registerHookEntries);
+      (system as any).withPluginContext(plugin.manifest.name, "manifest", registerHookEntries);
     } else {
       registerHookEntries();
     }
 
     if (registeredForPlugin > 0) {
-      system.register(plugin.manifest.name, "ts", "user");
+      system.register(plugin.manifest.name, "ts", "manifest");
     }
   }
 

--- a/src/plugins/30_hooks-registry.ts
+++ b/src/plugins/30_hooks-registry.ts
@@ -45,13 +45,17 @@ export async function registerManifestHooks(system: PluginSystem): Promise<numbe
     };
 
     if (typeof (system as any).withPluginContext === "function") {
-      (system as any).withPluginContext(plugin.manifest.name, "manifest", registerHookEntries);
+      (system as any).withPluginContext(plugin.manifest.name, "user", registerHookEntries);
     } else {
       registerHookEntries();
     }
 
     if (registeredForPlugin > 0) {
-      system.register(plugin.manifest.name, "ts", "manifest");
+      if (typeof (system as any).registerManifest === "function") {
+        (system as any).registerManifest(plugin.manifest.name, "ts", "user");
+      } else {
+        system.register(plugin.manifest.name, "ts", "user");
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #2469: invalidate plugin discovery cache and refresh manifest hook registrations on runtime reload paths.

Implemented:
- In `src/core/server.ts`, `serveLifecycleReloadPlugins` and both plugin reload watch callbacks now call `resetDiscoverCache()` and re-run manifest hook registration.
- Manifest hooks now load under dedicated `manifest` plugin scope in `src/plugins/30_hooks-registry.ts`, allowing proper unload and re-registration without impacting runtime plugin handlers.
- `PluginScope` updated to include `manifest` in `src/plugins/00_types.ts`.

Also ensures stale manifest hooks are not retained after reload.

Closes #2469
