### PR TITLE
release: v26.6.9-alpha.2229

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.6.9-alpha.2120",
+  "version": "26.6.9-alpha.2229",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
## Changes since v26.6.9-alpha.2120

- **fix: friendly agent concurrency cap error** (#2554) — UserError + agent table, no stack trace
- **perf: migrate test-isolated to bun --isolate** (#2552) — 3.4x faster (37s vs ~124s)
- **fix: unquarantine 24 test files** (#2550) — verified under --isolate

Cuts v26.6.9-alpha.2229 on merge via calver-release.yml.