### PR TITLE
Batch noisy ui-state serve access logs

### DIFF
--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -73,6 +73,28 @@ export function createServeLogger(verbosity: ServeVerbosity): ServeLogger {
   };
 }
 
+const UI_STATE_ACCESS_LOG_PATH = "/api/ui-state";
+const UI_STATE_ACCESS_LOG_INTERVAL_MS = 10_000;
+
+type UiStateAccessLogState = {
+  count: number;
+  windowStartedAt: number;
+};
+
+export function formatBatchedUiStateAccessLog(
+  state: UiStateAccessLogState,
+  input: { method: string; status: number; now: number },
+): string | null {
+  state.count++;
+  const elapsedMs = input.now - state.windowStartedAt;
+  if (elapsedMs < UI_STATE_ACCESS_LOG_INTERVAL_MS) return null;
+  const count = state.count;
+  const elapsedSec = Math.max(1, Math.round(elapsedMs / 1000));
+  state.count = 0;
+  state.windowStartedAt = input.now;
+  return `[serve:http] ${input.method} ${UI_STATE_ACCESS_LOG_PATH} -> ${input.status} (${count} requests/${elapsedSec}s)`;
+}
+
 function websocketRouteLabel(ws: { data?: Record<string, unknown> }): string {
   const route = ws.data?.__serveWsRoute;
   if (typeof route === "string") return route;
@@ -224,13 +246,27 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
     log.error("[plugins] failed to init:", err);
   }
 
+  const uiStateAccessLogState: UiStateAccessLogState = { count: 0, windowStartedAt: Date.now() };
+
   const fetchHandler = async (req: Request, server: any) => {
     const startedAt = Date.now();
     const url = new URL(req.url);
     const apiPath = url.pathname.replace(/^\/api/, "");
     const logAccess = (response?: Response) => {
       const status = response?.status ?? 101;
-      log.access(`[serve:http] ${req.method} ${url.pathname}${url.search} -> ${status} ${Date.now() - startedAt}ms`);
+      const finishedAt = Date.now();
+      if (url.pathname === UI_STATE_ACCESS_LOG_PATH) {
+        if (verbosity >= 3) {
+          const batchLine = formatBatchedUiStateAccessLog(uiStateAccessLogState, {
+            method: req.method,
+            status,
+            now: finishedAt,
+          });
+          if (batchLine) log.access(batchLine);
+        }
+        return response;
+      }
+      log.access(`[serve:http] ${req.method} ${url.pathname}${url.search} -> ${status} ${finishedAt - startedAt}ms`);
       return response;
     };
 

--- a/test/isolated/coverage-core-shared-server.test.ts
+++ b/test/isolated/coverage-core-shared-server.test.ts
@@ -123,7 +123,7 @@ mock.module(import.meta.resolve("../../src/plugins/index"), () => ({
 mock.module(import.meta.resolve("../../src/lib/peers/store"), () => ({ loadPeers: () => ({ peers: {} }) }));
 mock.module(import.meta.resolve("../../src/lib/peers/duplicate-detect"), () => ({ warnDuplicatesAtBoot: () => {} }));
 
-const { createViews, startServer, createServeLogger, normalizeServeVerbosity } = await import("../../src/core/server.ts?coverage-core-shared-server");
+const { createViews, startServer, createServeLogger, normalizeServeVerbosity, formatBatchedUiStateAccessLog } = await import("../../src/core/server.ts?coverage-core-shared-server");
 
 const original = {
   serve: Bun.serve,
@@ -224,6 +224,17 @@ describe("coverage core shared server", () => {
       console.warn = oldWarn;
       console.error = oldError;
     }
+  });
+
+  test("batches noisy ui-state access logs", () => {
+    const state = { count: 0, windowStartedAt: 1_000 };
+
+    expect(formatBatchedUiStateAccessLog(state, { method: "GET", status: 200, now: 1_100 })).toBeNull();
+    expect(formatBatchedUiStateAccessLog(state, { method: "GET", status: 200, now: 10_999 })).toBeNull();
+    expect(formatBatchedUiStateAccessLog(state, { method: "GET", status: 200, now: 11_000 })).toBe(
+      "[serve:http] GET /api/ui-state -> 200 (3 requests/10s)",
+    );
+    expect(state).toEqual({ count: 0, windowStartedAt: 11_000 });
   });
 
   test("createViews covers topology success, missing door fallback, and error JSON", async () => {


### PR DESCRIPTION
Closes #2518

## Summary
- Suppress per-request access logs for `/api/ui-state`, the high-frequency maw-ui polling endpoint.
- At access verbosity, emit a batched summary every 10s instead of one line per poll.
- Add regression coverage for the batching formatter and keep ui-state API tests passing.

## Tests
- bun test test/isolated/coverage-core-shared-server.test.ts test/api-runtime-default.test.ts