### PR TITLE
fix(wake): prompt before fresh-session rehydrate

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -469,6 +469,18 @@ function logAgentsRehydrationSource(count: number, worktrees: { path: string }[]
   console.log(`\x1b[90m↻ agents/ rehydrate: none from ${source}\x1b[0m`);
 }
 
+function shouldSkipAgentsRehydrationPrompt(plan: RehydrateWorktreePlan[]): boolean {
+  if (plan.length === 0 || !_wtPicker.isStdoutTTY()) return false;
+  console.log(`\x1b[36m↻\x1b[0m found ${plan.length} saved agent window${plan.length === 1 ? "" : "s"}:`);
+  for (const wt of plan) {
+    console.log(`  \x1b[90m${wt.windowName.padEnd(40)} ${formatWorktreeSource(wt.path)}\x1b[0m`);
+  }
+  console.log("");
+  process.stdout.write(`  Rehydrate all? [Y/n] `);
+  const answer = _wtPicker.readChoice();
+  return !!answer && /^n/i.test(answer);
+}
+
 async function restoreSnapshotWindows(
   oracle: string,
   session: string,
@@ -1186,19 +1198,24 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
       const rehydratableWt = await filterMergedWorktreesForRehydrate(allWt, { hostExec, baseBranch: "alpha" });
       const plan = planRehydrateWorktreeWindows(oracle, rehydratableWt, [...existingWindows]);
       logAgentsRehydrationSource(plan.length, allWt);
-      if (plan.length > 0) {
+      const skipRehydrate = shouldSkipAgentsRehydrationPrompt(plan);
+      if (skipRehydrate) {
+        console.log(`\x1b[33m⚡\x1b[0m skipped agent rehydration`);
+      } else if (plan.length > 0) {
         console.log(`\x1b[36m↻\x1b[0m rehydrating from agents/ folder:`);
       }
-      for (const wt of plan) {
-        await tmux.newWindow(session, wt.windowName, { cwd: wt.path });
-        await new Promise(r => setTimeout(r, 300));
-        const wtEngine = wakeSession.readWorktreeEngineFile(wt.path);
-        const wtOpts = wtEngine ? { ...opts, engine: wtEngine } : opts;
-        const target = `${session}:${wt.windowName}`;
-        await tmux.sendText(target, await buildWakeCommandForPane(wt.windowName, wt.path, wtOpts, target));
-        await wakeSession.waitForEngine(target, getPaneInfos, isAgentCommand);
-        existingWindows.add(wt.windowName);
-        console.log(`\x1b[32m+\x1b[0m window: ${wt.windowName}  \x1b[90m(from ${formatWorktreeSource(wt.path)})\x1b[0m`);
+      if (!skipRehydrate) {
+        for (const wt of plan) {
+          await tmux.newWindow(session, wt.windowName, { cwd: wt.path });
+          await new Promise(r => setTimeout(r, 300));
+          const wtEngine = wakeSession.readWorktreeEngineFile(wt.path);
+          const wtOpts = wtEngine ? { ...opts, engine: wtEngine } : opts;
+          const target = `${session}:${wt.windowName}`;
+          await tmux.sendText(target, await buildWakeCommandForPane(wt.windowName, wt.path, wtOpts, target));
+          await wakeSession.waitForEngine(target, getPaneInfos, isAgentCommand);
+          existingWindows.add(wt.windowName);
+          console.log(`\x1b[32m+\x1b[0m window: ${wt.windowName}  \x1b[90m(from ${formatWorktreeSource(wt.path)})\x1b[0m`);
+        }
       }
     }
     knownWindows = existingWindows;
@@ -1239,17 +1256,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
         const plan = planRehydrateWorktreeWindows(oracle, rehydratableWt, existingWindows, liveTileRoles);
         logAgentsRehydrationSource(plan.length, allWt);
         if (plan.length > 0) {
-          let skipRehydrate = false;
-          if (_wtPicker.isStdoutTTY()) {
-            console.log(`\x1b[36m↻\x1b[0m found ${plan.length} saved agent window${plan.length === 1 ? "" : "s"}:`);
-            for (const wt of plan) {
-              console.log(`  \x1b[90m${wt.windowName.padEnd(40)} ${formatWorktreeSource(wt.path)}\x1b[0m`);
-            }
-            console.log("");
-            process.stdout.write(`  Rehydrate all? [Y/n] `);
-            const answer = _wtPicker.readChoice();
-            skipRehydrate = !!answer && /^n/i.test(answer);
-          }
+          const skipRehydrate = shouldSkipAgentsRehydrationPrompt(plan);
           if (skipRehydrate) {
             console.log(`\x1b[33m⚡\x1b[0m skipped agent rehydration`);
           } else {

--- a/test/isolated/wake-cmd-branch-coverage.test.ts
+++ b/test/isolated/wake-cmd-branch-coverage.test.ts
@@ -59,6 +59,7 @@ let listWindowsThrows = false;
 let listClaudeSessionsThrows = false;
 let snapshot: any = null;
 let shouldWakeDecision = { wake: false, reason: "already-live" };
+let detectSessionResult: string | null = "54-mawjs";
 let paneCommand = "codex";
 let logs: string[] = [];
 let writes: string[] = [];
@@ -86,6 +87,7 @@ function resetState() {
   listClaudeSessionsThrows = false;
   snapshot = null;
   shouldWakeDecision = { wake: false, reason: "already-live" };
+  detectSessionResult = "54-mawjs";
   paneCommand = "codex";
   logs = [];
   writes = [];
@@ -184,7 +186,7 @@ mock.module(join(import.meta.dir, "../../src/commands/shared/wake-resolve"), () 
   findReusableWorktreeBySlug: (...args: any[]) => mockActive ? null : (realWakeResolve.findReusableWorktreeBySlug as any)(...args),
   getSessionMap: () => mockActive ? {} : realWakeResolve.getSessionMap(),
   resolveFleetSession: (oracle: string) => mockActive ? null : realWakeResolve.resolveFleetSession(oracle),
-  detectSession: async (oracle: string) => mockActive ? "54-mawjs" : realWakeResolve.detectSession(oracle),
+  detectSession: async (oracle: string) => mockActive ? detectSessionResult : realWakeResolve.detectSession(oracle),
   setSessionEnv: async (session: string) => mockActive ? undefined : realWakeResolve.setSessionEnv(session),
   sanitizeBranchName: (value: string) => mockActive ? value.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9._-]/g, "").slice(0, 50) : realWakeResolve.sanitizeBranchName(value),
 }));
@@ -295,6 +297,37 @@ describe("wake-cmd isolated executable branch coverage", () => {
     expect(windowsBySession.project).toEqual([{ name: "mawjs", cwd: repoPath }]);
     expect(newWindowCalls).toEqual([]);
     expect(sendTextCalls).toEqual([{ target: "project:mawjs", text: expect.stringContaining("--agent mawjs") }]);
+  });
+
+  test("#2586 prompts before rehydrating saved agent windows in a newly created session", async () => {
+    detectSessionResult = null;
+    sessions = [];
+    hasSessions = new Set();
+    shouldWakeDecision = { wake: true, reason: "missing-session" };
+    worktrees = [
+      { name: "1-review", path: join(repoPath, "agents", "1-review") },
+    ];
+    const originalIsStdoutTTY = _wtPicker.isStdoutTTY;
+    const originalReadChoice = _wtPicker.readChoice;
+    _wtPicker.isStdoutTTY = () => true;
+    _wtPicker.readChoice = () => "n";
+
+    try {
+      const { result, logs } = await captureLogs(() => cmdWake("mawjs", {}));
+
+      expect(result).toBe("01-mawjs:mawjs-oracle");
+      const rendered = logs.join("\n");
+      expect(rendered).toContain("found 1 saved agent window");
+      expect(writes.join("")).toContain("Rehydrate all? [Y/n]");
+      expect(rendered).toContain("skipped agent rehydration");
+      expect(sessions).toContainEqual({ name: "01-mawjs" });
+      expect(windowsBySession["01-mawjs"]).toEqual([{ name: "mawjs-oracle", cwd: repoPath }]);
+      expect(newWindowCalls).toEqual([]);
+      expect(sendTextCalls).toEqual([{ target: "01-mawjs:mawjs-oracle", text: expect.stringContaining("--agent mawjs-oracle") }]);
+    } finally {
+      _wtPicker.isStdoutTTY = originalIsStdoutTTY;
+      _wtPicker.readChoice = originalReadChoice;
+    }
   });
 
   test("rejects unavailable and non-matching requested snapshots", async () => {


### PR DESCRIPTION
## Summary
- Extract the agents/ rehydrate [Y/n] prompt into one helper shared by fresh-session and existing-session paths.
- Apply the prompt before rehydrating saved agent windows after creating a new session.
- Add a regression test for declining rehydrate on a newly created wake session.

## Verification
- MAW_TEST_MODE=1 bun test test/isolated/wake-cmd-branch-coverage.test.ts
- bun run build
- git diff --check

Closes #2586