### PR TITLE
feat: parallelize team up spawn phases

### DIFF
--- a/src/vendor/mpr-plugins/team/team-up.ts
+++ b/src/vendor/mpr-plugins/team/team-up.ts
@@ -247,36 +247,49 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
   }
 
   const sleep = deps.sleep ?? DEFAULT_SLEEP;
+  const launchTasks: Array<{ item: ClassifiedTeamMember; run: () => Promise<void> }> = [];
   for (const [index, item] of roster.entries()) {
     const memberKey = memberActionKey(item, index);
     if (item.state === "skipped") {
       actions.push({ role: item.role, memberKey, state: item.state, action: `skip (${item.skipReason ?? "guard"})` });
     } else if (opts.force) {
-      if (item.pane) await tmux.run("kill-window", "-t", `${item.pane.sessionName ?? session}:${item.pane.windowName}`);
       const command = engineCommand(item.engine, { resume: false, engines: charter.engines }, config);
-      await wakeMember(targetRepoSlug, item.member, { engine: item.engine, session, repoPath: repoRoot, channels: memberChannels(charter, item.member) }, { cmdWakeFn: deps.cmdWakeFn });
       actions.push({ role: item.role, memberKey, state: item.state, action: "force fresh wake", command });
-      await waitForNonShell(item.member, session, tmux, sleep, targetRepoSlug);
-      await sleep(promptDelayMs(charter));
-      await primeMember(item.member, session, repoRoot, deps, warnings);
+      launchTasks.push({
+        item,
+        run: async () => {
+          if (item.pane) await tmux.run("kill-window", "-t", `${item.pane.sessionName ?? session}:${item.pane.windowName}`);
+          await wakeMember(targetRepoSlug, item.member, { engine: item.engine, session, repoPath: repoRoot, channels: memberChannels(charter, item.member) }, { cmdWakeFn: deps.cmdWakeFn });
+        },
+      });
     } else if (item.state === "live") {
       actions.push({ role: item.role, memberKey, state: item.state, action: "skip live" });
     } else if (item.state === "dead") {
       const command = engineCommand(item.engine, { resume: true, engines: charter.engines }, config);
-      await tmux.run("send-keys", "-t", item.pane!.paneId, "C-u");
-      await tmux.run("send-keys", "-t", item.pane!.paneId, command, "Enter");
       actions.push({ role: item.role, memberKey, state: item.state, action: "resume in place", command });
-      await waitForNonShell(item.member, session, tmux, sleep, targetRepoSlug);
-      await sleep(promptDelayMs(charter));
-      await primeMember(item.member, session, repoRoot, deps, warnings);
+      launchTasks.push({
+        item,
+        run: async () => {
+          await tmux.run("send-keys", "-t", item.pane!.paneId, "C-u");
+          await tmux.run("send-keys", "-t", item.pane!.paneId, command, "Enter");
+        },
+      });
     } else {
       const command = engineCommand(item.engine, { resume: false, engines: charter.engines }, config);
-      await wakeMember(targetRepoSlug, item.member, { engine: item.engine, session, repoPath: repoRoot, channels: memberChannels(charter, item.member) }, { cmdWakeFn: deps.cmdWakeFn });
       actions.push({ role: item.role, memberKey, state: item.state, action: "fresh wake", command });
-      await waitForNonShell(item.member, session, tmux, sleep, targetRepoSlug);
-      await sleep(promptDelayMs(charter));
-      await primeMember(item.member, session, repoRoot, deps, warnings);
+      launchTasks.push({
+        item,
+        run: async () => {
+          await wakeMember(targetRepoSlug, item.member, { engine: item.engine, session, repoPath: repoRoot, channels: memberChannels(charter, item.member) }, { cmdWakeFn: deps.cmdWakeFn });
+        },
+      });
     }
+  }
+  await Promise.all(launchTasks.map((task) => task.run()));
+  if (launchTasks.length > 0) {
+    await Promise.all(launchTasks.map((task) => waitForNonShell(task.item.member, session, tmux, sleep, targetRepoSlug)));
+    await sleep(promptDelayMs(charter));
+    await Promise.all(launchTasks.map((task) => primeMember(task.item.member, session, repoRoot, deps, warnings)));
   }
 
   const finalPanes = await listPaneSnapshots(tmux).catch(() => panes);

