### PR TITLE
release: v26.6.9-alpha.2302

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.6.9-alpha.2229",
+  "version": "26.6.9-alpha.2302",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
perf: in-memory cache for /api/ui-state (#2561) — eliminates 16k disk reads/10s