### PR TITLE
fix: workon cwd-aware config + fleet double github.com/ (#2570, #2575)

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -779,12 +779,13 @@ async function resolveWakeFleetSessionRepo(meta: WakeFleetSessionMetadata): Prom
     return { repoPath: existing, repoName: existing.split("/").pop()!, parentDir: existing.replace(/\/[^/]+$/, "") };
   }
 
-  console.log(`\x1b[36m🌱\x1b[0m ${meta.session} pinned in fleet → github.com/${meta.repo} — cloning to ghq...`);
+  const cloneSlug = meta.repo.replace(/^github\.com\//i, "");
+  console.log(`\x1b[36m🌱\x1b[0m ${meta.session} pinned in fleet → github.com/${cloneSlug} — cloning to ghq...`);
   try {
-    await hostExec(`ghq get -u 'github.com/${meta.repo}'`);
+    await hostExec(`ghq get -u 'github.com/${cloneSlug}'`);
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : String(e);
-    console.error(`\x1b[33m⚠\x1b[0m fleet-pinned ${meta.repo} clone/update failed: ${msg.split("\n")[0]}`);
+    console.error(`\x1b[33m⚠\x1b[0m fleet-pinned ${cloneSlug} clone/update failed: ${msg.split("\n")[0]}`);
   }
   const cloned = await ghqFind(`/${meta.repo}`) || await ghqFind(`/${repoStem}`);
   if (cloned) {

--- a/src/vendor/mpr-plugins/workon/impl.ts
+++ b/src/vendor/mpr-plugins/workon/impl.ts
@@ -1,7 +1,7 @@
 import { hostExec } from "maw-js/sdk";
 import { tmux } from "maw-js/sdk";
 import { ghqFind } from "maw-js/core/ghq";
-import { buildCommand } from "maw-js/config";
+import { buildCommandInDir } from "maw-js/config";
 import { findWorktrees } from "maw-js/commands/shared/wake";
 import { resolveWorktreeTarget } from "maw-js/core/matcher/resolve-target";
 import { normalizeWorktreeLayout, worktreePathForLayout, type WorktreeLayout } from "maw-js/core/fleet/worktree-layout";
@@ -82,7 +82,7 @@ export async function cmdWorkon(repo: string, task?: string, opts: { layout?: Wo
   // Create window + start claude
   await tmux.newWindow(session, windowName, { cwd: targetPath });
   await new Promise(r => setTimeout(r, 300));
-  await tmux.sendText(`${session}:${windowName}`, buildCommand(windowName));
+  await tmux.sendText(`${session}:${windowName}`, buildCommandInDir(windowName, targetPath));
 
   console.log(`\x1b[32m✅\x1b[0m workon '${windowName}' in ${session} → ${targetPath}`);
 }


### PR DESCRIPTION
## Summary
- **workon**: `buildCommand` → `buildCommandInDir` so repo-local config (Discord channels, engine selection) applies when launching via `maw workon`
- **wake fleet clone**: strip `github.com/` prefix from fleet-pinned repo slug before `ghq get` to prevent `github.com/github.com/org` path doubling

## Root Cause (#2575)
`repoFromCwd()` in fleet-ensure.ts returns `github.com/org/repo` (3-segment match from ghqRoot). Then `resolveWakeFleetSessionRepo` prepends another `github.com/` → `github.com/github.com/org/repo`.

## Test plan
- [x] `bun test test/fleet-ensure-entry.test.ts` — 24 pass
- [x] `bun run build` — compiles clean
- [ ] `maw a neo` no longer crashes with doubled path

Closes #2570
Closes #2575

🤖 Generated with [Claude Code](https://claude.com/claude-code)