### PR TITLE
fix: mock isolation batch 3 (refs #2474)

### DIFF
--- a/test/isolated/comm-send-thirteenth-pass-coverage.test.ts
+++ b/test/isolated/comm-send-thirteenth-pass-coverage.test.ts
@@ -62,7 +62,20 @@ mock.module(join(srcRoot, "src/core/transport/tmux"), () => {
 });
 
 mock.module(join(srcRoot, "src/sdk/index.ts"), () => ({
+  // Keep broad: Bun evaluates isolated test modules in one process, so this
+  // mock can be visible to later files before their file-level cleanup runs.
+  hostExec: async () => "",
+  parseFlags: () => ({}),
+  getGhqRoot: () => "",
+  loadFleetCore: () => [],
   listSessions: async () => listSessionsReturn,
+  resolveTarget: () => resolveTargetReturn,
+  curlFetch: async (url: string, options: any) => {
+    curlFetchCalls.push({ url, options });
+    return curlFetchHandler(url, options);
+  },
+  tmuxCmd: () => "tmux",
+  resolveSocket: () => undefined,
   capture: async () => {
     const next = captureResponses.shift();
     if (next instanceof Error) throw next;
@@ -72,16 +85,53 @@ mock.module(join(srcRoot, "src/sdk/index.ts"), () => ({
     sendKeysCalls.push({ target, text });
   },
   getPaneCommand: async () => getPaneCommandReturn,
+  getPaneCommands: async () => [],
+  getPaneInfos: async () => [],
   isAgentCommand: (cmd: string | null | undefined) => ["claude", "codex", "node"].includes((cmd ?? "").trim()),
   findPeerForTarget: async () => findPeerUrl,
-  resolveTarget: () => resolveTargetReturn,
-  curlFetch: async (url: string, options: any) => {
-    curlFetchCalls.push({ url, options });
-    return curlFetchHandler(url, options);
-  },
   runHook: async (name: string, payload: any) => {
     runHookCalls.push({ name, payload });
   },
+  withPaneLock: async (fn: () => Promise<unknown>) => fn(),
+  splitWindowLocked: async () => "%1",
+  tagPane: async () => undefined,
+  readPaneTags: async () => ({}),
+  Tmux: class { async killSession() {} },
+  tmux: { listPaneIds: async () => new Set<string>(), listSessions: async () => [] },
+  resolveOraclePane: async (target: string) => target,
+  cmdSleep: async () => undefined,
+  cmdWakeAll: async () => undefined,
+  C: { green: "", red: "", yellow: "", gray: "", reset: "" },
+  invalidateManifest: () => undefined,
+  isMawXdgEnabled: () => false,
+  loadManifestCached: () => null,
+  legacyMawPath: (...parts: string[]) => ["/tmp", ".maw", ...parts].join("/"),
+  mawCacheDir: () => "/tmp/.maw/cache",
+  mawConfigDir: () => "/tmp/.maw/config",
+  mawDataDir: () => "/tmp/.maw",
+  mawDataPath: (...parts: string[]) => ["/tmp", ".maw", ...parts].join("/"),
+  mawStateDir: () => "/tmp/.maw/state",
+  mawStatePath: (...parts: string[]) => ["/tmp", ".maw", "state", ...parts].join("/"),
+  loadConfig: () => ({}),
+  ghqFindSync: () => "",
+  cmdWorkspaceCreate: async () => undefined,
+  cmdWorkspaceJoin: async () => undefined,
+  cmdWorkspaceShare: async () => undefined,
+  cmdWorkspaceUnshare: async () => undefined,
+  cmdWorkspaceLs: async () => undefined,
+  cmdWorkspaceAgents: async () => undefined,
+  cmdWorkspaceInvite: async () => undefined,
+  cmdWorkspaceLeave: async () => undefined,
+  cmdWorkspaceTeam: async () => undefined,
+  cmdWorkspaceStop: async () => undefined,
+  cmdWorkspaceSessions: async () => undefined,
+  cmdWorkspaceWhere: async () => undefined,
+  cmdWorkspaceStatus: async () => undefined,
+  cmdWorkspaceSend: async () => undefined,
+  cmdWorkspaceInspect: async () => undefined,
+  cmdWorkspaceSnapshot: async () => undefined,
+  cmdWorkspaceRestore: async () => undefined,
+  cmdWorkspaceClean: async () => undefined,
 }));
 
 mock.module(join(srcRoot, "src/config"), () => ({
@@ -211,6 +261,10 @@ beforeEach(() => {
   process.env.CLAUDE_AGENT_NAME = "sender";
   delete process.env.MAW_CONSENT;
   delete process.env.MAW_ACL_BYPASS;
+});
+
+afterAll(() => {
+  mock.restore();
 });
 
 afterEach(() => {

--- a/test/isolated/tile-impl-next-coverage.test.ts
+++ b/test/isolated/tile-impl-next-coverage.test.ts
@@ -4,6 +4,10 @@ import { join } from "path";
 
 const root = join(import.meta.dir, "../..");
 
+// This file imports tile impl at module scope; reset mocks first so earlier
+// isolated files cannot leak a partial src/sdk/index.ts shim into that import.
+mock.restore();
+
 let commands: string[] = [];
 let tilePaneList = "%lead|||leader|||\n";
 let plainPaneList = "%lead\n";
@@ -19,7 +23,7 @@ let layoutCalls: string[] = [];
 let borderCalls: Array<{ paneId: string; label: string; color: string }> = [];
 const originalTileCmdSettle = process.env.MAW_TILE_CMD_SETTLE_MS;
 
-mock.module(join(root, "src/sdk"), () => ({
+const sdkMock = () => ({
   hostExec: async (cmd: string) => {
     commands.push(cmd);
 
@@ -52,7 +56,12 @@ mock.module(join(root, "src/sdk"), () => ({
     }
     return "";
   },
-}));
+});
+
+// Mock both ids: tile imports ../../../sdk, which resolves to src/sdk/index.ts.
+// Earlier isolated tests can leak an index.ts mock that otherwise shadows this.
+mock.module(join(root, "src/sdk"), sdkMock);
+mock.module(join(root, "src/sdk/index.ts"), sdkMock);
 
 mock.module(join(root, "src/commands/plugins/tmux/layout-manager"), () => ({
   nextAgentColor: (idx: number) => `color-${idx}`,


### PR DESCRIPTION
## Summary
- broaden `comm-send-thirteenth-pass` SDK mock so it does not leak a partial SDK into later files
- make tile coverage reset prior mocks before module-scope impl import
- mock both `src/sdk` and `src/sdk/index.ts` for tile so exact-path SDK leaks cannot shadow tile behavior

Refs #2474

## Validation
- `bun test test/isolated/comm-send-thirteenth-pass-coverage.test.ts test/isolated/tile-impl-next-coverage.test.ts`
- `bun test test/isolated/coverage-next-vendor-b-dispatchers.test.ts test/isolated/dream-impl-more-coverage.test.ts test/isolated/coverage-100-last-five.test.ts test/isolated/doctor-impl-second-pass-coverage.test.ts test/isolated/comm-send-thirteenth-pass-coverage.test.ts test/isolated/tile-impl-next-coverage.test.ts`
- `bun scripts/check-plugin-coverage-gate.ts origin/alpha`

## Notes
#2481 already merged the first SDK mock leak batch. This follow-up fixes the comm-send → tile import-order cluster. Full isolated suite still has unrelated registry/fleet-load/dispatch clusters.
