### PR TITLE
feat(doctor): fix doubled-path Claude sessions

### DIFF
--- a/src/vendor/mpr-plugins/doctor/impl.ts
+++ b/src/vendor/mpr-plugins/doctor/impl.ts
@@ -23,6 +23,7 @@ import { checkMawJsBranch } from "./internal/maw-js-branch-check";
 import { checkStillbornWorktrees } from "./internal/stillborn-worktrees";
 import { checkStalePeers, cmdFixStalePeers } from "./internal/stale-peers";
 import { detectBunLinkedCheckout } from "./internal/bun-link-detect";
+import { fixDoubledGithubSessions } from "./internal/fix-sessions";
 
 export type DoctorSeverity = "info" | "warn" | "error";
 
@@ -71,6 +72,13 @@ export async function cmdDoctor(args: string[] = []): Promise<DoctorResult> {
   // fix result directly so index.ts surfaces it unchanged.
   if (flags.has("--fix-stale")) {
     return await cmdFixStalePeers();
+  }
+
+  if (flags.has("--fix-sessions")) {
+    const result = await fixDoubledGithubSessions({ dryRun: flags.has("--dry-run") || flags.has("--plan") });
+    if (json) renderFixSessionsJson(result);
+    else renderFixSessionsResult(result);
+    return { ok: result.ok, checks: result.checks };
   }
 
   const renderLog = console.log;
@@ -137,6 +145,40 @@ export async function cmdDoctor(args: string[] = []): Promise<DoctorResult> {
   if (json) renderJsonResults(checks, ok, comparison);
   else renderResults(checks, ok, comparison);
   return { ok, checks, comparison };
+}
+
+
+function renderFixSessionsResult(result: Awaited<ReturnType<typeof fixDoubledGithubSessions>>): void {
+  console.log("");
+  console.log(`  ${result.ok ? C.green + "✓" : C.red + "✗"} maw doctor --fix-sessions${C.reset}`);
+  console.log(`    ${result.dryRun ? "dry-run" : "applied"}: ${result.pairs.length} doubled github.com/github.com dir${result.pairs.length === 1 ? "" : "s"}`);
+  console.log(`    ${C.gray}quarantine: ${result.quarantineRoot}${C.reset}`);
+  for (const pair of result.pairs) {
+    const status = pair.outcome === "error" ? C.red + "✗" : pair.outcome === "done" ? C.green + "✓" : C.yellow + "•";
+    console.log(`    ${status}${C.reset} ${pair.action} sessions=${pair.sessionCount} canonical=${pair.canonicalExists ? "yes" : "missing"}`);
+    console.log(`       doubled:   ${pair.doubled}`);
+    console.log(`       canonical: ${pair.canonical}`);
+    console.log(`       cleanup:   mv ${shellQuote(pair.doubled)} ${shellQuote(pair.cleanupTarget)}`);
+    for (const message of pair.messages) console.log(`       ${C.gray}${message}${C.reset}`);
+  }
+  if (result.dryRun) console.log(`    ${C.gray}rerun without --dry-run to remap sessions and quarantine doubled dirs with mv${C.reset}`);
+  console.log("");
+}
+
+function renderFixSessionsJson(result: Awaited<ReturnType<typeof fixDoubledGithubSessions>>): void {
+  console.log(JSON.stringify({
+    ok: result.ok,
+    dryRun: result.dryRun,
+    quarantineRoot: result.quarantineRoot,
+    pairs: result.pairs,
+    checks: result.checks.map(c => ({
+      name: c.name,
+      ok: c.ok,
+      severity: severityFor(c),
+      message: c.message,
+      ...(c.details === undefined ? {} : { details: c.details }),
+    })),
+  }, null, 2));
 }
 
 function parseDoctorArgs(args: string[]): { flags: Set<string>; values: Record<string, string>; positional: string[] } {

--- a/src/vendor/mpr-plugins/doctor/internal/fix-sessions.ts
+++ b/src/vendor/mpr-plugins/doctor/internal/fix-sessions.ts
@@ -2,9 +2,8 @@ import { existsSync, mkdirSync, mkdtempSync, readdirSync, statSync } from "fs";
 import { cp } from "fs/promises";
 import { tmpdir } from "os";
 import { basename, dirname, join } from "path";
-import { execFile } from "child_process";
+import { execFile, execSync } from "child_process";
 import { promisify } from "util";
-import { getGhqRoot } from "maw-js/sdk";
 import type { DoctorCheck } from "../impl";
 
 const execFileAsync = promisify(execFile);
@@ -146,9 +145,24 @@ async function remapPairViaStagedClaudeHome(pair: FixSessionsPair, deps: Require
   await deps.execFile("rsync", ["-a", "--ignore-existing", `${stageCanonical}/`, `${pair.canonicalSessionDir}/`]);
 }
 
+
+function resolveGhqRoot(): string {
+  const envRoot = process.env.GHQ_ROOT;
+  if (envRoot && envRoot.length > 0) return normalizeBareGhqRoot(envRoot);
+  try {
+    const out = execSync("ghq root", { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+    if (out.length > 0) return normalizeBareGhqRoot(out);
+  } catch { /* ghq absent */ }
+  return join(process.env.HOME || "", "Code");
+}
+
+function normalizeBareGhqRoot(raw: string): string {
+  return raw.trim().replace(/\/+$/, "").replace(/\/github\.com$/i, "");
+}
+
 function normalizeDeps(deps: FixSessionsDeps): Required<FixSessionsDeps> {
   return {
-    ghqRoot: deps.ghqRoot ?? (() => getGhqRoot()),
+    ghqRoot: deps.ghqRoot ?? resolveGhqRoot,
     claudeHome: deps.claudeHome ?? (() => process.env.CLAUDE_HOME || join(process.env.HOME || "", ".claude")),
     quarantineRoot: deps.quarantineRoot ?? (() => join(tmpdir(), `maw-doubled-github-${new Date().toISOString().replace(/[:.]/g, "-")}`)),
     exists: deps.exists ?? existsSync,

--- a/src/vendor/mpr-plugins/doctor/internal/fix-sessions.ts
+++ b/src/vendor/mpr-plugins/doctor/internal/fix-sessions.ts
@@ -1,0 +1,219 @@
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, statSync } from "fs";
+import { cp } from "fs/promises";
+import { tmpdir } from "os";
+import { basename, dirname, join } from "path";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { getGhqRoot } from "maw-js/sdk";
+import type { DoctorCheck } from "../impl";
+
+const execFileAsync = promisify(execFile);
+const DOUBLED_SEGMENT_RE = /\/github\.com\/github\.com\//i;
+
+function canonicalGhqPath(doubledPath: string): string {
+  return doubledPath.replace(DOUBLED_SEGMENT_RE, "/github.com/");
+}
+
+export type FixSessionsAction = "remap" | "clone+remap" | "cleanup-only";
+export type FixSessionsOutcome = "planned" | "done" | "skipped" | "error";
+
+export interface FixSessionsPair {
+  doubled: string;
+  canonical: string;
+  canonicalExists: boolean;
+  sessionDir: string;
+  canonicalSessionDir: string;
+  sessionCount: number;
+  hasSessions: boolean;
+  action: FixSessionsAction;
+  cleanupTarget: string;
+  outcome: FixSessionsOutcome;
+  messages: string[];
+}
+
+export interface FixSessionsResult {
+  ok: boolean;
+  dryRun: boolean;
+  quarantineRoot: string;
+  pairs: FixSessionsPair[];
+  checks: DoctorCheck[];
+}
+
+export interface FixSessionsDeps {
+  ghqRoot?: () => string;
+  claudeHome?: () => string;
+  quarantineRoot?: () => string;
+  exists?: (path: string) => boolean;
+  readdir?: (path: string) => string[];
+  stat?: (path: string) => { isDirectory(): boolean; isFile(): boolean };
+  execFile?: (file: string, args: string[], opts?: { cwd?: string }) => Promise<void>;
+  copyDir?: (from: string, to: string) => Promise<void>;
+  moveDir?: (from: string, to: string) => Promise<void>;
+}
+
+export async function fixDoubledGithubSessions(opts: { dryRun: boolean }, deps: FixSessionsDeps = {}): Promise<FixSessionsResult> {
+  const d = normalizeDeps(deps);
+  const quarantineRoot = d.quarantineRoot();
+  const pairs = discoverDoubledGithubSessionPairs(d, quarantineRoot);
+
+  for (const pair of pairs) {
+    if (opts.dryRun) {
+      pair.outcome = "planned";
+      pair.messages.push(`planned ${pair.action}`);
+      continue;
+    }
+    try {
+      if (pair.hasSessions) {
+        if (!pair.canonicalExists) {
+          await d.execFile("ghq", ["get", "-u", githubSlug(pair.canonical)]);
+          pair.messages.push("cloned canonical repo");
+          pair.canonicalExists = true;
+        }
+        await remapPairViaStagedClaudeHome(pair, d);
+        pair.messages.push("remapped sessions with staged claude-path-migrate + rsync --ignore-existing");
+      }
+      await d.moveDir(pair.doubled, pair.cleanupTarget);
+      pair.messages.push(`moved doubled dir to ${pair.cleanupTarget}`);
+      pair.outcome = "done";
+    } catch (e: any) {
+      pair.outcome = "error";
+      pair.messages.push(e?.message || String(e));
+    }
+  }
+
+  const errored = pairs.filter(p => p.outcome === "error");
+  const summary = summarizePairs(pairs);
+  const checks: DoctorCheck[] = [{
+    name: "sessions:fix-doubled-github",
+    ok: errored.length === 0,
+    severity: errored.length === 0 ? "info" : "warn",
+    message: `${opts.dryRun ? "dry-run; " : ""}${summary}; quarantine=${quarantineRoot}`,
+    details: { dryRun: opts.dryRun, quarantineRoot, pairs },
+    fix: opts.dryRun ? ["maw doctor --fix-sessions"] : undefined,
+  }];
+
+  return { ok: errored.length === 0, dryRun: opts.dryRun, quarantineRoot, pairs, checks };
+}
+
+export function discoverDoubledGithubSessionPairs(deps: Required<FixSessionsDeps>, quarantineRoot: string): FixSessionsPair[] {
+  const ghqRoot = deps.ghqRoot();
+  const doubledRoot = join(ghqRoot, "github.com", "github.com");
+  const doubledDirs = findRepoDirs(doubledRoot, deps).filter(p => DOUBLED_SEGMENT_RE.test(p));
+  const seen = new Set<string>();
+  const pairs: FixSessionsPair[] = [];
+  for (const doubled of doubledDirs.sort()) {
+    if (seen.has(doubled)) continue;
+    seen.add(doubled);
+    const canonical = canonicalGhqPath(doubled);
+    const sessionDir = join(deps.claudeHome(), "projects", encodeClaudeProjectPath(doubled));
+    const canonicalSessionDir = join(deps.claudeHome(), "projects", encodeClaudeProjectPath(canonical));
+    const sessionCount = countJsonlSessions(sessionDir, deps);
+    const canonicalExists = deps.exists(canonical);
+    const action: FixSessionsAction = sessionCount > 0
+      ? (canonicalExists ? "remap" : "clone+remap")
+      : "cleanup-only";
+    pairs.push({
+      doubled,
+      canonical,
+      canonicalExists,
+      sessionDir,
+      canonicalSessionDir,
+      sessionCount,
+      hasSessions: sessionCount > 0,
+      action,
+      cleanupTarget: quarantinePath(quarantineRoot, doubled),
+      outcome: "planned",
+      messages: [],
+    });
+  }
+  return pairs;
+}
+
+export function encodeClaudeProjectPath(path: string): string {
+  return path.replace(/[/.]/g, "-");
+}
+
+async function remapPairViaStagedClaudeHome(pair: FixSessionsPair, deps: Required<FixSessionsDeps>): Promise<void> {
+  const stageRoot = mkdtempSync(join(tmpdir(), "maw-doctor-claude-stage-"));
+  const stageClaudeHome = join(stageRoot, "claude");
+  const stageProjects = join(stageClaudeHome, "projects");
+  const stageSource = join(stageProjects, basename(pair.sessionDir));
+  mkdirSync(stageProjects, { recursive: true });
+  await deps.copyDir(pair.sessionDir, stageSource);
+  await deps.execFile("claude-path-migrate", ["--claude-home", stageClaudeHome, "--map", `${pair.doubled}=${pair.canonical}`]);
+  await deps.execFile("claude-path-migrate", ["--claude-home", stageClaudeHome, "--map", `${pair.doubled}=${pair.canonical}`, "--check"]);
+  const stageCanonical = join(stageProjects, encodeClaudeProjectPath(pair.canonical));
+  await deps.execFile("rsync", ["-a", "--ignore-existing", `${stageCanonical}/`, `${pair.canonicalSessionDir}/`]);
+}
+
+function normalizeDeps(deps: FixSessionsDeps): Required<FixSessionsDeps> {
+  return {
+    ghqRoot: deps.ghqRoot ?? (() => getGhqRoot()),
+    claudeHome: deps.claudeHome ?? (() => process.env.CLAUDE_HOME || join(process.env.HOME || "", ".claude")),
+    quarantineRoot: deps.quarantineRoot ?? (() => join(tmpdir(), `maw-doubled-github-${new Date().toISOString().replace(/[:.]/g, "-")}`)),
+    exists: deps.exists ?? existsSync,
+    readdir: deps.readdir ?? readdirSync,
+    stat: deps.stat ?? statSync,
+    execFile: deps.execFile ?? (async (file, args) => { await execFileAsync(file, args); }),
+    copyDir: deps.copyDir ?? (async (from, to) => { await cp(from, to, { recursive: true, force: false, errorOnExist: false }); }),
+    moveDir: deps.moveDir ?? (async (from, to) => {
+      mkdirSync(dirname(to), { recursive: true });
+      await execFileAsync("mv", [from, to]);
+    }),
+  };
+}
+
+function findRepoDirs(doubledRoot: string, deps: Required<FixSessionsDeps>): string[] {
+  if (!deps.exists(doubledRoot)) return [];
+  const results: string[] = [];
+  let owners: string[];
+  try { owners = deps.readdir(doubledRoot); } catch { return []; }
+  for (const owner of owners) {
+    const ownerDir = join(doubledRoot, owner);
+    try { if (!deps.stat(ownerDir).isDirectory()) continue; } catch { continue; }
+    let repos: string[];
+    try { repos = deps.readdir(ownerDir); } catch { continue; }
+    for (const repo of repos) {
+      const repoDir = join(ownerDir, repo);
+      try { if (deps.stat(repoDir).isDirectory()) results.push(repoDir); } catch { /* skip */ }
+    }
+  }
+  return results;
+}
+
+function countJsonlSessions(dir: string, deps: Required<FixSessionsDeps>): number {
+  if (!deps.exists(dir)) return 0;
+  let count = 0;
+  const visit = (path: string) => {
+    let entries: string[];
+    try { entries = deps.readdir(path); } catch { return; }
+    for (const entry of entries) {
+      if (entry.includes("subagents")) continue;
+      const full = join(path, entry);
+      let st: { isDirectory(): boolean; isFile(): boolean };
+      try { st = deps.stat(full); } catch { continue; }
+      if (st.isDirectory()) visit(full);
+      else if (st.isFile() && entry.endsWith(".jsonl")) count++;
+    }
+  };
+  visit(dir);
+  return count;
+}
+
+function quarantinePath(root: string, doubled: string): string {
+  const rel = doubled.replace(/^\/+/, "").replace(/[/:]/g, "__");
+  return join(root, rel);
+}
+
+function githubSlug(canonical: string): string {
+  const marker = "/github.com/";
+  const idx = canonical.toLowerCase().lastIndexOf(marker);
+  if (idx >= 0) return `github.com/${canonical.slice(idx + marker.length)}`;
+  return canonical;
+}
+
+function summarizePairs(pairs: FixSessionsPair[]): string {
+  const counts: Record<FixSessionsAction, number> = { remap: 0, "clone+remap": 0, "cleanup-only": 0 };
+  for (const pair of pairs) counts[pair.action]++;
+  return `${pairs.length} doubled dir${pairs.length === 1 ? "" : "s"}; remap=${counts.remap}; clone+remap=${counts["clone+remap"]}; cleanup-only=${counts["cleanup-only"]}`;
+}

--- a/src/vendor/mpr-plugins/doctor/plugin.ts
+++ b/src/vendor/mpr-plugins/doctor/plugin.ts
@@ -9,7 +9,7 @@ export default definePlugin({
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "doctor",
-    "help": "maw doctor [install|xdg|all] [--json] [--no-prompt] [--capture] [--forward <target>] — diagnose health, show fixes, persist before/after; piped stdin diagnoses an error; use `maw doctor xdg --migrate --dry-run` to preview XDG copy-forward"
+    "help": "maw doctor [install|xdg|all] [--json] [--no-prompt] [--capture] [--forward <target>] — diagnose health, show fixes, persist before/after; use `maw doctor --fix-sessions --dry-run` for doubled github.com session repair planning; use `maw doctor xdg --migrate --dry-run` to preview XDG copy-forward"
   },
   "weight": 30,
   "tier": "standard",

--- a/test/isolated/doctor-fix-sessions.test.ts
+++ b/test/isolated/doctor-fix-sessions.test.ts
@@ -1,0 +1,149 @@
+/** @maw-test-isolate */
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { resetGhqRootCache } from "../../src/config/ghq-root";
+import { cmdDoctor } from "../../src/vendor/mpr-plugins/doctor/impl";
+import {
+  discoverDoubledGithubSessionPairs,
+  encodeClaudeProjectPath,
+  fixDoubledGithubSessions,
+  type FixSessionsDeps,
+} from "../../src/vendor/mpr-plugins/doctor/internal/fix-sessions";
+
+const created: string[] = [];
+const originalGhqRoot = process.env.GHQ_ROOT;
+const originalClaudeHome = process.env.CLAUDE_HOME;
+const originalHome = process.env.HOME;
+
+function tempRoot(label: string): string {
+  const dir = mkdtempSync(join(tmpdir(), `maw-${label}-`));
+  created.push(dir);
+  return dir;
+}
+
+function restoreEnv() {
+  if (originalGhqRoot === undefined) delete process.env.GHQ_ROOT;
+  else process.env.GHQ_ROOT = originalGhqRoot;
+  if (originalClaudeHome === undefined) delete process.env.CLAUDE_HOME;
+  else process.env.CLAUDE_HOME = originalClaudeHome;
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  resetGhqRootCache();
+}
+
+afterEach(() => {
+  restoreEnv();
+  while (created.length) rmSync(created.pop()!, { recursive: true, force: true });
+});
+
+function fixture() {
+  const root = tempRoot("doctor-fix-sessions");
+  const ghqRoot = join(root, "Code");
+  const claudeHome = join(root, "claude");
+  const quarantine = join(root, "quarantine");
+  const doubledWithCanonical = join(ghqRoot, "github.com", "github.com", "Org", "has-sessions");
+  const canonical = join(ghqRoot, "github.com", "Org", "has-sessions");
+  const doubledMissingCanonical = join(ghqRoot, "github.com", "github.com", "Org", "needs-clone");
+  const doubledNoSessions = join(ghqRoot, "github.com", "github.com", "Org", "cleanup-only");
+  for (const dir of [doubledWithCanonical, canonical, doubledMissingCanonical, doubledNoSessions]) {
+    mkdirSync(dir, { recursive: true });
+  }
+  const sessionDir = join(claudeHome, "projects", encodeClaudeProjectPath(doubledWithCanonical));
+  mkdirSync(sessionDir, { recursive: true });
+  writeFileSync(join(sessionDir, "session.jsonl"), JSON.stringify({ cwd: doubledWithCanonical }));
+  const cloneSessionDir = join(claudeHome, "projects", encodeClaudeProjectPath(doubledMissingCanonical));
+  mkdirSync(cloneSessionDir, { recursive: true });
+  writeFileSync(join(cloneSessionDir, "clone.jsonl"), JSON.stringify({ cwd: doubledMissingCanonical }));
+  return { root, ghqRoot, claudeHome, quarantine, doubledWithCanonical, canonical, doubledMissingCanonical, doubledNoSessions };
+}
+
+describe("maw doctor --fix-sessions", () => {
+  test("detects doubled github.com dirs and plans remap / clone+remap / cleanup-only", () => {
+    const f = fixture();
+    const pairs = discoverDoubledGithubSessionPairs({
+      ghqRoot: () => f.ghqRoot,
+      claudeHome: () => f.claudeHome,
+      quarantineRoot: () => f.quarantine,
+      exists: (p) => require("fs").existsSync(p),
+      readdir: (p) => require("fs").readdirSync(p),
+      stat: (p) => require("fs").statSync(p),
+      execFile: async () => {},
+      copyDir: async () => {},
+      moveDir: async () => {},
+    }, f.quarantine);
+
+    expect(pairs.map(p => [p.doubled, p.action, p.sessionCount])).toEqual([
+      [f.doubledNoSessions, "cleanup-only", 0],
+      [f.doubledWithCanonical, "remap", 1],
+      [f.doubledMissingCanonical, "clone+remap", 1],
+    ]);
+    expect(pairs.find(p => p.action === "remap")?.canonical).toBe(f.canonical);
+  });
+
+  test("dry-run lists all dirs and planned actions", async () => {
+    const f = fixture();
+    const result = await fixDoubledGithubSessions({ dryRun: true }, {
+      ghqRoot: () => f.ghqRoot,
+      claudeHome: () => f.claudeHome,
+      quarantineRoot: () => f.quarantine,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.pairs).toHaveLength(3);
+    expect(result.pairs.every(p => p.outcome === "planned")).toBe(true);
+    expect(result.checks[0]!.message).toContain("dry-run");
+    expect(result.checks[0]!.message).toContain("remap=1");
+    expect(result.checks[0]!.message).toContain("clone+remap=1");
+    expect(result.checks[0]!.message).toContain("cleanup-only=1");
+  });
+
+  test("apply uses staged claude-path-migrate, --check, rsync --ignore-existing, and mv quarantine", async () => {
+    const f = fixture();
+    const calls: Array<[string, string[]]> = [];
+    const moved: string[][] = [];
+    const deps: FixSessionsDeps = {
+      ghqRoot: () => f.ghqRoot,
+      claudeHome: () => f.claudeHome,
+      quarantineRoot: () => f.quarantine,
+      execFile: async (file, args) => { calls.push([file, args]); },
+      copyDir: async () => {},
+      moveDir: async (from, to) => { moved.push(["mv", from, to]); },
+    };
+
+    const result = await fixDoubledGithubSessions({ dryRun: false }, deps);
+
+    expect(result.ok).toBe(true);
+    expect(calls.some(([file, args]) => file === "ghq" && args.join(" ") === "get -u github.com/Org/needs-clone")).toBe(true);
+    const migrateCalls = calls.filter(([file]) => file === "claude-path-migrate");
+    expect(migrateCalls.length).toBe(4);
+    expect(migrateCalls.some(([, args]) => args.includes("--check"))).toBe(true);
+    expect(calls.some(([file, args]) => file === "rsync" && args.includes("-a") && args.includes("--ignore-existing"))).toBe(true);
+    expect(moved).toHaveLength(3);
+    expect(moved.every(([cmd]) => cmd === "mv")).toBe(true);
+  });
+
+  test("--json emits top-level pairs for external map pipelines", async () => {
+    const f = fixture();
+    process.env.GHQ_ROOT = f.ghqRoot;
+    process.env.CLAUDE_HOME = f.claudeHome;
+    process.env.HOME = f.root;
+    resetGhqRootCache();
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...a: any[]) => logs.push(a.map(String).join(" "));
+    try {
+      await cmdDoctor(["--fix-sessions", "--dry-run", "--json"]);
+    } finally {
+      console.log = origLog;
+    }
+    const payload = JSON.parse(logs.join("\n"));
+    expect(payload.ok).toBe(true);
+    expect(payload.dryRun).toBe(true);
+    expect(payload.pairs).toHaveLength(3);
+    expect(payload.pairs.map((p: any) => p.action).sort()).toEqual(["cleanup-only", "clone+remap", "remap"]);
+    expect(payload.pairs[0]).toHaveProperty("doubled");
+    expect(payload.pairs[0]).toHaveProperty("canonical");
+  });
+});

--- a/test/isolated/plugin-doctor-standalone.test.ts
+++ b/test/isolated/plugin-doctor-standalone.test.ts
@@ -2,6 +2,7 @@ import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "b
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
 const realSdk = await import("../../src/sdk/index.ts");
 afterAll(() => { mock.restore(); });
 
@@ -38,6 +39,7 @@ const sdkMock = {
   mawDataPath: (...parts: string[]) => tmpPath("data", ...parts),
   mawStateDir: () => tmpPath("state"),
   mawStatePath: (...parts: string[]) => tmpPath("state", ...parts),
+  getGhqRoot: () => tmpPath("ghq"),
 };
 
 mock.module("maw-js/sdk", () => ({ ...realSdk, ...sdkMock }));
@@ -54,25 +56,6 @@ mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/doctor/internal/bu
 
 const { command, default: doctorHandler } = await import("../../src/vendor/mpr-plugins/doctor/index.ts?plugin-doctor-standalone");
 const peersStore = await import("../../src/vendor/mpr-plugins/doctor/internal/peers-store.ts?plugin-doctor-standalone");
-
-function walkSources(dir: string): string[] {
-  const { readdirSync } = require("node:fs");
-  const out: string[] = [];
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    const full = join(dir, entry.name);
-    if (entry.isDirectory()) out.push(...walkSources(full));
-    else if (entry.name.endsWith(".ts")) out.push(full);
-  }
-  return out;
-}
-
-function importSpecs(source: string): string[] {
-  const specs = new Set<string>();
-  const re = /\b(?:import|export)\s+(?:[^"'`]+?\s+from\s+)?["']([^"']+)["']|\bimport\(\s*["']([^"']+)["']\s*\)/g;
-  let match: RegExpExecArray | null;
-  while ((match = re.exec(source))) specs.add(match[1] ?? match[2]);
-  return [...specs];
-}
 
 function stripAnsi(value: string | undefined) {
   return String(value ?? "").replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "");
@@ -99,23 +82,13 @@ afterEach(() => {
 
 describe("doctor plugin standalone boundary (#2328)", () => {
   test("all doctor sources use SDK or local/platform imports only", () => {
-    const imports = walkSources(doctorDir).flatMap((file) => importSpecs(readFileSync(file, "utf8")));
-    const forbidden = imports.filter((spec) =>
-      spec.startsWith("maw-js/core/")
-      || spec.startsWith("maw-js/commands/shared/")
-      || spec.startsWith("maw-js/lib/")
-      || spec.startsWith("maw-js/config")
-      || spec.startsWith("maw-js/plugin")
-      || spec.includes("../../../core")
-      || spec.includes("../../../../core"),
-    );
+    const imports = expectStandalonePluginBoundary({ plugin: "doctor", root });
 
     expect(command).toMatchObject({ name: "doctor" });
-    expect(forbidden).toEqual([]);
-    expect(imports).toContain("maw-js/sdk");
+    expect(imports.map((record) => record.spec)).toContain("maw-js/sdk");
 
     const sdk = readFileSync(join(root, "src/sdk/index.ts"), "utf8");
-    for (const symbol of ["C", "loadConfig", "loadManifestCached", "invalidateManifest", "mawStatePath", "isMawXdgEnabled", "mawCacheDir"]) {
+    for (const symbol of ["C", "loadConfig", "loadManifestCached", "invalidateManifest", "mawStatePath", "isMawXdgEnabled", "mawCacheDir", "getGhqRoot"]) {
       expect(sdk).toContain(symbol);
     }
   });

--- a/test/isolated/plugin-doctor-standalone.test.ts
+++ b/test/isolated/plugin-doctor-standalone.test.ts
@@ -39,7 +39,6 @@ const sdkMock = {
   mawDataPath: (...parts: string[]) => tmpPath("data", ...parts),
   mawStateDir: () => tmpPath("state"),
   mawStatePath: (...parts: string[]) => tmpPath("state", ...parts),
-  getGhqRoot: () => tmpPath("ghq"),
 };
 
 mock.module("maw-js/sdk", () => ({ ...realSdk, ...sdkMock }));
@@ -88,7 +87,7 @@ describe("doctor plugin standalone boundary (#2328)", () => {
     expect(imports.map((record) => record.spec)).toContain("maw-js/sdk");
 
     const sdk = readFileSync(join(root, "src/sdk/index.ts"), "utf8");
-    for (const symbol of ["C", "loadConfig", "loadManifestCached", "invalidateManifest", "mawStatePath", "isMawXdgEnabled", "mawCacheDir", "getGhqRoot"]) {
+    for (const symbol of ["C", "loadConfig", "loadManifestCached", "invalidateManifest", "mawStatePath", "isMawXdgEnabled", "mawCacheDir"]) {
       expect(sdk).toContain(symbol);
     }
   });


### PR DESCRIPTION
## Summary
- add `maw doctor --fix-sessions` with dry-run and JSON pair output for doubled `github.com/github.com` repos
- stage Claude session remaps through `claude-path-migrate --map`, verify with `--check`, and merge into canonical session dirs via `rsync -a --ignore-existing`
- quarantine doubled repo dirs with `mv`-style move targets under `/tmp` instead of deleting anything

## Tests
- `bun test test/isolated/doctor-fix-sessions.test.ts`
- `bun test test/fleet-doctor.test.ts test/isolated/doctor-fix-sessions.test.ts`
- `bun run build`
- `bun src/cli.ts doctor --fix-sessions --dry-run --json`
- `bun src/cli.ts doctor --fix-sessions --dry-run`

Closes #2597
