### PR TITLE
feat: extract serve engine health polling

### DIFF
--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -13,7 +13,6 @@ import {
   findEnginePluginRegistration,
   hasEnginePluginEventSink,
   proxyEnginePluginRequest,
-  startEnginePluginHealthPolling,
 } from "./engine-plugin-registry";
 import { mawDataPath } from "./xdg";
 import { UserError } from "./util/user-error";
@@ -273,7 +272,6 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
     throw err;
   }
   setBunServer(server);
-  startEnginePluginHealthPolling();
 
   const bindNote = reason ? ` (${reason})` : "";
   log.info(`maw ${VERSION} serve → ${HTTP_URL} (${WS_URL}) [${hostname}]${bindNote}`);

--- a/src/vendor-plugins/serve-engine-health-polling/index.ts
+++ b/src/vendor-plugins/serve-engine-health-polling/index.ts
@@ -1,0 +1,27 @@
+import { startEnginePluginHealthPolling as defaultStartEnginePluginHealthPolling } from "../../core/engine-plugin-registry";
+
+type ServeEngineHealthPollingDeps = {
+  startEnginePluginHealthPolling: typeof defaultStartEnginePluginHealthPolling;
+};
+
+type StopPolling = ReturnType<typeof defaultStartEnginePluginHealthPolling>;
+
+const defaultDeps: ServeEngineHealthPollingDeps = {
+  startEnginePluginHealthPolling: defaultStartEnginePluginHealthPolling,
+};
+
+export function startServeEngineHealthPolling(
+  deps: Partial<ServeEngineHealthPollingDeps> = {},
+): { ok: true; stopPolling: StopPolling } {
+  const d = { ...defaultDeps, ...deps };
+  return { ok: true, stopPolling: d.startEnginePluginHealthPolling() };
+}
+
+export function serve(
+  _ctx: Record<string, unknown> = {},
+  deps?: Partial<ServeEngineHealthPollingDeps>,
+): { ok: true; stopPolling: StopPolling } {
+  return startServeEngineHealthPolling(deps);
+}
+
+export default serve;

--- a/src/vendor-plugins/serve-engine-health-polling/plugin.json
+++ b/src/vendor-plugins/serve-engine-health-polling/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "serve-engine-health-polling",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "tier": "core",
+  "description": "Starts maw serve engine-plugin health polling during serve lifecycle startup.",
+  "author": "Soul-Brews-Studio",
+  "hooks": {
+    "serve": {
+      "script": "./index.ts",
+      "handler": "serve",
+      "ensures": ["serve:engine:health-polling"],
+      "policy": "fail-fast"
+    }
+  },
+  "module": {
+    "path": "./index.ts",
+    "exports": ["serve", "startServeEngineHealthPolling"]
+  },
+  "capabilities": ["serve:engine", "engine:health-polling"],
+  "capabilityNamespaces": ["serve", "engine"],
+  "weight": 3,
+  "license": "MIT",
+  "schemaVersion": 1
+}

--- a/test/isolated/coverage-core-shared-server.test.ts
+++ b/test/isolated/coverage-core-shared-server.test.ts
@@ -245,7 +245,10 @@ describe("coverage core shared server", () => {
       reloadPlugins: expect.any(Function),
     });
     expect((lifecyclePayloads[0] as any).http).toEqual(expect.objectContaining({ route: expect.any(Function) }));
-    expect(healthPolls).toBe(1);
+    // Engine plugin health polling moved to serve-engine-health-polling; this
+    // isolated server.ts test mocks lifecycle hooks and therefore does not run
+    // plugin-owned startup work directly.
+    expect(healthPolls).toBe(0);
 
     const ws = serveCalls[0].websocket;
     const normal = { data: {} };

--- a/test/isolated/plugin-serve-engine-health-polling-standalone.test.ts
+++ b/test/isolated/plugin-serve-engine-health-polling-standalone.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
+import {
+  serve,
+  startServeEngineHealthPolling,
+} from "../../src/vendor-plugins/serve-engine-health-polling/index.ts?plugin-serve-engine-health-polling-standalone";
+
+const root = join(import.meta.dir, "../..");
+
+describe("serve-engine-health-polling plugin standalone boundary", () => {
+  test("declares fail-fast serve hook for engine health polling", () => {
+    const manifest = JSON.parse(readFileSync(join(root, "src/vendor-plugins/serve-engine-health-polling/plugin.json"), "utf8"));
+    expect(manifest.hooks.serve).toMatchObject({ script: "./index.ts", handler: "serve", policy: "fail-fast" });
+    expect(manifest.api).toBeUndefined();
+    expect(manifest.module.exports).toContain("startServeEngineHealthPolling");
+  });
+
+  test("boundary drift is explicit for this core lifecycle plugin", () => {
+    expectStandalonePluginBoundary({
+      plugin: "serve-engine-health-polling",
+      pluginDir: "src/vendor-plugins/serve-engine-health-polling",
+      requireSdk: false,
+      allowRelative: [/^\.\.\/\.\.\/core\/engine-plugin-registry$/],
+    });
+  });
+
+  test("startServeEngineHealthPolling delegates to engine registry and returns stop handle", () => {
+    const calls: string[] = [];
+    const stop = () => { calls.push("stop"); };
+    const result = startServeEngineHealthPolling({
+      startEnginePluginHealthPolling: (() => { calls.push("start"); return stop; }) as any,
+    });
+
+    expect(result).toEqual({ ok: true, stopPolling: stop });
+    expect(calls).toEqual(["start"]);
+    result.stopPolling?.();
+    expect(calls).toEqual(["start", "stop"]);
+  });
+
+  test("serve hook starts polling", () => {
+    let count = 0;
+    const result = serve({}, {
+      startEnginePluginHealthPolling: (() => { count += 1; return undefined; }) as any,
+    });
+    expect(result).toEqual({ ok: true, stopPolling: undefined });
+    expect(count).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- re-scanned `src/core/server.ts` after #2478
- extracted direct `startEnginePluginHealthPolling()` startup into `serve-engine-health-polling` core vendor plugin
- updated isolated server coverage to assert health polling is now plugin-owned

Refs #2408
Refs #2475

## Validation
- `bun test test/isolated/core-server-more-coverage-2.test.ts test/isolated/coverage-core-shared-server.test.ts test/isolated/plugin-serve-engine-health-polling-standalone.test.ts`
- `bun test test/core/`
- `bun scripts/check-plugin-coverage-gate.ts origin/alpha`
- smoke: `bun src/cli.ts serve 3099 --as smoke-tier3c --quiet` + `curl -sf http://localhost:3099/health`

## Remaining Tier 3 work
- transport router / dispatch engine / feed event wiring
- plugin bootstrap + hot reload lifecycle
- bind/PID/TLS startup gates

Not marking serve extraction complete yet.