### PR TITLE
fix: clear wake inbox nags after attach consume

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -844,6 +844,10 @@ function findExistingWakeWindow(windowNames: Iterable<string>, oracle: string, w
   return findExistingWakeWindowEntry([...windowNames].map(name => ({ name })), oracle, windowName)?.name;
 }
 
+export function shouldMarkWakeInboxRead(opts: Pick<WakeOptions, "dryRun" | "listWt">, env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.MAW_ATTACH_FOLLOWS === "1" && !opts.dryRun && !opts.listWt;
+}
+
 export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string> {
   // Canonicalize the bare name before any lookup — strips trailing `/`, `/.git`, `/.git/`
   // so `maw wake token-oracle/` (tab-completion artifact) resolves the same as `token-oracle`.
@@ -1022,7 +1026,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
     return `${oracle}:list`;
   }
 
-  const drainedInbox = drainWakeInbox(repoPath, { markRead: false, engine: opts.engine });
+  const drainedInbox = drainWakeInbox(repoPath, { markRead: shouldMarkWakeInboxRead(opts), engine: opts.engine });
   if (drainedInbox.prompt.trim()) {
     opts = { ...opts, prompt: mergeWakeInboxPrompt(opts.prompt, drainedInbox.prompt) };
   }

--- a/src/vendor/mpr-plugins/inbox/impl.ts
+++ b/src/vendor/mpr-plugins/inbox/impl.ts
@@ -125,10 +125,10 @@ function parseFrontmatter(content: string): { frontmatter: InboxFrontmatter; bod
   const fm: InboxFrontmatter = { from: "unknown", to: "unknown", timestamp: "", read: false };
   if (!match) return { frontmatter: fm, body: content };
   for (const line of match[1].split("\n")) {
-    const colon = line.indexOf(": ");
+    const colon = line.indexOf(":");
     if (colon < 0) continue;
-    const k = line.slice(0, colon);
-    const v = line.slice(colon + 2).trim();
+    const k = line.slice(0, colon).trim();
+    const v = line.slice(colon + 1).trim();
     if (k === "from") fm.from = v;
     else if (k === "to") fm.to = v;
     else if (k === "timestamp" || k === "date") fm.timestamp = v;
@@ -650,6 +650,22 @@ export async function cmdInboxLs(opts: { unread?: boolean; from?: string; last?:
   console.log();
 }
 
+function markInboxFrontmatterRead(content: string, timestamp = new Date().toISOString()): string {
+  if (!content.startsWith("---\n")) return content;
+  const end = content.indexOf("\n---", 4);
+  if (end < 0) return content;
+  let frontmatter = content.slice(0, end + "\n---".length);
+  if (/^read:\s*false\s*$/im.test(frontmatter)) {
+    frontmatter = frontmatter.replace(/^read:\s*false\s*$/im, "read: true");
+  } else if (!/^read:/im.test(frontmatter)) {
+    frontmatter = frontmatter.replace(/\n---$/, "\nread: true\n---");
+  }
+  if (!/^readAt:/im.test(frontmatter)) {
+    frontmatter = frontmatter.replace(/\n---$/, `\nreadAt: ${timestamp}\n---`);
+  }
+  return frontmatter + content.slice(end + "\n---".length);
+}
+
 export async function cmdInboxMarkRead(id: string) {
   if (!id) { console.error("usage: maw inbox read <id>"); return; }
   const msgs = loadInboxMessages(resolveInboxDir());
@@ -657,7 +673,12 @@ export async function cmdInboxMarkRead(id: string) {
   if (!msg) { console.error(`\x1b[31merror\x1b[0m: message not found: ${id}`); return; }
   if (msg.frontmatter.read) { console.log(`\x1b[90malready read:\x1b[0m ${msg.filename}`); return; }
   const content = readFileSync(msg.path, "utf-8");
-  writeFileSync(msg.path, content.replace(/^read: false$/m, "read: true"));
+  const updated = markInboxFrontmatterRead(content);
+  if (updated === content) {
+    console.error(`\x1b[31merror\x1b[0m: could not mark read: ${msg.filename}`);
+    return;
+  }
+  writeFileSync(msg.path, updated);
   console.log(`\x1b[32m✓\x1b[0m marked read: ${msg.filename}`);
 }
 

--- a/test/isolated/plugin-inbox-standalone.test.ts
+++ b/test/isolated/plugin-inbox-standalone.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
-import { mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 const realSdk = await import("../../src/sdk/index.ts");
@@ -55,6 +55,7 @@ mock.module("maw-js/sdk", () => ({ ...realSdk, ...sdkMock }));
 
 const { command, default: handler } = await import("../../src/vendor/mpr-plugins/inbox/index.ts");
 const {
+  cmdInboxMarkRead,
   cmdInboxWrite,
   cmdQueueList,
   formatQueueDetail,
@@ -136,6 +137,38 @@ describe("inbox plugin standalone boundary (#2329)", () => {
     expect(updated).toEqual([{ id: "abc123", patch: { status: "approved" } }]);
     expect(sent).toEqual([{ target: "codex-5", message: "hello from queue", force: undefined }]);
     expect(deleted).toEqual(["abc123"]);
+  });
+
+
+  test("mark-read robustly updates compact or missing read frontmatter", async () => {
+    const inbox = join(psiPath, "inbox");
+    const compact = join(inbox, "2026-06-09_00-01_sender_compact.md");
+    const missing = join(inbox, "2026-06-09_00-02_sender_missing.md");
+    writeFileSync(compact, [
+      "---",
+      "from: sender",
+      "timestamp: 2026-06-09T00:01:00.000Z",
+      "read:false",
+      "---",
+      "",
+      "compact read flag",
+    ].join("\n"));
+    writeFileSync(missing, [
+      "---",
+      "from: sender",
+      "timestamp: 2026-06-09T00:02:00.000Z",
+      "---",
+      "",
+      "missing read flag",
+    ].join("\n"));
+
+    await cmdInboxMarkRead("compact");
+    await cmdInboxMarkRead("missing");
+
+    expect(readFileSync(compact, "utf8")).toContain("read: true");
+    expect(readFileSync(compact, "utf8")).toContain("readAt:");
+    expect(readFileSync(missing, "utf8")).toContain("read: true");
+    expect(readFileSync(missing, "utf8")).toContain("readAt:");
   });
 
   test("local inbox write and relative time are non-destructive and deterministic", async () => {

--- a/test/isolated/wake-cmd-thirteenth-pass-coverage.test.ts
+++ b/test/isolated/wake-cmd-thirteenth-pass-coverage.test.ts
@@ -308,11 +308,19 @@ const {
   getLiveTileRoles,
   _wtPicker,
   promptAmbiguousWorktreePick,
+  shouldMarkWakeInboxRead,
 } = await import("../../src/commands/shared/wake-cmd");
 
 beforeEach(resetState);
 
 describe("wake-cmd thirteenth-pass isolated coverage", () => {
+  test("marks wake inbox read only for attach-follow consume path", () => {
+    expect(shouldMarkWakeInboxRead({}, { MAW_ATTACH_FOLLOWS: "1" })).toBe(true);
+    expect(shouldMarkWakeInboxRead({ dryRun: true }, { MAW_ATTACH_FOLLOWS: "1" })).toBe(false);
+    expect(shouldMarkWakeInboxRead({ listWt: true }, { MAW_ATTACH_FOLLOWS: "1" })).toBe(false);
+    expect(shouldMarkWakeInboxRead({}, {})).toBe(false);
+  });
+
   test("exported helpers cover live tile parsing, failures, and picker defaults", async () => {
     await expect(getLiveTileRoles("54-neo", {
       hostExecFn: async () => "main\n\n side \nmain\n",

--- a/test/isolated/wake-inbox-drain-2013.test.ts
+++ b/test/isolated/wake-inbox-drain-2013.test.ts
@@ -35,6 +35,33 @@ describe("wake inbox drain (#2390)", () => {
     expect(updated).not.toContain("readAt:");
   });
 
+
+  test("marks unread messages read when the attach flow consumes wake inbox", () => {
+    const repo = mkdtempSync(join(tmpdir(), "maw-wake-drain-mark-read-"));
+    const inbox = join(repo, "ψ", "inbox");
+    mkdirSync(inbox, { recursive: true });
+    const unread = join(inbox, "001.md");
+    const missingRead = join(inbox, "002.md");
+    writeFileSync(unread, [
+      "---",
+      "from: alpha:sender",
+      "timestamp: 2026-06-06T00:00:00.000Z",
+      "read:false",
+      "---",
+      "",
+      "please review #2588",
+    ].join("\n"));
+    writeFileSync(missingRead, ["---", "from: beta:sender", "---", "", "missing read flag"].join("\n"));
+
+    const result = drainWakeInbox(repo, { markRead: true });
+
+    expect(result.count).toBe(2);
+    expect(readFileSync(unread, "utf-8")).toContain("read: true");
+    expect(readFileSync(unread, "utf-8")).toContain("readAt:");
+    expect(readFileSync(missingRead, "utf-8")).toContain("read: true");
+    expect(readFileSync(missingRead, "utf-8")).toContain("readAt:");
+  });
+
   test("merges drained inbox after an explicit wake prompt", () => {
     expect(mergeWakeInboxPrompt("continue task", "You have 1 unread messages in inbox. Run maw inbox --unread to review."))
       .toBe("continue task\n\nYou have 1 unread messages in inbox. Run maw inbox --unread to review.");


### PR DESCRIPTION
Closes #2588

## Summary
- mark wake-drained inbox messages read only when wake is invoked by the attach cascade (`MAW_ATTACH_FOLLOWS=1`), so `maw a` stops re-nagging the same messages
- keep plain `maw wake` / `--list` non-destructive
- make `maw inbox read` robust for `read:false`, whitespace/case variants, and missing `read:` frontmatter, with `readAt` stamping

## Verification
- `bun test --isolate test/isolated/wake-inbox-drain-2013.test.ts test/isolated/plugin-inbox-standalone.test.ts test/isolated/wake-cmd-thirteenth-pass-coverage.test.ts`
- `bun run build`
- `bun scripts/check-plugin-coverage-gate.ts origin/alpha`