### PR TITLE
Add selective wake agent rehydration

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -548,16 +548,55 @@ function logAgentsRehydrationSource(count: number, worktrees: { path: string }[]
   console.log(`\x1b[90m↻ agents/ rehydrate: none from ${source}\x1b[0m`);
 }
 
-function shouldSkipAgentsRehydrationPrompt(plan: RehydrateWorktreePlan[]): boolean {
-  if (plan.length === 0 || !_wtPicker.isStdoutTTY()) return false;
-  console.log(`\x1b[36m↻\x1b[0m found ${plan.length} saved agent window${plan.length === 1 ? "" : "s"}:`);
+export function parseRehydrationSelection(input: string, count: number): number[] {
+  const selected = new Set<number>();
+  for (const rawPart of input.split(",")) {
+    const part = rawPart.trim();
+    if (!part) continue;
+    const range = part.match(/^(\d+)\s*-\s*(\d+)$/);
+    if (range) {
+      const start = Number(range[1]);
+      const end = Number(range[2]);
+      if (!Number.isSafeInteger(start) || !Number.isSafeInteger(end)) continue;
+      const lo = Math.min(start, end);
+      const hi = Math.max(start, end);
+      for (let index = lo; index <= hi; index++) {
+        if (index >= 1 && index <= count) selected.add(index - 1);
+      }
+      continue;
+    }
+    if (/^\d+$/.test(part)) {
+      const index = Number(part);
+      if (index >= 1 && index <= count) selected.add(index - 1);
+    }
+  }
+  return [...selected].sort((a, b) => a - b);
+}
+
+function selectAgentsRehydrationPlan(plan: RehydrateWorktreePlan[]): RehydrateWorktreePlan[] {
+  if (plan.length === 0 || !_wtPicker.isStdoutTTY()) return plan;
+  console.log(`[36m↻[0m found ${plan.length} saved agent window${plan.length === 1 ? "" : "s"}:`);
   for (const wt of plan) {
-    console.log(`  \x1b[90m${wt.windowName.padEnd(40)} ${formatWorktreeSource(wt.path)}\x1b[0m`);
+    console.log(`  [90m${wt.windowName.padEnd(40)} ${formatWorktreeSource(wt.path)}[0m`);
   }
   console.log("");
-  process.stdout.write(`  Rehydrate all? [Y/n] `);
-  const answer = _wtPicker.readChoice();
-  return !!answer && /^n/i.test(answer);
+  process.stdout.write(`  Rehydrate? [Y]es all / [n]one / [s]elect: `);
+  const answer = (_wtPicker.readChoice() || "").trim();
+  if (/^n/i.test(answer)) return [];
+  if (!/^s/i.test(answer)) return plan;
+
+  console.log(`[36m↻[0m select saved agent windows:`);
+  plan.forEach((wt, index) => {
+    console.log(`  [36m${index + 1}[0m) ${wt.windowName}  [90m${formatWorktreeSource(wt.path)}[0m`);
+  });
+  process.stdout.write(`  → `);
+  const rawSelection = _wtPicker.readChoice() || "";
+  const selectedIndices = parseRehydrationSelection(rawSelection, plan.length);
+  const selectedPlan = selectedIndices.map(index => plan[index]!).filter(Boolean);
+  if (selectedPlan.length > 0) {
+    console.log(`[32m✓[0m rehydrating: ${selectedPlan.map(wt => wt.windowName).join(", ")}`);
+  }
+  return selectedPlan;
 }
 
 async function restoreSnapshotWindows(
@@ -1297,24 +1336,22 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
       const rehydratableWt = await filterMergedWorktreesForRehydrate(allWt, { hostExec, baseBranch: "alpha" });
       const plan = planRehydrateWorktreeWindows(oracle, rehydratableWt, [...existingWindows]);
       logAgentsRehydrationSource(plan.length, allWt);
-      const skipRehydrate = shouldSkipAgentsRehydrationPrompt(plan);
-      if (skipRehydrate) {
+      const selectedPlan = selectAgentsRehydrationPlan(plan);
+      if (plan.length > 0 && selectedPlan.length === 0) {
         console.log(`\x1b[33m⚡\x1b[0m skipped agent rehydration`);
-      } else if (plan.length > 0) {
+      } else if (selectedPlan.length > 0) {
         console.log(`\x1b[36m↻\x1b[0m rehydrating from agents/ folder:`);
       }
-      if (!skipRehydrate) {
-        for (const wt of plan) {
-          await tmux.newWindow(session, wt.windowName, { cwd: wt.path });
-          await new Promise(r => setTimeout(r, 300));
-          const wtEngine = wakeSession.readWorktreeEngineFile(wt.path);
-          const wtOpts = wtEngine ? { ...opts, engine: wtEngine } : opts;
-          const target = `${session}:${wt.windowName}`;
-          await tmux.sendText(target, await buildWakeCommandForPane(wt.windowName, wt.path, wtOpts, target));
-          await wakeSession.waitForEngine(target, getPaneInfos, isAgentCommand);
-          existingWindows.add(wt.windowName);
-          console.log(`\x1b[32m+\x1b[0m window: ${wt.windowName}  \x1b[90m(from ${formatWorktreeSource(wt.path)})\x1b[0m`);
-        }
+      for (const wt of selectedPlan) {
+        await tmux.newWindow(session, wt.windowName, { cwd: wt.path });
+        await new Promise(r => setTimeout(r, 300));
+        const wtEngine = wakeSession.readWorktreeEngineFile(wt.path);
+        const wtOpts = wtEngine ? { ...opts, engine: wtEngine } : opts;
+        const target = `${session}:${wt.windowName}`;
+        await tmux.sendText(target, await buildWakeCommandForPane(wt.windowName, wt.path, wtOpts, target));
+        await wakeSession.waitForEngine(target, getPaneInfos, isAgentCommand);
+        existingWindows.add(wt.windowName);
+        console.log(`\x1b[32m+\x1b[0m window: ${wt.windowName}  \x1b[90m(from ${formatWorktreeSource(wt.path)})\x1b[0m`);
       }
     }
     knownWindows = existingWindows;
@@ -1355,12 +1392,12 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
         const plan = planRehydrateWorktreeWindows(oracle, rehydratableWt, existingWindows, liveTileRoles);
         logAgentsRehydrationSource(plan.length, allWt);
         if (plan.length > 0) {
-          const skipRehydrate = shouldSkipAgentsRehydrationPrompt(plan);
-          if (skipRehydrate) {
+          const selectedPlan = selectAgentsRehydrationPlan(plan);
+          if (selectedPlan.length === 0) {
             console.log(`\x1b[33m⚡\x1b[0m skipped agent rehydration`);
           } else {
             console.log(`\x1b[36m↻\x1b[0m rehydrating from agents/ folder:`);
-            for (const wt of plan) {
+            for (const wt of selectedPlan) {
               await tmux.newWindow(session, wt.windowName, { cwd: wt.path });
               await new Promise(r => setTimeout(r, 300));
               const wtEngine = wakeSession.readWorktreeEngineFile(wt.path);

--- a/test/isolated/wake-cmd-branch-coverage.test.ts
+++ b/test/isolated/wake-cmd-branch-coverage.test.ts
@@ -318,7 +318,7 @@ describe("wake-cmd isolated executable branch coverage", () => {
       expect(result).toBe("01-mawjs:mawjs-oracle");
       const rendered = logs.join("\n");
       expect(rendered).toContain("found 1 saved agent window");
-      expect(writes.join("")).toContain("Rehydrate all? [Y/n]");
+      expect(writes.join("")).toContain("Rehydrate? [Y]es all / [n]one / [s]elect:");
       expect(rendered).toContain("skipped agent rehydration");
       expect(sessions).toContainEqual({ name: "01-mawjs" });
       expect(windowsBySession["01-mawjs"]).toEqual([{ name: "mawjs-oracle", cwd: repoPath }]);

--- a/test/wake-cmd-cmdwake-coverage.test.ts
+++ b/test/wake-cmd-cmdwake-coverage.test.ts
@@ -586,7 +586,7 @@ mock.module(join(import.meta.dir, "../src/commands/shared/fleet-ensure"), () => 
   },
 }));
 
-const { cmdWake, _wtPicker, promptAmbiguousBringPick, WakeSession } = await import("../src/commands/shared/wake-cmd");
+const { cmdWake, _wtPicker, promptAmbiguousBringPick, WakeSession, parseRehydrationSelection } = await import("../src/commands/shared/wake-cmd");
 const originalWtPickerIsStdoutTTY = _wtPicker.isStdoutTTY;
 const originalWtPickerReadChoice = _wtPicker.readChoice;
 
@@ -706,6 +706,48 @@ describe("cmdWake main-suite coverage", () => {
     expect(result).toBe("mawjs:dry-run");
     expect(newSessionCalls).toHaveLength(0);
     expect(existsSync(join(repoPath, ".gitignore"))).toBe(false);
+  });
+
+
+  test("#2604 parses comma and range rehydration selections", () => {
+    expect(parseRehydrationSelection("1,3", 4)).toEqual([0, 2]);
+    expect(parseRehydrationSelection("2-4,1", 4)).toEqual([0, 1, 2, 3]);
+    expect(parseRehydrationSelection("4-2,99,nope", 4)).toEqual([1, 2, 3]);
+  });
+
+  test("#2604 selective prompt rehydrates only chosen saved agents", async () => {
+    detectSessionReturn = null;
+    shouldWakeDecision = { wake: true, reason: "missing" };
+    sessions = [];
+    hasSessions = new Set();
+    windowsBySession = {};
+    worktrees = [
+      { name: "1-bridge", path: join(repoPath, "agents", "1-bridge") },
+      { name: "2-white", path: join(repoPath, "agents", "2-white") },
+      { name: "3-wezterm", path: join(repoPath, "agents", "3-wezterm") },
+    ];
+    const originalIsStdoutTTY = _wtPicker.isStdoutTTY;
+    const originalReadChoice = _wtPicker.readChoice;
+    const answers = ["s", "1,3"];
+    _wtPicker.isStdoutTTY = () => true;
+    _wtPicker.readChoice = () => answers.shift() ?? "";
+
+    try {
+      const { result, logs } = await captureLogs(() => cmdWake("mawjs", { engine: "codex" }));
+
+      expect(result).toBe("01-mawjs:mawjs-oracle");
+      expect(newWindowCalls).toEqual([
+        { session: "01-mawjs", name: "mawjs-bridge", opts: { cwd: worktrees[0]!.path } },
+        { session: "01-mawjs", name: "mawjs-wezterm", opts: { cwd: worktrees[2]!.path } },
+      ]);
+      const rendered = logs.join("\n");
+      expect(rendered).toContain("select saved agent windows");
+      expect(rendered).toContain("rehydrating: mawjs-bridge, mawjs-wezterm");
+      expect(rendered).not.toContain("window: mawjs-white");
+    } finally {
+      _wtPicker.isStdoutTTY = originalIsStdoutTTY;
+      _wtPicker.readChoice = originalReadChoice;
+    }
   });
 
   test("#1816 bring picker handles headless, empty, quit, invalid, and success choices", () => {


### PR DESCRIPTION
Closes #2604

## Summary
- replace the all-or-none agents rehydrate prompt with yes/none/select
- add numbered selective rehydrate parsing with comma indices and ranges
- keep Enter/Y and non-interactive stdin defaulting to rehydrate all

## Tests
- bun test test/wake-cmd-cmdwake-coverage.test.ts
- bun test test/isolated/wake-cmd-branch-coverage.test.ts
- bun run build
- bun run test:default:safe
- git diff --check