### PR TITLE
feat: support charter v3 flags and engine anchors

### DIFF
--- a/src/vendor/mpr-plugins/team/team-charter.ts
+++ b/src/vendor/mpr-plugins/team/team-charter.ts
@@ -21,6 +21,9 @@ export interface TeamCharterMember {
   discord?: false;
 }
 
+export type TeamCharterFlags = Record<string, unknown[]>;
+export type TeamCharterEngines = Record<string, unknown>;
+
 export interface TeamCharter {
   name: string;
   description?: string;
@@ -32,6 +35,10 @@ export interface TeamCharter {
   discord?: string | false;
   defaults?: Partial<TeamCharterMember>;
   members: TeamCharterMember[];
+  /** Reusable argv fragments, including YAML-anchor-expanded arrays. */
+  flags?: TeamCharterFlags;
+  /** Charter-local engine command map; arrays are flattened at launch resolution. */
+  engines?: TeamCharterEngines;
   /** New-style agent map (`agents: { codex: { engine: omx, ... } }`). */
   agents?: Record<string, Record<string, unknown>>;
   lifecycle?: Record<string, unknown>;
@@ -124,7 +131,102 @@ function readBlock(lines: string[], start: number, parentIndent: number): { valu
   };
 }
 
-function parseYamlMapBlock(lines: string[], start: number, parentIndent: number): { value: Record<string, Record<string, unknown>>; next: number } {
+
+function cloneYamlValue<T>(value: T): T {
+  if (Array.isArray(value)) return value.map((item) => cloneYamlValue(item)) as T;
+  if (value && typeof value === "object") return { ...(value as Record<string, unknown>) } as T;
+  return value;
+}
+
+function splitInlineArray(value: string): string[] {
+  const inner = value.trim().slice(1, -1);
+  const out: string[] = [];
+  let quote: string | null = null;
+  let current = "";
+  for (let i = 0; i < inner.length; i++) {
+    const ch = inner[i]!;
+    if ((ch === '"' || ch === "'") && inner[i - 1] !== "\\") {
+      quote = quote === ch ? null : quote || ch;
+      current += ch;
+      continue;
+    }
+    if (ch === "," && !quote) {
+      out.push(current.trim());
+      current = "";
+      continue;
+    }
+    current += ch;
+  }
+  if (current.trim()) out.push(current.trim());
+  return out;
+}
+
+function parseYamlValue(raw: string, anchors: Map<string, unknown>): unknown {
+  const trimmed = raw.trim();
+  const alias = trimmed.match(/^\*([A-Za-z_][\w-]*)$/);
+  if (alias) {
+    if (!anchors.has(alias[1]!)) throw new Error(`unknown YAML anchor reference: *${alias[1]}`);
+    return cloneYamlValue(anchors.get(alias[1]));
+  }
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    return splitInlineArray(trimmed).map((item) => parseYamlValue(item, anchors));
+  }
+  return scalar(trimmed);
+}
+
+function parseListBlock(lines: string[], start: number, parentIndent: number, anchors: Map<string, unknown>): { value: unknown[]; next: number } {
+  const items: unknown[] = [];
+  let i = start;
+  for (; i < lines.length; i++) {
+    const itemLine = lines[i]!;
+    if (!itemLine.trim()) continue;
+    if (lineIndent(itemLine) <= parentIndent) break;
+    const item = itemLine.match(new RegExp(`^ {${parentIndent + 2}}-\\s*(.*)$`));
+    if (!item) throw new Error(`unsupported list item near line ${i + 1}: ${itemLine.trim()}`);
+    items.push(parseYamlValue(item[1] ?? "", anchors));
+  }
+  return { value: items, next: i };
+}
+
+function parseAnchorPrefix(raw: string): { anchor?: string; rest: string } {
+  const match = raw.trim().match(/^&([A-Za-z_][\w-]*)(?:\s+(.*))?$/);
+  return match ? { anchor: match[1], rest: match[2] ?? "" } : { rest: raw };
+}
+
+function parseYamlValueMapBlock(lines: string[], start: number, parentIndent: number, anchors: Map<string, unknown>): { value: Record<string, unknown>; next: number } {
+  const out: Record<string, unknown> = {};
+  let i = start;
+  for (; i < lines.length; i++) {
+    const raw = lines[i]!;
+    if (!raw.trim()) continue;
+    const indent = lineIndent(raw);
+    if (indent <= parentIndent) break;
+
+    const header = raw.match(new RegExp(`^ {${parentIndent + 2}}([A-Za-z_][\\w.-]*):(?:\\s*(.*))?$`));
+    if (!header) throw new Error(`unsupported value map entry near line ${i + 1}: ${raw.trim()}`);
+    const key = header[1]!;
+    const keyValue = header[2] ?? "";
+    const { anchor, rest } = parseAnchorPrefix(keyValue);
+    let value: unknown;
+    if (rest.trim()) {
+      value = parseYamlValue(rest, anchors);
+      i++;
+    } else if (keyValue.trim() && !anchor) {
+      value = parseYamlValue(keyValue, anchors);
+      i++;
+    } else {
+      const list = parseListBlock(lines, i + 1, parentIndent + 2, anchors);
+      value = list.value;
+      i = list.next;
+    }
+    if (anchor) anchors.set(anchor, cloneYamlValue(value));
+    out[key] = value;
+    i--;
+  }
+  return { value: out, next: i };
+}
+
+function parseYamlMapBlock(lines: string[], start: number, parentIndent: number, anchors: Map<string, unknown>): { value: Record<string, Record<string, unknown>>; next: number } {
   const out: Record<string, Record<string, unknown>> = {};
   let i = start;
   for (; i < lines.length; i++) {
@@ -133,7 +235,7 @@ function parseYamlMapBlock(lines: string[], start: number, parentIndent: number)
     const indent = lineIndent(raw);
     if (indent <= parentIndent) break;
 
-    const header = raw.match(/^ {2}([A-Za-z_][\w-]*):(?:\s*(.*))?$/);
+    const header = raw.match(/^ {2}([A-Za-z_][\w.-]*):(?:\s*(.*))?$/);
     if (!header) throw new Error(`unsupported map entry near line ${i + 1}: ${raw.trim()}`);
     const key = header[1]!;
     const keyValue = header[2] ?? "";
@@ -148,7 +250,7 @@ function parseYamlMapBlock(lines: string[], start: number, parentIndent: number)
         continue;
       }
       if (lineIndent(child) <= 2) break;
-      const field = child.match(/^ {4}([A-Za-z_][\w-]*):(?:\s*(.*))?$/);
+      const field = child.match(/^ {4}([A-Za-z_][\w.-]*):(?:\s*(.*))?$/);
       if (!field) throw new Error(`unsupported map field near line ${i + 1}: ${child.trim()}`);
       const fieldKey = field[1]!;
       const fieldRaw = field[2] ?? "";
@@ -168,13 +270,13 @@ function parseYamlMapBlock(lines: string[], start: number, parentIndent: number)
           if (lineIndent(itemLine) <= 4) break;
           const item = itemLine.match(/^ {6}-\s*(.*)$/);
           if (!item) throw new Error(`unsupported map field near line ${j + 1}: ${itemLine.trim()}`);
-          items.push(scalar(item[1] ?? ""));
+          items.push(parseYamlValue(item[1] ?? "", anchors));
           j++;
         }
         record[fieldKey] = items;
         i = j;
       } else {
-        record[fieldKey] = scalar(fieldRaw);
+        record[fieldKey] = parseYamlValue(fieldRaw, anchors);
         i++;
       }
     }
