### PR TITLE
Add wake session mode for work repos

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -169,13 +169,14 @@ function printBringUsage(write: (line: string) => void = console.log): void {
 }
 
 function printWakeAliasUsage(verb: "wake" | "awake", write: (line: string) => void = console.log): void {
-  write(`usage: maw ${verb} <oracle> [--session <tmux-session>] [--task <s>] [--wt <s>] [--layout nested|legacy] [--bud] [--signal-on-birth] [-p|--prompt <s>] [--incubate <slug>] [--fresh|--new] [--pick] [--name <s>] [-a|--attach] [--list] [--dry-run] [--from-snapshot|--snapshot <id>] [--main|--solo|--no-rehydrate] [--no-fleet] [--split] [--parent-session-id <id>] [--session-id <id>] [--all-local] [-e|--engine <name>]`);
+  write(`usage: maw ${verb} <oracle> [--work|--oracle] [--session <tmux-session>] [--task <s>] [--wt <s>] [--layout nested|legacy] [--bud] [--signal-on-birth] [-p|--prompt <s>] [--incubate <slug>] [--fresh|--new] [--pick] [--name <s>] [-a|--attach] [--list] [--dry-run] [--from-snapshot|--snapshot <id>] [--main|--solo|--no-rehydrate] [--no-fleet] [--split] [--parent-session-id <id>] [--session-id <id>] [--all-local] [-e|--engine <name>]`);
   if (verb === "awake") {
     write("  Launch/start an oracle process with the selected engine. Does not send /awaken.");
     write("  Use `maw awaken` for the awakening ritual; use `maw new` for a plain workspace session.");
   } else {
     write("  Wake or reuse an oracle session, fuzzy-resolving repos and worktrees as needed.");
   }
+  write("  --work/--oracle overrides suffix-based mode detection; work mode uses repo identity and keeps ψ/ local.");
   write("  --session targets an existing foreign workspace session instead of the oracle's own session.");
   write("  --fresh/--new forces a new numbered worktree slot; default prefers a stable reusable slot.");
   write("  --layout selects new worktree filesystem layout: nested (default repo/agents/N-X) or legacy (.wt-N-X).");
@@ -438,6 +439,8 @@ export async function invokeDirectHandler(
       "--all-local": Boolean,
       "--engine": String, "-e": "--engine",
       "--parent": String,
+      "--work": Boolean,
+      "--oracle": Boolean,
       "--parent-session-id": String,
       "--session-id": String,
     }, 0);
@@ -475,7 +478,11 @@ export async function invokeDirectHandler(
       fromSnapshot?: boolean;
       snapshotId?: string;
       layout?: "nested" | "legacy";
+      sessionMode?: "oracle" | "work";
     } = {};
+    if (flags["--work"] && flags["--oracle"]) throw new UserError("wake: choose only one of --work or --oracle");
+    if (flags["--work"]) opts.sessionMode = "work";
+    if (flags["--oracle"]) opts.sessionMode = "oracle";
     if (flags["--task"]) opts.task = flags["--task"];
     if (flags["--wt"]) opts.wt = flags["--wt"];
     if (flags["--layout"]) {

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -1,5 +1,7 @@
 import { hostExec, tmux, restoreTabOrder, takeSnapshot, getPaneInfos, isAgentCommand } from "../../sdk";
 import { resolve } from "path";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
 import { ghqFind } from "../../core/ghq";
 import { buildCommandInDir, cfgTimeout, loadConfig, saveConfig } from "../../config";
 import { defaultEngineNameForConfig } from "../../config/engine-registry";
@@ -313,6 +315,81 @@ export async function getLiveTileRoles(
   }
 }
 
