### PR TITLE
feat: extract serve peer startup warnings

### DIFF
--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -88,17 +88,6 @@ export const views = serveViewsPlugin.createViews();
 const serveWsPlugin = await import(`../vendor/mpr-plugins/serve-ws/index.ts?server=${encodeURIComponent(import.meta.url)}`);
 const registerServeWs = serveWsPlugin.serve;
 
-const startupPeerWarningsLogged = new Set<string>();
-
-function warnMissingFederationTokenOnce(port: number, log = createServeLogger(1)): void {
-  const key = "missing-federation-token";
-  if (startupPeerWarningsLogged.has(key)) return;
-  startupPeerWarningsLogged.add(key);
-  log.warn(`\x1b[31m⚠ WARNING: peers configured but no federationToken set!\x1b[0m`);
-  log.warn(`\x1b[31m  Port ${port} is exposed to network WITHOUT authentication.\x1b[0m`);
-  log.warn(`\x1b[31m  Add "federationToken" (min 16 chars) to maw.config.json\x1b[0m`);
-}
-
 // --- Server ---
 
 export async function startServer(port = +(process.env.MAW_PORT || loadConfig().port || 3456), options: StartServerOptions = {}) {
@@ -265,25 +254,6 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
   const hasPeers = heuristic.reason !== null;
   log.debug(`[serve:debug] verbosity=${verbosity} port=${port} hostname=${hostname} reason=${reason ?? "explicit-local"}`);
   log.debug(`[serve:debug] peers=${hasPeers ? "configured" : "none"} tls=${config.tls?.cert && config.tls?.key ? "configured" : "off"}`);
-
-  if (hasPeers && !config.federationToken) {
-    warnMissingFederationTokenOnce(port, log);
-  }
-
-  // Duplicate <oracle>:<node> warn (#804 Step 3, ADR docs/federation/0001-peer-identity.md).
-  // Boot-time scan of the peer cache + the local identity. Non-blocking — per
-  // the ADR, "Crypto solves can't-fake; doctor + boot-time check solves
-  // operator confusion" — so we just warn loudly and let serve continue.
-  try {
-    const { loadPeers } = require("../lib/peers/store");
-    const { warnDuplicatesAtBoot } = require("../lib/peers/duplicate-detect");
-    const peers = loadPeers().peers;
-    const local = config.node ? { oracle: config.oracle ?? "mawjs", node: config.node } : undefined;
-    warnDuplicatesAtBoot({ peers, local, log: (message: string) => log.warn(message) });
-  } catch (e: any) {
-    // Never fail boot on a dedup-scan glitch — log and move on.
-    log.warn(`[startup] peer dedup scan skipped: ${e?.message || e}`);
-  }
 
   // P1 heartbeat-reaper: Bun-managed ws ping/pong + idle close. Dead clients
   // (ungraceful disconnect, no TCP FIN) close after wsIdleSec → close handler

--- a/src/vendor-plugins/serve-peer-startup-warnings/index.ts
+++ b/src/vendor-plugins/serve-peer-startup-warnings/index.ts
@@ -1,0 +1,97 @@
+import { loadConfig as defaultLoadConfig, type MawConfig } from "../../config";
+import { resolveBindHost as defaultResolveBindHost } from "../../core/bind-host";
+import { loadPeers as defaultLoadPeers } from "../../lib/peers/store";
+import { warnDuplicatesAtBoot as defaultWarnDuplicatesAtBoot } from "../../lib/peers/duplicate-detect";
+
+type ServeLog = { warn?: (...args: unknown[]) => void };
+
+type ServePeerStartupWarningsContext = {
+  port?: number;
+  log?: ServeLog;
+};
+
+type PeerStore = { peers: unknown };
+
+type ServePeerStartupWarningsDeps = {
+  loadConfig: () => MawConfig;
+  resolveBindHost: typeof defaultResolveBindHost;
+  loadPeers: () => PeerStore;
+  warnDuplicatesAtBoot: typeof defaultWarnDuplicatesAtBoot;
+};
+
+const defaultDeps: ServePeerStartupWarningsDeps = {
+  loadConfig: defaultLoadConfig,
+  resolveBindHost: defaultResolveBindHost,
+  loadPeers: defaultLoadPeers,
+  warnDuplicatesAtBoot: defaultWarnDuplicatesAtBoot,
+};
+
+const startupPeerWarningsLogged = new Set<string>();
+
+export function resetServePeerStartupWarningStateForTests(): void {
+  startupPeerWarningsLogged.clear();
+}
+
+export function warnMissingFederationTokenOnce(
+  port: number,
+  log: ServeLog,
+  key = "missing-federation-token",
+): boolean {
+  if (startupPeerWarningsLogged.has(key)) return false;
+  startupPeerWarningsLogged.add(key);
+  log.warn?.(`\x1b[31m⚠ WARNING: peers configured but no federationToken set!\x1b[0m`);
+  log.warn?.(`\x1b[31m  Port ${port} is exposed to network WITHOUT authentication.\x1b[0m`);
+  log.warn?.(`\x1b[31m  Add "federationToken" (min 16 chars) to maw.config.json\x1b[0m`);
+  return true;
+}
+
+export function warnMissingFederationTokenIfNeeded(
+  config: MawConfig,
+  port: number,
+  log: ServeLog,
+  deps: Pick<ServePeerStartupWarningsDeps, "resolveBindHost"> = defaultDeps,
+): boolean {
+  const heuristic = deps.resolveBindHost(config);
+  const hasPeers = heuristic.reason !== null;
+  if (!hasPeers || config.federationToken) return false;
+  return warnMissingFederationTokenOnce(port, log);
+}
+
+export function warnDuplicatePeerIdentityAtBoot(
+  config: MawConfig,
+  log: ServeLog,
+  deps: Pick<ServePeerStartupWarningsDeps, "loadPeers" | "warnDuplicatesAtBoot"> = defaultDeps,
+): boolean {
+  try {
+    const peers = deps.loadPeers().peers;
+    const local = config.node ? { oracle: config.oracle ?? "mawjs", node: config.node } : undefined;
+    deps.warnDuplicatesAtBoot({ peers, local, log: (message: string) => log.warn?.(message) });
+    return true;
+  } catch (e: any) {
+    // Never fail boot on a dedup-scan glitch — log and move on.
+    log.warn?.(`[startup] peer dedup scan skipped: ${e?.message || e}`);
+    return false;
+  }
+}
+
+export function runServePeerStartupWarnings(
+  ctx: ServePeerStartupWarningsContext = {},
+  deps: Partial<ServePeerStartupWarningsDeps> = {},
+): { ok: true; missingTokenWarned: boolean; duplicateScanRan: boolean } {
+  const d = { ...defaultDeps, ...deps };
+  const log = ctx.log ?? {};
+  const config = d.loadConfig();
+  const port = ctx.port ?? config.port;
+  const missingTokenWarned = warnMissingFederationTokenIfNeeded(config, port, log, d);
+  const duplicateScanRan = warnDuplicatePeerIdentityAtBoot(config, log, d);
+  return { ok: true, missingTokenWarned, duplicateScanRan };
+}
+
+export function serve(
+  ctx: ServePeerStartupWarningsContext = {},
+  deps?: Partial<ServePeerStartupWarningsDeps>,
+): { ok: true; missingTokenWarned: boolean; duplicateScanRan: boolean } {
+  return runServePeerStartupWarnings(ctx, deps);
+}
+
+export default serve;

--- a/src/vendor-plugins/serve-peer-startup-warnings/plugin.json
+++ b/src/vendor-plugins/serve-peer-startup-warnings/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "serve-peer-startup-warnings",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "tier": "core",
+  "description": "Emits maw serve startup warnings for peer auth exposure and duplicate peer identity.",
+  "author": "Soul-Brews-Studio",
+  "hooks": {
+    "serve": {
+      "script": "./index.ts",
+      "handler": "serve",
+      "ensures": ["serve:startup:peer-warnings"],
+      "policy": "best-effort"
+    }
+  },
+  "module": {
+    "path": "./index.ts",
+    "exports": ["serve", "runServePeerStartupWarnings", "warnMissingFederationTokenOnce", "warnMissingFederationTokenIfNeeded", "warnDuplicatePeerIdentityAtBoot", "resetServePeerStartupWarningStateForTests"]
+  },
+  "capabilities": ["serve:startup", "peers:read"],
+  "capabilityNamespaces": ["serve", "peers"],
+  "weight": 2,
+  "license": "MIT",
+  "schemaVersion": 1
+}

