### PR TITLE
fix: replace blocking auto-restore prompt with non-blocking hint

### DIFF
--- a/src/cli/auto-restore.ts
+++ b/src/cli/auto-restore.ts
@@ -1,12 +1,13 @@
 /**
- * Auto-restore: if no live tmux sessions exist and a recent (<24h) snapshot
- * is on disk, prompt the user to revive every session in the snapshot.
+ * Auto-restore hint: if no live tmux sessions exist and a recent (<24h)
+ * snapshot is on disk, print a non-blocking hint showing what can be restored.
+ *
+ * Previously this did a blocking /dev/tty read which could hang the CLI
+ * in wrapper scripts, multiplexers, or shell-init contexts. Now it just
+ * prints and returns — the user runs `maw wake <name>` themselves.
  *
  * Skipped for help-style invocations (--help / -h), non-interactive shells,
  * and diagnostic commands so automation output stays machine-readable.
- *
- * Exceptions are intentionally swallowed — auto-restore is best-effort
- * UX sugar, never load-bearing for the actual command the user typed.
  */
 export async function maybeAutoRestore(cmd: string | undefined): Promise<void> {
   if (!cmd || cmd === "--help" || cmd === "-h") return;
@@ -25,28 +26,9 @@ export async function maybeAutoRestore(cmd: string | undefined): Promise<void> {
 
     const mins = Math.round(ageMs / 60000);
     const ageStr = mins >= 60 ? `${Math.round(mins / 60)}h ago` : `${mins}m ago`;
-    console.log(`\x1b[36m📸\x1b[0m Last snapshot: ${snap.sessions.length} sessions (${ageStr})`);
+    console.log(`\x1b[36m📸\x1b[0m Last snapshot: ${snap.sessions.length} session${snap.sessions.length === 1 ? "" : "s"} (${ageStr})`);
     for (const s of snap.sessions) console.log(`   ${s.name}`);
-    process.stdout.write(`\nRestore all? [y/N] `);
-    const fs = await import("fs");
-    const buf = new Uint8Array(64);
-    const fd = fs.openSync("/dev/tty", "r");
-    const n = fs.readSync(fd, buf);
-    fs.closeSync(fd);
-    const answer = new TextDecoder().decode(buf.subarray(0, n)).trim().toLowerCase();
-    if (answer !== "y" && answer !== "yes") return;
-
-    const { cmdWake } = await import("../commands/shared/wake-cmd");
-    for (const s of snap.sessions) {
-      const oracle = s.name.replace(/^\d+-/, "");
-      try {
-        await cmdWake(oracle, { attach: false });
-        console.log(`  \x1b[32m✓\x1b[0m ${s.name}`);
-      } catch (e: any) {
-        console.log(`  \x1b[31m✗\x1b[0m ${s.name}: ${e?.message || String(e)}`);
-      }
-    }
-    console.log("");
+    console.log(`\x1b[36m↻\x1b[0m  restore: \x1b[1mmaw wake <name>\x1b[0m   or   \x1b[1mmaw wake --all\x1b[0m`);
   } catch {}
 }
 

