### PR TITLE
Show lifecycle hook plugin names in verbose serve logs

### DIFF
--- a/src/plugin/lifecycle.ts
+++ b/src/plugin/lifecycle.ts
@@ -189,6 +189,7 @@ export async function runLifecycleHooks(
   },
 ): Promise<LifecycleRunSummary> {
   const summary: LifecycleRunSummary = { phase, ran: 0, skipped: 0, failed: 0 };
+  const ranPluginNames: string[] = [];
 
   for (const plugin of sortByLifecycleOrder(discover())) {
     if (plugin.disabled) { summary.skipped++; continue; }
@@ -199,6 +200,7 @@ export async function runLifecycleHooks(
     try {
       await runOneLifecycleHook(phase, plugin, hook, baseContext);
       summary.ran++;
+      ranPluginNames.push(plugin.manifest.name);
     } catch (error) {
       summary.failed++;
       const msg = messageOf(error);
@@ -210,7 +212,8 @@ export async function runLifecycleHooks(
   }
 
   if (summary.ran > 0) {
-    logger.info(`\x1b[36m↻\x1b[0m plugin lifecycle ${phase}: ${summary.ran} hook${summary.ran === 1 ? "" : "s"}`);
+    const names = ranPluginNames.length > 0 ? ` (${ranPluginNames.join(", ")})` : "";
+    logger.info(`\x1b[36m↻\x1b[0m plugin lifecycle ${phase}: ${summary.ran} hook${summary.ran === 1 ? "" : "s"}${names}`);
   }
   return summary;
 }

--- a/test/plugin-lifecycle.test.ts
+++ b/test/plugin-lifecycle.test.ts
@@ -84,6 +84,25 @@ describe("plugin lifecycle hooks (#1576)", () => {
     ]);
   });
 
+  test("verbose lifecycle summary includes successful plugin names", async () => {
+    makeLog();
+    const plugins = [
+      makePlugin("later", { weight: 20 }),
+      makePlugin("earlier", { weight: 5 }),
+    ];
+    const info: string[] = [];
+
+    const summary = await runLifecycleHooks(
+      "wake",
+      { oracle: "mawjs", session: "47-mawjs" },
+      () => plugins,
+      { info: (message) => info.push(message), warn: () => {} },
+    );
+
+    expect(summary).toEqual({ phase: "wake", ran: 2, skipped: 0, failed: 0 });
+    expect(info).toEqual(["\x1b[36m↻\x1b[0m plugin lifecycle wake: 2 hooks (earlier, later)"]);
+  });
+
   test("hooks.wake.script + handler runs the declared module export", async () => {
     const log = makeLog();
     const plugin = makePlugin("scripted", {


### PR DESCRIPTION
Closes #2517

## Summary
- Track successful lifecycle hook plugin names during hook execution.
- Append the names to the existing verbose lifecycle summary line.
- Add regression coverage for deterministic name ordering in the summary.

## Tests
- bun test test/plugin-lifecycle.test.ts