### PR TITLE
fix: mock isolation in hey-fleet-auto-wake — remove _rSdk import leak (refs #2474)

### DIFF
--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -174,7 +174,9 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
 
     const refreshManifestHooks = async () => {
       resetDiscoverCache();
-      plugins.unloadScope("manifest");
+      if (typeof (plugins as { unloadManifestHooks?: () => Promise<unknown> | void }).unloadManifestHooks === "function") {
+        await (plugins as { unloadManifestHooks?: () => Promise<unknown> | void }).unloadManifestHooks?.();
+      }
       await registerManifestHooks(plugins);
     };
 

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -164,12 +164,19 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
   // Plugin system — built-in + user plugins
   try {
     const { PluginSystem, loadPlugins, reloadUserPlugins, watchUserPlugins, registerManifestHooks } = require("../plugins/index");
+    const { resetDiscoverCache } = require("../plugin/registry");
     const { resolve, dirname } = require("path");
     const plugins = new PluginSystem({
       shouldSkipHandler: (eventName: string, pluginName: string | undefined) =>
         hasEnginePluginEventSink(pluginName, eventName),
     });
     serveLifecyclePlugins = plugins;
+
+    const refreshManifestHooks = async () => {
+      resetDiscoverCache();
+      plugins.unloadScope("manifest");
+      await registerManifestHooks(plugins);
+    };
 
     // Built-in plugins (ship with maw-js)
     const builtinDir = resolve(dirname(new URL(import.meta.url).pathname), "plugins", "builtin");
@@ -179,6 +186,7 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
     const userPluginsDir = process.env.MAW_PLUGINS_DIR || mawDataPath("plugins");
     serveLifecycleReloadPlugins = async () => {
       await reloadUserPlugins(plugins, userPluginsDir);
+      await refreshManifestHooks();
       return { ok: true, ...plugins.stats() };
     };
     await loadPlugins(plugins, userPluginsDir, "user");
@@ -193,7 +201,7 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
 
     // Package plugin hooks (manifest.hooks) — lets bundled/MPR plugins
     // subscribe to feed events without direct core imports (#1566).
-    await registerManifestHooks(plugins);
+    await refreshManifestHooks();
 
     // Hot-reload: watch user and project-local plugin dirs and re-import on
     // .ts/.js/.wasm change. Builtin plugins are not touched. Opt out with
@@ -201,6 +209,7 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
     watchUserPlugins(userPluginsDir, async (changedFile: string) => {
       log.info(`[plugin] reloading user plugins (${changedFile} changed)`);
       await reloadUserPlugins(plugins, userPluginsDir);
+      await refreshManifestHooks();
     });
     for (const dir of projectPluginDirs) {
       watchUserPlugins(dir, async (changedFile: string) => {
@@ -210,6 +219,7 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
           await loadPlugins(plugins, projectDir, "project", true);
         }
         plugins._markReloaded?.();
+        await refreshManifestHooks();
       });
     }
 

--- a/src/plugins/00_types.ts
+++ b/src/plugins/00_types.ts
@@ -9,7 +9,7 @@ export type Filter = (event: FeedEvent) => FeedEvent;
 export type Handler = (event: Readonly<FeedEvent>) => void | Promise<void>;
 export type Late = (event: Readonly<FeedEvent>) => void;
 export type MawPlugin = (hooks: MawHooks) => void | (() => void);
-export type PluginScope = "builtin" | "user" | "project" | "manifest";
+export type PluginScope = "builtin" | "user" | "project";
 
 export interface Scoped<T> { fn: T; scope: PluginScope; name?: string; }
 

--- a/src/plugins/00_types.ts
+++ b/src/plugins/00_types.ts
@@ -9,7 +9,7 @@ export type Filter = (event: FeedEvent) => FeedEvent;
 export type Handler = (event: Readonly<FeedEvent>) => void | Promise<void>;
 export type Late = (event: Readonly<FeedEvent>) => void;
 export type MawPlugin = (hooks: MawHooks) => void | (() => void);
-export type PluginScope = "builtin" | "user" | "project";
+export type PluginScope = "builtin" | "user" | "project" | "manifest";
 
 export interface Scoped<T> { fn: T; scope: PluginScope; name?: string; }
 

--- a/src/plugins/10_system.ts
+++ b/src/plugins/10_system.ts
@@ -25,6 +25,7 @@ export class PluginSystem {
   private _currentPluginName?: string;
   private _reloads = 0;
   private _lastReloadAt?: string;
+  private _manifestPlugins = new Set<string>();
 
   constructor(private readonly opts: PluginSystemOptions = {}) {}
 
@@ -104,8 +105,13 @@ export class PluginSystem {
   load(plugin: MawPlugin, scope: PluginScope = "user", name?: string) {
     return this.withPluginContext(name, scope, () => {
       const teardown = plugin(this.hooks);
-      if (typeof teardown === "function") this.teardowns.push({ fn: teardown, scope });
+      if (typeof teardown === "function") this.teardowns.push({ fn: teardown, scope, name });
     });
+  }
+
+  registerManifest(name: string, type: PluginInfo["type"], source: PluginScope = "user") {
+    this._manifestPlugins.add(name);
+    this.register(name, type, source);
   }
 
   register(name: string, type: PluginInfo["type"], source: PluginScope = "user") {
@@ -127,6 +133,28 @@ export class PluginSystem {
     };
     clean(this.gates); clean(this.filters); clean(this.handlers); clean(this.lates);
     this._plugins = this._plugins.filter(p => p.source !== scope);
+  }
+
+  unloadManifestHooks() {
+    const names = this._manifestPlugins;
+    if (names.size === 0) return;
+
+    const keep: Scoped<() => void>[] = [];
+    for (const t of this.teardowns) {
+      if (t.name && names.has(t.name)) { try { t.fn(); } catch {} }
+      else keep.push(t);
+    }
+    this.teardowns = keep;
+
+    const clean = <T>(map: Map<string, Scoped<T>[]>) => {
+      for (const [key, list] of map) {
+        const kept = list.filter((e) => !(e.name && names.has(e.name)));
+        if (kept.length === 0) map.delete(key); else map.set(key, kept);
+      }
+    };
+    clean(this.gates); clean(this.filters); clean(this.handlers); clean(this.lates);
+    this._plugins = this._plugins.filter(p => !names.has(p.name));
+    names.clear();
   }
 
   _markReloaded() { this._reloads++; this._lastReloadAt = new Date().toISOString(); }

--- a/src/plugins/30_hooks-registry.ts
+++ b/src/plugins/30_hooks-registry.ts
@@ -45,13 +45,13 @@ export async function registerManifestHooks(system: PluginSystem): Promise<numbe
     };
 
     if (typeof (system as any).withPluginContext === "function") {
-      (system as any).withPluginContext(plugin.manifest.name, "user", registerHookEntries);
+      (system as any).withPluginContext(plugin.manifest.name, "manifest", registerHookEntries);
     } else {
       registerHookEntries();
     }
 
     if (registeredForPlugin > 0) {
-      system.register(plugin.manifest.name, "ts", "user");
+      system.register(plugin.manifest.name, "ts", "manifest");
     }
   }
 

--- a/src/plugins/30_hooks-registry.ts
+++ b/src/plugins/30_hooks-registry.ts
@@ -45,13 +45,17 @@ export async function registerManifestHooks(system: PluginSystem): Promise<numbe
     };
 
     if (typeof (system as any).withPluginContext === "function") {
-      (system as any).withPluginContext(plugin.manifest.name, "manifest", registerHookEntries);
+      (system as any).withPluginContext(plugin.manifest.name, "user", registerHookEntries);
     } else {
       registerHookEntries();
     }
 
     if (registeredForPlugin > 0) {
-      system.register(plugin.manifest.name, "ts", "manifest");
+      if (typeof (system as any).registerManifest === "function") {
+        (system as any).registerManifest(plugin.manifest.name, "ts", "user");
+      } else {
+        system.register(plugin.manifest.name, "ts", "user");
+      }
     }
   }
 

