### PR TITLE
feat(workon): optional fleet registration for oracle-repo windows (#2572)

### DIFF
--- a/src/vendor/mpr-plugins/workon/impl.ts
+++ b/src/vendor/mpr-plugins/workon/impl.ts
@@ -3,6 +3,7 @@ import { tmux } from "maw-js/sdk";
 import { ghqFind } from "maw-js/core/ghq";
 import { buildCommand } from "maw-js/config";
 import { findWorktrees } from "maw-js/commands/shared/wake";
+import { ensureFleetSessionEntry } from "maw-js/commands/shared/fleet-ensure";
 import { resolveWorktreeTarget } from "maw-js/core/matcher/resolve-target";
 import { normalizeWorktreeLayout, worktreePathForLayout, type WorktreeLayout } from "maw-js/core/fleet/worktree-layout";
 
@@ -93,6 +94,16 @@ export async function cmdWorkon(repo: string, task?: string, opts: { layout?: Wo
   await tmux.newWindow(session, windowName, { cwd: targetPath });
   await new Promise(r => setTimeout(r, 300));
   await tmux.sendText(`${session}:${windowName}`, buildCommand(windowName));
+
+  // #2572 — auto-register oracle-repo windows in the fleet so they show up in
+  // `maw ls` and rehydrate on wake. Scoped to `-oracle` repos; tool/lib repos
+  // are left out to keep the fleet registry oracle-only. Idempotent.
+  if (repoName.toLowerCase().endsWith("-oracle")) {
+    const fleet = ensureFleetSessionEntry({ session, window: windowName, cwd: targetPath, createdBy: "maw workon" });
+    if (fleet.status === "created" || fleet.status === "updated") {
+      console.log(`\x1b[32m+\x1b[0m fleet registered ${session}:${windowName}`);
+    }
+  }
 
   console.log(`\x1b[32m✅\x1b[0m workon '${windowName}' in ${session} → ${targetPath}`);
 }

--- a/test/isolated/workon-plugin-coverage.test.ts
+++ b/test/isolated/workon-plugin-coverage.test.ts
@@ -9,6 +9,8 @@ let newWindowCalls: Array<{ session: string; name: string; opts: unknown }> = []
 let sendTextCalls: Array<{ target: string; text: string }> = [];
 let listWindowsReturn: Array<{ index: number; name: string; active: boolean }> = [];
 let selectWindowCalls: string[] = [];
+let ensureFleetCalls: Array<{ session: string; window: string; cwd?: string; createdBy: string }> = [];
+let ensureFleetResult: { status: string } = { status: "created" };
 let logs: string[] = [];
 let errors: string[] = [];
 
@@ -35,6 +37,13 @@ mock.module("maw-js/commands/shared/wake", () => ({
     expect(parentDir).toBe("/opt/Code/github.com/Soul-Brews-Studio");
     expect(repoName).toBe("maw-js");
     return worktrees;
+  },
+}));
+
+mock.module("maw-js/commands/shared/fleet-ensure", () => ({
+  ensureFleetSessionEntry: (input: { session: string; window: string; cwd?: string; createdBy: string }) => {
+    ensureFleetCalls.push(input);
+    return ensureFleetResult;
   },
 }));
 
@@ -72,6 +81,8 @@ beforeEach(() => {
   sendTextCalls = [];
   listWindowsReturn = [];
   selectWindowCalls = [];
+  ensureFleetCalls = [];
+  ensureFleetResult = { status: "created" };
   logs = [];
   errors = [];
   process.env.TMUX = "/tmp/tmux-1000/default,1,0";
@@ -217,5 +228,46 @@ describe("workon plugin coverage", () => {
     process.env.TMUX = "/tmp/tmux-1000/default,1,0";
     hostExecFailures.set("tmux display-message", new Error("no tmux"));
     await expect(cmdWorkon("maw-js")).rejects.toThrow("could not detect current tmux session");
+  });
+
+  test("#2572 — auto-registers an oracle-repo window in the fleet", async () => {
+    ghqFindResult = "/opt/Code/github.com/laris-co/neo-oracle";
+
+    await cmdWorkon("laris-co/neo-oracle");
+
+    expect(ensureFleetCalls).toEqual([
+      { session: "alpha-session", window: "neo-oracle", cwd: "/opt/Code/github.com/laris-co/neo-oracle", createdBy: "maw workon" },
+    ]);
+    expect(logs.join("\n")).toContain("fleet registered alpha-session:neo-oracle");
+  });
+
+  test("#2572 — does NOT register a non-oracle repo window", async () => {
+    // default ghqFindResult is .../maw-js (no -oracle suffix)
+    await cmdWorkon("Soul-Brews-Studio/maw-js");
+
+    expect(ensureFleetCalls).toEqual([]);
+    expect(logs.join("\n")).not.toContain("fleet registered");
+  });
+
+  test("#2572 — registers but stays quiet when the entry already exists", async () => {
+    ghqFindResult = "/opt/Code/github.com/laris-co/neo-oracle";
+    ensureFleetResult = { status: "exists" };
+
+    await cmdWorkon("laris-co/neo-oracle");
+
+    expect(ensureFleetCalls.length).toBe(1);
+    expect(logs.join("\n")).not.toContain("fleet registered");
+  });
+
+  test("#2572 — does not register when an existing window is reused", async () => {
+    ghqFindResult = "/opt/Code/github.com/laris-co/neo-oracle";
+    listWindowsReturn = [{ index: 1, name: "neo-oracle", active: false }];
+
+    await cmdWorkon("laris-co/neo-oracle");
+
+    // #2571 dedup returns early — no new window, and nothing to register.
+    expect(selectWindowCalls).toEqual(["alpha-session:neo-oracle"]);
+    expect(newWindowCalls).toEqual([]);
+    expect(ensureFleetCalls).toEqual([]);
   });
 });


### PR DESCRIPTION
> **Stacked on #2582 (#2571).** Base is `fix/2571-workon-dedup` so this PR shows only the #2572 delta. It will auto-retarget to `alpha` once #2582 merges.

## What

After `tmux.newWindow` succeeds, `maw workon` now registers the new window in the fleet via `ensureFleetSessionEntry` (from `maw-js/commands/shared/fleet-ensure`) — so workon-spawned oracle sessions show up in `maw ls` and rehydrate on wake, exactly like `maw wake` already does.

- **Scoped to `-oracle` repos** (`repoName` ends with `-oracle`); tool/lib repos are skipped to keep the fleet registry oracle-only.
- `ensureFleetSessionEntry` is sync + idempotent and derives the repo slug from `cwd`.

```js
if (repoName.toLowerCase().endsWith("-oracle")) {
  const fleet = ensureFleetSessionEntry({ session, window: windowName, cwd: targetPath, createdBy: "maw workon" });
  if (fleet.status === "created" || fleet.status === "updated")
    console.log(`+ fleet registered ${session}:${windowName}`);
}
```

## Tests

`test/isolated/workon-plugin-coverage.test.ts` (+4; harness gains a `fleet-ensure` mock):
- registers an oracle-repo window — asserts exact `{session, window, cwd, createdBy}` + the log line;
- does **not** register a non-oracle repo;
- registers-but-stays-quiet on `status:"exists"`;
- (composing with #2571) does **not** register when an existing window is reused (dedup returns early).

**15 pass / 0 fail.**

Closes #2572

🤖 ตอบโดย mawjs-codex จาก Nat → mawjs-codex-oracle