### PR TITLE
feat(doctor): report doubled github.com/github.com/ ghq paths (#2578)

### DIFF
--- a/src/commands/shared/fleet-doctor-checks-ghq.ts
+++ b/src/commands/shared/fleet-doctor-checks-ghq.ts
@@ -1,0 +1,57 @@
+/**
+ * fleet-doctor-checks-ghq — doubled `github.com/github.com/` ghq paths (#2578).
+ *
+ * A misconfigured ghq root (one that already ends in `.../github.com`) makes
+ * ghq clone into a DOUBLED `…/github.com/github.com/<org>/<repo>` path. Both the
+ * doubled and the canonical clone then show up in `ghq list`, which is the
+ * resolution hazard #2577 fixed. This check surfaces the mess so an operator can
+ * clean it up — it NEVER deletes anything (`fixable: false`); it only reports
+ * each doubled path, whether the canonical copy exists, and a recommendation.
+ *
+ * Separated from fleet-doctor-checks.ts (like checks-repo) because it touches
+ * the filesystem via `existsSync` — injected here so the check stays unit-
+ * testable without a real ghq tree.
+ */
+
+import { existsSync } from "fs";
+import type { DoctorFinding } from "./fleet-doctor-checks";
+
+const DOUBLED_RE = /\/github\.com\/github\.com\//i;
+
+/** De-double the first `…/github.com/github.com/…` segment in a path. */
+export function canonicalGhqPath(doubledPath: string): string {
+  return doubledPath.replace(DOUBLED_RE, "/github.com/");
+}
+
+/**
+ * Check — repos cloned under a doubled `github.com/github.com/` path.
+ *
+ * @param repoPaths  full repo paths, e.g. the output of `ghq list --full-path`.
+ * @param exists     filesystem probe for the canonical path (injectable; tests
+ *                   pass a stub). Defaults to `existsSync`.
+ */
+export function checkDoubledGhqPaths(
+  repoPaths: string[],
+  exists: (path: string) => boolean = existsSync,
+): DoctorFinding[] {
+  const findings: DoctorFinding[] = [];
+  const seen = new Set<string>();
+  for (const path of repoPaths) {
+    if (!DOUBLED_RE.test(path) || seen.has(path)) continue;
+    seen.add(path);
+    const canonical = canonicalGhqPath(path);
+    const canonicalExists = repoPaths.includes(canonical) || exists(canonical);
+    findings.push({
+      level: "warn",
+      check: "doubled-ghq-path",
+      fixable: false,
+      message: canonicalExists
+        ? `doubled ghq path '${path}' duplicates the canonical '${canonical}' (which exists) — ` +
+          `after confirming no unpushed work, remove the doubled copy: rm -rf '${path}'`
+        : `doubled ghq path '${path}' has no canonical copy — ` +
+          `move it to the correct location: mv '${path}' '${canonical}'`,
+      detail: { doubled: path, canonical, canonicalExists },
+    });
+  }
+  return findings;
+}

--- a/src/commands/shared/fleet-doctor.ts
+++ b/src/commands/shared/fleet-doctor.ts
@@ -30,6 +30,7 @@ export {
 } from "./fleet-doctor-checks";
 export type { FleetEntryLike } from "./fleet-doctor-checks-repo";
 export { checkMissingRepos } from "./fleet-doctor-checks-repo";
+export { checkDoubledGhqPaths, canonicalGhqPath } from "./fleet-doctor-checks-ghq";
 export { checkStalePeers } from "./fleet-doctor-stale-peers";
 export { autoFix } from "./fleet-doctor-fixer";
 export { checkRebootReadiness } from "./fleet-doctor-reboot";
@@ -38,6 +39,7 @@ import { join } from "path";
 import { loadConfig } from "../../config";
 import { getGhqRoot } from "../../config/ghq-root";
 import { listSessions } from "../../sdk";
+import { ghqList } from "../../core/ghq";
 import { loadFleetEntries } from "./fleet-load";
 import {
   checkCollisions,
@@ -48,6 +50,7 @@ import {
   checkPeerVersionSkew,
 } from "./fleet-doctor-checks";
 import { checkMissingRepos } from "./fleet-doctor-checks-repo";
+import { checkDoubledGhqPaths } from "./fleet-doctor-checks-ghq";
 import { checkStalePeers } from "./fleet-doctor-stale-peers";
 import { autoFix, C, colorFor, iconFor } from "./fleet-doctor-fixer";
 import type { DoctorFinding, Level } from "./fleet-doctor-checks";
@@ -120,6 +123,11 @@ export async function cmdFleetDoctor(opts: DoctorOptions = {}): Promise<void> {
   findings.push(...checkDuplicatePeers(peers));
   findings.push(...checkSelfPeer(peers, localNode, config.port));
   findings.push(...checkMissingRepos(entries, join(getGhqRoot(), "github.com")));
+
+  // #2578 — surface doubled `github.com/github.com/` ghq clones (report only).
+  let repoPaths: string[] = [];
+  try { repoPaths = await ghqList(); } catch { /* ghq absent — nothing to scan */ }
+  findings.push(...checkDoubledGhqPaths(repoPaths));
 
   const { findings: staleFindings, identities } = await checkStalePeers(peers);
   findings.push(...staleFindings);

--- a/test/fleet-doctor.test.ts
+++ b/test/fleet-doctor.test.ts
@@ -6,6 +6,8 @@ import {
   checkDuplicatePeers,
   checkSelfPeer,
   checkMissingRepos,
+  checkDoubledGhqPaths,
+  canonicalGhqPath,
   autoFix,
   type DoctorFinding,
 } from "../src/commands/shared/fleet-doctor";
@@ -296,3 +298,57 @@ describe("autoFix — only safe transforms", () => {
 function safeAutoFix(findings: DoctorFinding[], config: MawConfig): string[] {
   return autoFix(findings, config, () => {});
 }
+
+describe("canonicalGhqPath (#2578)", () => {
+  test("de-doubles the first github.com/github.com/ segment", () => {
+    expect(canonicalGhqPath("/opt/Code/github.com/github.com/laris-co/neo-oracle"))
+      .toBe("/opt/Code/github.com/laris-co/neo-oracle");
+  });
+  test("leaves a single github.com path unchanged", () => {
+    expect(canonicalGhqPath("/opt/Code/github.com/laris-co/neo-oracle"))
+      .toBe("/opt/Code/github.com/laris-co/neo-oracle");
+  });
+});
+
+describe("checkDoubledGhqPaths (#2578) — report-only doubled github.com paths", () => {
+  const doubled = "/opt/Code/github.com/github.com/laris-co/neo-oracle";
+  const canonical = "/opt/Code/github.com/laris-co/neo-oracle";
+
+  test("no doubled paths → no findings", () => {
+    expect(checkDoubledGhqPaths([canonical, "/opt/Code/github.com/org/other"], () => false)).toEqual([]);
+  });
+
+  test("reports a doubled path whose canonical also exists, recommends removal (never fixable)", () => {
+    const out = checkDoubledGhqPaths([doubled, canonical], () => true);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      level: "warn",
+      check: "doubled-ghq-path",
+      fixable: false,
+      detail: { doubled, canonical, canonicalExists: true },
+    });
+    expect(out[0].message).toContain("rm -rf");
+    expect(out[0].message).toContain(doubled);
+  });
+
+  test("reports a doubled path with no canonical, recommends a move", () => {
+    // canonical not in the list and exists() says no
+    const out = checkDoubledGhqPaths([doubled], () => false);
+    expect(out).toHaveLength(1);
+    expect(out[0].detail).toMatchObject({ canonicalExists: false });
+    expect(out[0].message).toContain("mv ");
+    expect(out[0].fixable).toBe(false);
+  });
+
+  test("detects canonical via the path list even when exists() is false", () => {
+    const out = checkDoubledGhqPaths([doubled, canonical], () => false);
+    expect(out[0].detail).toMatchObject({ canonicalExists: true });
+  });
+
+  test("reports each distinct doubled path once", () => {
+    const second = "/opt/Code/github.com/github.com/acme/tool-oracle";
+    const out = checkDoubledGhqPaths([doubled, doubled, second], () => false);
+    expect(out).toHaveLength(2);
+    expect(out.map((f) => f.detail!.doubled)).toEqual([doubled, second]);
+  });
+});


### PR DESCRIPTION
## What

A `maw fleet doctor` check that surfaces **doubled** `…/github.com/github.com/<org>/<repo>` ghq clones. A misconfigured ghq root (already ending in `.../github.com`) makes ghq clone into the doubled path; both it and the canonical clone then appear in `ghq list` — the resolution hazard #2577 worked around. This **reports** the mess so an operator can clean it up. **Report-only — it never deletes.**

## How

**New `src/commands/shared/fleet-doctor-checks-ghq.ts`:**
- `canonicalGhqPath(path)` — de-doubles the first `github.com/github.com/` segment.
- `checkDoubledGhqPaths(repoPaths, exists?)` — pure check → `DoctorFinding[]`. Per doubled path: `level: "warn"`, `check: "doubled-ghq-path"`, **`fixable: false`**, plus whether the canonical exists (via the path list or an injectable `exists` probe) and a recommendation — `rm -rf` the doubled copy when the canonical exists, else `mv` it. `detail` carries `{ doubled, canonical, canonicalExists }` for `--json`.

**`fleet-doctor.ts`:** after `checkMissingRepos`, `cmdFleetDoctor` calls `ghqList()` (fail-soft if ghq is absent) and pushes the findings; barrel re-exports added. Follows the existing `checks-repo` split (own file because it touches fs via injectable `existsSync`).

## Tests

`test/fleet-doctor.test.ts` (+7): `canonicalGhqPath` de-double/no-op; `checkDoubledGhqPaths` — none, canonical-exists (`rm -rf`, never fixable), no-canonical (`mv`), canonical-detected-via-list, dedupes-by-path. **35 pass / 0 fail.**

Verified live against the real `ghq list` (798 repos → **101** doubled findings, report-only, correct recommendations).

> Note: on a doubled-heavy ghq root this emits one finding per doubled path (101 here). `--json` is the actionable form. Happy to add a "showing N of M" cap to the human output as a follow-up if desired.

Closes #2578

🤖 ตอบโดย mawjs-codex จาก Nat → mawjs-codex-oracle