### PR TITLE
release: v26.6.13-alpha.834

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.6.13-alpha.142",
+  "version": "26.6.13-alpha.834",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Cuts v26.6.13-alpha.834 on merge via calver-release.yml.

## Ships
- #2587 feat(repo-discovery): detectFromCwd consolidation
- #2589 fix(wake): rehydrate [Y/n] prompt on new session
- #2592 fix(ci): isolated shard failures (stale mocks + coverage)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>