### PR TITLE
fix(test): stabilize flaky isolated runtime tests

### DIFF
--- a/src/core/runtime/handlers.ts
+++ b/src/core/runtime/handlers.ts
@@ -52,7 +52,7 @@ const send: Handler = async (ws, data, engine) => {
       }
     } catch { /* pane check failed, proceed anyway */ }
   }
-  sendKeys(data.target, data.text)
+  return sendKeys(data.target, data.text)
     .then(() => {
       ws.send(JSON.stringify({ type: "sent", ok: true, target: data.target, text: data.text }));
       setTimeout(() => engine.pushCapture(ws), 300);
@@ -61,11 +61,11 @@ const send: Handler = async (ws, data, engine) => {
 };
 
 const sleep: Handler = (ws, data) => {
-  runAction(ws, "sleep", data.target, () => sendKeys(data.target, "\x03"));
+  return runAction(ws, "sleep", data.target, () => sendKeys(data.target, "\x03"));
 };
 
 const stop: Handler = (ws, data) => {
-  runAction(ws, "stop", data.target, () => tmux.killWindow(data.target));
+  return runAction(ws, "stop", data.target, () => tmux.killWindow(data.target));
 };
 
 /**
@@ -93,12 +93,12 @@ function buildSpawnCmd(data: { target?: string; command?: string; cwd?: string }
 
 const wake: Handler = (ws, data) => {
   const cmd = buildSpawnCmd(data);
-  runAction(ws, "wake", data.target, () => sendKeys(data.target, cmd + "\r"));
+  return runAction(ws, "wake", data.target, () => sendKeys(data.target, cmd + "\r"));
 };
 
 const restart: Handler = (ws, data) => {
   const cmd = buildSpawnCmd(data);
-  runAction(ws, "restart", data.target, async () => {
+  return runAction(ws, "restart", data.target, async () => {
     await sendKeys(data.target, "\x03"); // Ctrl+C
     await new Promise(r => setTimeout(r, 2000));
     await sendKeys(data.target, "\x03"); // Ctrl+C again (in case first was caught)

--- a/test/isolated/messages-index-coverage.test.ts
+++ b/test/isolated/messages-index-coverage.test.ts
@@ -123,6 +123,15 @@ function fastPollingClock() {
   Bun.sleep = (async () => undefined) as typeof Bun.sleep;
 }
 
+async function waitUntil(predicate: () => boolean, label: string, timeoutMs = 2_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`timed out waiting for ${label}`);
+}
+
 beforeEach(() => {
   tmpHome = mkdtempSync(join(tmpdir(), "maw-messages-slice-"));
   process.env.MAW_HOME = tmpHome;
@@ -600,23 +609,23 @@ describe("messages plugin coverage slice", () => {
 
     try {
       let pendingError: unknown;
+      let pendingResolved = false;
       void messagesHandler({
         source: "cli",
         args: ["serve", "--engine", `http://127.0.0.1:${engine.port}`, "--port", "45678"],
+      }).then(() => {
+        pendingResolved = true;
       }).catch((err) => {
         pendingError = err;
       });
 
-      for (let i = 0; i < 20 && !registered && !pendingError; i++) {
-        await new Promise((resolve) => setTimeout(resolve, 5));
-      }
+      await waitUntil(() => Boolean(registered) || Boolean(pendingError) || pendingResolved, "foreground messages registration");
       expect(pendingError).toBeUndefined();
+      expect(pendingResolved).toBe(false);
       expect(registered).toMatchObject({ plugin: "messages", upstream: "http://127.0.0.1:45678" });
       expect(Object.keys(callbacks).sort()).toEqual(["SIGINT", "SIGTERM"]);
       callbacks.SIGTERM();
-      for (let i = 0; i < 20 && stopped.length === 0; i++) {
-        await new Promise((resolve) => setTimeout(resolve, 5));
-      }
+      await waitUntil(() => stopped.length > 0, "foreground messages shutdown");
       expect(stopped).toEqual([true]);
       expect(exits).toEqual([0]);
     } finally {

--- a/test/isolated/runtime-teams-coverage.test.ts
+++ b/test/isolated/runtime-teams-coverage.test.ts
@@ -84,6 +84,15 @@ function makeEngine() {
   return { engine, handlers };
 }
 
+async function waitUntil(predicate: () => boolean, label: string, timeoutMs = 2_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`timed out waiting for ${label}`);
+}
+
 function makeWs() {
   const sent: string[] = [];
   return {
@@ -162,8 +171,8 @@ describe("runtime websocket handlers", () => {
 
     paneCommand = new Error("pane gone");
     await handlers.get("send")!(ws, { target: "alpha:0", text: "forced by failed check" }, engine);
-    await new Promise(resolve => setTimeout(resolve, 320));
     expect(JSON.parse(sent.at(-1)!)).toMatchObject({ type: "sent", target: "alpha:0" });
+    await waitUntil(() => engine.pushedCapture === 1, "send capture refresh");
     expect(engine.pushedCapture).toBe(1);
   });
 
@@ -189,9 +198,7 @@ describe("runtime websocket handlers", () => {
     await handlers.get("stop")!(ws, { target: "alpha" }, {});
     await handlers.get("wake")!(ws, { target: "known:0" }, {});
 
-    const restartPromise = handlers.get("restart")!(ws, { target: "plain:0", command: "custom-cmd" }, {});
-    await new Promise(resolve => setTimeout(resolve, 2510));
-    await restartPromise;
+    await handlers.get("restart")!(ws, { target: "plain:0", command: "custom-cmd" }, {});
 
     expect(sendKeyCalls).toContainEqual({ target: "alpha:0", text: "\x03" });
     expect(killedWindows).toEqual(["alpha"]);


### PR DESCRIPTION
## Summary
- Make runtime websocket action handlers return their async work so tests and callers can await completion.
- Replace fixed sleeps in the runtime websocket isolated test with observable completion waits.
- Replace short polling loops in the messages foreground serve isolated test with bounded deterministic waits for registration/shutdown state.

Closes #2607

## Tests
- `bash scripts/test-isolated.sh test/isolated/messages-index-coverage.test.ts test/isolated/runtime-teams-coverage.test.ts`
- repeated the same isolated pair 3 additional times
- `bun run build`
