### PR TITLE
fix: maw wake --task lands agent in invoking session, not unrelated workspace (#2557)

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -809,6 +809,24 @@ export async function chooseWakeSessionName(oracle: string, urlRepoName?: string
   return `${String(maxNum + 1).padStart(2, "0")}-${baseName}`;
 }
 
+/**
+ * Resolve the tmux session the operator ran `maw wake` from (#2557).
+ *
+ * Only consulted for `--task`/`--wt` placement so a budded oracle's worktree
+ * window lands in the current session instead of an unrelated workspace that
+ * happens to host the repo. Returns null when not inside tmux or on any tmux
+ * error, which makes detectSession fall back to its historical ordering.
+ */
+async function resolveInvokingTmuxSession(): Promise<string | null> {
+  if (!process.env.TMUX) return null;
+  try {
+    const name = (await tmux.run("display-message", "-p", "#{session_name}")).trim();
+    return name || null;
+  } catch {
+    return null;
+  }
+}
+
 type WakeWindowLookupEntry = { name: string; cwd?: string };
 
 function escapeRegExp(value: string): string {
@@ -1006,7 +1024,11 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
   }
 
   const foreignSession = requestedForeignSession;
-  let session = foreignSession ? "" : (preResolvedSession || await detectSession(oracle, opts.urlRepoName));
+  // #2557 — task/worktree wakes prefer the invoking session for placement so the
+  // new agent window lands where the operator ran the command, not in an
+  // unrelated workspace that the fleet registry happens to map the repo to.
+  const invokingSession = (opts.task || opts.wt) ? await resolveInvokingTmuxSession() : null;
+  let session = foreignSession ? "" : (preResolvedSession || await detectSession(oracle, opts.urlRepoName, { invokingSession }));
   if (foreignSession) {
     const exists = opts.dryRun || await tmux.hasSession(foreignSession);
     if (exists) {

--- a/src/commands/shared/wake-resolve-impl.test.ts
+++ b/src/commands/shared/wake-resolve-impl.test.ts
@@ -9,6 +9,8 @@
  */
 import { afterEach, beforeEach, describe, it, expect, mock } from "bun:test";
 import { join } from "path";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
 
 const root = join(import.meta.dir, "../..");
 const { mockConfigModule } = await import("../../../test/helpers/mock-config");
@@ -257,6 +259,81 @@ describe("detectSession (#769) — URL-aware resolution", () => {
     } finally {
       process.exit = origExit;
     }
+  });
+});
+
+describe("detectSession (#2557) — `--task` placement prefers the invoking session", () => {
+  // A budded oracle (`mawjs-codex`) whose repo windows were spawned into an
+  // unrelated `maw new` workspace (`03-catlab-hello`). The fleet registry maps
+  // the repo to that workspace via window metadata, so a bare `maw wake
+  // mawjs-codex --task` would otherwise scatter the new agent into catlab. The
+  // invoking session (`139-mawjs`) must win for task placement, while plain
+  // wakes keep resolving to the metadata home.
+  const fleetRoot = join(tmpdir(), "maw-2557-state");
+  const fleetDir = join(fleetRoot, "fleet");
+
+  function writeFleetSession(name: string, windows: Array<{ name: string; repo: string }>): void {
+    writeFileSync(join(fleetDir, `${name}.json`), JSON.stringify({ name, windows }));
+  }
+
+  beforeEach(() => {
+    rmSync(fleetRoot, { recursive: true, force: true });
+    mkdirSync(fleetDir, { recursive: true });
+    process.env.MAW_STATE_DIR = fleetRoot;
+  });
+
+  afterEach(() => {
+    rmSync(fleetRoot, { recursive: true, force: true });
+  });
+
+  it("scatters into the window-metadata workspace WITHOUT the fix signal (documents the bug)", async () => {
+    // Plain wake (no invokingSession) keeps the historical behavior: the fleet
+    // window-metadata home wins. This is also the exact path #2557 reported.
+    tmuxSessions = [{ name: "139-mawjs" }, { name: "03-catlab-hello" }];
+    writeFleetSession("03-catlab-hello", [
+      { name: "lead", repo: "github.com/Soul-Brews-Studio/mawjs-codex-oracle" },
+      { name: "mawjs-codex-oracle", repo: "github.com/Soul-Brews-Studio/mawjs-codex-oracle" },
+    ]);
+    expect(await detectSession("mawjs-codex")).toBe("03-catlab-hello");
+  });
+
+  it("places the task window in the invoking session, not the metadata workspace", async () => {
+    tmuxSessions = [{ name: "139-mawjs" }, { name: "03-catlab-hello" }];
+    writeFleetSession("03-catlab-hello", [
+      { name: "lead", repo: "github.com/Soul-Brews-Studio/mawjs-codex-oracle" },
+      { name: "mawjs-codex-oracle", repo: "github.com/Soul-Brews-Studio/mawjs-codex-oracle" },
+    ]);
+    expect(await detectSession("mawjs-codex", undefined, { invokingSession: "139-mawjs" })).toBe("139-mawjs");
+  });
+
+  it("still prefers the oracle's own name-matched session over the invoking session", async () => {
+    // If mawjs-codex has a real `NN-mawjs-codex` home, that wins over both the
+    // invoking session and the metadata workspace (ordering: name > invoking).
+    tmuxSessions = [{ name: "139-mawjs" }, { name: "03-catlab-hello" }, { name: "48-mawjs-codex" }];
+    writeFleetSession("03-catlab-hello", [
+      { name: "mawjs-codex-oracle", repo: "github.com/Soul-Brews-Studio/mawjs-codex-oracle" },
+    ]);
+    expect(await detectSession("mawjs-codex", undefined, { invokingSession: "139-mawjs" })).toBe("48-mawjs-codex");
+  });
+
+  it("does NOT disturb a deliberately role-named home (23-discord-admin) for plain wakes", async () => {
+    // Regression guard for the case resolveFleetWindowSessionTarget exists for:
+    // `discord-oracle` lives in `23-discord-admin`. Plain wake still resolves it.
+    tmuxSessions = [{ name: "23-discord-admin" }, { name: "03-catlab-hello" }];
+    writeFleetSession("23-discord-admin", [
+      { name: "discord-oracle", repo: "github.com/Soul-Brews-Studio/discord-oracle" },
+    ]);
+    expect(await detectSession("discord")).toBe("23-discord-admin");
+  });
+
+  it("falls back to the metadata home when the invoking session is no longer live", async () => {
+    // Defensive: a stale invokingSession (session died mid-wake) must not strand
+    // placement — the deferred window-metadata home is still returned.
+    tmuxSessions = [{ name: "03-catlab-hello" }];
+    writeFleetSession("03-catlab-hello", [
+      { name: "mawjs-codex-oracle", repo: "github.com/Soul-Brews-Studio/mawjs-codex-oracle" },
+    ]);
+    expect(await detectSession("mawjs-codex", undefined, { invokingSession: "139-mawjs" })).toBe("03-catlab-hello");
   });
 });
 