--- a/test/cli/auto-restore.test.ts
+++ b/test/cli/auto-restore.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+
+describe("maybeAutoRestore (hint mode)", () => {
+  let logged: string[];
+  const origLog = console.log;
+  const origWrite = process.stdout.write;
+  const origStdinTTY = process.stdin.isTTY;
+  const origStdoutTTY = process.stdout.isTTY;
+
+  beforeEach(() => {
+    logged = [];
+    console.log = (...args: any[]) => logged.push(args.join(" "));
+    (process.stdout as any).write = (s: string) => logged.push(s);
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+    Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+  });
+
+  afterEach(() => {
+    console.log = origLog;
+    (process.stdout as any).write = origWrite;
+    Object.defineProperty(process.stdin, "isTTY", { value: origStdinTTY, configurable: true });
+    Object.defineProperty(process.stdout, "isTTY", { value: origStdoutTTY, configurable: true });
+  });
+
+  it("skips for --help", async () => {
+    const { maybeAutoRestore } = await import("../../src/cli/auto-restore");
+    await maybeAutoRestore("--help");
+    expect(logged).toEqual([]);
+  });
+
+  it("skips for diagnostic commands", async () => {
+    const { maybeAutoRestore } = await import("../../src/cli/auto-restore");
+    for (const cmd of ["capture", "locate", "messages", "oracle", "peek"]) {
+      logged = [];
+      await maybeAutoRestore(cmd);
+      expect(logged).toEqual([]);
+    }
+  });
+
+  it("skips when MAW_NO_PROMPT is set", async () => {
+    process.env.MAW_NO_PROMPT = "1";
+    try {
+      const { maybeAutoRestore } = await import("../../src/cli/auto-restore");
+      await maybeAutoRestore("ls");
+      expect(logged).toEqual([]);
+    } finally {
+      delete process.env.MAW_NO_PROMPT;
+    }
+  });
+
+  it("never opens /dev/tty (no blocking read)", async () => {
+    const src = await Bun.file("src/cli/auto-restore.ts").text();
+    const code = src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*/g, "");
+    expect(code).not.toContain("openSync");
+    expect(code).not.toContain("readSync");
+    expect(code).not.toContain('"/dev/tty"');
+  });
+
+  it("does not contain Restore all? prompt", async () => {
+    const src = await Bun.file("src/cli/auto-restore.ts").text();
+    expect(src).not.toContain("Restore all?");
+    expect(src).not.toContain("[y/N]");
+  });
+
+  it("contains hint text for maw wake", async () => {
+    const src = await Bun.file("src/cli/auto-restore.ts").text();
+    expect(src).toContain("maw wake");
+  });
+});

--- a/test/comm-send-durable-inbox.test.ts
+++ b/test/comm-send-durable-inbox.test.ts
@@ -3,6 +3,30 @@ import { join } from "path";
 
 const srcRoot = join(import.meta.dir, "..");
 
+// Capture real implementations before mocking — gate pattern prevents mock
+// bleed into later files that share this process (#2474).
+const _rSdk = await import("../src/sdk");
+const _rConfig = await import("../src/config");
+const _rFeed = await import("../src/commands/shared/comm-log-feed");
+const _rOracle = await import("../src/lib/oracle-manifest");
+const _rAutoWake = await import("../src/commands/shared/should-auto-wake");
+
+const realSdk = {
+  listSessions: _rSdk.listSessions,
+  capture: _rSdk.capture,
+  sendKeys: _rSdk.sendKeys,
+  isAgentCommand: _rSdk.isAgentCommand,
+  findPeerForTarget: _rSdk.findPeerForTarget,
+  resolveTarget: _rSdk.resolveTarget,
+  curlFetch: _rSdk.curlFetch,
+  runHook: _rSdk.runHook,
+};
+const realConfig = { loadConfig: _rConfig.loadConfig, cfgLimit: _rConfig.cfgLimit };
+const realFeed = { logMessage: _rFeed.logMessage, emitFeed: _rFeed.emitFeed };
+const realOracle = { findOracle: _rOracle.findOracle, loadManifestCached: _rOracle.loadManifestCached };
+const realAutoWake = { shouldAutoWake: _rAutoWake.shouldAutoWake };
+
+let mockActive = false;
 let sendKeysShouldThrow = false;
 let order: string[];
 let logs: string[];
