### PR TITLE
fix: friendly agent concurrency cap error with agent table (#2554)

### DIFF
--- a/src/commands/shared/wake-concurrency.ts
+++ b/src/commands/shared/wake-concurrency.ts
@@ -20,6 +20,7 @@
 import { cfgLimit } from "../../config";
 import { tmux } from "../../core/transport/tmux";
 import { isAgentCommand } from "../../core/transport/ssh";
+import { UserError } from "../../core/util/user-error";
 
 /**
  * Pure cap decision — throws a loud, actionable error when `liveAgents` is at
@@ -29,7 +30,7 @@ import { isAgentCommand } from "../../core/transport/ssh";
 export function checkCapacity(liveAgents: number, cap: number, spawning: string): void {
   if (!cap || cap <= 0) return; // cap disabled by explicit opt-out
   if (liveAgents >= cap) {
-    throw new Error(
+    throw new UserError(
       `agent concurrency cap reached: ${liveAgents}/${cap} agents already live — ` +
       `refusing to spawn '${spawning}'. Raise limits.maxConcurrentAgents in maw.config.json ` +
       `or sleep an idle agent first (maw sleep <agent>).`,
@@ -37,10 +38,39 @@ export function checkCapacity(liveAgents: number, cap: number, spawning: string)
   }
 }
 
+export interface LiveAgent {
+  name: string;
+  target: string;
+  idleSec: number;
+}
+
+/** List tmux panes currently running an agent process with metadata. */
+export async function listLiveAgents(): Promise<LiveAgent[]> {
+  const panes = await tmux.listPanes();
+  const now = Date.now() / 1000;
+  return panes
+    .filter(p => isAgentCommand(p.command))
+    .map(p => ({
+      name: p.title || p.winName || p.target,
+      target: p.target,
+      idleSec: p.lastActivity ? Math.round(now - p.lastActivity) : 0,
+    }));
+}
+
 /** Count tmux panes currently running an agent process across all sessions. */
 export async function countLiveAgents(): Promise<number> {
-  const panes = await tmux.listPanes();
-  return panes.filter(p => isAgentCommand(p.command)).length;
+  return (await listLiveAgents()).length;
+}
+
+function formatAgentTable(agents: LiveAgent[]): string {
+  const sorted = [...agents].sort((a, b) => b.idleSec - a.idleSec);
+  const lines = sorted.map(a => {
+    const idle = a.idleSec > 60
+      ? `${Math.round(a.idleSec / 60)}m`
+      : `${a.idleSec}s`;
+    return `  ${a.name.padEnd(40)} idle ${idle.padStart(5)}   ${a.target}`;
+  });
+  return lines.join("\n");
 }
 
 /**
@@ -53,6 +83,16 @@ export async function countLiveAgents(): Promise<number> {
  */
 export async function assertAgentCapacity(spawning: string): Promise<void> {
   const cap = cfgLimit("maxConcurrentAgents");
-  if (!cap || cap <= 0) return; // disabled — don't even query tmux
-  checkCapacity(await countLiveAgents(), cap, spawning);
+  if (!cap || cap <= 0) return;
+  const agents = await listLiveAgents();
+  if (agents.length >= cap) {
+    const table = formatAgentTable(agents);
+    throw new UserError(
+      `agent concurrency cap reached: ${agents.length}/${cap} agents already live — ` +
+      `refusing to spawn '${spawning}'.\n\n` +
+      `Active agents:\n${table}\n\n` +
+      `Fix: maw sleep <name>  — free a slot by sleeping an idle agent\n` +
+      `     Set limits.maxConcurrentAgents in maw.config.json to raise the cap`,
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- Replace `throw new Error(...)` with `throw new UserError(...)` in `wake-concurrency.ts` — suppresses the scary stack trace
- Add `listLiveAgents()` returning `{name, target, idleSec}[]` — shows which agents are live and how long they've been idle
- Add `formatAgentTable()` — renders sorted agent table in the error message
- Actionable fix suggestions: `maw sleep <name>` + config override

### Before
```
error: agent concurrency cap reached: 10/10 agents already live...
      at Nfe (/Users/nat/.local/bin/maw:621:361)
      at zT (/Users/nat/.local/bin/maw:621:722)
      ... 20 lines of minified stack
```

### After
```
agent concurrency cap reached: 10/10 agents already live — refusing to spawn 'neo'.

Active agents:
  mawjs-codex-oracle                       idle   40m   03-catlab-hello:1
  noah-akot                                idle   15m   157-noah:2
  ...

Fix: maw sleep <name>  — free a slot by sleeping an idle agent
     Set limits.maxConcurrentAgents in maw.config.json to raise the cap
```

## Test plan
- [x] `bun test test/isolated/wake-concurrency.test.ts` — 66 pass
- [x] `bun run build` — 1.16 MB

Closes #2554

🤖 Generated with [Claude Code](https://claude.com/claude-code)