### PR TITLE
fix: make serve-views fallback registration idempotent

### DIFF
--- a/src/vendor/mpr-plugins/serve-views/index.ts
+++ b/src/vendor/mpr-plugins/serve-views/index.ts
@@ -47,12 +47,26 @@ export function createViews(
 
 export const views = createViews();
 
+function hasServeViewsFallback(http: ServeHookContext["http"]): boolean {
+  const listFallbacks = (http as { listFallbacks?: () => string[] } | undefined)?.listFallbacks;
+  if (typeof listFallbacks !== "function") return false;
+  return listFallbacks.call(http).includes("serve-views");
+}
+
 export async function serve(
   ctx: ServeHookContext,
   options: { views?: Hono } = {},
 ): Promise<{ ok: true }> {
   if (!ctx.http?.fallback) return { ok: true };
+  if (hasServeViewsFallback(ctx.http)) return { ok: true };
   const honoViews = options.views ?? createViews();
-  ctx.http.fallback("serve-views", (req, env) => honoViews.fetch(req, env));
+  try {
+    ctx.http.fallback("serve-views", (req, env) => honoViews.fetch(req, env));
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("serve fallback already registered: serve-views")) {
+      return { ok: true };
+    }
+    throw error;
+  }
   return { ok: true };
 }

--- a/test/isolated/plugin-serve-views-standalone.test.ts
+++ b/test/isolated/plugin-serve-views-standalone.test.ts
@@ -19,6 +19,7 @@ describe("serve-views plugin", () => {
     const registry = new ServeRouteRegistry();
 
     await serve({ http: registry, plugin: { name: "serve-views" } });
+    await serve({ http: registry, plugin: { name: "serve-views" } });
 
     expect(registry.listFallbacks()).toEqual(["serve-views"]);
     const response = await registry.handleFallback(new Request("http://local/"));


### PR DESCRIPTION
Closes #2489.

Fixes `maw serve` startup crashes when `serve-views` is loaded through multiple lifecycle paths, such as bundled plugin plus user plugin symlink. The serve route registry remains strict for unrelated duplicate fallback IDs; only the serve-views plugin treats its own already-registered fallback as idempotent.

Validation:
- bun test test/isolated/plugin-serve-views-standalone.test.ts test/isolated/serve-route-registry.test.ts
- bun scripts/check-plugin-coverage-gate.ts origin/alpha
- bun src/cli.ts serve 3099 --quiet + curl -sf http://localhost:3099/health

Note: serve-ws is already idempotent via route snapshot checks.