--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -473,7 +473,16 @@ function knownFleetSessionStems(): string[] {
   }
 }
 
-export async function detectSession(oracle: string, urlRepoName?: string): Promise<string | null> {
+export async function detectSession(
+  oracle: string,
+  urlRepoName?: string,
+  opts: { invokingSession?: string | null } = {},
+): Promise<string | null> {
+  // #2557 — `--task`/`--wt` wakes pass the operator's invoking tmux session so a
+  // budded oracle's worktree window lands in the current session instead of an
+  // unrelated workspace that merely hosts the repo. `null` (plain wake / not in
+  // tmux) preserves the historical placement order exactly.
+  const invokingSession = opts.invokingSession || null;
   const sessions = await tmux.listSessions();
   const mapped = getSessionMap()[oracle];
   if (mapped && sessions.find(s => s.name === mapped)) return mapped;
@@ -498,7 +507,11 @@ export async function detectSession(oracle: string, urlRepoName?: string): Promi
     const fleetSession =
       resolveFleetSession(urlRepoName) ||
       resolveFleetSession(oracle);
-    if (fleetSession && sessions.find(s => s.name === fleetSession)) return fleetSession;
+    const liveFleetSession = fleetSession && sessions.find(s => s.name === fleetSession) ? fleetSession : null;
+    // #2557 — defer the window-metadata home for task/worktree wakes so the
+    // oracle's own name-matched sessions and the invoking session (below) can
+    // claim placement first. Plain wakes keep the historical metadata-first win.
+    if (liveFleetSession && !invokingSession) return liveFleetSession;
 
     // #2461 — session stems may be registered/generated with or without
     // human-readable hyphens. A URL/repo target like `maw-js-oracle` should
@@ -515,6 +528,13 @@ export async function detectSession(oracle: string, urlRepoName?: string): Promi
       console.error(`\x1b[90m  use the full name: maw wake <exact-session>\x1b[0m`);
       process.exit(1);
     }
+
+    // #2557 — task/worktree wake: prefer the invoking session over the deferred
+    // window-metadata home once the strict name matches above have missed.
+    if (invokingSession) {
+      if (sessions.find(s => s.name === invokingSession)) return invokingSession;
+      if (liveFleetSession) return liveFleetSession;
+    }
     return null;
   }
 
