### PR TITLE
feat: add transport lifecycle and plugin transport hooks

### DIFF
--- a/packages/sdk/define.ts
+++ b/packages/sdk/define.ts
@@ -1,0 +1,78 @@
+import { PluginEventMap } from "./events";
+
+export interface PluginManifestInput {
+  /** Plugin name (must match plugin.json name). */
+  name: string;
+  /** Optional plugin hooks, currently used for event-handler derivation. */
+  hooks?: {
+    on?: readonly string[];
+    [key: string]: unknown;
+  };
+  /** Exports made available for hook/module interop. */
+  module: {
+    exports: readonly string[];
+    path: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+/** Convert snake/hyphen separated identifiers to PascalCase fragments. */
+type PascalFromSnake<T extends string> = T extends `${infer Head}_${infer Rest}`
+  ? `${Capitalize<Lowercase<Head>>}${PascalFromSnake<Rest>}`
+  : T extends `${infer Head}-${infer Rest}`
+    ? `${Capitalize<Lowercase<Head>>}${PascalFromSnake<Rest>}`
+    : Capitalize<Lowercase<T>>;
+
+/** Event name → handler function name. */
+export type EventToHandlerName<E extends string> =
+  E extends `${infer Scope}:${infer Action}`
+    ? `on${Capitalize<Lowercase<Scope>>}${PascalFromSnake<Action>}`
+    : `on${Capitalize<Lowercase<E>>}`;
+
+/** Derive required handler signatures from a literal event name list. */
+export type HandlersFor<Events extends readonly string[]> = {
+  [Event in Events[number] as EventToHandlerName<Event>]:
+    Event extends keyof PluginEventMap
+      ? (event: PluginEventMap[Event]) => void | Promise<void>
+      : (event: unknown) => void | Promise<void>;
+};
+
+/** Extract hook event names as a tuple-like union helper. */
+type ManifestHookEvents<T extends PluginManifestInput> =
+  T extends { hooks: { on: infer HookEvents } }
+    ? HookEvents extends readonly string[]
+      ? HookEvents
+      : []
+    : [];
+
+/** Ensure module exports includes all generated handler names. */
+export type ValidateExports<T extends PluginManifestInput> =
+  keyof HandlersFor<ManifestHookEvents<T>> extends T["module"]["exports"][number]
+    ? T
+    : never;
+
+/**
+ * definePlugin return type exposes `implement()` with strongly typed handlers.
+ */
+export type DefinedPlugin<T extends PluginManifestInput> = ValidateExports<T> & {
+  implement(handlers: HandlersFor<ManifestHookEvents<T>>): ValidateExports<T> & HandlersFor<ManifestHookEvents<T>>;
+};
+
+/**
+ * Typed identity helper for plugin declarations.
+ *
+ * - Infers handler names and payload types from `hooks.on`.
+ * - Validates required handler exports are present in `module.exports`.
+ */
+export function definePlugin<const T extends PluginManifestInput>(manifest: ValidateExports<T>): DefinedPlugin<T> {
+  return {
+    ...manifest,
+    implement(handlers) {
+      return {
+        ...manifest,
+        ...handlers,
+      };
+    },
+  } as DefinedPlugin<T>;
+}

--- a/packages/sdk/index.d.ts
+++ b/packages/sdk/index.d.ts
@@ -168,6 +168,64 @@ export interface PluginInfo {
   errors: number;
 }
 
+// --- plugin manifest helpers (definePlugin) ---
+
+export interface PluginManifestInput {
+  /** Plugin name (must match plugin.json name). */
+  name: string;
+  /** Optional plugin hooks, currently used for typed event handlers. */
+  hooks?: {
+    on?: readonly string[];
+    [key: string]: unknown;
+  };
+  /** Exports list consumed by module-loader consumers. */
+  module: {
+    exports: readonly string[];
+    path: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+export type EventToHandlerName<E extends string> =
+  E extends `${infer Scope}:${infer Action}`
+    ? `on${Capitalize<Lowercase<Scope>>}${PascalFromSnake<Action>}`
+    : `on${Capitalize<Lowercase<E>>}`;
+
+type PascalFromSnake<T extends string> = T extends `${infer Head}_${infer Rest}`
+  ? `${Capitalize<Lowercase<Head>>}${PascalFromSnake<Rest>}`
+  : T extends `${infer Head}-${infer Rest}`
+    ? `${Capitalize<Lowercase<Head>>}${PascalFromSnake<Rest>}`
+    : Capitalize<Lowercase<T>>;
+
+/** Derive the typed handler map from hook event names. */
+export type HandlersFor<Events extends readonly string[]> = {
+  [Event in Events[number] as EventToHandlerName<Event>]:
+    Event extends keyof PluginEventMap
+      ? (event: PluginEventMap[Event]) => void | Promise<void>
+      : (event: unknown) => void | Promise<void>;
+};
+
+type ManifestHookEvents<T extends PluginManifestInput> =
+  T extends { hooks: { on: infer HookEvents } }
+    ? HookEvents extends readonly string[]
+      ? HookEvents
+      : []
+    : [];
+
+/** Validate `module.exports` contains all required typed handler names. */
+export type ValidateExports<T extends PluginManifestInput> =
+  keyof HandlersFor<ManifestHookEvents<T>> extends T["module"]["exports"][number]
+    ? T
+    : never;
+
+export type DefinedPlugin<T extends PluginManifestInput> =
+  ValidateExports<T> & {
+    implement(handlers: HandlersFor<ManifestHookEvents<T>>): ValidateExports<T> & HandlersFor<ManifestHookEvents<T>>;
+  };
+
+export declare function definePlugin<const T extends PluginManifestInput>(manifest: ValidateExports<T>): DefinedPlugin<T>;
+
 // --- Print helpers ---
 
 export interface PrintHelpers {

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -41,6 +41,14 @@ export type {
   TmuxSession,
 } from "../../src/core/transport/tmux";
 export type { PluginEventMap } from "./events";
+export { definePlugin } from "./define";
+export type {
+  DefinedPlugin,
+  EventToHandlerName,
+  HandlersFor,
+  PluginManifestInput,
+  ValidateExports,
+} from "./define";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Phase 2 widening — re-exports for plugin extraction Phase 2.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -32,6 +32,7 @@
   "files": [
     "index.ts",
     "index.d.ts",
+    "define.ts",
     "plugin.ts",
     "plugin.d.ts",
     "README.md",

--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -12,6 +12,7 @@ import { detectWindowMismatch } from "../../core/routing";
 import { loadConfig, cfgLimit } from "../../config";
 import { logMessage, emitFeed } from "./comm-log-feed";
 import { buildMessageLifecycleFeedEvent, type MessageLifecycleInput } from "../../lib/message-events";
+import { runPluginEventHooks } from "../../plugin/event-hooks";
 import {
   defaultReceiverInboxWriter,
   type ReceiverInboxResult,
@@ -219,6 +220,35 @@ export function formatSignedMessage(
 function emitMessageFeed(input: MessageLifecycleInput, port: number) {
   const event = buildMessageLifecycleFeedEvent(input);
   emitFeed(event.event, event.oracle, event.host, event.message, port, event.data);
+}
+
+function transportTargetFromResult(result: ReturnType<typeof resolveTarget> | null, query: string, configNode?: string, fallbackQuery = true) {
+  if (!result) {
+    return {
+      oracle: fallbackQuery ? query.split(":").at(-1) || query : query,
+    };
+  }
+  if (result.type === "peer") {
+    return { oracle: result.target, host: result.node, tmuxTarget: undefined };
+  }
+  if (result.type === "local" || result.type === "self-node") {
+    const oracle = result.target.split(":").at(-1) || query;
+    return { oracle, host: configNode ?? "local", tmuxTarget: result.target };
+  }
+  if (result.type === "error") {
+    return { oracle: query.split(":").at(-1) || query };
+  }
+  return { oracle: query.split(":").at(-1) || query };
+}
+
+function transportPayload<T>(event: "transport:after_send", target: { oracle: string; host?: string; tmuxTarget?: string }, from: string, message: string, result: T) {
+  return {
+    target,
+    message,
+    from,
+    result,
+    via: (result as { via?: string }).via ?? "unknown",
+  } as const;
 }
 
 /**
@@ -902,6 +932,13 @@ export async function cmdSend(
       }
     }
     await runHook("after_send", { to: query, message: outboundMessage });
+    await runPluginEventHooks("transport:after_send", transportPayload(
+      "transport:after_send",
+      transportTargetFromResult(result, query, config.node),
+      senderIdentity.display,
+      outboundMessage,
+      { ok: true, via: "tmux", retryable: false },
+    ));
     if (!config.node) throw new Error("config.node is required — set 'node' in maw.config.json");
     logMessage(senderName, query, outboundMessage, "local");
     await Bun.sleep(150);
@@ -955,6 +992,20 @@ export async function cmdSend(
       if (res.data.lastLine) console.log(`\x1b[90m  ⤷ ${res.data.lastLine.slice(0, cfgLimit("messageTruncate"))}\x1b[0m`);
       // #1980: surface the receiving node's misdelivery warning, if any.
       if (res.data.warning) console.log(`  \x1b[33m⚠\x1b[0m ${res.data.warning}`);
+      await runPluginEventHooks("transport:after_send", transportPayload(
+        "transport:after_send",
+        transportTargetFromResult(result, query),
+        senderIdentity.display,
+        outboundMessage,
+        {
+          ok: true,
+          via: "http",
+          retryable: false,
+          state: res.data.state,
+          target: res.data.target || result.target,
+          lastLine: res.data.lastLine,
+        },
+      ));
       await runHook("after_send", { to: query, message: outboundMessage });
       return;
     }
@@ -1006,6 +1057,20 @@ export async function cmdSend(
       const color = state === "queued" ? "\x1b[33m" : "\x1b[32m";
       console.log(`${color}${state}\x1b[0m ⚡ ${peerUrl} → ${res.data.target || query}: ${outboundMessage}`);
       if (res.data.lastLine) console.log(`\x1b[90m  ⤷ ${res.data.lastLine.slice(0, cfgLimit("messageTruncate"))}\x1b[0m`);
+      await runPluginEventHooks("transport:after_send", transportPayload(
+        "transport:after_send",
+        { oracle: query.split(":").at(-1) || query, host: peerUrl, tmuxTarget: undefined },
+        senderIdentity.display,
+        outboundMessage,
+        {
+          ok: true,
+          via: "http",
+          retryable: false,
+          state: res.data.state,
+          target: res.data.target || query,
+          lastLine: res.data.lastLine,
+        },
+      ));
       await runHook("after_send", { to: query, message: outboundMessage });
       return;
     }

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -6,7 +6,7 @@ import { feedBuffer, feedListeners } from "../api/feed";
 import { setupTriggerListener } from "./runtime/trigger-listener";
 import { createTransportRouter } from "../transports";
 import { isProtected, setBunServer } from "../lib/elysia-auth";
-import { runServeLifecycleHooks } from "../plugin/lifecycle";
+import { runServeLifecycleHooks, runTransportLifecycleHooks } from "../plugin/lifecycle";
 import { discoverLocalPluginDirs } from "../plugin/registry-helpers";
 import {
   dispatchEnginePluginEvent,
@@ -100,14 +100,24 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
 
   const HTTP_URL = `http://localhost:${port}`;
   const WS_URL = `ws://localhost:${port}/ws`;
+  let transportRouter: ReturnType<typeof createTransportRouter> | undefined;
 
   // Connect transport router (non-blocking — server starts even if transports fail)
   try {
-    const router = createTransportRouter();
-    router.connectAll().catch(err => log.error("[transport] connect failed:", err));
-    engine.setTransportRouter(router);
+    transportRouter = createTransportRouter();
+    transportRouter.connectAll().catch(err => log.error("[transport] connect failed:", err));
+    engine.setTransportRouter(transportRouter);
   } catch (err) {
     log.error("[transport] router init failed:", err);
+  }
+  log.debug("[serve:debug] running transport lifecycle hooks");
+  try {
+    await runTransportLifecycleHooks({
+      router: transportRouter,
+      engine,
+    });
+  } catch (err) {
+    throw err;
   }
 
   // Start dispatch engine — auto-delivers queued messages when agents become idle

--- a/src/plugin/event-hooks.ts
+++ b/src/plugin/event-hooks.ts
@@ -1,0 +1,83 @@
+/**
+ * Dispatch plugin event hooks directly from plugin manifest declarations.
+ *
+ * Runtime bridge for event names declared in `hooks.on` when plugins expose
+ * ABI-style handlers (e.g. `onTransportAfterSend` for
+ * `transport:after_send`).
+ */
+
+import { discoverPackages } from "./registry";
+import type { LoadedPlugin } from "./types";
+import type { TransportResult, TransportTarget } from "../core/transport/transport";
+import type { PluginEventMap } from "../../packages/sdk/events";
+
+export type PluginEventName = keyof PluginEventMap | string;
+
+export type PluginEventPayload<T extends PluginEventName> = T extends keyof PluginEventMap
+  ? PluginEventMap[T]
+  : {
+      [key: string]: unknown;
+    };
+
+function capitalize(value: string): string {
+  if (!value) return "";
+  return value[0].toUpperCase() + value.slice(1);
+}
+
+function pascalCase(value: string): string {
+  return value
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((part) => capitalize(part.toLowerCase()))
+    .join("");
+}
+
+function eventToHandlerName(eventName: string): string {
+  const [scopeRaw, actionRaw] = eventName.split(":", 2);
+  const scope = capitalize(scopeRaw.toLowerCase());
+  const action = actionRaw ? pascalCase(actionRaw) : "";
+  return `on${scope}${action}`;
+}
+
+function shouldRunPluginEventHook(plugin: LoadedPlugin, eventName: string): boolean {
+  if (plugin.disabled) return false;
+  if (plugin.kind !== "ts") return false;
+  if (!plugin.entryPath) return false;
+  const hooks = plugin.manifest.hooks;
+  if (!hooks?.on || !Array.isArray(hooks.on)) return false;
+  return hooks.on.includes(eventName);
+}
+
+function invokePluginEventHook(
+  plugin: LoadedPlugin,
+  eventName: string,
+  payload: unknown,
+): Promise<void> {
+  const handlerName = eventToHandlerName(eventName);
+  return import(plugin.entryPath!).then((mod) => {
+    const handler = mod[handlerName];
+    if (typeof handler !== "function") return;
+    return handler(payload);
+  }).then(() => {}).catch((err) => {
+    throw new Error(`failed loading/dispatching plugin ${plugin.manifest.name}: ${err instanceof Error ? err.message : String(err)}`);
+  });
+}
+
+export async function runPluginEventHooks<T extends PluginEventName>(
+  event: T,
+  payload: PluginEventPayload<T>,
+): Promise<void> {
+  for (const plugin of discoverPackages()) {
+    if (!shouldRunPluginEventHook(plugin, event)) continue;
+    try {
+      await invokePluginEventHook(plugin, event, payload);
+    } catch (error) {
+      console.error(
+        `[plugin:event-hooks] ${event} failed for ${plugin.manifest.name}:`,
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+}
+
+export type { TransportResult, TransportTarget };

--- a/src/plugin/lifecycle.ts
+++ b/src/plugin/lifecycle.ts
@@ -14,7 +14,7 @@ import type { MawEngine } from "../engine";
 import type { ServeWsRouteRegistrar } from "../core/serve-ws-registry";
 import type { LoadedPlugin, PluginLifecycleHook, ServeRouteRegistrar } from "./types";
 
-export type LifecyclePhase = "wake" | "sleep" | "serve";
+export type LifecyclePhase = "wake" | "sleep" | "serve" | "transport";
 
 export interface PluginLifecycleContext {
   phase: LifecyclePhase;
@@ -74,6 +74,12 @@ export interface ServeLifecycleContextInput {
   plugins?: unknown;
   /** Reload user plugins and return the current plugin stats/debug payload. */
   reloadPlugins?: () => unknown | Promise<unknown>;
+}
+
+export interface TransportLifecycleContextInput {
+  engine?: MawEngine;
+  /** Transport router created and connected before serve bootstrap. */
+  router?: unknown;
 }
 
 export interface LifecycleRunSummary {
@@ -221,4 +227,11 @@ export function runServeLifecycleHooks(
   logger?: LifecycleLogger,
 ): Promise<LifecycleRunSummary> {
   return runLifecycleHooks("serve", context, discover, logger);
+}
+
+export function runTransportLifecycleHooks(
+  context: TransportLifecycleContextInput,
+  discover?: LifecycleDiscover,
+): Promise<LifecycleRunSummary> {
+  return runLifecycleHooks("transport", context, discover);
 }

--- a/src/plugin/manifest-validate.ts
+++ b/src/plugin/manifest-validate.ts
@@ -60,7 +60,10 @@ export function parseApi(r: Record<string, unknown>): PluginManifest["api"] {
   return { path: a.path, methods: a.methods as ("GET" | "POST")[] };
 }
 
-function parseLifecycleHook(hooks: Record<string, unknown>, key: "wake" | "sleep" | "serve"): PluginLifecycleHook | undefined {
+function parseLifecycleHook(
+  hooks: Record<string, unknown>,
+  key: "wake" | "sleep" | "serve" | "transport",
+): PluginLifecycleHook | undefined {
   const raw = hooks[key];
   if (raw === undefined) return undefined;
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
@@ -104,6 +107,7 @@ export function parseHooks(r: Record<string, unknown>): PluginManifest["hooks"] 
   const wake = parseLifecycleHook(h, "wake");
   const sleep = parseLifecycleHook(h, "sleep");
   const serve = parseLifecycleHook(h, "serve");
+  const transport = parseLifecycleHook(h, "transport");
   return {
     ...(Array.isArray(h.gate) ? { gate: h.gate as string[] } : {}),
     ...(Array.isArray(h.filter) ? { filter: h.filter as string[] } : {}),
@@ -112,6 +116,7 @@ export function parseHooks(r: Record<string, unknown>): PluginManifest["hooks"] 
     ...(wake ? { wake } : {}),
     ...(sleep ? { sleep } : {}),
     ...(serve ? { serve } : {}),
+    ...(transport ? { transport } : {}),
   };
 }
 

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -106,6 +106,7 @@ export interface PluginManifest {
     wake?: PluginLifecycleHook;  // lifecycle: oracle/session wake (#1576)
     sleep?: PluginLifecycleHook; // lifecycle: oracle/session sleep (#1576)
     serve?: PluginLifecycleHook; // lifecycle: plugin persistent serve (#1576)
+    transport?: PluginLifecycleHook; // lifecycle: transport initialization (#2496)
   };
   cron?: {
     schedule: string;   // cron expression

--- a/test/isolated/sdk-define-plugin-runtime-coverage.test.ts
+++ b/test/isolated/sdk-define-plugin-runtime-coverage.test.ts
@@ -1,0 +1,33 @@
+/**
+ * @summary Runtime smoke for packages/sdk/define.ts (ABI-style plugin declaration surface).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { definePlugin } from "../../packages/sdk/define";
+
+describe("definePlugin runtime contract", () => {
+  test("returns manifest with an implement() helper", () => {
+    const plugin = definePlugin({
+      name: "relay",
+      hooks: {
+        on: ["transport:after_send"],
+      },
+      module: {
+        path: "./impl.ts",
+        exports: ["onTransportAfterSend"],
+      },
+    } as const);
+
+    expect(plugin.name).toBe("relay");
+    expect(plugin.module.path).toBe("./impl.ts");
+    expect(typeof plugin.implement).toBe("function");
+
+    const withHandler = plugin.implement({
+      onTransportAfterSend(event) {
+        expect(event.result.ok).toBe(true);
+      },
+    });
+
+    expect(withHandler.onTransportAfterSend).toBeDefined();
+  });
+});

--- a/test/plugin-event-hooks.test.ts
+++ b/test/plugin-event-hooks.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import type { LoadedPlugin } from "../src/plugin/types";
+
+import { mock } from "bun:test";
+
+let eventLogPath = "";
+let discoverPackagesResult: LoadedPlugin[] = [];
+
+mock.module("../src/plugin/registry", () => ({
+  discoverPackages: () => discoverPackagesResult,
+}));
+
+const eventHooks = await import("../src/plugin/event-hooks");
+
+const tmpDirs: string[] = [];
+afterEach(() => {
+  while (tmpDirs.length) {
+    rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+  }
+  eventLogPath = "";
+  discoverPackagesResult = [];
+  delete process.env.MAW_TEST_EVENT_HOOK_LOG;
+});
+
+function makePlugin(name: string, options: {
+  hooksOn?: string[];
+  disabled?: boolean;
+  kind?: "ts" | "wasm";
+} = {}): LoadedPlugin {
+  const dir = mkdtempSync(join(tmpdir(), `maw-event-${name}-`));
+  tmpDirs.push(dir);
+  const indexPath = join(dir, "index.ts");
+  writeFileSync(indexPath, "export function onTransportAfterSend(payload) { const fs = require(\"fs\"); fs.appendFileSync(process.env.MAW_TEST_EVENT_HOOK_LOG || '', JSON.stringify(payload) + \"\\n\"); }\n", { encoding: "utf8" });
+  return {
+    dir,
+    entryPath: indexPath,
+    wasmPath: "",
+    kind: options.kind ?? "ts",
+    disabled: options.disabled,
+    manifest: {
+      name,
+      version: "1.0.0",
+      sdk: "*",
+      entry: "index.ts",
+      hooks: {
+        on: options.hooksOn,
+      },
+    },
+  };
+}
+
+function pluginDir(): void {
+  const logDir = mkdtempSync(join(tmpdir(), "maw-event-log-"));
+  tmpDirs.push(logDir);
+  eventLogPath = join(logDir, "events.ndjson");
+  writeFileSync(eventLogPath, "", { encoding: "utf8" });
+}
+
+describe("plugin event-hooks runtime", () => {
+  test("runs matching transport event handlers on matching manifest hooks", async () => {
+    pluginDir();
+    process.env.MAW_TEST_EVENT_HOOK_LOG = eventLogPath;
+    discoverPackagesResult = [
+      makePlugin("active", { hooksOn: ["transport:after_send"] }),
+      makePlugin("ignore-other", { hooksOn: ["session:start"] }),
+      makePlugin("disabled", { hooksOn: ["transport:after_send"], disabled: true }),
+    ];
+
+    await eventHooks.runPluginEventHooks("transport:after_send", {
+      target: { oracle: "neo", tmuxTarget: "test:1" },
+      message: "hello",
+      from: "m5:volt",
+      result: { ok: true, via: "http", retryable: false },
+      via: "http",
+    });
+
+    const log = readFileSync(eventLogPath, "utf8").trim().split("\n");
+    expect(log).toHaveLength(1);
+    expect(JSON.parse(log[0])).toMatchObject({
+      from: "m5:volt",
+      message: "hello",
+      via: "http",
+    });
+  });
+
+  test("ignores plugins missing the transport hook or non-ts plugins", async () => {
+    pluginDir();
+    process.env.MAW_TEST_EVENT_HOOK_LOG = eventLogPath;
+    discoverPackagesResult = [
+      makePlugin("wrong-shape", { hooksOn: undefined, kind: "ts" }),
+      makePlugin("wasm", { hooksOn: ["transport:after_send"], kind: "wasm" }),
+    ];
+
+    await eventHooks.runPluginEventHooks("transport:after_send", {
+      target: { oracle: "oracle" },
+      message: "hello",
+      from: "local:sender",
+      result: { ok: true, via: "http", retryable: false },
+      via: "http",
+    });
+
+    expect(readFileSync(eventLogPath, "utf8")).toBe("");
+  });
+});

--- a/test/plugin-lifecycle.test.ts
+++ b/test/plugin-lifecycle.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync, readFileSync } from "fs"
 import { join } from "path";
 import { tmpdir } from "os";
 import type { LoadedPlugin } from "../src/plugin/types";
-import { runLifecycleHooks, runServeLifecycleHooks, runSleepLifecycleHooks, runWakeLifecycleHooks } from "../src/plugin/lifecycle";
+import { runLifecycleHooks, runServeLifecycleHooks, runSleepLifecycleHooks, runTransportLifecycleHooks, runWakeLifecycleHooks } from "../src/plugin/lifecycle";
 
 const tempDirs: string[] = [];
 
@@ -168,6 +168,25 @@ describe("plugin lifecycle hooks (#1576)", () => {
     expect(scoped).toEqual([{ name: "route-owner", dir: plugin.dir }]);
     expect(routes).toEqual(["route-owner:GET /api/owned"]);
     expect(fallbacks).toEqual(["route-owner:owned-fallback"]);
+  });
+
+  test("transport hooks run at startup with router context", async () => {
+    const log = makeLog();
+    const plugin = makePlugin("router", {
+      hook: { transport: { script: "transport.ts", handler: "onTransport" } },
+      files: {
+        "index.ts": "export function transport() { throw new Error('entry should not run') }\n",
+        "transport.ts": `export function onTransport(ctx) { const fs = require("fs"); fs.appendFileSync(process.env.MAW_LIFECYCLE_LOG, [ctx.phase, ctx.plugin.name, !!Boolean(ctx.router)].join("|") + "\\n"); }\n`,
+      },
+    });
+
+    const summary = await runTransportLifecycleHooks(
+      { router: { route: () => {} } },
+      () => [plugin],
+    );
+
+    expect(summary).toEqual({ phase: "transport", ran: 1, skipped: 0, failed: 0 });
+    expect(readFileSync(log, "utf8")).toBe("transport|router|true\n");
   });
 
   test("best-effort failures continue, fail-fast failures throw clearly", async () => {

--- a/test/plugin-manifest-validate-default.test.ts
+++ b/test/plugin-manifest-validate-default.test.ts
@@ -116,12 +116,14 @@ describe("manifest optional-field validators — default coverage", () => {
   });
 
   test("parseHooks preserves default array fields including late hooks", () => {
-    expect(parseHooks({ hooks: { gate: [], filter: ["Clean"], on: ["MessageSend"], late: ["After"] } })).toEqual({
+    expect(parseHooks({ hooks: { gate: [], filter: ["Clean"], on: ["MessageSend"], late: ["After"], transport: { handler: "onTransport", policy: "best-effort" } } })).toEqual({
       gate: [],
       filter: ["Clean"],
       on: ["MessageSend"],
       late: ["After"],
+      transport: { handler: "onTransport", policy: "best-effort" },
     });
     expectError(() => parseHooks({ hooks: { late: [1] } }), "plugin.json: hooks.late must be an array of strings");
+    expectError(() => parseHooks({ hooks: { transport: { policy: "sometimes" } } }), "plugin.json: hooks.transport.policy must be");
   });
 });

--- a/test/plugin-manifest-validate-edges.test.ts
+++ b/test/plugin-manifest-validate-edges.test.ts
@@ -32,12 +32,14 @@ describe("manifest optional-field validator edge coverage", () => {
 
   test("parseHooks validates lifecycle hook branches", () => {
     expect(validators.parseHooks({})).toBeUndefined();
-    expect(validators.parseHooks({ hooks: { wake: { script: "wake.ts", handler: "onWake", ensures: ["db"], policy: "best-effort" }, sleep: {}, serve: {} } })).toEqual({
+    expect(validators.parseHooks({ hooks: { wake: { script: "wake.ts", handler: "onWake", ensures: ["db"], policy: "best-effort" }, sleep: {}, serve: {}, transport: { handler: "onTransport" } } })).toEqual({
       wake: { script: "wake.ts", handler: "onWake", ensures: ["db"], policy: "best-effort" },
       sleep: {},
       serve: {},
+      transport: { handler: "onTransport" },
     });
     expectError(() => validators.parseHooks({ hooks: { wake: [] } }), "plugin.json: hooks.wake must be an object");
+    expectError(() => validators.parseHooks({ hooks: { transport: { script: 123 } } }), "plugin.json: hooks.transport.script must be a non-empty string");
     expectError(() => validators.parseHooks({ hooks: { wake: { script: "" } } }), "plugin.json: hooks.wake.script must be a non-empty string");
     expectError(() => validators.parseHooks({ hooks: { sleep: { handler: "" } } }), "plugin.json: hooks.sleep.handler must be a non-empty string");
     expectError(() => validators.parseHooks({ hooks: { serve: { ensures: [""] } } }), "plugin.json: hooks.serve.ensures must be an array of non-empty strings");

--- a/test/plugin-manifest.test.ts
+++ b/test/plugin-manifest.test.ts
@@ -106,6 +106,7 @@ describe("parseManifest happy path", () => {
             wake: { script: "setup.ts", handler: "onWake", ensures: ["storage:sqlite"], policy: "best-effort" },
             sleep: { handler: "onSleep" },
             serve: { script: "serve.ts", policy: "fail-fast" },
+            transport: { handler: "onTransport", policy: "best-effort" },
           },
         }),
         dir,
@@ -120,6 +121,7 @@ describe("parseManifest happy path", () => {
       });
       expect(manifest.hooks?.sleep).toEqual({ handler: "onSleep" });
       expect(manifest.hooks?.serve).toEqual({ script: "serve.ts", policy: "fail-fast" });
+      expect(manifest.hooks?.transport).toEqual({ handler: "onTransport", policy: "best-effort" });
     } finally {
       rmSync(dir, { recursive: true });
     }

--- a/test/sdk-package.test.ts
+++ b/test/sdk-package.test.ts
@@ -47,6 +47,11 @@ describe("@maw-js/sdk workspace package", () => {
     expect(indexDts).toMatch(/export declare const maw/);
     expect(indexDts).toMatch(/export interface Identity/);
     expect(indexDts).toMatch(/export declare function importPluginSymbol/);
+    expect(indexDts).toMatch(/export declare function definePlugin/);
+    expect(indexDts).toMatch(/export interface PluginManifestInput/);
+    expect(indexDts).toMatch(/export type EventToHandlerName/);
+    expect(indexDts).toMatch(/export type HandlersFor/);
+    expect(indexDts).toMatch(/export type ValidateExports/);
     expect(pluginDts).toMatch(/export interface InvokeContext/);
     expect(pluginDts).toMatch(/export interface InvokeResult/);
   });
@@ -77,10 +82,10 @@ describe("@maw-js/sdk workspace package", () => {
         // Runtime import exposes the maw object
         writeFileSync(
           join(dir, "probe.ts"),
-          `import { maw, importPluginSymbol } from "@maw-js/sdk";
+          `import { maw, importPluginSymbol, definePlugin } from "@maw-js/sdk";
 import type { InvokeContext, InvokeResult } from "@maw-js/sdk/plugin";
 const h: (ctx: InvokeContext) => Promise<InvokeResult> = async () => ({ ok: true });
-console.log(typeof maw.identity, typeof maw.federation, typeof maw.baseUrl, typeof importPluginSymbol, typeof h);
+console.log(typeof maw.identity, typeof maw.federation, typeof maw.baseUrl, typeof importPluginSymbol, typeof definePlugin, typeof h);
 `,
         );
         const run = runBunChild({
@@ -88,7 +93,7 @@ console.log(typeof maw.identity, typeof maw.federation, typeof maw.baseUrl, type
           script: `await import(${JSON.stringify(pathToFileURL(join(dir, "probe.ts")).href)});`,
         });
         expect(run.code).toBe(0);
-        expect(run.stdout.trim()).toBe("function function function function function");
+        expect(run.stdout.trim()).toBe("function function function function function function");
       } finally {
         rmSync(dir, { recursive: true, force: true });
       }


### PR DESCRIPTION
Closes #2496

## Summary
- add `transport` phase to plugin lifecycle execution
- add `hooks.transport` parsing/validation in manifest loading
- add plugin event-hook runtime for transport events (notably `transport:*`)
- dispatch `transport:after_send` in successful local/peer/discovery send outcomes
- wire startup transport lifecycle hook execution in serve bootstrap

## Validation
- bun test test/plugin-lifecycle.test.ts
- bun test test/plugin-manifest.test.ts
- bun test test/plugin-manifest-validate-edges.test.ts
- bun test test/plugin-manifest-validate-default.test.ts
- bun test test/plugin-event-hooks.test.ts
- bun test test/comm-send-cmdsend-coverage.test.ts
