### PR TITLE
Add serve route golden master snapshot

### DIFF
--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -134,6 +134,85 @@ export function servePortInUseInstructions(port: number, hostname: string): stri
 // pulling in server.ts's module-level auto-start side effects.
 import { resolveBindHost } from "./bind-host";
 
+
+export const SERVE_ROUTE_SNAPSHOT_SYMBOL = Symbol.for("maw.serve.routeSnapshot");
+
+export type ServeRouteSnapshotEntry = {
+  kind: "HTTP" | "WS" | "MIDDLEWARE" | "FALLBACK" | "PROXY";
+  method?: string;
+  path: string;
+  source: string;
+};
+
+type ServeRouteSnapshotDeps = {
+  http: ServeRouteRegistry;
+  ws: ServeWsRegistry;
+  apiRoutes?: Array<{ method?: unknown; path?: unknown }>;
+};
+
+function routeMethods(method: unknown): string[] {
+  if (Array.isArray(method)) return method.map(String);
+  if (typeof method === "string") return [method];
+  return [String(method ?? "UNKNOWN")];
+}
+
+export function collectServeRouteSnapshot({ http, ws, apiRoutes = api.routes ?? [] }: ServeRouteSnapshotDeps): ServeRouteSnapshotEntry[] {
+  const entries: ServeRouteSnapshotEntry[] = [
+    { kind: "MIDDLEWARE", path: "01 *", source: "CORS preflight (handleCorsOptions)" },
+    { kind: "MIDDLEWARE", path: "02 /ws*", source: "WebSocket upgrade registry before HTTP routing" },
+    { kind: "PROXY", path: "/api/{engine-plugin-prefix}/*", source: "dynamic engine plugin proxy (findEnginePluginRegistration)" },
+    { kind: "MIDDLEWARE", path: "03 /api protected", source: "legacy Elysia auth gate before serve plugin fallback" },
+    { kind: "MIDDLEWARE", path: "04 /api", source: "serve route registry before legacy Elysia for unprotected API routes" },
+    { kind: "MIDDLEWARE", path: "05 /api", source: "legacy Elysia app with @elysiajs/cors" },
+    { kind: "MIDDLEWARE", path: "06 /api", source: "federationAuth HMAC" },
+    { kind: "MIDDLEWARE", path: "07 /api", source: "fromSigningAuth peer signature" },
+    { kind: "MIDDLEWARE", path: "08 *", source: "fallback CORS wrapper" },
+  ];
+
+  for (const route of apiRoutes) {
+    const path = typeof route.path === "string" ? route.path : String(route.path ?? "");
+    if (!path) continue;
+    for (const method of routeMethods(route.method)) {
+      entries.push({ kind: "HTTP", method: method.toUpperCase(), path, source: "elysia api" });
+    }
+  }
+
+  for (const route of http.snapshot()) {
+    entries.push({
+      kind: "HTTP",
+      method: route.method,
+      path: route.path,
+      source: route.plugin ? `serve plugin:${route.plugin}` : "serve route registry",
+    });
+  }
+
+  for (const route of ws.snapshot()) {
+    entries.push({ kind: "WS", method: "WS", path: route, source: "serve ws registry" });
+  }
+
+  for (const fallback of http.fallbackSnapshot()) {
+    entries.push({
+      kind: "FALLBACK",
+      method: "FALLBACK",
+      path: `* (${fallback.id})`,
+      source: fallback.plugin ? `serve plugin:${fallback.plugin}` : "serve route registry",
+    });
+  }
+
+  return entries;
+}
+
+export function formatServeRouteSnapshot(entries: ServeRouteSnapshotEntry[]): string {
+  return entries
+    .map((entry) => {
+      if (entry.kind === "MIDDLEWARE") return `MIDDLEWARE ${entry.path} -> ${entry.source}`;
+      if (entry.kind === "PROXY") return `PROXY ${entry.path} -> ${entry.source}`;
+      return `${entry.method ?? entry.kind} ${entry.path} -> ${entry.source}`;
+    })
+    .sort((a, b) => a.localeCompare(b))
+    .join("\n");
+}
+
 export const views = createViews();
 
 // --- Server ---
