### PR TITLE
Implement maw serve gateway selector seam

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "./core/fleet/validate": "./src/core/fleet/validate.ts",
     "./core/fleet/worktree-layout": "./src/core/fleet/worktree-layout.ts",
     "./core/ghq": "./src/core/ghq.ts",
+    "./core/gateway": "./src/core/gateway.ts",
     "./core/resolve": "./src/core/resolve.ts",
     "./core/matcher/normalize-target": "./src/core/matcher/normalize-target.ts",
     "./core/matcher/resolve-target": "./src/core/matcher/resolve-target.ts",

--- a/src/cli/route-tools.ts
+++ b/src/cli/route-tools.ts
@@ -2,6 +2,7 @@ import { existsSync } from "fs";
 import { join, resolve } from "path";
 import { homedir } from "os";
 import { UserError } from "../core/util/user-error";
+import { normalizeGateway, type GatewayKind } from "../core/gateway";
 import { mawDataPath } from "../core/xdg";
 
 // #388.1 — core-route usage strings for --help intercept. These routes don't
@@ -15,7 +16,7 @@ const CORE_HELP: Record<string, string> = {
   agents: "usage: maw agents [--json] [--all] [--node <node>]",
   agent: "usage: maw agent [--json] [--all] [--node <node>]",
   audit: "usage: maw audit [limit]",
-  serve: "usage: maw serve [port] [--as <name>] [--force-takeover] [--quiet|-q] [--verbose|-v|-vv|-vvv] | maw serve status|--status|stop",
+  serve: "usage: maw serve [port] [--gateway bun|rust|auto] [--as <name>] [--force-takeover] [--quiet|-q] [--verbose|-v|-vv|-vvv] | maw serve status|--status|stop",
 };
 
 type ServeVerbosity = 0 | 1 | 2 | 3 | 4;