--- a/test/isolated/core-server-more-coverage-2.test.ts
+++ b/test/isolated/core-server-more-coverage-2.test.ts
@@ -219,7 +219,7 @@ describe("core server remaining isolated coverage", () => {
     expect(await boom.json()).toEqual({ error: "view exploded" });
   });
 
-  test("startup tolerates tmux, transport, plugin, peer-scan, event-dispatch, reload, and pty-upgrade failure paths", async () => {
+  test("startup tolerates tmux, transport, plugin, event-dispatch, reload, and pty-upgrade failure paths", async () => {
     sessionsShouldThrow = true;
     connectShouldReject = true;
     pluginLoadShouldThrow = true;
@@ -230,7 +230,10 @@ describe("core server remaining isolated coverage", () => {
 
     expect(errors.join("\n")).toContain("connect failed");
     expect(errors.join("\n")).toContain("failed to init");
-    expect(warns.join("\n")).toContain("peer dedup scan skipped: peer cache corrupt");
+    // Peer dedup scan warnings moved to serve-peer-startup-warnings; isolated
+    // server.ts tests do not execute lifecycle plugins. The plugin standalone
+    // test covers the corrupt peer-cache warning.
+    expect(warns.join("\n")).not.toContain("peer dedup scan skipped");
 
     const fetch = serveCalls[0].fetch;
     const failedPty = await fetch(new Request("http://local/ws/pty"), upgradeServer(false));
@@ -242,15 +245,18 @@ describe("core server remaining isolated coverage", () => {
     expect(warns.join("\n")).toContain("event dispatch failed: dispatch rejected");
   });
 
-  test("deduplicates missing federation token startup warning across repeated serve starts", async () => {
+  test("missing federation token warning is plugin-owned after extraction", async () => {
     config = { peers: ["http://peer.local:3456"] };
 
     await startServer(4792);
     await startServer(4793);
 
     const joined = warns.join("\n");
-    expect(joined.match(/peers configured but no federationToken set/g)?.length).toBe(1);
-    expect(joined.match(/exposed to network WITHOUT authentication/g)?.length).toBe(1);
+    // Missing-token warning dedupe moved to serve-peer-startup-warnings; this
+    // isolated server.ts test mocks lifecycle hooks and therefore should not
+    // expect plugin-owned warnings.
+    expect(joined).not.toContain("peers configured but no federationToken set");
+    expect(joined).not.toContain("exposed to network WITHOUT authentication");
   });
 
   test("plugin reload watcher callback reloads user plugins", async () => {

--- a/test/isolated/plugin-serve-peer-startup-warnings-standalone.test.ts
+++ b/test/isolated/plugin-serve-peer-startup-warnings-standalone.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
+import {
+  resetServePeerStartupWarningStateForTests,
+  runServePeerStartupWarnings,
+  serve,
+  warnDuplicatePeerIdentityAtBoot,
+  warnMissingFederationTokenIfNeeded,
+  warnMissingFederationTokenOnce,
+} from "../../src/vendor-plugins/serve-peer-startup-warnings/index.ts?plugin-serve-peer-startup-warnings-standalone";
+import type { MawConfig } from "../../src/config/types";
+
+const root = join(import.meta.dir, "../..");
+
+function baseConfig(overrides: Partial<MawConfig> = {}): MawConfig {
+  return {
+    host: "localhost",
+    port: 3456,
+    node: "m5",
+    oracle: "mawjs",
+    commands: {},
+    env: {},
+    ...overrides,
+  } as MawConfig;
+}
+
+describe("serve-peer-startup-warnings plugin standalone boundary", () => {
+  beforeEach(() => {
+    resetServePeerStartupWarningStateForTests();
+  });
+
+  test("declares best-effort serve hook for peer startup warnings", () => {
+    const manifest = JSON.parse(readFileSync(join(root, "src/vendor-plugins/serve-peer-startup-warnings/plugin.json"), "utf8"));
+    expect(manifest.hooks.serve).toMatchObject({ script: "./index.ts", handler: "serve", policy: "best-effort" });
+    expect(manifest.api).toBeUndefined();
+    expect(manifest.module.exports).toContain("runServePeerStartupWarnings");
+  });
+
+  test("boundary drift is explicit for this core lifecycle plugin", () => {
+    expectStandalonePluginBoundary({
+      plugin: "serve-peer-startup-warnings",
+      pluginDir: "src/vendor-plugins/serve-peer-startup-warnings",
+      requireSdk: false,
+      allowRelative: [
+        /^\.\.\/\.\.\/config$/,
+        /^\.\.\/\.\.\/core\/bind-host$/,
+        /^\.\.\/\.\.\/lib\/peers\/store$/,
+        /^\.\.\/\.\.\/lib\/peers\/duplicate-detect$/,
+      ],
+    });
+  });
+
+  test("missing federation token warning fires once when peers expose serve", () => {
+    const warns: string[] = [];
+    const log = { warn: (line: unknown) => warns.push(String(line)) };
+
+    expect(warnMissingFederationTokenOnce(3099, log)).toBe(true);
+    expect(warnMissingFederationTokenOnce(3099, log)).toBe(false);
+
+    expect(warns).toHaveLength(3);
+    expect(warns[0]).toContain("peers configured but no federationToken");
+    expect(warns[1]).toContain("Port 3099 is exposed");
+  });
+
+  test("missing token decision follows bind heuristic and federation token presence", () => {
+    const warns: string[] = [];
+    const log = { warn: (line: unknown) => warns.push(String(line)) };
+    const exposed = { resolveBindHost: () => ({ hostname: "0.0.0.0", reason: "config.peers" as const }) };
+    const local = { resolveBindHost: () => ({ hostname: "127.0.0.1", reason: null }) };
+
+    expect(warnMissingFederationTokenIfNeeded(baseConfig(), 3099, log, local)).toBe(false);
+    expect(warnMissingFederationTokenIfNeeded(baseConfig({ federationToken: "1234567890123456" }), 3099, log, exposed)).toBe(false);
+    expect(warnMissingFederationTokenIfNeeded(baseConfig(), 3099, log, exposed)).toBe(true);
+    expect(warns).toHaveLength(3);
+  });
+
+  test("duplicate identity scan preserves local identity and non-fatal failure logging", () => {
+    const calls: any[] = [];
+    const warns: string[] = [];
+    const log = { warn: (line: unknown) => warns.push(String(line)) };
+
+    expect(warnDuplicatePeerIdentityAtBoot(baseConfig({ oracle: "sender", node: "m5" }), log, {
+      loadPeers: () => ({ peers: { one: { oracle: "sender", node: "m5" } } }),
+      warnDuplicatesAtBoot: (input: any) => { calls.push(input); input.log("duplicate warning"); },
+    })).toBe(true);
+
+    expect(calls[0]).toMatchObject({
+      peers: { one: { oracle: "sender", node: "m5" } },
+      local: { oracle: "sender", node: "m5" },
+    });
+    expect(warns).toEqual(["duplicate warning"]);
+
+    expect(warnDuplicatePeerIdentityAtBoot(baseConfig(), log, {
+      loadPeers: () => { throw new Error("peer store boom"); },
+      warnDuplicatesAtBoot: () => {},
+    })).toBe(false);
+    expect(warns[1]).toBe("[startup] peer dedup scan skipped: peer store boom");
+  });
+
+  test("serve hook runs both startup warning checks", () => {
+    const warns: string[] = [];
+    const duplicateCalls: any[] = [];
+    const result = serve({ port: 3099, log: { warn: (line) => warns.push(String(line)) } }, {
+      loadConfig: () => baseConfig(),
+      resolveBindHost: () => ({ hostname: "0.0.0.0", reason: "peers.json" }),
+      loadPeers: () => ({ peers: { one: { oracle: "mawjs", node: "m5" } } }),
+      warnDuplicatesAtBoot: (input: any) => { duplicateCalls.push(input); },
+    });
+
+    expect(result).toEqual({ ok: true, missingTokenWarned: true, duplicateScanRan: true });
+    expect(warns[1]).toContain("Port 3099");
+    expect(duplicateCalls).toHaveLength(1);
+  });
+
+  test("runServePeerStartupWarnings uses config port when context omits one", () => {
+    const warns: string[] = [];
+    const result = runServePeerStartupWarnings({ log: { warn: (line) => warns.push(String(line)) } }, {
+      loadConfig: () => baseConfig({ port: 4123 }),
+      resolveBindHost: () => ({ hostname: "0.0.0.0", reason: "MAW_HOST" }),
+      loadPeers: () => ({ peers: {} }),
+      warnDuplicatesAtBoot: () => {},
+    });
+
+    expect(result.missingTokenWarned).toBe(true);
+    expect(warns[1]).toContain("Port 4123");
+  });
+});


### PR DESCRIPTION
## Summary
- re-scanned `src/core/server.ts` after #2477 and found remaining lifecycle-shaped startup warnings
- extracted peer exposure and duplicate peer identity boot warnings into `serve-peer-startup-warnings` core vendor plugin
- kept bind/PID/TLS/plugin-bootstrap paths in `server.ts` because they are higher-risk startup gates and need focused coverage before extraction

Refs #2408

## Validation
- `bun test test/isolated/coverage-core-shared-server.test.ts test/isolated/plugin-serve-peer-startup-warnings-standalone.test.ts`
- `bun test test/core/`
- `bun scripts/check-plugin-coverage-gate.ts origin/alpha`
- smoke: `bun src/cli.ts serve 3099 --as smoke-tier3b --quiet` + `curl -sf http://localhost:3099/health`

## Remaining Tier 3 work
- transport router / dispatch engine / feed event wiring
- plugin bootstrap + hot reload lifecycle
- bind/PID/TLS startup gates
- engine health polling lifecycle