### PR TITLE
refactor: brand user-facing command errors

### DIFF
--- a/src/commands/shared/artifacts.ts
+++ b/src/commands/shared/artifacts.ts
@@ -8,6 +8,7 @@
  */
 
 import { listArtifacts, getArtifact } from "../../lib/artifacts";
+import { UserError } from "../../core/util/user-error";
 
 export async function cmdArtifacts(sub: string, args: string[], flags: Record<string, any>) {
   const json = flags["--json"];
@@ -43,10 +44,10 @@ export async function cmdArtifacts(sub: string, args: string[], flags: Record<st
   if (sub === "get" || sub === "show") {
     const team = args[0];
     const taskId = args[1];
-    if (!team || !taskId) { console.error("usage: maw artifacts get <team> <task-id>"); process.exit(1); }
+    if (!team || !taskId) throw new UserError("usage: maw artifacts get <team> <task-id>");
 
     const art = getArtifact(team, taskId);
-    if (!art) { console.error(`artifact not found: ${team}/${taskId}`); process.exit(1); }
+    if (!art) throw new UserError(`artifact not found: ${team}/${taskId}`);
 
     if (json) { console.log(JSON.stringify(art, null, 2)); return; }
 
@@ -77,8 +78,7 @@ export async function cmdArtifacts(sub: string, args: string[], flags: Record<st
     return;
   }
 
-  console.error("usage: maw artifacts [ls|get] [team] [task-id] [--json]");
-  process.exit(1);
+  throw new UserError("usage: maw artifacts [ls|get] [team] [task-id] [--json]");
 }
 
 function pad(s: string, n: number): string { return s.padEnd(n); }

--- a/src/commands/shared/fleet-manage.ts
+++ b/src/commands/shared/fleet-manage.ts
@@ -2,6 +2,7 @@ import { dirname, join } from "path";
 import { existsSync, renameSync, unlinkSync, readdirSync } from "fs";
 import { tmux } from "../../sdk";
 import { countDisabledFleetFiles, fleetDirForWrite, loadFleetEntries, getSessionNames, type FleetEntry } from "./fleet-load";
+import { UserError } from "../../core/util/user-error";
 
 export interface FleetManageDeps {
   loadFleetEntries: typeof loadFleetEntries;
@@ -35,7 +36,7 @@ function stripNumberPrefix(name: string): string {
 
 function validateFleetRenameName(label: string, name: string): void {
   if (!name || !/^[A-Za-z0-9._-]+$/.test(name) || name.startsWith("-") || name.includes("..")) {
-    throw new Error(`invalid ${label}: ${JSON.stringify(name)}`);
+    throw new UserError(`invalid ${label}: ${JSON.stringify(name)}`);
   }
 }
 
@@ -173,7 +174,7 @@ export async function cmdFleetRename(
   const newName = stripJson(options.newName);
   validateFleetRenameName("old fleet name", oldName);
   validateFleetRenameName("new fleet name", newName);
-  if (oldName === newName) throw new Error("old and new fleet names are identical");
+  if (oldName === newName) throw new UserError("old and new fleet names are identical");
 
   const entries = io.loadFleetEntries();
   const target = entries.find(e =>
@@ -182,7 +183,7 @@ export async function cmdFleetRename(
     e.groupName === oldName ||
     stripNumberPrefix(displaySessionName(e)) === oldName
   );
-  if (!target) throw new Error(`fleet not found: ${oldName}`);
+  if (!target) throw new UserError(`fleet not found: ${oldName}`);
 
   const existing = entries.find(e => e !== target && (
     stripJson(e.file) === newName ||
@@ -193,7 +194,7 @@ export async function cmdFleetRename(
   const targetDir = entryDir(io, target);
   const oldPath = entryPath(io, target);
   const newPath = io.join(targetDir, newFile);
-  if (existing || (newPath !== oldPath && io.existsSync(newPath))) throw new Error(`target fleet already exists: ${newName}`);
+  if (existing || (newPath !== oldPath && io.existsSync(newPath))) throw new UserError(`target fleet already exists: ${newName}`);
 
   const aliases = peerAliases(oldName);
   aliases.add(displaySessionName(target));
@@ -276,7 +277,7 @@ export async function cmdFleetRenumber(deps: Partial<FleetManageDeps> = {}) {
     const details = duplicateFleetNames
       .map(([name, files]) => `${name} (${files.join(", ")})`)
       .join(", ");
-    throw new Error(`duplicate fleet name(s): ${details}; renumber cannot safely merge duplicate fleets`);
+    throw new UserError(`duplicate fleet name(s): ${details}; renumber cannot safely merge duplicate fleets`);
   }
 
   const runningSessions = await io.getSessionNames();
@@ -298,7 +299,7 @@ export async function cmdFleetRenumber(deps: Partial<FleetManageDeps> = {}) {
     const exactRunning = runningSessions.find(s => s === oldName) ?? null;
     const sameFleetRunning = runningSessions.find(s => stripNumberPrefix(s) === e.groupName && s !== oldName);
     if (sameFleetRunning) {
-      throw new Error(`fleet '${e.groupName}' already running as ${sameFleetRunning}; refusing to renumber ${oldName} → ${newName}`);
+      throw new UserError(`fleet '${e.groupName}' already running as ${sameFleetRunning}; refusing to renumber ${oldName} → ${newName}`);
     }
     return { e, newFile, newName, oldName, runningMatch: exactRunning };
   });

--- a/src/commands/shared/fleet-sync.ts
+++ b/src/commands/shared/fleet-sync.ts
@@ -3,6 +3,7 @@ import { existsSync, unlinkSync, symlinkSync, mkdirSync, readdirSync } from "fs"
 import { tmux } from "../../sdk";
 import { getGhqRoot } from "../../config/ghq-root";
 import { loadFleetEntries, getSessionNames, fleetDirForWrite } from "./fleet-load";
+import { UserError } from "../../core/util/user-error";
 
 export async function cmdFleetSync() {
   const entries = loadFleetEntries();
@@ -59,8 +60,7 @@ export async function cmdFleetSyncConfigs() {
   const repoFleetDir = join(import.meta.dir, "..", "..", "fleet");
 
   if (!existsSync(repoFleetDir)) {
-    console.error(`  \x1b[31m✗\x1b[0m No fleet/ directory found in repo`);
-    process.exit(1);
+    throw new UserError("No fleet/ directory found in repo");
   }
 
   const files = readdirSync(repoFleetDir).filter(f => f.endsWith(".json"));

--- a/src/commands/shared/plugin-create-cmd.ts
+++ b/src/commands/shared/plugin-create-cmd.ts
@@ -4,6 +4,7 @@ import { mawDataPath } from "../../core/xdg";
 import { validatePluginName } from "./plugin-create-scaffold";
 import { scaffoldRust } from "./plugin-create-rust";
 import { scaffoldAs } from "./plugin-create-as";
+import { UserError } from "../../core/util/user-error";
 
 export async function cmdPluginCreate(
   name: string | undefined,
@@ -20,24 +21,19 @@ export async function cmdPluginCreate(
 
   // Validate flags
   if (!isRust && !isAs) {
-    console.error("usage: maw plugin create [--rust | --as] <name> [--here]");
-    console.error("  Specify either --rust or --as");
-    process.exit(1);
+    throw new UserError("usage: maw plugin create [--rust | --as] <name> [--here]\n  Specify either --rust or --as");
   }
   if (isRust && isAs) {
-    console.error("  Specify --rust or --as, not both");
-    process.exit(1);
+    throw new UserError("Specify --rust or --as, not both");
   }
 
   // Validate name
   if (!name) {
-    console.error("usage: maw plugin create [--rust | --as] <name> [--here]");
-    process.exit(1);
+    throw new UserError("usage: maw plugin create [--rust | --as] <name> [--here]");
   }
   const nameErr = validatePluginName(name);
   if (nameErr) {
-    console.error(`\x1b[31m✗\x1b[0m Invalid plugin name: ${nameErr}`);
-    process.exit(1);
+    throw new UserError(`Invalid plugin name: ${nameErr}`);
   }
 
   // Resolve destination
@@ -47,8 +43,7 @@ export async function cmdPluginCreate(
       : join(process.env.MAW_PLUGIN_HOME ?? mawDataPath("plugins"), name));
 
   if (existsSync(dest)) {
-    console.error(`\x1b[31m✗\x1b[0m Destination already exists: ${dest}`);
-    process.exit(1);
+    throw new UserError(`Destination already exists: ${dest}`);
   }
 
   const type = isRust ? "Rust" : "AssemblyScript";
@@ -62,8 +57,7 @@ export async function cmdPluginCreate(
       scaffoldAs(name, dest);
     }
   } catch (err: any) {
-    console.error(`\x1b[31m✗\x1b[0m ${err.message}`);
-    process.exit(1);
+    throw new UserError(String(err?.message ?? err));
   }
 
   console.log(`\n\x1b[32m✓\x1b[0m Plugin scaffolded: \x1b[1m${name}\x1b[0m`);

--- a/src/commands/shared/plugins-install.ts
+++ b/src/commands/shared/plugins-install.ts
@@ -8,6 +8,7 @@ import { join, resolve } from "path";
 import { parseManifest } from "../../plugin/manifest";
 import { archiveToTmp } from "./plugins-ui";
 import { mawDataPath } from "../../core/xdg";
+import { UserError } from "../../core/util/user-error";
 
 /** Allowlist: only http/https URLs permitted as plugin sources */
 const URL_SCHEME_RE = /^https?:\/\//;
@@ -35,8 +36,7 @@ export async function doInstall(
   if (srcPath.startsWith("http") || srcPath.startsWith("github.com/")) {
     const url = srcPath.startsWith("http") ? srcPath : `https://${srcPath}`;
     if (!URL_SCHEME_RE.test(url)) {
-      console.error(`invalid URL scheme: ${url}`);
-      process.exit(1);
+      throw new UserError(`invalid URL scheme: ${url}`);
     }
     console.log(`\x1b[36m⚡\x1b[0m cloning ${url}...`);
     try {
@@ -44,15 +44,14 @@ export async function doInstall(
       const code = await proc.exited;
       if (code !== 0) throw new Error(`ghq exited ${code}`);
     } catch {
-      console.error(`failed to clone: ${url}`);
-      process.exit(1);
+      throw new UserError(`failed to clone: ${url}`);
     }
     const rootProc = Bun.spawn(["ghq", "root"], { stdout: "pipe", stderr: "pipe" });
     await rootProc.exited;
     const ghqRoot = (await new Response(rootProc.stdout).text()).trim();
     const repoPath = url.replace(/^https?:\/\//, "").replace(/\.git$/, "");
     src = join(ghqRoot, repoPath);
-    if (!existsSync(src)) { console.error(`cloned but not found: ${src}`); process.exit(1); }
+    if (!existsSync(src)) throw new UserError(`cloned but not found: ${src}`);
 
     // Monorepo? List available plugins
     const pkgDir = join(src, "packages");
@@ -76,34 +75,28 @@ export async function doInstall(
   }
 
   if (!existsSync(src)) {
-    console.error(`path not found: ${src}`);
-    process.exit(1);
+    throw new UserError(`path not found: ${src}`);
   }
 
   let manifestJson: string;
   try {
     manifestJson = readFileSync(join(src, "plugin.json"), "utf8");
   } catch {
-    console.error(`no plugin.json in: ${src}`);
-    process.exit(1);
+    throw new UserError(`no plugin.json in: ${src}`);
   }
 
   let manifest: ReturnType<typeof parseManifest>;
   try {
     manifest = parseManifest(manifestJson, src);
   } catch (err: any) {
-    console.error(`invalid plugin: ${err.message}`);
-    process.exit(1);
+    throw new UserError(`invalid plugin: ${err.message}`);
   }
 
   const pluginHome = getPluginHome(options);
   const dest = join(pluginHome, manifest.name);
   if (existsSync(dest)) {
     if (!force) {
-      console.error(
-        `plugin '${manifest.name}' already installed — use --force to overwrite`,
-      );
-      process.exit(1);
+      throw new UserError(`plugin '${manifest.name}' already installed — use --force to overwrite`);
     }
     // Archive existing before overwrite (Nothing Deleted)
     archiveToTmp(manifest.name, dest);
@@ -123,10 +116,7 @@ export async function doInstall(
 export function doRemove(name: string, discover: () => LoadedPlugin[]): void {
   const plugins = discover();
   const p = plugins.find(x => x.manifest.name === name);
-  if (!p) {
-    console.error(`plugin not found: ${name}`);
-    process.exit(1);
-  }
+  if (!p) throw new UserError(`plugin not found: ${name}`);
   archiveToTmp(name, p.dir);
   console.log(
     `\x1b[32m✓\x1b[0m removed ${name} → archived to /tmp/maw-plugin-${name}-*`,

--- a/src/commands/shared/plugins-ls-info.ts
+++ b/src/commands/shared/plugins-ls-info.ts
@@ -6,6 +6,7 @@ import type { LoadedPlugin, PluginTier } from "../../plugin/types";
 import { weightToTier } from "../../plugin/tier";
 import { existsSync } from "fs";
 import { surfaces, shortenHome, printTable } from "./plugins-ui";
+import { UserError } from "../../core/util/user-error";
 
 export interface PluginLsOptions {
   verbose?: boolean;
@@ -190,10 +191,7 @@ export function doLs(
 export function doInfo(name: string, discover: () => LoadedPlugin[]): void {
   const plugins = discover();
   const p = plugins.find(x => x.manifest.name === name);
-  if (!p) {
-    console.error(`plugin not found: ${name}`);
-    process.exit(1);
-  }
+  if (!p) throw new UserError(`plugin not found: ${name}`);
 
   const m = p.manifest;
   const t = effectiveTier(p);

--- a/src/commands/shared/plugins-toggle.ts
+++ b/src/commands/shared/plugins-toggle.ts
@@ -5,6 +5,7 @@
 import { discoverPackages, resetDiscoverCache } from "../../plugin/registry";
 import { pluginCliNames } from "../../cli/dispatch-match";
 import { pluginDependencyNames } from "../../plugin/dependencies";
+import { UserError } from "../../core/util/user-error";
 
 function resolvePluginToggleName(input: string, plugins = discoverPackages()): string {
   const exact = plugins.find(p => p.manifest.name === input);
@@ -76,10 +77,7 @@ export function doDisable(name: string): void {
   }
   // Verify plugin exists
   const plugins = discoverPackages();
-  if (!plugins.find(p => p.manifest.name === pluginName)) {
-    console.error(`plugin not found: ${name}`);
-    process.exit(1);
-  }
+  if (!plugins.find(p => p.manifest.name === pluginName)) throw new UserError(`plugin not found: ${name}`);
   saveConfig({ disabledPlugins: [...disabled, pluginName] });
   resetDiscoverCache();  // config change → next discover call reflects it
   console.log(`\x1b[33m✗\x1b[0m disabled ${pluginName}`);

--- a/src/commands/shared/plugins.ts
+++ b/src/commands/shared/plugins.ts
@@ -17,6 +17,7 @@ import { doLs, doInfo, type PluginLsOptions } from "./plugins-ls-info";
 import { doInstall, doRemove } from "./plugins-install";
 import { doProfile, doNuke } from "./plugins-profile";
 import { doEnable, doDisable } from "./plugins-toggle";
+import { UserError } from "../../core/util/user-error";
 
 export { doLs, doInfo } from "./plugins-ls-info";
 export { doInstall, doRemove } from "./plugins-install";
@@ -68,16 +69,10 @@ export async function cmdPlugins(
     case "list":
       return doLs(flags["--json"] ?? false, flags["--all"] ?? false, discover, undefined, lsOptions(flags));
     case "info":
-      if (!name) {
-        console.error("usage: maw plugins info <name>");
-        process.exit(1);
-      }
+      if (!name) throw new UserError("usage: maw plugins info <name>");
       return doInfo(name, discover);
     case "install":
-      if (!name) {
-        console.error("usage: maw plugins install <path> [--force] [--local] [--symlink]");
-        process.exit(1);
-      }
+      if (!name) throw new UserError("usage: maw plugins install <path> [--force] [--local] [--symlink]");
       return doInstall(name, flags["--force"] ?? false, {
         local: flags["--local"] ?? false,
         symlink: flags["--symlink"] ?? false,
@@ -85,17 +80,14 @@ export async function cmdPlugins(
     case "remove":
     case "uninstall":
     case "rm":
-      if (!name) {
-        console.error("usage: maw plugins remove <name>");
-        process.exit(1);
-      }
+      if (!name) throw new UserError("usage: maw plugins remove <name>");
       return doRemove(name, discover);
     case "enable": {
-      if (!name) { console.error("usage: maw plugin enable <name> [more...]"); process.exit(1); }
+      if (!name) throw new UserError("usage: maw plugin enable <name> [more...]");
       return doEnable(flags._);
     }
     case "disable": {
-      if (!name) { console.error("usage: maw plugin disable <name>"); process.exit(1); }
+      if (!name) throw new UserError("usage: maw plugin disable <name>");
       return doDisable(name);
     }
     case "lean":

--- a/src/vendor/mpr-plugins/assign/impl.ts
+++ b/src/vendor/mpr-plugins/assign/impl.ts
@@ -1,8 +1,8 @@
-import { cmdWake, fetchIssuePrompt, hostExec } from "maw-js/sdk";
+import { cmdWake, fetchIssuePrompt, hostExec, UserError } from "maw-js/sdk";
 
 function parseIssueUrl(url: string): { org: string; repo: string; issueNum: number } {
   const m = url.match(/github\.com[:/]([^/]+)\/([^/]+)\/issues\/(\d+)/);
-  if (!m) throw new Error(`Invalid issue URL: ${url}\nExpected: https://github.com/org/repo/issues/N`);
+  if (!m) throw new UserError(`Invalid issue URL: ${url}\nExpected: https://github.com/org/repo/issues/N`);
   return { org: m[1], repo: m[2], issueNum: parseInt(m[3]) };
 }
 
@@ -26,7 +26,7 @@ export async function cmdAssign(issueUrl: string, opts: { oracle?: string }): Pr
     oracle = await detectCurrentOracle() ?? undefined;
   }
   if (!oracle) {
-    throw new Error("could not detect oracle — pass --oracle <name>");
+    throw new UserError("could not detect oracle — pass --oracle <name>");
   }
 
   console.log(`\x1b[36m⚡\x1b[0m fetching issue #${issueNum} from ${slug}...`);

--- a/src/vendor/mpr-plugins/assign/index.ts
+++ b/src/vendor/mpr-plugins/assign/index.ts
@@ -1,3 +1,4 @@
+import { UserError } from "maw-js/sdk";
 import type { InvokeContext, InvokeResult } from "maw-js/sdk";
 import { cmdAssign } from "./impl";
 
@@ -21,7 +22,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
   try {
     const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
     if (!args[0]) {
-      throw new Error("usage: maw assign <issue-url> [--oracle <name>]");
+      throw new UserError("usage: maw assign <issue-url> [--oracle <name>]");
     }
     const oracleIdx = args.indexOf("--oracle");
     const oracle = oracleIdx !== -1 ? args[oracleIdx + 1] : undefined;

--- a/src/vendor/mpr-plugins/find/index.ts
+++ b/src/vendor/mpr-plugins/find/index.ts
@@ -1,3 +1,4 @@
+import { UserError } from "maw-js/sdk";
 import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdFind } from "./impl";
 
@@ -20,7 +21,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
   };
   try {
     const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
-    if (!args[0]) throw new Error("usage: maw find <keyword> [--oracle <name>]");
+    if (!args[0]) throw new UserError("usage: maw find <keyword> [--oracle <name>]");
     const oracleIdx = args.indexOf("--oracle");
     await cmdFind(args[0], { oracle: oracleIdx !== -1 ? args[oracleIdx + 1] : undefined });
     return { ok: true, output: logs.join("\n") || undefined };

--- a/src/vendor/mpr-plugins/reply/impl.ts
+++ b/src/vendor/mpr-plugins/reply/impl.ts
@@ -1,9 +1,10 @@
+import { UserError } from "maw-js/sdk";
 const MAW_PORT = process.env.MAW_PORT || "3456";
 const MAW_URL = `http://localhost:${MAW_PORT}`;
 
 export async function cmdReply(correlationId: string, reply: string, data?: unknown) {
   if (!correlationId || !reply) {
-    throw new Error("usage: maw reply <correlationId> <message>");
+    throw new UserError("usage: maw reply <correlationId> <message>");
   }
 
   const res = await fetch(`${MAW_URL}/api/reply/${correlationId}`, {

--- a/src/vendor/mpr-plugins/send-enter/impl.ts
+++ b/src/vendor/mpr-plugins/send-enter/impl.ts
@@ -12,7 +12,7 @@
  *   maw send-enter <target> --N 3    # send N Enters
  */
 
-import { listSessions, loadConfig, resolveOraclePane, resolveTarget, tmux } from "maw-js/sdk";
+import { listSessions, loadConfig, resolveOraclePane, resolveTarget, tmux, UserError } from "maw-js/sdk";
 
 export interface SendEnterOpts {
   target: string;
@@ -23,24 +23,24 @@ export async function cmdSendEnter(opts: SendEnterOpts): Promise<void> {
   const { target: query } = opts;
   const count = Math.max(1, opts.count ?? 1);
 
-  if (!query) throw new Error("usage: maw send-enter <target> [--N <count>]");
+  if (!query) throw new UserError("usage: maw send-enter <target> [--N <count>]");
 
   const config = loadConfig();
   const sessions = await listSessions();
   const result = resolveTarget(query, config, sessions);
 
   if (!result) {
-    throw new Error(`could not resolve target: ${query}`);
+    throw new UserError(`could not resolve target: ${query}`);
   }
 
   if (result.type === "error") {
     const hint = result.hint ? ` — ${result.hint}` : "";
-    throw new Error(`${result.detail}${hint}`);
+    throw new UserError(`${result.detail}${hint}`);
   }
 
   if (result.type === "peer") {
     // Phase 1: local-only. Federation deferred to follow-up (see #728).
-    throw new Error(
+    throw new UserError(
       `send-enter: cross-node target '${query}' (node '${result.node}') not yet supported — Phase 1 is local-only. ` +
         `Workaround: ssh ${result.node} && maw send-enter ${result.target}`,
     );
@@ -73,7 +73,7 @@ export function parseSendEnterArgs(args: string[]): SendEnterOpts {
       const next = args[i + 1];
       const n = parseInt(next ?? "", 10);
       if (!Number.isFinite(n) || n < 1) {
-        throw new Error(`--N requires a positive integer (got: ${next ?? "nothing"})`);
+        throw new UserError(`--N requires a positive integer (got: ${next ?? "nothing"})`);
       }
       count = n;
       i++;
@@ -82,7 +82,7 @@ export function parseSendEnterArgs(args: string[]): SendEnterOpts {
     if (a.startsWith("--N=") || a.startsWith("--n=")) {
       const n = parseInt(a.split("=")[1] ?? "", 10);
       if (!Number.isFinite(n) || n < 1) {
-        throw new Error(`--N requires a positive integer (got: ${a})`);
+        throw new UserError(`--N requires a positive integer (got: ${a})`);
       }
       count = n;
       continue;
@@ -93,6 +93,6 @@ export function parseSendEnterArgs(args: string[]): SendEnterOpts {
     }
   }
 
-  if (!target) throw new Error("usage: maw send-enter <target> [--N <count>]");
+  if (!target) throw new UserError("usage: maw send-enter <target> [--N <count>]");
   return { target, count };
 }

--- a/src/vendor/mpr-plugins/send-text/impl.ts
+++ b/src/vendor/mpr-plugins/send-text/impl.ts
@@ -15,7 +15,7 @@
  *
  *   maw send-text <target> "<text>"
  */
-import { curlFetch, listSessions, loadConfig, resolveOraclePane, resolveTarget, Tmux } from "maw-js/sdk";
+import { curlFetch, listSessions, loadConfig, resolveOraclePane, resolveTarget, Tmux, UserError } from "maw-js/sdk";
 
 export interface SendTextOpts {
   target: string;
@@ -24,17 +24,17 @@ export interface SendTextOpts {
 
 export async function cmdSendText(opts: SendTextOpts): Promise<void> {
   const { target: query, text } = opts;
-  if (!query) throw new Error('usage: maw send-text <target> "<text>"');
-  if (text.length === 0) throw new Error('usage: maw send-text <target> "<text>" — text is required');
+  if (!query) throw new UserError('usage: maw send-text <target> "<text>"');
+  if (text.length === 0) throw new UserError('usage: maw send-text <target> "<text>" — text is required');
 
   const config = loadConfig();
   const sessions = await listSessions();
   const result = resolveTarget(query, config, sessions);
 
-  if (!result) throw new Error(`could not resolve target: ${query}`);
+  if (!result) throw new UserError(`could not resolve target: ${query}`);
   if (result.type === "error") {
     const hint = result.hint ? ` — ${result.hint}` : "";
-    throw new Error(`${result.detail}${hint}`);
+    throw new UserError(`${result.detail}${hint}`);
   }
 
   if (result.type === "peer") {
@@ -46,7 +46,7 @@ export async function cmdSendText(opts: SendTextOpts): Promise<void> {
     });
     if (!res.ok || !res.data?.ok) {
       const underlying = res.data?.error || (res.status ? `HTTP ${res.status}` : "connection failed");
-      throw new Error(`peer send-text failed (${result.node} ${result.peerUrl}): ${underlying}`);
+      throw new UserError(`peer send-text failed (${result.node} ${result.peerUrl}): ${underlying}`);
     }
     console.log(`\x1b[32msent\x1b[0m ⚡ ${result.node} → ${res.data.target || result.target}: ${truncate(text)}`);
     return;
@@ -78,9 +78,9 @@ function truncate(s: string, n = 200): string {
  */
 export function parseSendTextArgs(args: string[]): SendTextOpts {
   const targetIdx = args.findIndex((a) => !a.startsWith("-"));
-  if (targetIdx < 0) throw new Error('usage: maw send-text <target> "<text>"');
+  if (targetIdx < 0) throw new UserError('usage: maw send-text <target> "<text>"');
   const target = args[targetIdx];
   const text = args.slice(targetIdx + 1).join(" ");
-  if (text.length === 0) throw new Error('usage: maw send-text <target> "<text>" — text is required');
+  if (text.length === 0) throw new UserError('usage: maw send-text <target> "<text>" — text is required');
   return { target, text };
 }

--- a/src/vendor/mpr-plugins/send/impl.ts
+++ b/src/vendor/mpr-plugins/send/impl.ts
@@ -13,7 +13,7 @@
  *   maw send <target> "<text>"
  */
 
-import { curlFetch, listSessions, loadConfig, resolveOraclePane, resolveTarget, Tmux } from "maw-js/sdk";
+import { curlFetch, listSessions, loadConfig, resolveOraclePane, resolveTarget, Tmux, UserError } from "maw-js/sdk";
 
 export interface SendOpts {
   target: string;
@@ -22,19 +22,19 @@ export interface SendOpts {
 
 export async function cmdSend(opts: SendOpts): Promise<void> {
   const { target: query, text } = opts;
-  if (!query) throw new Error('usage: maw send <target> "<text>"');
+  if (!query) throw new UserError('usage: maw send <target> "<text>"');
 
   const config = loadConfig();
   const sessions = await listSessions();
   const result = resolveTarget(query, config, sessions);
 
   if (!result) {
-    throw new Error(`could not resolve target: ${query}`);
+    throw new UserError(`could not resolve target: ${query}`);
   }
 
   if (result.type === "error") {
     const hint = result.hint ? ` — ${result.hint}` : "";
-    throw new Error(`${result.detail}${hint}`);
+    throw new UserError(`${result.detail}${hint}`);
   }
 
   if (result.type === "peer") {
@@ -46,7 +46,7 @@ export async function cmdSend(opts: SendOpts): Promise<void> {
     });
     if (!res.ok || !res.data?.ok) {
       const underlying = res.data?.error || (res.status ? `HTTP ${res.status}` : "connection failed");
-      throw new Error(`peer send failed (${result.node} ${result.peerUrl}): ${underlying}`);
+      throw new UserError(`peer send failed (${result.node} ${result.peerUrl}): ${underlying}`);
     }
     console.log(`\x1b[32mtyped\x1b[0m ⚡ ${result.node} → ${res.data.target || result.target}: ${truncate(text)}`);
     return;
@@ -79,9 +79,9 @@ export function parseSendArgs(args: string[]): SendOpts {
   // Find the first non-flag arg — that's the target. Everything after
   // (regardless of dashes) is text.
   const targetIdx = args.findIndex(a => !a.startsWith("-"));
-  if (targetIdx < 0) throw new Error('usage: maw send <target> "<text>"');
+  if (targetIdx < 0) throw new UserError('usage: maw send <target> "<text>"');
   const target = args[targetIdx];
   const text = args.slice(targetIdx + 1).join(" ");
-  if (text.length === 0) throw new Error('usage: maw send <target> "<text>" — text is required');
+  if (text.length === 0) throw new UserError('usage: maw send <target> "<text>" — text is required');
   return { target, text };
 }

--- a/test/artifacts-command-default.test.ts
+++ b/test/artifacts-command-default.test.ts
@@ -30,6 +30,7 @@ mock.module(join(import.meta.dir, "../src/lib/artifacts"), () => ({
 }));
 
 const { cmdArtifacts } = await import("../src/commands/shared/artifacts");
+const { isUserError } = await import("../src/core/util/user-error");
 
 const origLog = console.log;
 const origError = console.error;
@@ -38,11 +39,13 @@ const origExit = process.exit;
 let logs: string[];
 let errors: string[];
 let exitCode: number | undefined;
+let thrown: unknown;
 
 async function runArtifacts(sub: string, args: string[] = [], flags: Record<string, any> = {}) {
   logs = [];
   errors = [];
   exitCode = undefined;
+  thrown = undefined;
   console.log = (...args: unknown[]) => { logs.push(args.map(String).join(" ")); };
   console.error = (...args: unknown[]) => { errors.push(args.map(String).join(" ")); };
   (process as unknown as { exit: (code?: number) => never }).exit = (code?: number): never => {
@@ -54,7 +57,7 @@ async function runArtifacts(sub: string, args: string[] = [], flags: Record<stri
     await cmdArtifacts(sub, args, flags);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    if (!message.startsWith("__exit__")) throw error;
+    if (!message.startsWith("__exit__")) thrown = error;
   } finally {
     console.log = origLog;
     console.error = origError;
@@ -71,6 +74,7 @@ beforeEach(() => {
   logs = [];
   errors = [];
   exitCode = undefined;
+  thrown = undefined;
 });
 
 afterEach(() => {
@@ -223,28 +227,34 @@ describe("maw artifacts command", () => {
     expect(output).not.toContain("attachments (");
   });
 
-  test("get usage errors exit when team or task id is missing", async () => {
+  test("get usage errors throw UserError when team or task id is missing", async () => {
     await runArtifacts("get", ["team-only"]);
 
-    expect(exitCode).toBe(1);
-    expect(errors).toEqual(["usage: maw artifacts get <team> <task-id>"]);
+    expect(exitCode).toBeUndefined();
+    expect(isUserError(thrown)).toBe(true);
+    expect((thrown as Error).message).toBe("usage: maw artifacts get <team> <task-id>");
+    expect(errors).toEqual([]);
     expect(getCalls).toEqual([]);
   });
 
-  test("get missing artifact errors and exits", async () => {
+  test("get missing artifact throws UserError", async () => {
     artifact = null;
 
     await runArtifacts("get", ["ghost-team", "404"]);
 
     expect(getCalls).toEqual([{ team: "ghost-team", taskId: "404" }]);
-    expect(exitCode).toBe(1);
-    expect(errors).toEqual(["artifact not found: ghost-team/404"]);
+    expect(exitCode).toBeUndefined();
+    expect(isUserError(thrown)).toBe(true);
+    expect((thrown as Error).message).toBe("artifact not found: ghost-team/404");
+    expect(errors).toEqual([]);
   });
 
-  test("unknown subcommand prints command usage and exits", async () => {
+  test("unknown subcommand throws command usage UserError", async () => {
     await runArtifacts("wat", []);
 
-    expect(exitCode).toBe(1);
-    expect(errors).toEqual(["usage: maw artifacts [ls|get] [team] [task-id] [--json]"]);
+    expect(exitCode).toBeUndefined();
+    expect(isUserError(thrown)).toBe(true);
+    expect((thrown as Error).message).toBe("usage: maw artifacts [ls|get] [team] [task-id] [--json]");
+    expect(errors).toEqual([]);
   });
 });

--- a/test/fleet-manage-default.test.ts
+++ b/test/fleet-manage-default.test.ts
@@ -11,6 +11,7 @@ import {
   type FleetManageDeps,
 } from "../src/commands/shared/fleet-manage";
 import type { FleetEntry, FleetSession } from "../src/commands/shared/fleet-load";
+import { isUserError } from "../src/core/util/user-error";
 
 const session = (name: string, windows: Array<{ name: string; repo?: string }> = []): FleetSession => ({
   name,
@@ -218,6 +219,12 @@ describe("cmdFleetRename", () => {
 
     await expect(cmdFleetRename({ oldName: "23-discord-admin", newName: "23-discord" }, h.deps))
       .rejects.toThrow(/already exists/);
+    try {
+      await cmdFleetRename({ oldName: "23-discord-admin", newName: "23-discord" }, h.deps);
+      throw new Error("expected duplicate fleet rename to throw");
+    } catch (err) {
+      expect(isUserError(err)).toBe(true);
+    }
 
     const dry = makeDeps([entries[0]], {
       exists: path => !path.endsWith("23-discord.json"),
@@ -306,6 +313,12 @@ describe("cmdFleetRenumber", () => {
 
     await expect(cmdFleetRenumber(h.deps))
       .rejects.toThrow("fleet 'mawjs' already running as 89-mawjs");
+    try {
+      await cmdFleetRenumber(h.deps);
+      throw new Error("expected running fleet conflict to throw");
+    } catch (err) {
+      expect(isUserError(err)).toBe(true);
+    }
 
     expect(h.writes).toEqual([]);
     expect(h.renames).toEqual([]);
@@ -323,6 +336,12 @@ describe("cmdFleetRenumber", () => {
 
     await expect(cmdFleetRenumber(h.deps))
       .rejects.toThrow("duplicate fleet name(s): mawjs (89-mawjs.json, 150-mawjs.json)");
+    try {
+      await cmdFleetRenumber(h.deps);
+      throw new Error("expected duplicate fleet names to throw");
+    } catch (err) {
+      expect(isUserError(err)).toBe(true);
+    }
 
     expect(h.writes).toEqual([]);
     expect(h.renames).toEqual([]);

--- a/test/isolated/assign-locks-extra-coverage.test.ts
+++ b/test/isolated/assign-locks-extra-coverage.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 const realFs = await import("fs");
+const { UserError, isUserError } = await import("../../src/core/util/user-error.ts");
 
 type FsCall = { fn: string; args: unknown[] };
 type PlannedOpen = number | { code: string };
@@ -114,6 +115,8 @@ let fetchIssuePromptImpl: (issueNum: number, slug: string) => Promise<string> = 
 ) => `prompt for ${slug}#${issueNum}`;
 
 await mock.module("maw-js/sdk", () => ({
+  UserError,
+  isUserError,
   hostExec: async (cmd: string) => {
     hostExecCalls.push(cmd);
     return hostExecImpl(cmd);
@@ -213,9 +216,14 @@ describe("assign plugin extra coverage", () => {
   });
 
   test("cmdAssign rejects malformed issue URLs before fetching", async () => {
-    await expect(assignImpl.cmdAssign("not-a-github-issue", { oracle: "orion" })).rejects.toThrow(
-      "Invalid issue URL: not-a-github-issue",
-    );
+    let thrown: unknown;
+    try {
+      await assignImpl.cmdAssign("not-a-github-issue", { oracle: "orion" });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(isUserError(thrown)).toBe(true);
+    expect((thrown as Error).message).toContain("Invalid issue URL: not-a-github-issue");
     expect(fetchIssueCalls).toEqual([]);
     expect(wakeCalls).toEqual([]);
   });

--- a/test/isolated/fleet-sync-extra-coverage.test.ts
+++ b/test/isolated/fleet-sync-extra-coverage.test.ts
@@ -79,6 +79,7 @@ mock.module(import.meta.resolve("../../src/commands/shared/fleet-load"), () => (
 const { cmdFleetSync, cmdFleetSyncConfigs } = await import(
   "../../src/commands/shared/fleet-sync.ts?fleet-sync-extra-coverage"
 );
+const { isUserError } = await import("../../src/core/util/user-error.ts");
 
 let logs: string[] = [];
 let errors: string[] = [];
@@ -281,13 +282,20 @@ describe("fleet sync extra coverage", () => {
     expect(logs.join("\n")).toContain("✓ Fleet in sync");
   });
 
-  test("sync configs exits with an error when the repo fleet directory is missing", async () => {
+  test("sync configs throws UserError when the repo fleet directory is missing", async () => {
     repoFleetExists = false;
 
-    await expect(cmdFleetSyncConfigs()).rejects.toThrow("process.exit:1");
+    let thrown: unknown;
+    try {
+      await cmdFleetSyncConfigs();
+    } catch (err) {
+      thrown = err;
+    }
 
-    expect(exitCalls).toEqual([1]);
-    expect(errors.join("\n")).toContain("No fleet/ directory found in repo");
+    expect(isUserError(thrown)).toBe(true);
+    expect((thrown as Error).message).toContain("No fleet/ directory found in repo");
+    expect(exitCalls).toEqual([]);
+    expect(errors.join("\n")).toBe("");
     expect(readdirSyncMock).not.toHaveBeenCalled();
     expect(mkdirSyncMock).not.toHaveBeenCalled();
   });

--- a/test/isolated/instance-preset-token-load-extra-coverage.test.ts
+++ b/test/isolated/instance-preset-token-load-extra-coverage.test.ts
@@ -91,6 +91,7 @@ mock.module(pluginsUiPath, () => ({
   printTable: () => undefined,
 }));
 
+const { isUserError } = await import("../../src/core/util/user-error.ts");
 const { applyInstancePreset } = await import("../../src/cli/instance-preset.ts?instance-preset-extra-coverage");
 const { cmdLoad } = await import("../../src/vendor/mpr-plugins/token/load.ts?token-load-extra-coverage");
 const { cmdPlugins } = await import("../../src/commands/shared/plugins.ts?plugins-extra-coverage");
@@ -338,18 +339,23 @@ describe("cmdPlugins isolated branch dispatcher", () => {
     ]);
   });
 
-  test("exits with usage for missing required plugin arguments", async () => {
-    stubExit();
+  test("throws UserError for missing required plugin arguments", async () => {
+    const cases = [
+      ["info", "usage: maw plugins info <name>"],
+      ["install", "usage: maw plugins install <path> [--force] [--local] [--symlink]"],
+      ["remove", "usage: maw plugins remove <name>"],
+      ["enable", "usage: maw plugin enable <name> [more...]"],
+      ["disable", "usage: maw plugin disable <name>"],
+    ] as const;
 
-    for (const sub of ["info", "install", "remove", "enable", "disable"] as const) {
-      await expect(cmdPlugins(sub, [], { _: [] })).rejects.toThrow("process.exit(1)");
+    for (const [sub, message] of cases) {
+      try {
+        await cmdPlugins(sub, [], { _: [] });
+        throw new Error(`expected ${sub} to throw`);
+      } catch (err) {
+        expect(isUserError(err)).toBe(true);
+        expect((err as Error).message).toBe(message);
+      }
     }
-
-    expect(exitCodes).toEqual([1, 1, 1, 1, 1]);
-    expect(errorSpy).toHaveBeenCalledWith("usage: maw plugins info <name>");
-    expect(errorSpy).toHaveBeenCalledWith("usage: maw plugins install <path> [--force] [--local] [--symlink]");
-    expect(errorSpy).toHaveBeenCalledWith("usage: maw plugins remove <name>");
-    expect(errorSpy).toHaveBeenCalledWith("usage: maw plugin enable <name> [more...]");
-    expect(errorSpy).toHaveBeenCalledWith("usage: maw plugin disable <name>");
   });
 });

--- a/test/isolated/plugin-assign-standalone.test.ts
+++ b/test/isolated/plugin-assign-standalone.test.ts
@@ -1,10 +1,10 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
-import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { loadManifestFromDir } from "../../src/plugin/manifest-load";
 import { invokePlugin } from "../../src/plugin/registry-invoke";
 import type { LoadedPlugin } from "../../src/plugin/types";
+import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
 const realSdk = await import("../../src/sdk/index.ts");
 afterAll(() => { mock.restore(); });
 
@@ -33,34 +33,6 @@ const sdkMock = {
 mock.module("maw-js/sdk", () => ({ ...realSdk, ...sdkMock }));
 mock.module(import.meta.resolve("../../src/sdk/index.ts"), () => ({ ...realSdk, ...sdkMock }));
 
-function walkSources(dir: string): string[] {
-  const out: string[] = [];
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    const full = join(dir, entry.name);
-    if (entry.isDirectory()) {
-      if (entry.name === "dist" || entry.name.startsWith(".")) continue;
-      out.push(...walkSources(full));
-    } else if (entry.name.endsWith(".ts") || entry.name.endsWith(".js")) {
-      out.push(full);
-    }
-  }
-  return out;
-}
-
-function parseImportSpecs(source: string): string[] {
-  const specs = new Set<string>();
-  const importFrom = /\b(?:import|export)\s+(?:[^"'`]+?\s+from\s+)?["']([^"']+)["']/g;
-  const importFn = /\bimport\(\s*["']([^"']+)["']\s*\)/g;
-  const requireFn = /\brequire\(\s*["']([^"']+)["']\s*\)/g;
-
-  for (const re of [importFrom, importFn, requireFn]) {
-    let m: RegExpExecArray | null;
-    while ((m = re.exec(source)) !== null) specs.add(m[1]);
-  }
-
-  return [...specs];
-}
-
 function loadAssignPlugin(): LoadedPlugin {
   const loaded = loadManifestFromDir(pluginDir);
   expect(loaded).not.toBeNull();
@@ -76,16 +48,8 @@ beforeEach(() => {
 
 describe("assign plugin standalone boundary (#2251)", () => {
   test("imports runtime dependencies only through the SDK boundary", () => {
-    const imports = walkSources(pluginDir).flatMap((file) => parseImportSpecs(readFileSync(file, "utf8")));
-
-    const disallowed = imports.filter((spec) => {
-      if (spec.startsWith(".")) return false;
-      if (spec.startsWith("node:")) return false;
-      return spec !== "maw-js/sdk";
-    });
-
-    expect(disallowed).toEqual([]);
-    expect(imports).toContain("maw-js/sdk");
+    const imports = expectStandalonePluginBoundary({ plugin: "assign" });
+    expect(imports.map((record) => record.spec)).toContain("maw-js/sdk");
   });
 
   test("plugin loads and missing issue URL returns InvokeResult error", async () => {

--- a/test/isolated/plugin-create-pane-lock-extra-coverage.test.ts
+++ b/test/isolated/plugin-create-pane-lock-extra-coverage.test.ts
@@ -50,6 +50,7 @@ mock.module(join(root, "src/commands/plugins/plugin/lock"), () => ({
 }));
 
 const { cmdPluginCreate } = await import("../../src/commands/shared/plugin-create-cmd");
+const { isUserError } = await import("../../src/core/util/user-error.ts");
 const panePlugin = await import("../../src/commands/plugins/pane/index");
 const { cmdPluginPin, cmdPluginUnpin } = await import("../../src/commands/plugins/plugin/lock-cli");
 
@@ -122,25 +123,30 @@ afterEach(() => {
 describe("cmdPluginCreate focused branch coverage", () => {
   test("rejects missing type, conflicting type, missing name, invalid name, and existing destination", async () => {
     let got = await capture(() => cmdPluginCreate("demo", {}));
-    expect(got.exitCode).toBe(1);
-    expect(got.stderr).toContain("Specify either --rust or --as");
+    expect(got.exitCode).toBeUndefined();
+    expect(isUserError(got.thrown)).toBe(true);
+    expect((got.thrown as Error).message).toContain("Specify either --rust or --as");
 
     got = await capture(() => cmdPluginCreate("demo", { "--rust": true, "--as": true }));
-    expect(got.exitCode).toBe(1);
-    expect(got.stderr).toContain("not both");
+    expect(got.exitCode).toBeUndefined();
+    expect(isUserError(got.thrown)).toBe(true);
+    expect((got.thrown as Error).message).toContain("not both");
 
     got = await capture(() => cmdPluginCreate(undefined, { "--rust": true }));
-    expect(got.exitCode).toBe(1);
-    expect(got.stderr).toContain("usage: maw plugin create");
+    expect(got.exitCode).toBeUndefined();
+    expect(isUserError(got.thrown)).toBe(true);
+    expect((got.thrown as Error).message).toContain("usage: maw plugin create");
 
     got = await capture(() => cmdPluginCreate("Bad Name", { "--as": true }));
-    expect(got.exitCode).toBe(1);
-    expect(got.stderr).toContain("Invalid plugin name");
+    expect(got.exitCode).toBeUndefined();
+    expect(isUserError(got.thrown)).toBe(true);
+    expect((got.thrown as Error).message).toContain("Invalid plugin name");
 
     const existing = tmpDir("maw-plugin-create-existing-");
     got = await capture(() => cmdPluginCreate("demo", { "--rust": true, "--dest": existing }));
-    expect(got.exitCode).toBe(1);
-    expect(got.stderr).toContain("Destination already exists");
+    expect(got.exitCode).toBeUndefined();
+    expect(isUserError(got.thrown)).toBe(true);
+    expect((got.thrown as Error).message).toContain("Destination already exists");
   });
 
   test("dispatches rust/as scaffolders and reports scaffold failures", async () => {
@@ -160,8 +166,9 @@ describe("cmdPluginCreate focused branch coverage", () => {
 
     rustFailure = new Error("scaffold exploded");
     got = await capture(() => cmdPluginCreate("bad-rust", { "--rust": true, "--dest": join(tmpDir("maw-plugin-create-fail-"), "bad-rust") }));
-    expect(got.exitCode).toBe(1);
-    expect(got.stderr).toContain("scaffold exploded");
+    expect(got.exitCode).toBeUndefined();
+    expect(isUserError(got.thrown)).toBe(true);
+    expect((got.thrown as Error).message).toContain("scaffold exploded");
   });
 });
 

--- a/test/isolated/plugin-find-standalone.test.ts
+++ b/test/isolated/plugin-find-standalone.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { mkdirSync, rmSync, writeFileSync, readFileSync } from "fs";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
+import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
 const realSdk = await import("../../src/sdk/index.ts");
 afterAll(() => { mock.restore(); });
 
@@ -57,18 +58,8 @@ afterEach(() => {
 
 describe("find plugin standalone boundary (#2113)", () => {
   test("imports runtime dependencies from the SDK boundary", () => {
-    const files = ["index.ts", "impl.ts"].map((file) =>
-      readFileSync(join(root, "src/vendor/mpr-plugins/find", file), "utf8"),
-    );
-    for (const source of files) {
-      expect(source).not.toMatch(/maw-js\/(?:core|commands\/shared|lib|config)(?:\/|")/);
-      expect(source).not.toMatch(/from\s+["'](?:\.\.\/)+/);
-    }
-    const combined = files.join("\n");
-    expect(combined).toContain('from "maw-js/sdk"');
-    expect(combined).toContain("getGhqRoot");
-    expect(combined).toContain("loadFleetCore");
-    expect(combined).toContain("hostExec");
+    const imports = expectStandalonePluginBoundary({ plugin: "find" });
+    expect(imports.map((record) => record.spec)).toContain("maw-js/sdk");
   });
 
   test("finds oracle and fleet matches with only SDK mocked", async () => {

--- a/test/isolated/plugin-reply-standalone.test.ts
+++ b/test/isolated/plugin-reply-standalone.test.ts
@@ -63,8 +63,8 @@ describe("reply plugin standalone boundary (#2284)", () => {
     const files = ["index.ts", "impl.ts"].map((file) => readFileSync(join(pluginDir, file), "utf8"));
     const imports = files.flatMap(parseImportSpecs);
 
-    expect(imports.filter((spec) => spec.startsWith("maw-js/core/") || spec.startsWith("maw-js/commands/shared/") || spec.startsWith("maw-js/lib/") || spec === "maw-js/config" || spec.startsWith("maw-js/config/") || spec === "maw-js/sdk")).toEqual([]);
-    expect(imports).toEqual(["maw-js/plugin/types", "./impl"]);
+    expect(imports.filter((spec) => spec.startsWith("maw-js/core/") || spec.startsWith("maw-js/commands/shared/") || spec.startsWith("maw-js/lib/") || spec === "maw-js/config" || spec.startsWith("maw-js/config/"))).toEqual([]);
+    expect(imports).toEqual(["maw-js/plugin/types", "./impl", "maw-js/sdk"]);
   });
 
   test("plugin loads from manifest and reports CLI metadata", async () => {

--- a/test/isolated/plugin-send-enter-standalone.test.ts
+++ b/test/isolated/plugin-send-enter-standalone.test.ts
@@ -57,6 +57,14 @@ describe("send-enter plugin standalone boundary", () => {
     expect(parseSendEnterArgs(["pane"])).toEqual({ target: "pane", count: 1 });
     expect(parseSendEnterArgs(["--N", "3", "pane"])).toEqual({ target: "pane", count: 3 });
     expect(parseSendEnterArgs(["pane", "--N=2"])).toEqual({ target: "pane", count: 2 });
+    let thrown: unknown;
+    try {
+      parseSendEnterArgs(["--N", "0", "pane"]);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(realSdk.isUserError(thrown)).toBe(true);
+    expect((thrown as Error).message).toContain("--N requires a positive integer");
   });
 
   test("local API invocation sends N enters through tmux", async () => {

--- a/test/isolated/plugin-send-standalone.test.ts
+++ b/test/isolated/plugin-send-standalone.test.ts
@@ -64,7 +64,14 @@ describe("send plugin standalone boundary", () => {
 
   test("parses target plus raw text including dash args", () => {
     expect(parseSendArgs(["pane", "ls", "-la", "/tmp"])).toEqual({ target: "pane", text: "ls -la /tmp" });
-    expect(() => parseSendArgs(["--flag"])).toThrow("usage: maw send");
+    let thrown: unknown;
+    try {
+      parseSendArgs(["--flag"]);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(realSdk.isUserError(thrown)).toBe(true);
+    expect((thrown as Error).message).toContain("usage: maw send");
   });
 
   test("local CLI invocation sends literal text without Enter", async () => {

--- a/test/isolated/plugin-send-text-standalone.test.ts
+++ b/test/isolated/plugin-send-text-standalone.test.ts
@@ -64,7 +64,14 @@ describe("send-text plugin standalone boundary", () => {
 
   test("parses target plus text and rejects missing text", () => {
     expect(parseSendTextArgs(["pane", "/awaken"])).toEqual({ target: "pane", text: "/awaken" });
-    expect(() => parseSendTextArgs(["pane"])).toThrow("text is required");
+    let thrown: unknown;
+    try {
+      parseSendTextArgs(["pane"]);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(realSdk.isUserError(thrown)).toBe(true);
+    expect((thrown as Error).message).toContain("text is required");
   });
 
   test("local CLI invocation sends text plus Enter through Tmux.sendText", async () => {

--- a/test/plugins-cli.test.ts
+++ b/test/plugins-cli.test.ts
@@ -10,6 +10,7 @@ import { mkdtempSync, writeFileSync, mkdirSync, existsSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { cmdPlugins } from "../src/commands/shared/plugins";
+import { isUserError } from "../src/core/util/user-error";
 import type { LoadedPlugin } from "../src/plugin/types";
 
 // ─── Fixtures ──────────────────────────────────────────────────────────────
@@ -124,22 +125,15 @@ describe("maw plugins CLI", () => {
     }
   });
 
-  test("info on unknown plugin exits with error", async () => {
-    let exited = false;
-    const origExit = process.exit;
-    (process as any).exit = () => {
-      exited = true;
-      throw new Error("exit");
-    };
+  test("info on unknown plugin throws UserError", async () => {
     try {
       await cmdPlugins("info", [], { _: ["ghost"] }, () => []);
-    } catch {
-      // expected
-    } finally {
-      (process as any).exit = origExit;
+      throw new Error("expected info to throw");
+    } catch (err) {
+      expect(isUserError(err)).toBe(true);
+      expect((err as Error).message).toBe("plugin not found: ghost");
     }
-    expect(exited).toBe(true);
-    expect(errors.some(e => e.includes("plugin not found: ghost"))).toBe(true);
+    expect(errors).toEqual([]);
   });
 
   // ─── install ─────────────────────────────────────────────────────────────
@@ -157,27 +151,22 @@ describe("maw plugins CLI", () => {
     }
   });
 
-  test("install duplicate without --force exits with error", async () => {
+  test("install duplicate without --force throws UserError", async () => {
     const src = mkdtempSync(join(tmpdir(), "maw-src-"));
-    let exited = false;
-    const origExit = process.exit;
-    (process as any).exit = () => {
-      exited = true;
-      throw new Error("exit");
-    };
     try {
       makePlugin(src, "dupl");
       await cmdPlugins("install", [], { _: [src] });
-      exited = false;
-      await cmdPlugins("install", [], { _: [src] });
-    } catch {
-      // expected on second install
+      try {
+        await cmdPlugins("install", [], { _: [src] });
+        throw new Error("expected duplicate install to throw");
+      } catch (err) {
+        expect(isUserError(err)).toBe(true);
+        expect((err as Error).message).toContain("already installed");
+      }
     } finally {
-      (process as any).exit = origExit;
       rmSync(src, { recursive: true, force: true });
     }
-    expect(exited).toBe(true);
-    expect(errors.some(e => e.includes("already installed"))).toBe(true);
+    expect(errors).toEqual([]);
   });
 
   // ─── remove ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- convert high-confidence user-facing command/plugin validation failures from raw `Error` or `process.exit(1)` to branded `UserError`
- update plugin management, plugin creation, artifacts, fleet management/sync, and selected vendor plugin error paths
- add focused regression coverage asserting converted paths throw branded `UserError` without test-killing exits

Closes #2611

## Verification
- `bash scripts/test-isolated.sh test/isolated/plugin-create-pane-lock-extra-coverage.test.ts test/isolated/fleet-sync-extra-coverage.test.ts test/isolated/instance-preset-token-load-extra-coverage.test.ts test/isolated/plugin-send-standalone.test.ts test/isolated/plugin-send-text-standalone.test.ts test/isolated/plugin-send-enter-standalone.test.ts test/isolated/plugin-reply-standalone.test.ts test/isolated/plugin-assign-standalone.test.ts test/isolated/assign-locks-extra-coverage.test.ts test/isolated/vendor-about-bud-sleep-run-send-extra-coverage.test.ts test/isolated/route-comm-send.test.ts`
- `bun test test/artifacts-command-default.test.ts test/fleet-manage-default.test.ts test/plugins-cli.test.ts --path-ignore-patterns '**/agents/**'`
- `bun run build`
- `git diff --check`
