### PR TITLE
feat: extract serve lifecycle maintenance plugins

### DIFF
--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -1,13 +1,10 @@
 import { MawEngine } from "../engine";
-import { loadConfig, cfgInterval, cfgTimeout } from "../config";
+import { loadConfig, cfgTimeout } from "../config";
 import { existsSync, readFileSync } from "fs";
 import { api } from "../api";
 import { feedBuffer, feedListeners } from "../api/feed";
 import { setupTriggerListener } from "./runtime/trigger-listener";
 import { createTransportRouter } from "../transports";
-import { listSessions } from "./transport/ssh";
-import { Tmux } from "./transport/tmux";
-import { sweepOrphanPtySessions } from "./transport/pty";
 import { isProtected, setBunServer } from "../lib/elysia-auth";
 import { runServeLifecycleHooks } from "../plugin/lifecycle";
 import { discoverLocalPluginDirs } from "../plugin/registry-helpers";
@@ -22,9 +19,6 @@ import { mawDataPath } from "./xdg";
 import { UserError } from "./util/user-error";
 import { startDispatchEngine } from "./dispatch-engine";
 import { sendKeys } from "./transport/ssh";
-import { messageQueue } from "./message-queue";
-import { requestReplyStore } from "./request-reply";
-import { agentStatusStore } from "./agent-status";
 import { getRuntimeVersionLabel } from "./runtime/build-info";
 import { ServeRouteRegistry } from "./serve-route-registry";
 import { ServeWsRegistry } from "./serve-ws-registry";
@@ -121,22 +115,6 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
 
   const HTTP_URL = `http://localhost:${port}`;
   const WS_URL = `ws://localhost:${port}/ws`;
