### PR TITLE
perf: in-memory cache for /api/ui-state (16k→0 disk reads) (#2561)

### DIFF
--- a/src/api/ui-state.ts
+++ b/src/api/ui-state.ts
@@ -4,17 +4,26 @@ import { join } from "path";
 
 const DEFAULT_PATH = join(import.meta.dir, "../../ui-state.json");
 
+let cachedState: object | null = null;
+
 export function readUiState(filePath = DEFAULT_PATH): object {
+  if (cachedState !== null) return cachedState;
   try {
     if (!existsSync(filePath)) return {};
-    return JSON.parse(readFileSync(filePath, "utf-8"));
+    cachedState = JSON.parse(readFileSync(filePath, "utf-8"));
+    return cachedState!;
   } catch {
     return {};
   }
 }
 
 export function writeUiState(data: object, filePath = DEFAULT_PATH): void {
+  cachedState = data;
   writeFileSync(filePath, JSON.stringify(data, null, 2), "utf-8");
+}
+
+export function invalidateUiStateCache(): void {
+  cachedState = null;
 }
 
 export interface UiStateApiDeps {


### PR DESCRIPTION
## Summary
- Cache parsed `ui-state.json` in memory after first read
- Subsequent GETs serve from RAM — zero disk I/O
- POST updates cache + writes to disk (invalidate-on-write)
- Exports `invalidateUiStateCache()` for external reset if needed

### Before
16,613 `readFileSync()` calls per 10 seconds

### After
1 `readFileSync()` on first request, then memory-only

## Test plan
- [x] `bun test test/api-runtime-default.test.ts` — 38 pass
- [x] `bun run build` — 1.16 MB

Closes #2561

🤖 Generated with [Claude Code](https://claude.com/claude-code)