### PR TITLE
refactor: prefer config.engines for command resolution

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -30,6 +30,7 @@ import { parseFlags } from "./parse-args";
 import { UserError } from "../core/util/user-error";
 import { parseBringToTarget } from "../commands/shared/bring-flags";
 import { lsFederated } from "../vendor/mpr-plugins/ls/internal/peer-call";
+import { engineNamesForConfig } from "../config/engine-registry";
 
 export type DirectHandler = { kind: "direct"; handler: string };
 export type AliasResolution =
@@ -510,13 +511,13 @@ export async function invokeDirectHandler(
     }
     if (flags["--session-id"]) opts.sessionId = flags["--session-id"] as string;
 
-    // Shorthand: --codex, --gemini etc. → engine from config.commands
+    // Shorthand: --codex, --gemini etc. → engine from config.engines/legacy commands.
     // Unknown flags land in flags._ (permissive mode), so scan for --<engine>
     if (!opts.engine) {
       const loadConfig = deps.loadConfig ?? (await import("../config")).loadConfig;
-      const commands = loadConfig().commands || {};
+      const engineNames = new Set(engineNamesForConfig(loadConfig()));
       for (const arg of (flags._ as string[])) {
-        if (arg.startsWith("--") && commands[arg.slice(2)]) {
+        if (arg.startsWith("--") && engineNames.has(arg.slice(2))) {
           opts.engine = arg.slice(2);
           break;
         }

--- a/src/commands/plugins/team/team-lifecycle.ts
+++ b/src/commands/plugins/team/team-lifecycle.ts
@@ -6,7 +6,7 @@ import { assertValidOracleName } from "../../../core/fleet/validate";
 import { prefixCommandWithSpawnSessionEnv } from "../../../core/fleet/parent-session";
 import { buildCommand, buildCommandInDir } from "../../../config/command";
 import { loadConfig } from "../../../config/load";
-import { resolveEngine } from "../../../config/engine-registry";
+import { defaultEngineNameForConfig, resolveEngine } from "../../../config/engine-registry";
 import { TEAMS_DIR, loadTeam, resolvePsi, writeShutdownRequest, cleanupTeamDir, type TeamConfig, type TeamMember } from "./team-helpers";
 
 const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
@@ -244,7 +244,7 @@ export async function cmdTeamSpawn(
 
   // Build spawn prompt
   const config = loadConfig();
-  const engine = opts.engine || config.defaultEngine || "claude";
+  const engine = opts.engine || config.defaultEngine || defaultEngineNameForConfig(config);
   const resolvedEngine = resolveEngine(engine, config);
   const model = opts.model || resolvedEngine.model?.default;
   const shellQuote = (s: string) => `'${s.replace(/'/g, "'\\''")}'`;

--- a/src/commands/plugins/team/team-liveness.ts
+++ b/src/commands/plugins/team/team-liveness.ts
@@ -3,6 +3,7 @@ import { basename, dirname, join } from "path";
 import { Tmux } from "../../../core/transport/tmux";
 import { isAgentCommand } from "../../../core/agent-detect";
 import { loadConfig } from "../../../config/load";
+import { defaultEngineNameForConfig, resolveEngine } from "../../../config/engine-registry";
 import type { MawConfig } from "../../../config/types";
 import { cmdWake, type WakeOptions } from "../../shared/wake-cmd";
 import type { TeamCharterMember } from "../../../vendor/mpr-plugins/team/team-charter";
@@ -81,7 +82,7 @@ export function classifyMember(
     candidate.sessionName === session && (candidate.windowName === windowIdentity || suffix.test(candidate.windowName))
   );
   const config = loadConfig();
-  const engine = opts.engine ?? member.engine ?? member.model ?? config.defaultEngine ?? "claude";
+  const engine = opts.engine ?? member.engine ?? member.model ?? config.defaultEngine ?? defaultEngineNameForConfig(config);
   const worktree = typeof member.worktree === "string" && member.worktree.trim() ? member.worktree.trim() : windowIdentity;
   if (!pane) return { member, role, engine, worktree, windowIdentity, state: "missing" };
   if (SHELL_RE.test(pane.command)) return { member, role, engine, worktree, windowIdentity, state: "dead", pane };
@@ -91,7 +92,7 @@ export function classifyMember(
 
 export function engineCommand(engine: string, opts: { resume?: boolean } = {}, config: MawConfig = loadConfig()): string {
   const key = opts.resume ? `${engine}-resume` : engine;
-  return config.commands?.[key] ?? config.commands?.default ?? key;
+  return resolveEngine(key, config).cmd;
 }
 
 export function repoSlugFromRoot(root: string): string {

--- a/src/commands/shared/preflight.ts
+++ b/src/commands/shared/preflight.ts
@@ -1,6 +1,7 @@
 import { listSessions, getPaneInfos, isAgentCommand } from "../../sdk";
 import { buildCommandInDir, loadConfig } from "../../config";
 import { Tmux } from "../../core/transport/tmux";
+import { enginePatternKeysForConfig } from "../../config/engine-registry";
 
 export interface PreflightFs {
   readdirSync: typeof import("fs").readdirSync;
@@ -142,7 +143,7 @@ export async function cmdPreflight(opts: { fix?: boolean } = {}, deps: Partial<P
 
   // 4. Config check
   const config = io.loadConfig();
-  const engines = Object.keys(config.commands || {}).filter(k => k !== "default");
+  const engines = enginePatternKeysForConfig(config).filter(k => k !== "default");
   io.log(`  \x1b[32m✓\x1b[0m config: node=${config.node || "?"}, engines=[${engines.join(", ") || "default only"}]`);
   pass++;
 

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -2,6 +2,7 @@ import { hostExec, tmux, restoreTabOrder, takeSnapshot, getPaneInfos, isAgentCom
 import { resolve } from "path";
 import { ghqFind } from "../../core/ghq";
 import { buildCommandInDir, cfgTimeout, loadConfig, saveConfig } from "../../config";
+import { defaultEngineNameForConfig } from "../../config/engine-registry";
 import { resolveWorktreeTarget } from "../../core/matcher/resolve-target";
 import { normalizeWorktreeLayout, type WorktreeLayout } from "../../core/fleet/worktree-layout";
 import { prefixCommandWithSpawnSessionEnv } from "../../core/fleet/parent-session";
@@ -955,6 +956,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
   }
 
   const { repoPath, repoName, parentDir } = resolved;
+  const config = loadConfig();
   const worktreeLayout = normalizeWorktreeLayout(opts.layout);
 
   if (opts.bud && !opts.task && !opts.wt) {
@@ -1134,7 +1136,6 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
     }
 
     // Auto-register agent in config.agents so federation peers can route to it (#285)
-    const config = loadConfig();
     const agents = config.agents || {};
     if (!(oracle in agents)) {
       const node = config.node || "local";
@@ -1331,7 +1332,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
           named: Boolean(stableName && !opts.fresh),
           layout: worktreeLayout,
           existingWindowNames: knownWindows,
-          engine: opts.engine || "claude",
+          engine: opts.engine || config.defaultEngine || defaultEngineNameForConfig(config),
         });
         targetPath = result.wtPath;
         windowName = result.windowName;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,8 @@
 // Barrel — re-exports from split config modules.
 export type { TriggerEvent, TriggerConfig, PeerConfig, MawIntervals, MawTimeouts, MawLimits, MawConfig } from "./config/types";
 export { D } from "./config/types";
-export { DEFAULT_ENGINES, resolveEngine } from "./config/engine-registry";
+/** @deprecated DEFAULT_ENGINES is seed-only; prefer resolveEngine(). */
+export { DEFAULT_ENGINES, defaultEngineNameForConfig, resolveEngine } from "./config/engine-registry";
 export type { EngineDef } from "./config/engine-def";
 export type { EngineRegistry } from "./config/engine-registry";
 export { validateConfigShape } from "./config/validate";

--- a/src/config/command-logic.ts
+++ b/src/config/command-logic.ts
@@ -4,7 +4,7 @@ import { join } from "path";
 import type { MawConfig } from "./types";
 import type { EngineDef } from "./engine-def";
 import { getChannelEnv, getChannelPermissionMode, getChannelPluginIds } from "../commands/shared/channel-loader";
-import { DEFAULT_ENGINES, isClaudeLikeCommand, resolveEngine } from "./engine-registry";
+import { defaultEngineNameForConfig, engineNamesForConfig, enginePatternKeysForConfig, isClaudeLikeEngine, resolveEngine } from "./engine-registry";
 
 const DISCORD_CHANNEL_PLUGIN = "plugin:discord@claude-plugins-official";
 
@@ -79,9 +79,9 @@ function enrichOptionsFromChannelConfig(
   return opts;
 }
 
-function applyChannelFlags(cmd: string, opts: BuildCommandOpts): string {
+function applyChannelFlags(cmd: string, opts: BuildCommandOpts, engine: EngineDef | null, config: Partial<MawConfig>): string {
   const channels = opts.channels?.filter(Boolean) ?? [];
-  if (!isClaudeLikeCommand(cmd)) return cmd;
+  if (!isClaudeLikeEngine(engine?.name, config)) return cmd;
   if (channels.length > 0 && !hasChannelsFlag(cmd)) {
     cmd += ` --channels ${channels.join(" ")}`;
   }
@@ -116,26 +116,39 @@ function shouldAutoDiscordChannels(cwd?: string): boolean {
   try { return existsSync(join(cwd, ".discord")); } catch { return false; }
 }
 
+function commandKeyForAgent(
+  config: Partial<MawConfig>,
+  agentName: string,
+  opts: BuildCommandOpts,
+): string {
+  const keys = enginePatternKeysForConfig(config);
+  const known = new Set(engineNamesForConfig(config));
+
+  if (opts.engine && known.has(opts.engine)) return opts.engine;
+
+  let key = defaultEngineNameForConfig(config);
+
+  for (const pattern of keys) {
+    if (pattern === "default") continue;
+    if (matchesAgentPattern(pattern, agentName)) {
+      key = pattern;
+      break;
+    }
+  }
+
+  return key;
+}
+
+function legacyConfig(config: Partial<MawConfig>): Partial<MawConfig> {
+  return { ...config, engines: undefined };
+}
+
 function legacyCommandForAgent(
   config: Partial<MawConfig>,
   agentName: string,
   opts: BuildCommandOpts,
 ): string {
-  const commands = config.commands || { default: config.defaultEngine ?? "claude" };
-  const defaultEngine = config.defaultEngine ?? "claude";
-  let cmd: string;
-
-  if (opts.engine && commands[opts.engine]) {
-    cmd = commands[opts.engine];
-  } else {
-    cmd = commands.default || defaultEngine;
-    for (const [pattern, command] of Object.entries(commands)) {
-      if (pattern === "default") continue;
-      if (matchesAgentPattern(pattern, agentName)) { cmd = command; break; }
-    }
-  }
-
-  return cmd;
+  return resolveEngine(commandKeyForAgent(legacyConfig(config), agentName, opts), legacyConfig(config)).cmd;
 }
 
 function selectEngineForAgent(
@@ -143,25 +156,7 @@ function selectEngineForAgent(
   agentName: string,
   opts: BuildCommandOpts,
 ): EngineDef {
-  const commands = config.commands || { default: "claude" };
-
-  // Preserve the legacy "unknown explicit engine falls back to default/pattern"
-  // behavior unless the new typed engine registry has an explicit entry.
-  if (opts.engine && (
-    config.engines?.[opts.engine]
-    || commands[opts.engine]
-    || DEFAULT_ENGINES[opts.engine as keyof typeof DEFAULT_ENGINES]
-  )) {
-    return resolveEngine(opts.engine, config);
-  }
-
-  let engineName = commands.default ? "default" : (config.defaultEngine ?? "default");
-  for (const pattern of Object.keys(commands)) {
-    if (pattern === "default") continue;
-    if (matchesAgentPattern(pattern, agentName)) { engineName = pattern; break; }
-  }
-
-  return resolveEngine(engineName, config);
+  return resolveEngine(commandKeyForAgent(config, agentName, opts), config);
 }
 
 function engineHas(engine: EngineDef | null, capability: string): boolean {
@@ -200,10 +195,10 @@ function applyResumeFlag(cmd: string, engine: EngineDef | null, sessionId: strin
   return `${cmd} ${engine.resume.flag} ${value}`;
 }
 
-function addDiscordChannelsForClaude(cmd: string, cwd?: string): string {
+function addDiscordChannelsForClaude(cmd: string, engine: EngineDef | null, config: Partial<MawConfig>, cwd?: string): string {
   if (!shouldAutoDiscordChannels(cwd)) return cmd;
   if (hasChannelsFlag(cmd)) return cmd;
-  if (!isClaudeLikeCommand(cmd)) return cmd;
+  if (!isClaudeLikeEngine(engine?.name, config)) return cmd;
   return `${cmd} --channels ${DISCORD_CHANNEL_PLUGIN}`;
 }
 
@@ -215,23 +210,23 @@ export function buildCommandFromConfig(
 ): string {
   const opts = enrichOptionsFromChannelConfig(agentName, normalizeBuildCommandOpts(optsOrEngine), context.cwd);
   const genericRenderer = process.env.MAW_GENERIC_ENGINES !== "0";
-  const engine = genericRenderer ? selectEngineForAgent(config, agentName, opts) : null;
+  const engine = selectEngineForAgent(genericRenderer ? config : legacyConfig(config), agentName, opts);
   let cmd = genericRenderer
-    ? engine!.cmd
+    ? engine.cmd
     : legacyCommandForAgent(config, agentName, opts);
 
   cmd = applyFreshLaunch(cmd, engine, opts);
   cmd = applyModelFlag(cmd, engine, opts);
   cmd = applySystemPromptFile(cmd, engine, opts);
 
-  const commandOpts = opts.channelConfigLoaded && !isClaudeLikeCommand(cmd)
+  const commandOpts = opts.channelConfigLoaded && !isClaudeLikeEngine(engine.name, config)
     ? { ...opts, channels: [], channelEnv: undefined }
     : opts;
 
   if (commandOpts.channels?.length) {
-    cmd = applyChannelFlags(cmd, commandOpts);
+    cmd = applyChannelFlags(cmd, commandOpts, engine, config);
   } else {
-    cmd = addDiscordChannelsForClaude(cmd, context.cwd);
+    cmd = addDiscordChannelsForClaude(cmd, engine, config, context.cwd);
   }
 
   // Inject --session-id if configured for this agent

--- a/src/config/engine-registry.ts
+++ b/src/config/engine-registry.ts
@@ -1,6 +1,7 @@
 import type { MawConfig } from "./types";
 import type { EngineDef } from "./engine-def";
 
+/** @deprecated Seed-only defaults. Prefer resolveEngine()/engineNamesForConfig(). */
 export const DEFAULT_ENGINES = {
   claude: {
     name: "claude",
@@ -53,4 +54,31 @@ export function resolveEngine(name: string, config: Partial<MawConfig> = {}): En
   if (builtIn) return { ...builtIn };
 
   return { name, cmd: name };
+}
+
+export function engineNamesForConfig(config: Partial<MawConfig> = {}): string[] {
+  return [...new Set([
+    ...Object.keys(config.engines ?? {}),
+    ...Object.keys(config.commands ?? {}),
+    ...Object.keys(DEFAULT_ENGINES),
+  ])];
+}
+
+export function enginePatternKeysForConfig(config: Partial<MawConfig> = {}): string[] {
+  return [...new Set([
+    ...Object.keys(config.engines ?? {}),
+    ...Object.keys(config.commands ?? {}),
+  ])];
+}
+
+export function defaultEngineNameForConfig(config: Partial<MawConfig> = {}): string {
+  return (config.engines?.default || config.commands?.default)
+    ? "default"
+    : (config.defaultEngine ?? "claude");
+}
+
+export function isClaudeLikeEngine(name: string | undefined, config: Partial<MawConfig> = {}): boolean {
+  const engineName = name?.trim();
+  if (!engineName) return false;
+  return resolveEngine(engineName, config).capabilities?.includes("system-prompt-file") ?? false;
 }

--- a/src/core/agent-detect.ts
+++ b/src/core/agent-detect.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_ENGINES } from "../config/engine-registry";
+import { engineNamesForConfig, resolveEngine } from "../config/engine-registry";
 import type { EngineDef } from "../config/engine-def";
 import type { MawConfig } from "../config/types";
 
@@ -25,21 +25,12 @@ function processNamesFromEngine(def: EngineDef | undefined): string[] {
   return normalizedProcessNames(def?.processNames ?? []);
 }
 
-function processNamesFromLegacyCommands(commands: Record<string, string> | undefined): string[] {
-  if (!commands) return [];
-  return normalizedProcessNames(
-    Object.entries(commands)
-      .filter(([name, command]) => name !== "default" && command !== "default")
-      .map(([, command]) => firstCommandToken(command)),
-  );
-}
-
-/** Engine process names from built-ins plus config.engines/processNames and legacy command bins. */
+/** Engine process names from config.engines, legacy command shims, and built-in registry fallbacks. */
 export function agentProcessNames(config?: Partial<MawConfig> | null): string[] {
   const names: string[] = [];
-  for (const def of Object.values(DEFAULT_ENGINES)) names.push(...processNamesFromEngine(def));
-  for (const def of Object.values(config?.engines ?? {})) names.push(...processNamesFromEngine(def));
-  names.push(...processNamesFromLegacyCommands(config?.commands));
+  for (const name of engineNamesForConfig(config ?? {})) {
+    names.push(...processNamesFromEngine(resolveEngine(name, config ?? {})));
+  }
   return normalizedProcessNames(names);
 }
 
@@ -90,9 +81,9 @@ export function matchesEngineIdlePrompt(output: string | null | undefined): bool
  * agent runtime.
  *
  * Detection layers (any match → true):
- *  1. Config/default engine `processNames` (claude, claude-code, codex,
- *     thclaws, thclaude, opencode, aider, plus configured engines).
- *  2. Legacy `config.commands` executable names, exact basename match.
+ *  1. Engine registry `processNames` (config.engines primary, legacy
+ *     config.commands shims, then built-in defaults).
+ *  2. Legacy command executable names are included through resolveEngine().
  *  3. Generic node wrapper panes.
  *  4. Claude Code 2.1+ version command strings (e.g. `2.1.121`).
  */

--- a/src/core/engine/is-claude-like.ts
+++ b/src/core/engine/is-claude-like.ts
@@ -1,5 +1,5 @@
 import type { MawConfig } from "../../config/types";
-import { resolveEngine } from "../../config/engine-registry";
+import { isClaudeLikeCommand, resolveEngine } from "../../config/engine-registry";
 
 /**
  * Shared claude-like engine detector (#2099).
@@ -16,9 +16,6 @@ import { resolveEngine } from "../../config/engine-registry";
  * claude-like, or it declares the claude-only `system-prompt-file` capability.
  */
 
-/** Matches a launch command whose executable is claude (or claude-prefixed). */
-const CLAUDE_LIKE_CMD = /(^|\s)(?:command\s+)?claude[A-Za-z0-9_-]*(?:\s|$)/;
-
 /** Capability only claude-like engines declare (the `-p`/system-prompt form). */
 const CLAUDE_LIKE_CAPABILITY = "system-prompt-file";
 
@@ -31,6 +28,6 @@ export function isClaudeLikeEngine(
   if (name.toLowerCase() === "claude") return true;
 
   const def = resolveEngine(name, config);
-  if (CLAUDE_LIKE_CMD.test(def.cmd)) return true;
+  if (isClaudeLikeCommand(def.cmd)) return true;
   return def.capabilities?.includes(CLAUDE_LIKE_CAPABILITY) ?? false;
 }

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -25,7 +25,8 @@ export {
   getEnvVars, cfgTimeout, cfgLimit, cfgInterval, cfg, D,
   resetConfig,
 } from "../config";
-export { DEFAULT_ENGINES, resolveEngine } from "../config/engine-registry";
+/** @deprecated DEFAULT_ENGINES is seed-only; plugins should call resolveEngine(). */
+export { DEFAULT_ENGINES, defaultEngineNameForConfig, resolveEngine } from "../config/engine-registry";
 export { getGhqRoot } from "../config/ghq-root";
 export {
   isMawXdgEnabled,

--- a/src/vendor/mpr-plugins/team/team-lifecycle.ts
+++ b/src/vendor/mpr-plugins/team/team-lifecycle.ts
@@ -2,12 +2,12 @@ import { readdirSync, readFileSync, writeFileSync, existsSync, mkdirSync, copyFi
 import { createHash } from "crypto";
 import { join } from "path";
 import { tmux } from "maw-js/sdk";
+import { defaultEngineNameForConfig, resolveEngine } from "../../../config/engine-registry";
 import { assertValidOracleName } from "maw-js/core/fleet/validate";
 import { prefixCommandWithSpawnSessionEnv } from "../../../core/fleet/parent-session";
 import { buildCommand, buildCommandInDir } from "../../../config/command";
 import { writeWorktreeEngineFile } from "../../../commands/shared/wake-session";
 import { loadConfig } from "../../../config/load";
-import { resolveEngine } from "../../../config/engine-registry";
 import { TEAMS_DIR, loadTeam, resolvePsi, writeShutdownRequest, cleanupTeamDir, currentLeadSessionId, type TeamConfig, type TeamMember } from "./team-helpers";
 
 const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
@@ -274,7 +274,7 @@ export async function cmdTeamSpawn(
 
   // Build spawn prompt
   const config = loadConfig();
-  const engine = opts.engine || config.defaultEngine || "claude";
+  const engine = opts.engine || config.defaultEngine || defaultEngineNameForConfig(config);
   if (opts.cwd && existsSync(opts.cwd)) writeWorktreeEngineFile(opts.cwd, engine, console.log.bind(console));
   const resolvedEngine = resolveEngine(engine, config);
   const model = opts.model || resolvedEngine.model?.default;

--- a/src/vendor/mpr-plugins/team/team-liveness.ts
+++ b/src/vendor/mpr-plugins/team/team-liveness.ts
@@ -2,8 +2,8 @@ import { existsSync } from "fs";
 import { basename, dirname, join } from "path";
 import { Tmux } from "../../../core/transport/tmux";
 import { isAgentCommand } from "../../../core/agent-detect";
-import { resolveEngine } from "maw-js/sdk";
 import { loadConfig } from "../../../config/load";
+import { defaultEngineNameForConfig, resolveEngine } from "maw-js/sdk";
 import type { MawConfig } from "../../../config/types";
 import { cmdWake, type WakeOptions } from "../../../commands/shared/wake-cmd";
 import type { TeamCharterEngines, TeamCharterMember } from "./team-charter";
@@ -82,7 +82,7 @@ export function memberWorktree(member: TeamCharterMember): string {
 }
 
 export function memberEngine(member: TeamCharterMember, override?: string, config: MawConfig = loadConfig()): string {
-  return override ?? member.engine ?? member.model ?? config.defaultEngine ?? "claude";
+  return override ?? member.engine ?? member.model ?? config.defaultEngine ?? defaultEngineNameForConfig(config);
 }
 
 export function memberMatchesSelector(member: TeamCharterMember, selector: string): boolean {

--- a/test/command-golden-master.test.ts
+++ b/test/command-golden-master.test.ts
@@ -112,6 +112,45 @@ describe("buildCommandFromConfig golden master (#1960 P0)", () => {
     } as any, "codex-agent", "codex")).toBe("codex --typed");
   });
 
+
+
+  test("config.engines default and patterns are primary over legacy commands", () => {
+    delete process.env.MAW_GENERIC_ENGINES;
+
+    expect(buildCommandFromConfig({
+      ...baseConfig,
+      commands: { default: "claude --legacy", "foo-*": "foo --legacy" },
+      engines: {
+        default: { name: "default", cmd: "codex --typed" },
+        "foo-*": { name: "foo-*", cmd: "foo --typed" },
+      },
+    } as any, "unmapped-agent")).toBe("codex --typed");
+
+    expect(buildCommandFromConfig({
+      ...baseConfig,
+      commands: { default: "claude --legacy", "foo-*": "foo --legacy" },
+      engines: { "foo-*": { name: "foo-*", cmd: "foo --typed" } },
+    } as any, "foo-agent")).toBe("foo --typed");
+  });
+
+  test("typed engine capabilities, not command spelling, control Claude-only channels", () => {
+    delete process.env.MAW_GENERIC_ENGINES;
+    const tmp = mkdtempSync(join(tmpdir(), "maw-typed-capability-"));
+    mkdirSync(join(tmp, ".discord"));
+
+    expect(buildCommandInDirFromConfig({
+      ...baseConfig,
+      commands: { default: "claude --legacy" },
+      engines: { default: { name: "default", cmd: "claude" } },
+    } as any, "plain-agent", tmp)).toBe("claude");
+
+    expect(buildCommandInDirFromConfig({
+      ...baseConfig,
+      commands: { default: "codex" },
+      engines: { default: { name: "default", cmd: "codex", capabilities: ["system-prompt-file"] } },
+    } as any, "cap-agent", tmp)).toBe("codex --channels plugin:discord@claude-plugins-official");
+  });
+
   test("defaultEngine supplies the default fallback when commands.default is absent", () => {
     delete process.env.MAW_GENERIC_ENGINES;
 

--- a/test/engine-registry.test.ts
+++ b/test/engine-registry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-const { DEFAULT_ENGINES, isClaudeLikeCommand, resolveEngine } = await import("../src/config/engine-registry");
+const { DEFAULT_ENGINES, defaultEngineNameForConfig, engineNamesForConfig, enginePatternKeysForConfig, isClaudeLikeCommand, isClaudeLikeEngine, resolveEngine } = await import("../src/config/engine-registry");
 
 describe("generic engine registry (#1960 P1)", () => {
   test("lowers the legacy swarm known agents into dormant EngineDef defaults", () => {
@@ -49,6 +49,28 @@ describe("generic engine registry (#1960 P1)", () => {
       name: "gemini",
       cmd: "gemini",
     });
+  });
+
+
+
+  test("lists typed engines before legacy shims and keeps configured pattern keys separate from defaults", () => {
+    const config = {
+      engines: { codex: { name: "codex", cmd: "codex --typed" }, "foo-*": { name: "foo-*", cmd: "foo-typed" } },
+      commands: { default: "claude", codex: "codex --legacy", "bar-*": "bar-legacy" },
+    } as any;
+
+    expect(engineNamesForConfig(config).slice(0, 5)).toEqual(["codex", "foo-*", "default", "bar-*", "claude"]);
+    expect(enginePatternKeysForConfig(config)).toEqual(["codex", "foo-*", "default", "bar-*"]);
+  });
+
+  test("chooses config default keys and gates Claude-like behavior by engine capability", () => {
+    expect(defaultEngineNameForConfig({ engines: { default: { name: "default", cmd: "codex --typed" } } } as any)).toBe("default");
+    expect(defaultEngineNameForConfig({ commands: { default: "claude --legacy" } } as any)).toBe("default");
+    expect(defaultEngineNameForConfig({ defaultEngine: "codex" } as any)).toBe("codex");
+
+    expect(isClaudeLikeEngine("claude", {} as any)).toBe(true);
+    expect(isClaudeLikeEngine("plain-claude", { engines: { "plain-claude": { name: "plain-claude", cmd: "claude" } } } as any)).toBe(false);
+    expect(isClaudeLikeEngine("cap-claude", { engines: { "cap-claude": { name: "cap-claude", cmd: "codex", capabilities: ["system-prompt-file"] } } } as any)).toBe(true);
   });
 
   test("exports Claude-like command detection for command rendering", () => {

--- a/test/isolated/plugin-team-standalone.test.ts
+++ b/test/isolated/plugin-team-standalone.test.ts
@@ -256,7 +256,7 @@ agents:
     );
   });
 
-  test("memberEngine honors config.defaultEngine before hard-coded claude fallback", async () => {
+  test("memberEngine honors config.defaultEngine without hard-coded claude fallback", async () => {
     mock.module(import.meta.resolve("../../src/commands/shared/wake-cmd.ts"), () => ({
       cmdWake: async () => "",
     }));
@@ -266,6 +266,7 @@ agents:
     expect(memberEngine({ role: "builder", model: "opencode" } as any, undefined, { defaultEngine: "codex" } as any)).toBe("opencode");
     expect(memberEngine({ role: "builder", engine: "aider" } as any, undefined, { defaultEngine: "codex" } as any)).toBe("aider");
     expect(memberEngine({ role: "builder", engine: "aider" } as any, "thclaws", { defaultEngine: "codex" } as any)).toBe("thclaws");
+    expect(memberEngine({ role: "builder" } as any, undefined, { commands: { default: "codex --legacy" } } as any)).toBe("default");
     expect(memberEngine({ role: "builder" } as any, undefined, {} as any)).toBe("claude");
     expect(resolveCharterEngineCommand("opus48", { opus48: ["claude --model opus", ["--dangerously-skip-permissions"]] })).toBe("claude --model opus --dangerously-skip-permissions");
   });


### PR DESCRIPTION
Closes #2519

## Summary
- make `config.engines` the primary source for command resolution while preserving legacy `config.commands` compatibility
- add registry helpers for engine names, configured pattern keys, default resolution, and capability-based Claude-like checks
- route agent detection, top-level engine shorthand, preflight, wake/team defaults, and team liveness command lookup through the engine registry
- keep `DEFAULT_ENGINES` exported but marked deprecated/seed-only

## Tests
- ✅ `bun test test/command-golden-master.test.ts test/command-simplified.test.ts test/build-command-channel-env.test.ts test/engine-registry.test.ts`
- ✅ `bun test test/is-agent-command.test.ts test/isolated/is-agent-command-config.test.ts`
- ✅ `bun test test/isolated/plugin-team-standalone.test.ts`
- ✅ `bun test test/isolated/team-lifecycle-default.test.ts test/isolated/team-lifecycle-second-pass-coverage.test.ts`
- ✅ `bun test test/preflight-default.test.ts`
- ✅ `bun scripts/check-plugin-coverage-gate.ts origin/alpha`
- ✅ `bun run build`

Note: full `bun test` still hits pre-existing single-process mock pollution/env failures unrelated to this PR (SDK/config exports mocked away, comm-send pollution, live tmux layout target). Targeted tests and coverage gate pass.
