### PR TITLE
fix(config): preserve limits dot-path config

### DIFF
--- a/src/commands/plugins/config/index.ts
+++ b/src/commands/plugins/config/index.ts
@@ -1,5 +1,5 @@
 import type { InvokeContext, InvokeResult } from "../../../plugin/types";
-import { loadConfigWithProvenance } from "../../../config";
+import { loadConfigWithProvenance, saveConfig } from "../../../config";
 
 export const command = {
   name: "config",
@@ -10,6 +10,61 @@ function valueAtPath(root: unknown, keyPath: string): unknown {
   return keyPath.split(".").reduce((node: any, key) => node?.[key], root as any);
 }
 
+type ConfigProvenanceEntry = {
+  path: string;
+  weight: number;
+  scope: string;
+  isLocal: boolean;
+  action: string;
+  value: unknown;
+};
+
+function provenanceAtPath(provenance: Record<string, unknown>, keyPath: string): ConfigProvenanceEntry[] {
+  const direct = provenance[keyPath];
+  if (Array.isArray(direct)) return direct as ConfigProvenanceEntry[];
+  const parts = keyPath.split(".");
+  while (parts.length > 1) {
+    parts.pop();
+    const parent = provenance[parts.join(".")];
+    if (Array.isArray(parent)) return parent as ConfigProvenanceEntry[];
+  }
+  return [];
+}
+
+function parseConfigValue(raw: string): unknown {
+  const trimmed = raw.trim();
+  if (trimmed === "true") return true;
+  if (trimmed === "false") return false;
+  if (trimmed === "null") return null;
+  if (/^-?(?:0|[1-9]\d*)(?:\.\d+)?$/.test(trimmed)) return Number(trimmed);
+  if ((trimmed.startsWith("{") && trimmed.endsWith("}")) || (trimmed.startsWith("[") && trimmed.endsWith("]"))) {
+    try { return JSON.parse(trimmed); } catch { /* keep as string */ }
+  }
+  return raw;
+}
+
+function objectPatchAtPath(keyPath: string, value: unknown, base: unknown): Record<string, unknown> {
+  const parts = keyPath.split(".").filter(Boolean);
+  if (parts.length === 0) return {};
+  const root: Record<string, unknown> = {};
+  let cursor = root;
+  let baseCursor: any = base;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const part = parts[i]!;
+    const existing = baseCursor?.[part];
+    const next: Record<string, unknown> = isPlainObject(existing) ? { ...existing } : {};
+    cursor[part] = next;
+    cursor = next;
+    baseCursor = existing;
+  }
+  cursor[parts.at(-1)!] = value;
+  return root;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
   const logs: string[] = [];
   const writer = ctx.writer ?? ((...args: unknown[]) => logs.push(args.map(String).join(" ")));
@@ -17,6 +72,18 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
   const sub = args[0] ?? "show";
   const json = args.includes("--json");
   const loaded = loadConfigWithProvenance({ cwd: process.cwd() });
+
+  if (sub === "set") {
+    const key = args[1];
+    const rawValue = args[2];
+    if (!key || rawValue === undefined || key.startsWith("-")) return { ok: false, error: "usage: maw config set <key> <value>" };
+    const patch = objectPatchAtPath(key, parseConfigValue(rawValue), loaded.config);
+    const saved = saveConfig(patch as any);
+    const finalValue = valueAtPath(saved, key);
+    if (json) writer(JSON.stringify({ key, value: finalValue }, null, 2));
+    else writer(`${key} = ${JSON.stringify(finalValue)}`);
+    return { ok: true, output: logs.join("\n") || undefined };
+  }
 
   if (sub === "show") {
     writer(JSON.stringify(loaded.config, null, 2));
@@ -41,7 +108,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
   if (sub === "explain") {
     const key = args.find((arg, index) => index > 0 && !arg.startsWith("-"));
     if (!key) return { ok: false, error: "usage: maw config explain <key> [--json]" };
-    const entries = loaded.provenance[key] ?? [];
+    const entries = provenanceAtPath(loaded.provenance, key);
     const finalValue = valueAtPath(loaded.config, key);
     if (json) writer(JSON.stringify({ key, finalValue, entries }, null, 2));
     else {
@@ -55,5 +122,5 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     return { ok: true, output: logs.join("\n") || undefined };
   }
 
-  return { ok: false, error: "usage: maw config <show|sources|explain <key>> [--json]" };
+  return { ok: false, error: "usage: maw config <show|sources|explain <key>|set <key> <value>> [--json]" };
 }

--- a/src/commands/plugins/config/plugin.ts
+++ b/src/commands/plugins/config/plugin.ts
@@ -9,7 +9,7 @@ export default definePlugin({
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "config",
-    "help": "maw config <show|sources|explain <key>> [--json] — inspect merged config and config layer provenance"
+    "help": "maw config <show|sources|explain <key>|set <key> <value>> [--json] — inspect or update merged config and config layer provenance"
   },
   "weight": 10,
   "tier": "standard"

--- a/src/commands/shared/wake-concurrency.ts
+++ b/src/commands/shared/wake-concurrency.ts
@@ -58,7 +58,7 @@ export function checkCapacity(
       `agent concurrency cap reached: ${liveAgents}/${cap} agents already live — ` +
       `refusing to spawn '${spawning}'.\n\n` +
       `Config: ${sourceLine}\n\n` +
-      `Fix: Raise limits.maxConcurrentAgents in your maw config ` +
+      `Fix: maw config set limits.maxConcurrentAgents ${Math.max(cap + 1, liveAgents + 1)} ` +
       `or sleep an idle agent first (maw sleep <agent>).`,
     );
   }
@@ -136,7 +136,7 @@ export async function assertAgentCapacity(spawning: string): Promise<void> {
       `Active agents:\n${table}\n\n` +
       `Config: ${sourceLine}\n\n` +
       `Fix: maw sleep <name>  — free a slot by sleeping an idle agent\n` +
-      `     Set limits.maxConcurrentAgents in your maw config to raise the cap`,
+      `     maw config set limits.maxConcurrentAgents ${Math.max(cap + 1, agents.length + 1)}`,
     );
   }
 }

