### PR TITLE
fix(config): inherit limits inside MAW_HOME sessions

### DIFF
--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -1,6 +1,6 @@
-import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, statSync, writeFileSync } from "fs";
 import { homedir } from "os";
-import { dirname, join } from "path";
+import { dirname, isAbsolute, join } from "path";
 import { CONFIG_FILE, CONFIG_WEIGHTED_FILE, discoverConfigs, type DiscoveredConfig } from "../core/paths";
 import { refreshContext } from "../lib/context";
 import { verbose, info } from "../cli/verbosity";
@@ -72,6 +72,7 @@ const RESTRICTED_PROJECT_KEYS = new Set([
 
 /** Bind-address values that should never appear as an outbound target (#713). */
 const BIND_ADDRESSES = new Set(["0.0.0.0", "::", "", "127.0.0.1", "localhost"]);
+const CONFIG_FILE_REGEX = /^maw\.config\.(\d+)(\.local)?\.json$/;
 
 /**
  * #820 — sentinel: the real homedir config path. Both `saveConfig` and the
@@ -149,6 +150,79 @@ function configCacheKey(sources: DiscoveredConfig[], cwd: string): string {
   });
 }
 
+function xdgConfigBase(): string {
+  const env = process.env.XDG_CONFIG_HOME;
+  return env && isAbsolute(env) ? env : join(homedir(), ".config");
+}
+
+function singletonConfigDir(): string {
+  return join(xdgConfigBase(), "maw");
+}
+
+function scanSingletonConfigDir(dir: string): DiscoveredConfig[] {
+  if (!existsSync(dir)) return [];
+  try {
+    return readdirSync(dir)
+      .map((name) => {
+        const match = name.match(CONFIG_FILE_REGEX);
+        if (!match) return null;
+        const path = join(dir, name);
+        return {
+          path,
+          weight: Number.parseInt(match[1]!, 10),
+          isLocal: Boolean(match[2]),
+          scope: "user",
+          scopeRank: 10,
+          depth: 0,
+          mtimeMs: statSync(path).mtimeMs,
+        } satisfies DiscoveredConfig;
+      })
+      .filter((item): item is DiscoveredConfig => item !== null);
+  } catch {
+    return [];
+  }
+}
+
+function discoverInheritedSingletonConfigs(): DiscoveredConfig[] {
+  const dir = singletonConfigDir();
+  if (dir === dirname(CONFIG_FILE)) return [];
+  const weighted = scanSingletonConfigDir(dir);
+  if (weighted.length > 0) return weighted;
+  const legacyPath = join(dir, "maw.config.json");
+  if (!existsSync(legacyPath)) return [];
+  try {
+    return [{
+      path: legacyPath,
+      weight: 50,
+      isLocal: false,
+      scope: "legacy",
+      scopeRank: 10,
+      depth: 0,
+      mtimeMs: statSync(legacyPath).mtimeMs,
+    }];
+  } catch {
+    return [];
+  }
+}
+
+function inheritSingletonConfigsForMawHome(sources: DiscoveredConfig[]): DiscoveredConfig[] {
+  // #2616 — MAW_HOME isolates runtime state for per-agent sessions, but team/wake
+  // commands still need operator-level limits from the singleton XDG config.
+  // Preserve test-mode isolation and explicit MAW_CONFIG_DIR overrides.
+  if (process.env.MAW_TEST_MODE === "1") return sources;
+  if (!process.env.MAW_HOME || process.env.MAW_CONFIG_DIR) return sources;
+  const inherited = discoverInheritedSingletonConfigs();
+  if (inherited.length === 0) return sources;
+  const seen = new Set(sources.map((source) => source.path));
+  const merged = [...inherited.filter((source) => !seen.has(source.path)), ...sources];
+  return merged.sort((a, b) =>
+    a.weight - b.weight ||
+    a.scopeRank - b.scopeRank ||
+    Number(a.isLocal) - Number(b.isLocal) ||
+    a.path.localeCompare(b.path)
+  );
+}
+
 function readConfigLayer(source: DiscoveredConfig): Partial<MawConfig> | null {
   try {
     const raw = JSON.parse(readFileSync(source.path, "utf-8"));
@@ -175,6 +249,7 @@ function buildLoadedConfig(opts: LoadConfigOptions = {}): LoadedConfigWithProven
   }
   maybeMigrateLegacyConfigFile();
   let sources = discoverConfigs(cwd);
+  sources = inheritSingletonConfigsForMawHome(sources);
   if (sources.length === 0) {
     sources = [{
       path: CONFIG_FILE,

--- a/test/isolated/config-limits-2616.test.ts
+++ b/test/isolated/config-limits-2616.test.ts
@@ -1,0 +1,98 @@
+/** @maw-test-isolate */
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+function parseResult(stdout: string): Record<string, any> {
+  const line = stdout.split("\n").find((entry) => entry.startsWith("RESULT:"));
+  expect(line).toBeTruthy();
+  return JSON.parse(line!.slice("RESULT:".length));
+}
+
+describe("config limits in MAW_HOME sessions (#2616)", () => {
+  test("inherits singleton limits for config explain, cfgLimit, and wake-concurrency source", () => {
+    const sandbox = mkdtempSync(join(tmpdir(), "maw-config-limits-2616-"));
+    try {
+      const xdgConfigHome = join(sandbox, "xdg-config");
+      const singletonConfigDir = join(xdgConfigHome, "maw");
+      const singletonConfigFile = join(singletonConfigDir, "maw.config.50.json");
+      mkdirSync(singletonConfigDir, { recursive: true });
+      writeFileSync(singletonConfigFile, JSON.stringify({
+        limits: { maxConcurrentAgents: 20 },
+      }, null, 2));
+
+      const mawHome = join(sandbox, "instance");
+      const scriptFile = join(sandbox, "repro-2616.ts");
+      writeFileSync(scriptFile, `
+        const { mkdirSync, writeFileSync } = await import("node:fs");
+        const { join } = await import("node:path");
+        const config = await import("${process.cwd()}/src/config/load.ts");
+        const wake = await import("${process.cwd()}/src/commands/shared/wake-concurrency.ts");
+        const plugin = (await import("${process.cwd()}/src/commands/plugins/config/index.ts")).default;
+
+        const firstLoaded = config.loadConfigWithProvenance();
+        const explainLogs = [];
+        const explain = await plugin({
+          source: "cli",
+          args: ["explain", "limits.maxConcurrentAgents", "--json"],
+          writer: (...args) => explainLogs.push(args.map(String).join(" ")),
+        });
+        const firstLimit = config.cfgLimit("maxConcurrentAgents");
+        const firstSourceLine = wake.maxConcurrentAgentsSourceLine();
+
+        mkdirSync(join(process.env.MAW_HOME, "config"), { recursive: true });
+        writeFileSync(join(process.env.MAW_HOME, "config", "maw.config.90.local.json"), JSON.stringify({
+          limits: { maxConcurrentAgents: 30 },
+        }, null, 2));
+        config.resetConfig();
+        const secondLoaded = config.loadConfigWithProvenance();
+
+        console.log("RESULT:" + JSON.stringify({
+          firstLimit,
+          firstConfigLimit: firstLoaded.config.limits?.maxConcurrentAgents,
+          firstSource: firstLoaded.provenance["limits.maxConcurrentAgents"]?.at(-1)?.path,
+          explainOk: explain.ok,
+          explain: JSON.parse(explainLogs.join("\\n")),
+          sourceLine: firstSourceLine,
+          secondLimit: secondLoaded.config.limits?.maxConcurrentAgents,
+          secondSource: secondLoaded.provenance["limits.maxConcurrentAgents"]?.at(-1)?.path,
+        }));
+      `);
+
+      const result = spawnSync(process.execPath, [scriptFile], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          HOME: sandbox,
+          XDG_CONFIG_HOME: xdgConfigHome,
+          MAW_HOME: mawHome,
+          MAW_CONFIG_DIR: "",
+          MAW_TEST_MODE: "",
+          MAW_QUIET: "1",
+        },
+      });
+
+      if (result.status !== 0) console.error(result.stderr || result.stdout);
+      expect(result.status).toBe(0);
+      const payload = parseResult(result.stdout);
+      expect(payload.firstLimit).toBe(20);
+      expect(payload.firstConfigLimit).toBe(20);
+      expect(payload.firstSource).toBe(singletonConfigFile);
+      expect(payload.explainOk).toBe(true);
+      expect(payload.explain.finalValue).toBe(20);
+      expect(payload.explain.entries.at(-1)).toMatchObject({
+        path: singletonConfigFile,
+        value: 20,
+        action: "set",
+      });
+      expect(payload.sourceLine).toBe(`limits.maxConcurrentAgents: 20 from ${singletonConfigFile}`);
+      expect(payload.secondLimit).toBe(30);
+      expect(payload.secondSource).toBe(join(mawHome, "config", "maw.config.90.local.json"));
+    } finally {
+      rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Inherit singleton XDG maw config layers when running under MAW_HOME so wake/team session commands see operator-level limits.
- Keep MAW_TEST_MODE and explicit MAW_CONFIG_DIR isolated.
- Add isolated regression covering config explain, cfgLimit, wake-concurrency source reporting, and MAW_HOME local override precedence.

Closes #2616

## Test plan
- `bash scripts/test-isolated.sh test/isolated/config-limits-2602.test.ts test/isolated/config-limits-2616.test.ts test/isolated/wake-concurrency.test.ts test/isolated/plugin-config-standalone.test.ts`
- `bun test test/isolated/config-load-coverage.test.ts test/isolated/config-load-real-home-guard-coverage.test.ts`
- `bun run build`
- `git diff --cached --check`
