### PR TITLE
fix(wake): show concurrency cap refusals

### DIFF
--- a/src/cli/error-handler.ts
+++ b/src/cli/error-handler.ts
@@ -5,8 +5,9 @@ import { renderAmbiguousMatch } from "../core/util/render-ambiguous";
 /**
  * Top-level error handler for `main()`. Always exits — never returns.
  *
- * - UserError: output already printed at throw site, exit 1 silently
- *   (no bun stack trace).
+ * - UserError: print its message without a bun stack trace, then exit 1.
+ *   Some call sites throw UserError directly; keeping it silent hides the
+ *   actionable reason (for example wake concurrency refusals).
  * - AmbiguousMatchError: escapes from findWindow via resolver chains
  *   (cmdSend, cmdPeek, talk-to, view, etc.). Render as actionable CLI
  *   output instead of a minified stack trace.
@@ -14,6 +15,7 @@ import { renderAmbiguousMatch } from "../core/util/render-ambiguous";
  */
 export function handleTopLevelError(e: unknown, args: string[]): never {
   if (isUserError(e)) {
+    if (e.message) process.stderr.write(`${e.message}\n`);
     process.exit(1);
   }
   if (e instanceof AmbiguousMatchError) {

--- a/src/core/util/user-error.ts
+++ b/src/core/util/user-error.ts
@@ -5,11 +5,9 @@
  * For genuinely unexpected runtime failures, throw a regular Error so
  * the stack stays visible for debugging.
  *
- * Convention: the throw site is responsible for printing the
- * user-facing output (primary error line + any "did you mean" hints)
- * BEFORE throwing. The top-level catch just exits cleanly. This lets
- * sites compose multi-line output (colors, hints, suggestions) without
- * the error class having to carry that structure.
+ * Convention: throw sites may print richer context (colors, hints,
+ * suggestions) before throwing. The top-level catch still prints this
+ * message so direct UserError throws never disappear silently.
  *
  * Throw UserError for: missing/invalid args, unknown commands, bad
  *   target resolution, help-path exits.

--- a/test/isolated/error-handler-more-coverage.test.ts
+++ b/test/isolated/error-handler-more-coverage.test.ts
@@ -10,11 +10,16 @@ import { UserError } from "../../src/core/util/user-error";
 
 const originalExit = process.exit;
 const originalError = console.error;
+const originalStderrWrite = process.stderr.write;
 const stderr: string[] = [];
 
 beforeEach(() => {
   stderr.length = 0;
   console.error = (...args: unknown[]) => stderr.push(args.map(String).join(" "));
+  process.stderr.write = ((chunk: unknown) => {
+    stderr.push(String(chunk).replace(/\n$/, ""));
+    return true;
+  }) as typeof process.stderr.write;
   process.exit = ((code?: string | number | null | undefined) => {
     throw new Error(`__exit__:${code ?? 0}`);
   }) as typeof process.exit;
@@ -23,13 +28,14 @@ beforeEach(() => {
 afterEach(() => {
   process.exit = originalExit;
   console.error = originalError;
+  process.stderr.write = originalStderrWrite;
 });
 
 describe("handleTopLevelError", () => {
-  test("exits silently for user-facing UserError failures", () => {
+  test("prints user-facing UserError messages without a stack trace", () => {
     expect(() => handleTopLevelError(new UserError("bad input"), ["wake"])).toThrow("__exit__:1");
 
-    expect(stderr).toEqual([]);
+    expect(stderr).toEqual(["bad input"]);
   });
 
   test("renders ambiguous tmux matches with actionable context", () => {

--- a/test/isolated/wake-cmd-thirteenth-pass-coverage.test.ts
+++ b/test/isolated/wake-cmd-thirteenth-pass-coverage.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { handleTopLevelError } from "../../src/cli/error-handler";
+import { UserError } from "../../src/core/util/user-error";
 
 type WindowInfo = { name: string };
 type WorktreeInfo = { name: string; path: string };
@@ -37,6 +39,7 @@ let savedConfigs: any[] = [];
 let ensureTeamConfigReturn = false;
 let offerAttachPrompt = false;
 let capacityChecks: string[] = [];
+let capacityError: Error | null = null;
 let setEnvCalls: string[] = [];
 let lifecycleCalls: any[] = [];
 let newSessions: Array<{ session: string; opts: any }> = [];
@@ -88,6 +91,7 @@ function resetState(): void {
   ensureTeamConfigReturn = false;
   offerAttachPrompt = false;
   capacityChecks = [];
+  capacityError = null;
   setEnvCalls = [];
   lifecycleCalls = [];
   newSessions = [];
@@ -267,6 +271,7 @@ mock.module(import.meta.resolve("../../src/commands/shared/wake-target"), () => 
 mock.module(import.meta.resolve("../../src/commands/shared/wake-concurrency"), () => ({
   assertAgentCapacity: async (oracle: string) => {
     capacityChecks.push(oracle);
+    if (capacityError) throw capacityError;
   },
 }));
 
@@ -615,6 +620,49 @@ describe("wake-cmd thirteenth-pass isolated coverage", () => {
     expect(result).toBe("03-neo:neo-oracle");
     expect(newSessions).toEqual([{ session: "03-neo", opts: { window: "neo-oracle", cwd: repoPath } }]);
     expect(plain()).toContain("created session '03-neo'");
+  });
+
+  test("over-cap missing-session wake prints the UserError reason at the CLI boundary", async () => {
+    detectSessionReturn = null;
+    shouldWake = true;
+    listSessionsReturn = [{ name: "02-old" }];
+    capacityError = new UserError("agent concurrency cap reached: 13/10 agents already live — refusing to spawn 'neo'.");
+
+    let thrown: unknown;
+    await captureLogs(async () => {
+      try {
+        await cmdWake("neo", { repoPath, noRehydrate: true });
+      } catch (error) {
+        thrown = error;
+      }
+    });
+
+    expect(thrown).toBe(capacityError);
+    expect(newSessions).toEqual([]);
+    expect(plain()).toContain("no session found, creating");
+
+    const originalExit = process.exit;
+    const originalError = console.error;
+    const originalStderrWrite = process.stderr.write;
+    const stderr: string[] = [];
+    console.error = (...args: unknown[]) => stderr.push(args.map(String).join(" "));
+    process.stderr.write = ((chunk: unknown) => {
+      stderr.push(String(chunk).replace(/\n$/, ""));
+      return true;
+    }) as typeof process.stderr.write;
+    process.exit = ((code?: string | number | null | undefined) => {
+      throw new Error(`__exit__:${code ?? 0}`);
+    }) as typeof process.exit;
+    try {
+      expect(() => handleTopLevelError(thrown, ["wake", "neo"])).toThrow("__exit__:1");
+    } finally {
+      process.exit = originalExit;
+      console.error = originalError;
+      process.stderr.write = originalStderrWrite;
+    }
+
+    expect(stderr.join("\n")).toContain("agent concurrency cap reached: 13/10 agents already live");
+    expect(stderr.join("\n")).toContain("refusing to spawn 'neo'");
   });
 
   test("existing sessions restore snapshots and rehydrate worktrees before ensuring panes", async () => {


### PR DESCRIPTION
Closes #2591

## Summary
- Print UserError messages at the CLI boundary without Bun stack traces so wake capacity refusals are visible.
- Update UserError guidance to reflect visible top-level handling.
- Add a regression covering an over-cap missing-session wake before tmux new-session.

## Verification
- bun test ./test/isolated/error-handler-more-coverage.test.ts
- bun test ./test/isolated/wake-cmd-thirteenth-pass-coverage.test.ts
- bun run build
- bun run test:default:safe
- Manual source CLI repro: `MAW_AGENT_BOOT_POLL_MS=0 bun src/cli.ts wake digger --main --no-fleet -e codex` now prints the agent concurrency cap refusal on stderr.