### PR TITLE
feat: transport lifecycle and cmdSend after_send event hooks (closes #2496)

### DIFF
--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -22,6 +22,7 @@ import {
   type HeyLocateResolution,
 } from "./hey-locate-resolution";
 import { checkBusyGuard, queueForDispatch } from "../../core/agent-status-guard";
+import { runPluginEventHooks } from "../../plugin/event-hooks";
 
 /**
  * Resolve a `session:window` target to a specific pane running an agent
@@ -921,6 +922,20 @@ export async function cmdSend(
     }, config.port || 3456);
     console.log(`\x1b[32mdelivered\x1b[0m → ${target}: ${outboundMessage}`);
     if (lastLine) console.log(`\x1b[90m  ⤷ ${lastLine.slice(0, cfgLimit("messageTruncate"))}\x1b[0m`);
+    await runPluginEventHooks("transport:after_send", {
+      event: "transport:after_send",
+      route: "local",
+      target,
+      to: query,
+      from: senderIdentity.display,
+      result: {
+        ok: true,
+        state: "local",
+        route: "local",
+      },
+      via: "tmux",
+      message: outboundMessage,
+    });
     // #1980: warn on silent misdelivery to a window that isn't the named oracle.
     const mismatch = detectWindowMismatch(query, result.target, sessions);
     if (mismatch) console.log(`  \x1b[33m⚠\x1b[0m ${mismatch}`);
@@ -955,6 +970,24 @@ export async function cmdSend(
       if (res.data.lastLine) console.log(`\x1b[90m  ⤷ ${res.data.lastLine.slice(0, cfgLimit("messageTruncate"))}\x1b[0m`);
       // #1980: surface the receiving node's misdelivery warning, if any.
       if (res.data.warning) console.log(`  \x1b[33m⚠\x1b[0m ${res.data.warning}`);
+      await runPluginEventHooks("transport:after_send", {
+        event: "transport:after_send",
+        route: "peer",
+        node: result.node,
+        target: result.target,
+        peerUrl: result.peerUrl,
+        to: query,
+        from: senderIdentity.display,
+        result: {
+          ok: state === "delivered",
+          state,
+          target: res.data.target || result.target,
+          peerUrl: result.peerUrl,
+          lastLine: res.data.lastLine,
+        },
+        via: "http",
+        message: outboundMessage,
+      });
       await runHook("after_send", { to: query, message: outboundMessage });
       return;
     }
@@ -1006,6 +1039,24 @@ export async function cmdSend(
       const color = state === "queued" ? "\x1b[33m" : "\x1b[32m";
       console.log(`${color}${state}\x1b[0m ⚡ ${peerUrl} → ${res.data.target || query}: ${outboundMessage}`);
       if (res.data.lastLine) console.log(`\x1b[90m  ⤷ ${res.data.lastLine.slice(0, cfgLimit("messageTruncate"))}\x1b[0m`);
+      await runPluginEventHooks("transport:after_send", {
+        event: "transport:after_send",
+        route: "discovery",
+        node: query.split(":")[0] ?? null,
+        target: res.data.target || query,
+        peerUrl,
+        to: query,
+        from: senderIdentity.display,
+        result: {
+          ok: state === "delivered",
+          state,
+          target: res.data.target || query,
+          peerUrl,
+          lastLine: res.data.lastLine,
+        },
+        via: "discovery",
+        message: outboundMessage,
+      });
       await runHook("after_send", { to: query, message: outboundMessage });
       return;
     }

--- a/src/plugin/event-hooks.ts
+++ b/src/plugin/event-hooks.ts
@@ -1,0 +1,106 @@
+import { discoverPackages } from "./registry";
+import type { LoadedPlugin } from "./types";
+
+type DiscoverPlugins = () => LoadedPlugin[];
+type AnyRecord = Record<string, unknown>;
+
+export interface PluginEventHooksSummary {
+  eventName: string;
+  matched: number;
+  invoked: number;
+  skipped: number;
+  failed: number;
+}
+
+const EVENT_HANDLER_EXPORTS = ["onEvent", "on", "handle"];
+
+function pascalCase(token: string): string {
+  return token
+    .split(/[-_.:]/)
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join("");
+}
+
+function deriveEventHandlerName(eventName: string): string {
+  const [scope, action] = eventName.split(":", 2);
+  if (!action) return `on${pascalCase(scope)}`;
+  return `on${pascalCase(scope)}${pascalCase(action)}`;
+}
+
+function sortByLifecycleOrder(plugins: LoadedPlugin[]): LoadedPlugin[] {
+  return [...plugins].sort(
+    (a, b) =>
+      (a.manifest.weight ?? 50) - (b.manifest.weight ?? 50)
+      || a.manifest.name.localeCompare(b.manifest.name),
+  );
+}
+
+function getEventHandler(mod: AnyRecord, eventName: string): ((payload: AnyRecord) => unknown) | null {
+  const eventHandler = eventName ? mod[deriveEventHandlerName(eventName)] : undefined;
+  if (typeof eventHandler === "function") {
+    return eventHandler as AnyRecord[keyof AnyRecord] as ((payload: AnyRecord) => unknown);
+  }
+  for (const name of EVENT_HANDLER_EXPORTS) {
+    const value = mod[name];
+    if (typeof value === "function") return value as AnyRecord[keyof AnyRecord] as ((payload: AnyRecord) => unknown);
+  }
+  return null;
+}
+
+function shouldHandle(hooks: { on?: string[] } | undefined, eventName: string): boolean {
+  const events = hooks?.on;
+  if (!Array.isArray(events)) return false;
+  return events.includes(eventName) || events.includes("*");
+}
+
+export async function runPluginEventHooks(
+  eventName: string,
+  payload: AnyRecord,
+  discover: DiscoverPlugins = discoverPackages,
+): Promise<PluginEventHooksSummary> {
+  const summary: PluginEventHooksSummary = {
+    eventName,
+    matched: 0,
+    invoked: 0,
+    skipped: 0,
+    failed: 0,
+  };
+
+  for (const plugin of sortByLifecycleOrder(discover())) {
+    if (plugin.disabled) {
+      summary.skipped += 1;
+      continue;
+    }
+    if (plugin.kind !== "ts" || !plugin.entryPath) {
+      summary.skipped += 1;
+      continue;
+    }
+    if (!shouldHandle(plugin.manifest.hooks, eventName)) {
+      continue;
+    }
+
+    summary.matched += 1;
+    try {
+      const mod = await import(plugin.entryPath);
+      const handler = getEventHandler(mod as AnyRecord, eventName);
+      if (!handler) {
+        summary.failed += 1;
+        continue;
+      }
+      await handler({
+        ...(payload as object),
+        plugin: {
+          name: plugin.manifest.name,
+          dir: plugin.dir,
+        },
+      } as AnyRecord);
+      summary.invoked += 1;
+    } catch {
+      summary.failed += 1;
+    }
+  }
+
+  return summary;
+}

--- a/src/plugin/lifecycle.ts
+++ b/src/plugin/lifecycle.ts
@@ -12,9 +12,11 @@ import { pathToFileURL } from "url";
 import { discoverPackages } from "./registry";
 import type { MawEngine } from "../engine";
 import type { ServeWsRouteRegistrar } from "../core/serve-ws-registry";
+import type { MawConfig } from "../config/types";
+import type { TransportRouter } from "../core/transport/transport";
 import type { LoadedPlugin, PluginLifecycleHook, ServeRouteRegistrar } from "./types";
 
-export type LifecyclePhase = "wake" | "sleep" | "serve";
+export type LifecyclePhase = "wake" | "sleep" | "serve" | "transport";
 
 export interface PluginLifecycleContext {
   phase: LifecyclePhase;
@@ -74,6 +76,18 @@ export interface ServeLifecycleContextInput {
   plugins?: unknown;
   /** Reload user plugins and return the current plugin stats/debug payload. */
   reloadPlugins?: () => unknown | Promise<unknown>;
+}
+
+export interface TransportLifecycleContextInput {
+  router: TransportRouter;
+  config: MawConfig;
+  /** Transport lifecycle logger scoped by CLI verbosity for transport plugins. */
+  log?: {
+    info?: (...args: unknown[]) => void;
+    warn?: (...args: unknown[]) => void;
+    debug?: (...args: unknown[]) => void;
+    error?: (...args: unknown[]) => void;
+  };
 }
 
 export interface LifecycleRunSummary {
@@ -221,4 +235,12 @@ export function runServeLifecycleHooks(
   logger?: LifecycleLogger,
 ): Promise<LifecycleRunSummary> {
   return runLifecycleHooks("serve", context, discover, logger);
+}
+
+export function runTransportLifecycleHooks(
+  context: TransportLifecycleContextInput,
+  discover?: LifecycleDiscover,
+  logger?: LifecycleLogger,
+): Promise<LifecycleRunSummary> {
+  return runLifecycleHooks("transport", context, discover, logger);
 }

--- a/src/plugin/manifest-validate.ts
+++ b/src/plugin/manifest-validate.ts
@@ -60,7 +60,10 @@ export function parseApi(r: Record<string, unknown>): PluginManifest["api"] {
   return { path: a.path, methods: a.methods as ("GET" | "POST")[] };
 }
 
-function parseLifecycleHook(hooks: Record<string, unknown>, key: "wake" | "sleep" | "serve" | "transport"): PluginLifecycleHook | undefined {
+function parseLifecycleHook(
+  hooks: Record<string, unknown>,
+  key: "wake" | "sleep" | "serve" | "transport",
+): PluginLifecycleHook | undefined {
   const raw = hooks[key];
   if (raw === undefined) return undefined;
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) {

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -106,7 +106,7 @@ export interface PluginManifest {
     wake?: PluginLifecycleHook;  // lifecycle: oracle/session wake (#1576)
     sleep?: PluginLifecycleHook; // lifecycle: oracle/session sleep (#1576)
     serve?: PluginLifecycleHook; // lifecycle: plugin persistent serve (#1576)
-    transport?: PluginLifecycleHook; // lifecycle: transport registration (#2496/#2498)
+    transport?: PluginLifecycleHook; // lifecycle: transport initialization (#2496)
   };
   cron?: {
     schedule: string;   // cron expression

--- a/test/comm-send-cmdsend-coverage.test.ts
+++ b/test/comm-send-cmdsend-coverage.test.ts
@@ -21,6 +21,7 @@ const _rScopeAcl = await import("../src/commands/shared/scope-acl");
 const _rQueueStore = await import("../src/commands/shared/queue-store");
 const _rTrustStore = await import("../src/lib/trust-store");
 const _rConsentGate = await import("../src/core/consent/gate");
+const _rEventHooks = await import("../src/plugin/event-hooks");
 const _rFindWindow = await import("../src/core/runtime/find-window");
 const realSdk = {
   listSessions: _rSdk.listSessions,
@@ -43,6 +44,7 @@ const realScopeAcl = { loadAllScopes: _rScopeAcl.loadAllScopes, evaluateAclFromD
 const realQueueStore = { savePending: _rQueueStore.savePending };
 const realTrustStore = { cmdAdd: _rTrustStore.cmdAdd };
 const realConsentGate = { maybeGateConsent: _rConsentGate.maybeGateConsent };
+const realEventHooks = { runPluginEventHooks: _rEventHooks.runPluginEventHooks };
 
 type Session = { name: string; windows: Array<{ index: number; name: string; active: boolean }> };
 type ResolvedTarget =
@@ -87,6 +89,7 @@ let savePendingCalls: any[];
 let trustAddCalls: Array<{ sender: string; target: string }>;
 let trustAddError: Error | null;
 let consentDecision: { allow: boolean; message?: string; exitCode?: number };
+let transportEventCalls: Array<{ eventName: string; payload: unknown }>;
 
 mock.module(join(import.meta.dir, "../src/sdk"), () => ({
   ..._rSdk,
@@ -207,6 +210,16 @@ mock.module(join(import.meta.dir, "../src/core/consent/gate"), () => ({
   maybeGateConsent: async (...args: Parameters<typeof realConsentGate.maybeGateConsent>) => mockActive ? consentDecision : realConsentGate.maybeGateConsent(...args),
 }));
 
+mock.module(join(import.meta.dir, "../src/plugin/event-hooks"), () => ({
+  ..._rEventHooks,
+  runPluginEventHooks: async (...args: Parameters<typeof realEventHooks.runPluginEventHooks>) => {
+    if (!mockActive) return realEventHooks.runPluginEventHooks(...args);
+    const [eventName, payload] = args;
+    transportEventCalls.push({ eventName, payload });
+    return { eventName, matched: 0, invoked: 0, skipped: 0, failed: 0 };
+  },
+}));
+
 const origSleep = Bun.sleep.bind(Bun);
 const origExit = process.exit;
 const origErr = console.error;
@@ -290,6 +303,7 @@ beforeEach(() => {
   trustAddCalls = [];
   trustAddError = null;
   consentDecision = { allow: true };
+  transportEventCalls = [];
   process.env.CLAUDE_AGENT_NAME = "sender";
   process.env.MAW_TEST_MODE = "1";
   delete process.env.MAW_CONSENT;
@@ -351,6 +365,23 @@ describe("cmdSend — delivery branch coverage", () => {
     expect(logMessageCalls).toEqual([{ from: "sender", to: "local:session:oracle", message: "[test-node:sender] hello", route: "local" }]);
     expect(captureCalls.map(c => c.lines)).toEqual([3]);
     expect(emitFeedCalls[0].data.route).toBe("local");
+    expect(transportEventCalls).toHaveLength(1);
+    expect(transportEventCalls[0]).toMatchObject({
+      eventName: "transport:after_send",
+      payload: {
+        event: "transport:after_send",
+        route: "local",
+        to: "local:session:oracle",
+        from: "test-node:sender",
+        via: "tmux",
+        message: "[test-node:sender] hello",
+        result: {
+          ok: true,
+          state: "local",
+          route: "local",
+        },
+      },
+    });
     expect(logs.join("\n")).toContain("delivered");
     expect(logs.join("\n")).toContain("accepted");
   });
@@ -521,6 +552,28 @@ describe("cmdSend — delivery branch coverage", () => {
     expect(logMessageCalls[0].route).toBe("peer:remote");
     expect(emitFeedCalls[0].data.route).toBe("peer");
     expect(emitFeedCalls[0].data.state).toBe("queued");
+    expect(transportEventCalls).toHaveLength(1);
+    expect(transportEventCalls[0]).toMatchObject({
+      eventName: "transport:after_send",
+      payload: {
+        event: "transport:after_send",
+        route: "peer",
+        node: "remote",
+        target: "oracle",
+        peerUrl: "http://remote:3456",
+        to: "remote:session:oracle",
+        from: "test-node:sender",
+        via: "http",
+        message: "[test-node:sender] ping",
+        result: {
+          ok: false,
+          state: "queued",
+          target: "remote-session:oracle.0",
+          peerUrl: "http://remote:3456",
+          lastLine: "remote ack",
+        },
+      },
+    });
     expect(logs.join("\n")).toContain("queued");
     expect(logs.join("\n")).not.toContain("delivered");
     expect(runHookCalls[0].name).toBe("after_send");
@@ -562,6 +615,28 @@ describe("cmdSend — delivery branch coverage", () => {
     expect(logMessageCalls[0].route).toBe("discovery");
     expect(emitFeedCalls[0].data.route).toBe("discovery");
     expect(emitFeedCalls[0].data.state).toBe("queued");
+    expect(transportEventCalls).toHaveLength(1);
+    expect(transportEventCalls[0]).toMatchObject({
+      eventName: "transport:after_send",
+      payload: {
+        event: "transport:after_send",
+        route: "discovery",
+        node: "path/target",
+        target: "found:0",
+        peerUrl: "http://discovered:3456",
+        to: "path/target",
+        from: "test-node:sender",
+        via: "discovery",
+        message: "[test-node:sender] hello",
+        result: {
+          ok: false,
+          state: "queued",
+          target: "found:0",
+          peerUrl: "http://discovered:3456",
+          lastLine: "found ack",
+        },
+      },
+    });
     expect(logs.join("\n")).toContain("queued");
     expect(logs.join("\n")).not.toContain("delivered");
   });

--- a/test/plugin-event-hooks.test.ts
+++ b/test/plugin-event-hooks.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { runPluginEventHooks } from "../src/plugin/event-hooks";
+import type { LoadedPlugin } from "../src/plugin/types";
+
+function pluginDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "maw-plugin-event-hooks-"));
+  return dir;
+}
+
+describe("runPluginEventHooks", () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    while (dirs.length) {
+      rmSync(dirs.pop()!, { recursive: true, force: true });
+    }
+  });
+
+  test("dispatches event-specific handler from plugin entry", async () => {
+    const dir = pluginDir();
+    dirs.push(dir);
+    const entry = join(dir, "index.ts");
+    writeFileSync(entry, "export function onTransportAfterSend(evt) { (globalThis as any).__transportAfterSend = evt; }\n");
+    const plugin: LoadedPlugin = {
+      manifest: {
+        name: "relay",
+        version: "1.0.0",
+        sdk: "*",
+        hooks: { on: ["transport:after_send"] },
+      },
+      dir,
+      wasmPath: "",
+      entryPath: entry,
+      kind: "ts",
+    };
+
+    (globalThis as any).__transportAfterSend = undefined;
+    const summary = await runPluginEventHooks("transport:after_send", { from: "a", to: "b", message: "m", result: { ok: true }, via: "tmux" }, () => [plugin]);
+
+    expect(summary).toEqual({ eventName: "transport:after_send", matched: 1, skipped: 0, invoked: 1, failed: 0 });
+    expect((globalThis as any).__transportAfterSend).toEqual({
+      from: "a",
+      to: "b",
+      message: "m",
+      via: "tmux",
+      result: { ok: true },
+      plugin: { name: "relay", dir },
+    });
+  });
+
+  test("uses fallback handler for plugin exports without event-specific name", async () => {
+    const dir = pluginDir();
+    dirs.push(dir);
+    const entry = join(dir, "index.ts");
+    writeFileSync(entry, "export function on(evt) { (globalThis as any).__fallbackHandler = evt; }\n");
+    const plugin: LoadedPlugin = {
+      manifest: {
+        name: "legacy",
+        version: "1.0.0",
+        sdk: "*",
+        hooks: { on: ["transport:after_send"] },
+      },
+      dir,
+      wasmPath: "",
+      entryPath: entry,
+      kind: "ts",
+    };
+
+    (globalThis as any).__fallbackHandler = undefined;
+    const summary = await runPluginEventHooks("transport:after_send", { route: "local", result: { ok: true } }, () => [plugin]);
+
+    expect(summary).toEqual({ eventName: "transport:after_send", matched: 1, skipped: 0, invoked: 1, failed: 0 });
+    expect((globalThis as any).__fallbackHandler).toMatchObject({
+      route: "local",
+      result: { ok: true },
+      plugin: { name: "legacy", dir },
+    });
+  });
+});

--- a/test/plugin-lifecycle.test.ts
+++ b/test/plugin-lifecycle.test.ts
@@ -3,7 +3,13 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync, readFileSync } from "fs"
 import { join } from "path";
 import { tmpdir } from "os";
 import type { LoadedPlugin } from "../src/plugin/types";
-import { runLifecycleHooks, runServeLifecycleHooks, runSleepLifecycleHooks, runWakeLifecycleHooks } from "../src/plugin/lifecycle";
+import {
+  runLifecycleHooks,
+  runServeLifecycleHooks,
+  runSleepLifecycleHooks,
+  runTransportLifecycleHooks,
+  runWakeLifecycleHooks,
+} from "../src/plugin/lifecycle";
 
 const tempDirs: string[] = [];
 
@@ -168,6 +174,25 @@ describe("plugin lifecycle hooks (#1576)", () => {
     expect(scoped).toEqual([{ name: "route-owner", dir: plugin.dir }]);
     expect(routes).toEqual(["route-owner:GET /api/owned"]);
     expect(fallbacks).toEqual(["route-owner:owned-fallback"]);
+  });
+
+  test("transport hooks run on new transport lifecycle", async () => {
+    const log = makeLog();
+    const plugin = makePlugin("router", {
+      hook: { transport: { script: "transport.ts", handler: "onTransport" } },
+      files: {
+        "index.ts": "export function serve() { throw new Error('entry should not run') }\n",
+        "transport.ts": `export function onTransport(ctx) { const fs = require(\"fs\"); fs.appendFileSync(process.env.MAW_LIFECYCLE_LOG, [ctx.phase, ctx.plugin.name, ctx.router ? 'router-ok' : 'missing-router', ctx.config.node || ''].join(":") + \"\\n\"); }\n`,
+      },
+    });
+
+    const summary = await runTransportLifecycleHooks(
+      { router: { connectAll: async () => {} } as any, config: { node: "test-node" } as any },
+      () => [plugin],
+    );
+
+    expect(summary).toEqual({ phase: "transport", ran: 1, skipped: 0, failed: 0 });
+    expect(readFileSync(log, "utf8")).toBe("transport:router:router-ok:test-node\n");
   });
 
   test("best-effort failures continue, fail-fast failures throw clearly", async () => {

--- a/test/plugin-manifest-validate-default.test.ts
+++ b/test/plugin-manifest-validate-default.test.ts
@@ -116,11 +116,18 @@ describe("manifest optional-field validators — default coverage", () => {
   });
 
   test("parseHooks preserves default array fields including late hooks", () => {
-    expect(parseHooks({ hooks: { gate: [], filter: ["Clean"], on: ["MessageSend"], late: ["After"] } })).toEqual({
+    expect(parseHooks({ hooks: {
       gate: [],
       filter: ["Clean"],
       on: ["MessageSend"],
       late: ["After"],
+      transport: { script: "transport.ts", handler: "onTransport", policy: "best-effort", ensures: ["ledger"] },
+    } })).toEqual({
+      gate: [],
+      filter: ["Clean"],
+      on: ["MessageSend"],
+      late: ["After"],
+      transport: { script: "transport.ts", handler: "onTransport", policy: "best-effort", ensures: ["ledger"] },
     });
     expectError(() => parseHooks({ hooks: { late: [1] } }), "plugin.json: hooks.late must be an array of strings");
   });

--- a/test/plugin-manifest-validate-edges.test.ts
+++ b/test/plugin-manifest-validate-edges.test.ts
@@ -39,6 +39,7 @@ describe("manifest optional-field validator edge coverage", () => {
       transport: { script: "transport.ts", handler: "transport", ensures: ["transport:workspace-hub"], policy: "best-effort" },
     });
     expectError(() => validators.parseHooks({ hooks: { wake: [] } }), "plugin.json: hooks.wake must be an object");
+    expectError(() => validators.parseHooks({ hooks: { transport: { script: 123 } } }), "plugin.json: hooks.transport.script must be a non-empty string");
     expectError(() => validators.parseHooks({ hooks: { wake: { script: "" } } }), "plugin.json: hooks.wake.script must be a non-empty string");
     expectError(() => validators.parseHooks({ hooks: { sleep: { handler: "" } } }), "plugin.json: hooks.sleep.handler must be a non-empty string");
     expectError(() => validators.parseHooks({ hooks: { serve: { ensures: [""] } } }), "plugin.json: hooks.serve.ensures must be an array of non-empty strings");


### PR DESCRIPTION
Closes #2496

Add transport lifecycle phase to plugin hook parsing and add runtime runner for event hooks. `cmdSend` now dispatches `transport:after_send` after successful local send, successful peer send, and successful discovery send paths. Includes tests for lifecycle/manifest validation/event-hook dispatch + comm-send coverage.