@@ -67,11 +68,11 @@ type ServeStatusTools = {
 
 type ServeStartTools = {
   acquirePidLock: (instanceName: string | null, opts: { forceTakeover: boolean }) => void;
-  startServer: (port: number, options?: { verbosity?: ServeVerbosity }) => Promise<void> | void;
+  startServer: (port: number, options?: { verbosity?: ServeVerbosity; gateway?: GatewayKind }) => Promise<void> | void;
 };
 
 type CoreServerTools = {
-  startServer: (port: number, options?: { verbosity?: ServeVerbosity }) => Promise<void> | void;
+  startServer: (port: number, options?: { verbosity?: ServeVerbosity; gateway?: GatewayKind }) => Promise<void> | void;
 };
 type CoreServerLoader = () => Promise<CoreServerTools>;
 
@@ -119,6 +120,29 @@ function serveVerbosityFromArgs(serveArgs: string[]): ServeVerbosity {
   if (stackedVCount > 0) return clampServeVerbosity(1 + stackedVCount);
   if (serveArgs.some((a) => a === "--verbose")) return 2;
   return envServeVerbosity(process.env.MAW_SERVE_VERBOSITY) ?? 1;
+}
+
+function readServeGatewayFlag(serveArgs: string[]): { gateway?: GatewayKind; args: string[] } {
+  const next: string[] = [];
+  let gateway: GatewayKind | undefined;
+  for (let i = 0; i < serveArgs.length; i++) {
+    const arg = serveArgs[i];
+    if (arg === "--gateway") {
+      const value = serveArgs[i + 1];
+      if (value === undefined) throw new UserError("--gateway requires one of: bun, rust, auto");
+      gateway = normalizeGateway(value, "--gateway");
+      i++;
+      continue;
+    }
+    if (arg.startsWith("--gateway=")) {
+      const value = arg.slice("--gateway=".length);
+      if (!value) throw new UserError("--gateway requires one of: bun, rust, auto");
+      gateway = normalizeGateway(value, "--gateway");
+      continue;
+    }
+    next.push(arg);
+  }
+  return { gateway, args: next };
 }
 
 export function createDefaultRouteToolsDeps(loadCoreServer?: CoreServerLoader): RouteToolsDeps {
@@ -179,7 +203,7 @@ export function createDefaultRouteToolsDeps(loadCoreServer?: CoreServerLoader): 
       const { acquirePidLock } = await import("./instance-pid");
       return {
         acquirePidLock,
-        startServer: async (port: number, options?: { verbosity?: 0 | 1 | 2 }) => {
+        startServer: async (port: number, options?: { verbosity?: ServeVerbosity; gateway?: GatewayKind }) => {
           const { startServer } = loadCoreServer ? await loadCoreServer() : await import("../core/server");
           await startServer(port, options);
         },
@@ -326,7 +350,8 @@ export async function routeToolsWithDeps(cmd: string, args: string[], deps: Rout
   if (cmd === "serve") {
     // Strip `--as <name>` from the flag check — already consumed by
     // applyInstancePreset() in cli.ts. Any OTHER flag is still a typo.
-    const serveArgs = args.slice(1);
+    const rawServeArgs = args.slice(1);
+    const { gateway, args: serveArgs } = readServeGatewayFlag(rawServeArgs);
     const asIdx = serveArgs.indexOf("--as");
     const forceIdx = serveArgs.indexOf("--force-takeover");
     const noScoutIdx = serveArgs.indexOf("--no-scout");
@@ -350,7 +375,7 @@ export async function routeToolsWithDeps(cmd: string, args: string[], deps: Rout
     const unknownFlag = filteredArgs.find(a => a.startsWith("-"));
     if (unknownFlag) {
       deps.error(`\x1b[31m✗\x1b[0m unknown flag '${unknownFlag}' for 'maw serve'`);
-      deps.error(`  usage: maw serve [port] [--as <name>] [--force-takeover] [--quiet|-q] [--verbose|-v|-vv|-vvv]  (run 'maw serve --help' for more)`);
+      deps.error(`  usage: maw serve [port] [--gateway bun|rust|auto] [--as <name>] [--force-takeover] [--quiet|-q] [--verbose|-v|-vv|-vvv]  (run 'maw serve --help' for more)`);
       throw new UserError(`unknown flag '${unknownFlag}'`);
     }
     const portArg = filteredArgs.find(a => /^\d+$/.test(a));
@@ -360,7 +385,7 @@ export async function routeToolsWithDeps(cmd: string, args: string[], deps: Rout
     const instanceName = asIdx === -1 ? null : serveArgs[asIdx + 1];
     acquirePidLock(instanceName, { forceTakeover: forceIdx !== -1 });
     if (noScoutIdx !== -1) process.env.MAW_NO_SCOUT = "1";
-    await startServer(portArg ? +portArg : 3456, { verbosity: serveVerbosity });
+    await startServer(portArg ? +portArg : 3456, { verbosity: serveVerbosity, gateway });
     return true;
   }
   return false;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -107,6 +107,8 @@ export interface MawConfig {
   commands: Record<string, string>;
   /** Default engine key/command used when no command-specific fallback is configured (#2400). */
   defaultEngine?: string;
+  /** Serve gateway preference (#2566). CLI --gateway and MAW_GATEWAY override this. */
+  gateway?: "bun" | "rust" | "auto";
   /**
    * Generic engine definitions (#1960 P1).
    *

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -75,6 +75,15 @@ export function validateBasicFields(
     }
   }
 
+  // gateway: serve gateway selector (#2566)
+  if ("gateway" in raw) {
+    if (raw.gateway === "bun" || raw.gateway === "rust" || raw.gateway === "auto") {
+      result.gateway = raw.gateway;
+    } else {
+      warn("gateway", "must be one of: bun, rust, auto");
+    }
+  }
+
   // engines: Record<string, EngineDef> (#1960 P1). Dormant typed surface; keep
   // validation intentionally light so future optional EngineDef fields can roll
   // out without rejecting existing config.
@@ -140,6 +149,9 @@ export function validateConfigShape(config: unknown): string[] {
   if (c.tmuxSocket !== undefined && typeof c.tmuxSocket !== "string") errors.push("tmuxSocket must be a string");
   if (c.federationToken !== undefined && typeof c.federationToken !== "string") errors.push("federationToken must be a string");
   if (c.scout !== undefined && typeof c.scout !== "boolean") errors.push("scout must be a boolean");
+  if (c.gateway !== undefined && c.gateway !== "bun" && c.gateway !== "rust" && c.gateway !== "auto") {
+    errors.push("gateway must be one of: bun, rust, auto");
+  }
 
   if (c.errorForward !== undefined) {
     if (!c.errorForward || typeof c.errorForward !== "object" || Array.isArray(c.errorForward)) {

--- a/src/core/gateway.ts
+++ b/src/core/gateway.ts
@@ -1,0 +1,78 @@
+import type { MawConfig } from "../config/types";
+import { UserError } from "./util/user-error";
+import type { StartServerOptions } from "./server";
+
+export type GatewayKind = "bun" | "rust" | "auto";
+
+export type GatewayStartOptions = StartServerOptions & {
+  gateway?: GatewayKind;
+};
+
+export type GatewaySelectionInput = {
+  cliGateway?: string | null;
+  env?: Pick<NodeJS.ProcessEnv, "MAW_GATEWAY">;
+  config?: Partial<Pick<MawConfig, "gateway">> | null;
+};
+
+export type Gateway = {
+  readonly kind: GatewayKind;
+  start(port: number, options?: GatewayStartOptions): Promise<unknown>;
+};
+
+const VALID_GATEWAYS = new Set<GatewayKind>(["bun", "rust", "auto"]);
+
+export function normalizeGateway(value: unknown, source = "gateway"): GatewayKind | undefined {
+  if (value === undefined || value === null || value === "") return undefined;
+  if (typeof value !== "string") throw new UserError(`${source} must be one of: bun, rust, auto`);
+  const normalized = value.trim().toLowerCase();
+  if (VALID_GATEWAYS.has(normalized as GatewayKind)) return normalized as GatewayKind;
+  throw new UserError(`${source} must be one of: bun, rust, auto`);
+}
+
+/**
+ * Select the maw serve gateway. Precedence is intentionally explicit for #2566:
+ * CLI flag > MAW_GATEWAY > config.gateway > bun default.
+ */
+export function selectGateway(input: GatewaySelectionInput = {}): Gateway {
+  const selected = normalizeGateway(input.cliGateway, "--gateway")
+    ?? normalizeGateway(input.env?.MAW_GATEWAY, "MAW_GATEWAY")
+    ?? normalizeGateway(input.config?.gateway, "config.gateway")
+    ?? "bun";
+
+  if (selected === "rust") return new RustGateway();
+  // auto remains conservative in Phase 2: preserve the existing Bun/Elysia path
+  // until the external maw-gateway binary is production-ready.
+  return new BunGateway(selected);
+}
+
+export class BunGateway implements Gateway {
+  readonly kind: GatewayKind;
+
+  constructor(kind: GatewayKind = "bun") {
+    this.kind = kind;
+  }
+
+  async start(port: number, options: GatewayStartOptions = {}): Promise<unknown> {
+    const { startBunGatewayServer } = await import("./server");
+    return startBunGatewayServer(port, options);
+  }
+}
+
+export class RustGateway implements Gateway {
+  readonly kind = "rust" as const;
+
+  constructor(private readonly binary = process.env.MAW_GATEWAY_BIN || "maw-gateway") {}
+
+  async start(port: number, options: GatewayStartOptions = {}): Promise<unknown> {
+    const verbosity = options.verbosity ?? 1;
+    if (verbosity >= 1) {
+      console.warn(
+        `[gateway:rust] ${this.binary} stub selected for port ${port}; ` +
+        `IPC contract register/request/response/ws-frame/ping/pong over /tmp/maw-${port}.sock or TCP is not wired yet; falling back to BunGateway.`,
+      );
+    }
+    // Phase 2 intentionally preserves runtime behavior while creating the seam
+    // where the future Rust gateway process will be spawned and supervised.
+    return new BunGateway("bun").start(port, { ...options, gateway: "bun" });
+  }
+}

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -1,5 +1,6 @@
 import { MawEngine } from "../engine";
 import { loadConfig, cfgTimeout } from "../config";
+import { selectGateway, type GatewayKind } from "./gateway";
 import { existsSync, readFileSync } from "fs";
 import { api } from "../api";
 import { feedBuffer, feedListeners } from "../api/feed";
@@ -34,6 +35,8 @@ export type ServeVerbosity = 0 | 1 | 2 | 3 | 4;
 export type StartServerOptions = {
   /** 0=quiet (errors only), 1=normal, 2=debug, 3=HTTP access, 4=WS frames */
   verbosity?: ServeVerbosity;
+  /** Serve gateway selection (#2566): CLI > env MAW_GATEWAY > config.gateway > bun. */
+  gateway?: GatewayKind;
 };
 
 type ServeLogger = {
@@ -139,6 +142,13 @@ export const views = createViews();
 // --- Server ---
 
 export async function startServer(port = +(process.env.MAW_PORT || loadConfig().port || 3456), options: StartServerOptions = {}) {
+  const config = loadConfig();
+  const gateway = selectGateway({ cliGateway: options.gateway, env: process.env, config });
+  if (gateway.kind !== "rust") return startBunGatewayServer(port, options);
+  return gateway.start(port, options);
+}
+
+export async function startBunGatewayServer(port = +(process.env.MAW_PORT || loadConfig().port || 3456), options: StartServerOptions = {}) {
   const verbosity = options.verbosity ?? normalizeServeVerbosity(process.env.MAW_SERVE_VERBOSITY);
   const log = createServeLogger(verbosity);
   const engine = new MawEngine({ feedBuffer, feedListeners });

--- a/test/isolated/gateway-selector.test.ts
+++ b/test/isolated/gateway-selector.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+
+import { BunGateway, RustGateway, normalizeGateway, selectGateway } from "../../src/core/gateway";
+import { routeToolsWithDeps, type RouteToolsDeps } from "../../src/cli/route-tools";
+
+function routeDeps(calls: Array<Record<string, unknown>>): RouteToolsDeps {
+  const unused = async () => { throw new Error("unexpected loader"); };
+  return {
+    log: (...args: unknown[]) => calls.push({ type: "log", args }),
+    error: (...args: unknown[]) => calls.push({ type: "error", args }),
+    stdoutWrite: (chunk: string) => calls.push({ type: "stdout", chunk }),
+    exit: (code?: number) => { throw new Error(`exit ${code ?? 0}`); },
+    paths: {
+      resolve: (...parts: string[]) => parts.join("/"),
+      join: (...parts: string[]) => parts.join("/"),
+      existsSync: () => false,
+      homedir: () => "/tmp",
+      sourceDir: "/src/cli",
+    },
+    loadPluginLegacyTools: unused as RouteToolsDeps["loadPluginLegacyTools"],
+    loadPluginLifecycleTools: unused as RouteToolsDeps["loadPluginLifecycleTools"],
+    loadPluginCreateTools: unused as RouteToolsDeps["loadPluginCreateTools"],
+    loadArtifactsTools: unused as RouteToolsDeps["loadArtifactsTools"],
+    loadAgentsTools: unused as RouteToolsDeps["loadAgentsTools"],
+    loadAuditTools: unused as RouteToolsDeps["loadAuditTools"],
+    loadTmuxTools: unused as RouteToolsDeps["loadTmuxTools"],
+    loadServeStatusTools: unused as RouteToolsDeps["loadServeStatusTools"],
+    loadServeStartTools: async () => ({
+      acquirePidLock: (instanceName, opts) => calls.push({ type: "lock", instanceName, opts }),
+      startServer: (port, options) => calls.push({ type: "start", port, options }),
+    }),
+  };
+}
+
+describe("gateway selector (#2566)", () => {
+  test("selectGateway honors CLI > env > config > bun precedence", () => {
+    expect(selectGateway({}).kind).toBe("bun");
+    expect(selectGateway({ config: { gateway: "auto" } })).toBeInstanceOf(BunGateway);
+    expect(selectGateway({ config: { gateway: "rust" } })).toBeInstanceOf(RustGateway);
+    expect(selectGateway({ env: { MAW_GATEWAY: "rust" }, config: { gateway: "bun" } })).toBeInstanceOf(RustGateway);
+    expect(selectGateway({ cliGateway: "bun", env: { MAW_GATEWAY: "rust" }, config: { gateway: "rust" } }).kind).toBe("bun");
+  });
+
+  test("rejects invalid gateway values at the selection boundary", () => {
+    expect(normalizeGateway("BUN")).toBe("bun");
+    expect(() => selectGateway({ cliGateway: "sidecar" })).toThrow("--gateway must be one of: bun, rust, auto");
+    expect(() => normalizeGateway(7, "config.gateway")).toThrow("config.gateway must be one of: bun, rust, auto");
+  });
+
+  test("maw serve forwards --gateway without treating it as an unknown flag", async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    await expect(routeToolsWithDeps("serve", ["serve", "--gateway", "rust", "4567", "--force-takeover"], routeDeps(calls))).resolves.toBe(true);
+
+    expect(calls).toContainEqual({ type: "lock", instanceName: null, opts: { forceTakeover: true } });
+    expect(calls).toContainEqual({ type: "start", port: 4567, options: { verbosity: 1, gateway: "rust" } });
+  });
+
+  test("maw serve accepts --gateway=auto and preserves --as handling", async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    await expect(routeToolsWithDeps("serve", ["serve", "--gateway=auto", "--as", "blue", "4568"], routeDeps(calls))).resolves.toBe(true);
+
+    expect(calls).toContainEqual({ type: "lock", instanceName: "blue", opts: { forceTakeover: false } });
+    expect(calls).toContainEqual({ type: "start", port: 4568, options: { verbosity: 1, gateway: "auto" } });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `maw serve --gateway bun|rust|auto` parsing and help text.
- Add `src/core/gateway.ts` with `selectGateway()` precedence: CLI > `MAW_GATEWAY` > `config.gateway` > `bun`.
- Route default/auto serve through the existing Bun/Elysia path and add a RustGateway stub that logs the #2566 IPC contract then falls back to Bun.
- Validate `config.gateway` and cover selection/CLI forwarding with isolated tests.

Closes #2566

## Tested
- `bun test test/isolated/gateway-selector.test.ts --path-ignore-patterns '**/agents/**'`
- `bun test test/isolated/coverage-core-shared-server.test.ts test/isolated/core-server-more-coverage-2.test.ts --path-ignore-patterns '**/agents/**'`
- `bun test test/isolated/api-probe.test.ts test/isolated/engine-plugin-registry.test.ts --path-ignore-patterns '**/agents/**'`
- `bun run build`

## Notes
- `bun run test:isolated` was attempted and failed on existing unrelated isolated cases in this worktree (plugin install/disable, fleet doctor, serve-views, busy guard, etc.); targeted gateway/server/engine checks pass.
