### PR TITLE
feat: auto-sleep idle agents with channel-aware exemption (#2555)

### DIFF
--- a/src/commands/shared/channel-loader.test.ts
+++ b/src/commands/shared/channel-loader.test.ts
@@ -24,6 +24,9 @@ import {
   getChannelPermissionMode,
   saveOracleChannels,
   saveRepoChannels,
+  channelStem,
+  isChannelListener,
+  channelListenerIds,
   type OracleChannelConfig,
 } from "./channel-loader";
 
@@ -98,5 +101,57 @@ describe("loadEffectiveChannels — #1195 Phase 2 repo > global precedence", () 
     saveOracleChannels(stem, globalConfig());
     saveRepoChannels(repoDir, repoConfig());
     expect(getChannelPluginIds(stem, ["plugin:fleet@1"], repoDir)).toEqual(["plugin:fleet@1"]);
+  });
+});
+
+describe("channelStem (#2555) — name → channel-config stem", () => {
+  it("strips a trailing -oracle suffix", () => {
+    expect(channelStem("discord-oracle")).toBe("discord");
+    expect(channelStem("mawjs-codex-oracle")).toBe("mawjs-codex");
+  });
+
+  it("strips a leading numeric fleet prefix", () => {
+    expect(channelStem("139-mawjs")).toBe("mawjs");
+    expect(channelStem("03-discord-oracle")).toBe("discord");
+  });
+
+  it("lowercases and trims", () => {
+    expect(channelStem("  Discord-Oracle ")).toBe("discord");
+  });
+
+  it("leaves a bare stem unchanged", () => {
+    expect(channelStem("mawjs-codex")).toBe("mawjs-codex");
+  });
+});
+
+describe("isChannelListener / channelListenerIds (#2555)", () => {
+  const stem = "discord";
+  beforeEach(() => {
+    try { rmSync(join(homeSandbox, ".claude", "channels", stem), { recursive: true, force: true }); } catch {}
+  });
+
+  it("false / [] when the agent subscribes to no channel", () => {
+    expect(isChannelListener("discord-oracle")).toBe(false);
+    expect(channelListenerIds("discord-oracle")).toEqual([]);
+  });
+
+  it("true once a channel plugin is configured (name resolves via stem)", () => {
+    saveOracleChannels(stem, { plugins: [{ id: "plugin:discord@1" }] });
+    // accepts the -oracle form, the numeric-prefixed form, and the bare stem
+    expect(isChannelListener("discord-oracle")).toBe(true);
+    expect(isChannelListener("23-discord-oracle")).toBe(true);
+    expect(isChannelListener("discord")).toBe(true);
+    expect(channelListenerIds("discord-oracle")).toEqual(["plugin:discord@1"]);
+  });
+
+  it("honors a repo-local channel.json override", () => {
+    const repoDir = mkdtempSync(join(tmpdir(), "maw-channel-listener-repo-"));
+    try {
+      saveRepoChannels(repoDir, { plugins: [{ id: "plugin:repo-telegram@1" }] });
+      expect(isChannelListener("telegram-oracle", repoDir)).toBe(true);
+      expect(channelListenerIds("telegram-oracle", repoDir)).toEqual(["plugin:repo-telegram@1"]);
+    } finally {
+      try { rmSync(repoDir, { recursive: true, force: true }); } catch {}
+    }
   });
 });

--- a/src/commands/shared/channel-loader.ts
+++ b/src/commands/shared/channel-loader.ts
@@ -171,6 +171,42 @@ export function getChannelEnv(
   return env;
 }
 
