### PR TITLE
feat: make maw ui source-installable quietly

### DIFF
--- a/src/vendor/mpr-plugins/serve-views/index.ts
+++ b/src/vendor/mpr-plugins/serve-views/index.ts
@@ -34,7 +34,6 @@ export function createViews(
       doorHtml = readFileSync(doorHtmlPath, "utf-8");
     } catch {
       // door.html missing (e.g. fresh clone without assets) — serve inline stub
-      process.stderr.write("→ maw-ui not found. Run `maw ui build` or install maw-ui.\n");
       doorHtml = `<!DOCTYPE html><html><head><meta charset="UTF-8"><title>maw</title></head><body style="font-family:monospace;background:#0d0d0d;color:#ccc;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0"><div style="text-align:center"><h1 style="color:#fff">maw</h1><p>maw-ui not installed. Run <code style="color:#7dd3fc">maw ui build</code> or install maw-ui.</p></div></body></html>`;
     }
     views.get("/", (c) => c.html(doorHtml));

--- a/src/vendor/mpr-plugins/ui/impl-helpers.ts
+++ b/src/vendor/mpr-plugins/ui/impl-helpers.ts
@@ -26,6 +26,7 @@ export interface UiOptions {
   dev?: boolean;
   threeD?: boolean;
   install?: boolean;
+  installSource?: boolean;
   installVersion?: string;
   /** Positional subcommand: "install" | "status" */
   subcommand?: "install" | "status";

--- a/src/vendor/mpr-plugins/ui/impl-render.ts
+++ b/src/vendor/mpr-plugins/ui/impl-render.ts
@@ -118,6 +118,7 @@ export function parseUiArgs(args: string[]): UiOptions {
     "--install": Boolean,
     "--tunnel": Boolean,
     "--dev": Boolean,
+    "--source": Boolean,
     "--3d": Boolean,
     "--version": String,
   }, 0);