@@ -523,7 +543,11 @@ export async function detectSession(oracle: string, urlRepoName?: string): Promi
   // in 23-discord-admin. Try this before generic suffix matching so unrelated
   // aux/channel sessions like odin-discord do not steal `maw wake discord`.
   const fleetSession = resolveFleetSession(oracle);
-  if (fleetSession && sessions.find(s => s.name === fleetSession)) return fleetSession;
+  const liveFleetSession = fleetSession && sessions.find(s => s.name === fleetSession) ? fleetSession : null;
+  // #2557 — for `--task`/`--wt` placement, defer the window-metadata home so the
+  // invoking session (resolved below, after the oracle's own name-matched
+  // sessions) can win over an unrelated workspace that hosts the oracle's repo.
+  if (liveFleetSession && !invokingSession) return liveFleetSession;
 
   // Numeric-prefixed fleet sessions get first dibs — "110-yeast" beats a bare
   // "yeast" or an ephemeral "yeast-view" when the user types "yeast". If two
@@ -551,6 +575,16 @@ export async function detectSession(oracle: string, urlRepoName?: string): Promi
     for (const s of numeric) console.error(`\x1b[90m    • ${s.name}\x1b[0m`);
     console.error(`\x1b[90m  use the full name: maw wake <exact-session>\x1b[0m`);
     process.exit(1);
+  }
+
+  // #2557 — task/worktree wake prefers the invoking tmux session over the
+  // deferred window-metadata home, but only after the oracle's own
+  // name-matched sessions (handled above) have had priority. This keeps a
+  // budded oracle's task window in the operator's current session instead of
+  // an unrelated workspace (e.g. `03-catlab-hello`) that merely hosts the repo.
+  if (invokingSession) {
+    if (sessions.find(s => s.name === invokingSession)) return invokingSession;
+    if (liveFleetSession) return liveFleetSession;
   }
 
   // #1794 — wake may be invoked with a short fuzzy oracle token ("homeke")


### PR DESCRIPTION
## Problem

`maw wake <oracle> --task X` spawned the new agent window in whatever tmux session the **fleet registry** mapped the oracle's repo to — even an unrelated generic `maw new` workspace (`03-catlab-hello`) — instead of the session the operator ran the command from (`139-mawjs`). The agent ended up orphaned and invisible in the operator's tmux bar.

## Root cause

`detectSession()` (`wake-resolve-impl.ts`) consulted **fleet-window-metadata matching** (`resolveFleetSession` → `resolveFleetWindowSessionTarget`) as its first step, *before* the invoking tmux session was considered. That matcher claims any session whose window repos strip to the oracle name — so a generic workspace that merely hosts `mawjs-codex-oracle` windows (`lead`, `mawjs-codex-oracle`, a prior task window) was indistinguishable from a deliberately role-named home like `23-discord-admin` → `discord-oracle`. It's self-reinforcing: each task window registered there strengthens the match.

So the issue's questions, answered: it's **not** "most recent / first available" — the fleet registry is decisive.

## Fix

For `--task`/`--wt` placement, `detectSession` now prefers the operator's invoking `$TMUX` session over the window-metadata home. New ordering:

```
explicit/preResolved → oracle's own name-matched session → invoking session → fleet-window-metadata → create new
```

The window-metadata return is **deferred only when an invoking session is supplied** (`liveFleetSession && !invokingSession`), so plain wakes, attach, sleep, and `about` keep their historical metadata-first behavior byte-for-byte. Falls back to the metadata home if the invoking session died mid-wake.

- `wake-cmd.ts` — `resolveInvokingTmuxSession()` (null when not in tmux / on error); passed to `detectSession` only when `opts.task || opts.wt`.
- `wake-resolve-impl.ts` — `detectSession` gains optional `{ invokingSession }`; URL and bare-name paths handled symmetrically.

## Tests

5 new regression tests (`#2557` block) driving a **real temp fleet registry**:
- documents the bug (plain wake still → `03-catlab-hello`)
- proves the fix (`--task` → `139-mawjs`)
- pins non-regressions: name-matched `48-mawjs-codex` beats the invoking session; `23-discord-admin` role home undisturbed; stale invoking session falls back to metadata home.

`bun test src/commands/shared/wake-resolve-impl.test.ts` → **149 pass / 0 fail**.

Closes #2557

🤖 ตอบโดย mawjs-codex จาก Nat → mawjs-codex-oracle