-
-  // Reap orphaned PTY + view sessions from previous server lifecycle (#300)
-  try {
-    const sessions = await listSessions();
-    const stale = sessions.filter(s =>
-      s.name.startsWith("maw-pty-") || s.name.endsWith("-view")
-    );
-    if (stale.length > 0) {
-      const reaper = new Tmux();
-      for (const s of stale) {
-        await reaper.killSession(s.name);
-        log.info(`[startup] reaped orphan: ${s.name}`);
-      }
-      log.info(`[startup] cleaned ${stale.length} orphaned sessions`);
-    }
-  } catch { /* tmux may not be running */ }
 
   // Connect transport router (non-blocking — server starts even if transports fail)
   try {
@@ -315,33 +293,6 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
   setBunServer(server);
   startEnginePluginHealthPolling();
 
-  // #P2 — periodic orphan-PTY sweep. The boot reaper above (#300) clears the
-  // server-restart class once at startup; this catches in-memory/tmux drift on
-  // a long-lived process. unref() so it never holds the event loop open.
-  const ptySweepTimer = setInterval(() => {
-    sweepOrphanPtySessions()
-      .then(({ killed, checked }) => {
-        if (killed.length > 0) {
-          log.info(`[pty-sweep] killed ${killed.length} orphan(s): ${killed.join(", ")} (checked ${checked})`);
-        }
-      })
-      .catch((err) => log.error("[pty-sweep] failed:", err));
-  }, cfgInterval("ptySweep"));
-  (ptySweepTimer as { unref?: () => void }).unref?.();
-
-  // #2165: maw serve is a multi-day process; keep in-memory queues/request
-  // reply records/status cache bounded. The stores already expose pruning for
-  // completed messages and expired request/reply entries, but serve never
-  // called them, so active federation traffic could retain old objects until
-  // process restart. Pending queues are preserved; only completed/expired/stale
-  // terminal state is removed.
-  const memoryMaintenanceTimer = setInterval(() => {
-    try { messageQueue.prune(); } catch { /* best effort */ }
-    try { requestReplyStore.prune(); } catch { /* best effort */ }
-    try { agentStatusStore.prune(); } catch { /* best effort */ }
-  }, 60_000);
-  (memoryMaintenanceTimer as { unref?: () => void }).unref?.();
-
   const bindNote = reason ? ` (${reason})` : "";
   log.info(`maw ${VERSION} serve → ${HTTP_URL} (${WS_URL}) [${hostname}]${bindNote}`);
 
@@ -355,6 +306,7 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
       http: serveRoutes,
       ws: serveWs,
       engine,
+      log,
       plugins: serveLifecyclePlugins,
       reloadPlugins: serveLifecycleReloadPlugins,
     }, undefined, {

--- a/src/plugin/lifecycle.ts
+++ b/src/plugin/lifecycle.ts
@@ -32,6 +32,12 @@ export interface PluginLifecycleContext {
   http?: ServeRouteRegistrar;
   ws?: ServeWsRouteRegistrar;
   engine?: MawEngine;
+  log?: {
+    info?: (...args: unknown[]) => void;
+    warn?: (...args: unknown[]) => void;
+    debug?: (...args: unknown[]) => void;
+    error?: (...args: unknown[]) => void;
+  };
   ensures?: string[];
 }
 
@@ -57,6 +63,13 @@ export interface ServeLifecycleContextInput {
   http?: ServeRouteRegistrar;
   ws?: ServeWsRouteRegistrar;
   engine?: MawEngine;
+  /** Serve logger scoped by CLI verbosity for core lifecycle plugins. */
+  log?: {
+    info?: (...args: unknown[]) => void;
+    warn?: (...args: unknown[]) => void;
+    debug?: (...args: unknown[]) => void;
+    error?: (...args: unknown[]) => void;
+  };
   /** In-memory feed plugin system, exposed for serve diagnostics/debug plugins. */
   plugins?: unknown;
   /** Reload user plugins and return the current plugin stats/debug payload. */

--- a/src/vendor-plugins/serve-maintenance/index.ts
+++ b/src/vendor-plugins/serve-maintenance/index.ts
@@ -1,0 +1,94 @@
+import { cfgInterval as defaultCfgInterval } from "../../config";
+import { sweepOrphanPtySessions as defaultSweepOrphanPtySessions } from "../../core/transport/pty";
+import { messageQueue as defaultMessageQueue } from "../../core/message-queue";
+import { requestReplyStore as defaultRequestReplyStore } from "../../core/request-reply";
+import { agentStatusStore as defaultAgentStatusStore } from "../../core/agent-status";
+
+type ServeLog = {
+  info?: (...args: unknown[]) => void;
+  error?: (...args: unknown[]) => void;
+};
+
+type TimerHandle = { unref?: () => void };
+type SetIntervalFn = (handler: () => void, timeout: number) => TimerHandle;
+
+type Prunable = { prune: () => unknown };
+
+type ServeMaintenanceContext = {
+  log?: ServeLog;
+};
+
+type ServeMaintenanceDeps = {
+  cfgInterval: typeof defaultCfgInterval;
+  sweepOrphanPtySessions: typeof defaultSweepOrphanPtySessions;
+  messageQueue: Prunable;
+  requestReplyStore: Prunable;
+  agentStatusStore: Prunable;
+  setInterval: SetIntervalFn;
+};
+
+const defaultDeps: ServeMaintenanceDeps = {
+  cfgInterval: defaultCfgInterval,
+  sweepOrphanPtySessions: defaultSweepOrphanPtySessions,
+  messageQueue: defaultMessageQueue,
+  requestReplyStore: defaultRequestReplyStore,
+  agentStatusStore: defaultAgentStatusStore,
+  setInterval: (handler, timeout) => setInterval(handler, timeout) as TimerHandle,
+};
+
+function unrefTimer(timer: TimerHandle): void {
+  timer.unref?.();
+}
+
+export function startServePtySweep(
+  deps: Partial<ServeMaintenanceDeps> = {},
+  log?: ServeLog,
+): TimerHandle {
+  const d = { ...defaultDeps, ...deps };
+  const timer = d.setInterval(() => {
+    d.sweepOrphanPtySessions()
+      .then(({ killed, checked }) => {
+        if (killed.length > 0) {
+          log?.info?.(`[pty-sweep] killed ${killed.length} orphan(s): ${killed.join(", ")} (checked ${checked})`);
+        }
+      })
+      .catch((err) => log?.error?.("[pty-sweep] failed:", err));
+  }, d.cfgInterval("ptySweep"));
+  unrefTimer(timer);
+  return timer;
+}
+
+export function startServeMemoryMaintenance(
+  deps: Partial<ServeMaintenanceDeps> = {},
+): TimerHandle {
+  const d = { ...defaultDeps, ...deps };
+  const timer = d.setInterval(() => {
+    try { d.messageQueue.prune(); } catch { /* best effort */ }
+    try { d.requestReplyStore.prune(); } catch { /* best effort */ }
+    try { d.agentStatusStore.prune(); } catch { /* best effort */ }
+  }, 60_000);
+  unrefTimer(timer);
+  return timer;
+}
+
+export function startServeMaintenance(
+  deps: Partial<ServeMaintenanceDeps> = {},
+  log?: ServeLog,
+): { ok: true; timers: TimerHandle[] } {
+  return {
+    ok: true,
+    timers: [
+      startServePtySweep(deps, log),
+      startServeMemoryMaintenance(deps),
+    ],
+  };
+}
+
+export function serve(
+  ctx: ServeMaintenanceContext = {},
+  deps?: Partial<ServeMaintenanceDeps>,
+): { ok: true; timers: TimerHandle[] } {
+  return startServeMaintenance(deps, ctx.log);
+}
+
+export default serve;

--- a/src/vendor-plugins/serve-maintenance/plugin.json
+++ b/src/vendor-plugins/serve-maintenance/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "serve-maintenance",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "tier": "core",
+  "description": "Starts maw serve PTY sweep and memory-pruning maintenance timers.",
+  "author": "Soul-Brews-Studio",
+  "hooks": {
+    "serve": {
+      "script": "./index.ts",
+      "handler": "serve",
+      "ensures": ["serve:timer:pty-sweep", "serve:timer:memory-maintenance"],
+      "policy": "fail-fast"
+    }
+  },
+  "module": {
+    "path": "./index.ts",
+    "exports": ["serve", "startServeMaintenance", "startServePtySweep", "startServeMemoryMaintenance"]
+  },
+  "capabilities": ["serve:timer", "pty:sweep", "queue:prune", "status:prune"],
+  "capabilityNamespaces": ["serve", "pty", "queue", "status"],
+  "weight": 90,
+  "license": "MIT",
+  "schemaVersion": 1
+}

--- a/src/vendor-plugins/serve-session-reaper/index.ts
+++ b/src/vendor-plugins/serve-session-reaper/index.ts
@@ -1,0 +1,60 @@
+import { listSessions as defaultListSessions } from "../../core/transport/ssh";
+import { Tmux as DefaultTmux } from "../../core/transport/tmux";
+
+type Session = { name: string };
+type Reaper = { killSession(name: string): Promise<unknown> };
+type ServeLog = { info?: (...args: unknown[]) => void };
+
+type ServeSessionReaperContext = {
+  log?: ServeLog;
+};
+
+type ServeSessionReaperDeps = {
+  listSessions: () => Promise<Session[]>;
+  createReaper: () => Reaper;
+};
+
+const defaultDeps: ServeSessionReaperDeps = {
+  listSessions: defaultListSessions,
+  createReaper: () => new DefaultTmux(),
+};
+
+export function isStaleServeSession(sessionName: string): boolean {
+  return sessionName.startsWith("maw-pty-") || sessionName.endsWith("-view");
+}
+
+export async function reapStaleServeSessions(
+  deps: Partial<ServeSessionReaperDeps> = {},
+  log?: ServeLog,
+): Promise<{ ok: true; killed: string[]; checked: number }> {
+  const d = { ...defaultDeps, ...deps };
+
+  try {
+    const sessions = await d.listSessions();
+    const stale = sessions.filter((session) => isStaleServeSession(session.name));
+    if (stale.length === 0) return { ok: true, killed: [], checked: sessions.length };
+
+    const reaper = d.createReaper();
+    const killed: string[] = [];
+    for (const session of stale) {
+      await reaper.killSession(session.name);
+      killed.push(session.name);
+      log?.info?.(`[startup] reaped orphan: ${session.name}`);
+    }
+    log?.info?.(`[startup] cleaned ${killed.length} orphaned sessions`);
+    return { ok: true, killed, checked: sessions.length };
+  } catch {
+    // tmux may not be running during serve startup; preserve the previous
+    // best-effort/no-noise behavior from core/server.ts.
+    return { ok: true, killed: [], checked: 0 };
+  }
+}
+
+export async function serve(
+  ctx: ServeSessionReaperContext = {},
+  deps?: Partial<ServeSessionReaperDeps>,
+): Promise<{ ok: true; killed: string[]; checked: number }> {
+  return reapStaleServeSessions(deps, ctx.log);
+}
+
+export default serve;

--- a/src/vendor-plugins/serve-session-reaper/plugin.json
+++ b/src/vendor-plugins/serve-session-reaper/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "serve-session-reaper",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "tier": "core",
+  "description": "Reaps stale maw PTY and view tmux sessions during maw serve startup.",
+  "author": "Soul-Brews-Studio",
+  "hooks": {
+    "serve": {
+      "script": "./index.ts",
+      "handler": "serve",
+      "ensures": ["serve:startup:stale-session-reap"],
+      "policy": "best-effort"
+    }
+  },
+  "module": {
+    "path": "./index.ts",
+    "exports": ["serve", "reapStaleServeSessions", "isStaleServeSession"]
+  },
+  "capabilities": ["serve:startup", "tmux:session-kill"],
+  "capabilityNamespaces": ["serve", "tmux"],
+  "weight": 1,
+  "license": "MIT",
+  "schemaVersion": 1
+}