@@ -129,6 +130,7 @@ export function parseUiArgs(args: string[]): UiOptions {
   return {
     peer,
     install: flags["--install"],
+    installSource: flags["--source"],
     tunnel: flags["--tunnel"],
     dev: flags["--dev"],
     threeD: flags["--3d"],
@@ -145,7 +147,7 @@ export async function cmdUi(args: string[]): Promise<void> {
   if (opts.subcommand === "install" || opts.install) {
     const { cmdUiInstall } = await import("./ui-install");
     // --version takes precedence; fall back to peer (backward compat with --install <version>)
-    await cmdUiInstall(opts.version ?? opts.peer);
+    await cmdUiInstall(opts.version ?? opts.peer, { source: opts.installSource });
     return;
   }
 

--- a/src/vendor/mpr-plugins/ui/plugin.json
+++ b/src/vendor/mpr-plugins/ui/plugin.json
@@ -7,7 +7,15 @@
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "ui",
-    "help": "maw ui [args] — open or manage the maw web UI"
+    "help": "maw ui [args] — open or manage the maw web UI",
+    "flags": {
+      "--install": "boolean",
+      "--source": "boolean",
+      "--tunnel": "boolean",
+      "--dev": "boolean",
+      "--3d": "boolean",
+      "--version": "string"
+    }
   },
   "weight": 10,
   "license": "MIT",

--- a/src/vendor/mpr-plugins/ui/ui-install.ts
+++ b/src/vendor/mpr-plugins/ui/ui-install.ts
@@ -15,12 +15,13 @@
  */
 
 import { spawnSync } from "child_process";
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { mawDataPath } from "../../../core/xdg";
 
 const REPO = "Soul-Brews-Studio/maw-ui";
+const REPO_URL = `https://github.com/${REPO}.git`;
 const VERSION_MARKER = ".maw-ui-version";
 
 export function uiDistDir(): string {
@@ -63,7 +64,19 @@ export function buildGhReleaseArgs(repo: string, ref: string | undefined, dir: s
   return args;
 }
 
-export async function cmdUiInstall(version?: string): Promise<void> {
+export function buildGitCloneArgs(repoUrl: string, ref: string | undefined, dir: string): string[] {
+  const args = ["clone", "--depth", "1"];
+  if (ref) args.push("--branch", ref);
+  args.push(repoUrl, dir);
+  return args;
+}
+
+export async function cmdUiInstall(version?: string, options: { source?: boolean } = {}): Promise<void> {
+  if (options.source) {
+    await cmdUiInstallFromSource(version);
+    return;
+  }
+
   const displayRef = version ?? "latest";
 
   process.stdout.write(`⚡ downloading maw-ui ${displayRef} from ${REPO}...\n`);
@@ -107,6 +120,53 @@ export async function cmdUiInstall(version?: string): Promise<void> {
     if (markerRef) writeFileSync(join(distDir, VERSION_MARKER), markerRef + "\n");
 
     console.log(`✓ maw-ui ${displayRef} installed → ${distDir} (${files.length} top-level entries)`);
+    console.log(`  → restart maw server to serve the new UI: pm2 restart maw OR maw serve`);
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+export async function cmdUiInstallFromSource(version?: string): Promise<void> {
+  const displayRef = version ?? "default branch";
+  process.stdout.write(`⚡ building maw-ui ${displayRef} from source ${REPO_URL}...\n`);
+
+  const tmpDir = mkdtempSync(join(tmpdir(), "maw-ui-src-"));
+  const srcDir = join(tmpDir, "maw-ui");
+  try {
+    const clone = spawnSync("git", buildGitCloneArgs(REPO_URL, version, srcDir), { encoding: "utf-8" });
+    if (clone.status !== 0) {
+      throw new Error(`git clone failed:\n${clone.stderr}`);
+    }
+
+    const install = spawnSync("bun", ["install"], { cwd: srcDir, encoding: "utf-8" });
+    if (install.status !== 0) {
+      throw new Error(`bun install failed:\n${install.stderr}`);
+    }
+
+    const build = spawnSync("bun", ["run", "build"], { cwd: srcDir, encoding: "utf-8" });
+    if (build.status !== 0) {
+      throw new Error(`bun run build failed:\n${build.stderr}`);
+    }
+
+    const builtDist = join(srcDir, "dist");
+    if (!existsSync(join(builtDist, "index.html"))) {
+      throw new Error(`maw-ui build did not produce ${join(builtDist, "index.html")}`);
+    }
+
+    const distDir = uiDistDir();
+    rmSync(distDir, { recursive: true, force: true });
+    mkdirSync(distDir, { recursive: true });
+    cpSync(builtDist, distDir, { recursive: true });
+
+    let markerRef = version;
+    if (!markerRef) {
+      const rev = spawnSync("git", ["-C", srcDir, "rev-parse", "--short", "HEAD"], { encoding: "utf-8" });
+      if (rev.status === 0 && rev.stdout.trim()) markerRef = `source:${rev.stdout.trim()}`;
+    }
+    if (markerRef) writeFileSync(join(distDir, VERSION_MARKER), markerRef + "\n");
+
+    const files = readdirSync(distDir);
+    console.log(`✓ maw-ui ${displayRef} built and installed → ${distDir} (${files.length} top-level entries)`);
     console.log(`  → restart maw server to serve the new UI: pm2 restart maw OR maw serve`);
   } finally {
     rmSync(tmpDir, { recursive: true, force: true });

--- a/test/isolated/plugin-serve-views-standalone.test.ts
+++ b/test/isolated/plugin-serve-views-standalone.test.ts
@@ -32,7 +32,11 @@ describe("serve-views plugin", () => {
     const tmp = mkdtempSync(join(tmpdir(), "maw-serve-views-"));
     const previousCwd = process.cwd();
     const previousWrite = process.stderr.write;
-    process.stderr.write = (() => true) as typeof process.stderr.write;
+    const stderr: string[] = [];
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      stderr.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
     try {
       mkdirSync(join(tmp, "ψ", "outbox"), { recursive: true });
       writeFileSync(join(tmp, "ψ", "outbox", "fleet-topology.html"), "<h1>topology</h1>");
@@ -44,6 +48,7 @@ describe("serve-views plugin", () => {
       rmSync(join(tmp, "ψ"), { recursive: true, force: true });
       expect((await views.request("http://local/topology")).status).toBe(404);
       expect(await (await views.request("http://local/")).text()).toContain("maw-ui not installed");
+      expect(stderr.join("")).not.toContain("maw-ui not found");
     } finally {
       process.chdir(previousCwd);
       process.stderr.write = previousWrite;

--- a/test/isolated/plugin-ui-standalone.test.ts
+++ b/test/isolated/plugin-ui-standalone.test.ts
@@ -1,0 +1,13 @@
+import { describe, test } from "bun:test";
+import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
+
+describe("ui plugin standalone boundary", () => {
+  test("keeps declared config/xdg exceptions explicit", () => {
+    expectStandalonePluginBoundary({
+      plugin: "ui",
+      requireSdk: false,
+      allowMawJs: ["maw-js/config", "maw-js/core/ghq"],
+      allowRelative: [/^\.\.\/\.\.\/\.\.\/core\/xdg$/],
+    });
+  });
+});

--- a/test/isolated/ui-impl-render-coverage.test.ts
+++ b/test/isolated/ui-impl-render-coverage.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 let distInstalled = false;
 let srcDir: string | null = null;
 let resolvedPeers = new Map<string, string | null>();
-let installCalls: Array<string | undefined> = [];
+let installCalls: Array<{ version: string | undefined; source?: boolean }> = [];
 let statusCalls = 0;
 let logs: string[] = [];
 
@@ -30,7 +30,7 @@ mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/ui/impl-helpers.ts
 }));
 
 mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/ui/ui-install.ts"), () => ({
-  cmdUiInstall: async (version?: string) => { installCalls.push(version); },
+  cmdUiInstall: async (version?: string, options?: { source?: boolean }) => { installCalls.push({ version, source: options?.source }); },
   cmdUiStatus: async () => { statusCalls += 1; },
 }));
 
@@ -60,6 +60,7 @@ describe("ui impl render coverage", () => {
     expect(parseUiArgs(["install", "--version", "v1.2.3", "ignored-peer"])).toEqual({
       peer: "ignored-peer",
       install: undefined,
+      installSource: undefined,
       tunnel: undefined,
       dev: undefined,
       threeD: undefined,
@@ -133,12 +134,12 @@ describe("ui impl render coverage", () => {
   });
 
   test("cmdUi dispatches install/status modules or logs rendered output", async () => {
-    await cmdUi(["install", "--version", "v9.9.9"]);
+    await cmdUi(["install", "--version", "v9.9.9", "--source"]);
     await cmdUi(["--install", "legacy-version"]);
     await cmdUi(["status"]);
     await cmdUi(["--3d"]);
 
-    expect(installCalls).toEqual(["v9.9.9", "legacy-version"]);
+    expect(installCalls).toEqual([{ version: "v9.9.9", source: true }, { version: "legacy-version", source: undefined }]);
     expect(statusCalls).toBe(1);
     expect(logs).toEqual(["http://localhost:5173/federation.html"]);
   });

--- a/test/isolated/ui-install-plugin-coverage.test.ts
+++ b/test/isolated/ui-install-plugin-coverage.test.ts
@@ -14,6 +14,7 @@ let stdoutWrites: string[] = [];
 let logs: string[] = [];
 let errors: string[] = [];
 let tarWritesFile = true;
+let sourceBuildWritesFile = false;
 
 const original = {
   write: process.stdout.write,
@@ -28,7 +29,7 @@ mock.module("os", () => ({
 }));
 
 mock.module("child_process", () => ({
-  spawnSync: (cmd: string, args: string[] = []) => {
+  spawnSync: (cmd: string, args: string[] = [], options?: Record<string, unknown>) => {
     spawnCalls.push({ cmd, args });
     const queued = spawnStatuses.shift();
 
@@ -38,13 +39,19 @@ mock.module("child_process", () => ({
       mkdirSync(target, { recursive: true });
       writeFileSync(join(target, "index.html"), '<div data-maw-ui-version="1.2.3"></div>');
     }
+    if (cmd === "bun" && args.join(" ") === "run build" && sourceBuildWritesFile) {
+      const cwd = String(options?.cwd ?? "");
+      mkdirSync(join(cwd, "dist"), { recursive: true });
+      writeFileSync(join(cwd, "dist", "index.html"), '<div data-maw-ui-version="source"></div>');
+      writeFileSync(join(cwd, "dist", "app.js"), "console.log(1)");
+    }
 
     return queued ?? { status: 0, stdout: "v9.9.9\n", stderr: "" };
   },
 }));
 
 const ui = await import("../../src/vendor/mpr-plugins/ui/ui-install.ts?ui-install-plugin-coverage");
-const { buildGhReleaseArgs, cmdUiInstall, cmdUiStatus, resolveInstalledVersion, uiDistDir } = ui;
+const { buildGhReleaseArgs, buildGitCloneArgs, cmdUiInstall, cmdUiStatus, resolveInstalledVersion, uiDistDir } = ui;
 
 beforeEach(() => {
   rmSync(distDir, { recursive: true, force: true });
@@ -54,6 +61,7 @@ beforeEach(() => {
   logs = [];
   errors = [];
   tarWritesFile = true;
+  sourceBuildWritesFile = false;
   delete process.env.MAW_DATA_DIR;
   process.stdout.write = ((chunk: string | Uint8Array) => {
     stdoutWrites.push(String(chunk));
@@ -87,6 +95,12 @@ describe("ui install plugin coverage", () => {
     ]);
     expect(buildGhReleaseArgs("owner/repo", "v1", "/tmp/out")).toEqual([
       "release", "download", "v1", "-R", "owner/repo", "--pattern", "maw-ui-dist.tar.gz", "--dir", "/tmp/out",
+    ]);
+    expect(buildGitCloneArgs("https://example/repo.git", undefined, "/tmp/src")).toEqual([
+      "clone", "--depth", "1", "https://example/repo.git", "/tmp/src",
+    ]);
+    expect(buildGitCloneArgs("https://example/repo.git", "v1", "/tmp/src")).toEqual([
+      "clone", "--depth", "1", "--branch", "v1", "https://example/repo.git", "/tmp/src",
     ]);
   });
 
@@ -184,5 +198,47 @@ describe("ui install plugin coverage", () => {
 
     expect(existsSync(join(distDir, ".maw-ui-version"))).toBe(false);
     expect(spawnCalls.at(-1)?.args).toEqual(["release", "view", "-R", "Soul-Brews-Studio/maw-ui", "--json", "tagName", "-q", ".tagName"]);
+  });
+
+  test("source install clones, builds, copies dist, and writes source marker", async () => {
+    sourceBuildWritesFile = true;
+    spawnStatuses = [
+      { status: 0, stdout: "", stderr: "" },
+      { status: 0, stdout: "", stderr: "" },
+      { status: 0, stdout: "", stderr: "" },
+      { status: 0, stdout: "abc123\n", stderr: "" },
+    ];
+
+    await cmdUiInstall(undefined, { source: true });
+
+    expect(stdoutWrites.join("")).toContain("building maw-ui default branch from source");
+    expect(spawnCalls.map((call) => call.cmd)).toEqual(["git", "bun", "bun", "git"]);
+    expect(spawnCalls[0].args.slice(0, 3)).toEqual(["clone", "--depth", "1"]);
+    expect(spawnCalls[1].args).toEqual(["install"]);
+    expect(spawnCalls[2].args).toEqual(["run", "build"]);
+    expect(readFileSync(join(distDir, "index.html"), "utf-8")).toContain("source");
+    expect(readFileSync(join(distDir, ".maw-ui-version"), "utf-8")).toBe("source:abc123\n");
+  });
+
+  test("source install supports explicit refs and reports build failures", async () => {
+    sourceBuildWritesFile = true;
+    spawnStatuses = [
+      { status: 0, stdout: "", stderr: "" },
+      { status: 0, stdout: "", stderr: "" },
+      { status: 0, stdout: "", stderr: "" },
+    ];
+
+    await cmdUiInstall("v5.0.0", { source: true });
+    expect(spawnCalls[0].args).toContain("--branch");
+    expect(spawnCalls[0].args).toContain("v5.0.0");
+    expect(readFileSync(join(distDir, ".maw-ui-version"), "utf-8")).toBe("v5.0.0\n");
+
+    spawnCalls = [];
+    sourceBuildWritesFile = false;
+    spawnStatuses = [
+      { status: 0, stdout: "", stderr: "" },
+      { status: 7, stdout: "", stderr: "install failed" },
+    ];
+    await expect(cmdUiInstall(undefined, { source: true })).rejects.toThrow("bun install failed");
   });
 });


### PR DESCRIPTION
Closes #2514

## Summary
- suppress the `maw-ui not found` stderr warning in serve-views; the door fallback still renders the install hint in-browser
- add `maw ui install --source [--version <ref>]` to clone maw-ui, run `bun install`, build, and copy `dist` into `mawDataPath('ui','dist')`
- declare UI plugin CLI flags and add standalone boundary coverage

## Tests
- `bun test test/isolated/plugin-serve-views-standalone.test.ts test/isolated/ui-install-plugin-coverage.test.ts test/isolated/ui-impl-render-coverage.test.ts test/isolated/plugin-ui-standalone.test.ts`
- `bun test test/plugins-ui.test.ts test/isolated/ui-capture-helpers-coverage.test.ts test/isolated/ui-impl-next-coverage.test.ts`
- `bun scripts/check-plugin-coverage-gate.ts origin/alpha`

## Not tested
- live clone/build against Soul-Brews-Studio/maw-ui`