+
+export type WakeSessionMode = "oracle" | "work";
+
+export class WakeSession {
+  readonly mode: WakeSessionMode;
+
+  constructor(mode: WakeSessionMode) {
+    this.mode = mode;
+    Object.freeze(this);
+  }
+}
+
+function repoNameFromPath(repoPath: string): string {
+  return repoPath.split("/").filter(Boolean).pop() ?? repoPath;
+}
+
+function stripGitSuffix(name: string): string {
+  return name.replace(/\.git$/i, "");
+}
+
+function repoNameFromTarget(target: string, urlRepoName?: string): string {
+  if (urlRepoName?.trim()) return stripGitSuffix(urlRepoName.trim());
+  const cleaned = stripGitSuffix(target.trim().replace(/\/+$/, ""));
+  return cleaned.split("/").filter(Boolean).pop() ?? cleaned;
+}
+
+function detectWakeSessionMode(target: string, opts: Pick<WakeOptions, "sessionMode" | "urlRepoName" | "repoPath">): WakeSession {
+  if (opts.sessionMode) return new WakeSession(opts.sessionMode);
+  if (/^\d+-/.test(target.trim())) return new WakeSession("oracle");
+  const repoName = opts.repoPath ? repoNameFromPath(opts.repoPath) : repoNameFromTarget(target, opts.urlRepoName);
+  if (repoName.toLowerCase().endsWith("-oracle")) return new WakeSession("oracle");
+  return new WakeSession(opts.repoPath || opts.urlRepoName ? "work" : "oracle");
+}
+
+function identityForWakeSession(session: WakeSession, repoName: string, currentIdentity: string): string {
+  if (session.mode === "work") return repoName;
+  return repoName.toLowerCase().endsWith("-oracle") ? repoName.replace(/-oracle$/i, "") : currentIdentity;
+}
+
+function mainWindowNameForWakeSession(session: WakeSession, identity: string): string {
+  return session.mode === "oracle" ? `${identity}-oracle` : identity;
+}
+
+async function resolveWorkRepository(target: string, parsedRepoPath: string | null, opts: Pick<WakeOptions, "repoPath" | "urlRepoName">): Promise<{ repoPath: string; repoName: string; parentDir: string }> {
+  if (opts.repoPath) {
+    const repoPath = opts.repoPath;
+    return { repoPath, repoName: repoNameFromPath(repoPath), parentDir: repoPath.replace(/\/[^/]+$/, "") };
+  }
+  if (parsedRepoPath) {
+    const repoPath = parsedRepoPath;
+    return { repoPath, repoName: repoNameFromPath(repoPath), parentDir: repoPath.replace(/\/[^/]+$/, "") };
+  }
+
+  const repoName = repoNameFromTarget(target, opts.urlRepoName);
+  const repoPath = await ghqFind(`/${repoName}`);
+  if (repoPath) {
+    return { repoPath, repoName: repoNameFromPath(repoPath), parentDir: repoPath.replace(/\/[^/]+$/, "") };
+  }
+
+  throw new UserError(`work repo not found: ${repoName} (try: ghq get <url> OR maw wake ${target} --oracle for oracle mode)`);
+}
+
+function ensureWakeSessionVault(session: WakeSession, repoPath: string): void {
+  if (session.mode !== "work") return;
+  const psiDir = join(repoPath, "ψ");
+  mkdirSync(psiDir, { recursive: true });
+
+  const gitignorePath = join(repoPath, ".gitignore");
+  const existing = existsSync(gitignorePath) ? readFileSync(gitignorePath, "utf-8") : "";
+  const lines = existing.split(/\r?\n/);
+  if (lines.some(line => line.trim() === "ψ/" || line.trim() === "ψ")) return;
+  const prefix = existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
+  writeFileSync(gitignorePath, `${existing}${prefix}ψ/\n`, "utf-8");
+}
+
 export interface WakeOptions {
   task?: string;
   wt?: string;
@@ -356,6 +433,8 @@ export interface WakeOptions {
   layout?: WorktreeLayout;
   /** Force Discord channel launch for Claude-like engines (#1999). */
   channels?: boolean;
+  /** Explicit wake session mode override. Auto mode infers from the resolved repo suffix. */
+  sessionMode?: WakeSessionMode;
 }
 
 function isAttachOnlyWake(opts: WakeOptions): boolean {
@@ -867,6 +946,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
     oracle = derived;
   }
 
+  const requestedTarget = oracle;
   const parsed = parseWakeTarget(oracle);
   let parsedRepoPath: string | null = null;
   if (parsed) {
@@ -875,9 +955,20 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
     // exact cloned/local slug instead of later resolving the bare oracle name
     // through `ghqFind(/repo)`, which can silently pick a different org.
     parsedRepoPath = await ghqFind(`/${parsed.slug}`);
-    oracle = parsed.oracle;
     if (!opts.urlRepoName) opts.urlRepoName = parsed.slug.split("/").pop();
   }
+
+  if (!opts.sessionMode && !parsed && !opts.repoPath && !opts.incubate) {
+    const candidateRepo = repoNameFromTarget(requestedTarget, opts.urlRepoName);
+    const workRepoPath = await ghqFind(`/${candidateRepo}`);
+    if (workRepoPath && !repoNameFromPath(workRepoPath).toLowerCase().endsWith("-oracle")) {
+      parsedRepoPath = workRepoPath;
+      opts = { ...opts, urlRepoName: repoNameFromPath(workRepoPath) };
+    }
+  }
+
+  let sessionContext = detectWakeSessionMode(requestedTarget, opts);
+  oracle = parsed && sessionContext.mode === "oracle" ? parsed.oracle : repoNameFromTarget(requestedTarget, opts.urlRepoName);
 
   // #358 — reject -view suffix at the user-input boundary (before any session work).
   assertValidOracleName(oracle);
@@ -921,7 +1012,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
       console.log(`\x1b[36m→\x1b[0m live tmux session: ${liveAttachSession}`);
       await wakeSession.attachToSession(liveAttachSession);
       await recordWakeSnapshot(opts);
-      const attachWindow = preResolvedFleetSession?.windowName || `${oracle}-oracle`;
+      const attachWindow = preResolvedFleetSession?.windowName || mainWindowNameForWakeSession(sessionContext, oracle);
       return `${liveAttachSession}:${attachWindow}`;
     }
   }