--- a/test/isolated/coverage-core-shared-server.test.ts
+++ b/test/isolated/coverage-core-shared-server.test.ts
@@ -229,7 +229,10 @@ describe("coverage core shared server", () => {
   test("startServer exposes fetch and websocket handlers without real network side effects", async () => {
     await startServer(4910);
 
-    expect(killed).toEqual(["maw-pty-stale", "sender-view"]);
+    // Startup stale-session cleanup moved to the serve-session-reaper lifecycle
+    // plugin; server.ts now proves the plugin context is wired instead of
+    // directly killing tmux sessions here.
+    expect(killed).toEqual([]);
     expect(engineCalls).toContain("router");
     expect(lifecyclePayloads).toHaveLength(1);
     expect(lifecyclePayloads[0]).toMatchObject({
@@ -237,6 +240,7 @@ describe("coverage core shared server", () => {
       httpUrl: "http://localhost:4910",
       wsUrl: "ws://localhost:4910/ws",
       hostname: "127.0.0.1",
+      log: expect.any(Object),
       plugins: expect.any(Object),
       reloadPlugins: expect.any(Function),
     });

--- a/test/isolated/plugin-serve-maintenance-standalone.test.ts
+++ b/test/isolated/plugin-serve-maintenance-standalone.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
+import {
+  serve,
+  startServeMaintenance,
+  startServeMemoryMaintenance,
+  startServePtySweep,
+} from "../../src/vendor-plugins/serve-maintenance/index.ts?plugin-serve-maintenance-standalone";
+
+const root = join(import.meta.dir, "../..");
+
+function makeTimerHarness() {
+  const handlers: Array<() => void> = [];
+  const intervals: number[] = [];
+  let unrefCount = 0;
+  return {
+    handlers,
+    intervals,
+    get unrefCount() { return unrefCount; },
+    setInterval(handler: () => void, timeout: number) {
+      handlers.push(handler);
+      intervals.push(timeout);
+      return { unref: () => { unrefCount += 1; } };
+    },
+  };
+}
+
+describe("serve-maintenance plugin standalone boundary", () => {
+  test("declares serve hook for PTY sweep and memory maintenance timers", () => {
+    const manifest = JSON.parse(readFileSync(join(root, "src/vendor-plugins/serve-maintenance/plugin.json"), "utf8"));
+    expect(manifest.hooks.serve).toMatchObject({ script: "./index.ts", handler: "serve", policy: "fail-fast" });
+    expect(manifest.api).toBeUndefined();
+    expect(manifest.module.exports).toContain("startServeMaintenance");
+  });
+
+  test("boundary drift is explicit for this core lifecycle plugin", () => {
+    expectStandalonePluginBoundary({
+      plugin: "serve-maintenance",
+      pluginDir: "src/vendor-plugins/serve-maintenance",
+      requireSdk: false,
+      allowRelative: [
+        /^\.\.\/\.\.\/config$/,
+        /^\.\.\/\.\.\/core\/transport\/pty$/,
+        /^\.\.\/\.\.\/core\/message-queue$/,
+        /^\.\.\/\.\.\/core\/request-reply$/,
+        /^\.\.\/\.\.\/core\/agent-status$/,
+      ],
+    });
+  });
+
+  test("PTY sweep timer preserves interval, unref, success logging, and error logging", async () => {
+    const timer = makeTimerHarness();
+    const info: string[] = [];
+    const errors: unknown[][] = [];
+    let fail = false;
+
+    startServePtySweep({
+      cfgInterval: ((key: string) => key === "ptySweep" ? 1234 : 0) as any,
+      sweepOrphanPtySessions: async () => {
+        if (fail) throw new Error("sweep boom");
+        return { killed: ["maw-pty-old"], checked: 4 };
+      },
+      setInterval: timer.setInterval,
+    }, {
+      info: (line) => info.push(String(line)),
+      error: (...args) => errors.push(args),
+    });
+
+    expect(timer.intervals).toEqual([1234]);
+    expect(timer.unrefCount).toBe(1);
+
+    timer.handlers[0]();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(info).toEqual(["[pty-sweep] killed 1 orphan(s): maw-pty-old (checked 4)"]);
+
+    fail = true;
+    timer.handlers[0]();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(errors[0][0]).toBe("[pty-sweep] failed:");
+    expect(errors[0][1]).toBeInstanceOf(Error);
+  });
+
+  test("memory maintenance timer prunes all stores and swallows individual failures", () => {
+    const timer = makeTimerHarness();
+    const calls: string[] = [];
+
+    startServeMemoryMaintenance({
+      setInterval: timer.setInterval,
+      messageQueue: { prune: () => { calls.push("message"); } },
+      requestReplyStore: { prune: () => { calls.push("request"); throw new Error("ignore"); } },
+      agentStatusStore: { prune: () => { calls.push("status"); } },
+    });
+
+    expect(timer.intervals).toEqual([60_000]);
+    expect(timer.unrefCount).toBe(1);
+    timer.handlers[0]();
+    expect(calls).toEqual(["message", "request", "status"]);
+  });
+
+  test("serve hook starts both maintenance timers", () => {
+    const timer = makeTimerHarness();
+    const result = serve({}, {
+      cfgInterval: (() => 300_000) as any,
+      sweepOrphanPtySessions: async () => ({ killed: [], checked: 0 }),
+      setInterval: timer.setInterval,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.timers).toHaveLength(2);
+    expect(timer.intervals).toEqual([300_000, 60_000]);
+    expect(timer.unrefCount).toBe(2);
+  });
+
+  test("startServeMaintenance mirrors serve hook behavior", () => {
+    const timer = makeTimerHarness();
+    const result = startServeMaintenance({
+      cfgInterval: (() => 300_000) as any,
+      sweepOrphanPtySessions: async () => ({ killed: [], checked: 0 }),
+      setInterval: timer.setInterval,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(timer.intervals).toEqual([300_000, 60_000]);
+  });
+});

--- a/test/isolated/plugin-serve-session-reaper-standalone.test.ts
+++ b/test/isolated/plugin-serve-session-reaper-standalone.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
+import {
+  isStaleServeSession,
+  reapStaleServeSessions,
+  serve,
+} from "../../src/vendor-plugins/serve-session-reaper/index.ts?plugin-serve-session-reaper-standalone";
+
+const root = join(import.meta.dir, "../..");
+
+describe("serve-session-reaper plugin standalone boundary", () => {
+  test("declares best-effort serve hook for startup stale session cleanup", () => {
+    const manifest = JSON.parse(readFileSync(join(root, "src/vendor-plugins/serve-session-reaper/plugin.json"), "utf8"));
+    expect(manifest.hooks.serve).toMatchObject({ script: "./index.ts", handler: "serve", policy: "best-effort" });
+    expect(manifest.api).toBeUndefined();
+    expect(manifest.module.exports).toContain("reapStaleServeSessions");
+  });
+
+  test("boundary drift is explicit for this core lifecycle plugin", () => {
+    expectStandalonePluginBoundary({
+      plugin: "serve-session-reaper",
+      pluginDir: "src/vendor-plugins/serve-session-reaper",
+      requireSdk: false,
+      allowRelative: [
+        /^\.\.\/\.\.\/core\/transport\/ssh$/,
+        /^\.\.\/\.\.\/core\/transport\/tmux$/,
+      ],
+    });
+  });
+
+  test("classifies stale PTY and view sessions only", () => {
+    expect(isStaleServeSession("maw-pty-abc")).toBe(true);
+    expect(isStaleServeSession("neo-view")).toBe(true);
+    expect(isStaleServeSession("mawjs")).toBe(false);
+    expect(isStaleServeSession("view-master")).toBe(false);
+  });
+
+  test("reaps stale sessions and preserves startup log shape", async () => {
+    const killed: string[] = [];
+    const lines: string[] = [];
+    const result = await reapStaleServeSessions({
+      listSessions: async () => [
+        { name: "maw-pty-old" },
+        { name: "alpha-view" },
+        { name: "mawjs" },
+      ],
+      createReaper: () => ({ killSession: async (name: string) => { killed.push(name); } }),
+    }, { info: (line) => lines.push(String(line)) });
+
+    expect(result).toEqual({ ok: true, killed: ["maw-pty-old", "alpha-view"], checked: 3 });
+    expect(killed).toEqual(["maw-pty-old", "alpha-view"]);
+    expect(lines).toEqual([
+      "[startup] reaped orphan: maw-pty-old",
+      "[startup] reaped orphan: alpha-view",
+      "[startup] cleaned 2 orphaned sessions",
+    ]);
+  });
+
+  test("tmux/list failures remain best-effort and quiet", async () => {
+    const result = await reapStaleServeSessions({
+      listSessions: async () => { throw new Error("tmux down"); },
+    });
+    expect(result).toEqual({ ok: true, killed: [], checked: 0 });
+  });
+
+  test("serve hook delegates to the reaper", async () => {
+    const result = await serve({}, {
+      listSessions: async () => [{ name: "maw-pty-one" }],
+      createReaper: () => ({ killSession: async () => {} }),
+    });
+    expect(result).toEqual({ ok: true, killed: ["maw-pty-one"], checked: 1 });
+  });
+});


### PR DESCRIPTION
## Summary
- mapped remaining `src/core/server.ts` Tier 3 surfaces: transport/dispatch/feed wiring, plugin bootstrap/reload, bind/PID/TLS, peer startup warnings, engine health polling, startup cleanup, and maintenance timers
- extracted two self-contained lifecycle sections into core vendor plugins:
  - `serve-session-reaper`: best-effort stale `maw-pty-*` / `*-view` tmux session cleanup
  - `serve-maintenance`: PTY orphan sweep and in-memory queue/request/status pruning timers
- added lifecycle logger context so extracted plugins preserve serve verbosity behavior

Closes #2475

## Validation
- `bun test test/isolated/plugin-serve-session-reaper-standalone.test.ts test/isolated/plugin-serve-maintenance-standalone.test.ts`
- `bun test test/core/`
- `bun scripts/check-plugin-coverage-gate.ts origin/alpha`
- smoke: `bun src/cli.ts serve 3099 --as smoke-2475 --quiet` + `curl -sf http://localhost:3099/health`

## Notes
- This PR intentionally leaves PID/bind/TLS and plugin bootstrap in `server.ts`; those are higher-risk startup gates and should be extracted with focused startup-failure coverage in a follow-up slice.