### PR TITLE
fix: deduplicate plugin scanDirs to prevent duplicate shadows (#2488)

### DIFF
--- a/src/plugin/registry-helpers.ts
+++ b/src/plugin/registry-helpers.ts
@@ -31,7 +31,8 @@ export function discoverLocalPluginDirs(cwd = process.cwd()): string[] {
 }
 
 export function scanDirs(cwd = process.cwd()): string[] {
-  return [...discoverLocalPluginDirs(cwd), process.env.MAW_PLUGINS_DIR || mawDataPath("plugins")];
+  const pluginDirs = [...discoverLocalPluginDirs(cwd), process.env.MAW_PLUGINS_DIR || mawDataPath("plugins")];
+  return [...new Set(pluginDirs)];
 }
 
 /** Runtime SDK version — sourced from @maw-js/sdk package.json (build-inlined). */

--- a/test/registry-helpers.test.ts
+++ b/test/registry-helpers.test.ts
@@ -58,6 +58,19 @@ describe("plugin registry runtime helpers", () => {
     expect(scanDirs(cwd)).toEqual([packagePlugins, projectPlugins, "/tmp/maw-test-plugins"]);
   });
 
+  test("scanDirs deduplicates plugin directories", () => {
+    const root = tempDir("maw-local-plugins-dupe-");
+    const packagePlugins = join(root, "packages", "app", ".maw", "plugins");
+    const cwd = join(root, "packages", "app", "src");
+    mkdirSync(packagePlugins, { recursive: true });
+    mkdirSync(cwd, { recursive: true });
+
+    saveEnv("MAW_PLUGINS_DIR");
+    process.env.MAW_PLUGINS_DIR = packagePlugins;
+
+    expect(scanDirs(cwd)).toEqual([packagePlugins]);
+  });
+
   test("discoverLocalPluginDirs stops walking at a .maw-root marker", () => {
     const root = tempDir("maw-root-marker-");
     const parentPlugins = join(root, ".maw", "plugins");


### PR DESCRIPTION
Deduplicates plugin scanDirs output before returning so duplicate directories (for example ~/.maw/plugins repeated via cascading scan inputs) do not generate false shadow warnings. Adds regression coverage in registry helpers tests for dedupe while preserving local/ancestor shadow behavior in existing discoverPackages logic.

Closes #2488