### PR TITLE
release: v26.6.9-alpha.2120

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.6.9-alpha.1219",
+  "version": "26.6.9-alpha.2120",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts v26.6.9-alpha.2120 on merge via calver-release.yml.

Changes since v26.6.9-alpha.1219:
- fix: cache federation status + backoff for down peers (#2547)
- test: quarantine 25 broken/hanging isolated tests (#2474)