### PR TITLE
feat: add quick in-memory team up charters

### DIFF
--- a/src/vendor/mpr-plugins/team/index.ts
+++ b/src/vendor/mpr-plugins/team/index.ts
@@ -408,11 +408,6 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     } else if (sub === "up") {
       // #1976 — charter-driven team wake: reconcile the charter against live
       // panes (skip live, resume dead in place, fresh-wake missing).
-      if (!args[1]) {
-        logs.push("usage: maw team up <team> [--session <name>] [--members <roles>] [--only <a,b>] [--dry-run] [--status] [--force] [--gather] [-e <engine>]");
-        return { ok: false, error: "team required", output: logs.join("\n") };
-      }
-      const { cmdTeamUp } = await import("./team-up");
       const flags = parseFlags(args, {
         "--dry-run": Boolean,
         "--status": Boolean,
@@ -420,20 +415,38 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         "--gather": Boolean,
         "--engine": String,
         "-e": "--engine",
+        "--quick": Number,
         "--only": String,
         "--members": String,
         "--session": String,
-      }, 2);
-      await cmdTeamUp(args[1], {
+      }, 1);
+      const quick = flags["--quick"] === undefined ? undefined : Number(flags["--quick"]);
+      const team = (flags._[0] as string | undefined) || (quick !== undefined ? "quick" : undefined);
+      if (!team) {
+        logs.push("usage: maw team up <team> [--session <name>] [--members <roles>] [--only <a,b>] [--dry-run] [--status] [--force] [--gather] [-e <engine>] [--quick N]");
+        logs.push("       maw team up --quick N [-e <engine>] [--session <name>]");
+        return { ok: false, error: "team required", output: logs.join("\n") };
+      }
+      if (quick !== undefined && (!Number.isInteger(quick) || quick < 1)) {
+        return { ok: false, error: "--quick must be a positive integer", output: logs.join("\n") || undefined };
+      }
+      const { cmdTeamUp, quickCharter } = await import("./team-up");
+      const engine = flags["--engine"] as string | undefined;
+      const session = flags["--session"] as string | undefined;
+      await cmdTeamUp(team, {
         dryRun: Boolean(flags["--dry-run"]),
         status: Boolean(flags["--status"]),
         force: Boolean(flags["--force"]),
         gather: Boolean(flags["--gather"]),
-        engine: flags["--engine"] as string | undefined,
+        engine,
+        quick,
         only: String(flags["--only"] || "").split(",").map((s) => s.trim()).filter(Boolean),
         members: String(flags["--members"] || "").split(",").map((s) => s.trim()).filter(Boolean),
-        session: flags["--session"] as string | undefined,
-      });
+        session,
+      }, quick !== undefined ? {
+        charterPath: null,
+        readTeamCharterFn: () => quickCharter(quick, { name: team, engine, session }),
+      } : undefined);
 
     } else {
       logs.push(`unknown team subcommand: ${sub}`);

--- a/src/vendor/mpr-plugins/team/team-up.ts
+++ b/src/vendor/mpr-plugins/team/team-up.ts
@@ -31,6 +31,7 @@ export interface TeamUpOptions {
   status?: boolean;
   gather?: boolean;
   engine?: string;
+  quick?: number;
   only?: string[];
   members?: string[];
   session?: string;
@@ -155,6 +156,20 @@ function promptDelayMs(charter: TeamCharter): number {
   return typeof configured === "number" ? configured : 3000;
 }
 
+export function quickCharter(count: number, opts: { name?: string; engine?: string; session?: string } = {}): TeamCharter {
+  const safeCount = Math.max(1, Math.floor(count));
+  const engine = opts.engine || "claude";
+  return {
+    name: opts.name || "quick",
+    ...(opts.session ? { session: opts.session } : {}),
+    members: Array.from({ length: safeCount }, (_, index) => {
+      const n = index + 1;
+      const role = `builder-${n}`;
+      return { role, name: role, engine, worktree: role };
+    }),
+  };
+}
+
 async function primeMember(
   member: TeamCharter["members"][number],
   session: string,
@@ -175,11 +190,13 @@ async function primeMember(
 export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: TeamUpDeps = {}): Promise<TeamUpResult> {
   const cwd = deps.cwd ?? process.cwd();
   const config: MawConfig = (deps.loadConfigFn ?? loadConfig)();
-  const charterPath = deps.charterPath !== undefined ? deps.charterPath : resolveCharterPath(team, cwd, config.node);
-  if (!charterPath) throw new Error(config.node ? `charter not found: ${team} (no team file for node '${config.node}')` : `charter not found: ${team}`);
+  const quickCount = typeof opts.quick === "number" && Number.isFinite(opts.quick) ? Math.floor(opts.quick) : undefined;
+  if (quickCount !== undefined && quickCount < 1) throw new Error("--quick must be a positive integer");
+  const charterPath = quickCount !== undefined ? null : (deps.charterPath !== undefined ? deps.charterPath : resolveCharterPath(team, cwd, config.node));
+  if (!charterPath && quickCount === undefined) throw new Error(config.node ? `charter not found: ${team} (no team file for node '${config.node}')` : `charter not found: ${team}`);
 
-  const read = deps.readTeamCharterFn ?? readTeamCharter;
-  const charter: TeamCharter = read(charterPath);
+  const read = deps.readTeamCharterFn ?? ((path: string) => quickCount !== undefined ? quickCharter(quickCount, { name: team, engine: opts.engine, session: opts.session }) : readTeamCharter(path));
+  const charter: TeamCharter = read(charterPath as string);
   const tmux = deps.tmux ?? new Tmux();
   const repoRoot = deps.repoRoot ?? findRepoRoot(cwd);
   const repoSlug = deps.repoSlug ?? repoSlugFromRoot(repoRoot);

--- a/test/isolated/plugin-team-standalone.test.ts
+++ b/test/isolated/plugin-team-standalone.test.ts
@@ -21,15 +21,16 @@ function parseFlags(args: string[], spec: Record<string, unknown>, start = 0) {
   const out: Record<string, any> & { _: string[] } = { _: [] };
   for (let i = start; i < args.length; i += 1) {
     const arg = args[i]!;
-    const parser = spec[arg];
+    const rawParser = spec[arg];
+    const key = typeof rawParser === "string" ? rawParser : arg;
+    const parser = typeof rawParser === "string" ? spec[rawParser] : rawParser;
     if (!parser) {
       out._.push(arg);
-    } else if (typeof parser === "string") {
-      out[parser] = true;
     } else if (parser === Boolean) {
-      out[arg] = true;
+      out[key] = true;
     } else if (parser === String || parser === Number) {
-      out[arg] = args[++i];
+      const value = args[++i];
+      out[key] = parser === Number ? Number(value) : value;
     }
   }
   return out;
@@ -69,7 +70,15 @@ mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/team/team-comms.ts
   },
 }));
 mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/team/team-up.ts"), () => ({
-  cmdTeamUp: async (...args: unknown[]) => calls.push({ name: "up", args }),
+  cmdTeamUp: async (...args: unknown[]) => {
+    calls.push({ name: "up", args });
+    const deps = args[2] as { readTeamCharterFn?: () => unknown } | undefined;
+    deps?.readTeamCharterFn?.();
+  },
+  quickCharter: (...args: unknown[]) => {
+    calls.push({ name: "quick-charter", args });
+    return { name: "quick", members: [] };
+  },
 }));
 mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/team/task-ops.ts"), () => ({
   cmdTeamTaskAdd: (...args: unknown[]) => calls.push({ name: "task-add", args }),
