### PR TITLE
Add PluginEventMap interface to @maw-js/sdk

### DIFF
--- a/packages/sdk/events.ts
+++ b/packages/sdk/events.ts
@@ -1,0 +1,52 @@
+import type { TransportResult, TransportTarget } from "../../src/core/transport/transport";
+
+export interface PluginEventMap {
+  "transport:before_send": {
+    target: TransportTarget;
+    message: string;
+    from: string;
+  };
+  "transport:after_send": {
+    target: TransportTarget;
+    message: string;
+    from: string;
+    result: TransportResult;
+    via: string;
+  };
+  "transport:receive": {
+    from: string;
+    body: string;
+    transport: string;
+    timestamp: number;
+  };
+  "session:start": {
+    oracle: string;
+    session: string;
+    repoPath: string;
+  };
+  "session:end": {
+    oracle: string;
+    session: string;
+    window: string;
+  };
+  "feed:message_send": {
+    from: string;
+    to: string;
+    body: string;
+    channel: string;
+  };
+  "feed:status_change": {
+    oracle: string;
+    pane: string;
+    from: string;
+    to: string;
+  };
+  "serve:start": {
+    port: number;
+    hostname: string;
+  };
+  "serve:plugin_loaded": {
+    name: string;
+    phase: string;
+  };
+}

--- a/packages/sdk/index.d.ts
+++ b/packages/sdk/index.d.ts
@@ -82,6 +82,83 @@ export type FeedEventType =
   | "PluginLoad"
   | "PluginError";
 
+/** Where a message should be delivered. */
+export interface TransportTarget {
+  oracle: string;
+  host?: string;
+  tmuxTarget?: string;
+}
+
+/** Failure reasons for transport send attempts. */
+export type TransportFailureReason =
+  | "timeout"
+  | "unreachable"
+  | "auth"
+  | "rate_limit"
+  | "rejected"
+  | "parse_error"
+  | "unknown";
+
+/** Result of a transport send attempt. */
+export interface TransportResult {
+  ok: boolean;
+  via: string;
+  reason?: TransportFailureReason;
+  retryable: boolean;
+}
+
+/** Event-name → payload registry for plugin event hooks. */
+export interface PluginEventMap {
+  "transport:before_send": {
+    target: TransportTarget;
+    message: string;
+    from: string;
+  };
+  "transport:after_send": {
+    target: TransportTarget;
+    message: string;
+    from: string;
+    result: TransportResult;
+    via: string;
+  };
+  "transport:receive": {
+    from: string;
+    body: string;
+    transport: string;
+    timestamp: number;
+  };
+  "session:start": {
+    oracle: string;
+    session: string;
+    repoPath: string;
+  };
+  "session:end": {
+    oracle: string;
+    session: string;
+    window: string;
+  };
+  "feed:message_send": {
+    from: string;
+    to: string;
+    body: string;
+    channel: string;
+  };
+  "feed:status_change": {
+    oracle: string;
+    pane: string;
+    from: string;
+    to: string;
+  };
+  "serve:start": {
+    port: number;
+    hostname: string;
+  };
+  "serve:plugin_loaded": {
+    name: string;
+    phase: string;
+  };
+}
+
 export interface PluginInfo {
   name: string;
   type: string;

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -40,6 +40,7 @@ export type {
   TmuxWindow,
   TmuxSession,
 } from "../../src/core/transport/tmux";
+export type { PluginEventMap } from "./events";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Phase 2 widening — re-exports for plugin extraction Phase 2.


### PR DESCRIPTION
## Summary
- Added `PluginEventMap` interface in `packages/sdk/events.ts`.
- Exported `PluginEventMap` from `packages/sdk/index.ts`.
- Mirrored `PluginEventMap` and transport payload helper types in `packages/sdk/index.d.ts`.

Closes #2493