--- a/test/isolated/plugin-team-standalone.test.ts
+++ b/test/isolated/plugin-team-standalone.test.ts
@@ -110,6 +110,9 @@ describe("team command plugin standalone boundary (#2336)", () => {
     expect(command).toMatchObject({ name: "team" });
     expect(imports).toContain("maw-js/sdk");
     expect(imports).toEqual(expect.arrayContaining(["./team-up", "../../../commands/shared/wake-cmd"]));
+    const teamUp = readFileSync(join(root, "src/vendor/mpr-plugins/team/team-up.ts"), "utf8");
+    expect(teamUp).toContain("Promise.all(launchTasks.map((task) => task.run()))");
+    expect(teamUp).toContain("Promise.all(launchTasks.map((task) => waitForNonShell");
     const sdk = readFileSync(join(root, "src/sdk/index.ts"), "utf8");
     expect(sdk).toContain("parseFlags");
     expect(sdk).toContain("hostExec");

--- a/test/isolated/team-up-coverage.test.ts
+++ b/test/isolated/team-up-coverage.test.ts
@@ -262,6 +262,75 @@ agents:
     expect(events.indexOf("sleep:42")).toBeLessThan(events.indexOf("send"));
   });
 
+  test("team up launches missing members in parallel before readiness waits and prompt priming", async () => {
+    const root = mkdtempSync(join(tmpdir(), "maw-node-parallel-wake-"));
+    dirs.push(root);
+    mkdirSync(join(root, ".git"));
+    mkdirSync(join(root, ".maw"), { recursive: true });
+    writeFileSync(join(root, ".maw", "m5.yaml"), `
+name: m5-team
+session: charter-session
+lifecycle:
+  prompt_delay: 7
+agents:
+  coder-a:
+    engine: omx
+    prompt: prompt a
+  coder-b:
+    engine: claude48
+    prompt: prompt b
+`, "utf-8");
+
+    let listCalls = 0;
+    const events: string[] = [];
+    const tmux = {
+      run: async (...args: string[]) => {
+        if (args[0] === "display-message") return "lead-session\n";
+        if (args[0] === "list-panes") {
+          listCalls++;
+          if (listCalls === 1) return "";
+          return [
+            "charter-session|coder-a|codex|/wt/coder-a|%1",
+            "charter-session|coder-b|claude|/wt/coder-b|%2",
+          ].join("\n");
+        }
+        return "";
+      },
+    };
+    const wakeResolvers: Array<() => void> = [];
+    const wakes: any[] = [];
+
+    const run = cmdTeamUp("any", { session: "charter-session" }, {
+      cwd: root,
+      tmux,
+      loadConfigFn: () => ({ ...config, node: "m5" }),
+      cmdWakeFn: async (...args: any[]) => {
+        wakes.push(args);
+        events.push(`wake:start:${args[1].wt}`);
+        await new Promise<void>((resolve) => wakeResolvers.push(resolve));
+        events.push(`wake:end:${args[1].wt}`);
+        return "woke";
+      },
+      cmdSendFn: async (...args: any[]) => { events.push(`prime:${args[0]}`); },
+      sleep: async (ms: number) => { events.push(`sleep:${ms}`); },
+      logger: () => {},
+    });
+
+    for (let i = 0; i < 20 && wakeResolvers.length < 2; i++) await Promise.resolve();
+
+    expect(wakeResolvers).toHaveLength(2);
+    expect(events).toEqual(["wake:start:coder-a", "wake:start:coder-b"]);
+    expect(wakes.map((wake) => wake[1].wt)).toEqual(["coder-a", "coder-b"]);
+
+    for (const resolveWake of wakeResolvers) resolveWake();
+    await run;
+
+    expect(events.indexOf("sleep:7")).toBeGreaterThan(events.indexOf("wake:end:coder-a"));
+    expect(events.indexOf("sleep:7")).toBeGreaterThan(events.indexOf("wake:end:coder-b"));
+    expect(events.indexOf("sleep:7")).toBeLessThan(events.indexOf("prime:charter-session:coder-a"));
+    expect(events.indexOf("sleep:7")).toBeLessThan(events.indexOf("prime:charter-session:coder-b"));
+  });
+
   test("team up wakes charter.project and primes inline plus file-ref prompts", async () => {
     const root = mkdtempSync(join(tmpdir(), "maw-node-prompt-"));
     dirs.push(root);


### PR DESCRIPTION
Closes #2528
Refs #2533

## Summary
- replace the sequential team-up launch loop with a three-phase parallel flow: wake/resume all, wait for non-shell panes, then prime prompts
- preserve roster/action ordering while allowing independent member startup work to overlap
- keep wake calls on explicit member worktree names, avoiding auto-number slot allocation while #2533 is still open

## Tests
- bun test test/isolated/team-up-coverage.test.ts
- bun test test/isolated/plugin-team-standalone.test.ts
- bun scripts/check-plugin-coverage-gate.ts origin/alpha
- bun run build

## Not run
- full bun test suite