### PR TITLE
Fast-path wake re-attaches after fuzzy resolve

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -1158,6 +1158,26 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
     return `${oracle}:list`;
   }
 
+  // #2609 — fuzzy attach targets may only resolve to the canonical oracle name
+  // after resolveOracle() (e.g. `transcri` → `transcriber`). If that canonical
+  // session is already live and has its oracle window, this is a re-attach: do
+  // not drain inbox or run agents/ rehydrate again. The first wake still falls
+  // through because there is no live session/window yet.
+  if (isAttachOnlyWake(opts)) {
+    const liveAttachSession = preResolvedSession || await detectSession(oracle, opts.urlRepoName);
+    if (liveAttachSession) {
+      const attachWindow = preResolvedFleetSession?.windowName || mainWindowNameForWakeSession(sessionContext, oracle);
+      const liveWindows = await tmux.listWindows(liveAttachSession).catch(() => [] as { name: string }[]);
+      if (liveWindows.some(w => w.name === attachWindow)) {
+        console.log(`\x1b[36m→\x1b[0m session exists: ${liveAttachSession}`);
+        await tmux.selectWindow(`${liveAttachSession}:${attachWindow}`);
+        await wakeSession.attachToSession(liveAttachSession);
+        await recordWakeSnapshot(opts);
+        return `${liveAttachSession}:${attachWindow}`;
+      }
+    }
+  }
+
   const drainedInbox = drainWakeInbox(repoPath, { markRead: shouldMarkWakeInboxRead(opts), engine: opts.engine });
   if (drainedInbox.prompt.trim()) {
     opts = { ...opts, prompt: mergeWakeInboxPrompt(opts.prompt, drainedInbox.prompt) };

--- a/test/wake-cmd-cmdwake-coverage.test.ts
+++ b/test/wake-cmd-cmdwake-coverage.test.ts
@@ -116,6 +116,7 @@ let sessions: Array<{ name: string }>;
 let sessionMap: Record<string, string>;
 let fleetSession: string | null;
 let detectSessionReturn: string | null;
+let detectSessionByOracle: Record<string, string | null>;
 let shouldWakeDecision: { wake: boolean; reason: string };
 let snapshotReturn: Snapshot | null;
 let claudeSessions: Array<{
@@ -374,6 +375,9 @@ mock.module(
       if (!mockActive)
         return realWakeResolve.detectSession(oracle, urlRepoName);
       detectSessionCalls.push({ oracle, urlRepoName });
+      if (Object.prototype.hasOwnProperty.call(detectSessionByOracle, oracle)) {
+        return detectSessionByOracle[oracle] ?? null;
+      }
       return detectSessionReturn;
     },
     setSessionEnv: async (session: string) => {
@@ -609,6 +613,7 @@ beforeEach(() => {
   sessionMap = {};
   fleetSession = null;
   detectSessionReturn = "54-mawjs";
+  detectSessionByOracle = {};
   shouldWakeDecision = { wake: false, reason: "already-live" };
   snapshotReturn = null;
   claudeSessions = [];
@@ -914,6 +919,49 @@ describe("cmdWake main-suite coverage", () => {
     expect(detectSessionCalls).toEqual([{ oracle: "mawjs", urlRepoName: undefined }]);
     expect(maybeSplitCalls).toEqual([]);
     expect(maybeOpenWindowCalls).toEqual([]);
+    expect(takeSnapshotCalls).toEqual(["wake"]);
+  });
+
+  test("#2609 attach re-run fast-path skips inbox and rehydrate after fuzzy resolve", async () => {
+    repoName = "transcriber-oracle";
+    repoPath = join(parentDir, repoName);
+    mkdirSync(repoPath, { recursive: true });
+    resolvedOracle = { repoPath, repoName, parentDir };
+    detectSessionReturn = null;
+    detectSessionByOracle = { transcri: null, transcriber: "162-transcriber" };
+    sessions = [{ name: "162-transcriber" }];
+    hasSessions = new Set(["162-transcriber"]);
+    windowsBySession = {
+      "162-transcriber": [
+        { index: 0, name: "transcriber-oracle", active: true, cwd: repoPath },
+      ],
+    };
+    worktrees = [
+      { name: "1-agent", path: join(repoPath, "agents", "1-agent") },
+    ];
+    const inboxDir = join(repoPath, "ψ", "inbox");
+    mkdirSync(inboxDir, { recursive: true });
+    writeFileSync(join(inboxDir, "001.md"), "---\nfrom: lead\nread: false\n---\nhello", "utf-8");
+
+    const { result, logs } = await captureLogs(() => cmdWake("transcri", { attach: true }));
+    const rendered = logs.join("\n");
+
+    expect(result).toBe("162-transcriber:transcriber-oracle");
+    expect(detectSessionCalls).toEqual([
+      { oracle: "transcri", urlRepoName: undefined },
+      { oracle: "transcriber", urlRepoName: undefined },
+    ]);
+    expect(selectWindowCalls).toEqual(["162-transcriber:transcriber-oracle"]);
+    expect(attachCalls).toEqual(["162-transcriber"]);
+    expect(rendered).toContain("session exists: 162-transcriber");
+    expect(rendered).not.toContain("📬");
+    expect(rendered).not.toContain("agents/ rehydrate");
+    expect(findWorktreesCalls).toEqual([]);
+    expect(setSessionEnvCalls).toEqual([]);
+    expect(lifecycleCalls).toEqual([]);
+    expect(newWindowCalls).toEqual([]);
+    expect(sendTextCalls).toEqual([]);
+    expect(ensureSessionRunningCalls).toEqual([]);
     expect(takeSnapshotCalls).toEqual(["wake"]);
   });
 


### PR DESCRIPTION
Closes #2609

## Summary
- add a post-resolve attach-only fast path for already-live oracle sessions
- require the canonical oracle window to be present before skipping wake maintenance
- skip inbox drain, lifecycle hooks, and agents/ rehydrate on re-attach while preserving first-wake flow

## Tests
- bun test test/wake-cmd-cmdwake-coverage.test.ts
- bun run build
- bun run test:default:safe
- git diff --check