### PR TITLE
feat: support plugin.ts manifest loading (fallback to plugin.json)

### DIFF
--- a/src/plugin/manifest-load.ts
+++ b/src/plugin/manifest-load.ts
@@ -5,14 +5,46 @@
 import type { LoadedPlugin } from "./types";
 import { existsSync, readFileSync } from "fs";
 import { join, resolve } from "path";
-import { parseManifest } from "./manifest-parse";
+import { createRequire } from "node:module";
+import { parseManifest, parseManifestFromSource } from "./manifest-parse";
+
+const requirePluginManifest = createRequire(import.meta.url);
+
+function pickManifestExport(mod: unknown): unknown {
+  if (!mod || typeof mod !== "object" || Array.isArray(mod)) return undefined;
+  const candidate = mod as {
+    default?: unknown;
+    manifest?: unknown;
+  };
+  if (candidate.default !== undefined) return candidate.default;
+  if (candidate.manifest !== undefined) return candidate.manifest;
+  return mod;
+}
 
 /**
  * Load a plugin package from a directory.
- * Returns null if no plugin.json is present.
- * Throws if plugin.json exists but fails validation.
+ * Returns null if no plugin.json/plugin.ts is present.
+ * Throws if a manifest is present but fails validation.
  */
 export function loadManifestFromDir(dir: string): LoadedPlugin | null {
+  const tsPath = join(dir, "plugin.ts");
+  if (existsSync(tsPath)) {
+    const loaded = requirePluginManifest(tsPath);
+    const manifestObj = pickManifestExport(loaded);
+    const manifest = parseManifestFromSource(manifestObj, dir, "plugin.ts");
+    const hasWasm = !!manifest.wasm;
+    const hasEntry = !!manifest.entry;
+    const hasArtifactJs = manifest.target !== "wasm" && !!manifest.artifact?.path;
+    const effectiveEntry = manifest.entry ?? (hasArtifactJs ? manifest.artifact!.path : undefined);
+    return {
+      manifest,
+      dir,
+      wasmPath: hasWasm ? resolve(dir, manifest.wasm!) : "",
+      ...(effectiveEntry ? { entryPath: resolve(dir, effectiveEntry) } : {}),
+      kind: (hasEntry || hasArtifactJs) ? "ts" as const : "wasm" as const,
+    };
+  }
+
   const manifestPath = join(dir, "plugin.json");
   if (!existsSync(manifestPath)) return null;
   const jsonText = readFileSync(manifestPath, "utf8");

--- a/src/plugin/manifest-parse.ts
+++ b/src/plugin/manifest-parse.ts
@@ -23,20 +23,11 @@ import {
 } from "./manifest-validate";
 
 /**
- * Parse and validate a plugin.json text.
- * @param jsonText - raw contents of plugin.json
- * @param dir      - absolute directory of the manifest (used to resolve wasm path)
- * @throws if any field is missing, invalid, or the wasm file is absent
+ * Internal parser shared by JSON + module-backed manifests.
  */
-export function parseManifest(jsonText: string, dir: string): PluginManifest {
-  let raw: unknown;
-  try {
-    raw = JSON.parse(jsonText);
-  } catch {
-    throw new Error("plugin.json: invalid JSON");
-  }
+function parseManifestInput(raw: unknown, dir: string, source: string): PluginManifest {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
-    throw new Error("plugin.json: must be a JSON object");
+    throw new Error(`${source}: must be a JSON object`);
   }
   const r = raw as Record<string, unknown>;
 
@@ -44,12 +35,12 @@ export function parseManifest(jsonText: string, dir: string): PluginManifest {
 
   if (typeof r.name !== "string" || !NAME_RE.test(r.name)) {
     throw new Error(
-      `plugin.json: name must match /^[a-z0-9-]+$/ (got ${JSON.stringify(r.name)})`,
+      `${source}: name must match /^[a-z0-9-]+$/ (got ${JSON.stringify(r.name)})`,
     );
   }
   if (typeof r.version !== "string" || !SEMVER_RE.test(r.version)) {
     throw new Error(
-      `plugin.json: version must be semver N.N.N (got ${JSON.stringify(r.version)})`,
+      `${source}: version must be semver N.N.N (got ${JSON.stringify(r.version)})`,
     );
   }
   // #869 — wasm / entry / artifact are all optional. When none are declared,
@@ -67,7 +58,7 @@ export function parseManifest(jsonText: string, dir: string): PluginManifest {
 
   if (typeof r.sdk !== "string" || !SEMVER_RANGE_RE.test(r.sdk)) {
     throw new Error(
-      `plugin.json: sdk must be a semver range (got ${JSON.stringify(r.sdk)})`,
+      `${source}: sdk must be a semver range (got ${JSON.stringify(r.sdk)})`,
     );
   }
 
@@ -75,13 +66,13 @@ export function parseManifest(jsonText: string, dir: string): PluginManifest {
   if (hasWasm) {
     const resolvedWasm = resolve(dir, r.wasm as string);
     if (!existsSync(resolvedWasm)) {
-      throw new Error(`plugin.json: wasm file not found: ${resolvedWasm}`);
+      throw new Error(`${source}: wasm file not found: ${resolvedWasm}`);
     }
   }
   if (hasEntry) {
     const resolvedEntry = resolve(dir, r.entry as string);
     if (!existsSync(resolvedEntry)) {
-      throw new Error(`plugin.json: entry file not found: ${resolvedEntry}`);
+      throw new Error(`${source}: entry file not found: ${resolvedEntry}`);
     }
   }
 
@@ -123,4 +114,27 @@ export function parseManifest(jsonText: string, dir: string): PluginManifest {
     ...(dependencies ? { dependencies } : {}),
     ...(artifact ? { artifact } : {}),
   };
+}
+
+/**
+ * Parse and validate plugin manifest text (from plugin.json).
+ *
+ * Kept for callsites that read JSON from disk and want parser errors to
+ * remain anchored to `plugin.json`.
+ */
+export function parseManifest(jsonText: string, dir: string): PluginManifest {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(jsonText);
+  } catch {
+    throw new Error("plugin.json: invalid JSON");
+  }
+  return parseManifestInput(raw, dir, "plugin.json");
+}
+
+/**
+ * Parse and validate manifest data emitted from executable sources (e.g. plugin.ts).
+ */
+export function parseManifestFromSource(raw: unknown, dir: string, source = "plugin.ts"): PluginManifest {
+  return parseManifestInput(raw, dir, source);
 }

--- a/test/plugin-manifest.test.ts
+++ b/test/plugin-manifest.test.ts
@@ -293,6 +293,48 @@ describe("loadManifestFromDir", () => {
       rmSync(dir, { recursive: true });
     }
   });
+
+  test("prefers plugin.ts over plugin.json and parses exported manifest", () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(join(dir, "index.ts"), "export default {}\n");
+      writeFileSync(
+        join(dir, "plugin.ts"),
+        `export default {\n` +
+          `  name: "from-plugin-ts",\n` +
+          `  version: "1.0.0",\n` +
+          `  sdk: "^1.0.0",\n` +
+          `  entry: "index.ts",\n` +
+          `};\n`,
+      );
+      writeFileSync(
+        join(dir, "plugin.json"),
+        JSON.stringify({ name: "from-plugin-json", version: "2.0.0", sdk: "^1.0.0", entry: "index.ts" }),
+      );
+      const loaded = loadManifestFromDir(dir);
+      expect(loaded).not.toBeNull();
+      expect(loaded!.manifest.name).toBe("from-plugin-ts");
+      expect(loaded!.manifest.version).toBe("1.0.0");
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  test("falls back to plugin.json when plugin.ts is missing", () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(
+        join(dir, "plugin.json"),
+        JSON.stringify({ name: "from-plugin-json", version: "1.0.0", sdk: "^1.0.0", entry: "index.ts" }),
+      );
+      writeFileSync(join(dir, "index.ts"), "export default {}\n");
+      const loaded = loadManifestFromDir(dir);
+      expect(loaded).not.toBeNull();
+      expect(loaded!.manifest.name).toBe("from-plugin-json");
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Implement #2495.

Plugin manifest discovery now prefers  by loading via require first (including default/named  exports), then parses and validates via manifest parser as  source.
If  is absent, behavior remains unchanged and falls back to .
This preserves local behavior while enabling plugin directories to ship executable manifest modules.

Closes #2495