+/**
+ * Reduce an agent/window/session name to the stem used to key channel config
+ * (the directory name under `~/.claude/channels/`). Strips a leading numeric
+ * fleet prefix (`139-mawjs` → `mawjs`) and a trailing `-oracle` suffix
+ * (`mawjs-codex-oracle` → `mawjs-codex`), and lowercases. Exported for #2555
+ * tests and reuse by the idle-exemption + `maw ls` display paths.
+ */
+export function channelStem(agent: string): string {
+  return agent.trim().toLowerCase().replace(/^\d+-/, "").replace(/-oracle$/, "");
+}
+
+/**
+ * #2555 — true when the agent subscribes to at least one channel plugin.
+ *
+ * Channel listeners (discord/telegram/etc. relays) are idle-but-waiting for
+ * inbound messages, so auto-sleep triggers must exempt them. Accepts any
+ * agent/window/session identifier; it is reduced to the channel stem via
+ * `channelStem()`. `repoPath` (when known) honors the repo-local
+ * `.claude/channel.json` override per #1195.
+ */
+export function isChannelListener(agent: string, repoPath?: string): boolean {
+  const stem = channelStem(agent);
+  if (!stem) return false;
+  return getChannelPluginIds(stem, undefined, repoPath).length > 0;
+}
+
+/**
+ * #2555 — channel plugin ids for an agent, or `[]` when it listens on none.
+ * Used by `maw ls` to render the `[ch: discord]` tag next to exempt agents.
+ */
+export function channelListenerIds(agent: string, repoPath?: string): string[] {
+  const stem = channelStem(agent);
+  if (!stem) return [];
+  return getChannelPluginIds(stem, undefined, repoPath);
+}
+
 export function listAllOracleChannels(): Array<{ oracle: string; plugins: ChannelPlugin[] }> {
   if (!existsSync(channelsBase())) return [];
   const { readdirSync } = require("fs");

--- a/src/commands/shared/comm-list.ts
+++ b/src/commands/shared/comm-list.ts
@@ -15,7 +15,10 @@ import {
   scanWorktrees as defaultScanWorktrees,
   cleanupWorktree as defaultCleanupWorktree,
   isAgentCommand as defaultIsAgentCommand,
+  tmux,
 } from "../../sdk";
+import { channelListenerIds } from "./channel-loader";
+import type { TmuxPane } from "../../core/transport/tmux-types";
 
 type LatestSnapshot = {
   timestamp: string;
@@ -28,6 +31,10 @@ export interface CommListDeps {
   scanWorktrees?: typeof defaultScanWorktrees;
   cleanupWorktree?: typeof defaultCleanupWorktree;
   isAgentCommand?: typeof defaultIsAgentCommand;
+  /** #2555 — panes carry `lastActivity` for the idle-duration column. */
+  listPanes?: () => Promise<TmuxPane[]>;
+  /** #2555 — channel plugin ids for an agent (drives the `[ch: …]` tag). */
+  channelIds?: (agent: string, repoPath?: string) => string[];
   latestSnapshot?: () => LatestSnapshot | null;
   log?: Pick<Console, "log" | "error">;
   env?: Record<string, string | undefined>;
@@ -41,11 +48,33 @@ function commListDeps(deps: CommListDeps) {
     scanWorktrees: deps.scanWorktrees ?? defaultScanWorktrees,
     cleanupWorktree: deps.cleanupWorktree ?? defaultCleanupWorktree,
     isAgentCommand: deps.isAgentCommand ?? defaultIsAgentCommand,
+    // Read-only (list-panes). The call site fail-soft-wraps this so a missing
+    // tmux server (or an injected stub that throws) never breaks `maw ls`.
+    listPanes: deps.listPanes ?? (() => tmux.listPanes()),
+    channelIds: deps.channelIds ?? channelListenerIds,
     latestSnapshot: deps.latestSnapshot,
     log: deps.log ?? console,
     env: deps.env ?? process.env,
     now: deps.now ?? Date.now,
   };
+}
+
+/** #2555 — compact idle age: `45s` → `12m` → `3h`. Negative clamps to 0s. */
+export function formatIdleAge(idleSec: number): string {
+  const s = Math.max(0, Math.round(idleSec));
+  if (s < 60) return `${s}s`;
+  if (s < 3600) return `${Math.round(s / 60)}m`;
+  return `${Math.round(s / 3600)}h`;
+}
+
+/**
+ * #2555 — derive the channel/oracle stem for a live agent window. The repo dir
+ * in the pane cwd (`…/mawjs-codex-oracle/agents/…`) is authoritative; the tmux
+ * window name is the fallback for non-worktree panes.
+ */
+export function oracleStemForChannel(cwd: string, windowName: string): string {
+  const m = cwd.match(/([^/]+)-oracle(?:\/|$)/);
+  return m ? m[1]! : windowName;
 }
 
 async function loadLatestSnapshot(depsLatestSnapshot?: () => LatestSnapshot | null): Promise<LatestSnapshot | null> {
@@ -101,6 +130,21 @@ export async function cmdList(opts: { fix?: boolean; verify?: boolean } = {}, de
   }
   const infos = await d.getPaneInfos(targets);
 
+  // #2555 — idle duration per window from `lastActivity` (epoch seconds). Keyed
+  // by `<session>:<winIdx>` to join the session→window rows below; take the most
+  // recent activity across a window's panes.
+  const nowSec = d.now() / 1000;
+  const lastActivityByWindow = new Map<string, number>();
+  let panes: TmuxPane[] = [];
+  try { panes = await d.listPanes(); } catch { panes = []; }
+  for (const p of panes) {
+    if (p.lastActivity === undefined || p.winIdx === undefined) continue;
+    const sess = p.target.split(":")[0];
+    const key = `${sess}:${p.winIdx}`;
+    const prev = lastActivityByWindow.get(key);
+    if (prev === undefined || p.lastActivity > prev) lastActivityByWindow.set(key, p.lastActivity);
+  }
+
   for (const s of sessions) {
     d.log.log(renderSessionName(s.name));
     for (const w of s.windows) {
@@ -122,7 +166,21 @@ export async function cmdList(opts: { fix?: boolean; verify?: boolean } = {}, de
         dot = "\x1b[31m●\x1b[0m"; // red — dead (shell only)
         suffix = `  \x1b[90m(${info.command || "?"})\x1b[0m`;
       }
-      d.log.log(`  ${dot} ${w.index}: ${w.name}${suffix}`);
+
+      // #2555 — for live agents, annotate idle duration + channel-listener
+      // status so operators can see why an agent is (or isn't) auto-sleep exempt.
+      let meta = "";
+      if (isAgent && !cwdBroken) {
+        const lastActive = lastActivityByWindow.get(target);
+        if (lastActive !== undefined) {
+          meta += `  \x1b[90midle ${formatIdleAge(nowSec - lastActive)}\x1b[0m`;
+        }
+        const channels = d.channelIds(oracleStemForChannel(info.cwd, w.name));
+        if (channels.length > 0) {
+          meta += `  \x1b[36m📡 [ch: ${channels.join(", ")}]\x1b[0m`;
+        }
+      }
+      d.log.log(`  ${dot} ${w.index}: ${w.name}${suffix}${meta}`);
     }
   }
 

--- a/src/commands/shared/wake-concurrency.ts
+++ b/src/commands/shared/wake-concurrency.ts
@@ -21,6 +21,7 @@ import { cfgLimit } from "../../config";
 import { tmux } from "../../core/transport/tmux";
 import { isAgentCommand } from "../../core/transport/ssh";
 import { UserError } from "../../core/util/user-error";
+import { channelListenerIds } from "./channel-loader";
 
 /**
  * Pure cap decision — throws a loud, actionable error when `liveAgents` is at
@@ -42,6 +43,18 @@ export interface LiveAgent {
   name: string;
   target: string;
   idleSec: number;
+  /** #2555 — channel plugin ids the agent listens on ([] = not a listener). */
+  channel: string[];
+}
+
+/**
+ * #2555 — channel plugin ids for a live agent pane. The repo dir in the pane
+ * cwd (`…/discord-oracle/agents/…`) is the authoritative stem; the pane title /
+ * window name is the fallback for non-worktree panes.
+ */
+function paneChannelIds(p: { cwd?: string; title?: string; winName?: string; target: string }): string[] {
+  const fromCwd = p.cwd?.match(/([^/]+)-oracle(?:\/|$)/)?.[1];
+  return channelListenerIds(fromCwd || p.title || p.winName || p.target);
 }
 
 /** List tmux panes currently running an agent process with metadata. */
@@ -54,6 +67,7 @@ export async function listLiveAgents(): Promise<LiveAgent[]> {
       name: p.title || p.winName || p.target,
       target: p.target,
       idleSec: p.lastActivity ? Math.round(now - p.lastActivity) : 0,
+      channel: paneChannelIds(p),
     }));
 }
 
