### PR TITLE
fix: cache federation status + backoff for down peers (#2547)

### DIFF
--- a/src/core/transport/peers.ts
+++ b/src/core/transport/peers.ts
@@ -24,6 +24,15 @@ function isValidPeerSession(item: unknown): item is Session {
 let aggregatedCache: { peers: (Session & { source?: string })[]; ts: number } | null = null;
 const CACHE_TTL = 30_000;
 
+/** TTL cache for federation status (#2547) — avoids 20s+ serial probes on every call */
+let federationStatusCache: { result: Awaited<ReturnType<typeof getFederationStatus>>; ts: number } | null = null;
+const FED_CACHE_TTL = 10_000;
+
+/** Per-peer backoff tracker: URL → { failures, nextProbeAfter } */
+const peerBackoff = new Map<string, { failures: number; nextProbeAfter: number }>();
+const BACKOFF_BASE = 5_000;
+const BACKOFF_MAX = 60_000;
+
 export interface PeerStatus {
   url: string;
   peerName?: string;
@@ -236,6 +245,10 @@ export async function getFederationStatus(options: FederationStatusOptions = {})
     uptimeSeconds: number;
   };
 }> {
+  if (!options.peers && !options.config && federationStatusCache && Date.now() - federationStatusCache.ts < FED_CACHE_TTL) {
+    return federationStatusCache.result;
+  }
+
   const config = options.config ?? loadConfig();
   const peerInputs = options.peers ?? getPeers().map((url) => ({ url }));
   const peers = peerInputs.map((peer) => peer.url);
@@ -249,7 +262,17 @@ export async function getFederationStatus(options: FederationStatusOptions = {})
   const [localProbe, rawStatuses] = await Promise.all([
     checkPeerReachable(localUrl),
     Promise.all(peers.map(async (url) => {
+      const bo = peerBackoff.get(url);
+      if (bo && Date.now() < bo.nextProbeAfter) {
+        return { url, peerName: peerNameByUrl.get(url), reachable: false, latency: 0, node: undefined, agents: undefined, clockDeltaMs: undefined };
+      }
       const { reachable, latency, node, agents, clockDeltaMs } = await checkPeerReachable(url);
+      if (reachable) {
+        peerBackoff.delete(url);
+      } else {
+        const prev = bo?.failures ?? 0;
+        peerBackoff.set(url, { failures: prev + 1, nextProbeAfter: Date.now() + Math.min(BACKOFF_BASE * 2 ** prev, BACKOFF_MAX) });
+      }
       return { url, peerName: peerNameByUrl.get(url), reachable, latency, node, agents, clockDeltaMs };
     })),
   ]);
@@ -267,7 +290,7 @@ export async function getFederationStatus(options: FederationStatusOptions = {})
   const statuses = [...byNode.values()];
   const reachablePeers = statuses.filter(s => s.reachable).length;
 
-  return {
+  const result = {
     localUrl,
     localReachable: localProbe.reachable,
     localLatency: localProbe.latency,
@@ -280,6 +303,10 @@ export async function getFederationStatus(options: FederationStatusOptions = {})
       uptimeSeconds: Math.floor(process.uptime()),
     },
   };
+  if (!options.peers && !options.config) {
+    federationStatusCache = { result, ts: Date.now() };
+  }
+  return result;
 }
 
 /**

--- a/src/core/transport/peers.ts
+++ b/src/core/transport/peers.ts
@@ -33,6 +33,11 @@ const peerBackoff = new Map<string, { failures: number; nextProbeAfter: number }
 const BACKOFF_BASE = 5_000;
 const BACKOFF_MAX = 60_000;
 
+export function resetPeerCaches() {
+  federationStatusCache = null;
+  peerBackoff.clear();
+}
+
 export interface PeerStatus {
   url: string;
   peerName?: string;

--- a/test/isolated/peers-reachable.test.ts
+++ b/test/isolated/peers-reachable.test.ts
@@ -18,9 +18,11 @@ mock.module("../../src/core/transport/curl-fetch", () => ({
   },
 }));
 
-const { getFederationStatus } = await import("../../src/core/transport/peers");
+const { getFederationStatus, resetPeerCaches } = await import("../../src/core/transport/peers");
+import { beforeEach } from "bun:test";
 
 describe("checkPeerReachable — identity failure visibility (#385 site 3)", () => {
+  beforeEach(() => { resetPeerCaches(); });
   test("warns when peer is reachable (sessions ok) but /api/identity fails", async () => {
     responses = [
       { match: "/api/sessions", res: { ok: true, status: 200, data: [] } },


### PR DESCRIPTION
## Summary
- Cache `getFederationStatus()` result with 10s TTL — repeated calls return instantly
- Exponential backoff for unreachable peers: 5s × 2^failures (max 60s) — skip known-down peers instead of waiting 5s timeout each time
- Resets backoff on successful probe

## Root cause
`getFederationStatus()` probes ALL peers with 5s HTTP timeout each. `getFederationStatusSymmetric()` cross-queries each reachable peer → another 5s. With N peers and some down, worst case = N × 20s+.

## Fix
1. **Result cache** (10s TTL): only probes when cache expired or explicit options provided
2. **Per-peer backoff**: unreachable peer → skip for 5s, then 10s, 20s, 40s, 60s (cap)
3. Backoff resets immediately when peer becomes reachable again

## Impact
- **Before**: GET /api/federation/status → 20,660ms
- **After**: first call same, subsequent calls <1ms, down-peer calls skip instantly

## Test plan
- [ ] `curl localhost:3456/api/federation/status` responds <2s on second call
- [ ] Down peer doesn't block response (backoff kicks in)
- [ ] Peer recovery detected within 60s (backoff cap)

Closes #2547

🤖 Generated with [Claude Code](https://claude.com/claude-code)