### PR TITLE
fix: add buddy alias for bud

### DIFF
--- a/src/vendor/mpr-plugins/bud/plugin.json
+++ b/src/vendor/mpr-plugins/bud/plugin.json
@@ -6,6 +6,9 @@
   "description": "Create a new oracle (bud from parent)",
   "cli": {
     "command": "bud",
+    "aliases": [
+      "buddy"
+    ],
     "help": "maw bud <name> [--from <oracle>] [--root] [--seed] [--org <org>] [--repo org/repo] [--issue N] [--note <text>] [--fast] [--split] [--scaffold-only] [--dry-run]\n       Or:    maw scaffold <name> [bud flags...]  (structure only; no commit/push/wake/awaken)\n       Or:    maw bud --from-repo <path> --stem <stem> [--pr] [--dry-run]  (#588, scaffold-only)\n       Default: born blank. Use --seed to pre-load parent's ψ at birth.\n       Pull memory later: maw soul-sync <parent> --from\n       NOTE: <name> is the STEM. Repo created as <name>-oracle.\n       e.g. 'maw bud fusion' → 'fusion-oracle'. 'maw bud fusion-oracle' → 'fusion-oracle-oracle' ✗",
     "flags": {
       "--from": "string",

--- a/src/vendor/mpr-plugins/bud/plugin.ts
+++ b/src/vendor/mpr-plugins/bud/plugin.ts
@@ -8,6 +8,9 @@ export default definePlugin({
   "description": "Create a new oracle (bud from parent)",
   "cli": {
     "command": "bud",
+    "aliases": [
+      "buddy"
+    ],
     "help": "maw bud <name> [--from <oracle>] [--root] [--seed] [--org <org>] [--repo org/repo] [--issue N] [--note <text>] [--fast] [--split] [--scaffold-only] [--dry-run]\n       Or:    maw scaffold <name> [bud flags...]  (structure only; no commit/push/wake/awaken)\n       Or:    maw bud --from-repo <path> --stem <stem> [--pr] [--dry-run]  (#588, scaffold-only)\n       Default: born blank. Use --seed to pre-load parent's ψ at birth.\n       Pull memory later: maw soul-sync <parent> --from\n       NOTE: <name> is the STEM. Repo created as <name>-oracle.\n       e.g. 'maw bud fusion' → 'fusion-oracle'. 'maw bud fusion-oracle' → 'fusion-oracle-oracle' ✗",
     "flags": {
       "--from": "string",

--- a/test/isolated/plugin-bud-standalone.test.ts
+++ b/test/isolated/plugin-bud-standalone.test.ts
@@ -104,6 +104,7 @@ beforeEach(() => {
 describe("bud plugin standalone boundary (#2314)", () => {
   test("all bud sources use SDK or local/platform imports only", () => {
     const imports = walkSources(budDir).flatMap((file) => importSpecs(readFileSync(file, "utf8")));
+    const manifest = JSON.parse(readFileSync(join(budDir, "plugin.json"), "utf8"));
     const forbidden = imports.filter((spec) =>
       spec.startsWith("maw-js/core/")
       || spec.startsWith("maw-js/commands/shared/")
@@ -116,6 +117,8 @@ describe("bud plugin standalone boundary (#2314)", () => {
     );
 
     expect(command).toMatchObject({ name: "bud" });
+    expect(manifest.cli.aliases).toEqual(["buddy"]);
+    expect(readFileSync(join(budDir, "plugin.ts"), "utf8")).toContain('"aliases": [\n      "buddy"\n    ]');
     expect(forbidden).toEqual([]);
     expect(imports).toContain("maw-js/sdk");
   });


### PR DESCRIPTION
Closes #2524

## Summary
- add `buddy` as a CLI alias for the bud vendor plugin manifest
- keep plugin.ts and plugin.json in sync
- update bud standalone boundary coverage for the alias

## Tests
- bun test test/isolated/plugin-bud-standalone.test.ts
- bun scripts/check-plugin-coverage-gate.ts origin/alpha
- bun run build

## Not run
- full bun test suite