--- a/src/config/validate-ext.ts
+++ b/src/config/validate-ext.ts
@@ -112,6 +112,24 @@ function validateExtFields(
     if (Object.keys(discovery).length > 0) result.discovery = discovery;
   }
 
+  // limits: Record<string, number >= 0>. Keep the object generic so new typed
+  // limits can be introduced without a validator whitelist update (#2602).
+  if ("limits" in raw) {
+    if (raw.limits && typeof raw.limits === "object" && !Array.isArray(raw.limits)) {
+      const limits: Record<string, number> = {};
+      for (const [key, value] of Object.entries(raw.limits as Record<string, unknown>)) {
+        if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+          limits[key] = value;
+        } else {
+          warn(`limits.${key}`, "must be a number >= 0");
+        }
+      }
+      if (Object.keys(limits).length > 0) result.limits = limits;
+    } else {
+      warn("limits", "must be an object");
+    }
+  }
+
   // pluginSources: string[] of URLs
   if ("pluginSources" in raw) {
     if (Array.isArray(raw.pluginSources)) {

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -191,6 +191,16 @@ export function validateConfigShape(config: unknown): string[] {
     }
   }
 
+  if (c.limits !== undefined) {
+    if (!c.limits || typeof c.limits !== "object" || Array.isArray(c.limits)) {
+      errors.push("limits must be a Record<string, number>");
+    } else {
+      for (const [k, v] of Object.entries(c.limits as Record<string, unknown>)) {
+        if (typeof v !== "number" || !Number.isFinite(v) || v < 0) errors.push(`limits.${k} must be a number >= 0`);
+      }
+    }
+  }
+
   if (c.sessions !== undefined) {
     if (!c.sessions || typeof c.sessions !== "object" || Array.isArray(c.sessions)) {
       errors.push("sessions must be a Record<string, string>");

--- a/test/isolated/config-limits-2602.test.ts
+++ b/test/isolated/config-limits-2602.test.ts
@@ -1,0 +1,51 @@
+/** @maw-test-isolate */
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const originalConfigDir = process.env.MAW_CONFIG_DIR;
+const originalTestMode = process.env.MAW_TEST_MODE;
+const configDir = mkdtempSync(join(tmpdir(), "maw-config-limits-2602-"));
+process.env.MAW_CONFIG_DIR = configDir;
+process.env.MAW_TEST_MODE = "1";
+mkdirSync(configDir, { recursive: true });
+writeFileSync(join(configDir, "maw.config.50.json"), JSON.stringify({
+  limits: {
+    maxConcurrentAgents: 20,
+    feedMax: 123,
+  },
+}, null, 2));
+
+const config = await import(`../../src/config/load.ts?limits2602=${Date.now()}`);
+const validate = await import(`../../src/config/validate-ext.ts?limits2602=${Date.now()}`);
+
+afterAll(() => {
+  if (originalConfigDir === undefined) delete process.env.MAW_CONFIG_DIR;
+  else process.env.MAW_CONFIG_DIR = originalConfigDir;
+  if (originalTestMode === undefined) delete process.env.MAW_TEST_MODE;
+  else process.env.MAW_TEST_MODE = originalTestMode;
+  rmSync(configDir, { recursive: true, force: true });
+});
+
+describe("config limits validation (#2602)", () => {
+  test("limits.maxConcurrentAgents survives config load and provenance", () => {
+    config.resetConfig();
+    const loaded = config.loadConfigWithProvenance();
+
+    expect(loaded.config.limits?.maxConcurrentAgents).toBe(20);
+    expect(loaded.config.limits?.feedMax).toBe(123);
+    expect(config.cfgLimit("maxConcurrentAgents")).toBe(20);
+    expect(loaded.provenance["limits.maxConcurrentAgents"]?.at(-1)).toMatchObject({
+      path: join(configDir, "maw.config.50.json"),
+      value: 20,
+      action: "set",
+    });
+  });
+
+  test("limits validator keeps non-negative numbers and drops invalid entries", () => {
+    const sanitized = validate.validateConfig({ limits: { maxConcurrentAgents: 0, bad: -1, nope: "10" } });
+
+    expect(sanitized.limits).toEqual({ maxConcurrentAgents: 0 });
+  });
+});

--- a/test/isolated/plugin-config-standalone.test.ts
+++ b/test/isolated/plugin-config-standalone.test.ts
@@ -20,6 +20,9 @@ const loadedConfig = {
     teams: {
       default: ["a", "b"],
     },
+    limits: {
+      maxConcurrentAgents: 20,
+    },
   },
   sources: [
     {
@@ -42,6 +45,26 @@ const loadedConfig = {
     },
   ],
   provenance: {
+    "limits": [
+      {
+        path: "/etc/maw/core.config.json",
+        weight: 10,
+        isLocal: false,
+        scope: "core",
+        action: "set",
+        value: { maxConcurrentAgents: 10 },
+      },
+    ],
+    "limits.maxConcurrentAgents": [
+      {
+        path: "/cwd/maw.config.json",
+        weight: 0,
+        isLocal: true,
+        scope: "project",
+        action: "set",
+        value: 20,
+      },
+    ],
     "teams.default": [
       {
         path: "/etc/maw/core.config.json",
@@ -66,9 +89,14 @@ const loadedConfig = {
 
 let loadCallCount = 0;
 let lastLoadOptions: unknown;
+let savedPatch: unknown;
 
 mock.module(import.meta.resolve("../../src/config.ts"), () => ({
   ...mockConfigModule(() => loadedConfig.config as any),
+  saveConfig: (patch: unknown) => {
+    savedPatch = patch;
+    return { ...loadedConfig.config, limits: { maxConcurrentAgents: 25 } };
+  },
   loadConfigWithProvenance: (opts?: unknown) => {
     loadCallCount += 1;
     lastLoadOptions = opts;
@@ -90,6 +118,7 @@ describe("src/commands/plugins/config/index.ts", () => {
   beforeEach(() => {
     loadCallCount = 0;
     lastLoadOptions = undefined;
+    savedPatch = undefined;
   });
 
   test("exports metadata", () => {
@@ -135,6 +164,15 @@ describe("src/commands/plugins/config/index.ts", () => {
     });
   });
 
+  test("set accepts dot-path nested keys and numeric values", async () => {
+    const logs: string[] = [];
+    const result = await run(["set", "limits.maxConcurrentAgents", "25", "--json"], (...parts) => logs.push(parts.map(String).join(" ")));
+
+    expect(result.ok).toBe(true);
+    expect(savedPatch).toEqual({ limits: { maxConcurrentAgents: 25 } });
+    expect(JSON.parse(logs.join("\n"))).toEqual({ key: "limits.maxConcurrentAgents", value: 25 });
+  });
+
   test("explain returns provenance and final value", async () => {
     const logs: string[] = [];
     const result = await run(
@@ -148,6 +186,19 @@ describe("src/commands/plugins/config/index.ts", () => {
       key: "teams.default",
       finalValue: ["a", "b"],
       entries: loadedConfig.provenance["teams.default"],
+    });
+  });
+
+  test("explain resolves nested limits final value and provenance", async () => {
+    const logs: string[] = [];
+    const result = await run(["explain", "limits.maxConcurrentAgents", "--json"], (...parts) => logs.push(parts.map(String).join(" ")));
+
+    const payload = JSON.parse(logs.join("\n"));
+    expect(result.ok).toBe(true);
+    expect(payload).toEqual({
+      key: "limits.maxConcurrentAgents",
+      finalValue: 20,
+      entries: loadedConfig.provenance["limits.maxConcurrentAgents"],
     });
   });
 
@@ -165,7 +216,7 @@ describe("src/commands/plugins/config/index.ts", () => {
 
     expect(result).toEqual({
       ok: false,
-      error: "usage: maw config <show|sources|explain <key>> [--json]",
+      error: "usage: maw config <show|sources|explain <key>|set <key> <value>> [--json]",
     });
   });
 });

--- a/test/isolated/wake-concurrency.test.ts
+++ b/test/isolated/wake-concurrency.test.ts
@@ -88,8 +88,8 @@ describe("checkCapacity — pure cap decision (#2)", () => {
     expect(() => checkCapacity(8, 5, "pulse")).toThrow(/8\/5/);
   });
 
-  test("error message is actionable — names the config knob", () => {
-    expect(() => checkCapacity(5, 5, "neo")).toThrow(/maxConcurrentAgents/);
+  test("error message is actionable — names the config set command", () => {
+    expect(() => checkCapacity(5, 5, "neo")).toThrow(/maw config set limits\.maxConcurrentAgents 6/);
   });
 
   test("error message can include the exact config source line", () => {
@@ -157,6 +157,7 @@ describe("assertAgentCapacity — the guard cmdWake calls before spawning", () =
 
     await expect(assertAgentCapacity("neo")).rejects.toThrow(/concurrency cap reached: 3\/2/);
     await expect(assertAgentCapacity("neo")).rejects.toThrow(/Config: limits\.maxConcurrentAgents: 2 from \/tmp\/maw\/maw\.config\.90\.local\.json/);
+    await expect(assertAgentCapacity("neo")).rejects.toThrow(/maw config set limits\.maxConcurrentAgents 4/);
   });
 
   test("exactly at cap → rejects (cap is inclusive)", async () => {


### PR DESCRIPTION
## Summary
- Preserve `limits.*` through config validation with non-negative number checks.
- Add nested `maw config set <dot.path> <value>` support and nested `config explain` final-value/provenance lookup.
- Make maxConcurrentAgents cap errors point at the exact `maw config set limits.maxConcurrentAgents ...` fix command.

Closes #2602

## Tests
- `bash scripts/test-isolated.sh test/isolated/config-limits-2602.test.ts test/isolated/plugin-config-standalone.test.ts test/isolated/wake-concurrency.test.ts`
- `bun run build`
- `bun run test:default:safe`
- `MAW_CONFIG_DIR=<tmp> bun src/cli.ts config set/explain limits.maxConcurrentAgents`