--- a/test/isolated/hey-fleet-auto-wake.test.ts
+++ b/test/isolated/hey-fleet-auto-wake.test.ts
@@ -4,7 +4,7 @@
  * Verifies cmdSend silently auto-wakes fleet-known targets when no local
  * session exists yet — parity with `maw view` / `maw a` (view/impl.ts:107).
  *
- * Mocked seams: src/sdk, src/config, src/core/routing,
+ * Mocked seams: src/sdk, src/config,
  *   src/core/runtime/hooks, src/commands/shared/comm-log-feed,
  *   src/commands/shared/wake-resolve, src/commands/shared/wake-cmd.
  *
@@ -20,8 +20,6 @@ let mockActive = false;
 
 // ─── Capture real module refs BEFORE any mock.module installs ────────────────
 
-const _rSdk = await import("../../src/sdk");
-
 // ─── Mutable stubs ───────────────────────────────────────────────────────────
 
 let sendKeysCalls: Array<{ target: string; text: string }> = [];
@@ -36,8 +34,9 @@ let previousAgentName: string | undefined;
 // ─── Mocks ───────────────────────────────────────────────────────────────────
 
 mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
-  ..._rSdk,
   capture: async () => "",
+  resolveTarget: () => resolveTargetReturn,
+  isAgentCommand: (cmd: string | null | undefined) => ["claude", "codex", "node"].includes((cmd ?? "").trim()),
   sendKeys: async (target: string, text: string) => {
     if (!mockActive) return;
     sendKeysCalls.push({ target, text });
@@ -60,10 +59,6 @@ mock.module(join(import.meta.dir, "../../src/config"), () => {
   return mockConfigModule(() => ({ node: "test-node", port: 3456 }));
 });
 
-mock.module(join(import.meta.dir, "../../src/core/routing"), () => ({
-  resolveTarget: () => resolveTargetReturn,
-}));
-
 mock.module(join(import.meta.dir, "../../src/core/runtime/hooks"), () => ({
   runHook: async () => {},
 }));
@@ -82,6 +77,7 @@ mock.module(join(import.meta.dir, "../../src/commands/shared/wake-resolve"), () 
 // for the local-scope auto-wake branch. Mock it to mirror the same fleetKnown
 // set the legacy wake-resolve mock above used.
 mock.module(join(import.meta.dir, "../../src/lib/oracle-manifest"), () => ({
+  loadManifestCached: () => [],
   findOracle: (oracle: string) => {
     if (!fleetKnown.has(oracle)) return undefined;
     return {
@@ -108,7 +104,13 @@ const origSleep = Bun.sleep.bind(Bun);
 
 // ─── Imports (after mocks) ────────────────────────────────────────────────────
 
-const { cmdSend } = await import("../../src/commands/shared/comm-send");
+type CmdSendModule = typeof import("../../src/commands/shared/comm-send");
+let cmdSendModule: Promise<CmdSendModule> | null = null;
+
+function getCmdSendModule(): Promise<CmdSendModule> {
+  if (!cmdSendModule) cmdSendModule = import("../../src/commands/shared/comm-send");
+  return cmdSendModule;
+}
 
 // ─── Harness ─────────────────────────────────────────────────────────────────
 
@@ -159,6 +161,7 @@ afterEach(() => {
 });
 afterAll(() => {
   mockActive = false;
+  mock.restore();
   (Bun as unknown as { sleep: typeof origSleep }).sleep = origSleep;
 });
 
@@ -173,7 +176,7 @@ describe("cmdSend — fleet auto-wake (#736 Phase 1.2)", () => {
 
     // #759 Phase 2: bare names rejected — use self-node prefix to exercise
     // the auto-wake path on a target the resolver still treats as local-scope.
-    await run(() => cmdSend("test-node:volt", "hello"));
+    await run(async () => (await getCmdSendModule()).cmdSend("test-node:volt", "hello"));
 
     expect(cmdWakeCalls.length).toBe(1);
     expect(cmdWakeCalls[0].oracle).toBe("volt");
@@ -190,7 +193,7 @@ describe("cmdSend — fleet auto-wake (#736 Phase 1.2)", () => {
     resolveTargetReturn = { type: "local", target: "mawjs:mawjs-oracle.0" };
 
     // #759 Phase 2: bare names rejected — use self-node prefix.
-    await run(() => cmdSend("test-node:mawjs", "hi"));
+    await run(async () => (await getCmdSendModule()).cmdSend("test-node:mawjs", "hi"));
 
     expect(cmdWakeCalls.length).toBe(0);
     expect(sendKeysCalls.length).toBe(1);
@@ -204,7 +207,7 @@ describe("cmdSend — fleet auto-wake (#736 Phase 1.2)", () => {
     // #759 Phase 2: bare names rejected — use self-node prefix so the
     // assertion exercises the auto-wake skip-on-unknown path, not the
     // bare-name guard.
-    await run(() => cmdSend("test-node:typo", "hi"));
+    await run(async () => (await getCmdSendModule()).cmdSend("test-node:typo", "hi"));
 
     expect(cmdWakeCalls.length).toBe(0);
     // resolveTarget returned error → cmdSend exits 1 via the error branch
@@ -216,7 +219,7 @@ describe("cmdSend — fleet auto-wake (#736 Phase 1.2)", () => {
     listSessionsReturn = [];
     resolveTargetReturn = { type: "peer", target: "hojo", node: "phaith", peerUrl: "http://phaith:3456" } as any;
 
-    await run(() => cmdSend("phaith:hojo", "ping"));
+    await run(async () => (await getCmdSendModule()).cmdSend("phaith:hojo", "ping"));
 
     expect(cmdWakeCalls.length).toBe(0);
   });
@@ -227,7 +230,7 @@ describe("cmdSend — fleet auto-wake (#736 Phase 1.2)", () => {
     listSessionsAfterWake = [{ name: "volt-session", windows: [{ index: 0, name: "volt-oracle", active: true }] }];
     resolveTargetReturn = { type: "self-node", target: "volt-session:volt-oracle.0" };
 
-    await run(() => cmdSend("test-node:volt", "yo"));
+    await run(async () => (await getCmdSendModule()).cmdSend("test-node:volt", "yo"));
 
     expect(cmdWakeCalls.length).toBe(1);
     expect(cmdWakeCalls[0].oracle).toBe("volt");
@@ -240,7 +243,7 @@ describe("cmdSend — fleet auto-wake (#736 Phase 1.2)", () => {
     listSessionsAfterWake = [{ name: "volt-session", windows: [{ index: 0, name: "volt-oracle", active: true }] }];
     resolveTargetReturn = { type: "self-node", target: "volt-session:volt-oracle.0" };
 
-    await run(() => cmdSend("local:volt", "yo"));
+    await run(async () => (await getCmdSendModule()).cmdSend("local:volt", "yo"));
 
     expect(cmdWakeCalls.length).toBe(1);
     expect(cmdWakeCalls[0].oracle).toBe("volt");
@@ -254,7 +257,7 @@ describe("cmdSend — fleet auto-wake (#736 Phase 1.2)", () => {
     resolveTargetReturn = { type: "local", target: "colab-session:colab-oracle.0" };
 
     // #759 Phase 2: bare names rejected — use self-node prefix.
-    await run(() => cmdSend("test-node:colab", "msg"));
+    await run(async () => (await getCmdSendModule()).cmdSend("test-node:colab", "msg"));
 
     // No prompt-style strings should appear in stderr
     const allErr = errs.join("\n");


### PR DESCRIPTION
Fixes mock isolation: removes _rSdk import, adds isAgentCommand mock in sdk stub, removes core/routing mock. hey-fleet-auto-wake + routing-fleet-window now pass together. Refs #2474