@@ -150,6 +159,18 @@ describe("team command plugin standalone boundary (#2336)", () => {
         members: ["coder-1", "oracle"],
         session: "alpha",
       }],
+    });
+  });
+
+  test("team up --quick dispatches through an in-memory charter seam", async () => {
+    await expect(teamHandler({ source: "cli", args: ["up", "--quick", "3", "-e", "omx", "--session", "charter-session"] } as any))
+      .resolves.toMatchObject({ ok: true });
+
+    expect(calls.find((call) => call.name === "quick-charter")).toMatchObject({
+      args: [3, { name: "quick", engine: "omx", session: "charter-session" }],
+    });
+    expect(calls.find((call) => call.name === "up")).toMatchObject({
+      args: ["quick", expect.objectContaining({ quick: 3, engine: "omx", session: "charter-session" }), expect.objectContaining({ charterPath: null })],
     });
   });
 

--- a/test/isolated/team-up-coverage.test.ts
+++ b/test/isolated/team-up-coverage.test.ts
@@ -9,7 +9,7 @@ import { tmpdir } from "os";
 // despite green tests. Guard the copy that actually ships.
 import { parseTeamCharterText } from "../../src/vendor/mpr-plugins/team/team-charter";
 import { classifyMember, engineCommand, memberWakeOptions, memberWakeTarget, resolveCharterPath } from "../../src/vendor/mpr-plugins/team/team-liveness";