@@ -953,7 +1044,9 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
 
   let resolved: { repoPath: string; repoName: string; parentDir: string };
 
-  if (opts.repoPath) {
+  if (sessionContext.mode === "work") {
+    resolved = await resolveWorkRepository(requestedTarget, parsedRepoPath, opts);
+  } else if (opts.repoPath) {
     // #421 — caller already knows the exact on-disk path (e.g. `maw bud --org`
     // just cloned it). Skip resolveOracle so a stale same-named repo in a
     // different org can't shadow the freshly-created one.
@@ -996,13 +1089,13 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
     throw new Error("--signal-on-birth requires --bud");
   }
 
-  // #997 — when fuzzy match resolved a different repo (e.g. "v3" → "arra-oracle-v3-oracle"),
-  // update oracle to the resolved name so session/window names are correct.
-  const resolvedOracle = repoName.replace(/-oracle$/, "");
-  if (!preResolvedFleetSession && resolvedOracle !== oracle && repoName.endsWith("-oracle")) {
-    oracle = resolvedOracle;
+  // #2598 — Session(mode) owns the identity source. Oracle sessions strip the
+  // repo suffix; work sessions use the repo name verbatim.
+  sessionContext = new WakeSession(sessionContext.mode);
+  const resolvedIdentity = identityForWakeSession(sessionContext, repoName, oracle);
+  if (!preResolvedFleetSession && resolvedIdentity !== oracle) {
+    oracle = resolvedIdentity;
   }
-
   // #673 — extract org/repo slug from ghq path (…/github.com/<org>/<repo>)
   const ghSlug = repoPath.includes("github.com/")
     ? repoPath.slice(repoPath.indexOf("github.com/") + "github.com/".length)
@@ -1071,7 +1164,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
     isLive: Boolean(session),
   });
 
-  const mainWindowName = foreignSession ? oracle : `${oracle}-oracle`;
+  const mainWindowName = foreignSession ? oracle : mainWindowNameForWakeSession(sessionContext, oracle);
   const shouldCreateSession = !session && (wakeDecision.wake || Boolean(foreignSession));
 
   if (opts.dryRun) {
@@ -1133,6 +1226,8 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
     }
     return session ? `${session}:${mainWindowName}` : `${oracle}:dry-run`;
   }
+
+  ensureWakeSessionVault(sessionContext, repoPath);
 
   let knownWindows = new Set<string>();
   let knownWindowEntries: WakeWindowLookupEntry[] = [];

