### PR TITLE
fix: mock isolation batch 5 (refs #2474)

### DIFF
--- a/test/isolated/coverage-vendor-dream-bud-find.test.ts
+++ b/test/isolated/coverage-vendor-dream-bud-find.test.ts
@@ -1,14 +1,15 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { join, resolve } from "path";
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "path";
 
 // Reset process-wide mocks before importing real modules for this file.
 mock.restore();
 
-const realFs = await import("fs");
 const realSdk = await import("../../src/sdk");
 
-const repoRoot = process.cwd();
-const ghqRoot = resolve(repoRoot, "../../../..");
+const tempRoot = mkdtempSync(join(tmpdir(), "maw-find-coverage-"));
+const ghqRoot = join(tempRoot, "ghq");
 const reposRoot = join(ghqRoot, "github.com");
 
 interface FleetSession {
@@ -18,29 +19,15 @@ interface FleetSession {
   project_repos?: string[];
 }
 
-type DirEntryLike = { name: string; isDirectory: () => boolean };
-
 let mockedFleet: FleetSession[] = [];
-let existingPaths = new Set<string>();
-let readdirEntries = new Map<string, DirEntryLike[]>();
 let searchFiles = new Map<string, string[]>();
 let matchLines = new Map<string, string>();
 let hostExecCalls: string[] = [];
 let logs: string[] = [];
 
-function dir(name: string): DirEntryLike {
-  return { name, isDirectory: () => true };
-}
-
 function shSingleQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
 }
-
-mock.module("fs", () => ({
-  ...realFs,
-  existsSync: (path: string) => existingPaths.has(path) || (path.includes("maw-audit-") && realFs.existsSync(path)),
-  readdirSync: (path: string) => (readdirEntries.get(path) ?? []) as ReturnType<typeof realFs.readdirSync>,
-}));
 
 mock.module("maw-js/config/ghq-root", () => ({
   getGhqRoot: () => ghqRoot,
@@ -81,8 +68,6 @@ const originalLog = console.log;
 
 beforeEach(() => {
   mockedFleet = [];
-  existingPaths = new Set<string>();
-  readdirEntries = new Map<string, DirEntryLike[]>();
   searchFiles = new Map<string, string[]>();
   matchLines = new Map<string, string>();
   hostExecCalls = [];
@@ -96,6 +81,11 @@ afterEach(() => {
   console.log = originalLog;
 });
 
+afterAll(() => {
+  mock.restore();
+  rmSync(tempRoot, { recursive: true, force: true });
+});
+
 describe("find impl fleet psi coverage", () => {
   test("searches fleet repo psi memory and renders overflow when more than ten code matches exist", async () => {
     const orgPath = join(reposRoot, "Soul-Brews-Studio");
@@ -103,9 +93,7 @@ describe("find impl fleet psi coverage", () => {
     const psiPath = join(repoPath, "ψ", "memory");
     const files = Array.from({ length: 12 }, (_, index) => join(psiPath, "notes", `hit-${index}.md`));
 
-    readdirEntries.set(reposRoot, [dir("Soul-Brews-Studio")]);
-    readdirEntries.set(orgPath, []);
-    existingPaths.add(psiPath);
+    mkdirSync(psiPath, { recursive: true });
     searchFiles.set(psiPath, files);
     for (const [index, file] of files.entries()) {
       matchLines.set(file, `needle line ${index}`);

--- a/test/isolated/fleet-audit-more-coverage.test.ts
+++ b/test/isolated/fleet-audit-more-coverage.test.ts
@@ -3,16 +3,17 @@
  * @maw-test-isolate
  */
 
-import { afterAll, describe, expect, test } from "bun:test";
-import * as realFs from "node:fs";
-import * as realOs from "node:os";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { afterAll, describe, expect, mock, test } from "bun:test";
 import { join } from "path";
-import { mock } from "bun:test";
 
-// Reset leaked mocks before importing audit helpers at module scope.
+// Reset leaked mocks before importing audit helpers or real node modules.
 mock.restore();
+
+const realFs = await import("node:fs");
+const realOs = await import("node:os");
+const { existsSync, mkdtempSync, readFileSync, rmSync } = realFs;
+const { tmpdir } = realOs;
+
 mock.module("fs", () => realFs);
 mock.module("os", () => realOs);
 


### PR DESCRIPTION
## Summary
- replace `coverage-vendor-dream-bud-find`'s global fs mock with a real temp ghq tree
- keep the find test's SDK/fleet mocks but remove the fs shim that blocked later audit tests
- make fleet-audit clear leaked mocks before dynamically importing real node fs/os and audit helpers

Refs #2474

## Validation
- `bun test test/isolated/coverage-vendor-dream-bud-find.test.ts test/isolated/fleet-audit-more-coverage.test.ts`
- `bun test test/isolated/bud-from-repo-fleet-coverage.test.ts test/isolated/plugin-serve-debug-standalone.test.ts test/isolated/instance-preset-token-load-extra-coverage.test.ts test/isolated/coverage-100c-executable-gaps.test.ts test/isolated/tmux-layout-manager.test.ts test/isolated/coverage-vendor-dream-bud-find.test.ts test/isolated/plugin-search-peers-next-coverage.test.ts test/isolated/fleet-audit-more-coverage.test.ts test/isolated/dispatch-runtime-coverage.test.ts`
- `bun scripts/check-plugin-coverage-gate.ts origin/alpha`

## Notes
Batch 5 fixes the current single-process isolated hang at `fleet-audit-more-coverage`. After this, the exploratory full-run sample advanced to later fleet-load/registry/SDK/tile clusters; sample broad marker count was 34.