-import { cmdTeamUp } from "../../src/vendor/mpr-plugins/team/team-up";
+import { cmdTeamUp, quickCharter } from "../../src/vendor/mpr-plugins/team/team-up";
 import { cmdTeamDown, TEAM_LIFECYCLE_GUARD_WINDOW } from "../../src/vendor/mpr-plugins/team/team-down";
 
 const dirs: string[] = [];
@@ -329,6 +329,57 @@ agents:
     expect(events.indexOf("sleep:7")).toBeGreaterThan(events.indexOf("wake:end:coder-b"));
     expect(events.indexOf("sleep:7")).toBeLessThan(events.indexOf("prime:charter-session:coder-a"));
     expect(events.indexOf("sleep:7")).toBeLessThan(events.indexOf("prime:charter-session:coder-b"));
+  });
+
+  test("--quick synthesizes an in-memory builder charter with explicit worktree names", async () => {
+    expect(quickCharter(3, { name: "quick", engine: "omx", session: "charter-session" })).toMatchObject({
+      name: "quick",
+      session: "charter-session",
+      members: [
+        { role: "builder-1", name: "builder-1", engine: "omx", worktree: "builder-1" },
+        { role: "builder-2", name: "builder-2", engine: "omx", worktree: "builder-2" },
+        { role: "builder-3", name: "builder-3", engine: "omx", worktree: "builder-3" },
+      ],
+    });
+
+    const root = tempRepo();
+    let listCalls = 0;
+    const tmux = {
+      run: async (...args: string[]) => {
+        if (args[0] === "display-message") return "lead-session\n";
+        if (args[0] === "list-panes") {
+          listCalls++;
+          if (listCalls === 1) return "";
+          return [
+            "charter-session|builder-1|codex|/wt/builder-1|%1",
+            "charter-session|builder-2|codex|/wt/builder-2|%2",
+            "charter-session|builder-3|codex|/wt/builder-3|%3",
+          ].join("\n");
+        }
+        return "";
+      },
+    };
+    const wakes: any[] = [];
+
+    const result = await cmdTeamUp("quick", { quick: 3, engine: "omx", session: "charter-session" }, {
+      cwd: root,
+      tmux,
+      loadConfigFn: () => config,
+      cmdWakeFn: async (...args: any[]) => { wakes.push(args); return "woke"; },
+      sleep: async () => {},
+      logger: () => {},
+    });
+
+    expect(wakes.map((wake) => wake[1])).toEqual([
+      { wt: "builder-1", engine: "omx", session: "charter-session", repoPath: root },
+      { wt: "builder-2", engine: "omx", session: "charter-session", repoPath: root },
+      { wt: "builder-3", engine: "omx", session: "charter-session", repoPath: root },
+    ]);
+    expect(result.roster.map((member) => [member.role, member.engine, member.state])).toEqual([
+      ["builder-1", "omx", "live"],
+      ["builder-2", "omx", "live"],
+      ["builder-3", "omx", "live"],
+    ]);
   });
 
   test("team up wakes charter.project and primes inline plus file-ref prompts", async () => {


### PR DESCRIPTION
Closes #2525

## Summary
- add `maw team up --quick N [-e engine]` for ephemeral in-memory builder charters
- synthesize `builder-N` members with explicit worktree names and no charter file writes
- wire quick mode through the existing `charterPath: null` + `readTeamCharterFn` injection seam
- preserve parallel wake behavior from #2528 for quick members

## Tests
- bun test test/isolated/team-up-coverage.test.ts
- bun test test/isolated/plugin-team-standalone.test.ts
- bun scripts/check-plugin-coverage-gate.ts origin/alpha
- bun run build

## Not run
- full bun test suite