--- a/test/top-aliases-default.test.ts
+++ b/test/top-aliases-default.test.ts
@@ -259,6 +259,7 @@ describe("direct handler invocation", () => {
 
     await invokeDirectHandler("../commands/shared/wake-cmd:cmdWake", [
       "neo",
+      "--work",
       "--task", "fix bug",
       "--wt", "issue-1",
       "--layout", "legacy",
@@ -285,6 +286,7 @@ describe("direct handler invocation", () => {
 
     expect(calls.loadConfig).toBe(1);
     expect(calls.wake).toEqual([["neo", {
+      sessionMode: "work",
       task: "fix bug",
       wt: "issue-1",
       layout: "legacy",
@@ -309,6 +311,14 @@ describe("direct handler invocation", () => {
       allLocal: true,
       engine: "codex",
     }]]);
+  });
+
+
+  test("wake rejects conflicting explicit session modes", async () => {
+    const { deps } = makeDeps();
+
+    await expect(invokeDirectHandler("../commands/shared/wake-cmd:cmdWake", ["neo", "--work", "--oracle"], deps))
+      .rejects.toThrow("choose only one");
   });
 
   test("#1897 wake -a is attach-only and does not set bring/split flags", async () => {

--- a/test/wake-cmd-cmdwake-coverage.test.ts
+++ b/test/wake-cmd-cmdwake-coverage.test.ts
@@ -586,7 +586,7 @@ mock.module(join(import.meta.dir, "../src/commands/shared/fleet-ensure"), () => 
   },
 }));
 
-const { cmdWake, _wtPicker, promptAmbiguousBringPick } = await import("../src/commands/shared/wake-cmd");
+const { cmdWake, _wtPicker, promptAmbiguousBringPick, WakeSession } = await import("../src/commands/shared/wake-cmd");
 const originalWtPickerIsStdoutTTY = _wtPicker.isStdoutTTY;
 const originalWtPickerReadChoice = _wtPicker.readChoice;
 
@@ -666,6 +666,48 @@ afterEach(() => {
 });
 
 describe("cmdWake main-suite coverage", () => {
+  test("#2598 WakeSession mode is immutable", () => {
+    const session = new WakeSession("work");
+    expect(session.mode).toBe("work");
+    expect(Object.isFrozen(session)).toBe(true);
+  });
+
+  test("#2598 work mode uses repo identity and keeps ψ local/gitignored", async () => {
+    repoName = "maw-js";
+    repoPath = join(parentDir, repoName);
+    mkdirSync(repoPath, { recursive: true });
+    sessions = [];
+    hasSessions = new Set();
+    detectSessionReturn = null;
+    shouldWakeDecision = { wake: true, reason: "missing" };
+
+    const { result } = await captureLogs(() =>
+      cmdWake("maw-js", { repoPath, sessionMode: "work", noRehydrate: true }),
+    );
+
+    expect(result).toBe("01-maw-js:maw-js");
+    expect(newSessionCalls).toEqual([{ name: "01-maw-js", opts: { window: "maw-js", cwd: repoPath } }]);
+    expect(sendTextCalls[0]?.target).toBe("01-maw-js:maw-js");
+    expect(existsSync(join(repoPath, "ψ"))).toBe(true);
+    expect(readFileSync(join(repoPath, ".gitignore"), "utf-8")).toContain("ψ/\n");
+  });
+
+  test("#2598 explicit oracle override wins over non-oracle repo detection", async () => {
+    ghqFindReturn = join(parentDir, "maw-js");
+    sessions = [];
+    hasSessions = new Set();
+    detectSessionReturn = null;
+    shouldWakeDecision = { wake: true, reason: "missing" };
+
+    const { result } = await captureLogs(() =>
+      cmdWake("maw-js", { sessionMode: "oracle", dryRun: true, noRehydrate: true }),
+    );
+
+    expect(result).toBe("mawjs:dry-run");
+    expect(newSessionCalls).toHaveLength(0);
+    expect(existsSync(join(repoPath, ".gitignore"))).toBe(false);
+  });
+
   test("#1816 bring picker handles headless, empty, quit, invalid, and success choices", () => {
     const candidate = { name: "mawjs-features", target: "54-mawjs:mawjs-features", detail: "tmux window" };
 


### PR DESCRIPTION
Closes #2598

## Summary
- add immutable wake `Session(mode)` context for `oracle` vs `work`
- support suffix auto-detection plus explicit `--work` / `--oracle` overrides
- keep divergence limited to identity source and work-mode local `ψ/` gitignore persistence

## Tests
- MAW_TEST_MODE=1 bun test test/top-aliases-default.test.ts test/wake-cmd-cmdwake-coverage.test.ts
- bun run build
- MAW_TEST_MODE=1 bun run test:default:safe
- git diff --check