### PR TITLE
Fix engine-aware done retrospectives

### DIFF
--- a/src/commands/shared/done.ts
+++ b/src/commands/shared/done.ts
@@ -8,6 +8,7 @@ import { normalizeTarget } from "../../core/matcher/normalize-target";
 import { mawDataPath } from "../../core/xdg";
 import { pruneJsonlFile } from "../../vendor/mpr-plugins/messages/retention";
 import { fleetDirForWrite, fleetDirsForRead, uniqueDirs } from "../../core/fleet/paths";
+import { inferRetrospectiveCommand } from "../../vendor/mpr-plugins/done/retrospective-command";
 
 export interface DoneOpts {
   force?: boolean;
@@ -429,12 +430,22 @@ export async function autoSave(
   const target = `${sessionName}:${windowName}`;
 
   let paneCwd = "";
+  let paneCurrentCommand = "";
   try {
-    paneCwd = (await d.hostExec(`tmux display-message -t '${target}' -p '#{pane_current_path}'`)).trim();
+    const paneInfo = await d.hostExec(`tmux display-message -t '${target}' -p '#{pane_current_command}\t#{pane_current_path}'`);
+    const [rawPaneCommand, rawPanePath] = paneInfo.split("\t");
+    paneCurrentCommand = (rawPaneCommand ?? "").trim();
+    paneCwd = (rawPanePath ?? "").trim();
   } catch { /* pane may not exist */ }
 
+  const retrospectiveCommand = inferRetrospectiveCommand(paneCurrentCommand);
+
   if (opts.dryRun) {
-    d.logger.log(`  \x1b[36m⬡\x1b[0m [dry-run] would send /rrr to ${target} and wait 10s`);
+    if (retrospectiveCommand) {
+      d.logger.log(`  \x1b[36m⬡\x1b[0m [dry-run] would send ${retrospectiveCommand} to ${target} and wait 10s`);
+    } else {
+      d.logger.log(`  \x1b[36m⬡\x1b[0m [dry-run] would skip retro (no retrospective command for this engine)`);
+    }
     if (paneCwd) {
       d.logger.log(`  \x1b[36m⬡\x1b[0m [dry-run] would git add + commit + push in ${paneCwd}`);
     }
@@ -444,13 +455,17 @@ export async function autoSave(
     return;
   }
 
-  d.logger.log(`  \x1b[36m⏳\x1b[0m sending /rrr to ${target}...`);
-  try {
-    await d.tmux.sendText(target, "/rrr");
-    await d.sleep(10_000);
-    d.logger.log(`  \x1b[32m✓\x1b[0m /rrr sent (waited 10s)`);
-  } catch {
-    d.logger.log(`  \x1b[33m⚠\x1b[0m could not send /rrr (agent may not be running)`);
+  if (retrospectiveCommand) {
+    d.logger.log(`  \x1b[36m⏳\x1b[0m sending ${retrospectiveCommand} to ${target}...`);
+    try {
+      await d.tmux.sendText(target, retrospectiveCommand);
+      await d.sleep(10_000);
+      d.logger.log(`  \x1b[32m✓\x1b[0m ${retrospectiveCommand} sent (waited 10s)`);
+    } catch {
+      d.logger.log(`  \x1b[33m⚠\x1b[0m could not send ${retrospectiveCommand} (agent may not be running)`);
+    }
+  } else {
+    d.logger.log(`  \x1b[90m○\x1b[0m no retrospective command for this engine — skipping retro`);
   }
 
   if (paneCwd) {

--- a/src/vendor/mpr-plugins/done/done-autosave.ts
+++ b/src/vendor/mpr-plugins/done/done-autosave.ts
@@ -6,27 +6,9 @@ import { cmdReunion } from "./internal/reunion-impl";
 import { cmdSoulSync } from "./internal/soul-sync-impl";
 import type { DoneOpts } from "./impl";
 import { mawDataPath } from "../../../core/xdg";
+import { inferRetrospectiveCommand } from "./retrospective-command";
 
 type SessionInfo = { name: string; windows: { index: number; name: string; active: boolean }[] };
-
-type RetrospectiveCommand = "/rrr" | "$rrr";
-
-/** Engines that support the `$rrr` retrospective command (oh-my-codex wrapper). */
-const DOLLAR_RRR_ENGINES = /\b(omx|oh-my-codex)\b/i;
-/** Engines with no retrospective command — skip the retro step entirely. */
-const NO_RETRO_ENGINES = /\b(codex|aider|opencode)\b/i;
-
-/**
- * Choose the retrospective command for a pane's engine.
- * Returns `null` to skip the retro entirely (engines that have no equivalent),
- * `$rrr` for the oh-my-codex wrapper, and `/rrr` for claude (the default).
- */
-function inferRetrospectiveCommand(paneCurrentCommand: string): RetrospectiveCommand | null {
-  const command = paneCurrentCommand || "";
-  if (DOLLAR_RRR_ENGINES.test(command)) return "$rrr";
-  if (NO_RETRO_ENGINES.test(command)) return null;
-  return "/rrr";
-}
 
 /** Signal parent oracle inbox that a worktree window is done (#81). */
 export async function signalParentInbox(

--- a/src/vendor/mpr-plugins/done/retrospective-command.ts
+++ b/src/vendor/mpr-plugins/done/retrospective-command.ts
@@ -1,0 +1,20 @@
+type RetrospectiveCommand = "/rrr" | "$rrr";
+
+/** Engines that support the `$rrr` retrospective command (oh-my-codex wrapper). */
+const DOLLAR_RRR_ENGINES = /\b(omx|oh-my-codex)\b/i;
+/** Engines with no retrospective command — skip the retro step entirely. */
+const NO_RETRO_ENGINES = /\b(codex|aider|opencode)\b/i;
+
+/**
+ * Choose the retrospective command for a pane's engine.
+ *
+ * Returns `null` to skip the retro entirely (engines that have no equivalent),
+ * `$rrr` for the oh-my-codex wrapper, and `/rrr` for claude/unknown engines
+ * (the historical default).
+ */
+export function inferRetrospectiveCommand(paneCurrentCommand: string): RetrospectiveCommand | null {
+  const command = paneCurrentCommand || "";
+  if (DOLLAR_RRR_ENGINES.test(command)) return "$rrr";
+  if (NO_RETRO_ENGINES.test(command)) return null;
+  return "/rrr";
+}

--- a/test/done-command.test.ts
+++ b/test/done-command.test.ts
@@ -92,7 +92,7 @@ function createHarness(options: {
     hostExec: async (command: string) => {
       commands.push(command);
       if (options.hostExec) return await options.hostExec(command);
-      if (command.includes("pane_current_path")) return "/repos/github.com/Soul-Brews-Studio/maw-js.wt-tile-1\n";
+      if (command.includes("pane_current_path")) return "claude\t/repos/github.com/Soul-Brews-Studio/maw-js.wt-tile-1\n";
       if (command.startsWith("find ")) return "";
       return "";
     },
@@ -141,7 +141,7 @@ describe("cmdDone", () => {
 
     await cmdDone(" tile-1/ ", { dryRun: true }, h.deps);
 
-    expect(h.commands).toEqual(["tmux display-message -t 'work:tile-1' -p '#{pane_current_path}'"]);
+    expect(h.commands).toEqual(["tmux display-message -t 'work:tile-1' -p '#{pane_current_command}\t#{pane_current_path}'"]);
     expect(h.killed).toEqual([]);
     expect(h.snapshots).toEqual([]);
     expect(h.logs.join("\n")).toContain("would send /rrr to work:tile-1");
@@ -178,7 +178,7 @@ describe("cmdDone", () => {
 
     await cmdDone("TILE-1", { force: true }, h.deps);
 
-    expect(h.commands).not.toContain("tmux display-message -t 'work:tile-1' -p '#{pane_current_path}'");
+    expect(h.commands).not.toContain("tmux display-message -t 'work:tile-1' -p '#{pane_current_command}\t#{pane_current_path}'");
     expect(h.killed).toEqual(["work:tile-1"]);
     expect(h.commands).toEqual([
       "git -C '/repos/github.com/Soul-Brews-Studio/maw-js.wt-tile-1' rev-parse --abbrev-ref HEAD",
@@ -310,7 +310,7 @@ describe("done inbox and autosave helpers", () => {
     expect(h.sent).toEqual([{ target: "work:tile-1", text: "/rrr" }]);
     expect(h.sleeps).toEqual([10_000]);
     expect(h.commands).toEqual([
-      "tmux display-message -t 'work:tile-1' -p '#{pane_current_path}'",
+      "tmux display-message -t 'work:tile-1' -p '#{pane_current_command}\t#{pane_current_path}'",
       "git -C '/repos/github.com/Soul-Brews-Studio/maw-js.wt-tile-1' add -A",
       "git -C '/repos/github.com/Soul-Brews-Studio/maw-js.wt-tile-1' commit -m 'chore: auto-save before done'",
       "git -C '/repos/github.com/Soul-Brews-Studio/maw-js.wt-tile-1' push",
@@ -326,7 +326,7 @@ describe("done inbox and autosave helpers", () => {
 
     const commitPushFail = createHarness({
       hostExec: (command) => {
-        if (command.includes("pane_current_path")) return "/repo";
+        if (command.includes("pane_current_path")) return "claude\t/repo";
         if (command.includes(" commit ")) throw new Error("nothing");
         if (command.endsWith(" push")) throw new Error("denied");
         return "";
@@ -338,7 +338,7 @@ describe("done inbox and autosave helpers", () => {
 
     const addFail = createHarness({
       hostExec: (command) => {
-        if (command.includes("pane_current_path")) return "/repo";
+        if (command.includes("pane_current_path")) return "claude\t/repo";
         if (command.endsWith(" add -A")) throw new Error("add failed");
         return "";
       },
@@ -358,6 +358,24 @@ describe("done inbox and autosave helpers", () => {
 
     expect(h.logs.join("\n")).toContain("would send /rrr to work:tile-1");
     expect(h.logs.join("\n")).not.toContain("would git add + commit + push");
+  });
+
+  test("autoSave uses engine-aware retrospective command from shared done", async () => {
+    const omx = createHarness({
+      hostExec: (command) => command.includes("pane_current_path") ? "omx\t/repo" : "",
+    });
+    await autoSave("tile-1", "work", {}, omx.deps);
+    expect(omx.sent).toEqual([{ target: "work:tile-1", text: "$rrr" }]);
+    expect(omx.sleeps).toEqual([10_000]);
+    expect(omx.logs.join("\n")).toContain("$rrr sent (waited 10s)");
+
+    const codex = createHarness({
+      hostExec: (command) => command.includes("pane_current_path") ? "codex\t/repo" : "",
+    });
+    await autoSave("tile-1", "work", {}, codex.deps);
+    expect(codex.sent).toEqual([]);
+    expect(codex.sleeps).toEqual([]);
+    expect(codex.logs.join("\n")).toContain("no retrospective command for this engine");
   });
 });
 

--- a/test/isolated/plugin-done-standalone.test.ts
+++ b/test/isolated/plugin-done-standalone.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
+
+const { inferRetrospectiveCommand } = await import(
+  "../../src/vendor/mpr-plugins/done/retrospective-command.ts?plugin-done-standalone"
+);
+
+describe("done command plugin standalone boundary", () => {
+  test("touched done autosave files keep explicit standalone import boundaries", () => {
+    const imports = expectStandalonePluginBoundary({
+      plugin: "done",
+      files: ["done-autosave.ts", "retrospective-command.ts"],
+      allowRelative: ["../../../core/xdg"],
+    }).map((record) => record.spec);
+
+    expect(imports).toContain("maw-js/sdk");
+    expect(imports).toContain("./retrospective-command");
+  });
+
+  test("shared retrospective inference covers claude, omx, and codex-style engines", () => {
+    expect(inferRetrospectiveCommand("claude")).toBe("/rrr");
+    expect(inferRetrospectiveCommand("node")).toBe("/rrr");
+    expect(inferRetrospectiveCommand("omx")).toBe("$rrr");
+    expect(inferRetrospectiveCommand("oh-my-codex")).toBe("$rrr");
+    expect(inferRetrospectiveCommand("codex")).toBeNull();
+    expect(inferRetrospectiveCommand("aider")).toBeNull();
+    expect(inferRetrospectiveCommand("opencode")).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #2532

## Summary
- move done retrospective command inference into a shared vendored helper
- make shared cmdDone/autoSave inspect pane_current_command before retro
- skip retros for codex/aider/opencode and send $rrr for omx/oh-my-codex
- add standalone plugin boundary coverage for done

## Tests
- bun test test/isolated/plugin-done-standalone.test.ts test/done-command.test.ts test/isolated/done-autosave-engine-retro.test.ts
- bun test test/isolated/team-remove-coverage.test.ts test/isolated/team-reassign-coverage.test.ts
- bun scripts/check-plugin-coverage-gate.ts origin/alpha
- bun run build