### PR TITLE
fix: mock isolation batch 4 (refs #2474)

### DIFF
--- a/test/isolated/bud-from-repo-fleet-coverage.test.ts
+++ b/test/isolated/bud-from-repo-fleet-coverage.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import * as realChildProcess from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
@@ -13,6 +13,11 @@ process.env.MAW_TEST_MODE = "1";
 mkdirSync(join(configDir, "fleet"), { recursive: true });
 
 const sdkMock = {
+  // Keep broad enough not to poison later isolated imports of maw-js/sdk.
+  hostExec: async () => "",
+  listSessions: async () => [],
+  loadFleetCore: () => [],
+  getGhqRoot: () => process.cwd(),
   FLEET_DIR: join(configDir, "fleet"),
   fleetLoadDirForWrite: () => join(configDir, "fleet"),
   loadFleetEntries: () => existsSync(join(configDir, "fleet"))
@@ -64,6 +69,14 @@ function readJson(file: string) {
 
 beforeEach(() => {
   resetFleet();
+});
+
+afterAll(() => {
+  mock.restore();
+  delete process.env.MAW_CONFIG_DIR;
+  delete process.env.MAW_STATE_DIR;
+  delete process.env.MAW_TEST_MODE;
+  rmSync(tempRoot, { recursive: true, force: true });
 });
 
 describe("bud from-repo fleet coverage", () => {

--- a/test/isolated/coverage-vendor-dream-bud-find.test.ts
+++ b/test/isolated/coverage-vendor-dream-bud-find.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { join, resolve } from "path";
 
+// Reset process-wide mocks before importing real modules for this file.
+mock.restore();
+
 const realFs = await import("fs");
 const realSdk = await import("../../src/sdk");
 
@@ -35,7 +38,7 @@ function shSingleQuote(value: string): string {
 
 mock.module("fs", () => ({
   ...realFs,
-  existsSync: (path: string) => existingPaths.has(path),
+  existsSync: (path: string) => existingPaths.has(path) || (path.includes("maw-audit-") && realFs.existsSync(path)),
   readdirSync: (path: string) => (readdirEntries.get(path) ?? []) as ReturnType<typeof realFs.readdirSync>,
 }));
 

--- a/test/isolated/dispatch-runtime-coverage.test.ts
+++ b/test/isolated/dispatch-runtime-coverage.test.ts
@@ -1,5 +1,8 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
+// Reset leaked mocks before registering dispatch-specific shims.
+mock.restore();
+
 function at(path: string): string {
   return new URL(path, import.meta.url).pathname;
 }
@@ -32,6 +35,16 @@ let exitCode: number | undefined;
 const originalExit = process.exit;
 const originalLog = console.log;
 const originalError = console.error;
+
+Object.defineProperty(globalThis, "__dispatchRuntimePlugins", {
+  configurable: true,
+  value: () => plugins,
+});
+Object.defineProperty(globalThis, "__dispatchRuntimeInvokeResult", {
+  configurable: true,
+  value: () => invokeResult,
+});
+(globalThis as any).__dispatchRuntimeInvokeCalls = invokeCalls;
 
 mock.module(at("../../src/cli/route-comm"), () => ({
   routeComm: async (cmd: string, args: string[]) => {
@@ -172,6 +185,9 @@ beforeEach(() => {
 });
 
 afterAll(() => {
+  delete (globalThis as any).__dispatchRuntimePlugins;
+  delete (globalThis as any).__dispatchRuntimeInvokeResult;
+  delete (globalThis as any).__dispatchRuntimeInvokeCalls;
   console.log = originalLog;
   console.error = originalError;
   (process as any).exit = originalExit;

--- a/test/isolated/fleet-audit-more-coverage.test.ts
+++ b/test/isolated/fleet-audit-more-coverage.test.ts
@@ -4,9 +4,17 @@
  */
 
 import { afterAll, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "fs";
-import { tmpdir } from "os";
+import * as realFs from "node:fs";
+import * as realOs from "node:os";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "path";
+import { mock } from "bun:test";
+
+// Reset leaked mocks before importing audit helpers at module scope.
+mock.restore();
+mock.module("fs", () => realFs);
+mock.module("os", () => realOs);
 
 const mawConfigDir = mkdtempSync(join(tmpdir(), "maw-audit-config-"));
 const mawStateDir = mkdtempSync(join(tmpdir(), "maw-audit-state-"));

--- a/test/isolated/instance-preset-token-load-extra-coverage.test.ts
+++ b/test/isolated/instance-preset-token-load-extra-coverage.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { homedir as realHomedir } from "os";
@@ -53,7 +53,15 @@ mock.module(tokenLibPath, () => ({
 }));
 
 mock.module(pluginsRegistryPath, () => ({
-  discoverPackages: () => registryDiscoverResult,
+  // Keep broad: this registry mock can be visible to later isolated files.
+  discoverPackages: () => (globalThis as any).__dispatchRuntimePlugins?.() ?? registryDiscoverResult,
+  hashFile: () => "mock-hash",
+  importPluginSymbol: async () => undefined,
+  invokePlugin: async (plugin: any, ctx: any) => {
+    (globalThis as any).__dispatchRuntimeInvokeCalls?.push({ plugin, ctx });
+    return (globalThis as any).__dispatchRuntimeInvokeResult?.() ?? { ok: true };
+  },
+  resetDiscoverCache: () => undefined,
 }));
 
 mock.module(pluginsLsInfoPath, () => ({
@@ -138,6 +146,10 @@ afterEach(() => {
   if (originalMawHome === undefined) delete process.env.MAW_HOME;
   else process.env.MAW_HOME = originalMawHome;
   for (const dir of tempRoots) rmSync(dir, { recursive: true, force: true });
+});
+
+afterAll(() => {
+  mock.restore();
 });
 
 describe("applyInstancePreset isolated branches", () => {

--- a/test/isolated/tmux-layout-manager.test.ts
+++ b/test/isolated/tmux-layout-manager.test.ts
@@ -1,5 +1,8 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { join } from "path";
+
+// Reset process-wide mocks before importing the real SDK for this file.
+mock.restore();
 
 const realSdk = await import("../../src/sdk");
 
@@ -7,8 +10,11 @@ let commands: string[] = [];
 let paneHeights = "12\n8\n4";
 let queryError: Error | null = null;
 
-mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
+const sdkMock = () => ({
   ...realSdk,
+  // Keep broad enough for later module evaluation if this mock leaks.
+  loadFleetCore: () => [],
+  getGhqRoot: () => process.cwd(),
   hostExec: async (cmd: string) => {
     commands.push(cmd);
     if (cmd.includes("list-panes") && cmd.includes("#{pane_height}")) {
@@ -17,13 +23,20 @@ mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
     }
     return "";
   },
-}));
+});
+
+mock.module(join(import.meta.dir, "../../src/sdk"), sdkMock);
+mock.module(join(import.meta.dir, "../../src/sdk/index.ts"), sdkMock);
 
 const {
   canEnableBorderStatus,
   enableBorderStatus,
   MIN_BORDER_STATUS_PANE_HEIGHT,
 } = await import("../../src/commands/plugins/tmux/layout-manager");
+
+afterAll(() => {
+  mock.restore();
+});
 
 describe("tmux layout-manager border status guard (#1468)", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- broaden early `maw-js/sdk` mocks so later SDK imports have `hostExec`, `listSessions`, and `loadFleetCore`
- broaden/cleanup the instance plugin registry mock so `coverage-100c` and dispatch runtime coverage no longer inherit a partial registry surface
- guard dispatch runtime globals when an earlier registry mock is still visible
- narrow coverage-vendor fs fallback and make fleet-audit use real node fs/os surfaces
- mock both `src/sdk` and `src/sdk/index.ts` for tmux layout coverage

Refs #2474

## Validation
- `bun test test/isolated/instance-preset-token-load-extra-coverage.test.ts test/isolated/coverage-100c-executable-gaps.test.ts test/isolated/dispatch-runtime-coverage.test.ts`
- `bun test test/isolated/bud-from-repo-fleet-coverage.test.ts test/isolated/coverage-vendor-dream-bud-find.test.ts`
- `bun test test/isolated/tmux-layout-manager.test.ts test/isolated/coverage-vendor-dream-bud-find.test.ts`
- `bun scripts/check-plugin-coverage-gate.ts origin/alpha`

## Notes
This is batch 4 after confirming the single-process isolated run still had 59 broad fail/error markers. It targets the early-file SDK/plugin-registry/fs mock leak cluster; remaining full-suite clusters are intentionally left for later batches.