@@ -62,13 +76,16 @@ export async function countLiveAgents(): Promise<number> {
   return (await listLiveAgents()).length;
 }
 
-function formatAgentTable(agents: LiveAgent[]): string {
+export function formatAgentTable(agents: LiveAgent[]): string {
   const sorted = [...agents].sort((a, b) => b.idleSec - a.idleSec);
   const lines = sorted.map(a => {
     const idle = a.idleSec > 60
       ? `${Math.round(a.idleSec / 60)}m`
       : `${a.idleSec}s`;
-    return `  ${a.name.padEnd(40)} idle ${idle.padStart(5)}   ${a.target}`;
+    // #2555 — flag channel listeners so the operator doesn't sleep an
+    // idle-but-waiting relay to free a slot (it's auto-sleep exempt).
+    const channel = a.channel?.length ? `  \x1b[36m📡 [ch: ${a.channel.join(", ")}]\x1b[0m` : "";
+    return `  ${a.name.padEnd(40)} idle ${idle.padStart(5)}   ${a.target}${channel}`;
   });
   return lines.join("\n");
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -8,6 +8,13 @@ export interface TriggerConfig {
   action: string;       // shell command to execute — supports {agent}, {repo}, {issue} templates
   name?: string;        // optional human label
   once?: boolean;       // fire once then self-destruct (#149)
+  /**
+   * #2555 — exemption tags that suppress this trigger for matching agents.
+   * Currently supports `"channel-listener"`: agents subscribed to a channel
+   * plugin (discord/telegram/etc.) are idle-but-waiting for inbound messages
+   * and must not be auto-slept. Absent/empty = no exemptions.
+   */
+  exempt?: string[];
 }
 
 /** Named peer with URL */

--- a/src/core/runtime/idle-exempt.test.ts
+++ b/src/core/runtime/idle-exempt.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "bun:test";
+import {
+  CHANNEL_LISTENER_EXEMPT,
+  DEFAULT_AGENT_IDLE_SLEEP_TRIGGER,
+  isAgentExemptFromTrigger,
+} from "./idle-exempt";
+
+/**
+ * #2555 — channel-aware exemption for agent-idle triggers.
+ *
+ * `isAgentExemptFromTrigger` is pure: the channel-membership probe is injected
+ * so these tests need no tmux, feed, or real channel config.
+ */
+describe("isAgentExemptFromTrigger (#2555)", () => {
+  const listener = (a: string) => a === "discord-relay";
+
+  it("not exempt when the trigger declares no exemptions", () => {
+    expect(isAgentExemptFromTrigger({}, "discord-relay", listener)).toBe(false);
+    expect(isAgentExemptFromTrigger({ exempt: [] }, "discord-relay", listener)).toBe(false);
+  });
+
+  it("not exempt when the agent is not a channel listener", () => {
+    expect(isAgentExemptFromTrigger({ exempt: [CHANNEL_LISTENER_EXEMPT] }, "codex-oracle", listener)).toBe(false);
+  });
+
+  it("exempt when the trigger opts in AND the agent is a channel listener", () => {
+    expect(isAgentExemptFromTrigger({ exempt: [CHANNEL_LISTENER_EXEMPT] }, "discord-relay", listener)).toBe(true);
+  });
+
+  it("ignores unrelated exemption tags", () => {
+    expect(isAgentExemptFromTrigger({ exempt: ["something-else"] }, "discord-relay", listener)).toBe(false);
+  });
+
+  it("never exempts an empty agent name", () => {
+    expect(isAgentExemptFromTrigger({ exempt: [CHANNEL_LISTENER_EXEMPT] }, "", listener)).toBe(false);
+  });
+});
+
+describe("DEFAULT_AGENT_IDLE_SLEEP_TRIGGER (#2555) — opt-in, not auto-enabled", () => {
+  it("is a 5-minute agent-idle sleep trigger that exempts channel listeners", () => {
+    expect(DEFAULT_AGENT_IDLE_SLEEP_TRIGGER.on).toBe("agent-idle");
+    expect(DEFAULT_AGENT_IDLE_SLEEP_TRIGGER.timeout).toBe(300);
+    expect(DEFAULT_AGENT_IDLE_SLEEP_TRIGGER.action).toBe("maw sleep {agent}");
+    expect(DEFAULT_AGENT_IDLE_SLEEP_TRIGGER.exempt).toEqual([CHANNEL_LISTENER_EXEMPT]);
+  });
+
+  it("a channel listener is shielded by the default trigger", () => {
+    const isListener = (a: string) => a === "discord-relay";
+    expect(isAgentExemptFromTrigger(DEFAULT_AGENT_IDLE_SLEEP_TRIGGER, "discord-relay", isListener)).toBe(true);
+    expect(isAgentExemptFromTrigger(DEFAULT_AGENT_IDLE_SLEEP_TRIGGER, "codex-oracle", isListener)).toBe(false);
+  });
+});

--- a/src/core/runtime/idle-exempt.ts
+++ b/src/core/runtime/idle-exempt.ts
@@ -1,0 +1,56 @@
+/**
+ * idle-exempt.ts — channel-aware exemption for agent-idle triggers (#2555).
+ *
+ * The trigger engine fires `agent-idle` actions (e.g. `maw sleep {agent}`)
+ * when an agent has been idle past a trigger's timeout. Some idle agents are
+ * idle *by design* — channel listeners (discord/telegram relays) sit idle
+ * waiting for inbound messages and must not be auto-slept. A trigger opts into
+ * this protection with `exempt: ["channel-listener"]`.
+ *
+ * The decision is a pure predicate (`isAgentExemptFromTrigger`) so it is
+ * unit-testable without tmux, the feed, or a real channel config — the
+ * channel-membership probe is injected and defaults to the real
+ * `isChannelListener`.
+ */
+
+import type { TriggerConfig } from "../../config";
+import { isChannelListener } from "../../commands/shared/channel-loader";
+
+/** Exemption tag for agents subscribed to a channel plugin. */
+export const CHANNEL_LISTENER_EXEMPT = "channel-listener";
+
+/**
+ * The opt-in default auto-sleep trigger (#2555).
+ *
+ * NOT auto-enabled — `getTriggers()` returns the operator's config verbatim.
+ * Operators opt in by copying this into their `maw.config.json` `triggers`
+ * array (or a future `maw fleet doctor --fix`). Sleeps non-channel agents
+ * after 5 minutes idle; channel listeners are exempt.
+ */
+export const DEFAULT_AGENT_IDLE_SLEEP_TRIGGER: TriggerConfig = {
+  on: "agent-idle",
+  timeout: 300,
+  action: "maw sleep {agent}",
+  name: "auto-sleep idle agents (5m, channel-exempt)",
+  exempt: [CHANNEL_LISTENER_EXEMPT],
+};
+
+/**
+ * True when `agent` is exempt from `trigger` and the trigger should NOT fire.
+ *
+ * Only `"channel-listener"` is recognized today: when the trigger lists it in
+ * `exempt` and the agent subscribes to a channel plugin, the trigger is
+ * suppressed. Triggers without `exempt` always return false (fire normally).
+ *
+ * @param channelListener  injectable membership probe (defaults to the real
+ *                         `isChannelListener`); tests pass a stub.
+ */
+export function isAgentExemptFromTrigger(
+  trigger: Pick<TriggerConfig, "exempt">,
+  agent: string,
+  channelListener: (agent: string) => boolean = isChannelListener,
+): boolean {
+  if (!agent) return false;
+  if (!trigger.exempt?.includes(CHANNEL_LISTENER_EXEMPT)) return false;
+  return channelListener(agent);
+}

--- a/src/core/runtime/triggers-engine.ts
+++ b/src/core/runtime/triggers-engine.ts
@@ -8,6 +8,7 @@
 // No execSync — use async Bun.spawn to avoid blocking event loop
 import { loadConfig, saveConfig, type TriggerConfig, type TriggerEvent } from "../../config";
 import { logAudit } from "../fleet/audit";
+import { isAgentExemptFromTrigger } from "./idle-exempt";
 
 export interface TriggerContext {
   agent?: string;
@@ -121,6 +122,12 @@ export async function fire(event: TriggerEvent, ctx: TriggerContext = {}): Promi
         const idleSec = (Date.now() - lastActivity) / 1000;
         if (idleSec < t.timeout) continue;
       }
+    }
+
+    // #2555 — channel-aware exemption: a trigger with exempt:["channel-listener"]
+    // never fires for an agent subscribed to a channel plugin (idle-but-waiting).
+    if (event === "agent-idle" && ctx.agent && isAgentExemptFromTrigger(t, ctx.agent)) {
+      continue;
     }
 
     const action = expandAction(t.action, event, ctx);

--- a/test/isolated/comm-list-idle-channel-2555.test.ts
+++ b/test/isolated/comm-list-idle-channel-2555.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "bun:test";
+import { cmdList, formatIdleAge, oracleStemForChannel } from "../../src/commands/shared/comm-list";
+import type { TmuxPane } from "../../src/core/transport/tmux-types";
+
+/**
+ * #2555 — `maw ls` shows idle duration + channel-listener status so operators
+ * can see why an agent is (or isn't) auto-sleep exempt. cmdList is fully
+ * dep-injected here, so this needs no tmux / FS / channel config.
+ */
+
+const NOW_MS = 1_000_000_000_000;
+
+function pane(target: string, winIdx: number, idleSec: number): TmuxPane {
+  return { id: target, command: "claude", target, title: "", winIdx, lastActivity: NOW_MS / 1000 - idleSec };
+}
+
+async function render(over: Partial<Parameters<typeof cmdList>[1]> = {}): Promise<string> {
+  const outs: string[] = [];
+  await cmdList({}, {
+    listSessions: async () => [
+      { name: "08-mawjs", windows: [{ index: 0, name: "mawjs-oracle", active: true }] },
+      { name: "03-catlab", windows: [{ index: 0, name: "discord-oracle", active: false }] },
+    ] as any,
+    getPaneInfos: async () => ({
+      "08-mawjs:0": { command: "claude", cwd: "/repos/mawjs-oracle" },
+      "03-catlab:0": { command: "claude", cwd: "/repos/discord-oracle/agents/1-x" },
+    }),
+    isAgentCommand: (c: string) => c === "claude",
+    listPanes: async () => [pane("08-mawjs:mawjs-oracle.0", 0, 600), pane("03-catlab:discord-oracle.0", 0, 7200)],
+    channelIds: (stem: string) => (stem === "discord" ? ["plugin:discord@1"] : []),
+    now: () => NOW_MS,
+    env: {},
+    log: { log: (m: string) => outs.push(m), error: () => {} },
+    ...over,
+  });
+  return outs.join("\n");
+}
+
+describe("cmdList (#2555) — idle duration + channel status", () => {
+  it("annotates each agent window with its idle duration", async () => {
+    const out = await render();
+    expect(out).toContain("0: mawjs-oracle");
+    expect(out).toContain("idle 10m");
+    expect(out).toContain("idle 2h");
+  });
+
+  it("tags channel listeners and leaves non-listeners untagged", async () => {
+    const out = await render();
+    const lines = out.split("\n");
+    const discordLine = lines.find(l => l.includes("discord-oracle"))!;
+    const mawjsLine = lines.find(l => l.includes("mawjs-oracle"))!;
+    expect(discordLine).toContain("📡 [ch: plugin:discord@1]");
+    expect(mawjsLine).not.toContain("[ch:");
+  });
+
+  it("fails soft when listPanes is unavailable (no idle column, rows still render)", async () => {
+    const out = await render({ listPanes: async () => { throw new Error("no tmux"); } });
+    expect(out).toContain("0: mawjs-oracle");
+    expect(out).not.toContain("idle ");
+  });
+});
+
+describe("formatIdleAge (#2555)", () => {
+  it("renders seconds, minutes, hours", () => {
+    expect(formatIdleAge(45)).toBe("45s");
+    expect(formatIdleAge(600)).toBe("10m");
+    expect(formatIdleAge(7200)).toBe("2h");
+  });
+  it("clamps negatives to 0s", () => {
+    expect(formatIdleAge(-5)).toBe("0s");
+  });
+});
+
+describe("oracleStemForChannel (#2555)", () => {
+  it("prefers the -oracle repo dir in the cwd", () => {
+    expect(oracleStemForChannel("/repos/discord-oracle/agents/1-x", "discord-fix-1")).toBe("discord");
+  });
+  it("falls back to the window name when cwd has no -oracle dir", () => {
+    expect(oracleStemForChannel("/tmp/scratch", "telegram-oracle")).toBe("telegram-oracle");
+  });
+});

--- a/test/isolated/wake-concurrency-channel-2555.test.ts
+++ b/test/isolated/wake-concurrency-channel-2555.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "bun:test";
+import { formatAgentTable, type LiveAgent } from "../../src/commands/shared/wake-concurrency";
+
+/**
+ * #2555 — the cap-reached agent table flags channel listeners so the operator
+ * doesn't sleep an idle-but-waiting relay to free a slot. formatAgentTable is
+ * pure, so this needs no tmux.
+ */
+describe("formatAgentTable (#2555) — channel listener flag", () => {
+  const base = (over: Partial<LiveAgent>): LiveAgent => ({
+    name: "x", target: "01-x:0.0", idleSec: 0, channel: [], ...over,
+  });
+
+  it("appends a [ch: …] tag for channel listeners", () => {
+    const table = formatAgentTable([
+      base({ name: "discord-relay", idleSec: 7200, channel: ["plugin:discord@1"] }),
+    ]);
+    expect(table).toContain("discord-relay");
+    expect(table).toContain("idle");
+    expect(table).toContain("📡 [ch: plugin:discord@1]");
+  });
+
+  it("omits the tag for non-listeners", () => {
+    const table = formatAgentTable([
+      base({ name: "codex-oracle", idleSec: 120, channel: [] }),
+    ]);
+    expect(table).toContain("codex-oracle");
+    expect(table).not.toContain("[ch:");
+  });
+
+  it("sorts most-idle first (existing behavior preserved)", () => {
+    const table = formatAgentTable([
+      base({ name: "fresh", idleSec: 5 }),
+      base({ name: "stale", idleSec: 9000 }),
+    ]);
+    expect(table.indexOf("stale")).toBeLessThan(table.indexOf("fresh"));
+  });
+});


### PR DESCRIPTION
## Problem

The agent concurrency cap fills with idle agents, blocking new spawns (#2554). Idle detection + the `agent-idle` trigger already existed; what was missing was a way to (a) exempt agents that are idle *by design* (channel listeners waiting for inbound messages), (b) ship a sensible default, and (c) see why an agent is exempt.

## What's added

### 1. `isChannelListener()` — `channel-loader.ts`
`channelStem(name)` reduces an agent/window/session name to its channel-config stem (strips a leading `NN-` fleet prefix and trailing `-oracle`). New `isChannelListener(agent, repoPath?)` and `channelListenerIds(agent, repoPath?)` read the existing channel config (repo-local `.claude/channel.json` wins per #1195). No new state.

### 2. `exempt` trigger field + opt-in default
- `TriggerConfig.exempt?: string[]` supporting `"channel-listener"` (`config/types.ts`).
- Pure, injectable `isAgentExemptFromTrigger()` (`core/runtime/idle-exempt.ts`) wired into `fire()` at the `agent-idle` chokepoint, so a channel listener is **never** auto-slept.
- `DEFAULT_AGENT_IDLE_SLEEP_TRIGGER` (5m, `maw sleep {agent}`, channel-exempt) exported as an **opt-in constant**. `getTriggers()` is unchanged → **no behavior change on upgrade**; operators enable it explicitly in their `maw.config.json` `triggers` array.

### 3. `maw ls` idle + channel display
- `maw ls` (`comm-list.ts`) annotates each live agent window with `idle 10m` + `📡 [ch: …]` (joined from `listPanes` `lastActivity` + the channel stem from the pane cwd). **Fail-soft**: a missing tmux server never breaks `maw ls`.
- `listLiveAgents`/`formatAgentTable` — the table shown when the cap is hit (#2554/#2555) — gained the `[ch: …]` flag so operators don't sleep an exempt listener to free a slot.

## Behavior

```
if agent idle > threshold AND NOT a channel listener:  auto-sleep (when the opt-in trigger is enabled)
if agent idle > threshold AND     a channel listener:  exempt — trigger suppressed
```

## Tests

- `idle-exempt.test.ts` — pure exemption predicate + default-trigger shape.
- `channel-loader.test.ts` — `channelStem` / `isChannelListener` / `channelListenerIds` against a sandboxed HOME (global + repo-local override).
- `comm-list-idle-channel-2555.test.ts` — dep-injected `maw ls` idle+channel rendering, incl. fail-soft when tmux is unavailable.
- `wake-concurrency-channel-2555.test.ts` — cap-table channel flag.

**119 pass / 0 fail** across new + affected suites (`comm-list`, `wake-concurrency`, trigger-engine).

Closes #2555

🤖 ตอบโดย mawjs-codex จาก Nat → mawjs-codex-oracle