### PR TITLE
feat(wake): zero-arg cwd detection (#2569)

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -10,6 +10,9 @@ import { normalizeTarget } from "../../core/matcher/normalize-target";
 import { assertValidOracleName } from "../../core/fleet/validate";
 import { canonicalSessionName } from "../../core/fleet/session-name";
 import { resolveOracle, findWorktrees, findReusableWorktreeBySlug, getSessionMap, resolveFleetSession, detectSession, setSessionEnv, sanitizeBranchName } from "./wake-resolve";
+import { stripOracleRepoSuffix, bringCwdMetadata, deriveOracleFromCwd } from "./wake-cwd";
+// #2569 — re-export so the wake barrel surface still exposes deriveOracleFromCwd.
+export { deriveOracleFromCwd } from "./wake-cwd";
 import * as wakeSession from "./wake-session";
 import { maybeOpenWindow, maybeSplit } from "./wake-maybe-split";
 import { runWakeLifecycleHooks } from "../../plugin/lifecycle";
@@ -137,31 +140,8 @@ type BringWindowLookupCandidate = BringWindowCandidate & {
   aliases: string[];
 };
 
-function stripOracleRepoSuffix(name: string): string | null {
-  return name.toLowerCase().endsWith("-oracle") ? name.slice(0, -"-oracle".length) : null;
-}
-
-function bringCwdMetadata(cwd: string | undefined): { oracle?: string; worktree?: string } {
-  const parts = cwd ? resolve(cwd).split(/[\\/]+/).filter(Boolean) : [];
-  const agentsIdx = parts.lastIndexOf("agents");
-  if (agentsIdx > 0 && parts[agentsIdx + 1]) {
-    return {
-      oracle: stripOracleRepoSuffix(parts[agentsIdx - 1] ?? "") ?? undefined,
-      worktree: parts[agentsIdx + 1],
-    };
-  }
-
-  for (const part of parts.slice().reverse()) {
-    const worktreeMarker = part.indexOf(".wt-");
-    if (worktreeMarker > 0) {
-      const oracle = stripOracleRepoSuffix(part.slice(0, worktreeMarker)) ?? undefined;
-      return { oracle, worktree: part.slice(worktreeMarker + ".wt-".length) || undefined };
-    }
-    const oracle = stripOracleRepoSuffix(part);
-    if (oracle) return { oracle };
-  }
-  return {};
-}
+// #2569 — cwd → oracle/worktree derivation lives in ./wake-cwd (deps-free so it
+// is unit-testable without the sdk/config mock cascade).
 
 function uniqueNonEmpty(values: string[]): string[] {
   return [...new Set(values.map(v => v.trim()).filter(Boolean))];
@@ -855,6 +835,20 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
   // Canonicalize the bare name before any lookup — strips trailing `/`, `/.git`, `/.git/`
   // so `maw wake token-oracle/` (tab-completion artifact) resolves the same as `token-oracle`.
   oracle = normalizeTarget(oracle);
+
+  // #2569 — zero-arg wake: `maw wake` (or `maw wake .`) inside an oracle repo
+  // derives the oracle from the current directory, then runs the normal flow.
+  if (!oracle || oracle === ".") {
+    const derived = deriveOracleFromCwd(process.cwd());
+    if (!derived) {
+      throw new UserError(
+        "maw wake: no oracle name given and the current directory is not an oracle repo.\n" +
+        "Run inside an oracle repo or its worktree, or pass a name: maw wake <oracle>.",
+      );
+    }
+    console.log(`\x1b[36m→\x1b[0m wake: derived oracle '\x1b[1m${derived}\x1b[0m' from cwd ${process.cwd()}`);
+    oracle = derived;
+  }
 
   const parsed = parseWakeTarget(oracle);
   let parsedRepoPath: string | null = null;

--- a/src/commands/shared/wake-cwd.test.ts
+++ b/src/commands/shared/wake-cwd.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "bun:test";
+import { stripOracleRepoSuffix, bringCwdMetadata, deriveOracleFromCwd } from "./wake-cwd";
+
+/**
+ * #2569 — zero-arg `maw wake` cwd → oracle derivation. Pure helpers, no mocks.
+ */
+
+describe("stripOracleRepoSuffix", () => {
+  it("strips a trailing -oracle (case-insensitive, preserves case)", () => {
+    expect(stripOracleRepoSuffix("mawjs-codex-oracle")).toBe("mawjs-codex");
+    expect(stripOracleRepoSuffix("Discord-Oracle")).toBe("Discord");
+  });
+  it("returns null when there is no -oracle suffix", () => {
+    expect(stripOracleRepoSuffix("maw-js")).toBeNull();
+    expect(stripOracleRepoSuffix("oracle")).toBeNull();
+  });
+});
+
+describe("bringCwdMetadata", () => {
+  it("derives oracle from a plain <name>-oracle repo dir", () => {
+    expect(bringCwdMetadata("/opt/Code/github.com/Soul-Brews-Studio/mawjs-codex-oracle"))
+      .toEqual({ oracle: "mawjs-codex" });
+  });
+  it("derives oracle + worktree from the nested agents/ layout", () => {
+    expect(bringCwdMetadata("/o/mawjs-oracle/agents/1-fix-2550"))
+      .toEqual({ oracle: "mawjs", worktree: "1-fix-2550" });
+  });
+  it("derives oracle + worktree from the legacy .wt- layout", () => {
+    expect(bringCwdMetadata("/o/mawjs-oracle.wt-2-white"))
+      .toEqual({ oracle: "mawjs", worktree: "2-white" });
+  });
+  it("returns {} for a non-oracle dir or empty path", () => {
+    expect(bringCwdMetadata("/opt/Code/github.com/Soul-Brews-Studio/maw-js")).toEqual({});
+    expect(bringCwdMetadata("")).toEqual({});
+    expect(bringCwdMetadata(undefined)).toEqual({});
+  });
+});
+
+describe("deriveOracleFromCwd (#2569)", () => {
+  it("resolves the maw-js source repo (no -oracle suffix) via the basename fallback", () => {
+    // The exact case from the issue: cwd is the maw-js checkout.
+    expect(deriveOracleFromCwd("/opt/Code/github.com/Soul-Brews-Studio/maw-js")).toBe("maw-js");
+  });
+
+  it("resolves a standard <name>-oracle repo to its stem", () => {
+    expect(deriveOracleFromCwd("/opt/Code/github.com/Soul-Brews-Studio/mawjs-codex-oracle")).toBe("mawjs-codex");
+  });
+
+  it("resolves from inside a nested-layout worktree", () => {
+    expect(deriveOracleFromCwd("/opt/Code/github.com/Soul-Brews-Studio/mawjs-codex-oracle/agents/1-fix-2550"))
+      .toBe("mawjs-codex");
+  });
+
+  it("resolves from inside a legacy .wt- worktree", () => {
+    expect(deriveOracleFromCwd("/opt/Code/github.com/laris-co/mawjs-oracle.wt-2-white")).toBe("mawjs");
+  });
+
+  it("falls back to the basename for a non-oracle repo cwd", () => {
+    expect(deriveOracleFromCwd("/opt/Code/github.com/acme/some-tool")).toBe("some-tool");
+  });
+
+  it("returns undefined for root / empty / undefined (cmdWake then surfaces a usage error)", () => {
+    expect(deriveOracleFromCwd("/")).toBeUndefined();
+    expect(deriveOracleFromCwd("")).toBeUndefined();
+    expect(deriveOracleFromCwd(undefined)).toBeUndefined();
+  });
+});

--- a/src/commands/shared/wake-cwd.ts
+++ b/src/commands/shared/wake-cwd.ts
@@ -1,0 +1,64 @@
+/**
+ * wake-cwd.ts — directory → oracle/worktree derivation for wake.
+ *
+ * Pure path-string helpers, intentionally free of sdk/config imports so they
+ * can be unit-tested with zero mocks (no cfgLimit/cfgTimeout cascade). Consumed
+ * by wake-cmd.ts for the `bring` window metadata and for #2569 zero-arg wake.
+ */
+
+import { resolve } from "path";
+
+export function stripOracleRepoSuffix(name: string): string | null {
+  return name.toLowerCase().endsWith("-oracle") ? name.slice(0, -"-oracle".length) : null;
+}
+
+/**
+ * Extract `{ oracle, worktree }` from a directory path. Recognizes:
+ *   - nested worktree layout `…/<oracle>-oracle/agents/<worktree>`,
+ *   - legacy worktree dirs `…/<oracle>-oracle.wt-<worktree>`,
+ *   - a plain `<oracle>-oracle` segment anywhere up the path.
+ * Returns `{}` when no `-oracle` segment is present (e.g. a source repo dir).
+ */
+export function bringCwdMetadata(cwd: string | undefined): { oracle?: string; worktree?: string } {
+  const parts = cwd ? resolve(cwd).split(/[\\/]+/).filter(Boolean) : [];
+  const agentsIdx = parts.lastIndexOf("agents");
+  if (agentsIdx > 0 && parts[agentsIdx + 1]) {
+    return {
+      oracle: stripOracleRepoSuffix(parts[agentsIdx - 1] ?? "") ?? undefined,
+      worktree: parts[agentsIdx + 1],
+    };
+  }
+
+  for (const part of parts.slice().reverse()) {
+    const worktreeMarker = part.indexOf(".wt-");
+    if (worktreeMarker > 0) {
+      const oracle = stripOracleRepoSuffix(part.slice(0, worktreeMarker)) ?? undefined;
+      return { oracle, worktree: part.slice(worktreeMarker + ".wt-".length) || undefined };
+    }
+    const oracle = stripOracleRepoSuffix(part);
+    if (oracle) return { oracle };
+  }
+  return {};
+}
+
+/**
+ * #2569 — derive an oracle name from a directory for zero-arg `maw wake`.
+ *
+ * Reuses {@link bringCwdMetadata} (handles `<oracle>-oracle` dirs, `agents/`
+ * worktrees, and `.wt-` worktrees). When that finds nothing — e.g. the maw-js
+ * source repo, whose dir is `maw-js` with no `-oracle` suffix — it falls back
+ * to the last path segment (stripping a trailing `-oracle` if present) so the
+ * normal `resolveOracle` fuzzy chain can take it from there. Returns undefined
+ * only for empty/root paths.
+ *
+ * Note: the fallback uses the path's final segment, so it assumes the cwd is a
+ * repo root (or any `-oracle` path, which the metadata pass already handles).
+ */
+export function deriveOracleFromCwd(cwd: string | undefined): string | undefined {
+  const meta = bringCwdMetadata(cwd);
+  if (meta.oracle) return meta.oracle;
+  const parts = cwd ? resolve(cwd).split(/[\\/]+/).filter(Boolean) : [];
+  const base = parts[parts.length - 1];
+  if (!base) return undefined;
+  return stripOracleRepoSuffix(base) ?? base;
+}

--- a/src/vendor/mpr-plugins/wake/index.ts
+++ b/src/vendor/mpr-plugins/wake/index.ts
@@ -27,14 +27,12 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
 
   try {
     if (ctx.source === "cli") {
-      const args = ctx.args as string[];
+      const args = [...(ctx.args as string[])];
 
-      if (!args[0]) {
-        return {
-          ok: false,
-          error: "usage: maw wake <oracle|org/repo|URL> [task] [--task \"<prompt>\"] [--wt <name>] [--layout nested|legacy] [--fresh|--new] [--pick] [--name <s>] [--attach] [--issue N] [--pr N] [--repo org/name] [--list] [--dry-run] [--from-snapshot|--snapshot <id>] [--keep-last N] [--max-age D] [--main|--solo|--no-rehydrate] [--all-local] [--peer <alias>]\n       maw wake all [--kill]\n       --layout selects new worktree layout: nested (default repo/agents/N-X) or legacy (.wt-N-X)\n       --list previews worktrees only; no tmux session/window changes\n       --dry-run previews session/worktree rehydrate actions; --from-snapshot previews/restores missing snapshot windows; --main skips worktree rehydrate\n       --new is an alias for --fresh: force a new numbered worktree slot; --pick opens the reusable picker; --name creates/reuses a stable named worktree",
-        };
-      }
+      // #2569 — zero-arg `maw wake` derives the oracle from process.cwd(). Hand
+      // the `.` sentinel down the normal flow; cmdWake resolves it from the cwd
+      // and surfaces a clear error if the directory is not an oracle repo.
+      if (!args[0]) args[0] = ".";
 
       if (args[0].toLowerCase() === "all") {
         const flags = parseFlags(args, { "--kill": Boolean, "--all": Boolean, "--resume": Boolean }, 1);


### PR DESCRIPTION
## What

`maw wake` with no args (or `maw wake .`) inside an oracle repo now derives the oracle from `process.cwd()` and runs the normal resolve/wake flow.

## Changes

- **`src/commands/shared/wake-cwd.ts`** (new) — deps-free cwd→oracle helpers (`stripOracleRepoSuffix`, `bringCwdMetadata`, `deriveOracleFromCwd`), extracted from `wake-cmd.ts` so they're unit-testable without the sdk/config mock cascade. `deriveOracleFromCwd` reuses `bringCwdMetadata` (handles `<name>-oracle` dirs + `agents/` and `.wt-` worktrees) and **falls back to the repo-dir basename** so a source repo like `maw-js` (no `-oracle` suffix — the issue's own test case) still resolves.
- **`src/commands/shared/wake-cmd.ts`** — `cmdWake` derives from cwd when the oracle arg is empty/`.`; throws a clear `UserError` when the cwd is not an oracle repo. (One derivation path → also covers any direct/API caller.)
- **`src/vendor/mpr-plugins/wake/index.ts`** — bare `maw wake` no longer returns the usage error; it passes the `.` sentinel through to `cmdWake`.

## Tests

`src/commands/shared/wake-cwd.test.ts` — 12 cases, **zero mocks**: the issue's exact case (`…/maw-js` → `maw-js`), `<name>-oracle` repos, nested + legacy worktrees, non-oracle repos, and root/empty/undefined → `undefined`. **12 pass / 0 fail.**

**Verified live**: `maw wake . --dry-run` from the maw-js dir printed `→ wake: derived oracle 'maw-js' from cwd …`, resolved the repo, found session `139-mawjs`, and dry-ran with no changes.

Closes #2569

🤖 ตอบโดย mawjs-codex จาก Nat → mawjs-codex-oracle