### PR TITLE
Add dry-run team charter apply

### DIFF
--- a/src/commands/plugins/team/team-liveness.ts
+++ b/src/commands/plugins/team/team-liveness.ts
@@ -5,7 +5,7 @@ import { isAgentCommand } from "../../../core/agent-detect";
 import { loadConfig } from "../../../config/load";
 import { defaultEngineNameForConfig, resolveEngine } from "../../../config/engine-registry";
 import type { MawConfig } from "../../../config/types";
-import { cmdWake, type WakeOptions } from "../../shared/wake-cmd";
+import type { WakeOptions } from "../../shared/wake-cmd";
 import type { TeamCharterMember } from "../../../vendor/mpr-plugins/team/team-charter";
 
 export type TeamMemberState = "live" | "dead" | "missing";
@@ -29,7 +29,7 @@ export interface ClassifiedTeamMember {
 }
 
 export interface WakeMemberDeps {
-  cmdWakeFn?: typeof cmdWake;
+  cmdWakeFn?: (oracle: string, opts: WakeOptions) => Promise<string>;
 }
 
 const SHELL_RE = /^-?(zsh|bash|sh|fish)$/i;
@@ -116,7 +116,7 @@ export async function wakeMember(
   opts: WakeOptions & { engine: string; session: string; repoPath: string },
   deps: WakeMemberDeps = {},
 ): Promise<string> {
-  const wake = deps.cmdWakeFn ?? cmdWake;
+  const wake = deps.cmdWakeFn ?? (await import("../../shared/wake-cmd")).cmdWake;
   return wake(repoSlug, {
     wt: typeof member.worktree === "string" && member.worktree.trim() ? member.worktree.trim() : (member.name?.trim() || member.role),
     engine: opts.engine,

--- a/src/vendor/mpr-plugins/team/impl.ts
+++ b/src/vendor/mpr-plugins/team/impl.ts
@@ -11,6 +11,7 @@ export { cmdTeamSend, cmdTeamBroadcast } from "./team-comms";
 export { cmdTeamBring, resolveTeamBringSession, teamOracleMemberNames, loadTeamOracleMemberNames, applyTeamBringLayout } from "./team-workspace";
 export { cmdTeamResume, cmdTeamLives } from "./team-reincarnation";
 export { cmdCleanupZombies } from "./team-cleanup-zombies";
+export { cmdTeamApply } from "./team-apply";
 export { parseTeamCharterText, readTeamCharter, planTeamCharter, formatTeamCharterPlan, preflightTeamCharter, formatTeamCharterPreflight, loadTeamCharter, formatTeamCharterLoad, composeTeamCharterMemberPrompt, spawnFromTeamCharter, formatTeamCharterSpawn } from "./team-charter";
 
 /**

--- a/src/vendor/mpr-plugins/team/index.ts
+++ b/src/vendor/mpr-plugins/team/index.ts
@@ -372,6 +372,26 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         status: Boolean(flags["--status"]),
       });
 
+    } else if (sub === "apply") {
+      // #2612 — reconcile an edited charter against live tmux state. Dry-run by default.
+      const flags = parseFlags(args, {
+        "--apply": Boolean,
+        "--session": String,
+        "--charter": String,
+      }, 1);
+      const team = flags._[0];
+      if (!team) {
+        logs.push("usage: maw team apply <team|team.yaml> [--charter <path>] [--session <name>] [--apply]");
+        logs.push("       dry-run by default; pass --apply to spawn missing members and gracefully shut down removed members");
+        return { ok: false, error: "team required", output: logs.join("\n") };
+      }
+      const { cmdTeamApply } = await import("./team-apply");
+      await cmdTeamApply(team, {
+        apply: Boolean(flags["--apply"]),
+        session: flags["--session"] as string | undefined,
+        charterPath: flags["--charter"] as string | undefined,
+      });
+
     } else if (sub === "remove") {
       // #2073 — single-verb member removal: teardown pane/worktree + drop from charter.
       if (!args[1]) {
@@ -450,7 +470,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
 
     } else {
       logs.push(`unknown team subcommand: ${sub}`);
-      logs.push("usage: maw team <create|plan|preflight|load|up|down|remove|reassign|spawn-from|spawn|bring|send|shutdown|prune|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members|enter>");
+      logs.push("usage: maw team <create|plan|preflight|load|up|down|apply|remove|reassign|spawn-from|spawn|bring|send|shutdown|prune|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members|enter>");
       return { ok: false, error: `unknown subcommand: ${sub}`, output: logs.join("\n") };
     }
 

--- a/src/vendor/mpr-plugins/team/team-apply.ts
+++ b/src/vendor/mpr-plugins/team/team-apply.ts
@@ -1,0 +1,206 @@
+// Charter-driven team apply (#2612). Dry-run by default; --apply mutates.
+import { existsSync } from "fs";
+import { basename } from "path";
+import { isAgentCommand } from "../../../core/agent-detect";
+import { loadConfig } from "../../../config/load";
+import type { MawConfig } from "../../../config/types";
+import { Tmux } from "../../../core/transport/tmux";
+import { cmdDone } from "../done/impl";
+import { readTeamCharter, type TeamCharter, type TeamCharterMember } from "./team-charter";
+import { TEAM_LIFECYCLE_GUARD_WINDOW } from "./team-down";
+import {
+  classifyMember,
+  currentTmuxSession,
+  engineCommand,
+  findRepoRoot,
+  listPaneSnapshots,
+  memberWindowCandidates,
+  repoSlugFromRoot,
+  resolveCharterPath,
+  wakeMember,
+  type ClassifiedTeamMember,
+  type TeamPaneSnapshot,
+  type WakeMemberDeps,
+} from "./team-liveness";
+
+export interface TeamApplyOptions {
+  apply?: boolean;
+  session?: string;
+  charterPath?: string;
+}
+
+export type TeamApplyActionKind = "spawn" | "shutdown" | "report" | "skip";
+
+export interface TeamApplyAction {
+  kind: TeamApplyActionKind;
+  role: string;
+  state: string;
+  action: string;
+  target?: string;
+  detail?: string;
+  command?: string;
+}
+
+export interface TeamApplyResult {
+  team: string;
+  session: string;
+  charter: TeamCharter;
+  roster: ClassifiedTeamMember[];
+  removed: TeamPaneSnapshot[];
+  actions: TeamApplyAction[];
+  warnings: string[];
+  output: string;
+}
+
+export interface TeamApplyDeps {
+  tmux?: Pick<Tmux, "run">;
+  cwd?: string;
+  readTeamCharterFn?: typeof readTeamCharter;
+  loadConfigFn?: typeof loadConfig;
+  cmdWakeFn?: WakeMemberDeps["cmdWakeFn"];
+  cmdDoneFn?: typeof cmdDone;
+  branchForPathFn?: (path: string) => string | undefined;
+  repoRoot?: string;
+  repoSlug?: string;
+  logger?: (line: string) => void;
+}
+
+function resolveApplyCharterPath(teamOrPath: string, cwd: string, config: MawConfig, explicit?: string): string | null {
+  if (explicit) return explicit;
+  if (existsSync(teamOrPath)) return teamOrPath;
+  return resolveCharterPath(teamOrPath, cwd, config.node);
+}
+
+function charterNameFromInput(teamOrPath: string, charter: TeamCharter): string {
+  return charter.name || basename(teamOrPath).replace(/\.(ya?ml|json)$/i, "");
+}
+
+function paneMatchesAnyMember(pane: TeamPaneSnapshot, members: TeamCharterMember[], repoSlug: string): boolean {
+  for (const member of members) {
+    const candidates = memberWindowCandidates(member, repoSlug);
+    if (candidates.includes(pane.windowName)) return true;
+    if (candidates.some((candidate) => pane.windowName.endsWith(`-${candidate}`))) return true;
+  }
+  return false;
+}
+
+function currentBranch(path: string): string | undefined {
+  try {
+    const proc = Bun.spawnSync(["git", "-C", path, "branch", "--show-current"], { stdout: "pipe", stderr: "pipe" });
+    if (proc.exitCode !== 0) return undefined;
+    return new TextDecoder().decode(proc.stdout).trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function engineLooksSame(liveCommand: string, expectedCommand: string, engine: string): boolean {
+  const live = liveCommand.trim();
+  if (!live) return false;
+  const expectedHead = expectedCommand.trim().split(/\s+/, 1)[0] ?? "";
+  return live === engine || live === expectedHead || live.includes(engine) || (!!expectedHead && live.includes(expectedHead));
+}
+
+function renderApply(result: Omit<TeamApplyResult, "output">, apply: boolean): string {
+  const mode = apply ? "apply" : "dry-run";
+  const lines = [`team apply: ${result.team} (${result.session}) ${mode}`, "kind\trole\tstate\taction"];
+  for (const action of result.actions) {
+    lines.push(`${action.kind}\t${action.role}\t${action.state}\t${action.action}`);
+  }
+  if (result.warnings.length) lines.push("", "warnings:", ...result.warnings.map((warning) => `  - ${warning}`));
+  if (!apply) lines.push("", "No changes made (pass --apply to execute)");
+  return lines.join("\n");
+}
+
+export async function cmdTeamApply(teamOrPath: string, opts: TeamApplyOptions = {}, deps: TeamApplyDeps = {}): Promise<TeamApplyResult> {
+  const cwd = deps.cwd ?? process.cwd();
+  const config: MawConfig = (deps.loadConfigFn ?? loadConfig)();
+  const charterPath = resolveApplyCharterPath(teamOrPath, cwd, config, opts.charterPath);
+  if (!charterPath) throw new Error(config.node ? `charter not found: ${teamOrPath} (no team file for node '${config.node}')` : `charter not found: ${teamOrPath}`);
+
+  const charter = (deps.readTeamCharterFn ?? readTeamCharter)(charterPath);
+  const team = charterNameFromInput(teamOrPath, charter);
+  const tmux = deps.tmux ?? new Tmux();
+  const repoRoot = deps.repoRoot ?? findRepoRoot(cwd);
+  const repoSlug = deps.repoSlug ?? repoSlugFromRoot(repoRoot);
+  const targetRepoSlug = charter.project ?? repoSlug;
+  const currentSession = await currentTmuxSession(tmux).catch(() => "");
+  const session = opts.session?.trim() || charter.session || currentSession;
+  if (!session) throw new Error("session required: pass --session <name> when running team apply outside tmux and charter.session is omitted");
+
+  const panes = await listPaneSnapshots(tmux);
+  const roster = charter.members.map((member) => classifyMember(member, panes, session, { currentNode: config.node, repoSlug: targetRepoSlug }));
+  const warnings: string[] = [];
+  const actions: TeamApplyAction[] = [];
+  const branchForPath = deps.branchForPathFn ?? currentBranch;
+
+  const removed = panes.filter((pane) =>
+    pane.sessionName === session &&
+    pane.windowName !== TEAM_LIFECYCLE_GUARD_WINDOW &&
+    isAgentCommand(pane.command) &&
+    !paneMatchesAnyMember(pane, charter.members, targetRepoSlug)
+  );
+
+  for (const item of roster) {
+    if (item.state === "skipped") {
+      actions.push({ kind: "skip", role: item.role, state: item.state, action: `skip (${item.skipReason ?? "guard"})` });
+      continue;
+    }
+    if (item.state === "missing") {
+      const command = engineCommand(item.engine, { resume: false, engines: charter.engines }, config);
+      actions.push({ kind: "spawn", role: item.role, state: item.state, action: opts.apply ? "spawn member" : "would spawn member", command });
+      if (opts.apply) {
+        await wakeMember(targetRepoSlug, item.member, { engine: item.engine, session, repoPath: repoRoot, channels: item.member.channels === true }, { cmdWakeFn: deps.cmdWakeFn });
+      }
+      continue;
+    }
+    if (item.state === "dead") {
+      actions.push({ kind: "skip", role: item.role, state: item.state, action: "skip dead member (team up can resume)" });
+      continue;
+    }
+
+    const expectedCommand = engineCommand(item.engine, { resume: false, engines: charter.engines }, config);
+    if (item.member.engine && item.pane && !engineLooksSame(item.pane.command, expectedCommand, item.engine)) {
+      actions.push({
+        kind: "report",
+        role: item.role,
+        state: item.state,
+        action: "engine changed; not migrated",
+        detail: `live=${item.pane.command} charter=${item.engine}`,
+      });
+    } else {
+      actions.push({ kind: "skip", role: item.role, state: item.state, action: "skip live" });
+    }
+
+    if (item.member.branch && item.pane?.path) {
+      const liveBranch = branchForPath(item.pane.path);
+      if (liveBranch && liveBranch !== item.member.branch) {
+        actions.push({
+          kind: "report",
+          role: item.role,
+          state: item.state,
+          action: "branch changed; not migrated",
+          detail: `live=${liveBranch} charter=${item.member.branch}`,
+        });
+      }
+    }
+  }
+
+  const done = deps.cmdDoneFn ?? cmdDone;
+  for (const pane of removed) {
+    const role = pane.windowName;
+    const action = opts.apply ? "maw done removed member" : "would maw done removed member";
+    actions.push({ kind: "shutdown", role, state: "extra", action, target: pane.windowName });
+    if (opts.apply) await done(pane.windowName, { sessionName: session });
+  }
+
+  if (!removed.length && !roster.some((item) => item.state === "missing")) {
+    warnings.push("no spawn/shutdown changes detected");
+  }
+
+  const resultBase = { team, session, charter, roster, removed, actions, warnings };
+  const output = renderApply(resultBase, Boolean(opts.apply));
+  const result = { ...resultBase, output };
+  if (deps.logger) deps.logger(output); else console.log(output);
+  return result;
+}

--- a/src/vendor/mpr-plugins/team/team-apply.ts
+++ b/src/vendor/mpr-plugins/team/team-apply.ts
@@ -5,7 +5,6 @@ import { isAgentCommand } from "../../../core/agent-detect";
 import { loadConfig } from "../../../config/load";
 import type { MawConfig } from "../../../config/types";
 import { Tmux } from "../../../core/transport/tmux";
-import { cmdDone } from "../done/impl";
 import { readTeamCharter, type TeamCharter, type TeamCharterMember } from "./team-charter";
 import { TEAM_LIFECYCLE_GUARD_WINDOW } from "./team-down";
 import {
@@ -58,7 +57,7 @@ export interface TeamApplyDeps {
   readTeamCharterFn?: typeof readTeamCharter;
   loadConfigFn?: typeof loadConfig;
   cmdWakeFn?: WakeMemberDeps["cmdWakeFn"];
-  cmdDoneFn?: typeof cmdDone;
+  cmdDoneFn?: (windowName: string, opts?: { sessionName?: string; dryRun?: boolean; force?: boolean }) => Promise<void>;
   branchForPathFn?: (path: string) => string | undefined;
   repoRoot?: string;
   repoSlug?: string;
@@ -186,12 +185,15 @@ export async function cmdTeamApply(teamOrPath: string, opts: TeamApplyOptions = 
     }
   }
 
-  const done = deps.cmdDoneFn ?? cmdDone;
+  let done = deps.cmdDoneFn;
   for (const pane of removed) {
     const role = pane.windowName;
     const action = opts.apply ? "maw done removed member" : "would maw done removed member";
     actions.push({ kind: "shutdown", role, state: "extra", action, target: pane.windowName });
-    if (opts.apply) await done(pane.windowName, { sessionName: session });
+    if (opts.apply) {
+      if (!done) done = (await import("../done/impl")).cmdDone;
+      await done(pane.windowName, { sessionName: session });
+    }
   }
 
   if (!removed.length && !roster.some((item) => item.state === "missing")) {

--- a/src/vendor/mpr-plugins/team/team-liveness.ts
+++ b/src/vendor/mpr-plugins/team/team-liveness.ts
@@ -3,9 +3,9 @@ import { basename, dirname, join } from "path";
 import { Tmux } from "../../../core/transport/tmux";
 import { isAgentCommand } from "../../../core/agent-detect";
 import { loadConfig } from "../../../config/load";
-import { defaultEngineNameForConfig, resolveEngine } from "maw-js/sdk";
+import * as mawSdk from "maw-js/sdk";
 import type { MawConfig } from "../../../config/types";
-import { cmdWake, type WakeOptions } from "../../../commands/shared/wake-cmd";
+import type { WakeOptions } from "../../../commands/shared/wake-cmd";
 import type { TeamCharterEngines, TeamCharterMember } from "./team-charter";
 
 export type TeamMemberState = "live" | "dead" | "missing" | "skipped";
@@ -35,7 +35,7 @@ export interface ClassifiedTeamMember {
 }
 
 export interface WakeMemberDeps {
-  cmdWakeFn?: typeof cmdWake;
+  cmdWakeFn?: (oracle: string, opts: WakeOptions) => Promise<string>;
 }
 
 export interface ClassifyMemberOptions {
@@ -82,7 +82,7 @@ export function memberWorktree(member: TeamCharterMember): string {
 }
 
 export function memberEngine(member: TeamCharterMember, override?: string, config: MawConfig = loadConfig()): string {
-  return override ?? member.engine ?? member.model ?? config.defaultEngine ?? defaultEngineNameForConfig(config);
+  return override ?? member.engine ?? member.model ?? config.defaultEngine ?? mawSdk.defaultEngineNameForConfig(config);
 }
 
 export function memberMatchesSelector(member: TeamCharterMember, selector: string): boolean {
@@ -208,7 +208,7 @@ export function resolveCharterEngineCommand(engine: string, engines?: TeamCharte
 
 export function engineCommand(engine: string, opts: EngineCommandOptions = {}, config: MawConfig = loadConfig()): string {
   const key = opts.resume ? `${engine}-resume` : engine;
-  return resolveCharterEngineCommand(key, opts.engines) ?? resolveEngine(key, config).cmd;
+  return resolveCharterEngineCommand(key, opts.engines) ?? mawSdk.resolveEngine(key, config).cmd;
 }
 
 export function repoSlugFromRoot(root: string): string {
@@ -232,6 +232,6 @@ export async function wakeMember(
   opts: WakeOptions & { engine: string; session: string; repoPath: string },
   deps: WakeMemberDeps = {},
 ): Promise<string> {
-  const wake = deps.cmdWakeFn ?? cmdWake;
+  const wake = deps.cmdWakeFn ?? (await import("../../../commands/shared/wake-cmd")).cmdWake;
   return wake(memberWakeTarget(repoSlug, member), memberWakeOptions(member, opts));
 }

--- a/src/vendor/mpr-plugins/team/team-up.ts
+++ b/src/vendor/mpr-plugins/team/team-up.ts
@@ -8,7 +8,7 @@ import { readTeamCharter, type TeamCharter } from "./team-charter";
 import { loadConfig } from "../../../config/load";
 import type { MawConfig } from "../../../config/types";
 import { Tmux } from "../../../core/transport/tmux";
-import { cmdWake } from "../../../commands/shared/wake-cmd";
+import type { WakeOptions } from "../../../commands/shared/wake-cmd";
 import { cmdSend } from "../../../commands/shared/comm-send";
 import { TEAM_LIFECYCLE_GUARD_WINDOW } from "./team-down";
 import {
@@ -64,7 +64,7 @@ export interface TeamUpDeps {
   charterPath?: string | null;
   readTeamCharterFn?: typeof readTeamCharter;
   loadConfigFn?: typeof loadConfig;
-  cmdWakeFn?: typeof cmdWake;
+  cmdWakeFn?: (oracle: string, opts: WakeOptions) => Promise<string>;
   cmdSendFn?: typeof cmdSend;
   sleep?: (ms: number) => Promise<void>;
   repoRoot?: string;

--- a/test/isolated/plugin-team-standalone.test.ts
+++ b/test/isolated/plugin-team-standalone.test.ts
@@ -80,6 +80,9 @@ mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/team/team-up.ts"),
     return { name: "quick", members: [] };
   },
 }));
+mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/team/team-apply.ts"), () => ({
+  cmdTeamApply: async (...args: unknown[]) => calls.push({ name: "apply", args }),
+}));
 mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/team/task-ops.ts"), () => ({
   cmdTeamTaskAdd: (...args: unknown[]) => calls.push({ name: "task-add", args }),
   cmdTeamTaskList: (...args: unknown[]) => calls.push({ name: "task-list", args }),
@@ -104,7 +107,7 @@ describe("team command plugin standalone boundary (#2336)", () => {
   test("entrypoint and touched team-up files keep explicit standalone import boundaries", () => {
     const imports = expectStandalonePluginBoundary({
       plugin: "team",
-      files: ["index.ts", "team-liveness.ts", "team-up.ts"],
+      files: ["index.ts", "team-liveness.ts", "team-up.ts", "team-apply.ts"],
       allowRelative: [
         "../../../core/transport/tmux",
         "../../../core/agent-detect",
@@ -112,13 +115,14 @@ describe("team command plugin standalone boundary (#2336)", () => {
         "../../../config/types",
         "../../../commands/shared/wake-cmd",
         "../../../commands/shared/comm-send",
+        "../done/impl",
       ],
     }).map((record) => record.spec);
 
 
     expect(command).toMatchObject({ name: "team" });
     expect(imports).toContain("maw-js/sdk");
-    expect(imports).toEqual(expect.arrayContaining(["./team-up", "../../../commands/shared/wake-cmd"]));
+    expect(imports).toEqual(expect.arrayContaining(["./team-up", "./team-apply", "../../../commands/shared/wake-cmd"]));
     const teamUp = readFileSync(join(root, "src/vendor/mpr-plugins/team/team-up.ts"), "utf8");
     expect(teamUp).toContain("Promise.all(launchTasks.map((task) => task.run()))");
     expect(teamUp).toContain("Promise.all(launchTasks.map((task) => waitForNonShell");
@@ -159,6 +163,12 @@ describe("team command plugin standalone boundary (#2336)", () => {
         members: ["coder-1", "oracle"],
         session: "alpha",
       }],
+    });
+
+    await teamHandler({ source: "cli", args: ["apply", "avengers", "--session", "alpha", "--charter", "/tmp/team.yaml", "--apply"] } as any);
+    expect(calls.pop()).toEqual({
+      name: "apply",
+      args: ["avengers", { apply: true, session: "alpha", charterPath: "/tmp/team.yaml" }],
     });
   });
 

--- a/test/isolated/team-up-coverage.test.ts
+++ b/test/isolated/team-up-coverage.test.ts
@@ -11,6 +11,7 @@ import { parseTeamCharterText } from "../../src/vendor/mpr-plugins/team/team-cha
 import { classifyMember, engineCommand, memberWakeOptions, memberWakeTarget, resolveCharterPath } from "../../src/vendor/mpr-plugins/team/team-liveness";
 import { cmdTeamUp, quickCharter } from "../../src/vendor/mpr-plugins/team/team-up";
 import { cmdTeamDown, TEAM_LIFECYCLE_GUARD_WINDOW } from "../../src/vendor/mpr-plugins/team/team-down";
+import { cmdTeamApply } from "../../src/vendor/mpr-plugins/team/team-apply";
 
 const dirs: string[] = [];
 afterEach(() => {
@@ -779,6 +780,128 @@ members:
     });
     expect(doneCalls.map((c) => c[0])).toEqual(["mawjs-oracle", "mawjs-codex", "mawjs-coder-1"]);
     expect(calls).toContainEqual(["new-window", "-d", "-t", "charter-session:", "-n", TEAM_LIFECYCLE_GUARD_WINDOW]);
+  });
+});
+
+describe("maw team apply (#2612)", () => {
+  test("dry-run compares charter to live tmux state without spawning or shutting down", async () => {
+    const root = tempRepo();
+    writeFileSync(join(root, ".maw", "teams", "apply.yaml"), `
+name: apply
+session: charter-session
+members:
+  - role: lead
+    name: mawjs-oracle
+    engine: claude
+    worktree: false
+  - role: reviewer
+    name: reviewer
+    engine: codex
+    worktree: true
+`, "utf-8");
+    const { tmux } = fakeTmux([
+      "charter-session|mawjs-oracle|claude|/repo|%1",
+      "charter-session|mawjs-old-worker|codex|/wt/old-worker|%2",
+    ]);
+    const wakes: any[] = [];
+    const doneCalls: any[] = [];
+
+    const result = await cmdTeamApply("apply", {}, {
+      cwd: root,
+      tmux,
+      loadConfigFn: () => config,
+      repoSlug: "Soul-Brews-Studio/maw-js",
+      cmdWakeFn: async (...a: any[]) => { wakes.push(a); return "woke"; },
+      cmdDoneFn: async (...a: any[]) => { doneCalls.push(a); },
+      logger: () => {},
+    });
+
+    expect(result.actions.map((a) => [a.kind, a.role, a.action, a.target])).toEqual([
+      ["skip", "lead", "skip live", undefined],
+      ["spawn", "reviewer", "would spawn member", undefined],
+      ["shutdown", "mawjs-old-worker", "would maw done removed member", "mawjs-old-worker"],
+    ]);
+    expect(wakes).toEqual([]);
+    expect(doneCalls).toEqual([]);
+    expect(result.output).toContain("No changes made (pass --apply to execute)");
+  });
+
+  test("--apply spawns missing members and gracefully shuts down removed panes", async () => {
+    const root = tempRepo();
+    writeFileSync(join(root, ".maw", "teams", "apply.yaml"), `
+name: apply
+session: charter-session
+members:
+  - role: reviewer
+    name: reviewer
+    engine: codex
+    worktree: true
+`, "utf-8");
+    const { tmux } = fakeTmux([
+      "charter-session|mawjs-old-worker|codex|/wt/old-worker|%2",
+    ]);
+    const wakes: any[] = [];
+    const doneCalls: any[] = [];
+
+    const result = await cmdTeamApply("apply", { apply: true }, {
+      cwd: root,
+      tmux,
+      loadConfigFn: () => config,
+      repoRoot: root,
+      repoSlug: "Soul-Brews-Studio/maw-js",
+      cmdWakeFn: async (...a: any[]) => { wakes.push(a); return "woke"; },
+      cmdDoneFn: async (...a: any[]) => { doneCalls.push(a); },
+      logger: () => {},
+    });
+
+    expect(result.actions.map((a) => [a.kind, a.role, a.action])).toEqual([
+      ["spawn", "reviewer", "spawn member"],
+      ["shutdown", "mawjs-old-worker", "maw done removed member"],
+    ]);
+    expect(wakes).toEqual([["Soul-Brews-Studio/maw-js", {
+      engine: "codex",
+      session: "charter-session",
+      repoPath: root,
+      wt: "reviewer",
+    }]]);
+    expect(doneCalls).toEqual([["mawjs-old-worker", { sessionName: "charter-session" }]]);
+  });
+
+  test("reports live member engine and branch drift without auto-migrating", async () => {
+    const root = tempRepo();
+    writeFileSync(join(root, ".maw", "teams", "apply.yaml"), `
+name: apply
+session: charter-session
+members:
+  - role: reviewer
+    name: reviewer
+    engine: codex
+    branch: next
+    worktree: true
+`, "utf-8");
+    const { tmux } = fakeTmux([
+      "charter-session|mawjs-reviewer|claude|/wt/reviewer|%2",
+    ]);
+    const wakes: any[] = [];
+    const doneCalls: any[] = [];
+
+    const result = await cmdTeamApply("apply", { apply: true }, {
+      cwd: root,
+      tmux,
+      loadConfigFn: () => config,
+      repoSlug: "Soul-Brews-Studio/maw-js",
+      cmdWakeFn: async (...a: any[]) => { wakes.push(a); return "woke"; },
+      cmdDoneFn: async (...a: any[]) => { doneCalls.push(a); },
+      branchForPathFn: () => "main",
+      logger: () => {},
+    });
+
+    expect(result.actions.map((a) => [a.kind, a.role, a.action, a.detail])).toEqual([
+      ["report", "reviewer", "engine changed; not migrated", "live=claude charter=codex"],
+      ["report", "reviewer", "branch changed; not migrated", "live=main charter=next"],
+    ]);
+    expect(wakes).toEqual([]);
+    expect(doneCalls).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Closes #2612

## Summary
- add `maw team apply <team|team.yaml>` with dry-run default and `--apply` execution
- diff charter members against live tmux panes to spawn missing members and gracefully shut down removed live agent panes
- report engine and branch drift for live charter members without auto-migrating them

## Tests
- bun test test/isolated/team-up-coverage.test.ts
- bun test test/isolated/plugin-team-standalone.test.ts
- bun run build
- bun run test:default:safe
- git diff --check