@@ -184,22 +286,23 @@ function parseYamlMapBlock(lines: string[], start: number, parentIndent: number)
   return { value: out, next: i };
 }
 
-function parseFlatScalarMapBlock(lines: string[], start: number, parentIndent: number, label: string): { value: Record<string, unknown>; next: number } {
+function parseFlatScalarMapBlock(lines: string[], start: number, parentIndent: number, label: string, anchors: Map<string, unknown>): { value: Record<string, unknown>; next: number } {
   const map: Record<string, unknown> = {};
   let i = start;
   for (; i < lines.length; i++) {
     const child = lines[i]!;
     if (!child.trim()) continue;
     if (lineIndent(child) <= parentIndent) break;
-    const field = child.match(/^ {2}([A-Za-z_][\w-]*):\s*(.*)$/);
+    const field = child.match(/^ {2}([A-Za-z_][\w.-]*):\s*(.*)$/);
     if (!field) throw new Error(`unsupported ${label} field near line ${i + 1}: ${child.trim()}`);
-    map[field[1]!] = scalar(field[2] ?? "");
+    map[field[1]!] = parseYamlValue(field[2] ?? "", anchors);
   }
   return { value: map, next: i };
 }
 
 function parseYamlSubset(text: string): TeamCharter {
   const lines = text.split(/\r?\n/).map(stripComment);
+  const anchors = new Map<string, unknown>();
   const root: Record<string, unknown> = { members: [] };
   let i = 0;
   while (i < lines.length) {
@@ -208,7 +311,7 @@ function parseYamlSubset(text: string): TeamCharter {
       i++;
       continue;
     }
-    const top = line.match(/^([A-Za-z_][\w-]*):(?:\s*(.*))?$/);
+    const top = line.match(/^([A-Za-z_][\w.-]*):(?:\s*(.*))?$/);
     if (!top) throw new Error(`unsupported team charter YAML near line ${i + 1}: ${line.trim()}`);
     const key = top[1]!;
     const raw = top[2] ?? "";
@@ -230,7 +333,7 @@ function parseYamlSubset(text: string): TeamCharter {
         if (lineIndent(memberLine) === 0) break;
         const first = memberLine.match(/^ {2}-\s+([A-Za-z_][\w-]*):\s*(.*)$/);
         if (!first) throw new Error(`unsupported member entry near line ${i + 1}: ${memberLine.trim()}`);
-        const member: Record<string, unknown> = { [first[1]!]: scalar(first[2] ?? "") };
+        const member: Record<string, unknown> = { [first[1]!]: parseYamlValue(first[2] ?? "", anchors) };
         i++;
         while (i < lines.length) {
           const child = lines[i]!;
@@ -239,7 +342,7 @@ function parseYamlSubset(text: string): TeamCharter {
             continue;
           }
           if (lineIndent(child) <= 2) break;
-          const field = child.match(/^ {4}([A-Za-z_][\w-]*):(?:\s*(.*))?$/);
+          const field = child.match(/^ {4}([A-Za-z_][\w.-]*):(?:\s*(.*))?$/);
           if (!field) throw new Error(`unsupported member field near line ${i + 1}: ${child.trim()}`);
           const fieldKey = field[1]!;
           const fieldRaw = field[2] ?? "";
@@ -259,13 +362,13 @@ function parseYamlSubset(text: string): TeamCharter {
               if (lineIndent(itemLine) <= 4) break;
               const item = itemLine.match(/^ {6}-\s*(.*)$/);
               if (!item) throw new Error(`unsupported member field near line ${j + 1}: ${itemLine.trim()}`);
-              items.push(scalar(item[1] ?? ""));
+              items.push(parseYamlValue(item[1] ?? "", anchors));
               j++;
             }
             member[fieldKey] = items;
             i = j;
           } else {
-            member[fieldKey] = scalar(fieldRaw);
+            member[fieldKey] = parseYamlValue(fieldRaw, anchors);
             i++;
           }
         }
@@ -274,25 +377,31 @@ function parseYamlSubset(text: string): TeamCharter {
       root.members = members;
       continue;
     }
+    if ((key === "flags" || key === "engines") && raw === "") {
+      const block = parseYamlValueMapBlock(lines, i + 1, 0, anchors);
+      i = block.next;
+      root[key] = block.value;
+      continue;
+    }
     if (key === "agents" && raw === "") {
-      const block = parseYamlMapBlock(lines, i + 1, 0);
+      const block = parseYamlMapBlock(lines, i + 1, 0, anchors);
       i = block.next;
       root.agents = block.value;
       continue;
     }
     if ((key === "defaults" || key === "lifecycle" || key === "governance") && raw === "") {
-      const block = parseFlatScalarMapBlock(lines, i + 1, 0, key);
+      const block = parseFlatScalarMapBlock(lines, i + 1, 0, key, anchors);
       root[key] = block.value;
       i = block.next;
       continue;
     }
-    root[key] = raw === "" ? "" : scalar(raw);
+    root[key] = raw === "" ? "" : parseYamlValue(raw, anchors);
     i++;
   }
   return normalizeCharter(root);
 }
 
-const KNOWN_TOP_LEVEL_KEYS = new Set(["name", "description", "goal", "session", "project", "discord", "defaults", "members", "agents", "lifecycle", "governance"]);
+const KNOWN_TOP_LEVEL_KEYS = new Set(["name", "description", "goal", "session", "project", "discord", "defaults", "flags", "engines", "members", "agents", "lifecycle", "governance"]);
 const KNOWN_MEMBER_KEYS = new Set(["role", "name", "target", "model", "cwd", "prompt", "engine", "worktree", "branch", "queue", "node", "channels", "discord"]);
 
 function normalizeTeamMember(roleRaw: string, m: Record<string, unknown>): TeamCharterMember {
@@ -378,6 +487,8 @@ function normalizeCharter(value: unknown): TeamCharter {
     ...(typeof raw.session === "string" && raw.session.trim() ? { session: raw.session.trim() } : {}),
     ...(Object.keys(defaults).length ? { defaults: normalizeTeamMemberDefaults(defaults) } : {}),
     members,
+    ...(raw.flags && typeof raw.flags === "object" && !Array.isArray(raw.flags) ? { flags: raw.flags as TeamCharterFlags } : {}),
+    ...(raw.engines && typeof raw.engines === "object" && !Array.isArray(raw.engines) ? { engines: raw.engines as TeamCharterEngines } : {}),
     ...(raw.agents && typeof raw.agents === "object" && !Array.isArray(raw.agents) ? { agents: raw.agents as Record<string, Record<string, unknown>> } : {}),
     ...(warnings.length ? { warnings } : {}),
     ...(raw.lifecycle && typeof raw.lifecycle === "object" && !Array.isArray(raw.lifecycle) ? { lifecycle: raw.lifecycle as Record<string, unknown> } : {}),

--- a/src/vendor/mpr-plugins/team/team-liveness.ts
+++ b/src/vendor/mpr-plugins/team/team-liveness.ts
@@ -2,10 +2,11 @@ import { existsSync } from "fs";
 import { basename, dirname, join } from "path";
 import { Tmux } from "../../../core/transport/tmux";
 import { isAgentCommand } from "../../../core/agent-detect";
+import { resolveEngine } from "maw-js/sdk";
 import { loadConfig } from "../../../config/load";
 import type { MawConfig } from "../../../config/types";
 import { cmdWake, type WakeOptions } from "../../../commands/shared/wake-cmd";
-import type { TeamCharterMember } from "./team-charter";
+import type { TeamCharterEngines, TeamCharterMember } from "./team-charter";
 
 export type TeamMemberState = "live" | "dead" | "missing" | "skipped";
 
@@ -186,9 +187,28 @@ export function classifyMember(
   return { member, role, engine, worktree, windowIdentity, state: "dead", pane };
 }
 
-export function engineCommand(engine: string, opts: { resume?: boolean } = {}, config: MawConfig = loadConfig()): string {
+export interface EngineCommandOptions {
+  resume?: boolean;
+  engines?: TeamCharterEngines;
+}
+
+function flattenEngineValue(value: unknown): string[] {
+  if (Array.isArray(value)) return value.flatMap((item) => flattenEngineValue(item));
+  if (typeof value === "string") return [value.trim()].filter(Boolean);
+  if (value == null) return [];
+  return [String(value).trim()].filter(Boolean);
+}
+
+export function resolveCharterEngineCommand(engine: string, engines?: TeamCharterEngines): string | undefined {
+  const value = engines?.[engine];
+  if (value === undefined) return undefined;
+  const command = flattenEngineValue(value).join(" ").trim();
+  return command || undefined;
+}
+
+export function engineCommand(engine: string, opts: EngineCommandOptions = {}, config: MawConfig = loadConfig()): string {
   const key = opts.resume ? `${engine}-resume` : engine;
-  return config.commands?.[key] ?? config.commands?.default ?? key;
+  return resolveCharterEngineCommand(key, opts.engines) ?? resolveEngine(key, config).cmd;
 }
 
 export function repoSlugFromRoot(root: string): string {

--- a/src/vendor/mpr-plugins/team/team-up.ts
+++ b/src/vendor/mpr-plugins/team/team-up.ts
@@ -228,15 +228,15 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
       if (item.state === "skipped") {
         actions.push({ role: item.role, memberKey, state: item.state, action: `skip (${item.skipReason ?? "guard"})` });
       } else if (opts.force) {
-        const command = engineCommand(item.engine, { resume: false }, config);
+        const command = engineCommand(item.engine, { resume: false, engines: charter.engines }, config);
         actions.push({ role: item.role, memberKey, state: item.state, action: freshWakePlan(item, targetRepoSlug, session, memberChannels(charter, item.member), "would force fresh wake"), command });
       } else if (item.state === "live") {
         actions.push({ role: item.role, memberKey, state: item.state, action: "skip live" });
       } else if (item.state === "dead") {
-        const command = engineCommand(item.engine, { resume: true }, config);
+        const command = engineCommand(item.engine, { resume: true, engines: charter.engines }, config);
         actions.push({ role: item.role, memberKey, state: item.state, action: "would relaunch in place with resume", command });
       } else {
-        const command = engineCommand(item.engine, { resume: false }, config);
+        const command = engineCommand(item.engine, { resume: false, engines: charter.engines }, config);
         actions.push({ role: item.role, memberKey, state: item.state, action: freshWakePlan(item, targetRepoSlug, session, memberChannels(charter, item.member)), command });
       }
     }
@@ -253,7 +253,7 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
       actions.push({ role: item.role, memberKey, state: item.state, action: `skip (${item.skipReason ?? "guard"})` });
     } else if (opts.force) {
       if (item.pane) await tmux.run("kill-window", "-t", `${item.pane.sessionName ?? session}:${item.pane.windowName}`);
-      const command = engineCommand(item.engine, { resume: false }, config);
+      const command = engineCommand(item.engine, { resume: false, engines: charter.engines }, config);
       await wakeMember(targetRepoSlug, item.member, { engine: item.engine, session, repoPath: repoRoot, channels: memberChannels(charter, item.member) }, { cmdWakeFn: deps.cmdWakeFn });
       actions.push({ role: item.role, memberKey, state: item.state, action: "force fresh wake", command });
       await waitForNonShell(item.member, session, tmux, sleep, targetRepoSlug);
@@ -262,7 +262,7 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
     } else if (item.state === "live") {
       actions.push({ role: item.role, memberKey, state: item.state, action: "skip live" });
     } else if (item.state === "dead") {
-      const command = engineCommand(item.engine, { resume: true }, config);
+      const command = engineCommand(item.engine, { resume: true, engines: charter.engines }, config);
       await tmux.run("send-keys", "-t", item.pane!.paneId, "C-u");
       await tmux.run("send-keys", "-t", item.pane!.paneId, command, "Enter");
       actions.push({ role: item.role, memberKey, state: item.state, action: "resume in place", command });
@@ -270,7 +270,7 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
       await sleep(promptDelayMs(charter));
       await primeMember(item.member, session, repoRoot, deps, warnings);
     } else {
-      const command = engineCommand(item.engine, { resume: false }, config);
+      const command = engineCommand(item.engine, { resume: false, engines: charter.engines }, config);
       await wakeMember(targetRepoSlug, item.member, { engine: item.engine, session, repoPath: repoRoot, channels: memberChannels(charter, item.member) }, { cmdWakeFn: deps.cmdWakeFn });
       actions.push({ role: item.role, memberKey, state: item.state, action: "fresh wake", command });
       await waitForNonShell(item.member, session, tmux, sleep, targetRepoSlug);

--- a/test/isolated/plugin-team-standalone.test.ts
+++ b/test/isolated/plugin-team-standalone.test.ts
@@ -257,13 +257,14 @@ agents:
     mock.module(import.meta.resolve("../../src/commands/shared/wake-cmd.ts"), () => ({
       cmdWake: async () => "",
     }));
-    const { memberEngine } = await import("../../src/vendor/mpr-plugins/team/team-liveness.ts?plugin-team-member-engine");
+    const { memberEngine, resolveCharterEngineCommand } = await import("../../src/vendor/mpr-plugins/team/team-liveness.ts?plugin-team-member-engine");
 
     expect(memberEngine({ role: "builder" } as any, undefined, { defaultEngine: "codex" } as any)).toBe("codex");
     expect(memberEngine({ role: "builder", model: "opencode" } as any, undefined, { defaultEngine: "codex" } as any)).toBe("opencode");
     expect(memberEngine({ role: "builder", engine: "aider" } as any, undefined, { defaultEngine: "codex" } as any)).toBe("aider");
     expect(memberEngine({ role: "builder", engine: "aider" } as any, "thclaws", { defaultEngine: "codex" } as any)).toBe("thclaws");
     expect(memberEngine({ role: "builder" } as any, undefined, {} as any)).toBe("claude");
+    expect(resolveCharterEngineCommand("opus48", { opus48: ["claude --model opus", ["--dangerously-skip-permissions"]] })).toBe("claude --model opus --dangerously-skip-permissions");
   });
 
   test("enter subcommand sends tmux enter via SDK hostExec", async () => {

--- a/test/isolated/team-charter-plan.test.ts
+++ b/test/isolated/team-charter-plan.test.ts
@@ -84,6 +84,47 @@ governance:
     expect(rendered).toContain("verifier: target 'new:light' is planned only");
   });
 
+
+  test("parses top-level flags and engines with YAML anchors", () => {
+    const charter = parseTeamCharterText(`
+name: charter-v3
+flags:
+  claude-combo: &claude-combo
+    - "--dangerously-skip-permissions"
+    - "--channels plugin:discord@claude-plugins-official"
+  omx-combo: &omx-combo ["--yolo", "--direct"]
+engines:
+  opus48: ["claude --model claude-opus-4-8", *claude-combo]
+  omx-5.5: ["omx --model gpt-5.5", *omx-combo]
+members:
+  - role: builder
+    engine: opus48
+`);
+
+    expect(charter.flags?.["claude-combo"]).toEqual([
+      "--dangerously-skip-permissions",
+      "--channels plugin:discord@claude-plugins-official",
+    ]);
+    expect(charter.flags?.["omx-combo"]).toEqual(["--yolo", "--direct"]);
+    expect(charter.engines?.opus48).toEqual([
+      "claude --model claude-opus-4-8",
+      ["--dangerously-skip-permissions", "--channels plugin:discord@claude-plugins-official"],
+    ]);
+    expect(charter.engines?.["omx-5.5"]).toEqual(["omx --model gpt-5.5", ["--yolo", "--direct"]]);
+    expect(charter.warnings).toBeUndefined();
+  });
+
+  test("fails loudly for unknown YAML anchor references", () => {
+    expect(() => parseTeamCharterText(`
+name: bad-anchor
+engines:
+  missing: ["claude", *nope]
+members:
+  - role: builder
+    engine: missing
+`)).toThrow("unknown YAML anchor reference: *nope");
+  });
+
   test("parses JSON charters without requiring a YAML dependency", () => {
     const charter = parseTeamCharterText(JSON.stringify({
       name: "json-team",

--- a/test/isolated/team-up-coverage.test.ts
+++ b/test/isolated/team-up-coverage.test.ts
@@ -482,9 +482,37 @@ members:
     expect(result.warnings).toContain("current tmux session 'lead-session' differs from --session '01-mawjs'; targeting explicit session");
   });
 
+
+  test("dry-run action commands resolve charter engines with YAML anchor flags", async () => {
+    const root = tempRepo();
+    writeFileSync(join(root, ".maw", "teams", "anchors.yaml"), `
+name: anchors
+session: charter-session
+flags:
+  claude-combo: &claude-combo
+    - "--dangerously-skip-permissions"
+    - "--channels plugin:discord@claude-plugins-official"
+engines:
+  opus48: ["claude --model claude-opus-4-8", *claude-combo]
+members:
+  - role: builder
+    engine: opus48
+`, "utf-8");
+    const { tmux } = fakeTmux([]);
+
+    const result = await cmdTeamUp("anchors", { dryRun: true }, { cwd: root, tmux, loadConfigFn: () => config, logger: () => {} });
+
+    expect(result.actions[0]).toMatchObject({
+      role: "builder",
+      command: "claude --model claude-opus-4-8 --dangerously-skip-permissions --channels plugin:discord@claude-plugins-official",
+    });
+  });
+
   test("engine command resolves resume key only when requested", () => {
     expect(engineCommand("omx", {}, config)).toBe("maw run omx");
     expect(engineCommand("omx", { resume: true }, config)).toBe("maw run omx-resume");
+    expect(engineCommand("opus48", { engines: { opus48: ["claude --model opus", ["--dangerously-skip-permissions", "--channels plugin:discord"]] } }, config)).toBe("claude --model opus --dangerously-skip-permissions --channels plugin:discord");
+    expect(engineCommand("opus48", { resume: true, engines: { "opus48-resume": ["claude --resume abc", ["--dangerously-skip-permissions"]] } }, config)).toBe("claude --resume abc --dangerously-skip-permissions");
   });
 });
 


### PR DESCRIPTION
Closes #2527
Refs #2522

## Summary
- add top-level `flags:` and `engines:` support to the hand-rolled team charter YAML parser
- add zero-dependency YAML anchor/alias resolution for `&name` and `*name` in block lists and inline arrays
- resolve charter-local engine maps in `maw team up` action commands by flattening nested anchor-expanded arrays
- keep vendored team plugin standalone boundary covered

## Tests
- ✅ `bun test test/isolated/team-charter-plan.test.ts`
- ✅ `bun test test/isolated/team-up-coverage.test.ts`
- ✅ `bun test test/isolated/plugin-team-standalone.test.ts`
- ✅ `bun scripts/check-plugin-coverage-gate.ts origin/alpha`
- ✅ `bun run build`

Note: running `plugin-team-standalone` and `team-up-coverage` in the same Bun process still leaks mocks between files; each target file passes separately.
