### PR TITLE
fix: allow wake target URLs for dotted repos

### DIFF
--- a/src/commands/shared/wake-target.ts
+++ b/src/commands/shared/wake-target.ts
@@ -15,7 +15,7 @@ import { ghqFind } from "../../core/ghq";
 const ORG_REPO_SLUG = /^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/;
 
 /** Matches GitHub URLs: https://github.com/org/repo[.git][/issues/N][/...] and git@ SSH form */
-const GITHUB_URL = /^(?:https?:\/\/|git@)github\.com[:/]([^/]+)\/([^/.]+?)(?:\.git)?(?:\/issues\/(\d+))?(?:\/.*)?$/;
+const GITHUB_URL = /^(?:https?:\/\/|git@)github\.com[:/]([^/]+)\/([^/]+?)(?:\.git)?(?:\/issues\/(\d+))?(?:\/.*)?$/;
 
 function matchGitHubUrl(input: string): { org: string; repo: string; issueNum?: number } | null {
   const m = input.match(GITHUB_URL);

--- a/test/wake-target-parser.test.ts
+++ b/test/wake-target-parser.test.ts
@@ -17,6 +17,16 @@ describe("parseWakeTarget — GitHub URLs", () => {
     expect(r).toEqual({ oracle: "repo", slug: "org/repo" });
   });
 
+  test("allows dotted repo names in HTTPS URLs", () => {
+    const r = parseWakeTarget("https://github.com/nicolo-ribaudo/ember.js");
+    expect(r).toEqual({ oracle: "ember.js", slug: "nicolo-ribaudo/ember.js" });
+  });
+
+  test("allows dotted repo names while stripping .git suffix", () => {
+    const r = parseWakeTarget("https://github.com/org/my.repo.git");
+    expect(r).toEqual({ oracle: "my.repo", slug: "org/my.repo" });
+  });
+
   test("HTTP without TLS", () => {
     const r = parseWakeTarget("http://github.com/org/repo");
     expect(r).toEqual({ oracle: "repo", slug: "org/repo" });


### PR DESCRIPTION
Fixes wake target parsing for GitHub repositories with dots in their names.

Changes:
- Allow dots in the GitHub URL repo capture group.
- Preserve optional `.git` suffix stripping.
- Add parser coverage for `ember.js` and `my.repo.git`.

Closes #2529

Tested:
- `bun test test/wake-target-parser.test.ts test/isolated/coverage-core-shared-helpers.test.ts`