### PR TITLE
fix: mock isolation batch 6 (refs #2474)

### DIFF
--- a/test/isolated/attach-impl-coverage.test.ts
+++ b/test/isolated/attach-impl-coverage.test.ts
@@ -5,8 +5,12 @@
  * this file runs only under scripts/test-isolated.sh and keeps all dependencies
  * mocked at the module boundary.
  */
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { join } from "path";
+
+
+// Reset process-wide mocks before registering this file's shims.
+mock.restore();
 
 const attachRoot = join(import.meta.dir, "../../src/vendor/mpr-plugins/attach");
 
@@ -48,13 +52,34 @@ const original = {
 const listSessions = async () => sessions;
 const loadFleet = () => fleet;
 
-mock.module("maw-js/sdk", () => ({
+const sdkMock = () => ({
   getGhqRoot: () => "/tmp/ghq",
   hostExec: async () => "",
+  capture: async () => "",
+  sendKeys: async () => undefined,
+  getPaneCommand: async () => "",
+  getPaneCommands: async () => [],
+  getPaneInfos: async () => [],
+  isAgentCommand: () => false,
+  resolveTarget: () => null,
+  curlFetch: async () => ({ ok: false }),
+  findPeerForTarget: async () => null,
   listSessions,
   loadFleetCore: loadFleet,
+  runHook: async () => undefined,
+  withPaneLock: async (fn: () => Promise<unknown>) => fn(),
+  splitWindowLocked: async () => "%1",
+  tagPane: async () => undefined,
+  readPaneTags: async () => ({}),
+  Tmux: class { async killSession() {} },
+  tmuxCmd: () => "tmux",
+  resolveSocket: () => undefined,
+  tmux: { listPaneIds: async () => new Set<string>(), listSessions: async () => [] },
   UserError: class UserError extends Error { readonly isUserError = true; },
-}));
+});
+mock.module("maw-js/sdk", sdkMock);
+mock.module(import.meta.resolve("../../src/sdk"), sdkMock);
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), sdkMock);
 
 mock.module(import.meta.resolve("../../src/commands/plugins/tmux/impl"), () => ({
   cmdTmuxAttach: (target: string) => {
@@ -131,6 +156,10 @@ afterEach(() => {
   console.error = original.error;
   Bun.spawn = original.spawn;
   Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: original.stdinIsTTY });
+});
+
+afterAll(() => {
+  mock.restore();
 });
 
 describe("attach impl command routing", () => {

--- a/test/isolated/comm-send-thirteenth-pass-coverage.test.ts
+++ b/test/isolated/comm-send-thirteenth-pass-coverage.test.ts
@@ -7,6 +7,10 @@
 import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { join } from "path";
 
+
+// Reset process-wide mocks before registering this file's shims.
+mock.restore();
+
 const srcRoot = join(import.meta.dir, "../..");
 
 type ResolvedTarget =
@@ -61,7 +65,7 @@ mock.module(join(srcRoot, "src/core/transport/tmux"), () => {
   return { Tmux: MockTmux, tmux: new MockTmux(), tmuxCmd: () => "tmux", resolveSocket: () => undefined };
 });
 
-mock.module(join(srcRoot, "src/sdk/index.ts"), () => ({
+const sdkMock = () => ({
   // Keep broad: Bun evaluates isolated test modules in one process, so this
   // mock can be visible to later files before their file-level cleanup runs.
   hostExec: async () => "",
@@ -132,12 +136,21 @@ mock.module(join(srcRoot, "src/sdk/index.ts"), () => ({
   cmdWorkspaceSnapshot: async () => undefined,
   cmdWorkspaceRestore: async () => undefined,
   cmdWorkspaceClean: async () => undefined,
-}));
+});
+mock.module(join(srcRoot, "src/sdk"), sdkMock);
+mock.module(join(srcRoot, "src/sdk/index.ts"), sdkMock);
+mock.module(import.meta.resolve("../../src/sdk"), sdkMock);
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), sdkMock);
+mock.module(new URL("../../src/sdk/index.ts", import.meta.url).pathname, sdkMock);
 
-mock.module(join(srcRoot, "src/config"), () => ({
+const configMock = () => ({
   loadConfig: () => config,
   cfgLimit: () => 24,
-}));
+});
+mock.module(join(srcRoot, "src/config"), configMock);
+mock.module(join(srcRoot, "src/config/index.ts"), configMock);
+mock.module(import.meta.resolve("../../src/config"), configMock);
+mock.module(import.meta.resolve("../../src/config/index.ts"), configMock);
 
 mock.module(join(srcRoot, "src/commands/shared/comm-log-feed"), () => ({
   logMessage: (from: string, to: string, message: string, route: string) => {

--- a/test/isolated/coverage-next-vendor-b-dispatchers.test.ts
+++ b/test/isolated/coverage-next-vendor-b-dispatchers.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+
+// Reset process-wide mocks before registering this file's shims.
+mock.restore();
+
 const pairImplPath = import.meta.resolve("../../src/vendor/mpr-plugins/pair/impl.ts");
 const trustImplPath = import.meta.resolve("../../src/vendor/mpr-plugins/trust/impl.ts");
 const scopeImplPath = import.meta.resolve("../../src/vendor/mpr-plugins/scope/impl.ts");
@@ -7,14 +11,11 @@ const teamImplPath = import.meta.resolve("../../src/vendor/mpr-plugins/team/impl
 
 const calls: string[] = [];
 
-const parseFlagsMock = (args: string[], spec: Record<string, unknown> = {}) => {
+const parseFlagsMock = (args: string[], spec: Record<string, unknown> = {}, skip = 0) => {
   const out: Record<string, any> = { _: [] };
-  const resolveAlias = (key: string): string => {
-    const parser = spec[key];
-    return typeof parser === "string" ? parser : key;
-  };
-  for (let i = 0; i < args.length; i += 1) {
-    const arg = args[i]!;
+  const argv = args.slice(skip);
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]!;
     const parser = spec[arg];
     if (!parser) {
       out._.push(arg);
@@ -25,11 +26,11 @@ const parseFlagsMock = (args: string[], spec: Record<string, unknown> = {}) => {
       const targetParser = spec[target];
       if (targetParser === Boolean) out[target] = true;
       else {
-        const value = args[++i];
+        const value = argv[++i];
         if (value !== undefined) out[target] = value;
       }
     } else {
-      const value = args[++i];
+      const value = argv[++i];
       if (value !== undefined) out[arg] = value;
     }
   }
@@ -150,6 +151,7 @@ const sdkMock = () => ({
 mock.module("maw-js/sdk", sdkMock);
 mock.module(import.meta.resolve("../../src/sdk"), sdkMock);
 mock.module(import.meta.resolve("../../src/sdk/index.ts"), sdkMock);
+mock.module(new URL("../../src/sdk/index.ts", import.meta.url).pathname, sdkMock);
 
 const { default: pairHandler } = await import("../../src/vendor/mpr-plugins/pair/index.ts?coverage-next-vendor-b-dispatchers");
 const { default: trustHandler } = await import("../../src/vendor/mpr-plugins/trust/index.ts?coverage-next-vendor-b-dispatchers");

--- a/test/isolated/coverage-vendor-dream-bud-find.test.ts
+++ b/test/isolated/coverage-vendor-dream-bud-find.test.ts
@@ -33,11 +33,17 @@ mock.module("maw-js/config/ghq-root", () => ({
   getGhqRoot: () => ghqRoot,
 }));
 
-mock.module("maw-js/commands/shared/fleet-load", () => ({
+const fleetLoadMock = () => ({
   loadFleet: () => mockedFleet,
-}));
+  loadFleetCore: () => mockedFleet,
+  loadFleetEntries: () => mockedFleet,
+  loadDisabledFleetEntries: () => [],
+  fleetDirForWrite: () => join(tempRoot, "fleet"),
+  resolveFleetSession: () => null,
+});
+mock.module("maw-js/commands/shared/fleet-load", fleetLoadMock);
 
-mock.module("maw-js/sdk", () => ({
+const sdkMock = () => ({
   ...realSdk,
   loadFleetCore: () => mockedFleet,
   getGhqRoot: () => ghqRoot,
@@ -60,7 +66,8 @@ mock.module("maw-js/sdk", () => ({
 
     throw new Error(`unexpected hostExec command: ${command}`);
   },
-}));
+});
+mock.module("maw-js/sdk", sdkMock);
 
 const { cmdFind } = await import("../../src/vendor/mpr-plugins/find/impl.ts?coverage-vendor-dream-bud-find");
 

--- a/test/isolated/dispatch-runtime-coverage.test.ts
+++ b/test/isolated/dispatch-runtime-coverage.test.ts
@@ -1,4 +1,6 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { createHash } from "crypto";
+import { readFileSync } from "fs";
 
 // Reset leaked mocks before registering dispatch-specific shims.
 mock.restore();
@@ -100,6 +102,13 @@ mock.module(at("../../src/plugin/registry"), () => ({
     invokeCalls.push({ plugin, ctx });
     return invokeResult;
   },
+  runtimeSdkVersion: () => "1.0.0",
+  satisfies: () => true,
+  formatSdkMismatchError: () => "sdk mismatch",
+  hashFile: (path: string) => `sha256:${createHash("sha256").update(readFileSync(path)).digest("hex")}`,
+  importPluginSymbol: async () => undefined,
+  resetDiscoverCache: () => undefined,
+  __resetDiscoverStateForTests: () => undefined,
 }));
 
 mock.module(at("../../src/cli/dispatch-match"), () => ({
@@ -116,9 +125,39 @@ mock.module(at("../../src/plugin/dependencies"), () => ({
   enablePlanFor: () => enablePlanReturn,
 }));
 
-mock.module(at("../../src/sdk"), () => ({
+const sdkMock = () => ({
+  hostExec: async () => "",
+  parseFlags: () => ({}),
+  getGhqRoot: () => process.cwd(),
+  loadFleetCore: () => [],
   listSessions: async () => sessionsReturn,
-}));
+  findPeerForTarget: async () => null,
+  resolveTarget: () => null,
+  curlFetch: async () => ({ ok: false }),
+  capture: async () => "",
+  sendKeys: async () => undefined,
+  getPaneCommand: async () => "",
+  getPaneCommands: async () => [],
+  getPaneInfos: async () => [],
+  isAgentCommand: () => false,
+  loadConfig: () => ({}),
+  runHook: async () => undefined,
+  withPaneLock: async (fn: () => Promise<unknown>) => fn(),
+  splitWindowLocked: async () => "%1",
+  tagPane: async () => undefined,
+  readPaneTags: async () => ({}),
+  Tmux: class { async killSession() {} },
+  tmuxCmd: () => "tmux",
+  resolveSocket: () => undefined,
+  tmux: { run: async () => "", listPaneIds: async () => new Set<string>(), listSessions: async () => [] },
+  resolveOraclePane: async (target: string) => target,
+  cmdSleep: async () => undefined,
+  cmdWakeAll: async () => undefined,
+  C: { green: "", red: "", yellow: "", gray: "", reset: "" },
+  UserError: class UserError extends Error {},
+});
+mock.module(at("../../src/sdk"), sdkMock);
+mock.module(at("../../src/sdk/index.ts"), sdkMock);
 
 const { dispatchCommand } = await import("../../src/cli/dispatch.ts?dispatch-runtime-coverage");
 const { UserError } = await import("../../src/core/util/user-error");
@@ -191,6 +230,7 @@ afterAll(() => {
   console.log = originalLog;
   console.error = originalError;
   (process as any).exit = originalExit;
+  mock.restore();
 });
 
 describe("dispatchCommand runtime coverage", () => {

--- a/test/isolated/fleet-consolidate-init-coverage.test.ts
+++ b/test/isolated/fleet-consolidate-init-coverage.test.ts
@@ -19,6 +19,9 @@ import {
 import { tmpdir } from "os";
 import { join } from "path";
 
+// Reset process-wide mocks before registering this file's shims.
+mock.restore();
+
 const SANDBOX = mkdtempSync(join(tmpdir(), "maw-fleet-init-consolidate-"));
 const FLEET_DIR = join(SANDBOX, "config", "fleet");
 const WRITE_FLEET_DIR = join(SANDBOX, "home", "fleet");
@@ -37,16 +40,66 @@ let hostExecCalls: string[] = [];
 let hostExecHandler: HostExecHandler = () => "";
 let ghqListReturn: string[] = [];
 
-mock.module(sdkPath, () => ({
+const sdkMock = () => ({
   FLEET_DIR,
+  loadFleetCore: () => [],
+  listSessions: async () => [],
+  findPeerForTarget: async () => null,
+  runHook: async () => undefined,
+  withPaneLock: async (fn: () => Promise<unknown>) => fn(),
+  splitWindowLocked: async () => "%1",
+  tagPane: async () => undefined,
+  readPaneTags: async () => ({}),
+  Tmux: class { async killSession() {} },
+  tmuxCmd: () => "tmux",
+  resolveSocket: () => undefined,
   tmux: {
     run: async () => "",
+    listPaneIds: async () => new Set<string>(),
+    listSessions: async () => [],
   },
+  capture: async () => "",
+  sendKeys: async () => undefined,
+  getPaneCommand: async () => "",
+  getPaneCommands: async () => [],
+  getPaneInfos: async () => [],
+  isAgentCommand: () => false,
+  resolveTarget: () => null,
+  curlFetch: async () => ({ ok: false }),
   hostExec: async (command: string) => {
     hostExecCalls.push(command);
     return await hostExecHandler(command);
   },
-}));
+});
+mock.module("maw-js/sdk", sdkMock);
+mock.module(sdkPath, sdkMock);
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), sdkMock);
+mock.module(new URL("../../src/sdk/index.ts", import.meta.url).pathname, sdkMock);
+
+
+const fleetLoadMock = () => ({
+  loadDisabledFleetEntries: () => {
+    const { readdirSync, readFileSync } = require("fs");
+    return readdirSync(FLEET_DIR)
+      .filter((file: string) => file.endsWith(".disabled"))
+      .sort()
+      .map((file: string) => {
+        const activeName = file.replace(/\.disabled$/i, "");
+        const match = activeName.match(/^(\d+)-(.+)\.json$/);
+        const base = { file, path: join(FLEET_DIR, file), num: match ? parseInt(match[1], 10) : 0, groupName: match ? match[2] : activeName.replace(/\.json$/i, "") };
+        try { return { ...base, session: JSON.parse(readFileSync(join(FLEET_DIR, file), "utf8")) }; }
+        catch (error) { return { ...base, error }; }
+      });
+  },
+  fleetDirForWrite: () => WRITE_FLEET_DIR,
+  loadFleet: () => [],
+  loadFleetCore: () => [],
+  loadFleetEntries: () => [],
+  resolveFleetSession: () => null,
+});
+mock.module("maw-js/commands/shared/fleet-load", fleetLoadMock);
+mock.module(import.meta.resolve("../../src/commands/shared/fleet-load"), fleetLoadMock);
+mock.module(new URL("../../src/commands/shared/fleet-load.ts", import.meta.url).pathname, fleetLoadMock);
 
 mock.module(ghqRootPath, () => ({
   getGhqRoot: () => GHQ_ROOT,
@@ -54,6 +107,9 @@ mock.module(ghqRootPath, () => ({
 
 mock.module(ghqPath, () => ({
   ghqList: async () => ghqListReturn,
+  ghqListSync: () => ghqListReturn,
+  ghqFind: async () => "",
+  ghqFindSync: () => "",
 }));
 
 const { cmdFleetConsolidate } = await import(
@@ -108,6 +164,7 @@ beforeEach(() => {
 });
 
 afterAll(() => {
+  mock.restore();
   rmSync(SANDBOX, { recursive: true, force: true });
 });
 

--- a/test/isolated/plugin-lock.test.ts
+++ b/test/isolated/plugin-lock.test.ts
@@ -12,7 +12,7 @@
  *   • schema version mismatch in lock → CLI refuses with migration hint.
  */
 
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
 import {
   chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync,
   rmSync, writeFileSync,
@@ -21,14 +21,17 @@ import { join } from "path";
 import { tmpdir } from "os";
 import { createHash } from "crypto";
 import { spawnSync } from "child_process";
-import { cmdPluginInstall } from "../../src/commands/plugins/plugin/install-impl";
-import {
+// Reset process-wide mocks before importing registry/lock modules.
+mock.restore();
+
+const { cmdPluginInstall } = await import("../../src/commands/plugins/plugin/install-impl");
+const {
   readLock, writeLock, pinPlugin, unpinPlugin, validateSha256, validateName,
   LOCK_SCHEMA,
-} from "../../src/commands/plugins/plugin/lock";
-import {
+} = await import("../../src/commands/plugins/plugin/lock");
+const {
   __resetDiscoverStateForTests, resetDiscoverCache,
-} from "../../src/plugin/registry";
+} = await import("../../src/plugin/registry");
 
 // ─── Harness ─────────────────────────────────────────────────────────────────
 

--- a/test/isolated/pulse-cmd-runtime-coverage.test.ts
+++ b/test/isolated/pulse-cmd-runtime-coverage.test.ts
@@ -5,6 +5,10 @@
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+
+// Reset process-wide mocks before registering this file's shims.
+mock.restore();
+
 let hostExecCalls: string[] = [];
 let hostExecImpl: (cmd: string) => Promise<string> | string = () => "";
 let wakeCalls: unknown[][] = [];
@@ -17,12 +21,71 @@ let logs: string[] = [];
 
 const originalLog = console.log;
 
-mock.module(import.meta.resolve("../../src/sdk"), () => ({
+const sdkMock = () => ({
+  parseFlags: () => ({}),
+  getGhqRoot: () => process.cwd(),
+  loadFleetCore: () => [],
+  listSessions: async () => [],
+  findPeerForTarget: async () => null,
+  resolveTarget: () => null,
+  curlFetch: async () => ({ ok: false }),
+  capture: async () => "",
+  sendKeys: async () => undefined,
+  getPaneCommand: async () => "",
+  getPaneCommands: async () => [],
+  getPaneInfos: async () => [],
+  isAgentCommand: () => false,
+  loadConfig: () => ({}),
+  runHook: async () => undefined,
+  withPaneLock: async (fn: () => Promise<unknown>) => fn(),
+  splitWindowLocked: async () => "%1",
+  tagPane: async () => undefined,
+  readPaneTags: async () => ({}),
+  Tmux: class { async killSession() {} },
+  tmuxCmd: () => "tmux",
+  resolveSocket: () => undefined,
+  tmux: { run: async () => "", listPaneIds: async () => new Set<string>(), listSessions: async () => [] },
+  resolveOraclePane: async (target: string) => target,
+  cmdSleep: async () => undefined,
+  cmdWakeAll: async () => undefined,
+  C: { green: "", red: "", yellow: "", gray: "", reset: "" },
+  invalidateManifest: () => undefined,
+  isMawXdgEnabled: () => false,
+  loadManifestCached: () => null,
+  legacyMawPath: (...parts: string[]) => ["/tmp", ".maw", ...parts].join("/"),
+  mawCacheDir: () => "/tmp/.maw/cache",
+  mawConfigDir: () => "/tmp/.maw/config",
+  mawDataDir: () => "/tmp/.maw",
+  mawDataPath: (...parts: string[]) => ["/tmp", ".maw", ...parts].join("/"),
+  mawStateDir: () => "/tmp/.maw/state",
+  mawStatePath: (...parts: string[]) => ["/tmp", ".maw", "state", ...parts].join("/"),
+  cmdWorkspaceCreate: async () => undefined,
+  cmdWorkspaceJoin: async () => undefined,
+  cmdWorkspaceShare: async () => undefined,
+  cmdWorkspaceUnshare: async () => undefined,
+  cmdWorkspaceLs: async () => undefined,
+  cmdWorkspaceAgents: async () => undefined,
+  cmdWorkspaceInvite: async () => undefined,
+  cmdWorkspaceLeave: async () => undefined,
+  cmdWorkspaceTeam: async () => undefined,
+  cmdWorkspaceStop: async () => undefined,
+  cmdWorkspaceSessions: async () => undefined,
+  cmdWorkspaceWhere: async () => undefined,
+  cmdWorkspaceStatus: async () => undefined,
+  cmdWorkspaceSend: async () => undefined,
+  cmdWorkspaceInspect: async () => undefined,
+  cmdWorkspaceSnapshot: async () => undefined,
+  cmdWorkspaceRestore: async () => undefined,
+  cmdWorkspaceClean: async () => undefined,
+  UserError: class UserError extends Error {},
   hostExec: async (cmd: string) => {
     hostExecCalls.push(cmd);
     return await hostExecImpl(cmd);
   },
-}));
+});
+mock.module(import.meta.resolve("../../src/sdk"), sdkMock);
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), sdkMock);
+mock.module(new URL("../../src/sdk/index.ts", import.meta.url).pathname, sdkMock);
 
 mock.module(import.meta.resolve("../../src/commands/shared/wake"), () => ({
   cmdWake: async (...args: unknown[]) => {

--- a/test/isolated/tile-impl-next-coverage.test.ts
+++ b/test/isolated/tile-impl-next-coverage.test.ts
@@ -24,6 +24,63 @@ let borderCalls: Array<{ paneId: string; label: string; color: string }> = [];
 const originalTileCmdSettle = process.env.MAW_TILE_CMD_SETTLE_MS;
 
 const sdkMock = () => ({
+  cmdWorkspaceCreate: async () => undefined,
+  cmdWorkspaceJoin: async () => undefined,
+  cmdWorkspaceShare: async () => undefined,
+  cmdWorkspaceUnshare: async () => undefined,
+  cmdWorkspaceLs: async () => undefined,
+  cmdWorkspaceAgents: async () => undefined,
+  cmdWorkspaceInvite: async () => undefined,
+  cmdWorkspaceLeave: async () => undefined,
+  cmdWorkspaceTeam: async () => undefined,
+  cmdWorkspaceStop: async () => undefined,
+  cmdWorkspaceSessions: async () => undefined,
+  cmdWorkspaceWhere: async () => undefined,
+  cmdWorkspaceStatus: async () => undefined,
+  cmdWorkspaceSend: async () => undefined,
+  cmdWorkspaceInspect: async () => undefined,
+  cmdWorkspaceSnapshot: async () => undefined,
+  cmdWorkspaceRestore: async () => undefined,
+  cmdWorkspaceClean: async () => undefined,
+  mawStatePath: (...parts: string[]) => ["/tmp", ".maw", "state", ...parts].join("/"),
+  UserError: class UserError extends Error {},
+
+  parseFlags: () => ({}),
+  getGhqRoot: () => process.cwd(),
+  loadFleetCore: () => [],
+  listSessions: async () => [],
+  findPeerForTarget: async () => null,
+  resolveTarget: () => null,
+  curlFetch: async () => ({ ok: false }),
+  capture: async () => "",
+  sendKeys: async () => undefined,
+  getPaneCommand: async () => "",
+  getPaneCommands: async () => [],
+  getPaneInfos: async () => [],
+  isAgentCommand: () => false,
+  loadConfig: () => ({}),
+  runHook: async () => undefined,
+  withPaneLock: async (fn: () => Promise<unknown>) => fn(),
+  splitWindowLocked: async () => "%1",
+  tagPane: async () => undefined,
+  readPaneTags: async () => ({}),
+  Tmux: class { async killSession() {} },
+  tmuxCmd: () => "tmux",
+  resolveSocket: () => undefined,
+  tmux: { run: async () => "", listPaneIds: async () => new Set<string>(), listSessions: async () => [] },
+  resolveOraclePane: async (target: string) => target,
+  cmdSleep: async () => undefined,
+  cmdWakeAll: async () => undefined,
+  C: { green: "", red: "", yellow: "", gray: "", reset: "" },
+  invalidateManifest: () => undefined,
+  isMawXdgEnabled: () => false,
+  loadManifestCached: () => null,
+  legacyMawPath: (...parts: string[]) => ["/tmp", ".maw", ...parts].join("/"),
+  mawCacheDir: () => "/tmp/.maw/cache",
+  mawConfigDir: () => "/tmp/.maw/config",
+  mawDataDir: () => "/tmp/.maw",
+  mawDataPath: (...parts: string[]) => ["/tmp", ".maw", ...parts].join("/"),
+  mawStateDir: () => "/tmp/.maw/state",
   hostExec: async (cmd: string) => {
     commands.push(cmd);
 
@@ -62,6 +119,9 @@ const sdkMock = () => ({
 // Earlier isolated tests can leak an index.ts mock that otherwise shadows this.
 mock.module(join(root, "src/sdk"), sdkMock);
 mock.module(join(root, "src/sdk/index.ts"), sdkMock);
+mock.module(import.meta.resolve("../../src/sdk"), sdkMock);
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), sdkMock);
+mock.module(new URL("../../src/sdk/index.ts", import.meta.url).pathname, sdkMock);
 
 mock.module(join(root, "src/commands/plugins/tmux/layout-manager"), () => ({
   nextAgentColor: (idx: number) => `color-${idx}`,
@@ -81,9 +141,13 @@ mock.module(join(root, "src/core/transport/tmux-pane-lock"), () => ({
   withPaneLock: async (fn: () => Promise<void>) => fn(),
 }));
 
-mock.module(join(root, "src/config"), () => ({
+const configMock = () => ({
   loadConfig: () => ({ commands: { codex: "codex --model fast" } }),
-}));
+});
+mock.module(join(root, "src/config"), configMock);
+mock.module(join(root, "src/config/index.ts"), configMock);
+mock.module(import.meta.resolve("../../src/config"), configMock);
+mock.module(import.meta.resolve("../../src/config/index.ts"), configMock);
 
 const { cmdTile, cmdTileClean, cmdTileSwap } = await import(
   "../../src/commands/plugins/tile/impl.ts?tile-impl-next-coverage"

--- a/test/isolated/wake-github-oracle-index-extra-coverage.test.ts
+++ b/test/isolated/wake-github-oracle-index-extra-coverage.test.ts
@@ -1,5 +1,9 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { join } from "path";
+
+
+// Reset process-wide mocks before registering this file's shims.
+mock.restore();
 
 type HostExecImpl = (cmd: string) => Promise<string> | string;
 
@@ -9,26 +13,83 @@ const oracleImplListPath = join(import.meta.dir, "../../src/commands/plugins/ora
 let hostExecCalls: string[] = [];
 let hostExecImpl: HostExecImpl = () => "";
 
-mock.module(sdkPath, () => ({
+const sdkMock = () => ({
   CONFIG_DIR: "/tmp/maw-test-config",
   FLEET_DIR: "/tmp/maw-test-fleet",
-  tmux: { listSessions: async () => [] },
+  // Keep broad: this SDK mock can be visible to later isolated files.
+  UserError: class UserError extends Error {},
+  runHook: async () => undefined,
+  withPaneLock: async (fn: () => Promise<unknown>) => fn(),
+  splitWindowLocked: async () => "%1",
+  tagPane: async () => undefined,
+  readPaneTags: async () => ({}),
+  Tmux: class { async killSession() {} },
+  tmuxCmd: () => "tmux",
+  resolveSocket: () => undefined,
+  tmux: { listPaneIds: async () => new Set<string>(), listSessions: async () => [] },
   saveTabOrder: async () => undefined,
   takeSnapshot: async () => ({ id: "test-snapshot" }),
+  loadFleetCore: () => [],
+  getGhqRoot: () => process.cwd(),
   hostExec: async (cmd: string) => {
     hostExecCalls.push(cmd);
     return await hostExecImpl(cmd);
   },
   listSessions: async () => [],
+  findPeerForTarget: async () => null,
   capture: async () => "",
+  sendKeys: async () => undefined,
+  getPaneCommand: async () => "",
+  getPaneCommands: async () => [],
+  getPaneInfos: async () => [],
+  isAgentCommand: () => false,
   curlFetch: async () => ({ ok: false }),
+  resolveTarget: () => null,
+  resolveOraclePane: async (target: string) => target,
+  cmdSleep: async () => undefined,
+  cmdWakeAll: async () => undefined,
   readCache: () => ({ oracles: [], scanned_at: new Date().toISOString() }),
   scanAndCache: async () => ({ oracles: [], scanned_at: new Date().toISOString() }),
   scanFull: async () => ({ oracles: [], scanned_at: new Date().toISOString() }),
   scanRemote: async () => ({ oracles: [], scanned_at: new Date().toISOString() }),
   isCacheStale: () => false,
   loadConfig: () => ({ sessions: {}, agents: {}, peers: [] }),
-}));
+  C: { green: "", red: "", yellow: "", gray: "", reset: "" },
+  invalidateManifest: () => undefined,
+  isMawXdgEnabled: () => false,
+  loadManifestCached: () => null,
+  legacyMawPath: (...parts: string[]) => ["/tmp", ".maw", ...parts].join("/"),
+  mawCacheDir: () => "/tmp/.maw/cache",
+  mawConfigDir: () => "/tmp/.maw/config",
+  mawDataDir: () => "/tmp/.maw",
+  mawDataPath: (...parts: string[]) => ["/tmp", ".maw", ...parts].join("/"),
+  mawStateDir: () => "/tmp/.maw/state",
+  mawStatePath: (...parts: string[]) => ["/tmp", ".maw", "state", ...parts].join("/"),
+  cmdWorkspaceCreate: async () => undefined,
+  cmdWorkspaceJoin: async () => undefined,
+  cmdWorkspaceShare: async () => undefined,
+  cmdWorkspaceUnshare: async () => undefined,
+  cmdWorkspaceLs: async () => undefined,
+  cmdWorkspaceAgents: async () => undefined,
+  cmdWorkspaceInvite: async () => undefined,
+  cmdWorkspaceLeave: async () => undefined,
+  cmdWorkspaceTeam: async () => undefined,
+  cmdWorkspaceStop: async () => undefined,
+  cmdWorkspaceSessions: async () => undefined,
+  cmdWorkspaceWhere: async () => undefined,
+  cmdWorkspaceStatus: async () => undefined,
+  cmdWorkspaceSend: async () => undefined,
+  cmdWorkspaceInspect: async () => undefined,
+  cmdWorkspaceSnapshot: async () => undefined,
+  cmdWorkspaceRestore: async () => undefined,
+  cmdWorkspaceClean: async () => undefined,
+});
+mock.module("maw-js/sdk", sdkMock);
+mock.module(sdkPath, sdkMock);
+mock.module(join(import.meta.dir, "../../src/sdk/index.ts"), sdkMock);
+mock.module(import.meta.resolve("../../src/sdk"), sdkMock);
+mock.module(import.meta.resolve("../../src/sdk/index.ts"), sdkMock);
+mock.module(new URL("../../src/sdk/index.ts", import.meta.url).pathname, sdkMock);
 
 type FakeEnrichedEntry = {
   entry: {
@@ -150,6 +211,10 @@ function makeOracleHandler(overrides: Record<string, any> = {}) {
 
   return { handler: createOracleHandler(deps as any), calls };
 }
+
+afterAll(() => {
+  mock.restore();
+});
 
 describe("wake GitHub prompt resolver", () => {
   test("formats explicit-repo issues without consulting git remote", async () => {


### PR DESCRIPTION
Refs #2474.

Batch 6 continues reducing single-process isolated mock leakage by making the next cluster of process-global Bun mocks reset-safe and export-complete enough for adjacent isolated files.

Validation:
- bun test selected isolated mock-leak cluster (dispatch, wake/oracle, fleet consolidate/init, plugin-lock, attach, comm-send thirteenth, tile next, vendor-b dispatchers, pulse, last-five, doctor slices)
- bun scripts/check-plugin-coverage-gate.ts origin/alpha
- timeout 90 bun test test/isolated/ 2>&1 | grep -E "^error:" | head -15 produced no ^error sample before timeout

Note: full single-process isolated suite still has known order-dependent failures outside this batch; this PR keeps scope to the next high-yield cluster.