### PR TITLE
Add ServeProfile for lean server startup

### DIFF
--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -32,11 +32,24 @@ export { createViews };
 export const VERSION = getRuntimeVersionLabel();
 
 export type ServeVerbosity = 0 | 1 | 2 | 3 | 4;
+export type ServeProfile = {
+  /** Transport names to initialize. Omit for today's full transport wiring. */
+  transports?: string[];
+  /** Maintenance timers such as capture/session/status polling and dispatch delivery. */
+  intervals?: boolean;
+  /** Static/browser view fallbacks registered by the serve-views lifecycle plugin. */
+  views?: boolean;
+  /** API serve lifecycle modules to mount, e.g. ["identity", "triggers"]. Omit for all. */
+  apiRouters?: string[];
+};
+
 export type StartServerOptions = {
   /** 0=quiet (errors only), 1=normal, 2=debug, 3=HTTP access, 4=WS frames */
   verbosity?: ServeVerbosity;
   /** Serve gateway selection (#2566): CLI > env MAW_GATEWAY > config.gateway > bun. */
   gateway?: GatewayKind;
+  /** Optional serve composition profile; default preserves today's full wiring. */
+  profile?: ServeProfile;
 };
 
 type ServeLogger = {
@@ -218,19 +231,48 @@ export function formatServeRouteSnapshot(entries: ServeRouteSnapshotEntry[]): st
 
 export const views = createViews();
 
+export type StartServerProfileOrOptions = ServeProfile | StartServerOptions;
+
+function looksLikeStartServerOptions(input: StartServerProfileOrOptions | undefined): input is StartServerOptions {
+  return !!input && ("verbosity" in input || "profile" in input || "gateway" in input);
+}
+
+function resolveStartServerInputs(input: StartServerProfileOrOptions | undefined, overrideOptions?: StartServerOptions): { profile: ServeProfile; options: StartServerOptions } {
+  const baseOptions = looksLikeStartServerOptions(input) ? input : {};
+  const profile = looksLikeStartServerOptions(input) ? (input.profile ?? {}) : (input ?? {});
+  return {
+    profile: { ...profile, ...overrideOptions?.profile },
+    options: { ...baseOptions, ...overrideOptions },
+  };
+}
+
+function profileFlag(profile: ServeProfile, key: "intervals" | "views"): boolean {
+  return profile[key] !== false;
+}
+
 // --- Server ---
 
-export async function startServer(port = +(process.env.MAW_PORT || loadConfig().port || 3456), options: StartServerOptions = {}) {
+export async function startServer(
+  port = +(process.env.MAW_PORT || loadConfig().port || 3456),
+  profileOrOptions: StartServerProfileOrOptions = {},
+  overrideOptions?: StartServerOptions,
+) {
+  const { options } = resolveStartServerInputs(profileOrOptions, overrideOptions);
   const config = loadConfig();
   const gateway = selectGateway({ cliGateway: options.gateway, env: process.env, config });
-  if (gateway.kind !== "rust") return startBunGatewayServer(port, options);
+  if (gateway.kind !== "rust") return startBunGatewayServer(port, profileOrOptions, overrideOptions);
   return gateway.start(port, options);
 }
 
-export async function startBunGatewayServer(port = +(process.env.MAW_PORT || loadConfig().port || 3456), options: StartServerOptions = {}) {
+export async function startBunGatewayServer(
+  port = +(process.env.MAW_PORT || loadConfig().port || 3456),
+  profileOrOptions: StartServerProfileOrOptions = {},
+  overrideOptions?: StartServerOptions,
+) {
+  const { profile, options } = resolveStartServerInputs(profileOrOptions, overrideOptions);
   const verbosity = options.verbosity ?? normalizeServeVerbosity(process.env.MAW_SERVE_VERBOSITY);
   const log = createServeLogger(verbosity);
-  const engine = new MawEngine({ feedBuffer, feedListeners });
+  const engine = new MawEngine({ feedBuffer, feedListeners, intervals: profileFlag(profile, "intervals") });
   const serveRoutes = new ServeRouteRegistry();
   const serveWs = new ServeWsRegistry();
   registerServeWs({
@@ -242,16 +284,20 @@ export async function startBunGatewayServer(port = +(process.env.MAW_PORT || loa
   const WS_URL = `ws://localhost:${port}/ws`;
 
   // Connect transport router (non-blocking — server starts even if transports fail)
-  try {
-    const router = createTransportRouter();
-    router.connectAll().catch(err => log.error("[transport] connect failed:", err));
-    engine.setTransportRouter(router);
-  } catch (err) {
-    log.error("[transport] router init failed:", err);
+  // Guard stays in the original startup slot so lean profiles do not reorder
+  // side effects relative to dispatch, trigger listeners, and feed plugin setup.
+  if (profile.transports === undefined || profile.transports.length > 0) {
+    try {
+      const router = createTransportRouter(profile.transports);
+      router.connectAll().catch(err => log.error("[transport] connect failed:", err));
+      engine.setTransportRouter(router);
+    } catch (err) {
+      log.error("[transport] router init failed:", err);
+    }
   }
 
   // Start dispatch engine — auto-delivers queued messages when agents become idle
-  startDispatchEngine(sendKeys);
+  if (profileFlag(profile, "intervals")) startDispatchEngine(sendKeys);
 
   // Hook workflow triggers into feed events
   setupTriggerListener(feedListeners);
@@ -461,6 +507,10 @@ export async function startBunGatewayServer(port = +(process.env.MAW_PORT || loa
       log,
       plugins: serveLifecyclePlugins,
       reloadPlugins: serveLifecycleReloadPlugins,
+      profile: {
+        views: profileFlag(profile, "views"),
+        apiRouters: profile.apiRouters,
+      },
     }, undefined, {
       info: (message) => log.info(message),
       warn: (message) => log.warn(message),

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -34,16 +34,18 @@ export class MawEngine {
   private lastTeamsJson = { value: "" };
   private feedUnsub: (() => void) | null = null;
   private transportRouter: TransportRouter | null = null;
+  private intervalsEnabled = true;
 
   private feedBuffer: FeedEvent[];
   private feedListeners: Set<(event: FeedEvent) => void>;
 
-  constructor({ feedBuffer, feedListeners }: { feedBuffer: FeedEvent[]; feedListeners: Set<(event: FeedEvent) => void> }) {
+  constructor({ feedBuffer, feedListeners, intervals = true }: { feedBuffer: FeedEvent[]; feedListeners: Set<(event: FeedEvent) => void>; intervals?: boolean }) {
     this.feedBuffer = feedBuffer;
     this.feedListeners = feedListeners;
+    this.intervalsEnabled = intervals;
     registerBuiltinHandlers(this);
     this.feedListeners.add((event) => agentStatusStore.handleFeedEvent(event));
-    this.initSessionCache();
+    if (intervals) this.initSessionCache();
   }
 
   private async initSessionCache() {
@@ -87,7 +89,7 @@ export class MawEngine {
 
   handleOpen(ws: MawWS) {
     this.clients.add(ws);
-    this.startIntervals();
+    if (this.intervalsEnabled) this.startIntervals();
     sendInitialSessions(ws, this.getIntervalState()).catch(() => {});
     ws.send(JSON.stringify({ type: "feed-history", events: this.feedBuffer.slice(-cfgLimit("feedHistory")) }));
   }
@@ -106,7 +108,7 @@ export class MawEngine {
     this.clients.delete(ws);
     this.lastContent.delete(ws);
     this.lastPreviews.delete(ws);
-    this.stopIntervals();
+    if (this.intervalsEnabled) this.stopIntervals();
   }
 
   // --- Public (handlers use these) ---

--- a/src/plugin/lifecycle.ts
+++ b/src/plugin/lifecycle.ts
@@ -14,6 +14,7 @@ import type { MawEngine } from "../engine";
 import type { ServeWsRouteRegistrar } from "../core/serve-ws-registry";
 import type { MawConfig } from "../config/types";
 import type { TransportRouter } from "../core/transport/transport";
+import type { ServeProfile } from "../core/server";
 import type { LoadedPlugin, PluginLifecycleHook, ServeRouteRegistrar } from "./types";
 
 export type LifecyclePhase = "wake" | "sleep" | "serve" | "transport";
@@ -76,6 +77,8 @@ export interface ServeLifecycleContextInput {
   plugins?: unknown;
   /** Reload user plugins and return the current plugin stats/debug payload. */
   reloadPlugins?: () => unknown | Promise<unknown>;
+  /** Optional lean serve composition profile for filtering serve hook mounts. */
+  profile?: Pick<ServeProfile, "views" | "apiRouters">;
 }
 
 export interface TransportLifecycleContextInput {
@@ -153,6 +156,27 @@ function resolveHookModulePath(plugin: LoadedPlugin, hook: PluginLifecycleHook):
   return realPath;
 }
 
+function serveApiRouterName(pluginName: string): string | null {
+  if (pluginName === "serve-views" || pluginName === "serve-ws") return null;
+  if (pluginName.startsWith("serve-")) return pluginName.slice("serve-".length);
+  return pluginName;
+}
+
+function shouldRunLifecycleHook(
+  phase: LifecyclePhase,
+  plugin: LoadedPlugin,
+  baseContext: Omit<PluginLifecycleContext, "phase" | "plugin" | "ensures">,
+): boolean {
+  if (phase !== "serve") return true;
+  const profile = (baseContext as { profile?: Pick<ServeProfile, "views" | "apiRouters"> }).profile;
+  if (!profile) return true;
+  const pluginName = plugin.manifest.name;
+  if (profile.views === false && pluginName === "serve-views") return false;
+  if (profile.apiRouters === undefined) return true;
+  const routerName = serveApiRouterName(pluginName);
+  return routerName === null || profile.apiRouters.includes(routerName);
+}
+
 async function runOneLifecycleHook(
   phase: LifecyclePhase,
   plugin: LoadedPlugin,
@@ -195,6 +219,7 @@ export async function runLifecycleHooks(
     if (plugin.disabled) { summary.skipped++; continue; }
     const hook = plugin.manifest.hooks?.[phase];
     if (!hook) continue;
+    if (!shouldRunLifecycleHook(phase, plugin, baseContext)) { summary.skipped++; continue; }
     if (plugin.kind !== "ts" && !hook.script) { summary.skipped++; continue; }
 
     try {

--- a/src/transports/index.ts
+++ b/src/transports/index.ts
@@ -39,23 +39,38 @@ export function discoveryTransport(config: ReturnType<typeof loadConfig>): Disco
 
 /** Singleton router instance */
 let router: TransportRouter | null = null;
+let routerProfileKey = "all";
+
+function transportEnabled(profile: Set<string> | null, name: string): boolean {
+  return !profile || profile.has(name);
+}
+
+function transportProfileKey(transports?: string[]): string {
+  return transports === undefined ? "all" : [...new Set(transports)].sort().join(",");
+}
 
 /** Build transport router from maw.config.json */
-export function createTransportRouter(): TransportRouter {
-  if (router) return router;
+export function createTransportRouter(transports?: string[]): TransportRouter {
+  const profileKey = transportProfileKey(transports);
+  if (router && routerProfileKey === profileKey) return router;
+  if (router) router.disconnectAll().catch(() => {});
 
   const config = loadConfig();
+  const enabledTransports = transports === undefined ? null : new Set(transports);
   router = new TransportRouter(config.broadcastTo ?? []);
+  routerProfileKey = profileKey;
 
-  // 1. Always register tmux (local fast path) — auto-connected
-  const tmux = new TmuxTransport();
-  tmux.connect().catch(() => {}); // tmux is always available locally
-  router.register(tmux);
+  // 1. Always register tmux (local fast path) by default — auto-connected
+  if (transportEnabled(enabledTransports, "tmux")) {
+    const tmux = new TmuxTransport();
+    tmux.connect().catch(() => {}); // tmux is always available locally
+    router.register(tmux);
+  }
 
   const discovery = discoveryTransport(config);
 
   // 2.5. Scout P2P — zero-config LAN discovery + auto-pairing.
-  if (discovery === "scout" || discovery === "both") {
+  if (transportEnabled(enabledTransports, "scout") && (discovery === "scout" || discovery === "both")) {
     const oracles = Object.keys(config.agents || {}).filter(k => k.endsWith("-oracle"));
     const scout = new ScoutTransport({
       node: config.node ?? "local",
@@ -71,14 +86,14 @@ export function createTransportRouter(): TransportRouter {
   // 2.5b. Zenoh Scout — opt-in discovery/presence provider only.
   // Pairing/trust remains in MAW's HTTP pair/peers flow. The transport is
   // provided by the plugin module surface so core does not import vendored code.
-  if (discovery === "zenoh" || discovery === "both") {
+  if (transportEnabled(enabledTransports, "zenoh-scout") && (discovery === "zenoh" || discovery === "both")) {
     const zenohScout = new PluginTransportAdapter(ZENOH_SCOUT_PLUGIN, ZENOH_SCOUT_TRANSPORT_FACTORY, config);
     zenohScout.connect().catch(() => {});
     router.register(zenohScout);
   }
 
   // 2.6. Zenoh transport — pub/sub + auto-discovery (dynamic import — WASM)
-  if (config.zenoh?.locator) {
+  if (transportEnabled(enabledTransports, "zenoh") && config.zenoh?.locator) {
     import("./zenoh").then(({ ZenohTransport }) => {
       const zt = new ZenohTransport({
         locator: config.zenoh!.locator,
@@ -90,7 +105,7 @@ export function createTransportRouter(): TransportRouter {
   }
 
   // 3. HTTP federation as fallback
-  if (config.peers && config.peers.length > 0) {
+  if (transportEnabled(enabledTransports, "http") && config.peers && config.peers.length > 0) {
     router.register(
       new HttpTransport({
         peers: config.peers,
@@ -100,7 +115,7 @@ export function createTransportRouter(): TransportRouter {
   }
 
   // 4. NanoClaw (external chat channels — Telegram, Discord, etc.)
-  router.register(new NanoclawTransport());
+  if (transportEnabled(enabledTransports, "nanoclaw")) router.register(new NanoclawTransport());
 
   return router;
 }
@@ -203,6 +218,7 @@ export function resetTransportRouter() {
     router.disconnectAll().catch(() => {});
     router = null;
   }
+  routerProfileKey = "all";
 }
 
 export { TmuxTransport } from "./tmux";

--- a/test/isolated/coverage-core-shared-server.test.ts
+++ b/test/isolated/coverage-core-shared-server.test.ts
@@ -18,6 +18,7 @@ let tmuxStreamEvents: string[] = [];
 let apiPaths: string[] = [];
 let proxiedPaths: string[] = [];
 let lifecyclePayloads: unknown[] = [];
+let transportProfiles: unknown[] = [];
 let healthPolls = 0;
 let tmp = "";
 
@@ -51,7 +52,10 @@ mock.module(import.meta.resolve("../../src/views/index"), () => ({
 }));
 mock.module(import.meta.resolve("../../src/core/runtime/trigger-listener"), () => ({ setupTriggerListener: () => {} }));
 mock.module(import.meta.resolve("../../src/transports"), () => ({
-  createTransportRouter: () => ({ connectAll: () => Promise.resolve() }),
+  createTransportRouter: (transports?: string[]) => {
+    transportProfiles.push(transports);
+    return { connectAll: () => Promise.resolve() };
+  },
   getTransportRouter: () => null,
   resetTransportRouter: () => {},
 }));
@@ -149,6 +153,7 @@ beforeEach(() => {
   apiPaths = [];
   proxiedPaths = [];
   lifecyclePayloads = [];
+  transportProfiles = [];
   healthPolls = 0;
   Bun.serve = ((opts: any) => {
     serveCalls.push(opts);
@@ -266,6 +271,7 @@ describe("coverage core shared server", () => {
     expect(killed).toEqual([]);
     expect(engineCalls).toContain("router");
     expect(lifecyclePayloads).toHaveLength(1);
+    expect(transportProfiles).toEqual([undefined]);
     expect(lifecyclePayloads[0]).toMatchObject({
       port: 4910,
       httpUrl: "http://localhost:4910",
@@ -274,6 +280,7 @@ describe("coverage core shared server", () => {
       log: expect.any(Object),
       plugins: expect.any(Object),
       reloadPlugins: expect.any(Function),
+      profile: { views: true, apiRouters: undefined },
     });
     expect((lifecyclePayloads[0] as any).http).toEqual(expect.objectContaining({ route: expect.any(Function) }));
     // Engine plugin health polling moved to serve-engine-health-polling; this
@@ -327,6 +334,20 @@ describe("coverage core shared server", () => {
     expect(serveLogs.some((line) => line.includes("[serve:http] OPTIONS /anything -> 204"))).toBe(true);
     expect(serveLogs.some((line) => line.includes("[serve:http] GET /ws/pty -> 101"))).toBe(true);
   });
+
+  test("startServer accepts a lean ServeProfile while preserving startup guard slots", async () => {
+    await startServer(4911, { transports: ["tmux"], views: false, intervals: false, apiRouters: ["identity"] });
+
+    expect(transportProfiles).toEqual([["tmux"]]);
+    expect(engineCalls).toContain("router");
+    expect(lifecyclePayloads).toHaveLength(1);
+    expect(lifecyclePayloads[0]).toMatchObject({
+      port: 4911,
+      profile: { views: false, apiRouters: ["identity"] },
+    });
+    expect(serveCalls).toHaveLength(1);
+  });
+
 });
 
 function upgradeServer(ok: boolean) {

--- a/test/isolated/engine.test.ts
+++ b/test/isolated/engine.test.ts
@@ -107,6 +107,10 @@ function newEngine() {
   return new MawEngine({ feedBuffer: [], feedListeners: new Set() });
 }
 
+function newEngineWithoutIntervals() {
+  return new MawEngine({ feedBuffer: [], feedListeners: new Set(), intervals: false });
+}
+
 // --- Tests ---
 
 describe("MawEngine (isolated)", () => {
@@ -114,6 +118,20 @@ describe("MawEngine (isolated)", () => {
     sshResult = "";
     sshCommands = [];
     mockSessions = [];
+  });
+
+  test("intervals:false skips headless startup polling but still serves initial sessions", async () => {
+    mockSessions = [{ name: "s", windows: [{ index: 0, name: "w", active: true }] }];
+    const engine = newEngineWithoutIntervals();
+    await Promise.resolve();
+    expect(sshCommands.some(cmd => cmd.includes("list-windows"))).toBe(false);
+
+    const { ws, messages } = makeWS();
+    engine.handleOpen(ws as any);
+    await new Promise(r => setTimeout(r, 50));
+
+    expect(messages.some(m => m.type === "sessions")).toBe(true);
+    expect(sshCommands.some(cmd => cmd.includes("list-windows"))).toBe(true);
   });
 
   describe("handleOpen — no stale recent agents", () => {

--- a/test/isolated/plugin-lifecycle.test.ts
+++ b/test/isolated/plugin-lifecycle.test.ts
@@ -169,6 +169,30 @@ describe("plugin lifecycle hooks (#1576)", () => {
     expect(routes).toEqual(["route-owner:GET /api/owned"]);
     expect(fallbacks).toEqual(["route-owner:owned-fallback"]);
   });
+  test("serve profile filters views and selected API routers without reordering remaining hooks", async () => {
+    const log = makeLog();
+    const plugins = [
+      makePlugin("serve-views", { weight: 1, hook: { serve: {} }, files: { "index.ts": `export function serve() { const fs = require("fs"); fs.appendFileSync(process.env.MAW_LIFECYCLE_LOG, "views\\n"); }\n` } }),
+      makePlugin("serve-identity", { weight: 2, hook: { serve: {} }, files: { "index.ts": `export function serve() { const fs = require("fs"); fs.appendFileSync(process.env.MAW_LIFECYCLE_LOG, "identity\\n"); }\n` } }),
+      makePlugin("serve-worktrees", { weight: 3, hook: { serve: {} }, files: { "index.ts": `export function serve() { const fs = require("fs"); fs.appendFileSync(process.env.MAW_LIFECYCLE_LOG, "worktrees\\n"); }\n` } }),
+      makePlugin("serve-ws", { weight: 4, hook: { serve: {} }, files: { "index.ts": `export function serve() { const fs = require("fs"); fs.appendFileSync(process.env.MAW_LIFECYCLE_LOG, "ws\\n"); }\n` } }),
+    ];
+
+    const summary = await runServeLifecycleHooks(
+      {
+        port: 4567,
+        httpUrl: "http://localhost:4567",
+        wsUrl: "ws://localhost:4567/ws",
+        hostname: "127.0.0.1",
+        profile: { views: false, apiRouters: ["identity"] },
+      },
+      () => plugins,
+    );
+
+    expect(summary).toEqual({ phase: "serve", ran: 2, skipped: 2, failed: 0 });
+    expect(readFileSync(log, "utf8").trim().split("\n")).toEqual(["identity", "ws"]);
+  });
+
 
   test("best-effort failures continue, fail-fast failures throw clearly", async () => {
     const log = makeLog();


### PR DESCRIPTION
## Summary
- Add ServeProfile and wire it through startServer with backward-compatible defaults.
- Keep default startup side-effect ordering while allowing lean profiles (for example { transports: ['tmux'], views: false, intervals: false }).
- Scope changes to server startup, engine lifecycle, transport composition, and lifecycle hook filtering.
- Add tests in test/isolated to lock default behavior and profile-specific startup.

Closes #2615