### PR TITLE
feat: definePlugin type utilities in SDK (#2494)

### DIFF
--- a/packages/sdk/define.ts
+++ b/packages/sdk/define.ts
@@ -1,0 +1,78 @@
+import { PluginEventMap } from "./events";
+
+export interface PluginManifestInput {
+  /** Plugin name (must match plugin.json name). */
+  name: string;
+  /** Optional plugin hooks, currently used for event-handler derivation. */
+  hooks?: {
+    on?: readonly string[];
+    [key: string]: unknown;
+  };
+  /** Exports made available for hook/module interop. */
+  module: {
+    exports: readonly string[];
+    path: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+/** Convert snake/hyphen separated identifiers to PascalCase fragments. */
+type PascalFromSnake<T extends string> = T extends `${infer Head}_${infer Rest}`
+  ? `${Capitalize<Lowercase<Head>>}${PascalFromSnake<Rest>}`
+  : T extends `${infer Head}-${infer Rest}`
+    ? `${Capitalize<Lowercase<Head>>}${PascalFromSnake<Rest>}`
+    : Capitalize<Lowercase<T>>;
+
+/** Event name → handler function name. */
+export type EventToHandlerName<E extends string> =
+  E extends `${infer Scope}:${infer Action}`
+    ? `on${Capitalize<Lowercase<Scope>>}${PascalFromSnake<Action>}`
+    : `on${Capitalize<Lowercase<E>>}`;
+
+/** Derive required handler signatures from a literal event name list. */
+export type HandlersFor<Events extends readonly string[]> = {
+  [Event in Events[number] as EventToHandlerName<Event>]:
+    Event extends keyof PluginEventMap
+      ? (event: PluginEventMap[Event]) => void | Promise<void>
+      : (event: unknown) => void | Promise<void>;
+};
+
+/** Extract hook event names as a tuple-like union helper. */
+type ManifestHookEvents<T extends PluginManifestInput> =
+  T extends { hooks: { on: infer HookEvents } }
+    ? HookEvents extends readonly string[]
+      ? HookEvents
+      : []
+    : [];
+
+/** Ensure module exports includes all generated handler names. */
+export type ValidateExports<T extends PluginManifestInput> =
+  keyof HandlersFor<ManifestHookEvents<T>> extends T["module"]["exports"][number]
+    ? T
+    : never;
+
+/**
+ * definePlugin return type exposes `implement()` with strongly typed handlers.
+ */
+export type DefinedPlugin<T extends PluginManifestInput> = ValidateExports<T> & {
+  implement(handlers: HandlersFor<ManifestHookEvents<T>>): ValidateExports<T> & HandlersFor<ManifestHookEvents<T>>;
+};
+
+/**
+ * Typed identity helper for plugin declarations.
+ *
+ * - Infers handler names and payload types from `hooks.on`.
+ * - Validates required handler exports are present in `module.exports`.
+ */
+export function definePlugin<const T extends PluginManifestInput>(manifest: ValidateExports<T>): DefinedPlugin<T> {
+  return {
+    ...manifest,
+    implement(handlers) {
+      return {
+        ...manifest,
+        ...handlers,
+      };
+    },
+  } as DefinedPlugin<T>;
+}

--- a/packages/sdk/index.d.ts
+++ b/packages/sdk/index.d.ts
@@ -168,6 +168,64 @@ export interface PluginInfo {
   errors: number;
 }
 
+// --- plugin manifest helpers (definePlugin) ---
+
+export interface PluginManifestInput {
+  /** Plugin name (must match plugin.json name). */
+  name: string;
+  /** Optional plugin hooks, currently used for typed event handlers. */
+  hooks?: {
+    on?: readonly string[];
+    [key: string]: unknown;
+  };
+  /** Exports list consumed by module-loader consumers. */
+  module: {
+    exports: readonly string[];
+    path: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+export type EventToHandlerName<E extends string> =
+  E extends `${infer Scope}:${infer Action}`
+    ? `on${Capitalize<Lowercase<Scope>>}${PascalFromSnake<Action>}`
+    : `on${Capitalize<Lowercase<E>>}`;
+
+type PascalFromSnake<T extends string> = T extends `${infer Head}_${infer Rest}`
+  ? `${Capitalize<Lowercase<Head>>}${PascalFromSnake<Rest>}`
+  : T extends `${infer Head}-${infer Rest}`
+    ? `${Capitalize<Lowercase<Head>>}${PascalFromSnake<Rest>}`
+    : Capitalize<Lowercase<T>>;
+
+/** Derive the typed handler map from hook event names. */
+export type HandlersFor<Events extends readonly string[]> = {
+  [Event in Events[number] as EventToHandlerName<Event>]:
+    Event extends keyof PluginEventMap
+      ? (event: PluginEventMap[Event]) => void | Promise<void>
+      : (event: unknown) => void | Promise<void>;
+};
+
+type ManifestHookEvents<T extends PluginManifestInput> =
+  T extends { hooks: { on: infer HookEvents } }
+    ? HookEvents extends readonly string[]
+      ? HookEvents
+      : []
+    : [];
+
+/** Validate `module.exports` contains all required typed handler names. */
+export type ValidateExports<T extends PluginManifestInput> =
+  keyof HandlersFor<ManifestHookEvents<T>> extends T["module"]["exports"][number]
+    ? T
+    : never;
+
+export type DefinedPlugin<T extends PluginManifestInput> =
+  ValidateExports<T> & {
+    implement(handlers: HandlersFor<ManifestHookEvents<T>>): ValidateExports<T> & HandlersFor<ManifestHookEvents<T>>;
+  };
+
+export declare function definePlugin<const T extends PluginManifestInput>(manifest: ValidateExports<T>): DefinedPlugin<T>;
+
 // --- Print helpers ---
 
 export interface PrintHelpers {

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -41,6 +41,14 @@ export type {
   TmuxSession,
 } from "../../src/core/transport/tmux";
 export type { PluginEventMap } from "./events";
+export { definePlugin } from "./define";
+export type {
+  DefinedPlugin,
+  EventToHandlerName,
+  HandlersFor,
+  PluginManifestInput,
+  ValidateExports,
+} from "./define";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Phase 2 widening — re-exports for plugin extraction Phase 2.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -32,6 +32,7 @@
   "files": [
     "index.ts",
     "index.d.ts",
+    "define.ts",
     "plugin.ts",
     "plugin.d.ts",
     "README.md",

--- a/test/isolated/sdk-define-plugin-runtime-coverage.test.ts
+++ b/test/isolated/sdk-define-plugin-runtime-coverage.test.ts
@@ -1,0 +1,33 @@
+/**
+ * @summary Runtime smoke for packages/sdk/define.ts (ABI-style plugin declaration surface).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { definePlugin } from "../../packages/sdk/define";
+
+describe("definePlugin runtime contract", () => {
+  test("returns manifest with an implement() helper", () => {
+    const plugin = definePlugin({
+      name: "relay",
+      hooks: {
+        on: ["transport:after_send"],
+      },
+      module: {
+        path: "./impl.ts",
+        exports: ["onTransportAfterSend"],
+      },
+    } as const);
+
+    expect(plugin.name).toBe("relay");
+    expect(plugin.module.path).toBe("./impl.ts");
+    expect(typeof plugin.implement).toBe("function");
+
+    const withHandler = plugin.implement({
+      onTransportAfterSend(event) {
+        expect(event.result.ok).toBe(true);
+      },
+    });
+
+    expect(withHandler.onTransportAfterSend).toBeDefined();
+  });
+});

--- a/test/sdk-package.test.ts
+++ b/test/sdk-package.test.ts
@@ -47,6 +47,11 @@ describe("@maw-js/sdk workspace package", () => {
     expect(indexDts).toMatch(/export declare const maw/);
     expect(indexDts).toMatch(/export interface Identity/);
     expect(indexDts).toMatch(/export declare function importPluginSymbol/);
+    expect(indexDts).toMatch(/export declare function definePlugin/);
+    expect(indexDts).toMatch(/export interface PluginManifestInput/);
+    expect(indexDts).toMatch(/export type EventToHandlerName/);
+    expect(indexDts).toMatch(/export type HandlersFor/);
+    expect(indexDts).toMatch(/export type ValidateExports/);
     expect(pluginDts).toMatch(/export interface InvokeContext/);
     expect(pluginDts).toMatch(/export interface InvokeResult/);
   });
@@ -77,10 +82,10 @@ describe("@maw-js/sdk workspace package", () => {
         // Runtime import exposes the maw object
         writeFileSync(
           join(dir, "probe.ts"),
-          `import { maw, importPluginSymbol } from "@maw-js/sdk";
+          `import { maw, importPluginSymbol, definePlugin } from "@maw-js/sdk";
 import type { InvokeContext, InvokeResult } from "@maw-js/sdk/plugin";
 const h: (ctx: InvokeContext) => Promise<InvokeResult> = async () => ({ ok: true });
-console.log(typeof maw.identity, typeof maw.federation, typeof maw.baseUrl, typeof importPluginSymbol, typeof h);
+console.log(typeof maw.identity, typeof maw.federation, typeof maw.baseUrl, typeof importPluginSymbol, typeof definePlugin, typeof h);
 `,
         );
         const run = runBunChild({
@@ -88,7 +93,7 @@ console.log(typeof maw.identity, typeof maw.federation, typeof maw.baseUrl, type
           script: `await import(${JSON.stringify(pathToFileURL(join(dir, "probe.ts")).href)});`,
         });
         expect(run.code).toBe(0);
-        expect(run.stdout.trim()).toBe("function function function function function");
+        expect(run.stdout.trim()).toBe("function function function function function function");
       } finally {
         rmSync(dir, { recursive: true, force: true });
       }


### PR DESCRIPTION
Closes #2494

## Summary
- Added `packages/sdk/define.ts` with the typed plugin authoring API:
  - `EventToHandlerName`
  - `HandlersFor`
  - `ValidateExports`
  - `definePlugin`
- Exported helper types and `definePlugin` from `packages/sdk/index.ts`
- Updated package file list to include `define.ts`
- Updated SDK package tests to assert new symbols are declared and importable
- Added runtime smoke coverage test for `definePlugin`

## Validation
- `bun test test/sdk-package.test.ts`
- `bun test test/isolated/sdk-define-plugin-runtime-coverage.test.ts`
- `bun test test/isolated/sdk-broadcast-exports.test.ts test/isolated/sdk-config-export.test.ts test/isolated/sdk-messages-export.test.ts test/isolated/sdk-tmux-export.test.ts`