@@ -13,42 +37,51 @@ let logMessageCalls: unknown[];
 let emitFeedCalls: unknown[];
 
 mock.module(join(srcRoot, "src/sdk"), () => ({
-  listSessions: async () => [{ name: "session", windows: [{ index: 0, name: "oracle", active: true }] }],
-  capture: async () => "",
-  sendKeys: async () => {
+  ..._rSdk,
+  listSessions: async () => mockActive ? [{ name: "session", windows: [{ index: 0, name: "oracle", active: true }] }] : realSdk.listSessions(),
+  capture: async (target: string, lines: number, host?: string) => mockActive ? "" : realSdk.capture(target, lines, host),
+  sendKeys: async (target: string, text: string) => {
+    if (!mockActive) return realSdk.sendKeys(target, text);
     order.push("sendKeys");
     if (sendKeysShouldThrow) throw new Error("pane vanished");
   },
-  isAgentCommand: () => true,
-  findPeerForTarget: async () => null,
-  resolveTarget: () => ({ type: "local", target: "session:oracle.0" }),
-  curlFetch: async () => ({ ok: true, data: { ok: true } }),
+  isAgentCommand: (cmd: string | null | undefined) => mockActive ? true : realSdk.isAgentCommand(cmd),
+  findPeerForTarget: async (...args: Parameters<typeof realSdk.findPeerForTarget>) => mockActive ? null : realSdk.findPeerForTarget(...args),
+  resolveTarget: (...args: Parameters<typeof realSdk.resolveTarget>) => mockActive ? ({ type: "local" as const, target: "session:oracle.0" }) : realSdk.resolveTarget(...args),
+  curlFetch: async (...args: Parameters<typeof realSdk.curlFetch>) => mockActive ? ({ ok: true, data: { ok: true } }) : realSdk.curlFetch(...args),
   runHook: async (...args: unknown[]) => {
+    if (!mockActive) return realSdk.runHook("" as any, {} as any);
     runHookCalls.push(args);
   },
 }));
 
 mock.module(join(srcRoot, "src/config"), () => ({
-  loadConfig: () => ({ node: "test-node", oracle: "sender", port: 3456, namedPeers: [] }),
-  cfgLimit: () => 120,
+  ..._rConfig,
+  loadConfig: () => mockActive ? ({ node: "test-node", oracle: "sender", port: 3456, namedPeers: [] }) : realConfig.loadConfig(),
+  cfgLimit: (...args: Parameters<typeof realConfig.cfgLimit>) => mockActive ? 120 : realConfig.cfgLimit(...args),
 }));
 
 mock.module(join(srcRoot, "src/commands/shared/comm-log-feed"), () => ({
+  ..._rFeed,
   logMessage: (...args: unknown[]) => {
+    if (!mockActive) return realFeed.logMessage("" as any, "" as any, "" as any, "" as any);
     logMessageCalls.push(args);
   },
   emitFeed: (...args: unknown[]) => {
+    if (!mockActive) return realFeed.emitFeed("" as any, "" as any, "" as any, "" as any, 0, {} as any);
     emitFeedCalls.push(args);
   },
 }));
 
 mock.module(join(srcRoot, "src/lib/oracle-manifest"), () => ({
-  findOracle: () => ({ name: "oracle", node: "test-node" }),
-  loadManifestCached: () => [],
+  ..._rOracle,
+  findOracle: (name: string) => mockActive ? ({ name: "oracle", node: "test-node" }) : realOracle.findOracle(name),
+  loadManifestCached: () => mockActive ? [] : realOracle.loadManifestCached(),
 }));
 
 mock.module(join(srcRoot, "src/commands/shared/should-auto-wake"), () => ({
-  shouldAutoWake: () => ({ wake: false }),
+  ..._rAutoWake,
+  shouldAutoWake: (...args: Parameters<typeof realAutoWake.shouldAutoWake>) => mockActive ? ({ wake: false }) : realAutoWake.shouldAutoWake(...args),
 }));
 
 const origExit = process.exit;
@@ -84,6 +117,7 @@ async function runCmd() {
 }
 
 beforeEach(() => {
+  mockActive = true;
   process.env.CLAUDE_AGENT_NAME = "sender";
   sendKeysShouldThrow = false;
   order = [];
@@ -96,11 +130,13 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  mockActive = false;
   if (origAgentName === undefined) delete process.env.CLAUDE_AGENT_NAME;
   else process.env.CLAUDE_AGENT_NAME = origAgentName;
 });
 
 afterAll(() => {
+  mockActive = false;
   console.log = origLog;
   console.error = origErr;
   (process as unknown as { exit: typeof origExit }).exit = origExit;

--- a/test/expand-probe.test.ts
+++ b/test/expand-probe.test.ts
@@ -1,20 +1,31 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mockConfigModule } from "./helpers/mock-config";
 
 const sdkPath = import.meta.resolve("../src/sdk/index.ts");
 const configPath = import.meta.resolve("../src/config.ts");
 
+// Capture real implementations before mocking (#2474 — mockActive gate prevents
+// live-binding contamination of sdk.curlFetch → curl-fetch.ts exports).
+const _rSdk = await import(sdkPath as any);
+const _rConfig = await import(configPath as any);
+const realCurlFetch = _rSdk.curlFetch as typeof _rSdk.curlFetch;
+const realConfig = { ..._rConfig };
+
+let mockActive = false;
 let nextResponse: any = { ok: true, status: 200, data: { node: "alpha", agents: ["mawjs", 7, "sila"] } };
 let nextError: Error | null = null;
 let calls: Array<{ url: string; opts: Record<string, unknown> }> = [];
 
 mock.module(configPath, () => ({
+  ...realConfig,
   ...mockConfigModule(() => ({ node: "alpha", federationToken: "test-token-16chars!" })),
-  cfgTimeout: () => 1234,
+  cfgTimeout: () => mockActive ? 1234 : (_rConfig as any).cfgTimeout?.(),
 }));
 
 mock.module(sdkPath, () => ({
+  ..._rSdk,
   curlFetch: async (url: string, opts: Record<string, unknown>) => {
+    if (!mockActive) return realCurlFetch(url, opts as any);
     calls.push({ url, opts });
     if (nextError) throw nextError;
     return nextResponse;
@@ -24,9 +35,19 @@ mock.module(sdkPath, () => ({
 const { fetchExpandProbeIdentity } = await import("../src/commands/shared/expand-probe.ts?probe-test");
 
 beforeEach(() => {
+  mockActive = true;
   nextResponse = { ok: true, status: 200, data: { node: "alpha", agents: ["mawjs", 7, "sila"] } };
   nextError = null;
   calls = [];
+});
+
+afterEach(() => {
+  mockActive = false;
+  nextError = null;
+});
+
+afterAll(() => {
+  mockActive = false;
 });
 
 describe("fetchExpandProbeIdentity", () => {

--- a/test/isolated/auto-restore-transport-coverage.test.ts
+++ b/test/isolated/auto-restore-transport-coverage.test.ts
@@ -136,34 +136,34 @@ describe("auto restore startup helper", () => {
     expect(writes.join("")).not.toContain("Restore all?");
   });
 
-  test("swallows list/session errors and handles declined restore prompts", async () => {
+  test("swallows list/session errors and prints hint for valid snapshots", async () => {
     listSessionsError = new Error("tmux unavailable");
     await maybeAutoRestore("wake");
-    expect(wakeCalls).toEqual([]);
+    expect(logs.join("\n")).not.toContain("Last snapshot");
 
     listSessionsError = null;
     snapshot = { timestamp: new Date(Date.now() - 10 * 60_000).toISOString(), sessions: [{ name: "01-alpha" }] };
-    ttyAnswer = "no\n";
     await maybeAutoRestore("wake");
-    expect(writes.join("")).toContain("Restore all?");
+    expect(logs.join("\n")).toContain("Last snapshot: 1 session");
+    expect(logs.join("\n")).toContain("01-alpha");
+    expect(logs.join("\n")).toContain("maw wake");
     expect(wakeCalls).toEqual([]);
   });
 
-  test("accepted snapshots wake each oracle and report per-session failures", async () => {
+  test("hint mode shows all sessions without waking any", async () => {
     snapshot = {
       timestamp: new Date(Date.now() - 65 * 60_000).toISOString(),
       sessions: [{ name: "01-alpha" }, { name: "02-beta" }],
     };
-    wakeErrorFor = "beta";
-    ttyAnswer = "yes\n";
 
     await maybeAutoRestore("wake");
 
-    expect(wakeCalls).toEqual([["alpha", { attach: false }], ["beta", { attach: false }]]);
+    expect(wakeCalls).toEqual([]);
     expect(logs.join("\n")).toContain("Last snapshot: 2 sessions (1h ago)");
     expect(logs.join("\n")).toContain("01-alpha");
-    expect(logs.join("\n")).toContain("02-beta: wake failed");
-    expect(writes.join("")).toContain("Restore all?");
+    expect(logs.join("\n")).toContain("02-beta");
+    expect(logs.join("\n")).toContain("maw wake");
+    expect(logs.join("\n")).not.toContain("Restore all?");
   });
 });
 


### PR DESCRIPTION
## Summary

- Remove synchronous `/dev/tty` read from `maybeAutoRestore()` — it hung the CLI in wrapper scripts, multiplexers, and shell-init contexts
- Replace with a non-blocking hint showing restorable sessions + `maw wake` command
- Add 6 tests verifying skip guards, no blocking read, and hint text

Before:
```
📸 Last snapshot: 3 sessions (15m ago)
   mawjs-oracle
Restore all? [y/N] _   ← blocks forever if user can't see this
```

After:
```
📸 Last snapshot: 3 sessions (15m ago)
   mawjs-oracle
↻  restore: maw wake <name>   or   maw wake --all
```

Closes #2544
Closes #2543

🤖 Generated with [Claude Code](https://claude.com/claude-code)