### PR TITLE
feat: add stacked maw serve verbosity

### DIFF
--- a/src/cli/route-tools.ts
+++ b/src/cli/route-tools.ts
@@ -15,8 +15,10 @@ const CORE_HELP: Record<string, string> = {
   agents: "usage: maw agents [--json] [--all] [--node <node>]",
   agent: "usage: maw agent [--json] [--all] [--node <node>]",
   audit: "usage: maw audit [limit]",
-  serve: "usage: maw serve [port] [--as <name>] [--force-takeover] [--quiet|-q] [--verbose|-v] | maw serve status|--status|stop",
+  serve: "usage: maw serve [port] [--as <name>] [--force-takeover] [--quiet|-q] [--verbose|-v|-vv|-vvv] | maw serve status|--status|stop",
 };
+
+type ServeVerbosity = 0 | 1 | 2 | 3 | 4;
 
 type ParseFlags = (args: string[], spec: Record<string, unknown>, skip?: number) => any;
 type InvokeResult = { ok: boolean; output?: string; error?: string; exitCode?: number };
@@ -65,11 +67,11 @@ type ServeStatusTools = {
 
 type ServeStartTools = {
   acquirePidLock: (instanceName: string | null, opts: { forceTakeover: boolean }) => void;
-  startServer: (port: number, options?: { verbosity?: 0 | 1 | 2 }) => Promise<void> | void;
+  startServer: (port: number, options?: { verbosity?: ServeVerbosity }) => Promise<void> | void;
 };
 
 type CoreServerTools = {
-  startServer: (port: number, options?: { verbosity?: 0 | 1 | 2 }) => Promise<void> | void;
+  startServer: (port: number, options?: { verbosity?: ServeVerbosity }) => Promise<void> | void;
 };
 type CoreServerLoader = () => Promise<CoreServerTools>;
 
@@ -89,6 +91,35 @@ export type RouteToolsDeps = {
   loadServeStatusTools: () => Promise<ServeStatusTools>;
   loadServeStartTools: () => Promise<ServeStartTools>;
 };
+
+function clampServeVerbosity(value: number): ServeVerbosity {
+  return Math.max(0, Math.min(4, Math.trunc(value))) as ServeVerbosity;
+}
+
+function envServeVerbosity(value: string | undefined): ServeVerbosity | undefined {
+  if (value === undefined) return undefined;
+  if (value === "quiet") return 0;
+  if (value === "normal") return 1;
+  if (value === "verbose" || value === "debug") return 2;
+  if (value === "access") return 3;
+  if (value === "frames" || value === "frame" || value === "ws") return 4;
+  if (/^\d+$/.test(value)) return clampServeVerbosity(Number(value));
+  return undefined;
+}
+
+function serveVerbosityFromArgs(serveArgs: string[]): ServeVerbosity {
+  const hasQuietFlag = serveArgs.some((a) => a === "--quiet" || a === "-q")
+    || process.argv.some((a) => a === "--quiet" || a === "-q")
+    || process.env.MAW_QUIET === "1";
+  if (hasQuietFlag) return 0;
+
+  const stackedVCount = serveArgs.reduce((count, arg) => (
+    /^-v+$/.test(arg) ? count + arg.length - 1 : count
+  ), 0);
+  if (stackedVCount > 0) return clampServeVerbosity(1 + stackedVCount);
+  if (serveArgs.some((a) => a === "--verbose")) return 2;
+  return envServeVerbosity(process.env.MAW_SERVE_VERBOSITY) ?? 1;
+}
 
 export function createDefaultRouteToolsDeps(loadCoreServer?: CoreServerLoader): RouteToolsDeps {
   return {
@@ -299,19 +330,11 @@ export async function routeToolsWithDeps(cmd: string, args: string[], deps: Rout
     const asIdx = serveArgs.indexOf("--as");
     const forceIdx = serveArgs.indexOf("--force-takeover");
     const noScoutIdx = serveArgs.indexOf("--no-scout");
-    const hasQuietFlag = serveArgs.some((a) => a === "--quiet" || a === "-q")
-      || process.argv.some((a) => a === "--quiet" || a === "-q")
-      || process.env.MAW_QUIET === "1"
-      || process.env.MAW_SERVE_VERBOSITY === "0"
-      || process.env.MAW_SERVE_VERBOSITY === "quiet";
-    const hasVerboseFlag = serveArgs.some((a) => a === "--verbose" || a === "-v")
-      || process.env.MAW_SERVE_VERBOSITY === "2"
-      || process.env.MAW_SERVE_VERBOSITY === "verbose";
-    const serveVerbosity: 0 | 1 | 2 = hasQuietFlag ? 0 : hasVerboseFlag ? 2 : 1;
+    const serveVerbosity = serveVerbosityFromArgs(serveArgs);
     const withoutAs = asIdx === -1
       ? serveArgs
       : [...serveArgs.slice(0, asIdx), ...serveArgs.slice(asIdx + 2)];
-    const withoutKnownFlags = withoutAs.filter((a) => !["--force-takeover", "--no-scout", "--quiet", "-q", "--verbose", "-v"].includes(a));
+    const withoutKnownFlags = withoutAs.filter((a) => !["--force-takeover", "--no-scout", "--quiet", "-q", "--verbose"].includes(a) && !/^-v+$/.test(a));
     const filteredArgs = withoutKnownFlags;
     const sub = filteredArgs[0] === "--status" ? "status" : filteredArgs[0];
     if (sub === "status" || sub === "stop") {
@@ -327,7 +350,7 @@ export async function routeToolsWithDeps(cmd: string, args: string[], deps: Rout
     const unknownFlag = filteredArgs.find(a => a.startsWith("-"));
     if (unknownFlag) {
       deps.error(`\x1b[31m✗\x1b[0m unknown flag '${unknownFlag}' for 'maw serve'`);
-      deps.error(`  usage: maw serve [port] [--as <name>] [--force-takeover] [--quiet|-q] [--verbose|-v]  (run 'maw serve --help' for more)`);
+      deps.error(`  usage: maw serve [port] [--as <name>] [--force-takeover] [--quiet|-q] [--verbose|-v|-vv|-vvv]  (run 'maw serve --help' for more)`);
       throw new UserError(`unknown flag '${unknownFlag}'`);
     }
     const portArg = filteredArgs.find(a => /^\d+$/.test(a));

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -30,9 +30,9 @@ export { createViews };
 
 export const VERSION = getRuntimeVersionLabel();
 
-export type ServeVerbosity = 0 | 1 | 2;
+export type ServeVerbosity = 0 | 1 | 2 | 3 | 4;
 export type StartServerOptions = {
-  /** 0=quiet (errors only), 1=normal, 2=verbose debug */
+  /** 0=quiet (errors only), 1=normal, 2=debug, 3=HTTP access, 4=WS frames */
   verbosity?: ServeVerbosity;
 };
 
@@ -40,12 +40,25 @@ type ServeLogger = {
   info: (...args: unknown[]) => void;
   warn: (...args: unknown[]) => void;
   debug: (...args: unknown[]) => void;
+  access: (...args: unknown[]) => void;
+  frame: (...args: unknown[]) => void;
   error: (...args: unknown[]) => void;
 };
 
 export function normalizeServeVerbosity(value: unknown): ServeVerbosity {
-  if (value === 0 || value === "0" || value === "quiet") return 0;
-  if (value === 2 || value === "2" || value === "verbose") return 2;
+  if (value === "quiet") return 0;
+  if (value === "normal") return 1;
+  if (value === "verbose" || value === "debug") return 2;
+  if (value === "access") return 3;
+  if (value === "frames" || value === "frame" || value === "ws") return 4;
+  const parsed = typeof value === "number"
+    ? value
+    : typeof value === "string" && /^\d+$/.test(value)
+      ? Number(value)
+      : null;
+  if (parsed !== null && Number.isFinite(parsed)) {
+    return Math.max(0, Math.min(4, Math.trunc(parsed))) as ServeVerbosity;
+  }
   return 1;
 }
 
@@ -54,8 +67,24 @@ export function createServeLogger(verbosity: ServeVerbosity): ServeLogger {
     info: (...args: unknown[]) => { if (verbosity >= 1) console.log(...args); },
     warn: (...args: unknown[]) => { if (verbosity >= 1) console.warn(...args); },
     debug: (...args: unknown[]) => { if (verbosity >= 2) console.log(...args); },
+    access: (...args: unknown[]) => { if (verbosity >= 3) console.log(...args); },
+    frame: (...args: unknown[]) => { if (verbosity >= 4) console.log(...args); },
     error: (...args: unknown[]) => { console.error(...args); },
   };
+}
+
+function websocketRouteLabel(ws: { data?: Record<string, unknown> }): string {
+  const route = ws.data?.__serveWsRoute;
+  if (typeof route === "string") return route;
+  const mode = ws.data?.mode;
+  return typeof mode === "string" ? `/ws:${mode}` : "/ws";
+}
+
+function websocketFrameSize(message: unknown): string {
+  if (typeof message === "string") return `${message.length}B`;
+  if (message instanceof ArrayBuffer) return `${message.byteLength}B`;
+  if (ArrayBuffer.isView(message)) return `${message.byteLength}B`;
+  return "unknown-size";
 }
 
 export function isAddressInUseError(err: unknown): boolean {
@@ -196,33 +225,39 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
   }
 
   const fetchHandler = async (req: Request, server: any) => {
+    const startedAt = Date.now();
     const url = new URL(req.url);
     const apiPath = url.pathname.replace(/^\/api/, "");
+    const logAccess = (response?: Response) => {
+      const status = response?.status ?? 101;
+      log.access(`[serve:http] ${req.method} ${url.pathname}${url.search} -> ${status} ${Date.now() - startedAt}ms`);
+      return response;
+    };
 
     // CORS preflight for all routes
     const corsPreflight = handleCorsOptions(req);
-    if (corsPreflight) return corsPreflight;
+    if (corsPreflight) return logAccess(corsPreflight);
     const wsUpgrade = serveWs.handleUpgrade(req, server);
-    if (wsUpgrade.matched) return wsUpgrade.response;
+    if (wsUpgrade.matched) return logAccess(wsUpgrade.response);
     // Elysia handles legacy /api/* routes (has its own CORS). Engine plugin
     // proxy stays first. For protected routes extracted into serve plugins,
     // preserve Elysia auth hooks by running legacy api.handle(req.clone())
     // before the registry and falling through only when legacy returns 404.
     if (url.pathname.startsWith("/api")) {
       const enginePlugin = findEnginePluginRegistration(url.pathname);
-      if (enginePlugin) return proxyEnginePluginRequest(req, enginePlugin);
+      if (enginePlugin) return logAccess(await proxyEnginePluginRequest(req, enginePlugin));
       if (isProtected(apiPath, req.method)) {
         const authOrLegacyRoute = await api.handle(req.clone());
-        if (authOrLegacyRoute.status !== 404) return authOrLegacyRoute;
+        if (authOrLegacyRoute.status !== 404) return logAccess(authOrLegacyRoute);
         const servedByPlugin = await serveRoutes.handle(req);
-        return servedByPlugin ?? authOrLegacyRoute;
+        return logAccess(servedByPlugin ?? authOrLegacyRoute);
       }
       const servedByPlugin = await serveRoutes.handle(req);
-      if (servedByPlugin) return servedByPlugin;
-      return api.handle(req);
+      if (servedByPlugin) return logAccess(servedByPlugin);
+      return logAccess(await api.handle(req));
     }
     const servedByPlugin = await serveRoutes.handle(req);
-    if (servedByPlugin) return servedByPlugin;
+    if (servedByPlugin) return logAccess(servedByPlugin);
 
     // Plugin-registered fallbacks handle views + static — clone response with CORS headers
     const addCors = (r: Response) => {
@@ -234,8 +269,8 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
       });
     };
     const res = serveRoutes.handleFallback(req, { server });
-    if (res instanceof Promise) return res.then(addCors);
-    return addCors(res as Response);
+    if (res instanceof Promise) return logAccess(addCors(await res));
+    return logAccess(addCors(res as Response));
   };
 
   // HTTP server (always)
@@ -256,7 +291,22 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
   // fires → handlePtyClose → detach → grace-timer reaps the maw-pty- tmux session.
   // sendPings: true is Bun's default but pinned for explicitness. Shared across
   // the HTTP + TLS Bun.serve calls below so both ws surfaces get the heartbeat.
-  const wsConfig = { ...serveWs.handlers, idleTimeout: cfgTimeout("wsIdleSec"), sendPings: true };
+  const wsHandlers = {
+    open: (ws: any) => {
+      log.frame(`[serve:ws] open ${websocketRouteLabel(ws)}`);
+      return serveWs.handlers.open(ws);
+    },
+    message: (ws: any, message: unknown) => {
+      log.frame(`[serve:ws] message ${websocketRouteLabel(ws)} ${websocketFrameSize(message)}`);
+      return serveWs.handlers.message(ws, message);
+    },
+    close: (ws: any, code?: number, reason?: string) => {
+      const suffix = code === undefined ? "" : ` code=${code}${reason ? ` reason=${reason}` : ""}`;
+      log.frame(`[serve:ws] close ${websocketRouteLabel(ws)}${suffix}`);
+      return serveWs.handlers.close(ws, code, reason);
+    },
+  };
+  const wsConfig = { ...wsHandlers, idleTimeout: cfgTimeout("wsIdleSec"), sendPings: true };
 
   let server: ReturnType<typeof Bun.serve>;
   try {

--- a/test/isolated/coverage-core-shared-server.test.ts
+++ b/test/isolated/coverage-core-shared-server.test.ts
@@ -182,12 +182,19 @@ describe("coverage core shared server", () => {
       expect(normalizeServeVerbosity("quiet")).toBe(0);
       expect(normalizeServeVerbosity("2")).toBe(2);
       expect(normalizeServeVerbosity("verbose")).toBe(2);
+      expect(normalizeServeVerbosity("3")).toBe(3);
+      expect(normalizeServeVerbosity("access")).toBe(3);
+      expect(normalizeServeVerbosity("4")).toBe(4);
+      expect(normalizeServeVerbosity("frames")).toBe(4);
+      expect(normalizeServeVerbosity(99)).toBe(4);
       expect(normalizeServeVerbosity(undefined)).toBe(1);
 
       const quiet = createServeLogger(0);
       quiet.info("quiet-info");
       quiet.warn("quiet-warn");
       quiet.debug("quiet-debug");
+      quiet.access("quiet-access");
+      quiet.frame("quiet-frame");
       quiet.error("quiet-error");
       expect(logs).toEqual([]);
       expect(warns).toEqual([]);
@@ -203,6 +210,15 @@ describe("coverage core shared server", () => {
       const verbose = createServeLogger(2);
       verbose.debug("verbose-debug");
       expect(logs).toEqual(["normal-info", "verbose-debug"]);
+
+      const access = createServeLogger(3);
+      access.access("access-log");
+      access.frame("hidden-frame");
+      expect(logs).toEqual(["normal-info", "verbose-debug", "access-log"]);
+
+      const frames = createServeLogger(4);
+      frames.frame("frame-log");
+      expect(logs).toEqual(["normal-info", "verbose-debug", "access-log", "frame-log"]);
     } finally {
       console.log = oldLog;
       console.warn = oldWarn;
@@ -227,7 +243,9 @@ describe("coverage core shared server", () => {
   });
 
   test("startServer exposes fetch and websocket handlers without real network side effects", async () => {
-    await startServer(4910);
+    const serveLogs: string[] = [];
+    console.log = (...a: unknown[]) => { serveLogs.push(a.map(String).join(" ")); };
+    await startServer(4910, { verbosity: 4 });
 
     // Startup stale-session cleanup moved to the serve-session-reaper lifecycle
     // plugin; server.ts now proves the plugin context is wired instead of
@@ -267,6 +285,8 @@ describe("coverage core shared server", () => {
     expect(ptyMessages).toHaveLength(1);
     expect(ptyCloses).toHaveLength(1);
     expect(tmuxStreamEvents).toEqual(["open", "message", "close"]);
+    expect(serveLogs.some((line) => line.includes("[serve:ws] open /ws"))).toBe(true);
+    expect(serveLogs.some((line) => line.includes("[serve:ws] message /ws:pty 6B"))).toBe(true);
 
     const fetch = serveCalls[0].fetch;
     const options = await fetch(new Request("http://local/anything", { method: "OPTIONS", headers: { origin: "http://origin.test" } }), upgradeServer(true));
@@ -291,6 +311,8 @@ describe("coverage core shared server", () => {
     expect(tmuxUpgrade.upgrades[0].data.mode).toBe("tmux-stream");
     const failedUpgrade = await fetch(new Request("http://local/ws"), upgradeServer(false));
     expect(failedUpgrade.status).toBe(400);
+    expect(serveLogs.some((line) => line.includes("[serve:http] OPTIONS /anything -> 204"))).toBe(true);
+    expect(serveLogs.some((line) => line.includes("[serve:http] GET /ws/pty -> 101"))).toBe(true);
   });
 });
 

--- a/test/route-tools-default.test.ts
+++ b/test/route-tools-default.test.ts
@@ -314,6 +314,26 @@ describe("routeTools default-suite seams", () => {
     expect(await routeToolsWithDeps("serve", ["serve", "4572", "-v"], shortVerbose.deps)).toBe(true);
     expect(shortVerbose.calls.servers).toEqual([{ port: 4572, options: { verbosity: 2 } }]);
 
+    const accessVerbose = harness();
+    expect(await routeToolsWithDeps("serve", ["serve", "4573", "-vv"], accessVerbose.deps)).toBe(true);
+    expect(accessVerbose.calls.servers).toEqual([{ port: 4573, options: { verbosity: 3 } }]);
+
+    const frameVerbose = harness();
+    expect(await routeToolsWithDeps("serve", ["serve", "4574", "-vvv"], frameVerbose.deps)).toBe(true);
+    expect(frameVerbose.calls.servers).toEqual([{ port: 4574, options: { verbosity: 4 } }]);
+
+    const repeatedVerbose = harness();
+    expect(await routeToolsWithDeps("serve", ["serve", "4575", "-v", "-v"], repeatedVerbose.deps)).toBe(true);
+    expect(repeatedVerbose.calls.servers).toEqual([{ port: 4575, options: { verbosity: 3 } }]);
+
+    const oldServeVerbosity = process.env.MAW_SERVE_VERBOSITY;
+    process.env.MAW_SERVE_VERBOSITY = "4";
+    const envFrameVerbose = harness();
+    expect(await routeToolsWithDeps("serve", ["serve", "4576"], envFrameVerbose.deps)).toBe(true);
+    expect(envFrameVerbose.calls.servers).toEqual([{ port: 4576, options: { verbosity: 4 } }]);
+    if (oldServeVerbosity === undefined) delete process.env.MAW_SERVE_VERBOSITY;
+    else process.env.MAW_SERVE_VERBOSITY = oldServeVerbosity;
+
     const bad = harness();
     await expect(routeToolsWithDeps("serve", ["serve", "--as", "blue", "--force-takeover", "--bogus"], bad.deps)).rejects.toBeInstanceOf(UserError);
     expect(bad.calls.errors.join("\n")).toContain("unknown flag '--bogus'");


### PR DESCRIPTION
Closes #2507

## Summary
- extend serve verbosity to levels 0-4
- parse `-v`, `-vv`, and `-vvv` for progressively richer `maw serve` diagnostics
- add level 3 HTTP access logs and level 4 websocket frame logs

## Tests
- `bun test test/route-tools-default.test.ts test/isolated/coverage-core-shared-server.test.ts`
- `bun test test/isolated/coverage-core-shared-server.test.ts --coverage`
- `bun scripts/check-plugin-coverage-gate.ts origin/alpha`