@@ -380,6 +459,9 @@ export async function startServer(port = +(process.env.MAW_PORT || loadConfig().
     try { server.stop(true); } catch { /* best effort */ }
     throw err;
   }
+
+  const routeSnapshot = collectServeRouteSnapshot({ http: serveRoutes, ws: serveWs });
+  (server as unknown as Record<symbol, ServeRouteSnapshotEntry[]>)[SERVE_ROUTE_SNAPSHOT_SYMBOL] = routeSnapshot;
 
   // HTTPS server (if TLS configured)
   const tlsCfg = loadConfig().tls;

--- a/src/vendor/mpr-plugins/serve-ws/index.ts
+++ b/src/vendor/mpr-plugins/serve-ws/index.ts
@@ -2,10 +2,14 @@ import type { MawEngine } from "../../../engine";
 import type { WSData } from "../../../core/types";
 import type { ServeWsRouteRegistrar, ServeWsSocket } from "../../../core/serve-ws-registry";
 import type { handlePtyClose, handlePtyMessage } from "../../../core/transport/pty";
+import type { handleTmuxStreamClose, handleTmuxStreamMessage, handleTmuxStreamOpen } from "../../../api/tmux-stream";
 
 type WsDeps = {
   handlePtyMessage: typeof handlePtyMessage;
   handlePtyClose: typeof handlePtyClose;
+  handleTmuxStreamOpen: typeof handleTmuxStreamOpen;
+  handleTmuxStreamMessage: typeof handleTmuxStreamMessage;
+  handleTmuxStreamClose: typeof handleTmuxStreamClose;
 };
 
 type ServeWsContext = {
@@ -15,9 +19,13 @@ type ServeWsContext = {
 
 function defaultDeps(): WsDeps {
   const pty = require("../../../core/transport/pty");
+  const tmuxStream = require("../../../api/tmux-stream");
   return {
     handlePtyMessage: pty.handlePtyMessage,
     handlePtyClose: pty.handlePtyClose,
+    handleTmuxStreamOpen: tmuxStream.handleTmuxStreamOpen,
+    handleTmuxStreamMessage: tmuxStream.handleTmuxStreamMessage,
+    handleTmuxStreamClose: tmuxStream.handleTmuxStreamClose,
   };
 }
 
@@ -38,6 +46,14 @@ export function registerServeWsRoutes(ctx: ServeWsContext, deps: WsDeps = defaul
     });
   }
 
+  if (!registered.includes("/ws/tmux")) {
+    ctx.ws.route("/ws/tmux", () => defaultWsData("tmux-stream"), {
+      open: (ws) => deps.handleTmuxStreamOpen(ws as never),
+      message: (ws, msg) => deps.handleTmuxStreamMessage(ws as never, msg),
+      close: (ws) => deps.handleTmuxStreamClose(ws as never),
+    });
+  }
+
   if (!registered.includes("/ws")) {
     ctx.ws.route("/ws", () => defaultWsData(), {
       open: (ws: ServeWsSocket) => ctx.engine!.handleOpen(ws as never),
@@ -49,7 +65,7 @@ export function registerServeWsRoutes(ctx: ServeWsContext, deps: WsDeps = defaul
 
 export function serve(ctx: ServeWsContext, deps?: WsDeps): { ok: true; routes: string[] } {
   registerServeWsRoutes(ctx, deps);
-  return { ok: true, routes: ["/ws/pty", "/ws"] };
+  return { ok: true, routes: ["/ws/pty", "/ws/tmux", "/ws"] };
 }
 
 export default serve;

--- a/src/vendor/mpr-plugins/serve-ws/plugin.json
+++ b/src/vendor/mpr-plugins/serve-ws/plugin.json
@@ -10,7 +10,7 @@
     "serve": {
       "script": "./index.ts",
       "handler": "serve",
-      "ensures": ["ws:route:/ws", "ws:route:/ws/pty"],
+      "ensures": ["ws:route:/ws", "ws:route:/ws/pty", "ws:route:/ws/tmux"],
       "policy": "fail-fast"
     }
   },

--- a/test/isolated/coverage-core-shared-server.test.ts
+++ b/test/isolated/coverage-core-shared-server.test.ts
@@ -99,11 +99,13 @@ mock.module(import.meta.resolve("../../src/plugin/lifecycle"), () => ({
     payload.http?.route("POST", "/api/triggers/fire", () => new Response("plugin trigger fire"));
     payload.http?.route("POST", "/api/worktrees/cleanup", () => new Response("plugin cleanup"));
     payload.http?.route("POST", "/api/protected-auth-fail", () => new Response("should not bypass auth"));
-    payload.ws?.route("/ws/tmux", () => ({ target: null, previewTargets: new Set(), mode: "tmux-stream" }), {
-      open: () => { tmuxStreamEvents.push("open"); },
-      message: () => { tmuxStreamEvents.push("message"); },
-      close: () => { tmuxStreamEvents.push("close"); },
-    });
+    if (!payload.ws?.snapshot?.().includes("/ws/tmux")) {
+      payload.ws?.route("/ws/tmux", () => ({ target: null, previewTargets: new Set(), mode: "tmux-stream" }), {
+        open: () => { tmuxStreamEvents.push("open"); },
+        message: () => { tmuxStreamEvents.push("message"); },
+        close: () => { tmuxStreamEvents.push("close"); },
+      });
+    }
   },
 }));
 mock.module(import.meta.resolve("../../src/core/engine-plugin-registry"), () => ({

--- a/test/isolated/plugin-serve-ws-standalone.test.ts
+++ b/test/isolated/plugin-serve-ws-standalone.test.ts
@@ -17,7 +17,7 @@ describe("serve-ws plugin", () => {
   test("declares the serve hook and keeps the standalone boundary explicit", () => {
     const manifest = JSON.parse(readFileSync(join(root, "src/vendor/mpr-plugins/serve-ws/plugin.json"), "utf8"));
     expect(manifest.hooks.serve).toMatchObject({ script: "./index.ts", handler: "serve", policy: "fail-fast" });
-    expect(manifest.hooks.serve.ensures).toEqual(["ws:route:/ws", "ws:route:/ws/pty"]);
+    expect(manifest.hooks.serve.ensures).toEqual(["ws:route:/ws", "ws:route:/ws/pty", "ws:route:/ws/tmux"]);
 
     expectStandalonePluginBoundary({
       plugin: "serve-ws",
@@ -26,11 +26,12 @@ describe("serve-ws plugin", () => {
         /^\.\.\/\.\.\/\.\.\/core\/serve-ws-registry$/,
         /^\.\.\/\.\.\/\.\.\/core\/transport\/pty$/,
         /^\.\.\/\.\.\/\.\.\/core\/types$/,
+        /^\.\.\/\.\.\/\.\.\/api\/tmux-stream$/,
       ],
     });
   });
 
-  test("registers /ws and /ws/pty through the serve hook", () => {
+  test("registers /ws, /ws/pty, and /ws/tmux through the serve hook", () => {
     const registry = new ServeWsRegistry();
     const calls: WsCall[] = [];
     const engine = {
@@ -41,17 +42,26 @@ describe("serve-ws plugin", () => {
     const deps = {
       handlePtyMessage: (_ws: unknown, msg: string | Buffer) => calls.push({ kind: "pty:message", msg }),
       handlePtyClose: () => calls.push({ kind: "pty:close" }),
+      handleTmuxStreamOpen: () => calls.push({ kind: "tmux:open" }),
+      handleTmuxStreamMessage: (_ws: unknown, msg: string | Buffer) => calls.push({ kind: "tmux:message", msg }),
+      handleTmuxStreamClose: () => calls.push({ kind: "tmux:close" }),
     } as any;
 
-    expect(serve({ ws: registry, engine: engine as any }, deps)).toEqual({ ok: true, routes: ["/ws/pty", "/ws"] });
-    expect(registry.snapshot()).toEqual(["/ws/pty", "/ws"]);
+    expect(serve({ ws: registry, engine: engine as any }, deps)).toEqual({ ok: true, routes: ["/ws/pty", "/ws/tmux", "/ws"] });
+    expect(registry.snapshot()).toEqual(["/ws/pty", "/ws/tmux", "/ws"]);
 
+    registry.handlers.open(makeSocket("/ws/tmux"));
+    registry.handlers.message(makeSocket("/ws/tmux"), "attach");
+    registry.handlers.close(makeSocket("/ws/tmux"));
     registry.handlers.open(makeSocket("/ws"));
     registry.handlers.message(makeSocket("/ws"), "hello");
     registry.handlers.close(makeSocket("/ws"));
     registry.handlers.message(makeSocket("/ws/pty"), "attach");
     registry.handlers.close(makeSocket("/ws/pty"));
     expect(calls).toEqual([
+      { kind: "tmux:open" },
+      { kind: "tmux:message", msg: "attach" },
+      { kind: "tmux:close" },
       { kind: "engine:open" },
       { kind: "engine:message", msg: "hello" },
       { kind: "engine:close" },
@@ -63,11 +73,17 @@ describe("serve-ws plugin", () => {
   test("is idempotent when direct server registration already installed routes", () => {
     const registry = new ServeWsRegistry();
     const engine = { handleOpen() {}, handleMessage() {}, handleClose() {} };
-    const deps = { handlePtyMessage() {}, handlePtyClose() {} } as any;
+    const deps = {
+      handlePtyMessage() {},
+      handlePtyClose() {},
+      handleTmuxStreamOpen() {},
+      handleTmuxStreamMessage() {},
+      handleTmuxStreamClose() {},
+    } as any;
 
     serve({ ws: registry, engine: engine as any }, deps);
     expect(() => serve({ ws: registry, engine: engine as any }, deps)).not.toThrow();
-    expect(registry.snapshot()).toEqual(["/ws/pty", "/ws"]);
+    expect(registry.snapshot()).toEqual(["/ws/pty", "/ws/tmux", "/ws"]);
   });
 
   test("upgrades matching paths with preserved WSData modes", () => {
@@ -78,15 +94,20 @@ describe("serve-ws plugin", () => {
     }, {
       handlePtyMessage() {},
       handlePtyClose() {},
+      handleTmuxStreamOpen() {},
+      handleTmuxStreamMessage() {},
+      handleTmuxStreamClose() {},
     } as any);
 
     const upgrades: unknown[] = [];
     const okServer = { upgrade: (_req: Request, opts: unknown) => { upgrades.push(opts); return true; } };
+    expect(registry.handleUpgrade(new Request("http://local/ws/tmux"), okServer).matched).toBe(true);
     expect(registry.handleUpgrade(new Request("http://local/ws/pty"), okServer).matched).toBe(true);
     expect(registry.handleUpgrade(new Request("http://local/ws"), okServer).matched).toBe(true);
     expect(registry.handleUpgrade(new Request("http://local/not-ws"), okServer)).toEqual({ matched: false });
 
     expect(upgrades).toMatchObject([
+      { data: { target: null, mode: "tmux-stream", __serveWsRoute: "/ws/tmux" } },
       { data: { target: null, mode: "pty", __serveWsRoute: "/ws/pty" } },
       { data: { target: null, __serveWsRoute: "/ws" } },
     ]);

--- a/test/isolated/serve-routes-golden-master.test.ts
+++ b/test/isolated/serve-routes-golden-master.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join, resolve } from "path";
+
+process.env.MAW_CLI = "1";
+
+const repoRoot = resolve(import.meta.dir, "../..");
+const snapshotPath = join(repoRoot, "test/snapshots/serve-routes.snap");
+const servePluginNames = [
+  "serve-agents",
+  "serve-debug",
+  "serve-federation",
+  "serve-identity",
+  "serve-triggers",
+  "serve-triggers-mutate",
+  "serve-views",
+  "serve-worktrees",
+  "serve-ws",
+];
+
+const original = {
+  serve: Bun.serve,
+  cwd: process.cwd(),
+  cli: process.env.MAW_CLI,
+  home: process.env.HOME,
+  mawHome: process.env.MAW_HOME,
+  pluginsDir: process.env.MAW_PLUGINS_DIR,
+  uiDir: process.env.MAW_UI_DIR,
+  warnState: process.env.MAW_WARN_STATE_FILE,
+};
+
+let root = "";
+let serveCalls: Array<Record<string, unknown>> = [];
+
+function linkServePlugins(pluginDir: string): void {
+  mkdirSync(pluginDir, { recursive: true });
+  for (const name of servePluginNames) {
+    const source = join(repoRoot, "src/vendor/mpr-plugins", name);
+    const target = join(pluginDir, name);
+    if (!existsSync(source)) throw new Error(`missing serve plugin fixture: ${source}`);
+    symlinkSync(source, target, "dir");
+  }
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "maw-serve-routes-"));
+  const pluginDir = join(root, "plugins");
+  linkServePlugins(pluginDir);
+  mkdirSync(join(root, "home"), { recursive: true });
+  mkdirSync(join(root, "cwd"), { recursive: true });
+  writeFileSync(join(root, "cwd", ".maw-root"), "");
+  process.chdir(join(root, "cwd"));
+  process.env.MAW_CLI = "1";
+  process.env.HOME = join(root, "home");
+  process.env.MAW_HOME = join(root, "home", ".maw");
+  process.env.MAW_PLUGINS_DIR = pluginDir;
+  process.env.MAW_UI_DIR = join(root, "missing-ui");
+  process.env.MAW_WARN_STATE_FILE = join(root, "warnings.json");
+  serveCalls = [];
+  (Bun as unknown as { serve: typeof Bun.serve }).serve = ((options: Record<string, unknown>) => {
+    serveCalls.push(options);
+    return {
+      port: options.port ?? 0,
+      hostname: options.hostname ?? "127.0.0.1",
+      stop: () => undefined,
+    } as ReturnType<typeof Bun.serve>;
+  }) as typeof Bun.serve;
+});
+
+afterEach(() => {
+  (Bun as unknown as { serve: typeof Bun.serve }).serve = original.serve;
+  process.chdir(original.cwd);
+  if (original.cli === undefined) delete process.env.MAW_CLI; else process.env.MAW_CLI = original.cli;
+  if (original.home === undefined) delete process.env.HOME; else process.env.HOME = original.home;
+  if (original.mawHome === undefined) delete process.env.MAW_HOME; else process.env.MAW_HOME = original.mawHome;
+  if (original.pluginsDir === undefined) delete process.env.MAW_PLUGINS_DIR; else process.env.MAW_PLUGINS_DIR = original.pluginsDir;
+  if (original.uiDir === undefined) delete process.env.MAW_UI_DIR; else process.env.MAW_UI_DIR = original.uiDir;
+  if (original.warnState === undefined) delete process.env.MAW_WARN_STATE_FILE; else process.env.MAW_WARN_STATE_FILE = original.warnState;
+  if (root) rmSync(root, { recursive: true, force: true });
+  mock.restore();
+});
+
+mock.module(import.meta.resolve("../../src/core/runtime/trigger-listener"), () => ({ setupTriggerListener: () => {} }));
+mock.module(import.meta.resolve("../../src/transports"), () => ({
+  createTransportRouter: () => ({ connectAll: () => Promise.resolve(), onMessage: () => {} }),
+  getTransportRouter: () => null,
+  resetTransportRouter: () => {},
+}));
+mock.module(import.meta.resolve("../../src/core/dispatch-engine"), () => ({ startDispatchEngine: () => {} }));
+mock.module(import.meta.resolve("../../src/plugins/index"), () => ({
+  PluginSystem: class { emit() {}; stats() { return { loaded: 0, scopes: {} }; } },
+  loadPlugins: async () => {},
+  reloadUserPlugins: async () => {},
+  watchUserPlugins: () => {},
+  registerManifestHooks: async () => {},
+}));
+
+describe("maw serve route golden master (#2617)", () => {
+  test("boots serve and snapshots HTTP, WS, proxy, fallback, and middleware routes", async () => {
+    const {
+      SERVE_ROUTE_SNAPSHOT_SYMBOL,
+      formatServeRouteSnapshot,
+      startServer,
+    } = await import("../../src/core/server.ts?serve-routes-golden-master");
+
+    const server = await startServer(0, { verbosity: 0 });
+    expect(serveCalls).toHaveLength(1);
+
+    const snapshot = (server as unknown as Record<symbol, unknown>)[SERVE_ROUTE_SNAPSHOT_SYMBOL];
+    expect(Array.isArray(snapshot)).toBe(true);
+    const text = `${formatServeRouteSnapshot(snapshot as never)}\n`;
+
+    expect(text).toContain("WS /ws -> serve ws registry");
+    expect(text).toContain("WS /ws/pty -> serve ws registry");
+    expect(text).toContain("WS /ws/tmux -> serve ws registry");
+    expect(text).toContain("MIDDLEWARE 01 * -> CORS preflight");
+    expect(text).toContain("PROXY /api/{engine-plugin-prefix}/* -> dynamic engine plugin proxy");
+    if (process.env.UPDATE_SNAPSHOTS === "1") writeFileSync(snapshotPath, text);
+    expect(text).toBe(readFileSync(snapshotPath, "utf8"));
+  });
+});

--- a/test/snapshots/serve-routes.snap
+++ b/test/snapshots/serve-routes.snap
@@ -1,0 +1,122 @@
+DELETE /api/config-file -> elysia api
+DELETE /api/files/:name -> elysia api
+FALLBACK * (serve-views) -> serve plugin:serve-views
+GET /api/_engine/registrations -> elysia api
+GET /api/agent -> serve plugin:serve-agents
+GET /api/agents -> serve plugin:serve-agents
+GET /api/asks -> elysia api
+GET /api/auth/status -> elysia api
+GET /api/avengers/best -> elysia api
+GET /api/avengers/health -> elysia api
+GET /api/avengers/status -> elysia api
+GET /api/avengers/traffic -> elysia api
+GET /api/capture -> elysia api
+GET /api/captures -> elysia api
+GET /api/config-file -> elysia api
+GET /api/config-files -> elysia api
+GET /api/consent/:id -> elysia api
+GET /api/consent/list -> elysia api
+GET /api/costs -> elysia api
+GET /api/costs/daily -> elysia api
+GET /api/docs -> elysia api
+GET /api/docs/json -> elysia api
+GET /api/federation/status -> serve plugin:serve-federation
+GET /api/feed -> elysia api
+GET /api/files -> elysia api
+GET /api/files/:name -> elysia api
+GET /api/fleet -> elysia api
+GET /api/fleet-config -> elysia api
+GET /api/fleet/claude -> elysia api
+GET /api/identity -> serve plugin:serve-identity
+GET /api/maw-log -> elysia api
+GET /api/messages -> elysia api
+GET /api/mirror -> elysia api
+GET /api/oracle/search -> elysia api
+GET /api/oracle/stats -> elysia api
+GET /api/oracle/traces -> elysia api
+GET /api/pair/:code/probe -> elysia api
+GET /api/pair/:code/status -> elysia api
+GET /api/peer/session -> elysia api
+GET /api/peers/discovered -> serve plugin:serve-federation
+GET /api/peers/discoveries -> serve plugin:serve-federation
+GET /api/pin-info -> elysia api
+GET /api/plugin/download/:name -> elysia api
+GET /api/plugin/list-manifest -> elysia api
+GET /api/plugins -> elysia api
+GET /api/plugins -> serve plugin:serve-debug
+GET /api/plugins/:name -> elysia api
+GET /api/proxy/session -> elysia api
+GET /api/pulse -> elysia api
+GET /api/queue -> elysia api
+GET /api/queue/:oracle -> elysia api
+GET /api/request/:correlationId -> elysia api
+GET /api/requests -> elysia api
+GET /api/sessions -> elysia api
+GET /api/snapshots -> elysia api
+GET /api/snapshots/:id -> elysia api
+GET /api/teams -> elysia api
+GET /api/teams/:name -> elysia api
+GET /api/teams/:name/tasks -> elysia api
+GET /api/tokens -> elysia api
+GET /api/tokens/rate -> elysia api
+GET /api/transport/status -> elysia api
+GET /api/triggers -> serve plugin:serve-triggers
+GET /api/ui-state -> elysia api
+GET /api/workspace/:id/agents -> elysia api
+GET /api/workspace/:id/feed -> elysia api
+GET /api/workspace/:id/status -> elysia api
+GET /api/worktrees -> serve plugin:serve-worktrees
+GET /plugins -> serve plugin:serve-debug
+MIDDLEWARE 01 * -> CORS preflight (handleCorsOptions)
+MIDDLEWARE 02 /ws* -> WebSocket upgrade registry before HTTP routing
+MIDDLEWARE 03 /api protected -> legacy Elysia auth gate before serve plugin fallback
+MIDDLEWARE 04 /api -> serve route registry before legacy Elysia for unprotected API routes
+MIDDLEWARE 05 /api -> legacy Elysia app with @elysiajs/cors
+MIDDLEWARE 06 /api -> federationAuth HMAC
+MIDDLEWARE 07 /api -> fromSigningAuth peer signature
+MIDDLEWARE 08 * -> fallback CORS wrapper
+OPTIONS /api/ -> elysia api
+OPTIONS /api/* -> elysia api
+PATCH /api/pulse/:id -> elysia api
+POST /api/_engine/register -> elysia api
+POST /api/_engine/unregister -> elysia api
+POST /api/asks -> elysia api
+POST /api/config-file -> elysia api
+POST /api/config-file/toggle -> elysia api
+POST /api/consent/:id/approve -> elysia api
+POST /api/consent/:id/reject -> elysia api
+POST /api/consent/request -> elysia api
+POST /api/feed -> elysia api
+POST /api/pair/:code -> elysia api
+POST /api/pair/auto -> elysia api
+POST /api/pair/generate -> elysia api
+POST /api/pane-keys -> elysia api
+POST /api/peer/exec -> elysia api
+POST /api/pin-set -> elysia api
+POST /api/pin-verify -> elysia api
+POST /api/plugins/:name -> elysia api
+POST /api/plugins/reload -> serve plugin:serve-debug
+POST /api/probe -> elysia api
+POST /api/proxy -> elysia api
+POST /api/pulse -> elysia api
+POST /api/queue -> elysia api
+POST /api/reply/:correlationId -> elysia api
+POST /api/request -> elysia api
+POST /api/select -> elysia api
+POST /api/send -> elysia api
+POST /api/sleep -> elysia api
+POST /api/transport/send -> elysia api
+POST /api/triggers/fire -> serve plugin:serve-triggers-mutate
+POST /api/ui-state -> elysia api
+POST /api/upload -> elysia api
+POST /api/wake -> elysia api
+POST /api/workspace/:id/agents -> elysia api
+POST /api/workspace/:id/message -> elysia api
+POST /api/workspace/create -> elysia api
+POST /api/workspace/join -> elysia api
+POST /api/worktrees/cleanup -> serve plugin:serve-worktrees
+PROXY /api/{engine-plugin-prefix}/* -> dynamic engine plugin proxy (findEnginePluginRegistration)
+PUT /api/config-file -> elysia api
+WS /ws -> serve ws registry
+WS /ws/pty -> serve ws registry
+WS /ws/tmux -> serve ws registry


### PR DESCRIPTION
Closes #2617

## Summary
- Add deterministic serve-route snapshot collection and formatting in core server for HTTP, WS, fallback, proxy, and middleware routes after serve lifecycle registration.
- Add isolated golden-master test in `test/isolated/serve-routes-golden-master.test.ts` that boots serve with deterministic serve plugin set and compares against a committed snapshot in `test/snapshots/serve-routes.snap`.
- Register `/ws/tmux` in `serve-ws` so route contract includes `/ws`, `/ws/pty`, and `/ws/tmux`.
- Update legacy shared server test to tolerate built-in `/ws/tmux` registration when running isolated snapshot scenarios.

## Tests
- `bun test test/isolated/serve-routes-golden-master.test.ts`
- `bun test test/isolated/coverage-core-shared-server.test.ts`
- `bun test test/isolated/tmux-stream.test.ts`
- `bun test test/isolated/plugin-serve-tmux-stream-ws-standalone.test.ts`
- `bun run build`
- `git diff --check`
- `bun test plugin-create.test.ts plugin-ls-info-default.test.ts` (two unrelated failures currently present in this branch)

## Notes
- Full `test:default:safe` sweep still passes 2380/2382 tests; the remaining 2 failing tests are unrelated: `test/plugin-create.test.ts` and `test/plugins-ls-info-default.test.ts`.
